### PR TITLE
feat(mail): role-aware routing and setup screens for the Mail app

### DIFF
--- a/frontend/src/apps/mail/pages/CredentialsSetupView.vue
+++ b/frontend/src/apps/mail/pages/CredentialsSetupView.vue
@@ -1,0 +1,43 @@
+<template>
+	<div class="bg-surface-gray-1 flex min-h-screen flex-col items-center justify-center p-6">
+		<div class="w-full max-w-xl">
+			<div class="mb-5 flex flex-col items-center gap-3 text-center">
+				<MailLogo class="h-10 w-10" />
+				<h1 class="text-xl-semibold text-ink-gray-9">{{ __('Set up Mail') }}</h1>
+				<p class="text-base text-ink-gray-6">
+					{{ __('Enter your credentials to start using Mail.') }}
+				</p>
+			</div>
+			<div class="bg-surface-base rounded-lg px-6 py-6 shadow-xl">
+				<CredentialsSettings />
+			</div>
+			<div class="mt-4 text-center">
+				<router-link to="/suite" class="text-sm text-ink-blue-link hover:underline">
+					{{ __('Back to launcher') }}
+				</router-link>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { watch } from 'vue'
+import { useRouter } from 'vue-router'
+
+import { userStore } from '@/apps/mail/stores/user'
+import CredentialsSettings from '@/apps/mail/components/Settings/CredentialsSettings.vue'
+import MailLogo from '@/apps/mail/components/Icons/MailLogo.vue'
+
+const router = useRouter()
+const { userResource } = userStore()
+
+// Saving valid credentials sets the username on User Settings and reloads $user, flipping
+// is_jmap_configured to true — at which point we drop the user into the app.
+watch(
+	() => userResource.data?.is_jmap_configured,
+	(configured) => {
+		if (configured) router.replace({ name: 'mail-root-shortcut' })
+	},
+	{ immediate: true },
+)
+</script>

--- a/frontend/src/apps/mail/pages/NotConfiguredView.vue
+++ b/frontend/src/apps/mail/pages/NotConfiguredView.vue
@@ -8,7 +8,7 @@
 				{{ __('Mail is not set up yet') }}
 			</h1>
 
