### PR TITLE
feat(sheets): overlay scrollbars for the grid

### DIFF
--- a/frontend/src/apps/sheets/canvas/constants.js
+++ b/frontend/src/apps/sheets/canvas/constants.js
@@ -2,6 +2,9 @@ export const COL_HEADER_H  = 24
 export const ROW_HEADER_W  = 50
 export const DEFAULT_COL_W = 100
 export const DEFAULT_ROW_H = 24
+// Thickness of the overlay scrollbars (see canvas/scrollbars.js). Shared so DOM
+// overlays (filter/pivot outlines) can keep clear of the scrollbar gutter.
+export const SCROLLBAR_THICK = 12
 // Default grid size a fresh/empty sub-sheet shows (Google-Sheets-like). The
 // live counts below grow past these when a sheet's data needs it, and reset
 // back to them per sub-sheet on switch so a 100k-row source doesn't leave every

--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -1,6 +1,7 @@
 import { createGeometry } from './geometry.js'
 import { createRenderer } from './renderer.js'
 import { createOverlay }  from './overlay.js'
+import { createScrollbars } from './scrollbars.js'
 import { TOTAL_ROWS, TOTAL_COLS, DEFAULT_TOTAL_ROWS, DEFAULT_TOTAL_COLS, DEFAULT_ROW_H, ROW_HEADER_W, COL_HEADER_H, setTotalRows, setTotalCols } from './constants.js'
 import { cellId, colLabel, parseCellId } from '../utils/cells.js'
 import { AC_FUNS, AC_FUN_KEYS, parseAcToken, parseSignatureContext, describeSignature } from '../utils/formula-ac.js'
@@ -72,6 +73,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
   const geo      = createGeometry(colW, rowH, scroll, freeze, hiddenRows, hiddenCols, () => _zoom, filterHiddenRows)
   const renderer = createRenderer(ctx, geo)
   const overlay  = createOverlay(canvas.parentElement)
+  const scrollbars = createScrollbars(canvas.parentElement, { getModel: () => _scrollModel(), scrollTo })
   _acSetup()
 
   // ── Render ──────────────────────────────────────────────────────────────────
@@ -111,6 +113,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
 
   function render() {
     renderer.render({ cssW, cssH, getValue, sel, selEnd, selMode, editing, getFormat, freeze, getMergeInfo, isSlave, getComment, getValidation, getCondFormat, getSparkline, getRightInset, getDiffFor: _diffCells ? _getDiffFor : null, marchAnts, marchPhase, pickerRect, zoom: _zoom })
+    scrollbars.layout()
     for (const cb of _renderListeners) cb()
   }
 
@@ -188,13 +191,48 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
   // Max scroll so the last col/row sits flush with the viewport's right/bottom.
   // Beyond this we'd just be showing empty canvas past the sheet — Google
   // Sheets clamps to here, so do we.
