### PR TITLE
feat(mail): search across accounts

### DIFF
--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -222,10 +222,15 @@ const menuItems = computed(() => [
 						{
 							class: 'flex items-center gap-2 p-1.5 rounded hover:bg-surface-gray-2 cursor-pointer w-48 shrink-0',
 							onClick: async () => {
-								router.push({
-									name: route.name,
-									params: { ...route.params, accountId: a.id },
-								})
+								// Account-scoped routes carry an accountId, so swap it in place to stay in the
+								// same section. Account-agnostic routes (All Inboxes) have no accountId param —
+								// reusing their name would go nowhere, so route through the account shortcut,
+								// which the guard resolves to that account's default mailbox.
+								router.push(
+									route.params.accountId
+										? { name: route.name, params: { ...route.params, accountId: a.id } }
+										: { name: 'mail-account-shortcut', params: { accountId: a.id } },
+								)
 							},
 						},
 						[

--- a/frontend/src/apps/mail/components/MailListItem.vue
+++ b/frontend/src/apps/mail/components/MailListItem.vue
@@ -65,13 +65,14 @@
 					>
 						{{ header }}
 					</h3>
-					<Badge
+					<!-- All Inboxes: which account received this mail. -->
+					<div
 						v-if="accountLabel"
-						size="sm"
-						:label="accountLabel"
-						theme="gray"
-						class="shrink-0"
-					/>
+						class="text-ink-gray-4 flex shrink-0 items-center gap-1 text-xs"
+					>
+						<span aria-hidden="true">·</span>
+						<span>{{ __('in {0}', [accountLabel]) }}</span>
+					</div>
 					<Badge v-if="mail.draft" size="sm" :label="__('Draft')" theme="red" />
 				</div>
 				<MailDate v-if="!isFullWidth" :datetime="mail.received_at" :in-list="true" />

--- a/frontend/src/apps/mail/components/MailListItemActions.vue
+++ b/frontend/src/apps/mail/components/MailListItemActions.vue
@@ -32,6 +32,12 @@ const emit = defineEmits(['setSeen', 'archiveThread', 'trashThread', 'deleteThre
 const { isMobile } = useScreenSize()
 const { mailboxIds } = userStore()
 
+// Prefer the row's own Archive/Trash ids when present (merged All Inboxes / cross-account search rows,
+// which can belong to a different account than the active one) so the Archive/Trash/Delete options
+// reflect where the mail actually lives. Falls back to the active account for a normal single-account view.
+const archiveId = computed(() => mail.archive ?? mailboxIds.archive)
+const trashId = computed(() => mail.trash ?? mailboxIds.trash)
+
 const actions = computed(() =>
 	[
 		{
@@ -50,19 +56,19 @@ const actions = computed(() =>
 			label: __('Archive Thread'),
 			onClick: () => emit('archiveThread'),
 			icon: Archive,
-			condition: !mail.mailboxes.some((m) => m.mailbox_id === mailboxIds.archive),
+			condition: !mail.mailboxes.some((m) => m.mailbox_id === archiveId.value),
 		},
 		{
 			label: __('Move to Trash'),
 			onClick: () => emit('trashThread'),
 			icon: Trash2,
-			condition: !mail.mailboxes.some((m) => m.mailbox_id === mailboxIds.trash),
+			condition: !mail.mailboxes.some((m) => m.mailbox_id === trashId.value),
 		},
 		{
 			label: __('Delete Thread'),
 			onClick: () => emit('deleteThread'),
 			icon: Trash2,
-			condition: mail.mailboxes.some((m) => m.mailbox_id === mailboxIds.trash),
+			condition: mail.mailboxes.some((m) => m.mailbox_id === trashId.value),
 		},
 	].filter((action) => action.condition),
 )

--- a/frontend/src/apps/mail/components/Modals/SearchModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SearchModal.vue
@@ -45,7 +45,17 @@
 				</div>
 				<template v-if="showAdvancedFilters">
 					<div class="space-y-4 p-4">
+						<Switch
+							v-if="hasMultipleAccounts"
+							v-model="allAccounts"
+							:label="__('Search across all accounts')"
+							:description="
+								__('Look through every account you own — slower, but finds a mail wherever it landed.')
+							"
+							class="!p-0"
+						/>
 						<FormControl
+							v-if="!allAccounts"
 							v-model="filter.inMailbox"
 							type="select"
 							:label="__('Look In')"
@@ -107,13 +117,19 @@
 						v-for="(result, idx) in results.data[0]"
 						:key="idx"
 						class="hover:bg-surface-gray-1 group flex rounded p-2 hover:cursor-pointer"
-						@click="openThread(result.thread_id)"
+						@click="openThread(result)"
 					>
 						<div class="mr-2 space-y-1 truncate">
 							<p class="truncate text-base-semibold">
 								{{ result.subject || __('[No subject]') }}
 							</p>
 							<p class="truncate text-sm">{{ getInterlocutors(result) }}</p>
+							<div
+								v-if="allAccounts && result.account_name"
+								class="bg-surface-gray-3 group-hover:bg-surface-gray-4 mr-1.5 inline-flex rounded p-1 text-xs font-medium"
+							>
+								{{ result.account_name }}
+							</div>
 							<div
 								v-for="m in result.mailboxes"
 								:key="m.mailbox_id"
@@ -161,7 +177,7 @@ import { computed, nextTick, reactive, ref, useTemplateRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { watchDebounced } from '@vueuse/core'
 import { ChevronLeft, Paperclip, Search, SlidersHorizontal } from 'lucide-vue-next'
-import { Button, Dialog, FormControl, createResource } from 'frappe-ui'
+import { Button, Dialog, FormControl, Switch, createResource } from 'frappe-ui'
 
 import { getAttachmentOptions, getReadStatusOptions } from '@/apps/mail/constants'
 import { getFormattedDate } from '@/apps/mail/utils'
@@ -211,8 +227,28 @@ const filteredFilter = computed(() =>
 			.filter(([, v]) => Boolean(v)),
 	),
 )
+
+// Cross-account search: an opt-in that fans the query out across every account (defaulting off, so a
+// search stays scoped to the current account for speed). Persisted, and pre-checked when the search
+// page was opened with the flag set, so reopening the dialog reflects the active scope.
+const ALL_ACCOUNTS_STORAGE_KEY = 'mail-search-all-accounts'
+const hasMultipleAccounts = computed(() => (store.userResource.data?.accounts?.length ?? 0) > 1)
+const allAccounts = ref(
+	hasMultipleAccounts.value &&
+		(route.query.all_accounts != null ||
+			localStorage.getItem(ALL_ACCOUNTS_STORAGE_KEY) === 'true'),
+)
+watch(allAccounts, (val) => {
+	localStorage.setItem(ALL_ACCOUNTS_STORAGE_KEY, String(val))
+	// "Look In" targets a folder in the current account; it can't carry across accounts, so drop it.
+	if (val) filter.inMailbox = ''
+	if (filter.text) results.reload()
+})
+
 const advancedFiltersLength = computed(
-	() => Object.keys(filteredFilter.value).filter((k) => k !== 'text').length,
+	() =>
+		Object.keys(filteredFilter.value).filter((k) => k !== 'text').length +
+		(allAccounts.value ? 1 : 0),
 )
 const showAdvancedFilters = ref(false)
 
@@ -227,8 +263,19 @@ const mailboxOptions = computed(() =>
 
 const results = createResource({
 	url: 'suite.mail.api.mail.search_mails',
-	makeParams: () => ({ account: store.accountId, filter: filteredFilter.value }),
+	makeParams: () => ({
+		account: store.accountId,
+		filter: filteredFilter.value,
+		all_accounts: allAccounts.value,
+	}),
 })
+
+// The query the results page reads to reproduce this search: the trimmed filters plus, when on, the
+// cross-account flag (kept out of `filter` so it never becomes a JMAP search condition on the server).
+const searchQuery = computed(() => ({
+	...filteredFilter.value,
+	...(allAccounts.value ? { all_accounts: '1' } : {}),
+}))
 
 const noOfAttachments = (result) =>
 	result.attachments?.filter((m) => m.filename && m.disposition === 'attachment').length || 0
@@ -243,17 +290,23 @@ watchDebounced(
 )
 
 const openSearchPage = () => {
-	router.push({ name: 'mail-mailbox', params: { mailbox: 'search' }, query: filteredFilter.value })
+	router.push({
+		name: 'mail-mailbox',
+		params: { accountId: store.accountId, mailbox: 'search' },
+		query: searchQuery.value,
+	})
 	show.value = false
 }
 
 const router = useRouter()
 
-const openThread = (threadID: string) => {
+// Open the result in its own account (tagged by the server) — for a cross-account search that may
+// differ from the active account; the mailbox route's guard switches to it.
+const openThread = (result: { account: string; thread_id: string }) => {
 	router.push({
 		name: 'mail-mail',
-		params: { mailbox: 'search', threadID },
-		query: filteredFilter.value,
+		params: { accountId: result.account, mailbox: 'search', threadID: result.thread_id },
+		query: searchQuery.value,
 	})
 	show.value = false
 }

--- a/frontend/src/apps/mail/components/Modals/SearchModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SearchModal.vue
@@ -123,12 +123,14 @@
 							<p class="truncate text-base-semibold">
 								{{ result.subject || __('[No subject]') }}
 							</p>
-							<p class="truncate text-sm">{{ getInterlocutors(result) }}</p>
-							<div
-								v-if="allAccounts && result.account_name"
-								class="bg-surface-gray-3 group-hover:bg-surface-gray-4 mr-1.5 inline-flex rounded p-1 text-xs font-medium"
-							>
-								{{ result.account_name }}
+							<div class="flex items-center gap-1 truncate text-sm">
+								<span class="truncate">{{ getInterlocutors(result) }}</span>
+								<template v-if="allAccounts && result.account_name">
+									<span aria-hidden="true" class="text-ink-gray-4">•</span>
+									<span class="text-ink-gray-4 shrink-0 text-xs">
+										{{ __('in {0}', [result.account_name]) }}
+									</span>
+								</template>
 							</div>
 							<div
 								v-for="m in result.mailboxes"

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -63,7 +63,7 @@
 				<div
 					class="relative flex items-center border-b border-l-transparent px-3.5 py-2.5 sm:border-l sm:px-5"
 				>
-					<div class="mr-5 max-sm:ml-3">
+					<div v-if="!isAllAccountsSearch" class="mr-5 max-sm:ml-3">
 						<Tooltip
 							:text="
 								isAllSelected
@@ -188,6 +188,7 @@
 								@click="toggleGroupCollapse(key)"
 							>
 								<div
+									v-if="!isAllAccountsSearch"
 									class="pr-7.5 checkbox-hitbox -m-3 cursor-pointer py-3 pl-6 sm:pl-3"
 									@click.stop.prevent="
 										toggleSelect(getGroupThreads(key), !isGroupSelected(key))
@@ -222,38 +223,27 @@
 							<MailListItem
 								v-for="mail in group"
 								ref="mailItems"
-								:key="mail.name"
+								:key="isAllAccountsSearch ? `${mail.account}:${mail.name}` : mail.name"
 								:mailbox
 								:mail
+								:account-id="isAllAccountsSearch ? mail.account : undefined"
+								:account-label="isAllAccountsSearch ? mail.account_name : undefined"
+								:selectable="!isAllAccountsSearch"
 								:is-selected="selections.includes(mail.thread_id)"
 								class="border-l-transparent sm:border-l"
 								:class="{
 									'!bg-surface-blue-1': mail.thread_id === threadID && !isMobile,
 									'!border-l-blue-500': mail.thread_id === threadInFocus,
 								}"
-								@set-seen="
-									(seen: boolean) =>
-										handleSetSeen({ [Number(seen)]: [mail.thread_id] })
-								"
-								@archive-thread="
-									mailbox === mailboxIds.sent
-										? handleAddThreadsToMailbox(mailboxIds.archive, [
-												mail.thread_id,
-											])
-										: handleMoveThreads({
-												[mailboxIds.archive]: [mail.thread_id],
-											})
-								"
-								@trash-thread="
-									handleMoveThreads({ [mailboxIds.trash]: [mail.thread_id] })
-								"
+								@set-seen="(seen: boolean) => rowSetSeen(mail, seen)"
+								@archive-thread="rowArchive(mail)"
+								@trash-thread="rowTrash(mail)"
 								@delete-thread="junkOrDeleteThreads([mail.thread_id], false)"
-								@set-flagged="
-									(flagged: boolean) =>
-										setFlaggedByThreadIDs([mail.thread_id], flagged)
-								"
+								@set-flagged="(flagged: boolean) => rowSetFlagged(mail, flagged)"
 								@set-selected="
-									(selected: boolean) => toggleSelect([mail.thread_id], selected)
+									(selected: boolean) =>
+										!isAllAccountsSearch &&
+										toggleSelect([mail.thread_id], selected)
 								"
 							/>
 						</template>
@@ -378,11 +368,19 @@ import {
 	Dialog,
 	Dropdown,
 	Tooltip,
+	call,
 	createResource,
 	usePageMeta,
 } from 'frappe-ui'
 
-import { getFormattedDate, isMac, raiseToast, shouldIgnoreKeypress, startResizing } from '@/apps/mail/utils'
+import {
+	getFormattedDate,
+	isMac,
+	raisePromiseToast,
+	raiseToast,
+	shouldIgnoreKeypress,
+	startResizing,
+} from '@/apps/mail/utils'
 import { useScreenSize, useSidebar, useUndo } from '@/apps/mail/utils/composables'
 import { useThreadActions } from '@/apps/mail/utils/useThreadActions'
 import { type MailboxRole, userStore } from '@/apps/mail/stores/user'
@@ -877,6 +875,11 @@ const onResetSuccess = () => {
 	scrollListToTop()
 }
 
+// Cross-account search: when the search dialog's "all accounts" toggle was on, the flag rides along in
+// the query (kept out of the filter conditions on the server). The merged results carry their owning
+// account, so each row opens in — and acts within — its own account (see the row-action wrappers).
+const isAllAccountsSearch = computed(() => mailbox === 'search' && route.query.all_accounts != null)
+
 // Reset resource for search: always the first window, over-fetching one row to drive `hasMore`.
 const searchResults = createResource({
 	url: 'suite.mail.api.mail.search_mails',
@@ -885,6 +888,7 @@ const searchResults = createResource({
 		filter: route.query,
 		limit: PAGE_LENGTH + 1,
 		start: 0,
+		all_accounts: isAllAccountsSearch.value,
 	}),
 	transform: (data: [Thread[], number]) => {
 		if (refreshMode.value) refreshSnapshot = threadsResource.value.data ?? []
@@ -980,6 +984,7 @@ const loadMoreSearch = createResource({
 		filter: route.query,
 		limit: PAGE_LENGTH + 1,
 		start: threadsResource.value.data.length,
+		all_accounts: isAllAccountsSearch.value,
 	}),
 	onSuccess: (data: [Thread[], number]) => appendThreads(data[0]),
 	onError: () => (loadingMore.value = false),
@@ -1089,7 +1094,12 @@ const restoreThreadsToList = (restored: Thread[]) => {
 
 watch(
 	() => [mailbox, accountId],
-	() => {
+	(_new, old) => {
+		// Opening a result in an all-accounts search switches the route's account (so the reading pane
+		// loads the thread from the right account) while the mailbox stays 'search'. The merged list spans
+		// every account, so a mere account switch mustn't reset it — keep the results and scroll position.
+		if (isAllAccountsSearch.value && mailbox === 'search' && old?.[0] === 'search') return
+
 		isMailboxLoaded.value = false
 		threadsResource.value.data = []
 		filter.value = localStorage.getItem(`user:${user.data.name}:filter:${mailbox}`) || null
@@ -1235,6 +1245,93 @@ const {
 	goToMailbox,
 	goToNextThreadOrMailbox,
 })
+
+// ── Cross-account search row actions ──────────────────────────────────────────────────────────────
+// In an all-accounts search the merged rows can belong to any account, so the shared handlers above
+// (which target the single active account) can't drive them. These act on each row's own account via
+// stateless call()s — mirroring the All Inboxes view — with the active account left untouched. Star and
+// read/unread update optimistically in place; archive/trash re-run the search on success, since a
+// result's membership is server-determined (an archived mail may still match the query). Delete is
+// account-agnostic (it targets Mail Message names), so it stays on the shared junk/delete flow below.
+const crossAccountSetSeen = (mail: Thread, seen: boolean) => {
+	if (mail.seen === (seen ? 1 : 0)) return
+	mail.seen = seen ? 1 : 0
+	call('suite.mail.api.mail.set_mails_seen', { account: mail.account, ids: [mail.id], seen })
+		.then(() => mailboxes.reload())
+		.catch((error) => {
+			mail.seen = seen ? 0 : 1 // revert the optimistic update
+			raiseToast(error?.messages?.[0] || error?.message, 'error')
+		})
+}
+
+const crossAccountSetFlagged = (mail: Thread, flagged: boolean) => {
+	mail.flagged = flagged ? 1 : 0
+	call('suite.mail.api.mail.set_flagged', {
+		account: mail.account,
+		ids: [mail.id],
+		flagged,
+	}).catch((error) => {
+		mail.flagged = flagged ? 0 : 1 // revert the optimistic update
+		raiseToast(error?.messages?.[0] || error?.message, 'error')
+	})
+}
+
+const crossAccountMoveOut = (
+	mail: Thread,
+	target: string | undefined,
+	loading: string,
+	success: string,
+	missing: string,
+) => {
+	if (!target) return raiseToast(missing, 'error')
+	raisePromiseToast(
+		() =>
+			call('suite.mail.api.mail.move_mails', {
+				account: mail.account,
+				ids: [mail.id],
+				mailbox: target,
+				clear_junk: true,
+			}).then(() => resetThreads(false)),
+		loading,
+		success,
+	)
+}
+
+// Route a list row's action to the cross-account handler in an all-accounts search, else to the shared
+// active-account handler (keeping single-account search behaviour identical).
+const rowSetSeen = (mail: Thread, seen: boolean) =>
+	isAllAccountsSearch.value
+		? crossAccountSetSeen(mail, seen)
+		: handleSetSeen({ [Number(seen)]: [mail.thread_id] })
+
+const rowSetFlagged = (mail: Thread, flagged: boolean) =>
+	isAllAccountsSearch.value
+		? crossAccountSetFlagged(mail, flagged)
+		: setFlaggedByThreadIDs([mail.thread_id], flagged)
+
+const rowArchive = (mail: Thread) =>
+	isAllAccountsSearch.value
+		? crossAccountMoveOut(
+				mail,
+				mail.archive,
+				__('Archiving...'),
+				__('Thread archived.'),
+				__('No Archive folder for this account.'),
+			)
+		: mailbox === mailboxIds.sent
+			? handleAddThreadsToMailbox(mailboxIds.archive, [mail.thread_id])
+			: handleMoveThreads({ [mailboxIds.archive]: [mail.thread_id] })
+
+const rowTrash = (mail: Thread) =>
+	isAllAccountsSearch.value
+		? crossAccountMoveOut(
+				mail,
+				mail.trash,
+				__('Moving to Trash...'),
+				__('Thread moved to Trash.'),
+				__('No Trash folder for this account.'),
+			)
+		: handleMoveThreads({ [mailboxIds.trash]: [mail.thread_id] })
 
 const showEmptyMailbox = ref(false)
 

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -1265,6 +1265,7 @@ const crossAccountSetSeen = (mail: Thread, seen: boolean) => {
 }
 
 const crossAccountSetFlagged = (mail: Thread, flagged: boolean) => {
+	if (mail.flagged === (flagged ? 1 : 0)) return
 	mail.flagged = flagged ? 1 : 0
 	call('suite.mail.api.mail.set_flagged', {
 		account: mail.account,

--- a/frontend/src/apps/mail/types/index.ts
+++ b/frontend/src/apps/mail/types/index.ts
@@ -156,9 +156,9 @@ export interface ComposeMailData {
 export interface Thread {
 	name: string
 	account: string
-	// Populated only by the All Inboxes view (get_all_inbox_threads): the owning account's display
-	// name and its Inbox/Archive/Trash mailbox ids, so a merged row can be opened in / acted on
-	// within the correct JMAP account.
+	// Populated by the cross-account views (All Inboxes' get_all_inbox_threads and search's
+	// search_mails): the owning account's display name and its Inbox/Archive/Trash mailbox ids, so a
+	// merged row can be opened in / acted on within the correct JMAP account.
 	account_name?: string
 	inbox?: string
 	archive?: string

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -774,17 +774,105 @@ def empty_user_mailbox(account: str, mailbox: str) -> None:
 
 @frappe.whitelist()
 def search_mails(
-	account: str, filter: dict | None = None, limit: int = 5, start: int = 0
+	account: str,
+	filter: dict | None = None,
+	limit: int = 5,
+	start: int = 0,
+	all_accounts: bool = False,
 ) -> tuple[list[dict], int]:
-	"""Returns search results for the given query."""
+	"""Returns search results for the given query.
+
+	By default the search is scoped to `account`. When `all_accounts` is truthy the query fans out
+	across every JMAP account the user owns and the results are merged newest-first, so a mail can be
+	found without remembering which account it landed in. Either way each result is tagged with its
+	owning account (and that account's Inbox/Archive/Trash mailbox ids) so the client can open — and
+	act on — it in the correct account.
+	"""
 
 	if not filter:
 		return ([], 0)
 
+	# `filter` may arrive carrying the search-page query blob (see MailboxView), which includes the
+	# out-of-band `all_accounts` flag — drop it so it never becomes a bogus JMAP search condition.
+	filter = {k: v for k, v in filter.items() if k != "all_accounts"}
+
+	# The flag crosses the wire as a bool, an int, or a "true"/"1" string depending on the caller, so
+	# normalize all truthy forms (cint("true") would be 0).
+	if str(all_accounts).lower() in ("1", "true"):
+		return _search_all_accounts(filter, limit=limit, start=start)
+
 	normalized_filter = normalize_filter(filter)
 	mails, total = search_messages(account, normalized_filter, position=start, limit=limit)
+	add_user_images_to_emails(account, mails)
+	_tag_search_results(account, mails)
 
-	return add_user_images_to_emails(account, mails), total
+	return mails, total
+
+
+def _search_all_accounts(filter: dict, limit: int, start: int) -> tuple[list[dict], int]:
+	"""Search across every JMAP account the user owns, returning a merged newest-first page.
+
+	Mirrors the All Inboxes fan-out (`get_all_inbox_threads`): each account is over-fetched to the
+	deepest global position this page can reach (`start + limit`, clamped), the results are tagged,
+	merged, sorted newest-first, then sliced to the requested window. `total` is the summed match
+	count across accounts.
+	"""
+
+	accounts = get_user_jmap_accounts()
+	if not accounts:
+		return ([], 0)
+
+	# Clamp user input before it fans out across accounts (see the All Inboxes bounds): limit to a sane
+	# page size, and start so the per-account fetch (start + limit) can never exceed ALL_INBOX_MAX_FETCH.
+	limit = min(max(cint(limit), 1), ALL_INBOX_MAX_LIMIT)
+	start = min(max(cint(start), 0), ALL_INBOX_MAX_FETCH - limit)
+	per_account_limit = start + limit
+
+	# Mailbox ids are account-specific, so a "Look In" folder filter can't carry across accounts.
+	filter = {k: v for k, v in filter.items() if k != "inMailbox"}
+	normalized_filter = normalize_filter(filter)
+
+	merged: list[dict] = []
+	total = 0
+	for account in accounts:
+		account_id = account["name"]
+		mails, account_total = search_messages(
+			account_id, normalized_filter, position=0, limit=per_account_limit
+		)
+		total += account_total
+		if not mails:
+			continue
+
+		add_user_images_to_emails(account_id, mails)
+		_tag_search_results(account_id, mails, account_name=account["_name"])
+		merged.extend(mails)
+
+	merged.sort(key=lambda mail: mail["received_at"], reverse=True)
+	return merged[start : start + limit], total
+
+
+def _tag_search_results(account: str, mails: list[dict], account_name: str | None = None) -> None:
+	"""Tag each result with its owning account and that account's Inbox/Archive/Trash mailbox ids.
+
+	Lets the client open a result in — and run per-row actions against — the correct JMAP account,
+	which matters when results are merged across accounts (the `all_accounts` search path)."""
+
+	if not mails:
+		return
+
+	if account_name is None:
+		account_name = frappe.db.get_value("JMAP Account", account, "_name")
+
+	inbox_id = get_mailbox_id_by_role(account, "inbox")
+	archive_id = get_mailbox_id_by_role(account, "archive")
+	trash_id = get_mailbox_id_by_role(account, "trash")
+
+	for mail in mails:
+		mail["account"] = account
+		mail["account_name"] = account_name
+		mail["inbox"] = inbox_id
+		mail["archive"] = archive_id
+		mail["trash"] = trash_id
 
 
 def normalize_filter(filter: dict) -> dict:


### PR DESCRIPTION
Closes #71

## What

Adds an opt-in **"Search across all accounts"** toggle to the search dialog. It defaults **off**, so a search stays scoped to the current account for speed. When on, the query fans out across every JMAP account the user owns and the results are merged newest-first — so a mail can be found without remembering which account it landed in.

## Backend (`suite/mail/api/mail.py`)

- `search_mails` gains an `all_accounts` flag. When set, `_search_all_accounts` fans out across all of the user's accounts, over-fetching, merging newest-first, and slicing — mirroring the All Inboxes fan-out (`get_all_inbox_threads`) and reusing its `ALL_INBOX_MAX_*` bounds. `total` is the summed match count.
- Every result (both scoped and cross-account) is tagged with its owning account and that account's Inbox/Archive/Trash mailbox ids (`_tag_search_results`), so the client can open — and act on — it in the correct account.
- The flag is normalized across bool/int/string forms and kept out of the JMAP filter conditions; `inMailbox` is dropped in cross-account mode (folder ids are per-account).

## Frontend

- **SearchModal** — a `Switch` shown only when the user has more than one account, persisted to localStorage. The merged preview shows an account badge per result; clicking opens the thread in its own account. "Look In" is hidden/reset in cross-account mode.
- **MailboxView** (the "View more" results page) — passes `all_accounts` through; rows show account badges. Opening a result switches the active account (via the route guard), so the reading pane and its actions target the correct account. Per-row quick actions (read/star/archive/trash) route to each row's own account via stateless calls (the All Inboxes pattern); cross-account bulk selection is disabled.
- **MailListItemActions** — Archive/Trash/Delete visibility prefers the row's own mailbox ids (correct for cross-account rows), falling back to the active account.

## Testing

- `vite build`, `ruff check`, `ruff format --check`, `py_compile` all pass.
- ⚠️ Not yet exercised end-to-end in a live app; worth a manual pass with a multi-account setup before merging.
