### PR TITLE
feat(mail): All Inboxes — unified inbox across all accounts

### DIFF
--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -374,25 +374,23 @@ const sidebarItems = computed(() => {
 		{ label: __('Custom'), items: customItems },
 		{ label: __('People'), items: contactsItems },
 	]
-	// Screener is its own nameless group, pinned first — only when screening is enabled.
-	if (screenerItem && screeningEnabled.value)
-		groups.unshift({ label: '', items: [screenerItem] })
 
-	// All Inboxes: a unified view of every account's Inbox, pinned above everything else. Only shown
-	// when the user has more than one account (otherwise it just mirrors their single inbox).
+	// All Inboxes and Screener share one nameless group pinned above the folders, so they sit at
+	// item spacing (not the wider section gap two separate groups would create). All Inboxes first
+	// (broadest scope: all accounts), then Screener (active account). Each is conditional:
+	// All Inboxes only with more than one account, Screener only when screening is enabled.
+	const pinnedItems = []
 	if (user.data.accounts?.length > 1)
-		groups.unshift({
-			label: '',
-			items: [
-				{
-					label: __('All Inboxes'),
-					icon: Mails,
-					to: { name: 'mail-all-inboxes' },
-					activeFor: ['mail-all-inboxes'],
-					suffix: allInboxesUnread.data ? String(allInboxesUnread.data) : '',
-				},
-			],
+		pinnedItems.push({
+			label: __('All Inboxes'),
+			icon: Mails,
+			to: { name: 'mail-all-inboxes' },
+			activeFor: ['mail-all-inboxes'],
+			suffix: allInboxesUnread.data ? String(allInboxesUnread.data) : '',
 		})
+	if (screenerItem && screeningEnabled.value) pinnedItems.push(screenerItem)
+
+	if (pinnedItems.length) groups.unshift({ label: '', items: pinnedItems })
 
 	return groups
 })

--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -101,6 +101,7 @@ import Globe from '~icons/lucide/globe'
 import LayoutGrid from '~icons/lucide/layout-grid'
 import LogOut from '~icons/lucide/log-out'
 import Mailbox from '~icons/lucide/mailbox'
+import Mails from '~icons/lucide/mails'
 import Plus from '~icons/lucide/plus'
 import Settings from '~icons/lucide/settings'
 import Star from '~icons/lucide/star'
@@ -114,7 +115,7 @@ const { isSidebarOpen, closeSidebar } = useSidebar()
 const isSidebarCollapsed = useStorage('isSidebarCollapsed', false)
 const { logout, branding } = sessionStore()
 const store = userStore()
-const { mailboxes } = store
+const { mailboxes, allInboxesUnread } = store
 
 const user = inject('$user')
 
@@ -376,6 +377,23 @@ const sidebarItems = computed(() => {
 	// Screener is its own nameless group, pinned first — only when screening is enabled.
 	if (screenerItem && screeningEnabled.value)
 		groups.unshift({ label: '', items: [screenerItem] })
+
+	// All Inboxes: a unified view of every account's Inbox, pinned above everything else. Only shown
+	// when the user has more than one account (otherwise it just mirrors their single inbox).
+	if (user.data.accounts?.length > 1)
+		groups.unshift({
+			label: '',
+			items: [
+				{
+					label: __('All Inboxes'),
+					icon: Mails,
+					to: { name: 'mail-all-inboxes' },
+					activeFor: ['mail-all-inboxes'],
+					suffix: allInboxesUnread.data ? String(allInboxesUnread.data) : '',
+				},
+			],
+		})
+
 	return groups
 })
 

--- a/frontend/src/apps/mail/components/MailListItem.vue
+++ b/frontend/src/apps/mail/components/MailListItem.vue
@@ -2,7 +2,11 @@
 	<router-link
 		:to="{
 			name: 'mail-mail',
-			params: { accountId: $route.params.accountId, mailbox, threadID: mail.thread_id },
+			params: {
+				accountId: accountId || $route.params.accountId,
+				mailbox,
+				threadID: mail.thread_id,
+			},
 			query: $route.query,
 		}"
 		class="sm:hover:bg-surface-gray-1 group flex cursor-default select-none space-x-2.5 border-b px-3.5 py-2.5 sm:space-x-5 sm:px-5"
@@ -22,7 +26,7 @@
 			:class="isFullWidth ? 'h-8' : 'h-10 sm:-mt-1.5'"
 		>
 			<div
-				v-if="!isMobile"
+				v-if="!isMobile && selectable"
 				class="checkbox-hitbox -m-3 cursor-pointer p-3"
 				@click.stop.prevent="emit('setSelected', !isSelected)"
 			>
