### PR TITLE
feat(mail): mobile PWA navigation shell and touch UX

### DIFF
--- a/frontend/src/apps/mail/components/AdaptiveDropdown.vue
+++ b/frontend/src/apps/mail/components/AdaptiveDropdown.vue
@@ -4,8 +4,10 @@
 	</Dropdown>
 	<template v-else>
 		<!-- inline-flex (not `contents`): display:contents elements ignore margins,
-		     which broke parents' space-x-* spacing between triggers. -->
-		<span class="inline-flex" @click="open = true"><slot /></span>
+		     which broke parents' space-x-* spacing between triggers. Skipped entirely
+		     for trigger-less (v-model:open only) usage — even an empty span adds a
+		     line box to the parent. -->
+		<span v-if="$slots.default" class="inline-flex" @click="open = true"><slot /></span>
 		<BottomSheet v-model:open="open" :title="title">
 			<div class="px-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))]">
 				<template v-for="(group, gi) in groups" :key="gi">
@@ -22,7 +24,7 @@
 						<component
 							:is="iconOf(item.icon)"
 							v-if="item.icon"
-							class="h-[18px] w-[18px] shrink-0"
+							class="h-4 w-4 shrink-0"
 							:class="item.theme === 'red' ? 'text-ink-red-6' : 'text-ink-gray-6'"
 						/>
 						<span class="flex-1 truncate text-left">{{ sheetLabel(item.label) }}</span>

--- a/frontend/src/apps/mail/components/AdaptiveDropdown.vue
+++ b/frontend/src/apps/mail/components/AdaptiveDropdown.vue
@@ -1,0 +1,103 @@
+<template>
+	<Dropdown v-if="!isMobile" :options="options" v-bind="$attrs">
+		<slot />
+	</Dropdown>
+	<template v-else>
+		<!-- inline-flex (not `contents`): display:contents elements ignore margins,
+		     which broke parents' space-x-* spacing between triggers. -->
+		<span class="inline-flex" @click="open = true"><slot /></span>
+		<BottomSheet v-model:open="open" :title="title">
+			<div class="px-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))]">
+				<template v-for="(group, gi) in groups" :key="gi">
+					<div v-if="group.label" class="text-ink-gray-5 px-3 pb-1 pt-3 text-sm">
+						{{ group.label }}
+					</div>
+					<button
+						v-for="item in group.items"
+						:key="item.label"
+						class="active:bg-surface-gray-1 flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-base"
+						:class="item.theme === 'red' ? 'text-ink-red-6' : 'text-ink-gray-8'"
+						@click="run(item)"
+					>
+						<component
+							:is="iconOf(item.icon)"
+							v-if="item.icon"
+							class="h-[18px] w-[18px] shrink-0"
+							:class="item.theme === 'red' ? 'text-ink-red-6' : 'text-ink-gray-6'"
+						/>
+						<span class="flex-1 truncate text-left">{{ sheetLabel(item.label) }}</span>
+					</button>
+				</template>
+			</div>
+		</BottomSheet>
+	</template>
+</template>
+
+<script setup lang="ts">
+import { computed, h, isVNode, type Component, type VNode } from 'vue'
+import { BottomSheet, Dropdown, FeatherIcon } from 'frappe-ui'
+
+import { stripShortcutHint } from '@/apps/mail/utils'
+import { useScreenSize } from '@/apps/mail/utils/composables'
+
+// Drop-in Dropdown replacement: desktop renders a frappe-ui Dropdown untouched,
+// mobile renders the same options as a bottom sheet (popup menus at the bottom
+// edge are thumb-hostile). Supports flat and grouped option arrays; `component`
+// items (custom rendered entries) are not supported here.
+
+interface OptionItem {
+	label: string
+	icon?: string | Component | VNode
+	onClick?: () => void
+	condition?: () => boolean
+	theme?: string
+}
+
+type Options = (OptionItem | { group: string; items: OptionItem[] })[]
+
+defineOptions({ inheritAttrs: false })
+
+const { options, title } = defineProps<{
+	options: Options
+	title?: string
+}>()
+
+const { isMobile } = useScreenSize()
+// Optional v-model:open for programmatic opening (e.g. chained from another
+// sheet); works standalone via defineModel's local fallback otherwise.
+const open = defineModel<boolean>('open', { default: false })
+
+const visible = (items: OptionItem[]) =>
+	items.filter((item) => (item.condition ? item.condition() : true))
+
+const groups = computed(() => {
+	const flat: OptionItem[] = []
+	const grouped: { label: string; items: OptionItem[] }[] = []
+	for (const entry of options ?? []) {
+		if (entry && 'items' in entry) {
+			const items = visible(entry.items ?? [])
+			if (items.length) grouped.push({ label: entry.group, items })
+		} else if (entry) {
+			flat.push(entry as OptionItem)
+		}
+	}
+	const flatVisible = visible(flat)
+	return [...(flatVisible.length ? [{ label: '', items: flatVisible }] : []), ...grouped]
+})
+
+// Dropdown option icons come in three shapes across the app: a feather name
+// string, a component, or a prebuilt vnode (h(Icon, ...)). Normalize all three
+// into something <component :is> accepts.
+const iconOf = (icon: OptionItem['icon']) => {
+	if (typeof icon === 'string') return h(FeatherIcon, { name: icon })
+	if (isVNode(icon)) return () => icon
+	return icon
+}
+
+const run = (item: OptionItem) => {
+	open.value = false
+	item.onClick?.()
+}
+
+const sheetLabel = stripShortcutHint
+</script>

--- a/frontend/src/apps/mail/components/AdaptiveDropdown.vue
+++ b/frontend/src/apps/mail/components/AdaptiveDropdown.vue
@@ -11,6 +11,8 @@
 		<BottomSheet v-model:open="open" :title="title">
 			<div class="px-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))]">
 				<template v-for="(group, gi) in groups" :key="gi">
+					<!-- Mirror the desktop Dropdown's separators between label-less groups. -->
+					<div v-if="gi && !group.label" class="mx-3 my-2 border-t" />
 					<div v-if="group.label" class="text-ink-gray-5 px-3 pb-1 pt-3 text-sm">
 						{{ group.label }}
 					</div>

--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -63,7 +63,20 @@
 	</Transition>
 
 	<SettingsModal v-if="!isMobile" v-model="showSettings" />
-	<PWASettings v-else-if="showSettings" @close="showSettings = false" />
+	<!-- Mobile settings pushes in from the right like a thread: its back-chevron
+	     header is push-navigation language (slide-up is reserved for summoned
+	     tasks — compose/search). Teleported to body: inside the layout's isolate
+	     stacking context the tab bar/FAB would paint over it. -->
+	<Teleport v-else to="body">
+		<Transition
+			enter-active-class="transition-transform duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
+			enter-from-class="translate-x-full"
+			leave-active-class="transition-transform duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
+			leave-to-class="translate-x-full"
+		>
+			<PWASettings v-if="showSettings" @close="showSettings = false" />
+		</Transition>
+	</Teleport>
 	<FolderModal v-model="showFolderModal" :mailbox="selectedMailbox" />
 	<DeleteFolderModal v-model="showDeleteMailbox" :mailbox="selectedMailbox" />
 	<ShortcutsModal v-model="showShortcuts" />

--- a/frontend/src/apps/mail/components/AttachmentCapsule.vue
+++ b/frontend/src/apps/mail/components/AttachmentCapsule.vue
@@ -19,22 +19,35 @@
 				</button>
 			</template>
 		</div>
-		<span class="truncate text-sm">{{ fileName }}</span>
+		<span class="truncate text-sm">{{ displayName }}</span>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { Download, Loader } from 'lucide-vue-next'
 
 import { getAttachmentUrl } from '@/apps/mail/resources'
 import { downloadUrlAsFile, getFileIcon } from '@/apps/mail/utils'
+import { useScreenSize } from '@/apps/mail/utils/composables'
 
 const { fileName, blobID, type } = defineProps<{
 	fileName: string
 	blobID?: string
 	type?: string
 }>()
+
+const { isMobile } = useScreenSize()
+
+// On mobile long names truncate in the middle so the extension survives
+// ("quarterly-report…-final.pdf", not "quarterly-repo…"). Desktop keeps CSS
+// end-truncation, whose tooltip shows the full name on hover anyway.
+const MOBILE_NAME_MAX = 24
+const displayName = computed(() => {
+	if (!isMobile.value || fileName.length <= MOBILE_NAME_MAX) return fileName
+	const tail = fileName.slice(-10)
+	return `${fileName.slice(0, MOBILE_NAME_MAX - 11)}…${tail}`
+})
 
 const isDownloading = ref(false)
 

--- a/frontend/src/apps/mail/components/DefaultLayout.vue
+++ b/frontend/src/apps/mail/components/DefaultLayout.vue
@@ -1,7 +1,7 @@
 <template>
-	<div v-if="userResource?.data?.name" class="relative flex h-full flex-col">
-		<div class="h-full flex-1">
-			<div class="isolate flex h-screen text-base">
+	<div v-if="userResource?.data?.name" class="relative flex h-[100dvh] flex-col">
+		<div class="min-h-0 flex-1">
+			<div class="isolate flex h-full text-base">
 				<AppSidebar v-if="isMobile" />
 				<div
 					v-else
@@ -14,12 +14,14 @@
 				</div>
 			</div>
 		</div>
+		<MobileTabBar v-if="isMobile" />
 	</div>
 </template>
 <script setup lang="ts">
 import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import AppSidebar from '@/apps/mail/components/AppSidebar.vue'
+import MobileTabBar from '@/apps/mail/components/mobile/MobileTabBar.vue'
 
 const { userResource } = userStore()
 

--- a/frontend/src/apps/mail/components/DefaultLayout.vue
+++ b/frontend/src/apps/mail/components/DefaultLayout.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-if="userResource?.data?.name" class="relative flex h-[100dvh] flex-col">
+	<div v-if="userResource?.data?.name" class="relative flex h-dvh flex-col">
 		<div class="min-h-0 flex-1">
 			<div class="isolate flex h-full text-base">
 				<AppSidebar v-if="isMobile" />
@@ -9,7 +9,7 @@
 				>
 					<AppSidebar />
 				</div>
-				<div id="scrollContainer" class="w-full overflow-auto">
+				<div id="scrollContainer" class="w-full overflow-auto max-sm:flex max-sm:flex-col max-sm:overflow-hidden">
 					<slot />
 				</div>
 			</div>

