### PR TITLE
fix(meet): stack avatar group to the right

### DIFF
--- a/frontend/src/apps/meet/components/UpcomingMeetings.vue
+++ b/frontend/src/apps/meet/components/UpcomingMeetings.vue
@@ -152,7 +152,6 @@ defineExpose({ reload })
 								:error="null"
 								:max-displayed="2"
 								size="sm"
-								stack-direction="left"
 							/>
 						</div>
 					</div>


### PR DESCRIPTION
### Before

<img width="1120" height="304" alt="image" src="https://github.com/user-attachments/assets/a39fefb7-3f50-4e6a-84b3-9e494bfed63b" />

### After

<img width="604" height="244" alt="image" src="https://github.com/user-attachments/assets/51f02141-23ed-46e6-9f50-b8301df3bba0" />
