### PR TITLE
feat(mail): optimistic UI for thread & message actions

### DIFF
--- a/frontend/src/apps/mail/components/MailActions.vue
+++ b/frontend/src/apps/mail/components/MailActions.vue
@@ -45,7 +45,7 @@ import { Button, Dropdown, createResource } from 'frappe-ui'
 import {
 	downloadUrlAsFile,
 	matchesScreenedValue,
-	raisePromiseToast,
+	raiseOptimisticToast,
 	raiseToast,
 } from '@/apps/mail/utils'
 import { useScreenSize, useUndo } from '@/apps/mail/utils/composables'
@@ -306,21 +306,37 @@ const unblockEmailAddress = createResource({
 	makeParams: () => ({ account: store.accountId, emails: [mail.from_email] }),
 })
 
+// Optimistically reflect the sender's blocked state so the immediate toast isn't lying, mirroring the
+// backend exactly: blocking adds an exact-address 'Reject' entry (overriding any existing rule for the
+// sender); unblocking removes the exact-address entry — a '@domain' rule that also covers the sender is
+// left in place, just as the unscreen API leaves it. Returns a revert to restore the list on failure.
+const applyScreenOptimistic = (block: boolean) => {
+	const prev = screenedAddresses.data
+	if (!prev) return () => {}
+	const isExact = (a: ScreenedAddress) =>
+		!a.email.startsWith('@') && matchesScreenedValue(mail.from_email, a.email)
+	const kept = prev.filter((a: ScreenedAddress) => !isExact(a))
+	const blocked: ScreenedAddress = { email: mail.from_email, action: 'Reject', creation: '', modified: '' }
+	screenedAddresses.data = block ? [...kept, blocked] : kept
+	return () => (screenedAddresses.data = prev)
+}
+
 const handleBlockAddress = (block: boolean, isUndo = false) => {
-	const action = () =>
-		(block ? blockEmailAddress : unblockEmailAddress)
-			.submit()
-			.then(() => screenedAddresses.reload())
+	const revert = applyScreenOptimistic(block) // optimistic: the menu item flips before the request
+	const forward = (async () => {
+		try {
+			await (block ? blockEmailAddress : unblockEmailAddress).submit()
+		} catch (error) {
+			revert()
+			throw error
+		}
+		screenedAddresses.reload()
+	})()
 	const successMessage = block ? __('Sender blocked.') : __('Sender unblocked.')
 
-	if (isUndo) return raisePromiseToast(action, __('Undoing...'), successMessage)
+	if (isUndo) return raiseOptimisticToast(forward, successMessage)
 
 	setUndoAction(() => handleBlockAddress(!block, true))
-	raisePromiseToast(
-		action,
-		block ? __('Blocking sender...') : __('Unblocking sender...'),
-		successMessage,
-		undo,
-	)
+	raiseOptimisticToast(forward, successMessage, undo)
 }
 </script>

--- a/frontend/src/apps/mail/components/MailActions.vue
+++ b/frontend/src/apps/mail/components/MailActions.vue
@@ -40,7 +40,7 @@ import {
 	Star,
 	Trash2,
 } from 'lucide-vue-next'
