### PR TITLE
fix(mail): replace whole roles field instead of patching union discriminator

### DIFF
--- a/suite/mail/stalwart/account.py
+++ b/suite/mail/stalwart/account.py
@@ -371,9 +371,11 @@ class AccountService(StalwartCLI):
 
 		merged = list(dict.fromkeys([*existing, *role_ids]))
 
-		commands = ["update", "Account", account, "--field", f"roles/@type={RoleType.CUSTOM.value}"]
-		for role_id in merged:
-			commands.extend(["--field", f"roles/roleIds/{role_id}=true"])
+		# `roles` is a tagged union; its `@type` discriminator can't be patched via a sub-path
+		# (the server rejects `roles/@type` as an invalid JSON Pointer path). Replace the whole
+		# field with a full JSON object instead.
+		roles = UserRoles(type=RoleType.CUSTOM, roles=CustomRoles(role_ids=merged))
+		commands = ["update", "Account", account, "--field", f"roles={json.dumps(roles.to_dict())}"]
 
 		response = self.run(commands)
 
@@ -396,15 +398,14 @@ class AccountService(StalwartCLI):
 		remove = set(role_ids)
 		remaining = [role_id for role_id in existing if role_id not in remove]
 
+		# Replace the whole `roles` field with a full JSON object rather than patching sub-paths of
+		# the tagged union (the server rejects patching the `@type` discriminator via a pointer path).
 		if remaining:
-			commands = ["update", "Account", account, "--field", f"roles/@type={RoleType.CUSTOM.value}"]
-			for role_id in remaining:
-				commands.extend(["--field", f"roles/roleIds/{role_id}=true"])
-			# explicitly clear the removed roles so the deep-merged update actually drops them
-			for role_id in remove:
-				commands.extend(["--field", f"roles/roleIds/{role_id}=false"])
+			roles = UserRoles(type=RoleType.CUSTOM, roles=CustomRoles(role_ids=remaining))
 		else:
-			commands = ["update", "Account", account, "--field", f"roles/@type={RoleType.USER.value}"]
+			roles = UserRoles(type=RoleType.USER)
+
+		commands = ["update", "Account", account, "--field", f"roles={json.dumps(roles.to_dict())}"]
 
 		response = self.run(commands)
 


### PR DESCRIPTION
## Problem

Assigning or removing a Stalwart account role failed with:

```
error: invalidPatch
  Invalid JSON Pointer path
  Properties: roles/@type
error: update failed
```

`AccountService.add_roles` / `remove_roles` updated roles by patching sub-paths of the `roles` field:

```python
["update", "Account", account, "--field", "roles/@type=Custom", "--field", "roles/roleIds/<id>=true"]
```

The Stalwart CLI turns each `--field key=value` into a JMAP `set` patch where the slash-separated key is a **JSON Pointer path**. But `roles` is a **tagged union** — `@type` is its variant discriminator, not a regular property — and the server rejects patching the discriminator via a pointer path (`/roles/@type`), failing the whole patch.

## Fix

Replace the entire `roles` field with a full JSON object in a single `--field` (the CLI parses a value starting with `{` as JSON), so the union variant is set atomically — the same way `create` builds it. The object is built from the existing `UserRoles` model via `to_dict()`.

This also lets `remove_roles` drop its `roleIds/<id>=false` clearing hack, since replacing the whole object naturally omits removed roles and reverts to `{"@type": "User"}` when none remain.

## Testing

- [x] `python -m ast` syntax check
- [x] Not yet exercised against a live Stalwart server — needs verification by assigning/removing a role on a mail user (path: `suite/mail/events.py → add_account_role → add_roles`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)