### PR TITLE
fix: polygon offsets and edge resizer options

### DIFF
--- a/frontend/src/apps/slides/components/Resizer.vue
+++ b/frontend/src/apps/slides/components/Resizer.vue
@@ -69,7 +69,7 @@ const resizeHandles = computed(() => {
 	} else if (props.elementType === 'text') {
 		directions = ['text-left', 'text-right']
 	} else {
-		directions = ['top-left', 'top-right', 'bottom-left', 'bottom-right']
+		directions = ['left', 'right', 'top', 'bottom', 'top-left', 'top-right', 'bottom-left', 'bottom-right']
 	}
 
 	return directions.map((direction) => ({

--- a/frontend/src/apps/slides/components/ShapeElement.vue
+++ b/frontend/src/apps/slides/components/ShapeElement.vue
@@ -161,8 +161,10 @@ const polygonPoints = computed(() => {
 	const sides = POLYGON_SIDES[element.value?.shapeType]
 	if (!sides) return ''
 
-	const width = (element.value?.width ?? 0) + (props.elementOffset.width ?? 0)
-	const height = (element.value?.height ?? 0) + (props.elementOffset.height ?? 0)
+	const offsetWidth = isActive.value ? (props.elementOffset.width ?? 0) : 0
+	const offsetHeight = isActive.value ? (props.elementOffset.height ?? 0) : 0
+	const width = (element.value?.width ?? 0) + offsetWidth
+	const height = (element.value?.height ?? 0) + offsetHeight
 	const strokeInset = (element.value?.strokeWidth ?? 0) / 2
 
 	// Unit-circle vertices evenly spaced, starting from the top (-π/2)
@@ -186,6 +188,7 @@ const polygonPoints = computed(() => {
 
 const canHaveText = computed(() => !isLine.value)
 const hasText = computed(() => !!element.value?.content)
+const isActive = computed(() => activeElementIds.value.includes(element.value?.id))
 const isEditable = computed(() => focusElementId.value === element.value?.id)
 
 const TEXT_OVERLAY_BASE = {

--- a/frontend/src/apps/slides/components/ShapeProperties.vue
+++ b/frontend/src/apps/slides/components/ShapeProperties.vue
@@ -37,7 +37,7 @@
 						:modelValue="activeElement.strokeWidth"
 						@update:modelValue="(val) => setProperty('strokeWidth', val)"
 						suffix="px"
-						:rangeStart="0.5"
+						:rangeStart="activeElement.shapeType === 'line' ? 0.5 : 0"
 						:rangeEnd="50"
 						:rangeStep="0.5"
 					/>


### PR DESCRIPTION
Fix polygon edge handles, elementOffset bleed on non-active shapes, and allow 0 stroke width for non-line shapes.