### PR TITLE
feat(sheets): Google Sheets keyboard shortcuts + fix whole-line select anchor

### DIFF
--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -165,11 +165,14 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
   // ── Selection ────────────────────────────────────────────────────────────────
 
   function getSelRange() {
-    return {
-      r0: Math.min(sel.r, selEnd.r), c0: Math.min(sel.c, selEnd.c),
-      r1: Math.max(sel.r, selEnd.r), c1: Math.max(sel.c, selEnd.c),
-      mode: selMode,
-    }
+    let r0 = Math.min(sel.r, selEnd.r), r1 = Math.max(sel.r, selEnd.r)
+    let c0 = Math.min(sel.c, selEnd.c), c1 = Math.max(sel.c, selEnd.c)
+    // Whole-row / column / sheet selections keep their anchor on the user's
+    // active cell — selMode, not the stored corners, defines the perpendicular
+    // span. So a Shift+Space row still reports every column for copy/delete/etc.
+    if (selMode === 'row' || selMode === 'all') { c0 = 0; c1 = TOTAL_COLS - 1 }
+    if (selMode === 'col' || selMode === 'all') { r0 = 0; r1 = TOTAL_ROWS - 1 }
+    return { r0, c0, r1, c1, mode: selMode }
   }
 
   // Restore a rectangular selection (used by the contextmenu handler when
@@ -1606,6 +1609,48 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
         for (const { id } of cells) delete data[id]
         render()
       }
+      return
+    }
+
+    // Shift+Space — select whole row(s); Ctrl/Cmd+Space — whole column(s);
+    // Ctrl/Cmd+Shift+Space — the entire sheet. Mirrors Google Sheets. Kept
+    // above the printable-char handler below so the Space keystroke isn't
+    // swallowed into cell-edit mode. The anchor stays on the active cell
+    // (r, c) — getSelRange() expands the perpendicular axis by selMode — so the
+    // highlighted cell keeps its column/row and arrows + typing resume from
+    // there, exactly like Sheets. A pre-existing range promotes its span.
+    if (e.code === 'Space' || e.key === ' ') {
+      if (mod && e.shiftKey) {
+        e.preventDefault()
+        selMode = 'all'; sel = { r: 0, c: 0 }; selEnd = { r: TOTAL_ROWS - 1, c: TOTAL_COLS - 1 }
+        render(); onSelect?.('A1'); return
+      }
+      if (mod) {
+        e.preventDefault()
+        selMode = 'col'; sel = { r, c }; selEnd = { r, c: ec }
+        const cc0 = Math.min(c, ec), cc1 = Math.max(c, ec)
+        render(); onSelect?.(colLabel(cc0) + ':' + colLabel(cc1)); return
+      }
+      if (e.shiftKey) {
+        e.preventDefault()
+        selMode = 'row'; sel = { r, c }; selEnd = { r: er, c }
+        const rr0 = Math.min(r, er), rr1 = Math.max(r, er)
+        render(); onSelect?.(String(rr0 + 1) + ':' + String(rr1 + 1)); return
+      }
+    }
+
+    // PageDown / PageUp — move the active cell one screenful down / up; Shift
+    // extends the selection instead. Page size is the count of rows currently
+    // visible in the viewport, so it tracks zoom and row heights.
+    if (e.key === 'PageDown' || e.key === 'PageUp') {
+      e.preventDefault()
+      _tabAnchorCol = null
+      const top  = geo.firstVisRow()
+      const page = Math.max(1, geo.lastVisRow(top, cssH) - top)
+      const dir  = e.key === 'PageDown' ? 1 : -1
+      const from = e.shiftKey ? er : r
+      const target = _skipHiddenR(from + dir * page, dir)
+      if (e.shiftKey) extendSel(target, ec); else moveSel(target, c)
       return
     }
 

--- a/frontend/src/apps/sheets/canvas/renderer.js
+++ b/frontend/src/apps/sheets/canvas/renderer.js
@@ -1,4 +1,4 @@
-import { COLORS, COL_HEADER_H, ROW_HEADER_W } from './constants.js'
+import { COLORS, COL_HEADER_H, ROW_HEADER_W, TOTAL_ROWS, TOTAL_COLS } from './constants.js'
 import { createGridPainter }      from './painters/grid-painter.js'
 import { createSelectionPainter } from './painters/selection-painter.js'
 import { createCellPainter }      from './painters/cell-painter.js'
@@ -32,11 +32,15 @@ export function createRenderer(ctx, geometry) {
     const c0s    = firstVisCol(), r0s = firstVisRow()
     const c1s    = lastVisCol(c0s, cssW), r1s = lastVisRow(r0s, cssH)
     const range  = _selRange(sel, selEnd)
+    // The fill spans the full width (row mode) / height (col mode) / both (all)
+    // while headers + anchor keep the literal `range`, so the active cell stays
+    // in the user's column even though the whole row/column is shaded.
+    const fillRange = _fillRange(range, selMode)
 
     const state = { cssW, cssH, getValue, getFormat, getMergeInfo, isSlave,
                     getComment, getValidation, getCondFormat, getRightInset,
                     getDiffFor, getSparkline,
-                    editing, range, marchAnts, marchPhase, pickerRect }
+                    editing, range, fillRange, marchAnts, marchPhase, pickerRect }
 
     _renderRegion(r0s, c0s, r1s, c1s, mainX, mainY, cssW - mainX, cssH - mainY, state)
     if (fr > 0) _renderRegion(0, c0s, fr - 1, c1s, mainX, COL_HEADER_H, cssW - mainX, frozH_, state)
@@ -60,10 +64,10 @@ export function createRenderer(ctx, geometry) {
     const { cssW, cssH, getValue, getFormat, getMergeInfo, isSlave,
             getComment, getValidation, getCondFormat, getRightInset,
             getDiffFor, getSparkline,
-            editing, range, marchAnts, marchPhase, pickerRect } = state
+            editing, range, fillRange, marchAnts, marchPhase, pickerRect } = state
     ctx.save()
     ctx.beginPath(); ctx.rect(clipX, clipY, clipW, clipH); ctx.clip()
-    if (!editing) selPainter.drawSelFill(range)
+    if (!editing) selPainter.drawSelFill(fillRange || range)
     gridPainter.drawGridLines(r0, c0, r1, c1, cssW, cssH)
     cellPainter.drawRegionCells(r0, c0, r1, c1, getValue, getFormat, getMergeInfo, isSlave, getComment, getValidation, getCondFormat, getRightInset, getDiffFor, getSparkline)
     cellPainter.drawRegionBorders(r0, c0, r1, c1, getFormat, getMergeInfo, isSlave)
@@ -77,6 +81,16 @@ export function createRenderer(ctx, geometry) {
       r0: Math.min(sel.r, selEnd.r), c0: Math.min(sel.c, selEnd.c),
       r1: Math.max(sel.r, selEnd.r), c1: Math.max(sel.c, selEnd.c),
     }
+  }
+
+  // Whole-line selections shade the full width/height regardless of where the
+  // anchor sits. Mirrors getSelRange()'s expansion in the grid module.
+  function _fillRange(range, selMode) {
+    if (!selMode || selMode === 'cell') return range
+    const r = { ...range }
+    if (selMode === 'row' || selMode === 'all') { r.c0 = 0; r.c1 = TOTAL_COLS - 1 }
+    if (selMode === 'col' || selMode === 'all') { r.r0 = 0; r.r1 = TOTAL_ROWS - 1 }
+    return r
   }
 
   return { render }

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -1020,28 +1020,10 @@
       </template>
     </Dialog>
 
