### PR TITLE
feat(calendar): redesign event modal

### DIFF
--- a/frontend/src/apps/calendar/components/EventAlertList.vue
+++ b/frontend/src/apps/calendar/components/EventAlertList.vue
@@ -46,35 +46,35 @@ const RELATIVE_TO_OPTIONS = [
 			:label="i === 0 ? (alerts.length > 1 ? __('Alerts') : __('Alert')) : ''"
 			type="select"
 			:options="ALERT_ACTION_OPTIONS"
-			class="w-40 shrink-0"
+			class="!w-36 shrink-0"
 			@update:model-value="updateAlert(i, 'action', $event)"
 		/>
 		<template v-if="alert.type === 'OffsetTrigger'">
 			<FormControl
 				:model-value="alert.number"
 				type="number"
-				class="mt-auto w-16 shrink-0"
+				class="mt-auto w-14 shrink-0"
 				@update:model-value="updateAlert(i, 'number', $event)"
 			/>
 			<FormControl
 				:model-value="alert.unit"
 				type="select"
 				:options="UNIT_OPTIONS"
-				class="mt-auto w-full"
+				class="mt-auto min-w-0 grow !w-auto"
 				@update:model-value="updateAlert(i, 'unit', $event)"
 			/>
 			<FormControl
 				:model-value="alert.direction"
 				type="select"
 				:options="DIRECTION_OPTIONS"
-				class="mt-auto w-full"
+				class="mt-auto min-w-0 grow !w-auto"
 				@update:model-value="updateAlert(i, 'direction', $event)"
 			/>
 			<FormControl
 				:model-value="alert.relative_to"
 				type="select"
 				:options="RELATIVE_TO_OPTIONS"
-				class="mt-auto w-full"
+				class="mt-auto min-w-0 grow !w-auto"
 				@update:model-value="updateAlert(i, 'relative_to', $event)"
 			/>
 		</template>

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { computed, inject, reactive, ref, watch } from 'vue'
-import { Button, Dialog, Dropdown, FormControl, createResource, toast } from 'frappe-ui'
+import { AlignLeft, Bell, Briefcase, Clock, MapPin, Users, X } from 'lucide-vue-next'
+import { Button, Dialog, Dropdown, FormControl, Switch, createResource, toast } from 'frappe-ui'
 
+import meetLogo from '@/assets/app-logos/meet.png'
 import { getReorderedParticipants } from '@/apps/calendar/utils'
 import { getRepeatMessage } from '@/apps/calendar/utils/format'
 import { userStore } from '@/apps/calendar/stores/user'
@@ -41,7 +43,7 @@ const getEventData = () => {
 		endDate: displayEnd.format('YYYY-MM-DD'),
 		endTime: end.format('HH:mm'),
 		free_busy_status: ev.free_busy_status,
-		privacy: ev.privacy,
+		privacy: ev.privacy || 'Public',
 		locations: ev.locations.length ? ev.locations.map((l) => l._name) : [''],
 		alerts: ev.alerts?.map(parseAlert) ?? [],
 		description: ev.description || '',
@@ -71,7 +73,7 @@ const getDefaultEventData = () => {
 		alerts: [],
 		description: '',
 		free_busy_status: 'Busy',
-		privacy: '',
+		privacy: 'Public',
 		participants: [
 			{
 				email: user.data.name,
@@ -107,9 +109,7 @@ const duration = computed(() => {
 const startsAt = computed(() =>
 	dayjs(`${event.startDate}T${event.isAllDay ? '00:00' : event.startTime}`),
 )
-const endsAt = computed(() =>
-	dayjs(`${event.endDate}T${event.isAllDay ? '00:00' : event.endTime}`),
-)
+const endsAt = computed(() => dayjs(`${event.endDate}T${event.isAllDay ? '00:00' : event.endTime}`))
 
 const isDateTimeValid = computed(() => {
 	if (!event.startDate || !event.endDate) return false
@@ -176,9 +176,7 @@ const eventParams = computed(() => {
 const patch = computed(() =>
 	Object.fromEntries(
 		[...new Set([...Object.keys(eventParams.value), ...Object.keys(originalParams)])]
-			.filter(
-				(k) => JSON.stringify(eventParams.value[k]) !== JSON.stringify(originalParams[k]),
-			)
+			.filter((k) => JSON.stringify(eventParams.value[k]) !== JSON.stringify(originalParams[k]))
 			.map((k) => [k, eventParams.value[k]]),
 	),
 )
@@ -335,7 +333,7 @@ const shouldShowRecurringEventModal = computed(
 
 const addAlertOptions = computed(() => [
 	{
-		label: __('Relative to event'),
+		label: __('Relative to Event'),
 		onClick: () =>
 			event.alerts.push({
 				type: 'OffsetTrigger',
@@ -347,7 +345,7 @@ const addAlertOptions = computed(() => [
 			}),
 	},
 	{
-		label: __('On specific date'),
+		label: __('On Specific Date'),
 		onClick: () =>
 			event.alerts.push({
 				type: 'AbsoluteTrigger',
@@ -373,10 +371,7 @@ const handleSaveClick = () => {
 	else handleSave()
 }
 
-const dialogOptions = computed(() => ({
-	title: isNew.value ? __('Add Event') : __('Edit Event'),
-	size: '5xl',
-}))
+const dialogTitle = computed(() => (isNew.value ? __('Add Event') : __('Edit Event')))
 
 const RSVP_OPTIONS = [
 	{ label: __(' '), value: 'NEEDS-ACTION' },
@@ -411,181 +406,233 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 </script>
 
 <template>
-	<Dialog v-model="show" :options="dialogOptions">
-		<template #body-content>
-			<div class="grid max-h-[48rem] grid-cols-11 gap-6 overflow-y-auto">
-				<div class="col-span-7 space-y-4">
-					<h3 class="text-base-medium">{{ __('Event Details') }}</h3>
-					<!-- Title -->
-					<FormControl
-						v-model="event.title"
-						:label="__('Title')"
-						:placeholder="__('Meeting with Team')"
-					/>
+	<Dialog v-model="show" size="4xl" bare>
+		<template #default="{ close }">
+			<div class="flex max-h-[85vh] flex-col text-ink-gray-8">
+				<!-- header -->
+				<div class="flex items-center border-b px-6 py-4">
+					<span class="text-lg font-semibold">{{ dialogTitle }}</span>
+					<Button variant="ghost" class="ml-auto" @click="close">
+						<template #icon><X :size="18" class="icon text-ink-gray-5" /></template>
+					</Button>
+				</div>
 
-					<!-- Date and Time -->
-					<FormControl v-model="event.isAllDay" :label="__('All Day')" type="checkbox" />
-					<div class="flex space-x-4">
-						<FormControl
-							v-model="event.startDate"
-							type="date"
-							:label="__('Start Date')"
-							class="w-full"
+				<div class="flex min-h-0 flex-1">
+					<!-- left: event details -->
+					<div class="min-w-0 flex-1 overflow-y-auto px-6 py-5">
+						<!-- lead title -->
+						<input
+							v-model="event.title"
+							:autofocus="isNew"
+							:placeholder="__('Add title')"
+							class="w-full border-none bg-transparent p-0 pb-4 text-2xl font-semibold tracking-tight text-ink-gray-8 outline-none placeholder:text-ink-gray-4 focus:ring-0"
 						/>
-						<FormControl
-							v-if="!event.isAllDay"
-							v-model="event.startTime"
-							type="time"
-							:label="__('Start Time')"
-							class="w-full"
-						/>
-					</div>
-					<div class="flex space-x-4">
-						<FormControl
-							v-model="event.endDate"
-							type="date"
-							:label="__('End Date')"
-							class="w-full"
-						/>
-						<FormControl
-							v-if="!event.isAllDay"
-							v-model="event.endTime"
-							type="time"
-							:label="__('End Time')"
-							class="w-full"
-						/>
-					</div>
 
-					<!-- Repeat -->
-					<div class="flex items-center space-x-3">
-						<FormControl
-							v-model="event.repeat"
-							:label="
-								event.recurrence_rule?.frequency
-									? __('Repeat: {0}', [getRepeatMessage(event.recurrence_rule)])
-									: __('Repeat')
-							"
-							type="checkbox"
-							@update:model-value="
-								$event ? (showRepeatSettings = true) : (event.recurrence_rule = {})
-							"
-						/>
-						<span
-							v-if="event.recurrence_rule?.frequency"
-							class="text-ink-gray-4 cursor-pointer text-base hover:underline"
-							@click="showRepeatSettings = true"
+						<!-- date & time — one grouped card -->
+						<div class="rounded-xl border border-outline-gray-2">
+							<div class="flex items-center gap-3 border-b px-3.5 py-3">
+								<Clock :size="18" class="icon shrink-0 text-ink-gray-5" />
+								<span class="flex-1 text-base font-medium">
+									{{ __('Date & Time') }}
+								</span>
+								<FormControl
+									v-model="event.isAllDay"
+									:label="__('All Day')"
+									type="checkbox"
+								/>
+							</div>
+							<div class="flex gap-3 p-3.5">
+								<div class="min-w-0 flex-1 space-y-1.5">
+									<label class="block text-xs text-ink-gray-5">
+										{{ __('Starts') }}
+									</label>
+									<div class="flex gap-2">
+										<FormControl v-model="event.startDate" type="date" class="w-full" />
+										<FormControl
+											v-if="!event.isAllDay"
+											v-model="event.startTime"
+											type="time"
+											class="w-full"
+										/>
+									</div>
+								</div>
+								<div class="min-w-0 flex-1 space-y-1.5">
+									<label class="block text-xs text-ink-gray-5">
+										{{ __('Ends') }}
+									</label>
+									<div class="flex gap-2">
+										<FormControl v-model="event.endDate" type="date" class="w-full" />
+										<FormControl
+											v-if="!event.isAllDay"
+											v-model="event.endTime"
+											type="time"
+											class="w-full"
+										/>
+									</div>
+								</div>
+							</div>
+							<div class="flex items-center gap-3 px-3.5 pb-3.5">
+								<FormControl
+									v-model="event.repeat"
+									:label="
+										event.recurrence_rule?.frequency
+											? __('Repeat: {0}', [getRepeatMessage(event.recurrence_rule)])
+											: __('Repeat')
+									"
+									type="checkbox"
+									@update:model-value="
+										$event ? (showRepeatSettings = true) : (event.recurrence_rule = {})
+									"
+								/>
+								<span
+									v-if="event.recurrence_rule?.frequency"
+									class="cursor-pointer text-base text-ink-gray-4 hover:underline"
+									@click="showRepeatSettings = true"
+								>
+									{{ __('Edit') }}
+								</span>
+							</div>
+						</div>
+
+						<!-- meet link -->
+						<div
+							v-if="isNew || hasMeetLink(selectedEvent?.calendarEvent)"
+							class="mt-4 flex items-center gap-3 rounded-xl border border-outline-gray-2 px-3.5 py-3"
 						>
-							{{ __('Edit') }}
-						</span>
-					</div>
+							<img :src="meetLogo" :alt="__('Frappe Meet')" class="size-[18px] shrink-0" />
+							<span class="flex-1 text-base">
+								{{ __('Add Frappe Meet Video Call') }}
+							</span>
+							<Switch
+								v-model="event.addMeetLink"
+								:disabled="!isNew && hasMeetLink(selectedEvent?.calendarEvent)"
+							/>
+						</div>
 
-					<!-- Locations -->
-					<div class="space-y-2">
-						<div v-for="(_, i) in event.locations" :key="i" class="flex space-x-2">
-							<FormControl
-								v-model="event.locations[i]"
-								:label="
-									i === 0
-										? event.locations.length > 1
-											? __('Locations')
-											: __('Location')
-										: ''
-								"
-								:placeholder="__('Meeting location {0}', [i + 1])"
-								class="w-full"
-							/>
-							<Button
-								v-if="
-									event.locations.length === i + 1 && event.locations.length < 3
-								"
-								icon="plus"
-								class="mt-auto"
-								@click="event.locations.push('')"
-							/>
-							<Button
-								v-else
-								icon="x"
-								class="mt-auto"
-								@click="event.locations.splice(i, 1)"
-							/>
+						<div class="mt-4 flex flex-col gap-4">
+							<!-- locations -->
+							<div class="flex gap-3">
+								<MapPin :size="18" class="icon mt-7 shrink-0 text-ink-gray-5" />
+								<div class="min-w-0 flex-1 space-y-2">
+									<div v-for="(_, i) in event.locations" :key="i" class="flex gap-2">
+										<FormControl
+											v-model="event.locations[i]"
+											:label="
+												i === 0
+													? event.locations.length > 1
+														? __('Locations')
+														: __('Location')
+													: ''
+											"
+											:placeholder="__('Meeting location {0}', [i + 1])"
+											class="w-full"
+										/>
+										<Button
+											v-if="event.locations.length === 1"
+											icon="plus"
+											class="mt-auto"
+											@click="event.locations.push('')"
+										/>
+										<Button v-else icon="x" class="mt-auto" @click="event.locations.splice(i, 1)" />
+									</div>
+									<Button
+										v-if="event.locations.length > 1 && event.locations.length < 3"
+										:label="__('Add Location')"
+										@click="event.locations.push('')"
+									/>
+								</div>
+							</div>
+
+							<!-- alerts -->
+							<div class="flex gap-3">
+								<Bell
+									:size="18"
+									class="icon shrink-0 text-ink-gray-5"
+									:class="event.alerts.length ? 'mt-7' : 'mt-2'"
+								/>
+								<div class="min-w-0 flex-1 space-y-2">
+									<EventAlertList v-model:alerts="event.alerts" />
+									<Dropdown
+										v-if="event.alerts.length < 3"
+										:button="{ label: __('Add Alert') }"
+										:options="addAlertOptions"
+									/>
+								</div>
+							</div>
+
+							<!-- availability & visibility -->
+							<div class="flex gap-3">
+								<Briefcase :size="18" class="icon mt-7 shrink-0 text-ink-gray-5" />
+								<div class="flex min-w-0 flex-1 gap-3">
+									<FormControl
+										v-model="event.free_busy_status"
+										type="select"
+										:label="__('Availability')"
+										:options="AVAILABILITY_OPTIONS"
+										class="w-full"
+									/>
+									<FormControl
+										v-model="event.privacy"
+										type="select"
+										:label="__('Visibility')"
+										:options="VISIBILITY_OPTIONS"
+										class="w-full"
+									/>
+								</div>
+							</div>
+
+							<!-- description -->
+							<div class="flex gap-3">
+								<AlignLeft :size="18" class="icon mt-7 shrink-0 text-ink-gray-5" />
+								<FormControl
+									v-model="event.description"
+									:label="__('Description')"
+									type="textarea"
+									:placeholder="__('Add description')"
+									class="min-w-0 flex-1"
+								/>
+							</div>
 						</div>
 					</div>
 
-					<!-- Alerts -->
-					<div class="space-y-2">
-						<EventAlertList v-model:alerts="event.alerts" />
-						<Dropdown
-							v-if="event.alerts.length < 3"
-							:button="{ label: __('Add Alert') }"
-							:options="addAlertOptions"
+					<!-- right: guests rail -->
+					<div class="w-[300px] shrink-0 overflow-y-auto border-l px-5 py-5">
+						<template v-if="showRSVP">
+							<h3 class="text-base-medium mb-2">{{ __('RSVP') }}</h3>
+							<FormControl
+								v-model="userParticipant.participation_status"
+								type="select"
+								:label="__('Are you attending?')"
+								:options="RSVP_OPTIONS"
+								class="mb-5 w-full"
+							/>
+						</template>
+
+						<div class="mb-3 flex items-baseline gap-2">
+							<Users :size="15" class="icon self-center text-ink-gray-5" />
+							<span class="text-base font-medium">{{ __('Participants') }}</span>
+							<span class="text-sm text-ink-gray-4">{{ participants.length }}</span>
+						</div>
+						<ParticipantSelector
+							v-model="event.participants"
+							:account="store.accountId"
+							:display-participants="participants"
+							label=""
 						/>
 					</div>
+				</div>
 
-					<!-- Availability and Privacy -->
-					<div class="flex space-x-4">
-						<FormControl
-							v-model="event.free_busy_status"
-							type="select"
-							:label="__('Availability')"
-							:options="AVAILABILITY_OPTIONS"
-							class="w-full"
-						/>
-						<FormControl
-							v-model="event.privacy"
-							type="select"
-							:label="__('Visibility')"
-							:options="VISIBILITY_OPTIONS"
-							class="w-full"
-						/>
-					</div>
-
-					<FormControl
-						v-if="isNew || hasMeetLink(selectedEvent?.calendarEvent)"
-						v-model="event.addMeetLink"
-						:label="__('Add Frappe Meet link')"
-						type="checkbox"
-						:disabled="!isNew && hasMeetLink(selectedEvent?.calendarEvent)"
-					/>
-
-					<!-- Description -->
-					<FormControl
-						v-model="event.description"
-						:label="__('Description')"
-						type="textarea"
-						:placeholder="__('Event description')"
+				<!-- footer -->
+				<div class="flex justify-end gap-2 border-t px-6 py-3.5">
+					<Button :label="__('Cancel')" variant="outline" @click="close" />
+					<Button
+						:label="__('Save')"
+						variant="solid"
+						:disabled="disableSave"
+						class="w-16"
+						@click="handleSaveClick"
 					/>
 				</div>
-				<div class="col-span-4 flex h-full flex-col space-y-4 border-l pl-6">
-					<!-- RSVP -->
-					<template v-if="showRSVP">
-						<h3 class="text-base-medium">{{ __('RSVP') }}</h3>
-						<FormControl
-							v-model="userParticipant.participation_status"
-							type="select"
-							:label="__('Are you attending?')"
-							:options="RSVP_OPTIONS"
-							class="w-full"
-						/>
-					</template>
-
-					<ParticipantSelector
-						v-model="event.participants"
-						:account="store.accountId"
-						:display-participants="participants"
-					/>
-				</div>
-			</div>
-		</template>
-		<template #actions="{ close }">
-			<div class="flex justify-end gap-2">
-				<Button :label="__('Cancel')" variant="outline" @click="close" />
-				<Button
-					:label="__('Save')"
-					variant="solid"
-					:disabled="disableSave"
-					class="w-16"
-					@click="handleSaveClick"
-				/>
 			</div>
 		</template>
 	</Dialog>
@@ -599,14 +646,16 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 	<Dialog v-model="showRecurringEventModal" :options="SHOW_RECURRING_EVENT_MODAL_OPTIONS">
 		<template #actions>
 			<div class="flex justify-end space-x-2">
-				<Button @click="handleSaveRecurringEvent(false)">{{ __('Entire series') }}</Button>
+				<Button @click="handleSaveRecurringEvent(false)">{{ __('Entire Series') }}</Button>
 			</div>
 		</template>
 	</Dialog>
 	<Dialog v-model="showNotifyParticipantsModal" :options="showNotifyParticipantsOptions">
 		<template #actions>
 			<div class="flex justify-end space-x-2">
-				<Button variant="outline" @click="submitEvent(false)"> {{ __('Skip') }} </Button>
+				<Button variant="outline" @click="submitEvent(false)">
+					{{ __('Skip') }}
+				</Button>
 				<Button variant="solid" @click="submitEvent(true)">
 					{{ __('Send Email') }}
 				</Button>

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -227,6 +227,24 @@ watch(showRepeatSettings, (val) => {
 	if (!val && !event.recurrence_rule?.frequency) event.repeat = false
 })
 
+// With a rule applied the row is an entry point to the settings — unchecking
+// only happens through Remove Repeat in the modal.
+const toggleRepeat = () => {
+	if (event.recurrence_rule?.frequency) {
+		showRepeatSettings.value = true
+		return
+	}
+	event.repeat = !event.repeat
+	if (event.repeat) showRepeatSettings.value = true
+	else event.recurrence_rule = {}
+}
+
+const repeatLabel = computed(() => {
+	if (!event.recurrence_rule?.frequency) return __('Repeat')
+	const message = getRepeatMessage(event.recurrence_rule)
+	return __('Repeats {0}', [message.charAt(0).toLowerCase() + message.slice(1)])
+})
+
 // --- Save logic ---
 
 const handleSuccess = () => {
@@ -439,6 +457,7 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 									v-model="event.isAllDay"
 									:label="__('All Day')"
 									type="checkbox"
+									class="dark:[&_input:not(:checked)]:bg-surface-gray-2"
 								/>
 							</div>
 							<div class="flex gap-3 p-3.5">
@@ -471,33 +490,27 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 									</div>
 								</div>
 							</div>
-							<div class="flex items-center gap-3 px-3.5 pb-3.5">
-								<FormControl
-									v-model="event.repeat"
-									:label="
-										event.recurrence_rule?.frequency
-											? __('Repeat: {0}', [getRepeatMessage(event.recurrence_rule)])
-											: __('Repeat')
-									"
-									type="checkbox"
-									@update:model-value="
-										$event ? (showRepeatSettings = true) : (event.recurrence_rule = {})
-									"
-								/>
-								<span
-									v-if="event.recurrence_rule?.frequency"
-									class="cursor-pointer text-base text-ink-gray-4 hover:underline"
-									@click="showRepeatSettings = true"
+							<div class="px-3.5 pb-3.5">
+								<div
+									class="group -mx-1.5 flex cursor-pointer items-center gap-2 rounded-lg px-1.5 py-1.5 hover:bg-surface-gray-2"
+									@click="toggleRepeat"
 								>
-									{{ __('Edit') }}
-								</span>
+									<FormControl
+										v-model="event.repeat"
+										type="checkbox"
+										class="pointer-events-none dark:[&_input:not(:checked)]:bg-surface-gray-2"
+									/>
+									<span class="min-w-0 flex-1 truncate text-base text-ink-gray-8">
+										{{ repeatLabel }}
+									</span>
+								</div>
 							</div>
 						</div>
 
 						<!-- meet link -->
 						<div
 							v-if="isNew || hasMeetLink(selectedEvent?.calendarEvent)"
-							class="mt-4 flex items-center gap-3 rounded-xl border border-outline-gray-2 px-3.5 py-3"
+							class="mt-4 flex items-center gap-3 rounded-lg border border-outline-gray-2 px-3.5 py-3"
 						>
 							<img :src="meetLogo" :alt="__('Frappe Meet')" class="size-[18px] shrink-0" />
 							<span class="flex-1 text-base">
@@ -519,7 +532,7 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 											v-model="event.locations[i]"
 											:label="
 												i === 0
-													? event.locations.length > 1
+													? event.locations?.length > 1
 														? __('Locations')
 														: __('Location')
 													: ''
@@ -528,7 +541,7 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 											class="w-full"
 										/>
 										<Button
-											v-if="event.locations.length === 1"
+											v-if="event.locations?.length === 1"
 											icon="plus"
 											class="mt-auto"
 											@click="event.locations.push('')"
@@ -536,7 +549,7 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 										<Button v-else icon="x" class="mt-auto" @click="event.locations.splice(i, 1)" />
 									</div>
 									<Button
-										v-if="event.locations.length > 1 && event.locations.length < 3"
+										v-if="event.locations?.length > 1 && event.locations?.length < 3"
 										:label="__('Add Location')"
 										@click="event.locations.push('')"
 									/>
@@ -548,12 +561,12 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 								<Bell
 									:size="18"
 									class="icon shrink-0 text-ink-gray-5"
-									:class="event.alerts.length ? 'mt-7' : 'mt-2'"
+									:class="event.alerts?.length ? 'mt-7' : 'mt-2'"
 								/>
 								<div class="min-w-0 flex-1 space-y-2">
 									<EventAlertList v-model:alerts="event.alerts" />
 									<Dropdown
-										v-if="event.alerts.length < 3"
+										v-if="event.alerts?.length < 3"
 										:button="{ label: __('Add Alert') }"
 										:options="addAlertOptions"
 									/>

--- a/frontend/src/apps/calendar/components/Modals/EventRepeatSettingsModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventRepeatSettingsModal.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { computed, inject, reactive, watch } from 'vue'
-import { Dialog, FormControl } from 'frappe-ui'
+import { Repeat } from 'lucide-vue-next'
+import { Button, Dialog, FormControl, TabButtons } from 'frappe-ui'
 
-import { getRepeatFrequencyOptions, getRepeatMessage } from '@/apps/calendar/utils/format'
+import { getRepeatMessage } from '@/apps/calendar/utils/format'
 
 const show = defineModel<boolean>()
 const { startDate, rRule } = defineProps<{ startDate: string; rRule: any }>()
@@ -142,13 +143,20 @@ const recurrenceRule = computed(() => {
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const WEEKDAYS = [
-	{ label: __('Sun'), value: 'su' },
-	{ label: __('Mon'), value: 'mo' },
-	{ label: __('Tue'), value: 'tu' },
-	{ label: __('Wed'), value: 'we' },
-	{ label: __('Thu'), value: 'th' },
-	{ label: __('Fri'), value: 'fr' },
-	{ label: __('Sat'), value: 'sa' },
+	{ label: __('Su'), value: 'su' },
+	{ label: __('Mo'), value: 'mo' },
+	{ label: __('Tu'), value: 'tu' },
+	{ label: __('We'), value: 'we' },
+	{ label: __('Th'), value: 'th' },
+	{ label: __('Fr'), value: 'fr' },
+	{ label: __('Sa'), value: 'sa' },
+]
+
+const FREQUENCIES = [
+	{ label: __('Day'), value: 'daily' },
+	{ label: __('Week'), value: 'weekly' },
+	{ label: __('Month'), value: 'monthly' },
+	{ label: __('Year'), value: 'yearly' },
 ]
 
 const END_OPTIONS = [
@@ -157,18 +165,16 @@ const END_OPTIONS = [
 	{ label: __('After Occurrences'), value: 'After Occurrences' },
 ]
 
-const DIALOG_OPTIONS = {
-	title: __('Repeat Settings'),
-	actions: [
-		{
-			label: __('Apply'),
-			variant: 'solid',
-			onClick: () => {
-				emit('updateRecurrenceRule', recurrenceRule.value)
-				show.value = false
-			},
-		},
-	],
+const DIALOG_OPTIONS = { title: __('Repeat') }
+
+const apply = () => {
+	emit('updateRecurrenceRule', recurrenceRule.value)
+	show.value = false
+}
+
+const removeRepeat = () => {
+	emit('updateRecurrenceRule', {})
+	show.value = false
 }
 </script>
 
@@ -176,40 +182,33 @@ const DIALOG_OPTIONS = {
 	<Dialog v-model="show" :options="DIALOG_OPTIONS">
 		<template #body-content>
 			<div class="space-y-4">
-				<!-- Interval + Frequency -->
-				<div class="flex space-x-4">
-					<FormControl
-						v-model.number="repeat.interval"
-						:label="__('Repeat Every')"
-						type="number"
-						class="w-full"
-					/>
-					<FormControl
-						v-model="repeat.frequency"
-						type="select"
-						label="‎"
-						:options="getRepeatFrequencyOptions(repeat.interval)"
-						class="w-full"
-					/>
+				<!-- Interval + segmented frequency -->
+				<div>
+					<label class="mb-1.5 block text-xs text-ink-gray-5">{{ __('Repeat Every') }}</label>
+					<div class="flex gap-2.5">
+						<FormControl v-model.number="repeat.interval" type="number" class="w-14 shrink-0" />
+						<TabButtons
+							v-model="repeat.frequency"
+							:options="FREQUENCIES"
+							class="min-w-0 flex-1 [&>div]:w-full [&>div>[data-slot=tab-button]]:flex-1 [&_[data-slot=tab-button]>span]:w-full"
+						/>
+					</div>
 				</div>
 
-				<!-- Repeat on days: weekly -->
+				<!-- Weekly: weekday dots -->
 				<div v-if="repeat.frequency === 'weekly'">
-					<label class="text-ink-gray-5 mb-1 block text-xs">
-						{{ __('Repeat On Days') }}
-					</label>
-					<div class="flex w-full overflow-hidden rounded border">
+					<label class="mb-1.5 block text-xs text-ink-gray-5">{{ __('On') }}</label>
+					<div class="flex gap-1.5">
 						<button
-							v-for="(d, i) in WEEKDAYS"
+							v-for="d in WEEKDAYS"
 							:key="d.value"
 							type="button"
-							class="text-ink-gray-7 h-7 w-full text-xs focus:outline-none"
-							:class="{
-								'border-r': i !== WEEKDAYS.length - 1,
-								'bg-surface-gray-2': !repeat.byDay
-									.map((d) => d.day)
-									.includes(d.value),
-							}"
+							class="size-7 rounded-full text-xs focus:outline-none"
+							:class="
+								repeat.byDay.some((x) => x.day === d.value)
+									? 'bg-surface-gray-10 text-ink-base'
+									: 'bg-surface-gray-2 text-ink-gray-8'
+							"
 							@click="toggleDay(d.value)"
 						>
 							{{ d.label }}
@@ -217,38 +216,45 @@ const DIALOG_OPTIONS = {
 					</div>
 				</div>
 
-				<!-- Repeat on: monthly -->
-				<FormControl
-					v-else-if="repeat.frequency === 'monthly'"
-					v-model="repeat.repeatOn"
-					type="select"
-					:label="__('Repeat On')"
-					:options="monthlyRepeatOnOptions"
-				/>
+				<!-- Monthly: repeat-on select -->
+				<div v-else-if="repeat.frequency === 'monthly'">
+					<label class="mb-1.5 block text-xs text-ink-gray-5">{{ __('On') }}</label>
+					<FormControl v-model="repeat.repeatOn" type="select" :options="monthlyRepeatOnOptions" />
+				</div>
 
 				<!-- End condition -->
-				<FormControl
-					v-model="repeat.end"
-					type="select"
-					:label="__('End')"
-					:options="END_OPTIONS"
-				/>
-				<FormControl
-					v-if="repeat.end === 'On Date'"
-					v-model="repeat.until"
-					type="date"
-					:label="__('End Date')"
-				/>
-				<FormControl
-					v-else-if="repeat.end === 'After Occurrences'"
-					v-model.number="repeat.count"
-					type="number"
-					:label="__('Total Occurrences')"
-				/>
+				<div>
+					<label class="mb-1.5 block text-xs text-ink-gray-5">{{ __('Ends') }}</label>
+					<div class="grid grid-cols-2 items-center gap-2.5">
+						<FormControl v-model="repeat.end" type="select" :options="END_OPTIONS" />
+						<FormControl
+							v-if="repeat.end === 'On Date'"
+							v-model="repeat.until"
+							type="date"
+							class="w-full"
+						/>
+						<FormControl
+							v-else-if="repeat.end === 'After Occurrences'"
+							v-model.number="repeat.count"
+							type="number"
+							class="w-full"
+						/>
+					</div>
+				</div>
 
-				<hr />
-
-				<div class="text-base-medium">{{ getRepeatMessage(recurrenceRule) }}</div>
+				<!-- Summary -->
+				<div
+					class="flex items-center gap-2.5 rounded bg-surface-gray-2 px-3 py-2 text-base text-ink-gray-8"
+				>
+					<Repeat :size="14" class="shrink-0 text-ink-gray-5" />
+					{{ getRepeatMessage(recurrenceRule) }}
+				</div>
+			</div>
+		</template>
+		<template #actions>
+			<div class="flex justify-end gap-2">
+				<Button :label="__('Remove Repeat')" @click="removeRepeat" />
+				<Button :label="__('Apply')" variant="solid" @click="apply" />
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/calendar/components/ParticipantSelector.vue
+++ b/frontend/src/apps/calendar/components/ParticipantSelector.vue
@@ -101,7 +101,7 @@ const removeParticipant = (email: string) => {
 <template>
 	<div class="space-y-4">
 		<div>
-			<h3 class="text-base-medium mb-2 text-ink-gray-8">{{ label }}</h3>
+			<h3 v-if="label" class="text-base-medium mb-2 text-ink-gray-8">{{ label }}</h3>
 			<Combobox
 				ref="combobox"
 				class="w-full"


### PR DESCRIPTION
Replaces the form-grid event dialog with a two-pane layout: lead title input, grouped date & time card, Frappe Meet toggle, icon-gutter rows for location/alerts/availability/visibility/description, and a participants rail.

Repeat is redesigned around the rule as a sentence:
- the repeat row renders the applied rule as human text ("Repeats every week on Tuesday"); clicking the row opens the settings, and unchecking happens only via Remove Repeat
- the settings modal uses a segmented frequency control (`TabButtons`), weekday dots for weekly rules, a stable two-column Ends row, and a promoted summary chip

Also:
- fixes the alert row overflowing the modal column (frappe-ui `FormControl` hardcodes `w-full` on select types, so passed widths lose)
- dark-mode visibility fixes: `surface-gray-2` for row hover and summary chip (`gray-1` is indistinguishable from the dialog surface), dark-only fill for unchecked checkboxes, legible title placeholder (`ink-gray-3` → `ink-gray-4`)
- defaults visibility to Public
- title case for control labels

| Light | Dark |
| --- | --- |
| ![event modal light](https://github.com/krantheman/suite/releases/download/pr-assets/event-modal-light.jpg) | ![event modal dark](https://github.com/krantheman/suite/releases/download/pr-assets/event-modal-dark.jpg) |

Repeat settings:

<img src="https://github.com/krantheman/suite/releases/download/pr-assets/repeat-modal-dark.jpg" width="600" alt="repeat settings modal (dark)">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
