### PR TITLE
feat: refine and extend editor interactions

### DIFF
--- a/frontend/src/apps/slides/components/MarqueeOverlay.vue
+++ b/frontend/src/apps/slides/components/MarqueeOverlay.vue
@@ -12,6 +12,7 @@ import {
 	resetFocus,
 	isWithinOverlappingBounds,
 } from '@/apps/slides/stores/element'
+import { getElementDiv } from '@/apps/slides/stores/elementRegistry'
 
 const slideDiv = inject('slideDiv')
 const slideContainerDiv = inject('slideContainerDiv')
@@ -76,6 +77,82 @@ const updateSelection = (e) => {
 	marqueeRect.height = Math.abs(y - startY)
 }
 
+const getRotatedRectCorners = (center, halfWidth, halfHeight, rotation) => {
+	const radians = (rotation * Math.PI) / 180
+	const cos = Math.cos(radians)
+	const sin = Math.sin(radians)
+
+	const cornerAt = (x, y) => ({
+		x: center.x + x * cos - y * sin,
+		y: center.y + x * sin + y * cos,
+	})
+
+	return [
+		cornerAt(-halfWidth, -halfHeight),
+		cornerAt(halfWidth, -halfHeight),
+		cornerAt(halfWidth, halfHeight),
+		cornerAt(-halfWidth, halfHeight),
+	]
+}
+
+const getRectCorners = (bounds) => [
+	{ x: bounds.left, y: bounds.top },
+	{ x: bounds.right, y: bounds.top },
+	{ x: bounds.right, y: bounds.bottom },
+	{ x: bounds.left, y: bounds.bottom },
+]
+
+const getProjectedSpan = (corners, axis) => {
+	const distances = corners.map((corner) => corner.x * axis.x + corner.y * axis.y)
+	return { min: Math.min(...distances), max: Math.max(...distances) }
+}
+
+const spansOverlap = (a, b) => a.min <= b.max && b.min <= a.max
+
+const rectsOverlap = (cornersA, cornersB, axes) =>
+	axes.every((axis) =>
+		spansOverlap(getProjectedSpan(cornersA, axis), getProjectedSpan(cornersB, axis)),
+	)
+
+// a rotated element's bounding box is mostly empty space, so test the marquee
+// against the element's actual rotated rectangle instead.
+const isRotatedElementWithinMarquee = (element, marqueeBounds) => {
+	const div = getElementDiv(element.id)
+	if (!div) return false
+
+	// the rotated rect shares its centre with the axis-aligned bounding box
+	const boundingBox = getElementPosition(element.id)
+	const center = {
+		x: (boundingBox.left + boundingBox.right) / 2,
+		y: (boundingBox.top + boundingBox.bottom) / 2,
+	}
+
+	const elementCorners = getRotatedRectCorners(
+		center,
+		div.offsetWidth / 2,
+		div.offsetHeight / 2,
+		element.rotation,
+	)
+	const marqueeCorners = getRectCorners(marqueeBounds)
+
+	// the marquee's edges run along x/y; the element's run along its rotated axes
+	const radians = (element.rotation * Math.PI) / 180
+	const elementAxis = { x: Math.cos(radians), y: Math.sin(radians) }
+	const axes = [
+		{ x: 1, y: 0 },
+		{ x: 0, y: 1 },
+		elementAxis,
+		{ x: -elementAxis.y, y: elementAxis.x },
+	]
+
+	return rectsOverlap(elementCorners, marqueeCorners, axes)
+}
+
+const isElementWithinMarquee = (element, marqueeBounds) => {
+	if (element.rotation) return isRotatedElementWithinMarquee(element, marqueeBounds)
+	return isWithinOverlappingBounds(marqueeBounds, getElementPosition(element.id))
+}
+
 const getElementsWithinMarquee = () => {
 	const marqueeBounds = {
 		left: marqueeRect.left,
@@ -84,17 +161,9 @@ const getElementsWithinMarquee = () => {
 		bottom: marqueeRect.top + marqueeRect.height,
 	}
 
-	const elements = []
-
-	currentSlide.value.elements.forEach((element) => {
-		const elementPosition = getElementPosition(element.id)
-
-		if (isWithinOverlappingBounds(marqueeBounds, elementPosition)) {
-			elements.push(element.id)
-		}
-	})
-
-	return elements
+	return currentSlide.value.elements
+		.filter((element) => isElementWithinMarquee(element, marqueeBounds))
+		.map((element) => element.id)
 }
 
 const endSelection = () => {

--- a/frontend/src/apps/slides/components/MarqueeOverlay.vue
+++ b/frontend/src/apps/slides/components/MarqueeOverlay.vue
@@ -1,0 +1,167 @@
+<template>
+	<div v-if="isSelecting" :style="marqueeStyles"></div>
+</template>
+<script setup>
+import { ref, reactive, computed, inject, onMounted, onBeforeUnmount } from 'vue'
+
+import { currentSlide, slideBounds } from '@/apps/slides/stores/slide'
+import {
+	activeElementIds,
+	setActiveElements,
+	getElementPosition,
+	resetFocus,
+	isWithinOverlappingBounds,
+} from '@/apps/slides/stores/element'
+
+const slideDiv = inject('slideDiv')
+const slideContainerDiv = inject('slideContainerDiv')
+
+const emit = defineEmits(['setIsSelecting'])
+
+const SELECTION_START_THRESHOLD = 4
+
+const isSelecting = ref(false)
+
+const marqueeRect = reactive({
+	left: 0,
+	top: 0,
+	width: 0,
+	height: 0,
+})
+
+let startX = 0
+let startY = 0
+
+const marqueeStyles = computed(() => ({
+	position: 'absolute',
+	backgroundColor: '#70b6f025',
+	outline: `#70B6F092 solid ${0.1 / slideBounds.scale}px`,
+	width: `${marqueeRect.width}px`,
+	height: `${marqueeRect.height}px`,
+	left: `${marqueeRect.left}px`,
+	top: `${marqueeRect.top}px`,
+	boxSizing: 'border-box',
+	zIndex: 9999,
+	pointerEvents: 'none',
+}))
+
+const toSlideCoords = (e) => ({
+	x: (e.clientX - slideBounds.left) / slideBounds.scale,
+	y: (e.clientY - slideBounds.top) / slideBounds.scale,
+})
+
+const initSelection = (e) => {
+	// drawing a marquee always starts from an empty selection
+	activeElementIds.value = []
+
+	isSelecting.value = true
+	emit('setIsSelecting', true)
+
+	const { x, y } = toSlideCoords(e)
+	startX = x
+	startY = y
+
+	Object.assign(marqueeRect, { left: x, top: y, width: 0, height: 0 })
+
+	document.addEventListener('mousemove', updateSelection)
+	document.addEventListener('mouseup', endSelection, { once: true })
+}
+
+const updateSelection = (e) => {
+	const { x, y } = toSlideCoords(e)
+
+	marqueeRect.left = Math.min(x, startX)
+	marqueeRect.top = Math.min(y, startY)
+	marqueeRect.width = Math.abs(x - startX)
+	marqueeRect.height = Math.abs(y - startY)
+}
+
+const getElementsWithinMarquee = () => {
+	const marqueeBounds = {
+		left: marqueeRect.left,
+		top: marqueeRect.top,
+		right: marqueeRect.left + marqueeRect.width,
+		bottom: marqueeRect.top + marqueeRect.height,
+	}
+
+	const elements = []
+
+	currentSlide.value.elements.forEach((element) => {
+		const elementPosition = getElementPosition(element.id)
+
+		if (isWithinOverlappingBounds(marqueeBounds, elementPosition)) {
+			elements.push(element.id)
+		}
+	})
+
+	return elements
+}
+
+const endSelection = () => {
+	isSelecting.value = false
+	emit('setIsSelecting', false)
+
+	document.removeEventListener('mousemove', updateSelection)
+
+	const selectedElements = getElementsWithinMarquee()
+	if (selectedElements.length) setActiveElements(selectedElements)
+
+	Object.assign(marqueeRect, { left: 0, top: 0, width: 0, height: 0 })
+}
+
+let cancelSelectionIntent = null
+
+const watchForSelectionIntent = (downEvent) => {
+	const detectSelection = (moveEvent) => {
+		// button already released (e.g. mouseup outside the window)
+		if (!moveEvent.buttons) return cancelSelectionIntent?.()
+
+		const dx = moveEvent.clientX - downEvent.clientX
+		const dy = moveEvent.clientY - downEvent.clientY
+		if (Math.hypot(dx, dy) < SELECTION_START_THRESHOLD) return
+
+		cancelSelectionIntent?.()
+
+		// anchor the marquee at the press position
+		initSelection(downEvent)
+	}
+
+	const deselectOnRelease = (upEvent) => {
+		cancelSelectionIntent?.()
+		selectSlide(upEvent)
+	}
+
+	cancelSelectionIntent = () => {
+		document.removeEventListener('mousemove', detectSelection)
+		document.removeEventListener('mouseup', deselectOnRelease)
+		cancelSelectionIntent = null
+	}
+
+	document.addEventListener('mousemove', detectSelection)
+	document.addEventListener('mouseup', deselectOnRelease)
+}
+
+const handleMouseDown = (e) => {
+	// marquee / deselect only start from the empty slide or container area
+	if (![slideDiv.value, slideContainerDiv.value].includes(e.target)) return
+
+	watchForSelectionIntent(e)
+}
+
+const selectSlide = (e) => {
+	e.preventDefault()
+	e.stopPropagation()
+	resetFocus()
+}
+
+onMounted(() => {
+	document.addEventListener('mousedown', handleMouseDown)
+})
+
+onBeforeUnmount(() => {
+	cancelSelectionIntent?.()
+	document.removeEventListener('mousedown', handleMouseDown)
+	document.removeEventListener('mousemove', updateSelection)
+	document.removeEventListener('mouseup', endSelection)
+})
+</script>

--- a/frontend/src/apps/slides/components/Resizer.vue
+++ b/frontend/src/apps/slides/components/Resizer.vue
@@ -7,15 +7,16 @@
 			v-show="resizeHandle.isVisible"
 			:key="resizeHandle.direction"
 			:direction="resizeHandle.direction"
+			:currentResizer="currentResizer"
 			@startResize="(e) => startResize(e, resizeHandle.direction)"
 		/>
 
-		<!-- <ResizeIndicator
+		<ResizeIndicator
 			v-show="currentResizer"
 			:type="elementType"
 			:dimensions="dimensions"
 			:indicatorStyles="indicatorStyles"
-		/> -->
+		/>
 	</div>
 </template>
 
@@ -42,7 +43,7 @@ const props = defineProps({
 const { currentResizer, startResize } = inject('resizer', {})
 
 const showRotateHandle = computed(() => {
-	return ['rectangle', 'circle', 'line', 'image'].includes(props.elementType)
+	return ['rectangle', 'circle', 'image'].includes(props.elementType)
 })
 
 const isResizeHandleVisible = (resizer) => {
@@ -104,13 +105,10 @@ const getLineIndicatorPosition = () => {
 const getMediaIndicatorPosition = () => {
 	const resizer = currentResizer.value
 	const offset = getScaledValue(8)
+	const horizontal = resizer.includes('right') ? { right: offset } : { left: offset }
+	const vertical = resizer.includes('bottom') ? { bottom: offset } : { top: offset }
 
-	return {
-		left: resizer.includes('left') ? offset : 'auto',
-		right: resizer.includes('right') ? offset : 'auto',
-		top: resizer.includes('top') ? offset : 'auto',
-		bottom: resizer.includes('bottom') ? offset : 'auto',
-	}
+	return { ...horizontal, ...vertical }
 }
 
 const getPositionStyles = () => {

--- a/frontend/src/apps/slides/components/SelectionBox.vue
+++ b/frontend/src/apps/slides/components/SelectionBox.vue
@@ -14,6 +14,7 @@ import { computed } from 'vue'
 import Resizer from '@/apps/slides/components/Resizer.vue'
 
 import { slideBounds, selectionBounds } from '@/apps/slides/stores/slide'
+import { rotationDelta } from '@/apps/slides/composables/useRotator'
 import {
 	activeElementIds,
 	focusElementId,
@@ -25,10 +26,6 @@ const props = defineProps({
 	isDragging: {
 		type: Boolean,
 		default: false,
-	},
-	rotationDelta: {
-		type: Number,
-		default: 0,
 	},
 	elementOffset: {
 		type: Object,
@@ -53,7 +50,7 @@ const isRotatable = computed(() => {
 
 const selectionRotation = computed(() => {
 	if (activeElementIds.value.length != 1 || !isRotatable.value) return 0
-	return (activeElement.value.rotation || 0) + props.rotationDelta
+	return (activeElement.value.rotation || 0) + rotationDelta.value
 })
 
 const boxStyles = computed(() => {

--- a/frontend/src/apps/slides/components/SelectionBox.vue
+++ b/frontend/src/apps/slides/components/SelectionBox.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-show="selectionBounds.width" ref="selected" :style="boxStyles">
+	<div v-if="activeElementIds.length" :style="boxStyles">
 		<Resizer
 			v-if="showResizers"
 			:elementType="activeElement?.shapeType || activeElement?.type"
@@ -9,11 +9,11 @@
 	</div>
 </template>
 <script setup>
-import { computed, useTemplateRef } from 'vue'
+import { computed } from 'vue'
 
 import Resizer from '@/apps/slides/components/Resizer.vue'
 
-import { slideBounds, selectionBounds, updateSelectionBounds } from '@/apps/slides/stores/slide'
+import { slideBounds, selectionBounds } from '@/apps/slides/stores/slide'
 import {
 	activeElementIds,
 	focusElementId,
@@ -31,8 +31,6 @@ const props = defineProps({
 		default: 0,
 	},
 })
-
-const selectedRef = useTemplateRef('selected')
 
 const showResizers = computed(() => {
 	return activeElementIds.value.length == 1 && !focusElementId.value && !props.isDragging
@@ -69,23 +67,9 @@ const boxStyles = computed(() => ({
 	transformOrigin: 'center center',
 }))
 
-const resetSelection = (oldVal) => {
-	updateSelectionBounds({
-		width: 0,
-		height: 0,
-		left: 0,
-		top: 0,
-	})
-}
-
-const handleSelection = (elementIds) => {
+const handleSelectionChange = (elementIds) => {
 	if (!elementIds.length) return
 	cropSelectionToFitContent(elementIds)
-}
-
-const handleSelectionChange = (elementIds, oldIds) => {
-	resetSelection(oldIds)
-	handleSelection(elementIds)
 }
 
 defineExpose({

--- a/frontend/src/apps/slides/components/SelectionBox.vue
+++ b/frontend/src/apps/slides/components/SelectionBox.vue
@@ -9,24 +9,17 @@
 	</div>
 </template>
 <script setup>
-import { ref, computed, nextTick, useTemplateRef, onMounted, onBeforeUnmount, inject } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 
 import Resizer from '@/apps/slides/components/Resizer.vue'
 
-import { currentSlide, slideBounds, selectionBounds, updateSelectionBounds } from '@/apps/slides/stores/slide'
+import { slideBounds, selectionBounds, updateSelectionBounds } from '@/apps/slides/stores/slide'
 import {
 	activeElementIds,
-	setActiveElements,
-	getElementPosition,
-	resetFocus,
 	focusElementId,
 	activeElement,
-	isWithinOverlappingBounds,
 	cropSelectionToFitContent,
 } from '@/apps/slides/stores/element'
-
-const slideDiv = inject('slideDiv')
-const slideContainerDiv = inject('slideContainerDiv')
 
 const props = defineProps({
 	isDragging: {
@@ -39,16 +32,11 @@ const props = defineProps({
 	},
 })
 
-const emit = defineEmits(['setIsSelecting'])
-
 const selectedRef = useTemplateRef('selected')
 
 const showResizers = computed(() => {
 	return activeElementIds.value.length == 1 && !focusElementId.value && !props.isDragging
 })
-
-const startX = ref(0)
-const startY = ref(0)
 
 const outline = computed(() => {
 	if (activeElement.value?.shapeType == 'line') return 'none'
@@ -81,95 +69,6 @@ const boxStyles = computed(() => ({
 	transformOrigin: 'center center',
 }))
 
-const initSelection = (e) => {
-	activeElementIds.value = []
-	emit('setIsSelecting', true)
-	nextTick(() => {
-		const currentX = (e.clientX - slideBounds.left) / slideBounds.scale
-		const currentY = (e.clientY - slideBounds.top) / slideBounds.scale
-
-		updateSelectionBounds({
-			left: currentX,
-			top: currentY,
-			width: 0,
-			height: 0,
-		})
-
-		startX.value = currentX
-		startY.value = currentY
-	})
-
-	document.addEventListener('mousemove', updateSelection)
-	document.addEventListener('mouseup', endSelection, { once: true })
-}
-
-const updateSelection = (e) => {
-	const currentX = (e.clientX - slideBounds.left) / slideBounds.scale
-	const currentY = (e.clientY - slideBounds.top) / slideBounds.scale
-
-	const newBounds = {
-		width: Math.abs(currentX - startX.value),
-		height: Math.abs(currentY - startY.value),
-	}
-
-	if (currentX < startX.value) {
-		newBounds.left = currentX
-	}
-	if (currentY < startY.value) {
-		newBounds.top = currentY
-	}
-
-	updateSelectionBounds(newBounds)
-}
-
-const removeSelectionBox = () => {
-	updateSelectionBounds({
-		left: 0,
-		top: 0,
-		width: 0,
-		height: 0,
-	})
-}
-
-const getElementsWithinBoxSurface = () => {
-	let elements = []
-
-	const boxBounds = {
-		left: selectionBounds.left,
-		top: selectionBounds.top,
-		right: selectionBounds.left + selectionBounds.width,
-		bottom: selectionBounds.top + selectionBounds.height,
-	}
-
-	currentSlide.value.elements.forEach((element) => {
-		const elementPosition = getElementPosition(element.id)
-
-		const isWithinBounds = isWithinOverlappingBounds(boxBounds, elementPosition)
-
-		if (isWithinBounds) elements.push(element.id)
-	})
-
-	return elements
-}
-
-const updateSelectedElements = () => {
-	const selectedElements = getElementsWithinBoxSurface()
-
-	if (selectedElements.length) {
-		setActiveElements(selectedElements)
-	} else {
-		removeSelectionBox()
-	}
-}
-
-const endSelection = (e) => {
-	emit('setIsSelecting', false)
-
-	document.removeEventListener('mousemove', updateSelection)
-
-	updateSelectedElements()
-}
-
 const resetSelection = (oldVal) => {
 	updateSelectionBounds({
 		width: 0,
@@ -179,50 +78,8 @@ const resetSelection = (oldVal) => {
 	})
 }
 
-const SELECTION_START_THRESHOLD = 4
-
-let cancelSelectionIntent = null
-
-const watchForSelectionIntent = (downEvent) => {
-	const detectSelection = (moveEvent) => {
-		// button already released (e.g. mouseup outside the window)
-		if (!moveEvent.buttons) return cancelSelectionIntent?.()
-
-		const dx = moveEvent.clientX - downEvent.clientX
-		const dy = moveEvent.clientY - downEvent.clientY
-		if (Math.hypot(dx, dy) < SELECTION_START_THRESHOLD) return
-
-		cancelSelectionIntent?.()
-
-		// anchor the marquee at the press position
-		initSelection(downEvent)
-	}
-
-	const deselectOnRelease = (upEvent) => {
-		cancelSelectionIntent?.()
-		selectSlide(upEvent)
-	}
-
-	cancelSelectionIntent = () => {
-		document.removeEventListener('mousemove', detectSelection)
-		document.removeEventListener('mouseup', deselectOnRelease)
-		cancelSelectionIntent = null
-	}
-
-	document.addEventListener('mousemove', detectSelection)
-	document.addEventListener('mouseup', deselectOnRelease)
-}
-
-const handleMouseDown = (e) => {
-	// marquee / deselect only start from the empty slide or container area
-	if (![slideDiv.value, slideContainerDiv.value].includes(e.target)) return
-
-	watchForSelectionIntent(e)
-}
-
 const handleSelection = (elementIds) => {
 	if (!elementIds.length) return
-	document.removeEventListener('mouseup', endSelection)
 	cropSelectionToFitContent(elementIds)
 }
 
@@ -230,23 +87,6 @@ const handleSelectionChange = (elementIds, oldIds) => {
 	resetSelection(oldIds)
 	handleSelection(elementIds)
 }
-
-const selectSlide = (e) => {
-	e.preventDefault()
-	e.stopPropagation()
-	resetFocus()
-}
-
-onMounted(() => {
-	document.addEventListener('mousedown', handleMouseDown)
-})
-
-onBeforeUnmount(() => {
-	cancelSelectionIntent?.()
-	document.removeEventListener('mousedown', handleMouseDown)
-	document.removeEventListener('mousemove', updateSelection)
-	document.removeEventListener('mouseup', endSelection)
-})
 
 defineExpose({
 	handleSelectionChange,

--- a/frontend/src/apps/slides/components/SelectionBox.vue
+++ b/frontend/src/apps/slides/components/SelectionBox.vue
@@ -50,10 +50,6 @@ const showResizers = computed(() => {
 const startX = ref(0)
 const startY = ref(0)
 
-let mousedownTimer = 0
-let longpressDuration = 200
-let mousedownStart
-
 const outline = computed(() => {
 	if (activeElement.value?.shapeType == 'line') return 'none'
 
@@ -104,6 +100,7 @@ const initSelection = (e) => {
 	})
 
 	document.addEventListener('mousemove', updateSelection)
+	document.addEventListener('mouseup', endSelection, { once: true })
 }
 
 const updateSelection = (e) => {
@@ -123,8 +120,6 @@ const updateSelection = (e) => {
 	}
 
 	updateSelectionBounds(newBounds)
-
-	document.addEventListener('mouseup', endSelection)
 }
 
 const removeSelectionBox = () => {
@@ -184,37 +179,45 @@ const resetSelection = (oldVal) => {
 	})
 }
 
-const handleMouseDown = (e) => {
-	// ignore long press outside slideContainer and slide elements
-	if (
-		![slideDiv.value, slideContainerDiv.value].includes(e.target) &&
-		!e.target.hasAttribute('data-index')
-	)
-		return
+const SELECTION_START_THRESHOLD = 4
 
-	// ignore long press when userSelect is enabled
-	if (e.target.getAttribute('contenteditable') == 'true') return
+let cancelSelectionIntent = null
 
-	mousedownStart = new Date().getTime()
-	mousedownTimer = setTimeout(() => {
-		initSelection(e)
-	}, longpressDuration)
+const watchForSelectionIntent = (downEvent) => {
+	const detectSelection = (moveEvent) => {
+		// button already released (e.g. mouseup outside the window)
+		if (!moveEvent.buttons) return cancelSelectionIntent?.()
 
-	document.addEventListener('mouseup', handleMouseUp)
-}
+		const dx = moveEvent.clientX - downEvent.clientX
+		const dy = moveEvent.clientY - downEvent.clientY
+		if (Math.hypot(dx, dy) < SELECTION_START_THRESHOLD) return
 
-const handleMouseLeave = () => {
-	mousedownStart = 0
-	clearTimeout(mousedownTimer)
-}
+		cancelSelectionIntent?.()
 
-const handleMouseUp = (e) => {
-	if (new Date().getTime() < mousedownStart + longpressDuration) {
-		selectSlide(e)
-		clearTimeout(mousedownTimer)
-	} else {
-		mousedownStart = 0
+		// anchor the marquee at the press position
+		initSelection(downEvent)
 	}
+
+	const deselectOnRelease = (upEvent) => {
+		cancelSelectionIntent?.()
+		selectSlide(upEvent)
+	}
+
+	cancelSelectionIntent = () => {
+		document.removeEventListener('mousemove', detectSelection)
+		document.removeEventListener('mouseup', deselectOnRelease)
+		cancelSelectionIntent = null
+	}
+
+	document.addEventListener('mousemove', detectSelection)
+	document.addEventListener('mouseup', deselectOnRelease)
+}
+
+const handleMouseDown = (e) => {
+	// marquee / deselect only start from the empty slide or container area
+	if (![slideDiv.value, slideContainerDiv.value].includes(e.target)) return
+
+	watchForSelectionIntent(e)
 }
 
 const handleSelection = (elementIds) => {
@@ -236,13 +239,12 @@ const selectSlide = (e) => {
 
 onMounted(() => {
 	document.addEventListener('mousedown', handleMouseDown)
-	document.addEventListener('mouseleave', handleMouseLeave)
 })
 
 onBeforeUnmount(() => {
+	cancelSelectionIntent?.()
 	document.removeEventListener('mousedown', handleMouseDown)
-	document.removeEventListener('mouseleave', handleMouseLeave)
-	document.removeEventListener('mouseup', handleMouseUp)
+	document.removeEventListener('mousemove', updateSelection)
 	document.removeEventListener('mouseup', endSelection)
 })
 

--- a/frontend/src/apps/slides/components/SelectionBox.vue
+++ b/frontend/src/apps/slides/components/SelectionBox.vue
@@ -30,6 +30,10 @@ const props = defineProps({
 		type: Number,
 		default: 0,
 	},
+	elementOffset: {
+		type: Object,
+		default: () => ({ left: 0, top: 0 }),
+	},
 })
 
 const showResizers = computed(() => {
@@ -52,20 +56,32 @@ const selectionRotation = computed(() => {
 	return (activeElement.value.rotation || 0) + props.rotationDelta
 })
 
-const boxStyles = computed(() => ({
-	position: 'absolute',
-	backgroundColor: activeElementIds.value.length == 1 ? '' : '#70b6f025',
-	outline: outline.value,
-	width: `${selectionBounds.width}px`,
-	height: `${selectionBounds.height}px`,
-	left: `${selectionBounds.left}px`,
-	top: `${selectionBounds.top}px`,
-	boxSizing: 'border-box',
-	zIndex: 9999,
-	pointerEvents: activeElementIds.value.length == 1 ? 'none' : 'auto',
-	transform: selectionRotation.value ? `rotate(${selectionRotation.value}deg)` : '',
-	transformOrigin: 'center center',
-}))
+const boxStyles = computed(() => {
+	const offsetLeft = props.elementOffset.left
+	const offsetTop = props.elementOffset.top
+
+	// selectionBounds track the live position; rendering subtracts the
+	// transient offset and reapplies it as a transform so moving the box
+	// never triggers layout (matches SlideElement)
+	const offsetTransform =
+		offsetLeft || offsetTop ? `translate(${offsetLeft}px, ${offsetTop}px)` : ''
+	const rotateTransform = selectionRotation.value ? `rotate(${selectionRotation.value}deg)` : ''
+
+	return {
+		position: 'absolute',
+		backgroundColor: activeElementIds.value.length == 1 ? '' : '#70b6f025',
+		outline: outline.value,
+		width: `${selectionBounds.width}px`,
+		height: `${selectionBounds.height}px`,
+		left: `${selectionBounds.left - offsetLeft}px`,
+		top: `${selectionBounds.top - offsetTop}px`,
+		boxSizing: 'border-box',
+		zIndex: 9999,
+		pointerEvents: activeElementIds.value.length == 1 ? 'none' : 'auto',
+		transform: [offsetTransform, rotateTransform].filter(Boolean).join(' '),
+		transformOrigin: 'center center',
+	}
+})
 
 const handleSelectionChange = (elementIds) => {
 	if (!elementIds.length) return

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -124,7 +124,7 @@ const hasOngoingInteraction = computed(
 	() => isDragging.value || isResizing.value || isRotating.value,
 )
 
-const { visibilityMap, resistanceMap, handleSnapping } = useSnapping(
+const { visibilityMap, applySnapping } = useSnapping(
 	selectionBoxRef,
 	slideRef,
 	currentResizer,
@@ -328,62 +328,6 @@ const togglePanZoom = () => {
 	allowPanAndZoom.value = !allowPanAndZoom.value
 }
 
-const applyResistance = (axis, delta) => {
-	const scaledThreshold = (0.01 * selectionBounds.width) / slideBounds.scale
-
-	const escapeDelta = Math.max(1.5, Math.min(5, scaledThreshold))
-
-	let useResistanceKeys = []
-	let pullDelta = null
-
-	if (axis == 'X') {
-		useResistanceKeys = ['left', 'right', 'centerY']
-		pullDelta = delta.left
-	} else if (axis == 'Y') {
-		useResistanceKeys = ['top', 'bottom', 'centerX']
-		pullDelta = delta.top
-	} else if (axis == null && currentResizer.value) {
-		useResistanceKeys = ['left', 'right', 'top', 'bottom', 'centerX', 'centerY']
-		pullDelta = delta.width
-	}
-
-	const useResistance = useResistanceKeys.some((key) => resistanceMap[key])
-
-	return useResistance && Math.abs(pullDelta) < escapeDelta
-}
-
-const updateTotalDeltaForResize = (totalDelta, delta, width, height) => {
-	totalDelta.width = applyResistance(null, delta) ? 0 : width
-	totalDelta.height = applyResistance(null, delta) ? 0 : height
-
-	// if resisting width change, don't apply top change either otherwise
-	// element sticks to one axis and drags on other which shouldn't happen on resize
-	if (totalDelta.width === 0 && !['top', 'bottom'].includes(currentResizer.value)) {
-		totalDelta.top = 0
-	}
-}
-
-const getTotalInteractionDelta = (delta, interaction = 'dragging') => {
-	const snapDelta = handleSnapping(interaction)
-
-	const left = snapDelta.x || delta.left
-	const top = snapDelta.y || delta.top
-
-	const totalDelta = {
-		left: applyResistance('X', delta) ? 0 : left,
-		top: applyResistance('Y', delta) ? 0 : top,
-	}
-
-	const width = snapDelta.width || delta.width
-	const height = snapDelta.height || delta.height
-
-	if (interaction === 'resizing') {
-		updateTotalDeltaForResize(totalDelta, delta, width, height)
-	}
-
-	return totalDelta
-}
-
 const elementOffset = reactive({
 	left: 0,
 	top: 0,
@@ -397,22 +341,27 @@ let dragAnchor = null
 const handlePositionChange = (total) => {
 	if (!dragAnchor) return
 
-	const desiredLeft = dragAnchor.left + total.left / slideBounds.scale
-	const desiredTop = dragAnchor.top + total.top / slideBounds.scale
+	// snap the desired (cursor-anchored) position, then correct toward it —
+	// the element sits wherever the snapped desired geometry says, so it can
+	// never drift from the cursor
+	const desired = applySnapping(
+		{
+			left: dragAnchor.left + total.left / slideBounds.scale,
+			top: dragAnchor.top + total.top / slideBounds.scale,
+			width: selectionBounds.width,
+			height: selectionBounds.height,
+		},
+		'dragging',
+	)
 
-	// correction toward the cursor-anchored position: snapping and resistance
-	// may withhold or replace it this frame, but the next frame re-measures
-	// against the cursor, so the element can never permanently drift
 	const delta = {
-		left: (desiredLeft - selectionBounds.left) * slideBounds.scale,
-		top: (desiredTop - selectionBounds.top) * slideBounds.scale,
+		left: (desired.left - selectionBounds.left) * slideBounds.scale,
+		top: (desired.top - selectionBounds.top) * slideBounds.scale,
 	}
 
 	if (!delta.left && !delta.top) return
 
-	const totalDelta = getTotalInteractionDelta(delta)
-
-	applyPositionDelta(totalDelta)
+	applyPositionDelta(delta)
 }
 
 const CORNER_RESIZERS = ['top-left', 'top-right', 'bottom-left', 'bottom-right']
@@ -491,22 +440,61 @@ const applyDimensionDelta = (delta) => {
 	elementOffset.height += deltaHeight
 }
 
-const handleDimensionChange = (delta) => {
-	if (!delta.width && !delta.height) return
+// selection bounds + dimensions at resize start — captured synchronously in
+// startElementResize, same rule as the drag anchor
+let resizeAnchor = null
 
-	if (['image', 'video'].includes(activeElement.value.type)) {
-		applyAspectRatio(delta)
+const startElementResize = (e, resizer) => {
+	resizeAnchor = {
+		left: selectionBounds.left,
+		top: selectionBounds.top,
+		width: selectionBounds.width,
+		height: selectionBounds.height,
 	}
+
+	startResize(e, resizer)
+}
+
+const handleDimensionChange = (total) => {
+	if (!resizeAnchor) return
+
+	const scale = slideBounds.scale
+	const size = getCurrentSize()
+
+	const isMedia = ['image', 'video'].includes(activeElement.value.type)
+
+	// snap the desired (cursor-anchored) geometry, then correct toward it —
+	// same model as drag, so the handle can never drift from the cursor.
+	// media only snap their width edges: height/top derive from aspect below
+	const desired = applySnapping(
+		{
+			left: resizeAnchor.left + total.left / scale,
+			top: resizeAnchor.top + total.top / scale,
+			width: resizeAnchor.width + total.width / scale,
+			height: resizeAnchor.height + total.height / scale,
+		},
+		'resizing',
+		{ axes: isMedia ? ['x'] : ['x', 'y'] },
+	)
+
+	const delta = {
+		width: (desired.width - size.width) * scale,
+		height: (desired.height - size.height) * scale,
+		left: (desired.left - selectionBounds.left) * scale,
+		top: (desired.top - selectionBounds.top) * scale,
+	}
+
+	if (!delta.width && !delta.height && !delta.left && !delta.top) return
+
+	if (isMedia) applyAspectRatio(delta)
 
 	clampToMinSizes(delta)
 
-	const totalDelta = getTotalInteractionDelta(delta, 'resizing')
-
-	applyPositionDelta(totalDelta)
+	applyPositionDelta(delta)
 
 	if (!activeElement.value.width) addFixedWidthToElement()
 
-	applyDimensionDelta(totalDelta)
+	applyDimensionDelta(delta)
 }
 
 const updateSlideBounds = () => {
@@ -583,7 +571,7 @@ provide('slideDiv', slideRef)
 provide('slideContainerDiv', slideContainerRef)
 provide('resizer', {
 	currentResizer,
-	startResize,
+	startResize: startElementResize,
 })
 provide('rotator', {
 	startRotate,

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -379,7 +379,29 @@ const elementOffset = reactive({
 	height: 0,
 })
 
-const handlePositionChange = (delta) => {
+// selection bounds at drag start — anchored lazily on the first flushed
+// delta, after any selection change from the same mousedown has updated bounds
+let dragAnchor = null
+
+const handlePositionChange = (total) => {
+	if (!dragAnchor) {
+		dragAnchor = {
+			left: selectionBounds.left - total.left / slideBounds.scale,
+			top: selectionBounds.top - total.top / slideBounds.scale,
+		}
+	}
+
+	const desiredLeft = dragAnchor.left + total.left / slideBounds.scale
+	const desiredTop = dragAnchor.top + total.top / slideBounds.scale
+
+	// correction toward the cursor-anchored position: snapping and resistance
+	// may withhold or replace it this frame, but the next frame re-measures
+	// against the cursor, so the element can never permanently drift
+	const delta = {
+		left: (desiredLeft - selectionBounds.left) * slideBounds.scale,
+		top: (desiredTop - selectionBounds.top) * slideBounds.scale,
+	}
+
 	if (!delta.left && !delta.top) return
 
 	const totalDelta = getTotalInteractionDelta(delta)
@@ -485,10 +507,19 @@ watch(
 	},
 )
 
+// registered before the positionDelta watcher so a new drag invalidates the
+// anchor before the first delta of that drag is processed
+watch(
+	() => isDragging.value,
+	(dragging) => {
+		if (dragging) dragAnchor = null
+	},
+)
+
 watch(
 	() => positionDelta.value,
-	(delta) => {
-		handlePositionChange(delta)
+	(total) => {
+		handlePositionChange(total)
 	},
 )
 

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -94,6 +94,7 @@ import {
 	getResizedBox,
 	getResizedLine,
 	getResizedTextBox,
+	getRotatedBoundingBox,
 	isAspectLocked,
 	getMinSizeForElement,
 } from '@/apps/slides/utils/resize'
@@ -333,6 +334,15 @@ const elementOffset = reactive({
 // selection bounds at drag start — captured synchronously in triggerDrag
 let dragStartBounds = null
 
+const snapRotatedPosition = (target, rotation) => {
+	const boundingBox = getRotatedBoundingBox(target, rotation)
+	const snapped = snapForDrag(boundingBox)
+	return {
+		left: target.left + (snapped.left - boundingBox.left),
+		top: target.top + (snapped.top - boundingBox.top),
+	}
+}
+
 const handlePositionChange = (total) => {
 	if (!dragStartBounds) return
 
@@ -342,7 +352,8 @@ const handlePositionChange = (total) => {
 		width: selectionBounds.width,
 		height: selectionBounds.height,
 	}
-	const desired = activeElement.value?.rotation ? target : snapForDrag(target)
+	const rotation = activeElement.value?.rotation
+	const desired = rotation ? snapRotatedPosition(target, rotation) : snapForDrag(target)
 
 	elementOffset.left = desired.left - dragStartBounds.left
 	elementOffset.top = desired.top - dragStartBounds.top
@@ -379,6 +390,8 @@ const resizeBox = (cursorMovement) => {
 	if (!box) return
 
 	const axes = isAspectLocked(resizeStartBounds.type) ? ['x'] : ['x', 'y']
+	// resize runs in the element's rotated local frame; the snap engine works on
+	// screen-axis-aligned boxes, so snapping a rotated resize isn't supported yet
 	const snappedBox = resizeStartBounds.rotation ? box : snapForResize(box, { axes })
 	setOffsetFromBox(snappedBox)
 }

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -13,7 +13,6 @@
 				ref="selectionBox"
 				v-if="!inReadonlyMode"
 				:isDragging
-				:rotationDelta="rotationDelta"
 				:elementOffset
 				@mousedown="(e) => handleMouseDown(e)"
 			/>
@@ -32,7 +31,6 @@
 				mode="editor"
 				:element
 				:elementOffset
-				:rotationDelta="rotationDelta"
 				:data-index="element.id"
 				:highlight="highlightElement(element)"
 				@mousedown="(e) => handleMouseDown(e, element)"

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -284,21 +284,31 @@ const activeDiv = computed(() => {
 useResizeObserver(activeDiv, (entries) => {
 	const entry = entries[0]
 	const { width, height } = entry.contentRect
-	const target = entry.target.getBoundingClientRect()
-	const useLayoutPosition = ['shape', 'image'].includes(activeElement.value?.type)
 
-	// case:
-	// when element dimensions are changed not by resizer
-	// but by other updates on properties - font size, line height, letter spacing etc.
+	// fires on any size change: resize gestures, and property updates like
+	// font size / line height / letter spacing
+
+	// shapes/images are layout-anchored: left/top derive from element state,
+	// no forced-layout read needed
+	if (['shape', 'image'].includes(activeElement.value?.type)) {
+		updateSelectionBounds({
+			width: width,
+			height: height,
+			left: activeElement.value.left + elementOffset.left,
+			top: activeElement.value.top + elementOffset.top,
+		})
+		return
+	}
+
+	// text elements are center-anchored (translate(-50%, -50%)): their visual
+	// left/top shift whenever the size changes, so read the rendered rect
+	const target = entry.target.getBoundingClientRect()
+
 	updateSelectionBounds({
 		width: width,
 		height: height,
-		left: useLayoutPosition
-			? activeElement.value.left + elementOffset.left
-			: (target.left - slideBounds.left) / scale.value,
-		top: useLayoutPosition
-			? activeElement.value.top + elementOffset.top
-			: (target.top - slideBounds.top) / scale.value,
+		left: (target.left - slideBounds.left) / scale.value,
+		top: (target.top - slideBounds.top) / scale.value,
 	})
 })
 

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -27,6 +27,7 @@
 			<SlideElement
 				v-for="element in currentSlide?.elements"
 				:key="`editor-${element.id}`"
+				:ref="(comp) => registerElementDiv(element.id, comp?.$el)"
 				mode="editor"
 				:element
 				:elementOffset
@@ -88,6 +89,8 @@ import {
 import { commandHistory } from '@/apps/slides/stores/historyMeta'
 
 import { handleCopy, handlePaste } from '@/apps/slides/stores/copyPaste'
+
+import { registerElementDiv, getElementDiv } from '@/apps/slides/stores/elementRegistry'
 
 import { useDragAndDrop } from '@/apps/slides/composables/useDragAndDrop'
 import { useResizer } from '@/apps/slides/composables/useResizer'
@@ -275,7 +278,7 @@ const scale = computed(() => {
 
 const activeDiv = computed(() => {
 	if (activeElementIds.value.length != 1) return null
-	return document.querySelector(`[data-index="${activeElementIds.value[0]}"]`)
+	return getElementDiv(activeElementIds.value[0])
 })
 
 useResizeObserver(activeDiv, (entries) => {

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -33,7 +33,6 @@
 				:data-index="element.id"
 				:highlight="highlightElement(element)"
 				@mousedown="(e) => handleMouseDown(e, element)"
-				@clearTimeouts="clearTimeouts"
 			/>
 		</div>
 		<DropTargetOverlay v-show="mediaDragOver" @hideOverlay="hideOverlay" />
@@ -177,12 +176,6 @@ const hideOverlay = () => {
 	mediaDragOver.value = false
 }
 
-let clickTimeout
-
-const clearTimeouts = () => {
-	clearTimeout(clickTimeout)
-}
-
 const triggerSelection = (e, id) => {
 	if (id) {
 		if (!activeElementIds.value.includes(id)) {
@@ -199,11 +192,9 @@ const triggerSelection = (e, id) => {
 }
 
 const handleMouseUp = (e, id) => {
-	clearTimeouts()
-
 	pairElementId.value = null
 
-	if (!isDragging.value) clickTimeout = setTimeout(() => triggerSelection(e, id), 200)
+	if (!isDragging.value) triggerSelection(e, id)
 }
 
 const triggerDrag = (e, id) => {

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -100,6 +100,7 @@ import { useSnapping } from '@/apps/slides/composables/useSnapping'
 import { editElementCommand, batchCommand } from '@/apps/slides/stores/commands'
 
 import { isCmdOrCtrl } from '@/apps/slides/utils/helpers'
+import { minElementSizes } from '@/apps/slides/utils/constants'
 
 const props = defineProps({
 	highlight: Boolean,
@@ -427,14 +428,41 @@ const applyAspectRatio = (delta, type) => {
 	delta.top = (delta.top ?? 0) / ratio
 }
 
-const validateMinWidth = (width) => {
-	const minWidth = activeElement.value?.type === 'text' ? 7 : 1
-	return width / slideBounds.scale + selectionBounds.width > minWidth
+const getMinSizes = () => {
+	return minElementSizes[activeElement.value?.type] ?? minElementSizes.default
 }
 
-const validateMinHeight = (height) => {
-	const minHeight = activeElement.value?.type === 'text' ? 7 : 29
-	return height / slideBounds.scale + selectionBounds.height > minHeight
+// live size during a gesture (selectionBounds lag a frame behind the observer)
+const getCurrentSize = () => ({
+	width: (activeElement.value?.width ?? selectionBounds.width) + elementOffset.width,
+	height: (activeElement.value?.height ?? selectionBounds.height) + elementOffset.height,
+})
+
+// fraction (0..1) of a shrink that fits above the minimum; growing always fits
+const allowedShrinkFraction = (deltaPx, current, min) => {
+	if (deltaPx >= 0) return 1
+
+	const requestedShrink = -deltaPx / slideBounds.scale
+	return Math.min(1, Math.max(0, (current - min) / requestedShrink))
+}
+
+// scale the whole delta so no dimension crosses its minimum — position deltas
+// derive from size deltas, so they must shrink together or the element slides
+const clampToMinSizes = (delta) => {
+	const min = getMinSizes()
+	const size = getCurrentSize()
+
+	const factor = Math.min(
+		allowedShrinkFraction(delta.width, size.width, min.width),
+		allowedShrinkFraction(delta.height, size.height, min.height),
+	)
+
+	if (factor < 1) {
+		delta.width *= factor
+		delta.height *= factor
+		delta.left *= factor
+		delta.top *= factor
+	}
 }
 
 const applyPositionDelta = (delta) => {
@@ -464,12 +492,12 @@ const applyDimensionDelta = (delta) => {
 
 const handleDimensionChange = (delta) => {
 	if (!delta.width && !delta.height) return
-	if (!validateMinWidth(delta.width)) delta.width = 0
-	if (!validateMinHeight(delta.height)) delta.height = 0
 
 	if (['shape', 'image', 'video'].includes(activeElement.value.type)) {
 		applyAspectRatio(delta, activeElement.value.type)
 	}
+
+	clampToMinSizes(delta)
 
 	const totalDelta = getTotalInteractionDelta(delta, 'resizing')
 

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -97,7 +97,13 @@ import { useSnapping } from '@/apps/slides/composables/useSnapping'
 import { editElementCommand, batchCommand } from '@/apps/slides/stores/commands'
 
 import { isCmdOrCtrl } from '@/apps/slides/utils/helpers'
-import { minElementSizes } from '@/apps/slides/utils/constants'
+import {
+	getResizedBox,
+	getResizedLine,
+	getResizedTextBox,
+	isAspectLocked,
+	getMinSizeForElement,
+} from '@/apps/slides/utils/resize'
 
 const props = defineProps({
 	highlight: Boolean,
@@ -113,7 +119,7 @@ const selectionBoxRef = useTemplateRef('selectionBox')
 
 const { isDragging, positionDelta, startDragging } = useDragAndDrop()
 
-const { isResizing, dimensionDelta, currentResizer, resizeCursor, startResize } = useResizer()
+const { isResizing, pointerDelta, currentResizer, resizeCursor, startResize } = useResizer()
 
 const { isRotating, rotationDelta, startRotate, resetRotation } = useRotator()
 
@@ -221,7 +227,7 @@ const triggerDrag = (e, id) => {
 
 		// anchor synchronously: the drag math must never depend on watcher
 		// flush order or on a previous gesture's state
-		dragAnchor = {
+		dragStartBounds = {
 			left: selectionBounds.left,
 			top: selectionBounds.top,
 		}
@@ -332,161 +338,96 @@ const elementOffset = reactive({
 })
 
 // selection bounds at drag start — captured synchronously in triggerDrag
-let dragAnchor = null
+let dragStartBounds = null
 
 const handlePositionChange = (total) => {
-	if (!dragAnchor) return
+	if (!dragStartBounds) return
 
-	// snap the desired (cursor-anchored) position, then correct toward it —
-	// the element sits wherever the snapped desired geometry says, so it can
-	// never drift from the cursor
-	const desired = snapForDrag({
-		left: dragAnchor.left + total.left / slideBounds.scale,
-		top: dragAnchor.top + total.top / slideBounds.scale,
+	const target = {
+		left: dragStartBounds.left + total.left / slideBounds.scale,
+		top: dragStartBounds.top + total.top / slideBounds.scale,
 		width: selectionBounds.width,
 		height: selectionBounds.height,
-	})
-
-	const delta = {
-		left: (desired.left - selectionBounds.left) * slideBounds.scale,
-		top: (desired.top - selectionBounds.top) * slideBounds.scale,
 	}
+	const desired = activeElement.value?.rotation ? target : snapForDrag(target)
 
-	if (!delta.left && !delta.top) return
-
-	applyPositionDelta(delta)
+	elementOffset.left = desired.left - dragStartBounds.left
+	elementOffset.top = desired.top - dragStartBounds.top
+	updateSelectionBounds({ left: desired.left, top: desired.top })
 }
 
-const CORNER_RESIZERS = ['top-left', 'top-right', 'bottom-left', 'bottom-right']
-
-// media corners lock aspect: rendered height follows width through layout,
-// so the cursor's Y axis is discarded and top derives from the width delta
-const applyAspectRatio = (delta) => {
-	if (!CORNER_RESIZERS.includes(currentResizer.value)) return
-
-	const ratio = selectionBounds.width / selectionBounds.height
-
-	delta.height = 0
-	delta.top = ['top-left', 'top-right'].includes(currentResizer.value) ? -delta.width / ratio : 0
-}
-
-const getMinSizes = () => {
-	return minElementSizes[activeElement.value?.type] ?? minElementSizes.default
-}
-
-// live size during a gesture (selectionBounds lag a frame behind the observer)
-const getCurrentSize = () => ({
-	width: (activeElement.value?.width ?? selectionBounds.width) + elementOffset.width,
-	height: (activeElement.value?.height ?? selectionBounds.height) + elementOffset.height,
-})
-
-// fraction (0..1) of a shrink that fits above the minimum; growing always fits
-const allowedShrinkFraction = (deltaPx, current, min) => {
-	if (deltaPx >= 0) return 1
-
-	const requestedShrink = -deltaPx / slideBounds.scale
-	return Math.min(1, Math.max(0, (current - min) / requestedShrink))
-}
-
-// clamp each axis at its minimum, scaling the linked position delta with it —
-// clamping size alone would let the element slide while pinned
-const clampToMinSizes = (delta) => {
-	const min = getMinSizes()
-	const size = getCurrentSize()
-
-	const widthFactor = allowedShrinkFraction(delta.width, size.width, min.width)
-	const heightFactor = allowedShrinkFraction(delta.height, size.height, min.height)
-
-	delta.width *= widthFactor
-	delta.left *= widthFactor
-
-	delta.height *= heightFactor
-
-	// media corner top derives from width (aspect lock); otherwise top
-	// belongs to the height axis
-	const topFollowsWidth = ['image', 'video'].includes(activeElement.value?.type)
-	delta.top *= topFollowsWidth ? widthFactor : heightFactor
-}
-
-const applyPositionDelta = (delta) => {
-	if (!delta.left && !delta.top) return
-
-	const deltaLeft = delta.left / slideBounds.scale
-	const deltaTop = delta.top / slideBounds.scale
-
-	updateSelectionBounds({
-		left: selectionBounds.left + deltaLeft,
-		top: selectionBounds.top + deltaTop,
-	})
-
-	elementOffset.left += deltaLeft
-	elementOffset.top += deltaTop
-}
-
-const applyDimensionDelta = (delta) => {
-	if (!delta.width && !delta.height) return
-
-	const deltaWidth = delta.width / slideBounds.scale
-	const deltaHeight = delta.height / slideBounds.scale
-
-	elementOffset.width += deltaWidth
-	elementOffset.height += deltaHeight
-}
-
-// selection bounds + dimensions at resize start — captured synchronously in
-// startElementResize, same rule as the drag anchor
-let resizeAnchor = null
+// the element's box + type when the resize began, captured synchronously like dragStartBounds
+let resizeStartBounds = null
 
 const startElementResize = (e, resizer) => {
-	resizeAnchor = {
+	resizeStartBounds = {
 		left: selectionBounds.left,
 		top: selectionBounds.top,
 		width: selectionBounds.width,
 		height: selectionBounds.height,
+		rotation: activeElement.value?.rotation || 0,
+		type: activeElement.value?.type,
 	}
 
 	startResize(e, resizer)
 }
 
-const handleDimensionChange = (total) => {
-	if (!resizeAnchor) return
+const setOffsetFromBox = (box) => {
+	elementOffset.left = box.left - resizeStartBounds.left
+	elementOffset.top = box.top - resizeStartBounds.top
+	elementOffset.width = box.width - resizeStartBounds.width
+	elementOffset.height = box.height - resizeStartBounds.height
 
-	const scale = slideBounds.scale
-	const size = getCurrentSize()
+	updateSelectionBounds({ left: box.left, top: box.top, width: box.width, height: box.height })
+}
 
-	const isMedia = ['image', 'video'].includes(activeElement.value.type)
+const resizeBox = (cursorMovement) => {
+	const box = getResizedBox(resizeStartBounds, currentResizer.value, cursorMovement)
+	if (!box) return
 
-	// snap the desired (cursor-anchored) geometry, then correct toward it —
-	// same model as drag, so the handle can never drift from the cursor.
-	// media only snap their width edges: height/top derive from aspect below
-	const desired = snapForResize(
-		{
-			left: resizeAnchor.left + total.left / scale,
-			top: resizeAnchor.top + total.top / scale,
-			width: resizeAnchor.width + total.width / scale,
-			height: resizeAnchor.height + total.height / scale,
-		},
-		{ axes: isMedia ? ['x'] : ['x', 'y'] },
-	)
+	const axes = isAspectLocked(resizeStartBounds.type) ? ['x'] : ['x', 'y']
+	const snappedBox = resizeStartBounds.rotation ? box : snapForResize(box, { axes })
+	setOffsetFromBox(snappedBox)
+}
 
-	const delta = {
-		width: (desired.width - size.width) * scale,
-		height: (desired.height - size.height) * scale,
-		left: (desired.left - selectionBounds.left) * scale,
-		top: (desired.top - selectionBounds.top) * scale,
-	}
+const resizeLine = (cursorMovement) => {
+	const box = getResizedLine(resizeStartBounds, currentResizer.value, cursorMovement)
 
-	if (!delta.width && !delta.height && !delta.left && !delta.top) return
+	setOffsetFromBox(box)
+	rotationDelta.value = box.rotation - resizeStartBounds.rotation
+}
 
-	if (isMedia) applyAspectRatio(delta)
+const setOffsetFromTextBox = (box) => {
+	const minWidth = getMinSizeForElement(resizeStartBounds.type).width
+	const grabbingRight = currentResizer.value === 'text-right'
 
-	clampToMinSizes(delta)
+	const fixedEdge = grabbingRight ? box.left : box.left + box.width
+	const width = Math.max(minWidth, box.width)
+	const centre = grabbingRight ? fixedEdge + width / 2 : fixedEdge - width / 2
 
-	applyPositionDelta(delta)
+	elementOffset.width = width - resizeStartBounds.width
+	elementOffset.left = centre - (resizeStartBounds.left + resizeStartBounds.width / 2)
+}
 
+const resizeText = (cursorMovement) => {
 	if (!activeElement.value.width) addFixedWidthToElement()
 
-	applyDimensionDelta(delta)
+	const box = getResizedTextBox(resizeStartBounds, currentResizer.value, cursorMovement)
+	const snappedBox = snapForResize(box, { axes: ['x'] })
+	setOffsetFromTextBox(snappedBox)
+}
+
+const handleResize = () => {
+	if (!resizeStartBounds) return
+
+	const cursorMovement = {
+		x: pointerDelta.value.x / slideBounds.scale,
+		y: pointerDelta.value.y / slideBounds.scale,
+	}
+	const handle = currentResizer.value
+	if (handle === 'text-left' || handle === 'text-right') return resizeText(cursorMovement)
+	if (handle === 'line-left' || handle === 'line-right') return resizeLine(cursorMovement)
+	resizeBox(cursorMovement)
 }
 
 const updateSlideBounds = () => {
@@ -529,10 +470,8 @@ watch(
 )
 
 watch(
-	() => dimensionDelta.value,
-	(delta) => {
-		handleDimensionChange(delta)
-	},
+	() => pointerDelta.value,
+	() => handleResize(),
 )
 
 const initSlideAndListeners = () => {

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -2,13 +2,7 @@
 	<div ref="slideContainer" class="flex size-full" @dragenter="showOverlay">
 		<!-- when mounting place slide directly in the center of the visible container -->
 		<!-- 1/2 width of viewport + 1/2 width of offset caused due to thinner navigation panel -->
-		<div
-			ref="slideRef"
-			:style="slideStyles"
-			:class="slideClasses"
-			@contextmenu.prevent
-			@dblclick="handleSlideDoubleClick"
-		>
+		<div ref="slideRef" :style="slideStyles" :class="slideClasses" @contextmenu.prevent>
 			<SelectionBox
 				ref="selectionBox"
 				v-if="!inReadonlyMode"
@@ -79,7 +73,6 @@ import {
 	setEditableState,
 	duplicateElements,
 	activeElements,
-	addTextElement,
 	cropSelectionToFitContent,
 } from '@/apps/slides/stores/element'
 
@@ -583,12 +576,4 @@ watch(
 		emit('update:hasOngoingInteraction', newVal)
 	},
 )
-
-const handleSlideDoubleClick = (e) => {
-	if (inReadonlyMode.value || e.target !== e.currentTarget) return
-	addTextElement('', {
-		left: (e.clientX - slideBounds.left) / scale.value,
-		top: (e.clientY - slideBounds.top) / scale.value,
-	})
-}
 </script>

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -415,17 +415,17 @@ const handlePositionChange = (total) => {
 	applyPositionDelta(totalDelta)
 }
 
-const applyAspectRatio = (delta, type) => {
-	if (!['top-left', 'top-right', 'bottom-left', 'bottom-right'].includes(currentResizer.value))
-		return
+const CORNER_RESIZERS = ['top-left', 'top-right', 'bottom-left', 'bottom-right']
 
-	if (type == 'shape') {
-		delta.height = delta.width
-	}
+// media corners lock aspect: rendered height follows width through layout,
+// so the cursor's Y axis is discarded and top derives from the width delta
+const applyAspectRatio = (delta) => {
+	if (!CORNER_RESIZERS.includes(currentResizer.value)) return
 
-	if (!delta.top || !['image', 'video'].includes(type)) return
 	const ratio = selectionBounds.width / selectionBounds.height
-	delta.top = (delta.top ?? 0) / ratio
+
+	delta.height = 0
+	delta.top = ['top-left', 'top-right'].includes(currentResizer.value) ? -delta.width / ratio : 0
 }
 
 const getMinSizes = () => {
@@ -446,23 +446,24 @@ const allowedShrinkFraction = (deltaPx, current, min) => {
 	return Math.min(1, Math.max(0, (current - min) / requestedShrink))
 }
 
-// scale the whole delta so no dimension crosses its minimum — position deltas
-// derive from size deltas, so they must shrink together or the element slides
+// clamp each axis at its minimum, scaling the linked position delta with it —
+// clamping size alone would let the element slide while pinned
 const clampToMinSizes = (delta) => {
 	const min = getMinSizes()
 	const size = getCurrentSize()
 
-	const factor = Math.min(
-		allowedShrinkFraction(delta.width, size.width, min.width),
-		allowedShrinkFraction(delta.height, size.height, min.height),
-	)
+	const widthFactor = allowedShrinkFraction(delta.width, size.width, min.width)
+	const heightFactor = allowedShrinkFraction(delta.height, size.height, min.height)
 
-	if (factor < 1) {
-		delta.width *= factor
-		delta.height *= factor
-		delta.left *= factor
-		delta.top *= factor
-	}
+	delta.width *= widthFactor
+	delta.left *= widthFactor
+
+	delta.height *= heightFactor
+
+	// media corner top derives from width (aspect lock); otherwise top
+	// belongs to the height axis
+	const topFollowsWidth = ['image', 'video'].includes(activeElement.value?.type)
+	delta.top *= topFollowsWidth ? widthFactor : heightFactor
 }
 
 const applyPositionDelta = (delta) => {
@@ -493,8 +494,8 @@ const applyDimensionDelta = (delta) => {
 const handleDimensionChange = (delta) => {
 	if (!delta.width && !delta.height) return
 
-	if (['shape', 'image', 'video'].includes(activeElement.value.type)) {
-		applyAspectRatio(delta, activeElement.value.type)
+	if (['image', 'video'].includes(activeElement.value.type)) {
+		applyAspectRatio(delta)
 	}
 
 	clampToMinSizes(delta)

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -19,10 +19,7 @@
 
 			<MarqueeOverlay v-if="!inReadonlyMode" @setIsSelecting="(val) => (isSelecting = val)" />
 
-			<SnapGuides
-				:ongoingInteraction="hasOngoingInteraction"
-				:visibilityMap="visibilityMap"
-			/>
+			<SnapGuides :ongoingInteraction="hasOngoingInteraction" :activeGuides="activeGuides" />
 
 			<SlideElement
 				v-for="element in currentSlide?.elements"
@@ -124,9 +121,8 @@ const hasOngoingInteraction = computed(
 	() => isDragging.value || isResizing.value || isRotating.value,
 )
 
-const { visibilityMap, applySnapping } = useSnapping(
+const { activeGuides, snapForDrag, snapForResize } = useSnapping(
 	selectionBoxRef,
-	slideRef,
 	currentResizer,
 	hasOngoingInteraction,
 )
@@ -344,15 +340,12 @@ const handlePositionChange = (total) => {
 	// snap the desired (cursor-anchored) position, then correct toward it —
 	// the element sits wherever the snapped desired geometry says, so it can
 	// never drift from the cursor
-	const desired = applySnapping(
-		{
-			left: dragAnchor.left + total.left / slideBounds.scale,
-			top: dragAnchor.top + total.top / slideBounds.scale,
-			width: selectionBounds.width,
-			height: selectionBounds.height,
-		},
-		'dragging',
-	)
+	const desired = snapForDrag({
+		left: dragAnchor.left + total.left / slideBounds.scale,
+		top: dragAnchor.top + total.top / slideBounds.scale,
+		width: selectionBounds.width,
+		height: selectionBounds.height,
+	})
 
 	const delta = {
 		left: (desired.left - selectionBounds.left) * slideBounds.scale,
@@ -466,14 +459,13 @@ const handleDimensionChange = (total) => {
 	// snap the desired (cursor-anchored) geometry, then correct toward it —
 	// same model as drag, so the handle can never drift from the cursor.
 	// media only snap their width edges: height/top derive from aspect below
-	const desired = applySnapping(
+	const desired = snapForResize(
 		{
 			left: resizeAnchor.left + total.left / scale,
 			top: resizeAnchor.top + total.top / scale,
 			width: resizeAnchor.width + total.width / scale,
 			height: resizeAnchor.height + total.height / scale,
 		},
-		'resizing',
 		{ axes: isMedia ? ['x'] : ['x', 'y'] },
 	)
 

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -429,12 +429,12 @@ const applyAspectRatio = (delta, type) => {
 
 const validateMinWidth = (width) => {
 	const minWidth = activeElement.value?.type === 'text' ? 7 : 1
-	return width + selectionBounds.width > minWidth
+	return width / slideBounds.scale + selectionBounds.width > minWidth
 }
 
 const validateMinHeight = (height) => {
 	const minHeight = activeElement.value?.type === 'text' ? 7 : 29
-	return height + selectionBounds.height > minHeight
+	return height / slideBounds.scale + selectionBounds.height > minHeight
 }
 
 const applyPositionDelta = (delta) => {

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -14,6 +14,7 @@
 				v-if="!inReadonlyMode"
 				:isDragging
 				:rotationDelta="rotationDelta"
+				:elementOffset
 				@mousedown="(e) => handleMouseDown(e)"
 			/>
 
@@ -84,6 +85,7 @@ import {
 	duplicateElements,
 	activeElements,
 	addTextElement,
+	cropSelectionToFitContent,
 } from '@/apps/slides/stores/element'
 
 import { commandHistory } from '@/apps/slides/stores/historyMeta'
@@ -216,6 +218,17 @@ const triggerDrag = (e, id) => {
 		if (id && !isMultiSelect && activeElementIds.value[0] !== id) {
 			activeElementIds.value = [id]
 			focusElementId.value = null
+
+			// the selection watcher will crop async — too late for the drag
+			// anchor below, so fit the bounds to this element now
+			cropSelectionToFitContent([id])
+		}
+
+		// anchor synchronously: the drag math must never depend on watcher
+		// flush order or on a previous gesture's state
+		dragAnchor = {
+			left: selectionBounds.left,
+			top: selectionBounds.top,
 		}
 	}
 }
@@ -379,17 +392,11 @@ const elementOffset = reactive({
 	height: 0,
 })
 
-// selection bounds at drag start — anchored lazily on the first flushed
-// delta, after any selection change from the same mousedown has updated bounds
+// selection bounds at drag start — captured synchronously in triggerDrag
 let dragAnchor = null
 
 const handlePositionChange = (total) => {
-	if (!dragAnchor) {
-		dragAnchor = {
-			left: selectionBounds.left - total.left / slideBounds.scale,
-			top: selectionBounds.top - total.top / slideBounds.scale,
-		}
-	}
+	if (!dragAnchor) return
 
 	const desiredLeft = dragAnchor.left + total.left / slideBounds.scale
 	const desiredTop = dragAnchor.top + total.top / slideBounds.scale
@@ -504,15 +511,6 @@ watch(
 	() => {
 		if (!transform.value) return
 		handleSlideTransform()
-	},
-)
-
-// registered before the positionDelta watcher so a new drag invalidates the
-// anchor before the first delta of that drag is processed
-watch(
-	() => isDragging.value,
-	(dragging) => {
-		if (dragging) dragAnchor = null
 	},
 )
 

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -15,8 +15,9 @@
 				:isDragging
 				:rotationDelta="rotationDelta"
 				@mousedown="(e) => handleMouseDown(e)"
-				@setIsSelecting="(val) => (isSelecting = val)"
 			/>
+
+			<MarqueeOverlay v-if="!inReadonlyMode" @setIsSelecting="(val) => (isSelecting = val)" />
 
 			<SnapGuides
 				:ongoingInteraction="hasOngoingInteraction"
@@ -59,6 +60,7 @@ import { useResizeObserver } from '@vueuse/core'
 
 import SnapGuides from '@/apps/slides/components/SnapGuides.vue'
 import SelectionBox from '@/apps/slides/components/SelectionBox.vue'
+import MarqueeOverlay from '@/apps/slides/components/MarqueeOverlay.vue'
 import SlideElement from '@/apps/slides/components/SlideElement.vue'
 import DropTargetOverlay from '@/apps/slides/components/DropTargetOverlay.vue'
 import OverflowContentOverlay from '@/apps/slides/components/OverflowContentOverlay.vue'

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -177,10 +177,9 @@ const hideOverlay = () => {
 	mediaDragOver.value = false
 }
 
-let dragTimeout, clickTimeout
+let clickTimeout
 
 const clearTimeouts = () => {
-	clearTimeout(dragTimeout)
 	clearTimeout(clickTimeout)
 }
 
@@ -225,9 +224,36 @@ const triggerDrag = (e, id) => {
 	}
 }
 
+const DRAG_START_THRESHOLD = 4
+
+const watchForDragIntent = (downEvent, id) => {
+	const cancelDragIntent = () => {
+		window.removeEventListener('mousemove', detectDrag)
+		window.removeEventListener('mouseup', cancelDragIntent)
+	}
+
+	const detectDrag = (moveEvent) => {
+		// button already released (e.g. mouseup outside the window)
+		if (!moveEvent.buttons) return cancelDragIntent()
+
+		const dx = moveEvent.clientX - downEvent.clientX
+		const dy = moveEvent.clientY - downEvent.clientY
+		if (Math.hypot(dx, dy) < DRAG_START_THRESHOLD) return
+
+		cancelDragIntent()
+
+		// pass the original mousedown event so the drag measures
+		// from the press position and no movement is lost
+		triggerDrag(downEvent, id)
+	}
+
+	window.addEventListener('mousemove', detectDrag)
+	window.addEventListener('mouseup', cancelDragIntent)
+}
+
 const duplicateAndDrag = (e, id) => {
 	duplicateElements(e, activeElements.value, slideIndex.value, false).then(() => {
-		triggerDrag(e, id)
+		watchForDragIntent(e, id)
 	})
 }
 
@@ -240,11 +266,10 @@ const handleMouseDown = (e, element) => {
 
 	if (e.altKey || e.ctrlKey) return duplicateAndDrag(e, id)
 
-	// wait for click to be registered
-	// if the click is not registered, it means the user is dragging
-	dragTimeout = setTimeout(() => triggerDrag(e, id), 100)
+	// start dragging once the pointer moves past a small threshold
+	watchForDragIntent(e, id)
 
-	// if the click is registered ie. mouseup happens before dragTimeout
+	// if mouseup happens before the threshold is crossed
 	// then consider it a selection instead of dragging
 	e.target.addEventListener('mouseup', () => handleMouseUp(e, id), { once: true })
 }

--- a/frontend/src/apps/slides/components/SlideElement.vue
+++ b/frontend/src/apps/slides/components/SlideElement.vue
@@ -66,9 +66,6 @@ const elementStyle = computed(() => {
 	const offsetWidth = isActive.value ? props.elementOffset.width : 0
 	const offsetHeight = isActive.value ? props.elementOffset.height : 0
 
-	const elementLeft = element.value.left + offsetLeft
-	const elementTop = element.value.top + offsetTop
-
 	let elementWidth = element.value.width
 	if (elementWidth) {
 		elementWidth = `${elementWidth + offsetWidth}px`
@@ -91,16 +88,24 @@ const elementStyle = computed(() => {
 			? elementRotation + props.rotationDelta
 			: elementRotation
 
+	// the transient gesture offset rides on the transform (compositor-only,
+	// no layout) while left/top hold the committed position; it must come
+	// first so it shifts the element in slide axes, before rotation/centering
+	const offsetTransform =
+		offsetLeft || offsetTop ? `translate(${offsetLeft}px, ${offsetTop}px)` : ''
+
+	const transform = [offsetTransform, getTransform(rotation)].filter(Boolean).join(' ')
+
 	return {
 		position: 'absolute',
 		width: elementWidth,
 		height: elementHeight,
-		left: `${elementLeft}px`,
-		top: `${elementTop}px`,
+		left: `${element.value.left}px`,
+		top: `${element.value.top}px`,
 		outline: props.highlight ? `#70B6F092 solid ${2 / slideBounds.scale}px` : 'none',
 		boxSizing: 'border-box',
 		zIndex: element.value.zIndex,
-		transform: getTransform(rotation),
+		transform: transform,
 		transformOrigin: getTransformOrigin(),
 		minWidth: element.value.type == 'text' ? '2px' : '',
 	}

--- a/frontend/src/apps/slides/components/SlideElement.vue
+++ b/frontend/src/apps/slides/components/SlideElement.vue
@@ -6,7 +6,6 @@
 			:element="element"
 			:mode="mode"
 			:elementOffset="elementOffset"
-			@clearTimeouts="$emit('clearTimeouts')"
 			:transitionStyles="transitionStyles"
 		/>
 	</div>
@@ -46,8 +45,6 @@ const props = defineProps({
 		default: 0,
 	},
 })
-
-const emit = defineEmits(['clearTimeouts'])
 
 const getElementKey = (element) => {
 	const id = element.refId || element.id

--- a/frontend/src/apps/slides/components/SlideElement.vue
+++ b/frontend/src/apps/slides/components/SlideElement.vue
@@ -23,6 +23,8 @@ import { activeElementIds } from '@/apps/slides/stores/element'
 
 import { slideBounds } from '@/apps/slides/stores/slide'
 
+import { rotationDelta } from '@/apps/slides/composables/useRotator'
+
 const props = defineProps({
 	mode: {
 		type: String,
@@ -39,10 +41,6 @@ const props = defineProps({
 	transitionStyles: {
 		type: Object,
 		default: () => ({}),
-	},
-	rotationDelta: {
-		type: Number,
-		default: 0,
 	},
 })
 
@@ -83,9 +81,12 @@ const elementStyle = computed(() => {
 	}
 
 	const elementRotation = element.value.rotation || 0
+
+	// only the active editor element tracks the live rotation delta —
+	// inactive elements never read it, so they don't re-render per frame
 	const rotation =
-		isActive.value && isRotatable.value
-			? elementRotation + props.rotationDelta
+		isActive.value && isRotatable.value && props.mode == 'editor'
+			? elementRotation + rotationDelta.value
 			: elementRotation
 
 	// the transient gesture offset rides on the transform (compositor-only,

--- a/frontend/src/apps/slides/components/SnapGuides.vue
+++ b/frontend/src/apps/slides/components/SnapGuides.vue
@@ -7,6 +7,7 @@ import { computed } from 'vue'
 
 import { slideBounds, selectionBounds, guideVisibilityMap } from '@/apps/slides/stores/slide'
 import { pairElementId } from '@/apps/slides/stores/element'
+import { getElementDiv } from '@/apps/slides/stores/elementRegistry'
 
 const props = defineProps({
 	visibilityMap: {
@@ -43,7 +44,7 @@ const getCenterStyles = (axis) => {
 }
 
 const pairedDiv = computed(() => {
-	return document.querySelector(`[data-index="${pairElementId.value}"]`)
+	return getElementDiv(pairElementId.value)
 })
 
 const getScaledValue = (value, axis) => {

--- a/frontend/src/apps/slides/components/SnapGuides.vue
+++ b/frontend/src/apps/slides/components/SnapGuides.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-for="guide in Object.keys(guideStyles)" :key="guide" :style="guideStyles[guide]"></div>
+	<div v-for="(style, name) in guideStyles" :key="name" :style="style"></div>
 </template>
 
 <script setup>
@@ -10,9 +10,10 @@ import { pairElementId } from '@/apps/slides/stores/element'
 import { getElementDiv } from '@/apps/slides/stores/elementRegistry'
 
 const props = defineProps({
-	visibilityMap: {
+	// { x: { source, line } | null, y: { source, line } | null } from useSnapping
+	activeGuides: {
 		type: Object,
-		default: null,
+		default: () => ({ x: null, y: null }),
 	},
 	ongoingInteraction: {
 		type: Boolean,
@@ -20,124 +21,139 @@ const props = defineProps({
 	},
 })
 
-const commonStyles = {
-	position: 'absolute',
-	zIndex: 9999,
-}
-
-const isVisible = (axis) => {
-	const closeToSnap = props.ongoingInteraction && props.visibilityMap?.[axis]
-	const hoveringOverControl = guideVisibilityMap[axis]
-	return closeToSnap || hoveringOverControl
-}
-
-const getCenterStyles = (axis) => {
-	return {
-		...commonStyles,
-		backgroundColor: '#70b6f080',
-		width: axis === 'centerY' ? '1px' : '100%',
-		height: axis === 'centerX' ? '1px' : '100%',
-		left: axis === 'centerY' ? '50%' : '0',
-		top: axis === 'centerX' ? '50%' : '0',
-		display: isVisible(axis) ? 'block' : 'none',
-	}
-}
+const GUIDE_COLOR = '#70b6f080'
+const commonStyles = { position: 'absolute', zIndex: 9999 }
 
 const getScaledValue = (value, axis) => {
 	if (axis == 'X') return (value - slideBounds.left) / slideBounds.scale
 	return (value - slideBounds.top) / slideBounds.scale
 }
 
-// computed so the paired element is measured once per pairing (it cannot move
-// mid-gesture), not on every re-render during the interaction
+// paired element measured once per pairing (it can't move mid-gesture)
 const pairedBounds = computed(() => {
 	const div = getElementDiv(pairElementId.value)
 	if (!div) return null
 
 	const rect = div.getBoundingClientRect()
-	return {
-		left: getScaledValue(rect.left, 'X'),
-		top: getScaledValue(rect.top, 'Y'),
-		right: getScaledValue(rect.right, 'X'),
-		bottom: getScaledValue(rect.bottom, 'Y'),
-		height: rect.height / slideBounds.scale,
-		width: rect.width / slideBounds.scale,
-	}
+	const left = getScaledValue(rect.left, 'X')
+	const top = getScaledValue(rect.top, 'Y')
+	const right = getScaledValue(rect.right, 'X')
+	const bottom = getScaledValue(rect.bottom, 'Y')
+
+	return { left, top, right, bottom, centerX: (left + right) / 2, centerY: (top + bottom) / 2 }
 })
 
-const getVerticalStyles = (direction) => {
-	if (!pairedBounds.value || !props.visibilityMap[direction]) return ''
+// the selection's edges in slide units
+const selectionEdges = computed(() => ({
+	left: selectionBounds.left,
+	right: selectionBounds.left + selectionBounds.width,
+	top: selectionBounds.top,
+	bottom: selectionBounds.top + selectionBounds.height,
+}))
 
-	const { top: pairedTop, height: pairedHeight } = pairedBounds.value
-
-	const left =
-		direction == 'left'
-			? selectionBounds.left - 1
-			: selectionBounds.left + selectionBounds.width
-	const top = Math.min(selectionBounds.top, pairedTop)
-	const lastElementHeight =
-		pairedTop < selectionBounds.top ? selectionBounds.height : pairedHeight
-	const height = Math.abs(pairedTop - selectionBounds.top) + lastElementHeight
+// solid center line through the slide (drag-to-center snap, or hovering a control)
+const getVerticalCenterStyle = () => {
+	const snapped = props.ongoingInteraction && props.activeGuides?.x?.source === 'slide'
+	if (!snapped && !guideVisibilityMap.centerY) return null
 
 	return {
 		...commonStyles,
-		borderColor: '#70b6f080',
+		backgroundColor: GUIDE_COLOR,
+		width: '1px',
+		height: '100%',
+		left: '50%',
+		top: '0',
+	}
+}
+
+const getHorizontalCenterStyle = () => {
+	const snapped = props.ongoingInteraction && props.activeGuides?.y?.source === 'slide'
+	if (!snapped && !guideVisibilityMap.centerX) return null
+
+	return {
+		...commonStyles,
+		backgroundColor: GUIDE_COLOR,
+		width: '100%',
+		height: '1px',
+		left: '0',
+		top: '50%',
+	}
+}
+
+// dashed line aligning the selection to a neighbour's edge/center; the line
+// sits on the neighbour's feature and spans the union of both elements
+const getVerticalElementStyle = () => {
+	const guide = props.activeGuides?.x
+	if (!props.ongoingInteraction || guide?.source !== 'element' || !pairedBounds.value) return null
+
+	const neighbour = pairedBounds.value
+	const selection = selectionEdges.value
+
+	// the dashed line spans from the topmost to the bottommost of the two elements
+	const top = Math.min(selection.top, neighbour.top)
+	const bottom = Math.max(selection.bottom, neighbour.bottom)
+
+	return {
+		...commonStyles,
+		borderColor: GUIDE_COLOR,
 		borderStyle: 'dashed',
 		borderWidth: '0 0 0 1px',
-		left: `${left}px`,
+		left: `${neighbour[guide.line]}px`,
 		top: `${top}px`,
-		height: `${height}px`,
-		display: isVisible(direction) ? 'block' : 'none',
+		height: `${bottom - top}px`,
 	}
 }
 
-const getHorizontalStyles = (direction) => {
-	if (!pairedBounds.value || !props.visibilityMap[direction]) return ''
+const getHorizontalElementStyle = () => {
+	const guide = props.activeGuides?.y
+	if (!props.ongoingInteraction || guide?.source !== 'element' || !pairedBounds.value) return null
 
-	const { left: pairedLeft, width: pairedWidth } = pairedBounds.value
+	const neighbour = pairedBounds.value
+	const selection = selectionEdges.value
 
-	const top =
-		direction == 'top' ? selectionBounds.top - 1 : selectionBounds.top + selectionBounds.height
-	const left = Math.min(selectionBounds.left, pairedLeft)
-
-	const lastElementWidth = pairedLeft < selectionBounds.left ? selectionBounds.width : pairedWidth
-	const width = Math.abs(pairedLeft - selectionBounds.left) + lastElementWidth
+	// the dashed line spans from the leftmost to the rightmost of the two elements
+	const left = Math.min(selection.left, neighbour.left)
+	const right = Math.max(selection.right, neighbour.right)
 
 	return {
 		...commonStyles,
-		borderColor: '#70b6f080',
+		borderColor: GUIDE_COLOR,
 		borderStyle: 'dashed',
 		borderWidth: '1px 0 0 0',
-		top: `${top}px`,
+		top: `${neighbour[guide.line]}px`,
 		left: `${left}px`,
-		width: `${width}px`,
-		display: isVisible(direction) ? 'block' : 'none',
+		width: `${right - left}px`,
 	}
 }
 
-const getEdgeStyles = (direction) => {
+// slide-edge guides shown while hovering alignment controls
+const getEdgeStyle = (direction) => {
+	if (!guideVisibilityMap[direction]) return null
+
+	const isVertical = ['leftEdge', 'rightEdge'].includes(direction)
 	return {
 		...commonStyles,
-		width: ['leftEdge', 'rightEdge'].includes(direction) ? '1.5px' : '100%',
-		height: ['topEdge', 'bottomEdge'].includes(direction) ? '1.5px' : '100%',
-		left: direction == 'rightEdge' ? `calc(100% - 1.5px)` : '0%',
-		top: direction == 'bottomEdge' ? `calc(100% - 1.5px)` : '0%',
-		display: isVisible(direction) ? 'block' : 'none',
+		backgroundColor: GUIDE_COLOR,
+		width: isVertical ? '1.5px' : '100%',
+		height: isVertical ? '100%' : '1.5px',
+		left: direction == 'rightEdge' ? 'calc(100% - 1.5px)' : '0',
+		top: direction == 'bottomEdge' ? 'calc(100% - 1.5px)' : '0',
 	}
 }
 
 const guideStyles = computed(() => {
-	return {
-		centerX: getCenterStyles('centerX'),
-		centerY: getCenterStyles('centerY'),
-		left: getVerticalStyles('left'),
-		right: getVerticalStyles('right'),
-		top: getHorizontalStyles('top'),
-		bottom: getHorizontalStyles('bottom'),
-		leftEdge: getEdgeStyles('leftEdge'),
-		rightEdge: getEdgeStyles('rightEdge'),
-		topEdge: getEdgeStyles('topEdge'),
-		bottomEdge: getEdgeStyles('bottomEdge'),
+	const guides = {
+		centerVertical: getVerticalCenterStyle(),
+		centerHorizontal: getHorizontalCenterStyle(),
+		elementVertical: getVerticalElementStyle(),
+		elementHorizontal: getHorizontalElementStyle(),
+		leftEdge: getEdgeStyle('leftEdge'),
+		rightEdge: getEdgeStyle('rightEdge'),
+		topEdge: getEdgeStyle('topEdge'),
+		bottomEdge: getEdgeStyle('bottomEdge'),
 	}
+
+	// only keep visible guides so the v-for renders nothing when idle
+	return Object.fromEntries(Object.entries(guides).filter(([, style]) => style))
 })
 </script>

--- a/frontend/src/apps/slides/components/SnapGuides.vue
+++ b/frontend/src/apps/slides/components/SnapGuides.vue
@@ -43,16 +43,17 @@ const getCenterStyles = (axis) => {
 	}
 }
 
-const pairedDiv = computed(() => {
-	return getElementDiv(pairElementId.value)
-})
-
 const getScaledValue = (value, axis) => {
 	if (axis == 'X') return (value - slideBounds.left) / slideBounds.scale
 	return (value - slideBounds.top) / slideBounds.scale
 }
 
-const getElementBounds = (div) => {
+// computed so the paired element is measured once per pairing (it cannot move
+// mid-gesture), not on every re-render during the interaction
+const pairedBounds = computed(() => {
+	const div = getElementDiv(pairElementId.value)
+	if (!div) return null
+
 	const rect = div.getBoundingClientRect()
 	return {
 		left: getScaledValue(rect.left, 'X'),
@@ -62,21 +63,21 @@ const getElementBounds = (div) => {
 		height: rect.height / slideBounds.scale,
 		width: rect.width / slideBounds.scale,
 	}
-}
+})
 
 const getVerticalStyles = (direction) => {
-	if (!pairElementId.value || !props.visibilityMap[direction]) return ''
+	if (!pairedBounds.value || !props.visibilityMap[direction]) return ''
 
-	const pairedBounds = getElementBounds(pairedDiv.value)
+	const { top: pairedTop, height: pairedHeight } = pairedBounds.value
 
 	const left =
 		direction == 'left'
 			? selectionBounds.left - 1
 			: selectionBounds.left + selectionBounds.width
-	const top = Math.min(selectionBounds.top, pairedBounds.top)
+	const top = Math.min(selectionBounds.top, pairedTop)
 	const lastElementHeight =
-		pairedBounds.top < selectionBounds.top ? selectionBounds.height : pairedBounds.height
-	const height = Math.abs(pairedBounds.top - selectionBounds.top) + lastElementHeight
+		pairedTop < selectionBounds.top ? selectionBounds.height : pairedHeight
+	const height = Math.abs(pairedTop - selectionBounds.top) + lastElementHeight
 
 	return {
 		...commonStyles,
@@ -91,17 +92,16 @@ const getVerticalStyles = (direction) => {
 }
 
 const getHorizontalStyles = (direction) => {
-	if (!pairElementId.value || !props.visibilityMap[direction]) return ''
+	if (!pairedBounds.value || !props.visibilityMap[direction]) return ''
 
-	const pairedBounds = getElementBounds(pairedDiv.value)
+	const { left: pairedLeft, width: pairedWidth } = pairedBounds.value
 
 	const top =
 		direction == 'top' ? selectionBounds.top - 1 : selectionBounds.top + selectionBounds.height
-	const left = Math.min(selectionBounds.left, pairedBounds.left)
+	const left = Math.min(selectionBounds.left, pairedLeft)
 
-	const lastElementWidth =
-		pairedBounds.left < selectionBounds.left ? selectionBounds.width : pairedBounds.width
-	const width = Math.abs(pairedBounds.left - selectionBounds.left) + lastElementWidth
+	const lastElementWidth = pairedLeft < selectionBounds.left ? selectionBounds.width : pairedWidth
+	const width = Math.abs(pairedLeft - selectionBounds.left) + lastElementWidth
 
 	return {
 		...commonStyles,

--- a/frontend/src/apps/slides/components/TextElement.vue
+++ b/frontend/src/apps/slides/components/TextElement.vue
@@ -61,8 +61,6 @@ const element = defineModel('element', {
 	default: null,
 })
 
-const emit = defineEmits(['clearTimeouts'])
-
 const isEditable = computed(() => focusElementId.value == element.value.id)
 
 const editorStyles = computed(() => ({
@@ -87,8 +85,6 @@ const handleDoubleClick = (e) => {
 		e.stopPropagation()
 		return
 	}
-
-	emit('clearTimeouts')
 
 	activeElementIds.value = [element.value.id]
 	focusElementId.value = element.value.id

--- a/frontend/src/apps/slides/composables/useCommandHistory.js
+++ b/frontend/src/apps/slides/composables/useCommandHistory.js
@@ -1,4 +1,5 @@
 import { ref, computed } from 'vue'
+import { markDirty } from '@/apps/slides/stores/saving'
 
 export const useCommandHistory = (state, historyMeta = {}) => {
 	const actionOrder = historyMeta.actionOrder
@@ -42,6 +43,8 @@ export const useCommandHistory = (state, historyMeta = {}) => {
 
 		prevCommands.value.push(command)
 		nextCommands.value = []
+
+		markDirty()
 	}
 
 	const undo = async () => {
@@ -55,6 +58,8 @@ export const useCommandHistory = (state, historyMeta = {}) => {
 		}
 
 		nextCommands.value.push(command)
+
+		markDirty()
 	}
 
 	const redo = async () => {
@@ -68,6 +73,8 @@ export const useCommandHistory = (state, historyMeta = {}) => {
 		}
 
 		prevCommands.value.push(command)
+
+		markDirty()
 	}
 
 	const clearHistory = () => {

--- a/frontend/src/apps/slides/composables/useDragAndDrop.js
+++ b/frontend/src/apps/slides/composables/useDragAndDrop.js
@@ -3,10 +3,23 @@ import { ref } from 'vue'
 export const useDragAndDrop = () => {
 	const isDragging = ref(false)
 
-	const prevX = ref(0)
-	const prevY = ref(0)
-
+	// total displacement from the press position (viewport px),
+	// flushed at most once per animation frame
 	const positionDelta = ref({ left: 0, top: 0 })
+
+	let startX = 0
+	let startY = 0
+	let lastX = 0
+	let lastY = 0
+	let frame = null
+
+	const flushDelta = () => {
+		frame = null
+		positionDelta.value = {
+			left: lastX - startX,
+			top: lastY - startY,
+		}
+	}
 
 	const startDragging = (e) => {
 		e.preventDefault()
@@ -14,8 +27,10 @@ export const useDragAndDrop = () => {
 
 		isDragging.value = true
 
-		prevX.value = e.clientX
-		prevY.value = e.clientY
+		startX = lastX = e.clientX
+		startY = lastY = e.clientY
+
+		positionDelta.value = { left: 0, top: 0 }
 
 		window.addEventListener('mousemove', drag)
 		window.addEventListener('mouseup', stopDragging)
@@ -24,27 +39,26 @@ export const useDragAndDrop = () => {
 	const drag = (e) => {
 		e.preventDefault()
 
-		if (isDragging.value) {
-			const dx = e.clientX - prevX.value
-			const dy = e.clientY - prevY.value
+		if (!isDragging.value) return
 
-			positionDelta.value = {
-				left: dx,
-				top: dy,
-			}
+		lastX = e.clientX
+		lastY = e.clientY
 
-			prevX.value = e.clientX
-			prevY.value = e.clientY
-		}
+		if (!frame) frame = requestAnimationFrame(flushDelta)
 	}
 
 	const stopDragging = (e) => {
 		e.preventDefault()
 		e.stopPropagation()
 
-		isDragging.value = false
+		// flush movement still waiting on the next frame so the
+		// final position is exact
+		if (frame) {
+			cancelAnimationFrame(frame)
+			flushDelta()
+		}
 
-		positionDelta.value = { left: 0, top: 0 }
+		isDragging.value = false
 
 		window.removeEventListener('mousemove', drag)
 		window.removeEventListener('mouseup', stopDragging)

--- a/frontend/src/apps/slides/composables/useDragAndDrop.js
+++ b/frontend/src/apps/slides/composables/useDragAndDrop.js
@@ -41,6 +41,10 @@ export const useDragAndDrop = () => {
 
 		if (!isDragging.value) return
 
+		// button was released outside the window — end the gesture so the
+		// pending offsets get committed instead of leaking into the next drag
+		if (!e.buttons) return stopDragging(e)
+
 		lastX = e.clientX
 		lastY = e.clientY
 

--- a/frontend/src/apps/slides/composables/useResizer.js
+++ b/frontend/src/apps/slides/composables/useResizer.js
@@ -1,4 +1,4 @@
-import { ref, computed } from 'vue'
+import { ref, computed, nextTick } from 'vue'
 
 export const useResizer = () => {
 	const isResizing = ref(false)
@@ -19,8 +19,13 @@ export const useResizer = () => {
 
 	const resizeCursor = computed(() => cursorMap[currentResizer.value] ?? 'default')
 
+	// last processed and latest cursor positions; diffs are summed
+	// per animation frame instead of per mousemove
 	let prevX = 0
 	let prevY = 0
+	let lastX = 0
+	let lastY = 0
+	let frame = null
 
 	const dimensionDelta = ref({
 		width: 0,
@@ -36,8 +41,8 @@ export const useResizer = () => {
 		currentResizer.value = resizer
 		isResizing.value = true
 
-		prevX = e.clientX
-		prevY = e.clientY
+		prevX = lastX = e.clientX
+		prevY = lastY = e.clientY
 
 		window.addEventListener('mousemove', resize)
 		window.addEventListener('mouseup', stopResize, { once: true })
@@ -65,17 +70,16 @@ export const useResizer = () => {
 		}
 	}
 
-	const resize = (e) => {
-		e.preventDefault()
-		e.stopImmediatePropagation()
+	const flushResize = () => {
+		frame = null
 
-		let diffX = prevX - e.clientX
-		let diffY = prevY - e.clientY
+		let diffX = prevX - lastX
+		let diffY = prevY - lastY
 
 		let diffLeft = 0
 		let diffTop = 0
 
-		if (!diffX) return
+		if (!diffX && !diffY) return
 
 		switch (currentResizer.value) {
 			case 'text-left':
@@ -121,16 +125,38 @@ export const useResizer = () => {
 
 		dimensionDelta.value = getDimensionDelta(diffX, diffY, diffLeft, diffTop)
 
-		prevX = e.clientX
-		prevY = e.clientY
+		prevX = lastX
+		prevY = lastY
+	}
+
+	const resize = (e) => {
+		e.preventDefault()
+		e.stopImmediatePropagation()
+
+		lastX = e.clientX
+		lastY = e.clientY
+
+		if (!frame) frame = requestAnimationFrame(flushResize)
 	}
 
 	const stopResize = (e) => {
 		e.preventDefault()
 		e.stopImmediatePropagation()
 
-		currentResizer.value = null
+		// flush movement still waiting on the next frame so the final size is exact
+		if (frame) {
+			cancelAnimationFrame(frame)
+			flushResize()
+		}
+
 		isResizing.value = false
+
+		// the flushed delta is processed by watchers after this task — they
+		// still need the resizer context (aspect ratio, snap offsets), so
+		// clear it only once the flush queue has drained
+		nextTick(() => {
+			currentResizer.value = null
+		})
 
 		window.removeEventListener('mousemove', resize)
 		window.removeEventListener('mouseup', stopResize)

--- a/frontend/src/apps/slides/composables/useResizer.js
+++ b/frontend/src/apps/slides/composables/useResizer.js
@@ -19,20 +19,14 @@ export const useResizer = () => {
 
 	const resizeCursor = computed(() => cursorMap[currentResizer.value] ?? 'default')
 
-	// press and latest cursor positions; the flush emits TOTAL deltas since
-	// gesture start (viewport px), at most once per animation frame
 	let startX = 0
 	let startY = 0
 	let lastX = 0
 	let lastY = 0
 	let frame = null
 
-	const dimensionDelta = ref({
-		width: 0,
-		height: 0,
-		left: 0,
-		top: 0,
-	})
+	// total cursor movement since press (viewport px), flushed once per frame
+	const pointerDelta = ref({ x: 0, y: 0 })
 
 	const startResize = (e, resizer) => {
 		e.preventDefault()
@@ -43,95 +37,15 @@ export const useResizer = () => {
 
 		startX = lastX = e.clientX
 		startY = lastY = e.clientY
-
-		dimensionDelta.value = { width: 0, height: 0, left: 0, top: 0 }
+		pointerDelta.value = { x: 0, y: 0 }
 
 		window.addEventListener('mousemove', resize)
 		window.addEventListener('mouseup', stopResize, { once: true })
 	}
 
-	const getDimensionDelta = (diffX, diffY, diffLeft, diffTop) => {
-		let width = 0,
-			height = 0,
-			left = 0,
-			top = 0
-		if (['top', 'bottom'].includes(currentResizer.value)) {
-			height = diffY
-			top = diffTop
-		} else {
-			width = diffX
-			height = diffY
-			left = diffLeft
-			top = diffTop
-		}
-
-		return {
-			width: width,
-			height: height,
-			left: left,
-			top: top,
-		}
-	}
-
 	const flushResize = () => {
 		frame = null
-
-		let diffX = startX - lastX
-		let diffY = startY - lastY
-
-		let diffLeft = 0
-		let diffTop = 0
-
-		switch (currentResizer.value) {
-			case 'text-left':
-				diffLeft = -diffX / 2
-				diffY = 0
-				break
-			case 'text-right':
-				diffLeft = -diffX / 2
-				diffX = -diffX
-				diffY = 0
-				break
-			case 'top-right':
-				diffX = -diffX
-				diffTop = -diffY
-				break
-			case 'bottom-left':
-				diffLeft = -diffX
-				diffY = -diffY
-				break
-			case 'top-left':
-				diffLeft = -diffX
-				diffTop = -diffY
-				break
-			case 'bottom-right':
-				diffX = -diffX
-				diffY = -diffY
-				break
-			case 'line-left':
-			case 'left':
-				diffLeft = -diffX
-				diffY = 0
-				break
-			case 'bottom':
-				diffY = -diffY
-				diffX = 0
-				break
-			case 'top':
-				diffTop = -diffY
-				diffX = 0
-				break
-			case 'line-right':
-			case 'right':
-				diffX = -diffX
-				diffY = 0
-				break
-			default:
-				diffX = -diffX
-				break
-		}
-
-		dimensionDelta.value = getDimensionDelta(diffX, diffY, diffLeft, diffTop)
+		pointerDelta.value = { x: lastX - startX, y: lastY - startY }
 	}
 
 	const resize = (e) => {
@@ -156,9 +70,8 @@ export const useResizer = () => {
 
 		isResizing.value = false
 
-		// the flushed delta is processed by watchers after this task — they
-		// still need the resizer context (aspect ratio, snap offsets), so
-		// clear it only once the flush queue has drained
+		// the final flush is processed by a watcher after this task, which still
+		// needs to know which handle moved — clear it once that has run
 		nextTick(() => {
 			currentResizer.value = null
 		})
@@ -167,5 +80,5 @@ export const useResizer = () => {
 		window.removeEventListener('mouseup', stopResize)
 	}
 
-	return { isResizing, dimensionDelta, currentResizer, startResize, resizeCursor }
+	return { isResizing, pointerDelta, currentResizer, startResize, resizeCursor }
 }

--- a/frontend/src/apps/slides/composables/useResizer.js
+++ b/frontend/src/apps/slides/composables/useResizer.js
@@ -58,6 +58,7 @@ export const useResizer = () => {
 			top = diffTop
 		} else {
 			width = diffX
+			height = diffY
 			left = diffLeft
 			top = diffTop
 		}
@@ -84,21 +85,28 @@ export const useResizer = () => {
 		switch (currentResizer.value) {
 			case 'text-left':
 				diffLeft = -diffX / 2
+				diffY = 0
 				break
 			case 'text-right':
 				diffLeft = -diffX / 2
 				diffX = -diffX
+				diffY = 0
 				break
 			case 'top-right':
 				diffX = -diffX
-				diffTop = -diffX
+				diffTop = -diffY
 				break
 			case 'bottom-left':
 				diffLeft = -diffX
+				diffY = -diffY
 				break
 			case 'top-left':
 				diffLeft = -diffX
-				diffTop = -diffX
+				diffTop = -diffY
+				break
+			case 'bottom-right':
+				diffX = -diffX
+				diffY = -diffY
 				break
 			case 'line-left':
 			case 'left':

--- a/frontend/src/apps/slides/composables/useResizer.js
+++ b/frontend/src/apps/slides/composables/useResizer.js
@@ -52,6 +52,8 @@ export const useResizer = () => {
 		e.preventDefault()
 		e.stopImmediatePropagation()
 
+		if (!e.buttons) return stopResize(e)
+
 		lastX = e.clientX
 		lastY = e.clientY
 

--- a/frontend/src/apps/slides/composables/useResizer.js
+++ b/frontend/src/apps/slides/composables/useResizer.js
@@ -19,10 +19,10 @@ export const useResizer = () => {
 
 	const resizeCursor = computed(() => cursorMap[currentResizer.value] ?? 'default')
 
-	// last processed and latest cursor positions; diffs are summed
-	// per animation frame instead of per mousemove
-	let prevX = 0
-	let prevY = 0
+	// press and latest cursor positions; the flush emits TOTAL deltas since
+	// gesture start (viewport px), at most once per animation frame
+	let startX = 0
+	let startY = 0
 	let lastX = 0
 	let lastY = 0
 	let frame = null
@@ -41,8 +41,10 @@ export const useResizer = () => {
 		currentResizer.value = resizer
 		isResizing.value = true
 
-		prevX = lastX = e.clientX
-		prevY = lastY = e.clientY
+		startX = lastX = e.clientX
+		startY = lastY = e.clientY
+
+		dimensionDelta.value = { width: 0, height: 0, left: 0, top: 0 }
 
 		window.addEventListener('mousemove', resize)
 		window.addEventListener('mouseup', stopResize, { once: true })
@@ -74,13 +76,11 @@ export const useResizer = () => {
 	const flushResize = () => {
 		frame = null
 
-		let diffX = prevX - lastX
-		let diffY = prevY - lastY
+		let diffX = startX - lastX
+		let diffY = startY - lastY
 
 		let diffLeft = 0
 		let diffTop = 0
-
-		if (!diffX && !diffY) return
 
 		switch (currentResizer.value) {
 			case 'text-left':
@@ -132,9 +132,6 @@ export const useResizer = () => {
 		}
 
 		dimensionDelta.value = getDimensionDelta(diffX, diffY, diffLeft, diffTop)
-
-		prevX = lastX
-		prevY = lastY
 	}
 
 	const resize = (e) => {

--- a/frontend/src/apps/slides/composables/useRotator.js
+++ b/frontend/src/apps/slides/composables/useRotator.js
@@ -1,9 +1,12 @@
 import { ref } from 'vue'
 import { getElementCenter } from '@/apps/slides/stores/element'
 
+// module-scoped so the active element and selection box read it directly —
+// passing it as a per-frame prop re-rendered every element during rotation
+export const rotationDelta = ref(0)
+
 export const useRotator = () => {
 	const isRotating = ref(false)
-	const rotationDelta = ref(0)
 
 	let startAngle = 0
 	let centerX = 0

--- a/frontend/src/apps/slides/composables/useShortcuts.js
+++ b/frontend/src/apps/slides/composables/useShortcuts.js
@@ -34,6 +34,8 @@ import {
 	performPreviousStep,
 } from '@/apps/slides/stores/slideshow'
 
+import { markDirty } from '@/apps/slides/stores/saving'
+
 import { isCmdOrCtrl } from '@/apps/slides/utils/helpers'
 
 const { toggleNavigationPanel } = useNavigationPanel()
@@ -111,6 +113,8 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 			element.left += dx
 			element.top += dy
 		})
+
+		markDirty()
 	}
 
 	const handleElementShortcuts = (e) => {

--- a/frontend/src/apps/slides/composables/useSnapping.js
+++ b/frontend/src/apps/slides/composables/useSnapping.js
@@ -1,190 +1,13 @@
-import { ref, reactive, computed, watch } from 'vue'
+import { reactive, computed, watch } from 'vue'
 import { selectionBounds, currentSlide, slideBounds } from '../stores/slide'
 import { activeElementIds, pairElementId } from '../stores/element'
 import { getElementDiv } from '../stores/elementRegistry'
 
 export const useSnapping = (target, parent, currentResizer, hasOngoingInteraction) => {
-	// element wrt slide center
-	const slideCenterAlignmentKeys = ['centerX', 'centerY', 'startX', 'startY', 'endX', 'endY']
+	const RELEASE_FACTOR = 1.25
 
-	// element wrt other elements
-	const matchedAlignmentKeys = ['left', 'right', 'top', 'bottom']
-
-	const initDiffs = () => {
-		const makeNullMap = (keys) => {
-			const map = {}
-			keys.forEach((k) => (map[k] = null))
-			return map
-		}
-
-		return {
-			slideCenter: makeNullMap(slideCenterAlignmentKeys),
-			matched: makeNullMap(matchedAlignmentKeys),
-		}
-	}
-
-	const diffs = reactive(initDiffs())
-	const prevDiffs = reactive(initDiffs())
-	const resistanceMap = reactive({
-		centerX: false,
-		centerY: false,
-		left: false,
-		right: false,
-		top: false,
-		bottom: false,
-	})
-
-	const getPointMap = (key) => {
-		if (key == 'centerY') {
-			return {
-				left: 'startX',
-				right: 'endX',
-				def: 'centerX',
-			}
-		}
-
-		return {
-			top: 'startY',
-			bottom: 'endY',
-			def: 'centerY',
-		}
-	}
-
-	const getPointForVisibilityKey = (key) => {
-		const pointMap = getPointMap(key)
-
-		let point = pointMap.def
-
-		if (mode.value == 'dragging' || !currentResizer.value) return point
-
-		point =
-			pointMap[Object.keys(pointMap).find((key) => currentResizer.value.includes(key))] ||
-			point
-
-		return point
-	}
-
-	const visibilityMap = computed(() => {
-		if (!hasOngoingInteraction.value) return {}
-
-		const keys = ['centerX', 'centerY', 'left', 'right', 'top', 'bottom']
-
-		const map = {}
-		keys.forEach((key) => {
-			let diff
-
-			if (key == 'centerY') {
-				const point = getPointForVisibilityKey(key)
-				diff = getDiffsForAxis('slideCenterY', point).diff
-			} else if (key == 'centerX') {
-				const point = getPointForVisibilityKey(key)
-				diff = getDiffsForAxis('slideCenterX', point).diff
-			} else {
-				diff = diffs.matched[key]
-			}
-			const threshold = getDynamicThresholds(key).threshold
-
-			map[key] = diff !== null && Math.abs(diff) < threshold
-		})
-
-		return map
-	})
-
-	const mode = ref(null)
-
-	const getGuideForDirection = (direction) => {
-		const guideMap = {
-			slideCenterY: 'centerX',
-			slideCenterX: 'centerY',
-		}
-		return guideMap[direction] || direction
-	}
-
-	const getSlideCenter = (axis) => {
-		let slideStart, slideSize
-
-		if (axis == 'Y') {
-			slideStart = slideBounds.left
-			slideSize = slideBounds.width
-		} else {
-			slideStart = slideBounds.top
-			slideSize = slideBounds.height
-		}
-
-		return slideStart + slideSize / 2
-	}
-
-	const getElementCenter = (axis) => {
-		if (!target.value) return
-		let elementStart, elementSize, slideStart
-
-		if (axis == 'Y') {
-			elementStart = selectionBounds.left
-			elementSize = selectionBounds.width
-			slideStart = slideBounds.left
-		} else {
-			elementStart = selectionBounds.top
-			elementSize = selectionBounds.height
-			slideStart = slideBounds.top
-		}
-
-		elementStart = elementStart * slideBounds.scale + slideStart
-		elementSize *= slideBounds.scale
-
-		return elementStart + elementSize / 2
-	}
-
-	const getDiffFromCenter = (axis) => {
-		if (!target.value) return
-
-		const slideCenter = getSlideCenter(axis)
-		const elementCenter = getElementCenter(axis)
-
-		return slideCenter - elementCenter
-	}
-
-	const updateDiffsRelativeToSlide = () => {
-		if (!target.value) return
-
-		diffs.slideCenter.centerX = getDiffFromCenter('Y')
-		diffs.slideCenter.centerY = getDiffFromCenter('X')
-
-		if (mode.value == 'dragging') return
-
-		diffs.slideCenter.startX =
-			getDiffFromCenter('Y') + (selectionBounds.width * slideBounds.scale) / 2
-		diffs.slideCenter.endX =
-			getDiffFromCenter('Y') - (selectionBounds.width * slideBounds.scale) / 2
-
-		diffs.slideCenter.startY =
-			getDiffFromCenter('X') + (selectionBounds.height * slideBounds.scale) / 2
-		diffs.slideCenter.endY =
-			getDiffFromCenter('X') - (selectionBounds.height * slideBounds.scale) / 2
-	}
-
-	const canElementPair = (diffsFromElement) => {
-		if (!diffsFromElement) return false
-
-		return Object.entries(diffsFromElement).some(([direction, diff]) => {
-			const threshold = getDynamicThresholds(direction).threshold
-			return diff !== null && Math.abs(diff) < threshold
-		})
-	}
-
-	const getActiveElementBounds = () => {
-		const scale = slideBounds.scale
-
-		const bounds = Object.fromEntries(
-			Object.entries(selectionBounds).map(([key, value]) => [key, value * scale]),
-		)
-
-		return {
-			left: bounds.left + slideBounds.left,
-			right: bounds.left + bounds.width + slideBounds.left,
-			top: bounds.top + slideBounds.top,
-			bottom: bounds.top + bounds.height + slideBounds.top,
-		}
-	}
+	// engaged guide per channel: 'x' snaps to vertical guides, 'y' to horizontal
+	const engaged = reactive({ x: null, y: null })
 
 	// rects of non-active elements, snapshotted once per gesture — they cannot
 	// move mid-gesture, and reading layout per mousemove forces synchronous reflow
@@ -210,8 +33,11 @@ export const useSnapping = (target, parent, currentResizer, hasOngoingInteractio
 	}
 
 	watch(hasOngoingInteraction, (ongoing) => {
-		if (ongoing) cacheStaticElementRects()
-		else staticElementRects.clear()
+		if (ongoing) return cacheStaticElementRects()
+
+		staticElementRects.clear()
+		engaged.x = null
+		engaged.y = null
 	})
 
 	// pan/zoom mid-gesture moves the cached rects on screen — resnapshot
@@ -222,320 +48,193 @@ export const useSnapping = (target, parent, currentResizer, hasOngoingInteractio
 		},
 	)
 
-	const getDiffFromElement = (element) => {
-		if (!target.value) return
+	// engage threshold in viewport px, sized to the selection
+	const getThreshold = () => {
+		const scaledHeight = selectionBounds.height * slideBounds.scale * 0.1
+		const minThreshold = scaledHeight > 50 ? scaledHeight / 6 : scaledHeight / 5
+		const maxThreshold = scaledHeight > 50 ? scaledHeight / 4 : scaledHeight / 3
+		return Math.max(minThreshold, Math.min(maxThreshold, scaledHeight))
+	}
 
-		// active elements are never cached, so this also skips self-pairing
-		const elementBounds = staticElementRects.get(element.id)
-		if (!elementBounds) return
-
-		const activeBounds = getActiveElementBounds()
+	// guides only show while actually snapped
+	const visibilityMap = computed(() => {
+		if (!hasOngoingInteraction.value) return {}
 
 		return {
-			left: activeBounds.left - elementBounds.left,
-			right: activeBounds.right - elementBounds.right,
-			top: activeBounds.top - elementBounds.top,
-			bottom: activeBounds.bottom - elementBounds.bottom,
+			centerY: engaged.x?.guide === 'centerY',
+			left: engaged.x?.guide === 'left',
+			right: engaged.x?.guide === 'right',
+			centerX: engaged.y?.guide === 'centerX',
+			top: engaged.y?.guide === 'top',
+			bottom: engaged.y?.guide === 'bottom',
+		}
+	})
+
+	const slideCenter = () => ({
+		x: slideBounds.left + slideBounds.width / 2,
+		y: slideBounds.top + slideBounds.height / 2,
+	})
+
+	const toViewport = (rect) => {
+		const scale = slideBounds.scale
+		const left = slideBounds.left + rect.left * scale
+		const top = slideBounds.top + rect.top * scale
+
+		return {
+			left,
+			top,
+			right: left + rect.width * scale,
+			bottom: top + rect.height * scale,
 		}
 	}
 
-	const pairElement = (id, diffFromElement) => {
-		if (!diffFromElement) return
+	// pair with the first cached element that has a like-edge near the desired
+	// rect; drives the pair highlight + the edge guide candidates
+	const updatePairing = (vp) => {
+		const threshold = getThreshold()
 
-		pairElementId.value = id
+		for (const [id, bounds] of staticElementRects) {
+			const isNear =
+				Math.abs(vp.left - bounds.left) < threshold ||
+				Math.abs(vp.right - bounds.right) < threshold ||
+				Math.abs(vp.top - bounds.top) < threshold ||
+				Math.abs(vp.bottom - bounds.bottom) < threshold
 
-		Object.entries(diffFromElement).forEach(([direction, diff]) => {
-			diffs.matched[direction] = diff
-		})
-	}
+			if (isNear) {
+				pairElementId.value = id
+				return bounds
+			}
+		}
 
-	const unpairElement = () => {
 		pairElementId.value = null
-
-		const resetDiffs = () => {
-			return ['left', 'right', 'top', 'bottom'].reduce((map, direction) => {
-				map[direction] = null
-				return map
-			}, {})
-		}
-
-		Object.assign(diffs.matched, resetDiffs())
-		Object.assign(prevDiffs.matched, resetDiffs())
-		Object.assign(resistanceMap, resetDiffs())
+		return null
 	}
 
-	const updateDiffsRelativeToPairedElement = () => {
-		currentSlide.value.elements.forEach((element) => {
-			const diffFromElement = getDiffFromElement(element)
+	// keep the engaged guide while desired stays inside the release window,
+	// otherwise engage the nearest candidate inside the engage threshold
+	const chooseGuide = (channel, candidates) => {
+		const current = engaged[channel]
 
-			const canPair = canElementPair(diffFromElement)
-			const isPaired = pairElementId.value == element.id
-
-			if (canPair) pairElement(element.id, diffFromElement)
-			else if (isPaired) unpairElement()
-		})
-	}
-
-	const updateDiffs = () => {
-		if (!target.value) return
-
-		// sync previous diffs
-		Object.entries(diffs).forEach(([key, value]) => {
-			Object.entries(value).forEach(([direction, diff]) => {
-				prevDiffs[key][direction] = diff
-			})
-		})
-
-		updateDiffsRelativeToSlide()
-
-		updateDiffsRelativeToPairedElement()
-	}
-
-	const getDynamicMargin = (axis) => {
-		if (['centerX', 'centerY'].includes(axis)) {
-			return selectionBounds.width * slideBounds.scale * 0.1
-		}
-		return selectionBounds.height * slideBounds.scale * 0.05
-	}
-
-	const getDynamicThresholds = (axis) => {
-		const scaleFactor = 0.1
-		const scaledHeight = selectionBounds.height * slideBounds.scale * scaleFactor
-
-		const isCenterAxis = ['centerX', 'centerY'].includes(axis)
-
-		let minThreshold, maxThreshold, maxResistanceThreshold
-
-		if (isCenterAxis) {
-			minThreshold = scaledHeight > 50 ? scaledHeight / 6 : scaledHeight / 5
-			maxThreshold = scaledHeight > 50 ? scaledHeight / 4 : scaledHeight / 3
-			maxResistanceThreshold = 5
-		} else {
-			minThreshold = scaledHeight > 50 ? scaledHeight / 6 : scaledHeight / 5
-			maxThreshold = scaledHeight > 50 ? scaledHeight / 4 : scaledHeight / 3
-			maxResistanceThreshold = 3
-		}
-
-		return {
-			threshold: Math.max(minThreshold, Math.min(maxThreshold, scaledHeight)),
-			resistance_threshold: Math.max(
-				1,
-				Math.min(maxResistanceThreshold, scaledHeight * 0.15),
-			),
-		}
-	}
-
-	const getDiffsForAxis = (axis, point) => {
-		let diff, prevDiff
-
-		if (['slideCenterY', 'slideCenterX'].includes(axis)) {
-			diff = diffs.slideCenter[point]
-			prevDiff = prevDiffs.slideCenter[point]
-		} else if (['left', 'right', 'top', 'bottom'].includes(axis)) {
-			diff = diffs.matched[axis]
-			prevDiff = prevDiffs.matched[axis]
-		}
-
-		return { diff, prevDiff }
-	}
-
-	const getThresholdsAndMargin = (axis) => {
-		return {
-			...getDynamicThresholds(axis),
-			margin: getDynamicMargin(axis),
-		}
-	}
-
-	const handleSnapMovement = (axis, point) => {
-		const isMovingAway = () => {
-			if (diff == null || prevDiff == null) return false
-
-			// If current diff is greater, element is moving away
-			const currDiffGreater = Math.abs(diff) >= Math.abs(prevDiff)
-
-			// If element just snapped, the prev diff is the threshold point
-			const justSnapped = Math.abs(Math.abs(prevDiff) - threshold) < margin
-
-			return currDiffGreater || justSnapped
-		}
-
-		const getSnapOffset = () => {
-			// check for threshold + / - margin
-			const canSnap = Math.abs(Math.abs(diff) - threshold) < margin
-			if (canSnap && !movingAway) {
-				return diff
-			}
-			return 0
-		}
-
-		const limitResistanceToOneSide = (activeGuide) => {
-			const resizer = currentResizer.value || ''
-
-			const oppositeGuides = {
-				left: 'right',
-				right: 'left',
-				top: 'bottom',
-				bottom: 'top',
-			}
-
-			Object.entries(oppositeGuides).forEach(([side, opposite]) => {
-				if (resizer.includes(side)) {
-					resistanceMap[opposite] = false
-					resistanceMap['centerX'] = false
-					resistanceMap['centerY'] = false
-				}
-			})
-		}
-
-		const setResistanceMap = () => {
-			const guide = getGuideForDirection(axis)
-			const withinResistanceRange = movingAway && Math.abs(diff) < resistance_threshold
-			resistanceMap[guide] = diff !== null && withinResistanceRange
-
-			limitResistanceToOneSide(guide)
-		}
-
-		const setResizeSnapOffsets = () => {
-			const resizer = currentResizer.value || ''
-			const snapOffset = getSnapOffset()
-
-			if (axis == 'right' && resizer.includes('right')) {
-				offsetWidth = -snapOffset
-			} else if (axis == 'left' && resizer.includes('left')) {
-				offsetX = snapOffset
-				offsetWidth = snapOffset
-			} else if (axis == 'bottom' && resizer.includes('bottom')) {
-				offsetHeight = -snapOffset
-			} else if (axis == 'top' && resizer.includes('top')) {
-				offsetY = snapOffset
-				offsetHeight = snapOffset
+		if (current) {
+			const held = candidates.find((c) => c.guide === current.guide && c.id === current.id)
+			if (held && Math.abs(held.offset) < held.threshold * RELEASE_FACTOR) {
+				return held
 			}
 		}
 
-		const setDragSnapOffsets = () => {
-			const snapOffset = getSnapOffset()
-			if (['slideCenterY', 'left', 'right'].includes(axis)) {
-				offsetX = snapOffset
-			} else if (['slideCenterX', 'top', 'bottom'].includes(axis)) {
-				offsetY = snapOffset
-			}
-		}
+		const within = candidates.filter((c) => Math.abs(c.offset) < c.threshold)
+		within.sort((a, b) => Math.abs(a.offset) - Math.abs(b.offset))
 
-		const { diff, prevDiff } = getDiffsForAxis(axis, point)
-
-		const { threshold, resistance_threshold, margin } = getThresholdsAndMargin(axis)
-
-		const movingAway = isMovingAway()
-
-		setResistanceMap()
-
-		let offsetX = 0
-		let offsetY = 0
-		let offsetWidth = 0
-		let offsetHeight = 0
-
-		if (mode.value == 'resizing') {
-			setResizeSnapOffsets()
-		} else {
-			setDragSnapOffsets()
-		}
-
-		return {
-			offsetX: offsetX,
-			offsetY: offsetY,
-			offsetWidth: offsetWidth,
-			offsetHeight: offsetHeight,
-		}
+		return within[0] || null
 	}
 
-	const getCenterOffsets = () => {
-		let pointX = 'centerX',
-			pointY = 'centerY'
+	const snapChannel = (channel, candidates) => {
+		const chosen = chooseGuide(channel, candidates)
+		engaged[channel] = chosen ? { guide: chosen.guide, id: chosen.id } : null
+		return chosen ? chosen.offset : 0
+	}
+
+	const translationCandidates = (vp, paired) => {
+		const threshold = getThreshold()
+		const center = slideCenter()
+
+		const x = [
+			{
+				guide: 'centerY',
+				id: 'slide',
+				offset: center.x - (vp.left + vp.right) / 2,
+				threshold,
+			},
+		]
+		const y = [
+			{
+				guide: 'centerX',
+				id: 'slide',
+				offset: center.y - (vp.top + vp.bottom) / 2,
+				threshold,
+			},
+		]
+
+		if (paired) {
+			const id = pairElementId.value
+			x.push({ guide: 'left', id, offset: paired.left - vp.left, threshold })
+			x.push({ guide: 'right', id, offset: paired.right - vp.right, threshold })
+			y.push({ guide: 'top', id, offset: paired.top - vp.top, threshold })
+			y.push({ guide: 'bottom', id, offset: paired.bottom - vp.bottom, threshold })
+		}
+
+		return { x, y }
+	}
+
+	const edgeCandidates = (vp, paired) => {
+		const threshold = getThreshold()
+		const center = slideCenter()
+		const resizer = currentResizer.value || ''
+		const id = pairElementId.value
+
+		const x = []
+		const y = []
+
+		if (resizer.includes('left')) {
+			x.push({ guide: 'centerY', id: 'slide', offset: center.x - vp.left, threshold })
+			if (paired) x.push({ guide: 'left', id, offset: paired.left - vp.left, threshold })
+		} else if (resizer.includes('right')) {
+			x.push({ guide: 'centerY', id: 'slide', offset: center.x - vp.right, threshold })
+			if (paired) x.push({ guide: 'right', id, offset: paired.right - vp.right, threshold })
+		}
+
+		if (resizer.includes('top')) {
+			y.push({ guide: 'centerX', id: 'slide', offset: center.y - vp.top, threshold })
+			if (paired) y.push({ guide: 'top', id, offset: paired.top - vp.top, threshold })
+		} else if (resizer.includes('bottom')) {
+			y.push({ guide: 'centerX', id: 'slide', offset: center.y - vp.bottom, threshold })
+			if (paired)
+				y.push({ guide: 'bottom', id, offset: paired.bottom - vp.bottom, threshold })
+		}
+
+		return { x, y }
+	}
+
+	// rect is the desired geometry in slide units; returns it with snapping applied
+	const applySnapping = (rect, interaction, { axes = ['x', 'y'] } = {}) => {
+		if (!target.value || !hasOngoingInteraction.value) return rect
+
+		const scale = slideBounds.scale
+		const vp = toViewport(rect)
+		const paired = updatePairing(vp)
+
+		if (interaction === 'dragging') {
+			const candidates = translationCandidates(vp, paired)
+			const dx = snapChannel('x', candidates.x) / scale
+			const dy = snapChannel('y', candidates.y) / scale
+
+			return { ...rect, left: rect.left + dx, top: rect.top + dy }
+		}
+
+		const candidates = edgeCandidates(vp, paired)
+		const dx = axes.includes('x') ? snapChannel('x', candidates.x) / scale : 0
+		const dy = axes.includes('y') ? snapChannel('y', candidates.y) / scale : 0
 
 		const resizer = currentResizer.value || ''
+		const snapped = { ...rect }
 
-		if (mode.value == 'resizing') {
-			if (resizer.includes('left')) pointX = 'startX'
-			else if (resizer.includes('right')) pointX = 'endX'
-
-			if (resizer.includes('top')) pointY = 'startY'
-			else if (resizer.includes('bottom')) pointY = 'endY'
+		// only the moving edge takes the offset; the opposite edge stays put
+		if (resizer.includes('left')) {
+			snapped.left += dx
+			snapped.width -= dx
+		} else if (resizer.includes('right')) {
+			snapped.width += dx
 		}
 
-		const x = handleSnapMovement('slideCenterX', pointX)
-		const y = handleSnapMovement('slideCenterY', pointY)
-
-		return {
-			centerOffsetX: x.offsetX,
-			centerOffsetY: y.offsetY,
-			centerOffsetWidth: x.offsetWidth + y.offsetWidth,
-			centerOffsetHeight: x.offsetHeight + y.offsetHeight,
-		}
-	}
-
-	const getOffset = (axis) => {
-		let start, end
-
-		if (axis == 'X') {
-			start = 'left'
-			end = 'right'
-		} else {
-			start = 'top'
-			end = 'bottom'
+		if (resizer.includes('top')) {
+			snapped.top += dy
+			snapped.height -= dy
+		} else if (resizer.includes('bottom')) {
+			snapped.height += dy
 		}
 
-		const dragEnd =
-			mode.value == 'dragging' &&
-			Math.abs(diffs.matched[end]) < Math.abs(diffs.matched[start])
-		const resizeEnd =
-			mode.value == 'resizing' && currentResizer.value?.includes(end.toLowerCase())
-
-		if (dragEnd || resizeEnd) {
-			return handleSnapMovement(end)
-		}
-
-		return handleSnapMovement(start)
+		return snapped
 	}
 
-	const getPairedOffsets = () => {
-		const x = getOffset('X')
-		const y = getOffset('Y')
-
-		return {
-			pairedOffsetX: x.offsetX,
-			pairedOffsetY: y.offsetY,
-			pairedOffsetWidth: x.offsetWidth + y.offsetWidth,
-			pairedOffsetHeight: x.offsetHeight + y.offsetHeight,
-		}
-	}
-
-	const getSnapDelta = () => {
-		if (!target.value) return
-
-		const center = getCenterOffsets()
-		const paired = getPairedOffsets()
-
-		return {
-			x: center.centerOffsetX - paired.pairedOffsetX || 0,
-			y: center.centerOffsetY - paired.pairedOffsetY || 0,
-			width: center.centerOffsetWidth + paired.pairedOffsetWidth || 0,
-			height: center.centerOffsetHeight + paired.pairedOffsetHeight || 0,
-		}
-	}
-
-	const handleSnapping = (interaction = 'dragging') => {
-		mode.value = interaction
-
-		// update diffs based on current position
-		updateDiffs()
-
-		// return delta to apply for closest snap
-		return getSnapDelta()
-	}
-
-	return {
-		visibilityMap,
-		resistanceMap,
-		handleSnapping,
-	}
+	return { visibilityMap, applySnapping }
 }

--- a/frontend/src/apps/slides/composables/useSnapping.js
+++ b/frontend/src/apps/slides/composables/useSnapping.js
@@ -400,17 +400,15 @@ export const useSnapping = (target, parent, currentResizer, hasOngoingInteractio
 			const snapOffset = getSnapOffset()
 
 			if (axis == 'right' && resizer.includes('right')) {
-				offsetX = 0
 				offsetWidth = -snapOffset
 			} else if (axis == 'left' && resizer.includes('left')) {
 				offsetX = snapOffset
 				offsetWidth = snapOffset
 			} else if (axis == 'bottom' && resizer.includes('bottom')) {
-				offsetY = 0
-				offsetWidth = -snapOffset
+				offsetHeight = -snapOffset
 			} else if (axis == 'top' && resizer.includes('top')) {
 				offsetY = snapOffset
-				offsetWidth = snapOffset
+				offsetHeight = snapOffset
 			}
 		}
 
@@ -434,6 +432,7 @@ export const useSnapping = (target, parent, currentResizer, hasOngoingInteractio
 		let offsetX = 0
 		let offsetY = 0
 		let offsetWidth = 0
+		let offsetHeight = 0
 
 		if (mode.value == 'resizing') {
 			setResizeSnapOffsets()
@@ -445,6 +444,7 @@ export const useSnapping = (target, parent, currentResizer, hasOngoingInteractio
 			offsetX: offsetX,
 			offsetY: offsetY,
 			offsetWidth: offsetWidth,
+			offsetHeight: offsetHeight,
 		}
 	}
 
@@ -462,14 +462,14 @@ export const useSnapping = (target, parent, currentResizer, hasOngoingInteractio
 			else if (resizer.includes('bottom')) pointY = 'endY'
 		}
 
-		const { offsetX, offsetWidth } = handleSnapMovement('slideCenterX', pointX)
-
-		const { offsetY, offsetWidth: offsetWidthY } = handleSnapMovement('slideCenterY', pointY)
+		const x = handleSnapMovement('slideCenterX', pointX)
+		const y = handleSnapMovement('slideCenterY', pointY)
 
 		return {
-			centerOffsetX: offsetX,
-			centerOffsetWidth: offsetWidth + offsetWidthY,
-			centerOffsetY: offsetY,
+			centerOffsetX: x.offsetX,
+			centerOffsetY: y.offsetY,
+			centerOffsetWidth: x.offsetWidth + y.offsetWidth,
+			centerOffsetHeight: x.offsetHeight + y.offsetHeight,
 		}
 	}
 
@@ -498,27 +498,28 @@ export const useSnapping = (target, parent, currentResizer, hasOngoingInteractio
 	}
 
 	const getPairedOffsets = () => {
-		const { offsetX, offsetWidth } = getOffset('X')
-		const { offsetY, offsetWidth: offsetWidthY } = getOffset('Y')
+		const x = getOffset('X')
+		const y = getOffset('Y')
 
 		return {
-			pairedOffsetX: offsetX,
-			pairedOffsetY: offsetY,
-			pairedOffsetWidth: offsetWidth + offsetWidthY,
+			pairedOffsetX: x.offsetX,
+			pairedOffsetY: y.offsetY,
+			pairedOffsetWidth: x.offsetWidth + y.offsetWidth,
+			pairedOffsetHeight: x.offsetHeight + y.offsetHeight,
 		}
 	}
 
 	const getSnapDelta = () => {
 		if (!target.value) return
 
-		const { centerOffsetX, centerOffsetY, centerOffsetWidth } = getCenterOffsets()
-
-		const { pairedOffsetX, pairedOffsetY, pairedOffsetWidth } = getPairedOffsets()
+		const center = getCenterOffsets()
+		const paired = getPairedOffsets()
 
 		return {
-			x: centerOffsetX - pairedOffsetX || 0,
-			y: centerOffsetY - pairedOffsetY || 0,
-			width: centerOffsetWidth + pairedOffsetWidth || 0,
+			x: center.centerOffsetX - paired.pairedOffsetX || 0,
+			y: center.centerOffsetY - paired.pairedOffsetY || 0,
+			width: center.centerOffsetWidth + paired.pairedOffsetWidth || 0,
+			height: center.centerOffsetHeight + paired.pairedOffsetHeight || 0,
 		}
 	}
 

--- a/frontend/src/apps/slides/composables/useSnapping.js
+++ b/frontend/src/apps/slides/composables/useSnapping.js
@@ -3,238 +3,313 @@ import { selectionBounds, currentSlide, slideBounds } from '../stores/slide'
 import { activeElementIds, pairElementId } from '../stores/element'
 import { getElementDiv } from '../stores/elementRegistry'
 
-export const useSnapping = (target, parent, currentResizer, hasOngoingInteraction) => {
+export const useSnapping = (selectionRef, currentResizer, hasOngoingInteraction) => {
 	const RELEASE_FACTOR = 1.25
 
-	// engaged guide per channel: 'x' snaps to vertical guides, 'y' to horizontal
-	const engaged = reactive({ x: null, y: null })
+	// the edges / centers a rect can align by
+	const X_LINES = ['left', 'right', 'centerX']
+	const Y_LINES = ['top', 'bottom', 'centerY']
 
-	// rects of non-active elements, snapshotted once per gesture — they cannot
-	// move mid-gesture, and reading layout per mousemove forces synchronous reflow
-	const staticElementRects = new Map()
+	// every [selection line, neighbour line] pair can align
+	const X_ALIGNMENTS = [
+		['left', 'left'],
+		['left', 'right'],
+		['right', 'left'],
+		['right', 'right'],
+		['centerX', 'centerX'],
+	]
+	const Y_ALIGNMENTS = [
+		['top', 'top'],
+		['top', 'bottom'],
+		['bottom', 'top'],
+		['bottom', 'bottom'],
+		['centerY', 'centerY'],
+	]
 
-	const cacheStaticElementRects = () => {
-		staticElementRects.clear()
+	const isSnapping = () => selectionRef.value && hasOngoingInteraction.value
+
+	const neighbourRects = new Map()
+
+	// for all neighbous, the rects don't change during gesture
+	// so cache them in the start until gesture ends
+	const cacheNeighbourRects = () => {
+		neighbourRects.clear()
 
 		currentSlide.value?.elements.forEach((element) => {
 			if (activeElementIds.value.includes(element.id)) return
 
-			const elementDiv = getElementDiv(element.id)
-			if (!elementDiv) return
+			const div = getElementDiv(element.id)
+			if (!div) return
 
-			const rect = elementDiv.getBoundingClientRect()
-			staticElementRects.set(element.id, {
-				left: rect.left,
-				right: rect.right,
-				top: rect.top,
-				bottom: rect.bottom,
+			const r = div.getBoundingClientRect()
+			neighbourRects.set(element.id, {
+				left: r.left,
+				right: r.right,
+				top: r.top,
+				bottom: r.bottom,
+				centerX: (r.left + r.right) / 2,
+				centerY: (r.top + r.bottom) / 2,
 			})
 		})
 	}
 
 	watch(hasOngoingInteraction, (ongoing) => {
-		if (ongoing) return cacheStaticElementRects()
-
-		staticElementRects.clear()
-		engaged.x = null
-		engaged.y = null
+		if (ongoing) return cacheNeighbourRects()
+		neighbourRects.clear()
+		clearSnap()
 	})
 
-	// pan/zoom mid-gesture moves the cached rects on screen — resnapshot
+	// pan / zoom moves the cached rects on screen — resnapshot
 	watch(
 		() => [slideBounds.left, slideBounds.top, slideBounds.scale],
-		() => {
-			if (hasOngoingInteraction.value) cacheStaticElementRects()
-		},
+		() => isSnapping() && cacheNeighbourRects(),
 	)
 
-	// engage threshold in viewport px, sized to the selection
-	const getThreshold = () => {
-		const scaledHeight = selectionBounds.height * slideBounds.scale * 0.1
-		const minThreshold = scaledHeight > 50 ? scaledHeight / 6 : scaledHeight / 5
-		const maxThreshold = scaledHeight > 50 ? scaledHeight / 4 : scaledHeight / 3
-		return Math.max(minThreshold, Math.min(maxThreshold, scaledHeight))
+	const toScreenRect = (rect) => {
+		const scale = slideBounds.scale
+		const left = slideBounds.left + rect.left * scale
+		const top = slideBounds.top + rect.top * scale
+		const right = left + rect.width * scale
+		const bottom = top + rect.height * scale
+		return {
+			left,
+			top,
+			right,
+			bottom,
+			centerX: (left + right) / 2,
+			centerY: (top + bottom) / 2,
+		}
 	}
 
-	// guides only show while actually snapped
-	const visibilityMap = computed(() => {
-		if (!hasOngoingInteraction.value) return {}
-
-		return {
-			centerY: engaged.x?.guide === 'centerY',
-			left: engaged.x?.guide === 'left',
-			right: engaged.x?.guide === 'right',
-			centerX: engaged.y?.guide === 'centerX',
-			top: engaged.y?.guide === 'top',
-			bottom: engaged.y?.guide === 'bottom',
-		}
-	})
-
-	const slideCenter = () => ({
+	const getSlideCenter = () => ({
 		x: slideBounds.left + slideBounds.width / 2,
 		y: slideBounds.top + slideBounds.height / 2,
 	})
 
-	const toViewport = (rect) => {
-		const scale = slideBounds.scale
-		const left = slideBounds.left + rect.left * scale
-		const top = slideBounds.top + rect.top * scale
+	const getThreshold = () => {
+		const height = selectionBounds.height * slideBounds.scale * 0.1
+		const min = height > 50 ? height / 6 : height / 5
+		const max = height > 50 ? height / 4 : height / 3
+		return Math.max(min, Math.min(max, height))
+	}
 
+	const getMovingLine = (axis) => {
+		const handle = currentResizer.value || ''
+		if (axis === 'x')
+			return handle.includes('left') ? 'left' : handle.includes('right') ? 'right' : null
+		return handle.includes('top') ? 'top' : handle.includes('bottom') ? 'bottom' : null
+	}
+
+	// a candidate snap: the selection's `selectionLine` (e.g. its left edge or
+	// centerX) could land on a `guideLine` belonging to `source`. it stores:
+	//   key    — unique per candidate, so the hysteresis can re-find it
+	//   source — 'slide' | 'element' (what the guide belongs to)
+	//   line   — the guide line: where SnapGuides draws and what we align onto
+	//   offset — px to move the selection so its line lands on the guide
+	const createAlignment = (
+		source,
+		selectionLine,
+		guideLine,
+		guidePosition,
+		selectionPosition,
+	) => ({
+		key: `${source}:${guideLine}:${selectionLine}`,
+		source,
+		line: guideLine,
+		offset: guidePosition - selectionPosition,
+	})
+
+	const getNeighbourAlignmentsForDrag = (selectionScreenRect, neighbour) => {
+		const make = ([selectionLine, guideLine]) =>
+			createAlignment(
+				'element',
+				selectionLine,
+				guideLine,
+				neighbour[guideLine],
+				selectionScreenRect[selectionLine],
+			)
 		return {
-			left,
-			top,
-			right: left + rect.width * scale,
-			bottom: top + rect.height * scale,
+			x: X_ALIGNMENTS.map(make),
+			y: Y_ALIGNMENTS.map(make),
 		}
 	}
 
-	// pair with the first cached element that has a like-edge near the desired
-	// rect; drives the pair highlight + the edge guide candidates
-	const updatePairing = (vp) => {
-		const threshold = getThreshold()
+	const getNeighbourAlignmentsForResize = (selectionScreenRect, neighbour) => {
+		const movingX = getMovingLine('x')
+		const movingY = getMovingLine('y')
+		const make = (selectionLine, guideLine) =>
+			createAlignment(
+				'element',
+				selectionLine,
+				guideLine,
+				neighbour[guideLine],
+				selectionScreenRect[selectionLine],
+			)
+		return {
+			x: movingX ? X_LINES.map((guideLine) => make(movingX, guideLine)) : [],
+			y: movingY ? Y_LINES.map((guideLine) => make(movingY, guideLine)) : [],
+		}
+	}
 
-		for (const [id, bounds] of staticElementRects) {
-			const isNear =
-				Math.abs(vp.left - bounds.left) < threshold ||
-				Math.abs(vp.right - bounds.right) < threshold ||
-				Math.abs(vp.top - bounds.top) < threshold ||
-				Math.abs(vp.bottom - bounds.bottom) < threshold
+	const getSlideAlignmentsForDrag = (selectionScreenRect) => {
+		const center = getSlideCenter()
+		const x = createAlignment(
+			'slide',
+			'centerX',
+			'centerX',
+			center.x,
+			selectionScreenRect.centerX,
+		)
+		const y = createAlignment(
+			'slide',
+			'centerY',
+			'centerY',
+			center.y,
+			selectionScreenRect.centerY,
+		)
+		return { x: [x], y: [y] }
+	}
 
-			if (isNear) {
-				pairElementId.value = id
-				return bounds
-			}
+	const getSlideAlignmentsForResize = (selectionScreenRect) => {
+		const center = getSlideCenter()
+
+		// one candidate if this axis is resizing, otherwise none
+		const centerCandidates = (movingLine, guideLine, slideCenter) => {
+			if (!movingLine) return []
+			const selectionPosition = selectionScreenRect[movingLine]
+			return [createAlignment('slide', movingLine, guideLine, slideCenter, selectionPosition)]
 		}
 
+		return {
+			x: centerCandidates(getMovingLine('x'), 'centerX', center.x),
+			y: centerCandidates(getMovingLine('y'), 'centerY', center.y),
+		}
+	}
+
+	const getSlideAlignments = (selectionScreenRect, mode) => {
+		if (mode === 'drag') return getSlideAlignmentsForDrag(selectionScreenRect)
+		if (mode === 'resize') return getSlideAlignmentsForResize(selectionScreenRect)
+		return { x: [], y: [] }
+	}
+
+	const getNeighbourAlignmentsBuilder = (mode) => {
+		if (mode === 'drag') return getNeighbourAlignmentsForDrag
+		if (mode === 'resize') return getNeighbourAlignmentsForResize
+		return null
+	}
+
+	// first neighbour with any alignment in range becomes the pair (highlighted)
+	const getNeighbourAlignments = (selectionScreenRect, mode) => {
+		const buildAlignments = getNeighbourAlignmentsBuilder(mode)
+		if (!buildAlignments) return null
+
+		const limit = getThreshold()
+		for (const [id, neighbour] of neighbourRects) {
+			const aligned = buildAlignments(selectionScreenRect, neighbour)
+			const inRange = [...aligned.x, ...aligned.y].some((a) => Math.abs(a.offset) < limit)
+			if (inRange) {
+				pairElementId.value = id
+				return aligned
+			}
+		}
 		pairElementId.value = null
 		return null
 	}
 
-	// keep the engaged guide while desired stays inside the release window,
-	// otherwise engage the nearest candidate inside the engage threshold
-	const chooseGuide = (channel, candidates) => {
-		const current = engaged[channel]
-
-		if (current) {
-			const held = candidates.find((c) => c.guide === current.guide && c.id === current.id)
-			if (held && Math.abs(held.offset) < held.threshold * RELEASE_FACTOR) {
-				return held
-			}
-		}
-
-		const within = candidates.filter((c) => Math.abs(c.offset) < c.threshold)
-		within.sort((a, b) => Math.abs(a.offset) - Math.abs(b.offset))
-
-		return within[0] || null
+	// what each axis is snapped to, or null. each entry is an alignment object:
+	//   { key, source: 'slide' | 'element', line, offset }
+	const activeSnap = reactive({ x: null, y: null })
+	const clearSnap = () => {
+		activeSnap.x = null
+		activeSnap.y = null
 	}
 
-	const snapChannel = (channel, candidates) => {
-		const chosen = chooseGuide(channel, candidates)
-		engaged[channel] = chosen ? { guide: chosen.guide, id: chosen.id } : null
-		return chosen ? chosen.offset : 0
+	// stay on the current alignment until it leaves the release window,
+	// otherwise take the nearest one within the threshold
+	const chooseAlignment = (axis, alignments) => {
+		const limit = getThreshold()
+		const current = activeSnap[axis]
+		const held = current && alignments.find((a) => a.key === current.key)
+		if (held && Math.abs(held.offset) < limit * RELEASE_FACTOR) return held
+
+		const inRange = alignments.filter((a) => Math.abs(a.offset) < limit)
+		inRange.sort((a, b) => Math.abs(a.offset) - Math.abs(b.offset))
+		return inRange[0] || null
 	}
 
-	const translationCandidates = (vp, paired) => {
-		const threshold = getThreshold()
-		const center = slideCenter()
-
-		const x = [
-			{
-				guide: 'centerY',
-				id: 'slide',
-				offset: center.x - (vp.left + vp.right) / 2,
-				threshold,
-			},
-		]
-		const y = [
-			{
-				guide: 'centerX',
-				id: 'slide',
-				offset: center.y - (vp.top + vp.bottom) / 2,
-				threshold,
-			},
-		]
-
-		if (paired) {
-			const id = pairElementId.value
-			x.push({ guide: 'left', id, offset: paired.left - vp.left, threshold })
-			x.push({ guide: 'right', id, offset: paired.right - vp.right, threshold })
-			y.push({ guide: 'top', id, offset: paired.top - vp.top, threshold })
-			y.push({ guide: 'bottom', id, offset: paired.bottom - vp.bottom, threshold })
-		}
-
-		return { x, y }
+	// records what the axis snapped to and returns how far to move it (slide units).
+	// shouldSnap is false for an aspect-locked axis (e.g. media height)
+	const getSnapOffsetForAxis = (axis, alignments, shouldSnap) => {
+		const chosen = shouldSnap ? chooseAlignment(axis, alignments) : null
+		activeSnap[axis] = chosen
+		return (chosen ? chosen.offset : 0) / slideBounds.scale
 	}
 
-	const edgeCandidates = (vp, paired) => {
-		const threshold = getThreshold()
-		const center = slideCenter()
-		const resizer = currentResizer.value || ''
-		const id = pairElementId.value
-
-		const x = []
-		const y = []
-
-		if (resizer.includes('left')) {
-			x.push({ guide: 'centerY', id: 'slide', offset: center.x - vp.left, threshold })
-			if (paired) x.push({ guide: 'left', id, offset: paired.left - vp.left, threshold })
-		} else if (resizer.includes('right')) {
-			x.push({ guide: 'centerY', id: 'slide', offset: center.x - vp.right, threshold })
-			if (paired) x.push({ guide: 'right', id, offset: paired.right - vp.right, threshold })
+	const mergeCandidates = (slide, neighbour) => {
+		const neighbourCandidates = neighbour ?? { x: [], y: [] }
+		return {
+			x: [...slide.x, ...neighbourCandidates.x],
+			y: [...slide.y, ...neighbourCandidates.y],
 		}
-
-		if (resizer.includes('top')) {
-			y.push({ guide: 'centerX', id: 'slide', offset: center.y - vp.top, threshold })
-			if (paired) y.push({ guide: 'top', id, offset: paired.top - vp.top, threshold })
-		} else if (resizer.includes('bottom')) {
-			y.push({ guide: 'centerX', id: 'slide', offset: center.y - vp.bottom, threshold })
-			if (paired)
-				y.push({ guide: 'bottom', id, offset: paired.bottom - vp.bottom, threshold })
-		}
-
-		return { x, y }
 	}
 
-	// rect is the desired geometry in slide units; returns it with snapping applied
-	const applySnapping = (rect, interaction, { axes = ['x', 'y'] } = {}) => {
-		if (!target.value || !hasOngoingInteraction.value) return rect
+	const getSnapCandidates = (selectionScreenRect, mode) => {
+		const slide = getSlideAlignments(selectionScreenRect, mode)
+		const neighbour = getNeighbourAlignments(selectionScreenRect, mode)
+		return mergeCandidates(slide, neighbour)
+	}
 
-		const scale = slideBounds.scale
-		const vp = toViewport(rect)
-		const paired = updatePairing(vp)
+	const snapForDrag = (rect) => {
+		if (!isSnapping()) return rect
 
-		if (interaction === 'dragging') {
-			const candidates = translationCandidates(vp, paired)
-			const dx = snapChannel('x', candidates.x) / scale
-			const dy = snapChannel('y', candidates.y) / scale
+		const selectionScreenRect = toScreenRect(rect)
+		const candidates = getSnapCandidates(selectionScreenRect, 'drag')
 
-			return { ...rect, left: rect.left + dx, top: rect.top + dy }
-		}
+		const dx = getSnapOffsetForAxis('x', candidates.x, true)
+		const dy = getSnapOffsetForAxis('y', candidates.y, true)
 
-		const candidates = edgeCandidates(vp, paired)
-		const dx = axes.includes('x') ? snapChannel('x', candidates.x) / scale : 0
-		const dy = axes.includes('y') ? snapChannel('y', candidates.y) / scale : 0
+		const left = rect.left + dx
+		const top = rect.top + dy
 
-		const resizer = currentResizer.value || ''
+		return { ...rect, left, top }
+	}
+
+	// apply the offset to the moving edge, the opposite edge stays put
+	const applyOffsetToMovingEdges = (rect, dx, dy) => {
+		const handle = currentResizer.value || ''
 		const snapped = { ...rect }
 
-		// only the moving edge takes the offset; the opposite edge stays put
-		if (resizer.includes('left')) {
+		if (handle.includes('left')) {
 			snapped.left += dx
 			snapped.width -= dx
-		} else if (resizer.includes('right')) {
+		} else if (handle.includes('right')) {
 			snapped.width += dx
 		}
 
-		if (resizer.includes('top')) {
+		if (handle.includes('top')) {
 			snapped.top += dy
 			snapped.height -= dy
-		} else if (resizer.includes('bottom')) {
+		} else if (handle.includes('bottom')) {
 			snapped.height += dy
 		}
 
 		return snapped
 	}
 
-	return { visibilityMap, applySnapping }
+	const snapForResize = (rect, { axes = ['x', 'y'] } = {}) => {
+		if (!isSnapping()) return rect
+
+		const selectionScreenRect = toScreenRect(rect)
+		const candidates = getSnapCandidates(selectionScreenRect, 'resize')
+
+		const dx = getSnapOffsetForAxis('x', candidates.x, axes.includes('x'))
+		const dy = getSnapOffsetForAxis('y', candidates.y, axes.includes('y'))
+
+		return applyOffsetToMovingEdges(rect, dx, dy)
+	}
+
+	// what SnapGuides draws per axis
+	const activeGuides = computed(() => ({ x: activeSnap.x, y: activeSnap.y }))
+
+	return { activeGuides, snapForDrag, snapForResize }
 }

--- a/frontend/src/apps/slides/composables/useSnapping.js
+++ b/frontend/src/apps/slides/composables/useSnapping.js
@@ -1,6 +1,7 @@
 import { ref, reactive, computed } from 'vue'
 import { selectionBounds, currentSlide, slideBounds } from '../stores/slide'
 import { activeElementIds, pairElementId } from '../stores/element'
+import { getElementDiv } from '../stores/elementRegistry'
 
 export const useSnapping = (target, parent, currentResizer, hasOngoingInteraction) => {
 	// element wrt slide center
@@ -188,7 +189,7 @@ export const useSnapping = (target, parent, currentResizer, hasOngoingInteractio
 	const getDiffFromElement = (element) => {
 		if (activeElementIds.value.includes(element.id)) return
 
-		const elementDiv = document.querySelector(`[data-index="${element.id}"]`)
+		const elementDiv = getElementDiv(element.id)
 		if (!elementDiv || !target.value) return
 
 		const elementBounds = elementDiv.getBoundingClientRect()

--- a/frontend/src/apps/slides/composables/useSnapping.js
+++ b/frontend/src/apps/slides/composables/useSnapping.js
@@ -38,6 +38,8 @@ export const useSnapping = (selectionRef, currentResizer, hasOngoingInteraction)
 		currentSlide.value?.elements.forEach((element) => {
 			if (activeElementIds.value.includes(element.id)) return
 
+			if (element.rotation) return
+
 			const div = getElementDiv(element.id)
 			if (!div) return
 

--- a/frontend/src/apps/slides/composables/useSnapping.js
+++ b/frontend/src/apps/slides/composables/useSnapping.js
@@ -38,8 +38,6 @@ export const useSnapping = (selectionRef, currentResizer, hasOngoingInteraction)
 		currentSlide.value?.elements.forEach((element) => {
 			if (activeElementIds.value.includes(element.id)) return
 
-			if (element.rotation) return
-
 			const div = getElementDiv(element.id)
 			if (!div) return
 

--- a/frontend/src/apps/slides/composables/useSnapping.js
+++ b/frontend/src/apps/slides/composables/useSnapping.js
@@ -1,4 +1,4 @@
-import { ref, reactive, computed } from 'vue'
+import { ref, reactive, computed, watch } from 'vue'
 import { selectionBounds, currentSlide, slideBounds } from '../stores/slide'
 import { activeElementIds, pairElementId } from '../stores/element'
 import { getElementDiv } from '../stores/elementRegistry'
@@ -186,13 +186,49 @@ export const useSnapping = (target, parent, currentResizer, hasOngoingInteractio
 		}
 	}
 
+	// rects of non-active elements, snapshotted once per gesture — they cannot
+	// move mid-gesture, and reading layout per mousemove forces synchronous reflow
+	const staticElementRects = new Map()
+
+	const cacheStaticElementRects = () => {
+		staticElementRects.clear()
+
+		currentSlide.value?.elements.forEach((element) => {
+			if (activeElementIds.value.includes(element.id)) return
+
+			const elementDiv = getElementDiv(element.id)
+			if (!elementDiv) return
+
+			const rect = elementDiv.getBoundingClientRect()
+			staticElementRects.set(element.id, {
+				left: rect.left,
+				right: rect.right,
+				top: rect.top,
+				bottom: rect.bottom,
+			})
+		})
+	}
+
+	watch(hasOngoingInteraction, (ongoing) => {
+		if (ongoing) cacheStaticElementRects()
+		else staticElementRects.clear()
+	})
+
+	// pan/zoom mid-gesture moves the cached rects on screen — resnapshot
+	watch(
+		() => [slideBounds.left, slideBounds.top, slideBounds.scale],
+		() => {
+			if (hasOngoingInteraction.value) cacheStaticElementRects()
+		},
+	)
+
 	const getDiffFromElement = (element) => {
-		if (activeElementIds.value.includes(element.id)) return
+		if (!target.value) return
 
-		const elementDiv = getElementDiv(element.id)
-		if (!elementDiv || !target.value) return
+		// active elements are never cached, so this also skips self-pairing
+		const elementBounds = staticElementRects.get(element.id)
+		if (!elementBounds) return
 
-		const elementBounds = elementDiv.getBoundingClientRect()
 		const activeBounds = getActiveElementBounds()
 
 		return {

--- a/frontend/src/apps/slides/composables/useTextEditor.js
+++ b/frontend/src/apps/slides/composables/useTextEditor.js
@@ -89,6 +89,8 @@ export const useTextEditor = () => {
 				property: 'content',
 				oldValue: contentHistory.value,
 				newValue: editor.getHTML(),
+				// saving on blur must not pull selection back to this element
+				skipJumpOnExecute: true,
 			}),
 		)
 	}

--- a/frontend/src/apps/slides/composables/useTextEditor.js
+++ b/frontend/src/apps/slides/composables/useTextEditor.js
@@ -3,6 +3,7 @@ import { Editor } from '@tiptap/vue-3'
 import { extensions } from '@/apps/slides/stores/tiptapSetup'
 import { TextSelection } from 'prosemirror-state'
 import { commandHistory } from '@/apps/slides/stores/historyMeta'
+import { markDirty } from '@/apps/slides/stores/saving'
 import { activeElement } from '@/apps/slides/stores/element'
 import { editElementCommand } from '@/apps/slides/stores/commands'
 import { currentSlide } from '@/apps/slides/stores/slide'
@@ -57,6 +58,7 @@ export const useTextEditor = () => {
 
 	const updateElementContent = (editor) => {
 		activeElement.value.content = editor.getHTML()
+		markDirty()
 	}
 
 	const handleOnTransaction = (editor, transaction) => {

--- a/frontend/src/apps/slides/composables/useThumbnailCapture.js
+++ b/frontend/src/apps/slides/composables/useThumbnailCapture.js
@@ -5,7 +5,7 @@ import { call } from 'frappe-ui'
 import { presentationDoc, unsyncedPresentationRecord, inReadonlyMode } from '@/apps/slides/stores/presentation'
 import { slides } from '@/apps/slides/stores/slide'
 import { focusElementId } from '@/apps/slides/stores/element'
-import { isDirty, isSaving } from '@/apps/slides/stores/saving'
+import { dirty, isSaving } from '@/apps/slides/stores/saving'
 import { captureDOM } from '@/apps/slides/utils/domToWebp'
 
 const DEBOUNCE_MS = 5000
@@ -40,7 +40,7 @@ export const useThumbnailCapture = (thumbnailCapture, hasOngoingInteraction) => 
 			return false
 		}
 		if (unsyncedPresentationRecord.value.deleted) return false
-		if (!navigator.onLine || isDirty.value || isSaving.value) return false
+		if (!navigator.onLine || dirty.value || isSaving.value) return false
 		if (hasOngoingInteraction.value || focusElementId.value != null) return false
 		return true
 	}

--- a/frontend/src/apps/slides/pages/PresentationEditor.vue
+++ b/frontend/src/apps/slides/pages/PresentationEditor.vue
@@ -122,7 +122,7 @@ import {
 } from '@/apps/slides/stores/historyMeta'
 
 import { useShortcuts } from '@/apps/slides/composables/useShortcuts'
-import { saveChanges, saveCurrentState, isDirty } from '@/apps/slides/stores/saving'
+import { saveChanges, saveCurrentState, dirty } from '@/apps/slides/stores/saving'
 import { inSlideShowMode, startSlideShow } from '@/apps/slides/stores/slideshow'
 import { Layout } from 'lucide-vue-next'
 import { useCommandHistory } from '@/apps/slides/composables/useCommandHistory'
@@ -209,7 +209,7 @@ const updateUnsyncedRecord = () => {
 }
 
 const handleBeforeUnload = (e) => {
-	if (isDirty.value) {
+	if (dirty.value) {
 		e.preventDefault()
 		e.returnValue = ''
 	}

--- a/frontend/src/apps/slides/stores/commands.js
+++ b/frontend/src/apps/slides/stores/commands.js
@@ -50,10 +50,18 @@ const editElements = (state, slideId, elementIds, property, value) => {
 	})
 }
 
-const editElementCommand = ({ slideId, elementIds, property, oldValue, newValue }) => ({
+const editElementCommand = ({
+	slideId,
+	elementIds,
+	property,
+	oldValue,
+	newValue,
+	skipJumpOnExecute,
+}) => ({
 	key: 'editElement',
 	jumpToSlideId: slideId,
 	jumpToElementIds: elementIds,
+	skipJumpOnExecute,
 	debug: `Edit ${property} of element ${elementIds} on slide ${slideId} to ${newValue}`,
 	execute(state) {
 		editElements(state, slideId, elementIds, property, newValue)
@@ -144,11 +152,12 @@ const reorderSlidesCommand = ({ oldIndex, newIndex }) => ({
 	},
 })
 
-const batchCommand = ({ slideId, elementIds, focusElementId, commands }) => ({
+const batchCommand = ({ slideId, elementIds, focusElementId, commands, skipJumpOnExecute }) => ({
 	key: 'batch',
 	jumpToSlideId: slideId,
 	jumpToElementIds: elementIds,
 	focusElementId: focusElementId,
+	skipJumpOnExecute,
 	debug: 'Batch edit',
 	execute: (state) => {
 		commands.forEach((c) => c.execute(state))

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -678,7 +678,10 @@ const resetFocus = () => {
 }
 
 const getElementPosition = (elementId) => {
-	const elementRect = getElementDiv(elementId).getBoundingClientRect()
+	const elementDiv = getElementDiv(elementId)
+	if (!elementDiv) return { left: 0, top: 0, right: 0, bottom: 0 }
+
+	const elementRect = elementDiv.getBoundingClientRect()
 
 	const elementLeft = (elementRect.left - slideBounds.left) / slideBounds.scale
 	const elementTop = (elementRect.top - slideBounds.top) / slideBounds.scale
@@ -695,7 +698,15 @@ const getElementPosition = (elementId) => {
 
 const getElementLayoutPosition = (element) => {
 	const elementDiv = getElementDiv(element.id)
-	if (!elementDiv) return getElementPosition(element.id)
+	// no rendered node yet: fall back to the element's stored bounds
+	if (!elementDiv) {
+		return {
+			left: element.left,
+			top: element.top,
+			right: element.left + (element.width || 0),
+			bottom: element.top + (element.height || 0),
+		}
+	}
 
 	return {
 		left: element.left,
@@ -720,7 +731,7 @@ const isWithinOverlappingBounds = (outer, inner) => {
 	return withinWidth && withinHeight
 }
 
-const addFixedWidthToElement = (deltaWidth) => {
+const addFixedWidthToElement = () => {
 	const elementDiv = getElementDiv(activeElement.value.id)
 	if (elementDiv) {
 		const rect = elementDiv.getBoundingClientRect()

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -11,6 +11,7 @@ import {
 } from './slide'
 import { useTextEditor } from '@/apps/slides/composables/useTextEditor'
 
+import { getElementDiv } from './elementRegistry'
 import { generateUniqueId, cloneObj } from '../utils/helpers'
 import { guessTextColorFromBackground } from '../utils/color'
 import { presentationId } from './presentation'
@@ -676,9 +677,7 @@ const resetFocus = () => {
 }
 
 const getElementPosition = (elementId) => {
-	const elementRect = document
-		.querySelector(`[data-index="${elementId}"]`)
-		.getBoundingClientRect()
+	const elementRect = getElementDiv(elementId).getBoundingClientRect()
 
 	const elementLeft = (elementRect.left - slideBounds.left) / slideBounds.scale
 	const elementTop = (elementRect.top - slideBounds.top) / slideBounds.scale
@@ -694,7 +693,7 @@ const getElementPosition = (elementId) => {
 }
 
 const getElementLayoutPosition = (element) => {
-	const elementDiv = document.querySelector(`[data-index="${element.id}"]`)
+	const elementDiv = getElementDiv(element.id)
 	if (!elementDiv) return getElementPosition(element.id)
 
 	return {
@@ -721,7 +720,7 @@ const isWithinOverlappingBounds = (outer, inner) => {
 }
 
 const addFixedWidthToElement = (deltaWidth) => {
-	const elementDiv = document.querySelector(`[data-index="${activeElement.value.id}"]`)
+	const elementDiv = getElementDiv(activeElement.value.id)
 	if (elementDiv) {
 		const rect = elementDiv.getBoundingClientRect()
 		activeElement.value.width = rect.width

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -724,7 +724,7 @@ const addFixedWidthToElement = (deltaWidth) => {
 	const elementDiv = getElementDiv(activeElement.value.id)
 	if (elementDiv) {
 		const rect = elementDiv.getBoundingClientRect()
-		activeElement.value.width = rect.width
+		activeElement.value.width = rect.width / slideBounds.scale
 		markDirty()
 	}
 }

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -749,6 +749,8 @@ const updateElementContent = (element) => {
 				slideId: currentSlide.value.clientId,
 				elementIds: [element.id],
 				commands: refCommands,
+				// runs while blurring away from the element, must not steal selection
+				skipJumpOnExecute: true,
 			}),
 		)
 	}

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -12,6 +12,7 @@ import {
 import { useTextEditor } from '@/apps/slides/composables/useTextEditor'
 
 import { getElementDiv } from './elementRegistry'
+import { markDirty } from './saving'
 import { generateUniqueId, cloneObj } from '../utils/helpers'
 import { guessTextColorFromBackground } from '../utils/color'
 import { presentationId } from './presentation'
@@ -724,6 +725,7 @@ const addFixedWidthToElement = (deltaWidth) => {
 	if (elementDiv) {
 		const rect = elementDiv.getBoundingClientRect()
 		activeElement.value.width = rect.width
+		markDirty()
 	}
 }
 
@@ -756,6 +758,8 @@ const updateElementContent = (element) => {
 
 	element.content = updatedHTML
 	editorOldText = currentText
+
+	markDirty()
 }
 
 const blurAndSaveContent = (element) => {

--- a/frontend/src/apps/slides/stores/elementRegistry.js
+++ b/frontend/src/apps/slides/stores/elementRegistry.js
@@ -1,0 +1,13 @@
+// non-reactive registry of editor-mode element DOM nodes keyed by element id
+// replaces document.querySelector('[data-index="..."]') lookups, which scan
+// the whole DOM and can collide with previews that render the same ids
+const elementDivs = new Map()
+
+const registerElementDiv = (id, el) => {
+	if (el) elementDivs.set(id, el)
+	else elementDivs.delete(id)
+}
+
+const getElementDiv = (id) => elementDivs.get(id) || null
+
+export { registerElementDiv, getElementDiv }

--- a/frontend/src/apps/slides/stores/historyMeta.js
+++ b/frontend/src/apps/slides/stores/historyMeta.js
@@ -94,6 +94,10 @@ const getSlideIndexForJump = (action, command, operation) => {
 }
 
 const handleJumpToSlide = (action, command, operation) => {
+	// passive commands (e.g. blur-save) must not navigate away from
+	// wherever the user has moved on to; undo/redo should still jump
+	if (operation === 'execute' && command.skipJumpOnExecute) return
+
 	const slideIdx = getSlideIndexForJump(action, command, operation)
 	const focus = command.key === 'removeSlide' && operation === 'undo' ? false : true
 
@@ -101,6 +105,8 @@ const handleJumpToSlide = (action, command, operation) => {
 }
 
 const handleJumpToElements = (action, command, operation) => {
+	if (operation === 'execute' && command.skipJumpOnExecute) return
+
 	const jumpToIds = command.jumpToElementIds
 	const focusOnId = command.focusElementId
 

--- a/frontend/src/apps/slides/stores/presentation.js
+++ b/frontend/src/apps/slides/stores/presentation.js
@@ -1,6 +1,5 @@
 import { ref, computed } from 'vue'
 import { createResource, call, createDocumentResource } from 'frappe-ui'
-import { isEqual } from 'lodash'
 
 import { router } from '@/apps/slides/router'
 import { slides } from './slide'
@@ -222,42 +221,6 @@ const getCompositePresentationResource = (name) => {
 	})
 }
 
-const hasSlideChanged = (originalState, slideState) => {
-	const keysToCompare = [
-		'background',
-		'transition',
-		'transitionDuration',
-		'fadeUnmatchedElements',
-	]
-
-	for (const key of keysToCompare) {
-		if (slideState[key] != originalState[key]) return true
-	}
-
-	if (slideState.clientId != originalState.clientId) {
-		return true
-	}
-
-	const currElements = parseElements(slideState.elements)
-	const origElements = parseElements(originalState.elements)
-
-	return !isEqual(currElements, origElements)
-}
-
-const hasStateChanged = (original, current) => {
-	if (original.length != current.length) return true
-
-	let hasChanged = false
-	for (let i = 0; i < current.length; i++) {
-		if (hasSlideChanged(original[i], current[i])) {
-			hasChanged = true
-			break
-		}
-	}
-
-	return hasChanged
-}
-
 const savePresentationDoc = async (updatedSlides) => {
 	const newSlides = updatedSlides.map((slide) => {
 		const { thumbnail, ...slideData } = slide
@@ -362,7 +325,6 @@ export {
 	presentationTheme,
 	inReadonlyMode,
 	updatePresentationTitle,
-	hasStateChanged,
 	savePresentationDoc,
 	initPresentationDoc,
 	deletePresentation,

--- a/frontend/src/apps/slides/stores/presentation.js
+++ b/frontend/src/apps/slides/stores/presentation.js
@@ -4,6 +4,7 @@ import { isEqual } from 'lodash'
 
 import { router } from '@/apps/slides/router'
 import { slides } from './slide'
+import { markClean } from './saving'
 import { normalizeZIndices } from '@/apps/slides/stores/element'
 import { v4 as uuid4 } from 'uuid'
 import { commandHistory } from './historyMeta'
@@ -156,6 +157,7 @@ const getPresentationResource = (name) => {
 			}
 			slides.value = JSON.parse(JSON.stringify(doc.slides || []))
 			isPublicPresentation.value = Boolean(doc.is_public)
+			markClean()
 		},
 	})
 }
@@ -185,6 +187,7 @@ const getPublicPresentationResource = (name) => {
 			slidesLength.value = doc.slides?.length || 0
 			slides.value = JSON.parse(JSON.stringify(doc.slides || []))
 			isPublicPresentation.value = Boolean(doc.is_public)
+			markClean()
 		},
 	})
 }
@@ -214,6 +217,7 @@ const getCompositePresentationResource = (name) => {
 			slidesLength.value = doc.slides?.length || 0
 			slides.value = JSON.parse(JSON.stringify(doc.slides || []))
 			isPublicPresentation.value = true
+			markClean()
 		},
 	})
 }
@@ -342,6 +346,7 @@ const resetEditorState = () => {
 	slidesLength.value = 0
 	isPublicPresentation.value = false
 	commandHistory.clearHistory()
+	markClean()
 }
 
 export {

--- a/frontend/src/apps/slides/stores/saving.js
+++ b/frontend/src/apps/slides/stores/saving.js
@@ -1,10 +1,5 @@
-import { ref, computed } from 'vue'
-import {
-	presentationDoc,
-	presentationId,
-	hasStateChanged,
-	savePresentationDoc,
-} from '@/apps/slides/stores/presentation'
+import { ref } from 'vue'
+import { presentationId, savePresentationDoc } from '@/apps/slides/stores/presentation'
 import { slides } from '@/apps/slides/stores/slide'
 import { cloneObj } from '@/apps/slides/utils/helpers'
 
@@ -86,15 +81,6 @@ const getPresentationFromLocalDB = async (id) => {
 	})
 }
 
-const isDirty = computed(() => {
-	if (!presentationDoc.value || !slides.value) return false
-
-	const original = JSON.parse(JSON.stringify(presentationDoc.value.slides || []))
-	const current = JSON.parse(JSON.stringify(slides.value || []))
-
-	return hasStateChanged(original, current)
-})
-
 // explicit dirty flag set by every mutation path
 const dirty = ref(false)
 
@@ -153,8 +139,8 @@ const saveCurrentState = async () => {
 			dirty: true,
 		})
 
-		// changes are persisted locally (and queued for sync) — matches the
-		// old isDirty semantics, which also went false after a local save
+		// changes are persisted locally (and queued for sync), so the editor
+		// state is no longer ahead of storage
 		markClean()
 
 		// if offline, do not attempt to sync to server
@@ -168,8 +154,8 @@ const saveCurrentState = async () => {
 }
 
 const saveChanges = async () => {
-	if (!isDirty.value) return
+	if (!dirty.value) return
 	await saveCurrentState()
 }
 
-export { saveCurrentState, saveChanges, isDirty, isSaving, dirty, markDirty, markClean }
+export { saveCurrentState, saveChanges, isSaving, dirty, markDirty, markClean }

--- a/frontend/src/apps/slides/stores/saving.js
+++ b/frontend/src/apps/slides/stores/saving.js
@@ -95,6 +95,17 @@ const isDirty = computed(() => {
 	return hasStateChanged(original, current)
 })
 
+// explicit dirty flag set by every mutation path
+const dirty = ref(false)
+
+const markDirty = () => {
+	dirty.value = true
+}
+
+const markClean = () => {
+	dirty.value = false
+}
+
 const isSaving = ref(false)
 
 const syncSnapshotToServer = async (snapshot) => {
@@ -142,6 +153,10 @@ const saveCurrentState = async () => {
 			dirty: true,
 		})
 
+		// changes are persisted locally (and queued for sync) — matches the
+		// old isDirty semantics, which also went false after a local save
+		markClean()
+
 		// if offline, do not attempt to sync to server
 		if (!navigator.onLine) return
 
@@ -157,4 +172,4 @@ const saveChanges = async () => {
 	await saveCurrentState()
 }
 
-export { saveCurrentState, saveChanges, isDirty, isSaving }
+export { saveCurrentState, saveChanges, isDirty, isSaving, dirty, markDirty, markClean }

--- a/frontend/src/apps/slides/stores/slide.js
+++ b/frontend/src/apps/slides/stores/slide.js
@@ -8,7 +8,7 @@ import {
 	presentationTheme,
 } from '@/apps/slides/stores/presentation'
 import { resetFocus } from '@/apps/slides/stores/element'
-import { saveChanges, isDirty } from '@/apps/slides/stores/saving'
+import { saveChanges, isDirty, markDirty } from '@/apps/slides/stores/saving'
 import { commandHistory } from '@/apps/slides/stores/historyMeta'
 import { generateUniqueId, cloneObj } from '@/apps/slides/utils/helpers'
 import { router } from '@/apps/slides/router'
@@ -140,6 +140,7 @@ const deleteSlide = (deleteActive) => {
 	if (totalLength == 1) {
 		slides.value[0].elements = []
 		focusedSlide.value = null
+		markDirty()
 		return
 	}
 
@@ -188,6 +189,8 @@ const replaceSlide = (layoutObj) => {
 	slides.value.forEach((slide, index) => {
 		slide.idx = index + 1
 	})
+
+	markDirty()
 }
 
 const handleInsertSlide = (index, layoutObj) => {

--- a/frontend/src/apps/slides/stores/slide.js
+++ b/frontend/src/apps/slides/stores/slide.js
@@ -8,7 +8,7 @@ import {
 	presentationTheme,
 } from '@/apps/slides/stores/presentation'
 import { resetFocus } from '@/apps/slides/stores/element'
-import { saveChanges, isDirty, markDirty } from '@/apps/slides/stores/saving'
+import { saveChanges, dirty, markDirty } from '@/apps/slides/stores/saving'
 import { commandHistory } from '@/apps/slides/stores/historyMeta'
 import { generateUniqueId, cloneObj } from '@/apps/slides/utils/helpers'
 import { router } from '@/apps/slides/router'
@@ -112,7 +112,7 @@ const changeSlide = async (index, focus = true) => {
 
 const resetAndSave = async () => {
 	await resetFocus()
-	if (!isDirty.value) {
+	if (!dirty.value) {
 		toast.info('No changes to save')
 		return
 	}

--- a/frontend/src/apps/slides/utils/constants.js
+++ b/frontend/src/apps/slides/utils/constants.js
@@ -11,4 +11,18 @@ const allowedImageFileTypes = [
 	'image/svg+xml',
 ]
 
-export { sectionClasses, sectionTitleClasses, fieldLabelClasses, allowedImageFileTypes }
+const minElementSizes = {
+	text: { width: 7, height: 7 },
+	shape: { width: 10, height: 16 },
+	image: { width: 20, height: 20 },
+	video: { width: 20, height: 20 },
+	default: { width: 10, height: 16 },
+}
+
+export {
+	sectionClasses,
+	sectionTitleClasses,
+	fieldLabelClasses,
+	allowedImageFileTypes,
+	minElementSizes,
+}

--- a/frontend/src/apps/slides/utils/constants.js
+++ b/frontend/src/apps/slides/utils/constants.js
@@ -11,18 +11,4 @@ const allowedImageFileTypes = [
 	'image/svg+xml',
 ]
 
-const minElementSizes = {
-	text: { width: 7, height: 7 },
-	shape: { width: 10, height: 16 },
-	image: { width: 20, height: 20 },
-	video: { width: 20, height: 20 },
-	default: { width: 10, height: 16 },
-}
-
-export {
-	sectionClasses,
-	sectionTitleClasses,
-	fieldLabelClasses,
-	allowedImageFileTypes,
-	minElementSizes,
-}
+export { sectionClasses, sectionTitleClasses, fieldLabelClasses, allowedImageFileTypes }

--- a/frontend/src/apps/slides/utils/resize.js
+++ b/frontend/src/apps/slides/utils/resize.js
@@ -40,6 +40,18 @@ const getBoxFromCenter = (center, width, height) => ({
 	top: center.y - height / 2,
 })
 
+// the axis-aligned bounding box of `box` once it is rotated about its centre
+export const getRotatedBoundingBox = (box, degrees) => {
+	const radians = (degrees * Math.PI) / 180
+	const cos = Math.abs(Math.cos(radians))
+	const sin = Math.abs(Math.sin(radians))
+
+	const width = box.width * cos + box.height * sin
+	const height = box.width * sin + box.height * cos
+
+	return getBoxFromCenter(getCenter(box), width, height)
+}
+
 // each handle keeps the opposite edge/corner fixed. these signs say where that
 // fixed point sits relative to the centre, along the element's own axes.
 // a 0 means that axis doesn't resize (a side handle).

--- a/frontend/src/apps/slides/utils/resize.js
+++ b/frontend/src/apps/slides/utils/resize.js
@@ -1,0 +1,161 @@
+const MIN_SIZE = {
+	text: { width: 7, height: 7 },
+	shape: { width: 10, height: 16 },
+	image: { width: 20, height: 20 },
+	video: { width: 20, height: 20 },
+	default: { width: 10, height: 16 },
+}
+
+export const getMinSizeForElement = (type) => MIN_SIZE[type] ?? MIN_SIZE.default
+
+export const isAspectLocked = (type) => type === 'image' || type === 'video'
+
+// 2d vector helpers, all working on { x, y } points
+const addVectors = (a, b) => ({ x: a.x + b.x, y: a.y + b.y })
+const subtractVectors = (a, b) => ({ x: a.x - b.x, y: a.y - b.y })
+const scaleVector = (v, factor) => ({ x: v.x * factor, y: v.y * factor })
+const getLength = (v) => Math.hypot(v.x, v.y)
+const getMidpoint = (a, b) => scaleVector(addVectors(a, b), 0.5)
+const getAngle = (v) => (Math.atan2(v.y, v.x) * 180) / Math.PI
+
+const getUnitVector = (v) => {
+	const length = getLength(v)
+	if (!length) return { x: 1, y: 0 }
+	return scaleVector(v, 1 / length)
+}
+
+const getRotatedVector = (v, degrees) => {
+	const radians = (degrees * Math.PI) / 180
+	const cos = Math.cos(radians)
+	const sin = Math.sin(radians)
+	return { x: v.x * cos - v.y * sin, y: v.x * sin + v.y * cos }
+}
+
+const getCenter = (box) => ({ x: box.left + box.width / 2, y: box.top + box.height / 2 })
+
+const getBoxFromCenter = (center, width, height) => ({
+	width,
+	height,
+	left: center.x - width / 2,
+	top: center.y - height / 2,
+})
+
+// each handle keeps the opposite edge/corner fixed. these signs say where that
+// fixed point sits relative to the centre, along the element's own axes.
+// a 0 means that axis doesn't resize (a side handle).
+const FIXED_SIGN = {
+	right: { x: -1, y: 0 },
+	left: { x: 1, y: 0 },
+	bottom: { x: 0, y: -1 },
+	top: { x: 0, y: 1 },
+	'bottom-right': { x: -1, y: -1 },
+	'bottom-left': { x: 1, y: -1 },
+	'top-right': { x: -1, y: 1 },
+	'top-left': { x: 1, y: 1 },
+}
+
+// new length of one side. the grabbed edge moves by `movementAlongAxis`; the
+// opposite edge stays put. a fixedSign of 0 means this side doesn't resize.
+const getResizedSide = (startLength, fixedSign, movementAlongAxis, minLength) => {
+	if (!fixedSign) return startLength
+
+	const resized = startLength - fixedSign * movementAlongAxis
+	return Math.max(minLength, resized)
+}
+
+// how far the centre moves toward the grabbed edge, along the element's local axes
+const getCenterShift = (fixedSign, startBox, width, height) => ({
+	x: (-fixedSign.x * (width - startBox.width)) / 2,
+	y: (-fixedSign.y * (height - startBox.height)) / 2,
+})
+
+export const getResizedBox = (start, handle, cursorMovement) => {
+	const fixedSign = FIXED_SIGN[handle]
+	if (!fixedSign) return null
+
+	const minSize = getMinSizeForElement(start.type)
+	// rotate the cursor onto the element's local axes
+	const movementInLocalAxes = getRotatedVector(cursorMovement, -start.rotation)
+
+	// resize as if unrotated, keeping the opposite edge fixed
+	const width = getResizedSide(start.width, fixedSign.x, movementInLocalAxes.x, minSize.width)
+	let height = getResizedSide(start.height, fixedSign.y, movementInLocalAxes.y, minSize.height)
+
+	const isCornerHandle = fixedSign.x !== 0 && fixedSign.y !== 0
+	if (isAspectLocked(start.type) && isCornerHandle) {
+		height = width * (start.height / start.width)
+	}
+
+	// then move the centre so the fixed point stays put
+	const centerShiftInLocalAxes = getCenterShift(fixedSign, start, width, height)
+	const centerShiftInScreenAxes = getRotatedVector(centerShiftInLocalAxes, start.rotation)
+
+	const newCenter = addVectors(getCenter(start), centerShiftInScreenAxes)
+
+	return getBoxFromCenter(newCenter, width, height)
+}
+
+export const getResizedTextBox = (start, handle, cursorMovement) => {
+	const minWidth = getMinSizeForElement(start.type).width
+	const { left, top, height } = start
+
+	// dragging the right edge: the left edge stays put, width grows with the cursor
+	if (handle === 'text-right') {
+		const width = Math.max(minWidth, start.width + cursorMovement.x)
+		return { left, top, width, height }
+	}
+
+	// dragging the left edge: the right edge stays put, so the left edge moves in
+	const width = Math.max(minWidth, start.width - cursorMovement.x)
+	const rightEdge = left + start.width
+	return { left: rightEdge - width, top, width, height }
+}
+
+const getLineEndpoints = (box) => {
+	const center = getCenter(box)
+	// line's own rotation determines which way is "along" the line
+	const centerToRightEnd = getRotatedVector({ x: box.width / 2, y: 0 }, box.rotation)
+
+	return {
+		leftEnd: subtractVectors(center, centerToRightEnd),
+		rightEnd: addVectors(center, centerToRightEnd),
+	}
+}
+
+// the grabbed end can't come closer than minLength to the fixed end
+const getClampedEnd = (fixedEnd, cursorTarget, minLength) => {
+	const span = subtractVectors(cursorTarget, fixedEnd)
+	if (getLength(span) >= minLength) return cursorTarget
+
+	// too short: keep the drag direction but push the end out to the minimum
+	const direction = getUnitVector(span)
+	return addVectors(fixedEnd, scaleVector(direction, minLength))
+}
+
+export const getResizedLine = (start, handle, cursorMovement) => {
+	const minLength = getMinSizeForElement(start.type).width
+
+	// for line resize + rotate happens through endpoints
+	const { leftEnd, rightEnd } = getLineEndpoints(start)
+
+	const grabbingRightEnd = handle === 'line-right'
+	const fixedEnd = grabbingRightEnd ? leftEnd : rightEnd
+	const grabbedEnd = grabbingRightEnd ? rightEnd : leftEnd
+
+	// add cursorMovement to the grabbed end and get new position of that endpoint
+	const cursorTarget = addVectors(grabbedEnd, cursorMovement)
+	const newEnd = getClampedEnd(fixedEnd, cursorTarget, minLength)
+
+	// where the two ends sit now: the one we didn't grab stayed put
+	const newLeftEnd = grabbingRightEnd ? fixedEnd : newEnd
+	const newRightEnd = grabbingRightEnd ? newEnd : fixedEnd
+
+	// the box spans between them: its length, centre, and angle
+	const lineVector = subtractVectors(newRightEnd, newLeftEnd)
+	const center = getMidpoint(newLeftEnd, newRightEnd)
+
+	return {
+		...getBoxFromCenter(center, getLength(lineVector), start.height),
+		rotation: getAngle(lineVector),
+	}
+}


### PR DESCRIPTION
### Latency
**Gestures start on movement, not timers**
  **Before:** a `mousedown` is ambiguous (click vs drag vs selection box), so we waited on timers to guess: a ~200ms long-press for selection, a click delay for drag. That wait was 100–200ms of dead time before anything moved.
  **Now:** we disambiguate by distance, not time. Move past a small threshold and it's a drag / selection box, release before it and it's a click. Gestures start instantly, and click-vs-drag is more accurate.

### Smoothness
- **Movement batched per frame + applied via `transform`**
  **Before:** every mouse move wrote `left/top/width/height`, forcing the browser to re-layout each time.
  **Now:** one update per animation frame, moved on the compositor, so there are no per-move reflows and it stays smooth on big slides.
- **DOM lookups go through a registry**
  **Before:** hit-testing / snapping ran `querySelector('[data-index]')` every frame, scanning the whole DOM and colliding with preview/thumbnail copies.
  **Now:** a direct `id → node` map, so no scans and no collisions.
- **Snap targets measured once per gesture**
  **Before:** neighbour positions were read from layout on every move.
  **Now:** snapshotted at gesture start and reused until it ends.

### Resize / rotate correctness

- **Correct at any zoom**
  **Before:** resize math mixed screen and slide units, so sizes were wrong at zoom ≠ 1.
  **Now:** all math in slide units; accurate at any zoom.
- **Min-size no longer slides the element**
  **Before:** hitting the minimum size pushed the element sideways instead of stopping.
  **Now:** it just stops resizing.
- **Shapes resize freely, media keeps aspect**
  **Before:** shape corners forced a ratio they shouldn't.
  **Now:** shape corners are free; images/videos stay locked to their ratio.
- **Rotated elements resize in their own frame**
  **Before:** resize assumed no rotation, so a tilted element resized in the wrong direction.
  **Now:** the opposite edge/corner stays put and the dragged edge follows the cursor, even tilted.
- **Lines resize + rotate by dragging an endpoint**
  **Before:** lines used the generic box resize plus a separate rotate handle.
  **Now:** one gesture on an endpoint resizes and rotates; the other end stays fixed.
- **Snapping no longer drifts**
  **Before:** resistance-based snapping ate movement, so the handle separated from the cursor past a guide.
  **Now:** position-based snapping with a release window, so cursor and handle stay together and the guide you see is the line you snap to.

### Marquee selection

- **Own overlay, separate from the selection box**
  **Before:** the marquee rect and the persistent selection box shared one piece of state, forcing mode-juggling.
  **Now:** split into their own components, so there's no mode ambiguity.
- **Rotated elements hit-tested by their real shape**
  **Before:** the marquee tested an element's bounding box (mostly empty space for a tilted element), so it over-selected them.
  **Now:** a rotated-rectangle test, so you only catch what you actually drew over.

### Snapping for rotated elements (new)

**Rotated elements now snap**
  **Before:** rotated elements were skipped entirely (no guides, no snap) because the snap engine only understood upright boxes.
  **Now:** dragging a rotated element snaps its bounding box, and others snap to a rotated element's bounding box too. (Resizing a rotated element still doesn't snap; deferred because it's a harder local-frame vs. bounding-box problem.)

### Saving
- **Explicit "dirty" flag**
  **Before:** "is there anything to save?" was answered by deep-serializing and comparing the whole deck on a 500ms timer.
  **Now:** a simple flag flipped by each edit, so there's no repeated whole-deck diffing.
- **Blur-saving text no longer steals selection**
  **Before:** committing a text edit on blur yanked selection back to that element.
  **Now:** the save is passive; your selection stays put (undo / redo still jump as expected).

### Removed / cleaned up

- **Double-click-to-add-text removed**
  **Before:** double-clicking empty slide space dropped a text box, easy to trigger by accident.
  **Now:** press `t` to add text.
- **Restored the active-handle highlight + live size readout**
  These were commented out; resize now shows the enlarged active handle and a live size readout again.
- **Dead code gone**
  Old deep-compare helpers plus an unused import, an unused parameter, and stale event plumbing; plus null-safety so a missing DOM node returns safe bounds instead of throwing.

### Perf
Chrome DevTools Performance traces, 4× CPU throttle, same 20-element deck, one gesture per recording. Figures are ms of main-thread work per second of gesture (interval-merged to avoid double-counting nested events).

- **resize:** scripting 138 → 72 ms/s (−48%), painting 24 → 13 ms/s (−46%), layout 16 → 10 ms/s (−37%). Biggest across-the-board win.
- **rotate:** scripting 52 → 23 ms/s (−56%). Re-render scoping (only the rotating element re-renders).
- **multidrag:** painting 31 → 23 ms/s (−26%), scripting 123 → 114 ms/s (−7%). Compositor-only movement path.
- **drag:** scripting 105 → 106 ms/s (flat). Already near frame-rate under throttle; structural wins (no reflows, compositor-only) show on heavier decks and low-end hardware.
- **marquee:** all categories flat. The marquee wins are correctness and latency (SAT hit-test for rotated elements, no dropped frame), not main-thread budget.
