### PR TITLE
feat(sheets): recoverable trash for deleted sheets

### DIFF
--- a/frontend/src/apps/sheets/pages/Home.vue
+++ b/frontend/src/apps/sheets/pages/Home.vue
@@ -56,6 +56,13 @@
             @click="setViewMode('grid')"
           />
         </div>
+        <!-- Overflow menu for secondary home-level destinations. Kept separate
+             from the New Sheet CTA so a nav item isn't styled as a peer action. -->
+        <Dropdown :options="overflowActions" placement="bottom-end">
+          <template #default="{ open }">
+            <Button :variant="open ? 'subtle' : 'ghost'" size="sm" icon="lucide-ellipsis-vertical" tooltip="More" />
+          </template>
+        </Dropdown>
         <Button variant="solid" @click="newSheet()">New Sheet</Button>
       </div>
     </div>
@@ -191,11 +198,12 @@
     <!-- Delete confirm dialog -->
     <Dialog
       v-model="showDeleteDialog"
-      :options="{ title: 'Delete sheet?', size: 'sm' }"
+      :options="{ title: 'Move to trash?', size: 'sm' }"
     >
       <template #body-content>
         <p class="home-confirm-text">
-          "<strong>{{ deleteTarget?.title }}</strong>" will be permanently deleted.
+          "<strong>{{ deleteTarget?.title }}</strong>" will be moved to Trash. You
+          can restore it from there before it's permanently deleted.
         </p>
       </template>
       <template #actions>
@@ -205,7 +213,7 @@
             theme="red"
             :loading="deleting"
             @click="doDelete"
-          >Delete</Button>
+          >Move to trash</Button>
           <Button @click="showDeleteDialog = false">Cancel</Button>
         </div>
       </template>
