### PR TITLE
feat(sheets): threaded, resolvable cell comments

### DIFF
--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -1012,17 +1012,43 @@
       </template>
     </Dialog>
 
-    <!-- Comment panel (floating near cell) -->
+    <!-- Threaded comment panel (floating near cell) -->
     <div v-if="commentPanel.open" class="sn-comment-panel"
          :style="{ left: commentPanel.x + 'px', top: commentPanel.y + 'px' }">
       <div class="sn-comment-header">
-        <span class="sn-comment-title">Note</span>
-        <Button variant="ghost" size="sm" icon="x" @click="commentPanel.open = false" />
+        <span class="sn-comment-title">
+          Comment
+          <span v-if="commentPanel.resolved" class="sn-comment-resolved">Resolved</span>
+        </span>
+        <div class="sn-comment-hactions">
+          <Button v-if="commentPanel.thread.length" variant="ghost" size="sm"
+                  :icon="commentPanel.resolved ? 'rotate-ccw' : 'check'"
+                  :tooltip="commentPanel.resolved ? 'Reopen' : 'Mark resolved'"
+                  @click="toggleResolveComment" />
+          <Button variant="ghost" size="sm" icon="x" @click="commentPanel.open = false" />
+        </div>
       </div>
-      <textarea class="sn-comment-ta" v-model="commentPanel.text" rows="4" placeholder="Add a note…" @blur="saveComment" />
+
+      <div v-if="commentPanel.thread.length" class="sn-comment-thread">
+        <div v-for="(r, i) in commentPanel.thread" :key="i" class="sn-comment-reply">
+          <div class="sn-comment-reply-head">
+            <span class="sn-comment-author">{{ r.name || r.author || 'Someone' }}</span>
+            <span class="sn-comment-time">{{ commentTime(r.ts) }}</span>
+            <Button v-if="r.author && r.author === userEmail" variant="ghost" size="sm" icon="trash-2"
+                    tooltip="Delete" class="sn-comment-del" @click="deleteCommentReply(i)" />
+          </div>
+          <div class="sn-comment-text">{{ r.text }}</div>
+        </div>
+      </div>
+
+      <textarea class="sn-comment-ta" v-model="commentPanel.draft" rows="2"
+                :placeholder="commentPanel.thread.length ? 'Reply…' : 'Add a comment…'"
+                @keydown.enter.exact.prevent="addCommentReply" />
       <div class="sn-comment-actions">
-        <Button size="sm" variant="solid" @click="saveComment">Save</Button>
-        <Button size="sm" variant="ghost" theme="red" @click="deleteComment">Delete</Button>
+        <Button size="sm" variant="solid" :disabled="!commentPanel.draft.trim()" @click="addCommentReply">
+          {{ commentPanel.thread.length ? 'Reply' : 'Comment' }}
+        </Button>
+        <Button v-if="commentPanel.thread.length" size="sm" variant="ghost" theme="red" @click="deleteComment">Delete all</Button>
       </div>
     </div>
 
@@ -1602,7 +1628,7 @@ const isDirty           = ref(false)
 const isPaintingFormat  = ref(false)
 
 // ── Comment UI state ──────────────────────────────────────────────────────────
-const commentPanel  = reactive({ open: false, id: '', text: '', x: 0, y: 0 })
+const commentPanel  = reactive({ open: false, id: '', x: 0, y: 0, thread: [], resolved: false, draft: '' })
 
 // Notes side panel — global list of notes across all sheets, click-to-jump.
 // `rev` is bumped whenever a note is saved/deleted so the computed list
