### PR TITLE
fix(sheets): smooth, tight-fitting document title input

### DIFF
--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -42,16 +42,21 @@
             <path d="M73.6617 50.6653H63.1611V70.1439H73.6617V50.6653Z" fill="white"/>
           </svg>
         </button>
-        <input
-          name="sheet-title"
-          class="sn-title-input"
-          v-model="currentTitle"
-          :style="{ width: titleInputWidth }"
-          placeholder="Untitled Sheet"
-          spellcheck="false"
-          @focus="onTitleFocus"
-          @blur="onTitleBlur"
-        />
+        <!-- Auto-sizing title. A hidden ::after pseudo mirrors the text and
+             sizes the box via real DOM text layout, so the input grows
+             pixel-perfect and smooth per keystroke, with no JS canvas measuring
+             and no width animation lagging behind the caret. -->
+        <span class="sn-title-fit" :data-value="currentTitle || 'Untitled Sheet'">
+          <input
+            name="sheet-title"
+            class="sn-title-input"
+            v-model="currentTitle"
+            placeholder="Untitled Sheet"
+            spellcheck="false"
+            @focus="onTitleFocus"
+            @blur="onTitleBlur"
+          />
+        </span>
         <!-- Save status — muted inline text; never competes with the title -->
         <span v-if="isSaving" class="sn-save-status">
           <FeatherIcon name="loader" class="sn-save-icon sn-save-spin" />
@@ -1946,25 +1951,6 @@ const hAlignIcon = computed(() => {
   return 'align-left'
 })
 
-
-// Title input auto-sizes to content so the "Saved / Saving…" status sits
-// right next to the title text — no trailing whitespace. Canvas measurement
-// is exact (per-char estimates over-allocated and left visible empty space
-// between title and status). Lower bound is a clickable target for very
-// short titles; upper bound stops a runaway title from eating the topbar.
-let _titleMeasureCtx = null
-function _measureTitle(text) {
-  if (!_titleMeasureCtx) {
-    _titleMeasureCtx = document.createElement('canvas').getContext('2d')
-    _titleMeasureCtx.font = '600 15px InterVar, ui-sans-serif, system-ui, sans-serif'
-  }
-  return _titleMeasureCtx.measureText(text).width
-}
-const titleInputWidth = computed(() => {
-  const text = currentTitle.value || 'Untitled Sheet'
-  // +22 = 20px horizontal padding + 2px caret/safety
-  return Math.max(56, Math.min(520, _measureTitle(text) + 22)) + 'px'
-})
 
 
 // The logged-in user for the top-right avatar, from the shared suite session
