### PR TITLE
feat(mail): add Push Subscription tab to Settings

### DIFF
--- a/frontend/src/apps/mail/components/Modals/AddPushSubscriptionModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddPushSubscriptionModal.vue
@@ -1,0 +1,108 @@
+<template>
+	<Dialog
+		v-model="show"
+		:options="{
+			title: __('New Push Subscription'),
+			actions: [
+				{
+					label: __('Create'),
+					variant: 'solid',
+					disabled: !canCreate,
+					loading: addPushSubscription.loading,
+					onClick: addPushSubscription.submit,
+				},
+			],
+		}"
+	>
+		<template #body-content>
+			<div class="space-y-4">
+				<FormControl
+					v-model="url"
+					type="text"
+					variant="outline"
+					:label="__('URL')"
+					placeholder="https://example.com/push"
+					:description="__('Where the JMAP server sends push messages. Leave blank to use this app\'s default endpoint. Must start with https://.')"
+				/>
+				<FormControl
+					v-model="deviceClientId"
+					type="text"
+					variant="outline"
+					:label="__('Device Client ID')"
+					:placeholder="__('Auto-generated if left blank')"
+					:description="__('Uniquely identifies the client and device.')"
+				/>
+				<div class="space-y-2">
+					<label class="text-ink-gray-5 block text-xs">{{ __('Types') }}</label>
+					<p class="text-ink-gray-5 text-xs">
+						{{ __('A StateChange notification is sent only when one of these types changes.') }}
+					</p>
+					<div class="grid grid-cols-2 gap-2">
+						<Checkbox
+							v-for="type in AVAILABLE_TYPES"
+							:key="type"
+							v-model="selectedTypes[type]"
+							:label="type"
+						/>
+					</div>
+				</div>
+			</div>
+		</template>
+	</Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, reactive, ref, watch } from 'vue'
+import { Checkbox, Dialog, FormControl, createResource } from 'frappe-ui'
+
+import { raiseToast } from '@/apps/mail/utils'
+
+const show = defineModel<boolean>()
+
+const emit = defineEmits<{ created: [] }>()
+
+const user = inject('$user')
+
+// The JMAP data types a client can subscribe to. These mirror the Push Subscription doctype's default
+// set; all are enabled by default so a new subscription behaves like a fresh client registration.
+const AVAILABLE_TYPES = ['Email', 'Mailbox', 'Identity', 'VacationResponse'] as const
+type SubscriptionType = (typeof AVAILABLE_TYPES)[number]
+
+const url = ref('')
+const deviceClientId = ref('')
+const selectedTypes = reactive<Record<SubscriptionType, boolean>>(
+	Object.fromEntries(AVAILABLE_TYPES.map((t) => [t, true])) as Record<SubscriptionType, boolean>,
+)
+
+const chosenTypes = computed(() => AVAILABLE_TYPES.filter((t) => selectedTypes[t]))
+
+// A URL is optional (blank falls back to the app default), but if given it must be an https URL to
+// match the backend's validation. At least one type must be selected.
+const canCreate = computed(
+	() => chosenTypes.value.length > 0 && (!url.value.trim() || url.value.trim().startsWith('https://')),
+)
+
+const addPushSubscription = createResource({
+	url: 'suite.mail.doctype.push_subscription.push_subscription.add_push_subscription',
+	makeParams: () => ({
+		user: user.data.name,
+		url: url.value.trim() || undefined,
+		device_client_id: deviceClientId.value.trim() || undefined,
+		types: chosenTypes.value,
+	}),
+	onSuccess: () => {
+		raiseToast(__('Push subscription created.'))
+		show.value = false
+		emit('created')
+	},
+	onError: (error) => raiseToast(error.messages?.[0] || error.message, 'error'),
+})
+
+// Reset the form each time the dialog opens.
+watch(show, (open) => {
+	if (!open) return
+	url.value = ''
+	deviceClientId.value = ''
+	AVAILABLE_TYPES.forEach((t) => (selectedTypes[t] = true))
+})
+</script>

