### PR TITLE
feat(sheets): protected cell ranges and sheet lock

### DIFF
--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -10,7 +10,7 @@ import { checkboxRect } from './checkbox-geometry.js'
 
 export { colLabel, cellId, parseCellId } from '../utils/cells.js'
 
-export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getFormat, onFill, onBatchCommit, getMergeInfo, isSlave, getMasterId, getComment, getValidation, getCondFormat, getRightInset, onHyperlinkClick, onDropdownClick, onCheckboxToggle, onPivotDrill, onResizeEnd, getSheetNames, getCurrentSheet, getEditingHomeSheet, getDisplay, getCellIds, lazyValues = false, canEdit = () => true } = {}) {
+export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getFormat, onFill, onBatchCommit, getMergeInfo, isSlave, getMasterId, getComment, getValidation, getCondFormat, getRightInset, onHyperlinkClick, onDropdownClick, onCheckboxToggle, onPivotDrill, onResizeEnd, getSheetNames, getCurrentSheet, getEditingHomeSheet, getDisplay, getCellIds, lazyValues = false, canEdit = () => true, isCellEditable, onBlockedEdit } = {}) {
   const ctx = canvas.getContext('2d')
   const dpr = window.devicePixelRatio || 1
 
@@ -675,12 +675,24 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     // last picked rect. It'll clear on next selection move / commit / cancel.
   }
 
