### PR TITLE
fix(sheets): use green Suite mark in home topbar

### DIFF
--- a/frontend/src/apps/sheets/pages/Home.vue
+++ b/frontend/src/apps/sheets/pages/Home.vue
@@ -3,22 +3,13 @@
     <!-- Top bar -->
     <div class="home-topbar">
       <div class="home-brand">
-        <!-- Brand mark from claude.ai/design handoff (logo/preview.html).
-             Deep cyan #0E7490, rising line in #A5F0FA, white nodes. -->
-        <svg width="28" height="28" viewBox="0 0 256 256" fill="none" style="flex-shrink:0">
-          <rect width="256" height="256" rx="60" fill="#0E7490"/>
-          <rect x="0.5" y="0.5" width="255" height="255" rx="59.5" stroke="white" stroke-opacity="0.12"/>
-          <g stroke="white" stroke-opacity="0.18" stroke-width="2" stroke-linecap="round">
-            <line x1="85"  y1="32"  x2="85"  y2="224"/>
-            <line x1="171" y1="32"  x2="171" y2="224"/>
-            <line x1="32"  y1="85"  x2="224" y2="85"/>
-            <line x1="32"  y1="171" x2="224" y2="171"/>
-          </g>
-          <polyline points="48,180 96,148 136,164 184,80 216,108"
-                    fill="none" stroke="#A5F0FA" stroke-width="18"
-                    stroke-linecap="round" stroke-linejoin="round"/>
-          <circle cx="136" cy="164" r="11" fill="white"/>
-          <circle cx="184" cy="80"  r="11" fill="white"/>
+        <!-- Frappe Suite brand mark: green #278F5E rounded square, white
+             spreadsheet glyph. Matches the app-launcher and sheet-editor icons. -->
+        <svg width="28" height="28" viewBox="0 0 118 118" fill="none" style="flex-shrink:0">
+          <path d="M93.9278 0H23.1013C10.3428 0 0 10.3428 0 23.1013V93.9278C0 106.686 10.3428 117.029 23.1013 117.029H93.9278C106.686 117.029 117.029 106.686 117.029 93.9278V23.1013C117.029 10.3428 106.686 0 93.9278 0Z" fill="#278F5E"/>
+          <path d="M77.757 25.9364H23.5215V36.437H77.757C80.6447 36.437 83.0073 38.7996 83.0073 41.6873V75.3942C83.0073 78.2818 80.6447 80.6445 77.757 80.6445H39.2724C36.3847 80.6445 34.0221 78.2818 34.0221 75.3942V50.6653H23.5215V75.3942C23.5215 84.0572 30.6094 91.1451 39.2724 91.1451H77.757C86.42 91.1451 93.5079 84.0572 93.5079 75.3942V41.6873C93.5079 33.0243 86.42 25.9364 77.757 25.9364Z" fill="white"/>
+          <path d="M53.8678 59.6958H43.3672V70.0914H53.8678V59.6958Z" fill="white"/>
+          <path d="M73.6617 50.6653H63.1611V70.1439H73.6617V50.6653Z" fill="white"/>
         </svg>
         <span class="home-brand-name">Frappe Sheets</span>
       </div>


### PR DESCRIPTION
The Sheets home topbar still rendered the old cyan chart mark (#0E7490) while the app launcher, sheet-editor topbar, and splash already use the green (#278F5E) spreadsheet glyph. Swap the home brand mark to match so branding is consistent everywhere.