### PR TITLE
chore: issue forms with required app selection + app labeler

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -41,17 +41,14 @@ body:
         3. See error
     validations:
       required: true
-  - type: input
-    id: version
-    attributes:
-      label: App / bench version
-      description: Output of `bench version`, or the app version, if known.
-    validations:
-      required: false
   - type: textarea
     id: environment
     attributes:
       label: Environment
-      description: Browser, OS, self-hosted vs Frappe Cloud, etc.
+      description: App / bench version, browser, OS, and whether you're self-hosted or on Frappe Cloud.
+      placeholder: |
+        - App / bench version: (output of `bench version`, if known)
+        - Browser & OS:
+        - Hosting: self-hosted / Frappe Cloud
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,7 +27,7 @@ body:
     id: what-happened
     attributes:
       label: What happened?
-      description: A clear description of the bug, and what you expected to happen instead.
+      description: A clear description of the bug and what you expected instead. Include any relevant logs, console errors, screenshots, or a screen recording.
       placeholder: When I …, I expected …, but instead …
     validations:
       required: true
@@ -53,12 +53,5 @@ body:
     attributes:
       label: Environment
       description: Browser, OS, self-hosted vs Frappe Cloud, etc.
-    validations:
-      required: false
-  - type: textarea
-    id: logs
-    attributes:
-      label: Relevant logs / screenshots
-      description: Console errors, screenshots, or a screen recording.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: 🐛 Bug report
+description: Report a problem with a Frappe Suite app
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug! Start by telling us **which app** this is about — it's required.
+  - type: dropdown
+    id: app
+    attributes:
+      label: App
+      description: Which Suite app does this issue affect?
+      options:
+        - Drive
+        - Slides
+        - Writer
+        - Sheets
+        - Meet
+        - Mail
+        - Calendar
+        - General
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, and what you expected to happen instead.
+      placeholder: When I …, I expected …, but instead …
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to …
+        2. Click …
+        3. See error
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: App / bench version
+      description: Output of `bench version`, or the app version, if known.
+    validations:
+      required: false
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, OS, self-hosted vs Frappe Cloud, etc.
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / screenshots
+      description: Console errors, screenshots, or a screen recording.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+# Force every issue through a form (each form requires picking an App).
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & usage help
+    url: https://discuss.frappe.io
+    about: For how-to questions and general discussion, please use the Frappe community forum instead of an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: ✨ Feature request
+description: Suggest an idea or improvement for a Frappe Suite app
+title: "[Feature]: "
+labels: ["feature-request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Start by telling us **which app** this is for — it's required.
+  - type: dropdown
+    id: app
+    attributes:
+      label: App
+      description: Which Suite app is this request for?
+      options:
+        - Drive
+        - Slides
+        - Writer
+        - Sheets
+        - Meet
+        - Mail
+        - Calendar
+        - General
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and what problem does this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -37,9 +37,3 @@ body:
       description: What would you like to see happen?
     validations:
       required: true
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives considered
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: ✨ Feature request
 description: Suggest an idea or improvement for a Frappe Suite app
 title: "[Feature]: "
-labels: ["feature-request"]
+labels: ["feature request"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/issue-app-labeler.yml
+++ b/.github/workflows/issue-app-labeler.yml
@@ -35,8 +35,8 @@ jobs:
               }
             }
 
-            // Map the dropdown display value to a label slug. Keep this in sync with the
-            // options in .github/ISSUE_TEMPLATE/*.yml.
+            // Map each App option to the repo's existing app label (bare names, no prefix).
+            // Keep this in sync with the options in .github/ISSUE_TEMPLATE/*.yml and the repo labels.
             const MAP = {
               'Drive': 'drive',
               'Slides': 'slides',
@@ -47,17 +47,18 @@ jobs:
               'Calendar': 'calendar',
               'General': 'general',
             }
+            // The set this automation manages, so edits can reconcile to a single one.
+            const APP_LABELS = new Set([...Object.values(MAP), 'needs-triage'])
 
             const { owner, repo } = context.repo
             const issue_number = context.payload.issue.number
