### PR TITLE
fix: remove duplicate proxy that broke file uploads in dev

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -67,16 +67,6 @@ export default defineConfig(({ mode }) => ({
   server: {
     port: 8085,
     allowedHosts: [defaultSite, 'suite.localhost'],
-    proxy: {
-      // Fallback explicit proxy in case frappeProxy autodetection misses the
-      // port; forward the Frappe API surface to the bench webserver port.
-      '^/(app|api|assets|files|private|method|website_script\\.js)': {
-        target: frappeBackendUrl,
-        ws: true,
-        changeOrigin: true,
-        router: () => frappeBackendUrl,
-      },
-    },
     fs: {
       // Meet imports socketio_port from sites/common_site_config.json (outside
       // the frontend root); allow the bench + frappe-ui source paths.


### PR DESCRIPTION
The `server.proxy` block in `vite.config.ts` overlapped with the proxy rule already set up by the `frappeProxy` plugin from frappe-ui. Both rules matched `/api/*` routes but with different settings: the plugin's rule had no `changeOrigin`, the user rule did, and they used different `router` functions.

This caused multipart POST requests (file uploads) to be routed inconsistently. Removing the redundant block lets `frappeProxy` handle all API routing cleanly, which is the intended setup.
