### PR TITLE
fix(drive): change loader to skeleton in breadcrumbs

### DIFF
--- a/frontend/src/apps/drive/components/DriveToolBar.vue
+++ b/frontend/src/apps/drive/components/DriveToolBar.vue
@@ -7,7 +7,7 @@
     </div>
     <div v-if="$route.name === 'drive-Shared'"
       class="bg-surface-gray-2 rounded-[10px] space-x-0.5 h-7 flex items-center mr-4 py-1">
-      <TabButtons v-model="shareView" :buttons="[
+      <TabButtons v-model="shareView" :options="[
         {
           label: __('Site'),
           value: false,
@@ -53,14 +53,14 @@
           }" :disabled placement="right" />
         <SortControl v-if="$route.name !== 'Recents'" v-model="sortOrder" :options="columnHeaders" :menu-items="sortMenuItems" :disabled />
 
-        <TabButtons v-model="view" :buttons="[
+        <TabButtons v-model="view" :options="[
           {
-            icon: 'grid',
+            icon: 'lucide-grid',
             value: 'grid',
             disabled,
           },
           {
-            icon: 'list',
+            icon: 'lucide-list',
             value: 'list',
             disabled,
           },

--- a/frontend/src/apps/drive/components/DriveToolBar.vue
+++ b/frontend/src/apps/drive/components/DriveToolBar.vue
@@ -55,7 +55,7 @@
 
         <TabButtons v-model="view" :options="[
           {
-            icon: 'lucide-grid',
+            icon: 'lucide-layout-grid',
             value: 'grid',
             disabled,
           },

--- a/frontend/src/apps/drive/components/Navbar.vue
+++ b/frontend/src/apps/drive/components/Navbar.vue
@@ -4,7 +4,7 @@
     <slot name="breadcrumbs">
       <Breadcrumbs :items="breadcrumbItems" class="select-none truncate max-w-[80%]">
         <template #prefix="{ item, index }">
-          <LoadingIndicator v-if="item.loading" width="20" scale="70" />
+          <LoadingIndicator v-if="item.loading" width="20" :scale="70" />
         </template>
       </Breadcrumbs>
     </slot>

--- a/frontend/src/apps/drive/components/Navbar.vue
+++ b/frontend/src/apps/drive/components/Navbar.vue
@@ -4,7 +4,7 @@
     <slot name="breadcrumbs">
       <Breadcrumbs :items="breadcrumbItems" class="select-none truncate max-w-[80%]">
         <template #prefix="{ item, index }">
-          <LoadingIndicator v-if="item.loading" width="20" :scale="70" />
+          <Skeleton v-if="item.loading" class="h-4 w-16 rounded" />
         </template>
       </Breadcrumbs>
     </slot>
@@ -56,7 +56,7 @@
 </template>
 <script setup>
 import EntityDialogs from '@/apps/drive/components/EntityDialogs.vue'
-import { Button, Breadcrumbs, LoadingIndicator, Dropdown } from 'frappe-ui'
+import { Button, Breadcrumbs, Skeleton, Dropdown } from 'frappe-ui'
 import { useSessionStore, useCurrentUser } from '@/boot/session'
 import { isHomeContext, pageBreadcrumbs } from '@/apps/drive/data/breadcrumbs'
 const { systemUser } = useCurrentUser()

--- a/frontend/src/apps/drive/components/Settings/StorageSettings.vue
+++ b/frontend/src/apps/drive/components/Settings/StorageSettings.vue
@@ -12,7 +12,7 @@
     <div class="bg-surface-gray-2 rounded-[10px] space-x-0.5 h-7 flex items-center px-0.5 py-1">
       <TabButtons
         v-model="showFileStorage"
-        :buttons="[
+        :options="[
           {
             label: __('You'),
             value: true,

--- a/frontend/src/apps/drive/pages/Notifications.vue
+++ b/frontend/src/apps/drive/pages/Notifications.vue
@@ -3,7 +3,7 @@
     <div class="bg-surface-gray-2 rounded-[10px] space-x-0.5 h-7 flex items-center px-0.5 py-1">
       <TabButtons
         v-model="onlyUnread"
-        :buttons="[
+        :options="[
           {
             label: 'Unread',
             value: true,


### PR DESCRIPTION
and remove a few deprecated stuff

### Before

<img width="504" alt="telegram-cloud-photo-size-5-6280279821245944782-x" src="https://github.com/user-attachments/assets/188bae16-eaf2-4a59-b104-457a9c425aa5" />

### After

<img width="452" alt="Screenshot 2026-07-25 at 12 42 26 PM" src="https://github.com/user-attachments/assets/cc8001f9-5b6f-4a04-ad02-ba82132aca82" />
