### PR TITLE
fix(slides): data loss and other editing bugs

### DIFF
--- a/frontend/src/apps/slides/components/EditorNavbar.vue
+++ b/frontend/src/apps/slides/components/EditorNavbar.vue
@@ -14,6 +14,10 @@
 				<LucideWifiOff class="mr-1 size-3.5 stroke-[1.5]" />
 				<span>Offline</span>
 			</Badge>
+			<Badge v-if="saveFailed && isOnline" variant="subtle" theme="orange" size="md">
+				<LucideCloudOff class="mr-1 size-3.5 stroke-[1.5]" />
+				<span>Save failed. Keep this tab open.</span>
+			</Badge>
 			<SharePopover v-if="presentationDoc" />
 		</template>
 	</Navbar>
@@ -30,6 +34,7 @@ import PresentationHeader from '@/apps/slides/components/PresentationHeader.vue'
 import SharePopover from '@/apps/slides/components/SharePopover.vue'
 
 import { presentationDoc } from '@/apps/slides/stores/presentation'
+import { saveFailed } from '@/apps/slides/stores/saving'
 import { useRoute } from 'vue-router'
 
 const isOnline = inject('isOnline', ref(false))

--- a/frontend/src/apps/slides/stores/copyPaste.js
+++ b/frontend/src/apps/slides/stores/copyPaste.js
@@ -136,10 +136,8 @@ const handlePastedSlideJSON = async (json) => {
 		}
 	}
 
