### PR TITLE
feat(mail): domain as trusted/screened sender (#147)

### DIFF
--- a/frontend/src/apps/mail/components/MailActions.vue
+++ b/frontend/src/apps/mail/components/MailActions.vue
@@ -42,7 +42,12 @@ import {
 } from 'lucide-vue-next'
 import { Button, Dropdown, createResource, toast } from 'frappe-ui'
 
-import { downloadUrlAsFile, raisePromiseToast, raiseToast } from '@/apps/mail/utils'
+import {
+	downloadUrlAsFile,
+	matchesScreenedValue,
+	raisePromiseToast,
+	raiseToast,
+} from '@/apps/mail/utils'
 import { useBlockSender, useScreenSize, useUndo } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 
@@ -87,10 +92,11 @@ const { setUndoAction, undo } = useUndo()
 const { promptBlockSenders, willJunkSenders } = useBlockSender()
 const user = inject('$user')
 
-// A sender is "blocked" when screened with the Reject action (their mail is discarded).
+// A sender is "blocked" when screened with the Reject action (their mail is discarded) — either by their
+// exact address or by a '@domain' entry covering them.
 const isSenderBlocked = (email: string) =>
 	screenedAddresses.data?.some(
-		(a: ScreenedAddress) => a.email === email && a.action === 'Reject',
+		(a: ScreenedAddress) => a.action === 'Reject' && matchesScreenedValue(email, a.email),
 	)
 
 const primaryActions = (mail: Mail): MailAction[] => [

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -387,6 +387,7 @@ import {
 	getFormattedRecipients,
 	getGroupedRecipients,
 	hasHtmlContent,
+	matchesScreenedValue,
 	raiseToast,
 	shouldIgnoreKeypress,
 } from '@/apps/mail/utils'
@@ -449,10 +450,11 @@ const user = inject('$user')
 const store = userStore()
 const { mailboxes, mailboxIds, identities, screenedAddresses } = store
 
-// A sender is "blocked" when screened with the Reject action (their mail is discarded).
+// A sender is "blocked" when screened with the Reject action (their mail is discarded) — either by their
+// exact address or by an accepted/blocked '@domain' entry covering them.
 const isSenderBlocked = (email: string) =>
 	!!screenedAddresses.data?.some(
-		(a: ScreenedAddress) => a.email === email && a.action === 'Reject',
+		(a: ScreenedAddress) => a.action === 'Reject' && matchesScreenedValue(email, a.email),
 	)
 
 // Trusted senders — you, or anyone you've accepted — load images normally. For everyone else, the
@@ -465,7 +467,7 @@ const blockRemoteImagesEnabled = computed(
 const isScreenedIn = (email: string) =>
 	!!identities.data?.some((i: Identity) => i.email === email) ||
 	!!screenedAddresses.data?.some(
-		(a: ScreenedAddress) => a.email === email && a.action === 'Accepted',
+		(a: ScreenedAddress) => a.action === 'Accepted' && matchesScreenedValue(email, a.email),
 	)
 const shouldBlockImages = (mail: { from_email: string }) =>
 	blockRemoteImagesEnabled.value && !isScreenedIn(mail.from_email)

--- a/frontend/src/apps/mail/components/Settings/BlockListSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/BlockListSettings.vue
@@ -9,7 +9,7 @@
 				v-model="email"
 				type="text"
 				variant="outline"
-				:placeholder="__('Enter email address')"
+				:placeholder="__('Enter email or domain (e.g. @example.com)')"
 				class="flex-1"
 				@keydown.enter="screenEmailAddress.submit()"
 			/>
@@ -27,7 +27,7 @@
 				:label="__('Add')"
 				variant="solid"
 				:loading="screenEmailAddress.loading"
-				:disabled="!isEmail(email) || isAlreadyScreened"
+				:disabled="!isEmailOrDomain(email) || isAlreadyScreened"
 				@click="screenEmailAddress.submit()"
 			/>
 		</div>
@@ -74,7 +74,7 @@ import {
 	createResource,
 } from 'frappe-ui'
 
-import { isEmail, raiseToast } from '@/apps/mail/utils'
+import { isEmailOrDomain, raiseToast } from '@/apps/mail/utils'
 import { userStore } from '@/apps/mail/stores/user'
 
 import type { ScreenedAddress, ScreeningAction } from '@/apps/mail/types'
@@ -100,8 +100,17 @@ const ACTION_LABELS: Partial<Record<ScreeningAction, string>> = {
 	Spam: __('Move to Junk'),
 }
 
+// Mirror the backend's normalisation (trim; lowercase a '@domain' entry) so '@Frappe.io' is caught as
+// a duplicate of a stored '@frappe.io'.
+const normalizeScreenedValue = (value: string) => {
+	const trimmed = value.trim()
+	return trimmed.startsWith('@') ? '@' + trimmed.slice(1).toLowerCase() : trimmed
+}
+
 const isAlreadyScreened = computed(() =>
-	(screenedAddresses.data ?? []).some((a: ScreenedAddress) => a.email === email.value),
+	(screenedAddresses.data ?? []).some(
+		(a: ScreenedAddress) => a.email === normalizeScreenedValue(email.value),
+	),
 )
 
 const rows = computed(() =>
@@ -151,11 +160,11 @@ const removeModalOptions = computed(() => ({
 // `fr` units (numbers) so the columns share the row width instead of overflowing (percentages plus the
 // checkbox column would exceed 100% and add a horizontal scrollbar).
 const COLUMNS = [
-	{ label: __('Email Address'), key: 'email', width: 4 },
+	{ label: __('Email or Domain'), key: 'email', width: 4 },
 	{ label: __('Action'), key: 'action', width: 1 },
 ]
 
 const MESSAGE = __(
-	'Screen specific senders to either reject their messages or send them straight to Spam.',
+	'Screen specific senders — or a whole domain (e.g. @example.com) — to either reject their messages or send them straight to Spam.',
 )
 </script>

--- a/frontend/src/apps/mail/utils/composables.ts
+++ b/frontend/src/apps/mail/utils/composables.ts
@@ -1,7 +1,7 @@
 import { computed, onMounted, onUnmounted, reactive, ref } from 'vue'
 import { createResource } from 'frappe-ui'
 
-import { raisePromiseToast, raiseToast } from '@/apps/mail/utils'
+import { matchesScreenedValue, raisePromiseToast, raiseToast } from '@/apps/mail/utils'
 import { userStore } from '@/apps/mail/stores/user'
 
 import type { COLOR_SCHEME, Identity, ScreenedAddress } from '@/apps/mail/types'
@@ -129,16 +129,16 @@ export const useBlockSender = () => {
 	// and de-duplicate by email (keeping the first occurrence's display name).
 	const blockableSenders = (senders: { name?: string; email?: string }[]) => {
 		const own = new Set((identities.data ?? []).map((i: Identity) => i.email))
-		// "Already blocked" = screened with the Reject action (their mail is discarded).
-		const blocked = new Set<string>(
-			(screenedAddresses.data ?? [])
-				.filter((a: ScreenedAddress) => a.action === 'Reject')
-				.map((a: ScreenedAddress) => a.email),
-		)
+		// "Already blocked" = screened with the Reject action (their mail is discarded), whether by their
+		// exact address or by a '@domain' entry covering them.
+		const blockedValues = (screenedAddresses.data ?? [])
+			.filter((a: ScreenedAddress) => a.action === 'Reject')
+			.map((a: ScreenedAddress) => a.email)
+		const isBlocked = (email: string) => blockedValues.some((v) => matchesScreenedValue(email, v))
 		const seen = new Set<string>()
 		const result: BlockableSender[] = []
 		for (const { name, email } of senders) {
-			if (!email || own.has(email) || blocked.has(email) || seen.has(email)) continue
+			if (!email || own.has(email) || isBlocked(email) || seen.has(email)) continue
 			seen.add(email)
 			result.push({ name, email })
 		}

--- a/frontend/src/apps/mail/utils/index.ts
+++ b/frontend/src/apps/mail/utils/index.ts
@@ -243,6 +243,12 @@ export const convertHtmlToText = (html: string) => {
 
 export const isEmail = (s: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s)
 
+// A domain entry, prefixed with @ (e.g. @example.com). Used by screening to trust/block a whole domain.
+export const isDomain = (s: string) => /^@[^\s@]+\.[^\s@]+$/.test(s)
+
+// A screened value: either a full email address or a whole domain (@example.com).
+export const isEmailOrDomain = (s: string) => isEmail(s) || isDomain(s)
+
 // An externally-hosted reference (http/https or protocol-relative //). cid: (inline attachments) and
 // data: URIs are part of the message, so they're never remote.
 const REMOTE_URL = /^\s*(?:https?:)?\/\//i

--- a/frontend/src/apps/mail/utils/index.ts
+++ b/frontend/src/apps/mail/utils/index.ts
@@ -253,6 +253,21 @@ export const isDomain = (s: string) =>
 // A screened value: either a full email address or a whole domain (@example.com).
 export const isEmailOrDomain = (s: string) => isEmail(s) || isDomain(s)
 
+// Whether `email` is covered by the screened value `value` — either an exact address match, or a
+// '@domain' entry (@example.com) that matches every sender from that domain. Case-insensitive, mirroring
+// the backend's sieve matching so a sender from an accepted/blocked domain is treated consistently.
+export const matchesScreenedValue = (email: string, value: string) => {
+	const normalizedEmail = (email ?? '').trim().toLowerCase()
+	const normalizedValue = (value ?? '').trim().toLowerCase()
+	if (!normalizedEmail || !normalizedValue) return false
+
+	if (normalizedValue.startsWith('@')) {
+		return normalizedEmail.split('@').pop() === normalizedValue.slice(1)
+	}
+
+	return normalizedEmail === normalizedValue
+}
+
 // An externally-hosted reference (http/https or protocol-relative //). cid: (inline attachments) and
 // data: URIs are part of the message, so they're never remote.
 const REMOTE_URL = /^\s*(?:https?:)?\/\//i

--- a/frontend/src/apps/mail/utils/index.ts
+++ b/frontend/src/apps/mail/utils/index.ts
@@ -244,7 +244,11 @@ export const convertHtmlToText = (html: string) => {
 export const isEmail = (s: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s)
 
 // A domain entry, prefixed with @ (e.g. @example.com). Used by screening to trust/block a whole domain.
-export const isDomain = (s: string) => /^@[^\s@]+\.[^\s@]+$/.test(s)
+// Mirrors the backend's DOMAIN_NAME_PATTERN: 1-63 char labels of letters/digits/hyphens (no leading or
+// trailing hyphen), joined by dots, at most 253 chars overall — so the Add button never enables a value
+// the API would reject.
+export const isDomain = (s: string) =>
+	/^@(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(?:\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))+$/.test(s)
 
 // A screened value: either a full email address or a whole domain (@example.com).
 export const isEmailOrDomain = (s: string) => isEmail(s) || isDomain(s)

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -55,6 +55,7 @@ from suite.mail.jmap import (
 )
 from suite.mail.utils import convert_html_to_text, get_config, log_error
 from suite.mail.utils.user import get_account_emails, is_jmap_configured
+from suite.mail.utils.validation import normalize_screened_value, validate_screened_value
 
 AVATAR_CACHE_TTL = 60 * 60 * 24
 SCREENING_FETCH_LIMIT = 500
@@ -903,9 +904,15 @@ def _screen_email_addresses(
 	if action not in ("Spam", "Reject", "Accepted"):
 		frappe.throw(_("Invalid screening action: {0}").format(action))
 
+	# Normalise + validate here too: bulk_insert below bypasses the doctype's validate hook, and this
+	# is the choke point every screening flow (settings UI, mark-as-junk, auto-accept) funnels through.
+	emails = [normalize_screened_value(email) for email in emails]
 	emails = [email for email in dict.fromkeys(emails) if email]  # de-duplicate, drop empties
 	if not emails:
 		return
+
+	for email in emails:
+		validate_screened_value(email, raise_exception=True)
 
 	existing = {
 		row.email: row

--- a/suite/mail/doctype/screened_email_address/screened_email_address.json
+++ b/suite/mail/doctype/screened_email_address/screened_email_address.json
@@ -20,13 +20,12 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "The email address whose mail is blocked (discarded) for the account.",
+   "description": "The screened sender: either an email address (john@example.com) or a domain prefixed with @ (@example.com), which applies to every sender from that domain.",
    "fieldname": "email",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Email",
+   "label": "Email or Domain",
    "no_copy": 1,
-   "options": "Email",
    "reqd": 1,
    "search_index": 1,
    "set_only_once": 1

--- a/suite/mail/doctype/screened_email_address/screened_email_address.py
+++ b/suite/mail/doctype/screened_email_address/screened_email_address.py
@@ -32,7 +32,16 @@ class ScreenedEmailAddress(Document):
 		self.name = str(uuid7())
 
 	def validate(self) -> None:
+		self.validate_email()
 		self.validate_duplicate_email()
+
+	def validate_email(self) -> None:
+		"""Normalise and validate the screened value — a full email address or an '@domain' entry."""
+
+		from suite.mail.utils.validation import normalize_screened_value, validate_screened_value
+
+		self.email = normalize_screened_value(self.email)
+		validate_screened_value(self.email, raise_exception=True)
 
 	def on_update(self) -> None:
 		from suite.mail.doctype.sieve_script.sieve_script import maybe_build_automation_sieve

--- a/suite/mail/doctype/screened_email_address/test_screened_email_address.py
+++ b/suite/mail/doctype/screened_email_address/test_screened_email_address.py
@@ -17,4 +17,26 @@ class IntegrationTestScreenedEmailAddress(IntegrationTestCase):
 	Use this class for testing interactions between multiple components.
 	"""
 
-	pass
+	def test_normalize_screened_value(self):
+		from suite.mail.utils.validation import normalize_screened_value
+
+		# Trims whitespace and leaves a plain email address untouched.
+		self.assertEqual(normalize_screened_value("  john@example.com  "), "john@example.com")
+		# Lowercases the domain of a '@domain' entry so it collapses to a single rule.
+		self.assertEqual(normalize_screened_value("@Frappe.io"), "@frappe.io")
+		self.assertEqual(normalize_screened_value(" @Example.COM "), "@example.com")
+
+	def test_validate_screened_value(self):
+		from suite.mail.utils.validation import validate_screened_value
+
+		# Valid: full email addresses and '@domain' entries.
+		self.assertTrue(validate_screened_value("john@example.com"))
+		self.assertTrue(validate_screened_value("@example.com"))
+		self.assertTrue(validate_screened_value("@sub.example.co.uk"))
+
+		# Invalid: bare domains, bare '@', local parts, and blanks.
+		self.assertFalse(validate_screened_value("example.com"))
+		self.assertFalse(validate_screened_value("@"))
+		self.assertFalse(validate_screened_value("@example"))
+		self.assertFalse(validate_screened_value("john"))
+		self.assertFalse(validate_screened_value(""))

--- a/suite/mail/doctype/sieve_script/sieve_script.py
+++ b/suite/mail/doctype/sieve_script/sieve_script.py
@@ -695,11 +695,18 @@ def remove_sieve_block(script: str, block_name: str) -> str:
 	return result
 
 
+def _escape_sieve_string(value: str) -> str:
+	"""Escape a value for embedding in a Sieve quoted string (RFC 5228): backslash then double-quote."""
+
+	return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
 def _sender_match_condition(value: str) -> str | None:
 	"""Return the Sieve `address` test that matches a screened value, or None when it is blank.
 
 	A `@domain` entry matches every sender from that domain (`address :domain :is "from" "example.com"`);
-	anything else is matched as a full address (`address :is "from" "john@example.com"`).
+	anything else is matched as a full address (`address :is "from" "john@example.com"`). Values are
+	escaped before being embedded so a stray quote or backslash can't corrupt the generated script.
 	"""
 
 	from suite.mail.utils.validation import is_domain_entry
@@ -710,9 +717,9 @@ def _sender_match_condition(value: str) -> str | None:
 
 	if is_domain_entry(value):
 		domain = value[1:].strip()
-		return f'address :domain :is "from" "{domain}"' if domain else None
+		return f'address :domain :is "from" "{_escape_sieve_string(domain)}"' if domain else None
 
-	return f'address :is "from" "{value}"'
+	return f'address :is "from" "{_escape_sieve_string(value)}"'
 
 
 def _build_screening_block(block_name: str, emails: list[str], action_lines: list[str]) -> str:

--- a/suite/mail/doctype/sieve_script/sieve_script.py
+++ b/suite/mail/doctype/sieve_script/sieve_script.py
@@ -695,13 +695,33 @@ def remove_sieve_block(script: str, block_name: str) -> str:
 	return result
 
 
+def _sender_match_condition(value: str) -> str | None:
+	"""Return the Sieve `address` test that matches a screened value, or None when it is blank.
+
+	A `@domain` entry matches every sender from that domain (`address :domain :is "from" "example.com"`);
+	anything else is matched as a full address (`address :is "from" "john@example.com"`).
+	"""
+
+	from suite.mail.utils.validation import is_domain_entry
+
+	value = (value or "").strip()
+	if not value:
+		return None
+
+	if is_domain_entry(value):
+		domain = value[1:].strip()
+		return f'address :domain :is "from" "{domain}"' if domain else None
+
+	return f'address :is "from" "{value}"'
+
+
 def _build_screening_block(block_name: str, emails: list[str], action_lines: list[str]) -> str:
 	"""Build a labeled sieve block matching the given senders and running `action_lines`.
 
 	Returns an empty string when there are no senders to match.
 	"""
 
-	conditions = [f'address :is "from" "{e.strip()}"' for e in emails if e and e.strip()]
+	conditions = [c for c in (_sender_match_condition(e) for e in emails) if c]
 	if not conditions:
 		return ""
 
@@ -747,9 +767,16 @@ def build_screening_gate(account: str, accepted_emails: list[str]) -> str:
 
 	trusted = list(dict.fromkeys(e.strip() for e in [*accepted_emails, *own_emails] if e and e.strip()))
 
-	if trusted:
-		joined = ",\n  ".join(f'"{e}"' for e in trusted)
-		condition_block = f'if not address :is "from" [\n  {joined}\n] {{'
+	# `accepted_emails` may hold `@domain` entries, so build one address test per trusted value (own
+	# identity emails are always plain addresses). The gate lets mail through when the sender matches
+	# any trusted value, so the tests are OR-ed and the whole thing negated.
+	conditions = [c for c in (_sender_match_condition(e) for e in trusted) if c]
+
+	if len(conditions) == 1:
+		condition_block = f"if not {conditions[0]} {{"
+	elif conditions:
+		joined = ",\n  ".join(conditions)
+		condition_block = f"if not anyof (\n  {joined}\n) {{"
 	else:
 		# Nothing trusted yet → screen everything (only reached after the Reject/Spam blocks).
 		condition_block = 'if exists "from" {'

--- a/suite/mail/doctype/sieve_script/test_sieve_script.py
+++ b/suite/mail/doctype/sieve_script/test_sieve_script.py
@@ -17,4 +17,32 @@ class IntegrationTestSieveScript(IntegrationTestCase):
 	Use this class for testing interactions between multiple components.
 	"""
 
-	pass
+	def test_sender_match_condition(self):
+		from suite.mail.doctype.sieve_script.sieve_script import _sender_match_condition
+
+		# A plain email matches the full From address.
+		self.assertEqual(
+			_sender_match_condition("john@example.com"),
+			'address :is "from" "john@example.com"',
+		)
+		# A '@domain' entry matches every sender from that domain via the :domain address part.
+		self.assertEqual(
+			_sender_match_condition("@example.com"),
+			'address :domain :is "from" "example.com"',
+		)
+		# Blank / bare '@' values produce no condition.
+		self.assertIsNone(_sender_match_condition(""))
+		self.assertIsNone(_sender_match_condition("   "))
+		self.assertIsNone(_sender_match_condition("@"))
+
+	def test_build_screening_block_with_domain(self):
+		from suite.mail.doctype.sieve_script.sieve_script import _build_screening_block
+
+		# A mix of an address and a domain OR-es both address tests inside a single anyof block.
+		block = _build_screening_block(
+			"Rejected Emails", ["spammer@bad.com", "@bad-domain.io"], ["  discard;", "  stop;"]
+		)
+		self.assertIn('address :is "from" "spammer@bad.com"', block)
+		self.assertIn('address :domain :is "from" "bad-domain.io"', block)
+		self.assertIn("if anyof (", block)
+		self.assertIn("# Rejected Emails", block)

--- a/suite/mail/utils/validation.py
+++ b/suite/mail/utils/validation.py
@@ -4,10 +4,58 @@ import re
 import frappe
 from croniter import CroniterBadCronError, croniter
 from frappe import _
-from frappe.utils import cint
+from frappe.utils import cint, validate_email_address
 from frappe.utils.caching import request_cache
 
 from suite.mail.utils import get_config
+
+# A domain label is 1-63 chars of letters/digits/hyphens (no leading/trailing hyphen); a domain name is
+# two or more such labels joined by dots, at most 253 chars overall (e.g. "frappe.io").
+DOMAIN_NAME_PATTERN = re.compile(
+	r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))+$"
+)
+
+
+def is_domain_entry(value: str) -> bool:
+	"""Whether a screened value denotes a whole domain, i.e. is prefixed with '@' (e.g. '@frappe.io')."""
+
+	return (value or "").startswith("@")
+
+
+def normalize_screened_value(value: str) -> str:
+	"""Normalise a screened value: trim it, and lowercase the domain of a '@domain' entry so that
+	'@Frappe.io' and '@frappe.io' collapse to a single rule."""
+
+	value = (value or "").strip()
+	if is_domain_entry(value):
+		return "@" + value[1:].strip().lower()
+
+	return value
+
+
+def validate_screened_value(value: str, raise_exception: bool = False) -> bool:
+	"""Validate a Screened Email Address value.
+
+	A value is valid when it is either a full email address (e.g. "john@example.com") or a domain
+	prefixed with '@' (e.g. "@example.com"), which screens every sender from that domain.
+	"""
+
+	value = (value or "").strip()
+
+	if is_domain_entry(value):
+		is_valid = bool(DOMAIN_NAME_PATTERN.match(value[1:]))
+	else:
+		is_valid = bool(value) and bool(validate_email_address(value))
+
+	if not is_valid and raise_exception:
+		frappe.throw(
+			_(
+				"{0} is not a valid email address or domain. Enter an email address (e.g. john@example.com) "
+				"or a domain prefixed with @ (e.g. @example.com)."
+			).format(frappe.bold(value or "''"))
+		)
+
+	return is_valid
 
 
 def is_subaddressed_email(email: str, raise_exception: bool = False) -> bool:


### PR DESCRIPTION
## Summary

Closes #147.

The **Screened Email Address** list previously accepted only individual email addresses. This PR adds support for **domain-based entries** — a value like `@frappe.io` now applies the screening action (Accept / Block / Move to Junk) to **every** sender from that domain — and adds validation so a value must be either a valid email address or a valid `@domain`.

## Changes

**Backend**
- `utils/validation.py`: new `is_domain_entry`, `normalize_screened_value`, and `validate_screened_value` helpers. A value is valid when it is a full email address (`john@example.com`) or a domain prefixed with `@` (`@example.com`). `@domain` entries are lowercased on save so `@Frappe.io` and `@frappe.io` collapse to one rule.
- `screened_email_address.py`: validate + normalise in the doctype `validate` hook.
- `api/mail.py`: validate + normalise in `_screen_email_addresses` too — it's the choke point every screening flow funnels through, and `bulk_insert` bypasses the doctype hook.
- `screened_email_address.json`: dropped the field's `"Email"` option (which rejected `@domain`) and relabelled it **Email or Domain**.
- `sieve_script.py`: new `_sender_match_condition` helper generates `address :domain :is "from" "example.com"` for `@domain` entries (and the existing `address :is "from" "john@example.com"` for addresses). Applied across the Reject/Spam blocks and the screening gate (which OR-es the trusted tests and negates the whole thing). No new `require` — `address`/`:domain` are core Sieve.

**Frontend**
- `utils/index.ts`: new `isDomain` / `isEmailOrDomain` helpers.
- `BlockListSettings.vue`: the *Screened Senders* input now accepts `@domain`, with matching placeholder/column/help copy and case-insensitive duplicate detection.

## Testing
- Added unit tests for the validation helpers and the sieve condition/block builders (`test_screened_email_address.py`, `test_sieve_script.py`).
- Verified the domain regex and `frappe.utils.validate_email_address` behavior against the sample inputs locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)