### PR TITLE
fix(mail): restore login layout and assign roles before User insert

### DIFF
--- a/frontend/src/apps/mail/components/LoginLayout.vue
+++ b/frontend/src/apps/mail/components/LoginLayout.vue
@@ -1,0 +1,53 @@
+<template>
+	<div class="sm:bg-surface-gray-1 min-h-screen">
+		<div class="relative z-[1] mx-auto py-8 sm:w-max sm:py-32">
+			<div class="flex">
+				<slot name="logo">
+					<div class="mx-auto flex items-center space-x-2">
+						<MailLogo class="inline-block h-7 w-7" />
+						<span class="select-none text-3xl-semibold tracking-tight">
+							Frappe Mail
+						</span>
+					</div>
+				</slot>
+			</div>
+			<div
+				class="bg-surface-base mx-auto w-full px-4 py-8 sm:mt-6 sm:w-[26rem] sm:rounded-lg sm:px-8 sm:shadow-xl"
+			>
+				<div class="mb-6 text-center">
+					<span class="text-center text-xl-medium leading-5 tracking-tight">
+						{{ title }}
+					</span>
+				</div>
+				<slot>
+					<router-view />
+				</slot>
+			</div>
+		</div>
+		<div class="absolute bottom-4 flex w-full justify-center">
+			<FrappeLogo class="h-4" />
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+
+import FrappeLogo from '@/apps/mail/components/Icons/FrappeLogo.vue'
+import MailLogo from '@/apps/mail/components/Icons/MailLogo.vue'
+
+const route = useRoute()
+
+const title = computed(() => {
+	switch (route.name) {
+		case 'mail-login':
+			return __('Sign in to your account')
+		case 'mail-forgot-password':
+		case 'mail-reset-password':
+			return __('Reset Password')
+		default:
+			return __('Create a new account')
+	}
+})
+</script>

