### PR TITLE
feat(sheets): custom Excel-style number formats

### DIFF
--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -958,6 +958,34 @@
       </template>
     </Dialog>
 
+    <!-- Custom number-format dialog -->
+    <Dialog v-model="customFormatDialog.open" :options="{ title: 'Custom number format', size: 'sm' }">
+      <template #body-content>
+        <div class="sn-form-stack">
+          <FormControl
+            v-model="customFormatDialog.pattern"
+            label="Format code"
+            placeholder="#,##0.00"
+            @keydown.enter="confirmCustomFormat"
+          />
+          <div class="text-sm text-ink-gray-6">
+            Preview: <span class="font-medium text-ink-gray-9">{{ customFormatPreview || '—' }}</span>
+          </div>
+          <div class="text-xs text-ink-gray-5 leading-relaxed">
+            <code>0</code> padded digit · <code>#</code> optional digit · <code>,</code> thousands ·
+            <code>.</code> decimal · <code>%</code> percent · <code>"text"</code> literal.
+            e.g. <code>#,##0.00</code>, <code>0.0%</code>, <code>"$"#,##0</code>
+          </div>
+        </div>
+      </template>
+      <template #actions>
+        <div class="flex flex-row-reverse gap-2">
+          <Button variant="solid" @click="confirmCustomFormat">Apply</Button>
+          <Button @click="customFormatDialog.open = false">Cancel</Button>
+        </div>
+      </template>
+    </Dialog>
+
     <!-- Keyboard shortcut help (?) — uses Frappe UI's KeyboardShortcut for the
          key chips so modifiers render as proper Mac glyphs and look native. -->
     <Dialog v-model="showShortcutsHelp" :options="{ title: 'Keyboard shortcuts', size: 'xl' }">
@@ -2154,6 +2182,30 @@ const _FORMAT_LABELS = (() => {
   return m
 })()
 
