### PR TITLE
fix: add owner/modified_by to Identity virtual doctype

### DIFF
--- a/suite/mail/doctype/identity/identity.py
+++ b/suite/mail/doctype/identity/identity.py
@@ -294,6 +294,8 @@ def format_identity(account: str, identity: dict) -> dict:
 		"html_signature": identity["htmlSignature"],
 		"text_signature": identity["textSignature"],
 		"may_delete": cint(identity["mayDelete"]),
+		"owner": frappe.session.user,
+		"modified_by": frappe.session.user,
 		"creation": today(),
 		"modified": today(),
 	}


### PR DESCRIPTION
## Problem

Saving an `Identity` (e.g. via `frappe.client.set_value`) raised:

```
AttributeError: 'Identity' object has no attribute 'owner'
  File "frappe/model/base_document.py", line 1229, in _validate_data_fields
    if (self.owner in frappe.STANDARD_USERS) and (data in frappe.STANDARD_USERS):
```

## Root cause

`Identity` is a **virtual DocType** (`is_virtual: 1`), so it has none of the standard fields (`owner`, `modified_by`, …) unless the controller supplies them. Virtual docs are populated in `load_from_db` from the dict returned by `format_identity()`.

The `email` field has `options: "Email"`, so `doc.save()` → `_validate()` → `_validate_data_fields()` runs the email-validation branch, which reads `self.owner`. `format_identity()` provided `creation`/`modified` but not `owner`, so the access raised `AttributeError`.

## Fix

Populate `owner` and `modified_by` in `format_identity()` alongside the existing `creation`/`modified` fields, so the loaded document has these standard fields available during validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)