### PR TITLE
feat(sheets): lossless XLSX import/export

### DIFF
--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -1955,8 +1955,13 @@ const { exportCSV, exportXLSX, exportPDF, importCSV, importXLSX } = useExportImp
   getSheet:        () => sheet,
   getCurrentTitle: () => currentTitle.value,
   getGrid:         () => grid,
+  getFormats:      () => formats,
+  getMerge:        () => merge,
   queueOp:         _queueOp,
   repopulateGrid:  _repopulateGrid,
+  // Defined later by useSheetTabs — lazy-wrapped so they resolve at call time.
+  syncNames:       () => syncNames(),
+  switchSheet:     (n) => switchSheet(n),
   syncFlags,
   isDirty,
 })

--- a/frontend/src/apps/sheets/components/SheetEditor/useExportImport.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useExportImport.js
@@ -261,11 +261,17 @@ export function useExportImport({
         await _ingestWorksheet(ws, sheet, formats, merge, name)
       }
     } finally {
+      // Always resync the tab bar so engine + UI agree even after a partial
+      // import; only dirty the doc when a sheet was actually added (an empty
+      // workbook, or a throw before the first add, must not mark it dirty).
       syncNames?.()
-      if (firstAdded) switchSheet?.(firstAdded)
-      else            repopulateGrid()
-      syncFlags()
-      isDirty.value = true
+      if (firstAdded) {
+        switchSheet?.(firstAdded)
+        syncFlags()
+        isDirty.value = true
+      } else {
+        repopulateGrid()
+      }
     }
   }
 

--- a/frontend/src/apps/sheets/components/SheetEditor/useExportImport.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useExportImport.js
@@ -1,4 +1,5 @@
 import { colLabel, parseCellId } from '../../utils/cells.js'
+import { toXlsxCell, fromXlsxCell, mergesToXlsx, mergesFromXlsx } from '../../engine/xlsx-io.js'
 
 // ── private helpers ────────────────────────────────────────────────────────────
 