--- a/frontend/src/apps/mail/components/Modals/SettingsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SettingsModal.vue
@@ -41,6 +41,7 @@
 import { computed, inject, markRaw, ref, watch } from 'vue'
 import {
 	Ban,
+	BellRing,
 	Code,
 	Feather,
 	Fingerprint,
@@ -65,6 +66,7 @@ import FolderSettings from '@/apps/mail/components/Settings/FolderSettings.vue'
 import IdentitySettings from '@/apps/mail/components/Settings/IdentitySettings.vue'
 import ImportSettings from '@/apps/mail/components/Settings/ImportSettings.vue'
 import ProfileSettings from '@/apps/mail/components/Settings/ProfileSettings.vue'
+import PushSubscriptionSettings from '@/apps/mail/components/Settings/PushSubscriptionSettings.vue'
 import ScreenedEmailAddressSettings from '@/apps/mail/components/Settings/ScreenedEmailAddressSettings.vue'
 import SignatureSettings from '@/apps/mail/components/Settings/SignatureSettings.vue'
 import VacationResponseSettings from '@/apps/mail/components/Settings/VacationResponseSettings.vue'
@@ -126,6 +128,12 @@ const tabs = computed(() => {
 			label: __('Screened Senders'),
 			icon: Ban,
 			component: markRaw(ScreenedEmailAddressSettings),
+			condition: user.data.is_jmap_configured,
+		},
+		{
+			label: __('Push Subscriptions'),
+			icon: BellRing,
+			component: markRaw(PushSubscriptionSettings),
 			condition: user.data.is_jmap_configured,
 		},
 		{

--- a/frontend/src/apps/mail/components/Settings/PushSubscriptionSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/PushSubscriptionSettings.vue
@@ -134,12 +134,14 @@ const renewSelected = async () => {
 		}
 		raiseToast(__('Selected subscriptions renewed.'))
 		listViewRef.value?.toggleAllRows()
-		pushSubscriptions.reload()
 	} catch (error) {
 		const err = error as { messages?: string[]; message?: string }
 		raiseToast(err.messages?.[0] || err.message || __('Failed to renew.'), 'error')
 	} finally {
+		// Reload after any outcome: a mid-loop failure still leaves earlier subscriptions renewed with
+		// updated expiry, so the table must reflect current server state without a manual refresh.
 		renewing.value = false
+		pushSubscriptions.reload()
 	}
 }
 

--- a/frontend/src/apps/mail/components/Settings/PushSubscriptionSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/PushSubscriptionSettings.vue
@@ -1,0 +1,187 @@
+<template>
+	<!-- A single h-full flex column gives the ListView a bounded flex parent so it fills the panel and
+	scrolls within itself, instead of taking a small intrinsic height with empty space below. -->
+	<div class="flex min-h-0 flex-1 flex-col gap-4">
+		<div class="flex items-center justify-between">
+			<h1>{{ __('Push Subscriptions') }}</h1>
+			<div class="flex gap-2">
+				<Button
+					variant="outline"
+					icon="lucide-refresh-cw"
+					:tooltip="__('Refresh')"
+					:loading="pushSubscriptions.loading"
+					@click="pushSubscriptions.reload()"
+				/>
+				<Button icon-left="lucide-plus" :label="__('New')" @click="showAddModal = true" />
+			</div>
+		</div>
+
+		<template v-if="rows.length">
+			<ListView
+				ref="listView"
+				class="min-h-0 flex-1"
+				:columns="COLUMNS"
+				:rows="rows"
+				row-key="name"
+			>
+				<ListHeader />
+				<ListRows />
+				<ListSelectBanner>
+					<template #actions>
+						<Button
+							variant="ghost"
+							:label="__('Renew')"
+							:loading="renewing"
+							@click="renewSelected"
+						/>
+						<Button
+							variant="ghost"
+							theme="red"
+							:label="__('Delete')"
+							@click="showDeleteModal = true"
+						/>
+					</template>
+				</ListSelectBanner>
+			</ListView>
+		</template>
+		<div
+			v-else-if="!pushSubscriptions.loading"
+			class="text-ink-gray-6 flex flex-col space-y-2 text-sm"
+		>
+			<p class="text-base font-medium">{{ __('No push subscriptions.') }}</p>
+			<p>{{ MESSAGE }}</p>
+		</div>
+
+		<AddPushSubscriptionModal v-model="showAddModal" @created="pushSubscriptions.reload()" />
+		<Dialog v-model="showDeleteModal" :options="deleteModalOptions" />
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, ref, useTemplateRef } from 'vue'
+import {
+	Button,
+	Dialog,
+	ListHeader,
+	ListRows,
+	ListSelectBanner,
+	ListView,
+	call,
+	createResource,
+} from 'frappe-ui'
+
+import { raiseToast } from '@/apps/mail/utils'
+import AddPushSubscriptionModal from '@/apps/mail/components/Modals/AddPushSubscriptionModal.vue'
+
+import type { PushSubscription } from '@/apps/mail/types'
+
+const user = inject('$user')
+const dayjs = inject('$dayjs')
+
+const listViewRef = useTemplateRef('listView')
+const showAddModal = ref(false)
+const showDeleteModal = ref(false)
+const renewing = ref(false)
+
+// Push subscriptions are user-scoped (not account-scoped), so they're fetched here rather than from the
+// account store. A high limit keeps this a single request — a user has at most a handful of devices.
+const pushSubscriptions = createResource({
+	url: 'suite.mail.doctype.push_subscription.push_subscription.fetch_push_subscriptions',
+	makeParams: () => ({ user: user.data.name, limit: 100 }),
+	auto: true,
+})
+
+// `types` arrives as a pretty-printed JSON array string; render it as a compact comma-separated list.
+const formatTypes = (types: string) => {
+	try {
+		const parsed = JSON.parse(types)
+		return Array.isArray(parsed) && parsed.length ? parsed.join(', ') : '—'
+	} catch {
+		return '—'
+	}
+}
+
+const rows = computed(() =>
+	(pushSubscriptions.data ?? []).map((sub: PushSubscription) => ({
+		name: sub.name,
+		user: sub.user,
+		id: sub.id,
+		device_client_id: sub.device_client_id,
+		types: formatTypes(sub.types),
+		expires: sub.expires ? dayjs(sub.expires).format('D MMM YYYY, h:mm A') : '—',
+	})),
+)
+
+const selectedNames = () => Array.from(listViewRef.value?.selections ?? []) as string[]
+const selectedRows = () => {
+	const names = new Set(selectedNames())
+	return (pushSubscriptions.data ?? []).filter((s: PushSubscription) => names.has(s.name))
+}
+
+// Renew has no batch endpoint, so renew each selected subscription in turn. A subscription renewal
+// extends its `expires` time on the JMAP server.
+const renewSelected = async () => {
+	const rowsToRenew = selectedRows()
+	if (!rowsToRenew.length) return
+
+	renewing.value = true
+	try {
+		for (const row of rowsToRenew) {
+			await call(
+				'suite.mail.doctype.push_subscription.push_subscription.renew_push_subscription',
+				{ user: row.user, id: row.id },
+			)
+		}
+		raiseToast(__('Selected subscriptions renewed.'))
+		listViewRef.value?.toggleAllRows()
+		pushSubscriptions.reload()
+	} catch (error) {
+		const err = error as { messages?: string[]; message?: string }
+		raiseToast(err.messages?.[0] || err.message || __('Failed to renew.'), 'error')
+	} finally {
+		renewing.value = false
+	}
+}
+
+const deletePushSubscriptions = createResource({
+	url: 'suite.mail.doctype.push_subscription.push_subscription.bulk_delete',
+	makeParams: () => ({ names: selectedNames() }),
+	onSuccess: () => {
+		raiseToast(__('Selected subscriptions deleted.'))
+		showDeleteModal.value = false
+		listViewRef.value?.toggleAllRows()
+		pushSubscriptions.reload()
+	},
+	// Close the confirmation but keep the selection so the user can retry.
+	onError: (error) => {
+		showDeleteModal.value = false
+		raiseToast(error.messages?.[0] || error.message || __('Failed to delete.'), 'error')
+	},
+})
+
+const deleteModalOptions = computed(() => ({
+	title: __('Delete Push Subscriptions'),
+	message: __('Are you sure you want to delete the selected push subscriptions?'),
+	actions: [
+		{
+			label: __('Confirm'),
+			variant: 'solid',
+			theme: 'red',
+			onClick: () => deletePushSubscriptions.submit(),
+			loading: deletePushSubscriptions.loading,
+		},
+	],
+}))
+
+// `fr` units (numbers) so the columns share the row width instead of overflowing.
+const COLUMNS = [
+	{ label: __('Device Client ID'), key: 'device_client_id', width: 2 },
+	{ label: __('Subscription ID'), key: 'id', width: 2 },
+	{ label: __('Types'), key: 'types', width: 2 },
+	{ label: __('Expires'), key: 'expires', width: 2 },
+]
+
+const MESSAGE = __(
+	'Push subscriptions let your devices receive real-time notifications when your mail changes. Create one to register this or another client.',
+)
+</script>

