### PR TITLE
feat(store): add Search Store support to Store Entry browser

### DIFF
--- a/suite/store/search_store.py
+++ b/suite/store/search_store.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import os
 import shutil
 from dataclasses import dataclass
@@ -343,3 +344,115 @@ class SearchStore:
 
 		spec = repr([(f.name, f.kind, f.stored, f.fast, f.tokenizer) for f in self.FIELDS])
 		return hashlib.sha1(f"{self.ID_FIELD}|{spec}".encode()).hexdigest()[:16]
+
+
+def list_index_entities(namespace: Namespace) -> list[str]:
+	"""Return the entity names of the Tantivy indexes directly under `namespace`'s directory.
+
+	Each `SearchStore` writes its index to ``<base>/<namespace>/<entity>``, so a namespace's
+	directory holds one sub-directory per indexed entity. Used by tooling (the Store Entry
+	browser) to discover a namespace's indexes without knowing their subclasses.
+	"""
+
+	namespace_path = resolve_namespace_path(get_search_base_path(), namespace)
+	if not os.path.isdir(namespace_path):
+		return []
+
+	entities = [
+		entry.name
+		for entry in os.scandir(namespace_path)
+		if entry.is_dir(follow_symlinks=False) and tantivy.Index.exists(entry.path)
+	]
+	return sorted(entities)
+
+
+class SearchIndexBrowser:
+	"""Read-only, schema-agnostic view of one on-disk Tantivy index, for tooling.
+
+	Unlike `SearchStore`, this does not know the index's subclass schema (ENTITY/FIELDS); it
+	opens the index with the schema persisted on disk, so any index can be browsed or read
+	generically by the Store Entry browser. Stored fields are the only ones a document exposes.
+	"""
+
+	# Field preferred as the human-facing document key when a document stores it.
+	KEY_FIELD: ClassVar[str] = "id"
+
+	def __init__(self, namespace: Namespace, entity: str) -> None:
+		namespace_path = resolve_namespace_path(get_search_base_path(), namespace)
+		self.path = os.path.join(namespace_path, entity)
+
+	def count(self) -> int:
+		"""Return the number of documents in the index (0 when it has not been created yet)."""
+
+		searcher = self._searcher()
+		return searcher.num_docs if searcher else 0
+
+	def browse(self, limit: int | None = None) -> list[dict]:
+		"""List documents as ``{key, size}`` (stored fields only), for the Store Entry browser."""
+
+		return [
+			{"key": self._key(fields), "size": _document_size(fields)}
+			for fields in self._documents(limit=limit)
+		]
+
+	def read(self, key: str) -> dict | None:
+		"""Return ``{value, size}`` for the document whose key is `key`, or None if it is absent.
+
+		`value` is the document's stored fields, flattened to scalars where a field holds a single
+		value. Scans the index because the key is a stored value, not necessarily an indexed term.
+		"""
+
+		for fields in self._documents():
+			if self._key(fields) == key:
+				return {"value": _flatten(fields), "size": _document_size(fields)}
+
+		return None
+
+	def _searcher(self) -> "tantivy.Searcher | None":
+		"""Open the on-disk index with its persisted schema and return a fresh searcher, or None."""
+
+		if not tantivy.Index.exists(self.path):
+			return None
+
+		index = tantivy.Index.open(self.path)
+		# Pick up commits made since the index files were opened.
+		index.reload()
+		return index.searcher()
+
+	def _documents(self, limit: int | None = None):
+		"""Yield each document's stored fields (a ``{name: [values]}`` dict) via a match-all query."""
+
+		searcher = self._searcher()
+		if not searcher:
+			return
+
+		total = searcher.num_docs
+		if not total:
+			return
+
+		# Tantivy needs a positive limit; cap it at the document count so a single page covers all.
+		page = total if limit is None else min(limit, total)
+		result = searcher.search(tantivy.Query.all_query(), limit=page)
+		for _score, address in result.hits:
+			yield searcher.doc(address).to_dict()
+
+	def _key(self, fields: dict) -> str:
+		"""Pick a document's key: the `KEY_FIELD` value when present, else the first stored field."""
+
+		values = fields.get(self.KEY_FIELD)
+		if values is None and fields:
+			values = next(iter(fields.values()))
+
+		return str(values[0]) if values else ""
+
+
+def _flatten(fields: dict) -> dict:
+	"""Collapse Tantivy's ``{name: [values]}`` into scalars where a field holds a single value."""
+
+	return {name: (values[0] if len(values) == 1 else values) for name, values in fields.items()}
+
+
+def _document_size(fields: dict) -> int:
+	"""Approximate a stored document's size as the byte length of its normalized JSON."""
+
+	return len(json.dumps(_flatten(fields), ensure_ascii=False, default=str).encode())

