### PR TITLE
fix(mail): repair JMAP push webhook for the (user, account) model

### DIFF
--- a/suite/mail/api/jmap.py
+++ b/suite/mail/api/jmap.py
@@ -100,7 +100,7 @@ def push_notification() -> dict:
 					else:
 						logger.warning("unhandled-state-change-entity", entity=entity)
 
-				return {"status": "processed"}
+			return {"status": "processed"}
 
 		else:
 			logger.warning("unknown-push-type")

--- a/suite/mail/jmap/__init__.py
+++ b/suite/mail/jmap/__init__.py
@@ -232,7 +232,7 @@ def get_push_subscription_service(
 	"""Returns an instance of PushSubscriptionService for handling push subscription-related operations for the specified user."""
 
 	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return PushSubscriptionService(user, connection)
+	return PushSubscriptionService(connection)
 
 
 def get_quota_service(

--- a/suite/mail/jmap/services/push_subscription.py
+++ b/suite/mail/jmap/services/push_subscription.py
@@ -11,13 +11,13 @@ class PushSubscriptionService(CoreService):
 
 	type: ClassVar[str] = "PushSubscription"
 
-	def __init__(self, user: str, connection: "JMAPConnection") -> None:
-		"""Initializes the PushSubscriptionService with the provided user and JMAP connection."""
+	def __init__(self, connection: "JMAPConnection") -> None:
+		"""Initializes the PushSubscriptionService with the provided JMAP connection."""
 
 		self.connection = connection
-		# PushSubscription is not account-scoped (requests omit accountId); use a per-user
-		# cache key so subscriptions for different users don't collide.
-		self.account = f"{user}:{self.primary_account_id}"
+		# PushSubscription is user-scoped, not account-scoped (requests omit accountId); key the
+		# cache by the connection's user so subscriptions for different users don't collide.
+		self.account = connection.user
 
 	def create(self, subscriptions: list[dict]) -> dict:
 		"""Public method to create push subscriptions, handling batching if the number of subscriptions exceeds the server's maximum allowed in a single 'set' call."""

--- a/suite/mail/patches/create_push_subscriptions.py
+++ b/suite/mail/patches/create_push_subscriptions.py
@@ -11,7 +11,7 @@ def execute() -> None:
 	if not frappe.utils.get_url().startswith("https://"):
 		return
 
-	for user in frappe.db.get_all("User Settings", {"username": ["!=", ""]}, pluck="name"):
+	for user in frappe.db.get_all("User Settings", {"username": ["!=", ""]}, pluck="user"):
 		try:
 			service = get_push_subscription_service(user, ignore_permissions=True)
 


### PR DESCRIPTION
## Problem

The account refactor (#138) moved from a composite `user:account_id` handle to an explicit `(user, account)` model, but a few push-subscription paths were left inconsistent, breaking the JMAP push notification flow (create subscription → verify → server sends StateChange notifications to the `jmap.push_notification` webhook).

Since this flow requires HTTPS, it can't be exercised locally — these are static fixes verified by inspection and an end-to-end trace of the webhook flow against the pre-refactor code.

## Fixes

- **`api/jmap.py` — StateChange dropped all but the first account.** The `return {"status": "processed"}` sat *inside* the `for account, changes` loop. Under the new model a single per-user push subscription receives one `StateChange` spanning multiple accounts, so the misplaced `return` silently dropped every account after the first (i.e. right after adding a second account, only one account's mail would sync). Dedented out of the loop so all changed accounts are processed.

- **`patches/create_push_subscriptions.py` — wrong `pluck` field.** `User Settings` is UUID-named (`self.name = str(uuid7())`), so `pluck="name"` yielded a UUID that was passed as `user` → `get_jmap_connection` fails the `User` existence check for every user. Changed to `pluck="user"` so the patch actually recreates subscriptions carrying the new `?user=` webhook URL.

- **`jmap/services/push_subscription.py` + `jmap/__init__.py` — drop the redundant `user` param.** `PushSubscriptionService` still built the old `f"{user}:{primary_account_id}"` composite as its cache key — the last remnant of the removed `user:account_id` syntax. `PushSubscription/*` requests omit `accountId`, so this value only keys the class-level shared cache. The connection already carries the user, so the param is removed and the cache is keyed by `connection.user`, keeping different users' subscriptions from colliding (and avoiding cross-user collisions now that accounts can be shared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)