+// Custom number-format dialog. `pattern` is a raw Excel-style code; it's
+// stored as `custom:<pattern>` so the display path routes it to applyCustomFmt.
+const customFormatDialog = reactive({ open: false, pattern: '' })
+
+function openCustomFormatDialog() {
+  const cur = parseNumberFmt(activeNumberFormat.value)
+  customFormatDialog.pattern = cur.type === 'custom' ? cur.pattern : '#,##0.00'
+  customFormatDialog.open = true
+}
+
+// Live preview against a representative value so the user sees the effect
+// before applying. Falls back to empty on a pattern that throws.
+const customFormatPreview = computed(() => {
+  const p = customFormatDialog.pattern.trim()
+  if (!p) return ''
+  try { return applyNumberFmt(1234.567, 'custom:' + p) } catch { return '' }
+})
+
+function confirmCustomFormat() {
+  const p = customFormatDialog.pattern.trim()
+  if (p) onNumberFormatChange('custom:' + p)
+  customFormatDialog.open = false
+}
+
 const numberFormatLabel = computed(() => {
   const cur = activeNumberFormat.value
   if (_FORMAT_LABELS.has(cur)) return _FORMAT_LABELS.get(cur)
@@ -2168,15 +2220,18 @@ const numberFormatLabel = computed(() => {
   return type[0].toUpperCase() + type.slice(1)
 })
 
-const numberFormatDropdownOptions = computed(() =>
-  NUMBER_FORMAT_GROUPS.map(g => ({
+const numberFormatDropdownOptions = computed(() => [
+  ...NUMBER_FORMAT_GROUPS.map(g => ({
     group: g.group,
     items: g.items.map(it => ({
       label: it.label,
       onClick: () => onNumberFormatChange(activeNumberFormat.value === it.value ? '' : it.value),
     })),
-  }))
-)
+  })),
+  { group: 'Custom', items: [
+    { label: 'Custom format…', onClick: () => openCustomFormatDialog() },
+  ]},
+])
 
 // Active currency code (for the $-button symbol). Defaults to $ when the cell
 // isn't a currency at all, so the button always says *something* clickable.

--- a/frontend/src/apps/sheets/utils/format-number.js
+++ b/frontend/src/apps/sheets/utils/format-number.js
@@ -19,7 +19,11 @@
 
 export function parseNumberFmt(fmt) {
   if (!fmt) return { type: '', variant: '', decimals: null }
-  const parts = String(fmt).split(':')
+  // Custom patterns carry a raw Excel-style string that may itself contain ':'
+  // (e.g. a time mask), so they're kept whole rather than split on ':'.
+  const s = String(fmt)
+  if (s.startsWith('custom:')) return { type: 'custom', pattern: s.slice(7), variant: '', decimals: null }
+  const parts = s.split(':')
   const type = parts[0]
   let variant = ''
   let decimals = null
@@ -159,6 +163,7 @@ const DATE_LIKE = new Set(['date', 'time', 'datetime'])
 
 export function applyNumberFmt(value, format) {
   if (!format) return value
+  if (String(format).startsWith('custom:')) return applyCustomFmt(value, String(format).slice(7))
   const { type, variant, decimals } = parseNumberFmt(format)
   // Text format leaves the value untouched (no numeric coercion at display).
   // Cells flagged 'text' should also be treated as text in formulas; that's
@@ -198,4 +203,76 @@ export function applyNumberFmt(value, format) {
     return `${datePart}, ${timePart}`
   }
   return value
+}
+
+// ─── Custom Excel-style number patterns ─────────────────────────────────────
+//
+// Numeric subset of Excel's format codes — covers the common cases without
+// pulling in the full date-token grammar (dates keep their own format types):
+//   0   digit, zero-padded              #   digit, no padding
+//   .   decimal point                   ,   thousands grouping
+//   %   scale by 100 and show a percent  "text" / \c   literal passthrough
+// A pattern has one numeric run; anything before/after it is emitted verbatim,
+// so `"$"#,##0.00`, `0.0%`, `#,##0 "kg"` all work. Negatives get a leading '-'
+// (Excel's `positive;negative` sections are a later follow-up).
+export function applyCustomFmt(value, pattern) {
+  const n = parseFloat(value)
+  if (isNaN(n)) return value == null ? '' : String(value)
+  const { prefix, numSpec, suffix, percent } = _parseCustomPattern(pattern)
+  if (!numSpec) return prefix + suffix
+  const body = _renderNumSpec(n * Math.pow(100, percent), numSpec)
+  return prefix + body + suffix
+}
+
+// Split a pattern into its literal prefix/suffix and the single numeric run,
+// counting '%' signs (each scales the value by 100). Quotes and `\` escape
+// literals so a stray '0' or '#' inside text isn't treated as a placeholder.
+function _parseCustomPattern(pattern) {
+  let prefix = '', numSpec = '', suffix = '', percent = 0
+  let state = 'pre'   // pre → num → post
+  for (let i = 0; i < pattern.length; i++) {
+    const ch = pattern[i]
+    let lit
+    if (ch === '"') {
+      let s = ''; i++
+      while (i < pattern.length && pattern[i] !== '"') s += pattern[i++]
+      lit = s
+    } else if (ch === '\\') {
+      lit = pattern[i + 1] ?? ''; i++
+    } else if ('0#,.'.includes(ch) && state !== 'post') {
+      state = 'num'; numSpec += ch; continue
+    } else if (ch === '%') {
+      percent++; lit = '%'
+    } else {
+      lit = ch
+    }
+    if (state === 'num') state = 'post'
+    if (state === 'pre') prefix += lit
+    else suffix += lit
+  }
+  return { prefix, numSpec, suffix, percent }
+}
+
+// Render a number against a numeric run like `#,##0.00`: honour min integer
+// digits ('0'), optional digits ('#'), thousands grouping, and min/max decimals.
+function _renderNumSpec(n, spec) {
+  const neg = n < 0
+  n = Math.abs(n)
+  const dot = spec.indexOf('.')
+  const intSpec  = dot === -1 ? spec : spec.slice(0, dot)
+  const fracSpec = dot === -1 ? ''   : spec.slice(dot + 1)
+  const grouping = intSpec.includes(',')
+  const minInt   = (intSpec.match(/0/g) || []).length
+  const minFrac  = (fracSpec.match(/0/g) || []).length
+  const maxFrac  = (fracSpec.match(/[0#]/g) || []).length
+
+  let [ip, fp = ''] = n.toFixed(maxFrac).split('.')
+  while (fp.length > minFrac && fp.endsWith('0')) fp = fp.slice(0, -1)  // drop optional trailing zeros
+  if (fp.length < minFrac) fp = fp.padEnd(minFrac, '0')
+  if (ip.length < minInt) ip = ip.padStart(minInt, '0')
+  else if (ip === '0' && minInt === 0) ip = ''                          // `#.##` on 0.5 → ".5"
+  if (grouping) ip = ip.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+
+  const out = fp.length ? `${ip}.${fp}` : ip
+  return (neg && out ? '-' : '') + out
 }

--- a/frontend/src/apps/sheets/utils/format-number.js
+++ b/frontend/src/apps/sheets/utils/format-number.js
@@ -274,5 +274,7 @@ function _renderNumSpec(n, spec) {
   if (grouping) ip = ip.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
 
   const out = fp.length ? `${ip}.${fp}` : ip
-  return (neg && out ? '-' : '') + out
+  // Suppress the sign when the value rounded to zero, so -0.4 with `0` shows
+  // "0", not "-0". `out` has no significant digit iff it's all zeros/separators.
+  return (neg && /[1-9]/.test(out) ? '-' : '') + out
 }

--- a/frontend/src/apps/sheets/utils/format-number.js
+++ b/frontend/src/apps/sheets/utils/format-number.js
@@ -220,8 +220,12 @@ export function applyCustomFmt(value, pattern) {
   if (isNaN(n)) return value == null ? '' : String(value)
   const { prefix, numSpec, suffix, percent } = _parseCustomPattern(pattern)
   if (!numSpec) return prefix + suffix
-  const body = _renderNumSpec(n * Math.pow(100, percent), numSpec)
-  return prefix + body + suffix
+  const scaled = n * Math.pow(100, percent)
+  const body = _renderNumSpec(scaled, numSpec)
+  // Sign sits before any literal prefix (Excel: -$1,234.50, not $-1,234.50)
+  // and is dropped when the value rounded to zero (avoid "-0").
+  const sign = scaled < 0 && /[1-9]/.test(body) ? '-' : ''
+  return sign + prefix + body + suffix
 }
 
 // Split a pattern into its literal prefix/suffix and the single numeric run,
@@ -256,7 +260,6 @@ function _parseCustomPattern(pattern) {
 // Render a number against a numeric run like `#,##0.00`: honour min integer
 // digits ('0'), optional digits ('#'), thousands grouping, and min/max decimals.
 function _renderNumSpec(n, spec) {
-  const neg = n < 0
   n = Math.abs(n)
   const dot = spec.indexOf('.')
   const intSpec  = dot === -1 ? spec : spec.slice(0, dot)
@@ -273,8 +276,5 @@ function _renderNumSpec(n, spec) {
   else if (ip === '0' && minInt === 0) ip = ''                          // `#.##` on 0.5 → ".5"
   if (grouping) ip = ip.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
 
-  const out = fp.length ? `${ip}.${fp}` : ip
-  // Suppress the sign when the value rounded to zero, so -0.4 with `0` shows
-  // "0", not "-0". `out` has no significant digit iff it's all zeros/separators.
-  return (neg && /[1-9]/.test(out) ? '-' : '') + out
+  return fp.length ? `${ip}.${fp}` : ip
 }

--- a/frontend/src/apps/sheets/utils/format-number.test.ts
+++ b/frontend/src/apps/sheets/utils/format-number.test.ts
@@ -308,6 +308,10 @@ describe('applyCustomFmt — Excel-style patterns', () => {
   it('negative gets a leading minus', () => {
     expect(f(-1234.5, '#,##0.00')).toBe('-1,234.50')
   })
+  it('does not render negative zero when the value rounds to 0', () => {
+    expect(f(-0.4, '0')).toBe('0')
+    expect(f(-0.001, '0.00')).toBe('0.00')
+  })
   it('non-numeric value passes through untouched', () => {
     expect(f('hello', '0.00')).toBe('hello')
   })

--- a/frontend/src/apps/sheets/utils/format-number.test.ts
+++ b/frontend/src/apps/sheets/utils/format-number.test.ts
@@ -312,6 +312,10 @@ describe('applyCustomFmt — Excel-style patterns', () => {
     expect(f(-0.4, '0')).toBe('0')
     expect(f(-0.001, '0.00')).toBe('0.00')
   })
+  it('places the sign before a literal prefix', () => {
+    expect(f(-1234.5, '"$"#,##0.00')).toBe('-$1,234.50')
+    expect(f(-50, '"$"0')).toBe('-$50')
+  })
   it('non-numeric value passes through untouched', () => {
     expect(f('hello', '0.00')).toBe('hello')
   })

--- a/frontend/src/apps/sheets/utils/format-number.test.ts
+++ b/frontend/src/apps/sheets/utils/format-number.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect } from 'vitest'
+import { parseNumberFmt, buildNumberFmt, applyNumberFmt } from './format-number.js'
+
+describe('parseNumberFmt', () => {
+  it('returns empty fields for falsy input', () => {
+    expect(parseNumberFmt('')).toEqual({ type: '', variant: '', decimals: null })
+    expect(parseNumberFmt(null)).toEqual({ type: '', variant: '', decimals: null })
+    expect(parseNumberFmt(undefined)).toEqual({ type: '', variant: '', decimals: null })
+  })
+
+  it('parses bare type', () => {
+    expect(parseNumberFmt('number')).toEqual({ type: 'number', variant: '', decimals: null })
+    expect(parseNumberFmt('currency')).toEqual({ type: 'currency', variant: '', decimals: null })
+  })
+
+  it('parses legacy two-part `type:N` as decimals-only (no variant)', () => {
+    expect(parseNumberFmt('number:3')).toEqual({ type: 'number', variant: '', decimals: 3 })
+    expect(parseNumberFmt('currency:0')).toEqual({ type: 'currency', variant: '', decimals: 0 })
+  })
+
+  it('parses two-part `type:variant` as variant-only', () => {
+    expect(parseNumberFmt('currency:INR')).toEqual({ type: 'currency', variant: 'INR', decimals: null })
+    expect(parseNumberFmt('date:dmy')).toEqual({ type: 'date', variant: 'dmy', decimals: null })
+  })
+
+  it('parses three-part `type:variant:N`', () => {
+    expect(parseNumberFmt('currency:INR:2')).toEqual({ type: 'currency', variant: 'INR', decimals: 2 })
+    expect(parseNumberFmt('number:in:0')).toEqual({ type: 'number', variant: 'in', decimals: 0 })
+  })
+
+  it('handles empty decimals slot in three-part form', () => {
+    expect(parseNumberFmt('currency:INR:')).toEqual({ type: 'currency', variant: 'INR', decimals: null })
+  })
+})
+
+describe('buildNumberFmt', () => {
+  it('returns empty string for no type', () => {
+    expect(buildNumberFmt('', '', null)).toBe('')
+    expect(buildNumberFmt(null, 'INR', 2)).toBe('')
+  })
+
+  it('emits bare type when no variant + no decimals', () => {
+    expect(buildNumberFmt('number', '', null)).toBe('number')
+  })
+
+  it('emits legacy `type:N` when decimals-only (backwards-compat)', () => {
+    expect(buildNumberFmt('number', '', 3)).toBe('number:3')
+    expect(buildNumberFmt('currency', '', 0)).toBe('currency:0')
+  })
+
+  it('emits `type:variant` when variant-only', () => {
+    expect(buildNumberFmt('currency', 'INR', null)).toBe('currency:INR')
+    expect(buildNumberFmt('date', 'dmy', null)).toBe('date:dmy')
+  })
+
+  it('emits `type:variant:N` when both', () => {
+    expect(buildNumberFmt('currency', 'INR', 2)).toBe('currency:INR:2')
+    expect(buildNumberFmt('number', 'in', 0)).toBe('number:in:0')
+  })
+
+  it('round-trips through parseNumberFmt', () => {
+    for (const fmt of ['number', 'number:3', 'currency:USD:2', 'currency:INR', 'date:dmy', 'number:in:0']) {
+      const { type, variant, decimals } = parseNumberFmt(fmt)
+      expect(buildNumberFmt(type, variant, decimals)).toBe(fmt)
+    }
+  })
+})
+
+describe('applyNumberFmt — backwards-compat baseline', () => {
+  // These pin the existing behaviour from before the grammar extension.
+  // New variant renderers land in subsequent commits — until then, an
+  // unknown variant just falls through to the default for that type.
+  it('returns value unchanged when no format', () => {
+    expect(applyNumberFmt('hello', '')).toBe('hello')
+    expect(applyNumberFmt(42, null)).toBe(42)
+  })
+
+  it('text passes value through as string', () => {
+    expect(applyNumberFmt(42, 'text')).toBe('42')
+    expect(applyNumberFmt(null, 'text')).toBe('')
+  })
+
+  it('number applies decimals', () => {
+    expect(applyNumberFmt(1234.5, 'number:2')).toBe((1234.5).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }))
+  })
+
+  it('currency defaults to USD with 2 decimals', () => {
+    // Locale-sensitive output; just assert it contains the USD symbol and the integer part.
+    const out = applyNumberFmt(1234, 'currency')
+    expect(out).toMatch(/\$/)
+    expect(out).toContain('1,234')
+  })
+
+  it('legacy currency:N still works', () => {
+    expect(applyNumberFmt(10, 'currency:0')).toBe('$10')
+  })
+
+  it('percentage scales x100 and appends %', () => {
+    expect(applyNumberFmt(0.25, 'percentage')).toBe('25.00%')
+    expect(applyNumberFmt(0.5,  'percentage:0')).toBe('50%')
+  })
+
+  it('non-numeric value with numeric format passes through', () => {
+    expect(applyNumberFmt('abc', 'number')).toBe('abc')
+    expect(applyNumberFmt('abc', 'currency')).toBe('abc')
+  })
+})
+
+describe('applyNumberFmt — currency variants', () => {
+  // Intl output is locale-data-dependent, so assertions check for the
+  // currency symbol + the grouped digits rather than exact glyph-for-glyph.
+  it('USD uses $ with US grouping', () => {
+    const out = applyNumberFmt(1234567.89, 'currency:USD:2')
+    expect(out).toContain('$')
+    expect(out).toContain('1,234,567')
+  })
+
+  it('INR uses ₹ with Indian lakhs grouping', () => {
+    const out = applyNumberFmt(1234567.89, 'currency:INR:2')
+    expect(out).toContain('₹')
+    // en-IN groups as 12,34,567 — first group is 3, then 2s.
+    expect(out).toContain('12,34,567')
+  })
+
+  it('EUR formats with € (de-DE conventions)', () => {
+    const out = applyNumberFmt(1234.5, 'currency:EUR:2')
+    expect(out).toContain('€')
+    // de-DE uses period as thousands sep: 1.234,50
+    expect(out).toMatch(/1[.\s  ]234/)
+  })
+
+  it('GBP uses £', () => {
+    expect(applyNumberFmt(99, 'currency:GBP:0')).toContain('£')
+  })
+
+  it('JPY defaults to 0 decimals', () => {
+    const out = applyNumberFmt(12345, 'currency:JPY')
+    // ja-JP locale emits fullwidth yen (￥); en-* would emit halfwidth (¥).
+    expect(out).toMatch(/[¥￥]/)
+    expect(out).not.toContain('.')
+  })
+
+  it('unknown currency variant falls back to USD', () => {
+    expect(applyNumberFmt(10, 'currency:XYZ:0')).toBe('$10')
+  })
+
+  it('bare `currency` still defaults to USD (backwards-compat)', () => {
+    expect(applyNumberFmt(10, 'currency:0')).toBe('$10')
+    expect(applyNumberFmt(10, 'currency')).toMatch(/^\$10/)
+  })
+})
+
+describe('applyNumberFmt — date variants', () => {
+  // 2025-01-15T00:00:00 UTC — exact ms varies with the test-runner TZ, so we
+  // assert on character/format shape rather than exact string.
+  const ms = Date.UTC(2025, 0, 15)
+
+  it('bare `date` defers to user locale (legacy)', () => {
+    // Just verify we get *some* date-like string, not the raw number.
+    const out = applyNumberFmt(ms, 'date')
+    expect(out).not.toBe(String(ms))
+    expect(out).toMatch(/\d/)
+  })
+
+  it('date:dmy → DD/MM/YYYY', () => {
+    expect(applyNumberFmt(ms, 'date:dmy')).toMatch(/^\d{2}\/\d{2}\/\d{4}$/)
+  })
+
+  it('date:mdy → MM/DD/YYYY', () => {
+    expect(applyNumberFmt(ms, 'date:mdy')).toMatch(/^\d{2}\/\d{2}\/\d{4}$/)
+  })
+
+  it('date:ymd → YYYY-MM-DD', () => {
+    expect(applyNumberFmt(ms, 'date:ymd')).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('date:long → "15 Jan 2025"', () => {
+    const out = applyNumberFmt(ms, 'date:long')
+    expect(out).toMatch(/^\d{1,2} [A-Z][a-z]{2} \d{4}$/)
+  })
+
+  it('date:full → weekday-prefixed long date', () => {
+    const out = applyNumberFmt(ms, 'date:full')
+    expect(out).toMatch(/^[A-Z][a-z]{2}, \d{1,2} [A-Z][a-z]{2} \d{4}$/)
+  })
+
+  it('unknown date variant falls back to locale default', () => {
+    expect(applyNumberFmt(ms, 'date:xyz')).toMatch(/\d/)
+  })
+
+  it('non-numeric value passes through (no ms-since-epoch to parse)', () => {
+    expect(applyNumberFmt('hello', 'date:dmy')).toBe('hello')
+  })
+
+  // Regression: datetime *strings* (e.g. Frappe creation/modified columns)
+  // were parseFloat'd to a small int and rendered as 1970-01-01.
+  it('parses a datetime string with microseconds (not 1970)', () => {
+    expect(applyNumberFmt('2026-03-15 14:50:30.789345', 'date:ymd')).toBe('2026-03-15')
+    expect(applyNumberFmt('2026-03-15 14:50:30.789345', 'date:dmy')).toBe('15/03/2026')
+  })
+
+  it('parses a bare date string', () => {
+    expect(applyNumberFmt('2026-01-08', 'date:ymd')).toBe('2026-01-08')
+  })
+
+  it('time/datetime read the same string', () => {
+    expect(applyNumberFmt('2026-03-15 14:50:30.789345', 'time:hm')).toBe('14:50')
+    expect(applyNumberFmt('2026-03-15 14:50:30.789345', 'datetime:ymd_hm')).toBe('2026-03-15, 14:50')
+  })
+})
+
+describe('applyNumberFmt — time variants', () => {
+  // 15:30:45 local — pick a fixed clock-only ms so all assertions stay in
+  // local timezone without ms-since-epoch arithmetic.
+  const d = new Date(2025, 0, 15, 15, 30, 45)
+  const ms = d.getTime()
+
+  it('time:hm → HH:MM (24h)', () => {
+    expect(applyNumberFmt(ms, 'time:hm')).toBe('15:30')
+  })
+
+  it('time:hms → HH:MM:SS (24h)', () => {
+    expect(applyNumberFmt(ms, 'time:hms')).toBe('15:30:45')
+  })
+
+  it('time:hm12 → H:MM AM/PM', () => {
+    expect(applyNumberFmt(ms, 'time:hm12')).toMatch(/^3:30 PM$/)
+  })
+
+  it('time:hms12 → H:MM:SS AM/PM', () => {
+    expect(applyNumberFmt(ms, 'time:hms12')).toMatch(/^3:30:45 PM$/)
+  })
+
+  it('non-numeric value passes through', () => {
+    expect(applyNumberFmt('hello', 'time:hm')).toBe('hello')
+  })
+})
+
+describe('applyNumberFmt — datetime', () => {
+  const d = new Date(2025, 0, 15, 15, 30, 0)
+  const ms = d.getTime()
+
+  it('datetime:dmy_hm12 → "DD/MM/YYYY, H:MM AM/PM"', () => {
+    expect(applyNumberFmt(ms, 'datetime:dmy_hm12')).toBe('15/01/2025, 3:30 PM')
+  })
+
+  it('datetime:ymd_hms → "YYYY-MM-DD, HH:MM:SS"', () => {
+    expect(applyNumberFmt(ms, 'datetime:ymd_hms')).toBe('2025-01-15, 15:30:00')
+  })
+
+  it('datetime:long_hm → "15 Jan 2025, 15:30"', () => {
+    expect(applyNumberFmt(ms, 'datetime:long_hm')).toBe('15 Jan 2025, 15:30')
+  })
+})
+
+describe('applyNumberFmt — number variants', () => {
+  it('number:in groups as Indian lakhs', () => {
+    expect(applyNumberFmt(1234567, 'number:in:0')).toBe('12,34,567')
+  })
+
+  it('number:us groups with commas every 3 digits', () => {
+    expect(applyNumberFmt(1234567, 'number:us:0')).toBe('1,234,567')
+  })
+
+  it('legacy number:N (no variant) keeps user-default grouping', () => {
+    // Just verify the function doesn't throw and emits something sensible —
+    // the exact grouping depends on test-runner locale.
+    expect(applyNumberFmt(1234, 'number:0')).toMatch(/\d/)
+  })
+})
+
+describe('applyCustomFmt — Excel-style patterns', () => {
+  const f = (v, p) => applyNumberFmt(v, 'custom:' + p)
+
+  it('pads integer digits with 0', () => {
+    expect(f(42, '000')).toBe('042')
+  })
+  it('# does not pad', () => {
+    expect(f(42, '#')).toBe('42')
+  })
+  it('thousands grouping', () => {
+    expect(f(1234567, '#,##0')).toBe('1,234,567')
+  })
+  it('fixed decimals with rounding', () => {
+    expect(f(3.14159, '0.00')).toBe('3.14')
+    expect(f(2.5, '0')).toBe('3')
+  })
+  it('optional decimals trim trailing zeros', () => {
+    expect(f(3.5, '0.##')).toBe('3.5')
+    expect(f(3, '0.##')).toBe('3')
+  })
+  it('min decimals pad', () => {
+    expect(f(3.5, '0.00')).toBe('3.50')
+  })
+  it('leading digit dropped when no integer placeholder', () => {
+    expect(f(0.5, '#.##')).toBe('.5')
+  })
+  it('percent scales by 100 and appends %', () => {
+    expect(f(0.1234, '0.0%')).toBe('12.3%')
+  })
+  it('literal prefix/suffix passthrough', () => {
+    expect(f(1234.5, '"$"#,##0.00')).toBe('$1,234.50')
+    expect(f(12, '#,##0 "kg"')).toBe('12 kg')
+  })
+  it('escaped literal char', () => {
+    expect(f(5, '0\\%')).toBe('5%')   // backslash-escaped % is literal, no scaling
+  })
+  it('negative gets a leading minus', () => {
+    expect(f(-1234.5, '#,##0.00')).toBe('-1,234.50')
+  })
+  it('non-numeric value passes through untouched', () => {
+    expect(f('hello', '0.00')).toBe('hello')
+  })
+  it('parseNumberFmt recognises custom and keeps the raw pattern', () => {
+    expect(parseNumberFmt('custom:0.00%')).toEqual({ type: 'custom', pattern: '0.00%', variant: '', decimals: null })
+  })
+})


### PR DESCRIPTION
Adds a `custom:<pattern>` number-format type so users can enter Excel-style format codes beyond the built-in currency/percent/date presets.

### Interpreter
A small numeric-pattern interpreter (`applyCustomFmt` in `format-number.js`) covering the common codes:
- `0` padded digit · `#` optional digit · `,` thousands grouping · `.` decimal point
- `%` scales by 100 and prints a percent · `"text"` and `\c` literal passthrough

Handles min/max decimals, thousands grouping, negatives, and the leading-zero drop (`#.##` on `0.5` → `.5`). Date/time tokens intentionally stay on the existing `date`/`time` format types — this is the numeric subset.

### UI
A **"Custom format…"** entry in the number-format dropdown opens a dialog with a format-code input, a **live preview**, and a short cheatsheet.

### Tests
`format-number.test.ts` covers padding, grouping, rounding, optional-decimal trimming, percent scaling, literal prefix/suffix, escaped literals, negatives, and non-numeric passthrough.

Ported from standalone frappe/sheets (`feat/parity-phase1`).