### PR TITLE
fix(writer): show comments at viewport top

### DIFF
--- a/frontend/src/apps/writer/components/FloatingComments.test.ts
+++ b/frontend/src/apps/writer/components/FloatingComments.test.ts
@@ -1,0 +1,237 @@
+import { renderToString } from '@vue/server-renderer'
+import { createApp, h, nextTick } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('frappe-ui', () => {
+  const Stub = { template: '<span><slot /></span>' }
+  return {
+    Avatar: Stub,
+    Button: { template: '<button><slot name="prefix" /><slot /></button>' },
+    Dropdown: Stub,
+    onOutsideClickDirective: {},
+  }
+})
+
+vi.mock('@/boot/session', () => ({
+  useSessionStore: () => ({ user: 'Administrator' }),
+}))
+
+vi.mock('@/apps/writer/composables/useUsers', () => ({
+  useUsers: () => ({
+    getUser: () => ({ full_name: 'Administrator', user_image: null }),
+  }),
+}))
+
+vi.mock('@/apps/writer/extensions/comments', () => ({
+  getEditorPos: () => 0,
+  rebuild: vi.fn(),
+}))
+
+vi.mock('@/apps/writer/utils/', () => ({
+  dynamicList: (items: unknown[]) => items.filter(Boolean),
+}))
+
+vi.mock('@vueuse/core', () => ({
+  useDebounceFn: (fn: (...args: unknown[]) => unknown) => fn,
+  useEventListener: vi.fn(),
+}))
+
+vi.mock('./CommentEditor.vue', () => ({
+  default: { template: '<span class="comment-editor-stub" />' },
+}))
+
+import FloatingComments from './FloatingComments.vue'
+
+const renderComment = async (
+  top: number | null | undefined,
+  overrides: Record<string, unknown> = {},
+) => {
+  Object.assign(globalThis, { store: {} })
+
+  const comment = {
+    id: 'comment-1',
+    top,
+    owner: 'Administrator',
+    creation: 0,
+    text: 'Test comment',
+    replies: [],
+    resolved: false,
+    anchor: {},
+    ...overrides,
+  }
+  const map = new Map([[comment.id, comment]])
+  const yComments = {
+    _map: map,
+    forEach: map.forEach.bind(map),
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+  }
+  const editorDom = new EventTarget()
+  const editor = {
+    state: { doc: { descendants: vi.fn() } },
+    view: { dom: editorDom },
+    on: vi.fn(),
+  }
+
+  return renderToString(
+    h(FloatingComments, {
+      editor,
+      file: { doc: { write: true } },
+      showComments: true,
+      showResolved: true,
+      showUnanchored: false,
+      yComments,
+    }),
+  )
+}
+
+describe('FloatingComments positioning', () => {
+  it('renders a zero-positioned card and keeps the sidebar expanded', async () => {
+    const html = await renderComment(0)
+
+    expect(html).toContain('w-72 shrink-0 px-5')
+    expect(html).toContain('opacity-100 pointer-events-auto')
+    expect(html).toContain('style="top:0px;"')
+  })
+
+  it.each([
+    ['null', null, {}],
+    ['undefined', undefined, {}],
+    ['detached', null, { detached: 1 }],
+    ['remote new', null, { new: true, owner: 'another@example.com' }],
+  ])('keeps %s comments hidden', async (_label, top, overrides) => {
+    const html = await renderComment(top, overrides)
+
+    expect(html).toContain('w-0')
+    expect(html).toContain('opacity-0 pointer-events-none')
+    expect(html).not.toContain('style="top:')
+  })
+
+  it('stacks from zero while detached and remote-new cards stay hidden', async () => {
+    Object.assign(globalThis, { store: {} })
+    document.body.innerHTML = `
+      <div id="app"></div>
+      <span data-comment-name="first"></span>
+      <span data-comment-name="second"></span>
+    `
+
+    const firstAnchor = document.querySelector('[data-comment-name="first"]')!
+    const secondAnchor = document.querySelector('[data-comment-name="second"]')!
+    firstAnchor.getBoundingClientRect = () => ({ top: 0 }) as DOMRect
+    secondAnchor.getBoundingClientRect = () => ({ top: 10 }) as DOMRect
+
+    const originalOffsetHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'offsetHeight',
+    )
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      get() {
+        return this.id?.startsWith('comment-') ? 88 : 0
+      },
+    })
+
+    const comments = [
+      {
+        id: 'first',
+        owner: 'Administrator',
+        creation: 0,
+        text: 'First',
+        replies: [],
+        resolved: false,
+        anchor: {},
+        anchorText: 'First',
+      },
+      {
+        id: 'second',
+        owner: 'Administrator',
+        creation: 1,
+        text: 'Second',
+        replies: [],
+        resolved: false,
+        anchor: {},
+        anchorText: 'Second',
+      },
+      {
+        id: 'detached',
+        owner: 'Administrator',
+        creation: 2,
+        text: 'Detached',
+        replies: [],
+        resolved: false,
+        anchor: {},
+        anchorText: 'Detached',
+      },
+      {
+        id: 'remote-new',
+        owner: 'another@example.com',
+        creation: 3,
+        text: 'Remote new',
+        replies: [],
+        resolved: false,
+        anchor: {},
+        anchorText: 'Remote new',
+        new: true,
+      },
+    ]
+    const map = new Map(comments.map((comment) => [comment.id, comment]))
+    let updateComments: (() => void) | undefined
+    const yComments = {
+      _map: map,
+      forEach: map.forEach.bind(map),
+      observe: vi.fn((callback: () => void) => {
+        updateComments = callback
+      }),
+      unobserve: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    }
+    const editor = {
+      state: { doc: { descendants: vi.fn() } },
+      view: { dom: new EventTarget() },
+      on: vi.fn(),
+    }
+    const app = createApp(FloatingComments, {
+      editor,
+      file: { doc: { write: true } },
+      showComments: true,
+      showResolved: true,
+      showUnanchored: false,
+      yComments,
+    })
+
+    try {
+      app.mount(document.querySelector('#app')!)
+      await nextTick()
+      await nextTick()
+
+      expect((document.querySelector('#comment-first') as HTMLElement).style.top).toBe(
+        '0px',
+      )
+      expect((document.querySelector('#comment-second') as HTMLElement).style.top).toBe(
+        '100px',
+      )
+      for (const id of ['detached', 'remote-new']) {
+        const card = document.querySelector(`#comment-${id}`) as HTMLElement
+        expect(card.style.top).toBe('')
+        expect(card.className).toContain('opacity-0 pointer-events-none')
+      }
+      expect(document.querySelector('#app > div')?.className).toContain('w-72')
+    } finally {
+      comments[3].new = false
+      updateComments?.()
+      await nextTick()
+      app.unmount()
+      if (originalOffsetHeight)
+        Object.defineProperty(
+          HTMLElement.prototype,
+          'offsetHeight',
+          originalOffsetHeight,
+        )
+      else delete (HTMLElement.prototype as { offsetHeight?: number }).offsetHeight
+      document.body.innerHTML = ''
+    }
+  })
+})

