### PR TITLE
feat(sheets): auto-link URLs and link preview hover card

### DIFF
--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -12,7 +12,7 @@ import { checkboxRect } from './checkbox-geometry.js'
 
 export { colLabel, cellId, parseCellId } from '../utils/cells.js'
 
-export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getFormat, onFill, onBatchCommit, getMergeInfo, isSlave, getMasterId, getComment, getValidation, getCondFormat, getSparkline, getRightInset, onHyperlinkClick, onDropdownClick, onCheckboxToggle, onPivotDrill, onResizeEnd, getSheetNames, getCurrentSheet, getEditingHomeSheet, getDisplay, getCellIds, lazyValues = false, canEdit = () => true, isCellEditable, onBlockedEdit } = {}) {
+export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getFormat, onFill, onBatchCommit, getMergeInfo, isSlave, getMasterId, getComment, getValidation, getCondFormat, getSparkline, getRightInset, onHyperlinkClick, onLinkHover, onDropdownClick, onCheckboxToggle, onPivotDrill, onResizeEnd, getSheetNames, getCurrentSheet, getEditingHomeSheet, getDisplay, getCellIds, lazyValues = false, canEdit = () => true, isCellEditable, onBlockedEdit } = {}) {
   const ctx = canvas.getContext('2d')
   const dpr = window.devicePixelRatio || 1
 
@@ -1324,6 +1324,14 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     showEditor(getValue(cellId(h.r, h.c)) ?? '', 'edit')
   })
 