+  // True unless the host marks any cell in the rect protected. Guards the two
+  // canvas-owned write paths (opening the editor, and Delete-clear) so a
+  // protected cell can't be edited even before the host handlers run.
+  function _rangeEditable(r0, c0, r1, c1) {
+    if (!isCellEditable) return true
+    for (let r = r0; r <= r1; r++)
+      for (let c = c0; c <= c1; c++)
+        if (!isCellEditable(r, c)) return false
+    return true
+  }
+
   function showEditor(initialValue, mode = 'enter') {
     // Read-only viewers: never open the in-cell editor. This is the single
     // choke point for every begin-edit path (typing, F2, Enter, double-click),
     // so blocking it here keeps a viewer from typing into a cell that can't be
     // saved. Selection/navigation still work.
     if (!canEdit()) return
+    if (isCellEditable && !isCellEditable(sel.r, sel.c)) { onBlockedEdit?.(); return }
     editMode = mode
     selEnd = { r: sel.r, c: sel.c }
     const fmt = getFormat ? getFormat(cellId(sel.r, sel.c)) : {}
@@ -1385,6 +1397,9 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
       e.preventDefault()
       if (!canEdit()) return
       const { r0, c0, r1, c1 } = getSelRange()
+      // Bail before touching the local cell cache — otherwise a blocked host
+      // handler would leave the canvas showing empty cells the engine still holds.
+      if (!_rangeEditable(r0, c0, r1, c1)) { onBlockedEdit?.(); return }
       if (r0 === r1 && c0 === c1) {
         onCommit?.(cellId(r, c), '')
       } else {

--- a/frontend/src/apps/sheets/components/SheetEditor/FindReplace.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/FindReplace.vue
@@ -35,6 +35,8 @@ import { Button, FormControl } from 'frappe-ui'
 const props = defineProps({
   sheet: { type: Object, required: true },
   grid:  { type: Object, required: true },
+  // (id) => boolean — true when a cell is protected and must not be rewritten.
+  isProtected: { type: Function, default: null },
 })
 const emit = defineEmits(['close', 'navigateTo'])
 
@@ -72,6 +74,7 @@ function findNext() {
 function replaceCurrent() {
   if (matchIndex.value < 0 || !matches.value.length) return
   const id  = matches.value[matchIndex.value]
+  if (props.isProtected?.(id)) { status.value = 'Cell is protected'; return }
   const cur = String(props.sheet.getCell(id))
   const q   = findQuery.value
   props.sheet.setCell(id, cur.replace(new RegExp(q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi'), replaceQuery.value))
@@ -82,13 +85,16 @@ function replaceAll() {
   const q = findQuery.value
   if (!q) return
   _buildMatches()
-  let count = 0
+  let count = 0, skipped = 0
   for (const id of matches.value) {
+    if (props.isProtected?.(id)) { skipped++; continue }   // leave protected cells untouched
     const cur = String(props.sheet.getCell(id))
     props.sheet.setCell(id, cur.replace(new RegExp(q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi'), replaceQuery.value))
     count++
   }
-  status.value = `Replaced ${count} cell(s)`
+  status.value = skipped
+    ? `Replaced ${count} cell(s), skipped ${skipped} protected`
+    : `Replaced ${count} cell(s)`
   _buildMatches()
 }
 </script>

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -680,6 +680,7 @@
     <div v-if="tabMenu.open" class="sn-ctx-menu" :style="{ left: tabMenu.x + 'px', bottom: tabMenu.bottom + 'px' }">
       <Button variant="ghost" size="sm" iconLeft="edit-2"  label="Rename"    @click="openRenameDialog(tabMenu.name)" />
       <Button variant="ghost" size="sm" iconLeft="copy"    label="Duplicate" @click="doDuplicateSheet(tabMenu.name)" />
+      <Button variant="ghost" size="sm" :iconLeft="tabMenuSheetLocked() ? 'unlock' : 'lock'" :label="tabMenuSheetLocked() ? 'Unprotect sheet' : 'Protect sheet'" @click="toggleSheetProtection(tabMenu.name)" />
       <Button
         variant="ghost"
         size="sm"
@@ -761,6 +762,8 @@
         <hr class="sn-ctx-sep" />
         <Button variant="ghost" size="sm" iconLeft="check-square"   label="Data validation…" @click="contextMenu.open=false; openValidationDialog()" />
         <Button variant="ghost" size="sm" iconLeft="blend"          label="Conditional format…" @click="contextMenu.open=false; openCfDialog(null)" />
+        <Button v-if="!selectionHasProtectedRange()" variant="ghost" size="sm" iconLeft="lock"   label="Protect range"     @click="protectSelection()" />
+        <Button v-else                               variant="ghost" size="sm" iconLeft="unlock" label="Remove protection" @click="unprotectSelection()" />
         <hr class="sn-ctx-sep" />
         <Button variant="ghost" size="sm" iconLeft="columns"        label="Split text to columns" @click="doSplitTextToColumns()" />
         <hr class="sn-ctx-sep" />
@@ -832,6 +835,7 @@
       v-if="showFindReplace"
       :sheet="sheet"
       :grid="grid"
+      :is-protected="(id) => _cellSilentlyProtected(id)"
       @close="showFindReplace = false"
       @navigate-to="onNavigateTo"
     />
@@ -1169,6 +1173,7 @@ import { createClipboard }     from '../../engine/clipboard.js'
 import { createSortFilter }    from '../../engine/sortFilter.js'
 import { createCommentsEngine }  from '../../engine/comments.js'
 import { createValidationEngine } from '../../engine/validation.js'
+import { createProtectionEngine } from '../../engine/protection.js'
 import { chipColor } from '../../canvas/chip-geometry.js'
 import { createCondFormatEngine } from '../../engine/cond-format.js'
 import { useToolbar }          from './useToolbar.js'
@@ -1275,9 +1280,10 @@ const merge      = createMergeEngine()
 const sortFilter = createSortFilter(sheet)
 const comments   = createCommentsEngine()
 const validation = createValidationEngine()
+const protection = createProtectionEngine()
 const condFormat = createCondFormatEngine()
 const clipboard  = createClipboard({
-  sheet, formats, condFormat, validation,
+  sheet, formats, condFormat, validation, protection,
   // Late-bound to the pivot integration (declared below). Only invoked at
   // copy/paste time, long after setup runs, so the forward reference is safe.
   getPivotAt: (sel, sn) => getPivotAt(sel, sn),
@@ -1357,6 +1363,7 @@ const history = createHistory({
       sortFilter:   sortFilter.snapshot(),
       comments:     comments.snapshot(),
       validation:   validation.snapshot(),
+      protection:   protection.snapshot(),
       condFormat:   condFormat.snapshot(),
       pivot:        pivot.snapshot(),
       charts:       charts.snapshot(),
@@ -1381,6 +1388,7 @@ const history = createHistory({
     if (snap.sortFilter)  sortFilter.restore(snap.sortFilter)
     if (snap.comments)    comments.restore(snap.comments)
     if (snap.validation)  validation.restore(snap.validation)
+    if (snap.protection)  protection.restore(snap.protection)
     if (snap.condFormat)  condFormat.restore(snap.condFormat)
     if (snap.pivot)       pivot.restore(snap.pivot)
     if (snap.charts)      charts.restore(snap.charts)
@@ -1853,7 +1861,11 @@ async function onAskSubmit(promptText) {
 // Returns the number of cells written.
 function _applyAiActions(actions) {
   const sn = sheet.getCurrentSheet()
-  const setCells = actions.filter(a => a.type === 'setCell')
+  let setCells = actions.filter(a => a.type === 'setCell')
+  // Drop writes that land on protected cells (rest still apply).
+  const allowed = setCells.filter(a => !_cellSilentlyProtected(a.cell, sn))
+  if (allowed.length !== setCells.length) _flashProtected(sn)
+  setCells = allowed
   if (!setCells.length) return 0
 
   const before = {}
@@ -2301,7 +2313,7 @@ const textWrapDropdownOptions = computed(() => [
 let _sheetTabs = null
 const { isSaving, saveError, canWrite, loadError, loadSheet, autoCreate, saveExisting, retrySave } =
   usePersistence({
-    sheet, formats, merge, comments, validation, condFormat, sortFilter, pivot,
+    sheet, formats, merge, comments, validation, protection, condFormat, sortFilter, pivot,
     charts, namedRanges,
     getViewState:   () => _sheetTabs?.viewSnapshot?.() ?? grid?.viewSnapshot?.(),
     applyViewState: (s) => {
@@ -2318,7 +2330,7 @@ const { isSaving, saveError, canWrite, loadError, loadSheet, autoCreate, saveExi
 // can't persist (and never triggers the server's PermissionError on save).
 const readOnly = computed(() => !canWrite.value)
 
-_sheetTabs = useSheetTabs({ sheet, formats, extras: [merge, comments, validation, condFormat, sortFilter], getGrid: () => grid, activeCell, formulaValue, refreshActiveFormat, onSwitch: () => {
+_sheetTabs = useSheetTabs({ sheet, formats, extras: [merge, comments, validation, protection, condFormat, sortFilter], getGrid: () => grid, activeCell, formulaValue, refreshActiveFormat, onSwitch: () => {
     filterPanel.open = false     // close any open filter popover so it doesn't carry stale state
     _repopulateGrid()
     grid?.setMarchingAnts(null); clipboard.clear(); clipboardHas.value = false
@@ -2422,6 +2434,7 @@ const {
   getMerge:       () => merge,
   getComments:    () => comments,
   getValidation:  () => validation,
+  getProtection:  () => protection,
   getCondFormat:  () => condFormat,
   getSortFilter:  () => sortFilter,
   getGrid:        () => grid,
@@ -2456,6 +2469,7 @@ const {
   syncFlags,
   captureRange:   _captureRange,
   diffRefs:       _diffRefs,
+  blockProtected: (rect, sn) => _rectBlocked(rect, sn),
 })
 
 // `showSortFilter` is the existing template/handler API; with ranged filters
@@ -3023,6 +3037,16 @@ function _setupGridInstance() {
       const homeSheet = editingHomeSheet.value
       const writeSheet = (homeSheet && homeSheet !== sheet.getCurrentSheet()) ? homeSheet : sheet.getCurrentSheet()
 
+      // Protection first — blocks writes AND clears (empty value) on a locked
+      // cell. Nothing was written, so repaint the pre-edit value and bail.
+      if (_cellBlocked(id, writeSheet)) {
+        grid?.render?.()
+        editingHomeSheet.value = null
+        editingHomeCell.value  = null
+        syncFlags()
+        return
+      }
+
       // Enforce data validation rules. The engine stores rules in the snapshot
       // and the canvas paints a dropdown arrow for `list` rules, but until
       // now nothing surfaced number / text_length rejection — so "between 1
@@ -3122,13 +3146,17 @@ function _setupGridInstance() {
     // active cross-sheet edit, in which case the prefix is omitted.
     getCurrentSheet()    { return sheet.getCurrentSheet() },
     getEditingHomeSheet() { return editingHomeSheet.value },
+    isCellEditable: (r, c) => !protection.isProtected(r, c, sheet.getCurrentSheet()),
+    onBlockedEdit: () => _flashProtected(sheet.getCurrentSheet()),
     onFill(src, total, { withModifier = false } = {}) {
+      if (_rectBlocked(total)) return
       const series = _previewSeriesKind(src)
       // Cmd/Ctrl held inverts the auto-detected mode — Google Sheets behaviour.
       const mode = withModifier ? (series ? 'copy' : 'series') : 'auto'
       _runFill(src, total, mode)
     },
     onBatchCommit(cells) {
+      if (_cellsBlocked(cells.map(c => c.id))) return
       const { before, after, refs } = diffCells(cells, id => sheet.getCell(id))
       for (const { id, value } of cells) sheet.setCell(id, value)
       if (refs.length) {
@@ -3398,6 +3426,86 @@ function _pasteAffectedRects(destSel) {
 	return rects
 }
 
+// ── Protection enforcement ────────────────────────────────────────────────────
+// The single gate every user-initiated write consults. Each helper returns true
+// — and flashes a transient notice — when the target is protected, so callers
+// bail with `if (…) return`. Programmatic paths (undo/restore/collab) never call
+// these, so they can still rewrite protected cells.
+function _flashProtected(sn) {
+  const msg = protection.isSheetLocked(sn)
+    ? 'This sheet is protected'
+    : 'This range is protected and can’t be edited'
+  saveError.value = msg
+  setTimeout(() => { if (saveError.value === msg) saveError.value = '' }, 3500)
+}
+function _rectBlocked(rect, sn = sheet.getCurrentSheet()) {
+  if (!rect || !protection.isAnyProtected(rect, sn)) return false
+  _flashProtected(sn); return true
+}
+function _cellBlocked(id, sn = sheet.getCurrentSheet()) {
+  const p = parseCellId(id)
+  if (!p || !protection.isProtected(p.row, p.col, sn)) return false
+  _flashProtected(sn); return true
+}
+function _cellsBlocked(ids, sn = sheet.getCurrentSheet()) {
+  const hit = ids.some(id => _cellSilentlyProtected(id, sn))
+  if (hit) _flashProtected(sn)
+  return hit
+}
+function _cellSilentlyProtected(id, sn = sheet.getCurrentSheet()) {
+  const p = parseCellId(id)
+  return !!(p && protection.isProtected(p.row, p.col, sn))
+}
+
+// ── Protection UI actions ─────────────────────────────────────────────────────
+function protectSelection() {
+  contextMenu.open = false
+  const sel = grid?.getSelection?.()
+  if (!sel) return
+  protection.addRange(sel, '', sheet.getCurrentSheet())
+  history.push()
+  isDirty.value = true
+  grid?.render?.()
+}
+function unprotectSelection() {
+  contextMenu.open = false
+  const sel = grid?.getSelection?.()
+  if (!sel) return
+  const sn = sheet.getCurrentSheet()
+  // Drop every protected range that overlaps the selection.
+  for (const r of [...protection.getRanges(sn)]) {
+    if (sel.r0 <= r.r1 && sel.r1 >= r.r0 && sel.c0 <= r.c1 && sel.c1 >= r.c0) {
+      protection.removeRange(r.id, sn)
+    }
+  }
+  history.push()
+  isDirty.value = true
+  grid?.render?.()
+}
+function toggleSheetProtection(name) {
+  tabMenu.open = false
+  protection.setSheetLocked(!protection.isSheetLocked(name), name)
+  history.push()
+  isDirty.value = true
+  grid?.render?.()
+}
+// Menu-label reads. These are plain functions (not computed) so the template
+// re-evaluates them against the live selection each time the menu re-renders —
+// a computed would cache a stale answer when neither dep happened to change.
+// selectionHasProtectedRange looks only at ranges: the whole-sheet lock is a
+// separate affordance in the tab menu, so "Remove protection" here never lies
+// about a lock it can't clear.
+function selectionHasProtectedRange() {
+  const sel = grid?.getSelection?.()
+  if (!sel) return false
+  const sn = sheet.getCurrentSheet()
+  return protection.getRanges(sn).some(r =>
+    sel.r0 <= r.r1 && sel.r1 >= r.r0 && sel.c0 <= r.c1 && sel.c1 >= r.c0)
+}
+function tabMenuSheetLocked() {
+  return !!tabMenu.name && protection.isSheetLocked(tabMenu.name)
+}
+
 // Diff two id→value maps, returning the ids whose value changed.  Used to
 // trim noisy before/after pairs down to the cells that actually moved.
 function _diffRefs(before, after) {
@@ -3570,6 +3678,13 @@ function _commitFormulaBar() {
   const homeCell    = editingHomeCell.value
   const targetSheet = homeSheet || sheet.getCurrentSheet()
   const targetId    = homeCell  || activeCell.value
+  // Protected target — discard the edit and restore the bar to the cell value.
+  if (_cellBlocked(targetId, targetSheet)) {
+    editingHomeSheet.value = null
+    editingHomeCell.value  = null
+    formulaValue.value = sheet.getCell(targetId, targetSheet)
+    return
+  }
   const before      = { [targetId]: sheet.getCell(targetId, targetSheet) }
   if (homeSheet && homeSheet !== sheet.getCurrentSheet()) {
     switchSheet(homeSheet, { preserveEdit: true })
@@ -3606,6 +3721,7 @@ function fillDown() {
   const { r0, c0, r1, c1 } = grid.getSelection()
   if (r1 <= r0) return
   const sn = sheet.getCurrentSheet()
+  if (_rectBlocked({ r0: r0 + 1, c0, r1, c1 }, sn)) return
   const before = {}
   for (let c = c0; c <= c1; c++) {
     for (let r = r0 + 1; r <= r1; r++) {
@@ -3629,6 +3745,7 @@ function fillRight() {
   const { r0, c0, r1, c1 } = grid.getSelection()
   if (c1 <= c0) return
   const sn = sheet.getCurrentSheet()
+  if (_rectBlocked({ r0, c0: c0 + 1, r1, c1 }, sn)) return
   const before = {}
   for (let r = r0; r <= r1; r++) {
     for (let c = c0 + 1; c <= c1; c++) {
@@ -3687,6 +3804,8 @@ function onDocCut(e) {
   e.preventDefault()
   const src    = grid.getSelection()
   const sn     = sheet.getCurrentSheet()
+  // Cut moves content out of the source — block it when the source is protected.
+  if (_rectBlocked(src, sn)) return
   const before = _captureRange(src, sn)
   clipboard.cut(src)
   clipboardHas.value = true
@@ -3706,6 +3825,7 @@ async function onDocPaste(e) {
   // Await the async render, then take one full history.push() snapshot, which
   // captures both the pivot registry and the written cells atomically.
   if (clipboard.hasData() && clipboard.getPivotBlob?.()) {
+    if (_rectBlocked(destSel, sn)) return   // a pivot paste bypasses the cell-write guard
     await clipboard.paste(activeCell.value, () => {}, 'all', destSel)
     clipboardHas.value = clipboard.hasData()
     grid.setMarchingAnts(null)
@@ -3751,13 +3871,21 @@ async function onDocPaste(e) {
   if (clipboard.hasData()) {
     // Internal cut/copy — empty historyPush callback so we control the
     // history entry from out here. clipboard still does its mutations.
-    clipboard.paste(activeCell.value, () => {}, 'all', destSel)
+    // A protected destination returns { blocked } and writes nothing; leave
+    // the marching ants + cut buffer intact so the user can retry elsewhere.
+    if (clipboard.paste(activeCell.value, () => {}, 'all', destSel)?.blocked) { _flashProtected(sn); return }
     pasted = true
-  } else if (html && clipboard.pasteFromHTML(html, activeCell.value, () => {}, destSel)) {
-    pasted = true
-  } else if (text) {
-    clipboard.pasteFromText(text, activeCell.value, () => {}, destSel)
-    pasted = true
+  } else {
+    // Prefer a real HTML table; fall back to plain text. Either write into a
+    // protected cell returns { blocked } and we bail without recording it.
+    const htmlRes = html ? clipboard.pasteFromHTML(html, activeCell.value, () => {}, destSel) : false
+    if (htmlRes?.blocked) { _flashProtected(sn); return }
+    if (htmlRes) {
+      pasted = true
+    } else if (text) {
+      if (clipboard.pasteFromText(text, activeCell.value, () => {}, destSel)?.blocked) { _flashProtected(sn); return }
+      pasted = true
+    }
   }
   clipboardHas.value = clipboard.hasData()
   grid.setMarchingAnts(null)
@@ -3800,7 +3928,9 @@ function doPasteSpecial(kind) {
   const beforeFmt  = Object.assign({}, ...rects.map(r => _captureFormatsRange(r, sn)))
   const beforeVal  = Object.assign({}, ...rects.map(r => _captureValidationRange(r, sn)))
   const cfBefore   = condFormat?.getRules?.(sn)?.length ?? 0
-  clipboard.paste(activeCell.value, () => {}, kind, destSel)
+  if (clipboard.paste(activeCell.value, () => {}, kind, destSel)?.blocked) {
+    _flashProtected(sn); return   // keep the pending cut/copy + its marching ants
+  }
   for (const r of rects) _refreshDisplayForRange(r, sn)
   clipboardHas.value = clipboard.hasData()
   grid?.setMarchingAnts(null)
@@ -4139,6 +4269,7 @@ function openDropdown(id, rule, pos = {}) {
 function pickDropdownOption(opt) {
   const id     = dropdownPanel.id
   const sn     = sheet.getCurrentSheet()
+  if (_cellBlocked(id, sn)) { dropdownPanel.open = false; return }
   const before = { [id]: sheet.getCell(id, sn) }
   sheet.setCell(id, opt)
   dropdownPanel.open = false
@@ -4537,7 +4668,12 @@ function clearFilterCol() {
 }
 
 function doSort(colIdx, dir) {
-  sortFilter.sort(colIdx, dir, sheet.getCurrentSheet())
+  const sn = sheet.getCurrentSheet()
+  // Sorting permutes values across the filter range — refuse if it overlaps
+  // protection, matching Google Sheets (a protected range blocks the sort).
+  const range = sortFilter.getRange(sn)
+  if (range && _rectBlocked(range, sn)) return
+  sortFilter.sort(colIdx, dir, sn)
   filterPanel.open = false
   _repopulateGrid()
   _applyHiddenRows()
@@ -4630,6 +4766,7 @@ function doInsertRow(below = false, count = 1) {
     formats.insertRow(atRow, sn)
     comments.insertRow(atRow, sn)
     validation.insertRow(atRow, sn)
+    protection.insertRow(atRow, sn)
     condFormat.insertRow(atRow, sn)
     sortFilter.insertRow(atRow, sn)
     grid.shiftRowHeights(atRow, 1)
@@ -4721,6 +4858,7 @@ function confirmHyperlink() {
   if (!url) { showHyperlinkDialog.value = false; return }
   const id = activeCell.value
   const sh = sheet.getCurrentSheet()
+  if (_cellBlocked(id, sh)) { showHyperlinkDialog.value = false; return }
   if (hyperlinkText.value !== sheet.getCell(id)) sheet.setCell(id, hyperlinkText.value)
   formats.applyToRange([id], { hyperlink: url }, sh)
   history.push()   // post-mutate
@@ -4772,6 +4910,7 @@ function doDeleteRow() {
     formats.deleteRow(start, sn)
     comments.deleteRow(start, sn)
     validation.deleteRow(start, sn)
+    protection.deleteRow(start, sn)
     condFormat.deleteRow(start, sn)
     sortFilter.deleteRow(start, sn)
     grid.shiftRowHeights(start + 1, -1)
@@ -4791,6 +4930,7 @@ function doInsertCol(right = false, count = 1) {
     formats.insertCol(atCol, sn)
     comments.insertCol(atCol, sn)
     validation.insertCol(atCol, sn)
+    protection.insertCol(atCol, sn)
     condFormat.insertCol(atCol, sn)
     sortFilter.insertCol(atCol, sn)
     grid.shiftColWidths(atCol, 1)
@@ -4815,6 +4955,7 @@ function doDeleteCol() {
     formats.deleteCol(start, sn)
     comments.deleteCol(start, sn)
     validation.deleteCol(start, sn)
+    protection.deleteCol(start, sn)
     condFormat.deleteCol(start, sn)
     sortFilter.deleteCol(start, sn)
     grid.shiftColWidths(start + 1, -1)

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -3150,7 +3150,7 @@ function _setupGridInstance() {
     isCellEditable: (r, c) => !protection.isProtected(r, c, sheet.getCurrentSheet()),
     onBlockedEdit: () => _flashProtected(sheet.getCurrentSheet()),
     onFill(src, total, { withModifier = false } = {}) {
-      if (_rectBlocked(total)) return
+      if (_fillDestBlocked(src, total)) return   // only the destination cells, not the source
       const series = _previewSeriesKind(src)
       // Cmd/Ctrl held inverts the auto-detected mode — Google Sheets behaviour.
       const mode = withModifier ? (series ? 'copy' : 'series') : 'auto'
@@ -3460,6 +3460,19 @@ function _cellsBlocked(ids, sn = sheet.getCurrentSheet()) {
 function _cellSilentlyProtected(id, sn = sheet.getCurrentSheet()) {
   const p = parseCellId(id)
   return !!(p && protection.isProtected(p.row, p.col, sn))
+}
+// A fill writes only the destination — the strip(s) of `total` outside `src`.
+// Checking the whole extent would wrongly block a fill that merely *starts*
+// from a protected cell (reading a protected source is fine; only writes are
+// guarded). A fill extends in one direction, so at most one strip is non-empty.
+function _fillDestBlocked(src, total, sn = sheet.getCurrentSheet()) {
+  const strips = []
+  if (total.r1 > src.r1) strips.push({ r0: src.r1 + 1, r1: total.r1, c0: total.c0, c1: total.c1 })
+  if (total.r0 < src.r0) strips.push({ r0: total.r0, r1: src.r0 - 1, c0: total.c0, c1: total.c1 })
+  if (total.c1 > src.c1) strips.push({ r0: total.r0, r1: total.r1, c0: src.c1 + 1, c1: total.c1 })
+  if (total.c0 < src.c0) strips.push({ r0: total.r0, r1: total.r1, c0: total.c0, c1: src.c0 - 1 })
+  if (!strips.some(s => protection.isAnyProtected(s, sn))) return false
+  _flashProtected(sn); return true
 }
 
 // ── Protection UI actions ─────────────────────────────────────────────────────

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -72,6 +72,7 @@
             @click="onRetrySave"
           />
         </template>
+        <Badge v-if="protectionNotice" theme="gray" variant="subtle" size="sm" :label="protectionNotice" :tooltip="protectionNotice" />
         <!-- View-only indicator — shown up front so a viewer knows they can't
              edit before they try. Neutral gray (not an error) because read
              access is expected, not a failure. Uses the Frappe UI Badge so it
@@ -3431,12 +3432,16 @@ function _pasteAffectedRects(destSel) {
 // — and flashes a transient notice — when the target is protected, so callers
 // bail with `if (…) return`. Programmatic paths (undo/restore/collab) never call
 // these, so they can still rewrite protected cells.
+//
+// A dedicated notice ref — NOT saveError — so a "protected" message renders as a
+// neutral badge and doesn't arm the save-error watchdog / retry affordance.
+const protectionNotice = ref('')
 function _flashProtected(sn) {
   const msg = protection.isSheetLocked(sn)
     ? 'This sheet is protected'
     : 'This range is protected and can’t be edited'
-  saveError.value = msg
-  setTimeout(() => { if (saveError.value === msg) saveError.value = '' }, 3500)
+  protectionNotice.value = msg
+  setTimeout(() => { if (protectionNotice.value === msg) protectionNotice.value = '' }, 3500)
 }
 function _rectBlocked(rect, sn = sheet.getCurrentSheet()) {
   if (!rect || !protection.isAnyProtected(rect, sn)) return false

--- a/frontend/src/apps/sheets/components/SheetEditor/usePersistence.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/usePersistence.js
@@ -6,7 +6,7 @@ import { packSheet, packSheetChunked, unpackSheet, boundsOf } from '../../utils/
 // `merge` and the view-state getters/setters are optional — they were missing
 // from earlier versions and their absence caused merged cells / column widths /
 // freeze panes / hidden cols/rows to silently disappear after every save.
-export function usePersistence({ sheet, formats, merge, comments, validation, condFormat, sortFilter, pivot, charts, namedRanges, getViewState, applyViewState, currentTitle, emit }) {
+export function usePersistence({ sheet, formats, merge, comments, validation, protection, condFormat, sortFilter, pivot, charts, namedRanges, getViewState, applyViewState, currentTitle, emit }) {
   const isSaving  = ref(false)
   const saveError = ref('')
   // Write permission for the currently-loaded sheet, from get_sheet's `can_write`.
@@ -33,6 +33,7 @@ export function usePersistence({ sheet, formats, merge, comments, validation, co
       if (saved.merge      && merge?.restore)      merge.restore(saved.merge)
       if (saved.comments   && comments?.restore)   comments.restore(saved.comments)
       if (saved.validation && validation?.restore) validation.restore(saved.validation)
+      if (saved.protection && protection?.restore) protection.restore(saved.protection)
       if (saved.condFormat && condFormat?.restore) condFormat.restore(saved.condFormat)
       if (saved.sortFilter && sortFilter?.restore) sortFilter.restore(saved.sortFilter)
       if (saved.view       && applyViewState)      applyViewState(saved.view)
@@ -117,6 +118,7 @@ export function usePersistence({ sheet, formats, merge, comments, validation, co
         merge:      merge?.snapshot?.()      ?? null,
         comments:   comments?.snapshot?.()   ?? null,
         validation: validation?.snapshot?.() ?? null,
+        protection: protection?.snapshot?.() ?? null,
         condFormat: condFormat?.snapshot?.() ?? null,
         sortFilter: sortFilter?.snapshot?.() ?? null,
         pivot:      pivot?.snapshot?.()      ?? null,

--- a/frontend/src/apps/sheets/components/SheetEditor/useSplitText.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useSplitText.js
@@ -37,6 +37,7 @@ export function useSplitText({
   syncFlags,
   captureRange,
   diffRefs,
+  blockProtected,   // (rect, sheet) => boolean — true (and flashes) if protected
 }) {
   // Reactive state consumed by SplitTextPopover.vue
   const splitText = reactive({
@@ -202,6 +203,14 @@ export function useSplitText({
       }
     }
     const newRect = { r0: selectionRange.r0, r1: selectionRange.r1, c0: selectionRange.c0, c1: maximumColumn }
+
+    // Refuse if the split (source + rightward overflow) touches a protected
+    // cell. Revert any prior preview and close so nothing is left half-written.
+    if (blockProtected?.(newRect, subSheetName)) {
+      _revertSplitPreview()
+      _closeSplit()
+      return
+    }
 
     // Capture original snapshot once; grow it if a later preview overflows
     // further right than the first one.

--- a/frontend/src/apps/sheets/components/SheetEditor/useVersionHistory.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useVersionHistory.js
@@ -20,13 +20,14 @@ function flattenDiff(diff, parse) {
 }
 
 function captureLiveState({ getCurrentTitle, getSheet, getFormats, getMerge,
-                            getComments, getValidation, getCondFormat,
+                            getComments, getValidation, getProtection, getCondFormat,
                             getSortFilter, getGrid }) {
   const sheet      = getSheet()
   const formats    = getFormats()
   const merge      = getMerge()
   const comments   = getComments()
   const validation = getValidation()
+  const protection = getProtection?.()
   const condFormat = getCondFormat()
   const sortFilter = getSortFilter()
   const grid       = getGrid()
@@ -38,6 +39,7 @@ function captureLiveState({ getCurrentTitle, getSheet, getFormats, getMerge,
       merge:      merge?.snapshot(),
       comments:   comments?.snapshot(),
       validation: validation?.snapshot(),
+      protection: protection?.snapshot(),
       condFormat: condFormat?.snapshot(),
       sortFilter: sortFilter?.snapshot(),
       view:       grid?.viewSnapshot?.() ?? null,
@@ -46,7 +48,7 @@ function captureLiveState({ getCurrentTitle, getSheet, getFormats, getMerge,
 }
 
 function applyEngineState(saved, title,
-    { getSheet, getFormats, getMerge, getComments, getValidation,
+    { getSheet, getFormats, getMerge, getComments, getValidation, getProtection,
       getCondFormat, getSortFilter, getGrid, getCurrentTitle,
       repopulateGrid, syncViewMirrors, syncNames, currentTitle }) {
   const sheet      = getSheet()
@@ -54,6 +56,7 @@ function applyEngineState(saved, title,
   const merge      = getMerge()
   const comments   = getComments()
   const validation = getValidation()
+  const protection = getProtection?.()
   const condFormat = getCondFormat()
   const sortFilter = getSortFilter()
   const grid       = getGrid()
@@ -62,6 +65,7 @@ function applyEngineState(saved, title,
   if (saved.merge      && merge?.restore)      merge.restore(saved.merge)
   if (saved.comments   && comments?.restore)   comments.restore(saved.comments)
   if (saved.validation && validation?.restore) validation.restore(saved.validation)
+  if (saved.protection && protection?.restore) protection.restore(saved.protection)
   if (saved.condFormat && condFormat?.restore) condFormat.restore(saved.condFormat)
   if (saved.sortFilter && sortFilter?.restore) sortFilter.restore(saved.sortFilter)
   if (saved.view       && grid?.viewRestore)   grid.viewRestore(saved.view)
@@ -80,6 +84,7 @@ export function useVersionHistory({
   getMerge,
   getComments,
   getValidation,
+  getProtection,
   getCondFormat,
   getSortFilter,
   getGrid,
@@ -107,7 +112,7 @@ export function useVersionHistory({
 
   // Shared engine context forwarded to pure helpers.
   const ctx = {
-    getSheet, getFormats, getMerge, getComments, getValidation,
+    getSheet, getFormats, getMerge, getComments, getValidation, getProtection,
     getCondFormat, getSortFilter, getGrid,
     getCurrentTitle: () => currentTitle.value,
     currentTitle, repopulateGrid, syncViewMirrors, syncNames,

--- a/frontend/src/apps/sheets/engine/clipboard.js
+++ b/frontend/src/apps/sheets/engine/clipboard.js
@@ -3,7 +3,7 @@
 import { colLabel, parseCellId } from '../utils/cells.js'
 import { adjustFormula } from './formula-adjust.js'
 
-export function createClipboard({ sheet, formats, condFormat = null, validation = null, getPivotAt = null, createPivotFromPaste = null }) {
+export function createClipboard({ sheet, formats, condFormat = null, validation = null, getPivotAt = null, createPivotFromPaste = null, protection = null }) {
 	let _data    = null   // { 'dr,dc': rawValue }
 	let _fmts    = null   // { 'dr,dc': formatObj }
 	let _vals    = null   // { 'dr,dc': validationRule | null }
@@ -128,6 +128,13 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 		}
 
 		const targets = _resolveTargets(anch, destSel)
+
+		// Block the whole paste if any destination cell is protected — `targets`
+		// is the exact output extent, so a multi-cell block anchored at an
+		// unprotected cell is still caught when it spills into a locked one.
+		if (protection && targets.some(({ r, c }) => protection.isProtected(r, c, sh))) {
+			return { blocked: true }
+		}
 
 		// Two-pass: build the cell-value map first, hand it to batchSetCells in
 		// one shot so the engine does ONE dep-rebuild + ONE bulk notify instead
@@ -345,6 +352,11 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 				}))
 		}
 		const sn = sheet.getCurrentSheet()
+		if (protection && Object.keys(writes).some(id => {
+			const p = parseCellId(id); return p && protection.isProtected(p.row, p.col, sn)
+		})) {
+			return { blocked: true }
+		}
 		if (sheet.batchSetCells) sheet.batchSetCells(writes, sn, { replace: false })
 		else                     for (const [id, v] of Object.entries(writes)) sheet.setCell(id, v, sn)
 		historyPush?.()   // post-mutate snapshot

--- a/frontend/src/apps/sheets/engine/protection.js
+++ b/frontend/src/apps/sheets/engine/protection.js
@@ -1,0 +1,151 @@
+// Protection engine — per-sheet protected ranges plus a whole-sheet lock.
+//
+// A protected cell rejects value edits, clears, pastes and fills (enforcement
+// lives in the SheetEditor; this engine is the pure source of truth for "is
+// this cell/rect protected?"). Ranges are { id, r0, c0, r1, c1, description }
+// with 0-indexed, inclusive bounds. A whole-sheet lock protects every cell.
+//
+// Structural ops shift ranges with full interval semantics: inserting a line
+// inside a range grows it, deleting a line inside a range shrinks it, and a
+// range that collapses to nothing is dropped. This matches Google Sheets and,
+// unlike the cond-format engine, handles ranges that *span* the pivot line.
+
+import { deepClone } from '../utils/deep-clone.js'
+
+let _nextId = 1
+
+export function createProtectionEngine() {
+  // { sheetName: { locked: bool, ranges: [{ id, r0, c0, r1, c1, description }] } }
+  const store = {}
+
+  function ensure(sheet) {
+    if (!store[sheet]) store[sheet] = { locked: false, ranges: [] }
+    return store[sheet]
+  }
+
+  // ── Queries ────────────────────────────────────────────────────────────────
+
+  function getRanges(sheet = 'Sheet1') {
+    return store[sheet]?.ranges || []
+  }
+
+  function isSheetLocked(sheet = 'Sheet1') {
+    return !!store[sheet]?.locked
+  }
+
+  // Is a single cell protected? Sheet lock short-circuits every range check.
+  function isProtected(row, col, sheet = 'Sheet1') {
+    const s = store[sheet]
+    if (!s) return false
+    if (s.locked) return true
+    return s.ranges.some(r => row >= r.r0 && row <= r.r1 && col >= r.c0 && col <= r.c1)
+  }
+
+  // Does `rect` overlap any protected cell? Used to block a whole block-write
+  // (paste / fill / delete-block) when any target cell is protected.
+  function isAnyProtected(rect, sheet = 'Sheet1') {
+    const s = store[sheet]
+    if (!s) return false
+    if (s.locked) return true
+    const { r0, c0, r1, c1 } = _norm(rect)
+    return s.ranges.some(r => r0 <= r.r1 && r1 >= r.r0 && c0 <= r.c1 && c1 >= r.c0)
+  }
+
+  // ── Mutations ────────────────────────────────────────────────────────────────
+
+  function setSheetLocked(locked, sheet = 'Sheet1') {
+    ensure(sheet).locked = !!locked
+  }
+
+  function addRange(rect, description = '', sheet = 'Sheet1') {
+    const s = ensure(sheet)
+    const id = _nextId++
+    s.ranges.push({ id, ..._norm(rect), description })
+    return id
+  }
+
+  function removeRange(id, sheet = 'Sheet1') {
+    const s = store[sheet]
+    if (s) s.ranges = s.ranges.filter(r => r.id !== id)
+  }
+
+  // ── Structural shifts ────────────────────────────────────────────────────────
+  //
+  // Shift both endpoints of every range on the given axis. Insert (delta +1)
+  // pushes any endpoint at/after `at` down, so a range straddling `at` grows.
+  // Delete (delta -1) pulls the start down only past `at` and the end down at
+  // or past `at`, so a straddling range shrinks and a range that was only the
+  // deleted line collapses (start > end) and is removed.
+
+  function _shift(sheet, axis, at, delta) {
+    const s = store[sheet]
+    if (!s) return
+    const lo = axis === 'row' ? 'r0' : 'c0'
+    const hi = axis === 'row' ? 'r1' : 'c1'
+    const kept = []
+    for (const r of s.ranges) {
+      let a = r[lo], b = r[hi]
+      if (delta > 0) {
+        if (a >= at) a += 1
+        if (b >= at) b += 1
+      } else {
+        if (a > at) a -= 1
+        if (b >= at) b -= 1
+        if (a > b) continue
+      }
+      kept.push({ ...r, [lo]: a, [hi]: b })
+    }
+    s.ranges = kept
+  }
+
+  function insertRow(at, sheet = 'Sheet1') { _shift(sheet, 'row', at, +1) }
+  function deleteRow(at, sheet = 'Sheet1') { _shift(sheet, 'row', at, -1) }
+  function insertCol(at, sheet = 'Sheet1') { _shift(sheet, 'col', at, +1) }
+  function deleteCol(at, sheet = 'Sheet1') { _shift(sheet, 'col', at, -1) }
+
+  // ── Sheet lifecycle ──────────────────────────────────────────────────────────
+
+  function renameSheet(oldName, newName) {
+    if (!store[oldName] || store[newName] || oldName === newName) return
+    store[newName] = store[oldName]
+    delete store[oldName]
+  }
+
+  function duplicateSheet(srcName, newName) {
+    if (store[newName]) return
+    store[newName] = deepClone(store[srcName] || { locked: false, ranges: [] })
+  }
+
+  function deleteSheet(name) { delete store[name] }
+
+  function snapshot() { return deepClone(store) }
+
+  function restore(snap) {
+    for (const k of Object.keys(store)) delete store[k]
+    // Advance the id counter past every restored range. Without this a reload
+    // (module re-init → _nextId=1) followed by a new addRange would mint an id
+    // that collides with a restored one, so removeRange would drop both.
+    let maxId = 0
+    for (const [k, v] of Object.entries(snap)) {
+      store[k] = v
+      for (const r of (v?.ranges || [])) if (r.id > maxId) maxId = r.id
+    }
+    if (maxId >= _nextId) _nextId = maxId + 1
+  }
+
+  return {
+    getRanges, isSheetLocked, isProtected, isAnyProtected,
+    setSheetLocked, addRange, removeRange,
+    insertRow, deleteRow, insertCol, deleteCol,
+    renameSheet, duplicateSheet, deleteSheet,
+    snapshot, restore,
+  }
+}
+
+// Normalise a rect so r0<=r1 and c0<=c1 regardless of selection direction.
+function _norm({ r0, c0, r1, c1 }) {
+  return {
+    r0: Math.min(r0, r1), r1: Math.max(r0, r1),
+    c0: Math.min(c0, c1), c1: Math.max(c0, c1),
+  }
+}

--- a/frontend/src/apps/sheets/engine/protection.test.ts
+++ b/frontend/src/apps/sheets/engine/protection.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createProtectionEngine } from './protection.js'
+
+// Ranges are 0-indexed, inclusive: { r0, c0, r1, c1 }.
+const rect = (r0, c0, r1, c1) => ({ r0, c0, r1, c1 })
+
+describe('ProtectionEngine — ranges & queries', () => {
+  let p
+  beforeEach(() => { p = createProtectionEngine() })
+
+  it('no protection by default', () => {
+    expect(p.isProtected(0, 0)).toBe(false)
+    expect(p.isSheetLocked()).toBe(false)
+    expect(p.getRanges()).toEqual([])
+  })
+
+  it('protects cells inside an added range, inclusive of edges', () => {
+    p.addRange(rect(1, 1, 3, 3))
+    expect(p.isProtected(1, 1)).toBe(true)   // top-left corner
+    expect(p.isProtected(3, 3)).toBe(true)   // bottom-right corner
+    expect(p.isProtected(2, 2)).toBe(true)   // interior
+    expect(p.isProtected(0, 1)).toBe(false)  // one row above
+    expect(p.isProtected(1, 0)).toBe(false)  // one col left
+    expect(p.isProtected(4, 3)).toBe(false)  // one row below
+    expect(p.isProtected(3, 4)).toBe(false)  // one col right
+  })
+
+  it('normalises a reversed rect', () => {
+    p.addRange(rect(3, 3, 1, 1))
+    expect(p.isProtected(2, 2)).toBe(true)
+    expect(p.getRanges()[0]).toMatchObject({ r0: 1, c0: 1, r1: 3, c1: 3 })
+  })
+
+  it('whole-sheet lock protects every cell', () => {
+    p.setSheetLocked(true)
+    expect(p.isProtected(0, 0)).toBe(true)
+    expect(p.isProtected(999, 999)).toBe(true)
+    p.setSheetLocked(false)
+    expect(p.isProtected(0, 0)).toBe(false)
+  })
+
+  it('removeRange lifts protection', () => {
+    const id = p.addRange(rect(0, 0, 0, 0))
+    expect(p.isProtected(0, 0)).toBe(true)
+    p.removeRange(id)
+    expect(p.isProtected(0, 0)).toBe(false)
+  })
+
+  it('isAnyProtected detects rect overlap', () => {
+    p.addRange(rect(5, 5, 7, 7))
+    expect(p.isAnyProtected(rect(0, 0, 5, 5))).toBe(true)   // touches corner
+    expect(p.isAnyProtected(rect(6, 0, 6, 10))).toBe(true)  // crosses through
+    expect(p.isAnyProtected(rect(0, 0, 4, 4))).toBe(false)  // no overlap
+    expect(p.isAnyProtected(rect(8, 8, 9, 9))).toBe(false)  // past it
+  })
+
+  it('isAnyProtected returns true for a locked sheet regardless of rect', () => {
+    p.setSheetLocked(true)
+    expect(p.isAnyProtected(rect(100, 100, 100, 100))).toBe(true)
+  })
+
+  it('keeps protection per sheet', () => {
+    p.addRange(rect(0, 0, 0, 0), '', 'Sheet1')
+    expect(p.isProtected(0, 0, 'Sheet1')).toBe(true)
+    expect(p.isProtected(0, 0, 'Sheet2')).toBe(false)
+  })
+})
+
+describe('ProtectionEngine — row/col shifts', () => {
+  let p
+  beforeEach(() => { p = createProtectionEngine() })
+
+  it('insertRow at/above a range shifts it down', () => {
+    p.addRange(rect(6, 0, 8, 0))
+    p.insertRow(5)
+    expect(p.getRanges()[0]).toMatchObject({ r0: 7, r1: 9 })
+  })
+
+  it('insertRow inside a range grows it (straddle)', () => {
+    p.addRange(rect(3, 0, 8, 0))
+    p.insertRow(5)
+    expect(p.getRanges()[0]).toMatchObject({ r0: 3, r1: 9 })
+  })
+
+  it('insertRow below a range leaves it', () => {
+    p.addRange(rect(3, 0, 4, 0))
+    p.insertRow(5)
+    expect(p.getRanges()[0]).toMatchObject({ r0: 3, r1: 4 })
+  })
+
+  it('deleteRow below a range shifts it up', () => {
+    p.addRange(rect(6, 0, 8, 0))
+    p.deleteRow(5)
+    expect(p.getRanges()[0]).toMatchObject({ r0: 5, r1: 7 })
+  })
+
+  it('deleteRow inside a range shrinks it', () => {
+    p.addRange(rect(3, 0, 8, 0))
+    p.deleteRow(5)
+    expect(p.getRanges()[0]).toMatchObject({ r0: 3, r1: 7 })
+  })
+
+  it('deleteRow above a range leaves it', () => {
+    p.addRange(rect(6, 0, 8, 0))
+    p.deleteRow(9)
+    expect(p.getRanges()[0]).toMatchObject({ r0: 6, r1: 8 })
+  })
+
+  it('deleting the only row of a single-row range drops it', () => {
+    p.addRange(rect(5, 0, 5, 3))
+    p.deleteRow(5)
+    expect(p.getRanges()).toEqual([])
+  })
+
+  it('col shifts mirror row shifts', () => {
+    p.addRange(rect(0, 3, 0, 8))
+    p.insertCol(5)
+    expect(p.getRanges()[0]).toMatchObject({ c0: 3, c1: 9 })  // grew
+    p.deleteCol(5)
+    expect(p.getRanges()[0]).toMatchObject({ c0: 3, c1: 8 })  // shrank back
+  })
+
+  it('deleting the only col of a single-col range drops it', () => {
+    p.addRange(rect(0, 5, 3, 5))
+    p.deleteCol(5)
+    expect(p.getRanges()).toEqual([])
+  })
+})
+
+describe('ProtectionEngine — sheet lifecycle & snapshot', () => {
+  let p
+  beforeEach(() => { p = createProtectionEngine() })
+
+  it('rename moves protection to the new name', () => {
+    p.addRange(rect(0, 0, 1, 1), '', 'A')
+    p.setSheetLocked(true, 'A')
+    p.renameSheet('A', 'B')
+    expect(p.isProtected(0, 0, 'B')).toBe(true)
+    expect(p.isSheetLocked('B')).toBe(true)
+    expect(p.getRanges('A')).toEqual([])
+  })
+
+  it('duplicate deep-copies protection', () => {
+    p.addRange(rect(0, 0, 1, 1), '', 'A')
+    p.duplicateSheet('A', 'A copy')
+    p.insertRow(0, 'A')                       // mutate source only
+    expect(p.getRanges('A copy')[0]).toMatchObject({ r0: 0, r1: 1 })
+  })
+
+  it('deleteSheet clears protection', () => {
+    p.addRange(rect(0, 0, 1, 1), '', 'A')
+    p.deleteSheet('A')
+    expect(p.getRanges('A')).toEqual([])
+  })
+
+  it('restore advances the id counter so new ranges never collide', () => {
+    // Simulate a reload: a fresh engine restores a saved range (id already 1),
+    // then the user adds a new range. The new id must differ from the restored
+    // one, or removeRange would drop both.
+    const src = createProtectionEngine()
+    const savedId = src.addRange(rect(0, 0, 0, 0))
+    const snap = src.snapshot()
+
+    const fresh = createProtectionEngine()
+    fresh.restore(snap)
+    const newId = fresh.addRange(rect(5, 5, 5, 5))
+    expect(newId).not.toBe(savedId)
+    fresh.removeRange(newId)
+    expect(fresh.isProtected(0, 0)).toBe(true)   // restored range survives
+    expect(fresh.isProtected(5, 5)).toBe(false)
+  })
+
+  it('snapshot/restore round-trips and is independent of later edits', () => {
+    p.addRange(rect(2, 2, 4, 4))
+    p.setSheetLocked(true, 'Locked')
+    const snap = p.snapshot()
+    p.addRange(rect(0, 0, 0, 0))              // mutate after snapshot
+    p.restore(snap)
+    expect(p.isProtected(3, 3)).toBe(true)
+    expect(p.isProtected(0, 0)).toBe(false)   // the post-snapshot add is gone
+    expect(p.isSheetLocked('Locked')).toBe(true)
+  })
+})

--- a/frontend/src/apps/sheets/engine/protection.test.ts
+++ b/frontend/src/apps/sheets/engine/protection.test.ts
@@ -153,21 +153,21 @@ describe('ProtectionEngine — sheet lifecycle & snapshot', () => {
     expect(p.getRanges('A')).toEqual([])
   })
 
-  it('restore advances the id counter so new ranges never collide', () => {
-    // Simulate a reload: a fresh engine restores a saved range (id already 1),
-    // then the user adds a new range. The new id must differ from the restored
-    // one, or removeRange would drop both.
-    const src = createProtectionEngine()
-    const savedId = src.addRange(rect(0, 0, 0, 0))
-    const snap = src.snapshot()
-
-    const fresh = createProtectionEngine()
-    fresh.restore(snap)
-    const newId = fresh.addRange(rect(5, 5, 5, 5))
-    expect(newId).not.toBe(savedId)
-    fresh.removeRange(newId)
-    expect(fresh.isProtected(0, 0)).toBe(true)   // restored range survives
-    expect(fresh.isProtected(5, 5)).toBe(false)
+  it('restore advances the id counter past restored ids (no post-reload collision)', () => {
+    // A saved doc's range ids can exceed a freshly re-initialised module
+    // counter (the reload case). Restore a snapshot whose id is far above any
+    // the counter has reached, then add a range: its id must clear the restored
+    // one, or removeRange would later drop both. HIGH is picked well above the
+    // handful of addRange calls in this file so the assertion is real, not
+    // trivially satisfied by an already-advanced counter.
+    const HIGH = 1_000_000
+    const p2 = createProtectionEngine()
+    p2.restore({ Sheet1: { locked: false, ranges: [{ id: HIGH, r0: 0, c0: 0, r1: 0, c1: 0 }] } })
+    const newId = p2.addRange(rect(5, 5, 5, 5))
+    expect(newId).toBeGreaterThan(HIGH)          // fails if restore didn't advance the counter
+    p2.removeRange(newId)
+    expect(p2.isProtected(0, 0)).toBe(true)      // restored range survives its own removal
+    expect(p2.isProtected(5, 5)).toBe(false)
   })
 
   it('snapshot/restore round-trips and is independent of later edits', () => {


### PR DESCRIPTION
Adds cell/range **protection** — protected ranges and a whole-sheet lock — enforced across every write path.

### Engine
`protection.js`: per-sheet protected ranges `{r0,c0,r1,c1}` + a whole-sheet lock. Range shifts use full interval semantics on row/col insert/delete (a range straddling the pivot grows on insert / shrinks on delete; a collapsed range is dropped), and follow sheet rename/duplicate/delete. `restore()` advances the id counter so a reload never mints a colliding range id. **22 unit tests** (`protection.test.ts`).

### Enforcement (no write path left unguarded)
Typing, delete/clear (single + range), **paste** (internal, external text, and HTML-table — blocked inside the shared `_pasteGrid` where the exact spill extent is known — plus the pivot-paste path), cut, fill handle, Ctrl+D/Ctrl+R, formula bar, dropdown pick, hyperlink, AI actions, **Find & Replace**, **Sort**, and **Split-text-to-columns**. Composes with the existing read-only `canEdit()`; a canvas edit-start guard stops the in-cell editor from even opening on a protected cell.

### State integrity
Protection rides in undo snapshots, server persistence, and version-history preview — it survives reload, undo/redo, and version stepping.

### UI
Right-click → *Protect range* / *Remove protection*; sheet-tab menu → *Protect sheet* / *Unprotect sheet*; a transient notice when a blocked edit is attempted.

### Reviewed
A 3-agent adversarial self-review ran on the standalone diff; all findings fixed (id-collision on restore, a "remove protection" no-op under sheet-lock, a stale cut buffer after a blocked paste, version-history preview, and the Find&Replace / Sort / Split-text bypasses).

### Known follow-up
Live collaboration: a protection change isn't broadcast to a peer already in the doc until they reload (it persists, so it syncs on reload).

Ported from standalone frappe/sheets (`feat/parity-phase1`).