### PR TITLE
fix: pass only `account` to JMAP service getters

### DIFF
--- a/suite/mail/doctype/calendar_exchange/calendar_exchange.py
+++ b/suite/mail/doctype/calendar_exchange/calendar_exchange.py
@@ -373,7 +373,7 @@ class CalendarExchange(Document):
 			logger.debug("import-source-prepared", base_dir=base_dir)
 			self._log_output(_("Prepared the source files for import."))
 
-			service = get_calendar_event_service(self.user, self.account)
+			service = get_calendar_event_service(self.account)
 
 			if self.import_format == "ics":
 				events = self._load_ics_events(service, base_dir, logger)
@@ -427,7 +427,7 @@ class CalendarExchange(Document):
 
 		kwargs = {}
 		try:
-			service = get_calendar_event_service(self.user, self.account)
+			service = get_calendar_event_service(self.account)
 
 			limit = min(self.max_export, cint(self.export_limit or self.max_export))
 			data = service.query(self.export_filter_dict, limit=limit, sort=self.export_sort_clause)

--- a/suite/mail/doctype/jmap_account/jmap_account.py
+++ b/suite/mail/doctype/jmap_account/jmap_account.py
@@ -75,7 +75,7 @@ class JMAPAccount(Document):
 			return None
 
 		try:
-			return get_core_service(self._user, self.name)
+			return get_core_service(self.name)
 		except Exception:
 			frappe.msgprint(f"Error getting JMAP core service for account {self.name}")
 			return None

--- a/suite/mail/doctype/mail_exchange/mail_exchange.py
+++ b/suite/mail/doctype/mail_exchange/mail_exchange.py
@@ -743,7 +743,7 @@ class MailExchange(Document):
 			logger.debug("import-source-prepared", base_dir=base_dir)
 			self._log_output(_("Prepared the source files for import."))
 
-			service = get_email_service(self.user, self.account)
+			service = get_email_service(self.account)
 
 			mailbox_map = {}
 			if self.import_format == "maildir-nested":
@@ -796,7 +796,7 @@ class MailExchange(Document):
 
 		kwargs = {}
 		try:
-			service = get_email_service(self.user, self.account)
+			service = get_email_service(self.account)
 			total = service.query(self.export_filter_dict, limit=1)["total"]
 			limit = min(total, cint(self.export_limit or total))
 			logger.info("export-query-resolved", total=total, limit=limit, max_export=self.max_export)

--- a/suite/mail/doctype/mail_queue/mail_queue.py
+++ b/suite/mail/doctype/mail_queue/mail_queue.py
@@ -606,7 +606,7 @@ class MailQueue(Document):
 
 		if self.in_reply_to and not self.in_reply_to_id:
 			try:
-				service = get_email_service(self.user, self.account)
+				service = get_email_service(self.account)
 				result = service.query({"header": ["Message-ID", self.in_reply_to]})
 				if ids := result["ids"]:
 					self.in_reply_to_id = ids[0]


### PR DESCRIPTION
## Problem

The #138 refactor (`composite handle → explicit (user, account)`) narrowed all JMAP service getters to a single-arg signature:

```python
def get_email_service(account: str, ignore_permissions: bool = False) -> EmailService:
    user = get_user_for_jmap_account(account, raise_exception=True)
    ...
```

The `user` is now derived internally from the account. But five call sites were left passing the old `(self.user, self.account)` positional pair. Python bound `self.user` (an email) to `account` and `self.account` (the real JMAP account id) to `ignore_permissions`, producing:

```
frappe.exceptions.ValidationError: JMAP account <strong>dinesh@frappe.io</strong> does not exist.
```

(seen with `account='dinesh@frappe.io'`, `ignore_permissions='hv'`).

## Fix

Pass only the account to each getter:

- `mail_queue.validate_in_reply_to_id`
- `mail_exchange` — import + export
- `calendar_exchange` — import + export
- `jmap_account.core_service` — passes `self.name` (the account id)

In `mail_queue` this was caught and logged (In Reply To resolution fell back to `None`); in the exchange doctypes and `jmap_account.core_service` it broke import/export and the core-service property outright.

`get_push_subscription_service(user, ...)` is intentionally per-user and left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)