### PR TITLE
fix(slides): switch text elements to top-left anchoring

### DIFF
--- a/frontend/src/apps/slides/components/Resizer.vue
+++ b/frontend/src/apps/slides/components/Resizer.vue
@@ -64,6 +64,8 @@ const resizeHandles = computed(() => {
 			'bottom-left',
 			'bottom-right',
 		]
+	} else if (['image', 'video'].includes(props.elementType)) {
+		directions = ['top-left', 'top-right', 'bottom-left', 'bottom-right']
 	} else if (props.elementType === 'line') {
 		directions = ['line-left', 'line-right']
 	} else if (props.elementType === 'text') {

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -99,7 +99,6 @@ import {
 	getResizedTextBox,
 	getRotatedBoundingBox,
 	isAspectLocked,
-	getMinSizeForElement,
 } from '@/apps/slides/utils/resize'
 
 const props = defineProps({
@@ -293,33 +292,20 @@ const activeDiv = computed(() => {
 })
 
 useResizeObserver(activeDiv, (entries) => {
+	if (!activeElement.value) return
+
 	const entry = entries[0]
 	const { width, height } = entry.contentRect
 
 	// fires on any size change: resize gestures, and property updates like
-	// font size / line height / letter spacing
-
-	// shapes/images are layout-anchored: left/top derive from element state,
-	// no forced-layout read needed
-	if (['shape', 'image'].includes(activeElement.value?.type)) {
-		updateSelectionBounds({
-			width: width,
-			height: height,
-			left: activeElement.value.left + elementOffset.left,
-			top: activeElement.value.top + elementOffset.top,
-		})
-		return
-	}
-
-	// text elements are center-anchored (translate(-50%, -50%)): their visual
-	// left/top shift whenever the size changes, so read the rendered rect
-	const target = entry.target.getBoundingClientRect()
-
+	// font size / line height / letter spacing. every element type is
+	// layout-anchored — left/top derive from element state, so no
+	// forced-layout read is needed
 	updateSelectionBounds({
 		width: width,
 		height: height,
-		left: (target.left - slideBounds.left) / scale.value,
-		top: (target.top - slideBounds.top) / scale.value,
+		left: activeElement.value.left + elementOffset.left,
+		top: activeElement.value.top + elementOffset.top,
 	})
 })
 
@@ -407,15 +393,8 @@ const resizeLine = (cursorMovement) => {
 }
 
 const setOffsetFromTextBox = (box) => {
-	const minWidth = getMinSizeForElement(resizeStartBounds.type).width
-	const grabbingRight = currentResizer.value === 'text-right'
-
-	const fixedEdge = grabbingRight ? box.left : box.left + box.width
-	const width = Math.max(minWidth, box.width)
-	const centre = grabbingRight ? fixedEdge + width / 2 : fixedEdge - width / 2
-
-	elementOffset.width = width - resizeStartBounds.width
-	elementOffset.left = centre - (resizeStartBounds.left + resizeStartBounds.width / 2)
+	elementOffset.width = box.width - resizeStartBounds.width
+	elementOffset.left = box.left - resizeStartBounds.left
 }
 
 const resizeText = (cursorMovement) => {

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -98,6 +98,7 @@ import {
 	getResizedLine,
 	getResizedTextBox,
 	getRotatedBoundingBox,
+	getMinSizeForElement,
 	isAspectLocked,
 } from '@/apps/slides/utils/resize'
 
@@ -402,6 +403,15 @@ const resizeText = (cursorMovement) => {
 
 	const box = getResizedTextBox(resizeStartBounds, currentResizer.value, cursorMovement)
 	const snappedBox = snapForResize(box, { axes: ['x'] })
+
+	const minWidth = getMinSizeForElement(resizeStartBounds.type).width
+	if (snappedBox.width < minWidth) {
+		if (currentResizer.value === 'text-left') {
+			snappedBox.left = snappedBox.left + snappedBox.width - minWidth
+		}
+		snappedBox.width = minWidth
+	}
+
 	setOffsetFromTextBox(snappedBox)
 }
 

--- a/frontend/src/apps/slides/components/SlideElement.vue
+++ b/frontend/src/apps/slides/components/SlideElement.vue
@@ -117,7 +117,10 @@ const isRotatable = computed(() => {
 })
 
 const getTransform = (rotation) => {
-	if (element.value.type == 'text') return element.value.transform
+	if (element.value.type == 'text') {
+		const t = element.value.transform
+		return t && t !== 'none' ? t : ''
+	}
 	if (!isRotatable.value) return ''
 	return `rotate(${rotation}deg)`
 }

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -286,15 +286,13 @@ const addTextElement = async (text, position) => {
 	if (!position) {
 		const { elementWidth, elementHeight } = getTextElementDimensions(elementPresets)
 		position = getLeftTopForCenteredElement(elementWidth, elementHeight)
-		position.left += elementWidth / 2
-		position.top += elementHeight / 2
 	}
 
 	const element = {
 		id: generateUniqueId(),
 		zIndex: currentSlide.value.elements.length + 1,
-		transformOrigin: 'center center',
-		transform: 'translate(-50%, -50%)',
+		transformOrigin: 'top left',
+		transform: 'none',
 		left: position.left,
 		top: position.top,
 		type: 'text',

--- a/frontend/src/apps/slides/stores/presentation.js
+++ b/frontend/src/apps/slides/stores/presentation.js
@@ -335,6 +335,7 @@ export {
 	applyReverseTransition,
 	createPresentationResource,
 	presentationDoc,
+	transformElements,
 	unsyncedPresentationRecord,
 	isPublicPresentation,
 	slidesLength,

--- a/frontend/src/apps/slides/stores/presentation.js
+++ b/frontend/src/apps/slides/stores/presentation.js
@@ -61,8 +61,15 @@ const getElementDimensions = async (el) => {
 	tempDiv.style.position = 'absolute'
 	tempDiv.style.visibility = 'hidden'
 	tempDiv.style.height = 'auto'
-	tempDiv.style.width = 'auto'
-	tempDiv.style.whiteSpace = 'pre'
+	tempDiv.style.lineHeight = el.lineHeight || '1.5'
+
+	if (el.width) {
+		tempDiv.style.width = `${el.width}px`
+		tempDiv.style.whiteSpace = 'pre-wrap'
+	} else {
+		tempDiv.style.width = 'auto'
+		tempDiv.style.whiteSpace = 'pre'
+	}
 
 	tempDiv.innerHTML = el.content || ''
 	document.body.appendChild(tempDiv)
@@ -81,23 +88,30 @@ const transformElements = async (elements) => {
 	const newEls = []
 
 	for (const el of elements) {
-		if ('transform' in el || el.type !== 'text') {
+		if (el.type !== 'text') {
 			newEls.push(el)
 			continue
 		}
 
-		const { width, height } = await getElementDimensions(el)
+		if (el.transform === 'translate(-50%, -50%)') {
+			const { width, height } = await getElementDimensions(el)
 
-		const newLeft = el.left + width / 2
-		const newTop = el.top + height / 2
-
-		newEls.push({
-			...el,
-			transform: 'translate(-50%, -50%)',
-			transformOrigin: 'center center',
-			left: newLeft,
-			top: newTop,
-		})
+			newEls.push({
+				...el,
+				transform: 'none',
+				transformOrigin: 'top left',
+				left: el.left - width / 2,
+				top: el.top - height / 2,
+			})
+		} else if (!('transform' in el)) {
+			newEls.push({
+				...el,
+				transform: 'none',
+				transformOrigin: 'top left',
+			})
+		} else {
+			newEls.push(el)
+		}
 	}
 
 	return newEls

--- a/frontend/src/apps/slides/stores/slide.js
+++ b/frontend/src/apps/slides/stores/slide.js
@@ -6,6 +6,7 @@ import {
 	templateList,
 	inReadonlyMode,
 	presentationTheme,
+	transformElements,
 } from '@/apps/slides/stores/presentation'
 import { resetFocus } from '@/apps/slides/stores/element'
 import { saveChanges, dirty, markDirty } from '@/apps/slides/stores/saving'
@@ -164,6 +165,8 @@ const insertDuplicateSlide = async (index, layoutObj, toDuplicate) => {
 	if (toDuplicate || !index) index = slideIndex.value
 
 	const newSlide = getNewSlide(toDuplicate, layoutObj)
+
+	if (!toDuplicate) newSlide.elements = await transformElements(newSlide.elements)
 
 	insertSlide(newSlide, index)
 }


### PR DESCRIPTION
Text used to be center-anchored, so typing grew it from both sides. This switches text to top-left anchoring to match standard slide editors.

- New text elements are created top-left anchored instead of center-anchored.
- A one-time migration converts existing center-anchored text to top-left, so old decks don't move. It's idempotent and also runs on layout/template inserts.

Misc - Image/video now show corner resize handles only (no edge handles).