### PR TITLE
feat(mail): search filter chips, quick filters & inline editing

### DIFF
--- a/frontend/src/apps/mail/components/ContactCombobox.vue
+++ b/frontend/src/apps/mail/components/ContactCombobox.vue
@@ -1,0 +1,65 @@
+<template>
+	<Combobox
+		v-model="model"
+		:label="label"
+		:options="options"
+		placeholder=""
+		:open-on-click="false"
+		@input="search"
+	>
+		<template #item-prefix="{ item, query }">
+			<Avatar :image="item.image" :label="item.label || query" size="sm" />
+		</template>
+		<template #item-label="{ item }">
+			<div class="truncate">{{ item.display_name || item.email }}</div>
+			<div v-if="item.display_name" class="text-ink-gray-5 truncate text-xs">{{ item.email }}</div>
+		</template>
+		<template #item-create="{ query }"> {{ query }} </template>
+	</Combobox>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useDebounceFn } from '@vueuse/core'
+import { Avatar, Combobox, createResource } from 'frappe-ui'
+
+import { userStore } from '@/apps/mail/stores/user'
+
+// Self-contained contact-autocomplete combobox: searches contacts as you type (Avatar + name over email)
+// and offers a "use what you typed" create row for a value that isn't a contact.
+defineProps<{ label: string }>()
+const model = defineModel<string>()
+
+const store = userStore()
+
+const contactSearch = createResource({
+	url: 'suite.mail.api.contacts.get_contacts',
+	auto: false,
+	makeParams: (text: string) => ({
+		account: store.accountId,
+		filter: { operator: 'OR', conditions: [{ text }, { email: text }] },
+	}),
+	transform: (data: { email: string; full_name?: string; user_image?: string }[]) =>
+		data.map((o) => {
+			const name = o.full_name || ''
+			return { value: o.email, label: name || o.email, email: o.email, display_name: name, image: o.user_image }
+		}),
+})
+const search = useDebounceFn((text: string) => {
+	if (text) contactSearch.fetch(text)
+}, 300)
+
+// Contact matches plus a "create" entry (like compose's RecipientInput) so a typed value that isn't a
+// contact can still be applied.
+const options = computed(() => [
+	...(contactSearch.data ?? []),
+	{
+		type: 'custom',
+		slot: 'create',
+		condition: () => !contactSearch.data?.length,
+		onClick: ({ query }: { query: string }) => {
+			model.value = query
+		},
+	},
+])
+</script>

--- a/frontend/src/apps/mail/components/HeaderActions.vue
+++ b/frontend/src/apps/mail/components/HeaderActions.vue
@@ -27,7 +27,8 @@ import SendMail from '@/apps/mail/components/SendMail.vue'
 
 const emit = defineEmits(['reloadMails'])
 
-const showSearchModal = ref(false)
+// Exposed as a model so other views (e.g. the search results header's query chip) can reopen the modal.
+const showSearchModal = defineModel<boolean>('showSearch', { default: false })
 const showSendModal = ref(false)
 
 const modifier = computed(() => (isMac ? '⌘' : 'Ctrl'))

--- a/frontend/src/apps/mail/components/HeaderActions.vue
+++ b/frontend/src/apps/mail/components/HeaderActions.vue
@@ -15,7 +15,11 @@
 	</div>
 
 	<SendMail v-model="showSendModal" @reload-mails="emit('reloadMails')" />
-	<SearchModal v-model="showSearchModal" v-model:show-advanced="showSearchAdvanced" />
+	<SearchModal
+		v-model="showSearchModal"
+		v-model:show-advanced="showSearchAdvanced"
+		v-model:edit-filter="showSearchEditFilter"
+	/>
 </template>
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue'
@@ -30,6 +34,8 @@ const emit = defineEmits(['reloadMails'])
 // Exposed as a model so other views (e.g. the search results header's query chip) can reopen the modal.
 const showSearchModal = defineModel<boolean>('showSearch', { default: false })
 const showSearchAdvanced = defineModel<boolean>('showAdvanced', { default: false })
+// Filter key a results-page chip asked to reopen inline; forwarded to the search modal.
+const showSearchEditFilter = defineModel<string>('editFilter', { default: '' })
 const showSendModal = ref(false)
 
 const modifier = computed(() => (isMac ? '⌘' : 'Ctrl'))

--- a/frontend/src/apps/mail/components/HeaderActions.vue
+++ b/frontend/src/apps/mail/components/HeaderActions.vue
@@ -15,7 +15,7 @@
 	</div>
 
 	<SendMail v-model="showSendModal" @reload-mails="emit('reloadMails')" />
-	<SearchModal v-model="showSearchModal" />
+	<SearchModal v-model="showSearchModal" v-model:show-advanced="showSearchAdvanced" />
 </template>
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue'
@@ -29,6 +29,7 @@ const emit = defineEmits(['reloadMails'])
 
 // Exposed as a model so other views (e.g. the search results header's query chip) can reopen the modal.
 const showSearchModal = defineModel<boolean>('showSearch', { default: false })
+const showSearchAdvanced = defineModel<boolean>('showAdvanced', { default: false })
 const showSendModal = ref(false)
 
 const modifier = computed(() => (isMac ? '⌘' : 'Ctrl'))

--- a/frontend/src/apps/mail/components/MailListItem.vue
+++ b/frontend/src/apps/mail/components/MailListItem.vue
@@ -62,9 +62,8 @@
 					<h3
 						class="truncate text-[15px] !font-medium sm:text-base"
 						:class="{ '!font-semibold': !mail.seen }"
-					>
-						{{ header }}
-					</h3>
+						v-html="highlight(header)"
+					/>
 					<!-- All Inboxes: which account received this mail. -->
 					<div
 						v-if="accountLabel"
@@ -85,7 +84,7 @@
 					'!font-semibold': !mail.seen,
 				}"
 			>
-				{{ mail.subject || __('[No subject]') }}
+				<span v-html="highlight(mail.subject || __('[No subject]'))" />
 			</h4>
 			<div
 				class="flex items-center justify-between truncate"
@@ -95,7 +94,7 @@
 					class="text-ink-gray-5 truncate text-sm !leading-[1.5]"
 					:class="{ italic: !mail.preview, '!text-base': isFullWidth }"
 				>
-					{{ mail.preview || __('— No message body —') }}
+					<span v-html="highlight(mail.preview || __('— No message body —'))" />
 				</h5>
 
 				<div v-if="!isFullWidth" class="ml-3.5 flex space-x-3.5">
@@ -227,6 +226,7 @@
 
 <script setup lang="ts">
 import { computed, inject, ref } from 'vue'
+import { useRoute } from 'vue-router'
 import { Check, Download, Loader } from 'lucide-vue-next'
 import { Avatar, Badge, Checkbox, Popover, Tooltip } from 'frappe-ui'
 
@@ -292,6 +292,28 @@ const header = computed(() => {
 		? getFormattedRecipients(mail.recipients) || __('To:')
 		: mail.from_name || mail.from_email
 })
