### PR TITLE
Port latest Sheets changes from standalone frappe/sheets

### DIFF
--- a/frontend/src/apps/sheets/canvas/chip-geometry.js
+++ b/frontend/src/apps/sheets/canvas/chip-geometry.js
@@ -1,0 +1,55 @@
+// Geometry, colour + font helpers for data-validation dropdown chips.
+// Shared by the cell painter (which draws the pill) and the grid hit-test
+// (which needs to know where the caret is) so the clickable caret zone
+// always lines up with what's painted. Keep the two in sync by routing all
+// chip measurement through here.
+
+export const CHIP = {
+  padX:     4,   // gap from the cell's edge to the pill
+  innerPad: 8,   // text padding inside the pill
+  caretW:   16,  // room reserved on the pill's right for the caret + its click zone
+  maxH:     22,  // the pill never grows taller than this
+  minH:     13,  // below this the row is too short for a pill — fall back to a plain arrow
+}
+
+// Soft pastel chip backgrounds, à la Sheets. A value's colour is derived from
+// the value itself, so the same option is always the same colour without any
+// per-option config in the rule. Dark cell text stays readable on all of them.
+const CHIP_PALETTE = [
+  '#FCE8E6', '#FEF7E0', '#E6F4EA', '#E8F0FE',
+  '#F3E8FD', '#FEEFE3', '#E4F7FB', '#FDE7F3',
+]
+
+// Canvas font string for a cell format. Mirrors the cell painter exactly so
+// text measured here for hit-testing matches what gets drawn.
+export function chipFont(fmt = {}) {
+  const weight = fmt.bold   ? 'bold'   : 'normal'
+  const style  = fmt.italic ? 'italic' : 'normal'
+  const px     = Math.max(8, Math.min(72, fmt.fontSize || 13))
+  const family = fmt.fontFamily || 'InterVar, Inter, ui-sans-serif, system-ui, sans-serif'
+  return `${style} ${weight} ${px}px ${family}`
+}
+
+// Stable pastel background for a known option value.
+export function chipColor(value) {
+  const s = String(value)
+  let h = 0
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0
+  return CHIP_PALETTE[h % CHIP_PALETTE.length]
+}
+
+// Pill placement for `text` in a cell of width `cellW`: its x-offset from the
+// cell's left edge and its width, honouring the cell's horizontal alignment.
+// Caller need not pre-set ctx.font. Returns { offsetX, chipW }.
+export function chipMetrics(ctx, text, fmt, cellW) {
+  ctx.save()
+  ctx.font = chipFont(fmt)
+  const tw = ctx.measureText(text).width
+  ctx.restore()
+  const chipW = Math.min(cellW - CHIP.padX * 2, CHIP.innerPad + tw + CHIP.caretW)
+  const align = fmt.align || 'left'
+  const offsetX = align === 'right'  ? cellW - CHIP.padX - chipW
+                : align === 'center' ? (cellW - chipW) / 2
+                :                      CHIP.padX
+  return { offsetX, chipW }
+}

--- a/frontend/src/apps/sheets/canvas/constants.js
+++ b/frontend/src/apps/sheets/canvas/constants.js
@@ -2,11 +2,18 @@ export const COL_HEADER_H  = 24
 export const ROW_HEADER_W  = 50
 export const DEFAULT_COL_W = 100
 export const DEFAULT_ROW_H = 24
+// Default grid size a fresh/empty sub-sheet shows (Google-Sheets-like). The
+// live counts below grow past these when a sheet's data needs it, and reset
+// back to them per sub-sheet on switch so a 100k-row source doesn't leave every
+// new / pivot / drill-down sheet stuck at 100k empty rows.
+export const DEFAULT_TOTAL_ROWS = 1000
+export const DEFAULT_TOTAL_COLS = 26
+
 // Live bindings — `let` so the row/column count can grow at runtime via the
 // grid's `expandRows` / `expandCols` API. ES modules expose live bindings, so
 // importers always see the current value.
-export let TOTAL_ROWS = 1000
-export let TOTAL_COLS = 26    // A–Z (Google-Sheets default; more can be added on demand)
+export let TOTAL_ROWS = DEFAULT_TOTAL_ROWS
+export let TOTAL_COLS = DEFAULT_TOTAL_COLS    // A–Z; more can be added on demand
 export function setTotalRows(n) { TOTAL_ROWS = Math.max(1, Math.floor(n)) }
 export function setTotalCols(n) { TOTAL_COLS = Math.max(1, Math.floor(n)) }
 
@@ -33,4 +40,8 @@ export const COLORS = {
   // by being a *static dashed* outline in the softer ink-gray-7.
   pickerFill:   'rgba(23, 23, 23, 0.05)',   // --ink-gray-9 @ 5% — subtle wash
   pickerBorder: '#525252',                  // --ink-gray-7 — static dashed outline
+  // Data-validation dropdown chips
+  chipFill:     '#EDEDED',                  // --surface-gray-3 — neutral pill
+  chipCaret:    '#525252',                  // --ink-gray-7 — pill caret
+  invalidMark:  '#D93025',                  // red — value fails its validation rule
 }

--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -1,18 +1,39 @@
 import { createGeometry } from './geometry.js'
 import { createRenderer } from './renderer.js'
 import { createOverlay }  from './overlay.js'
-import { TOTAL_ROWS, TOTAL_COLS, DEFAULT_ROW_H, ROW_HEADER_W, COL_HEADER_H, setTotalRows, setTotalCols } from './constants.js'
+import { TOTAL_ROWS, TOTAL_COLS, DEFAULT_TOTAL_ROWS, DEFAULT_TOTAL_COLS, DEFAULT_ROW_H, ROW_HEADER_W, COL_HEADER_H, setTotalRows, setTotalCols } from './constants.js'
 import { cellId, colLabel, parseCellId } from '../utils/cells.js'
 import { AC_FUNS, AC_FUN_KEYS, parseAcToken } from '../utils/formula-ac.js'
 import { isWrapText } from '../utils/text-wrap.js'
+import { CHIP, chipMetrics } from './chip-geometry.js'
 
 export { colLabel, cellId, parseCellId } from '../utils/cells.js'
 
-export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getFormat, onFill, onBatchCommit, getMergeInfo, isSlave, getMasterId, getComment, getValidation, getCondFormat, getRightInset, onHyperlinkClick, onDropdownClick, onResizeEnd, getSheetNames, getCurrentSheet, getEditingHomeSheet } = {}) {
+export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getFormat, onFill, onBatchCommit, getMergeInfo, isSlave, getMasterId, getComment, getValidation, getCondFormat, getRightInset, onHyperlinkClick, onDropdownClick, onPivotDrill, onResizeEnd, getSheetNames, getCurrentSheet, getEditingHomeSheet, getDisplay, getCellIds, lazyValues = false } = {}) {
   const ctx = canvas.getContext('2d')
   const dpr = window.devicePixelRatio || 1
 
   const data = {}
+
+  // ── Value-source seam (lazy-viewport cutover) ────────────────────────────────
+  // Legacy/eager path reads the grid's own `data` cache, populated wholesale by
+  // the host's repopulate. Lazy path pulls each cell's display string from the
+  // host's `getDisplay` on demand, so switch/load cost no longer scales with
+  // total cell count — the grid only ever touches visible cells plus the cells
+  // a cold-path scan (Cmd+Arrow, Cmd+A, autofit) walks.
+  //
+  // Three seams, used everywhere instead of touching `data` directly:
+  //   getValue(id) — display string for a cell
+  //   hasVal(id)   — is the cell non-empty (matches the legacy `!!data[id]`)
+  //   cellIds()    — every non-empty cell id on the current sheet
+  // In eager mode they read `data`; in lazy mode they read the engine via the
+  // host callbacks. Flipping `_lazyValues` is the cutover.
+  let _lazyValues = lazyValues && typeof getDisplay === 'function'
+  const getValue = id => _lazyValues ? getDisplay(id) : data[id]
+  const hasVal   = id => !!getValue(id)
+  const cellIds  = () => _lazyValues ? (getCellIds ? getCellIds() : []) : Object.keys(data)
+  function setLazyValues(on) { _lazyValues = !!on && typeof getDisplay === 'function'; render() }
+  function isLazyValues() { return _lazyValues }
   const colW = {}
   const rowH = {}
 
@@ -88,7 +109,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
   }
 
   function render() {
-    renderer.render({ cssW, cssH, data, sel, selEnd, selMode, editing, getFormat, freeze, getMergeInfo, isSlave, getComment, getValidation, getCondFormat, getRightInset, getDiffFor: _diffCells ? _getDiffFor : null, marchAnts, marchPhase, pickerRect, zoom: _zoom })
+    renderer.render({ cssW, cssH, getValue, sel, selEnd, selMode, editing, getFormat, freeze, getMergeInfo, isSlave, getComment, getValidation, getCondFormat, getRightInset, getDiffFor: _diffCells ? _getDiffFor : null, marchAnts, marchPhase, pickerRect, zoom: _zoom })
     for (const cb of _renderListeners) cb()
   }
 