-  function _sheetTotalW() { let w = 0; for (let c = 0; c < TOTAL_COLS; c++) w += geo.cw(c); return w }
-  function _sheetTotalH() { let h = 0; for (let r = 0; r < TOTAL_ROWS; r++) h += geo.rh(r); return h }
-  function _maxScrollX()  { return Math.max(0, _sheetTotalW() + ROW_HEADER_W - cssW) }
-  function _maxScrollY()  { return Math.max(0, _sheetTotalH() + COL_HEADER_H - cssH) }
+  // Full sheet extent incl. the header gutter, in logical px. Summing every
+  // column/row is O(cols+rows) — up to tens of thousands of iterations — so we
+  // cache it and recompute only in `_applyCanvasSize`, the single choke point
+  // every structural change (resize, col/row size, expand, freeze, hide) routes
+  // through. Scroll clamping and the scrollbar model then read it for free.
+  let _contentW = ROW_HEADER_W, _contentH = COL_HEADER_H
+  function _recomputeExtent() {
+    let w = 0; for (let c = 0; c < TOTAL_COLS; c++) w += geo.cw(c)
+    let h = 0; for (let r = 0; r < TOTAL_ROWS; r++) h += geo.rh(r)
+    _contentW = w + ROW_HEADER_W
+    _contentH = h + COL_HEADER_H
+  }
+  function _maxScrollX()  { return Math.max(0, _contentW - cssW) }
+  function _maxScrollY()  { return Math.max(0, _contentH - cssH) }
   function _clampScroll() {
     scroll.x = Math.max(0, Math.min(scroll.x, _maxScrollX()))
     scroll.y = Math.max(0, Math.min(scroll.y, _maxScrollY()))
+  }
+
+  // Single entry point for setting the scroll offset (logical units). Used by
+  // the wheel handler and the overlay scrollbars so both keep the in-cell
+  // editor pinned to its cell and repaint. Values are clamped to the sheet.
+  function scrollTo(x, y) {
+    scroll.x = x
+    scroll.y = y
+    _clampScroll()
+    if (editing) {
+      const fmt = getFormat ? getFormat(cellId(sel.r, sel.c)) : {}
+      overlay.position(geo.colX(sel.c) * _zoom, geo.rowY(sel.r) * _zoom, geo.cw(sel.c) * _zoom, geo.rh(sel.r) * _zoom, fmt, _zoom)
+    }
+    render()
+  }
+
+  // Scroll model consumed by the overlay scrollbars — everything the thumbs
+  // need to size and position themselves, in logical units (the scrollbars work
+  // in ratios, so zoom cancels out). `content` is the full sheet extent incl.
+  // the header gutter; `view` is the visible logical span.
+  function _scrollModel() {
+    return {
+      x: { pos: scroll.x, max: _maxScrollX(), view: cssW, content: _contentW },
+      y: { pos: scroll.y, max: _maxScrollY(), view: cssH, content: _contentH },
+    }
   }
 
   function ensureVisible(r, c) {
@@ -1322,14 +1360,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     e.preventDefault()
     // Wheel deltas are physical pixels; scroll is logical. Divide so a single
     // notch advances the same logical distance regardless of zoom.
-    scroll.x += e.deltaX / _zoom
-    scroll.y += e.deltaY / _zoom
-    _clampScroll()
-    if (editing) {
-      const fmt = getFormat ? getFormat(cellId(sel.r, sel.c)) : {}
-      overlay.position(geo.colX(sel.c) * _zoom, geo.rowY(sel.r) * _zoom, geo.cw(sel.c) * _zoom, geo.rh(sel.r) * _zoom, fmt, _zoom)
-    }
-    render()
+    scrollTo(scroll.x + e.deltaX / _zoom, scroll.y + e.deltaY / _zoom)
   }, { passive: false })
 
   canvas.setAttribute('tabindex', '0')
@@ -1456,8 +1487,9 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     // smaller area while the on-screen pixels stay constant. The canvas's
     // *physical* size is tied to the viewport (×dpr ×zoom), so high-DPI plus
     // zoom both contribute to backing-store resolution.
-    const sheetW = _sheetTotalW() + ROW_HEADER_W
-    const sheetH = _sheetTotalH() + COL_HEADER_H
+    _recomputeExtent()
+    const sheetW = _contentW
+    const sheetH = _contentH
     const viewLogicalW = _viewportW / _zoom
     const viewLogicalH = _viewportH / _zoom
     cssW = Math.min(viewLogicalW, sheetW)
@@ -1510,6 +1542,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
 
   function destroy() {
     overlay.remove()
+    scrollbars.destroy()
     _acEl?.remove()
     if (_raf)       { cancelAnimationFrame(_raf);       _raf = null }
     if (_marchRAF)  { cancelAnimationFrame(_marchRAF);  _marchRAF = null }

--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -203,6 +203,10 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     _contentW = w + ROW_HEADER_W
     _contentH = h + COL_HEADER_H
   }
