### PR TITLE
fix(sheets): undo of an external paste reverts only the anchor cell

### DIFF
--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -3577,6 +3577,24 @@ async function onDocPaste(e) {
     return
   }
 
+  // Prefer the HTML flavor when it carries a real table — external apps
+  // (Gameplan, Google Sheets, web pages) put a structured <table> there, while
+  // their text/plain flavor can lack tab delimiters and collapse into a single
+  // column. Read both flavors up front so we can also MEASURE the paste extent
+  // before writing (see below).
+  const html = clipboard.hasData() ? null : e.clipboardData?.getData('text/html')
+  const text = clipboard.hasData() ? null : e.clipboardData?.getData('text/plain')
+
+  // For an external paste there is no internal source selection, so
+  // _pasteAffectedRects only sees the clicked cell — the output block's real
+  // size lives in the clipboard payload. Measure it (side-effect free, same
+  // grid math the write uses) and fold it into the capture rect, or undo would
+  // record only the anchor cell and leave the rest of the block behind.
+  const externalRect = clipboard.hasData()
+    ? null
+    : (clipboard.measureHTMLPaste(html, activeCell.value, destSel)
+       ?? clipboard.measureTextPaste(text, activeCell.value, destSel))
+
   // Snapshot the pre-paste state for cells + formats + validation across
   // the destination rect, plus cond-format rule count for the fallback
   // decision. The cells+formats+validation diff drives op-based undo; if
