### PR TITLE
fix(sheets): hide filter/pivot outlines behind open dialogs

### DIFF
--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -5944,4 +5944,14 @@ function toggleShowFormulas() {
   max-height: min(60vh, 480px);
   overflow-y: auto;
 }
+
+/* A Frappe UI Dialog draws a translucent (~12% black) scrim over the grid.
+   The filter-range outline and pivot-output highlight are full-height dark
+   1.5px borders spanning the whole data region, so their vertical borders stay
+   visible THROUGH that scrim and flank the open dialog — reading as a line
+   cutting across it (e.g. the Share dialog while a filter is active). Hide
+   those decorations whenever a dialog is up. `.dialog-overlay` portals to
+   <body>, so `:has` from body catches every one. */
+body:has(.dialog-overlay) .sn-filter-range,
+body:has(.dialog-overlay) .sn-pivot-highlight { display: none; }
 </style>


### PR DESCRIPTION
## Problem

When a filter (or pivot) is active and you open a Frappe UI dialog — most visibly the **Share** dialog — a dark vertical line appears cutting across the dialog.

The line is the **filter-range outline** (`.sn-filter-range`) — and equivalently the pivot-output highlight (`.sn-pivot-highlight`). Both are full-height `1.5px solid var(--ink-gray-8)` borders drawn around the whole data region.

## Why it happens

They correctly sit *below* the dialog (the outlines are `z-index: 14/15`), but the dialog's overlay scrim is only ~12% black — **translucent**. On a filtered dataset the outline spans the entire data height, so its vertical borders run the full viewport and stay visible *through* the scrim, flanking the dialog and reading as a line across it. It's a paint-through-a-translucent-scrim issue, not a z-order one.

## Fix

Hide these full-region grid decorations while any dialog is open:

```css
body:has(.dialog-overlay) .sn-filter-range,
body:has(.dialog-overlay) .sn-pivot-highlight { display: none; }
```

`.dialog-overlay` portals to `<body>`, so `:has` from `body` catches every Frappe UI dialog. The outlines return the moment the dialog closes.

## Testing

Verified end-to-end in the running app: with a filter active, the flanking line is gone while the Share dialog is open, and the outline reappears on close. Scoped strictly to dialog-open state — no change to normal grid rendering.