### PR TITLE
fix(sheets): resolve avatar/presence user from shared session store

### DIFF
--- a/frontend/src/apps/sheets/components/SheetEditor/ShareDialog.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/ShareDialog.vue
@@ -109,12 +109,12 @@
       <div v-else class="sd-member-list">
         <!-- Owner always first -->
         <div class="sd-member-row">
-          <Avatar :label="ownerInitials" size="md" :tooltip="ownerFullName" />
+          <Avatar :label="ownerInitials" :image="ownerImage || undefined" size="md" :tooltip="ownerFullName" />
           <div class="sd-member-info">
             <span class="sd-member-name">{{ ownerFullName }}</span>
             <span v-if="props.ownerId !== ownerFullName" class="sd-member-email">{{ props.ownerId }}</span>
           </div>
-          <span class="sd-role-label">Owner (you)</span>
+          <span class="sd-role-label">{{ _ownerIsMe ? 'Owner (you)' : 'Owner' }}</span>
         </div>
 
         <div v-for="s in shares" :key="s.user" class="sd-member-row">
@@ -188,6 +188,7 @@ watch(show, (open) => {
     searchQuery.value = ''
     searchResults.value = []
     fetchShares()
+    fetchOwnerInfo()
   }
 })
 
@@ -208,13 +209,33 @@ function _flashError(err) {
 // ── owner ──────────────────────────────────────────────────────────────────
 
 const currentUser = useCurrentUser()
-const ownerFullName = computed(() => {
-  // Show the resolved session name when the current user *is* the owner
-  // (from the shared suite session store); otherwise fall back to the id.
-  if (props.ownerId && props.ownerId === currentUser.user.value && currentUser.fullName.value)
-    return currentUser.fullName.value
-  return props.ownerId || 'You'
-})
+
+// A read-only member can open this dialog for a sheet they don't own (see the
+// error-banner note below), so the owner is often *not* the current user. When
+// it is, read the name/image from the shared session store; otherwise fetch the
+// owner's User record — the same way the invite autocomplete resolves people —
+// so the owner row shows a real name instead of the raw email.
+const ownerInfo = ref(null)   // { full_name, user_image } for a non-self owner
+async function fetchOwnerInfo() {
+  ownerInfo.value = null
+  if (!props.ownerId || props.ownerId === currentUser.user.value) return
+  try {
+    ownerInfo.value = await call('frappe.client.get_value', {
+      doctype: 'User', filters: props.ownerId, fieldname: ['full_name', 'user_image'],
+    })
+  } catch (_) { /* fall back to the id below */ }
+}
+
+const _ownerIsMe = computed(() => !!props.ownerId && props.ownerId === currentUser.user.value)
+const ownerFullName = computed(() =>
+  (_ownerIsMe.value && currentUser.fullName.value)
+  || ownerInfo.value?.full_name
+  || props.ownerId
+  || 'You'
+)
+const ownerImage = computed(() =>
+  (_ownerIsMe.value ? currentUser.imageURL.value : ownerInfo.value?.user_image) || ''
+)
 const ownerInitials = computed(() => userInitials(ownerFullName.value, props.ownerId))
 
 // ── general access ─────────────────────────────────────────────────────────

--- a/frontend/src/apps/sheets/components/SheetEditor/ShareDialog.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/ShareDialog.vue
@@ -160,6 +160,8 @@
 import { ref, computed, watch } from 'vue'
 import { Badge, Button, Dialog, Spinner, Dropdown, Avatar } from 'frappe-ui'
 import { call } from '../../utils/api.js'
+import { useCurrentUser } from '@/boot/session'
+import { userInitials } from '../../utils/session.js'
 
 const props = defineProps({
   modelValue:  { type: Boolean, default: false },
@@ -205,15 +207,15 @@ function _flashError(err) {
 
 // ── owner ──────────────────────────────────────────────────────────────────
 
-const ownerFullName = computed(() =>
-  window.frappe?.session?.user_fullname
-  || window.frappe?.boot?.user_info?.[props.ownerId]?.fullname
-  || props.ownerId
-  || 'You'
-)
-const ownerInitials = computed(() =>
-  ownerFullName.value.split(' ').map(p => p[0]).join('').slice(0, 2).toUpperCase()
-)
+const currentUser = useCurrentUser()
+const ownerFullName = computed(() => {
+  // Show the resolved session name when the current user *is* the owner
+  // (from the shared suite session store); otherwise fall back to the id.
+  if (props.ownerId && props.ownerId === currentUser.user.value && currentUser.fullName.value)
+    return currentUser.fullName.value
+  return props.ownerId || 'You'
+})
+const ownerInitials = computed(() => userInitials(ownerFullName.value, props.ownerId))
 
 // ── general access ─────────────────────────────────────────────────────────
 

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -1092,6 +1092,8 @@ import { h, ref, reactive, computed, watch, nextTick, onMounted, onBeforeUnmount
 import { createGrid }          from '../../canvas/index.js'
 import { colLabel, parseCellId, cellId } from '../../utils/cells.js'
 import { call } from '../../utils/api.js'
+import { useCurrentUser } from '@/boot/session'
+import { userInitials } from '../../utils/session.js'
 import { parseNumberFmt, buildNumberFmt, applyNumberFmt } from '../../utils/format-number.js'
 import { getTextWrap } from '../../utils/text-wrap.js'
 import { computeFillDown, computeFillRight } from '../../engine/fill-series.js'
@@ -1862,29 +1864,12 @@ const titleInputWidth = computed(() => {
 })
 
 
-// window.frappe is now seeded by sheets.html (see www/sheets.py).
-// Read it lazily into refs and refresh on mount so the avatar reflects
-// the actual logged-in user instead of the "U" fallback if Frappe's
-// own boot script later re-populates the global.
-const userEmail    = ref(window.frappe?.session?.user || '')
-const userFullName = ref(window.frappe?.session?.user_fullname || '')
-const userImage    = ref(window.frappe?.session?.user_image || '')
-const userInitial  = computed(() => {
-  // Prefer initials from full name ("Asif Mulani" → "AM"); fall back to
-  // the first letter of the email, then the literal "U" so the avatar
-  // never collapses into something empty.
-  const fn = userFullName.value.trim()
-  if (fn) {
-    const parts = fn.split(/\s+/)
-    return ((parts[0][0] || '') + (parts.length > 1 ? parts[parts.length - 1][0] : '')).toUpperCase()
-  }
-  return (userEmail.value ? userEmail.value[0] : 'U').toUpperCase()
-})
-onMounted(() => {
-  userEmail.value    = window.frappe?.session?.user          || userEmail.value
-  userFullName.value = window.frappe?.session?.user_fullname || userFullName.value
-  userImage.value    = window.frappe?.session?.user_image    || userImage.value
-})
+// The logged-in user for the top-right avatar, from the shared suite session
+// store (cookie-backed, refreshed by userResource — see @/boot/session). The
+// old window.frappe.session reads only worked on the standalone www page; the
+// suite shell never sets window.frappe, so the avatar collapsed to "U".
+const { user: userEmail, fullName: userFullName, imageURL: userImage } = useCurrentUser()
+const userInitial = computed(() => userInitials(userFullName.value, userEmail.value))
 
 // Collaboration — presence + sharing
 const shareOpen   = ref(false)

--- a/frontend/src/apps/sheets/components/SheetEditor/useCollaboration.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useCollaboration.js
@@ -325,17 +325,18 @@ export function useCollaboration({
   }
 
   function _readUserIdentity() {
+    // This only ever describes THIS client's own presence (id === _self, the
+    // local user), so the name/image come straight from the shared suite
+    // session profile — no need to re-derive "is this me", which meant a
+    // second getSessionUser() read that could drift from the _self captured
+    // at init (e.g. after a re-login).
     const id = _self
-    // Resolve the local user's name/image from the shared suite session store
-    // (cookie-backed, refreshed by userResource) so presence shows a real name
-    // instead of the raw email. Only trust it when it's actually this user.
-    const mine = id && id === getSessionUser()
-    const fullName = (mine && sessionFullName.value) || id || 'Anonymous'
+    const fullName = sessionFullName.value || id || 'Anonymous'
     return {
       id,
       fullName: String(fullName),
-      initials: userInitials(mine ? sessionFullName.value : '', id),
-      image: (mine && sessionImageURL.value) || '',
+      initials: userInitials(sessionFullName.value, id),
+      image: sessionImageURL.value || '',
     }
   }
 

--- a/frontend/src/apps/sheets/components/SheetEditor/useCollaboration.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useCollaboration.js
@@ -1,5 +1,7 @@
 import { ref, watch, onUnmounted } from 'vue'
 import { call }                        from '../../utils/api.js'
+import { getSessionUser, fullName as sessionFullName, imageURL as sessionImageURL } from '@/boot/session'
+import { userInitials }                from '../../utils/session.js'
 import { createYDoc, hydrateYDoc }     from '../../collab/ydoc.js'
 import { bindCells }                   from '../../collab/cells-binding.js'
 import { createFrappeProvider }        from '../../collab/frappe-provider.js'
@@ -115,7 +117,7 @@ export function useCollaboration({
   currentSheet,
   getSheet,
   repopulateGrid,
-  _self        = window.frappe?.session?.user,
+  _self        = getSessionUser(),
   _realtime    = window.frappe?.realtime,
   _callFn      = (method, args) => call(method, args),
   _watch       = watch,
@@ -324,21 +326,16 @@ export function useCollaboration({
 
   function _readUserIdentity() {
     const id = _self
-    // Guard against `window` being undefined (tests run in node) — the
-    // composable should still function with just an id.
-    const w = (typeof window !== 'undefined') ? window : undefined
-    const fullName = w?.frappe?.session?.user_fullname
-      || w?.frappe?.boot?.user_info?.[id]?.fullname
-      || id
-      || 'Anonymous'
-    const parts = String(fullName).split(' ').filter(Boolean)
-    const initials = ((parts[0]?.[0] || '?')
-      + (parts.length > 1 ? parts[parts.length - 1][0] : '')).toUpperCase()
+    // Resolve the local user's name/image from the shared suite session store
+    // (cookie-backed, refreshed by userResource) so presence shows a real name
+    // instead of the raw email. Only trust it when it's actually this user.
+    const mine = id && id === getSessionUser()
+    const fullName = (mine && sessionFullName.value) || id || 'Anonymous'
     return {
       id,
       fullName: String(fullName),
-      initials,
-      image: w?.frappe?.boot?.user_info?.[id]?.image || '',
+      initials: userInitials(mine ? sessionFullName.value : '', id),
+      image: (mine && sessionImageURL.value) || '',
     }
   }
 

--- a/frontend/src/apps/sheets/utils/session.js
+++ b/frontend/src/apps/sheets/utils/session.js
@@ -1,0 +1,15 @@
+// Two-letter initials for the avatar, derived from a full name
+// ("Asif Mulani" → "AM"); falls back to the first letter of the email, then
+// "U" so the avatar never collapses into something empty.
+//
+// Identity itself comes from the shared suite session store (@/boot/session);
+// this is only the presentation helper shared by the avatar, the collab
+// presence pile, and the ShareDialog owner row.
+export function userInitials(fullName, email) {
+  const fn = (fullName || '').trim()
+  if (fn) {
+    const parts = fn.split(/\s+/)
+    return ((parts[0][0] || '') + (parts.length > 1 ? parts[parts.length - 1][0] : '')).toUpperCase()
+  }
+  return (email ? email[0] : 'U').toUpperCase()
+}


### PR DESCRIPTION
## Problem

On the production suite site the Sheets top-right avatar renders the literal **"U"** instead of the logged-in user's initials.

The Sheets sub-app resolves the current user only from `window.frappe.session.{user,user_fullname,user_image}`. That global is injected solely by the **standalone** `www/sheets.html` Jinja shim. The suite shell serves the SPA from `/assets/suite/frontend/…` and never sets `window.frappe`, so all three reads are empty and `userInitial` falls through to its `"U"` last-resort. The same root cause left collab presence and the ShareDialog owner row showing the raw email instead of a name.

## Fix

Route the three call sites through the shared suite session store (`@/boot/session`), which is cookie-backed (`user_id` / `full_name` / `user_image`) and refreshed by `userResource` — the source of truth already used across the other suite apps:

- **Avatar** (`SheetEditor/index.vue`) — `useCurrentUser()` for `user` / `fullName` / `imageURL`.
- **Collaboration presence** (`SheetEditor/useCollaboration.js`) — `getSessionUser()` for `_self`, and `fullName`/`imageURL` for the local user's presence identity.
- **ShareDialog owner row** (`SheetEditor/ShareDialog.vue`) — resolved session name when the current user is the owner.

Adds a small pure `userInitials()` helper (`apps/sheets/utils/session.js`) shared by all three.

## Notes

- No behavior change on the standalone www page (cookies + the shim carry the same identity there).
- Validated import resolution and script syntax locally; did not run a full `vite build` (fresh-clone install) — relying on CI.