### PR TITLE
fix(mail): stop the login layout shadowing /mail

### DIFF
--- a/frontend/src/apps/mail/__tests__/routes.test.ts
+++ b/frontend/src/apps/mail/__tests__/routes.test.ts
@@ -1,0 +1,57 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { createMemoryHistory, createRouter, type Router } from 'vue-router'
+
+// `@/apps/mail/routes` imports the mail guard for side effects, which pulls in
+// the whole suite router + session store. Stub it out: this suite is about the
+// shape of the route table, not the guard.
+vi.mock('@/apps/mail/router', () => ({ default: {}, router: {} }))
+vi.mock('frappe-ui', () => ({ createResource: () => ({ fetch: () => {} }) }))
+
+let router: Router
+
+beforeAll(async () => {
+	const { routes } = await import('@/apps/mail/routes')
+	router = createRouter({
+		history: createMemoryHistory('/'),
+		// Mounted the way the suite router mounts it: relative paths under /mail.
+		routes: [{ path: '/mail', component: { render: () => null }, children: routes }],
+	})
+})
+
+const PUBLIC_ROUTES: [string, string][] = [
+	['/mail/login', 'mail-login'],
+	['/mail/signup', 'mail-signup'],
+	['/mail/signup/abc123', 'mail-invite-setup'],
+	['/mail/reset-password', 'mail-forgot-password'],
+	['/mail/reset-password/abc123', 'mail-reset-password'],
+]
+
+describe('mail route table', () => {
+	// Regression: a `path: ''` LoginLayout wrapper shadowed `mail-root-shortcut`,
+	// so /mail rendered a bare "Create a new account" card for authed users.
+	it('resolves /mail to the root shortcut, not the login layout', () => {
+		expect(router.resolve('/mail').name).toBe('mail-root-shortcut')
+	})
+
+	it('resolves the public routes to their named records', () => {
+		for (const [path, name] of PUBLIC_ROUTES) {
+			expect(router.resolve(path).name, path).toBe(name)
+		}
+	})
+
+	it('wraps every public route in LoginLayout', () => {
+		for (const [path] of PUBLIC_ROUTES) {
+			const resolved = router.resolve(path)
+			expect(resolved.meta.isLogin, path).toBe(true)
+			expect(resolved.meta.allowGuest, path).toBe(true)
+			// /mail wrapper -> LoginLayout -> leaf view
+			expect(resolved.matched.length, path).toBeGreaterThanOrEqual(3)
+		}
+	})
+
+	it('keeps authed routes matching under MailLayout', () => {
+		expect(router.resolve('/mail/dashboard/members').name).toBe('mail-members')
+		expect(router.resolve('/mail/all-inboxes').name).toBe('mail-all-inboxes')
+		expect(router.resolve('/mail/mailbox/inbox').name).toBe('mail-mailbox-shortcut')
+	})
+})

--- a/frontend/src/apps/mail/routes.ts
+++ b/frontend/src/apps/mail/routes.ts
@@ -23,46 +23,64 @@ import '@/apps/mail/router'
 // them and redirects before any component ever mounts.
 const ShortcutRedirect = { render: () => null }
 
