### PR TITLE
fix(sheets): deleting a single row destroys every row below it

### DIFF
--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -5391,9 +5391,12 @@ function doDeleteRow() {
   contextMenu.open = false
   const sn = sheet.getCurrentSheet()
   // Same span logic as doDeleteCol: delete the whole selected row block when
-  // the right-clicked row falls inside it, else just the targeted row.
+  // the right-clicked row falls inside it, else just the targeted row. Only a
+  // real row span counts — in 'col'/'all' selections getSelection() reports
+  // r1 = last row, which would otherwise delete every row below the target.
   const sel = grid.getSelection()
-  const within = sel && contextMenu.targetRow >= sel.r0 && contextMenu.targetRow <= sel.r1
+  const rowSpan = sel && (sel.mode === 'row' || sel.mode === 'cell')
+  const within = rowSpan && contextMenu.targetRow >= sel.r0 && contextMenu.targetRow <= sel.r1
   const start  = within ? sel.r0 : contextMenu.targetRow
   const count  = within ? sel.r1 - sel.r0 + 1 : 1
   for (let i = 0; i < count; i++) {
@@ -5438,8 +5441,11 @@ function doDeleteCol() {
   // When the right-clicked column is inside a multi-column selection, delete
   // every selected column; otherwise just the targeted one. Each delete shifts
   // the rest left, so the block start index stays fixed across iterations.
+  // Only a real column span counts — in 'row'/'all' selections getSelection()
+  // reports c1 = last col, which would otherwise delete every column to the right.
   const sel = grid.getSelection()
-  const within = sel && contextMenu.targetCol >= sel.c0 && contextMenu.targetCol <= sel.c1
+  const colSpan = sel && (sel.mode === 'col' || sel.mode === 'cell')
+  const within = colSpan && contextMenu.targetCol >= sel.c0 && contextMenu.targetCol <= sel.c1
   const start  = within ? sel.c0 : contextMenu.targetCol
   const count  = within ? sel.c1 - sel.c0 + 1 : 1
   for (let i = 0; i < count; i++) {

--- a/frontend/src/apps/sheets/engine/sheet.js
+++ b/frontend/src/apps/sheets/engine/sheet.js
@@ -239,15 +239,21 @@ export function createSheet({ onCellChanged, onCellsChanged } = {}) {
 		// cached formula result might now reference the wrong cell. Safer
 		// to clear everything than try to remap memo keys.
 		_clearAllMemo()
-		const entries = Object.entries(sh)
-			.map(([id, v]) => ({ id, p: parseCellId(id), v }))
-			.filter(({ p }) => p && pred(p))
-		entries.sort((a, b) => a.p.row !== b.p.row ? b.p.row - a.p.row : b.p.col - a.p.col)
-		for (const { id, p, v } of entries) {
+		// Two-phase move: clear every source id first, then write the targets.
+		// A single-pass delete-then-write breaks whenever the shift is *toward*
+		// existing cells (e.g. deleteRow shifts rows up): a target id can still
+		// hold an unprocessed source, and its later delete would wipe the value
+		// we just moved there. Draining sources up front makes the order — and
+		// the shift direction — irrelevant.
+		const moves = []
+		for (const [id, v] of Object.entries(sh)) {
+			const p = parseCellId(id)
+			if (!p || !pred(p)) continue
 			delete sh[id]
 			const nid = newIdFn(p)
-			if (nid) sh[nid] = v
+			if (nid) moves.push([nid, v])
 		}
+		for (const [nid, v] of moves) sh[nid] = v
 		deps.rebuild(sh, sheet)
 	}
 

--- a/frontend/src/apps/sheets/engine/sheet.test.ts
+++ b/frontend/src/apps/sheets/engine/sheet.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createSheet } from './sheet.js'
+
+describe('row / column shifting', () => {
+  let sheet
+  beforeEach(() => { sheet = createSheet() })
+
+  function column() {
+    // Materialise column A as { row(1-indexed): value } for terse assertions.
+    const data = sheet.getRawData()
+    const out = {}
+    for (const id in data) {
+      const m = id.match(/^A(\d+)$/)
+      if (m) out[m[1]] = data[id]?.value ?? data[id]
+    }
+    return out
+  }
+
+  it('deleteRow keeps every row below the deleted one (regression)', () => {
+    // Deleting a single row used to destroy all rows below it: _shiftCells
+    // moved rows up in descending order, so each cell landed on a slot a
+    // not-yet-processed cell still held, and the next delete wiped it.
+    ;['r1', 'r2', 'r3', 'r4', 'r5'].forEach((v, i) => sheet.setCell('A' + (i + 1), v))
+    sheet.deleteRow(1)                   // remove row 2 (r2), rest shift up
+    expect(column()).toEqual({ 1: 'r1', 2: 'r3', 3: 'r4', 4: 'r5' })
+  })
+
+  it('deleteRow rewrites formula-bearing cells without loss', () => {
+    sheet.setCell('A1', '10')
+    sheet.setCell('A2', '20')
+    sheet.setCell('A3', '=A1+A2')        // 30
+    sheet.setCell('A4', 'tail')
+    sheet.deleteRow(1)                   // drop A2; A3→A2, A4→A3
+    expect(column()).toEqual({ 1: '10', 2: '=A1+A2', 3: 'tail' })
+  })
+
+  it('insertRow still pushes rows down without loss', () => {
+    ;['r1', 'r2', 'r3'].forEach((v, i) => sheet.setCell('A' + (i + 1), v))
+    sheet.insertRow(1)                   // open a gap at row 2
+    expect(column()).toEqual({ 1: 'r1', 3: 'r2', 4: 'r3' })
+  })
+})


### PR DESCRIPTION
## Problem

Deleting a single row from a sheet destroyed **every row below it**. The row directly above the deletion survived and shifted up as expected, but all data further down vanished (it only came back on a full reload from the server).

## Root cause

The engine's `_shiftCells` (used by both `insertRow` and `deleteRow`) always sorted the moved cells in **descending** row order.

- For `insertRow` the cells shift **down**, so descending order is correct — you move the bottom-most cell first, into empty space.
- For `deleteRow` the cells shift **up**. Processing descending means each cell is rewritten into a *lower* id that a not-yet-processed cell still occupies; that cell's later `delete sh[id]` then erases the value just moved there. The effect cascades down the column, leaving only the first shifted row intact.

The sibling metadata modules (`formats` / `comments` / `validation`) already handle this correctly by passing a `descending` flag to their shift helper (`insert=true`, `delete=false`) — the core cell engine was the lone module that hardcoded descending.

## Fix

- Rewrite `_shiftCells` as a **direction-independent two-phase move**: drain every source id first, then write all targets. Ordering can no longer clobber, for either insert or delete.
- Gate `doDeleteRow` / `doDeleteCol` on the **selection mode**. A whole-column (`col`) or whole-sheet (`all`) selection reports `r1`/`c1` = last row/col; without the guard, choosing "Delete row" while a column was selected removed the target row plus every row below it. The span now only applies to genuine `row`/`cell` (resp. `col`/`cell`) selections.

## Tests

New `engine/sheet.test.ts` regression coverage:
- `deleteRow` keeps every row below the deleted one (the reported bug — fails without the fix).
- `deleteRow` preserves formula-bearing cells while shifting.
- `insertRow` still shifts rows down without loss.

Frontend-only; no bundle committed (CI builds it).