### PR TITLE
feat(exchange): rollback imports on failure

### DIFF
--- a/suite/mail/doctype/calendar_exchange/calendar_exchange.py
+++ b/suite/mail/doctype/calendar_exchange/calendar_exchange.py
@@ -363,6 +363,8 @@ class CalendarExchange(Document):
 		os.makedirs(base_dir, exist_ok=True)
 
 		kwargs = {}
+		service = None
+		staging_calendar_id = None
 		try:
 			if self.import_format == "ics" and self.import_file.endswith(".ics"):
 				shutil.copy(import_file, os.path.join(base_dir, os.path.basename(import_file)))
@@ -386,8 +388,16 @@ class CalendarExchange(Document):
 			if len(events) > self.max_import:
 				frappe.throw(_("Import limit exceeded."))
 
-			created, skipped, failed = self._create_events(service, events, logger)
+			# Stage everything into one throwaway calendar first, then move it to the destination
+			# calendar(s). A failure before the move leaves nothing scattered across the account: the
+			# staging calendar and every event in it are deleted on rollback.
+			staging_calendar_id = self._create_staging_calendar(service, logger)
+			targets, skipped, failed = self._create_events(service, events, staging_calendar_id, logger)
+			self._move_to_target_calendars(service, targets, logger)
+			self._discard_staging_calendar(service, staging_calendar_id, logger)
+			staging_calendar_id = None
 