-	// Reassign identity so pasting the same clipboard more than once never
-	// yields slides that share a clientId (root cause of the wrong-slide
-	// symptoms). Element ids are the within-slide handle, so regenerate them
-	// too; refId (cross-slide transition key) is intentionally left as-is.
+	// Give each paste a fresh identity so repeated pastes don't share ids.
+	// refId (cross-slide transition key) is intentionally kept.
 	slideJSON.clientId = uuid4()
 	slideJSON.elements = (slideJSON.elements || []).map((el) => ({
 		...el,

--- a/frontend/src/apps/slides/stores/copyPaste.js
+++ b/frontend/src/apps/slides/stores/copyPaste.js
@@ -14,7 +14,8 @@ import {
 
 import { useTextEditor } from '@/apps/slides/composables/useTextEditor'
 
-import { getDocFromHTML } from '@/apps/slides/utils/helpers'
+import { getDocFromHTML, generateUniqueId } from '@/apps/slides/utils/helpers'
+import { v4 as uuid4 } from 'uuid'
 import { handleUploadedMedia } from '@/apps/slides/utils/mediaUploads'
 
 const { activeEditor } = useTextEditor()
@@ -134,6 +135,16 @@ const handlePastedSlideJSON = async (json) => {
 			slideJSON.elements = JSON.parse(slideJSON.elements)
 		}
 	}
+
+	// Reassign identity so pasting the same clipboard more than once never
+	// yields slides that share a clientId (root cause of the wrong-slide
+	// symptoms). Element ids are the within-slide handle, so regenerate them
+	// too; refId (cross-slide transition key) is intentionally left as-is.
+	slideJSON.clientId = uuid4()
+	slideJSON.elements = (slideJSON.elements || []).map((el) => ({
+		...el,
+		id: generateUniqueId(),
+	}))
 
 	insertSlide(slideJSON, index)
 }

--- a/frontend/src/apps/slides/stores/presentation.js
+++ b/frontend/src/apps/slides/stores/presentation.js
@@ -3,7 +3,7 @@ import { createResource, call, createDocumentResource } from 'frappe-ui'
 
 import { router } from '@/apps/slides/router'
 import { slides } from './slide'
-import { markClean, markDirty } from './saving'
+import { markClean, markDirty, getPresentationFromLocalDB } from './saving'
 import { normalizeZIndices } from '@/apps/slides/stores/element'
 import { v4 as uuid4 } from 'uuid'
 import { commandHistory } from './historyMeta'
@@ -188,8 +188,18 @@ const getPresentationResource = (name) => {
 			for (const slide of doc.slides || []) {
 				slide.elements = await transformElements(slide.elements)
 			}
-			slides.value = JSON.parse(JSON.stringify(doc.slides || []))
 			isPublicPresentation.value = Boolean(doc.is_public)
+
+			// restore unsynced local edits, but only if the server hasn't moved past them
+			const local = await getPresentationFromLocalDB(name)
+			if (local?.dirty && local.baseModified === doc.modified) {
+				slides.value = JSON.parse(JSON.stringify(local.content))
+				slidesLength.value = slides.value.length
+				markDirty()
+				return
+			}
+
+			slides.value = JSON.parse(JSON.stringify(doc.slides || []))
 			markClean()
 			// persist the repair
 			if (clientIdsRepaired) markDirty()

--- a/frontend/src/apps/slides/stores/presentation.js
+++ b/frontend/src/apps/slides/stores/presentation.js
@@ -3,7 +3,7 @@ import { createResource, call, createDocumentResource } from 'frappe-ui'
 
 import { router } from '@/apps/slides/router'
 import { slides } from './slide'
-import { markClean } from './saving'
+import { markClean, markDirty } from './saving'
 import { normalizeZIndices } from '@/apps/slides/stores/element'
 import { v4 as uuid4 } from 'uuid'
 import { commandHistory } from './historyMeta'
@@ -147,9 +147,24 @@ const parseElements = (value) => {
 	return normalizeZIndices(parsed)
 }
 
+// Rescue decks saved with duplicate client_ids. Returns true if anything changed.
+const ensureUniqueClientIds = (slides) => {
+	const seen = new Set()
+	let repaired = false
+	for (const slide of slides) {
+		if (seen.has(slide.clientId)) {
+			slide.clientId = uuid4()
+			repaired = true
+		}
+		seen.add(slide.clientId)
+	}
+	return repaired
+}
+
 const slidesLength = ref(0)
 
 const getPresentationResource = (name) => {
+	let clientIdsRepaired = false
 	return createDocumentResource({
 		doctype: 'Presentation',
 		name: name,
@@ -166,6 +181,7 @@ const getPresentationResource = (name) => {
 				delete slide.fade_unmatched_elements
 				delete slide.client_id
 			}
+			clientIdsRepaired = ensureUniqueClientIds(doc.slides || [])
 		},
 		async onSuccess(doc) {
 			slidesLength.value = doc.slides?.length || 0
@@ -175,6 +191,8 @@ const getPresentationResource = (name) => {
 			slides.value = JSON.parse(JSON.stringify(doc.slides || []))
 			isPublicPresentation.value = Boolean(doc.is_public)
 			markClean()
+			// persist the repair
+			if (clientIdsRepaired) markDirty()
 		},
 	})
 }
@@ -199,6 +217,7 @@ const getPublicPresentationResource = (name) => {
 				delete slide.fade_unmatched_elements
 				delete slide.client_id
 			}
+			ensureUniqueClientIds(doc.slides || [])
 		},
 		onSuccess(doc) {
 			slidesLength.value = doc.slides?.length || 0
@@ -229,6 +248,7 @@ const getCompositePresentationResource = (name) => {
 				delete slide.fade_unmatched_elements
 				delete slide.client_id
 			}
+			ensureUniqueClientIds(doc.slides || [])
 		},
 		onSuccess(doc) {
 			slidesLength.value = doc.slides?.length || 0

--- a/frontend/src/apps/slides/stores/presentation.js
+++ b/frontend/src/apps/slides/stores/presentation.js
@@ -193,7 +193,10 @@ const getPresentationResource = (name) => {
 			// restore unsynced local edits, but only if the server hasn't moved past them
 			const local = await getPresentationFromLocalDB(name)
 			if (local?.dirty && local.baseModified === doc.modified) {
-				slides.value = JSON.parse(JSON.stringify(local.content))
+				const restored = JSON.parse(JSON.stringify(local.content))
+				// local content skips the transform's repair, so dedup it here too
+				ensureUniqueClientIds(restored)
+				slides.value = restored
 				slidesLength.value = slides.value.length
 				markDirty()
 				return

--- a/frontend/src/apps/slides/stores/saving.js
+++ b/frontend/src/apps/slides/stores/saving.js
@@ -1,5 +1,5 @@
 import { ref } from 'vue'
-import { presentationId, savePresentationDoc } from '@/apps/slides/stores/presentation'
+import { presentationId, savePresentationDoc, presentationDoc } from '@/apps/slides/stores/presentation'
 import { slides } from '@/apps/slides/stores/slide'
 import { cloneObj } from '@/apps/slides/utils/helpers'
 
@@ -100,11 +100,12 @@ const saveFailed = ref(false)
 const syncSnapshotToServer = async (snapshot) => {
 	await savePresentationDoc(snapshot.content)
 
-	// after successful sync, make sure local copy is marked as clean so it's not synced again
+	// mark local copy clean; baseModified tracks the server version we're now in sync with
 	await savePresentationToLocalDB({
 		...snapshot,
 		dirty: false,
 		updatedAt: Date.now(),
+		baseModified: presentationDoc.value?.modified,
 	})
 }
 
@@ -130,12 +131,13 @@ const saveCurrentState = async () => {
 	try {
 		const content = getLatestSlideContent()
 
-		// save latest content to indexedDB with dirty flag since it's not yet synced to server
+		// save to indexedDB as dirty (not yet synced); baseModified = server version these build on
 		await savePresentationToLocalDB({
 			id: presentationId.value,
 			content: content,
 			updatedAt: Date.now(),
 			dirty: true,
+			baseModified: presentationDoc.value?.modified,
 		})
 
 		// if offline, stay dirty so we retry once back online
@@ -159,4 +161,13 @@ const saveChanges = async () => {
 	await saveCurrentState()
 }
 
-export { saveCurrentState, saveChanges, isSaving, dirty, markDirty, markClean, saveFailed }
+export {
+	saveCurrentState,
+	saveChanges,
+	isSaving,
+	dirty,
+	markDirty,
+	markClean,
+	saveFailed,
+	getPresentationFromLocalDB,
+}

--- a/frontend/src/apps/slides/stores/saving.js
+++ b/frontend/src/apps/slides/stores/saving.js
@@ -94,6 +94,9 @@ const markClean = () => {
 
 const isSaving = ref(false)
 
+// true when an online save to the server failed; drives the "Not saved" indicator
+const saveFailed = ref(false)
+
 const syncSnapshotToServer = async (snapshot) => {
 	await savePresentationDoc(snapshot.content)
 
@@ -106,15 +109,11 @@ const syncSnapshotToServer = async (snapshot) => {
 }
 
 const syncPresentationToServer = async () => {
-	try {
-		const snapshot = await getPresentationFromLocalDB(presentationId.value)
-		if (!snapshot || !snapshot.dirty) return
+	const snapshot = await getPresentationFromLocalDB(presentationId.value)
+	if (!snapshot || !snapshot.dirty) return
 
-		// if there's an unsynced snapshot locally, sync it to server
-		await syncSnapshotToServer(snapshot)
-	} catch (err) {
-		console.error('Sync to server failed: ', err)
-	}
+	// throws on failure so the caller keeps the state dirty and retries
+	await syncSnapshotToServer(snapshot)
 }
 
 const getLatestSlideContent = () => {
@@ -139,15 +138,17 @@ const saveCurrentState = async () => {
 			dirty: true,
 		})
 
-		// changes are persisted locally (and queued for sync), so the editor
-		// state is no longer ahead of storage
-		markClean()
-
-		// if offline, do not attempt to sync to server
+		// if offline, stay dirty so we retry once back online
 		if (!navigator.onLine) return
 
-		// if online, sync to server
+		// only mark clean once the server actually has the changes
 		await syncPresentationToServer()
+		markClean()
+		saveFailed.value = false
+	} catch (err) {
+		// keep dirty so autosave retries and beforeunload warns; log once per outage
+		if (!saveFailed.value) console.error('Save failed: ', err)
+		saveFailed.value = true
 	} finally {
 		isSaving.value = false
 	}
@@ -158,4 +159,4 @@ const saveChanges = async () => {
 	await saveCurrentState()
 }
 
-export { saveCurrentState, saveChanges, isSaving, dirty, markDirty, markClean }
+export { saveCurrentState, saveChanges, isSaving, dirty, markDirty, markClean, saveFailed }

--- a/frontend/src/apps/slides/stores/slide.js
+++ b/frontend/src/apps/slides/stores/slide.js
@@ -69,9 +69,7 @@ const getNewSlide = (toDuplicate = false, layoutObject) => {
 	} else {
 		layout = layoutObject || null
 		layout.elements =
-			typeof layout?.elements === 'string'
-				? JSON.parse(layout.elements)
-				: layout?.elements || []
+			typeof layout?.elements === 'string' ? JSON.parse(layout.elements) : layout?.elements || []
 	}
 
 	let slide = {}
@@ -137,7 +135,7 @@ const saveSlide = (e) => {
 
 const deleteSlide = (deleteActive) => {
 	let deleteIndex = focusedSlide.value
-	if (!deleteIndex && deleteActive) deleteIndex = slideIndex.value
+	if (deleteIndex == null && deleteActive) deleteIndex = slideIndex.value
 	if (deleteIndex == null) return
 
 	// if there is only one slide, reset the slide state instead of deleting
@@ -167,7 +165,7 @@ const changeEditorSlide = async (index, focus = true) => {
 }
 
 const insertDuplicateSlide = async (index, layoutObj, toDuplicate) => {
-	if (toDuplicate || !index) index = slideIndex.value
+	if (toDuplicate || index == null) index = slideIndex.value
 
 	const newSlide = getNewSlide(toDuplicate, layoutObj)
 

--- a/frontend/src/apps/slides/stores/slide.js
+++ b/frontend/src/apps/slides/stores/slide.js
@@ -9,14 +9,14 @@ import {
 	transformElements,
 } from '@/apps/slides/stores/presentation'
 import { resetFocus } from '@/apps/slides/stores/element'
-import { saveChanges, dirty, markDirty, saveFailed } from '@/apps/slides/stores/saving'
+import { saveChanges, dirty, saveFailed } from '@/apps/slides/stores/saving'
 import { commandHistory } from '@/apps/slides/stores/historyMeta'
 import { generateUniqueId, cloneObj } from '@/apps/slides/utils/helpers'
 import { router } from '@/apps/slides/router'
 
 import { toast } from 'frappe-ui'
 import { inSlideShowMode } from './slideshow'
-import { addSlideCommand, removeSlideCommand } from './commands'
+import { addSlideCommand, removeSlideCommand, editSlideCommand } from './commands'
 
 const slides = ref([])
 
@@ -142,9 +142,17 @@ const deleteSlide = (deleteActive) => {
 	const totalLength = slides.value.length
 
 	if (totalLength == 1) {
-		slides.value[0].elements = []
+		// clearing the only slide's contents must go through history so it stays undoable
+		const slide = slides.value[0]
+		commandHistory.execute(
+			editSlideCommand({
+				slideId: slide.clientId,
+				property: 'elements',
+				oldValue: cloneObj(slide.elements),
+				newValue: [],
+			}),
+		)
 		focusedSlide.value = null
-		markDirty()
 		return
 	}
 
@@ -187,26 +195,9 @@ const addEmptySlide = (e, index) => {
 	if (layout) handleInsertSlide(index, cloneObj(layout))
 }
 
-const replaceSlide = (layoutObj) => {
-	const index = slideIndex.value
-	const newSlide = getNewSlide(false, layoutObj)
-
-	slides.value.splice(index, 1, newSlide)
-	slides.value.forEach((slide, index) => {
-		slide.idx = index + 1
-	})
-
-	markDirty()
-}
-
 const handleInsertSlide = (index, layoutObj) => {
-	// TODO: change this to use replace
-	let replace = false
-	if (replace) {
-		replaceSlide(layoutObj)
-	} else {
-		insertDuplicateSlide(index, layoutObj)
-	}
+	// TODO: support replacing the current slide (must route through command history)
+	insertDuplicateSlide(index, layoutObj)
 }
 
 export {

--- a/frontend/src/apps/slides/stores/slide.js
+++ b/frontend/src/apps/slides/stores/slide.js
@@ -9,7 +9,7 @@ import {
 	transformElements,
 } from '@/apps/slides/stores/presentation'
 import { resetFocus } from '@/apps/slides/stores/element'
-import { saveChanges, dirty, markDirty } from '@/apps/slides/stores/saving'
+import { saveChanges, dirty, markDirty, saveFailed } from '@/apps/slides/stores/saving'
 import { commandHistory } from '@/apps/slides/stores/historyMeta'
 import { generateUniqueId, cloneObj } from '@/apps/slides/utils/helpers'
 import { router } from '@/apps/slides/router'
@@ -122,7 +122,12 @@ const resetAndSave = async () => {
 		success: () => `Saved`,
 		error: () => 'Could not save presentation. Please try again.',
 	}
-	toast.promise(saveChanges(), toastProps)
+	toast.promise(
+		saveChanges().then(() => {
+			if (saveFailed.value) throw new Error('Save failed')
+		}),
+		toastProps,
+	)
 }
 
 const saveSlide = (e) => {


### PR DESCRIPTION
Fixes several saving and slide-editing bugs.

- Edits, deletes, and undo hitting the wrong slide. New slides already got fresh ids, but the paste path reused the copied slide's id, so pasting twice made two slides share one. Fixed the paste path and added repair logic for any already-saved presentations on load.
- Failed saves were silently lost. The presentation now stays unsaved and retries, and shows a "Save failed" message.
- Offline edits vanished on re-open. They are now restored, without overwriting newer changes.
- Clearing the last slide couldn't be undone because of missing command. Added command for that.