### PR TITLE
refactor: clean up duplicated transition, handle, and shortcut code

### DIFF
--- a/frontend/src/apps/slides/components/EditorNavbar.vue
+++ b/frontend/src/apps/slides/components/EditorNavbar.vue
@@ -1,7 +1,7 @@
 <template>
 	<Navbar
 		:primaryButton="primaryButtonProps"
-		:showNavbarDropdown="showNavbarDropdown"
+		:dropdown="showNavbarDropdown ? 'context' : null"
 		@performDropdownAction="(action) => emit('performDropdownAction', action)"
 	>
 		<template v-if="!inReadonlyMode" #left-actions>

--- a/frontend/src/apps/slides/components/LayoutSection.vue
+++ b/frontend/src/apps/slides/components/LayoutSection.vue
@@ -49,7 +49,7 @@ import {
 } from '@/apps/slides/stores/element'
 import { selectionBounds } from '@/apps/slides/stores/slide'
 import { commitInteraction } from '@/apps/slides/stores/interaction'
-import { rotationDelta } from '@/apps/slides/composables/useRotator'
+import { rotationDelta } from '@/apps/slides/stores/interaction'
 import { normalizeRotation } from '@/apps/slides/utils/helpers'
 import { useInteractionScrub } from '@/apps/slides/composables/useInteractionScrub'
 

--- a/frontend/src/apps/slides/components/Navbar.vue
+++ b/frontend/src/apps/slides/components/Navbar.vue
@@ -6,7 +6,7 @@
 	>
 		<div class="flex w-fit items-center gap-2">
 			<router-link
-				v-if="!showNavbarDropdown && !showHomeDropdown"
+				v-if="!dropdown"
 				class="flex w-fit items-center gap-2"
 				:to="{ name: 'slides-home' }"
 			>
@@ -15,7 +15,7 @@
 
 			<Dropdown
 				v-else
-				:options="showHomeDropdown ? getHomeMenuOptions() : getContextMenuOptions()"
+				:options="dropdown === 'home' ? getHomeMenuOptions() : getContextMenuOptions()"
 				:offset="16"
 			>
 				<template #default="{ open }">
