### PR TITLE
perf(meet): keep DTLN worklet out of the Vite graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ yarn-error.log
 /suite/**/public/frontend/
 /suite/**/public/dist/
 /suite/sheets/public/sheets/
+# Meet DTLN worklet (~17MB) — copied from node_modules by frontend prebuild
+/suite/public/noise-suppression/
 # Built www entrypoints (one per app); sheets.html is a hand-written template
 /suite/**/www/*.html
 !/suite/sheets/www/sheets.html

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,11 +4,13 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "node scripts/unlink-frappe-ui.mjs && vite --host",
-    "dev:frappe-ui": "node scripts/link-frappe-ui.mjs && vite --host",
+    "dev": "node scripts/copy-noise-suppression-assets.mjs && node scripts/unlink-frappe-ui.mjs && vite --host",
+    "dev:frappe-ui": "node scripts/copy-noise-suppression-assets.mjs && node scripts/link-frappe-ui.mjs && vite --host",
+    "prebuild": "node scripts/copy-noise-suppression-assets.mjs",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "copy-noise-assets": "node scripts/copy-noise-suppression-assets.mjs"
   },
   "comment": "Minimal foundation deps only — enough to build the shell+router+stubs (the Phase 5 foundation gate). The full 94+42 union merged from the 7 source apps is preserved in package.union.json; each per-app port re-adds its real deps from there.",
   "dependencies": {

--- a/frontend/scripts/copy-noise-suppression-assets.mjs
+++ b/frontend/scripts/copy-noise-suppression-assets.mjs
@@ -1,0 +1,41 @@
+/**
+ * Copy the prebundled DTLN AudioWorklet processor out of node_modules into
+ * suite/public so Vite never fingerprints/emits ~40MB of wasm + models on
+ * every production build.
+ *
+ * Frappe serves: /assets/suite/noise-suppression/audio-worklet-processor.js
+ * Vite dev serves the same directory via vite.config middleware at
+ * /noise-suppression/audio-worklet-processor.js
+ *
+ * The processor ships LiteRT wasm + DTLN models base64-inlined (package
+ * README); only this single file is required for the worklet path.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const frontendRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const appRoot = path.resolve(frontendRoot, '..')
+
+const source = path.join(
+  appRoot,
+  'node_modules/@workadventure/noise-suppression/dist/assets/audio-worklet-processor.js',
+)
+
+const dest = path.join(
+  appRoot,
+  'suite/public/noise-suppression/audio-worklet-processor.js',
+)
+
+if (!fs.existsSync(source)) {
+  console.error(
+    `[copy-noise-suppression-assets] Source missing: ${source}\n` +
+      'Install @workadventure/noise-suppression first (yarn install).',
+  )
+  process.exit(1)
+}
+
+fs.mkdirSync(path.dirname(dest), { recursive: true })
+fs.copyFileSync(source, dest)
+const mb = (fs.statSync(dest).size / (1024 * 1024)).toFixed(1)
+console.log(`[copy-noise-suppression-assets] ${dest} (${mb} MB)`)

--- a/frontend/src/apps/meet/composables/useNoiseCancellation.ts
+++ b/frontend/src/apps/meet/composables/useNoiseCancellation.ts
@@ -1,7 +1,7 @@
 import {
 	createNoiseSuppressionAudioWorklet,
 	type NoiseSuppressionAudioWorkletHandle,
-} from "@workadventure/noise-suppression/audio-worklet";
+} from "@/shims/noise-suppression-audio-worklet";
 import { onUnmounted, type Ref, ref } from "vue";
 
 const DTLN_SAMPLE_RATE = 16000;

--- a/frontend/src/shims/noise-suppression-audio-worklet.ts
+++ b/frontend/src/shims/noise-suppression-audio-worklet.ts
@@ -1,0 +1,161 @@
+/**
+ * Thin reimplementation of @workadventure/noise-suppression/audio-worklet that
+ * never references `new URL(..., import.meta.url)`.
+ *
+ * Importing the package entry would pull the 17MB processor + LiteRT vendor
+ * assets into the Vite/Rollup graph on every production build. We load the
+ * prebundled processor from a static Frappe/Vite public path instead.
+ *
+ * Processor name and message protocol match package v0.0.4.
+ */
+
+/** Absolute URL of the static worklet (see scripts/copy-noise-suppression-assets.mjs). */
+export const NOISE_SUPPRESSION_WORKLET_URL = import.meta.env.DEV
+  ? '/noise-suppression/audio-worklet-processor.js'
+  : '/assets/suite/noise-suppression/audio-worklet-processor.js'
+
+export const NOISE_SUPPRESSION_AUDIO_WORKLET_PROCESSOR_NAME =
+  'workadventure-noise-suppression'
+
+const DEFAULT_READY_TIMEOUT_MS = 30_000
+
+interface AudioWorkletCapableContext extends BaseAudioContext {
+  readonly audioWorklet: AudioWorklet
+}
+
+export interface NoiseSuppressionAudioWorkletOptions {
+  moduleUrl?: string
+  threads?: boolean
+  numThreads?: number
+  bypassUntilReady?: boolean
+  readyTimeoutMs?: number
+}
+
+export interface NoiseSuppressionAudioWorkletReadyMessage {
+  type: 'ready'
+  modelDetails?: unknown
+}
+
+export interface NoiseSuppressionAudioWorkletHandle {
+  node: AudioWorkletNode
+  ready: Promise<NoiseSuppressionAudioWorkletReadyMessage>
+  moduleUrl: string
+  processorName: string
+  dispose(): void
+}
+
+const moduleLoadCache = new WeakMap<AudioWorkletCapableContext, Map<string, Promise<void>>>()
+
+function defaultNumThreads(override?: number): number {
+  if (Number.isFinite(override) && override !== undefined && override > 0) {
+    return Math.floor(override)
+  }
+  const cores =
+    typeof navigator !== 'undefined' &&
+    Number.isFinite(navigator.hardwareConcurrency) &&
+    navigator.hardwareConcurrency > 0
+      ? navigator.hardwareConcurrency
+      : 1
+  return Math.max(1, Math.min(4, cores))
+}
+
+function addModuleOnce(
+  context: AudioWorkletCapableContext,
+  moduleUrl: string,
+): Promise<void> {
+  let byUrl = moduleLoadCache.get(context)
+  if (!byUrl) {
+    byUrl = new Map()
+    moduleLoadCache.set(context, byUrl)
+  }
+  let pending = byUrl.get(moduleUrl)
+  if (pending) return pending
+  pending = context.audioWorklet.addModule(moduleUrl)
+  byUrl.set(moduleUrl, pending)
+  return pending
+}
+
+function waitForReady(
+  node: AudioWorkletNode,
+  timeoutMs: number,
+): Promise<NoiseSuppressionAudioWorkletReadyMessage> {
+  return new Promise((resolve, reject) => {
+    const timer = globalThis.setTimeout(() => {
+      cleanup()
+      reject(
+        new Error(
+          'Timed out waiting for the noise suppression worklet to initialize.',
+        ),
+      )
+    }, timeoutMs)
+
+    const onMessage = (event: MessageEvent) => {
+      const data = event.data as { type?: string; message?: string }
+      if (data?.type === 'ready') {
+        cleanup()
+        resolve(data as NoiseSuppressionAudioWorkletReadyMessage)
+        return
+      }
+      if (data?.type === 'error') {
+        cleanup()
+        reject(new Error(data.message || 'Noise suppression worklet error'))
+      }
+    }
+
+    const onProcessorError = () => {
+      cleanup()
+      reject(new Error('The noise suppression AudioWorklet processor failed.'))
+    }
+
+    const cleanup = () => {
+      globalThis.clearTimeout(timer)
+      node.port.removeEventListener('message', onMessage)
+      node.removeEventListener('processorerror', onProcessorError)
+    }
+
+    node.port.addEventListener('message', onMessage)
+    node.port.start()
+    node.addEventListener('processorerror', onProcessorError)
+  })
+}
+
+export async function createNoiseSuppressionAudioWorklet(
+  context: AudioWorkletCapableContext,
+  options: NoiseSuppressionAudioWorkletOptions = {},
+): Promise<NoiseSuppressionAudioWorkletHandle> {
+  const moduleUrl = options.moduleUrl ?? NOISE_SUPPRESSION_WORKLET_URL
+  const readyTimeoutMs = options.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS
+  const threads = options.threads === true
+  const numThreads = defaultNumThreads(options.numThreads)
+  const bypassUntilReady = options.bypassUntilReady ?? true
+
+  await addModuleOnce(context, moduleUrl)
+
+  const node = new AudioWorkletNode(
+    context,
+    NOISE_SUPPRESSION_AUDIO_WORKLET_PROCESSOR_NAME,
+    {
+      channelCount: 1,
+      channelCountMode: 'explicit',
+      numberOfInputs: 1,
+      numberOfOutputs: 1,
+      outputChannelCount: [1],
+      processorOptions: {
+        threads,
+        numThreads,
+        bypassUntilReady,
+      },
+    },
+  )
+
+  return {
+    node,
+    ready: waitForReady(node, readyTimeoutMs),
+    moduleUrl,
+    processorName: NOISE_SUPPRESSION_AUDIO_WORKLET_PROCESSOR_NAME,
+    dispose() {
+      node.port.postMessage({ type: 'dispose' })
+      node.disconnect()
+    },
+  }
+}

