### PR TITLE
feat(sheets): homepage filters, recency groups, and server-side pagination

### DIFF
--- a/frontend/src/apps/sheets/pages/Home.vue
+++ b/frontend/src/apps/sheets/pages/Home.vue
@@ -67,15 +67,25 @@
       </div>
     </div>
 
-    <!-- Content -->
-    <div class="home-body">
-      <!-- Loading -->
-      <div v-if="loading" class="home-empty">
+    <!-- Filter toolbar — ownership tabs + sort. Hidden on the true-empty
+         state so a brand-new account isn't offered filters over nothing. -->
+    <div v-if="loading || !isTrueEmpty" class="home-toolbar">
+      <div class="home-toolbar-inner">
+        <TabButtons v-model="ownerTab" :buttons="ownerTabs" />
+        <Select v-model="sortBy" :options="sortOptions" aria-label="Sort by" />
+      </div>
+    </div>
+
+    <!-- Loading (initial fetch or a filter/sort/search reset) -->
+    <div v-if="loading" class="home-body">
+      <div class="home-empty">
         <Spinner class="home-spinner" />
       </div>
+    </div>
 
-      <!-- Empty state (no sheets at all) -->
-      <div v-else-if="!sheets.length" class="home-empty">
+    <!-- Empty state (no sheets at all, no filters in play) -->
+    <div v-else-if="isTrueEmpty" class="home-body">
+      <div class="home-empty">
         <div class="home-empty-icon">
           <svg width="48" height="48" viewBox="0 0 48 48" fill="none">
             <rect width="48" height="48" rx="8" fill="#f3f3f3"/>
@@ -89,18 +99,20 @@
         <p class="home-empty-sub">Create one to get started</p>
         <Button variant="solid" @click="newSheet()">New Sheet</Button>
       </div>
+    </div>
 
-      <!-- No search match (grid only — list mode delegates to ListView's
-           built-in emptyState option). -->
-      <div v-else-if="viewMode === 'grid' && !filteredSheets.length" class="home-empty">
-        <p class="home-empty-title">No matches for “{{ searchQuery }}”</p>
-        <p class="home-empty-sub">Try a different name.</p>
+    <!-- Sheet grid — keeps the whole-body scroll; Load More is a plain
+         centered button (ListFooter is list-view chrome). -->
+    <div v-else-if="viewMode === 'grid'" class="home-body">
+      <div v-if="!sheets.length" class="home-empty">
+        <p class="home-empty-title">{{ filteredEmptyState.title }}</p>
+        <p class="home-empty-sub">{{ filteredEmptyState.description }}</p>
+        <Button v-if="filteredEmptyState.button" variant="solid" @click="newSheet()">New Sheet</Button>
       </div>
-
-      <!-- Sheet grid -->
-      <div v-else-if="viewMode === 'grid'" class="home-grid">
+      <template v-else>
+      <div class="home-grid">
         <div
-          v-for="sheet in filteredSheets"
+          v-for="sheet in sheets"
           :key="sheet.name"
           class="home-card"
           @click="openSheet(sheet.name)"
@@ -143,14 +155,29 @@
           </div>
         </div>
       </div>
+      <div class="home-loadmore">
+        <Button
+          v-if="sheets.length < total"
+          variant="subtle"
+          :loading="loadingMore"
+          @click="loadMore"
+        >Load more</Button>
+        <span class="home-count">{{ sheets.length }} of {{ total }}</span>
+      </div>
+      </template>
+    </div>
 
-      <!-- Sheet list — Frappe UI ListView. No custom wrapper; the
-           component owns its header bg + row dividers. Empty / no-match
-           states are handled via the options.emptyState contract. -->
+    <!-- Sheet list — Frappe UI ListView with its own internal scroll (its
+         rows region is h-full overflow-y-auto), so topbar, toolbar, column
+         header and footer stay put while rows scroll. Rows are grouped by
+         recency under the default sort; empty / no-match states go through
+         the options.emptyState contract. -->
+    <div v-else class="home-listshell">
+      <div class="home-listcol">
       <ListView
-        v-else
+        class="h-full"
         :columns="listColumns"
-        :rows="filteredSheets"
+        :rows="listRows"
         row-key="name"
         :options="listOptions"
       >
@@ -180,6 +207,17 @@
           />
         </template>
       </ListView>
+      <!-- The empty #left slot suppresses ListFooter's page-size TabButtons —
+           we only want its Load More button + "X of Y" count. -->
+      <ListFooter
+        v-if="sheets.length"
+        class="home-listfooter"
+        :options="{ rowCount: sheets.length, totalCount: total }"
+        @loadMore="loadMore"
+      >
+        <template #left><span /></template>
+      </ListFooter>
+      </div>
     </div>
 
     <!-- Rename dialog -->