@@ -3586,6 +3604,7 @@ async function onDocPaste(e) {
   // Capture across everything the paste can touch (dest, full output block,
   // and — for a cut — the vacated source) so undo restores all of it.
   const rects      = _pasteAffectedRects(destSel)
+  if (externalRect) rects.push(externalRect)
   const before     = Object.assign({}, ...rects.map(r => _captureRange(r, sn)))
   const beforeFmt  = Object.assign({}, ...rects.map(r => _captureFormatsRange(r, sn)))
   const beforeVal  = Object.assign({}, ...rects.map(r => _captureValidationRange(r, sn)))
@@ -3597,21 +3616,11 @@ async function onDocPaste(e) {
     // history entry from out here. clipboard still does its mutations.
     clipboard.paste(activeCell.value, () => {}, 'all', destSel)
     pasted = true
-  } else {
-    // Prefer the HTML flavor when it carries a real table — external apps
-    // (Gameplan, Google Sheets, web pages) put a structured <table> there,
-    // while their text/plain flavor can lack tab delimiters and collapse into
-    // a single column. Fall back to tab/newline-delimited plain text.
-    const html = e.clipboardData?.getData('text/html')
-    if (html && clipboard.pasteFromHTML(html, activeCell.value, () => {}, destSel)) {
-      pasted = true
-    } else {
-      const text = e.clipboardData?.getData('text/plain')
-      if (text) {
-        clipboard.pasteFromText(text, activeCell.value, () => {}, destSel)
-        pasted = true
-      }
-    }
+  } else if (html && clipboard.pasteFromHTML(html, activeCell.value, () => {}, destSel)) {
+    pasted = true
+  } else if (text) {
+    clipboard.pasteFromText(text, activeCell.value, () => {}, destSel)
+    pasted = true
   }
   clipboardHas.value = clipboard.hasData()
   grid.setMarchingAnts(null)

--- a/frontend/src/apps/sheets/engine/clipboard.js
+++ b/frontend/src/apps/sheets/engine/clipboard.js
@@ -268,9 +268,55 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 	// pasting a single token into a multi-cell selection fills the whole range.
 	function pasteFromText(text, anchorId, historyPush, destSel = null) {
 		if (!text?.trim()) return
+		return _pasteGrid(_textToGrid(text), anchorId, historyPush, destSel)
+	}
+
+	// Split raw clipboard text into a 2D grid (tab = column, newline = row).
+	// Shared by pasteFromText and measureTextPaste so the write and the undo
+	// capture agree on exactly what a text paste covers.
+	function _textToGrid(text) {
 		const lines = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trimEnd().split('\n')
-		const grid  = lines.map(l => l.split('\t'))
-		return _pasteGrid(grid, anchorId, historyPush, destSel)
+		return lines.map(l => l.split('\t'))
+	}
+
+	// Geometry of a grid paste: its source dimensions and whether it tiles across
+	// the destination. Single source of truth for both the write (_pasteGrid) and
+	// the undo-capture bounds (_gridRect) — an external paste's extent must never
+	// be computed two different ways, or undo silently under-covers the write.
+	function _gridGeometry(grid, anch, destSel) {
+		const srcRows = grid.length
+		const srcCols = grid.reduce((m, r) => Math.max(m, r.length), 0)
+		const tileable = destSel
+			&& !(destSel.r0 === destSel.r1 && destSel.c0 === destSel.c1)
+			&& ((destSel.r1 - destSel.r0 + 1) % srcRows === 0)
+			&& ((destSel.c1 - destSel.c0 + 1) % srcCols === 0)
+		return { srcRows, srcCols, tileable }
+	}
+
+	// The destination rect a grid paste will actually write. A tiled paste fills
+	// exactly destSel; otherwise it's the anchor plus the grid's own dimensions.
+	function _gridRect(grid, anchorId, destSel = null) {
+		const anch = parseCellId(anchorId)
+		if (!anch) return null
+		const { srcRows, srcCols, tileable } = _gridGeometry(grid, anch, destSel)
+		if (tileable) return { r0: destSel.r0, c0: destSel.c0, r1: destSel.r1, c1: destSel.c1 }
+		return { r0: anch.row, c0: anch.col, r1: anch.row + srcRows - 1, c1: anch.col + srcCols - 1 }
+	}
+
+	// Extent an external text paste would cover, WITHOUT writing anything. Lets
+	// the editor size its undo capture to the full pasted block instead of just
+	// the clicked cell (the internal copy/paste path gets this from
+	// getSourceSel(); an external paste has no source selection to read).
+	function measureTextPaste(text, anchorId, destSel = null) {
+		if (!text?.trim()) return null
+		return _gridRect(_textToGrid(text), anchorId, destSel)
+	}
+
+	// Extent an external HTML-table paste would cover, WITHOUT writing anything.
+	function measureHTMLPaste(html, anchorId, destSel = null) {
+		const grid = parseHTMLTable(html)
+		if (!grid) return null
+		return _gridRect(grid, anchorId, destSel)
 	}
 
 	// Place a 2D grid of cell strings at the anchor (or tiled across destSel),
@@ -278,13 +324,7 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 	function _pasteGrid(grid, anchorId, historyPush, destSel = null) {
 		const anch = parseCellId(anchorId)
 		if (!anch) return false
-		const srcRows = grid.length
-		const srcCols = grid.reduce((m, r) => Math.max(m, r.length), 0)
-
-		const tileable = destSel
-			&& !(destSel.r0 === destSel.r1 && destSel.c0 === destSel.c1)
-			&& ((destSel.r1 - destSel.r0 + 1) % srcRows === 0)
-			&& ((destSel.c1 - destSel.c0 + 1) % srcCols === 0)
+		const { srcRows, srcCols, tileable } = _gridGeometry(grid, anch, destSel)
 
 		// Build the cell map first, then ship one bulk write — same reason as
 		// paste() above. Big external pastes (Excel/CSV via system clipboard)
@@ -321,5 +361,5 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 	function getPivotBlob() { return _data ? _pivot : null }
 	function clear() { _data = _fmts = _vals = _mode = _srcSel = _pivot = null }
 
-	return { copy, cut, paste, pasteFromText, pasteFromHTML, hasData, getMode, getSourceSel, getPivotBlob, clear }
+	return { copy, cut, paste, pasteFromText, pasteFromHTML, measureTextPaste, measureHTMLPaste, hasData, getMode, getSourceSel, getPivotBlob, clear }
 }

--- a/frontend/src/apps/sheets/engine/clipboard.test.js
+++ b/frontend/src/apps/sheets/engine/clipboard.test.js
@@ -213,3 +213,48 @@ describe('clipboard — cut clears the source but not overlapping dest cells', (
     expect(sheet.getCell('C2')).toBe('2')
   })
 })
