### PR TITLE
fix(mail): route screener mailbox URL to the screener view

### DIFF
--- a/frontend/src/apps/mail/router.ts
+++ b/frontend/src/apps/mail/router.ts
@@ -96,6 +96,13 @@ function installMailGuard(r: Router) {
 
 		// Validate mailbox param for mailbox routes.
 		if (to.name === 'mail-mailbox' || to.name === 'mail-mail') {
+			// The screener mailbox has its own dedicated view (Allow/Block UI). Redirect its
+			// plain mailbox URL to the screener route so direct navigation and reloads land on
+			// the screener view, matching the sidebar link (which already targets 'mail-screener').
+			const screenerId = userStore().mailboxIds.screener
+			if (screenerId && to.params.mailbox === screenerId)
+				return { name: 'mail-screener', params: { accountId } }
+
 			const mailboxExists =
 				mailboxes.data?.some((m: { id: string }) => m.id === to.params.mailbox) ||
 				['starred', 'search'].includes(to.params.mailbox as string)


### PR DESCRIPTION
## Problem

Opening the Screener via its direct URL (e.g. `/mail/account/mh/mailbox/<screenerId>`) — a direct visit, bookmark, or page reload — rendered it as a plain mailbox with **no Allow/Block buttons**. The buttons only appeared after navigating Inbox → Screener via the sidebar, and would then persist on reload.

## Root cause

The Screener is a real JMAP mailbox (with its own id), but its Allow/Block UI lives on a **dedicated route**, `mail-screener` → `ScreenerView.vue`. Only the sidebar translated the screener mailbox id into that route (`AppSidebar.vue`). Any other entry point matched the generic `mail-mailbox` route and rendered `MailboxView.vue` (a normal mailbox), which has no Allow/Block UI.

So going through the sidebar landed on `/account/mh/screener` (which reloads fine), while a direct URL to the screener mailbox id never reached `ScreenerView`.

## Fix

Redirect `mail-mailbox`/`mail-mail` navigations whose `:mailbox` param equals `mailboxIds.screener` to the `mail-screener` route, in the mail navigation guard. The guard runs after the mailbox list resolves, so the screener id is available on every entry path — not just via the sidebar. Shortcut routes are covered through guard re-entry.

## Testing

- Load `/mail/account/mh/mailbox/<screenerId>` directly (cold, no prior navigation) → redirects to `/mail/account/mh/screener` with the Allow/Block buttons visible.
- Reload on the screener → stays on the screener view.
- Regular mailboxes and the sidebar screener link are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)