### PR TITLE
fix(slides): shape enters edit mode after drag

### DIFF
--- a/frontend/src/apps/slides/components/ShapeElement.vue
+++ b/frontend/src/apps/slides/components/ShapeElement.vue
@@ -121,7 +121,7 @@ import { computed, inject, ref } from 'vue'
 
 import TextElement from '@/apps/slides/components/TextElement.vue'
 import { useSVGShadow } from '@/apps/slides/composables/useSVGShadow'
-import { focusElementId, activeElementIds } from '@/apps/slides/stores/element'
+import { focusElementId, activeElementIds, dragOccurred } from '@/apps/slides/stores/element'
 
 const props = defineProps({
 	transitionStyles: {
@@ -209,6 +209,8 @@ const textOverlayStyles = computed(() => ({
 
 const handleDoubleClick = (e) => {
 	e.stopPropagation()
+	// don't enter edit mode when the gesture was a drag
+	if (dragOccurred.value) return
 	if (inSlideShowMode.value || inReadonlyMode.value || !canHaveText.value || isEditable.value)
 		return
 	activeElementIds.value = [element.value.id]

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -72,6 +72,7 @@ import {
 	activeElement,
 	focusElementId,
 	pairElementId,
+	dragOccurred,
 	addFixedWidthToElement,
 	setEditableState,
 	duplicateElements,
@@ -211,6 +212,7 @@ const triggerDrag = (e, id) => {
 	if (isMultiSelect && isNotInSelection) return
 
 	if (notEditable || isMultiSelect) {
+		dragOccurred.value = true
 		startDragging(e)
 
 		if (id && !isMultiSelect && activeElementIds.value[0] !== id) {
@@ -270,6 +272,8 @@ const handleMouseDown = (e, element) => {
 
 	e.stopPropagation()
 	e.preventDefault()
+
+	dragOccurred.value = false
 
 	if (e.altKey || e.ctrlKey) return duplicateAndDrag(e, id)
 

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -33,6 +33,9 @@ const focusElementId = ref(null)
 const pairElementId = ref(null)
 const pendingShapeType = ref(null)
 
+// true once a gesture crosses the drag threshold
+const dragOccurred = ref(false)
+
 const activeElements = computed(() => {
 	let elements = []
 	currentSlide.value?.elements.forEach((element) => {
@@ -1004,6 +1007,7 @@ export {
 	focusElementId,
 	pairElementId,
 	pendingShapeType,
+	dragOccurred,
 	activeElements,
 	activeElement,
 	setActiveElements,


### PR DESCRIPTION
**Bug**
A drag gesture that the browser also reports as a `dblclick` was making shapes go into text-edit mode and de-syncing the selection box mid-drag sometimes.

**Fix**
Track when a gesture crosses the drag threshold and skip `dblclick` handler in that case.