### PR TITLE
fix(mail): stop the login layout from shadowing bare /mail

### DIFF
--- a/frontend/src/apps/mail/routes.test.ts
+++ b/frontend/src/apps/mail/routes.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createMemoryHistory, createRouter, type RouteLocation, type Router } from 'vue-router'
+
+// routes.ts imports the mail guard (which drags in the whole suite router) for its
+// side effects, and frappe-ui for a resource — neither affects route matching.
+vi.mock('@/apps/mail/router', () => ({}))
+vi.mock('frappe-ui', () => ({ createResource: () => ({ fetch: () => {} }) }))
+
+import { routes } from './routes'
+
+const Stub = { render: () => null }
+
+/** Mirror src/router/index.ts: the mail module is mounted as children of '/mail'. */
+const makeRouter = () =>
+	createRouter({
+		history: createMemoryHistory(),
+		routes: [{ path: '/mail', component: Stub, children: routes }],
+	})
+
+/** resolve() never follows `redirect`; hop once so assertions see the landing route. */
+const resolveFollowingRedirect = (router: Router, to: string): RouteLocation => {
+	const resolved = router.resolve(to)
+	const redirect = resolved.matched.at(-1)?.redirect
+	if (!redirect) return resolved
+	return router.resolve(typeof redirect === 'function' ? redirect(resolved) : redirect)
+}
+
+describe('mail route matching', () => {
+	// Regression: the LoginLayout wrapper restored in #281 sits at path '' — the same
+	// full path as the root shortcut — and, registered first, won the matcher tie.
+	// Bare /mail then rendered an empty login card instead of redirecting to the inbox.
+	it('bare /mail lands on the root shortcut', () => {
+		const landed = resolveFollowingRedirect(makeRouter(), '/mail')
+		expect(String(landed.name)).toBe('mail-root-shortcut')
+	})
+
+	it('public pre-auth routes still resolve', () => {
+		const router = makeRouter()
+		expect(router.resolve('/mail/login').name).toBe('mail-login')
+		expect(router.resolve('/mail/signup').name).toBe('mail-signup')
+	})
+
+	it('account-scoped routes still resolve', () => {
+		expect(makeRouter().resolve('/mail/account/ih/mailbox/a').name).toBe('mail-mailbox')
+	})
+})

--- a/frontend/src/apps/mail/routes.ts
+++ b/frontend/src/apps/mail/routes.ts
@@ -31,6 +31,12 @@ export const routes: RouteRecordRaw[] = [
 	{
 		path: '',
 		component: () => import('@/apps/mail/components/LoginLayout.vue'),
+		// This wrapper's own full path is bare '/mail' — the same as the root
+		// shortcut below — and, being registered first, it wins the matcher tie:
+		// without the redirect, '/mail' renders an empty login card instead of
+		// the inbox. Redirect exact matches to the shortcut; children
+		// ('/mail/login' etc.) are unaffected.
+		redirect: { name: 'mail-root-shortcut' },
 		children: [
 			{
 				path: 'signup',


### PR DESCRIPTION
Opening bare `/mail` on prod showed an empty "Create a new account" card for logged-in users; account-scoped URLs (`/mail/account/…`) worked fine.

**Cause:** the LoginLayout wrapper restored in #281 sits at `path: ''` — the same full path as `mail-root-shortcut` — and, registered first, wins vue-router's matcher tie. The match is unnamed, so the mail guard bails too: no account resolution, no redirect, and the layout renders an empty card with its fallback title.

**Fix:** redirect exact matches on the wrapper to `mail-root-shortcut` (children like `/mail/login` are unaffected), plus a regression test over the real route table.

Verified: new test fails before / passes after, full `vitest` suite green (853), and browser-checked — `/mail` lands on the inbox again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)