@@ -36,7 +40,7 @@
 				<Check class="text-ink-base m-auto h-5 w-5 stroke-[3px]" />
 			</div>
 			<Avatar
-				v-show="!isSelected && isMobile"
+				v-show="!isSelected && (isMobile || !selectable)"
 				:label="getFirstAlphabet(mail.from_name) || getFirstAlphabet(mail.from_email)"
 				:image="mail.user_image"
 				size="xl"
@@ -61,6 +65,13 @@
 					>
 						{{ header }}
 					</h3>
+					<Badge
+						v-if="accountLabel"
+						size="sm"
+						:label="accountLabel"
+						theme="gray"
+						class="shrink-0"
+					/>
 					<Badge v-if="mail.draft" size="sm" :label="__('Draft')" theme="red" />
 				</div>
 				<MailDate v-if="!isFullWidth" :datetime="mail.received_at" :in-list="true" />
@@ -229,10 +240,24 @@ import MailListItemActions from '@/apps/mail/components/MailListItemActions.vue'
 
 import type { Attachment, Thread } from '@/apps/mail/types'
 
-const { mailbox, mail, isSelected } = defineProps<{
+const {
+	mailbox,
+	mail,
+	isSelected,
+	accountId,
+	accountLabel,
+	selectable = true,
+} = defineProps<{
 	mailbox: string
 	mail: Thread
 	isSelected: boolean
+	// Set by the All Inboxes view: the row's owning account (overrides the route's accountId in the
+	// thread link) and a short label chip identifying which account the mail belongs to.
+	accountId?: string
+	accountLabel?: string
+	// When false, the desktop selection checkbox is replaced by the sender avatar (the All Inboxes
+	// view has no cross-account bulk selection).
+	selectable?: boolean
 }>()
 
 const emit = defineEmits([

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -1,0 +1,377 @@
+<template>
+	<!-- Header -->
+	<header class="flex items-center justify-between border-b px-3 py-2.5 sm:px-5">
+		<div class="flex items-center space-x-2">
+			<Button v-if="isMobile" icon="menu" variant="ghost" @click="openSidebar" />
+			<Breadcrumbs :items="[{ label: __('All Inboxes'), route: { name: 'mail-all-inboxes' } }]" />
+		</div>
+		<HeaderActions @reload-mails="reload()" />
+	</header>
+
+	<div class="relative flex h-[calc(100dvh-3.05rem)]">
+		<!-- Loading -->
+		<div v-if="isLoading" class="flex w-full flex-col items-center justify-center">
+			<div class="text-ink-gray-5 flex items-center space-x-2">
+				<LoaderCircle class="h-5 w-5 animate-spin" />
+				<span>{{ __('Loading...') }}</span>
+			</div>
+		</div>
+
+		<template v-else-if="threads.data?.length">
+			<div ref="mailSidebar" class="sticky top-16 flex w-full flex-col border-r">
+				<!-- Toolbar -->
+				<div
+					class="relative flex items-center border-b border-l-transparent px-3.5 py-2.5 sm:border-l sm:px-5"
+				>
+					<Dropdown :options="FILTER_OPTIONS">
+						<button
+							class="text-ink-gray-8 hover:bg-surface-gray-2 -ml-2 flex min-w-0 items-center gap-1 rounded px-2 py-1"
+						>
+							<span class="truncate">{{ title }}</span>
+							<ChevronDown class="text-ink-gray-5 icon shrink-0" />
+						</button>
+					</Dropdown>
+					<Button
+						class="ml-1.5"
+						variant="ghost"
+						:tooltip="__('Refresh')"
+						:disabled="threads.loading"
+						@click="reload()"
+					>
+						<template #icon>
+							<RefreshCw class="icon" :class="{ 'animate-spin': threads.loading }" />
+						</template>
+					</Button>
+					<div class="-mr-1.5 ml-auto flex items-center space-x-1.5 sm:space-x-3">
+						<div v-if="displayTotal" class="text-ink-gray-6 flex items-center gap-1">
+							<span class="whitespace-nowrap text-sm tabular-nums">
+								{{ range }} {{ __('of') }} {{ totalLabel }}
+							</span>
+							<Button
+								:tooltip="__('Previous Page')"
+								variant="ghost"
+								:disabled="!canGoPrev"
+								@click="goToPage(false)"
+							>
+								<template #icon>
+									<ChevronLeft class="icon" />
+								</template>
+							</Button>
+							<Button
+								:tooltip="__('Next Page')"
+								variant="ghost"
+								:disabled="!canGoNext"
+								@click="goToPage(true)"
+							>
+								<template #icon>
+									<ChevronRight class="icon" />
+								</template>
+							</Button>
+						</div>
+					</div>
+
+					<!-- Loading bar -->
+					<div
+						v-if="threads.loading"
+						class="loading-bar pointer-events-none absolute bottom-[-1px] left-[-1px] right-0 h-0.5 overflow-hidden"
+						role="progressbar"
+						aria-busy="true"
+					>
+						<div
+							class="loading-bar__fill via-ink-gray-3 absolute inset-y-0 left-0 w-[30%] bg-gradient-to-r from-transparent to-transparent"
+						/>
+					</div>
+				</div>
+
+				<!-- Mail list -->
+				<div ref="mailList" class="h-full overflow-y-auto overscroll-contain">
+					<div v-for="(group, key) in groupedThreads" :key="key">
+						<div
+							v-if="groupMessagesBy !== 'None'"
+							class="text-ink-gray-6 flex items-center border-b border-l-transparent p-3.5 text-xs-semibold sm:border-l sm:px-5"
+						>
+							<span class="select-none pt-[2px]">
+								{{ getFormattedDate(key, groupMessagesBy === 'Month').toUpperCase() }}
+							</span>
+						</div>
+						<MailListItem
+							v-for="mail in group"
+							:key="`${mail.account}:${mail.thread_id}`"
+							:mailbox="mail.inbox || ''"
+							:account-id="mail.account"
+							:account-label="mail.account_name || undefined"
+							:mail
+							:is-selected="false"
+							:selectable="false"
+							class="border-l-transparent sm:border-l"
+							@set-seen="(seen: boolean) => handleSetSeen(mail, seen)"
+							@archive-thread="handleArchive(mail)"
+							@trash-thread="handleTrash(mail)"
+							@set-flagged="(flagged: boolean) => handleSetFlagged(mail, flagged)"
+						/>
+					</div>
+				</div>
+			</div>
+		</template>
+
+		<!-- No mails -->
+		<div v-else class="text-ink-gray-5 flex w-full flex-col items-center justify-center">
+			<NoMails class="text-ink-gray-2 mb-2 h-16 w-16" />
+			<p>{{ __('You have no mails in any inbox.') }}</p>
+			<Button
+				class="mt-3"
+				variant="ghost"
+				:label="__('Refresh')"
+				:disabled="threads.loading"
+				@click="reload()"
+			>
+				<template #prefix>
+					<RefreshCw class="icon" :class="{ 'animate-spin': threads.loading }" />
+				</template>
+			</Button>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, onMounted, onUnmounted, ref, useTemplateRef } from 'vue'
+import { useDebounceFn } from '@vueuse/core'
+import {
+	ChevronDown,
+	ChevronLeft,
+	ChevronRight,
+	LoaderCircle,
+	Mail as MailIcon,
+	Mails,
+	Paperclip,
+	RefreshCw,
+	Star,
+} from 'lucide-vue-next'
+import { Breadcrumbs, Button, Dropdown, createResource, usePageMeta } from 'frappe-ui'
+
+import { getFormattedDate, raisePromiseToast, raiseToast } from '@/apps/mail/utils'
+import { useScreenSize, useSidebar } from '@/apps/mail/utils/composables'
+import { userStore } from '@/apps/mail/stores/user'
+import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
+import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
+import MailListItem from '@/apps/mail/components/MailListItem.vue'
+
+import type { Thread, UserResource } from '@/apps/mail/types'
+
+const { isMobile } = useScreenSize()
+const { openSidebar } = useSidebar()
+
+const socket = inject('$socket')
+const user = inject('$user') as UserResource
+const dayjs = inject('$dayjs')
+
+const store = userStore()
+
+// Pagination (lookahead only — there's no cheap exact total across accounts, so the running count
+// gets a "+" suffix while a next page is detected, mirroring the mailbox view's filtered mode).
+const PAGE_LENGTH = 25
+const page = ref(0) // navigation target
+const displayedPage = ref(0) // page currently shown; lags `page` until its data loads
+const hasMore = ref(false) // an extra row was returned, so a next page exists
+const isLoaded = ref(false)
+const filter = ref<string | null>(
+	localStorage.getItem(`user:${user.data.name}:filter:all-inboxes`) || null,
+)
+
+const mailListRef = useTemplateRef('mailList')
+
+const threads = createResource({
+	url: 'suite.mail.api.mail.get_all_inbox_threads',
+	makeParams: () => ({
+		limit: PAGE_LENGTH + 1,
+		start: page.value * PAGE_LENGTH,
+		filter_by: filter.value,
+	}),
+	transform: (rows: Thread[]) => {
+		// Fetch one extra row to detect a next page without a total, then clip it from the display.
+		hasMore.value = rows.length > PAGE_LENGTH
+		return rows.slice(0, PAGE_LENGTH)
+	},
+	onSuccess: () => {
+		if (displayedPage.value !== page.value) {
+			displayedPage.value = page.value
+			mailListRef.value?.scrollTo({ top: 0 })
+		}
+		isLoaded.value = true
+	},
+	auto: true,
+})
+
+const isLoading = computed(() => !isLoaded.value && threads.loading)
+
+// After an action, refresh the sidebar counts: the active account's per-mailbox counts, which via the
+// store's mailboxes.onSuccess hook also refreshes the unified All Inboxes badge.
+const refreshCounts = () => store.mailboxes.reload()
+
+const reload = () => {
+	threads.reload()
+	refreshCounts()
+}
+
+// Pagination controls
+const threadsOnPage = computed(() => threads.data?.length ?? 0)
+const rangeEnd = computed(() => displayedPage.value * PAGE_LENGTH + threadsOnPage.value)
+const rangeStart = computed(() => (rangeEnd.value === 0 ? 0 : displayedPage.value * PAGE_LENGTH + 1))
+const range = computed(() =>
+	rangeStart.value === rangeEnd.value
+		? `${rangeStart.value}`
+		: `${rangeStart.value}–${rangeEnd.value}`,
+)
+const displayTotal = computed(() => rangeEnd.value)
+const totalLabel = computed(() => `${rangeEnd.value}${hasMore.value ? '+' : ''}`)
+
+const canGoPrev = computed(() => page.value > 0)
+const canGoNext = computed(() => hasMore.value && page.value === displayedPage.value)
+
+const navigate = useDebounceFn(() => threads.reload(), 250)
+
+const goToPage = (next: boolean) => {
+	if (next ? !canGoNext.value : !canGoPrev.value) return
+	page.value += next ? 1 : -1
+	navigate()
+}
+
+// Date grouping (headers only — no collapsing, unlike the per-mailbox view)
+const groupMessagesBy = computed(() => user.data.group_messages_by)
+
+const groupedThreads = computed<Record<string, Thread[]>>(() =>
+	(threads.data ?? []).reduce((groups: Record<string, Thread[]>, thread: Thread) => {
+		const date = dayjs(thread.received_at).format(
+			groupMessagesBy.value === 'Day' ? 'YYYY-MM-DD' : 'YYYY-MM',
+		)
+		if (!groups[date]) groups[date] = []
+		groups[date].push(thread)
+		return groups
+	}, {}),
+)
+
+// Per-item actions — each row carries its own account + that account's mailbox ids, so actions target
+// the correct JMAP account without touching the active-account state.
+const messageIds = (thread: Thread) => (thread.messages ?? []).map((m) => m.id)
+
+const removeFromList = (thread: Thread) => {
+	threads.data = threads.data?.filter(
+		(t: Thread) => !(t.thread_id === thread.thread_id && t.account === thread.account),
+	)
+}
+
+const setSeen = createResource({ url: 'suite.mail.api.mail.set_mails_seen' })
+const setFlagged = createResource({ url: 'suite.mail.api.mail.set_flagged' })
+const moveMails = createResource({ url: 'suite.mail.api.mail.move_mails' })
+
+const handleSetSeen = (thread: Thread, seen: boolean) => {
+	if (thread.seen === (seen ? 1 : 0)) return
+	thread.seen = seen ? 1 : 0
+	thread.messages?.forEach((m) => (m.seen = seen ? 1 : 0))
+	setSeen.submit({ account: thread.account, ids: messageIds(thread), seen }).then(refreshCounts)
+}
+
+const handleSetFlagged = (thread: Thread, flagged: boolean) => {
+	thread.flagged = flagged ? 1 : 0
+	setFlagged.submit({ account: thread.account, ids: [thread.id], flagged })
+}
+
+const handleArchive = (thread: Thread) => {
+	if (!thread.archive) return raiseToast(__('No Archive folder for this account.'), 'error')
+	removeFromList(thread)
+	raisePromiseToast(
+		() =>
+			moveMails
+				.submit({
+					account: thread.account,
+					ids: messageIds(thread),
+					mailbox: thread.archive,
+					clear_junk: true,
+				})
+				.then(reload),
+		__('Archiving...'),
+		__('Thread archived.'),
+	)
+}
+
+const handleTrash = (thread: Thread) => {
+	if (!thread.trash) return raiseToast(__('No Trash folder for this account.'), 'error')
+	removeFromList(thread)
+	raisePromiseToast(
+		() =>
+			moveMails
+				.submit({
+					account: thread.account,
+					ids: messageIds(thread),
+					mailbox: thread.trash,
+					clear_junk: true,
+				})
+				.then(reload),
+		__('Moving to Trash...'),
+		__('Thread moved to Trash.'),
+	)
+}
+
+// Filter
+const FILTER_OPTIONS = [
+	{ label: __('All'), icon: Mails, onClick: () => setFilter(null) },
+	{ label: __('Unread'), icon: MailIcon, onClick: () => setFilter('unread') },
+	{ label: __('Starred'), icon: Star, onClick: () => setFilter('starred') },
+	{ label: __('Has attachments'), icon: Paperclip, onClick: () => setFilter('has_attachments') },
+]
+
+const setFilter = (value: string | null) => {
+	filter.value = value
+	localStorage.setItem(`user:${user.data.name}:filter:all-inboxes`, value ?? '')
+	page.value = 0
+	threads.reload()
+}
+
+const title = computed(() => {
+	switch (filter.value) {
+		case 'unread':
+			return __('Unread Mails')
+		case 'starred':
+			return __('Starred Mails')
+		case 'has_attachments':
+			return __('With Attachments')
+		default:
+			return __('All Mails')
+	}
+})
+
+const unreadPrefix = computed(() =>
+	store.allInboxesUnread.data ? `(${store.allInboxesUnread.data})` : '',
+)
+
+usePageMeta(() => ({ title: `${unreadPrefix.value} ${__('All Inboxes')}` }))
+
+// Keep the merged list fresh: poll periodically and react to new-mail push events (which can arrive
+// for any account). Both are cheap reloads of the current page.
+const reloadInterval = ref<ReturnType<typeof setInterval>>()
+
+onMounted(() => {
+	reloadInterval.value = setInterval(reload, 30000)
+	socket.on('new_mail_created', reload)
+})
+
+onUnmounted(() => {
+	if (reloadInterval.value) clearInterval(reloadInterval.value)
+	socket.off('new_mail_created', reload)
+})
+</script>
+
+<style scoped>
+.loading-bar__fill {
+	animation: loading-bar-slide 1.2s linear infinite;
+}
+
+@keyframes loading-bar-slide {
+	0% {
+		transform: translateX(-100%);
+	}
+	100% {
+		transform: translateX(333%);
+	}
+}
+</style>

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -147,7 +147,7 @@ import {
 	RefreshCw,
 	Star,
 } from 'lucide-vue-next'
-import { Breadcrumbs, Button, Dropdown, createResource, usePageMeta } from 'frappe-ui'
+import { Breadcrumbs, Button, Dropdown, call, createResource, usePageMeta } from 'frappe-ui'
 
 import { getFormattedDate, raisePromiseToast, raiseToast } from '@/apps/mail/utils'
 import { useScreenSize, useSidebar } from '@/apps/mail/utils/composables'
@@ -260,35 +260,59 @@ const removeFromList = (thread: Thread) => {
 	)
 }
 
-const setSeen = createResource({ url: 'suite.mail.api.mail.set_mails_seen' })
-const setFlagged = createResource({ url: 'suite.mail.api.mail.set_flagged' })
-const moveMails = createResource({ url: 'suite.mail.api.mail.move_mails' })
-
+// Each action is a stateless one-shot `call()` rather than a shared createResource: rows act on
+// different accounts/threads and can be fired in rapid succession, so every invocation must be a
+// fully independent request. A shared resource carries a single reactive state slot (and one abort
+// controller); call() has no shared state, so concurrent row actions can never clobber one another.
 const handleSetSeen = (thread: Thread, seen: boolean) => {
 	if (thread.seen === (seen ? 1 : 0)) return
-	thread.seen = seen ? 1 : 0
-	thread.messages?.forEach((m) => (m.seen = seen ? 1 : 0))
-	setSeen.submit({ account: thread.account, ids: messageIds(thread), seen }).then(refreshCounts)
+	const applySeen = (value: 0 | 1) => {
+		thread.seen = value
+		thread.messages?.forEach((m) => (m.seen = value))
+	}
+	applySeen(seen ? 1 : 0)
+	call('suite.mail.api.mail.set_mails_seen', {
+		account: thread.account,
+		ids: messageIds(thread),
+		seen,
+	})
+		.then(refreshCounts)
+		.catch((error) => {
+			applySeen(seen ? 0 : 1) // revert the optimistic update
+			raiseToast(error?.messages?.[0] || error?.message, 'error')
+		})
 }
 
 const handleSetFlagged = (thread: Thread, flagged: boolean) => {
 	thread.flagged = flagged ? 1 : 0
-	setFlagged.submit({ account: thread.account, ids: [thread.id], flagged })
+	call('suite.mail.api.mail.set_flagged', {
+		account: thread.account,
+		ids: [thread.id],
+		flagged,
+	}).catch((error) => {
+		thread.flagged = flagged ? 0 : 1 // revert the optimistic update
+		raiseToast(error?.messages?.[0] || error?.message, 'error')
+	})
 }
+
+// Optimistically drop the row, then move on the server. Reload on both outcomes so a failure restores
+// the true list (the row reappears); rethrow on failure so the toast reports the error, not success.
+const moveThreadOut = (thread: Thread, mailbox: string) =>
+	call('suite.mail.api.mail.move_mails', {
+		account: thread.account,
+		ids: messageIds(thread),
+		mailbox,
+		clear_junk: true,
+	}).then(reload, (error) => {
+		reload()
+		throw error
+	})
 
 const handleArchive = (thread: Thread) => {
 	if (!thread.archive) return raiseToast(__('No Archive folder for this account.'), 'error')
 	removeFromList(thread)
 	raisePromiseToast(
-		() =>
-			moveMails
-				.submit({
-					account: thread.account,
-					ids: messageIds(thread),
-					mailbox: thread.archive,
-					clear_junk: true,
-				})
-				.then(reload),
+		() => moveThreadOut(thread, thread.archive!),
 		__('Archiving...'),
 		__('Thread archived.'),
 	)
@@ -298,15 +322,7 @@ const handleTrash = (thread: Thread) => {
 	if (!thread.trash) return raiseToast(__('No Trash folder for this account.'), 'error')
 	removeFromList(thread)
 	raisePromiseToast(
-		() =>
-			moveMails
-				.submit({
-					account: thread.account,
-					ids: messageIds(thread),
-					mailbox: thread.trash,
-					clear_junk: true,
-				})
-				.then(reload),
+		() => moveThreadOut(thread, thread.trash!),
 		__('Moving to Trash...'),
 		__('Thread moved to Trash.'),
 	)

--- a/frontend/src/apps/mail/routes.ts
+++ b/frontend/src/apps/mail/routes.ts
@@ -97,6 +97,11 @@ export const routes: RouteRecordRaw[] = [
 		component: () => import('@/apps/mail/pages/MailLayout.vue'),
 		children: [
 			{
+				path: 'all-inboxes',
+				name: 'mail-all-inboxes',
+				component: () => import('@/apps/mail/pages/AllInboxesView.vue'),
+			},
+			{
 				path: 'account/:accountId/mailbox/:mailbox',
 				name: 'mail-mailbox',
 				component: () => import('@/apps/mail/pages/MailboxView.vue'),

--- a/frontend/src/apps/mail/stores/user.ts
+++ b/frontend/src/apps/mail/stores/user.ts
@@ -50,6 +50,8 @@ export const userStore = defineStore('mail-user', () => {
 		url: 'suite.mail.api.account.get_user_info',
 		onSuccess: (data) => {
 			if (data?.is_mail_admin) domains.fetch()
+			// The unified All Inboxes badge only applies when there's more than one account to merge.
+			if ((data?.accounts?.length ?? 0) > 1) allInboxesUnread.fetch()
 			resolveAccount(data?.accounts)
 		},
 		onError: (error) => {
@@ -59,10 +61,22 @@ export const userStore = defineStore('mail-user', () => {
 		auto: true,
 	})
 
+	// Total unread across every account's Inbox — drives the "All Inboxes" sidebar badge. Not scoped to
+	// the active account, so (unlike the per-account resources) it isn't re-fetched in setAccount().
+	const allInboxesUnread = createResource({ url: 'suite.mail.api.mail.get_all_inbox_unread_count' })
+
+	// Keep the unified badge in step with the per-account mailbox counts: refresh it whenever the active
+	// account's mailboxes reload — i.e. after any thread action (read, move, archive, trash, …) and on
+	// the periodic poll, since every one of those calls mailboxes.reload(). Only relevant with >1 account.
+	const reloadAllInboxesUnread = () => {
+		if ((userResource.data?.accounts?.length ?? 0) > 1) allInboxesUnread.reload()
+	}
+
 	const mailboxes = createResource({
 		url: 'suite.mail.api.mail.get_mailboxes',
 		makeParams: () => ({ account: accountId.value }),
 		cache: ['mailboxes', accountId.value],
+		onSuccess: reloadAllInboxesUnread,
 	})
 
 	const mailboxIds = computed(() => {
@@ -124,6 +138,7 @@ export const userStore = defineStore('mail-user', () => {
 		screenedAddresses.reset()
 		sieveScripts.reset()
 		domains.reset()
+		allInboxesUnread.reset()
 	}
 
 	return {
@@ -137,6 +152,7 @@ export const userStore = defineStore('mail-user', () => {
 		domains,
 		sieveScripts,
 		screenedAddresses,
+		allInboxesUnread,
 		reset,
 	}
 })

--- a/frontend/src/apps/mail/types/index.ts
+++ b/frontend/src/apps/mail/types/index.ts
@@ -156,6 +156,13 @@ export interface ComposeMailData {
 export interface Thread {
 	name: string
 	account: string
+	// Populated only by the All Inboxes view (get_all_inbox_threads): the owning account's display
+	// name and its Inbox/Archive/Trash mailbox ids, so a merged row can be opened in / acted on
+	// within the correct JMAP account.
+	account_name?: string
+	inbox?: string
+	archive?: string
+	trash?: string
 	id: string
 	thread_id: string
 	from_name: string

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -9,7 +9,7 @@ import pydenticon
 import requests
 from frappe import _
 from frappe.model.document import bulk_insert
-from frappe.utils import format_datetime, random_string
+from frappe.utils import cint, format_datetime, random_string
 
 from suite.mail.api.contacts import create_contacts_if_not_exists
 from suite.mail.api.utils import get_avatar_url
@@ -52,6 +52,7 @@ from suite.mail.jmap import (
 	get_email_service,
 	get_mailbox_id_by_name,
 	get_mailbox_id_by_role,
+	get_mailbox_service,
 )
 from suite.mail.utils import convert_html_to_text, get_config, log_error
 from suite.mail.utils.user import get_account_emails, is_jmap_configured
@@ -239,6 +240,88 @@ def get_threads(account: str, mailbox: str, limit: int, start: int = 0, filter_b
 	add_user_images_to_emails(account, [m for thread in threads for m in thread["messages"]], is_thread=True)
 
 	return threads, mailbox
+
+
+def get_user_jmap_accounts() -> list[dict]:
+	"""Return the current user's JMAP accounts (id + display name), personal first.
+
+	Ordered personal-first, then by name, so the merged All Inboxes list has a stable tie-break when
+	two accounts have threads at the same timestamp.
+	"""
+
+	account_names = frappe.db.get_all("User Account", {"user": frappe.session.user}, pluck="account")
+	if not account_names:
+		return []
+
+	accounts = frappe.db.get_all(
+		"JMAP Account",
+		filters={"name": ["in", account_names]},
+		fields=["name", "_name", "is_personal"],
+	)
+	accounts.sort(key=lambda a: (not a["is_personal"], a["_name"] or ""))
+	return accounts
+
+
+@frappe.whitelist()
+def get_all_inbox_threads(limit: int, start: int = 0, filter_by: str | None = None) -> list:
+	"""Returns a merged, newest-first page of Inbox threads across all of the user's accounts.
+
+	Each thread is tagged with its owning account (`account`, `account_name`) and that account's
+	Inbox/Archive/Trash mailbox ids, so the client can open it in — and act on it within — the correct
+	JMAP account. Every account is over-fetched to `start + limit` (the deepest global position this
+	page can reach), the results are merged, sorted newest-first, then sliced to the requested window.
+	"""
+
+	accounts = get_user_jmap_accounts()
+	if not accounts:
+		return []
+
+	per_account_limit = start + limit
+	merged: list[dict] = []
+	for account in accounts:
+		account_id = account["name"]
+		inbox_id = get_mailbox_id_by_role(account_id, "inbox")
+		if not inbox_id:
+			continue
+
+		threads, _mailbox = get_threads(account_id, inbox_id, per_account_limit, 0, filter_by)
+		if not threads:
+			continue
+
+		# Attach once per account (role lookups are cached) so per-item actions can target the right
+		# mailbox without another round trip.
+		archive_id = get_mailbox_id_by_role(account_id, "archive")
+		trash_id = get_mailbox_id_by_role(account_id, "trash")
+		for thread in threads:
+			thread["account"] = account_id
+			thread["account_name"] = account["_name"]
+			thread["inbox"] = inbox_id
+			thread["archive"] = archive_id
+			thread["trash"] = trash_id
+		merged.extend(threads)
+
+	merged.sort(key=lambda thread: thread["received_at"], reverse=True)
+	return merged[start : start + limit]
+
+
+@frappe.whitelist()
+def get_all_inbox_unread_count() -> int:
+	"""Returns the total unread Inbox thread count across all of the user's accounts (sidebar badge).
+
+	Mailbox is a JMAP-backed virtual DocType, so it can't be queried across accounts with a table
+	filter. Each account's Inbox unread count is fetched live via the mailbox service (a fresh
+	Mailbox/get, bypassing the 1-hour `.mailboxes` cache) — the same source the per-account inbox
+	badge uses — and summed.
+	"""
+
+	total = 0
+	for account in get_user_jmap_accounts():
+		for mailbox in get_mailbox_service(account["name"]).get():
+			if (mailbox.get("role") or "").lower() == "inbox":
+				total += cint(mailbox.get("unreadThreads"))
+				break
+
+	return total
 
 
 @frappe.whitelist()

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -61,6 +61,12 @@ from suite.mail.utils.validation import normalize_screened_value, validate_scree
 AVATAR_CACHE_TTL = 60 * 60 * 24
 SCREENING_FETCH_LIMIT = 500
 
+# All Inboxes bounds. limit/start are user-supplied, and per_account_limit (= start + limit) is fetched
+# from *every* account and merged in memory, so both are clamped. MAX_FETCH caps the deepest reachable
+# position (page length ~25 → ~20 pages), which is far beyond any real unified-inbox scroll.
+ALL_INBOX_MAX_LIMIT = 100
+ALL_INBOX_MAX_FETCH = 500
+
 
 @frappe.whitelist()
 def get_mailboxes(account: str) -> list[dict]:
@@ -276,7 +282,13 @@ def get_all_inbox_threads(limit: int, start: int = 0, filter_by: str | None = No
 	if not accounts:
 		return []
 
+	# Clamp user input before it fans out across accounts: limit to a sane page size, and start so the
+	# per-account fetch (start + limit) can never exceed ALL_INBOX_MAX_FETCH — bounding both the JMAP
+	# fetch per account and the in-memory merge, regardless of what the client sends.
+	limit = min(max(cint(limit), 1), ALL_INBOX_MAX_LIMIT)
+	start = min(max(cint(start), 0), ALL_INBOX_MAX_FETCH - limit)
 	per_account_limit = start + limit
+
 	merged: list[dict] = []
 	for account in accounts:
 		account_id = account["name"]


### PR DESCRIPTION
Closes #70

## What

Adds an **All Inboxes** page that merges the Inbox of every linked account into a single, newest-first list — so personal and shared/group accounts can be viewed together without switching accounts.

## How

**Backend** (`suite/mail/api/mail.py`)
- `get_all_inbox_threads()` — fans out per account, tags each thread with its owning account and that account's `inbox`/`archive`/`trash` mailbox ids, then merges, sorts newest-first, and paginates.
- `get_all_inbox_unread_count()` — sums each account's **live** Inbox unread count (a fresh `Mailbox/get`, since `Mailbox` is a JMAP-backed virtual DocType and can't be queried across accounts with a table filter).

**Frontend**
- New `AllInboxesView` — merged list with date grouping, filters (All / Unread / Starred / Attachments) and pagination. Per-row quick actions (read/unread, star, archive, trash) act on each row's **own** account; clicking a mail opens it in that account's normal reader.
- Sidebar **All Inboxes** entry with an unread badge, pinned at the top and shown only when the user has more than one account.
- `MailListItem` gains optional `accountId` / `accountLabel` / `selectable` props to support the cross-account list.
- The unified badge and the per-account counts refresh together after any action (read, move, archive, trash) and on poll, via a shared `mailboxes.onSuccess` hook in the user store.

## Notes / follow-ups
- Scope is a unified **list** with per-item actions that open threads in-account (no cross-account bulk selection / inline reading pane) — the low-risk 90% of the value; a full unified inbox can follow.
- The unread count is one live JMAP `Mailbox/get` per account per refresh. If that becomes heavy with many accounts, batching all accounts into a single JMAP request is the optimization to pursue.

## Testing
- Frontend production build passes; backend passes `py_compile` + `ruff`.
- Needs a manual pass on a multi-account user (Stalwart/JMAP): verify merged ordering, that clicking a row opens the correct account, and that quick actions + counts update correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)