@@ -242,6 +250,12 @@ function openSheet(name) {
 function newSheet() {
   router.push({ name: 'sheets-editor', params: { id: 'new' } })
 }
+
+// Top-level overflow menu (the ⋮ next to New Sheet). Just Trash for now; this
+// is the home for future home-level destinations (Shared, Settings, …).
+const overflowActions = [
+  { label: 'Trash', icon: 'trash-2', onClick: () => router.push({ name: 'sheets-trash' }) },
+]
 
 const sheets       = ref([])
 const loading      = ref(true)

--- a/frontend/src/apps/sheets/pages/Trash.vue
+++ b/frontend/src/apps/sheets/pages/Trash.vue
@@ -1,0 +1,203 @@
+<template>
+  <div class="home">
+    <!-- Top bar — mirrors Home's chrome, minus search/view-toggle/New. -->
+    <div class="home-topbar">
+      <div class="home-brand">
+        <Button variant="ghost" size="sm" icon="arrow-left" tooltip="Back to sheets" @click="goHome()" />
+        <span class="home-brand-name">Trash</span>
+      </div>
+      <div class="home-topbar-right">
+        <Badge v-if="errorMessage" theme="red" variant="subtle" size="sm" :label="errorMessage" />
+        <span class="home-trash-note">Items are deleted forever after {{ retentionDays }} days</span>
+      </div>
+    </div>
+
+    <div class="home-body">
+      <div v-if="loading" class="home-empty">
+        <Spinner class="home-spinner" />
+      </div>
+
+      <div v-else-if="!sheets.length" class="home-empty">
+        <div class="home-empty-icon">
+          <FeatherIcon name="trash-2" class="home-trash-empty-icon" />
+        </div>
+        <p class="home-empty-title">Trash is empty</p>
+        <p class="home-empty-sub">Deleted sheets show up here.</p>
+      </div>
+
+      <ListView
+        v-else
+        :columns="listColumns"
+        :rows="sheets"
+        row-key="name"
+        :options="listOptions"
+      >
+        <template #cell="{ item, row, column }">
+          <div
+            v-if="column.key === '_actions'"
+            class="flex w-full justify-end gap-1"
+            @click.stop
+          >
+            <Button variant="ghost" size="sm" :loading="busy === row.name" @click="restore(row)">Restore</Button>
+            <Button variant="ghost" theme="red" size="sm" :loading="busy === row.name" @click="confirmPurge(row)">Delete forever</Button>
+          </div>
+          <ListRowItem v-else :column="column" :row="row" :item="item" :align="column.align" />
+        </template>
+      </ListView>
+    </div>
+
+    <!-- Permanent delete confirm -->
+    <Dialog v-model="showPurgeDialog" :options="{ title: 'Delete forever?', size: 'sm' }">
+      <template #body-content>
+        <p class="home-confirm-text">
+          "<strong>{{ purgeTarget?.title }}</strong>" and its full history will be
+          <strong>permanently deleted</strong>. This can't be undone.
+        </p>
+      </template>
+      <template #actions>
+        <div class="flex flex-row-reverse gap-2">
+          <Button variant="solid" theme="red" :loading="purging" @click="doPurge">Delete forever</Button>
+          <Button @click="showPurgeDialog = false">Cancel</Button>
+        </div>
+      </template>
+    </Dialog>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { Badge, Button, Dialog, Spinner, FeatherIcon, ListView, ListRowItem } from 'frappe-ui'
+import { useRouter } from 'vue-router'
+
+import { call } from '@/apps/sheets/utils/api.js'
+
+const router = useRouter()
+
+const sheets  = ref([])
+const loading = ref(true)
+const busy    = ref('')   // name of the row with an in-flight restore/purge
+const retentionDays = ref(30)
+
+const errorMessage = ref('')
+function _flashError(msg) {
+  errorMessage.value = msg
+  setTimeout(() => { if (errorMessage.value === msg) errorMessage.value = '' }, 4000)
+}
+
+function goHome() {
+  router.push({ name: 'sheets-home' })
+}
+
+const listColumns = [
+  { label: 'Name', key: 'title', width: 3 },
+  { label: 'Trashed', key: 'trashed_on', width: 1, getLabel: ({ row }) => formatDate(row.trashed_on) },
+  { label: '', key: '_actions', width: '220px', align: 'right' },
+]
+
+const listOptions = { selectable: false, showTooltip: false, rowHeight: 40 }
+
+onMounted(fetchTrash)
+
+async function fetchTrash() {
+  loading.value = true
+  try {
+    const res = await call('suite.sheets.api.list_trash')
+    sheets.value = res.sheets ?? []
+    if (res.retention_days) retentionDays.value = res.retention_days
+  } finally {
+    loading.value = false
+  }
+}
+
+function formatDate(iso) {
+  if (!iso) return ''
+  const d = new Date(iso.replace(' ', 'T'))
+  return d.toLocaleDateString()
+}
+
+async function restore(sheet) {
+  busy.value = sheet.name
+  try {
+    await call('suite.sheets.api.restore_sheet', { name: sheet.name })
+    sheets.value = sheets.value.filter(s => s.name !== sheet.name)
+  } catch (err) {
+    _flashError(err?.message || 'Restore failed')
+  } finally {
+    busy.value = ''
+  }
+}
+
+const showPurgeDialog = ref(false)
+const purgeTarget     = ref(null)
+const purging         = ref(false)
+
+function confirmPurge(sheet) {
+  purgeTarget.value = sheet
+  showPurgeDialog.value = true
+}
+
+async function doPurge() {
+  if (!purgeTarget.value) return
+  purging.value = true
+  try {
+    await call('suite.sheets.api.delete_sheet_permanent', { name: purgeTarget.value.name })
+    sheets.value = sheets.value.filter(s => s.name !== purgeTarget.value.name)
+    showPurgeDialog.value = false
+  } catch (err) {
+    _flashError(err?.message || 'Delete failed')
+  } finally {
+    purging.value = false
+  }
+}
+</script>
+
+<style scoped>
+/* Reuses Home.vue's class names for the shared shell (.home, .home-topbar,
+   .home-body, .home-empty, .home-confirm-text) — those live in Home's scoped
+   block, so the shared bits are duplicated here to keep this page standalone. */
+.home {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  background: var(--surface-white);
+  font-family: InterVar, ui-sans-serif, system-ui, sans-serif;
+  color: var(--ink-gray-9);
+}
+.home-topbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 0 32px;
+  height: 48px;
+  background: var(--surface-white);
+  border-bottom: 1px solid var(--outline-gray-2);
+  flex-shrink: 0;
+}
+.home-brand { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+.home-brand-name { font-size: 16px; font-weight: 600; letter-spacing: .01em; color: var(--ink-gray-9); }
+.home-topbar-right { display: flex; align-items: center; gap: 16px; margin-left: auto; }
+.home-trash-note { font-size: 12px; letter-spacing: .02em; color: var(--ink-gray-5); }
+.home-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 40px 32px;
+  width: 100%;
+}
+.home-body > * { max-width: 1200px; margin-left: auto; margin-right: auto; }
+.home-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  min-height: 300px;
+  color: var(--ink-gray-5);
+}
+.home-spinner { width: 32px; height: 32px; color: var(--ink-gray-5); }
+.home-empty-icon { margin-bottom: 4px; }
+.home-trash-empty-icon { width: 40px; height: 40px; color: var(--ink-gray-4); }
+.home-empty-title { font-size: 15px; font-weight: 500; letter-spacing: .01em; color: var(--ink-gray-8); margin: 0; }
+.home-empty-sub { font-size: 13px; letter-spacing: .02em; color: var(--ink-gray-5); margin: 0 0 8px; }
+.home-confirm-text { font-size: 14px; letter-spacing: .02em; color: var(--ink-gray-7); margin: 0; }
+</style>

