### PR TITLE
feat(sheets): read-only mode for view-only access

### DIFF
--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -10,7 +10,7 @@ import { checkboxRect } from './checkbox-geometry.js'
 
 export { colLabel, cellId, parseCellId } from '../utils/cells.js'
 
-export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getFormat, onFill, onBatchCommit, getMergeInfo, isSlave, getMasterId, getComment, getValidation, getCondFormat, getRightInset, onHyperlinkClick, onDropdownClick, onCheckboxToggle, onPivotDrill, onResizeEnd, getSheetNames, getCurrentSheet, getEditingHomeSheet, getDisplay, getCellIds, lazyValues = false } = {}) {
+export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getFormat, onFill, onBatchCommit, getMergeInfo, isSlave, getMasterId, getComment, getValidation, getCondFormat, getRightInset, onHyperlinkClick, onDropdownClick, onCheckboxToggle, onPivotDrill, onResizeEnd, getSheetNames, getCurrentSheet, getEditingHomeSheet, getDisplay, getCellIds, lazyValues = false, canEdit = () => true } = {}) {
   const ctx = canvas.getContext('2d')
   const dpr = window.devicePixelRatio || 1
 
@@ -648,6 +648,11 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
   }
 
   function showEditor(initialValue, mode = 'enter') {
+    // Read-only viewers: never open the in-cell editor. This is the single
+    // choke point for every begin-edit path (typing, F2, Enter, double-click),
+    // so blocking it here keeps a viewer from typing into a cell that can't be
+    // saved. Selection/navigation still work.
+    if (!canEdit()) return
     editMode = mode
     selEnd = { r: sel.r, c: sel.c }
     const fmt = getFormat ? getFormat(cellId(sel.r, sel.c)) : {}
@@ -942,7 +947,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
       return
     }
 
-    const resizeCol = geo.hitTestColResize(e.clientX, e.clientY, rect)
+    const resizeCol = canEdit() ? geo.hitTestColResize(e.clientX, e.clientY, rect) : null
     if (resizeCol !== null) {
       e.preventDefault()
       // Broadcast resize: when the dragged column is part of a multi-column
@@ -959,7 +964,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
       return
     }
 
-    const resizeRowHit = geo.hitTestRowResize(e.clientX, e.clientY, rect)
+    const resizeRowHit = canEdit() ? geo.hitTestRowResize(e.clientX, e.clientY, rect) : null
     if (resizeRowHit !== null) {
       e.preventDefault()
       const range = getSelRange()
@@ -972,7 +977,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
       return
     }
 