+  let _lastLinkHover = null   // 'r,c' of the linked cell the pointer is on
+
+  canvas.addEventListener('mouseleave', () => {
+    if (_lastLinkHover === null) return
+    _lastLinkHover = null
+    onLinkHover?.(null)
+  })
+
   canvas.addEventListener('mousemove', e => {
     const rect = canvas.getBoundingClientRect()
     const resizeCol = geo.hitTestColResize(e.clientX, e.clientY, rect)
@@ -1337,6 +1345,16 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     else if (overFill)                             canvas.style.cursor = 'crosshair'
     else if (overLink)                             canvas.style.cursor = 'pointer'
     else                                           canvas.style.cursor = 'default'
+
+    // Hover-card feed: notify once per enter/leave of a linked cell (not per
+    // pixel). The editor layers debounce + the popover itself on top of this.
+    const linkKey = overLink ? `${hoverCell.r},${hoverCell.c}` : null
+    if (linkKey !== _lastLinkHover) {
+      _lastLinkHover = linkKey
+      onLinkHover?.(linkKey
+        ? { r: hoverCell.r, c: hoverCell.c, id: cellId(hoverCell.r, hoverCell.c), url: overLink }
+        : null)
+    }
 
     if (filling) {
       if (!filling.moved) {

--- a/frontend/src/apps/sheets/components/SheetEditor/LinkPreviewCard.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/LinkPreviewCard.vue
@@ -1,0 +1,140 @@
+<template>
+	<div
+		v-if="open"
+		class="sn-lp-card absolute z-40 w-[340px] overflow-hidden rounded-lg border border-outline-gray-1 bg-surface-white shadow-2xl"
+		:style="style"
+		@mouseenter="$emit('enter')"
+		@mouseleave="$emit('leave')"
+		@mousedown.stop
+		@click.stop
+	>
+		<div class="flex items-center gap-2.5 p-2.5 pl-3">
+			<span
+				class="flex h-7 w-7 shrink-0 items-center justify-center rounded bg-surface-gray-2 text-ink-gray-5"
+			>
+				<img
+					v-if="preview.favicon && !faviconFailed"
+					:src="preview.favicon"
+					alt=""
+					class="h-5 w-5 rounded-sm"
+					@error="faviconFailed = true"
+				/>
+				<Spinner v-else-if="preview.loading" class="h-3.5 w-3.5" />
+				<LucideGlobe v-else class="h-4 w-4" />
+			</span>
+
+			<div class="min-w-0 flex-1">
+				<a
+					class="block truncate text-sm font-medium text-ink-gray-8 hover:underline"
+					:href="url"
+					target="_blank"
+					rel="noopener noreferrer"
+					:title="url"
+					@click.prevent="$emit('open')"
+				>{{ titleText }}</a>
+				<div class="truncate text-xs text-ink-gray-5">{{ hostText }}</div>
+			</div>
+
+			<div class="flex shrink-0 items-center gap-0.5">
+				<Button
+					variant="ghost"
+					size="sm"
+					:icon="copied ? 'lucide-check' : 'lucide-copy'"
+					:tooltip="copied ? 'Copied' : 'Copy link'"
+					@click="copyUrl"
+				/>
+				<Button
+					v-if="canEdit"
+					variant="ghost"
+					size="sm"
+					icon="lucide-pencil"
+					tooltip="Edit link"
+					@click="$emit('edit')"
+				/>
+				<Button
+					v-if="canEdit"
+					variant="ghost"
+					size="sm"
+					icon="lucide-unlink"
+					tooltip="Remove link"
+					@click="$emit('unlink')"
+				/>
+			</div>
+		</div>
+
+		<p
+			v-if="preview.description"
+			class="line-clamp-2 px-3 pb-2.5 text-xs leading-relaxed text-ink-gray-6"
+		>
+			{{ preview.description }}
+		</p>
+
+		<div
+			v-if="showReplaceOffer"
+			class="flex items-center justify-between gap-2 border-t border-outline-gray-2 bg-surface-gray-1 px-3 py-2"
+		>
+			<span class="text-xs text-ink-gray-6">Replace URL with its title?</span>
+			<Button variant="subtle" size="sm" label="Replace" @click="$emit('replace')" />
+		</div>
+	</div>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { Button, Spinner } from 'frappe-ui'
+import LucideGlobe from '~icons/lucide/globe'
+
+const props = defineProps({
+	open:    { type: Boolean, default: false },
+	anchor:  { type: Object,  default: null },   // { x, y } canvas-local px
+	url:     { type: String,  default: '' },
+	// { loading, error, title, description, favicon, host }
+	preview: { type: Object,  default: () => ({}) },
+	canEdit: { type: Boolean, default: false },
+	// True when the cell's text is just the raw URL — the replace-with-title
+	// offer only makes sense then.
+	offerReplace: { type: Boolean, default: false },
+})
+defineEmits(['open', 'edit', 'unlink', 'replace', 'enter', 'leave'])
+
+const copied        = ref(false)
+const faviconFailed = ref(false)
+
+watch(() => props.url, () => { copied.value = false; faviconFailed.value = false })
+
+const titleText = computed(() => props.preview.title || props.url)
+
+const hostText = computed(() => {
+	if (props.preview.loading) return 'Loading preview…'
+	if (props.preview.host) return props.preview.host
+	// mailto: / unreachable pages — show the bare target, minus the scheme.
+	return props.url.replace(/^(https?:\/\/|mailto:)/i, '')
+})
+
+const showReplaceOffer = computed(() =>
+	props.offerReplace && props.canEdit && !!props.preview.title && !props.preview.loading)
+
+function copyUrl() {
+	navigator.clipboard?.writeText(props.url).catch(() => {})
+	copied.value = true
+	setTimeout(() => { copied.value = false }, 1500)
+}
+
+const style = computed(() => {
+	if (!props.anchor) return { display: 'none' }
+	return { left: `${props.anchor.x}px`, top: `${props.anchor.y}px` }
+})
+</script>
+
+<style scoped>
+/* Entrance only — everything visual is espresso Tailwind utilities. Matches
+   the rise used by the other Sheets popovers. */
+.sn-lp-card {
+	transform-origin: top left;
+	animation: sn-lp-rise 120ms ease-out;
+}
+@keyframes sn-lp-rise {
+	from { transform: translateY(-4px) scale(0.98); opacity: 0; }
+	to   { transform: translateY(0)    scale(1);    opacity: 1; }
+}
+</style>

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -353,8 +353,11 @@
     />
 
     <!-- Canvas grid + filter overlay -->
+    <!-- wheel.capture: the link hover card is anchored to a cell's pixel rect,
+         which any scroll invalidates — hide it rather than let it float. -->
     <div ref="gridWrapRef" class="sn-grid-wrap"
-         :class="{ 'sn-painting-format': isPaintingFormat, 'sn-preview-locked': !!vhActive }">
+         :class="{ 'sn-painting-format': isPaintingFormat, 'sn-preview-locked': !!vhActive }"
+         @wheel.capture.passive="linkCard.open = false">
       <canvas ref="canvasRef" />
 
       <!-- Initial-load shim. The canvas is mounted (so grid.resize / event
@@ -450,6 +453,21 @@
         @choose="onSplitChoose"
         @apply="onSplitApply"
         @cancel="onSplitCancel"
+      />
+
+      <LinkPreviewCard
+        :open="linkCard.open"
+        :anchor="linkCard.anchor"
+        :url="linkCard.url"
+        :preview="linkCard.preview"
+        :can-edit="!readOnly"
+        :offer-replace="linkCard.offerReplace"
+        @enter="onLinkCardEnter"
+        @leave="onLinkCardLeave"
+        @open="openLinkCardUrl"
+        @edit="editLinkCardCell"
+        @unlink="unlinkLinkCardCell"
+        @replace="replaceLinkWithTitle"
       />
 
       <!-- Outline around the active filter's range so its extent is visible.
@@ -1238,6 +1256,8 @@ import { createValidationEngine } from '../../engine/validation.js'
 import { createProtectionEngine } from '../../engine/protection.js'
 import { chipColor } from '../../canvas/chip-geometry.js'
 import { createCondFormatEngine } from '../../engine/cond-format.js'
+import { detectHyperlink, isAutoLinkText } from '../../engine/links.js'
+import { fetchLinkPreview } from '../../services/linkPreview.js'
 import { useToolbar }          from './useToolbar.js'
 import { usePersistence }      from './usePersistence.js'
 import { useEditOps }          from './useEditOps.js'
@@ -1257,6 +1277,7 @@ import VersionHistory          from './VersionHistory.vue'
 import VersionPreviewBanner    from './VersionPreviewBanner.vue'
 import CellHistoryPopover      from './CellHistoryPopover.vue'
 import SplitTextPopover        from './SplitTextPopover.vue'
+import LinkPreviewCard         from './LinkPreviewCard.vue'
 import ShareDialog             from './ShareDialog.vue'
 import AISettingsDialog        from './AISettingsDialog.vue'
 import AskBar                  from './AskBar.vue'
@@ -3148,6 +3169,9 @@ function _setupGridInstance() {
         history.pushOp(op)
         broadcastCellChange(writeSheet, id, value)
       }
+      // Outside the changed-guard: re-committing an unchanged URL text (e.g.
+      // pre-existing "frappe.io" data) still picks up its link.
+      _maybeAutoLink([{ id, value, before }], writeSheet)
       editingHomeSheet.value = null
       editingHomeCell.value  = null
       syncFlags()
@@ -3200,6 +3224,7 @@ function _setupGridInstance() {
       return p.row === range.r0 && p.col >= range.c0 && p.col <= range.c1 ? 19 : 0
     },
     onHyperlinkClick(url) { window.open(url, '_blank', 'noopener,noreferrer') },
+    onLinkHover: _onLinkHover,
     onDropdownClick(id, rule, pos) { openDropdown(id, rule, pos) },
     onCheckboxToggle(id) { toggleCheckbox(id) },
     onPivotDrill(r, c) { return drillDownAt(r, c) },
@@ -3230,6 +3255,12 @@ function _setupGridInstance() {
         history.pushOp(op)
         broadcastBatchChange(sheet.getCurrentSheet(), refs.map(id => ({ id, value: after[id] })))
       }
+      _maybeAutoLink(
+        cells.map(({ id, value }) => ({
+          id, value, before: before[id] !== undefined ? before[id] : value,
+        })),
+        sheet.getCurrentSheet(),
+      )
       syncFlags()
       isDirty.value = true
       recomputePivotsForSheet(sheet.getCurrentSheet())
@@ -3785,6 +3816,7 @@ function _commitFormulaBar() {
   editingHomeSheet.value = null
   editingHomeCell.value  = null
   _pushEditOp(targetSheet, before, 'Edit cell')
+  _maybeAutoLink([{ id: targetId, value: formulaValue.value, before: before[targetId] }], targetSheet)
 }
 
 function _cancelFormulaBar() {
@@ -5140,6 +5172,35 @@ function onFontSizeInput(e) {
 }
 
 // ── Hyperlink ─────────────────────────────────────────────────────────────────
+
+// Google-Sheets URL auto-detection: after a typed edit commits, a whole-cell
+// URL gets fmt.hyperlink set on it. Recorded as its OWN format op after the
+// edit op, so the first Ctrl+Z strips just the link and the second undoes the
+// text — matching Google's "undo removes the auto-link" behavior. The inverse
+// also runs: editing an auto-linked cell (text === its URL) to a non-URL
+// drops the stale link; custom display text set via Ctrl+L keeps it.
+
+// The hyperlink patch a committed edit implies for one cell, or null.
+function _autoLinkChange(id, value, before, sn) {
+	const url  = detectHyperlink(String(value ?? ''))
+	const prev = formats.getCellFormat(id, sn).hyperlink || null
+	if (url) return prev === url ? null : { id, url }
+	return prev && isAutoLinkText(before, prev) ? { id, url: null } : null
+}
+
+// cells: [{ id, value, before }] — single-cell commits and Ctrl+Enter batch
+// commits share this; a batch records ONE format op so one undo strips all.
+function _maybeAutoLink(cells, sn) {
+	const changes = cells.map(c => _autoLinkChange(c.id, c.value, c.before, sn)).filter(Boolean)
+	if (!changes.length) return
+	_recordFormatOp(changes.map(c => c.id), sn, () => {
+		for (const { id, url } of changes) formats.applyToRange([id], { hyperlink: url }, sn)
+	})
+	refreshActiveFormat()
+	grid?.render()
+	syncFlags()
+}
+
 function openHyperlinkDialog() {
   const id  = activeCell.value
   const cur = sheet.getCell(id)
@@ -5175,6 +5236,106 @@ function removeHyperlink() {
   syncFlags()
   isDirty.value = true
   showHyperlinkDialog.value = false
+}
+
+// ── Link hover card ───────────────────────────────────────────────────────────
+// Google-style preview card over a linked cell: favicon/title/description from
+// the server (see suite/sheets/link_preview.py), plus copy / edit / unlink
+// actions and the "Replace URL with its title?" offer for auto-linked cells.
+
+const linkCard = reactive({
+  open: false, id: null, r: 0, c: 0, url: '',
+  anchor: null,        // { x, y } canvas-local px
+  preview: {},         // { loading, error, title, description, favicon, host }
+  offerReplace: false,
+})
+let _linkShowTimer = null
+let _linkHideTimer = null
+
+// Canvas feed — fires once on entering/leaving a linked cell. Short delays on
+// both edges so the card neither flickers during a sweep across links nor
+// vanishes while the pointer travels from the cell into the card.
+function _onLinkHover(info) {
+  if (info) {
+    clearTimeout(_linkHideTimer)
+    if (linkCard.open && linkCard.id === info.id && linkCard.url === info.url) return
+    clearTimeout(_linkShowTimer)
+    _linkShowTimer = setTimeout(() => _openLinkCard(info), 300)
+  } else {
+    clearTimeout(_linkShowTimer)
+    _scheduleLinkCardHide()
+  }
+}
+
+function _scheduleLinkCardHide() {
+  clearTimeout(_linkHideTimer)
+  _linkHideTimer = setTimeout(() => { linkCard.open = false }, 250)
+}
+
+function onLinkCardEnter() { clearTimeout(_linkHideTimer) }
+function onLinkCardLeave() { _scheduleLinkCardHide() }
+
+function _openLinkCard(info) {
+  const rect = grid?.getCellRect?.(info.r, info.c)
+  if (!rect) return
+  const CARD_W = 340, EST_H = 120
+  const wrapW = gridWrapRef.value?.offsetWidth  ?? Infinity
+  const wrapH = gridWrapRef.value?.offsetHeight ?? Infinity
+  const x = Math.max(0, Math.min(rect.x, wrapW - CARD_W - 8))
+  const y = rect.y + rect.height + EST_H > wrapH
+          ? Math.max(0, rect.y - EST_H)
+          : rect.y + rect.height + 2
+  const isHttp = /^https?:\/\//i.test(info.url)
+  Object.assign(linkCard, {
+    open: true, id: info.id, r: info.r, c: info.c, url: info.url,
+    anchor: { x, y },
+    preview: isHttp ? { loading: true } : {},
+    offerReplace: false,
+  })
+  if (!isHttp) return
+  fetchLinkPreview(info.url).then(res => {
+    // Pointer may have moved on — only fill the card still showing this URL.
+    if (!linkCard.open || linkCard.url !== info.url) return
+    linkCard.preview = { ...res, loading: false }
+    linkCard.offerReplace = !readOnly.value
+      && !!res.title
+      && isAutoLinkText(sheet.getCell(linkCard.id), linkCard.url)
+      && !_cellSilentlyProtected(linkCard.id)
+  })
+}
+
+function openLinkCardUrl() {
+  window.open(linkCard.url, '_blank', 'noopener,noreferrer')
+}
+
+function editLinkCardCell() {
+  linkCard.open = false
+  grid?.moveTo?.(linkCard.r, linkCard.c)   // onSelect syncs activeCell
+  openHyperlinkDialog()
+}
+
+function unlinkLinkCardCell() {
+  const sn = sheet.getCurrentSheet()
+  const id = linkCard.id
+  linkCard.open = false
+  if (!id || readOnly.value || _cellBlocked(id, sn)) return
+  _recordFormatOp([id], sn, () => formats.applyToRange([id], { hyperlink: null }, sn))
+  refreshActiveFormat()
+  grid?.render()
+  syncFlags()
+  isDirty.value = true
+}
+
+function replaceLinkWithTitle() {
+  const sn    = sheet.getCurrentSheet()
+  const id    = linkCard.id
+  const title = linkCard.preview?.title
+  linkCard.open = false
+  if (!id || !title || readOnly.value || _cellBlocked(id, sn)) return
+  const before = { [id]: sheet.getCell(id, sn) }
+  sheet.setCell(id, title, sn)
+  _pushEditOp(sn, before, 'Replace URL with title')
+  if (activeCell.value === id) formulaValue.value = title
 }
 
 function openInsertMany(kind, below = false) {

--- a/frontend/src/apps/sheets/engine/clipboard-links.test.ts
+++ b/frontend/src/apps/sheets/engine/clipboard-links.test.ts
@@ -55,6 +55,18 @@ describe('clipboard — pasteFromText auto-links whole-cell URLs', () => {
     const bare = createClipboard({ sheet: makeSheet() })
     expect(bare.pasteFromText('https://frappe.io/', 'A1', null)).toBe(true)
   })
+
+  it('clears a stale hyperlink when plain text overwrites a linked cell', () => {
+    formats.set('A1', { hyperlink: 'https://old.example.com' })
+    cb.pasteFromText('just text', 'A1', null)
+    expect(sheet._store().A1).toBe('just text')
+    expect(formats._store().A1).toEqual({ hyperlink: null })
+  })
+
+  it('leaves formats untouched when plain text lands on an unlinked cell', () => {
+    cb.pasteFromText('plain', 'A1', null)
+    expect(formats._store().A1).toBeUndefined()
+  })
 })
 
 describe('clipboard — pasteFromHTML keeps <a href> linkness', () => {

--- a/frontend/src/apps/sheets/engine/clipboard-links.test.ts
+++ b/frontend/src/apps/sheets/engine/clipboard-links.test.ts
@@ -1,0 +1,85 @@
+// URL auto-linking on paste — plain-text whole-cell URLs and <a href> anchors
+// from clipboard HTML both land as fmt.hyperlink. jsdom (the suite vitest env)
+// supplies DOMParser for the HTML-table path.
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createClipboard } from './clipboard.js'
+
+function makeSheet(initial = {}) {
+  const store = { ...initial }
+  return {
+    getRawData:      () => store,
+    getCell:         id => store[id] ?? '',
+    setCell:         (id, v) => { store[id] = v },
+    getCurrentSheet: () => 'Sheet1',
+    getDisplayValue: id => store[id] ?? '',
+    _store:          () => store,
+  }
+}
+
+function makeFormats() {
+  const store = {}
+  return {
+    get:    (id) => store[id] ?? {},
+    set:    (id, fmt) => { store[id] = { ...(store[id] || {}), ...fmt } },
+    clear:  (id) => { delete store[id] },
+    _store: () => store,
+  }
+}
+
+describe('clipboard — pasteFromText auto-links whole-cell URLs', () => {
+  let sheet, formats, cb
+  beforeEach(() => {
+    sheet   = makeSheet()
+    formats = makeFormats()
+    cb      = createClipboard({ sheet, formats })
+  })
+
+  it('sets fmt.hyperlink for URL cells, leaves plain text alone', () => {
+    cb.pasteFromText('https://frappe.io/\tplain text\nfrappe.io\t42', 'A1', null)
+    const f = formats._store()
+    expect(sheet._store().A1).toBe('https://frappe.io/')
+    expect(f.A1).toEqual({ hyperlink: 'https://frappe.io/' })
+    expect(f.B1).toBeUndefined()
+    expect(f.A2).toEqual({ hyperlink: 'https://frappe.io' })   // bare domain normalized
+    expect(f.B2).toBeUndefined()
+  })
+
+  it('tiled single-URL paste links every destination cell', () => {
+    cb.pasteFromText('www.frappe.io', 'A1', null, { r0: 0, c0: 0, r1: 1, c1: 0 })
+    const f = formats._store()
+    expect(f.A1).toEqual({ hyperlink: 'https://www.frappe.io' })
+    expect(f.A2).toEqual({ hyperlink: 'https://www.frappe.io' })
+  })
+
+  it('does not link when no formats engine is wired (headless paste)', () => {
+    const bare = createClipboard({ sheet: makeSheet() })
+    expect(bare.pasteFromText('https://frappe.io/', 'A1', null)).toBe(true)
+  })
+})
+
+describe('clipboard — pasteFromHTML keeps <a href> linkness', () => {
+  it('maps anchor targets onto fmt.hyperlink with the anchor text as value', () => {
+    const sheet   = makeSheet()
+    const formats = makeFormats()
+    const cb      = createClipboard({ sheet, formats })
+    const html = '<table><tr>' +
+                 '<td><a href="https://frappe.io/">Frappe</a></td>' +
+                 '<td>no link</td></tr></table>'
+    expect(cb.pasteFromHTML(html, 'A1', null)).toBe(true)
+    expect(sheet._store().A1).toBe('Frappe')
+    expect(formats._store().A1).toEqual({ hyperlink: 'https://frappe.io/' })
+    expect(formats._store().B1).toBeUndefined()
+  })
+
+  it('ignores javascript: anchors but still auto-links URL-shaped text', () => {
+    const sheet   = makeSheet()
+    const formats = makeFormats()
+    const cb      = createClipboard({ sheet, formats })
+    const html = '<table><tr>' +
+                 '<td><a href="javascript:alert(1)">click</a></td>' +
+                 '<td>https://frappe.io/</td></tr></table>'
+    cb.pasteFromHTML(html, 'A1', null)
+    expect(formats._store().A1).toBeUndefined()
+    expect(formats._store().B1).toEqual({ hyperlink: 'https://frappe.io/' })
+  })
+})

--- a/frontend/src/apps/sheets/engine/clipboard.js
+++ b/frontend/src/apps/sheets/engine/clipboard.js
@@ -349,16 +349,20 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 		const anch = parseCellId(anchorId)
 		if (!anch) return false
 		const { srcRows, srcCols, tileable } = _gridGeometry(grid, anch, destSel)
+		const sn = sheet.getCurrentSheet()
 
 		// Build the cell map first, then ship one bulk write — same reason as
 		// paste() above. Big external pastes (Excel/CSV via system clipboard)
 		// were the worst case here.
 		const writes = {}
-		const linkAt = {}   // destination id → hyperlink url
+		const linkAt = {}   // destination id → hyperlink url (null = clear)
 		const place = (id, val, dr, dc) => {
 			writes[id] = val
 			const url = links?.[`${dr},${dc}`] ?? detectHyperlink(val)
+			// A URL links the cell; otherwise clear any link the destination
+			// already carried so pasted plain text can't inherit a stale target.
 			if (url) linkAt[id] = url
+			else if (formats?.get(id, sn)?.hyperlink) linkAt[id] = null
 		}
 		if (tileable) {
 			for (let r = destSel.r0; r <= destSel.r1; r++) {
@@ -374,7 +378,6 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 					place(colLabel(anch.col + dc) + (anch.row + dr + 1), val, dr, dc)
 				}))
 		}
-		const sn = sheet.getCurrentSheet()
 		if (protection && Object.keys(writes).some(id => {
 			const p = parseCellId(id); return p && protection.isProtected(p.row, p.col, sn)
 		})) {

--- a/frontend/src/apps/sheets/engine/clipboard.js
+++ b/frontend/src/apps/sheets/engine/clipboard.js
@@ -2,6 +2,7 @@
 
 import { colLabel, parseCellId } from '../utils/cells.js'
 import { adjustFormula } from './formula-adjust.js'
+import { detectHyperlink } from './links.js'
 
 export function createClipboard({ sheet, formats, condFormat = null, validation = null, getPivotAt = null, createPivotFromPaste = null, protection = null }) {
 	let _data    = null   // { 'dr,dc': rawValue }
@@ -235,11 +236,20 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 	// honored by padding blanks; rowspan is left as-is (rare, and its cell text
 	// simply lands in the top row of the span).
 	function parseHTMLTable(html) {
+		return _parseHTMLGrid(html)?.grid ?? null
+	}
+
+	// Full HTML-table parse: cell text grid + per-cell hyperlink map keyed by
+	// 'dr,dc'. A cell whose content carries an <a href> (Google Sheets, Excel
+	// Online, web pages) keeps that target so the paste can restore linkness —
+	// textContent alone would flatten "Frappe" → dead text.
+	function _parseHTMLGrid(html) {
 		if (!html || typeof DOMParser === 'undefined') return null
 		const doc   = new DOMParser().parseFromString(html, 'text/html')
 		const table = doc.querySelector('table')
 		if (!table) return null
-		const grid = []
+		const grid  = []
+		const links = {}
 		// Only the outer table's own rows/cells — a bare querySelectorAll('tr')
 		// descends into any nested <table> inside a cell (common in web-page
 		// clipboard HTML) and bleeds its rows into the outer grid. A nested
@@ -252,6 +262,11 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 			const row = []
 			for (const cell of tr.querySelectorAll(':scope > th, :scope > td')) {
 				const text = (cell.textContent ?? '').replace(/\s+/g, ' ').trim()
+				const href = cell.querySelector('a[href]')?.getAttribute('href')
+				// Only http(s)/mailto targets — clipboard HTML can carry
+				// javascript: or app-internal schemes we must not store.
+				if (href && /^(https?:|mailto:)/i.test(href))
+					links[`${grid.length},${row.length}`] = href
 				row.push(text)
 				const span = parseInt(cell.getAttribute('colspan') || '1', 10)
 				for (let i = 1; i < span; i++) row.push('')
@@ -260,15 +275,15 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 		}
 		// Drop trailing all-empty rows some editors append.
 		while (grid.length && grid[grid.length - 1].every(c => c === '')) grid.pop()
-		return grid.length ? grid : null
+		return grid.length ? { grid, links } : null
 	}
 
 	// Paste an HTML-table grid (from an external app's `text/html` flavor).
 	// Shares the placement/tiling/bulk-write path with pasteFromText.
 	function pasteFromHTML(html, anchorId, historyPush, destSel = null) {
-		const grid = parseHTMLTable(html)
-		if (!grid) return false
-		return _pasteGrid(grid, anchorId, historyPush, destSel)
+		const parsed = _parseHTMLGrid(html)
+		if (!parsed) return false
+		return _pasteGrid(parsed.grid, anchorId, historyPush, destSel, parsed.links)
 	}
 
 	// Paste raw text (from system clipboard / external app).  Honors destSel so
@@ -328,7 +343,9 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 
 	// Place a 2D grid of cell strings at the anchor (or tiled across destSel),
 	// then ship one bulk write. Shared by pasteFromText and pasteFromHTML.
-	function _pasteGrid(grid, anchorId, historyPush, destSel = null) {
+	// `links` maps 'dr,dc' → href for cells that arrived as HTML anchors; cells
+	// without one still auto-link when their pasted text IS a URL (Google UX).
+	function _pasteGrid(grid, anchorId, historyPush, destSel = null, links = null) {
 		const anch = parseCellId(anchorId)
 		if (!anch) return false
 		const { srcRows, srcCols, tileable } = _gridGeometry(grid, anch, destSel)
@@ -337,18 +354,24 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 		// paste() above. Big external pastes (Excel/CSV via system clipboard)
 		// were the worst case here.
 		const writes = {}
+		const linkAt = {}   // destination id → hyperlink url
+		const place = (id, val, dr, dc) => {
+			writes[id] = val
+			const url = links?.[`${dr},${dc}`] ?? detectHyperlink(val)
+			if (url) linkAt[id] = url
+		}
 		if (tileable) {
 			for (let r = destSel.r0; r <= destSel.r1; r++) {
 				for (let c = destSel.c0; c <= destSel.c1; c++) {
 					const dr = (r - destSel.r0) % srcRows
 					const dc = (c - destSel.c0) % srcCols
-					writes[colLabel(c) + (r + 1)] = grid[dr][dc] ?? ''
+					place(colLabel(c) + (r + 1), grid[dr][dc] ?? '', dr, dc)
 				}
 			}
 		} else {
 			grid.forEach((row, dr) =>
 				row.forEach((val, dc) => {
-					writes[colLabel(anch.col + dc) + (anch.row + dr + 1)] = val
+					place(colLabel(anch.col + dc) + (anch.row + dr + 1), val, dr, dc)
 				}))
 		}
 		const sn = sheet.getCurrentSheet()
@@ -359,6 +382,7 @@ export function createClipboard({ sheet, formats, condFormat = null, validation 
 		}
 		if (sheet.batchSetCells) sheet.batchSetCells(writes, sn, { replace: false })
 		else                     for (const [id, v] of Object.entries(writes)) sheet.setCell(id, v, sn)
+		if (formats) for (const [id, url] of Object.entries(linkAt)) formats.set(id, { hyperlink: url }, sn)
 		historyPush?.()   // post-mutate snapshot
 		return true
 	}

--- a/frontend/src/apps/sheets/engine/links.js
+++ b/frontend/src/apps/sheets/engine/links.js
@@ -1,0 +1,45 @@
+// URL auto-detection for cell input — the Google Sheets behavior where typing
+// or pasting "https://frappe.io/" turns the cell into a live link.
+//
+// Detection is whole-cell only: the trimmed value must BE the URL, not merely
+// contain one. Partial-text links need per-run rich text, which cells don't
+// have — fmt.hyperlink is cell-level.
+
+// Bare-domain TLDs we auto-link without a scheme ("frappe.io", "google.com").
+// Kept to common TLDs so "file.txt" or "v1.2" never turn into links; anything
+// else still links fine when typed with http(s):// or www.
+const BARE_TLDS = new Set([
+	'com', 'org', 'net', 'io', 'dev', 'ai', 'app', 'co', 'in', 'uk', 'us',
+	'de', 'fr', 'es', 'it', 'nl', 'au', 'ca', 'jp', 'br', 'edu', 'gov',
+	'me', 'so', 'sh', 'xyz', 'info', 'biz', 'cloud', 'tech', 'site',
+])
+
+const SCHEME_RE = /^https?:\/\/[^\s]+$/i
+const WWW_RE    = /^www\.[^\s]+\.[^\s]+$/i
+const DOMAIN_RE = /^([a-z0-9-]+\.)+([a-z]{2,24})(\/[^\s]*|\?[^\s]*|#[^\s]*)?$/i
+
+// Returns the normalized target URL when `value` is a whole-cell URL, else
+// null. Formulas, multi-token text, and bare emails never match (Sheets
+// auto-links emails only in Docs, not in cells).
+export function detectHyperlink(value) {
+	if (typeof value !== 'string') return null
+	const v = value.trim()
+	if (!v || /\s/.test(v) || v.startsWith('=')) return null
+	if (SCHEME_RE.test(v)) return v
+	// Past the scheme check, an '@' means an email (or userinfo trickery like
+	// "evil.com@127.0.0.1") — never auto-link those schemeless.
+	if (v.includes('@'))   return null
+	if (WWW_RE.test(v))    return 'https://' + v
+	const m = v.match(DOMAIN_RE)
+	if (m && BARE_TLDS.has(m[2].toLowerCase())) return 'https://' + v
+	return null
+}
+
+// True when the cell's text is just its own URL (an auto-linked cell, not a
+// custom display text set via the hyperlink dialog). Editing such a cell to a
+// non-URL should drop the stale link; custom display text keeps it.
+export function isAutoLinkText(text, url) {
+	if (!url) return false
+	const detected = detectHyperlink(String(text ?? ''))
+	return detected === url
+}

--- a/frontend/src/apps/sheets/engine/links.test.ts
+++ b/frontend/src/apps/sheets/engine/links.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { detectHyperlink, isAutoLinkText } from './links.js'
+
+describe('detectHyperlink', () => {
+	it('accepts full http(s) URLs as-is', () => {
+		expect(detectHyperlink('https://frappe.io/')).toBe('https://frappe.io/')
+		expect(detectHyperlink('http://example.com/a?b=1#c')).toBe('http://example.com/a?b=1#c')
+		expect(detectHyperlink('  https://frappe.io  ')).toBe('https://frappe.io')
+	})
+
+	it('prefixes www. and bare common-TLD domains with https://', () => {
+		expect(detectHyperlink('www.frappe.io')).toBe('https://www.frappe.io')
+		expect(detectHyperlink('frappe.io')).toBe('https://frappe.io')
+		expect(detectHyperlink('frappe.io/sheets?x=1')).toBe('https://frappe.io/sheets?x=1')
+		expect(detectHyperlink('sub.domain.google.com')).toBe('https://sub.domain.google.com')
+	})
+
+	it('keeps URLs with @ in the path when a scheme is present', () => {
+		expect(detectHyperlink('https://medium.com/@user/post')).toBe('https://medium.com/@user/post')
+	})
+
+	it('rejects non-URL cell values', () => {
+		expect(detectHyperlink('hello world')).toBe(null)          // spaces
+		expect(detectHyperlink('see frappe.io today')).toBe(null)  // not whole-cell
+		expect(detectHyperlink('=HYPERLINK("https://x.com")')).toBe(null)
+		expect(detectHyperlink('3.14')).toBe(null)                 // numeric
+		expect(detectHyperlink('file.txt')).toBe(null)             // uncommon TLD
+		expect(detectHyperlink('v1.2.3')).toBe(null)
+		expect(detectHyperlink('')).toBe(null)
+		expect(detectHyperlink(42)).toBe(null)
+		expect(detectHyperlink(null)).toBe(null)
+	})
+
+	it('rejects emails and schemeless userinfo tricks', () => {
+		expect(detectHyperlink('user@gmail.com')).toBe(null)
+		expect(detectHyperlink('evil.com@127.0.0.1')).toBe(null)
+	})
+
+	it('rejects non-http schemes', () => {
+		expect(detectHyperlink('javascript:alert(1)')).toBe(null)
+		expect(detectHyperlink('ftp://host/file')).toBe(null)
+	})
+})
+
+describe('isAutoLinkText', () => {
+	it('true when the text is exactly the URL the link points at', () => {
+		expect(isAutoLinkText('https://frappe.io/', 'https://frappe.io/')).toBe(true)
+		expect(isAutoLinkText('frappe.io', 'https://frappe.io')).toBe(true)
+		expect(isAutoLinkText('www.frappe.io', 'https://www.frappe.io')).toBe(true)
+	})
+
+	it('false for custom display text or a different target', () => {
+		expect(isAutoLinkText('Frappe website', 'https://frappe.io/')).toBe(false)
+		expect(isAutoLinkText('frappe.io', 'https://other.com')).toBe(false)
+		expect(isAutoLinkText('', 'https://frappe.io/')).toBe(false)
+		expect(isAutoLinkText('https://frappe.io/', null)).toBe(false)
+	})
+})

--- a/frontend/src/apps/sheets/services/linkPreview.js
+++ b/frontend/src/apps/sheets/services/linkPreview.js
@@ -1,0 +1,18 @@
+// Client for the link-preview endpoint (hover card metadata). Deduped and
+// memoised per URL for the session — the server caches too, but this avoids
+// even the round-trip when the same link is hovered twice.
+
+import { call } from '../utils/api.js'
+
+const _cache = new Map()   // url → result | in-flight promise
+
+export function fetchLinkPreview(url) {
+	if (!/^https?:\/\//i.test(url || '')) return Promise.resolve({ error: true })
+	if (_cache.has(url)) return Promise.resolve(_cache.get(url))
+	const p = call('suite.sheets.link_preview.get_link_preview', { url })
+		.then(res => res || { error: true })
+		.catch(() => ({ error: true }))
+		.then(res => { _cache.set(url, res); return res })
+	_cache.set(url, p)
+	return p
+}

--- a/suite/sheets/link_preview.py
+++ b/suite/sheets/link_preview.py
@@ -1,0 +1,171 @@
+# Link preview metadata for hyperlinked cells — the hover card's title /
+# description / favicon (Google Sheets' link chip UX).
+#
+# The browser can't fetch a foreign page's HTML (CORS), so the server does it.
+# That makes this endpoint an SSRF vector by construction, so every fetch:
+#   * allows only http/https on default ports,
+#   * resolves the hostname and refuses private / loopback / link-local /
+#     reserved address space (re-checked on every redirect hop),
+#   * follows at most MAX_REDIRECTS redirects, manually,
+#   * reads at most MAX_BYTES with a short timeout, HTML content types only.
+# Results (including failures) are cached in Redis so hover traffic doesn't
+# hammer external sites.
+#
+# Known limitation: the guard resolves DNS, then requests re-resolves for the
+# actual fetch — a racing rebinding nameserver could slip a private IP between
+# the two. Closing that needs IP-pinned transport (custom adapter + SNI);
+# accepted for now since the endpoint is auth-only, rate-limited, and the
+# response is only ever parsed as HTML metadata.
+
+import ipaddress
+import socket
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+import frappe
+from frappe.rate_limiter import rate_limit
+
+MAX_REDIRECTS = 3
+MAX_BYTES = 100 * 1024
+TIMEOUT = (3, 4)  # (connect, read) seconds
+CACHE_OK_SEC = 24 * 60 * 60
+CACHE_ERR_SEC = 5 * 60
+USER_AGENT = "Mozilla/5.0 (compatible; FrappeSheets-LinkPreview/1.0)"
+
+
+@frappe.whitelist(methods=["GET", "POST"])
+@rate_limit(limit=60, seconds=60)
+def get_link_preview(url: str) -> dict:
+	"""Fetch {title, description, favicon, host} for a cell hyperlink."""
+	cache_key = f"sheets_link_preview::{url}"
+	cached = frappe.cache.get_value(cache_key)
+	if cached is not None:
+		return cached
+
+	try:
+		result = _fetch_preview(url)
+		ttl = CACHE_OK_SEC
+	except Exception:
+		# Unreachable host, non-HTML target, blocked address, parse error —
+		# the card just degrades to the bare URL. Cache briefly so a dead
+		# link hovered repeatedly doesn't retry every time.
+		frappe.logger("sheets").error(f"link preview failed for {url}", exc_info=True)
+		result = {"error": True}
+		ttl = CACHE_ERR_SEC
+
+	frappe.cache.set_value(cache_key, result, expires_in_sec=ttl)
+	return result
+
+
+def _fetch_preview(url: str) -> dict:
+	final_url, html = _fetch_html(url)
+	soup = BeautifulSoup(html, "html.parser")
+
+	title = _first(
+		_meta(soup, property="og:title"),
+		soup.title.string if soup.title else None,
+	)
+	description = _first(
+		_meta(soup, property="og:description"),
+		_meta(soup, name="description"),
+	)
+	favicon = _favicon(soup, final_url)
+	host = urlparse(final_url).hostname or ""
+	if host.startswith("www."):
+		host = host[4:]
+
+	return {
+		"title": _clip(title, 200),
+		"description": _clip(description, 300),
+		"favicon": favicon,
+		"host": host,
+	}
+
+
+def _fetch_html(url: str) -> tuple[str, str]:
+	"""GET `url` with SSRF guards; returns (final_url, first MAX_BYTES of body)."""
+	current = url
+	for _ in range(MAX_REDIRECTS + 1):
+		_assert_public_http_url(current)
+		resp = requests.get(
+			current,
+			timeout=TIMEOUT,
+			stream=True,
+			allow_redirects=False,
+			headers={"User-Agent": USER_AGENT, "Accept": "text/html"},
+		)
+		try:
+			if resp.is_redirect or resp.is_permanent_redirect:
+				location = resp.headers.get("location")
+				if not location:
+					raise frappe.ValidationError("Redirect without location")
+				current = urljoin(current, location)
+				continue
+			resp.raise_for_status()
+			ctype = resp.headers.get("content-type", "")
+			if "html" not in ctype:
+				raise frappe.ValidationError("Not an HTML page")
+			body = resp.raw.read(MAX_BYTES, decode_content=True)
+			return current, body.decode(resp.encoding or "utf-8", errors="replace")
+		finally:
+			resp.close()
+	raise frappe.ValidationError("Too many redirects")
+
+
+def _assert_public_http_url(url: str) -> None:
+	parsed = urlparse(url)
+	if parsed.scheme not in ("http", "https"):
+		raise frappe.ValidationError("Only http/https URLs allowed")
+	if parsed.port not in (None, 80, 443):
+		raise frappe.ValidationError("Non-standard port not allowed")
+	host = parsed.hostname
+	if not host:
+		raise frappe.ValidationError("Invalid URL")
+	# Resolve every A/AAAA record — a public name pointing at 127.0.0.1 or
+	# 10.x (DNS-based SSRF) is refused, not just literal private IPs. The
+	# explicit port + SOCK_STREAM matter: macOS getaddrinfo(host, None) fails
+	# with EAI_NONAME inside threaded web workers.
+	port = parsed.port or (443 if parsed.scheme == "https" else 80)
+	try:
+		infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+	except socket.gaierror:
+		raise frappe.ValidationError("Host not resolvable")
+	for info in infos:
+		addr = ipaddress.ip_address(info[4][0])
+		if (
+			addr.is_private
+			or addr.is_loopback
+			or addr.is_link_local
+			or addr.is_multicast
+			or addr.is_reserved
+			or addr.is_unspecified
+		):
+			raise frappe.ValidationError("Address not allowed")
+
+
+def _meta(soup, **attrs):
+	tag = soup.find("meta", attrs=attrs)
+	return tag.get("content") if tag else None
+
+
+def _favicon(soup, base_url: str) -> str:
+	link = soup.find("link", rel=lambda r: r and "icon" in str(r).lower())
+	href = link.get("href") if link else None
+	icon = urljoin(base_url, href or "/favicon.ico")
+	# Only expose http(s) icons — data: URIs are fine to render but can be
+	# megabytes; skip anything else the page might declare.
+	return icon if icon.startswith(("http://", "https://")) else ""
+
+
+def _first(*values):
+	for v in values:
+		if v and str(v).strip():
+			return str(v).strip()
+	return ""
+
+
+def _clip(text: str, limit: int) -> str:
+	text = " ".join((text or "").split())
+	return text[: limit - 1] + "…" if len(text) > limit else text

--- a/suite/sheets/link_preview.py
+++ b/suite/sheets/link_preview.py
@@ -4,24 +4,22 @@
 # The browser can't fetch a foreign page's HTML (CORS), so the server does it.
 # That makes this endpoint an SSRF vector by construction, so every fetch:
 #   * allows only http/https on default ports,
-#   * resolves the hostname and refuses private / loopback / link-local /
-#     reserved address space (re-checked on every redirect hop),
+#   * resolves the hostname, refuses private / loopback / link-local / reserved
+#     address space, and then CONNECTS TO THAT EXACT IP — the Host header, TLS
+#     SNI, and cert hostname stay the original name, so the address we validated
+#     is the address we talk to. A rebinding nameserver can't hand a public IP
+#     to the check and a private one to the connection (re-done per redirect).
 #   * follows at most MAX_REDIRECTS redirects, manually,
 #   * reads at most MAX_BYTES with a short timeout, HTML content types only.
 # Results (including failures) are cached in Redis so hover traffic doesn't
 # hammer external sites.
-#
-# Known limitation: the guard resolves DNS, then requests re-resolves for the
-# actual fetch — a racing rebinding nameserver could slip a private IP between
-# the two. Closing that needs IP-pinned transport (custom adapter + SNI);
-# accepted for now since the endpoint is auth-only, rate-limited, and the
-# response is only ever parsed as HTML metadata.
 
 import ipaddress
 import socket
 from urllib.parse import urljoin, urlparse
 
-import requests
+import certifi
+import urllib3
 from bs4 import BeautifulSoup
 
 import frappe
@@ -29,7 +27,9 @@ from frappe.rate_limiter import rate_limit
 
 MAX_REDIRECTS = 3
 MAX_BYTES = 100 * 1024
-TIMEOUT = (3, 4)  # (connect, read) seconds
+CONNECT_TIMEOUT = 3
+READ_TIMEOUT = 4
+REDIRECT_STATUSES = {301, 302, 303, 307, 308}
 CACHE_OK_SEC = 24 * 60 * 60
 CACHE_ERR_SEC = 5 * 60
 USER_AGENT = "Mozilla/5.0 (compatible; FrappeSheets-LinkPreview/1.0)"
@@ -61,6 +61,7 @@ def get_link_preview(url: str) -> dict:
 
 def _fetch_preview(url: str) -> dict:
 	final_url, html = _fetch_html(url)
+	# Hand raw bytes to BeautifulSoup so it detects the page's charset itself.
 	soup = BeautifulSoup(html, "html.parser")
 
 	title = _first(
@@ -84,37 +85,59 @@ def _fetch_preview(url: str) -> dict:
 	}
 
 
-def _fetch_html(url: str) -> tuple[str, str]:
+def _fetch_html(url: str) -> tuple[str, bytes]:
 	"""GET `url` with SSRF guards; returns (final_url, first MAX_BYTES of body)."""
 	current = url
 	for _ in range(MAX_REDIRECTS + 1):
-		_assert_public_http_url(current)
-		resp = requests.get(
-			current,
-			timeout=TIMEOUT,
-			stream=True,
-			allow_redirects=False,
-			headers={"User-Agent": USER_AGENT, "Accept": "text/html"},
-		)
+		ip, host, port, scheme, path = _validate_and_resolve(current)
+		pool = _pinned_pool(ip, host, port, scheme)
 		try:
-			if resp.is_redirect or resp.is_permanent_redirect:
+			resp = pool.urlopen(
+				"GET",
+				path,
+				headers={"Host": host, "User-Agent": USER_AGENT, "Accept": "text/html"},
+				redirect=False,
+				preload_content=False,
+				decode_content=True,
+			)
+			if resp.status in REDIRECT_STATUSES:
 				location = resp.headers.get("location")
 				if not location:
 					raise frappe.ValidationError("Redirect without location")
 				current = urljoin(current, location)
 				continue
-			resp.raise_for_status()
-			ctype = resp.headers.get("content-type", "")
-			if "html" not in ctype:
+			if resp.status >= 400:
+				raise frappe.ValidationError(f"HTTP {resp.status}")
+			if "html" not in resp.headers.get("content-type", ""):
 				raise frappe.ValidationError("Not an HTML page")
-			body = resp.raw.read(MAX_BYTES, decode_content=True)
-			return current, body.decode(resp.encoding or "utf-8", errors="replace")
+			return current, resp.read(MAX_BYTES)
 		finally:
-			resp.close()
+			pool.close()
 	raise frappe.ValidationError("Too many redirects")
 
 
-def _assert_public_http_url(url: str) -> None:
+def _pinned_pool(ip: str, host: str, port: int, scheme: str):
+	"""Connection pool bound to the pre-validated IP, but presenting the original
+	hostname for Host header, TLS SNI, and cert verification."""
+	timeout = urllib3.Timeout(connect=CONNECT_TIMEOUT, read=READ_TIMEOUT)
+	if scheme == "https":
+		return urllib3.HTTPSConnectionPool(
+			ip,
+			port=port,
+			maxsize=1,
+			retries=False,
+			timeout=timeout,
+			cert_reqs="CERT_REQUIRED",
+			ca_certs=certifi.where(),
+			server_hostname=host,
+			assert_hostname=host,
+		)
+	return urllib3.HTTPConnectionPool(ip, port=port, maxsize=1, retries=False, timeout=timeout)
+
+
+def _validate_and_resolve(url: str) -> tuple[str, str, int, str, str]:
+	"""Resolve `url`'s host, reject non-public targets, and return the exact IP to
+	connect to plus (host, port, scheme, path+query)."""
 	parsed = urlparse(url)
 	if parsed.scheme not in ("http", "https"):
 		raise frappe.ValidationError("Only http/https URLs allowed")
@@ -123,17 +146,18 @@ def _assert_public_http_url(url: str) -> None:
 	host = parsed.hostname
 	if not host:
 		raise frappe.ValidationError("Invalid URL")
-	# Resolve every A/AAAA record — a public name pointing at 127.0.0.1 or
-	# 10.x (DNS-based SSRF) is refused, not just literal private IPs. The
-	# explicit port + SOCK_STREAM matter: macOS getaddrinfo(host, None) fails
-	# with EAI_NONAME inside threaded web workers.
 	port = parsed.port or (443 if parsed.scheme == "https" else 80)
+	# Resolve every A/AAAA record and reject if ANY is non-public — a rebinding
+	# nameserver can rotate which record it hands out, so one bad answer taints
+	# the name. We then connect to the first (validated) IP directly.
 	try:
 		infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
 	except socket.gaierror:
 		raise frappe.ValidationError("Host not resolvable")
+	pinned_ip = None
 	for info in infos:
-		addr = ipaddress.ip_address(info[4][0])
+		ip = info[4][0]
+		addr = ipaddress.ip_address(ip)
 		if (
 			addr.is_private
 			or addr.is_loopback
@@ -143,6 +167,10 @@ def _assert_public_http_url(url: str) -> None:
 			or addr.is_unspecified
 		):
 			raise frappe.ValidationError("Address not allowed")
+		if pinned_ip is None:
+			pinned_ip = ip
+	path = (parsed.path or "/") + (f"?{parsed.query}" if parsed.query else "")
+	return pinned_ip, host, port, parsed.scheme, path
 
 
 def _meta(soup, **attrs):

--- a/suite/sheets/tests/test_link_preview.py
+++ b/suite/sheets/tests/test_link_preview.py
@@ -8,7 +8,7 @@ import unittest
 from unittest import mock
 
 import frappe
-from suite.sheets.link_preview import _assert_public_http_url
+from suite.sheets.link_preview import _validate_and_resolve
 
 
 def _addrinfo(*ips):
@@ -18,12 +18,12 @@ def _addrinfo(*ips):
 class AssertPublicHttpUrl(unittest.TestCase):
 	def _allow(self, url, resolves_to="93.184.216.34"):
 		with mock.patch("suite.sheets.link_preview.socket.getaddrinfo", return_value=_addrinfo(resolves_to)):
-			_assert_public_http_url(url)  # must not raise
+			_validate_and_resolve(url)  # must not raise
 
 	def _block(self, url, resolves_to="93.184.216.34"):
 		with mock.patch("suite.sheets.link_preview.socket.getaddrinfo", return_value=_addrinfo(resolves_to)):
 			with self.assertRaises(frappe.ValidationError):
-				_assert_public_http_url(url)
+				_validate_and_resolve(url)
 
 	def test_public_https_url_passes(self):
 		self._allow("https://frappe.io/")
@@ -55,11 +55,11 @@ class AssertPublicHttpUrl(unittest.TestCase):
 			return_value=_addrinfo("93.184.216.34", "127.0.0.1"),
 		):
 			with self.assertRaises(frappe.ValidationError):
-				_assert_public_http_url("https://tricky.example.com/")
+				_validate_and_resolve("https://tricky.example.com/")
 
 	def test_unresolvable_host_blocked(self):
 		import socket as _socket
 
 		with mock.patch("suite.sheets.link_preview.socket.getaddrinfo", side_effect=_socket.gaierror):
 			with self.assertRaises(frappe.ValidationError):
-				_assert_public_http_url("https://no-such-host.invalid/")
+				_validate_and_resolve("https://no-such-host.invalid/")

--- a/suite/sheets/tests/test_link_preview.py
+++ b/suite/sheets/tests/test_link_preview.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026, Asif and Contributors
+# See license.txt
+"""SSRF guard for the link-preview fetcher — the security-critical piece."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import frappe
+from suite.sheets.link_preview import _assert_public_http_url
+
+
+def _addrinfo(*ips):
+	return [(None, None, None, None, (ip, 0)) for ip in ips]
+
+
+class AssertPublicHttpUrl(unittest.TestCase):
+	def _allow(self, url, resolves_to="93.184.216.34"):
+		with mock.patch("suite.sheets.link_preview.socket.getaddrinfo", return_value=_addrinfo(resolves_to)):
+			_assert_public_http_url(url)  # must not raise
+
+	def _block(self, url, resolves_to="93.184.216.34"):
+		with mock.patch("suite.sheets.link_preview.socket.getaddrinfo", return_value=_addrinfo(resolves_to)):
+			with self.assertRaises(frappe.ValidationError):
+				_assert_public_http_url(url)
+
+	def test_public_https_url_passes(self):
+		self._allow("https://frappe.io/")
+		self._allow("http://example.com/page?x=1")
+
+	def test_non_http_schemes_blocked(self):
+		self._block("ftp://example.com/")
+		self._block("file:///etc/passwd")
+		self._block("gopher://example.com/")
+
+	def test_non_standard_ports_blocked(self):
+		self._block("http://example.com:8080/")
+		self._block("https://example.com:6379/")
+
+	def test_literal_private_and_loopback_ips_blocked(self):
+		self._block("http://127.0.0.1/", resolves_to="127.0.0.1")
+		self._block("http://10.1.2.3/", resolves_to="10.1.2.3")
+		self._block("http://192.168.0.10/", resolves_to="192.168.0.10")
+		self._block("http://169.254.169.254/", resolves_to="169.254.169.254")  # cloud metadata
+		self._block("http://[::1]/", resolves_to="::1")
+
+	def test_dns_pointing_at_private_space_blocked(self):
+		# A public-looking name whose A record is internal (DNS-based SSRF).
+		self._block("https://innocent.example.com/", resolves_to="10.0.0.5")
+
+	def test_mixed_resolution_blocked_if_any_ip_private(self):
+		with mock.patch(
+			"suite.sheets.link_preview.socket.getaddrinfo",
+			return_value=_addrinfo("93.184.216.34", "127.0.0.1"),
+		):
+			with self.assertRaises(frappe.ValidationError):
+				_assert_public_http_url("https://tricky.example.com/")
+
+	def test_unresolvable_host_blocked(self):
+		import socket as _socket
+
+		with mock.patch("suite.sheets.link_preview.socket.getaddrinfo", side_effect=_socket.gaierror):
+			with self.assertRaises(frappe.ValidationError):
+				_assert_public_http_url("https://no-such-host.invalid/")


### PR DESCRIPTION
## What

Brings Google-Sheets-style link handling to Sheets: URLs auto-detect as you type or paste, and a hover card surfaces a rich preview with quick actions.

### Auto-linking
- Typing or pasting a whole-cell URL (`https://…`, `www.…`, or a bare common-TLD domain like `frappe.io`) sets `fmt.hyperlink` on the cell automatically.
- Recorded as its **own** format op after the edit, so the first ⌘/Ctrl+Z strips just the link and the second undoes the text — matching Google's "undo removes the auto-link" behavior.
- Editing an auto-linked cell to a non-URL drops the stale link; custom display text set via the hyperlink dialog is preserved.
- Emails are intentionally **not** auto-linked in cells (Sheets links those only in Docs).

### Clipboard
- Pasted HTML anchors (`<a href>` from web pages, Google Sheets, Excel Online) keep their target as `fmt.hyperlink` with the anchor text as the cell value.
- URL-shaped plain text auto-links on paste; `javascript:`/other non-http schemes are refused.
- Clearing a range drops its auto-links along with the content.

### Hover card
- Favicon / title / description preview over a linked cell, with **copy**, **edit**, and **unlink** actions.
- A **"Replace URL with its title?"** offer appears for auto-linked cells whose text is still the raw URL.
- Styled with espresso Tailwind tokens (mirrors frappe-ui's own `LinkPopup.vue`).

### Backend — `suite.sheets.link_preview.get_link_preview`
The browser can't fetch a foreign page's HTML (CORS), so the server does it. Because that makes the endpoint an SSRF vector by construction, every fetch:
- allows only `http`/`https` on default ports;
- resolves the hostname and refuses private / loopback / link-local / reserved address space, **re-checked on every redirect hop** (blocks DNS-rebinding to internal IPs);
- follows at most 3 redirects, manually;
- reads at most 100 KB with a short timeout, HTML content types only.

Results (including failures) are Redis-cached; the endpoint is auth-only and rate-limited (60/min).

## Tests
- `links.test.ts` — URL detection + auto-link-text classification (scheme, www, bare TLD, emails, `javascript:`, userinfo tricks).
- `clipboard-links.test.ts` — paste auto-linking for plain text and `<a href>` anchors, including the `javascript:` refusal.
- `test_link_preview.py` — the SSRF guard: scheme/port allowlist, literal private/loopback IPs, DNS pointing at internal space, mixed-resolution, unresolvable hosts.

## Notes
- Verified end-to-end on the standalone Sheets build (typed + bare-domain linking, hover card with live frappe.io/GitHub metadata, replace-with-title, unlink, undo granularity, HTML-anchor paste); full standalone suite is green (1295 vitest + 89 py). Suite frontend has no local node_modules, so JS tests here rely on CI + the identical standalone run.
- Source-only (the built bundle is gitignored in suite / built by CI).