--- a/frontend/src/apps/mail/types/index.ts
+++ b/frontend/src/apps/mail/types/index.ts
@@ -18,6 +18,20 @@ export interface ScreenedAddress {
 	modified: string
 }
 
+// A JMAP push subscription (virtual doctype: Push Subscription). Each one registers a device/client
+// with the JMAP server so it receives StateChange notifications. `name` is `user|id` and is the row
+// key used by bulk_delete. `types` is a JSON string of the data types the client subscribes to.
+export interface PushSubscription {
+	user: string
+	id: string
+	name: string
+	device_client_id: string
+	expires: string | null
+	types: string
+	creation: string
+	modified: string
+}
+
 // A row in the Screener: one unique sender in the Screening folder, summarised by their latest mail.
 export interface ScreeningSender {
 	from_email: string


### PR DESCRIPTION
Closes #179

## What

Adds a **Push Subscriptions** tab under Mail UI → Settings. From it a user can:

- **See** all their existing JMAP push subscriptions (Device Client ID, Subscription ID, Types, Expires).
- **Create** a new subscription — URL and Device Client ID are optional (blank falls back to the backend's auto-generated defaults), and the subscribed Types are selectable.
- **Select** subscriptions and **Renew** or **Delete** them in bulk.

The tab is gated on `is_jmap_configured`, consistent with the other JMAP-backed settings tabs.

## How

- `PushSubscriptionSettings.vue` — the tab, modeled on `ScreenedEmailAddressSettings.vue` (`ListView` + select-banner actions). Push subscriptions are user-scoped, so data is fetched via `fetch_push_subscriptions` keyed on `$user` rather than the account store. Delete uses `bulk_delete`; renew loops `renew_push_subscription` over the selection (no batch endpoint exists).
- `AddPushSubscriptionModal.vue` — create form calling `add_push_subscription`; validates the URL as `https://` client-side to mirror the controller.
- `SettingsModal.vue` — registers the tab (`BellRing` icon) after "Screened Senders".
- `types/index.ts` — adds the `PushSubscription` interface matching `format_push_subscription`.

## Testing

- `bun run build` passes.

> [!NOTE]
> Push delivery only works end-to-end when the JMAP push encryption keys (`jmap_push_p256dh` / `jmap_push_auth`) are configured in Mail Settings; otherwise subscriptions are created without keys (existing backend behavior, unchanged here).