### PR TITLE
fix(meet): switch back to stereo

### DIFF
--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -574,7 +574,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		const constraints: Record<string, unknown> = {};
 
 		const audioConstraints = {
-			channelCount: 1,
+			channelCount: { ideal: 2 },
 			echoCancellation: true,
 			noiseSuppression: true,
 			autoGainControl: true,

--- a/frontend/src/apps/meet/utils/media/encodings.ts
+++ b/frontend/src/apps/meet/utils/media/encodings.ts
@@ -52,9 +52,9 @@ export const videoCodecOptions: CodecOptions = {
 
 export const audioCodecOptions: CodecOptions = {
 	// ref: https://mediasoup.org/documentation/v3/mediasoup-client/api/#ProducerCodecOptions
-	opusStereo: 0, // disable stereo to save bandwidth, as most meetings are voice-only
+	opusStereo: 1,
 	opusDtx: 1, // enable DTX to save bandwidth during silence periods
 	opusFec: 1, // enable FEC to improve audio quality in case of packet loss
-	opusMaxAverageBitrate: 96000, // more headroom for fuller speech while staying efficient for mono voice
+	opusMaxAverageBitrate: 128000, // more headroom for stereo voice while staying efficient
 	opusMaxPlaybackRate: 48000, // allow fullband Opus instead of forcing 24 kHz wideband
 };


### PR DESCRIPTION
we switched to mono in https://github.com/frappe/meet/commit/1e4eb51340c67d397456bd5dae51c34359c4c5f7