### PR TITLE
feat(sheets): surface sheets in Drive as content files

### DIFF
--- a/frontend/src/apps/drive/components/ActivityTreeItem.vue
+++ b/frontend/src/apps/drive/components/ActivityTreeItem.vue
@@ -28,7 +28,7 @@
       v-else-if="!strikeThrough"
       loading="lazy"
       class="h-full"
-      :src="getIconUrl(entity.file_type)"
+      :src="getEntityIcon(entity)"
       :draggable="false"
     />
     <span
@@ -39,7 +39,7 @@
   </div>
 </template>
 <script setup>
-import { getIconUrl } from '@/apps/drive/utils/files'
+import { getEntityIcon } from '@/apps/drive/utils/files'
 
 defineProps({
   title: {

--- a/frontend/src/apps/drive/components/GridItem.vue
+++ b/frontend/src/apps/drive/components/GridItem.vue
@@ -35,7 +35,7 @@
           v-if="showTypeIcon"
           loading="lazy"
           class="h-4 w-auto"
-          :src="getIconUrl(file.file_type)"
+          :src="getEntityIcon(file)"
           :draggable="false"
         />
         <p class="truncate">
@@ -51,7 +51,7 @@
   </div>
 </template>
 <script setup>
-import { getIconUrl, getThumbnailUrl } from '@/apps/drive/utils/files'
+import { getEntityIcon, getThumbnailUrl } from '@/apps/drive/utils/files'
 import { ref, computed } from 'vue'
 const props = defineProps({ file: Object })
 

--- a/frontend/src/apps/drive/components/Navbar.vue
+++ b/frontend/src/apps/drive/components/Navbar.vue
@@ -96,6 +96,7 @@ import LucideFileUp from '~icons/lucide/file-up'
 import LucideFolderUp from '~icons/lucide/folder-up'
 import LucideFilePlus2 from '~icons/lucide/file-plus-2'
 import LucideGalleryVerticalEnd from '~icons/lucide/gallery-vertical-end'
+import LucideSheet from '~icons/lucide/sheet'
 import LucideFolderPlus from '~icons/lucide/folder-plus'
 
 const route = useRoute()
@@ -305,6 +306,12 @@ const newEntityOptions = computed(() => [
         icon: LucideGalleryVerticalEnd,
         onClick: () => newExternal('Presentation'),
         cond: isPrivate.value && apps.data?.find?.((k) => k.name === 'slides'),
+      },
+      {
+        label: 'Spreadsheet',
+        icon: LucideSheet,
+        onClick: () => newExternal('Spreadsheet'),
+        cond: isPrivate.value && apps.data?.find?.((k) => k.name === 'sheets'),
       },
       {
         label: 'Folder',

--- a/frontend/src/apps/drive/components/SearchPopup.vue
+++ b/frontend/src/apps/drive/components/SearchPopup.vue
@@ -24,7 +24,7 @@
           @click="openEntity(entity), (open = false)"
         >
           <div class="flex items-center gap-2 w-full col-span-6">
-            <img class="size-4" :src="getIconUrl(entity.is_folder ? 'Folder' : entity.file_type)" />
+            <img class="size-4" :src="entity.is_folder ? getIconUrl('Folder') : getEntityIcon(entity)" />
             <span class="truncate">{{ entity.file_name }}</span>
           </div>
           <div class="col-span-2 grid grid-flow-col justify-start items-center truncate">
@@ -96,7 +96,7 @@
 </template>
 <script setup>
 import { Dialog, Avatar, createResource } from 'frappe-ui'
-import { getIconUrl, openEntity } from '@/apps/drive/utils/files'
+import { getIconUrl, getEntityIcon, openEntity } from '@/apps/drive/utils/files'
 import { ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 

--- a/frontend/src/apps/drive/resources/files.js
+++ b/frontend/src/apps/drive/resources/files.js
@@ -299,6 +299,12 @@ export const createDocument = createResource({
   makeParams: (params) => params,
 })
 
+export const createSheet = createResource({
+  method: 'POST',
+  url: 'suite.sheets.api.create_sheet',
+  makeParams: (params) => params,
+})
+
 
 export const move = createResource({
   url: 'suite.drive.api.files.move',

--- a/frontend/src/apps/drive/utils/files.js
+++ b/frontend/src/apps/drive/utils/files.js
@@ -19,6 +19,7 @@ import {
   getRecents,
   mutate,
   createDocument,
+  createSheet,
   getDocuments,
 } from '@/apps/drive/resources/files'
 import { getTeams, getPublicTeams } from '@/apps/drive/resources/files'
@@ -43,6 +44,9 @@ import videoIcon from '../../../../../suite/public/drive/images/icons/video.svg'
 import applicationIcon from '../../../../../suite/public/drive/images/icons/application.svg'
 import archiveIcon from '../../../../../suite/public/drive/images/icons/archive.svg'
 import unknownIcon from '../../../../../suite/public/drive/images/icons/unknown.svg'
+// Native sheets get the Frappe Sheets brand logo rather than the generic
+// spreadsheet icon (which is shared with uploaded .xlsx/.csv).
+import sheetsLogo from '@/assets/app-logos/sheets.svg'
 
 const FILE_ICONS = {
   Folder: folderIcon,
@@ -64,6 +68,7 @@ const FILE_ICONS = {
 
 export const WRITER_CONTENT_DOCTYPE = 'Writer Document'
 export const PRESENTATION_CONTENT_DOCTYPE = 'Presentation'
+export const SHEET_CONTENT_DOCTYPE = 'Sheet'
 export const ATTACHMENT_CONTENT_DOCTYPE = 'File'
 
 export function isWriterDocument(entity) {
@@ -74,8 +79,15 @@ export function isPresentation(entity) {
   return entity?.content_doctype === PRESENTATION_CONTENT_DOCTYPE
 }
 
+// A native Sheets doc (its own `Sheet` doctype), distinct from an *uploaded*
+// spreadsheet (.xlsx/.csv) — both carry file_type 'Spreadsheet', so the
+// content_doctype is the only reliable discriminator.
+export function isSheet(entity) {
+  return entity?.content_doctype === SHEET_CONTENT_DOCTYPE
+}
+
 export function hasHostedContent(entity) {
-  return isWriterDocument(entity) || isPresentation(entity)
+  return isWriterDocument(entity) || isPresentation(entity) || isSheet(entity)
 }
 
 export function isManaged(entity) {
@@ -126,7 +138,7 @@ export const openEntity = (entity, new_tab = false) => {
   if (new_tab) {
     return window.open(getFileLink(entity, false), '_blank')
   }
-  if (!['Link', 'Presentation'].includes(entity.file_type)) {
+  if (!['Link', 'Presentation'].includes(entity.file_type) && !isSheet(entity)) {
     if (!entity.breadcrumbs?.length)
       appendBreadcrumb({
         label: entity.file_name,
@@ -162,6 +174,8 @@ export const openEntity = (entity, new_tab = false) => {
     entity.file_type === 'Markdown'
   ) {
     window.location.href = '/writer/w/' + entity.name
+  } else if (isSheet(entity)) {
+    window.location.href = '/sheets/' + (entity.content_docname || entity.name)
   } else {
     router.push({
       name: 'drive-File',
@@ -284,9 +298,18 @@ export function getIconUrl(file_type) {
   return FILE_ICONS[file_type] ?? unknownIcon
 }
 
+// Entity-aware icon: native sheets show the Frappe Sheets brand logo; everything
+// else falls back to the generic file-type icon.
+export function getEntityIcon(entity) {
+  return isSheet(entity) ? sheetsLogo : getIconUrl(entity?.file_type)
+}
+
 // `src` is the thumbnail (images/videos/PDFs) or the icon; `fallback` is the icon.
-export function getThumbnailUrl({ name, file_type, thumbnail, external }, view = 'list') {
-  const fallback = getIconUrl(file_type ?? 'Presentation')
+export function getThumbnailUrl(
+  { name, file_type, thumbnail, external, content_doctype },
+  view = 'list'
+) {
+  const fallback = getEntityIcon({ file_type: file_type ?? 'Presentation', content_doctype })
   let src = ''
   if (external) src = view !== 'list' ? thumbnail : ''
   else if (['Image', 'Video', 'PDF'].includes(file_type))
@@ -482,6 +505,11 @@ export function getLink(entity, copy = true, withDomain = true) {
     entity.file_type === 'Markdown'
   ) {
     link = window.location.origin + '/writer/w/' + entity.name
+  } else if (entity.mime_type === 'frappe/sheet' || isSheet(entity)) {
+    link =
+      window.location.origin +
+      '/sheets/' +
+      (entity.content_docname || entity.name)
   } else {
     link = `${
       withDomain ? window.location.origin + '/drive' : ''
@@ -693,6 +721,14 @@ export const newExternal = async (type) => {
     window.location.href = `/slides/presentation/new?parent=${
       currentFolder.value.name
     }&team=${route.params.team || ''}`
+    return
+  }
+  if (type === 'Spreadsheet') {
+    // Sheets owns its own doctype + editor, so — like Slides — we create the
+    // sheet (its after_insert backs it with the Drive File in this folder)
+    // then hand off to the Sheets SPA.
+    const name = await createSheet.submit({ parent: currentFolder.value.name })
+    window.location.href = '/sheets/' + name
     return
   }
   const data = await createDocument.submit({

--- a/suite/drive/overrides/file.py
+++ b/suite/drive/overrides/file.py
@@ -19,6 +19,7 @@ from suite.drive.utils import (
 	ATTACHMENT_CONTENT_DOCTYPE,
 	STATUS_ACTIVE,
 	STATUS_REMOVED,
+	STATUS_TRASHED,
 	generate_upward_path,
 	get_default_team,
 	get_home_folder,
@@ -499,6 +500,38 @@ def sync_content_file(doc, event):
 		drive_file.rename(doc.get_title() or drive_file.file_name)
 	elif event == "on_trash":
 		drive_file.permanent_delete()
+
+
+def sync_content_file_title(doctype: str, docname: str, title: str) -> None:
+	"""Content-app SDK: rename the backing Drive File to match `title`, deduping
+	within its folder instead of throwing on a name clash (content docs may share
+	titles; Drive files can't). No-op when unbacked or already in sync. Apps whose
+	own save writes the title via `db.set_value` (which doesn't fire the on_update
+	doc-event, so `sync_content_file` never runs) call this from their rename/save
+	paths — ideally only when the title actually changed, since `get_for_doc` is a
+	lookup on the un-indexed content_docname."""
+	name = File.get_for_doc(doctype, docname)
+	if not name:
+		return
+	drive_file = frappe.get_doc("File", name)
+	desired = title or drive_file.file_name
+	if desired == drive_file.file_name:
+		return
+	drive_file.rename(get_new_file_name(desired, drive_file.folder, drive_file.file_type))
+
+
+def set_content_file_trashed(doctype: str, docname: str, trashed: bool) -> None:
+	"""Content-app SDK: mirror a content doc's own soft-trash onto its backing
+	Drive File's status, so trashing/restoring the doc removes it from — or
+	returns it to — the Drive listing in lockstep. Apps whose trash is a status
+	flag (not a `frappe.delete_doc`, which `sync_content_file`'s `on_trash`
+	already covers) call this from their trash/restore endpoints."""
+	name = File.get_for_doc(doctype, docname)
+	if not name:
+		return
+	frappe.db.set_value(
+		"File", name, "status", STATUS_TRASHED if trashed else STATUS_ACTIVE, update_modified=False
+	)
 
 
 @frappe.whitelist()

--- a/suite/drive/overrides/file.py
+++ b/suite/drive/overrides/file.py
@@ -431,13 +431,22 @@ class File(FrappeFile):
 	):
 		"""Create the Drive File backing `doc`, in `parent` or the session
 		user's home folder. Returns None when the user has no Drive team."""
-		from suite.drive.utils import create_file, get_default_team
+		from suite.drive.utils import create_file, get_default_team, get_home_folder
 
-		if not parent and not get_default_team():
-			return None
+		if not parent:
+			team = get_default_team()
+			if not team:
+				return None
+			parent = get_home_folder(team).name
+
+		# Dedupe within the folder: content docs may share titles, but two Drive
+		# files can't share a name in one folder without becoming ambiguous.
+		# Mirrors validate_filename (rename) — get_new_file_name only counts
+		# active siblings, so it's a no-op when the name is free.
+		title = get_new_file_name(doc.get_title() or "Untitled", parent, file_type)
 
 		return create_file(
-			title=doc.get_title() or "Untitled",
+			title=title,
 			parent=parent,
 			mime_type=mime_type,
 			file_type=file_type,
@@ -529,8 +538,21 @@ def set_content_file_trashed(doctype: str, docname: str, trashed: bool) -> None:
 	name = File.get_for_doc(doctype, docname)
 	if not name:
 		return
+	if trashed:
+		frappe.db.set_value("File", name, "status", STATUS_TRASHED, update_modified=False)
+		return
+	# Restoring: an active sibling may have taken this file's name while it was
+	# trashed, so dedupe before it re-enters the active namespace (the trashed
+	# file itself isn't counted — get_new_file_name only sees active files).
+	f = frappe.db.get_value("File", name, ["file_name", "folder", "file_type"], as_dict=True)
 	frappe.db.set_value(
-		"File", name, "status", STATUS_TRASHED if trashed else STATUS_ACTIVE, update_modified=False
+		"File",
+		name,
+		{
+			"file_name": get_new_file_name(f.file_name, f.folder, f.file_type),
+			"status": STATUS_ACTIVE,
+		},
+		update_modified=False,
 	)
 
 

--- a/suite/drive/utils/__init__.py
+++ b/suite/drive/utils/__init__.py
@@ -72,6 +72,7 @@ MIME_LIST_MAP = {
         "frappe_doc",
     ],
     "Spreadsheet": [
+        "frappe/sheet",
         "application/vnd.ms-excel",
         "link/googlesheets",
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",

--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -218,6 +218,15 @@ doc_events = {
 		"on_update": ["suite.drive.overrides.file.sync_content_file"],
 		"on_trash": ["suite.drive.overrides.file.sync_content_file"],
 	},
+	"Sheet": {
+		# Remove the backing Drive File when a sheet is hard-deleted (the nightly
+		# purge / "delete forever" calls frappe.delete_doc). Title-sync is NOT an
+		# on_update handler here: a sheet's title is written via db.set_value
+		# (save_sheet / rename_sheet), which never fires on_update — so those
+		# paths call sync_content_file_title explicitly instead. Soft-trash is
+		# likewise a status flag, handled in the trash API.
+		"on_trash": ["suite.drive.overrides.file.sync_content_file"],
+	},
 	"User": {
 		# Roles are assigned before insert so they are present when Frappe's
 		# User.validate runs — assigning them after insert triggers a spurious

--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -42,6 +42,7 @@ suite.writer.patches.change_versioning_schema
 suite.writer.patches.autopopulate_html
 # --- sheets ---
 suite.sheets.patches.v0_1.migrate_blob_to_cells
+suite.sheets.patches.integrate_with_drive
 # --- meet ---
 suite.meet.patches.migrate_meeting_fields_to_table_multiselect
 suite.meet.patches.switch_meet_user_to_suite_user

--- a/suite/sheets/api.py
+++ b/suite/sheets/api.py
@@ -2,6 +2,7 @@ import json
 
 import frappe
 
+from suite.drive.overrides.file import set_content_file_trashed, sync_content_file_title
 from suite.sheets.doctype.sheet.cell_codec import cell_map as unpack_cell_map
 from suite.sheets.doctype.sheet.storage import decode_sheets_data
 from suite.sheets.versioning import save as save_mod
@@ -385,6 +386,26 @@ def save_sheet(
 
 
 @frappe.whitelist()
+def create_sheet(title: str = "", parent: str = "") -> str:
+	# Create a blank sheet and return its id. Used by Drive's "New › Spreadsheet"
+	# so the sheet is born inside the folder the user is looking at — `parent`
+	# is the Drive folder its backing File should land in (validated for upload
+	# access here, then threaded to Sheet.after_insert). Mirrors Writer's
+	# create_document. "{}" is a valid empty workbook — the editor's loader
+	# falls back to a fresh Sheet1 when the packed payload is absent.
+	if parent:
+		from suite.drive.api.permissions import user_has_permission
+
+		if not user_has_permission(parent, "upload"):
+			frappe.throw(
+				"Cannot access folder due to insufficient permissions",
+				frappe.PermissionError,
+			)
+	result = save_mod.save_sheet(title or "Untitled Spreadsheet", "{}", name=None, parent=parent or None)
+	return result["name"]
+
+
+@frappe.whitelist()
 def record_op(
 	sheet: str,
 	op_type: str,
@@ -426,6 +447,10 @@ def delete_sheet(name: str) -> str:
 		{"trashed": 1, "trashed_on": frappe.utils.now_datetime(), "trashed_by": frappe.session.user},
 		update_modified=False,
 	)
+	# Mirror onto the backing Drive File so a trashed sheet drops out of the
+	# Drive listing too (soft-trash is a status flag, not a delete, so the
+	# on_trash doc-event doesn't fire).
+	set_content_file_trashed("Sheet", name, True)
 	return "ok"
 
 
@@ -439,6 +464,8 @@ def restore_sheet(name: str) -> str:
 		{"trashed": 0, "trashed_on": None, "trashed_by": None},
 		update_modified=False,
 	)
+	# Bring the backing Drive File back into the listing alongside the sheet.
+	set_content_file_trashed("Sheet", name, False)
 	return "ok"
 
 
@@ -489,6 +516,9 @@ def rename_sheet(name: str, title: str) -> str:
 	doc = frappe.get_doc("Sheet", name)
 	doc.title = title
 	doc.save()
+	# doc.save() writes the title but doesn't rename the backing Drive File
+	# (Sheet has no on_update sync — see hooks.py), so mirror it explicitly.
+	sync_content_file_title("Sheet", name, title)
 	return doc.name
 
 

--- a/suite/sheets/doctype/sheet/sheet.json
+++ b/suite/sheets/doctype/sheet/sheet.json
@@ -101,5 +101,6 @@
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],
+ "title_field": "title",
  "track_changes": 0
 }

--- a/suite/sheets/doctype/sheet/sheet.py
+++ b/suite/sheets/doctype/sheet/sheet.py
@@ -3,6 +3,7 @@ import json
 import frappe
 from frappe.model.document import Document
 
+from suite.drive.overrides.file import File as DriveFile
 from suite.sheets.doctype.sheet.storage import (
 	MAX_SHEETS_DATA_BYTES,
 	decode_sheets_data,
@@ -50,3 +51,19 @@ class Sheet(Document):
 				json.loads(decode_sheets_data(self.sheets_data))
 			except (ValueError, TypeError):
 				frappe.throw("sheets_data is not valid JSON")
+
+	def after_insert(self):
+		# Back every sheet with a Drive File so it shows up in — and opens
+		# from — Drive, exactly like Writer/Slides docs. The Drive File is a
+		# thin pointer (content_doctype/content_docname); the workbook itself
+		# stays in this doctype. `create_for_doc` no-ops (returns None) when
+		# the creator has no Drive team, so this never blocks sheet creation.
+		self.create_drive_file()
+
+	def create_drive_file(self, parent: str | None = None):
+		return DriveFile.create_for_doc(
+			self,
+			parent=parent or self.flags.get("drive_parent"),
+			mime_type="frappe/sheet",
+			file_type="Spreadsheet",
+		)

--- a/suite/sheets/patches/integrate_with_drive.py
+++ b/suite/sheets/patches/integrate_with_drive.py
@@ -1,6 +1,6 @@
 import frappe
 
-from suite.drive.utils import STATUS_TRASHED, create_drive_file, get_home_folder
+from suite.drive.utils import STATUS_TRASHED, create_drive_file, get_home_folder, get_new_file_name
 
 
 def execute():
@@ -31,10 +31,14 @@ def execute():
 				)
 				continue
 
+			home = get_home_folder(team).name
 			file = create_drive_file(
 				team,
-				sheet.title or "Untitled Spreadsheet",
-				get_home_folder(team).name,
+				# Dedupe within the home folder so backfilling many like-titled
+				# sheets (e.g. several "Untitled Spreadsheet") doesn't create
+				# ambiguous same-named Drive files.
+				get_new_file_name(sheet.title or "Untitled Spreadsheet", home, "Spreadsheet"),
+				home,
 				"Spreadsheet",
 				None,
 				mime_type="frappe/sheet",

--- a/suite/sheets/patches/integrate_with_drive.py
+++ b/suite/sheets/patches/integrate_with_drive.py
@@ -1,0 +1,49 @@
+import frappe
+
+from suite.drive.utils import STATUS_TRASHED, create_drive_file, get_home_folder
+
+
+def execute():
+	"""Back existing sheets with Drive Files so they show up in Drive, the same
+	way sheets created after this change are auto-backed in Sheet.after_insert.
+
+	Only existence/listing is mirrored — sharing stays on the sheet's own
+	DocShare model. Idempotent: sheets that already have a backing File are
+	skipped, so a re-run (or a sheet created between deploy and patch) is safe.
+	"""
+	frappe.flags.mute_drive_activity_log = True
+	try:
+		sheets = frappe.get_all("Sheet", fields=["name", "title", "owner", "trashed"])
+		for sheet in sheets:
+			if frappe.db.get_value(
+				"File", {"content_doctype": "Sheet", "content_docname": sheet.name}, "name"
+			):
+				continue
+
+			team = frappe.db.get_value("Drive Team", {"owner": sheet.owner, "personal": 1}, "name")
+			if not team:
+				frappe.log_error(
+					title="Sheet left unbacked by Drive File",
+					message=(
+						f"Sheet {sheet.name} (owner {sheet.owner}) has no personal Drive Team, "
+						f"so no Drive File was created; it won't appear in Drive until re-saved."
+					),
+				)
+				continue
+
+			file = create_drive_file(
+				team,
+				sheet.title or "Untitled Spreadsheet",
+				get_home_folder(team).name,
+				"Spreadsheet",
+				None,
+				mime_type="frappe/sheet",
+				content_doctype="Sheet",
+				content_docname=sheet.name,
+				owner=sheet.owner,
+			)
+			# A trashed sheet's File must land in the trash too, not the listing.
+			if sheet.trashed:
+				frappe.db.set_value("File", file.name, "status", STATUS_TRASHED, update_modified=False)
+	finally:
+		frappe.flags.mute_drive_activity_log = False

--- a/suite/sheets/versioning/save.py
+++ b/suite/sheets/versioning/save.py
@@ -48,11 +48,16 @@ def save_sheet(
 	sheets_data: str,
 	name: str | None = None,
 	ops: list | str | None = None,
+	parent: str | None = None,
 ) -> dict:
 	"""Create or update a sheet.
 
 	Returns ``{"name": <sheet_id>, "head_seq": <int>}`` so the client
 	knows where its ops landed in the canonical order.
+
+	``parent`` is only honoured on creation (``name`` is falsy): it is the
+	Drive folder the new sheet's backing File should land in, passed through
+	to ``Sheet.after_insert``.
 	"""
 	plain = _validate_payload(sheets_data)
 	clean_title = _clean_title(title)
@@ -63,7 +68,7 @@ def save_sheet(
 	if name:
 		sheet_id, head_seq = _update_existing(name, clean_title, encoded, byte_size, ops_list)
 	else:
-		sheet_id, head_seq = _insert_new(clean_title, encoded, byte_size, ops_list)
+		sheet_id, head_seq = _insert_new(clean_title, encoded, byte_size, ops_list, parent=parent)
 
 	# Snapshot inline — no worker dependency. A failure here must NOT fail
 	# the save; the ops are already persisted (no data loss) and the next
@@ -79,12 +84,16 @@ def save_sheet(
 
 
 def _insert_new(
-	title: str, encoded: str, byte_size: int, ops_list: list[dict]
+	title: str, encoded: str, byte_size: int, ops_list: list[dict], parent: str | None = None
 ) -> tuple[str, int]:
 	doc = frappe.new_doc("Sheet")
 	doc.title = title
 	doc.sheets_data = encoded
 	doc.head_seq = 0
+	# Drive folder for the backing File, read in Sheet.after_insert. Set as a
+	# flag (not a field) so it never persists on the Sheet row itself.
+	if parent:
+		doc.flags.drive_parent = parent
 	doc.insert()
 	head_seq = _append_ops_and_save(doc.name, ops_list, byte_size, save_op_type="create")
 	frappe.db.set_value("Sheet", doc.name, "head_seq", head_seq, update_modified=False)
@@ -95,6 +104,9 @@ def _update_existing(
 	name: str, title: str, encoded: str, byte_size: int, ops_list: list[dict]
 ) -> tuple[str, int]:
 	frappe.has_permission("Sheet", doc=name, ptype="write", throw=True)
+	# Cheap PK read so the (un-indexed) Drive-file title sync below only runs on
+	# an actual rename, not on every autosave.
+	old_title = frappe.db.get_value("Sheet", name, "title")
 	head_seq = _append_ops_and_save(name, ops_list, byte_size, save_op_type="save")
 	frappe.db.set_value(
 		"Sheet",
@@ -102,6 +114,12 @@ def _update_existing(
 		{"title": title, "sheets_data": encoded, "head_seq": head_seq},
 		update_modified=True,
 	)
+	# The editor renames a sheet through the autosave (db.set_value skips the
+	# on_update doc-event), so keep the backing Drive File's name in step here.
+	if title != old_title:
+		from suite.drive.overrides.file import sync_content_file_title
+
+		sync_content_file_title("Sheet", name, title)
 	return name, head_seq
 
 


### PR DESCRIPTION
## Why

Sheets is currently a fully parallel app: a `Sheet` has no Drive presence, so it never shows up in — or opens from — Drive, and Drive's **New** menu has no way to create one. This makes Sheet a first-class **Drive content-app**, using the same `content_doctype` / `content_docname` mechanism Writer and Slides already use.

## What

**Backend**
- `Sheet.after_insert` backs every sheet with a Drive `File` (mime `frappe/sheet`, file_type `Spreadsheet`) via `File.create_for_doc`. A new `create_sheet(parent)` endpoint lets Drive create one directly in the folder the user is looking at. `title_field` is set on the doctype so the File inherits the sheet's title rather than its hash name.
- **Lifecycle sync** so the backing File never dangles:
  - rename (`rename_sheet`) **and** in-editor rename (autosave writes the title via `db.set_value`, which skips `on_update`) keep the File's name in step through `sync_content_file_title` — deduped within the folder, so a duplicate title **renames to `Title (1)` instead of throwing**.
  - soft-trash / restore flip the File's status (`set_content_file_trashed`);
  - hard-delete removes it via the existing `on_trash` doc-event.
- `integrate_with_drive` patch backs **existing** sheets (idempotent).
- Two small additions to the content-app SDK in `drive/overrides/file.py` (`sync_content_file_title`, `set_content_file_trashed`) that any status-trash / db.set_value-titled content app can reuse.

**Frontend**
- **New › Spreadsheet** (gated on the sheets app), plus open + share-link routing to `/sheets/<id>` (keyed on `content_doctype === 'Sheet'`, since `file_type: 'Spreadsheet'` is shared with uploaded `.xlsx`).
- Native sheets render the **Frappe Sheets brand logo** in Drive rows/grid/search, distinct from uploaded `.xlsx/.csv` which keep the generic spreadsheet icon.

## Deliberate scope (follow-ups)

- **Sharing stays on the sheet's own model** for now — the Drive File is a listing/opening pointer, not the permission source. Unifying Sheets onto Drive permissions needs a share-migration and is intentionally out of this PR.
- Drive → Sheet trash is one-way (trashing the *sheet* trashes its File; trashing the File from Drive doesn't trash the sheet).

## Verification

Driven end-to-end on a local suite bench (develop tip):
- New › Spreadsheet creates + opens the editor; the sheet appears in Drive Home with the brand logo and a correct `/sheets/<id>` link; clicking it reopens the editor. 0 console errors.
- rename (editor-save + `rename_sheet`), duplicate-title **dedupe** (`Title (1)`, no throw), soft-trash → File `Trashed`, restore → `Active`, backfill patch (idempotent) — all confirmed against the DB.
- All Sheets tests green (list/permissions/api-security/collab/retention/boot/www/share-notify); Slides `test_presentation` + `test_file` and Drive storage tests green (content-app SDK unaffected).