### PR TITLE
feat(mail): add Verify SSL option for JMAP connection

### DIFF
--- a/suite/mail/doctype/mail_settings/mail_settings.json
+++ b/suite/mail/doctype/mail_settings/mail_settings.json
@@ -7,6 +7,7 @@
   "config_tab",
   "jmap_section",
   "server_url",
+  "verify_ssl",
   "column_break_xvlo",
   "username",
   "password",
@@ -271,6 +272,13 @@
    "label": "Server URL",
    "options": "URL",
    "placeholder": "https://mail.frappemail.com"
+  },
+  {
+   "default": "1",
+   "description": "Verify the server's SSL certificate. Disable only for local development against a server with a self-signed certificate.",
+   "fieldname": "verify_ssl",
+   "fieldtype": "Check",
+   "label": "Verify SSL"
   },
   {
    "fieldname": "config_tab",

--- a/suite/mail/doctype/user_settings/user_settings.py
+++ b/suite/mail/doctype/user_settings/user_settings.py
@@ -74,7 +74,7 @@ class UserSettings(Document):
 		"""Returns a JMAP connection for the user if the username and app password are set, otherwise returns None."""
 
 		if self.username and self.get_password("app_password"):
-			server_url, verify_ssl = get_config(["server_url", "verify_ssl"])
+			server_url, verify_ssl = get_config(("server_url", "verify_ssl"))
 
 			try:
 				return JMAPConnection(

--- a/suite/mail/doctype/user_settings/user_settings.py
+++ b/suite/mail/doctype/user_settings/user_settings.py
@@ -74,11 +74,16 @@ class UserSettings(Document):
 		"""Returns a JMAP connection for the user if the username and app password are set, otherwise returns None."""
 
 		if self.username and self.get_password("app_password"):
-			server_url = get_config("server_url")
+			server_url, verify_ssl = get_config(["server_url", "verify_ssl"])
 
 			try:
 				return JMAPConnection(
-					JMAPConnectionInfo(server_url, self.username, self.get_password("app_password"))
+					JMAPConnectionInfo(
+						server_url,
+						self.username,
+						self.get_password("app_password"),
+						verify_ssl=bool(verify_ssl),
+					)
 				)
 			except Exception:
 				pass

--- a/suite/mail/jmap/__init__.py
+++ b/suite/mail/jmap/__init__.py
@@ -59,13 +59,15 @@ def get_jmap_connection(
 		frappe.throw(_("User {0} does not have JMAP settings configured.").format(frappe.bold(user)))
 
 	user_settings = frappe.get_cached_doc("User Settings", settings)
+	server_url, verify_ssl = get_config(["server_url", "verify_ssl"])
 
 	return JMAPConnection(
 		JMAPConnectionInfo(
-			get_config("server_url"),
+			server_url,
 			user_settings.username,
 			user_settings.get_password("app_password"),
 			timeout,
+			verify_ssl=bool(verify_ssl),
 		),
 		session_manager=get_jmap_session_manager(user),
 		user=user,

--- a/suite/mail/jmap/__init__.py
+++ b/suite/mail/jmap/__init__.py
@@ -59,7 +59,7 @@ def get_jmap_connection(
 		frappe.throw(_("User {0} does not have JMAP settings configured.").format(frappe.bold(user)))
 
 	user_settings = frappe.get_cached_doc("User Settings", settings)
-	server_url, verify_ssl = get_config(["server_url", "verify_ssl"])
+	server_url, verify_ssl = get_config(("server_url", "verify_ssl"))
 
 	return JMAPConnection(
 		JMAPConnectionInfo(

--- a/suite/mail/jmap/connection.py
+++ b/suite/mail/jmap/connection.py
@@ -16,12 +16,15 @@ class JMAPConnectionInfo:
 	- username: The username for authentication.
 	- password: The password for authentication.
 	- timeout: A tuple specifying the connection and read timeouts for requests (default: (30.0, 60.0)).
+	- verify_ssl: Whether to verify the server's SSL certificate (default: True). Disable only for local
+	  development against a server with a self-signed certificate.
 	"""
 
 	url: str
 	username: str
 	password: str
 	timeout: tuple[float, float] = (30.0, 60.0)
+	verify_ssl: bool = True
 
 
 class JMAPSessionManager:
@@ -71,6 +74,7 @@ class JMAPConnection:
 		self.__info = info
 		self.__session = requests.Session()
 		self.__session.auth = (self.__info.username, self.__info.password)
+		self.__session.verify = self.__info.verify_ssl
 		self.__session_manager = session_manager
 		self.user = user
 

--- a/suite/mail/utils/__init__.py
+++ b/suite/mail/utils/__init__.py
@@ -119,7 +119,7 @@ def reconnect_on_failure(max_retries: int = 3) -> callable:
 
 
 @request_cache
-def get_config(key: str | list[str] | None = None) -> dict[str, Any] | tuple | Any:
+def get_config(key: str | tuple[str, ...] | None = None) -> dict[str, Any] | tuple | Any:
 	"""Fetches configuration values, prioritizing Mail Settings over global config.
 
 	Cached per request: the returned dict is shared, so callers must treat it as read-only.

--- a/suite/mail/utils/__init__.py
+++ b/suite/mail/utils/__init__.py
@@ -42,6 +42,7 @@ CONFIG_KEYS = [
 	"server_url",
 	"username",
 	"password",
+	"verify_ssl",
 	# SpamAssassin
 	"spamd_host",
 	"spamd_port",
@@ -118,7 +119,7 @@ def reconnect_on_failure(max_retries: int = 3) -> callable:
 
 
 @request_cache
-def get_config(key: str | None = None) -> dict[str, Any] | Any:
+def get_config(key: str | list[str] | None = None) -> dict[str, Any] | tuple | Any:
 	"""Fetches configuration values, prioritizing Mail Settings over global config.
 
 	Cached per request: the returned dict is shared, so callers must treat it as read-only.
@@ -135,10 +136,14 @@ def get_config(key: str | None = None) -> dict[str, Any] | Any:
 			config[field] = settings.get(field) or mail_conf.get(field)
 
 	if key:
-		if key not in config:
-			frappe.throw(_("Mail config key '{0}' not found").format(key))
+		if isinstance(key, str):
+			key = [key]
 
-		return config[key]
+		for k in key:
+			if k not in config:
+				frappe.throw(_("Mail config key '{0}' not found").format(k))
+
+		return tuple(config[k] for k in key) if len(key) > 1 else config[key[0]]
 
 	return config
 

--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -53,5 +53,6 @@ suite.mail.patches.sync_jmap_accounts_for_configured_users
 suite.mail.patches.copy_sync_history_account_id_to_account
 suite.mail.patches.destroy_data_store
 suite.mail.patches.backfill_screened_email_address_account
+execute:frappe.db.set_single_value("Mail Settings", "verify_ssl", 1)
 # --- calendar ---
 # (no patches)


### PR DESCRIPTION
### Problem

Connecting to a JMAP server that presents a self-signed certificate (e.g. a local Stalwart instance on \`localhost\`) fails with:

\`\`\`
requests.exceptions.SSLError: ... certificate verify failed: self-signed certificate
\`\`\`

There was no way to relax TLS certificate verification for local development.

### Change

- Add a **Verify SSL** checkbox to **Mail Settings** (Config → Stalwart/JMAP), enabled by default.
- Thread the setting through \`JMAPConnectionInfo\` → \`JMAPConnection\`, applying it to the \`requests\` session so it covers both session discovery and all subsequent requests.
- Register \`verify_ssl\` in \`CONFIG_KEYS\` so it is resolvable via \`get_config\`.

Verification stays on by default, so production behaviour is unchanged. It can be unchecked for local development against a server with a self-signed certificate.

### Notes

- With verification off, \`requests\` emits an \`InsecureRequestWarning\` — expected for local dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)