### PR TITLE
fix(mail): screener polish, Screener settings tab, iOS install banner

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,7 +63,7 @@
     "feather-icons": "^4.29.2",
     "file-saver": "^2.0.5",
     "firebase": "^12.2.1",
-    "frappe-ui": "1.0.0-beta.25",
+    "frappe-ui": "frappe/frappe-ui#568c2a854028544c976df2cc5dfa1490cbd1310a",
     "fuzzysort": "^3.1.0",
     "gemoji": "^8.1.0",
     "hast-util-to-html": "^9.0.5",

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -21,7 +21,6 @@ const store = userStore()
 const { identities } = store
 
 const isNew = computed(() => !selectedEvent?.calendarEvent)
-const showRSVP = computed(() => !isNew.value && selectedEvent.calendarEvent.role !== 'Organizer')
 
 // --- Event initialization ---
 
@@ -127,10 +126,6 @@ const participants = computed(() =>
 		event.organizer,
 		selectedEvent?.calendarEvent?.participants,
 	),
-)
-
-const userParticipant = computed(() =>
-	participants.value.find((p) => identities.data.some((id) => id.email === p.email)),
 )
 
 const eventParams = computed(() => {
@@ -457,13 +452,6 @@ const handleSaveClick = () => {
 
 const dialogTitle = computed(() => (isNew.value ? __('Add Event') : __('Edit Event')))
 
-const RSVP_OPTIONS = [
-	{ label: __(' '), value: 'NEEDS-ACTION' },
-	{ label: __('Yes'), value: 'ACCEPTED' },
-	{ label: __('Maybe'), value: 'TENTATIVE' },
-	{ label: __('No'), value: 'DECLINED' },
-]
-
 const AVAILABILITY_OPTIONS = [
 	{ label: __('Free'), value: 'Free' },
 	{ label: __('Busy'), value: 'Busy' },
@@ -683,17 +671,6 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 
 					<!-- right: guests rail -->
 					<div class="w-[300px] shrink-0 overflow-y-auto border-l px-5 py-5">
-						<template v-if="showRSVP">
-							<h3 class="text-base-medium mb-2">{{ __('RSVP') }}</h3>
-							<FormControl
-								v-model="userParticipant.participation_status"
-								type="select"
-								:label="__('Are you attending?')"
-								:options="RSVP_OPTIONS"
-								class="mb-5 w-full"
-							/>
-						</template>
-
 						<div class="mb-3 flex items-baseline gap-2">
 							<Users :size="15" class="icon self-center text-ink-gray-5" />
 							<span class="text-base font-medium">{{ __('Participants') }}</span>

--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -50,7 +50,7 @@
 								</Button>
 							</Dropdown>
 							<span
-								class="text-ink-gray-4 text-sm"
+								class="text-ink-gray-4 mr-2 text-sm"
 								:class="{ 'group-hover:hidden': item.menuOptions }"
 							>
 								{{ item.suffix }}

--- a/frontend/src/apps/mail/components/InstallPrompt.vue
+++ b/frontend/src/apps/mail/components/InstallPrompt.vue
@@ -14,48 +14,46 @@
 		</template>
 	</Dialog>
 
-	<!-- iOS installation info message -->
-	<Popover :show="iosInstallMessage" placement="bottom">
-		<template #body>
-			<div
-				class="bg-surface-blue-2 mx-2 mt-[calc(100vh-15rem)] flex flex-col gap-3 rounded py-5 drop-shadow-xl"
-			>
-				<div class="mb-1 flex flex-row items-center justify-between px-3 text-center">
-					<span class="text-base-bold">
-						{{ __('Install Frappe Mail') }}
-					</span>
-					<span class="inline-flex items-baseline">
-						<FeatherIcon
-							name="x"
-							class="text-ink-gray-6 ml-auto h-4 w-4"
-							@click="iosInstallMessage = false"
-						/>
-					</span>
-				</div>
-				<div class="text-ink-gray-7 px-3 text-xs">
-					<span class="flex flex-col gap-2">
-						<span>
-							{{
-								__(
-									'Get the app on your iPhone for easy access & a better experience',
-								)
-							}}
-						</span>
-						<span class="inline-flex items-start whitespace-nowrap">
-							<span>Tap&nbsp;</span>
-							<FeatherIcon name="share" class="h-4 w-4 text-blue-600" />
-							<span>&nbsp;and then "Add to Home Screen"</span>
-						</span>
-					</span>
-				</div>
-			</div>
-		</template>
-	</Popover>
+	<!-- iOS installation info message — a plain fixed banner, not a Popover: no overlay to
+	     block the app behind it, and the viewport (not the content) bounds its width. -->
+	<div
+		v-if="iosInstallMessage"
+		class="bg-surface-blue-2 fixed inset-x-2 bottom-4 z-20 flex flex-col gap-3 rounded py-5 drop-shadow-xl"
+	>
+		<div class="mb-1 flex flex-row items-center justify-between px-3 text-center">
+			<span class="text-base-bold">
+				{{ __('Install Frappe Mail') }}
+			</span>
+			<span class="inline-flex items-baseline">
+				<FeatherIcon
+					name="x"
+					class="text-ink-gray-6 ml-auto h-4 w-4"
+					@click="iosInstallMessage = false"
+				/>
+			</span>
+		</div>
+		<div class="text-ink-gray-7 px-3 text-xs">
+			<span class="flex flex-col gap-2">
+				<span>
+					{{
+						__(
+							'Get the app on your iPhone for easy access & a better experience',
+						)
+					}}
+				</span>
+				<span>
+					{{ __('Tap') }}
+					<FeatherIcon name="share" class="inline h-4 w-4 align-[-3px] text-blue-600" />
+					{{ __('and then "Add to Home Screen"') }}
+				</span>
+			</span>
+		</div>
+	</div>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import { Button, Dialog, FeatherIcon, Popover } from 'frappe-ui'
+import { Button, Dialog, FeatherIcon } from 'frappe-ui'
 
 // Initialize deferredPrompt for use later to show browser install prompt.
 const deferredPrompt = ref(null)

--- a/frontend/src/apps/mail/components/MailListItem.vue
+++ b/frontend/src/apps/mail/components/MailListItem.vue
@@ -234,7 +234,7 @@ const highlight = (text?: string) => {
 	if (!term) return escaped
 	return escaped.replace(
 		new RegExp(`(${escapeRegExp(escapeHtml(term))})`, 'gi'),
-		'<mark class="bg-surface-yellow-5 text-ink-gray-9">$1</mark>',
+		'<mark class="bg-surface-yellow-5 text-ink-gray-8">$1</mark>',
 	)
 }
 

--- a/frontend/src/apps/mail/components/Modals/SearchModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SearchModal.vue
@@ -585,7 +585,7 @@ const highlight = (text?: string) => {
 	if (!term) return escaped
 	return escaped.replace(
 		new RegExp(`(${escapeRegExp(escapeHtml(term))})`, 'gi'),
-		'<mark class="bg-surface-yellow-5 text-ink-gray-9">$1</mark>',
+		'<mark class="bg-surface-yellow-5 text-ink-gray-8">$1</mark>',
 	)
 }
 

--- a/frontend/src/apps/mail/components/Modals/SettingsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SettingsModal.vue
@@ -25,9 +25,9 @@
 <script setup lang="ts">
 import { computed, inject, markRaw, ref, watch, type Component } from 'vue'
 import {
-	Ban,
 	BellRing,
 	Code,
+	Eye,
 	Feather,
 	Fingerprint,
 	Folders,
@@ -160,9 +160,9 @@ const tabGroups = computed((): SettingsTabGroup[] => {
 			label: __('Privacy'),
 			items: [
 				{
-					label: __('Screened Senders'),
+					label: __('Screener'),
 					value: 'screened-senders',
-					icon: Ban,
+					icon: Eye,
 					component: markRaw(ScreenedEmailAddressSettings),
 					condition: jmap,
 				},

--- a/frontend/src/apps/mail/components/Settings/ScreenedEmailAddressSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/ScreenedEmailAddressSettings.vue
@@ -1,10 +1,20 @@
 <template>
-	<AppSettingsHeader :title="__('Screened Senders')">
-		<template #actions>
-			<Button icon-left="lucide-plus" :label="__('New')" @click="showAddModal = true" />
-		</template>
-	</AppSettingsHeader>
+	<AppSettingsHeader :title="__('Screener')" />
 	<div class="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden px-[4.4rem] pb-8 pt-6">
+		<!-- The Screener's master switch, so this tab shows both the switch and the rules. Saves
+		     immediately (no Save button here) — same JMAP Account flag the Account tab edits. -->
+		<SettingsRow
+			class="shrink-0 !py-0"
+			:title="__('Screen New Senders')"
+			:description="
+				__(
+					'Emails from new senders go to the Screener instead of your Inbox. Only accepted senders reach your Inbox.',
+				)
+			"
+		>
+			<Switch v-model="screeningEnabled" :disabled="setScreening.loading" />
+		</SettingsRow>
+
 		<template v-if="screenedAddresses.data?.length">
 			<div class="flex shrink-0 gap-2">
 				<FormControl
@@ -31,6 +41,7 @@
 					:tooltip="sortDir === 'asc' ? __('Ascending') : __('Descending')"
 					@click="toggleSortDir"
 				/>
+				<Button icon-left="lucide-plus" :label="__('New')" @click="showAddModal = true" />
 			</div>
 
 			<div v-if="rows.length" class="relative min-h-0 flex-1">
@@ -73,10 +84,17 @@
 		<div v-else class="text-ink-gray-6 flex flex-col space-y-2 text-sm">
 			<p class="text-base font-medium">{{ __('No screened senders.') }}</p>
 			<p>{{ MESSAGE }}</p>
+			<Button
+				icon-left="lucide-plus"
+				:label="__('New')"
+				class="w-fit"
+				@click="showAddModal = true"
+			/>
 		</div>
 
 		<AddScreenedSenderModal v-model="showAddModal" />
 		<Dialog v-model="showRemoveModal" :options="removeModalOptions" />
+		<Dialog v-model="showMoveToInbox" :options="moveToInboxOptions" />
 	</div>
 </template>
 
@@ -92,6 +110,8 @@ import {
 	ListRows,
 	ListSelectBanner,
 	ListView,
+	SettingsRow,
+	Switch,
 	createResource,
 } from 'frappe-ui'
 import AppSettingsHeader from '@/components/settings/AppSettingsHeader.vue'
@@ -100,15 +120,82 @@ import { getFormattedDate, raiseToast } from '@/apps/mail/utils'
 import { userStore } from '@/apps/mail/stores/user'
 import AddScreenedSenderModal from '@/apps/mail/components/Modals/AddScreenedSenderModal.vue'
 
-import type { ScreenedAddress, ScreeningAction } from '@/apps/mail/types'
+import type { MailboxData, ScreenedAddress, ScreeningAction } from '@/apps/mail/types'
 
 const store = userStore()
-const { screenedAddresses } = store
+const { screenedAddresses, mailboxes, mailboxIds } = store
 
 const search = ref('')
 const listViewRef = useTemplateRef('listView')
 const showAddModal = ref(false)
 const showRemoveModal = ref(false)
+
+// Read the flag from the shared user data (not a document draft) so the sidebar pin and the
+// Screener view react to a toggle here without a reload — mirroring the ScreenerView turn-off flow.
+const activeAccount = computed(() =>
+	store.userResource?.data?.accounts?.find((a) => a.id === store.accountId),
+)
+
+const setScreening = createResource({
+	url: 'frappe.client.set_value',
+	makeParams: ({ value }: { value: boolean }) => ({
+		doctype: 'JMAP Account',
+		name: activeAccount.value?.jmap_account,
+		fieldname: 'enable_screening',
+		value: value ? 1 : 0,
+	}),
+})
+
+const screeningEnabled = computed({
+	get: () => !!activeAccount.value?.enable_screening,
+	set: (val: boolean) => toggleScreening(val),
+})
+
+const toggleScreening = async (val: boolean) => {
+	const account = activeAccount.value
+	if (!account) return
+	// Read the count before the reload below refreshes the data from the server.
+	const waiting =
+		mailboxes.data?.find((m: MailboxData) => m.id === mailboxIds.screener)?.total_threads ?? 0
+	account.enable_screening = val
+	try {
+		await setScreening.submit({ value: val })
+		// Enabling screening creates the Screening folder server-side; reload so it shows up.
+		mailboxes.reload()
+		raiseToast(val ? __('Screener turned on.') : __('Screener turned off.'))
+		// Turning screening off leaves the already-screened mail in the Screening folder — offer to
+		// move it to the inbox (only worth asking when there's something there).
+		if (!val && waiting > 0) showMoveToInbox.value = true
+	} catch (error) {
+		account.enable_screening = !val
+		raiseToast((error as Error).message || __('Could not update the Screener.'), 'error')
+	}
+}
+
+const showMoveToInbox = ref(false)
+
+const moveScreeningToInbox = createResource({
+	url: 'suite.mail.api.mail.move_screening_mails_to_inbox',
+	makeParams: () => ({ account: store.accountId }),
+	onSuccess: () => {
+		raiseToast(__('Unscreened messages moved to Inbox.'))
+		showMoveToInbox.value = false
+		mailboxes.reload()
+	},
+})
+
+const moveToInboxOptions = computed(() => ({
+	title: __('Move unscreened messages?'),
+	message: __('Screening is off. Move the messages currently in the Screener to your Inbox?'),
+	actions: [
+		{
+			label: __('Move to Inbox'),
+			variant: 'solid',
+			onClick: () => moveScreeningToInbox.submit(),
+			loading: moveScreeningToInbox.loading,
+		},
+	],
+}))
 
 const ACTION_LABELS: Partial<Record<ScreeningAction, string>> = {
 	Accepted: __('Accept'),

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -3,7 +3,11 @@
 	<header class="flex items-center justify-between border-b px-3 py-2.5 sm:px-5">
 		<div class="flex items-center space-x-2">
 			<Button v-if="isMobile" icon="menu" variant="ghost" @click="openSidebar" />
-			<Breadcrumbs :items="[{ label: __('All Inboxes'), route: { name: 'mail-all-inboxes' } }]" />
+			<!-- -ml-0.5 cancels the crumb's own padding so the title sits on the px-5 axis -->
+			<Breadcrumbs
+				:items="[{ label: __('All Inboxes'), route: { name: 'mail-all-inboxes' } }]"
+				class="-ml-0.5"
+			/>
 		</div>
 		<HeaderActions @reload-mails="refreshThreads()" />
 	</header>

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -3,7 +3,9 @@
 	<header class="flex items-center justify-between border-b px-3 py-2.5 sm:px-5">
 		<div class="flex items-center space-x-2">
 			<Button v-if="isMobile" icon="menu" variant="ghost" @click="openSidebar" />
+			<!-- -ml-0.5 cancels the crumb's own padding so the title sits on the px-5 axis -->
 			<Breadcrumbs
+				class="-ml-0.5"
 				:items="[
 					{
 						label: mailboxName,
@@ -23,9 +25,12 @@
 	<!-- Unscreened-thread nudge on the inbox, mirroring the trash/junk info bar: shown while Hey-style
 	     screening is on and threads are waiting to be screened. -->
 	<div v-if="showScreenerBanner" class="flex items-center space-x-1 border-b py-2.5 px-5">
-		<span class="bg-blue-500 mr-1.5 inline-block h-2 w-2 shrink-0 rounded-full" />
+		<!-- w-4 wrapper centers the dot on the checkbox column below (checkbox is w-4) -->
+		<span class="mr-1 flex w-4 shrink-0 justify-center">
+			<span class="bg-blue-500 inline-block h-2 w-2 rounded-full" />
+		</span>
 		<span class="text-ink-gray-5">{{ screenerBanner.before
-		}}<span class="font-medium text-ink-gray-9">{{ screenerBanner.phrase }}</span>{{ screenerBanner.after }}</span>
+		}}<span class="font-medium text-ink-gray-8">{{ screenerBanner.phrase }}</span>{{ screenerBanner.after }}</span>
 		<Button :label="__('Review Now')" variant="ghost" @click="goToScreener" />
 	</div>
 

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -303,7 +303,6 @@
 
 		<Dialog v-model="showClearAll" :options="clearAllOptions" />
 		<Dialog v-model="showBulkConfirm" :options="bulkConfirmOptions" />
-		<Dialog v-model="showTurnOff" :options="turnOffOptions" />
 	</div>
 </template>
 
@@ -652,75 +651,25 @@ const clearAllOptions = computed(() => ({
 // First-visit explainer card. Dismissal is stored per device, not per account — it's education about
 // the feature, not account state.
 const EXPLAINER_STORAGE_KEY = 'mail-screener-explainer-dismissed'
-const explainerDismissed = ref(localStorage.getItem(EXPLAINER_STORAGE_KEY) === 'true')
+// localStorage can throw (private browsing, storage disabled); a broken slab
+// preference must not take the whole view down with it.
+const readExplainerDismissed = () => {
+	try {
+		return localStorage.getItem(EXPLAINER_STORAGE_KEY) === 'true'
+	} catch {
+		return false
+	}
+}
+const explainerDismissed = ref(readExplainerDismissed())
 
 const dismissExplainer = () => {
 	explainerDismissed.value = true
-	localStorage.setItem(EXPLAINER_STORAGE_KEY, 'true')
-}
-
-// Turning the Screener off from within the Screener: same JMAP Account flag the Account settings tab
-// saves, plus the move-to-inbox the dialog promises. The redirect to the inbox falls out of the
-// `screeningEnabled` watcher once the shared account flag is synced.
-const showTurnOff = ref(false)
-const turningOff = ref(false)
-
-const disableScreening = createResource({
-	url: 'frappe.client.set_value',
-	makeParams: () => ({
-		doctype: 'JMAP Account',
-		name: store.userResource?.data?.accounts?.find((a) => a.id === store.accountId)
-			?.jmap_account,
-		fieldname: 'enable_screening',
-		value: 0,
-	}),
-})
-
-const turnOffScreener = async () => {
-	turningOff.value = true
 	try {
-		// Move the waiting mail out first, while screening is still on — the dialog promised it.
-		await moveScreeningToInbox.submit()
-		await disableScreening.submit()
-		showTurnOff.value = false
-		store.mailboxes.reload()
-		raiseToast(__('Screener turned off.'))
-		const account = store.userResource?.data?.accounts?.find((a) => a.id === store.accountId)
-		if (account) account.enable_screening = false
-	} catch (error) {
-		raiseToast((error as Error).message || __('Could not turn off the Screener.'), 'error')
-	} finally {
-		turningOff.value = false
+		localStorage.setItem(EXPLAINER_STORAGE_KEY, 'true')
+	} catch {
+		// Storage unavailable — the slab reappears next visit, nothing worse.
 	}
 }
-
-const turnOffOptions = computed(() => {
-	const count = senders.data?.length ?? 0
-	const waiting =
-		count === 1
-			? __('The sender waiting now will be moved there too.')
-			: __('The {0} senders waiting now will be moved there too.', [String(count)])
-	return {
-		title: __('Turn Off Screener?'),
-		message: [
-			__('New senders will go straight to your Inbox.'),
-			count ? waiting : '',
-			__(
-				"Senders you've already allowed or denied keep their decisions. You can turn the Screener back on anytime in Settings.",
-			),
-		]
-			.filter(Boolean)
-			.join(' '),
-		actions: [
-			{
-				label: __('Turn Off'),
-				variant: 'solid',
-				onClick: turnOffScreener,
-				loading: turningOff.value,
-			},
-		],
-	}
-})
 
 // Bulk triage over every waiting sender. Allow/Deny reuse the per-sender flow (optimistic clear +
 // batched request) but, since they act on everyone at once, go behind a confirm dialog.
@@ -765,6 +714,5 @@ const bulkConfirmOptions = computed(() => {
 const bulkOptions = computed(() => [
 	{ label: __('Deny All'), onClick: denyAll },
 	{ label: __('Move All to Inbox'), onClick: () => (showClearAll.value = true) },
-	{ label: __('Turn Off Screener'), onClick: () => (showTurnOff.value = true) },
 ])
 </script>

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -3,10 +3,56 @@
 		<header class="flex items-center justify-between border-b px-3 py-2.5 sm:px-5">
 			<div class="flex items-center space-x-2">
 				<Button v-if="isMobile" icon="menu" variant="ghost" @click="openSidebar" />
-				<Breadcrumbs :items="[{ label: __('Screener') }]" />
+				<!-- -ml-0.5 cancels the crumb's own padding so the title sits on the px-5 axis -->
+				<Breadcrumbs :items="[{ label: __('Screener') }]" class="-ml-0.5" />
 			</div>
 			<HeaderActions @reload-mails="senders.reload()" />
 		</header>
+
+		<!-- First-visit explainer — a full-width slab under the header, spanning list and reading
+		     pane. Dismissal sticks per device (education, not account state). -->
+		<div
+			v-if="!explainerDismissed && senders.data?.length && !(openSender && !showReadingPane)"
+			class="bg-surface-blue-1 flex shrink-0 items-start gap-3 border-b px-5 py-4"
+		>
+			<div class="min-w-0 flex-1">
+				<div class="text-ink-gray-8 text-base !font-semibold">
+					{{ __('New senders wait here first') }}
+				</div>
+				<!-- The rows act through icon buttons, so the copy shows the icons next to the words
+				     they stand for — "Allow" and "Deny" appear nowhere else in the view. -->
+				<p class="text-ink-gray-6 mt-1 text-sm !leading-[1.5]">
+					{{
+						__(
+							'The first time someone emails you, their message lands in the Screener instead of your Inbox.',
+						)
+					}}
+					<!-- nowrap keeps each word+icon parenthetical on one line -->
+					<span class="whitespace-nowrap">
+						{{ __('Allow') }} (<Check
+							class="inline h-3.5 w-3.5 align-[-2.5px]"
+							stroke-width="2"
+						/>)
+					</span>
+					{{ __('a sender once and their emails reach your Inbox from then on;') }}
+					<span class="whitespace-nowrap">
+						{{ __('Deny') }} (<X
+							class="inline h-3.5 w-3.5 align-[-2.5px]"
+							stroke-width="2"
+						/>)
+					</span>
+					{{ __('sends them to Junk.') }}
+				</p>
+			</div>
+			<Button
+				variant="ghost"
+				class="-mr-2 -mt-2"
+				:tooltip="__('Dismiss')"
+				@click="dismissExplainer"
+			>
+				<template #icon><X class="icon" /></template>
+			</Button>
+		</div>
 
 		<div class="relative flex flex-1 overflow-hidden">
 			<!-- Loading the sender list — centered like the mailbox empty/loading states. -->
@@ -38,8 +84,56 @@
 					<div class="pb-20">
 						<!-- Count bar — matches the mailbox "All Mails" toolbar height/style. -->
 						<div class="flex min-h-[49px] items-center justify-between border-b px-5">
-							<span class="truncate">{{ waitingLabel }}</span>
-							<div class="-mr-2 flex items-center gap-1">
+							<div class="flex min-w-0 items-center">
+								<span class="truncate">{{ waitingLabel }}</span>
+								<!-- Redundant while the explainer slab is teaching the same lesson above,
+								     and skipped on mobile where the popover doesn't sit well. -->
+								<Popover v-if="explainerDismissed && !isMobile" placement="bottom-start">
+									<template #target="{ togglePopover }">
+										<Button
+											variant="ghost"
+											class="ml-1 !px-1.5"
+											:tooltip="__('How the Screener works')"
+											@click="togglePopover()"
+										>
+											<template #icon><CircleHelp class="icon" /></template>
+										</Button>
+									</template>
+									<template #body-main>
+										<div class="w-80 p-4">
+											<div class="text-ink-gray-8 mb-1.5 text-sm !font-semibold">
+												{{ __('How the Screener works') }}
+											</div>
+											<p class="text-ink-gray-6 text-sm !leading-[1.5]">
+												{{ __('First-time senders wait here until you decide.') }}
+												<!-- nowrap keeps each word+icon parenthetical on one line -->
+												<span class="whitespace-nowrap">
+													{{ __('Allow') }} (<Check
+														class="inline h-3.5 w-3.5 align-[-2.5px]"
+														stroke-width="2"
+													/>)
+												</span>
+												{{ __('a sender and their emails go to your Inbox — now and in the future.') }}
+												<span class="whitespace-nowrap">
+													{{ __('Deny') }} (<X
+														class="inline h-3.5 w-3.5 align-[-2.5px]"
+														stroke-width="2"
+													/>)
+												</span>
+												{{ __('sends them to Junk.') }}
+											</p>
+											<p class="text-ink-gray-6 mt-3 text-sm !leading-[1.5]">
+												{{ __('You can undo decisions or turn the Screener off in') }}
+												<a
+													class="cursor-pointer underline"
+													@click="openSettings(__('Screener'))"
+												>{{ __('Settings') }}</a>{{ '.' }}
+											</p>
+										</div>
+									</template>
+								</Popover>
+							</div>
+							<div class="-mr-2 flex shrink-0 items-center gap-1">
 								<Dropdown :options="bulkOptions" placement="bottom-end">
 									<Button variant="ghost" class="!px-1.5">
 										<template #icon><Ellipsis class="icon" /></template>
@@ -87,7 +181,7 @@
 									:in-list="true"
 									class="text-ink-gray-4 whitespace-nowrap pt-px text-xs tabular-nums"
 								/>
-								<div class="-mr-2 flex gap-2">
+								<div class="flex gap-2">
 									<Button
 										variant="outline"
 										:tooltip="__('Deny')"
@@ -133,7 +227,8 @@
 										<ChevronLeft class="icon" />
 									</template>
 								</Button>
-								<h2 class="truncate font-semibold leading-5">
+								<!-- On mobile the thread header right below shows the subject already. -->
+								<h2 v-if="!isMobile" class="truncate font-semibold leading-5">
 									{{ openSender.subject || __('[No subject]') }}
 								</h2>
 							</div>
@@ -208,17 +303,34 @@
 
 		<Dialog v-model="showClearAll" :options="clearAllOptions" />
 		<Dialog v-model="showBulkConfirm" :options="bulkConfirmOptions" />
+		<Dialog v-model="showTurnOff" :options="turnOffOptions" />
 	</div>
 </template>
 
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { Check, ChevronDown, ChevronLeft, Ellipsis, LoaderCircle, X } from 'lucide-vue-next'
-import { Breadcrumbs, Button, Dialog, Dropdown, createResource, usePageMeta } from 'frappe-ui'
+import {
+	Check,
+	ChevronDown,
+	ChevronLeft,
+	CircleHelp,
+	Ellipsis,
+	LoaderCircle,
+	X,
+} from 'lucide-vue-next'
+import {
+	Breadcrumbs,
+	Button,
+	Dialog,
+	Dropdown,
+	Popover,
+	createResource,
+	usePageMeta,
+} from 'frappe-ui'
 
 import { raiseToast, shouldIgnoreKeypress } from '@/apps/mail/utils'
-import { useScreenSize, useSidebar } from '@/apps/mail/utils/composables'
+import { useScreenSize, useSettings, useSidebar } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
@@ -232,6 +344,7 @@ const store = userStore()
 const router = useRouter()
 const { isMobile } = useScreenSize()
 const { openSidebar } = useSidebar()
+const { openSettings } = useSettings()
 
 const showReadingPane = computed(() => !!store.userResource?.data?.show_reading_pane)
 
@@ -505,17 +618,20 @@ const domainOptions = (action: 'allow' | 'screenOut', sender: ScreeningSender) =
 // creates no Deny/Allow rule, so a mixed queue can't accidentally whitelist spam or block a real sender.
 const showClearAll = ref(false)
 
-const clearAllResource = createResource({
+// Shared by Clear All and the turn-off flow, which is why the success handling lives with each caller.
+const moveScreeningToInbox = createResource({
 	url: 'suite.mail.api.mail.move_screening_mails_to_inbox',
 	makeParams: () => ({ account: store.accountId }),
-	onSuccess: () => {
-		senders.data = []
-		closeSender()
-		showClearAll.value = false
-		store.mailboxes.reload()
-		raiseToast(__('Unscreened messages moved to Inbox.'))
-	},
 })
+
+const clearAll = async () => {
+	await moveScreeningToInbox.submit()
+	senders.data = []
+	closeSender()
+	showClearAll.value = false
+	store.mailboxes.reload()
+	raiseToast(__('Unscreened messages moved to Inbox.'))
+}
 
 const clearAllOptions = computed(() => ({
 	title: __('Move All to Inbox'),
@@ -527,11 +643,84 @@ const clearAllOptions = computed(() => ({
 		{
 			label: __('Move to Inbox'),
 			variant: 'solid',
-			onClick: () => clearAllResource.submit(),
-			loading: clearAllResource.loading,
+			onClick: clearAll,
+			loading: moveScreeningToInbox.loading,
 		},
 	],
 }))
+
+// First-visit explainer card. Dismissal is stored per device, not per account — it's education about
+// the feature, not account state.
+const EXPLAINER_STORAGE_KEY = 'mail-screener-explainer-dismissed'
+const explainerDismissed = ref(localStorage.getItem(EXPLAINER_STORAGE_KEY) === 'true')
+
+const dismissExplainer = () => {
+	explainerDismissed.value = true
+	localStorage.setItem(EXPLAINER_STORAGE_KEY, 'true')
+}
+
+// Turning the Screener off from within the Screener: same JMAP Account flag the Account settings tab
+// saves, plus the move-to-inbox the dialog promises. The redirect to the inbox falls out of the
+// `screeningEnabled` watcher once the shared account flag is synced.
+const showTurnOff = ref(false)
+const turningOff = ref(false)
+
+const disableScreening = createResource({
+	url: 'frappe.client.set_value',
+	makeParams: () => ({
+		doctype: 'JMAP Account',
+		name: store.userResource?.data?.accounts?.find((a) => a.id === store.accountId)
+			?.jmap_account,
+		fieldname: 'enable_screening',
+		value: 0,
+	}),
+})
+
+const turnOffScreener = async () => {
+	turningOff.value = true
+	try {
+		// Move the waiting mail out first, while screening is still on — the dialog promised it.
+		await moveScreeningToInbox.submit()
+		await disableScreening.submit()
+		showTurnOff.value = false
+		store.mailboxes.reload()
+		raiseToast(__('Screener turned off.'))
+		const account = store.userResource?.data?.accounts?.find((a) => a.id === store.accountId)
+		if (account) account.enable_screening = false
+	} catch (error) {
+		raiseToast((error as Error).message || __('Could not turn off the Screener.'), 'error')
+	} finally {
+		turningOff.value = false
+	}
+}
+
+const turnOffOptions = computed(() => {
+	const count = senders.data?.length ?? 0
+	const waiting =
+		count === 1
+			? __('The sender waiting now will be moved there too.')
+			: __('The {0} senders waiting now will be moved there too.', [String(count)])
+	return {
+		title: __('Turn Off Screener?'),
+		message: [
+			__('New senders will go straight to your Inbox.'),
+			count ? waiting : '',
+			__(
+				"Senders you've already allowed or denied keep their decisions. You can turn the Screener back on anytime in Settings.",
+			),
+		]
+			.filter(Boolean)
+			.join(' '),
+		actions: [
+			{
+				label: __('Turn Off'),
+				variant: 'solid',
+				onClick: turnOffScreener,
+				loading: turningOff.value,
+			},
+		],
+	}
+})
 
 // Bulk triage over every waiting sender. Allow/Deny reuse the per-sender flow (optimistic clear +
 // batched request) but, since they act on everyone at once, go behind a confirm dialog.
@@ -576,5 +765,6 @@ const bulkConfirmOptions = computed(() => {
 const bulkOptions = computed(() => [
 	{ label: __('Deny All'), onClick: denyAll },
 	{ label: __('Move All to Inbox'), onClick: () => (showClearAll.value = true) },
+	{ label: __('Turn Off Screener'), onClick: () => (showTurnOff.value = true) },
 ])
 </script>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -118,6 +118,9 @@ export default defineConfig(({ mode }) => ({
     },
     // Keep single ProseMirror / Yjs / reka-ui / vue singletons across the 7
     // merged editors (drive/writer/sheets/mail collab) — see _resolved.json.
+    // @vueuse/core must NOT be deduped: frappe-ui needs v10 while reka-ui
+    // ships with its own nested v14, and collapsing them onto one copy breaks
+    // reka-ui (e.g. TabsIndicator's useResizeObserver call under vueuse 10).
     dedupe: [
       'vue',
       'vue-router',
@@ -126,7 +129,6 @@ export default defineConfig(({ mode }) => ({
       'prosemirror-state',
       'prosemirror-view',
       'reka-ui',
-      '@vueuse/core',
     ],
   },
   build: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2713,15 +2713,10 @@
   dependencies:
     pdfjs-dist "4.2.67"
 
-"@tiptap/core@^3.26.0":
+"@tiptap/core@3.26.0", "@tiptap/core@^3.26.0", "@tiptap/core@^3.27.1":
   version "3.26.0"
   resolved "https://registry.yarnpkg.com/@tiptap/core/-/core-3.26.0.tgz#7e1989377c851bcc89d8c7c8f893d65cdc378434"
   integrity sha512-7jTed/RirIVsp+lLdLvGzGqF3EBGpnGHGYKOwz6t28V2BIJLAFdUhfEVdWie7xPxQNWK0TP+fPlsqZS0vxfHBg==
-
-"@tiptap/core@^3.27.1":
-  version "3.28.0"
-  resolved "https://registry.yarnpkg.com/@tiptap/core/-/core-3.28.0.tgz#be8b23f6727ee411895b45b68f261fdfd5c714b3"
-  integrity sha512-gUuD5WAYfbDxNSSJya/emh2KSzXZXLUYKW4fEnc1AQ5FE2twzh4LJ9UlKFIawigrUCAksWI5Fy1hRbv+5m4ZdQ==
 
 "@tiptap/extension-blockquote@^3.26.0", "@tiptap/extension-blockquote@^3.27.1":
   version "3.27.1"
@@ -2946,7 +2941,7 @@
   dependencies:
     marked "^17.0.1"
 
-"@tiptap/pm@^3.26.0":
+"@tiptap/pm@3.26.0", "@tiptap/pm@^3.26.0", "@tiptap/pm@^3.27.1":
   version "3.26.0"
   resolved "https://registry.yarnpkg.com/@tiptap/pm/-/pm-3.26.0.tgz#87e31e43df9aaca5db81ba8106e0fec744938c31"
   integrity sha512-q4RDeWwVrhOL0jJCGRgGxLSdjOYwzQ4h2InURZVhC66433ipcHd6f3bqSOhcXZ4r0sFmMNsuF7aZmUntjWLc7w==
@@ -2964,25 +2959,6 @@
     prosemirror-tables "^1.8.0"
     prosemirror-transform "^1.12.0"
     prosemirror-view "^1.41.8"
-
-"@tiptap/pm@^3.27.1":
-  version "3.28.0"
-  resolved "https://registry.yarnpkg.com/@tiptap/pm/-/pm-3.28.0.tgz#db64c3a57ceaf0e8b0b90c5a80bf37625ca7a2a9"
-  integrity sha512-ALcpwZMUdat9gjJKlpscpoqXStoLhU246LPEVBDvJdIsoUKvUu3MrzfXik2Y8mtSGfhjtm9O2TRkWxQiFVMwsQ==
-  dependencies:
-    prosemirror-changeset "^2.4.1"
-    prosemirror-commands "^1.7.1"
-    prosemirror-dropcursor "^1.8.2"
-    prosemirror-gapcursor "^1.4.1"
-    prosemirror-history "^1.5.0"
-    prosemirror-inputrules "^1.5.1"
-    prosemirror-keymap "^1.2.3"
-    prosemirror-model "^1.25.9"
-    prosemirror-schema-list "^1.5.1"
-    prosemirror-state "^1.4.4"
-    prosemirror-tables "^1.8.5"
-    prosemirror-transform "^1.12.0"
-    prosemirror-view "^1.41.9"
 
 "@tiptap/starter-kit@^3.26.0":
   version "3.27.1"
@@ -3019,7 +2995,7 @@
   resolved "https://registry.yarnpkg.com/@tiptap/suggestion/-/suggestion-3.27.1.tgz#f37411e9cb9ef08b8af0c6a8ae1202f8300c29c8"
   integrity sha512-GNBPRav+lAfXzqmmUAS6ylRAn3G8JfsP6XosjoORxJIQJLx1ktDqwp6tm1Vgz9aGIM2TrBxLS1uBbI1Gb2/1VA==
 
-"@tiptap/vue-3@^3.26.0":
+"@tiptap/vue-3@3.26.0", "@tiptap/vue-3@^3.26.0":
   version "3.26.0"
   resolved "https://registry.yarnpkg.com/@tiptap/vue-3/-/vue-3-3.26.0.tgz#1804b40de4eb8850402663020167f00d13b28557"
   integrity sha512-ephdd355RvM69T2bjEHK1VPkAnZLuskwYZ8ta9L22iRLSIGpk1ERT9W+jOe6hYVyP4AiidOwK0yOvv1a5QiyJg==
@@ -4704,10 +4680,9 @@ fraction.js@^5.3.4:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-5.3.4.tgz#8c0fcc6a9908262df4ed197427bdeef563e0699a"
   integrity sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==
 
-frappe-ui@1.0.0-beta.25:
+frappe-ui@frappe/frappe-ui#568c2a854028544c976df2cc5dfa1490cbd1310a:
   version "1.0.0-beta.25"
-  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-1.0.0-beta.25.tgz#99aa2463de799ae98550e9be7e4770e79b431680"
-  integrity sha512-RiHl6Nv3vy8ywtQfWG9pvWYiH9aRdhzteXPiF2+Qjsh0owBVnim0ZP6ZE03jhtmaZ5QgrPovZu+rcBTOORWzuA==
+  resolved "https://codeload.github.com/frappe/frappe-ui/tar.gz/568c2a854028544c976df2cc5dfa1490cbd1310a"
   dependencies:
     "@codemirror/lang-css" "^6.3.0"
     "@codemirror/lang-html" "^6.4.9"
@@ -6475,14 +6450,14 @@ property-information@^7.0.0:
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-7.2.0.tgz#0809b34264e995c0bfcd3227028a1e35210af80a"
   integrity sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==
 
-prosemirror-changeset@^2.3.0, prosemirror-changeset@^2.4.1:
+prosemirror-changeset@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz#685091245bf3299cd1cae2b8983cf9b0342e6b39"
   integrity sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==
   dependencies:
     prosemirror-transform "^1.0.0"
 
-prosemirror-commands@^1.6.2, prosemirror-commands@^1.7.1:
+prosemirror-commands@^1.6.2:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz#d101fef85618b1be53d5b99ea17bee5600781b38"
   integrity sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==
@@ -6500,16 +6475,7 @@ prosemirror-dropcursor@^1.8.1:
     prosemirror-transform "^1.1.0"
     prosemirror-view "^1.1.0"
 
-prosemirror-dropcursor@^1.8.2:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.3.tgz#726ae97baa251097306b0f7194a217a5ad9e8f9f"
-  integrity sha512-FoYbsJR8gK+DGlqhNoE29Loa38eIZPzQRIb1VMaDNBoo4OLP6vVof/jR8qFY/6XvUd6Dhug8MDCHl2a/h8RTfQ==
-  dependencies:
-    prosemirror-state "^1.0.0"
-    prosemirror-transform "^1.1.0"
-    prosemirror-view "^1.1.0"
-
-prosemirror-gapcursor@^1.3.2, prosemirror-gapcursor@^1.4.1:
+prosemirror-gapcursor@^1.3.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz#da33c905fece147df577342c06f4929b25d365ee"
   integrity sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==
@@ -6519,7 +6485,7 @@ prosemirror-gapcursor@^1.3.2, prosemirror-gapcursor@^1.4.1:
     prosemirror-state "^1.0.0"
     prosemirror-view "^1.0.0"
 
-prosemirror-history@^1.4.1, prosemirror-history@^1.5.0:
+prosemirror-history@^1.4.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/prosemirror-history/-/prosemirror-history-1.5.0.tgz#ee21fc5de85a1473e3e3752015ffd6d649a06859"
   integrity sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==
@@ -6529,7 +6495,7 @@ prosemirror-history@^1.4.1, prosemirror-history@^1.5.0:
     prosemirror-view "^1.31.0"
     rope-sequence "^1.3.0"
 
-prosemirror-inputrules@^1.4.0, prosemirror-inputrules@^1.5.1:
+prosemirror-inputrules@^1.4.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz#d2e935f6086e3801486b09222638f61dae89a570"
   integrity sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==
@@ -6552,14 +6518,7 @@ prosemirror-model@^1.0.0, prosemirror-model@^1.21.0, prosemirror-model@^1.25.4, 
   dependencies:
     orderedmap "^2.0.0"
 
-prosemirror-model@^1.25.9:
-  version "1.25.11"
-  resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.25.11.tgz#2ac01dce5176094a52cc1b889c20f3849563aba9"
-  integrity sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==
-  dependencies:
-    orderedmap "^2.0.0"
-
-prosemirror-schema-list@^1.5.0, prosemirror-schema-list@^1.5.1:
+prosemirror-schema-list@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz#5869c8f749e8745c394548bb11820b0feb1e32f5"
   integrity sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==
@@ -6577,7 +6536,7 @@ prosemirror-state@^1.0.0, prosemirror-state@^1.2.2, prosemirror-state@^1.4.4:
     prosemirror-transform "^1.0.0"
     prosemirror-view "^1.27.0"
 
-prosemirror-tables@^1.8.0, prosemirror-tables@^1.8.1, prosemirror-tables@^1.8.5:
+prosemirror-tables@^1.8.0, prosemirror-tables@^1.8.1:
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz#104427012e5a5da1d2a38c122efee8d66bdd5104"
   integrity sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==
@@ -6599,15 +6558,6 @@ prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.27.0, pros
   version "1.41.9"
   resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.41.9.tgz#e756493e7116f7df7c73aaf050f60871cab42100"
   integrity sha512-clTunTX+eaLbr87L1V1QPheRlEQJyTlL3gXe9x3jQIk3rL0RVWxviDGz8tFaydwIVm+hKhYCyr+R/zBtWr9s6A==
-  dependencies:
-    prosemirror-model "^1.25.8"
-    prosemirror-state "^1.0.0"
-    prosemirror-transform "^1.1.0"
-
-prosemirror-view@^1.41.9:
-  version "1.42.1"
-  resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.42.1.tgz#7d8dae19a757de11b918760ba094a68a293dbb87"
-  integrity sha512-rRqzZnRgkyh69XoOMrfFJHwauHscLBmHbq772kwbic1ymQAM8gXjzEbJse5j1ep2UO2HRIAQL0bY3kZ/RoqjVw==
   dependencies:
     prosemirror-model "^1.25.8"
     prosemirror-state "^1.0.0"


### PR DESCRIPTION
- Screener explainer is a full-width slab under the header (light blue, dismissible); the `?` popover shows only after dismissal, with tightened copy linking to Settings
- Settings: Screened Senders tab renamed to **Screener** (eye icon) and gains the master switch — instant save, move-to-inbox prompt on disable; New button moved into the list toolbar
- Screener preview top bar hides the subject on mobile
- iOS install banner rebuilt as a fixed bottom banner — close button no longer off-screen, page no longer blocked
- Calendar: RSVP block removed from the event modal
- Misc: breadcrumb/screener-dot alignment, `ink-gray-8` for search highlights, frappe-ui git pin + `@vueuse/core` dedupe fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Screenshots

**Screener — explainer slab**
![explainer-slab](https://raw.githubusercontent.com/krantheman/suite/pr-333-assets/.assets/pr-333/explainer-slab.jpg)

**Help popover (after dismissal)**
![help-popover](https://raw.githubusercontent.com/krantheman/suite/pr-333-assets/.assets/pr-333/help-popover.jpg)

**Screener settings tab**
![screener-settings](https://raw.githubusercontent.com/krantheman/suite/pr-333-assets/.assets/pr-333/screener-settings.jpg)

**Event modal — RSVP block removed**
![event-modal](https://raw.githubusercontent.com/krantheman/suite/pr-333-assets/.assets/pr-333/event-modal.jpg)