--- a/suite/suite_core/doctype/store_entry/store_entry.json
+++ b/suite/suite_core/doctype/store_entry/store_entry.json
@@ -22,7 +22,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Store",
-   "options": "Data Store\nBlob Store",
+   "options": "Data Store\nBlob Store\nSearch Store",
    "read_only": 1,
    "reqd": 1
   },
@@ -41,7 +41,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "Data store only: the entity a key belongs to.",
+   "description": "Data/search store only: the entity (index) a key belongs to.",
    "fieldname": "entity",
    "fieldtype": "Data",
    "in_list_view": 1,

--- a/suite/suite_core/doctype/store_entry/store_entry.py
+++ b/suite/suite_core/doctype/store_entry/store_entry.py
@@ -10,13 +10,27 @@ from frappe.model.document import Document
 from frappe.types.filter import FilterTuple
 from frappe.utils import cint, now
 
-from suite.store import get_blob_base_path, get_data_base_path, list_namespaces
+from suite.store import (
+	get_blob_base_path,
+	get_data_base_path,
+	get_search_base_path,
+	list_namespaces,
+)
 from suite.store.base_store import resolve_namespace_path
 from suite.store.blob_store import BlobStore
 from suite.store.data_store import DataStore
+from suite.store.search_store import SearchIndexBrowser, list_index_entities
 
 DATA_STORE = "Data Store"
 BLOB_STORE = "Blob Store"
+SEARCH_STORE = "Search Store"
+
+# Short, filesystem-agnostic code embedded in a record name so it round-trips through the browser.
+_STORE_CODES = {DATA_STORE: "data", BLOB_STORE: "blob", SEARCH_STORE: "search"}
+_CODE_STORES = {code: store for store, code in _STORE_CODES.items()}
+
+# Stores that scope keys under an entity (``<entity>:<key>``); the blob store has no entity.
+_ENTITY_STORES = (DATA_STORE, SEARCH_STORE)
 
 # Cap the rendered value so browsing a huge cached record doesn't ship megabytes to the client.
 _VALUE_PREVIEW_LIMIT = 20_000
@@ -35,7 +49,7 @@ class StoreEntry(Document):
 		key: DF.Data | None
 		namespace: DF.Data
 		size: DF.Data | None
-		store: DF.Literal["Data Store", "Blob Store"]
+		store: DF.Literal["Data Store", "Blob Store", "Search Store"]
 		value: DF.Code | None
 	# end: auto-generated types
 
@@ -50,6 +64,13 @@ class StoreEntry(Document):
 		if store == DATA_STORE:
 			entity, _sep, key = key_part.partition(":")
 			entry = _data_store(namespace).read(entity, key)
+			if entry is None:
+				_not_found(self.name)
+
+			record = _row(store, namespace, entity, key, entry["size"], value=_pretty(entry["value"]))
+		elif store == SEARCH_STORE:
+			entity, _sep, key = key_part.partition(":")
+			entry = _search_index(namespace, entity).read(key)
 			if entry is None:
 				_not_found(self.name)
 
@@ -79,7 +100,7 @@ class StoreEntry(Document):
 		namespace = _filter_value(filters, "namespace")
 
 		if not namespace:
-			available = ["/".join(ns) for ns in list_namespaces(_base_path(store))]
+			available = _available_namespaces(store)
 			hint = ", ".join(available) if available else _("none")
 			frappe.msgprint(_("Select a namespace to browse. Available: {0}").format(hint), alert=True)
 			return []
