### PR TITLE
refactor: use registry for app switcher data

### DIFF
--- a/frontend/src/apps/calendar/components/AppSidebar.vue
+++ b/frontend/src/apps/calendar/components/AppSidebar.vue
@@ -2,8 +2,9 @@
 import { computed, h, inject, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { Check, Eye, EyeOff, LayoutGrid, LogOut, Settings, User } from 'lucide-vue-next'
-import { Avatar, Sidebar, createResource } from 'frappe-ui'
+import { Avatar, Sidebar } from 'frappe-ui'
 
+import { getAppSwitcherItems } from '@/apps/registry'
 import { useSessionStore } from '@/boot/session'
 import { toTitleCase } from '@/apps/calendar/utils/format'
 import { brandingStore } from '@/apps/calendar/stores/branding'
@@ -38,12 +39,7 @@ const subtitle = computed(() => {
 	return currentAccount._name
 })
 
-const apps = createResource({
-	url: 'suite.mail.api.get_permitted_apps',
-	cache: 'otherApps',
-	auto: true,
-	transform: (data) => data.filter((app) => app.name !== 'calendar_app'),
-})
+const apps = { get data() { return getAppSwitcherItems('calendar') } }
 
 const showSettings = ref(false)
 

--- a/frontend/src/apps/drive/components/Sidebar.vue
+++ b/frontend/src/apps/drive/components/Sidebar.vue
@@ -70,7 +70,6 @@ const router = useRouter()
 const route = useRoute()
 notifCount.fetch()
 getTeams.fetch()
-apps.fetch()
 
 const teamExists = createResource({
   url: 'suite.drive.utils.get_default_team',

--- a/frontend/src/apps/drive/resources/permissions.js
+++ b/frontend/src/apps/drive/resources/permissions.js
@@ -1,4 +1,5 @@
 import { createResource } from 'frappe-ui'
+import { getAppSwitcherItems } from '@/apps/registry'
 import { toast } from '@/apps/drive/utils/toasts'
 import { useSessionStore } from '@/boot/session'
 
@@ -69,31 +70,11 @@ export const isAdmin = createResource({
   url: 'suite.drive.api.product.is_site_admin',
 })
 
-export const apps = createResource({
-  url: 'frappe.apps.get_apps',
-  cache: 'apps',
-  transform: (data) => {
-    let apps = [
-      {
-        name: 'frappe',
-        logo: '/assets/frappe/images/framework.png',
-        title: 'Desk',
-        route: '/app',
-      },
-    ]
-    data.map((app) => {
-      if (app.name === 'drive') return
-      apps.push({
-        name: app.name,
-        logo: app.logo,
-        title: app.title,
-        route: app.route,
-      })
-    })
-
-    return apps
+export const apps = {
+  get data() {
+    return getAppSwitcherItems('drive')
   },
-})
+}
 
 export const diskSettings = createResource({
   url: 'suite.drive.api.product.disk_settings',

--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -75,8 +75,9 @@ import { useRoute, useRouter } from 'vue-router'
 import { useStorage } from '@vueuse/core'
 import { Icon } from 'frappe-ui/icons'
 import { Check, Keyboard, User } from 'lucide-vue-next'
-import { Avatar, Button, Dropdown, Sidebar, SidebarItem, createResource } from 'frappe-ui'
+import { Avatar, Button, Dropdown, Sidebar, SidebarItem } from 'frappe-ui'
 
+import { getAppSwitcherItems } from '@/apps/registry'
 import { FOLDER_ICON_COLOR_MAP } from '@/apps/mail/constants'
 import { getIcon, getMailboxName, toTitleCase } from '@/apps/mail/utils'
 import { useScreenSize, useSettings, useSidebar } from '@/apps/mail/utils/composables'
@@ -117,12 +118,7 @@ const { mailboxes } = store
 
 const user = inject('$user')
 
-const apps = createResource({
-	url: 'suite.mail.api.get_permitted_apps',
-	cache: 'otherApps',
-	auto: true,
-	transform: (data) => data.filter((app) => app.name !== 'mail'),
-})
+const apps = { get data() { return getAppSwitcherItems('mail') } }
 
 const { showSettings } = useSettings()
 const showFolderModal = ref(false)

--- a/frontend/src/apps/registry.ts
+++ b/frontend/src/apps/registry.ts
@@ -17,6 +17,7 @@ import sheetsLogo from '@/assets/app-logos/sheets.svg'
 import slidesLogo from '@/assets/app-logos/slides.svg'
 import suiteLogo from '@/assets/app-logos/suite.svg'
 import writerLogo from '@/assets/app-logos/writer.png'
+import { systemUser } from '@/boot/session'
 
 export interface SuiteApp {
   id: string
@@ -25,6 +26,13 @@ export interface SuiteApp {
   /** URL prefix this app owns; preserved from the original standalone app. */
   prefix: string
   /** Imported, build-fingerprinted brand-logo URL. */
+  logo: string
+}
+
+export interface SuiteAppSwitcherItem {
+  name: string
+  title: string
+  route: string
   logo: string
 }
 
@@ -39,3 +47,24 @@ export const SUITE_APPS: SuiteApp[] = [
   { id: 'mail', name: 'Mail', prefix: '/mail', logo: mailLogo },
   { id: 'calendar', name: 'Calendar', prefix: '/calendar', logo: calendarLogo },
 ]
+
+export const SUITE_APP_SWITCHER_ITEMS: SuiteAppSwitcherItem[] = SUITE_APPS.map((app) => ({
+  name: app.id,
+  title: app.name,
+  route: app.prefix,
+  logo: app.logo,
+}))
+
+export const DESK_APP_SWITCHER_ITEM: SuiteAppSwitcherItem = {
+  name: 'frappe',
+  title: 'Desk',
+  route: '/app',
+  logo: '/assets/frappe/images/framework.png',
+}
+
+export function getAppSwitcherItems(currentApp: string): SuiteAppSwitcherItem[] {
+  return [
+    ...(systemUser.value ? [DESK_APP_SWITCHER_ITEM] : []),
+    ...SUITE_APP_SWITCHER_ITEMS.filter((app) => app.name !== currentApp),
+  ]
+}

--- a/frontend/src/apps/registry.ts
+++ b/frontend/src/apps/registry.ts
@@ -17,7 +17,7 @@ import sheetsLogo from '@/assets/app-logos/sheets.svg'
 import slidesLogo from '@/assets/app-logos/slides.svg'
 import suiteLogo from '@/assets/app-logos/suite.svg'
 import writerLogo from '@/assets/app-logos/writer.png'
-import { systemUser } from '@/boot/session'
+import { jmapUser, systemUser } from '@/boot/session'
 
 export interface SuiteApp {
   id: string
@@ -63,8 +63,12 @@ export const DESK_APP_SWITCHER_ITEM: SuiteAppSwitcherItem = {
 }
 
 export function getAppSwitcherItems(currentApp: string): SuiteAppSwitcherItem[] {
-  return [
+  const items = [
     ...(systemUser.value ? [DESK_APP_SWITCHER_ITEM] : []),
     ...SUITE_APP_SWITCHER_ITEMS.filter((app) => app.name !== currentApp),
   ]
+  if (!jmapUser.value) {
+    return items.filter((app) => app.name !== 'mail' && app.name !== 'calendar')
+  }
+  return items
 }

--- a/frontend/src/apps/writer/resources/index.js
+++ b/frontend/src/apps/writer/resources/index.js
@@ -1,5 +1,6 @@
 import { useList, createResource, useCall } from 'frappe-ui'
 import { prettyData } from '@/apps/writer/utils'
+import { getAppSwitcherItems } from '@/apps/registry'
 
 export const getDocuments = useList({
   url: '/api/method/suite.writer.api.general.get_document_list',
@@ -38,8 +39,8 @@ export const updateComments = createResource({
 })
 
 
-export const apps = createResource({
-  url: 'frappe.apps.get_apps',
-  cache: 'apps',
-  transform: (data) => data.filter((app) => app.name !== 'writer'),
-})
+export const apps = {
+  get data() {
+    return getAppSwitcherItems('writer')
+  },
+}

--- a/frontend/src/apps/writer/routes.ts
+++ b/frontend/src/apps/writer/routes.ts
@@ -6,10 +6,8 @@ import { createResource } from 'frappe-ui'
 // suite's shared main.ts does not run them, so trigger them on writer module
 // load. Backend method paths preserved as-is.
 import { allUsers } from '@/apps/drive/ui/drive/js/resources'
-import { apps } from '@/apps/writer/resources/'
 
 allUsers.fetch()
-apps.fetch()
 
 /**
  * Writer route module — mounted by the suite router under the '/writer' prefix.

--- a/frontend/src/boot/session.ts
+++ b/frontend/src/boot/session.ts
@@ -25,6 +25,7 @@ const _cookies = _getCookies()
 export const fullName = ref(_cookies.full_name || '')
 export const imageURL = ref(_cookies.user_image || '')
 export const systemUser = ref(_cookies.system_user === 'yes')
+export const jmapUser = ref(false)
 
 export const userResource = createResource({
   url: 'suite.api.account.get_logged_in_user',
@@ -39,6 +40,7 @@ export const userResource = createResource({
     if (data.full_name) fullName.value = data.full_name as string
     if (data.avatar) imageURL.value = data.avatar as string
     systemUser.value = ((data.roles as string[]) ?? []).includes('System Manager')
+    jmapUser.value = !!data.is_jmap_configured
   },
 })
 
@@ -99,5 +101,6 @@ export function useCurrentUser() {
         ? ((userResource.data.roles as string[]) ?? []).includes('System Manager')
         : systemUser.value,
     ),
+    jmapUser: computed(() => (userResource.data ? !!userResource.data.is_jmap_configured : jmapUser.value)),
   }
 }

--- a/suite/api/account.py
+++ b/suite/api/account.py
@@ -1,7 +1,11 @@
 import frappe
+from frappe.utils.caching import redis_cache
+
+from suite.mail.utils.user import is_jmap_configured
 
 
 @frappe.whitelist()
+@redis_cache(user=True)
 def get_logged_in_user() -> dict | None:
 	user = frappe.session.user
 	if user == "Guest":
@@ -14,4 +18,5 @@ def get_logged_in_user() -> dict | None:
 		"full_name": user_doc.full_name,
 		"avatar": user_doc.user_image,
 		"roles": [role.role for role in user_doc.roles],
+		"is_jmap_configured": is_jmap_configured(user),
 	}

--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -16,7 +16,7 @@ app_license = "agpl-3.0"
 add_to_apps_screen = [
 	{
 		"name": "suite",
-		"logo": "/assets/suite/drive/images/icons/logo.svg",
+		"logo": "/assets/suite/frontend/logo.svg",
 		"title": "Frappe Suite",
 		"route": "/suite",
 	},

--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -15,46 +15,10 @@ app_license = "agpl-3.0"
 # ============================================================================
 add_to_apps_screen = [
 	{
-		"name": "drive",
+		"name": "suite",
 		"logo": "/assets/suite/drive/images/icons/logo.svg",
-		"title": "Drive",
-		"route": "/drive",
-	},
-	{
-		"name": "slides",
-		"logo": "/assets/suite/slides/images/slides.svg",
-		"title": "Slides",
-		"route": "/slides",
-	},
-	{
-		"name": "writer",
-		"logo": "/assets/suite/writer/images/writer.png",
-		"title": "Writer",
-		"route": "/writer",
-	},
-	{
-		"name": "sheets",
-		"logo": "/assets/suite/sheets/logo.svg",
-		"title": "Sheets",
-		"route": "/sheets",
-	},
-	{
-		"name": "meet",
-		"logo": "/assets/suite/meet/images/meet.png",
-		"title": "Meet",
-		"route": "/meet",
-	},
-	{
-		"name": "mail",
-		"logo": "/assets/suite/mail/images/logo.svg",
-		"title": "Mail",
-		"route": "/mail",
-	},
-	{
-		"name": "calendar",
-		"logo": "/assets/suite/calendar/images/logo.svg",
-		"title": "Calendar",
-		"route": "/calendar",
+		"title": "Frappe Suite",
+		"route": "/suite",
 	},
 ]
 

--- a/suite/mail/api/__init__.py
+++ b/suite/mail/api/__init__.py
@@ -45,26 +45,3 @@ def get_translations() -> dict:
 		language = frappe.db.get_single_value("System Settings", "language")
 
 	return get_all_translations(language)
-
-
-@frappe.whitelist()
-@redis_cache(user=True)
-def get_permitted_apps():
-	apps = get_apps()
-
-	# Calendar rides on mail's JMAP; hide it from users without a configured mail account.
-	if not is_jmap_configured(frappe.session.user):
-		apps = [app for app in apps if app.get("name") != "calendar"]
-
-	if not is_system_manager(frappe.session.user):
-		return apps
-
-	desk = {
-		"name": "frappe",
-		"logo": "/assets/suite/mail/images/desk.png",
-		"title": "Desk",
-		"route": "/app",
-	}
-	apps.append(desk)
-
-	return apps


### PR DESCRIPTION
no api call needed since we are already storing necessary data in the registry