### PR TITLE
fix(calendar): resolve event masters via baseEventId so fresh events can be edited

### DIFF
--- a/suite/calendar/api/__init__.py
+++ b/suite/calendar/api/__init__.py
@@ -6,12 +6,12 @@ from frappe import _
 from suite.calendar.doctype.calendar.calendar import fetch_calendars
 from suite.calendar.doctype.calendar_event.calendar_event import (
 	fetch_calendar_events,
-	get_master_events_by_uids,
 	update_calendar_event,
 )
 from suite.calendar.doctype.calendar_event.calendar_event import (
 	get_calendar_events as get_calendar_events_by_ids,
 )
+from suite.mail.jmap import get_calendar_event_service
 
 
 @frappe.whitelist()
@@ -42,22 +42,38 @@ def get_calendar_events(account: str, from_date: str, to_date: str, time_zone: s
 
 
 def enrich_events_with_master_data(account: str, events: list[dict]) -> None:
-	"""Attaches recurrence/master info to each event in-place."""
+	"""Attaches recurrence/master info to each event in-place.
 
-	uids = {event["uid"] for event in events}
-	masters = get_master_events_by_uids(account, list(uids))
-	master_map = {
-		uid: {
-			"recurrence_rule": json.loads(master["recurrence_rule"]),
-			"master_id": master["id"],
-			"master_start": master["start"],
-			"master_duration": master["duration"],
-		}
-		for uid, master in masters.items()
+	Masters are resolved through baseEventId rather than a uid query: the uid filter runs on
+	the server's search index, which is updated asynchronously, so a query-based lookup misses
+	events created moments ago — leaving them without a master_id (so the frontend falls back
+	to the synthetic id, which cannot be updated or deleted) and with an unparsed
+	recurrence_rule string until the index catches up."""
+
+	if not events:
+		return
+
+	base_ids = get_calendar_event_service(account).get_base_event_ids(
+		[event["id"] for event in events]
+	)
+	masters = {
+		master["id"]: master
+		for master in get_calendar_events_by_ids(account, sorted(set(base_ids.values())))
 	}
 
 	for event in events:
-		event.update(master_map.get(event["uid"], {}))
+		master = masters.get(base_ids.get(event["id"]))
+		if not master:
+			continue
+
+		event.update(
+			{
+				"recurrence_rule": json.loads(master["recurrence_rule"]),
+				"master_id": master["id"],
+				"master_start": master["start"],
+				"master_duration": master["duration"],
+			}
+		)
 
 
 def enrich_participants_with_avatars(events: list[dict]) -> None:

--- a/suite/calendar/api/__init__.py
+++ b/suite/calendar/api/__init__.py
@@ -56,6 +56,9 @@ def enrich_events_with_master_data(account: str, events: list[dict]) -> None:
 	base_ids = get_calendar_event_service(account).get_base_event_ids(
 		[event["id"] for event in events]
 	)
+	if not base_ids:
+		return
+
 	masters = {
 		master["id"]: master
 		for master in get_calendar_events_by_ids(account, sorted(set(base_ids.values())))

--- a/suite/calendar/doctype/calendar_event/calendar_event.py
+++ b/suite/calendar/doctype/calendar_event/calendar_event.py
@@ -447,23 +447,6 @@ def get_calendar_events(account: str, ids: list[str]) -> list[dict]:
 
 
 @frappe.whitelist()
-def get_master_events_by_uids(account: str, uids: list[str]) -> dict:
-	"""Returns a dictionary of master calendar events for the specified account and UIDs."""
-
-	events = {}
-	service = get_calendar_event_service(account)
-
-	if master_ids := service.get_master_ids(uids):
-		calendar_map = {c["id"]: c["name"] for c in service.calendars}
-
-		for event in service.get(master_ids):
-			event = format_calendar_event(account, calendar_map, event)
-			events[event["uid"]] = event
-
-	return events
-
-
-@frappe.whitelist()
 def update_calendar_event(
 	account: str,
 	id: str,

--- a/suite/mail/jmap/services/calendars/calendar_event.py
+++ b/suite/mail/jmap/services/calendars/calendar_event.py
@@ -282,6 +282,24 @@ class CalendarEventService(CalendarsService):
 
 		return result
 
+	def get_base_event_ids(self, ids: list[str]) -> dict[str, str]:
+		"""Public method to map event ids (including synthetic ids from recurrence-expanded queries)
+		to the id of the real event they belong to.
+
+		Resolved via a lightweight get requesting only baseEventId, which the server derives
+		directly from the id itself — unlike a uid query, it does not depend on the search index
+		(updated asynchronously), so it works immediately after an event is created."""
+
+		base_ids = {}
+		for batch in self.create_batches(ids, self.max_objects_in_get):
+			response = self._get(batch, properties=["id", "baseEventId"])
+
+			if method_responses := response.get("methodResponses"):
+				for event in method_responses[0][1].get("list", []):
+					base_ids[event["id"]] = event.get("baseEventId") or event["id"]
+
+		return base_ids
+
 	def get_master_ids(self, uids: list[str]) -> list[str]:
 		"""Public method to get master event IDs for a list of UIDs."""
 


### PR DESCRIPTION
Editing or deleting an event immediately after creating it failed until a page reload.

Master enrichment in `get_calendar_events` resolved events through a uid-filtered `CalendarEvent/query`. That filter runs on the server's search index, which is updated asynchronously — a just-created event was returned by the date-range fetch but missed by the uid lookup. The event then reached the frontend without `master_id` (falling back to the synthetic occurrence id, which the server refuses to update and cannot delete: *"Deleting synthetic ids is not yet supported"*) and with `recurrence_rule` as an unparsed JSON string, which failed type validation on update.

Resolve masters through a lightweight get of `baseEventId` instead — the server derives it directly from the id, so it's correct immediately after creation. Round-trip count is unchanged. Each event now also maps to its own master by id rather than by uid, so an organizer copy and an attendee copy sharing a uid can no longer cross-wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)