### PR TITLE
feat(mail): show SMTP/IMAP/POP details for third-party clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ stalwart-cli
 .DS_Store
 *.swp
 *.swo
+.vscode

--- a/frontend/src/apps/mail/components/Settings/AdvancedSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/AdvancedSettings.vue
@@ -20,59 +20,57 @@
 		</template>
 	</Dialog>
 
-	<template v-if="configRows.length">
-		<h1>{{ __('Mail Client Configuration') }}</h1>
-		<p class="text-ink-gray-6 text-base">
-			{{
-				__(
-					'Use these details to connect a third-party mail client such as Thunderbird or the Gmail app.',
-				)
-			}}
-		</p>
-		<ListView
-			class="max-w-full flex-1"
-			:columns="CONFIG_COLUMNS"
-			:rows="configRows"
-			:options="{ selectable: false }"
-			row-key="key"
-		>
-			<ListHeader />
-			<ListRows>
-				<ListRow v-for="row in configRows" :key="row.key" :row="row">
-					<template #default="{ item }">
-						<ListRowItem>
-							<Tooltip :text="__('Click to copy')">
-								<div
-									class="cursor-copy truncate"
-									@click="copyToClipBoard(String(item))"
-								>
-									{{ item }}
-								</div>
-							</Tooltip>
-						</ListRowItem>
-					</template>
-				</ListRow>
-			</ListRows>
-		</ListView>
+	<div v-if="configRows.length" class="space-y-4 border-t pt-5">
+		<div class="space-y-1">
+			<h1>{{ __('Mail Client Configuration') }}</h1>
+			<p class="text-ink-gray-6 text-base">
+				{{
+					__(
+						'Use these details to connect a third-party mail client such as Thunderbird or the Gmail app.',
+					)
+				}}
+			</p>
+		</div>
+
+		<div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+			<div
+				v-for="row in configRows"
+				:key="row.key"
+				class="space-y-3 rounded-lg border p-4"
+			>
+				<div class="flex items-center justify-between gap-2">
+					<span class="text-ink-gray-8 font-medium">{{ row.protocol }}</span>
+					<Badge :label="row.connection_security" theme="gray" variant="subtle" />
+				</div>
+				<div class="space-y-2 text-base">
+					<div
+						v-for="field in row.fields"
+						:key="field.label"
+						class="flex items-center justify-between gap-3"
+					>
+						<span class="text-ink-gray-5">{{ field.label }}</span>
+						<Tooltip :text="__('Click to copy')">
+							<span
+								class="text-ink-gray-8 cursor-copy truncate"
+								@click="copyToClipBoard(field.value)"
+							>
+								{{ field.value }}
+							</span>
+						</Tooltip>
+					</div>
+				</div>
+			</div>
+		</div>
+
 		<CopyControl :label="__('Username')" :value="user.data?.email" />
 		<p class="text-ink-gray-5 text-sm">
 			{{ __('Sign in using your existing mail account password.') }}
 		</p>
-	</template>
+	</div>
 </template>
 <script setup lang="ts">
 import { computed, inject, ref } from 'vue'
-import {
-	Button,
-	Dialog,
-	ListHeader,
-	ListRow,
-	ListRowItem,
-	ListRows,
-	ListView,
-	Tooltip,
-	createResource,
-} from 'frappe-ui'
+import { Badge, Button, Dialog, Tooltip, createResource } from 'frappe-ui'
 
 import CopyControl from '@/apps/mail/components/Controls/CopyControl.vue'
 import { copyToClipBoard } from '@/apps/mail/utils'
@@ -92,13 +90,6 @@ const generateKeys = createResource({
 	},
 })
 
