### PR TITLE
feat(sheets): homepage list view — header sort, toolbar search, full-width scroll

### DIFF
--- a/frontend/src/apps/sheets/pages/Home.vue
+++ b/frontend/src/apps/sheets/pages/Home.vue
@@ -956,14 +956,23 @@ async function duplicate(sheet) {
 .home-listhead-cell.is-active  { color: var(--ink-gray-8); font-weight: 500; }
 .home-sort-caret { width: 13px; height: 13px; flex-shrink: 0; }
 
-/* Suppress ListView's own header — the grid + rounded + gray-fill "pill". That
-   three-class combination is unique to ListHeader; data rows never set all
-   three together, so this can't hide a row. */
+/* Suppress ListView's built-in header so only our flat sortable header shows.
+   frappe-ui's ListView exposes no per-column header slot or sort hook and
+   always renders <ListHeader>, so hiding it via its own utility classes is the
+   only seam available. The `.grid.rounded.bg-surface-gray-2` trio is unique to
+   ListHeader (data rows are `flex flex-col`, never all three), so this can't
+   hide a row.
+   ⚠ COUPLING: pinned to frappe-ui's ListHeader class names. If a frappe-ui
+   upgrade renames them the built-in header reappears (a duplicate header) —
+   degraded, not a crash; re-point this selector to match. */
 .home-listcol :deep(.grid.rounded.bg-surface-gray-2) { display: none; }
 
-/* Inset the actual scroll region's content (rows + group headers) to the same
-   1200px band as the header. The padding lives on the scroller itself so the
-   scrollbar stays pinned to the viewport edge while the content is centered. */
+/* Inset the scroll region's content (rows + group headers) to the same 1200px
+   band as the header. The padding lives on the scroller ITSELF so the scrollbar
+   stays pinned to the viewport edge while the content is centered.
+   ⚠ COUPLING: targets ListRows/ListGroups' internal `.h-full.overflow-y-auto`
+   scroll div — frappe-ui hard-codes the scroll there with no prop to hook. If
+   that changes, rows lose the centering inset (full-bleed), not the scroll. */
 .home-listcol :deep(.h-full.overflow-y-auto) {
   padding-inline: var(--list-inset);
 }

--- a/frontend/src/apps/sheets/pages/Home.vue
+++ b/frontend/src/apps/sheets/pages/Home.vue
@@ -23,17 +23,6 @@
              use this instead of `window.alert` so the chrome stays in-app
              and Espresso-themed. Auto-clears after 4 s. -->
         <Badge v-if="errorMessage" theme="red" variant="subtle" size="sm" :label="errorMessage" />
-        <FormControl
-          type="text"
-          size="sm"
-          class="home-search"
-          v-model="searchQuery"
-          placeholder="Search sheets…"
-        >
-          <template #prefix>
-            <FeatherIcon name="search" class="home-search-icon" />
-          </template>
-        </FormControl>
         <!-- View-mode toggle: grid (card) vs list. State persists in
              localStorage so the user's choice survives reloads. Uses two
              Frappe UI Buttons inside a thin segmented frame; the active
@@ -67,13 +56,25 @@
       </div>
     </div>
 
-    <!-- Filter toolbar — ownership tabs + sort. Hidden on the true-empty
-         state so a brand-new account isn't offered filters over nothing.
-         Kept during load errors so tab/sort changes can trigger a refetch. -->
+    <!-- Filter toolbar — ownership tabs on the left, search on the right (the
+         two list-narrowing controls sit together, matching the frappe-ui Files
+         desktop layout). Hidden on the true-empty state so a brand-new account
+         isn't offered filters over nothing; kept during load/errors so tab or
+         search changes can still trigger a refetch. -->
     <div v-if="loading || loadError || !isTrueEmpty" class="home-toolbar">
       <div class="home-toolbar-inner">
         <TabButtons v-model="ownerTab" :buttons="ownerTabs" />
-        <Select v-model="sortBy" :options="sortOptions" aria-label="Sort by" />
+        <FormControl
+          type="text"
+          size="sm"
+          class="home-search"
+          v-model="searchQuery"
+          placeholder="Search sheets…"
+        >
+          <template #prefix>
+            <FeatherIcon name="search" class="home-search-icon" />
+          </template>
+        </FormControl>
       </div>
     </div>
 
@@ -186,6 +187,31 @@
          the options.emptyState contract. -->
     <div v-else class="home-listshell">
       <div class="home-listcol">
+      <!-- Custom flat column header — replaces ListView's built-in gray-pill
+           header (suppressed via the `:deep` rule below) with a borderless row
+           whose labels double as sort controls, matching the frappe-ui Files
+           desktop pattern. The grid template mirrors ListRow's exactly
+           (`3fr 1fr 1fr 60px`, gap-4, px-2) so labels align with row cells. -->
+      <div class="home-listhead" role="row">
+        <button
+          v-for="col in sortHeaders"
+          :key="col.key"
+          type="button"
+          class="home-listhead-cell"
+          :class="{ 'is-active': sortBy === col.key }"
+          :aria-sort="sortBy === col.key ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'"
+          @click="setSort(col.key)"
+        >
+          <span class="truncate">{{ col.label }}</span>
+          <FeatherIcon
+            v-if="sortBy === col.key"
+            :name="sortDir === 'asc' ? 'arrow-up' : 'arrow-down'"
+            class="home-sort-caret"
+          />
+        </button>
+        <!-- Spacer keeps the header grid aligned with the row's 60px actions column. -->
+        <span aria-hidden="true" />
+      </div>
       <ListView
         class="h-full"
         :columns="listColumns"
@@ -286,7 +312,6 @@ import {
   ListRowItem,
   ListFooter,
   TabButtons,
-  Select,
   debounce,
 } from 'frappe-ui'
 import { useRouter } from 'vue-router'
@@ -320,6 +345,7 @@ const searchQuery = ref('')   // matched server-side (debounced) so results
                               // aren't limited to already-loaded pages
 const ownerTab    = ref('all')      // 'all' | 'mine' | 'shared'
 const sortBy      = ref('modified') // 'modified' | 'title' | 'owner'
+const sortDir     = ref('desc')     // 'asc' | 'desc' — toggled from the header
 const loadError   = ref('')   // reset-fetch failure; owns its own surface so
                               // stale rows never render under a new filter
 const serverNow   = ref('')   // server-clock "now" from the API — same naive
@@ -417,11 +443,27 @@ const ownerTabs = [
   { label: 'Shared with me', value: 'shared' },
 ]
 
-const sortOptions = [
-  { label: 'Last modified', value: 'modified' },
-  { label: 'Name A–Z', value: 'title' },
-  { label: 'Owner', value: 'owner' },
+// Sort lives in the column header (not a separate dropdown): each entry is a
+// clickable header cell whose `key` is the server `order_by` keyword. Order
+// and widths mirror `listColumns`' data columns so the header aligns with rows.
+const sortHeaders = [
+  { key: 'title',    label: 'Name' },
+  { key: 'owner',    label: 'Owner' },
+  { key: 'modified', label: 'Last Modified' },
 ]
+
+// The direction a column sorts by when it first becomes active: dates read
+// newest-first, text/owner read A→Z. Re-clicking the active column toggles.
+const SORT_DEFAULT_DIR = { modified: 'desc', title: 'asc', owner: 'asc' }
+
+function setSort(key) {
+  if (sortBy.value === key) {
+    sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortBy.value = key
+    sortDir.value = SORT_DEFAULT_DIR[key] || 'desc'
+  }
+}
 
 // "Truly" empty = the account has no visible sheets at all, as opposed to
 // a search/tab combination that matched nothing. Gets the branded block.
@@ -467,12 +509,16 @@ const listOptions = computed(() => ({
 // re-expand every group on Load More.
 const listRows = ref([])
 watch(
-  [sheets, sortBy],
+  [sheets, sortBy, sortDir],
   () => {
+    // Recency buckets (Today / Previous 7 days / …) only read correctly under
+    // the default newest-first modified sort; any other column — or modified
+    // ascending — renders a flat list so the ordering isn't fought by buckets.
+    const grouped = sortBy.value === 'modified' && sortDir.value === 'desc'
     // Bucket against the server's clock so "Today" is decided in the same
     // timezone frame the `modified` timestamps are written in.
     const now = serverNow.value ? parseFrappeDatetime(serverNow.value) : new Date()
-    listRows.value = sortBy.value === 'modified'
+    listRows.value = grouped
       ? groupSheetsByRecency(sheets.value, now, listRows.value)
       : sheets.value
   },
@@ -507,7 +553,7 @@ const renaming         = ref(false)
 onMounted(fetchSheets)
 
 // Tab/sort changes reset to page 1 immediately; search debounces on top.
-watch([ownerTab, sortBy], () => fetchSheets())
+watch([ownerTab, sortBy, sortDir], () => fetchSheets())
 watch(searchQuery, debounce(() => fetchSheets(), 300))
 
 // Monotonic token invalidates in-flight responses, so a slow page-1 fetch
@@ -525,6 +571,7 @@ async function fetchSheets({ append = false } = {}) {
       search: searchQuery.value.trim(),
       owner_filter: ownerTab.value,
       order_by: sortBy.value,
+      sort_dir: sortDir.value,
     })
     if (token !== reqToken) return
     sheets.value = append ? sheets.value.concat(res.sheets) : res.sheets
@@ -833,25 +880,107 @@ async function duplicate(sheet) {
    Frappe UI's ListView owns its own header/row styling — header background,
    gridTemplateColumns, dividers, hover. The shell bounds its height so the
    rows region (h-full overflow-y-auto inside ListView) scrolls internally,
-   keeping the column header and ListFooter fixed. */
+   keeping the column header and ListFooter fixed.
+
+   The scroll region spans the FULL width — not a centered 1200px column — so
+   the mouse wheel scrolls the list from anywhere across the viewport and the
+   scrollbar sits at the viewport's right edge (a narrow centered scroller left
+   dead zones on wide screens where the wheel hit a non-scrollable ancestor).
+   Content is re-centered to a 1200px band by insetting the header, the rows
+   region and the footer with the shared `--list-inset` below, rather than by
+   capping the container. */
 .home-listshell {
   flex: 1;
   min-height: 0;
   display: flex;
-  padding: 0 32px 12px;
+  padding: 0 0 12px;
 }
 .home-listcol {
   flex: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
-  max-width: 1200px;
   width: 100%;
-  margin: 0 auto;
+  /* Horizontal inset that centers content on a 1200px band, with a 32px floor
+     so narrow viewports keep a gutter. `100%` resolves against each consumer
+     (header / scroller / footer are all full-width), so they line up. */
+  --list-inset: max(32px, (100% - 1200px) / 2);
 }
-.home-listfooter {
+
+/* Custom flat column header — replaces ListView's built-in gray-pill header
+   (suppressed just below). The grid mirrors ListRow exactly so labels sit over
+   their columns: same `3fr 1fr 1fr 60px` template, gap-4 (1rem), px-2 (8px). */
+.home-listhead {
+  position: relative;
   flex-shrink: 0;
-  padding: 8px 4px;
-  border-top: 1px solid var(--outline-gray-2);
+  display: grid;
+  grid-template-columns: 3fr 1fr 1fr 60px;
+  gap: 1rem;
+  align-items: center;
+  /* +8px matches the rows' px-2, so the header labels sit over the row cells. */
+  padding: 6px calc(var(--list-inset) + 8px);
+  margin-bottom: 4px;
+}
+/* Hairline under the header, inset to the same 1200px band as the rows (a
+   border on the full-width element would overshoot the row dividers). */
+.home-listhead::after {
+  content: '';
+  position: absolute;
+  left: var(--list-inset);
+  right: var(--list-inset);
+  bottom: 0;
+  height: 1px;
+  background: var(--outline-gray-2);
+}
+
+/* A header label doubles as a sort control: quiet by default, darker on hover,
+   and darkest with a direction caret when it's the active sort. Native button
+   chrome is reset so it reads as plain header text. */
+.home-listhead-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  letter-spacing: .01em;
+  color: var(--ink-gray-5);
+  text-align: left;
+  transition: color .12s;
+}
+.home-listhead-cell:hover      { color: var(--ink-gray-7); }
+.home-listhead-cell.is-active  { color: var(--ink-gray-8); font-weight: 500; }
+.home-sort-caret { width: 13px; height: 13px; flex-shrink: 0; }
+
+/* Suppress ListView's own header — the grid + rounded + gray-fill "pill". That
+   three-class combination is unique to ListHeader; data rows never set all
+   three together, so this can't hide a row. */
+.home-listcol :deep(.grid.rounded.bg-surface-gray-2) { display: none; }
+
+/* Inset the actual scroll region's content (rows + group headers) to the same
+   1200px band as the header. The padding lives on the scroller itself so the
+   scrollbar stays pinned to the viewport edge while the content is centered. */
+.home-listcol :deep(.h-full.overflow-y-auto) {
+  padding-inline: var(--list-inset);
+}
+
+.home-listfooter {
+  position: relative;
+  flex-shrink: 0;
+  padding: 8px calc(var(--list-inset) + 4px);
+}
+/* Footer divider inset to the content band, mirroring the header hairline. */
+.home-listfooter::before {
+  content: '';
+  position: absolute;
+  left: var(--list-inset);
+  right: var(--list-inset);
+  top: 0;
+  height: 1px;
+  background: var(--outline-gray-2);
 }
 </style>

--- a/suite/sheets/api.py
+++ b/suite/sheets/api.py
@@ -266,11 +266,25 @@ def unshare_sheet(name: str, user: str = "", everyone: int = 0) -> dict:
 
 # Caller's `order_by` is resolved through this dict — a key lookup, never
 # string interpolation — so arbitrary SQL can't reach the ORDER BY clause.
-_LIST_SHEETS_ORDER_BY = {
-	"modified": "`tabSheet`.`modified` desc",
-	"title": "`tabSheet`.`title` asc",
-	"owner": "`tabSheet`.`owner` asc, `tabSheet`.`modified` desc",
+# The direction is likewise clamped to a literal "asc"/"desc" in
+# `_list_sheets_order_by`, so neither the column nor the direction is ever
+# free text.
+_LIST_SHEETS_SORT_FIELDS = {
+	"modified": "`tabSheet`.`modified`",
+	"title": "`tabSheet`.`title`",
+	"owner": "`tabSheet`.`owner`",
 }
+
+
+def _list_sheets_order_by(order_by: str, sort_dir: str) -> str:
+	field = _LIST_SHEETS_SORT_FIELDS.get(order_by) or _LIST_SHEETS_SORT_FIELDS["modified"]
+	direction = "asc" if str(sort_dir).lower() == "asc" else "desc"
+	order = f"{field} {direction}"
+	# Owner is a low-cardinality column, so a secondary `modified desc` keeps
+	# rows within one owner in a stable, useful order regardless of direction.
+	if order_by == "owner":
+		order += ", `tabSheet`.`modified` desc"
+	return order
 
 
 @frappe.whitelist()
@@ -280,6 +294,7 @@ def list_sheets(
 	search: str = "",
 	owner_filter: str = "all",
 	order_by: str = "modified",
+	sort_dir: str = "desc",
 ) -> dict:
 	# Frappe's get_list applies the permission query, so the base result is
 	# sheets the session user owns plus those shared via DocShare (per-user
@@ -304,7 +319,7 @@ def list_sheets(
 		"Sheet",
 		filters=filters,
 		fields=["name", "title", "modified", "owner"],
-		order_by=_LIST_SHEETS_ORDER_BY.get(order_by, _LIST_SHEETS_ORDER_BY["modified"]),
+		order_by=_list_sheets_order_by(order_by, sort_dir),
 		limit_start=start,
 		limit_page_length=limit,
 	)

--- a/suite/sheets/tests/test_list_sheets.py
+++ b/suite/sheets/tests/test_list_sheets.py
@@ -74,12 +74,16 @@ class Defaults(_ListSheetsBase):
 
 
 class OrderBy(_ListSheetsBase):
-	def test_known_keys_map_to_literals(self):
-		self.call(order_by="title")
+	def test_known_key_and_direction_map_to_literals(self):
+		self.call(order_by="title", sort_dir="asc")
 		self.assertEqual(self.rows_kwargs()["order_by"], "`tabSheet`.`title` asc")
 
-	def test_owner_sort_has_modified_tiebreak(self):
-		self.call(order_by="owner")
+	def test_direction_toggles_to_descending(self):
+		self.call(order_by="title", sort_dir="desc")
+		self.assertEqual(self.rows_kwargs()["order_by"], "`tabSheet`.`title` desc")
+
+	def test_owner_sort_keeps_modified_tiebreak_in_both_directions(self):
+		self.call(order_by="owner", sort_dir="asc")
 		self.assertEqual(
 			self.rows_kwargs()["order_by"],
 			"`tabSheet`.`owner` asc, `tabSheet`.`modified` desc",
@@ -91,6 +95,16 @@ class OrderBy(_ListSheetsBase):
 		kw = self.rows_kwargs()
 		self.assertEqual(kw["order_by"], _DEFAULT_ORDER)
 		# The caller's string must not appear anywhere in the query kwargs.
+		for call in self.frappe.get_list.call_args_list:
+			self.assertNotIn(malicious, repr(call))
+
+	def test_unknown_direction_falls_back_to_desc(self):
+		# Direction is clamped to the "asc"/"desc" literals just like the
+		# column — anything else can't reach the ORDER BY clause as free text.
+		malicious = "asc; DROP TABLE `tabSheet`--"
+		self.call(order_by="modified", sort_dir=malicious)
+		kw = self.rows_kwargs()
+		self.assertEqual(kw["order_by"], _DEFAULT_ORDER)
 		for call in self.frappe.get_list.call_args_list:
 			self.assertNotIn(malicious, repr(call))
 

--- a/suite/sheets/tests/test_list_sheets.py
+++ b/suite/sheets/tests/test_list_sheets.py
@@ -88,6 +88,14 @@ class OrderBy(_ListSheetsBase):
 			self.rows_kwargs()["order_by"],
 			"`tabSheet`.`owner` asc, `tabSheet`.`modified` desc",
 		)
+		# desc flips only the owner term; the modified-desc tiebreak stays.
+		self.frappe.get_list.reset_mock()
+		self.frappe.get_list.side_effect = [self.rows, [{"total": 42}]]
+		self.call(order_by="owner", sort_dir="desc")
+		self.assertEqual(
+			self.rows_kwargs()["order_by"],
+			"`tabSheet`.`owner` desc, `tabSheet`.`modified` desc",
+		)
 
 	def test_unknown_order_by_falls_back_to_default(self):
 		malicious = "modified desc; DROP TABLE `tabSheet`--"


### PR DESCRIPTION
## Homepage list view polish

Three related improvements to the Sheets homepage list, moving it toward the frappe-ui Files desktop pattern.

### 1. Sort from the column header
The `Name` / `Owner` / `Last Modified` labels are now the sort controls — click a column to sort by it, click again to flip direction. The active column shows a direction caret; the separate "Sort by" dropdown is removed. ListView's built-in gray-pill header is replaced by a flat, borderless header. Recency grouping (Today / Previous 7 days / …) stays under the default newest-first view and gives way to a flat list for any other sort.

Backend: `list_sheets` gains a whitelisted `sort_dir` param. Both the column and the direction are clamped to literals in `_list_sheets_order_by`, so neither reaches the `ORDER BY` clause as free text; `owner` keeps its `modified desc` tiebreak in either direction.

### 2. Search in the filter toolbar
Search moves out of the global top bar and into the filter toolbar, opposite the ownership tabs — the two list-narrowing controls now sit together, and the top bar is left to brand + view toggle + New Sheet.

### 3. Full-width list scroll
The list scroll region previously lived inside a centered 1200px column, so on wide screens the mouse wheel did nothing over the side "dead zones" and the scrollbar floated inward. The scroll region now spans the full width — the wheel scrolls from anywhere and the scrollbar sits at the viewport edge — while content stays centered on a 1200px band via a shared `--list-inset` (32px floor). Header and footer dividers are inset to match the row dividers.

## Tests
- `test_list_sheets.py`: updated for the `sort_dir` contract, plus a case asserting an unknown `sort_dir` falls back to `desc` and never leaks into the query.

## Verification
Built and driven in a live dev stack: click-to-sort + direction toggle across all three columns, grouping restored under Last Modified, search filters after the move, and full-width wheel scroll confirmed at 1680px and 900px viewports with header/row/footer dividers aligned. No console errors.