--- a/frontend/src/apps/mail/components/EmailContent.vue
+++ b/frontend/src/apps/mail/components/EmailContent.vue
@@ -214,6 +214,26 @@ const srcdoc = computed(() => {
 		<body>
 			${transformedContent}
 			<script>
+				// The stylesheet's max-width clamp can't reach fixed-width tables nested
+				// inside other tables: during the outer table's intrinsic sizing a
+				// percentage max-width counts as auto, so the inner pixel width still
+				// propagates up and the whole grid overflows. Rewrite any fixed pixel
+				// width wider than the sheet instead. Desktop panes are wider than the
+				// usual 600px email grid, so this effectively only bites on mobile.
+				const normalizeWidths = () => {
+					const limit = document.documentElement.clientWidth;
+					if (!limit) return;
+					document.querySelectorAll('[width], [style*="width"]').forEach((el) => {
+						if (parseInt(el.getAttribute('width'), 10) > limit) el.setAttribute('width', '100%');
+						const style = el.style;
+						if (style.width.endsWith('px') && parseFloat(style.width) > limit) style.width = '100%';
+						if (style.maxWidth.endsWith('px') && parseFloat(style.maxWidth) > limit) style.maxWidth = '100%';
+						if (style.minWidth.endsWith('px') && parseFloat(style.minWidth) > limit) style.minWidth = '0';
+					});
+				};
+				normalizeWidths();
+				window.addEventListener('resize', normalizeWidths);
+
 				// Forward keyboard events to parent
 				['keydown', 'keyup', 'keypress'].forEach(eventType => {
 					document.addEventListener(eventType, (e) => {

--- a/frontend/src/apps/mail/components/EmailContent.vue
+++ b/frontend/src/apps/mail/components/EmailContent.vue
@@ -152,6 +152,22 @@ const srcdoc = computed(() => {
 					line-height: 1.25rem;
 					background-color: ${colors.value.background};
 					margin: 0;
+					/* 'anywhere' (unlike 'break-word') also shrinks min-content width, so an
+					   unbreakable run (nbsp-joined text, long URLs) inside a table cell can't
+					   force the table wider than the viewport. */
+					overflow-wrap: anywhere;
+				}
+
+				/* Emails routinely hardcode widths (width attrs, inline styles); clamp them to the
+				   viewport so the message reflows instead of scrolling sideways. max-width wins over
+				   both the width attribute and inline width, covering every fixed-width variant. */
+				table, td, th, div {
+					max-width: 100% !important;
+				}
+
+				img {
+					max-width: 100% !important;
+					height: auto !important;
 				}
 
 				blockquote {
@@ -192,13 +208,6 @@ const srcdoc = computed(() => {
 					white-space: pre;
 					overflow-x: auto;
 				}
-
-				@media (max-width: 640px) {
-                    /* Only override specific problematic patterns */
-                    table[width="600"], table[width="600px"] {
-                        width: 100% !important;
-                    }
-                }
 			</style>
 			<script> ${iframeResizerChildScript} <\/script>
 		</head>

--- a/frontend/src/apps/mail/components/EmailContent.vue
+++ b/frontend/src/apps/mail/components/EmailContent.vue
@@ -87,8 +87,14 @@ const handleTrust = () => {
 	emit('trust')
 }
 
-// Listen for keyboard events from iframe
+// Listen for keyboard/swipe events from iframe
 const handleMessage = (event: MessageEvent) => {
+	// Horizontal swipes detected inside the iframe, re-broadcast for the thread pane's
+	// swipe navigation (MailboxView listens; it dedupes across EmailContent instances).
+	if (event.data?.type === 'swipe') {
+		window.dispatchEvent(new CustomEvent('email-swipe', { detail: event.data.direction }))
+		return
+	}
 	if (event.data?.type !== 'keyboard') return
 
 	// Create a synthetic keyboard event in the parent
@@ -259,6 +265,36 @@ const srcdoc = computed(() => {
 						}
 					}
 				});
+
+				// Forward horizontal swipes to the parent — touches never leave the iframe, so
+				// the thread pane's swipe navigation can't see them otherwise. A gesture that
+				// starts on horizontally scrollable content (incl. an overflowing body) means
+				// scroll, not navigate.
+				const inHorizontalScroller = (el) => {
+					const doc = document.documentElement;
+					if (doc.scrollWidth > doc.clientWidth + 1) return true;
+					for (; el && el.nodeType === 1; el = el.parentElement) {
+						if (el.scrollWidth > el.clientWidth + 1) {
+							const overflowX = getComputedStyle(el).overflowX;
+							if (overflowX === 'auto' || overflowX === 'scroll') return true;
+						}
+					}
+					return false;
+				};
+				let swipeOrigin = null;
+				document.addEventListener('touchstart', (e) => {
+					swipeOrigin = e.touches.length === 1 && !inHorizontalScroller(e.target)
+						? { x: e.touches[0].clientX, y: e.touches[0].clientY }
+						: null;
+				}, { passive: true });
+				document.addEventListener('touchend', (e) => {
+					if (!swipeOrigin) return;
+					const dx = e.changedTouches[0].clientX - swipeOrigin.x;
+					const dy = e.changedTouches[0].clientY - swipeOrigin.y;
+					swipeOrigin = null;
+					if (Math.abs(dx) < 64 || Math.abs(dx) < Math.abs(dy) * 2) return;
+					window.parent.postMessage({ type: 'swipe', direction: dx < 0 ? 'left' : 'right' }, '*');
+				}, { passive: true });
 				${colors.value.script}
 			<\/script>
 		</body>

--- a/frontend/src/apps/mail/components/HeaderActions.vue
+++ b/frontend/src/apps/mail/components/HeaderActions.vue
@@ -1,5 +1,7 @@
 <template>
-	<div class="flex space-x-2">
+	<!-- On mobile the tab bar's Search tab and Compose FAB own these actions; the
+	     header keeps only the modals (still reachable via v-model from views). -->
+	<div v-if="!isMobile" class="flex space-x-2">
 		<Button
 			icon="search"
 			:tooltip="__('Search ({0}+K)', [modifier])"
@@ -26,8 +28,11 @@ import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { Button } from 'frappe-ui'
 
 import { isMac } from '@/apps/mail/utils'
+import { useScreenSize } from '@/apps/mail/utils/composables'
 import SearchModal from '@/apps/mail/components/Modals/SearchModal.vue'
 import SendMail from '@/apps/mail/components/SendMail.vue'
+
+const { isMobile } = useScreenSize()
 
 const emit = defineEmits(['reloadMails'])
 

--- a/frontend/src/apps/mail/components/HeaderActions.vue
+++ b/frontend/src/apps/mail/components/HeaderActions.vue
@@ -1,6 +1,7 @@
 <template>
-	<!-- On mobile the tab bar's Search tab and Compose FAB own these actions; the
-	     header keeps only the modals (still reachable via v-model from views). -->
+	<!-- On mobile the tab bar owns these actions (Search tab, Compose FAB, Profile
+	     tab); the header is CSS-hidden there but stays mounted so these modals
+	     remain reachable via v-model from views. -->
 	<div v-if="!isMobile" class="flex space-x-2">
 		<Button
 			icon="search"

--- a/frontend/src/apps/mail/components/LoadingBar.vue
+++ b/frontend/src/apps/mail/components/LoadingBar.vue
@@ -1,0 +1,29 @@
+<template>
+	<!-- Indeterminate hairline progress bar under a toolbar: absolutely pinned to the
+	     nearest positioned ancestor's bottom edge, overlapping its border by 1px so the
+	     sweep replaces the border line rather than stacking under it. -->
+	<div
+		class="loading-bar pointer-events-none absolute bottom-[-1px] left-[-1px] right-0 h-0.5 overflow-hidden"
+		role="progressbar"
+		aria-busy="true"
+	>
+		<div
+			class="loading-bar__fill via-ink-gray-3 absolute inset-y-0 left-0 w-[30%] bg-gradient-to-r from-transparent to-transparent"
+		/>
+	</div>
+</template>
+
+<style scoped>
+.loading-bar__fill {
+	animation: loading-bar-slide 1.2s linear infinite;
+}
+
+@keyframes loading-bar-slide {
+	0% {
+		transform: translateX(-100%);
+	}
+	100% {
+		transform: translateX(333%);
+	}
+}
+</style>

--- a/frontend/src/apps/mail/components/MailActions.vue
+++ b/frontend/src/apps/mail/components/MailActions.vue
@@ -11,13 +11,18 @@
 		</template>
 	</Button>
 
-	<Dropdown v-if="!mail.draft && !isCollapsed" :options="moreActions(mail)">
-		<Button variant="ghost" :tooltip="__('More')" @click.stop>
-			<template #icon>
-				<Ellipsis class="text-ink-gray-5 icon" />
-			</template>
-		</Button>
-	</Dropdown>
+	<!-- .stop lives on the wrapper: AdaptiveDropdown's mobile trigger opens via
+	     the click bubbling to its own span, so stopping on the Button itself
+	     would keep the sheet from opening. -->
+	<div v-if="!mail.draft && !isCollapsed" class="flex" @click.stop>
+		<AdaptiveDropdown :options="moreActions(mail)">
+			<Button variant="ghost" :tooltip="__('More')">
+				<template #icon>
+					<Ellipsis class="text-ink-gray-5 icon" />
+				</template>
+			</Button>
+		</AdaptiveDropdown>
+	</div>
 </template>
 
 <script lang="ts" setup>
@@ -37,11 +42,14 @@ import {
 	MailOpen,
 	Reply,
 	ReplyAll,
+	ShieldCheck,
 	SquarePen,
 	Star,
 	Trash2,
 } from 'lucide-vue-next'
-import { Button, Dropdown, createResource } from 'frappe-ui'
+import { Button, createResource } from 'frappe-ui'
+
+import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 
 import {
 	downloadUrlAsFile,
@@ -231,6 +239,16 @@ const moreActions = (mail: Mail): GroupedAction[] => [
 				condition: () =>
 					mailbox !== mailboxIds.screener && isSenderBlocked(mail.from_email),
 			},
+			{
+				label: __('Mark Domain as Trusted'),
+				onClick: () => trustDomain.submit(),
+				icon: ShieldCheck,
+				condition: () =>
+					mailbox !== mailboxIds.screener &&
+					!mail.draft &&
+					!!mail.from_email &&
+					!isDomainTrusted(mail.from_email),
+			},
 		],
 	},
 	{
@@ -303,6 +321,29 @@ const handleMarkUnreadFromHere = () => {
 		.map((m: Mail) => m.id)
 	if (ids.length) setMailsSeen.submit({ ids })
 }
+
+// The sender's domain as a screened value ('@example.com'). "Trusted" = an
+// Accepted '@domain' entry — the same state that lets remote images load.
+const senderDomain = (email: string) => `@${(email ?? '').trim().toLowerCase().split('@').pop()}`
+const isDomainTrusted = (email: string) =>
+	!!screenedAddresses.data?.some(
+		(a: ScreenedAddress) =>
+			a.action === 'Accepted' && a.email.trim().toLowerCase() === senderDomain(email),
+	)
+
+const trustDomain = createResource({
+	url: 'suite.mail.api.mail.screen_email_addresses',
+	makeParams: () => ({
+		account: store.accountId,
+		emails: [senderDomain(mail.from_email)],
+		action: 'Accepted',
+	}),
+	onSuccess: () => {
+		raiseToast(__('Domain marked as trusted.'))
+		screenedAddresses.reload()
+	},
+	onError: (error) => raiseToast(error.message, 'error'),
+})
 
 const blockEmailAddress = createResource({
 	url: 'suite.mail.api.mail.screen_email_address',

--- a/frontend/src/apps/mail/components/MailListItem.vue
+++ b/frontend/src/apps/mail/components/MailListItem.vue
@@ -3,6 +3,7 @@
 		:to
 		:is-selected
 		:selectable
+		:selection-mode
 		:unread="!mail.seen"
 		:hide-sender
 		:avatar-label="getSenderInitial(mail)"
@@ -61,7 +62,7 @@
 						:blob-i-d="attachment.blob_id"
 						:type="attachment.type"
 						class="mr-2"
-						:class="isFullWidth ? 'max-w-32' : 'max-w-20'"
+						:class="isFullWidth ? 'max-w-32' : 'max-w-44 sm:max-w-20'"
 						@click.stop.prevent="openAttachment(idx)"
 					/>
 				</Tooltip>
@@ -163,6 +164,7 @@ const {
 	accountLabel,
 	selectable = true,
 	hideSender = false,
+	selectionMode = false,
 } = defineProps<{
 	mailbox: string
 	mail: Thread
@@ -176,6 +178,8 @@ const {
 	selectable?: boolean
 	// Set on the members of an expanded stack, whose stack row already names the sender.
 	hideSender?: boolean
+	// Mobile selection mode — forwarded to MailRow.
+	selectionMode?: boolean
 }>()
 
 const emit = defineEmits([

--- a/frontend/src/apps/mail/components/MailRow.vue
+++ b/frontend/src/apps/mail/components/MailRow.vue
@@ -2,13 +2,14 @@
 	<component
 		:is="to ? RouterLink : 'div'"
 		:to="to"
-		class="sm:hover:bg-surface-gray-1 group flex cursor-default select-none space-x-2.5 border-b px-3.5 py-2.5 sm:space-x-5 sm:px-5"
+		class="sm:hover:bg-surface-gray-1 group flex cursor-default select-none space-x-2.5 border-b px-3.5 py-2.5 [-webkit-touch-callout:none] sm:space-x-5 sm:px-5"
 		:class="{ '!bg-surface-blue-1': isSelected || isTouching, '!py-2': isFullWidth }"
 		@mouseenter="isHovered = true"
 		@mouseleave="isHovered = false"
 		@touchstart="onTouchStart"
 		@touchend="clearTouchTimer"
 		@touchcancel="clearTouchTimer"
+		@contextmenu="onContextMenu"
 		@click.capture="onRowClick"
 	>
 		<!-- Selection column: checkbox on desktop, sender avatar on mobile or where the list has no
@@ -211,6 +212,14 @@ const clearTouchTimer = () => {
 		clearTimeout(touchTimer)
 		touchTimer = null
 	}
+}
+
+// The row is an anchor, so a long press also summons the browser's link menu on top of the
+// selection the row already handles. Suppress it for touch presses only — a desktop right-click
+// keeps its menu. (iOS shows a callout instead of firing contextmenu; -webkit-touch-callout on
+// the row covers that.)
+const onContextMenu = (e: Event) => {
+	if (isTouching.value) e.preventDefault()
 }
 
 const onTouchMove = (e: TouchEvent) => {

--- a/frontend/src/apps/mail/components/MailRow.vue
+++ b/frontend/src/apps/mail/components/MailRow.vue
@@ -9,11 +9,14 @@
 		@touchstart="onTouchStart"
 		@touchend="clearTouchTimer"
 		@touchcancel="clearTouchTimer"
+		@click.capture="onRowClick"
 	>
 		<!-- Selection column: checkbox on desktop, sender avatar on mobile or where the list has no
 		     bulk selection. Long-pressing the row anywhere selects it on touch. -->
+		<!-- max-sm:justify-start pins the avatar/checkbox to the row's 14px padding
+		     axis; centered, the 40px column left them 2-4px "inside" it. -->
 		<div
-			class="flex shrink-0 items-center justify-center max-sm:w-10"
+			class="flex shrink-0 items-center justify-center max-sm:w-10 max-sm:justify-start"
 			:class="isFullWidth ? 'h-8' : 'h-10 sm:-mt-1.5'"
 		>
 			<div
@@ -25,17 +28,17 @@
 			</div>
 			<div
 				v-else-if="isSelected"
-				class="bg-surface-gray-10 hitbox flex h-8 w-8 shrink-0 rounded-full"
+				class="bg-surface-gray-10 hitbox flex h-8 w-8 shrink-0 rounded-full max-sm:h-10 max-sm:w-10"
 				@click.stop.prevent="emit('setSelected', false)"
 			>
-				<Check class="text-ink-base m-auto h-5 w-5 stroke-[3px]" />
+				<Check class="text-ink-base m-auto h-5 w-5 stroke-[3.5px]" />
 			</div>
 			<Avatar
 				v-show="!isSelected && (isMobile || !selectable)"
 				:label="avatarLabel"
 				:image="avatarImage"
 				size="xl"
-				class="hitbox"
+				class="hitbox max-sm:!h-10 max-sm:!w-10"
 				@click.stop.prevent="emit('setSelected', true)"
 			/>
 		</div>
@@ -128,6 +131,7 @@ const {
 	datetime,
 	subjectItalic = false,
 	previewItalic = false,
+	selectionMode = false,
 } = defineProps<{
 	// Renders the row as a link when set, and as a plain div when not — a thread opens, a stack expands.
 	to?: RouteLocationRaw
@@ -144,6 +148,9 @@ const {
 	datetime: string
 	subjectItalic?: boolean
 	previewItalic?: boolean
+	// Mobile selection mode (a selection exists): rows swap avatars for checkboxes,
+	// hide trailing actions, and a tap toggles selection instead of navigating.
+	selectionMode?: boolean
 }>()
 
 const emit = defineEmits<{ setSelected: [selected: boolean] }>()
@@ -152,6 +159,17 @@ const user = inject('$user') as UserResource
 const { isMobile } = useScreenSize()
 
 const isHovered = ref(false)
+
+// In selection mode a row tap toggles membership; capture-phase so the
+// RouterLink navigation never fires. Real buttons inside the row (the trailing
+// star) are exempt and keep their own action.
+const onRowClick = (e: MouseEvent) => {
+	if (!selectionMode) return
+	if ((e.target as HTMLElement).closest('button')) return
+	e.preventDefault()
+	e.stopPropagation()
+	emit('setSelected', !isSelected)
+}
 
 // With the reading pane hidden the list has the window to itself, so a row lays out as one wide line
 // instead of a stacked block.

--- a/frontend/src/apps/mail/components/MailRow.vue
+++ b/frontend/src/apps/mail/components/MailRow.vue
@@ -32,7 +32,7 @@
 				class="bg-surface-gray-10 hitbox flex h-8 w-8 shrink-0 rounded-full max-sm:h-10 max-sm:w-10"
 				@click.stop.prevent="emit('setSelected', false)"
 			>
-				<Check class="text-ink-base m-auto h-5 w-5 stroke-[3.5px]" />
+				<Check class="text-ink-base m-auto h-5 w-5 stroke-[4px]" />
 			</div>
 			<Avatar
 				v-show="!isSelected && (isMobile || !selectable)"

--- a/frontend/src/apps/mail/components/MailRowActions.vue
+++ b/frontend/src/apps/mail/components/MailRowActions.vue
@@ -6,7 +6,7 @@
 			</button>
 		</Tooltip>
 	</template>
-	<Tooltip v-if="showStar" :text="flagged ? __('Unstar Mail') : __('Star Mail')">
+	<Tooltip v-if="showStar && !isMobile" :text="flagged ? __('Unstar Mail') : __('Star Mail')">
 		<button class="action-btn" @click.stop.prevent="emit('setFlagged', !flagged)">
 			<Star
 				class="icon text-ink-gray-5"
@@ -14,6 +14,20 @@
 			/>
 		</button>
 	</Tooltip>
+	<!-- Touch: no Tooltip wrapper (it can eat the first tap and never shows anyway),
+	     and a larger glyph. -->
+	<button
+		v-else-if="showStar"
+		class="action-btn"
+		:aria-label="flagged ? __('Unstar Mail') : __('Star Mail')"
+		@click.stop.prevent="emit('setFlagged', !flagged)"
+	>
+		<Star
+			class="text-ink-gray-5 h-5 w-5"
+			stroke-width="1.5"
+			:style="flagged ? 'fill: var(--ink-amber-6); color: var(--ink-amber-6)' : ''"
+		/>
+	</button>
 </template>
 
 <script setup lang="ts">
@@ -105,11 +119,18 @@ const actions = computed(() =>
 
 <style scoped>
 .action-btn {
-	@apply relative after:absolute after:-inset-4 after:content-[''] sm:after:-inset-1.5;
+	/* Mobile: uneven halo — generous left/right/top, but bottom capped at 10px (the
+	   star's clearance to the row border) so taps meant for the next row's first
+	   line are never captured. ~68×54px effective target on a 20px glyph. */
+	@apply relative after:absolute after:content-[''] max-sm:after:-bottom-2.5 max-sm:after:-left-6 max-sm:after:-right-6 max-sm:after:-top-6 sm:after:-inset-1.5;
 }
 
-.action-btn:hover > * {
-	color: var(--ink-gray-8) !important;
-	stroke-width: 2 !important;
+/* Hover-capable pointers only: on touch, :hover sticks after a tap and the
+   star would stay dark until something else is touched. */
+@media (hover: hover) {
+	.action-btn:hover > * {
+		color: var(--ink-gray-8) !important;
+		stroke-width: 2 !important;
+	}
 }
 </style>

--- a/frontend/src/apps/mail/components/MailRowActions.vue
+++ b/frontend/src/apps/mail/components/MailRowActions.vue
@@ -24,7 +24,6 @@
 	>
 		<Star
 			class="text-ink-gray-5 h-5 w-5"
-			stroke-width="1.5"
 			:style="flagged ? 'fill: var(--ink-amber-6); color: var(--ink-amber-6)' : ''"
 		/>
 	</button>

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -17,6 +17,13 @@
 			@prev-thread="emit('prevThread')"
 			@next-thread="emit('nextThread')"
 		/>
+		<!-- The swipe slide (`slide` prop) pages only the thread-specific part — subject,
+		     messages, reply bar — while the toolbar above stays put. Keyed per thread on
+		     mobile: the outgoing thread's frozen DOM slides away as the incoming one
+		     slides in. Desktop keys statically, so switching threads never remounts. -->
+		<div class="relative min-h-0 flex-1 overflow-hidden">
+		<Transition :name="slide || ''" @after-enter="emit('slideDone')">
+		<div :key="isMobile ? threadID : 'thread'" class="flex h-full flex-col">
 		<!-- Mobile: the subject is part of the fixed chrome — scrolling starts below it,
 		     and its border is the separator content passes under. -->
 		<div v-if="isMobile && thread?.length" class="shrink-0 border-b px-3.5 pb-3.5 pt-1.5">
@@ -351,6 +358,9 @@
 				</div>
 			</div>
 		</div>
+		</div>
+		</Transition>
+		</div>
 		<SendMail
 			v-if="focusedDraft"
 			v-model="showSendModal"
@@ -433,7 +443,7 @@ import type {
 	ScreenedAddress,
 } from '@/apps/mail/types'
 
-const { mailbox, threadID, threads, messages, canGoNext, readonly } = defineProps<{
+const { mailbox, threadID, threads, messages, canGoNext, readonly, slide } = defineProps<{
 	mailbox: string
 	threadID?: string
 	threads: string[]
@@ -442,6 +452,9 @@ const { mailbox, threadID, threads, messages, canGoNext, readonly } = defineProp
 	// Read-only thread (e.g. the Screener): renders the messages but hides every action — the thread
 	// toolbar, per-message actions, the block banner and the reply/forward bar — and never marks read.
 	readonly?: boolean
+	// Transition name for the mobile swipe paging ('thread-next' / 'thread-prev'); the owner
+	// arms it per swipe and clears it on slideDone, so other thread changes swap instantly.
+	slide?: string
 }>()
 
 const emit = defineEmits([
@@ -460,6 +473,7 @@ const emit = defineEmits([
 	'moveMail',
 	'markMailSpam',
 	'deleteMail',
+	'slideDone',
 ])
 
 const { isMobile } = useScreenSize()
@@ -1062,3 +1076,37 @@ const getForwardedContent = (mail: Mail) => {
 	`
 }
 </script>
+
+<style scoped>
+/* Swipe paging between threads (mobile): the incoming thread's content slides in from
+   the swipe side while the outgoing one — lifted out of flow so they overlap — slides
+   away in tandem. The toolbar above the sliding region stays put. */
+.thread-next-enter-active,
+.thread-next-leave-active,
+.thread-prev-enter-active,
+.thread-prev-leave-active {
+	transition: transform 0.2s cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.thread-next-leave-active,
+.thread-prev-leave-active {
+	position: absolute;
+	inset: 0;
+}
+
+.thread-next-enter-from {
+	transform: translateX(100%);
+}
+
+.thread-next-leave-to {
+	transform: translateX(-100%);
+}
+
+.thread-prev-enter-from {
+	transform: translateX(-100%);
+}
+
+.thread-prev-leave-to {
+	transform: translateX(100%);
+}
+</style>

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -17,12 +17,14 @@
 			@prev-thread="emit('prevThread')"
 			@next-thread="emit('nextThread')"
 		/>
+		<!-- Mobile: the subject is part of the fixed chrome — scrolling starts below it,
+		     and its border is the separator content passes under. -->
+		<div v-if="isMobile && thread?.length" class="shrink-0 border-b px-3.5 pb-3.5 pt-1.5">
+			<h2 class="text-xl-semibold leading-5">
+				{{ thread[0].subject || __('[No subject]') }}
+			</h2>
+		</div>
 		<div ref="threadContainer" class="flex-1 overflow-y-auto">
-			<div v-if="isMobile && thread?.length" class="border-b px-3.5 pb-3.5 pt-1.5">
-				<h2 class="text-xl-semibold leading-5">
-					{{ thread[0].subject || __('[No subject]') }}
-				</h2>
-			</div>
 
 			<div
 				class="sm:space-y-4 sm:px-5 sm:py-6"

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -18,7 +18,7 @@
 			@next-thread="emit('nextThread')"
 		/>
 		<div ref="threadContainer" class="flex-1 overflow-y-auto">
-			<div v-if="isMobile && thread?.length" class="border-b px-3 py-3.5">
+			<div v-if="isMobile && thread?.length" class="border-b px-3.5 pb-3.5 pt-1.5">
 				<h2 class="text-xl-semibold leading-5">
 					{{ thread[0].subject || __('[No subject]') }}
 				</h2>
@@ -56,7 +56,7 @@
 							v-if="!collapsedMailNames.has(mail.name)"
 							:data-mail-name="mail.name"
 							:class="{
-								'px-3 py-5': isMobile,
+								'px-3.5 py-5': isMobile,
 								'max-sm:border-b':
 									(thread.length > 1 || mail.draft) &&
 									mail.name !== mailBeforeCollapsedGroup &&

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -894,17 +894,20 @@ const createLocalDraft = (mail: Mail, draftDetails: ComposeMailData) => {
 
 	nextTick(() => {
 		draftMails[name] = { name, ...draftDetails }
+		// The thread entry only hosts the inline desktop editor. On mobile the draft
+		// lives in the slide-up sheet instead — splicing it in anyway would hide the
+		// reply bar (it's suppressed while the thread ends in a draft) until a reload
+		// cleans the entry up, well after the sheet has slid out.
+		if (isMobile.value) return popOutDraft(draftMails[name])
 		const index = thread.value.indexOf(mail)
 		const draft = thread.value.find((m: Mail) => m.name === name)
 		if (index !== -1 && !draft)
 			thread.value.splice(index + 1, 0, { ...draftMails[name], draft: 1, show: true })
-		if (isMobile.value) popOutDraft(draftMails[name])
-		else
-			setTimeout(() =>
-				threadContainerRef.value
-					?.querySelector(`[data-mail-name="${name}"]`)
-					?.scrollIntoView({ behavior: 'smooth', block: 'start' }),
-			)
+		setTimeout(() =>
+			threadContainerRef.value
+				?.querySelector(`[data-mail-name="${name}"]`)
+				?.scrollIntoView({ behavior: 'smooth', block: 'start' }),
+		)
 	})
 }
 

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -452,8 +452,9 @@ const { mailbox, threadID, threads, messages, canGoNext, readonly, slide } = def
 	// Read-only thread (e.g. the Screener): renders the messages but hides every action — the thread
 	// toolbar, per-message actions, the block banner and the reply/forward bar — and never marks read.
 	readonly?: boolean
-	// Transition name for the mobile swipe paging ('thread-next' / 'thread-prev'); the owner
-	// arms it per swipe and clears it on slideDone, so other thread changes swap instantly.
+	// Transition name for the mobile swipe paging ('page-next' / 'page-prev', styled in
+	// MailLayout); the owner arms it per swipe and clears it on slideDone, so other thread
+	// changes swap instantly.
 	slide?: string
 }>()
 
@@ -1077,36 +1078,3 @@ const getForwardedContent = (mail: Mail) => {
 }
 </script>
 
-<style scoped>
-/* Swipe paging between threads (mobile): the incoming thread's content slides in from
-   the swipe side while the outgoing one — lifted out of flow so they overlap — slides
-   away in tandem. The toolbar above the sliding region stays put. */
-.thread-next-enter-active,
-.thread-next-leave-active,
-.thread-prev-enter-active,
-.thread-prev-leave-active {
-	transition: transform 0.2s cubic-bezier(0.32, 0.72, 0, 1);
-}
-
-.thread-next-leave-active,
-.thread-prev-leave-active {
-	position: absolute;
-	inset: 0;
-}
-
-.thread-next-enter-from {
-	transform: translateX(100%);
-}
-
-.thread-next-leave-to {
-	transform: translateX(-100%);
-}
-
-.thread-prev-enter-from {
-	transform: translateX(-100%);
-}
-
-.thread-prev-leave-to {
-	transform: translateX(100%);
-}
-</style>

--- a/frontend/src/apps/mail/components/Modals/SearchModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SearchModal.vue
@@ -99,18 +99,14 @@
 							v-model="filter.to"
 							:label="__('To')"
 						/>
-						<div class="flex space-x-4">
-							<ContactCombobox
-								v-model="filter.cc"
-								:label="__('Cc')"
-								class="w-full"
-							/>
-							<ContactCombobox
-								v-model="filter.bcc"
-								:label="__('Bcc')"
-								class="w-full"
-							/>
-						</div>
+						<ContactCombobox
+							v-model="filter.cc"
+							:label="__('Cc')"
+						/>
+						<ContactCombobox
+							v-model="filter.bcc"
+							:label="__('Bcc')"
+						/>
 						<div class="flex space-x-4">
 							<FormControl
 								v-model="filter.after"
@@ -125,32 +121,32 @@
 								class="w-full"
 							/>
 						</div>
-						<FormControl
-							v-model="filter.hasAttachment"
-							type="select"
-							:label="__('Attachments')"
-							:options="getAttachmentOptions()"
-						/>
-						<FormControl
-							v-model="filter.isRead"
-							type="select"
-							:label="__('Read Status')"
-							:options="getReadStatusOptions()"
-						/>
+						<div class="flex space-x-4">
+							<FormControl
+								v-model="filter.hasAttachment"
+								type="select"
+								:label="__('Attachments')"
+								:options="getAttachmentOptions()"
+								class="w-full min-w-0"
+							/>
+							<FormControl
+								v-model="filter.isRead"
+								type="select"
+								:label="__('Read Status')"
+								:options="getReadStatusOptions()"
+								class="w-full min-w-0"
+							/>
+						</div>
 					</div>
-					<div
-						class="flex w-full p-4"
-						:class="isMobile ? 'flex-col space-y-4' : 'justify-end space-x-4'"
-					>
-						<Button
-							:label="__('Clear Filters')"
-							class="w-full sm:w-28"
-							@click="clearFilters()"
-						/>
+					<!-- Desktop-only: on mobile filters apply live (the chips row and quick
+					     results reflect them as they're set), so the footer buttons are
+					     redundant next to the filters toggle and Enter. -->
+					<div v-if="!isMobile" class="flex w-full justify-end space-x-4 p-4">
+						<Button :label="__('Clear Filters')" class="w-28" @click="clearFilters()" />
 						<Button
 							:label="__('Search')"
 							variant="solid"
-							class="w-full sm:w-28"
+							class="w-28"
 							@click="openSearchPage"
 						/>
 					</div>

--- a/frontend/src/apps/mail/components/Modals/SearchModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SearchModal.vue
@@ -38,9 +38,6 @@
 					v-if="!showAdvancedFilters && !opTrigger"
 					class="flex flex-wrap items-center gap-1.5 px-4 py-2"
 				>
-					<span v-if="!activeFilters.length" class="text-ink-gray-5 text-xs">
-						{{ __('Filter by') }}
-					</span>
 					<span
 						v-for="chip in activeFilters"
 						:key="chip.key"
@@ -465,7 +462,7 @@ const QUICK_FILTERS = computed<QuickFilter[]>(() =>
 		{ label: __('From'), key: 'from', op: 'from' },
 		{ label: __('To'), key: 'to', op: 'to' },
 		{ label: __('With attachments'), key: 'hasAttachment', apply: () => (filter.hasAttachment = 'true') },
-		{ label: __('Read'), key: 'isRead', apply: () => (filter.isRead = 'true') },
+		{ label: __('Unread'), key: 'isRead', apply: () => (filter.isRead = 'false') },
 		// `in:` (folder) is account-scoped, so it's dropped from a cross-account search.
 	].filter((f) => f.op !== 'in' || !allAccounts.value),
 )

--- a/frontend/src/apps/mail/components/Modals/SearchModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SearchModal.vue
@@ -7,12 +7,7 @@
 		<template #body>
 			<div class="bg-surface-base">
 				<div class="flex items-center border-b px-4 py-2">
-					<Button v-if="isMobile" variant="ghost" @click="show = false">
-						<template #icon>
-							<ChevronLeft class="text-ink-gray-5 h-4 w-4" />
-						</template>
-					</Button>
-					<Search v-else class="text-ink-gray-5 h-4 w-4" />
+					<Search class="text-ink-gray-5 h-4 w-4" />
 					<input
 						ref="searchInput"
 						v-model="filter.text"
@@ -41,8 +36,11 @@
 					<span
 						v-for="chip in activeFilters"
 						:key="chip.key"
-						class="bg-surface-gray-2 inline-flex h-7 items-center gap-1 rounded pl-2 pr-1 text-xs"
-						:class="{ 'hover:bg-surface-gray-3 cursor-pointer': isClickableChip(chip.key) }"
+						class="bg-surface-gray-2 inline-flex items-center gap-1 rounded pl-2 pr-1"
+						:class="[
+							isMobile ? 'h-8 text-sm' : 'h-7 text-xs',
+							{ 'hover:bg-surface-gray-3 cursor-pointer': isClickableChip(chip.key) },
+						]"
 						@click="isClickableChip(chip.key) && handleChipClick(chip.key)"
 					>
 						<span class="max-w-40 truncate">{{ chip.label }}</span>
@@ -58,7 +56,7 @@
 						v-for="f in inactiveQuickFilters"
 						:key="f.label"
 						variant="outline"
-						class="!h-7 text-xs"
+						:class="isMobile ? '!h-8 text-sm' : '!h-7 text-xs'"
 						@click="applyQuickFilter(f)"
 					>
 						<span class="flex items-center gap-1">
@@ -69,7 +67,7 @@
 					<Button
 						v-if="activeFilters.length"
 						variant="ghost"
-						class="text-xs"
+						:class="isMobile ? 'text-sm' : 'text-xs'"
 						:label="__('Clear all')"
 						@click="clearFilters()"
 					/>
@@ -266,7 +264,7 @@
 import { computed, nextTick, reactive, ref, useTemplateRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { watchDebounced } from '@vueuse/core'
-import { ChevronLeft, Paperclip, Plus, Search, SlidersHorizontal, X } from 'lucide-vue-next'
+import { Paperclip, Plus, Search, SlidersHorizontal, X } from 'lucide-vue-next'
 import { Avatar, Button, Dialog, FormControl, Switch, createResource } from 'frappe-ui'
 import { Icon } from 'frappe-ui/icons'
 

--- a/frontend/src/apps/mail/components/PWASettings.vue
+++ b/frontend/src/apps/mail/components/PWASettings.vue
@@ -1,49 +1,217 @@
 <template>
 	<div class="bg-surface-base fixed inset-0 z-20 flex flex-col">
-		<!-- Same compact-header recipe as ThreadHeader: -ml-2 cancels the ghost
-		     button's padding so the chevron glyph lands on the body's px-3 axis. -->
-		<div class="sticky top-0 flex min-h-14 items-center border-b px-3">
+		<!-- Root bar — same compact-header recipe as ThreadHeader: -ml-2 cancels
+		     the ghost button's padding so the chevron glyph lands on the body's
+		     px-3 axis. -->
+		<div class="bg-surface-base flex min-h-14 shrink-0 items-center border-b px-3">
 			<Button variant="ghost" class="-ml-2 mr-2 !h-8 !w-8 shrink-0" @click="emit('close')">
 				<template #icon>
 					<ChevronLeft class="icon !h-[18px] !w-[18px]" />
 				</template>
 			</Button>
 
-			<h2 class="text-xl-semibold leading-5">{{ __('Settings') }}</h2>
+			<h2 class="text-xl-semibold min-w-0 flex-1 truncate leading-5">{{ __('Settings') }}</h2>
 		</div>
 
-		<div class="px-3 py-2">
-			<SettingsRow :title="__('Enable Push Notifications')" :description>
-				<Switch
-					size="md"
-					:model-value="isPushNotificationsSettingEnabled"
-					:disabled="!isPushNotificationEnabled || isLoading"
-					@update:model-value="togglePushNotifications"
-				/>
-			</SettingsRow>
+		<!-- Root: grouped section list mirroring the desktop dialog's groups -->
+		<div class="min-h-0 flex-1 overflow-y-auto px-3 pb-[calc(1rem+env(safe-area-inset-bottom))] pt-2">
+			<template v-for="group in groups" :key="group.label">
+				<div class="text-ink-gray-5 px-1 pb-1 pt-3 text-sm">{{ group.label }}</div>
+				<button
+					v-for="tab in group.items"
+					:key="tab.value"
+					class="active:bg-surface-gray-1 text-ink-gray-8 flex w-full items-center gap-3 rounded-lg px-1 py-2.5 text-base"
+					@click="activeTab = tab"
+				>
+					<component :is="tab.icon" class="text-ink-gray-6 h-4 w-4 shrink-0" />
+					<span class="flex-1 truncate text-left">{{ tab.label }}</span>
+					<ChevronRight class="text-ink-gray-4 h-4 w-4 shrink-0" />
+				</button>
+			</template>
+		</div>
 
-			<div v-if="isLoading" class="-mt-0.5 flex items-center gap-2">
-				<LoadingIndicator class="text-ink-gray-7 h-3 w-3" />
-				<span class="text-sm">
-					{{
-						isPushNotificationsSettingEnabled
-							? __('Disabling Push Notifications...')
-							: __('Enabling Push Notifications...')
-					}}
-				</span>
+		<!-- Sub-page: a full-height layer with its own bar, so the entire page
+		     (bar included) slides in as one — same push as the thread pane. -->
+		<Transition
+			enter-active-class="transition-transform duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
+			enter-from-class="translate-x-full"
+			leave-active-class="transition-transform duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
+			leave-to-class="translate-x-full"
+		>
+			<div v-if="activeTab" class="bg-surface-base absolute inset-0 flex flex-col">
+				<div class="bg-surface-base flex min-h-14 shrink-0 items-center border-b px-3">
+					<Button variant="ghost" class="-ml-2 mr-2 !h-8 !w-8 shrink-0" @click="activeTab = null">
+						<template #icon>
+							<ChevronLeft class="icon !h-[18px] !w-[18px]" />
+						</template>
+					</Button>
+
+					<h2 class="text-xl-semibold min-w-0 flex-1 truncate leading-5">
+						{{ activeTab.label }}
+					</h2>
+
+					<!-- Sub-page actions (e.g. Save) teleport here from AppSettingsHeader —
+					     nav-bar placement; the target lives in this layer, so actions slide
+					     out with the page. -->
+					<div id="app-settings-page-actions" class="flex shrink-0 items-center gap-2" />
+				</div>
+
+				<div class="flex min-h-0 flex-1 flex-col overflow-y-auto pb-[env(safe-area-inset-bottom)]">
+					<!-- Notifications is PWA-specific, so it lives here instead of the
+					     shared Settings/ components. -->
+					<div v-if="activeTab.value === 'notifications'" class="px-4 py-2">
+						<SettingsRow :title="__('Enable Push Notifications')" :description>
+							<Switch
+								size="md"
+								:model-value="isPushNotificationsSettingEnabled"
+								:disabled="!isPushNotificationEnabled || isLoading"
+								@update:model-value="togglePushNotifications"
+							/>
+						</SettingsRow>
+
+						<div v-if="isLoading" class="-mt-0.5 flex items-center gap-2">
+							<LoadingIndicator class="text-ink-gray-7 h-3 w-3" />
+							<span class="text-sm">
+								{{
+									isPushNotificationsSettingEnabled
+										? __('Disabling Push Notifications...')
+										: __('Enabling Push Notifications...')
+								}}
+							</span>
+						</div>
+					</div>
+					<component :is="activeTab.component" v-else />
+				</div>
 			</div>
-		</div>
+		</Transition>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
-import { ChevronLeft } from 'lucide-vue-next'
+import { computed, inject, markRaw, provide, ref, type Component } from 'vue'
+import {
+	BellRing,
+	ChevronLeft,
+	ChevronRight,
+	Eye,
+	Feather,
+	Fingerprint,
+	Folders,
+	Mailbox,
+	Palette,
+	TreePalm,
+	User,
+} from 'lucide-vue-next'
 import { Button, LoadingIndicator, SettingsRow, Switch, createResource } from 'frappe-ui'
 
 import { raiseToast } from '@/apps/mail/utils'
+import Account from '@/apps/mail/components/Settings/Account.vue'
+import AppearanceSettings from '@/apps/mail/components/Settings/AppearanceSettings.vue'
+import FolderSettings from '@/apps/mail/components/Settings/FolderSettings.vue'
+import IdentitySettings from '@/apps/mail/components/Settings/IdentitySettings.vue'
+import ProfileSettings from '@/apps/mail/components/Settings/ProfileSettings.vue'
+import ScreenedEmailAddressSettings from '@/apps/mail/components/Settings/ScreenedEmailAddressSettings.vue'
+import SignatureSettings from '@/apps/mail/components/Settings/SignatureSettings.vue'
+import VacationResponseSettings from '@/apps/mail/components/Settings/VacationResponseSettings.vue'
+
+type SettingsTab = {
+	label: string
+	value: string
+	icon: Component
+	component?: Component
+	condition?: boolean
+}
 
 const emit = defineEmits(['close'])
+
+// Embedded Settings/* components render AppSettingsHeader/Body; this flag makes
+// those wrappers use page paddings and drop the duplicate section title (the
+// top bar here carries it).
+provide('app-settings-mobile-page', true)
+
+const user = inject('$user') as { data: Record<string, any> }
+
+const activeTab = ref<SettingsTab | null>(null)
+
+// Mobile subset of the desktop dialog's tabs: Credentials/Identity/Automation/
+// Import/Export/Advanced stay desktop-only (rare, file-heavy, or developer tasks).
+const groups = computed(() => {
+	const jmap = !!user.data?.is_jmap_configured
+
+	return [
+		{
+			label: __('General'),
+			items: [
+				{ label: __('Profile'), value: 'profile', icon: User, component: markRaw(ProfileSettings) },
+				{
+					label: __('Account'),
+					value: 'account',
+					icon: Mailbox,
+					component: markRaw(Account),
+					condition: jmap,
+				},
+				{
+					label: __('Identity'),
+					value: 'identity',
+					icon: Fingerprint,
+					component: markRaw(IdentitySettings),
+					condition: jmap,
+				},
+				{
+					label: __('Appearance'),
+					value: 'appearance',
+					icon: Palette,
+					component: markRaw(AppearanceSettings),
+				},
+				// Per-browser-installation state: toggling push affects only this device.
+				{ label: __('Notifications'), value: 'notifications', icon: BellRing },
+			],
+		},
+		{
+			label: __('Mail'),
+			items: [
+				{
+					label: __('Folders'),
+					value: 'folders',
+					icon: Folders,
+					component: markRaw(FolderSettings),
+					condition: jmap,
+				},
+				{
+					label: __('Signatures'),
+					value: 'signatures',
+					icon: Feather,
+					component: markRaw(SignatureSettings),
+					condition: jmap,
+				},
+				{
+					label: __('Vacation Response'),
+					value: 'vacation-response',
+					icon: TreePalm,
+					component: markRaw(VacationResponseSettings),
+					condition: jmap,
+				},
+			],
+		},
+		{
+			label: __('Privacy'),
+			items: [
+				{
+					label: __('Screener'),
+					value: 'screened-senders',
+					icon: Eye,
+					component: markRaw(ScreenedEmailAddressSettings),
+					condition: jmap,
+				},
+			],
+		},
+	]
+		.map((group) => ({
+			...group,
+			items: group.items.filter((tab) => tab.condition === undefined || tab.condition),
+		}))
+		.filter((group) => group.items.length > 0)
+})
 
 const isPushNotificationsSettingEnabled = ref(
 	window.frappePushNotification?.isNotificationEnabled(),

--- a/frontend/src/apps/mail/components/PWASettings.vue
+++ b/frontend/src/apps/mail/components/PWASettings.vue
@@ -1,16 +1,18 @@
 <template>
-	<div class="bg-surface-base fixed inset-0 z-10 flex flex-col">
-		<div class="sticky top-0 flex items-center border-b px-3 py-2.5">
-			<Button variant="ghost" class="mr-2" @click="emit('close')">
+	<div class="bg-surface-base fixed inset-0 z-20 flex flex-col">
+		<!-- Same compact-header recipe as ThreadHeader: -ml-2 cancels the ghost
+		     button's padding so the chevron glyph lands on the body's px-3 axis. -->
+		<div class="sticky top-0 flex min-h-14 items-center border-b px-3">
+			<Button variant="ghost" class="-ml-2 mr-2 !h-8 !w-8 shrink-0" @click="emit('close')">
 				<template #icon>
-					<ChevronLeft class="text-ink-gray-5 h-4 w-4" />
+					<ChevronLeft class="icon !h-[18px] !w-[18px]" />
 				</template>
 			</Button>
 
 			<h2 class="text-xl-semibold leading-5">{{ __('Settings') }}</h2>
 		</div>
 
-		<div class="px-3 py-4">
+		<div class="px-3 py-2">
 			<SettingsRow :title="__('Enable Push Notifications')" :description>
 				<Switch
 					size="md"
@@ -20,7 +22,7 @@
 				/>
 			</SettingsRow>
 
-			<div v-if="isLoading" class="-mt-0.5 flex items-center gap-2 px-3">
+			<div v-if="isLoading" class="-mt-0.5 flex items-center gap-2">
 				<LoadingIndicator class="text-ink-gray-7 h-3 w-3" />
 				<span class="text-sm">
 					{{

--- a/frontend/src/apps/mail/components/SearchMobileLayout.vue
+++ b/frontend/src/apps/mail/components/SearchMobileLayout.vue
@@ -1,5 +1,9 @@
 <template>
-	<div class="bg-surface-base fixed inset-0 z-10" :class="{ hidden: !show }">
+	<!-- Presents as a slide-up sheet, same motion as compose/settings. -->
+	<div
+		class="bg-surface-base fixed inset-0 z-10 transition-[transform,visibility] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
+		:class="{ 'invisible translate-y-full': !show }"
+	>
 		<slot name="body" />
 	</div>
 </template>

--- a/frontend/src/apps/mail/components/SearchMobileLayout.vue
+++ b/frontend/src/apps/mail/components/SearchMobileLayout.vue
@@ -1,11 +1,20 @@
 <template>
-	<!-- Presents as a slide-up sheet, same motion as compose/settings. -->
-	<div
-		class="bg-surface-base fixed inset-0 z-10 transition-[transform,visibility] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
-		:class="{ 'invisible translate-y-full': !show }"
-	>
-		<slot name="body" />
-	</div>
+	<!-- Appears in place, no slide: searching and results are one page, so motion would read
+	     as a different surface. Stops above the tab bar (border + h-14 + safe area, so the
+	     bar's top hairline stays visible) — the bar's tabs dismiss the overlay; back gesture
+	     works via the history entry. Teleported to body: one host instance lives inside
+	     MailboxView's CSS-hidden desktop header (via HeaderActions), where a fixed child
+	     would never paint on mobile — and the layout's isolate stacking context would trap
+	     its z-index anyway. -->
+	<Teleport to="body">
+		<div
+			v-show="show"
+			class="bg-surface-base fixed inset-x-0 top-0 z-10 overflow-y-auto"
+			:style="{ bottom: 'calc(3.5rem + 1px + env(safe-area-inset-bottom))' }"
+		>
+			<slot name="body" />
+		</div>
+	</Teleport>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/apps/mail/components/SearchMobileLayout.vue
+++ b/frontend/src/apps/mail/components/SearchMobileLayout.vue
@@ -1,6 +1,6 @@
 <template>
 	<!-- Appears in place, no slide: searching and results are one page, so motion would read
-	     as a different surface. Stops above the tab bar (border + h-14 + safe area, so the
+	     as a different surface. Stops above the tab bar (border + h-15 + safe area, so the
 	     bar's top hairline stays visible) — the bar's tabs dismiss the overlay; back gesture
 	     works via the history entry. Teleported to body: one host instance lives inside
 	     MailboxView's CSS-hidden desktop header (via HeaderActions), where a fixed child
@@ -9,7 +9,7 @@
 	<Teleport to="body">
 		<div
 			v-show="show"
-			class="bg-surface-base fixed inset-x-0 bottom-[calc(3.5rem+1px+env(safe-area-inset-bottom))] top-0 z-10 overflow-y-auto"
+			class="bg-surface-base fixed inset-x-0 bottom-[calc(3.75rem+1px+env(safe-area-inset-bottom))] top-0 z-10 overflow-y-auto"
 		>
 			<slot name="body" />
 		</div>

--- a/frontend/src/apps/mail/components/SearchMobileLayout.vue
+++ b/frontend/src/apps/mail/components/SearchMobileLayout.vue
@@ -9,8 +9,7 @@
 	<Teleport to="body">
 		<div
 			v-show="show"
-			class="bg-surface-base fixed inset-x-0 top-0 z-10 overflow-y-auto"
-			:style="{ bottom: 'calc(3.5rem + 1px + env(safe-area-inset-bottom))' }"
+			class="bg-surface-base fixed inset-x-0 bottom-[calc(3.5rem+1px+env(safe-area-inset-bottom))] top-0 z-10 overflow-y-auto"
 		>
 			<slot name="body" />
 		</div>

--- a/frontend/src/apps/mail/components/SearchResultsHeader.vue
+++ b/frontend/src/apps/mail/components/SearchResultsHeader.vue
@@ -1,10 +1,33 @@
 <template>
-	<div class="flex flex-col gap-2.5 border-b border-l-transparent px-3.5 py-3 sm:border-l sm:px-5">
+	<!-- Mobile mirrors the search overlay's header exactly (same row, same input classes) —
+	     searching and results are one page; tapping the readonly input resumes editing. -->
+	<div
+		:class="
+			isMobile ? '' : 'flex flex-col gap-2.5 border-b border-l-transparent px-3.5 py-3 sm:border-l sm:px-5'
+		"
+	>
+		<div v-if="isMobile" class="flex items-center border-b px-4 py-2">
+			<Search class="text-ink-gray-5 h-4 w-4 shrink-0" />
+			<input
+				readonly
+				:value="searchQuery"
+				:placeholder="__('Search')"
+				:aria-label="__('Edit search')"
+				class="placeholder-ink-gray-4 w-full cursor-pointer border-none bg-transparent text-base focus:ring-0"
+				@mousedown.prevent="openSearch()"
+			/>
+			<Button variant="ghost" :aria-label="__('Filters')" @click="openSearch(true)">
+				<template #icon>
+					<SlidersHorizontal class="text-ink-gray-5 h-4 w-4" />
+				</template>
+			</Button>
+		</div>
 		<FormControl
+			v-else
 			type="text"
 			size="sm"
 			class="w-full cursor-pointer [&_input]:cursor-pointer"
-			:class="{ 'max-w-2xl': isMobile || !showReadingPane }"
+			:class="{ 'max-w-2xl': !showReadingPane }"
 			:model-value="searchQuery"
 			:placeholder="__('Search')"
 			:aria-label="__('Edit search')"
@@ -25,12 +48,19 @@
 				</button>
 			</template>
 		</FormControl>
-		<div v-if="searchFilterChips.length" class="flex flex-wrap items-center gap-1.5">
+		<div
+			v-if="searchFilterChips.length"
+			class="flex flex-wrap items-center gap-1.5"
+			:class="{ 'px-4 py-2': isMobile }"
+		>
 			<span
 				v-for="chip in searchFilterChips"
 				:key="chip.key"
-				class="bg-surface-gray-2 inline-flex h-7 items-center gap-1 rounded pl-2 pr-1 text-xs"
-				:class="{ 'hover:bg-surface-gray-3 cursor-pointer': isClickableChip(chip.key) }"
+				class="bg-surface-gray-2 inline-flex items-center gap-1 rounded pl-2 pr-1"
+				:class="[
+					isMobile ? 'h-8 text-sm' : 'h-7 text-xs',
+					{ 'hover:bg-surface-gray-3 cursor-pointer': isClickableChip(chip.key) },
+				]"
 				@click="isClickableChip(chip.key) && handleChipClick(chip.key)"
 			>
 				<span class="max-w-40 truncate">{{ chip.label }}</span>
@@ -43,7 +73,12 @@
 				</button>
 			</span>
 
-			<Button variant="ghost" class="text-xs" :label="__('Clear all')" @click="clearSearch" />
+			<Button
+				variant="ghost"
+				:class="isMobile ? 'text-sm' : 'text-xs'"
+				:label="__('Clear all')"
+				@click="clearSearch"
+			/>
 		</div>
 	</div>
 </template>

--- a/frontend/src/apps/mail/components/SendMailMobileLayout.vue
+++ b/frontend/src/apps/mail/components/SendMailMobileLayout.vue
@@ -1,10 +1,12 @@
 <template>
 	<!-- Presents as a slide-up sheet (modal task), unlike the thread's lateral push.
 	     Stays mounted and slides via transform so dismissal animates too; visibility
-	     flips after the slide-out, keeping the closed sheet out of the focus order. -->
+	     flips after the slide-out, keeping the closed sheet out of the focus order.
+	     z-30: above the thread's reply bar (z-20), which stays mounted underneath
+	     and is revealed as the sheet slides out. -->
 	<div
-		class="bg-surface-base fixed inset-0 z-10 flex flex-col transition-[transform,visibility] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
-		:class="{ 'invisible translate-y-full': !show }"
+		class="bg-surface-base fixed inset-0 z-30 flex flex-col transition-[transform,visibility] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
+		:class="{ 'invisible translate-y-full': !show || !painted }"
 	>
 		<div class="sticky top-0 flex items-center border-b px-3 py-2.5">
 			<Button variant="ghost" class="mr-2" @click="close">
@@ -14,7 +16,7 @@
 			</Button>
 			<h2 class="flex-1">{{ __('Compose Mail') }}</h2>
 			<!-- AdaptiveDropdown (bottom sheet, z-50): a plain Dropdown's popup portals
-			     to body with no z-index, so this z-10 sheet would paint over it. -->
+			     to body with no z-index, so this sheet would paint over it. -->
 			<AdaptiveDropdown :options="ACTIONS">
 				<Button variant="ghost" class="mr-2">
 					<template #icon>
@@ -33,7 +35,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, watch } from 'vue'
+import { onMounted, onUnmounted, ref, watch } from 'vue'
 import { EllipsisVertical, SendHorizontal, Trash2, X } from 'lucide-vue-next'
 import { Button } from 'frappe-ui'
 
@@ -50,11 +52,26 @@ const close = () => {
 	}
 }
 
-watch(show, (val) => {
-	if (val) history.pushState(null, '')
-})
+// Reply/forward mounts this sheet on demand with `show` already true, so the open
+// state must be gated on a first painted frame in the closed position — otherwise
+// the first open renders in place instead of sliding up. Double rAF: the closed
+// frame is committed before the class flips, which a single rAF doesn't guarantee.
+const painted = ref(false)
 
-onMounted(() => window.addEventListener('popstate', close))
+// `immediate` covers that same mounted-already-open case for the history entry,
+// so the back gesture closes the sheet on first open too.
+watch(
+	show,
+	(val) => {
+		if (val) history.pushState(null, '')
+	},
+	{ immediate: true },
+)
+
+onMounted(() => {
+	requestAnimationFrame(() => requestAnimationFrame(() => (painted.value = true)))
+	window.addEventListener('popstate', close)
+})
 onUnmounted(() => window.removeEventListener('popstate', close))
 
 const ACTIONS = [

--- a/frontend/src/apps/mail/components/SendMailMobileLayout.vue
+++ b/frontend/src/apps/mail/components/SendMailMobileLayout.vue
@@ -1,19 +1,27 @@
 <template>
-	<div class="bg-surface-base fixed inset-0 z-10 flex flex-col" :class="{ hidden: !show }">
+	<!-- Presents as a slide-up sheet (modal task), unlike the thread's lateral push.
+	     Stays mounted and slides via transform so dismissal animates too; visibility
+	     flips after the slide-out, keeping the closed sheet out of the focus order. -->
+	<div
+		class="bg-surface-base fixed inset-0 z-10 flex flex-col transition-[transform,visibility] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
+		:class="{ 'invisible translate-y-full': !show }"
+	>
 		<div class="sticky top-0 flex items-center border-b px-3 py-2.5">
 			<Button variant="ghost" class="mr-2" @click="close">
 				<template #icon>
 					<X class="text-ink-gray-5 h-4 w-4" />
 				</template>
 			</Button>
-			<h2>{{ __('Compose Mail') }}</h2>
-			<Dropdown :options="ACTIONS">
-				<Button variant="ghost" class="ml-auto mr-2">
+			<h2 class="flex-1">{{ __('Compose Mail') }}</h2>
+			<!-- AdaptiveDropdown (bottom sheet, z-50): a plain Dropdown's popup portals
+			     to body with no z-index, so this z-10 sheet would paint over it. -->
+			<AdaptiveDropdown :options="ACTIONS">
+				<Button variant="ghost" class="mr-2">
 					<template #icon>
 						<EllipsisVertical class="text-ink-gray-5 h-4 w-4" />
 					</template>
 				</Button>
-			</Dropdown>
+			</AdaptiveDropdown>
 			<Button variant="ghost" @click="emit('sendMail')">
 				<template #icon>
 					<SendHorizontal class="text-ink-gray-5 h-4 w-4" />
@@ -27,7 +35,9 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, watch } from 'vue'
 import { EllipsisVertical, SendHorizontal, Trash2, X } from 'lucide-vue-next'
-import { Button, Dropdown } from 'frappe-ui'
+import { Button } from 'frappe-ui'
+
+import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 
 const show = defineModel<boolean>()
 
@@ -52,6 +62,7 @@ const ACTIONS = [
 		label: __('Discard'),
 		onClick: () => emit('discardMail'),
 		icon: Trash2,
+		theme: 'red',
 	},
 ]
 </script>

--- a/frontend/src/apps/mail/components/Settings/Account.vue
+++ b/frontend/src/apps/mail/components/Settings/Account.vue
@@ -4,6 +4,7 @@
 			<Button
 				:label="__('Save')"
 				variant="solid"
+				:size="isMobile ? 'md' : 'sm'"
 				:disabled="loading || !isDirty"
 				:loading="saving"
 				@click="save"
@@ -110,10 +111,12 @@ import AppSettingsHeader from '@/components/settings/AppSettingsHeader.vue'
 import AppSettingsBody from '@/components/settings/AppSettingsBody.vue'
 
 import { raiseToast } from '@/apps/mail/utils'
+import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 
 import type { Identity, MailboxData } from '@/apps/mail/types'
 
+const { isMobile } = useScreenSize()
 const user = inject('$user')
 // Read store.accountId live in makeParams; destructuring would snapshot the
 // unwrapped value and miss account switches while this component stays mounted.

--- a/frontend/src/apps/mail/components/Settings/AppearanceSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/AppearanceSettings.vue
@@ -19,7 +19,9 @@
 				variant="outline"
 				:options="COLOR_SCHEMES"
 			/>
-			<template v-if="user.data.is_jmap_configured">
+			<!-- Desktop-only concepts: the reading pane doesn't exist on mobile and
+			     the mobile list renders without group headers. -->
+			<template v-if="user.data.is_jmap_configured && !isMobile">
 				<SettingsRow
 					class="!py-0"
 					:title="__('Show Reading Pane')"
@@ -56,8 +58,10 @@ import AppSettingsHeader from '@/components/settings/AppSettingsHeader.vue'
 import AppSettingsBody from '@/components/settings/AppSettingsBody.vue'
 
 import { raiseToast } from '@/apps/mail/utils'
+import { useScreenSize } from '@/apps/mail/utils/composables'
 
 const user = inject('$user')
+const { isMobile } = useScreenSize()
 
 const colorScheme = ref(user.data.color_scheme)
 const showReadingPane = ref(!!user.data.show_reading_pane)

--- a/frontend/src/apps/mail/components/Settings/AppearanceSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/AppearanceSettings.vue
@@ -4,6 +4,7 @@
 			<Button
 				:label="__('Save')"
 				variant="solid"
+				:size="isMobile ? 'md' : 'sm'"
 				:loading="saveSettings.loading"
 				:disabled="isNotDirty"
 				@click="() => saveSettings.submit()"

--- a/frontend/src/apps/mail/components/Settings/FolderSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/FolderSettings.vue
@@ -1,7 +1,12 @@
 <template>
 	<AppSettingsHeader :title="__('Folders')">
 		<template #actions>
-			<Button icon-left="plus" :label="__('New')" @click="editMailbox()" />
+			<Button
+				icon-left="plus"
+				:label="__('New')"
+				:size="isMobile ? 'md' : 'sm'"
+				@click="editMailbox()"
+			/>
 		</template>
 	</AppSettingsHeader>
 	<AppSettingsBody>
@@ -66,6 +71,7 @@ import AppSettingsBody from '@/components/settings/AppSettingsBody.vue'
 
 import { FOLDER_ICON_COLOR_MAP, SCREENER_MAILBOX_NAME } from '@/apps/mail/constants'
 import { getIcon, raiseToast } from '@/apps/mail/utils'
+import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import DeleteFolderModal from '@/apps/mail/components/Modals/DeleteFolderModal.vue'
 import FolderModal from '@/apps/mail/components/Modals/FolderModal.vue'
@@ -73,6 +79,7 @@ import FolderModal from '@/apps/mail/components/Modals/FolderModal.vue'
 import type { MailboxData } from '@/apps/mail/types'
 
 const { mailboxes } = userStore()
+const { isMobile } = useScreenSize()
 
 // The Screener is a system folder driven by the screening flow, not a user-configurable folder — keep
 // it out of the management list so it can't be renamed, deleted, or given a folder icon/color here.

--- a/frontend/src/apps/mail/components/Settings/FolderSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/FolderSettings.vue
@@ -9,10 +9,10 @@
 			<div
 				v-for="mailbox in managedMailboxes"
 				:key="mailbox.name"
-				class="hover:bg-surface-gray-1 -mx-2 flex cursor-pointer items-center justify-between rounded px-3 py-1"
+				class="hover:bg-surface-gray-1 -mx-2 flex cursor-pointer items-center justify-between rounded px-3 py-1 max-sm:-mx-4 max-sm:px-4 max-sm:py-2"
 				@click="editMailbox(mailbox)"
 			>
-				<div class="flex items-center gap-2">
+				<div class="flex items-center gap-2 max-sm:gap-3">
 					<Icon
 						:name="getIcon(mailbox)"
 						class="icon shrink-0"
@@ -20,15 +20,20 @@
 					/>
 					<span class="text-base">{{ mailbox._name }}</span>
 				</div>
-				<div class="flex items-center gap-3">
+				<div class="flex items-center gap-3 max-sm:-mr-1.5">
 					<EyeOff v-if="!mailbox.subscribed" class="text-ink-gray-5 h-4 w-4" />
-					<Dropdown :options="mailboxOptions(mailbox)">
-						<Button variant="" @click.stop>
-							<template #icon>
-								<Ellipsis class="text-ink-gray-5 h-4 w-4" />
-							</template>
-						</Button>
-					</Dropdown>
+					<!-- .stop lives on the wrapper: AdaptiveDropdown's mobile trigger opens
+					     via the click bubbling to its own span, so stopping on the Button
+					     itself would keep the sheet from opening. -->
+					<div class="flex" @click.stop>
+						<AdaptiveDropdown :options="mailboxOptions(mailbox)" :title="mailbox._name">
+							<Button variant="">
+								<template #icon>
+									<Ellipsis class="text-ink-gray-5 h-4 w-4" />
+								</template>
+							</Button>
+						</AdaptiveDropdown>
+					</div>
 				</div>
 			</div>
 		</div>
@@ -52,9 +57,10 @@ import { Icon } from 'frappe-ui/icons'
 import { Ellipsis, Eye, EyeOff, Settings, Trash2 } from 'lucide-vue-next'
 import {
 	Button,
-	Dropdown,
 	createResource,
 } from 'frappe-ui'
+
+import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 import AppSettingsHeader from '@/components/settings/AppSettingsHeader.vue'
 import AppSettingsBody from '@/components/settings/AppSettingsBody.vue'
 

--- a/frontend/src/apps/mail/components/Settings/IdentitySettings.vue
+++ b/frontend/src/apps/mail/components/Settings/IdentitySettings.vue
@@ -4,6 +4,7 @@
 			<Button
 				:label="__('Save')"
 				variant="solid"
+				:size="isMobile ? 'md' : 'sm'"
 				:disabled="
 					identity.get.loading ||
 					JSON.stringify(identity.doc) === JSON.stringify(identity.originalDoc)
@@ -150,7 +151,7 @@ import AppSettingsHeader from '@/components/settings/AppSettingsHeader.vue'
 import AppSettingsBody from '@/components/settings/AppSettingsBody.vue'
 
 import { convertHtmlToText, raiseToast } from '@/apps/mail/utils'
-import { useTextEditorButtons } from '@/apps/mail/utils/composables'
+import { useScreenSize, useTextEditorButtons } from '@/apps/mail/utils/composables'
 import { CustomParagraphExtension } from '@/apps/mail/utils/text-editor'
 import { userStore } from '@/apps/mail/stores/user'
 import IdentitySettingsListView from '@/apps/mail/components/IdentitySettingsListView.vue'
@@ -161,6 +162,7 @@ const user = inject('$user')
 const { identities } = userStore()
 
 const { buttons } = useTextEditorButtons()
+const { isMobile } = useScreenSize()
 
 const signatures = useList({
 	doctype: 'Mail Signature',

--- a/frontend/src/apps/mail/components/Settings/ScreenedEmailAddressSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/ScreenedEmailAddressSettings.vue
@@ -51,7 +51,7 @@
 						@click="toggleSortDir"
 					/>
 				</div>
-				</div>
+			</div>
 
 			<div v-if="rows.length" class="relative min-h-0 flex-1">
 				<div

--- a/frontend/src/apps/mail/components/Settings/ScreenedEmailAddressSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/ScreenedEmailAddressSettings.vue
@@ -1,6 +1,6 @@
 <template>
 	<AppSettingsHeader :title="__('Screener')" />
-	<div class="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden px-[4.4rem] pb-8 pt-6">
+	<div class="flex min-h-0 flex-1 flex-col gap-5 overflow-hidden px-[4.4rem] pb-8 pt-6 max-sm:px-4 max-sm:pt-4">
 		<!-- The Screener's master switch, so this tab shows both the switch and the rules. Saves
 		     immediately (no Save button here) — same JMAP Account flag the Account tab edits. -->
 		<SettingsRow
@@ -16,6 +16,10 @@
 		</SettingsRow>
 
 		<template v-if="screenedAddresses.data?.length">
+			<div class="flex shrink-0 items-center justify-between">
+				<h2 class="text-base-semibold text-ink-gray-8">{{ __('Screened Senders') }}</h2>
+				<Button icon-left="lucide-plus" :label="__('New')" @click="showAddModal = true" />
+			</div>
 			<div class="flex shrink-0 gap-2">
 				<FormControl
 					v-model="search"
@@ -28,21 +32,26 @@
 						<FeatherIcon name="search" class="text-ink-gray-5 w-4" />
 					</template>
 				</FormControl>
-				<Dropdown :options="sortOptions">
+				<!-- Segmented sort control: field picker + direction toggle share a seam
+					(-ml-px collapses the doubled border). -->
+				<div class="flex">
+					<AdaptiveDropdown :options="sortOptions" :title="__('Sort By')">
+						<Button
+							variant="outline"
+							:label="sortLabel"
+							icon-right="lucide-chevron-down"
+							class="!rounded-r-none"
+						/>
+					</AdaptiveDropdown>
 					<Button
 						variant="outline"
-						:label="sortLabel"
-						icon-right="lucide-chevron-down"
+						:icon="sortDir === 'asc' ? 'lucide-arrow-up' : 'lucide-arrow-down'"
+						:tooltip="sortDir === 'asc' ? __('Ascending') : __('Descending')"
+						class="-ml-px !rounded-l-none"
+						@click="toggleSortDir"
 					/>
-				</Dropdown>
-				<Button
-					variant="outline"
-					:icon="sortDir === 'asc' ? 'lucide-arrow-up' : 'lucide-arrow-down'"
-					:tooltip="sortDir === 'asc' ? __('Ascending') : __('Descending')"
-					@click="toggleSortDir"
-				/>
-				<Button icon-left="lucide-plus" :label="__('New')" @click="showAddModal = true" />
-			</div>
+				</div>
+				</div>
 
 			<div v-if="rows.length" class="relative min-h-0 flex-1">
 				<div
@@ -57,21 +66,30 @@
 					>
 						<ListHeader />
 						<ListRows />
-						<ListSelectBanner>
-							<template #actions>
-								<Dropdown :options="bulkActionOptions">
+						<!-- Default-slot override: drops the banner's built-in "Select all"
+						     (redundant next to the header's master checkbox) and, on mobile,
+						     its min-w-[596px], which is wider than the screen. -->
+						<ListSelectBanner class="max-sm:!min-w-0">
+							<template #default="{ selections, unselectAll }">
+								<span class="text-ink-gray-9 shrink-0">
+									{{ __('{0} selected', [String(selections.size)]) }}
+								</span>
+								<div class="ml-auto flex items-center gap-1">
+									<AdaptiveDropdown :options="bulkActionOptions" :title="__('Change Action')">
+										<Button
+											variant="ghost"
+											:label="__('Change Action')"
+											icon-right="lucide-chevron-down"
+										/>
+									</AdaptiveDropdown>
 									<Button
 										variant="ghost"
-										:label="__('Change Action')"
-										icon-right="lucide-chevron-down"
+										theme="red"
+										:label="__('Remove')"
+										@click="showRemoveModal = true"
 									/>
-								</Dropdown>
-								<Button
-									variant="ghost"
-									theme="red"
-									:label="__('Remove')"
-									@click="showRemoveModal = true"
-								/>
+									<Button icon="lucide-x" variant="ghost" @click="unselectAll" />
+								</div>
 							</template>
 						</ListSelectBanner>
 					</ListView>
@@ -103,7 +121,6 @@ import { computed, ref, useTemplateRef } from 'vue'
 import {
 	Button,
 	Dialog,
-	Dropdown,
 	FeatherIcon,
 	FormControl,
 	ListHeader,
@@ -115,6 +132,8 @@ import {
 	createResource,
 } from 'frappe-ui'
 import AppSettingsHeader from '@/components/settings/AppSettingsHeader.vue'
+
+import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 
 import { getFormattedDate, raiseToast } from '@/apps/mail/utils'
 import { userStore } from '@/apps/mail/stores/user'
@@ -214,7 +233,7 @@ const SORT_LABELS: Record<SortField, string> = {
 const sortField = ref<SortField>('modified')
 const sortDir = ref<'asc' | 'desc'>('desc')
 
-const sortLabel = computed(() => __('Sort: {0}', [SORT_LABELS[sortField.value]]))
+const sortLabel = computed(() => SORT_LABELS[sortField.value])
 const sortOptions = computed(() =>
 	(Object.keys(SORT_LABELS) as SortField[]).map((field) => ({
 		label: SORT_LABELS[field],

--- a/frontend/src/apps/mail/components/Settings/SignatureSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/SignatureSettings.vue
@@ -1,7 +1,12 @@
 <template>
 	<AppSettingsHeader :title="__('Signatures')">
 		<template #actions>
-			<Button icon-left="plus" :label="__('New')" @click="showAddSignature = true" />
+			<Button
+				icon-left="plus"
+				:label="__('New')"
+				:size="isMobile ? 'md' : 'sm'"
+				@click="showAddSignature = true"
+			/>
 		</template>
 	</AppSettingsHeader>
 	<AppSettingsBody>
@@ -50,6 +55,8 @@
 import { inject, ref } from 'vue'
 import { Edit2, Ellipsis, Pin, Trash2 } from 'lucide-vue-next'
 import { Button, useList } from 'frappe-ui'
+
+import { useScreenSize } from '@/apps/mail/utils/composables'
 import AppSettingsHeader from '@/components/settings/AppSettingsHeader.vue'
 import AppSettingsBody from '@/components/settings/AppSettingsBody.vue'
 
@@ -61,6 +68,7 @@ import SetDefaultSignatureModal from '@/apps/mail/components/Modals/SetDefaultSi
 import type { MailSignature } from '@/apps/mail/types'
 
 const user = inject('$user')
+const { isMobile } = useScreenSize()
 
 const showAddSignature = ref(false)
 const selectedSignature = ref('')

--- a/frontend/src/apps/mail/components/Settings/SignatureSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/SignatureSettings.vue
@@ -9,17 +9,22 @@
 			<div
 				v-for="signature in signatures?.data"
 				:key="signature.name"
-				class="hover:bg-surface-gray-1 -mx-2 flex cursor-pointer items-center justify-between rounded px-3 py-1"
+				class="hover:bg-surface-gray-1 -mx-2 flex cursor-pointer items-center justify-between rounded px-3 py-1 max-sm:-mx-4 max-sm:px-4 max-sm:py-2"
 				@click="editSignature(signature.name)"
 			>
 				<span class="text-base">{{ signature.signature_name }}</span>
-				<Dropdown :options="signatureOptions(signature)">
-					<Button variant="" @click.stop>
-						<template #icon>
-							<Ellipsis class="text-ink-gray-5 h-4 w-4" />
-						</template>
-					</Button>
-				</Dropdown>
+				<!-- .stop lives on the wrapper: AdaptiveDropdown's mobile trigger opens
+				     via the click bubbling to its own span, so stopping on the Button
+				     itself would keep the sheet from opening. -->
+				<div class="flex max-sm:-mr-1.5" @click.stop>
+					<AdaptiveDropdown :options="signatureOptions(signature)" :title="signature.signature_name">
+						<Button variant="">
+							<template #icon>
+								<Ellipsis class="text-ink-gray-5 h-4 w-4" />
+							</template>
+						</Button>
+					</AdaptiveDropdown>
+				</div>
 			</div>
 		</div>
 
@@ -44,10 +49,11 @@
 <script setup lang="ts">
 import { inject, ref } from 'vue'
 import { Edit2, Ellipsis, Pin, Trash2 } from 'lucide-vue-next'
-import { Button, Dropdown, useList } from 'frappe-ui'
+import { Button, useList } from 'frappe-ui'
 import AppSettingsHeader from '@/components/settings/AppSettingsHeader.vue'
 import AppSettingsBody from '@/components/settings/AppSettingsBody.vue'
 
+import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 import AddSignatureModal from '@/apps/mail/components/Modals/AddSignatureModal.vue'
 import EditSignatureModal from '@/apps/mail/components/Modals/EditSignatureModal.vue'
 import SetDefaultSignatureModal from '@/apps/mail/components/Modals/SetDefaultSignatureModal.vue'

--- a/frontend/src/apps/mail/components/Settings/VacationResponseSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/VacationResponseSettings.vue
@@ -4,6 +4,7 @@
 			<Button
 				:label="__('Save')"
 				variant="solid"
+				:size="isMobile ? 'md' : 'sm'"
 				:disabled="
 					vacationResponse.loading ||
 					JSON.stringify(vacationResponse.data) === JSON.stringify(original)
@@ -73,7 +74,7 @@ import AppSettingsHeader from '@/components/settings/AppSettingsHeader.vue'
 import AppSettingsBody from '@/components/settings/AppSettingsBody.vue'
 
 import { convertHtmlToText, raiseToast } from '@/apps/mail/utils'
-import { useTextEditorButtons } from '@/apps/mail/utils/composables'
+import { useScreenSize, useTextEditorButtons } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import SetSieveScriptStateModal from '@/apps/mail/components/Modals/SetSieveScriptStateModal.vue'
 
@@ -83,6 +84,7 @@ const store = userStore()
 const dayjs = inject('$dayjs')
 
 const { buttons } = useTextEditorButtons()
+const { isMobile } = useScreenSize()
 
 const showConfirmDialog = ref(false)
 

--- a/frontend/src/apps/mail/components/ThreadHeader.vue
+++ b/frontend/src/apps/mail/components/ThreadHeader.vue
@@ -1,14 +1,14 @@
 <template>
 	<!-- px-3.5 matches the body/subject axis; the max-sm negative margins cancel the
 	     ghost buttons' own padding so the edge glyphs land on that axis too. -->
-	<div class="bg-surface-base border-b sticky top-0 flex items-center px-3.5 py-2.5 max-sm:border-b-0">
+	<div class="bg-surface-base border-b sticky top-0 flex items-center px-3.5 py-2.5 max-sm:min-h-14 max-sm:border-b-0 max-sm:py-0">
 		<Button
 			variant="ghost"
-			class="mr-2 shrink-0 max-sm:-ml-2"
+			class="mr-2 shrink-0 max-sm:-ml-2 max-sm:!h-8 max-sm:!w-8"
 			@click="$router.push({ name: 'mail-mailbox', params: { mailbox }, query: route.query })"
 		>
 			<template #icon>
-				<ChevronLeft class="icon" />
+				<ChevronLeft class="icon max-sm:!h-[18px] max-sm:!w-[18px]" />
 			</template>
 		</Button>
 		<template v-if="thread?.length">
@@ -17,50 +17,54 @@
 					{{ thread?.[0]?.subject || __('[No subject]') }}
 				</h2>
 			</Tooltip>
-			<div class="ml-auto shrink-0 space-x-2 max-sm:-mr-2">
-				<!-- Mobile always shows the actions inline — no "more" collapse. -->
-				<Dropdown v-if="user.data?.show_reading_pane && !isMobile" :options="threadActions">
+			<div class="ml-auto shrink-0 space-x-2 max-sm:-mr-2 max-sm:space-x-2">
+				<AdaptiveDropdown
+					v-if="user.data?.show_reading_pane && !isMobile"
+					:options="threadActions"
+					:title="__('Actions')"
+				>
 					<Button variant="ghost" :tooltip="__('Actions')">
 						<template #icon>
 							<Ellipsis class="icon" />
 						</template>
 					</Button>
-				</Dropdown>
+				</AdaptiveDropdown>
 				<template v-else>
 					<Button
 						v-for="action in threadActions.filter((a) => a.condition())"
 						:key="action.label"
 						:tooltip="action.label"
 						variant="ghost"
+						class="max-sm:!h-8 max-sm:!w-8"
 						@click="action.onClick"
 					>
 						<template #icon>
-							<component :is="action.icon" class="icon" />
+							<component :is="action.icon" class="icon max-sm:!h-[18px] max-sm:!w-[18px]" />
 						</template>
 					</Button>
 				</template>
 
-				<Dropdown :options="moveToOptions">
-					<Button variant="ghost" :tooltip="__('Move To')">
+				<AdaptiveDropdown :options="moveToOptions" :title="__('Move To')">
+					<Button variant="ghost" class="max-sm:!h-8 max-sm:!w-8" :tooltip="__('Move To')">
 						<template #icon>
-							<FolderInput class="icon" />
+							<FolderInput class="icon max-sm:!h-[18px] max-sm:!w-[18px]" />
 						</template>
 					</Button>
-				</Dropdown>
-				<Dropdown v-if="showAddTo" :options="addToOptions">
-					<Button variant="ghost" :tooltip="__('Add To')">
+				</AdaptiveDropdown>
+				<AdaptiveDropdown v-if="showAddTo" :options="addToOptions" :title="__('Add To')">
+					<Button variant="ghost" class="max-sm:!h-8 max-sm:!w-8" :tooltip="__('Add To')">
 						<template #icon>
-							<FolderPlus class="icon" />
+							<FolderPlus class="icon max-sm:!h-[18px] max-sm:!w-[18px]" />
 						</template>
 					</Button>
-				</Dropdown>
-				<Dropdown v-if="canRemoveFrom" :options="removeFromOptions">
-					<Button variant="ghost" :tooltip="__('Remove From')">
+				</AdaptiveDropdown>
+				<AdaptiveDropdown v-if="canRemoveFrom" :options="removeFromOptions" :title="__('Remove From')">
+					<Button variant="ghost" class="max-sm:!h-8 max-sm:!w-8" :tooltip="__('Remove From')">
 						<template #icon>
-							<FolderMinus class="icon" />
+							<FolderMinus class="icon max-sm:!h-[18px] max-sm:!w-[18px]" />
 						</template>
 					</Button>
-				</Dropdown>
+				</AdaptiveDropdown>
 
 				<!-- Prev/next thread arrows are a desktop affordance (↑/K, ↓/J). -->
 				<template v-if="threads.includes(threadID) && !isMobile">
@@ -113,6 +117,7 @@ import {
 import { Button, Dropdown, Tooltip } from 'frappe-ui'
 
 import { FOLDER_ICON_COLOR_MAP } from '@/apps/mail/constants'
+import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 import { getIcon, getMailboxName } from '@/apps/mail/utils'
 import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
@@ -168,7 +173,7 @@ const canRemoveFrom = computed(() =>
 
 const threadActions = computed((): Action[] => [
 	{
-		label: __('Star Thread'),
+		label: __('Star'),
 		onClick: () =>
 			emit(
 				'setFlagged',
@@ -179,7 +184,7 @@ const threadActions = computed((): Action[] => [
 		condition: () => thread.some((m) => !m.flagged),
 	},
 	{
-		label: __('Unstar Thread'),
+		label: __('Unstar'),
 		onClick: () =>
 			emit(
 				'setFlagged',
@@ -190,7 +195,7 @@ const threadActions = computed((): Action[] => [
 		condition: () => thread.every((m) => m.flagged),
 	},
 	{
-		label: __('Archive Thread (E)'),
+		label: __('Archive (E)'),
 		onClick: () =>
 			emit(
 				mailbox.value === mailboxIds.sent ? 'addThreadToMailbox' : 'moveThread',

--- a/frontend/src/apps/mail/components/ThreadHeader.vue
+++ b/frontend/src/apps/mail/components/ThreadHeader.vue
@@ -17,7 +17,7 @@
 					{{ thread?.[0]?.subject || __('[No subject]') }}
 				</h2>
 			</Tooltip>
-			<div class="ml-auto shrink-0 space-x-2 max-sm:-mr-2 max-sm:space-x-2">
+			<div class="ml-auto shrink-0 space-x-2 max-sm:-mr-2">
 				<AdaptiveDropdown
 					v-if="user.data?.show_reading_pane && !isMobile"
 					:options="threadActions"
@@ -114,7 +114,7 @@ import {
 	Star,
 	Trash2,
 } from 'lucide-vue-next'
-import { Button, Dropdown, Tooltip } from 'frappe-ui'
+import { Button, Tooltip } from 'frappe-ui'
 
 import { FOLDER_ICON_COLOR_MAP } from '@/apps/mail/constants'
 import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'

--- a/frontend/src/apps/mail/components/ThreadHeader.vue
+++ b/frontend/src/apps/mail/components/ThreadHeader.vue
@@ -1,8 +1,10 @@
 <template>
-	<div class="bg-surface-base sticky top-0 flex items-center border-b py-2.5 sm:px-3.5">
+	<!-- px-3.5 matches the body/subject axis; the max-sm negative margins cancel the
+	     ghost buttons' own padding so the edge glyphs land on that axis too. -->
+	<div class="bg-surface-base border-b sticky top-0 flex items-center px-3.5 py-2.5 max-sm:border-b-0">
 		<Button
 			variant="ghost"
-			class="mr-2 shrink-0"
+			class="mr-2 shrink-0 max-sm:-ml-2"
 			@click="$router.push({ name: 'mail-mailbox', params: { mailbox }, query: route.query })"
 		>
 			<template #icon>
@@ -15,8 +17,9 @@
 					{{ thread?.[0]?.subject || __('[No subject]') }}
 				</h2>
 			</Tooltip>
-			<div class="ml-auto shrink-0 space-x-2">
-				<Dropdown v-if="user.data?.show_reading_pane" :options="threadActions">
+			<div class="ml-auto shrink-0 space-x-2 max-sm:-mr-2">
+				<!-- Mobile always shows the actions inline — no "more" collapse. -->
+				<Dropdown v-if="user.data?.show_reading_pane && !isMobile" :options="threadActions">
 					<Button variant="ghost" :tooltip="__('Actions')">
 						<template #icon>
 							<Ellipsis class="icon" />
@@ -59,7 +62,8 @@
 					</Button>
 				</Dropdown>
 
-				<template v-if="threads.includes(threadID)">
+				<!-- Prev/next thread arrows are a desktop affordance (↑/K, ↓/J). -->
+				<template v-if="threads.includes(threadID) && !isMobile">
 					<Button
 						variant="ghost"
 						:tooltip="__('Previous Thread (↑/K)')"

--- a/frontend/src/apps/mail/components/mobile/MobileFolderSheet.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileFolderSheet.vue
@@ -1,0 +1,119 @@
+<template>
+	<BottomSheet v-model:open="isFolderSheetOpen" :title="__('Folders')">
+		<!-- BottomSheet provides the scroll container (h-[70vh] overflow-y-auto); this
+		     div only pads the content, including the home-indicator safe area. -->
+		<div class="px-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))]">
+			<button
+				v-if="showAllInboxes"
+				:class="rowClass(allInboxesActive)"
+				@click="go({ name: 'mail-all-inboxes' })"
+			>
+				<Mails class="text-ink-gray-6 h-[18px] w-[18px] shrink-0" stroke-width="1.6" />
+				<span class="flex-1 truncate text-left">{{ __('All Inboxes') }}</span>
+				<span v-if="allInboxesUnread.data" class="text-ink-gray-5 text-sm">
+					{{ allInboxesUnread.data }}
+				</span>
+			</button>
+
+			<template v-for="group in groups" :key="group.label">
+				<div class="text-ink-gray-5 px-3 pb-1 pt-3 text-sm">{{ group.label }}</div>
+				<button
+					v-for="folder in group.rows"
+					:key="folder.id"
+					:class="rowClass(folder.active)"
+					@click="go(folder.to)"
+				>
+					<Icon
+						:name="folder.icon"
+						class="h-[18px] w-[18px] shrink-0"
+						:class="folder.iconColor || 'text-ink-gray-6'"
+					/>
+					<span class="flex-1 truncate text-left">{{ folder.label }}</span>
+					<span v-if="folder.count" class="text-ink-gray-5 text-sm">{{ folder.count }}</span>
+				</button>
+			</template>
+		</div>
+	</BottomSheet>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter, type RouteLocationRaw } from 'vue-router'
+import { Mails } from 'lucide-vue-next'
+import { BottomSheet } from 'frappe-ui'
+import { Icon } from 'frappe-ui/icons'
+
+import { FOLDER_ICON_COLOR_MAP } from '@/apps/mail/constants'
+import { getIcon, getMailboxName } from '@/apps/mail/utils'
+import { useFolderSheet } from '@/apps/mail/utils/composables'
+import { userStore } from '@/apps/mail/stores/user'
+
+import type { MailboxData } from '@/apps/mail/types'
+
+const route = useRoute()
+const router = useRouter()
+const store = userStore()
+const { mailboxes, allInboxesUnread } = store
+const { isFolderSheetOpen, closeFolderSheet } = useFolderSheet()
+
+const showAllInboxes = computed(
+	() => (store.userResource?.data?.accounts?.length ?? 0) > 1,
+)
+const allInboxesActive = computed(() => route.name === 'mail-all-inboxes')
+
+// Same source, split, and ordering as the desktop sidebar: role folders (+ the
+// virtual Starred mailbox) under Default, roleless ones under Custom. The
+// Screener is excluded because it has its own tab in the bar.
+const groups = computed(() => {
+	const toRow = (mailbox: MailboxData) => ({
+		id: mailbox.id,
+		label: getMailboxName(mailbox),
+		icon: getIcon(mailbox),
+		iconColor: FOLDER_ICON_COLOR_MAP[mailbox.color],
+		count: mailbox.unread_threads || 0,
+		active: route.params.mailbox === mailbox.id,
+		to: {
+			name: 'mail-mailbox',
+			params: { accountId: store.accountId, mailbox: mailbox.id },
+		} as RouteLocationRaw,
+	})
+
+	const items =
+		mailboxes.data?.filter(
+			(mailbox: MailboxData) =>
+				mailbox.subscribed && mailbox.id !== store.mailboxIds.screener,
+		) ?? []
+
+	const starredRow = {
+		id: 'starred',
+		label: __('Starred'),
+		icon: 'star',
+		iconColor: '',
+		count: 0,
+		active: route.params.mailbox === 'starred',
+		to: {
+			name: 'mail-mailbox',
+			params: { accountId: store.accountId, mailbox: 'starred' },
+		} as RouteLocationRaw,
+	}
+
+	return [
+		{
+			label: __('Default'),
+			rows: [...items.filter((m: MailboxData) => m.role).map(toRow), starredRow],
+		},
+		{ label: __('Custom'), rows: items.filter((m: MailboxData) => !m.role).map(toRow) },
+	].filter((group) => group.rows.length)
+})
+
+const go = (to: RouteLocationRaw) => {
+	closeFolderSheet()
+	router.push(to)
+}
+
+const rowClass = (active: boolean) =>
+	[
+		'flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-base text-ink-gray-8',
+		active ? 'bg-surface-gray-2 !font-semibold' : 'active:bg-surface-gray-1',
+	].join(' ')
+</script>

--- a/frontend/src/apps/mail/components/mobile/MobileFolderSheet.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileFolderSheet.vue
@@ -8,7 +8,7 @@
 				:class="rowClass(allInboxesActive)"
 				@click="go({ name: 'mail-all-inboxes' })"
 			>
-				<Mails class="text-ink-gray-6 h-[18px] w-[18px] shrink-0" stroke-width="1.6" />
+				<Mails class="text-ink-gray-6 h-[18px] w-[18px] shrink-0" />
 				<span class="flex-1 truncate text-left">{{ __('All Inboxes') }}</span>
 				<span v-if="allInboxesUnread.data" class="text-ink-gray-5 text-sm">
 					{{ allInboxesUnread.data }}
@@ -33,7 +33,7 @@
 				</button>
 				<!-- Folder creation lives here now that the mobile drawer is gone. -->
 				<button v-if="group.isCustom" :class="rowClass(false)" @click="createFolder">
-					<Plus class="text-ink-gray-6 h-[18px] w-[18px] shrink-0" stroke-width="1.6" />
+					<Plus class="text-ink-gray-6 h-[18px] w-[18px] shrink-0" />
 					<span class="flex-1 truncate text-left">{{ __('New Folder') }}</span>
 				</button>
 			</template>

--- a/frontend/src/apps/mail/components/mobile/MobileFolderSheet.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileFolderSheet.vue
@@ -31,17 +31,25 @@
 					<span class="flex-1 truncate text-left">{{ folder.label }}</span>
 					<span v-if="folder.count" class="text-ink-gray-5 text-sm">{{ folder.count }}</span>
 				</button>
+				<!-- Folder creation lives here now that the mobile drawer is gone. -->
+				<button v-if="group.isCustom" :class="rowClass(false)" @click="createFolder">
+					<Plus class="text-ink-gray-6 h-[18px] w-[18px] shrink-0" stroke-width="1.6" />
+					<span class="flex-1 truncate text-left">{{ __('New Folder') }}</span>
+				</button>
 			</template>
 		</div>
 	</BottomSheet>
+	<FolderModal v-model="showFolderModal" :mailbox="undefined" />
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useRoute, useRouter, type RouteLocationRaw } from 'vue-router'
-import { Mails } from 'lucide-vue-next'
+import { Mails, Plus } from 'lucide-vue-next'
 import { BottomSheet } from 'frappe-ui'
 import { Icon } from 'frappe-ui/icons'
+
+import FolderModal from '@/apps/mail/components/Modals/FolderModal.vue'
 
 import { FOLDER_ICON_COLOR_MAP } from '@/apps/mail/constants'
 import { getIcon, getMailboxName } from '@/apps/mail/utils'
@@ -100,11 +108,24 @@ const groups = computed(() => {
 	return [
 		{
 			label: __('Default'),
+			isCustom: false,
 			rows: [...items.filter((m: MailboxData) => m.role).map(toRow), starredRow],
 		},
-		{ label: __('Custom'), rows: items.filter((m: MailboxData) => !m.role).map(toRow) },
-	].filter((group) => group.rows.length)
+		{
+			// Always rendered (even with no custom folders yet): it hosts New Folder.
+			label: __('Custom'),
+			isCustom: true,
+			rows: items.filter((m: MailboxData) => !m.role).map(toRow),
+		},
+	].filter((group) => group.isCustom || group.rows.length)
 })
+
+const showFolderModal = ref(false)
+
+const createFolder = () => {
+	closeFolderSheet()
+	showFolderModal.value = true
+}
 
 const go = (to: RouteLocationRaw) => {
 	closeFolderSheet()

--- a/frontend/src/apps/mail/components/mobile/MobileProfileSheet.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileProfileSheet.vue
@@ -17,11 +17,11 @@
 			<div class="border-outline-gray-1 my-2 border-t" />
 
 			<button :class="rowClass" @click="openAppSettings">
-				<Settings class="text-ink-gray-6 h-[18px] w-[18px] shrink-0" stroke-width="1.6" />
+				<Settings class="text-ink-gray-6 h-[18px] w-[18px] shrink-0" />
 				<span class="flex-1 truncate text-left">{{ __('Settings') }}</span>
 			</button>
 			<button :class="rowClass" @click="logout.submit">
-				<LogOut class="text-ink-red-6 h-[18px] w-[18px] shrink-0" stroke-width="1.6" />
+				<LogOut class="text-ink-red-6 h-[18px] w-[18px] shrink-0" />
 				<span class="text-ink-red-6 flex-1 truncate text-left">{{ __('Log Out') }}</span>
 			</button>
 		</div>

--- a/frontend/src/apps/mail/components/mobile/MobileProfileSheet.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileProfileSheet.vue
@@ -23,8 +23,8 @@
 				<span class="flex-1 truncate text-left">{{ __('Settings') }}</span>
 			</button>
 			<button :class="rowClass" @click="logout.submit">
-				<LogOut class="text-ink-red-4 h-[18px] w-[18px] shrink-0" stroke-width="1.6" />
-				<span class="text-ink-red-4 flex-1 truncate text-left">{{ __('Log Out') }}</span>
+				<LogOut class="text-ink-red-6 h-[18px] w-[18px] shrink-0" stroke-width="1.6" />
+				<span class="text-ink-red-6 flex-1 truncate text-left">{{ __('Log Out') }}</span>
 			</button>
 		</div>
 	</BottomSheet>

--- a/frontend/src/apps/mail/components/mobile/MobileProfileSheet.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileProfileSheet.vue
@@ -1,0 +1,73 @@
+<template>
+	<BottomSheet v-model:open="isProfileSheetOpen">
+		<div class="px-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))]">
+			<!-- Accounts: tap to switch (no add-account flow on mobile). -->
+			<button
+				v-for="account in accounts"
+				:key="account.id"
+				:class="rowClass"
+				@click="switchAccount(account.id)"
+			>
+				<Avatar :label="account._name" size="md" />
+				<span class="flex-1 truncate text-left">{{ account._name }}</span>
+				<Check v-if="account.id === store.accountId" class="text-ink-gray-6 icon shrink-0" />
+			</button>
+
+			<div class="border-outline-gray-1 my-2 border-t" />
+
+			<!-- Storage moved here from the (removed) mobile drawer. -->
+			<QuotaBar v-if="jmapConfigured" :is-collapsed="false" class="px-1" />
+
+			<button :class="rowClass" @click="openAppSettings">
+				<Settings class="text-ink-gray-6 h-[18px] w-[18px] shrink-0" stroke-width="1.6" />
+				<span class="flex-1 truncate text-left">{{ __('Settings') }}</span>
+			</button>
+			<button :class="rowClass" @click="logout.submit">
+				<LogOut class="text-ink-red-4 h-[18px] w-[18px] shrink-0" stroke-width="1.6" />
+				<span class="text-ink-red-4 flex-1 truncate text-left">{{ __('Log Out') }}</span>
+			</button>
+		</div>
+	</BottomSheet>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { Check, LogOut, Settings } from 'lucide-vue-next'
+import { Avatar, BottomSheet } from 'frappe-ui'
+
+import { useProfileSheet, useSettings } from '@/apps/mail/utils/composables'
+import { sessionStore } from '@/apps/mail/stores/session'
+import { userStore } from '@/apps/mail/stores/user'
+import QuotaBar from '@/apps/mail/components/QuotaBar.vue'
+
+const route = useRoute()
+const router = useRouter()
+const store = userStore()
+const { logout } = sessionStore()
+const { isProfileSheetOpen, closeProfileSheet } = useProfileSheet()
+const { openSettings } = useSettings()
+
+const accounts = computed(() => store.userResource?.data?.accounts ?? [])
+const jmapConfigured = computed(() => !!store.userResource?.data?.is_jmap_configured)
+
+// Same in-place accountId swap the sidebar's account submenu does; account-agnostic
+// routes (All Inboxes) go through the account shortcut instead.
+const switchAccount = (accountId: string) => {
+	closeProfileSheet()
+	if (accountId === store.accountId) return
+	router.push(
+		route.params.accountId
+			? { name: route.name!, params: { ...route.params, accountId } }
+			: { name: 'mail-account-shortcut', params: { accountId } },
+	)
+}
+
+const openAppSettings = () => {
+	closeProfileSheet()
+	openSettings()
+}
+
+const rowClass =
+	'flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-base text-ink-gray-8 active:bg-surface-gray-1'
+</script>

--- a/frontend/src/apps/mail/components/mobile/MobileProfileSheet.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileProfileSheet.vue
@@ -2,6 +2,7 @@
 	<BottomSheet v-model:open="isProfileSheetOpen">
 		<div class="px-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))]">
 			<!-- Accounts: tap to switch (no add-account flow on mobile). -->
+			<div class="text-ink-gray-5 px-3 pb-1 pt-1 text-sm">{{ __('Accounts') }}</div>
 			<button
 				v-for="account in accounts"
 				:key="account.id"
@@ -14,9 +15,6 @@
 			</button>
 
 			<div class="border-outline-gray-1 my-2 border-t" />
-
-			<!-- Storage moved here from the (removed) mobile drawer. -->
-			<QuotaBar v-if="jmapConfigured" :is-collapsed="false" class="px-1" />
 
 			<button :class="rowClass" @click="openAppSettings">
 				<Settings class="text-ink-gray-6 h-[18px] w-[18px] shrink-0" stroke-width="1.6" />
@@ -39,7 +37,6 @@ import { Avatar, BottomSheet } from 'frappe-ui'
 import { useProfileSheet, useSettings } from '@/apps/mail/utils/composables'
 import { sessionStore } from '@/apps/mail/stores/session'
 import { userStore } from '@/apps/mail/stores/user'
-import QuotaBar from '@/apps/mail/components/QuotaBar.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -49,7 +46,6 @@ const { isProfileSheetOpen, closeProfileSheet } = useProfileSheet()
 const { openSettings } = useSettings()
 
 const accounts = computed(() => store.userResource?.data?.accounts ?? [])
-const jmapConfigured = computed(() => !!store.userResource?.data?.is_jmap_configured)
 
 // Same in-place accountId swap the sidebar's account submenu does; account-agnostic
 // routes (All Inboxes) go through the account shortcut instead.

--- a/frontend/src/apps/mail/components/mobile/MobileProfileSheet.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileProfileSheet.vue
@@ -61,7 +61,11 @@ const switchAccount = (accountId: string) => {
 
 const openAppSettings = () => {
 	closeProfileSheet()
-	openSettings()
+	// The sheet (z-50) closes above the settings dialog (which has no z-index),
+	// so present settings only after the sheet's ~200ms exit — otherwise the
+	// dialog's slide-up plays hidden behind the closing sheet and reads as no
+	// animation at all.
+	setTimeout(openSettings, 250)
 }
 
 const rowClass =

--- a/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
@@ -50,7 +50,7 @@
 				</span>
 				<span class="text-[11px] font-medium !leading-3">{{ __('Screener') }}</span>
 			</button>
-			<button :class="tabClass(searchActive)" @click="showSearchModal = true">
+			<button :class="tabClass(searchActive)" @click="openSearch">
 				<Search class="h-[22px] w-[22px] stroke-2" />
 				<span class="text-[11px] font-medium !leading-3">{{ __('Search') }}</span>
 			</button>
@@ -127,9 +127,22 @@ const mailActive = computed(
 const screenerActive = computed(() => route.name === 'mail-screener')
 const searchActive = computed(() => showSearchModal.value || isSearchRoute.value)
 
+// The Search tab is a navigation like the others: it lands on the search page (so tab
+// selection stays route-driven — an overlay over a mail route read as two active tabs),
+// then opens the query editor on top of it. Navigate first: the editor pushes its own
+// history state, which must sit above the search page's entry for back to unwind cleanly.
+const openSearch = async () => {
+	if (!isSearchRoute.value)
+		await router.push({
+			name: 'mail-mailbox',
+			params: { accountId: store.accountId, mailbox: 'search' },
+		})
+	showSearchModal.value = true
+}
+
 const openMail = () => {
-	// The search overlay leaves the bar visible; a tab tap first dismisses it, landing
-	// back on whatever page the overlay covered.
+	// The query editor overlay leaves the bar visible; a tab tap first dismisses it. It
+	// only ever covers the search page now, so the tap always navigates on to the inbox.
 	if (showSearchModal.value) {
 		showSearchModal.value = false
 		if (!mailActive.value) router.push('/mail')

--- a/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
@@ -2,12 +2,17 @@
 	<!-- Compose FAB — floats above the bar, right thumb zone. Both the FAB and the
 	     bar step aside while a thread is open: the thread's own reply actions own
 	     the bottom edge there (the modals below stay mounted regardless). Hidden in
-	     search results too — composing isn't part of the search task. -->
+	     search results and the screener too — composing isn't part of those tasks. -->
 	<Button
-		v-if="!isThreadOpen && !isMobileSelectionActive && !isSearchRoute && !showSearchModal"
+		v-if="
+			!isThreadOpen &&
+			!isMobileSelectionActive &&
+			!isSearchRoute &&
+			!showSearchModal &&
+			!screenerActive
+		"
 		variant="solid"
-		class="fixed right-4 z-10 !h-12 !w-12 !rounded-full shadow-lg"
-		:style="{ bottom: 'calc(4.75rem + env(safe-area-inset-bottom))' }"
+		class="fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] right-4 z-10 !h-12 !w-12 !rounded-full shadow-lg"
 		:aria-label="__('Compose')"
 		@click="showSendModal = true"
 	>
@@ -24,7 +29,7 @@
 		v-if="!isThreadOpen"
 		class="bg-surface-base/80 z-10 shrink-0 border-t pb-[env(safe-area-inset-bottom)] shadow-[0_-2px_5px_rgba(0,0,0,0.03)] backdrop-blur-lg"
 	>
-		<div class="flex h-14 items-stretch">
+		<div class="flex h-15 items-stretch">
 			<!-- Tab 1 morphs into the current folder: the fixed slot position is the
 			     stable cue; icon + label say where you are. Re-tap opens the switcher. -->
 			<button :class="tabClass(mailActive)" @click="openMail">
@@ -32,33 +37,33 @@
 					<Icon
 						v-if="currentFolder"
 						:name="currentFolder.icon"
-						class="h-[22px] w-[22px] shrink-0"
+						:class="iconClass(mailActive)"
 					/>
-					<Inbox v-else class="h-[22px] w-[22px] stroke-2" />
+					<Icon v-else name="inbox" :class="iconClass(mailActive)" />
 					<span v-if="mailBadgeCount" :class="badgeClass">{{
 						badgeText(mailBadgeCount)
 					}}</span>
 				</span>
-				<span class="max-w-full truncate px-1 text-[11px] font-medium !leading-3">
+				<span class="max-w-full truncate px-1" :class="labelClass(mailActive)">
 					{{ currentFolder?.label ?? __('Inbox') }}
 				</span>
 			</button>
 			<button v-if="screeningEnabled" :class="tabClass(screenerActive)" @click="openScreener">
 				<span class="relative">
-					<Eye class="h-[22px] w-[22px] stroke-2" />
+					<Icon name="eye" :class="iconClass(screenerActive)" />
 					<span v-if="screenerCount" :class="badgeClass">{{ badgeText(screenerCount) }}</span>
 				</span>
-				<span class="text-[11px] font-medium !leading-3">{{ __('Screener') }}</span>
+				<span :class="labelClass(screenerActive)">{{ __('Screener') }}</span>
 			</button>
 			<button :class="tabClass(searchActive)" @click="openSearch">
-				<Search class="h-[22px] w-[22px] stroke-2" />
-				<span class="text-[11px] font-medium !leading-3">{{ __('Search') }}</span>
+				<Icon name="search" :class="iconClass(searchActive)" />
+				<span :class="labelClass(searchActive)">{{ __('Search') }}</span>
 			</button>
 			<!-- Profile is a sheet over the current surface (search included), not a navigation —
 			     it must not dismiss the search overlay. -->
 			<button :class="tabClass(isProfileSheetOpen)" @click="openProfileSheet">
 				<Avatar :label="activeAccountName" size="md" class="shrink-0" />
-				<span class="text-[11px] font-medium !leading-3">{{ __('Profile') }}</span>
+				<span :class="labelClass(isProfileSheetOpen)">{{ __('Profile') }}</span>
 			</button>
 		</div>
 	</nav>
@@ -72,7 +77,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { Eye, Inbox, Search } from 'lucide-vue-next'
 import { Avatar, Button, FeatherIcon } from 'frappe-ui'
 import { Icon } from 'frappe-ui/icons'
 
@@ -198,18 +202,28 @@ const mailBadgeCount = computed(() => {
 
 // Numeric unread badge shared by the Mail and Screener tabs (replaces the old
 // presence dot). Bordered like the dot was, to read against the translucent bar.
-// Left-anchored at the icon's top-right corner so wide counts ("99+") grow
-// outward instead of spreading back across the glyph. ink-red-1 (not ink-white,
-// which this token set lacks) is white in both themes — the on-red text step.
+// Anchored at the icon's top-right (left 60%) and allowed to overflow, so wide
+// counts ("99+") grow outward instead of spreading back across the glyph — the
+// icon keeps its optical centering. ink-red-1 (not ink-white, which this token
+// set lacks) is white in both themes — the on-red text step.
 const badgeClass =
-	'bg-surface-red-6 text-ink-red-1 absolute -top-1 left-4 flex h-4 min-w-4 items-center justify-center rounded-full border border-[var(--surface-base)] px-1 text-[10px] font-semibold leading-none'
+	'bg-surface-red-6 text-ink-red-1 absolute -top-1.5 left-[60%] flex h-4 min-w-5 items-center justify-center rounded-full border border-[var(--surface-base)] px-1 text-[10px] font-semibold leading-none'
 
 const badgeText = (count: number) => (count > 99 ? '99+' : String(count))
 
-// Raven's tint model: active tabs at full ink, inactive at ~40%.
+// Active/inactive contrast rides two channels: ink (9 vs 4 — dropping inactive
+// to 3 read as more disparity but tipped into illegible) and weight (stroke 2
+// vs 1.75, semibold vs medium), so the active tab pops without any label going
+// faint.
 const tabClass = (active: boolean) =>
 	[
 		'flex flex-1 flex-col items-center justify-center gap-1',
-		active ? 'text-ink-gray-8' : 'text-ink-gray-4',
+		active ? 'text-ink-gray-9' : 'text-ink-gray-4',
 	].join(' ')
+
+const iconClass = (active: boolean) =>
+	['h-6 w-6 shrink-0', active ? 'stroke-2' : '[stroke-width:1.75]'].join(' ')
+
+const labelClass = (active: boolean) =>
+	['text-xs !leading-3', active ? '!font-semibold' : '!font-medium'].join(' ')
 </script>

--- a/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
@@ -1,0 +1,122 @@
+<template>
+	<!-- Compose FAB — floats above the bar, right thumb zone. -->
+	<Button
+		variant="solid"
+		class="fixed right-4 z-10 !h-12 !w-12 !rounded-full shadow-lg"
+		:style="{ bottom: 'calc(4.5rem + env(safe-area-inset-bottom))' }"
+		:aria-label="__('Compose')"
+		@click="showSendModal = true"
+	>
+		<template #icon>
+			<FeatherIcon name="edit" class="h-5 w-5" />
+		</template>
+	</Button>
+
+	<!-- Bottom tab bar — Raven-inspired: translucent bar with a hairline top border
+	     and faint upward shadow; lucide icons, tint-only active state. -->
+	<nav
+		class="bg-surface-base/80 z-10 shrink-0 border-t pb-[env(safe-area-inset-bottom)] shadow-[0_-2px_5px_rgba(0,0,0,0.03)] backdrop-blur-lg"
+	>
+		<div class="flex h-[52px] items-stretch">
+			<button :class="tabClass(mailActive)" @click="openMail">
+				<Inbox class="h-[22px] w-[22px]" stroke-width="2" />
+				<span class="text-[11px] font-medium !leading-3">{{ __('Mail') }}</span>
+			</button>
+			<button :class="tabClass(showSearchModal)" @click="showSearchModal = true">
+				<Search class="h-[22px] w-[22px]" stroke-width="2" />
+				<span class="text-[11px] font-medium !leading-3">{{ __('Search') }}</span>
+			</button>
+			<button v-if="screeningEnabled" :class="tabClass(screenerActive)" @click="openScreener">
+				<span class="relative">
+					<Eye class="h-[22px] w-[22px]" stroke-width="2" />
+					<!-- Raven-style unread dot (RailItemBadge dot recipe): presence, not a count. -->
+					<span
+						v-if="screenerCount"
+						class="bg-surface-red-6 absolute -right-0.5 -top-0.5 block size-2 rounded-full border border-[var(--surface-base)]"
+					/>
+				</span>
+				<span class="text-[11px] font-medium !leading-3">{{ __('Screener') }}</span>
+			</button>
+		</div>
+	</nav>
+
+	<SendMail v-model="showSendModal" />
+	<SearchModal v-model="showSearchModal" />
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { Eye, Inbox, Search } from 'lucide-vue-next'
+import { Button, FeatherIcon } from 'frappe-ui'
+
+import { userStore } from '@/apps/mail/stores/user'
+import SearchModal from '@/apps/mail/components/Modals/SearchModal.vue'
+import SendMail from '@/apps/mail/components/SendMail.vue'
+
+import type { MailboxData } from '@/apps/mail/types'
+
+const route = useRoute()
+const router = useRouter()
+const store = userStore()
+const { mailboxes } = store
+
+const showSendModal = ref(false)
+const showSearchModal = ref(false)
+
+const MAIL_ROUTES = ['mail-mailbox', 'mail-all-inboxes']
+const mailActive = computed(() => MAIL_ROUTES.includes(route.name as string))
+const screenerActive = computed(() => route.name === 'mail-screener')
+
+// Model 2 (grill-me): the Mail tab reopens the last-viewed mailbox, Inbox on first
+// launch. Stored per device; storage failures degrade to the /mail default redirect.
+const LAST_MAILBOX_KEY = 'mail-last-mailbox-path'
+
+watch(
+	() => route.fullPath,
+	() => {
+		if (!mailActive.value) return
+		try {
+			localStorage.setItem(LAST_MAILBOX_KEY, route.fullPath)
+		} catch {
+			// Storage unavailable — the tab falls back to /mail.
+		}
+	},
+	{ immediate: true },
+)
+
+const openMail = () => {
+	if (mailActive.value) return
+	let target = '/mail'
+	try {
+		target = localStorage.getItem(LAST_MAILBOX_KEY) || '/mail'
+	} catch {
+		// Storage unavailable — /mail redirects to the inbox.
+	}
+	router.push(target)
+}
+
+const openScreener = () => {
+	if (screenerActive.value) return
+	router.push({ name: 'mail-screener', params: { accountId: store.accountId } })
+}
+
+const screeningEnabled = computed(
+	() =>
+		!!store.userResource?.data?.accounts?.find((a) => a.id === store.accountId)
+			?.enable_screening,
+)
+
+const screenerCount = computed(
+	() =>
+		mailboxes.data?.find((m: MailboxData) => m.id === store.mailboxIds.screener)
+			?.unread_threads ?? 0,
+)
+
+// Raven's tint model: active tabs at full ink, inactive at ~40%.
+const tabClass = (active: boolean) =>
+	[
+		'flex flex-1 flex-col items-center justify-center gap-1',
+		active ? 'text-ink-gray-8' : 'text-ink-gray-4',
+	].join(' ')
+</script>

--- a/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
@@ -1,6 +1,9 @@
 <template>
-	<!-- Compose FAB — floats above the bar, right thumb zone. -->
+	<!-- Compose FAB — floats above the bar, right thumb zone. Both the FAB and the
+	     bar step aside while a thread is open: the thread's own reply actions own
+	     the bottom edge there (the modals below stay mounted regardless). -->
 	<Button
+		v-if="!isThreadOpen"
 		variant="solid"
 		class="fixed right-4 z-10 !h-12 !w-12 !rounded-full shadow-lg"
 		:style="{ bottom: 'calc(4.5rem + env(safe-area-inset-bottom))' }"
@@ -15,12 +18,22 @@
 	<!-- Bottom tab bar — Raven-inspired: translucent bar with a hairline top border
 	     and faint upward shadow; lucide icons, tint-only active state. -->
 	<nav
+		v-if="!isThreadOpen"
 		class="bg-surface-base/80 z-10 shrink-0 border-t pb-[env(safe-area-inset-bottom)] shadow-[0_-2px_5px_rgba(0,0,0,0.03)] backdrop-blur-lg"
 	>
 		<div class="flex h-[52px] items-stretch">
+			<!-- Tab 1 morphs into the current folder: the fixed slot position is the
+			     stable cue; icon + label say where you are. Re-tap opens the switcher. -->
 			<button :class="tabClass(mailActive)" @click="openMail">
-				<Inbox class="h-[22px] w-[22px]" stroke-width="2" />
-				<span class="text-[11px] font-medium !leading-3">{{ __('Mail') }}</span>
+				<Icon
+					v-if="currentFolder"
+					:name="currentFolder.icon"
+					class="h-[22px] w-[22px] shrink-0"
+				/>
+				<Inbox v-else class="h-[22px] w-[22px]" stroke-width="2" />
+				<span class="max-w-full truncate px-1 text-[11px] font-medium !leading-3">
+					{{ currentFolder?.label ?? __('Mail') }}
+				</span>
 			</button>
 			<button :class="tabClass(showSearchModal)" @click="showSearchModal = true">
 				<Search class="h-[22px] w-[22px]" stroke-width="2" />
@@ -37,25 +50,33 @@
 				</span>
 				<span class="text-[11px] font-medium !leading-3">{{ __('Screener') }}</span>
 			</button>
+			<button :class="tabClass(isProfileSheetOpen)" @click="openProfileSheet">
+				<Avatar :label="activeAccountName" size="md" class="shrink-0" />
+				<span class="text-[11px] font-medium !leading-3">{{ __('Profile') }}</span>
+			</button>
 		</div>
 	</nav>
 
 	<SendMail v-model="showSendModal" />
 	<SearchModal v-model="showSearchModal" />
 	<MobileFolderSheet />
+	<MobileProfileSheet />
 </template>
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { Eye, Inbox, Search } from 'lucide-vue-next'
-import { Button, FeatherIcon } from 'frappe-ui'
+import { Avatar, Button, FeatherIcon } from 'frappe-ui'
+import { Icon } from 'frappe-ui/icons'
 
-import { useFolderSheet } from '@/apps/mail/utils/composables'
+import { getIcon, getMailboxName } from '@/apps/mail/utils'
+import { useFolderSheet, useProfileSheet } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import SearchModal from '@/apps/mail/components/Modals/SearchModal.vue'
 import SendMail from '@/apps/mail/components/SendMail.vue'
 import MobileFolderSheet from '@/apps/mail/components/mobile/MobileFolderSheet.vue'
+import MobileProfileSheet from '@/apps/mail/components/mobile/MobileProfileSheet.vue'
 
 import type { MailboxData } from '@/apps/mail/types'
 
@@ -64,11 +85,26 @@ const router = useRouter()
 const store = userStore()
 const { mailboxes } = store
 const { openFolderSheet } = useFolderSheet()
+const { isProfileSheetOpen, openProfileSheet } = useProfileSheet()
+
+const activeAccountName = computed(
+	() => store.userResource?.data?.accounts?.find((a) => a.id === store.accountId)?._name ?? '',
+)
+
+// The folder currently shown by a mail route; null elsewhere (tab falls back to "Mail").
+const currentFolder = computed(() => {
+	if (route.name === 'mail-all-inboxes') return { label: __('All Inboxes'), icon: 'mails' }
+	if (route.name !== 'mail-mailbox') return null
+	if (route.params.mailbox === 'starred') return { label: __('Starred'), icon: 'star' }
+	const mailbox = mailboxes.data?.find((m: MailboxData) => m.id === route.params.mailbox)
+	return mailbox ? { label: getMailboxName(mailbox), icon: getIcon(mailbox) } : null
+})
 
 const showSendModal = ref(false)
 const showSearchModal = ref(false)
 
 const MAIL_ROUTES = ['mail-mailbox', 'mail-all-inboxes']
+const isThreadOpen = computed(() => !!route.params.threadID)
 const mailActive = computed(() => MAIL_ROUTES.includes(route.name as string))
 const screenerActive = computed(() => route.name === 'mail-screener')
 

--- a/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
@@ -204,10 +204,12 @@ const mailBadgeCount = computed(() => {
 // presence dot). Bordered like the dot was, to read against the translucent bar.
 // Anchored at the icon's top-right (left 60%) and allowed to overflow, so wide
 // counts ("99+") grow outward instead of spreading back across the glyph — the
-// icon keeps its optical centering. ink-red-1 (not ink-white, which this token
-// set lacks) is white in both themes — the on-red text step.
+// icon keeps its optical centering. Neutral ink pill, not red — counts are
+// information here, and red shouted louder than the active tab. gray-10 +
+// ink-base is the app's inverted-chip pair (see the row selection check),
+// flipping correctly in both themes.
 const badgeClass =
-	'bg-surface-red-6 text-ink-red-1 absolute -top-1.5 left-[60%] flex h-4 min-w-5 items-center justify-center rounded-full border border-[var(--surface-base)] px-1 text-[10px] font-semibold leading-none'
+	'bg-surface-gray-10 text-ink-base absolute -top-1.5 left-[60%] flex h-4 min-w-5 items-center justify-center rounded-full border border-[var(--surface-base)] px-1 text-[10px] font-semibold leading-none'
 
 const badgeText = (count: number) => (count > 99 ? '99+' : String(count))
 

--- a/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
@@ -42,6 +42,7 @@
 
 	<SendMail v-model="showSendModal" />
 	<SearchModal v-model="showSearchModal" />
+	<MobileFolderSheet />
 </template>
 
 <script setup lang="ts">
@@ -50,9 +51,11 @@ import { useRoute, useRouter } from 'vue-router'
 import { Eye, Inbox, Search } from 'lucide-vue-next'
 import { Button, FeatherIcon } from 'frappe-ui'
 
+import { useFolderSheet } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import SearchModal from '@/apps/mail/components/Modals/SearchModal.vue'
 import SendMail from '@/apps/mail/components/SendMail.vue'
+import MobileFolderSheet from '@/apps/mail/components/mobile/MobileFolderSheet.vue'
 
 import type { MailboxData } from '@/apps/mail/types'
 
@@ -60,6 +63,7 @@ const route = useRoute()
 const router = useRouter()
 const store = userStore()
 const { mailboxes } = store
+const { openFolderSheet } = useFolderSheet()
 
 const showSendModal = ref(false)
 const showSearchModal = ref(false)
@@ -86,7 +90,11 @@ watch(
 )
 
 const openMail = () => {
-	if (mailActive.value) return
+	// Re-tapping the active Mail tab opens the folder switcher (model 2).
+	if (mailActive.value) {
+		openFolderSheet()
+		return
+	}
 	let target = '/mail'
 	try {
 		target = localStorage.getItem(LAST_MAILBOX_KEY) || '/mail'

--- a/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
@@ -32,14 +32,14 @@
 					:name="currentFolder.icon"
 					class="h-[22px] w-[22px] shrink-0"
 				/>
-				<Inbox v-else class="h-[22px] w-[22px]" stroke-width="2" />
+				<Inbox v-else class="h-[22px] w-[22px] stroke-2" />
 				<span class="max-w-full truncate px-1 text-[11px] font-medium !leading-3">
 					{{ currentFolder?.label ?? __('Mail') }}
 				</span>
 			</button>
 			<button v-if="screeningEnabled" :class="tabClass(screenerActive)" @click="openScreener">
 				<span class="relative">
-					<Eye class="h-[22px] w-[22px]" stroke-width="2" />
+					<Eye class="h-[22px] w-[22px] stroke-2" />
 					<!-- Raven-style unread dot (RailItemBadge dot recipe): presence, not a count. -->
 					<span
 						v-if="screenerCount"
@@ -49,7 +49,7 @@
 				<span class="text-[11px] font-medium !leading-3">{{ __('Screener') }}</span>
 			</button>
 			<button :class="tabClass(showSearchModal)" @click="showSearchModal = true">
-				<Search class="h-[22px] w-[22px]" stroke-width="2" />
+				<Search class="h-[22px] w-[22px] stroke-2" />
 				<span class="text-[11px] font-medium !leading-3">{{ __('Search') }}</span>
 			</button>
 			<button :class="tabClass(isProfileSheetOpen)" @click="openProfileSheet">

--- a/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
@@ -6,7 +6,7 @@
 		v-if="!isThreadOpen && !isMobileSelectionActive"
 		variant="solid"
 		class="fixed right-4 z-10 !h-12 !w-12 !rounded-full shadow-lg"
-		:style="{ bottom: 'calc(4.5rem + env(safe-area-inset-bottom))' }"
+		:style="{ bottom: 'calc(4.75rem + env(safe-area-inset-bottom))' }"
 		:aria-label="__('Compose')"
 		@click="showSendModal = true"
 	>
@@ -23,7 +23,7 @@
 		v-if="!isThreadOpen"
 		class="bg-surface-base/80 z-10 shrink-0 border-t pb-[env(safe-area-inset-bottom)] shadow-[0_-2px_5px_rgba(0,0,0,0.03)] backdrop-blur-lg"
 	>
-		<div class="flex h-13 items-stretch">
+		<div class="flex h-14 items-stretch">
 			<!-- Tab 1 morphs into the current folder: the fixed slot position is the
 			     stable cue; icon + label say where you are. Re-tap opens the switcher. -->
 			<button :class="tabClass(mailActive)" @click="openMail">

--- a/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
@@ -27,24 +27,25 @@
 			<!-- Tab 1 morphs into the current folder: the fixed slot position is the
 			     stable cue; icon + label say where you are. Re-tap opens the switcher. -->
 			<button :class="tabClass(mailActive)" @click="openMail">
-				<Icon
-					v-if="currentFolder"
-					:name="currentFolder.icon"
-					class="h-[22px] w-[22px] shrink-0"
-				/>
-				<Inbox v-else class="h-[22px] w-[22px] stroke-2" />
+				<span class="relative">
+					<Icon
+						v-if="currentFolder"
+						:name="currentFolder.icon"
+						class="h-[22px] w-[22px] shrink-0"
+					/>
+					<Inbox v-else class="h-[22px] w-[22px] stroke-2" />
+					<span v-if="mailBadgeCount" :class="badgeClass">{{
+						badgeText(mailBadgeCount)
+					}}</span>
+				</span>
 				<span class="max-w-full truncate px-1 text-[11px] font-medium !leading-3">
-					{{ currentFolder?.label ?? __('Mail') }}
+					{{ currentFolder?.label ?? __('Inbox') }}
 				</span>
 			</button>
 			<button v-if="screeningEnabled" :class="tabClass(screenerActive)" @click="openScreener">
 				<span class="relative">
 					<Eye class="h-[22px] w-[22px] stroke-2" />
-					<!-- Raven-style unread dot (RailItemBadge dot recipe): presence, not a count. -->
-					<span
-						v-if="screenerCount"
-						class="bg-surface-red-6 absolute -right-0.5 -top-0.5 block size-2 rounded-full border border-[var(--surface-base)]"
-					/>
+					<span v-if="screenerCount" :class="badgeClass">{{ badgeText(screenerCount) }}</span>
 				</span>
 				<span class="text-[11px] font-medium !leading-3">{{ __('Screener') }}</span>
 			</button>
@@ -66,7 +67,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { Eye, Inbox, Search } from 'lucide-vue-next'
 import { Avatar, Button, FeatherIcon } from 'frappe-ui'
@@ -89,7 +90,7 @@ import type { MailboxData } from '@/apps/mail/types'
 const route = useRoute()
 const router = useRouter()
 const store = userStore()
-const { mailboxes } = store
+const { mailboxes, allInboxesUnread } = store
 const { openFolderSheet } = useFolderSheet()
 const { isProfileSheetOpen, openProfileSheet } = useProfileSheet()
 const { isMobileSelectionActive } = useMobileSelection()
@@ -98,7 +99,7 @@ const activeAccountName = computed(
 	() => store.userResource?.data?.accounts?.find((a) => a.id === store.accountId)?._name ?? '',
 )
 
-// The folder currently shown by a mail route; null elsewhere (tab falls back to "Mail").
+// The folder currently shown by a mail route; null elsewhere (tab falls back to "Inbox").
 const currentFolder = computed(() => {
 	if (route.name === 'mail-all-inboxes') return { label: __('All Inboxes'), icon: 'mails' }
 	if (route.name !== 'mail-mailbox') return null
@@ -115,36 +116,16 @@ const isThreadOpen = computed(() => !!route.params.threadID)
 const mailActive = computed(() => MAIL_ROUTES.includes(route.name as string))
 const screenerActive = computed(() => route.name === 'mail-screener')
 
-// Model 2 (grill-me): the Mail tab reopens the last-viewed mailbox, Inbox on first
-// launch. Stored per device; storage failures degrade to the /mail default redirect.
-const LAST_MAILBOX_KEY = 'mail-last-mailbox-path'
-
-watch(
-	() => route.fullPath,
-	() => {
-		if (!mailActive.value) return
-		try {
-			localStorage.setItem(LAST_MAILBOX_KEY, route.fullPath)
-		} catch {
-			// Storage unavailable — the tab falls back to /mail.
-		}
-	},
-	{ immediate: true },
-)
-
 const openMail = () => {
-	// Re-tapping the active Mail tab opens the folder switcher (model 2).
+	// Re-tapping the active Mail tab opens the folder switcher.
 	if (mailActive.value) {
 		openFolderSheet()
 		return
 	}
-	let target = '/mail'
-	try {
-		target = localStorage.getItem(LAST_MAILBOX_KEY) || '/mail'
-	} catch {
-		// Storage unavailable — /mail redirects to the inbox.
-	}
-	router.push(target)
+	// From elsewhere the tab reads "Inbox" with the Inbox's unread badge, so the
+	// tap must land there — restoring the last-viewed folder made a badged tab
+	// open Sent. (/mail redirects to the inbox.)
+	router.push('/mail')
 }
 
 const openScreener = () => {
@@ -163,6 +144,34 @@ const screenerCount = computed(
 		mailboxes.data?.find((m: MailboxData) => m.id === store.mailboxIds.screener)
 			?.unread_threads ?? 0,
 )
+
+// The badge follows what the tab is showing: the current folder's unread while
+// on a mail route (so Drafts with nothing unread shows no badge), the Inbox's
+// unread when the tab reads "Inbox" from elsewhere. Starred is virtual — no count.
+const mailBadgeCount = computed(() => {
+	if (route.name === 'mail-all-inboxes') return allInboxesUnread.data ?? 0
+	if (route.name === 'mail-mailbox') {
+		if (route.params.mailbox === 'starred') return 0
+		return (
+			mailboxes.data?.find((m: MailboxData) => m.id === route.params.mailbox)
+				?.unread_threads ?? 0
+		)
+	}
+	return (
+		mailboxes.data?.find((m: MailboxData) => m.id === store.mailboxIds.inbox)
+			?.unread_threads ?? 0
+	)
+})
+
+// Numeric unread badge shared by the Mail and Screener tabs (replaces the old
+// presence dot). Bordered like the dot was, to read against the translucent bar.
+// Left-anchored at the icon's top-right corner so wide counts ("99+") grow
+// outward instead of spreading back across the glyph. ink-red-1 (not ink-white,
+// which this token set lacks) is white in both themes — the on-red text step.
+const badgeClass =
+	'bg-surface-red-6 text-ink-red-1 absolute -top-1 left-4 flex h-4 min-w-4 items-center justify-center rounded-full border border-[var(--surface-base)] px-1 text-[10px] font-semibold leading-none'
+
+const badgeText = (count: number) => (count > 99 ? '99+' : String(count))
 
 // Raven's tint model: active tabs at full ink, inactive at ~40%.
 const tabClass = (active: boolean) =>

--- a/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
@@ -37,10 +37,6 @@
 					{{ currentFolder?.label ?? __('Mail') }}
 				</span>
 			</button>
-			<button :class="tabClass(showSearchModal)" @click="showSearchModal = true">
-				<Search class="h-[22px] w-[22px]" stroke-width="2" />
-				<span class="text-[11px] font-medium !leading-3">{{ __('Search') }}</span>
-			</button>
 			<button v-if="screeningEnabled" :class="tabClass(screenerActive)" @click="openScreener">
 				<span class="relative">
 					<Eye class="h-[22px] w-[22px]" stroke-width="2" />
@@ -51,6 +47,10 @@
 					/>
 				</span>
 				<span class="text-[11px] font-medium !leading-3">{{ __('Screener') }}</span>
+			</button>
+			<button :class="tabClass(showSearchModal)" @click="showSearchModal = true">
+				<Search class="h-[22px] w-[22px]" stroke-width="2" />
+				<span class="text-[11px] font-medium !leading-3">{{ __('Search') }}</span>
 			</button>
 			<button :class="tabClass(isProfileSheetOpen)" @click="openProfileSheet">
 				<Avatar :label="activeAccountName" size="md" class="shrink-0" />

--- a/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
@@ -1,9 +1,10 @@
 <template>
 	<!-- Compose FAB — floats above the bar, right thumb zone. Both the FAB and the
 	     bar step aside while a thread is open: the thread's own reply actions own
-	     the bottom edge there (the modals below stay mounted regardless). -->
+	     the bottom edge there (the modals below stay mounted regardless). Hidden in
+	     search results too — composing isn't part of the search task. -->
 	<Button
-		v-if="!isThreadOpen && !isMobileSelectionActive"
+		v-if="!isThreadOpen && !isMobileSelectionActive && !isSearchRoute && !showSearchModal"
 		variant="solid"
 		class="fixed right-4 z-10 !h-12 !w-12 !rounded-full shadow-lg"
 		:style="{ bottom: 'calc(4.75rem + env(safe-area-inset-bottom))' }"
@@ -49,10 +50,12 @@
 				</span>
 				<span class="text-[11px] font-medium !leading-3">{{ __('Screener') }}</span>
 			</button>
-			<button :class="tabClass(showSearchModal)" @click="showSearchModal = true">
+			<button :class="tabClass(searchActive)" @click="showSearchModal = true">
 				<Search class="h-[22px] w-[22px] stroke-2" />
 				<span class="text-[11px] font-medium !leading-3">{{ __('Search') }}</span>
 			</button>
+			<!-- Profile is a sheet over the current surface (search included), not a navigation —
+			     it must not dismiss the search overlay. -->
 			<button :class="tabClass(isProfileSheetOpen)" @click="openProfileSheet">
 				<Avatar :label="activeAccountName" size="md" class="shrink-0" />
 				<span class="text-[11px] font-medium !leading-3">{{ __('Profile') }}</span>
@@ -113,10 +116,25 @@ const showSearchModal = ref(false)
 
 const MAIL_ROUTES = ['mail-mailbox', 'mail-all-inboxes']
 const isThreadOpen = computed(() => !!route.params.threadID)
-const mailActive = computed(() => MAIL_ROUTES.includes(route.name as string))
+// Search results live on the mailbox route with the virtual 'search' mailbox, but
+// they belong to the Search tab — the Mail tab must not read as active there.
+const isSearchRoute = computed(
+	() => route.name === 'mail-mailbox' && route.params.mailbox === 'search',
+)
+const mailActive = computed(
+	() => MAIL_ROUTES.includes(route.name as string) && !isSearchRoute.value,
+)
 const screenerActive = computed(() => route.name === 'mail-screener')
+const searchActive = computed(() => showSearchModal.value || isSearchRoute.value)
 
 const openMail = () => {
+	// The search overlay leaves the bar visible; a tab tap first dismisses it, landing
+	// back on whatever page the overlay covered.
+	if (showSearchModal.value) {
+		showSearchModal.value = false
+		if (!mailActive.value) router.push('/mail')
+		return
+	}
 	// Re-tapping the active Mail tab opens the folder switcher.
 	if (mailActive.value) {
 		openFolderSheet()
@@ -129,6 +147,7 @@ const openMail = () => {
 }
 
 const openScreener = () => {
+	showSearchModal.value = false
 	if (screenerActive.value) return
 	router.push({ name: 'mail-screener', params: { accountId: store.accountId } })
 }
@@ -150,7 +169,8 @@ const screenerCount = computed(
 // unread when the tab reads "Inbox" from elsewhere. Starred is virtual — no count.
 const mailBadgeCount = computed(() => {
 	if (route.name === 'mail-all-inboxes') return allInboxesUnread.data ?? 0
-	if (route.name === 'mail-mailbox') {
+	// In search the tab reads "Inbox" (below), so fall through to the Inbox's count.
+	if (route.name === 'mail-mailbox' && !isSearchRoute.value) {
 		if (route.params.mailbox === 'starred') return 0
 		return (
 			mailboxes.data?.find((m: MailboxData) => m.id === route.params.mailbox)

--- a/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
@@ -3,7 +3,7 @@
 	     bar step aside while a thread is open: the thread's own reply actions own
 	     the bottom edge there (the modals below stay mounted regardless). -->
 	<Button
-		v-if="!isThreadOpen"
+		v-if="!isThreadOpen && !isMobileSelectionActive"
 		variant="solid"
 		class="fixed right-4 z-10 !h-12 !w-12 !rounded-full shadow-lg"
 		:style="{ bottom: 'calc(4.5rem + env(safe-area-inset-bottom))' }"
@@ -17,11 +17,13 @@
 
 	<!-- Bottom tab bar — Raven-inspired: translucent bar with a hairline top border
 	     and faint upward shadow; lucide icons, tint-only active state. -->
+	<!-- Stays mounted during selection mode — the selection action bar overlays it at
+	     identical geometry, so the layout never shifts. -->
 	<nav
 		v-if="!isThreadOpen"
 		class="bg-surface-base/80 z-10 shrink-0 border-t pb-[env(safe-area-inset-bottom)] shadow-[0_-2px_5px_rgba(0,0,0,0.03)] backdrop-blur-lg"
 	>
-		<div class="flex h-[52px] items-stretch">
+		<div class="flex h-13 items-stretch">
 			<!-- Tab 1 morphs into the current folder: the fixed slot position is the
 			     stable cue; icon + label say where you are. Re-tap opens the switcher. -->
 			<button :class="tabClass(mailActive)" @click="openMail">
@@ -71,7 +73,11 @@ import { Avatar, Button, FeatherIcon } from 'frappe-ui'
 import { Icon } from 'frappe-ui/icons'
 
 import { getIcon, getMailboxName } from '@/apps/mail/utils'
-import { useFolderSheet, useProfileSheet } from '@/apps/mail/utils/composables'
+import {
+	useFolderSheet,
+	useMobileSelection,
+	useProfileSheet,
+} from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import SearchModal from '@/apps/mail/components/Modals/SearchModal.vue'
 import SendMail from '@/apps/mail/components/SendMail.vue'
@@ -86,6 +92,7 @@ const store = userStore()
 const { mailboxes } = store
 const { openFolderSheet } = useFolderSheet()
 const { isProfileSheetOpen, openProfileSheet } = useProfileSheet()
+const { isMobileSelectionActive } = useMobileSelection()
 
 const activeAccountName = computed(
 	() => store.userResource?.data?.accounts?.find((a) => a.id === store.accountId)?._name ?? '',

--- a/frontend/src/apps/mail/components/mobile/MobileTitleHeader.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileTitleHeader.vue
@@ -1,0 +1,36 @@
+<template>
+	<!-- Shared mobile title row (mailbox / all inboxes / screener): 3xl semibold
+	     title, optional count, optional folder-sheet hamburger, actions slot on
+	     the right. Without the hamburger the title gets pl-4 (4px row + 16px =
+	     20px) to sit on the px-5 axis of the list content below it; with it,
+	     the button's own inset provides the offset. -->
+	<div class="flex items-center gap-1 px-1 pb-2.5 pt-2">
+		<button
+			v-if="withMenu"
+			:aria-label="__('Folders')"
+			class="text-ink-gray-6 flex h-10 w-10 shrink-0 items-center justify-center rounded-full"
+			@click="openFolderSheet"
+		>
+			<Menu :size="18" />
+		</button>
+		<div class="flex min-w-0 flex-1 items-baseline gap-2" :class="{ 'pl-4': !withMenu }">
+			<span class="truncate text-3xl !font-semibold tracking-[-0.01em]">{{ title }}</span>
+			<span v-if="count" class="text-ink-gray-5 shrink-0 text-sm !font-medium">{{ count }}</span>
+		</div>
+		<slot name="actions" />
+	</div>
+</template>
+
+<script setup lang="ts">
+import { Menu } from 'lucide-vue-next'
+
+import { useFolderSheet } from '@/apps/mail/utils/composables'
+
+defineProps<{
+	title: string
+	count?: string
+	withMenu?: boolean
+}>()
+
+const { openFolderSheet } = useFolderSheet()
+</script>

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -40,16 +40,7 @@
 					</AdaptiveDropdown>
 
 					<!-- Loading bar -->
-					<div
-						v-if="threads.loading"
-						class="loading-bar pointer-events-none absolute bottom-[-1px] left-[-1px] right-0 h-0.5 overflow-hidden"
-						role="progressbar"
-						aria-busy="true"
-					>
-						<div
-							class="loading-bar__fill via-ink-gray-3 absolute inset-y-0 left-0 w-[30%] bg-gradient-to-r from-transparent to-transparent"
-						/>
-					</div>
+					<LoadingBar v-if="threads.loading" />
 				</div>
 				<div
 					v-else
@@ -77,16 +68,7 @@
 					</div>
 
 					<!-- Loading bar -->
-					<div
-						v-if="threads.loading"
-						class="loading-bar pointer-events-none absolute bottom-[-1px] left-[-1px] right-0 h-0.5 overflow-hidden"
-						role="progressbar"
-						aria-busy="true"
-					>
-						<div
-							class="loading-bar__fill via-ink-gray-3 absolute inset-y-0 left-0 w-[30%] bg-gradient-to-r from-transparent to-transparent"
-						/>
-					</div>
+					<LoadingBar v-if="threads.loading" />
 				</div>
 
 				<!-- Mail list -->
@@ -183,6 +165,7 @@ import { userStore } from '@/apps/mail/stores/user'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
 import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
+import LoadingBar from '@/apps/mail/components/LoadingBar.vue'
 import MailListItem from '@/apps/mail/components/MailListItem.vue'
 import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
 
@@ -512,16 +495,4 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
-.loading-bar__fill {
-	animation: loading-bar-slide 1.2s linear infinite;
-}
-
-@keyframes loading-bar-slide {
-	0% {
-		transform: translateX(-100%);
-	}
-	100% {
-		transform: translateX(333%);
-	}
-}
 </style>

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -14,7 +14,7 @@
 		<HeaderActions @reload-mails="refreshThreads()" />
 	</header>
 
-	<div class="relative flex h-[calc(100dvh-3.05rem)]">
+	<div class="relative flex h-[calc(100dvh-3.05rem)] max-sm:min-h-0 max-sm:flex-1 max-sm:!h-auto">
 		<!-- Loading -->
 		<div v-if="isLoading" class="flex w-full flex-col items-center justify-center">
 			<div class="text-ink-gray-5 flex items-center space-x-2">
@@ -64,10 +64,10 @@
 				</div>
 
 				<!-- Mail list -->
-				<div ref="mailList" class="h-full overflow-y-auto overscroll-contain">
+				<div ref="mailList" class="h-full overflow-y-auto overscroll-contain max-sm:pb-20">
 					<div v-for="(group, key) in groupedThreads" :key="key">
 						<Tooltip
-							v-if="groupMessagesBy !== 'None'"
+							v-if="groupMessagesBy !== 'None' && !isMobile"
 							:text="
 								isLastGroup(key)
 									? ''
@@ -89,7 +89,7 @@
 								/>
 							</div>
 						</Tooltip>
-						<template v-if="!collapsedGroups.includes(key)">
+						<template v-if="isMobile || !collapsedGroups.includes(key)">
 							<MailListItem
 								v-for="mail in group"
 								:key="`${mail.account}:${mail.thread_id}`"

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -1,20 +1,12 @@
 <template>
 	<!-- Header -->
-	<header class="flex items-center justify-between border-b px-3 py-2.5 sm:px-5">
+	<!-- hidden on mobile: the tab bar's morphing Mail tab carries the folder name, and
+	     the header's actions live in the bar/FAB. Hidden (not v-if) so HeaderActions'
+	     modals stay mounted for the views' v-model bindings. -->
+	<header class="hidden items-center justify-between border-b px-3 py-2.5 sm:flex sm:px-5">
 		<div class="flex items-center space-x-2">
-			<Button v-if="isMobile" icon="menu" variant="ghost" @click="openSidebar" />
-			<!-- On mobile the title is the folder switcher (model 2) -->
-			<button
-				v-if="isMobile"
-				class="text-ink-gray-8 flex items-center gap-1 text-lg font-semibold"
-				@click="openFolderSheet"
-			>
-				<span class="truncate">{{ __('All Inboxes') }}</span>
-				<ChevronDown class="text-ink-gray-5 h-4 w-4 shrink-0" stroke-width="2" />
-			</button>
 			<!-- -ml-0.5 cancels the crumb's own padding so the title sits on the px-5 axis -->
 			<Breadcrumbs
-				v-else
 				:items="[{ label: __('All Inboxes'), route: { name: 'mail-all-inboxes' } }]"
 				class="-ml-0.5"
 			/>
@@ -160,7 +152,7 @@ import {
 import { Breadcrumbs, Button, Dropdown, Tooltip, call, createResource, usePageMeta } from 'frappe-ui'
 
 import { getFormattedDate, raiseOptimisticToast, raiseToast } from '@/apps/mail/utils'
-import { useFolderSheet, useScreenSize, useSidebar } from '@/apps/mail/utils/composables'
+import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
@@ -169,8 +161,6 @@ import MailListItem from '@/apps/mail/components/MailListItem.vue'
 import type { Thread, UserResource } from '@/apps/mail/types'
 
 const { isMobile } = useScreenSize()
-const { openSidebar } = useSidebar()
-const { openFolderSheet } = useFolderSheet()
 
 const socket = inject('$socket')
 const user = inject('$user') as UserResource

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -3,8 +3,18 @@
 	<header class="flex items-center justify-between border-b px-3 py-2.5 sm:px-5">
 		<div class="flex items-center space-x-2">
 			<Button v-if="isMobile" icon="menu" variant="ghost" @click="openSidebar" />
+			<!-- On mobile the title is the folder switcher (model 2) -->
+			<button
+				v-if="isMobile"
+				class="text-ink-gray-8 flex items-center gap-1 text-lg font-semibold"
+				@click="openFolderSheet"
+			>
+				<span class="truncate">{{ __('All Inboxes') }}</span>
+				<ChevronDown class="text-ink-gray-5 h-4 w-4 shrink-0" stroke-width="2" />
+			</button>
 			<!-- -ml-0.5 cancels the crumb's own padding so the title sits on the px-5 axis -->
 			<Breadcrumbs
+				v-else
 				:items="[{ label: __('All Inboxes'), route: { name: 'mail-all-inboxes' } }]"
 				class="-ml-0.5"
 			/>
@@ -150,7 +160,7 @@ import {
 import { Breadcrumbs, Button, Dropdown, Tooltip, call, createResource, usePageMeta } from 'frappe-ui'
 
 import { getFormattedDate, raiseOptimisticToast, raiseToast } from '@/apps/mail/utils'
-import { useScreenSize, useSidebar } from '@/apps/mail/utils/composables'
+import { useFolderSheet, useScreenSize, useSidebar } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
@@ -160,6 +170,7 @@ import type { Thread, UserResource } from '@/apps/mail/types'
 
 const { isMobile } = useScreenSize()
 const { openSidebar } = useSidebar()
+const { openFolderSheet } = useFolderSheet()
 
 const socket = inject('$socket')
 const user = inject('$user') as UserResource

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -29,8 +29,30 @@
 
 		<template v-else-if="threads.data?.length">
 			<div ref="mailSidebar" class="sticky top-16 flex w-full flex-col border-r">
-				<!-- Toolbar -->
+				<!-- Toolbar — mobile mirrors the mailbox one (h-12, semibold selector in a
+				     bottom sheet, no refresh: pull the tab or reopen instead). -->
+				<div v-if="isMobile" class="relative flex h-12 items-center border-b px-4">
+					<AdaptiveDropdown :options="FILTER_OPTIONS" :title="__('Filter')">
+						<button class="flex min-w-0 items-center gap-1.5 text-base !font-medium">
+							<span class="truncate">{{ title }}</span>
+							<ChevronDown class="text-ink-gray-5 h-4 w-4 shrink-0" />
+						</button>
+					</AdaptiveDropdown>
+
+					<!-- Loading bar -->
+					<div
+						v-if="threads.loading"
+						class="loading-bar pointer-events-none absolute bottom-[-1px] left-[-1px] right-0 h-0.5 overflow-hidden"
+						role="progressbar"
+						aria-busy="true"
+					>
+						<div
+							class="loading-bar__fill via-ink-gray-3 absolute inset-y-0 left-0 w-[30%] bg-gradient-to-r from-transparent to-transparent"
+						/>
+					</div>
+				</div>
 				<div
+					v-else
 					class="relative flex items-center border-b border-l-transparent px-3.5 py-2.5 sm:border-l sm:px-5"
 				>
 					<Dropdown :options="FILTER_OPTIONS">
@@ -160,6 +182,7 @@ import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
+import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 import MailListItem from '@/apps/mail/components/MailListItem.vue'
 import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
 

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -1,4 +1,8 @@
 <template>
+	<!-- Mobile title header — no thread count since the merged view has no total.
+	     The toolbar below carries the bottom border, matching the mailbox structure. -->
+	<MobileTitleHeader v-if="isMobile" with-menu :title="__('All Inboxes')" />
+
 	<!-- Header -->
 	<!-- hidden on mobile: the tab bar's morphing Mail tab carries the folder name, and
 	     the header's actions live in the bar/FAB. Hidden (not v-if) so HeaderActions'
@@ -157,6 +161,7 @@ import { userStore } from '@/apps/mail/stores/user'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
 import MailListItem from '@/apps/mail/components/MailListItem.vue'
+import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
 
 import type { Thread, UserResource } from '@/apps/mail/types'
 

--- a/frontend/src/apps/mail/pages/MailLayout.vue
+++ b/frontend/src/apps/mail/pages/MailLayout.vue
@@ -191,4 +191,15 @@ body.mail-app .bottom-sheet-content > .h-\[70vh\] {
 	max-height: 70vh;
 }
 
+/* Portaled dialogs and menus ship without a z-index (they rely on body DOM
+   order), so the mobile panes with explicit z (thread pane, settings — z-20)
+   would paint over them. Lift them above the panes but below bottom sheets
+   (z-50), preserving sheet-over-dialog ordering. */
+body.mail-app .dialog-overlay {
+	z-index: 30;
+}
+body.mail-app .menu-content {
+	z-index: 30;
+}
+
 </style>

--- a/frontend/src/apps/mail/pages/MailLayout.vue
+++ b/frontend/src/apps/mail/pages/MailLayout.vue
@@ -202,4 +202,30 @@ body.mail-app .menu-content {
 	z-index: 30;
 }
 
+/* Swipe paging (mobile) — shared by the thread pane (MailThread) and the screener
+   preview: the incoming page slides in from the swipe side while the outgoing one —
+   lifted out of flow so they overlap — slides away in tandem. */
+body.mail-app .page-next-enter-active,
+body.mail-app .page-next-leave-active,
+body.mail-app .page-prev-enter-active,
+body.mail-app .page-prev-leave-active {
+	transition: transform 0.2s cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+body.mail-app .page-next-leave-active,
+body.mail-app .page-prev-leave-active {
+	position: absolute;
+	inset: 0;
+}
+
+body.mail-app .page-next-enter-from,
+body.mail-app .page-prev-leave-to {
+	transform: translateX(100%);
+}
+
+body.mail-app .page-next-leave-to,
+body.mail-app .page-prev-enter-from {
+	transform: translateX(-100%);
+}
+
 </style>

--- a/frontend/src/apps/mail/pages/MailLayout.vue
+++ b/frontend/src/apps/mail/pages/MailLayout.vue
@@ -172,6 +172,16 @@ body.mail-app h2 {
 	color: var(--ink-gray-6);
 }
 
+/* The mail app's icon weight is 1.5 (.icon, FeatherIcon's default, and
+   frappe-ui's ~icons pipeline all agree), but icons imported straight from
+   lucide-vue-next ship stroke-width 2 — so default every lucide svg to 1.5
+   instead of repeating the attribute at each call site. :where() keeps the
+   rule at zero specificity, so an explicit stroke-* utility (e.g. stroke-2
+   on the tab bar) still wins. Covers teleported menus/sheets too. */
+:where(body.mail-app svg.lucide) {
+	stroke-width: 1.5;
+}
+
 /* BottomSheets hug their content instead of frappe-ui's fixed 70vh well — a
    five-row menu shouldn't own the whole screen. The old height stays as the
    scroll cap, so tall content (the folder list) behaves exactly as before.

--- a/frontend/src/apps/mail/pages/MailLayout.vue
+++ b/frontend/src/apps/mail/pages/MailLayout.vue
@@ -190,4 +190,5 @@ body.mail-app .bottom-sheet-content > .h-\[70vh\] {
 	height: auto;
 	max-height: 70vh;
 }
+
 </style>

--- a/frontend/src/apps/mail/pages/MailLayout.vue
+++ b/frontend/src/apps/mail/pages/MailLayout.vue
@@ -171,4 +171,13 @@ body.mail-app h2 {
 	height: 1rem;
 	color: var(--ink-gray-6);
 }
+
+/* BottomSheets hug their content instead of frappe-ui's fixed 70vh well — a
+   five-row menu shouldn't own the whole screen. The old height stays as the
+   scroll cap, so tall content (the folder list) behaves exactly as before.
+   Scoped to body.mail-app since sheets teleport to <body>. */
+body.mail-app .bottom-sheet-content > .h-\[70vh\] {
+	height: auto;
+	max-height: 70vh;
+}
 </style>

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -3,8 +3,18 @@
 	<header class="flex items-center justify-between border-b px-3 py-2.5 sm:px-5">
 		<div class="flex items-center space-x-2">
 			<Button v-if="isMobile" icon="menu" variant="ghost" @click="openSidebar" />
+			<!-- On mobile the title is the folder switcher (model 2) -->
+			<button
+				v-if="isMobile"
+				class="text-ink-gray-8 flex items-center gap-1 text-lg font-semibold"
+				@click="openFolderSheet"
+			>
+				<span class="truncate">{{ mailboxName }}</span>
+				<ChevronDown class="text-ink-gray-5 h-4 w-4 shrink-0" stroke-width="2" />
+			</button>
 			<!-- -ml-0.5 cancels the crumb's own padding so the title sits on the px-5 axis -->
 			<Breadcrumbs
+				v-else
 				class="-ml-0.5"
 				:items="[
 					{
@@ -417,7 +427,7 @@ import {
 	shouldIgnoreKeypress,
 	startResizing,
 } from '@/apps/mail/utils'
-import { useScreenSize, useSidebar, useUndo } from '@/apps/mail/utils/composables'
+import { useFolderSheet, useScreenSize, useSidebar, useUndo } from '@/apps/mail/utils/composables'
 import { buildListRows } from '@/apps/mail/utils/threadStacks'
 import { useThreadActions } from '@/apps/mail/utils/useThreadActions'
 import { type MailboxRole, userStore } from '@/apps/mail/stores/user'
@@ -448,6 +458,7 @@ const route = useRoute()
 const router = useRouter()
 const { isMobile } = useScreenSize()
 const { openSidebar } = useSidebar()
+const { openFolderSheet } = useFolderSheet()
 const { undo, setUndoAction } = useUndo()
 
 const socket = inject('$socket')

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -78,9 +78,17 @@
 
 				<!-- Mobile header: title row (folders · mailbox + count · search · compose) over
 				     a toolbar row (filter selector on the left, filter/refresh pills on the
-				     right). In selection mode the toolbar row swaps to ✕ / count / Select All. -->
-				<div v-if="isMobile" class="relative shrink-0 border-b">
+				     right). In selection mode the toolbar row swaps to ✕ / count / Select All.
+				     Search skips both rows (SearchResultsHeader is the header there; the tab
+				     bar carries the "you are in search" cue), keeping only the selection
+				     toolbar and the loading bar — the border goes with the rows it underlines. -->
+				<div
+					v-if="isMobile"
+					class="relative shrink-0"
+					:class="{ 'border-b': mailbox !== 'search' || !!selections.length }"
+				>
 					<MobileTitleHeader
+						v-if="mailbox !== 'search'"
 						with-menu
 						:title="mailboxName"
 						:count="threadCount ? __('{0} threads', [threadCount]) : undefined"
@@ -103,14 +111,10 @@
 							{{ isAllSelected ? __('Unselect All') : __('Select All') }}
 						</button>
 					</div>
-					<div v-else class="flex h-12 items-center px-4">
+					<div v-else-if="mailbox !== 'search'" class="flex h-12 items-center px-4">
 						<!-- The selector label carries the active filter ("Unread Mails", …);
 						     picking "All" in the sheet clears it, so no dismissal chip needed. -->
-						<AdaptiveDropdown
-							v-if="mailbox !== 'search'"
-							:options="FILTER_OPTIONS"
-							:title="__('Filter')"
-						>
+						<AdaptiveDropdown :options="FILTER_OPTIONS" :title="__('Filter')">
 							<button class="flex min-w-0 items-center gap-1.5 text-base !font-medium">
 								<span class="truncate">{{ title }}</span>
 								<ChevronDown class="text-ink-gray-5 h-4 w-4 shrink-0" />
@@ -354,7 +358,13 @@
 					</div>
 				</div>
 				<div v-else class="flex h-full items-center justify-center">
-					<p class="text-ink-gray-5">
+					<!-- While the (still-mounted) search header's new query loads, this area is the
+					     loading surface — the empty message must not flash first. -->
+					<LoaderCircle
+						v-if="threadsResource?.loading"
+						class="text-ink-gray-5 h-5 w-5 animate-spin"
+					/>
+					<p v-else class="text-ink-gray-5">
 						{{
 							mailbox === 'search'
 								? __('No results found for the given query.')
@@ -1431,6 +1441,10 @@ watch(groupedRows, () => {
 const canGoNext = computed(() => hasMore.value)
 
 const isLoading = computed(() => {
+	// Search is one page: its header (input + filter chips) mounts immediately and stays put
+	// across query changes — loading shows inline in the list area, never as the full spinner.
+	// Checked first: entering the route resets isMailboxLoaded, which must not blank the view.
+	if (mailbox === 'search') return false
 	if (!isMailboxLoaded.value) return true
 	if (emptyMailbox.loading) return true
 	if (refillPending.value) return true

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -87,15 +87,17 @@
 					/>
 
 					<!-- Both toolbar variants share h-12 so toggling selection mode doesn't shift the list. -->
-					<div v-if="selections.length" class="flex h-12 items-center gap-1.5 px-3">
+					<!-- px-1/gap-1 match the title row above, so the ✕ shares the hamburger's
+					     axis and the count text starts where the title does. -->
+					<div v-if="selections.length" class="flex h-12 items-center gap-1 px-1">
 						<Button variant="ghost" class="!h-10 !w-10 !rounded-full" @click="toggleSelectAll(false)">
-							<template #icon><X class="icon !h-[22px] !w-[22px]" /></template>
+							<template #icon><X class="icon !h-5 !w-5" /></template>
 						</Button>
 						<span class="flex-1 truncate text-base !font-medium">
 							{{ __('{0} selected', [String(selections.length)]) }}
 						</span>
 						<button
-							class="text-ink-gray-8 text-md shrink-0 !font-medium"
+							class="text-ink-gray-8 text-md shrink-0 px-2 !font-medium"
 							@click="toggleSelectAll(!isAllSelected)"
 						>
 							{{ isAllSelected ? __('Unselect All') : __('Select All') }}
@@ -109,7 +111,7 @@
 							:options="FILTER_OPTIONS"
 							:title="__('Filter')"
 						>
-							<button class="flex min-w-0 items-center gap-1.5 text-base !font-semibold">
+							<button class="flex min-w-0 items-center gap-1.5 text-base !font-medium">
 								<span class="truncate">{{ title }}</span>
 								<ChevronDown class="text-ink-gray-5 h-4 w-4 shrink-0" />
 							</button>
@@ -369,13 +371,23 @@
 			</div>
 
 			<!-- Mail thread -->
+			<!-- Mobile opens as a page push (iOS-style slide from the right): the pane
+			     stays mounted and slides via transform, so close animates too.
+			     visibility rides the same transition — it flips only after the
+			     slide-out ends, keeping the offscreen pane out of the focus order.
+			     Teleported to body on mobile (like the selection bar): inside the
+			     layout's isolate stacking context the remounting tab bar would paint
+			     over the pane during the slide-out. -->
+			<Teleport to="body" :disabled="!isMobile">
 			<div
 				class="bg-surface-base overflow-y-auto"
 				:class="{
 					'w-2/3': !isMobile && showReadingPane,
 					'absolute bottom-0 left-0 right-0 top-0': !isMobile && !showReadingPane,
-					'fixed inset-0': isMobile,
-					hidden: (isMobile || !showReadingPane) && !threadID,
+					'fixed inset-0 z-20 transition-[transform,visibility] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]':
+						isMobile,
+					'invisible translate-x-full': isMobile && !threadID,
+					hidden: !isMobile && !showReadingPane && !threadID,
 				}"
 			>
 				<MailThread
@@ -419,6 +431,7 @@
 					@next-thread="goToThreadByOffset(1)"
 				/>
 			</div>
+			</Teleport>
 		</template>
 
 		<!-- No mails (the search view keeps its header and shows an inline message instead) -->
@@ -444,19 +457,21 @@
 		<!-- Four labeled actions + More: seven unlabeled icons were the old screener
 		     trap (no labels, no tooltips on touch). Overflow actions and the folder
 		     menus live in the More sheet, which chains into the folder sheets. -->
-		<div class="flex h-13 items-stretch justify-around">
+		<!-- flex-1 columns (like the tab bar underneath): equal widths keep the icon
+		     centers evenly spaced regardless of label length. -->
+		<div class="flex h-14 items-stretch">
 			<button
 				v-for="action in visibleSelectActions.slice(0, 4)"
 				:key="action.label"
-				class="text-ink-gray-7 flex flex-col items-center justify-center gap-1 px-2 text-[11px] !font-semibold"
+				class="text-ink-gray-7 flex flex-1 flex-col items-center justify-center gap-1 px-1 text-[11px] !font-semibold"
 				@click="action.onClick"
 			>
 				<component :is="action.icon" class="h-5 w-5" />
-				<span class="max-w-20 truncate">{{ stripShortcutHint(action.label) }}</span>
+				<span class="max-w-full truncate">{{ action.shortLabel ?? stripShortcutHint(action.label) }}</span>
 			</button>
 			<button
 				v-if="moreSelectionOptions.length"
-				class="text-ink-gray-7 flex flex-col items-center justify-center gap-1 px-2 text-[11px] !font-semibold"
+				class="text-ink-gray-7 flex flex-1 flex-col items-center justify-center gap-1 px-1 text-[11px] !font-semibold"
 				@click="showMoreActions = true"
 			>
 				<Ellipsis class="h-5 w-5" />
@@ -1020,6 +1035,8 @@ const handleKeyUp = (e: KeyboardEvent) => {
 
 interface SelectAction {
 	label: string
+	// One-word label for the mobile selection bar; verb phrases stay in menus/tooltips.
+	shortLabel?: string
 	onClick: () => void
 	icon: typeof RefreshCw
 	condition: () => boolean
@@ -1059,6 +1076,7 @@ const selectActions = computed((): SelectAction[] => [
 	},
 	{
 		label: __('Mark as Junk (!)'),
+		shortLabel: __('Junk'),
 		onClick: () => junkOrDeleteThreads(selections.value, true),
 		icon: CircleAlert,
 		condition: () =>
@@ -1071,6 +1089,7 @@ const selectActions = computed((): SelectAction[] => [
 	},
 	{
 		label: __('Mark as Not Junk'),
+		shortLabel: __('Not Junk'),
 		onClick: () => handleSetSpamStatus({ 0: selections.value }),
 		icon: CircleCheck,
 		condition: () =>
@@ -1082,18 +1101,21 @@ const selectActions = computed((): SelectAction[] => [
 	},
 	{
 		label: __('Move to Trash (Delete)'),
+		shortLabel: __('Trash'),
 		onClick: () => handleMoveThreads({ [mailboxIds.trash]: selections.value }),
 		icon: Trash2,
 		condition: () => mailbox !== mailboxIds.trash,
 	},
 	{
 		label: __('Delete Threads (Shift+Delete)'),
+		shortLabel: __('Delete'),
 		onClick: () => junkOrDeleteThreads(selections.value, false),
 		icon: Trash2,
 		condition: () => mailbox === mailboxIds.trash,
 	},
 	{
 		label: __('Mark as Read (Shift+U)'),
+		shortLabel: __('Read'),
 		onClick: () => handleSetSeen({ 1: selections.value }),
 		icon: MailOpen,
 		condition: () =>
@@ -1105,6 +1127,7 @@ const selectActions = computed((): SelectAction[] => [
 	},
 	{
 		label: __('Mark as Unread (U)'),
+		shortLabel: __('Unread'),
 		onClick: () => handleSetSeen({ 0: selections.value }),
 		icon: MailIcon,
 		condition: () =>
@@ -1653,6 +1676,10 @@ const rowForThread = (threadID?: string): NavRow | undefined => {
 const focusOnThread = (threadID?: string) => focusRow(rowForThread(threadID))
 
 const scrollIntoView = (rowKey: string) => {
+	// Centering the focused row is a keyboard-navigation affordance; on mobile it
+	// only made the list visibly jump behind the thread pane's slide-in.
+	if (isMobile.value) return
+
 	// The row may have only just been revealed by its stack or its day opening, so wait for the render
 	// before looking it up. A no-op when nothing changed.
 	nextTick(() => {

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -76,56 +76,45 @@
 					v-model:edit-filter="searchEditFilter"
 				/>
 
-				<!-- Mobile toolbar (design: 1·Inbox + 5·Selection): folder name leads and opens
-				     the folder sheet; filter is a funnel icon until active, then a dismissible
-				     chip. In selection mode it swaps to ✕ / count / Select All. -->
-				<div
-					v-if="isMobile"
-					class="relative flex h-14 shrink-0 items-center gap-1.5 border-b px-3.5"
-				>
-					<template v-if="selections.length">
-						<Button variant="ghost" class="-ml-1.5 !h-9 !w-9" @click="toggleSelectAll(false)">
-							<template #icon><X class="icon !h-[18px] !w-[18px]" /></template>
+				<!-- Mobile header: title row (folders · mailbox + count · search · compose) over
+				     a toolbar row (filter selector on the left, filter/refresh pills on the
+				     right). In selection mode the toolbar row swaps to ✕ / count / Select All. -->
+				<div v-if="isMobile" class="relative shrink-0 border-b">
+					<MobileTitleHeader
+						with-menu
+						:title="mailboxName"
+						:count="threadCount ? __('{0} threads', [threadCount]) : undefined"
+					/>
+
+					<!-- Both toolbar variants share h-12 so toggling selection mode doesn't shift the list. -->
+					<div v-if="selections.length" class="flex h-12 items-center gap-1.5 px-3">
+						<Button variant="ghost" class="!h-10 !w-10 !rounded-full" @click="toggleSelectAll(false)">
+							<template #icon><X class="icon !h-[22px] !w-[22px]" /></template>
 						</Button>
-						<span class="flex-1 truncate text-base !font-semibold">
+						<span class="flex-1 truncate text-base !font-medium">
 							{{ __('{0} selected', [String(selections.length)]) }}
 						</span>
 						<button
-							class="text-ink-gray-8 shrink-0 text-[15px] !font-semibold"
+							class="text-ink-gray-8 text-md shrink-0 !font-medium"
 							@click="toggleSelectAll(!isAllSelected)"
 						>
 							{{ isAllSelected ? __('Unselect All') : __('Select All') }}
 						</button>
-					</template>
-					<template v-else>
-						<button
-							class="flex min-w-0 items-center gap-1.5 text-lg !font-semibold"
-							@click="openFolderSheet"
-						>
-							<span class="truncate">{{ mailboxName }}</span>
-							<ChevronDown class="text-ink-gray-5 h-5 w-5 shrink-0" stroke-width="2" />
-						</button>
-						<span class="flex-1" />
-						<!-- Applied filter: visible and dismissible. Hidden filters lose mail. -->
-						<button
-							v-if="filter && mailbox !== 'search'"
-							class="bg-surface-gray-2 text-ink-gray-7 flex max-w-40 items-center gap-1 rounded-full px-3 py-1.5 text-[13px] !font-semibold"
-							@click="setFilter(null)"
-						>
-							<span class="truncate">{{ title }}</span>
-							<X class="h-3 w-3 shrink-0" stroke-width="2" />
-						</button>
+					</div>
+					<div v-else class="flex h-12 items-center px-4">
+						<!-- The selector label carries the active filter ("Unread Mails", …);
+						     picking "All" in the sheet clears it, so no dismissal chip needed. -->
 						<AdaptiveDropdown
-							v-else-if="mailbox !== 'search'"
+							v-if="mailbox !== 'search'"
 							:options="FILTER_OPTIONS"
 							:title="__('Filter')"
-							placement="bottom-end"
 						>
-							<Button variant="ghost" class="-mr-1.5 !h-9 !w-9" :tooltip="__('Filter')">
-								<template #icon><Funnel class="icon !h-[18px] !w-[18px]" /></template>
-							</Button>
+							<button class="flex min-w-0 items-center gap-1.5 text-base !font-semibold">
+								<span class="truncate">{{ title }}</span>
+								<ChevronDown class="text-ink-gray-5 h-4 w-4 shrink-0" />
+							</button>
 						</AdaptiveDropdown>
-					</template>
+					</div>
 
 					<!-- Loading bar -->
 					<div
@@ -462,7 +451,7 @@
 				class="text-ink-gray-7 flex flex-col items-center justify-center gap-1 px-2 text-[11px] !font-semibold"
 				@click="action.onClick"
 			>
-				<component :is="action.icon" class="h-5 w-5" stroke-width="1.8" />
+				<component :is="action.icon" class="h-5 w-5" />
 				<span class="max-w-20 truncate">{{ stripShortcutHint(action.label) }}</span>
 			</button>
 			<button
@@ -470,7 +459,7 @@
 				class="text-ink-gray-7 flex flex-col items-center justify-center gap-1 px-2 text-[11px] !font-semibold"
 				@click="showMoreActions = true"
 			>
-				<Ellipsis class="h-5 w-5" stroke-width="1.8" />
+				<Ellipsis class="h-5 w-5" />
 				<span>{{ __('More') }}</span>
 			</button>
 		</div>
@@ -479,22 +468,22 @@
 			v-model:open="showMoreActions"
 			:options="moreSelectionOptions"
 			:title="__('More')"
-		><span /></AdaptiveDropdown>
+		/>
 		<AdaptiveDropdown
 			v-model:open="showMoveToSheet"
 			:options="moveToOptions"
 			:title="__('Move To')"
-		><span /></AdaptiveDropdown>
+		/>
 		<AdaptiveDropdown
 			v-model:open="showAddToSheet"
 			:options="addToOptions"
 			:title="__('Add To')"
-		><span /></AdaptiveDropdown>
+		/>
 		<AdaptiveDropdown
 			v-model:open="showRemoveFromSheet"
 			:options="removeFromOptions"
 			:title="__('Remove From')"
-		><span /></AdaptiveDropdown>
+		/>
 	</div>
 	</Teleport>
 
@@ -511,7 +500,6 @@ import {
 	CircleAlert,
 	CircleCheck,
 	Ellipsis,
-	Filter as Funnel,
 	FolderInput,
 	FolderMinus,
 	FolderPlus,
@@ -548,7 +536,6 @@ import {
 	stripShortcutHint,
 } from '@/apps/mail/utils'
 import {
-	useFolderSheet,
 	useMobileSelection,
 	useScreenSize,
 	useUndo,
@@ -561,6 +548,7 @@ import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
 import MailListItem from '@/apps/mail/components/MailListItem.vue'
 import MailThread from '@/apps/mail/components/MailThread.vue'
+import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
 import ScreenedEmailAddressModal from '@/apps/mail/components/Modals/ScreenedEmailAddressModal.vue'
 import SearchResultsHeader from '@/apps/mail/components/SearchResultsHeader.vue'
 import ShortcutsModal from '@/apps/mail/components/Modals/ShortcutsModal.vue'
@@ -583,7 +571,6 @@ const { accountId, mailbox, threadID } = defineProps<{
 const route = useRoute()
 const router = useRouter()
 const { isMobile } = useScreenSize()
-const { openFolderSheet } = useFolderSheet()
 const { setMobileSelectionActive } = useMobileSelection()
 const { undo, setUndoAction } = useUndo()
 
@@ -1938,6 +1925,11 @@ const title = computed(() => {
 const showSearchModal = ref(false)
 const showSearchAdvanced = ref(false)
 const searchEditFilter = ref('')
+
+const threadCount = computed(() => {
+	const count = mailboxObj.value?.total_threads
+	return count ? count.toLocaleString() : ''
+})
 </script>
 
 <style scoped>

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -43,8 +43,10 @@
 		<Button :label="__('Delete Now')" variant="ghost" @click="showEmptyMailbox = true" />
 	</div>
 
+	<!-- Mobile sizes by flex (the dvh calcs assume desktop chrome and overshoot
+	     once the tab bar exists, making the outer container scroll too). -->
 	<div
-		class="relative flex"
+		class="relative flex max-sm:min-h-0 max-sm:flex-1 max-sm:!h-auto"
 		:class="
 			showDeleteBanner || showScreenerBanner
 				? 'h-[calc(100dvh-6.1rem)]'
@@ -74,12 +76,76 @@
 					v-model:edit-filter="searchEditFilter"
 				/>
 
+				<!-- Mobile toolbar (design: 1·Inbox + 5·Selection): folder name leads and opens
+				     the folder sheet; filter is a funnel icon until active, then a dismissible
+				     chip. In selection mode it swaps to ✕ / count / Select All. -->
+				<div
+					v-if="isMobile"
+					class="relative flex h-14 shrink-0 items-center gap-1.5 border-b px-3.5"
+				>
+					<template v-if="selections.length">
+						<Button variant="ghost" class="-ml-1.5 !h-9 !w-9" @click="toggleSelectAll(false)">
+							<template #icon><X class="h-[18px] w-[18px]" /></template>
+						</Button>
+						<span class="flex-1 truncate text-base !font-semibold">
+							{{ __('{0} selected', [String(selections.length)]) }}
+						</span>
+						<button
+							class="text-ink-gray-8 shrink-0 text-[15px] !font-semibold"
+							@click="toggleSelectAll(!isAllSelected)"
+						>
+							{{ isAllSelected ? __('Unselect All') : __('Select All') }}
+						</button>
+					</template>
+					<template v-else>
+						<button
+							class="flex min-w-0 items-center gap-1.5 text-lg !font-semibold"
+							@click="openFolderSheet"
+						>
+							<span class="truncate">{{ mailboxName }}</span>
+							<ChevronDown class="text-ink-gray-5 h-5 w-5 shrink-0" stroke-width="2" />
+						</button>
+						<span class="flex-1" />
+						<!-- Applied filter: visible and dismissible. Hidden filters lose mail. -->
+						<button
+							v-if="filter && mailbox !== 'search'"
+							class="bg-surface-gray-2 text-ink-gray-7 flex max-w-40 items-center gap-1 rounded-full px-3 py-1.5 text-[13px] !font-semibold"
+							@click="setFilter(null)"
+						>
+							<span class="truncate">{{ title }}</span>
+							<X class="h-3 w-3 shrink-0" stroke-width="2" />
+						</button>
+						<AdaptiveDropdown
+							v-else-if="mailbox !== 'search'"
+							:options="FILTER_OPTIONS"
+							:title="__('Filter')"
+							placement="bottom-end"
+						>
+							<Button variant="ghost" class="-mr-1.5 !h-9 !w-9" :tooltip="__('Filter')">
+								<template #icon><Funnel class="h-[18px] w-[18px]" /></template>
+							</Button>
+						</AdaptiveDropdown>
+					</template>
+
+					<!-- Loading bar -->
+					<div
+						v-if="threadsResource?.loading"
+						class="loading-bar pointer-events-none absolute bottom-[-1px] left-[-1px] right-0 h-0.5 overflow-hidden"
+						role="progressbar"
+						aria-busy="true"
+					>
+						<div
+							class="loading-bar__fill via-ink-gray-3 absolute inset-y-0 left-0 w-[30%] bg-gradient-to-r from-transparent to-transparent"
+						/>
+					</div>
+				</div>
+
 				<!-- Toolbar/Actions -->
 				<div
+					v-else
 					class="relative flex items-center border-b border-l-transparent px-3.5 py-2.5 sm:border-l sm:px-5"
 				>
-					<!-- max-sm:ml-2 centers the 16px checkbox on the rows' 32px avatar column -->
-					<div v-if="!isAllAccountsSearch" class="mr-5 max-sm:ml-2">
+					<div v-if="!isAllAccountsSearch" class="mr-5">
 						<Tooltip
 							:text="
 								isAllSelected
@@ -188,11 +254,11 @@
 				<div
 					v-if="threadsResource?.data?.length"
 					ref="mailList"
-					class="h-full overflow-y-auto overscroll-contain"
+					class="h-full overflow-y-auto overscroll-contain max-sm:pb-20"
 				>
 					<div v-for="(group, key) in groupedThreads" :key="key">
 						<div
-							v-if="groupMessagesBy !== 'None'"
+							v-if="groupMessagesBy !== 'None' && !isMobile"
 							class="text-ink-gray-6 group flex items-center border-b border-l-transparent p-3.5 text-xs-semibold sm:border-l sm:px-5"
 							:class="{
 								'!bg-surface-blue-1': isGroupSelected(key),
@@ -202,9 +268,10 @@
 							:data-row-key="`group:${key}`"
 							@click="toggleGroupCollapse(key)"
 						>
+							<!-- Mobile: group select ("all of Today") appears only in selection mode. -->
 							<div
-								v-if="!isAllAccountsSearch"
-								class="pr-7.5 checkbox-hitbox -m-3 cursor-pointer py-3 pl-5 sm:pl-3"
+								v-if="!isAllAccountsSearch && (!isMobile || mobileSelectionMode)"
+								class="pr-7.5 checkbox-hitbox -m-3 cursor-pointer py-3 pl-3"
 								@click.stop.prevent="
 									toggleSelect(getGroupThreads(key), !isGroupSelected(key))
 								"
@@ -226,7 +293,7 @@
 								class="icon ml-auto"
 							/>
 						</div>
-						<template v-if="!collapsedGroups.includes(key)">
+						<template v-if="isMobile || !collapsedGroups.includes(key)">
 							<!-- A stack row stands in for a run of look-alike threads; when expanded, its
 							     members follow it as ordinary (indented) rows. -->
 							<template v-for="row in groupedRows[key]" :key="row.key">
@@ -262,6 +329,7 @@
 										isAllAccountsSearch ? row.thread.account_name : undefined
 									"
 									:selectable="!isAllAccountsSearch"
+									:selection-mode="mobileSelectionMode"
 									:is-selected="selections.includes(row.thread.thread_id)"
 									:hide-sender="row.inStack"
 									class="border-l-transparent sm:border-l"
@@ -374,6 +442,62 @@
 	<Dialog v-model="showEmptyMailbox" :options="emptyMailboxOptions" />
 	<Dialog v-model="showJunkOrDeleteThreads" :options="junkOrDeleteThreadsOptions" />
 	<ScreenedEmailAddressModal />
+	<!-- Selection action bar (design: 5·Selection) — replaces the tab bar while
+	     selecting: thumb reach, Delete last and red. -->
+	<!-- Same 52px row + safe-area padding as the tab bar it overlays, so entering/
+	     leaving selection mode never shifts the layout. Teleported to body: inside
+	     the layout's `isolate` stacking context, no z-index could beat the nav. -->
+	<Teleport to="body">
+	<div
+		v-if="mobileSelectionMode"
+		class="bg-surface-base fixed inset-x-0 bottom-0 z-20 border-t pb-[env(safe-area-inset-bottom)]"
+	>
+		<!-- Four labeled actions + More: seven unlabeled icons were the old screener
+		     trap (no labels, no tooltips on touch). Overflow actions and the folder
+		     menus live in the More sheet, which chains into the folder sheets. -->
+		<div class="flex h-13 items-stretch justify-around">
+			<button
+				v-for="action in visibleSelectActions.slice(0, 4)"
+				:key="action.label"
+				class="text-ink-gray-7 flex flex-col items-center justify-center gap-1 px-2 text-[11px] !font-semibold"
+				@click="action.onClick"
+			>
+				<component :is="action.icon" class="h-5 w-5" stroke-width="1.8" />
+				<span class="max-w-20 truncate">{{ stripShortcutHint(action.label) }}</span>
+			</button>
+			<button
+				v-if="moreSelectionOptions.length"
+				class="text-ink-gray-7 flex flex-col items-center justify-center gap-1 px-2 text-[11px] !font-semibold"
+				@click="showMoreActions = true"
+			>
+				<Ellipsis class="h-5 w-5" stroke-width="1.8" />
+				<span>{{ __('More') }}</span>
+			</button>
+		</div>
+
+		<AdaptiveDropdown
+			v-model:open="showMoreActions"
+			:options="moreSelectionOptions"
+			:title="__('More')"
+		><span /></AdaptiveDropdown>
+		<AdaptiveDropdown
+			v-model:open="showMoveToSheet"
+			:options="moveToOptions"
+			:title="__('Move To')"
+		><span /></AdaptiveDropdown>
+		<AdaptiveDropdown
+			v-model:open="showAddToSheet"
+			:options="addToOptions"
+			:title="__('Add To')"
+		><span /></AdaptiveDropdown>
+		<AdaptiveDropdown
+			v-model:open="showRemoveFromSheet"
+			:options="removeFromOptions"
+			:title="__('Remove From')"
+		><span /></AdaptiveDropdown>
+	</div>
+	</Teleport>
+
 	<ShortcutsModal v-model="showShortcuts" />
 </template>
 <script setup lang="ts">
@@ -387,6 +511,7 @@ import {
 	CircleAlert,
 	CircleCheck,
 	Ellipsis,
+	Filter as Funnel,
 	FolderInput,
 	FolderMinus,
 	FolderPlus,
@@ -399,6 +524,7 @@ import {
 	Star,
 	StarOff,
 	Trash2,
+	X,
 } from 'lucide-vue-next'
 import {
 	Breadcrumbs,
@@ -419,11 +545,18 @@ import {
 	raiseToast,
 	shouldIgnoreKeypress,
 	startResizing,
+	stripShortcutHint,
 } from '@/apps/mail/utils'
-import { useScreenSize, useUndo } from '@/apps/mail/utils/composables'
+import {
+	useFolderSheet,
+	useMobileSelection,
+	useScreenSize,
+	useUndo,
+} from '@/apps/mail/utils/composables'
 import { buildListRows } from '@/apps/mail/utils/threadStacks'
 import { useThreadActions } from '@/apps/mail/utils/useThreadActions'
 import { type MailboxRole, userStore } from '@/apps/mail/stores/user'
+import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
 import MailListItem from '@/apps/mail/components/MailListItem.vue'
@@ -450,6 +583,8 @@ const { accountId, mailbox, threadID } = defineProps<{
 const route = useRoute()
 const router = useRouter()
 const { isMobile } = useScreenSize()
+const { openFolderSheet } = useFolderSheet()
+const { setMobileSelectionActive } = useMobileSelection()
 const { undo, setUndoAction } = useUndo()
 
 const socket = inject('$socket')
@@ -621,6 +756,44 @@ const mailThreadRef = useTemplateRef('mailThread')
 const mailListRef = useTemplateRef('mailList')
 
 const selections = ref<string[]>([])
+
+// Mobile selection mode (design: 5·Selection): rows show checkboxes, the toolbar
+// turns contextual, and the action bar replaces the tab bar (via the composable).
+const mobileSelectionMode = computed(() => isMobile.value && selections.value.length > 0)
+watch(mobileSelectionMode, (active) => setMobileSelectionActive(active))
+onUnmounted(() => setMobileSelectionActive(false))
+
+// Selection bar: first four condition-passing actions get labeled slots; the rest,
+// plus the folder menus, overflow into the More sheet (chained sheet opens).
+const showMoreActions = ref(false)
+const showMoveToSheet = ref(false)
+const showAddToSheet = ref(false)
+const showRemoveFromSheet = ref(false)
+
+const visibleSelectActions = computed(() => selectActions.value.filter((a) => a.condition()))
+
+const moreSelectionOptions = computed(() => [
+	...visibleSelectActions.value.slice(4).map((a) => ({
+		label: a.label,
+		icon: a.icon,
+		onClick: a.onClick,
+	})),
+	...(!['search', 'starred'].includes(mailbox)
+		? [{ label: __('Move To'), icon: FolderInput, onClick: () => (showMoveToSheet.value = true) }]
+		: []),
+	...(showAddTo.value
+		? [{ label: __('Add To'), icon: FolderPlus, onClick: () => (showAddToSheet.value = true) }]
+		: []),
+	...(showRemoveFrom.value
+		? [
+				{
+					label: __('Remove From'),
+					icon: FolderMinus,
+					onClick: () => (showRemoveFromSheet.value = true),
+				},
+			]
+		: []),
+])
 const lastSelected = ref<string[]>()
 
 const isAllSelected = computed(
@@ -867,7 +1040,7 @@ interface SelectAction {
 
 const selectActions = computed((): SelectAction[] => [
 	{
-		label: __('Star Mails'),
+		label: __('Star'),
 		onClick: () => setFlaggedByThreadIDs(selections.value, true),
 		icon: Star,
 		condition: () =>
@@ -878,7 +1051,7 @@ const selectActions = computed((): SelectAction[] => [
 			),
 	},
 	{
-		label: __('Unstar Mails'),
+		label: __('Unstar'),
 		onClick: () => setFlaggedByThreadIDs(selections.value, false),
 		icon: StarOff,
 		condition: () =>
@@ -889,7 +1062,7 @@ const selectActions = computed((): SelectAction[] => [
 			),
 	},
 	{
-		label: __('Archive Threads (E)'),
+		label: __('Archive (E)'),
 		onClick: () =>
 			mailbox === mailboxIds.sent
 				? handleAddThreadsToMailbox(mailboxIds.archive, selections.value)
@@ -955,6 +1128,7 @@ const selectActions = computed((): SelectAction[] => [
 			),
 	},
 ])
+
 
 // Search
 

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -482,7 +482,7 @@
 		<AdaptiveDropdown
 			v-model:open="showMoreActions"
 			:options="moreSelectionOptions"
-			:title="__('More')"
+			:title="__('{0} selected', [String(selections.length)])"
 		/>
 		<AdaptiveDropdown
 			v-model:open="showMoveToSheet"

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -366,9 +366,11 @@
 					/>
 					<p v-else class="text-ink-gray-5">
 						{{
-							mailbox === 'search'
-								? __('No results found for the given query.')
-								: __('No mails found for the selected filter.')
+							mailbox !== 'search'
+								? __('No mails found for the selected filter.')
+								: hasSearchQuery
+									? __('No results found for the given query.')
+									: __('Search your mail')
 						}}
 					</p>
 				</div>
@@ -390,8 +392,10 @@
 			     over the pane during the slide-out. -->
 			<Teleport to="body" :disabled="!isMobile">
 			<div
-				class="bg-surface-base overflow-y-auto"
+				class="bg-surface-base"
 				:class="{
+					'overflow-y-auto': !isMobile,
+					'overflow-hidden': isMobile,
 					'w-2/3': !isMobile && showReadingPane,
 					'absolute bottom-0 left-0 right-0 top-0': !isMobile && !showReadingPane,
 					'fixed inset-0 z-20 transition-[transform,visibility] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]':
@@ -399,7 +403,18 @@
 					'invisible translate-x-full': isMobile && !threadID,
 					hidden: !isMobile && !showReadingPane && !threadID,
 				}"
+				@touchstart.passive="onThreadTouchStart"
+				@touchend.passive="onThreadTouchEnd"
 			>
+				<!-- Mobile keys the wrapper by thread so a swipe pages: the old thread slides out
+				     while the new one (remounted, so it loads fresh) slides in from the swipe side.
+				     Scroll lives on the wrapper there — each thread carries its own scroll position
+				     through the slide. Desktop keys statically: no remount, pane scrolls itself. -->
+				<Transition :name="threadSlide" @after-enter="threadSlide = ''">
+				<div
+					:key="isMobile ? threadPaneKey : 'pane'"
+					:class="{ 'h-full overflow-y-auto': isMobile }"
+				>
 				<MailThread
 					ref="mailThread"
 					:mailbox
@@ -440,6 +455,8 @@
 					@prev-thread="goToThreadByOffset(-1)"
 					@next-thread="goToThreadByOffset(1)"
 				/>
+				</div>
+				</Transition>
 			</div>
 			</Teleport>
 		</template>
@@ -1253,6 +1270,11 @@ const onResetSuccess = () => {
 // account, so each row opens in — and acts within — its own account (see the row-action wrappers).
 const isAllAccountsSearch = computed(() => mailbox === 'search' && route.query.all_accounts != null)
 
+// The mobile Search tab lands on this route with no query yet. There's nothing to fetch —
+// an empty filter would run an unbounded search — so the list area shows a hint instead
+// (all_accounts is scope, not a search condition, so it alone doesn't count as a query).
+const hasSearchQuery = computed(() => Object.keys(route.query).some((k) => k !== 'all_accounts'))
+
 // Null while a search is pending — the count is only known once the fetch resolves (set in the
 // searchResults transform below, reset in resetThreads). Guards the title against a stale or zero count.
 const searchTotal = ref<number | null>(null)
@@ -1471,7 +1493,15 @@ const resetThreads: (reloadMailboxes?: boolean, mailboxRoles?: MailboxRole[]) =>
 	epoch.value++
 	resetSelections()
 	// Clear the previous search's count so the header doesn't show a stale total while the new fetch runs.
-	if (mailbox === 'search') searchTotal.value = null
+	if (mailbox === 'search') {
+		searchTotal.value = null
+		// No query yet (the Search tab's landing state): skip the fetch and settle the count
+		// so nothing sits on "Searching…".
+		if (!hasSearchQuery.value) {
+			searchTotal.value = 0
+			return
+		}
+	}
 	threadsResource.value.reload()
 	if (reloadMailboxes) mailboxes.reload()
 }
@@ -1585,6 +1615,7 @@ const pollForChanges = async () => {
 onMounted(() => {
 	window.addEventListener('keydown', handleKeyDown)
 	window.addEventListener('keyup', handleKeyUp)
+	window.addEventListener('email-swipe', onEmailSwipe)
 	reloadInterval.value = setInterval(pollForChanges, 30000)
 
 	socket.on('new_mail_created', (updatedMailboxes: string[]) => {
@@ -1603,6 +1634,7 @@ onMounted(() => {
 onUnmounted(() => {
 	window.removeEventListener('keydown', handleKeyDown)
 	window.removeEventListener('keyup', handleKeyUp)
+	window.removeEventListener('email-swipe', onEmailSwipe)
 	if (reloadInterval.value) clearInterval(reloadInterval.value)
 	// Leaving the mailbox drops any pending undo so a lingering toast can't undo into another view.
 	setUndoAction(undefined)
@@ -1615,6 +1647,7 @@ const getThreadByOffset = (offset: number, currentThread: string = threadID!) =>
 	threadIDs.value[threadIDs.value.indexOf(currentThread) + offset]
 
 const goToThread = (threadID: string) => {
+	threadSlide.value = pendingThreadSlide
 	if (threadID)
 		router.push({ name: 'mail-mail', params: { accountId, mailbox, threadID }, query: route.query })
 }
@@ -1641,6 +1674,62 @@ const goToThreadByOffset = (offset: number) => {
 	if (next) return goToThread(next)
 	loadMoreThenOpenEdge(offset, 'open')
 }
+
+// Horizontal swipe on the open thread (mobile): left → next thread, right → previous.
+// Judged on touchend (passive) so vertical scrolling is never delayed; a swipe must be
+// decisively horizontal — long enough and at least twice its vertical drift. Swipes over
+// an email body are detected inside the iframe and forwarded (see EmailContent).
+const SWIPE_MIN_X = 64
+let threadTouchOrigin: { x: number; y: number } | null = null
+const onThreadTouchStart = (e: TouchEvent) => {
+	threadTouchOrigin =
+		isMobile.value && threadID && e.touches.length === 1
+			? { x: e.touches[0].clientX, y: e.touches[0].clientY }
+			: null
+}
+const onThreadTouchEnd = (e: TouchEvent) => {
+	if (!threadTouchOrigin) return
+	const dx = e.changedTouches[0].clientX - threadTouchOrigin.x
+	const dy = e.changedTouches[0].clientY - threadTouchOrigin.y
+	threadTouchOrigin = null
+	if (Math.abs(dx) < SWIPE_MIN_X || Math.abs(dx) < Math.abs(dy) * 2) return
+	swipeToThread(dx < 0 ? 1 : -1)
+}
+
+// Shared by the pane's own touch handlers and swipes forwarded out of email iframes —
+// the time guard also dedupes: expanded mails each mount an EmailContent whose message
+// listener re-dispatches the same forwarded swipe.
+let lastSwipeAt = 0
+const swipeToThread = (offset: number) => {
+	if (!isMobile.value || !threadID) return
+	const now = Date.now()
+	if (now - lastSwipeAt < 250) return
+	lastSwipeAt = now
+	// Arms the paging animation for this navigation only — goToThread consumes it, so
+	// taps/arrows (which never set it) keep swapping instantly.
+	pendingThreadSlide = offset > 0 ? 'thread-next' : 'thread-prev'
+	goToThreadByOffset(offset)
+	pendingThreadSlide = ''
+}
+
+const onEmailSwipe = (e: Event) =>
+	swipeToThread((e as CustomEvent).detail === 'left' ? 1 : -1)
+
+// The <Transition> name while a swipe navigation renders; cleared after the slide (and
+// left empty for every other thread change, where the wrapper should just swap).
+const threadSlide = ref('')
+let pendingThreadSlide = ''
+
+// The paging wrapper's key: follows the open thread but freezes on close, so the pane's
+// slide-out still shows the thread it closed on instead of a remounted blank wrapper.
+const threadPaneKey = ref('none')
+watch(
+	() => threadID,
+	(id) => {
+		if (id) threadPaneKey.value = id
+	},
+	{ immediate: true },
+)
 
 const openPendingEdgeThread = () => {
 	if (!pendingEdgeThread) return
@@ -1989,5 +2078,37 @@ const threadCount = computed(() => {
 	100% {
 		transform: translateX(333%);
 	}
+}
+
+/* Swipe paging between threads (mobile): the incoming thread slides in from the swipe
+   side while the outgoing one — lifted out of flow so they overlap — slides away in
+   tandem. Snappier than the pane's open/close slide: paging is a repeated gesture. */
+.thread-next-enter-active,
+.thread-next-leave-active,
+.thread-prev-enter-active,
+.thread-prev-leave-active {
+	transition: transform 0.2s cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.thread-next-leave-active,
+.thread-prev-leave-active {
+	position: absolute;
+	inset: 0;
+}
+
+.thread-next-enter-from {
+	transform: translateX(100%);
+}
+
+.thread-next-leave-to {
+	transform: translateX(-100%);
+}
+
+.thread-prev-enter-from {
+	transform: translateX(-100%);
+}
+
+.thread-prev-leave-to {
+	transform: translateX(100%);
 }
 </style>

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -36,7 +36,9 @@
 		<Button :label="__('Review Now')" variant="ghost" @click="goToScreener" />
 	</div>
 
-	<div v-if="showDeleteBanner" class="space-x-1 border-b px-3 py-2.5 sm:px-5">
+	<!-- On mobile this banner renders below the title header instead (inside the mobile
+	     header block) — above it, it read as page chrome sitting on top of the title. -->
+	<div v-if="showDeleteBanner && !isMobile" class="space-x-1 border-b px-3 py-2.5 sm:px-5">
 		<span class="text-ink-gray-5">
 			{{ __('Items in this mailbox will be automatically deleted after 30 days.') }}
 		</span>
@@ -93,6 +95,20 @@
 						:title="mailboxName"
 						:count="threadCount ? __('{0} threads', [threadCount]) : undefined"
 					/>
+
+					<!-- Trash/Junk auto-delete banner — below the title (its desktop slot above
+					     the whole header read as chrome on top of the page). Borderless: it
+					     reads as part of the header block, not a boxed-off strip. -->
+					<div v-if="showDeleteBanner && mailbox !== 'search'" class="space-x-1 px-4">
+						<span class="text-ink-gray-5">
+							{{ __('Items in this mailbox will be automatically deleted after 30 days.') }}
+						</span>
+						<Button
+							:label="__('Delete Now')"
+							variant="ghost"
+							@click="showEmptyMailbox = true"
+						/>
+					</div>
 
 					<!-- Both toolbar variants share h-12 so toggling selection mode doesn't shift the list. -->
 					<!-- px-1/gap-1 match the title row above, so the ✕ shares the hamburger's
@@ -463,7 +479,7 @@
 		     menus live in the More sheet, which chains into the folder sheets. -->
 		<!-- flex-1 columns (like the tab bar underneath): equal widths keep the icon
 		     centers evenly spaced regardless of label length. -->
-		<div class="flex h-14 items-stretch">
+		<div class="flex h-15 items-stretch">
 			<button
 				v-for="action in visibleSelectActions.slice(0, 4)"
 				:key="action.label"

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -482,7 +482,6 @@
 		<AdaptiveDropdown
 			v-model:open="showMoreActions"
 			:options="moreSelectionOptions"
-			:title="__('{0} selected', [String(selections.length)])"
 		/>
 		<AdaptiveDropdown
 			v-model:open="showMoveToSheet"

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -394,7 +394,6 @@
 			<div
 				class="bg-surface-base"
 				:class="{
-					'overflow-y-auto': !isMobile,
 					'overflow-hidden': isMobile,
 					'w-2/3': !isMobile && showReadingPane,
 					'absolute bottom-0 left-0 right-0 top-0': !isMobile && !showReadingPane,
@@ -406,17 +405,14 @@
 				@touchstart.passive="onThreadTouchStart"
 				@touchend.passive="onThreadTouchEnd"
 			>
-				<!-- Mobile keys the wrapper by thread so a swipe pages: the old thread slides out
-				     while the new one (remounted, so it loads fresh) slides in from the swipe side.
-				     Scroll lives on the wrapper there — each thread carries its own scroll position
-				     through the slide. Desktop keys statically: no remount, pane scrolls itself. -->
-				<Transition :name="threadSlide" @after-enter="threadSlide = ''">
-				<div
-					:key="isMobile ? threadPaneKey : 'pane'"
-					:class="{ 'h-full overflow-y-auto': isMobile }"
-				>
+				<!-- The swipe slide lives inside MailThread (its toolbar must not move), armed
+				     via `slide` per swipe and cleared on slide-done. The scroll wrapper must be
+				     h-full on desktop too, or the empty state's h-full collapses. -->
+				<div class="h-full overflow-y-auto">
 				<MailThread
 					ref="mailThread"
+					:slide="threadSlide"
+					@slide-done="threadSlide = ''"
 					:mailbox
 					:thread-i-d
 					:threads="threadIDs"
@@ -456,7 +452,6 @@
 					@next-thread="goToThreadByOffset(1)"
 				/>
 				</div>
-				</Transition>
 			</div>
 			</Teleport>
 		</template>
@@ -1715,21 +1710,10 @@ const swipeToThread = (offset: number) => {
 const onEmailSwipe = (e: Event) =>
 	swipeToThread((e as CustomEvent).detail === 'left' ? 1 : -1)
 
-// The <Transition> name while a swipe navigation renders; cleared after the slide (and
-// left empty for every other thread change, where the wrapper should just swap).
+// MailThread's slide name while a swipe navigation renders; cleared on its slide-done
+// (and left empty for every other thread change, which should swap instantly).
 const threadSlide = ref('')
 let pendingThreadSlide = ''
-
-// The paging wrapper's key: follows the open thread but freezes on close, so the pane's
-// slide-out still shows the thread it closed on instead of a remounted blank wrapper.
-const threadPaneKey = ref('none')
-watch(
-	() => threadID,
-	(id) => {
-		if (id) threadPaneKey.value = id
-	},
-	{ immediate: true },
-)
 
 const openPendingEdgeThread = () => {
 	if (!pendingEdgeThread) return
@@ -2080,35 +2064,4 @@ const threadCount = computed(() => {
 	}
 }
 
-/* Swipe paging between threads (mobile): the incoming thread slides in from the swipe
-   side while the outgoing one — lifted out of flow so they overlap — slides away in
-   tandem. Snappier than the pane's open/close slide: paging is a repeated gesture. */
-.thread-next-enter-active,
-.thread-next-leave-active,
-.thread-prev-enter-active,
-.thread-prev-leave-active {
-	transition: transform 0.2s cubic-bezier(0.32, 0.72, 0, 1);
-}
-
-.thread-next-leave-active,
-.thread-prev-leave-active {
-	position: absolute;
-	inset: 0;
-}
-
-.thread-next-enter-from {
-	transform: translateX(100%);
-}
-
-.thread-next-leave-to {
-	transform: translateX(-100%);
-}
-
-.thread-prev-enter-from {
-	transform: translateX(-100%);
-}
-
-.thread-prev-leave-to {
-	transform: translateX(100%);
-}
 </style>

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -85,7 +85,7 @@
 				>
 					<template v-if="selections.length">
 						<Button variant="ghost" class="-ml-1.5 !h-9 !w-9" @click="toggleSelectAll(false)">
-							<template #icon><X class="h-[18px] w-[18px]" /></template>
+							<template #icon><X class="icon !h-[18px] !w-[18px]" /></template>
 						</Button>
 						<span class="flex-1 truncate text-base !font-semibold">
 							{{ __('{0} selected', [String(selections.length)]) }}
@@ -122,7 +122,7 @@
 							placement="bottom-end"
 						>
 							<Button variant="ghost" class="-mr-1.5 !h-9 !w-9" :tooltip="__('Filter')">
-								<template #icon><Funnel class="h-[18px] w-[18px]" /></template>
+								<template #icon><Funnel class="icon !h-[18px] !w-[18px]" /></template>
 							</Button>
 						</AdaptiveDropdown>
 					</template>

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -1,20 +1,12 @@
 <template>
 	<!-- Header -->
-	<header class="flex items-center justify-between border-b px-3 py-2.5 sm:px-5">
+	<!-- hidden on mobile: the tab bar's morphing Mail tab carries the folder name, and
+	     the header's actions live in the bar/FAB. Hidden (not v-if) so HeaderActions'
+	     modals stay mounted for the views' v-model bindings. -->
+	<header class="hidden items-center justify-between border-b px-3 py-2.5 sm:flex sm:px-5">
 		<div class="flex items-center space-x-2">
-			<Button v-if="isMobile" icon="menu" variant="ghost" @click="openSidebar" />
-			<!-- On mobile the title is the folder switcher (model 2) -->
-			<button
-				v-if="isMobile"
-				class="text-ink-gray-8 flex items-center gap-1 text-lg font-semibold"
-				@click="openFolderSheet"
-			>
-				<span class="truncate">{{ mailboxName }}</span>
-				<ChevronDown class="text-ink-gray-5 h-4 w-4 shrink-0" stroke-width="2" />
-			</button>
 			<!-- -ml-0.5 cancels the crumb's own padding so the title sits on the px-5 axis -->
 			<Breadcrumbs
-				v-else
 				class="-ml-0.5"
 				:items="[
 					{
@@ -86,7 +78,8 @@
 				<div
 					class="relative flex items-center border-b border-l-transparent px-3.5 py-2.5 sm:border-l sm:px-5"
 				>
-					<div v-if="!isAllAccountsSearch" class="mr-5 max-sm:ml-3">
+					<!-- max-sm:ml-2 centers the 16px checkbox on the rows' 32px avatar column -->
+					<div v-if="!isAllAccountsSearch" class="mr-5 max-sm:ml-2">
 						<Tooltip
 							:text="
 								isAllSelected
@@ -211,7 +204,7 @@
 						>
 							<div
 								v-if="!isAllAccountsSearch"
-								class="pr-7.5 checkbox-hitbox -m-3 cursor-pointer py-3 pl-6 sm:pl-3"
+								class="pr-7.5 checkbox-hitbox -m-3 cursor-pointer py-3 pl-5 sm:pl-3"
 								@click.stop.prevent="
 									toggleSelect(getGroupThreads(key), !isGroupSelected(key))
 								"
@@ -427,7 +420,7 @@ import {
 	shouldIgnoreKeypress,
 	startResizing,
 } from '@/apps/mail/utils'
-import { useFolderSheet, useScreenSize, useSidebar, useUndo } from '@/apps/mail/utils/composables'
+import { useScreenSize, useUndo } from '@/apps/mail/utils/composables'
 import { buildListRows } from '@/apps/mail/utils/threadStacks'
 import { useThreadActions } from '@/apps/mail/utils/useThreadActions'
 import { type MailboxRole, userStore } from '@/apps/mail/stores/user'
@@ -457,8 +450,6 @@ const { accountId, mailbox, threadID } = defineProps<{
 const route = useRoute()
 const router = useRouter()
 const { isMobile } = useScreenSize()
-const { openSidebar } = useSidebar()
-const { openFolderSheet } = useFolderSheet()
 const { undo, setUndoAction } = useUndo()
 
 const socket = inject('$socket')

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -123,16 +123,7 @@
 					</div>
 
 					<!-- Loading bar -->
-					<div
-						v-if="threadsResource?.loading"
-						class="loading-bar pointer-events-none absolute bottom-[-1px] left-[-1px] right-0 h-0.5 overflow-hidden"
-						role="progressbar"
-						aria-busy="true"
-					>
-						<div
-							class="loading-bar__fill via-ink-gray-3 absolute inset-y-0 left-0 w-[30%] bg-gradient-to-r from-transparent to-transparent"
-						/>
-					</div>
+					<LoadingBar v-if="threadsResource?.loading" />
 				</div>
 
 				<!-- Toolbar/Actions -->
@@ -233,16 +224,7 @@
 						</Dropdown>
 					</div>
 					<!-- Subtle loading bar: a segment sliding across the bottom outline (no layout shift) -->
-					<div
-						v-if="threadsResource?.loading"
-						class="loading-bar pointer-events-none absolute bottom-[-1px] left-[-1px] right-0 h-0.5 overflow-hidden"
-						role="progressbar"
-						aria-busy="true"
-					>
-						<div
-							class="loading-bar__fill via-ink-gray-3 absolute inset-y-0 left-0 w-[30%] bg-gradient-to-r from-transparent to-transparent"
-						/>
-					</div>
+					<LoadingBar v-if="threadsResource?.loading" />
 				</div>
 
 				<!-- Mail list -->
@@ -574,6 +556,7 @@ import {
 import {
 	useMobileSelection,
 	useScreenSize,
+	useSwipeNav,
 	useUndo,
 } from '@/apps/mail/utils/composables'
 import { buildListRows } from '@/apps/mail/utils/threadStacks'
@@ -581,6 +564,7 @@ import { useThreadActions } from '@/apps/mail/utils/useThreadActions'
 import { type MailboxRole, userStore } from '@/apps/mail/stores/user'
 import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
+import LoadingBar from '@/apps/mail/components/LoadingBar.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
 import MailListItem from '@/apps/mail/components/MailListItem.vue'
 import MailThread from '@/apps/mail/components/MailThread.vue'
@@ -1160,7 +1144,6 @@ const selectActions = computed((): SelectAction[] => [
 	},
 ])
 
-
 // Search
 
 // Infinite-scroll state (shared by the threads and search resources — only one is active at a time)
@@ -1610,7 +1593,6 @@ const pollForChanges = async () => {
 onMounted(() => {
 	window.addEventListener('keydown', handleKeyDown)
 	window.addEventListener('keyup', handleKeyUp)
-	window.addEventListener('email-swipe', onEmailSwipe)
 	reloadInterval.value = setInterval(pollForChanges, 30000)
 
 	socket.on('new_mail_created', (updatedMailboxes: string[]) => {
@@ -1629,7 +1611,6 @@ onMounted(() => {
 onUnmounted(() => {
 	window.removeEventListener('keydown', handleKeyDown)
 	window.removeEventListener('keyup', handleKeyUp)
-	window.removeEventListener('email-swipe', onEmailSwipe)
 	if (reloadInterval.value) clearInterval(reloadInterval.value)
 	// Leaving the mailbox drops any pending undo so a lingering toast can't undo into another view.
 	setUndoAction(undefined)
@@ -1670,45 +1651,17 @@ const goToThreadByOffset = (offset: number) => {
 	loadMoreThenOpenEdge(offset, 'open')
 }
 
-// Horizontal swipe on the open thread (mobile): left → next thread, right → previous.
-// Judged on touchend (passive) so vertical scrolling is never delayed; a swipe must be
-// decisively horizontal — long enough and at least twice its vertical drift. Swipes over
-// an email body are detected inside the iframe and forwarded (see EmailContent).
-const SWIPE_MIN_X = 64
-let threadTouchOrigin: { x: number; y: number } | null = null
-const onThreadTouchStart = (e: TouchEvent) => {
-	threadTouchOrigin =
-		isMobile.value && threadID && e.touches.length === 1
-			? { x: e.touches[0].clientX, y: e.touches[0].clientY }
-			: null
-}
-const onThreadTouchEnd = (e: TouchEvent) => {
-	if (!threadTouchOrigin) return
-	const dx = e.changedTouches[0].clientX - threadTouchOrigin.x
-	const dy = e.changedTouches[0].clientY - threadTouchOrigin.y
-	threadTouchOrigin = null
-	if (Math.abs(dx) < SWIPE_MIN_X || Math.abs(dx) < Math.abs(dy) * 2) return
-	swipeToThread(dx < 0 ? 1 : -1)
-}
-
-// Shared by the pane's own touch handlers and swipes forwarded out of email iframes —
-// the time guard also dedupes: expanded mails each mount an EmailContent whose message
-// listener re-dispatches the same forwarded swipe.
-let lastSwipeAt = 0
-const swipeToThread = (offset: number) => {
-	if (!isMobile.value || !threadID) return
-	const now = Date.now()
-	if (now - lastSwipeAt < 250) return
-	lastSwipeAt = now
-	// Arms the paging animation for this navigation only — goToThread consumes it, so
-	// taps/arrows (which never set it) keep swapping instantly.
-	pendingThreadSlide = offset > 0 ? 'thread-next' : 'thread-prev'
-	goToThreadByOffset(offset)
-	pendingThreadSlide = ''
-}
-
-const onEmailSwipe = (e: Event) =>
-	swipeToThread((e as CustomEvent).detail === 'left' ? 1 : -1)
+// Swipe on the open thread (mobile): left → next thread, right → previous.
+const { onTouchStart: onThreadTouchStart, onTouchEnd: onThreadTouchEnd } = useSwipeNav(
+	() => isMobile.value && !!threadID,
+	(offset) => {
+		// Arms the paging animation for this navigation only — goToThread consumes it, so
+		// taps/arrows (which never set it) keep swapping instantly.
+		pendingThreadSlide = offset > 0 ? 'page-next' : 'page-prev'
+		goToThreadByOffset(offset)
+		pendingThreadSlide = ''
+	},
+)
 
 // MailThread's slide name while a swipe navigation renders; cleared on its slide-done
 // (and left empty for every other thread change, which should swap instantly).
@@ -2051,17 +2004,5 @@ const threadCount = computed(() => {
 	border-color: var(--outline-gray-7);
 }
 
-.loading-bar__fill {
-	animation: loading-bar-slide 1.2s linear infinite;
-}
-
-@keyframes loading-bar-slide {
-	0% {
-		transform: translateX(-100%);
-	}
-	100% {
-		transform: translateX(333%);
-	}
-}
 
 </style>

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -996,6 +996,8 @@ const screenerCount = computed(
 )
 const showScreenerBanner = computed(
 	() =>
+		// The mobile tab bar's Screener badge carries this nudge; the banner is desktop-only.
+		!isMobile.value &&
 		mailbox === mailboxIds.inbox &&
 		screeningEnabled.value &&
 		screenerCount.value > 0 &&

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -283,14 +283,14 @@
 										class="!rounded-r-none"
 										@click="screenOut([openSender.from_email])"
 									/>
-									<Dropdown
+									<AdaptiveDropdown
 										:options="domainOptions('screenOut', openSender)"
 										placement="bottom-end"
 									>
 										<Button variant="outline" class="-ml-px !rounded-l-none !px-1.5">
 											<template #icon><ChevronDown class="h-4 w-4" /></template>
 										</Button>
-									</Dropdown>
+									</AdaptiveDropdown>
 								</div>
 								<div class="flex items-center">
 									<Button
@@ -299,7 +299,7 @@
 										class="!rounded-r-none"
 										@click="allow([openSender.from_email])"
 									/>
-									<Dropdown
+									<AdaptiveDropdown
 										:options="domainOptions('allow', openSender)"
 										placement="bottom-end"
 									>
@@ -310,7 +310,7 @@
 										>
 											<template #icon><ChevronDown class="h-4 w-4" /></template>
 										</Button>
-									</Dropdown>
+									</AdaptiveDropdown>
 								</div>
 							</div>
 						</div>
@@ -655,6 +655,7 @@ const domainOptions = (action: 'allow' | 'screenOut', sender: ScreeningSender) =
 			action === 'allow'
 				? __('Allow all emails from {0}', [domainOf(sender.from_email)])
 				: __('Deny all emails from {0}', [domainOf(sender.from_email)]),
+		icon: action === 'allow' ? Check : X,
 		onClick: () => runDomainAction(action, sender),
 	},
 ]

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -1,9 +1,26 @@
 <template>
 	<div v-if="screeningEnabled" class="flex h-full flex-col">
-		<header class="hidden items-center justify-between border-b px-3 py-2.5 sm:flex sm:px-5">
-			<div class="flex items-center space-x-2">
+		<!-- On mobile this is the toolbar (same 49px/px-3.5 metrics as the mailbox one)
+		     and it absorbs the count bar's actions; desktop keeps breadcrumbs + count bar. -->
+		<header
+			class="flex items-center justify-between border-b px-3 py-2.5 max-sm:h-[49px] max-sm:px-3.5 max-sm:py-0 sm:px-5"
+		>
+			<div class="flex min-w-0 items-center space-x-2">
+				<span v-if="isMobile" class="flex min-w-0 items-baseline gap-1.5">
+					<span class="truncate text-[15px] !font-semibold">{{ __('Screener') }}</span>
+					<span v-if="senders.data?.length" class="text-ink-gray-5 text-sm">
+						{{ senders.data.length }}
+					</span>
+				</span>
 				<!-- -ml-0.5 cancels the crumb's own padding so the title sits on the px-5 axis -->
-				<Breadcrumbs :items="[{ label: __('Screener') }]" class="-ml-0.5" />
+				<Breadcrumbs v-else :items="[{ label: __('Screener') }]" class="-ml-0.5" />
+			</div>
+			<div v-if="isMobile" class="-mr-1.5 flex shrink-0 items-center gap-1">
+				<AdaptiveDropdown :options="bulkOptions" placement="bottom-end">
+					<Button variant="ghost" class="!px-1.5">
+						<template #icon><Ellipsis class="icon" /></template>
+					</Button>
+				</AdaptiveDropdown>
 			</div>
 			<HeaderActions @reload-mails="senders.reload()" />
 		</header>
@@ -82,7 +99,8 @@
 				>
 					<div class="pb-20">
 						<!-- Count bar — matches the mailbox "All Mails" toolbar height/style. -->
-						<div class="flex min-h-[49px] items-center justify-between border-b px-5">
+						<!-- Desktop-only: on mobile the header above carries these actions. -->
+					<div class="hidden min-h-[49px] items-center justify-between border-b px-5 sm:flex">
 							<div class="flex min-w-0 items-center">
 								<span class="truncate">{{ waitingLabel }}</span>
 								<!-- Redundant while the explainer slab is teaching the same lesson above,
@@ -138,7 +156,6 @@
 										<template #icon><Ellipsis class="icon" /></template>
 									</Button>
 								</Dropdown>
-								<Button :label="__('Allow All')" variant="ghost" @click="allowAll" />
 							</div>
 						</div>
 
@@ -314,6 +331,7 @@ import {
 	ChevronLeft,
 	CircleHelp,
 	Ellipsis,
+	Inbox,
 	LoaderCircle,
 	X,
 } from 'lucide-vue-next'
@@ -330,6 +348,7 @@ import {
 import { raiseToast, shouldIgnoreKeypress } from '@/apps/mail/utils'
 import { useScreenSize, useSettings } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
+import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
 import MailDate from '@/apps/mail/components/MailDate.vue'
@@ -710,7 +729,8 @@ const bulkConfirmOptions = computed(() => {
 })
 
 const bulkOptions = computed(() => [
-	{ label: __('Deny All'), onClick: denyAll },
-	{ label: __('Move All to Inbox'), onClick: () => (showClearAll.value = true) },
+	{ label: __('Allow All'), icon: Check, onClick: allowAll },
+	{ label: __('Deny All'), icon: X, onClick: denyAll },
+	{ label: __('Move All to Inbox'), icon: Inbox, onClick: () => (showClearAll.value = true) },
 ])
 </script>

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -9,7 +9,7 @@
 				v-if="isMobile"
 				class="min-w-0 flex-1"
 				:title="__('Screener')"
-				:count="senders.data?.length ? String(senders.data.length) : undefined"
+				:count="senders.data?.length ? waitingLabel : undefined"
 			>
 				<template #actions>
 					<AdaptiveDropdown :options="bulkOptions" placement="bottom-end">
@@ -240,14 +240,19 @@
 					</div>
 				</div>
 
-				<!-- Read-only thread preview — split when the reading pane is on, full-width otherwise -->
+				<!-- Read-only thread preview — split when the reading pane is on, full-width otherwise.
+				     Teleported to body on mobile (like the selection bar): inside the layout's
+				     isolate stacking context the tab bar would paint over the sliding pane. -->
+				<Teleport to="body" :disabled="!isMobile">
 				<div
 					class="bg-surface-base flex flex-col"
 					:class="{
 						'w-2/3': !isMobile && showReadingPane,
 						'absolute bottom-0 left-0 right-0 top-0': !isMobile && !showReadingPane,
-						'fixed inset-0': isMobile,
-						hidden: (isMobile || !showReadingPane) && !openSender,
+						'fixed inset-0 z-20 transition-[transform,visibility] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]':
+							isMobile,
+						'invisible translate-x-full': isMobile && !openSender,
+						hidden: !isMobile && !showReadingPane && !openSender,
 					}"
 				>
 					<template v-if="openSender">
@@ -336,6 +341,7 @@
 						</div>
 					</div>
 				</div>
+				</Teleport>
 			</template>
 		</div>
 

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -1,8 +1,7 @@
 <template>
 	<div v-if="screeningEnabled" class="flex h-full flex-col">
-		<header class="flex items-center justify-between border-b px-3 py-2.5 sm:px-5">
+		<header class="hidden items-center justify-between border-b px-3 py-2.5 sm:flex sm:px-5">
 			<div class="flex items-center space-x-2">
-				<Button v-if="isMobile" icon="menu" variant="ghost" @click="openSidebar" />
 				<!-- -ml-0.5 cancels the crumb's own padding so the title sits on the px-5 axis -->
 				<Breadcrumbs :items="[{ label: __('Screener') }]" class="-ml-0.5" />
 			</div>
@@ -329,7 +328,7 @@ import {
 } from 'frappe-ui'
 
 import { raiseToast, shouldIgnoreKeypress } from '@/apps/mail/utils'
-import { useScreenSize, useSettings, useSidebar } from '@/apps/mail/utils/composables'
+import { useScreenSize, useSettings } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
@@ -342,7 +341,6 @@ import type { Mail, MailboxData, ScreeningSender } from '@/apps/mail/types'
 const store = userStore()
 const router = useRouter()
 const { isMobile } = useScreenSize()
-const { openSidebar } = useSidebar()
 const { openSettings } = useSettings()
 
 const showReadingPane = computed(() => !!store.userResource?.data?.show_reading_pane)

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -1,27 +1,26 @@
 <template>
 	<div v-if="screeningEnabled" class="flex h-full flex-col">
-		<!-- On mobile this is the toolbar (same 49px/px-3.5 metrics as the mailbox one)
-		     and it absorbs the count bar's actions; desktop keeps breadcrumbs + count bar. -->
+		<!-- On mobile this is the shared title header (minus the hamburger) and it
+		     absorbs the count bar's actions; desktop keeps breadcrumbs + count bar. -->
 		<header
-			class="flex items-center justify-between border-b px-3 py-2.5 max-sm:h-[49px] max-sm:px-3.5 max-sm:py-0 sm:px-5"
+			class="flex items-center justify-between border-b px-3 py-2.5 max-sm:p-0 sm:px-5"
 		>
-			<div class="flex min-w-0 items-center space-x-2">
-				<span v-if="isMobile" class="flex min-w-0 items-baseline gap-1.5">
-					<span class="truncate text-[15px] !font-semibold">{{ __('Screener') }}</span>
-					<span v-if="senders.data?.length" class="text-ink-gray-5 text-sm">
-						{{ senders.data.length }}
-					</span>
-				</span>
-				<!-- -ml-0.5 cancels the crumb's own padding so the title sits on the px-5 axis -->
-				<Breadcrumbs v-else :items="[{ label: __('Screener') }]" class="-ml-0.5" />
-			</div>
-			<div v-if="isMobile" class="-mr-1.5 flex shrink-0 items-center gap-1">
-				<AdaptiveDropdown :options="bulkOptions" placement="bottom-end">
-					<Button variant="ghost" class="!px-1.5">
-						<template #icon><Ellipsis class="icon" /></template>
-					</Button>
-				</AdaptiveDropdown>
-			</div>
+			<MobileTitleHeader
+				v-if="isMobile"
+				class="min-w-0 flex-1"
+				:title="__('Screener')"
+				:count="senders.data?.length ? String(senders.data.length) : undefined"
+			>
+				<template #actions>
+					<AdaptiveDropdown :options="bulkOptions" placement="bottom-end">
+						<Button variant="ghost" class="!h-10 !w-10 !rounded-full">
+							<template #icon><Ellipsis class="icon" /></template>
+						</Button>
+					</AdaptiveDropdown>
+				</template>
+			</MobileTitleHeader>
+			<!-- -ml-0.5 cancels the crumb's own padding so the title sits on the px-5 axis -->
+			<Breadcrumbs v-else :items="[{ label: __('Screener') }]" class="-ml-0.5" />
 			<HeaderActions @reload-mails="senders.reload()" />
 		</header>
 
@@ -46,15 +45,13 @@
 					<!-- nowrap keeps each word+icon parenthetical on one line -->
 					<span class="whitespace-nowrap">
 						{{ __('Allow') }} (<Check
-							class="inline h-3.5 w-3.5 align-[-2.5px]"
-							stroke-width="2"
+							class="inline h-3.5 w-3.5 stroke-2 align-[-2.5px]"
 						/>)
 					</span>
 					{{ __('a sender once and their emails reach your Inbox from then on;') }}
 					<span class="whitespace-nowrap">
 						{{ __('Deny') }} (<X
-							class="inline h-3.5 w-3.5 align-[-2.5px]"
-							stroke-width="2"
+							class="inline h-3.5 w-3.5 stroke-2 align-[-2.5px]"
 						/>)
 					</span>
 					{{ __('sends them to Junk.') }}
@@ -126,15 +123,13 @@
 												<!-- nowrap keeps each word+icon parenthetical on one line -->
 												<span class="whitespace-nowrap">
 													{{ __('Allow') }} (<Check
-														class="inline h-3.5 w-3.5 align-[-2.5px]"
-														stroke-width="2"
+														class="inline h-3.5 w-3.5 stroke-2 align-[-2.5px]"
 													/>)
 												</span>
 												{{ __('a sender and their emails go to your Inbox — now and in the future.') }}
 												<span class="whitespace-nowrap">
 													{{ __('Deny') }} (<X
-														class="inline h-3.5 w-3.5 align-[-2.5px]"
-														stroke-width="2"
+														class="inline h-3.5 w-3.5 stroke-2 align-[-2.5px]"
 													/>)
 												</span>
 												{{ __('sends them to Junk.') }}
@@ -203,7 +198,7 @@
 										:label="__('Deny')"
 										@click.stop="screenOut([sender.from_email])"
 									>
-										<template #prefix><X class="h-4 w-4" stroke-width="1.5" /></template>
+										<template #prefix><X class="h-4 w-4" /></template>
 									</Button>
 									<Button
 										variant="outline"
@@ -211,7 +206,7 @@
 										:label="__('Allow')"
 										@click.stop="allow([sender.from_email])"
 									>
-										<template #prefix><Check class="h-4 w-4" stroke-width="1.5" /></template>
+										<template #prefix><Check class="h-4 w-4" /></template>
 									</Button>
 								</div>
 							</div>
@@ -229,14 +224,14 @@
 										:tooltip="__('Deny')"
 										@click.stop="screenOut([sender.from_email])"
 									>
-										<template #icon><X class="h-4 w-4" stroke-width="1.5" /></template>
+										<template #icon><X class="h-4 w-4" /></template>
 									</Button>
 									<Button
 										variant="outline"
 										:tooltip="__('Allow')"
 										@click.stop="allow([sender.from_email])"
 									>
-										<template #icon><Check class="h-4 w-4" stroke-width="1.5" /></template>
+										<template #icon><Check class="h-4 w-4" /></template>
 									</Button>
 								</div>
 							</div>
@@ -288,7 +283,7 @@
 										placement="bottom-end"
 									>
 										<Button variant="outline" class="-ml-px !rounded-l-none !px-1.5">
-											<template #icon><ChevronDown class="h-4 w-4" stroke-width="1.5" /></template>
+											<template #icon><ChevronDown class="h-4 w-4" /></template>
 										</Button>
 									</Dropdown>
 								</div>
@@ -308,7 +303,7 @@
 											class="!rounded-l-none !px-1.5"
 											style="border-left: 1px solid color-mix(in srgb, currentColor 35%, transparent)"
 										>
-											<template #icon><ChevronDown class="h-4 w-4" stroke-width="1.5" /></template>
+											<template #icon><ChevronDown class="h-4 w-4" /></template>
 										</Button>
 									</Dropdown>
 								</div>
@@ -380,6 +375,7 @@ import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
 import MailDate from '@/apps/mail/components/MailDate.vue'
 import MailThread from '@/apps/mail/components/MailThread.vue'
+import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
 import MailThreadSkeleton from '@/apps/mail/components/MailThreadSkeleton.vue'
 
 import type { Mail, MailboxData, ScreeningSender } from '@/apps/mail/types'

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -97,7 +97,7 @@
 					<div class="pb-20">
 						<!-- Count bar — matches the mailbox "All Mails" toolbar height/style. -->
 						<!-- Desktop-only: on mobile the header above carries these actions. -->
-					<div class="hidden min-h-[49px] items-center justify-between border-b px-5 sm:flex">
+						<div class="hidden min-h-[49px] items-center justify-between border-b px-5 sm:flex">
 							<div class="flex min-w-0 items-center">
 								<span class="truncate">{{ waitingLabel }}</span>
 								<!-- Redundant while the explainer slab is teaching the same lesson above,
@@ -383,7 +383,7 @@ import {
 } from 'frappe-ui'
 
 import { raiseToast, shouldIgnoreKeypress } from '@/apps/mail/utils'
-import { useScreenSize, useSettings } from '@/apps/mail/utils/composables'
+import { useScreenSize, useSettings, useSwipeNav } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
@@ -464,50 +464,23 @@ const senders = createResource({
 	auto: true,
 })
 
-// Horizontal swipe on the open preview (mobile): left → next sender, right → previous —
-// the screener counterpart of the mailbox thread swipe, same detection (judged on
-// touchend, decisively horizontal only). Swipes over the email body arrive as
-// email-swipe events forwarded out of EmailContent's iframe.
-const SWIPE_MIN_X = 64
-let senderTouchOrigin: { x: number; y: number } | null = null
-
-const onPreviewTouchStart = (e: TouchEvent) => {
-	senderTouchOrigin =
-		isMobile.value && openSender.value && e.touches.length === 1
-			? { x: e.touches[0].clientX, y: e.touches[0].clientY }
-			: null
-}
-
-const onPreviewTouchEnd = (e: TouchEvent) => {
-	if (!senderTouchOrigin) return
-	const dx = e.changedTouches[0].clientX - senderTouchOrigin.x
-	const dy = e.changedTouches[0].clientY - senderTouchOrigin.y
-	senderTouchOrigin = null
-	if (Math.abs(dx) < SWIPE_MIN_X || Math.abs(dx) < Math.abs(dy) * 2) return
-	swipeSender(dx < 0 ? 1 : -1)
-}
-
-// The time guard also dedupes the forwarded swipes: expanded mails each mount an
-// EmailContent whose message listener re-dispatches the same event.
-let lastSenderSwipeAt = 0
-const swipeSender = (offset: 1 | -1) => {
-	if (!isMobile.value || !openSender.value) return
-	const now = Date.now()
-	if (now - lastSenderSwipeAt < 250) return
-	const list = senders.data ?? []
-	const idx = list.findIndex(
-		(s: ScreeningSender) => s.from_email === openSender.value!.from_email,
-	)
-	const next = idx === -1 ? undefined : list[idx + offset]
-	if (!next) return
-	lastSenderSwipeAt = now
-	// Arms the paging animation for this navigation only — row taps and the allow/deny
-	// auto-advance keep swapping instantly.
-	senderSlide.value = offset > 0 ? 'sender-next' : 'sender-prev'
-	selectSender(next)
-}
-
-const onEmailSwipe = (e: Event) => swipeSender((e as CustomEvent).detail === 'left' ? 1 : -1)
+// Swipe on the open preview (mobile): left → next sender, right → previous — the
+// screener counterpart of the mailbox thread swipe.
+const { onTouchStart: onPreviewTouchStart, onTouchEnd: onPreviewTouchEnd } = useSwipeNav(
+	() => isMobile.value && !!openSender.value,
+	(offset) => {
+		const list = senders.data ?? []
+		const idx = list.findIndex(
+			(s: ScreeningSender) => s.from_email === openSender.value!.from_email,
+		)
+		const next = idx === -1 ? undefined : list[idx + offset]
+		if (!next) return
+		// Arms the paging animation for this navigation only — row taps and the allow/deny
+		// auto-advance keep swapping instantly.
+		senderSlide.value = offset > 0 ? 'page-next' : 'page-prev'
+		selectSender(next)
+	},
+)
 
 // The <Transition> name while a swipe navigation renders; cleared after the slide.
 const senderSlide = ref('')
@@ -518,9 +491,6 @@ const senderPaneKey = ref('none')
 watch(openSender, (sender) => {
 	if (sender) senderPaneKey.value = sender.from_email
 })
-
-onMounted(() => window.addEventListener('email-swipe', onEmailSwipe))
-onUnmounted(() => window.removeEventListener('email-swipe', onEmailSwipe))
 
 // Once a mail is open, ↑/↓ (or k/j) step to the previous/next sender and Esc closes it. Else inert.
 const handleKeydown = (e: KeyboardEvent) => {
@@ -832,36 +802,3 @@ const bulkOptions = computed(() => [
 ])
 </script>
 
-<style scoped>
-/* Swipe paging between senders (mobile): the incoming preview slides in from the swipe
-   side while the outgoing one — lifted out of flow so they overlap — slides away in
-   tandem. Mirrors the mailbox thread swipe's timing. */
-.sender-next-enter-active,
-.sender-next-leave-active,
-.sender-prev-enter-active,
-.sender-prev-leave-active {
-	transition: transform 0.2s cubic-bezier(0.32, 0.72, 0, 1);
-}
-
-.sender-next-leave-active,
-.sender-prev-leave-active {
-	position: absolute;
-	inset: 0;
-}
-
-.sender-next-enter-from {
-	transform: translateX(100%);
-}
-
-.sender-next-leave-to {
-	transform: translateX(-100%);
-}
-
-.sender-prev-enter-from {
-	transform: translateX(-100%);
-}
-
-.sender-prev-leave-to {
-	transform: translateX(100%);
-}
-</style>

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -174,7 +174,13 @@
 									<span class="text-ink-gray-8 truncate text-[15px] !font-semibold sm:text-base">
 										{{ sender.from_name || sender.from_email }}
 									</span>
-									<span class="text-ink-gray-5 truncate text-[13px]">{{ sender.from_email }}</span>
+									<span class="text-ink-gray-5 flex-1 truncate text-[13px]">{{ sender.from_email }}</span>
+									<MailDate
+										v-if="isMobile"
+										:datetime="sender.received_at"
+										:in-list="true"
+										class="text-ink-gray-4 shrink-0 whitespace-nowrap text-xs tabular-nums"
+									/>
 								</div>
 								<div class="text-ink-gray-8 truncate text-sm !font-semibold !leading-[1.5]">
 									{{ sender.subject || __('[No subject]') }}
@@ -188,10 +194,30 @@
 										{{ sender.preview ? ' · ' : '' }}{{ __('{0} messages', [String(sender.count)]) }}
 									</span>
 								</div>
+								<!-- Variant E: full-width labeled verdict pills — x/check icons alone
+								     relied on tooltips, which never fire on touch. -->
+								<div v-if="isMobile" class="flex gap-2 pt-1.5">
+									<Button
+										variant="outline"
+										class="!h-8 flex-1"
+										:label="__('Deny')"
+										@click.stop="screenOut([sender.from_email])"
+									>
+										<template #prefix><X class="h-4 w-4" stroke-width="1.5" /></template>
+									</Button>
+									<Button
+										variant="outline"
+										class="!h-8 flex-1"
+										:label="__('Allow')"
+										@click.stop="allow([sender.from_email])"
+									>
+										<template #prefix><Check class="h-4 w-4" stroke-width="1.5" /></template>
+									</Button>
+								</div>
 							</div>
 
 							<!-- Received time, with Deny / Allow icon buttons -->
-							<div class="flex shrink-0 flex-col items-end justify-between">
+							<div v-if="!isMobile" class="flex shrink-0 flex-col items-end justify-between">
 								<MailDate
 									:datetime="sender.received_at"
 									:in-list="true"
@@ -215,6 +241,7 @@
 								</div>
 							</div>
 						</div>
+
 					</div>
 				</div>
 
@@ -231,7 +258,7 @@
 					<template v-if="openSender">
 						<!-- Subject + Deny/Allow; back button only when the preview owns the whole pane -->
 						<div
-							class="bg-surface-base sticky top-0 z-10 flex shrink-0 items-center justify-between gap-3 border-b p-2.5 sm:px-5"
+							class="bg-surface-base border-b sticky top-0 z-10 flex shrink-0 items-center justify-between gap-3 p-2.5 max-sm:border-b-0 sm:px-5"
 						>
 							<div class="flex min-w-0 items-center">
 								<Button

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -254,6 +254,8 @@
 						'invisible translate-x-full': isMobile && !openSender,
 						hidden: !isMobile && !showReadingPane && !openSender,
 					}"
+					@touchstart.passive="onPreviewTouchStart"
+					@touchend.passive="onPreviewTouchEnd"
 				>
 					<template v-if="openSender">
 						<!-- Subject + Deny/Allow; back button only when the preview owns the whole pane -->
@@ -315,17 +317,24 @@
 							</div>
 						</div>
 
-						<MailThreadSkeleton v-if="previewLoading" />
-						<MailThread
-							v-else-if="previewMails?.length"
-							:key="openSender.from_email"
-							class="min-h-0 flex-1"
-							readonly
-							mailbox=""
-							:thread-i-d="openSender.from_email"
-							:threads="[]"
-							:messages="previewMails"
-						/>
+						<!-- Keyed by sender so a swipe pages like the mailbox thread view: the old
+					     preview slides out while the next sender's slides in. -->
+						<div class="relative min-h-0 flex-1 overflow-hidden">
+							<Transition :name="senderSlide" @after-enter="senderSlide = ''">
+								<div :key="senderPaneKey" class="flex h-full flex-col">
+									<MailThreadSkeleton v-if="previewLoading" />
+									<MailThread
+										v-else-if="previewMails?.length"
+										class="min-h-0 flex-1"
+										readonly
+										mailbox=""
+										:thread-i-d="openSender.from_email"
+										:threads="[]"
+										:messages="previewMails"
+									/>
+								</div>
+							</Transition>
+						</div>
 					</template>
 
 					<div v-else class="flex-1 overflow-hidden">
@@ -454,6 +463,64 @@ const senders = createResource({
 	makeParams: () => ({ account: store.accountId }),
 	auto: true,
 })
+
+// Horizontal swipe on the open preview (mobile): left → next sender, right → previous —
+// the screener counterpart of the mailbox thread swipe, same detection (judged on
+// touchend, decisively horizontal only). Swipes over the email body arrive as
+// email-swipe events forwarded out of EmailContent's iframe.
+const SWIPE_MIN_X = 64
+let senderTouchOrigin: { x: number; y: number } | null = null
+
+const onPreviewTouchStart = (e: TouchEvent) => {
+	senderTouchOrigin =
+		isMobile.value && openSender.value && e.touches.length === 1
+			? { x: e.touches[0].clientX, y: e.touches[0].clientY }
+			: null
+}
+
+const onPreviewTouchEnd = (e: TouchEvent) => {
+	if (!senderTouchOrigin) return
+	const dx = e.changedTouches[0].clientX - senderTouchOrigin.x
+	const dy = e.changedTouches[0].clientY - senderTouchOrigin.y
+	senderTouchOrigin = null
+	if (Math.abs(dx) < SWIPE_MIN_X || Math.abs(dx) < Math.abs(dy) * 2) return
+	swipeSender(dx < 0 ? 1 : -1)
+}
+
+// The time guard also dedupes the forwarded swipes: expanded mails each mount an
+// EmailContent whose message listener re-dispatches the same event.
+let lastSenderSwipeAt = 0
+const swipeSender = (offset: 1 | -1) => {
+	if (!isMobile.value || !openSender.value) return
+	const now = Date.now()
+	if (now - lastSenderSwipeAt < 250) return
+	const list = senders.data ?? []
+	const idx = list.findIndex(
+		(s: ScreeningSender) => s.from_email === openSender.value!.from_email,
+	)
+	const next = idx === -1 ? undefined : list[idx + offset]
+	if (!next) return
+	lastSenderSwipeAt = now
+	// Arms the paging animation for this navigation only — row taps and the allow/deny
+	// auto-advance keep swapping instantly.
+	senderSlide.value = offset > 0 ? 'sender-next' : 'sender-prev'
+	selectSender(next)
+}
+
+const onEmailSwipe = (e: Event) => swipeSender((e as CustomEvent).detail === 'left' ? 1 : -1)
+
+// The <Transition> name while a swipe navigation renders; cleared after the slide.
+const senderSlide = ref('')
+
+// The preview wrapper's key: follows the open sender but freezes on close, so the pane's
+// slide-out still shows the preview it closed on instead of a remounted blank wrapper.
+const senderPaneKey = ref('none')
+watch(openSender, (sender) => {
+	if (sender) senderPaneKey.value = sender.from_email
+})
+
+onMounted(() => window.addEventListener('email-swipe', onEmailSwipe))
+onUnmounted(() => window.removeEventListener('email-swipe', onEmailSwipe))
 
 // Once a mail is open, ↑/↓ (or k/j) step to the previous/next sender and Esc closes it. Else inert.
 const handleKeydown = (e: KeyboardEvent) => {
@@ -764,3 +831,37 @@ const bulkOptions = computed(() => [
 	{ label: __('Move All to Inbox'), icon: Inbox, onClick: () => (showClearAll.value = true) },
 ])
 </script>
+
+<style scoped>
+/* Swipe paging between senders (mobile): the incoming preview slides in from the swipe
+   side while the outgoing one — lifted out of flow so they overlap — slides away in
+   tandem. Mirrors the mailbox thread swipe's timing. */
+.sender-next-enter-active,
+.sender-next-leave-active,
+.sender-prev-enter-active,
+.sender-prev-leave-active {
+	transition: transform 0.2s cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.sender-next-leave-active,
+.sender-prev-leave-active {
+	position: absolute;
+	inset: 0;
+}
+
+.sender-next-enter-from {
+	transform: translateX(100%);
+}
+
+.sender-next-leave-to {
+	transform: translateX(-100%);
+}
+
+.sender-prev-enter-from {
+	transform: translateX(-100%);
+}
+
+.sender-prev-leave-to {
+	transform: translateX(100%);
+}
+</style>

--- a/frontend/src/apps/mail/utils/composables.ts
+++ b/frontend/src/apps/mail/utils/composables.ts
@@ -33,6 +33,51 @@ export const useSidebar = () => {
 	return { isSidebarOpen, openSidebar, closeSidebar }
 }
 
+// Horizontal swipe-to-page detection, shared by the mailbox thread pane and the screener
+// preview: left → onSwipe(1) (next), right → onSwipe(-1). Judged on touchend (passive) so
+// vertical scrolling is never delayed; a swipe must be decisively horizontal — at least
+// 64px long and twice its vertical drift. Swipes over an email body never reach the pane:
+// EmailContent detects them inside its iframe and re-broadcasts them as `email-swipe`
+// window events, which this subscribes to as well. The time guard dedupes those (every
+// mounted EmailContent re-dispatches the same message) and paces direct swipes alike.
+const SWIPE_MIN_X = 64
+
+export const useSwipeNav = (enabled: () => boolean, onSwipe: (offset: 1 | -1) => void) => {
+	let origin: { x: number; y: number } | null = null
+	let lastSwipeAt = 0
+
+	const swipe = (offset: 1 | -1) => {
+		if (!enabled()) return
+		const now = Date.now()
+		if (now - lastSwipeAt < 250) return
+		lastSwipeAt = now
+		onSwipe(offset)
+	}
+
+	const onTouchStart = (e: TouchEvent) => {
+		origin =
+			enabled() && e.touches.length === 1
+				? { x: e.touches[0].clientX, y: e.touches[0].clientY }
+				: null
+	}
+
+	const onTouchEnd = (e: TouchEvent) => {
+		if (!origin) return
+		const dx = e.changedTouches[0].clientX - origin.x
+		const dy = e.changedTouches[0].clientY - origin.y
+		origin = null
+		if (Math.abs(dx) < SWIPE_MIN_X || Math.abs(dx) < Math.abs(dy) * 2) return
+		swipe(dx < 0 ? 1 : -1)
+	}
+
+	const onEmailSwipe = (e: Event) => swipe((e as CustomEvent).detail === 'left' ? 1 : -1)
+
+	onMounted(() => window.addEventListener('email-swipe', onEmailSwipe))
+	onUnmounted(() => window.removeEventListener('email-swipe', onEmailSwipe))
+
+	return { onTouchStart, onTouchEnd }
+}
+
 // Mobile folder bottom sheet — shared so both the header title (mailbox views)
 // and the tab bar's Mail re-tap can open the same sheet.
 const isFolderSheetOpen = ref(false)

--- a/frontend/src/apps/mail/utils/composables.ts
+++ b/frontend/src/apps/mail/utils/composables.ts
@@ -44,6 +44,16 @@ export const useFolderSheet = () => {
 	return { isFolderSheetOpen, openFolderSheet, closeFolderSheet }
 }
 
+// Mobile selection mode — MailboxView owns the selection; the tab bar and FAB
+// (mounted in DefaultLayout) hide behind the contextual action bar while it's on.
+const isMobileSelectionActive = ref(false)
+
+export const useMobileSelection = () => {
+	const setMobileSelectionActive = (active: boolean) => (isMobileSelectionActive.value = active)
+
+	return { isMobileSelectionActive, setMobileSelectionActive }
+}
+
 // Mobile profile bottom sheet — opened from the header avatar (any view), so the
 // trigger (HeaderActions) and the mounted sheet (tab bar) stay decoupled.
 const isProfileSheetOpen = ref(false)

--- a/frontend/src/apps/mail/utils/composables.ts
+++ b/frontend/src/apps/mail/utils/composables.ts
@@ -33,6 +33,17 @@ export const useSidebar = () => {
 	return { isSidebarOpen, openSidebar, closeSidebar }
 }
 
+// Mobile folder bottom sheet — shared so both the header title (mailbox views)
+// and the tab bar's Mail re-tap can open the same sheet.
+const isFolderSheetOpen = ref(false)
+
+export const useFolderSheet = () => {
+	const openFolderSheet = () => (isFolderSheetOpen.value = true)
+	const closeFolderSheet = () => (isFolderSheetOpen.value = false)
+
+	return { isFolderSheetOpen, openFolderSheet, closeFolderSheet }
+}
+
 export const useTextEditorButtons = () => {
 	const { isMobile } = useScreenSize()
 

--- a/frontend/src/apps/mail/utils/composables.ts
+++ b/frontend/src/apps/mail/utils/composables.ts
@@ -44,6 +44,17 @@ export const useFolderSheet = () => {
 	return { isFolderSheetOpen, openFolderSheet, closeFolderSheet }
 }
 
+// Mobile profile bottom sheet — opened from the header avatar (any view), so the
+// trigger (HeaderActions) and the mounted sheet (tab bar) stay decoupled.
+const isProfileSheetOpen = ref(false)
+
+export const useProfileSheet = () => {
+	const openProfileSheet = () => (isProfileSheetOpen.value = true)
+	const closeProfileSheet = () => (isProfileSheetOpen.value = false)
+
+	return { isProfileSheetOpen, openProfileSheet, closeProfileSheet }
+}
+
 export const useTextEditorButtons = () => {
 	const { isMobile } = useScreenSize()
 

--- a/frontend/src/apps/mail/utils/index.ts
+++ b/frontend/src/apps/mail/utils/index.ts
@@ -11,6 +11,13 @@ import VideoIcon from '@/apps/mail/components/Icons/VideoIcon.vue'
 
 import type { ComposeMailData, MailboxData, Recipient } from '@/apps/mail/types'
 
+// Keyboard hints in action labels — "Archive Thread (E)", "Move to Trash (Delete)" —
+// are noise on touch surfaces. Strips only trailing parentheticals that look like
+// shortcuts, so a folder named "Work (old)" is never clipped.
+const SHORTCUT_HINT =
+	/\s*\((?:(?:Shift|Ctrl|Cmd|Alt|⌘|⇧|⌥)\+)*(?:[A-Z!,.;]|Delete|Backspace|Esc(?:ape)?|Enter|Tab|Space|↑\/K|↓\/J)\)$/
+export const stripShortcutHint = (label: string) => label.replace(SHORTCUT_HINT, '')
+
 export const toTitleCase = (str: string) =>
 	str
 		?.toLowerCase()

--- a/frontend/src/components/settings/AppSettingsBody.vue
+++ b/frontend/src/components/settings/AppSettingsBody.vue
@@ -1,5 +1,11 @@
 <template>
-	<SettingsBody v-bind="$attrs">
+	<!-- Inside a mobile settings page (see mail's PWASettings): plain page-padded
+	     flow — the sub-page container scrolls. Desktop keeps the dialog's padded
+	     ScrollArea untouched. -->
+	<div v-if="mobilePage" class="px-4 pb-8 pt-4">
+		<slot />
+	</div>
+	<SettingsBody v-else v-bind="$attrs">
 		<div class="pt-6">
 			<slot />
 		</div>
@@ -7,7 +13,10 @@
 </template>
 
 <script setup lang="ts">
+import { inject } from 'vue'
 import { SettingsBody } from 'frappe-ui'
 
 defineOptions({ inheritAttrs: false })
+
+const mobilePage = inject('app-settings-mobile-page', false)
 </script>

--- a/frontend/src/components/settings/AppSettingsHeader.vue
+++ b/frontend/src/components/settings/AppSettingsHeader.vue
@@ -1,5 +1,23 @@
 <template>
-	<SettingsHeader v-bind="$attrs">
+	<!-- Inside a mobile settings page (see mail's PWASettings) the page's top bar
+	     already shows the section title and hosts the actions (teleported into
+	     its #app-settings-page-actions slot, nav-bar style), so only an optional
+	     description renders in the flow. Desktop keeps the frappe-ui dialog
+	     header untouched. -->
+	<template v-if="mobilePage">
+		<!-- defer: the settings sub-page slides in as one freshly-mounted layer, so
+		     the bar's teleport target isn't in the document yet while this header
+		     mounts — a non-deferred Teleport fails and breaks the whole page. -->
+		<Teleport defer to="#app-settings-page-actions">
+			<slot name="actions" />
+		</Teleport>
+		<div v-if="$slots.default || $attrs.description" class="shrink-0 px-4 pt-4">
+			<slot>
+				<p class="text-ink-gray-6 min-w-0 text-base">{{ $attrs.description }}</p>
+			</slot>
+		</div>
+	</template>
+	<SettingsHeader v-else v-bind="$attrs">
 		<template v-if="$slots.default" #default>
 			<slot />
 		</template>
@@ -10,7 +28,10 @@
 </template>
 
 <script setup lang="ts">
+import { inject } from 'vue'
 import { SettingsHeader } from 'frappe-ui'
 
 defineOptions({ inheritAttrs: false })
+
+const mobilePage = inject('app-settings-mobile-page', false)
 </script>


### PR DESCRIPTION
Mobile-only revamp of Mail's chrome; desktop unchanged throughout.

- Bottom tab bar (Mail · Screener · Search · Profile) + Compose FAB; the Mail tab morphs into the current folder and re-tapping it opens a folder bottom sheet (grouped like the desktop sidebar, incl. New Folder). Bar and FAB step aside in thread view, selection mode, and search; the FAB also hides in the screener. Neutral ink unread badges anchored to the icon corner (red is reserved for urgency, not volume); active state reads on two channels — ink 9/4 plus stroke/label weight.
- Profile tab replaces the drawer: account switching, Settings, Log Out. Hamburger and mobile drawer removed; top bars slimmed per view (screener gets its own); the Trash/Junk auto-delete banner sits below the mobile title.
- Full-screen mobile settings: grouped section list, sections push in as full-screen panels with back navigation; nav-bar Save/New actions at md size for touch.
- Search is one page: the Search tab lands on the search route with the query editor appearing in place over it (no slide-up) — tab bar stays visible, filter chips and quick filters sit under the header, and results load inline below it instead of blanking to a full-page spinner. Advanced filters lay out for narrow screens (stacked Cc/Bcc, paired attachment/read, no redundant footer buttons).
- Compose slides up as a full-screen sheet (first-open slide and z-order fixed); replying on mobile pops straight into it instead of splicing an inline draft into the thread.
- Selection mode: long-press or avatar tap; contextual toolbar (✕ / count / Select All), full desktop action set in a bottom bar (4 labeled + More sheet chaining into Move To / Add To / Remove From).
- AdaptiveDropdown: frappe-ui Dropdown on desktop, content-hugging bottom sheet on mobile — adopted for filter, screener bulk menu, thread folder menus; label-less groups get separators; shortcut hints stripped on touch.
- Swipe paging: swipe left/right in an open thread for next/previous (200ms slide; the toolbar stays put, only subject + messages page; works over email-body iframes, skips horizontally scrollable content). Same gesture pages between senders in the screener preview — one shared useSwipeNav composable.
- Email rendering on mobile: bodies clamped to the viewport, incl. nested fixed-width tables the stylesheet clamp can't reach.
- Inbox toolbar leads with the folder name; funnel-icon filter with dismissible chip; flat lists (no group headers) on mobile; FAB clearance; sticky :hover fixes; larger tap targets (star halo, 40px avatars).
- Screener: labeled Deny/Allow pills on rows; thread view: fixed subject, inline actions, px-3.5 axis alignment.

Refs krantheman/suite#3, krantheman/suite#4, krantheman/suite#5, krantheman/suite#7, krantheman/suite#10 (partial: no drag gestures yet), krantheman/suite#15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)