-            const slug = MAP[choice]
-            // Every option maps to a slug; `needs-triage` is only a safety net if parsing ever misses.
-            const label = slug ? `app: ${slug}` : 'needs-triage'
+            // Every option maps to a label; `needs-triage` is only a safety net if parsing ever misses.
+            const label = MAP[choice] || 'needs-triage'
 
             // Drop any previously-applied app label so exactly one stays (handles edits).
             const current = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number })
             for (const l of current.data) {
-              if ((l.name.startsWith('app: ') || l.name === 'needs-triage') && l.name !== label) {
+              if (APP_LABELS.has(l.name) && l.name !== label) {
                 await github.rest.issues
                   .removeLabel({ owner, repo, issue_number, name: l.name })
                   .catch(() => {})

--- a/.github/workflows/issue-app-labeler.yml
+++ b/.github/workflows/issue-app-labeler.yml
@@ -1,0 +1,69 @@
+name: Label issues by app
+
+# Reads the required "App" dropdown from the issue form and applies an
+# `app: <name>` label so issues are filterable/triageable per app.
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body || ''
+
+            // Issue forms render each field as "### <label>" followed by the value on a
+            // later line. Find the line that is exactly "### App", then take the next
+            // non-empty line as the selected option.
+            const lines = body.split(/\r?\n/)
+            const idx = lines.findIndex((l) => /^###\s+App\s*$/.test(l))
+            if (idx === -1) {
+              core.info('No "App" field found in the issue body; skipping.')
+              return
+            }
+            let choice = ''
+            for (let i = idx + 1; i < lines.length; i++) {
+              if (lines[i].trim()) {
+                choice = lines[i].trim()
+                break
+              }
+            }
+
+            // Map the dropdown display value to a label slug. Keep this in sync with the
+            // options in .github/ISSUE_TEMPLATE/*.yml.
+            const MAP = {
+              'Drive': 'drive',
+              'Slides': 'slides',
+              'Writer': 'writer',
+              'Sheets': 'sheets',
+              'Meet': 'meet',
+              'Mail': 'mail',
+              'Calendar': 'calendar',
+              'General': 'general',
+            }
+
+            const { owner, repo } = context.repo
+            const issue_number = context.payload.issue.number
+            const slug = MAP[choice]
+            // Every option maps to a slug; `needs-triage` is only a safety net if parsing ever misses.
+            const label = slug ? `app: ${slug}` : 'needs-triage'
+
+            // Drop any previously-applied app label so exactly one stays (handles edits).
+            const current = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number })
+            for (const l of current.data) {
+              if ((l.name.startsWith('app: ') || l.name === 'needs-triage') && l.name !== label) {
+                await github.rest.issues
+                  .removeLabel({ owner, repo, issue_number, name: l.name })
+                  .catch(() => {})
+              }
+            }
+
+            // addLabels creates the label if it doesn't exist yet (default color).
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] })
+            core.info(`Applied "${label}" for App = "${choice}".`)

--- a/.github/workflows/issue-app-labeler.yml
+++ b/.github/workflows/issue-app-labeler.yml
@@ -47,8 +47,10 @@ jobs:
               'Calendar': 'calendar',
               'General': 'general',
             }
-            // The set this automation manages, so edits can reconcile to a single one.
-            const APP_LABELS = new Set([...Object.values(MAP), 'needs-triage'])
+            // The app labels this automation manages, so edits can reconcile to a single one.
+            // `needs-triage` is intentionally NOT tracked here: it's only a parse-failure fallback, and
+            // reconciling it would strip a `needs-triage` a maintainer applied by hand.
+            const APP_LABELS = new Set(Object.values(MAP))
 
             const { owner, repo } = context.repo
             const issue_number = context.payload.issue.number


### PR DESCRIPTION
## Overview

Adds a GitHub issue workflow that requires choosing an **app** before an issue can be filed, and auto-labels the issue with that app.

## What's included

- **Issue forms** (`.github/ISSUE_TEMPLATE/`): `🐛 Bug report` and `✨ Feature request`, each opening with a **required App dropdown** — Drive, Slides, Writer, Sheets, Meet, Mail, Calendar, General. You can't submit without picking one.
  - Bug: App → What happened? (incl. logs/screenshots) → Steps to reproduce → Environment.
  - Feature: App → Problem / motivation → Proposed solution.
- **Blank issues disabled** (`config.yml`) so every report goes through a form; adds a "Questions & usage help" link to the Frappe forum.
- **App labeler** (`.github/workflows/issue-app-labeler.yml`): reads the selected app from the form and applies the repo's **existing** app label (`mail`, `drive`, `slides`, `writer`, `meet`, `calendar`), reconciling to a single app label if the reporter edits their choice.

## Notes for maintainers

- Uses the repo's existing bare app labels. Two dropdown options have **no matching label yet** and will be auto-created (gray) on first use unless created beforehand with colors:
  - **`sheets`** (the other six apps already have labels)
  - **`general`** (for the General / shell / not-app-specific bucket)
- The labeler needs **Settings → Actions → Workflow permissions → Read and write** to apply labels.
- The dropdown option list is duplicated across both forms and the workflow's `MAP`; adding a new app means updating all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)