### PR TITLE
feat: draggable corner radius handle

### DIFF
--- a/frontend/src/apps/slides/components/BorderSection.vue
+++ b/frontend/src/apps/slides/components/BorderSection.vue
@@ -25,7 +25,7 @@
 			label="Radius"
 			suffix="px"
 			:min="0"
-			:max="50"
+			:max="MAX_BORDER_RADIUS"
 			:max-digits="3"
 			:step="0.5"
 			@update:modelValue="borderRadius.set"
@@ -56,7 +56,7 @@ import {
 	setElementProperties,
 	useElementProperty,
 } from '@/apps/slides/composables/editProperty'
-import { defaultBorderColor } from '@/apps/slides/utils/constants'
+import { defaultBorderColor, MAX_BORDER_RADIUS } from '@/apps/slides/utils/constants'
 
 const defaultBorderWidth = 1
 

--- a/frontend/src/apps/slides/components/CornerHandle.vue
+++ b/frontend/src/apps/slides/components/CornerHandle.vue
@@ -45,6 +45,7 @@ const handleStyles = computed(() => {
 	return {
 		...getHandleBaseStyles(slideBounds.scale),
 		borderRadius: '50%',
+		opacity: 0.75,
 		cursor: 'grab',
 		width: `${size}px`,
 		height: `${size}px`,

--- a/frontend/src/apps/slides/components/CornerHandle.vue
+++ b/frontend/src/apps/slides/components/CornerHandle.vue
@@ -1,0 +1,55 @@
+<template>
+	<div
+		:style="handleStyles"
+		@mousedown="(e) => cornerRadius.startRound(props.corner, e)"
+		@mouseenter="cornerRadius.setHovered(activeElement?.id)"
+		@mouseleave="cornerRadius.setHovered(null)"
+	></div>
+</template>
+<script setup>
+import { computed, inject } from 'vue'
+
+import { activeElement } from '@/apps/slides/stores/element'
+import { slideBounds } from '@/apps/slides/stores/slide'
+import { getHandleBaseStyles } from '@/apps/slides/utils/constants'
+
+const props = defineProps({
+	corner: {
+		type: String,
+		required: true,
+	},
+})
+
+const HANDLE_SIZE = 8
+const MIN_INSET = 14
+
+const EDGES = {
+	'top-left': { hEdge: 'left', vEdge: 'top' },
+	'top-right': { hEdge: 'right', vEdge: 'top' },
+	'bottom-left': { hEdge: 'left', vEdge: 'bottom' },
+	'bottom-right': { hEdge: 'right', vEdge: 'bottom' },
+}
+
+const cornerRadius = inject('cornerRadius')
+
+const displayInset = computed(() => {
+	const radius = activeElement.value?.borderRadius ?? 0
+	const minInset = MIN_INSET / slideBounds.scale
+	return Math.min(Math.max(radius, minInset), cornerRadius.maxRadius.value)
+})
+
+const handleStyles = computed(() => {
+	const size = HANDLE_SIZE / slideBounds.scale
+	const offset = `${displayInset.value - size / 2}px`
+	const edge = EDGES[props.corner]
+	return {
+		...getHandleBaseStyles(slideBounds.scale),
+		borderRadius: '50%',
+		cursor: 'grab',
+		width: `${size}px`,
+		height: `${size}px`,
+		[edge.hEdge]: offset,
+		[edge.vEdge]: offset,
+	}
+})
+</script>

--- a/frontend/src/apps/slides/components/SelectionBox.vue
+++ b/frontend/src/apps/slides/components/SelectionBox.vue
@@ -1,7 +1,7 @@
 <template>
 	<div v-if="activeElementIds.length" data-selection-box :style="boxStyles">
-		<Resizer
-			v-if="showResizers"
+		<SelectionControls
+			v-if="showControls"
 			:elementType="activeElement?.shapeType || activeElement?.type"
 			:dimensions="selectionBounds"
 			:style="{ pointerEvents: 'auto' }"
@@ -11,7 +11,7 @@
 <script setup>
 import { computed } from 'vue'
 
-import Resizer from '@/apps/slides/components/Resizer.vue'
+import SelectionControls from '@/apps/slides/components/SelectionControls.vue'
 
 import { slideBounds, selectionBounds } from '@/apps/slides/stores/slide'
 import { interactionOffset } from '@/apps/slides/stores/interaction'
@@ -31,7 +31,7 @@ const props = defineProps({
 	},
 })
 
-const showResizers = computed(() => {
+const showControls = computed(() => {
 	return activeElementIds.value.length == 1 && !focusElementId.value && !props.isDragging
 })
 

--- a/frontend/src/apps/slides/components/SelectionControls.vue
+++ b/frontend/src/apps/slides/components/SelectionControls.vue
@@ -11,6 +11,8 @@
 			@startResize="(e) => startResize(e, resizeHandle.direction)"
 		/>
 
+		<CornerHandle v-for="corner in cornerHandles" :key="corner" :corner="corner" />
+
 		<ResizeIndicator
 			v-show="currentResizer"
 			:type="elementType"
@@ -26,6 +28,7 @@ import { computed, inject } from 'vue'
 import ResizeHandle from '@/apps/slides/components/ResizeHandle.vue'
 import RotateHandle from '@/apps/slides/components/RotateHandle.vue'
 import ResizeIndicator from '@/apps/slides/components/ResizeIndicator.vue'
+import CornerHandle from '@/apps/slides/components/CornerHandle.vue'
 
 import { selectionBounds, slideBounds } from '@/apps/slides/stores/slide'
 
@@ -41,6 +44,7 @@ const props = defineProps({
 })
 
 const { currentResizer, startResize } = inject('resizer', {})
+const { isHovered, isRounding } = inject('cornerRadius', {})
 
 const showRotateHandle = computed(() => {
 	return !['line', 'text', 'video'].includes(props.elementType)
@@ -71,13 +75,35 @@ const resizeHandles = computed(() => {
 	} else if (props.elementType === 'text') {
 		directions = ['text-left', 'text-right']
 	} else {
-		directions = ['left', 'right', 'top', 'bottom', 'top-left', 'top-right', 'bottom-left', 'bottom-right']
+		directions = [
+			'left',
+			'right',
+			'top',
+			'bottom',
+			'top-left',
+			'top-right',
+			'bottom-left',
+			'bottom-right',
+		]
 	}
 
 	return directions.map((direction) => ({
 		direction,
 		isVisible: isResizeHandleVisible(direction),
 	}))
+})
+
+const CORNERS = ['top-left', 'top-right', 'bottom-left', 'bottom-right']
+
+const ROUNDABLE = ['rectangle', 'image', 'video']
+
+const cornerHandles = computed(() => {
+	if (!ROUNDABLE.includes(props.elementType) || currentResizer.value) return []
+
+	if (!isHovered.value && !isRounding.value) return []
+
+	const shortestSidePx = Math.min(selectionBounds.width, selectionBounds.height) * slideBounds.scale
+	return shortestSidePx >= 44 ? CORNERS : []
 })
 
 const getScaledValue = (value) => `${value / slideBounds.scale}px`

--- a/frontend/src/apps/slides/components/ShapeStyleSection.vue
+++ b/frontend/src/apps/slides/components/ShapeStyleSection.vue
@@ -41,7 +41,7 @@
 			label="Corner Radius"
 			suffix="px"
 			:min="0"
-			:max="50"
+			:max="MAX_BORDER_RADIUS"
 			:max-digits="3"
 			:step="0.5"
 			@update:modelValue="borderRadius.set"
@@ -75,7 +75,7 @@ import PropertyRow from '@/apps/slides/components/controls/PropertyRow.vue'
 import NumberControl from '@/apps/slides/components/controls/NumberControl.vue'
 import Section from '@/apps/slides/components/controls/Section.vue'
 import LineStyleSelect from '@/apps/slides/components/controls/LineStyleSelect.vue'
-import { chevronClasses } from '@/apps/slides/utils/constants'
+import { chevronClasses, MAX_BORDER_RADIUS } from '@/apps/slides/utils/constants'
 
 import { activeElement } from '@/apps/slides/stores/element'
 import {

--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -31,6 +31,8 @@
 					:data-index="element.id"
 					:highlight="highlightElement(element)"
 					@mousedown="(e) => handleMouseDown(e, element)"
+					@mouseenter="hoveredElementId = element.id"
+					@mouseleave="hoveredElementId = null"
 				/>
 			</ElementContextMenu>
 
@@ -95,6 +97,7 @@ import { registerElementDiv, getElementDiv } from '@/apps/slides/stores/elementR
 import { useDragAndDrop } from '@/apps/slides/composables/useDragAndDrop'
 import { useResizer } from '@/apps/slides/composables/useResizer'
 import { useRotator } from '@/apps/slides/composables/useRotator'
+import { useCornerRadius } from '@/apps/slides/composables/useCornerRadius'
 import { usePanAndZoom } from '@/apps/slides/composables/usePanAndZoom'
 import { useSnapping } from '@/apps/slides/composables/useSnapping'
 import { isCmdOrCtrl } from '@/apps/slides/utils/helpers'
@@ -122,6 +125,12 @@ const { isDragging, positionDelta, startDragging } = useDragAndDrop()
 const { isResizing, pointerDelta, currentResizer, resizeCursor, startResize } = useResizer()
 
 const { isRotating, rotationDelta, startRotate } = useRotator()
+
+const { isRounding, maxRadius, startRound } = useCornerRadius()
+
+const hoveredElementId = ref(null)
+const isHovered = computed(() => hoveredElementId.value === activeElement.value?.id)
+const setHovered = (id) => (hoveredElementId.value = id)
 
 const hasOngoingInteraction = computed(
 	() => isDragging.value || isResizing.value || isRotating.value,
@@ -523,6 +532,13 @@ provide('resizer', {
 })
 provide('rotator', {
 	startRotate,
+})
+provide('cornerRadius', {
+	startRound,
+	maxRadius,
+	isRounding,
+	isHovered,
+	setHovered,
 })
 
 defineExpose({

--- a/frontend/src/apps/slides/composables/useCornerRadius.js
+++ b/frontend/src/apps/slides/composables/useCornerRadius.js
@@ -1,0 +1,68 @@
+import { ref, computed, onBeforeUnmount } from 'vue'
+
+import { activeElement } from '@/apps/slides/stores/element'
+import { selectionBounds, slideBounds } from '@/apps/slides/stores/slide'
+import { useElementProperty } from '@/apps/slides/composables/editProperty'
+import { MAX_BORDER_RADIUS } from '@/apps/slides/utils/constants'
+
+const CORNER_VECTORS = {
+	'top-left': { ux: 1, uy: 1 },
+	'top-right': { ux: -1, uy: 1 },
+	'bottom-left': { ux: 1, uy: -1 },
+	'bottom-right': { ux: -1, uy: -1 },
+}
+
+export const useCornerRadius = () => {
+	const isRounding = ref(false)
+	const borderRadius = useElementProperty('borderRadius')
+
+	const maxRadius = computed(() => {
+		const minSide = Math.min(selectionBounds.width, selectionBounds.height)
+		return Math.min(MAX_BORDER_RADIUS, minSide / 2)
+	})
+
+	let corner = null
+	let startRadius = 0
+	let startX = 0
+	let startY = 0
+
+	const round = (e) => {
+		const dx = e.clientX - startX
+		const dy = e.clientY - startY
+
+		const phi = -((activeElement.value?.rotation || 0) * Math.PI) / 180
+		const localX = dx * Math.cos(phi) - dy * Math.sin(phi)
+		const localY = dx * Math.sin(phi) + dy * Math.cos(phi)
+
+		const { ux, uy } = CORNER_VECTORS[corner]
+		const projected = (localX * ux + localY * uy) / Math.SQRT2 / slideBounds.scale
+
+		const next = Math.min(Math.max(startRadius + projected, 0), maxRadius.value)
+		borderRadius.set(Math.round(next * 2) / 2)
+	}
+
+	const stopRound = () => {
+		window.removeEventListener('mousemove', round)
+		isRounding.value = false
+		borderRadius.commit()
+	}
+
+	const startRound = (activeCorner, e) => {
+		e.preventDefault()
+		e.stopPropagation()
+
+		corner = activeCorner
+		borderRadius.begin()
+		isRounding.value = true
+		startRadius = activeElement.value?.borderRadius ?? 0
+		startX = e.clientX
+		startY = e.clientY
+
+		window.addEventListener('mousemove', round)
+		window.addEventListener('mouseup', stopRound, { once: true })
+	}
+
+	onBeforeUnmount(() => window.removeEventListener('mousemove', round))
+
+	return { isRounding, maxRadius, startRound }
+}

--- a/frontend/src/apps/slides/utils/constants.js
+++ b/frontend/src/apps/slides/utils/constants.js
@@ -5,6 +5,8 @@ const fieldLabelClasses = 'text-sm text-gray-600'
 const selectionColor = '#3B82F6'
 const guideColor = '#C026D3'
 
+const MAX_BORDER_RADIUS = 50
+
 const defaultBorderColor = '#d2d2d2ff'
 const defaultShadowColor = '#7C7C7CFF'
 
@@ -36,6 +38,7 @@ export {
 	allowedImageFileTypes,
 	selectionColor,
 	guideColor,
+	MAX_BORDER_RADIUS,
 	defaultBorderColor,
 	defaultShadowColor,
 	labelClasses,


### PR DESCRIPTION
- Adds draggable corner handles to round rectangles, images, and videos directly on the slide.
- Gesture logic lives in a `useCornerRadius` composable, `CornerHandle` is the handle that renders inside the selected element.
- Renamed Resizer → SelectionControls, since it now hosts resize, rotate, and corner handles.
- Centralizes the border-radius max as a shared `MAX_BORDER_RADIUS` constant.