### PR TITLE
feat(mail): infinite scroll for All Inboxes

### DIFF
--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -5,7 +5,7 @@
 			<Button v-if="isMobile" icon="menu" variant="ghost" @click="openSidebar" />
 			<Breadcrumbs :items="[{ label: __('All Inboxes'), route: { name: 'mail-all-inboxes' } }]" />
 		</div>
-		<HeaderActions @reload-mails="reload()" />
+		<HeaderActions @reload-mails="refreshThreads()" />
 	</header>
 
 	<div class="relative flex h-[calc(100dvh-3.05rem)]">
@@ -31,43 +31,17 @@
 							<ChevronDown class="text-ink-gray-5 icon shrink-0" />
 						</button>
 					</Dropdown>
-					<Button
-						class="ml-1.5"
-						variant="ghost"
-						:tooltip="__('Refresh')"
-						:disabled="threads.loading"
-						@click="reload()"
-					>
-						<template #icon>
-							<RefreshCw class="icon" :class="{ 'animate-spin': threads.loading }" />
-						</template>
-					</Button>
 					<div class="-mr-1.5 ml-auto flex items-center space-x-1.5 sm:space-x-3">
-						<div v-if="displayTotal" class="text-ink-gray-6 flex items-center gap-1">
-							<span class="whitespace-nowrap text-sm tabular-nums">
-								{{ range }} {{ __('of') }} {{ totalLabel }}
-							</span>
-							<Button
-								:tooltip="__('Previous Page')"
-								variant="ghost"
-								:disabled="!canGoPrev"
-								@click="goToPage(false)"
-							>
-								<template #icon>
-									<ChevronLeft class="icon" />
-								</template>
-							</Button>
-							<Button
-								:tooltip="__('Next Page')"
-								variant="ghost"
-								:disabled="!canGoNext"
-								@click="goToPage(true)"
-							>
-								<template #icon>
-									<ChevronRight class="icon" />
-								</template>
-							</Button>
-						</div>
+						<Button
+							variant="ghost"
+							:tooltip="__('Refresh')"
+							:disabled="threads.loading || loadingMore"
+							@click="refreshThreads()"
+						>
+							<template #icon>
+								<RefreshCw class="icon" />
+							</template>
+						</Button>
 					</div>
 
 					<!-- Loading bar -->
@@ -86,29 +60,52 @@
 				<!-- Mail list -->
 				<div ref="mailList" class="h-full overflow-y-auto overscroll-contain">
 					<div v-for="(group, key) in groupedThreads" :key="key">
-						<div
+						<Tooltip
 							v-if="groupMessagesBy !== 'None'"
-							class="text-ink-gray-6 flex items-center border-b border-l-transparent p-3.5 text-xs-semibold sm:border-l sm:px-5"
+							:text="
+								isLastGroup(key)
+									? ''
+									: __(collapsedGroups.includes(key) ? 'Expand' : 'Collapse')
+							"
 						>
-							<span class="select-none pt-[2px]">
-								{{ getFormattedDate(key, groupMessagesBy === 'Month').toUpperCase() }}
-							</span>
-						</div>
-						<MailListItem
-							v-for="mail in group"
-							:key="`${mail.account}:${mail.thread_id}`"
-							:mailbox="mail.inbox || ''"
-							:account-id="mail.account"
-							:account-label="mail.account_name || undefined"
-							:mail
-							:is-selected="false"
-							:selectable="false"
-							class="border-l-transparent sm:border-l"
-							@set-seen="(seen: boolean) => handleSetSeen(mail, seen)"
-							@archive-thread="handleArchive(mail)"
-							@trash-thread="handleTrash(mail)"
-							@set-flagged="(flagged: boolean) => handleSetFlagged(mail, flagged)"
-						/>
+							<div
+								class="text-ink-gray-6 flex items-center border-b border-l-transparent p-3.5 text-xs-semibold sm:border-l sm:px-5"
+								:class="{ 'cursor-pointer': !isLastGroup(key) }"
+								@click="toggleGroupCollapse(key)"
+							>
+								<span class="select-none pt-[2px]">
+									{{ getFormattedDate(key, groupMessagesBy === 'Month').toUpperCase() }}
+								</span>
+								<component
+									:is="collapsedGroups.includes(key) ? ChevronRight : ChevronDown"
+									v-if="!isLastGroup(key)"
+									class="icon ml-auto"
+								/>
+							</div>
+						</Tooltip>
+						<template v-if="!collapsedGroups.includes(key)">
+							<MailListItem
+								v-for="mail in group"
+								:key="`${mail.account}:${mail.thread_id}`"
+								:mailbox="mail.inbox || ''"
+								:account-id="mail.account"
+								:account-label="mail.account_name || undefined"
+								:mail
+								:is-selected="false"
+								:selectable="false"
+								class="border-l-transparent sm:border-l"
+								@set-seen="(seen: boolean) => handleSetSeen(mail, seen)"
+								@archive-thread="handleArchive(mail)"
+								@trash-thread="handleTrash(mail)"
+								@set-flagged="(flagged: boolean) => handleSetFlagged(mail, flagged)"
+							/>
+						</template>
+					</div>
+					<!-- Infinite-scroll sentinel: entering the viewport near the list bottom loads the next
+					     batch (appended, never refetching loaded rows). Sits after all groups. -->
+					<div ref="loadMoreSentinel" class="h-px" />
+					<div v-if="loadingMore" class="flex justify-center py-3">
+						<LoaderCircle class="text-ink-gray-5 h-4 w-4 animate-spin" />
 					</div>
 				</div>
 			</div>
