### PR TITLE
fix(drive): make File permissions fully authoritative in Drive

### DIFF
--- a/suite/drive/api/permissions.py
+++ b/suite/drive/api/permissions.py
@@ -1,7 +1,6 @@
 import frappe
 from frappe.utils import getdate
 from frappe.model.document import Document
-from frappe.core.doctype.file.file import has_permission as ff_has_permission
 
 from suite.drive.utils import (
     generate_upward_path,
@@ -44,14 +43,14 @@ def get_user_access(entity: str | Document | frappe._dict, user: str = None, tea
         entity = frappe.get_cached_doc("File", entity)
 
     # Site files defer to the framework's own permissions, read-only.
-    # Needs a full doc (ff_has_permission reads is_private, absent from FILE_FIELDS rows).
+    # Needs a full doc (site_file_has_permission reads is_private, absent from FILE_FIELDS rows).
     if is_site_file(entity):
         if team:
             return {**NO_ACCESS, "type": "guest"}
         if not user:
             user = frappe.session.user
         doc = entity if isinstance(entity, Document) else frappe.get_cached_doc("File", entity.name)
-        return {**NO_ACCESS, "read": int(bool(ff_has_permission(doc, "read", user))), "type": "guest"}
+        return {**NO_ACCESS, "read": int(bool(site_file_has_permission(doc, "read", user))), "type": "guest"}
 
     access = NO_ACCESS.copy()
     if not user:
@@ -246,11 +245,46 @@ def get_shared_with_list(entity: str):
     return permissions
 
 
+def site_file_has_permission(doc, ptype=None, user=None):
+    """Framework `File.has_permission` semantics for site files, reimplemented
+    because `ignore_file_permissions` short-circuits the original."""
+    user = user or frappe.session.user
+    if user == "Administrator":
+        return True
+    if not doc.is_private and ptype in ("read", "select"):
+        return True
+    if user != "Guest" and doc.owner == user:
+        return True
+    if (
+        user != "Guest"
+        and ptype in ("read", "write", "share", "submit")
+        and frappe.share.get_shared(
+            "File", filters=[["share_name", "=", doc.name]], rights=[ptype], user=user
+        )
+    ):
+        return True
+
+    if doc.attached_to_doctype and doc.attached_to_name:
+        try:
+            ref_doc = frappe.get_doc(doc.attached_to_doctype, doc.attached_to_name)
+        except (ModuleNotFoundError, ImportError):
+            return False
+        except frappe.DoesNotExistError:
+            frappe.clear_last_message()
+            return False
+
+        if ptype in ("write", "create", "delete"):
+            return ref_doc.has_permission("write", user=user)
+        return ref_doc.has_permission("read", user=user)
+
+    return False
+
+
 def user_has_permission(doc, ptype, user=None, team=0):
     if isinstance(doc, str):
         doc = frappe.get_doc("File", doc)
     if is_site_file(doc):
-        return ff_has_permission(doc, ptype, user)
+        return site_file_has_permission(doc, ptype, user)
 
     if not user:
         user = frappe.session.user

--- a/suite/drive/utils/overrides.py
+++ b/suite/drive/utils/overrides.py
@@ -5,77 +5,80 @@ from suite.drive.api.permissions import get_teams
 
 
 def filter_file(user=None):
-    """Replaces the framework's File query conditions (skipped because of the
-    `ignore_file_permissions` hook): original framework semantics for site
-    files, Drive access (membership, ownership, explicit permission) for team files."""
-    user = user or frappe.session.user
-    roles = frappe.get_roles(user)
-    if user == "Administrator" or "Drive Admin" in roles:
-        return ""
+	"""Replaces the framework's File query conditions (skipped because of the
+	`ignore_file_permissions` hook): original framework semantics for site
+	files, Drive access (membership, ownership, explicit permission) for team files."""
+	user = user or frappe.session.user
+	roles = frappe.get_roles(user)
+	if user == "Administrator" or "Drive Admin" in roles:
+		return ""
 
-    escaped = frappe.db.escape(user)
-    site = "COALESCE(`tabFile`.`team`, '') = ''"
-    if SYSTEM_USER_ROLE in roles:
-        readable = ", ".join(frappe.db.escape(dt) for dt in get_doctypes_with_read(user)) or "''"
-        site_cond = (
-            f"({site} AND (`tabFile`.`is_private` = 0"
-            f" OR (`tabFile`.`attached_to_doctype` IS NULL AND `tabFile`.`owner` = {escaped})"
-            f" OR `tabFile`.`attached_to_doctype` IN ({readable})))"
-        )
-    else:
-        site_cond = f"({site} AND `tabFile`.`owner` = {escaped})"
+	escaped = frappe.db.escape(user)
+	site = "COALESCE(`tabFile`.`team`, '') = ''"
+	docshare_cond = (
+		f"`tabFile`.`name` IN (SELECT `share_name` FROM `tabDocShare`"
+		f" WHERE `share_doctype` = 'File' AND `user` = {escaped} AND `read` = 1)"
+	)
+	if SYSTEM_USER_ROLE in roles:
+		readable = ", ".join(frappe.db.escape(dt) for dt in get_doctypes_with_read(user)) or "''"
+		site_cond = (
+			f"({site} AND (`tabFile`.`is_private` = 0"
+			f" OR (`tabFile`.`attached_to_doctype` IS NULL AND `tabFile`.`owner` = {escaped})"
+			f" OR `tabFile`.`attached_to_doctype` IN ({readable})"
+			f" OR {docshare_cond}))"
+		)
+	else:
+		site_cond = f"({site} AND (`tabFile`.`owner` = {escaped} OR {docshare_cond}))"
 
-    teams = get_teams(user, exclude_personal=False)
-    team_cond = (
-        f"`tabFile`.`team` IN ({', '.join(frappe.db.escape(t) for t in teams)})" if teams else "1=0"
-    )
-    drive_cond = (
-        f"(NOT {site} AND ({team_cond}"
-        f" OR `tabFile`.`owner` = {escaped}"
-        f" OR `tabFile`.`name` IN (SELECT `entity` FROM `tabDrive Permission`"
-        f" WHERE `user` = {escaped} AND `read` = 1)))"
-    )
-    return f"({site_cond} OR {drive_cond})"
+	teams = get_teams(user, exclude_personal=False)
+	team_cond = f"`tabFile`.`team` IN ({', '.join(frappe.db.escape(t) for t in teams)})" if teams else "1=0"
+	drive_cond = (
+		f"(NOT {site} AND ({team_cond}"
+		f" OR `tabFile`.`owner` = {escaped}"
+		f" OR `tabFile`.`name` IN (SELECT `entity` FROM `tabDrive Permission`"
+		f" WHERE `user` = {escaped} AND `read` = 1)))"
+	)
+	return f"({site_cond} OR {drive_cond})"
 
 
 def common_filters(func):
-    def decorator(user):
-        user = user or frappe.session.user
-        if user == "Administrator" or "Drive Admin" in frappe.get_roles(user):
-            return ""
-        return func(user)
+	def decorator(user):
+		user = user or frappe.session.user
+		if user == "Administrator" or "Drive Admin" in frappe.get_roles(user):
+			return ""
+		return func(user)
 
-    return decorator
+	return decorator
 
 
 @common_filters
 def filter_drive_permission(user):
-    user = frappe.db.escape(user)
-    return f"""(`tabDrive Permission`.`owner` = {user} or `tabDrive Permission`.user = {user})"""
+	user = frappe.db.escape(user)
+	return f"""(`tabDrive Permission`.`owner` = {user} or `tabDrive Permission`.user = {user})"""
 
 
 @common_filters
 def filter_drive_team(user):
-    teams = get_teams(user, exclude_personal=False)
-    member = (
-        f"`tabDrive Team`.name in ({', '.join(frappe.db.escape(team) for team in teams)}) or "
-        if teams
-        else ""
-    )
-    return f"({member}`tabDrive Team`.public = 1)"
+	teams = get_teams(user, exclude_personal=False)
+	member = (
+		f"`tabDrive Team`.name in ({', '.join(frappe.db.escape(team) for team in teams)}) or "
+		if teams
+		else ""
+	)
+	return f"({member}`tabDrive Team`.public = 1)"
 
 
 @common_filters
 def filter_drive_favourite(user):
-    return f"""(`tabDrive Favourite`.`user` = {frappe.db.escape(user)})"""
+	return f"""(`tabDrive Favourite`.`user` = {frappe.db.escape(user)})"""
 
 
 @common_filters
 def filter_drive_recent(user):
-    return f"""(`tabDrive Entity Log`.`user` = {frappe.db.escape(user)})"""
+	return f"""(`tabDrive Entity Log`.`user` = {frappe.db.escape(user)})"""
 
 
 @common_filters
 def filter_drive_notif(user):
-    user = frappe.db.escape(user)
-    return f"(`tabDrive Notification`.to_user = {user} or `tabDrive Notification`.from_user = {user})"
+	user = frappe.db.escape(user)
+	return f"(`tabDrive Notification`.to_user = {user} or `tabDrive Notification`.from_user = {user})"

--- a/suite/drive/utils/overrides.py
+++ b/suite/drive/utils/overrides.py
@@ -16,7 +16,7 @@ def filter_file(user=None):
     escaped = frappe.db.escape(user)
     site = "COALESCE(`tabFile`.`team`, '') = ''"
     if SYSTEM_USER_ROLE in roles:
-        readable = ", ".join(repr(dt) for dt in get_doctypes_with_read(user)) or "''"
+        readable = ", ".join(frappe.db.escape(dt) for dt in get_doctypes_with_read(user)) or "''"
         site_cond = (
             f"({site} AND (`tabFile`.`is_private` = 0"
             f" OR (`tabFile`.`attached_to_doctype` IS NULL AND `tabFile`.`owner` = {escaped})"

--- a/suite/drive/utils/overrides.py
+++ b/suite/drive/utils/overrides.py
@@ -28,7 +28,9 @@ def filter_file(user=None):
 			f" OR {docshare_cond}))"
 		)
 	else:
-		site_cond = f"({site} AND (`tabFile`.`owner` = {escaped} OR {docshare_cond}))"
+		site_cond = (
+			f"({site} AND (`tabFile`.`is_private` = 0 OR `tabFile`.`owner` = {escaped} OR {docshare_cond}))"
+		)
 
 	teams = get_teams(user, exclude_personal=False)
 	team_cond = f"`tabFile`.`team` IN ({', '.join(frappe.db.escape(t) for t in teams)})" if teams else "1=0"

--- a/suite/drive/utils/overrides.py
+++ b/suite/drive/utils/overrides.py
@@ -1,44 +1,81 @@
 import frappe
+from frappe.permissions import SYSTEM_USER_ROLE, get_doctypes_with_read
 
 from suite.drive.api.permissions import get_teams
+
+
+def filter_file(user=None):
+    """Replaces the framework's File query conditions (skipped because of the
+    `ignore_file_permissions` hook): original framework semantics for site
+    files, Drive access (membership, ownership, explicit permission) for team files."""
+    user = user or frappe.session.user
+    roles = frappe.get_roles(user)
+    if user == "Administrator" or "Drive Admin" in roles:
+        return ""
+
+    escaped = frappe.db.escape(user)
+    site = "COALESCE(`tabFile`.`team`, '') = ''"
+    if SYSTEM_USER_ROLE in roles:
+        readable = ", ".join(repr(dt) for dt in get_doctypes_with_read(user)) or "''"
+        site_cond = (
+            f"({site} AND (`tabFile`.`is_private` = 0"
+            f" OR (`tabFile`.`attached_to_doctype` IS NULL AND `tabFile`.`owner` = {escaped})"
+            f" OR `tabFile`.`attached_to_doctype` IN ({readable})))"
+        )
+    else:
+        site_cond = f"({site} AND `tabFile`.`owner` = {escaped})"
+
+    teams = get_teams(user, exclude_personal=False)
+    team_cond = (
+        f"`tabFile`.`team` IN ({', '.join(frappe.db.escape(t) for t in teams)})" if teams else "1=0"
+    )
+    drive_cond = (
+        f"(NOT {site} AND ({team_cond}"
+        f" OR `tabFile`.`owner` = {escaped}"
+        f" OR `tabFile`.`name` IN (SELECT `entity` FROM `tabDrive Permission`"
+        f" WHERE `user` = {escaped} AND `read` = 1)))"
+    )
+    return f"({site_cond} OR {drive_cond})"
 
 
 def common_filters(func):
     def decorator(user):
         user = user or frappe.session.user
-        if user == "Administrator" or "Drive Admin" in frappe.get_roles():
+        if user == "Administrator" or "Drive Admin" in frappe.get_roles(user):
             return ""
-        return func(frappe.db.escape(user))
+        return func(user)
 
     return decorator
 
 
 @common_filters
 def filter_drive_permission(user):
+    user = frappe.db.escape(user)
     return f"""(`tabDrive Permission`.`owner` = {user} or `tabDrive Permission`.user = {user})"""
 
 
 @common_filters
 def filter_drive_team(user):
-    teams = get_teams(user)
-    if teams:
-        teams = ", ".join(frappe.db.escape(team) for team in teams)
-        return f"""(`tabDrive Team`.name in ({teams}))"""
+    teams = get_teams(user, exclude_personal=False)
+    member = (
+        f"`tabDrive Team`.name in ({', '.join(frappe.db.escape(team) for team in teams)}) or "
+        if teams
+        else ""
+    )
+    return f"({member}`tabDrive Team`.public = 1)"
 
 
 @common_filters
 def filter_drive_favourite(user):
-    user = user or frappe.session.user
-    if user == "Administrator":
-        return ""
-    return f"""(`tabDrive Favourite`.`user` = {user})"""
+    return f"""(`tabDrive Favourite`.`user` = {frappe.db.escape(user)})"""
 
 
 @common_filters
 def filter_drive_recent(user):
-    return f"""(`tabDrive Entity Log`.`user` = {user})"""
+    return f"""(`tabDrive Entity Log`.`user` = {frappe.db.escape(user)})"""
 
 
 @common_filters
 def filter_drive_notif(user):
+    user = frappe.db.escape(user)
     return f"(`tabDrive Notification`.to_user = {user} or `tabDrive Notification`.from_user = {user})"

--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -111,11 +111,15 @@ website_redirects = [
 	},
 ]
 
+# Framework File permission logic is fully replaced by Drive's
+ignore_file_permissions = True
+
 # ============================================================================
 # Permissions — permission_query_conditions (deep-merged union; no key clashes)
 # ============================================================================
 permission_query_conditions = {
 	# drive
+	"File": "suite.drive.utils.overrides.filter_file",
 	"Drive Team": "suite.drive.utils.overrides.filter_drive_team",
 	"Drive Permission": "suite.drive.utils.overrides.filter_drive_permission",
 	"Drive Favourite": "suite.drive.utils.overrides.filter_drive_favourite",


### PR DESCRIPTION
## Summary
- Register `ignore_file_permissions` (frappe#40752) so the framework's deny-only File permission check no longer overrides Drive's own grants — this fixed team members being unable to move/save files they don't own.
- Reimplement the framework's site-file permission semantics and query conditions locally, since the hook short-circuits the originals.
- Fix bugs in the existing Drive query-condition filters (`common_filters` passed the escaped user string into `get_teams`, and checked the session user's roles instead of the target user's).

## Test plan
- [x] Verified via bench console on `suite.localhost`: a non-owner team member can now move/save a team file that only failed before due to the framework's `write` check.
- [x] Verified private site files and non-team-member visibility are still denied (no permission regression).