### PR TITLE
fix(slides): re-entering list view shows empty list until hard reload

### DIFF
--- a/frontend/src/apps/slides/pages/Home.vue
+++ b/frontend/src/apps/slides/pages/Home.vue
@@ -73,10 +73,15 @@ const presentationListResource = createResource({
 	method: 'GET',
 	auto: true,
 	cache: 'presentations',
-	onSuccess: (data) => {
-		presentationList.value = data
-	},
 })
+
+watch(
+	() => presentationListResource.data,
+	(data) => {
+		if (data) presentationList.value = data
+	},
+	{ immediate: true },
+)
 
 const navigateToPresentation = (name, present) => {
 	name = name || previewPresentation.value?.name


### PR DESCRIPTION
### Bug
Coming back into slides from the launcher showed no presentations until a hard reload. `Home.vue` filled its list from `createResource` onSuccess. In the suite SPA, leaving and re-entering slides no longer clears frappe-ui's resource cache. So a remount got the old cached resource, its onSuccess was dropped, and the new list stayed empty.

### Fix
Read the list from `presentationListResource.data` with an immediate watch instead of onSuccess. Now a remount picks up the cached data right away and stays in sync.