### PR TITLE
fix(mail): sidebar background in mobile view

### DIFF
--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -17,7 +17,7 @@
 				logo: branding.data?.brand_html || MailLogo,
 			}"
 			:sections="sidebarItems"
-			:class="{ 'fixed left-0 top-0 z-10 w-60': isMobile }"
+			:class="{ 'fixed left-0 top-0 z-10 w-60 !bg-surface-base': isMobile }"
 			:disable-collapse="isMobile"
 		>
 			<template #footer-items="{ isCollapsed }">


### PR DESCRIPTION
frappe-ui `Sidebar` is transparent in dark mode by design. It sits flush on `surface-base` and is set apart only by its border. 

But mail's mobile view re-uses the same `Sidebar` as a fixed overlay over content, so the transparent background lets content show through. Since we add the overlay behavior, this fix forces an opaque `bg-surface-base` only on mobile, leaving desktop untouched. 

If the design intent changes, this can move upstream to `frappe-ui` later. For now, keeping it in our app makes sense.