@@ -122,8 +119,8 @@
 				class="mt-3"
 				variant="ghost"
 				:label="__('Refresh')"
-				:disabled="threads.loading"
-				@click="reload()"
+				:disabled="threads.loading || loadingMore"
+				@click="refreshThreads()"
 			>
 				<template #prefix>
 					<RefreshCw class="icon" :class="{ 'animate-spin': threads.loading }" />
@@ -134,11 +131,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, onMounted, onUnmounted, ref, useTemplateRef } from 'vue'
-import { useDebounceFn } from '@vueuse/core'
+import { computed, inject, nextTick, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
+import { useIntersectionObserver } from '@vueuse/core'
 import {
 	ChevronDown,
-	ChevronLeft,
 	ChevronRight,
 	LoaderCircle,
 	Mail as MailIcon,
@@ -147,7 +143,7 @@ import {
 	RefreshCw,
 	Star,
 } from 'lucide-vue-next'
-import { Breadcrumbs, Button, Dropdown, call, createResource, usePageMeta } from 'frappe-ui'
+import { Breadcrumbs, Button, Dropdown, Tooltip, call, createResource, usePageMeta } from 'frappe-ui'
 
 import { getFormattedDate, raisePromiseToast, raiseToast } from '@/apps/mail/utils'
 import { useScreenSize, useSidebar } from '@/apps/mail/utils/composables'
@@ -167,12 +163,26 @@ const dayjs = inject('$dayjs')
 
 const store = userStore()
 
-// Pagination (lookahead only — there's no cheap exact total across accounts, so the running count
-// gets a "+" suffix while a next page is detected, mirroring the mailbox view's filtered mode).
+// ── Infinite scroll ─────────────────────────────────────────────────────────────────────────────
+// The loaded list (threads.data) is the single source of truth. The reset resource replaces it (from
+// the top); the load-more resource appends the next window onto it. Rows are keyed by account +
+// thread_id since the same thread_id can recur across accounts in this merged view.
 const PAGE_LENGTH = 25
-const page = ref(0) // navigation target
-const displayedPage = ref(0) // page currently shown; lags `page` until its data loads
-const hasMore = ref(false) // an extra row was returned, so a next page exists
+const hasMore = ref(false) // lookahead: the last fetched window returned an extra row, so more exist
+const loadingMore = ref(false) // an append fetch is in flight (drives the bottom spinner)
+// Bumped on every reset/refresh; an in-flight append captures it and discards its result if it changed
+// meanwhile, so a stale window can't land on a freshly reset list.
+const epoch = ref(0)
+let loadEpoch = 0 // epoch captured when the current append was triggered
+// Refresh ("check for new mail") state: merges the newest window into the loaded list, preserving
+// scroll — set while such a reload is in flight so its onSuccess prepends instead of replacing.
+const refreshMode = ref(false)
+let refreshEpoch = 0 // epoch captured when the refresh was triggered (dropped if a reset intervenes)
+// The loaded list to merge the fresh window into. Captured at *response* time (in the resource
+// transform), not refresh-start, so it reflects any optimistic removals that happened while the
+// refresh was in flight — otherwise a thread archived mid-refresh would reappear.
+let refreshSnapshot: Thread[] = []
+
 const isLoaded = ref(false)
 const filter = ref<string | null>(
 	localStorage.getItem(`user:${user.data.name}:filter:all-inboxes`) || null,
@@ -180,27 +190,104 @@ const filter = ref<string | null>(
 
 const mailListRef = useTemplateRef('mailList')
 
+const threadKey = (thread: Thread) => `${thread.account}:${thread.thread_id}`
+
+const scrollListToTop = () => mailListRef.value?.scrollTo({ top: 0 })
+
+// Called when a first-window fetch resolves. Two modes:
+// - refresh: keep the loaded rows, prepend only threads not already loaded (new mail), and hold the
+//   scroll position (re-anchored by the height the prepended rows added).
+// - reset: reveal the fresh first window and scroll to top (filter change, initial load, …).
+const onResetSuccess = () => {
+	if (refreshMode.value) {
+		refreshMode.value = false
+		// A reset (filter change) raced in and bumped the epoch — drop this stale merge.
+		if (refreshEpoch !== epoch.value) return
+		// Anchor to the current scroll before merging. The window replaced `data` a beat ago but the DOM
+		// hasn't re-rendered yet, so these still reflect the loaded list the reader is looking at.
+		const el = mailListRef.value
+		const prevTop = el?.scrollTop ?? 0
+		const prevHeight = el?.scrollHeight ?? 0
+		const freshWindow = threads.data ?? []
+		const existing = new Set(refreshSnapshot.map(threadKey))
+		const fresh = freshWindow.filter((t: Thread) => !existing.has(threadKey(t)))
+		threads.data = [...fresh, ...refreshSnapshot]
+		// Keep the reader where they were: shift scroll by the height the prepended rows added. If they
+		// were already at the top, leave them there so the new mail is visible.
+		nextTick(() => {
+			if (el && prevTop > 0) el.scrollTop = prevTop + (el.scrollHeight - prevHeight)
+		})
+		return
+	}
+
+	scrollListToTop()
+}
+
+// Reset resource: always the first window, over-fetching one row (PAGE_LENGTH + 1) to detect whether
+// more exist without a total.
 const threads = createResource({
 	url: 'suite.mail.api.mail.get_all_inbox_threads',
 	makeParams: () => ({
 		limit: PAGE_LENGTH + 1,
-		start: page.value * PAGE_LENGTH,
+		start: 0,
 		filter_by: filter.value,
 	}),
 	transform: (rows: Thread[]) => {
-		// Fetch one extra row to detect a next page without a total, then clip it from the display.
+		// In refresh mode, snapshot the live loaded list now — before this window replaces it — so the
+		// merge in onResetSuccess reflects any optimistic removals made during the fetch.
+		if (refreshMode.value) refreshSnapshot = threads.data ?? []
 		hasMore.value = rows.length > PAGE_LENGTH
 		return rows.slice(0, PAGE_LENGTH)
 	},
 	onSuccess: () => {
-		if (displayedPage.value !== page.value) {
-			displayedPage.value = page.value
-			mailListRef.value?.scrollTo({ top: 0 })
-		}
+		onResetSuccess()
 		isLoaded.value = true
 	},
 	auto: true,
 })
+
+// Appends the next window onto the loaded list, deduped by account + thread_id. `start = data.length`
+// stays correct across optimistic removals (the server list shifts left by the same rows we dropped);
+// the only skew is new mail inserted at the front, which the dedupe absorbs and the next reset reconciles.
+const appendThreads = (rows: Thread[]) => {
+	loadingMore.value = false
+	// Discard a stale window that resolved after a reset/refresh began.
+	if (loadEpoch !== epoch.value) return
+	const seen = new Set((threads.data ?? []).map(threadKey))
+	const fresh = rows.slice(0, PAGE_LENGTH).filter((t) => !seen.has(threadKey(t)))
+	// Stop auto-loading if the window added nothing new (offset stuck behind heavy front-inserted mail,
+	// or the server's fetch depth cap reached); the next reset reconciles. Guards a tight reload loop
+	// while the sentinel stays in view.
+	hasMore.value = rows.length > PAGE_LENGTH && fresh.length > 0
+	threads.data = [...(threads.data ?? []), ...fresh]
+}
+
+const loadMoreThreads = createResource({
+	url: 'suite.mail.api.mail.get_all_inbox_threads',
+	makeParams: () => ({
+		limit: PAGE_LENGTH + 1,
+		start: threads.data?.length ?? 0,
+		filter_by: filter.value,
+	}),
+	onSuccess: (rows: Thread[]) => appendThreads(rows),
+	onError: () => (loadingMore.value = false),
+})
+
+const loadMore = () => {
+	if (!hasMore.value || loadingMore.value || threads.loading) return
+	loadingMore.value = true
+	loadEpoch = epoch.value
+	loadMoreThreads.reload()
+}
+
+const loadMoreSentinel = useTemplateRef('loadMoreSentinel')
+useIntersectionObserver(
+	loadMoreSentinel,
+	([entry]) => {
+		if (entry?.isIntersecting) loadMore()
+	},
+	{ root: mailListRef },
+)
 
 const isLoading = computed(() => !isLoaded.value && threads.loading)
 
@@ -208,35 +295,32 @@ const isLoading = computed(() => !isLoaded.value && threads.loading)
 // store's mailboxes.onSuccess hook also refreshes the unified All Inboxes badge.
 const refreshCounts = () => store.mailboxes.reload()
 
-const reload = () => {
+// Reset-to-top: refetch only the first window, replacing the loaded list and scrolling to the top (via
+// onResetSuccess). Bumping `epoch` discards any append/refresh still in flight. Used on filter change.
+const resetThreads = () => {
+	refreshMode.value = false
+	epoch.value++
 	threads.reload()
 	refreshCounts()
 }
 
-// Pagination controls
-const threadsOnPage = computed(() => threads.data?.length ?? 0)
-const rangeEnd = computed(() => displayedPage.value * PAGE_LENGTH + threadsOnPage.value)
-const rangeStart = computed(() => (rangeEnd.value === 0 ? 0 : displayedPage.value * PAGE_LENGTH + 1))
-const range = computed(() =>
-	rangeStart.value === rangeEnd.value
-		? `${rangeStart.value}`
-		: `${rangeStart.value}–${rangeEnd.value}`,
-)
-const displayTotal = computed(() => rangeEnd.value)
-const totalLabel = computed(() => `${rangeEnd.value}${hasMore.value ? '+' : ''}`)
-
-const canGoPrev = computed(() => page.value > 0)
-const canGoNext = computed(() => hasMore.value && page.value === displayedPage.value)
-
-const navigate = useDebounceFn(() => threads.reload(), 250)
-
-const goToPage = (next: boolean) => {
-	if (next ? !canGoNext.value : !canGoPrev.value) return
-	page.value += next ? 1 : -1
-	navigate()
+// Check for new mail without losing the reader's place: refetch the newest window and prepend only the
+// threads not already loaded (see onResetSuccess), keeping scroll position and the loaded rows. Used by
+// the Refresh button, the periodic poll, and the new-mail socket.
+const refreshThreads = (reloadCounts = true) => {
+	if (threads.loading || loadingMore.value) return
+	refreshMode.value = true
+	// Bump the epoch so an append still in flight is discarded (appendThreads checks it) instead of
+	// landing after the merge and clobbering it. A new append can't start mid-refresh (loadMore bails
+	// while the resource is loading), so this fully closes the refresh/append race.
+	epoch.value++
+	refreshEpoch = epoch.value
+	threads.reload()
+	if (reloadCounts) refreshCounts()
 }
 
-// Date grouping (headers only — no collapsing, unlike the per-mailbox view)
+// Date grouping with collapsible headers (mirroring the per-mailbox view). The last group never
+// collapses — it's where infinite scroll appends, so hiding it would swallow newly loaded rows.
 const groupMessagesBy = computed(() => user.data.group_messages_by)
 
 const groupedThreads = computed<Record<string, Thread[]>>(() =>
@@ -250,14 +334,29 @@ const groupedThreads = computed<Record<string, Thread[]>>(() =>
 	}, {}),
 )
 
+const isLastGroup = (key: string) => Object.keys(groupedThreads.value).at(-1) === key
+
+const collapsedGroups = ref<string[]>([])
+
+const toggleGroupCollapse = (key: string) => {
+	if (isLastGroup(key)) return
+	if (collapsedGroups.value.includes(key))
+		collapsedGroups.value = collapsedGroups.value.filter((d) => d !== key)
+	else collapsedGroups.value.push(key)
+}
+
+watch(groupMessagesBy, () => (collapsedGroups.value = []))
+
 // Per-item actions — each row carries its own account + that account's mailbox ids, so actions target
 // the correct JMAP account without touching the active-account state.
 const messageIds = (thread: Thread) => (thread.messages ?? []).map((m) => m.id)
 
+// Optimistically drop the row. Its server row leaves the current view too, so the append offset
+// (data.length) stays aligned. If the list empties while more remain, reset to top (the sentinel
+// unmounts with an empty list and couldn't otherwise re-trigger a load).
 const removeFromList = (thread: Thread) => {
-	threads.data = threads.data?.filter(
-		(t: Thread) => !(t.thread_id === thread.thread_id && t.account === thread.account),
-	)
+	threads.data = threads.data?.filter((t: Thread) => threadKey(t) !== threadKey(thread))
+	if (!threads.data?.length && hasMore.value) resetThreads()
 }
 
 // Each action is a stateless one-shot `call()` rather than a shared createResource: rows act on
@@ -295,16 +394,17 @@ const handleSetFlagged = (thread: Thread, flagged: boolean) => {
 	})
 }
 
-// Optimistically drop the row, then move on the server. Reload on both outcomes so a failure restores
-// the true list (the row reappears); rethrow on failure so the toast reports the error, not success.
+// Optimistically drop the row, then move on the server. On success just refresh counts (the row and its
+// server row are both gone, so the append offset stays aligned and scroll is preserved). On failure,
+// reset to restore the true list (the row reappears); rethrow so the toast reports the error.
 const moveThreadOut = (thread: Thread, mailbox: string) =>
 	call('suite.mail.api.mail.move_mails', {
 		account: thread.account,
 		ids: messageIds(thread),
 		mailbox,
 		clear_junk: true,
-	}).then(reload, (error) => {
-		reload()
+	}).then(refreshCounts, (error) => {
+		resetThreads()
 		throw error
 	})
 
@@ -339,8 +439,7 @@ const FILTER_OPTIONS = [
 const setFilter = (value: string | null) => {
 	filter.value = value
 	localStorage.setItem(`user:${user.data.name}:filter:all-inboxes`, value ?? '')
-	page.value = 0
-	threads.reload()
+	resetThreads()
 }
 
 const title = computed(() => {
@@ -363,17 +462,18 @@ const unreadPrefix = computed(() =>
 usePageMeta(() => ({ title: `${unreadPrefix.value} ${__('All Inboxes')}` }))
 
 // Keep the merged list fresh: poll periodically and react to new-mail push events (which can arrive
-// for any account). Both are cheap reloads of the current page.
+// for any account). Both merge the newest window at the top, preserving scroll.
 const reloadInterval = ref<ReturnType<typeof setInterval>>()
+const onNewMail = () => refreshThreads()
 
 onMounted(() => {
-	reloadInterval.value = setInterval(reload, 30000)
-	socket.on('new_mail_created', reload)
+	reloadInterval.value = setInterval(onNewMail, 30000)
+	socket.on('new_mail_created', onNewMail)
 })
 
 onUnmounted(() => {
 	if (reloadInterval.value) clearInterval(reloadInterval.value)
-	socket.off('new_mail_created', reload)
+	socket.off('new_mail_created', onNewMail)
 })
 </script>
 

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -300,6 +300,9 @@ const refreshCounts = () => store.mailboxes.reload()
 const resetThreads = () => {
 	refreshMode.value = false
 	epoch.value++
+	// A reset replaces the list with a fresh first window, so any prior collapse no longer maps to what's
+	// shown — clear it (else a group collapsed under one filter stays collapsed and hides its threads).
+	collapsedGroups.value = []
 	threads.reload()
 	refreshCounts()
 }

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -123,7 +123,7 @@
 				@click="refreshThreads()"
 			>
 				<template #prefix>
-					<RefreshCw class="icon" :class="{ 'animate-spin': threads.loading }" />
+					<RefreshCw class="icon" />
 				</template>
 			</Button>
 		</div>


### PR DESCRIPTION
Brings the **All Inboxes** view in line with the per-mailbox view (#208): replaces offset pagination with infinite scroll, and adds collapsible date groups.

## Changes

- **Infinite scroll.** Drop the "1–25 of N+" count and prev/next arrows. The accumulated list in the threads resource is the single source of truth: a reset resource replaces it from the top (filter change, initial load); a load-more resource appends the next window (`start = data.length`), deduped by `account + thread_id`. An `IntersectionObserver` sentinel drives loading, and an epoch guard drops stale appends that resolve after a reset.
- **Scroll-preserving refresh.** The Refresh button, the 30s poll, and the `new_mail_created` socket now merge only genuinely-new threads at the top, preserving scroll position instead of jumping to the top.
- **Optimistic row actions.** Archive/trash drop the row optimistically and only refresh counts on success (scroll preserved); a failure resets to the true list.
- **Collapsible date groups**, matching the per-mailbox view. The last group never collapses, since it's where infinite scroll appends new rows.
- **Refresh button moved** to the right of the toolbar, consistent with the other mailboxes.

## Notes

The backend `get_all_inbox_threads` already supports this (`limit`/`start`/`filter_by`), clamping fetch depth to `ALL_INBOX_MAX_FETCH`; the `hasMore && fresh.length > 0` guard stops auto-loading cleanly once the cap is reached or a window adds nothing new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)