### PR TITLE
fix(meet-sfu): request keyframe on consumer resume with no layer change

### DIFF
--- a/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
@@ -472,6 +472,20 @@ export class MediasoupManager {
 		await this.consumerManager.resumeConsumer(options.consumerId);
 		loggers.mediasoupManager.debug('Resumed consumer %s', options.consumerId);
 
+		// A resumed consumer would otherwise show a frozen frame until
+		// the next encoder keyframe (typically 1-5 s).
+		if (wasPaused && consumer.kind === 'video') {
+			try {
+				await consumer.requestKeyFrame();
+			} catch (error) {
+				loggers.mediasoupManager.warn(
+					'Failed to request key frame for resumed consumer %s: %s',
+					consumer.id,
+					(error as Error).message,
+				);
+			}
+		}
+
 		let appliedLayers:
 			| { spatialLayer: number | null; temporalLayer: number | null }
 			| undefined;
@@ -512,10 +526,12 @@ export class MediasoupManager {
 					);
 					const currentLayers = consumer.currentLayers;
 					const previousSpatial = currentLayers?.spatialLayer ?? null;
+					// Request a keyframe on spatial layer upgrade so the
+					// higher layer is visible without waiting for the next
+					// encoder keyframe.
 					if (
-						(previousSpatial !== null &&
-							layerResult.spatialLayer > previousSpatial) ||
-						wasPaused
+						previousSpatial !== null &&
+						layerResult.spatialLayer > previousSpatial
 					) {
 						try {
 							await consumer.requestKeyFrame();

--- a/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
@@ -472,23 +472,10 @@ export class MediasoupManager {
 		await this.consumerManager.resumeConsumer(options.consumerId);
 		loggers.mediasoupManager.debug('Resumed consumer %s', options.consumerId);
 
-		// A resumed consumer would otherwise show a frozen frame until
-		// the next encoder keyframe (typically 1-5 s).
-		if (wasPaused && consumer.kind === 'video') {
-			try {
-				await consumer.requestKeyFrame();
-			} catch (error) {
-				loggers.mediasoupManager.warn(
-					'Failed to request key frame for resumed consumer %s: %s',
-					consumer.id,
-					(error as Error).message,
-				);
-			}
-		}
-
 		let appliedLayers:
 			| { spatialLayer: number | null; temporalLayer: number | null }
 			| undefined;
+		let previousSpatial: number | null = null;
 
 		if (consumer.kind === 'video') {
 			const spatialLayer = this.estimateSpatialLayer(
@@ -525,24 +512,7 @@ export class MediasoupManager {
 						layerResult.temporalLayer,
 					);
 					const currentLayers = consumer.currentLayers;
-					const previousSpatial = currentLayers?.spatialLayer ?? null;
-					// Request a keyframe on spatial layer upgrade so the
-					// higher layer is visible without waiting for the next
-					// encoder keyframe.
-					if (
-						previousSpatial !== null &&
-						layerResult.spatialLayer > previousSpatial
-					) {
-						try {
-							await consumer.requestKeyFrame();
-						} catch (error) {
-							loggers.mediasoupManager.warn(
-								'Failed to request key frame for consumer %s: %s',
-								consumer.id,
-								(error as Error).message,
-							);
-						}
-					}
+					previousSpatial = currentLayers?.spatialLayer ?? null;
 				}
 			} else {
 				// Even if we didn't change layers, return the current state
@@ -559,6 +529,23 @@ export class MediasoupManager {
 						appliedLayers.temporalLayer,
 					);
 				}
+			}
+		}
+
+		const layerUpgraded =
+			appliedLayers &&
+			appliedLayers.spatialLayer !== null &&
+			previousSpatial !== null &&
+			appliedLayers.spatialLayer > previousSpatial;
+		if (consumer.kind === 'video' && (wasPaused || layerUpgraded)) {
+			try {
+				await consumer.requestKeyFrame();
+			} catch (error) {
+				loggers.mediasoupManager.warn(
+					'Failed to request key frame for consumer %s: %s',
+					consumer.id,
+					(error as Error).message,
+				);
 			}
 		}
 

--- a/suite/meet/sfu-server/src/mediasoup/__tests__/MediasoupManager.test.ts
+++ b/suite/meet/sfu-server/src/mediasoup/__tests__/MediasoupManager.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Consumer } from '../../types';
+import { MediasoupManager } from '../MediasoupManager';
+
+function makeConsumer(opts: {
+	paused: boolean;
+	preferredLayers?: { spatialLayer: number; temporalLayer: number } | null;
+	currentLayers?: { spatialLayer: number; temporalLayer: number } | null;
+}): Consumer {
+	return {
+		id: 'c1',
+		kind: 'video',
+		paused: opts.paused,
+		preferredLayers: opts.preferredLayers ?? {
+			spatialLayer: 1,
+			temporalLayer: 1,
+		},
+		currentLayers: opts.currentLayers ?? {
+			spatialLayer: 1,
+			temporalLayer: 1,
+		},
+		rtpParameters: { encodings: [{ scalabilityMode: 'L3T1' }] },
+		requestKeyFrame: vi.fn().mockResolvedValue(undefined),
+		setPreferredLayers: vi.fn(),
+	} as unknown as Consumer;
+}
+
+describe('MediasoupManager.updateConsumerPreferences', () => {
+	it('requests a keyframe when a paused consumer is resumed with no layer change', async () => {
+		const mgr = new MediasoupManager();
+		const consumer = makeConsumer({ paused: true });
+		vi.spyOn(mgr.consumerManager, 'getConsumerData').mockReturnValue({
+			roomId: 'r1',
+			peerId: 'p1',
+			consumer,
+		} as never);
+		vi.spyOn(mgr.consumerManager, 'resumeConsumer').mockResolvedValue(true);
+		vi.spyOn(
+			mgr.consumerManager,
+			'setConsumerPreferredLayers',
+		).mockResolvedValue(null);
+
+		await mgr.updateConsumerPreferences({
+			consumerId: 'c1',
+			visible: true,
+			width: 640,
+			height: 360,
+		});
+
+		expect(consumer.requestKeyFrame).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not request a keyframe on a running consumer with no layer change', async () => {
+		const mgr = new MediasoupManager();
+		const consumer = makeConsumer({ paused: false });
+		vi.spyOn(mgr.consumerManager, 'getConsumerData').mockReturnValue({
+			roomId: 'r1',
+			peerId: 'p1',
+			consumer,
+		} as never);
+		vi.spyOn(mgr.consumerManager, 'resumeConsumer').mockResolvedValue(true);
+		vi.spyOn(
+			mgr.consumerManager,
+			'setConsumerPreferredLayers',
+		).mockResolvedValue(null);
+
+		await mgr.updateConsumerPreferences({
+			consumerId: 'c1',
+			visible: true,
+			width: 640,
+			height: 360,
+		});
+
+		expect(consumer.requestKeyFrame).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
When a consumer was paused and resumed with no spatial-layer change, the previous code did not request a keyframe. Remote tiles then showed a frozen frame for the duration of  1-5s when scrolled into view after being off-screen.

Tests added: paused->resumed with no layer change requests a keyframe; running consumer with no layer change does not.

