### PR TITLE
feat(sheets): Google-Sheets formula UX — click-to-range, auto-close parens, range suggestion

### DIFF
--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -4,7 +4,8 @@ import { createOverlay }  from './overlay.js'
 import { createScrollbars } from './scrollbars.js'
 import { TOTAL_ROWS, TOTAL_COLS, DEFAULT_TOTAL_ROWS, DEFAULT_TOTAL_COLS, DEFAULT_ROW_H, ROW_HEADER_W, COL_HEADER_H, setTotalRows, setTotalCols } from './constants.js'
 import { cellId, colLabel, parseCellId } from '../utils/cells.js'
-import { AC_FUNS, AC_FUN_KEYS, parseAcToken, parseSignatureContext, describeSignature } from '../utils/formula-ac.js'
+import { AC_FUNS, AC_FUN_KEYS, parseAcToken, parseSignatureContext, describeSignature, shouldSuggestRange, detectAdjacentRange, isNumericText } from '../utils/formula-ac.js'
+import { autoCloseKey } from '../utils/formula-autoclose.js'
 import { isWrapText } from '../utils/text-wrap.js'
 import { CHIP, chipMetrics } from './chip-geometry.js'
 import { checkboxRect } from './checkbox-geometry.js'
@@ -341,13 +342,43 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     canvas.parentElement.appendChild(_acEl)
   }
 
-  // _acItems: { name, kind: 'fn' | 'sheet' }[]
+  // Drop a passive range-suggestion highlight (never touches a real pick).
+  function _clearSuggestion() {
+    if (!_sugActive) return
+    _sugActive = false
+    pickerRect = null
+    render()
+  }
+
+  // Build the { kind:'range', name, rect } suggestion for an empty SUM-style
+  // first argument, or null when there's nothing sensible to offer.
+  function _suggestRangeItem(value, cursor) {
+    if (!shouldSuggestRange(value, cursor)) return null
+    const rect = detectAdjacentRange(sel.r, sel.c, (r, c) => isNumericText(getValue(cellId(r, c))))
+    if (!rect) return null
+    const name = _refForRange(rect.r0, rect.c0, rect.r1, rect.c1, _crossSheetName())
+    return { kind: 'range', name, rect }
+  }
+
+  // _acItems: { name, kind: 'fn' | 'sheet' | 'range' }[]
   function _acUpdate(value, cursor) {
     if (!_acEl) return
+    _clearSuggestion()
     const result = parseAcToken(value, cursor)
-    // No name being typed — fall back to parameter help if the caret is inside
-    // a known function's parens. Leaves _acItems empty so key nav ignores it.
-    if (!result) { _acShowSignature(value, cursor); return }
+    if (!result) {
+      // Empty first arg of a SUM-style function — offer the adjacent numeric
+      // run as a one-tap range (Google Sheets behaviour). Otherwise fall back
+      // to passive parameter help. Both leave _acItems empty for key nav only
+      // in the signature case; the range item IS selectable.
+      const sug = _suggestRangeItem(value, cursor)
+      if (sug) {
+        _acItems = [sug]; _acIdx = 0
+        pickerRect = sug.rect; _sugActive = true
+        _acRender(); render()
+        return
+      }
+      _acShowSignature(value, cursor); return
+    }
     const up     = result.tok.toUpperCase()
     const fns    = AC_FUN_KEYS.filter(n => n.startsWith(up)).slice(0, 6)
     const sheets = (getSheetNames?.() || [])
@@ -370,7 +401,9 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
       row.style.cssText = `display:flex;align-items:baseline;gap:10px;padding:6px 12px;cursor:pointer;white-space:nowrap;border-radius:4px;${i === _acIdx ? 'background:#f3f3f3;' : ''}`
       const right = item.kind === 'sheet'
         ? `<span style="font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;color:#0891b2;background:#ecfeff;border-radius:3px;padding:1px 5px;">sheet</span>`
-        : `<span style="font-size:11px;color:#7c7c7c;">${AC_FUNS[item.name]}</span>`
+        : item.kind === 'range'
+          ? `<span style="font-size:11px;color:#7c7c7c;">Tab to fill range</span>`
+          : `<span style="font-size:11px;color:#7c7c7c;">${AC_FUNS[item.name]}</span>`
       row.innerHTML = `<span style="font-weight:600;min-width:80px;color:#171717;">${item.name}</span>${right}`
       row.addEventListener('mousedown', e => { e.preventDefault(); _acCommit(item) })
       row.addEventListener('mouseover', () => { _acIdx = i; _acHighlight() })
@@ -398,6 +431,9 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
 
   function _acHide() {
     _acItems = []; _acIdx = 0
+    // A live range suggestion owns pickerRect — drop that highlight too. The
+    // range-accept path pre-clears _sugActive so its inserted ref stays lit.
+    if (_sugActive) { _sugActive = false; pickerRect = null }
     if (_acEl) _acEl.style.display = 'none'
   }
 
@@ -422,22 +458,38 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     _acEl.style.display = 'block'
   }
 
