### PR TITLE
fix(sheets): include formula-cell values in selection Sum/Avg

### DIFF
--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -2119,9 +2119,15 @@ async function _computeSelectionStatsAsync(token) {
   for (let r = r0; r <= r1; r++) {
     const rowSuffix = r + 1
     for (let c = c0; c <= c1; c++) {
-      const val = sheet.getCell(labels[c - c0] + rowSuffix, sn)
-      if (val !== '' && val != null) count++
-      const n = parseFloat(val)
+      const id = labels[c - c0] + rowSuffix
+      const raw = sheet.getCell(id, sn)
+      if (raw === '' || raw == null) continue
+      count++
+      // Aggregate the computed value, not the raw text: a formula cell holds
+      // "=SUM(...)" in getCell but evaluates to a number via getCellValue, so
+      // parseFloat on the raw string would drop it from Sum/Avg (but not Count).
+      const val = sheet.getCellValue(id, sn)
+      const n = typeof val === 'number' ? val : parseFloat(val)
       if (!isNaN(n)) { numCount++; sum += n }
     }
     since += rowWidth


### PR DESCRIPTION
## Problem

The bottom status-bar selection summary miscounts when the selection includes a **formula cell**. Selecting `1`, `2`, `3` and a `=SUM(A1:A3)` (which displays `6`) showed:

> Count: 4 · **Sum: 6** · **Avg: 2**

instead of the correct **Sum: 12 · Avg: 3**.

## Cause

`_computeSelectionStatsAsync` read each cell with `sheet.getCell()`, which returns the **raw** cell content. For a formula cell that's the literal string `"=SUM(A1:A3)"`, not its computed value. `parseFloat("=SUM(...)")` is `NaN`, so the cell was dropped from **Sum/Avg** — but it was still non-empty, so it was counted in **Count**. Hence Count 4, but Sum/Avg over only the three literal numbers (6, and 6÷3).

## Fix

Aggregate the **computed** value via `sheet.getCellValue()` (which evaluates the formula to `6`) instead of the raw text. Emptiness/Count still uses `getCell()`; empty cells are skipped first, so formulas are only evaluated when a cell is actually present (no perf regression on large mostly-empty selections — those get slightly faster).

This matches Google Sheets: Count = non-empty cells, Sum/Avg = numeric cells using their evaluated values.

## Testing

Verified live in the running SPA — selecting `1, 2, 3, =SUM(A1:A3)` now reports **Count: 4 · Sum: 12 · Avg: 3**. Frontend-only, single hunk; stats logic is inline in the editor component (no unit-test seam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)