-			<p v-if="isAdmin" class="text-base text-ink-gray-6">
+			<p v-if="isSystemManager" class="text-base text-ink-gray-6">
 				{{
 					__(
 						'The mail server hasn’t been configured yet. To get started, set the server connection details (server_url, username and password) in your site config (site_config.json) or under Mail Settings.',
@@ -18,22 +18,21 @@
 			<p v-else class="text-base text-ink-gray-6">
 				{{
 					__(
-						'The mail server hasn’t been configured yet. Please contact your administrator to finish setting up Mail.',
+						'The mail server hasn’t been configured yet. Please ask your administrator to set up Mail.',
 					)
 				}}
 			</p>
 
-			<div class="mt-2 flex items-center gap-2">
-				<Button
-					v-if="isAdmin"
-					variant="solid"
-					:label="__('Open Mail Settings')"
-					@click="openMailSettings"
-				/>
-				<router-link
-					to="/suite"
+			<div class="mt-2 flex items-center gap-4">
+				<a
+					v-if="isSystemManager"
+					href="/app/mail-settings"
+					target="_blank"
 					class="text-sm text-ink-blue-link hover:underline"
 				>
+					{{ __('Open Mail Settings') }}
+				</a>
+				<router-link to="/suite" class="text-sm text-ink-blue-link hover:underline">
 					{{ __('Back to launcher') }}
 				</router-link>
 			</div>
@@ -43,18 +42,13 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { Button } from 'frappe-ui'
 
 import { userStore } from '@/apps/mail/stores/user'
 import MailLogo from '@/apps/mail/components/Icons/MailLogo.vue'
 
 const { userResource } = userStore()
 
-const isAdmin = computed(
-	() => !!(userResource.data?.is_suite_admin || userResource.data?.is_system_manager),
-)
-
-const openMailSettings = () => {
-	window.open('/app/mail-settings', '_blank')
-}
+// Only System Managers (which includes the Administrator) can edit Mail Settings, so only they
+// get the direct link. Suite Admins / Suite Users are told to reach out to their administrator.
+const isSystemManager = computed(() => !!userResource.data?.is_system_manager)
 </script>

--- a/frontend/src/apps/mail/pages/NotConfiguredView.vue
+++ b/frontend/src/apps/mail/pages/NotConfiguredView.vue
@@ -1,0 +1,60 @@
+<template>
+	<div class="bg-surface-gray-1 flex h-screen flex-col items-center justify-center p-6">
+		<div
+			class="bg-surface-base flex w-full max-w-md flex-col items-center gap-4 rounded-lg px-8 py-10 text-center shadow-xl"
+		>
+			<MailLogo class="h-10 w-10" />
+			<h1 class="text-xl-semibold text-ink-gray-9">
+				{{ __('Mail is not set up yet') }}
+			</h1>
+
+			<p v-if="isAdmin" class="text-base text-ink-gray-6">
+				{{
+					__(
+						'The mail server hasn’t been configured yet. To get started, set the server connection details (server_url, username and password) in your site config (site_config.json) or under Mail Settings.',
+					)
+				}}
+			</p>
+			<p v-else class="text-base text-ink-gray-6">
+				{{
+					__(
+						'The mail server hasn’t been configured yet. Please contact your administrator to finish setting up Mail.',
+					)
+				}}
+			</p>
+
+			<div class="mt-2 flex items-center gap-2">
+				<Button
+					v-if="isAdmin"
+					variant="solid"
+					:label="__('Open Mail Settings')"
+					@click="openMailSettings"
+				/>
+				<router-link
+					to="/suite"
+					class="text-sm text-ink-blue-link hover:underline"
+				>
+					{{ __('Back to launcher') }}
+				</router-link>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { Button } from 'frappe-ui'
+
+import { userStore } from '@/apps/mail/stores/user'
+import MailLogo from '@/apps/mail/components/Icons/MailLogo.vue'
+
+const { userResource } = userStore()
+
+const isAdmin = computed(
+	() => !!(userResource.data?.is_suite_admin || userResource.data?.is_system_manager),
+)
+
+const openMailSettings = () => {
+	window.open('/app/mail-settings', '_blank')
+}
+</script>

--- a/frontend/src/apps/mail/router.ts
+++ b/frontend/src/apps/mail/router.ts
@@ -74,23 +74,47 @@ function installMailGuard(r: Router) {
 		await userResource.promise
 		const user = userResource.data
 
-		// Mail server not set up yet (Stalwart not fully configured — missing server_url,
-		// username or password): show a friendly "not configured" message instead of a blank,
-		// error-filled page. This is the most fundamental gate, so it runs before the
-		// JMAP/dashboard checks below — the admin dashboard is only reachable once the server
-		// is configured.
-		if (!user?.is_stalwart_configured) {
+		// The admin dashboard manages mail infrastructure, so it requires the full server
+		// connection (server_url + username + password). If that isn't set up, show the
+		// "not configured" screen (which explains the fix to admins and tells everyone else to
+		// contact one). Account is already resolved on user load, so nothing else to do here.
+		if (to.meta.isDashboard) {
+			if (!user?.is_stalwart_configured) {
+				return to.name === 'mail-not-configured' ? undefined : { name: 'mail-not-configured' }
+			}
+			return
+		}
+
+		// Users without a "Suite User" role have no personal mailbox, so the mail UI isn't for
+		// them — Administrators / System Managers / Suite Admins belong in the admin area. (This
+		// is also why the credentials-setup screen below is only ever shown to Suite Users.)
+		if (!user?.is_suite_user) {
+			// A user with no suite or admin role at all doesn't belong in Mail — hand them to Desk.
+			if (!user?.is_system_manager && !user?.is_suite_admin) {
+				window.location.replace('/desk')
+				return
+			}
+			// When the server isn't set up, keep them on the not-configured screen rather than
+			// bouncing to the admin area (which would just send them back here).
+			if (to.name === 'mail-not-configured' && !user?.is_stalwart_configured) return
+			return to.name === 'mail-admin' ? undefined : { name: 'mail-admin' }
+		}
+
+		// Suite Users (mail users). Mail viewing needs a server_url...
+		if (!user?.is_server_configured) {
 			return to.name === 'mail-not-configured' ? undefined : { name: 'mail-not-configured' }
 		}
-		// Configured now, but sitting on the not-configured screen — send them into the app.
-		if (to.name === 'mail-not-configured') return { name: 'mail-root-shortcut' }
 
-		// Admin / dashboard access control.
+		// ...and this user's own JMAP credentials.
 		if (!user?.is_jmap_configured) {
-			if (!user?.is_suite_admin) window.location.replace('/desk')
-			if (to.meta.isDashboard) return
-			return { name: 'mail-domains' }
+			return to.name === 'mail-credentials-setup'
+				? undefined
+				: { name: 'mail-credentials-setup' }
 		}
+
+		// Fully configured — bounce off any setup/not-configured screen into the app.
+		if (to.name === 'mail-not-configured' || to.name === 'mail-credentials-setup')
+			return { name: 'mail-root-shortcut' }
 
 		// Resolve active account.
 		resolveAccount(user?.accounts, to.params.accountId as string | undefined)

--- a/frontend/src/apps/mail/router.ts
+++ b/frontend/src/apps/mail/router.ts
@@ -74,6 +74,17 @@ function installMailGuard(r: Router) {
 		await userResource.promise
 		const user = userResource.data
 
+		// Mail server not set up yet (Stalwart not fully configured — missing server_url,
+		// username or password): show a friendly "not configured" message instead of a blank,
+		// error-filled page. This is the most fundamental gate, so it runs before the
+		// JMAP/dashboard checks below — the admin dashboard is only reachable once the server
+		// is configured.
+		if (!user?.is_stalwart_configured) {
+			return to.name === 'mail-not-configured' ? undefined : { name: 'mail-not-configured' }
+		}
+		// Configured now, but sitting on the not-configured screen — send them into the app.
+		if (to.name === 'mail-not-configured') return { name: 'mail-root-shortcut' }
+
 		// Admin / dashboard access control.
 		if (!user?.is_jmap_configured) {
 			if (!user?.is_suite_admin) window.location.replace('/desk')

--- a/frontend/src/apps/mail/routes.test.ts
+++ b/frontend/src/apps/mail/routes.test.ts
@@ -43,4 +43,8 @@ describe('mail route matching', () => {
 	it('account-scoped routes still resolve', () => {
 		expect(makeRouter().resolve('/mail/account/ih/mailbox/a').name).toBe('mail-mailbox')
 	})
+
+	it('the not-configured screen resolves', () => {
+		expect(makeRouter().resolve('/mail/not-configured').name).toBe('mail-not-configured')
+	})
 })

--- a/frontend/src/apps/mail/routes.test.ts
+++ b/frontend/src/apps/mail/routes.test.ts
@@ -47,4 +47,12 @@ describe('mail route matching', () => {
 	it('the not-configured screen resolves', () => {
 		expect(makeRouter().resolve('/mail/not-configured').name).toBe('mail-not-configured')
 	})
+
+	it('the credentials-setup screen resolves', () => {
+		expect(makeRouter().resolve('/mail/credentials-setup').name).toBe('mail-credentials-setup')
+	})
+
+	it('the admin entry resolves to the dashboard', () => {
+		expect(resolveFollowingRedirect(makeRouter(), '/mail/admin').name).toBe('mail-domains')
+	})
 })

--- a/frontend/src/apps/mail/routes.ts
+++ b/frontend/src/apps/mail/routes.ts
@@ -96,6 +96,15 @@ export const routes: RouteRecordRaw[] = [
 				meta: { noLayout: true },
 			},
 			{
+				// Server is configured but the user hasn't set their own JMAP credentials. The
+				// guard sends them here to enter them before they can use Mail. `noLayout` because
+				// a credential-less user has no account/mailbox to render the sidebar around.
+				path: 'credentials-setup',
+				name: 'mail-credentials-setup',
+				component: () => import('@/apps/mail/pages/CredentialsSetupView.vue'),
+				meta: { noLayout: true },
+			},
+			{
 				path: 'all-inboxes',
 				name: 'mail-all-inboxes',
 				component: () => import('@/apps/mail/pages/AllInboxesView.vue'),
@@ -183,6 +192,15 @@ export const routes: RouteRecordRaw[] = [
 			},
 			{
 				path: 'dashboard',
+				redirect: { name: 'mail-domains' },
+				meta: { isDashboard: true },
+			},
+			{
+				// Admin-area entry. The mail guard sends admin-type users (System Manager /
+				// Administrator / Suite Admin without a Suite User role) here instead of the mail
+				// UI. Lands on the dashboard, same as '/mail/dashboard'.
+				path: 'admin',
+				name: 'mail-admin',
 				redirect: { name: 'mail-domains' },
 				meta: { isDashboard: true },
 			},

--- a/frontend/src/apps/mail/routes.ts
+++ b/frontend/src/apps/mail/routes.ts
@@ -87,6 +87,15 @@ export const routes: RouteRecordRaw[] = [
 		component: () => import('@/apps/mail/pages/MailLayout.vue'),
 		children: [
 			{
+				// Shown when the mail server isn't configured yet (no server_url set). The mail
+				// guard (see ./router.ts) redirects here instead of dropping the user on a blank,
+				// error-filled page. `noLayout` renders it without the sidebar chrome.
+				path: 'not-configured',
+				name: 'mail-not-configured',
+				component: () => import('@/apps/mail/pages/NotConfiguredView.vue'),
+				meta: { noLayout: true },
+			},
+			{
 				path: 'all-inboxes',
 				name: 'mail-all-inboxes',
 				component: () => import('@/apps/mail/pages/AllInboxesView.vue'),

--- a/frontend/src/apps/mail/types/index.ts
+++ b/frontend/src/apps/mail/types/index.ts
@@ -59,7 +59,9 @@ export interface User {
 
 	enabled: boolean
 	is_suite_admin: boolean
+	is_suite_user: boolean
 	is_system_manager: boolean
+	is_server_configured: boolean
 	is_stalwart_configured: boolean
 	is_jmap_configured: boolean
 

--- a/frontend/src/apps/mail/types/index.ts
+++ b/frontend/src/apps/mail/types/index.ts
@@ -60,6 +60,7 @@ export interface User {
 	enabled: boolean
 	is_suite_admin: boolean
 	is_system_manager: boolean
+	is_stalwart_configured: boolean
 	is_jmap_configured: boolean
 
 	mailboxes: { id: string; name: string; role: string }[]

--- a/suite/mail/api/account.py
+++ b/suite/mail/api/account.py
@@ -167,6 +167,7 @@ def get_user_info() -> dict | None:
 
 	data.is_suite_admin = is_suite_admin(user)
 	data.is_system_manager = is_system_manager(user)
+	data.is_stalwart_configured = is_stalwart_configured()
 	data.is_jmap_configured = is_jmap_configured(user)
 	data.accounts = frappe.db.get_all("User Account", {"user": user}, ["account"])
 

--- a/suite/mail/api/account.py
+++ b/suite/mail/api/account.py
@@ -12,7 +12,7 @@ from suite.mail.api.utils import get_avatar_url
 from suite.mail.doctype.identity.identity import fetch_identities
 from suite.mail.doctype.mail_settings.mail_settings import get_signup_domains
 from suite.mail.stalwart import get_domains
-from suite.mail.utils import is_stalwart_configured, log_mail_error
+from suite.mail.utils import get_config, is_stalwart_configured, log_mail_error
 from suite.mail.utils.dns import parse_dns_zone_file
 from suite.utils.rate_limiter import dynamic_rate_limit
 from suite.mail.utils.user import (
@@ -20,7 +20,7 @@ from suite.mail.utils.user import (
 	is_jmap_configured,
 )
 from suite.utils import convert_html_to_text, user_context
-from suite.utils.user import is_suite_admin, is_system_manager
+from suite.utils.user import is_suite_admin, is_suite_user, is_system_manager
 
 # SRV service label -> (protocol, connection security). See RFC 6186.
 _SRV_SERVICE_MAP = {
@@ -166,7 +166,13 @@ def get_user_info() -> dict | None:
 	data = result[0]
 
 	data.is_suite_admin = is_suite_admin(user)
+	data.is_suite_user = is_suite_user(user)
 	data.is_system_manager = is_system_manager(user)
+	# Two levels of server config drive the frontend routing:
+	# - is_server_configured (a server_url exists) gates mail viewing: unset -> "not configured"
+	#   screen; set but the user has no JMAP creds -> credentials setup.
+	# - is_stalwart_configured (server_url + username + password) gates the admin dashboard.
+	data.is_server_configured = bool(get_config("server_url"))
 	data.is_stalwart_configured = is_stalwart_configured()
 	data.is_jmap_configured = is_jmap_configured(user)
 	data.accounts = frappe.db.get_all("User Account", {"user": user}, ["account"])


### PR DESCRIPTION
## Why

Opening Mail before setup was complete dropped users on a blank, error-filled page (or bounced them to Desk). This adds friendly, role-aware routing that guides each user to the right place based on their role and how far mail setup has progressed.

## Behavior

**Users without a "Suite User" role** (Administrator / System Manager / Suite Admin — no personal mailbox) → the admin area (`/mail/admin`):
- `server_url` unset → "not configured" screen with a link to Mail Settings (shown to System Managers/Administrator) to configure it.
- `server_url` set but username/password not (`is_stalwart_configured` is `False`) → message that the Admin Dashboard is only accessible after the mail server is fully configured.
- Fully configured (`is_stalwart_configured` is `True`) → Admin Dashboard is visible.

**Users with a "Suite User" role** → `/mail`:
- `server_url` unset → message to ask the administrator to set up Mail.
- `server_url` set but the user's own username/password not set → a page to enter their JMAP account credentials.
- Fully configured (`is_jmap_configured` is `True`) → renders their mail.

## Changes

- `get_user_info` now returns `is_server_configured`, `is_stalwart_configured`, and `is_suite_user`.
- Mail navigation guard split into dashboard (gated on `is_stalwart_configured`) vs. mail-viewing (gated on `is_server_configured` → `is_jmap_configured`) branches, with role-based landing.
- New `NotConfiguredView` (role-based messaging) and `CredentialsSetupView` pages, plus a `/mail/admin` entry.
- New **Credentials** tab in Mail → Settings to manage the JMAP connection (Server URL read-only, Username, App Password, Backup Email — the last moved out of the Account tab).

## Tests

- Frontend route tests extended (not-configured, credentials-setup, admin entry); all mail tests pass.