### PR TITLE
refactor(meet): don't preload noise cancellation worker

### DIFF
--- a/frontend/src/apps/meet/composables/useNoiseCancellation.ts
+++ b/frontend/src/apps/meet/composables/useNoiseCancellation.ts
@@ -32,8 +32,8 @@ interface PreloadedWorklet {
  * Composable for noise cancellation using DTLN (via @workadventure/noise-suppression).
  *
  * DTLN is hard-coded to 16 kHz mono, 512-sample frames. The worklet is
- * preloaded at composable init so toggling never waits on wasm/model load.
- * On toggle, the raw and denoised branches are crossfaded over 50 ms to
+ * loaded on first use (lazy) so it does not consume resources until noise
+ * cancellation is actually enabled. On toggle, the raw and denoised branches are crossfaded over 50 ms to
  * avoid an audible click. If preload or apply fails, the caller falls
  * back to the raw stream and `error` is set.
  */

--- a/frontend/src/apps/meet/composables/useNoiseCancellation.ts
+++ b/frontend/src/apps/meet/composables/useNoiseCancellation.ts
@@ -227,9 +227,6 @@ export function useNoiseCancellation(): UseNoiseCancellationReturn {
 		preloaded = null;
 	});
 
-	// Kick off preload eagerly so toggling is instant.
-	void preloadWorklet();
-
 	return {
 		isProcessing,
 		processedStream,


### PR DESCRIPTION
Users might not even enable it, but this will hang around in the background consuming resources. And loading the worker is pretty much fast so no need.