### PR TITLE
fix(meet): remove action gap for non-hosts

### DIFF
--- a/frontend/src/apps/meet/components/PeoplePanel.vue
+++ b/frontend/src/apps/meet/components/PeoplePanel.vue
@@ -39,7 +39,7 @@
 
 				<div class="flex-1 overflow-y-auto px-2">
 					<PeopleWaitingSection
-						v-if="isCreator"
+						v-if="isHostOrCohost"
 						:lobbyUsers="filteredLobbyUsers"
 						@approve="handleApproveLobbyUser"
 						@reject="handleRejectLobbyUser"
@@ -60,6 +60,7 @@
 							:isCurrentUser="participant.isCurrentUser"
 							:isHost="participant.isHost"
 							:canControlParticipant="participant.canControlParticipant"
+							:reserveHostControlSpace="isHostOrCohost"
 							@muteParticipant="handleMuteParticipant"
 							@kickParticipant="handleKickParticipant"
 							@lowerHand="handleLowerHand"
@@ -141,7 +142,7 @@ const emit = defineEmits<{
 
 const searchQuery = ref<string>("");
 
-const isCreator = computed(() => {
+const isHostOrCohost = computed(() => {
 	return (
 		props.currentUser.user_id === props.creatorUserId ||
 		props.coHosts.includes(props.currentUser.user_id || "")
@@ -233,7 +234,7 @@ const allVisibleParticipants = computed(() => {
 			user_id: props.currentUser?.user_id || "",
 			participantData: currentUserData.value,
 			isCurrentUser: true,
-			isHost: isCreator.value,
+			isHost: isHostOrCohost.value,
 			canControlParticipant: false,
 			canPromoteToCohost: false,
 		});
@@ -248,7 +249,7 @@ const allVisibleParticipants = computed(() => {
 				participant.user_id === props.creatorUserId ||
 				props.coHosts.includes(participant.user_id),
 			canControlParticipant:
-				isCreator.value && participant.user_id !== props.creatorUserId,
+				isHostOrCohost.value && participant.user_id !== props.creatorUserId,
 			canPromoteToCohost:
 				isHost.value &&
 				!participant.is_guest &&

--- a/frontend/src/apps/meet/components/PeopleParticipantTile.vue
+++ b/frontend/src/apps/meet/components/PeopleParticipantTile.vue
@@ -74,7 +74,7 @@
 					</template>
 				</Dropdown>
 			</div>
-			<div v-else class="w-7 shrink-0" aria-hidden="true" />
+			<div v-else-if="reserveHostControlSpace" class="w-7 shrink-0" aria-hidden="true" />
 		</div>
 	</div>
 
@@ -103,6 +103,7 @@ interface Props {
 	isCurrentUser?: boolean;
 	isHost?: boolean;
 	canControlParticipant?: boolean;
+	reserveHostControlSpace?: boolean;
 	canPromoteToCohost?: boolean;
 }
 
@@ -110,6 +111,7 @@ const props = withDefaults(defineProps<Props>(), {
 	isCurrentUser: false,
 	isHost: false,
 	canControlParticipant: false,
+	reserveHostControlSpace: false,
 	canPromoteToCohost: false,
 });
 


### PR DESCRIPTION
We were adding a small gap the size of a button to make the icons look aligned for host layout like below. But the same gap was there for non-hosts as well, which we don't need.

### Host
<img width="396" height="168" alt="Screenshot 2026-07-23 at 7 12 11 PM" src="https://github.com/user-attachments/assets/b3c94265-9f9a-4dc2-bd0a-03a25019e201" />

### Non-host
<img width="396" height="168" alt="Screenshot 2026-07-23 at 7 16 08 PM" src="https://github.com/user-attachments/assets/c40bfcd5-0c21-4394-9712-8001646b2018" />

