### PR TITLE
fix(drive): import context menu in grid view

### DIFF
--- a/frontend/src/apps/drive/components/GridView.vue
+++ b/frontend/src/apps/drive/components/GridView.vue
@@ -72,6 +72,7 @@
 
 <script setup>
 import GridItem from '@/apps/drive/components/GridItem.vue'
+import ContextMenu from '@/apps/drive/components/ContextMenu.vue'
 import emitter from '@/apps/drive/emitter'
 import { Button } from 'frappe-ui'
 import { ref, computed } from 'vue'


### PR DESCRIPTION
otherwise context menu won't open up