--- a/frontend/src/apps/writer/components/FloatingComments.vue
+++ b/frontend/src/apps/writer/components/FloatingComments.vue
@@ -19,10 +19,14 @@
         }
           " class="absolute rounded shadow w-64 comment-group scroll-m-24 bg-surface-base dark:border" :class="[
             activeComment === comment.id && 'shadow-xl ',
-            comment.top
+            isCommentPositioned(comment.top)
               ? 'opacity-100 pointer-events-auto'
               : 'opacity-0 pointer-events-none',
-          ]" :style="`top: ${comment.top}px;`" @click="activeComment = comment.id">
+          ]" :style="{
+            top: isCommentPositioned(comment.top)
+              ? `${comment.top}px`
+              : undefined,
+          }" @click="activeComment = comment.id">
         <div v-show="activeComment === comment.id &&
           currentUserId !== 'Guest' &&
           !comment.new &&
@@ -201,6 +205,11 @@ const currentUserId = computed(() => useSessionStore().user)
 import { useUsers } from '@/apps/writer/composables/useUsers'
 import CommentEditor from './CommentEditor.vue'
 import { rebuild, getEditorPos } from '@/apps/writer/extensions/comments'
+import {
+  getCommentAnchorTop,
+  isCommentPositioned,
+  stackCommentTop,
+} from '@/apps/writer/utils/commentPosition'
 
 // Template compat: standalone app exposed `$store` (Vuex) and `$user` globals.
 const $store = store