@@ -102,8 +123,16 @@ class StoreEntry(Document):
 		if not namespace or not _namespace_exists(store, namespace):
 			return 0
 
+		entity = _filter_value(filters, "entity")
+
 		if store == DATA_STORE:
-			return _data_store(namespace).count_entries(_filter_value(filters, "entity"))
+			return _data_store(namespace).count_entries(entity)
+
+		if store == SEARCH_STORE:
+			return sum(
+				_search_index(namespace, index_entity).count()
+				for index_entity in _search_index_entities(namespace, entity)
+			)
 
 		return _blob_store(namespace).count()
 
@@ -145,7 +174,11 @@ def _not_found(name: str) -> None:
 def _base_path(store: str) -> str:
 	"""Return the base directory for the given store."""
 
-	return get_data_base_path() if store == DATA_STORE else get_blob_base_path()
+	if store == DATA_STORE:
+		return get_data_base_path()
+	if store == SEARCH_STORE:
+		return get_search_base_path()
+	return get_blob_base_path()
 
 
 def _data_store(namespace: str) -> DataStore:
@@ -154,6 +187,32 @@ def _data_store(namespace: str) -> DataStore:
 
 def _blob_store(namespace: str) -> BlobStore:
 	return BlobStore(base_path=get_blob_base_path(), namespace=namespace)
+
+
+def _search_index(namespace: str, entity: str) -> SearchIndexBrowser:
+	return SearchIndexBrowser(namespace, entity)
+
+
+def _search_index_entities(namespace: str, entity: str | None = None) -> list[str]:
+	"""Return a namespace's index entities, narrowed to `entity` when the caller filters on one."""
+
+	entities = list_index_entities(namespace)
+	return [e for e in entities if e == entity] if entity else entities
+
+
+def _available_namespaces(store: str) -> list[str]:
+	"""Return the namespaces a user can browse for `store`, for the "select a namespace" hint.
+
+	A search store nests one index directory per entity under each namespace
+	(``<base>/<namespace>/<entity>``), so its browsable namespaces are the parents of those leaf
+	directories rather than the leaves themselves.
+	"""
+
+	if store == SEARCH_STORE:
+		namespaces = {"/".join(ns[:-1]) for ns in list_namespaces(get_search_base_path()) if len(ns) > 1}
+		return sorted(namespaces)
+
+	return ["/".join(ns) for ns in list_namespaces(_base_path(store))]
 
 
 def _namespace_exists(store: str, namespace: str) -> bool:
