### PR TITLE
feat(sheets): add checkbox cells

### DIFF
--- a/frontend/src/apps/sheets/canvas/checkbox-geometry.js
+++ b/frontend/src/apps/sheets/canvas/checkbox-geometry.js
@@ -1,0 +1,21 @@
+// Geometry for data-validation checkbox cells. Shared by the cell painter
+// (which draws the box) and the grid hit-test (which decides whether a click
+// toggled it) so the clickable box always lines up with what's painted.
+
+export const CHECKBOX = {
+  maxSize: 16,  // the box never grows larger than this
+  minSize: 8,   // below this the row is too short to draw a box
+  margin:  6,   // keeps the box off the cell's top/bottom edge
+}
+
+// Box placement inside a cell of `cellW` × `cellH`, offsets from the cell's
+// top-left corner. Always centred, regardless of the cell's text alignment
+// (matches Sheets). Returns { x, y, size }.
+export function checkboxRect(cellW, cellH) {
+  const size = Math.min(CHECKBOX.maxSize, cellH - CHECKBOX.margin, cellW - CHECKBOX.margin)
+  return {
+    x: (cellW - size) / 2,
+    y: (cellH - size) / 2,
+    size,
+  }
+}

--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -6,10 +6,11 @@ import { cellId, colLabel, parseCellId } from '../utils/cells.js'
 import { AC_FUNS, AC_FUN_KEYS, parseAcToken } from '../utils/formula-ac.js'
 import { isWrapText } from '../utils/text-wrap.js'
 import { CHIP, chipMetrics } from './chip-geometry.js'
+import { checkboxRect } from './checkbox-geometry.js'
 
 export { colLabel, cellId, parseCellId } from '../utils/cells.js'
 
-export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getFormat, onFill, onBatchCommit, getMergeInfo, isSlave, getMasterId, getComment, getValidation, getCondFormat, getRightInset, onHyperlinkClick, onDropdownClick, onPivotDrill, onResizeEnd, getSheetNames, getCurrentSheet, getEditingHomeSheet, getDisplay, getCellIds, lazyValues = false } = {}) {
+export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getFormat, onFill, onBatchCommit, getMergeInfo, isSlave, getMasterId, getComment, getValidation, getCondFormat, getRightInset, onHyperlinkClick, onDropdownClick, onCheckboxToggle, onPivotDrill, onResizeEnd, getSheetNames, getCurrentSheet, getEditingHomeSheet, getDisplay, getCellIds, lazyValues = false } = {}) {
   const ctx = canvas.getContext('2d')
   const dpr = window.devicePixelRatio || 1
 
@@ -1031,11 +1032,28 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
       return
     }
 
+    const vrule = getValidation?.(hId)
+
+    // Click on the tickbox of a checkbox-validated cell → toggle it. Clicking
+    // elsewhere in the cell falls through to a normal selection.
+    if (vrule?.type === 'checkbox') {
+      const x = geo.colX(h.c), y = geo.rowY(h.r)
+      const w = geo.cw(h.c), hh = geo.rh(h.r)
+      const box = checkboxRect(w, hh)
+      const lx = (e.clientX - rect.left) / _zoom - x
+      const ly = (e.clientY - rect.top)  / _zoom - y
+      if (lx >= box.x && lx <= box.x + box.size && ly >= box.y && ly <= box.y + box.size) {
+        e.stopPropagation()
+        moveSel(h.r, h.c)
+        onCheckboxToggle?.(hId)
+        return
+      }
+    }
+
     // Click on the dropdown caret of a list-validated cell → open dropdown.
     // The caret zone tracks the chip when one is drawn (list rule + value),
     // else it's the plain arrow box at the cell's right edge. Only list rules
     // get a dropdown — number/length rules fall through to normal selection.