+
+// In search results, highlight the matched query term. Escape the text first (so any markup in the
+// content is neutralized), then wrap matches in <mark> — the only HTML we inject — for safe v-html.
+const route = useRoute()
+const searchTerm = computed(() =>
+	mailbox === 'search' ? ((route.query.text as string) || '').trim() : '',
+)
+const escapeHtml = (s: string) =>
+	s.replace(
+		/[&<>"']/g,
+		(c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c] ?? c,
+	)
+const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const highlight = (text?: string) => {
+	const escaped = escapeHtml(text ?? '')
+	const term = searchTerm.value
+	if (!term) return escaped
+	return escaped.replace(
+		new RegExp(`(${escapeRegExp(escapeHtml(term))})`, 'gi'),
+		'<mark class="bg-surface-yellow-5 text-ink-gray-9">$1</mark>',
+	)
+}
 
 const isHovered = ref(false)
 

--- a/frontend/src/apps/mail/components/Modals/SearchModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SearchModal.vue
@@ -8,7 +8,9 @@
 			<div class="bg-surface-base">
 				<div
 					class="flex items-center px-4 py-2"
-					:class="{ 'border-b': showAdvancedFilters || results?.data?.length }"
+					:class="{
+						'border-b': showAdvancedFilters || results?.data?.length || activeFilters.length,
+					}"
 				>
 					<Button v-if="isMobile" variant="ghost" @click="show = false">
 						<template #icon>
@@ -26,22 +28,30 @@
 						@click="showAdvancedFilters = false"
 						@keyup.enter="openSearchPage"
 					/>
-					<div class="group">
-						<span
-							v-if="advancedFiltersLength"
-							class="bg-surface-gray-10 text-ink-gray-1 border-outline-base absolute right-4 top-3 flex h-3 w-3 items-center justify-center rounded-full border text-[6px] font-bold group-hover:invisible"
+					<Button variant="ghost" @click="showAdvancedFilters = !showAdvancedFilters">
+						<template #icon>
+							<SlidersHorizontal class="text-ink-gray-5 h-4 w-4" />
+						</template>
+					</Button>
+				</div>
+				<div
+					v-if="!showAdvancedFilters && activeFilters.length"
+					class="flex flex-wrap gap-1.5 px-4 py-2"
+				>
+					<span
+						v-for="chip in activeFilters"
+						:key="chip.key"
+						class="bg-surface-gray-2 text-ink-gray-7 inline-flex items-center gap-1 rounded py-0.5 pl-2 pr-1 text-xs"
+					>
+						<span class="max-w-40 truncate">{{ chip.label }}</span>
+						<button
+							class="rounded p-0.5"
+							:aria-label="__('Remove filter')"
+							@click="removeFilter(chip.key)"
 						>
-							{{ advancedFiltersLength }}
-						</span>
-						<Button
-							variant="ghost"
-							@click="showAdvancedFilters = !showAdvancedFilters"
-						>
-							<template #icon>
-								<SlidersHorizontal class="text-ink-gray-5 h-4 w-4" />
-							</template>
-						</Button>
-					</div>
+							<X class="size-3" />
+						</button>
+					</span>
 				</div>
 				<template v-if="showAdvancedFilters">
 					<div class="space-y-4 p-4">
@@ -112,7 +122,11 @@
 						/>
 					</div>
 				</template>
-				<div v-else-if="results?.data?.[0]?.length" class="p-2">
+				<div
+					v-else-if="results?.data?.[0]?.length"
+					class="px-2 pb-2"
+					:class="{ 'pt-2': !activeFilters.length }"
+				>
 					<div
 						v-for="(result, idx) in results.data[0]"
 						:key="idx"
@@ -178,7 +192,7 @@
 import { computed, nextTick, reactive, ref, useTemplateRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { watchDebounced } from '@vueuse/core'
-import { ChevronLeft, Paperclip, Search, SlidersHorizontal } from 'lucide-vue-next'
+import { ChevronLeft, Paperclip, Search, SlidersHorizontal, X } from 'lucide-vue-next'
 import { Button, Dialog, FormControl, Switch, createResource } from 'frappe-ui'
 
 import { getAttachmentOptions, getReadStatusOptions } from '@/apps/mail/constants'
@@ -247,11 +261,6 @@ watch(allAccounts, (val) => {
 	if (filter.text) results.reload()
 })
 
-const advancedFiltersLength = computed(
-	() =>
-		Object.keys(filteredFilter.value).filter((k) => k !== 'text').length +
-		(allAccounts.value ? 1 : 0),
-)
 const showAdvancedFilters = ref(false)
 
 const mailboxOptions = computed(() =>
@@ -262,6 +271,40 @@ const mailboxOptions = computed(() =>
 		})),
 	),
 )
