### PR TITLE
feat(sheets): in-cell SPARKLINE mini-charts

### DIFF
--- a/frontend/src/apps/sheets/canvas/constants.js
+++ b/frontend/src/apps/sheets/canvas/constants.js
@@ -29,6 +29,7 @@ export const COLORS = {
   headerBg:     '#F8F8F8',                  // --surface-sidebar
   headerText:   '#7C7C7C',                  // --ink-gray-5
   cellText:     '#171717',                  // --ink-gray-9
+  sparkline:    '#0F766E',                  // teal-700 — default in-cell chart stroke/fill
   selFill:      'rgba(23, 23, 23, 0.06)',   // --ink-gray-9 @ 6% — subtle neutral wash
   selBorder:    '#171717',                  // --ink-gray-9
   selHandle:    '#171717',                  // --ink-gray-9

--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -10,7 +10,7 @@ import { checkboxRect } from './checkbox-geometry.js'
 
 export { colLabel, cellId, parseCellId } from '../utils/cells.js'
 
-export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getFormat, onFill, onBatchCommit, getMergeInfo, isSlave, getMasterId, getComment, getValidation, getCondFormat, getRightInset, onHyperlinkClick, onDropdownClick, onCheckboxToggle, onPivotDrill, onResizeEnd, getSheetNames, getCurrentSheet, getEditingHomeSheet, getDisplay, getCellIds, lazyValues = false, canEdit = () => true, isCellEditable, onBlockedEdit } = {}) {
+export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getFormat, onFill, onBatchCommit, getMergeInfo, isSlave, getMasterId, getComment, getValidation, getCondFormat, getSparkline, getRightInset, onHyperlinkClick, onDropdownClick, onCheckboxToggle, onPivotDrill, onResizeEnd, getSheetNames, getCurrentSheet, getEditingHomeSheet, getDisplay, getCellIds, lazyValues = false, canEdit = () => true, isCellEditable, onBlockedEdit } = {}) {
   const ctx = canvas.getContext('2d')
   const dpr = window.devicePixelRatio || 1
 
@@ -110,7 +110,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
   }
 
   function render() {
-    renderer.render({ cssW, cssH, getValue, sel, selEnd, selMode, editing, getFormat, freeze, getMergeInfo, isSlave, getComment, getValidation, getCondFormat, getRightInset, getDiffFor: _diffCells ? _getDiffFor : null, marchAnts, marchPhase, pickerRect, zoom: _zoom })
+    renderer.render({ cssW, cssH, getValue, sel, selEnd, selMode, editing, getFormat, freeze, getMergeInfo, isSlave, getComment, getValidation, getCondFormat, getSparkline, getRightInset, getDiffFor: _diffCells ? _getDiffFor : null, marchAnts, marchPhase, pickerRect, zoom: _zoom })
     for (const cb of _renderListeners) cb()
   }
 

--- a/frontend/src/apps/sheets/canvas/painters/cell-painter.js
+++ b/frontend/src/apps/sheets/canvas/painters/cell-painter.js
@@ -4,6 +4,7 @@ import { getTextWrap, isWrapText } from '../../utils/text-wrap.js'
 import { CHIP, chipFont, chipColor, chipMetrics } from '../chip-geometry.js'
 import { checkboxRect, CHECKBOX } from '../checkbox-geometry.js'
 import { checkRule } from '../../engine/validation.js'
+import { sparkGeometry } from '../../engine/sparkline.js'
 
 export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
 
@@ -14,7 +15,7 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
   // engine-backed lookup. The painter only ever touches cells in the visible
   // region, so the lazy path computes display strings for ~hundreds of cells
   // per frame instead of materialising the whole sheet up front.
