### PR TITLE
fix(writer): flexible comment layout with chips and mobile support

### DIFF
--- a/frontend/src/apps/drive/ui/drive/components/MoveDialog.vue
+++ b/frontend/src/apps/drive/ui/drive/components/MoveDialog.vue
@@ -1,78 +1,65 @@
 <template>
   <Dialog v-model:open="open" size="lg" @close="dialogType = ''">
     <template #body-main>
-      <div class="p-4 sm:px-6">
-        <div class="flex w-full justify-between gap-x-15 mb-4">
-          <div class="text-2xl-semibold flex text-nowrap overflow-hidden">
-            <template v-if="props.entities.length > 1">
-              Moving {{ props.entities.length }} items
-            </template>
-            <template v-else>
-              Moving "
-              <div class="truncate max-w-[80%]">
-                {{ props.entities[0].file_name }}
-              </div>
-              "
-            </template>
-          </div>
+      <div class="px-4 pt-5 pb-6 sm:px-6">
+        <div class="text-2xl-semibold flex text-nowrap overflow-hidden pr-8 mb-4">
+          <template v-if="props.entities.length > 1">
+            Moving {{ props.entities.length }} items
+          </template>
+          <template v-else>
+            Moving "
+            <div class="truncate max-w-[80%]">
+              {{ props.entities[0].file_name }}
+            </div>
+            "
+          </template>
         </div>
         <Tabs v-model="tabIndex" as="div" :tabs="tabs">
           <template #tab-panel>
-            <div class="py-1 h-64 overflow-auto flex flex-col">
-              <TeamSelector v-if="tabIndex === 1" v-model="chosenTeam" class="py-2 px-1" />
-              <Tree v-for="k in tree.children" :key="k.value" node-key="value" :node="k">
-                <template #node="{ node, hasChildren, isCollapsed, toggleCollapsed }">
-                  <div class="flex items-center cursor-pointer select-none gap-1 h-7 shrink-0"
-                    @click="openEntity(node)">
-                    <div ref="iconRef" @click="
-                      (e) => {
-                        if (isCollapsed)
-                          node.children.forEach((k) =>
-                            fetchFolderContents(
-                              k,
-                              { entity_name: k.value },
-                              true,
-                            ),
-                          )
-                        toggleCollapsed(e)
-                      }
-                    ">
-                      <LucideChevronDown v-if="hasChildren && !isCollapsed" class="size-3.5" />
-                      <LucideChevronRight v-else-if="hasChildren" class="size-3.5" />
-                      <div v-else class="ps-3.5" />
+            <div class="px-1 py-1 h-64 overflow-auto flex flex-col">
+              <TeamSelector v-if="tabIndex === 1" v-model="chosenTeam" class="mb-2" />
+              <Tree v-if="tree.children.length" :nodes="tree.children" node-key="value" guides="none">
+                <template #item="{ node, expanded, hasChildren, toggle }">
+                  <div class="group grow min-w-0 flex items-center gap-2"
+                    :class="entities[0].folder === node.value ? 'cursor-not-allowed' : 'cursor-pointer'"
+                    @click.stop="openEntity(node)">
+                    <button v-if="hasChildren" class="flex shrink-0 text-ink-gray-5 hover:text-ink-gray-8"
+                      @click.stop="
+                        () => {
+                          if (!expanded)
+                            node.children.forEach((k) =>
+                              fetchFolderContents(k, { entity_name: k.value }, true),
+                            )
+                          toggle()
+                        }
+                      ">
+                      <LucideChevronDown v-if="expanded" class="size-3.5" />
+                      <LucideChevronRight v-else class="size-3.5" />
+                    </button>
+                    <span v-else class="w-3.5 shrink-0" />
+                    <LucideFolder class="size-4 shrink-0 text-ink-gray-5" />
+                    <div v-if="node.value === null" class="grow">
+                      <Input v-model="node.label" autofocus type="text" input-class="!h-6" @click.stop
+                        @keydown.enter="openEntity(node)" />
                     </div>