@@ -74,8 +75,12 @@ export function useExportImport({
   getSheet,
   getCurrentTitle,
   getGrid,
+  getFormats,
+  getMerge,
   queueOp,
   repopulateGrid,
+  syncNames,
+  switchSheet,
   syncFlags,
   isDirty,
 }) {
@@ -103,15 +108,56 @@ export function useExportImport({
     a.click()
   }
 
+  // Build a SheetJS worksheet from one sub-sheet, preserving value types,
+  // formulas (with their computed value), number formats, and merges — the
+  // lossy display-string path only round-tripped visible text.
+  function _buildWorksheet(sheet, formats, merge, sn) {
+    const data = sheet.getRawData(sn)
+    const ws = {}
+    let maxR = 0, maxC = 0
+    for (const [id, raw] of Object.entries(data)) {
+      const p = parseCellId(id)
+      if (!p) continue
+      const isFormula = typeof raw === 'string' && raw.startsWith('=')
+      const computed  = isFormula ? sheet.getCellValue(id, sn) : null
+      const fmt  = formats?.get(id, sn)?.numberFormat || ''
+      const cell = toXlsxCell(raw, computed, fmt)
+      if (!cell) continue
+      ws[id] = cell
+      if (p.row > maxR) maxR = p.row
+      if (p.col > maxC) maxC = p.col
+    }
+    ws['!ref'] = `A1:${colLabel(maxC)}${maxR + 1}`
+    const merges = merge ? mergesToXlsx(merge.snapshot()?.[sn]?.masterMap) : []
+    if (merges.length) ws['!merges'] = merges
+    return ws
+  }
+
   async function exportXLSX() {
-    const sheet = getSheet()
+    const sheet   = getSheet()
+    const formats = getFormats?.()
+    const merge   = getMerge?.()
     const { utils, writeFile } = await import('xlsx')
     const wb = utils.book_new()
+    const used = new Set()
     for (const sn of sheet.getSheetNames()) {
-      const ws = utils.aoa_to_sheet(_sheetToAoa(sn, sheet))
-      utils.book_append_sheet(wb, ws, sn)
+      const ws = _buildWorksheet(sheet, formats, merge, sn)
+      utils.book_append_sheet(wb, ws, _excelSheetName(sn, used))
     }
     writeFile(wb, `${getCurrentTitle() || 'sheet'}.xlsx`)
+  }
+
+  // Excel caps sheet names at 31 chars, bans []:*?/\ and duplicates. Coerce to
+  // a safe, unique name so book_append_sheet never throws mid-export.
+  function _excelSheetName(name, used) {
+    let base = String(name || 'Sheet').replace(/[[\]:*?/\\]/g, ' ').slice(0, 31).trim() || 'Sheet'
+    let out = base, n = 1
+    while (used.has(out.toLowerCase())) {
+      const suffix = ` (${++n})`
+      out = base.slice(0, 31 - suffix.length) + suffix
+    }
+    used.add(out.toLowerCase())
+    return out
   }
 
   function exportPDF() {
@@ -180,13 +226,74 @@ export function useExportImport({
   async function importXLSX(e) {
     const file = e.target.files?.[0]
     if (!file) return
-    const { read, utils } = await import('xlsx')
-    const buf  = await file.arrayBuffer()
-    const wb   = read(buf, { type: 'array' })
-    const ws   = wb.Sheets[wb.SheetNames[0]]
-    const rows = utils.sheet_to_json(ws, { header: 1, defval: '' })
-    await _ingestRows(rows, file.name)
-    e.target.value = ''
+    try {
+      const { read } = await import('xlsx')
+      const buf = await file.arrayBuffer()
+      // cellFormula keeps `=…`, cellDates yields Date objects, cellNF keeps the
+      // number-format code — all three are what makes the import lossless.
+      const wb = read(buf, { type: 'array', cellFormula: true, cellDates: true, cellNF: true })
+      await _ingestWorkbook(wb)
+    } finally {
+      e.target.value = ''   // always reset so re-picking the same file re-fires
+    }
+  }
+
+  // Import every worksheet as a NEW sub-sheet — non-destructive, so the user's
+  // current sheets are untouched. Each cell carries its value/formula, number
+  // format, and the sheet's merges.
+  async function _ingestWorkbook(wb) {
+    const sheet    = getSheet()
+    const formats  = getFormats?.()
+    const merge    = getMerge?.()
+    const existing = new Set(sheet.getSheetNames().map(n => n.toLowerCase()))
+    let firstAdded = null
+    // finally: even if a worksheet throws mid-import, resync the tab bar so the
+    // engine and UI never disagree about which sheets exist, and surface what
+    // was already ingested.
+    try {
+      for (const wsName of wb.SheetNames) {
+        const ws = wb.Sheets[wsName]
+        if (!ws) continue
+        const name = _uniqueSheetName(wsName, existing)
+        existing.add(name.toLowerCase())
+        sheet.addSheet(name)
+        if (!firstAdded) firstAdded = name
+        await _ingestWorksheet(ws, sheet, formats, merge, name)
+      }
+    } finally {
+      syncNames?.()
+      if (firstAdded) switchSheet?.(firstAdded)
+      else            repopulateGrid()
+      syncFlags()
+      isDirty.value = true
+    }
+  }
+
+  async function _ingestWorksheet(ws, sheet, formats, merge, name) {
+    const map = {}
+    const fmts = []
+    let n = 0
+    for (const [id, cell] of Object.entries(ws)) {
+      if (id[0] === '!') continue                  // !ref, !merges, !cols meta keys
+      if (!parseCellId(id)) continue
+      const { value, fmt } = fromXlsxCell(cell)
+      if (value !== '' && value != null) map[id] = value
+      if (fmt) fmts.push([id, fmt])
+      if (++n % CHUNK_ROWS === 0) await _yield()
+    }
+    sheet.batchSetCells(map, name, { replace: false })
+    if (formats) for (const [id, fmt] of fmts) formats.set(id, { numberFormat: fmt }, name)
+    if (merge && Array.isArray(ws['!merges'])) {
+      for (const { r0, c0, r1, c1 } of mergesFromXlsx(ws['!merges'])) merge.merge(r0, c0, r1, c1, name)
+    }
+  }
+
+  // Ensure an imported worksheet name doesn't collide with an existing sheet.
+  function _uniqueSheetName(name, existing) {
+    const base = String(name || 'Sheet').trim() || 'Sheet'
+    let out = base, n = 1
+    while (existing.has(out.toLowerCase())) out = `${base} (${++n})`
+    return out
   }
 
   function importCSV(e) {

--- a/frontend/src/apps/sheets/engine/xlsx-io.js
+++ b/frontend/src/apps/sheets/engine/xlsx-io.js
@@ -31,6 +31,18 @@ for (const [code, c] of Object.entries(CURRENCIES)) if (!(c.symbol in SYMBOL_TO_
 function _dec(n) { return n > 0 ? '.' + '0'.repeat(n) : '' }
 // Count of fraction placeholders after the decimal point in a z-code.
 function _decCount(z) { const m = z.match(/\.(0+)/); return m ? m[1].length : 0 }
+// True only for a '%' that actually scales — i.e. outside quotes and not
+// backslash-escaped. A literal `"%"` or `\%` is just a character.
+function _hasActivePercent(z) {
+  let inQuote = false
+  for (let i = 0; i < z.length; i++) {
+    const c = z[i]
+    if (c === '\\') { i++; continue }
+    if (c === '"') { inQuote = !inQuote; continue }
+    if (c === '%' && !inQuote) return true
+  }
+  return false
+}
 function _invert(o) { return Object.fromEntries(Object.entries(o).map(([k, v]) => [v, k])) }
 
 // Our format string → Excel z-code (or null for General / no format).
@@ -68,7 +80,7 @@ export function zToNumFmt(z) {
   if (sp > 0 && Z_DATE[t.slice(0, sp)] && Z_TIME[t.slice(sp + 1)]) {
     return `datetime:${Z_DATE[t.slice(0, sp)]}_${Z_TIME[t.slice(sp + 1)]}`
   }
-  if (t.includes('%')) return _withDec('percentage', _decCount(t))
+  if (_hasActivePercent(t)) return _withDec('percentage', _decCount(t))
   const cur = t.match(/^"([^"]+)"#,##0/)   // capture the WHOLE symbol (C$, A$, …)
   if (cur && SYMBOL_TO_CODE[cur[1]]) return `currency:${SYMBOL_TO_CODE[cur[1]]}:${_decCount(t)}`
   if (/^#,##0(\.0+)?$/.test(t)) return _withDec('number', _decCount(t))

--- a/frontend/src/apps/sheets/engine/xlsx-io.js
+++ b/frontend/src/apps/sheets/engine/xlsx-io.js
@@ -1,0 +1,182 @@
+// XLSX interchange adapter — maps between the engine's per-cell state and
+// SheetJS cell objects, with lossless round-tripping of the formats this app
+// produces. Pure functions only (no SheetJS import, no DOM) so the mapping is
+// unit-testable in isolation; the composable that owns file I/O calls in.
+//
+// A SheetJS cell is { t, v, f?, z? }:
+//   t  cell type — 'n' number, 's' string, 'b' boolean, 'd' date
+//   v  the value (typed per t)
+//   f  a formula WITHOUT the leading '=' (Excel convention)
+//   z  a number-format code (Excel's grammar, e.g. '#,##0.00', '0.00%')
+
+import { parseNumberFmt, CURRENCIES } from '../utils/format-number.js'
+
+// ── Number-format mapping ────────────────────────────────────────────────────
+//
+// Our format strings (`type[:variant][:decimals]`, plus `custom:<pattern>`)
+// carry the same intent as Excel `z` codes. These two functions are inverses
+// for every format the app can produce; an Excel code we don't recognise is
+// preserved verbatim as `custom:<code>` so it round-trips untouched.
+
+const DATE_Z = { dmy: 'dd/mm/yyyy', mdy: 'mm/dd/yyyy', ymd: 'yyyy-mm-dd', long: 'd mmm yyyy', full: 'ddd, d mmm yyyy' }
+const TIME_Z = { hm: 'hh:mm', hms: 'hh:mm:ss', hm12: 'h:mm AM/PM', hms12: 'h:mm:ss AM/PM' }
+const Z_DATE = _invert(DATE_Z)
+const Z_TIME = _invert(TIME_Z)
+// First currency wins a shared symbol (¥ is both JPY and CNY) so reverse
+// mapping is deterministic — a ¥ cell round-trips as JPY.
+const SYMBOL_TO_CODE = {}
+for (const [code, c] of Object.entries(CURRENCIES)) if (!(c.symbol in SYMBOL_TO_CODE)) SYMBOL_TO_CODE[c.symbol] = code
+
+// Fraction-digit suffix: 2 → ".00", 0 → "".
+function _dec(n) { return n > 0 ? '.' + '0'.repeat(n) : '' }
+// Count of fraction placeholders after the decimal point in a z-code.
+function _decCount(z) { const m = z.match(/\.(0+)/); return m ? m[1].length : 0 }
+function _invert(o) { return Object.fromEntries(Object.entries(o).map(([k, v]) => [v, k])) }
+
+// Our format string → Excel z-code (or null for General / no format).
+export function numFmtToZ(fmt) {
+  if (!fmt) return null
+  const s = String(fmt)
+  if (s.startsWith('custom:')) return s.slice(7) || null
+  const { type, variant, decimals } = parseNumberFmt(s)
+  if (type === 'text')       return '@'
+  if (type === 'number')     return '#,##0' + _dec(decimals ?? 0)
+  if (type === 'percentage') return '0' + _dec(decimals ?? 2) + '%'
+  if (type === 'currency') {
+    const cfg = CURRENCIES[variant] || CURRENCIES.USD
+    return `"${cfg.symbol}"#,##0` + _dec(decimals ?? cfg.defaultDecimals)
+  }
+  if (type === 'date') return DATE_Z[variant] || DATE_Z.ymd
+  if (type === 'time') return TIME_Z[variant] || TIME_Z.hm
+  if (type === 'datetime') {
+    const [dv, tv] = String(variant || '').split('_')
+    return `${DATE_Z[dv] || DATE_Z.ymd} ${TIME_Z[tv] || TIME_Z.hm}`
+  }
+  return null
+}
+
+// Excel z-code → our format string (best-effort; unknown codes preserved as
+// `custom:` so a re-export reproduces them exactly).
+export function zToNumFmt(z) {
+  if (!z || z === 'General') return ''
+  const t = z.trim()
+  if (t === '@') return 'text'
+  if (Z_DATE[t]) return 'date:' + Z_DATE[t]
+  if (Z_TIME[t]) return 'time:' + Z_TIME[t]
+  // datetime = a known date code + space + known time code
+  const sp = t.indexOf(' ')
+  if (sp > 0 && Z_DATE[t.slice(0, sp)] && Z_TIME[t.slice(sp + 1)]) {
+    return `datetime:${Z_DATE[t.slice(0, sp)]}_${Z_TIME[t.slice(sp + 1)]}`
+  }
+  if (t.includes('%')) return _withDec('percentage', _decCount(t))
+  const cur = t.match(/^"([^"]+)"#,##0/)   // capture the WHOLE symbol (C$, A$, …)
+  if (cur && SYMBOL_TO_CODE[cur[1]]) return `currency:${SYMBOL_TO_CODE[cur[1]]}:${_decCount(t)}`
+  if (/^#,##0(\.0+)?$/.test(t)) return _withDec('number', _decCount(t))
+  return 'custom:' + z            // preserve verbatim
+}
+
+// Reattach a decimals suffix only when non-zero, so `number`/`percentage`
+// (whose defaults differ) stay minimal and round-trip.
+function _withDec(type, dec) {
+  if (type === 'percentage') return dec === 2 ? 'percentage' : `percentage:${dec}`
+  return dec === 0 ? 'number' : `number:${dec}`
+}
+
+// ── Cell mapping ─────────────────────────────────────────────────────────────
+
+const DATE_TYPES = new Set(['date', 'time', 'datetime'])
+
+// Is `v` a value that should export as an Excel number (not text)? Rejects ''
+// and whitespace, and leading-zero / plus-sign strings that must stay text.
+function _isNumeric(v) {
+  if (typeof v === 'number') return isFinite(v)
+  if (typeof v !== 'string' || v.trim() === '') return false
+  return isFinite(Number(v)) && !/^[+0]\d/.test(v.trim())
+}
+
+// Parse loosely into a Date for date-typed export. Anchored to UTC so the
+// serial SheetJS writes and reads back (with cellDates:true) doesn't drift by a
+// timezone offset — a local-midnight Date would lose up to a full day on
+// round-trip in any non-UTC zone.
+function _toDate(v) {
+  if (v instanceof Date) return isNaN(v) ? null : v
+  const s = String(v).trim()
+  if (!s) return null
+  const m = s.match(/^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2})(?::(\d{2}))?)?/)
+  if (m) return new Date(Date.UTC(+m[1], +m[2] - 1, +m[3], +(m[4] || 0), +(m[5] || 0), +(m[6] || 0)))
+  const d = new Date(s)
+  return isNaN(d) ? null : d
+}
+
+function _iso(d) {
+  // Read UTC components to match _toDate's UTC anchoring — stable across zones.
+  const p = (n) => String(n).padStart(2, '0')
+  const base = `${d.getUTCFullYear()}-${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())}`
+  if (d.getUTCHours() || d.getUTCMinutes() || d.getUTCSeconds()) {
+    return `${base} ${p(d.getUTCHours())}:${p(d.getUTCMinutes())}:${p(d.getUTCSeconds())}`
+  }
+  return base
+}
+
+/**
+ * Build a SheetJS cell from the engine's raw value, its computed display value
+ * (for formula cells), and the cell's format string. Returns null for an empty
+ * non-formula cell (nothing to write).
+ */
+export function toXlsxCell(raw, computed, fmt) {
+  const isFormula = typeof raw === 'string' && raw.startsWith('=')
+  const src = isFormula ? computed : raw
+  if (!isFormula && (src === '' || src == null)) return null
+
+  const z = numFmtToZ(fmt)
+  const cell = {}
+  if (isFormula) cell.f = raw.slice(1)
+
+  const { type } = parseNumberFmt(fmt || '')
+  const asDate = DATE_TYPES.has(type) ? _toDate(src) : null
+  if (asDate) {
+    cell.t = 'd'; cell.v = asDate
+  } else if (src === true || src === false || src === 'TRUE' || src === 'FALSE') {
+    cell.t = 'b'; cell.v = src === true || src === 'TRUE'
+  } else if (_isNumeric(src) && type !== 'text') {
+    cell.t = 'n'; cell.v = Number(src)
+  } else {
+    cell.t = 's'; cell.v = src == null ? '' : String(src)
+  }
+  // A value that fell back to text under a numeric format (e.g. "007", kept as
+  // text to preserve the leading zero) is genuinely text — don't stamp it with
+  // a numeric format code Excel ignores and our renderer would mis-apply (→ 7).
+  const numericFmt = type === 'number' || type === 'currency' || type === 'percentage'
+  if (z && !(cell.t === 's' && numericFmt)) cell.z = z
+  return cell
+}
+
+/**
+ * Convert a parsed SheetJS cell back into the engine's { value, fmt } shape.
+ * `value` is the raw string the engine stores (formulas keep their leading '=').
+ */
+export function fromXlsxCell(cell) {
+  if (!cell) return { value: '', fmt: '' }
+  const fmt = cell.z ? zToNumFmt(cell.z) : ''
+  let value
+  if (cell.f != null && cell.f !== '') value = '=' + cell.f
+  else if (cell.t === 'd' && cell.v instanceof Date) value = _iso(cell.v)
+  else if (cell.t === 'b') value = cell.v ? 'TRUE' : 'FALSE'
+  else if (cell.v == null) value = ''
+  else value = String(cell.v)
+  return { value, fmt }
+}
+
+// ── Merge mapping ────────────────────────────────────────────────────────────
+
+// engine masterMap ({ id: { r, c, rowSpan, colSpan } }) → SheetJS !merges.
+export function mergesToXlsx(masterMap) {
+  return Object.values(masterMap || {}).map(({ r, c, rowSpan, colSpan }) => ({
+    s: { r, c }, e: { r: r + rowSpan - 1, c: c + colSpan - 1 },
+  }))
+}
+
+// SheetJS !merges → [{ r0, c0, r1, c1 }] for the merge engine's merge().
+export function mergesFromXlsx(merges) {
+  return (merges || []).map(({ s, e }) => ({ r0: s.r, c0: s.c, r1: e.r, c1: e.c }))
+}

--- a/frontend/src/apps/sheets/engine/xlsx-io.test.ts
+++ b/frontend/src/apps/sheets/engine/xlsx-io.test.ts
@@ -31,6 +31,13 @@ describe('zToNumFmt — Excel z → our format', () => {
   it('unknown code preserved as custom', () => {
     expect(zToNumFmt('#,##0.000;[Red]-#,##0.000')).toBe('custom:#,##0.000;[Red]-#,##0.000')
   })
+  it('a real percent still maps to percentage', () => {
+    expect(zToNumFmt('0.00%')).toBe('percentage')
+  })
+  it('a quoted or escaped percent is a literal, not a percentage', () => {
+    expect(zToNumFmt('0 "50%"')).toBe('custom:0 "50%"')
+    expect(zToNumFmt('#,##0\\%')).toBe('custom:#,##0\\%')
+  })
 })
 
 describe('format round-trips (our → z → our) are lossless', () => {

--- a/frontend/src/apps/sheets/engine/xlsx-io.test.ts
+++ b/frontend/src/apps/sheets/engine/xlsx-io.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import {
+  numFmtToZ, zToNumFmt, toXlsxCell, fromXlsxCell, mergesToXlsx, mergesFromXlsx,
+} from './xlsx-io.js'
+
+describe('numFmtToZ — our format → Excel z', () => {
+  it('General / empty → null', () => expect(numFmtToZ('')).toBe(null))
+  it('text → @', () => expect(numFmtToZ('text')).toBe('@'))
+  it('number, no decimals', () => expect(numFmtToZ('number')).toBe('#,##0'))
+  it('number with decimals', () => expect(numFmtToZ('number:2')).toBe('#,##0.00'))
+  it('percentage default 2', () => expect(numFmtToZ('percentage')).toBe('0.00%'))
+  it('percentage 0', () => expect(numFmtToZ('percentage:0')).toBe('0%'))
+  it('currency USD 2', () => expect(numFmtToZ('currency:USD:2')).toBe('"$"#,##0.00'))
+  it('currency JPY 0', () => expect(numFmtToZ('currency:JPY:0')).toBe('"¥"#,##0'))
+  it('date variants', () => {
+    expect(numFmtToZ('date:dmy')).toBe('dd/mm/yyyy')
+    expect(numFmtToZ('date:ymd')).toBe('yyyy-mm-dd')
+  })
+  it('time + datetime', () => {
+    expect(numFmtToZ('time:hm12')).toBe('h:mm AM/PM')
+    expect(numFmtToZ('datetime:ymd_hms')).toBe('yyyy-mm-dd hh:mm:ss')
+  })
+  it('custom passes the raw pattern through', () => {
+    expect(numFmtToZ('custom:#,##0.00 "kg"')).toBe('#,##0.00 "kg"')
+  })
+})
+
+describe('zToNumFmt — Excel z → our format', () => {
+  it('General → empty', () => expect(zToNumFmt('General')).toBe(''))
+  it('@ → text', () => expect(zToNumFmt('@')).toBe('text'))
+  it('unknown code preserved as custom', () => {
+    expect(zToNumFmt('#,##0.000;[Red]-#,##0.000')).toBe('custom:#,##0.000;[Red]-#,##0.000')
+  })
+})
+
+describe('format round-trips (our → z → our) are lossless', () => {
+  const cases = ['text', 'number', 'number:3', 'percentage', 'percentage:0',
+    'currency:USD:2', 'currency:INR:0', 'currency:CAD:2', 'currency:AUD:0', 'currency:JPY:0',
+    'date:dmy', 'date:ymd', 'time:hms', 'datetime:ymd_hms', 'custom:#,##0.00 "kg"']
+  for (const f of cases) {
+    it(f, () => expect(zToNumFmt(numFmtToZ(f))).toBe(f))
+  }
+  it("General round-trips as ''", () => expect(numFmtToZ(zToNumFmt('General'))).toBe(null))
+  it('multi-char currency symbols (C$/A$) map back to their code', () => {
+    expect(zToNumFmt('"C$"#,##0.00')).toBe('currency:CAD:2')
+    expect(zToNumFmt('"A$"#,##0')).toBe('currency:AUD:0')
+  })
+  it('¥ resolves deterministically to JPY (shared with CNY)', () => {
+    expect(zToNumFmt('"¥"#,##0')).toBe('currency:JPY:0')
+  })
+})
+
+describe('toXlsxCell — engine → SheetJS', () => {
+  it('numeric string exports as a number', () => {
+    expect(toXlsxCell('42', null, '')).toEqual({ t: 'n', v: 42 })
+  })
+  it('text stays text', () => {
+    expect(toXlsxCell('hello', null, '')).toEqual({ t: 's', v: 'hello' })
+  })
+  it('leading-zero string stays text (not 007 → 7)', () => {
+    expect(toXlsxCell('007', null, '')).toEqual({ t: 's', v: '007' })
+  })
+  it('leading-zero under a numeric format stays text WITHOUT the numeric z', () => {
+    // else the imported cell (text "007" + "#,##0") would render as 7.
+    expect(toXlsxCell('007', null, 'number')).toEqual({ t: 's', v: '007' })
+  })
+  it('a text-formatted number stays text', () => {
+    expect(toXlsxCell('42', null, 'text')).toEqual({ t: 's', v: '42', z: '@' })
+  })
+  it('boolean', () => {
+    expect(toXlsxCell('TRUE', null, '')).toEqual({ t: 'b', v: true })
+  })
+  it('formula keeps f + its computed value', () => {
+    expect(toXlsxCell('=SUM(A1:A2)', 7, '')).toEqual({ t: 'n', v: 7, f: 'SUM(A1:A2)' })
+  })
+  it('carries the number format as z', () => {
+    expect(toXlsxCell('1234.5', null, 'currency:USD:2')).toEqual({ t: 'n', v: 1234.5, z: '"$"#,##0.00' })
+  })
+  it('date-formatted value becomes a date cell', () => {
+    const c = toXlsxCell('2026-03-15', null, 'date:ymd')
+    expect(c.t).toBe('d')
+    expect(c.v instanceof Date).toBe(true)
+    expect(c.z).toBe('yyyy-mm-dd')
+  })
+  it('empty non-formula cell → null (skip)', () => {
+    expect(toXlsxCell('', null, '')).toBe(null)
+    expect(toXlsxCell(null, null, '')).toBe(null)
+  })
+})
+
+describe('fromXlsxCell — SheetJS → engine', () => {
+  it('number', () => expect(fromXlsxCell({ t: 'n', v: 42 })).toEqual({ value: '42', fmt: '' }))
+  it('string', () => expect(fromXlsxCell({ t: 's', v: 'hi' })).toEqual({ value: 'hi', fmt: '' }))
+  it('boolean', () => expect(fromXlsxCell({ t: 'b', v: false })).toEqual({ value: 'FALSE', fmt: '' }))
+  it('formula regains its =', () => {
+    expect(fromXlsxCell({ t: 'n', v: 7, f: 'SUM(A1:A2)' })).toEqual({ value: '=SUM(A1:A2)', fmt: '' })
+  })
+  it('z-code maps back to our format', () => {
+    expect(fromXlsxCell({ t: 'n', v: 1234.5, z: '"$"#,##0.00' })).toEqual({ value: '1234.5', fmt: 'currency:USD:2' })
+  })
+  it('date cell → iso string + date format (UTC-anchored)', () => {
+    const d = new Date(Date.UTC(2026, 2, 15))
+    expect(fromXlsxCell({ t: 'd', v: d, z: 'yyyy-mm-dd' })).toEqual({ value: '2026-03-15', fmt: 'date:ymd' })
+  })
+  it('null cell is inert', () => expect(fromXlsxCell(null)).toEqual({ value: '', fmt: '' }))
+})
+
+describe('date round-trip is timezone-independent', () => {
+  // The whole point of UTC anchoring: export→import yields the same date string
+  // regardless of the runner's local zone.
+  it('bare date', () => {
+    expect(fromXlsxCell(toXlsxCell('2026-03-15', null, 'date:ymd')))
+      .toEqual({ value: '2026-03-15', fmt: 'date:ymd' })
+  })
+  it('datetime', () => {
+    expect(fromXlsxCell(toXlsxCell('2026-03-15 14:30:00', null, 'datetime:ymd_hms')))
+      .toEqual({ value: '2026-03-15 14:30:00', fmt: 'datetime:ymd_hms' })
+  })
+})
+
+describe('merge mapping', () => {
+  it('engine masterMap → SheetJS !merges', () => {
+    expect(mergesToXlsx({ A1: { r: 0, c: 0, rowSpan: 2, colSpan: 3 } }))
+      .toEqual([{ s: { r: 0, c: 0 }, e: { r: 1, c: 2 } }])
+  })
+  it('!merges → engine rects', () => {
+    expect(mergesFromXlsx([{ s: { r: 0, c: 0 }, e: { r: 1, c: 2 } }]))
+      .toEqual([{ r0: 0, c0: 0, r1: 1, c1: 2 }])
+  })
+  it('round-trips', () => {
+    const master = { B2: { r: 1, c: 1, rowSpan: 3, colSpan: 2 } }
+    const [rect] = mergesFromXlsx(mergesToXlsx(master))
+    expect(rect).toEqual({ r0: 1, c0: 1, r1: 3, c1: 2 })
+  })
+})


### PR DESCRIPTION
The existing XLSX bridge round-tripped only computed **display strings** — formulas, number types, number formats, merges, and every sheet past the first were silently lost. This replaces it with a real workbook adapter.

### `engine/xlsx-io.js` — pure adapter (54 unit tests)
Maps engine cells ↔ SheetJS cells `{t,v,f,z}` with **lossless** round-tripping of the formats this app produces: number / percent / currency / date / time / custom ↔ Excel `z`-codes, plus value-type inference, formulas, and merges. No SheetJS or DOM import, so it's unit-tested in isolation.

### Export
Per sub-sheet: real typed cells (numbers as numbers, not text), formulas with their computed value, `z`-codes, and merges. Excel-safe unique sheet names (31-char cap, banned chars, de-dup).

### Import
Reads **all** worksheets (`cellFormula` / `cellDates` / `cellNF`) and adds each as a **new** sub-sheet (non-destructive) with values, formulas, number formats, and merges. Refreshes the tab bar and switches to the first imported sheet.

### Hardened via adversarial self-review (before this PR)
- **Dates UTC-anchored** — a local-midnight Date drifts up to a full day through SheetJS's UTC serials; round-trip is now timezone-independent (tested under +5:30 and −8).
- **Multi-char currency symbols** (`C$`/`A$`) and the **shared ¥** (JPY/CNY) resolve deterministically instead of degrading to `custom:`.
- Leading-zero text (`007`) under a numeric format keeps **no** misleading numeric `z` (would otherwise render as `7`).
- A **mid-import failure** still resyncs the tab bar + input via `try/finally`, so the engine and UI never disagree.

Ported from standalone frappe/sheets (`feat/parity-xlsx`).