### PR TITLE
 fix(slides): properties panel stealing focus from text editor

### DIFF
--- a/frontend/src/apps/slides/components/PropertiesPanel.vue
+++ b/frontend/src/apps/slides/components/PropertiesPanel.vue
@@ -1,5 +1,8 @@
 <template>
-	<div class="no-scrollbar flex h-full w-72 flex-col overflow-y-auto border-l bg-surface-base px-4">
+	<div
+		class="no-scrollbar flex h-full w-72 flex-col overflow-y-auto border-l bg-surface-base px-4"
+		@mousedown="keepEditorFocus"
+	>
 		<div v-if="activeElementIds.length">
 			<PositionSection />
 			<Divider flexItem />
@@ -59,4 +62,9 @@ import TransitionSection from './TransitionSection.vue'
 const isEditingShapeText = computed(
 	() => activeElement.value?.type === 'shape' && focusElementId.value === activeElement.value?.id,
 )
+
+const keepEditorFocus = (e) => {
+	if (e.target.closest('input, textarea')) return
+	e.preventDefault()
+}
 </script>

--- a/frontend/src/apps/slides/components/TextElement.vue
+++ b/frontend/src/apps/slides/components/TextElement.vue
@@ -132,6 +132,10 @@ onBeforeMount(() => normalizeContent())
 	outline: none;
 }
 
+.persisted-selection {
+	background-color: Highlight;
+}
+
 .tiptap ul,
 .textElement > ul {
 	list-style: none;

--- a/frontend/src/apps/slides/composables/useTextEditor.js
+++ b/frontend/src/apps/slides/composables/useTextEditor.js
@@ -107,7 +107,7 @@ export const useTextEditor = () => {
 	const toggleMark = (property) => {
 		const currentEditor = activeEditor.value
 
-		const chain = currentEditor.chain().focus()
+		const chain = currentEditor.chain()
 
 		const { empty } = currentEditor.state.selection
 		if (empty) chain.selectAll()
@@ -160,7 +160,7 @@ export const useTextEditor = () => {
 
 		if (value == current) return
 
-		const chain = activeEditor.value.chain().focus()
+		const chain = activeEditor.value.chain()
 
 		if (value == 'none') {
 			chain.liftListItem('listItem').run()
@@ -179,7 +179,7 @@ export const useTextEditor = () => {
 	const updateProperty = (property, value) => {
 		const currentEditor = activeEditor.value
 
-		const chain = currentEditor.chain().focus()
+		const chain = currentEditor.chain()
 
 		if (property == 'list') return setListProperty(value)
 

--- a/frontend/src/apps/slides/stores/tiptapSetup.js
+++ b/frontend/src/apps/slides/stores/tiptapSetup.js
@@ -9,6 +9,7 @@ import BulletList from '@tiptap/extension-bullet-list'
 import OrderedList from '@tiptap/extension-ordered-list'
 import ListItem from '@tiptap/extension-list-item'
 import Color from '@tiptap/extension-color'
+import { Selection } from '@tiptap/extensions'
 
 import { Plugin, PluginKey, TextSelection } from 'prosemirror-state'
 import { joinBackward } from 'prosemirror-commands'
@@ -689,4 +690,5 @@ export const extensions = [
 	}),
 	StyledEmptyLine,
 	LineHeight,
+	Selection.configure({ className: 'persisted-selection' }),
 ]


### PR DESCRIPTION
### Problem

Editing text using the properties panel was breaking in a few ways:

- Dragging in the color picker closed the picker.
- Changing the font or color made the text highlight disappear.
- Clicking into the font size box made the highlight disappear.
- Arrow keys in the font size box moved the text cursor instead of changing the number.

#### What was happening before?

**1. The panel was pulling focus back to the editor.**

Panel property writes called `.chain().focus()`. That fires a `focusin` event on the editor. The popover closes on any `focusin` outside itself, so the color picker shut the moment you dragged.

It also explains the font size box. The first arrow key worked, then focus jumped back to the editor, so every arrow key after that moved the text cursor instead.

**2. Browsers do not paint a selection inside an unfocused editor.**

Some controls genuinely need focus, like the font size box and the hex field. Once they take it, the highlight disappears even though the selection is still there.

<br>

### Fix

- Removed `.focus()` from the three panel property writes. They already work on the current selection without it.
- Added a `mousedown` guard on the panel so clicking it does not blur the editor. Real inputs are exempt, so they still work normally.
- Enabled tiptap's `Selection` extension, which keeps the selection visible while the editor is unfocused.