### PR TITLE
feat(sheets): private-by-default with an explicit public link

### DIFF
--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -8,7 +8,11 @@ import { isWrapText } from '../utils/text-wrap.js'
 
 export { colLabel, cellId, parseCellId } from '../utils/cells.js'
 
-export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getFormat, onFill, onBatchCommit, getMergeInfo, isSlave, getMasterId, getComment, getValidation, getCondFormat, getRightInset, onHyperlinkClick, onDropdownClick, onResizeEnd, getSheetNames, getCurrentSheet, getEditingHomeSheet } = {}) {
+export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getFormat, onFill, onBatchCommit, getMergeInfo, isSlave, getMasterId, getComment, getValidation, getCondFormat, getRightInset, onHyperlinkClick, onDropdownClick, onResizeEnd, getSheetNames, getCurrentSheet, getEditingHomeSheet, readOnly = false } = {}) {
+  // When true, the grid is a viewer: the in-cell editor never opens, so no
+  // keystroke / F2 / double-click can mutate a cell. Selection, scrolling and
+  // copy still work. Toggled at runtime via setReadOnly (public link viewers).
+  let _readOnly = readOnly
   const ctx = canvas.getContext('2d')
   const dpr = window.devicePixelRatio || 1
 
@@ -626,6 +630,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
   }
 
   function showEditor(initialValue, mode = 'enter') {
+    if (_readOnly) return   // viewer: editing is disabled
     editMode = mode
     selEnd = { r: sel.r, c: sel.c }
     const fmt = getFormat ? getFormat(cellId(sel.r, sel.c)) : {}
@@ -1294,6 +1299,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     if (e.key === 'F2') { e.preventDefault(); showEditor(data[cellId(r, c)] ?? '', 'edit'); return }
 
     if ((e.key === 'Delete' || e.key === 'Backspace') && !mod) {
+      if (_readOnly) return   // viewer: clearing cells is disabled
       e.preventDefault()
       const { r0, c0, r1, c1 } = getSelRange()
       if (r0 === r1 && c0 === c1) {
@@ -1574,6 +1580,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     expandCols, getTotalCols,
     setZoom, getZoom,
     viewSnapshot, viewRestore,
+    setReadOnly: (v) => { _readOnly = !!v },
     destroy,
   }
 }

--- a/frontend/src/apps/sheets/components/SheetEditor/ShareDialog.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/ShareDialog.vue
@@ -20,27 +20,24 @@
             <Button
               variant="outline"
               size="sm"
-              :iconLeft="generalAccess === 'all' ? 'globe' : 'lock'"
+              :iconLeft="generalAccess === 'public' ? 'globe' : 'lock'"
               iconRight="chevron-down"
-              :label="generalAccess === 'all' ? 'Accessible to all' : 'Restricted'"
+              :label="generalAccess === 'public' ? 'Anyone with the link' : 'Restricted'"
               class="sd-pill-btn"
             />
           </template>
         </Dropdown>
 
-        <Dropdown v-if="generalAccess === 'all'" :options="generalRoleOpts" placement="bottom-end">
-          <template #default>
-            <Button
-              variant="outline"
-              size="sm"
-              icon-left="eye"
-              icon-right="chevron-down"
-              :label="generalRole === '1' ? 'Can edit' : 'Can view'"
-              class="sd-pill-btn"
-            />
-          </template>
-        </Dropdown>
+        <!-- Public is deliberately view-only — no edit option (mirrors Drive's
+             public-link model). The role pill is static so the scope is clear. -->
+        <span v-if="generalAccess === 'public'" class="sd-view-only">Can view</span>
       </div>
+
+      <!-- Sub-label clarifies the scope: a public sheet needs no login. -->
+      <p v-if="generalAccess === 'public'" class="sd-access-hint">
+        Anyone with the link can open this sheet read-only — no sign-in required.
+      </p>
+      <p v-else class="sd-access-hint">Only people added below can open this sheet.</p>
 
       <div class="sd-divider" />
 
@@ -166,8 +163,12 @@ const props = defineProps({
   sheetId:     { type: String,  default: '' },
   sheetTitle:  { type: String,  default: '' },
   ownerId:     { type: String,  default: '' },
+  // Whether this sheet currently has the public link enabled. Owned by the
+  // editor (it learns this from get_sheet); the dialog seeds its toggle from
+  // it on open and emits `public-changed` when the owner flips it.
+  isPublic:    { type: Boolean, default: false },
 })
-const emit = defineEmits(['update:modelValue', 'shares-changed'])
+const emit = defineEmits(['update:modelValue', 'shares-changed', 'public-changed'])
 
 // ── open/close ─────────────────────────────────────────────────────────────
 
@@ -185,8 +186,17 @@ watch(show, (open) => {
     pendingRole.value = '0'
     searchQuery.value = ''
     searchResults.value = []
+    // Re-seed the public toggle from the editor's flag on each open.
+    generalAccess.value = props.isPublic ? 'public' : 'restricted'
     fetchShares()
   }
+})
+
+// Keep the toggle in sync if the editor's flag changes while the dialog is
+// open (e.g. get_sheet resolves after the dialog mounts). Doesn't touch staged
+// chips — only the general-access state.
+watch(() => props.isPublic, (v) => {
+  if (show.value) generalAccess.value = v ? 'public' : 'restricted'
 })
 
 // ── inline error banner ──────────────────────────────────────────────────