@@ -57,13 +57,9 @@ import { useThemeMenuOption } from '@/apps/slides/composables/useThemeMenuOption
 import { useSessionStore } from '@/boot/session'
 
 const props = defineProps({
-	showNavbarDropdown: {
-		type: Boolean,
-		default: false,
-	},
-	showHomeDropdown: {
-		type: Boolean,
-		default: false,
+	dropdown: {
+		type: String,
+		default: null,
 	},
 	primaryButton: Object,
 })

--- a/frontend/src/apps/slides/components/NavigationPanel.vue
+++ b/frontend/src/apps/slides/components/NavigationPanel.vue
@@ -118,9 +118,10 @@ const SLIDE_WIDTH = 960
 const SLIDE_ASPECT = 540 / 960
 const ROW_GAP = 8
 
-// Available thumbnail width = panel width (w-56 = 224px) minus the scroll area's
-// horizontal padding (p-4 = 16px each side). Keep in sync if the panel width changes.
-const THUMBNAIL_WIDTH = 224 - 32
+// keep in sync with the panel's w-56 width and its p-4 horizontal padding
+const PANEL_WIDTH = 224
+const PANEL_PADDING_X = 16
+const THUMBNAIL_WIDTH = PANEL_WIDTH - PANEL_PADDING_X * 2
 const thumbnailScale = THUMBNAIL_WIDTH / SLIDE_WIDTH
 const thumbnailHeight = THUMBNAIL_WIDTH * SLIDE_ASPECT
 const rowSize = thumbnailHeight + ROW_GAP * 2

--- a/frontend/src/apps/slides/components/ResizeHandle.vue
+++ b/frontend/src/apps/slides/components/ResizeHandle.vue
@@ -5,7 +5,7 @@
 import { computed } from 'vue'
 
 import { slideBounds } from '@/apps/slides/stores/slide'
-import { selectionColor } from '@/apps/slides/utils/constants'
+import { getHandleBaseStyles } from '@/apps/slides/utils/constants'
 
 const props = defineProps({
 	direction: {
@@ -20,20 +20,7 @@ const props = defineProps({
 
 const emit = defineEmits(['startResize'])
 
-const baseStyles = {
-	position: 'absolute',
-	zIndex: 9999,
-	backgroundColor: '#ffffff',
-	borderRadius: '9999px',
-	boxSizing: 'border-box',
-}
-
 const scaledPx = (value) => `${value / slideBounds.scale}px`
-
-const handleDecoration = () => ({
-	border: `${1.5 / slideBounds.scale}px solid ${selectionColor}`,
-	boxShadow: `0 ${1 / slideBounds.scale}px ${2 / slideBounds.scale}px rgba(0, 0, 0, 0.16)`,
-})
 
 const EDGE_THICKNESS = 7
 const EDGE_LENGTH = 18
@@ -44,8 +31,8 @@ const getWidthResizerStyles = () => {
 
 	const offset = `-${scaledPx(EDGE_THICKNESS / 2 + OUTLINE_WIDTH / 2)}`
 	return {
-		...baseStyles,
-		...handleDecoration(),
+		...getHandleBaseStyles(slideBounds.scale),
+		borderRadius: '9999px',
 		cursor: 'ew-resize',
 		left: resizer.includes('left') ? offset : 'auto',
 		right: resizer.includes('right') ? offset : 'auto',
@@ -60,8 +47,8 @@ const getHeightResizerStyles = () => {
 
 	const offset = `-${scaledPx(EDGE_THICKNESS / 2 + OUTLINE_WIDTH / 2)}`
 	return {
-		...baseStyles,
-		...handleDecoration(),
+		...getHandleBaseStyles(slideBounds.scale),
+		borderRadius: '9999px',
 		cursor: 'ns-resize',
 		left: `calc(50% - ${scaledPx(EDGE_LENGTH / 2)})`,
 		top: resizer.includes('top') ? offset : 'auto',
@@ -82,8 +69,8 @@ const getDimensionResizerStyles = () => {
 	const size = props.currentResizer ? 11 : 9
 	const offset = `-${scaledPx(size / 2 + OUTLINE_WIDTH / 2)}`
 	return {
-		...baseStyles,
-		...handleDecoration(),
+		...getHandleBaseStyles(slideBounds.scale),
+		borderRadius: '9999px',
 		top: resizer.includes('top') ? offset : 'auto',
 		bottom: resizer.includes('bottom') ? offset : 'auto',
 		left: resizer.includes('left') ? offset : 'auto',
@@ -100,8 +87,8 @@ const getLineResizerStyles = () => {
 	const size = props.currentResizer ? 11 : 9
 	const offset = `-${scaledPx(size / 2)}`
 	return {
-		...baseStyles,
-		...handleDecoration(),
+		...getHandleBaseStyles(slideBounds.scale),
+		borderRadius: '9999px',
 		cursor: 'ew-resize',
 		left: resizer === 'line-left' ? offset : 'auto',
 		right: resizer === 'line-right' ? offset : 'auto',

--- a/frontend/src/apps/slides/components/RotateHandle.vue
+++ b/frontend/src/apps/slides/components/RotateHandle.vue
@@ -12,7 +12,7 @@
 import { computed, inject } from 'vue'
 
 import { slideBounds } from '@/apps/slides/stores/slide'
-import { selectionColor } from '@/apps/slides/utils/constants'
+import { selectionColor, getHandleBaseStyles } from '@/apps/slides/utils/constants'
 
 const { startRotate } = inject('rotator', {})
 
@@ -24,13 +24,8 @@ const rotateHandleStyles = computed(() => {
 	const size = 20 / slideBounds.scale
 	const gap = STEM_GAP / slideBounds.scale
 	return {
-		position: 'absolute',
-		zIndex: 9999,
-		backgroundColor: '#ffffff',
-		border: `${1.5 / slideBounds.scale}px solid ${HANDLE_COLOR}`,
-		boxSizing: 'border-box',
+		...getHandleBaseStyles(slideBounds.scale),
 		borderRadius: '50%',
-		boxShadow: `0 ${1 / slideBounds.scale}px ${2 / slideBounds.scale}px rgba(0, 0, 0, 0.16)`,
 		cursor: 'grab',
 		left: `calc(50% - ${size / 2}px)`,
 		top: `${-(size + gap)}px`,

--- a/frontend/src/apps/slides/components/SelectionBox.vue
+++ b/frontend/src/apps/slides/components/SelectionBox.vue
@@ -15,7 +15,7 @@ import Resizer from '@/apps/slides/components/Resizer.vue'
 
 import { slideBounds, selectionBounds } from '@/apps/slides/stores/slide'
 import { interactionOffset } from '@/apps/slides/stores/interaction'
-import { rotationDelta } from '@/apps/slides/composables/useRotator'
+import { rotationDelta } from '@/apps/slides/stores/interaction'
 import {
 	activeElementIds,
 	focusElementId,

--- a/frontend/src/apps/slides/components/SlideElement.vue
+++ b/frontend/src/apps/slides/components/SlideElement.vue
@@ -23,7 +23,7 @@ import { activeElementIds } from '@/apps/slides/stores/element'
 import { slideBounds } from '@/apps/slides/stores/slide'
 import { interactionOffset } from '@/apps/slides/stores/interaction'
 
-import { rotationDelta } from '@/apps/slides/composables/useRotator'
+import { rotationDelta } from '@/apps/slides/stores/interaction'
 import { selectionColor } from '@/apps/slides/utils/constants'
 
 const props = defineProps({

--- a/frontend/src/apps/slides/components/ThumbnailContainer.vue
+++ b/frontend/src/apps/slides/components/ThumbnailContainer.vue
@@ -1,5 +1,5 @@
 <template>
-	<div :class="getThumbnailClasses(slide)" :style="getThumbnailStyles(slide)">
+	<div :class="getThumbnailClasses()" :style="getThumbnailStyles(slide)">
 		<SlidePreview :slide="slide" :scale="scale" />
 		<div
 			class="absolute inset-0 flex w-full justify-between rounded-sm p-2"
@@ -12,6 +12,8 @@
 </template>
 
 <script setup>
+import { computed } from 'vue'
+
 import { focusedSlide, slides } from '@/apps/slides/stores/slide'
 import { recentlyRestored } from '@/apps/slides/stores/historyMeta'
 
@@ -41,7 +43,10 @@ const getGradientOverlayStyles = (slide) => {
 	}
 }
 
-const getThumbnailClasses = (slide) => {
+const isFocused = computed(() => focusedSlide.value == slides.value.indexOf(props.slide))
+const usesSelectionRing = computed(() => (props.isActive && recentlyRestored.value) || isFocused.value)
+
+const getThumbnailClasses = () => {
 	const baseClasses = [
 		'relative',
 		'first:mt-0',
@@ -58,12 +63,11 @@ const getThumbnailClasses = (slide) => {
 	]
 
 	const isActive = props.isActive
-	const isFocused = focusedSlide.value == slides.value.indexOf(slide)
 
 	let outlineClasses = []
 	if (isActive && recentlyRestored.value) {
 		outlineClasses.push('ring-2', 'ring-offset-2', 'scale-[1.02]')
-	} else if (isFocused) {
+	} else if (isFocused.value) {
 		outlineClasses.push('ring-2', 'ring-offset-2')
 	} else if (isActive) {
 		outlineClasses.push(
@@ -79,14 +83,11 @@ const getThumbnailClasses = (slide) => {
 }
 
 const getThumbnailStyles = (s) => {
-	const isFocused = focusedSlide.value == slides.value.indexOf(s)
-	const usesSelectionRing = (props.isActive && recentlyRestored.value) || isFocused
-
 	return {
 		backgroundColor: s.background || '#ffffff',
 		height: `${props.height}px`,
 		'--tw-ring-offset-color': 'var(--surface-base)',
-		...(usesSelectionRing ? { '--tw-ring-color': selectionColor } : {}),
+		...(usesSelectionRing.value ? { '--tw-ring-color': selectionColor } : {}),
 	}
 }
 </script>

--- a/frontend/src/apps/slides/components/TransitionSection.vue
+++ b/frontend/src/apps/slides/components/TransitionSection.vue
@@ -72,10 +72,7 @@ import Section from '@/apps/slides/components/controls/Section.vue'
 import { chevronClasses } from '@/apps/slides/utils/constants'
 
 import { slides, slideIndex, currentSlide } from '@/apps/slides/stores/slide'
-import {
-	getCommandsToAddMagicMove,
-	getCommandsToRemoveMagicMove,
-} from '@/apps/slides/stores/transition'
+import { getCommandsToSetTransition } from '@/apps/slides/stores/transition'
 import { editSlideCommand, batchCommand } from '@/apps/slides/stores/commands'
 import { commandHistory } from '@/apps/slides/stores/historyMeta'
 import { useSlideProperty } from '@/apps/slides/composables/editProperty'
@@ -97,43 +94,12 @@ const addTransition = () => setSlideTransition('Fade')
 const removeTransition = () => setSlideTransition('None')
 
 const setSlideTransition = (option) => {
-	const duration = option == 'None' ? 0 : 1
 	const slide = currentSlide.value
-
-	let commands = []
-
-	commands.push(
-		editSlideCommand({
-			slideId: currentSlide.value.clientId,
-			property: 'transition',
-			oldValue: currentSlide.value.transition,
-			newValue: option,
-		}),
-	)
-
-	commands.push(
-		editSlideCommand({
-			slideId: currentSlide.value.clientId,
-			property: 'transitionDuration',
-			oldValue: currentSlide.value.transitionDuration,
-			newValue: duration,
-		}),
-	)
-
-	commands.push(
-		editSlideCommand({
-			slideId: currentSlide.value.clientId,
-			property: 'fadeUnmatchedElements',
-			oldValue: currentSlide.value.fadeUnmatchedElements,
-			newValue: option == 'Magic Move',
-		}),
-	)
-
-	if (option == 'Magic Move') {
-		commands = commands.concat(getCommandsToAddMagicMove(slideIndex.value) || [])
-	} else {
-		commands = commands.concat(getCommandsToRemoveMagicMove(slideIndex.value) || [])
-	}
+	const commands = getCommandsToSetTransition(slide, slideIndex.value, {
+		transition: option,
+		transitionDuration: option == 'None' ? 0 : 1,
+		fadeUnmatchedElements: option == 'Magic Move',
+	})
 
 	commandHistory.execute(
 		batchCommand({
@@ -161,40 +127,14 @@ const applyTransitionToAllSlides = () => {
 	const commands = []
 
 	slides.value.forEach((slide, index) => {
-		if (index !== slideIndex.value) {
-			commands.push(
-				editSlideCommand({
-					slideId: slide.clientId,
-					property: 'transition',
-					oldValue: slide.transition,
-					newValue: sourceSlide.transition,
-				}),
-			)
-
-			commands.push(
-				editSlideCommand({
-					slideId: slide.clientId,
-					property: 'transitionDuration',
-					oldValue: slide.transitionDuration,
-					newValue: sourceSlide.transitionDuration,
-				}),
-			)
-
-			commands.push(
-				editSlideCommand({
-					slideId: slide.clientId,
-					property: 'fadeUnmatchedElements',
-					oldValue: slide.fadeUnmatchedElements,
-					newValue: sourceSlide.fadeUnmatchedElements,
-				}),
-			)
-
-			if (sourceSlide.transition == 'Magic Move') {
-				commands.push(...(getCommandsToAddMagicMove(index) || []))
-			} else {
-				commands.push(...(getCommandsToRemoveMagicMove(index) || []))
-			}
-		}
+		if (index === slideIndex.value) return
+		commands.push(
+			...getCommandsToSetTransition(slide, index, {
+				transition: sourceSlide.transition,
+				transitionDuration: sourceSlide.transitionDuration,
+				fadeUnmatchedElements: sourceSlide.fadeUnmatchedElements,
+			}),
+		)
 	})
 
 	commandHistory.execute(

--- a/frontend/src/apps/slides/composables/useRotator.js
+++ b/frontend/src/apps/slides/composables/useRotator.js
@@ -1,9 +1,6 @@
 import { ref } from 'vue'
 import { getElementCenter } from '@/apps/slides/stores/element'
-
-// module-scoped so the active element and selection box read it directly —
-// passing it as a per-frame prop re-rendered every element during rotation
-export const rotationDelta = ref(0)
+import { rotationDelta } from '@/apps/slides/stores/interaction'
 
 export const useRotator = () => {
 	const isRotating = ref(false)

--- a/frontend/src/apps/slides/composables/useShortcuts.js
+++ b/frontend/src/apps/slides/composables/useShortcuts.js
@@ -137,13 +137,12 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 	}
 
 	const deleteElementOrSlide = (e) => {
-		if (!inEditMode()) return
 		if (hasElements()) deleteElements(e)
 		else deleteSlide()
 	}
 
 	const addShape = (shapeType) => {
-		if (inEditMode()) pendingShapeType.value = shapeType
+		pendingShapeType.value = shapeType
 	}
 
 	useShortcut([
@@ -167,9 +166,7 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 			description: 'Save',
 			group: 'General',
 			condition: inEditMode,
-			handler: (e) => {
-				if (inEditMode()) saveSlide(e)
-			},
+			handler: (e) => saveSlide(e),
 		},
 		{
 			key: 'z',
@@ -180,7 +177,7 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 			condition: inEditMode,
 			handler: (e) => {
 				if (isPlainInput(e)) return
-				if (inEditMode()) performHistory('undo')
+				performHistory('undo')
 			},
 		},
 		{
@@ -192,7 +189,7 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 			condition: inEditMode,
 			handler: (e) => {
 				if (isPlainInput(e)) return
-				if (inEditMode()) performHistory('redo')
+				performHistory('redo')
 			},
 		},
 		{
@@ -205,7 +202,7 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 			condition: inEditMode,
 			handler: (e) => {
 				if (isPlainInput(e)) return
-				if (inEditMode()) performHistory('redo')
+				performHistory('redo')
 			},
 		},
 
@@ -214,18 +211,14 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 			description: 'Add slide below',
 			group: 'Insert',
 			condition: inEditMode,
-			handler: (e) => {
-				if (inEditMode()) addEmptySlide(e)
-			},
+			handler: (e) => addEmptySlide(e),
 		},
 		{
 			key: 't',
 			description: 'Add text box',
 			group: 'Insert',
 			condition: inEditMode,
-			handler: () => {
-				if (inEditMode()) addTextElement()
-			},
+			handler: () => addTextElement(),
 		},
 		{
 			key: 'r',
@@ -254,18 +247,14 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 			description: 'Select all elements',
 			group: 'Edit',
 			condition: inEditMode,
-			handler: (e) => {
-				if (inEditMode()) selectAllElements(e)
-			},
+			handler: (e) => selectAllElements(e),
 		},
 		{
 			key: 'Escape',
 			description: 'Deselect',
 			group: 'Edit',
 			condition: inEditMode,
-			handler: () => {
-				if (inEditMode()) resetFocus()
-			},
+			handler: () => resetFocus(),
 		},
 		{
 			key: 'd',
@@ -274,7 +263,6 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 			group: 'Edit',
 			condition: inEditMode,
 			handler: (e) => {
-				if (!inEditMode()) return
 				if (hasElements()) duplicateElements(e, activeElements.value)
 				else duplicateSlide()
 			},
@@ -349,7 +337,7 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 			group: 'Format Text',
 			condition: inEditMode,
 			handler: () => {
-				if (inEditMode() && hasActiveTextEditor()) toggleMark('italic')
+				if (hasActiveTextEditor()) toggleMark('italic')
 			},
 		},
 		{
@@ -359,7 +347,7 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 			group: 'Format Text',
 			condition: inEditMode,
 			handler: () => {
-				if (inEditMode() && hasActiveTextEditor()) toggleMark('underline')
+				if (hasActiveTextEditor()) toggleMark('underline')
 			},
 		},
 
@@ -377,9 +365,7 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 			description: 'Restart',
 			group: 'Slideshow',
 			condition: inSlideShow,
-			handler: () => {
-				if (inSlideShow()) changeSlideInSlideshow(0)
-			},
+			handler: () => changeSlideInSlideshow(0),
 		},
 		{
 			key: 'ArrowLeft',

--- a/frontend/src/apps/slides/pages/Home.vue
+++ b/frontend/src/apps/slides/pages/Home.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="flex h-screen w-screen flex-col bg-surface-base">
 		<Navbar
-			:showHomeDropdown="true"
+			dropdown="home"
 			:primaryButton="{
 				label: 'New',
 				icon: Plus,

--- a/frontend/src/apps/slides/stores/interaction.js
+++ b/frontend/src/apps/slides/stores/interaction.js
@@ -1,13 +1,14 @@
-import { reactive } from 'vue'
+import { reactive, ref } from 'vue'
 
 import { currentSlide } from './slide'
 import { activeElements, activeElementIds } from './element'
 import { editElementCommand, batchCommand } from './commands'
 import { commandHistory } from './historyMeta'
-import { rotationDelta } from '@/apps/slides/composables/useRotator'
 import { normalizeRotation } from '@/apps/slides/utils/helpers'
 
 const interactionOffset = reactive({ left: 0, top: 0, width: 0, height: 0 })
+
+const rotationDelta = ref(0)
 
 const commitInteraction = () => {
 	const commands = []
@@ -54,4 +55,4 @@ const commitInteraction = () => {
 	rotationDelta.value = 0
 }
 
-export { interactionOffset, commitInteraction }
+export { interactionOffset, rotationDelta, commitInteraction }

--- a/frontend/src/apps/slides/stores/transition.js
+++ b/frontend/src/apps/slides/stores/transition.js
@@ -1,6 +1,6 @@
 import { slides, slideIndex, currentSlide } from '@/apps/slides/stores/slide'
 import { generateUniqueId } from '@/apps/slides/utils/helpers'
-import { editElementCommand } from './commands'
+import { editElementCommand, editSlideCommand } from './commands'
 
 const canCreateTextConnection = (currentContent, nextContent) => {
 	const parser = new DOMParser()
@@ -295,10 +295,43 @@ const getCommandsForRefIdSeries = (fromSlideIndex, element, refId, isForward) =>
 	return commands
 }
 
+const getCommandsToSetTransition = (slide, index, settings) => {
+	const { transition, transitionDuration, fadeUnmatchedElements } = settings
+	const commands = [
+		editSlideCommand({
+			slideId: slide.clientId,
+			property: 'transition',
+			oldValue: slide.transition,
+			newValue: transition,
+		}),
+		editSlideCommand({
+			slideId: slide.clientId,
+			property: 'transitionDuration',
+			oldValue: slide.transitionDuration,
+			newValue: transitionDuration,
+		}),
+		editSlideCommand({
+			slideId: slide.clientId,
+			property: 'fadeUnmatchedElements',
+			oldValue: slide.fadeUnmatchedElements,
+			newValue: fadeUnmatchedElements,
+		}),
+	]
+
+	if (transition == 'Magic Move') {
+		commands.push(...(getCommandsToAddMagicMove(index) || []))
+	} else {
+		commands.push(...(getCommandsToRemoveMagicMove(index) || []))
+	}
+
+	return commands
+}
+
 export {
 	isAffectedByMagicMove,
 	getCommandsToAddMagicMove,
 	getCommandsToRemoveMagicMove,
+	getCommandsToSetTransition,
 	getCommandsToInitElementRefId,
 	getCommandsToUpdateElementRefId,
 }

--- a/frontend/src/apps/slides/utils/constants.js
+++ b/frontend/src/apps/slides/utils/constants.js
@@ -11,6 +11,15 @@ const defaultShadowColor = '#7C7C7CFF'
 const labelClasses = 'select-none font-text text-base text-ink-gray-5'
 const chevronClasses = 'lucide-chevron-down ml-auto size-4 shrink-0 text-ink-gray-4'
 
+const getHandleBaseStyles = (scale) => ({
+	position: 'absolute',
+	zIndex: 9999,
+	backgroundColor: '#ffffff',
+	border: `${1.5 / scale}px solid ${selectionColor}`,
+	boxShadow: `0 ${1 / scale}px ${2 / scale}px rgba(0, 0, 0, 0.16)`,
+	boxSizing: 'border-box',
+})
+
 const allowedImageFileTypes = [
 	'image/jpeg',
 	'image/jpg',
@@ -31,4 +40,5 @@ export {
 	defaultShadowColor,
 	labelClasses,
 	chevronClasses,
+	getHandleBaseStyles,
 }


### PR DESCRIPTION
Removes duplication and dead re-checks across the editor.

- Transitions: collapsed the repeated command-building in TransitionSection into one `getCommandsToSetTransition()` helper.
- Handles: shared `getHandleBaseStyles()` between ResizeHandle and RotateHandle instead of duplicating styles.
- rotationDelta: moved from **useRotator.js** to `stores/interaction.js` where it belongs.
- Shortcuts: dropped redundant `inEditMode()` checks already covered by condition.
- Navbar: replaced the two dropdown booleans with a single dropdown string prop.