### PR TITLE
fix(sheets): keep link hover card opaque on browsers without color-mix()

### DIFF
--- a/frontend/src/apps/sheets/components/SheetEditor/LinkPreviewCard.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/LinkPreviewCard.vue
@@ -133,6 +133,16 @@ const style = computed(() => {
 	transform-origin: top left;
 	animation: sn-lp-rise 120ms ease-out;
 }
+/* Opaque-fill fallback. The bg-surface-white utility compiles to a color-mix()
+   value, which browsers without color-mix() support (pre Chrome 111 / Safari
+   16.2 / Firefox 113) discard as invalid — leaving the card transparent so the
+   canvas cell text shows through. Where color-mix is unsupported, paint the
+   fill from the plain design token instead (equals #fff / dark #0f0f0f). */
+@supports not (background-color: color-mix(in srgb, red, blue)) {
+	.sn-lp-card {
+		background-color: var(--surface-white, #fff);
+	}
+}
 @keyframes sn-lp-rise {
 	from { transform: translateY(-4px) scale(0.98); opacity: 0; }
 	to   { transform: translateY(0)    scale(1);    opacity: 1; }


### PR DESCRIPTION
### Problem

The link preview hover card (shown when hovering a cell that contains a hyperlink) can render **transparent** on some browsers, so the spreadsheet's cell text bleeds straight through the card and the whole thing becomes unreadable. The card's drop-shadow still draws, so it looks like a floating shadow with no body.

<!-- reported from a production sheet full of mailto: links -->

### Root cause

The card's white fill comes solely from the `bg-surface-white` utility on the root element. Tailwind compiles that token to a `color-mix()` value:

```css
background-color: color-mix(in srgb, var(--surface-white,#fff) …, transparent)
```

`color-mix()` only shipped in **Chrome 111 / Safari 16.2 / Firefox 113** (early 2023). On any older browser or embedded webview, that `background-color` declaration is **invalid and silently dropped** — there's no `@supports` fallback — so the card has no fill. The `shadow-2xl` on the same element compiles to plain hex colors, so the shadow keeps rendering, which is why the card looks like an empty outline. The sheet grid behind it is painted on a `<canvas>` with an opaque fill, so its text reads clearly through the see-through card.

### Fix

Add an `@supports` fallback that paints the fill from the plain `--surface-white` design token where `color-mix()` is unavailable:

```css
@supports not (background-color: color-mix(in srgb, red, blue)) {
	.sn-lp-card { background-color: var(--surface-white, #fff); }
}
```

- **Modern browsers:** the block is inert — no change, the frappe-ui token/dark-mode behavior is untouched.
- **Older browsers:** the card gets a solid fill (`#fff`, or `#0f0f0f` in dark mode via the same token).

Scoped to the one component; no template or logic changes.