-    <!-- Keyboard shortcut help — generated from frappe-ui's shortcut registry
-         (see useShortcuts.js), so it can never drift from the handlers. Read via
-         getActiveShortcuts() off the same 'frappe-ui' import that registers them,
-         so both share one registry instance. -->
-    <Dialog v-model="showShortcutsHelp" :options="{ title: 'Keyboard shortcuts', size: 'xl' }">
-      <template #body-content>
-        <div class="sn-help-grid">
-          <div v-for="(items, group) in shortcutGroups" :key="group" class="sn-help-group">
-            <div class="sn-help-title">{{ group }}</div>
-            <div v-for="s in items" :key="s.id.toString()" class="sn-help-row">
-              <span class="sn-help-label">{{ s.description }}</span>
-              <span class="sn-help-keys">
-                <template v-for="(k, i) in s.keys" :key="k">
-                  <KeyboardShortcut :combo="shortcutCombo(s, k)" />
-                  <span v-if="i < s.keys.length - 1" class="sn-help-or">or</span>
-                </template>
-              </span>
-            </div>
-          </div>
-        </div>
-      </template>
-    </Dialog>
+    <!-- Keyboard shortcut help — frappe-ui's KeyboardShortcutsModal, generated
+         from the shortcut registry populated by useShortcuts.js (via useShortcut),
+         so it can never drift from the handlers. -->
+    <KeyboardShortcutsModal v-model:open="showShortcutsHelp" title="Keyboard shortcuts" />
 
     <!-- Slicers — floating value-filter controls bound to a filter column -->
     <div v-for="sl in activeSlicers" :key="sl.id" class="sn-slicer"
@@ -1311,10 +1293,10 @@ import {
   FeatherIcon,
   FormControl,
   KeyboardShortcut,
+  KeyboardShortcutsModal,
   Spinner,
   TextInput,
   Tooltip,
-  getActiveShortcuts,
 } from 'frappe-ui'
 
 const props = defineProps({ id: { type: String, default: 'new' } })
@@ -1658,26 +1640,6 @@ const hyperlinkText        = ref('')
 const hyperlinkUrl         = ref('')
 const hasActiveHyperlink   = computed(() => !!activeFormat.value?.hyperlink)
 const showFormulas      = ref(false)
-
-// Keyboard-shortcut help is generated from frappe-ui's live shortcut registry
-// (populated by useShortcuts.js via useShortcut). Grouped by each shortcut's
-// `group`; read-only-gated shortcuts drop out automatically (getActiveShortcuts
-// filters by their condition).
-const activeShortcuts = getActiveShortcuts()
-const shortcutGroups = computed(() => {
-  const groups = {}
-  for (const s of activeShortcuts.value) (groups[s.group] ??= []).push(s)
-  return groups
-})
-// Build a KeyboardShortcut `combo` string ("Mod+Shift+K") from a registry entry.
-function shortcutCombo(s, key) {
-  const parts = []
-  if (s.ctrl) parts.push('Mod')
-  if (s.shift) parts.push('Shift')
-  if (s.alt) parts.push('Alt')
-  parts.push(key)
-  return parts.join('+')
-}
 
 const selectionStats    = ref(null)
 const isDirty           = ref(false)
