### PR TITLE
fix(sheets): lighten filter outline, active-cell border and fill handle

### DIFF
--- a/frontend/src/apps/sheets/canvas/painters/selection-painter.js
+++ b/frontend/src/apps/sheets/canvas/painters/selection-painter.js
@@ -26,7 +26,9 @@ export function createSelectionPainter(ctx, { cw, rh, colX, rowY }) {
     ctx.rect(clipX, clipY, Math.max(0, cssW - clipX), Math.max(0, cssH - clipY))
     ctx.clip()
     ctx.strokeStyle = COLORS.selBorder
-    ctx.lineWidth = 2
+    // 1.5px — a full 2px black frame read as chunky against the gridlines
+    // (Google Sheets' active-cell outline is a comparably thin line).
+    ctx.lineWidth = 1.5
     ctx.strokeRect(colX(sel.c) + 1, rowY(sel.r) + 1, mergedW - 2, mergedH - 2)
     ctx.lineWidth = 1
     // Fill handle anchors at the bottom-right of the *visible* selection.
@@ -49,11 +51,11 @@ export function createSelectionPainter(ctx, { cw, rh, colX, rowY }) {
     // White ring so the dot stands out against the cell border
     ctx.fillStyle = COLORS.white
     ctx.beginPath()
-    ctx.arc(hx, hy, 5, 0, Math.PI * 2)
+    ctx.arc(hx, hy, 4, 0, Math.PI * 2)
     ctx.fill()
     ctx.fillStyle = COLORS.selHandle
     ctx.beginPath()
-    ctx.arc(hx, hy, 4, 0, Math.PI * 2)
+    ctx.arc(hx, hy, 3, 0, Math.PI * 2)
     ctx.fill()
     ctx.restore()
   }

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -5570,7 +5570,9 @@ function toggleShowFormulas() {
    stays off so the chevron buttons and canvas underneath keep receiving clicks. */
 .sn-filter-range {
   position: absolute; z-index: 14; pointer-events: none;
-  border: 1.5px solid var(--ink-gray-8);
+  /* Thin green outline, Google-Sheets-style — a 1.5px near-black frame read
+     as far too heavy against the gridlines. */
+  border: 1px solid var(--ink-green-3, #15803d);
   border-radius: 2px;
 }
 


### PR DESCRIPTION
Three pieces of grid chrome read visibly heavier than Google Sheets. This dials each back to a comparable weight.

### Changes
| Element | Before | After |
|---|---|---|
| Filter-range outline | 1.5px near-black (\`--ink-gray-8\`) | 1px green (\`--ink-green-3\`) |
| Active-cell border | 2px | 1.5px |
| Fill-handle dot | r=4 (white ring r=5) | r=3 (white ring r=4) |

The filter outline in particular matches Google Sheets, which draws a thin green line around the filtered range rather than a heavy dark frame.

### Testing
Verified all three live in the running app against a filtered dataset — thin green filter outline, lighter selection border, and a smaller, proportionate fill-handle dot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)