### PR TITLE
perf(mail): bulk-update sync states in a single transaction

### DIFF
--- a/suite/mail/utils/user.py
+++ b/suite/mail/utils/user.py
@@ -262,9 +262,14 @@ def update_sync_state(account: str, type: Literal["email"], state: str) -> None:
 	store = get_data_store(parse_account(account)[1])
 
 	current_state = store.get(Entity.STATE, f"{type}_current_state")
-	store.set(Entity.STATE, f"{type}_previous_state", current_state)
-	store.set(Entity.STATE, f"{type}_current_state", state)
-	store.set(Entity.STATE, f"{type}_state_last_update", frappe.utils.now())
+	store.set_many(
+		Entity.STATE,
+		{
+			f"{type}_previous_state": current_state,
+			f"{type}_current_state": state,
+			f"{type}_state_last_update": frappe.utils.now(),
+		},
+	)
 
 
 @reconnect_on_failure()


### PR DESCRIPTION
## Description

`update_sync_state` issued three separate `.set` calls, each opening its own write transaction in the per-account data store. This replaces them with a single `.set_many` call so all sync-state keys (`previous_state`, `current_state`, `state_last_update`) are written in one transaction.

No behavior change — purely a write-efficiency improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)