### PR TITLE
fix(mail): don't nest stale params into contact search filter

### DIFF
--- a/frontend/src/apps/mail/components/Modals/SearchModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SearchModal.vue
@@ -398,14 +398,19 @@ const folderMatches = computed<MailboxData[]>(() =>
 const contactSearch = createResource({
 	url: 'suite.mail.api.contacts.get_contacts',
 	auto: false,
-	makeParams: (text: string) => ({
-		account: store.accountId,
-		limit: 5,
-		// Omit the filter entirely for an empty query → the backend returns a default contact list, so the
-		// dropdown is populated the moment an operator (e.g. `from:`) is inserted, before anything is typed.
-		// (Sending `filter: undefined` can serialize to the string "undefined" and error server-side.)
-		...(text ? { filter: { operator: 'OR', conditions: [{ text }, { email: text }] } } : {}),
-	}),
+	makeParams: (text: string) => {
+		// frappe-ui's fetch reuses the previous params object when called with a falsy value (our
+		// intended empty query) and feeds it back here as `text`, so guard against a non-string.
+		const query = typeof text === 'string' ? text : ''
+		return {
+			account: store.accountId,
+			limit: 5,
+			// Omit the filter entirely for an empty query → the backend returns a default contact list, so the
+			// dropdown is populated the moment an operator (e.g. `from:`) is inserted, before anything is typed.
+			// (Sending `filter: undefined` can serialize to the string "undefined" and error server-side.)
+			...(query ? { filter: { operator: 'OR', conditions: [{ text: query }, { email: query }] } } : {}),
+		}
+	},
 	transform: (data: { email: string; full_name?: string; user_image?: string }[]) =>
 		data.map((o) => {
 			const name = o.full_name || ''


### PR DESCRIPTION
## Problem

Contact autocomplete in the search modal intermittently fails with a `400` from the JMAP server. The request carries a malformed filter where the search text has been replaced by an object:

```json
{"filter": {"operator": "OR", "conditions": [
  {"text": {"account": "mh", "limit": 5}},
  {"email": {"account": "mh", "limit": 5}}
]}}
```

## Root cause

`SearchModal.vue`'s `contactSearch` resource is the only caller that intentionally fetches with an **empty** query (to pre-populate the dropdown the moment an operator like `from:` is inserted).

frappe-ui's `fetch` does `params = params || out.params`. Since an empty string is falsy, the second empty fetch falls back to the **previous params object** (`{account, limit}`) and passes it straight into `makeParams` as `text`. Being a truthy object, it triggers the filter branch and nests the whole object into the JMAP conditions — the malformed payload above.

## Fix

Guard `makeParams` against receiving a non-string `text`, coercing it to an empty query so a re-fetch with no query correctly omits the filter (the intended "default contact list" behavior).

The other four `get_contacts` callers aren't affected — they guard with `if (text)` before fetching, or ignore the argument entirely.