--- a/frontend/src/apps/mail/routes.ts
+++ b/frontend/src/apps/mail/routes.ts
@@ -25,37 +25,46 @@ const ShortcutRedirect = { render: () => null }
 
 export const routes: RouteRecordRaw[] = [
 	// --- Public (pre-auth) routes -------------------------------------------
+	// Nested under LoginLayout, which supplies the Frappe Mail logo, the centered
+	// card and the per-route title. Without it these views render as bare,
+	// full-bleed forms.
 	{
-		path: 'signup',
-		name: 'mail-signup',
-		component: () => import('@/apps/mail/pages/SignupView.vue'),
-		meta: { isLogin: true, allowGuest: true },
-	},
-	{
-		path: 'signup/:requestKey',
-		name: 'mail-invite-setup',
-		component: () => import('@/apps/mail/pages/InviteSetupView.vue'),
-		props: true,
-		meta: { isLogin: true, allowGuest: true },
-	},
-	{
-		path: 'login',
-		name: 'mail-login',
-		component: () => import('@/apps/mail/pages/LoginView.vue'),
-		meta: { isLogin: true, allowGuest: true },
-	},
-	{
-		path: 'reset-password',
-		name: 'mail-forgot-password',
-		component: () => import('@/apps/mail/pages/ForgotPasswordView.vue'),
-		meta: { isLogin: true, allowGuest: true },
-	},
-	{
-		path: 'reset-password/:requestKey',
-		name: 'mail-reset-password',
-		component: () => import('@/apps/mail/pages/ResetPasswordView.vue'),
-		props: true,
-		meta: { isLogin: true, allowGuest: true },
+		path: '',
+		component: () => import('@/apps/mail/components/LoginLayout.vue'),
+		children: [
+			{
+				path: 'signup',
+				name: 'mail-signup',
+				component: () => import('@/apps/mail/pages/SignupView.vue'),
+				meta: { isLogin: true, allowGuest: true },
+			},
+			{
+				path: 'signup/:requestKey',
+				name: 'mail-invite-setup',
+				component: () => import('@/apps/mail/pages/InviteSetupView.vue'),
+				props: true,
+				meta: { isLogin: true, allowGuest: true },
+			},
+			{
+				path: 'login',
+				name: 'mail-login',
+				component: () => import('@/apps/mail/pages/LoginView.vue'),
+				meta: { isLogin: true, allowGuest: true },
+			},
+			{
+				path: 'reset-password',
+				name: 'mail-forgot-password',
+				component: () => import('@/apps/mail/pages/ForgotPasswordView.vue'),
+				meta: { isLogin: true, allowGuest: true },
+			},
+			{
+				path: 'reset-password/:requestKey',
+				name: 'mail-reset-password',
+				component: () => import('@/apps/mail/pages/ResetPasswordView.vue'),
+				props: true,
+				meta: { isLogin: true, allowGuest: true },
+			},
+		],
 	},
 	// A guest must be able to reach a public MIME message view.
 	{

--- a/suite/drive/utils/users.py
+++ b/suite/drive/utils/users.py
@@ -79,22 +79,27 @@ def get_country_info():
 	return frappe.cache().hget("ip_country_map", ip, generator=_get_country_info)
 
 
-def assign_drive_role_and_create_settings(user, method: str) -> None:
-	"""Assign the "Drive User" role, settings and a personal team to a new User."""
+def assign_drive_role(user, method: str | None = None) -> None:
+	"""Assign the "Drive User" role to a new User.
+
+	Runs on `before_insert` (not `after_insert`) so the role is present by the
+	time Frappe's `User.validate` runs: `check_roles_added` would otherwise warn
+	"Newly created user X has no roles enabled", and `set_system_user` would
+	demote the user to a Website User for having no desk-access role.
+	"""
+	from suite.suite_core.roles import assign_role
+
+	assign_role(user, "Drive User")
+
+
+def create_drive_settings_and_team(user, method: str | None = None) -> None:
+	"""Create Drive Settings and a personal team for a newly created User."""
 	from suite.drive.api.product import create_team
 
-	role_name = "Drive User"
 	user_name = user.name
 
 	if not user_name or user_name in ("Guest", "Administrator"):
 		return
-
-	if not frappe.db.exists("Role", role_name):
-		frappe.get_doc({"doctype": "Role", "role_name": role_name}).insert(ignore_permissions=True)
-
-	user_doc = frappe.get_doc("User", user_name)
-	user_doc.append("roles", {"role": role_name})
-	user_doc.save(ignore_permissions=True)
 
 	frappe.get_doc({"doctype": "Drive Settings", "user": user.email}).insert(ignore_permissions=True)
 

--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -233,9 +233,15 @@ doc_events = {
 		"on_trash": ["suite.drive.overrides.file.sync_content_file"],
 	},
 	"User": {
-		"after_insert": [
-			"suite.drive.utils.users.assign_drive_role_and_create_settings",
+		# Roles are assigned before insert so they are present when Frappe's
+		# User.validate runs — assigning them after insert triggers a spurious
+		# "No Roles Specified" warning and leaves user_type mis-resolved.
+		"before_insert": [
+			"suite.drive.utils.users.assign_drive_role",
 			"suite.meet.utils.user.assign_meet_role",
+		],
+		"after_insert": [
+			"suite.drive.utils.users.create_drive_settings_and_team",
 			"suite.mail.events.create_user_settings",
 		],
 		"on_update": [

--- a/suite/meet/utils/user.py
+++ b/suite/meet/utils/user.py
@@ -33,20 +33,15 @@ def unique_users(user_list: list) -> list[dict]:
 	return unique_list
 
 
-def assign_meet_role(user: User, method: str) -> None:
-	"""Assign the "Meet User" role to a newly created User."""
-	role_name = "Meet User"
-	user_name = user.name
+def assign_meet_role(user: User, method: str | None = None) -> None:
+	"""Assign the "Meet User" role to a new User.
 
-	if not user_name or user_name in ("Guest", "Administrator"):
-		return
+	Runs on `before_insert` so the role is in place before Frappe validates the
+	User — see `suite.suite_core.roles.assign_role`.
+	"""
+	from suite.suite_core.roles import assign_role
 
-	if not frappe.db.exists("Role", role_name):
-		frappe.get_doc({"doctype": "Role", "role_name": role_name}).insert(ignore_permissions=True)
-
-	user_doc = frappe.get_doc("User", user_name)
-	user_doc.append("roles", {"role": role_name})
-	user_doc.save(ignore_permissions=True)
+	assign_role(user, "Meet User")
 
 
 def is_guest_user(user_id: str) -> bool:

--- a/suite/suite_core/roles.py
+++ b/suite/suite_core/roles.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+
+RESERVED_USERS = ("Guest", "Administrator")
+
+
+def assign_role(user, role_name: str) -> None:
+	"""Append `role_name` to an in-memory User doc, creating the Role if missing.
+
+	Meant to be called from a `before_insert` hook so the role is part of the
+	document Frappe validates. Assigning roles after insert is too late for
+	`User.check_roles_added` (which warns "Newly created user X has no roles
+	enabled") and for `User.set_system_user` (which demotes a role-less user to
+	a Website User), and it costs an extra `User.save` per role.
+	"""
+	# `before_insert` runs ahead of `set_new_name`, so `user.name` is still unset
+	# on a fresh User — fall back to the email it will be named after.
+	identifier = user.name or user.email
+	if not identifier or identifier in RESERVED_USERS:
+		return
+
+	if not frappe.db.exists("Role", role_name):
+		frappe.get_doc({"doctype": "Role", "role_name": role_name}).insert(ignore_permissions=True)
+
+	if any(row.role == role_name for row in user.get("roles") or []):
+		return
+
+	user.append("roles", {"role": role_name})


### PR DESCRIPTION
Fixes two bugs in the invite-accept flow reached from `/mail/dashboard/members`.

## 1. The invite form is malformed

The invitation email links to `/mail/signup/<request_key>`. Those public routes carry `meta.isLogin`, which in the standalone mail app told `App.vue` to wrap them in `LoginLayout` (logo, centered card, per-route title). The suite port dropped `App.vue`, and e29bb762df then removed `LoginLayout.vue` as dead code — but nothing ever took over the wrapping. `isLogin` was left with no consumer, so every pre-auth view (invite setup, signup, login, forgot/reset password) rendered as a bare, full-bleed form.

- Restore `LoginLayout.vue` and nest the public routes under it.
- Its `title` switch still matched pre-port route names (`Login`, `ForgotPassword`, …), so every page fell through to _"Create a new account"_ — retargeted at the namespaced `mail-*` names.
- The layout renders `<router-view />` as default slot content, so it works both as a route component and, as before, with an explicit slot.

## 2. "No Roles Specified" when clicking Create Account

Suite assigns `Drive User` / `Meet User` in the User `after_insert` hook, which is too late. By then Frappe's `User.validate` has already run [`check_roles_added`](https://github.com/frappe/frappe/blob/develop/frappe/core/doctype/user/user.py), which sees an empty roles table on a `System User` and warns:

> **No Roles Specified** — Newly created user _x@y.com_ has no roles enabled.

An invited non-admin gets no roles from the mail flow itself (`create_user` only passes `["Mail Admin"]` when `is_admin`), so this fired on every invite acceptance. `set_system_user` also runs during validate, so `user_type` was being resolved against roles that were not there yet.

- Move role assignment to `before_insert` via a shared `suite.suite_core.roles.assign_role` helper; Drive Settings and personal-team creation stay in `after_insert`.
- `before_insert` runs ahead of `set_new_name`, so the helper falls back to `user.email` for the reserved-user check.
- The helper dedupes, so an explicitly assigned role is not appended twice.
- Side effect: drops two redundant `User.save` calls per user creation.

## Verification

Browser-verified against a seeded `Mail Account Request` on `suite.localhost`:

- `/mail/signup/<key>` renders the card layout with the invited email prefilled and readonly.
- `/mail/login` shows "Sign in to your account" (previously "Create a new account").
- Authed dashboard routes (`/mail/dashboard/members`) unaffected by the new nested group.
- `create_user(...)` for an invited non-admin: `System User`, roles `['Drive User', 'Meet User']`, **empty message log** (previously the "No Roles Specified" warning).
- Desk-created user with explicit `System Manager` + `Drive User`: no duplicate roles, no warning.
- `yarn vitest run` — 846 tests across 33 files pass.

Note: this bench has Stalwart unconfigured, so the Stalwart-side steps of `MailAccountRequest.create_account` (account + app-password creation) could not be exercised end to end; the Frappe `create_user` step was verified directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