@@ -270,7 +279,9 @@ const filteredComments = computed(() => {
 })
 
 const hasVisibleCards = computed(() =>
-  filteredComments.value.some((comment) => comment.top),
+  filteredComments.value.some((comment) =>
+    isCommentPositioned(comment.top),
+  ),
 )
 watch(
   () => props.showResolved,
@@ -387,19 +398,20 @@ const setCommentHeights = useDebounceFn(() => {
         const el =
           document.querySelector(`[data-comment-name="${comment.id}"]`) ||
           document.querySelector(`[data-comment-id="${comment.id}"]`)
-        let anchorTop
-        if (comment.new && comment.owner !== currentUserId.value) anchorTop = 0
+        let anchorTop = null
+        if (comment.new && comment.owner !== currentUserId.value)
+          anchorTop = null
         else if (!el && comment.anchorText) {
           comment.detached = 1
-          anchorTop = props.showUnanchored ? 48 : 0
+          anchorTop = props.showUnanchored ? 48 : null
         } else {
           const elTop = el.getBoundingClientRect().top
-          anchorTop = elTop ? elTop - containerTop : 0
+          anchorTop = getCommentAnchorTop(elTop, containerTop)
           comment.detached = 0
         }
-        const adjustedTop = anchorTop ? Math.max(anchorTop, lastBottom) : 0
+        const adjustedTop = stackCommentTop(anchorTop, lastBottom)
         comment.top = adjustedTop
-        if (adjustedTop)
+        if (isCommentPositioned(adjustedTop))
           lastBottom = adjustedTop + commentRefs[comment.id].offsetHeight + 12
       } catch (e) {
         console.log(e)

--- a/frontend/src/apps/writer/utils/commentPosition.test.ts
+++ b/frontend/src/apps/writer/utils/commentPosition.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getCommentAnchorTop,
+  isCommentPositioned,
+  stackCommentTop,
+} from './commentPosition'
+
+describe('Writer comment positioning', () => {
+  it('calculates an anchor position when the element is at viewport top', () => {
+    expect(getCommentAnchorTop(0, -42)).toBe(42)
+    expect(getCommentAnchorTop(0, 0)).toBe(0)
+  })
+
+  it('treats zero as positioned and only nullish values as hidden', () => {
+    expect(isCommentPositioned(0)).toBe(true)
+    expect(isCommentPositioned(48)).toBe(true)
+    expect(isCommentPositioned(null)).toBe(false)
+    expect(isCommentPositioned(undefined)).toBe(false)
+  })
+
+  it('keeps a card at zero and advances stacking from it', () => {
+    expect(stackCommentTop(0, 0)).toBe(0)
+    expect(stackCommentTop(10, 100)).toBe(100)
+  })
+
+  it('does not position hidden comments or disturb the stack', () => {
+    expect(stackCommentTop(null, 100)).toBeNull()
+    expect(stackCommentTop(undefined, 100)).toBeNull()
+  })
+})

--- a/frontend/src/apps/writer/utils/commentPosition.ts
+++ b/frontend/src/apps/writer/utils/commentPosition.ts
@@ -1,0 +1,13 @@
+export type CommentTop = number | null | undefined
+
+export const isCommentPositioned = (top: CommentTop): top is number =>
+	top !== null && top !== undefined
+
+export const getCommentAnchorTop = (elementTop: number, containerTop: number) =>
+  elementTop - containerTop
+
+export const stackCommentTop = (
+  anchorTop: CommentTop,
+  lastBottom: number,
+): number | null =>
+  isCommentPositioned(anchorTop) ? Math.max(anchorTop, lastBottom) : null

--- a/frontend/src/test/iconStub.ts
+++ b/frontend/src/test/iconStub.ts
@@ -1,0 +1,1 @@
+export default { template: '<i />' }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,12 +1,18 @@
 import path from "node:path"
 
+import vue from "@vitejs/plugin-vue"
 import { defineConfig } from "vitest/config"
 
 export default defineConfig({
+	plugins: [vue()],
 	resolve: {
-		alias: {
-			"@": path.resolve(__dirname, "src"),
-		},
+		alias: [
+			{ find: "@", replacement: path.resolve(__dirname, "src") },
+			{
+				find: /^~icons\/.+$/,
+				replacement: path.resolve(__dirname, "src/test/iconStub.ts"),
+			},
+		],
 	},
 	test: {
 		environment: "jsdom",


### PR DESCRIPTION
## What changed

- Treat numeric `0` as a valid Writer comment position.
- Reserve `null`/`undefined` for comments that are intentionally unpositioned or hidden.
- Calculate anchor offsets even when an anchor is exactly at the viewport top.
- Advance collision stacking when the preceding card starts at `0`.
- Add helper and mounted Vue regression coverage for visible, stacked, detached, and remote-new comments.

Closes #203.

## Verification

- `yarn test`: 23 files / 357 tests passed
- focused Writer tests: 10 passed (4 helper + 6 component)
- `bench build --app suite`: passed
- `bench --site suite-203.localhost migrate`: passed
- `git diff --check`: passed
- unchanged-upstream browser reproduction: anchored element at `top: 0` produced a hidden card and collapsed sidebar
- fixed browser replay: the same anchor produced a visible card at `top: 42px` and a 288px sidebar
- detached negative: no anchor, no `top` style, hidden pointer/opacity state, and collapsed sidebar

Mutation checks confirmed that restoring the old truthiness condition breaks zero-position visibility/stacking tests, while restoring detached/remote-new `0` sentinels makes a hidden card appear at `200px`.

Before/after screenshots and exact runtime measurements are attached below.

@safwansamsudeen, would you mind reviewing this Writer fix when you have a chance?
