### PR TITLE
feat(calendar): meet links on existing events, richer meet row

### DIFF
--- a/frontend/src/apps/calendar/components/EventDetailSidebar.vue
+++ b/frontend/src/apps/calendar/components/EventDetailSidebar.vue
@@ -194,17 +194,23 @@ const sanitizedDescription = computed(() => {
 
 // --- Meet link ---
 
+// Same fallback as the event modal: prefer the sanitized same-origin path, but
+// keep a raw foreign-origin link joinable rather than hiding the section.
 const meetUrl = computed(() => {
-	const link = calendarEvent.links?.find((item: any) => getMeetUrl(item?.href))
-	if (link?.href) return getMeetUrl(link.href)
-
-	const match = calendarEvent.description?.match(
-		/https?:\/\/\S+\/meet\/[a-zA-Z0-9-]+|\/meet\/[a-zA-Z0-9-]+/,
-	)
-	return getMeetUrl(match?.[0])
+	const href =
+		calendarEvent.links?.find((item: any) => item?.href?.includes('/meet/'))?.href ||
+		calendarEvent.description?.match(
+			/https?:\/\/\S+\/meet\/[a-zA-Z0-9-]+|\/meet\/[a-zA-Z0-9-]+/,
+		)?.[0]
+	if (!href) return ''
+	return getMeetUrl(href) || href.replace(/\W+$/, '')
 })
 
-const meetCode = computed(() => meetUrl.value.split('/meet/')[1]?.split(/[?#]/)[0] ?? '')
+const meetLinkDisplay = computed(() =>
+	meetUrl.value
+		? new URL(meetUrl.value, window.location.origin).href.replace(/^https?:\/\//, '')
+		: '',
+)
 
 const copyMeetLink = async () => {
 	await navigator.clipboard.writeText(new URL(meetUrl.value, window.location.origin).href)
@@ -213,7 +219,9 @@ const copyMeetLink = async () => {
 
 const joinMeet = () => {
 	if (!meetUrl.value) return
-	window.location.href = meetUrl.value
+	// Same-origin paths stay in-app; foreign links open in a new tab.
+	if (meetUrl.value.startsWith('/')) window.location.href = meetUrl.value
+	else window.open(meetUrl.value, '_blank', 'noopener')
 }
 
 // --- Actions dropdown (delete) ---
@@ -386,6 +394,13 @@ const openUrl = (location: string) => {
 						{{ calendarEvent.title || __('[No title]') }}
 					</h3>
 					<div class="text-ink-gray-6 break-words text-sm">{{ dateLabel }}</div>
+					<div
+						v-if="calendarEvent.recurrence_id"
+						class="text-ink-gray-5 flex items-center gap-1.5 text-sm"
+					>
+						<Repeat class="icon size-3.5 shrink-0" />
+						{{ getRepeatMessage(calendarEvent.recurrence_rule) }}
+					</div>
 				</div>
 			</div>
 
@@ -393,21 +408,16 @@ const openUrl = (location: string) => {
 
 			<!-- Details -->
 			<div class="flex flex-col py-2">
-				<!-- Recurrence -->
-				<div v-if="calendarEvent.recurrence_id" class="flex items-center gap-2.5 px-[18px] py-[7px]">
-					<Repeat class="icon text-ink-gray-5 size-4 shrink-0" />
-					<span class="text-ink-gray-7 min-w-0 break-words text-sm">
-						{{ getRepeatMessage(calendarEvent.recurrence_rule) }}
-					</span>
-				</div>
-
 				<!-- Meet link -->
 				<template v-if="meetUrl">
 					<div class="flex items-center gap-2.5 px-[18px] py-[7px]">
-						<img :src="meetLogo" :alt="__('Frappe Meet')" class="size-4 shrink-0" />
-						<span class="text-ink-gray-7 min-w-0 flex-1 truncate text-sm">
-							{{ meetCode }}
-						</span>
+						<img :src="meetLogo" :alt="__('Frappe Meet')" class="size-7 shrink-0" />
+						<div class="min-w-0 flex-1">
+							<div class="text-ink-gray-8 text-sm font-medium">
+								{{ __('Frappe Meet') }}
+							</div>
+							<div class="text-ink-gray-5 truncate text-xs">{{ meetLinkDisplay }}</div>
+						</div>
 						<button
 							class="text-ink-gray-5 hover:text-ink-gray-7 shrink-0"
 							:title="__('Copy Frappe Meet link')"
@@ -421,7 +431,7 @@ const openUrl = (location: string) => {
 							class="bg-surface-gray-2 hover:bg-surface-gray-3 text-ink-gray-7 flex w-full items-center justify-center gap-2 rounded py-1.5 text-sm"
 							@click="joinMeet"
 						>
-							{{ __('Join Frappe Meet') }}
+							{{ __('Join') }}
 						</button>
 					</div>
 				</template>

--- a/frontend/src/apps/calendar/components/EventDetailSidebar.vue
+++ b/frontend/src/apps/calendar/components/EventDetailSidebar.vue
@@ -9,19 +9,19 @@ import {
 	Mail,
 	MapPin,
 	MoreHorizontal,
-	Phone,
 	Repeat,
 	SquarePen,
 	Text,
 	Trash2,
 	Users,
-	Video,
 	X,
 } from 'lucide-vue-next'
 import { Button, Dialog, Dropdown, TabButtons, createResource, toast } from 'frappe-ui'
 import DOMPurify from 'dompurify'
 
-import { getReorderedParticipants, isUrl } from '@/apps/calendar/utils'
+import meetLogo from '@/assets/app-logos/meet.png'
+
+import { getMeetUrl, getReorderedParticipants, isUrl } from '@/apps/calendar/utils'
 import { getRepeatMessage } from '@/apps/calendar/utils/format'
 import { userStore } from '@/apps/calendar/stores/user'
 import EventParticipantList from '@/apps/calendar/components/EventParticipantList.vue'
@@ -203,29 +203,6 @@ const meetUrl = computed(() => {
 	)
 	return getMeetUrl(match?.[0])
 })
-
-const getMeetUrl = (url?: string) => {
-	if (!url) return ''
-	const value = url.replace(/\W+$/, '')
-
-	try {
-		// Meet links are stored as absolute URLs built from the site origin
-		// (get_url), which differs from the frontend origin in dev. Only the
-		// path is kept for navigation, so joining always stays on our own
-		// origin regardless of the stored host.
-		const parsed = new URL(value, window.location.origin)
-		// Accept if the stored host matches ours, OR if it was a relative path
-		// (no host in the original string). Rejects external meeting services
-		// whose URLs happen to contain /meet/.
-		const isRelative = !value.startsWith('http')
-		if (parsed.pathname.startsWith('/meet/') && (isRelative || parsed.origin === window.location.origin))
-			return parsed.pathname + parsed.search + parsed.hash
-	} catch {
-		return ''
-	}
-
-	return ''
-}
 
 const meetCode = computed(() => meetUrl.value.split('/meet/')[1]?.split(/[?#]/)[0] ?? '')
 
@@ -427,7 +404,7 @@ const openUrl = (location: string) => {
 				<!-- Meet link -->
 				<template v-if="meetUrl">
 					<div class="flex items-center gap-2.5 px-[18px] py-[7px]">
-						<Phone class="icon text-ink-gray-5 size-4 shrink-0" />
+						<img :src="meetLogo" :alt="__('Frappe Meet')" class="size-4 shrink-0" />
 						<span class="text-ink-gray-7 min-w-0 flex-1 truncate text-sm">
 							{{ meetCode }}
 						</span>
@@ -444,7 +421,6 @@ const openUrl = (location: string) => {
 							class="bg-surface-gray-2 hover:bg-surface-gray-3 text-ink-gray-7 flex w-full items-center justify-center gap-2 rounded py-1.5 text-sm"
 							@click="joinMeet"
 						>
-							<Video class="icon size-4" />
 							{{ __('Join Frappe Meet') }}
 						</button>
 					</div>

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { computed, inject, reactive, ref, watch } from 'vue'
-import { AlignLeft, Bell, Briefcase, Clock, MapPin, Users, X } from 'lucide-vue-next'
+import { computed, inject, nextTick, reactive, ref, watch } from 'vue'
+import { AlignLeft, Bell, Briefcase, Clock, Copy, MapPin, Users, X } from 'lucide-vue-next'
 import { Button, Dialog, Dropdown, FormControl, Switch, createResource, toast } from 'frappe-ui'
 
 import meetLogo from '@/assets/app-logos/meet.png'
-import { getReorderedParticipants } from '@/apps/calendar/utils'
+import { getMeetUrl, getReorderedParticipants } from '@/apps/calendar/utils'
 import { getRepeatMessage } from '@/apps/calendar/utils/format'
 import { userStore } from '@/apps/calendar/stores/user'
 import EventAlertList from '@/apps/calendar/components/EventAlertList.vue'
@@ -44,7 +44,8 @@ const getEventData = () => {
 		endTime: end.format('HH:mm'),
 		free_busy_status: ev.free_busy_status,
 		privacy: ev.privacy || 'Public',
-		locations: ev.locations.length ? ev.locations.map((l) => l._name) : [''],
+		locations: ev.locations.map((l) => l._name),
+		links: ev.links ? [...ev.links] : [],
 		alerts: ev.alerts?.map(parseAlert) ?? [],
 		description: ev.description || '',
 		participants: [...ev.participants],
@@ -69,7 +70,8 @@ const getDefaultEventData = () => {
 		startTime,
 		endDate: dayjs(selectedEvent.date).format('YYYY-MM-DD'),
 		endTime: dayjs(startTime, 'HH:mm').add(1, 'hour').format('HH:mm'),
-		locations: [''],
+		locations: [],
+		links: [],
 		alerts: [],
 		description: '',
 		free_busy_status: 'Busy',
@@ -152,6 +154,9 @@ const eventParams = computed(() => {
 	if (event.description) params.description = event.description
 	if (event.locations?.some((l) => l?.trim()))
 		params.locations = event.locations.filter((l) => l?.trim()).map((name) => ({ name }))
+	// Always carry existing links on updates — the JMAP update is a full replace,
+	// so omitting them would strip Meet links from the event.
+	if (event.links?.length) params.links = event.links
 	if (event.participants?.length) params.participants = event.participants
 	if (event.alerts?.length) {
 		params.alerts = event.alerts.map((a) => {
@@ -214,6 +219,33 @@ const hasMeetLink = (ev: any) =>
 	(ev?.links || []).some((link: any) => link?.href?.includes('/meet/')) ||
 	!!ev?.description?.includes('/meet/')
 
+// Prefer the sanitized same-origin path, but fall back to the raw URL so events
+// whose Meet link lives on another origin (e.g. created against a different site
+// URL) still get a Join affordance — the same link is already clickable in the
+// detail sidebar's description.
+const meetUrl = computed(() => {
+	const href =
+		event.links?.find((item: any) => item?.href?.includes('/meet/'))?.href ||
+		event.description?.match(/https?:\/\/\S+\/meet\/[a-zA-Z0-9-]+|\/meet\/[a-zA-Z0-9-]+/)?.[0]
+	if (!href) return ''
+	return getMeetUrl(href) || href.replace(/\W+$/, '')
+})
+
+const joinMeet = () => {
+	if (meetUrl.value) window.open(meetUrl.value, '_blank', 'noopener')
+}
+
+const copyMeetLink = async () => {
+	await navigator.clipboard.writeText(new URL(meetUrl.value, window.location.origin).href)
+	toast.success(__('Frappe Meet link copied.'))
+}
+
+const meetLinkDisplay = computed(() =>
+	meetUrl.value
+		? new URL(meetUrl.value, window.location.origin).href.replace(/^https?:\/\//, '')
+		: '',
+)
+
 // --- Watchers ---
 
 watch(show, (val) => {
@@ -226,6 +258,15 @@ const showRepeatSettings = ref(false)
 watch(showRepeatSettings, (val) => {
 	if (!val && !event.recurrence_rule?.frequency) event.repeat = false
 })
+
+const locationsEl = ref<HTMLElement | null>(null)
+
+const addLocation = async () => {
+	event.locations.push('')
+	await nextTick()
+	const inputs = locationsEl.value?.querySelectorAll('input')
+	inputs?.[inputs.length - 1]?.focus()
+}
 
 // With a rule applied the row is an entry point to the settings — unchecking
 // only happens through Remove Repeat in the modal.
@@ -297,6 +338,11 @@ const editEvent = createResource({
 	onSuccess: handleSuccess,
 })
 
+const createMeetLink = createResource({
+	url: 'suite.meet.api.schedule.create_meet_link',
+	makeParams: () => ({ account: store.accountId, title: event.title }),
+})
+
 const isUpdateInstance = ref(false)
 
 const submitEvent = (sendEmail: boolean) => {
@@ -312,7 +358,18 @@ const submitEvent = (sendEmail: boolean) => {
 		? { loading: __('Creating event...'), success: __('Event created.') }
 		: { loading: __('Updating event...'), success: __('Event updated.') }
 
-	toast.promise(resource.submit({ sendEmail }), {
+	// Attaching a Meet link to an existing event: mint the room first, then send the
+	// regular update with the link included (creation bundles this server-side).
+	const attachMeetLink = !isNew.value && event.addMeetLink && !hasMeetLink(selectedEvent?.calendarEvent)
+	const submit = async () => {
+		if (attachMeetLink) {
+			const { meeting_url } = await createMeetLink.submit()
+			event.links = [...(event.links || []), { href: meeting_url, content_type: 'text/html' }]
+		}
+		return resource.submit({ sendEmail })
+	}
+
+	toast.promise(submit(), {
 		...messages,
 		error: __('Action failed. Please try again in some time.'),
 	})
@@ -508,25 +565,37 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 						</div>
 
 						<!-- meet link -->
-						<div
-							v-if="isNew || hasMeetLink(selectedEvent?.calendarEvent)"
-							class="mt-4 flex items-center gap-3 rounded-lg border border-outline-gray-2 px-3.5 py-3"
-						>
-							<img :src="meetLogo" :alt="__('Frappe Meet')" class="size-[18px] shrink-0" />
-							<span class="flex-1 text-base">
-								{{ __('Add Frappe Meet Video Call') }}
-							</span>
-							<Switch
-								v-model="event.addMeetLink"
-								:disabled="!isNew && hasMeetLink(selectedEvent?.calendarEvent)"
-							/>
+						<div class="mt-4 flex items-center gap-3 rounded-lg border border-outline-gray-2 px-3.5 py-3">
+							<template v-if="meetUrl">
+								<img :src="meetLogo" :alt="__('Frappe Meet')" class="size-7 shrink-0" />
+								<div class="min-w-0 flex-1">
+									<div class="text-sm font-medium text-ink-gray-8 mb-0.5">
+										{{ __('Frappe Meet video call') }}
+									</div>
+									<div class="truncate text-xs text-ink-gray-5">{{ meetLinkDisplay }}</div>
+								</div>
+								<Button variant="ghost" :title="__('Copy Frappe Meet link')" @click="copyMeetLink">
+									<template #icon><Copy :size="14" class="icon text-ink-gray-5" /></template>
+								</Button>
+								<Button :label="__('Join')" @click="joinMeet" />
+							</template>
+							<template v-else>
+								<img :src="meetLogo" :alt="__('Frappe Meet')" class="size-[18px] shrink-0" />
+								<span class="flex-1 text-base">{{ __('Add Frappe Meet video call') }}</span>
+								<Switch v-model="event.addMeetLink" />
+							</template>
 						</div>
+
 
 						<div class="mt-4 flex flex-col gap-4">
 							<!-- locations -->
 							<div class="flex gap-3">
-								<MapPin :size="18" class="icon mt-7 shrink-0 text-ink-gray-5" />
-								<div class="min-w-0 flex-1 space-y-2">
+								<MapPin
+									:size="18"
+									class="icon shrink-0 text-ink-gray-5"
+									:class="event.locations?.length ? 'mt-7' : 'mt-2'"
+								/>
+								<div ref="locationsEl" class="min-w-0 flex-1 space-y-2">
 									<div v-for="(_, i) in event.locations" :key="i" class="flex gap-2">
 										<FormControl
 											v-model="event.locations[i]"
@@ -540,18 +609,12 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 											:placeholder="__('Meeting location {0}', [i + 1])"
 											class="w-full"
 										/>
-										<Button
-											v-if="event.locations?.length === 1"
-											icon="plus"
-											class="mt-auto"
-											@click="event.locations.push('')"
-										/>
-										<Button v-else icon="x" class="mt-auto" @click="event.locations.splice(i, 1)" />
+										<Button icon="x" class="mt-auto" @click="event.locations.splice(i, 1)" />
 									</div>
 									<Button
-										v-if="event.locations?.length > 1 && event.locations?.length < 3"
+										v-if="(event.locations?.length ?? 0) < 3"
 										:label="__('Add Location')"
-										@click="event.locations.push('')"
+										@click="addLocation"
 									/>
 								</div>
 							</div>

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -368,7 +368,10 @@ const submitEvent = (sendEmail: boolean) => {
 	// regular update with the link included (creation bundles this server-side).
 	const attachMeetLink = pendingMeetAttach.value
 	const submit = async () => {
-		if (attachMeetLink) {
+		// A failed update leaves the minted room in event.links only — reuse it on
+		// retry rather than creating an orphaned duplicate.
+		const alreadyMinted = (event.links || []).some((l: any) => l?.href?.includes('/meet/'))
+		if (attachMeetLink && !alreadyMinted) {
 			const { meeting_url } = await createMeetLink.submit()
 			event.links = [...(event.links || []), { href: meeting_url, content_type: 'text/html' }]
 		}

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -235,6 +235,12 @@ const joinMeet = () => {
 	if (meetUrl.value) window.open(meetUrl.value, '_blank', 'noopener')
 }
 
+// Toggling Meet on an existing event isn't part of eventParams/patch, so it
+// must count as a pending change on its own (both for Save and for submit).
+const pendingMeetAttach = computed(
+	() => !isNew.value && event.addMeetLink && !hasMeetLink(selectedEvent?.calendarEvent),
+)
+
 const copyMeetLink = async () => {
 	await navigator.clipboard.writeText(new URL(meetUrl.value, window.location.origin).href)
 	toast.success(__('Frappe Meet link copied.'))
@@ -360,7 +366,7 @@ const submitEvent = (sendEmail: boolean) => {
 
 	// Attaching a Meet link to an existing event: mint the room first, then send the
 	// regular update with the link included (creation bundles this server-side).
-	const attachMeetLink = !isNew.value && event.addMeetLink && !hasMeetLink(selectedEvent?.calendarEvent)
+	const attachMeetLink = pendingMeetAttach.value
 	const submit = async () => {
 		if (attachMeetLink) {
 			const { meeting_url } = await createMeetLink.submit()
@@ -437,7 +443,7 @@ const disableSave = computed(() => {
 	if (createEvent.loading || editEvent.loading || editEventInstance.loading) return true
 	if (createMeetEvent.loading) return true
 	if (!isDateTimeValid.value) return true
-	if (!isNew.value && !Object.keys(patch.value).length) return true
+	if (!isNew.value && !Object.keys(patch.value).length && !pendingMeetAttach.value) return true
 	return false
 })
 
@@ -570,7 +576,7 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 								<img :src="meetLogo" :alt="__('Frappe Meet')" class="size-7 shrink-0" />
 								<div class="min-w-0 flex-1">
 									<div class="text-sm font-medium text-ink-gray-8 mb-0.5">
-										{{ __('Frappe Meet video call') }}
+										{{ __('Frappe Meet') }}
 									</div>
 									<div class="truncate text-xs text-ink-gray-5">{{ meetLinkDisplay }}</div>
 								</div>
@@ -585,6 +591,7 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 								<Switch v-model="event.addMeetLink" />
 							</template>
 						</div>
+
 
 
 						<div class="mt-4 flex flex-col gap-4">

--- a/frontend/src/apps/calendar/utils/index.ts
+++ b/frontend/src/apps/calendar/utils/index.ts
@@ -76,3 +76,26 @@ export const shouldIgnoreKeypress = (
 		e.altKey
 	)
 }
+
+// Meet links are stored as absolute URLs built from the site origin (get_url),
+// which differs from the frontend origin in dev. Only the path is kept for
+// navigation, so joining always stays on our own origin regardless of the
+// stored host. Rejects external meeting services whose URLs contain /meet/.
+export const getMeetUrl = (url?: string) => {
+	if (!url) return ''
+	const value = url.replace(/\W+$/, '')
+
+	try {
+		const parsed = new URL(value, window.location.origin)
+		const isRelative = !value.startsWith('http')
+		if (
+			parsed.pathname.startsWith('/meet/') &&
+			(isRelative || parsed.origin === window.location.origin)
+		)
+			return parsed.pathname + parsed.search + parsed.hash
+	} catch {
+		return ''
+	}
+
+	return ''
+}

--- a/suite/meet/api/schedule.py
+++ b/suite/meet/api/schedule.py
@@ -70,3 +70,13 @@ def create_scheduled_meeting(
 	)
 
 	return {"meeting_id": meeting_id, "meeting_url": meet_url, "event_id": event_id}
+
+
+@frappe.whitelist()
+def create_meet_link(account: str, title: str | None = None, meeting_type: str = "open") -> dict[str, str]:
+	"""Create a Meet room and return its link, for attaching to an existing calendar event."""
+
+	is_jmap_account_belongs_to_user(account, raise_exception=True)
+
+	meeting_id = create_meeting(meeting_type=meeting_type, title=title)
+	return {"meeting_id": meeting_id, "meeting_url": get_url(f"/meet/{meeting_id}")}


### PR DESCRIPTION
Meet links can now be added to existing events, not just at creation: a new `create_meet_link` endpoint mints the room, and the event modal patches it into the event's links on save. A pending attach counts as a change, so Save enables even when nothing else was edited.

Also:
- **bug fix**: updates now always carry the event's existing links — the JMAP update is a full replace, so omitting them silently stripped meet links on every edit
- the meet row shows an existing link as a two-line card (logo, "Frappe Meet", host+path) with copy and Join actions, in both the event modal and the detail sidebar; the add-toggle remains for events without a link
- foreign-origin meet links fall back to their raw URL (opened in a new tab) instead of hiding the Join affordance
- `getMeetUrl` moved to calendar utils, shared between modal and sidebar
- the sidebar shows the repeat rule directly under the date/time line
- locations start as an Add Location button that focuses the new input on click, matching the alerts pattern

Verified end-to-end: attach on save fires `create_meet_link` + `update_calendar_event`, the link persists, and it survives subsequent edits.

<img width="584" height="74" alt="image" src="https://github.com/user-attachments/assets/512c6455-7171-490d-af03-03f38684a503" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)