-  function drawRegionCells(r0, c0, r1, c1, getVal, getFormat, getMergeInfo, isSlave, getComment, getValidation, getCondFormat, getRightInset, getDiffFor) {
+  function drawRegionCells(r0, c0, r1, c1, getVal, getFormat, getMergeInfo, isSlave, getComment, getValidation, getCondFormat, getRightInset, getDiffFor, getSparkline) {
     ctx.textBaseline = 'middle'
     // Two-pass paint: every cell's background + decorations first, then
     // every cell's text. Splitting the passes means an upstream cell's
@@ -30,7 +31,7 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
     for (let r = r0; r <= r1; r++) {
       if (rh(r) === 0) continue
       for (let c = c0; c <= c1; c++)
-        _paintTextAt(r, c, getVal, getFormat, getMergeInfo, isSlave, getCondFormat, getRightInset, getValidation)
+        _paintTextAt(r, c, getVal, getFormat, getMergeInfo, isSlave, getCondFormat, getRightInset, getValidation, getSparkline)
     }
   }
 
@@ -105,10 +106,13 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
     if (condFmt?.icon) _drawCellIcon(x, y, h, condFmt.icon)
   }
 
-  function _paintTextAt(r, c, getVal, getFormat, getMergeInfo, isSlave, getCondFormat, getRightInset, getValidation) {
+  function _paintTextAt(r, c, getVal, getFormat, getMergeInfo, isSlave, getCondFormat, getRightInset, getValidation, getSparkline) {
     const g = _cellGeom(r, c, getVal, getFormat, getMergeInfo, isSlave, getCondFormat)
     if (!g) return
     const { id, val, fmt, condFmt, x, y, w, h } = g
+    // A sparkline cell renders a mini chart in place of text.
+    const spark = getSparkline?.(id)
+    if (spark) { _drawSparkline(x, y, w, h, spark); return }
     if (val == null || val === '') return
     // List / checkbox cells render their value as a chip or tickbox in the bg
     // pass — don't paint the raw text a second time on top.
@@ -141,6 +145,32 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
       }
     }
     _drawCellText(drawX, y, drawW, h, s, efmt, rightInset)
+  }
+
+  // Paint a sparkline spec into the cell box. Geometry (points / bars) comes
+  // from the pure sparkline module; here we just stroke/fill it.
+  function _drawSparkline(x, y, w, h, spec) {
+    const geo = sparkGeometry(spec, w, h)
+    if (!geo) return
+    const color = spec.color || COLORS.sparkline
+    ctx.save()
+    ctx.beginPath(); ctx.rect(x, y, w, h); ctx.clip()   // dense charts can't spill into neighbours
+    if (geo.kind === 'bars') {
+      ctx.fillStyle = color
+      for (const b of geo.bars) ctx.fillRect(x + b.x, y + b.y, b.w, b.h)
+    } else if (geo.points.length === 1) {
+      const p = geo.points[0]                            // a lone point renders as a dot, not an empty stroke
+      ctx.fillStyle = color
+      ctx.beginPath(); ctx.arc(x + p.x, y + p.y, 1.5, 0, Math.PI * 2); ctx.fill()
+    } else {
+      ctx.strokeStyle = color
+      ctx.lineWidth = 1
+      ctx.lineJoin = 'round'
+      ctx.beginPath()
+      geo.points.forEach((p, i) => (i ? ctx.lineTo(x + p.x, y + p.y) : ctx.moveTo(x + p.x, y + p.y)))
+      ctx.stroke()
+    }
+    ctx.restore()
   }
 
   // Walk adjacent cells in the alignment direction and return how many CSS

