### PR TITLE
feat(mail): keep forwarded emails in the same thread

### DIFF
--- a/frontend/src/apps/mail/components/Settings/Account.vue
+++ b/frontend/src/apps/mail/components/Settings/Account.vue
@@ -47,6 +47,17 @@
 		>
 			<Switch v-model="destroyNewsletterAfterSubmit" />
 		</SettingsRow>
+		<SettingsRow
+			class="!py-0"
+			:title="__('Keep Forwarded Email In Thread')"
+			:description="
+				__(
+					'Keep forwarded emails in the same thread as the original by referencing it in the In-Reply-To header.',
+				)
+			"
+		>
+			<Switch v-model="keepForwardedEmailInThread" />
+		</SettingsRow>
 
 		<h2 class="text-base-semibold text-ink-gray-8">{{ __('Incoming') }}</h2>
 		<SettingsRow
@@ -148,6 +159,11 @@ const destroyEmailAfterSubmit = computed({
 const destroyNewsletterAfterSubmit = computed({
 	get: () => !!jmapAccount.doc.destroy_newsletter_after_submit,
 	set: (val: boolean) => (jmapAccount.doc.destroy_newsletter_after_submit = val ? 1 : 0),
+})
+
+const keepForwardedEmailInThread = computed({
+	get: () => !!jmapAccount.doc.keep_forwarded_email_in_thread,
+	set: (val: boolean) => (jmapAccount.doc.keep_forwarded_email_in_thread = val ? 1 : 0),
 })
 
 const enableScreening = computed({

--- a/suite/mail/doctype/jmap_account/jmap_account.json
+++ b/suite/mail/doctype/jmap_account/jmap_account.json
@@ -16,6 +16,7 @@
   "create_contacts_after_email_submit",
   "destroy_email_after_submit",
   "destroy_newsletter_after_submit",
+  "keep_forwarded_email_in_thread",
   "incoming_section",
   "on_mark_as_junk",
   "column_break_fnnk",
@@ -74,6 +75,14 @@
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Destroy Newsletter After Submit"
+  },
+  {
+   "default": "0",
+   "description": "When enabled, forwarded emails include an In-Reply-To header pointing to the original email, so the mail server keeps them in the same thread as the original.",
+   "fieldname": "keep_forwarded_email_in_thread",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Keep Forwarded Email In Thread"
   },
   {
    "fieldname": "incoming_section",
@@ -330,7 +339,7 @@
    "link_fieldname": "account"
   }
  ],
- "modified": "2026-07-22 14:56:41.320704",
+ "modified": "2026-07-22 15:10:00.000000",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "JMAP Account",

--- a/suite/mail/doctype/jmap_account/jmap_account.py
+++ b/suite/mail/doctype/jmap_account/jmap_account.py
@@ -53,6 +53,7 @@ class JMAPAccount(Document):
 		enable_screening: DF.Check
 		is_personal: DF.Check
 		is_readonly: DF.Check
+		keep_forwarded_email_in_thread: DF.Check
 		last_active_sieve_script_id: DF.Data | None
 		on_mark_as_junk: DF.Literal["Junk Sender's Mail", "Ask to Block Sender"]
 	# end: auto-generated types

--- a/suite/mail/doctype/mail_queue/mail_queue.py
+++ b/suite/mail/doctype/mail_queue/mail_queue.py
@@ -270,7 +270,7 @@ class MailQueue(OwnerFromUser, Document):
 		from suite.mail.doctype.mail_message.mail_message import _get_cached_blobs
 
 		if self.blob_id:
-			blobs = _get_cached_blobs(f"{self.user}:{self.account}", [self.blob_id])
+			blobs = _get_cached_blobs(self.account, [self.blob_id])
 			if content := blobs.get(self.blob_id):
 				return content.decode("utf-8")
 
@@ -664,7 +664,7 @@ class MailQueue(OwnerFromUser, Document):
 
 		from suite.mail.doctype.mail_message.mail_message import fetch_blob
 
-		return fetch_blob(f"{self.user}:{self.account}", self.blob_id).decode("utf-8")
+		return fetch_blob(self.account, self.blob_id).decode("utf-8")
 
 	def _process(self) -> None:
 		"""Create, Update or Submit the Email."""

--- a/suite/mail/doctype/mail_queue/mail_queue.py
+++ b/suite/mail/doctype/mail_queue/mail_queue.py
@@ -326,6 +326,7 @@ class MailQueue(OwnerFromUser, Document):
 			self.validate_priority()
 			self.validate_in_reply_to()
 			self.validate_in_reply_to_id()
+			self.validate_forwarded_in_reply_to()
 
 	def after_insert(self) -> None:
 		if self.delivery_mode == "Immediate":
@@ -615,6 +616,33 @@ class MailQueue(OwnerFromUser, Document):
 			except Exception:
 				self.in_reply_to_id = None
 				log_mail_error(_("Failed to fetch In Reply To ID"), frappe.get_traceback(with_context=True))
+
+	def validate_forwarded_in_reply_to(self) -> None:
+		"""Threads a forwarded email with the original.
+
+		When the account has "Keep Forwarded Email In Thread" enabled, sets the
+		In-Reply-To (Message-ID) of the forwarded email to the original's Message-ID
+		so the mail server assigns it the same thread as the original. The
+		In-Reply-To ID is intentionally left untouched: a forward should mark the
+		original as ``$forwarded`` (via ``forwarded_from_id``), not ``$answered``.
+		"""
+
+		if not self.forwarded_from_id or self.in_reply_to:
+			return
+
+		if not frappe.db.get_value("JMAP Account", self.account, "keep_forwarded_email_in_thread"):
+			return
+
+		try:
+			service = get_email_service(self.account)
+			emails = service.get([self.forwarded_from_id], properties=["messageId"])
+			# JMAP returns messageId as a list of Message-ID strings (RFC 5322 msg-id values).
+			if emails and (message_ids := emails[0].get("messageId")):
+				self.in_reply_to = message_ids[0].strip("<>")
+		except Exception:
+			log_mail_error(
+				_("Failed to fetch forwarded email Message-ID"), frappe.get_traceback(with_context=True)
+			)
 
 	@frappe.whitelist()
 	def retry(self) -> None:


### PR DESCRIPTION
## Summary

Two independent mail changes:

### 1. Keep forwarded emails in the same thread (feature)
Adds a per-account **Keep Forwarded Email In Thread** setting on JMAP Account. When enabled, a forwarded email gets an `In-Reply-To` header pointing to the original email's `Message-ID`, so the mail server assigns it the same thread as the original.

- New `keep_forwarded_email_in_thread` Check field on **JMAP Account** (Outgoing section) + matching controller type hint.
- `MailQueue.validate_forwarded_in_reply_to()` populates `in_reply_to` from the forwarded email's `Message-ID` (fetched via the JMAP email service) when the setting is on and the mail is a forward. It runs after `validate_in_reply_to_id` and leaves `in_reply_to_id` untouched, so the original is marked `$forwarded` (not `$answered`).
- Toggle surfaced in the mail account settings UI (`Account.vue`).

The compose/forward flow needed no change: it already sends `forwarded_from_id` without `in_reply_to`, so the backend picks up the setting automatically.

### 2. Fix blob fetch for Mail Queue (bug fix)
Mail's blob/data stores are namespaced solely by the JMAP account id, and `fetch_blobs` validates the account via `get_user_for_jmap_account`. Two Mail Queue call sites passed a combined `"{user}:{account}"` key, which is not a valid JMAP Account — raising `JMAP account ... does not exist` when reading a queued mail's cached body or MIME message. Now pass the bare `self.account`, matching every other caller.

## Testing
- Python syntax validated; JSON validated.
- Codebase scanned for other combined-key misuses — none found (the two remaining `{user}:{account}` strings are lock names, which are intentional).
