### PR TITLE
feat(mail): replace mailbox pagination with infinite scroll

### DIFF
--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -4,7 +4,6 @@
 			v-if="!readonly"
 			:threads
 			:thread
-			:can-go-prev="canGoPrev"
 			:can-go-next="canGoNext"
 			@set-flagged="(ids: string[], flagged: boolean) => emit('setFlagged', ids, flagged)"
 			@set-seen="setThreadSeen"
@@ -416,12 +415,11 @@ import type {
 	ScreenedAddress,
 } from '@/apps/mail/types'
 
-const { mailbox, threadID, threads, messages, canGoPrev, canGoNext, readonly } = defineProps<{
+const { mailbox, threadID, threads, messages, canGoNext, readonly } = defineProps<{
 	mailbox: string
 	threadID?: string
 	threads: string[]
 	messages?: Mail[]
-	canGoPrev?: boolean
 	canGoNext?: boolean
 	// Read-only thread (e.g. the Screener): renders the messages but hides every action — the thread
 	// toolbar, per-message actions, the block banner and the reply/forward bar — and never marks read.

--- a/frontend/src/apps/mail/components/ThreadHeader.vue
+++ b/frontend/src/apps/mail/components/ThreadHeader.vue
@@ -63,7 +63,7 @@
 					<Button
 						variant="ghost"
 						:tooltip="__('Previous Thread (↑/K)')"
-						:disabled="threadID === threads[0] && !canGoPrev"
+						:disabled="threadID === threads[0]"
 						@click="emit('prevThread')"
 					>
 						<template #icon>
@@ -115,10 +115,9 @@ import { userStore } from '@/apps/mail/stores/user'
 
 import type { Mail, MailboxData } from '@/apps/mail/types'
 
-const { thread, threads, canGoPrev, canGoNext } = defineProps<{
+const { thread, threads, canGoNext } = defineProps<{
 	thread: Mail[]
 	threads: string[]
-	canGoPrev?: boolean
 	canGoNext?: boolean
 }>()
 const emit = defineEmits([

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -12,12 +12,12 @@
 				]"
 			/>
 		</div>
-		<HeaderActions @reload-mails="reloadThreads(true, ['drafts', 'sent'])" />
+		<HeaderActions @reload-mails="resetThreads(true, ['drafts', 'sent'])" />
 	</header>
 
 	<!-- Unscreened-thread nudge on the inbox, mirroring the trash/junk info bar: shown while Hey-style
 	     screening is on and threads are waiting to be screened. -->
-	<div v-if="showScreenerBanner" class="space-x-1 border-b px-3 py-2.5 sm:px-5">
+	<div v-if="showScreenerBanner" class="space-x-1 border-b py-2.5 px-5">
 		<span class="text-ink-gray-5">{{ screenerBannerLabel }}</span>
 		<Button :label="__('Review Now')" variant="ghost" @click="goToScreener" />
 	</div>
@@ -95,52 +95,19 @@
 						</button>
 					</Dropdown>
 					<p v-else class="pb-[2px]">{{ title }}</p>
-					<Button
-						v-if="!selections.length"
-						class="ml-1.5"
-						variant="ghost"
-						:tooltip="__('Refresh')"
-						:disabled="threadsResource?.loading"
-						@click="reloadThreads()"
-					>
-						<template #icon>
-							<RefreshCw
-								class="icon"
-								:class="{ 'animate-spin': threadsResource?.loading }"
-							/>
-						</template>
-					</Button>
 					<div class="-mr-1.5 ml-auto flex items-center space-x-1.5 sm:space-x-3">
-						<div
-							v-if="!selections.length && displayTotal"
-							class="text-ink-gray-6 flex items-center gap-1"
+						<Button
+							v-if="!selections.length"
+							variant="ghost"
+							:tooltip="__('Refresh')"
+							:disabled="threadsResource?.loading"
+							@click="refreshThreads()"
 						>
-							<span class="whitespace-nowrap text-sm tabular-nums">
-								{{ range }} {{ __('of') }} {{ totalLabel }}
-							</span>
-							<Button
-								:tooltip="__('Previous Page')"
-								variant="ghost"
-								:disabled="!canGoPrev"
-								@click="goToPage(false)"
-							>
-								<template #icon>
-									<ChevronLeft class="icon" />
-								</template>
-							</Button>
-							<Button
-								:tooltip="__('Next Page')"
-								variant="ghost"
-								:disabled="!canGoNext"
-								@click="goToPage(true)"
-							>
-								<template #icon>
-									<ChevronRight class="icon" />
-								</template>
-							</Button>
-						</div>
-
-						<template v-else-if="selections.length">
+							<template #icon>
+								<RefreshCw class="icon" />
+							</template>
+						</Button>
+						<template v-if="selections.length">
 							<Dropdown v-if="showReadingPane" :options="selectActions">
 								<Button variant="ghost" :tooltip="__('Actions')">
 									<template #icon>
@@ -291,6 +258,13 @@
 							/>
 						</template>
 					</div>
+					<!-- Infinite-scroll sentinel: entering the viewport near the list bottom loads the next
+					     batch (appended, never refetching loaded rows). Sits after all groups so collapsing
+					     a group can't disable it. -->
+					<div ref="loadMoreSentinel" class="h-px" />
+					<div v-if="loadingMore" class="flex justify-center py-3">
+						<LoaderCircle class="text-ink-gray-5 h-4 w-4 animate-spin" />
+					</div>
 				</div>
 				<div v-else class="flex h-full items-center justify-center">
 					<p class="text-ink-gray-5">
@@ -321,9 +295,8 @@
 					:thread-i-d
 					:threads="threadIDs"
 					:messages="currentThread?.messages"
-					:can-go-prev="canGoPrev"
 					:can-go-next="canGoNext"
-					@reload-mails="reloadThreads"
+					@reload-mails="resetThreads"
 					@set-seen="
 						(seen: boolean, ids: string[]) =>
 							handleSetSeen({ [Number(seen)]: [threadID!] }, seen, ids)
@@ -366,18 +339,6 @@
 						: __('You have no mails in this folder.')
 				}}
 			</p>
-			<Button
-				v-if="mailbox !== 'search'"
-				class="mt-3"
-				variant="ghost"
-				:label="__('Refresh')"
-				:disabled="threadsResource?.loading"
-				@click="reloadThreads()"
-			>
-				<template #prefix>
-					<RefreshCw class="icon" :class="{ 'animate-spin': threadsResource?.loading }" />
-				</template>
-			</Button>
 		</div>
 	</div>
 
@@ -387,13 +348,12 @@
 	<ShortcutsModal v-model="showShortcuts" />
 </template>
 <script setup lang="ts">
-import { computed, inject, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
+import { computed, inject, nextTick, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { useDebounceFn } from '@vueuse/core'
+import { useIntersectionObserver } from '@vueuse/core'
 import {
 	Archive,
 	ChevronDown,
-	ChevronLeft,
 	ChevronRight,
 	CircleAlert,
 	CircleCheck,
@@ -712,9 +672,9 @@ const handleArrowNavigation = (e: KeyboardEvent, key: string) => {
 
 	let newThread = undefined
 
-	// Step across the page boundary at the first/last thread, like the ThreadHeader arrows.
-	// newThread stays the in-page target (undefined at an edge), so shift-select skips a
-	// cross-page move — the new page resolves asynchronously and goToPage resets selections.
+	// At the last loaded thread, stepping further loads the next window (like the ThreadHeader arrows).
+	// newThread stays the in-list target (undefined at the edge), so shift-select skips the crossing —
+	// the appended thread resolves asynchronously and a reset would clear selections anyway.
 	if (threadID) {
 		newThread = getThreadByOffset(offset)
 		goToThreadByOffset(offset)
@@ -838,12 +798,20 @@ const selectActions = computed((): SelectAction[] => [
 
 // Search
 
-// Pagination state (shared by the threads and search resources — only one is active at a time)
+// Infinite-scroll state (shared by the threads and search resources — only one is active at a time)
 const PAGE_LENGTH = 25
-const page = ref(0) // navigation target: the page being fetched
-const displayedPage = ref(0) // the page currently shown; lags `page` until its data loads
-const total = ref(0) // exact total matching the current view (search only)
-const hasMore = ref(false) // lookahead: an extra row was returned, so a next page exists
+const hasMore = ref(false) // lookahead: the last fetched window returned an extra row, so more exist
+const loadingMore = ref(false) // an append fetch is in flight (drives the bottom spinner)
+// Bumped on every reset-to-top; an in-flight append captures it and discards its result if it changed
+// meanwhile, so a stale window can't land on a freshly reset list.
+const epoch = ref(0)
+let loadEpoch = 0 // epoch captured when the current append was triggered
+// Refresh ("check for new mail") state: merges the newest window into the loaded list, preserving
+// scroll — set while such a reload is in flight so its onSuccess prepends instead of replacing.
+const refreshMode = ref(false)
+let refreshEpoch = 0 // epoch captured when the refresh was triggered (dropped if a reset intervenes)
+let refreshSnapshot: Thread[] = [] // the loaded list at refresh time, merged with the fresh window
+let refreshAnchor = { top: 0, height: 0 } // scroll position to re-anchor after prepending
 // Current mailbox's record (carries total_threads/unread_threads); used by the periodic poll to
 // detect count changes and by the tab title's unread badge.
 const mailboxObj = computed(() => mailboxes.data?.find((m) => m.id === mailbox))
@@ -873,30 +841,52 @@ const screenerBannerLabel = computed(() =>
 )
 const goToScreener = () => router.push({ name: 'mail-screener', params: { accountId } })
 
-// Called once a page's data has loaded: reveal it (range + list update together) and scroll to top.
-// No-op for same-page reloads (e.g. the periodic refresh) so those don't yank the scroll position.
-const syncDisplayedPage = () => {
-	if (displayedPage.value === page.value) return
-	displayedPage.value = page.value
-	mailListRef.value?.scrollTo({ top: 0 })
+const scrollListToTop = () => mailListRef.value?.scrollTo({ top: 0 })
+
+// Called when a first-window fetch resolves. Two modes:
+// - refresh: keep the loaded rows, prepend only threads not already loaded (new mail), and hold the
+//   reader's scroll position (re-anchored by the height the prepended rows added).
+// - reset: reveal the fresh first window and scroll to top (mailbox switch, filter, undo, …).
+// Either way, cancel any pending edge navigation.
+const onResetSuccess = () => {
+	pendingEdgeThread = null
+
+	if (refreshMode.value) {
+		refreshMode.value = false
+		// A reset (mailbox switch, filter, undo) raced in and bumped the epoch — drop this stale merge.
+		if (refreshEpoch !== epoch.value) return
+		const window = threadsResource.value.data ?? []
+		const existing = new Set(refreshSnapshot.map((t) => t.thread_id))
+		const fresh = window.filter((t: Thread) => !existing.has(t.thread_id))
+		threadsResource.value.data = [...fresh, ...refreshSnapshot]
+		// Keep the reader where they were: shift scroll by the height the prepended rows added. If they
+		// were already at the top, leave them there so the new mail is visible.
+		nextTick(() => {
+			const el = mailListRef.value
+			if (el && refreshAnchor.top > 0)
+				el.scrollTop = refreshAnchor.top + (el.scrollHeight - refreshAnchor.height)
+		})
+		return
+	}
+
+	scrollListToTop()
 }
 
+// Reset resource for search: always the first window, over-fetching one row to drive `hasMore`.
 const searchResults = createResource({
 	url: 'suite.mail.api.mail.search_mails',
 	makeParams: () => ({
 		account: store.accountId,
 		filter: route.query,
-		limit: PAGE_LENGTH,
-		start: page.value * PAGE_LENGTH,
+		limit: PAGE_LENGTH + 1,
+		start: 0,
 	}),
 	transform: (data: [Thread[], number]) => {
-		total.value = data[1]
-		return data[0]
+		hasMore.value = data[0].length > PAGE_LENGTH
+		return data[0].slice(0, PAGE_LENGTH)
 	},
-	onSuccess: (data: [Thread[], number]) => {
-		correctPageOverflow(data[0])
-		openPendingEdgeThread()
-		syncDisplayedPage()
+	onSuccess: () => {
+		onResetSuccess()
 		if (mailbox === 'search') isMailboxLoaded.value = true
 	},
 })
@@ -904,10 +894,7 @@ const searchResults = createResource({
 watch(
 	() => JSON.stringify(route.query),
 	() => {
-		if (mailbox === 'search') {
-			page.value = 0
-			searchResults.reload()
-		}
+		if (mailbox === 'search') resetThreads()
 	},
 )
 
@@ -918,124 +905,97 @@ const filter = ref<string | null>(
 )
 const isMailboxLoaded = ref(false)
 
+// Reset resource for a mailbox: always the first window. Over-fetches one row (PAGE_LENGTH + 1) to
+// detect whether more exist without relying on the (flaky) stored count.
 const threads = createResource({
 	url: 'suite.mail.api.mail.get_threads',
 	makeParams: () => ({
 		account: store.accountId,
 		mailbox,
 		limit: PAGE_LENGTH + 1,
-		start: page.value * PAGE_LENGTH,
+		start: 0,
 		filter_by: filter.value,
 	}),
 	transform: (data: [Thread[], string]) => {
 		const rows = data[0]
-		// This resource always fetches one extra row (PAGE_LENGTH + 1) to detect a next page without
-		// relying on the (flaky) stored count: clip the extra row from the display and record whether it
-		// was there. Drives `hasMore` for both plain and filtered mailboxes.
 		hasMore.value = rows.length > PAGE_LENGTH
 		return rows.slice(0, PAGE_LENGTH)
 	},
 	onSuccess: (data: [Thread[], string]) => {
-		correctPageOverflow(data[0])
-		openPendingEdgeThread()
-		syncDisplayedPage()
+		onResetSuccess()
 		if (mailbox === data[1]) isMailboxLoaded.value = true
 	},
 })
 
 const threadsResource = computed(() => (mailbox === 'search' ? searchResults : threads))
 
-// If a page ends up empty because threads were removed (e.g. deleted/moved), step back a page.
-// Decrementing one at a time is bounded by 0, so it can't loop even if `total` is stale.
-const correctPageOverflow = (pageData: Thread[]) => {
-	if (pageData.length || page.value === 0) return
-	page.value -= 1
-	threadsResource.value.reload()
+// ── Infinite scroll ─────────────────────────────────────────────────────────────────────────────
+// Two fetch paths that both write `threadsResource.value.data` — the single accumulated list every
+// consumer reads: the reset resources above replace it (start:0); the append resources below push the
+// next window onto it. Kept separate so createResource's replace-on-reload never fights the append.
+
+// Appends the next window onto the loaded list, deduped by thread_id. `start = data.length` stays
+// correct across optimistic removals (the server list shifts left by the same rows we dropped); the
+// only skew is new mail inserted at the front, which the dedupe absorbs and the next reset reconciles.
+const appendThreads = (rows: Thread[]) => {
+	loadingMore.value = false
+	// Discard a stale window that resolved after a reset began (mailbox switch, refresh, undo, …).
+	if (loadEpoch !== epoch.value) return
+	const seen = new Set(threadsResource.value.data.map((t: Thread) => t.thread_id))
+	const fresh = rows.slice(0, PAGE_LENGTH).filter((t) => !seen.has(t.thread_id))
+	// Stop auto-loading if the window added nothing new (offset stuck behind heavy front-inserted mail);
+	// the next reset (poll/refresh/socket) reconciles. Guards against a tight reload loop while the
+	// sentinel stays in view.
+	hasMore.value = rows.length > PAGE_LENGTH && fresh.length > 0
+	threadsResource.value.data = [...threadsResource.value.data, ...fresh]
+	openPendingEdgeThread()
 }
 
-const threadsOnPage = computed(() => threadsResource.value.data?.length ?? 0)
-
-// How the count *label* is resolved (pagination/range never depend on the stored count — see below):
-// - 'exact'     (search): the backend returns the exact total.
-// - 'mailbox'   (a plain mailbox, no filter): show the mailbox's stored thread count for the "of N".
-//   It's occasionally wrong (server `totalThreads` drops then self-heals), but it's the only cheap
-//   exact total we have, so we use it for the label only — never to drive fetching or navigation.
-// - 'lookahead' (a filtered mailbox or the cross-mailbox "starred" view): no cheap total exists, so
-//   we show the running count with a "+" suffix and only enable Next while a next page is detected.
-const countMode = computed<'exact' | 'mailbox' | 'lookahead'>(() => {
-	if (mailbox === 'search') return 'exact'
-	if (mailbox === 'starred' || filter.value) return 'lookahead'
-	return 'mailbox'
+const loadMoreThreads = createResource({
+	url: 'suite.mail.api.mail.get_threads',
+	makeParams: () => ({
+		account: store.accountId,
+		mailbox,
+		limit: PAGE_LENGTH + 1,
+		start: threadsResource.value.data.length,
+		filter_by: filter.value,
+	}),
+	onSuccess: (data: [Thread[], string]) => appendThreads(data[0]),
+	onError: () => (loadingMore.value = false),
 })
 
-// The stored thread count, shown as the "of N" total for a plain mailbox. Used for display only.
-const mailboxTotal = computed(() => mailboxObj.value?.total_threads ?? 0)
-
-// A *reliable* fixed total used to clamp the displayed range (so it never overshoots during a page
-// change, when the previous page's rows linger). Only search has one — the mailbox's `totalThreads`
-// is too flaky to clamp against, so plain/lookahead views derive the range from the loaded rows.
-const knownTotal = computed<number | null>(() =>
-	countMode.value === 'exact' ? total.value : null,
-)
-
-const rangeEnd = computed(() => {
-	// Based on the displayed (loaded) page, not the navigation target, so the range only moves once the
-	// new page's data arrives. For a known total, derive the end from the page bounds (clamped to the
-	// total) rather than the row count; the fetch is clamped to the same bound, so it matches the loaded
-	// page while staying stable during a page change, when the previous page's rows still linger.
-	if (knownTotal.value && knownTotal.value > 0) {
-		return Math.min((displayedPage.value + 1) * PAGE_LENGTH, knownTotal.value)
-	}
-	return displayedPage.value * PAGE_LENGTH + threadsOnPage.value
-})
-const rangeStart = computed(() =>
-	rangeEnd.value === 0 ? 0 : displayedPage.value * PAGE_LENGTH + 1,
-)
-// Collapse to a single number when the page holds one thread (e.g. "1" instead of "1–1").
-const range = computed(() =>
-	rangeStart.value === rangeEnd.value
-		? `${rangeStart.value}`
-		: `${rangeStart.value}–${rangeEnd.value}`,
-)
-const displayTotal = computed(() => {
-	if (countMode.value === 'lookahead') return rangeEnd.value
-	if (countMode.value === 'mailbox') return mailboxTotal.value
-	return knownTotal.value ?? 0 // exact
-})
-// In lookahead mode the count is a lower bound — show "n+" while a next page exists, else "n".
-const totalLabel = computed(() =>
-	countMode.value === 'lookahead'
-		? `${rangeEnd.value}${hasMore.value ? '+' : ''}`
-		: `${displayTotal.value}`,
-)
-
-// Whether a next page exists. When we have a total (search, or a plain mailbox), we compare the next
-// page's range against it so presses can be *queued* several pages ahead while a page is still
-// loading. A plain mailbox also keeps the extra-row probe (`hasMore`) as a fallback, so a transiently
-// low stored count can't strand the user mid-list — it still advances one page at a time (bounded to
-// the loaded page) until the count self-heals. Lookahead has no total, so it relies on the probe alone.
-const canGoPrev = computed(() => page.value > 0)
-// A next page exists if the next page's range fits within the total.
-const rangeHasNext = (total: number) => (page.value + 1) * PAGE_LENGTH < total
-// Fallback when the total is unreliable/absent: the extra-row probe, bounded to the loaded page.
-const probeHasNext = computed(() => hasMore.value && page.value === displayedPage.value)
-const canGoNext = computed(() => {
-	if (countMode.value === 'exact') return rangeHasNext(knownTotal.value ?? 0)
-	if (countMode.value === 'mailbox')
-		return rangeHasNext(mailboxTotal.value) || probeHasNext.value
-	return probeHasNext.value // lookahead
+const loadMoreSearch = createResource({
+	url: 'suite.mail.api.mail.search_mails',
+	makeParams: () => ({
+		account: store.accountId,
+		filter: route.query,
+		limit: PAGE_LENGTH + 1,
+		start: threadsResource.value.data.length,
+	}),
+	onSuccess: (data: [Thread[], number]) => appendThreads(data[0]),
+	onError: () => (loadingMore.value = false),
 })
 
-// Coalesce rapid Prev/Next presses: only the final target page is fetched, and the displayed page
-// (range + list) updates once it loads — intermediate pages are never shown.
-const navigate = useDebounceFn(() => threadsResource.value.reload(), 250)
-
-const goToPage = (next: boolean) => {
-	if (next ? !canGoNext.value : !canGoPrev.value) return
-	page.value += next ? 1 : -1
-	resetSelections()
-	navigate()
+const loadMore = () => {
+	if (!hasMore.value || loadingMore.value || threadsResource.value.loading) return
+	loadingMore.value = true
+	loadEpoch = epoch.value
+	;(mailbox === 'search' ? loadMoreSearch : loadMoreThreads).reload()
 }
+
+const loadMoreSentinel = useTemplateRef('loadMoreSentinel')
+useIntersectionObserver(
+	loadMoreSentinel,
+	([entry]) => {
+		if (entry?.isIntersecting) loadMore()
+	},
+	{ root: mailListRef },
+)
+
+// The reading pane's Next arrow can always advance while more threads remain to load (crossing the
+// last loaded thread triggers an append). The Prev arrow is disabled at the first loaded thread, which
+// is the first thread overall (we always start from the top).
+const canGoNext = computed(() => hasMore.value)
 
 const isLoading = computed(() => {
 	if (!isMailboxLoaded.value) return true
@@ -1047,15 +1007,74 @@ const threadIDs = computed(
 	() => threadsResource.value.data?.map((thread: Thread) => thread.thread_id) || [],
 )
 
-const reloadThreads: (reloadMailboxes?: boolean, mailboxRoles?: MailboxRole[]) => void = (
+// Reset-to-top: refetch only the first window, replacing the loaded list and scrolling to the top
+// (via onResetSuccess). Bumping `epoch` discards any append/refresh still in flight. Used for
+// mailbox/account switch, filter change, undo, and empty-mailbox.
+const resetThreads: (reloadMailboxes?: boolean, mailboxRoles?: MailboxRole[]) => void = (
 	reloadMailboxes = true,
 	mailboxRoles = [],
 ) => {
 	if (mailboxRoles.length && !mailboxRoles.map((m) => mailboxIds[m]).includes(mailbox)) return
 
+	refreshMode.value = false
+	epoch.value++
 	resetSelections()
 	threadsResource.value.reload()
 	if (reloadMailboxes) mailboxes.reload()
+}
+
+// Check for new mail without losing the reader's place: refetch the newest window and prepend only the
+// threads not already loaded (see onResetSuccess), keeping scroll position and the loaded rows. Used by
+// the Refresh button, the periodic poll, and the new-mail socket. Selections are preserved.
+const refreshThreads = (reloadMailboxes = true) => {
+	if (threadsResource.value.loading) return
+
+	refreshMode.value = true
+	refreshEpoch = epoch.value
+	refreshSnapshot = [...(threadsResource.value.data ?? [])]
+	refreshAnchor = {
+		top: mailListRef.value?.scrollTop ?? 0,
+		height: mailListRef.value?.scrollHeight ?? 0,
+	}
+	threadsResource.value.reload()
+	if (reloadMailboxes) mailboxes.reload()
+}
+
+// After an optimistic action whose threads stay in the list (add-to-mailbox, or a move that leaves
+// copies in the current mailbox): refresh selections + sidebar counts only, never refetch the list.
+const syncAfterAction = () => {
+	resetSelections()
+	mailboxes.reload()
+}
+
+// Drops threads from the loaded list optimistically and returns the removed rows (so an undo can put
+// them back). Their server rows leave the current view too, so the append offset (data.length) stays
+// aligned. If the list empties while more remain, reset to top (the sentinel unmounts with an empty
+// list and couldn't otherwise re-trigger a load).
+const removeThreadsFromList = (thread_ids: string[]): Thread[] => {
+	const data = threadsResource.value.data ?? []
+	const removed = data.filter((thread: Thread) => thread_ids.includes(thread.thread_id))
+	threadsResource.value.data = data.filter(
+		(thread: Thread) => !thread_ids.includes(thread.thread_id),
+	)
+	if (!threadsResource.value.data.length && hasMore.value) resetThreads()
+	return removed
+}
+
+// Re-insert threads (after undoing a move/junk) at their correct position by received_at, so they
+// return to where they were instead of jumping to the top. Scroll stays put — the browser's
+// scroll-anchoring holds the viewport as rows reappear above it.
+const restoreThreadsToList = (restored: Thread[]) => {
+	if (!restored.length) return
+	const list = [...(threadsResource.value.data ?? [])]
+	const present = new Set(list.map((t: Thread) => t.thread_id))
+	for (const thread of restored) {
+		if (present.has(thread.thread_id)) continue
+		// The list is sorted newest-first; drop the thread before the first older row.
+		const idx = list.findIndex((t: Thread) => t.received_at < thread.received_at)
+		idx === -1 ? list.push(thread) : list.splice(idx, 0, thread)
+	}
+	threadsResource.value.data = list
 }
 
 watch(
@@ -1064,21 +1083,20 @@ watch(
 		isMailboxLoaded.value = false
 		threadsResource.value.data = []
 		filter.value = localStorage.getItem(`user:${user.data.name}:filter:${mailbox}`) || null
-		page.value = 0
 		threadInFocus.value = undefined
 		collapsedGroups.value = []
-		reloadThreads(false)
+		resetThreads(false)
 	},
 	{ immediate: true },
 )
 
-// Periodically refresh the mailbox list (keeps sidebar counts current), then reload the open
-// mailbox's threads only when its thread count actually changed — so a quiet mailbox isn't reloaded
-// (and scroll-reset) every 30s.
+// Periodically refresh the mailbox list (keeps sidebar counts current), then merge in new threads only
+// when the mailbox's thread count actually changed — so a quiet mailbox isn't touched (and the reader
+// isn't disturbed) every 30s.
 const pollForChanges = async () => {
 	const prevTotal = mailboxObj.value?.total_threads
 	await mailboxes.reload()
-	if (mailboxObj.value?.total_threads !== prevTotal) threadsResource.value.reload()
+	if (mailboxObj.value?.total_threads !== prevTotal) refreshThreads(false)
 }
 
 onMounted(() => {
@@ -1087,7 +1105,7 @@ onMounted(() => {
 	reloadInterval.value = setInterval(pollForChanges, 30000)
 
 	socket.on('new_mail_created', (updatedMailboxes: string[]) => {
-		if (updatedMailboxes.includes(mailbox)) threadsResource.value.reload()
+		if (updatedMailboxes.includes(mailbox)) refreshThreads()
 	})
 
 	socket.on('mail_exchange_completed', (payload: { success: boolean; message: string }) =>
@@ -1118,37 +1136,34 @@ const goToThread = (threadID: string) => {
 		router.push({ name: 'mail-mail', params: { accountId, mailbox, threadID }, query: route.query })
 }
 
-// When stepping past the first/last thread of a page, move to the adjacent page (if any) and open
-// or focus its edge thread once the new page has loaded (`openPendingEdgeThread`, called from
-// onSuccess). `action` distinguishes the reading view (open) from list keyboard focus (focus).
-let pendingEdgeThread: { edge: 'first' | 'last'; action: 'open' | 'focus' } | null = null
+// Stepping past the last loaded thread loads the next window, then opens/focuses the newly appended
+// thread once it arrives (`openPendingEdgeThread`, called from the append's onSuccess). `action`
+// distinguishes the reading view (open) from list keyboard focus (focus). `anchor` is the thread we
+// stepped off (the previously-last loaded), captured so we can resolve its successor after the append.
+// There's no backward case — the first loaded thread is the first thread overall.
+let pendingEdgeThread: { action: 'open' | 'focus'; anchor: string | undefined } | null = null
 
-const crossPageByOffset = (offset: number, action: 'open' | 'focus') => {
-	// While a page transition is in flight (flag set until the new page loads), ignore further
-	// crossings — otherwise key auto-repeat at an edge keeps incrementing page.value and blows
-	// through many pages before the debounced reload fires.
-	if (pendingEdgeThread) return
-	if (offset > 0 && canGoNext.value) {
-		pendingEdgeThread = { edge: 'first', action }
-		goToPage(true)
-	} else if (offset < 0 && canGoPrev.value) {
-		pendingEdgeThread = { edge: 'last', action }
-		goToPage(false)
-	}
+const loadMoreThenOpenEdge = (offset: number, action: 'open' | 'focus') => {
+	// One crossing at a time: ignore further edge steps until the append resolves, so key auto-repeat
+	// at the bottom of the list can't fire a burst of loads.
+	if (pendingEdgeThread || offset < 0 || !hasMore.value) return
+	pendingEdgeThread = { action, anchor: action === 'open' ? threadID : threadInFocus.value }
+	loadMore()
 }
 
 const goToThreadByOffset = (offset: number) => {
 	const next = getThreadByOffset(offset)
 	if (next) return goToThread(next)
-	crossPageByOffset(offset, 'open')
+	loadMoreThenOpenEdge(offset, 'open')
 }
 
 const openPendingEdgeThread = () => {
 	if (!pendingEdgeThread) return
-	const id = pendingEdgeThread.edge === 'first' ? threadIDs.value[0] : threadIDs.value.at(-1)
-	if (!id) return // keep the flag if the page is still empty (e.g. after overflow correction)
-	const { action } = pendingEdgeThread
+	const { action, anchor } = pendingEdgeThread
+	// The successor of the anchor is now loaded (undefined only if nothing new arrived — then stop).
+	const id = getThreadByOffset(1, anchor)
 	pendingEdgeThread = null
+	if (!id) return
 	if (action === 'open') goToThread(id)
 	else focusOnThread(id)
 }
@@ -1170,7 +1185,7 @@ const focusOnThread = (threadID: string) => {
 const focusOnThreadByOffset = (offset: number) => {
 	const next = getThreadByOffset(offset, threadInFocus.value)
 	if (next) return focusOnThread(next)
-	crossPageByOffset(offset, 'focus')
+	loadMoreThenOpenEdge(offset, 'focus')
 }
 
 const scrollIntoView = (threadID: string) => {
@@ -1203,7 +1218,10 @@ const {
 	threadID: computed(() => threadID),
 	selections,
 	mailThreadRef,
-	reloadThreads,
+	resetThreads,
+	syncAfterAction,
+	removeThreadsFromList,
+	restoreThreadsToList,
 	goToMailbox,
 	goToNextThreadOrMailbox,
 })
@@ -1216,7 +1234,7 @@ const emptyMailbox = createResource({
 	onSuccess: () => {
 		threadsResource.value.data = []
 		raiseToast(__('{0} emptied.', [mailboxName.value]))
-		reloadThreads()
+		resetThreads()
 	},
 	onError: (error) => raiseToast(error.message, 'error'),
 })
@@ -1266,9 +1284,7 @@ const FILTER_OPTIONS = [
 const setFilter = (value: string | null) => {
 	filter.value = value
 	localStorage.setItem(`user:${user.data.name}:filter:${mailbox}`, value ?? '')
-	page.value = 0
-	threads.reload()
-	resetSelections()
+	resetThreads(false)
 }
 
 // UI formatting

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -1030,6 +1030,11 @@ const refreshThreads = (reloadMailboxes = true) => {
 	if (threadsResource.value.loading) return
 
 	refreshMode.value = true
+	// Bump the epoch so an append still in flight is discarded (appendThreads checks it) instead of
+	// landing after the merge and clobbering it — the merge rebuilds from the snapshot taken just below,
+	// which wouldn't include that append. A new append can't start mid-refresh (loadMore bails while the
+	// resource is loading), so this fully closes the refresh/append race.
+	epoch.value++
 	refreshEpoch = epoch.value
 	refreshSnapshot = [...(threadsResource.value.data ?? [])]
 	refreshAnchor = {

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -855,9 +855,9 @@ const onResetSuccess = () => {
 		refreshMode.value = false
 		// A reset (mailbox switch, filter, undo) raced in and bumped the epoch — drop this stale merge.
 		if (refreshEpoch !== epoch.value) return
-		const window = threadsResource.value.data ?? []
+		const freshWindow = threadsResource.value.data ?? []
 		const existing = new Set(refreshSnapshot.map((t) => t.thread_id))
-		const fresh = window.filter((t: Thread) => !existing.has(t.thread_id))
+		const fresh = freshWindow.filter((t: Thread) => !existing.has(t.thread_id))
 		threadsResource.value.data = [...fresh, ...refreshSnapshot]
 		// Keep the reader where they were: shift scroll by the height the prepended rows added. If they
 		// were already at the top, leave them there so the new mail is visible.

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -1027,7 +1027,7 @@ const resetThreads: (reloadMailboxes?: boolean, mailboxRoles?: MailboxRole[]) =>
 // threads not already loaded (see onResetSuccess), keeping scroll position and the loaded rows. Used by
 // the Refresh button, the periodic poll, and the new-mail socket. Selections are preserved.
 const refreshThreads = (reloadMailboxes = true) => {
-	if (threadsResource.value.loading) return
+	if (threadsResource.value.loading || loadingMore.value) return
 
 	refreshMode.value = true
 	// Bump the epoch so an append still in flight is discarded (appendThreads checks it) instead of

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -810,8 +810,10 @@ let loadEpoch = 0 // epoch captured when the current append was triggered
 // scroll — set while such a reload is in flight so its onSuccess prepends instead of replacing.
 const refreshMode = ref(false)
 let refreshEpoch = 0 // epoch captured when the refresh was triggered (dropped if a reset intervenes)
-let refreshSnapshot: Thread[] = [] // the loaded list at refresh time, merged with the fresh window
-let refreshAnchor = { top: 0, height: 0 } // scroll position to re-anchor after prepending
+// The loaded list to merge the fresh window into. Captured at *response* time (in the resource
+// transform), not refresh-start, so it reflects any optimistic removals/undo-inserts that happened
+// while the refresh was in flight — otherwise a thread archived mid-refresh would reappear.
+let refreshSnapshot: Thread[] = []
 // Current mailbox's record (carries total_threads/unread_threads); used by the periodic poll to
 // detect count changes and by the tab title's unread badge.
 const mailboxObj = computed(() => mailboxes.data?.find((m) => m.id === mailbox))
@@ -855,6 +857,11 @@ const onResetSuccess = () => {
 		refreshMode.value = false
 		// A reset (mailbox switch, filter, undo) raced in and bumped the epoch — drop this stale merge.
 		if (refreshEpoch !== epoch.value) return
+		// Anchor to the current scroll before merging. The window replaced `data` a beat ago but the DOM
+		// hasn't re-rendered yet, so these still reflect the loaded list the reader is looking at.
+		const el = mailListRef.value
+		const prevTop = el?.scrollTop ?? 0
+		const prevHeight = el?.scrollHeight ?? 0
 		const freshWindow = threadsResource.value.data ?? []
 		const existing = new Set(refreshSnapshot.map((t) => t.thread_id))
 		const fresh = freshWindow.filter((t: Thread) => !existing.has(t.thread_id))
@@ -862,9 +869,7 @@ const onResetSuccess = () => {
 		// Keep the reader where they were: shift scroll by the height the prepended rows added. If they
 		// were already at the top, leave them there so the new mail is visible.
 		nextTick(() => {
-			const el = mailListRef.value
-			if (el && refreshAnchor.top > 0)
-				el.scrollTop = refreshAnchor.top + (el.scrollHeight - refreshAnchor.height)
+			if (el && prevTop > 0) el.scrollTop = prevTop + (el.scrollHeight - prevHeight)
 		})
 		return
 	}
@@ -882,6 +887,7 @@ const searchResults = createResource({
 		start: 0,
 	}),
 	transform: (data: [Thread[], number]) => {
+		if (refreshMode.value) refreshSnapshot = threadsResource.value.data ?? []
 		hasMore.value = data[0].length > PAGE_LENGTH
 		return data[0].slice(0, PAGE_LENGTH)
 	},
@@ -917,6 +923,9 @@ const threads = createResource({
 		filter_by: filter.value,
 	}),
 	transform: (data: [Thread[], string]) => {
+		// In refresh mode, snapshot the live loaded list now — before this window replaces it — so the
+		// merge in onResetSuccess reflects any optimistic removals/undo-inserts made during the fetch.
+		if (refreshMode.value) refreshSnapshot = threadsResource.value.data ?? []
 		const rows = data[0]
 		hasMore.value = rows.length > PAGE_LENGTH
 		return rows.slice(0, PAGE_LENGTH)
@@ -1031,16 +1040,12 @@ const refreshThreads = (reloadMailboxes = true) => {
 
 	refreshMode.value = true
 	// Bump the epoch so an append still in flight is discarded (appendThreads checks it) instead of
-	// landing after the merge and clobbering it — the merge rebuilds from the snapshot taken just below,
-	// which wouldn't include that append. A new append can't start mid-refresh (loadMore bails while the
-	// resource is loading), so this fully closes the refresh/append race.
+	// landing after the merge and clobbering it. A new append can't start mid-refresh (loadMore bails
+	// while the resource is loading), so this fully closes the refresh/append race. The merge base
+	// (refreshSnapshot) and scroll anchor are captured later, at response time, so they reflect the list
+	// as it actually is when the window arrives — not a stale start-of-refresh copy.
 	epoch.value++
 	refreshEpoch = epoch.value
-	refreshSnapshot = [...(threadsResource.value.data ?? [])]
-	refreshAnchor = {
-		top: mailListRef.value?.scrollTop ?? 0,
-		height: mailListRef.value?.scrollHeight ?? 0,
-	}
 	threadsResource.value.reload()
 	if (reloadMailboxes) mailboxes.reload()
 }

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -100,7 +100,7 @@
 							v-if="!selections.length"
 							variant="ghost"
 							:tooltip="__('Refresh')"
-							:disabled="threadsResource?.loading"
+							:disabled="threadsResource?.loading || loadingMore"
 							@click="refreshThreads()"
 						>
 							<template #icon>

--- a/frontend/src/apps/mail/utils/useThreadActions.ts
+++ b/frontend/src/apps/mail/utils/useThreadActions.ts
@@ -7,7 +7,7 @@ import { getIcon, raisePromiseToast, raiseToast } from '@/apps/mail/utils'
 import { useBlockSender, useUndo } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 
-import type { Mail, Thread } from '@/apps/mail/types'
+import type { Mail, Mailbox, Thread } from '@/apps/mail/types'
 
 export type SetSeenParams = {
 	0?: string[]
@@ -214,11 +214,36 @@ export function useThreadActions(deps: {
 			})),
 	)
 
+	// Optimistically reflect an add/remove of a mailbox on the loaded list rows (thread summary + its
+	// nested messages) so MailListItem's folder tags update immediately, without waiting for a refetch.
+	// Mirrors MailThread.syncMailboxMembership, which does the same for the open thread's reading pane.
+	const syncListMailboxMembership = (mailboxId: string, threadIds: string[], add: boolean) => {
+		const mb = mailboxes.data?.find((m) => m.id === mailboxId)
+		if (!mb) return
+		const entry: Mailbox = { mailbox: mb.name, mailbox_id: mb.id, mailbox_name: mb._name }
+		const apply = (item: { mailboxes: Mailbox[] }) => {
+			if (add) {
+				if (!item.mailboxes.some((m) => m.mailbox_id === mailboxId))
+					item.mailboxes.push({ ...entry })
+			} else if (item.mailboxes.length > 1) {
+				item.mailboxes = item.mailboxes.filter((m) => m.mailbox_id !== mailboxId)
+			}
+		}
+		threadsResource.value.data
+			?.filter((t: Thread) => threadIds.includes(t.thread_id))
+			.forEach((t: Thread) => {
+				apply(t)
+				t.messages?.forEach(apply)
+			})
+	}
+
 	const handleAddThreadsToMailbox = (mailboxId: string, threadIds: string[], isUndo = false) => {
 		const mailboxName = mailboxes.data?.find((m) => m.id === mailboxId)?._name
 		const action = async () => {
 			await addMails.submit({ ids: allMailIds(threadIds), mailbox_id: mailboxId })
-			// The threads stay in the current view (only gain another mailbox) — no list refetch.
+			// The threads stay in the current view (only gain another mailbox) — no list refetch; update
+			// the list rows' folder tags in place instead, and refresh selections + sidebar counts.
+			syncListMailboxMembership(mailboxId, threadIds, true)
 			syncAfterAction()
 			if (threadID.value && threadIds.includes(threadID.value))
 				mailThreadRef.value?.syncMailboxMembership(mailboxId, true)
@@ -275,8 +300,9 @@ export function useThreadActions(deps: {
 				.map((m) => m.id)
 			await removeMails.submit({ ids, mailbox_id: mailboxId })
 			// Removing from the current mailbox drops the threads from the view; removing from another
-			// mailbox leaves them here (they just lose that membership).
+			// mailbox leaves them here (they just lose that membership) — drop the tag from the list rows.
 			if (mailboxId === mailbox.value) removeThreadsFromList(threadIdsToBeUpdated)
+			else syncListMailboxMembership(mailboxId, threadIdsToBeUpdated, false)
 			syncAfterAction()
 			if (threadID.value && threadIdsToBeUpdated.includes(threadID.value)) {
 				if (mailboxId === mailbox.value) goToNextThreadOrMailbox(threadIdsToBeUpdated)

--- a/frontend/src/apps/mail/utils/useThreadActions.ts
+++ b/frontend/src/apps/mail/utils/useThreadActions.ts
@@ -34,7 +34,14 @@ export function useThreadActions(deps: {
 	threadID: ComputedRef<string>
 	selections: Ref<string[]>
 	mailThreadRef: Ref<MailThreadInstance | null>
-	reloadThreads: (reloadMailboxes?: boolean, mailboxRoles?: string[]) => void
+	// Refetch only the first window, replacing the list and scrolling to top (mailbox switch, undo, …).
+	resetThreads: (reloadMailboxes?: boolean, mailboxRoles?: string[]) => void
+	// Refresh selections + sidebar counts only, without refetching the loaded list.
+	syncAfterAction: () => void
+	// Drop the given threads from the loaded list optimistically; returns the removed rows for undo.
+	removeThreadsFromList: (threadIds: string[]) => Thread[]
+	// Re-insert threads at their sorted position (undo of a move/junk) without jumping to top.
+	restoreThreadsToList: (threads: Thread[]) => void
 	goToMailbox: () => void
 	goToNextThreadOrMailbox: (excludedThreads?: string[]) => void
 }) {
@@ -44,7 +51,10 @@ export function useThreadActions(deps: {
 		threadID,
 		selections,
 		mailThreadRef,
-		reloadThreads,
+		resetThreads,
+		syncAfterAction,
+		removeThreadsFromList,
+		restoreThreadsToList,
 		goToMailbox,
 		goToNextThreadOrMailbox,
 	} = deps
@@ -208,7 +218,8 @@ export function useThreadActions(deps: {
 		const mailboxName = mailboxes.data?.find((m) => m.id === mailboxId)?._name
 		const action = async () => {
 			await addMails.submit({ ids: allMailIds(threadIds), mailbox_id: mailboxId })
-			reloadThreads()
+			// The threads stay in the current view (only gain another mailbox) — no list refetch.
+			syncAfterAction()
 			if (threadID.value && threadIds.includes(threadID.value))
 				mailThreadRef.value?.syncMailboxMembership(mailboxId, true)
 		}
@@ -263,7 +274,10 @@ export function useThreadActions(deps: {
 				.filter(isRemovable)
 				.map((m) => m.id)
 			await removeMails.submit({ ids, mailbox_id: mailboxId })
-			reloadThreads()
+			// Removing from the current mailbox drops the threads from the view; removing from another
+			// mailbox leaves them here (they just lose that membership).
+			if (mailboxId === mailbox.value) removeThreadsFromList(threadIdsToBeUpdated)
+			syncAfterAction()
 			if (threadID.value && threadIdsToBeUpdated.includes(threadID.value)) {
 				if (mailboxId === mailbox.value) goToNextThreadOrMailbox(threadIdsToBeUpdated)
 				else mailThreadRef.value?.syncMailboxMembership(mailboxId, false)
@@ -342,19 +356,27 @@ export function useThreadActions(deps: {
 		makeParams: ({ names }: { names: string[] }) => ({ names }),
 	})
 
+	// Removes the given threads from the loaded list and returns them (so an undo can re-insert the exact
+	// rows in place). Empty for the search/starred path, which resets instead.
 	const handleSuccessAndRemoveFromList = (
 		thread_ids: string[] | SetSeenParams,
 		excludeCommonMailboxes: boolean = true,
-	) => {
-		reloadThreads()
+	): Thread[] => {
+		// In search/starred, membership is server-determined (a moved thread may still be starred / still
+		// match the query), so reset to top and let the server decide rather than removing locally.
+		if (excludeCommonMailboxes && ['search', 'starred'].includes(mailbox.value)) {
+			resetThreads()
+			return []
+		}
 
-		if (excludeCommonMailboxes && ['search', 'starred'].includes(mailbox.value)) return
 		if (!Array.isArray(thread_ids)) thread_ids = Object.values(thread_ids).flat()
+		// Navigate off a removed open thread before dropping it, so the "next thread" is resolved
+		// against the still-complete list.
 		if (threadID.value && thread_ids.includes(threadID.value))
 			goToNextThreadOrMailbox(thread_ids)
-		threadsResource.value.data = threadsResource.value.data?.filter(
-			(thread: Thread) => !thread_ids.includes(thread.thread_id),
-		)
+		const removed = removeThreadsFromList(thread_ids)
+		syncAfterAction()
+		return removed
 	}
 
 	const handleSetSeen = (threadIDs: SetSeenParams, silent = false, mailIds?: string[]) => {
@@ -491,16 +513,22 @@ export function useThreadActions(deps: {
 		const keptInList =
 			mailbox.value === mailboxIds.sent && Object.keys(threadIDs).every((t) => !movesAll(t))
 
+		// The rows removed from the list on success, captured so undo can put them back in place.
+		let removedThreads: Thread[] = []
+
 		const action = async () => {
 			for (const op of forward) await op()
-			if (keptInList) reloadThreads()
-			else handleSuccessAndRemoveFromList(threadIDs)
+			if (keptInList) syncAfterAction()
+			else removedThreads = handleSuccessAndRemoveFromList(threadIDs)
 		}
 
 		setUndoAction(() => {
 			const undoAction = async () => {
 				await setMailsMailboxes.submit({ mails: snapshot })
-				reloadThreads()
+				// Re-insert the exact rows at their original position (no jump to top). The search/starred
+				// path removed nothing locally, so fall back to a reset there.
+				removedThreads.length ? restoreThreadsToList(removedThreads) : resetThreads()
+				mailboxes.reload()
 			}
 			raisePromiseToast(
 				undoAction,
@@ -545,9 +573,12 @@ export function useThreadActions(deps: {
 		// the same call as the mailbox restore.
 		const screenForward = spam ? (willJunkSenders(senders) ? 'Spam' : null) : 'Accepted'
 
+		// The rows removed from the list on success, captured so undo can put them back in place.
+		let removedThreads: Thread[] = []
+
 		const action = async () => {
 			await setMailsSpam.submit({ ids, spam, screen_action: screenForward })
-			handleSuccessAndRemoveFromList(threadIDs)
+			removedThreads = handleSuccessAndRemoveFromList(threadIDs)
 			// 'Ask to Block Sender' mode: junking still prompts to fully block the sender (Reject).
 			if (spam && !screenForward) promptBlockSenders(senders)
 		}
@@ -558,7 +589,10 @@ export function useThreadActions(deps: {
 					mails: snapshot,
 					screen_action: screenForward ? (spam ? 'Accepted' : 'Spam') : null,
 				})
-				reloadThreads()
+				// Re-insert the exact rows at their original position (no jump to top). The search/starred
+				// path removed nothing locally, so fall back to a reset there.
+				removedThreads.length ? restoreThreadsToList(removedThreads) : resetThreads()
+				mailboxes.reload()
 			}
 			// Undo flips the junk status back — name the resulting state, like the forward toast does.
 			const restored =


### PR DESCRIPTION
## What & why

The mail list used offset pagination — a `1–25 of N` toolbar with prev/next arrows — that refetched the current 25-row page on every page change and after every optimistic action. This replaces it with **infinite scroll**: the next batch is appended as you scroll, and already-loaded rows are never refetched (fetching >25 at once is expensive).

## Changes

- **Append-based loading.** `threadsResource.data` stays the single accumulated list every consumer reads. A dedicated load-more resource fetches the next window (`start = data.length`, deduped by `thread_id`) and appends it; the reset resources replace it. An `IntersectionObserver` sentinel triggers loading, and an `epoch` guard discards a stale append that resolves after a reset.
- **Toolbar.** Removed the count label and prev/next arrows. `canGoNext = hasMore`; in the reading pane, stepping past the last loaded thread loads more and then opens it.
- **Reload semantics split** into three intents so optimistic actions no longer collapse the list to the top:
  - `resetThreads` — replace + scroll to top (mailbox/account switch, filter change, undo, empty-mailbox, search-query change).
  - `syncAfterAction` — refresh selections + sidebar counts only.
  - `removeThreadsFromList` — optimistic local removal. Search/starred removals reset instead, since membership there is server-decided.
- **Refresh / poll / socket preserve scroll.** The Refresh button, the 30s poll, and the `new_mail` socket now merge only genuinely-new threads at the top instead of resetting to the top, so the reader isn't yanked around. The Refresh button no longer spins on load.
- **Undo restores in place.** Undoing a move/junk re-inserts the exact rows at their sorted (`received_at`) position rather than jumping to the top.

## Notes / tradeoffs

- Because refresh only *adds* new threads (never re-fetches loaded ones), changes to already-loaded threads made elsewhere (e.g. an external deletion, or a reply that should bump a thread to the top) won't reflect until a full reset (mailbox switch / filter). That's the cost of not refetching old rows, which was the goal.
- No backend changes — `get_threads` / `search_mails` already page by `start`/`limit`.

## Test plan

In a mailbox with >25 threads:
- Scroll to the bottom → the next 25 append (one `get_threads` with growing `start`, no refetch of earlier rows); repeat for several batches.
- Reading pane: `j`/`↓` / next arrow past the last loaded thread loads more and opens the next; `k`/`↑` stops at the first.
- Optimistic actions on a mid-list thread (archive/trash/junk/mark-read) drop the row with no scroll jump; **undo** restores it in place; sidebar counts update.
- Refresh / the 30s poll / a new incoming mail merge new threads at the top and preserve scroll position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)