-    const vrule = getValidation?.(hId)
     if (vrule?.type === 'list') {
       const x = geo.colX(h.c), y = geo.rowY(h.r)
       const w = geo.cw(h.c), cellRight = x + w

--- a/frontend/src/apps/sheets/canvas/painters/cell-painter.js
+++ b/frontend/src/apps/sheets/canvas/painters/cell-painter.js
@@ -2,6 +2,7 @@ import { COLORS, TOTAL_COLS } from '../constants.js'
 import { cellId } from '../../utils/cells.js'
 import { getTextWrap, isWrapText } from '../../utils/text-wrap.js'
 import { CHIP, chipFont, chipColor, chipMetrics } from '../chip-geometry.js'
+import { checkboxRect, CHECKBOX } from '../checkbox-geometry.js'
 import { checkRule } from '../../engine/validation.js'
 
 export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
@@ -86,6 +87,12 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
         // it's a plain caret so you know it's a dropdown.
         if (has) _drawValidationChip(x, y, w, h, String(val), fmt, !invalid)
         else     _drawDropdownArrow(x, y, w, h)
+      } else if (rule.type === 'checkbox') {
+        // Checkbox rule → a tickbox that owns the cell (the text pass skips
+        // it). Empty reads as unchecked; a value that isn't TRUE/FALSE still
+        // gets the invalid marker below.
+        _drawCheckbox(x, y, w, h, String(val).toUpperCase() === 'TRUE')
+        if (invalid) _drawInvalidTriangle(x, y)
       } else if (invalid) {
         // Number / text-length rules have no dropdown (matching Sheets) — they
         // only surface a marker when the current value breaks the rule.
@@ -103,9 +110,10 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
     if (!g) return
     const { id, val, fmt, condFmt, x, y, w, h } = g
     if (val == null || val === '') return
-    // List-validation cells render their value inside the chip drawn in the
-    // bg pass — don't paint it a second time on top.
-    if (getValidation?.(id)?.type === 'list') return
+    // List / checkbox cells render their value as a chip or tickbox in the bg
+    // pass — don't paint the raw text a second time on top.
+    const vtype = getValidation?.(id)?.type
+    if (vtype === 'list' || vtype === 'checkbox') return
     const s = String(val)
     const baseFmt = condFmt ? { ...fmt, ...condFmt } : fmt
     const efmt = { ...baseFmt, align: baseFmt.align || _autoAlign(s) }
@@ -313,6 +321,38 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
     ctx.lineTo(mx, my + 2.5)
     ctx.closePath()
     ctx.fill()
+    ctx.restore()
+  }
+
+  // Sheets-style checkbox: a rounded grey square centred in the cell. Checked
+  // is filled with a white tick; unchecked is a hollow outline. Geometry comes
+  // from checkbox-geometry so the painted box matches the click zone in
+  // canvas/index.js exactly.
+  function _drawCheckbox(x, y, w, h, checked) {
+    const { x: ox, y: oy, size } = checkboxRect(w, h)
+    if (size < CHECKBOX.minSize) return   // row too short for a legible box
+    const bx = x + ox, by = y + oy
+    const grey = '#6b7280'
+    ctx.save()
+    _roundRectPath(bx, by, size, size, 3)
+    if (checked) {
+      ctx.fillStyle = grey
+      ctx.fill()
+      // Tick — three-point polyline scaled to the box.
+      ctx.strokeStyle = '#ffffff'
+      ctx.lineWidth = Math.max(1.5, size / 8)
+      ctx.lineJoin = 'round'
+      ctx.lineCap = 'round'
+      ctx.beginPath()
+      ctx.moveTo(bx + size * 0.26, by + size * 0.52)
+      ctx.lineTo(bx + size * 0.44, by + size * 0.70)
+      ctx.lineTo(bx + size * 0.74, by + size * 0.32)
+      ctx.stroke()
+    } else {
+      ctx.strokeStyle = grey
+      ctx.lineWidth = 1.5
+      ctx.stroke()
+    }
     ctx.restore()
   }
 

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -845,6 +845,7 @@
           <!-- Type -->
           <FormControl type="select" label="Type" v-model="validationDialog.type"
             :options="[
