### PR TITLE
chore: allow frappe v16 through current develop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 description = "Frappe Suite — Drive, Slides, Writer, Sheets, Meet, Mail, Calendar in one app."
 readme = "README.md"
 version = "0.0.1"
-requires-python = ">=3.10"
+requires-python = ">=3.14,<3.15"
 dependencies = [
     # drive
     "av>=12.0.0",
@@ -44,9 +44,12 @@ packages = [
 requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 
+[tool.bench.frappe-dependencies]
+frappe = ">=16.0.0,<18.0.0"
+
 [tool.ruff]
 line-length = 110
-target-version = "py310"
+target-version = "py314"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## Summary
- Set the frappe dependency to `>=16.0.0,<18.0.0` so v16 releases and the current v17 `develop` branch (`17.0.0-dev`) are both supported. The previous constraint had a dangling trailing comma and no upper bound.
- Bump `requires-python` to `>=3.14,<3.15` to match frappe develop, which now pins the same range (`frappe/pyproject.toml`). Installs on 3.10–3.13 cannot run frappe develop regardless, so this aligns the app with its dependency rather than restricting it arbitrarily.
- Update ruff `target-version` from the stale `py310` to `py314` so linting reflects the actual supported interpreter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)