@@ -5487,7 +5473,7 @@ function toggleShowFormulas() {
 /* Left cluster groups: brand+title tight (gap:4); status chips sit further away
    (gap:12) so the title reads as the focal point, not crowded by badges. */
 .sn-topbar-left  { display:flex; align-items:center; gap:8px; min-width:0; }
-.sn-topbar-left  > .sn-app-icon-btn + .sn-title-input { margin-left:-8px; }
+.sn-topbar-left  > .sn-app-icon-btn + .sn-title-fit { margin-left:-8px; }
 .sn-topbar-right { display:flex; align-items:center; gap:6px; flex-shrink:0; }
 
 .sn-app-icon { width:28px; height:28px; flex-shrink:0; display:block; }
@@ -5499,7 +5485,26 @@ function toggleShowFormulas() {
 .sn-app-icon-btn:hover  { background:var(--surface-gray-2); }
 .sn-app-icon-btn:focus-visible { outline:2px solid var(--outline-gray-4); outline-offset:2px; }
 
-.sn-title-input { height:32px; border:1px solid transparent; border-radius:6px; padding:0 10px; font-size:15px; font-weight:600; color:var(--ink-gray-9); background:transparent; outline:none; font-family:inherit; letter-spacing:-.005em; transition:background-color .12s, border-color .12s, width .1s; }
+/* Auto-sizing title. A hidden ::after mirror carries the exact same typography
+   and box as the input; being normal flow, ITS width sizes the wrapper to the
+   real rendered text. The input is positioned absolutely on top so its own
+   intrinsic ~20ch width is taken out of the layout — otherwise it, not the
+   text, would dictate the box. Result: the box hugs the text and grows smoothly
+   per keystroke, with no width animation lagging the caret and no canvas
+   measurement drifting from actual metrics. min/max-width keep the old
+   click-target floor and runaway-title ceiling. */
+.sn-title-fit { position:relative; display:inline-block; min-width:56px; max-width:520px; }
+.sn-title-fit::after {
+  content:attr(data-value) ' ';
+  display:block;
+  visibility:hidden;
+  white-space:pre;
+  box-sizing:border-box;
+  height:32px; border:1px solid transparent; padding:0 10px;
+  max-width:520px; overflow:hidden;
+  font-size:15px; font-weight:600; font-family:inherit; letter-spacing:-.005em;
+}
+.sn-title-input { position:absolute; inset:0; box-sizing:border-box; width:100%; height:100%; border:1px solid transparent; border-radius:6px; padding:0 10px; font-size:15px; font-weight:600; color:var(--ink-gray-9); background:transparent; outline:none; font-family:inherit; letter-spacing:-.005em; transition:background-color .12s, border-color .12s; }
 
 .sn-title-input:hover { background:var(--surface-gray-2); }
 .sn-title-input:focus { border-color:var(--outline-gray-4); background:var(--surface-base); box-shadow:0 0 0 2px rgba(23,23,23,.10); }

--- a/frontend/src/apps/sheets/components/SheetEditor/usePersistence.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/usePersistence.js
@@ -150,7 +150,13 @@ export function usePersistence({ sheet, formats, merge, comments, validation, pr
         }
         try {
           const result = await call('suite.sheets.api.save_sheet', args, { keepalive })
-          currentTitle.value = title
+          // Deliberately DON'T write `title` back into currentTitle here.
+          // `title` is a snapshot captured when this save was queued (up to
+          // the 2s debounce + network round-trip ago), and the server echoes
+          // nothing new — so assigning it back can only clobber keystrokes the
+          // user typed while the save was in flight and reset their caret to
+          // the end (the "jittery title" bug). currentTitle is already the
+          // local source of truth; leave it alone.
           // First success clears any sticky error from a previous failure.
           saveError.value = ''
           _lastSaveArgs   = null


### PR DESCRIPTION
## What

The Sheets editor's document-title input felt **jittery on every keystroke** and, in some states, sat inside an **unnecessarily wide box**. This fixes both.

## Why it was jittery

1. **Width animation fighting the caret.** The input's width was recomputed per keystroke via JS canvas measurement and animated with `transition: width .1s`. Keystrokes arrive faster than 100ms, so the box was perpetually animating toward a moving target — visibly lagging behind the caret. The canvas also measured the font *without* the input's `-.005em` letter-spacing, so each width was slightly off and the text wobbled.
2. **Stale save write-back.** On every successful save, `_persist` wrote the save-request's snapshot `title` back into `currentTitle` — the same ref bound to the input via `v-model`. Because the save is a debounced async round-trip, this reverted any keystrokes typed while it was in flight and reset the caret to the end.

## The fix

- **Drop the JS measuring; let real DOM text layout size the input.** A hidden `::after` mirror carries identical typography and sizes the box to the actual rendered text. The input is positioned **absolutely** on top so its own intrinsic ~20-character width stays out of the layout — otherwise the `<input>` (not the text) padded the box out to ~20 chars regardless of content, which is what caused the oversized box. Grows smoothly, hugs the text, no width animation, no metric drift. `min/max-width` preserve the old click-target floor (56px) and runaway-title ceiling (520px).
- **Stop writing the stale title back after save.** `currentTitle` is already the local source of truth; the server echoes nothing new, so the write-back could only clobber in-flight keystrokes.

## Scope

Source-only, two files under `frontend/src/apps/sheets/components/SheetEditor/`:
- `index.vue` — template wrapper + auto-sizing CSS; removed the canvas-measuring helper/computed.
- `usePersistence.js` — removed the post-save `currentTitle` write-back.

## Testing

- SFC parses + compiles clean; `usePersistence.js` passes `node --check`.
- Existing `usePersistence` unit tests pass (none asserted the removed write-back).
- Verified live in the standalone dev server: the title box now hugs the text and grows smoothly while typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)