### PR TITLE
fix(slides): blank thumbnails when re-opening a presentation

### DIFF
--- a/frontend/src/apps/slides/components/NavigationPanel.vue
+++ b/frontend/src/apps/slides/components/NavigationPanel.vue
@@ -47,7 +47,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, useTemplateRef, useAttrs, inject } from 'vue'
+import { ref, computed, watch, useTemplateRef, useAttrs, inject, onActivated, nextTick } from 'vue'
 
 import ThumbnailContainer from '@/apps/slides/components/ThumbnailContainer.vue'
 
@@ -173,10 +173,10 @@ const handleHoverChange = (e) => {
 	}
 }
 
-const scrollToVirtualItem = (index) => {
+const scrollToVirtualItem = (index, behavior = 'smooth') => {
 	rowVirtualizer.value.scrollToIndex(index, {
 		align: 'center',
-		behavior: 'smooth',
+		behavior,
 	})
 }
 
@@ -196,8 +196,8 @@ const scrollToSlide = (index) => {
 
 	const virtualItem = rowVirtualizer.value.getVirtualItems().find((v) => v.index === index)
 	if (!virtualItem) {
-		// item is not rendered by virtual list so scroll directly without checking visibility
-		return scrollToVirtualItem(index)
+		// jump instantly; a smooth scroll here can stall on re-measurement during a reload
+		return scrollToVirtualItem(index, 'auto')
 	}
 
 	const fullyVisible = isItemFullyVisible(scrollElement, virtualItem)
@@ -224,6 +224,17 @@ watch(
 		scrollToSlide(index)
 	},
 )
+
+// keep-alive detaches the panel and resets scrollTop, but the virtualizer keeps its cached
+// offset (no scroll event fires); dispatch one so it re-reads before repositioning
+onActivated(() => {
+	nextTick(() => {
+		const scrollElement = scrollableArea.value
+		if (!scrollElement || !isNavigationPanelOpen.value) return
+		scrollElement.dispatchEvent(new Event('scroll'))
+		rowVirtualizer.value.scrollToIndex(slideIndex.value, { align: 'start', behavior: 'auto' })
+	})
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
Reopening a presentation sometimes showed the navigation panel scrolled to the wrong spot with blank space at the top, because the panel is cached and its scroll position got out of sync. Now we reset the panel to the current slide whenever a presentation is reopened, and make the scroll jump instantly so it can't get stuck partway and land on the wrong slide.