--- a/frontend/src/apps/sheets/routes.ts
+++ b/frontend/src/apps/sheets/routes.ts
@@ -22,6 +22,11 @@ export const routes: RouteRecordRaw[] = [
     component: () => import('@/apps/sheets/pages/Home.vue'),
   },
   {
+    path: 'trash',
+    name: 'sheets-trash',
+    component: () => import('@/apps/sheets/pages/Trash.vue'),
+  },
+  {
     path: ':id',
     name: 'sheets-editor',
     component: () => import('@/apps/sheets/pages/SheetEditor.vue'),

--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -247,6 +247,7 @@ scheduler_events = {
 		# sheets
 		"suite.sheets.versioning.tasks.rollup_snapshots",
 		"suite.sheets.versioning.tasks.truncate_op_log",
+		"suite.sheets.trash.purge_trashed_sheets",
 		# mail
 		"suite.mail.doctype.jmap_account.jmap_account.delete_orphaned_jmap_accounts",
 		"suite.mail.doctype.mail_exchange.mail_exchange.clean_import_export_directories",

--- a/suite/sheets/api.py
+++ b/suite/sheets/api.py
@@ -276,6 +276,7 @@ def list_sheets() -> list:
 	me = frappe.session.user
 	rows = frappe.get_list(
 		"Sheet",
+		filters={"trashed": 0},
 		fields=["name", "title", "modified", "owner"],
 		order_by="modified desc",
 		limit=100,
@@ -292,6 +293,10 @@ def get_sheet(name: str, compressed: int = 0) -> dict:
 	# its contents.
 	frappe.has_permission("Sheet", doc=name, throw=True)
 	doc = frappe.get_doc("Sheet", name)
+	# A trashed sheet must not open from a bookmarked/shared link — it's
+	# "deleted" as far as the app is concerned until restored.
+	if doc.trashed:
+		frappe.throw("This sheet is in the trash.", frappe.DoesNotExistError)
 	# When the client can gunzip (DecompressionStream), ship the stored envelope
 	# as-is — ~1.5MB instead of the ~20MB decoded JSON for a big sheet — and let
 	# it decompress. Clients without it (older Safari) get the decoded payload.
@@ -346,18 +351,63 @@ def record_op(
 
 @frappe.whitelist()
 def delete_sheet(name: str) -> str:
-	# Frappe's default link enforcement blocks deletion when child rows exist.
-	# We own the lifecycle of Sheet Snapshot / Sheet Op Log / Sheet Seq, so a
-	# Sheet delete should cascade across them — atomically and in dependency
-	# order. The head pointer on Sheet is cleared first so the snapshot delete
-	# doesn't trip the "linked from Sheet" check.
+	# Soft delete: flag the sheet as trashed instead of destroying it, so the
+	# owner can restore it within the retention window. The `delete` ptype gate
+	# is owner-only (the "All" role's delete perm is `if_owner`), so a shared
+	# collaborator can't trash someone else's sheet. Versioning tables are left
+	# fully intact — a restore is a perfect restore, not a last-save recovery.
+	# The nightly purge (suite.sheets.trash.purge_trashed_sheets) does the real erase.
 	frappe.has_permission("Sheet", doc=name, ptype="delete", throw=True)
-	frappe.db.set_value("Sheet", name, "head_snapshot", None, update_modified=False)
-	frappe.db.delete("Sheet Snapshot", {"sheet": name})
-	frappe.db.delete("Sheet Op Log",   {"sheet": name})
-	frappe.db.delete("Sheet Seq",      {"sheet": name})
-	frappe.delete_doc("Sheet", name, ignore_permissions=False)
+	frappe.db.set_value(
+		"Sheet",
+		name,
+		{"trashed": 1, "trashed_on": frappe.utils.now_datetime(), "trashed_by": frappe.session.user},
+		update_modified=False,
+	)
 	return "ok"
+
+
+@frappe.whitelist()
+def restore_sheet(name: str) -> str:
+	# Same owner-only gate as trashing — restore is the inverse of delete.
+	frappe.has_permission("Sheet", doc=name, ptype="delete", throw=True)
+	frappe.db.set_value(
+		"Sheet",
+		name,
+		{"trashed": 0, "trashed_on": None, "trashed_by": None},
+		update_modified=False,
+	)
+	return "ok"
+
+
+@frappe.whitelist()
+def delete_sheet_permanent(name: str) -> str:
+	# Irreversible "delete forever" from the trash. Owner-only, same as trashing.
+	# The cascade lives in suite.sheets.trash so it stays in lockstep with the purge.
+	frappe.has_permission("Sheet", doc=name, ptype="delete", throw=True)
+	from suite.sheets.trash import hard_delete_sheet
+
+	hard_delete_sheet(name)
+	return "ok"
+
+
+@frappe.whitelist()
+def list_trash() -> dict:
+	# Trash is owner-scoped: only the owner can trash/restore, so a shared
+	# collaborator has no business seeing another user's trash. Filter to the
+	# caller's own trashed sheets explicitly rather than leaning on the share
+	# grant that list_sheets uses. `retention_days` rides along so the UI can
+	# state the exact purge window instead of assuming the default.
+	from suite.sheets.trash import retention_days
+
+	sheets = frappe.get_list(
+		"Sheet",
+		filters={"trashed": 1, "owner": frappe.session.user},
+		fields=["name", "title", "trashed_on"],
+		order_by="trashed_on desc",
+		limit=100,
+	)
+	return {"sheets": sheets, "retention_days": retention_days()}
 
 
 @frappe.whitelist()

--- a/suite/sheets/api.py
+++ b/suite/sheets/api.py
@@ -385,6 +385,10 @@ def delete_sheet_permanent(name: str) -> str:
 	# Irreversible "delete forever" from the trash. Owner-only, same as trashing.
 	# The cascade lives in suite.sheets.trash so it stays in lockstep with the purge.
 	frappe.has_permission("Sheet", doc=name, ptype="delete", throw=True)
+	# Only ever fire from the trash flow: a direct call on a live sheet must not
+	# skip the recovery window and destroy it in one shot.
+	if not frappe.db.get_value("Sheet", name, "trashed"):
+		frappe.throw("Only sheets in the trash can be permanently deleted.")
 	from suite.sheets.trash import hard_delete_sheet
 
 	hard_delete_sheet(name)

--- a/suite/sheets/doctype/sheet/sheet.json
+++ b/suite/sheets/doctype/sheet/sheet.json
@@ -8,7 +8,10 @@
   "title",
   "sheets_data",
   "head_seq",
-  "head_snapshot"
+  "head_snapshot",
+  "trashed",
+  "trashed_on",
+  "trashed_by"
  ],
  "fields": [
   {
@@ -35,6 +38,29 @@
    "fieldtype": "Link",
    "options": "Sheet Snapshot",
    "label": "Latest snapshot"
+  },
+  {
+   "fieldname": "trashed",
+   "fieldtype": "Check",
+   "label": "Trashed",
+   "default": "0",
+   "in_standard_filter": 1,
+   "description": "Soft-delete flag. Trashed sheets are hidden from the app and purged after the retention window."
+  },
+  {
+   "fieldname": "trashed_on",
+   "fieldtype": "Datetime",
+   "label": "Trashed On",
+   "read_only": 1,
+   "depends_on": "trashed"
+  },
+  {
+   "fieldname": "trashed_by",
+   "fieldtype": "Link",
+   "options": "User",
+   "label": "Trashed By",
+   "read_only": 1,
+   "depends_on": "trashed"
   }
  ],
  "links": [],

--- a/suite/sheets/trash.py
+++ b/suite/sheets/trash.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 import frappe
-from frappe.utils import now_datetime
+from frappe.utils import get_datetime, now_datetime
 
 DEFAULT_RETENTION_DAYS = 30
 MIN_RETENTION_DAYS = 1
@@ -63,7 +63,17 @@ def purge_trashed_sheets() -> dict:
 		filters={"trashed": 1, "trashed_on": ["<", cutoff]},
 		pluck="name",
 	)
+	purged = 0
 	for name in expired:
+		# Re-check current state before erasing. The snapshot above is a moment
+		# in time; a restore — or a restore-then-retrash with a fresh timestamp —
+		# may have landed since. Never purge a sheet the user just recovered.
+		row = frappe.db.get_value("Sheet", name, ["trashed", "trashed_on"], as_dict=True)
+		if not row or not row.trashed or not row.trashed_on:
+			continue
+		if get_datetime(row.trashed_on) >= cutoff:
+			continue
 		hard_delete_sheet(name)
 		frappe.db.commit()
-	return {"purged": len(expired)}
+		purged += 1
+	return {"purged": purged}

--- a/suite/sheets/trash.py
+++ b/suite/sheets/trash.py
@@ -1,0 +1,69 @@
+"""Sheet trash lifecycle: soft-delete retention and permanent purge.
+
+`delete_sheet` no longer destroys a Sheet — it flags it `trashed` so the owner
+can restore it (see :mod:`suite.sheets.api`). This module owns the two ends that
+flag implies:
+
+  * ``hard_delete_sheet`` — the actual cascade that erases a Sheet and its
+    versioning tables. Called by the user-facing "delete forever" endpoint and
+    by the nightly purge. Kept here (not in the API) so both paths share one
+    definition of "gone".
+
+  * ``purge_trashed_sheets`` — the scheduled job that permanently removes
+    sheets trashed longer than the retention window.
+
+Retention defaults to 30 days (matching Google Drive / Figma / iCloud), and is
+overridable per-site via ``sheets_trash_retention_days`` in site_config. The
+floor of 1 day stops a misconfigured ``0`` from turning the trash back into an
+instant hard delete.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import frappe
+from frappe.utils import now_datetime
+
+DEFAULT_RETENTION_DAYS = 30
+MIN_RETENTION_DAYS = 1
+
+
+def retention_days() -> int:
+	configured = frappe.conf.get("sheets_trash_retention_days")
+	if configured is None:
+		return DEFAULT_RETENTION_DAYS
+	return max(MIN_RETENTION_DAYS, int(configured))
+
+
+def hard_delete_sheet(name: str) -> None:
+	"""Permanently erase a Sheet and its versioning tables, in dependency order.
+
+	Frappe's default link enforcement blocks deletion while child rows exist, so
+	the head pointer is cleared first and the child tables are dropped directly
+	before the parent doc. This is the original `delete_sheet` cascade, moved
+	here so the "delete forever" endpoint and the purge job stay in lockstep.
+	"""
+	frappe.db.set_value("Sheet", name, "head_snapshot", None, update_modified=False)
+	frappe.db.delete("Sheet Snapshot", {"sheet": name})
+	frappe.db.delete("Sheet Op Log",   {"sheet": name})
+	frappe.db.delete("Sheet Seq",      {"sheet": name})
+	frappe.delete_doc("Sheet", name, ignore_permissions=True)
+
+
+def purge_trashed_sheets() -> dict:
+	"""Permanently delete sheets trashed longer than the retention window.
+
+	Idempotent and safe to re-run. Commits per sheet so a mid-run failure
+	doesn't strand progress. Returns a counter for telemetry.
+	"""
+	cutoff = now_datetime() - timedelta(days=retention_days())
+	expired = frappe.get_all(
+		"Sheet",
+		filters={"trashed": 1, "trashed_on": ["<", cutoff]},
+		pluck="name",
+	)
+	for name in expired:
+		hard_delete_sheet(name)
+		frappe.db.commit()
+	return {"purged": len(expired)}


### PR DESCRIPTION
## What

Deleting a sheet is currently an irreversible hard delete — the Sheet row and its entire versioning history (Sheet Snapshot / Op Log / Seq) are wiped, and there's no user-facing recovery. Non-admin users have no way to get a sheet back.

This adds a **Trash** with recovery, modelled on Google Drive / Figma (30-day retention).

## How

**Soft delete instead of destroy.** `delete_sheet` now flags the sheet (`trashed` / `trashed_on` / `trashed_by`) instead of erasing it, keeping the full snapshot + op-log history intact — so a restore is an *exact* restore, not a last-save recovery.

- Trashed sheets are filtered out of `list_sheets` and refuse to open via `get_sheet` (blocks bookmarked links).
- New endpoints: `restore_sheet`, `delete_sheet_permanent`, `list_trash`.
- The hard-delete cascade moved to `suite/sheets/trash.py` so "delete forever" and the nightly purge share one definition of "gone".
- `purge_trashed_sheets` runs on the daily scheduler, erasing sheets trashed past the retention window.
- **Owner-only:** the `delete` perm gate is `if_owner`, so a shared collaborator can't trash someone else's sheet.

**Retention:** 30 days by default, overridable per-site via `sheets_trash_retention_days` in site_config, floored at 1 day so a misconfigured `0` can't reintroduce instant hard delete.

**Frontend:** a new Trash page (Restore / Delete-forever) reachable from a `⋮` overflow menu on Home; delete dialog copy updated from "permanently deleted" → "moved to Trash". The retention window shown in the Trash header comes from the server so it stays accurate.

## Testing

The full lifecycle was exercised server-side on the standalone equivalent: create → trash (hidden from list, present in trash, `get_sheet` blocked) → restore (back in list) → permanent delete (gone) → purge with a back-dated `trashed_on` (`{'purged': 1}`). All assertions passed.

## Notes

- Ported from the standalone `frappe/sheets` repo (same change, suite paths + `suite.sheets.*` module names). Needs a `bench migrate` to add the three Sheet fields.
- An unrelated filter-range-highlight change that rode along on the standalone branch is intentionally **not** included here — it can be a separate PR to keep this one focused.