### PR TITLE
fix: remove top bar and setup slides shell correctly

### DIFF
--- a/frontend/src/apps/slides/SlidesShell.vue
+++ b/frontend/src/apps/slides/SlidesShell.vue
@@ -1,0 +1,46 @@
+<template>
+  <router-view v-slot="{ Component }">
+    <keep-alive :max="5">
+      <component :is="Component" />
+    </keep-alive>
+  </router-view>
+</template>
+
+<script setup>
+import { h, onMounted, onUnmounted, provide, ref } from 'vue'
+import { toast } from 'frappe-ui'
+import { Wifi, WifiOff } from 'lucide-vue-next'
+import { saveCurrentState } from '@/apps/slides/stores/saving'
+
+const isOnline = ref(false)
+
+const handleOffline = () => {
+  isOnline.value = false
+  toast.create({
+    message: 'Lost internet connection.',
+    icon: h(WifiOff, { color: 'white' }),
+  })
+}
+
+const handleOnline = () => {
+  isOnline.value = true
+  saveCurrentState()
+  toast.create({
+    message: 'You are back online.',
+    icon: h(Wifi, { color: 'white' }),
+  })
+}
+
+onMounted(() => {
+  isOnline.value = navigator?.onLine
+  window.addEventListener('online', handleOnline)
+  window.addEventListener('offline', handleOffline)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('online', handleOnline)
+  window.removeEventListener('offline', handleOffline)
+})
+
+provide('isOnline', isOnline)
+</script>

--- a/frontend/src/apps/slides/SlidesShell.vue
+++ b/frontend/src/apps/slides/SlidesShell.vue
@@ -12,7 +12,7 @@ import { toast } from 'frappe-ui'
 import { Wifi, WifiOff } from 'lucide-vue-next'
 import { saveCurrentState } from '@/apps/slides/stores/saving'
 