+// LoginLayout supplies the Frappe Mail logo, the centered card and the per-route
+// title. Without it the public views render as bare, full-bleed forms.
+const LoginLayout = () => import('@/apps/mail/components/LoginLayout.vue')
+const publicMeta = { isLogin: true, allowGuest: true }
+
 export const routes: RouteRecordRaw[] = [
 	// --- Public (pre-auth) routes -------------------------------------------
-	// Nested under LoginLayout, which supplies the Frappe Mail logo, the centered
-	// card and the per-route title. Without it these views render as bare,
-	// full-bleed forms.
+	// One LoginLayout wrapper PER path segment rather than a single `path: ''`
+	// parent: an empty-path wrapper would tie with the MailLayout group below
+	// for an exact `/mail` match and, being declared first, would win — leaving
+	// `mail-root-shortcut` unreachable and rendering an empty login card.
 	{
-		path: '',
-		component: () => import('@/apps/mail/components/LoginLayout.vue'),
+		path: 'login',
+		component: LoginLayout,
 		children: [
 			{
-				path: 'signup',
+				path: '',
+				name: 'mail-login',
+				component: () => import('@/apps/mail/pages/LoginView.vue'),
+				meta: publicMeta,
+			},
+		],
+	},
+	{
+		path: 'signup',
+		component: LoginLayout,
+		children: [
+			{
+				path: '',
 				name: 'mail-signup',
 				component: () => import('@/apps/mail/pages/SignupView.vue'),
-				meta: { isLogin: true, allowGuest: true },
+				meta: publicMeta,
 			},
 			{
-				path: 'signup/:requestKey',
+				path: ':requestKey',
 				name: 'mail-invite-setup',
 				component: () => import('@/apps/mail/pages/InviteSetupView.vue'),
 				props: true,
-				meta: { isLogin: true, allowGuest: true },
+				meta: publicMeta,
 			},
+		],
+	},
+	{
+		path: 'reset-password',
+		component: LoginLayout,
+		children: [
 			{
-				path: 'login',
-				name: 'mail-login',
-				component: () => import('@/apps/mail/pages/LoginView.vue'),
-				meta: { isLogin: true, allowGuest: true },
-			},
-			{
-				path: 'reset-password',
+				path: '',
 				name: 'mail-forgot-password',
 				component: () => import('@/apps/mail/pages/ForgotPasswordView.vue'),
-				meta: { isLogin: true, allowGuest: true },
+				meta: publicMeta,
 			},
 			{
-				path: 'reset-password/:requestKey',
+				path: ':requestKey',
 				name: 'mail-reset-password',
 				component: () => import('@/apps/mail/pages/ResetPasswordView.vue'),
 				props: true,
-				meta: { isLogin: true, allowGuest: true },
+				meta: publicMeta,
 			},
 		],
 	},


### PR DESCRIPTION
Follow-up to #281, which regressed `/mail`: an authenticated user navigating there got a bare **"Create a new account"** card instead of being redirected into their mailbox.

## Cause

#281 restored `LoginLayout.vue` and wired the public views under it as a `path: ''` parent record. That collided with the pre-existing `path: ''` MailLayout group at the same `/mail` prefix:

| Order | `path` | Purpose |
|---|---|---|
| 1st | `''` | **new** — `LoginLayout` wrapper (`signup` / `login` / `reset-password`) |
| 2nd | `''` | `mail-root-shortcut` under `MailLayout` |

Vue Router scores both records identically for an exact `/mail` match and breaks the tie by declaration order, so the `LoginLayout` parent won and rendered alone with an empty `<router-view />`. Its `title` computed fell through its `switch` to the default branch — "Create a new account".

Two consequences: `mail-root-shortcut` became unreachable, and because the shadowing parent is *unnamed*, the mail guard's `to.name.startsWith('mail-')` check early-returned before it could redirect the logged-in user.

## Fix

Give each public view group a real path segment — `login`, `signup`, `reset-password` — each with its own `LoginLayout` wrapper and a default `''` child, instead of one empty-path wrapper.

- No route names or URLs change.
- Every public view keeps its card layout, so #281's original fix (the invite form at `/mail/signup/<request_key>`) stays fixed.
- No empty-path record competes with `mail-root-shortcut` any more, so this cannot regress on declaration order again — unlike simply reordering the two groups.

The roles half of #281 (`suite_core/roles.py::assign_role`) is untouched.

## Testing

New `src/apps/mail/__tests__/routes.test.ts` resolves the real mail route table against a memory router mounted the way the suite router mounts it, and asserts:

- `/mail` → `mail-root-shortcut` (**fails on the parent commit**, resolving to an unnamed record)
- each public path → its expected `mail-*` name, wrapped in `LoginLayout`, with `isLogin` + `allowGuest` intact
- authed routes still match under `MailLayout`

`yarn vitest run` → 850 passed / 34 files.

https://claude.ai/code/session_0197XhsarQqm8jbb7VjGb6AF