### PR TITLE
feat(mail): attach files from Frappe Drive in the composer

### DIFF
--- a/frontend/src/apps/mail/components/ComposeMailEditor.vue
+++ b/frontend/src/apps/mail/components/ComposeMailEditor.vue
@@ -194,6 +194,7 @@
 				class="border-t"
 				:class="{ 'border-transparent': isDragging }"
 				@select-files="(files: File[]) => uploadFiles(files)"
+				@attach-from-drive="showDrivePicker = true"
 				@append-emoji="(emoji: string) => appendEmoji(emoji)"
 				@discard-mail="discardMail"
 				@send-mail="sendMail"
@@ -205,6 +206,8 @@
 		v-model="showContactsModal"
 		@insert="(selections) => mail[insertContactsInto].push(...selections)"
 	/>
+
+	<DriveFilePicker v-model="showDrivePicker" @attach="attachFromDrive" />
 </template>
 
 <script setup lang="ts">
@@ -261,6 +264,7 @@ import type { Attachment, ComposeMailData, File as FileDoc, Identity, UserResour
 
 import RecipientInput from './Controls/RecipientInput.vue'
 import ContactsModal from './Modals/ContactsModal.vue'
+import DriveFilePicker from './Modals/DriveFilePicker.vue'
 
 const show = defineModel<boolean>()
 
@@ -300,6 +304,7 @@ const toInput = useTemplateRef('toInput')
 const ccInput = useTemplateRef('ccInput')
 
 const showContactsModal = ref(false)
+const showDrivePicker = ref(false)
 const insertContactsInto = ref('')
 
 const insertContacts = (insertInto: string) => {
@@ -700,6 +705,31 @@ const uploadFiles = async (files: File[]) => {
 		if (res.status === 'rejected')
 			raiseToast(__('Failed to upload {0}', [files[i].name]), 'error')
 	})
+}
+
+// Drive files are fetched as bytes (permission-checked server-side) and pushed through the same
+// upload pipeline as local files, so they become ordinary Frappe File attachments — no send-path change.
+const attachFromDrive = async (
+	entries: { name: string; file_name: string; mime_type?: string }[],
+) => {
+	const results = await Promise.allSettled(
+		entries.map(async (entry) => {
+			const res = await fetch(
+				`/api/method/suite.drive.api.files.get_file_content?entity_name=${encodeURIComponent(entry.name)}`,
+			)
+			if (!res.ok) throw new Error(entry.file_name)
+			const blob = await res.blob()
+			return new File([blob], entry.file_name, { type: entry.mime_type || blob.type })
+		}),
+	)
+
+	const files: File[] = []
+	results.forEach((res, i) => {
+		if (res.status === 'fulfilled') files.push(res.value)
+		else raiseToast(__('Failed to fetch {0} from Drive', [entries[i].file_name]), 'error')
+	})
+
+	await uploadFiles(files)
 }
 
 const uploadFile = async (file: File) => {

--- a/frontend/src/apps/mail/components/ComposeMailToolbar.vue
+++ b/frontend/src/apps/mail/components/ComposeMailToolbar.vue
@@ -18,11 +18,13 @@
 						</template>
 					</Button>
 				</EmojiPicker>
-				<Button variant="ghost" class="max-h-6 max-w-6" @click="fileInput?.click()">
-					<template #icon>
-						<Paperclip class="icon" />
-					</template>
-				</Button>
+				<Dropdown :options="attachOptions">
+					<Button variant="ghost" class="max-h-6 max-w-6">
+						<template #icon>
+							<Paperclip class="icon" />
+						</template>
+					</Button>
+				</Dropdown>
 				<input
 					ref="fileInput"
 					type="file"
@@ -54,8 +56,8 @@
 </template>
 <script setup lang="ts">
 import { computed, useTemplateRef } from 'vue'
-import { Laugh, Paperclip, SendHorizontal, Trash2 } from 'lucide-vue-next'
-import { Button, TextEditorFixedMenu } from 'frappe-ui'
+import { HardDrive, Laugh, Monitor, Paperclip, SendHorizontal, Trash2 } from 'lucide-vue-next'
+import { Button, Dropdown, TextEditorFixedMenu } from 'frappe-ui'
 
 import { isMac } from '@/apps/mail/utils'
 import { useScreenSize, useTextEditorButtons, useVisualViewport } from '@/apps/mail/utils/composables'
@@ -65,9 +67,22 @@ const { isRecipientsEmpty } = defineProps<{
 	isRecipientsEmpty: boolean
 }>()
 
-const emit = defineEmits(['appendEmoji', 'selectFiles', 'discardMail', 'sendMail'])
+const emit = defineEmits(['appendEmoji', 'selectFiles', 'attachFromDrive', 'discardMail', 'sendMail'])
 
 const modifier = computed(() => (isMac ? '⌘' : 'Ctrl'))
+
+const attachOptions = [
+	{
+		label: __('Upload from computer'),
+		icon: Monitor,
+		onClick: () => fileInput.value?.click(),
+	},
+	{
+		label: __('Attach from Frappe Drive'),
+		icon: HardDrive,
+		onClick: () => emit('attachFromDrive'),
+	},
+]
 
 // Make toolbar hover over keyboard on mobile
 

--- a/frontend/src/apps/mail/components/Modals/DriveFilePicker.vue
+++ b/frontend/src/apps/mail/components/Modals/DriveFilePicker.vue
@@ -1,0 +1,209 @@
+<template>
+	<Dialog v-model="show" :options="{ title: __('Attach from Frappe Drive'), size: '3xl' }">
+		<template #body-content>
+			<div class="flex flex-col gap-3">
+				<!-- Team selector (only when the user belongs to more than one team) -->
+				<FormControl
+					v-if="teamOptions.length > 1"
+					v-model="team"
+					type="select"
+					:label="__('Team')"
+					:options="teamOptions"
+					@update:model-value="onTeamChange"
+				/>
+
+				<!-- Breadcrumb: click a crumb to jump back up the folder path -->
+				<div class="text-ink-gray-6 flex items-center gap-1 text-sm">
+					<button
+						v-for="(crumb, i) in breadcrumbs"
+						:key="crumb.name ?? 'root'"
+						class="flex items-center gap-1 hover:text-ink-gray-8"
+						:class="{ 'text-ink-gray-8 font-medium': i === breadcrumbs.length - 1 }"
+						@click="goToCrumb(i)"
+					>
+						<ChevronRight v-if="i > 0" class="h-3.5 w-3.5" />
+						<span class="max-w-40 truncate">{{ crumb.label }}</span>
+					</button>
+				</div>
+
+				<!-- File / folder list -->
+				<div class="h-72 overflow-y-auto rounded border">
+					<div
+						v-if="files.loading"
+						class="text-ink-gray-5 flex h-full items-center justify-center text-sm"
+					>
+						{{ __('Loading…') }}
+					</div>
+					<div
+						v-else-if="!entries.length"
+						class="text-ink-gray-5 flex h-full items-center justify-center text-sm"
+					>
+						{{ __('This folder is empty.') }}
+					</div>
+					<template v-else>
+						<div
+							v-for="entry in entries"
+							:key="entry.name"
+							class="hover:bg-surface-gray-2 flex items-center gap-2 px-3 py-2"
+							:class="{ 'cursor-pointer': entry.is_folder }"
+							@click="entry.is_folder ? openFolder(entry) : toggle(entry)"
+						>
+							<Checkbox
+								v-if="!entry.is_folder"
+								:model-value="selected.has(entry.name)"
+								@click.stop="toggle(entry)"
+							/>
+							<component
+								:is="entry.is_folder ? Folder : File"
+								class="text-ink-gray-6 h-4 w-4 shrink-0"
+							/>
+							<span class="min-w-0 flex-1 truncate text-sm">{{ entry.file_name }}</span>
+							<span v-if="!entry.is_folder" class="text-ink-gray-5 shrink-0 text-xs">
+								{{ formatSize(entry.file_size) }}
+							</span>
+							<ChevronRight v-else class="text-ink-gray-5 h-4 w-4 shrink-0" />
+						</div>
+					</template>
+				</div>
+			</div>
+		</template>
+		<template #actions>
+			<div class="flex items-center justify-between">
+				<span class="text-ink-gray-5 text-sm">
+					{{ selected.size ? __('{0} selected', [String(selected.size)]) : '' }}
+				</span>
+				<Button
+					variant="solid"
+					:label="__('Attach')"
+					:disabled="!selected.size"
+					@click="attach"
+				/>
+			</div>
+		</template>
+	</Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { ChevronRight, File, Folder } from 'lucide-vue-next'
+import { Button, Checkbox, Dialog, FormControl, createResource } from 'frappe-ui'
+
+interface DriveEntry {
+	name: string
+	file_name: string
+	is_folder: 0 | 1 | boolean
+	file_size: number
+	mime_type?: string
+}
+
+const show = defineModel<boolean>()
+const emit = defineEmits<{ attach: [entries: DriveEntry[]] }>()
+
+// Folder path we've navigated into; the first crumb (name: null) is the team home.
+const breadcrumbs = ref<{ name: string | null; label: string }[]>([
+	{ name: null, label: __('Home') },
+])
+const currentFolder = computed(() => breadcrumbs.value.at(-1)?.name ?? undefined)
+const selected = ref<Set<string>>(new Set())
+const selectedEntries = new Map<string, DriveEntry>()
+
+// Teams the user can browse. `get_teams(details=1)` returns a dict keyed by team id, with the team
+// doc as the value. First team is used by default; a selector shows only when there's a choice.
+type TeamMap = Record<string, { title?: string; team_name?: string }>
+const team = ref<string>('')
+const teams = createResource({
+	url: 'suite.drive.api.permissions.get_teams',
+	// exclude_personal: 0 → include the user's personal Drive team (excluded by default), so
+	// single-user setups (whose only team is personal) still have somewhere to browse.
+	params: { details: 1, exclude_personal: 0 },
+	auto: false,
+	onSuccess: (data: TeamMap) => {
+		const ids = Object.keys(data ?? {})
+		if (!team.value && ids.length) team.value = ids[0]
+		load()
+	},
+})
+const teamOptions = computed(() =>
+	Object.entries((teams.data ?? {}) as TeamMap).map(([name, t]) => ({
+		label: t.title || t.team_name || name,
+		value: name,
+	})),
+)
+
+const files = createResource({
+	url: 'suite.drive.api.list.files',
+	// Omit entity_name at the root so the backend defaults to the team home folder; a serialized
+	// `entity_name=undefined` would be looked up as a (missing) File and error out.
+	makeParams: () => {
+		const params: { team: string; entity_name?: string } = { team: team.value }
+		if (currentFolder.value) params.entity_name = currentFolder.value
+		return params
+	},
+	auto: false,
+})
+// Folders first, then files, each alphabetical — a predictable browse order.
+const entries = computed<DriveEntry[]>(() =>
+	[...((files.data as DriveEntry[]) ?? [])].sort(
+		(a, b) =>
+			Number(!!b.is_folder) - Number(!!a.is_folder) ||
+			a.file_name.localeCompare(b.file_name),
+	),
+)
+
+const formatSize = (bytes: number) => {
+	if (!bytes) return ''
+	const units = ['B', 'KB', 'MB', 'GB']
+	let size = bytes
+	let unit = 0
+	while (size >= 1024 && unit < units.length - 1) {
+		size /= 1024
+		unit++
+	}
+	return `${size.toFixed(unit ? 1 : 0)} ${units[unit]}`
+}
+
+// Fetch the current folder's contents. Called explicitly on open, folder navigation, and team change
+// (rather than via a watcher) so the request reliably fires once a team is known.
+const load = () => {
+	if (team.value) files.reload()
+}
+
+const openFolder = (entry: DriveEntry) => {
+	breadcrumbs.value.push({ name: entry.name, label: entry.file_name })
+	load()
+}
+const goToCrumb = (i: number) => {
+	if (i === breadcrumbs.value.length - 1) return
+	breadcrumbs.value = breadcrumbs.value.slice(0, i + 1)
+	load()
+}
+const toggle = (entry: DriveEntry) => {
+	if (selected.value.has(entry.name)) {
+		selected.value.delete(entry.name)
+		selectedEntries.delete(entry.name)
+	} else {
+		selected.value.add(entry.name)
+		selectedEntries.set(entry.name, entry)
+	}
+}
+const attach = () => {
+	emit('attach', [...selectedEntries.values()])
+	show.value = false
+}
+
+// Reset to the team home and (re)load whenever the picker opens.
+watch(show, (open) => {
+	if (!open) return
+	breadcrumbs.value = [{ name: null, label: __('Home') }]
+	selected.value = new Set()
+	selectedEntries.clear()
+	// teams.onSuccess calls load() once the team is known; if teams are already loaded, load now.
+	if (teams.data) load()
+	else teams.fetch()
+})
+// Changing team (multi-team users) re-roots the browse at that team's home.
+const onTeamChange = () => {
+	breadcrumbs.value = [{ name: null, label: __('Home') }]
+	load()
+}
+</script>


### PR DESCRIPTION
## Overview

Implements #46 — attach files from **Frappe Drive** while composing a mail.

The composer's paperclip becomes a small menu:

- **Upload from computer** — the existing local upload, unchanged.
- **Attach from Frappe Drive** — opens a Drive file picker.

## What's included

- **`DriveFilePicker.vue`** (new modal): browses the user's Drive — team home with breadcrumb folder navigation, folders-first listing, and multi-select — backed by `suite.drive.api.list.files` (+ `permissions.get_teams`). A team selector appears only for multi-team users.
- **`ComposeMailToolbar.vue`**: the paperclip is now a `Dropdown` with the two attach options.
- **`ComposeMailEditor.vue`**: on Drive selection, each file's bytes are fetched via `suite.drive.api.files.get_file_content` (permission-checked server-side), wrapped as a `File`, and pushed through the **existing** upload pipeline (`upload_file` → `attachDoc`). A Drive attachment therefore becomes an ordinary Frappe `File` with a real `file_url`, and the send path (`create_mail`/`update_draft_mail`) needs **no changes**.

Scope matches the maintainer's note on #46: Frappe Drive only (no Google Drive etc.).

## Design note

The "copy bytes" approach (fetch from Drive → re-upload through mail's `upload_file`) was chosen over teaching the mail backend to resolve a Drive `entity_name`, because a Drive file's `file_url` is a storage key that the mail queue can't read directly — Drive always serves bytes through permission-checked `get_file_content`. Reusing the proven attachment pipeline keeps the change frontend-only.

## Testing

Compose a mail → paperclip → **Attach from Frappe Drive** → browse/select one or more files → **Attach**. The files appear as normal attachments and send with the mail. Verified end-to-end locally: select → `get_file_content` → `upload_file` → attachment chip in the composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)