### PR TITLE
feat(slides): add service worker dropped in monorepo port

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Commits listed here are skipped by `git blame` (large whitespace/formatting-only
+# changes that would otherwise obscure authorship). Enable locally with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# style(slides): convert service-worker.js to tab indentation
+6ed2aa9d8881c18ce4d581e20ca18eae8ad512ed

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,8 @@ node_modules
 # Built www entrypoints (one per app); sheets.html is a hand-written template
 /suite/**/www/*.html
 !/suite/sheets/www/sheets.html
-/suite/slides/www/service-worker.js
+# Slides service worker — emitted to the unified www root by the vite build
+/suite/www/service-worker.js
 
 # Migrated Node sidecar build output (sfu-server / collab-server also carry own .gitignore)
 /suite/meet/sfu-server/dist/

--- a/HISTORY-GRAFT.md
+++ b/HISTORY-GRAFT.md
@@ -1,11 +1,28 @@
 # Git history preservation (graft procedure)
 
-> **STATUS — DONE (2026-06-16).** All 7 apps' original per-file authorship now shows in
-> GitHub's **History *and* Blame UI** on `develop`. This was achieved with the
+> **STATUS — DONE (regrafted 2026-06-17).** All 7 apps' original per-file authorship now
+> shows in GitHub's **History *and* Blame UI** on `develop`. This was achieved with the
 > **content-bearing append** method documented immediately below. The `-s ours` procedure
 > described later in this file is **SUPERSEDED** (it linked ancestry but left blame
 > collapsed on the port commit, because `-s ours` never introduces the original file
 > content into the mainline tree) — kept only as historical context.
+
+## Live commit SHAs (the regraft that is actually in `develop`)
+
+> ⚠️ The first append run (tip `4e5219a86`, base `3f9e986cc`) described in the diagram
+> below was **superseded by a regraft on 2026-06-17** and is **NOT in the current
+> `develop` ancestry** (`git merge-base --is-ancestor 4e5219a86 develop` fails). The
+> method/topology is identical; only the SHAs changed. When verifying blame, use the
+> **live** port commit below — grepping the old `4e5219a86` returns misleading zeros.
+
+The structure in `develop` today is `T' → G' → M' → P'`:
+
+| Role | SHA | Subject |
+|------|-----|---------|
+| `T'` base | `64d776f6fa` | mainline tip the regraft built on |
+| `G'` remove | `7475c253e0` | `regraft: remove app files (re-added with original authorship below)` |
+| `M'` union | `31c428a021` | `regraft: graft original per-app authorship (content-bearing)` — **8-parent** (`G'` + the 7 filter-repo'd app histories) |
+| `P'` port | `494c3ce9fb` | `Phase 5/6 port: 7 apps into suite (tree byte-identical to develop)` — single parent `M'` |
 
 ## The method actually used: content-bearing fast-forward append
 

--- a/frontend/src/apps/slides/SlidesShell.vue
+++ b/frontend/src/apps/slides/SlidesShell.vue
@@ -31,10 +31,18 @@ const handleOnline = () => {
   })
 }
 
+const registerServiceWorker = () => {
+  if (!('serviceWorker' in navigator) || !import.meta.env.PROD) return
+  navigator.serviceWorker.register('/service-worker.js').catch((err) => {
+    console.warn('Slides Service Worker registration failed:', err)
+  })
+}
+
 onMounted(() => {
   isOnline.value = navigator?.onLine
   window.addEventListener('online', handleOnline)
   window.addEventListener('offline', handleOffline)
+  registerServiceWorker()
 })
 
 onUnmounted(() => {

--- a/frontend/src/apps/slides/composables/useThumbnailCapture.js
+++ b/frontend/src/apps/slides/composables/useThumbnailCapture.js
@@ -7,6 +7,7 @@ import { slides } from '@/apps/slides/stores/slide'
 import { focusElementId } from '@/apps/slides/stores/element'
 import { dirty, isSaving } from '@/apps/slides/stores/saving'
 import { captureDOM } from '@/apps/slides/utils/domToWebp'
+import { getAttachmentUrl } from '@/apps/slides/utils/mediaUploads'
 
 const DEBOUNCE_MS = 5000
 
@@ -87,7 +88,9 @@ export const useThumbnailCapture = (thumbnailCapture, hasOngoingInteraction) => 
 	const evictThumbnailCache = async (url) => {
 		if (!('caches' in window) || !url) return
 		const cache = await caches.open('slides-media')
-		await cache.delete(url)
+		// delete the exact URL the SW cached under — getAttachmentUrl() adds the
+		// slides_media marker / proxy path, so the raw url alone wouldn't match
+		await cache.delete(getAttachmentUrl(url))
 	}
 
 	const apply = async (thumbnail) => {

--- a/frontend/src/apps/slides/service-worker.js
+++ b/frontend/src/apps/slides/service-worker.js
@@ -1,6 +1,8 @@
 const MEDIA_CACHE_NAME = 'slides-media'
 const API_CACHE_NAME = 'slides-api'
 
+const CACHE_NAMES = { media: MEDIA_CACHE_NAME, api: API_CACHE_NAME }
+
 const MAX_AGE = 24 * 60 * 60 * 1000 // 1 day
 
 self.addEventListener('install', () => {
@@ -38,7 +40,7 @@ const cleanupOldMediaCache = async () => {
 }
 
 const handleSWActivate = async () => {
-    cleanupOldMediaCache()
+    await cleanupOldMediaCache()
     // this takes control of all client pages that are already open
     await self.clients.claim()
 }
@@ -59,21 +61,14 @@ const getModifiedResponse = (response) => {
     })
 }
 
+// These matchers mirror the URL contract owned by utils/mediaUploads.js: the
+// `slides_media` marker (SLIDES_MEDIA_PARAM) on owner /private/files/ requests
+// and the suite.slides.* proxy path. A service worker can't import app modules,
+// so keep these in sync with mediaUploads.js if either changes.
 const isMedia = (url) =>
     url.pathname.startsWith('/api/method/suite.slides.api.file.get_media_file') ||
     (url.pathname.startsWith('/private/files/') && url.searchParams.has('slides_media'))
 const isAPI = (url) => url.pathname.startsWith('/api/method/suite.slides.')
-
-const getCacheObject = async (type) => {
-    switch (type) {
-        case 'media':
-            return await caches.open(MEDIA_CACHE_NAME)
-        case 'api':
-            return await caches.open(API_CACHE_NAME)
-        default:
-            return null
-    }
-}
 
 const addCacheEntry = async (type, cache, request, response) => {
     if (type === 'media') {
@@ -95,24 +90,27 @@ const fetchAndCache = async (request, type, cache) => {
     return response
 }
 
-const getResponseForRequest = async (request, type) => {
-    const cache = await getCacheObject(type)
-
-    if (type === 'api') {
-        // network-first: keep API data fresh, fall back to cache only offline
-        try {
-            await fetchAndCache(request, type, cache)
-        } catch {
-            const cached = await cache.match(request)
-            if (cached) return cached
-            throw new Error('No cached response available')
-        }
+// network-first: serve the live response (preserving its real headers) and fall
+// back to cache only when the network is unavailable
+const networkFirst = async (request, cache) => {
+    try {
+        return await fetchAndCache(request, 'api', cache)
+    } catch {
+        const cached = await cache.match(request)
+        if (cached) return cached
+        throw new Error('No cached response available')
     }
+}
 
-    // media (and the revalidated api response): cache-first
+const cacheFirst = async (request, type, cache) => {
     const cached = await cache.match(request)
     if (cached) return cached
-    return await fetchAndCache(request, type, cache)
+    return fetchAndCache(request, type, cache)
+}
+
+const getResponseForRequest = async (request, type) => {
+    const cache = await caches.open(CACHE_NAMES[type])
+    return type === 'api' ? networkFirst(request, cache) : cacheFirst(request, type, cache)
 }
 
 const getRequestType = (url) => {

--- a/frontend/src/apps/slides/service-worker.js
+++ b/frontend/src/apps/slides/service-worker.js
@@ -1,6 +1,4 @@
 const MEDIA_CACHE_NAME = 'slides-media'
-const version = '__BUILD_TIMESTAMP__'
-const ASSET_CACHE_NAME = `slides-assets-v${version}`
 const API_CACHE_NAME = 'slides-api'
 
 const MAX_AGE = 24 * 60 * 60 * 1000 // 1 day
@@ -39,24 +37,8 @@ const cleanupOldMediaCache = async () => {
     )
 }
 
-const cleanupOldAssetCache = async () => {
-    const cacheNames = await caches.keys()
-    await Promise.all(
-        cacheNames.map((cacheName) => {
-            if (cacheName.startsWith('slides-assets') && cacheName !== ASSET_CACHE_NAME) {
-                return caches.delete(cacheName)
-            }
-        }),
-    )
-}
-
-const cleanupOldCaches = () => {
-    cleanupOldAssetCache()
-    cleanupOldMediaCache()
-}
-
 const handleSWActivate = async () => {
-    cleanupOldCaches()
+    cleanupOldMediaCache()
     // this takes control of all client pages that are already open
     await self.clients.claim()
 }
@@ -77,21 +59,18 @@ const getModifiedResponse = (response) => {
     })
 }
 
-const isMedia = (url) => {
-    return (
-        url.pathname.startsWith('/private/files/') ||
-        url.pathname.startsWith('/api/method/slides.api.file.get_media_file')
-    )
-}
-const isAsset = (url) => url.pathname.startsWith('/assets/') || url.pathname.startsWith('/slides/')
-const isAPI = (url) =>
-    url.pathname.startsWith('/api/method/frappe.client.') ||
-    url.pathname.startsWith('/api/method/slides.slides.')
+// Slides-only matchers. `/assets/` (shared SPA bundle) is never matched.
+// Media is either the slides-namespaced proxy (non-owner/public viewers) or a
+// /private/files/ request tagged with the `slides_media` marker that
+// getAttachmentUrl() adds for the owner — so we cache slides' own files without
+// ever touching another app's /private/files/ traffic (Drive, Mail, ...).
+const isMedia = (url) =>
+    url.pathname.startsWith('/api/method/suite.slides.api.file.get_media_file') ||
+    (url.pathname.startsWith('/private/files/') && url.searchParams.has('slides_media'))
+const isAPI = (url) => url.pathname.startsWith('/api/method/suite.slides.')
 
 const getCacheObject = async (type) => {
     switch (type) {
-        case 'asset':
-            return await caches.open(ASSET_CACHE_NAME)
         case 'media':
             return await caches.open(MEDIA_CACHE_NAME)
         case 'api':
@@ -125,6 +104,7 @@ const getResponseForRequest = async (request, type) => {
     const cache = await getCacheObject(type)
 
     if (type === 'api') {
+        // network-first: keep API data fresh, fall back to cache only offline
         try {
             await fetchAndCache(request, type, cache)
         } catch {
@@ -134,6 +114,7 @@ const getResponseForRequest = async (request, type) => {
         }
     }
 
+    // media (and the revalidated api response): cache-first
     const cached = await cache.match(request)
     if (cached) return cached
     return await fetchAndCache(request, type, cache)
@@ -141,7 +122,6 @@ const getResponseForRequest = async (request, type) => {
 
 const getRequestType = (url) => {
     if (isMedia(url)) return 'media'
-    if (isAsset(url)) return 'asset'
     if (isAPI(url)) return 'api'
     return 'other'
 }
@@ -153,7 +133,9 @@ const handleSWFetch = async (event) => {
     if (request.method !== 'GET' || url.origin !== self.location.origin) return
 
     const requestType = getRequestType(url)
-    const isAffectedByCache = ['media', 'asset', 'api'].includes(requestType)
+    const isAffectedByCache = ['media', 'api'].includes(requestType)
+    // Not a slides request -> do nothing, let the browser fetch it normally.
+    // This is what keeps the other 6 apps completely unaffected.
     if (!isAffectedByCache) return
 
     const response = getResponseForRequest(request, requestType)

--- a/frontend/src/apps/slides/service-worker.js
+++ b/frontend/src/apps/slides/service-worker.js
@@ -59,11 +59,6 @@ const getModifiedResponse = (response) => {
     })
 }
 
-// Slides-only matchers. `/assets/` (shared SPA bundle) is never matched.
-// Media is either the slides-namespaced proxy (non-owner/public viewers) or a
-// /private/files/ request tagged with the `slides_media` marker that
-// getAttachmentUrl() adds for the owner — so we cache slides' own files without
-// ever touching another app's /private/files/ traffic (Drive, Mail, ...).
 const isMedia = (url) =>
     url.pathname.startsWith('/api/method/suite.slides.api.file.get_media_file') ||
     (url.pathname.startsWith('/private/files/') && url.searchParams.has('slides_media'))
@@ -134,8 +129,6 @@ const handleSWFetch = async (event) => {
 
     const requestType = getRequestType(url)
     const isAffectedByCache = ['media', 'api'].includes(requestType)
-    // Not a slides request -> do nothing, let the browser fetch it normally.
-    // This is what keeps the other 6 apps completely unaffected.
     if (!isAffectedByCache) return
 
     const response = getResponseForRequest(request, requestType)

--- a/frontend/src/apps/slides/service-worker.js
+++ b/frontend/src/apps/slides/service-worker.js
@@ -85,7 +85,11 @@ const addCacheEntry = async (type, cache, request, response) => {
 const fetchAndCache = async (request, type, cache) => {
 	const response = await fetch(request)
 	if (response.ok && response.status === 200) {
-		await addCacheEntry(type, cache, request, response)
+		try {
+			await addCacheEntry(type, cache, request, response)
+		} catch (err) {
+			console.warn('Slides SW cache write failed:', err)
+		}
 	}
 	return response
 }

--- a/frontend/src/apps/slides/service-worker.js
+++ b/frontend/src/apps/slides/service-worker.js
@@ -6,59 +6,59 @@ const CACHE_NAMES = { media: MEDIA_CACHE_NAME, api: API_CACHE_NAME }
 const MAX_AGE = 24 * 60 * 60 * 1000 // 1 day
 
 self.addEventListener('install', () => {
-    self.skipWaiting()
+	self.skipWaiting()
 })
 
 const cleanupOldCacheEntry = async (cache, request, response) => {
-    const now = Date.now()
+	const now = Date.now()
 
-    const cachedTimeHeader = response.headers.get('x-cached-time')
-    if (!cachedTimeHeader) return
+	const cachedTimeHeader = response.headers.get('x-cached-time')
+	if (!cachedTimeHeader) return
 
-    const cachedTime = parseInt(cachedTimeHeader, 10)
-    if (isNaN(cachedTime)) return
+	const cachedTime = parseInt(cachedTimeHeader, 10)
+	if (isNaN(cachedTime)) return
 
-    const age = now - cachedTime
+	const age = now - cachedTime
 
-    if (age > MAX_AGE) {
-        await cache.delete(request)
-    }
+	if (age > MAX_AGE) {
+		await cache.delete(request)
+	}
 }
 
 const cleanupOldMediaCache = async () => {
-    const cache = await caches.open(MEDIA_CACHE_NAME)
-    const keys = await cache.keys()
+	const cache = await caches.open(MEDIA_CACHE_NAME)
+	const keys = await cache.keys()
 
-    await Promise.all(
-        keys.map(async (request) => {
-            const response = await cache.match(request)
-            if (!response) return
+	await Promise.all(
+		keys.map(async (request) => {
+			const response = await cache.match(request)
+			if (!response) return
 
-            return cleanupOldCacheEntry(cache, request, response)
-        }),
-    )
+			return cleanupOldCacheEntry(cache, request, response)
+		}),
+	)
 }
 
 const handleSWActivate = async () => {
-    await cleanupOldMediaCache()
-    // this takes control of all client pages that are already open
-    await self.clients.claim()
+	await cleanupOldMediaCache()
+	// this takes control of all client pages that are already open
+	await self.clients.claim()
 }
 
 self.addEventListener('activate', (event) => {
-    event.waitUntil(handleSWActivate())
+	event.waitUntil(handleSWActivate())
 })
 
 const getModifiedResponse = (response) => {
-    const responseToCache = response.clone()
-    const headers = new Headers(responseToCache.headers)
-    headers.set('x-cached-time', Date.now().toString())
+	const responseToCache = response.clone()
+	const headers = new Headers(responseToCache.headers)
+	headers.set('x-cached-time', Date.now().toString())
 
-    return new Response(responseToCache.body, {
-        status: responseToCache.status,
-        statusText: responseToCache.statusText,
-        headers: headers,
-    })
+	return new Response(responseToCache.body, {
+		status: responseToCache.status,
+		statusText: responseToCache.statusText,
+		headers: headers,
+	})
 }
 
 // These matchers mirror the URL contract owned by utils/mediaUploads.js: the
@@ -66,73 +66,73 @@ const getModifiedResponse = (response) => {
 // and the suite.slides.* proxy path. A service worker can't import app modules,
 // so keep these in sync with mediaUploads.js if either changes.
 const isMedia = (url) =>
-    url.pathname.startsWith('/api/method/suite.slides.api.file.get_media_file') ||
-    (url.pathname.startsWith('/private/files/') && url.searchParams.has('slides_media'))
+	url.pathname.startsWith('/api/method/suite.slides.api.file.get_media_file') ||
+	(url.pathname.startsWith('/private/files/') && url.searchParams.has('slides_media'))
 const isAPI = (url) => url.pathname.startsWith('/api/method/suite.slides.')
 
 const addCacheEntry = async (type, cache, request, response) => {
-    if (type === 'media') {
-        const contentType = response.headers.get('Content-Type') || ''
-        const validContentTypes = ['image/', 'video/']
-        if (!validContentTypes.some((ct) => contentType.startsWith(ct))) return
-    }
+	if (type === 'media') {
+		const contentType = response.headers.get('Content-Type') || ''
+		const validContentTypes = ['image/', 'video/']
+		if (!validContentTypes.some((ct) => contentType.startsWith(ct))) return
+	}
 
-    // clone response and add cache timestamp header
-    const modifiedResponse = getModifiedResponse(response)
-    await cache.put(request, modifiedResponse)
+	// clone response and add cache timestamp header
+	const modifiedResponse = getModifiedResponse(response)
+	await cache.put(request, modifiedResponse)
 }
 
 const fetchAndCache = async (request, type, cache) => {
-    const response = await fetch(request)
-    if (response.ok && response.status === 200) {
-        await addCacheEntry(type, cache, request, response)
-    }
-    return response
+	const response = await fetch(request)
+	if (response.ok && response.status === 200) {
+		await addCacheEntry(type, cache, request, response)
+	}
+	return response
 }
 
 // network-first: serve the live response (preserving its real headers) and fall
 // back to cache only when the network is unavailable
 const networkFirst = async (request, cache) => {
-    try {
-        return await fetchAndCache(request, 'api', cache)
-    } catch {
-        const cached = await cache.match(request)
-        if (cached) return cached
-        throw new Error('No cached response available')
-    }
+	try {
+		return await fetchAndCache(request, 'api', cache)
+	} catch {
+		const cached = await cache.match(request)
+		if (cached) return cached
+		throw new Error('No cached response available')
+	}
 }
 
 const cacheFirst = async (request, type, cache) => {
-    const cached = await cache.match(request)
-    if (cached) return cached
-    return fetchAndCache(request, type, cache)
+	const cached = await cache.match(request)
+	if (cached) return cached
+	return fetchAndCache(request, type, cache)
 }
 
 const getResponseForRequest = async (request, type) => {
-    const cache = await caches.open(CACHE_NAMES[type])
-    return type === 'api' ? networkFirst(request, cache) : cacheFirst(request, type, cache)
+	const cache = await caches.open(CACHE_NAMES[type])
+	return type === 'api' ? networkFirst(request, cache) : cacheFirst(request, type, cache)
 }
 
 const getRequestType = (url) => {
-    if (isMedia(url)) return 'media'
-    if (isAPI(url)) return 'api'
-    return 'other'
+	if (isMedia(url)) return 'media'
+	if (isAPI(url)) return 'api'
+	return 'other'
 }
 
 const handleSWFetch = async (event) => {
-    const request = event.request
-    const url = new URL(request.url)
+	const request = event.request
+	const url = new URL(request.url)
 
-    if (request.method !== 'GET' || url.origin !== self.location.origin) return
+	if (request.method !== 'GET' || url.origin !== self.location.origin) return
 
-    const requestType = getRequestType(url)
-    const isAffectedByCache = ['media', 'api'].includes(requestType)
-    if (!isAffectedByCache) return
+	const requestType = getRequestType(url)
+	const isAffectedByCache = ['media', 'api'].includes(requestType)
+	if (!isAffectedByCache) return
 
-    const response = getResponseForRequest(request, requestType)
-    event.respondWith(response)
+	const response = getResponseForRequest(request, requestType)
+	event.respondWith(response)
 }
 
 self.addEventListener('fetch', (event) => {
-    handleSWFetch(event)
+	handleSWFetch(event)
 })

--- a/frontend/src/apps/slides/utils/mediaUploads.js
+++ b/frontend/src/apps/slides/utils/mediaUploads.js
@@ -7,6 +7,8 @@ import { session } from '@/apps/slides/stores/session'
 
 const fileUploadHandler = new FileUploadHandler()
 
+export const SLIDES_MEDIA_PARAM = 'slides_media=1'
+
 const performPostUploadActions = async (fileDoc, fileType, targetElement) => {
 	if (fileType === 'image') {
 		fileDoc = await getWebPDoc(fileDoc)
@@ -108,7 +110,10 @@ export const getAttachmentUrl = (fileUrl) => {
 	if (fileUrl.startsWith('/private')) {
 		// if owner is trying to access just send static path
 		if (presentationDoc.value?.owner === session.user || session.user === 'Administrator') {
-			return fileUrl
+			// Tag the request so the slides service worker can cache it without
+			// touching other apps' /private/files/ traffic (Drive, Mail, ...).
+			// Non-owner media already goes through the slides-namespaced proxy below.
+			return `${fileUrl}${fileUrl.includes('?') ? '&' : '?'}${SLIDES_MEDIA_PARAM}`
 		}
 		return `/api/method/suite.slides.api.file.get_media_file?src=${fileUrl}&public=${isPublicPresentation.value}`
 	}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,24 @@ import { noiseSuppressionAudioWorkletVitePlugin } from '@workadventure/noise-sup
 import frappeui from 'frappe-ui/vite'
 import { defineConfig } from 'vite'
 
+// Emits the slides-scoped service worker to suite/www so Frappe serves it at the
+// origin root ('/service-worker.js'). Root scope is required for it to intercept
+// slides' /api/method/suite.slides.* requests. Build-only (no SW in dev to avoid
+// HMR/caching conflicts); the stamped timestamp makes each build a new SW so the
+// browser picks up updates. Slides-only: reads/writes only the slides SW file.
+const emitSlidesServiceWorker = () => ({
+  name: 'slides-service-worker',
+  apply: 'build' as const,
+  async writeBundle() {
+    const swSource = path.resolve(__dirname, 'src/apps/slides/service-worker.js')
+    const swOutput = path.resolve(__dirname, '../suite/www/service-worker.js')
+    const source = fs.readFileSync(swSource, 'utf-8')
+    const stamped = source.replace(/__BUILD_TIMESTAMP__/g, Date.now().toString())
+    fs.mkdirSync(path.dirname(swOutput), { recursive: true })
+    fs.writeFileSync(swOutput, stamped)
+  },
+})
+
 const benchRoot = path.resolve(__dirname, '../../..')
 const commonSiteConfig = JSON.parse(
   fs.readFileSync(path.join(benchRoot, 'sites/common_site_config.json'), 'utf-8'),
@@ -40,6 +58,7 @@ export default defineConfig(({ mode }) => ({
       },
     }),
     vue(),
+    emitSlidesServiceWorker(),
   ],
   resolve: {
     alias: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,11 +6,6 @@ import { noiseSuppressionAudioWorkletVitePlugin } from '@workadventure/noise-sup
 import frappeui from 'frappe-ui/vite'
 import { defineConfig } from 'vite'
 
-// Emits the slides-scoped service worker to suite/www so Frappe serves it at the
-// origin root ('/service-worker.js'). Root scope is required for it to intercept
-// slides' /api/method/suite.slides.* requests. Build-only (no SW in dev to avoid
-// HMR/caching conflicts); the stamped timestamp makes each build a new SW so the
-// browser picks up updates. Slides-only: reads/writes only the slides SW file.
 const emitSlidesServiceWorker = () => ({
   name: 'slides-service-worker',
   apply: 'build' as const,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,13 +9,11 @@ import { defineConfig } from 'vite'
 const emitSlidesServiceWorker = () => ({
   name: 'slides-service-worker',
   apply: 'build' as const,
-  async writeBundle() {
+  writeBundle() {
     const swSource = path.resolve(__dirname, 'src/apps/slides/service-worker.js')
     const swOutput = path.resolve(__dirname, '../suite/www/service-worker.js')
-    const source = fs.readFileSync(swSource, 'utf-8')
-    const stamped = source.replace(/__BUILD_TIMESTAMP__/g, Date.now().toString())
     fs.mkdirSync(path.dirname(swOutput), { recursive: true })
-    fs.writeFileSync(swOutput, stamped)
+    fs.copyFileSync(swSource, swOutput)
   },
 })
 


### PR DESCRIPTION
Slides originally shipped a service worker in frappe/slides for offline media / data caching. It was dropped during the monorepo port, the Phase 5/6 port set the suite tree byte-identical to develop, which had already lost the file. The SW source, its vite build plugin, and the `main.ts` registration all went missing. Only the cache consumers (`useThumbnailCapture`, the `saving.js` IndexedDB layer, the online / offline banner) survived. So caches.open('slides-media') was being read / evicted but never populated.

This PR restores it and re-wires it for the single-SPA monorepo.