-                    <div class="flex-grow rounded-sm text-base truncate h-full flex items-center pl-1" :class="[
-                      selected === node.value
-                        ? 'bg-surface-gray-3'
-                        : 'hover:bg-surface-gray-2',
-                      entities[0].folder === node.value
-                        ? 'cursor-not-allowed hover:bg-surface-base'
-                        : 'group',
-                    ]">
-                      <LucideFolderClosed v-if="isCollapsed" class="mr-1 size-4" />
-                      <LucideFolder v-else class="mr-1 size-4" />
-                      <div v-if="node.value === null" class="overflow-visible">
-                        <Input v-model="node.label" autofocus type="text" input-class=" !h-6" @click.stop
-                          @keydown.enter="openEntity(node)" />
-                      </div>
-                      <span v-else>{{ node.label }}
-                        <span v-if="entities[0].folder === node.value" class="text-ink-gray-5">(current)</span></span>
-                      <Button class="shrink hidden group-hover:block ml-auto" :class="{
-                        '!bg-surface-gray-3': selected === node.value,
-                      }" @click.stop="
-                          (e) => {
-                            let obj = {
-                              parent: node.value,
-                              value: null,
-                              label: 'New folder',
-                            }
-                            node.children.push(obj)
-                            if (isCollapsed) toggleCollapsed(e)
-                          }
-                        ">
-                        <LucideFolderPlus class="size-4" />
-                      </Button>
-                    </div>
+                    <span v-else class="grow truncate text-base"
+                      :class="selected === node.value ? 'font-medium text-ink-gray-9' : 'text-ink-gray-8'">{{
+                        node.label }}<span v-if="entities[0].folder === node.value" class="text-ink-gray-5 font-normal">
+                        (current)</span></span>
+                    <Button v-if="entities[0].folder !== node.value"
+                      class="shrink-0 opacity-0 group-hover:opacity-100" variant="ghost" @click.stop="
+                        () => {
+                          node.children.push({
+                            parent: node.value,
+                            value: null,
+                            label: 'New folder',
+                          })
+                          if (!expanded) toggle()
+                        }
+                      ">
+                      <template #icon><LucideFolderPlus class="size-4" /></template>
+                    </Button>
+                    <LucideCheck v-if="selected === node.value" class="shrink-0 size-4 text-ink-gray-6" />
                   </div>
                 </template>
               </Tree>
@@ -92,9 +79,9 @@
             </div>
           </template>
         </Tabs>
-        <div class="flex items-center justify-between pt-4">
+        <div class="flex items-center justify-between border-t border-outline-gray-1 pt-4">
           <div class="flex items-center my-auto justify-start">
-            <p class="text-sm pr-0.5 shrink-0">Moving to:</p>
+            <p class="text-sm text-ink-gray-5 pr-1 shrink-0">Moving to:</p>
             <Dropdown v-if="dropDownBreadcrumbs.length" class="h-7" :options="dropDownBreadcrumbs">
               <Button variant="ghost">
                 <LucideEllipsis class="size-3.5" />
@@ -149,6 +136,7 @@ import { move, getTeams } from '../js/resources'
 import { useRoute } from 'vue-router'
 
 import LucideBuilding2 from '~icons/lucide/building-2'
+import LucideCheck from '~icons/lucide/check'
 import LucideChevronDown from '~icons/lucide/chevron-down'
 import LucideChevronRight from '~icons/lucide/chevron-right'
 import LucideFolder from '~icons/lucide/folder'
@@ -191,20 +179,21 @@ const breadcrumbs = ref([
   { name: '', file_name: tabIndex.value === 0 ? 'Home' : 'Team' },
 ])
 
