### PR TITLE
fix: backfill Screened Email Address `account` from legacy `account_id`

### DIFF
--- a/suite/mail/patches/backfill_screened_email_address_account.py
+++ b/suite/mail/patches/backfill_screened_email_address_account.py
@@ -1,0 +1,66 @@
+import frappe
+
+DOCTYPE = "Screened Email Address"
+
+
+def execute() -> None:
+	"""Backfill `account` from the legacy `account_id` column on Screened Email Address.
+
+	The `account_id` -> `account` refactor dropped `account_id` from the doctype but leaves
+	the orphaned DB column behind, so existing rows have an empty `account`. Copy the value
+	over, first dropping rows that would duplicate an existing `(email, account)` pair — the
+	same de-duplication the controller enforces on save.
+
+	Idempotent: once the orphaned column is gone (or every row is backfilled) this is a no-op.
+	"""
+
+	if not frappe.db.has_column(DOCTYPE, "account_id"):
+		return
+
+	delete_duplicates()
+	backfill_account()
+
+
+def delete_duplicates() -> None:
+	"""Drop empty-`account` rows whose (email, account_id) is already covered by a sibling."""
+
+	s = frappe.qb.DocType(DOCTYPE).as_("s")
+	t = frappe.qb.DocType(DOCTYPE).as_("t")
+
+	# A sibling covers the row when it shares its (email, account_id) and outranks it: either a
+	# row already populated with that account, or an earlier still-empty row (smaller `name`
+	# wins, matching the original loop's "keep first").
+	populated_sibling = t.account.isnotnull() & (t.account != "") & (t.account == s.account_id)
+	earlier_empty_sibling = is_empty(t.account) & (t.account_id == s.account_id) & (t.name < s.name)
+
+	victims = (
+		frappe.qb.from_(s)
+		.join(t)
+		.on((t.email == s.email) & (t.name != s.name) & (populated_sibling | earlier_empty_sibling))
+		.where(is_empty(s.account))
+		.select(s.name)
+		.distinct()
+		.run(pluck="name")
+	)
+
+	if victims:
+		table = frappe.qb.DocType(DOCTYPE)
+		frappe.qb.from_(table).delete().where(table.name.isin(victims)).run()
+
+
+def backfill_account() -> None:
+	"""Set `account` = `account_id` on the surviving empty-`account` rows."""
+
+	table = frappe.qb.DocType(DOCTYPE)
+	(
+		frappe.qb.update(table)
+		.set(table.account, table.account_id)
+		.where(is_empty(table.account) & table.account_id.isnotnull() & (table.account_id != ""))
+		.run()
+	)
+
+
+def is_empty(field):
+	"""Match a column that is NULL or the empty string."""
+
+	return field.isnull() | (field == "")

--- a/suite/mail/patches/backfill_screened_email_address_account.py
+++ b/suite/mail/patches/backfill_screened_email_address_account.py
@@ -11,6 +11,11 @@ def execute() -> None:
 	over, first dropping rows that would duplicate an existing `(email, account)` pair — the
 	same de-duplication the controller enforces on save.
 
+	Only rows with a present `account_id` are touched: those without one have no value to
+	backfill from (`account` is `reqd`), so they're left untouched rather than mishandled as
+	de-dup candidates. `account_id` was `reqd` before the refactor, so such rows shouldn't
+	exist, but the guard keeps the de-dup and backfill sets identical.
+
 	Idempotent: once the orphaned column is gone (or every row is backfilled) this is a no-op.
 	"""
 
@@ -30,14 +35,14 @@ def delete_duplicates() -> None:
 	# A sibling covers the row when it shares its (email, account_id) and outranks it: either a
 	# row already populated with that account, or an earlier still-empty row (smaller `name`
 	# wins, matching the original loop's "keep first").
-	populated_sibling = t.account.isnotnull() & (t.account != "") & (t.account == s.account_id)
+	populated_sibling = is_present(t.account) & (t.account == s.account_id)
 	earlier_empty_sibling = is_empty(t.account) & (t.account_id == s.account_id) & (t.name < s.name)
 
 	victims = (
 		frappe.qb.from_(s)
 		.join(t)
 		.on((t.email == s.email) & (t.name != s.name) & (populated_sibling | earlier_empty_sibling))
-		.where(is_empty(s.account))
+		.where(is_empty(s.account) & is_present(s.account_id))
 		.select(s.name)
 		.distinct()
 		.run(pluck="name")
@@ -55,7 +60,7 @@ def backfill_account() -> None:
 	(
 		frappe.qb.update(table)
 		.set(table.account, table.account_id)
-		.where(is_empty(table.account) & table.account_id.isnotnull() & (table.account_id != ""))
+		.where(is_empty(table.account) & is_present(table.account_id))
 		.run()
 	)
 
@@ -64,3 +69,9 @@ def is_empty(field):
 	"""Match a column that is NULL or the empty string."""
 
 	return field.isnull() | (field == "")
+
+
+def is_present(field):
+	"""Match a column that is neither NULL nor the empty string."""
+
+	return field.isnotnull() & (field != "")

--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -51,5 +51,6 @@ suite.mail.patches.configure_inbound_outbound_log
 suite.mail.patches.configure_exchange_log
 suite.mail.patches.sync_jmap_accounts_for_configured_users
 suite.mail.patches.destroy_data_store
+suite.mail.patches.backfill_screened_email_address_account
 # --- calendar ---
 # (no patches)


### PR DESCRIPTION
## Problem

The `account_id` → `account` refactor dropped `account_id` from the **Screened Email Address** doctype, but Frappe leaves the orphaned DB column in place. Existing rows therefore have an empty `account` and need it backfilled from `account_id`.

## Patch

`suite/mail/patches/backfill_screened_email_address_account.py`, registered under the mail section of `patches.txt`. It replaces an ad-hoc per-row script with set-based query-builder statements:

1. **Guard** — no-op if the orphaned `account_id` column is already gone (idempotent / re-run safe).
2. **De-dup delete** — a self-joined lookup finds empty-`account` rows whose `(email, account_id)` is already covered by a sibling — either a row already populated with that account, or an earlier still-empty row (smaller `name` wins, matching the original "keep first" behaviour) — and bulk-deletes them. This mirrors the uniqueness the controller enforces on save. (Victim names are plucked into Python before the delete to avoid MySQL error 1093 on a same-table delete subquery.)
3. **Backfill** — bulk `UPDATE account = account_id` on the survivors (skipping empty `account_id`, since `account` is `reqd=1`).

Equivalent to the original loop but without the O(N) `exists`/`delete`/`set_value` round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)