+              { label: 'Checkbox',       value: 'checkbox' },
               { label: 'List of items',  value: 'list' },
               { label: 'Number',         value: 'number' },
               { label: 'Text length',    value: 'text_length' },
@@ -859,7 +860,7 @@
           />
 
           <!-- Operator (number / text_length) -->
-          <FormControl v-if="validationDialog.type !== 'list'"
+          <FormControl v-if="['number','text_length'].includes(validationDialog.type)"
             type="select" label="Condition" v-model="validationDialog.operator"
             :options="[
               { label: 'Between',             value: 'between' },
@@ -874,7 +875,7 @@
           />
 
           <!-- Values -->
-          <div v-if="validationDialog.type !== 'list'" class="sn-vd-vals">
+          <div v-if="['number','text_length'].includes(validationDialog.type)" class="sn-vd-vals">
             <FormControl
               v-model="validationDialog.val1"
               type="number"
@@ -2988,6 +2989,7 @@ function _setupGridInstance() {
     },
     onHyperlinkClick(url) { window.open(url, '_blank', 'noopener,noreferrer') },
     onDropdownClick(id, rule, pos) { openDropdown(id, rule, pos) },
+    onCheckboxToggle(id) { toggleCheckbox(id) },
     onPivotDrill(r, c) { return drillDownAt(r, c) },
     getSheetNames() { return sheetNames.value },
     // Cross-sheet picker — grid prefixes inserted refs with the current sheet