+
+// Active advanced filters as removable chips, shown under the search box (collapsed view) so a single
+// filter can be cleared without opening the whole panel.
+const FILTER_LABELS: Record<string, string> = {
+	inMailbox: __('In'),
+	subject: __('Subject'),
+	from: __('From'),
+	to: __('To'),
+	cc: __('Cc'),
+	bcc: __('Bcc'),
+	after: __('After'),
+	before: __('Before'),
+}
+
+const optionLabel = (options: { label: string; value: string }[], value: string) =>
+	options.find((o) => o.value === value)?.label ?? value
+
+const activeFilters = computed(() =>
+	Object.entries(filteredFilter.value)
+		.filter(([key]) => key !== 'text')
+		.map(([key, value]) => {
+			// hasAttachment/isRead values ("Without Attachments", "Unread") are self-descriptive, so show
+			// them on their own — the rest get a "Field: value" label.
+			if (key === 'hasAttachment') return { key, label: optionLabel(getAttachmentOptions(), value) }
+			if (key === 'isRead') return { key, label: optionLabel(getReadStatusOptions(), value) }
+			const display = key === 'inMailbox' ? optionLabel(mailboxOptions.value, value) : value
+			return { key, label: `${FILTER_LABELS[key]}: ${display}` }
+		}),
+)
+
+const removeFilter = (key: string) => {
+	filter[key] = ''
+	if (filter.text) results.reload()
+}
 
 const results = createResource({
 	url: 'suite.mail.api.mail.search_mails',

--- a/frontend/src/apps/mail/components/Modals/SearchModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SearchModal.vue
@@ -357,7 +357,7 @@ watch(allAccounts, (val) => {
 	localStorage.setItem(ALL_ACCOUNTS_STORAGE_KEY, String(val))
 	// "Look In" targets a folder in the current account; it can't carry across accounts, so drop it.
 	if (val) filter.inMailbox = ''
-	if (filter.text) results.reload()
+	if (hasQuery.value) results.reload()
 })
 
 // Exposed as a model so the results page can open the modal straight to the filter form (clicking a

--- a/frontend/src/apps/mail/components/Modals/SearchModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SearchModal.vue
@@ -459,8 +459,6 @@ const QUICK_FILTERS = computed<QuickFilter[]>(() =>
 		{ label: __('Folder'), key: 'inMailbox', op: 'in' },
 		{ label: __('From'), key: 'from', op: 'from' },
 		{ label: __('To'), key: 'to', op: 'to' },
-		{ label: __('Cc'), key: 'cc', op: 'cc' },
-		{ label: __('Bcc'), key: 'bcc', op: 'bcc' },
 		{ label: __('With attachments'), key: 'hasAttachment', apply: () => (filter.hasAttachment = 'true') },
 		{ label: __('Read'), key: 'isRead', apply: () => (filter.isRead = 'true') },
 		// `in:` (folder) is account-scoped, so it's dropped from a cross-account search.

--- a/frontend/src/apps/mail/components/Modals/SearchModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SearchModal.vue
@@ -41,7 +41,7 @@
 					<span
 						v-for="chip in activeFilters"
 						:key="chip.key"
-						class="bg-surface-gray-2 inline-flex items-center gap-1 rounded py-1 pl-2 pr-1 text-xs"
+						class="bg-surface-gray-2 inline-flex h-7 items-center gap-1 rounded pl-2 pr-1 text-xs"
 					>
 						<span class="max-w-40 truncate">{{ chip.label }}</span>
 						<button
@@ -265,7 +265,9 @@ watch(allAccounts, (val) => {
 	if (filter.text) results.reload()
 })
 
-const showAdvancedFilters = ref(false)
+// Exposed as a model so the results page can open the modal straight to the filter form (clicking a
+// filter pill or "Add filter").
+const showAdvancedFilters = defineModel<boolean>('showAdvanced', { default: false })
 
 const mailboxOptions = computed(() =>
 	[{ label: __('All folders'), value: '' }].concat(

--- a/frontend/src/apps/mail/components/Modals/SearchModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SearchModal.vue
@@ -9,7 +9,12 @@
 				<div
 					class="flex items-center px-4 py-2"
 					:class="{
-						'border-b': showAdvancedFilters || results?.data?.length || activeFilters.length,
+						'border-b':
+							showAdvancedFilters ||
+							results?.data?.length ||
+							activeFilters.length ||
+							folderMatches.length ||
+							contactMatches.length,
 					}"
 				>
 					<Button v-if="isMobile" variant="ghost" @click="show = false">
@@ -26,6 +31,7 @@
 						class="placeholder-ink-gray-4 w-full border-none bg-transparent text-base focus:ring-0"
 						placeholder="Search"
 						@click="showAdvancedFilters = false"
+						@input="showAdvancedFilters = false"
 						@keyup.enter="openSearchPage"
 					/>
 					<Button variant="ghost" @click="showAdvancedFilters = !showAdvancedFilters">
@@ -72,11 +78,25 @@
 							:options="mailboxOptions"
 						/>
 						<FormControl v-model="filter.subject" :label="__('Subject')" />
-						<FormControl v-model="filter.from" :label="__('From')" />
-						<FormControl v-model="filter.to" :label="__('To')" />
+						<ContactCombobox
+							v-model="filter.from"
+							:label="__('From')"
+						/>
+						<ContactCombobox
+							v-model="filter.to"
+							:label="__('To')"
+						/>
 						<div class="flex space-x-4">
-							<FormControl v-model="filter.cc" :label="__('Cc')" class="w-full" />
-							<FormControl v-model="filter.bcc" :label="__('Bcc')" class="w-full" />
+							<ContactCombobox
+								v-model="filter.cc"
+								:label="__('Cc')"
+								class="w-full"
+							/>
+							<ContactCombobox
+								v-model="filter.bcc"
+								:label="__('Bcc')"
+								class="w-full"
+							/>
 						</div>
 						<div class="flex space-x-4">
 							<FormControl
@@ -122,6 +142,42 @@
 						/>
 					</div>
 				</template>
+				<div
+					v-else-if="folderMatches.length || contactMatches.length"
+					class="px-2 pb-2"
+					:class="{ 'pt-2': !activeFilters.length }"
+				>
+					<button
+						v-for="mb in folderMatches"
+						:key="mb.id"
+						class="hover:bg-surface-gray-1 flex w-full items-center gap-2 rounded p-2 text-left"
+						@click="applyFolder(mb)"
+					>
+						<Icon
+							:name="getIcon(mb)"
+							class="size-4 shrink-0"
+							:class="FOLDER_ICON_COLOR_MAP[mb.color]"
+						/>
+						<span class="text-sm">{{ mb._name }}</span>
+					</button>
+					<button
+						v-for="c in contactMatches"
+						:key="c.email"
+						class="hover:bg-surface-gray-1 flex w-full items-center gap-2 rounded p-2 text-left"
+						@click="applyContact(c)"
+					>
+						<Avatar :image="c.image" :label="c.name || c.email" size="lg" />
+						<div class="min-w-0">
+							<div class="truncate text-sm">{{ c.name || c.email }}</div>
+							<div
+								v-if="c.name && c.name !== c.email"
+								class="text-ink-gray-5 truncate text-xs"
+							>
+								{{ c.email }}
+							</div>
+						</div>
+					</button>
+				</div>
 				<div
 					v-else-if="results?.data?.[0]?.length"
 					class="px-2 pb-2"
@@ -193,15 +249,17 @@ import { computed, nextTick, reactive, ref, useTemplateRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { watchDebounced } from '@vueuse/core'
 import { ChevronLeft, Paperclip, Search, SlidersHorizontal, X } from 'lucide-vue-next'
-import { Button, Dialog, FormControl, Switch, createResource } from 'frappe-ui'
+import { Avatar, Button, Dialog, FormControl, Switch, createResource } from 'frappe-ui'
+import { Icon } from 'frappe-ui/icons'
 
-import { getAttachmentOptions, getReadStatusOptions } from '@/apps/mail/constants'
-import { getFormattedDate } from '@/apps/mail/utils'
+import { FOLDER_ICON_COLOR_MAP, getAttachmentOptions, getReadStatusOptions } from '@/apps/mail/constants'
+import { getFormattedDate, getIcon } from '@/apps/mail/utils'
 import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import SearchMobileLayout from '@/apps/mail/components/SearchMobileLayout.vue'
+import ContactCombobox from '@/apps/mail/components/ContactCombobox.vue'
 
-import type { Recipient } from '@/apps/mail/types'
+import type { MailboxData, Recipient } from '@/apps/mail/types'
 
 const show = defineModel<boolean>()
 
@@ -277,6 +335,75 @@ const mailboxOptions = computed(() =>
 		})),
 	),
 )
+
+// Inline operator autocomplete: `in:` lists folders, `from:`/`to:`/`cc:`/`bcc:` list contacts. Picking
+// one applies the matching filter and drops the token from the query text.
+const CONTACT_OPS = ['from', 'to', 'cc', 'bcc']
+const OP_TOKEN = /(?:^|\s)(in|from|to|cc|bcc):(\S*)$/i
+const opTrigger = computed(() => {
+	const m = String(filter.text || '').match(OP_TOKEN)
+	return m ? { op: m[1].toLowerCase(), partial: m[2] } : null
+})
+const isContactOp = computed(() => !!opTrigger.value && CONTACT_OPS.includes(opTrigger.value.op))
+
+const folderMatches = computed<MailboxData[]>(() =>
+	opTrigger.value?.op === 'in'
+		? (mailboxes.data ?? []).filter((m: MailboxData) =>
+				m._name.toLowerCase().includes(opTrigger.value!.partial.toLowerCase()),
+			)
+		: [],
+)
+
+const contactSearch = createResource({
+	url: 'suite.mail.api.contacts.get_contacts',
+	auto: false,
+	makeParams: (text: string) => ({
+		account: store.accountId,
+		filter: { operator: 'OR', conditions: [{ text }, { email: text }] },
+	}),
+	transform: (data: { email: string; full_name?: string; user_image?: string }[]) =>
+		data.map((o) => {
+			const name = o.full_name || ''
+			// Shape serves both consumers: the inline operator dropdown (email/name/image) and the advanced
+			// comboboxes (value/label/display_name for frappe-ui's Combobox).
+			return { value: o.email, label: name || o.email, email: o.email, name, display_name: name, image: o.user_image }
+		}),
+})
+watchDebounced(
+	opTrigger,
+	(t) => {
+		if (t && CONTACT_OPS.includes(t.op)) contactSearch.fetch(t.partial)
+	},
+	{ debounce: 200 },
+)
+const contactMatches = computed(() => {
+	if (!isContactOp.value) return []
+	const partial = opTrigger.value!.partial
+	const matches = contactSearch.data ?? []
+	const hasExact = matches.some((c) => c.email.toLowerCase() === partial.toLowerCase())
+	// Offer the raw typed value as an option when it isn't already one of the matched contacts.
+	return partial && !hasExact
+		? [
+				...matches,
+				{ value: partial, label: partial, email: partial, name: '', display_name: '', image: undefined },
+			]
+		: matches
+})
+
+const applyFolder = (mailbox: MailboxData) => {
+	filter.inMailbox = mailbox.id
+	stripToken()
+}
+const applyContact = (contact: { email: string }) => {
+	if (opTrigger.value) (filter as Record<string, string>)[opTrigger.value.op] = contact.email
+	stripToken()
+}
+const stripToken = () => {
+	filter.text = String(filter.text || '')
+		.replace(OP_TOKEN, '')
+		.trim()
+	nextTick(() => searchInput.value?.focus())
+}
 
 // Active advanced filters as removable chips, shown under the search box (collapsed view) so a single
 // filter can be cleared without opening the whole panel.

--- a/frontend/src/apps/mail/components/Modals/SearchModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SearchModal.vue
@@ -6,17 +6,7 @@
 	>
 		<template #body>
 			<div class="bg-surface-base">
-				<div
-					class="flex items-center px-4 py-2"
-					:class="{
-						'border-b':
-							showAdvancedFilters ||
-							results?.data?.length ||
-							activeFilters.length ||
-							folderMatches.length ||
-							contactMatches.length,
-					}"
-				>
+				<div class="flex items-center border-b px-4 py-2">
 					<Button v-if="isMobile" variant="ghost" @click="show = false">
 						<template #icon>
 							<ChevronLeft class="text-ink-gray-5 h-4 w-4" />