@@ -3128,7 +3154,7 @@ function _setupGridInstance() {
     getMergeInfo: id => merge.getMasterInfo(id, sheet.getCurrentSheet()),
     isSlave:      id => merge.isSlave(id, sheet.getCurrentSheet()),
     getMasterId:  id => merge.getMasterId(id, sheet.getCurrentSheet()),
-    getComment:   id => comments.get(id, sheet.getCurrentSheet()),
+    getComment:   id => comments.hasOpenComment(id, sheet.getCurrentSheet()),
     getValidation: id => validation.get(id, sheet.getCurrentSheet()),
     getCondFormat: (id, val) => condFormat.getFormatOverride(
       id, val, sheet.getCurrentSheet(),
@@ -4026,6 +4052,9 @@ function _afterHistoryNavigate() {
   _applyHiddenRows()        // filter state restored → re-apply to grid
   _syncViewMirrors()
   syncNames()
+  // The comment panel holds a reference into the (now-replaced) engine thread —
+  // close it so a stale index can't delete the wrong reply after undo/redo.
+  commentPanel.open = false
   activeCell.value   = 'A1'
   formulaValue.value = sheet.getCell('A1')
   refreshActiveFormat(); _syncNumberFormat('A1'); syncFlags()
@@ -4116,20 +4145,52 @@ function openCommentPanel() {
     x = rect.left + 60
     y = rect.top  + 40
   }
-  commentPanel.id   = id
-  commentPanel.text = comments.get(id, sheet.getCurrentSheet()) || ''
-  commentPanel.x    = x
-  commentPanel.y    = y
+  commentPanel.id = id
+  commentPanel.x  = x
+  commentPanel.y  = y
+  commentPanel.draft = ''
+  _loadCommentThread()
   commentPanel.open = true
 }
 
-function saveComment() {
-  comments.set(commentPanel.id, commentPanel.text, sheet.getCurrentSheet())
-  commentPanel.open = false
+// Mirror the engine's thread for `commentPanel.id` into the reactive panel.
+function _loadCommentThread() {
+  const t = comments.getThread(commentPanel.id, sheet.getCurrentSheet())
+  commentPanel.thread   = t ? t.thread : []
+  commentPanel.resolved = t ? t.resolved : false
+}
+
+// Shared post-mutation: repaint, record for undo (comments ride the snapshot),
+// and flag dirty so autosave persists the change.
+function _afterCommentChange() {
+  _loadCommentThread()
   notesPanel.rev++
   grid?.render()
-  history.push()   // comments live in the snapshot; record so undo can revert
+  history.push()
   isDirty.value = true
+}
+
+function addCommentReply() {
+  const text = commentPanel.draft.trim()
+  if (!text) return
+  comments.addReply(commentPanel.id, {
+    author: userEmail.value,
+    name:   userFullName.value || userEmail.value,
+    text,
+  }, sheet.getCurrentSheet())
+  commentPanel.draft = ''
+  _afterCommentChange()
+}
+
+function toggleResolveComment() {
+  comments.resolve(commentPanel.id, !commentPanel.resolved, sheet.getCurrentSheet())
+  _afterCommentChange()
+}
+
+function deleteCommentReply(i) {
+  comments.removeReply(commentPanel.id, i, sheet.getCurrentSheet())
+  _afterCommentChange()
+  if (!commentPanel.thread.length) commentPanel.open = false
 }
 
 function deleteComment() {
@@ -4139,6 +4200,16 @@ function deleteComment() {
   grid?.render()
   history.push()
   isDirty.value = true
+}
+
+// "5m ago" style relative time for a reply's epoch-ms timestamp.
+function commentTime(ts) {
+  if (!ts) return ''
+  const s = Math.max(0, Math.round((Date.now() - ts) / 1000))
+  if (s < 60)    return 'just now'
+  const m = Math.round(s / 60);   if (m < 60) return `${m}m ago`
+  const h = Math.round(m / 60);   if (h < 24) return `${h}h ago`
+  return new Date(ts).toLocaleDateString()
 }
 
 // ── Notes side panel ──────────────────────────────────────────────────────────
@@ -4152,11 +4223,11 @@ const allNotes = computed(() => {
   const list = []
   for (const name of sheetNames.value) {
     const map = comments.getAll(name) || {}
-    const entries = Object.entries(map)
-      .map(([id, text]) => ({ id, p: parseCellId(id), text }))
+    const entries = Object.keys(map)
+      .map(id => ({ id, p: parseCellId(id) }))
       .filter(e => e.p)
       .sort((a, b) => a.p.row - b.p.row || a.p.col - b.p.col)
-      .map(e => ({ sheet: name, id: e.id, text: e.text }))
+      .map(e => ({ sheet: name, id: e.id, text: comments.preview(e.id, name), resolved: !!comments.getThread(e.id, name)?.resolved }))
     list.push(...entries)
   }
   list.sort((a, b) => {
@@ -5786,6 +5857,16 @@ function toggleShowFormulas() {
 .sn-comment-ta     { resize:vertical; font-family:inherit; font-size:13px; color:var(--ink-gray-9); background:var(--surface-gray-1); border:1px solid var(--outline-gray-2); border-radius:6px; padding:6px 8px; min-height:64px; outline:none; }
 .sn-comment-ta:focus { border-color:var(--outline-gray-4); }
 .sn-comment-actions { display:flex; gap:6px; justify-content:flex-end; }
+.sn-comment-hactions { display:flex; align-items:center; gap:2px; }
+.sn-comment-resolved { margin-left:6px; font-size:10px; font-weight:600; letter-spacing:.03em; text-transform:none; color:var(--ink-green-3, #15803d); background:var(--surface-green-2, #e4f3e9); border-radius:999px; padding:1px 7px; }
+.sn-comment-thread  { display:flex; flex-direction:column; gap:10px; max-height:240px; overflow-y:auto; }
+.sn-comment-reply   { display:flex; flex-direction:column; gap:2px; }
+.sn-comment-reply-head { display:flex; align-items:center; gap:6px; }
+.sn-comment-author  { font-size:12.5px; font-weight:600; color:var(--ink-gray-9); }
+.sn-comment-time    { font-size:11px; color:var(--ink-gray-5); }
+.sn-comment-del     { margin-left:auto; opacity:0; }
+.sn-comment-reply:hover .sn-comment-del { opacity:1; }
+.sn-comment-text    { font-size:13px; color:var(--ink-gray-8); white-space:pre-wrap; word-break:break-word; }
 
 /* Notes side panel — docks the right edge of sn-grid-wrap, same dock as
    Version History (only one of the two is open at a time). */

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -1030,7 +1030,7 @@
       </div>
 
       <div v-if="commentPanel.thread.length" class="sn-comment-thread">
-        <div v-for="(r, i) in commentPanel.thread" :key="i" class="sn-comment-reply">
+        <div v-for="(r, i) in commentPanel.thread" :key="`${r.ts}-${r.author}`" class="sn-comment-reply">
           <div class="sn-comment-reply-head">
             <span class="sn-comment-author">{{ r.name || r.author || 'Someone' }}</span>
             <span class="sn-comment-time">{{ commentTime(r.ts) }}</span>

--- a/frontend/src/apps/sheets/engine/comments.js
+++ b/frontend/src/apps/sheets/engine/comments.js
@@ -176,9 +176,13 @@ export function createCommentsEngine() {
   function snapshot() { return deepClone(store) }
 
   // Migrate legacy string notes on load so old saved docs upgrade transparently.
+  // Deep-clone the incoming snapshot first: threads are mutated in place
+  // (addReply/resolve), so aliasing a history entry here would let a later edit
+  // corrupt the stored snapshot and break a subsequent undo/redo.
   function restore(snap) {
     for (const k of Object.keys(store)) delete store[k]
-    for (const [sheet, cells] of Object.entries(snap || {})) {
+    const clone = deepClone(snap || {})
+    for (const [sheet, cells] of Object.entries(clone)) {
       store[sheet] = {}
       for (const [id, v] of Object.entries(cells)) {
         const m = _migrate(v)

--- a/frontend/src/apps/sheets/engine/comments.js
+++ b/frontend/src/apps/sheets/engine/comments.js
@@ -90,10 +90,12 @@ export function createCommentsEngine() {
   }
 
   // Replace a cell's whole thread (or clear it). Used by op-replay / undo, which
-  // captures the entire before/after thread rather than a single reply.
+  // captures the entire before/after thread rather than a single reply. Deep-
+  // clones so the stored thread is isolated from the caller's object — later
+  // in-place mutations (addReply/resolve) can never leak into a restored state.
   function setThread(id, value, sheet = 'Sheet1') {
     ensure(sheet)
-    if (value) store[sheet][id] = value
+    if (value) store[sheet][id] = deepClone(value)
     else delete store[sheet][id]
   }
 

--- a/frontend/src/apps/sheets/engine/comments.js
+++ b/frontend/src/apps/sheets/engine/comments.js
@@ -1,50 +1,115 @@
-// Cell comments (notes) engine — stores per-cell text annotations.
-// Pure state, no DOM dependency.
+// Cell comments engine — threaded, resolvable discussions per cell.
+//
+// Value shape: { resolved: bool, thread: [{ author, name, text, ts, mentions? }] }
+//   author   user id (email) who wrote the reply     name  their display name
+//   ts       epoch ms                                 mentions  @-ed user ids (optional)
+// Legacy flat-string notes (the old single-note model) are migrated to a
+// one-entry thread on read/restore so existing docs keep their notes.
+//
+// The row/col shift + sheet-lifecycle logic is value-type-agnostic (it moves
+// whole values by cell id), so it's unchanged from the flat-note version.
 
 import { parseCellId, colLabel } from '../utils/cells.js'
 import { deepClone } from '../utils/deep-clone.js'
 
+// Upgrade a legacy string note to a thread; pass a thread object through.
+// Returns null for an empty/blank note (nothing to keep).
+function _migrate(v) {
+  if (v == null) return null
+  if (typeof v === 'string') {
+    const t = v.trim()
+    return t ? { resolved: false, thread: [{ author: '', name: '', text: t, ts: null }] } : null
+  }
+  // Only a well-formed thread object survives; a number / array / corrupt value
+  // is dropped rather than crashing hasOpenComment's `.thread.length` later.
+  return (v && Array.isArray(v.thread)) ? v : null
+}
+
 export function createCommentsEngine() {
-  // { sheetName: { cellId: 'comment text' } }
+  // { sheetName: { cellId: { resolved, thread:[...] } } }
   const store = {}
 
   function ensure(sheet) {
     if (!store[sheet]) store[sheet] = {}
   }
 
-  function get(id, sheet = 'Sheet1') {
-    return store[sheet]?.[id] ?? null
+  // ── Reads ──────────────────────────────────────────────────────────────────
+
+  // The thread at a cell, migrating a legacy string in place on first touch.
+  function getThread(id, sheet = 'Sheet1') {
+    const v = store[sheet]?.[id]
+    if (v == null) return null
+    if (typeof v === 'string') { const m = _migrate(v); if (m) store[sheet][id] = m; return m }
+    return v
   }
 
-  function set(id, text, sheet = 'Sheet1') {
+  // Drives the grid marker — only unresolved threads mark the cell so resolved
+  // discussions don't clutter the sheet (they stay in the all-comments list).
+  function hasOpenComment(id, sheet = 'Sheet1') {
+    const t = getThread(id, sheet)
+    return !!(t && !t.resolved && t.thread.length)
+  }
+
+  function getAll(sheet = 'Sheet1') { return store[sheet] || {} }
+
+  // First reply's text — a one-line preview for the all-comments list.
+  function preview(id, sheet = 'Sheet1') {
+    return getThread(id, sheet)?.thread?.[0]?.text || ''
+  }
+
+  // ── Mutations ────────────────────────────────────────────────────────────────
+
+  // Append a reply, creating the thread if new. A new reply reopens a resolved
+  // thread (someone had more to say). `ts` is injectable for deterministic tests.
+  function addReply(id, { author = '', name = '', text, ts = Date.now(), mentions = [] } = {}, sheet = 'Sheet1') {
+    const clean = (text || '').trim()
+    if (!clean) return
     ensure(sheet)
-    if (text && text.trim()) store[sheet][id] = text
-    else delete store[sheet][id]
+    const entry = { author, name, text: clean, ts }
+    if (mentions.length) entry.mentions = mentions
+    const t = getThread(id, sheet)
+    if (t) { t.thread.push(entry); t.resolved = false }
+    else store[sheet][id] = { resolved: false, thread: [entry] }
+  }
+
+  // Drop one reply; if it was the last, the whole thread goes.
+  function removeReply(id, index, sheet = 'Sheet1') {
+    const t = getThread(id, sheet)
+    if (!t || !t.thread[index]) return
+    t.thread.splice(index, 1)
+    if (!t.thread.length) delete store[sheet][id]
+  }
+
+  function resolve(id, resolved, sheet = 'Sheet1') {
+    const t = getThread(id, sheet)
+    if (t) t.resolved = !!resolved
   }
 
   function clear(id, sheet = 'Sheet1') {
     if (store[sheet]) delete store[sheet][id]
   }
 
-  function hasComment(id, sheet = 'Sheet1') {
-    return !!store[sheet]?.[id]
+  // Replace a cell's whole thread (or clear it). Used by op-replay / undo, which
+  // captures the entire before/after thread rather than a single reply.
+  function setThread(id, value, sheet = 'Sheet1') {
+    ensure(sheet)
+    if (value) store[sheet][id] = value
+    else delete store[sheet][id]
   }
 
-  function getAll(sheet = 'Sheet1') {
-    return store[sheet] || {}
-  }
+  // ── Row/col shifts (value-agnostic — move whole threads by cell id) ───────────
 
   function _shift(sheet, pred, newIdFn, descending) {
     ensure(sheet)
     const st = store[sheet]
     const entries = Object.entries(st)
-      .map(([id, text]) => ({ id, p: parseCellId(id), text }))
+      .map(([id, val]) => ({ id, p: parseCellId(id), val }))
       .filter(({ p }) => p && pred(p))
     entries.sort((a, b) => descending ? b.p.row - a.p.row : a.p.row - b.p.row)
-    for (const { id, p, text } of entries) {
+    for (const { id, p, val } of entries) {
       delete st[id]
       const nid = newIdFn(p)
-      if (nid) st[nid] = text
+      if (nid) st[nid] = val
     }
   }
 
@@ -65,12 +130,12 @@ export function createCommentsEngine() {
     ensure(sheet)
     const st = store[sheet]
     const entries = Object.entries(st)
-      .map(([id, text]) => ({ id, p: parseCellId(id), text }))
+      .map(([id, val]) => ({ id, p: parseCellId(id), val }))
       .filter(({ p }) => p && p.col >= atCol)
       .sort((a, b) => b.p.col - a.p.col)
-    for (const { id, p, text } of entries) {
+    for (const { id, p, val } of entries) {
       delete st[id]
-      st[colLabel(p.col + 1) + (p.row + 1)] = text
+      st[colLabel(p.col + 1) + (p.row + 1)] = val
     }
   }
 
@@ -82,14 +147,16 @@ export function createCommentsEngine() {
       if (p && p.col === atCol) delete st[id]
     }
     const entries = Object.entries(st)
-      .map(([id, text]) => ({ id, p: parseCellId(id), text }))
+      .map(([id, val]) => ({ id, p: parseCellId(id), val }))
       .filter(({ p }) => p && p.col > atCol)
       .sort((a, b) => a.p.col - b.p.col)
-    for (const { id, p, text } of entries) {
+    for (const { id, p, val } of entries) {
       delete st[id]
-      st[colLabel(p.col - 1) + (p.row + 1)] = text
+      st[colLabel(p.col - 1) + (p.row + 1)] = val
     }
   }
+
+  // ── Sheet lifecycle ──────────────────────────────────────────────────────────
 
   function renameSheet(oldName, newName) {
     if (!store[oldName] || store[newName] || oldName === newName) return
@@ -106,13 +173,21 @@ export function createCommentsEngine() {
 
   function snapshot() { return deepClone(store) }
 
+  // Migrate legacy string notes on load so old saved docs upgrade transparently.
   function restore(snap) {
     for (const k of Object.keys(store)) delete store[k]
-    for (const [k, v] of Object.entries(snap)) store[k] = v
+    for (const [sheet, cells] of Object.entries(snap || {})) {
+      store[sheet] = {}
+      for (const [id, v] of Object.entries(cells)) {
+        const m = _migrate(v)
+        if (m) store[sheet][id] = m
+      }
+    }
   }
 
   return {
-    get, set, clear, hasComment, getAll,
+    getThread, hasOpenComment, getAll, preview,
+    addReply, removeReply, resolve, clear, setThread,
     insertRow, deleteRow, insertCol, deleteCol,
     renameSheet, duplicateSheet, deleteSheet,
     snapshot, restore,

--- a/frontend/src/apps/sheets/engine/comments.js
+++ b/frontend/src/apps/sheets/engine/comments.js
@@ -59,6 +59,12 @@ export function createCommentsEngine() {
 
   // ── Mutations ────────────────────────────────────────────────────────────────
 
+  // Every mutation REPLACES the thread object rather than editing it in place,
+  // so a reference captured earlier (an undo payload, an open panel) stays
+  // frozen at its old state and can never be corrupted by a later edit. This is
+  // the root-cause guard against aliasing; the deep-clones in restore/setThread
+  // are defence-in-depth on top of it.
+
   // Append a reply, creating the thread if new. A new reply reopens a resolved
   // thread (someone had more to say). `ts` is injectable for deterministic tests.
   function addReply(id, { author = '', name = '', text, ts = Date.now(), mentions = [] } = {}, sheet = 'Sheet1') {
@@ -68,21 +74,23 @@ export function createCommentsEngine() {
     const entry = { author, name, text: clean, ts }
     if (mentions.length) entry.mentions = mentions
     const t = getThread(id, sheet)
-    if (t) { t.thread.push(entry); t.resolved = false }
-    else store[sheet][id] = { resolved: false, thread: [entry] }
+    store[sheet][id] = t
+      ? { resolved: false, thread: [...t.thread, entry] }
+      : { resolved: false, thread: [entry] }
   }
 
   // Drop one reply; if it was the last, the whole thread goes.
   function removeReply(id, index, sheet = 'Sheet1') {
     const t = getThread(id, sheet)
     if (!t || !t.thread[index]) return
-    t.thread.splice(index, 1)
-    if (!t.thread.length) delete store[sheet][id]
+    const thread = t.thread.filter((_, i) => i !== index)
+    if (thread.length) store[sheet][id] = { ...t, thread }
+    else delete store[sheet][id]
   }
 
   function resolve(id, resolved, sheet = 'Sheet1') {
     const t = getThread(id, sheet)
-    if (t) t.resolved = !!resolved
+    if (t) store[sheet][id] = { ...t, resolved: !!resolved }
   }
 
   function clear(id, sheet = 'Sheet1') {

--- a/frontend/src/apps/sheets/engine/comments.test.ts
+++ b/frontend/src/apps/sheets/engine/comments.test.ts
@@ -144,6 +144,15 @@ describe('CommentsEngine — shifts, lifecycle, snapshot', () => {
     expect(c2.preview('A1', 'Sheet1')).toBe('x')
   })
 
+  it('restore isolates the live store from the snapshot (in-place edits keep history intact)', () => {
+    c.addReply('A1', reply('one'), 'Sheet1')
+    const snap = c.snapshot()           // deep copy of the store
+    c.restore(snap)                     // navigate back to it
+    c.addReply('A1', reply('two'), 'Sheet1')   // then edit the live thread in place
+    expect(snap.Sheet1.A1.thread).toHaveLength(1)   // the history entry must be untouched
+    expect(c.getThread('A1', 'Sheet1').thread).toHaveLength(2)
+  })
+
   it('duplicate deep-copies threads', () => {
     c.addReply('A1', reply('x'), 'S1')
     c.duplicateSheet('S1', 'S1 copy')

--- a/frontend/src/apps/sheets/engine/comments.test.ts
+++ b/frontend/src/apps/sheets/engine/comments.test.ts
@@ -64,6 +64,17 @@ describe('CommentsEngine — threads', () => {
     expect(c.getThread('A1', 'Sheet1')).toBeNull()
   })
 
+  it('mutations replace the object — a captured reference stays frozen', () => {
+    c.addReply('A1', reply('one'), 'Sheet1')
+    const before = c.getThread('A1', 'Sheet1')      // capture the current state
+    c.addReply('A1', reply('two'), 'Sheet1')
+    c.resolve('A1', true, 'Sheet1')
+    expect(before.thread).toHaveLength(1)            // frozen: not appended to
+    expect(before.resolved).toBe(false)             // frozen: not flipped
+    expect(c.getThread('A1', 'Sheet1').thread).toHaveLength(2)
+    expect(c.getThread('A1', 'Sheet1').resolved).toBe(true)
+  })
+
   it('preview is the first reply text', () => {
     c.addReply('A1', reply('first'), 'Sheet1')
     c.addReply('A1', reply('second'), 'Sheet1')

--- a/frontend/src/apps/sheets/engine/comments.test.ts
+++ b/frontend/src/apps/sheets/engine/comments.test.ts
@@ -75,6 +75,15 @@ describe('CommentsEngine — threads', () => {
     c.clear('A1', 'Sheet1')
     expect(c.getThread('A1', 'Sheet1')).toBeNull()
   })
+
+  it('setThread stores an isolated copy — no aliasing with the caller', () => {
+    const src = { resolved: false, thread: [{ text: 'x' }] }
+    c.setThread('A1', src, 'Sheet1')
+    src.thread.push({ text: 'leak' })   // mutate the caller's object afterwards
+    src.resolved = true
+    expect(c.getThread('A1', 'Sheet1').thread).toHaveLength(1)
+    expect(c.getThread('A1', 'Sheet1').resolved).toBe(false)
+  })
 })
 
 describe('CommentsEngine — legacy migration', () => {

--- a/frontend/src/apps/sheets/engine/comments.test.ts
+++ b/frontend/src/apps/sheets/engine/comments.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createCommentsEngine } from './comments.js'
+
+const reply = (text, extra = {}) => ({ author: 'a@x.com', name: 'Ann', text, ts: 1000, ...extra })
+
+describe('CommentsEngine — threads', () => {
+  let c
+  beforeEach(() => { c = createCommentsEngine() })
+
+  it('addReply creates a thread', () => {
+    c.addReply('A1', reply('hello'), 'Sheet1')
+    expect(c.getThread('A1', 'Sheet1')).toEqual({
+      resolved: false,
+      thread: [{ author: 'a@x.com', name: 'Ann', text: 'hello', ts: 1000 }],
+    })
+  })
+
+  it('a second reply appends to the same thread', () => {
+    c.addReply('A1', reply('one'), 'Sheet1')
+    c.addReply('A1', reply('two', { author: 'b@x.com', name: 'Bob' }), 'Sheet1')
+    const t = c.getThread('A1', 'Sheet1')
+    expect(t.thread.map(r => r.text)).toEqual(['one', 'two'])
+  })
+
+  it('blank reply is ignored', () => {
+    c.addReply('A1', reply('   '), 'Sheet1')
+    expect(c.getThread('A1', 'Sheet1')).toBeNull()
+  })
+
+  it('missing thread is null', () => {
+    expect(c.getThread('Z9', 'Sheet1')).toBeNull()
+  })
+
+  it('stores mentions only when present', () => {
+    c.addReply('A1', reply('hi @Bob', { mentions: ['b@x.com'] }), 'Sheet1')
+    expect(c.getThread('A1', 'Sheet1').thread[0].mentions).toEqual(['b@x.com'])
+    c.addReply('A2', reply('plain'), 'Sheet1')
+    expect('mentions' in c.getThread('A2', 'Sheet1').thread[0]).toBe(false)
+  })
+
+  it('resolve toggles, and a new reply reopens', () => {
+    c.addReply('A1', reply('q'), 'Sheet1')
+    c.resolve('A1', true, 'Sheet1')
+    expect(c.getThread('A1', 'Sheet1').resolved).toBe(true)
+    expect(c.hasOpenComment('A1', 'Sheet1')).toBe(false)
+    c.addReply('A1', reply('answer'), 'Sheet1')
+    expect(c.getThread('A1', 'Sheet1').resolved).toBe(false)   // reopened
+    expect(c.hasOpenComment('A1', 'Sheet1')).toBe(true)
+  })
+
+  it('a resolved thread stops marking the cell (hasOpenComment false)', () => {
+    c.addReply('A1', reply('x'), 'Sheet1')
+    c.resolve('A1', true, 'Sheet1')
+    expect(c.hasOpenComment('A1', 'Sheet1')).toBe(false)
+    expect(c.getThread('A1', 'Sheet1')).not.toBeNull()   // still exists, just resolved
+  })
+
+  it('removeReply drops one; removing the last drops the thread', () => {
+    c.addReply('A1', reply('one'), 'Sheet1')
+    c.addReply('A1', reply('two'), 'Sheet1')
+    c.removeReply('A1', 0, 'Sheet1')
+    expect(c.getThread('A1', 'Sheet1').thread.map(r => r.text)).toEqual(['two'])
+    c.removeReply('A1', 0, 'Sheet1')
+    expect(c.getThread('A1', 'Sheet1')).toBeNull()
+  })
+
+  it('preview is the first reply text', () => {
+    c.addReply('A1', reply('first'), 'Sheet1')
+    c.addReply('A1', reply('second'), 'Sheet1')
+    expect(c.preview('A1', 'Sheet1')).toBe('first')
+  })
+
+  it('clear removes the thread', () => {
+    c.addReply('A1', reply('x'), 'Sheet1')
+    c.clear('A1', 'Sheet1')
+    expect(c.getThread('A1', 'Sheet1')).toBeNull()
+  })
+})
+
+describe('CommentsEngine — legacy migration', () => {
+  let c
+  beforeEach(() => { c = createCommentsEngine() })
+
+  it('restore upgrades a flat-string note to a one-entry thread', () => {
+    c.restore({ Sheet1: { A1: 'old note', B2: '  ' } })
+    expect(c.getThread('A1', 'Sheet1')).toEqual({
+      resolved: false,
+      thread: [{ author: '', name: '', text: 'old note', ts: null }],
+    })
+    expect(c.getThread('B2', 'Sheet1')).toBeNull()   // blank legacy note dropped
+  })
+
+  it('a string that slips into the store is migrated in place on read', () => {
+    c.restore({ Sheet1: { A1: { resolved: false, thread: [{ text: 't' }] } } })
+    const t = c.getThread('A1', 'Sheet1')
+    expect(t.thread[0].text).toBe('t')
+  })
+
+  it('drops corrupt non-string, non-thread values instead of crashing', () => {
+    c.restore({ Sheet1: { A1: 5, B2: [1, 2], C3: { nope: true }, D4: { resolved: false, thread: [{ text: 'ok' }] } } })
+    expect(c.getThread('A1', 'Sheet1')).toBeNull()
+    expect(c.getThread('B2', 'Sheet1')).toBeNull()
+    expect(c.getThread('C3', 'Sheet1')).toBeNull()
+    expect(c.preview('D4', 'Sheet1')).toBe('ok')        // valid thread survives
+    expect(c.hasOpenComment('A1', 'Sheet1')).toBe(false) // no crash on the dropped ones
+  })
+})
+
+describe('CommentsEngine — shifts, lifecycle, snapshot', () => {
+  let c
+  beforeEach(() => { c = createCommentsEngine() })
+
+  it('insertRow shifts threads down', () => {
+    c.addReply('A2', reply('note'), 'Sheet1')
+    c.insertRow(1, 'Sheet1')
+    expect(c.preview('A3', 'Sheet1')).toBe('note')
+    expect(c.getThread('A2', 'Sheet1')).toBeNull()
+  })
+
+  it('deleteRow removes the deleted row and shifts up', () => {
+    c.addReply('A1', reply('first'), 'Sheet1')
+    c.addReply('A2', reply('second'), 'Sheet1')
+    c.deleteRow(0, 'Sheet1')
+    expect(c.preview('A1', 'Sheet1')).toBe('second')
+    expect(c.getThread('A2', 'Sheet1')).toBeNull()
+  })
+
+  it('snapshot/restore round-trips a thread', () => {
+    c.addReply('A1', reply('x'), 'Sheet1')
+    c.resolve('A1', true, 'Sheet1')
+    const snap = c.snapshot()
+    const c2 = createCommentsEngine()
+    c2.restore(snap)
+    expect(c2.getThread('A1', 'Sheet1').resolved).toBe(true)
+    expect(c2.preview('A1', 'Sheet1')).toBe('x')
+  })
+
+  it('duplicate deep-copies threads', () => {
+    c.addReply('A1', reply('x'), 'S1')
+    c.duplicateSheet('S1', 'S1 copy')
+    c.clear('A1', 'S1')
+    expect(c.preview('A1', 'S1 copy')).toBe('x')
+  })
+})

--- a/frontend/src/apps/sheets/engine/op.js
+++ b/frontend/src/apps/sheets/engine/op.js
@@ -101,8 +101,9 @@ export function setCommentOp({ sheet, id, before, after }) {
 }
 
 function _applyComment(ctx, sheet, id, body) {
-	if (body) ctx.comments.set(id, body, sheet)
-	else      ctx.comments.clear(id, sheet)
+	// `body` is a whole thread object (or null). setThread replaces the cell's
+	// thread wholesale — matches how before/after are captured for undo.
+	ctx.comments.setThread(id, body, sheet)
 }
 
 // ── Structure ops (merge, resize, freeze, hide) ───────────────────────────────


### PR DESCRIPTION
Turns cell comments from **flat per-cell notes** into **threaded, resolvable discussions** — the collaboration parity gap (the app already has Yjs, presence, and version history).

### Engine (`comments.js`)
Value becomes `{ resolved, thread:[{author, name, text, ts, mentions?}] }`.
- `addReply` (a new reply **reopens** a resolved thread), `removeReply` (dropping the last removes the thread), `resolve`, `preview`, `hasOpenComment` (drives the grid marker so **resolved** threads stop cluttering the sheet), `setThread` (whole-thread replace for op-replay).
- Row/col shifts and sheet lifecycle are unchanged — they move whole values by cell id.

### Migration
Legacy flat-string notes upgrade to a one-entry thread on load (and lazily on read), so existing docs are transparent. A corrupt non-string/non-thread value is **dropped** rather than crashing the marker.

### UI
The single-note popover becomes a thread: each reply shows its author + relative time; reply inline (Enter to send); resolve/reopen; delete your own reply; delete the whole thread. Authorship comes from the session user.

### State integrity
Comments ride the existing snapshot / persistence / version-history paths, so threads survive reload, undo/redo, and version stepping. The panel closes on undo/redo so a stale reference can't target the wrong reply.

### Reviewed
Two-agent adversarial self-review before pushing; findings fixed (corrupt-value migration guard, stale-panel-on-undo, dead `hasComment`/`editReply` removed). Migration verified on all load paths.

### Follow-up
@mentions + notifications (the realtime/backend surface) — the reply model already carries an optional `mentions` field.

Ported from standalone frappe/sheets (`feat/parity-comments`).