### PR TITLE
feat(sheets): paste tables from external apps via the HTML clipboard flavor

### DIFF
--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -3596,10 +3596,19 @@ async function onDocPaste(e) {
     clipboard.paste(activeCell.value, () => {}, 'all', destSel)
     pasted = true
   } else {
-    const text = e.clipboardData?.getData('text/plain')
-    if (text) {
-      clipboard.pasteFromText(text, activeCell.value, () => {}, destSel)
+    // Prefer the HTML flavor when it carries a real table — external apps
+    // (Gameplan, Google Sheets, web pages) put a structured <table> there,
+    // while their text/plain flavor can lack tab delimiters and collapse into
+    // a single column. Fall back to tab/newline-delimited plain text.
+    const html = e.clipboardData?.getData('text/html')
+    if (html && clipboard.pasteFromHTML(html, activeCell.value, () => {}, destSel)) {
       pasted = true
+    } else {
+      const text = e.clipboardData?.getData('text/plain')
+      if (text) {
+        clipboard.pasteFromText(text, activeCell.value, () => {}, destSel)
+        pasted = true
+      }
     }
   }
   clipboardHas.value = clipboard.hasData()

--- a/frontend/src/apps/sheets/engine/clipboard.js
+++ b/frontend/src/apps/sheets/engine/clipboard.js
@@ -233,9 +233,17 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 		const table = doc.querySelector('table')
 		if (!table) return null
 		const grid = []
-		for (const tr of table.querySelectorAll('tr')) {
+		// Only the outer table's own rows/cells — a bare querySelectorAll('tr')
+		// descends into any nested <table> inside a cell (common in web-page
+		// clipboard HTML) and bleeds its rows into the outer grid. A nested
+		// table's text still lands in the parent cell via textContent, which is
+		// what we want.
+		const rows = table.querySelectorAll(
+			':scope > tr, :scope > thead > tr, :scope > tbody > tr, :scope > tfoot > tr',
+		)
+		for (const tr of rows) {
 			const row = []
-			for (const cell of tr.querySelectorAll('th, td')) {
+			for (const cell of tr.querySelectorAll(':scope > th, :scope > td')) {
 				const text = (cell.textContent ?? '').replace(/\s+/g, ' ').trim()
 				row.push(text)
 				const span = parseInt(cell.getAttribute('colspan') || '1', 10)
@@ -313,5 +321,5 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 	function getPivotBlob() { return _data ? _pivot : null }
 	function clear() { _data = _fmts = _vals = _mode = _srcSel = _pivot = null }
 
-	return { copy, cut, paste, pasteFromText, pasteFromHTML, parseHTMLTable, hasData, getMode, getSourceSel, getPivotBlob, clear }
+	return { copy, cut, paste, pasteFromText, pasteFromHTML, hasData, getMode, getSourceSel, getPivotBlob, clear }
 }

--- a/frontend/src/apps/sheets/engine/clipboard.js
+++ b/frontend/src/apps/sheets/engine/clipboard.js
@@ -220,14 +220,56 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 		return sheet.getDisplayValue(srcId)
 	}
 
+	// Parse an HTML fragment's first <table> into a 2D grid of cell strings, or
+	// null if there's no usable table. External apps (Gameplan, Google Sheets,
+	// Excel Online, web pages) put a full <table> on the `text/html` clipboard
+	// flavor — richer than their `text/plain` flavor, which some editors emit
+	// without tab delimiters (so it collapses into a single column). colspan is
+	// honored by padding blanks; rowspan is left as-is (rare, and its cell text
+	// simply lands in the top row of the span).
+	function parseHTMLTable(html) {
+		if (!html || typeof DOMParser === 'undefined') return null
+		const doc   = new DOMParser().parseFromString(html, 'text/html')
+		const table = doc.querySelector('table')
+		if (!table) return null
+		const grid = []
+		for (const tr of table.querySelectorAll('tr')) {
+			const row = []
+			for (const cell of tr.querySelectorAll('th, td')) {
+				const text = (cell.textContent ?? '').replace(/\s+/g, ' ').trim()
+				row.push(text)
+				const span = parseInt(cell.getAttribute('colspan') || '1', 10)
+				for (let i = 1; i < span; i++) row.push('')
+			}
+			grid.push(row)
+		}
+		// Drop trailing all-empty rows some editors append.
+		while (grid.length && grid[grid.length - 1].every(c => c === '')) grid.pop()
+		return grid.length ? grid : null
+	}
+
+	// Paste an HTML-table grid (from an external app's `text/html` flavor).
+	// Shares the placement/tiling/bulk-write path with pasteFromText.
+	function pasteFromHTML(html, anchorId, historyPush, destSel = null) {
+		const grid = parseHTMLTable(html)
+		if (!grid) return false
+		return _pasteGrid(grid, anchorId, historyPush, destSel)
+	}
+
 	// Paste raw text (from system clipboard / external app).  Honors destSel so
 	// pasting a single token into a multi-cell selection fills the whole range.
 	function pasteFromText(text, anchorId, historyPush, destSel = null) {
 		if (!text?.trim()) return
-		const anch = parseCellId(anchorId)
-		if (!anch) return
 		const lines = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trimEnd().split('\n')
 		const grid  = lines.map(l => l.split('\t'))
+		return _pasteGrid(grid, anchorId, historyPush, destSel)
+	}
+
+	// Place a 2D grid of cell strings at the anchor (or tiled across destSel),
+	// then ship one bulk write. Shared by pasteFromText and pasteFromHTML.
+	function _pasteGrid(grid, anchorId, historyPush, destSel = null) {
+		const anch = parseCellId(anchorId)
+		if (!anch) return false
 		const srcRows = grid.length
 		const srcCols = grid.reduce((m, r) => Math.max(m, r.length), 0)
 
@@ -258,6 +300,7 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 		if (sheet.batchSetCells) sheet.batchSetCells(writes, sn, { replace: false })
 		else                     for (const [id, v] of Object.entries(writes)) sheet.setCell(id, v, sn)
 		historyPush?.()   // post-mutate snapshot
+		return true
 	}
 
 	// Expand selection to fit pasted content (used for visual feedback).
@@ -270,5 +313,5 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 	function getPivotBlob() { return _data ? _pivot : null }
 	function clear() { _data = _fmts = _vals = _mode = _srcSel = _pivot = null }
 
-	return { copy, cut, paste, pasteFromText, hasData, getMode, getSourceSel, getPivotBlob, clear }
+	return { copy, cut, paste, pasteFromText, pasteFromHTML, parseHTMLTable, hasData, getMode, getSourceSel, getPivotBlob, clear }
 }

--- a/frontend/src/apps/sheets/engine/clipboard.test.js
+++ b/frontend/src/apps/sheets/engine/clipboard.test.js
@@ -1,0 +1,200 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createClipboard } from './clipboard.js'
+
+function makeSheet(initial = {}) {
+  const store = { ...initial }
+  return {
+    getRawData:     () => store,
+    getCell:        id => store[id] ?? '',
+    setCell:        (id, v) => { store[id] = v },
+    getCurrentSheet: () => 'Sheet1',
+    getDisplayValue: id => store[id] ?? '',
+    _store: () => store,
+  }
+}
+
+describe('clipboard — copy/paste a pivot', () => {
+  let sheet
+  const pivotBlob = { sourceSheet: 'Src', sourceRange: 'A1:B9', rows: ['R'], cols: [], values: [{ field: 'V', agg: 'sum' }] }
+
+  beforeEach(() => { sheet = makeSheet({ A1: 'H1', A2: 'a', B2: 1 }) })
+
+  it('captures the pivot blob when the copied range overlaps a pivot', () => {
+    const cb = createClipboard({ sheet, getPivotAt: () => pivotBlob })
+    cb.copy({ r0: 0, c0: 0, r1: 2, c1: 1 })
+    expect(cb.getPivotBlob()).toEqual(pivotBlob)
+  })
+
+  it('a full paste mints a new pivot at the anchor instead of writing cells', () => {
+    const calls = []
+    const cb = createClipboard({
+      sheet,
+      getPivotAt: () => pivotBlob,
+      createPivotFromPaste: (blob, anchorId, sn) => { calls.push({ blob, anchorId, sn }) },
+    })
+    cb.copy({ r0: 0, c0: 0, r1: 2, c1: 1 })
+    cb.paste('H1', null, 'all')
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({ blob: pivotBlob, anchorId: 'H1' })
+    expect(sheet.getCell('H1')).toBe('')   // no static cells written
+  })
+
+  it('paste-special (values) ignores the blob and pastes dead cells', () => {
+    const calls = []
+    const cb = createClipboard({
+      sheet,
+      getPivotAt: () => pivotBlob,
+      createPivotFromPaste: (...a) => { calls.push(a) },
+    })
+    cb.copy({ r0: 0, c0: 0, r1: 2, c1: 1 })
+    cb.paste('H1', null, 'values')
+    expect(calls).toHaveLength(0)          // not treated as a pivot
+    expect(sheet.getCell('H1')).toBe('H1') // static value pasted
+  })
+
+  it('clears the captured blob on clear()', () => {
+    const cb = createClipboard({ sheet, getPivotAt: () => pivotBlob })
+    cb.copy({ r0: 0, c0: 0, r1: 2, c1: 1 })
+    cb.clear()
+    expect(cb.getPivotBlob()).toBeNull()
+  })
+})
+
+describe('clipboard — destination-aware paste', () => {
+  let sheet, cb
+  beforeEach(() => {
+    sheet = makeSheet({ A1: 'X' })
+    cb = createClipboard({ sheet })
+  })
+
+  it('1×1 source pasted into a multi-cell selection fills every dest cell', () => {
+    cb.copy({ r0: 0, c0: 0, r1: 0, c1: 0 })
+    cb.paste('B1', null, 'all', { r0: 0, c0: 1, r1: 0, c1: 3 })       // B1:D1
+    expect(sheet.getCell('B1')).toBe('X')
+    expect(sheet.getCell('C1')).toBe('X')
+    expect(sheet.getCell('D1')).toBe('X')
+  })
+
+  it('1×1 source into a multi-row + multi-col selection tiles fully', () => {
+    cb.copy({ r0: 0, c0: 0, r1: 0, c1: 0 })
+    cb.paste('B2', null, 'all', { r0: 1, c0: 1, r1: 2, c1: 2 })       // B2:C3
+    expect(sheet.getCell('B2')).toBe('X')
+    expect(sheet.getCell('C2')).toBe('X')
+    expect(sheet.getCell('B3')).toBe('X')
+    expect(sheet.getCell('C3')).toBe('X')
+  })
+
+  it('multi-cell source tiles into a destination that is an integer multiple', () => {
+    sheet = makeSheet({ A1: '1', B1: '2' })
+    cb = createClipboard({ sheet })
+    cb.copy({ r0: 0, c0: 0, r1: 0, c1: 1 })                            // A1:B1 = [1, 2]
+    cb.paste('A2', null, 'all', { r0: 1, c0: 0, r1: 1, c1: 3 })        // A2:D2
+    expect(sheet.getCell('A2')).toBe('1')
+    expect(sheet.getCell('B2')).toBe('2')
+    expect(sheet.getCell('C2')).toBe('1')
+    expect(sheet.getCell('D2')).toBe('2')
+  })
+
+  it('non-tileable destination falls back to anchor paste', () => {
+    sheet = makeSheet({ A1: '1', B1: '2' })
+    cb = createClipboard({ sheet })
+    cb.copy({ r0: 0, c0: 0, r1: 0, c1: 1 })                            // 2 cols
+    cb.paste('A2', null, 'all', { r0: 1, c0: 0, r1: 1, c1: 2 })        // 3 cols → not divisible
+    expect(sheet.getCell('A2')).toBe('1')
+    expect(sheet.getCell('B2')).toBe('2')
+    expect(sheet.getCell('C2')).toBe('')                                // untouched
+  })
+
+  it('single-cell destination behaves the same as no destSel', () => {
+    cb.copy({ r0: 0, c0: 0, r1: 0, c1: 0 })
+    cb.paste('B1', null, 'all', { r0: 0, c0: 1, r1: 0, c1: 1 })
+    expect(sheet.getCell('B1')).toBe('X')
+    expect(sheet.getCell('C1')).toBe('')
+  })
+
+  it('pasteFromText tiles a single token across a multi-cell destination', () => {
+    cb.pasteFromText('hello', 'B1', null, { r0: 0, c0: 1, r1: 0, c1: 3 })
+    expect(sheet.getCell('B1')).toBe('hello')
+    expect(sheet.getCell('C1')).toBe('hello')
+    expect(sheet.getCell('D1')).toBe('hello')
+  })
+
+  it('pasteFromText with a single token but single-cell dest writes one cell', () => {
+    cb.pasteFromText('hi', 'B1', null, { r0: 0, c0: 1, r1: 0, c1: 1 })
+    expect(sheet.getCell('B1')).toBe('hi')
+    expect(sheet.getCell('C1')).toBe('')
+  })
+})
+
+describe('clipboard — pasteFromHTML (external table)', () => {
+  let sheet, cb
+  beforeEach(() => {
+    sheet = makeSheet({})
+    cb = createClipboard({ sheet })
+  })
+
+  it('parses a <table> into rows and columns at the anchor', () => {
+    const html = '<table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>'
+    expect(cb.pasteFromHTML(html, 'A1', null)).toBe(true)
+    expect(sheet.getCell('A1')).toBe('a')
+    expect(sheet.getCell('B1')).toBe('b')
+    expect(sheet.getCell('A2')).toBe('c')
+    expect(sheet.getCell('B2')).toBe('d')
+  })
+
+  it('handles th headers and collapses whitespace in cells', () => {
+    const html = '<table><tr><th>Name</th><th>MRR</th></tr>' +
+                 '<tr><td>webdev@lush\n.co.uk</td><td>9,415</td></tr></table>'
+    cb.pasteFromHTML(html, 'A1', null)
+    expect(sheet.getCell('A1')).toBe('Name')
+    expect(sheet.getCell('B1')).toBe('MRR')
+    expect(sheet.getCell('A2')).toBe('webdev@lush .co.uk')
+    expect(sheet.getCell('B2')).toBe('9,415')
+  })
+
+  it('pads blanks for colspan so columns stay aligned', () => {
+    const html = '<table><tr><td colspan="2">June 2026</td><td>x</td></tr>' +
+                 '<tr><td>1</td><td>2</td><td>3</td></tr></table>'
+    cb.pasteFromHTML(html, 'A1', null)
+    expect(sheet.getCell('A1')).toBe('June 2026')
+    expect(sheet.getCell('B1')).toBe('')
+    expect(sheet.getCell('C1')).toBe('x')
+    expect(sheet.getCell('C2')).toBe('3')
+  })
+
+  it('returns false when the HTML has no table', () => {
+    expect(cb.pasteFromHTML('<p>hello world</p>', 'A1', null)).toBe(false)
+    expect(sheet.getCell('A1')).toBe('')
+  })
+})
+
+describe('clipboard — cut clears the source but not overlapping dest cells', () => {
+  it('cut C2:C7 then paste at C3:C8 shifts the column down by one row', () => {
+    // Repro for the "all values vanish, only the last survives" bug: the
+    // cut-clear pass used to wipe the whole source range, including cells
+    // that had just received the pasted content.
+    const sheet = makeSheet({ C2: '1', C3: '2', C4: '3', C5: '4', C6: '5', C7: '6' })
+    const cb = createClipboard({ sheet })
+    cb.cut({ r0: 1, c0: 2, r1: 6, c1: 2 })                    // C2:C7
+    cb.paste('C3', null, 'all', { r0: 2, c0: 2, r1: 7, c1: 2 }) // C3:C8
+    expect(sheet.getCell('C2')).toBe('')                       // source-only cell vacated
+    expect(sheet.getCell('C3')).toBe('1')
+    expect(sheet.getCell('C4')).toBe('2')
+    expect(sheet.getCell('C5')).toBe('3')
+    expect(sheet.getCell('C6')).toBe('4')
+    expect(sheet.getCell('C7')).toBe('5')
+    expect(sheet.getCell('C8')).toBe('6')
+  })
+
+  it('cut still fully vacates the source when there is no overlap', () => {
+    const sheet = makeSheet({ A1: '1', A2: '2' })
+    const cb = createClipboard({ sheet })
+    cb.cut({ r0: 0, c0: 0, r1: 1, c1: 0 })                    // A1:A2
+    cb.paste('C1', null, 'all')                                // C1:C2 — no overlap
+    expect(sheet.getCell('A1')).toBe('')
+    expect(sheet.getCell('A2')).toBe('')
+    expect(sheet.getCell('C1')).toBe('1')
+    expect(sheet.getCell('C2')).toBe('2')
+  })
+})

--- a/frontend/src/apps/sheets/engine/clipboard.test.js
+++ b/frontend/src/apps/sheets/engine/clipboard.test.js
@@ -167,6 +167,21 @@ describe('clipboard — pasteFromHTML (external table)', () => {
     expect(cb.pasteFromHTML('<p>hello world</p>', 'A1', null)).toBe(false)
     expect(sheet.getCell('A1')).toBe('')
   })
+
+  it('ignores rows/cells of a table nested inside a cell (no row bleed)', () => {
+    // Web-page clipboard HTML often embeds a <table> inside a <td>. Only the
+    // outer table's rows should become grid rows; the nested table collapses
+    // into its parent cell's text.
+    const html = '<table><tr><td>outer</td>' +
+                 '<td><table><tr><td>inner1</td></tr><tr><td>inner2</td></tr></table></td></tr>' +
+                 '<tr><td>next</td><td>row</td></tr></table>'
+    cb.pasteFromHTML(html, 'A1', null)
+    expect(sheet.getCell('A1')).toBe('outer')
+    expect(sheet.getCell('B1')).toBe('inner1inner2') // nested text, one cell
+    expect(sheet.getCell('A2')).toBe('next')          // outer row 2, not bled
+    expect(sheet.getCell('B2')).toBe('row')
+    expect(sheet.getCell('A3')).toBe('')              // no phantom rows
+  })
 })
 
 describe('clipboard — cut clears the source but not overlapping dest cells', () => {


### PR DESCRIPTION
## What

Sheets can now paste a **structured table** copied from an external app — Google Sheets, Excel Online, Gameplan, or any web page.

## Why

External apps put a real `<table>` on the clipboard's `text/html` flavor. Their `text/plain` flavor often lacks tab delimiters, so a multi-column table collapses into a single column on paste. We now prefer the HTML flavor when it carries a usable table, falling back to tab/newline-delimited plain text.

## Changes

- **`engine/clipboard.js`** — `parseHTMLTable` (first `<table>` → 2D grid; honors `colspan`, drops trailing empty rows) and `pasteFromHTML`. Both share the placement / tiling / bulk-write path with `pasteFromText` via a new `_pasteGrid` helper.
- **`SheetEditor/index.vue`** — `onDocPaste` tries the HTML table first, falls back to plain text.
- **`engine/clipboard.test.js`** — tests for HTML-table parsing and paste (ported alongside the existing pivot/paste/cut coverage).

Ported from the standalone `frappe/sheets` repo. 17/17 clipboard unit tests pass.