@@ -34,30 +24,58 @@
 						@input="showAdvancedFilters = false"
 						@keyup.enter="openSearchPage"
 					/>
-					<Button variant="ghost" @click="showAdvancedFilters = !showAdvancedFilters">
+					<Button
+						variant="ghost"
+						:class="{ '-mr-1.5': !isMobile }"
+						@click="showAdvancedFilters = !showAdvancedFilters"
+					>
 						<template #icon>
 							<SlidersHorizontal class="text-ink-gray-5 h-4 w-4" />
 						</template>
 					</Button>
 				</div>
 				<div
-					v-if="!showAdvancedFilters && activeFilters.length"
-					class="flex flex-wrap gap-1.5 px-4 py-2"
+					v-if="!showAdvancedFilters && !opTrigger"
+					class="flex flex-wrap items-center gap-1.5 px-4 py-2"
 				>
+					<span v-if="!activeFilters.length" class="text-ink-gray-5 text-xs">
+						{{ __('Filter by') }}
+					</span>
 					<span
 						v-for="chip in activeFilters"
 						:key="chip.key"
 						class="bg-surface-gray-2 inline-flex h-7 items-center gap-1 rounded pl-2 pr-1 text-xs"
+						:class="{ 'hover:bg-surface-gray-3 cursor-pointer': isClickableChip(chip.key) }"
+						@click="isClickableChip(chip.key) && handleChipClick(chip.key)"
 					>
 						<span class="max-w-40 truncate">{{ chip.label }}</span>
 						<button
-							class="rounded p-0.5"
+							class="text-ink-gray-5 hover:text-ink-gray-8 rounded p-1"
 							:aria-label="__('Remove filter')"
-							@click="removeFilter(chip.key)"
+							@click.stop="removeFilter(chip.key)"
 						>
 							<X class="size-3" />
 						</button>
 					</span>
+					<Button
+						v-for="f in inactiveQuickFilters"
+						:key="f.label"
+						variant="outline"
+						class="!h-7 text-xs"
+						@click="applyQuickFilter(f)"
+					>
+						<span class="flex items-center gap-1">
+							<Plus class="size-3" />
+							{{ f.label }}
+						</span>
+					</Button>
+					<Button
+						v-if="activeFilters.length"
+						variant="ghost"
+						class="text-xs"
+						:label="__('Clear all')"
+						@click="clearFilters()"
+					/>
 				</div>
 				<template v-if="showAdvancedFilters">
 					<div class="space-y-4 p-4">
@@ -132,7 +150,7 @@
 						<Button
 							:label="__('Clear Filters')"
 							class="w-full sm:w-28"
-							@click="Object.assign(filter, getDefaultFilter(true))"
+							@click="clearFilters()"
 						/>
 						<Button
 							:label="__('Search')"
@@ -143,7 +161,7 @@
 					</div>
 				</template>
 				<div
-					v-else-if="folderMatches.length || contactMatches.length"
+					v-else-if="opTrigger"
 					class="px-2 pb-2"
 					:class="{ 'pt-2': !activeFilters.length }"
 				>
@@ -177,12 +195,14 @@
 							</div>
 						</div>
 					</button>
+					<div
+						v-if="!folderMatches.length && !contactMatches.length"
+						class="text-ink-gray-5 px-2 py-2 text-sm"
+					>
+						{{ isContactOp && contactSearch.loading ? __('Loading…') : __('No matches') }}
+					</div>
 				</div>
-				<div
-					v-else-if="results?.data?.[0]?.length"
-					class="px-2 pb-2"
-					:class="{ 'pt-2': !activeFilters.length }"
-				>
+				<div v-else-if="results?.data?.[0]?.length" class="px-2 pb-2">
 					<div
 						v-for="(result, idx) in results.data[0]"
 						:key="idx"
@@ -190,11 +210,9 @@
 						@click="openThread(result)"
 					>
 						<div class="mr-2 space-y-1 truncate">
-							<p class="truncate text-base-semibold">
-								{{ result.subject || __('[No subject]') }}
-							</p>
+							<p class="truncate text-base-semibold" v-html="highlight(result.subject || __('[No subject]'))" />
 							<div class="flex items-center gap-1 truncate text-sm">
-								<span class="truncate">{{ getInterlocutors(result) }}</span>
+								<span class="truncate" v-html="highlight(getInterlocutors(result))" />
 								<template v-if="allAccounts && result.account_name">
 									<span aria-hidden="true" class="text-ink-gray-4">•</span>
 									<span class="text-ink-gray-4 shrink-0 text-xs">
@@ -239,6 +257,9 @@
 				>
 					{{ __('No results found for the given query.') }}
 				</div>
+				<div v-else-if="hasQuery" class="text-ink-gray-4 py-4 text-center text-sm">
+					{{ __('Searching…') }}
+				</div>
 			</div>
 		</template>
 	</component>
@@ -248,7 +269,7 @@
 import { computed, nextTick, reactive, ref, useTemplateRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { watchDebounced } from '@vueuse/core'
-import { ChevronLeft, Paperclip, Search, SlidersHorizontal, X } from 'lucide-vue-next'
+import { ChevronLeft, Paperclip, Plus, Search, SlidersHorizontal, X } from 'lucide-vue-next'
 import { Avatar, Button, Dialog, FormControl, Switch, createResource } from 'frappe-ui'
 import { Icon } from 'frappe-ui/icons'
 
@@ -262,6 +283,8 @@ import ContactCombobox from '@/apps/mail/components/ContactCombobox.vue'
 import type { MailboxData, Recipient } from '@/apps/mail/types'
 
 const show = defineModel<boolean>()
+// Set by the results page when a filter chip is clicked: the filter key to reopen inline on open.
+const editFilterKey = defineModel<string>('editFilter', { default: '' })
 
 // Read store.accountId live in makeParams; destructuring would snapshot the
 // unwrapped value and miss account switches while this modal stays mounted.
@@ -277,6 +300,16 @@ watch(show, (val) => {
 	// Re-sync from the URL each time the modal opens so it reflects changes made on the results page
 	// (Clear all, removing a filter pill) rather than showing stale state.
 	Object.assign(filter, getDefaultFilter())
+	// Opened by clicking a filter chip on the results page: reopen that filter as an inline editable token,
+	// exactly as clicking the chip inside the modal does.
+	if (editFilterKey.value) {
+		if (EDITABLE_OP[editFilterKey.value]) editFilterInline(editFilterKey.value)
+		editFilterKey.value = ''
+	}
+	// Fetch on open when a query is already present (e.g. opened from the results page): the watcher
+	// only reloads on change, so reopening the same search would otherwise sit on "Searching…" forever.
+	if (hasQuery.value) results.reload()
+	else results.reset()
 	nextTick(() => searchInput.value?.focus())
 })
 
@@ -298,6 +331,8 @@ const getDefaultFilter = (reset = false) =>
 	)
 
 const filter = reactive({ ...getDefaultFilter() })