@@ -3913,7 +3915,9 @@ function confirmValidation() {
   const sn  = sheet.getCurrentSheet()
   const msg = validationDialog.message.trim() || undefined
   let rule
-  if (validationDialog.type === 'list') {
+  if (validationDialog.type === 'checkbox') {
+    rule = { type: 'checkbox', message: msg }
+  } else if (validationDialog.type === 'list') {
     const options = validationDialog.listRaw.split(',').map(s => s.trim()).filter(Boolean)
     rule = { type: 'list', options, message: msg }
   } else {
@@ -3925,9 +3929,29 @@ function confirmValidation() {
     rule = { type: validationDialog.type, operator: op, min, max, message: msg }
   }
   for (const id of ids) validation.set(id, rule, sn)
+
+  // Checkbox cells need a concrete value to render as unchecked and to feed
+  // formulas (SUM / COUNTIF) right away — fill blanks with FALSE, à la Sheets.
+  // The rule + these values ride in the single history.push() snapshot below,
+  // so one undo reverts the whole "apply checkboxes" action.
+  if (validationDialog.type === 'checkbox') {
+    const filled = []
+    for (const id of ids) {
+      const cur = sheet.getCell(id, sn)
+      if (cur == null || String(cur) === '') {
+        sheet.setCell(id, 'FALSE', sn)
+        filled.push({ id, value: 'FALSE' })
+      }
+    }
+    if (filled.length) {
+      broadcastBatchChange(sn, filled)
+      recomputePivotsForSheet(sn)
+    }
+  }
+
   validationDialog.open = false
   grid?.render()
-  history.push()   // validation rules live in the snapshot; record for undo
+  history.push()   // rule + any FALSE-fill live in the snapshot; record for undo
   isDirty.value = true
 }
 
@@ -3959,6 +3983,17 @@ function pickDropdownOption(opt) {
   sheet.setCell(id, opt)
   dropdownPanel.open = false
   _pushEditOp(sn, before, 'Edit cell')
+  recomputePivotsForSheet(sn)
+}
+
+// Clicking a checkbox cell's tickbox flips TRUE ↔ FALSE (empty → TRUE). Routed
+// through the same edit-op path as a dropdown pick so undo + collab match.
+function toggleCheckbox(id) {
+  const sn     = sheet.getCurrentSheet()
+  const before = { [id]: sheet.getCell(id, sn) }
+  const next   = String(before[id]).toUpperCase() === 'TRUE' ? 'FALSE' : 'TRUE'
+  sheet.setCell(id, next, sn)
+  _pushEditOp(sn, before, 'Toggle checkbox')
   recomputePivotsForSheet(sn)
 }
 

--- a/frontend/src/apps/sheets/engine/validation.js
+++ b/frontend/src/apps/sheets/engine/validation.js
@@ -2,6 +2,7 @@
 // Rule shape: { type: 'list',        options: ['A','B','C'], message? }
 //             { type: 'number',      operator: 'between'|'gt'|'gte'|'lt'|'lte'|'eq'|'neq'|'not_between', min, max?, message? }
 //             { type: 'text_length', operator: 'between'|'gt'|'gte'|'lt'|'lte'|'eq'|'neq'|'not_between', min, max?, message? }
+//             { type: 'checkbox',    message? }  — cell holds TRUE / FALSE, painted as a tickbox
 // Pure state, no DOM dependency.
 
 import { parseCellId, colLabel } from '../utils/cells.js'
@@ -45,6 +46,12 @@ export function checkRule(rule, value) {
     const len = String(value == null ? '' : value).length
     const ok = _checkNumOp(len, rule.operator, rule.min, rule.max)
     return { valid: ok, message: ok ? null : (rule.message || 'Text length out of allowed range') }
+  }
+
+  if (rule.type === 'checkbox') {
+    const up = String(value).toUpperCase()
+    const ok = up === 'TRUE' || up === 'FALSE'
+    return { valid: ok, message: ok ? null : (rule.message || 'Value must be TRUE or FALSE') }
   }
 
   return { valid: true }


### PR DESCRIPTION
## What

Adds **Google-Sheets-style checkboxes** to Sheets: a cell that renders a tickable box and stores a boolean.


## How

A checkbox is a new **data-validation rule** `{ type: 'checkbox' }`, so it reuses the existing validation engine (snapshot/undo, row/col shifting, copy-paste round-trip) and the canvas-chip rendering pattern — near-zero new infrastructure.

- The cell stores `TRUE` / `FALSE`, which the formula tokenizer already treats as booleans, so `=IF(A1,…)`, `SUM`, and `COUNTIF(range,TRUE)` work with no extra code.
- **Apply:** Data-validation dialog → **Type: Checkbox** → Apply. Blank cells in the selection are filled with `FALSE` (matching Sheets) so they render unchecked and feed formulas immediately. The rule + fill land in a single undo step.
- **Toggle:** click the box to flip `TRUE`/`FALSE`, routed through the same edit-op path as a dropdown pick (identical undo + collaborative-sync behavior).

## Files

- `engine/validation.js` — `checkbox` branch in `checkRule` (accepts `TRUE`/`FALSE`).
- `canvas/checkbox-geometry.js` *(new)* — shared `checkboxRect()` keeps the painted box and click zone aligned (mirrors `chip-geometry.js`).
- `canvas/painters/cell-painter.js` — `_drawCheckbox()` (grey box, white tick) + skips raw text for checkbox cells.
- `canvas/index.js` — `onCheckboxToggle` prop + mousedown hit-test on the box rect.
- `components/SheetEditor/index.vue` — Checkbox type in the dialog, `FALSE`-fill in `confirmValidation`, and `toggleCheckbox()`.

## Testing

Unit tests for the validation rule, geometry, and painter pass in the standalone Sheets repo (744 green across the engine + canvas suites). Suite/develop doesn't currently carry the sheets `*.test.js` files, so this PR ports source only — happy to add the tests if the monorepo wants them.

Manual: apply checkboxes to a range → blanks become unchecked boxes; click toggles; a neighbouring `=COUNTIF(range,TRUE)` updates; undo/redo restores boxes + values; insert-row-above keeps checkboxes aligned; copy/paste carries the rule.