-import { Button, Dropdown, createResource, toast } from 'frappe-ui'
+import { Button, Dropdown, createResource } from 'frappe-ui'
 
 import {
 	downloadUrlAsFile,
@@ -48,7 +48,7 @@ import {
 	raisePromiseToast,
 	raiseToast,
 } from '@/apps/mail/utils'
-import { useBlockSender, useScreenSize, useUndo } from '@/apps/mail/utils/composables'
+import { useScreenSize, useUndo } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 
 import type { ComposeMailData, Identity, Mail, ScreenedAddress } from '@/apps/mail/types'
@@ -79,7 +79,7 @@ const {
 	thread: Mail[]
 }>()
 
-const emit = defineEmits(['setFlagged', 'syncUnseen'])
+const emit = defineEmits(['setFlagged', 'syncUnseen', 'moveMail', 'markMailSpam', 'deleteMail'])
 
 const { isMobile } = useScreenSize()
 const route = useRoute()
@@ -89,7 +89,6 @@ const router = useRouter()
 const store = userStore()
 const { mailboxes, mailboxIds, identities, screenedAddresses } = store
 const { setUndoAction, undo } = useUndo()
-const { promptBlockSenders, willJunkSenders } = useBlockSender()
 const user = inject('$user')
 
 // A sender is "blocked" when screened with the Reject action (their mail is discarded) — either by their
@@ -180,25 +179,25 @@ const moreActions = (mail: Mail): GroupedAction[] => [
 			},
 			{
 				label: __('Mark as Junk'),
-				onClick: () => handleMarkAsSpam(true),
+				onClick: () => emit('markMailSpam', mail, true),
 				icon: CircleAlert,
 				condition: () => mailbox !== mailboxIds.drafts && mail.junk === 0,
 			},
 			{
 				label: __('Mark as Not Junk'),
-				onClick: () => handleMarkAsSpam(false),
+				onClick: () => emit('markMailSpam', mail, false),
 				icon: CircleCheck,
 				condition: () => mail.junk === 1,
 			},
 			{
 				label: __('Move to Trash'),
-				onClick: () => handleMoveMail(mailboxIds.trash),
+				onClick: () => emit('moveMail', mail, mailboxIds.trash),
 				icon: Trash2,
 				condition: () => mailbox !== mailboxIds.trash,
 			},
 			{
 				label: __('Delete Message'),
-				onClick: () => handleDeleteMail(),
+				onClick: () => emit('deleteMail', mail),
 				icon: Trash2,
 				condition: () => mailbox === mailboxIds.trash,
 			},
@@ -207,18 +206,6 @@ const moreActions = (mail: Mail): GroupedAction[] => [
 				onClick: () => handleMarkUnreadFromHere(),
 				icon: MailOpen,
 				condition: () => !mail.draft,
-			},
-			{
-				label: __('Accept Sender'),
-				onClick: () => handleScreenSender('Accepted'),
-				icon: CircleCheck,
-				condition: () => mailbox === mailboxIds.screener,
-			},
-			{
-				label: __('Reject Sender'),
-				onClick: () => handleScreenSender('Reject'),
-				icon: Ban,
-				condition: () => mailbox === mailboxIds.screener,
 			},
 			{
 				label: __('Block Sender'),
@@ -275,40 +262,6 @@ const downloadEmail = createResource({
 	onError: (error) => raiseToast(error.message, 'error'),
 })
 
-const markAsSpam = createResource({
-	url: 'suite.mail.api.mail.set_mails_spam_status',
-	makeParams: ({ spam }: { spam: boolean }) => ({ account: store.accountId, ids: [mail.id], spam }),
-})
-
-const handleMarkAsSpam = (spam: boolean, isUndo = false) => {
-	const action = () =>
-		markAsSpam.submit({ spam }).then(() => {
-			reloadMails(isUndo)
-			// After marking as Junk, apply the account's "on mark as junk" behaviour (silently junk the
-			// sender's future mail, or prompt to block). Not on the undo of Mark as Not Junk.
-			if (spam && !isUndo)
-				promptBlockSenders([{ name: mail.from_name, email: mail.from_email }])
-		})
-	// When the account auto-junks the sender, surface that as the single toast for the whole action.
-	const autoJunk =
-		spam && !isUndo && willJunkSenders([{ name: mail.from_name, email: mail.from_email }])
-	const successMessage = autoJunk
-		? __('Mails from sender will go to Junk.')
-		: spam
-			? __('Mail marked as Junk.')
-			: __('Mail marked as Not Junk.')
-
-	if (isUndo) return raisePromiseToast(action, __('Undoing...'), successMessage)
-
-	setUndoAction(() => handleMarkAsSpam(!spam, true))
-	raisePromiseToast(
-		action,
-		spam ? __('Marking as Junk...') : __('Marking as Not Junk...'),
-		successMessage,
-		undo,
-	)
-}
-
 const moveMail = createResource({
 	url: 'suite.mail.api.mail.move_mails',
 	makeParams: (mailbox: string) => ({
@@ -318,39 +271,6 @@ const moveMail = createResource({
 		clear_junk: mail.junk === 1 && mailbox !== mailboxIds.junk,
 	}),
 })
-
-const handleMoveMail = (mailbox: string, isUndo = false) => {
-	const action = () => moveMail.submit(mailbox).then(() => reloadMails(isUndo))
-	const mailboxName = mailboxes.data?.find((m) => m.id === mailbox)._name
-
-	if (isUndo)
-		return raisePromiseToast(
-			action,
-			__('Undoing...'),
-			__('Mail moved back to {0}.', [mailboxName]),
-		)
-
-	setUndoAction(() => handleMoveMail(mail.mailboxes[0].mailbox_id, true))
-	raisePromiseToast(
-		action,
-		__('Moving to {0}...', [mailboxName]),
-		__('Mail moved to {0}.', [mailboxName]),
-		undo,
-	)
-}
-
-const deleteMail = createResource({
-	url: 'suite.mail.doctype.mail_message.mail_message.bulk_delete',
-	makeParams: () => ({ names: [mail.name] }),
-	onSuccess: () => reloadMails(),
-})
-
-const handleDeleteMail = () =>
-	toast.promise(deleteMail.submit(), {
-		loading: __('Deleting...'),
-		success: __('Mail deleted.'),
-		error: __('Action failed. Please try again in some time.'),
-	})
 
 const setMailsSeen = createResource({
 	url: 'suite.mail.api.mail.set_mails_seen',
@@ -374,33 +294,6 @@ const handleMarkUnreadFromHere = () => {
 		.filter((m: Mail) => !m.draft)
 		.map((m: Mail) => m.id)
 	if (ids.length) setMailsSeen.submit({ ids })
-}
-
-// Screening-folder decisions: accept the sender (let future mail in, move this one to Inbox) or
-// reject them (discard future mail, move this one to Trash). The sieve regenerates from the list.
-const screenSender = createResource({
-	url: 'suite.mail.api.mail.screen_email_address',
-	makeParams: ({ action }: { action: string }) => ({
-		account: store.accountId,
-		email: mail.from_email,
-		action,
-	}),
-})
-
-const handleScreenSender = (action: 'Accepted' | 'Reject') => {
-	const accepted = action === 'Accepted'
-	const target = accepted ? mailboxIds.inbox : mailboxIds.trash
-	const run = async () => {
-		await screenSender.submit({ action })
-		screenedAddresses.reload()
-		await moveMail.submit(target)
-		reloadMails()
-	}
-	raisePromiseToast(
-		run,
-		accepted ? __('Accepting sender...') : __('Rejecting sender...'),
-		accepted ? __('Sender accepted.') : __('Sender rejected.'),
-	)
 }
 
 const blockEmailAddress = createResource({

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -272,25 +272,30 @@
 									<div v-if="filteredAttachments(mail).length" class="mt-8">
 										<div
 											v-if="zippableAttachments(mail).length > 1"
-											class="mb-3 flex items-center justify-between"
+											class="text-ink-gray-5 mb-3 flex items-center gap-1.5 text-sm"
 										>
-											<span class="text-ink-gray-5 text-sm">
+											<span>
 												{{
 													__('{0} attachments', [
 														String(filteredAttachments(mail).length),
 													])
 												}}
 											</span>
-											<Button
-												variant="ghost"
-												:icon="Download"
-												:label="__('Download all')"
-												:tooltip="__('Download all')"
-												:loading="downloadingZipMail === mail.name"
+											<span aria-hidden="true">·</span>
+											<button
+												class="hover:text-ink-gray-8 disabled:opacity-70"
+												:disabled="downloadingZipMail === mail.name"
+												:title="__('Download all')"
 												@click.stop.prevent="
 													downloadAttachmentsAsZip(mail)
 												"
-											/>
+											>
+												<LoaderCircle
+													v-if="downloadingZipMail === mail.name"
+													class="h-3.5 w-3.5 animate-spin"
+												/>
+												<Download v-else class="h-3.5 w-3.5" />
+											</button>
 										</div>
 										<div class="flex flex-wrap">
 											<AttachmentCapsule
@@ -380,7 +385,7 @@ import {
 	watch,
 } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { ChevronDown, Download, Forward, Reply, ReplyAll } from 'lucide-vue-next'
+import { ChevronDown, Download, Forward, LoaderCircle, Reply, ReplyAll } from 'lucide-vue-next'
 import { Alert, Avatar, Badge, Button, createResource } from 'frappe-ui'
 
 import { getAttachmentsZipUrl } from '@/apps/mail/resources'

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -353,9 +353,9 @@
 		/>
 	</div>
 
-	<div v-else class="h-full overflow-hidden">
+	<div v-else class="h-full overflow-hidden p-5">
 		<div
-			class="bg-surface-gray-1 m-5 flex h-[calc(100%-2.9em)] items-center justify-center rounded-md"
+			class="bg-surface-gray-1 flex h-full items-center justify-center rounded-md"
 		>
 			<div class="flex flex-col items-center space-y-3">
 				<NoMails class="text-ink-gray-2 h-16 w-16" />

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -118,6 +118,9 @@
 												emit('setFlagged', [id], flagged)
 										"
 										@sync-unseen="handleSyncUnseen"
+										@move-mail="(m: Mail, target: string) => emit('moveMail', m, target)"
+										@mark-mail-spam="(m: Mail, spam: boolean) => emit('markMailSpam', m, spam)"
+										@delete-mail="(m: Mail) => emit('deleteMail', m)"
 									/>
 								</div>
 								<div
@@ -196,6 +199,9 @@
 														emit('setFlagged', [id], flagged)
 												"
 												@sync-unseen="handleSyncUnseen"
+												@move-mail="(m: Mail, target: string) => emit('moveMail', m, target)"
+												@mark-mail-spam="(m: Mail, spam: boolean) => emit('markMailSpam', m, spam)"
+												@delete-mail="(m: Mail) => emit('deleteMail', m)"
 											/>
 										</div>
 									</div>
@@ -439,6 +445,9 @@ const emit = defineEmits([
 	'prevThread',
 	'nextThread',
 	'syncUnseen',
+	'moveMail',
+	'markMailSpam',
+	'deleteMail',
 ])
 
 const { isMobile } = useScreenSize()
@@ -548,10 +557,15 @@ const threadFallback = createResource({
 	onError: () => goToMailbox(),
 })
 
+// Mails optimistically removed from the pane (per-message trash/junk/delete) whose request is still in
+// flight. The server still returns them for a moment, so any re-derive — our own reload, the 30s poll,
+// or the new-mail socket — would otherwise re-add them here. Cleared when the open thread changes.
+const removedMailIds = new Set<string>()
+
 const transformThreadMails = (mails: Mail[]) =>
 	mails
 		// Read-only views (the Screener) pass an explicit message list that isn't scoped to a mailbox.
-		.filter((mail) => readonly || filterRelevantMails(mail))
+		.filter((mail) => readonly || (!removedMailIds.has(mail.id) && filterRelevantMails(mail)))
 		.map((mail) => ({
 			...mail,
 			groupedRecipients: getGroupedRecipients(mail.recipients, false),
@@ -702,6 +716,7 @@ watch(
 	() => threadID,
 	() => {
 		resetCollapsedGroup()
+		removedMailIds.clear()
 		thread.value = []
 		loadThread()
 	},
@@ -933,7 +948,28 @@ const syncMailboxMembership = (mailboxId: string, add: boolean) => {
 		)
 }
 
-defineExpose({ syncFlagged, syncMailboxMembership })
+// Optimistically drop a message from the pane (per-message trash/junk/delete) before its request
+// fires. Returns whether that emptied the visible thread (so the caller can close the pane + drop the
+// row from the list) and a rollback that restores the message in place. Action-agnostic.
+const removeMailFromView = (mailId: string): { emptied: boolean; rollback: () => void } => {
+	const idx = thread.value.findIndex((m: Mail) => m.id === mailId)
+	if (idx === -1) return { emptied: false, rollback: () => {} }
+	const [removed] = thread.value.splice(idx, 1)
+	removedMailIds.add(mailId)
+	return {
+		emptied: thread.value.length === 0,
+		rollback: () => {
+			removedMailIds.delete(mailId)
+			// Only re-insert into the pane if it's STILL showing this mail's thread. If the removal
+			// emptied the thread, the pane navigated to a different thread by now — splicing the mail in
+			// there would append it to an unrelated conversation. The undo restores the thread to the
+			// list instead; re-opening it reloads its messages fresh.
+			if (removed.thread_id === threadID) thread.value.splice(idx, 0, removed)
+		},
+	}
+}
+
+defineExpose({ syncFlagged, syncMailboxMembership, removeMailFromView })
 
 const focusedDraft = ref<string>()
 const showSendModal = ref(false)

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -145,7 +145,7 @@ import {
 } from 'lucide-vue-next'
 import { Breadcrumbs, Button, Dropdown, Tooltip, call, createResource, usePageMeta } from 'frappe-ui'
 
-import { getFormattedDate, raisePromiseToast, raiseToast } from '@/apps/mail/utils'
+import { getFormattedDate, raiseOptimisticToast, raiseToast } from '@/apps/mail/utils'
 import { useScreenSize, useSidebar } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
@@ -356,10 +356,16 @@ const messageIds = (thread: Thread) => (thread.messages ?? []).map((m) => m.id)
 
 // Optimistically drop the row. Its server row leaves the current view too, so the append offset
 // (data.length) stays aligned. If the list empties while more remain, reset to top (the sentinel
-// unmounts with an empty list and couldn't otherwise re-trigger a load).
+// unmounts with an empty list and couldn't otherwise re-trigger a load). Returns a restore closure
+// that re-inserts the row at its original index (or falls back to resetThreads if we had to reset).
 const removeFromList = (thread: Thread) => {
+	const index = threads.data?.findIndex((t: Thread) => threadKey(t) === threadKey(thread)) ?? -1
 	threads.data = threads.data?.filter((t: Thread) => threadKey(t) !== threadKey(thread))
-	if (!threads.data?.length && hasMore.value) resetThreads()
+	if (!threads.data?.length && hasMore.value) {
+		resetThreads()
+		return () => resetThreads()
+	}
+	return () => threads.data?.splice(index, 0, thread)
 }
 
 // Each action is a stateless one-shot `call()` rather than a shared createResource: rows act on
@@ -397,38 +403,30 @@ const handleSetFlagged = (thread: Thread, flagged: boolean) => {
 	})
 }
 
-// Optimistically drop the row, then move on the server. On success just refresh counts (the row and its
-// server row are both gone, so the append offset stays aligned and scroll is preserved). On failure,
-// reset to restore the true list (the row reappears); rethrow so the toast reports the error.
-const moveThreadOut = (thread: Thread, mailbox: string) =>
+// The row is already dropped optimistically by the caller, so move on the server directly. On success just
+// refresh counts (the row and its server row are both gone, so the append offset stays aligned and scroll is
+// preserved). On failure, restore the row in place via the passed closure; rethrow so the toast reports the error.
+const moveThreadOut = (thread: Thread, mailbox: string, restore: () => void) =>
 	call('suite.mail.api.mail.move_mails', {
 		account: thread.account,
 		ids: messageIds(thread),
 		mailbox,
 		clear_junk: true,
 	}).then(refreshCounts, (error) => {
-		resetThreads()
+		restore()
 		throw error
 	})
 
 const handleArchive = (thread: Thread) => {
 	if (!thread.archive) return raiseToast(__('No Archive folder for this account.'), 'error')
-	removeFromList(thread)
-	raisePromiseToast(
-		() => moveThreadOut(thread, thread.archive!),
-		__('Archiving...'),
-		__('Thread archived.'),
-	)
+	const restore = removeFromList(thread)
+	raiseOptimisticToast(moveThreadOut(thread, thread.archive!, restore), __('Thread archived.'))
 }
 
 const handleTrash = (thread: Thread) => {
 	if (!thread.trash) return raiseToast(__('No Trash folder for this account.'), 'error')
-	removeFromList(thread)
-	raisePromiseToast(
-		() => moveThreadOut(thread, thread.trash!),
-		__('Moving to Trash...'),
-		__('Thread moved to Trash.'),
-	)
+	const restore = removeFromList(thread)
+	raiseOptimisticToast(moveThreadOut(thread, thread.trash!, restore), __('Thread moved to Trash.'))
 }
 
 // Filter

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -323,6 +323,9 @@
 								: handleSetSpamStatus({ 0: [threadID!] })
 					"
 					@delete-thread="junkOrDeleteThreads([threadID!], false)"
+					@move-mail="handleMailMove"
+					@mark-mail-spam="handleMailSpam"
+					@delete-mail="handleMailDelete"
 					@prev-thread="goToThreadByOffset(-1)"
 					@next-thread="goToThreadByOffset(1)"
 				/>
@@ -814,6 +817,10 @@ let refreshEpoch = 0 // epoch captured when the refresh was triggered (dropped i
 // transform), not refresh-start, so it reflects any optimistic removals/undo-inserts that happened
 // while the refresh was in flight — otherwise a thread archived mid-refresh would reappear.
 let refreshSnapshot: Thread[] = []
+// Thread ids optimistically removed by an action whose request is still in flight. The server still
+// returns these for a moment, so a refresh/append landing in that window would re-insert the row; the
+// merges below skip them. Cleared on rollback (restoreThreadsToList) and after a short timeout.
+const recentlyRemoved = new Set<string>()
 // Current mailbox's record (carries total_threads/unread_threads); used by the periodic poll to
 // detect count changes and by the tab title's unread badge.
 const mailboxObj = computed(() => mailboxes.data?.find((m) => m.id === mailbox))
@@ -864,7 +871,9 @@ const onResetSuccess = () => {
 		const prevHeight = el?.scrollHeight ?? 0
 		const freshWindow = threadsResource.value.data ?? []
 		const existing = new Set(refreshSnapshot.map((t) => t.thread_id))
-		const fresh = freshWindow.filter((t: Thread) => !existing.has(t.thread_id))
+		const fresh = freshWindow.filter(
+			(t: Thread) => !existing.has(t.thread_id) && !recentlyRemoved.has(t.thread_id),
+		)
 		threadsResource.value.data = [...fresh, ...refreshSnapshot]
 		// Keep the reader where they were: shift scroll by the height the prepended rows added. If they
 		// were already at the top, leave them there so the new mail is visible.
@@ -951,7 +960,9 @@ const appendThreads = (rows: Thread[]) => {
 	// Discard a stale window that resolved after a reset began (mailbox switch, refresh, undo, …).
 	if (loadEpoch !== epoch.value) return
 	const seen = new Set(threadsResource.value.data.map((t: Thread) => t.thread_id))
-	const fresh = rows.slice(0, PAGE_LENGTH).filter((t) => !seen.has(t.thread_id))
+	const fresh = rows
+		.slice(0, PAGE_LENGTH)
+		.filter((t) => !seen.has(t.thread_id) && !recentlyRemoved.has(t.thread_id))
 	// Stop auto-loading if the window added nothing new (offset stuck behind heavy front-inserted mail);
 	// the next reset (poll/refresh/socket) reconciles. Guards against a tight reload loop while the
 	// sentinel stays in view.
@@ -1067,6 +1078,11 @@ const removeThreadsFromList = (thread_ids: string[]): Thread[] => {
 	threadsResource.value.data = data.filter(
 		(thread: Thread) => !thread_ids.includes(thread.thread_id),
 	)
+	// Suppress re-insertion by an in-flight refresh/append until the server-side removal lands.
+	thread_ids.forEach((id) => {
+		recentlyRemoved.add(id)
+		setTimeout(() => recentlyRemoved.delete(id), 15000)
+	})
 	if (!threadsResource.value.data.length && hasMore.value) resetThreads()
 	return removed
 }
@@ -1076,6 +1092,8 @@ const removeThreadsFromList = (thread_ids: string[]): Thread[] => {
 // scroll-anchoring holds the viewport as rows reappear above it.
 const restoreThreadsToList = (restored: Thread[]) => {
 	if (!restored.length) return
+	// A restored thread should be visible again — lift any removal suppression.
+	restored.forEach((t: Thread) => recentlyRemoved.delete(t.thread_id))
 	const list = [...(threadsResource.value.data ?? [])]
 	const present = new Set(list.map((t: Thread) => t.thread_id))
 	for (const thread of restored) {
@@ -1214,6 +1232,9 @@ const {
 	handleAddThreadsToMailbox,
 	handleRemoveThreadsFromMailbox,
 	junkOrDeleteThreads,
+	handleMailMove,
+	handleMailSpam,
+	handleMailDelete,
 	setFlagged,
 	moveToOptions,
 	addToOptions,

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -22,15 +22,7 @@
 		<Button :label="__('Review Now')" variant="ghost" @click="goToScreener" />
 	</div>
 
-	<div
-		v-if="
-			[mailboxIds.trash, mailboxIds.junk].includes(mailbox) &&
-			!threadsResource.data?.loading &&
-			threadsResource.data?.length &&
-			(showReadingPane || !threadID)
-		"
-		class="space-x-1 border-b px-3 py-2.5 sm:px-5"
-	>
+	<div v-if="showDeleteBanner" class="space-x-1 border-b px-3 py-2.5 sm:px-5">
 		<span class="text-ink-gray-5">
 			{{ __('Items in this mailbox will be automatically deleted after 30 days.') }}
 		</span>
@@ -40,7 +32,7 @@
 	<div
 		class="relative flex"
 		:class="
-			[mailboxIds.trash, mailboxIds.junk].includes(mailbox) || showScreenerBanner
+			showDeleteBanner || showScreenerBanner
 				? 'h-[calc(100dvh-6.1rem)]'
 				: 'h-[calc(100dvh-3.05rem)]'
 		"
@@ -946,6 +938,17 @@ const threads = createResource({
 })
 
 const threadsResource = computed(() => (mailbox === 'search' ? searchResults : threads))
+
+// The Trash/Junk "auto-deleted after 30 days" banner is about the whole mailbox, so show it whenever the
+// mailbox has threads — or a filter is applied (the filtered view may be empty while the mailbox isn't).
+// The layout below reserves height for it only when it's actually rendered, so the two stay in sync.
+const showDeleteBanner = computed(
+	() =>
+		[mailboxIds.trash, mailboxIds.junk].includes(mailbox) &&
+		!threadsResource.value.data?.loading &&
+		(!!threadsResource.value.data?.length || !!filter.value) &&
+		(showReadingPane.value || !threadID),
+)
 
 // ── Infinite scroll ─────────────────────────────────────────────────────────────────────────────
 // Two fetch paths that both write `threadsResource.value.data` — the single accumulated list every

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -797,6 +797,9 @@ const selectActions = computed((): SelectAction[] => [
 const PAGE_LENGTH = 25
 const hasMore = ref(false) // lookahead: the last fetched window returned an extra row, so more exist
 const loadingMore = ref(false) // an append fetch is in flight (drives the bottom spinner)
+// An optimistic removal emptied the list but more threads exist, so a refill is coming once the server
+// mutation lands. Keeps the loading state (not the empty state) during the gap before the refill fetch.
+const refillPending = ref(false)
 // Bumped on every reset-to-top; an in-flight append captures it and discards its result if it changed
 // meanwhile, so a stale window can't land on a freshly reset list.
 const epoch = ref(0)
@@ -1023,6 +1026,7 @@ const canGoNext = computed(() => hasMore.value)
 const isLoading = computed(() => {
 	if (!isMailboxLoaded.value) return true
 	if (emptyMailbox.loading) return true
+	if (refillPending.value) return true
 	return !threadsResource.value.data.length && threadsResource.value?.loading
 })
 
@@ -1039,6 +1043,9 @@ const resetThreads: (reloadMailboxes?: boolean, mailboxRoles?: MailboxRole[]) =>
 ) => {
 	if (mailboxRoles.length && !mailboxRoles.map((m) => mailboxIds[m]).includes(mailbox)) return
 
+	// This reload supersedes any pending refill (its own, or an interrupting mailbox switch); from here
+	// the resource's `loading` drives isLoading, so the flag has done its job.
+	refillPending.value = false
 	refreshMode.value = false
 	epoch.value++
 	resetSelections()
@@ -1073,8 +1080,7 @@ const syncAfterAction = () => {
 
 // Drops threads from the loaded list optimistically and returns the removed rows (so an undo can put
 // them back). Their server rows leave the current view too, so the append offset (data.length) stays
-// aligned. If the list empties while more remain, reset to top (the sentinel unmounts with an empty
-// list and couldn't otherwise re-trigger a load).
+// aligned.
 const removeThreadsFromList = (thread_ids: string[]): Thread[] => {
 	const data = threadsResource.value.data ?? []
 	const removed = data.filter((thread: Thread) => thread_ids.includes(thread.thread_id))
@@ -1086,8 +1092,20 @@ const removeThreadsFromList = (thread_ids: string[]): Thread[] => {
 		recentlyRemoved.add(id)
 		setTimeout(() => recentlyRemoved.delete(id), 15000)
 	})
-	if (!threadsResource.value.data.length && hasMore.value) resetThreads()
+	// If this emptied the list but more exist, a refill is coming (refillIfEmpty, once the mutation
+	// lands) — flag it so the empty state doesn't flash in the meantime.
+	if (!threadsResource.value.data.length && hasMore.value) refillPending.value = true
 	return removed
+}
+
+// When an optimistic removal empties the loaded list while more threads exist server-side (e.g. select
+// all + delete/move), refetch the first window so the view refills — the sentinel unmounts with an empty
+// list and couldn't otherwise re-trigger a load. Must run *after* the server mutation lands: a reset
+// mid-request refetches start:0 and gets the same not-yet-removed rows back (they'd reappear).
+const refillIfEmpty = () => {
+	if (!threadsResource.value.data.length && hasMore.value) resetThreads()
+	// resetThreads sets the resource loading (so isLoading holds the spinner from here); clear the flag.
+	refillPending.value = false
 }
 
 // Re-insert threads (after undoing a move/junk) at their correct position by received_at, so they
@@ -1095,6 +1113,8 @@ const removeThreadsFromList = (thread_ids: string[]): Thread[] => {
 // scroll-anchoring holds the viewport as rows reappear above it.
 const restoreThreadsToList = (restored: Thread[]) => {
 	if (!restored.length) return
+	// Rows are back (removal failed / undo), so no refill is coming — drop the pending-refill hold.
+	refillPending.value = false
 	// A restored thread should be visible again — lift any removal suppression.
 	restored.forEach((t: Thread) => recentlyRemoved.delete(t.thread_id))
 	const list = [...(threadsResource.value.data ?? [])]
@@ -1256,6 +1276,7 @@ const {
 	syncAfterAction,
 	removeThreadsFromList,
 	restoreThreadsToList,
+	refillIfEmpty,
 	goToMailbox,
 	goToNextThreadOrMailbox,
 })

--- a/frontend/src/apps/mail/utils/composables.ts
+++ b/frontend/src/apps/mail/utils/composables.ts
@@ -1,7 +1,7 @@
 import { computed, onMounted, onUnmounted, reactive, ref } from 'vue'
 import { createResource } from 'frappe-ui'
 
-import { matchesScreenedValue, raisePromiseToast, raiseToast } from '@/apps/mail/utils'
+import { matchesScreenedValue, raiseOptimisticToast, raiseToast } from '@/apps/mail/utils'
 import { userStore } from '@/apps/mail/stores/user'
 
 import type { COLOR_SCHEME, Identity, ScreenedAddress } from '@/apps/mail/types'
@@ -183,6 +183,26 @@ export const useBlockSender = () => {
 		onSuccess: () => screenedAddresses.reload(),
 	})
 
+	// Optimistically reflect the senders' blocked state so the immediate toast isn't lying, mirroring the
+	// backend exactly: blocking adds an exact-address 'Reject' entry per sender (overriding any existing
+	// rule); unblocking removes the exact-address entries — '@domain' rules that also cover a sender are
+	// left in place, just as the unscreen API leaves them. Returns a revert to restore the list on failure.
+	const applyScreenOptimistic = (emails: string[], block: boolean) => {
+		const prev = screenedAddresses.data
+		if (!prev) return () => {}
+		const isExact = (a: ScreenedAddress) =>
+			!a.email.startsWith('@') && emails.some((email) => matchesScreenedValue(email, a.email))
+		const kept = prev.filter((a: ScreenedAddress) => !isExact(a))
+		const blocked: ScreenedAddress[] = emails.map((email) => ({
+			email,
+			action: 'Reject',
+			creation: '',
+			modified: '',
+		}))
+		screenedAddresses.data = block ? [...kept, ...blocked] : kept
+		return () => (screenedAddresses.data = prev)
+	}
+
 	// Block the senders chosen in the prompt ('Ask to Block Sender' confirm). Blocking becomes the new
 	// undo action: Cmd+Z unblocks (it does not also reverse the junk move, which stays).
 	const blockSenders = (senders: BlockableSender[]) => {
@@ -190,15 +210,31 @@ export const useBlockSender = () => {
 		if (!emails.length) return
 
 		setUndoAction(() => {
-			const undoAction = () => unblockResource.submit({ emails })
+			const revert = applyScreenOptimistic(emails, false) // optimistic: unblock reflected at once
+			const forward = (async () => {
+				try {
+					await unblockResource.submit({ emails })
+				} catch (error) {
+					revert()
+					throw error
+				}
+			})()
 			const restored =
 				emails.length === 1 ? __('Sender unblocked.') : __('Senders unblocked.')
-			raisePromiseToast(undoAction, __('Undoing...'), restored)
+			raiseOptimisticToast(forward, restored)
 		})
 
-		const action = () => blockResource.submit({ emails })
+		const revert = applyScreenOptimistic(emails, true) // optimistic: senders shown blocked at once
+		const forward = (async () => {
+			try {
+				await blockResource.submit({ emails })
+			} catch (error) {
+				revert()
+				throw error
+			}
+		})()
 		const success = emails.length === 1 ? __('Sender blocked.') : __('Senders blocked.')
-		raisePromiseToast(action, __('Blocking...'), success, undo)
+		raiseOptimisticToast(forward, success, undo)
 	}
 
 	// File the senders' future mail into Junk (the default 'Junk Sender's Mail'). Side effect only — the
@@ -272,8 +308,8 @@ export const useTheme = () => {
 			name: userResource.data?.user_settings,
 			fieldname: { color_scheme },
 		}),
-		onSuccess: (data: { color_scheme: COLOR_SCHEME }) => {
-			raiseToast(__('Color scheme updated to {0}.', [data.color_scheme]))
+		onSuccess: () => {
+			// Reconcile the optimistic value against server truth (sets the same value; harmless).
 			userResource.reload()
 		},
 	})
@@ -283,7 +319,18 @@ export const useTheme = () => {
 		const current = userResource.data?.color_scheme
 		const idx = COLOR_SCHEME_CYCLE.indexOf(current as COLOR_SCHEME)
 		const next = COLOR_SCHEME_CYCLE[(idx + 1) % COLOR_SCHEME_CYCLE.length]
-		updateColorScheme.submit(next)
+
+		// Optimistic: flip the theme and confirm at once, before the server round-trip resolves.
+		const prev = current
+		if (userResource.data) userResource.data.color_scheme = next
+		raiseToast(__('Color scheme updated to {0}.', [next]))
+
+		updateColorScheme.submit(next, {
+			onError: () => {
+				if (userResource.data) userResource.data.color_scheme = prev
+				raiseToast(__('Failed to update color scheme. Please try again later.'), 'error')
+			},
+		})
 	}
 
 	return { dataTheme, cycleTheme }

--- a/frontend/src/apps/mail/utils/index.ts
+++ b/frontend/src/apps/mail/utils/index.ts
@@ -92,6 +92,25 @@ export const raisePromiseToast = (
 	toast.promise(action(), { loading, success, error })
 }
 
+// Toast for an OPTIMISTIC action: the UI has already updated, so show the success message (with an
+// optional Undo) immediately — no "…ing" loading phase. If the (already in-flight) request fails, the
+// caller rolls the UI back; this only swaps the confirmation for an error toast.
+export const raiseOptimisticToast = (
+	forward: Promise<unknown>,
+	success: string,
+	undoAction?: () => void,
+) => {
+	toast.removeAll()
+	const id = toast.success(
+		success,
+		undoAction ? { action: { label: __('Undo'), onClick: () => undoAction() } } : undefined,
+	)
+	forward.catch(() => {
+		toast.dismiss(id)
+		raiseToast(__('Action failed. Please try again later.'), 'error')
+	})
+}
+
 export const copyToClipBoard = async (text: string) => {
 	try {
 		await navigator.clipboard.writeText(text)

--- a/frontend/src/apps/mail/utils/useThreadActions.ts
+++ b/frontend/src/apps/mail/utils/useThreadActions.ts
@@ -232,13 +232,17 @@ export function useThreadActions(deps: {
 			})),
 	)
 
+	const mailboxEntry = (mailboxId: string): Mailbox | null => {
+		const mb = mailboxes.data?.find((m) => m.id === mailboxId)
+		return mb ? { mailbox: mb.name, mailbox_id: mb.id, mailbox_name: mb._name } : null
+	}
+
 	// Optimistically reflect an add/remove of a mailbox on the loaded list rows (thread summary + its
 	// nested messages) so MailListItem's folder tags update immediately, without waiting for a refetch.
 	// Mirrors MailThread.syncMailboxMembership, which does the same for the open thread's reading pane.
 	const syncListMailboxMembership = (mailboxId: string, threadIds: string[], add: boolean) => {
-		const mb = mailboxes.data?.find((m) => m.id === mailboxId)
-		if (!mb) return
-		const entry: Mailbox = { mailbox: mb.name, mailbox_id: mb.id, mailbox_name: mb._name }
+		const entry = mailboxEntry(mailboxId)
+		if (!entry) return
 		const apply = (item: { mailboxes: Mailbox[] }) => {
 			if (add) {
 				if (!item.mailboxes.some((m) => m.mailbox_id === mailboxId))
@@ -253,6 +257,32 @@ export function useThreadActions(deps: {
 				apply(t)
 				t.messages?.forEach(apply)
 			})
+	}
+
+	// Optimistically mirror a move on the rows that STAY in the list (Sent / Starred keptInList): each item
+	// (summary + nested messages) takes the target mailbox, keeping Sent for sent copies — exactly what the
+	// forward ops do server-side — so MailListItem's folder tags update at once instead of showing the old
+	// folder until a refetch. Returns a revert closure (restores the exact prior mailbox sets).
+	const syncListMove = (threadIDs: Record<string, string[]>) => {
+		const prev = new Map<{ mailboxes: Mailbox[] }, Mailbox[]>()
+		const sentEntry = mailboxEntry(mailboxIds.sent)
+		for (const [target, tids] of Object.entries(threadIDs)) {
+			const targetEntry = mailboxEntry(target)
+			if (!targetEntry) continue
+			threadsResource.value.data
+				?.filter((t: Thread) => tids.includes(t.thread_id))
+				.forEach((t: Thread) => {
+					;[t, ...(t.messages ?? [])].forEach((item: { mailboxes: Mailbox[] }) => {
+						prev.set(item, item.mailboxes)
+						const keepsSent = item.mailboxes.some((mb) => mb.mailbox_id === mailboxIds.sent)
+						item.mailboxes =
+							keepsSent && sentEntry
+								? [{ ...targetEntry }, { ...sentEntry }]
+								: [{ ...targetEntry }]
+					})
+				})
+		}
+		return () => prev.forEach((mailboxes, item) => (item.mailboxes = mailboxes))
 	}
 
 	const handleAddThreadsToMailbox = (mailboxId: string, threadIds: string[], isUndo = false) => {
@@ -623,17 +653,24 @@ export function useThreadActions(deps: {
 			}
 		}
 
-		// In Sent, a non-junk/trash move leaves the sent copies in Sent, so the threads stay here.
+		// In Sent, a non-junk/trash move leaves the sent copies in Sent; in Starred, any move other than to
+		// Trash keeps a non-junk/trash copy (and the flag), so the thread stays starred — either way the
+		// row stays in the list.
 		const keptInList =
-			mailbox.value === mailboxIds.sent && Object.keys(threadIDs).every((t) => !movesAll(t))
-		// In search/starred, membership is server-determined (a moved thread may still be starred / still
-		// match the query), so reconcile from the server *after* it responds instead of removing now.
-		const reconcileView = !keptInList && ['search', 'starred'].includes(mailbox.value)
+			(mailbox.value === mailboxIds.sent || mailbox.value === 'starred') &&
+			Object.keys(threadIDs).every((t) => !movesAll(t))
+		// Only Search stays server-reconciled: its membership is a text query we can't re-evaluate locally.
+		// Starred's rule (a non-junk/trash copy AND some flagged message) is computable from the loaded
+		// thread, so a move to Trash removes the row optimistically below.
+		const reconcileView = !keptInList && mailbox.value === 'search'
 
-		// Optimistic (plain mailbox): drop the rows now, before any request fires. Captured so a failure
-		// can restore them in place, and so undo can re-insert them.
+		// Optimistic (plain mailbox, or a Starred thread leaving via Trash): drop the rows now, before any
+		// request fires. Captured so a failure can restore them in place, and so undo can re-insert them.
+		// Pass excludeCommonMailboxes=false so the removal also applies in Starred (Search never reaches
+		// here — it's reconcileView).
 		let removedThreads: Thread[] = []
-		if (!keptInList && !reconcileView) removedThreads = handleSuccessAndRemoveFromList(threadIDs)
+		if (!keptInList && !reconcileView)
+			removedThreads = handleSuccessAndRemoveFromList(threadIDs, false)
 
 		const moveToMailboxName = mailboxes.data?.find(
 			(m) => m.id === Object.keys(threadIDs)[0],
@@ -686,8 +723,41 @@ export function useThreadActions(deps: {
 			return raiseOptimisticToast(forwardPromise, success, undo)
 		}
 
-		// Reconcile (search/starred) or keptInList (Sent): the list only changes once the server
-		// responds, so keep the loading → success toast.
+		if (keptInList) {
+			// The rows stay (Sent keeps its sent copy; a Starred thread keeps a non-junk/trash copy), but
+			// their folder tags change — update them now, before the request, and revert on failure/undo.
+			const revertMove = syncListMove(threadIDs)
+			let forwardOk = false
+			const forwardPromise = (async () => {
+				try {
+					for (const op of forward) await op()
+					forwardOk = true
+					mailboxes.reload()
+				} catch (error) {
+					revertMove()
+					setMailsMailboxes.submit({ mails: snapshot }).catch(() => {})
+					setUndoAction(undefined)
+					throw error
+				}
+			})()
+
+			setUndoAction(() =>
+				void (async () => {
+					await forwardPromise.catch(() => {})
+					if (!forwardOk) return
+					revertMove()
+					setUndoAction(undefined)
+					const restore = setMailsMailboxes
+						.submit({ mails: snapshot })
+						.then(() => mailboxes.reload())
+					raiseOptimisticToast(restore, movedBack)
+				})(),
+			)
+			return raiseOptimisticToast(forwardPromise, success, undo)
+		}
+
+		// Reconcile (Search only): membership is a server-side text query, so the list changes once the
+		// server responds — keep the loading → success toast.
 		const action = async () => {
 			try {
 				for (const op of forward) await op()
@@ -695,8 +765,7 @@ export function useThreadActions(deps: {
 				await setMailsMailboxes.submit({ mails: snapshot }).catch(() => {})
 				throw error
 			}
-			if (keptInList) syncAfterAction()
-			else handleSuccessAndRemoveFromList(threadIDs)
+			handleSuccessAndRemoveFromList(threadIDs)
 			setUndoAction(() => {
 				const undoAction = async () => {
 					await setMailsMailboxes.submit({ mails: snapshot })
@@ -734,12 +803,15 @@ export function useThreadActions(deps: {
 		// the same call as the mailbox restore.
 		const screenForward = spam ? (willJunkSenders(senders) ? 'Spam' : null) : 'Accepted'
 
-		// In search/starred, membership is server-determined — reconcile after the server responds.
-		const reconcileView = ['search', 'starred'].includes(mailbox.value)
+		// Only Search stays server-reconciled. Starred is computable: junking removes the last non-junk copy
+		// (→ the thread leaves), so junk there is optimistic; the rare Not-Junk-in-Starred keeps a non-junk
+		// copy (→ stays starred), so leave that one reconciled.
+		const reconcileView = mailbox.value === 'search' || (mailbox.value === 'starred' && !spam)
 
-		// Optimistic (plain mailbox): drop the rows now, before the request. Captured for rollback + undo.
+		// Optimistic (plain mailbox, or junking a Starred thread): drop the rows now, before the request.
+		// excludeCommonMailboxes=false so the removal also applies in Starred. Captured for rollback + undo.
 		let removedThreads: Thread[] = []
-		if (!reconcileView) removedThreads = handleSuccessAndRemoveFromList(threadIDs)
+		if (!reconcileView) removedThreads = handleSuccessAndRemoveFromList(threadIDs, false)
 
 		const restore = {
 			mails: snapshot,

--- a/frontend/src/apps/mail/utils/useThreadActions.ts
+++ b/frontend/src/apps/mail/utils/useThreadActions.ts
@@ -1,9 +1,9 @@
 import { type ComputedRef, type Ref, computed, h, ref } from 'vue'
 import { Icon } from 'frappe-ui/icons'
-import { createResource, toast } from 'frappe-ui'
+import { createResource } from 'frappe-ui'
 
 import { FOLDER_ICON_COLOR_MAP } from '@/apps/mail/constants'
-import { getIcon, raisePromiseToast, raiseToast } from '@/apps/mail/utils'
+import { getIcon, raiseOptimisticToast, raisePromiseToast, raiseToast } from '@/apps/mail/utils'
 import { useBlockSender, useUndo } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 
@@ -22,6 +22,7 @@ interface ThreadsResource {
 interface MailThreadInstance {
 	syncFlagged: (ids: string[], flagged: boolean) => void
 	syncMailboxMembership: (mailboxId: string, isMember: boolean) => void
+	removeMailFromView: (mailId: string) => { emptied: boolean; rollback: () => void }
 }
 
 /**
@@ -99,6 +100,10 @@ export function useThreadActions(deps: {
 		onSuccess: () => mailboxes.reload(),
 	})
 
+	// Optimistic star/unstar: flip `flagged` on the affected rows (and the open thread) *before* the
+	// request fires, remembering the prior state so a failure rolls it back. Both entry points — the
+	// list (setFlaggedByThreadIDs) and the reading pane (setFlagged.submit) — go through beforeSubmit.
+	let flagRollback: (() => void) | null = null
 	const setFlagged = createResource({
 		url: 'suite.mail.api.mail.set_flagged',
 		makeParams: ({ ids, flagged }: { ids: string[]; flagged: boolean }) => ({
@@ -106,14 +111,27 @@ export function useThreadActions(deps: {
 			ids,
 			flagged,
 		}),
-		onSuccess: ({ ids, flagged }: { ids: string[]; flagged: boolean }) => {
+		beforeSubmit: ({ ids, flagged }: { ids: string[]; flagged: boolean }) => {
+			const changed: Array<{ thread: Thread; prev: 0 | 1 }> = []
 			ids.forEach((id) => {
 				const thread = threadsResource.value.data?.find((t: Thread) => t.id === id)
-				if (thread) thread.flagged = flagged ? 1 : 0
+				if (thread) {
+					changed.push({ thread, prev: thread.flagged })
+					thread.flagged = flagged ? 1 : 0
+				}
 			})
 			if (threadID.value) mailThreadRef.value?.syncFlagged(ids, flagged)
+			flagRollback = () => {
+				changed.forEach(({ thread, prev }) => (thread.flagged = prev))
+				if (threadID.value) mailThreadRef.value?.syncFlagged(ids, !flagged)
+			}
 		},
-		onError: (error) => raiseToast(error.messages[0], 'error'),
+		onSuccess: () => (flagRollback = null),
+		onError: (error) => {
+			flagRollback?.()
+			flagRollback = null
+			raiseToast(error.messages[0], 'error')
+		},
 	})
 
 	const moveMails = createResource({
@@ -239,29 +257,54 @@ export function useThreadActions(deps: {
 
 	const handleAddThreadsToMailbox = (mailboxId: string, threadIds: string[], isUndo = false) => {
 		const mailboxName = mailboxes.data?.find((m) => m.id === mailboxId)?._name
-		const action = async () => {
-			await addMails.submit({ ids: allMailIds(threadIds), mailbox_id: mailboxId })
-			// The threads stay in the current view (only gain another mailbox) — no list refetch; update
-			// the list rows' folder tags in place instead, and refresh selections + sidebar counts.
+
+		// The threads stay in the current view (only gain another mailbox) — no list refetch; toggle the
+		// folder tag on the list rows + the open thread. Applied before the request, reverted on failure.
+		const applyAdd = () => {
 			syncListMailboxMembership(mailboxId, threadIds, true)
-			syncAfterAction()
 			if (threadID.value && threadIds.includes(threadID.value))
 				mailThreadRef.value?.syncMailboxMembership(mailboxId, true)
 		}
-
-		if (isUndo) {
-			const success =
-				threadIds.length === 1 ? __('Thread added back.') : __('Threads added back.')
-			return raisePromiseToast(action, __('Undoing...'), success)
+		const revertAdd = () => {
+			syncListMailboxMembership(mailboxId, threadIds, false)
+			if (threadID.value && threadIds.includes(threadID.value))
+				mailThreadRef.value?.syncMailboxMembership(mailboxId, false)
 		}
 
-		setUndoAction(() => handleRemoveThreadsFromMailbox(mailboxId, threadIds, true))
-		const loading = __('Adding to {0}...', [mailboxName])
+		const mailIds = allMailIds(threadIds)
+		applyAdd() // optimistic: tag shown before the request
+
+		setUndoAction(undefined)
+		const forward = (async () => {
+			try {
+				await addMails.submit({ ids: mailIds, mailbox_id: mailboxId })
+			} catch (error) {
+				revertAdd()
+				if (!isUndo) setUndoAction(undefined)
+				throw error
+			}
+			syncAfterAction()
+		})()
+
+		if (isUndo) {
+			// Undo of a remove — immediate confirmation, no further undo.
+			const success =
+				threadIds.length === 1 ? __('Thread added back.') : __('Threads added back.')
+			return raiseOptimisticToast(forward, success)
+		}
+
+		// Undo = remove again, but only once the add has actually landed (no-op if it failed).
+		setUndoAction(() =>
+			void forward.then(
+				() => handleRemoveThreadsFromMailbox(mailboxId, threadIds, true),
+				() => {},
+			),
+		)
 		const success =
 			threadIds.length === 1
 				? __('Thread added to {0}.', [mailboxName])
 				: __('Threads added to {0}.', [mailboxName])
-		raisePromiseToast(action, loading, success, undo)
+		raiseOptimisticToast(forward, success, undo)
 	}
 
 	const removeFromOptions = computed(() => {
@@ -294,21 +337,49 @@ export function useThreadActions(deps: {
 			threadMails([threadId]).some(isRemovable),
 		)
 
-		const action = async () => {
-			const ids = threadMails(threadIdsToBeUpdated)
-				.filter(isRemovable)
-				.map((m) => m.id)
-			await removeMails.submit({ ids, mailbox_id: mailboxId })
-			// Removing from the current mailbox drops the threads from the view; removing from another
-			// mailbox leaves them here (they just lose that membership) — drop the tag from the list rows.
-			if (mailboxId === mailbox.value) removeThreadsFromList(threadIdsToBeUpdated)
-			else syncListMailboxMembership(mailboxId, threadIdsToBeUpdated, false)
-			syncAfterAction()
-			if (threadID.value && threadIdsToBeUpdated.includes(threadID.value)) {
-				if (mailboxId === mailbox.value) goToNextThreadOrMailbox(threadIdsToBeUpdated)
-				else mailThreadRef.value?.syncMailboxMembership(mailboxId, false)
+		// Removing from the current mailbox drops the rows from the view; removing from another mailbox
+		// leaves them here (they just lose that membership). Compute the mail ids now, before the
+		// optimistic mutation empties threadMails.
+		const isCurrentMailbox = mailboxId === mailbox.value
+		const ids = threadMails(threadIdsToBeUpdated)
+			.filter(isRemovable)
+			.map((m) => m.id)
+
+		let removedThreads: Thread[] = []
+		const applyRemove = () => {
+			if (isCurrentMailbox) {
+				if (threadID.value && threadIdsToBeUpdated.includes(threadID.value))
+					goToNextThreadOrMailbox(threadIdsToBeUpdated)
+				removedThreads = removeThreadsFromList(threadIdsToBeUpdated)
+			} else {
+				syncListMailboxMembership(mailboxId, threadIdsToBeUpdated, false)
+				if (threadID.value && threadIdsToBeUpdated.includes(threadID.value))
+					mailThreadRef.value?.syncMailboxMembership(mailboxId, false)
 			}
 		}
+		const revertRemove = () => {
+			if (isCurrentMailbox) {
+				if (removedThreads.length) restoreThreadsToList(removedThreads)
+			} else {
+				syncListMailboxMembership(mailboxId, threadIdsToBeUpdated, true)
+				if (threadID.value && threadIdsToBeUpdated.includes(threadID.value))
+					mailThreadRef.value?.syncMailboxMembership(mailboxId, true)
+			}
+		}
+
+		applyRemove() // optimistic: row/tag dropped before the request
+
+		setUndoAction(undefined)
+		const forward = (async () => {
+			try {
+				await removeMails.submit({ ids, mailbox_id: mailboxId })
+			} catch (error) {
+				revertRemove()
+				if (!isUndo) setUndoAction(undefined)
+				throw error
+			}
+			syncAfterAction()
+		})()
 
 		const mailboxName = mailboxes.data?.find((m) => m.id === mailboxId)?._name
 		const success =
@@ -316,11 +387,17 @@ export function useThreadActions(deps: {
 				? __('Thread removed from {0}.', [mailboxName])
 				: __('Threads removed from {0}.', [mailboxName])
 
-		if (isUndo) return raisePromiseToast(action, __('Undoing...'), success)
+		// Undo of an add — immediate confirmation, no further undo.
+		if (isUndo) return raiseOptimisticToast(forward, success)
 
-		setUndoAction(() => handleAddThreadsToMailbox(mailboxId, threadIdsToBeUpdated, true))
-		const loading = __('Removing from {0}...', [mailboxName])
-		raisePromiseToast(action, loading, success, undo)
+		// Undo = add back, but only once the remove has landed (no-op if it failed).
+		setUndoAction(() =>
+			void forward.then(
+				() => handleAddThreadsToMailbox(mailboxId, threadIdsToBeUpdated, true),
+				() => {},
+			),
+		)
+		raiseOptimisticToast(forward, success, undo)
 	}
 
 	const setMailsSpam = createResource({
@@ -422,12 +499,23 @@ export function useThreadActions(deps: {
 
 		// Apply optimistically so a quick reopen sees the new seen state immediately — waiting for the
 		// server round-trip would leave the thread's messages stale (no auto mark-as-read / unseen marker).
-		// (No-op for threads not in the list, e.g. ones opened via the get_thread fallback.)
-		threadsResource.value.data
-			?.filter((t: Thread) => selectedThreads.includes(t.thread_id))
-			.forEach((t: Thread) => {
-				t.seen = seen ? 1 : 0
-				t.messages?.forEach((message) => (message.seen = seen ? 1 : 0))
+		// (No-op for threads not in the list, e.g. ones opened via the get_thread fallback.) Snapshot the
+		// prior state first so a failure can roll it back.
+		const seenSnapshot = (threadsResource.value.data ?? [])
+			.filter((t: Thread) => selectedThreads.includes(t.thread_id))
+			.map((t: Thread) => ({
+				thread: t,
+				prev: t.seen,
+				messages: (t.messages ?? []).map((m) => ({ message: m, prev: m.seen })),
+			}))
+		seenSnapshot.forEach(({ thread }) => {
+			thread.seen = seen ? 1 : 0
+			thread.messages?.forEach((message) => (message.seen = seen ? 1 : 0))
+		})
+		const rollback = () =>
+			seenSnapshot.forEach(({ thread, prev, messages }) => {
+				thread.seen = prev
+				messages.forEach(({ message, prev }) => (message.seen = prev))
 			})
 		if (!seen && threadID.value && selectedThreads.includes(threadID.value)) goToMailbox()
 
@@ -435,16 +523,16 @@ export function useThreadActions(deps: {
 		// the open thread's mail ids from the reading pane (covers fallback threads not in the list).
 		const ids = mailIds ?? allMailIds(selectedThreads)
 
-		// The auto mark-as-read on opening a thread is silent (no toast).
-		if (silent) return void setSeen.submit({ ids, seen })
+		// The auto mark-as-read on opening a thread is silent (no toast); still roll back on failure.
+		if (silent) return void setSeen.submit({ ids, seen }, { onError: rollback })
 
-		const loading = seen ? __('Marking as read...') : __('Marking as unread...')
+		// The seen flag already flipped — confirm immediately; roll back + error toast only if it fails.
 		const success =
 			selectedThreads.length === 1
 				? __('Thread marked as {0}.', [seen ? __('read') : __('unread')])
 				: __('Threads marked as {0}.', [seen ? __('read') : __('unread')])
 
-		raisePromiseToast(() => setSeen.submit({ ids, seen }), loading, success)
+		raiseOptimisticToast(setSeen.submit({ ids, seen }, { onError: rollback }), success)
 	}
 
 	// "Mark Unread from Here" (set_mails_seen) marks individual messages unread. Sync those message ids
@@ -538,42 +626,89 @@ export function useThreadActions(deps: {
 		// In Sent, a non-junk/trash move leaves the sent copies in Sent, so the threads stay here.
 		const keptInList =
 			mailbox.value === mailboxIds.sent && Object.keys(threadIDs).every((t) => !movesAll(t))
+		// In search/starred, membership is server-determined (a moved thread may still be starred / still
+		// match the query), so reconcile from the server *after* it responds instead of removing now.
+		const reconcileView = !keptInList && ['search', 'starred'].includes(mailbox.value)
 
-		// The rows removed from the list on success, captured so undo can put them back in place.
+		// Optimistic (plain mailbox): drop the rows now, before any request fires. Captured so a failure
+		// can restore them in place, and so undo can re-insert them.
 		let removedThreads: Thread[] = []
-
-		const action = async () => {
-			for (const op of forward) await op()
-			if (keptInList) syncAfterAction()
-			else removedThreads = handleSuccessAndRemoveFromList(threadIDs)
-		}
-
-		setUndoAction(() => {
-			const undoAction = async () => {
-				await setMailsMailboxes.submit({ mails: snapshot })
-				// Re-insert the exact rows at their original position (no jump to top). The search/starred
-				// path removed nothing locally, so fall back to a reset there.
-				removedThreads.length ? restoreThreadsToList(removedThreads) : resetThreads()
-				mailboxes.reload()
-			}
-			raisePromiseToast(
-				undoAction,
-				__('Undoing...'),
-				selectedThreads.length === 1
-					? __('Thread moved back.')
-					: __('Threads moved back.'),
-			)
-		})
+		if (!keptInList && !reconcileView) removedThreads = handleSuccessAndRemoveFromList(threadIDs)
 
 		const moveToMailboxName = mailboxes.data?.find(
 			(m) => m.id === Object.keys(threadIDs)[0],
 		)?._name
-		const loading = __('Moving to {0}...', [moveToMailboxName])
+		const movedBack =
+			selectedThreads.length === 1 ? __('Thread moved back.') : __('Threads moved back.')
 		const success =
 			selectedThreads.length === 1
 				? __('Thread moved to {0}.', [moveToMailboxName])
 				: __('Threads moved to {0}.', [moveToMailboxName])
 
+		// Drop any prior undo so it isn't triggerable while this action is in flight.
+		setUndoAction(undefined)
+
+		if (!keptInList && !reconcileView) {
+			// Optimistic path: confirm immediately, arm undo now, fire the request in the background.
+			let forwardOk = false
+			const forwardPromise = (async () => {
+				try {
+					for (const op of forward) await op()
+					forwardOk = true
+					mailboxes.reload()
+				} catch (error) {
+					// Roll back the optimistic UI now, and undo any partial server move in the background
+					// (the snapshot restores the exact pre-move state) so the error toast isn't delayed.
+					restoreThreadsToList(removedThreads)
+					setMailsMailboxes.submit({ mails: snapshot }).catch(() => {})
+					setUndoAction(undefined)
+					throw error
+				}
+			})()
+
+			setUndoAction(() =>
+				void (async () => {
+					// Wait for the forward to settle (instant if already done); no-op if it failed.
+					await forwardPromise.catch(() => {})
+					if (!forwardOk) return
+					restoreThreadsToList(removedThreads)
+					setUndoAction(undefined)
+					const restore = setMailsMailboxes
+						.submit({ mails: snapshot })
+						.then(() => mailboxes.reload())
+						.catch((error) => {
+							removeThreadsFromList(removedThreads.map((t) => t.thread_id))
+							throw error
+						})
+					raiseOptimisticToast(restore, movedBack)
+				})(),
+			)
+			return raiseOptimisticToast(forwardPromise, success, undo)
+		}
+
+		// Reconcile (search/starred) or keptInList (Sent): the list only changes once the server
+		// responds, so keep the loading → success toast.
+		const action = async () => {
+			try {
+				for (const op of forward) await op()
+			} catch (error) {
+				await setMailsMailboxes.submit({ mails: snapshot }).catch(() => {})
+				throw error
+			}
+			if (keptInList) syncAfterAction()
+			else handleSuccessAndRemoveFromList(threadIDs)
+			setUndoAction(() => {
+				const undoAction = async () => {
+					await setMailsMailboxes.submit({ mails: snapshot })
+					resetThreads()
+					mailboxes.reload()
+				}
+				raisePromiseToast(undoAction, __('Undoing...'), movedBack)
+			})
+			mailboxes.reload()
+		}
+
+		const loading = __('Moving to {0}...', [moveToMailboxName])
 		raisePromiseToast(action, loading, success, undo)
 	}
 
@@ -599,35 +734,22 @@ export function useThreadActions(deps: {
 		// the same call as the mailbox restore.
 		const screenForward = spam ? (willJunkSenders(senders) ? 'Spam' : null) : 'Accepted'
 
-		// The rows removed from the list on success, captured so undo can put them back in place.
+		// In search/starred, membership is server-determined — reconcile after the server responds.
+		const reconcileView = ['search', 'starred'].includes(mailbox.value)
+
+		// Optimistic (plain mailbox): drop the rows now, before the request. Captured for rollback + undo.
 		let removedThreads: Thread[] = []
+		if (!reconcileView) removedThreads = handleSuccessAndRemoveFromList(threadIDs)
 
-		const action = async () => {
-			await setMailsSpam.submit({ ids, spam, screen_action: screenForward })
-			removedThreads = handleSuccessAndRemoveFromList(threadIDs)
-			// 'Ask to Block Sender' mode: junking still prompts to fully block the sender (Reject).
-			if (spam && !screenForward) promptBlockSenders(senders)
+		const restore = {
+			mails: snapshot,
+			screen_action: screenForward ? (spam ? 'Accepted' : 'Spam') : null,
 		}
-
-		setUndoAction(() => {
-			const undoAction = async () => {
-				await setMailsMailboxes.submit({
-					mails: snapshot,
-					screen_action: screenForward ? (spam ? 'Accepted' : 'Spam') : null,
-				})
-				// Re-insert the exact rows at their original position (no jump to top). The search/starred
-				// path removed nothing locally, so fall back to a reset there.
-				removedThreads.length ? restoreThreadsToList(removedThreads) : resetThreads()
-				mailboxes.reload()
-			}
-			// Undo flips the junk status back — name the resulting state, like the forward toast does.
-			const restored =
-				selectedThreads.length === 1
-					? __('Thread marked as {0}.', [spam ? __('Not Junk') : __('Junk')])
-					: __('Threads marked as {0}.', [spam ? __('Not Junk') : __('Junk')])
-			raisePromiseToast(undoAction, __('Undoing...'), restored)
-		})
-		const loading = spam ? __('Marking as Junk...') : __('Marking as Not Junk...')
+		// Undo flips the junk status back — name the resulting state, like the forward toast does.
+		const restored =
+			selectedThreads.length === 1
+				? __('Thread marked as {0}.', [spam ? __('Not Junk') : __('Junk')])
+				: __('Threads marked as {0}.', [spam ? __('Not Junk') : __('Junk')])
 		// When the account auto-junks the sender, surface that as the single toast for the whole action.
 		const success =
 			spam && willJunkSenders(senders)
@@ -636,24 +758,194 @@ export function useThreadActions(deps: {
 					? __('Thread marked as {0}.', [spam ? __('Junk') : __('Not Junk')])
 					: __('Threads marked as {0}.', [spam ? __('Junk') : __('Not Junk')])
 
+		// 'Ask to Block Sender' mode: junking still prompts to fully block the sender (Reject).
+		const maybePromptBlock = () => spam && !screenForward && promptBlockSenders(senders)
+
+		// Drop any prior undo so it isn't triggerable while this action is in flight.
+		setUndoAction(undefined)
+
+		if (!reconcileView) {
+			// Optimistic path: confirm immediately, arm undo now, fire in the background.
+			let forwardOk = false
+			const forwardPromise = (async () => {
+				try {
+					await setMailsSpam.submit({ ids, spam, screen_action: screenForward })
+					forwardOk = true
+					mailboxes.reload()
+					maybePromptBlock()
+				} catch (error) {
+					// Single request: the server is unchanged on failure, so just restore the UI.
+					restoreThreadsToList(removedThreads)
+					setUndoAction(undefined)
+					throw error
+				}
+			})()
+
+			setUndoAction(() =>
+				void (async () => {
+					await forwardPromise.catch(() => {})
+					if (!forwardOk) return
+					restoreThreadsToList(removedThreads)
+					setUndoAction(undefined)
+					const undoReq = setMailsMailboxes
+						.submit(restore)
+						.then(() => mailboxes.reload())
+						.catch((error) => {
+							removeThreadsFromList(removedThreads.map((t) => t.thread_id))
+							throw error
+						})
+					raiseOptimisticToast(undoReq, restored)
+				})(),
+			)
+			return raiseOptimisticToast(forwardPromise, success, undo)
+		}
+
+		// Reconcile (search/starred): the list only changes once the server responds.
+		const action = async () => {
+			await setMailsSpam.submit({ ids, spam, screen_action: screenForward })
+			handleSuccessAndRemoveFromList(threadIDs)
+			setUndoAction(() => {
+				const undoAction = async () => {
+					await setMailsMailboxes.submit(restore)
+					resetThreads()
+					mailboxes.reload()
+				}
+				raisePromiseToast(undoAction, __('Undoing...'), restored)
+			})
+			mailboxes.reload()
+			maybePromptBlock()
+		}
+
+		const loading = spam ? __('Marking as Junk...') : __('Marking as Not Junk...')
 		raisePromiseToast(action, loading, success, undo)
 	}
 
 	const handleDeleteThreads = (thread_ids: string[]) => {
 		if (!thread_ids?.length) return
 
+		// Resolve mail names before the optimistic removal empties currentMailboxMails.
 		const names = currentMailboxMails(thread_ids).map((m) => m.name)
-		toast.promise(
-			bulkDelete
-				.submit({ names })
-				.then(() => handleSuccessAndRemoveFromList(thread_ids, false)),
+		// Optimistic: drop the rows now (excludeCommonMailboxes=false removes locally even in
+		// search/starred — a hard delete is unambiguous). No undo; restore the rows if the request fails.
+		const removed = handleSuccessAndRemoveFromList(thread_ids, false)
+		const forward = bulkDelete.submit({ names }).catch((error) => {
+			if (removed.length) restoreThreadsToList(removed)
+			throw error
+		})
+		raiseOptimisticToast(
+			forward,
+			thread_ids.length === 1 ? __('Thread deleted.') : __('Threads deleted.'),
+		)
+	}
+
+	// ── Per-message (single mail) actions from the reading pane ─────────────────────────────────────
+	// Optimistically drops the mail from the open thread's pane (via the exposed removeMailFromView); if
+	// that empties the thread's view, the pane closes and the thread row leaves the list — all before the
+	// request fires, mirroring the thread-level pattern. `undoReq` (when present) restores the server
+	// state for undo; `afterSuccess` runs once the forward request lands (e.g. the block-sender prompt).
+	const runMailRemoval = (
+		mail: Mail,
+		req: () => Promise<unknown>,
+		success: string,
+		opts: { undoReq?: () => Promise<unknown>; undoSuccess?: string; afterSuccess?: () => void } = {},
+	) => {
+		const { emptied, rollback } = mailThreadRef.value?.removeMailFromView(mail.id) ?? {
+			emptied: false,
+			rollback: () => {},
+		}
+		let removed: Thread[] = []
+		if (emptied) {
+			goToNextThreadOrMailbox([mail.thread_id])
+			removed = removeThreadsFromList([mail.thread_id])
+		}
+		const restoreUi = () => {
+			rollback()
+			if (removed.length) restoreThreadsToList(removed)
+		}
+
+		setUndoAction(undefined)
+		let forwardOk = false
+		const forwardPromise = (async () => {
+			try {
+				await req()
+				forwardOk = true
+				mailboxes.reload()
+				opts.afterSuccess?.()
+			} catch (error) {
+				restoreUi()
+				setUndoAction(undefined)
+				throw error
+			}
+		})()
+
+		if (!opts.undoReq) return raiseOptimisticToast(forwardPromise, success)
+
+		setUndoAction(() =>
+			void (async () => {
+				await forwardPromise.catch(() => {})
+				if (!forwardOk) return
+				restoreUi()
+				setUndoAction(undefined)
+				raiseOptimisticToast(
+					opts.undoReq!().then(() => mailboxes.reload()),
+					opts.undoSuccess ?? success,
+				)
+			})(),
+		)
+		raiseOptimisticToast(forwardPromise, success, undo)
+	}
+
+	const mailSnapshot = (mail: Mail) => [
+		{ id: mail.id, mailbox_ids: mail.mailboxes.map((mb) => mb.mailbox_id), junk: mail.junk },
+	]
+
+	const handleMailMove = (mail: Mail, target: string) => {
+		const snapshot = mailSnapshot(mail)
+		const mailboxName = mailboxes.data?.find((m) => m.id === target)?._name
+		runMailRemoval(
+			mail,
+			() =>
+				moveMails.submit({
+					ids: [mail.id],
+					mailbox: target,
+					clear_junk: mail.junk === 1 && target !== mailboxIds.junk,
+				}),
+			__('Mail moved to {0}.', [mailboxName]),
+			{ undoReq: () => setMailsMailboxes.submit({ mails: snapshot }), undoSuccess: __('Mail moved back.') },
+		)
+	}
+
+	const handleMailSpam = (mail: Mail, spam: boolean) => {
+		const snapshot = mailSnapshot(mail)
+		const senders = [{ name: mail.from_name, email: mail.from_email }]
+		// Screen the sender in the same call (see handleSetSpamStatus): Junk → Spam (unless the account
+		// prompts to block instead), Not Junk → Accept.
+		const screenForward = spam ? (willJunkSenders(senders) ? 'Spam' : null) : 'Accepted'
+		const success =
+			spam && willJunkSenders(senders)
+				? __('Mails from sender will go to Junk.')
+				: spam
+					? __('Mail marked as Junk.')
+					: __('Mail marked as Not Junk.')
+		runMailRemoval(
+			mail,
+			() => setMailsSpam.submit({ ids: [mail.id], spam, screen_action: screenForward }),
+			success,
 			{
-				loading: __('Deleting...'),
-				success: thread_ids.length === 1 ? __('Thread deleted.') : __('Threads deleted.'),
-				error: __('Action failed. Please try again in some time.'),
+				undoReq: () =>
+					setMailsMailboxes.submit({
+						mails: snapshot,
+						screen_action: screenForward ? (spam ? 'Accepted' : 'Spam') : null,
+					}),
+				undoSuccess: __('Mail marked as {0}.', [spam ? __('Not Junk') : __('Junk')]),
+				// 'Ask to Block Sender' mode: junking still prompts to fully block the sender (Reject).
+				afterSuccess: () => spam && !screenForward && promptBlockSenders(senders),
 			},
 		)
 	}
+
+	const handleMailDelete = (mail: Mail) =>
+		runMailRemoval(mail, () => bulkDelete.submit({ names: [mail.name] }), __('Mail deleted.'))
 
 	const getOriginalState = (
 		selectedThreads: string[],
@@ -687,6 +979,10 @@ export function useThreadActions(deps: {
 		handleAddThreadsToMailbox,
 		handleRemoveThreadsFromMailbox,
 		junkOrDeleteThreads,
+		// Per-message (reading-pane) actions
+		handleMailMove,
+		handleMailSpam,
+		handleMailDelete,
 		// Resource exposed to the template (MailThread @set-flagged)
 		setFlagged,
 		// Toolbar option lists

--- a/frontend/src/apps/mail/utils/useThreadActions.ts
+++ b/frontend/src/apps/mail/utils/useThreadActions.ts
@@ -43,6 +43,9 @@ export function useThreadActions(deps: {
 	removeThreadsFromList: (threadIds: string[]) => Thread[]
 	// Re-insert threads at their sorted position (undo of a move/junk) without jumping to top.
 	restoreThreadsToList: (threads: Thread[]) => void
+	// Refetch the first window if an optimistic removal emptied the list while more threads exist. Call
+	// only after the server mutation lands, or the refetch returns the not-yet-removed rows.
+	refillIfEmpty: () => void
 	goToMailbox: () => void
 	goToNextThreadOrMailbox: (excludedThreads?: string[]) => void
 }) {
@@ -56,6 +59,7 @@ export function useThreadActions(deps: {
 		syncAfterAction,
 		removeThreadsFromList,
 		restoreThreadsToList,
+		refillIfEmpty,
 		goToMailbox,
 		goToNextThreadOrMailbox,
 	} = deps
@@ -409,6 +413,7 @@ export function useThreadActions(deps: {
 				throw error
 			}
 			syncAfterAction()
+			refillIfEmpty()
 		})()
 
 		const mailboxName = mailboxes.data?.find((m) => m.id === mailboxId)?._name
@@ -693,6 +698,7 @@ export function useThreadActions(deps: {
 					for (const op of forward) await op()
 					forwardOk = true
 					mailboxes.reload()
+					refillIfEmpty()
 				} catch (error) {
 					// Roll back the optimistic UI now, and undo any partial server move in the background
 					// (the snapshot restores the exact pre-move state) so the error toast isn't delayed.
@@ -844,6 +850,7 @@ export function useThreadActions(deps: {
 					await setMailsSpam.submit({ ids, spam, screen_action: screenForward })
 					forwardOk = true
 					mailboxes.reload()
+					refillIfEmpty()
 					maybePromptBlock()
 				} catch (error) {
 					// Single request: the server is unchanged on failure, so just restore the UI.
@@ -900,10 +907,13 @@ export function useThreadActions(deps: {
 		// Optimistic: drop the rows now (excludeCommonMailboxes=false removes locally even in
 		// search/starred — a hard delete is unambiguous). No undo; restore the rows if the request fails.
 		const removed = handleSuccessAndRemoveFromList(thread_ids, false)
-		const forward = bulkDelete.submit({ names }).catch((error) => {
-			if (removed.length) restoreThreadsToList(removed)
-			throw error
-		})
+		const forward = bulkDelete
+			.submit({ names })
+			.then(() => refillIfEmpty())
+			.catch((error) => {
+				if (removed.length) restoreThreadsToList(removed)
+				throw error
+			})
 		raiseOptimisticToast(
 			forward,
 			thread_ids.length === 1 ? __('Thread deleted.') : __('Threads deleted.'),
@@ -942,6 +952,7 @@ export function useThreadActions(deps: {
 				await req()
 				forwardOk = true
 				mailboxes.reload()
+				refillIfEmpty()
 				opts.afterSuccess?.()
 			} catch (error) {
 				restoreUi()

--- a/frontend/src/apps/mail/utils/useThreadActions.ts
+++ b/frontend/src/apps/mail/utils/useThreadActions.ts
@@ -756,6 +756,12 @@ export function useThreadActions(deps: {
 					const restore = setMailsMailboxes
 						.submit({ mails: snapshot })
 						.then(() => mailboxes.reload())
+						.catch((error) => {
+							// The undo didn't land server-side — re-apply the move to the tags so they
+							// match the server instead of showing the stale pre-move folder.
+							syncListMove(threadIDs)
+							throw error
+						})
 					raiseOptimisticToast(restore, movedBack)
 				})(),
 			)

--- a/frontend/src/apps/mail/utils/useThreadActions.ts
+++ b/frontend/src/apps/mail/utils/useThreadActions.ts
@@ -976,7 +976,16 @@ export function useThreadActions(deps: {
 				restoreUi()
 				setUndoAction(undefined)
 				raiseOptimisticToast(
-					opts.undoReq!().then(() => mailboxes.reload()),
+					opts
+						.undoReq!()
+						.then(() => mailboxes.reload())
+						.catch((error) => {
+							// The undo didn't land server-side — re-remove so the UI matches the server
+							// instead of showing the mail (and its row) as restored.
+							mailThreadRef.value?.removeMailFromView(mail.id)
+							if (removed.length) removeThreadsFromList([mail.thread_id])
+							throw error
+						}),
 					opts.undoSuccess ?? success,
 				)
 			})(),

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -371,24 +371,20 @@ def serialize_thread(messages: list[dict], thread_messages: list[dict], latest: 
 
 	first = thread_messages[0]
 	latest = latest or messages[-1]
+	# The row's identity + state come from the thread's representative message in the CURRENT mailbox
+	# (`messages` is scoped to it), so its folder tags and junk/flag/seen reflect THIS view — not a
+	# sibling message that was moved to Junk/Trash/Sent. The activity fields (preview/date/sender) still
+	# come from `latest` (most recent activity across the whole conversation). For single-mailbox threads
+	# `current` and `latest` are the same message, so nothing changes.
+	current = messages[-1]
 
-	thread_fields = [
-		"name",
-		"id",
-		"thread_id",
-		"mailboxes",
-		"from_name",
-		"from_email",
-		"received_at",
-		"recipients",
-		"seen",
-		"draft",
-		"junk",
-		"flagged",
-		"preview",
-	]
+	# From the current-mailbox message: identity + state (so star/junk actions target the right mail).
+	current_fields = ["name", "id", "mailboxes", "seen", "junk", "flagged"]
+	# From the most recent activity: what the row displays.
+	activity_fields = ["thread_id", "from_name", "from_email", "received_at", "recipients", "draft", "preview"]
 	return {
-		**{field: latest[field] for field in thread_fields},
+		**{field: current[field] for field in current_fields},
+		**{field: latest[field] for field in activity_fields},
 		"subject": first["subject"],
 		"attachments": serialize_attachments(latest.get("attachments", [])),
 		"messages": [serialize_mail(message) for message in thread_messages],


### PR DESCRIPTION
## What & why

Mail actions previously waited on the server round-trip before the UI updated (a "Moving to Trash…" spinner, the row lingering, Undo only appearing after the server confirmed). This makes them **optimistic**: the UI updates *before* the request fires, with rollback on failure, so archive / trash / junk / delete / move / star / mark-read and add/remove-mailbox feel instant.

## Changes

**Thread-level (`useThreadActions.ts`)** — fire-now + rollback:
- Apply the optimistic change (remove rows / flip flags / toggle folder tags) before firing; on failure restore the rows in place (plus a compensating `setMailsMailboxes` for a partial multi-step move) and show an error toast.
- Undo is armed only on success and **awaits the forward promise**, so a stray Ctrl+Z can't fire a restore mid-flight; undo re-inserts rows at their sorted position.
- **Search/Starred** stay reconcile-based (membership is server-decided).

**Toasts (`raiseOptimisticToast` in `utils/index.ts`)**:
- Optimistic actions show the confirmation **immediately** (with Undo) — no "…ing" loading phase — and swap to an error toast only if the request fails. The loading/promise toast is kept for the genuinely-waiting reconcile/`keptInList` paths.

**Per-message reading-pane actions (`MailActions` → `MailThread` → `MailboxView`)**:
- Move to Trash / Mark as Junk / Not Junk / Delete Message are now optimistic — the message drops from the pane immediately; if that empties the thread's view the pane closes and the thread row leaves the list optimistically; undo restores.
- `MailThread` exposes `removeMailFromView` with a `removedMailIds` guard so a background poll/socket/reload can't re-add the in-flight message. Its rollback only re-inserts when the pane still shows that mail's thread — so undoing *after* the pane has navigated away can't append the mail to an unrelated conversation.

**Backend (`serialize_thread` in `mail.py`)**:
- Derive a thread row's identity + state (`mailboxes`, `junk`, `flag`, `seen`) from its message **in the current mailbox**, not the newest message across all mailboxes — so a thread whose latest message was junked/trashed no longer shows a stray **Junk/Trash tag in the Inbox**. Activity fields (preview/date/sender) still reflect most-recent activity; single-mailbox threads are unaffected.

## Test plan

In a mailbox with the reading pane open:
- Archive/trash/junk/delete a thread → the row disappears **instantly** with an immediate "…d · Undo" toast (no "…ing" phase); confirm in the Network tab the UI changed before the request resolved.
- Force a failure (offline/blocked endpoint) → the row/message is **restored to its spot** and the toast becomes an error; Undo no longer acts.
- **Undo** restores the thread/message in place; a Ctrl+Z during the request is a no-op.
- Per-message: trash a single-message thread's mail → pane navigates to the next thread, row leaves the list; Undo restores it **without** appending the mail to the now-open thread. Trash one message of a multi-message thread → only that message vanishes.
- A thread whose newest message is junked/trashed but which still has an Inbox message → the Inbox row shows **no** Junk/Trash tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)