### PR TITLE
feat(mail): add push encryption toggle and fix encrypted push decoding

### DIFF
--- a/suite/mail/doctype/mail_settings/mail_settings.json
+++ b/suite/mail/doctype/mail_settings/mail_settings.json
@@ -95,10 +95,11 @@
   "dns_provider_private_zone",
   "jmap_push_tab",
   "section_break_qvpk",
-  "jmap_push_p256dh",
-  "jmap_push_private_key",
+  "enable_jmap_push_encryption",
   "column_break_wpvf",
-  "jmap_push_auth"
+  "jmap_push_auth",
+  "jmap_push_private_key",
+  "jmap_push_p256dh"
  ],
  "fields": [
   {
@@ -136,6 +137,13 @@
   {
    "fieldname": "section_break_qvpk",
    "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "description": "When enabled, push subscriptions are created with the encryption keys below, so the JMAP server end-to-end encrypts push payloads. Leave disabled to send push notifications as plain JSON.",
+   "fieldname": "enable_jmap_push_encryption",
+   "fieldtype": "Check",
+   "label": "Enable Push Encryption"
   },
   {
    "description": "P-256 ECDH public key for JMAP PushSubscription encryption.",
@@ -726,7 +734,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-06-23 17:16:11.209239",
+ "modified": "2026-07-09 15:48:38.043660",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Settings",

--- a/suite/mail/doctype/mail_settings/mail_settings.py
+++ b/suite/mail/doctype/mail_settings/mail_settings.py
@@ -14,6 +14,84 @@ from suite.mail.utils import is_stalwart_configured
 
 
 class MailSettings(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+		from suite.mail.doctype.mail_client_configuration.mail_client_configuration import MailClientConfiguration
+
+		allow_signup: DF.Check
+		ansible_play_timeout: DF.Int
+		default_disk_quota_gb: DF.Int
+		default_dns_ttl: DF.Int
+		default_gravatar: DF.Literal["404"]
+		dns_provider: DF.Literal["", "AmazonRoute53", "DigitalOcean", "Cloudflare", "Hetzner", "Linode", "Namecheap", "GoDaddy"]
+		dns_provider_access_key: DF.Data | None
+		dns_provider_access_secret: DF.Password | None
+		dns_provider_client_ip: DF.Data | None
+		dns_provider_key: DF.Data | None
+		dns_provider_private_zone: DF.Check
+		dns_provider_secret: DF.Password | None
+		dns_provider_token: DF.Password | None
+		dns_provider_username: DF.Data | None
+		dns_provider_zone_id: DF.Data | None
+		enable_gravatar: DF.Check
+		enable_jmap_push_encryption: DF.Check
+		exchange_export_batch_size: DF.Int
+		exchange_export_timeout: DF.Int
+		exchange_import_timeout: DF.Int
+		exchange_log_file_count: DF.Int
+		exchange_log_level: DF.Literal["ERROR", "WARNING", "INFO", "DEBUG"]
+		exchange_log_max_file_size: DF.Int
+		exchange_max_export: DF.Int
+		exchange_max_import: DF.Int
+		fetch_lock_timeout: DF.Int
+		inbound_log_file_count: DF.Int
+		inbound_log_level: DF.Literal["ERROR", "WARNING", "INFO", "DEBUG"]
+		inbound_log_max_file_size: DF.Int
+		jmap_push_auth: DF.Password | None
+		jmap_push_p256dh: DF.Data | None
+		jmap_push_private_key: DF.Password | None
+		lock_acquire_timeout: DF.Int
+		lock_timeout: DF.Int
+		mail_client_configurations: DF.Table[MailClientConfiguration]
+		max_email_sync: DF.Int
+		max_message_payload_size_mb: DF.Int
+		max_push_notifications: DF.Int
+		outbound_log_file_count: DF.Int
+		outbound_log_level: DF.Literal["ERROR", "WARNING", "INFO", "DEBUG"]
+		outbound_log_max_file_size: DF.Int
+		password: DF.Password | None
+		process_pending_emails_batch_size: DF.Int
+		process_pending_emails_max_batch_size: DF.Int
+		process_pending_emails_timeout: DF.Int
+		push_log_file_count: DF.Int
+		push_log_level: DF.Literal["ERROR", "WARNING", "INFO", "DEBUG"]
+		push_log_max_file_size: DF.Int
+		root_domain_name: DF.Data | None
+		scan_message_timeout: DF.Int
+		server_deployment_timeout: DF.Int
+		server_job_timeout: DF.Int
+		server_url: DF.Data | None
+		show_mail_client_config: DF.Check
+		signup_domains: DF.SmallText | None
+		spamd_host: DF.Data | None
+		spamd_hybrid_scanning_threshold: DF.Float
+		spamd_port: DF.Int
+		spamd_scanning_mode: DF.Literal["Exclude Attachments", "Include Attachments", "Hybrid Approach"]
+		stalwart_cli_command_timeout: DF.Int
+		stalwart_cli_version: DF.Data
+		stalwart_version: DF.Data
+		storage_log_file_count: DF.Int
+		storage_log_level: DF.Literal["ERROR", "WARNING", "INFO", "DEBUG"]
+		storage_log_max_file_size: DF.Int
+		username: DF.Data | None
+		verify_ssl: DF.Check
+	# end: auto-generated types
+
 	def validate(self) -> None:
 		if not frappe.flags.in_migrate:
 			self.validate_root_domain_name()
@@ -115,6 +193,13 @@ class MailSettings(Document):
 			frappe.throw(
 				_(
 					"JMAP Push Subscription keys are incomplete. Use Actions → Generate JMAP Push Keys to regenerate them."
+				)
+			)
+
+		if self.enable_jmap_push_encryption and set_count != 3:
+			frappe.throw(
+				_(
+					"Push encryption is enabled but the JMAP Push Subscription keys are not configured. Use Actions → Generate JMAP Push Keys to generate them, or disable Enable Push Encryption."
 				)
 			)
 

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -276,14 +276,34 @@ def format_push_subscription(user: str, push_subscription: dict) -> dict:
 
 
 def get_push_subscription_keys() -> dict | None:
-	"""Returns the JMAP push subscription encryption keys from Mail Settings, or None if not configured."""
+	"""Returns the JMAP push subscription encryption keys from Mail Settings, or None if encryption is disabled or the keys are not configured."""
 
 	settings = frappe.get_cached_doc("Mail Settings")
+	if not settings.get("enable_jmap_push_encryption"):
+		return None
+
 	p256dh = (settings.get("jmap_push_p256dh") or "").strip()
 	auth = (settings.get_password("jmap_push_auth") if settings.get("jmap_push_auth") else "").strip()
 
 	if p256dh and auth:
 		return {"p256dh": p256dh, "auth": auth}
+
+
+
+
+def _decode_encrypted_push_body(raw_body: bytes) -> bytes:
+	"""Returns the raw aes128gcm ciphertext from a push request body."""
+
+	_B64URL_BYTES = frozenset(b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=")
+
+	stripped = raw_body.strip()
+	if not stripped or any(byte not in _B64URL_BYTES for byte in stripped):
+		return raw_body
+
+	try:
+		return base64.urlsafe_b64decode(stripped + b"=" * (-len(stripped) % 4))
+	except Exception:
+		return raw_body
 
 
 def decrypt_jmap_push_payload(raw_body: bytes) -> dict:
@@ -326,6 +346,8 @@ def decrypt_jmap_push_payload(raw_body: bytes) -> dict:
 		private_key = ec.derive_private_key(int.from_bytes(priv_bytes, "big"), ec.SECP256R1())
 	except Exception:
 		frappe.throw(_("Failed to construct EC private key."))
+
+	raw_body = _decode_encrypted_push_body(raw_body)
 
 	if len(raw_body) < 21:
 		frappe.throw(_("Encrypted push payload is too short."))


### PR DESCRIPTION
## Summary

JMAP push subscriptions were created successfully, but the JMAP server's verification `POST` never reached the app, so subscriptions were never verified. Root cause: for encrypted push, the server sends `Content-Type: application/json` with a base64 (non-JSON) body; Frappe's `make_form_dict` tries to parse it as JSON, fails, and returns **HTTP 417 (`DataError: Invalid request body`)** before the handler runs.

This PR makes unencrypted push the default (which works end-to-end) and fixes a latent bug in the encrypted-payload decoder.

## Changes

- **Add `Enable Push Encryption` toggle to Mail Settings** (`enable_jmap_push_encryption`, default off).
  - `get_push_subscription_keys()` returns `None` when disabled, so subscriptions are created without keys and the server delivers push notifications as **plain JSON** — which passes Frappe's request-body parsing and reaches `push_notification`.
  - Settings validation now blocks enabling encryption unless the push keys are configured.
- **Fix encrypted push payload decoding.** Stalwart base64url-encodes the `aes128gcm` ciphertext before POSTing it, but `decrypt_jmap_push_payload` treated the body as raw binary. It now base64url-decodes the body when it detects that form, and falls back to raw binary for RFC 8291-compliant servers.

## Notes / follow-ups

- After deploy, existing subscriptions created *with* keys must be deleted and recreated (the server keeps encrypting them otherwise).
- With encryption **on**, delivery still won't work behind Frappe's JSON body parsing (e.g. Frappe Cloud) without a `before_request` shim that rewrites the `Content-Type` for the push route. The decoder fix here is a prerequisite for that; the shim is left as a follow-up.

## Testing

- `bench --site s1 migrate` syncs the new field; `get_push_subscription_keys()` returns `None` while disabled.
- Verified the decoder: Stalwart-style base64 (with/without trailing newline) decodes correctly, raw binary passes through unchanged, and the base64-vs-raw detector had 0 false positives over 100k random 16-byte salts.
- `ruff check` passes on the changed files.