-const tabs = [
-  {
-    label: 'Home',
-    icon: h(LucideHome, { class: 'size-4' }),
+const tabs = computed(() => {
+  const items = [{ label: 'Home', icon: h(LucideHome, { class: 'size-4' }) }]
+  if (Object.keys(getTeams.data || {}).length)
+    items.push({ label: 'Teams', icon: h(LucideBuilding2, { class: 'size-4' }) })
+  return items
+})
+
+// Keep the active tab valid when the Teams tab is hidden (no teams).
+watch(
+  tabs,
+  (t) => {
+    if (tabIndex.value > t.length - 1) tabIndex.value = 0
   },
-  {
-    label: 'Teams',
-    icon: h(LucideBuilding2, { class: 'size-4' }),
-  },
-  // {
-  //   label: "Favourites",
-  //   icon: h(Star, { class: "size-4" }),
-  // },
-]
+  { immediate: true },
+)
 
 const folderContents = createResource({
   url: 'suite.drive.api.list.files',
@@ -225,8 +214,8 @@ const fetchFolderContents = (tree, params = {}, nested = false) => {
           label: item.file_name,
           value: item.name,
           children: [],
+          expanded: false,
         })
-        node.isCollapsed = true
         tree.children.push(node)
         if (!nested)
           fetchFolderContents(

--- a/frontend/src/apps/writer/components/CoreEditor.vue
+++ b/frontend/src/apps/writer/components/CoreEditor.vue
@@ -5,32 +5,31 @@
       :editor="editor" :items="menuButtons" />
     <div class="relative flex flex-1 overflow-hidden">
       <ToC v-if="editor" :editor :anchors />
-      <div id="editor-scroll-container" class="flex w-full min-w-0 overflow-y-auto overflow-x-hidden relative">
-        <div class="self-start flex flex-col flex-grow min-h-full md:border-l md:pl-72 border-outline-gray-2"
-          @click="onBackgroundClick" @keydown="onEditorKeydown">
-          <FTextEditor ref="textEditor" :upload-function="uploadFunction"
-            :autofocus="true" v-model="localContent" placeholder="Start thinking..." :extensions="editorExtensions"
-            :editable @change="(val) => emit('editor-change', val)">
-            <template #default="{ editor }">
-              <EditorBubbleMenu :editor :items="bubbleMenuButtons" :options="bubbleMenuOpts" />
-              <EditorTableMenu :editor />
-              <EditorDropZone :editor :disabled="!editable" class="grow flex flex-col">
-                <EditorContent :editor
-                  class="grow w-full md:mx-auto bg-surface-base overflow-x-auto pt-10 pb-24 px-5 prose prose-sm prose-v3 prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:relative prose-th:relative prose-th:bg-surface-gray-2"
-                  :class="[
-                    settings?.wide
-                      ? 'md:max-w-[100ch]'
-                      : 'md:max-w-[48rem]',
-                    isPainting && 'cursor-crosshair',
-                  ]" :style="editorStyle" />
-              </EditorDropZone>
-            </template>
-          </FTextEditor>
+      <div id="editor-scroll-container"
+        class="relative flex-1 min-w-0 overflow-y-auto overflow-x-hidden md:border-l border-outline-gray-2">
+        <div class="min-h-full flex flex-col md:grid md:grid-rows-[1fr]" :style="gridStyle" @click="onBackgroundClick"
+          @keydown="onEditorKeydown">
+          <div class="hidden md:block" />
+          <div class="flex flex-col grow min-w-0">
+            <FTextEditor ref="textEditor" :upload-function="uploadFunction"
+              :autofocus="true" v-model="localContent" placeholder="Start thinking..." :extensions="editorExtensions"
+              :editable @change="(val) => emit('editor-change', val)">
+              <template #default="{ editor }">
+                <EditorBubbleMenu :editor :items="bubbleMenuButtons" :options="bubbleMenuOpts" />
+                <EditorTableMenu :editor />
+                <EditorDropZone :editor :disabled="!editable" class="grow flex flex-col">
+                  <EditorContent :editor
+                    class="grow w-full bg-surface-base overflow-x-auto pt-10 pb-24 px-5 prose prose-sm prose-v3 prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:relative prose-th:relative prose-th:bg-surface-gray-2"
+                    :class="isPainting && 'cursor-crosshair'" :style="editorStyle" />
+                </EditorDropZone>
+              </template>
+            </FTextEditor>
+          </div>
+          <div class="relative hidden md:block min-w-0">
+            <FloatingComments v-if="commentsPainted" v-model:active-comment="activeComment" :y-comments="comments"
+              :file :show-comments :show-resolved :show-unanchored :editor @save="saveComments" />
+          </div>
         </div>
-
-        <FloatingComments v-if="commentsPainted" v-model:active-comment="activeComment" :y-comments="comments" :file
-          :show-comments :show-resolved :show-unanchored :editor @save="saveComments" />
-        <div v-else class="hidden md:block w-72 shrink-0" />
       </div>
       <div v-if="commentsPainted && comments._map.size" class="hidden md:block absolute top-4 right-4">
         <Dropdown :options="commentFilterOptions" placement="right">
@@ -269,6 +268,12 @@ const bubbleMenuButtons = [
 const bubbleMenuOpts = computed(() =>
   bubbleMenuOptions({ editor, comments: props.comments }),
 )
+
+const gridStyle = computed(() => ({
+  gridTemplateColumns: `minmax(0, 1fr) minmax(0, ${
+    props.settings?.wide ? '100ch' : '48rem'
+  }) minmax(0, 1fr)`,
+}))
 
 const editorStyle = computed(() => ({
   fontFamily:

--- a/frontend/src/apps/writer/components/FloatingComments.vue
+++ b/frontend/src/apps/writer/components/FloatingComments.vue
@@ -14,8 +14,8 @@
               ? 'opacity-100 pointer-events-auto'
               : 'opacity-0 pointer-events-none',
           ]" :style="cardStyle(comment)" @click="activeComment = comment.id">
-          <Button class="md:!hidden absolute top-1.5 right-1.5" variant="ghost"
-            :icon="h(LucideX, { class: 'size-4' })" @click.stop="activeComment = null" />
+          <Button class="md:!hidden absolute top-1 right-1" size="sm" variant="ghost" :icon="LucideX"
+            @click.stop="activeComment = null" />
         <div v-show="activeComment === comment.id &&
           currentUserId !== 'Guest' &&
           !comment.new &&
@@ -108,12 +108,12 @@
                     <Button :disabled="activeComment !== comment.id ||
                       reply.edit ||
                       reply.resolved
-                      " class="!h-5 !text-xs !px-1.5 !rounded-sm opacity-0" :class="activeComment === comment.id &&
+                      " size="xs" class="opacity-0" :class="activeComment === comment.id &&
                         !reply.edit &&
                         !reply.resolved &&
                         comment.owner == currentUserId &&
                         'opacity-100'
-                        " variant="ghost" :icon="h(LucideMoreVertical, { class: 'size-3' })" />
+                        " variant="ghost" :icon="LucideMoreVertical" />
                   </Dropdown>
                   <LucideBadgeCheck v-if="comment.resolved" class="text-ink-gray-6 size-4" />
                 </div>
@@ -188,7 +188,6 @@ import {
   watch,
   onMounted,
   ref,
-  h,
   onBeforeUnmount,
   nextTick,
 } from 'vue'
@@ -233,11 +232,7 @@ const onOutsideCardClick = (e, comment) => {
   if (activeComment.value !== comment.id || comment.new) return
   const t = e.target
   if (t.getAttribute?.('data-comment-name')) return
-  if (
-    t.closest?.('.ProseMirror') ||
-    (t.nodeName === 'DIV' && !t.classList?.contains?.('replies-count'))
-  )
-    activeComment.value = null
+  if (!t.closest?.('.comment-group')) activeComment.value = null
 }
 
 const cardStyle = (comment) =>

--- a/frontend/src/apps/writer/components/FloatingComments.vue
+++ b/frontend/src/apps/writer/components/FloatingComments.vue
@@ -1,27 +1,21 @@
 <template>
-  <div ref="scrollContainer"
-    class="sticky hidden md:flex flex-col gap-8 justify-start self-stretch shrink-0 w-72 px-5 bg-surface-base">
+  <div ref="scrollContainer" class="absolute inset-0">
     <template v-if="showComments" v-for="comment in filteredComments" :key="comment.id">
-      <div :id="'comment-' + comment.id" :ref="(el) => {
+      <Teleport v-if="!collapsed || activeComment === comment.id" :disabled="!isMobile" to="body">
+        <div :id="'comment-' + comment.id" :ref="(el) => {
         if (el) commentRefs[comment.id] = el
         else delete commentRefs[comment.id]
       }
-        " v-on-outside-click="(e) => {
-          if (
-            activeComment === comment.id &&
-            !e.target.getAttribute('data-comment-name') &&
-            e.target.nodeName === 'DIV' &&
-            !comment.new &&
-            !e.target.classList?.contains?.('replies-count')
-          )
-            activeComment = null
-        }
-          " class="absolute rounded shadow w-64 comment-group scroll-m-24 bg-surface-base dark:border" :class="[
+        " v-on-outside-click="(e) => onOutsideCardClick(e, comment)"
+          class="absolute rounded shadow w-56 comment-group scroll-m-24 bg-surface-base dark:border max-md:fixed max-md:z-20 max-md:inset-x-3 max-md:bottom-3 max-md:top-auto max-md:w-auto max-md:max-h-[65vh] max-md:overflow-y-auto max-md:shadow-xl"
+          :class="[
             activeComment === comment.id && 'shadow-xl ',
-            comment.top
+            isMobile || comment.top
               ? 'opacity-100 pointer-events-auto'
               : 'opacity-0 pointer-events-none',
-          ]" :style="`top: ${comment.top}px;`" @click="activeComment = comment.id">
+          ]" :style="cardStyle(comment)" @click="activeComment = comment.id">
+          <Button class="md:!hidden absolute top-1.5 right-1.5" variant="ghost"
+            :icon="h(LucideX, { class: 'size-4' })" @click.stop="activeComment = null" />
         <div v-show="activeComment === comment.id &&
           currentUserId !== 'Guest' &&
           !comment.new &&
@@ -83,15 +77,15 @@
               </div>
               <div class="grow flex flex-col min-w-0" :class="reply.edit && 'gap-1'">
                 <div class="w-full flex justify-between items-start label-group gap-1 text-sm">
-                  <div class="flex gap-1">
-                    <label class="font-medium text-ink-gray-8 max-w-[70%] truncate">{{ $user(reply.owner)?.full_name ||
+                  <div class="flex gap-1 min-w-0">
+                    <label class="font-medium text-ink-gray-8 truncate">{{ $user(reply.owner)?.full_name ||
                       reply.owner }}</label>
 
-                    <label class="text-ink-gray-6 truncate" :title="new Date(reply.creation)">
+                    <label class="text-ink-gray-6 shrink-0 whitespace-nowrap" :title="new Date(reply.creation)">
                       &#183;
                       {{ formatDateOrTime(reply.creation) }}</label>
                   </div>
-                  <Dropdown class="ml-auto opacity-0" :class="activeComment === comment.id &&
+                  <Dropdown class="ml-auto shrink-0 opacity-0" :class="activeComment === comment.id &&
                     !reply.edit &&
                     !reply.resolved &&
                     comment.owner == currentUserId &&
@@ -170,7 +164,20 @@
           {{ comment.replies.length }}
           {{ comment.replies.length === 1 ? 'reply' : 'replies' }}
         </div>
-      </div>
+        </div>
+      </Teleport>
+      <button v-else :id="'comment-' + comment.id" :ref="(el) => {
+        if (el) commentRefs[comment.id] = el
+        else delete commentRefs[comment.id]
+      }
+        " class="absolute flex items-center rounded-full border border-outline-gray-2 bg-surface-base p-0.5 transition-colors hover:bg-surface-gray-2"
+        :class="comment.top ? 'opacity-100' : 'opacity-0 pointer-events-none'"
+        :style="{ top: `${comment.top}px`, right: '1rem' }" @click.stop="activeComment = comment.id">
+        <Avatar size="sm" :label="$user(comment.owner)?.full_name || comment.owner"
+          :image="$user(comment.owner)?.user_image" />
+        <span v-if="comment.replies.length" class="px-1 text-[10px] leading-none text-ink-gray-6">
+          {{ comment.replies.length + 1 }}</span>
+      </button>
     </template>
   </div>
 </template>
@@ -189,7 +196,7 @@ import { Avatar, Button, Dropdown, onOutsideClickDirective as vOnOutsideClick } 
 import { formatDate } from '@/apps/writer/utils/format'
 import { dynamicList } from '@/apps/writer/utils/'
 import { v4 } from 'uuid'
-import { useDebounceFn, useEventListener } from '@vueuse/core'
+import { useDebounceFn, useEventListener, useMediaQuery } from '@vueuse/core'
 import LucideX from '~icons/lucide/x'
 import LucideCheck from '~icons/lucide/check'
 import LucideMessageCircleCode from '~icons/lucide/message-circle-code'
@@ -217,6 +224,24 @@ const emit = defineEmits(['save'])
 
 const activeComment = defineModel('activeComment')
 const scrollContainer = ref('scrollContainer')
+
+const isMobile = useMediaQuery('(max-width: 767px)')
+const compact = ref(false)
+const collapsed = computed(() => compact.value || isMobile.value)
+
+const onOutsideCardClick = (e, comment) => {
+  if (activeComment.value !== comment.id || comment.new) return
+  const t = e.target
+  if (t.getAttribute?.('data-comment-name')) return
+  if (
+    t.closest?.('.ProseMirror') ||
+    (t.nodeName === 'DIV' && !t.classList?.contains?.('replies-count'))
+  )
+    activeComment.value = null
+}
+
+const cardStyle = (comment) =>
+  isMobile.value ? {} : { top: `${comment.top}px`, right: '1rem' }
 
 const newReplies = reactive({})
 const commentRefs = reactive({})
@@ -279,7 +304,7 @@ watch(
   () => rebuild(props.editor),
 )
 
-watch([activeComment, () => props.showUnanchored], () => {
+watch([activeComment, collapsed, () => props.showUnanchored], () => {
   setCommentHeights()
 })
 
@@ -419,8 +444,13 @@ onMounted(() => {
   props.editor.view.dom.addEventListener('tab-changed', onTabChange)
   const resizeObserver = new ResizeObserver(setCommentHeights)
   resizeObserver.observe(props.editor.view.dom)
+  const railObserver = new ResizeObserver(([entry]) => {
+    compact.value = entry.contentRect.width < 220
+  })
+  railObserver.observe(scrollContainer.value)
   onBeforeUnmount(() => {
     resizeObserver.disconnect()
+    railObserver.disconnect()
     try {
       const dom = props.editor?.view?.dom
       dom.removeEventListener('tab-changed', onTabChange)

--- a/frontend/src/apps/writer/components/RoundedListView.vue
+++ b/frontend/src/apps/writer/components/RoundedListView.vue
@@ -12,7 +12,7 @@
       <div
         class="flex justify-between items-center sticky top-0 bg-surface-base h-8 z-10 mt-3 mb-1 -mx-3"
       >
-        <h2 class="text-sm-medium text-ink-gray-5">
+        <h2 class="text-sm font-medium text-ink-gray-5">
           {{ group }}
         </h2>
         <TabButtons

--- a/frontend/src/apps/writer/components/ToC.vue
+++ b/frontend/src/apps/writer/components/ToC.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="editor && (hasContent || editor.isEditable)"
     class="gap-2 hidden md:block overflow-y-auto overflow-x-hidden flex-shrink-0 h-full transition-[width] duration-300 ease-in-out"
-    :class="[show ? 'w-64 p-2' : 'w-12 p-2.5']">
+    :class="[show ? 'w-56 p-2' : 'w-12 p-2.5']">
     <div v-if="!show" class="flex justify-center">
       <Button variant="ghost" :icon="LucideTableOfContents" tooltip="Table of Contents" @click="show = !show" />
     </div>

--- a/frontend/src/apps/writer/components/VersionsSidebar.vue
+++ b/frontend/src/apps/writer/components/VersionsSidebar.vue
@@ -79,7 +79,7 @@
           :key="title"
           class="flex flex-col gap-1 mb-2 justify-start bg-surface-base"
         >
-          <div v-if="title !== 'Manual'" class="text-ink-gray-5 text-sm-medium mb-1 my-2">
+          <div v-if="title !== 'Manual'" class="text-ink-gray-5 text-sm font-medium mb-1 my-2">
             {{ title }}
           </div>
           <div class="grid grid-cols-3 gap-0.5">

--- a/frontend/src/apps/writer/components/WriterSettings.vue
+++ b/frontend/src/apps/writer/components/WriterSettings.vue
@@ -10,21 +10,15 @@
             <template #default="{ dirty, setDirty, error }">
               <div class="overflow-y-auto max-h-96 px-2 pt-3">
                 <div class="flex flex-col gap-4 pb-5 pr-5">
-                  <div class="space-y-1.5">
-                    <FormLabel label="Font Family" />
-                    <FontSelect
-                      v-model="settings.font_family"
-                      variant="subtle"
-                      :options="fontOptions"
-                    />
-                    <div class="text-xs text-ink-gray-5">
-                      {{
-                        `Choose the default font family for ${
-                          tabIndex === 1 ? 'this document' : 'new documents'
-                        }.`
-                      }}
-                    </div>
-                  </div>
+                  <FontSelect
+                    v-model="settings.font_family"
+                    variant="subtle"
+                    :options="fontOptions"
+                    label="Font Family"
+                    :description="`Choose the default font family for ${
+                      tabIndex === 1 ? 'this document' : 'new documents'
+                    }.`"
+                  />
                   <FormControl
                     v-model="settings.font_size"
                     type="number"
@@ -42,7 +36,7 @@
                     description="Set the line height of the editor."
                   />
                   <div class="space-y-1.5">
-                    <FormLabel label="Paragraph Spacing" />
+                    <FormLabel label="Paragraph Spacing" size="md" />
                     <div class="grid grid-cols-2 gap-2">
                       <FormControl
                         v-model.number="settings.paragraph_spacing_before"
@@ -51,7 +45,7 @@
                         :min="0"
                         :step="1"
                         autocomplete="off"
-                        description="Above"
+                        label="Above"
                       />
                       <FormControl
                         v-model.number="settings.paragraph_spacing_after"
@@ -60,10 +54,10 @@
                         :min="0"
                         autocomplete="off"
                         :step="1"
-                        description="Below"
+                        label="Below"
                       />
                     </div>
-                    <div class="text-xs text-ink-gray-5">
+                    <div class="text-p-sm text-ink-gray-5">
                       Set the default spacing around paragraphs.
                     </div>
                   </div>
@@ -72,29 +66,29 @@
                 <!-- Print Settings Section -->
                 <div class="flex flex-col gap-3 pb-5 pr-5">
                   <template v-if="tabIndex === 1">
-                    <h3 class="text-sm-medium text-ink-gray-7">Print Settings</h3>
+                    <h3 class="text-base font-medium text-ink-gray-7">Print Settings</h3>
                     <div class="space-y-2">
-                      <FormLabel label="Header & Footer" />
+                      <FormLabel label="Header & Footer" size="md" />
                       <div class="grid grid-cols-2 gap-2">
                         <FormControl
                           v-model="settings.print_header_left"
                           type="text"
                           placeholder="Header Left"
-                          description="Top Left"
+                          label="Top Left"
                           autocomplete="off"
                         />
                         <FormControl
                           v-model="settings.print_header_right"
                           type="text"
                           placeholder="Header Right"
-                          description="Top Right"
+                          label="Top Right"
                           autocomplete="off"
                         />
                         <FormControl
                           v-model="settings.print_footer_left"
                           type="text"
                           placeholder="Footer Left"
-                          description="Bottom Left"
+                          label="Bottom Left"
                           autocomplete="off"
                         />
                         <FormControl
@@ -102,11 +96,11 @@
                           :disabled="settings.print_show_pages"
                           type="text"
                           placeholder="Footer Right"
-                          description="Bottom Right"
+                          label="Bottom Right"
                           autocomplete="off"
                         />
                       </div>
-                      <div class="text-xs text-ink-gray-5 mt-2">
+                      <div class="text-p-sm text-ink-gray-5 mt-2">
                         Set the text to appear in headers and footers when printing.
                       </div>
                     </div>
@@ -138,7 +132,7 @@
                     </div>
                   </template>
                   <template v-else>
-                    <h3 class="text-sm-medium text-ink-gray-7">Watermark</h3>
+                    <h3 class="text-base font-medium text-ink-gray-7">Watermark</h3>
                     <FormControl
                       v-model="settings.watermark_text"
                       type="text"
@@ -174,7 +168,7 @@
                 </div>
               </div>
               <div class="mt-2">
-                <div v-if="error" class="text-xs text-ink-red-8">
+                <div v-if="error" class="text-p-sm text-ink-red-6">
                   {{ error }}
                 </div>
                 <Button


### PR DESCRIPTION
Replaces the fixed 288px comment gutter + matching left padding with a symmetric grid inside the single scroll container, so the document stays centered and both gutters flex on resize. Comments are a zero-width absolute overlay in the right gutter: full cards when space allows, avatar chips in tight gutters, and a bottom sheet on mobile. Includes fixes for chip clicks being swallowed by the outside-click directive, card header overflow, cards stacking above dropdown menus, and closing the open card on editor clicks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)