-const isOnline = ref(false)
+const isOnline = ref(navigator?.onLine ?? true)
 
 const handleOffline = () => {
   isOnline.value = false

--- a/frontend/src/apps/slides/components/LayoutProperties.vue
+++ b/frontend/src/apps/slides/components/LayoutProperties.vue
@@ -73,6 +73,7 @@
 
 <script setup>
 import { computed } from 'vue'
+import { Button } from 'frappe-ui'
 
 import Forward from '@/apps/slides/icons/Forward.vue'
 import Backward from '@/apps/slides/icons/Backward.vue'

--- a/frontend/src/apps/slides/components/PresentationActionDialog.vue
+++ b/frontend/src/apps/slides/components/PresentationActionDialog.vue
@@ -38,7 +38,7 @@
 <script setup>
 import { ref, watch, nextTick, useTemplateRef } from 'vue'
 
-import { Dialog, FormControl, call } from 'frappe-ui'
+import { Button, Dialog, FormControl, call } from 'frappe-ui'
 
 import { deletePresentation, updatePresentationTitle } from '@/apps/slides/stores/presentation'
 

--- a/frontend/src/apps/slides/components/SharePopover.vue
+++ b/frontend/src/apps/slides/components/SharePopover.vue
@@ -39,7 +39,7 @@
 
 <script setup>
 import { ref } from 'vue'
-import { Popover, Switch, call, toast } from 'frappe-ui'
+import { Button, Popover, Switch, call, toast } from 'frappe-ui'
 import { presentationId, isPublicPresentation } from '@/apps/slides/stores/presentation'
 import { resetFocus } from '@/apps/slides/stores/element'
 import { copyToClipboard } from '@/apps/slides/stores/copyPaste'

--- a/frontend/src/apps/slides/components/SlideProperties.vue
+++ b/frontend/src/apps/slides/components/SlideProperties.vue
@@ -69,7 +69,7 @@
 
 <script setup>
 import { inject } from 'vue'
-import { Select, Checkbox, toast } from 'frappe-ui'
+import { Button, Select, Checkbox, toast } from 'frappe-ui'
 
 import { slides, slideIndex, currentSlide } from '@/apps/slides/stores/slide'
 import { sectionClasses, sectionTitleClasses, fieldLabelClasses } from '@/apps/slides/utils/constants'

--- a/frontend/src/apps/slides/components/SlideshowEndScreen.vue
+++ b/frontend/src/apps/slides/components/SlideshowEndScreen.vue
@@ -24,6 +24,7 @@
 </template>
 
 <script setup>
+import { Button } from 'frappe-ui'
 const emit = defineEmits(['restartSlideShow'])
 </script>
 

--- a/frontend/src/apps/slides/components/controls/ColorPicker.vue
+++ b/frontend/src/apps/slides/components/controls/ColorPicker.vue
@@ -97,7 +97,7 @@
 import { ref, unref, computed, useTemplateRef, watch } from 'vue'
 import { useElementBounding, useEyeDropper } from '@vueuse/core'
 
-import { Popover, Input } from 'frappe-ui'
+import { Button, Popover, Input } from 'frappe-ui'
 
 import { copyToClipboard } from '@/apps/slides/stores/copyPaste'
 import EyeDropper from '@/apps/slides/icons/EyeDropper.vue'

--- a/frontend/src/apps/slides/pages/errorPages/NotPermitted.vue
+++ b/frontend/src/apps/slides/pages/errorPages/NotPermitted.vue
@@ -9,5 +9,6 @@
 </template>
 
 <script setup>
+import { Button } from 'frappe-ui'
 import { session } from '@/apps/slides/stores/session'
 </script>

--- a/frontend/src/apps/slides/routes.ts
+++ b/frontend/src/apps/slides/routes.ts
@@ -3,6 +3,7 @@ import type { RouteLocationNormalized, RouteRecordRaw, Router } from 'vue-router
 import { createResource } from 'frappe-ui'
 
 import { router, setEditorAccess, setPreviousRoute } from '@/apps/slides/router'
+import SlidesShell from '@/apps/slides/SlidesShell.vue'
 
 /**
  * Slides route module — mounted by the suite router under the '/slides' prefix.
@@ -15,6 +16,8 @@ import { router, setEditorAccess, setPreviousRoute } from '@/apps/slides/router'
  * EditorNew -> slides-editor-new, PresentationEditor -> slides-editor,
  * Slideshow -> slides-slideshow, NotPermitted -> slides-not-permitted.
  */
+
+let currentEditorAccess = 'none'
 
 const withPresentationProps = (route: RouteLocationNormalized) => {
   const slide = parseInt(route.query.slide as string)
@@ -30,39 +33,45 @@ const withPresentationProps = (route: RouteLocationNormalized) => {
 export const routes: RouteRecordRaw[] = [
   {
     path: '',
-    name: 'slides-home',
-    component: () => import('@/apps/slides/pages/Home.vue'),
-  },
-  {
-    path: 'presentation/new',
-    name: 'slides-editor-new',
-    component: () => import('@/apps/slides/pages/PresentationEditor.vue'),
-    props: withPresentationProps,
-  },
-  {
-    path: 'presentation/:presentationId/:slug?',
-    name: 'slides-editor',
-    component: () => import('@/apps/slides/pages/PresentationEditor.vue'),
-    props: withPresentationProps,
-  },
-  {
-    path: 'presentation/view/:presentationId/:slug?',
-    redirect: (route: RouteLocationNormalized) => ({
-      name: 'slides-editor',
-      params: route.params,
-      query: route.query,
-    }),
-  },
-  {
-    path: 'slideshow/:presentationId/:slug?',
-    name: 'slides-slideshow',
-    component: () => import('@/apps/slides/pages/Slideshow.vue'),
-    props: withPresentationProps,
-  },
-  {
-    path: 'not-permitted',
-    name: 'slides-not-permitted',
-    component: () => import('@/apps/slides/pages/errorPages/NotPermitted.vue'),
+    component: SlidesShell,
+    children: [
+      {
+        path: '',
+        name: 'slides-home',
+        component: () => import('@/apps/slides/pages/Home.vue'),
+      },
+      {
+        path: 'presentation/new',
+        name: 'slides-editor-new',
+        component: () => import('@/apps/slides/pages/PresentationEditor.vue'),
+        props: withPresentationProps,
+      },
+      {
+        path: 'presentation/:presentationId/:slug?',
+        name: 'slides-editor',
+        component: () => import('@/apps/slides/pages/PresentationEditor.vue'),
+        props: withPresentationProps,
+      },
+      {
+        path: 'presentation/view/:presentationId/:slug?',
+        redirect: (route: RouteLocationNormalized) => ({
+          name: 'slides-editor',
+          params: route.params,
+          query: route.query,
+        }),
+      },
+      {
+        path: 'slideshow/:presentationId/:slug?',
+        name: 'slides-slideshow',
+        component: () => import('@/apps/slides/pages/Slideshow.vue'),
+        props: withPresentationProps,
+      },
+      {
+        path: 'not-permitted',
+        name: 'slides-not-permitted',
+        component: () => import('@/apps/slides/pages/errorPages/NotPermitted.vue'),
+      },
+    ],
   },
 ]
 
@@ -75,8 +84,6 @@ export default routes
 /* and gate the editor route on the per-presentation access level. Installed   */
 /* once, the first time this module is loaded (see bottom of file).            */
 /* -------------------------------------------------------------------------- */
-
-let currentEditorAccess = 'none'
 
 const getEditorAccess = async (presentationId: string) => {
   try {

--- a/frontend/src/shell/SuiteLayout.vue
+++ b/frontend/src/shell/SuiteLayout.vue
@@ -5,6 +5,3 @@
     </main>
   </div>
 </template>
-
-<script setup lang="ts">
-</script>

--- a/frontend/src/shell/SuiteLayout.vue
+++ b/frontend/src/shell/SuiteLayout.vue
@@ -1,33 +1,5 @@
 <template>
   <div class="flex h-screen flex-col bg-surface-base">
-    <!-- Top-nav: hidden on the '/suite' launcher (which is its own full-screen
-         app switcher); shown inside every app with brand-logo tabs. -->
-    <header
-      v-if="!isLauncher"
-      class="flex h-12 shrink-0 items-center gap-1 border-b border-outline-gray-2 px-3"
-    >
-      <router-link
-        to="/suite"
-        title="Suite launcher"
-        class="mr-1 flex items-center rounded px-2 py-1 text-sm-semibold text-ink-gray-9 hover:bg-surface-gray-2"
-      >
-        Suite
-      </router-link>
-
-      <nav class="flex items-center gap-0.5 overflow-x-auto">
-        <router-link
-          v-for="app in apps"
-          :key="app.id"
-          :to="app.prefix"
-          class="flex shrink-0 items-center gap-1.5 rounded px-2 py-1 text-sm text-ink-gray-7 hover:bg-surface-gray-2"
-          :class="{ 'bg-surface-gray-3 text-ink-gray-9': isActive(app.prefix) }"
-        >
-          <img :src="app.logo" alt="" aria-hidden="true" class="size-4 object-contain" />
-          {{ app.name }}
-        </router-link>
-      </nav>
-    </header>
-
     <main class="min-h-0 flex-1 overflow-auto">
       <slot />
     </main>
@@ -35,18 +7,4 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import { useRoute } from 'vue-router'
-
-import { SUITE_APPS } from '@/apps/registry'
-
-const apps = SUITE_APPS
-const route = useRoute()
-
-const isLauncher = computed(
-  () => route.path === '/suite' || route.meta.isShell === true,
-)
-
-const isActive = (prefix: string) =>
-  route.path === prefix || route.path.startsWith(prefix + '/')
 </script>


### PR DESCRIPTION
Adds `SlidesShell.vue` as a parent route wrapper for slides, restoring the keep-alive (preserving editor lifecycle hooks) and online / offline detection with `isOnline` provide that were lost when slides moved to the shared `App.vue`

Also removes the suite-wide top navbar.