+  // Prime the cache at construction so _clampScroll / scrollTo are correct even
+  // before the first resize() → _applyCanvasSize. Otherwise the header-only
+  // seed values above would clamp any pre-resize scroll to ~0.
+  _recomputeExtent()
   function _maxScrollX()  { return Math.max(0, _contentW - cssW) }
   function _maxScrollY()  { return Math.max(0, _contentH - cssH) }
   function _clampScroll() {

--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -236,6 +236,11 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     return {
       x: { pos: scroll.x, max: _maxScrollX(), view: cssW, content: _contentW },
       y: { pos: scroll.y, max: _maxScrollY(), view: cssH, content: _contentH },
+      // Physical viewport (the grid-wrap's content box). Lets the scrollbars
+      // size their tracks arithmetically instead of reading clientWidth/Height
+      // each render — avoiding a forced reflow in the scroll/selection hot path.
+      viewportW: _viewportW,
+      viewportH: _viewportH,
     }
   }
 

--- a/frontend/src/apps/sheets/canvas/scrollbars.js
+++ b/frontend/src/apps/sheets/canvas/scrollbars.js
@@ -97,14 +97,21 @@ export function createScrollbars(host, { getModel, scrollTo }) {
     hTrack.style.right   = showV ? THICK + 'px' : '0'
     corner.style.display = showV && showH ? 'block' : 'none'
 
+    // Track length = the viewport minus the perpendicular bar's gutter. Derived
+    // from the model's physical viewport rather than read from the DOM, so this
+    // hot path (every scroll / selection render) writes styles without ever
+    // reading clientWidth/Height — no forced synchronous reflow.
+    const vTrackPx = m.viewportH - (showH ? THICK : 0)
+    const hTrackPx = m.viewportW - (showV ? THICK : 0)
+
     if (showV) {
-      const g = geom.y = measure(vTrack.clientHeight, m.y)
+      const g = geom.y = measure(vTrackPx, m.y)
       vThumb.style.height    = g.thumbPx + 'px'
       vThumb.style.transform = `translateY(${g.offset}px)`
       vTrack.setAttribute('aria-valuenow', String(Math.round(g.posFrac * 100)))
     }
     if (showH) {
-      const g = geom.x = measure(hTrack.clientWidth, m.x)
+      const g = geom.x = measure(hTrackPx, m.x)
       hThumb.style.width     = g.thumbPx + 'px'
       hThumb.style.transform = `translateX(${g.offset}px)`
       hTrack.setAttribute('aria-valuenow', String(Math.round(g.posFrac * 100)))

--- a/frontend/src/apps/sheets/canvas/scrollbars.js
+++ b/frontend/src/apps/sheets/canvas/scrollbars.js
@@ -1,0 +1,180 @@
+// Overlay scrollbars for the canvas grid.
+//
+// The grid owns its scroll position as a logical `{x, y}` offset, driven by the
+// wheel handler and keyboard navigation. These scrollbars are a draggable DOM
+// affordance layered over that same state — they don't own it. On every render
+// they re-read the grid's scroll model and resize/reposition their thumbs; on
+// drag or track-click they write back through `scrollTo`.
+//
+// Everything here is fraction-based (pos/max, view/content) so it stays correct
+// at any zoom without the module needing to know logical-vs-physical units: the
+// track's physical pixel length is the only device measurement it takes.
+//
+// Dragging uses Pointer Events with pointer capture so a fast drag that outruns
+// the thumb keeps tracking, and so touch / pen work alongside the mouse.
+//
+// The bars auto-hide: they fade in on scroll, on pointer movement over the grid,
+// and while hovered/dragged, then fade back out after a spell of inactivity —
+// the modern overlay-scrollbar behaviour. When hidden they drop pointer-events
+// so the cells beneath the gutter stay clickable.
+
+import { SCROLLBAR_THICK as THICK } from './constants.js'
+
+const MIN_THUMB  = 24    // floor on thumb length so it stays grabbable near the ends
+const HIDE_DELAY = 1400  // ms of inactivity before the bars fade out
+
+export function createScrollbars(host, { getModel, scrollTo }) {
+  const el = cls => { const d = document.createElement('div'); d.className = cls; return d }
+
+  const vTrack = el('sn-sb sn-sb-v'); const vThumb = el('sn-sb-thumb'); vTrack.appendChild(vThumb)
+  const hTrack = el('sn-sb sn-sb-h'); const hThumb = el('sn-sb-thumb'); hTrack.appendChild(hThumb)
+  // Opaque filler for the square where the two tracks meet — without it the
+  // canvas (cell fills, chevrons) shows through the corner gap.
+  const corner = el('sn-sb-corner')
+  vTrack.setAttribute('role', 'scrollbar'); vTrack.setAttribute('aria-orientation', 'vertical')
+  hTrack.setAttribute('role', 'scrollbar'); hTrack.setAttribute('aria-orientation', 'horizontal')
+  for (const t of [vTrack, hTrack]) { t.setAttribute('aria-valuemin', '0'); t.setAttribute('aria-valuemax', '100') }
+  host.appendChild(vTrack)
+  host.appendChild(hTrack)
+  host.appendChild(corner)
+
+  // Per-axis geometry cached from the last layout(), read by the drag handlers.
+  const geom = { x: null, y: null }
+
+  // ── Auto-hide ────────────────────────────────────────────────────────────
+  // `_pinned` (hover/drag) suppresses the fade entirely; otherwise a timer
+  // fades the bars out after HIDE_DELAY. layout() calls reveal() whenever the
+  // scroll position changes, so wheel/keyboard scrolling wakes them too.
+  const parts    = [vTrack, hTrack, corner]
+  let _hideTimer = null
+  let _pinned    = false
+  let _lastX = -1, _lastY = -1
+
+  function reveal() {
+    for (const p of parts) p.classList.remove('sn-sb--hidden')
+    if (_hideTimer) { clearTimeout(_hideTimer); _hideTimer = null }
+    if (_pinned) return
+    _hideTimer = setTimeout(() => {
+      _hideTimer = null
+      for (const p of parts) p.classList.add('sn-sb--hidden')
+    }, HIDE_DELAY)
+  }
+  function pin(on) {
+    _pinned = on
+    if (on) { if (_hideTimer) { clearTimeout(_hideTimer); _hideTimer = null }
+              for (const p of parts) p.classList.remove('sn-sb--hidden') }
+    else reveal()
+  }
+
+  const onHostMove = () => reveal()
+  host.addEventListener('pointermove', onHostMove, { passive: true })
+  for (const t of [vTrack, hTrack]) {
+    t.addEventListener('pointerenter', () => pin(true))
+    t.addEventListener('pointerleave', () => pin(false))
+  }
+
+  function measure(trackPx, a) {
+    const thumbPx = Math.max(MIN_THUMB, Math.round(trackPx * Math.min(1, a.view / a.content)))
+    const travel  = Math.max(0, trackPx - thumbPx)
+    const posFrac = a.max > 0 ? a.pos / a.max : 0
+    return { trackPx, thumbPx, travel, offset: posFrac * travel, posFrac, max: a.max }
+  }
+
+  function layout() {
+    const m = getModel()
+    // Any change in scroll position (wheel, keyboard, drag) wakes the bars.
+    if (m.x.pos !== _lastX || m.y.pos !== _lastY) { _lastX = m.x.pos; _lastY = m.y.pos; reveal() }
+    const showV = m.y.max > 1
+    const showH = m.x.max > 1
+    vTrack.style.display = showV ? 'block' : 'none'
+    hTrack.style.display = showH ? 'block' : 'none'
+    // Reserve a corner gutter when both are shown so the tracks don't overlap,
+    // and fill it so nothing shows through where they meet.
+    vTrack.style.bottom  = showH ? THICK + 'px' : '0'
+    hTrack.style.right   = showV ? THICK + 'px' : '0'
+    corner.style.display = showV && showH ? 'block' : 'none'
+
+    if (showV) {
+      const g = geom.y = measure(vTrack.clientHeight, m.y)
+      vThumb.style.height    = g.thumbPx + 'px'
+      vThumb.style.transform = `translateY(${g.offset}px)`
+      vTrack.setAttribute('aria-valuenow', String(Math.round(g.posFrac * 100)))
+    }
+    if (showH) {
+      const g = geom.x = measure(hTrack.clientWidth, m.x)
+      hThumb.style.width     = g.thumbPx + 'px'
+      hThumb.style.transform = `translateX(${g.offset}px)`
+      hTrack.setAttribute('aria-valuenow', String(Math.round(g.posFrac * 100)))
+    }
+  }
+
+  // Set one axis to `pos`, leaving the other where the model has it.
+  function applyAxis(axis, pos) {
+    const m = getModel()
+    if (axis === 'y') scrollTo(m.x.pos, pos)
+    else              scrollTo(pos, m.y.pos)
+  }
+
+  function startDrag(axis, thumb, e) {
+    const g = geom[axis]
+    if (!g || g.travel <= 0 || e.button != null && e.button !== 0) return
+    e.preventDefault()
+    e.stopPropagation()
+    thumb.setPointerCapture?.(e.pointerId)
+    const client0 = axis === 'y' ? e.clientY : e.clientX
+    const off0    = g.offset
+    document.body.classList.add('sn-sb-dragging')
+    pin(true)   // keep bars up for the whole drag, even off the thumb
+    const move = ev => {
+      const client = axis === 'y' ? ev.clientY : ev.clientX
+      const off  = Math.max(0, Math.min(g.travel, off0 + (client - client0)))
+      applyAxis(axis, (off / g.travel) * g.max)
+    }
+    const up = () => {
+      thumb.removeEventListener('pointermove', move)
+      thumb.removeEventListener('pointerup', up)
+      thumb.removeEventListener('pointercancel', up)
+      document.body.classList.remove('sn-sb-dragging')
+      // Release the pin, but only if the pointer isn't still over the track
+      // (pointerenter already set it) — pin(false) restarts the fade timer.
+      pin(false)
+    }
+    // With pointer capture the captured element receives the moves, so listen
+    // on the thumb rather than the document.
+    thumb.addEventListener('pointermove', move)
+    thumb.addEventListener('pointerup', up)
+    thumb.addEventListener('pointercancel', up)
+  }
+
+  // Click in the track gutter (not the thumb) pages toward the click by ~90% of
+  // a viewport — matching the native page-scroll behaviour. scrollTo clamps, so
+  // overshoot at the ends is harmless.
+  function trackClick(axis, track, e) {
+    if (e.target !== track) return
+    const g = geom[axis]
+    if (!g) return
+    const rect = track.getBoundingClientRect()
+    const click = axis === 'y' ? e.clientY - rect.top : e.clientX - rect.left
+    const m = getModel()
+    const page = (axis === 'y' ? m.y.view : m.x.view) * 0.9
+    const dir  = click < g.offset ? -1 : 1
+    applyAxis(axis, (axis === 'y' ? m.y.pos : m.x.pos) + dir * page)
+  }
+
+  vThumb.addEventListener('pointerdown', e => startDrag('y', vThumb, e))
+  hThumb.addEventListener('pointerdown', e => startDrag('x', hThumb, e))
+  vTrack.addEventListener('pointerdown', e => trackClick('y', vTrack, e))
+  hTrack.addEventListener('pointerdown', e => trackClick('x', hTrack, e))
+
+  reveal()   // show on mount, then fade — so they're discoverable on first paint
+
+  function destroy() {
+    if (_hideTimer) clearTimeout(_hideTimer)
+    host.removeEventListener('pointermove', onHostMove)
+    vTrack.remove()
+    hTrack.remove()
+    corner.remove()
+  }
+
+  return { layout, destroy }
+}

--- a/frontend/src/apps/sheets/canvas/scrollbars.js
+++ b/frontend/src/apps/sheets/canvas/scrollbars.js
@@ -37,6 +37,9 @@ export function createScrollbars(host, { getModel, scrollTo }) {
   host.appendChild(vTrack)
   host.appendChild(hTrack)
   host.appendChild(corner)
+  // Publish the track thickness so the CSS (track width/height, corner size)
+  // reads a single source of truth instead of duplicating the pixel value.
+  host.style.setProperty('--sn-sb-thick', THICK + 'px')
 
   // Per-axis geometry cached from the last layout(), read by the drag handlers.
   const geom = { x: null, y: null }
@@ -171,6 +174,7 @@ export function createScrollbars(host, { getModel, scrollTo }) {
   function destroy() {
     if (_hideTimer) clearTimeout(_hideTimer)
     host.removeEventListener('pointermove', onHostMove)
+    host.style.removeProperty('--sn-sb-thick')
     vTrack.remove()
     hTrack.remove()
     corner.remove()

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -5968,9 +5968,12 @@ body:has(.dialog-overlay) .sn-pivot-highlight { display: none; }
 .sn-sb          { position:absolute; z-index:16; background:var(--surface-menu-bar, #f8f8f8);
                   border:0 solid var(--outline-gray-2, #e2e2e2);
                   opacity:1; transition:opacity .2s ease; }
-.sn-sb-v        { top:0; right:0; width:12px; border-left-width:1px; }
-.sn-sb-h        { left:0; bottom:0; height:12px; border-top-width:1px; }
-.sn-sb-corner   { position:absolute; z-index:16; right:0; bottom:0; width:12px; height:12px;
+/* --sn-sb-thick is published by canvas/scrollbars.js from SCROLLBAR_THICK, the
+   single source of truth; the 12px fallback only covers the pre-mount frame. */
+.sn-sb-v        { top:0; right:0; width:var(--sn-sb-thick, 12px); border-left-width:1px; }
+.sn-sb-h        { left:0; bottom:0; height:var(--sn-sb-thick, 12px); border-top-width:1px; }
+.sn-sb-corner   { position:absolute; z-index:16; right:0; bottom:0;
+                  width:var(--sn-sb-thick, 12px); height:var(--sn-sb-thick, 12px);
                   background:var(--surface-menu-bar, #f8f8f8);
                   border-left:1px solid var(--outline-gray-2, #e2e2e2);
                   border-top:1px solid var(--outline-gray-2, #e2e2e2);

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -2687,6 +2687,10 @@ const filterHighlightStyle = computed(() => {
   const headerX = ROW_HEADER_W * zoom
   const right   = br.x + br.width
   const bottom  = br.y + br.height
+  // No viewport clamp: when the range runs past the viewport the far borders
+  // sit off-screen and the grid-wrap's overflow:hidden clips them (no frame at
+  // the edge); the opaque scrollbar (z-index 16) covers any border landing in
+  // its gutter while it's visible.
   if (bottom <= headerY || right <= headerX) return null
   const top  = Math.max(tl.y, headerY)
   const left = Math.max(tl.x, headerX)
@@ -5954,4 +5958,31 @@ function toggleShowFormulas() {
    <body>, so `:has` from body catches every one. */
 body:has(.dialog-overlay) .sn-filter-range,
 body:has(.dialog-overlay) .sn-pivot-highlight { display: none; }
+
+/* Overlay scrollbars for the canvas grid. The elements are created imperatively
+   in canvas/scrollbars.js (appended to .sn-grid-wrap), so they carry no scoped
+   data-attr — these rules must live in the UNSCOPED block to reach them.
+   z-index sits above the filter (14) / pivot (15) range outlines so the opaque
+   track paints over any outline border that reaches the scrollbar gutter, but
+   below the notes drawer (30) and popovers. */
+.sn-sb          { position:absolute; z-index:16; background:var(--surface-menu-bar, #f8f8f8);
+                  border:0 solid var(--outline-gray-2, #e2e2e2);
+                  opacity:1; transition:opacity .2s ease; }
+.sn-sb-v        { top:0; right:0; width:12px; border-left-width:1px; }
+.sn-sb-h        { left:0; bottom:0; height:12px; border-top-width:1px; }
+.sn-sb-corner   { position:absolute; z-index:16; right:0; bottom:0; width:12px; height:12px;
+                  background:var(--surface-menu-bar, #f8f8f8);
+                  border-left:1px solid var(--outline-gray-2, #e2e2e2);
+                  border-top:1px solid var(--outline-gray-2, #e2e2e2);
+                  opacity:1; transition:opacity .2s ease; }
+/* Auto-hidden state — faded out and click-through so cells under the gutter
+   stay reachable. JS (canvas/scrollbars.js) toggles this on inactivity. */
+.sn-sb--hidden  { opacity:0; pointer-events:none; }
+.sn-sb-thumb    { position:absolute; border-radius:6px; background:var(--ink-gray-4, #b8b8b8);
+                  transition:background .12s ease; cursor:grab; touch-action:none; }
+.sn-sb-v .sn-sb-thumb { top:0; left:2px; right:2px; }
+.sn-sb-h .sn-sb-thumb { left:0; top:2px; bottom:2px; }
+.sn-sb-thumb:hover           { background:var(--ink-gray-5, #7c7c7c); }
+.sn-sb-dragging .sn-sb-thumb { background:var(--ink-gray-6, #6b6b6b); cursor:grabbing; }
+.sn-sb-dragging              { cursor:grabbing; user-select:none; }
 </style>


### PR DESCRIPTION
## What

The Sheets canvas grid tracked its scroll position internally (mouse wheel + keyboard navigation) but had **no visible, draggable scrollbar** — so there was no affordance to scroll by dragging, and no indication of position/extent. This adds horizontal and vertical overlay scrollbars.

## How

- **New `canvas/scrollbars.js`** — draggable overlay bars layered over the grid's existing scroll state (they don't own it; they read a scroll model each render and write back through a single `scrollTo`). Fraction-based so they stay correct at any zoom.
  - Thumb dragging via **Pointer Events + `setPointerCapture`** (a fast drag never drops; touch/pen work alongside mouse), plus track-click paging (~90% viewport).
  - **Auto-hide / fade** — reveal on scroll, on pointer movement over the grid, and while hovered/dragged; fade after ~1.4s idle. Hidden bars drop `pointer-events` so cells under the gutter stay clickable. Shown once on mount for discoverability.
  - **Accessibility** — `role="scrollbar"`, `aria-orientation`, live `aria-valuenow`.
  - An **opaque corner filler** covers the square where the two tracks meet.
- **`canvas/index.js`** — route the wheel handler through one `scrollTo()`; expose a scroll model for the bars. **Memoize the sheet extent** in `_applyCanvasSize` (the single structural-change choke point) so scroll clamping and the bar model are O(1) instead of re-summing every row/column each render — up to tens of thousands of iterations on large sheets.
- **z-index 16** on the bars (above the filter/pivot range outlines) so the opaque track paints over any outline border that reaches its gutter; the outlines themselves stay **unclamped** so the grid-wrap's `overflow:hidden` clips off-screen borders rather than stranding a frame at the viewport edge (matches Google Sheets).

## Testing

Verified end-to-end in the standalone app (identical source): drag on a ~1000-row / 40k-row sheet scrolls correctly; thumbs auto-size and track wheel/keyboard scrolling; ARIA `aria-valuenow` updates; auto-hide fades on idle and reveals on movement/scroll/hover; hidden bars are click-through; the corner filler and filter/pivot outlines render cleanly against the bars in both visible and idle states. Existing canvas unit tests pass. Suite CI builds the frontend bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)