### PR TITLE
fix(meet): recover media after signaling and ICE failures

### DIFF
--- a/.github/workflows/meet-e2e.yml
+++ b/.github/workflows/meet-e2e.yml
@@ -179,6 +179,8 @@ jobs:
           WEBRTC_LISTEN_IP: 127.0.0.1
           WEBRTC_ANNOUNCED_IP: 127.0.0.1
           MEDIASOUP_NUM_WORKERS: 1
+          SOCKET_PING_INTERVAL: 1000
+          SOCKET_PING_TIMEOUT: 3000
 
       - name: Run E2E Tests
         working-directory: ${{ github.workspace }}/suite/meet/e2e
@@ -187,6 +189,8 @@ jobs:
           BASE_URL: http://meet.test:8000
           SFU_URL: http://localhost:3000
           CI: true
+          SFU_E2E_DISCONNECT_TEST: true
+          SFU_E2E_DISCONNECT_WAIT_MS: 7000
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4

--- a/frontend/src/apps/meet/composables/__tests__/useConnectionState.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useConnectionState.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { useConnectionState } from "../useConnectionState";
+
+describe("useConnectionState recovery timeline", () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	it("keeps the latest 40 recovery transitions", () => {
+		const connectionState = useConnectionState();
+
+		for (let index = 0; index < 41; index++) {
+			connectionState.setRecoveryState("reconnecting", `attempt-${index}`);
+		}
+
+		expect(connectionState.recoveryState).toBe("reconnecting");
+		expect(connectionState.recoveryTimeline).toHaveLength(40);
+		expect(connectionState.recoveryTimeline[0].detail).toBe("attempt-1");
+		expect(connectionState.recoveryTimeline[39].detail).toBe("attempt-40");
+	});
+
+	it("clears recovery state with the rest of the connection state", () => {
+		const connectionState = useConnectionState();
+		connectionState.setRecoveryState("failed", "session rebuild failed");
+
+		connectionState.$reset();
+
+		expect(connectionState.recoveryState).toBe("healthy");
+		expect(connectionState.recoveryTimeline).toEqual([]);
+	});
+});

--- a/frontend/src/apps/meet/composables/useConnectionState.ts
+++ b/frontend/src/apps/meet/composables/useConnectionState.ts
@@ -1,6 +1,22 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
 