@@ -217,30 +227,26 @@ const ownerInitials = computed(() =>
 
 // ── general access ─────────────────────────────────────────────────────────
 
-const generalAccess = ref('restricted')
-const generalRole   = ref('0')
+// Seeded from the prop so a dialog mounted already-open reflects the right
+// state immediately; the `show` watcher re-seeds on every subsequent open.
+const generalAccess = ref(props.isPublic ? 'public' : 'restricted')   // 'restricted' | 'public'
 
 const generalAccessOpts = computed(() => [
-  { label: 'Restricted',        onClick: () => applyGeneralAccess('restricted') },
-  { label: 'Accessible to all', onClick: () => applyGeneralAccess('all') },
-])
-const generalRoleOpts = computed(() => [
-  { label: 'Can view', onClick: () => { generalRole.value = '0'; applyGeneralAccess('all') } },
-  { label: 'Can edit', onClick: () => { generalRole.value = '1'; applyGeneralAccess('all') } },
+  { label: 'Restricted',          onClick: () => applyGeneralAccess('restricted') },
+  { label: 'Anyone with the link', onClick: () => applyGeneralAccess('public') },
 ])
 
 async function applyGeneralAccess(type) {
   const prevAccess = generalAccess.value
+  if (type === prevAccess) return
   generalAccess.value = type
   if (!props.sheetId) return
   try {
-    if (type === 'all') {
-      await call('suite.sheets.api.share_sheet', {
-        name: props.sheetId, everyone: 1, write: generalRole.value === '1' ? 1 : 0,
-      })
-    } else {
-      await call('suite.sheets.api.unshare_sheet', { name: props.sheetId, everyone: 1 })
-    }
+    await call('suite.sheets.api.set_sheet_public', {
+      name: props.sheetId, public: type === 'public' ? 1 : 0,
+    })
+    // Tell the editor so its topbar "Public" indicator stays in sync.
+    emit('public-changed', type === 'public')
   } catch (err) {
     generalAccess.value = prevAccess   // revert visual state
     _flashError(err)
@@ -256,19 +262,11 @@ async function fetchShares() {
   if (!props.sheetId) return
   loading.value = true
   try {
+    // get_sheet_shares now returns only named members — public access is the
+    // `is_public` flag, seeded from the prop in the `show` watcher above.
     const rows = await call('suite.sheets.api.get_sheet_shares', { name: props.sheetId })
-    // The "everyone" row encodes general access; keep it out of the member
-    // list and use it to seed the General Access dropdown so the dialog
-    // reflects persisted state on re-open.
-    const everyoneRow = rows.find(r => r.everyone)
-    if (everyoneRow) {
-      generalAccess.value = 'all'
-      generalRole.value   = everyoneRow.write ? '1' : '0'
-    } else {
-      generalAccess.value = 'restricted'
-    }
     shares.value = rows
-      .filter(r => !r.everyone && r.user !== props.ownerId)
+      .filter(r => r.user !== props.ownerId)
       .map(r => ({ ...r, write: !!r.write }))
     emit('shares-changed', shares.value.length)
   } catch (err) {
@@ -437,6 +435,20 @@ async function copyLink() {
 
 /* Make Frappe UI Button pill-shaped inside the access row */
 .sd-pill-btn :deep(button) { border-radius: 999px; }
+
+/* Static "Can view" pill shown when the public link is on — public access is
+   deliberately view-only, so this isn't a dropdown. */
+.sd-view-only {
+  font-size: 12px; color: var(--ink-gray-6);
+  padding: 4px 10px; border-radius: 999px;
+  background: var(--surface-gray-2); white-space: nowrap;
+}
+
+/* One-line clarification of what the current general-access level means. */
+.sd-access-hint {
+  font-size: 11px; color: var(--ink-gray-5);
+  margin: 8px 0 0; line-height: 1.4;
+}
 
 /* ── Divider ── */
 .sd-divider { height: 1px; background: var(--outline-gray-1); margin: 16px 0; }

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -165,8 +165,10 @@
       </div>
     </div>
 
-    <!-- Bar 2 · Formatting toolbar -->
-    <div class="sn-toolbar">
+    <!-- Bar 2 · Formatting toolbar — hidden for read-only viewers: every control
+         here mutates (number/font/style/align/colour/border/merge/painter/
+         hyperlink/conditional-format/chart), and the server rejects their writes. -->
+    <div v-if="!readOnly" class="sn-toolbar">
 
       <!-- Number format -->
       <Dropdown :options="numberFormatDropdownOptions" placement="left" class="sn-numfmt">
@@ -299,6 +301,7 @@
           name="formula-bar"
           class="sn-formula-input"
           :value="formulaValue"
+          :readonly="readOnly"
           @input="onFormulaInput"
           @keydown="onFormulaKey"
           @blur="closeAc"
@@ -428,8 +431,9 @@
         @cancel="onSplitCancel"
       />
 
-      <!-- Filter chevrons on row 0 (the user's header row of data) -->
-      <div v-if="showSortFilter" class="sn-filter-overlay">
+      <!-- Filter chevrons on row 0 (the user's header row of data). Hidden for
+           viewers — the panel they open sorts/filters (and persists) the data. -->
+      <div v-if="showSortFilter && !readOnly" class="sn-filter-overlay">
         <button
           v-for="col in visibleFilterCols"
           :key="col.col"
@@ -569,7 +573,7 @@
     </div>
 
     <!-- Add-more-rows strip — only when the user has scrolled near the bottom -->
-    <div v-if="showAddRows" class="sn-addrows">
+    <div v-if="showAddRows && !readOnly" class="sn-addrows">
       <span class="sn-addrows-label">Add</span>
       <input name="add-rows-count" class="sn-addrows-input" type="number" min="1" max="10000" v-model.number="addRowsCount" />
       <span class="sn-addrows-label">more rows at the bottom</span>
@@ -638,7 +642,7 @@
           </span>
         </div>
 
-        <Button variant="ghost" size="sm" icon="plus" class="sn-tab-add" tooltip="Add sheet" @click="addSheet" />
+        <Button v-if="!readOnly" variant="ghost" size="sm" icon="plus" class="sn-tab-add" tooltip="Add sheet" @click="addSheet" />
       </div>
 
       <div v-if="selectionStats" class="sn-stats">
@@ -1624,10 +1628,14 @@ const fileDropdownOptions = computed(() => [
     { label: 'Export as XLSX', icon: 'download',  onClick: () => exportXLSX() },
     { label: 'Export as PDF',  icon: 'printer',   onClick: () => exportPDF() },
   ]},
-  { group: 'Import', items: [
-    { label: 'Import CSV',  icon: 'upload', onClick: () => csvInputRef.value?.click() },
-    { label: 'Import XLSX', icon: 'upload', onClick: () => xlsxInputRef.value?.click() },
-  ]},
+  // Import overwrites the sheet — hidden for read-only viewers (export stays,
+  // it only reads).
+  ...(readOnly.value
+    ? []
+    : [{ group: 'Import', items: [
+        { label: 'Import CSV',  icon: 'upload', onClick: () => csvInputRef.value?.click() },
+        { label: 'Import XLSX', icon: 'upload', onClick: () => xlsxInputRef.value?.click() },
+      ]}]),
 ])
 
 const hAlignIcon = computed(() => {
@@ -2036,7 +2044,7 @@ const { acItems, acIdx, acUp, acVisible, updateAc, commitAc, closeAc } =
 
 // Context menu — placed here because contextMenu is passed to usePivotIntegration below.
 const { contextMenu, tabMenu, openCanvasContextMenu: onCanvasContextMenu, openTabMenu } =
-  useContextMenu({ getGrid: () => grid })
+  useContextMenu({ getGrid: () => grid, readOnly: () => readOnly.value })
 
 // renderVersion is defined here because usePivotIntegration reads it at call time.
 const renderVersion = ref(0)
@@ -3097,6 +3105,7 @@ function onFormulaKey(e) {
 // the user wandered off to another sheet to pick a range. If there's no
 // cross-sheet edit, this collapses to the legacy "write to activeCell" path.
 function _commitFormulaBar() {
+  if (readOnly.value) return   // viewer: formula bar is read-only (see :readonly bind)
   const homeSheet   = editingHomeSheet.value
   const homeCell    = editingHomeCell.value
   const targetSheet = homeSheet || sheet.getCurrentSheet()
@@ -4002,6 +4011,7 @@ const renameInputRef   = ref(null)
 let _renameTarget      = ''
 
 function openRenameDialog(name) {
+  if (readOnly.value) return   // viewer: renaming a sheet is a write
   tabMenu.open = false
   _renameTarget      = name
   renameValue.value  = name

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -81,6 +81,22 @@
             @click="onRetrySave"
           />
         </template>
+        <!-- View-only badge for guests / read-only sharees so it's never
+             ambiguous why editing is disabled. -->
+        <Badge
+          v-if="readOnly"
+          theme="gray" variant="subtle" size="sm"
+          label="View only"
+          tooltip="You have read-only access to this sheet"
+        />
+        <!-- Public indicator for the owner/editors — surfaces that the sheet
+             is exposed via a public link (the missing transparency signal). -->
+        <Badge
+          v-else-if="isPublic"
+          theme="blue" variant="subtle" size="sm"
+          label="Public"
+          tooltip="Anyone with the link can view this sheet"
+        />
       </div>
       <div class="sn-topbar-right">
         <Dropdown :options="fileDropdownOptions" placement="right">
@@ -127,8 +143,10 @@
             :title="`${presentUsers.length - 3} more people`"
           >+{{ presentUsers.length - 3 }}</span>
         </div>
-        <!-- Share -->
+        <!-- Share — hidden for read-only viewers (guests can't grant access,
+             and get_sheet_shares would 403 for them anyway). -->
         <Button
+          v-if="!readOnly"
           variant="ghost"
           size="sm"
           icon="share-2"
@@ -136,7 +154,7 @@
           tooltip="Share this sheet"
           @click="shareOpen = true"
         />
-        <span class="sn-topbar-divider" aria-hidden="true" />
+        <span v-if="!readOnly" class="sn-topbar-divider" aria-hidden="true" />
         <Avatar
           :label="userInitial"
           :image="userImage || undefined"
@@ -761,7 +779,9 @@
       :sheet-id="props.id"
       :sheet-title="currentTitle"
       :owner-id="userEmail"
+      :is-public="isPublic"
       @shares-changed="shareCount = $event"
+      @public-changed="isPublic = $event"
     />
 
     <!-- Find & Replace panel -->
@@ -1968,7 +1988,7 @@ const textWrapDropdownOptions = computed(() => [
 // fallbacks only cover the impossible window where someone saves before
 // useSheetTabs has finished initializing.
 let _sheetTabs = null
-const { isSaving, saveError, loadError, loadSheet, autoCreate, saveExisting, retrySave } =
+const { isSaving, saveError, loadError, canWrite, isPublic, loadSheet, autoCreate, saveExisting, retrySave } =
   usePersistence({
     sheet, formats, merge, comments, validation, condFormat, sortFilter, pivot,
     charts, namedRanges,
@@ -1979,6 +1999,13 @@ const { isSaving, saveError, loadError, loadSheet, autoCreate, saveExisting, ret
     },
     currentTitle, emit,
   })
+
+// Read-only mode: a guest or a view-only sharee can open a sheet but must not
+// mutate it. `canWrite` comes from get_sheet (false for guests / viewers); the
+// server already rejects their writes, so this is the UX layer that stops us
+// even attempting them (no autosave chips, no editable cells, no Share grant).
+const isGuest  = computed(() => (window.frappe?.session?.user || 'Guest') === 'Guest')
+const readOnly = computed(() => !canWrite.value)
 
 _sheetTabs = useSheetTabs({ sheet, formats, extras: [merge, comments, validation, condFormat, sortFilter], getGrid: () => grid, activeCell, formulaValue, refreshActiveFormat, onSwitch: () => {
     filterPanel.open = false     // close any open filter popover so it doesn't carry stale state
@@ -2056,6 +2083,10 @@ const { presentUsers, remoteCursors, broadcastCellChange, broadcastBatchChange, 
     currentSheet,
     getSheet:       () => sheet,
     repopulateGrid: _repopulateGrid,
+    // Guests viewing a public link don't collaborate — the collab server
+    // rejects the Guest session anyway, so skip the doomed socket and just
+    // show the static snapshot loaded by get_sheet.
+    canCollaborate: computed(() => !isGuest.value),
   })
 // Wire the binding's per-segment touch-tracking into the history we declared
 // up top — undo() will now revert only this client's writes from the undone
@@ -2703,6 +2734,7 @@ function _setupGridInstance() {
     getCurrentSheet()    { return sheet.getCurrentSheet() },
     getEditingHomeSheet() { return editingHomeSheet.value },
     onFill(src, total, { withModifier = false } = {}) {
+      if (readOnly.value) return   // viewer: drag-fill disabled
       const series = _previewSeriesKind(src)
       // Cmd/Ctrl held inverts the auto-detected mode — Google Sheets behaviour.
       const mode = withModifier ? (series ? 'copy' : 'series') : 'auto'
@@ -2727,10 +2759,19 @@ function _setupGridInstance() {
       history.push()
       isDirty.value = true
     },
+    // Viewer mode: a guest / view-only sharee can select & scroll but the
+    // in-cell editor never opens. `canWrite` resolves async (after get_sheet),
+    // so the watch below keeps the grid in sync once it lands.
+    readOnly: readOnly.value,
   })
   // Keep DOM overlays (filter chevrons) in sync with canvas scroll/resize/freeze.
   grid.onRender(() => { renderVersion.value++ })
 }
+
+// `canWrite` arrives after the first get_sheet, so the grid may have been
+// created editable; flip it to viewer the moment we learn the caller is
+// read-only (and back, e.g. if an owner regains write on reload).
+watch(readOnly, (ro) => grid?.setReadOnly?.(ro))
 
 function _setupEventListeners() {
   canvasRef.value.addEventListener('contextmenu', onCanvasContextMenu)
@@ -2806,7 +2847,7 @@ onBeforeUnmount(() => {
   // debounce window) silently drops the most recent changes — exactly the
   // "data is lost when I come back" report. The fetch uses `keepalive: true`
   // so the request survives the unmount.
-  if (isDirty.value && props.id && props.id !== 'new') {
+  if (!readOnly.value && isDirty.value && props.id && props.id !== 'new') {
     saveExisting(props.id, currentTitle.value, { keepalive: true })
   }
   window.removeEventListener('beforeunload', onBeforeUnloadGuard)
@@ -2934,11 +2975,16 @@ function _truncatedSummary(op) {
 }
 
 function _triggerAutoSave() {
+  // Read-only viewers (guests / view-only sharees) never persist. The server
+  // rejects their writes anyway; bailing here avoids surfacing a "couldn't
+  // save" chip for edits they were never allowed to make.
+  if (readOnly.value) return
   clearTimeout(_autoSaveTimer)
   _autoSaveTimer = setTimeout(_doAutoSave, 2000)
 }
 
 async function _doAutoSave() {
+  if (readOnly.value) return
   if (!isDirty.value) return
   // Bootstrap is handled by _loadInitialData's autoCreate(); calling
   // saveExisting('new') would explode with "Sheet new not found". If the
@@ -3147,6 +3193,7 @@ const { onGlobalKey } = useShortcuts({
   clipboard, clipboardHas, setMarchingAnts: (v) => grid?.setMarchingAnts(v),
   fillDown, fillRight,
   runSmartFill,
+  readOnly: () => readOnly.value,
 })
 
 // ── Clipboard ─────────────────────────────────────────────────────────────────
@@ -3166,6 +3213,7 @@ function onDocCopy(e) {
 }
 function onDocCut(e) {
   if (!_canvasActive()) return
+  if (readOnly.value) return   // viewer: cut (which clears cells) disabled
   e.preventDefault()
   const src    = grid.getSelection()
   const sn     = sheet.getCurrentSheet()
@@ -3177,6 +3225,7 @@ function onDocCut(e) {
 }
 function onDocPaste(e) {
   if (!_canvasActive()) return
+  if (readOnly.value) return   // viewer: paste disabled
   e.preventDefault()
   const destSel = grid.getSelection()
   const sn = sheet.getCurrentSheet()

--- a/frontend/src/apps/sheets/components/SheetEditor/useCollaboration.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useCollaboration.js
@@ -115,6 +115,10 @@ export function useCollaboration({
   currentSheet,
   getSheet,
   repopulateGrid,
+  // Reactive gate — when false (e.g. a logged-out guest on a public link) we
+  // never stand up a provider. Defaults to an always-true ref so existing
+  // callers and tests are unaffected.
+  canCollaborate = { value: true },
   _self        = window.frappe?.session?.user,
   _realtime    = window.frappe?.realtime,
   _callFn      = (method, args) => call(method, args),
@@ -343,8 +347,8 @@ export function useCollaboration({
   }
 
   _watch(sheetId, docId => {
-    if (docId && docId !== 'new') _start(docId)
-    else                          _stop()
+    if (docId && docId !== 'new' && canCollaborate.value) _start(docId)
+    else                                                  _stop()
   }, { immediate: true })
 
   _onUnmounted(_stop)

--- a/frontend/src/apps/sheets/components/SheetEditor/useContextMenu.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useContextMenu.js
@@ -4,9 +4,9 @@ import { reactive } from 'vue'
 const MENU_HEIGHT_EST = { cell: 620, colHeader: 240, rowHeader: 240 }
 
 /**
- * @param {{ getGrid: () => object, getViewport?: () => { width: number, height: number } }} opts
+ * @param {{ getGrid: () => object, getViewport?: () => { width: number, height: number }, readOnly?: () => boolean }} opts
  */
-export function useContextMenu({ getGrid, getViewport = () => ({ width: window.innerWidth, height: window.innerHeight }) }) {
+export function useContextMenu({ getGrid, getViewport = () => ({ width: window.innerWidth, height: window.innerHeight }), readOnly = () => false }) {
   const contextMenu = reactive({
     open: false, x: 0, y: 0, bottom: 0, useBottom: false, maxH: 0,
     targetRow: 0, targetCol: 0, mode: 'cell',
@@ -16,6 +16,9 @@ export function useContextMenu({ getGrid, getViewport = () => ({ width: window.i
 
   function openCanvasContextMenu(e) {
     e.preventDefault()
+    // Every entry in this menu mutates the sheet (insert/delete/freeze/hide/
+    // paste-special/validation/…), so view-only viewers get no menu at all.
+    if (readOnly()) return
     tabMenu.open = false
     const grid = getGrid()
     const hit  = grid.getHitRegion(e.clientX, e.clientY)
@@ -52,6 +55,8 @@ export function useContextMenu({ getGrid, getViewport = () => ({ width: window.i
   }
 
   function openTabMenu(e, name) {
+    // Rename / duplicate / delete sheet — all writes, so skip for viewers.
+    if (readOnly()) return
     const vp = getViewport()
     contextMenu.open = false
     tabMenu.name   = name

--- a/frontend/src/apps/sheets/components/SheetEditor/usePersistence.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/usePersistence.js
@@ -12,6 +12,13 @@ export function usePersistence({ sheet, formats, merge, comments, validation, co
   // editor so it can render a proper error screen instead of mounting a
   // blank canvas. Shape: { kind: 'denied' | 'missing' | 'other', message }.
   const loadError = ref(null)
+  // Access flags from get_sheet. `canWrite` drives the editor's read-only
+  // mode (false for guests and view-only viewers); `isPublic` powers the
+  // "Public" indicator + the share dialog's public-link toggle. Default
+  // canWrite=true so a brand-new ('new') sheet — which the owner is creating —
+  // is editable before its first load resolves.
+  const canWrite = ref(true)
+  const isPublic = ref(false)
 
   async function loadSheet(name) {
     loadError.value = null
@@ -30,6 +37,11 @@ export function usePersistence({ sheet, formats, merge, comments, validation, co
       if (saved.charts     && charts?.restore)     charts.restore(saved.charts)
       if (saved.namedRanges && namedRanges?.restore) namedRanges.restore(saved.namedRanges)
       currentTitle.value = doc.title
+      // get_sheet reports whether this caller may write and whether the sheet
+      // is publicly linked. A guest / view-only sharee gets can_write=false →
+      // the editor renders read-only.
+      canWrite.value = doc.can_write !== false
+      isPublic.value = !!doc.is_public
     } catch (err) {
       console.error('Load failed:', err)
       const t = err?.excType || ''
@@ -151,5 +163,5 @@ export function usePersistence({ sheet, formats, merge, comments, validation, co
     }
   }
 
-  return { isSaving, saveError, loadError, loadSheet, autoCreate, saveExisting, retrySave }
+  return { isSaving, saveError, loadError, canWrite, isPublic, loadSheet, autoCreate, saveExisting, retrySave }
 }

--- a/frontend/src/apps/sheets/components/SheetEditor/useShortcuts.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useShortcuts.js
@@ -32,6 +32,10 @@ export function useShortcuts(actions) {
     clipboard, clipboardHas, setMarchingAnts,
     fillDown, fillRight,
     runSmartFill,
+    // Optional getter — true for a view-only viewer (guest / read-only share).
+    // When set, shortcuts that would mutate the sheet are swallowed; pure
+    // navigation / view shortcuts (find, zoom, formula-peek, escape) stay live.
+    readOnly = () => false,
   } = actions
 
   function _isInInput() {
@@ -40,6 +44,9 @@ export function useShortcuts(actions) {
   }
 
   function _handleFormatKeys(e, mod, inInput) {
+    // Viewer: undo/redo/format/repeat all mutate — swallow them so a stray
+    // Cmd+B doesn't paint local-only changes the viewer can never save.
+    if (readOnly()) return false
     if (mod && e.key === 'z' && !e.shiftKey)                              { e.preventDefault(); undo();                         return true }
     if (mod && (e.key === 'y' || (e.shiftKey && e.key === 'z')))          { e.preventDefault(); redo();                         return true }
     if (mod && e.key === 'b' && !inInput)                                  { e.preventDefault(); toggleFmt('bold');              return true }
@@ -91,13 +98,16 @@ export function useShortcuts(actions) {
     if (_handleViewKeys(e, mod, inInput))   return
     if (_handleNavKeys(e, mod, inInput))    return
     if (_handleEscape(e, inInput))          return
-    if (mod && e.key === 'd' && !inInput) { e.preventDefault(); fillDown();  return }
-    if (mod && e.key === 'r' && !inInput) { e.preventDefault(); fillRight(); return }
-    // Cmd/Ctrl+E — Smart Fill. Matches Excel's Flash Fill shortcut. Detects
-    // a pattern from the user's example values in the selected column and
-    // fills the remaining empty cells in the selection.
-    if (mod && (e.key === 'e' || e.key === 'E') && !inInput) {
-      e.preventDefault(); runSmartFill?.(); return
+    // Fill / smart-fill mutate — disabled for viewers.
+    if (!readOnly()) {
+      if (mod && e.key === 'd' && !inInput) { e.preventDefault(); fillDown();  return }
+      if (mod && e.key === 'r' && !inInput) { e.preventDefault(); fillRight(); return }
+      // Cmd/Ctrl+E — Smart Fill. Matches Excel's Flash Fill shortcut. Detects
+      // a pattern from the user's example values in the selected column and
+      // fills the remaining empty cells in the selection.
+      if (mod && (e.key === 'e' || e.key === 'E') && !inInput) {
+        e.preventDefault(); runSmartFill?.(); return
+      }
     }
   }
 

--- a/frontend/src/apps/sheets/pages/Home.vue
+++ b/frontend/src/apps/sheets/pages/Home.vue
@@ -130,7 +130,17 @@
           <!-- Card footer -->
           <div class="home-card-footer">
             <div class="home-card-info">
-              <span class="home-card-title">{{ sheet.title }}</span>
+              <span class="home-card-title">
+                {{ sheet.title }}
+                <!-- Globe = this sheet is exposed via a public link. Surfaces
+                     the exposure on the owner's own list (transparency). -->
+                <FeatherIcon
+                  v-if="sheet.is_public"
+                  name="globe"
+                  class="home-public-icon"
+                  title="Anyone with the link can view"
+                />
+              </span>
               <span class="home-card-date">
                 <template v-if="!isOwnedByMe(sheet)">Shared · </template>{{ formatDate(sheet.modified) }}
               </span>
@@ -172,6 +182,16 @@
                 />
               </template>
             </Dropdown>
+          </div>
+          <div v-else-if="column.key === 'title'" class="flex items-center gap-1.5 min-w-0">
+            <ListRowItem :column="column" :row="row" :item="item" :align="column.align" />
+            <!-- Public-link indicator, mirrors the grid card's globe. -->
+            <FeatherIcon
+              v-if="row.is_public"
+              name="globe"
+              class="home-public-icon"
+              title="Anyone with the link can view"
+            />
           </div>
           <ListRowItem
             v-else
@@ -610,6 +630,15 @@ async function duplicate(sheet) {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* Public-link indicator on a sheet card — small, muted, inline with the title. */
+.home-public-icon {
+  width: 12px;
+  height: 12px;
+  margin-left: 4px;
+  color: var(--ink-gray-5);
+  vertical-align: -1px;
 }
 
 .home-card-date {

--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -34,6 +34,7 @@ suite.writer.patches.change_versioning_schema
 suite.writer.patches.autopopulate_html
 # --- sheets ---
 suite.sheets.patches.v0_1.migrate_blob_to_cells
+suite.sheets.patches.v0_1.drop_everyone_sheet_shares
 # --- meet ---
 suite.meet.patches.migrate_meeting_fields_to_table_multiselect
 # --- mail ---

--- a/suite/sheets/api.py
+++ b/suite/sheets/api.py
@@ -125,19 +125,19 @@ _YJS_WRITE_EVENTS = frozenset({"yjs_update", "yjs_state"})
 
 @frappe.whitelist()
 def get_sheet_shares(name: str) -> list:
-	"""Return users who have explicit share access to this sheet."""
+	"""Return users who have explicit per-user share access to this sheet.
+
+	Org-wide / public access is no longer a DocShare row — it lives on the
+	Sheet's `is_public` flag (see `set_sheet_public`). The dialog reads that
+	separately, so we only return named members here.
+	"""
 	frappe.has_permission("Sheet", doc=name, throw=True)
 	rows = frappe.get_all(
 		"DocShare",
-		filters={"share_doctype": "Sheet", "share_name": name},
-		fields=["user", "read", "write", "share", "everyone"],
+		filters={"share_doctype": "Sheet", "share_name": name, "everyone": 0},
+		fields=["user", "read", "write", "share"],
 	)
 	for row in rows:
-		if row.get("everyone"):
-			row["full_name"] = ""
-			row["initials"] = ""
-			row["user_image"] = ""
-			continue
 		identity = _user_identity(row["user"])
 		row.update(identity)
 		row["user_image"] = frappe.db.get_value("User", row["user"], "user_image") or ""
@@ -145,19 +145,26 @@ def get_sheet_shares(name: str) -> list:
 
 
 @frappe.whitelist()
-def share_sheet(name: str, user: str = "", write: int = 0, everyone: int = 0) -> dict:
+def set_sheet_public(name: str, public: int = 0) -> dict:
+	"""Toggle the public, view-only link for a sheet.
+
+	Public access is a single boolean on the Sheet — `is_public`. When on,
+	anyone with the link can open the sheet read-only (no login required, see
+	`get_sheet`'s `allow_guest`). It is deliberately view-only: there is no
+	public-edit. Gated by `ptype="share"` so only the owner (or someone the
+	owner granted the share right) can expose a sheet.
+	"""
+	frappe.has_permission("Sheet", doc=name, ptype="share", throw=True)
+	frappe.db.set_value("Sheet", name, "is_public", 1 if int(public or 0) else 0)
+	return {"status": "ok", "is_public": bool(int(public or 0))}
+
+
+@frappe.whitelist()
+def share_sheet(name: str, user: str = "", write: int = 0) -> dict:
 	# `ptype="share"` — only users who themselves hold the share right
 	# may grant access to others. Default `read` was too permissive
 	# (any viewer could re-share a sheet to anyone).
 	frappe.has_permission("Sheet", doc=name, ptype="share", throw=True)
-	if int(everyone or 0):
-		# "Accessible to all" → single DocShare with everyone=1, user=NULL.
-		# notify=False because there's no individual to email.
-		frappe.share.add(
-			"Sheet", name, user=None, write=int(write), share=0,
-			everyone=1, notify=False,
-		)
-		return {"status": "ok"}
 	# Reject disabled users (and non-existent ones) up front — silently
 	# carrying a share to an account that's been turned off lets it light
 	# up again the moment the account is re-enabled, which is rarely what
@@ -245,18 +252,8 @@ def _notify_sheet_shared(sheet_name: str, recipient: str, can_edit: bool) -> Non
 
 
 @frappe.whitelist()
-def unshare_sheet(name: str, user: str = "", everyone: int = 0) -> dict:
+def unshare_sheet(name: str, user: str = "") -> dict:
 	frappe.has_permission("Sheet", doc=name, ptype="share", throw=True)
-	if int(everyone or 0):
-		# frappe.share.remove() looks up by user; for the everyone row we
-		# locate the DocShare directly and delete it.
-		share_name = frappe.db.get_value(
-			"DocShare",
-			{"share_doctype": "Sheet", "share_name": name, "everyone": 1},
-		)
-		if share_name:
-			frappe.delete_doc("DocShare", share_name, ignore_permissions=True)
-		return {"status": "ok"}
 	frappe.share.remove("Sheet", name, user)
 	return {"status": "ok"}
 
@@ -265,34 +262,49 @@ def unshare_sheet(name: str, user: str = "", everyone: int = 0) -> dict:
 def list_sheets() -> list:
 	# No explicit owner filter — Frappe's get_list already applies the
 	# permission query, so this returns sheets the session user owns plus
-	# those reaching them via DocShare (per-user or everyone=1). The
-	# `owner` field is included so the UI can mark non-owned rows as
-	# "Shared with you", and `is_owner` is computed here because the SPA
-	# template doesn't inject window.frappe.session — the client has no
-	# reliable way to know who it is.
+	# those explicitly shared with them via DocShare. A public sheet only
+	# shows in its owner's list (public access is link-only, not a share),
+	# matching Drive. The `owner` field is included so the UI can mark
+	# non-owned rows as "Shared with you", and `is_owner`/`is_public` are
+	# computed here because the SPA template doesn't inject
+	# window.frappe.session — the client has no reliable way to know who it is.
 	me = frappe.session.user
 	rows = frappe.get_list(
 		"Sheet",
-		fields=["name", "title", "modified", "owner"],
+		fields=["name", "title", "modified", "owner", "is_public"],
 		order_by="modified desc",
 		limit=100,
 	)
 	for r in rows:
 		r["is_owner"] = (r["owner"] == me)
+		r["is_public"] = bool(r.get("is_public"))
 	return rows
 
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_sheet(name: str) -> dict:
-	# `frappe.get_doc` does NOT check read permission by itself — without
-	# this guard, any logged-in user who knows a sheet id could exfiltrate
-	# its contents.
-	frappe.has_permission("Sheet", doc=name, throw=True)
+	# `allow_guest=True` powers the public-link feature: a logged-out viewer
+	# can open a sheet whose owner flipped `is_public`. We gate carefully so
+	# nothing else leaks — `is_public` is read FIRST, and only public sheets
+	# skip the permission check. Private sheets keep the exact old behaviour:
+	# `frappe.get_doc` does NOT check read permission by itself, so without
+	# this guard any caller who knows a sheet id could exfiltrate its contents.
+	is_public = bool(frappe.db.get_value("Sheet", name, "is_public"))
+	if not is_public:
+		frappe.has_permission("Sheet", doc=name, throw=True)
 	doc = frappe.get_doc("Sheet", name)
+	# `can_write` drives the frontend's read-only mode. Guests and public
+	# viewers are always view-only; logged-in users get their real write right.
+	# Public access is view-only by design — there is no public-edit.
+	can_write = frappe.session.user != "Guest" and bool(
+		frappe.has_permission("Sheet", doc=name, ptype="write", throw=False)
+	)
 	return {
 		"name": doc.name,
 		"title": doc.title,
 		"sheets_data": decode_sheets_data(doc.sheets_data),
+		"is_public": is_public,
+		"can_write": can_write,
 	}
 
 

--- a/suite/sheets/doctype/sheet/sheet.json
+++ b/suite/sheets/doctype/sheet/sheet.json
@@ -8,7 +8,8 @@
   "title",
   "sheets_data",
   "head_seq",
-  "head_snapshot"
+  "head_snapshot",
+  "is_public"
  ],
  "fields": [
   {
@@ -35,6 +36,13 @@
    "fieldtype": "Link",
    "options": "Sheet Snapshot",
    "label": "Latest snapshot"
+  },
+  {
+   "fieldname": "is_public",
+   "fieldtype": "Check",
+   "label": "Anyone with the link can view",
+   "default": "0",
+   "description": "When set, anyone with the link can open this sheet read-only — no login required."
   }
  ],
  "links": [],

--- a/suite/sheets/patches/v0_1/drop_everyone_sheet_shares.py
+++ b/suite/sheets/patches/v0_1/drop_everyone_sheet_shares.py
@@ -1,0 +1,22 @@
+"""Remove blanket "accessible to all logged-in users" shares from sheets.
+
+Sheets used to expose an org-wide share via a `DocShare` row with `everyone=1`
+(labelled "Accessible to all" in the share dialog). That concept is gone:
+public access is now an explicit, view-only `Sheet.is_public` link instead.
+
+We delete the old `everyone=1` rows rather than converting them to public — a
+public link is *more* exposing (anyone on the internet, no login), so silently
+upgrading would be the wrong default. Affected sheets simply revert to
+restricted; owners can re-enable the new public link deliberately if they
+still want it. This directly resolves the "sheets made by me are accessible to
+everyone" report.
+"""
+
+import frappe
+
+
+def execute():
+	frappe.db.delete(
+		"DocShare",
+		{"share_doctype": "Sheet", "everyone": 1},
+	)

--- a/suite/sheets/tests/test_api_security.py
+++ b/suite/sheets/tests/test_api_security.py
@@ -123,6 +123,90 @@ class ShareSheetRejectsDisabledUsers(_PermCheckBase):
 		self.frappe.share.add.assert_called_once()
 
 
+class GetSheetPublicGate(_PermCheckBase):
+	"""The public-link gate: only public sheets skip the read permission check.
+
+	`get_sheet` is `allow_guest=True`, so the read gate is what stops a guest /
+	stranger from reading a *private* sheet. We assert the gate fires for
+	private sheets and is skipped for public ones.
+	"""
+
+	def test_private_sheet_checks_read_permission(self):
+		from suite.sheets import api
+
+		# is_public falsy → the read gate must fire (throw=True).
+		self.frappe.db.get_value.return_value = 0
+		api.get_sheet("SH-1")
+		read_gate = [
+			c for c in self.frappe.has_permission.call_args_list
+			if c.kwargs.get("throw") is True
+		]
+		self.assertTrue(read_gate, "private sheet must hit the read gate")
+		self.assertEqual(read_gate[0].kwargs.get("doc"), "SH-1")
+
+	def test_public_sheet_skips_read_gate(self):
+		from suite.sheets import api
+
+		# is_public truthy → no throwing read gate (anyone may read).
+		self.frappe.db.get_value.return_value = 1
+		out = api.get_sheet("SH-1")
+		threw = [
+			c for c in self.frappe.has_permission.call_args_list
+			if c.kwargs.get("throw") is True
+		]
+		self.assertEqual(threw, [], "public sheet must not throw on read")
+		self.assertTrue(out["is_public"])
+
+	def test_guest_on_public_sheet_is_view_only(self):
+		from suite.sheets import api
+
+		self.frappe.session.user = "Guest"
+		self.frappe.db.get_value.return_value = 1
+		out = api.get_sheet("SH-1")
+		# Guests never get write — and we don't even consult write perm.
+		self.assertFalse(out["can_write"])
+
+	def test_logged_in_writer_gets_can_write(self):
+		from suite.sheets import api
+
+		self.frappe.db.get_value.return_value = 1
+		self.frappe.has_permission.return_value = True
+		out = api.get_sheet("SH-1")
+		self.assertTrue(out["can_write"])
+
+
+class SetSheetPublicGated(_PermCheckBase):
+	def test_requires_share_permission(self):
+		from suite.sheets import api
+
+		api.set_sheet_public("SH-1", public=1)
+		# Share right is the gate — same bar as granting access to a user.
+		self.frappe.has_permission.assert_called_with(
+			"Sheet", doc="SH-1", ptype="share", throw=True
+		)
+
+	def test_sets_is_public_flag(self):
+		from suite.sheets import api
+
+		api.set_sheet_public("SH-1", public=1)
+		self.frappe.db.set_value.assert_called_with("Sheet", "SH-1", "is_public", 1)
+		api.set_sheet_public("SH-1", public=0)
+		self.frappe.db.set_value.assert_called_with("Sheet", "SH-1", "is_public", 0)
+
+
+class UnshareSheetGated(_PermCheckBase):
+	def test_unshare_removes_named_user(self):
+		from suite.sheets import api
+
+		api.unshare_sheet("SH-1", "bob@example.com")
+		self.frappe.has_permission.assert_called_with(
+			"Sheet", doc="SH-1", ptype="share", throw=True
+		)
+		self.frappe.share.remove.assert_called_once_with(
+			"Sheet", "SH-1", "bob@example.com"
+		)
+
+
 class RenameSheetGated(_PermCheckBase):
 	def test_rename_checks_write_before_load(self):
 		from suite.sheets import api

--- a/suite/sheets/tests/test_share_notify.py
+++ b/suite/sheets/tests/test_share_notify.py
@@ -106,13 +106,11 @@ class CustomShareNotification(unittest.TestCase):
         # And the failure was logged for observability.
         self.frappe.log_error.assert_called_once()
 
-    def test_everyone_share_does_not_send_a_per_user_notification(self):
-        # everyone=1 shares aren't addressed to a specific user, so no
-        # personalised notification makes sense. The original notify=False
-        # path on the everyone branch is already correct; this guards
-        # that we didn't accidentally introduce a notification dispatch
-        # there.
+    def test_public_link_does_not_send_a_notification(self):
+        # Public access is now a flag on the Sheet (set_sheet_public), not a
+        # per-user grant — there's no recipient to email, so no notification
+        # should ever fire from flipping the public link on.
         from suite.sheets import api
 
-        api.share_sheet("SH-1", everyone=1, write=1)
+        api.set_sheet_public("SH-1", public=1)
         self.frappe.sendmail.assert_not_called()

--- a/suite/sheets/www/sheets.py
+++ b/suite/sheets/www/sheets.py
@@ -52,8 +52,27 @@ def _asset_paths() -> dict:
     }
 
 
+def _guest_may_view(sheet_id) -> bool:
+    """True only when `sheet_id` names an existing, public sheet.
+
+    Kept defensive: a missing id, an unknown name, or any DB hiccup means
+    "no" — a guest never renders the shell unless the link is genuinely public.
+    """
+    if not sheet_id:
+        return False
+    try:
+        return bool(frappe.db.get_value("Sheet", sheet_id, "is_public"))
+    except Exception:
+        return False
+
+
 def get_context(context):
-    if frappe.session.user == "Guest":
+    if frappe.session.user == "Guest" and not _guest_may_view(frappe.form_dict.get("id")):
+        # A logged-out visitor only gets in for a public sheet they opened by
+        # link (`/sheets?id=<name>`). Everything else — the Home list, private
+        # sheets, a bare `/sheets` — still bounces to login. The actual content
+        # gate lives in `api.get_sheet` (it re-checks `is_public`); this is just
+        # so the SPA shell renders instead of redirecting.
         frappe.local.flags.redirect_location = "/login?redirect-to=/sheets"
         raise frappe.Redirect
 


### PR DESCRIPTION
## Why

A user reported **"Sheets made by me is accessible to everyone."** The ask: follow the access model of docs in Frappe Drive.

Sheets are already private-by-default (`if_owner` + per-user DocShare). The mismatch was the **sharing model**: a single ambiguous **"Accessible to all"** toggle that silently meant *every logged-in user of the site* (`everyone=1` DocShare), with no indication to the owner that a sheet was exposed. Drive's personal docs are **private + named-people sharing + an optional, explicit, view-only public link** — no "all logged-in users" blanket. This PR brings Sheets in line.

## What changed

**Backend**
- New `Sheet.is_public` flag — the single source of truth for public access.
- `get_sheet` is now `allow_guest=True` but reads `is_public` **first**: private sheets keep the exact same permission gate (still 403 for guests/non-owners), and it returns `can_write` so the client can render read-only.
- New `set_sheet_public(name, public)` gated on the **share** right; removed the `everyone=1` branch from `share_sheet` / `unshare_sheet` / `get_sheet_shares`; `list_sheets` returns `is_public`.
- `www/sheets.py` lets a logged-out visitor through **only** for a sheet that's actually public.
- Migration patch (`suite.sheets.patches.v0_1.drop_everyone_sheet_shares`) deletes any pre-existing `everyone=1` Sheet DocShares — revert to restricted rather than silently upgrading to a more-exposing public link.

**Frontend**
- Real **read-only editor mode**: in-cell editing, Delete/clear, fill, cut/paste, mutating shortcuts and autosave are all disabled; guests skip the collab socket and render the static `get_sheet` snapshot.
- **ShareDialog** general access becomes **Restricted / "Anyone with the link"** (view-only), wired to `set_sheet_public`.
- **Transparency**: "Public" / "View only" badges in the editor topbar and a globe indicator on the Home grid + list; Share button hidden for viewers.

## Scope
- Public access is **view-only** — no public edit.
- Live collaboration for anonymous viewers is out of scope (they get a static read-only snapshot).
- Bundle is not rebuilt here (source-only).

## Provenance & validation
- Ported from standalone **frappe/sheets#2** (where the same change passed 59 python + 1041 frontend tests + build).
- In this monorepo I validated syntax only — python `ast.parse`, JS `node --check`, and `@vue/compiler-sfc` compile all pass — because the suite frontend deps aren't wired in my checkout (no `node_modules`) and suite isn't bench-installed locally. **Please let CI run the build + python tests.**
- Backend python tests are included (`test_api_security`, `test_share_notify`). The frontend test port is deferred — suite has no vitest infra for sheets yet.