--- a/frontend/src/shims/noise-suppression-audio-worklet.ts
+++ b/frontend/src/shims/noise-suppression-audio-worklet.ts
@@ -70,7 +70,12 @@ function addModuleOnce(
   }
   let pending = byUrl.get(moduleUrl)
   if (pending) return pending
-  pending = context.audioWorklet.addModule(moduleUrl)
+  // Drop failed loads from the cache so a missing file / transient fetch
+  // error can succeed on a later call (e.g. after prebuild copies the asset).
+  pending = context.audioWorklet.addModule(moduleUrl).catch((err) => {
+    byUrl.delete(moduleUrl)
+    throw err
+  })
   byUrl.set(moduleUrl, pending)
   return pending
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -26,8 +26,15 @@ const serveNoiseSuppressionAssets = () => {
     configureServer(server: { middlewares: { use: (path: string, fn: (req: any, res: any, next: () => void) => void) => void } }) {
       server.middlewares.use('/noise-suppression', (req, res, next) => {
         const rel = (req.url || '/').split('?')[0].replace(/^\//, '') || 'audio-worklet-processor.js'
-        const filePath = path.join(noiseDir, rel)
-        if (!filePath.startsWith(noiseDir) || !fs.existsSync(filePath)) {
+        const filePath = path.resolve(noiseDir, rel)
+        // Directory containment (not string prefix): avoid
+        // /noise-suppression/../noise-suppression-sibling/secret.js escapes.
+        const relative = path.relative(noiseDir, filePath)
+        if (
+          relative.startsWith('..') ||
+          path.isAbsolute(relative) ||
+          !fs.existsSync(filePath)
+        ) {
           next()
           return
         }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,7 +2,6 @@ import fs from 'fs'
 import path from 'path'
 
 import vue from '@vitejs/plugin-vue'
-import { noiseSuppressionAudioWorkletVitePlugin } from '@workadventure/noise-suppression/vite'
 import frappeui from 'frappe-ui/vite'
 import { defineConfig } from 'vite'
 import { VitePWA } from 'vite-plugin-pwa'
@@ -17,6 +16,29 @@ const emitSlidesServiceWorker = () => ({
     fs.copyFileSync(swSource, swOutput)
   },
 })
+
+/** Serve suite/public/noise-suppression at /noise-suppression in Vite dev (not via publicDir — that would re-emit 17MB into the SPA build). */
+const serveNoiseSuppressionAssets = () => {
+  const noiseDir = path.resolve(__dirname, '../suite/public/noise-suppression')
+  return {
+    name: 'serve-noise-suppression-assets',
+    apply: 'serve' as const,
+    configureServer(server: { middlewares: { use: (path: string, fn: (req: any, res: any, next: () => void) => void) => void } }) {
+      server.middlewares.use('/noise-suppression', (req, res, next) => {
+        const rel = (req.url || '/').split('?')[0].replace(/^\//, '') || 'audio-worklet-processor.js'
+        const filePath = path.join(noiseDir, rel)
+        if (!filePath.startsWith(noiseDir) || !fs.existsSync(filePath)) {
+          next()
+          return
+        }
+        res.statusCode = 200
+        res.setHeader('Content-Type', 'text/javascript')
+        res.setHeader('Cache-Control', 'no-cache')
+        fs.createReadStream(filePath).pipe(res)
+      })
+    },
+  }
+}
 
 const benchRoot = path.resolve(__dirname, '../../..')
 const commonSiteConfig = JSON.parse(
@@ -37,7 +59,11 @@ export default defineConfig(({ mode }) => ({
   // ../suite/public/frontend -> exposed as /assets/suite/frontend).
   base: mode === 'production' ? '/assets/suite/frontend/' : '/',
   plugins: [
-    noiseSuppressionAudioWorkletVitePlugin(),
+    // Noise-suppression worklet lives under suite/public/noise-suppression
+    // (see scripts/copy-noise-suppression-assets.mjs + src/shims/...).
+    // Do not reintroduce @workadventure/noise-suppression/vite — that path
+    // re-pulls the processor into the Rollup graph via import.meta.url.
+    serveNoiseSuppressionAssets(),
     frappeui({
       // frappe-ui/vite wires the dev proxy to the local bench, injects the
       // CSRF/boot data, and emits the Jinja-templated index html.


### PR DESCRIPTION
Serve the noise-suppression AudioWorklet as a static Frappe asset instead of pulling the package's import.meta.url entry into Rollup. That drops ~57MB of worklet/wasm/tflite from suite/public/frontend on every production build while loading the same processor at runtime.