### PR TITLE
fix(sheets): re-baseline undo history after load so insert-column undo doesn't blank the sheet

### DIFF
--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -3359,7 +3359,11 @@ async function _loadInitialData() {
     formulaValue.value = sheet.getCell('A1')
     refreshActiveFormat()
     _syncNumberFormat('A1')
-    history.init()
+    // Re-baseline history to the loaded state. The pre-load init() above
+    // seeded an EMPTY snapshot; a plain init() here is a no-op (stack already
+    // seeded), which would leave the empty snapshot as the undo baseline and
+    // blank the sheet on the first snapshot-based undo (e.g. insert column).
+    history.reset()
     syncFlags()
   } else if (props.id === 'new') {
     // Google-Sheets model: create the doc immediately so there is never an

--- a/frontend/src/apps/sheets/engine/history.js
+++ b/frontend/src/apps/sheets/engine/history.js
@@ -116,5 +116,17 @@ export function createHistory({ snapshot, restore, applyOp, revertOp, maxSize = 
 	// Seed the initial snapshot so the first undo lands on the blank state.
 	function init() { if (stack.length === 0) push() }
 
-	return { push, pushOp, undo, redo, canUndo, canRedo, init }
+	// Re-baseline: discard all history and seed a single snapshot of the
+	// CURRENT engine state. Call this after loading a doc — the pre-load
+	// init() seeded an empty snapshot, and a plain init() won't replace it
+	// (its stack-empty guard makes it a no-op once seeded). Without a
+	// re-baseline the first snapshot-based undo (e.g. insert column) would
+	// restore that empty pre-load state and blank the whole sheet.
+	function reset() {
+		stack.length = 0
+		index = -1
+		push()
+	}
+
+	return { push, pushOp, undo, redo, canUndo, canRedo, init, reset }
 }

--- a/frontend/src/apps/sheets/engine/history.test.ts
+++ b/frontend/src/apps/sheets/engine/history.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createHistory } from './history.js'
+
+// Guards the undo baseline set up at doc load: init() seeds an EMPTY snapshot
+// before the doc loads, then reset() must re-baseline to the loaded state so a
+// later snapshot-based undo (e.g. insert column) lands on the loaded data and
+// never on the empty pre-load snapshot (which blanked the whole sheet).
+describe('history — load baseline', () => {
+  it('init seeds the first snapshot and is idempotent', () => {
+    const snapshot = vi.fn(() => 1)
+    const h = createHistory({ snapshot, restore: () => {} })
+    h.init()
+    h.init()
+    expect(snapshot).toHaveBeenCalledTimes(1)
+  })
+
+  it('reset re-baselines: undo after reset restores the reset snapshot, not the pre-reset one', () => {
+    const snaps = ['empty', 'loaded', 'afterEdit']
+    let idx = 0
+    const restore = vi.fn()
+    const h = createHistory({ snapshot: () => snaps[idx++], restore })
+    h.init()          // seed 'empty' (pre-load)
+    h.reset()         // re-baseline to 'loaded'
+    h.push()          // 'afterEdit' — a snapshot mutation (e.g. insert column)
+    expect(h.undo()).toBe(true)
+    expect(restore).toHaveBeenLastCalledWith('loaded', { touches: null })
+    // No further undo past the re-baselined start.
+    expect(h.canUndo()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

On any sheet loaded with data, inserting a column and then pressing **Undo** blanks the entire grid — it looks like the whole sheet's data is lost. Navigating home and back restores it, because the data was never actually gone: only the client's in-memory view was wiped, and it gets re-fetched from the server on reload.

## Root cause

`_loadInitialData()` seeds the undo baseline with `history.init()` **before** `loadSheet()` runs — i.e. a snapshot of the *empty* sheet. A second `history.init()` after the load is *meant* to re-capture the baseline now that data is present, but `init()` only pushes when the stack is empty:

```js
function init() { if (stack.length === 0) push() }
```

Since the pre-load call already seeded the stack, the post-load call is a silent **no-op**. The undo baseline therefore stays frozen as the empty pre-load snapshot.

Ordinary cell edits are unaffected — they record cheap per-cell `{before, after}` ops and undo reverts just those cells. But **insert-column records a full snapshot**. Undoing it steps the stack all the way back to the empty baseline and restores it, wiping the whole local sheet.

## Fix

Add `history.reset()`, which discards the stack and seeds a single snapshot of the **current (loaded)** engine state, and call it after `loadSheet()` in place of the no-op `init()`. The first snapshot-based undo now lands on the loaded data instead of the empty pre-load snapshot.

- `engine/history.js` — new `reset()` (+ export).
- `components/SheetEditor/index.vue` — post-load `history.init()` → `history.reset()`.

## Testing

- New `engine/history.test.ts`: after `init()` (empty) → `reset()` (loaded) → `push()` (edit), the first `undo()` restores the **loaded** snapshot, not the empty one; `canUndo()` is then `false` (no undo past the re-baselined start).
- Verified the test fails without the fix (pre-fix, undo restores the empty snapshot).
- Reproduced the blank-screen live on the built app, applied the fix, and confirmed undo-after-insert-column now fully restores every cell to its original position with zero console errors.