### PR TITLE
fix(sheets): gate sheet-tab mutations for view-only users

### DIFF
--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -2593,18 +2593,25 @@ function onTabClick(name) {
 const tabDragName = ref(null)
 const tabDragOver = ref(null)
 
+// Reorder is a mutation. `:draggable="!readOnly"` stops a viewer starting a
+// drag, but dragover/drop still fire when *another* element is dragged onto a
+// tab — guard the whole lifecycle so the invariant "viewers can't reorder" is
+// explicit here, not just an emergent effect of the null tabDragName.
 function onTabDragStart(e, name) {
+  if (readOnly.value) return
   tabDragName.value = name
   e.dataTransfer.effectAllowed = 'move'
   // Some browsers require setData to allow the drag
   try { e.dataTransfer.setData('text/plain', name) } catch (_) {}
 }
 function onTabDragOver(e, name) {
+  if (readOnly.value) return
   if (!tabDragName.value || tabDragName.value === name) return
   e.dataTransfer.dropEffect = 'move'
   tabDragOver.value = name
 }
 function onTabDrop(e, target) {
+  if (readOnly.value) return
   const src = tabDragName.value
   if (!src || src === target) { tabDragOver.value = null; return }
   const next = sheetNames.value.filter(n => n !== src)

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -634,8 +634,10 @@
            the Button itself stays a clean square pill (frappe-ui puts our
            `class` on the <button> root, so any spacing/border set on it would
            become part of the button's own hover box). -->
-      <div class="sn-tab-add-wrap">
-        <Button variant="ghost" size="sm" icon="plus" class="sn-tab-add" tooltip="Add sheet" :disabled="readOnly" @click="addSheet" />
+      <!-- Add-sheet is a mutation, so viewers don't get it — hide the whole
+           wrapper (button + its divider) rather than leave a dead, greyed pill. -->
+      <div v-if="!readOnly" class="sn-tab-add-wrap">
+        <Button variant="ghost" size="sm" icon="plus" class="sn-tab-add" tooltip="Add sheet" @click="addSheet" />
       </div>
       <div class="sn-tabs-track">
         <div
@@ -646,17 +648,18 @@
             'sn-tab--active':   name === currentSheet,
             'sn-tab--pivot':    isPivotSheet(name),
             'sn-tab-drag-over': tabDragOver === name && tabDragName !== name,
+            'sn-tab--static':   readOnly,
           }"
-          draggable="true"
+          :draggable="!readOnly"
           @dragstart="onTabDragStart($event, name)"
           @dragend="onTabDragEnd"
           @dragover.prevent="onTabDragOver($event, name)"
           @drop.prevent="onTabDrop($event, name)"
         >
           <!-- One visual unit: label + chevron share a single pill background
-               so they read as one button. Chevron renders on every tab so
-               the menu affordance is always visible; clicking it opens the
-               tab menu, clicking the label switches sheets. -->
+               so they read as one button. The chevron — the tab-menu affordance
+               — renders only when editable; a viewer has no tab actions, so it
+               would be a dead button. Clicking the label switches sheets. -->
           <Button
             variant="ghost"
             size="sm"
@@ -666,14 +669,15 @@
             @mousedown="onTabMousedown($event, name)"
             @click="onTabClick(name)"
             @dblclick="openRenameDialog(name)"
-            @contextmenu.prevent="openTabMenu($event, name)"
+            @contextmenu.prevent="_onTabMenu($event, name)"
           />
           <Button
+            v-if="!readOnly"
             variant="ghost"
             size="sm"
             icon="chevron-down"
             class="sn-tab-chevron"
-            @click.stop="openTabMenu($event, name)"
+            @click.stop="_onTabMenu($event, name)"
           />
           <!-- Peer dots — one colored circle per peer currently on this
                tab. Capped at 3 + a "+N" overflow so a busy tab doesn't
@@ -2404,6 +2408,15 @@ const { contextMenu, tabMenu, openCanvasContextMenu: onCanvasContextMenu, openTa
 function _onCanvasContextMenu(e) {
   if (readOnly.value) return
   onCanvasContextMenu(e)
+}
+
+// Same reasoning for the sheet-tab menu: every item (rename/duplicate/protect/
+// delete) mutates, so a viewer has nothing to do there. Suppress it entirely —
+// `.prevent` on the binding still eats the native menu — rather than open an
+// empty popover. Rename (dbl-click) and reorder (drag) are gated separately.
+function _onTabMenu(e, name) {
+  if (readOnly.value) return
+  openTabMenu(e, name)
 }
 
 // renderVersion is defined here because usePivotIntegration reads it at call time.
@@ -5058,6 +5071,9 @@ const renameInputRef   = ref(null)
 let _renameTarget      = ''
 
 function openRenameDialog(name) {
+  // Reachable via dbl-click on the tab even when the menu is suppressed — gate
+  // here so rename is denied for viewers regardless of entry point.
+  if (readOnly.value) return
   tabMenu.open = false
   _renameTarget      = name
   renameValue.value  = name
@@ -6258,6 +6274,16 @@ function toggleShowFormulas() {
 /* Sheet-tab drag visual — Espresso ink-gray-9 left edge on the drop target. */
 .sn-tab               { cursor:grab; }
 .sn-tab:active        { cursor:grabbing; }
+
+/* Viewer tabs — no chevron, no drag. The `.sn-tab-btn` right padding is only
+   2px because it normally butts against the chevron; with the chevron gone the
+   label needs its own symmetric breathing room. And a grab cursor lies about a
+   tab that can't be dragged — clicking still switches sheets, so use pointer.
+   Placed after the base `.sn-tab` cursor rules to win on equal specificity. */
+.sn-tab--static,
+.sn-tab--static:active            { cursor:pointer; }
+.sn-tab--static .sn-tab-btn       { padding-right:8px !important; }
+
 .sn-tab-drag-over::before {
   content: ''; position:absolute; left:-1px; top:4px; bottom:4px; width:2px;
   background: var(--ink-gray-9); border-radius:1px;


### PR DESCRIPTION
## Problem

A **view-only** user was shown every sheet-tab mutation as if it were live:

- Right-clicking (or the tab chevron) opened the context menu with **Rename / Duplicate / Protect sheet / Delete**
- Tabs could be **dragged to reorder**
- **Double-clicking** a tab opened the rename dialog
- The **add-sheet `+`** sat there greyed-out with a divider trailing into nothing

None of these persist — autosave and the write endpoints are already read-only gated — so they were dead, misleading affordances. Only the *cell* context menu was suppressed for viewers; the tab bar was missed.

## Fix

Gate every tab write path on write access, mirroring the existing `_onCanvasContextMenu` guard. A viewer can switch tabs and nothing else (matching Google Sheets):

- `_onTabMenu` wrapper suppresses the tab menu for both openers (right-click + chevron)
- chevron hidden via `v-if` so there's no dead dropdown button
- `:draggable="!readOnly"` disables tab reorder
- `openRenameDialog` early-returns for viewers (covers the double-click path, independent of the menu)
- add-sheet button **and its divider** hidden for viewers rather than rendered disabled

## Visual polish

With the chevron gone for viewers, a `.sn-tab--static` modifier restores symmetric label padding (the tight `2px` right padding only makes sense butted against a chevron) and swaps the `grab` cursor for `pointer` (viewer tabs switch on click but can't be dragged).

|  | Editor | Viewer |
|---|---|---|
| Tabs visible / switchable | ✓ | ✓ |
| Drag-reorder | on | off |
| Chevron / tab menu | present | hidden / suppressed |
| Add `+` | present | hidden |
| Label padding | hugs chevron | balanced |

Frontend-only, single file. Verified in the built bundle by toggling `get_sheet` `can_write`: the editor keeps all four actions + drag; the viewer shows tab pills only — no menu, no chevron, `draggable=false`, double-click opens no rename dialog — and the bar is balanced and centered.