-    if (hitTestFillHandle(e.clientX, e.clientY, rect)) {
+    if (canEdit() && hitTestFillHandle(e.clientX, e.clientY, rect)) {
       const { r0, c0, r1, c1 } = getSelRange()
       // Track the mousedown screen position so mousemove can ignore sub-pixel
       // jitter — otherwise a 1px wobble during the click extends the selection
@@ -1036,7 +1041,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
 
     // Click on the tickbox of a checkbox-validated cell → toggle it. Clicking
     // elsewhere in the cell falls through to a normal selection.
-    if (vrule?.type === 'checkbox') {
+    if (vrule?.type === 'checkbox' && canEdit()) {
       const x = geo.colX(h.c), y = geo.rowY(h.r)
       const w = geo.cw(h.c), hh = geo.rh(h.r)
       const box = checkboxRect(w, hh)
@@ -1054,7 +1059,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     // The caret zone tracks the chip when one is drawn (list rule + value),
     // else it's the plain arrow box at the cell's right edge. Only list rules
     // get a dropdown — number/length rules fall through to normal selection.
-    if (vrule?.type === 'list') {
+    if (vrule?.type === 'list' && canEdit()) {
       const x = geo.colX(h.c), y = geo.rowY(h.r)
       const w = geo.cw(h.c), cellRight = x + w
       const lx = (e.clientX - rect.left) / _zoom
@@ -1090,6 +1095,9 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
 
   canvas.addEventListener('dblclick', e => {
     const rect = canvas.getBoundingClientRect()
+
+    // Read-only viewers: dbl-click neither edits a cell nor resizes/fills.
+    if (!canEdit()) return
 
     // Double-click on the fill handle → fill down to the bottom of the
     // adjacent column's contiguous data run (Google Sheets behaviour).
@@ -1347,6 +1355,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
 
     if ((e.key === 'Delete' || e.key === 'Backspace') && !mod) {
       e.preventDefault()
+      if (!canEdit()) return
       const { r0, c0, r1, c1 } = getSelRange()
       if (r0 === r1 && c0 === c1) {
         onCommit?.(cellId(r, c), '')

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -72,11 +72,20 @@
             @click="onRetrySave"
           />
         </template>
+        <!-- View-only indicator — shown up front so a viewer knows they can't
+             edit before they try. Neutral gray (not an error) because read
+             access is expected, not a failure. Uses the Frappe UI Badge so it
+             matches the save-error chip beside it and the Espresso tokens. -->
+        <Tooltip v-if="readOnly" text="You have view access. Ask the owner for edit access to make changes.">
+          <Badge theme="gray" variant="subtle" size="lg" label="View only">
+            <template #prefix><FeatherIcon name="eye" class="h-3.5 w-3.5" /></template>
+          </Badge>
+        </Tooltip>
       </div>
       <div class="sn-topbar-right">
         <!-- AI Assist entry point — shown only when an admin has configured a
              key and enabled it (gated server-side via the boot flag). -->
-        <template v-if="aiEnabled">
+        <template v-if="aiEnabled && !readOnly">
           <Button
             variant="ghost"
             size="sm"
@@ -155,7 +164,11 @@
     </div>
 
     <!-- Bar 2 · Formatting toolbar -->
-    <div class="sn-toolbar">
+    <!-- Read-only viewers: dim the whole bar and swallow pointer events so no
+         formatting/insert/chart action is reachable. Undo/Redo and dropdowns
+         come along for free without touching each button. -->
+    <div class="sn-toolbar" :class="{ 'sn-toolbar--readonly': readOnly }"
+         :aria-disabled="readOnly || undefined">
 
       <!-- Number format -->
       <Dropdown :options="numberFormatDropdownOptions" placement="left" class="sn-numfmt">
@@ -296,10 +309,11 @@
           name="formula-bar"
           class="sn-formula-input"
           :value="formulaValue"
+          :readonly="readOnly"
           @input="onFormulaInput"
           @keydown="onFormulaKey"
           @blur="closeAc"
-          placeholder="Enter value or formula"
+          :placeholder="readOnly ? '' : 'Enter value or formula'"
           spellcheck="false"
           autocomplete="off"
         />
@@ -584,7 +598,7 @@
     <div class="sn-bottom">
       <!-- Pinned outside the scroll track so it stays reachable no matter
            how many tabs there are. -->
-      <Button variant="ghost" size="sm" icon="plus" class="sn-tab-add" tooltip="Add sheet" @click="addSheet" />
+      <Button variant="ghost" size="sm" icon="plus" class="sn-tab-add" tooltip="Add sheet" :disabled="readOnly" @click="addSheet" />
       <div class="sn-tabs-track">
         <div
           v-for="name in sheetNames"
@@ -1702,10 +1716,11 @@ const fileDropdownOptions = computed(() => [
     { label: 'Export as XLSX', icon: 'download',  onClick: () => exportXLSX() },
     { label: 'Export as PDF',  icon: 'printer',   onClick: () => exportPDF() },
   ]},
-  { group: 'Import', items: [
+  // Import writes cells — hide it for viewers (export/read stays available).
+  ...(readOnly.value ? [] : [{ group: 'Import', items: [
     { label: 'Import CSV',  icon: 'upload', onClick: () => csvInputRef.value?.click() },
     { label: 'Import XLSX', icon: 'upload', onClick: () => xlsxInputRef.value?.click() },
-  ]},
+  ]}]),
   // Only shown to admins — gated server-side via the boot flag so non-admins
   // never see a settings entry they can't use.
   ...(window.frappe?.boot?.ai_assist_can_configure
@@ -2209,7 +2224,7 @@ const textWrapDropdownOptions = computed(() => [
 // fallbacks only cover the impossible window where someone saves before
 // useSheetTabs has finished initializing.
 let _sheetTabs = null
-const { isSaving, saveError, loadError, loadSheet, autoCreate, saveExisting, retrySave } =
+const { isSaving, saveError, canWrite, loadError, loadSheet, autoCreate, saveExisting, retrySave } =
   usePersistence({
     sheet, formats, merge, comments, validation, condFormat, sortFilter, pivot,
     charts, namedRanges,
@@ -2220,6 +2235,13 @@ const { isSaving, saveError, loadError, loadSheet, autoCreate, saveExisting, ret
     },
     currentTitle, emit,
   })
+
+// View-only mode: the loaded sheet is shared with the current user at read
+// (not write) permission. Everything that mutates the doc keys off this — the
+// grid edit gate, the toolbar/formula-bar disable, the context menu, and the
+// autosave path all no-op so a viewer is never misled into editing a doc they
+// can't persist (and never triggers the server's PermissionError on save).
+const readOnly = computed(() => !canWrite.value)
 
 _sheetTabs = useSheetTabs({ sheet, formats, extras: [merge, comments, validation, condFormat, sortFilter], getGrid: () => grid, activeCell, formulaValue, refreshActiveFormat, onSwitch: () => {
     filterPanel.open = false     // close any open filter popover so it doesn't carry stale state
@@ -2251,6 +2273,14 @@ const { acItems, acIdx, acUp, acVisible, updateAc, commitAc, closeAc } =
 // Context menu — placed here because contextMenu is passed to usePivotIntegration below.
 const { contextMenu, tabMenu, openCanvasContextMenu: onCanvasContextMenu, openTabMenu } =
   useContextMenu({ getGrid: () => grid })
+
+// The right-click menu is entirely mutation actions (insert/delete/freeze/
+// paste-special/…), so suppress it for viewers — the native browser menu still
+// offers copy. Defined here (after the alias) and wired at listener setup.
+function _onCanvasContextMenu(e) {
+  if (readOnly.value) return
+  onCanvasContextMenu(e)
+}
 
 // renderVersion is defined here because usePivotIntegration reads it at call time.
 const renderVersion = ref(0)
@@ -3010,13 +3040,17 @@ function _setupGridInstance() {
     // Lazy render is the default; eager `data` cache stays as an opt-out
     // fallback (`?lazy=0`). See _lazyValuesEnabled.
     lazyValues: _lazyValuesEnabled(),
+    // Gate every in-canvas mutation (begin-edit, delete, fill, resize,
+    // checkbox/dropdown) on write permission. Read-only viewers keep
+    // selection, navigation and copy.
+    canEdit: () => !readOnly.value,
   })
   // Keep DOM overlays (filter chevrons) in sync with canvas scroll/resize/freeze.
   grid.onRender(() => { renderVersion.value++ })
 }
 
 function _setupEventListeners() {
-  canvasRef.value.addEventListener('contextmenu', onCanvasContextMenu)
+  canvasRef.value.addEventListener('contextmenu', _onCanvasContextMenu)
   // computeSelectionStats fires from the grid's onSelect callback on every
   // selection change (moveSel + extendSel both emit it). The redundant
   // mouseup/keyup listeners that used to live here doubled the per-event
@@ -3098,7 +3132,7 @@ onBeforeUnmount(() => {
   // debounce window) silently drops the most recent changes — exactly the
   // "data is lost when I come back" report. The fetch uses `keepalive: true`
   // so the request survives the unmount.
-  if (isDirty.value && props.id && props.id !== 'new') {
+  if (isDirty.value && !readOnly.value && props.id && props.id !== 'new') {
     saveExisting(props.id, currentTitle.value, { keepalive: true })
   }
   window.removeEventListener('beforeunload', onBeforeUnloadGuard)
@@ -3307,6 +3341,10 @@ function _triggerAutoSave() {
 
 async function _doAutoSave() {
   if (!isDirty.value) return
+  // Backstop: a viewer should never reach save_sheet (which would throw
+  // PermissionError). The input layer already blocks their edits, so isDirty
+  // stays false — but guard here too in case a mutation path is ever missed.
+  if (readOnly.value) return
   // Bootstrap is handled by _loadInitialData's autoCreate(); calling
   // saveExisting('new') would explode with "Sheet new not found". If the
   // bootstrap save failed for any reason, leave it to a subsequent reload
@@ -3514,6 +3552,7 @@ const { onGlobalKey } = useShortcuts({
   clipboard, clipboardHas, setMarchingAnts: (v) => grid?.setMarchingAnts(v),
   fillDown, fillRight,
   runSmartFill,
+  readOnly: () => readOnly.value,
 })
 
 // ── Clipboard ─────────────────────────────────────────────────────────────────
@@ -3533,6 +3572,8 @@ function onDocCopy(e) {
 }
 function onDocCut(e) {
   if (!_canvasActive()) return
+  if (readOnly.value) return   // cut deletes cells — viewers may only copy
+
   e.preventDefault()
   const src    = grid.getSelection()
   const sn     = sheet.getCurrentSheet()
@@ -3544,6 +3585,7 @@ function onDocCut(e) {
 }
 async function onDocPaste(e) {
   if (!_canvasActive()) return
+  if (readOnly.value) return   // viewers can't write pasted cells
   e.preventDefault()
   const destSel = grid.getSelection()
   const sn = sheet.getCurrentSheet()
@@ -5190,6 +5232,10 @@ function toggleShowFormulas() {
 
 /* ── Bar 3 · Formatting toolbar ──────────────────────────────────────────── */
 .sn-toolbar { display:flex; align-items:center; gap:2px; height:44px; padding:0 15px; border-bottom:1px solid var(--outline-gray-2); background:var(--surface-base); flex-shrink:0; }
+/* Read-only: dim and make the whole formatting bar inert. pointer-events:none
+   swallows clicks on every control (buttons + dropdowns) without per-button
+   wiring; the reduced opacity is the visual "disabled" cue. */
+.sn-toolbar--readonly { opacity:.45; pointer-events:none; }
 .sn-toolbar :deep(.fui-form-control) { width:auto; }
 .sn-toolbar :deep(select) { min-width:118px; }
 /* Font family dropdown — uses a Button trigger that hugs the short label. */

--- a/frontend/src/apps/sheets/components/SheetEditor/usePersistence.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/usePersistence.js
@@ -9,6 +9,10 @@ import { packSheet, packSheetChunked, unpackSheet, boundsOf } from '../../utils/
 export function usePersistence({ sheet, formats, merge, comments, validation, condFormat, sortFilter, pivot, charts, namedRanges, getViewState, applyViewState, currentTitle, emit }) {
   const isSaving  = ref(false)
   const saveError = ref('')
+  // Write permission for the currently-loaded sheet, from get_sheet's `can_write`.
+  // Defaults to true so a brand-new (autoCreate) doc — which the creator always
+  // owns — never flashes read-only before the first load resolves.
+  const canWrite  = ref(true)
   // Surfaces "couldn't open this sheet" cases (404 / 403 / network) to the
   // editor so it can render a proper error screen instead of mounting a
   // blank canvas. Shape: { kind: 'denied' | 'missing' | 'other', message }.
@@ -36,6 +40,9 @@ export function usePersistence({ sheet, formats, merge, comments, validation, co
       if (saved.charts     && charts?.restore)     charts.restore(saved.charts)
       if (saved.namedRanges && namedRanges?.restore) namedRanges.restore(saved.namedRanges)
       currentTitle.value = doc.title
+      // Older backends predate `can_write`; treat its absence as writable so we
+      // never lock out an editor on a stale server.
+      canWrite.value = doc.can_write !== false
     } catch (err) {
       console.error('Load failed:', err)
       const t = err?.excType || ''
@@ -164,5 +171,5 @@ export function usePersistence({ sheet, formats, merge, comments, validation, co
     }
   }
 
-  return { isSaving, saveError, loadError, loadSheet, autoCreate, saveExisting, retrySave }
+  return { isSaving, saveError, canWrite, loadError, loadSheet, autoCreate, saveExisting, retrySave }
 }

--- a/frontend/src/apps/sheets/components/SheetEditor/useShortcuts.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useShortcuts.js
@@ -20,6 +20,7 @@
  *   setMarchingAnts: (v: null) => void,
  *   fillDown: () => void, fillRight: () => void,
  *   runSmartFill: () => void,
+ *   readOnly?: () => boolean,
  * }} actions
  */
 export function useShortcuts(actions) {
@@ -32,6 +33,7 @@ export function useShortcuts(actions) {
     clipboard, clipboardHas, setMarchingAnts,
     fillDown, fillRight,
     runSmartFill,
+    readOnly = () => false,
   } = actions
 
   function _isInInput() {
@@ -87,10 +89,16 @@ export function useShortcuts(actions) {
   function onGlobalKey(e) {
     const mod     = e.metaKey || e.ctrlKey
     const inInput = _isInInput()
-    if (_handleFormatKeys(e, mod, inInput)) return
-    if (_handleViewKeys(e, mod, inInput))   return
-    if (_handleNavKeys(e, mod, inInput))    return
-    if (_handleEscape(e, inInput))          return
+    // Read-only viewers: only the non-mutating shortcuts stay live (find,
+    // formulas toggle, zoom, help, Escape). Format/undo/redo, nav-edits
+    // (hyperlink, comment, quick-filter), and fill/smart-fill all mutate the
+    // doc, so skip them — they'd set isDirty for a save that can never land.
+    const ro = readOnly()
+    if (!ro && _handleFormatKeys(e, mod, inInput)) return
+    if (_handleViewKeys(e, mod, inInput))          return
+    if (!ro && _handleNavKeys(e, mod, inInput))    return
+    if (_handleEscape(e, inInput))                 return
+    if (ro) return
     if (mod && e.key === 'd' && !inInput) { e.preventDefault(); fillDown();  return }
     if (mod && e.key === 'r' && !inInput) { e.preventDefault(); fillRight(); return }
     // Cmd/Ctrl+E — Smart Fill. Matches Excel's Flash Fill shortcut. Detects

--- a/suite/sheets/api.py
+++ b/suite/sheets/api.py
@@ -296,9 +296,14 @@ def get_sheet(name: str, compressed: int = 0) -> dict:
 	# as-is — ~1.5MB instead of the ~20MB decoded JSON for a big sheet — and let
 	# it decompress. Clients without it (older Safari) get the decoded payload.
 	raw = doc.sheets_data
+	# The read guard above only proves the caller can *view* the sheet. Ship an
+	# explicit write flag so the editor can render read-only (dim the toolbar,
+	# lock the grid, hide the save path) instead of letting a viewer type into a
+	# doc they can't persist and only discovering it when save_sheet throws.
 	return {
 		"name": doc.name,
 		"title": doc.title,
+		"can_write": bool(frappe.has_permission("Sheet", doc=name, ptype="write", throw=False)),
 		"sheets_data": raw if frappe.utils.cint(compressed) else decode_sheets_data(raw),
 	}
 


### PR DESCRIPTION
## Problem

A user with only **read** permission on a Sheet saw a fully editable UI — toolbar, formula bar, editable grid — and only discovered they couldn't edit when a save failed with a raw `PermissionError No permission for Sheet` badge in the header. The UI actively misled viewers into typing work they could never persist.

## Fix

Surface write permission at load time and render a proper read-only mode, modelled on Google Sheets' "View only" treatment (announce up front, strip the editing surface, keep read/copy, never fail a save).

**Backend**
- `get_sheet()` now returns `can_write` (a `has_permission(..., ptype="write")` check) alongside the payload.

**Frontend**
- The editor derives a `readOnly` state from `can_write`.
- The canvas gains a `canEdit` gate — the single `showEditor` choke point plus delete, fill, resize, and checkbox/dropdown all no-op. Selection, navigation and **copy** still work.
- The formatting toolbar is dimmed and made inert; the formula bar is read-only.
- The right-click menu (all mutation actions) is suppressed; document paste/cut and mutating keyboard shortcuts are guarded; Import and Ask-AI are hidden; add-sheet is disabled.
- A neutral **"View only"** `Badge` in the header states the mode plainly.
- **Backstop:** `_doAutoSave` and the keepalive unmount save bail when read-only, so a viewer never calls `save_sheet` and never triggers the server `PermissionError`.

## Testing

Verified locally: a user shared a sheet at read-only permission gets `can_write: false` from `get_sheet`, sees the View-only badge, a dimmed toolbar and locked grid, and cannot trigger a failing save. The owner/editor is unaffected.

Ported from the standalone `frappe/sheets` change (branch `perf/lazy-grid-render`).