### PR TITLE
fix(mail): run invite account creation as Administrator

### DIFF
--- a/suite/mail/api/account.py
+++ b/suite/mail/api/account.py
@@ -118,7 +118,11 @@ def create_account(request_key: str, first_name: str, last_name: str, password: 
 	account_request.save(ignore_permissions=True)
 
 	if account_request.account:
-		account_request.create_account(first_name, last_name, password)
+		# Account setup (JMAP account sync, archive mailbox, sieve) resolves ownership
+		# against the session user, which is Guest on this endpoint — run it elevated,
+		# same as signup().
+		with user_context("Administrator"):
+			account_request.create_account(first_name, last_name, password)
 
 
 @frappe.whitelist(allow_guest=True)


### PR DESCRIPTION
`create_account` (the invite/request-key endpoint) runs as Guest, but the setup it triggers — `sync_jmap_accounts` → archive mailbox / automation sieve — resolves ownership from the session user via `get_user_for_jmap_account`, so it threw **JMAP account does not belong to the user Guest** and rolled the transaction back. The Stalwart principal and app password survive the rollback, so every retry then failed with `primaryKeyViolation` on the email.

Wrap the call in `user_context("Administrator")`, matching what `signup()` already does. The elevation grants nothing the caller controls: access is still gated by the emailed 32-char request key, and the address/domain/roles all come from the stored Mail Account Request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)