+// Reset every filter field but keep the text query — clearing filter chips shouldn't wipe the search.
+const clearFilters = () => Object.assign(filter, getDefaultFilter(true), { text: filter.text })
 const filteredFilter = computed(() =>
 	Object.fromEntries(
 		Object.entries(filter)
@@ -305,6 +340,8 @@ const filteredFilter = computed(() =>
 			.filter(([, v]) => Boolean(v)),
 	),
 )
+// A search runs when there's anything to search by — a text query or at least one filter.
+const hasQuery = computed(() => Object.keys(filteredFilter.value).length > 0)
 
 // Cross-account search: an opt-in that fans the query out across every account (defaulting off, so a
 // search stays scoped to the current account for speed). Persisted, and pre-checked when the search
@@ -342,7 +379,11 @@ const CONTACT_OPS = ['from', 'to', 'cc', 'bcc']
 const OP_TOKEN = /(?:^|\s)(in|from|to|cc|bcc):(\S*)$/i
 const opTrigger = computed(() => {
 	const m = String(filter.text || '').match(OP_TOKEN)
-	return m ? { op: m[1].toLowerCase(), partial: m[2] } : null
+	if (!m) return null
+	const op = m[1].toLowerCase()
+	// `in:` filters by folder, which is account-scoped — meaningless in a cross-account search.
+	if (op === 'in' && allAccounts.value) return null
+	return { op, partial: m[2] }
 })
 const isContactOp = computed(() => !!opTrigger.value && CONTACT_OPS.includes(opTrigger.value.op))
 
@@ -359,7 +400,11 @@ const contactSearch = createResource({
 	auto: false,
 	makeParams: (text: string) => ({
 		account: store.accountId,
-		filter: { operator: 'OR', conditions: [{ text }, { email: text }] },
+		limit: 5,
+		// Omit the filter entirely for an empty query → the backend returns a default contact list, so the
+		// dropdown is populated the moment an operator (e.g. `from:`) is inserted, before anything is typed.
+		// (Sending `filter: undefined` can serialize to the string "undefined" and error server-side.)
+		...(text ? { filter: { operator: 'OR', conditions: [{ text }, { email: text }] } } : {}),
 	}),
 	transform: (data: { email: string; full_name?: string; user_image?: string }[]) =>
 		data.map((o) => {
@@ -405,6 +450,72 @@ const stripToken = () => {
 	nextTick(() => searchInput.value?.focus())
 }
 
+// Quick-filter chips for filters not yet applied. Operator chips (`op`) drop a token into the input and
+// focus it so the folder/contact dropdown takes over; action chips (`apply`) set a filter directly.
+// `key` is the filter field each one populates, used to hide a chip once that filter is active.
+type QuickFilter = { label: string; key: string; op?: string; apply?: () => void }
+const QUICK_FILTERS = computed<QuickFilter[]>(() =>
+	[
+		{ label: __('Folder'), key: 'inMailbox', op: 'in' },
+		{ label: __('From'), key: 'from', op: 'from' },
+		{ label: __('To'), key: 'to', op: 'to' },
+		{ label: __('Cc'), key: 'cc', op: 'cc' },
+		{ label: __('Bcc'), key: 'bcc', op: 'bcc' },
+		{ label: __('With attachments'), key: 'hasAttachment', apply: () => (filter.hasAttachment = 'true') },
+		{ label: __('Read'), key: 'isRead', apply: () => (filter.isRead = 'true') },
+		// `in:` (folder) is account-scoped, so it's dropped from a cross-account search.
+	].filter((f) => f.op !== 'in' || !allAccounts.value),
+)
+// Drop chips whose filter is already applied (shown instead as an active pill).
+const inactiveQuickFilters = computed(() =>
+	QUICK_FILTERS.value.filter((f) => !filteredFilter.value[f.key]),
+)
+const applyQuickFilter = (f: QuickFilter) => {
+	if (f.apply) f.apply()
+	else if (f.op) insertOperator(f.op)
+}
+const insertOperator = (op: string, value = '') => {
+	// Append the operator to any existing query (space-separated) rather than replacing it.
+	const current = String(filter.text || '')
+	const prefix = current && !current.endsWith(' ') ? `${current} ` : current
+	const valueStart = `${prefix}${op}:`.length
+	filter.text = `${prefix}${op}:${value}`
+	nextTick(() => {
+		const el = searchInput.value as HTMLInputElement | null
+		el?.focus()
+		// Select the value so it's ready to replace when reopening an existing filter for editing.
+		el?.setSelectionRange(valueStart, el.value.length)
+	})
+}
+
+// Filters that have an inline operator form can be "reopened" for editing: clicking the pill clears it and
+// drops it back into the query as an editable token (e.g. `from:bob@x.com`), which reopens the dropdown.
+const EDITABLE_OP: Record<string, string> = { inMailbox: 'in', from: 'from', to: 'to', cc: 'cc', bcc: 'bcc' }
+const editFilterInline = (key: string) => {
+	const op = EDITABLE_OP[key]
+	if (!op) return
+	// `inMailbox` stores a folder id; seed the token with its name so `in:` matches it again.
+	const value =
+		key === 'inMailbox'
+			? optionLabel(mailboxOptions.value, String(filter.inMailbox || ''))
+			: String((filter as Record<string, string>)[key] || '')
+	filter[key] = ''
+	insertOperator(op, value)
+}
+// Two-state chips (attachment/read) flip between their values on click — With ↔ Without Attachments,
+// Read ↔ Unread — instead of reopening as an editable token.
+const TOGGLEABLE_FILTER_KEYS = ['hasAttachment', 'isRead']
+const isToggleableChip = (key: string) => TOGGLEABLE_FILTER_KEYS.includes(key)
+const isClickableChip = (key: string) => !!EDITABLE_OP[key] || isToggleableChip(key)
+const toggleFilter = (key: string) => {
+	filter[key] = filter[key] === 'true' ? 'false' : 'true'
+}
+// Route a chip click to toggling (attachment/read) or editing (operator chips).
+const handleChipClick = (key: string) => {
+	if (isToggleableChip(key)) return toggleFilter(key)
+	if (EDITABLE_OP[key]) return editFilterInline(key)
+}
+
 // Active advanced filters as removable chips, shown under the search box (collapsed view) so a single
 // filter can be cleared without opening the whole panel.
 const FILTER_LABELS: Record<string, string> = {
@@ -436,7 +547,6 @@ const activeFilters = computed(() =>
 
 const removeFilter = (key: string) => {
 	filter[key] = ''
-	if (filter.text) results.reload()
 }
 
 const results = createResource({
@@ -458,10 +568,31 @@ const searchQuery = computed(() => ({
 const noOfAttachments = (result) =>
 	result.attachments?.filter((m) => m.filename && m.disposition === 'attachment').length || 0
 
+// Highlight the matched query term in the results. Escape the text first (so any markup in the content
+// is neutralized), then wrap matches in <mark> — the only HTML we inject — for safe v-html.
+const escapeHtml = (s: string) =>
+	s.replace(
+		/[&<>"']/g,
+		(c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c] ?? c,
+	)
+const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const highlight = (text?: string) => {
+	const escaped = escapeHtml(text ?? '')
+	const term = String(filter.text || '').trim()
+	if (!term) return escaped
+	return escaped.replace(
+		new RegExp(`(${escapeRegExp(escapeHtml(term))})`, 'gi'),
+		'<mark class="bg-surface-yellow-5 text-ink-gray-9">$1</mark>',
+	)
+}
+
+// Reload whenever any filter changes (text, chips, quick filters, Clear all) — debounced so typing and
+// rapid chip edits coalesce. `filteredFilter` recomputes to a fresh object on every change, so the watch
+// fires for all of them. A search needs text; with none, reset so the empty/hint state shows.
 watchDebounced(
-	() => filter.text,
-	(val) => {
-		if (val) results.reload()
+	filteredFilter,
+	() => {
+		if (hasQuery.value) results.reload()
 		else results.reset()
 	},
 	{ debounce: 250 },

--- a/frontend/src/apps/mail/components/Modals/SearchModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SearchModal.vue
@@ -41,7 +41,7 @@
 					<span
 						v-for="chip in activeFilters"
 						:key="chip.key"
-						class="bg-surface-gray-2 text-ink-gray-7 inline-flex items-center gap-1 rounded py-0.5 pl-2 pr-1 text-xs"
+						class="bg-surface-gray-2 inline-flex items-center gap-1 rounded py-1 pl-2 pr-1 text-xs"
 					>
 						<span class="max-w-40 truncate">{{ chip.label }}</span>
 						<button
@@ -215,7 +215,11 @@ const { isMobile } = useScreenSize()
 
 const searchInput = useTemplateRef('searchInput')
 watch(show, (val) => {
-	if (val) nextTick(() => searchInput.value?.focus())
+	if (!val) return
+	// Re-sync from the URL each time the modal opens so it reflects changes made on the results page
+	// (Clear all, removing a filter pill) rather than showing stale state.
+	Object.assign(filter, getDefaultFilter())
+	nextTick(() => searchInput.value?.focus())
 })
 
 const getDefaultFilter = (reset = false) =>

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -971,6 +971,11 @@ const searchResults = createResource({
 		onResetSuccess()
 		if (mailbox === 'search') isMailboxLoaded.value = true
 	},
+	// On failure the count never arrives, so clear the pending state instead of leaving the title stuck
+	// on "Searching…" — the empty result list then reads as "0 results".
+	onError: () => {
+		searchTotal.value = 0
+	},
 })
 
 watch(

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -12,7 +12,10 @@
 				]"
 			/>
 		</div>
-		<HeaderActions @reload-mails="resetThreads(true, ['drafts', 'sent'])" />
+		<HeaderActions
+			v-model:show-search="showSearchModal"
+			@reload-mails="resetThreads(true, ['drafts', 'sent'])"
+		/>
 	</header>
 
 	<!-- Unscreened-thread nudge on the inbox, mirroring the trash/junk info bar: shown while Hey-style
@@ -51,6 +54,51 @@
 				class="sticky top-16 flex flex-col border-r"
 				:class="!isMobile && showReadingPane ? 'w-1/3' : 'w-full'"
 			>
+				<!-- Search header: the query (click to edit) + removable filter pills, above the results toolbar. -->
+				<div
+					v-if="mailbox === 'search'"
+					class="flex flex-col gap-2.5 border-b border-l-transparent px-3.5 py-3 sm:border-l sm:px-5"
+				>
+					<button
+						class="text-ink-gray-8 hover:border-outline-gray-3 flex h-7 w-full items-center gap-2.5 rounded border pl-3 pr-2.5 text-left transition-colors"
+						:class="{ 'max-w-2xl': isMobile || !showReadingPane }"
+						:aria-label="__('Edit search')"
+						@click="showSearchModal = true"
+					>
+						<Search class="text-ink-gray-5 size-4 shrink-0" />
+						<span class="min-w-0 flex-1 truncate text-sm">{{ searchQuery || __('Search') }}</span>
+						<SlidersHorizontal class="text-ink-gray-5 size-4 shrink-0" />
+					</button>
+					<div v-if="searchFilterChips.length" class="flex flex-wrap items-center gap-1.5">
+						<span
+							v-for="chip in searchFilterChips"
+							:key="chip.key"
+							class="bg-surface-gray-2 inline-flex items-center gap-1 rounded py-1 pl-2 pr-1 text-xs"
+						>
+							<span class="max-w-40 truncate">{{ chip.label }}</span>
+							<button
+								class="rounded p-0.5"
+								:aria-label="__('Remove filter')"
+								@click="removeSearchFilter(chip.key)"
+							>
+								<X class="size-3" />
+							</button>
+						</span>
+
+						<Button
+							variant="outline"
+							class="text-xs !h-6"
+							@click="showSearchModal = true"
+						>
+							<span class="flex items-center gap-1">
+								<Plus class="size-3" />
+								{{ __('Add filter') }}
+							</span>
+						</Button>
+						<Button variant="ghost" class="text-xs !h-6" :label="__('Clear all')" @click="clearSearch" />
+					</div>
+				</div>
+
 				<!-- Toolbar/Actions -->
 				<div
 					class="relative flex items-center border-b border-l-transparent px-3.5 py-2.5 sm:border-l sm:px-5"
@@ -351,10 +399,14 @@ import {
 	MailOpen,
 	Mails,
 	Paperclip,
+	Plus,
 	RefreshCw,
+	Search,
+	SlidersHorizontal,
 	Star,
 	StarOff,
 	Trash2,
+	X,
 } from 'lucide-vue-next'
 import {
 	Breadcrumbs,
@@ -368,6 +420,7 @@ import {
 	usePageMeta,
 } from 'frappe-ui'
 
+import { getAttachmentOptions, getReadStatusOptions } from '@/apps/mail/constants'
 import {
 	getFormattedDate,
 	isMac,
@@ -898,6 +951,7 @@ const searchResults = createResource({
 	transform: (data: [Thread[], number]) => {
 		if (refreshMode.value) refreshSnapshot = threadsResource.value.data ?? []
 		hasMore.value = data[0].length > PAGE_LENGTH
+		searchTotal.value = data[1] ?? 0
 		return data[0].slice(0, PAGE_LENGTH)
 	},
 	onSuccess: () => {
@@ -1472,6 +1526,11 @@ const title = computed(() => {
 			? __('1 item selected')
 			: __('{0} items selected', [String(selections.value.length)])
 
+	if (mailbox === 'search')
+		return searchTotal.value === 1
+			? __('1 result')
+			: __('{0} results', [String(searchTotal.value)])
+
 	switch (filter.value) {
 		case 'unread':
 			return __('Unread Mails')
@@ -1483,6 +1542,63 @@ const title = computed(() => {
 			return __('All Mails')
 	}
 })
+
+// Search-results header. The free-text term is shown as a chip you click to reopen the search modal
+// (showSearchModal, bound to HeaderActions); the advanced filters show as removable pills below, and
+// searchTotal drives the result count. Labels mirror the search dialog.
+const showSearchModal = ref(false)
+const searchTotal = ref(0)
+
+const SEARCH_FILTER_LABELS: Record<string, string> = {
+	inMailbox: __('In'),
+	subject: __('Subject'),
+	from: __('From'),
+	to: __('To'),
+	cc: __('Cc'),
+	bcc: __('Bcc'),
+	after: __('After'),
+	before: __('Before'),
+}
+const optionLabel = (options: { label: string; value: string }[], value: string) =>
+	options.find((o) => o.value === value)?.label ?? value
+
+const searchQuery = computed(() => (route.query.text as string) || '')
+
+const searchFilterChips = computed(() => {
+	const query = route.query
+	const chips: { key: string; label: string }[] = []
+	for (const key of Object.keys(SEARCH_FILTER_LABELS)) {
+		const value = query[key]
+		if (!value) continue
+		const display =
+			key === 'inMailbox'
+				? (mailboxes.data?.find((m: MailboxData) => m.id === value)?._name ?? String(value))
+				: String(value)
+		chips.push({ key, label: `${SEARCH_FILTER_LABELS[key]}: ${display}` })
+	}
+	// Attachment/read values ("Without Attachments", "Unread") are self-descriptive — show them on their own.
+	if (query.hasAttachment)
+		chips.push({ key: 'hasAttachment', label: optionLabel(getAttachmentOptions(), String(query.hasAttachment)) })
+	if (query.isRead)
+		chips.push({ key: 'isRead', label: optionLabel(getReadStatusOptions(), String(query.isRead)) })
+	return chips
+})
+
+// Re-run the search with one filter (or all filters) dropped. When nothing is left to search, leave the
+// search view for the Inbox.
+const searchWith = (query: Record<string, string>) => {
+	if (!Object.keys(query).length) return exitSearch()
+	router.push({ name: 'mail-mailbox', params: { accountId, mailbox: 'search' }, query })
+}
+const removeSearchFilter = (key: string) => {
+	const query = { ...route.query } as Record<string, string>
+	delete query[key]
+	searchWith(query)
+}
+const clearSearch = () => searchWith(searchQuery.value ? { text: searchQuery.value } : {})
+
+const exitSearch = () =>
+	router.push({ name: 'mail-mailbox', params: { accountId, mailbox: mailboxIds.inbox } })
 </script>
 
 <style scoped>

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -15,6 +15,7 @@
 		<HeaderActions
 			v-model:show-search="showSearchModal"
 			v-model:show-advanced="showSearchAdvanced"
+			v-model:edit-filter="searchEditFilter"
 			@reload-mails="resetThreads(true, ['drafts', 'sent'])"
 		/>
 	</header>
@@ -49,7 +50,7 @@
 			</div>
 		</div>
 
-		<template v-else-if="threadsResource?.data?.length || filter">
+		<template v-else-if="threadsResource?.data?.length || filter || mailbox === 'search'">
 			<div
 				ref="mailSidebar"
 				class="sticky top-16 flex flex-col border-r"
@@ -77,7 +78,7 @@
 						</template>
 						<template #suffix>
 							<button
-								class="text-ink-gray-5 hover:text-ink-gray-8 flex"
+								class="text-ink-gray-5 hover:text-ink-gray-8 -m-1 flex p-1"
 								:aria-label="__('Filters')"
 								@mousedown.stop.prevent="openSearch(true)"
 							>
@@ -89,12 +90,15 @@
 						<span
 							v-for="chip in searchFilterChips"
 							:key="chip.key"
-							@click="openSearch(true)"
-							class="bg-surface-gray-2 inline-flex h-7 cursor-pointer items-center gap-1 rounded pl-2 pr-1 text-xs"
+							class="bg-surface-gray-2 inline-flex h-7 items-center gap-1 rounded pl-2 pr-1 text-xs"
+							:class="{
+								'hover:bg-surface-gray-3 cursor-pointer': isClickableChip(chip.key),
+							}"
+							@click="isClickableChip(chip.key) && handleChipClick(chip.key)"
 						>
 							<span class="max-w-40 truncate">{{ chip.label }}</span>
 							<button
-								class="text-ink-gray-5 hover:text-ink-gray-8 rounded p-0.5"
+								class="text-ink-gray-5 hover:text-ink-gray-8 rounded p-1"
 								:aria-label="__('Remove filter')"
 								@click.stop="removeSearchFilter(chip.key)"
 							>
@@ -102,16 +106,6 @@
 							</button>
 						</span>
 
-						<Button
-							variant="outline"
-							class="text-xs"
-							@click="openSearch(true)"
-						>
-							<span class="flex items-center gap-1">
-								<Plus class="size-3" />
-								{{ __('Add filter') }}
-							</span>
-						</Button>
 						<Button variant="ghost" class="text-xs" :label="__('Clear all')" @click="clearSearch" />
 					</div>
 				</div>
@@ -315,7 +309,11 @@
 				</div>
 				<div v-else class="flex h-full items-center justify-center">
 					<p class="text-ink-gray-5">
-						{{ __('No mails found for the selected filter.') }}
+						{{
+							mailbox === 'search'
+								? __('No results found for the given query.')
+								: __('No mails found for the selected filter.')
+						}}
 					</p>
 				</div>
 			</div>
@@ -379,16 +377,10 @@
 			</div>
 		</template>
 
-		<!-- No mails -->
+		<!-- No mails (the search view keeps its header and shows an inline message instead) -->
 		<div v-else class="text-ink-gray-5 flex w-full flex-col items-center justify-center">
 			<NoMails class="text-ink-gray-2 mb-2 h-16 w-16" />
-			<p>
-				{{
-					mailbox === 'search'
-						? __('No results found for the given query.')
-						: __('You have no mails in this folder.')
-				}}
-			</p>
+			<p>{{ __('You have no mails in this folder.') }}</p>
 		</div>
 	</div>
 
@@ -416,7 +408,6 @@ import {
 	MailOpen,
 	Mails,
 	Paperclip,
-	Plus,
 	RefreshCw,
 	Search,
 	SlidersHorizontal,
@@ -1566,11 +1557,42 @@ const title = computed(() => {
 // searchTotal drives the result count. Labels mirror the search dialog.
 const showSearchModal = ref(false)
 const showSearchAdvanced = ref(false)
+// Set when a filter chip is clicked; the modal reopens that filter inline for editing (see editSearchFilter).
+const searchEditFilter = ref('')
 // Open the search modal — to the filter form when `advanced` (clicking a pill / "Add filter"), or to the
 // plain search input otherwise (clicking the query).
 const openSearch = (advanced = false) => {
 	showSearchAdvanced.value = advanced
 	showSearchModal.value = true
+}
+// Filter chips whose value can be edited inline in the modal (operator-backed: folder + contacts). The
+// rest (subject/dates) have no inline form, so their chips only remove — matching the modal, where only
+// these keys are clickable.
+const EDITABLE_FILTER_KEYS = ['inMailbox', 'from', 'to', 'cc', 'bcc']
+const isEditableChip = (key: string) => EDITABLE_FILTER_KEYS.includes(key)
+// Two-state chips (attachment/read) flip between their values on click — With ↔ Without Attachments,
+// Read ↔ Unread — instead of opening the modal.
+const TOGGLEABLE_FILTER_KEYS = ['hasAttachment', 'isRead']
+const isToggleableChip = (key: string) => TOGGLEABLE_FILTER_KEYS.includes(key)
+const isClickableChip = (key: string) => isEditableChip(key) || isToggleableChip(key)
+// Route a chip click to editing (operator chips) or toggling (attachment/read chips); non-clickable
+// chips only expose the remove button.
+const handleChipClick = (key: string) => {
+	if (isToggleableChip(key)) return toggleSearchFilter(key)
+	if (isEditableChip(key)) return editSearchFilter(key)
+}
+// Clicking an editable chip opens the modal (plain search view) with that filter dropped back into the
+// query as an editable token — the same effect as clicking the chip inside the modal.
+const editSearchFilter = (key: string) => {
+	showSearchAdvanced.value = false
+	searchEditFilter.value = key
+	showSearchModal.value = true
+}
+// Re-run the search with the chip's value flipped between its two states ('true' ⇄ 'false').
+const toggleSearchFilter = (key: string) => {
+	const query = { ...route.query } as Record<string, string>
+	query[key] = query[key] === 'true' ? 'false' : 'true'
+	searchWith(query)
 }
 const searchTotal = ref(0)
 

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -14,6 +14,7 @@
 		</div>
 		<HeaderActions
 			v-model:show-search="showSearchModal"
+			v-model:show-advanced="showSearchAdvanced"
 			@reload-mails="resetThreads(true, ['drafts', 'sent'])"
 		/>
 	</header>
@@ -59,27 +60,43 @@
 					v-if="mailbox === 'search'"
 					class="flex flex-col gap-2.5 border-b border-l-transparent px-3.5 py-3 sm:border-l sm:px-5"
 				>
-					<button
-						class="text-ink-gray-8 hover:border-outline-gray-3 flex h-7 w-full items-center gap-2.5 rounded border pl-3 pr-2.5 text-left transition-colors"
+					<FormControl
+						type="text"
+						size="sm"
+						class="w-full cursor-pointer [&_input]:cursor-pointer"
 						:class="{ 'max-w-2xl': isMobile || !showReadingPane }"
+						:model-value="searchQuery"
+						:placeholder="__('Search')"
 						:aria-label="__('Edit search')"
-						@click="showSearchModal = true"
+						readonly
+						variant="outline"
+						@mousedown.prevent="openSearch()"
 					>
-						<Search class="text-ink-gray-5 size-4 shrink-0" />
-						<span class="min-w-0 flex-1 truncate text-sm">{{ searchQuery || __('Search') }}</span>
-						<SlidersHorizontal class="text-ink-gray-5 size-4 shrink-0" />
-					</button>
+						<template #prefix>
+							<Search class="text-ink-gray-5 size-4" />
+						</template>
+						<template #suffix>
+							<button
+								class="text-ink-gray-5 hover:text-ink-gray-8 flex"
+								:aria-label="__('Filters')"
+								@mousedown.stop.prevent="openSearch(true)"
+							>
+								<SlidersHorizontal class="size-4" />
+							</button>
+						</template>
+					</FormControl>
 					<div v-if="searchFilterChips.length" class="flex flex-wrap items-center gap-1.5">
 						<span
 							v-for="chip in searchFilterChips"
 							:key="chip.key"
-							class="bg-surface-gray-2 inline-flex items-center gap-1 rounded py-1 pl-2 pr-1 text-xs"
+							@click="openSearch(true)"
+							class="bg-surface-gray-2 inline-flex h-7 cursor-pointer items-center gap-1 rounded pl-2 pr-1 text-xs"
 						>
 							<span class="max-w-40 truncate">{{ chip.label }}</span>
 							<button
-								class="rounded p-0.5"
+								class="text-ink-gray-5 hover:text-ink-gray-8 rounded p-0.5"
 								:aria-label="__('Remove filter')"
-								@click="removeSearchFilter(chip.key)"
+								@click.stop="removeSearchFilter(chip.key)"
 							>
 								<X class="size-3" />
 							</button>
@@ -87,15 +104,15 @@
 
 						<Button
 							variant="outline"
-							class="text-xs !h-6"
-							@click="showSearchModal = true"
+							class="text-xs"
+							@click="openSearch(true)"
 						>
 							<span class="flex items-center gap-1">
 								<Plus class="size-3" />
 								{{ __('Add filter') }}
 							</span>
 						</Button>
-						<Button variant="ghost" class="text-xs !h-6" :label="__('Clear all')" @click="clearSearch" />
+						<Button variant="ghost" class="text-xs" :label="__('Clear all')" @click="clearSearch" />
 					</div>
 				</div>
 
@@ -414,6 +431,7 @@ import {
 	Checkbox,
 	Dialog,
 	Dropdown,
+	FormControl,
 	Tooltip,
 	call,
 	createResource,
@@ -1547,6 +1565,13 @@ const title = computed(() => {
 // (showSearchModal, bound to HeaderActions); the advanced filters show as removable pills below, and
 // searchTotal drives the result count. Labels mirror the search dialog.
 const showSearchModal = ref(false)
+const showSearchAdvanced = ref(false)
+// Open the search modal — to the filter form when `advanced` (clicking a pill / "Add filter"), or to the
+// plain search input otherwise (clicking the query).
+const openSearch = (advanced = false) => {
+	showSearchAdvanced.value = advanced
+	showSearchModal.value = true
+}
 const searchTotal = ref(0)
 
 const SEARCH_FILTER_LABELS: Record<string, string> = {

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -947,6 +947,10 @@ const onResetSuccess = () => {
 // account, so each row opens in — and acts within — its own account (see the row-action wrappers).
 const isAllAccountsSearch = computed(() => mailbox === 'search' && route.query.all_accounts != null)
 
+// Null while a search is pending — the count is only known once the fetch resolves (set in the
+// searchResults transform below, reset in resetThreads). Guards the title against a stale or zero count.
+const searchTotal = ref<number | null>(null)
+
 // Reset resource for search: always the first window, over-fetching one row to drive `hasMore`.
 const searchResults = createResource({
 	url: 'suite.mail.api.mail.search_mails',
@@ -1118,6 +1122,8 @@ const resetThreads: (reloadMailboxes?: boolean, mailboxRoles?: MailboxRole[]) =>
 	refreshMode.value = false
 	epoch.value++
 	resetSelections()
+	// Clear the previous search's count so the header doesn't show a stale total while the new fetch runs.
+	if (mailbox === 'search') searchTotal.value = null
 	threadsResource.value.reload()
 	if (reloadMailboxes) mailboxes.reload()
 }
@@ -1535,10 +1541,13 @@ const title = computed(() => {
 			? __('1 item selected')
 			: __('{0} items selected', [String(selections.value.length)])
 
-	if (mailbox === 'search')
+	if (mailbox === 'search') {
+		// Null until the current search resolves — show a neutral label rather than a stale/zero count.
+		if (searchTotal.value === null) return __('Searching…')
 		return searchTotal.value === 1
 			? __('1 result')
 			: __('{0} results', [String(searchTotal.value)])
+	}
 
 	switch (filter.value) {
 		case 'unread':
@@ -1594,7 +1603,6 @@ const toggleSearchFilter = (key: string) => {
 	query[key] = query[key] === 'true' ? 'false' : 'true'
 	searchWith(query)
 }
-const searchTotal = ref(0)
 
 const SEARCH_FILTER_LABELS: Record<string, string> = {
 	inMailbox: __('In'),


### PR DESCRIPTION
## Overview

Overhauls the mail search experience — a redesigned results header, active-filter chips, inline operator autocomplete, a quick-filter bar, and inline filter editing.

## What's included

- **Results header redesign** — the query as a click-to-edit control, removable filter pills, and a result count.
- **Matched-term highlighting** in search result rows.
- **Inline operator autocomplete** in the search box: `in:` lists folders (real icons/colors); `from:`/`to:`/`cc:`/`bcc:` list contacts (Avatar + name/email), each with a "use what you typed" fallback. Picking one applies the filter and strips the token.
- **Advanced From/To/Cc/Bcc fields** become contact comboboxes (extracted into a self-contained `ContactCombobox`).
- **Quick-filter bar** ("Filter by …"): active filters as removable pills first, then `+ Folder / From / To / With attachments / Read` chips for filters not yet applied. Operator chips append an editable token and open the dropdown; action chips apply directly.
- **Inline filter editing** — clicking an operator-backed pill reopens it in the query as an editable token (value pre-selected); ✕ removes. Also round-trips from the results page.
- **Behavior fixes**: search runs when any single filter is set (not just text); debounced reload on any filter change (Clear all / chip edits refresh results); empty-operator loads a default contact list; "Clear all" keeps the text query; the results page keeps its header and shows an inline "No results" message.

## Testing

Open search on a mailbox. Verify: typing operators shows the right dropdowns; quick-filter chips add/apply; pills edit inline and remove; Clear all keeps the query; a filter-only search returns results; zero-result search keeps the header with an inline message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