@@ -222,7 +260,7 @@
 </template>
 
 <script setup>
-import { ref, computed, h, onMounted } from 'vue'
+import { ref, computed, h, onMounted, watch } from 'vue'
 import {
   Avatar,
   Badge,
@@ -234,10 +272,15 @@ import {
   Dropdown,
   ListView,
   ListRowItem,
+  ListFooter,
+  TabButtons,
+  Select,
+  debounce,
 } from 'frappe-ui'
 import { useRouter } from 'vue-router'
 
 import { call } from '@/apps/sheets/utils/api.js'
+import { groupSheetsByRecency } from '@/apps/sheets/utils/recency-groups.js'
 
 const router = useRouter()
 
@@ -255,9 +298,16 @@ const overflowActions = [
   { label: 'Trash', icon: 'trash-2', onClick: () => router.push({ name: 'sheets-trash' }) },
 ]
 
-const sheets       = ref([])
-const loading      = ref(true)
-const searchQuery  = ref('')
+const PAGE_SIZE = 50
+
+const sheets      = ref([])   // accumulated pages, in server sort order
+const total       = ref(0)    // permission-aware count for the active filters
+const loading     = ref(true) // initial load + any filter/sort/search reset
+const loadingMore = ref(false)
+const searchQuery = ref('')   // matched server-side (debounced) so results
+                              // aren't limited to already-loaded pages
+const ownerTab    = ref('all')      // 'all' | 'mine' | 'shared'
+const sortBy      = ref('modified') // 'modified' | 'title' | 'owner'
 
 // Inline error banner used by the destructive actions (delete / duplicate).
 // Mirrors the editor's `saveError` pattern — Frappe UI Badge, auto-dismissed
@@ -344,37 +394,70 @@ const listColumns = [
   { label: '', key: '_actions', width: '60px', align: 'right' },
 ]
 
+const ownerTabs = [
+  { label: 'All', value: 'all' },
+  { label: 'My sheets', value: 'mine' },
+  { label: 'Shared with me', value: 'shared' },
+]
+
+const sortOptions = [
+  { label: 'Last modified', value: 'modified' },
+  { label: 'Name A–Z', value: 'title' },
+  { label: 'Owner', value: 'owner' },
+]
+
+// "Truly" empty = the account has no visible sheets at all, as opposed to
+// a search/tab combination that matched nothing. Gets the branded block.
+const isTrueEmpty = computed(
+  () => !sheets.value.length && !searchQuery.value.trim() && ownerTab.value === 'all'
+)
+
+// Empty-state copy when a search or tab filtered everything out. Reached
+// only when !isTrueEmpty, so no search + non-"shared" tab implies "mine".
+// Shared by ListView's emptyState contract and the grid empty branch.
+const filteredEmptyState = computed(() => {
+  const q = searchQuery.value.trim()
+  if (q) {
+    return { title: `No matches for "${q}"`, description: 'Try a different name.' }
+  }
+  if (ownerTab.value === 'shared') {
+    return {
+      title: 'Nothing shared with you yet',
+      description: 'Sheets others share with you show up here.',
+    }
+  }
+  return {
+    title: "You don't own any sheets yet",
+    description: 'Create one to get started.',
+    button: { label: 'New Sheet', variant: 'solid', onClick: () => newSheet() },
+  }
+})
+
 // `emptyState` is ListView's built-in contract — it renders inside the
-// component (below the header) when `rows` is empty, so we don't need an
-// outer v-if branch for the no-match case in list mode.
+// component (below the header) when `rows` is empty.
 const listOptions = computed(() => ({
   selectable: false,
   showTooltip: true,
   rowHeight: 40,
   onRowClick: (row) => openSheet(row.name),
-  emptyState: searchQuery.value
-    ? {
-        title: `No matches for "${searchQuery.value}"`,
-        description: 'Try a different name.',
-      }
-    : {
-        title: 'No sheets yet',
-        description: 'Create one to get started.',
-        button: {
-          label: 'New Sheet',
-          variant: 'solid',
-          onClick: () => newSheet(),
-        },
-      },
+  emptyState: filteredEmptyState.value,
 }))
 
-// Filter by title, case-insensitive substring match. Sort order from the API
-// (modified desc) is preserved by `filter`.
-const filteredSheets = computed(() => {
-  const q = searchQuery.value.trim().toLowerCase()
-  if (!q) return sheets.value
-  return sheets.value.filter(s => (s.title || '').toLowerCase().includes(q))
-})
+// List rows, grouped by recency only under the default modified sort —
+// time buckets make no sense against a name/owner ordering. Rebuilt via a
+// watch (not a computed) so each rebuild can carry forward the `collapsed`
+// flags that ListView's group headers mutate in place; a computed would
+// re-expand every group on Load More.
+const listRows = ref([])
+watch(
+  [sheets, sortBy],
+  () => {
+    listRows.value = sortBy.value === 'modified'
+      ? groupSheetsByRecency(sheets.value, new Date(), listRows.value)
+      : sheets.value
+  },
+  { immediate: true }
+)
 
 // Per-card 3-dot menu. Rename/Delete are owner-only — both backend
 // endpoints require write/delete perm, which a shared viewer/editor
@@ -403,13 +486,41 @@ const renaming         = ref(false)
 
 onMounted(fetchSheets)
 
-async function fetchSheets() {
-  loading.value = true
+// Tab/sort changes reset to page 1 immediately; search debounces on top.
+watch([ownerTab, sortBy], () => fetchSheets())
+watch(searchQuery, debounce(() => fetchSheets(), 300))
+
+// Monotonic token invalidates in-flight responses, so a slow page-1 fetch
+// can't clobber the rows of a newer tab/sort/search request.
+let reqToken = 0
+
+async function fetchSheets({ append = false } = {}) {
+  const token = ++reqToken
+  if (append) loadingMore.value = true
+  else loading.value = true
   try {
-    sheets.value = await call('suite.sheets.api.list_sheets')
+    const res = await call('suite.sheets.api.list_sheets', {
+      start: append ? sheets.value.length : 0,
+      limit: PAGE_SIZE,
+      search: searchQuery.value.trim(),
+      owner_filter: ownerTab.value,
+      order_by: sortBy.value,
+    })
+    if (token !== reqToken) return
+    sheets.value = append ? sheets.value.concat(res.sheets) : res.sheets
+    total.value = res.total
   } finally {
-    loading.value = false
+    if (token === reqToken) {
+      loading.value = false
+      loadingMore.value = false
+    }
   }
+}
+
+function loadMore() {
+  if (loading.value || loadingMore.value) return
+  if (sheets.value.length >= total.value) return
+  fetchSheets({ append: true })
 }
 
 function formatDate(iso) {
@@ -434,6 +545,7 @@ async function doDelete() {
   try {
     await call('suite.sheets.api.delete_sheet', { name: deleteTarget.value.name })
     sheets.value = sheets.value.filter(s => s.name !== deleteTarget.value.name)
+    total.value = Math.max(0, total.value - 1)
     showDeleteDialog.value = false
   } catch (err) {
     console.error('Delete failed:', err)
@@ -532,11 +644,26 @@ async function duplicate(sheet) {
   color: var(--ink-gray-9);
 }
 
+/* Filter toolbar — sits between the topbar and content, outside any scroll
+   region so it stays put in both view modes. */
+.home-toolbar {
+  flex-shrink: 0;
+  padding: 16px 32px 8px;
+}
+.home-toolbar-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .home-body {
   flex: 1;
   min-height: 0;          /* lets flex children own their own scroll */
   overflow-y: auto;       /* the actual scroll container */
-  padding: 40px 32px;
+  padding: 16px 32px 40px;
   width: 100%;
 }
 
@@ -653,7 +780,43 @@ async function duplicate(sheet) {
   flex-shrink: 0;
 }
 
+/* Grid-mode Load More — centered button + quiet count below the cards. */
+.home-loadmore {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 16px 0;
+}
+.home-count {
+  font-size: 12px;
+  letter-spacing: .02em;
+  color: var(--ink-gray-5);
+}
+
 /* ── List view ─────────────────────────────────────────────────────────────
    Frappe UI's ListView owns its own header/row styling — header background,
-   gridTemplateColumns, dividers, hover. We don't wrap it. */
+   gridTemplateColumns, dividers, hover. The shell bounds its height so the
+   rows region (h-full overflow-y-auto inside ListView) scrolls internally,
+   keeping the column header and ListFooter fixed. */
+.home-listshell {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  padding: 0 32px 12px;
+}
+.home-listcol {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+}
+.home-listfooter {
+  flex-shrink: 0;
+  padding: 8px 4px;
+  border-top: 1px solid var(--outline-gray-2);
+}
 </style>

--- a/frontend/src/apps/sheets/pages/Home.vue
+++ b/frontend/src/apps/sheets/pages/Home.vue
@@ -68,8 +68,9 @@
     </div>
 
     <!-- Filter toolbar — ownership tabs + sort. Hidden on the true-empty
-         state so a brand-new account isn't offered filters over nothing. -->
-    <div v-if="loading || !isTrueEmpty" class="home-toolbar">
+         state so a brand-new account isn't offered filters over nothing.
+         Kept during load errors so tab/sort changes can trigger a refetch. -->
+    <div v-if="loading || loadError || !isTrueEmpty" class="home-toolbar">
       <div class="home-toolbar-inner">
         <TabButtons v-model="ownerTab" :buttons="ownerTabs" />
         <Select v-model="sortBy" :options="sortOptions" aria-label="Sort by" />
@@ -80,6 +81,17 @@
     <div v-if="loading" class="home-body">
       <div class="home-empty">
         <Spinner class="home-spinner" />
+      </div>
+    </div>
+
+    <!-- Load failure — its own surface so stale rows from the previous
+         filter are never shown under the new one, and the branded
+         "No sheets yet" block can't masquerade as a successful result. -->
+    <div v-else-if="loadError" class="home-body">
+      <div class="home-empty">
+        <p class="home-empty-title">Couldn't load sheets</p>
+        <p class="home-empty-sub">{{ loadError }}</p>
+        <Button variant="subtle" @click="fetchSheets()">Retry</Button>
       </div>
     </div>
 
@@ -280,7 +292,7 @@ import {
 import { useRouter } from 'vue-router'
 
 import { call } from '@/apps/sheets/utils/api.js'
-import { groupSheetsByRecency } from '@/apps/sheets/utils/recency-groups.js'
+import { groupSheetsByRecency, parseFrappeDatetime } from '@/apps/sheets/utils/recency-groups.js'
 
 const router = useRouter()
 
@@ -308,6 +320,11 @@ const searchQuery = ref('')   // matched server-side (debounced) so results
                               // aren't limited to already-loaded pages
 const ownerTab    = ref('all')      // 'all' | 'mine' | 'shared'
 const sortBy      = ref('modified') // 'modified' | 'title' | 'owner'
+const loadError   = ref('')   // reset-fetch failure; owns its own surface so
+                              // stale rows never render under a new filter
+const serverNow   = ref('')   // server-clock "now" from the API — same naive
+                              // frame as `modified`, keeps recency buckets
+                              // timezone-consistent
 
 // Inline error banner used by the destructive actions (delete / duplicate).
 // Mirrors the editor's `saveError` pattern — Frappe UI Badge, auto-dismissed
@@ -452,8 +469,11 @@ const listRows = ref([])
 watch(
   [sheets, sortBy],
   () => {
+    // Bucket against the server's clock so "Today" is decided in the same
+    // timezone frame the `modified` timestamps are written in.
+    const now = serverNow.value ? parseFrappeDatetime(serverNow.value) : new Date()
     listRows.value = sortBy.value === 'modified'
-      ? groupSheetsByRecency(sheets.value, new Date(), listRows.value)
+      ? groupSheetsByRecency(sheets.value, now, listRows.value)
       : sheets.value
   },
   { immediate: true }
@@ -509,6 +529,21 @@ async function fetchSheets({ append = false } = {}) {
     if (token !== reqToken) return
     sheets.value = append ? sheets.value.concat(res.sheets) : res.sheets
     total.value = res.total
+    serverNow.value = res.now || ''
+    loadError.value = ''
+  } catch (err) {
+    if (token !== reqToken) return
+    console.error('list_sheets failed:', err)
+    if (append) {
+      // Keep what's already on screen; surface the failure via the badge.
+      _flashError(err?.message || 'Load more failed')
+    } else {
+      // A failed reset must not leave the previous filter's rows rendered
+      // under the new tab/sort/search — clear and show the error surface.
+      sheets.value = []
+      total.value = 0
+      loadError.value = err?.message || 'Something went wrong. Check your connection and retry.'
+    }
   } finally {
     if (token === reqToken) {
       loading.value = false

--- a/frontend/src/apps/sheets/utils/recency-groups.js
+++ b/frontend/src/apps/sheets/utils/recency-groups.js
@@ -1,0 +1,45 @@
+// Recency bucketing for the homepage list — groups sheets by how recently
+// they were modified, in the shape frappe-ui's ListView needs for grouped
+// rendering ([{group, collapsed, rows}], all rows matching that shape).
+
+const GROUP_ORDER = ['Today', 'Previous 7 days', 'Previous 30 days', 'Earlier']
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+// Frappe datetimes are "YYYY-MM-DD HH:mm:ss.ffffff" (server-local, may carry
+// microseconds). Trim to seconds and switch to a 'T' separator — Safari
+// rejects the space-separated form in `new Date(...)`.
+export function parseFrappeDatetime(s) {
+  return new Date(String(s).slice(0, 19).replace(' ', 'T'))
+}
+
+export function recencyBucket(dateStr, now = new Date()) {
+  const d = parseFrappeDatetime(dateStr)
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  // Future timestamps (client/server clock skew) fold into Today rather
+  // than falling through to Earlier.
+  if (d >= startOfToday) return 'Today'
+  if (d >= new Date(startOfToday - 7 * DAY_MS)) return 'Previous 7 days'
+  if (d >= new Date(startOfToday - 30 * DAY_MS)) return 'Previous 30 days'
+  return 'Earlier'
+}
+
+// Buckets `rows` (already sorted by the server) into ListView group objects.
+// Empty buckets are omitted; row order within a bucket is preserved.
+// `prevGroups` carries each group's `collapsed` flag forward — ListView's
+// group header mutates it in place, and the groups array is rebuilt on every
+// fetch/append, so without this a Load More would re-expand collapsed groups.
+export function groupSheetsByRecency(rows, now = new Date(), prevGroups = []) {
+  const buckets = new Map(GROUP_ORDER.map(g => [g, []]))
+  for (const row of rows) {
+    buckets.get(recencyBucket(row.modified, now)).push(row)
+  }
+  const collapsedByLabel = new Map(prevGroups.map(g => [g.group, g.collapsed]))
+  return GROUP_ORDER
+    .filter(g => buckets.get(g).length)
+    .map(g => ({
+      group: g,
+      collapsed: collapsedByLabel.get(g) ?? false,
+      rows: buckets.get(g),
+    }))
+}

--- a/frontend/src/apps/sheets/utils/recency-groups.test.ts
+++ b/frontend/src/apps/sheets/utils/recency-groups.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseFrappeDatetime,
+  recencyBucket,
+  groupSheetsByRecency,
+} from './recency-groups.js'
+
+// Fixed reference point: a Wednesday mid-afternoon.
+const NOW = new Date('2026-07-22T15:00:00')
+
+describe('parseFrappeDatetime', () => {
+  it('parses Frappe datetimes with microseconds', () => {
+    const d = parseFrappeDatetime('2026-07-22 10:11:12.123456')
+    expect(d.getFullYear()).toBe(2026)
+    expect(d.getMonth()).toBe(6)
+    expect(d.getDate()).toBe(22)
+    expect(d.getHours()).toBe(10)
+    expect(d.getSeconds()).toBe(12)
+  })
+
+  it('parses datetimes without microseconds', () => {
+    expect(parseFrappeDatetime('2026-07-22 10:11:12').getTime()).not.toBeNaN()
+  })
+})
+
+describe('recencyBucket', () => {
+  it('buckets by calendar day and rolling windows', () => {
+    expect(recencyBucket('2026-07-22 00:00:01', NOW)).toBe('Today')
+    expect(recencyBucket('2026-07-21 23:59:59', NOW)).toBe('Previous 7 days')
+    expect(recencyBucket('2026-07-15 00:00:00', NOW)).toBe('Previous 7 days')
+    expect(recencyBucket('2026-07-14 23:59:59', NOW)).toBe('Previous 30 days')
+    expect(recencyBucket('2026-06-22 00:00:00', NOW)).toBe('Previous 30 days')
+    expect(recencyBucket('2026-06-21 23:59:59', NOW)).toBe('Earlier')
+    expect(recencyBucket('2026-06-07 12:00:00', NOW)).toBe('Earlier')
+  })
+
+  it('folds future timestamps (clock skew) into Today', () => {
+    expect(recencyBucket('2026-07-23 09:00:00', NOW)).toBe('Today')
+  })
+})
+
+describe('groupSheetsByRecency', () => {
+  const row = (name, modified) => ({ name, modified })
+
+  it('emits groups in fixed order, omitting empty buckets', () => {
+    const rows = [
+      row('a', '2026-07-22 09:00:00'), // Today
+      row('b', '2026-05-01 09:00:00'), // Earlier
+      row('c', '2026-07-20 09:00:00'), // Previous 7 days
+    ]
+    const groups = groupSheetsByRecency(rows, NOW)
+    expect(groups.map(g => g.group)).toEqual(['Today', 'Previous 7 days', 'Earlier'])
+  })
+
+  it('preserves row order within a bucket and matches the ListView shape', () => {
+    const rows = [
+      row('a', '2026-07-22 12:00:00'),
+      row('b', '2026-07-22 09:00:00'),
+    ]
+    const groups = groupSheetsByRecency(rows, NOW)
+    expect(groups).toHaveLength(1)
+    for (const g of groups) {
+      // ListView only renders grouped mode when EVERY row is {group, rows: []}.
+      expect(typeof g.group).toBe('string')
+      expect(Array.isArray(g.rows)).toBe(true)
+    }
+    expect(groups[0].rows.map(r => r.name)).toEqual(['a', 'b'])
+  })
+
+  it('carries collapsed state forward from prevGroups by label', () => {
+    const rows = [
+      row('a', '2026-07-22 09:00:00'), // Today
+      row('b', '2026-07-20 09:00:00'), // Previous 7 days
+    ]
+    const prev = [{ group: 'Previous 7 days', collapsed: true, rows: [] }]
+    const groups = groupSheetsByRecency(rows, NOW, prev)
+    expect(groups.find(g => g.group === 'Today').collapsed).toBe(false)
+    expect(groups.find(g => g.group === 'Previous 7 days').collapsed).toBe(true)
+  })
+
+  it('returns an empty array for no rows', () => {
+    expect(groupSheetsByRecency([], NOW)).toEqual([])
+  })
+})

--- a/suite/sheets/api.py
+++ b/suite/sheets/api.py
@@ -264,26 +264,62 @@ def unshare_sheet(name: str, user: str = "", everyone: int = 0) -> dict:
 	return {"status": "ok"}
 
 
+# Caller's `order_by` is resolved through this dict — a key lookup, never
+# string interpolation — so arbitrary SQL can't reach the ORDER BY clause.
+_LIST_SHEETS_ORDER_BY = {
+	"modified": "`tabSheet`.`modified` desc",
+	"title": "`tabSheet`.`title` asc",
+	"owner": "`tabSheet`.`owner` asc, `tabSheet`.`modified` desc",
+}
+
+
 @frappe.whitelist()
-def list_sheets() -> list:
-	# No explicit owner filter — Frappe's get_list already applies the
-	# permission query, so this returns sheets the session user owns plus
-	# those reaching them via DocShare (per-user or everyone=1). The
-	# `owner` field is included so the UI can mark non-owned rows as
-	# "Shared with you", and `is_owner` is computed here because the SPA
-	# template doesn't inject window.frappe.session — the client has no
-	# reliable way to know who it is.
+def list_sheets(
+	start: int = 0,
+	limit: int = 50,
+	search: str = "",
+	owner_filter: str = "all",
+	order_by: str = "modified",
+) -> dict:
+	# Frappe's get_list applies the permission query, so the base result is
+	# sheets the session user owns plus those shared via DocShare (per-user
+	# or everyone=1). `owner_filter` narrows within that visible set:
+	# "mine" / "shared" split on ownership, anything else means "all".
+	# `is_owner` is computed here because the SPA template doesn't inject
+	# window.frappe.session — the client can't know who it is on its own.
 	me = frappe.session.user
+	start = max(frappe.utils.cint(start), 0)
+	limit = min(max(frappe.utils.cint(limit) or 50, 1), 100)
+
+	filters = {"trashed": 0}
+	search = (search or "").strip()
+	if search:
+		filters["title"] = ["like", f"%{search}%"]
+	if owner_filter == "mine":
+		filters["owner"] = me
+	elif owner_filter == "shared":
+		filters["owner"] = ["!=", me]
+
 	rows = frappe.get_list(
 		"Sheet",
-		filters={"trashed": 0},
+		filters=filters,
 		fields=["name", "title", "modified", "owner"],
-		order_by="modified desc",
-		limit=100,
+		order_by=_LIST_SHEETS_ORDER_BY.get(order_by, _LIST_SHEETS_ORDER_BY["modified"]),
+		limit_start=start,
+		limit_page_length=limit,
 	)
 	for r in rows:
 		r["is_owner"] = (r["owner"] == me)
-	return rows
+
+	# Permission-aware total for the same filters — an aggregate get_list
+	# keeps the owner + DocShare conditions that frappe.db.count would drop.
+	# Dict field syntax: newer Frappe rejects string SQL functions in SELECT.
+	total = frappe.get_list(
+		"Sheet",
+		filters=filters,
+		fields=[{"COUNT": "*", "as": "total"}],
+	)[0]["total"]
+	return {"sheets": rows, "total": total}
 
 
 @frappe.whitelist()

--- a/suite/sheets/api.py
+++ b/suite/sheets/api.py
@@ -319,7 +319,9 @@ def list_sheets(
 		filters=filters,
 		fields=[{"COUNT": "*", "as": "total"}],
 	)[0]["total"]
-	return {"sheets": rows, "total": total}
+	# `now` shares the naive server-local frame of `modified`, so the client
+	# can bucket rows by recency without mixing server and client clocks.
+	return {"sheets": rows, "total": total, "now": str(frappe.utils.now())}
 
 
 @frappe.whitelist()

--- a/suite/sheets/tests/test_list_sheets.py
+++ b/suite/sheets/tests/test_list_sheets.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026, Asif and Contributors
+# See license.txt
+"""Shape tests for ``list_sheets`` pagination, filtering and sorting.
+
+DB-free (``suite.sheets.api.frappe`` is mocked, matching test_api_security.py):
+they assert what the endpoint passes to ``get_list`` — the clamped window,
+the whitelisted ORDER BY literal, the derived filters — and the shape of
+the response. The order_by test is the important one: caller input must
+never reach the SQL clause, only dict-mapped literals may.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+ME = "alice@example.com"
+
+_DEFAULT_ORDER = "`tabSheet`.`modified` desc"
+
+
+class _ListSheetsBase(unittest.TestCase):
+	def setUp(self):
+		patcher = mock.patch("suite.sheets.api.frappe")
+		self.frappe = patcher.start()
+		self.addCleanup(patcher.stop)
+		self.frappe.session.user = ME
+		# The module calls frappe.utils.cint for clamping — give the mock a
+		# real implementation so the arithmetic works.
+		self.frappe.utils.cint.side_effect = _cint
+		self.rows = [
+			{"name": "SH-1", "title": "Mine", "modified": "2026-07-22 10:00:00", "owner": ME},
+			{"name": "SH-2", "title": "Theirs", "modified": "2026-07-21 10:00:00", "owner": "bob@example.com"},
+		]
+		self.frappe.get_list.side_effect = [self.rows, [{"total": 42}]]
+
+	def call(self, **kwargs):
+		from suite.sheets import api
+
+		return api.list_sheets(**kwargs)
+
+	def rows_kwargs(self):
+		return self.frappe.get_list.call_args_list[0].kwargs
+
+	def count_kwargs(self):
+		return self.frappe.get_list.call_args_list[1].kwargs
+
+
+class Defaults(_ListSheetsBase):
+	def test_default_window_and_order(self):
+		self.call()
+		kw = self.rows_kwargs()
+		self.assertEqual(kw["limit_start"], 0)
+		self.assertEqual(kw["limit_page_length"], 50)
+		self.assertEqual(kw["order_by"], _DEFAULT_ORDER)
+		self.assertEqual(kw["filters"], {"trashed": 0})
+
+	def test_response_shape_and_is_owner(self):
+		res = self.call()
+		self.assertEqual(res["total"], 42)
+		self.assertTrue(res["sheets"][0]["is_owner"])
+		self.assertFalse(res["sheets"][1]["is_owner"])
+
+	def test_count_uses_aggregate_with_same_filters(self):
+		self.call(search="foo", owner_filter="mine")
+		kw = self.count_kwargs()
+		# Frappe 17 dict field syntax — string "count(...)" fields are rejected.
+		self.assertEqual(kw["fields"], [{"COUNT": "*", "as": "total"}])
+		self.assertEqual(kw["filters"], self.rows_kwargs()["filters"])
+
+
+class OrderBy(_ListSheetsBase):
+	def test_known_keys_map_to_literals(self):
+		self.call(order_by="title")
+		self.assertEqual(self.rows_kwargs()["order_by"], "`tabSheet`.`title` asc")
+
+	def test_owner_sort_has_modified_tiebreak(self):
+		self.call(order_by="owner")
+		self.assertEqual(
+			self.rows_kwargs()["order_by"],
+			"`tabSheet`.`owner` asc, `tabSheet`.`modified` desc",
+		)
+
+	def test_unknown_order_by_falls_back_to_default(self):
+		malicious = "modified desc; DROP TABLE `tabSheet`--"
+		self.call(order_by=malicious)
+		kw = self.rows_kwargs()
+		self.assertEqual(kw["order_by"], _DEFAULT_ORDER)
+		# The caller's string must not appear anywhere in the query kwargs.
+		for call in self.frappe.get_list.call_args_list:
+			self.assertNotIn(malicious, repr(call))
+
+
+class OwnerFilter(_ListSheetsBase):
+	def test_mine(self):
+		self.call(owner_filter="mine")
+		self.assertEqual(self.rows_kwargs()["filters"]["owner"], ME)
+
+	def test_shared(self):
+		self.call(owner_filter="shared")
+		self.assertEqual(self.rows_kwargs()["filters"]["owner"], ["!=", ME])
+
+	def test_unknown_means_all(self):
+		self.call(owner_filter="everything-please")
+		self.assertNotIn("owner", self.rows_kwargs()["filters"])
+
+
+class Search(_ListSheetsBase):
+	def test_search_is_trimmed_like_filter(self):
+		self.call(search="  foo  ")
+		self.assertEqual(self.rows_kwargs()["filters"]["title"], ["like", "%foo%"])
+
+	def test_blank_search_adds_no_filter(self):
+		self.call(search="   ")
+		self.assertNotIn("title", self.rows_kwargs()["filters"])
+
+
+class WindowClamping(_ListSheetsBase):
+	def test_limit_capped_at_100(self):
+		self.call(limit=1000)
+		self.assertEqual(self.rows_kwargs()["limit_page_length"], 100)
+
+	def test_zero_limit_uses_default(self):
+		self.call(limit=0)
+		self.assertEqual(self.rows_kwargs()["limit_page_length"], 50)
+
+	def test_negative_start_clamped_to_zero(self):
+		self.call(start=-5)
+		self.assertEqual(self.rows_kwargs()["limit_start"], 0)
+
+	def test_string_params_from_http_are_coerced(self):
+		# Whitelisted endpoints receive query params as strings.
+		self.call(start="50", limit="25")
+		kw = self.rows_kwargs()
+		self.assertEqual(kw["limit_start"], 50)
+		self.assertEqual(kw["limit_page_length"], 25)
+
+
+def _cint(value):
+	try:
+		return int(float(value))
+	except (TypeError, ValueError):
+		return 0
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/suite/sheets/tests/test_list_sheets.py
+++ b/suite/sheets/tests/test_list_sheets.py
@@ -28,6 +28,7 @@ class _ListSheetsBase(unittest.TestCase):
 		# The module calls frappe.utils.cint for clamping — give the mock a
 		# real implementation so the arithmetic works.
 		self.frappe.utils.cint.side_effect = _cint
+		self.frappe.utils.now.return_value = "2026-07-23 12:00:00.000001"
 		self.rows = [
 			{"name": "SH-1", "title": "Mine", "modified": "2026-07-22 10:00:00", "owner": ME},
 			{"name": "SH-2", "title": "Theirs", "modified": "2026-07-21 10:00:00", "owner": "bob@example.com"},
@@ -58,6 +59,9 @@ class Defaults(_ListSheetsBase):
 	def test_response_shape_and_is_owner(self):
 		res = self.call()
 		self.assertEqual(res["total"], 42)
+		# Server-clock `now` rides along so the client buckets recency in the
+		# same timezone frame as `modified`.
+		self.assertEqual(res["now"], "2026-07-23 12:00:00.000001")
 		self.assertTrue(res["sheets"][0]["is_owner"])
 		self.assertFalse(res["sheets"][1]["is_owner"])
 


### PR DESCRIPTION
## What

Upgrades the Sheets homepage from a flat, silently-capped listing to a filterable, paginated one:

- **Ownership tabs** — All / My sheets / Shared with me (frappe-ui `TabButtons`), scoped server-side so results stay correct under pagination.
- **Sort control** — Last modified / Name A–Z / Owner (frappe-ui `Select`), whitelisted server-side via an `order_by` → literal map (caller input never reaches SQL).
- **Recency groups** — under the default sort, list rows group into Today / Previous 7 days / Previous 30 days / Earlier using ListView's native grouped-rows mode; collapse state survives Load More appends (`recency-groups.js`, unit-tested).
- **Server-side pagination** — `list_sheets` gains `start`/`limit` (50/page, capped at 100), server-side title search (300 ms debounce), and returns `{sheets, total}` with a permission-aware aggregate count. This removes the old hard `limit=100` that silently hid older sheets.
- **Scroll layout** — in list mode the ListView owns its internal scroll: topbar, filter toolbar, column header, and the `ListFooter` (Load More + "X of Y", page-size picker suppressed) stay fixed while rows scroll. Grid mode keeps body scroll with a centered Load more + count.
- Filtered/tab empty states get dedicated copy; the branded "No sheets yet" block stays reserved for a truly empty account.

## Why

With more than a screenful of sheets the homepage became a single undifferentiated scroll, and past 100 sheets rows silently vanished. Filters + recency landmarks + explicit pagination fix both.

## Notes

- Sole caller of `list_sheets` is Sheets Home; the response-shape change has no other consumers (verified by repo-wide grep).
- The count query uses dict field syntax (`{"COUNT": "*", "as": "total"}`) — required on current Frappe develop, which rejects string SQL functions in SELECT.
- Feature was runtime-verified in the standalone repo against a 106-sheet dataset (pagination, tab counts, grouping, collapse persistence, stale-response guard, SQL-ish search probes); this port is hunk-identical modulo suite's router navigation and API namespace.
- Tests: 15 DB-free python tests for the API window/filter/order_by-injection behavior; 8 vitest cases for the recency bucketing (`.test.ts` so the suite glob picks it up).