+			created = len(targets)
 			logger.info("import-completed", created=created, skipped=skipped, failed=failed)
 			self._log_output(
 				_("Import completed. {0} created, {1} skipped (already present), {2} failed.").format(
@@ -398,6 +408,8 @@ class CalendarExchange(Document):
 		except Exception:
 			logger.exception("import-failed")
 			self._log_output(_("Import failed. See the error details below."))
+			if staging_calendar_id and service:
+				self._rollback_staging_calendar(service, staging_calendar_id, logger)
 			kwargs.update(
 				{"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
 			)
@@ -532,13 +544,35 @@ class CalendarExchange(Document):
 
 		return events
 
-	def _create_events(
-		self, service: CalendarEventService, events: list[dict], logger: ExchangeLogger
-	) -> tuple[int, int, int]:
-		"""Creates the given JSCalendar events, skipping any whose UID already exists (idempotency).
+	def _create_staging_calendar(self, service: CalendarEventService, logger: ExchangeLogger) -> str:
+		"""Creates a temporary calendar (named after this exchange) to stage the import into."""
 
-		Returns a ``(created, skipped, failed)`` tuple. Failures within a batch are recorded and the
-		remaining batches continue, so a few malformed events do not abort the whole import."""
+		self._log_output(_("Creating a temporary calendar to stage the import."))
+		response = CalendarService(service.account, service.connection).create(
+			[{"creation_id": str(uuid7()), "name": self.name, "is_subscribed": False, "is_visible": False}]
+		)
+		created = response.get("created") or {}
+		if not created:
+			frappe.throw(_("Failed to create the staging calendar: {0}").format(response.get("notCreated")))
+
+		staging_calendar_id = next(iter(created.values()))["id"]
+		logger.info("import-staging-calendar-created", calendar=staging_calendar_id)
+		return staging_calendar_id
+
+	def _create_events(
+		self,
+		service: CalendarEventService,
+		events: list[dict],
+		staging_calendar_id: str,
+		logger: ExchangeLogger,
+	) -> tuple[dict[str, dict[str, bool]], int, int]:
+		"""Creates the given JSCalendar events in the staging calendar, skipping any whose UID already
+		exists (idempotency).
+
+		Returns a ``(targets, skipped, failed)`` tuple, where ``targets`` maps each created event's ID
+		to the destination calendarIds it should ultimately land in. Failures within a batch are
+		recorded and the remaining batches continue, so a few malformed events do not abort the whole
+		import."""
 
 		# Idempotency: skip events whose UID is already present in the account.
 		uids = [e["uid"] for e in events if e.get("uid")]
@@ -570,40 +604,91 @@ class CalendarExchange(Document):
 				continue
 			pending.append(event)
 
-		created = 0
+		targets: dict[str, dict[str, bool]] = {}
 		failed = 0
 		total = len(pending)
 		for batch in create_batch(pending, service.max_objects_in_set):
 			payload: dict[str, dict] = {}
-			creation_to_uid: dict[str, str] = {}
+			creation_meta: dict[str, tuple[str, dict]] = {}
 			for event in batch:
+				# Resolve the destination before overwriting calendarIds with the staging calendar.
+				destination = resolve_calendar_ids(event)
 				event = {k: v for k, v in event.items() if k not in SERVER_MANAGED_KEYS}
 				event["@type"] = "Event"
-				event["calendarIds"] = resolve_calendar_ids(event)
+				event["calendarIds"] = {staging_calendar_id: True}
 
 				creation_id = str(uuid7())
 				payload[creation_id] = event
-				creation_to_uid[creation_id] = event.get("uid", creation_id)
+				creation_meta[creation_id] = (event.get("uid", creation_id), destination)
 
 			response = service._create(payload, sendSchedulingMessages=False)
 			method_responses = response.get("methodResponses") or []
 			result = method_responses[0][1] if method_responses else {}
 
-			batch_created = result.get("created") or {}
 			batch_failed = result.get("notCreated") or {}
-			created += len(batch_created)
 			failed += len(batch_failed)
+
+			for creation_id, info in (result.get("created") or {}).items():
+				targets[info["id"]] = creation_meta[creation_id][1]
 
 			for creation_id, error in batch_failed.items():
 				logger.warning(
 					"import-event-not-created",
-					uid=creation_to_uid.get(creation_id),
+					uid=creation_meta.get(creation_id, (None,))[0],
 					reason=str(error),
 				)
 
-			self._log_output(_("Imported {0} of {1} event(s).").format(created, total))
+			self._log_output(_("Staged {0} of {1} event(s).").format(len(targets), total))
 
-		return created, skipped, failed
+		return targets, skipped, failed
+
+	def _move_to_target_calendars(
+		self, service: CalendarEventService, targets: dict[str, dict[str, bool]], logger: ExchangeLogger
+	) -> None:
+		"""Moves the staged events into their destination calendars, replacing the staging calendar.
+
+		This is the commit step: until it runs, every event lives only in the staging calendar, so a
+		failure up to this point rolls back cleanly."""
+
+		if not targets:
+			return
+
+		self._log_output(_("Moving {0} event(s) into the destination calendar(s).").format(len(targets)))
+		result = service.set_calendar_ids(targets)
+
+		if not_updated := result.get("notUpdated"):
+			logger.warning("import-event-not-moved", count=len(not_updated))
+			frappe.throw(
+				_("Failed to move {0} event(s) into the destination calendar(s).").format(len(not_updated))
+			)
+
+		logger.info("import-events-moved", events=len(result.get("updated", [])))
+
+	def _discard_staging_calendar(
+		self, service: CalendarEventService, staging_calendar_id: str, logger: ExchangeLogger
+	) -> None:
+		"""Deletes the now-empty staging calendar after a successful import. A failure here is logged
+		but not fatal: the events are already safely in their destination calendars."""
+
+		try:
+			CalendarService(service.account, service.connection).delete([staging_calendar_id])
+			logger.info("import-staging-calendar-removed", calendar=staging_calendar_id)
+		except Exception:
+			logger.warning("import-staging-calendar-remove-failed", calendar=staging_calendar_id)
+
+	def _rollback_staging_calendar(
+		self, service: CalendarEventService, staging_calendar_id: str, logger: ExchangeLogger
+	) -> None:
+		"""Deletes the staging calendar and every event still staged in it, undoing a failed import."""
+
+		self._log_output(_("Rolling back: removing the staging calendar and any staged events."))
+		try:
+			CalendarService(service.account, service.connection).delete(
+				[staging_calendar_id], remove_events=True
+			)
+			logger.info("import-rolled-back", calendar=staging_calendar_id)
+		except Exception:
+			logger.exception("import-rollback-failed", calendar=staging_calendar_id)
 
 	def _mark_started(self) -> None:
 		"""Marks the calendar exchange as started and updates the started_at and started_after fields."""

--- a/suite/mail/doctype/calendar_exchange/calendar_exchange.py
+++ b/suite/mail/doctype/calendar_exchange/calendar_exchange.py
@@ -393,6 +393,12 @@ class CalendarExchange(Document):
 			# staging calendar and every event in it are deleted on rollback.
 			staging_calendar_id = self._create_staging_calendar(service, logger)
 			targets, skipped, failed = self._create_events(service, events, staging_calendar_id, logger)
+
+			# The server rejecting every event is a failure, not a successful zero-import, and must
+			# trigger a rollback.
+			if not targets and failed > 0:
+				frappe.throw(_("Import failed: the server rejected all {0} event(s).").format(failed))
+
 			self._move_to_target_calendars(service, targets, logger)
 			self._discard_staging_calendar(service, staging_calendar_id, logger)
 			staging_calendar_id = None

--- a/suite/mail/doctype/contacts_exchange/contacts_exchange.py
+++ b/suite/mail/doctype/contacts_exchange/contacts_exchange.py
@@ -324,6 +324,8 @@ class ContactsExchange(Document):
 		os.makedirs(base_dir, exist_ok=True)
 
 		kwargs = {}
+		service = None
+		staging_address_book_id = None
 		try:
 			if self.import_format == "vcf" and self.import_file.endswith(".vcf"):
 				shutil.copy(import_file, os.path.join(base_dir, os.path.basename(import_file)))
@@ -348,24 +350,34 @@ class ContactsExchange(Document):
 			if len(cards) > self.max_import:
 				frappe.throw(_("Import limit exceeded."))
 
-			created, skipped, failed = self._create_cards(service, cards, logger)
+			# Stage everything into one throwaway address book first, then move it to the destination
+			# address book(s). A failure before the move leaves nothing scattered across the account: the
+			# staging address book and every card in it are deleted on rollback.
+			staging_address_book_id = self._create_staging_address_book(service, logger)
+			targets, skipped, failed = self._create_cards(service, cards, staging_address_book_id, logger)
 
+			# The server rejecting every card (e.g. an invalid target address book) is a failure,
+			# not a successful zero-import.
+			if not targets and failed > 0:
+				frappe.throw(_("Import failed: the server rejected all {0} contact(s).").format(failed))
+
+			self._move_to_target_address_books(service, targets, logger)
+			self._discard_staging_address_book(service, staging_address_book_id, logger)
+			staging_address_book_id = None
+
+			created = len(targets)
 			logger.info("import-completed", created=created, skipped=skipped, failed=failed)
 			self._log_output(
 				_("Import completed. {0} created, {1} skipped (already present), {2} failed.").format(
 					created, skipped, failed
 				)
 			)
-
-			# The server rejecting every card (e.g. an invalid target address book) is a failure,
-			# not a successful zero-import.
-			if created == 0 and failed > 0:
-				frappe.throw(_("Import failed: the server rejected all {0} contact(s).").format(failed))
-
 			kwargs.update({"status": "Completed"})
 		except Exception:
 			logger.exception("import-failed")
 			self._log_output(_("Import failed. See the error details below."))
+			if staging_address_book_id and service:
+				self._rollback_staging_address_book(service, staging_address_book_id, logger)
 			kwargs.update(
 				{"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
 			)
@@ -554,13 +566,36 @@ class ContactsExchange(Document):
 
 		return cards
 
-	def _create_cards(
-		self, service: ContactCardService, cards: list[dict], logger: ExchangeLogger
-	) -> tuple[int, int, int]:
-		"""Creates the given JSContact cards, skipping any whose UID already exists (idempotency).
+	def _create_staging_address_book(self, service: ContactCardService, logger: ExchangeLogger) -> str:
+		"""Creates a temporary address book (named after this exchange) to stage the import into."""
 
-		Returns a ``(created, skipped, failed)`` tuple. Failures within a batch are recorded and the
-		remaining batches continue, so a few malformed cards do not abort the whole import."""
+		self._log_output(_("Creating a temporary address book to stage the import."))
+		response = AddressBookService(service.account, service.connection).create(
+			[{"creation_id": str(uuid7()), "name": self.name, "is_subscribed": False}]
+		)
+		created = response.get("created") or {}
+		if not created:
+			frappe.throw(
+				_("Failed to create the staging address book: {0}").format(response.get("notCreated"))
+			)
+
+		staging_address_book_id = next(iter(created.values()))["id"]
+		logger.info("import-staging-address-book-created", address_book=staging_address_book_id)
+		return staging_address_book_id
+
+	def _create_cards(
+		self,
+		service: ContactCardService,
+		cards: list[dict],
+		staging_address_book_id: str,
+		logger: ExchangeLogger,
+	) -> tuple[dict[str, dict[str, bool]], int, int]:
+		"""Creates the given JSContact cards in the staging address book, skipping any whose UID already
+		exists (idempotency).
+
+		Returns a ``(targets, skipped, failed)`` tuple, where ``targets`` maps each created card's ID to
+		the destination addressBookIds it should ultimately land in. Failures within a batch are recorded
+		and the remaining batches continue, so a few malformed cards do not abort the whole import."""
 
 		# Idempotency: skip cards whose UID is already present in the account.
 		uids = [c["uid"] for c in cards if c.get("uid")]
@@ -592,41 +627,96 @@ class ContactsExchange(Document):
 				continue
 			pending.append(card)
 
-		created = 0
+		targets: dict[str, dict[str, bool]] = {}
 		failed = 0
 		total = len(pending)
 		for batch in create_batch(pending, service.max_objects_in_set):
 			payload: dict[str, dict] = {}
-			creation_to_uid: dict[str, str] = {}
+			creation_meta: dict[str, tuple[str, dict]] = {}
 			for card in batch:
+				# Resolve the destination before overwriting addressBookIds with the staging book.
+				destination = resolve_address_book_ids(card)
 				card = {k: v for k, v in card.items() if k not in SERVER_MANAGED_KEYS}
 				card["@type"] = "Card"
 				card.setdefault("version", "1.0")
-				card["addressBookIds"] = resolve_address_book_ids(card)
+				card["addressBookIds"] = {staging_address_book_id: True}
 
 				creation_id = str(uuid7())
 				payload[creation_id] = card
-				creation_to_uid[creation_id] = card.get("uid", creation_id)
+				creation_meta[creation_id] = (card.get("uid", creation_id), destination)
 
 			response = service._create(payload)
 			method_responses = response.get("methodResponses") or []
 			result = method_responses[0][1] if method_responses else {}
 
-			batch_created = result.get("created") or {}
 			batch_failed = result.get("notCreated") or {}
-			created += len(batch_created)
 			failed += len(batch_failed)
+
+			for creation_id, info in (result.get("created") or {}).items():
+				targets[info["id"]] = creation_meta[creation_id][1]
 
 			for creation_id, error in batch_failed.items():
 				logger.warning(
 					"import-card-not-created",
-					uid=creation_to_uid.get(creation_id),
+					uid=creation_meta.get(creation_id, (None,))[0],
 					reason=str(error),
 				)
 
-			self._log_output(_("Imported {0} of {1} contact(s).").format(created, total))
+			self._log_output(_("Staged {0} of {1} contact(s).").format(len(targets), total))
 
-		return created, skipped, failed
+		return targets, skipped, failed
+
+	def _move_to_target_address_books(
+		self, service: ContactCardService, targets: dict[str, dict[str, bool]], logger: ExchangeLogger
+	) -> None:
+		"""Moves the staged cards into their destination address books, replacing the staging book.
+
+		This is the commit step: until it runs, every card lives only in the staging address book, so a
+		failure up to this point rolls back cleanly."""
+
+		if not targets:
+			return
+
+		self._log_output(
+			_("Moving {0} contact(s) into the destination address book(s).").format(len(targets))
+		)
+		result = service.set_address_book_ids(targets)
+
+		if not_updated := result.get("notUpdated"):
+			logger.warning("import-card-not-moved", count=len(not_updated))
+			frappe.throw(
+				_("Failed to move {0} contact(s) into the destination address book(s).").format(
+					len(not_updated)
+				)
+			)
+
+		logger.info("import-cards-moved", cards=len(result.get("updated", [])))
+
+	def _discard_staging_address_book(
+		self, service: ContactCardService, staging_address_book_id: str, logger: ExchangeLogger
+	) -> None:
+		"""Deletes the now-empty staging address book after a successful import. A failure here is logged
+		but not fatal: the cards are already safely in their destination address books."""
+
+		try:
+			AddressBookService(service.account, service.connection).delete([staging_address_book_id])
+			logger.info("import-staging-address-book-removed", address_book=staging_address_book_id)
+		except Exception:
+			logger.warning("import-staging-address-book-remove-failed", address_book=staging_address_book_id)
+
+	def _rollback_staging_address_book(
+		self, service: ContactCardService, staging_address_book_id: str, logger: ExchangeLogger
+	) -> None:
+		"""Deletes the staging address book and every card still staged in it, undoing a failed import."""
+
+		self._log_output(_("Rolling back: removing the staging address book and any staged contacts."))
+		try:
+			AddressBookService(service.account, service.connection).delete(
+				[staging_address_book_id], remove_contents=True
+			)
+			logger.info("import-rolled-back", address_book=staging_address_book_id)
+		except Exception:
+			logger.exception("import-rollback-failed", address_book=staging_address_book_id)
 
 	def _mark_started(self) -> None:
 		"""Marks the contacts exchange as started and updates the started_at and started_after fields."""

--- a/suite/mail/doctype/mail_exchange/mail_exchange.py
+++ b/suite/mail/doctype/mail_exchange/mail_exchange.py
@@ -954,9 +954,11 @@ class MailExchange(Document):
 			logger.debug("import-batch-processed", batch=len(batch), imported=len(imported), total=total)
 			self._log_output(_("Staged {0} of {1} email(s).").format(len(imported), total))
 
-		# The server rejecting every email (e.g. an invalid destination) is a failure, not a
-		# successful zero-import, and must trigger a rollback.
-		if not imported:
+		# `metadata` is non-empty here (an empty import is rejected upstream), so an empty `imported`
+		# means the server rejected every email — a failure that must roll back. Guarding on `total`
+		# keeps this from ever misreporting an empty input as "rejected all 0". Unlike calendar/contacts
+		# there is no idempotency-skip, so `not imported` already means "all rejected".
+		if total and not imported:
 			frappe.throw(_("Import failed: the server rejected all {0} email(s).").format(total))
 
 		return imported

--- a/suite/mail/doctype/mail_exchange/mail_exchange.py
+++ b/suite/mail/doctype/mail_exchange/mail_exchange.py
@@ -38,6 +38,7 @@ from suite.mail.doctype.push_subscription.push_subscription import (
 from suite.mail.doctype.user_account.user_account import is_jmap_account_belongs_to_user
 from suite.mail.jmap import get_jmap_connection
 from suite.mail.jmap.services.mail.email import EmailService
+from suite.mail.jmap.services.mail.mailbox import MailboxService
 from suite.mail.utils import (
 	get_config,
 	get_mail_export_directory,
@@ -728,6 +729,8 @@ class MailExchange(Document):
 		os.makedirs(base_dir, exist_ok=True)
 
 		kwargs = {}
+		service = None
+		staging_mailbox_id = None
 		try:
 			if self.import_format == "eml" and self.import_file.endswith(".eml"):
 				shutil.copy(import_file, os.path.join(base_dir, os.path.basename(import_file)))
@@ -753,15 +756,25 @@ class MailExchange(Document):
 			if len(meta) > self.max_import:
 				frappe.throw(_("Import limit exceeded."))
 
-			self._import_batches(service, base_dir, meta, logger)
+			# Stage everything into one throwaway mailbox first, then move it to the destination
+			# mailbox(es). A failure before the move leaves nothing scattered across the account: the
+			# staging mailbox and every email in it are deleted on rollback.
+			staging_mailbox_id = self._create_staging_mailbox(service, logger)
+			imported = self._import_batches(service, base_dir, meta, staging_mailbox_id, logger)
+			self._move_to_target_mailboxes(service, imported, logger)
+			self._discard_staging_mailbox(service, staging_mailbox_id, logger)
+			staging_mailbox_id = None
+
 			clear_sync_state(self.account, type="email")
 
-			logger.info("import-completed", emails=len(meta))
-			self._log_output(_("Import completed successfully. {0} email(s) imported.").format(len(meta)))
+			logger.info("import-completed", emails=len(imported))
+			self._log_output(_("Import completed successfully. {0} email(s) imported.").format(len(imported)))
 			kwargs.update({"status": "Completed"})
 		except Exception:
 			logger.exception("import-failed")
 			self._log_output(_("Import failed. See the error details below."))
+			if staging_mailbox_id and service:
+				self._rollback_staging_mailbox(service, staging_mailbox_id, logger)
 			kwargs.update(
 				{"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
 			)
@@ -872,17 +885,34 @@ class MailExchange(Document):
 
 		self._db_set(**kwargs)
 
+	def _create_staging_mailbox(self, service: EmailService, logger: ExchangeLogger) -> str:
+		"""Creates a temporary mailbox (named after this exchange) to stage the import into."""
+
+		self._log_output(_("Creating a temporary folder to stage the import."))
+		response = MailboxService(service.account, service.connection).create(
+			[{"creation_id": str(uuid7()), "name": self.name, "is_subscribed": False}]
+		)
+		created = response.get("created") or {}
+		if not created:
+			frappe.throw(_("Failed to create the staging folder: {0}").format(response.get("notCreated")))
+
+		staging_mailbox_id = next(iter(created.values()))["id"]
+		logger.info("import-staging-mailbox-created", mailbox=staging_mailbox_id)
+		return staging_mailbox_id
+
 	def _import_batches(
 		self,
 		service: EmailService,
 		base_dir: str,
 		metadata: list[ImportEmailMeta],
+		staging_mailbox_id: str,
 		logger: ExchangeLogger,
-	) -> None:
-		"""Imports emails in batches using the EmailService."""
+	) -> dict[str, dict[str, bool]]:
+		"""Imports emails into the staging mailbox in batches, returning a map of each created email's
+		ID to the destination mailboxIds it should ultimately land in."""
 
 		total = len(metadata)
-		imported = 0
+		imported: dict[str, dict[str, bool]] = {}
 		batch_size = service.max_objects_in_set
 		for batch in create_batch(metadata, batch_size):
 			blobs: list[tuple[bytes, str]] = []
@@ -892,16 +922,18 @@ class MailExchange(Document):
 
 			responses = service.upload_blobs_concurrently(blobs)
 			emails = {}
+			targets: dict[str, dict[str, bool]] = {}
 			for i, resp in enumerate(responses):
 				meta = batch[i]
 				emails[f"e{i}"] = {
 					"blobId": resp["blobId"],
-					"mailboxIds": {mid: True for mid in meta.mailbox_ids},
+					"mailboxIds": {staging_mailbox_id: True},
 					"keywords": {k: True for k in meta.keywords or []},
 					"receivedAt": meta.received_at.isoformat(),
 				}
+				targets[f"e{i}"] = {mid: True for mid in meta.mailbox_ids}
 
-			service._call(
+			response = service._call(
 				capabilities=service.capabilities,
 				method_calls=[
 					[
@@ -911,10 +943,69 @@ class MailExchange(Document):
 					]
 				],
 			)
+			method_responses = response.get("methodResponses") or []
+			result = method_responses[0][1] if method_responses else {}
 
-			imported += len(batch)
-			logger.debug("import-batch-processed", batch=len(batch), imported=imported, total=total)
-			self._log_output(_("Imported {0} of {1} email(s).").format(imported, total))
+			for creation_id, info in (result.get("created") or {}).items():
+				imported[info["id"]] = targets.get(creation_id, {})
+			for creation_id, error in (result.get("notCreated") or {}).items():
+				logger.warning("import-email-not-created", creation_id=creation_id, reason=str(error))
+
+			logger.debug("import-batch-processed", batch=len(batch), imported=len(imported), total=total)
+			self._log_output(_("Staged {0} of {1} email(s).").format(len(imported), total))
+
+		# The server rejecting every email (e.g. an invalid destination) is a failure, not a
+		# successful zero-import, and must trigger a rollback.
+		if not imported:
+			frappe.throw(_("Import failed: the server rejected all {0} email(s).").format(total))
+
+		return imported
+
+	def _move_to_target_mailboxes(
+		self, service: EmailService, imported: dict[str, dict[str, bool]], logger: ExchangeLogger
+	) -> None:
+		"""Moves the staged emails into their destination mailboxes, replacing the staging mailbox.
+
+		This is the commit step: until it runs, every email lives only in the staging mailbox, so a
+		failure up to this point rolls back cleanly."""
+
+		self._log_output(_("Moving {0} email(s) into the destination folder(s).").format(len(imported)))
+		emails = [{"id": email_id, "mailbox_ids": mailbox_ids} for email_id, mailbox_ids in imported.items()]
+		result = service.update(emails, replace_mailboxes=True)
+
+		if not_updated := result.get("notUpdated"):
+			logger.warning("import-email-not-moved", count=len(not_updated))
+			frappe.throw(
+				_("Failed to move {0} email(s) into the destination folder(s).").format(len(not_updated))
+			)
+
+		logger.info("import-emails-moved", emails=len(result.get("updated", [])))
+
+	def _discard_staging_mailbox(
+		self, service: EmailService, staging_mailbox_id: str, logger: ExchangeLogger
+	) -> None:
+		"""Deletes the now-empty staging mailbox after a successful import. A failure here is logged
+		but not fatal: the emails are already safely in their destination folders."""
+
+		try:
+			MailboxService(service.account, service.connection).delete([staging_mailbox_id])
+			logger.info("import-staging-mailbox-removed", mailbox=staging_mailbox_id)
+		except Exception:
+			logger.warning("import-staging-mailbox-remove-failed", mailbox=staging_mailbox_id)
+
+	def _rollback_staging_mailbox(
+		self, service: EmailService, staging_mailbox_id: str, logger: ExchangeLogger
+	) -> None:
+		"""Deletes the staging mailbox and every email still staged in it, undoing a failed import."""
+
+		self._log_output(_("Rolling back: removing the staging folder and any staged emails."))
+		try:
+			MailboxService(service.account, service.connection).delete(
+				[staging_mailbox_id], remove_emails=True
+			)
+			logger.info("import-rolled-back", mailbox=staging_mailbox_id)
+		except Exception:
+			logger.exception("import-rollback-failed", mailbox=staging_mailbox_id)
 
 	def _export_batches(
 		self,

--- a/suite/mail/jmap/services/calendars/calendar_event.py
+++ b/suite/mail/jmap/services/calendars/calendar_event.py
@@ -153,6 +153,27 @@ class CalendarEventService(CalendarsService):
 
 		return result
 
+	def set_calendar_ids(self, mapping: dict[str, dict[str, bool]]) -> dict:
+		"""Replaces the calendarIds of each given event with the provided map, batching to stay within
+		the server's per-'set' limit.
+
+		Used by the import rollback flow to move events out of the staging calendar into their final
+		calendar(s) once every event has been created; only calendarIds is touched, so the rest of the
+		event is left untouched."""
+
+		result = {"updated": [], "notUpdated": {}}
+		for batch in self.create_batches(list(mapping.items()), self.max_objects_in_set):
+			payload = {id: {"calendarIds": calendar_ids, "updated": utcnow()} for id, calendar_ids in batch}
+
+			response = self._update(payload)
+
+			if method_responses := response.get("methodResponses"):
+				result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+				if not_updated := method_responses[0][1].get("notUpdated", {}):
+					result["notUpdated"].update(not_updated)
+
+		return result
+
 	def delete(self, ids: list[str]) -> dict:
 		"""Public method to delete calendar events, handling batching if the number of events exceeds the server's maximum allowed in a single 'set' call."""
 

--- a/suite/mail/jmap/services/calendars/calendar_event.py
+++ b/suite/mail/jmap/services/calendars/calendar_event.py
@@ -161,9 +161,11 @@ class CalendarEventService(CalendarsService):
 		calendar(s) once every event has been created; only calendarIds is touched, so the rest of the
 		event is left untouched."""
 
+		# `updated` is server-managed for CalendarEvent (it is stripped on create; see the exchange's
+		# SERVER_MANAGED_KEYS), so patch calendarIds only and let the server set the timestamp itself.
 		result = {"updated": [], "notUpdated": {}}
 		for batch in self.create_batches(list(mapping.items()), self.max_objects_in_set):
-			payload = {id: {"calendarIds": calendar_ids, "updated": utcnow()} for id, calendar_ids in batch}
+			payload = {id: {"calendarIds": calendar_ids} for id, calendar_ids in batch}
 
 			response = self._update(payload)
 

--- a/suite/mail/jmap/services/contacts/contact_card.py
+++ b/suite/mail/jmap/services/contacts/contact_card.py
@@ -333,9 +333,11 @@ class ContactCardService(ContactsService):
 		address book(s) once every card has been created; only addressBookIds is touched, so the rest of
 		the card is left untouched."""
 
+		# Mirror set_calendar_ids: patch addressBookIds only and let the server manage the `updated`
+		# timestamp, so we never depend on `updated` being client-writable for ContactCard.
 		result = {"updated": [], "notUpdated": {}}
 		for batch in self.create_batches(list(mapping.items()), self.max_objects_in_set):
-			payload = {id: {"addressBookIds": book_ids, "updated": utcnow()} for id, book_ids in batch}
+			payload = {id: {"addressBookIds": book_ids} for id, book_ids in batch}
 
 			response = self._update(payload)
 

--- a/suite/mail/jmap/services/contacts/contact_card.py
+++ b/suite/mail/jmap/services/contacts/contact_card.py
@@ -325,6 +325,27 @@ class ContactCardService(ContactsService):
 
 		return result
 
+	def set_address_book_ids(self, mapping: dict[str, dict[str, bool]]) -> dict:
+		"""Replaces the addressBookIds of each given card with the provided map, batching to stay within
+		the server's per-'set' limit.
+
+		Used by the import rollback flow to move cards out of the staging address book into their final
+		address book(s) once every card has been created; only addressBookIds is touched, so the rest of
+		the card is left untouched."""
+
+		result = {"updated": [], "notUpdated": {}}
+		for batch in self.create_batches(list(mapping.items()), self.max_objects_in_set):
+			payload = {id: {"addressBookIds": book_ids, "updated": utcnow()} for id, book_ids in batch}
+
+			response = self._update(payload)
+
+			if method_responses := response.get("methodResponses"):
+				result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+				if not_updated := method_responses[0][1].get("notUpdated", {}):
+					result["notUpdated"].update(not_updated)
+
+		return result
+
 	@staticmethod
 	def _get_name_map(full_name: str | None = None) -> dict:
 		"""Helper method to construct the 'name' property map for a contact card based on the provided full name."""


### PR DESCRIPTION
## Summary

Implements the rollback mechanism from #55 for all three JMAP-based importers (Mail, Calendar, Contacts Exchange).

Each import now runs **staged**: everything lands in one throwaway container first, and is only moved to its real destination once the whole batch has imported successfully. A failure at any point before the move deletes the staging container and everything staged in it — so the account is never left with a half-finished import.

**Per import (identical shape across the three doctypes):**
1. **Create staging container** — a mailbox / calendar / address book named after `Exchange.name`, hidden (`is_subscribed=False`).
2. **Import into staging** — items are created in the staging container only; each item's real destination (`mailboxIds` / `calendarIds` / `addressBookIds`, resolved from metadata, per-item source, or the account default) is remembered in a `created-id → destination` map.
3. **Commit** — move every staged item into its destination in one batched `set` update (staging is replaced by the destination).
4. **Discard** the now-empty staging container on success (a delete failure here is logged, not fatal — the data is already safe).
5. **Rollback** on any failure — delete the staging container with `remove_emails` / `remove_events` / `remove_contents=True`, wiping the container and every item still staged in it.

## Changes

- `jmap/services/calendars/calendar_event.py` — add `set_calendar_ids(mapping)` (per-event `calendarIds`-only patch).
- `jmap/services/contacts/contact_card.py` — add `set_address_book_ids(mapping)` (per-card `addressBookIds`-only patch).
- `mail_exchange.py` — add staging/move/discard/rollback helpers; `_import_batches` now imports into staging and returns the id→destination map (email moves reuse `EmailService.update(..., replace_mailboxes=True)`).
- `calendar_exchange.py` / `contacts_exchange.py` — parallel staging/move/discard/rollback helpers; `_create_events` / `_create_cards` now stage and return `(targets, skipped, failed)`.

Existing idempotency (skip already-present UIDs), batch limits, and the "server rejected everything → fail" guard are preserved.

## Note

JMAP has no cross-object transaction, so the commit is the atomicity boundary: if the *move* itself partially fails, items already moved stay committed while the rest roll back. Full atomicity holds for failures during the staging phase, which is where mid-import failures realistically occur.

Closes #55