@@ -170,6 +229,12 @@ def _entries(store: str, namespace: str, entity: str | None = None) -> list[dict
 			_row(store, namespace, item["entity"], item["key"], item["size"])
 			for item in _data_store(namespace).browse()
 			if not entity or item["entity"] == entity
+		]
+	elif store == SEARCH_STORE:
+		rows = [
+			_row(store, namespace, index_entity, item["key"], item["size"])
+			for index_entity in _search_index_entities(namespace, entity)
+			for item in _search_index(namespace, index_entity).browse()
 		]
 	else:
 		rows = [
@@ -191,7 +256,7 @@ def _row(
 ) -> dict:
 	"""Build a Store Entry record dict for either store."""
 
-	key_part = f"{entity}:{key}" if store == DATA_STORE else key
+	key_part = f"{entity}:{key}" if store in _ENTITY_STORES else key
 	stamp = now()
 
 	return {
@@ -208,16 +273,17 @@ def _row(
 
 
 def _make_name(store: str, namespace: str, key_part: str) -> str:
-	"""Encode a stable, parseable record name: ``<data|blob>|<namespace>|<key_part>``."""
+	"""Encode a stable, parseable record name: ``<data|blob|search>|<namespace>|<key_part>``."""
 
-	return f"{'data' if store == DATA_STORE else 'blob'}|{namespace}|{key_part}"
+	return f"{_STORE_CODES[store]}|{namespace}|{key_part}"
 
 
 def _parse_name(name: str) -> tuple[str, str, str]:
 	"""Split a record name back into (store, namespace, key_part).
 
-	A well-formed name is ``<data|blob>|<namespace>|<key_part>``. A malformed one (e.g. a
-	hand-crafted URL) is treated as a missing record rather than allowed to raise ValueError.
+	A well-formed name is ``<data|blob|search>|<namespace>|<key_part>``. A malformed one (e.g. a
+	hand-crafted URL, or an unknown store code) is treated as a missing record rather than
+	allowed to raise ValueError.
 	"""
 
 	parts = name.split("|", 2)
@@ -225,7 +291,11 @@ def _parse_name(name: str) -> tuple[str, str, str]:
 		_not_found(name)
 
 	code, namespace, key_part = parts
-	return (DATA_STORE if code == "data" else BLOB_STORE), namespace, key_part
+	store = _CODE_STORES.get(code)
+	if store is None:
+		_not_found(name)
+
+	return store, namespace, key_part
 
 
 def _pretty(value) -> str:

--- a/suite/suite_core/doctype/store_entry/store_entry.py
+++ b/suite/suite_core/doctype/store_entry/store_entry.py
@@ -69,7 +69,7 @@ class StoreEntry(Document):
 
 			record = _row(store, namespace, entity, key, entry["size"], value=_pretty(entry["value"]))
 		elif store == SEARCH_STORE:
-			entity, _sep, key = key_part.partition(":")
+			entity, key = _split_search_key(namespace, key_part)
 			entry = _search_index(namespace, entity).read(key)
 			if entry is None:
 				_not_found(self.name)
@@ -198,6 +198,26 @@ def _search_index_entities(namespace: str, entity: str | None = None) -> list[st
 
 	entities = list_index_entities(namespace)
 	return [e for e in entities if e == entity] if entity else entities
+
+
+def _split_search_key(namespace: str, key_part: str) -> tuple[str, str]:
+	"""Split an ``<entity>:<key>`` search key_part back into (entity, key).
+
+	The entity is resolved against the namespace's real on-disk index names rather than by
+	splitting at the first colon, so an entity that itself contains ``:`` is not mis-parsed (which
+	would otherwise open the wrong index and report an existing document as missing). The longest
+	matching entity wins, disambiguating the case where one entity name is a prefix of another.
+	Falls back to a first-colon split when no index matches (e.g. one dropped since the row was
+	built).
+	"""
+
+	matches = [e for e in list_index_entities(namespace) if key_part == e or key_part.startswith(f"{e}:")]
+	if matches:
+		entity = max(matches, key=len)
+		return entity, key_part[len(entity) + 1 :]
+
+	entity, _sep, key = key_part.partition(":")
+	return entity, key
 
 
 def _available_namespaces(store: str) -> list[str]:


### PR DESCRIPTION
## Summary

Extends the read-only **Store Entry** browser to browse Tantivy **search indexes**, alongside the existing Data Store and Blob Store.

A search store is laid out as `<base>/<namespace>/<entity>`, with one Tantivy index per entity and its schema declared in a `SearchStore` subclass. Since the browser is generic and can't know those subclasses, a new schema-agnostic `SearchIndexBrowser` opens each index with the schema persisted on disk (`tantivy.Index.open`), so any index can be listed and read.

## Changes

- **`store/search_store.py`**
  - `list_index_entities(namespace)` — discovers the index directories under a namespace.
  - `SearchIndexBrowser` — opens one on-disk index generically and exposes `count()`, `browse()` (`{key, size}`), and `read(key)` (`{value, size}`). Documents are enumerated via a match-all query; the key is the `id` field (or first stored field) and the value is the stored fields flattened from Tantivy's `{name: [values]}` shape.
- **`suite_core/doctype/store_entry/store_entry.py`** — wires the search store into `load_from_db`, `get_list`, `get_count`, `_entries`, and `_base_path`; adds a store-code map so record names round-trip; and adds `_available_namespaces`, which lists the parent namespaces of index leaves (search nests one extra directory level).
- **`store_entry.json`** — adds `Search Store` to the `store` options and updates the `entity` field description.

## Testing

Verified end-to-end against a real `EmailAddressIndex`: namespace hint, total and entity-filtered counts, list rows, single-document load via the encoded record name, and the missing-document error path all behave correctly.