@@ -6259,20 +6221,6 @@ function toggleShowFormulas() {
 .sn-ctx-menu :deep(button) { width:100%; justify-content:flex-start; padding-left:10px; padding-right:10px; }
 .sn-ctx-sep { height:1px; background:var(--outline-gray-1); margin:4px 0; border:none; }
 .sn-rename-err { margin:6px 0 0; font-size:12px; color:var(--ink-red-6); letter-spacing:.02em; }
-
-/* Keyboard-shortcut help dialog — two-column grid of grouped Espresso list rows. */
-.sn-help-grid    { display:grid; grid-template-columns:1fr 1fr; gap:20px 28px; }
-.sn-help-group   { display:flex; flex-direction:column; gap:2px; }
-.sn-help-title   { font-size:11px; font-weight:600; letter-spacing:.06em; color:var(--ink-gray-5); text-transform:uppercase; padding:0 4px; margin-bottom:6px; }
-.sn-help-row     { display:flex; align-items:center; justify-content:space-between; gap:12px; padding:6px 8px; border-radius:6px; }
-.sn-help-row:hover { background:var(--surface-gray-2); }
-.sn-help-label   { font-size:13px; letter-spacing:.02em; color:var(--ink-gray-9); }
-.sn-help-keys    { display:inline-flex; align-items:center; gap:6px; color:var(--ink-gray-7); }
-.sn-help-keys :deep(> div) {
-  padding:2px 6px; border:1px solid var(--outline-gray-2); border-radius:4px;
-  background:var(--surface-base); color:var(--ink-gray-8); min-height:20px;
-}
-.sn-help-or      { font-size:11px; letter-spacing:.02em; color:var(--ink-gray-5); }
 
 /* Sheet-tab drag visual — Espresso ink-gray-9 left edge on the drop target. */
 .sn-tab               { cursor:grab; }

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -1665,6 +1665,9 @@ const SHORTCUT_GROUPS = [
     { label: 'Jump to data-region edge',  combos: ['Mod+ArrowLeft'] },
     { label: 'Extend selection',          combos: ['Shift+ArrowRight'] },
     { label: 'Jump to start / end',       combos: ['Mod+Home', 'Mod+End'] },
+    { label: 'Scroll one screen',         combos: ['PageDown', 'PageUp'] },
+    { label: 'Select row / column',       combos: ['Shift+Space', 'Mod+Space'] },
+    { label: 'Select all',                combos: ['Mod+A', 'Mod+Shift+Space'] },
   ]},
   { title: 'Editing', items: [
     { label: 'Edit cell',                 combos: ['F2'] },
@@ -1675,6 +1678,9 @@ const SHORTCUT_GROUPS = [
     { label: 'Fill down / right',         combos: ['Mod+D', 'Mod+R'] },
     { label: 'Smart Fill from examples',  combos: ['Mod+E'] },
     { label: 'Cut / Copy / Paste',        combos: ['Mod+X', 'Mod+C', 'Mod+V'] },
+    { label: 'Paste values only',         combos: ['Mod+Shift+V'] },
+    { label: 'Insert rows / columns',     combos: ['Mod+Alt+='] },
+    { label: 'Delete rows / columns',     combos: ['Mod+Alt+-'] },
     { label: 'Undo / Redo',               combos: ['Mod+Z', 'Mod+Y'] },
     { label: 'Repeat last action',        combos: ['F4'] },
     { label: 'Add / edit comment',        combos: ['Shift+F2'] },
@@ -1684,6 +1690,9 @@ const SHORTCUT_GROUPS = [
     { label: 'Italic',                    combos: ['Mod+I'] },
     { label: 'Underline',                 combos: ['Mod+U'] },
     { label: 'Strikethrough',             combos: ['Mod+Shift+X'] },
+    { label: 'Number / percent',          combos: ['Mod+Shift+1', 'Mod+Shift+5'] },
+    { label: 'Time / date',               combos: ['Mod+Shift+2', 'Mod+Shift+3'] },
+    { label: 'Currency',                  combos: ['Mod+Shift+4'] },
   ]},
   { title: 'View / Tools', items: [
     { label: 'Command palette',           combos: ['Mod+K'] },
@@ -3922,6 +3931,27 @@ function fillRight() {
 // hide its Paste-Special entries without polling.
 const clipboardHas = ref(false)
 
+// Keyboard-driven insert/delete of rows or columns (Ctrl+Alt+= / Ctrl+Alt+-).
+// The context-menu handlers key off contextMenu.target{Row,Col}, which only a
+// right-click normally populates — so seed it from the live selection first. A
+// whole-column selection acts on columns; anything else acts on rows (matching
+// Google Sheets). The delete/insert span (N selected lines) flows from the
+// selection the same way the right-click menu computes it.
+function _insertRowsColsFromSelection() {
+  if (readOnly.value) return
+  const s = grid?.getSelection?.()
+  if (!s) return
+  if (s.mode === 'col') { contextMenu.targetCol = s.c0; doInsertCol(false, s.c1 - s.c0 + 1) }
+  else                  { contextMenu.targetRow = s.r0; doInsertRow(false, s.r1 - s.r0 + 1) }
+}
+function _deleteRowsColsFromSelection() {
+  if (readOnly.value) return
+  const s = grid?.getSelection?.()
+  if (!s) return
+  if (s.mode === 'col') { contextMenu.targetCol = s.c0; doDeleteCol() }
+  else                  { contextMenu.targetRow = s.r0; doDeleteRow() }
+}
+
 const { onGlobalKey } = useShortcuts({
   formulaInputEl:           () => formulaInputRef.value,
   undo, redo, onSave, toggleFmt, repeatLast, toggleShowFormulas,
@@ -3933,6 +3963,10 @@ const { onGlobalKey } = useShortcuts({
   clipboard, clipboardHas, setMarchingAnts: (v) => grid?.setMarchingAnts(v),
   fillDown, fillRight,
   runSmartFill,
+  insertRowsCols:    _insertRowsColsFromSelection,
+  deleteRowsCols:    _deleteRowsColsFromSelection,
+  applyNumberFormat: onNumberFormatChange,
+  pasteValues:       () => doPasteSpecial('values'),
   readOnly: () => readOnly.value,
 })
 

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -125,7 +125,7 @@
                 size="sm" icon="clock"
                 tooltip="Version history"
                 @click="vhOpen ? closeVersionHistory() : (notesPanel.open = false, openVersionHistory())" />
-        <Button variant="ghost" size="sm" icon="help-circle" tooltip="Keyboard shortcuts (?)" @click="showShortcutsHelp = true" />
+        <Button variant="ghost" size="sm" icon="help-circle" tooltip="Keyboard shortcuts" @click="showShortcutsHelp = true" />
         <span class="sn-topbar-divider" aria-hidden="true" />
         <!-- Presence avatars — other users currently in the workbook.
              Outline = their cursor color; tooltip says which sub-sheet
@@ -1020,19 +1020,21 @@
       </template>
     </Dialog>
 
-    <!-- Keyboard shortcut help (?) — uses Frappe UI's KeyboardShortcut for the
-         key chips so modifiers render as proper Mac glyphs and look native. -->
+    <!-- Keyboard shortcut help — generated from frappe-ui's shortcut registry
+         (see useShortcuts.js), so it can never drift from the handlers. Read via
+         getActiveShortcuts() off the same 'frappe-ui' import that registers them,
+         so both share one registry instance. -->
     <Dialog v-model="showShortcutsHelp" :options="{ title: 'Keyboard shortcuts', size: 'xl' }">
       <template #body-content>
         <div class="sn-help-grid">
-          <div v-for="g in SHORTCUT_GROUPS" :key="g.title" class="sn-help-group">
-            <div class="sn-help-title">{{ g.title }}</div>
-            <div v-for="s in g.items" :key="s.label" class="sn-help-row">
-              <span class="sn-help-label">{{ s.label }}</span>
+          <div v-for="(items, group) in shortcutGroups" :key="group" class="sn-help-group">
+            <div class="sn-help-title">{{ group }}</div>
+            <div v-for="s in items" :key="s.id.toString()" class="sn-help-row">
+              <span class="sn-help-label">{{ s.description }}</span>
               <span class="sn-help-keys">
-                <template v-for="(combo, i) in s.combos" :key="combo">
-                  <KeyboardShortcut :combo="combo" />
-                  <span v-if="i < s.combos.length - 1" class="sn-help-or">or</span>
+                <template v-for="(k, i) in s.keys" :key="k">
+                  <KeyboardShortcut :combo="shortcutCombo(s, k)" />
+                  <span v-if="i < s.keys.length - 1" class="sn-help-or">or</span>
                 </template>
               </span>
             </div>
@@ -1312,6 +1314,7 @@ import {
   Spinner,
   TextInput,
   Tooltip,
+  getActiveShortcuts,
 } from 'frappe-ui'
 
 const props = defineProps({ id: { type: String, default: 'new' } })
@@ -1656,56 +1659,26 @@ const hyperlinkUrl         = ref('')
 const hasActiveHyperlink   = computed(() => !!activeFormat.value?.hyperlink)
 const showFormulas      = ref(false)
 
-// Each row's `combos` is an array of KeyboardShortcut-compatible strings —
-// the dialog renders them as `<KeyboardShortcut :combo="…"/>` chips joined
-// by a small "or" separator when there's more than one.
-const SHORTCUT_GROUPS = [
-  { title: 'Navigation', items: [
-    { label: 'Move selection',            combos: ['ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown'] },
-    { label: 'Jump to data-region edge',  combos: ['Mod+ArrowLeft'] },
-    { label: 'Extend selection',          combos: ['Shift+ArrowRight'] },
-    { label: 'Jump to start / end',       combos: ['Mod+Home', 'Mod+End'] },
-    { label: 'Scroll one screen',         combos: ['PageDown', 'PageUp'] },
-    { label: 'Select row / column',       combos: ['Shift+Space', 'Mod+Space'] },
-    { label: 'Select all',                combos: ['Mod+A', 'Mod+Shift+Space'] },
-  ]},
-  { title: 'Editing', items: [
-    { label: 'Edit cell',                 combos: ['F2'] },
-    { label: 'Clear cell',                combos: ['Delete', 'Backspace'] },
-    { label: 'Commit + move down',        combos: ['Enter'] },
-    { label: 'Commit + move right',       combos: ['Tab'] },
-    { label: 'Cancel edit',               combos: ['Escape'] },
-    { label: 'Fill down / right',         combos: ['Mod+D', 'Mod+R'] },
-    { label: 'Smart Fill from examples',  combos: ['Mod+E'] },
-    { label: 'Cut / Copy / Paste',        combos: ['Mod+X', 'Mod+C', 'Mod+V'] },
-    { label: 'Paste values only',         combos: ['Mod+Shift+V'] },
-    { label: 'Insert rows / columns',     combos: ['Mod+Alt+='] },
-    { label: 'Delete rows / columns',     combos: ['Mod+Alt+-'] },
-    { label: 'Undo / Redo',               combos: ['Mod+Z', 'Mod+Y'] },
-    { label: 'Repeat last action',        combos: ['F4'] },
-    { label: 'Add / edit comment',        combos: ['Shift+F2'] },
-  ]},
-  { title: 'Formatting', items: [
-    { label: 'Bold',                      combos: ['Mod+B'] },
-    { label: 'Italic',                    combos: ['Mod+I'] },
-    { label: 'Underline',                 combos: ['Mod+U'] },
-    { label: 'Strikethrough',             combos: ['Mod+Shift+X'] },
-    { label: 'Number / percent',          combos: ['Mod+Shift+1', 'Mod+Shift+5'] },
-    { label: 'Time / date',               combos: ['Mod+Shift+2', 'Mod+Shift+3'] },
-    { label: 'Currency',                  combos: ['Mod+Shift+4'] },
-  ]},
-  { title: 'View / Tools', items: [
-    { label: 'Command palette',           combos: ['Mod+K'] },
-    { label: 'Find & replace',            combos: ['Mod+F'] },
-    { label: 'Save',                      combos: ['Mod+S'] },
-    { label: 'Show formulas',             combos: ['Mod+`'] },
-    { label: 'Insert hyperlink',          combos: ['Mod+L'] },
-    { label: 'Quick filter on column',    combos: ['Alt+ArrowDown'] },
-    { label: 'Version history',           combos: ['Mod+Alt+Shift+H'] },
-    { label: 'Zoom in / out / reset',     combos: ['Mod+=', 'Mod+-', 'Mod+0'] },
-    { label: 'Shortcut help',             combos: ['?'] },
-  ]},
-]
+// Keyboard-shortcut help is generated from frappe-ui's live shortcut registry
+// (populated by useShortcuts.js via useShortcut). Grouped by each shortcut's
+// `group`; read-only-gated shortcuts drop out automatically (getActiveShortcuts
+// filters by their condition).
+const activeShortcuts = getActiveShortcuts()
+const shortcutGroups = computed(() => {
+  const groups = {}
+  for (const s of activeShortcuts.value) (groups[s.group] ??= []).push(s)
+  return groups
+})
+// Build a KeyboardShortcut `combo` string ("Mod+Shift+K") from a registry entry.
+function shortcutCombo(s, key) {
+  const parts = []
+  if (s.ctrl) parts.push('Mod')
+  if (s.shift) parts.push('Shift')
+  if (s.alt) parts.push('Alt')
+  parts.push(key)
+  return parts.join('+')
+}
+
 const selectionStats    = ref(null)
 const isDirty           = ref(false)
 const isPaintingFormat  = ref(false)
@@ -3955,7 +3928,7 @@ function _deleteRowsColsFromSelection() {
 const { onGlobalKey } = useShortcuts({
   formulaInputEl:           () => formulaInputRef.value,
   undo, redo, onSave, toggleFmt, repeatLast, toggleShowFormulas,
-  showFindReplace, showShortcutsHelp,
+  showFindReplace,
   openVersionHistory, openHyperlinkDialog, openCommentPanel, openQuickFilterForActive,
   zoomBy, resetZoom,
   commentPanel, dropdownPanel, splitText,

--- a/frontend/src/apps/sheets/components/SheetEditor/useShortcuts.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useShortcuts.js
@@ -1,5 +1,18 @@
+import { useShortcut } from 'frappe-ui'
+
 /**
  * Keyboard shortcut dispatch for SheetEditor.
+ *
+ * App-level shortcuts are registered through frappe-ui's `useShortcut` registry
+ * so they are the single source of truth for the `<KeyboardShortcutsModal>` — the
+ * shortcut description lives next to its handler, so the help dialog can never
+ * drift. Grid navigation/edit shortcuts stay in the canvas (they need the canvas
+ * element + edit-mode state); they're registered here as *display-only* entries
+ * (no handler, `preventDefault: false`) purely so the modal lists them too.
+ *
+ * A small residual `onGlobalKey` handles the shortcuts frappe-ui's `e.key`
+ * matcher cannot: the context-sensitive Escape cascade, and the `e.code`-based
+ * combos (macOS rewrites Alt+= → ≠ and Shift+<digit> → a symbol).
  *
  * @param {{
  *   formulaInputEl: () => HTMLElement | null,
@@ -7,7 +20,6 @@
  *   toggleFmt: (fmt: string) => void, repeatLast: () => void,
  *   toggleShowFormulas: () => void,
  *   showFindReplace: import('vue').Ref<boolean>,
- *   showShortcutsHelp: import('vue').Ref<boolean>,
  *   openVersionHistory: () => void, openHyperlinkDialog: () => void,
  *   openCommentPanel: () => void, openQuickFilterForActive: () => void,
  *   zoomBy: (d: number) => void, resetZoom: () => void,
@@ -41,7 +53,7 @@ const NUMBER_FORMAT_KEYS = {
 export function useShortcuts(actions) {
   const {
     formulaInputEl, undo, redo, onSave, toggleFmt, repeatLast,
-    toggleShowFormulas, showFindReplace, showShortcutsHelp,
+    toggleShowFormulas, showFindReplace,
     openVersionHistory, openHyperlinkDialog, openCommentPanel, openQuickFilterForActive,
     zoomBy, resetZoom,
     commentPanel, dropdownPanel, splitText, revertSplitPreview, closeSplit,
@@ -49,98 +61,123 @@ export function useShortcuts(actions) {
     fillDown, fillRight,
     runSmartFill,
     insertRowsCols, deleteRowsCols, applyNumberFormat, pasteValues,
+    // Optional getter — true for a view-only viewer (guest / read-only share).
+    // Mutating shortcuts carry `condition: notReadOnly` so they're both inert
+    // AND hidden from the modal while read-only; pure view shortcuts stay live.
     readOnly = () => false,
   } = actions
+
+  const notReadOnly = () => !readOnly()
 
   function _isInInput() {
     const ae = document.activeElement
     return ae?.tagName === 'INPUT' && ae !== formulaInputEl?.()
   }
 
-  function _handleFormatKeys(e, mod, inInput) {
-    if (mod && e.key === 'z' && !e.shiftKey)                              { e.preventDefault(); undo();                         return true }
-    if (mod && (e.key === 'y' || (e.shiftKey && e.key === 'z')))          { e.preventDefault(); redo();                         return true }
-    if (mod && e.key === 'b' && !inInput)                                  { e.preventDefault(); toggleFmt('bold');              return true }
-    if (mod && e.key === 'i' && !inInput)                                  { e.preventDefault(); toggleFmt('italic');            return true }
-    if (mod && e.key === 'u' && !inInput)                                  { e.preventDefault(); toggleFmt('underline');         return true }
-    if (mod && e.shiftKey && (e.key === 'x' || e.key === 'X') && !inInput) {
-      e.preventDefault(); toggleFmt('strikethrough'); return true
-    }
-    if (e.key === 'F4' && !inInput)                                        { e.preventDefault(); repeatLast();                   return true }
-    return false
-  }
+  // ── Registry (source of truth for the modal) ─────────────────────────────────
+  // Shortcuts frappe-ui can match on `e.key`, registered with handler + label.
+  useShortcut([
+    // View / tools — available even in read-only.
+    { key: 's',  ctrl: true, description: 'Save',            group: 'View', handler: onSave },
+    { key: 'f',  ctrl: true, description: 'Find & replace',  group: 'View', handler: () => { showFindReplace.value = true } },
+    { key: '`',  ctrl: true, description: 'Show formulas',   group: 'View', handler: toggleShowFormulas },
+    { key: '=',  ctrl: true, description: 'Zoom in',         group: 'View', handler: () => zoomBy(+0.1) },
+    { key: '+',  ctrl: true, description: 'Zoom in',         group: 'View', handler: () => zoomBy(+0.1) },
+    { key: '-',  ctrl: true, description: 'Zoom out',        group: 'View', handler: () => zoomBy(-0.1) },
+    { key: '0',  ctrl: true, description: 'Reset zoom',      group: 'View', handler: resetZoom },
 
-  function _handleViewKeys(e, mod, inInput) {
-    if (mod && (e.key === '`' || e.code === 'Backquote') && !inInput) {
-      e.preventDefault(); toggleShowFormulas(); return true
-    }
-    if (mod && e.key === 's')                                              { e.preventDefault(); onSave();                       return true }
-    if (mod && e.key === 'f')                                              { e.preventDefault(); showFindReplace.value = true;   return true }
-    // Alt is excluded so Mod+Alt+= / Mod+Alt+- fall through to insert/delete
-    // rows below rather than being swallowed as zoom.
-    if (mod && !e.altKey && (e.key === '=' || e.key === '+'))              { e.preventDefault(); zoomBy(+0.1);                   return true }
-    if (mod && !e.altKey && e.key === '-')                                 { e.preventDefault(); zoomBy(-0.1);                   return true }
-    if (mod && e.key === '0')                                              { e.preventDefault(); resetZoom();                    return true }
-    if (!mod && !inInput && e.key === '?')                                 { e.preventDefault(); showShortcutsHelp.value = true; return true }
-    return false
-  }
+    // Editing — mutating, so hidden + inert while read-only.
+    { key: 'z', ctrl: true,              description: 'Undo',                    group: 'Editing', condition: notReadOnly, handler: undo },
+    { key: 'z', ctrl: true, shift: true, description: 'Redo',                    group: 'Editing', condition: notReadOnly, handler: redo },
+    { key: 'y', ctrl: true,              description: 'Redo',                    group: 'Editing', condition: notReadOnly, handler: redo },
+    { key: 'F4',                         description: 'Repeat last action',      group: 'Editing', condition: notReadOnly, handler: repeatLast },
+    { key: 'd', ctrl: true,              description: 'Fill down',               group: 'Editing', condition: notReadOnly, handler: fillDown },
+    { key: 'r', ctrl: true,              description: 'Fill right',              group: 'Editing', condition: notReadOnly, handler: fillRight },
+    { key: 'e', ctrl: true,              description: 'Smart Fill from examples', group: 'Editing', condition: notReadOnly, handler: () => runSmartFill?.() },
+    { key: 'v', ctrl: true, shift: true, description: 'Paste values only',       group: 'Editing', condition: notReadOnly, handler: () => pasteValues?.() },
+    { key: 'l', ctrl: true,              description: 'Insert hyperlink',        group: 'Editing', condition: notReadOnly, handler: openHyperlinkDialog },
+    { key: 'F2', shift: true,            description: 'Add / edit comment',      group: 'Editing', condition: notReadOnly, handler: openCommentPanel },
+    { key: 'ArrowDown', alt: true,       description: 'Quick filter on column',  group: 'Editing', condition: notReadOnly, handler: openQuickFilterForActive },
+    { key: 'h', ctrl: true, alt: true, shift: true, description: 'Version history', group: 'Editing', condition: notReadOnly, handler: openVersionHistory },
 
-  function _handleNavKeys(e, mod, inInput) {
-    if (mod && e.altKey && e.shiftKey && (e.key === 'h' || e.key === 'H')) {
-      e.preventDefault(); openVersionHistory(); return true
-    }
-    if (mod && e.key === 'l' && !inInput)                                  { e.preventDefault(); openHyperlinkDialog();          return true }
-    if (e.shiftKey && e.key === 'F2' && !inInput)                          { e.preventDefault(); openCommentPanel();             return true }
-    if (e.altKey && e.key === 'ArrowDown' && !inInput)                     { e.preventDefault(); openQuickFilterForActive();     return true }
-    return false
-  }
+    // Formatting — mutating.
+    { key: 'b', ctrl: true,              description: 'Bold',          group: 'Formatting', condition: notReadOnly, handler: () => toggleFmt('bold') },
+    { key: 'i', ctrl: true,              description: 'Italic',        group: 'Formatting', condition: notReadOnly, handler: () => toggleFmt('italic') },
+    { key: 'u', ctrl: true,              description: 'Underline',     group: 'Formatting', condition: notReadOnly, handler: () => toggleFmt('underline') },
+    { key: 'x', ctrl: true, shift: true, description: 'Strikethrough', group: 'Formatting', condition: notReadOnly, handler: () => toggleFmt('strikethrough') },
+  ])
 
-  function _handleEscape(e, inInput) {
-    if (e.key !== 'Escape' || inInput) return false
-    if (commentPanel.open)   { commentPanel.open  = false; return true }
-    if (dropdownPanel.open)  { dropdownPanel.open = false; return true }
-    if (splitText.open)      { revertSplitPreview(); closeSplit(); return true }
-    if (clipboard.hasData()) { clipboard.clear(); clipboardHas.value = false; setMarchingAnts(null); return true }
-    return false
-  }
+  // ── Display-only entries ─────────────────────────────────────────────────────
+  // Real handlers live in the grid canvas, the native clipboard events, or the
+  // residual onGlobalKey below. `preventDefault: false` + no handler keeps them
+  // passive — they never intercept a keystroke, they just populate the modal.
+  useShortcut([
+    // Navigation (grid canvas)
+    { key: 'ArrowUp',    description: 'Move selection', group: 'Navigation', preventDefault: false },
+    { key: 'ArrowDown',  description: 'Move selection', group: 'Navigation', preventDefault: false },
+    { key: 'ArrowLeft',  description: 'Move selection', group: 'Navigation', preventDefault: false },
+    { key: 'ArrowRight', description: 'Move selection', group: 'Navigation', preventDefault: false },
+    { key: 'ArrowRight', shift: true, description: 'Extend selection',       group: 'Navigation', preventDefault: false },
+    { key: 'ArrowLeft',  ctrl: true,  description: 'Jump to data-region edge', group: 'Navigation', preventDefault: false },
+    { key: 'Home',       ctrl: true,  description: 'Jump to start / end',    group: 'Navigation', preventDefault: false },
+    { key: 'End',        ctrl: true,  description: 'Jump to start / end',    group: 'Navigation', preventDefault: false },
+    { key: 'PageDown',   description: 'Scroll one screen', group: 'Navigation', preventDefault: false },
+    { key: 'PageUp',     description: 'Scroll one screen', group: 'Navigation', preventDefault: false },
 
+    // Selection (grid canvas)
+    { key: ' ', shift: true,             description: 'Select row',          group: 'Selection', preventDefault: false },
+    { key: ' ', ctrl: true,              description: 'Select column',       group: 'Selection', preventDefault: false },
+    { key: 'a', ctrl: true,              description: 'Select data / all',   group: 'Selection', preventDefault: false },
+    { key: ' ', ctrl: true, shift: true, description: 'Select entire sheet', group: 'Selection', preventDefault: false },
+
+    // Editing (grid canvas / native clipboard / residual handler)
+    { key: 'F2',                         description: 'Edit cell',            group: 'Editing', preventDefault: false },
+    { key: 'Delete',                     description: 'Clear cell',           group: 'Editing', preventDefault: false },
+    { key: 'Backspace',                  description: 'Clear cell',           group: 'Editing', preventDefault: false },
+    { key: 'Enter',                      description: 'Commit + move down',   group: 'Editing', preventDefault: false },
+    { key: 'Tab',                        description: 'Commit + move right',  group: 'Editing', preventDefault: false },
+    { key: 'Enter', alt: true,           description: 'New line in cell',     group: 'Editing', condition: notReadOnly, preventDefault: false },
+    { key: 'c', ctrl: true,              description: 'Copy',                 group: 'Editing', preventDefault: false },
+    { key: 'x', ctrl: true,              description: 'Cut',                  group: 'Editing', condition: notReadOnly, preventDefault: false },
+    { key: 'v', ctrl: true,              description: 'Paste',                group: 'Editing', condition: notReadOnly, preventDefault: false },
+    { key: '=', ctrl: true, alt: true,   description: 'Insert rows / columns', group: 'Editing', condition: notReadOnly, preventDefault: false },
+    { key: '-', ctrl: true, alt: true,   description: 'Delete rows / columns', group: 'Editing', condition: notReadOnly, preventDefault: false },
+
+    // Number formats (Ctrl+Shift+1..5) — handled via e.code below; here for display.
+    { key: '1', ctrl: true, shift: true, description: 'Format as number',   group: 'Formatting', condition: notReadOnly, preventDefault: false },
+    { key: '2', ctrl: true, shift: true, description: 'Format as time',     group: 'Formatting', condition: notReadOnly, preventDefault: false },
+    { key: '3', ctrl: true, shift: true, description: 'Format as date',     group: 'Formatting', condition: notReadOnly, preventDefault: false },
+    { key: '4', ctrl: true, shift: true, description: 'Format as currency', group: 'Formatting', condition: notReadOnly, preventDefault: false },
+    { key: '5', ctrl: true, shift: true, description: 'Format as percent',  group: 'Formatting', condition: notReadOnly, preventDefault: false },
+  ])
+
+  // ── Residual handler (window keydown) ────────────────────────────────────────
+  // Everything frappe-ui's e.key matcher can't do: the Escape cascade and the
+  // e.code-based combos.
   function onGlobalKey(e) {
-    const mod     = e.metaKey || e.ctrlKey
     const inInput = _isInInput()
-    // Read-only viewers: only the non-mutating shortcuts stay live (find,
-    // formulas toggle, zoom, help, Escape). Format/undo/redo, nav-edits
-    // (hyperlink, comment, quick-filter), and fill/smart-fill all mutate the
-    // doc, so skip them — they'd set isDirty for a save that can never land.
-    const ro = readOnly()
-    if (!ro && _handleFormatKeys(e, mod, inInput)) return
-    if (_handleViewKeys(e, mod, inInput))          return
-    if (!ro && _handleNavKeys(e, mod, inInput))    return
-    if (_handleEscape(e, inInput))                 return
-    if (ro) return
-    if (mod && e.key === 'd' && !inInput) { e.preventDefault(); fillDown();  return }
-    if (mod && e.key === 'r' && !inInput) { e.preventDefault(); fillRight(); return }
-    // Cmd/Ctrl+E — Smart Fill. Matches Excel's Flash Fill shortcut. Detects
-    // a pattern from the user's example values in the selected column and
-    // fills the remaining empty cells in the selection.
-    if (mod && (e.key === 'e' || e.key === 'E') && !inInput) {
-      e.preventDefault(); runSmartFill?.(); return
+
+    // Escape — context-sensitive close (first match wins). Kept custom because
+    // it's a cascade, not a single action; while editing a cell the canvas owns
+    // Escape (cancel edit) and focus is in the editor, so inInput short-circuits.
+    if (e.key === 'Escape' && !inInput) {
+      if (commentPanel.open)   { commentPanel.open  = false; return }
+      if (dropdownPanel.open)  { dropdownPanel.open = false; return }
+      if (splitText.open)      { revertSplitPreview(); closeSplit(); return }
+      if (clipboard.hasData()) { clipboard.clear(); clipboardHas.value = false; setMarchingAnts(null); return }
+      return
     }
-    // Mod+Alt+= / Mod+Alt+-  — insert / delete rows or columns. Match on
-    // e.code: with Alt held, macOS rewrites e.key ('=' → '≠', '-' → '–'), so
-    // the physical key is the only reliable signal here.
-    if (mod && e.altKey && e.code === 'Equal' && !inInput) {
-      e.preventDefault(); insertRowsCols?.(); return
-    }
-    if (mod && e.altKey && e.code === 'Minus' && !inInput) {
-      e.preventDefault(); deleteRowsCols?.(); return
-    }
-    // Mod+Shift+1..5 — apply a number format to the selection (GS parity).
-    if (mod && e.shiftKey && !inInput && NUMBER_FORMAT_KEYS[e.code]) {
+
+    if (readOnly() || inInput) return
+    const mod = e.metaKey || e.ctrlKey
+
+    // Mod+Alt+= / Mod+Alt+-  — insert / delete rows or columns. Match on e.code:
+    // with Alt held, macOS rewrites e.key ('=' → '≠', '-' → '–').
+    if (mod && e.altKey && e.code === 'Equal') { e.preventDefault(); insertRowsCols?.(); return }
+    if (mod && e.altKey && e.code === 'Minus') { e.preventDefault(); deleteRowsCols?.(); return }
+    // Mod+Shift+1..5 — number formats. Match on e.code so shifted digits resolve.
+    if (mod && e.shiftKey && NUMBER_FORMAT_KEYS[e.code]) {
       e.preventDefault(); applyNumberFormat?.(NUMBER_FORMAT_KEYS[e.code]); return
-    }
-    // Mod+Shift+V — paste values only (drops formatting / formulas).
-    if (mod && e.shiftKey && (e.key === 'v' || e.key === 'V') && !inInput) {
-      e.preventDefault(); pasteValues?.(); return
     }
   }
 

--- a/frontend/src/apps/sheets/components/SheetEditor/useShortcuts.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useShortcuts.js
@@ -20,9 +20,24 @@
  *   setMarchingAnts: (v: null) => void,
  *   fillDown: () => void, fillRight: () => void,
  *   runSmartFill: () => void,
+ *   insertRowsCols: () => void, deleteRowsCols: () => void,
+ *   applyNumberFormat: (fmt: string) => void, pasteValues: () => void,
  *   readOnly?: () => boolean,
  * }} actions
  */
+
+// Ctrl/Cmd+Shift+<digit> → number-format key, matching Google Sheets' 1-6 row.
+// Keyed by KeyboardEvent.code so shifted digits ('!', '@', …) still resolve.
+// Exponent/scientific (GS's Ctrl+Shift+6) is intentionally absent — the format
+// engine has no scientific renderer yet, so there's nothing correct to apply.
+const NUMBER_FORMAT_KEYS = {
+  Digit1: 'number',
+  Digit2: 'time',
+  Digit3: 'date',
+  Digit4: 'currency:USD:2',
+  Digit5: 'percentage',
+}
+
 export function useShortcuts(actions) {
   const {
     formulaInputEl, undo, redo, onSave, toggleFmt, repeatLast,
@@ -33,6 +48,7 @@ export function useShortcuts(actions) {
     clipboard, clipboardHas, setMarchingAnts,
     fillDown, fillRight,
     runSmartFill,
+    insertRowsCols, deleteRowsCols, applyNumberFormat, pasteValues,
     readOnly = () => false,
   } = actions
 
@@ -60,8 +76,10 @@ export function useShortcuts(actions) {
     }
     if (mod && e.key === 's')                                              { e.preventDefault(); onSave();                       return true }
     if (mod && e.key === 'f')                                              { e.preventDefault(); showFindReplace.value = true;   return true }
-    if (mod && (e.key === '=' || e.key === '+'))                           { e.preventDefault(); zoomBy(+0.1);                   return true }
-    if (mod && e.key === '-')                                              { e.preventDefault(); zoomBy(-0.1);                   return true }
+    // Alt is excluded so Mod+Alt+= / Mod+Alt+- fall through to insert/delete
+    // rows below rather than being swallowed as zoom.
+    if (mod && !e.altKey && (e.key === '=' || e.key === '+'))              { e.preventDefault(); zoomBy(+0.1);                   return true }
+    if (mod && !e.altKey && e.key === '-')                                 { e.preventDefault(); zoomBy(-0.1);                   return true }
     if (mod && e.key === '0')                                              { e.preventDefault(); resetZoom();                    return true }
     if (!mod && !inInput && e.key === '?')                                 { e.preventDefault(); showShortcutsHelp.value = true; return true }
     return false
@@ -106,6 +124,23 @@ export function useShortcuts(actions) {
     // fills the remaining empty cells in the selection.
     if (mod && (e.key === 'e' || e.key === 'E') && !inInput) {
       e.preventDefault(); runSmartFill?.(); return
+    }
+    // Mod+Alt+= / Mod+Alt+-  — insert / delete rows or columns. Match on
+    // e.code: with Alt held, macOS rewrites e.key ('=' → '≠', '-' → '–'), so
+    // the physical key is the only reliable signal here.
+    if (mod && e.altKey && e.code === 'Equal' && !inInput) {
+      e.preventDefault(); insertRowsCols?.(); return
+    }
+    if (mod && e.altKey && e.code === 'Minus' && !inInput) {
+      e.preventDefault(); deleteRowsCols?.(); return
+    }
+    // Mod+Shift+1..5 — apply a number format to the selection (GS parity).
+    if (mod && e.shiftKey && !inInput && NUMBER_FORMAT_KEYS[e.code]) {
+      e.preventDefault(); applyNumberFormat?.(NUMBER_FORMAT_KEYS[e.code]); return
+    }
+    // Mod+Shift+V — paste values only (drops formatting / formulas).
+    if (mod && e.shiftKey && (e.key === 'v' || e.key === 'V') && !inInput) {
+      e.preventDefault(); pasteValues?.(); return
     }
   }
 

--- a/frontend/src/apps/sheets/components/SheetEditor/useShortcuts.test.ts
+++ b/frontend/src/apps/sheets/components/SheetEditor/useShortcuts.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+
+// frappe-ui's barrel drags in resources that don't resolve under vitest, and we
+// only care that the right shortcut *configs* get registered — so mock
+// `useShortcut` to capture every config it's handed.
+const { registered } = vi.hoisted(() => ({ registered: [] }))
+vi.mock('frappe-ui', () => ({
+  useShortcut: (configs) => registered.push(...(Array.isArray(configs) ? configs : [configs])),
+}))
+
+import { useShortcuts } from './useShortcuts.js'
+
+// In node env there is no `document`, so stub activeElement per test.
+function stubActiveElement(tagName = 'DIV') {
+  Object.defineProperty(global, 'document', {
+    value: { activeElement: { tagName, value: '' } },
+    writable: true, configurable: true,
+  })
+}
+
+function makeActions(overrides = {}) {
+  return {
+    formulaInputEl:         () => null,
+    undo:                   vi.fn(),
+    redo:                   vi.fn(),
+    onSave:                 vi.fn(),
+    toggleFmt:              vi.fn(),
+    repeatLast:             vi.fn(),
+    toggleShowFormulas:     vi.fn(),
+    showFindReplace:        ref(false),
+    openVersionHistory:     vi.fn(),
+    openHyperlinkDialog:    vi.fn(),
+    openCommentPanel:       vi.fn(),
+    openQuickFilterForActive: vi.fn(),
+    zoomBy:                 vi.fn(),
+    resetZoom:              vi.fn(),
+    commentPanel:           { open: false },
+    dropdownPanel:          { open: false },
+    splitText:              { open: false },
+    revertSplitPreview:     vi.fn(),
+    closeSplit:             vi.fn(),
+    clipboard:              { hasData: vi.fn(() => false), clear: vi.fn() },
+    clipboardHas:           ref(false),
+    setMarchingAnts:        vi.fn(),
+    fillDown:               vi.fn(),
+    fillRight:              vi.fn(),
+    runSmartFill:           vi.fn(),
+    insertRowsCols:         vi.fn(),
+    deleteRowsCols:         vi.fn(),
+    applyNumberFormat:      vi.fn(),
+    pasteValues:            vi.fn(),
+    readOnly:               () => false,
+    ...overrides,
+  }
+}
+
+function key(opts = {}) {
+  return {
+    key: '', code: '', metaKey: false, ctrlKey: false, shiftKey: false, altKey: false,
+    preventDefault: vi.fn(),
+    ...opts,
+  }
+}
+
+// Find a registered shortcut with a real handler by combo, then fire it.
+function find(combo) {
+  return registered.find(c =>
+    c.key === combo.key &&
+    !!c.ctrl === !!combo.ctrl && !!c.shift === !!combo.shift && !!c.alt === !!combo.alt &&
+    typeof c.handler === 'function')
+}
+function fire(combo) { find(combo)?.handler?.() }
+
+beforeEach(() => {
+  registered.length = 0
+  stubActiveElement('DIV')
+})
+
+// ── Registered shortcuts (frappe-ui useShortcut) ─────────────────────────────
+
+describe('registered shortcuts', () => {
+  it('Mod+Z registers undo', () => {
+    const a = makeActions(); useShortcuts(a)
+    fire({ key: 'z', ctrl: true }); expect(a.undo).toHaveBeenCalled()
+  })
+  it('Mod+Y and Mod+Shift+Z register redo', () => {
+    const a = makeActions(); useShortcuts(a)
+    fire({ key: 'y', ctrl: true }); fire({ key: 'z', ctrl: true, shift: true })
+    expect(a.redo).toHaveBeenCalledTimes(2)
+  })
+  it('Mod+B registers bold', () => {
+    const a = makeActions(); useShortcuts(a)
+    fire({ key: 'b', ctrl: true }); expect(a.toggleFmt).toHaveBeenCalledWith('bold')
+  })
+  it('Mod+Shift+X registers strikethrough', () => {
+    const a = makeActions(); useShortcuts(a)
+    fire({ key: 'x', ctrl: true, shift: true }); expect(a.toggleFmt).toHaveBeenCalledWith('strikethrough')
+  })
+  it('F4 registers repeat', () => {
+    const a = makeActions(); useShortcuts(a)
+    fire({ key: 'F4' }); expect(a.repeatLast).toHaveBeenCalled()
+  })
+  it('Mod+S registers save', () => {
+    const a = makeActions(); useShortcuts(a)
+    fire({ key: 's', ctrl: true }); expect(a.onSave).toHaveBeenCalled()
+  })
+  it('Mod+F opens find/replace', () => {
+    const a = makeActions(); useShortcuts(a)
+    fire({ key: 'f', ctrl: true }); expect(a.showFindReplace.value).toBe(true)
+  })
+  it('Mod+= / Mod+- / Mod+0 register zoom', () => {
+    const a = makeActions(); useShortcuts(a)
+    fire({ key: '=', ctrl: true }); expect(a.zoomBy).toHaveBeenCalledWith(+0.1)
+    fire({ key: '-', ctrl: true }); expect(a.zoomBy).toHaveBeenCalledWith(-0.1)
+    fire({ key: '0', ctrl: true }); expect(a.resetZoom).toHaveBeenCalled()
+  })
+  it('Mod+L / Shift+F2 / Alt+ArrowDown register nav-edits', () => {
+    const a = makeActions(); useShortcuts(a)
+    fire({ key: 'l', ctrl: true });        expect(a.openHyperlinkDialog).toHaveBeenCalled()
+    fire({ key: 'F2', shift: true });       expect(a.openCommentPanel).toHaveBeenCalled()
+    fire({ key: 'ArrowDown', alt: true });  expect(a.openQuickFilterForActive).toHaveBeenCalled()
+  })
+  it('Mod+Alt+Shift+H registers version history', () => {
+    const a = makeActions(); useShortcuts(a)
+    fire({ key: 'h', ctrl: true, alt: true, shift: true }); expect(a.openVersionHistory).toHaveBeenCalled()
+  })
+  it('Mod+D / Mod+R / Mod+E register fill + smart-fill', () => {
+    const a = makeActions(); useShortcuts(a)
+    fire({ key: 'd', ctrl: true }); expect(a.fillDown).toHaveBeenCalled()
+    fire({ key: 'r', ctrl: true }); expect(a.fillRight).toHaveBeenCalled()
+    fire({ key: 'e', ctrl: true }); expect(a.runSmartFill).toHaveBeenCalled()
+  })
+  it('Mod+Shift+V registers paste-values', () => {
+    const a = makeActions(); useShortcuts(a)
+    fire({ key: 'v', ctrl: true, shift: true }); expect(a.pasteValues).toHaveBeenCalled()
+  })
+})
+
+// ── Read-only gating (via the registered condition) ──────────────────────────
+
+describe('read-only gating', () => {
+  it('mutating shortcuts carry a condition that is false when read-only', () => {
+    const a = makeActions({ readOnly: () => true }); useShortcuts(a)
+    expect(find({ key: 'z', ctrl: true }).condition()).toBe(false)  // undo
+    expect(find({ key: 'b', ctrl: true }).condition()).toBe(false)  // bold
+  })
+  it('view shortcuts have no condition (stay live when read-only)', () => {
+    const a = makeActions({ readOnly: () => true }); useShortcuts(a)
+    expect(find({ key: 's', ctrl: true }).condition).toBeUndefined()  // save
+  })
+})
+
+// ── Residual onGlobalKey: e.code shortcuts ───────────────────────────────────
+
+describe('e.code shortcuts (onGlobalKey)', () => {
+  it('Mod+Alt+Equal inserts rows/cols', () => {
+    const a = makeActions()
+    const { onGlobalKey } = useShortcuts(a)
+    onGlobalKey(key({ code: 'Equal', metaKey: true, altKey: true }))
+    expect(a.insertRowsCols).toHaveBeenCalled()
+  })
+  it('Mod+Alt+Minus deletes rows/cols', () => {
+    const a = makeActions()
+    const { onGlobalKey } = useShortcuts(a)
+    onGlobalKey(key({ code: 'Minus', metaKey: true, altKey: true }))
+    expect(a.deleteRowsCols).toHaveBeenCalled()
+  })
+  it('Mod+Shift+Digit1 applies number format', () => {
+    const a = makeActions()
+    const { onGlobalKey } = useShortcuts(a)
+    onGlobalKey(key({ code: 'Digit1', metaKey: true, shiftKey: true }))
+    expect(a.applyNumberFormat).toHaveBeenCalledWith('number')
+  })
+  it('Mod+Shift+Digit4 applies currency format', () => {
+    const a = makeActions()
+    const { onGlobalKey } = useShortcuts(a)
+    onGlobalKey(key({ code: 'Digit4', metaKey: true, shiftKey: true }))
+    expect(a.applyNumberFormat).toHaveBeenCalledWith('currency:USD:2')
+  })
+  it('e.code shortcuts are inert when read-only', () => {
+    const a = makeActions({ readOnly: () => true })
+    const { onGlobalKey } = useShortcuts(a)
+    onGlobalKey(key({ code: 'Equal', metaKey: true, altKey: true }))
+    expect(a.insertRowsCols).not.toHaveBeenCalled()
+  })
+})
+
+// ── Residual onGlobalKey: Escape cascade ─────────────────────────────────────
+
+describe('escape cascade (onGlobalKey)', () => {
+  it('Escape closes commentPanel when open', () => {
+    const a = makeActions(); a.commentPanel.open = true
+    const { onGlobalKey } = useShortcuts(a)
+    onGlobalKey(key({ key: 'Escape' }))
+    expect(a.commentPanel.open).toBe(false)
+  })
+  it('Escape closes dropdownPanel when open', () => {
+    const a = makeActions(); a.dropdownPanel.open = true
+    const { onGlobalKey } = useShortcuts(a)
+    onGlobalKey(key({ key: 'Escape' }))
+    expect(a.dropdownPanel.open).toBe(false)
+  })
+  it('Escape clears clipboard marching ants', () => {
+    const a = makeActions({ clipboard: { hasData: vi.fn(() => true), clear: vi.fn() } })
+    const { onGlobalKey } = useShortcuts(a)
+    onGlobalKey(key({ key: 'Escape' }))
+    expect(a.clipboard.clear).toHaveBeenCalled()
+    expect(a.setMarchingAnts).toHaveBeenCalledWith(null)
+  })
+})


### PR DESCRIPTION
## What & why

A real user reported that Sheets was missing common Google-Sheets keyboard shortcuts, and that **Shift+Space felt buggy** because the active cell jumped to column A. This PR closes both gaps.

### New shortcuts (Google Sheets parity)

| Shortcut | Action |
|---|---|
| **Shift+Space** / **Ctrl+Space** / **Ctrl+Shift+Space** | Select row / column / whole sheet |
| **Ctrl+Alt+=** / **Ctrl+Alt+-** | Insert / delete rows or columns from the selection |
| **Ctrl+Shift+1…5** | Number · Time · Date · Currency · Percent |
| **Ctrl+Shift+V** | Paste values only |
| **PageDown / PageUp** | Scroll one screen (Shift extends) |

All are reflected in the in-app shortcut help (`?`).

### Whole-line selection now keeps its anchor (the "buggy" report)

Previously a whole-row/column selection forced the anchor to the top-left corner, so after Shift+Space the active cell dropped to column A and arrows/typing continued from there. Now `selMode` — not the stored corners — drives the perpendicular span, so the highlighted cell **keeps its column/row** and navigation resumes from it, exactly like Google Sheets. `getSelRange()` still reports the full row/column so copy/delete/sum operate on the whole line.

Also: zoom (`Mod+=`) now excludes Alt so `Ctrl+Alt+=` reaches the insert handler; insert/delete match on `e.code` (macOS rewrites `Alt+=`→`≠`); number-format shortcuts match on `e.code` so shifted digits resolve.

## Scope & notes
- **Frontend only**, no backend/schema changes.
- **Ctrl+Shift+6 (exponent)** intentionally omitted — the format engine has no scientific renderer yet.
- Number-format keys reuse the existing `onNumberFormatChange`; insert/delete reuse the existing context-menu handlers (seeded from the live selection); paste-values reuses `doPasteSpecial('values')`.

## Testing
- Full standalone suite green (1304 vitest, incl. 64 canvas tests) — file contents are line-for-line identical to this port.
- Verified live in the running app: row/column/all select (anchor stays in place; ArrowDown after Shift+Space keeps the column; whole-row Count intact), currency/percent formatting, insert/delete column, PageDown, and Ctrl+Shift+V binding.

Ported from the standalone `frappe/sheets` `main` (same change, suite paths).