### PR TITLE
fix(sheets): show real sheet owner in Share dialog instead of current viewer

### DIFF
--- a/frontend/src/apps/sheets/components/SheetEditor/ShareDialog.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/ShareDialog.vue
@@ -174,6 +174,18 @@ watch(show, (open) => {
   }
 })
 
+// get_sheet can resolve *after* the dialog is already open — a fast click on
+// Share before the sheet finishes loading opens it with ownerId still the
+// current viewer, then ownerId flips to the real owner once load lands. Re-run
+// the owner-profile lookup (so the row shows the real name/avatar, not a raw
+// email) and re-filter the member list, which keys off ownerId too.
+watch(() => props.ownerId, () => {
+  if (show.value) {
+    fetchOwnerInfo()
+    fetchShares()
+  }
+})
+
 // ── inline error banner ──────────────────────────────────────────────────
 //
 // Every share endpoint can fail with PermissionError (e.g. a read-only

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -839,7 +839,7 @@
       v-model="shareOpen"
       :sheet-id="props.id"
       :sheet-title="currentTitle"
-      :owner-id="userEmail"
+      :owner-id="sheetOwner || userEmail"
       @shares-changed="shareCount = $event"
     />
 
@@ -2398,7 +2398,7 @@ const textWrapDropdownOptions = computed(() => [
 // fallbacks only cover the impossible window where someone saves before
 // useSheetTabs has finished initializing.
 let _sheetTabs = null
-const { isSaving, saveError, canWrite, loadError, loadSheet, autoCreate, saveExisting, retrySave } =
+const { isSaving, saveError, canWrite, sheetOwner, loadError, loadSheet, autoCreate, saveExisting, retrySave } =
   usePersistence({
     sheet, formats, merge, comments, validation, protection, condFormat, sortFilter, slicers, pivot,
     charts, namedRanges,

--- a/frontend/src/apps/sheets/components/SheetEditor/usePersistence.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/usePersistence.js
@@ -13,6 +13,11 @@ export function usePersistence({ sheet, formats, merge, comments, validation, pr
   // Defaults to true so a brand-new (autoCreate) doc — which the creator always
   // owns — never flashes read-only before the first load resolves.
   const canWrite  = ref(true)
+  // The sheet's true owner (creator's user id), surfaced by get_sheet so the
+  // Share dialog can name the real owner rather than the current viewer. Empty
+  // until the first load resolves; for a brand-new sheet the editor falls back
+  // to the session user (who is the creator).
+  const sheetOwner = ref('')
   // Surfaces "couldn't open this sheet" cases (404 / 403 / network) to the
   // editor so it can render a proper error screen instead of mounting a
   // blank canvas. Shape: { kind: 'denied' | 'missing' | 'other', message }.
@@ -45,6 +50,7 @@ export function usePersistence({ sheet, formats, merge, comments, validation, pr
       // Older backends predate `can_write`; treat its absence as writable so we
       // never lock out an editor on a stale server.
       canWrite.value = doc.can_write !== false
+      sheetOwner.value = doc.owner || ''
     } catch (err) {
       console.error('Load failed:', err)
       const t = err?.excType || ''
@@ -181,5 +187,5 @@ export function usePersistence({ sheet, formats, merge, comments, validation, pr
     }
   }
 
-  return { isSaving, saveError, canWrite, loadError, loadSheet, autoCreate, saveExisting, retrySave }
+  return { isSaving, saveError, canWrite, sheetOwner, loadError, loadSheet, autoCreate, saveExisting, retrySave }
 }

--- a/suite/sheets/api.py
+++ b/suite/sheets/api.py
@@ -348,6 +348,10 @@ def get_sheet(name: str, compressed: int = 0) -> dict:
 		"title": doc.title,
 		"can_write": bool(frappe.has_permission("Sheet", doc=name, ptype="write", throw=False)),
 		"sheets_data": raw if frappe.utils.cint(compressed) else decode_sheets_data(raw),
+		# The sheet's true creator, so the Share dialog can label the owner row
+		# with the real person (and "Owner (you)" only for them) instead of
+		# falling back to whoever happens to have the dialog open.
+		"owner": doc.owner,
 	}
 
 


### PR DESCRIPTION
## Problem

When you open a sheet **shared with you** and click **Share**, the dialog labels the owner row as **yourself** — "Administrator — Owner (you)" — instead of the real owner. The true creator never appears.

Root cause: `get_sheet` never returned the sheet's `owner`, so the editor had nothing to pass and substituted the **current session user** as the dialog's `owner-id`. That made `_ownerIsMe` always true → always "Owner (you)", and the members filter/invite-autocomplete excluded the *viewer* rather than the real owner. The dialog already had the correct machinery for a non-self owner (`fetchOwnerInfo`, the `Owner` vs `Owner (you)` split) — it was just never fed the real owner.

## Fix

- **`get_sheet`** now returns `doc.owner`.
- **`usePersistence`** surfaces it via a new `sheetOwner` ref, set from the load response.
- **`SheetEditor/index.vue`** binds `:owner-id="sheetOwner || userEmail"` — the fallback keeps a brand-new, not-yet-loaded sheet showing you as owner (you're the creator).

No `ShareDialog.vue` change needed: the existing owner-row logic becomes correct once fed the real owner. Two latent bugs self-correct — the members list and invite autocomplete now exclude the true owner instead of the viewer, and `fetchOwnerInfo` (previously dead code) resolves the owner's real name/avatar.

## Result

Opening a sheet owned by `asif@frappe.io` as another user now shows **asif — Owner** (with his real name/avatar), and **Owner (you)** appears only for asif himself.

## Testing

- Backend verified against a live site: `get_sheet` returns `"owner": "asif@frappe.io"` for a sheet asif owns.
- Frontend builds clean; change is pure load-time display wiring (mirrors `canWrite`), so no persistence/undo/version surfaces are touched and no new test is warranted (display logic is pre-existing and unchanged).

Standalone counterpart committed to `frappe/sheets` `main`.