### PR TITLE
fix(writer): scroll hierarchy and side-panel layout

### DIFF
--- a/frontend/src/apps/writer/components/CoreEditor.vue
+++ b/frontend/src/apps/writer/components/CoreEditor.vue
@@ -3,10 +3,10 @@
     <TextEditorFixedMenu v-if="editable"
       class="w-full max-w-[100vw] py-1.5 !px-4 md:px-0 overflow-x-auto flex shrink-0 border-b border-outline-elevation-2"
       :editor="editor" :items="menuButtons" />
-    <div class="relative flex flex-1 min-h-0 overflow-hidden">
+    <div class="relative flex flex-1 overflow-hidden">
       <ToC v-if="editor" :editor :anchors />
       <div id="editor-scroll-container" class="flex w-full min-w-0 overflow-y-auto overflow-x-hidden relative">
-        <div class="self-start flex flex-col flex-grow min-h-full border-x border-outline-gray-2"
+        <div class="self-start flex flex-col flex-grow min-h-full md:border-x border-outline-gray-2"
           @click="onBackgroundClick" @keydown="onEditorKeydown">
           <FTextEditor ref="textEditor" :upload-function="uploadFunction"
             :autofocus="true" v-model="localContent" placeholder="Start thinking..." :extensions="editorExtensions"
@@ -31,7 +31,7 @@
         <FloatingComments v-if="commentsPainted" v-model:active-comment="activeComment" :y-comments="comments" :file
           :show-comments :show-resolved :show-unanchored :editor @save="saveComments" />
       </div>
-      <div v-if="commentsPainted && comments._map.size" class="absolute top-4 right-4 z-10">
+      <div v-if="commentsPainted && comments._map.size" class="hidden md:block absolute top-4 right-4 z-10">
         <Dropdown :options="commentFilterOptions" placement="right">
           <Button :icon="LucideMessageSquareQuote" variant="outline" />
         </Dropdown>

--- a/frontend/src/apps/writer/components/FloatingComments.vue
+++ b/frontend/src/apps/writer/components/FloatingComments.vue
@@ -1,7 +1,7 @@
 <template>
   <div ref="scrollContainer"
-    class="sticky hidden md:flex flex-col gap-8 justify-start self-stretch bg-surface-base transition-[width,padding] duration-200"
-    :class="showComments && hasVisibleCards ? 'w-72 shrink-0 px-5' : 'w-0'">
+    class="sticky hidden md:flex flex-col gap-8 justify-start self-stretch shrink-0 bg-surface-base transition-[width,padding] duration-300 ease-in-out"
+    :class="showComments && hasVisibleCards ? 'w-72 px-5' : 'w-0'">
     <template v-if="showComments" v-for="comment in filteredComments" :key="comment.id">
       <div :id="'comment-' + comment.id" :ref="(el) => {
         if (el) commentRefs[comment.id] = el
@@ -243,20 +243,26 @@ function useYMapReactive(yMap) {
   const local = ref([])
 
   const update = () => {
+    const prev = new Map(local.value.map((c) => [c.id, c]))
     const arr = []
     yMap.forEach((v) => {
       let pos
       if (!v.anchor?.from) pos = commentPositions.value.get(v.id) ?? 0
       else pos = getEditorPos(v.anchor.from, props.editor)
-      arr.push({ ...v, pos })
+      const old = prev.get(v.id)
+      arr.push({ top: old?.top, detached: old?.detached, ...v, pos })
     })
     local.value = arr.sort((a, b) => a.pos - b.pos)
   }
 
   update()
-  yMap.observe(update)
+  const onChange = () => {
+    update()
+    setCommentHeights()
+  }
+  yMap.observe(onChange)
 
-  onBeforeUnmount(() => yMap.unobserve(update))
+  onBeforeUnmount(() => yMap.unobserve(onChange))
 
   return local
 }
@@ -415,7 +421,10 @@ onMounted(() => {
     setCommentHeights()
   }
   props.editor.view.dom.addEventListener('tab-changed', onTabChange)
+  const resizeObserver = new ResizeObserver(setCommentHeights)
+  resizeObserver.observe(props.editor.view.dom)
   onBeforeUnmount(() => {
+    resizeObserver.disconnect()
     try {
       const dom = props.editor?.view?.dom
       dom.removeEventListener('tab-changed', onTabChange)

--- a/frontend/src/apps/writer/components/ToC.vue
+++ b/frontend/src/apps/writer/components/ToC.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="editor && (hasContent || editor.isEditable)"
-    class="px-2.5 pt-3 gap-2 hidden md:block overflow-y-auto overflow-x-hidden flex-shrink-0 h-full transition-[width] duration-200"
+    class="px-2.5 pt-3 gap-2 hidden md:block overflow-y-auto overflow-x-hidden flex-shrink-0 h-full transition-[width] duration-300 ease-in-out"
     :class="show ? 'w-64' : 'w-12'">
     <div v-if="!show">
       <Button variant="ghost" :icon="h(show ? LucidePanelLeftClose : LucideTableOfContents, {


### PR DESCRIPTION
- Single scroll owner for the document; comments scroll with the editor, ToC scrolls independently
- Responsive prose width (drops `min-w`) — no more horizontally clipped/unreachable content in narrow windows
- ToC and comments gutter collapse to zero width when empty and animate open/closed; content recenters in the available space
- Comment filter button floats as an overlay (stays put while scrolling); full-height divider lines on the editor column
- Comment card positions survive Y.Map rebuilds (e.g. Resolve) and re-measure when the editor column resizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)