### PR TITLE
feat(mail): enable screening by default for new accounts

### DIFF
--- a/suite/mail/doctype/jmap_account/jmap_account.json
+++ b/suite/mail/doctype/jmap_account/jmap_account.json
@@ -91,7 +91,7 @@
    "options": "Junk Sender's Mail\nAsk to Block Sender"
   },
   {
-   "default": "0",
+   "default": "1",
    "description": "When enabled, mail from senders not on the Accepted list is filed into the Screening folder instead of the inbox (Hey-style screening). Only senders you accept reach the inbox.",
    "fieldname": "enable_screening",
    "fieldtype": "Check",


### PR DESCRIPTION
## Summary

Screening previously had to be turned on manually per account. This makes it **enabled by default for newly created accounts** by flipping the `enable_screening` default on the **JMAP Account** DocType from `0` to `1`.

New accounts are created via `frappe.new_doc("JMAP Account")` in `_ensure_jmap_account_docs`, so each new account now starts with screening on. Immediately after creation, `sync_jmap_accounts` calls `build_automation_sieve(account, activate=True)`; since `is_screening_enabled()` reads the DB value (now `1`), the screening gate is emitted into the sieve automatically — so screening is genuinely active, not just a ticked checkbox.

## Scope

- New accounts only. Existing accounts keep their current setting and can still toggle screening under **Settings → Account → Enable Screening**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)