@@ -220,16 +241,16 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
   // Jump to data-region edge (Cmd+Arrow behaviour matching Google Sheets)
   function _jumpEdge(startR, startC, dr, dc) {
     const maxR = TOTAL_ROWS - 1, maxC = TOTAL_COLS - 1
-    const curFilled = !!data[cellId(startR, startC)]
+    const curFilled = hasVal(cellId(startR, startC))
     let nr = Math.max(0, Math.min(maxR, startR + dr))
     let nc = Math.max(0, Math.min(maxC, startC + dc))
-    if (curFilled && !!data[cellId(nr, nc)]) {
+    if (curFilled && hasVal(cellId(nr, nc))) {
       // Scan forward to end of contiguous block
       let r = startR, c = startC
       while (true) {
         const tr = r + dr, tc = c + dc
         if (tr < 0 || tr > maxR || tc < 0 || tc > maxC) break
-        if (!data[cellId(tr, tc)]) break
+        if (!hasVal(cellId(tr, tc))) break
         r = tr; c = tc
       }
       return { r, c }
@@ -237,7 +258,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
       // Scan forward to next filled cell
       let r = startR + dr, c = startC + dc
       while (r >= 0 && r <= maxR && c >= 0 && c <= maxC) {
-        if (data[cellId(r, c)]) return { r, c }
+        if (hasVal(cellId(r, c))) return { r, c }
         r += dr; c += dc
       }
       // No filled cell — go to grid boundary
@@ -250,7 +271,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
 
   function _lastUsedCell() {
     let maxR = 0, maxC = 0
-    for (const id of Object.keys(data)) {
+    for (const id of cellIds()) {
       const p = parseCellId(id)
       if (p) { if (p.row > maxR) maxR = p.row; if (p.col > maxC) maxC = p.col }
     }
@@ -763,17 +784,16 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
   // Double-click-fill extent: pick a non-empty neighbour column (left, then
   // right) and walk its contiguous run starting at r1+1 — Google Sheets rule.
   function _autoFillDownExtent(src) {
-    const hasVal = (r, c) => {
+    const filled = (r, c) => {
       if (r < 0 || r >= TOTAL_ROWS || c < 0 || c >= TOTAL_COLS) return false
-      const v = data[cellId(r, c)]
-      return v != null && v !== ''
+      return hasVal(cellId(r, c))
     }
     let anchor = null
-    if (hasVal(src.r1 + 1, src.c0 - 1))      anchor = src.c0 - 1
-    else if (hasVal(src.r1 + 1, src.c1 + 1)) anchor = src.c1 + 1
+    if (filled(src.r1 + 1, src.c0 - 1))      anchor = src.c0 - 1
+    else if (filled(src.r1 + 1, src.c1 + 1)) anchor = src.c1 + 1
     if (anchor === null) return src.r1
     let r = src.r1 + 1
-    while (r < TOTAL_ROWS && hasVal(r, anchor)) r++
+    while (r < TOTAL_ROWS && filled(r, anchor)) r++
     return r - 1
   }
 
@@ -796,10 +816,10 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     const MIN_W      = 40
     const MAX_W      = 600
     let widest = _measureWidth(colLabel(c), { bold: true }) + HEADER_PAD
-    for (const id of Object.keys(data)) {
+    for (const id of cellIds()) {
       const p = parseCellId(id)
       if (!p || p.col !== c) continue
-      const val = data[id]
+      const val = getValue(id)
       if (val == null || val === '') continue
       const fmt = getFormat ? getFormat(id) : {}
       // Skip wrap-text columns — they auto-grow rows, not cols.
@@ -817,10 +837,10 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     const MIN_H   = DEFAULT_ROW_H
     const MAX_H   = 400
     let tallest = MIN_H
-    for (const id of Object.keys(data)) {
+    for (const id of cellIds()) {
       const p = parseCellId(id)
       if (!p || p.row !== r) continue
-      const val = data[id]
+      const val = getValue(id)
       if (val == null || val === '') continue
       const fmt = getFormat ? getFormat(id) : {}
       let h = 18 // single line height at 13px
@@ -1011,12 +1031,22 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
       return
     }
 
-    // Click on the dropdown arrow of a validated cell → open dropdown
-    if (getValidation?.(hId)) {
+    // Click on the dropdown caret of a list-validated cell → open dropdown.
+    // The caret zone tracks the chip when one is drawn (list rule + value),
+    // else it's the plain arrow box at the cell's right edge. Only list rules
+    // get a dropdown — number/length rules fall through to normal selection.
+    const vrule = getValidation?.(hId)
+    if (vrule?.type === 'list') {
       const x = geo.colX(h.c), y = geo.rowY(h.r)
       const w = geo.cw(h.c), cellRight = x + w
       const lx = (e.clientX - rect.left) / _zoom
-      if (lx >= cellRight - 14) {
+      const val = getValue(hId)
+      let caretL = cellRight - 14
+      if (val != null && String(val) !== '') {
+        const { offsetX, chipW } = chipMetrics(ctx, String(val), getFormat?.(hId) || {}, w)
+        caretL = x + offsetX + chipW - CHIP.caretW
+      }
+      if (lx >= caretL && lx <= cellRight) {
         e.stopPropagation()   // prevent _onDocMouseDown from closing the just-opened panel
         moveSel(h.r, h.c)
         const pos = {
@@ -1024,7 +1054,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
           y: rect.top  + (y + geo.rh(h.r)) * _zoom,
           w: w * _zoom,
         }
-        onDropdownClick?.(hId, getValidation(hId), pos)
+        onDropdownClick?.(hId, vrule, pos)
         return
       }
     }
@@ -1069,7 +1099,11 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
 
     const h = geo.hitTest(e.clientX, e.clientY, rect)
     if (!h) return
-    showEditor(data[cellId(h.r, h.c)] ?? '', 'edit')
+    // On a pivot output sheet, a double-click drills into the source rows
+    // instead of editing the (regenerated) cell. The handler returns true
+    // when it took over.
+    if (onPivotDrill?.(h.r, h.c)) return
+    showEditor(getValue(cellId(h.r, h.c)) ?? '', 'edit')
   })
 
   canvas.addEventListener('mousemove', e => {
@@ -1246,7 +1280,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     if (mod && (e.key === 'a' || e.key === 'A')) {
       e.preventDefault()
       const last = _lastUsedCell()
-      const hasData = last.r > 0 || last.c > 0 || data[cellId(0, 0)] !== undefined
+      const hasData = last.r > 0 || last.c > 0 || hasVal(cellId(0, 0))
       const cur = getSelRange()
       const onDataRegion = hasData
         && cur.r0 === 0 && cur.c0 === 0
@@ -1291,7 +1325,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
       return
     }
 
-    if (e.key === 'F2') { e.preventDefault(); showEditor(data[cellId(r, c)] ?? '', 'edit'); return }
+    if (e.key === 'F2') { e.preventDefault(); showEditor(getValue(cellId(r, c)) ?? '', 'edit'); return }
 
     if ((e.key === 'Delete' || e.key === 'Backspace') && !mod) {
       e.preventDefault()
@@ -1378,16 +1412,23 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     render()
   }
 
+  // In lazy mode the grid owns no value cache — getValue pulls from the engine,
+  // which the host has already updated before calling here — so these just
+  // schedule a repaint. In eager mode they keep the `data` cache current.
   function setCell(id, value) {
-    if (!value && value !== 0) delete data[id]
-    else data[id] = value
+    if (!_lazyValues) {
+      if (!value && value !== 0) delete data[id]
+      else data[id] = value
+    }
     scheduleRender()
   }
 
   function batchSetCells(map) {
-    for (const [id, value] of Object.entries(map)) {
-      if (!value && value !== 0) delete data[id]
-      else data[id] = value
+    if (!_lazyValues) {
+      for (const [id, value] of Object.entries(map)) {
+        if (!value && value !== 0) delete data[id]
+        else data[id] = value
+      }
     }
     scheduleRender()
   }
@@ -1518,7 +1559,11 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
       rowH:       { ...rowH },
       freezeRows: freeze.rows || 0,
       freezeCols: freeze.cols || 0,
-      hiddenRows: Array.from(hiddenRows),
+      // Only MANUAL hides belong in the per-sheet view. Filter hides are
+      // transient and derived per-sheet from the sortFilter engine; baking
+      // them in here leaked one sheet's filter onto others (they were read
+      // back as manual hides and re-applied everywhere).
+      hiddenRows: Array.from(hiddenRows).filter(r => !filterHiddenRows.has(r)),
       hiddenCols: Array.from(hiddenCols),
       totalRows:  TOTAL_ROWS,
       totalCols:  TOTAL_COLS,
@@ -1536,10 +1581,17 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     freeze.cols = snap.freezeCols || 0
     hiddenRows.clear()
     for (const r of (snap.hiddenRows || [])) hiddenRows.add(r)
+    // Filter hides are transient and re-applied per-sheet by _applyHiddenRows;
+    // drop any stale tag from the previous sheet so it can't bleed through.
+    filterHiddenRows.clear()
     hiddenCols.clear()
     for (const c of (snap.hiddenCols || [])) hiddenCols.add(c)
-    if (typeof snap.totalRows === 'number') setTotalRows(snap.totalRows)
-    if (typeof snap.totalCols === 'number') setTotalCols(snap.totalCols)
+    // Reset to the default size when the view doesn't carry an explicit count
+    // (new / pivot / drill-down sheets) — otherwise the count stays at whatever
+    // a large source sheet grew the global binding to. _repopulateGrid expands
+    // again to fit any real data right after this, so nothing gets hidden.
+    setTotalRows(typeof snap.totalRows === 'number' ? snap.totalRows : DEFAULT_TOTAL_ROWS)
+    setTotalCols(typeof snap.totalCols === 'number' ? snap.totalCols : DEFAULT_TOTAL_COLS)
     if (typeof snap.zoom === 'number')      _zoom = Math.max(0.5, Math.min(2.5, snap.zoom))
     _applyCanvasSize()
     render()
@@ -1547,7 +1599,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
 
   return {
     resize, render, setCell, batchSetCells, clearAll,
-    getCell: id => data[id] ?? '',
+    getCell: id => getValue(id) ?? '',
     getActiveCell: () => cellId(sel.r, sel.c),
     // Whether the in-cell overlay is currently editing a `=…` formula —
     // SheetEditor uses this to keep the editor alive across sheet-tab clicks
@@ -1574,6 +1626,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     expandCols, getTotalCols,
     setZoom, getZoom,
     viewSnapshot, viewRestore,
+    setLazyValues, isLazyValues,
     destroy,
   }
 }

--- a/frontend/src/apps/sheets/canvas/painters/cell-painter.js
+++ b/frontend/src/apps/sheets/canvas/painters/cell-painter.js
@@ -1,12 +1,19 @@
 import { COLORS, TOTAL_COLS } from '../constants.js'
 import { cellId } from '../../utils/cells.js'
 import { getTextWrap, isWrapText } from '../../utils/text-wrap.js'
+import { CHIP, chipFont, chipColor, chipMetrics } from '../chip-geometry.js'
+import { checkRule } from '../../engine/validation.js'
 
 export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
 
   // ── Public API ───────────────────────────────────────────────────────────────
 
-  function drawRegionCells(r0, c0, r1, c1, data, getFormat, getMergeInfo, isSlave, getComment, getValidation, getCondFormat, getRightInset, getDiffFor) {
+  // `getVal(id)` returns a cell's display string. It abstracts over the
+  // value source: the legacy eager `data` map (id => data[id]) or the lazy
+  // engine-backed lookup. The painter only ever touches cells in the visible
+  // region, so the lazy path computes display strings for ~hundreds of cells
+  // per frame instead of materialising the whole sheet up front.
+  function drawRegionCells(r0, c0, r1, c1, getVal, getFormat, getMergeInfo, isSlave, getComment, getValidation, getCondFormat, getRightInset, getDiffFor) {
     ctx.textBaseline = 'middle'
     // Two-pass paint: every cell's background + decorations first, then
     // every cell's text. Splitting the passes means an upstream cell's
@@ -17,12 +24,12 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
     for (let r = r0; r <= r1; r++) {
       if (rh(r) === 0) continue
       for (let c = c0; c <= c1; c++)
-        _paintBgAt(r, c, data, getFormat, getMergeInfo, isSlave, getComment, getValidation, getCondFormat, getDiffFor)
+        _paintBgAt(r, c, getVal, getFormat, getMergeInfo, isSlave, getComment, getValidation, getCondFormat, getDiffFor)
     }
     for (let r = r0; r <= r1; r++) {
       if (rh(r) === 0) continue
       for (let c = c0; c <= c1; c++)
-        _paintTextAt(r, c, data, getFormat, getMergeInfo, isSlave, getCondFormat, getRightInset)
+        _paintTextAt(r, c, getVal, getFormat, getMergeInfo, isSlave, getCondFormat, getRightInset, getValidation)
     }
   }
 
@@ -44,13 +51,13 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
 
   // Shared per-cell geometry + format lookup. Both paint phases call this,
   // returns null for slave cells (so the caller knows to skip).
-  function _cellGeom(r, c, data, getFormat, getMergeInfo, isSlave, getCondFormat) {
+  function _cellGeom(r, c, getVal, getFormat, getMergeInfo, isSlave, getCondFormat) {
     const id = cellId(r, c)
     if (isSlave && isSlave(id)) return null
     const merge = getMergeInfo && getMergeInfo(id)
     const spanC = merge ? merge.colSpan : 1
     const spanR = merge ? merge.rowSpan : 1
-    const val   = data[id]
+    const val   = getVal(id)
     const fmt   = getFormat ? getFormat(id) : {}
     const x = colX(c), y = rowY(r)
     let w = 0, h = 0
@@ -60,27 +67,45 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
     return { id, val, fmt, condFmt, merge, x, y, w, h }
   }
 
-  function _paintBgAt(r, c, data, getFormat, getMergeInfo, isSlave, getComment, getValidation, getCondFormat, getDiffFor) {
-    const g = _cellGeom(r, c, data, getFormat, getMergeInfo, isSlave, getCondFormat)
+  function _paintBgAt(r, c, getVal, getFormat, getMergeInfo, isSlave, getComment, getValidation, getCondFormat, getDiffFor) {
+    const g = _cellGeom(r, c, getVal, getFormat, getMergeInfo, isSlave, getCondFormat)
     if (!g) return
-    const { id, fmt, condFmt, merge, x, y, w, h } = g
+    const { id, val, fmt, condFmt, merge, x, y, w, h } = g
     _drawCellBackground(x, y, w, h, merge, fmt, condFmt)
     // Data-bar between background and text so values stay readable on top.
     if (condFmt?.dataBar) _drawDataBar(x, y, w, h, condFmt.dataBar)
     if (getDiffFor && getDiffFor(id)) _drawDiffOverlay(x, y, w, h)
-    if (getComment?.(id))    _drawCommentTriangle(x, y, w)
-    if (getValidation?.(id)) _drawDropdownArrow(x, y, w, h)
+    if (getComment?.(id)) _drawCommentTriangle(x, y, w)
+    const rule = getValidation?.(id)
+    if (rule) {
+      const has = val != null && String(val) !== ''
+      const invalid = has && !checkRule(rule, val).valid
+      if (rule.type === 'list') {
+        // List rule → a Sheets-style dropdown affordance. With a value it's a
+        // chip (which owns the cell text — the text pass skips it); empty,
+        // it's a plain caret so you know it's a dropdown.
+        if (has) _drawValidationChip(x, y, w, h, String(val), fmt, !invalid)
+        else     _drawDropdownArrow(x, y, w, h)
+      } else if (invalid) {
+        // Number / text-length rules have no dropdown (matching Sheets) — they
+        // only surface a marker when the current value breaks the rule.
+        _drawInvalidTriangle(x, y)
+      }
+    }
     // Icon belongs in the bg pass — it's drawn before text and shifts the
     // text rect right. The text pass computes the same inset to position
     // text correctly without re-drawing the icon.
     if (condFmt?.icon) _drawCellIcon(x, y, h, condFmt.icon)
   }
 
-  function _paintTextAt(r, c, data, getFormat, getMergeInfo, isSlave, getCondFormat, getRightInset) {
-    const g = _cellGeom(r, c, data, getFormat, getMergeInfo, isSlave, getCondFormat)
+  function _paintTextAt(r, c, getVal, getFormat, getMergeInfo, isSlave, getCondFormat, getRightInset, getValidation) {
+    const g = _cellGeom(r, c, getVal, getFormat, getMergeInfo, isSlave, getCondFormat)
     if (!g) return
     const { id, val, fmt, condFmt, x, y, w, h } = g
     if (val == null || val === '') return
+    // List-validation cells render their value inside the chip drawn in the
+    // bg pass — don't paint it a second time on top.
+    if (getValidation?.(id)?.type === 'list') return
     const s = String(val)
     const baseFmt = condFmt ? { ...fmt, ...condFmt } : fmt
     const efmt = { ...baseFmt, align: baseFmt.align || _autoAlign(s) }
@@ -102,7 +127,7 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
       const textW = ctx.measureText(s).width + 8
       const inside = drawW - rightInset
       if (textW > inside) {
-        const ext = _overflowExtension(r, c, efmt.align, textW - inside, data, getFormat, getMergeInfo, isSlave)
+        const ext = _overflowExtension(r, c, efmt.align, textW - inside, getVal, getFormat, getMergeInfo, isSlave)
         drawX -= ext.left
         drawW += ext.left + ext.right
       }
@@ -114,12 +139,12 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
   // pixels of extra room we can use. Stops at the first cell with a value,
   // an explicit background fill, or the grid edge — mirroring Sheets' rule
   // that bg-styled cells block overflow even when otherwise empty.
-  function _overflowExtension(r, c, align, needed, data, getFormat, getMergeInfo, isSlave) {
+  function _overflowExtension(r, c, align, needed, getVal, getFormat, getMergeInfo, isSlave) {
     const out = { left: 0, right: 0 }
     if (align === 'left' || align === 'center') {
       let nc = c + 1, want = align === 'center' ? needed / 2 : needed
       while (out.right < want && nc < TOTAL_COLS) {
-        if (_blocksOverflow(r, nc, data, getFormat, getMergeInfo, isSlave)) break
+        if (_blocksOverflow(r, nc, getVal, getFormat, getMergeInfo, isSlave)) break
         out.right += cw(nc); nc++
       }
     }
@@ -129,19 +154,19 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
       const want = align === 'center' ? (needed - out.right) : needed
       let nc = c - 1
       while (out.left < want && nc >= 0) {
-        if (_blocksOverflow(r, nc, data, getFormat, getMergeInfo, isSlave)) break
+        if (_blocksOverflow(r, nc, getVal, getFormat, getMergeInfo, isSlave)) break
         out.left += cw(nc); nc--
       }
     }
     return out
   }
 
-  function _blocksOverflow(r, c, data, getFormat, getMergeInfo, isSlave) {
+  function _blocksOverflow(r, c, getVal, getFormat, getMergeInfo, isSlave) {
     if (c < 0 || c >= TOTAL_COLS) return true
     const id = cellId(r, c)
     if (isSlave?.(id)) return true
     if (getMergeInfo?.(id)) return true
-    const v = data[id]
+    const v = getVal(id)
     if (v != null && v !== '') return true
     const f = getFormat ? getFormat(id) : null
     if (f?.backgroundColor) return true
@@ -291,16 +316,92 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
     ctx.restore()
   }
 
+  // Sheets-style dropdown chip: a rounded pill holding the cell value with a
+  // caret on its right. Drawn in the bg pass; the matching click zone lives in
+  // canvas/index.js (both measure through chip-geometry so they stay aligned).
+  function _drawValidationChip(x, y, w, h, text, fmt, valid) {
+    const chipH = Math.min(h - 4, CHIP.maxH)
+    if (chipH < CHIP.minH) { _drawDropdownArrow(x, y, w, h); return }  // row too short for a pill
+    ctx.save()
+    _setCellFont(fmt)
+    const textColor = fmt.color || COLORS.cellText
+    const { offsetX, chipW } = chipMetrics(ctx, text, fmt, w)
+    const chipX = x + offsetX
+    const chipY = y + (h - chipH) / 2
+    // Pill — known options get a stable pastel colour; an out-of-list value
+    // stays neutral grey (it isn't one of the choices).
+    _roundRectPath(chipX, chipY, chipW, chipH, chipH / 2)
+    ctx.fillStyle = valid ? chipColor(text) : COLORS.chipFill
+    ctx.fill()
+    // Value — ellipsised to the room left of the caret so a long option
+    // doesn't get hard-clipped mid-glyph.
+    ctx.fillStyle   = textColor
+    ctx.textAlign   = 'left'
+    ctx.textBaseline = 'middle'
+    const textRoom = chipW - CHIP.innerPad - CHIP.caretW
+    ctx.fillText(_ellipsize(text, textRoom), chipX + CHIP.innerPad, chipY + chipH / 2)
+    // Caret
+    const mx = chipX + chipW - CHIP.caretW / 2, my = chipY + chipH / 2
+    ctx.fillStyle = COLORS.chipCaret
+    ctx.beginPath()
+    ctx.moveTo(mx - 3, my - 1.5)
+    ctx.lineTo(mx + 3, my - 1.5)
+    ctx.lineTo(mx, my + 2.5)
+    ctx.closePath()
+    ctx.fill()
+    ctx.restore()
+    if (!valid) _drawInvalidTriangle(x, y)
+  }
+
+  // Trim `text` to fit `maxW` px (current ctx.font), appending an ellipsis.
+  function _ellipsize(text, maxW) {
+    if (maxW <= 0) return ''
+    if (ctx.measureText(text).width <= maxW) return text
+    const ell = '…'
+    let lo = 0, hi = text.length
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1
+      if (ctx.measureText(text.slice(0, mid) + ell).width <= maxW) lo = mid
+      else hi = mid - 1
+    }
+    return lo > 0 ? text.slice(0, lo) + ell : ell
+  }
+
+  // Rounded-rect path with a roundRect fallback for older canvas engines.
+  function _roundRectPath(x, y, w, h, r) {
+    ctx.beginPath()
+    if (ctx.roundRect) { ctx.roundRect(x, y, w, h, r); return }
+    r = Math.min(r, w / 2, h / 2)
+    ctx.moveTo(x + r, y)
+    ctx.arcTo(x + w, y,     x + w, y + h, r)
+    ctx.arcTo(x + w, y + h, x,     y + h, r)
+    ctx.arcTo(x,     y + h, x,     y,     r)
+    ctx.arcTo(x,     y,     x + w, y,     r)
+    ctx.closePath()
+  }
+
+  // Red corner triangle marking a value that fails its validation rule.
+  // Anchored top-LEFT to stay clear of the top-right comment triangle, so a
+  // cell with both a note and a bad value shows two distinct markers.
+  function _drawInvalidTriangle(x, y) {
+    const sz = 7
+    ctx.save()
+    ctx.fillStyle = COLORS.invalidMark
+    ctx.beginPath()
+    ctx.moveTo(x, y)
+    ctx.lineTo(x + sz, y)
+    ctx.lineTo(x, y + sz)
+    ctx.closePath()
+    ctx.fill()
+    ctx.restore()
+  }
+
   function _autoAlign(s) {
     return s !== '' && !isNaN(Number(s)) ? 'right' : 'left'
   }
 
   function _setCellFont(fmt) {
-    const weight = fmt.bold   ? 'bold'   : 'normal'
-    const style  = fmt.italic ? 'italic' : 'normal'
-    const fontPx = Math.max(8, Math.min(72, fmt.fontSize || 13))
-    const family = fmt.fontFamily || 'InterVar, Inter, ui-sans-serif, system-ui, sans-serif'
-    ctx.font      = `${style} ${weight} ${fontPx}px ${family}`
+    ctx.font      = chipFont(fmt)
     ctx.fillStyle = fmt.color || (fmt.hyperlink ? '#007BE0' : COLORS.cellText)
     ctx.textAlign = fmt.align || 'left'
   }

--- a/frontend/src/apps/sheets/canvas/renderer.js
+++ b/frontend/src/apps/sheets/canvas/renderer.js
@@ -14,7 +14,7 @@ export function createRenderer(ctx, geometry) {
   const cellPainter   = createCellPainter(ctx, geometry)
   const headerPainter = createHeaderPainter(ctx, geometry)
 
-  function render({ cssW, cssH, data, sel, selEnd, selMode = 'cell', editing, getFormat,
+  function render({ cssW, cssH, getValue, sel, selEnd, selMode = 'cell', editing, getFormat,
                     freeze: frz = { rows: 0, cols: 0 }, getMergeInfo, isSlave,
                     getComment = null, getValidation = null, getCondFormat = null,
                     getRightInset = null, getDiffFor = null,
@@ -33,7 +33,7 @@ export function createRenderer(ctx, geometry) {
     const c1s    = lastVisCol(c0s, cssW), r1s = lastVisRow(r0s, cssH)
     const range  = _selRange(sel, selEnd)
 
-    const state = { cssW, cssH, data, getFormat, getMergeInfo, isSlave,
+    const state = { cssW, cssH, getValue, getFormat, getMergeInfo, isSlave,
                     getComment, getValidation, getCondFormat, getRightInset,
                     getDiffFor,
                     editing, range, marchAnts, marchPhase, pickerRect }
@@ -57,7 +57,7 @@ export function createRenderer(ctx, geometry) {
 
   function _renderRegion(r0, c0, r1, c1, clipX, clipY, clipW, clipH, state) {
     if (clipW <= 0 || clipH <= 0 || r1 < r0 || c1 < c0) return
-    const { cssW, cssH, data, getFormat, getMergeInfo, isSlave,
+    const { cssW, cssH, getValue, getFormat, getMergeInfo, isSlave,
             getComment, getValidation, getCondFormat, getRightInset,
             getDiffFor,
             editing, range, marchAnts, marchPhase, pickerRect } = state
@@ -65,7 +65,7 @@ export function createRenderer(ctx, geometry) {
     ctx.beginPath(); ctx.rect(clipX, clipY, clipW, clipH); ctx.clip()
     if (!editing) selPainter.drawSelFill(range)
     gridPainter.drawGridLines(r0, c0, r1, c1, cssW, cssH)
-    cellPainter.drawRegionCells(r0, c0, r1, c1, data, getFormat, getMergeInfo, isSlave, getComment, getValidation, getCondFormat, getRightInset, getDiffFor)
+    cellPainter.drawRegionCells(r0, c0, r1, c1, getValue, getFormat, getMergeInfo, isSlave, getComment, getValidation, getCondFormat, getRightInset, getDiffFor)
     cellPainter.drawRegionBorders(r0, c0, r1, c1, getFormat, getMergeInfo, isSlave)
     if (marchAnts)  selPainter.drawMarchingAnts(marchAnts, marchPhase)
     if (pickerRect) selPainter.drawPickerRect(pickerRect)

--- a/frontend/src/apps/sheets/components/SheetEditor/AISettingsDialog.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/AISettingsDialog.vue
@@ -1,0 +1,158 @@
+<template>
+  <Dialog v-model="show" :options="{ title: 'AI Assist', size: 'md' }">
+    <template #body-content>
+
+      <!-- Inline error banner (permission / network failures). Auto-clears. -->
+      <Badge
+        v-if="errorMessage"
+        theme="red" variant="subtle" size="sm"
+        class="ai-error"
+        :label="errorMessage"
+        :tooltip="errorMessage"
+      />
+
+      <div v-if="loading" class="ai-loading"><Spinner size="sm" /></div>
+
+      <template v-else>
+        <p class="ai-help">
+          Lets people describe what they want in plain words and have it applied
+          to the grid. The API key is stored encrypted on the server and is
+          never sent back to the browser.
+        </p>
+
+        <!-- Enable toggle -->
+        <div class="ai-row">
+          <div class="ai-row-text">
+            <span class="ai-row-title">Enable AI Assist</span>
+            <span class="ai-row-sub">Show the “Ask” entry point for everyone on this site.</span>
+          </div>
+          <Switch v-model="enabled" />
+        </div>
+
+        <div class="ai-divider" />
+
+        <!-- API key -->
+        <p class="ai-label">Anthropic API key</p>
+        <FormControl
+          type="password"
+          :modelValue="apiKey"
+          :placeholder="keyIsSet ? '•••••••••• key on file — leave blank to keep' : 'sk-ant-...'"
+          autocomplete="off"
+          @update:modelValue="apiKey = $event"
+        />
+        <p v-if="keyIsSet" class="ai-key-state">A key is currently configured.</p>
+
+        <!-- Model -->
+        <p class="ai-label ai-label--gap">Model</p>
+        <FormControl
+          type="text"
+          :modelValue="model"
+          placeholder="claude-opus-4-8"
+          @update:modelValue="model = $event"
+        />
+        <p class="ai-key-state">
+          Tip: set this to <code>mock</code> for a keyless local demo — sums, averages,
+          counts, min/max/median, running totals, % of total, and text transforms
+          (uppercase, trim, first/last name, email domain) over a selection. No API key, no spend.
+        </p>
+      </template>
+
+    </template>
+
+    <template #actions>
+      <div class="flex flex-row-reverse gap-2">
+        <Button
+          variant="solid"
+          size="sm"
+          label="Save"
+          :loading="saving"
+          :disabled="loading || saving"
+          @click="save"
+        />
+        <Button variant="outline" size="sm" label="Cancel" @click="show = false" />
+      </div>
+    </template>
+  </Dialog>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { Badge, Switch, FormControl, Spinner } from 'frappe-ui'
+import { call } from '../../utils/api.js'
+
+const props = defineProps({
+  modelValue: { type: Boolean, default: false },
+})
+const emit = defineEmits(['update:modelValue', 'saved'])
+
+const show = computed({
+  get: () => props.modelValue,
+  set: (v) => emit('update:modelValue', v),
+})
+
+const loading  = ref(false)
+const saving   = ref(false)
+const enabled  = ref(false)
+const model    = ref('claude-opus-4-8')
+const apiKey   = ref('')          // only sent if the admin types a new key
+const keyIsSet = ref(false)       // whether a key is already on file (the real key is never fetched)
+
+const errorMessage = ref('')
+function _flashError(err) {
+  const msg = (err && err.message) ? String(err.message) : 'Something went wrong'
+  errorMessage.value = msg
+  setTimeout(() => { if (errorMessage.value === msg) errorMessage.value = '' }, 5000)
+}
+
+watch(show, async (open) => {
+  if (!open) return
+  errorMessage.value = ''
+  apiKey.value = ''
+  loading.value = true
+  try {
+    const s = await call('suite.sheets.api.get_ai_settings')
+    enabled.value  = !!s.enabled
+    model.value    = s.model || 'claude-opus-4-8'
+    keyIsSet.value = !!s.keyIsSet
+  } catch (err) {
+    _flashError(err)
+  } finally {
+    loading.value = false
+  }
+})
+
+async function save() {
+  saving.value = true
+  try {
+    const s = await call('suite.sheets.api.save_ai_settings', {
+      api_key: apiKey.value,                 // '' = keep existing key
+      enabled: enabled.value ? 1 : 0,
+      model: model.value || '',
+    })
+    keyIsSet.value = !!s.keyIsSet
+    emit('saved', s)
+    show.value = false
+  } catch (err) {
+    _flashError(err)
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<style scoped>
+.ai-error { display: block; margin: 0 0 12px; max-width: 100%; }
+.ai-loading { display: flex; justify-content: center; padding: 24px; }
+.ai-help { font-size: 13px; color: var(--ink-gray-6); margin: 0 0 16px; line-height: 1.5; }
+
+.ai-row { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.ai-row-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.ai-row-title { font-size: 13px; font-weight: 500; color: var(--ink-gray-9); }
+.ai-row-sub { font-size: 12px; color: var(--ink-gray-5); }
+
+.ai-divider { height: 1px; background: var(--outline-gray-1); margin: 16px 0; }
+
+.ai-label { font-size: 13px; font-weight: 500; color: var(--ink-gray-6); margin: 0 0 8px; }
+.ai-label--gap { margin-top: 16px; }
+.ai-key-state { font-size: 11px; color: var(--ink-gray-5); margin: 6px 0 0; }
+</style>

--- a/frontend/src/apps/sheets/components/SheetEditor/AskBar.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/AskBar.vue
@@ -1,0 +1,137 @@
+<template>
+  <div class="ab-wrap" @keydown.esc.stop="emit('close')">
+    <div class="ab-card">
+      <!-- Input row -->
+      <div class="ab-input-row">
+        <span class="ab-spark" aria-hidden="true">✨</span>
+        <input
+          ref="inputRef"
+          v-model="text"
+          type="text"
+          class="ab-input"
+          :placeholder="`Ask about ${selectionLabel || 'your selection'}…  e.g. “sum each column below”`"
+          :disabled="busy"
+          autocomplete="off"
+          @keydown.enter="onEnter"
+        />
+        <Spinner v-if="busy" size="sm" />
+        <Button
+          v-else
+          variant="solid"
+          size="sm"
+          label="Ask"
+          :disabled="!text.trim()"
+          @click="onEnter"
+        />
+        <button type="button" class="ab-close" aria-label="Close" @click="emit('close')">×</button>
+      </div>
+
+      <!-- Error -->
+      <Badge
+        v-if="error"
+        theme="red" variant="subtle" size="sm"
+        class="ab-msg"
+        :label="error"
+        :tooltip="error"
+      />
+
+      <!-- Read-only answer -->
+      <p v-if="answer" class="ab-answer">{{ answer }}</p>
+
+      <!-- Keep / Undo bar for an applied change -->
+      <div v-if="pending" class="ab-keep-row">
+        <span class="ab-keep-text">
+          Applied to {{ pending.count }} cell{{ pending.count === 1 ? '' : 's' }}.
+        </span>
+        <div class="ab-keep-actions">
+          <Button variant="ghost" size="sm" label="Undo" @click="emit('undo')" />
+          <Button variant="solid" size="sm" label="Keep" @click="emit('keep')" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, nextTick } from 'vue'
+import { Badge, Spinner } from 'frappe-ui'
+
+defineProps({
+  busy:           { type: Boolean, default: false },
+  selectionLabel: { type: String,  default: '' },
+  error:          { type: String,  default: '' },
+  answer:         { type: String,  default: '' },
+  // null, or { count } when a change has been applied and awaits Keep/Undo
+  pending:        { type: Object,  default: null },
+})
+const emit = defineEmits(['submit', 'close', 'keep', 'undo'])
+
+const text     = ref('')
+const inputRef = ref(null)
+
+function onEnter() {
+  const t = text.value.trim()
+  if (!t) return
+  emit('submit', t)
+}
+
+onMounted(async () => {
+  await nextTick()
+  inputRef.value?.focus()
+})
+</script>
+
+<style scoped>
+.ab-wrap {
+  /* Fixed below the topbar + toolbar (~92px) so it never depends on an
+     ancestor's positioning context. */
+  position: fixed;
+  top: 96px; left: 50%; transform: translateX(-50%);
+  z-index: 600; width: min(620px, calc(100vw - 32px));
+}
+.ab-card {
+  background: var(--surface-elevation-2, #fff);
+  border: 1px solid var(--outline-gray-2);
+  border-radius: 12px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, .16);
+  padding: 10px 12px;
+}
+.ab-input-row { display: flex; align-items: center; gap: 8px; }
+.ab-spark { font-size: 14px; line-height: 1; }
+.ab-input {
+  flex: 1; min-width: 0;
+  border: 0; background: transparent;
+  font-size: 14px; color: var(--ink-gray-9); padding: 6px 2px;
+}
+/* Strip the global focus ring/box-shadow some base styles add to inputs —
+   the bordered card is the container, the input itself stays borderless
+   (Espresso style). */
+.ab-input:focus,
+.ab-input:focus-visible {
+  outline: none !important;
+  box-shadow: none !important;
+  border: 0 !important;
+}
+.ab-input::placeholder { color: var(--ink-gray-4); }
+.ab-input:disabled { color: var(--ink-gray-5); }
+.ab-close {
+  border: 0; background: transparent; cursor: pointer;
+  font-size: 18px; line-height: 1; color: var(--ink-gray-5);
+  padding: 0 4px; border-radius: 4px;
+}
+.ab-close:hover { color: var(--ink-gray-8); background: var(--surface-gray-2); }
+
+.ab-msg { display: block; margin: 8px 0 0; max-width: 100%; }
+.ab-answer {
+  margin: 8px 2px 0; font-size: 13px; line-height: 1.5;
+  color: var(--ink-gray-8); white-space: pre-wrap;
+}
+
+.ab-keep-row {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 12px; margin-top: 10px; padding-top: 10px;
+  border-top: 1px solid var(--outline-gray-1);
+}
+.ab-keep-text { font-size: 13px; color: var(--ink-gray-6); }
+.ab-keep-actions { display: flex; gap: 8px; }
+</style>

--- a/frontend/src/apps/sheets/components/SheetEditor/ChartOverlay.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/ChartOverlay.vue
@@ -65,9 +65,10 @@ const props = defineProps({
   // (sourceSheet, sourceRange) → 2D matrix. Caller-owned so it can pull from
   // the sheet engine and re-derive on cell edits.
   getMatrix:    { type: Function, required: true },
-  // Bumps when the source data should be re-pulled (refresh). Part of the
-  // matrix cache key so position-only re-renders (drag/resize) reuse the
-  // cached matrix instead of re-materialising it every frame.
+  // Bumps when the source data should be re-pulled — on refresh and on any
+  // sheet cell edit, but NOT on drag/resize/scroll. Part of the matrix cache
+  // key so position-only re-renders (drag/resize) reuse the cached matrix
+  // instead of re-materialising it every frame, while edits refresh the chart.
   dataVersion:  { type: Number, default: 0 },
   selectedId:   { type: String, default: '' },
   // When true the whole overlay is hidden (e.g. while the chart dialog is

--- a/frontend/src/apps/sheets/components/SheetEditor/ChartOverlay.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/ChartOverlay.vue
@@ -65,6 +65,10 @@ const props = defineProps({
   // (sourceSheet, sourceRange) → 2D matrix. Caller-owned so it can pull from
   // the sheet engine and re-derive on cell edits.
   getMatrix:    { type: Function, required: true },
+  // Bumps when the source data should be re-pulled (refresh). Part of the
+  // matrix cache key so position-only re-renders (drag/resize) reuse the
+  // cached matrix instead of re-materialising it every frame.
+  dataVersion:  { type: Number, default: 0 },
   selectedId:   { type: String, default: '' },
   // When true the whole overlay is hidden (e.g. while the chart dialog is
   // open) — prevents the chart's z-indexed action toolbar from floating
@@ -84,8 +88,19 @@ function _hostStyle(chart) {
   }
 }
 
+// Cache the materialised matrix per chart, keyed by source + dataVersion. This
+// runs in the template, so it fires on every overlay re-render — including the
+// chartVersion bumps that move/resize trigger on each drag frame. Without the
+// cache, dragging a chart over a 100k-row source re-pulled the whole range
+// (and made ChartView rebuild the ECharts option) every mouse move.
+const _matrixCache = new Map()
 function _matrixFor(chart) {
-  return props.getMatrix(chart.sourceSheet, chart.sourceRange) || []
+  const key = `${chart.sourceSheet}\x00${chart.sourceRange}\x00${props.dataVersion}`
+  const hit = _matrixCache.get(chart.id)
+  if (hit && hit.key === key) return hit.matrix
+  const matrix = props.getMatrix(chart.sourceSheet, chart.sourceRange) || []
+  _matrixCache.set(chart.id, { key, matrix })
+  return matrix
 }
 
 // ── Drag (move) ──────────────────────────────────────────────────────────────

--- a/frontend/src/apps/sheets/components/SheetEditor/ColorPicker.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/ColorPicker.vue
@@ -1,0 +1,137 @@
+<!--
+  Frappe-styled colour picker, modelled on Gameplan's ColorPicker: a Popover
+  with a grid of round Tailwind-palette chips (one family per row, light→dark).
+  frappe-ui ships no reusable colour picker, so this replaces the bare
+  <input type="color"> (the OS dialog) everywhere in the editor.
+
+  Beyond Gameplan's grid we keep a Default/None reset and a hex + Custom row,
+  which a spreadsheet needs (clear text colour, no fill, arbitrary hex).
+
+  v-model is the colour as a literal #rrggbb, or '' for the default/unset state.
+  The trigger is a small swatch by default; pass a #trigger slot to supply your
+  own (the toolbar uses its glyph + underline button).
+-->
+<template>
+  <Popover :placement="placement">
+    <template #target="{ togglePopover, isOpen }">
+      <slot name="trigger" :toggle="togglePopover" :open="isOpen" :color="modelValue">
+        <button type="button" class="sn-cp-trigger" :class="{ open: isOpen }" :title="title" @click="togglePopover()">
+          <span class="sn-cp-trigger-sw" :style="{ background: isHex(modelValue) ? modelValue : 'transparent' }" />
+        </button>
+      </slot>
+    </template>
+    <template #body="{ close }">
+      <div class="sn-cp-pop">
+        <div class="sn-cp-grid">
+          <button v-for="c in COLORS" :key="c" type="button" class="sn-cp-sw"
+                  :class="{ sel: eqHex(c, modelValue) }" :style="{ background: c }" :title="c"
+                  @click="choose(c, close)">
+            <FeatherIcon v-if="eqHex(c, modelValue)" name="check" class="sn-cp-check" :style="{ color: contrast(c) }" />
+          </button>
+        </div>
+        <div class="sn-cp-foot">
+          <button v-if="allowDefault" type="button" class="sn-cp-iconbtn" :class="{ sel: !isHex(modelValue) }"
+                  :title="defaultLabel" @click="choose(defaultValue, close)">
+            <FeatherIcon name="slash" class="sn-cp-icon" />
+          </button>
+          <span class="sn-cp-hash">#</span>
+          <input class="sn-cp-hex" :value="hexBody" maxlength="6" placeholder="rrggbb" spellcheck="false"
+                 @input="hexBody = norm($event.target.value)"
+                 @keydown.enter.prevent="commitHex(close)" @blur="commitHex(null)" />
+          <label class="sn-cp-iconbtn" :title="`Custom colour`">
+            <FeatherIcon name="plus" class="sn-cp-icon" />
+            <input type="color" :value="nativeValue()" @input="choose($event.target.value, null)" />
+          </label>
+        </div>
+      </div>
+    </template>
+  </Popover>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import { Popover, FeatherIcon } from 'frappe-ui'
+
+// Tailwind palette, one family per row (50→900), flattened in row order so the
+// grid reads as 9 columns × 8 families — same source palette Gameplan uses.
+const PALETTE = {
+  gray:   ['#f3f4f6', '#e5e7eb', '#d1d5db', '#9ca3af', '#6b7280', '#4b5563', '#374151', '#1f2937', '#111827'],
+  red:    ['#fee2e2', '#fecaca', '#fca5a5', '#f87171', '#ef4444', '#dc2626', '#b91c1c', '#991b1b', '#7f1d1d'],
+  orange: ['#ffedd5', '#fed7aa', '#fdba74', '#fb923c', '#f97316', '#ea580c', '#c2410c', '#9a3412', '#7c2d12'],
+  yellow: ['#fef9c3', '#fef08a', '#fde047', '#facc15', '#eab308', '#ca8a04', '#a16207', '#854d0e', '#713f12'],
+  green:  ['#dcfce7', '#bbf7d0', '#86efac', '#4ade80', '#22c55e', '#16a34a', '#15803d', '#166534', '#14532d'],
+  teal:   ['#ccfbf1', '#99f6e4', '#5eead4', '#2dd4bf', '#14b8a6', '#0d9488', '#0f766e', '#115e59', '#134e4a'],
+  blue:   ['#dbeafe', '#bfdbfe', '#93c5fd', '#60a5fa', '#3b82f6', '#2563eb', '#1d4ed8', '#1e40af', '#1e3a8a'],
+  purple: ['#f3e8ff', '#e9d5ff', '#d8b4fe', '#c084fc', '#a855f7', '#9333ea', '#7e22ce', '#6b21a8', '#581c87'],
+  pink:   ['#fce7f3', '#fbcfe8', '#f9a8d4', '#f472b6', '#ec4899', '#db2777', '#be185d', '#9d174d', '#831843'],
+}
+const COLORS = Object.values(PALETTE).flat()
+
+const props = defineProps({
+  modelValue:   { type: String, default: '' },
+  allowDefault: { type: Boolean, default: false },
+  defaultValue: { type: String, default: '' },
+  defaultLabel: { type: String, default: 'Default' },
+  title:        { type: String, default: 'Colour' },
+  placement:    { type: String, default: 'bottom-start' },
+  // The native picker needs a literal hex even when modelValue is unset.
+  fallback:     { type: String, default: '#000000' },
+})
+const emit = defineEmits(['update:modelValue'])
+
+const isHex = v => typeof v === 'string' && /^#[0-9a-fA-F]{6}$/.test(v)
+const eqHex = (a, b) => isHex(a) && isHex(b) && a.toLowerCase() === b.toLowerCase()
+const norm  = s => s.replace(/[^0-9a-fA-F]/g, '').slice(0, 6)
+
+const nativeValue = () => isHex(props.modelValue) ? props.modelValue : (isHex(props.fallback) ? props.fallback : '#000000')
+
+// Editable hex field, kept in sync with the model.
+const hexBody = ref(isHex(props.modelValue) ? props.modelValue.slice(1) : '')
+watch(() => props.modelValue, v => { hexBody.value = isHex(v) ? v.slice(1) : '' })
+
+function choose(v, close) {
+  emit('update:modelValue', v)
+  if (close) close()
+}
+
+function commitHex(close) {
+  const h = hexBody.value
+  if (h.length !== 3 && h.length !== 6) return
+  const full = h.length === 3 ? h.split('').map(c => c + c).join('') : h
+  choose('#' + full.toLowerCase(), close)
+}
+
+// Readable ink for a chip background (dark on light, white on dark).
+function contrast(hex) {
+  if (!isHex(hex)) return '#1F2937'
+  const n = parseInt(hex.slice(1), 16)
+  const r = (n >> 16) & 255, g = (n >> 8) & 255, b = n & 255
+  return (0.299 * r + 0.587 * g + 0.114 * b) > 150 ? '#1F2937' : '#FFFFFF'
+}
+</script>
+
+<style scoped>
+.sn-cp-trigger { display:inline-flex; align-items:center; justify-content:center; width:28px; height:28px; border-radius:6px; border:1px solid var(--outline-gray-2); background:var(--surface-base); cursor:pointer; padding:0; }
+.sn-cp-trigger:hover, .sn-cp-trigger.open { background:var(--surface-gray-2); }
+.sn-cp-trigger-sw { width:16px; height:16px; border-radius:4px; border:1px solid var(--outline-gray-2); }
+
+/* Width pinned to the grid (9×20px chips + 8×6px gaps + 12px padding each side)
+   so the footer's hex input can't widen the popover past the swatches. */
+.sn-cp-pop { padding:12px; width:252px; background:var(--surface-elevation-2, #fff); border:1px solid var(--outline-elevation-2, var(--outline-gray-2)); border-radius:10px; box-shadow:0 6px 24px rgba(0,0,0,.14); }
+
+.sn-cp-grid { display:grid; grid-template-columns:repeat(9, 20px); gap:6px; justify-content:space-between; }
+.sn-cp-sw { width:20px; height:20px; border-radius:9999px; border:1px solid rgba(0,0,0,.10); cursor:pointer; padding:0; display:flex; align-items:center; justify-content:center; transition:transform .1s; }
+.sn-cp-sw:hover { transform:scale(1.18); }
+.sn-cp-sw.sel { box-shadow:0 0 0 2px var(--surface-base), 0 0 0 3.5px var(--outline-gray-5); }
+.sn-cp-check { width:11px; height:11px; }
+
+.sn-cp-foot { display:flex; align-items:center; gap:6px; margin-top:12px; }
+.sn-cp-hash { font-size:13px; color:var(--ink-gray-5); margin-left:2px; }
+.sn-cp-hex { flex:1; min-width:0; height:30px; padding:0 10px; font-size:13px; text-transform:uppercase; border:1px solid var(--outline-gray-2); border-radius:8px; color:var(--ink-gray-9); background:var(--surface-base); outline:none; }
+.sn-cp-hex:focus { border-color:var(--outline-gray-4); }
+.sn-cp-iconbtn { position:relative; display:inline-flex; align-items:center; justify-content:center; width:30px; height:30px; border-radius:8px; border:1px solid var(--outline-gray-2); cursor:pointer; color:var(--ink-gray-7); background:var(--surface-base); flex-shrink:0; }
+.sn-cp-iconbtn:hover { background:var(--surface-gray-2); }
+.sn-cp-iconbtn.sel { border-color:var(--outline-gray-4); color:var(--ink-gray-9); }
+.sn-cp-icon { width:15px; height:15px; pointer-events:none; }
+.sn-cp-iconbtn input[type=color] { position:absolute; inset:0; opacity:0; width:100%; height:100%; cursor:pointer; }
+</style>

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -1168,6 +1168,10 @@ const sheet = createSheet({
     // per-rule min/max stats — any cell change can shift those bounds, so the
     // cache must be cleared before the next paint.
     condFormat?.invalidate()
+    // A chart may source from this cell — bump the chart data version so the
+    // overlay's matrix cache re-pulls. Drag/resize/scroll don't fire cell-change
+    // callbacks, so those keep hitting the cache (the reason it exists).
+    chartDataVersion.value++
     if (showFormulas.value) {
       grid?.setCell(id, String(sheet.getCell(id) ?? ''))
       return
@@ -1186,6 +1190,9 @@ const sheet = createSheet({
   //     onCellsChanged at 181 ms self time after the snapshot fix.
   onCellsChanged(_sheet, affected) {
     condFormat?.invalidate()
+    // Source data for any chart may have moved — invalidate the overlay's matrix
+    // cache (kept stale on drag/scroll, which don't reach this callback).
+    chartDataVersion.value++
     if (!affected) { _repopulateGrid(); return }
     const sn = sheet.getCurrentSheet()
     for (const id of affected) {
@@ -1193,6 +1200,10 @@ const sheet = createSheet({
       const displayValue = sheet.getDisplayValue(id)
       grid?.setCell(id, fmt.numberFormat ? applyNumberFmt(displayValue, fmt.numberFormat) : displayValue)
     }
+    // A bulk edit (paste/fill) can change a pivot's source data; recompute so
+    // pivot output cells don't lag. affectsPivot() short-circuits when this
+    // sheet feeds no pivot, keeping the cheap incremental path cheap.
+    recomputePivotsForSheet(sn)
   },
 })
 const formats    = createFormatsEngine()
@@ -3655,7 +3666,8 @@ function doPasteSpecial(kind) {
     syncFlags()
   }
   isDirty.value = true
-  recomputePivotsForSheet(sheet.getCurrentSheet())
+  // Pivot recompute is handled centrally: the paste routed through
+  // batchSetCells, whose onCellsChanged callback recomputes affected pivots.
 }
 
 // Push the right history entry for a paste. Cell + format + validation

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -83,6 +83,19 @@
         </template>
       </div>
       <div class="sn-topbar-right">
+        <!-- AI Assist entry point — shown only when an admin has configured a
+             key and enabled it (gated server-side via the boot flag). -->
+        <template v-if="aiEnabled">
+          <Button
+            variant="ghost"
+            size="sm"
+            icon="lucide-sparkles"
+            label="Ask AI"
+            tooltip="Ask AI to work on your selection"
+            @click="openAskBar"
+          />
+          <span class="sn-topbar-divider" aria-hidden="true" />
+        </template>
         <Dropdown :options="fileDropdownOptions" placement="right">
           <template #default="{ open }">
             <Button :variant="open ? 'subtle' : 'ghost'" size="sm" iconLeft="file-text" iconRight="chevron-down" label="File" tooltip="Import / export" />
@@ -93,10 +106,13 @@
         <span class="sn-topbar-divider" aria-hidden="true" />
         <!-- Notes: button toggles the side panel listing all notes across sheets.
              Shift+F2 still opens the per-cell inline editor for quick capture. -->
-        <Button :variant="notesPanel.open ? 'subtle' : 'ghost'"
-                size="sm" icon="lucide-message-square"
-                :tooltip="`Notes${allNotes.length ? ` (${allNotes.length})` : ''} — Shift+F2 to add`"
-                @click="toggleNotesPanel" />
+        <span class="sn-notes-btn-wrap">
+          <Button :variant="notesPanel.open ? 'subtle' : 'ghost'"
+                  size="sm" icon="lucide-message-square"
+                  :tooltip="`Notes${allNotes.length ? ` (${allNotes.length})` : ''} — Shift+F2 to add`"
+                  @click="toggleNotesPanel" />
+          <span v-if="allNotes.length" class="sn-notes-badge">{{ allNotes.length > 9 ? '9+' : allNotes.length }}</span>
+        </span>
         <!-- Variant flips to "subtle" while the panel is open so the trigger
              reads as toggled, matching Frappe UI's standard toggle pattern. -->
         <Button :variant="vhOpen ? 'subtle' : 'ghost'"
@@ -198,20 +214,28 @@
           <Button :variant="open ? 'subtle' : 'ghost'" size="sm" :icon="hAlignIcon" tooltip="Alignment" />
         </template>
       </Dropdown>
-      <Tooltip text="Text colour">
-        <label class="sn-swatch-btn">
-          <FeatherIcon name="type" class="sn-swatch-glyph" />
-          <span class="sn-swatch-underline" :style="{ background: activeFormat.color || '#171717' }"></span>
-          <input name="text-color" type="color" title="" :value="activeFormat.color || '#171717'" @input="setColor('color', $event.target.value)" />
-        </label>
-      </Tooltip>
-      <Tooltip text="Fill colour">
-        <label class="sn-swatch-btn">
-          <FeatherIcon name="droplet" class="sn-swatch-glyph" />
-          <span class="sn-swatch-underline sn-swatch-fill" :style="{ background: activeFormat.backgroundColor || '#ffffff' }"></span>
-          <input name="fill-color" type="color" title="" :value="activeFormat.backgroundColor || '#ffffff'" @input="setColor('backgroundColor', $event.target.value)" />
-        </label>
-      </Tooltip>
+      <ColorPicker :model-value="activeFormat.color || ''" allow-default default-label="Default text color"
+                   title="Text colour" fallback="#171717" @update:model-value="setColor('color', $event)">
+        <template #trigger="{ toggle, open }">
+          <Tooltip text="Text colour">
+            <button type="button" class="sn-swatch-btn" :class="{ 'is-open': open }" @click="toggle()">
+              <FeatherIcon name="type" class="sn-swatch-glyph" />
+              <span class="sn-swatch-underline" :style="{ background: activeFormat.color || '#171717' }"></span>
+            </button>
+          </Tooltip>
+        </template>
+      </ColorPicker>
+      <ColorPicker :model-value="activeFormat.backgroundColor || ''" allow-default default-label="No fill"
+                   title="Fill colour" fallback="#ffffff" @update:model-value="setColor('backgroundColor', $event)">
+        <template #trigger="{ toggle, open }">
+          <Tooltip text="Fill colour">
+            <button type="button" class="sn-swatch-btn" :class="{ 'is-open': open }" @click="toggle()">
+              <FeatherIcon name="droplet" class="sn-swatch-glyph" />
+              <span class="sn-swatch-underline sn-swatch-fill" :style="{ background: activeFormat.backgroundColor || '#ffffff' }"></span>
+            </button>
+          </Tooltip>
+        </template>
+      </ColorPicker>
 
       <div class="sn-vr" />
 
@@ -330,11 +354,18 @@
         <Spinner class="sn-canvas-loading-spinner" />
       </div>
 
+<!-- Non-blocking spinner while a large pivot aggregates in the background. -->
+      <div v-if="pivotBuilding" class="sn-pivot-building" aria-busy="true">
+        <Spinner class="sn-canvas-loading-spinner" />
+        <span>Building pivot…</span>
+      </div>
+
 <!-- Floating charts (filtered to current sub-sheet by the overlay). -->
       <ChartOverlay
         :charts="chartList"
         :current-sheet="currentSheet"
         :get-matrix="getChartMatrix"
+        :data-version="chartDataVersion"
         :selected-id="selectedChartId"
         :suppressed="chartDialogOpen"
         @select="selectChart"
@@ -418,7 +449,7 @@
           class="sn-filter-btn"
           :class="{ active: filterConfig[col.col] }"
           :style="col.style"
-          @click="openFilterPanel(col.col, $event)"
+          @click="openFilterPanel(col.col)"
         >
           <FeatherIcon name="chevron-down" class="sn-filter-btn-icon" />
         </button>
@@ -460,7 +491,7 @@
 
       <!-- Inline filter panel — sort + condition + Google-Sheets-style
            "Filter by values" checklist with search and Select all/Clear. -->
-      <div v-if="filterPanel.open" class="sn-filter-panel" :style="filterPanel.style">
+      <div v-if="filterPanel.open" class="sn-filter-panel" :style="filterPanelStyle">
         <div class="sn-fp-title">Column {{ colLabel(filterPanel.col) }}</div>
         <div class="sn-fp-row">
           <Button class="sn-fp-grow" size="sm" iconLeft="arrow-up"   label="A → Z" tooltip="Sort ascending"  @click="doSort(filterPanel.col, 'asc')" />
@@ -560,6 +591,9 @@
 
     <!-- Bottom · sheet tabs + selection stats -->
     <div class="sn-bottom">
+      <!-- Pinned outside the scroll track so it stays reachable no matter
+           how many tabs there are. -->
+      <Button variant="ghost" size="sm" icon="plus" class="sn-tab-add" tooltip="Add sheet" @click="addSheet" />
       <div class="sn-tabs-track">
         <div
           v-for="name in sheetNames"
@@ -619,8 +653,6 @@
             >+{{ peersBySubSheet.get(name).length - 3 }}</span>
           </span>
         </div>
-
-        <Button variant="ghost" size="sm" icon="plus" class="sn-tab-add" tooltip="Add sheet" @click="addSheet" />
       </div>
 
       <div v-if="selectionStats" class="sn-stats">
@@ -762,6 +794,23 @@
       :sheet-title="currentTitle"
       :owner-id="userEmail"
       @shares-changed="shareCount = $event"
+    />
+
+    <!-- AI Assist settings (in-app, never the desk form) -->
+    <AISettingsDialog v-model="aiSettingsOpen" @saved="onAiSettingsSaved" />
+
+    <!-- AI Assist "Ask" command bar -->
+    <AskBar
+      v-if="askOpen"
+      :busy="askBusy"
+      :selection-label="askSelectionLabel"
+      :error="askError"
+      :answer="askAnswer"
+      :pending="aiPending"
+      @submit="onAskSubmit"
+      @keep="onAskKeep"
+      @undo="onAskUndo"
+      @close="closeAskBar"
     />
 
     <!-- Find & Replace panel -->
@@ -924,8 +973,15 @@
     <div v-if="dropdownPanel.open" class="sn-dropdown-panel"
          :style="{ left: dropdownPanel.x + 'px', top: dropdownPanel.y + 'px', minWidth: dropdownPanel.w + 'px' }">
       <div v-for="opt in dropdownPanel.options" :key="opt"
-           class="sn-dropdown-opt" @mousedown.prevent="pickDropdownOption(opt)">
-        {{ opt }}
+           class="sn-dropdown-opt" :class="{ 'is-active': opt === dropdownPanel.value }"
+           @mousedown.prevent="pickDropdownOption(opt)">
+        <FeatherIcon name="check" class="sn-dropdown-check" :style="{ visibility: opt === dropdownPanel.value ? 'visible' : 'hidden' }" />
+        <span class="sn-dropdown-chip" :style="{ background: chipColor(opt) }">{{ opt }}</span>
+      </div>
+      <div v-if="dropdownPanel.value" class="sn-dropdown-opt sn-dropdown-clear"
+           @mousedown.prevent="pickDropdownOption('')">
+        <FeatherIcon name="x" class="sn-dropdown-check" />
+        <span class="sn-dropdown-label">Clear</span>
       </div>
     </div>
 
@@ -958,16 +1014,22 @@
             <FormControl v-if="cfDialog.condType === 'between'"
                          v-model="cfDialog.condValue2" label="And" placeholder="e.g. 100" />
             <div class="sn-cf-fmt">
-              <label class="sn-swatch-btn" title="Text colour">
-                <FeatherIcon name="type" class="sn-swatch-glyph" />
-                <span class="sn-swatch-underline" :style="{ background: cfDialog.fmtColor || '#171717' }"></span>
-                <input name="cf-text-color" type="color" :value="cfDialog.fmtColor || '#171717'" @input="cfDialog.fmtColor = $event.target.value" />
-              </label>
-              <label class="sn-swatch-btn" title="Fill colour">
-                <FeatherIcon name="droplet" class="sn-swatch-glyph" />
-                <span class="sn-swatch-underline sn-swatch-fill" :style="{ background: cfDialog.fmtBg || '#ffffff' }"></span>
-                <input name="cf-fill-color" type="color" :value="cfDialog.fmtBg || '#ffffff'" @input="cfDialog.fmtBg = $event.target.value" />
-              </label>
+              <ColorPicker v-model="cfDialog.fmtColor" allow-default default-label="Automatic" title="Text colour" fallback="#171717">
+                <template #trigger="{ toggle, open }">
+                  <button type="button" class="sn-swatch-btn" :class="{ 'is-open': open }" title="Text colour" @click="toggle()">
+                    <FeatherIcon name="type" class="sn-swatch-glyph" />
+                    <span class="sn-swatch-underline" :style="{ background: cfDialog.fmtColor || '#171717' }"></span>
+                  </button>
+                </template>
+              </ColorPicker>
+              <ColorPicker v-model="cfDialog.fmtBg" allow-default default-label="No fill" title="Fill colour" fallback="#ffffff">
+                <template #trigger="{ toggle, open }">
+                  <button type="button" class="sn-swatch-btn" :class="{ 'is-open': open }" title="Fill colour" @click="toggle()">
+                    <FeatherIcon name="droplet" class="sn-swatch-glyph" />
+                    <span class="sn-swatch-underline sn-swatch-fill" :style="{ background: cfDialog.fmtBg || '#ffffff' }"></span>
+                  </button>
+                </template>
+              </ColorPicker>
               <span class="sn-cf-fmt-label">Apply to range: {{ cfRangeLabel }}</span>
             </div>
           </template>
@@ -976,18 +1038,18 @@
           <template v-else-if="cfDialog.kind === 'color-scale'">
             <FormControl type="select" label="Variant" v-model="cfDialog.scaleVariant" :options="CF_SCALE_VARIANT_OPTIONS" />
             <div class="sn-cf-scale">
-              <label class="sn-cf-stop">
+              <div class="sn-cf-stop">
                 <span>Min</span>
-                <input name="cf-scale-min" type="color" v-model="cfDialog.scaleMin" />
-              </label>
-              <label v-if="cfDialog.scaleVariant === '3color'" class="sn-cf-stop">
+                <ColorPicker v-model="cfDialog.scaleMin" title="Min colour" :fallback="cfDialog.scaleMin" />
+              </div>
+              <div v-if="cfDialog.scaleVariant === '3color'" class="sn-cf-stop">
                 <span>Mid</span>
-                <input name="cf-scale-mid" type="color" v-model="cfDialog.scaleMid" />
-              </label>
-              <label class="sn-cf-stop">
+                <ColorPicker v-model="cfDialog.scaleMid" title="Mid colour" :fallback="cfDialog.scaleMid" />
+              </div>
+              <div class="sn-cf-stop">
                 <span>Max</span>
-                <input name="cf-scale-max" type="color" v-model="cfDialog.scaleMax" />
-              </label>
+                <ColorPicker v-model="cfDialog.scaleMax" title="Max colour" :fallback="cfDialog.scaleMax" />
+              </div>
             </div>
             <div
               class="sn-cf-scale-preview"
@@ -1000,10 +1062,10 @@
 
           <!-- Data bars: horizontal bar inside each cell, proportional to value. -->
           <template v-else-if="cfDialog.kind === 'data-bar'">
-            <label class="sn-cf-stop">
+            <div class="sn-cf-stop">
               <span>Bar colour</span>
-              <input name="cf-bar-color" type="color" v-model="cfDialog.barColor" />
-            </label>
+              <ColorPicker v-model="cfDialog.barColor" title="Bar colour" :fallback="cfDialog.barColor" />
+            </div>
             <div class="sn-cf-bar-preview">
               <div class="sn-cf-bar-row" v-for="t in [0.25, 0.5, 0.85]" :key="t">
                 <div class="sn-cf-bar-fill" :style="{ width: (t * 100) + '%', background: cfDialog.barColor }" />
@@ -1037,6 +1099,7 @@
 import { h, ref, reactive, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { createGrid }          from '../../canvas/index.js'
 import { colLabel, parseCellId, cellId } from '../../utils/cells.js'
+import { call } from '../../utils/api.js'
 import { parseNumberFmt, buildNumberFmt, applyNumberFmt } from '../../utils/format-number.js'
 import { getTextWrap } from '../../utils/text-wrap.js'
 import { computeFillDown, computeFillRight } from '../../engine/fill-series.js'
@@ -1045,11 +1108,13 @@ import { adjustFormula }                    from '../../engine/formula-adjust.js
 import { createSheet }         from '../../engine/sheet.js'
 import { createHistory }       from '../../engine/history.js'
 import { createFormatsEngine } from '../../engine/formats.js'
+import { formatScope }         from '../../engine/format-scope.js'
 import { createMergeEngine }   from '../../engine/merge.js'
 import { createClipboard }     from '../../engine/clipboard.js'
 import { createSortFilter }    from '../../engine/sortFilter.js'
 import { createCommentsEngine }  from '../../engine/comments.js'
 import { createValidationEngine } from '../../engine/validation.js'
+import { chipColor } from '../../canvas/chip-geometry.js'
 import { createCondFormatEngine } from '../../engine/cond-format.js'
 import { useToolbar }          from './useToolbar.js'
 import { usePersistence }      from './usePersistence.js'
@@ -1071,7 +1136,10 @@ import VersionPreviewBanner    from './VersionPreviewBanner.vue'
 import CellHistoryPopover      from './CellHistoryPopover.vue'
 import SplitTextPopover        from './SplitTextPopover.vue'
 import ShareDialog             from './ShareDialog.vue'
+import AISettingsDialog        from './AISettingsDialog.vue'
+import AskBar                  from './AskBar.vue'
 import PivotDialog             from './PivotDialog.vue'
+import ColorPicker             from './ColorPicker.vue'
 import { createPivotEngine } from '../../engine/pivot.js'
 import { createChartEngine } from '../../engine/charts.js'
 import { useChartIntegration } from './useChartIntegration.js'
@@ -1142,7 +1210,13 @@ const sortFilter = createSortFilter(sheet)
 const comments   = createCommentsEngine()
 const validation = createValidationEngine()
 const condFormat = createCondFormatEngine()
-const clipboard  = createClipboard({ sheet, formats, condFormat, validation })
+const clipboard  = createClipboard({
+  sheet, formats, condFormat, validation,
+  // Late-bound to the pivot integration (declared below). Only invoked at
+  // copy/paste time, long after setup runs, so the forward reference is safe.
+  getPivotAt: (sel, sn) => getPivotAt(sel, sn),
+  createPivotFromPaste: (blob, anchorId, sn) => createPastedPivot(blob, anchorId, sn),
+})
 const pivot      = createPivotEngine()
 const charts     = createChartEngine()
 // Named ranges: the validator hook prevents users from defining names that
@@ -1261,14 +1335,22 @@ const history = createHistory({
   // so the full paste effect (values + formats + validation) round-trips
   // through undo/redo without the 320 ms snapshot tax.
   revertOp(op) {
+    // Structural op: undo of "add sheet" is just deleting the (empty) sheet.
+    if (op.opType === 'sheet_add') { _deleteSheet(op.name); return }
     _applyCellMap(op.before, op.subSheet)
     if (op.beforeFormats)    _applyFormatMap(op.beforeFormats, op.subSheet)
+    if (op.beforeCols)       _applyAxisFormatMap('col', op.beforeCols, op.subSheet)
+    if (op.beforeRows)       _applyAxisFormatMap('row', op.beforeRows, op.subSheet)
     if (op.beforeValidation) _applyValidationMap(op.beforeValidation, op.subSheet)
     if (op.beforeMerge)      { merge.restore(op.beforeMerge); grid?.render?.() }
   },
   applyOp(op) {
+    // Structural op: redo of "add sheet" recreates the same empty sheet.
+    if (op.opType === 'sheet_add') { _addSheet(op.name); return }
     _applyCellMap(op.after, op.subSheet)
     if (op.afterFormats)    _applyFormatMap(op.afterFormats, op.subSheet)
+    if (op.afterCols)       _applyAxisFormatMap('col', op.afterCols, op.subSheet)
+    if (op.afterRows)       _applyAxisFormatMap('row', op.afterRows, op.subSheet)
     if (op.afterValidation) _applyValidationMap(op.afterValidation, op.subSheet)
     if (op.afterMerge)      { merge.restore(op.afterMerge); grid?.render?.() }
   },
@@ -1316,6 +1398,17 @@ function _applyFormatMap(map, sheetName) {
     const dv = sheet.getDisplayValue(id, sn)
     grid?.setCell(id, f.numberFormat ? applyNumberFmt(dv, f.numberFormat) : dv)
   }
+}
+
+// Apply a { colIdx|rowIdx: format|null } diff to the column or row format
+// layer (undo/redo of range-level formatting). Exact replacement, so undo
+// restores the captured layer precisely. One render covers the whole axis.
+function _applyAxisFormatMap(axis, map, sheetName) {
+  if (!map) return
+  const sn = sheetName || sheet.getCurrentSheet()
+  const replace = axis === 'col' ? formats.replaceCol : formats.replaceRow
+  for (const [k, fmt] of Object.entries(map)) replace(+k, fmt || {}, sn)
+  grid?.render?.()
 }
 
 function _applyValidationMap(map, sheetName) {
@@ -1442,7 +1535,7 @@ const commentPanel  = reactive({ open: false, id: '', text: '', x: 0, y: 0 })
 const notesPanel = reactive({ open: false, rev: 0 })
 
 // ── Dropdown (validation) UI state ────────────────────────────────────────────
-const dropdownPanel    = reactive({ open: false, id: '', options: [], x: 0, y: 0, w: 120 })
+const dropdownPanel    = reactive({ open: false, id: '', options: [], value: '', x: 0, y: 0, w: 120 })
 const validationDialog = reactive({
   open: false,
   type:     'list',      // 'list' | 'number' | 'text_length'
@@ -1608,7 +1701,136 @@ const fileDropdownOptions = computed(() => [
     { label: 'Import CSV',  icon: 'upload', onClick: () => csvInputRef.value?.click() },
     { label: 'Import XLSX', icon: 'upload', onClick: () => xlsxInputRef.value?.click() },
   ]},
+  // Only shown to admins — gated server-side via the boot flag so non-admins
+  // never see a settings entry they can't use.
+  ...(window.frappe?.boot?.ai_assist_can_configure
+    ? [{ group: 'AI', items: [
+        { label: 'AI settings', icon: 'cpu', onClick: () => { aiSettingsOpen.value = true } },
+      ]}]
+    : []),
 ])
+
+// ── AI Assist ─────────────────────────────────────────────────────────────────
+//
+// One primitive: select → ask in plain words → see it applied → Keep or Undo.
+// The backend returns a validated action plan; the model emits formulas, the
+// engine computes. Applying goes through the same pushOp + _queueOp path that
+// fill/paste use, so a single Undo reverts the whole batch and the change
+// joins the existing op-log / autosave / collab pipeline.
+
+const aiEnabled  = ref(!!window.frappe?.boot?.ai_assist_enabled)
+const askOpen    = ref(false)
+const askBusy    = ref(false)
+const askError   = ref('')
+const askAnswer  = ref('')
+const aiPending  = ref(null)              // null | { count }
+const askSelectionLabel = ref('')
+
+// After saving AI settings, refresh the boot flag + reactive ref in-place so
+// the "Ask" entry point appears/disappears without a full reload.
+function onAiSettingsSaved(s) {
+  // The keyless "mock"/"demo" model counts as configured too.
+  const isMock = ['mock', 'demo'].includes(String(s?.model || '').trim().toLowerCase())
+  const on = !!(s?.enabled && (s?.keyIsSet || isMock))
+  if (window.frappe?.boot) window.frappe.boot.ai_assist_enabled = on
+  aiEnabled.value = on
+}
+
+function openAskBar() {
+  askError.value = ''
+  askAnswer.value = ''
+  aiPending.value = null
+  askSelectionLabel.value = grid?.getActiveCell?.() || ''
+  askOpen.value = true
+}
+
+function closeAskBar() {
+  // Closing with a pending change is an implicit Keep — it's already applied
+  // and queued.
+  askOpen.value = false
+  askError.value = ''
+  askAnswer.value = ''
+  aiPending.value = null
+}
+
+async function onAskSubmit(promptText) {
+  askError.value = ''
+  askAnswer.value = ''
+  aiPending.value = null
+  askBusy.value = true
+  try {
+    const sel = grid?.getSelection?.() || { r0: 0, c0: 0, r1: 0, c1: 0 }
+    const selection = JSON.stringify({
+      sheet:  sheet.getCurrentSheet(),
+      r0: sel.r0, c0: sel.c0, r1: sel.r1, c1: sel.c1,
+      active: grid?.getActiveCell?.() || '',
+    })
+    const res = await call('suite.sheets.api.ai_assist', {
+      name: props.id, prompt: promptText, selection,
+    })
+    const actions = Array.isArray(res?.actions) ? res.actions : []
+    const answers = actions.filter(a => a.type === 'answer')
+    if (answers.length) askAnswer.value = answers.map(a => a.text).join('\n\n')
+    const applied = _applyAiActions(actions)
+    if (applied > 0) aiPending.value = { count: applied }
+    else if (!answers.length) askAnswer.value = 'No changes suggested for that.'
+  } catch (e) {
+    askError.value = (e && e.message) ? String(e.message) : 'Something went wrong'
+  } finally {
+    askBusy.value = false
+  }
+}
+
+// Apply setCell actions as ONE undoable op (mirrors the fill/paste path).
+// Returns the number of cells written.
+function _applyAiActions(actions) {
+  const sn = sheet.getCurrentSheet()
+  const setCells = actions.filter(a => a.type === 'setCell')
+  if (!setCells.length) return 0
+
+  const before = {}
+  const after  = {}
+  for (const a of setCells) before[a.cell] = sheet.getCell(a.cell, sn) ?? ''
+  for (const a of setCells) {
+    sheet.setCell(a.cell, a.formula, sn)
+    after[a.cell] = a.formula
+  }
+  const refs = setCells.map(a => a.cell)
+
+  // Undo (op-based, like fill) + server sync (op-log on next save).
+  history.pushOp({ opType: 'ai_assist', subSheet: sn, cellRefs: refs, before, after })
+  _queueOp({
+    opType: 'ai_assist', subSheet: sn, cellRefs: refs, before, after,
+    summary: `AI: ${refs.length} cell${refs.length === 1 ? '' : 's'}`,
+  })
+
+  grid?.render()
+  refreshActiveFormat()
+  syncFlags()
+  isDirty.value = true
+  return refs.length
+}
+
+function onAskKeep() {
+  // Already applied + queued; just dismiss and close.
+  closeAskBar()
+}
+
+function onAskUndo() {
+  // Reverts the whole batch in one step (single op). Drop the still-queued
+  // op so a stale ai_assist entry isn't persisted on the next save.
+  undo()
+  _popLastOp('ai_assist')
+  aiPending.value = null
+}
+
+// Remove the most recently queued op of a given type (used when an AI change
+// is undone before it has been flushed to the server).
+function _popLastOp(opType) {
+  for (let i = _opQueue.length - 1; i >= 0; i--) {
+    if (_opQueue[i].opType === opType) { _opQueue.splice(i, 1); return }
+  }
+}
 
 const hAlignIcon = computed(() => {
   if (activeFormat.value?.align === 'center') return 'align-center'
@@ -1664,16 +1886,15 @@ onMounted(() => {
 // Collaboration — presence + sharing
 const shareOpen   = ref(false)
 const shareCount  = ref(0)   // explicit share count (excluding owner); updated by ShareDialog
+const aiSettingsOpen = ref(false)
 const { exportCSV, exportXLSX, exportPDF, importCSV, importXLSX } = useExportImport({
   getSheet:        () => sheet,
   getCurrentTitle: () => currentTitle.value,
   getGrid:         () => grid,
   queueOp:         _queueOp,
-  markEdited,
   repopulateGrid:  _repopulateGrid,
   syncFlags,
   isDirty,
-  history,
 })
 
 // Filter panel state.
@@ -1685,7 +1906,7 @@ const { exportCSV, exportXLSX, exportPDF, importCSV, importXLSX } = useExportImp
 //   - allValues: distinct displayed values in the column's data range, cached
 //     while the panel is open so we don't recompute on every keystroke.
 const filterPanel = reactive({
-  open: false, col: 0, style: {},
+  open: false, col: 0,
   mode: 'values',
   operator: 'contains', value: '',
   valueSet: new Set(),
@@ -1772,28 +1993,51 @@ function selectionIds() {
 // a 5×5 selection that's 25 reads instead of 25k. Worst case is Ctrl+A
 // (whole sheet) which is the same as before. RAF-coalesced so a drag-
 // extend that fires onSelect 1000× still computes stats once per frame.
+// Stats run ASYNC and chunked. Selecting to the end of a big sheet
+// (Cmd+Shift+Down → ~2M cells) used to compute Count/Sum/Avg synchronously in
+// one RAF, freezing the interaction for ~6s. The status bar is a non-critical
+// readout, so we yield every CHUNK_CELLS and bail the instant a newer
+// selection supersedes us — the selection paints immediately and the numbers
+// fill in a moment later.
+const _STATS_CHUNK_CELLS = 50000
 let _statsRAF = null
+let _statsToken = 0
 function computeSelectionStats() {
-  if (_statsRAF) return
+  _statsToken++
+  if (_statsRAF) cancelAnimationFrame(_statsRAF)
+  const token = _statsToken
   _statsRAF = requestAnimationFrame(() => {
     _statsRAF = null
-    _computeSelectionStatsNow()
+    _computeSelectionStatsAsync(token)
   })
 }
-function _computeSelectionStatsNow() {
+async function _computeSelectionStatsAsync(token) {
   if (!grid) return
   const { r0, c0, r1, c1 } = grid.getSelection()
   if ((r1 - r0 + 1) * (c1 - c0 + 1) <= 1) { selectionStats.value = null; return }
   const sn = sheet.getCurrentSheet()
-  let count = 0, numCount = 0, sum = 0
+  // Precompute column labels once instead of rebuilding each cell id's prefix
+  // 2M times (colLabel walks characters per call).
+  const labels = []
+  for (let c = c0; c <= c1; c++) labels.push(colLabel(c))
+  const rowWidth = c1 - c0 + 1
+  let count = 0, numCount = 0, sum = 0, since = 0
   for (let r = r0; r <= r1; r++) {
+    const rowSuffix = r + 1
     for (let c = c0; c <= c1; c++) {
-      const val = sheet.getCell(cellId(r, c), sn)
+      const val = sheet.getCell(labels[c - c0] + rowSuffix, sn)
       if (val !== '' && val != null) count++
       const n = parseFloat(val)
       if (!isNaN(n)) { numCount++; sum += n }
     }
+    since += rowWidth
+    if (since >= _STATS_CHUNK_CELLS) {
+      since = 0
+      await new Promise(res => setTimeout(res, 0))
+      if (token !== _statsToken) return   // a newer selection took over
+    }
   }
+  if (token !== _statsToken) return
   selectionStats.value = (count === 0 && numCount === 0) ? null : {
     count,
     sum:  numCount > 0 ? sum : null,
@@ -1816,6 +2060,7 @@ function formatStat(n) {
 function adjustDecimals(delta) {
   const ids = selectionIds()
   const sh = sheet.getCurrentSheet()
+  _recordFormatOp(ids, sh, () => {
   for (const id of ids) {
     const cur = formats.get(id, sh).numberFormat || ''
     let { type, variant, decimals } = parseNumberFmt(cur)
@@ -1832,7 +2077,7 @@ function adjustDecimals(delta) {
     const raw = sheet.getDisplayValue(id)
     grid?.setCell(id, applyNumberFmt(raw, next))
   }
-  history.push()   // post-mutate snapshot
+  })
   _syncNumberFormat(activeCell.value)
   syncFlags()
   isDirty.value = true
@@ -1842,7 +2087,15 @@ function adjustDecimals(delta) {
 // ── Composables ───────────────────────────────────────────────────────────────
 
 const { activeFormat, refreshActiveFormat, toggleFmt, setAlign, setValign, setColor, clearFormatting, getLastAction, recordAction } =
-  useToolbar({ sheet, formats, getGrid: () => grid, history, selectionIds, syncFlags, markDirty: () => { isDirty.value = true } })
+  useToolbar({ sheet, formats, getGrid: () => grid, history, selectionIds, getScope: _selectionScope, syncFlags, markDirty: () => { isDirty.value = true } })
+
+// Selection + grid bounds, so full-column / full-row / whole-sheet selections
+// format at the column/row level (one entry) instead of per cell. Null when
+// the grid isn't mounted yet → callers fall back to per-cell.
+function _selectionScope() {
+  if (!grid) return null
+  return { rect: grid.getSelection(), totalRows: grid.getTotalRows(), totalCols: grid.getTotalCols() }
+}
 
 // Toolbar dropdown configs that don't depend on pivot composable.
 function toggleSortFilter() { showSortFilter.value = !showSortFilter.value }
@@ -2016,12 +2269,12 @@ const renderVersion = ref(0)
 
 // Pivot integration — placed here because switchSheet/syncNames come from useSheetTabs above.
 const {
-  pivotDialogOpen, pivotInitialRange, pivotEditId, pivotEditConfig, pivotVersion,
+  pivotDialogOpen, pivotInitialRange, pivotEditId, pivotEditConfig, pivotVersion, pivotBuilding,
   activePivotConfig, pivotFabStyle, pivotHighlightStyle, pivotBannerMenuOptions,
   isPivotSheet, openPivotDialog, onPivotEdit, onPivotRefresh, onPivotDelete, onPivotConfirm,
-  recomputePivotsForSheet,
+  recomputePivotsForSheet, drillDownAt, getPivotAt, createPastedPivot,
 } = usePivotIntegration({
-  pivot, sheet, formats, currentSheet, renderVersion,
+  pivot, sheet, formats, currentSheet, activeCell, renderVersion,
   getGrid: () => grid,
   contextMenu, switchSheet, syncNames,
   history, isDirty, repopulateGrid: _repopulateGrid,
@@ -2032,7 +2285,7 @@ const {
 // sheet engine, so any cell edit propagates without explicit refresh calls.
 const {
   chartDialogOpen, chartInitialRange, chartEditId, chartEditConfig,
-  charts: chartList, selectedChartId, chartVersion,
+  charts: chartList, selectedChartId, chartVersion, chartDataVersion,
   openInsert: openChartDialog, openEdit: openChartEdit,
   onChartConfirm, onChartDelete, onChartMove, onChartResize, onChartRefresh,
   selectChart, getMatrix: getChartMatrix,
@@ -2123,7 +2376,14 @@ const showSortFilter = computed({
   set(v) { v ? _createFilterOnSelection() : _removeFilter() },
 })
 
-function addSheet() { _addSheet(); history.push(); isDirty.value = true }
+// Adding a sheet used to push a full-workbook snapshot (history.push deep-clones
+// every cell of every sheet — ~2s on a large workbook). The new sheet is empty,
+// so undo/redo only needs its name: a cheap structural op instead of a snapshot.
+function addSheet() {
+  const name = _addSheet()
+  history.pushOp({ opType: 'sheet_add', subSheet: name, name })
+  isDirty.value = true
+}
 
 // ── Sheet-tab click — cross-sheet picker support ──────────────────────────────
 // When the user is mid-edit in the formula bar (`=…` content + bar has focus),
@@ -2249,6 +2509,26 @@ const visibleFilterCols = computed(() => {
       height: BTN + 'px',
     },
   }))
+})
+
+// Live position for the open filter panel. Recomputed on every canvas render
+// (renderVersion) so the panel tracks its column as the grid scrolls, anchored
+// to the column's chevron just like visibleFilterCols. Returns display:none when
+// the column scrolls out of the visible header range so the panel hides instead
+// of floating over unrelated columns; it reappears when scrolled back into view.
+const filterPanelStyle = computed(() => {
+  renderVersion.value
+  if (!filterPanel.open || !grid || !filterRange.value) return { display: 'none' }
+  const { r0 } = filterRange.value
+  const colRect = grid.getColumnHeaderRects().find(({ c }) => c === filterPanel.col)
+  const rowRect = grid.getRowRect(r0)
+  if (!colRect || !rowRect) return { display: 'none' }
+  const BTN = 16
+  const wrapW = gridWrapRef.value?.getBoundingClientRect().width ?? Infinity
+  return {
+    top:  (rowRect.y + rowRect.height + 2) + 'px',
+    left: clampFilterLeft(colRect.x + colRect.width - BTN - 3, wrapW) + 'px',
+  }
 })
 
 // Per-sub-sheet peer dots — small colored circles next to each tab label
@@ -2677,6 +2957,16 @@ function _setupGridInstance() {
       formulaValue.value = sheet.getCell(id)
     },
     getFormat:    id => formats.get(id, sheet.getCurrentSheet()),
+    // Lazy render value source (Phase 1, off by default). Mirrors exactly what
+    // _repopulateGrid / onCellChanged bake into the grid's eager `data` cache,
+    // so the lazy and eager render paths produce identical pixels. When enabled
+    // (grid.setLazyValues(true)), the grid pulls this per visible cell instead
+    // of materialising every cell up front.
+    getDisplay:   _cellDisplay,
+    // Non-empty cell ids for the current sheet — the lazy path's source for
+    // cold-path scans (Cmd+A extent, autofit) that used to walk the grid's
+    // own `data` keys.
+    getCellIds:   () => Object.keys(sheet.getRawData()),
     getMergeInfo: id => merge.getMasterInfo(id, sheet.getCurrentSheet()),
     isSlave:      id => merge.isSlave(id, sheet.getCurrentSheet()),
     getMasterId:  id => merge.getMasterId(id, sheet.getCurrentSheet()),
@@ -2696,6 +2986,7 @@ function _setupGridInstance() {
     },
     onHyperlinkClick(url) { window.open(url, '_blank', 'noopener,noreferrer') },
     onDropdownClick(id, rule, pos) { openDropdown(id, rule, pos) },
+    onPivotDrill(r, c) { return drillDownAt(r, c) },
     getSheetNames() { return sheetNames.value },
     // Cross-sheet picker — grid prefixes inserted refs with the current sheet
     // when it differs from the edit's home sheet. Home is null outside of an
@@ -2727,6 +3018,9 @@ function _setupGridInstance() {
       history.push()
       isDirty.value = true
     },
+    // Lazy render is the default; eager `data` cache stays as an opt-out
+    // fallback (`?lazy=0`). See _lazyValuesEnabled.
+    lazyValues: _lazyValuesEnabled(),
   })
   // Keep DOM overlays (filter chevrons) in sync with canvas scroll/resize/freeze.
   grid.onRender(() => { renderVersion.value++ })
@@ -2765,9 +3059,18 @@ async function _loadInitialData() {
     if (restored) {
       freezeRows.value = restored.freezeRows || 0
       freezeCols.value = restored.freezeCols || 0
-      manualHiddenRows.clear(); for (const r of (restored.hiddenRows || [])) manualHiddenRows.add(r)
+      // Legacy docs (saved before filter hides were split out of the view)
+      // baked the active sheet's filter rows into hiddenRows. Strip the
+      // sheet's current filter rows so they aren't mistaken for manual hides
+      // and re-applied to every sheet. Harmless for clean docs.
+      const filterHidden = new Set(sortFilter.computeHiddenRows(sheet.getCurrentSheet()))
+      manualHiddenRows.clear()
+      for (const r of (restored.hiddenRows || [])) if (!filterHidden.has(r)) manualHiddenRows.add(r)
       manualHiddenCols.clear(); for (const c of (restored.hiddenCols || [])) manualHiddenCols.add(c)
     }
+    // The view now holds manual hides only; re-apply the active sheet's filter
+    // so a saved filter still shows its hidden rows on first load.
+    _applyHiddenRows()
     syncNames()
     activeCell.value   = 'A1'
     formulaValue.value = sheet.getCell('A1')
@@ -2868,9 +3171,60 @@ function _captureFormatsRange(rect, sheetName) {
 	for (let r = rect.r0; r <= rect.r1; r++) {
 		for (let c = rect.c0; c <= rect.c1; c++) {
 			const id = cellId(r, c)
-			out[id] = formats.get(id, sn) || null
+			out[id] = formats.getCellFormat(id, sn) || null
 		}
 	}
+	return out
+}
+
+// Record a cell-level format change to `ids` as an op DIFF instead of a full
+// history.push() snapshot (the snapshot deep-clones every cell — ~2s on a
+// 2M-cell sheet, ×50 in the undo stack). Captures cell-LEVEL formats so undo
+// restores the cell layer without baking column/row formats into cells.
+// Used by handlers that must touch cells directly (number formats bake the
+// display string per cell). `mutate` runs between the before/after captures.
+function _recordFormatOp(ids, sn, mutate) {
+	const beforeFormats = {}
+	for (const id of ids) beforeFormats[id] = formats.getCellFormat(id, sn) || null
+	mutate()
+	const afterFormats = {}
+	for (const id of ids) afterFormats[id] = formats.getCellFormat(id, sn) || null
+	history.pushOp({ opType: 'format', subSheet: sn, beforeFormats, afterFormats })
+}
+
+// Scope-aware variant for VISUAL formats (font, size, painted format) that the
+// renderer resolves live via the column<row<cell cascade. Full-column /
+// full-row selections write one layer entry instead of per-cell records, so
+// "set font on the whole sheet" stays tiny and instant. `ops` supplies the
+// three mutation variants: { cols, rows, cells }.
+function _recordScopedFormatOp(ops) {
+	const sn = sheet.getCurrentSheet()
+	const info = _selectionScope()
+	const scope = info ? formatScope(info.rect, info.totalRows, info.totalCols) : { kind: 'cells' }
+	const op = { opType: 'format', subSheet: sn }
+	if (scope.kind === 'cols') {
+		op.beforeCols = _captureAxis('col', scope.cols, sn)
+		ops.cols(scope.cols, sn)
+		op.afterCols = _captureAxis('col', scope.cols, sn)
+	} else if (scope.kind === 'rows') {
+		op.beforeRows = _captureAxis('row', scope.rows, sn)
+		ops.rows(scope.rows, sn)
+		op.afterRows = _captureAxis('row', scope.rows, sn)
+	} else {
+		const ids = selectionIds()
+		op.beforeFormats = {}
+		for (const id of ids) op.beforeFormats[id] = formats.getCellFormat(id, sn) || null
+		ops.cells(ids, sn)
+		op.afterFormats = {}
+		for (const id of ids) op.afterFormats[id] = formats.getCellFormat(id, sn) || null
+	}
+	history.pushOp(op)
+}
+
+function _captureAxis(axis, keys, sn) {
+	const get = axis === 'col' ? formats.getCol : formats.getRow
+	const out = {}
+	for (const k of keys) out[k] = get(k, sn) || null
 	return out
 }
 
@@ -2885,6 +3239,30 @@ function _captureValidationRange(rect, sheetName) {
 		}
 	}
 	return out
+}
+
+// Every cell a paste can touch — used so the paste's before/after capture
+// (and thus undo) covers all of it:
+//   1. the destination selection (tiled pastes fill exactly this),
+//   2. the paste's output rect — anchor + buffer dimensions — so a single-cell
+//      selection still records the whole pasted block, and
+//   3. for a cut, the source range the paste vacates; its cells are cleared,
+//      and any outside the destination would otherwise be lost on undo.
+// Returns an array of rects; callers merge per-cell captures across them.
+// Must be called BEFORE clipboard.paste(), which consumes the cut buffer.
+function _pasteAffectedRects(destSel) {
+	const rects = destSel ? [destSel] : []
+	const src = clipboard.getSourceSel()
+	if (src) {
+		const anch = parseCellId(activeCell.value)
+		if (anch) rects.push({
+			r0: anch.row, c0: anch.col,
+			r1: anch.row + (src.r1 - src.r0),
+			c1: anch.col + (src.c1 - src.c0),
+		})
+		if (clipboard.getMode() === 'cut') rects.push(src)
+	}
+	return rects
 }
 
 // Diff two id→value maps, returning the ids whose value changed.  Used to
@@ -3175,20 +3553,38 @@ function onDocCut(e) {
   grid.setMarchingAnts(src)
   _pushEditOp(sn, before, 'Cut')
 }
-function onDocPaste(e) {
+async function onDocPaste(e) {
   if (!_canvasActive()) return
   e.preventDefault()
   const destSel = grid.getSelection()
   const sn = sheet.getCurrentSheet()
+
+  // Pasting a copied pivot mints a new live pivot at the anchor rather than
+  // writing cells, so the op-based cell-diff undo below can't capture it (it
+  // would leave the rendered cells without their _pivots registry entry).
+  // Await the async render, then take one full history.push() snapshot, which
+  // captures both the pivot registry and the written cells atomically.
+  if (clipboard.hasData() && clipboard.getPivotBlob?.()) {
+    await clipboard.paste(activeCell.value, () => {}, 'all', destSel)
+    clipboardHas.value = clipboard.hasData()
+    grid.setMarchingAnts(null)
+    history.push()
+    isDirty.value = true
+    return
+  }
+
   // Snapshot the pre-paste state for cells + formats + validation across
   // the destination rect, plus cond-format rule count for the fallback
   // decision. The cells+formats+validation diff drives op-based undo; if
   // the paste also added a cond-format rule, the rule list isn't part of
   // the op and we'd lose it on undo — fall back to a full snapshot in
   // that rarer case.
-  const before     = _captureRange(destSel, sn)
-  const beforeFmt  = _captureFormatsRange(destSel, sn)
-  const beforeVal  = _captureValidationRange(destSel, sn)
+  // Capture across everything the paste can touch (dest, full output block,
+  // and — for a cut — the vacated source) so undo restores all of it.
+  const rects      = _pasteAffectedRects(destSel)
+  const before     = Object.assign({}, ...rects.map(r => _captureRange(r, sn)))
+  const beforeFmt  = Object.assign({}, ...rects.map(r => _captureFormatsRange(r, sn)))
+  const beforeVal  = Object.assign({}, ...rects.map(r => _captureValidationRange(r, sn)))
   const cfBefore   = condFormat?.getRules?.(sn)?.length ?? 0
 
   let pasted = false
@@ -3207,14 +3603,14 @@ function onDocPaste(e) {
   clipboardHas.value = clipboard.hasData()
   grid.setMarchingAnts(null)
   if (pasted) {
-    // Refresh display strings for the dest range — the engine already
+    // Refresh display strings for every touched rect — the engine already
     // notified for cell-value changes, but format changes happened AFTER
     // batchSetCells so the canvas painted those cells with the old
-    // format. One pass over the rect catches up.
-    _refreshDisplayForRange(destSel, sn)
-    const after    = _captureRange(destSel, sn)
-    const afterFmt = _captureFormatsRange(destSel, sn)
-    const afterVal = _captureValidationRange(destSel, sn)
+    // format, and a cut's vacated source needs to repaint as empty.
+    for (const r of rects) _refreshDisplayForRange(r, sn)
+    const after    = Object.assign({}, ...rects.map(r => _captureRange(r, sn)))
+    const afterFmt = Object.assign({}, ...rects.map(r => _captureFormatsRange(r, sn)))
+    const afterVal = Object.assign({}, ...rects.map(r => _captureValidationRange(r, sn)))
     const cfAfter  = condFormat?.getRules?.(sn)?.length ?? 0
     const refs     = _diffRefs(before, after)
     if (refs.length || cfBefore !== cfAfter) {
@@ -3240,17 +3636,18 @@ function doPasteSpecial(kind) {
   if (!clipboard.hasData()) return
   const destSel = grid.getSelection()
   const sn = sheet.getCurrentSheet()
-  const before     = _captureRange(destSel, sn)
-  const beforeFmt  = _captureFormatsRange(destSel, sn)
-  const beforeVal  = _captureValidationRange(destSel, sn)
+  const rects      = _pasteAffectedRects(destSel)
+  const before     = Object.assign({}, ...rects.map(r => _captureRange(r, sn)))
+  const beforeFmt  = Object.assign({}, ...rects.map(r => _captureFormatsRange(r, sn)))
+  const beforeVal  = Object.assign({}, ...rects.map(r => _captureValidationRange(r, sn)))
   const cfBefore   = condFormat?.getRules?.(sn)?.length ?? 0
   clipboard.paste(activeCell.value, () => {}, kind, destSel)
-  _refreshDisplayForRange(destSel, sn)
+  for (const r of rects) _refreshDisplayForRange(r, sn)
   clipboardHas.value = clipboard.hasData()
   grid?.setMarchingAnts(null)
-  const after    = _captureRange(destSel, sn)
-  const afterFmt = _captureFormatsRange(destSel, sn)
-  const afterVal = _captureValidationRange(destSel, sn)
+  const after    = Object.assign({}, ...rects.map(r => _captureRange(r, sn)))
+  const afterFmt = Object.assign({}, ...rects.map(r => _captureFormatsRange(r, sn)))
+  const afterVal = Object.assign({}, ...rects.map(r => _captureValidationRange(r, sn)))
   const cfAfter  = condFormat?.getRules?.(sn)?.length ?? 0
   const refs     = _diffRefs(before, after)
   if (refs.length || cfBefore !== cfAfter) {
@@ -3360,9 +3757,7 @@ function toggleFormatPainter() {
 
 function _applyPaintedFormat() {
   if (!isPaintingFormat.value || !_copiedFormat) return
-  const ids = selectionIds()
-  formats.applyToRange(ids, _copiedFormat, sheet.getCurrentSheet())
-  history.push()
+  _recordScopedFormatOp(_patchFmtOps(_copiedFormat))
   syncFlags()
   isDirty.value = true
   isPaintingFormat.value = false
@@ -3371,14 +3766,14 @@ function _applyPaintedFormat() {
 }
 
 function onNumberFormatChange(value) {
+  const sn  = sheet.getCurrentSheet()
   const ids = selectionIds()
-  formats.applyToRange(ids, { numberFormat: value }, sheet.getCurrentSheet())
+  _recordFormatOp(ids, sn, () => formats.applyToRange(ids, { numberFormat: value }, sn))
   for (const id of ids) {
     const raw = sheet.getDisplayValue(id)
     grid?.setCell(id, value ? applyNumberFmt(raw, value) : raw)
   }
   _syncNumberFormat(activeCell.value)
-  history.push()   // post-mutate
   syncFlags()
   isDirty.value = true
 }
@@ -3420,6 +3815,7 @@ function saveComment() {
   commentPanel.open = false
   notesPanel.rev++
   grid?.render()
+  history.push()   // comments live in the snapshot; record so undo can revert
   isDirty.value = true
 }
 
@@ -3428,6 +3824,7 @@ function deleteComment() {
   commentPanel.open = false
   notesPanel.rev++
   grid?.render()
+  history.push()
   isDirty.value = true
 }
 
@@ -3527,6 +3924,7 @@ function confirmValidation() {
   for (const id of ids) validation.set(id, rule, sn)
   validationDialog.open = false
   grid?.render()
+  history.push()   // validation rules live in the snapshot; record for undo
   isDirty.value = true
 }
 
@@ -3536,6 +3934,7 @@ function removeValidation() {
   for (const id of ids) validation.clear(id, sn)
   validationDialog.open = false
   grid?.render()
+  history.push()
   isDirty.value = true
 }
 
@@ -3543,6 +3942,7 @@ function openDropdown(id, rule, pos = {}) {
   if (rule?.type !== 'list') return
   dropdownPanel.id      = id
   dropdownPanel.options = rule.options
+  dropdownPanel.value   = String(sheet.getCell(id, sheet.getCurrentSheet()) ?? '')
   dropdownPanel.x       = pos.x ?? 0
   dropdownPanel.y       = pos.y ?? 0
   dropdownPanel.w       = pos.w ?? 120
@@ -3556,6 +3956,7 @@ function pickDropdownOption(opt) {
   sheet.setCell(id, opt)
   dropdownPanel.open = false
   _pushEditOp(sn, before, 'Edit cell')
+  recomputePivotsForSheet(sn)
 }
 
 // ── Conditional formatting ────────────────────────────────────────────────────
@@ -3829,9 +4230,7 @@ function _removeFilter() {
   isDirty.value = true
 }
 
-function openFilterPanel(colIdx, event) {
-  const rect = event.target.getBoundingClientRect()
-  const wrapRect = gridWrapRef.value.getBoundingClientRect()
+function openFilterPanel(colIdx) {
   const sn  = sheet.getCurrentSheet()
   const cfg = sortFilter.getFilterConfig(sn)
   const existing = cfg[colIdx]
@@ -3858,11 +4257,18 @@ function openFilterPanel(colIdx, event) {
     filterPanel.value     = ''
     filterPanel.valueSet  = new Set(allValues)
   }
-  filterPanel.style = {
-    top:  (rect.bottom - wrapRect.top + 2) + 'px',
-    left: (rect.left   - wrapRect.left)    + 'px',
-  }
   filterPanel.open = true
+}
+
+// The panel renders at FILTER_PANEL_W px outer width (260 content + 24 padding +
+// 2 border, content-box). clampFilterLeft keeps its full width inside the grid
+// wrap so chevrons on right-edge columns don't push the Apply/Close buttons
+// off-screen. Live positioning lives in the filterPanelStyle computed.
+const FILTER_PANEL_W = 286
+function clampFilterLeft(left, wrapWidth) {
+  const GAP = 6
+  const maxLeft = wrapWidth - FILTER_PANEL_W - GAP
+  return Math.max(GAP, Math.min(left, maxLeft))
 }
 
 // Alt+↓ on a canvas cell opens the filter panel for that cell's column. Forces
@@ -3885,10 +4291,8 @@ function openQuickFilterForActive() {
     filterPanel.col      = p.col
     filterPanel.operator = cfg[p.col]?.operator || 'contains'
     filterPanel.value    = cfg[p.col]?.value    || ''
-    filterPanel.style    = {
-      top:  (rowRect.y + rowRect.height + 2) + 'px',
-      left: (colRect.x + colRect.width - 232 - 4) + 'px',  // 232px panel width
-    }
+    // Position is derived live by the filterPanelStyle computed; we only need
+    // the column visible here so the panel has a valid anchor on open.
   })
 }
 
@@ -4046,9 +4450,7 @@ function setFontFamily(keyOrStack) {
   // Accept either a short key ('inter', 'mono', …) from the toolbar select or
   // a raw CSS font-family stack (used by F4 replay). Normalize to the stack.
   const stack = FONT_FAMILY_STACK[keyOrStack] || keyOrStack
-  const ids = selectionIds()
-  formats.applyToRange(ids, { fontFamily: stack }, sheet.getCurrentSheet())
-  history.push()   // post-mutate
+  _recordScopedFormatOp(_patchFmtOps({ fontFamily: stack }))
   refreshActiveFormat()
   grid?.render()
   syncFlags()
@@ -4056,15 +4458,24 @@ function setFontFamily(keyOrStack) {
   isDirty.value = true
 }
 
-function adjustFontSize(delta) {
-  const ids = selectionIds()
-  const sh  = sheet.getCurrentSheet()
-  for (const id of ids) {
-    const cur = formats.get(id, sh).fontSize || 13
-    const next = Math.max(8, Math.min(72, cur + delta))
-    formats.applyToRange([id], { fontSize: next }, sh)
+// Mutation triple ({ cols, rows, cells }) that applies a visual format patch at
+// whichever scope the selection implies.
+function _patchFmtOps(patch) {
+  return {
+    cols:  (cols, sn) => formats.applyToColumns(cols, patch, sn),
+    rows:  (rows, sn) => formats.applyToRows(rows, patch, sn),
+    cells: (ids, sn)  => formats.applyToRange(ids, patch, sn),
   }
-  history.push()   // post-mutate
+}
+
+const _clampFont = v => Math.max(8, Math.min(72, v))
+
+function adjustFontSize(delta) {
+  _recordScopedFormatOp({
+    cols:  (cols, sn) => { for (const c of cols) formats.setCol(c, { fontSize: _clampFont((formats.getCol(c, sn).fontSize || 13) + delta) }, sn) },
+    rows:  (rows, sn) => { for (const r of rows) formats.setRow(r, { fontSize: _clampFont((formats.getRow(r, sn).fontSize || 13) + delta) }, sn) },
+    cells: (ids, sn)  => { for (const id of ids) formats.applyToRange([id], { fontSize: _clampFont((formats.get(id, sn).fontSize || 13) + delta) }, sn) },
+  })
   refreshActiveFormat()
   grid?.render()
   syncFlags()
@@ -4076,11 +4487,8 @@ function adjustFontSize(delta) {
 // to [8, 72] to match adjustFontSize. Called from the toolbar's font-size
 // input on commit (Enter / blur).
 function setFontSize(px) {
-  const n = Math.max(8, Math.min(72, parseInt(px, 10) || 13))
-  const ids = selectionIds()
-  const sh  = sheet.getCurrentSheet()
-  formats.applyToRange(ids, { fontSize: n }, sh)
-  history.push()   // post-mutate
+  const n = _clampFont(parseInt(px, 10) || 13)
+  _recordScopedFormatOp(_patchFmtOps({ fontSize: n }))
   refreshActiveFormat()
   grid?.render()
   syncFlags()
@@ -4149,15 +4557,22 @@ function confirmInsertMany() {
 
 function doDeleteRow() {
   contextMenu.open = false
-  const atRow = contextMenu.targetRow
   const sn = sheet.getCurrentSheet()
-  sheet.deleteRow(atRow)
-  formats.deleteRow(atRow, sn)
-  comments.deleteRow(atRow, sn)
-  validation.deleteRow(atRow, sn)
-  condFormat.deleteRow(atRow, sn)
-  sortFilter.deleteRow(atRow, sn)
-  grid.shiftRowHeights(atRow + 1, -1)
+  // Same span logic as doDeleteCol: delete the whole selected row block when
+  // the right-clicked row falls inside it, else just the targeted row.
+  const sel = grid.getSelection()
+  const within = sel && contextMenu.targetRow >= sel.r0 && contextMenu.targetRow <= sel.r1
+  const start  = within ? sel.r0 : contextMenu.targetRow
+  const count  = within ? sel.r1 - sel.r0 + 1 : 1
+  for (let i = 0; i < count; i++) {
+    sheet.deleteRow(start)
+    formats.deleteRow(start, sn)
+    comments.deleteRow(start, sn)
+    validation.deleteRow(start, sn)
+    condFormat.deleteRow(start, sn)
+    sortFilter.deleteRow(start, sn)
+    grid.shiftRowHeights(start + 1, -1)
+  }
   _repopulateGrid()
   _applyHiddenRows()
   markEdited()
@@ -4184,15 +4599,23 @@ function doInsertCol(right = false, count = 1) {
 
 function doDeleteCol() {
   contextMenu.open = false
-  const atCol = contextMenu.targetCol
   const sn = sheet.getCurrentSheet()
-  sheet.deleteCol(atCol)
-  formats.deleteCol(atCol, sn)
-  comments.deleteCol(atCol, sn)
-  validation.deleteCol(atCol, sn)
-  condFormat.deleteCol(atCol, sn)
-  sortFilter.deleteCol(atCol, sn)
-  grid.shiftColWidths(atCol + 1, -1)
+  // When the right-clicked column is inside a multi-column selection, delete
+  // every selected column; otherwise just the targeted one. Each delete shifts
+  // the rest left, so the block start index stays fixed across iterations.
+  const sel = grid.getSelection()
+  const within = sel && contextMenu.targetCol >= sel.c0 && contextMenu.targetCol <= sel.c1
+  const start  = within ? sel.c0 : contextMenu.targetCol
+  const count  = within ? sel.c1 - sel.c0 + 1 : 1
+  for (let i = 0; i < count; i++) {
+    sheet.deleteCol(start)
+    formats.deleteCol(start, sn)
+    comments.deleteCol(start, sn)
+    validation.deleteCol(start, sn)
+    condFormat.deleteCol(start, sn)
+    sortFilter.deleteCol(start, sn)
+    grid.shiftColWidths(start + 1, -1)
+  }
   _repopulateGrid()
   _applyHiddenRows()
   markEdited()
@@ -4440,38 +4863,107 @@ const { pushEditOp: _pushEditOp } = useEditOps({
 
 // ── Repopulate ────────────────────────────────────────────────────────────────
 
-function _repopulateGrid() {
-  if (!grid) return
-  grid.clearAll()
-  const data    = sheet.getRawData()
-  const sheetSn = sheet.getCurrentSheet()
-  const show    = showFormulas.value
-  // Hot path on load for big sheets — 25k cells × parseCellId (regex match +
-  // {row,col} object allocation per call) was eating ~250 ms of GC + script
-  // time. Skip the regex entirely: walk the id's characters by char code to
-  // track maxCol/maxRow without allocating. The grid only needs the bounds
-  // to know whether to expand its default 26 × 1000 rectangle.
+// Lazy render path is the default (Phase 3 cutover): the grid pulls each
+// visible cell's display string on demand, so switch/load cost no longer scales
+// with cell count. The eager `data`-cache path is kept intact as a fallback —
+// disable lazy per-browser with `?lazy=0` or localStorage['sheets:lazy']='0' if
+// a rendering regression turns up on a real sheet.
+function _lazyValuesEnabled() {
+  try {
+    if (new URLSearchParams(window.location.search).get('lazy') === '0') return false
+    if (window.localStorage?.getItem('sheets:lazy') === '0') return false
+  } catch { /* no window/storage — fall through to default */ }
+  return true
+}
+
+// Display string for a single cell — the formatted value the canvas paints.
+// Single source of truth shared by the eager repopulate (below), the per-cell
+// onCellChanged repaint, and the lazy render path (grid `getDisplay`), so all
+// three render identical pixels. showFormulas mode paints raw formula text.
+function _cellDisplay(id) {
+  if (showFormulas.value) return String(sheet.getCell(id) ?? '')
+  const sn  = sheet.getCurrentSheet()
+  const fmt = formats.get(id, sn)
+  const dv  = sheet.getDisplayValue(id)
+  return fmt.numberFormat ? applyNumberFmt(dv, fmt.numberFormat) : dv
+}
+
+// Grow the grid's scrollable area to cover a sheet's used extent so the user
+// can scroll to their data. Shared by the eager and lazy repopulate paths.
+function _expandGridTo(maxCol, maxRow) {
+  const neededCols = maxCol + 1
+  const neededRows = maxRow + 1
+  if (grid.getTotalCols && grid.expandCols && neededCols > grid.getTotalCols())
+    grid.expandCols(neededCols - grid.getTotalCols())
+  if (grid.getTotalRows && grid.expandRows && neededRows > grid.getTotalRows())
+    grid.expandRows(neededRows - grid.getTotalRows())
+}
+
+// Sheet extent via a cheap char-code id-parse over the raw cell ids — no
+// formula eval or format work. The lazy path's fallback when the engine has
+// no load-time bounds hint (post-edit / never-visited sheet).
+function _scanBounds(sheetSn) {
+  const data = sheet.getRawData(sheetSn)
   let maxCol = 0, maxRow = 0
-  for (const id of Object.keys(data)) {
-    // Inline cellId parse — letters → col index, then digits → row number.
-    // No regex, no result object.
+  for (const id in data) {
     let col = 0, row = 0, i = 0
     const len = id.length
-    while (i < len) {
-      const c = id.charCodeAt(i)
-      if (c < 65 || c > 90) break
-      col = col * 26 + (c - 64)
-      i++
-    }
-    while (i < len) {
-      const c = id.charCodeAt(i)
-      if (c < 48 || c > 57) { row = 0; break }
-      row = row * 10 + (c - 48)
-      i++
-    }
-    if (col > 0 && row > 0) {
-      if (col - 1 > maxCol) maxCol = col - 1
-      if (row - 1 > maxRow) maxRow = row - 1
+    while (i < len) { const c = id.charCodeAt(i); if (c < 65 || c > 90) break; col = col * 26 + (c - 64); i++ }
+    while (i < len) { const c = id.charCodeAt(i); if (c < 48 || c > 57) { row = 0; break } row = row * 10 + (c - 48); i++ }
+    if (col > 0 && row > 0) { if (col - 1 > maxCol) maxCol = col - 1; if (row - 1 > maxRow) maxRow = row - 1 }
+  }
+  return { maxCol, maxRow }
+}
+
+function _repopulateGrid() {
+  if (!grid) return
+  const sheetSn = sheet.getCurrentSheet()
+
+  // Lazy path: the grid pulls each visible cell's display string on demand, so
+  // we materialise nothing here — switch/load no longer scale with cell count.
+  // Still size the grid to the sheet extent (cheap id-parse, or the engine's
+  // free load-time hint) and repaint.
+  if (grid.isLazyValues?.()) {
+    const b = sheet.consumeBounds?.(sheetSn) || _scanBounds(sheetSn)
+    _expandGridTo(b.maxCol, b.maxRow)
+    grid.render?.()
+    return
+  }
+
+  grid.clearAll()
+  const data    = sheet.getRawData()
+  const show    = showFormulas.value
+  // Bounds: on load the engine hands us the sheet extent (derived cheaply from
+  // the packed payload), so we skip re-parsing every cell id here entirely —
+  // that scan was ~0.5s on a 2M-cell sheet. When bounds are unknown (post-edit
+  // repopulates) we fall back to the inline char-code parse below.
+  const bounds = sheet.consumeBounds?.(sheetSn)
+  let maxCol = bounds ? bounds.maxCol : 0
+  let maxRow = bounds ? bounds.maxRow : 0
+  // for-in avoids allocating a 2M-entry Object.keys array (alloc + GC was a
+  // measurable chunk of the cold-load task).
+  for (const id in data) {
+    if (!bounds) {
+      // Inline cellId parse — letters → col index, then digits → row number.
+      // No regex, no result object.
+      let col = 0, row = 0, i = 0
+      const len = id.length
+      while (i < len) {
+        const c = id.charCodeAt(i)
+        if (c < 65 || c > 90) break
+        col = col * 26 + (c - 64)
+        i++
+      }
+      while (i < len) {
+        const c = id.charCodeAt(i)
+        if (c < 48 || c > 57) { row = 0; break }
+        row = row * 10 + (c - 48)
+        i++
+      }
+      if (col > 0 && row > 0) {
+        if (col - 1 > maxCol) maxCol = col - 1
+        if (row - 1 > maxRow) maxRow = row - 1
+      }
     }
 
     if (show) {
@@ -4482,12 +4974,7 @@ function _repopulateGrid() {
     const displayValue = sheet.getDisplayValue(id)
     grid.setCell(id, fmt.numberFormat ? applyNumberFmt(displayValue, fmt.numberFormat) : displayValue)
   }
-  const neededCols = maxCol + 1
-  const neededRows = maxRow + 1
-  if (grid.getTotalCols && grid.expandCols && neededCols > grid.getTotalCols())
-    grid.expandCols(neededCols - grid.getTotalCols())
-  if (grid.getTotalRows && grid.expandRows && neededRows > grid.getTotalRows())
-    grid.expandRows(neededRows - grid.getTotalRows())
+  _expandGridTo(maxCol, maxRow)
 }
 
 function toggleShowFormulas() {
@@ -4515,6 +5002,15 @@ function toggleShowFormulas() {
   pointer-events: none;   /* don't intercept clicks if it lingers a frame */
 }
 .sn-canvas-loading-spinner { color: var(--ink-gray-5); }
+.sn-pivot-building {
+  position: absolute; top: 12px; left: 50%; transform: translateX(-50%);
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 14px; border-radius: 999px;
+  background: var(--surface-base); border: 1px solid var(--outline-gray-2);
+  box-shadow: 0 2px 8px rgba(0,0,0,.08);
+  font-size: 13px; color: var(--ink-gray-7);
+  z-index: 5; pointer-events: none;
+}
 
 /* ── Load-time error state ───────────────────────────────────────────────── */
 .sn-load-error {
@@ -4551,6 +5047,16 @@ function toggleShowFormulas() {
 /* Hairline between action buttons and avatar — groups the cluster without
    relying on extra padding. */
 .sn-topbar-divider { width:1px; height:20px; background:var(--outline-gray-2); margin:0 4px; flex-shrink:0; }
+/* Notes count badge — workbook-wide teal badge on the notes icon. */
+.sn-notes-btn-wrap { position:relative; display:inline-flex; }
+.sn-notes-badge {
+  position:absolute; top:-3px; right:-3px; box-sizing:border-box;
+  min-width:15px; height:15px; padding:0 3px;
+  display:flex; align-items:center; justify-content:center;
+  font-size:9px; font-weight:600; line-height:1; color:#fff;
+  background:#0d7490; border-radius:999px; border:1.5px solid var(--surface-base);
+  pointer-events:none;
+}
 
 /* Brand-coloured current-user avatar. Avatar's inner label uses
    `bg-surface-gray-2 text-ink-gray-5` by default — we override both so the
@@ -4677,10 +5183,10 @@ function toggleShowFormulas() {
   .sn-tool-more  { display: inline-flex; }
 }
 
-/* Color-picker swatch buttons (FeatherIcon glyph above a colored underline). Native <input type=color> kept; Frappe UI has no color picker. */
-.sn-swatch-btn { position:relative; height:28px; width:28px; border-radius:6px; display:inline-flex; flex-direction:column; align-items:center; justify-content:center; cursor:pointer; border:1px solid transparent; gap:1px; transition:background-color .12s; }
-.sn-swatch-btn:hover { background:var(--surface-gray-3); }
-.sn-swatch-btn input[type=color] { position:absolute; opacity:0; width:100%; height:100%; left:0; top:0; cursor:pointer; }
+/* Color-picker trigger buttons (FeatherIcon glyph above a colored underline).
+   These open the ColorPicker popover; the swatch grid + hex + custom live there. */
+.sn-swatch-btn { position:relative; height:28px; width:28px; border-radius:6px; display:inline-flex; flex-direction:column; align-items:center; justify-content:center; cursor:pointer; border:1px solid transparent; gap:1px; transition:background-color .12s; background:transparent; padding:0; }
+.sn-swatch-btn:hover, .sn-swatch-btn.is-open { background:var(--surface-gray-3); }
 .sn-swatch-glyph     { width:14px; height:14px; color:var(--ink-gray-8); pointer-events:none; }
 .sn-merge-glyph      { width:16px; height:16px; color:currentColor; pointer-events:none; }
 .sn-swatch-underline { width:16px; height:3px; border-radius:1px; pointer-events:none; }
@@ -4839,8 +5345,14 @@ function toggleShowFormulas() {
 /* Add-sheet button — pin its inner Button to the same 28px height as the
    tab labels and center within the track so the `+` sits on the same row
    axis as the tab text, not floating a couple of pixels above. */
-.sn-tab-add { flex-shrink:0; align-self:center; margin:0 4px; }
+/* Pinned at the start of the bottom bar (outside the scroll track) so it's
+   always reachable regardless of how many tabs there are. Full-height flex
+   box keeps the 28px button optically centered against the tab labels. */
+.sn-tab-add { flex-shrink:0; display:flex; align-items:center; align-self:center; margin:0 8px 0 12px; padding-right:8px; border-right:1px solid var(--outline-gray-2); }
 .sn-tab-add :deep(button) { height:28px; width:28px; padding:0; display:inline-flex; align-items:center; justify-content:center; }
+/* Feather `plus` sits ~1px high inside its box; pull the glyph down so it
+   lands on the same optical row as the tab labels' text. */
+.sn-tab-add :deep(svg) { display:block; position:relative; top:1px; }
 
 .sn-tab-drag-over::before {
   content:''; position:absolute; left:0; top:6px; bottom:6px;
@@ -4916,9 +5428,14 @@ function toggleShowFormulas() {
 .sn-notes-row-text    { font-size:12px; color:var(--ink-gray-6); margin-top:2px; line-height:1.4; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; word-break:break-word; }
 
 /* Validation dropdown panel */
-.sn-dropdown-panel { position:fixed; z-index:8500; background:var(--surface-elevation-2); border:1px solid var(--outline-elevation-2); border-radius:8px; box-shadow:0 4px 12px rgba(0,0,0,.12); min-width:120px; max-height:200px; overflow-y:auto; }
-.sn-dropdown-opt   { padding:7px 14px; font-size:13px; color:var(--ink-gray-9); cursor:pointer; white-space:nowrap; }
+.sn-dropdown-panel { position:fixed; z-index:8500; padding:4px; background:var(--surface-elevation-2); border:1px solid var(--outline-elevation-2); border-radius:8px; box-shadow:0 4px 12px rgba(0,0,0,.12); min-width:140px; max-height:240px; overflow-y:auto; }
+.sn-dropdown-opt   { display:flex; align-items:center; gap:8px; padding:6px 10px; border-radius:6px; font-size:13px; color:var(--ink-gray-9); cursor:pointer; white-space:nowrap; }
 .sn-dropdown-opt:hover { background:var(--surface-gray-2); }
+.sn-dropdown-opt.is-active { font-weight:500; }
+.sn-dropdown-check { width:14px; height:14px; flex-shrink:0; color:var(--ink-gray-7); }
+.sn-dropdown-chip  { max-width:200px; padding:2px 10px; border-radius:999px; color:var(--ink-gray-9); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.sn-dropdown-clear .sn-dropdown-label { overflow:hidden; text-overflow:ellipsis; }
+.sn-dropdown-clear { color:var(--ink-gray-6); border-top:1px solid var(--outline-gray-1); border-radius:0 0 6px 6px; margin-top:2px; padding-top:8px; }
 
 /* Conditional format dialog rows */
 .sn-form-stack  { display:flex; flex-direction:column; gap:12px; }

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -35,20 +35,11 @@
         <!-- Brand mark doubles as the "back to home" action. Clicking it runs
              flushAndClose so any pending edits are saved before navigation. -->
         <button class="sn-app-icon-btn" type="button" aria-label="Back to home" title="Back to home" @click="flushAndClose">
-          <svg class="sn-app-icon" width="28" height="28" viewBox="0 0 256 256" fill="none" aria-hidden="true">
-            <rect width="256" height="256" rx="60" fill="#0E7490"/>
-            <rect x="0.5" y="0.5" width="255" height="255" rx="59.5" stroke="white" stroke-opacity="0.12"/>
-            <g stroke="white" stroke-opacity="0.18" stroke-width="2" stroke-linecap="round">
-              <line x1="85"  y1="32"  x2="85"  y2="224"/>
-              <line x1="171" y1="32"  x2="171" y2="224"/>
-              <line x1="32"  y1="85"  x2="224" y2="85"/>
-              <line x1="32"  y1="171" x2="224" y2="171"/>
-            </g>
-            <polyline points="48,180 96,148 136,164 184,80 216,108"
-                      fill="none" stroke="#A5F0FA" stroke-width="18"
-                      stroke-linecap="round" stroke-linejoin="round"/>
-            <circle cx="136" cy="164" r="11" fill="white"/>
-            <circle cx="184" cy="80"  r="11" fill="white"/>
+          <svg class="sn-app-icon" width="28" height="28" viewBox="0 0 118 118" fill="none" aria-hidden="true">
+            <path d="M93.9278 0H23.1013C10.3428 0 0 10.3428 0 23.1013V93.9278C0 106.686 10.3428 117.029 23.1013 117.029H93.9278C106.686 117.029 117.029 106.686 117.029 93.9278V23.1013C117.029 10.3428 106.686 0 93.9278 0Z" fill="#278F5E"/>
+            <path d="M77.757 25.9364H23.5215V36.437H77.757C80.6447 36.437 83.0073 38.7996 83.0073 41.6873V75.3942C83.0073 78.2818 80.6447 80.6445 77.757 80.6445H39.2724C36.3847 80.6445 34.0221 78.2818 34.0221 75.3942V50.6653H23.5215V75.3942C23.5215 84.0572 30.6094 91.1451 39.2724 91.1451H77.757C86.42 91.1451 93.5079 84.0572 93.5079 75.3942V41.6873C93.5079 33.0243 86.42 25.9364 77.757 25.9364Z" fill="white"/>
+            <path d="M53.8678 59.6958H43.3672V70.0914H53.8678V59.6958Z" fill="white"/>
+            <path d="M73.6617 50.6653H63.1611V70.1439H73.6617V50.6653Z" fill="white"/>
           </svg>
         </button>
         <input

--- a/frontend/src/apps/sheets/components/SheetEditor/useChartIntegration.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useChartIntegration.js
@@ -35,6 +35,10 @@ export function useChartIntegration({
 	const chartEditId       = ref('')
 	const chartEditConfig   = ref(null)
 	const chartVersion      = ref(0)
+	// Bumped ONLY when the source data should be re-pulled (refresh) — NOT on
+	// move/resize. The overlay keys its matrix cache on this so dragging a chart
+	// over a 100k-row source doesn't re-materialise the matrix every frame.
+	const chartDataVersion  = ref(0)
 	const selectedChartId   = ref('')
 
 	// One source of reactive truth — bumped on every engine mutation so
@@ -151,8 +155,8 @@ export function useChartIntegration({
 	// Refresh isn't strictly needed (charts re-derive reactively from the
 	// sheet engine) but the explicit "refresh" button is reassuring.
 	function onChartRefresh(id) {
-		// Force a version bump — overlay re-fetches the matrix.
-		chartVersion.value++
+		// Invalidate the overlay's matrix cache so it re-pulls fresh source data.
+		chartDataVersion.value++
 	}
 
 	function selectChart(id) { selectedChartId.value = id }
@@ -166,7 +170,7 @@ export function useChartIntegration({
 
 	return {
 		chartDialogOpen, chartInitialRange, chartEditId, chartEditConfig,
-		charts, selectedChartId, chartVersion,
+		charts, selectedChartId, chartVersion, chartDataVersion,
 		openInsert, openEdit,
 		onChartConfirm, onChartDelete, onChartMove, onChartResize, onChartRefresh,
 		selectChart, getMatrix,

--- a/frontend/src/apps/sheets/components/SheetEditor/useChartIntegration.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useChartIntegration.js
@@ -35,9 +35,11 @@ export function useChartIntegration({
 	const chartEditId       = ref('')
 	const chartEditConfig   = ref(null)
 	const chartVersion      = ref(0)
-	// Bumped ONLY when the source data should be re-pulled (refresh) — NOT on
-	// move/resize. The overlay keys its matrix cache on this so dragging a chart
-	// over a 100k-row source doesn't re-materialise the matrix every frame.
+	// Bumped when the source data should be re-pulled: on refresh AND on any
+	// sheet cell change (index.vue's onCellChanged/onCellsChanged) — but NOT on
+	// move/resize/scroll. The overlay keys its matrix cache on this so dragging a
+	// chart over a 100k-row source doesn't re-materialise the matrix every frame,
+	// while edits to the source range still refresh the chart.
 	const chartDataVersion  = ref(0)
 	const selectedChartId   = ref('')
 

--- a/frontend/src/apps/sheets/components/SheetEditor/useExportImport.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useExportImport.js
@@ -66,22 +66,18 @@ export function _parseCSV(text) {
  * @param {() => string}  opts.getCurrentTitle – current document title
  * @param {() => object|null} opts.getGrid     – returns the canvas grid or null
  * @param {(op: object) => void} opts.queueOp  – enqueue an operation
- * @param {() => void}    opts.markEdited      – push history + syncFlags + dirty
  * @param {() => void}    opts.repopulateGrid  – full canvas repaint
  * @param {() => void}    opts.syncFlags       – sync undo/redo button state
  * @param {import('vue').Ref<boolean>} opts.isDirty – dirty flag ref
- * @param {{ push: () => void }} opts.history  – history object
  */
 export function useExportImport({
   getSheet,
   getCurrentTitle,
   getGrid,
   queueOp,
-  markEdited,
   repopulateGrid,
   syncFlags,
   isDirty,
-  history,
 }) {
   function _diffRefs(before, after) {
     const ids = new Set([...Object.keys(before || {}), ...Object.keys(after || {})])
@@ -201,9 +197,6 @@ export function useExportImport({
       const text = ev.target.result
       const rows = _parseCSV(text)
       await _ingestRows(rows, file.name)
-      history.push()       // post-mutate snapshot
-      syncFlags()
-      isDirty.value = true
     }
     reader.readAsText(file)
     e.target.value = ''
@@ -218,9 +211,12 @@ export function useExportImport({
     const map       = await _rowsToCellMap(rows)
     if (grid) grid.clearAll()
     sheet.batchSetCells(map, currentSh)
-    markEdited()
-    // queueOp omitted on purpose — imports aren't undoable (Sheets parity)
-    // and a 100k-cell before/after snapshot was the dominant memory cost.
+    // No history entry: imports aren't undoable (Sheets parity). The old
+    // markEdited() path pushed a full-workbook snapshot here — a ~1.9s
+    // deepClone on a 2M-cell import, for an op the user can't even undo.
+    // Just flag dirty + refresh the toolbar so autosave picks it up.
+    syncFlags()
+    isDirty.value = true
     return fileName
   }
 

--- a/frontend/src/apps/sheets/components/SheetEditor/usePersistence.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/usePersistence.js
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
-import { call }            from '../../utils/api.js'
-import { encodeForUpload } from '../../utils/compress.js'
+import { call }                  from '../../utils/api.js'
+import { encodeForUpload, isDecompressionSupported, decodeFromDownload } from '../../utils/compress.js'
+import { packSheet, packSheetChunked, unpackSheet, boundsOf } from '../../utils/sheet-codec.js'
 
 // `merge` and the view-state getters/setters are optional — they were missing
 // from earlier versions and their absence caused merged cells / column widths /
@@ -16,10 +17,15 @@ export function usePersistence({ sheet, formats, merge, comments, validation, co
   async function loadSheet(name) {
     loadError.value = null
     try {
-      const doc    = await call('suite.sheets.api.get_sheet', { name })
-      const saved  = JSON.parse(doc.sheets_data || '{}')
+      const canGz  = isDecompressionSupported()
+      const doc    = await call('suite.sheets.api.get_sheet', { name, compressed: canGz ? 1 : 0 })
+      const plain  = canGz ? await decodeFromDownload(doc.sheets_data) : doc.sheets_data
+      const saved  = JSON.parse(plain || '{}')
       if (saved.formats)    formats.restore(saved.formats)
-      sheet.restore(saved.sheet ?? { sheets: { Sheet1: {} }, current: 'Sheet1' })
+      sheet.restore(
+        unpackSheet(saved.sheet) ?? { sheets: { Sheet1: {} }, current: 'Sheet1' },
+        boundsOf(saved.sheet),
+      )
       if (saved.merge      && merge?.restore)      merge.restore(saved.merge)
       if (saved.comments   && comments?.restore)   comments.restore(saved.comments)
       if (saved.validation && validation?.restore) validation.restore(saved.validation)
@@ -91,8 +97,15 @@ export function usePersistence({ sheet, formats, merge, comments, validation, co
     // attempts, racing with the user's keystrokes.
     let args
     try {
+      // Pack straight from live cell data — the packer builds a fresh compact
+      // structure, so it's an independent payload without snapshot()'s
+      // deepClone. The chunked packer yields to the event loop so a 2M-cell
+      // pack doesn't block input for seconds; the keepalive/unmount save can't
+      // afford to yield (the page may die first), so it packs synchronously.
+      const live   = { sheets: sheet.getAllRaw(), current: sheet.getCurrentSheet() }
+      const packed = keepalive ? packSheet(live) : await packSheetChunked(live)
       const sheetsData = JSON.stringify({
-        sheet:      sheet.snapshot(),
+        sheet:      packed,
         formats:    formats.snapshot(),
         merge:      merge?.snapshot?.()      ?? null,
         comments:   comments?.snapshot?.()   ?? null,

--- a/frontend/src/apps/sheets/components/SheetEditor/usePivotIntegration.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/usePivotIntegration.js
@@ -1,11 +1,23 @@
 import { ref, computed, watch } from 'vue'
-import { computePivot, writePivotToSheet } from '../../engine/pivot.js'
-import { colLabel, cellId } from '../../utils/cells.js'
+import { computePivotModel, computePivotModelAsync, pivotDrillDown, writePivotToSheet } from '../../engine/pivot.js'
+import { colLabel, cellId, parseCellId } from '../../utils/cells.js'
 import { COL_HEADER_H, ROW_HEADER_W } from '../../canvas/constants.js'
 
 // Styling applied to the pivot's column header row (row 0) and Grand Total
 // row (last row). Matches the Google Sheets look the user asked for.
 const PIVOT_HEADER_FORMAT = { bold: true, backgroundColor: '#d9e0e8' }
+
+// Does an output rectangle contain a cell?
+function _rectContains(ext, row, col) {
+  return !!ext && row >= ext.r0 && row <= ext.r1 && col >= ext.c0 && col <= ext.c1
+}
+
+// Do an output rectangle and a selection {r0,c0,r1,c1} overlap?
+function _rectIntersects(ext, sel) {
+  return !!ext && !!sel &&
+    sel.r0 <= ext.r1 && sel.r1 >= ext.r0 &&
+    sel.c0 <= ext.c1 && sel.c1 >= ext.c0
+}
 
 /**
  * @param {{
@@ -23,7 +35,7 @@ const PIVOT_HEADER_FORMAT = { bold: true, backgroundColor: '#d9e0e8' }
  * }} opts
  */
 export function usePivotIntegration({
-  pivot, sheet, formats, currentSheet, renderVersion, getGrid,
+  pivot, sheet, formats, currentSheet, activeCell, renderVersion, getGrid,
   contextMenu, switchSheet, syncNames,
   history, isDirty, repopulateGrid,
 }) {
@@ -32,11 +44,9 @@ export function usePivotIntegration({
   const pivotEditId       = ref('')
   const pivotEditConfig   = ref(null)
   const pivotVersion      = ref(0)
-  // Row/column count of the last-rendered pivot output; used to position the
-  // edit FAB and the highlight overlay without re-running the full
-  // computePivot() on every canvas render frame.
-  const _pivotRowCount    = ref(0)
-  const _pivotColCount    = ref(0)
+  // True while an async pivot build is aggregating the source rows — drives a
+  // spinner so big sheets don't look frozen.
+  const pivotBuilding     = ref(false)
 
   // Every engine mutation (including restore on page reload) bumps the version,
   // so reactive computeds like `activePivotConfig` re-evaluate. Without this,
@@ -44,10 +54,28 @@ export function usePivotIntegration({
   // silently and the cached computed never sees the new pivot list.
   pivot.setOnChange?.(() => { pivotVersion.value++ })
 
-  // Reading pivotVersion forces Vue to re-evaluate on every add/update/delete.
+  // The pivot the edit FAB / drill-down / delete should target: among the
+  // pivots on the current sheet, the one whose output rectangle contains the
+  // active cell. Several pivots can now share an outputSheet, so this is
+  // selection-aware. Reading pivotVersion + renderVersion + activeCell forces
+  // Vue to re-evaluate on add/update/delete, after each render (which sets
+  // pivot _extents), and whenever the selection moves.
   const activePivotConfig = computed(() => {
     void pivotVersion.value
-    return pivot.list().find(p => p.outputSheet === currentSheet.value) ?? null
+    void renderVersion.value
+    const candidates = pivot.list().filter(p => p.outputSheet === currentSheet.value)
+    if (!candidates.length) return null
+    const cell = parseCellId(activeCell?.value || '')
+    if (cell) {
+      const hit = candidates
+        .filter(p => _rectContains(p._extent, cell.row, cell.col))
+        .sort((a, b) => (a._extent.r0 - b._extent.r0) || (a._extent.c0 - b._extent.c0))[0]
+      if (hit) return hit
+    }
+    // Fall back to the sole pivot on the sheet so single-pivot sheets always
+    // show the edit affordance — and so a freshly-added pivot whose _extent
+    // isn't computed yet is still active. With several pivots, require a hit.
+    return candidates.length === 1 ? candidates[0] : null
   })
 
   // Set of sheet names that are pivot outputs — computed so templates reactively
@@ -59,32 +87,33 @@ export function usePivotIntegration({
 
   function isPivotSheet(name) { return pivotSheetNames.value.has(name) }
 
-  // After a page reload, pivot.restore() puts the config back but never calls
-  // _applyPivotOutput, so the in-memory _pivotRowCount stays at 0 — and both
-  // the edit FAB and the highlight overlay (which gate on rows > 0) silently
-  // hide. Watch the active config: when it becomes non-null, do a READ-ONLY
-  // computePivot() to derive dimensions. We don't go through _applyPivotOutput
-  // because its setCell writes would bump renderVersion and could mark the
-  // sheet dirty even though the cells already match the saved snapshot.
+  // After a page reload, pivot.restore() puts the config back but the transient
+  // _extent (not persisted) is gone, so both the edit FAB and the highlight
+  // overlay (which gate on _extent) silently hide. Watch the active config:
+  // when it lacks an _extent, derive one from the already-written cells without
+  // touching the sheet, so we don't bump renderVersion or mark the sheet dirty
+  // even though the cells already match the saved snapshot.
   //
   // Also (re-)apply the header/total banding so older pivots created before
   // this styling existed pick it up the first time they're opened. formats.set
-  // is idempotent and doesn't mark isDirty by itself, so this is safe to run
-  // on every activation.
+  // is idempotent and doesn't mark isDirty by itself, so this is safe.
   watch(activePivotConfig, (cfg) => {
-    if (!cfg) {
-      _pivotRowCount.value = 0
-      _pivotColCount.value = 0
-      return
-    }
-    const table = computePivot(cfg, (s, e, sh) => sheet.getRangeValues(s, e, sh))
-    _pivotRowCount.value = table.length
-    _pivotColCount.value = table[0]?.length || 0
-    _styleHeaderAndTotal(table, cfg.outputSheet)
+    // _extent is transient render state that isn't persisted, so after a reload
+    // a pivot's rectangle is unknown until it's recomputed. Derive it from the
+    // already-written cells (cheap contiguous scan from the anchor) rather than
+    // re-running the aggregation, then cache it. Once cached we skip — extents
+    // are otherwise refreshed at render time in _applyPivotOutput.
+    if (!cfg || cfg._extent) return
+    const ext = _outputExtentAt(cfg.outputSheet, cfg.anchorRow || 0, cfg.anchorCol || 0)
+    if (!ext) return
+    pivot.setExtent(cfg.id, ext)
+    _restyleHeaderAndTotal(cfg.outputSheet, ext)
+    // setExtent doesn't notify; nudge the overlays to pick up the new rect.
+    pivotVersion.value++
   }, { immediate: true })
 
-  // Positions the edit FAB below the Grand Total row without re-running
-  // computePivot() — _pivotRowCount is updated whenever pivot output is written.
+  // Positions the edit FAB below the active pivot's Grand Total row from its
+  // cached _extent, without re-running computePivot() on every render frame.
   // getCellRect returns coordinates even when the cell has scrolled above the
   // visible cell area, so the FAB would otherwise overlap the column/row
   // headers when the user scrolls past the pivot. Gate on the headers.
@@ -93,9 +122,9 @@ export function usePivotIntegration({
     renderVersion.value
     const cfg  = activePivotConfig.value
     const grid = getGrid()
-    const rows = _pivotRowCount.value
-    if (!grid || !cfg || !rows) return null
-    const rect = grid.getCellRect?.(rows - 1, 0)
+    const ext  = cfg?._extent
+    if (!grid || !ext) return null
+    const rect = grid.getCellRect?.(ext.r1, ext.c0)
     if (!rect) return null
     const zoom = grid.getZoom?.() ?? 1
     const top  = rect.y + rect.height + 6
@@ -118,11 +147,10 @@ export function usePivotIntegration({
     renderVersion.value
     const cfg  = activePivotConfig.value
     const grid = getGrid()
-    const rows = _pivotRowCount.value
-    const cols = _pivotColCount.value
-    if (!grid || !cfg || !rows || !cols) return null
-    const tl = grid.getCellRect?.(0, 0)
-    const br = grid.getCellRect?.(rows - 1, cols - 1)
+    const ext  = cfg?._extent
+    if (!grid || !ext) return null
+    const tl = grid.getCellRect?.(ext.r0, ext.c0)
+    const br = grid.getCellRect?.(ext.r1, ext.c1)
     if (!tl || !br) return null
     const zoom    = grid.getZoom?.() ?? 1
     const headerY = COL_HEADER_H * zoom
@@ -166,10 +194,10 @@ export function usePivotIntegration({
     pivotDialogOpen.value   = true
   }
 
-  function onPivotRefresh() {
+  async function onPivotRefresh() {
     const cfg = activePivotConfig.value
     if (!cfg) return
-    _applyPivotOutput(cfg)
+    await _applyPivotOutput(cfg)
     repopulateGrid()
   }
 
@@ -179,80 +207,217 @@ export function usePivotIntegration({
     pivot.remove(cfg.id)
   }
 
-  function _clearPivotOutputSheet(sheetName) {
-    const data = sheet.getRawData(sheetName)
-    for (const id of Object.keys(data)) {
-      sheet.setCell(id, '', sheetName)
-      // Clear the format too — otherwise the previous header/total band
-      // lingers on rows the new (shorter) pivot no longer occupies.
-      formats?.clear?.(id, sheetName)
-    }
-  }
-
-  function _applyPivotOutput(config) {
-    const table = computePivot(config, (s, e, sh) => sheet.getRangeValues(s, e, sh))
-    _pivotRowCount.value = table.length
-    _pivotColCount.value = table[0]?.length || 0
-    writePivotToSheet(
-      table, config.outputSheet,
-      (id, val, sh) => sheet.setCell(id, val, sh),
-      shName => _clearPivotOutputSheet(shName),
-    )
-    _styleHeaderAndTotal(table, config.outputSheet)
-  }
-
-  // Apply the bold + #d9e0e8 banding to row 0 (column headers) and the last
-  // row (Grand Total). Walks every column in the pivot width so the band is
-  // continuous even for cells the engine left empty (which writePivotToSheet
-  // skipped). Re-applied on every recompute since _clearPivotOutputSheet wipes
-  // formats first.
-  function _styleHeaderAndTotal(table, outputSheet) {
-    if (!formats?.set || !table.length) return
-    const cols = table[0]?.length || 0
-    const lastRow = table.length - 1
-    for (let c = 0; c < cols; c++) {
-      formats.set(cellId(0, c), PIVOT_HEADER_FORMAT, outputSheet)
-      if (lastRow > 0) {
-        formats.set(cellId(lastRow, c), PIVOT_HEADER_FORMAT, outputSheet)
+  // Clear only the pivot's previous output rectangle — never the whole sheet,
+  // which would wipe a neighbouring pivot or user data now that several pivots
+  // can live on one sheet. `extent` is the previously-rendered rect (null on a
+  // pivot's first render → nothing to clear).
+  function _clearPivotRect(sheetName, extent) {
+    if (!extent) return
+    for (let r = extent.r0; r <= extent.r1; r++) {
+      for (let c = extent.c0; c <= extent.c1; c++) {
+        const id = cellId(r, c)
+        sheet.setCell(id, '', sheetName)
+        // Clear the format too — otherwise the previous header/total band
+        // lingers on rows the new (shorter) pivot no longer occupies.
+        formats?.clear?.(id, sheetName)
       }
     }
   }
 
-  function recomputePivotsForSheet(srcSheet) {
+  // Async, chunked build. Aggregates the source in row blocks, yielding between
+  // them so a 100k-row pivot doesn't freeze the UI. A newer build supersedes an
+  // in-flight one via the token (e.g. rapid edits / refresh).
+  let _buildToken = 0
+  async function _applyPivotOutput(config) {
+    const token = ++_buildToken
+    pivotBuilding.value = true
+    try {
+      const model = await computePivotModelAsync(
+        config,
+        (s, e, sh) => sheet.getRangeValues(s, e, sh),
+        { onYield: () => _yieldUnlessSuperseded(token) },
+      )
+      if (token !== _buildToken) return
+      const table = model?.table ?? []
+      const ar = config.anchorRow || 0
+      const ac = config.anchorCol || 0
+      const prevExtent = pivot.get(config.id)?._extent ?? null
+      writePivotToSheet(
+        table, config.outputSheet,
+        (id, val, sh) => sheet.setCell(id, val, sh),
+        (sh, ext) => _clearPivotRect(sh, ext),
+        { row: ar, col: ac },
+        prevExtent,
+      )
+      const newExtent = table.length
+        ? { r0: ar, c0: ac, r1: ar + table.length - 1, c1: ac + (table[0]?.length || 1) - 1 }
+        : null
+      pivot.setExtent(config.id, newExtent)
+      _styleHeaderAndTotal(table, config.outputSheet, ar, ac)
+    } finally {
+      if (token === _buildToken) pivotBuilding.value = false
+    }
+  }
+
+  // Yield a macrotask so the UI can paint/respond between blocks; resolves
+  // false when a newer build has taken over so the engine bails early.
+  function _yieldUnlessSuperseded(token) {
+    return new Promise(res => setTimeout(() => res(token === _buildToken), 0))
+  }
+
+  // Output rectangle of an already-written pivot, derived without re-aggregating
+  // the source: the output is a solid block anchored at (ar, ac), so walk the
+  // header row right and the row-label column down to the first gap. Scoped to
+  // the anchor so it never unions a neighbouring pivot's cells. Returns null
+  // when nothing is written at the anchor.
+  function _outputExtentAt(sheetName, ar, ac) {
+    const data = sheet.getRawData(sheetName)
+    const has = (r, c) => {
+      const v = data[cellId(r, c)]
+      return v !== undefined && v !== null && v !== ''
+    }
+    if (!has(ar, ac)) return null
+    let lastCol = ac
+    while (has(ar, lastCol + 1)) lastCol++
+    let lastRow = ar
+    while (has(lastRow + 1, ac)) lastRow++
+    return { r0: ar, c0: ac, r1: lastRow, c1: lastCol }
+  }
+
+  // Re-apply header/total banding over an extent (used on load so pivots made
+  // before this styling existed pick it up, without recomputing the table).
+  function _restyleHeaderAndTotal(outputSheet, ext) {
+    if (!formats?.set || !ext) return
+    for (let c = ext.c0; c <= ext.c1; c++) {
+      formats.set(cellId(ext.r0, c), PIVOT_HEADER_FORMAT, outputSheet)
+      if (ext.r1 > ext.r0) formats.set(cellId(ext.r1, c), PIVOT_HEADER_FORMAT, outputSheet)
+    }
+  }
+
+  // Apply the bold + #d9e0e8 banding to the header row (anchorRow) and the
+  // Grand Total row (last). Walks every column in the pivot width so the band
+  // is continuous even for cells the engine left empty (which writePivotToSheet
+  // skipped). Re-applied on every recompute since _clearPivotRect wipes formats
+  // first.
+  function _styleHeaderAndTotal(table, outputSheet, anchorRow = 0, anchorCol = 0) {
+    if (!formats?.set || !table.length) return
+    const cols = table[0]?.length || 0
+    const lastRow = anchorRow + table.length - 1
+    for (let c = 0; c < cols; c++) {
+      formats.set(cellId(anchorRow, anchorCol + c), PIVOT_HEADER_FORMAT, outputSheet)
+      if (lastRow > anchorRow) {
+        formats.set(cellId(lastRow, anchorCol + c), PIVOT_HEADER_FORMAT, outputSheet)
+      }
+    }
+  }
+
+  // Double-click drill-down: given a cell (r, c) on the current pivot output
+  // sheet, open the underlying source rows in a fresh sheet (Google Sheets
+  // behaviour). Returns true when it handled the cell so the grid skips the
+  // cell editor; false for non-pivot sheets or non-drillable cells.
+  function drillDownAt(r, c) {
+    const cfg = activePivotConfig.value
+    if (!cfg) return false
+    // The grid passes absolute (r, c); pivotDrillDown works in pivot-local
+    // coordinates, so translate by the pivot's anchor first.
+    const lr = r - (cfg.anchorRow || 0)
+    const lc = c - (cfg.anchorCol || 0)
+    if (lr < 0 || lc < 0) return false
+    const model = computePivotModel(cfg, (s, e, sh) => sheet.getRangeValues(s, e, sh))
+    const res = pivotDrillDown(model, lr, lc)
+    if (!res || !res.rows.length) return false
+
+    const existing = sheet.getSheetNames()
+    let name = 'Drill-down'; let n = 2
+    while (existing.includes(name)) name = `Drill-down ${n++}`
+    sheet.addSheet(name)
+    syncNames()
+
+    const table = [res.headers, ...res.rows]
+    for (let rr = 0; rr < table.length; rr++) {
+      const tr = table[rr]
+      for (let cc = 0; cc < tr.length; cc++) {
+        const v = tr[cc]
+        if (v === null || v === undefined || v === '') continue
+        sheet.setCell(cellId(rr, cc), typeof v === 'number' ? v : String(v), name)
+      }
+    }
+    if (formats?.set) {
+      for (let cc = 0; cc < res.headers.length; cc++) formats.set(cellId(0, cc), { bold: true }, name)
+    }
+
+    switchSheet(name)
+    repopulateGrid()
+    history.push(); isDirty.value = true
+    return true
+  }
+
+  async function recomputePivotsForSheet(srcSheet) {
     if (!pivot.affectsPivot(srcSheet)) return
     for (const cfg of pivot.list()) {
-      if (cfg.sourceSheet === srcSheet) _applyPivotOutput(cfg)
+      if (cfg.sourceSheet === srcSheet) await _applyPivotOutput(cfg)
     }
     repopulateGrid()
   }
 
-  function onPivotConfirm(config) {
+  async function onPivotConfirm(config) {
     const existing = sheet.getSheetNames()
+    let id, outputSheet
     if (config.id) {
       const old = pivot.get(config.id)
-      const outputSheet = old?.outputSheet || `Pivot – ${config.rows.join(', ')}`
+      outputSheet = old?.outputSheet || `Pivot – ${config.rows.join(', ')}`
       pivot.update(config.id, { ...config, outputSheet })
-      _applyPivotOutput({ ...config, outputSheet })
-      switchSheet(outputSheet)
+      id = config.id
     } else {
       const baseName = `Pivot – ${config.rows.join(', ')}`
-      let outputSheet = baseName; let n = 2
+      outputSheet = baseName; let n = 2
       while (existing.includes(outputSheet)) outputSheet = `${baseName} ${n++}`
       sheet.addSheet(outputSheet)
       syncNames()
-      config.outputSheet = outputSheet
-      pivot.add(config)
-      _applyPivotOutput({ ...config, outputSheet })
-      switchSheet(outputSheet)
+      id = pivot.add({ ...config, outputSheet })
     }
+    // Switch first so the user sees the output sheet (with a spinner) while it
+    // builds, then fill it in. Render from the stored config so _applyPivotOutput
+    // can read/write the pivot's _extent by id.
+    switchSheet(outputSheet)
+    await _applyPivotOutput(pivot.get(id))
     repopulateGrid()
     history.push(); isDirty.value = true
   }
 
+  // ── Copy/paste a pivot as a new live pivot ──────────────────────────────────
+
+  // If a selection overlaps a pivot's output on `sheetName`, return a portable
+  // blob (config minus identity/placement) the clipboard can stash so a paste
+  // can mint an independent copy. null when the selection touches no pivot.
+  function getPivotAt(sel, sheetName) {
+    const hit = pivot.list().find(p =>
+      p.outputSheet === sheetName && _rectIntersects(p._extent, sel))
+    if (!hit) return null
+    return {
+      sourceSheet: hit.sourceSheet,
+      sourceRange: hit.sourceRange,
+      rows:   [...(hit.rows   || [])],
+      cols:   [...(hit.cols   || [])],
+      values: (hit.values || []).map(v => ({ ...v })),
+    }
+  }
+
+  // Create a new, independent pivot from a pasted blob, anchored at the paste
+  // cell on `outputSheet` (the current sheet — the headline "multiple pivots on
+  // one page" case). History/dirty are owned by the caller (onDocPaste).
+  async function createPastedPivot(blob, anchorId, outputSheet) {
+    const anch = parseCellId(anchorId)
+    if (!anch) return
+    const id = pivot.add({ ...blob, outputSheet, anchorRow: anch.row, anchorCol: anch.col })
+    await _applyPivotOutput(pivot.get(id))
+    repopulateGrid()
+  }
+
   return {
-    pivotDialogOpen, pivotInitialRange, pivotEditId, pivotEditConfig, pivotVersion,
+    pivotDialogOpen, pivotInitialRange, pivotEditId, pivotEditConfig, pivotVersion, pivotBuilding,
     activePivotConfig, pivotFabStyle, pivotHighlightStyle, pivotBannerMenuOptions,
     isPivotSheet, openPivotDialog, onPivotEdit, onPivotRefresh, onPivotDelete, onPivotConfirm,
-    recomputePivotsForSheet,
+    recomputePivotsForSheet, drillDownAt, getPivotAt, createPastedPivot,
   }
 }

--- a/frontend/src/apps/sheets/components/SheetEditor/useSheetTabs.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useSheetTabs.js
@@ -58,11 +58,14 @@ export function useSheetTabs({ sheet, formats, extras = [], getGrid, activeCell,
     onSwitch?.()
   }
 
-  function addSheet() {
-    const name = 'Sheet' + (sheet.getSheetNames().length + 1)
+  // name is optional: callers normally let us auto-name the next sheet, but
+  // undo/redo passes an explicit name to recreate the exact sheet it removed.
+  function addSheet(name) {
+    name = name || ('Sheet' + (sheet.getSheetNames().length + 1))
     sheet.addSheet(name)
     sheetNames.value = sheet.getSheetNames()
     switchSheet(name)
+    return name
   }
 
   // Returns true on success, false on collision / invalid name.

--- a/frontend/src/apps/sheets/components/SheetEditor/useToolbar.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useToolbar.js
@@ -1,9 +1,12 @@
 import { ref } from 'vue'
+import { formatScope } from '../../engine/format-scope.js'
 
 // getGrid is a getter fn () => grid so the toolbar always has the live reference.
 // markDirty (optional) is called after every mutation so the SheetEditor can
 // trigger autosave — without it, format changes never persist.
-export function useToolbar({ sheet, formats, getGrid, history, selectionIds, syncFlags, markDirty }) {
+// getScope (optional) returns { rect, totalRows, totalCols } so full-column /
+// full-row selections format at the column/row level instead of per-cell.
+export function useToolbar({ sheet, formats, getGrid, history, selectionIds, getScope, syncFlags, markDirty }) {
   const activeFormat = ref({})
 
   // Last-action ledger — what F4 replays. Captured by every toolbar mutator
@@ -17,13 +20,57 @@ export function useToolbar({ sheet, formats, getGrid, history, selectionIds, syn
     )
   }
 
-  // History uses post-mutate semantics: snapshot AFTER each mutation so that
-  // stack[index] always equals the current live state. Undo decrements + reads
-  // stack[index]; redo increments + reads. Reversing the order (push before
-  // mutate) makes a single undo revert TWO actions at once — the visible bug
-  // where formatting one cell + typing into another cell would undo both.
-  function _afterMutation(kind, args) {
-    history.push()
+  function _captureCells(ids, sn) {
+    const out = {}
+    for (const id of ids) out[id] = formats.getCellFormat(id, sn) || null
+    return out
+  }
+  function _captureCols(cols, sn) {
+    const out = {}
+    for (const c of cols) out[c] = formats.getCol(c, sn) || null
+    return out
+  }
+  function _captureRows(rows, sn) {
+    const out = {}
+    for (const r of rows) out[r] = formats.getRow(r, sn) || null
+    return out
+  }
+
+  function _scope() {
+    const s = getScope?.()
+    return s ? formatScope(s.rect, s.totalRows, s.totalCols) : { kind: 'cells' }
+  }
+
+  // Run a format mutation and record it as an op DIFF — never a full-workbook
+  // snapshot (that deep-clone was ~2s on a 2M-cell sheet, ×50 in the undo
+  // stack: the 10s toolbar INP). The op carries before/after for just the
+  // touched layer; applyOp/revertOp restore it. Full-column / full-row
+  // selections format the column/row LAYER (one entry each) instead of writing
+  // per-cell records — that's what stops "bold the whole sheet" from inflating
+  // the payload to 100MB+ and freezing on apply.
+  //
+  // `ops` supplies the three mutation variants: { cols, rows, cells }.
+  // Post-mutate ordering is preserved (push AFTER mutating) so one undo reverts
+  // one action — reversing it was the old format+type double-undo bug.
+  function _formatOp(kind, args, ops) {
+    const sn = sheet.getCurrentSheet()
+    const scope = _scope()
+    const op = { opType: 'format', subSheet: sn }
+    if (scope.kind === 'cols') {
+      op.beforeCols = _captureCols(scope.cols, sn)
+      ops.cols(scope.cols, sn)
+      op.afterCols = _captureCols(scope.cols, sn)
+    } else if (scope.kind === 'rows') {
+      op.beforeRows = _captureRows(scope.rows, sn)
+      ops.rows(scope.rows, sn)
+      op.afterRows = _captureRows(scope.rows, sn)
+    } else {
+      const ids = selectionIds()
+      op.beforeFormats = _captureCells(ids, sn)
+      ops.cells(ids, sn)
+      op.afterFormats = _captureCells(ids, sn)
+    }
+    history.pushOp(op)
     getGrid()?.render()
     refreshActiveFormat()
     syncFlags()
@@ -32,30 +79,40 @@ export function useToolbar({ sheet, formats, getGrid, history, selectionIds, syn
   }
 
   function toggleFmt(key) {
-    formats.toggleRange(selectionIds(), key, sheet.getCurrentSheet())
-    _afterMutation('toggleFmt', [key])
+    _formatOp('toggleFmt', [key], {
+      cols:  (cols, sn) => formats.toggleColumns(cols, key, sn),
+      rows:  (rows, sn) => formats.toggleRows(rows, key, sn),
+      cells: (ids, sn)  => formats.toggleRange(ids, key, sn),
+    })
   }
 
   function setAlign(align) {
-    formats.applyToRange(selectionIds(), { align }, sheet.getCurrentSheet())
-    _afterMutation('setAlign', [align])
+    _formatOp('setAlign', [align], _patchOps({ align }))
   }
 
   function setValign(valign) {
-    formats.applyToRange(selectionIds(), { valign }, sheet.getCurrentSheet())
-    _afterMutation('setValign', [valign])
+    _formatOp('setValign', [valign], _patchOps({ valign }))
   }
 
   function setColor(key, value) {
-    formats.applyToRange(selectionIds(), { [key]: value }, sheet.getCurrentSheet())
-    _afterMutation('setColor', [key, value])
+    _formatOp('setColor', [key, value], _patchOps({ [key]: value }))
   }
 
   function clearFormatting() {
-    const ids = selectionIds()
-    const sh  = sheet.getCurrentSheet()
-    for (const id of ids) formats.clear(id, sh)
-    _afterMutation('clearFormatting', [])
+    _formatOp('clearFormatting', [], {
+      cols:  (cols, sn) => formats.clearColumns(cols, sn),
+      rows:  (rows, sn) => formats.clearRows(rows, sn),
+      cells: (ids, sn)  => { for (const id of ids) formats.clear(id, sn) },
+    })
+  }
+
+  // Shared mutation triple for "apply this format patch" handlers.
+  function _patchOps(patch) {
+    return {
+      cols:  (cols, sn) => formats.applyToColumns(cols, patch, sn),
+      rows:  (rows, sn) => formats.applyToRows(rows, patch, sn),
+      cells: (ids, sn)  => formats.applyToRange(ids, patch, sn),
+    }
   }
 
   function getLastAction() { return lastAction }

--- a/frontend/src/apps/sheets/components/SheetEditor/useVersionHistory.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useVersionHistory.js
@@ -1,5 +1,6 @@
 import { ref }          from 'vue'
 import { parseCellId }  from '../../utils/cells.js'
+import { unpackSheet }  from '../../utils/sheet-codec.js'
 import * as _defaultApi from '../../services/versions.js'
 
 // ── helpers ────────────────────────────────────────────────────────────────────
@@ -57,7 +58,7 @@ function applyEngineState(saved, title,
   const sortFilter = getSortFilter()
   const grid       = getGrid()
   if (saved.formats)    formats?.restore(saved.formats)
-  if (saved.sheet)      sheet?.restore(saved.sheet)
+  if (saved.sheet)      sheet?.restore(unpackSheet(saved.sheet))
   if (saved.merge      && merge?.restore)      merge.restore(saved.merge)
   if (saved.comments   && comments?.restore)   comments.restore(saved.comments)
   if (saved.validation && validation?.restore) validation.restore(saved.validation)

--- a/frontend/src/apps/sheets/engine/chart-data.js
+++ b/frontend/src/apps/sheets/engine/chart-data.js
@@ -59,6 +59,13 @@ function _cartesianOption(config, headerRow, dataRows, encoding, kind) {
 		type:      isLineish ? 'line' : kind,
 		stack:     stacked ? 'total' : undefined,
 		smooth:    !!config.options?.smooth,
+		// Big-data rendering: LTTB downsamples line/area to roughly the pixel
+		// width (visually identical, but plotting 113k points instead of ~1k
+		// was the chart's main render cost); large-mode batches bar/scatter.
+		// Both only engage past their thresholds, so small charts are unaffected.
+		sampling:       isLineish ? 'lttb' : undefined,
+		large:          (kind === 'scatter' || kind === 'bar') || undefined,
+		largeThreshold: 2000,
 		// Line/area normally hide point symbols for a cleaner look — but
 		// ECharts anchors per-point labels on the symbol, so symbol:'none'
 		// silently kills labels too. When labels are on, draw a small dot at

--- a/frontend/src/apps/sheets/engine/clipboard.js
+++ b/frontend/src/apps/sheets/engine/clipboard.js
@@ -3,18 +3,22 @@
 import { colLabel, parseCellId } from '../utils/cells.js'
 import { adjustFormula } from './formula-adjust.js'
 
-export function createClipboard({ sheet, formats, condFormat = null, validation = null }) {
+export function createClipboard({ sheet, formats, condFormat = null, validation = null, getPivotAt = null, createPivotFromPaste = null }) {
 	let _data    = null   // { 'dr,dc': rawValue }
 	let _fmts    = null   // { 'dr,dc': formatObj }
 	let _vals    = null   // { 'dr,dc': validationRule | null }
 	let _mode    = null   // 'copy' | 'cut'
 	let _srcSel  = null   // { r0, c0, r1, c1 } of the source
+	let _pivot   = null   // portable pivot config when the source overlaps a pivot
 
 	// ── Capture ───────────────────────────────────────────────────────────────
 
 	function _capture(sel, mode) {
 		const { r0, c0, r1, c1 } = sel
 		_data = {}; _fmts = {}; _vals = {}; _mode = mode; _srcSel = sel
+		// If the copied range overlaps a pivot, remember its config so a paste
+		// can mint a new live pivot instead of dead values (Google Sheets UX).
+		_pivot = getPivotAt ? getPivotAt(sel, sheet.getCurrentSheet()) : null
 		for (let r = r0; r <= r1; r++) {
 			for (let c = c0; c <= c1; c++) {
 				const key = `${r - r0},${c - c0}`
@@ -111,6 +115,18 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 		const anch = parseCellId(anchorId)
 		if (!anch) return
 		const sh = sheet.getCurrentSheet()
+
+		// A full paste of a copied pivot mints a new live pivot at the anchor
+		// instead of writing static cells — the pivot renders its own output, so
+		// writing the copied values first would just be overwritten (and would
+		// drag the source sheet's formats along). Paste-special (values/formulas/
+		// formats) skips this and pastes dead cells — the "just the numbers" path.
+		// Returns the (async) render promise so the caller can await it before
+		// snapshotting history.
+		if (_pivot && kind === 'all' && createPivotFromPaste) {
+			return createPivotFromPaste(_pivot, anchorId, sh)
+		}
+
 		const targets = _resolveTargets(anch, destSel)
 
 		// Two-pass: build the cell-value map first, hand it to batchSetCells in
@@ -168,17 +184,23 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 		// Only consume the cut buffer when we actually moved content.
 		if (_mode === 'cut' && _srcSel && (kind === 'all' || kind === 'values' || kind === 'formulas')) {
 			const { r0, c0, r1, c1 } = _srcSel
+			// Cells that just received the paste — when source and destination
+			// overlap (e.g. cut C2:C7, paste at C3:C8) the clear pass must NOT
+			// touch these or it wipes the content we just wrote. Only the source
+			// cells outside the destination should be vacated.
+			const destIds = new Set(targets.map(({ r, c }) => colLabel(c) + (r + 1)))
 			const clears = {}
 			for (let r = r0; r <= r1; r++)
 				for (let c = c0; c <= c1; c++) {
 					const id = colLabel(c) + (r + 1)
+					if (destIds.has(id)) continue
 					clears[id] = ''
 					if (formats)    formats.clear(id, sh)
 					if (validation) validation.clear(id, sh)
 				}
 			if (sheet.batchSetCells) sheet.batchSetCells(clears, sh, { replace: false })
 			else                     for (const id of Object.keys(clears)) sheet.setCell(id, '', sh)
-			_data = _fmts = _vals = _mode = _srcSel = null
+			_data = _fmts = _vals = _mode = _srcSel = _pivot = null
 		}
 		// Post-mutate snapshot — history.push() must run after the data has
 		// settled so undo restores the correct state.
@@ -242,7 +264,11 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 	function hasData() { return !!_data }
 	function getMode() { return _mode }
 	function getSourceSel() { return _data ? _srcSel : null }
-	function clear() { _data = _fmts = _vals = _mode = _srcSel = null }
+	// The pivot config captured on copy, if the source overlapped a pivot. Lets
+	// the paste dispatcher branch its undo bookkeeping (a pivot paste needs a
+	// full snapshot, not the cell-diff op).
+	function getPivotBlob() { return _data ? _pivot : null }
+	function clear() { _data = _fmts = _vals = _mode = _srcSel = _pivot = null }
 
-	return { copy, cut, paste, pasteFromText, hasData, getMode, getSourceSel, clear }
+	return { copy, cut, paste, pasteFromText, hasData, getMode, getSourceSel, getPivotBlob, clear }
 }

--- a/frontend/src/apps/sheets/engine/deps.js
+++ b/frontend/src/apps/sheets/engine/deps.js
@@ -145,8 +145,18 @@ export function createDepsEngine() {
 		for (const cellId of Object.keys(depMap[sheet] || {})) removeEdges(cellId, sheet)
 		// reverseDep[sheet] still holds *inbound* edges from *other* sheets'
 		// formulas. Don't reset it wholesale.
-		for (const [cellId, value] of Object.entries(sheetData || {})) {
-			register(cellId, value, sheet)
+		//
+		// Only formula cells (value starting with '=') create edges, so skip
+		// everything else without paying the per-cell register/removeEdges cost.
+		// Iterate with for-in instead of Object.entries to avoid allocating a
+		// 2M-entry pair array — that allocation + its GC was ~1.4s of the cold
+		// load on a 2M-cell sheet (the rest of the cells aren't formulas).
+		if (!sheetData) return
+		for (const cellId in sheetData) {
+			const value = sheetData[cellId]
+			if (typeof value === 'string' && value.charCodeAt(0) === 61 /* '=' */) {
+				register(cellId, value, sheet)
+			}
 		}
 	}
 

--- a/frontend/src/apps/sheets/engine/format-scope.js
+++ b/frontend/src/apps/sheets/engine/format-scope.js
@@ -1,0 +1,25 @@
+// Decide whether a selection should be formatted at the column, row, or cell
+// level. A selection that spans every row of some columns is column-level
+// formatting (one entry per column instead of one per cell); every column of
+// some rows is row-level. Whole-sheet selections land as columns (which cover
+// all cells). Anything else stays per-cell.
+//
+// This is what keeps "bold the whole column / whole sheet" from writing
+// hundreds of thousands of per-cell format records.
+
+export function formatScope(rect, totalRows, totalCols) {
+  if (!rect) return { kind: 'cells' }
+  const { r0, c0, r1, c1 } = rect
+  const fullCols = r0 === 0 && r1 >= totalRows - 1
+  const fullRows = c0 === 0 && c1 >= totalCols - 1
+  // Prefer columns when both hold (whole sheet) — columns cover every cell.
+  if (fullCols) return { kind: 'cols', cols: _range(c0, c1) }
+  if (fullRows) return { kind: 'rows', rows: _range(r0, r1) }
+  return { kind: 'cells' }
+}
+
+function _range(a, b) {
+  const out = []
+  for (let i = a; i <= b; i++) out.push(i)
+  return out
+}

--- a/frontend/src/apps/sheets/engine/formats.js
+++ b/frontend/src/apps/sheets/engine/formats.js
@@ -1,114 +1,229 @@
-// Cell format store — bold, italic, underline, color, backgroundColor, align, wrapText, numberFormat.
-// Pure state, zero DOM dependency.
+// Cell format store — bold, italic, underline, color, backgroundColor, align,
+// wrapText, numberFormat, fontFamily, fontSize, …
+//
+// Three layers per sheet so uniform formatting over a whole column/row costs
+// ONE entry instead of one-per-cell:
+//
+//   store[sheet] = { cells: { cellId: fmt }, cols: { colIdx: fmt }, rows: { rowIdx: fmt } }
+//
+// A cell's effective format is the cascade  col < row < cell  (most specific
+// wins). get() returns that merge, so the renderer — which only ever calls
+// get(id) — picks up column/row formatting with no changes. Bolding all of
+// column F is now `setCol(F, {bold:true})`, not 100k cell writes that bloat the
+// saved payload to 100MB+ and freeze the main thread.
 
 import { parseCellId, colLabel } from '../utils/cells.js'
 import { deepClone } from '../utils/deep-clone.js'
 
 export function createFormatsEngine() {
-	// { sheetName: { cellId: { bold, italic, underline, color, backgroundColor, align } } }
 	const store = {}
 
 	function ensure(sheet) {
-		if (!store[sheet]) store[sheet] = {}
+		if (!store[sheet]) store[sheet] = { cells: {}, cols: {}, rows: {} }
+		return store[sheet]
 	}
 
+	// Raw cell-level format only (no cascade) — the mutation layer reads this so
+	// it never denormalises column/row formats down into a cell.
+	function _cell(id, sheet) { return store[sheet]?.cells?.[id] || {} }
+	function _col(c, sheet)   { return store[sheet]?.cols?.[c]  || {} }
+	function _row(r, sheet)   { return store[sheet]?.rows?.[r]  || {} }
+
+	function _empty(o) { for (const _ in o) return false; return true }
+
+	// Resolved (cascaded) format for a cell — col < row < cell. Fast path: when
+	// no column/row formats exist (the overwhelmingly common case) skip the
+	// cellId parse and hand back the cell entry directly, exactly as the old
+	// per-cell store did — keeps get() cheap on the renderer's hot path.
 	function get(id, sheet = 'Sheet1') {
-		return store[sheet]?.[id] || {}
+		const s = store[sheet]
+		if (!s) return {}
+		const cell = s.cells[id]
+		if (_empty(s.cols) && _empty(s.rows)) return cell || {}
+		const p = parseCellId(id)
+		const col = p ? s.cols[p.col] : undefined
+		const row = p ? s.rows[p.row] : undefined
+		if (!col && !row) return cell || {}
+		return { ...col, ...row, ...cell }
 	}
+
+	// ── Cell-level mutation ───────────────────────────────────────────────────
+
+	// Raw cell-level format (no cascade) — for op capture, so undo restores the
+	// cell layer without baking column/row formats into cells.
+	function getCellFormat(id, sheet = 'Sheet1') { return _cell(id, sheet) }
 
 	function set(id, format, sheet = 'Sheet1') {
-		ensure(sheet)
-		store[sheet][id] = { ...get(id, sheet), ...format }
+		ensure(sheet).cells[id] = { ..._cell(id, sheet), ...format }
 	}
 
-	// Toggle a boolean format key (bold, italic, underline).
+	// Toggle reads the RESOLVED value so a cell in a bold column toggles off by
+	// writing an explicit cell-level override.
 	function toggle(id, key, sheet = 'Sheet1') {
 		set(id, { [key]: !get(id, sheet)[key] }, sheet)
 	}
 
 	function clear(id, sheet = 'Sheet1') {
-		if (store[sheet]) delete store[sheet][id]
+		if (store[sheet]?.cells) delete store[sheet].cells[id]
 	}
 
-	// Apply a format to many cell IDs at once.
 	function applyToRange(ids, format, sheet = 'Sheet1') {
 		for (const id of ids) set(id, format, sheet)
 	}
 
 	function toggleRange(ids, key, sheet = 'Sheet1') {
-		// Toggle on if ANY cell in range lacks the property; toggle off only if ALL have it.
 		const allOn = ids.every(id => !!get(id, sheet)[key])
 		applyToRange(ids, { [key]: !allOn }, sheet)
 	}
 
+	// ── Column / row-level mutation ───────────────────────────────────────────
+	//
+	// Used when a format covers entire columns/rows (header-click or select-all).
+	// One entry covers every cell — present and future — in that column/row.
+
+	function getCol(c, sheet = 'Sheet1') { return _col(c, sheet) }
+	function getRow(r, sheet = 'Sheet1') { return _row(r, sheet) }
+
+	function setCol(c, format, sheet = 'Sheet1') {
+		ensure(sheet).cols[c] = { ..._col(c, sheet), ...format }
+	}
+	function setRow(r, format, sheet = 'Sheet1') {
+		ensure(sheet).rows[r] = { ..._row(r, sheet), ...format }
+	}
+
+	// Exact replacement (not merge) — undo/redo restores a captured layer state.
+	// An empty format drops the entry entirely.
+	function replaceCol(c, format, sheet = 'Sheet1') {
+		const cols = ensure(sheet).cols
+		if (format && Object.keys(format).length) cols[c] = { ...format }
+		else delete cols[c]
+	}
+	function replaceRow(r, format, sheet = 'Sheet1') {
+		const rows = ensure(sheet).rows
+		if (format && Object.keys(format).length) rows[r] = { ...format }
+		else delete rows[r]
+	}
+
+	function applyToColumns(cols, format, sheet = 'Sheet1') {
+		for (const c of cols) setCol(c, format, sheet)
+	}
+	function applyToRows(rows, format, sheet = 'Sheet1') {
+		for (const r of rows) setRow(r, format, sheet)
+	}
+
+	function toggleColumns(cols, key, sheet = 'Sheet1') {
+		const allOn = cols.every(c => !!_col(c, sheet)[key])
+		applyToColumns(cols, { [key]: !allOn }, sheet)
+	}
+	function toggleRows(rows, key, sheet = 'Sheet1') {
+		const allOn = rows.every(r => !!_row(r, sheet)[key])
+		applyToRows(rows, { [key]: !allOn }, sheet)
+	}
+
+	// Clear a whole column/row: drop its layer entry. Per-cell overrides inside
+	// it are left alone (rare, and keeping them undoable without capturing the
+	// whole column keeps clear-formatting cheap).
+	function clearColumns(cols, sheet = 'Sheet1') {
+		const s = store[sheet]
+		if (!s) return
+		for (const c of cols) delete s.cols[c]
+	}
+	function clearRows(rows, sheet = 'Sheet1') {
+		const s = store[sheet]
+		if (!s) return
+		for (const r of rows) delete s.rows[r]
+	}
+
 	// ── Row / column structural shifts ────────────────────────────────────────
 
-	function _shiftFmts(sheet, pred, newIdFn, descending) {
-		ensure(sheet)
-		const st = store[sheet]
-		const entries = Object.entries(st)
+	function _shiftCells(sheet, pred, newIdFn, descending) {
+		const cells = ensure(sheet).cells
+		const entries = Object.entries(cells)
 			.map(([id, fmt]) => ({ id, p: parseCellId(id), fmt }))
 			.filter(({ p }) => p && pred(p))
 		entries.sort((a, b) => descending ? b.p.row - a.p.row || b.p.col - a.p.col
 		                                  : a.p.row - b.p.row || a.p.col - b.p.col)
 		for (const { id, p, fmt } of entries) {
-			delete st[id]
+			delete cells[id]
 			const nid = newIdFn(p)
-			if (nid) st[nid] = fmt
+			if (nid) cells[nid] = fmt
 		}
+	}
+
+	// Shift the integer keys of a col/row layer (≥ `at` move by `delta`).
+	function _shiftAxis(axis, at, delta) {
+		const keys = Object.keys(axis).map(Number).filter(k => k >= at)
+		keys.sort((a, b) => delta > 0 ? b - a : a - b)
+		for (const k of keys) { axis[k + delta] = axis[k]; delete axis[k] }
 	}
 
 	function insertRow(atRow, sheet = 'Sheet1') {
-		_shiftFmts(sheet, p => p.row >= atRow, p => colLabel(p.col) + (p.row + 2), true)
+		_shiftCells(sheet, p => p.row >= atRow, p => colLabel(p.col) + (p.row + 2), true)
+		_shiftAxis(ensure(sheet).rows, atRow, +1)
 	}
 
 	function deleteRow(atRow, sheet = 'Sheet1') {
-		ensure(sheet)
-		for (const id of Object.keys(store[sheet] || {})) {
+		const s = ensure(sheet)
+		for (const id of Object.keys(s.cells)) {
 			const p = parseCellId(id)
-			if (p && p.row === atRow) delete store[sheet][id]
+			if (p && p.row === atRow) delete s.cells[id]
 		}
-		_shiftFmts(sheet, p => p.row > atRow, p => colLabel(p.col) + p.row, false)
+		delete s.rows[atRow]
+		_shiftCells(sheet, p => p.row > atRow, p => colLabel(p.col) + p.row, false)
+		_shiftAxis(s.rows, atRow + 1, -1)
 	}
 
 	function insertCol(atCol, sheet = 'Sheet1') {
-		ensure(sheet)
-		const st = store[sheet]
-		const entries = Object.entries(st)
+		const s = ensure(sheet)
+		const entries = Object.entries(s.cells)
 			.map(([id, fmt]) => ({ id, p: parseCellId(id), fmt }))
 			.filter(({ p }) => p && p.col >= atCol)
 		entries.sort((a, b) => b.p.col - a.p.col)
 		for (const { id, p, fmt } of entries) {
-			delete st[id]
-			st[colLabel(p.col + 1) + (p.row + 1)] = fmt
+			delete s.cells[id]
+			s.cells[colLabel(p.col + 1) + (p.row + 1)] = fmt
 		}
+		_shiftAxis(s.cols, atCol, +1)
 	}
 
 	function deleteCol(atCol, sheet = 'Sheet1') {
-		ensure(sheet)
-		const st = store[sheet]
-		for (const id of Object.keys(st)) {
+		const s = ensure(sheet)
+		for (const id of Object.keys(s.cells)) {
 			const p = parseCellId(id)
-			if (p && p.col === atCol) delete st[id]
+			if (p && p.col === atCol) delete s.cells[id]
 		}
-		const entries = Object.entries(st)
+		delete s.cols[atCol]
+		const entries = Object.entries(s.cells)
 			.map(([id, fmt]) => ({ id, p: parseCellId(id), fmt }))
 			.filter(({ p }) => p && p.col > atCol)
 		entries.sort((a, b) => a.p.col - b.p.col)
 		for (const { id, p, fmt } of entries) {
-			delete st[id]
-			st[colLabel(p.col - 1) + (p.row + 1)] = fmt
+			delete s.cells[id]
+			s.cells[colLabel(p.col - 1) + (p.row + 1)] = fmt
 		}
+		_shiftAxis(s.cols, atCol + 1, -1)
 	}
 
-	// Snapshot / restore for history integration.
+	// ── Snapshot / restore for history integration ────────────────────────────
+
 	function snapshot() {
 		return deepClone(store)
 	}
 
+	// Accepts both the layered shape and the legacy flat { sheet: { cellId: fmt } }
+	// so documents saved before column/row formats keep loading.
 	function restore(snap) {
 		for (const k of Object.keys(store)) delete store[k]
-		for (const [k, v] of Object.entries(snap)) store[k] = v
+		for (const [name, v] of Object.entries(snap || {})) {
+			store[name] = _normalizeSheet(v)
+		}
+	}
+
+	function _normalizeSheet(v) {
+		if (v && (v.cells || v.cols || v.rows)) {
+			return { cells: v.cells || {}, cols: v.cols || {}, rows: v.rows || {} }
+		}
+		return { cells: v || {}, cols: {}, rows: {} }   // legacy flat cell map
 	}
 
 	// ── Sheet-level operations (rename / duplicate / delete) ──────────────────
@@ -121,7 +236,7 @@ export function createFormatsEngine() {
 
 	function duplicateSheet(srcName, newName) {
 		if (store[newName]) return
-		store[newName] = deepClone(store[srcName] || {})
+		store[newName] = deepClone(store[srcName] || { cells: {}, cols: {}, rows: {} })
 	}
 
 	function deleteSheet(name) {
@@ -137,7 +252,10 @@ export function createFormatsEngine() {
 	}
 
 	return {
-		get, set, toggle, clear, applyToRange, toggleRange,
+		get, getCellFormat, set, toggle, clear, applyToRange, toggleRange,
+		getCol, getRow, setCol, setRow, replaceCol, replaceRow,
+		applyToColumns, applyToRows, toggleColumns, toggleRows,
+		clearColumns, clearRows,
 		insertRow, deleteRow, insertCol, deleteCol,
 		renameSheet, duplicateSheet, deleteSheet, reorderSheets,
 		snapshot, restore,

--- a/frontend/src/apps/sheets/engine/history.js
+++ b/frontend/src/apps/sheets/engine/history.js
@@ -61,20 +61,44 @@ export function createHistory({ snapshot, restore, applyOp, revertOp, maxSize = 
 			revertOp?.(entry.op)
 			index--
 		} else {
-			// Snapshot path: step back, restore the previous snapshot. The
-			// touches hint travels with the entry being undone.
+			// Snapshot path: step back to the state of the previous entry.
+			// The touches hint travels with the entry being undone.
 			const undoingTouches = entry.touches || null
 			index--
-			// The entry we land on might also be an op — but a snapshot
-			// undo is "restore to that point in time" regardless, so we
-			// only restore from snapshot entries. If we land on an op
-			// entry, the engine state is already coherent (we just
-			// reverted the op above; there's no separate state to restore).
 			if (stack[index].kind === 'snap') {
+				// Previous entry is itself a snapshot — restore it directly.
 				restore?.(stack[index].snap, { touches: undoingTouches })
+			} else {
+				// Previous entry is an op, which stores only a {before,after}
+				// diff — there is no full snapshot of that point to restore.
+				// Reconstruct it from the nearest preceding snapshot, then
+				// replay the intervening ops forward. Without this the
+				// snapshot mutation being undone would never be reverted (the
+				// engine would stay in its post-mutation state) — e.g. type
+				// into a cell (op) then bold it (snapshot): the first undo
+				// must remove the bold.
+				_rebuildTo(index)
 			}
 		}
 		return true
+	}
+
+	// Bring the engine to the exact state after stack[target] by restoring
+	// the closest snapshot at or before `target` and replaying every op
+	// between it and `target`. Used when a snapshot-undo lands on an op
+	// entry (op entries carry a diff, not a full restorable state).
+	//
+	// This full-restore + replay reverts to a clean reconstructed state; in
+	// collab mode it does not honour the per-cell `touches` optimisation for
+	// this (rarer) path, trading a touch of collab precision for correctness
+	// over the previous behaviour, which silently did nothing.
+	function _rebuildTo(target) {
+		let base = target
+		while (base >= 0 && stack[base].kind !== 'snap') base--
+		if (base >= 0) restore?.(stack[base].snap, { touches: null })
+		for (let k = base + 1; k <= target; k++) {
+			if (stack[k].kind === 'op') applyOp?.(stack[k].op)
+		}
 	}
 
 	function redo() {

--- a/frontend/src/apps/sheets/engine/pivot.js
+++ b/frontend/src/apps/sheets/engine/pivot.js
@@ -37,37 +37,113 @@ function _keyParts(key) { return key.split('\x00') }
 // ── Pivot computation (pure) ─────────────────────────────────────────────────
 
 export function computePivot(config, getRangeValues) {
-  const { sourceSheet, sourceRange, rows, cols, values } = config
-  if (!sourceRange || !rows.length || !values.length) return []
+  return computePivotModel(config, getRangeValues)?.table ?? []
+}
 
+// Like computePivot but returns the full intermediate model alongside the
+// rendered table: { table, headers, dataRows, rowIdxs, colIdxs, valCols,
+// rowKeyList, colKeyList, hasColFields }. Drill-down needs the keys + source
+// rows to map an output cell back to the rows that fed it. Returns null when
+// there's nothing to pivot. computePivot() is a thin wrapper over this.
+export function computePivotModel(config, getRangeValues) {
+  const { sourceSheet, sourceRange } = config
+  if (!sourceRange) return null
   const [start, end] = sourceRange.includes(':') ? sourceRange.split(':') : [sourceRange, sourceRange]
   const data = getRangeValues(start, end, sourceSheet)
-  if (!data || data.length < 2) return []
+  if (!data || data.length < 2) return null
 
-  const headers = data[0].map(h => String(h ?? ''))
+  const plan = _planPivot(config, data[0])
+  if (!plan) return null
   const dataRows = data.slice(1).filter(r => r.some(v => v !== null && v !== undefined && v !== ''))
-  if (!dataRows.length) return []
+  if (!dataRows.length) return null
 
+  // Single pass: collect ordered keys AND fill aggregation buckets together,
+  // computing each row's keys once instead of once per loop (this was two full
+  // walks of every source row — doubled the work on a 100k-row sheet).
+  const acc = _newAccumulator()
+  for (const row of dataRows) _accumulate(acc, row, plan)
+  return _finishModel(acc, dataRows, plan)
+}
+
+// Async variant: reads the source range in row blocks and aggregates each
+// block single-pass, yielding to the event loop between blocks so building a
+// pivot over a 100k-row sheet doesn't freeze the UI. Same getRangeValues
+// contract as the sync version. `onYield` is awaited between blocks and may
+// return false to cancel (e.g. a newer recompute superseded this one).
+export async function computePivotModelAsync(config, getRangeValues, { blockRows = 5000, onYield } = {}) {
+  const { sourceSheet, sourceRange } = config
+  if (!sourceRange) return null
+  const [start, end] = sourceRange.includes(':') ? sourceRange.split(':') : [sourceRange, sourceRange]
+  const s = parseCellId(start), e = parseCellId(end)
+  if (!s || !e) return null
+  const r0 = Math.min(s.row, e.row), rEnd = Math.max(s.row, e.row)
+  const c0 = Math.min(s.col, e.col), c1 = Math.max(s.col, e.col)
+
+  const headerRow = (getRangeValues(cellId(r0, c0), cellId(r0, c1), sourceSheet) || [])[0]
+  const plan = _planPivot(config, headerRow)
+  if (!plan || rEnd <= r0) return null
+
+  const acc = _newAccumulator()
+  const dataRows = []
+  for (let br = r0 + 1; br <= rEnd; br += blockRows) {
+    const be = Math.min(br + blockRows - 1, rEnd)
+    const block = getRangeValues(cellId(br, c0), cellId(be, c1), sourceSheet) || []
+    for (const row of block) {
+      if (!row.some(v => v !== null && v !== undefined && v !== '')) continue
+      _accumulate(acc, row, plan)
+      dataRows.push(row)
+    }
+    if (onYield) { const ok = await onYield(); if (ok === false) return null }
+  }
+  if (!dataRows.length) return null
+  return _finishModel(acc, dataRows, plan)
+}
+
+// Resolve field names → column indices from the header row, validating that
+// there's something to pivot. Returns null when the config can't produce a table.
+function _planPivot(config, headerRowRaw) {
+  const { rows, cols, values } = config
+  if (!rows?.length || !values?.length || !headerRowRaw) return null
+  const headers = headerRowRaw.map(h => String(h ?? ''))
   const rowIdxs = rows.map(f => headers.indexOf(f)).filter(i => i >= 0)
   const colIdxs = (cols || []).map(f => headers.indexOf(f)).filter(i => i >= 0)
   const valCols = values
     .map(v => ({ idx: headers.indexOf(v.field), agg: v.agg || 'sum', field: v.field }))
     .filter(v => v.idx >= 0)
-  if (!valCols.length || !rowIdxs.length) return []
+  if (!valCols.length || !rowIdxs.length) return null
+  return { headers, rows, rowIdxs, colIdxs, valCols, hasColFields: colIdxs.length > 0 }
+}
 
-  // Collect ordered unique row/col keys
-  const rowKeyList = [], colKeyList = []
-  const rowKeySet = new Set(), colKeySet = new Set()
-  const hasColFields = colIdxs.length > 0
-
-  for (const row of dataRows) {
-    const rk = _makeKey(row, rowIdxs)
-    const ck = hasColFields ? _makeKey(row, colIdxs) : ''
-    if (!rowKeySet.has(rk)) { rowKeySet.add(rk); rowKeyList.push(rk) }
-    if (hasColFields && !colKeySet.has(ck)) { colKeySet.add(ck); colKeyList.push(ck) }
+function _newAccumulator() {
+  return {
+    buckets: new Map(),                                   // rk\x01ck\x01vi → [values]
+    rowKeyList: [], colKeyList: [],
+    rowKeySet: new Set(), colKeySet: new Set(),
   }
+}
 
-  // Sort keys: numeric-looking keys numerically, otherwise alphabetically.
+function _accumulate(acc, row, plan) {
+  const { rowIdxs, colIdxs, valCols, hasColFields } = plan
+  const rk = _makeKey(row, rowIdxs)
+  const ck = hasColFields ? _makeKey(row, colIdxs) : ''
+  if (!acc.rowKeySet.has(rk)) { acc.rowKeySet.add(rk); acc.rowKeyList.push(rk) }
+  if (hasColFields && !acc.colKeySet.has(ck)) { acc.colKeySet.add(ck); acc.colKeyList.push(ck) }
+  for (let vi = 0; vi < valCols.length; vi++) {
+    const key = `${rk}\x01${ck}\x01${vi}`
+    let arr = acc.buckets.get(key)
+    if (!arr) { arr = []; acc.buckets.set(key, arr) }
+    const raw = row[valCols[vi].idx]
+    if (raw !== null && raw !== undefined && raw !== '') {
+      const n = Number(raw)
+      arr.push(isNaN(n) ? raw : n)
+    }
+  }
+}
+
+function _finishModel(acc, dataRows, plan) {
+  const { headers, rows, rowIdxs, colIdxs, valCols, hasColFields } = plan
+  const { buckets, rowKeyList, colKeyList } = acc
+
   const _sortKeys = list => list.sort((a, b) => {
     const an = Number(a), bn = Number(b)
     if (!isNaN(an) && !isNaN(bn)) return an - bn
@@ -76,24 +152,7 @@ export function computePivot(config, getRangeValues) {
   _sortKeys(rowKeyList)
   if (hasColFields) _sortKeys(colKeyList)
 
-  // Build aggregation buckets  rk\x01ck\x01vi → [values]
-  const buckets = new Map()
-  for (const row of dataRows) {
-    const rk = _makeKey(row, rowIdxs)
-    const ck = hasColFields ? _makeKey(row, colIdxs) : ''
-    for (let vi = 0; vi < valCols.length; vi++) {
-      const key = `${rk}\x01${ck}\x01${vi}`
-      if (!buckets.has(key)) buckets.set(key, [])
-      const raw = row[valCols[vi].idx]
-      if (raw !== null && raw !== undefined && raw !== '') {
-        const n = Number(raw)
-        buckets.get(key).push(isNaN(n) ? raw : n)
-      }
-    }
-  }
-
   const get = (rk, ck, vi) => buckets.get(`${rk}\x01${ck}\x01${vi}`) || []
-
   const table = []
 
   // ── Header row ────────────────────────────────────────────────────────────
@@ -159,19 +218,62 @@ export function computePivot(config, getRangeValues) {
   }
   table.push(totalRow)
 
-  return table
+  return { table, headers, dataRows, rowIdxs, colIdxs, valCols, rowKeyList, colKeyList, hasColFields }
+}
+
+// Map a clicked pivot output cell (r, c) back to the source rows that feed it.
+// Returns { headers, rows } (rows = matching source data rows) or null if the
+// cell isn't a drillable value/total/row-label cell. Which rows belong to a
+// group depends only on the row-key ∩ col-key — not on which value field is
+// aggregated — so we match on those two and ignore the value index.
+export function pivotDrillDown(model, r, c) {
+  if (!model) return null
+  const { headers, dataRows, rowIdxs, colIdxs, valCols, rowKeyList, colKeyList, hasColFields } = model
+  const nRowFields = rowIdxs.length
+  const nData = rowKeyList.length
+
+  // Row 0 is the header; rows 1..nData are groups; the last row is the grand
+  // total (rk = null → every row group).
+  if (r < 1 || r > nData + 1) return null
+  const rk = r === nData + 1 ? null : rowKeyList[r - 1]
+
+  let ck = null            // null → every column group
+  let drillable = false
+  if (c < nRowFields) {
+    drillable = true                                 // row-label cell → whole row group
+  } else if (hasColFields) {
+    const cp = c - nRowFields
+    const groupCount = colKeyList.length * valCols.length
+    if (cp < groupCount) { ck = colKeyList[Math.floor(cp / valCols.length)]; drillable = true }
+    else if (cp < groupCount + valCols.length) drillable = true   // totals block → all columns
+  } else {
+    const cp = c - nRowFields
+    const width = valCols.length + (valCols.length > 1 ? 1 : 0)   // +1 for the multi-value grand total
+    if (cp >= 0 && cp < width) drillable = true
+  }
+  if (!drillable) return null
+
+  const rows = dataRows.filter(row =>
+    (rk === null || _makeKey(row, rowIdxs) === rk) &&
+    (ck === null || _makeKey(row, colIdxs) === ck))
+  return { headers, rows }
 }
 
 // ── Write pivot output to sheet ──────────────────────────────────────────────
 
-export function writePivotToSheet(table, outputSheet, setCell, clearSheet) {
-  clearSheet(outputSheet)
+// Write a computed pivot table into the sheet, offset by `anchor` (so several
+// pivots can coexist on one sheet at different origins). `clearRect` wipes only
+// the pivot's *previous* output rectangle (`prevExtent`, or nothing on the
+// first render) instead of the whole sheet, so a rebuild never erases a
+// neighbouring pivot or user data.
+export function writePivotToSheet(table, outputSheet, setCell, clearRect, anchor = { row: 0, col: 0 }, prevExtent = null) {
+  clearRect(outputSheet, prevExtent)
   for (let r = 0; r < table.length; r++) {
     for (let c = 0; c < table[r].length; c++) {
       const v = table[r][c]
       if (v === null || v === undefined || v === '') continue
       // Preserve numeric type so values sort/formula-reference correctly.
-      setCell(cellId(r, c), typeof v === 'number' ? v : String(v), outputSheet)
+      setCell(cellId(anchor.row + r, anchor.col + c), typeof v === 'number' ? v : String(v), outputSheet)
     }
   }
 }
@@ -194,9 +296,19 @@ export function createPivotEngine() {
 
   function add(config) {
     const id = config.id || _newId()
-    _pivots[id] = { ...config, id }
+    // anchor defaults go before the spread so an explicit anchor in `config`
+    // wins, while callers that pass none (and old configs) default to A1.
+    _pivots[id] = { anchorRow: 0, anchorCol: 0, ...config, id }
     _notify()
     return id
+  }
+
+  // Record the last-written output rectangle for a pivot. This is transient
+  // render state (recomputed on every render) — it is NOT persisted by
+  // snapshot(), so it never goes stale across reload/undo. Mutates without
+  // notifying since overlays read it via renderVersion, not pivotVersion.
+  function setExtent(id, extent) {
+    if (_pivots[id]) _pivots[id]._extent = extent
   }
 
   function update(id, config) {
@@ -219,14 +331,30 @@ export function createPivotEngine() {
     return Object.values(_pivots).some(p => p.sourceSheet === sheetName)
   }
 
-  function snapshot() { return { pivots: deepClone(_pivots), nextId: _nextId } }
+  // Strip the transient `_extent` render cache from each config so it's never
+  // persisted — a stale rectangle surviving reload/undo would mis-clear cells.
+  function snapshot() {
+    const pivots = {}
+    for (const [id, p] of Object.entries(_pivots)) {
+      const { _extent, ...rest } = p
+      pivots[id] = deepClone(rest)
+    }
+    return { pivots, nextId: _nextId }
+  }
 
   function restore(data) {
     if (!data) return
     _pivots = deepClone(data.pivots || {})
+    // Configs saved before anchors existed lack anchorRow/anchorCol; default
+    // them to A1. restore() bypasses add(), so it must default them itself.
+    // Use == null so a legitimately-stored 0 isn't re-defaulted.
+    for (const p of Object.values(_pivots)) {
+      if (p.anchorRow == null) p.anchorRow = 0
+      if (p.anchorCol == null) p.anchorCol = 0
+    }
     _nextId  = data.nextId  || 1
     _notify()
   }
 
-  return { add, update, remove, list, get, affectsPivot, snapshot, restore, setOnChange }
+  return { add, update, remove, list, get, affectsPivot, snapshot, restore, setOnChange, setExtent }
 }

--- a/frontend/src/apps/sheets/engine/sheet.js
+++ b/frontend/src/apps/sheets/engine/sheet.js
@@ -20,6 +20,11 @@ export function createSheet({ onCellChanged, onCellsChanged } = {}) {
 	const deps     = createDepsEngine()
 	let   current  = 'Sheet1'
 	const circular = new Set()
+	// One-shot { sheet: {maxRow,maxCol} } set by restore() from the unpacked
+	// payload, consumed by the first repopulate so the grid sizes itself without
+	// re-parsing every cell id. Any cell mutation clears it (the extent may have
+	// changed), so a stale value can never drive a later repopulate.
+	let _restoreBounds = null
 	// Optional resolver injected after construction (named ranges live in
 	// a separate engine; we don't want a hard import circle). Returns
 	// `{ sheet, start, end }` or null for unknown names.
@@ -125,6 +130,7 @@ export function createSheet({ onCellChanged, onCellsChanged } = {}) {
 	// ── Mutation ──────────────────────────────────────────────────────────────
 
 	function setCell(id, value, sheet = current) {
+		_restoreBounds = null   // extent may change → drop the load-time bounds hint
 		if (!sheets[sheet]) sheets[sheet] = {}
 		if (value === '' || value == null) delete sheets[sheet][id]
 		else sheets[sheet][id] = value
@@ -158,6 +164,7 @@ export function createSheet({ onCellChanged, onCellsChanged } = {}) {
 	// Returns the diff (before/after) so callers can decide whether to
 	// queue an undo op.
 	function batchSetCells(map, sheet = current, { replace = true } = {}) {
+		_restoreBounds = null
 		if (!sheets[sheet]) sheets[sheet] = {}
 		const sh = sheets[sheet]
 		const before = {}
@@ -296,9 +303,11 @@ export function createSheet({ onCellChanged, onCellsChanged } = {}) {
 	function switchSheet(name) {
 		if (!sheets[name]) { sheets[name] = {}; deps.rebuild({}, name) }
 		current = name
-		// Notify all cells so the canvas is fully redrawn for the new sheet
-		for (const id of Object.keys(sheets[current]))
-			onCellChanged?.(id, getDisplayValue(id, current), current)
+		// No per-cell notify here. The host repaints the whole target sheet
+		// via its own switch handler (useSheetTabs onSwitch → _repopulateGrid),
+		// so firing onCellChanged for every cell of the target sheet just made
+		// the canvas paint it twice — and ran condFormat.invalidate() once per
+		// cell — doubling tab-switch cost on large sheets.
 	}
 
 	function addSheet(name) {
@@ -364,6 +373,20 @@ export function createSheet({ onCellChanged, onCellsChanged } = {}) {
 	function getCurrentSheet()              { return current }
 	function getSheetNames()                { return Object.keys(sheets) }
 	function getRawData(sheet = current)    { return sheets[sheet] || {} }
+	// Live reference to every sheet's cell map. Read-only by contract — the
+	// save path packs straight from this instead of snapshot()'s deepClone,
+	// which on a 2M-cell sheet was ~1.9s of pure waste before serializing.
+	function getAllRaw()                    { return sheets }
+	// Load-time { maxRow, maxCol } for a sheet, or null if unknown. One-shot: the
+	// post-restore repopulate reads it once, then it's gone, so no later
+	// repopulate (after edits / row inserts that bypass setCell) can act on a
+	// stale extent. Lets that one repopulate skip re-deriving bounds from ids.
+	function consumeBounds(sheet = current) {
+		if (!_restoreBounds) return null
+		const b = _restoreBounds[sheet] || null
+		delete _restoreBounds[sheet]
+		return b
+	}
 
 	// ── Snapshot / restore (for history) ─────────────────────────────────────
 
@@ -374,7 +397,7 @@ export function createSheet({ onCellChanged, onCellsChanged } = {}) {
 		}
 	}
 
-	function restore(snap) {
+	function restore(snap, bounds = null) {
 		_clearAllMemo()
 		for (const key of Object.keys(sheets)) delete sheets[key]
 		for (const [name, data] of Object.entries(snap.sheets)) {
@@ -382,6 +405,9 @@ export function createSheet({ onCellChanged, onCellsChanged } = {}) {
 			deps.rebuild(data, name)
 		}
 		current = snap.current
+		// Bounds (from the load path) let the next repopulate skip its per-cell
+		// id re-parse. Set AFTER deps.rebuild so nothing above clears it.
+		_restoreBounds = bounds
 		// One bulk notification instead of N per-cell ones. With 5k rows × 5
 		// cols a per-cell loop was a ~750ms tax on every page load — each
 		// onCellChanged invalidated the cond-format cache, did a format
@@ -398,7 +424,7 @@ export function createSheet({ onCellChanged, onCellsChanged } = {}) {
 	return {
 		setCell, batchSetCells, getCell, getDisplayValue, getCellValue, getRangeValues,
 		switchSheet, addSheet, renameSheet, duplicateSheet, deleteSheet, reorderSheets,
-		getSheetNames, getCurrentSheet, getRawData,
+		getSheetNames, getCurrentSheet, getRawData, getAllRaw, consumeBounds,
 		insertRow, deleteRow, insertCol, deleteCol,
 		snapshot, restore,
 		setNamedRangeResolver,

--- a/frontend/src/apps/sheets/engine/validation.js
+++ b/frontend/src/apps/sheets/engine/validation.js
@@ -7,6 +7,49 @@
 import { parseCellId, colLabel } from '../utils/cells.js'
 import { deepClone } from '../utils/deep-clone.js'
 
+function _checkNumOp(n, op, min, max) {
+  switch (op || 'between') {
+    case 'between':     return (min == null || n >= min) && (max == null || n <= max)
+    case 'not_between': return !(n >= min && n <= max)
+    case 'gt':          return n >  min
+    case 'gte':         return n >= min
+    case 'lt':          return n <  min
+    case 'lte':         return n <= min
+    case 'eq':          return n === min
+    case 'neq':         return n !== min
+    default:            return true
+  }
+}
+
+// Pure rule check — given a rule and a value, is the value allowed?
+// Shared by the engine's per-cell validate() and the canvas painter (which
+// needs to know validity to draw the invalid marker) so there's one source
+// of truth for what "valid" means. No state, no sheet lookup.
+export function checkRule(rule, value) {
+  if (!rule) return { valid: true }
+
+  if (rule.type === 'list') {
+    const opts = rule.options || []
+    const ok = opts.includes(String(value))
+    return { valid: ok, message: ok ? null : (rule.message || `Value must be one of: ${opts.join(', ')}`) }
+  }
+
+  if (rule.type === 'number') {
+    const n = parseFloat(value)
+    if (isNaN(n)) return { valid: false, message: rule.message || 'Value must be a number' }
+    const ok = _checkNumOp(n, rule.operator, rule.min, rule.max)
+    return { valid: ok, message: ok ? null : (rule.message || 'Value out of allowed range') }
+  }
+
+  if (rule.type === 'text_length') {
+    const len = String(value == null ? '' : value).length
+    const ok = _checkNumOp(len, rule.operator, rule.min, rule.max)
+    return { valid: ok, message: ok ? null : (rule.message || 'Text length out of allowed range') }
+  }
+
+  return { valid: true }
+}
+
 export function createValidationEngine() {
   // { sheetName: { cellId: rule } }
   const store = {}
@@ -33,43 +76,8 @@ export function createValidationEngine() {
     return store[sheet] || {}
   }
 
-  function _checkNumOp(n, op, min, max) {
-    switch (op || 'between') {
-      case 'between':     return (min == null || n >= min) && (max == null || n <= max)
-      case 'not_between': return !(n >= min && n <= max)
-      case 'gt':          return n >  min
-      case 'gte':         return n >= min
-      case 'lt':          return n <  min
-      case 'lte':         return n <= min
-      case 'eq':          return n === min
-      case 'neq':         return n !== min
-      default:            return true
-    }
-  }
-
   function validate(id, value, sheet = 'Sheet1') {
-    const rule = get(id, sheet)
-    if (!rule) return { valid: true }
-
-    if (rule.type === 'list') {
-      const ok = rule.options.includes(String(value))
-      return { valid: ok, message: ok ? null : (rule.message || `Value must be one of: ${rule.options.join(', ')}`) }
-    }
-
-    if (rule.type === 'number') {
-      const n = parseFloat(value)
-      if (isNaN(n)) return { valid: false, message: rule.message || 'Value must be a number' }
-      const ok = _checkNumOp(n, rule.operator, rule.min, rule.max)
-      return { valid: ok, message: ok ? null : (rule.message || 'Value out of allowed range') }
-    }
-
-    if (rule.type === 'text_length') {
-      const len = String(value == null ? '' : value).length
-      const ok = _checkNumOp(len, rule.operator, rule.min, rule.max)
-      return { valid: ok, message: ok ? null : (rule.message || 'Text length out of allowed range') }
-    }
-
-    return { valid: true }
+    return checkRule(get(id, sheet), value)
   }
 
   function _shift(sheet, pred, newIdFn, descending) {

--- a/frontend/src/apps/sheets/pages/Home.vue
+++ b/frontend/src/apps/sheets/pages/Home.vue
@@ -49,20 +49,20 @@
              one switches to `subtle` so it inverts against the row. -->
         <div class="home-viewtoggle" role="tablist" aria-label="View mode">
           <Button
-            :variant="viewMode === 'grid' ? 'subtle' : 'ghost'"
-            size="sm" icon="grid"
-            tooltip="Grid view"
-            role="tab"
-            :aria-selected="viewMode === 'grid'"
-            @click="setViewMode('grid')"
-          />
-          <Button
             :variant="viewMode === 'list' ? 'subtle' : 'ghost'"
             size="sm" icon="list"
             tooltip="List view"
             role="tab"
             :aria-selected="viewMode === 'list'"
             @click="setViewMode('list')"
+          />
+          <Button
+            :variant="viewMode === 'grid' ? 'subtle' : 'ghost'"
+            size="sm" icon="grid"
+            tooltip="Grid view"
+            role="tab"
+            :aria-selected="viewMode === 'grid'"
+            @click="setViewMode('grid')"
           />
         </div>
         <Button variant="solid" @click="newSheet()">New Sheet</Button>
@@ -265,17 +265,17 @@ function _flashError(msg) {
   setTimeout(() => { if (errorMessage.value === msg) errorMessage.value = '' }, 4000)
 }
 
-// Persisted view preference. Default to grid because the previews are the
-// existing visual identity of the page; users who want density opt in.
+// Persisted view preference. Default to list for a dense, scannable
+// listing; users who prefer the card previews opt into grid.
 const VIEW_KEY = 'frappe_sheets:home_view_mode'
 const viewMode = ref(_readViewMode())
 
 function _readViewMode() {
   try {
     const v = localStorage.getItem(VIEW_KEY)
-    return v === 'list' || v === 'grid' ? v : 'grid'
+    return v === 'list' || v === 'grid' ? v : 'list'
   } catch (_) {
-    return 'grid'
+    return 'list'
   }
 }
 
@@ -494,7 +494,7 @@ async function duplicate(sheet) {
   align-items: center;
   gap: 16px;
   padding: 0 32px;
-  height: 60px;
+  height: 48px;
   background: var(--surface-base);
   border-bottom: 1px solid var(--outline-gray-2);
   flex-shrink: 0;

--- a/frontend/src/apps/sheets/utils/compress.js
+++ b/frontend/src/apps/sheets/utils/compress.js
@@ -20,6 +20,41 @@ export function isCompressionSupported() {
   return typeof CompressionStream !== 'undefined'
 }
 
+export function isDecompressionSupported() {
+  return typeof DecompressionStream !== 'undefined'
+}
+
+// Inverse of encodeForUpload, for the download path: unwrap a stored envelope
+// ({"_z":"gzip","data":"<base64>"}) back into the plain JSON string. Legacy
+// values (plain JSON, or a server that already decoded) pass through untouched.
+// Lets get_sheet ship the ~1.5MB compressed payload instead of the ~20MB
+// decoded one and decompress here — gunzip runs on a stream, off the critical
+// parse path.
+export async function decodeFromDownload(stored) {
+  if (!stored || typeof stored !== 'string') return stored
+  // Envelopes are tiny and always start with the marker key; the workbook JSON
+  // starts with `{"sheet"`/`{"v"`, so this cheap check avoids parsing a 20MB
+  // legacy string just to discover it isn't an envelope.
+  if (!stored.startsWith('{"_z"')) return stored
+  let env
+  try { env = JSON.parse(stored) } catch { return stored }
+  if (!env || env[MARKER] !== KIND || typeof env.data !== 'string') return stored
+  return _gunzip(env.data)
+}
+
+async function _gunzip(base64) {
+  const bytes  = _base64ToBytes(base64)
+  const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream('gzip'))
+  return new Response(stream).text()
+}
+
+function _base64ToBytes(b64) {
+  const bin = atob(b64)
+  const out = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+  return out
+}
+
 export async function encodeForUpload(jsonString) {
   if (!jsonString || jsonString.length < MIN_BYTES) return jsonString
   if (!isCompressionSupported())                    return jsonString

--- a/frontend/src/apps/sheets/utils/format-number.js
+++ b/frontend/src/apps/sheets/utils/format-number.js
@@ -133,6 +133,30 @@ function _formatWith(map, variant, d) {
   return _dtFmt(cfg[0], cfg[1]).format(d)
 }
 
+// Coerce a cell value into a Date for date/time/datetime formatting, or null
+// if it isn't a date. Handles three shapes:
+//   • a Date instance
+//   • a number / bare numeric string → epoch milliseconds (the serial model)
+//   • a date string like "2026-03-15 14:50:30.789345" or "2026-03-15"
+// For strings we normalise "YYYY-MM-DD HH:mm:ss.ffffff": space→T and trim
+// sub-millisecond digits (JS Date only takes 3), and pin a bare date to local
+// midnight so an ISO date-only value isn't parsed as UTC and shifted a day.
+function _toDate(value) {
+  if (value instanceof Date) return isNaN(value.getTime()) ? null : value
+  if (typeof value === 'number') return isNaN(value) ? null : new Date(value)
+  const s = String(value).trim()
+  if (s === '') return null
+  if (/^-?\d+(\.\d+)?$/.test(s)) return new Date(parseFloat(s))
+  let norm = s.replace(' ', 'T').replace(/(\.\d{3})\d+/, '$1')
+  if (/^\d{4}-\d{2}-\d{2}$/.test(norm)) norm += 'T00:00:00'
+  let d = new Date(norm)
+  if (isNaN(d.getTime())) d = new Date(s)
+  return isNaN(d.getTime()) ? null : d
+}
+
+// Types whose value is a date, not a plain number to round/group.
+const DATE_LIKE = new Set(['date', 'time', 'datetime'])
+
 export function applyNumberFmt(value, format) {
   if (!format) return value
   const { type, variant, decimals } = parseNumberFmt(format)
@@ -141,7 +165,7 @@ export function applyNumberFmt(value, format) {
   // handled by the engine's strict-arithmetic — see toNumStrict.
   if (type === 'text') return value == null ? '' : String(value)
   const n = parseFloat(value)
-  if (isNaN(n) && type !== 'date') return value
+  if (isNaN(n) && !DATE_LIKE.has(type)) return value
   if (type === 'number') {
     const loc = NUMBER_LOCALES[variant] !== undefined ? NUMBER_LOCALES[variant] : undefined
     return _numFmt(loc, decimals).format(n)
@@ -154,21 +178,18 @@ export function applyNumberFmt(value, format) {
   }
   if (type === 'percentage') return (n * 100).toFixed(decimals ?? 2) + '%'
   if (type === 'date') {
-    const ms = parseFloat(value)
-    if (isNaN(ms)) return value
-    const d = new Date(ms)
+    const d = _toDate(value)
+    if (!d) return value
     return _formatWith(DATE_FORMATTERS, variant, d) ?? d.toLocaleDateString()
   }
   if (type === 'time') {
-    const ms = parseFloat(value)
-    if (isNaN(ms)) return value
-    const d = new Date(ms)
+    const d = _toDate(value)
+    if (!d) return value
     return _formatWith(TIME_FORMATTERS, variant, d) ?? d.toLocaleTimeString()
   }
   if (type === 'datetime') {
-    const ms = parseFloat(value)
-    if (isNaN(ms)) return value
-    const d = new Date(ms)
+    const d = _toDate(value)
+    if (!d) return value
     // Combined variant is `<dateKey>_<timeKey>` (e.g. dmy_hm12). Falls back
     // to the locale's default for either half if a token is missing/unknown.
     const [dv, tv] = String(variant || '').split('_')

--- a/frontend/src/apps/sheets/utils/sheet-codec.js
+++ b/frontend/src/apps/sheets/utils/sheet-codec.js
@@ -1,0 +1,150 @@
+// Compact row-major codec for the `sheet` slice of a saved payload.
+//
+// In memory the engine keys every cell by its id ({ "A1": "v", "B1": "w" }).
+// As JSON that map inflates ~2.5x: each value drags its cell-id key along, and
+// the keys are unique so gzip can't crush them. Packing each sheet into per-row
+// value arrays drops the keys entirely. On a 2M-cell import the `sheet` slice
+// goes 36MB -> 20MB uncompressed and 6.4MB -> 1.5MB gzipped, and stringify
+// drops from ~1s to ~0.15s. The smaller uncompressed size is also what the
+// server's size gate measures, so real sheets stop tripping the limit.
+//
+// Wire shape (version 2):
+//   { v: 2, current: "Sheet1",
+//     sheets: { Sheet1: { rows: { "0": ["a","b"], "4": [null,"x"] } } } }
+// Row keys are 0-based row indices; array slots are 0-based columns. Empty
+// slots / holes are dropped on unpack. Legacy payloads (no `v`) are the old
+// { sheets: { name: { cellId: val } }, current } shape and pass through
+// untouched in both directions, so old documents keep loading and migrate
+// lazily on their next save.
+
+import { colLabel } from './cells.js'
+
+const PACK_VERSION = 2
+
+// Pack a `{ sheets, current }` snapshot into the compact wire shape. Reads the
+// input without mutating it, so callers can hand it the engine's live data.
+// Synchronous: use for the keepalive/unmount save, where the page may die
+// before an async pass could finish. Interactive autosave should prefer
+// packSheetChunked so it doesn't freeze the main thread.
+export function packSheet(snap) {
+  const sheets = (snap && snap.sheets) || {}
+  const out = {}
+  for (const name of Object.keys(sheets)) {
+    const cells = sheets[name]
+    const rows = {}
+    for (const id in cells) _packCellInto(rows, id, cells[id])
+    out[name] = { rows }
+  }
+  return { v: PACK_VERSION, current: (snap && snap.current) || 'Sheet1', sheets: out }
+}
+
+// Async, chunked variant of packSheet. Yields to the event loop every
+// `yieldEvery` cells so a multi-million-cell pack doesn't monopolise the main
+// thread — that monopoly was the ~6s "input delay" before the browser could
+// even handle a keystroke during autosave. Consistency: each sheet's cell ids
+// are snapshotted up front and each value read is atomic, so a concurrent edit
+// at worst lands in the NEXT autosave rather than tearing this payload (still
+// valid JSON either way; isDirty stays set so the follow-up save catches it).
+export async function packSheetChunked(snap, { yieldEvery = 50000 } = {}) {
+  const sheets = (snap && snap.sheets) || {}
+  const out = {}
+  let since = 0
+  for (const name of Object.keys(sheets)) {
+    const cells = sheets[name]
+    const rows = {}
+    const ids = Object.keys(cells)
+    for (let k = 0; k < ids.length; k++) {
+      _packCellInto(rows, ids[k], cells[ids[k]])
+      if (++since >= yieldEvery) { since = 0; await _tick() }
+    }
+    out[name] = { rows }
+  }
+  return { v: PACK_VERSION, current: (snap && snap.current) || 'Sheet1', sheets: out }
+}
+
+function _tick() { return new Promise(r => setTimeout(r, 0)) }
+
+// Unpack the compact wire shape back to `{ sheets, current }`. Anything that
+// isn't a version-2 envelope (legacy snapshots, the empty-default fallback) is
+// returned unchanged.
+export function unpackSheet(data) {
+  if (!data || typeof data !== 'object' || data.v !== PACK_VERSION) return data
+  const sheets = {}
+  const packed = data.sheets || {}
+  for (const name of Object.keys(packed)) sheets[name] = _unpackRows(packed[name] && packed[name].rows)
+  return { sheets, current: data.current || 'Sheet1' }
+}
+
+// Cheaply derive each sheet's { maxRow, maxCol } extent straight from the
+// packed structure — row keys and array lengths give it without parsing a
+// single cell id. The load path hands this to the engine so the grid can size
+// itself without _repopulateGrid re-parsing every cell id for bounds (~0.5s on
+// a 2M-cell sheet). Returns null for legacy/non-packed input.
+export function boundsOf(data) {
+  if (!data || typeof data !== 'object' || data.v !== PACK_VERSION) return null
+  const out = {}
+  const packed = data.sheets || {}
+  for (const name of Object.keys(packed)) {
+    const rows = packed[name] && packed[name].rows
+    let maxRow = 0, maxCol = 0
+    for (const r in (rows || {})) {
+      const arr = rows[r]
+      if (!arr) continue
+      const row = +r
+      if (row > maxRow) maxRow = row
+      if (arr.length - 1 > maxCol) maxCol = arr.length - 1
+    }
+    out[name] = { maxRow, maxCol }
+  }
+  return out
+}
+
+// Column labels are stable, so cache them module-wide and grow on demand —
+// unpacking 2M cells otherwise re-walks colLabel's character loop per cell.
+const _labelCache = []
+function _label(c) {
+  for (let i = _labelCache.length; i <= c; i++) _labelCache[i] = colLabel(i)
+  return _labelCache[c]
+}
+
+// Place one cell into the row-major `rows` accumulator. Shared by the sync and
+// chunked packers so they can't drift. Skips empties and malformed ids.
+function _packCellInto(rows, id, v) {
+  if (v === '' || v == null) return
+  const { row, col } = _parseId(id)
+  if (!(row >= 0) || !(col >= 0)) return
+  let arr = rows[row]
+  if (!arr) arr = rows[row] = []
+  arr[col] = v
+}
+
+function _unpackRows(rows) {
+  const cells = {}
+  if (!rows) return cells
+  for (const r in rows) {
+    const arr = rows[r]
+    if (!arr) continue
+    // Build the row suffix once and reuse cached column labels, instead of
+    // recomputing colLabel + string concat for every one of the row's cells.
+    const suffix = String(+r + 1)
+    for (let c = 0; c < arr.length; c++) {
+      const v = arr[c]
+      if (v === '' || v == null) continue
+      cells[_label(c) + suffix] = v
+    }
+  }
+  return cells
+}
+
+// Regex-free cell-id parse — the hot path runs once per cell on multi-million
+// cell sheets, where `parseCellId`'s regex + split is ~3x slower. Returns
+// 0-based { row, col }; row/col are NaN for malformed ids and skipped above.
+function _parseId(id) {
+  let i = 0, col = 0
+  for (; i < id.length; i++) {
+    const cc = id.charCodeAt(i)
+    if (cc < 65 || cc > 90) break // first non-A-Z char starts the row digits
+    col = col * 26 + (cc - 64)
+  }
+  return { row: +id.slice(i) - 1, col: col - 1 }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
     "dns-lexicon~=3.20.1",
     "markdown-it-py~=4.0.0",
     "ansible-runner~=2.4.1",
+    # sheets — AI Assist (Claude)
+    "anthropic>=0.40",
 ]
 
 [deploy.dependencies.apt]

--- a/suite/sheets/ai/client.py
+++ b/suite/sheets/ai/client.py
@@ -1,0 +1,119 @@
+"""Call Claude to turn a plain-language request into a spreadsheet action plan.
+
+The model is *forced* to emit its answer through the ``emit_actions`` tool, so
+the response is always structured — never prose we'd have to parse. It produces
+formulas and ranges; it never computes values (the sheet engine does that on
+the client). The Anthropic SDK is imported lazily so a server without the
+package fails with a clear message instead of breaking ``api`` import, and the
+API key is never logged.
+"""
+
+import json
+
+import frappe
+
+DEFAULT_MODEL = "claude-opus-4-8"
+MAX_TOKENS = 2048
+
+_SYSTEM = (
+	"You are a spreadsheet assistant embedded in a web spreadsheet app. "
+	"The user selects cells and asks, in plain language, for something to be done. "
+	"You translate that into concrete actions via the emit_actions tool.\n\n"
+	"Rules:\n"
+	"- To put something in a cell, emit a setCell action whose `formula` is a "
+	"spreadsheet formula starting with '=' (e.g. '=SUM(B2:B10)'), or a literal "
+	"value for plain text/numbers. Mirror the formula style already used in the "
+	"sample rows.\n"
+	"- NEVER compute results yourself — always return a formula and let the app "
+	"evaluate it. Reference real cells/ranges from the provided context.\n"
+	"- Target cells using A1 notation (column letters + row number), consistent "
+	"with the selection and headers given.\n"
+	"- If the request is a question about the data rather than an edit, return a "
+	"single `answer` action with a short text reply and do not modify any cells.\n"
+	"- Only emit actions you are confident about. If nothing sensible can be done, "
+	"return an empty actions list."
+)
+
+_EMIT_ACTIONS_TOOL = {
+	"name": "emit_actions",
+	"description": "Return the ordered list of spreadsheet actions that fulfil the user's request.",
+	"input_schema": {
+		"type": "object",
+		"properties": {
+			"actions": {
+				"type": "array",
+				"description": "Actions to apply, in order.",
+				"items": {
+					"type": "object",
+					"properties": {
+						"type": {
+							"type": "string",
+							"enum": ["setCell", "answer"],
+							"description": "setCell writes one cell; answer is a read-only text reply.",
+						},
+						"cell": {
+							"type": "string",
+							"description": "For setCell: target cell in A1 notation, e.g. 'B2'.",
+						},
+						"formula": {
+							"type": "string",
+							"description": "For setCell: a formula starting with '=', or a literal value.",
+						},
+						"text": {
+							"type": "string",
+							"description": "For answer: the text reply to show the user.",
+						},
+					},
+					"required": ["type"],
+					"additionalProperties": False,
+				},
+			}
+		},
+		"required": ["actions"],
+		"additionalProperties": False,
+	},
+}
+
+
+def generate_actions(prompt: str, context: dict, api_key: str, model: str) -> list:
+	"""Ask Claude for an action plan. Returns the raw `actions` list (unvalidated)."""
+	try:
+		import anthropic
+	except ImportError:
+		frappe.throw(
+			"AI Assist needs the 'anthropic' Python package, which isn't installed "
+			"on the server. Run `bench pip install anthropic`."
+		)
+
+	client = anthropic.Anthropic(api_key=api_key)
+	user_content = (
+		"Worksheet context (JSON):\n"
+		f"{json.dumps(context, default=str)}\n\n"
+		f"User request: {prompt}"
+	)
+
+	try:
+		resp = client.messages.create(
+			model=model or DEFAULT_MODEL,
+			max_tokens=MAX_TOKENS,
+			system=_SYSTEM,
+			tools=[_EMIT_ACTIONS_TOOL],
+			tool_choice={"type": "tool", "name": "emit_actions"},
+			output_config={"effort": "low"},
+			messages=[{"role": "user", "content": user_content}],
+		)
+	except anthropic.AuthenticationError:
+		frappe.throw("The Anthropic API key is invalid or has been revoked.")
+	except anthropic.RateLimitError:
+		frappe.throw("The AI service is rate-limited right now. Try again in a moment.")
+	except anthropic.APIStatusError as e:
+		# Never echo the exception body — it can include request details.
+		frappe.throw(f"The AI request failed (HTTP {e.status_code}).")
+	except anthropic.APIConnectionError:
+		frappe.throw("Could not reach the AI service. Check the server's network access.")
+
+	for block in resp.content:
+		if getattr(block, "type", None) == "tool_use" and block.name == "emit_actions":
+			actions = (block.input or {}).get("actions")
+			return actions if isinstance(actions, list) else []
+	return []

--- a/suite/sheets/ai/context.py
+++ b/suite/sheets/ai/context.py
@@ -1,0 +1,145 @@
+"""Assemble a compact, model-friendly view of a worksheet.
+
+The whole workbook blob is far too large (and too private) to hand to the
+model. Instead we send only what's needed to write a correct formula against
+the user's selection: the header row, an inferred type per column, a bounded
+sample of data rows, and the current selection in A1 notation. Everything is
+hard-capped (rows, columns, total bytes) so a huge sheet can't blow the
+request up — `truncated` tells the model the view is partial.
+
+The cell map handed in is the flat ``{cellId: rawValue}`` form stored under
+``decoded["sheet"]["sheets"][sheetName]`` — values are raw primitives, and a
+formula is just a string beginning with ``=``.
+"""
+
+import re
+
+_CELL_RE = re.compile(r"^([A-Za-z]+)([0-9]+)$")
+
+MAX_SAMPLE_ROWS = 25
+MAX_COLS = 40
+MAX_CONTEXT_BYTES = 12_000
+
+
+def col_to_letters(c: int) -> str:
+	"""0-indexed column number → spreadsheet letters (0 → 'A', 26 → 'AA')."""
+	s = ""
+	c += 1
+	while c:
+		c, rem = divmod(c - 1, 26)
+		s = chr(65 + rem) + s
+	return s
+
+
+def parse_cell(cid: str):
+	"""'B2' → (row, col) 0-indexed, or None if it isn't a plain cell id."""
+	m = _CELL_RE.match(cid or "")
+	if not m:
+		return None
+	letters, digits = m.group(1).upper(), m.group(2)
+	col = 0
+	for ch in letters:
+		col = col * 26 + (ord(ch) - 64)
+	return int(digits) - 1, col - 1
+
+
+def _selection_a1(sel: dict) -> dict:
+	"""Render the selection rectangle + active cell in A1 notation."""
+	try:
+		r0, c0 = int(sel.get("r0", 0)), int(sel.get("c0", 0))
+		r1, c1 = int(sel.get("r1", r0)), int(sel.get("c1", c0))
+	except (TypeError, ValueError):
+		r0 = c0 = r1 = c1 = 0
+	lo_r, hi_r = sorted((r0, r1))
+	lo_c, hi_c = sorted((c0, c1))
+	start = f"{col_to_letters(lo_c)}{lo_r + 1}"
+	end = f"{col_to_letters(hi_c)}{hi_r + 1}"
+	rng = start if start == end else f"{start}:{end}"
+	return {"range": rng, "active": sel.get("active") or start}
+
+
+def _infer_type(values: list) -> str:
+	"""Cheap per-column type from its sampled values."""
+	seen = False
+	for v in values:
+		if v is None or v == "":
+			continue
+		seen = True
+		if isinstance(v, str) and v.startswith("="):
+			return "formula"
+		if isinstance(v, (int, float)):
+			continue
+		if isinstance(v, str):
+			if re.match(r"^-?\d+(\.\d+)?$", v.strip()):
+				continue
+			if re.match(r"^\d{1,4}[-/]\d{1,2}[-/]\d{1,4}", v.strip()):
+				return "date"
+			return "text"
+		return "text"
+	return "number" if seen else "empty"
+
+
+def build_context(cell_map: dict, sheet_name: str, sel: dict) -> dict:
+	"""Build the compact context dict sent to the model."""
+	cells = {}
+	max_r = max_c = -1
+	for cid, val in (cell_map or {}).items():
+		pc = parse_cell(cid)
+		if pc is None:
+			continue
+		r, c = pc
+		cells[(r, c)] = val
+		if r > max_r:
+			max_r = r
+		if c > max_c:
+			max_c = c
+
+	selection = _selection_a1(sel or {})
+	if max_r < 0:
+		return {"sheet_name": sheet_name, "empty": True, "selection": selection}
+
+	ncols = min(max_c + 1, MAX_COLS)
+	nrows = min(max_r + 1, MAX_SAMPLE_ROWS)
+
+	headers = {}
+	for c in range(ncols):
+		v = cells.get((0, c))
+		if v not in (None, ""):
+			headers[col_to_letters(c)] = v
+
+	column_types = {}
+	for c in range(ncols):
+		col_vals = [cells.get((r, c)) for r in range(1, nrows)]
+		column_types[col_to_letters(c)] = _infer_type(col_vals)
+
+	sample_rows = []
+	for r in range(nrows):
+		row = {"_row": r + 1}
+		has = False
+		for c in range(ncols):
+			v = cells.get((r, c))
+			if v not in (None, ""):
+				row[col_to_letters(c)] = v
+				has = True
+		if has:
+			sample_rows.append(row)
+
+	ctx = {
+		"sheet_name": sheet_name,
+		"selection": selection,
+		"headers": headers,
+		"column_types": column_types,
+		"sample_rows": sample_rows,
+		"truncated": (max_r + 1 > nrows) or (max_c + 1 > ncols),
+	}
+	_enforce_byte_cap(ctx)
+	return ctx
+
+
+def _enforce_byte_cap(ctx: dict) -> None:
+	"""Drop sample rows from the end until the serialized context fits."""
+	import json
+
+	while len(json.dumps(ctx, default=str)) > MAX_CONTEXT_BYTES and ctx["sample_rows"]:
+		ctx["sample_rows"].pop()
+		ctx["truncated"] = True

--- a/suite/sheets/ai/heuristics.py
+++ b/suite/sheets/ai/heuristics.py
@@ -1,0 +1,159 @@
+"""Deterministic intent → grid-action resolver (no LLM).
+
+Handles the common, unambiguous spreadsheet asks straight from the prompt +
+selection — aggregations, running totals, percent-of-total, and row-wise text
+transforms. Returns a list of actions when it confidently recognises the ask,
+or ``None`` when it can't, which lets the caller fall back to the model (or, in
+the keyless demo, show a hint).
+
+This is the fast path of a heuristic-first → model-fallback cascade: the muscle
+-memory operations resolve here instantly, for free, and deterministically (no
+hallucinated formula); the model is only paid for when the heuristic shrugs.
+
+Design rule: be CONSERVATIVE. If the prompt carries a condition or qualifier a
+template can't honour ("sum where status is paid", "top 5", "group by"), return
+None so the model handles it rather than silently doing the wrong thing. Only
+formula functions the engine actually implements are emitted.
+"""
+
+import re
+
+from suite.sheets.ai.context import col_to_letters
+
+# A match here means the ask has nuance a template can't capture — hand it off.
+# Deliberately excludes positional words like "below"/"above" (which appear in
+# plain asks such as "total the column below").
+_QUALIFIER_RE = re.compile(
+	r"\b(where|only|unless|except|exclud\w*|filter|"
+	r"greater than|less than|more than|at least|at most|between|"
+	r"group by|grouped by|pivot|distinct|"
+	r"top \d|bottom \d|highest \d|lowest \d|"
+	r"if)\b",
+	re.I,
+)
+
+# Aggregations: keyword → engine function. Order matters (specific first).
+_AGG = [
+	(("average", "avg", "mean"), "AVERAGE"),
+	(("median",), "MEDIAN"),
+	(("count", "how many", "number of"), "COUNTA"),
+	(("maximum", "max", "largest", "highest", "biggest"), "MAX"),
+	(("minimum", "min", "smallest", "lowest"), "MIN"),
+	(("standard deviation", "std dev", "stdev"), "STDEV"),
+	(("product", "multiply"), "PRODUCT"),
+	(("sum", "total", "add up", "add them", "add these"), "SUM"),
+]
+
+# Row-wise transforms: keyword → builder(srcCellRef) → formula string.
+_TRANSFORM = [
+	(("uppercase", "upper case", "all caps"), lambda c: f"=UPPER({c})"),
+	(("lowercase", "lower case"), lambda c: f"=LOWER({c})"),
+	(("proper case", "title case", "propercase", "titlecase", "capitalize"), lambda c: f"=PROPER({c})"),
+	(("trim", "remove whitespace", "remove extra spaces", "strip spaces"), lambda c: f"=TRIM({c})"),
+	(("length", "char count", "number of characters"), lambda c: f"=LEN({c})"),
+	(("domain",), lambda c: f'=MID({c},FIND("@",{c})+1,LEN({c}))'),
+	(("before the @", "email user", "username", "local part"), lambda c: f'=LEFT({c},FIND("@",{c})-1)'),
+	(("first name",), lambda c: f'=LEFT({c},FIND(" ",{c})-1)'),
+	(("last name", "surname"), lambda c: f'=MID({c},FIND(" ",{c})+1,LEN({c}))'),
+]
+
+
+def resolve(prompt: str, context: dict, sel: dict):
+	"""Return a list of actions for a recognised ask, else None."""
+	p = (prompt or "").lower().strip()
+	if not p:
+		return None
+	rect = _rect(sel)
+	if rect is None:
+		return None
+	lo_r, hi_r, lo_c, hi_c = rect
+	qualified = bool(_QUALIFIER_RE.search(p))
+
+	# 1) Running total / percent-of-total — single column, multi-row.
+	if not qualified and hi_r > lo_r and lo_c == hi_c:
+		if "running total" in p or "cumulative" in p:
+			return _running_total(rect)
+		if any(x in p for x in ("percent of total", "% of total", "percentage of total", "share of total")):
+			return _pct_of_total(rect)
+
+	# 2) Aggregation — one or more columns.
+	if not qualified:
+		fn = _detect(p, _AGG)
+		if fn:
+			return _aggregate(fn, rect, context)
+
+	# 3) Row-wise transform — single column.
+	if lo_c == hi_c:
+		builder = _detect(p, _TRANSFORM)
+		if builder:
+			return _transform(builder, rect)
+
+	return None
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _rect(sel):
+	try:
+		r0, c0 = int(sel.get("r0", 0)), int(sel.get("c0", 0))
+		r1, c1 = int(sel.get("r1", r0)), int(sel.get("c1", c0))
+	except (TypeError, ValueError, AttributeError):
+		return None
+	lo_r, hi_r = sorted((r0, r1))
+	lo_c, hi_c = sorted((c0, c1))
+	return lo_r, hi_r, lo_c, hi_c
+
+
+def _detect(p, table):
+	for keys, val in table:
+		if any(k in p for k in keys):
+			return val
+	return None
+
+
+def _aggregate(fn, rect, context):
+	lo_r, hi_r, lo_c, hi_c = rect
+	col_types = (context or {}).get("column_types") or {}
+	actions = []
+	if hi_r > lo_r:
+		# Multi-row: result under each column (skip text columns unless counting).
+		for c in range(lo_c, hi_c + 1):
+			letter = col_to_letters(c)
+			if fn != "COUNTA" and col_types.get(letter) == "text":
+				continue
+			rng = f"{letter}{lo_r + 1}:{letter}{hi_r + 1}"
+			actions.append({"type": "setCell", "cell": f"{letter}{hi_r + 2}", "formula": f"={fn}({rng})"})
+	else:
+		# Single row: result in the next cell to the right.
+		rng = f"{col_to_letters(lo_c)}{lo_r + 1}:{col_to_letters(hi_c)}{lo_r + 1}"
+		actions.append({"type": "setCell", "cell": f"{col_to_letters(hi_c + 1)}{lo_r + 1}", "formula": f"={fn}({rng})"})
+	return actions or None
+
+
+def _running_total(rect):
+	lo_r, hi_r, lo_c, _ = rect
+	src, out = col_to_letters(lo_c), col_to_letters(lo_c + 1)
+	return [
+		{"type": "setCell", "cell": f"{out}{r + 1}", "formula": f"=SUM({src}${lo_r + 1}:{src}{r + 1})"}
+		for r in range(lo_r, hi_r + 1)
+	]
+
+
+def _pct_of_total(rect):
+	lo_r, hi_r, lo_c, _ = rect
+	src, out = col_to_letters(lo_c), col_to_letters(lo_c + 1)
+	total = f"SUM({src}${lo_r + 1}:{src}${hi_r + 1})"
+	return [
+		{"type": "setCell", "cell": f"{out}{r + 1}", "formula": f"={src}{r + 1}/{total}"}
+		for r in range(lo_r, hi_r + 1)
+	]
+
+
+def _transform(builder, rect):
+	lo_r, hi_r, lo_c, _ = rect
+	src, out = col_to_letters(lo_c), col_to_letters(lo_c + 1)
+	return [
+		{"type": "setCell", "cell": f"{out}{r + 1}", "formula": builder(f"{src}{r + 1}")}
+		for r in range(lo_r, hi_r + 1)
+	]

--- a/suite/sheets/ai/validate.py
+++ b/suite/sheets/ai/validate.py
@@ -1,0 +1,46 @@
+"""Server-side validation of the action plan the model returns.
+
+The model is *forced* to call ``emit_actions``, but its arguments are still
+untrusted — clamp and drop anything that doesn't match the contract before the
+frontend applies it to the grid. Phase 1 understands two action types:
+
+  * ``setCell`` — write a formula/value into one cell (A1 notation)
+  * ``answer``  — read-only text response, no mutation
+"""
+
+import re
+
+_CELL_RE = re.compile(r"^[A-Z]{1,3}[1-9][0-9]{0,6}$")
+
+MAX_ACTIONS = 200
+MAX_FORMULA_LEN = 1000
+MAX_ANSWER_LEN = 4000
+
+
+def clean_actions(raw) -> list:
+	"""Return the subset of `raw` that is well-formed; drop the rest."""
+	if not isinstance(raw, list):
+		return []
+	out = []
+	for a in raw[:MAX_ACTIONS]:
+		if not isinstance(a, dict):
+			continue
+		t = a.get("type")
+		if t == "setCell":
+			cell = str(a.get("cell") or "").strip().upper()
+			if not _CELL_RE.match(cell):
+				continue
+			formula = a.get("formula")
+			if not isinstance(formula, str):
+				if formula is None:
+					continue
+				formula = str(formula)
+			if len(formula) > MAX_FORMULA_LEN:
+				continue
+			out.append({"type": "setCell", "cell": cell, "formula": formula})
+		elif t == "answer":
+			text = a.get("text")
+			if not isinstance(text, str) or not text.strip():
+				continue
+			out.append({"type": "answer", "text": text[:MAX_ANSWER_LEN]})
+	return out

--- a/suite/sheets/api.py
+++ b/suite/sheets/api.py
@@ -1,5 +1,8 @@
+import json
+
 import frappe
 
+from suite.sheets.doctype.sheet.cell_codec import cell_map as unpack_cell_map
 from suite.sheets.doctype.sheet.storage import decode_sheets_data
 from suite.sheets.versioning import save as save_mod
 
@@ -283,16 +286,20 @@ def list_sheets() -> list:
 
 
 @frappe.whitelist()
-def get_sheet(name: str) -> dict:
+def get_sheet(name: str, compressed: int = 0) -> dict:
 	# `frappe.get_doc` does NOT check read permission by itself — without
 	# this guard, any logged-in user who knows a sheet id could exfiltrate
 	# its contents.
 	frappe.has_permission("Sheet", doc=name, throw=True)
 	doc = frappe.get_doc("Sheet", name)
+	# When the client can gunzip (DecompressionStream), ship the stored envelope
+	# as-is — ~1.5MB instead of the ~20MB decoded JSON for a big sheet — and let
+	# it decompress. Clients without it (older Safari) get the decoded payload.
+	raw = doc.sheets_data
 	return {
 		"name": doc.name,
 		"title": doc.title,
-		"sheets_data": decode_sheets_data(doc.sheets_data),
+		"sheets_data": raw if frappe.utils.cint(compressed) else decode_sheets_data(raw),
 	}
 
 
@@ -383,6 +390,129 @@ def duplicate_sheet(name: str) -> str:
 	plain = decode_sheets_data(src.sheets_data)
 	result = save_mod.save_sheet(f"{src.title} (copy)", plain, name=None)
 	return result["name"] if isinstance(result, dict) else result
+
+
+# ── AI Assist ───────────────────────────────────────────────────────────────
+#
+# Configuration lives in the "Sheets AI Settings" singleton but is driven
+# entirely from the in-app settings panel — never the desk form. The key is a
+# Password field (encrypted at rest) and is NEVER returned to the browser:
+# `get_ai_settings` reports only whether a key is on file, and the cleartext is
+# read server-side via `get_password` only at the moment of the Anthropic call.
+
+AI_SETTINGS = "Sheets AI Settings"
+DEFAULT_AI_MODEL = "claude-opus-4-8"
+
+
+def _ai_key(doc) -> str:
+	"""Return the decrypted API key, or '' if none is stored.
+
+	`get_password` raises when the field is empty unless `raise_exception` is
+	off — coerce the absent case to '' so callers can treat it as a plain bool.
+	"""
+	return doc.get_password("api_key", raise_exception=False) or ""
+
+
+@frappe.whitelist()
+def get_ai_settings() -> dict:
+	# Read is ungated: the response only reveals whether AI is available
+	# (enabled + a key is configured), never the key itself, so any logged-in
+	# user can decide whether to show the "Ask" entry point.
+	doc = frappe.get_cached_doc(AI_SETTINGS)
+	return {
+		"enabled": bool(doc.enabled),
+		"model": doc.model or DEFAULT_AI_MODEL,
+		"keyIsSet": bool(_ai_key(doc)),
+	}
+
+
+@frappe.whitelist()
+def save_ai_settings(api_key: str = "", enabled: int = 0, model: str = "") -> dict:
+	# Write is gated to System Manager — this is org-level config, not per-sheet.
+	if "System Manager" not in frappe.get_roles():
+		frappe.throw("Not permitted to change AI settings", frappe.PermissionError)
+	doc = frappe.get_doc(AI_SETTINGS)
+	doc.enabled = 1 if int(enabled or 0) else 0
+	if model:
+		doc.model = model
+	# An empty api_key means "leave the existing key untouched" — the panel
+	# never receives the real key back, so it submits "" unless the admin
+	# deliberately types a new one.
+	if api_key:
+		doc.api_key = api_key
+	doc.save(ignore_permissions=True)
+	frappe.clear_document_cache(AI_SETTINGS, AI_SETTINGS)
+	return get_ai_settings()
+
+
+MAX_PROMPT_LEN = 2000
+
+
+@frappe.whitelist()
+def ai_assist(name: str, prompt: str, selection: str) -> dict:
+	"""Turn a plain-language request into a validated spreadsheet action plan.
+
+	`selection` is a JSON string describing the active selection
+	({sheet, r0, c0, r1, c1, active}). The sheet is decoded server-side, a
+	compact context is assembled, and the model is asked for actions — which
+	are validated here before returning. We do NOT mutate the sheet: the
+	frontend applies the actions through the engine so they join the existing
+	undo / op-log / autosave pipeline.
+	"""
+	# AI mutates the grid → require write permission, matching save/record_op.
+	frappe.has_permission("Sheet", doc=name, ptype="write", throw=True)
+
+	prompt = (prompt or "").strip()
+	if not prompt:
+		frappe.throw("Type what you'd like to do first.")
+	if len(prompt) > MAX_PROMPT_LEN:
+		frappe.throw("That request is too long.")
+
+	cfg = frappe.get_cached_doc(AI_SETTINGS)
+	if not cfg.enabled:
+		frappe.throw("AI Assist isn't enabled for this site.")
+	model = cfg.model or DEFAULT_AI_MODEL
+
+	sel = frappe.parse_json(selection) if selection else {}
+	if not isinstance(sel, dict):
+		sel = {}
+	sheet_name = sel.get("sheet") or "Sheet1"
+
+	data = json.loads(decode_sheets_data(frappe.get_doc("Sheet", name).sheets_data) or "{}")
+	cell_map = unpack_cell_map((data or {}).get("sheet") or {}, sheet_name)
+
+	from suite.sheets.ai import context as ai_context
+	from suite.sheets.ai import heuristics as ai_heuristics
+	from suite.sheets.ai import validate as ai_validate
+
+	ctx = ai_context.build_context(cell_map, sheet_name, sel)
+
+	# Heuristic-first cascade: common, unambiguous asks resolve locally —
+	# instant, free, deterministic — and only fall through to the model when
+	# they can't. `mock`/`demo` is the keyless mode: heuristic only, no call.
+	raw = ai_heuristics.resolve(prompt, ctx, sel)
+	source = "heuristic"
+	if raw is None:
+		if model.strip().lower() in ("mock", "demo"):
+			raw = [{"type": "answer", "text": _DEMO_HINT}]
+			source = "demo"
+		else:
+			key = _ai_key(cfg)
+			if not key:
+				frappe.throw("No Anthropic API key is configured.")
+			from suite.sheets.ai import client as ai_client
+			raw = ai_client.generate_actions(prompt, ctx, key, model)
+			source = "model"
+
+	return {"actions": ai_validate.clean_actions(raw), "model": model, "source": source}
+
+
+_DEMO_HINT = (
+	"Local demo (no API key). I can do: sum / average / count / min / max / median over a "
+	"selection, running totals and percent-of-total down a column, and text transforms "
+	"(uppercase, lowercase, proper case, trim, length, email domain, first/last name). "
+	"For anything beyond that, add an Anthropic API key in AI settings."
+)
 
 
 # ── internal helpers ──────────────────────────────────────────────────────────

--- a/suite/sheets/doctype/sheet/cell_codec.py
+++ b/suite/sheets/doctype/sheet/cell_codec.py
@@ -1,0 +1,48 @@
+"""Read cell values out of the compact `sheet` slice of a saved payload.
+
+The frontend stores each sheet's cells per-row to keep the JSON small (see
+``frontend/src/utils/sheet-codec.js``): the inflated ``{cellId: value}`` map
+becomes ``{rows: {"0": [v, v, ...]}}``. Server code that needs the actual cell
+values back — currently only AI Assist context-building — goes through here so
+it transparently understands both the compact (v2) and legacy shapes.
+"""
+
+PACK_VERSION = 2
+
+
+def cell_map(sheet_slice: dict | None, sheet_name: str) -> dict:
+	"""Return ``{cellId: value}`` for one sheet from a saved ``sheet`` slice.
+
+	Accepts both the compact v2 envelope and the legacy
+	``{sheets: {name: {cellId: val}}}`` shape; unknown input yields ``{}``.
+	"""
+	if not isinstance(sheet_slice, dict):
+		return {}
+	sheet = (sheet_slice.get("sheets") or {}).get(sheet_name)
+	if not isinstance(sheet, dict):
+		return {}
+	if sheet_slice.get("v") != PACK_VERSION:
+		return sheet  # legacy: already a {cellId: value} map
+	return _unpack_rows(sheet.get("rows") or {})
+
+
+def _unpack_rows(rows: dict) -> dict:
+	out = {}
+	for r, arr in rows.items():
+		if not arr:
+			continue
+		row = int(r)
+		for col, value in enumerate(arr):
+			if value is None or value == "":
+				continue
+			out[f"{_col_label(col)}{row + 1}"] = value
+	return out
+
+
+def _col_label(idx: int) -> str:
+	s = ""
+	idx += 1
+	while idx > 0:
+		idx, rem = divmod(idx - 1, 26)
+		s = chr(65 + rem) + s
+	return s

--- a/suite/sheets/doctype/sheet/cell_codec.py
+++ b/suite/sheets/doctype/sheet/cell_codec.py
@@ -31,7 +31,12 @@ def _unpack_rows(rows: dict) -> dict:
 	for r, arr in rows.items():
 		if not arr:
 			continue
-		row = int(r)
+		try:
+			row = int(r)
+		except (TypeError, ValueError):
+			continue
+		if not isinstance(arr, list):
+			continue
 		for col, value in enumerate(arr):
 			if value is None or value == "":
 				continue

--- a/suite/sheets/doctype/sheet/sheet.py
+++ b/suite/sheets/doctype/sheet/sheet.py
@@ -38,9 +38,13 @@ class Sheet(Document):
 		if self.sheets_data:
 			if not isinstance(self.sheets_data, str):
 				frappe.throw("sheets_data must be a string")
-			if effective_size(self.sheets_data) > MAX_SHEETS_DATA_BYTES:
+			size = effective_size(self.sheets_data)
+			if size > MAX_SHEETS_DATA_BYTES:
+				limit_mb = MAX_SHEETS_DATA_BYTES // (1024 * 1024)
+				size_mb = size / (1024 * 1024)
 				frappe.throw(
-					f"Sheet exceeds the {MAX_SHEETS_DATA_BYTES // (1024 * 1024)} MB limit"
+					f"This spreadsheet is {size_mb:.1f} MB, over the {limit_mb} MB limit. "
+					f"Remove some data or split it across multiple spreadsheets."
 				)
 			try:
 				json.loads(decode_sheets_data(self.sheets_data))

--- a/suite/sheets/doctype/sheet/storage.py
+++ b/suite/sheets/doctype/sheet/storage.py
@@ -20,10 +20,15 @@ import gzip
 import io
 import json
 
-# Cap on the *uncompressed* (effective workbook) byte size. Lifted from the
-# original 5 MB now that compression gives us roughly 5-10× headroom for the
-# same physical row size.
-MAX_SHEETS_DATA_BYTES = 30 * 1024 * 1024
+# Cap on the *uncompressed* (effective workbook) byte size. This is the real
+# constraint: the whole workbook is decompressed and parsed into memory on
+# every load, so the uncompressed size — not the on-disk compressed size —
+# bounds load RAM and parse time. The client now stores cells in a compact
+# row-major form (see frontend/src/utils/sheet-codec.js) that roughly halves
+# this number for the same data, so the cap is raised to 75 MB to give real
+# headroom (~6M cells of typical data) without inviting sheets so large they
+# lag on load.
+MAX_SHEETS_DATA_BYTES = 75 * 1024 * 1024
 
 # Hard upper bound on the size of a compressed base64 payload we are willing
 # to even *attempt* to decompress. Anything legitimately ≤ MAX_SHEETS_DATA_BYTES
@@ -108,9 +113,14 @@ def _bounded_decompress(b64_payload: str) -> bytes:
 def _throw_bomb(reason: str | None = None) -> None:
 	import frappe
 
+	limit_mb = MAX_SHEETS_DATA_BYTES // (1024 * 1024)
 	frappe.throw(
 		reason
-		or f"Sheet exceeds the {MAX_SHEETS_DATA_BYTES // (1024 * 1024)} MB limit"
+		or (
+			f"This spreadsheet is too large to save (over {limit_mb} MB uncompressed). "
+			f"This usually comes from formatting applied across a very large range — "
+			f"clear formatting you don't need, or split the data across sheets."
+		)
 	)
 
 

--- a/suite/sheets/doctype/sheet/test_cell_codec.py
+++ b/suite/sheets/doctype/sheet/test_cell_codec.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026, Asif and Contributors
+# See license.txt
+"""Tests for the server-side compact `sheet` slice reader.
+
+Parity with the frontend packer (frontend/src/utils/sheet-codec.js) matters:
+AI Assist reads cell values out of a payload the browser wrote, so the column
+labelling and row offsets must agree exactly.
+"""
+
+import unittest
+
+from suite.sheets.doctype.sheet.cell_codec import cell_map
+
+
+class CellMapCompact(unittest.TestCase):
+	def test_reads_compact_v2_slice(self):
+		# As produced by packSheet: rows keyed by 0-based row, value arrays by
+		# 0-based column.
+		slice_ = {
+			"v": 2,
+			"current": "Sheet1",
+			"sheets": {"Sheet1": {"rows": {"0": ["Date", "Day"], "1": ["2013-11-26", "26"]}}},
+		}
+		self.assertEqual(
+			cell_map(slice_, "Sheet1"),
+			{"A1": "Date", "B1": "Day", "A2": "2013-11-26", "B2": "26"},
+		)
+
+	def test_column_labels_past_z(self):
+		# Column 26 -> "AA"; holes before it must not become cells.
+		slice_ = {"v": 2, "sheets": {"S": {"rows": {"0": [None] * 26 + ["wide"]}}}}
+		self.assertEqual(cell_map(slice_, "S"), {"AA1": "wide"})
+
+	def test_skips_empty_and_null_slots(self):
+		slice_ = {"v": 2, "sheets": {"S": {"rows": {"0": ["keep", "", None]}}}}
+		self.assertEqual(cell_map(slice_, "S"), {"A1": "keep"})
+
+	def test_unknown_sheet_is_empty(self):
+		slice_ = {"v": 2, "sheets": {"S": {"rows": {"0": ["x"]}}}}
+		self.assertEqual(cell_map(slice_, "Other"), {})
+
+
+class CellMapLegacy(unittest.TestCase):
+	def test_reads_legacy_unversioned_slice(self):
+		slice_ = {"current": "Sheet1", "sheets": {"Sheet1": {"A1": "old", "B2": "v"}}}
+		self.assertEqual(cell_map(slice_, "Sheet1"), {"A1": "old", "B2": "v"})
+
+	def test_garbage_inputs_yield_empty(self):
+		self.assertEqual(cell_map(None, "Sheet1"), {})
+		self.assertEqual(cell_map({}, "Sheet1"), {})
+		self.assertEqual(cell_map({"sheets": {"Sheet1": "nope"}}, "Sheet1"), {})
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/suite/sheets/doctype/sheet_op_log/sheet_op_log.py
+++ b/suite/sheets/doctype/sheet_op_log/sheet_op_log.py
@@ -32,6 +32,7 @@ VALID_OP_TYPES = {
 	"comment",
 	"cond-format",
 	"chart",         # chart add / edit / move / resize / delete
+	"ai_assist",     # cells written by an accepted AI Assist action plan
 }
 
 

--- a/suite/sheets/doctype/sheets_ai_settings/sheets_ai_settings.json
+++ b/suite/sheets/doctype/sheets_ai_settings/sheets_ai_settings.json
@@ -1,0 +1,50 @@
+{
+ "actions": [],
+ "creation": "2026-06-22 00:00:00",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "enabled",
+  "model",
+  "api_key"
+ ],
+ "fields": [
+  {
+   "fieldname": "enabled",
+   "fieldtype": "Check",
+   "label": "Enable AI Assist",
+   "default": "0"
+  },
+  {
+   "fieldname": "model",
+   "fieldtype": "Data",
+   "label": "Model",
+   "default": "claude-opus-4-8"
+  },
+  {
+   "fieldname": "api_key",
+   "fieldtype": "Password",
+   "label": "Anthropic API Key"
+  }
+ ],
+ "issingle": 1,
+ "links": [],
+ "modified": "2026-06-22 00:00:00",
+ "modified_by": "Administrator",
+ "module": "Sheets",
+ "name": "Sheets AI Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "read": 1,
+   "role": "System Manager",
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 0
+}

--- a/suite/sheets/doctype/sheets_ai_settings/sheets_ai_settings.py
+++ b/suite/sheets/doctype/sheets_ai_settings/sheets_ai_settings.py
@@ -1,0 +1,29 @@
+"""Sheets AI Settings — singleton vault for the AI Assist configuration.
+
+Holds the Anthropic API key (encrypted at rest via the Password fieldtype),
+the enable toggle, and the model id. The desk form is unused — configuration
+happens in-app via the ``get_ai_settings`` / ``save_ai_settings`` endpoints
+(see ``suite.sheets.api``). The key is never returned to the browser; the server
+reads the cleartext with ``self.get_password("api_key")`` only when calling
+the Anthropic API.
+"""
+
+import frappe
+from frappe.model.document import Document
+
+
+class SheetsAISettings(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		api_key: DF.Password | None
+		enabled: DF.Check
+		model: DF.Data | None
+	# end: auto-generated types
+
+	pass

--- a/suite/sheets/versioning/save.py
+++ b/suite/sheets/versioning/save.py
@@ -187,9 +187,13 @@ def _validate_payload(sheets_data: str) -> str:
 	if not isinstance(sheets_data, str):
 		frappe.throw("sheets_data must be a JSON string")
 	plain = decode_sheets_data(sheets_data)
-	if len(plain.encode("utf-8")) > MAX_SHEETS_DATA_BYTES:
+	size = len(plain.encode("utf-8"))
+	if size > MAX_SHEETS_DATA_BYTES:
+		limit_mb = MAX_SHEETS_DATA_BYTES // (1024 * 1024)
 		frappe.throw(
-			f"Sheet exceeds the {MAX_SHEETS_DATA_BYTES // (1024 * 1024)} MB limit"
+			f"This spreadsheet is {_format_bytes(size)}, over the {limit_mb} MB limit. "
+			f"Formatting applied across a very large range is the usual cause — clear "
+			f"formatting you don't need, or split the data across sheets."
 		)
 	try:
 		json.loads(plain)

--- a/suite/sheets/www/sheets.html
+++ b/suite/sheets/www/sheets.html
@@ -36,6 +36,8 @@
         sentry_dsn:         {{ sentry_dsn         | tojson }},
         sentry_environment: {{ sentry_environment | tojson }},
         sentry_release:     {{ sentry_release     | tojson }},
+        ai_assist_enabled:        {{ ai_assist_enabled        | tojson }},
+        ai_assist_can_configure:  {{ ai_assist_can_configure  | tojson }},
       },
     };
   </script>

--- a/suite/sheets/www/sheets.py
+++ b/suite/sheets/www/sheets.py
@@ -88,6 +88,27 @@ def get_context(context):
     context.sitename       = frappe.local.site
     context.socketio_port  = frappe.conf.get("socketio_port") or 9000
 
+    # AI Assist gating for the SPA topbar. `extend_bootinfo` is desk-only, so —
+    # like the collab flags above — these are seeded here into the SPA's boot:
+    #   * ai_assist_enabled gates the "Ask AI" entry point — true only when an
+    #     admin has both stored a key and flipped the toggle.
+    #   * ai_assist_can_configure gates the in-app "AI settings" menu item.
+    # The key itself never reaches the browser. Guarded so a missing /
+    # not-yet-migrated settings doctype degrades to "AI off" rather than 500.
+    context.ai_assist_enabled = False
+    context.ai_assist_can_configure = "System Manager" in frappe.get_roles()
+    try:
+        ai = frappe.get_cached_doc("Sheets AI Settings")
+        # The keyless "mock"/"demo" model counts as configured so the button
+        # shows for a local, no-spend trial.
+        model = (ai.model or "").strip().lower()
+        has_creds = model in ("mock", "demo") or bool(
+            ai.get_password("api_key", raise_exception=False)
+        )
+        context.ai_assist_enabled = bool(ai.enabled and has_creds)
+    except Exception:
+        pass
+
     # Vite-emitted hashed bundle URLs — see _asset_paths above.
     context.assets = _asset_paths()
 


### PR DESCRIPTION
Ports everything `frappe/sheets` gained since the Phase-5 monorepo cutoff
(`rename: spreadsheet → sheets`, 2026-06-15) into `suite/sheets`. ~20
substantive commits, grouped here into 4 thematic commits.

Path/namespace adaptation matches the original port: `frontend/src/*` →
`frontend/src/apps/sheets/*` (the `pages/SheetEditor/` dir → `components/SheetEditor/`),
backend `sheets/*` → `suite/sheets/*` (nested `sheets/sheets/doctype` flattened),
`sheets.api.*`/`sheets.versioning.*` → `suite.sheets.*`, and the frappe-ui
beta.9 design-token renames (`--surface-white` → `--surface-base`, etc.).

## What's included
- **perf** — compact row-major sheet codec, compressed `sheets_data`, clone-free
  chunked autosave, async pivot/chart aggregation + downsampling, lazy-viewport
  canvas render (switch/load no longer scale with cell count).
- **AI Assist (Claude)** — `sheets/ai` package + `ai_assist`/`get_ai_settings`/
  `save_ai_settings` endpoints, `Sheets AI Settings` doctype, AskBar +
  AISettingsDialog, www boot gating. Adds `anthropic>=0.40`. The key never
  reaches the client; the model returns formulas/ranges, never computed values.
- **editor features** — column/row formats with cascade, validation chips with
  per-option colors, Frappe-styled color picker, pivot copy/paste → live pivot,
  pivot drill-down to source rows.
- **fixes** — clipboard cut/paste overlap, op-based undo history repair, home
  list-first view + shorter topbar.

## Not included (deliberate)
- Built frontend bundle (`sheets/public/sheets/`) — gitignored; suite builds its own.
- Frontend `.test.js` files — the original Phase-5 port dropped sheets frontend
  tests; not reintroduced here. Backend Python tests (e.g. `test_cell_codec.py`)
  are included.

## Verification done
Static: adaptation transform proven complete against all 161 ported files, no
leftover un-prefixed `sheets.` backend refs, all design tokens resolve, Python
compiles, JS syntax checks pass, new-module imports + AI endpoint wiring confirmed.

## Verification still needed
A frontend build was **not** run (full monorepo install). Please build and do
the Phase-6 smoke test per `PORT-NOTES.md`: log in at `suite.localhost/sheets`,
confirm listing/open/edit/persist, charts, version history, validation chips,
color picker, and AI Assist (with a key configured). Run `bench migrate` to
create the `Sheets AI Settings` doctype.