--- a/frontend/src/apps/sheets/canvas/renderer.js
+++ b/frontend/src/apps/sheets/canvas/renderer.js
@@ -17,7 +17,7 @@ export function createRenderer(ctx, geometry) {
   function render({ cssW, cssH, getValue, sel, selEnd, selMode = 'cell', editing, getFormat,
                     freeze: frz = { rows: 0, cols: 0 }, getMergeInfo, isSlave,
                     getComment = null, getValidation = null, getCondFormat = null,
-                    getRightInset = null, getDiffFor = null,
+                    getRightInset = null, getDiffFor = null, getSparkline = null,
                     marchAnts = null, marchPhase = 0, pickerRect = null, zoom = 1 }) {
     if (!cssW || !cssH) return
     ctx.save()
@@ -35,7 +35,7 @@ export function createRenderer(ctx, geometry) {
 
     const state = { cssW, cssH, getValue, getFormat, getMergeInfo, isSlave,
                     getComment, getValidation, getCondFormat, getRightInset,
-                    getDiffFor,
+                    getDiffFor, getSparkline,
                     editing, range, marchAnts, marchPhase, pickerRect }
 
     _renderRegion(r0s, c0s, r1s, c1s, mainX, mainY, cssW - mainX, cssH - mainY, state)
@@ -59,13 +59,13 @@ export function createRenderer(ctx, geometry) {
     if (clipW <= 0 || clipH <= 0 || r1 < r0 || c1 < c0) return
     const { cssW, cssH, getValue, getFormat, getMergeInfo, isSlave,
             getComment, getValidation, getCondFormat, getRightInset,
-            getDiffFor,
+            getDiffFor, getSparkline,
             editing, range, marchAnts, marchPhase, pickerRect } = state
     ctx.save()
     ctx.beginPath(); ctx.rect(clipX, clipY, clipW, clipH); ctx.clip()
     if (!editing) selPainter.drawSelFill(range)
     gridPainter.drawGridLines(r0, c0, r1, c1, cssW, cssH)
-    cellPainter.drawRegionCells(r0, c0, r1, c1, getValue, getFormat, getMergeInfo, isSlave, getComment, getValidation, getCondFormat, getRightInset, getDiffFor)
+    cellPainter.drawRegionCells(r0, c0, r1, c1, getValue, getFormat, getMergeInfo, isSlave, getComment, getValidation, getCondFormat, getRightInset, getDiffFor, getSparkline)
     cellPainter.drawRegionBorders(r0, c0, r1, c1, getFormat, getMergeInfo, isSlave)
     if (marchAnts)  selPainter.drawMarchingAnts(marchAnts, marchPhase)
     if (pickerRect) selPainter.drawPickerRect(pickerRect)

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -3160,6 +3160,13 @@ function _setupGridInstance() {
       id, val, sheet.getCurrentSheet(),
       (cid) => sheet.getDisplayValue(cid, sheet.getCurrentSheet()),
     ),
+    // A SPARKLINE formula evaluates to a spec object; the painter draws it.
+    // In show-formulas mode the cell shows its =SPARKLINE(...) text instead.
+    getSparkline: id => {
+      if (showFormulas.value) return null
+      const v = sheet.getCellValue(id, sheet.getCurrentSheet())
+      return (v && v.__spark) ? v : null
+    },
     getRightInset: id => {
       const range = sortFilter.getRange(sheet.getCurrentSheet())
       if (!range) return 0

--- a/frontend/src/apps/sheets/engine/formula.js
+++ b/frontend/src/apps/sheets/engine/formula.js
@@ -1,5 +1,7 @@
 // FormulaEngine — full expression parser + evaluator for Frappe Sheets
-// Converted from v1 IIFE to ES module. Zero dependencies.
+// Converted from v1 IIFE to ES module. One local dep: the sparkline spec builder.
+
+import { sparkSpec, isSparkSpec } from './sparkline.js'
 
 const T = {
 	NUM:'NUM', STR:'STR', BOOL:'BOOL', ERR:'ERR',
@@ -175,6 +177,10 @@ function toNumStrict(v) {
 }
 
 function isErr(v) { return typeof v === 'string' && v.startsWith('#') }
+
+// A sparkline spec is a render-only object — coerce it to '' anywhere it would
+// otherwise stringify to "[object Object]" (concat, string comparison).
+function _str(v) { return v == null || isSparkSpec(v) ? '' : String(v) }
 
 // Loose equality for lookups: case-insensitive string match, or numeric match
 // when BOTH sides are genuinely numeric. Guards against toNum('a')===toNum('b')
@@ -772,6 +778,11 @@ const FUNCTIONS = {
 	ROWS:    ([v]) => Array.isArray(v)?v.length:1,
 	COLUMNS: ([v]) => Array.isArray(v)&&Array.isArray(v[0])?v[0].length:(Array.isArray(v)?v.length:1),
 
+	// SPARKLINE(data_range, [type], [color]) — returns a spec the cell renders as
+	// an in-cell mini chart instead of text (type: line | column | bar). It's a
+	// normal formula, so it recomputes and shifts with its range like any other.
+	SPARKLINE: ([range, type, color]) => sparkSpec(flatten([range]), type, color),
+
 	// ── Array functions ─────────────────────────────────────────────────────
 	//
 	// These return arrays. They work as input to other functions (e.g.
@@ -935,8 +946,8 @@ function createParser(tokens, getCellValue, getRangeValues, getSheetCellValue, g
 		while (peek()?.t===T.OP && ['=','<>','>','<','>=','<='].includes(peek().v)) {
 			const op=next().v, r=concat()
 			switch(op) {
-				case '=':  l = String(l).toLowerCase()===String(r).toLowerCase() || toNum(l)===toNum(r); break
-				case '<>': l = String(l).toLowerCase()!==String(r).toLowerCase(); break
+				case '=':  l = _str(l).toLowerCase()===_str(r).toLowerCase() || toNum(l)===toNum(r); break
+				case '<>': l = _str(l).toLowerCase()!==_str(r).toLowerCase(); break
 				case '>':  l = toNum(l)>toNum(r);  break
 				case '<':  l = toNum(l)<toNum(r);  break
 				case '>=': l = toNum(l)>=toNum(r); break
@@ -951,7 +962,7 @@ function createParser(tokens, getCellValue, getRangeValues, getSheetCellValue, g
 		while (peek()?.t===T.OP && peek().v==='&') {
 			next()
 			const r = add()
-			l = (l==null?'':String(l)) + (r==null?'':String(r))
+			l = _str(l) + _str(r)
 		}
 		return l
 	}
@@ -1162,6 +1173,7 @@ const FN_HINTS = {
 	CHOOSE:'(index_num, value1, [value2, ...])',
 	ROW:'([reference])', COLUMN:'([reference])', ROWS:'(array)', COLUMNS:'(array)',
 	LARGE:'(array, k)', SMALL:'(array, k)',
+	SPARKLINE:'(data_range, [type], [color])',
 }
 
 export function getFunctionNames() { return _fnNames }

--- a/frontend/src/apps/sheets/engine/formula.test.ts
+++ b/frontend/src/apps/sheets/engine/formula.test.ts
@@ -484,6 +484,18 @@ describe('ADDRESS', () => {
 
 // ── Array (newly added) ─────────────────────────────────────────────────────
 
+describe('SPARKLINE', () => {
+  it('returns a spec with the numeric range data, type and color', () => {
+    expect(evalExpr('=SPARKLINE(A1:A3, "column", "#f00")', { cells: { A1: 1, A2: 2, A3: 3 } }))
+      .toEqual({ __spark: true, type: 'column', data: [1, 2, 3], color: '#f00' })
+  })
+  it('defaults to a line chart and drops blank/non-numeric cells', () => {
+    const s = evalExpr('=SPARKLINE(A1:A4)', { cells: { A1: 1, A3: 'x', A4: 4 } })  // A2 empty
+    expect(s.type).toBe('line')
+    expect(s.data).toEqual([1, 4])
+  })
+})
+
 describe('array functions', () => {
   it('TRANSPOSE 1D vertical → 1 row × 3 cols', () => {
     // A1:A3 arrives as [[1],[2],[3]] (column vector). Transposed it should be

--- a/frontend/src/apps/sheets/engine/sheet.js
+++ b/frontend/src/apps/sheets/engine/sheet.js
@@ -122,6 +122,7 @@ export function createSheet({ onCellChanged, onCellsChanged } = {}) {
 		const raw = sheets[sheet]?.[id] ?? ''
 		if (typeof raw === 'string' && raw.startsWith('=')) {
 			const result = _evalFormula(raw.slice(1), sheet, id)
+			if (result?.__spark) return ''   // a sparkline renders as a chart, not text
 			return result === null || result === undefined ? '' : String(result)
 		}
 		return raw === null || raw === undefined ? '' : String(raw)

--- a/frontend/src/apps/sheets/engine/sparkline.js
+++ b/frontend/src/apps/sheets/engine/sparkline.js
@@ -1,0 +1,81 @@
+// Sparkline model + geometry — the pure core behind in-cell mini charts.
+//
+// A sparkline is a formula, not a stored object: `=SPARKLINE(A1:A10, "column")`
+// evaluates to a spec `{ __spark, type, data, color }`. The sheet engine shows
+// no text for a spec (the cell renders a chart instead), and the canvas painter
+// asks `sparkGeometry` for the drawing primitives. Because it's just a formula,
+// it inherits recompute-on-change, row/col shifting, persistence, and undo for
+// free — there's no separate registry to keep in sync.
+//
+// This module has no canvas/DOM dependency so the geometry is unit-testable.
+
+export const SPARK_TYPES = new Set(['line', 'column'])
+
+// A hex (#rgb…#rrggbbaa) or bare CSS colour keyword — enough to reject a stray
+// #REF! / label that would otherwise reach the canvas as an invalid style
+// (which canvas silently ignores, painting in a leftover colour).
+const COLOR_RE = /^(#[0-9a-f]{3,8}|[a-z]+)$/i
+
+// Normalise a type argument to a supported chart type (default 'line').
+export function sparkType(v) {
+  const t = String(v ?? '').toLowerCase()
+  return SPARK_TYPES.has(t) ? t : 'line'
+}
+
+// Build a spec from a (possibly mixed) data array plus options. Empty cells and
+// non-numeric values are dropped (treated as gaps, like Google Sheets) so a
+// blank or a stray label in the range doesn't read as a spurious 0.
+export function sparkSpec(data, type, color) {
+  const nums = (data || [])
+    .filter(v => !(v == null || (typeof v === 'string' && v.trim() === '')))
+    .map(v => Number(v))
+    .filter(Number.isFinite)
+  const c = typeof color === 'string' ? color.trim() : ''
+  return {
+    __spark: true,
+    type: sparkType(type),
+    data: nums,
+    color: COLOR_RE.test(c) ? c : null,
+  }
+}
+
+export function isSparkSpec(v) {
+  return !!(v && typeof v === 'object' && v.__spark === true)
+}
+
+// Given a spec and the cell's pixel box, return the primitives to draw:
+//   { kind:'line', points:[{x,y},…] }
+//   { kind:'bars', bars:[{x,y,w,h,neg},…] }   (column/bar)
+// or null when there's nothing to draw (no numeric data, or a box too small).
+// Coordinates are relative to the cell's top-left, inset by `pad`.
+export function sparkGeometry(spec, w, h, pad = 3) {
+  const data = spec?.data || []
+  const pw = w - pad * 2
+  const ph = h - pad * 2
+  if (!data.length || pw <= 0 || ph <= 0) return null
+
+  const min = Math.min(...data)
+  const max = Math.max(...data)
+  const span = (max - min) || 1
+  // Map a value to a y inside the padded box, higher value = higher (smaller y).
+  const yOf = (v) => pad + (ph - ((v - min) / span) * ph)
+
+  if (spec.type === 'column') {
+    const n = data.length
+    const gap = n > 20 ? 0 : 1                       // drop gaps when very dense
+    const bw = Math.max(1, (pw - gap * (n - 1)) / n)
+    // Bars grow from zero when the range straddles it, else from the low edge.
+    const baseY = yOf(min < 0 && max > 0 ? 0 : min)
+    const bars = data.map((v, i) => {
+      const bx = pad + i * (bw + gap)
+      const vy = yOf(v)
+      return { x: bx, y: Math.min(vy, baseY), w: bw, h: Math.max(1, Math.abs(vy - baseY)), neg: v < 0 }
+    })
+    return { kind: 'bars', bars }
+  }
+
+  const n = data.length
+  const step = n > 1 ? pw / (n - 1) : 0
+  const points = data.map((v, i) => ({ x: pad + i * step, y: yOf(v) }))
+  return { kind: 'line', points }
+}

--- a/frontend/src/apps/sheets/engine/sparkline.js
+++ b/frontend/src/apps/sheets/engine/sparkline.js
@@ -11,10 +11,33 @@
 
 export const SPARK_TYPES = new Set(['line', 'column'])
 
-// A hex (#rgb…#rrggbbaa) or bare CSS colour keyword — enough to reject a stray
-// #REF! / label that would otherwise reach the canvas as an invalid style
-// (which canvas silently ignores, painting in a leftover colour).
-const COLOR_RE = /^(#[0-9a-f]{3,8}|[a-z]+)$/i
+// A colour is a hex literal (#rgb…#rrggbbaa) or a real CSS colour keyword. We
+// validate against the actual keyword set — a bare /[a-z]+/ would admit a typo
+// ("bluee") that canvas silently ignores, leaving the sparkline in whatever
+// colour was last set. An unrecognised value falls back to the default.
+const HEX_RE = /^#[0-9a-f]{3,8}$/i
+const CSS_COLORS = new Set((
+  'aliceblue antiquewhite aqua aquamarine azure beige bisque black blanchedalmond blue ' +
+  'blueviolet brown burlywood cadetblue chartreuse chocolate coral cornflowerblue cornsilk ' +
+  'crimson cyan darkblue darkcyan darkgoldenrod darkgray darkgreen darkgrey darkkhaki ' +
+  'darkmagenta darkolivegreen darkorange darkorchid darkred darksalmon darkseagreen ' +
+  'darkslateblue darkslategray darkslategrey darkturquoise darkviolet deeppink deepskyblue ' +
+  'dimgray dimgrey dodgerblue firebrick floralwhite forestgreen fuchsia gainsboro ghostwhite ' +
+  'gold goldenrod gray green greenyellow grey honeydew hotpink indianred indigo ivory khaki ' +
+  'lavender lavenderblush lawngreen lemonchiffon lightblue lightcoral lightcyan ' +
+  'lightgoldenrodyellow lightgray lightgreen lightgrey lightpink lightsalmon lightseagreen ' +
+  'lightskyblue lightslategray lightslategrey lightsteelblue lightyellow lime limegreen linen ' +
+  'magenta maroon mediumaquamarine mediumblue mediumorchid mediumpurple mediumseagreen ' +
+  'mediumslateblue mediumspringgreen mediumturquoise mediumvioletred midnightblue mintcream ' +
+  'mistyrose moccasin navajowhite navy oldlace olive olivedrab orange orangered orchid ' +
+  'palegoldenrod palegreen paleturquoise palevioletred papayawhip peachpuff peru pink plum ' +
+  'powderblue purple rebeccapurple red rosybrown royalblue saddlebrown salmon sandybrown ' +
+  'seagreen seashell sienna silver skyblue slateblue slategray slategrey snow springgreen ' +
+  'steelblue tan teal thistle tomato transparent turquoise violet wheat white whitesmoke ' +
+  'yellow yellowgreen'
+).split(' '))
+
+function _isColor(c) { return HEX_RE.test(c) || CSS_COLORS.has(c.toLowerCase()) }
 
 // Normalise a type argument to a supported chart type (default 'line').
 export function sparkType(v) {
@@ -35,7 +58,7 @@ export function sparkSpec(data, type, color) {
     __spark: true,
     type: sparkType(type),
     data: nums,
-    color: COLOR_RE.test(c) ? c : null,
+    color: _isColor(c) ? c : null,
   }
 }
 

--- a/frontend/src/apps/sheets/engine/sparkline.test.ts
+++ b/frontend/src/apps/sheets/engine/sparkline.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { sparkType, sparkSpec, isSparkSpec, sparkGeometry } from './sparkline.js'
+
+describe('sparkType', () => {
+  it('accepts known types, defaults to line', () => {
+    expect(sparkType('column')).toBe('column')
+    expect(sparkType('COLUMN')).toBe('column')
+    expect(sparkType('bar')).toBe('line')     // unimplemented → falls back to line
+    expect(sparkType('pie')).toBe('line')
+    expect(sparkType(undefined)).toBe('line')
+  })
+})
+
+describe('sparkSpec', () => {
+  it('keeps numeric data, drops non-numeric', () => {
+    const s = sparkSpec([1, '2', 'x', '', 4], 'line')
+    expect(s.data).toEqual([1, 2, 4])
+    expect(s.__spark).toBe(true)
+    expect(s.type).toBe('line')
+    expect(s.color).toBe(null)
+  })
+  it('keeps a valid color (hex or keyword), rejects garbage', () => {
+    expect(sparkSpec([1], 'line', '  #f00 ').color).toBe('#f00')
+    expect(sparkSpec([1], 'line', 'red').color).toBe('red')
+    expect(sparkSpec([1], 'line', '#REF!').color).toBe(null)   // stray error text, not a colour
+    expect(sparkSpec([1], 'line', '').color).toBe(null)
+    expect(sparkSpec([1], 'line', 5).color).toBe(null)
+  })
+  it('isSparkSpec recognises a spec', () => {
+    expect(isSparkSpec(sparkSpec([1]))).toBe(true)
+    expect(isSparkSpec({})).toBe(false)
+    expect(isSparkSpec('#spark')).toBe(false)
+    expect(isSparkSpec(null)).toBe(false)
+  })
+})
+
+describe('sparkGeometry — line', () => {
+  it('spreads points across the padded width, inverts y', () => {
+    const g = sparkGeometry(sparkSpec([0, 10], 'line'), 26, 20, 3)
+    expect(g.kind).toBe('line')
+    expect(g.points).toHaveLength(2)
+    expect(g.points[0].x).toBe(3)             // left inset
+    expect(g.points[1].x).toBe(23)            // right inset (26 - 3)
+    expect(g.points[0].y).toBeGreaterThan(g.points[1].y)  // 0 is lower (bigger y) than 10
+  })
+  it('a single point sits at the left', () => {
+    const g = sparkGeometry(sparkSpec([5], 'line'), 26, 20)
+    expect(g.points).toHaveLength(1)
+    expect(g.points[0].x).toBe(3)
+  })
+})
+
+describe('sparkGeometry — bars', () => {
+  it('lays one bar per value within the box', () => {
+    const g = sparkGeometry(sparkSpec([1, 2, 3], 'column'), 30, 20, 3)
+    expect(g.kind).toBe('bars')
+    expect(g.bars).toHaveLength(3)
+    for (const b of g.bars) {
+      expect(b.x).toBeGreaterThanOrEqual(3)
+      expect(b.h).toBeGreaterThanOrEqual(1)
+    }
+  })
+  it('negatives grow the other side of the zero baseline', () => {
+    const g = sparkGeometry(sparkSpec([-2, 3], 'column'), 30, 20, 3)
+    expect(g.bars[0].neg).toBe(true)
+    expect(g.bars[1].neg).toBe(false)
+    // the negative bar's top is below the positive bar's top
+    expect(g.bars[0].y).toBeGreaterThan(g.bars[1].y)
+  })
+})
+
+describe('sparkGeometry — nothing to draw', () => {
+  it('returns null with no data', () => {
+    expect(sparkGeometry(sparkSpec([]), 26, 20)).toBe(null)
+    expect(sparkGeometry(sparkSpec(['a', 'b']), 26, 20)).toBe(null)
+  })
+  it('returns null when the box is too small', () => {
+    expect(sparkGeometry(sparkSpec([1, 2]), 4, 4)).toBe(null)
+  })
+})

--- a/frontend/src/apps/sheets/engine/sparkline.test.ts
+++ b/frontend/src/apps/sheets/engine/sparkline.test.ts
@@ -22,6 +22,8 @@ describe('sparkSpec', () => {
   it('keeps a valid color (hex or keyword), rejects garbage', () => {
     expect(sparkSpec([1], 'line', '  #f00 ').color).toBe('#f00')
     expect(sparkSpec([1], 'line', 'red').color).toBe('red')
+    expect(sparkSpec([1], 'line', 'steelblue').color).toBe('steelblue')
+    expect(sparkSpec([1], 'line', 'bluee').color).toBe(null)   // typo → default, not a leftover colour
     expect(sparkSpec([1], 'line', '#REF!').color).toBe(null)   // stray error text, not a colour
     expect(sparkSpec([1], 'line', '').color).toBe(null)
     expect(sparkSpec([1], 'line', 5).color).toBe(null)

--- a/frontend/src/apps/sheets/utils/formula-ac.js
+++ b/frontend/src/apps/sheets/utils/formula-ac.js
@@ -37,6 +37,7 @@ export const AC_FUNS = {
   VLOOKUP:'(value, table, col_index, [range_lookup])',
   XLOOKUP:'(lookup, lookup_array, return_array, [if_not_found], [match_mode])',
   WEEKDAY:'(date, [return_type])', YEAR:'(date)',
+  SPARKLINE:'(data_range, [type], [color])',
 }
 
 // Pre-sorted for O(1) reuse in autocomplete filtering.


### PR DESCRIPTION
`SPARKLINE(data_range, [type], [color])` renders an in-cell **line** or **column** mini-chart. It's modelled as a **formula** (not a separate registry), so it inherits recompute-on-change, row/col shifting, persistence, and undo from the formula engine for free — nothing new to keep in the snapshot/persist/version-history surfaces.

### How it works
- **`engine/sparkline.js`** — a pure spec builder (`sparkSpec`) + drawing geometry (`sparkGeometry`), unit-tested in isolation (no canvas/DOM). Empty and non-numeric cells are dropped (gaps, like Google Sheets — not spurious zeros); an invalid `color` argument (e.g. a `#REF!` or a label) is rejected so it can't reach the canvas as a bad style.
- **`formula.js`** — the `SPARKLINE` function, plus a `_str()` coercion so a spec object never leaks into string concat / comparison as `"[object Object]"`.
- **`sheet.getDisplayValue`** returns `''` for a spec (no text); the canvas threads a `getSparkline(id)` callback that the painter draws — clipped to the cell (dense data can't spill into neighbours), and a lone data point renders as a dot rather than an empty stroke.
- In **show-formulas** mode the cell shows its `=SPARKLINE(...)` text instead of the chart.

### Hardened via adversarial self-review (before this PR)
Fixed pre-review: the `[object Object]` concat leak, bar overflow into adjacent cells, the invisible single-point line, invalid-colour passthrough, and an unimplemented `bar` type advertised in the type set (dropped to `line`/`column`).

The array-spill engine this was prototyped on is **intentionally excluded** — it ships with its integration when full spilling lands, not as unwired dead code.

Ported from standalone frappe/sheets.