### PR TITLE
fix(mail): add backward-compatible redirects for `mail.api.spamd.*`

### DIFF
--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -227,16 +227,19 @@ override_doctype_class = {
 # ============================================================================
 override_whitelisted_methods = {
 	"frappe.core.doctype.user.user.update_password": "suite.mail.events.update_password",
-	# mail — backward-compatible redirects for the standalone `mail` app's
-	# endpoints (still called by Frappe Framework's frappe/email/frappemail.py)
-	# now that the API lives under the combined `suite` app.
+	# Auth
 	"mail.api.auth.validate": "suite.mail.api.auth.validate",
+	# Outbound
 	"mail.api.outbound.upload_attachment": "suite.mail.api.outbound.upload_attachment",
 	"mail.api.outbound.send": "suite.mail.api.outbound.send",
 	"mail.api.outbound.send_raw": "suite.mail.api.outbound.send_raw",
+	# Inbound
 	"mail.api.inbound.fetch_blob": "suite.mail.api.inbound.fetch_blob",
 	"mail.api.inbound.pull": "suite.mail.api.inbound.pull",
 	"mail.api.inbound.pull_raw": "suite.mail.api.inbound.pull_raw",
+	# SpamD
+	"mail.api.spamd.scan": "suite.mail.api.spamd.scan",
+	"mail.api.spamd.get_spam_score": "suite.mail.api.spamd.get_spam_score",
 }
 
 # ============================================================================


### PR DESCRIPTION
## Description

Adds backward-compatible whitelisted-method redirects for the standalone `mail` app's SpamD endpoints, now that the API lives under the combined `suite` app:

- `mail.api.spamd.scan` → `suite.mail.api.spamd.scan`
- `mail.api.spamd.get_spam_score` → `suite.mail.api.spamd.get_spam_score`

Also groups the existing redirects under section comments (Auth / Outbound / Inbound / SpamD) for readability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)