### PR TITLE
feat(mail): add manual refresh button for new emails

### DIFF
--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -95,6 +95,21 @@
 						</button>
 					</Dropdown>
 					<p v-else class="pb-[2px]">{{ title }}</p>
+					<Button
+						v-if="!selections.length"
+						class="ml-1.5"
+						variant="ghost"
+						:tooltip="__('Refresh')"
+						:disabled="threadsResource?.loading"
+						@click="reloadThreads()"
+					>
+						<template #icon>
+							<RefreshCw
+								class="icon"
+								:class="{ 'animate-spin': threadsResource?.loading }"
+							/>
+						</template>
+					</Button>
 					<div class="-mr-1.5 ml-auto flex items-center space-x-1.5 sm:space-x-3">
 						<div
 							v-if="!selections.length && displayTotal"
@@ -351,6 +366,18 @@
 						: __('You have no mails in this folder.')
 				}}
 			</p>
+			<Button
+				v-if="mailbox !== 'search'"
+				class="mt-3"
+				variant="ghost"
+				:label="__('Refresh')"
+				:disabled="threadsResource?.loading"
+				@click="reloadThreads()"
+			>
+				<template #prefix>
+					<RefreshCw class="icon" :class="{ 'animate-spin': threadsResource?.loading }" />
+				</template>
+			</Button>
 		</div>
 	</div>
 


### PR DESCRIPTION
### Summary

Adds a manual refresh affordance to the Mail UI so users can fetch new emails on demand rather than waiting for the 30s poll / socket push.

- **Toolbar** — a ghost refresh icon button next to the mailbox filter ("All Mails"). Hidden while a selection is active (matching the filter dropdown's behavior).
- **Empty state** — a ghost refresh button under "You have no mails in this folder.", so a refresh is still reachable when the toolbar isn't rendered (empty, unfiltered mailbox). Hidden on the search view.

Both reuse the existing `reloadThreads()` path (same one driven by the periodic poll and `new_mail_created` socket event), reloading the current mailbox's threads and the sidebar counts. The icon spins and the button is disabled while a reload is in flight.

Styled as ghost icon buttons per the Espresso design system — no border/shadow, hover gray background, keyboard-only (`:focus-visible`) focus ring — consistent with the adjacent pagination buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)