### PR TITLE
fix(sheets): keep renamed sheet tab in place instead of jumping to the end

### DIFF
--- a/frontend/src/apps/sheets/engine/sheet.js
+++ b/frontend/src/apps/sheets/engine/sheet.js
@@ -319,8 +319,13 @@ export function createSheet({ onCellChanged, onCellsChanged } = {}) {
 
 	function renameSheet(oldName, newName) {
 		if (!sheets[oldName] || sheets[newName] || oldName === newName) return false
-		sheets[newName] = sheets[oldName]
-		delete sheets[oldName]
+		// Rename in place: rebuild the dict in the same key order, swapping
+		// newName into oldName's slot. A naive `sheets[newName] = sheets[oldName];
+		// delete sheets[oldName]` would re-add the key at the end, jumping the
+		// renamed tab to the last position (tab order == Object.keys order).
+		const entries = Object.entries(sheets)
+		for (const [k] of entries) delete sheets[k]
+		for (const [k, v] of entries) sheets[k === oldName ? newName : k] = v
 		// Walk every sheet (not just the renamed one) and rewrite cross-sheet
 		// formulas that referenced the old name. Without this, `=OldName!A1`
 		// formulas in *other* sheets break with `#REF!` after a rename.


### PR DESCRIPTION
## Problem

Renaming a sheet tab moved it to the **last** position in the tab bar. With tabs `Sheet1, Sheet2, Sheet3, Sheet4`, renaming `Sheet1` left you with `Sheet2, Sheet3, Sheet4, <renamed>`.

## Root cause

Sheets are stored as a plain JS object keyed by name (`engine/sheet.js`), and tab order is literally `Object.keys(sheets)` order (`getSheetNames()` → `v-for` in the tab bar). `renameSheet` did:

```js
sheets[newName] = sheets[oldName]
delete sheets[oldName]
```

Adding `newName` as a fresh key places it **last** in JS insertion order, so the renamed tab jumped to the end.

## Fix

Rebuild the dict in its original key order, swapping `newName` into `oldName`'s exact slot (mirrors what `reorderSheets` already does to control position). The cross-sheet formula rewrite, dep rebuild, memo clear, and `current` reassignment are unchanged.

```js
const entries = Object.entries(sheets)
for (const [k] of entries) delete sheets[k]
for (const [k, v] of entries) sheets[k === oldName ? newName : k] = v
```

## Testing

- Verified live: renaming any tab now keeps it in place across positions.
- `node --check` on the changed module.
- Frontend-only; single file.