-const CONFIG_COLUMNS = [
-	{ label: __('Protocol'), key: 'protocol', width: '20%' },
-	{ label: __('Hostname'), key: 'hostname', width: '40%' },
-	{ label: __('Port'), key: 'port', width: '15%' },
-	{ label: __('Security'), key: 'connection_security', width: '25%' },
-]
-
 const clientConfig = createResource({
 	url: 'suite.mail.api.account.get_mail_client_config',
 	auto: true,
@@ -107,8 +98,13 @@ const clientConfig = createResource({
 const configRows = computed(() =>
 	(clientConfig.data ?? []).map(
 		(row: Record<string, string | number>, index: number) => ({
-			...row,
 			key: `${row.protocol}-${row.port}-${index}`,
+			protocol: row.protocol,
+			connection_security: row.connection_security,
+			fields: [
+				{ label: __('Hostname'), value: String(row.hostname) },
+				{ label: __('Port'), value: String(row.port) },
+			],
 		}),
 	),
 )

--- a/frontend/src/apps/mail/components/Settings/AdvancedSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/AdvancedSettings.vue
@@ -19,12 +19,63 @@
 			<CopyControl :label="__('API Secret')" :value="apiSecret" />
 		</template>
 	</Dialog>
+
+	<template v-if="configRows.length">
+		<h1>{{ __('Mail Client Configuration') }}</h1>
+		<p class="text-ink-gray-6 text-base">
+			{{
+				__(
+					'Use these details to connect a third-party mail client such as Thunderbird or the Gmail app.',
+				)
+			}}
+		</p>
+		<ListView
+			class="max-w-full flex-1"
+			:columns="CONFIG_COLUMNS"
+			:rows="configRows"
+			:options="{ selectable: false }"
+			row-key="key"
+		>
+			<ListHeader />
+			<ListRows>
+				<ListRow v-for="row in configRows" :key="row.key" :row="row">
+					<template #default="{ item }">
+						<ListRowItem>
+							<Tooltip :text="__('Click to copy')">
+								<div
+									class="cursor-copy truncate"
+									@click="copyToClipBoard(String(item))"
+								>
+									{{ item }}
+								</div>
+							</Tooltip>
+						</ListRowItem>
+					</template>
+				</ListRow>
+			</ListRows>
+		</ListView>
+		<CopyControl :label="__('Username')" :value="user.data?.email" />
+		<p class="text-ink-gray-5 text-sm">
+			{{ __('Sign in using your existing mail account password.') }}
+		</p>
+	</template>
 </template>
 <script setup lang="ts">
-import { inject, ref } from 'vue'
-import { Button, Dialog, createResource } from 'frappe-ui'
+import { computed, inject, ref } from 'vue'
+import {
+	Button,
+	Dialog,
+	ListHeader,
+	ListRow,
+	ListRowItem,
+	ListRows,
+	ListView,
+	Tooltip,
+	createResource,
+} from 'frappe-ui'
 
 import CopyControl from '@/apps/mail/components/Controls/CopyControl.vue'
+import { copyToClipBoard } from '@/apps/mail/utils'
 
 const user = inject('$user')
 
@@ -40,4 +91,25 @@ const generateKeys = createResource({
 		showSecret.value = true
 	},
 })
+
+const CONFIG_COLUMNS = [
+	{ label: __('Protocol'), key: 'protocol', width: '20%' },
+	{ label: __('Hostname'), key: 'hostname', width: '40%' },
+	{ label: __('Port'), key: 'port', width: '15%' },
+	{ label: __('Security'), key: 'connection_security', width: '25%' },
+]
+
+const clientConfig = createResource({
+	url: 'suite.mail.api.account.get_mail_client_config',
+	auto: true,
+})
+
+const configRows = computed(() =>
+	(clientConfig.data ?? []).map(
+		(row: Record<string, string | number>, index: number) => ({
+			...row,
+			key: `${row.protocol}-${row.port}-${index}`,
+		}),
+	),
+)
 </script>

--- a/suite/mail/api/account.py
+++ b/suite/mail/api/account.py
@@ -1,4 +1,5 @@
 import json
+from contextlib import suppress
 from typing import Literal
 
 import frappe
@@ -11,7 +12,9 @@ from suite.mail.api.mail import normalize_filter
 from suite.mail.api.utils import get_avatar_url
 from suite.mail.doctype.identity.identity import fetch_identities
 from suite.mail.doctype.mail_settings.mail_settings import get_signup_domains
-from suite.mail.utils import convert_html_to_text, user_context
+from suite.mail.stalwart import get_domains
+from suite.mail.utils import convert_html_to_text, is_stalwart_configured, user_context
+from suite.mail.utils.dns import parse_dns_zone_file
 from suite.mail.utils.rate_limiter import dynamic_rate_limit
 from suite.mail.utils.user import (
 	has_user_settings,
@@ -19,6 +22,16 @@ from suite.mail.utils.user import (
 	is_mail_admin,
 	is_system_manager,
 )
+
+# SRV service label -> (protocol, connection security). See RFC 6186.
+_SRV_SERVICE_MAP = {
+	"_submissions": ("SMTP", "SSL/TLS"),
+	"_submission": ("SMTP", "STARTTLS"),
+	"_imaps": ("IMAP", "SSL/TLS"),
+	"_imap": ("IMAP", "STARTTLS"),
+	"_pop3s": ("POP3", "SSL/TLS"),
+	"_pop3": ("POP3", "STARTTLS"),
+}
 
 
 @frappe.whitelist(allow_guest=True)
@@ -188,6 +201,75 @@ def get_user_info() -> dict | None:
 	data.user_image = data.user_image or get_avatar_url(user)
 
 	return data
+
+
+@frappe.whitelist()
+def get_mail_client_config() -> list[dict]:
+	"""Returns the SMTP/IMAP/POP endpoints for connecting third-party mail clients.
+
+	Resolution order:
+	1. Master switch off -> nothing.
+	2. Endpoints entered by the admin in Mail Settings.
+	3. Fallback: parse the user's domain DNS SRV records (if Stalwart is configured).
+	"""
+
+	settings = frappe.get_cached_doc("Mail Settings")
+	if not settings.show_mail_client_config:
+		return []
+
+	if settings.mail_client_configurations:
+		return [
+			{
+				"protocol": row.protocol,
+				"hostname": row.hostname,
+				"port": row.port,
+				"connection_security": row.connection_security,
+			}
+			for row in settings.mail_client_configurations
+		]
+
+	if is_stalwart_configured():
+		return _get_client_config_from_dns()
+
+	return []
+
+
+def _get_client_config_from_dns() -> list[dict]:
+	"""Derives mail-client endpoints from the domain DNS SRV records."""
+
+	with suppress(Exception):
+		domains = get_domains()
+		if not domains:
+			return []
+
+		config = []
+		domain = domains[0]
+		for record in parse_dns_zone_file(domain["dnsZoneFile"]):
+			if record["type"] != "SRV":
+				continue
+
+			mapping = _SRV_SERVICE_MAP.get(record["name"].split(".")[0])
+			if not mapping:
+				continue
+
+			# SRV rdata: <priority> <weight> <port> <target>. "." target means not offered.
+			parts = record["value"].split()
+			if len(parts) < 4 or parts[3] == ".":
+				continue
+
+			protocol, connection_security = mapping
+			config.append(
+				{
+					"protocol": protocol,
+					"hostname": parts[3].rstrip("."),
+					"port": cint(parts[2]),
+					"connection_security": connection_security,
+				}
+			)
+
+		return config
+
+	return []
 
 
 def get_backup_email(user: str) -> str:

--- a/suite/mail/api/account.py
+++ b/suite/mail/api/account.py
@@ -243,7 +243,11 @@ def _get_client_config_from_dns() -> list[dict]:
 			return []
 
 		config = []
+
+		# Every domain on the cluster points at the same mail server, so their SRV records
+		# resolve to identical client endpoints. Any one domain's zone is enough.
 		domain = domains[0]
+
 		for record in parse_dns_zone_file(domain["dnsZoneFile"]):
 			if record["type"] != "SRV":
 				continue

--- a/suite/mail/api/account.py
+++ b/suite/mail/api/account.py
@@ -1,5 +1,4 @@
 import json
-from contextlib import suppress
 from typing import Literal
 
 import frappe
@@ -13,7 +12,7 @@ from suite.mail.api.utils import get_avatar_url
 from suite.mail.doctype.identity.identity import fetch_identities
 from suite.mail.doctype.mail_settings.mail_settings import get_signup_domains
 from suite.mail.stalwart import get_domains
-from suite.mail.utils import convert_html_to_text, is_stalwart_configured, user_context
+from suite.mail.utils import convert_html_to_text, is_stalwart_configured, log_error, user_context
 from suite.mail.utils.dns import parse_dns_zone_file
 from suite.mail.utils.rate_limiter import dynamic_rate_limit
 from suite.mail.utils.user import (
@@ -235,9 +234,13 @@ def get_mail_client_config() -> list[dict]:
 
 
 def _get_client_config_from_dns() -> list[dict]:
-	"""Derives mail-client endpoints from the domain DNS SRV records."""
+	"""Derives mail-client endpoints from the domain DNS SRV records.
 
-	with suppress(Exception):
+	Best-effort: on any failure (Stalwart unreachable, malformed zone file) the error is
+	logged and an empty list is returned so the Advanced tab degrades gracefully.
+	"""
+
+	try:
 		domains = get_domains()
 		if not domains:
 			return []
@@ -272,8 +275,9 @@ def _get_client_config_from_dns() -> list[dict]:
 			)
 
 		return config
-
-	return []
+	except Exception:
+		log_error(title=_("Failed to derive mail client config from DNS"), message=frappe.get_traceback())
+		return []
 
 
 def get_backup_email(user: str) -> str:

--- a/suite/mail/doctype/mail_client_configuration/mail_client_configuration.json
+++ b/suite/mail/doctype/mail_client_configuration/mail_client_configuration.json
@@ -1,0 +1,67 @@
+{
+ "actions": [],
+ "creation": "2026-07-09 00:00:00",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "protocol",
+  "hostname",
+  "column_break_port",
+  "port",
+  "connection_security"
+ ],
+ "fields": [
+  {
+   "fieldname": "protocol",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Protocol",
+   "options": "SMTP\nIMAP\nPOP3",
+   "reqd": 1
+  },
+  {
+   "fieldname": "hostname",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Hostname",
+   "placeholder": "mail.example.com",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_port",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "port",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Port",
+   "non_negative": 1,
+   "reqd": 1
+  },
+  {
+   "default": "SSL/TLS",
+   "fieldname": "connection_security",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Connection Security",
+   "options": "SSL/TLS\nSTARTTLS\nNone",
+   "reqd": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-07-09 11:06:31.416111",
+ "modified_by": "Administrator",
+ "module": "Mail",
+ "name": "Mail Client Configuration",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/suite/mail/doctype/mail_client_configuration/mail_client_configuration.py
+++ b/suite/mail/doctype/mail_client_configuration/mail_client_configuration.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class MailClientConfiguration(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		connection_security: DF.Literal["SSL/TLS", "STARTTLS", "None"]
+		hostname: DF.Data
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		port: DF.Int
+		protocol: DF.Literal["SMTP", "IMAP", "POP3"]
+	# end: auto-generated types
+
+	pass

--- a/suite/mail/doctype/mail_settings/mail_settings.json
+++ b/suite/mail/doctype/mail_settings/mail_settings.json
@@ -11,6 +11,9 @@
   "column_break_xvlo",
   "username",
   "password",
+  "mail_client_config_section",
+  "show_mail_client_config",
+  "mail_client_configurations",
   "spamassassin_section",
   "spamd_host",
   "spamd_port",
@@ -558,6 +561,28 @@
    "fieldtype": "Int",
    "label": "Process Pending Emails Max Batch Size",
    "reqd": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval: true",
+   "fieldname": "mail_client_config_section",
+   "fieldtype": "Section Break",
+   "label": "Mail Client Configuration"
+  },
+  {
+   "default": "1",
+   "description": "Show the SMTP/IMAP/POP connection details in the Mail UI so users can set up third-party mail clients. When unchecked, nothing is shown.",
+   "fieldname": "show_mail_client_config",
+   "fieldtype": "Check",
+   "label": "Show Connection Details in Mail UI"
+  },
+  {
+   "depends_on": "eval: doc.show_mail_client_config",
+   "description": "Connection endpoints shown to users. Leave empty to fall back to the domain's DNS records.",
+   "fieldname": "mail_client_configurations",
+   "fieldtype": "Table",
+   "label": "Mail Client Configuration",
+   "options": "Mail Client Configuration"
   },
   {
    "collapsible": 1,

--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -54,5 +54,6 @@ suite.mail.patches.copy_sync_history_account_id_to_account
 suite.mail.patches.destroy_data_store
 suite.mail.patches.backfill_screened_email_address_account
 execute:frappe.db.set_single_value("Mail Settings", "verify_ssl", 1)
+execute:frappe.db.set_single_value("Mail Settings", "show_mail_client_config", 1)
 # --- calendar ---
 # (no patches)


### PR DESCRIPTION
### Closes #178

Adds a **Mail Client Configuration** block to the **Advanced** tab in Mail UI → Settings so users can connect third-party mail clients (Thunderbird, Gmail app, etc.).

### How it works

Endpoints are resolved server-side in a new whitelisted API `suite.mail.api.account.get_mail_client_config`, in this order:

1. **Master switch off** → nothing is shown.
2. **Admin-entered rows** — a new `Mail Client Configuration` child table on **Mail Settings** (Protocol · Hostname · Port · Connection Security).
3. **DNS fallback** — when no rows are set but Stalwart is configured, the domain's DNS SRV records (`_imaps`, `_imap`, `_pop3s`, `_pop3`, `_submissions`, `_submission`) are parsed into endpoints.

The Advanced tab renders whatever the API returns as a copyable table, plus the user's email as the username and a note to use their existing mail password. The whole block is hidden when the API returns nothing.

### Changes

- **New child DocType** `Mail Client Configuration`.
- **Mail Settings**: `show_mail_client_config` (Check, default on) master switch + `mail_client_configurations` (Table).
- **API** `get_mail_client_config` with the resolution order above; SRV parsing reuses `parse_dns_zone_file`.
- **Frontend**: extends the existing `AdvancedSettings.vue` (no new tab), mirroring the `DNSRecords.vue` click-to-copy list.

### Testing

- `bench migrate` creates the child DocType and both Mail Settings fields.
- API verified across all three paths (explicit rows, master switch off, DNS fallback).
- SRV parsing validated across all six service labels, correctly skipping services not offered (`.` target).
- Frontend production build compiles; `ruff check`/`ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)