### PR TITLE
fix(slides): punctuation jumping when editing text elements

### DIFF
--- a/frontend/src/apps/slides/components/TextElement.vue
+++ b/frontend/src/apps/slides/components/TextElement.vue
@@ -132,6 +132,14 @@ onBeforeMount(() => normalizeContent())
 	outline: none;
 }
 
+/* match prosemirror's own .ProseMirror rule, else Inter's contextual alternates
+   raise punctuation (+ : - =) on the static render but not in the editor */
+.textElement,
+.textElement .ProseMirror {
+	font-variant-ligatures: none;
+	font-feature-settings: 'liga' 0;
+}
+
 .persisted-selection {
 	background-color: Highlight;
 }


### PR DESCRIPTION
`+`, `:`,`-` and few other characters shifted vertically on select / de-select, and again when typed at the start of a line. 

<br>

Two causes:
- ProseMirror disables ligatures on `.ProseMirror`, which also kills Inter's contextual alternates. The static render kept them, so the same text rendered at two different heights.
- Chrome skips re-shaping a text run when a character is pre-pended at offset 0, so a newly typed `+` stayed low until blur.

<br>

Turning contextual alternates off on both render paths removes the glyph swap entirely. Punctuation next to digits and caps now sits slightly lower everywhere, matching what the editor already showed.