+
+describe('clipboard — measure external paste extent (undo-capture bounds)', () => {
+  // Repro for the live bug: a multi-row text file pasted into a single clicked
+  // cell wrote every row, but undo only reverted the anchor because the editor
+  // sized its before/after capture to the clicked cell alone. The measure
+  // helpers report the true output rect so the capture covers the whole block.
+  let sheet, cb
+  beforeEach(() => { sheet = makeSheet({}); cb = createClipboard({ sheet }) })
+
+  it('measureTextPaste covers the whole block for a single-cell selection', () => {
+    const text = 'a\tb\tc\n1\t2\t3\n4\t5\t6'          // 3 rows × 3 cols
+    const rect = cb.measureTextPaste(text, 'A1', { r0: 0, c0: 0, r1: 0, c1: 0 })
+    expect(rect).toEqual({ r0: 0, c0: 0, r1: 2, c1: 2 })
+  })
+
+  it('measureTextPaste matches the cells the write actually touches', () => {
+    const text = 'a\tb\tc\n1\t2\t3\n4\t5\t6'
+    const rect = cb.measureTextPaste(text, 'C3', null)
+    cb.pasteFromText(text, 'C3', null, null)
+    // Every written cell falls inside the measured rect, and its corners are
+    // written — the capture neither under- nor over-covers.
+    expect(rect).toEqual({ r0: 2, c0: 2, r1: 4, c1: 4 })
+    expect(sheet.getCell('C3')).toBe('a')            // top-left
+    expect(sheet.getCell('E5')).toBe('6')            // bottom-right
+  })
+
+  it('measureTextPaste honours a tiled destination (rect === destSel)', () => {
+    const rect = cb.measureTextPaste('x', 'B1', { r0: 0, c0: 1, r1: 0, c1: 3 })
+    expect(rect).toEqual({ r0: 0, c0: 1, r1: 0, c1: 3 })
+  })
+
+  it('measureTextPaste returns null for empty/blank text', () => {
+    expect(cb.measureTextPaste('', 'A1', null)).toBeNull()
+    expect(cb.measureTextPaste('   ', 'A1', null)).toBeNull()
+  })
+
+  it('measureHTMLPaste reports the table block; null when there is no table', () => {
+    const html = '<table>' +
+                 '<tr><td>a</td><td>b</td><td>c</td></tr>' +
+                 '<tr><td>1</td><td>2</td><td>3</td></tr></table>'
+    expect(cb.measureHTMLPaste(html, 'A1', { r0: 0, c0: 0, r1: 0, c1: 0 }))
+      .toEqual({ r0: 0, c0: 0, r1: 1, c1: 2 })
+    expect(cb.measureHTMLPaste('<p>no table</p>', 'A1', null)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Problem

A live user pasted a multi-row text file into a single clicked cell. The paste worked — every row landed. But **Undo removed only the anchor cell** and left every other pasted row behind.

## Root cause

The paste and its undo-record were sized from two different sources:

- **The write** goes through `pasteFromText`/`pasteFromHTML` → one `batchSetCells`, covering the whole block. ✅
- **The undo capture** (`onDocPaste`) sizes its `before`/`after` snapshot from `_pasteAffectedRects(destSel)`. The full-block rect there is only added when `clipboard.getSourceSel()` is non-null — and that source selection **only exists for an internal copy/cut**. For a paste off the OS clipboard it's `null`, so the capture rect collapsed to just the clicked cell.

Result: for an external paste into a single-cell selection, the recorded op's `before`/`after`/`cellRefs` covered only the anchor. Undo faithfully reverted exactly what the op recorded — one cell. This affected **every external text/HTML paste into a single-cell selection**; internal copy/paste was unaffected because it gets the block dimensions from `_srcSel`.

## Fix

The paste's true extent lives in the clipboard payload (the parsed grid), so surface it:

- `clipboard.js`: factor the grid placement math into a single `_gridRect`/`_gridGeometry` shared by the write path and two new **side-effect-free** helpers — `measureTextPaste` and `measureHTMLPaste` — that return the exact `{r0,c0,r1,c1}` a paste will write (honoring tiling), without mutating anything. One source of truth means the write and the undo-capture can't drift.
- `SheetEditor/index.vue` (`onDocPaste`): for an external paste, measure the block **before** capturing `before`, and fold that rect into `_pasteAffectedRects`. Now `before`/`after`/`cellRefs` span the whole region and a single undo clears it all. Also simplified the paste branch to read each clipboard flavor once.

## Tests

Added regression tests for the measure helpers in `clipboard.test.js`: text-measure covers the full block for a single-cell selection, matches the cells actually written (corner assertions), honors tiled destinations, returns null for blank text; HTML-measure reports the table block and returns null when there's no table.

All clipboard tests pass (23/23).

## Manual verification

Reproduced the original bug, applied the fix, rebuilt, and confirmed: pasting a multi-row text file into a single clicked cell and hitting Undo now clears the entire block in one step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)