### PR TITLE
feat(mail): add Credentials settings tab to manage JMAP connection

### DIFF
--- a/frontend/src/apps/mail/components/Modals/SettingsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SettingsModal.vue
@@ -33,6 +33,7 @@ import {
 	Folders,
 	HardDriveDownload,
 	HardDriveUpload,
+	KeyRound,
 	Mailbox,
 	Palette,
 	TreePalm,
@@ -51,6 +52,7 @@ import {
 import { useSettings } from '@/apps/mail/utils/composables'
 import Account from '@/apps/mail/components/Settings/Account.vue'
 import AdvancedSettings from '@/apps/mail/components/Settings/AdvancedSettings.vue'
+import CredentialsSettings from '@/apps/mail/components/Settings/CredentialsSettings.vue'
 import AppearanceSettings from '@/apps/mail/components/Settings/AppearanceSettings.vue'
 import AutomationSettings from '@/apps/mail/components/Settings/AutomationSettings.vue'
 import ExportSettings from '@/apps/mail/components/Settings/ExportSettings.vue'
@@ -93,6 +95,12 @@ const tabGroups = computed((): SettingsTabGroup[] => {
 					value: 'profile',
 					icon: User,
 					component: markRaw(ProfileSettings),
+				},
+				{
+					label: __('Credentials'),
+					value: 'credentials',
+					icon: KeyRound,
+					component: markRaw(CredentialsSettings),
 				},
 				{
 					label: __('Account'),

--- a/frontend/src/apps/mail/components/Settings/Account.vue
+++ b/frontend/src/apps/mail/components/Settings/Account.vue
@@ -86,19 +86,7 @@
 			:options="ON_MARK_AS_JUNK_OPTIONS"
 		/>
 
-		<template v-if="userSettings.doc">
-			<h2 class="text-base-semibold text-ink-gray-8">{{ __('Recovery') }}</h2>
-			<FormControl
-				v-model="userSettings.doc.backup_email"
-				:label="__('Backup Email')"
-				:description="
-					__(`We'll contact you here if there's an issue with your main account.`)
-				"
-				variant="outline"
-			/>
-		</template>
-
-		<ErrorMessage :message="jmapAccount.save.error || userSettings.save.error" />
+		<ErrorMessage :message="jmapAccount.save.error" />
 
 		<Dialog v-model="showMoveToInbox" :options="moveToInboxOptions" />
 		</div>
@@ -132,18 +120,13 @@ const user = inject('$user')
 const store = userStore()
 const { identities, mailboxes, mailboxIds } = store
 
-// Outgoing settings now live on the active account's JMAP Account; backup_email
-// (Recovery) is still per-user on User Settings.
+// Outgoing settings live on the active account's JMAP Account. Recovery (backup_email) and the
+// JMAP connection credentials moved to the dedicated Credentials tab (CredentialsSettings.vue).
 const activeAccount = user.data?.accounts?.find((a) => a.id === store.accountId)
 
 const jmapAccount = createDocumentResource({
 	doctype: 'JMAP Account',
 	name: activeAccount?.jmap_account,
-})
-
-const userSettings = createDocumentResource({
-	doctype: 'User Settings',
-	name: user.data?.user_settings,
 })
 
 const createContactsAfterEmailSubmit = computed({
@@ -187,12 +170,9 @@ const ON_MARK_AS_JUNK_OPTIONS = [
 const accountDirty = computed(
 	() => JSON.stringify(jmapAccount.doc) !== JSON.stringify(jmapAccount.originalDoc),
 )
-const userDirty = computed(
-	() => JSON.stringify(userSettings.doc) !== JSON.stringify(userSettings.originalDoc),
-)
-const isDirty = computed(() => accountDirty.value || userDirty.value)
-const loading = computed(() => jmapAccount.get.loading || userSettings.get.loading)
-const saving = computed(() => jmapAccount.save.loading || userSettings.save.loading)
+const isDirty = computed(() => accountDirty.value)
+const loading = computed(() => jmapAccount.get.loading)
+const saving = computed(() => jmapAccount.save.loading)
 
 const showMoveToInbox = ref(false)
 
@@ -244,7 +224,6 @@ const save = async () => {
 		// Enabling screening creates the Screening folder server-side; reload so it shows up.
 		if (screeningChanged) mailboxes.reload()
 	}
-	if (userDirty.value) await userSettings.save.submit()
 	raiseToast(__('Account updated.'))
 	if (askMoveToInbox) showMoveToInbox.value = true
 }

--- a/frontend/src/apps/mail/components/Settings/CredentialsSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/CredentialsSettings.vue
@@ -1,0 +1,134 @@
+<template>
+	<AppSettingsHeader :title="__('Credentials')">
+		<template v-if="userSettings.doc" #actions>
+			<Button
+				:label="__('Save')"
+				variant="solid"
+				:loading="saveSettings.loading"
+				:disabled="isNotDirty"
+				@click="() => saveSettings.submit()"
+			/>
+		</template>
+	</AppSettingsHeader>
+	<AppSettingsBody>
+		<template v-if="userSettings.doc">
+			<div class="flex flex-col gap-5">
+				<h2 class="text-base-semibold text-ink-gray-8">{{ __('Connection') }}</h2>
+				<FormControl
+					:model-value="userSettings.doc.server_url"
+					:label="__('Server URL')"
+					variant="outline"
+					disabled
+					:placeholder="__('Not configured')"
+					:description="__('The mail server this account connects to. Set by your administrator.')"
+				/>
+				<FormControl
+					v-model="username"
+					:label="__('Username')"
+					variant="outline"
+					:placeholder="__('user@example.com')"
+				/>
+				<FormControl
+					v-model="appPassword"
+					type="password"
+					:label="__('App Password')"
+					variant="outline"
+					:placeholder="hasPassword ? __('Leave blank to keep unchanged') : ''"
+					:description="__('Used to connect to your mailbox.')"
+				/>
+
+				<h2 class="text-base-semibold text-ink-gray-8">{{ __('Recovery') }}</h2>
+				<FormControl
+					v-model="backupEmail"
+					:label="__('Backup Email')"
+					variant="outline"
+					:description="
+						__(`We'll contact you here if there's an issue with your main account.`)
+					"
+				/>
+
+				<ErrorMessage :message="saveSettings.error as Error | undefined" />
+			</div>
+		</template>
+	</AppSettingsBody>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, ref, watch } from 'vue'
+import {
+	Button,
+	ErrorMessage,
+	FormControl,
+	createDocumentResource,
+	createResource,
+} from 'frappe-ui'
+import AppSettingsHeader from '@/components/settings/AppSettingsHeader.vue'
+import AppSettingsBody from '@/components/settings/AppSettingsBody.vue'
+
+import { raiseToast } from '@/apps/mail/utils'
+
+import type { UserResource } from '@/apps/mail/types'
+
+const user = inject('$user') as UserResource
+
+// get_user_info always ensures a User Settings doc exists and returns its name, so this is set.
+const userSettingsName = user.data.user_settings as string
+
+const userSettings = createDocumentResource({
+	doctype: 'User Settings',
+	name: userSettingsName,
+})
+
+const username = ref('')
+// Password fields come back masked from the API, so we never prefill this. It stays blank and is
+// only sent on save when the user actually types a new value (see makeParams below).
+const appPassword = ref('')
+const backupEmail = ref('')
+const hasPassword = ref(false)
+
+// Sync the local inputs from the doc once it loads (and after a reload).
+watch(
+	() => userSettings.doc,
+	(doc) => {
+		if (!doc) return
+		username.value = doc.username ?? ''
+		backupEmail.value = doc.backup_email ?? ''
+		hasPassword.value = !!doc.app_password
+		appPassword.value = ''
+	},
+	{ immediate: true },
+)
+
+const isNotDirty = computed(
+	() =>
+		username.value === (userSettings.doc?.username ?? '') &&
+		backupEmail.value === (userSettings.doc?.backup_email ?? '') &&
+		appPassword.value === '',
+)
+
+const saveSettings = createResource({
+	url: 'frappe.client.set_value',
+	makeParams: () => {
+		const fieldname: Record<string, string | null> = {
+			username: username.value || null,
+			backup_email: backupEmail.value || null,
+		}
+		// Only overwrite the stored password when the user entered a new one.
+		if (appPassword.value) fieldname.app_password = appPassword.value
+
+		return {
+			doctype: 'User Settings',
+			name: userSettingsName,
+			fieldname,
+		}
+	},
+	onSuccess: () => {
+		raiseToast(__('Credentials updated.'))
+		appPassword.value = ''
+		userSettings.reload()
+		// Refresh shared user data so is_jmap_configured / username reflect the change app-wide.
+		user.reload()
+	},
+	onError: () => raiseToast(__('Unable to save credentials.'), 'error'),
+})
+</script>


### PR DESCRIPTION
Add a "Credentials" tab under Mail -> Settings that lets a user view and update their own User Settings connection fields:

- Username and App Password (JMAP connection credentials)
- Backup Email, moved here from the Account -> Recovery section
- Server URL shown as a read-only field (virtual, set by the administrator)

App Password is never prefilled (Password fields come back masked) and is only written on save when the user enters a new value. Saving runs the doctype's JMAP validation, so bad credentials surface inline.

The tab is available to all logged-in users so it can also be used for initial self-setup, and backup_email handling is removed from Account.vue accordingly.

---

Split out from #331 (this was the second of its three commits).