### PR TITLE
chore: remove unwired launcher view search

### DIFF
--- a/frontend/src/apps/registry.ts
+++ b/frontend/src/apps/registry.ts
@@ -24,10 +24,6 @@ export interface SuiteApp {
   name: string
   /** URL prefix this app owns; preserved from the original standalone app. */
   prefix: string
-  /** Short blurb for the launcher tile. */
-  description: string
-  /** lucide icon name — fallback chrome (e.g. top-nav) when a logo isn't shown. */
-  icon: string
   /** Imported, build-fingerprinted brand-logo URL. */
   logo: string
 }
@@ -35,11 +31,11 @@ export interface SuiteApp {
 export const SUITE_LOGO = suiteLogo
 
 export const SUITE_APPS: SuiteApp[] = [
-  { id: 'drive', name: 'Drive', prefix: '/drive', description: 'Files & folders', icon: 'HardDrive', logo: driveLogo },
-  { id: 'slides', name: 'Slides', prefix: '/slides', description: 'Presentations', icon: 'Presentation', logo: slidesLogo },
-  { id: 'writer', name: 'Writer', prefix: '/writer', description: 'Documents', icon: 'FileText', logo: writerLogo },
-  { id: 'sheets', name: 'Sheets', prefix: '/sheets', description: 'Spreadsheets', icon: 'Table', logo: sheetsLogo },
-  { id: 'meet', name: 'Meet', prefix: '/meet', description: 'Video meetings', icon: 'Video', logo: meetLogo },
-  { id: 'mail', name: 'Mail', prefix: '/mail', description: 'Email', icon: 'Mail', logo: mailLogo },
-  { id: 'calendar', name: 'Calendar', prefix: '/calendar', description: 'Schedule', icon: 'Calendar', logo: calendarLogo },
+  { id: 'drive', name: 'Drive', prefix: '/drive', logo: driveLogo },
+  { id: 'slides', name: 'Slides', prefix: '/slides', logo: slidesLogo },
+  { id: 'writer', name: 'Writer', prefix: '/writer', logo: writerLogo },
+  { id: 'sheets', name: 'Sheets', prefix: '/sheets', logo: sheetsLogo },
+  { id: 'meet', name: 'Meet', prefix: '/meet', logo: meetLogo },
+  { id: 'mail', name: 'Mail', prefix: '/mail', logo: mailLogo },
+  { id: 'calendar', name: 'Calendar', prefix: '/calendar', logo: calendarLogo },
 ]

--- a/frontend/src/shell/LauncherView.vue
+++ b/frontend/src/shell/LauncherView.vue
@@ -4,12 +4,6 @@
     <div class="mx-auto flex min-h-full max-w-5xl flex-col px-6 pt-[10%] pb-16">
 
       <div class="mx-auto grid grid-cols-4 gap-x-20 gap-y-10">
-        <div class=" col-span-4">
-          <TextInput placeholder="Search" variant="subtle">
-            <template #prefix><span class="lucide-search size-4 text-ink-gray-4" /></template>
-            </TextInput>
-
-        </div>
         <router-link
           v-for="app in apps"
           :key="app.id"
@@ -51,7 +45,6 @@ import { onMounted } from 'vue'
 
 import { SUITE_APPS, SUITE_LOGO } from '@/apps/registry'
 import { useRootStore } from '@/stores/root'
-import { TextInput } from 'frappe-ui'
 
 const apps = SUITE_APPS
 const suiteLogo = SUITE_LOGO


### PR DESCRIPTION
#### Changes
- Removed the unused `icon` and `description` fields from the `SuiteApp` registry interface and all 7 app entries, since the launcher now renders logos directly.
- Stripped the non-functional search bar and its orphaned `TextInput` import from `LauncherView.vue`.