-  // item: { name, kind: 'fn' | 'sheet' }
+  // item: { name, kind: 'fn' | 'sheet' | 'range' }
   function _acCommit(item) {
     const input  = overlay.el
     const cursor = input.selectionStart
+    if (item.kind === 'range') {
+      // Splice the suggested ref in at the caret (which sits just after the
+      // opening paren). Keep the highlight lit until the formula commits.
+      const newVal = input.value.slice(0, cursor) + item.name + input.value.slice(cursor)
+      input.value  = newVal
+      const pos    = cursor + item.name.length
+      input.setSelectionRange(pos, pos)
+      onInput?.(cellId(sel.r, sel.c), newVal)
+      _sugActive = false            // the ref is now committed text, not a suggestion
+      _acHide()
+      input.focus()
+      render()
+      return
+    }
     const result = parseAcToken(input.value, cursor)
     if (result) {
       const { tokStart } = result
-      const suffix = item.kind === 'sheet' ? '!' : '('
+      // A function accepts an auto-closed '()' with the caret between; a sheet
+      // gets a trailing '!'. Caret lands one char past the name either way.
+      const suffix = item.kind === 'sheet' ? '!' : '()'
       const newVal = input.value.slice(0, tokStart) + item.name + suffix + input.value.slice(cursor)
       input.value  = newVal
       const pos    = tokStart + item.name.length + 1
       input.setSelectionRange(pos, pos)
       onInput?.(cellId(sel.r, sel.c), newVal)
       input.focus()
-      // Accepting a function inserts its '(' — surface its parameter help
-      // immediately instead of leaving the user with a bare, empty popup.
+      // Caret now sits inside the fresh '(' — surface a range suggestion or
+      // parameter help instead of leaving the user with a bare, empty popup.
       _acUpdate(newVal, pos)
       return
     }
@@ -466,6 +518,12 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
   // arrow keys while editing a formula at a ref-acceptable caret position.
   // Going to null returns us to EDITING (text caret moves). See _pickerKb*.
   let pickerKb   = null  // { target, anchorR, anchorC, headR, headC, insertStart, insertEnd, savedValue, savedCaret }
+  // Anchor for click-to-extend range picking. Survives mouseup (unlike
+  // `picker`) so the next click extends the ref from the first-clicked cell.
+  let pickMouseAnchor = null  // { r, c }
+  // True while `pickerRect` is a passive range *suggestion* (not a real pick),
+  // so we know it's safe to clear when the suggestion goes away.
+  let _sugActive = false
 
   function _pickTarget() {
     const ae = document.activeElement
@@ -527,6 +585,8 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     picker = null
     pickerKb = null
     pickerRect = null
+    pickMouseAnchor = null
+    _sugActive = false
     render()
   }
 
@@ -769,10 +829,27 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
 
   overlay.el.addEventListener('keydown', e => {
     if (_acItems.length) {
+      const cur = _acItems[_acIdx]
+      // A range suggestion accepts on Tab only; Enter falls through to commit
+      // the formula (so an unwanted guess never hijacks Enter). Fn/sheet items
+      // accept on either key.
+      const acceptKey = cur && cur.kind === 'range' ? e.key === 'Tab' : (e.key === 'Tab' || e.key === 'Enter')
       if (e.key === 'ArrowDown') { e.preventDefault(); _acIdx = Math.min(_acIdx + 1, _acItems.length - 1); _acHighlight(); return }
       if (e.key === 'ArrowUp')   { e.preventDefault(); _acIdx = Math.max(_acIdx - 1, 0); _acHighlight(); return }
-      if ((e.key === 'Tab' || e.key === 'Enter') && _acItems[_acIdx]) { e.preventDefault(); _acCommit(_acItems[_acIdx]); return }
+      if (acceptKey && cur) { e.preventDefault(); _acCommit(cur); return }
       if (e.key === 'Escape')    { _acHide(); return }
+    }
+    // Auto-close parens (`(` → `()`, `)` steps over, Backspace clears an empty
+    // pair) — only inside a formula. Handle before the picker/nav branches so
+    // typing `(` never leaks into them.
+    const ac = autoCloseKey(e.key, overlay.el.value, overlay.el.selectionStart, overlay.el.selectionEnd)
+    if (ac) {
+      e.preventDefault()
+      if (pickerKb) _pickerKbCommit()   // finalize an in-progress keyboard pick first
+      overlay.el.value = ac.value
+      overlay.el.setSelectionRange(ac.caret, ac.caret)
+      overlay.el.dispatchEvent(new Event('input', { bubbles: true }))
+      return
     }
     // Commit any active cell-ref pick when the user types a printable char
     // (e.g. '+' after picking C1) so the next arrow key starts a fresh ref
@@ -1026,9 +1103,26 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
         const mid = getMasterId(cellId(h.r, h.c))
         if (mid) { const p = parseCellId(mid); if (p) { tr = p.row; tc = p.col } }
       }
-      _writeRef(pickInput, _refForRange(tr, tc, tr, tc, _crossSheetName()), _refReplaceStart(pickInput))
-      picker     = { anchorR: tr, anchorC: tc, target: pickInput, kind: 'cell' }
-      pickerRect = { r0: tr, c0: tc, r1: tr, c1: tc }
+      // Range picking by click (Google Sheets style). A plain click writes a
+      // single-cell ref and remembers it as the anchor; the NEXT click extends
+      // from that anchor to here → A1:A3, no drag or modifier needed. The
+      // anchor only "continues" while the last-picked ref still abuts the caret
+      // (the user hasn't typed since) — so typing an operator/comma, or picking
+      // in a new argument, resets to a fresh ref. Shift+click always extends.
+      // pickMouseAnchor outlives `picker` (which mouseup clears).
+      const rStart   = _refReplaceStart(pickInput)
+      const abutting = pickInput.value.slice(rStart, pickInput.selectionStart)
+      const lastRef  = (pickerRect && !_sugActive)
+        ? _refForRange(pickerRect.r0, pickerRect.c0, pickerRect.r1, pickerRect.c1, _crossSheetName())
+        : null
+      const continuing = !!pickMouseAnchor && lastRef !== null && abutting === lastRef
+      const anchor = ((e.shiftKey || continuing) && pickMouseAnchor) ? pickMouseAnchor : { r: tr, c: tc }
+      const r0 = Math.min(anchor.r, tr), r1 = Math.max(anchor.r, tr)
+      const c0 = Math.min(anchor.c, tc), c1 = Math.max(anchor.c, tc)
+      _writeRef(pickInput, _refForRange(r0, c0, r1, c1, _crossSheetName()), rStart)
+      picker     = { anchorR: anchor.r, anchorC: anchor.c, target: pickInput, kind: 'cell' }
+      pickerRect = { r0, c0, r1, c1 }
+      pickMouseAnchor = anchor   // keep the origin so the next click re-extends
       pickerKb   = null   // mouse-pick supersedes any keyboard pick state
       render()
       return

--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -464,13 +464,22 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     const cursor = input.selectionStart
     if (item.kind === 'range') {
       // Splice the suggested ref in at the caret (which sits just after the
-      // opening paren). Keep the highlight lit until the formula commits.
+      // opening paren).
       const newVal = input.value.slice(0, cursor) + item.name + input.value.slice(cursor)
       input.value  = newVal
       const pos    = cursor + item.name.length
       input.setSelectionRange(pos, pos)
       onInput?.(cellId(sel.r, sel.c), newVal)
-      _sugActive = false            // the ref is now committed text, not a suggestion
+      // Promote the accepted suggestion to a real pick so the highlight is
+      // owned exactly like a click-picked ref — cleared on commit/cancel, and
+      // extendable from its origin on the next click — instead of lingering as
+      // a stale, unowned suggestion. Set `pickMouseAnchor` (survives with no
+      // active drag) but NOT `picker`: `picker` marks an in-flight drag, and
+      // the mousemove handler would rewrite the ref on the next pointer move.
+      const rr = item.rect
+      pickerRect      = { r0: rr.r0, c0: rr.c0, r1: rr.r1, c1: rr.c1 }
+      pickMouseAnchor = { r: rr.r0, c: rr.c0 }
+      _sugActive      = false       // the ref is now committed text, not a suggestion
       _acHide()
       input.focus()
       render()

--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -431,9 +431,11 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
 
   function _acHide() {
     _acItems = []; _acIdx = 0
-    // A live range suggestion owns pickerRect — drop that highlight too. The
-    // range-accept path pre-clears _sugActive so its inserted ref stays lit.
-    if (_sugActive) { _sugActive = false; pickerRect = null }
+    // A live range suggestion owns pickerRect — drop that highlight too, and
+    // repaint so it actually leaves the canvas (the Escape path returns without
+    // its own render()). The range-accept path pre-clears _sugActive so its
+    // inserted ref stays lit.
+    if (_sugActive) { _sugActive = false; pickerRect = null; render() }
     if (_acEl) _acEl.style.display = 'none'
   }
 

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -1188,6 +1188,7 @@ import { useCurrentUser } from '@/boot/session'
 import { userInitials } from '../../utils/session.js'
 import { parseNumberFmt, buildNumberFmt, applyNumberFmt } from '../../utils/format-number.js'
 import { getTextWrap } from '../../utils/text-wrap.js'
+import { autoCloseKey } from '../../utils/formula-autoclose.js'
 import { computeFillDown, computeFillRight } from '../../engine/fill-series.js'
 import { detectSeries }                       from '../../engine/patterns/index.js'
 import { adjustFormula }                    from '../../engine/formula-adjust.js'
@@ -3718,6 +3719,16 @@ function onFormulaKey(e) {
     if (e.key === 'ArrowUp')   { e.preventDefault(); acIdx.value = Math.max(acIdx.value - 1, 0); return }
     if ((e.key === 'Tab' || e.key === 'Enter') && acItems.value[acIdx.value]) { e.preventDefault(); commitAc(acItems.value[acIdx.value]); return }  // item obj
     if (e.key === 'Escape') { acItems.value = []; return }
+  }
+  // Auto-close parens in the formula bar, mirroring the in-cell editor.
+  const ac = autoCloseKey(e.key, e.target.value, e.target.selectionStart, e.target.selectionEnd)
+  if (ac) {
+    e.preventDefault()
+    const el = e.target
+    formulaValue.value = ac.value
+    updateAc(ac.value, ac.caret)
+    nextTick(() => el.setSelectionRange(ac.caret, ac.caret))
+    return
   }
   if (e.key === 'Enter' || e.key === 'Tab') {
     e.preventDefault()

--- a/frontend/src/apps/sheets/components/SheetEditor/useFormulaAutocomplete.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useFormulaAutocomplete.js
@@ -34,7 +34,9 @@ export function useFormulaAutocomplete({ formulaInputRef, formulaValue, sheetNam
     if (!result) { acItems.value = []; return }
     const { tok: _tok, tokStart } = result
     const cursor = input.selectionStart
-    const suffix = item.kind === 'sheet' ? '!' : '('
+    // Functions get an auto-closed '()' with the caret landing inside; sheets
+    // get a trailing '!'. Caret sits one char past the name in both cases.
+    const suffix = item.kind === 'sheet' ? '!' : '()'
     formulaValue.value = input.value.slice(0, tokStart) + item.name + suffix + input.value.slice(cursor)
     nextTick(() => {
       const pos = tokStart + item.name.length + 1

--- a/frontend/src/apps/sheets/components/SheetEditor/useFormulaAutocomplete.test.ts
+++ b/frontend/src/apps/sheets/components/SheetEditor/useFormulaAutocomplete.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { parseAcToken, useFormulaAutocomplete, AC_FUNS } from './useFormulaAutocomplete.js'
+import { AC_FUN_KEYS } from '../../utils/formula-ac.js'
+
+// ── parseAcToken ──────────────────────────────────────────────────────────────
+
+describe('parseAcToken', () => {
+  it('returns null for plain text (no leading =)', () => {
+    expect(parseAcToken('hello', 5)).toBeNull()
+  })
+
+  it('returns null for empty value', () => {
+    expect(parseAcToken('', 0)).toBeNull()
+  })
+
+  it('extracts token at start of formula', () => {
+    expect(parseAcToken('=SU', 3)).toEqual({ tok: 'SU', tokStart: 1 })
+  })
+
+  it('extracts token after opening paren', () => {
+    expect(parseAcToken('=SUM(AV', 7)).toEqual({ tok: 'AV', tokStart: 5 })
+  })
+
+  it('extracts token after comma', () => {
+    expect(parseAcToken('=IF(A1,TR', 9)).toEqual({ tok: 'TR', tokStart: 7 })
+  })
+
+  it('extracts token after operator', () => {
+    expect(parseAcToken('=A1+RO', 6)).toEqual({ tok: 'RO', tokStart: 4 })
+  })
+
+  it('returns the token even when it looks like a cell ref (no function filter here)', () => {
+    // Token extraction is permissive; updateAc will simply find no matches for 'A1'
+    expect(parseAcToken('=A1', 3)).toEqual({ tok: 'A1', tokStart: 1 })
+  })
+
+  it('returns null when formula has no token at cursor', () => {
+    expect(parseAcToken('=SUM(', 5)).toBeNull()
+  })
+})
+
+describe('AC_FUN_KEYS', () => {
+  it('is pre-sorted and matches AC_FUNS keys', () => {
+    expect(AC_FUN_KEYS).toEqual(Object.keys(AC_FUNS).sort())
+  })
+})
+
+// ── useFormulaAutocomplete ────────────────────────────────────────────────────
+
+function makeAc(sheetList = []) {
+  const formulaInputRef = ref(null)
+  const formulaValue    = ref('')
+  const sheetNames      = ref(sheetList)
+  const ac = useFormulaAutocomplete({ formulaInputRef, formulaValue, sheetNames })
+  return { ...ac, formulaInputRef, formulaValue, sheetNames }
+}
+
+describe('updateAc', () => {
+  it('populates acItems with matching function names', () => {
+    const { acItems, updateAc } = makeAc()
+    updateAc('=SU', 3)
+    const names = acItems.value.map(i => i.name)
+    expect(names).toContain('SUM')
+    expect(names).toContain('SUBSTITUTE')
+    expect(acItems.value.every(i => i.kind === 'fn')).toBe(true)
+  })
+
+  it('clears acItems when no match', () => {
+    const { acItems, updateAc } = makeAc()
+    updateAc('=SU', 3)
+    updateAc('=ZZZ', 4)
+    expect(acItems.value).toHaveLength(0)
+  })
+
+  it('clears acItems when not in a formula', () => {
+    const { acItems, updateAc } = makeAc()
+    updateAc('hello', 5)
+    expect(acItems.value).toHaveLength(0)
+  })
+
+  it('includes sheet names with kind=sheet', () => {
+    const { acItems, updateAc } = makeAc(['Sales', 'Summary'])
+    updateAc('=SA', 3)
+    const sheets = acItems.value.filter(i => i.kind === 'sheet')
+    expect(sheets.map(i => i.name)).toContain('Sales')
+  })
+
+  it('does not duplicate sheet names already matched as functions', () => {
+    const { acItems, updateAc } = makeAc(['SUM'])
+    updateAc('=SU', 3)
+    const sumItems = acItems.value.filter(i => i.name === 'SUM')
+    expect(sumItems).toHaveLength(1)
+  })
+
+  it('resets acIdx to 0 on each update', () => {
+    const { acIdx, updateAc } = makeAc()
+    acIdx.value = 3
+    updateAc('=SU', 3)
+    expect(acIdx.value).toBe(0)
+  })
+
+  it('limits function results to 6', () => {
+    const { acItems, updateAc } = makeAc()
+    updateAc('=C', 2)
+    expect(acItems.value.filter(i => i.kind === 'fn').length).toBeLessThanOrEqual(6)
+  })
+})
+
+describe('acVisible', () => {
+  it('is false when acItems is empty', () => {
+    const { acVisible } = makeAc()
+    expect(acVisible.value).toBe(false)
+  })
+
+  it('is true when acItems has entries', () => {
+    const { acVisible, updateAc } = makeAc()
+    updateAc('=SU', 3)
+    expect(acVisible.value).toBe(true)
+  })
+})
+
+describe('closeAc', () => {
+  it('clears acItems and resets acUp', () => {
+    const { acItems, acUp, acVisible, closeAc, updateAc } = makeAc()
+    updateAc('=SU', 3)
+    acUp.value = true
+    closeAc()
+    expect(acVisible.value).toBe(false)
+    expect(acUp.value).toBe(false)
+  })
+})
+
+describe('commitAc', () => {
+  it('inserts function name with auto-closed () into formulaValue', () => {
+    const { commitAc, formulaValue, formulaInputRef } = makeAc()
+    formulaValue.value = '=SU'
+    formulaInputRef.value = { selectionStart: 3, value: '=SU', setSelectionRange: () => {} }
+    commitAc({ name: 'SUM', kind: 'fn' })
+    expect(formulaValue.value).toBe('=SUM()')
+  })
+
+  it('inserts sheet name with ! suffix', () => {
+    const { commitAc, formulaValue, formulaInputRef } = makeAc()
+    formulaValue.value = '=SA'
+    formulaInputRef.value = { selectionStart: 3, value: '=SA', setSelectionRange: () => {} }
+    commitAc({ name: 'Sales', kind: 'sheet' })
+    expect(formulaValue.value).toBe('=Sales!')
+  })
+
+  it('clears acItems after commit', () => {
+    const { commitAc, acItems, updateAc, formulaInputRef, formulaValue } = makeAc()
+    updateAc('=SU', 3)
+    formulaValue.value = '=SU'
+    formulaInputRef.value = { selectionStart: 3, value: '=SU', setSelectionRange: () => {} }
+    commitAc({ name: 'SUM', kind: 'fn' })
+    expect(acItems.value).toHaveLength(0)
+  })
+
+  it('does nothing when formulaInputRef is null', () => {
+    const { commitAc, formulaValue } = makeAc()
+    formulaValue.value = '=SU'
+    expect(() => commitAc({ name: 'SUM', kind: 'fn' })).not.toThrow()
+    expect(formulaValue.value).toBe('=SU')
+  })
+})
+
+describe('AC_FUNS', () => {
+  it('exports the full function signature map', () => {
+    expect(AC_FUNS['SUM']).toBe('(number1, ...)')
+    expect(AC_FUNS['IF']).toContain('test')
+    expect(AC_FUNS['VLOOKUP']).toContain('col_index')
+  })
+})

--- a/frontend/src/apps/sheets/utils/formula-ac.js
+++ b/frontend/src/apps/sheets/utils/formula-ac.js
@@ -88,6 +88,57 @@ export function parseSignatureContext(value, cursor) {
   return null
 }
 
+// Functions where an adjacent numeric run is a sensible first-argument guess.
+// Kept narrow so we never nudge a range into e.g. IF( or CONCAT(.
+export const RANGE_SUGGEST_FUNS = new Set([
+  'SUM', 'AVERAGE', 'COUNT', 'COUNTA', 'MAX', 'MIN', 'PRODUCT', 'MEDIAN',
+])
+
+/**
+ * True when the caret sits at the empty first argument of a range-friendly
+ * function — the spot where Google Sheets offers an adjacent-range guess.
+ * Requires the arg to be empty on both sides so `=SUM(A1)` never re-suggests.
+ */
+export function shouldSuggestRange(value, cursor) {
+  const ctx = parseSignatureContext(value, cursor)
+  if (!ctx || ctx.argIndex !== 0 || !RANGE_SUGGEST_FUNS.has(ctx.fn)) return false
+  const left = value.slice(0, cursor).replace(/\s+$/, '')
+  if (!left.endsWith('(')) return false
+  const right = value.slice(cursor).replace(/^\s+/, '')
+  return right === '' || right.startsWith(')') || right.startsWith(',')
+}
+
+/**
+ * True when a display string reads as a number (tolerating currency symbols,
+ * thousands separators, percent and surrounding space) — used to decide which
+ * cells belong to a suggested range.
+ */
+export function isNumericText(v) {
+  if (v == null) return false
+  const stripped = String(v).replace(/[$€£₹%,\s]/g, '')
+  return stripped !== '' && Number.isFinite(Number(stripped))
+}
+
+/**
+ * Walk up (then left) from the active cell over a contiguous run of numeric
+ * cells — the adjacency Google Sheets guesses for SUM-style ranges.
+ * `isNumericAt(r, c)` reports whether that cell holds a number. Returns
+ * { r0, c0, r1, c1 } or null when no run of >= 2 cells abuts the cell.
+ */
+export function detectAdjacentRange(r, c, isNumericAt) {
+  if (r - 1 >= 0 && isNumericAt(r - 1, c)) {
+    let top = r - 1
+    while (top - 1 >= 0 && isNumericAt(top - 1, c)) top--
+    if (r - top >= 2) return { r0: top, c0: c, r1: r - 1, c1: c }
+  }
+  if (c - 1 >= 0 && isNumericAt(r, c - 1)) {
+    let left = c - 1
+    while (left - 1 >= 0 && isNumericAt(r, left - 1)) left--
+    if (c - left >= 2) return { r0: r, c0: left, r1: r, c1: c - 1 }
+  }
+  return null
+}
+
 /**
  * Split a function's signature into its parameter names and mark which one is
  * active for the given argument index. The trailing variadic param (`...`)

--- a/frontend/src/apps/sheets/utils/formula-ac.test.ts
+++ b/frontend/src/apps/sheets/utils/formula-ac.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { parseAcToken, parseSignatureContext, describeSignature } from './formula-ac.js'
+import {
+  parseAcToken, parseSignatureContext, describeSignature,
+  shouldSuggestRange, detectAdjacentRange, isNumericText,
+} from './formula-ac.js'
 
 describe('parseAcToken', () => {
   it('finds the function name being typed', () => {
@@ -55,5 +58,62 @@ describe('describeSignature', () => {
   })
   it('returns null for an unknown function', () => {
     expect(describeSignature('NOPE', 0)).toBeNull()
+  })
+})
+
+describe('isNumericText', () => {
+  it('accepts plain, formatted and signed numbers', () => {
+    for (const v of ['1', '-5', '3.14', '1,234', '$5', '42%', ' 7 '])
+      expect(isNumericText(v)).toBe(true)
+  })
+  it('rejects blanks and non-numbers', () => {
+    for (const v of [null, undefined, '', '   ', 'abc', '=SUM(A1)'])
+      expect(isNumericText(v)).toBe(false)
+  })
+})
+
+describe('shouldSuggestRange', () => {
+  it('is true at the empty first arg of a range function', () => {
+    expect(shouldSuggestRange('=SUM(', 5)).toBe(true)
+    expect(shouldSuggestRange('=AVERAGE(', 9)).toBe(true)
+  })
+  it('is false once the arg has content', () => {
+    expect(shouldSuggestRange('=SUM(A1', 7)).toBe(false)
+  })
+  it('is true when the caret precedes a closing paren', () => {
+    expect(shouldSuggestRange('=SUM()', 5)).toBe(true)
+  })
+  it('is false past the first argument', () => {
+    expect(shouldSuggestRange('=SUM(A1,', 8)).toBe(false)
+  })
+  it('is false for non-range functions', () => {
+    expect(shouldSuggestRange('=IF(', 4)).toBe(false)
+    expect(shouldSuggestRange('=CONCAT(', 8)).toBe(false)
+  })
+})
+
+describe('detectAdjacentRange', () => {
+  // Grid of numeric cells keyed "r,c"; everything else is blank.
+  const grid = (cells) => (r, c) => cells.has(`${r},${c}`)
+
+  it('walks up a contiguous column above the active cell', () => {
+    const numeric = grid(new Set(['0,0', '1,0', '2,0']))   // A1:A3 filled, active A4
+    expect(detectAdjacentRange(3, 0, numeric)).toEqual({ r0: 0, c0: 0, r1: 2, c1: 0 })
+  })
+  it('stops at a blank gap', () => {
+    const numeric = grid(new Set(['0,0', '2,0']))          // A2 blank, active A4
+    // Only A3 (row 2) abuts A4 → single cell, below the 2-cell floor.
+    expect(detectAdjacentRange(3, 0, numeric)).toBeNull()
+  })
+  it('falls back to the row on the left when nothing is above', () => {
+    const numeric = grid(new Set(['3,0', '3,1', '3,2']))   // A4:C4 filled, active D4
+    expect(detectAdjacentRange(3, 3, numeric)).toEqual({ r0: 3, c0: 0, r1: 3, c1: 2 })
+  })
+  it('prefers the column above over the row to the left', () => {
+    const numeric = grid(new Set(['1,3', '2,3', '3,0', '3,1', '3,2']))  // above D2:D3, left A4:C4
+    expect(detectAdjacentRange(3, 3, numeric)).toEqual({ r0: 1, c0: 3, r1: 2, c1: 3 })
+  })
+  it('returns null with no adjacent numbers', () => {
+    expect(detectAdjacentRange(3, 3, grid(new Set()))).toBeNull()
   })
 })

--- a/frontend/src/apps/sheets/utils/formula-autoclose.js
+++ b/frontend/src/apps/sheets/utils/formula-autoclose.js
@@ -1,0 +1,35 @@
+// Auto-close of parentheses inside a formula input, matching Google Sheets:
+// typing `(` inserts a matching `)`, typing `)` in front of an auto-inserted
+// one skips over it, and Backspace between an empty `()` pair removes both.
+// Pure over (value, caret) so the in-cell overlay and the formula bar can
+// share it. Only formulas (`=…`) are auto-closed — plain text is left alone.
+
+// Handle a keydown that may trigger auto-close. Returns the next
+// { value, caret } when handled (caller should preventDefault and apply it),
+// or null when the key isn't one we act on and native input should proceed.
+export function autoCloseKey(key, value, selStart, selEnd) {
+  if (!value.startsWith('=')) return null
+
+  if (key === '(') {
+    const inner = value.slice(selStart, selEnd)   // wrap any selection
+    const next  = value.slice(0, selStart) + '(' + inner + ')' + value.slice(selEnd)
+    return { value: next, caret: selStart + 1 }
+  }
+
+  // Nothing else acts on a non-empty selection.
+  if (selStart !== selEnd) return null
+
+  // Typing `)` directly before an existing `)` steps over it instead of
+  // stacking a duplicate — the natural counterpart to auto-inserting one.
+  if (key === ')' && value[selStart] === ')') {
+    return { value, caret: selStart + 1 }
+  }
+
+  // Backspace inside an empty `()` clears the whole pair.
+  if (key === 'Backspace' && value[selStart - 1] === '(' && value[selStart] === ')') {
+    const next = value.slice(0, selStart - 1) + value.slice(selStart + 1)
+    return { value: next, caret: selStart - 1 }
+  }
+
+  return null
+}

--- a/frontend/src/apps/sheets/utils/formula-autoclose.js
+++ b/frontend/src/apps/sheets/utils/formula-autoclose.js
@@ -13,7 +13,11 @@ export function autoCloseKey(key, value, selStart, selEnd) {
   if (key === '(') {
     const inner = value.slice(selStart, selEnd)   // wrap any selection
     const next  = value.slice(0, selStart) + '(' + inner + ')' + value.slice(selEnd)
-    return { value: next, caret: selStart + 1 }
+    // With a selection, drop the caret past the wrapped text (after the new
+    // `)`) so typing continues the call — matching Google Sheets. With no
+    // selection, leave it inside the fresh pair to type the first argument.
+    const caret = selStart === selEnd ? selStart + 1 : selEnd + 2
+    return { value: next, caret }
   }
 
   // Nothing else acts on a non-empty selection.

--- a/frontend/src/apps/sheets/utils/formula-autoclose.test.ts
+++ b/frontend/src/apps/sheets/utils/formula-autoclose.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { autoCloseKey } from './formula-autoclose.js'
+
+describe('autoCloseKey', () => {
+  it('leaves plain text alone (no leading =)', () => {
+    expect(autoCloseKey('(', 'note (', 6, 6)).toBeNull()
+  })
+
+  it('inserts a matching ) and keeps the caret inside', () => {
+    expect(autoCloseKey('(', '=SUM', 4, 4)).toEqual({ value: '=SUM()', caret: 5 })
+  })
+
+  it('wraps a selection when ( is typed over it', () => {
+    // caret span covers "A1" in "=A1"
+    expect(autoCloseKey('(', '=A1', 1, 3)).toEqual({ value: '=(A1)', caret: 2 })
+  })
+
+  it('steps over an existing ) instead of duplicating it', () => {
+    expect(autoCloseKey(')', '=SUM()', 5, 5)).toEqual({ value: '=SUM()', caret: 6 })
+  })
+
+  it('does not step over when the next char is not )', () => {
+    expect(autoCloseKey(')', '=SUM(1', 6, 6)).toBeNull()
+  })
+
+  it('Backspace clears an empty () pair', () => {
+    expect(autoCloseKey('Backspace', '=SUM()', 5, 5)).toEqual({ value: '=SUM', caret: 4 })
+  })
+
+  it('Backspace is left to native handling when the pair is not empty', () => {
+    expect(autoCloseKey('Backspace', '=SUM(1)', 6, 6)).toBeNull()
+  })
+
+  it('returns null for ) / Backspace when there is a selection', () => {
+    expect(autoCloseKey(')', '=SUM()', 4, 6)).toBeNull()
+    expect(autoCloseKey('Backspace', '=SUM()', 4, 6)).toBeNull()
+  })
+
+  it('returns null for keys it does not handle', () => {
+    expect(autoCloseKey('a', '=SUM', 4, 4)).toBeNull()
+  })
+})

--- a/frontend/src/apps/sheets/utils/formula-autoclose.test.ts
+++ b/frontend/src/apps/sheets/utils/formula-autoclose.test.ts
@@ -10,9 +10,9 @@ describe('autoCloseKey', () => {
     expect(autoCloseKey('(', '=SUM', 4, 4)).toEqual({ value: '=SUM()', caret: 5 })
   })
 
-  it('wraps a selection when ( is typed over it', () => {
-    // caret span covers "A1" in "=A1"
-    expect(autoCloseKey('(', '=A1', 1, 3)).toEqual({ value: '=(A1)', caret: 2 })
+  it('wraps a selection when ( is typed over it and lands past the )', () => {
+    // caret span covers "A1" in "=A1"; caret ends after the inserted ')'
+    expect(autoCloseKey('(', '=A1', 1, 3)).toEqual({ value: '=(A1)', caret: 5 })
   })
 
   it('steps over an existing ) instead of duplicating it', () => {


### PR DESCRIPTION
Closes three formula-editing parity gaps versus Google Sheets, reported from real use in the in-cell editor.

## What changed

### 1. Click-to-extend range picking
While editing a formula, a plain **click** inserts a cell ref and the **next click extends it to a range** (`=SUM(A1)` → `=SUM(A1:A3)`) — no drag or modifier needed. The anchor only "continues" while the last-picked ref still abuts the caret, so typing an operator/comma — or picking in a new argument (e.g. VLOOKUP's 2nd arg) — starts a fresh ref. `Shift`+click also extends. This replaces the previous *replace-on-second-click* behavior. Works for both the in-cell editor and the formula bar.

### 2. Auto-close parentheses
New shared `formula-autoclose.js`, wired into both the in-cell overlay and the formula bar:
- typing `(` inserts `()` with the caret inside
- typing `)` in front of an auto-inserted one steps over it instead of duplicating
- `Backspace` inside an empty `()` deletes the pair
- accepting a function from autocomplete now inserts `SUM()` (caret inside) instead of `SUM(`

Only active inside formulas (`=…`), so plain text like `(note)` is untouched.

### 3. Adjacent range suggestion
At the empty first argument of a SUM-style function (`SUM`, `AVERAGE`, `COUNT`, `MAX`, `MIN`, `PRODUCT`, `MEDIAN`, …), the contiguous numeric run directly **above** (or to the **left** if nothing is above) is offered as a one-tap `A1:A3` range, highlighted on the grid. **Tab** fills it; **Enter** still commits the formula (so a wrong guess never hijacks Enter). In-cell only.

## Tests
Pure logic is unit-tested as `.test.ts` (`autoCloseKey`, `shouldSuggestRange`, `detectAdjacentRange`, `isNumericText`, plus the autocomplete suffix change) — runs in suite CI's vitest glob. Standalone full suite green (1272 tests).

## Notes
- Source-only; the built bundle is gitignored in suite and produced by CI.
- Range suggestion is in-cell only for now — the formula bar's autocomplete lives in the Vue layer without grid-value access; wiring it there is a straightforward follow-up.