+export type MeetingRecoveryState =
+	| "healthy"
+	| "reconnecting"
+	| "rejoining"
+	| "recovering_send"
+	| "recovering_receive"
+	| "failed";
+
+export type RecoveryTimelineEntry = {
+	at: string;
+	state: MeetingRecoveryState;
+	detail?: string;
+};
+
+const RECOVERY_TIMELINE_LIMIT = 40;
+
 export interface ConnectionState {
 	isConnecting: boolean;
 	connectionError: string | null;
@@ -14,6 +30,9 @@ export interface ConnectionState {
 	guestSfuUrl: string | null;
 	guestSfuPort: string | null;
 	guestSessionToken: string | null;
+	recoveryState: MeetingRecoveryState;
+	recoveryTimeline: RecoveryTimelineEntry[];
+	setRecoveryState: (state: MeetingRecoveryState, detail?: string) => void;
 	$reset: () => void;
 }
 
@@ -31,6 +50,16 @@ export const useConnectionState = defineStore("meet-connection", () => {
 	const guestSfuPort = ref<string | null>(null);
 	const guestSessionToken = ref<string | null>(null);
 	const justCreated = ref(false);
+	const recoveryState = ref<MeetingRecoveryState>("healthy");
+	const recoveryTimeline = ref<RecoveryTimelineEntry[]>([]);
+
+	function setRecoveryState(state: MeetingRecoveryState, detail?: string) {
+		recoveryState.value = state;
+		recoveryTimeline.value = [
+			...recoveryTimeline.value,
+			{ at: new Date().toISOString(), state, ...(detail ? { detail } : {}) },
+		].slice(-RECOVERY_TIMELINE_LIMIT);
+	}
 
 	function $reset() {
 		connectionError.value = null;
@@ -46,6 +75,8 @@ export const useConnectionState = defineStore("meet-connection", () => {
 		guestSfuPort.value = null;
 		guestSessionToken.value = null;
 		justCreated.value = false;
+		recoveryState.value = "healthy";
+		recoveryTimeline.value = [];
 	}
 
 	return {
@@ -62,6 +93,9 @@ export const useConnectionState = defineStore("meet-connection", () => {
 		guestSfuPort,
 		guestSessionToken,
 		justCreated,
+		recoveryState,
+		recoveryTimeline,
+		setRecoveryState,
 		$reset,
 	};
 });

--- a/frontend/src/apps/meet/composables/useE2EEConnectionHandshake.ts
+++ b/frontend/src/apps/meet/composables/useE2EEConnectionHandshake.ts
@@ -113,8 +113,8 @@ export function useE2EEConnectionHandshake(
 
 	function teardownRealtimeEventListeners(): void {
 		if (!realtimeListenersAttached) return;
-		sfuClient.off("e2ee:epoch");
-		sfuClient.off("reconnect");
+		sfuClient.off("e2ee:epoch", handleEpochMessageBound);
+		sfuClient.off("reconnect", handleSFUReconnectBound);
 		document.removeEventListener(
 			"meet:e2ee-host-enabled",
 			handleHostE2EEKeySetBound,

--- a/frontend/src/apps/meet/composables/useMeetingHandlers.ts
+++ b/frontend/src/apps/meet/composables/useMeetingHandlers.ts
@@ -309,6 +309,7 @@ export function useMeetingHandlers(deps: MeetingHandlersDeps) {
 			transportManager:
 				deps.sfuConnection.sfuManager.value?.transportManager || null,
 			sfuClient: deps.sfuConnection.sfuClient,
+			recoveryTimeline: deps.connectionState.recoveryTimeline,
 		});
 	};
 

--- a/frontend/src/apps/meet/composables/useSFUConnection.ts
+++ b/frontend/src/apps/meet/composables/useSFUConnection.ts
@@ -207,6 +207,10 @@ export function useSFUConnection(deps: {
 
 	const createSFUEventHandlers = () => {
 		return {
+			onRecoveryStateChange: (
+				state: Parameters<typeof connectionState.setRecoveryState>[0],
+				detail?: string,
+			) => connectionState.setRecoveryState(state, detail),
 			onParticipantJoined: handleParticipantJoined,
 			onParticipantLeft: handleParticipantLeft,
 			onParticipantUpdated: handleParticipantUpdated,

--- a/frontend/src/apps/meet/pages/Meeting.vue
+++ b/frontend/src/apps/meet/pages/Meeting.vue
@@ -70,6 +70,15 @@
 			<template v-else>
 			<div class="relative grid flex-1 min-h-0 grid-rows-[minmax(0,1fr)_auto] overflow-hidden">
 				<div
+					v-if="recoveryMessage"
+					class="absolute top-4 left-1/2 -translate-x-1/2 z-[60] max-w-[calc(100%-2rem)] rounded-full border border-blue-300/30 bg-blue-950/80 px-4 py-2 text-sm text-blue-50 shadow-lg backdrop-blur-md flex items-center gap-2"
+					role="status"
+					data-testid="meet-recovery-banner"
+				>
+					<Spinner class="h-4" />
+					<span>{{ recoveryMessage }}</span>
+				</div>
+				<div
 					v-if="e2eeJoinPendingMessage"
 					class="absolute top-4 left-1/2 -translate-x-1/2 z-[60] max-w-[calc(100%-2rem)] rounded-full border border-amber-300/30 bg-amber-950/80 px-4 py-2 text-sm text-amber-50 shadow-lg backdrop-blur-md flex items-center gap-2"
 					role="status"
@@ -549,6 +558,22 @@ provide("poll", poll);
 // --- Computed properties ---
 const isConnecting = computed(() => connectionState.isConnecting);
 const hasConnectionError = computed(() => !!connectionState.connectionError);
+const recoveryMessage = computed(() => {
+	switch (connectionState.recoveryState) {
+		case "reconnecting":
+			return "Reconnecting to the meeting...";
+		case "rejoining":
+			return "Restoring your meeting session...";
+		case "recovering_send":
+			return "Restoring your microphone and camera...";
+		case "recovering_receive":
+			return "Restoring incoming media...";
+		case "failed":
+			return "Connection recovery failed. Try leaving and joining again.";
+		default:
+			return "";
+	}
+});
 const isInLobby = computed(() => lobbyStore.isInLobby || false);
 const isWaitingForApproval = computed(
 	() => lobbyStore.isWaitingForApproval || false,

--- a/frontend/src/apps/meet/utils/SFUClient.ts
+++ b/frontend/src/apps/meet/utils/SFUClient.ts
@@ -215,6 +215,7 @@ export class SFUClient {
 	connected: boolean;
 	connectionDetails: ConnectionDetails;
 	eventHandlers: Map<string, SFUEventHandler>;
+	private eventListeners: Map<string, Set<SFUEventHandler>>;
 	isRefreshingToken: boolean;
 	tokenRefreshTimer: ReturnType<typeof setTimeout> | null;
 	ownSenderId: number | null;
@@ -236,6 +237,7 @@ export class SFUClient {
 			isCohost: false,
 		};
 		this.eventHandlers = new Map();
+		this.eventListeners = new Map();
 		this.isRefreshingToken = false;
 		this.tokenRefreshTimer = null;
 		this.ownSenderId = null;
@@ -593,7 +595,7 @@ export class SFUClient {
 		};
 
 		for (const [event, handler] of Object.entries(defaultHandlers)) {
-			this.eventHandlers.set(event, handler);
+			this.addEventListener(event, handler);
 		}
 	}
 
@@ -604,16 +606,42 @@ export class SFUClient {
 	}
 
 	on(event: string, handler: SFUEventHandler): void {
-		this.eventHandlers.set(event, handler);
-		this.signalChannel.on(event, handler);
+		const hadDispatcher = this.eventHandlers.has(event);
+		this.addEventListener(event, handler);
+		if (!this.connected || !hadDispatcher) {
+			this.signalChannel.on(event, this.eventHandlers.get(event) as SFUEventHandler);
+		}
 	}
 
-	off(event: string): void {
-		const handler = this.eventHandlers.get(event);
+	off(event: string, handler?: SFUEventHandler): void {
 		if (handler) {
-			this.signalChannel.off(event, handler);
+			const listeners = this.eventListeners.get(event);
+			listeners?.delete(handler);
+			if (listeners?.size) return;
+		}
+
+		const dispatcher = this.eventHandlers.get(event);
+		if (dispatcher) {
+			this.signalChannel.off(event, dispatcher);
 		}
 		this.eventHandlers.delete(event);
+		this.eventListeners.delete(event);
+	}
+
+	private addEventListener(event: string, handler: SFUEventHandler): void {
+		let listeners = this.eventListeners.get(event);
+		if (!listeners) {
+			listeners = new Set();
+			this.eventListeners.set(event, listeners);
+		}
+		listeners.add(handler);
+
+		if (this.eventHandlers.has(event)) return;
+		this.eventHandlers.set(event, (...args: unknown[]) => {
+			for (const listener of this.eventListeners.get(event) || []) {
+				listener(...args);
+			}
+		});
 	}
 
 	// ==================== WEBRTC OPERATIONS ====================

--- a/frontend/src/apps/meet/utils/SFUClient.ts
+++ b/frontend/src/apps/meet/utils/SFUClient.ts
@@ -608,7 +608,7 @@ export class SFUClient {
 	on(event: string, handler: SFUEventHandler): void {
 		const hadDispatcher = this.eventHandlers.has(event);
 		this.addEventListener(event, handler);
-		if (!this.connected || !hadDispatcher) {
+		if (this.connected && !hadDispatcher) {
 			this.signalChannel.on(event, this.eventHandlers.get(event) as SFUEventHandler);
 		}
 	}

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -51,7 +51,14 @@ export class SFUMeetingManager {
 			transportManager: this.transportManager,
 			meetingId: () => this.connectionManager?.meetingId ?? null,
 			onRecovered: () => this.connectionManager?.resetReceiveSide(),
-			onFailed: () => this.connectionManager?.resetReceiveSide(),
+			onFailed: async (_reason, result) => {
+				if (result.send === "failed") {
+					await this.mediaManager.rebuildSendSide();
+				}
+				if (result.recv === "failed") {
+					await this.connectionManager?.resetReceiveSide();
+				}
+			},
 		});
 
 		this.mediaManager = new SFUMediaManager(

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -50,13 +50,29 @@ export class SFUMeetingManager {
 			sfuClient,
 			transportManager: this.transportManager,
 			meetingId: () => this.connectionManager?.meetingId ?? null,
-			onRecovered: () => this.connectionManager?.resetReceiveSide(),
+			onStarted: (reason) =>
+				this.connectionManager?.reportRecoveryState(
+					reason.includes("send") ? "recovering_send" : "recovering_receive",
+					reason,
+				),
+			onRecovered: async (reason) => {
+				await this.connectionManager?.resetReceiveSide();
+				this.connectionManager?.reportRecoveryState("healthy", reason);
+			},
 			onFailed: async (_reason, result) => {
-				if (result.send === "failed") {
-					await this.mediaManager.rebuildSendSide();
-				}
-				if (result.recv === "failed") {
-					await this.connectionManager?.resetReceiveSide();
+				try {
+					if (result.send === "failed") {
+						this.connectionManager?.reportRecoveryState("recovering_send", _reason);
+						await this.mediaManager.rebuildSendSide();
+					}
+					if (result.recv === "failed") {
+						this.connectionManager?.reportRecoveryState("recovering_receive", _reason);
+						await this.connectionManager?.resetReceiveSide();
+					}
+					this.connectionManager?.reportRecoveryState("healthy", _reason);
+				} catch (error) {
+					this.connectionManager?.reportRecoveryState("failed", _reason);
+					throw error;
 				}
 			},
 		});

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -61,13 +61,20 @@ export class SFUMeetingManager {
 			},
 			onFailed: async (_reason, result) => {
 				try {
+					const recoveries: Promise<unknown>[] = [];
 					if (result.send === "failed") {
 						this.connectionManager?.reportRecoveryState("recovering_send", _reason);
-						await this.mediaManager.rebuildSendSide();
+						recoveries.push(this.mediaManager.rebuildSendSide());
 					}
 					if (result.recv === "failed") {
 						this.connectionManager?.reportRecoveryState("recovering_receive", _reason);
-						await this.connectionManager?.resetReceiveSide();
+						recoveries.push(this.connectionManager.resetReceiveSide());
+					}
+					const failedRecovery = (await Promise.allSettled(recoveries)).find(
+						(result) => result.status === "rejected",
+					);
+					if (failedRecovery?.status === "rejected") {
+						throw failedRecovery.reason;
 					}
 					this.connectionManager?.reportRecoveryState("healthy", _reason);
 				} catch (error) {

--- a/frontend/src/apps/meet/utils/__tests__/SFUClient.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUClient.test.ts
@@ -106,6 +106,20 @@ describe("isConnected / getters", () => {
 	});
 });
 
+describe("event handler registration", () => {
+	it("registers pre-connect handlers with SignalChannel only once", () => {
+		const signalChannel = mockSignalChannel();
+		const client = new SFUClient(signalChannel);
+		client.on("custom_event", vi.fn());
+
+		client.registerEventHandlers();
+
+		expect(
+			signalChannel.on.mock.calls.filter(([event]) => event === "custom_event"),
+		).toHaveLength(1);
+	});
+});
+
 describe("isTokenExpiringSoon", () => {
 	it("returns false when tokenExpiresAt is far in the future", () => {
 		const client = createClient();
@@ -335,6 +349,7 @@ describe("on / off event handling", () => {
 		const client = createClient();
 		const handler = vi.fn();
 		client.on("participant_joined", handler);
+		client.registerEventHandlers();
 		const dispatcher = client.eventHandlers.get("participant_joined");
 		dispatcher?.();
 		expect(handler).toHaveBeenCalledTimes(1);

--- a/frontend/src/apps/meet/utils/__tests__/SFUClient.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUClient.test.ts
@@ -335,10 +335,12 @@ describe("on / off event handling", () => {
 		const client = createClient();
 		const handler = vi.fn();
 		client.on("participant_joined", handler);
-		expect(client.eventHandlers.get("participant_joined")).toBe(handler);
+		const dispatcher = client.eventHandlers.get("participant_joined");
+		dispatcher?.();
+		expect(handler).toHaveBeenCalledTimes(1);
 		expect(client.signalChannel.on).toHaveBeenCalledWith(
 			"participant_joined",
-			handler,
+			dispatcher,
 		);
 	});
 
@@ -350,8 +352,23 @@ describe("on / off event handling", () => {
 		expect(client.eventHandlers.has("participant_joined")).toBe(false);
 		expect(client.signalChannel.off).toHaveBeenCalledWith(
 			"participant_joined",
-			handler,
+			expect.any(Function),
 		);
+	});
+
+	it("keeps other listeners when removing one handler", () => {
+		const client = createClient();
+		const first = vi.fn();
+		const second = vi.fn();
+		client.on("reconnect", first);
+		client.on("reconnect", second);
+
+		client.off("reconnect", first);
+		client.eventHandlers.get("reconnect")?.(1);
+
+		expect(first).not.toHaveBeenCalled();
+		expect(second).toHaveBeenCalledWith(1);
+		expect(client.signalChannel.off).not.toHaveBeenCalled();
 	});
 });
 

--- a/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import { SFUMeetingManager } from "../SFUMeetingManager";
+
+describe("SFUMeetingManager recovery fallback", () => {
+	it("resets receive media when send rebuild fails", async () => {
+		const manager = new SFUMeetingManager({
+			isConnected: vi.fn(() => true),
+		} as never);
+		vi.spyOn(manager.transportManager, "restartAllTransportIce").mockResolvedValue({
+			send: "failed",
+			recv: "failed",
+		});
+		vi.spyOn(manager.mediaManager, "rebuildSendSide").mockRejectedValue(
+			new Error("send rebuild failed"),
+		);
+		const resetReceiveSide = vi
+			.spyOn(manager.connectionManager, "resetReceiveSide")
+			.mockResolvedValue();
+
+		await expect(
+			manager.recoveryManager.recoverTransportIce("transport_send_failed"),
+		).resolves.toBe("failed");
+
+		expect(resetReceiveSide).toHaveBeenCalledOnce();
+	});
+});

--- a/frontend/src/apps/meet/utils/diagnostics/problemReport.ts
+++ b/frontend/src/apps/meet/utils/diagnostics/problemReport.ts
@@ -1,4 +1,5 @@
 import type { SFUClient } from "../SFUClient";
+import type { RecoveryTimelineEntry } from "../../composables/useConnectionState";
 import { getConsoleLogLines, getConsoleLogSummary } from "./consoleBuffer";
 
 type TransportStats = {
@@ -26,6 +27,7 @@ type BuildProblemReportMailtoOptions = {
 	sfuClient?: SFUClient | null;
 	consoleLogLimit?: number;
 	maxBodyChars?: number;
+	recoveryTimeline?: RecoveryTimelineEntry[];
 };
 
 function getTransportStats(
@@ -60,6 +62,7 @@ async function buildProblemReportMailto(
 		sfuClient = null,
 		consoleLogLimit = 40,
 		maxBodyChars = 7000,
+		recoveryTimeline = [],
 	} = options;
 
 	const connectionStatus = sfuClient?.getConnectionStatus?.() || {
@@ -77,6 +80,7 @@ async function buildProblemReportMailto(
 	const consoleLogLines = getConsoleLogLines(consoleLogLimit);
 	const consoleSummary = getConsoleLogSummary();
 	const consoleHeader = `Console logs (last ${consoleLogLines.length}):`;
+	const recoveryHeader = `Recovery timeline (last ${recoveryTimeline.length}):`;
 
 	const bodyLines = [
 		"Hi,",
@@ -119,6 +123,11 @@ async function buildProblemReportMailto(
 		}`,
 		`- Console logs captured: ${consoleSummary.total}`,
 		`- Console errors/warnings: ${consoleSummary.error}/${consoleSummary.warn}`,
+		"",
+		recoveryHeader,
+		...recoveryTimeline.map(
+			(entry) => `- ${entry.at}: ${entry.state}${entry.detail ? ` (${entry.detail})` : ""}`,
+		),
 		"",
 		consoleHeader,
 		...consoleLogLines,

--- a/frontend/src/apps/meet/utils/media/TransportManager.ts
+++ b/frontend/src/apps/meet/utils/media/TransportManager.ts
@@ -15,6 +15,13 @@ import {
 
 type Direction = "send" | "recv";
 
+export type IceRestartDirectionResult = "restarted" | "not-needed" | "failed";
+
+export type TransportIceRestartResult = Record<
+	Direction,
+	IceRestartDirectionResult
+>;
+
 type TransportStatReport = {
 	type?: string;
 	state?: string;
@@ -372,15 +379,28 @@ export class TransportManager {
 		return true;
 	}
 
-	async restartAllTransportIce() {
-		const results = await Promise.allSettled([
-			this.restartTransportIce("send"),
-			this.restartTransportIce("recv"),
-		]);
+	async restartAllTransportIce(): Promise<TransportIceRestartResult> {
+		const restartDirection = async (
+			direction: Direction,
+		): Promise<IceRestartDirectionResult> => {
+			const transport =
+				direction === "send" ? this.sendTransport : this.recvTransport;
+			if (!transport) return "not-needed";
 
-		return results.some(
-			(result) => result.status === "fulfilled" && result.value === true,
-		);
+			try {
+				return (await this.restartTransportIce(direction))
+					? "restarted"
+					: "failed";
+			} catch {
+				return "failed";
+			}
+		};
+
+		const [send, recv] = await Promise.all([
+			restartDirection("send"),
+			restartDirection("recv"),
+		]);
+		return { send, recv };
 	}
 
 	async createProducer(

--- a/frontend/src/apps/meet/utils/media/TransportManager.ts
+++ b/frontend/src/apps/meet/utils/media/TransportManager.ts
@@ -337,6 +337,16 @@ export class TransportManager {
 		this.recvTransport = null;
 	}
 
+	closeSendTransport() {
+		if (!this.sendTransport) return;
+		try {
+			this.sendTransport.close();
+		} catch (_e) {
+			/* ignore */
+		}
+		this.sendTransport = null;
+	}
+
 	setupReceiveTransportHandlers() {
 		if (!this.recvTransport) return;
 		const client = this.getClient();

--- a/frontend/src/apps/meet/utils/media/__tests__/TransportManager.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/TransportManager.test.ts
@@ -261,7 +261,7 @@ describe("emitTransportConnectionState", () => {
 });
 
 describe("restartAllTransportIce", () => {
-	it("returns true if at least one transport ice restart succeeds", async () => {
+	it("reports a restarted send transport and no receive transport", async () => {
 		const manager = createManager();
 		manager.sfuClient = mockSfuClient() as never;
 		const restartIce = vi.fn();
@@ -277,10 +277,10 @@ describe("restartAllTransportIce", () => {
 				.restartWebRtcTransportIce as ReturnType<typeof vi.fn>,
 		).mockResolvedValue({ iceParams: true });
 		const result = await manager.restartAllTransportIce();
-		expect(result).toBe(true);
+		expect(result).toEqual({ send: "restarted", recv: "not-needed" });
 	});
 
-	it("returns false when all ice restarts fail", async () => {
+	it("reports a failed transport restart", async () => {
 		const manager = createManager();
 		manager.sfuClient = mockSfuClient() as never;
 		manager.sendTransport = {
@@ -295,7 +295,127 @@ describe("restartAllTransportIce", () => {
 				.restartWebRtcTransportIce as ReturnType<typeof vi.fn>,
 		).mockRejectedValue(new Error("fail"));
 		const result = await manager.restartAllTransportIce();
-		expect(result).toBe(false);
+		expect(result).toEqual({ send: "failed", recv: "not-needed" });
+	});
+
+	it("reports send success and receive failure independently", async () => {
+		const manager = createManager();
+		manager.sfuClient = mockSfuClient() as never;
+		manager.sendTransport = {
+			id: "send-tp",
+			connectionState: "connected",
+			restartIce: vi.fn(),
+			close: vi.fn(),
+			getStats: vi.fn(),
+		} as never;
+		manager.recvTransport = {
+			id: "recv-tp",
+			connectionState: "connected",
+			restartIce: vi.fn(),
+			close: vi.fn(),
+			getStats: vi.fn(),
+		} as never;
+		vi.mocked(
+			(manager.sfuClient as unknown as Record<string, unknown>)
+				.restartWebRtcTransportIce as ReturnType<typeof vi.fn>,
+		).mockImplementation((transportId: string) => {
+			return transportId === "send-tp"
+				? Promise.resolve({ iceParams: true })
+				: Promise.reject(new Error("recv failed"));
+		});
+
+		await expect(manager.restartAllTransportIce()).resolves.toEqual({
+			send: "restarted",
+			recv: "failed",
+		});
+	});
+
+	it("reports both active directions as restarted", async () => {
+		const manager = createManager();
+		manager.sfuClient = mockSfuClient() as never;
+		manager.sendTransport = {
+			id: "send-tp",
+			connectionState: "connected",
+			restartIce: vi.fn(),
+			close: vi.fn(),
+			getStats: vi.fn(),
+		} as never;
+		manager.recvTransport = {
+			id: "recv-tp",
+			connectionState: "connected",
+			restartIce: vi.fn(),
+			close: vi.fn(),
+			getStats: vi.fn(),
+		} as never;
+		vi.mocked(
+			(manager.sfuClient as unknown as Record<string, unknown>)
+				.restartWebRtcTransportIce as ReturnType<typeof vi.fn>,
+		).mockResolvedValue({ iceParams: true });
+
+		await expect(manager.restartAllTransportIce()).resolves.toEqual({
+			send: "restarted",
+			recv: "restarted",
+		});
+	});
+
+	it("reports send failure and receive success independently", async () => {
+		const manager = createManager();
+		manager.sfuClient = mockSfuClient() as never;
+		manager.sendTransport = {
+			id: "send-tp",
+			connectionState: "connected",
+			restartIce: vi.fn(),
+			close: vi.fn(),
+			getStats: vi.fn(),
+		} as never;
+		manager.recvTransport = {
+			id: "recv-tp",
+			connectionState: "connected",
+			restartIce: vi.fn(),
+			close: vi.fn(),
+			getStats: vi.fn(),
+		} as never;
+		vi.mocked(
+			(manager.sfuClient as unknown as Record<string, unknown>)
+				.restartWebRtcTransportIce as ReturnType<typeof vi.fn>,
+		).mockImplementation((transportId: string) => {
+			return transportId === "send-tp"
+				? Promise.reject(new Error("send failed"))
+				: Promise.resolve({ iceParams: true });
+		});
+
+		await expect(manager.restartAllTransportIce()).resolves.toEqual({
+			send: "failed",
+			recv: "restarted",
+		});
+	});
+
+	it("reports both active directions as failed when neither can restart", async () => {
+		const manager = createManager();
+		manager.sfuClient = mockSfuClient() as never;
+		manager.sendTransport = {
+			id: "send-tp",
+			connectionState: "connected",
+			restartIce: vi.fn(),
+			close: vi.fn(),
+			getStats: vi.fn(),
+		} as never;
+		manager.recvTransport = {
+			id: "recv-tp",
+			connectionState: "connected",
+			restartIce: vi.fn(),
+			close: vi.fn(),
+			getStats: vi.fn(),
+		} as never;
+		vi.mocked(
+			(manager.sfuClient as unknown as Record<string, unknown>)
+				.restartWebRtcTransportIce as ReturnType<typeof vi.fn>,
+		).mockRejectedValue(new Error("restart failed"));
+
+		await expect(manager.restartAllTransportIce()).resolves.toEqual({
+			send: "failed",
+			recv: "failed",
+		});
 	});
 });
 

--- a/frontend/src/apps/meet/utils/sfu/SFUConnectionManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUConnectionManager.ts
@@ -79,6 +79,9 @@ export class SFUConnectionManager {
 	initialSyncInProgress = false;
 	bufferedProducerEvents: SFUProducerEvent[] = [];
 	eventHandlers: SFUEventHandlers = {};
+	private lastJoinUserData: unknown = null;
+	private lastJoinMediaState: Record<string, unknown> = {};
+	private activeRejoin: Promise<void> | null = null;
 
 	constructor(options: ConnectionManagerOptions) {
 		this.sfuClient = options.sfuClient;
@@ -130,6 +133,11 @@ export class SFUConnectionManager {
 	async joinRoom(userData: unknown, mediaState: unknown): Promise<boolean> {
 		try {
 			await this.sfuClient.joinRoom(this.meetingId ?? "", userData, mediaState);
+			this.lastJoinUserData = userData;
+			this.lastJoinMediaState =
+				mediaState && typeof mediaState === "object"
+					? { ...(mediaState as Record<string, unknown>) }
+					: {};
 			console.log("Successfully joined room:", this.meetingId);
 			return true;
 		} catch (error) {
@@ -335,6 +343,41 @@ export class SFUConnectionManager {
 		}
 	}
 
+	async rejoinAfterSignalingReconnect(): Promise<void> {
+		if (this.activeRejoin) return this.activeRejoin;
+		if (!this.meetingId || !this.lastJoinUserData) {
+			throw new Error("Cannot rejoin before joining a meeting");
+		}
+
+		const rejoin = (async () => {
+			this.transportManager.closeReceiveTransport();
+			this.mediaManager.consumerManager.clear();
+			this.mediaManager.processedConsumers.clear();
+			this.mediaManager.isScreenShareActive = false;
+
+			await this.sfuClient.joinRoom(
+				this.meetingId as string,
+				this.lastJoinUserData,
+				this.getCurrentRejoinMediaState(),
+			);
+			if (!(await this.waitForE2EEContextIfRequired())) {
+				throw new Error("E2EE context is not ready after signaling reconnect");
+			}
+
+			await this.transportManager.initializeDevice();
+			if (!(await this.createReceiveTransport())) {
+				throw new Error("Failed to recreate receive transport after reconnect");
+			}
+			await this.mediaManager.rebuildSendSide();
+			await this.setupExistingParticipants();
+		})().finally(() => {
+			this.activeRejoin = null;
+		});
+		this.activeRejoin = rejoin;
+
+		return rejoin;
+	}
+
 	private hasConsumerForProducer(participantId: string, producerId: string): boolean {
 		const existingConsumers =
 			this.mediaManager.consumerManager.getConsumersByParticipant(participantId);
@@ -343,6 +386,21 @@ export class SFUConnectionManager {
 				!c.consumer.closed &&
 				(c.producerId === producerId || c.consumer.producerId === producerId),
 		);
+	}
+
+	private getCurrentRejoinMediaState(): Record<string, unknown> {
+		const localStream = this.mediaManager.mediaHandler.localStream;
+		if (!localStream) return this.lastJoinMediaState;
+
+		return {
+			...this.lastJoinMediaState,
+			audio_enabled: localStream
+				.getAudioTracks()
+				.some((track) => track.readyState === "live"),
+			video_enabled: localStream
+				.getVideoTracks()
+				.some((track) => track.readyState === "live"),
+		};
 	}
 
 	private async waitForE2EEContextIfRequired(): Promise<boolean> {
@@ -428,7 +486,9 @@ export class SFUConnectionManager {
 
 	private setupSFUEventHandlers(): void {
 		this.sfuClient.on("reconnect", () => {
-			void this.resyncAfterRecovery("socket_reconnect");
+			void this.rejoinAfterSignalingReconnect().catch((error) => {
+				console.warn("Failed to rejoin after signaling reconnect:", error);
+			});
 		});
 
 		this.sfuClient.on("participant_joined", (data: ParticipantData) => {
@@ -696,5 +756,8 @@ export class SFUConnectionManager {
 		this.eventHandlers = {};
 		this.isConnected = false;
 		this.initialSyncInProgress = false;
+		this.lastJoinUserData = null;
+		this.lastJoinMediaState = {};
+		this.activeRejoin = null;
 	}
 }

--- a/frontend/src/apps/meet/utils/sfu/SFUConnectionManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUConnectionManager.ts
@@ -54,6 +54,16 @@ export interface SFUEventHandlers {
 	onActiveSpeakerChanged?: (participantIds: string[]) => void;
 	onHostMutedYou?: () => void;
 	onHostKickedYou?: (data: unknown) => void;
+	onRecoveryStateChange?: (
+		state:
+			| "reconnecting"
+			| "rejoining"
+			| "recovering_send"
+			| "recovering_receive"
+			| "healthy"
+			| "failed",
+		detail?: string,
+	) => void;
 }
 
 interface ConnectionManagerOptions {
@@ -343,6 +353,13 @@ export class SFUConnectionManager {
 		}
 	}
 
+	reportRecoveryState(
+		state: Parameters<NonNullable<SFUEventHandlers["onRecoveryStateChange"]>>[0],
+		detail?: string,
+	): void {
+		this.eventHandlers.onRecoveryStateChange?.(state, detail);
+	}
+
 	async rejoinAfterSignalingReconnect(): Promise<void> {
 		if (this.activeRejoin) return this.activeRejoin;
 		if (!this.meetingId || !this.lastJoinUserData) {
@@ -350,6 +367,7 @@ export class SFUConnectionManager {
 		}
 
 		const rejoin = (async () => {
+			this.reportRecoveryState("rejoining", "signaling reconnected");
 			this.transportManager.closeReceiveTransport();
 			this.mediaManager.consumerManager.clear();
 			this.mediaManager.processedConsumers.clear();
@@ -370,9 +388,15 @@ export class SFUConnectionManager {
 			}
 			await this.mediaManager.rebuildSendSide();
 			await this.setupExistingParticipants();
-		})().finally(() => {
-			this.activeRejoin = null;
-		});
+			this.reportRecoveryState("healthy", "session rebuilt");
+		})()
+			.catch((error) => {
+				this.reportRecoveryState("failed", "session rebuild failed");
+				throw error;
+			})
+			.finally(() => {
+				this.activeRejoin = null;
+			});
 		this.activeRejoin = rejoin;
 
 		return rejoin;
@@ -485,7 +509,16 @@ export class SFUConnectionManager {
 	}
 
 	private setupSFUEventHandlers(): void {
+		this.sfuClient.on("reconnect_attempt", () => {
+			this.reportRecoveryState("reconnecting", "signaling reconnect attempt");
+		});
+
+		this.sfuClient.on("reconnect_failed", () => {
+			this.reportRecoveryState("failed", "signaling reconnect failed");
+		});
+
 		this.sfuClient.on("reconnect", () => {
+			this.reportRecoveryState("reconnecting", "signaling reconnected");
 			void this.rejoinAfterSignalingReconnect().catch((error) => {
 				console.warn("Failed to rejoin after signaling reconnect:", error);
 			});

--- a/frontend/src/apps/meet/utils/sfu/SFUConnectionManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUConnectionManager.ts
@@ -365,6 +365,7 @@ export class SFUConnectionManager {
 		if (!this.meetingId || !this.lastJoinUserData) {
 			throw new Error("Cannot rejoin before joining a meeting");
 		}
+		this.recoveryManager.reset();
 
 		const rejoin = (async () => {
 			this.reportRecoveryState("rejoining", "signaling reconnected");

--- a/frontend/src/apps/meet/utils/sfu/SFUConnectionManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUConnectionManager.ts
@@ -330,7 +330,7 @@ export class SFUConnectionManager {
 
 	async resyncAfterRecovery(reason: string): Promise<void> {
 		const result = await this.recoveryManager.recoverTransportIce(reason);
-		if (result === "failed" || result === "skipped") {
+		if (result === "skipped") {
 			await this.resetReceiveSide();
 		}
 	}

--- a/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
@@ -159,6 +159,30 @@ export class SFUMediaManager {
 		}
 	}
 
+	async rebuildSendSide(): Promise<Record<string, unknown>> {
+		const localStream = this.mediaHandler.localStream;
+		this.transportManager.closeSendTransport();
+		this.mediaHandler.setProducers({
+			audioProducer: null,
+			videoProducer: null,
+		});
+
+		if (!localStream) return {};
+
+		const hasLiveVideo = localStream
+			.getVideoTracks()
+			.some((track) => track.readyState === "live");
+		const hasLiveAudio = localStream
+			.getAudioTracks()
+			.some((track) => track.readyState === "live");
+		if (!hasLiveVideo && !hasLiveAudio) return {};
+
+		return this.publishMedia(localStream, {
+			publishAudio: hasLiveAudio,
+			publishVideo: hasLiveVideo,
+		});
+	}
+
 	async subscribeToProducer(
 		producerId: string,
 		participantId: string,

--- a/frontend/src/apps/meet/utils/sfu/SFURecoveryManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFURecoveryManager.ts
@@ -4,14 +4,21 @@
  */
 
 import type { TransportManager } from "../media/TransportManager";
+import type { TransportIceRestartResult } from "../media/TransportManager";
 import type { SFUClient } from "../SFUClient";
 
 interface RecoveryManagerOptions {
 	sfuClient: SFUClient;
 	transportManager: TransportManager;
 	meetingId: () => string | null;
-	onRecovered?: (reason: string) => Promise<void> | void;
-	onFailed?: (reason: string) => Promise<void> | void;
+	onRecovered?: (
+		reason: string,
+		result: TransportIceRestartResult,
+	) => Promise<void> | void;
+	onFailed?: (
+		reason: string,
+		result: TransportIceRestartResult,
+	) => Promise<void> | void;
 }
 
 type TransportDirection = "send" | "recv";
@@ -21,11 +28,10 @@ export class SFURecoveryManager {
 	private sfuClient: SFUClient;
 	private transportManager: TransportManager;
 	private getMeetingId: () => string | null;
-	private onRecovered?: (reason: string) => Promise<void> | void;
-	private onFailed?: (reason: string) => Promise<void> | void;
+	private onRecovered?: RecoveryManagerOptions["onRecovered"];
+	private onFailed?: RecoveryManagerOptions["onFailed"];
 	private recoveryInProgress = false;
 	private activeRecovery: Promise<RecoveryResult> | null = null;
-	private failedRecoveryCallback: Promise<RecoveryResult> | null = null;
 	private lastRecoveryAt = 0;
 	private static readonly RECOVERY_COOLDOWN_MS = 7000;
 	private static readonly DISCONNECTED_GRACE_MS = 3000;
@@ -61,14 +67,14 @@ export class SFURecoveryManager {
 		this.lastRecoveryAt = now;
 
 		this.activeRecovery = (async (): Promise<RecoveryResult> => {
+			let restartResult: TransportIceRestartResult;
 			try {
 				console.warn("Restarting SFU transport ICE", {
 					reason,
 					meetingId: this.getMeetingId(),
 				});
 
-				const restartResult =
-					await this.transportManager.restartAllTransportIce();
+				restartResult = await this.transportManager.restartAllTransportIce();
 				const didRestart = Object.values(restartResult).some(
 					(result) => result === "restarted",
 				);
@@ -76,14 +82,19 @@ export class SFURecoveryManager {
 					(result) => result === "failed",
 				);
 				if (!didRestart || didFail) {
+					await this.notifyFailed(reason, restartResult);
 					return "failed";
 				}
 
 				console.log("SFU transport ICE restart completed", { reason });
-				await this.onRecovered?.(reason);
+				await this.onRecovered?.(reason, restartResult);
 				return "recovered";
 			} catch (error) {
 				console.error("SFU transport ICE restart failed:", error);
+				await this.notifyFailed(reason, {
+					send: "failed",
+					recv: "failed",
+				});
 				return "failed";
 			} finally {
 				this.recoveryInProgress = false;
@@ -92,6 +103,17 @@ export class SFURecoveryManager {
 		})();
 
 		return this.activeRecovery;
+	}
+
+	private async notifyFailed(
+		reason: string,
+		result: TransportIceRestartResult,
+	): Promise<void> {
+		try {
+			await this.onFailed?.(reason, result);
+		} catch (error) {
+			console.warn("SFU recovery failure fallback failed:", error);
+		}
 	}
 
 	private recoverTransportFailure(
@@ -103,17 +125,6 @@ export class SFURecoveryManager {
 			.then(async (result) => {
 				if (result === "recovered") {
 					onRecovered?.();
-				}
-
-				if (result === "failed") {
-					if (this.failedRecoveryCallback === recovery) return;
-					this.failedRecoveryCallback = recovery;
-					await this.onFailed?.(reason);
-				}
-			})
-			.finally(() => {
-				if (this.failedRecoveryCallback === recovery) {
-					this.failedRecoveryCallback = null;
 				}
 			})
 			.catch((error) => {
@@ -174,7 +185,6 @@ export class SFURecoveryManager {
 
 	reset(): void {
 		this.recoveryInProgress = false;
-		this.failedRecoveryCallback = null;
 		this.lastRecoveryAt = 0;
 		this.disconnectedSince.clear();
 		if (this.watchdogHandle !== null) {

--- a/frontend/src/apps/meet/utils/sfu/SFURecoveryManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFURecoveryManager.ts
@@ -19,6 +19,7 @@ interface RecoveryManagerOptions {
 		reason: string,
 		result: TransportIceRestartResult,
 	) => Promise<void> | void;
+	onStarted?: (reason: string) => void;
 }
 
 type TransportDirection = "send" | "recv";
@@ -30,6 +31,7 @@ export class SFURecoveryManager {
 	private getMeetingId: () => string | null;
 	private onRecovered?: RecoveryManagerOptions["onRecovered"];
 	private onFailed?: RecoveryManagerOptions["onFailed"];
+	private onStarted?: RecoveryManagerOptions["onStarted"];
 	private recoveryInProgress = false;
 	private activeRecovery: Promise<RecoveryResult> | null = null;
 	private lastRecoveryAt = 0;
@@ -45,6 +47,7 @@ export class SFURecoveryManager {
 		this.getMeetingId = options.meetingId;
 		this.onRecovered = options.onRecovered;
 		this.onFailed = options.onFailed;
+		this.onStarted = options.onStarted;
 	}
 
 	get isRecovering(): boolean {
@@ -65,6 +68,7 @@ export class SFURecoveryManager {
 
 		this.recoveryInProgress = true;
 		this.lastRecoveryAt = now;
+		this.onStarted?.(reason);
 
 		this.activeRecovery = (async (): Promise<RecoveryResult> => {
 			let restartResult: TransportIceRestartResult;

--- a/frontend/src/apps/meet/utils/sfu/SFURecoveryManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFURecoveryManager.ts
@@ -34,6 +34,7 @@ export class SFURecoveryManager {
 	private onStarted?: RecoveryManagerOptions["onStarted"];
 	private recoveryInProgress = false;
 	private activeRecovery: Promise<RecoveryResult> | null = null;
+	private recoveryGeneration = 0;
 	private lastRecoveryAt = 0;
 	private static readonly RECOVERY_COOLDOWN_MS = 7000;
 	private static readonly DISCONNECTED_GRACE_MS = 3000;
@@ -69,6 +70,7 @@ export class SFURecoveryManager {
 		this.recoveryInProgress = true;
 		this.lastRecoveryAt = now;
 		this.onStarted?.(reason);
+		const recoveryGeneration = ++this.recoveryGeneration;
 
 		this.activeRecovery = (async (): Promise<RecoveryResult> => {
 			let restartResult: TransportIceRestartResult;
@@ -80,6 +82,7 @@ export class SFURecoveryManager {
 					});
 
 					restartResult = await this.transportManager.restartAllTransportIce();
+					if (recoveryGeneration !== this.recoveryGeneration) return "skipped";
 					const didRestart = Object.values(restartResult).some(
 						(result) => result === "restarted",
 					);
@@ -93,6 +96,7 @@ export class SFURecoveryManager {
 
 					console.log("SFU transport ICE restart completed", { reason });
 				} catch (error) {
+					if (recoveryGeneration !== this.recoveryGeneration) return "skipped";
 					console.error("SFU transport ICE restart failed:", error);
 					await this.notifyFailed(reason, {
 						send: "failed",
@@ -102,6 +106,7 @@ export class SFURecoveryManager {
 				}
 
 				try {
+					if (recoveryGeneration !== this.recoveryGeneration) return "skipped";
 					await this.onRecovered?.(reason, restartResult);
 					return "recovered";
 				} catch (error) {
@@ -109,8 +114,10 @@ export class SFURecoveryManager {
 					return "failed";
 				}
 			} finally {
-				this.recoveryInProgress = false;
-				this.activeRecovery = null;
+				if (recoveryGeneration === this.recoveryGeneration) {
+					this.recoveryInProgress = false;
+					this.activeRecovery = null;
+				}
 			}
 		})();
 
@@ -196,7 +203,9 @@ export class SFURecoveryManager {
 	}
 
 	reset(): void {
+		this.recoveryGeneration++;
 		this.recoveryInProgress = false;
+		this.activeRecovery = null;
 		this.lastRecoveryAt = 0;
 		this.disconnectedSince.clear();
 		if (this.watchdogHandle !== null) {

--- a/frontend/src/apps/meet/utils/sfu/SFURecoveryManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFURecoveryManager.ts
@@ -91,14 +91,20 @@ export class SFURecoveryManager {
 				}
 
 				console.log("SFU transport ICE restart completed", { reason });
-				await this.onRecovered?.(reason, restartResult);
-				return "recovered";
 			} catch (error) {
 				console.error("SFU transport ICE restart failed:", error);
 				await this.notifyFailed(reason, {
 					send: "failed",
 					recv: "failed",
 				});
+				return "failed";
+			}
+
+			try {
+				await this.onRecovered?.(reason, restartResult);
+				return "recovered";
+			} catch (error) {
+				console.error("SFU post-recovery sync failed:", error);
 				return "failed";
 			} finally {
 				this.recoveryInProgress = false;

--- a/frontend/src/apps/meet/utils/sfu/SFURecoveryManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFURecoveryManager.ts
@@ -67,9 +67,15 @@ export class SFURecoveryManager {
 					meetingId: this.getMeetingId(),
 				});
 
-				const restarted =
+				const restartResult =
 					await this.transportManager.restartAllTransportIce();
-				if (!restarted) {
+				const didRestart = Object.values(restartResult).some(
+					(result) => result === "restarted",
+				);
+				const didFail = Object.values(restartResult).some(
+					(result) => result === "failed",
+				);
+				if (!didRestart || didFail) {
 					return "failed";
 				}
 

--- a/frontend/src/apps/meet/utils/sfu/SFURecoveryManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFURecoveryManager.ts
@@ -73,39 +73,41 @@ export class SFURecoveryManager {
 		this.activeRecovery = (async (): Promise<RecoveryResult> => {
 			let restartResult: TransportIceRestartResult;
 			try {
-				console.warn("Restarting SFU transport ICE", {
-					reason,
-					meetingId: this.getMeetingId(),
-				});
+				try {
+					console.warn("Restarting SFU transport ICE", {
+						reason,
+						meetingId: this.getMeetingId(),
+					});
 
-				restartResult = await this.transportManager.restartAllTransportIce();
-				const didRestart = Object.values(restartResult).some(
-					(result) => result === "restarted",
-				);
-				const didFail = Object.values(restartResult).some(
-					(result) => result === "failed",
-				);
-				if (!didRestart || didFail) {
-					await this.notifyFailed(reason, restartResult);
+					restartResult = await this.transportManager.restartAllTransportIce();
+					const didRestart = Object.values(restartResult).some(
+						(result) => result === "restarted",
+					);
+					const didFail = Object.values(restartResult).some(
+						(result) => result === "failed",
+					);
+					if (!didRestart || didFail) {
+						await this.notifyFailed(reason, restartResult);
+						return "failed";
+					}
+
+					console.log("SFU transport ICE restart completed", { reason });
+				} catch (error) {
+					console.error("SFU transport ICE restart failed:", error);
+					await this.notifyFailed(reason, {
+						send: "failed",
+						recv: "failed",
+					});
 					return "failed";
 				}
 
-				console.log("SFU transport ICE restart completed", { reason });
-			} catch (error) {
-				console.error("SFU transport ICE restart failed:", error);
-				await this.notifyFailed(reason, {
-					send: "failed",
-					recv: "failed",
-				});
-				return "failed";
-			}
-
-			try {
-				await this.onRecovered?.(reason, restartResult);
-				return "recovered";
-			} catch (error) {
-				console.error("SFU post-recovery sync failed:", error);
-				return "failed";
+				try {
+					await this.onRecovered?.(reason, restartResult);
+					return "recovered";
+				} catch (error) {
+					console.error("SFU post-recovery sync failed:", error);
+					return "failed";
+				}
 			} finally {
 				this.recoveryInProgress = false;
 				this.activeRecovery = null;

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFUConnectionManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFUConnectionManager.test.ts
@@ -42,7 +42,10 @@ function createManager({ e2eeRequired = false } = {}) {
 		participantManager,
 		transportManager: transportManager as never,
 		mediaManager: mediaManager as never,
-		recoveryManager: { setupTransportEventHandlers: vi.fn() } as never,
+		recoveryManager: {
+			setupTransportEventHandlers: vi.fn(),
+			reset: vi.fn(),
+		} as never,
 	});
 	manager.currentUser = { value: { user_id: "me" } };
 	return {
@@ -52,6 +55,7 @@ function createManager({ e2eeRequired = false } = {}) {
 		participantManager,
 		sfuClient,
 		transportManager,
+		recoveryManager: manager.recoveryManager,
 	};
 }
 
@@ -145,7 +149,7 @@ describe("SFUConnectionManager", () => {
 	});
 
 	it("rejoins the room and rebuilds media after signaling reconnect", async () => {
-		const { manager, mediaManager, sfuClient, transportManager } =
+		const { manager, mediaManager, sfuClient, transportManager, recoveryManager } =
 			createManager();
 		manager.initialize("meeting-1", { user_id: "me" });
 		await manager.joinRoom(
@@ -162,6 +166,7 @@ describe("SFUConnectionManager", () => {
 			{ audio_enabled: true, video_enabled: true },
 		);
 		expect(transportManager.closeReceiveTransport).toHaveBeenCalledTimes(1);
+		expect(recoveryManager.reset).toHaveBeenCalledTimes(1);
 		expect(transportManager.initializeDevice).toHaveBeenCalledTimes(1);
 		expect(transportManager.createReceiveTransport).toHaveBeenCalledTimes(1);
 		expect(mediaManager.rebuildSendSide).toHaveBeenCalledTimes(1);

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFUConnectionManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFUConnectionManager.test.ts
@@ -8,20 +8,31 @@ function createManager({ e2eeRequired = false } = {}) {
 	const handlers = new Map<string, (data: unknown) => unknown>();
 	const sfuClient = {
 		connect: vi.fn().mockResolvedValue(undefined),
+		getExistingProducers: vi.fn().mockResolvedValue([]),
+		getRoomParticipants: vi.fn().mockResolvedValue([]),
 		isE2EERequired: vi.fn(() => e2eeRequired),
+		joinRoom: vi.fn().mockResolvedValue(undefined),
 		on: vi.fn((event: string, handler: (data: unknown) => unknown) => {
 			handlers.set(event, handler);
 		}),
 	};
 	const mediaManager = {
+		rebuildSendSide: vi.fn().mockResolvedValue({}),
 		subscribeToRemoteProducer: vi.fn().mockResolvedValue(undefined),
+		processedConsumers: new Set<string>(),
+		isScreenShareActive: false,
+		mediaHandler: { localStream: null },
 		consumerManager: {
+			clear: vi.fn(),
 			setEventHandlers: vi.fn(),
 			getConsumersByParticipant: vi.fn(() => []),
 		},
 		setEventHandlers: vi.fn(),
 	};
 	const transportManager = {
+		closeReceiveTransport: vi.fn(),
+		createReceiveTransport: vi.fn().mockResolvedValue(undefined),
+		initializeDevice: vi.fn().mockResolvedValue(undefined),
 		initialize: vi.fn(),
 		isDeviceLoaded: vi.fn(() => true),
 	};
@@ -34,7 +45,14 @@ function createManager({ e2eeRequired = false } = {}) {
 		recoveryManager: { setupTransportEventHandlers: vi.fn() } as never,
 	});
 	manager.currentUser = { value: { user_id: "me" } };
-	return { handlers, manager, mediaManager, participantManager };
+	return {
+		handlers,
+		manager,
+		mediaManager,
+		participantManager,
+		sfuClient,
+		transportManager,
+	};
 }
 
 describe("SFUConnectionManager", () => {
@@ -124,5 +142,61 @@ describe("SFUConnectionManager", () => {
 			producerId: "producer-1",
 			isScreen: false,
 		});
+	});
+
+	it("rejoins the room and rebuilds media after signaling reconnect", async () => {
+		const { manager, mediaManager, sfuClient, transportManager } =
+			createManager();
+		manager.initialize("meeting-1", { user_id: "me" });
+		await manager.joinRoom(
+			{ name: "Me", userId: "me" },
+			{ audio_enabled: true, video_enabled: true },
+		);
+
+		await manager.rejoinAfterSignalingReconnect();
+
+		expect(sfuClient.joinRoom).toHaveBeenNthCalledWith(
+			2,
+			"meeting-1",
+			{ name: "Me", userId: "me" },
+			{ audio_enabled: true, video_enabled: true },
+		);
+		expect(transportManager.closeReceiveTransport).toHaveBeenCalledTimes(1);
+		expect(transportManager.initializeDevice).toHaveBeenCalledTimes(1);
+		expect(transportManager.createReceiveTransport).toHaveBeenCalledTimes(1);
+		expect(mediaManager.rebuildSendSide).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses current live tracks for rejoin media state", async () => {
+		const { manager, mediaManager, sfuClient } = createManager();
+		mediaManager.mediaHandler.localStream = {
+			getAudioTracks: () => [{ readyState: "live" }],
+			getVideoTracks: () => [{ readyState: "ended" }],
+		};
+		manager.initialize("meeting-1", { user_id: "me" });
+		await manager.joinRoom(
+			{ name: "Me", userId: "me" },
+			{ audio_enabled: true, video_enabled: true },
+		);
+
+		await manager.rejoinAfterSignalingReconnect();
+
+		expect(sfuClient.joinRoom).toHaveBeenLastCalledWith(
+			"meeting-1",
+			expect.anything(),
+			{ audio_enabled: true, video_enabled: false },
+		);
+	});
+
+	it("starts a session rebuild when signaling reconnects", async () => {
+		const { handlers, manager } = createManager();
+		const rejoin = vi
+			.spyOn(manager, "rejoinAfterSignalingReconnect")
+			.mockResolvedValue(undefined);
+
+		await manager.connect("token");
+		handlers.get("reconnect")?.({});
+
+		expect(rejoin).toHaveBeenCalledTimes(1);
 	});
 });

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
@@ -2,6 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SFUMediaManager } from "../SFUMediaManager";
 
 type MockTransportManager = {
+	closeSendTransport: ReturnType<typeof vi.fn>;
+	createProducer: ReturnType<typeof vi.fn>;
+	createSendTransport: ReturnType<typeof vi.fn>;
 	createConsumer: ReturnType<typeof vi.fn>;
 };
 type MockParticipantManager = {
@@ -18,6 +21,9 @@ function createManager(
 	participantManager: MockParticipantManager;
 } {
 	const transportManager: MockTransportManager = {
+		closeSendTransport: vi.fn(),
+		createProducer: vi.fn().mockResolvedValue({}),
+		createSendTransport: vi.fn(),
 		createConsumer: vi.fn().mockResolvedValue({
 			id: "new-c1",
 			producerId: "producer-1",
@@ -64,6 +70,47 @@ function createManager(
 		participantManager,
 	};
 }
+
+describe("SFUMediaManager.rebuildSendSide", () => {
+	it("recreates the send transport and republishes live local tracks", async () => {
+		const { mediaManager, transportManager } = createManager();
+		const videoTrack = { kind: "video", readyState: "live" };
+		const audioTrack = { kind: "audio", readyState: "live" };
+		mediaManager.mediaHandler.localStream = {
+			getAudioTracks: () => [audioTrack],
+			getVideoTracks: () => [videoTrack],
+		} as never;
+		mediaManager.mediaHandler.setProducers({
+			audioProducer: { close: vi.fn() } as never,
+			videoProducer: { close: vi.fn() } as never,
+		});
+
+		await mediaManager.rebuildSendSide();
+
+		expect(transportManager.closeSendTransport).toHaveBeenCalledTimes(1);
+		expect(transportManager.createSendTransport).toHaveBeenCalledTimes(1);
+		expect(transportManager.createProducer).toHaveBeenCalledWith(videoTrack, {
+			type: "camera",
+		});
+		expect(transportManager.createProducer).toHaveBeenCalledWith(audioTrack, {
+			type: "microphone",
+		});
+	});
+
+	it("does not create a send transport without live local tracks", async () => {
+		const { mediaManager, transportManager } = createManager();
+		mediaManager.mediaHandler.localStream = {
+			getAudioTracks: () => [],
+			getVideoTracks: () => [{ kind: "video", readyState: "ended" }],
+		} as never;
+
+		await expect(mediaManager.rebuildSendSide()).resolves.toEqual({});
+
+		expect(transportManager.closeSendTransport).toHaveBeenCalledTimes(1);
+		expect(transportManager.createSendTransport).not.toHaveBeenCalled();
+		expect(transportManager.createProducer).not.toHaveBeenCalled();
+	});
+});
 
 describe("SFUMediaManager.handleConsumerLost", () => {
 	beforeEach(() => {

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFURecoveryManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFURecoveryManager.test.ts
@@ -227,11 +227,17 @@ describe("SFURecoveryManager", () => {
 		});
 
 		it("fails recovery when one active direction cannot restart", async () => {
+			const onFailed = vi.fn();
 			const { manager } = createManager({
 				restartResult: { send: "failed", recv: "restarted" },
+				onFailed,
 			});
 
 			await expect(manager.recoverTransportIce("test")).resolves.toBe("failed");
+			expect(onFailed).toHaveBeenCalledWith("test", {
+				send: "failed",
+				recv: "restarted",
+			});
 		});
 	});
 });

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFURecoveryManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFURecoveryManager.test.ts
@@ -260,5 +260,15 @@ describe("SFURecoveryManager", () => {
 
 			expect(onFailed).not.toHaveBeenCalled();
 		});
+
+		it("clears recovery state after an ICE restart failure", async () => {
+			const { manager } = createManager({
+				restartResult: { send: "failed", recv: "failed" },
+			});
+
+			await manager.recoverTransportIce("test");
+
+			expect(manager.isRecovering).toBe(false);
+		});
 	});
 });

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFURecoveryManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFURecoveryManager.test.ts
@@ -250,5 +250,15 @@ describe("SFURecoveryManager", () => {
 				recv: "restarted",
 			});
 		});
+
+		it("does not run failed-direction recovery when post-recovery sync throws", async () => {
+			const onRecovered = vi.fn().mockRejectedValue(new Error("sync failed"));
+			const onFailed = vi.fn();
+			const { manager } = createManager({ onRecovered, onFailed });
+
+			await expect(manager.recoverTransportIce("test")).resolves.toBe("failed");
+
+			expect(onFailed).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFURecoveryManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFURecoveryManager.test.ts
@@ -270,5 +270,22 @@ describe("SFURecoveryManager", () => {
 
 			expect(manager.isRecovering).toBe(false);
 		});
+
+		it("cancels an in-flight recovery when reset", async () => {
+			let resolveRestart: (result: TransportIceRestartResult) => void;
+			const restart = new Promise<TransportIceRestartResult>((resolve) => {
+				resolveRestart = resolve;
+			});
+			const onRecovered = vi.fn();
+			const { manager, transportManager } = createManager({ onRecovered });
+			transportManager.restartAllTransportIce.mockReturnValue(restart);
+
+			const recovery = manager.recoverTransportIce("test");
+			manager.reset();
+			resolveRestart!({ send: "restarted", recv: "restarted" });
+
+			await expect(recovery).resolves.toBe("skipped");
+			expect(onRecovered).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFURecoveryManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFURecoveryManager.test.ts
@@ -17,6 +17,7 @@ function createManager(
 		restartResult?: TransportIceRestartResult;
 		onRecovered?: ReturnType<typeof vi.fn>;
 		onFailed?: ReturnType<typeof vi.fn>;
+		onStarted?: ReturnType<typeof vi.fn>;
 	} = {},
 ) {
 	const sfuClient: MockSfuClient = {
@@ -36,11 +37,21 @@ function createManager(
 		meetingId: () => "meeting-1",
 		onRecovered: opts.onRecovered,
 		onFailed: opts.onFailed,
+		onStarted: opts.onStarted,
 	});
 	return { manager, sfuClient, transportManager };
 }
 
 describe("SFURecoveryManager", () => {
+	it("reports the recovery reason before restarting ICE", async () => {
+		const onStarted = vi.fn();
+		const { manager } = createManager({ onStarted });
+
+		await manager.recoverTransportIce("transport_send_failed");
+
+		expect(onStarted).toHaveBeenCalledWith("transport_send_failed");
+	});
+
 	beforeEach(() => {
 		vi.useFakeTimers();
 	});

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFURecoveryManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFURecoveryManager.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TransportIceRestartResult } from "../../media/TransportManager";
 import { SFURecoveryManager } from "../SFURecoveryManager";
 
 type MockTransportManager = {
@@ -13,7 +14,7 @@ type MockSfuClient = {
 function createManager(
 	opts: {
 		connected?: boolean;
-		restartResult?: boolean;
+		restartResult?: TransportIceRestartResult;
 		onRecovered?: ReturnType<typeof vi.fn>;
 		onFailed?: ReturnType<typeof vi.fn>;
 	} = {},
@@ -22,9 +23,11 @@ function createManager(
 		isConnected: vi.fn().mockReturnValue(opts.connected ?? true),
 	};
 	const transportManager: MockTransportManager = {
-		restartAllTransportIce: vi
-			.fn()
-			.mockResolvedValue(opts.restartResult ?? true),
+			restartAllTransportIce: vi
+				.fn()
+				.mockResolvedValue(
+					opts.restartResult ?? { send: "restarted", recv: "restarted" },
+				),
 		setEventHandlers: vi.fn(),
 	};
 	const manager = new SFURecoveryManager({
@@ -170,7 +173,9 @@ describe("SFURecoveryManager", () => {
 				"recovered",
 			);
 
-			const failed = createManager({ restartResult: false });
+			const failed = createManager({
+				restartResult: { send: "failed", recv: "restarted" },
+			});
 			await expect(failed.manager.recoverTransportIce("test")).resolves.toBe(
 				"failed",
 			);
@@ -183,7 +188,7 @@ describe("SFURecoveryManager", () => {
 
 		it("shares the active recovery so concurrent callers observe the same outcome", async () => {
 			const { manager, transportManager } = createManager({
-				restartResult: false,
+				restartResult: { send: "failed", recv: "restarted" },
 			});
 
 			const first = manager.recoverTransportIce("first");
@@ -197,7 +202,7 @@ describe("SFURecoveryManager", () => {
 		it("runs the failed callback for transport-triggered recovery failures", async () => {
 			const onFailed = vi.fn();
 			const { manager } = createManager({
-				restartResult: false,
+				restartResult: { send: "restarted", recv: "failed" },
 				onFailed,
 			});
 
@@ -210,7 +215,7 @@ describe("SFURecoveryManager", () => {
 		it("runs one failed callback when multiple transport failures share a recovery", async () => {
 			const onFailed = vi.fn();
 			const { manager } = createManager({
-				restartResult: false,
+				restartResult: { send: "failed", recv: "failed" },
 				onFailed,
 			});
 
@@ -219,6 +224,14 @@ describe("SFURecoveryManager", () => {
 
 			await vi.advanceTimersByTimeAsync(0);
 			expect(onFailed).toHaveBeenCalledTimes(1);
+		});
+
+		it("fails recovery when one active direction cannot restart", async () => {
+			const { manager } = createManager({
+				restartResult: { send: "failed", recv: "restarted" },
+			});
+
+			await expect(manager.recoverTransportIce("test")).resolves.toBe("failed");
 		});
 	});
 });

--- a/suite/meet/e2e/specs/sfu-reconnect.spec.ts
+++ b/suite/meet/e2e/specs/sfu-reconnect.spec.ts
@@ -1,0 +1,45 @@
+import { expect, joinHostAndGuest, test } from "../fixtures/test";
+import { expectRemoteVideoReceiving } from "../helpers/media";
+
+const disconnectTestEnabled =
+	process.env.SFU_E2E_DISCONNECT_TEST === "true";
+const disconnectWaitMs = Number.parseInt(
+	process.env.SFU_E2E_DISCONNECT_WAIT_MS || "7000",
+	10,
+);
+
+test.describe("SFU reconnect", () => {
+	test.skip(
+		!disconnectTestEnabled,
+		"Requires the SFU E2E socket timeout configuration",
+	);
+
+	test("rejoins after the SFU removes an offline participant", async ({
+		hostPage,
+		createMeeting,
+		createParticipant,
+	}) => {
+		const meetingId = await createMeeting();
+		const guestName = "Guest Server Disconnect";
+		const guest = await createParticipant();
+
+		await joinHostAndGuest(hostPage, guest, meetingId, guestName);
+		await expectRemoteVideoReceiving(hostPage, guestName);
+		await expectRemoteVideoReceiving(guest.page, "Administrator");
+
+		await guest.context.setOffline(true);
+		await expect(hostPage.locator("[data-participant-id]")).toHaveCount(1, {
+			timeout: disconnectWaitMs + 10_000,
+		});
+		await guest.context.setOffline(false);
+
+		await expect(hostPage.locator("[data-participant-id]")).toHaveCount(2, {
+			timeout: 45_000,
+		});
+		await expect(guest.page.locator("[data-participant-id]")).toHaveCount(2, {
+			timeout: 45_000,
+		});
+		await expectRemoteVideoReceiving(hostPage, guestName);
+		await expectRemoteVideoReceiving(guest.page, "Administrator");
+	});
+});

--- a/suite/meet/sfu-server/src/server.ts
+++ b/suite/meet/sfu-server/src/server.ts
@@ -14,6 +14,11 @@ import { SocketHandlerManager } from './server/SocketHandlerManager';
 import type { ServerConfig } from './types';
 import { loggers } from './utils/logger';
 
+function socketTimeout(envName: string, fallback: number): number {
+	const value = Number.parseInt(process.env[envName] || '', 10);
+	return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
 export class SFUServer {
 	private app: Application;
 	private server: http.Server;
@@ -50,8 +55,8 @@ export class SFUServer {
 				allowedHeaders: ['*'],
 				credentials: false,
 			},
-			pingTimeout: 60000,
-			pingInterval: 25000,
+			pingTimeout: socketTimeout('SOCKET_PING_TIMEOUT', 60000),
+			pingInterval: socketTimeout('SOCKET_PING_INTERVAL', 25000),
 		});
 
 		this.mediasoup = new MediasoupManager();


### PR DESCRIPTION
- Recover send and receive transports independently after ICE failures
- Rebuild local camera and microphone producers when send recovery fails
- Rejoin the SFU room and resync participants/producers after signaling reconnects
- Preserve E2EE reconnect listeners alongside connection recovery
- Show meeting recovery status and capture a bounded timeline in problem reports
- Add server-observed disconnect E2E coverage, enabled in CI