### PR TITLE
security: require type-annotated API methods

### DIFF
--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -327,7 +327,6 @@ ALLOWED_PATHS = [
 	"/api/method/frappe.integrations.oauth2.approve",
 	"/api/method/frappe.integrations.oauth2.get_token",
 	"/api/method/frappe.integrations.oauth2.openid_profile",
-	"/api/method/frappe.integrations.oauth2_logins.login_via_frappe",
 	"/api/method/frappe.website.doctype.web_page_view.web_page_view.make_view_log",
 	"/api/method/ping",
 	"/api/method/login",
@@ -341,10 +340,14 @@ ALLOWED_PATHS = [
 ]
 
 ALLOWED_WILDCARD_PATHS = [
-	# drive
+	"/api/method/frappe.integrations.oauth2_logins.",
+	"/api/method/suite.mail.api.",
+	"/api/method/suite.calendar.api.",
+	"/api/method/suite.meet.api.",
 	"/api/method/suite.drive.api.",
-	# writer
 	"/api/method/suite.writer.api.",
+	"/api/method/suite.slides.api.",
+	"/api/method/suite.sheets.api.",
 ]
 
 DENIED_PATHS = []

--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -302,14 +302,8 @@ ignore_links_on_delete = [
 # mail — log retention (only definer; kept as dict)
 default_log_clearing_doctypes = {"Mail Queue": 3, "Spam Check Log": 7}
 
-# meet / sheets / calendar — type annotation enforcement (singletons, all True)
 export_python_type_annotations = True
-# Temporarily disabled for the suite merge: drive/meet/calendar enforced this as
-# standalone apps and comply, but writer/slides/mail were written without
-# whitelist arg annotations and now live under the same `suite` app, so blanket
-# enforcement 417s their methods. Re-enable once the ~23 laggard methods in
-# suite/{writer,slides,client} are annotated (tracked follow-up).
-require_type_annotated_api_methods = False
+require_type_annotated_api_methods = True
 
 # ============================================================================
 # Access-control path lists (concatenated; identical entries de-duplicated)

--- a/suite/slides/doctype/presentation/presentation.py
+++ b/suite/slides/doctype/presentation/presentation.py
@@ -168,7 +168,7 @@ def get_presentations() -> list[dict]:
 
 
 @frappe.whitelist()
-def update_slide_attachments(parent: str, slide: str):
+def update_slide_attachments(parent: str, slide: dict | str):
 	slide = json.loads(slide) if isinstance(slide, str) else slide
 
 	elements_data = slide.get("elements") or "[]"

--- a/suite/slides/doctype/presentation/presentation.py
+++ b/suite/slides/doctype/presentation/presentation.py
@@ -168,7 +168,7 @@ def get_presentations() -> list[dict]:
 
 
 @frappe.whitelist()
-def update_slide_attachments(parent, slide):
+def update_slide_attachments(parent: str, slide: str):
 	slide = json.loads(slide) if isinstance(slide, str) else slide
 
 	elements_data = slide.get("elements") or "[]"
@@ -269,7 +269,7 @@ def set_template_metadata(presentation, template):
 
 
 @frappe.whitelist()
-def create_presentation(template=None, duplicate_from=None):
+def create_presentation(template: str | None = None, duplicate_from: str | None = None):
 	presentation = frappe.new_doc("Presentation")
 	if duplicate_from:
 		set_duplicate_metadata(presentation, duplicate_from)
@@ -284,12 +284,12 @@ def create_presentation(template=None, duplicate_from=None):
 
 
 @frappe.whitelist()
-def delete_presentation(name):
+def delete_presentation(name: str):
 	return frappe.delete_doc("Presentation", name)
 
 
 @frappe.whitelist()
-def update_title(name, title):
+def update_title(name: str, title: str):
 	frappe.set_value("Presentation", name, "title", title)
 	return slug(title)
 
@@ -314,7 +314,7 @@ def get_attachment(presentation, file_url):
 
 
 @frappe.whitelist()
-def get_updated_json(presentation, json):
+def get_updated_json(presentation: str, json: list[dict]):
 	for element in json:
 		if element.get("type") in ["image", "video"]:
 			file_url = element.get("src").replace(frappe.local.site_name, "")
@@ -340,17 +340,17 @@ def has_permission(doc, ptype="read", user=None):
 
 
 @frappe.whitelist(allow_guest=True)
-def is_public_presentation(name):
+def is_public_presentation(name: str):
 	return frappe.db.get_value("Presentation", name, "is_public") == 1
 
 
 @frappe.whitelist(allow_guest=True)
-def is_composite_presentation(name):
+def is_composite_presentation(name: str):
 	return frappe.db.get_value("Presentation", name, "is_composite") == 1
 
 
 @frappe.whitelist(allow_guest=True)
-def get_public_presentation(name):
+def get_public_presentation(name: str):
 	if not is_public_presentation(name):
 		frappe.throw("Presentation is not public", frappe.PermissionError)
 
@@ -389,7 +389,7 @@ def get_templates():
 
 
 @frappe.whitelist(allow_guest=True)
-def get_composite_presentation(name):
+def get_composite_presentation(name: str):
 	doc = frappe.get_doc("Presentation", name)
 
 	composite_slides = []
@@ -437,7 +437,7 @@ def create_new_webp_file_doc(presentation_name, file_url, image, extn):
 
 
 @frappe.whitelist()
-def get_webp_doc(presentation_name, file_doc):
+def get_webp_doc(presentation_name: str, file_doc: dict):
 	file_url = file_doc.get("file_url", "")
 	if file_url.endswith((".webp", ".svg")):
 		return file_doc
@@ -462,7 +462,7 @@ def update_element_urls(presentation, element):
 
 
 @frappe.whitelist()
-def optimize_images(name):
+def optimize_images(name: str):
 	doc = frappe.get_doc("Presentation", name)
 
 	for slide in doc.slides:

--- a/suite/writer/api/docs.py
+++ b/suite/writer/api/docs.py
@@ -27,7 +27,7 @@ QUICK_MAP = {
 
 @frappe.whitelist()
 @default_team
-def create_document(team, title=None, parent=None, template=None):
+def create_document(team: str, title: str | None = None, parent: str | None = None, template: str | None = None):
     home_directory = get_home_folder(team)
     parent = parent or home_directory.name
     parent_doc = frappe.get_doc("File", parent)
@@ -85,7 +85,7 @@ def create_document(team, title=None, parent=None, template=None):
 
 
 @frappe.whitelist(allow_guest=True)
-def get_document(file_id):
+def get_document(file_id: str):
     return_obj = get_entity_with_permissions(file_id)
     entity = frappe._dict(return_obj)
 
@@ -146,7 +146,7 @@ def save_comments(doc: str, data: str):
 
 
 @frappe.whitelist()
-def get_extension(entity_name):
+def get_extension(entity_name: str):
     mime_type = frappe.get_value("File", entity_name, "mime_type")
     try:
         return mimemapper.get_extension(mime_type)
@@ -155,7 +155,7 @@ def get_extension(entity_name):
 
 
 @frappe.whitelist()
-def create_blog(entity_name, html, attachments=None):
+def create_blog(entity_name: str, html: str, attachments: str | None = None):
     """
     If the blog app is installed, creates a blog
     """

--- a/suite/writer/api/embed.py
+++ b/suite/writer/api/embed.py
@@ -4,7 +4,7 @@ from suite.drive.api.permissions import user_has_permission
 
 
 @frappe.whitelist()
-def add(file_id):
+def add(file_id: str):
     file_doc = frappe.get_doc("File", file_id)
     file = frappe.request.files["file"]
     file.filename = f"{file_doc.name} embed -{file.filename}"
@@ -13,7 +13,7 @@ def add(file_id):
 
 
 @frappe.whitelist(allow_guest=True)
-def get(id):
+def get(id: str):
     embed = frappe.get_cached_doc("File", id)
     parent = frappe.db.get_value(
         "File", embed.folder, ["name", "content_docname"], as_dict=True

--- a/suite/writer/api/general.py
+++ b/suite/writer/api/general.py
@@ -22,14 +22,10 @@ Binary = CustomFunction("BINARY", ["expression"])
 
 @frappe.whitelist()
 def get_document_list(
-    start=0,
-    limit=20,
+    start: int = 0,
+    limit: int = 20,
 ):
     user = frappe.session.user
-
-    # Convert string parameters to integers
-    limit = int(limit)
-    start = int(start)
 
     recently_opened = (
         frappe.qb.from_(Recents).select(Recents.entity_name).where(Recents.user == user)
@@ -124,7 +120,7 @@ def get_document_list(
 
 
 @frappe.whitelist()
-def get_versions(id):
+def get_versions(id: str):
     if not get_user_access(id).get("write"):
         frappe.throw("You don't have write access.", frappe.PermissionError)
 
@@ -141,7 +137,7 @@ def get_versions(id):
 
 
 @frappe.whitelist()
-def search(query, filters=None):
+def search(query: str, filters: str | None = None):
     client = WriterSearch()
     search = client.search(query, filters=filters)
     metadata = get_drive_file_meta([k["name"] for k in search["results"]])


### PR DESCRIPTION
Enables `require_type_annotated_api_methods` and adds the missing type annotations across Writer, Slides, and the endpoint whitelist fixes.