### PR TITLE
fix(drive): resumable downloads + async folder-zip build

### DIFF
--- a/frontend/src/apps/drive/utils/download.js
+++ b/frontend/src/apps/drive/utils/download.js
@@ -1,9 +1,17 @@
-// Folder / multi-file downloads are streamed as a zip by the backend
-// (drive.api.files.download_folder). Single files stream directly. Nothing is
-// buffered in browser memory, so large folders no longer hang the tab.
+// Downloads are served by storage (S3 presigned URL / nginx / disk) with HTTP
+// Range support, so the browser resumes on flaky connections instead of
+// restarting, and no server worker is held open for the transfer.
+//
+// Single files stream directly. Folders / multi-selections are built into a zip
+// by a background job (suite.drive.api.files.download_folder); we poll for it
+// and then download the finished archive — so a large folder can never time out
+// midway into a corrupt half-zip.
+
+import { call } from 'frappe-ui'
+import { toast } from '@/apps/drive/utils/toasts.js'
 
 export function entitiesDownload(entities, transfer = false) {
-  // Single file → stream directly (supports transfer links).
+  // Single file → resumable direct download (supports transfer links).
   if (entities.length === 1 && !entities[0].is_folder) {
     window.location.href = `/api/method/suite.drive.api.files.get_file_content?entity_name=${
       entities[0].name
@@ -11,9 +19,40 @@ export function entitiesDownload(entities, transfer = false) {
     return
   }
 
-  // A folder, or a multi-selection → let the server build and stream the zip.
+  prepareArchive(entities)
+}
+
+async function prepareArchive(entities) {
   const names = JSON.stringify(entities.map((entity) => entity.name))
-  window.location.href = `/api/method/suite.drive.api.files.download_folder?entities=${encodeURIComponent(
-    names
-  )}`
+  try {
+    const { token } = await call('suite.drive.api.files.download_folder', { entities: names })
+    toast('Preparing download…')
+    const result = await pollArchive(token)
+    if (result.status !== 'ready') {
+      toast({ title: result.error || 'Could not prepare this download', type: 'error' })
+      return
+    }
+    window.location.href = `/api/method/suite.drive.api.files.download_archive?token=${encodeURIComponent(
+      token
+    )}`
+  } catch (error) {
+    toast({ title: error?.message || 'Download failed', type: 'error' })
+  }
+}
+
+function pollArchive(token, { interval = 2000, timeout = 30 * 60 * 1000 } = {}) {
+  const start = Date.now()
+  return new Promise((resolve, reject) => {
+    const tick = async () => {
+      try {
+        const res = await call('suite.drive.api.files.download_status', { token })
+        if (res.status === 'ready' || res.status === 'failed') return resolve(res)
+        if (Date.now() - start > timeout) return reject(new Error('Timed out preparing download'))
+        setTimeout(tick, interval)
+      } catch (error) {
+        reject(error)
+      }
+    }
+    tick()
+  })
 }

--- a/frontend/src/apps/drive/utils/download.js
+++ b/frontend/src/apps/drive/utils/download.js
@@ -1,17 +1,10 @@
-// Downloads are served by storage (S3 presigned URL / nginx / disk) with HTTP
-// Range support, so the browser resumes on flaky connections instead of
-// restarting, and no server worker is held open for the transfer.
-//
-// Single files stream directly. Folders / multi-selections are built into a zip
-// by a background job (suite.drive.api.files.download_folder); we poll for it
-// and then download the finished archive — so a large folder can never time out
-// midway into a corrupt half-zip.
+// Folders build into a zip via a background job, then download; single files
+// download directly. Both are served range/resume-capable off storage.
 
 import { call } from 'frappe-ui'
 import { toast } from '@/apps/drive/utils/toasts.js'
 
 export function entitiesDownload(entities, transfer = false) {
-  // Single file → resumable direct download (supports transfer links).
   if (entities.length === 1 && !entities[0].is_folder) {
     window.location.href = `/api/method/suite.drive.api.files.get_file_content?entity_name=${
       entities[0].name

--- a/frontend/src/apps/drive/utils/download.js
+++ b/frontend/src/apps/drive/utils/download.js
@@ -33,7 +33,9 @@ async function prepareArchive(entities) {
   }
 }
 
-function pollArchive(token, { interval = 2000, timeout = 30 * 60 * 1000 } = {}) {
+// timeout must outlast the job's 1h timeout, or we give up on builds that
+// would still succeed
+function pollArchive(token, { interval = 2000, timeout = 70 * 60 * 1000 } = {}) {
   const start = Date.now()
   return new Promise((resolve, reject) => {
     const tick = async () => {

--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import os
 import re
@@ -6,9 +7,11 @@ import tempfile
 import zipfile
 from io import BytesIO
 from pathlib import Path
+from urllib.parse import quote
 
 import frappe
 import mimemapper
+from frappe.rate_limiter import rate_limit
 from pypika import Order
 from werkzeug.utils import secure_filename, send_file
 from werkzeug.wrappers import Response
@@ -29,7 +32,13 @@ from suite.drive.utils import (
 	validate_filename,
 )
 from suite.drive.utils.api import prettify_file
-from suite.drive.utils.files import FileManager, get_s3_key, get_s3_url, storage_key
+from suite.drive.utils.files import (
+	FileManager,
+	content_disposition,
+	get_s3_key,
+	get_s3_url,
+	storage_key,
+)
 from suite.drive.utils.users import mark_as_viewed
 
 from .permissions import get_teams, user_has_permission
@@ -324,8 +333,9 @@ def _serve_resumable(manager, key, team, download_name, mime_type=None):
 	xaccel_prefix = frappe.conf.get("drive_xaccel_prefix")
 	if xaccel_prefix:
 		response = Response(status=200)
-		response.headers["X-Accel-Redirect"] = f"{xaccel_prefix.rstrip('/')}/{key}"
-		response.headers["Content-Disposition"] = f'attachment; filename="{secure_filename(download_name)}"'
+		# header values must be latin-1 and nginx expects an encoded URI
+		response.headers["X-Accel-Redirect"] = f"{xaccel_prefix.rstrip('/')}/{quote(key)}"
+		response.headers["Content-Disposition"] = content_disposition(download_name)
 		if mime_type:
 			response.headers["Content-Type"] = mime_type
 		return response
@@ -459,6 +469,9 @@ def _collect_download_files(entity_names):
 
 
 DOWNLOAD_TTL = 60 * 60  # finished archives live for an hour
+# a build's cache entry must outlive queue wait + the job timeout, or polls 404
+# on a still-running build
+BUILDING_TTL = 3 * 60 * 60
 ARCHIVE_DIR = "private/files/.drive-downloads"
 
 
@@ -528,6 +541,7 @@ def build_download_archive(token, entities, zip_name, user):
 
 
 @frappe.whitelist(allow_guest=True)
+@rate_limit(limit=10, seconds=10 * 60)
 def download_folder(entities: str):
 	"""Enqueue a zip build and return a token; client polls download_status then
 	fetches download_archive. Avoids timing out large folders into a corrupt zip.
@@ -544,16 +558,32 @@ def download_folder(entities: str):
 	if not files:
 		frappe.throw("No downloadable files found", frappe.NotFound)
 
+	cache = frappe.cache()
+	user = frappe.session.user
+
+	# same selection already building or built → hand back that token instead of
+	# burning another job + artifact
+	selection_key = (
+		f"drive-download-sel:{user}:{hashlib.sha1(json.dumps(sorted(entities)).encode()).hexdigest()}"
+	)
+	existing = cache.get_value(selection_key)
+	if existing:
+		entry = cache.get_value(_download_cache_key(existing))
+		if entry and entry.get("status") in ("building", "ready"):
+			return {"token": existing, "file_name": entry["file_name"]}
+
 	if len(entities) == 1:
 		zip_name = f"{frappe.get_value('File', entities[0], 'file_name')}.zip"
 	else:
 		zip_name = f"Drive Download {frappe.utils.now()}.zip"
 
 	token = secrets.token_urlsafe(24)
-	user = frappe.session.user
-	frappe.cache().set_value(
-		_download_cache_key(token), {"status": "building", "owner": user}, expires_in_sec=DOWNLOAD_TTL
+	cache.set_value(
+		_download_cache_key(token),
+		{"status": "building", "owner": user, "file_name": zip_name},
+		expires_in_sec=BUILDING_TTL,
 	)
+	cache.set_value(selection_key, token, expires_in_sec=BUILDING_TTL)
 	frappe.enqueue(
 		build_download_archive,
 		queue="long",
@@ -586,7 +616,9 @@ def download_archive(token: str):
 	entry = _get_download_entry(token)
 	if entry.get("status") != "ready":
 		frappe.throw("Not found", frappe.DoesNotExistError)
-	return _serve_resumable(FileManager(), entry["key"], entry.get("team"), entry["file_name"], "application/zip")
+	return _serve_resumable(
+		FileManager(), entry["key"], entry.get("team"), entry["file_name"], "application/zip"
+	)
 
 
 @frappe.whitelist()

--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -312,14 +312,9 @@ def get_file_content(entity_name: str, trigger_download: bool = False, token: st
 
 
 def _serve_resumable(manager, key, team, download_name, mime_type=None):
-	"""Hand the client a Range/resume-capable download that streams from storage
-	instead of through this worker. A dropped connection (flaky link) resumes
-	from where it stopped rather than restarting, and no worker is tied up for
-	the length of the transfer.
+	"""Range/resume-capable download served by storage, not this worker.
 
-	- S3: redirect to a short-lived presigned URL; S3 serves the bytes.
-	- Disk + nginx: X-Accel-Redirect to an internal location; nginx serves them.
-	- Disk otherwise: send_file streams off disk with conditional Range support.
+	S3 → presigned URL; disk+nginx → X-Accel-Redirect; disk → send_file.
 	"""
 	if manager.s3_enabled:
 		frappe.local.response["type"] = "redirect"
@@ -335,7 +330,7 @@ def _serve_resumable(manager, key, team, download_name, mime_type=None):
 			response.headers["Content-Type"] = mime_type
 		return response
 
-	return send_file(
+	response = send_file(
 		str(manager.site_folder / key),
 		mimetype=mime_type or "application/octet-stream",
 		as_attachment=True,
@@ -344,6 +339,9 @@ def _serve_resumable(manager, key, team, download_name, mime_type=None):
 		max_age=0,
 		environ=frappe.request.environ,
 	)
+	# advertise ranges on the 200 too, so browsers resume rather than restart
+	response.headers["Accept-Ranges"] = "bytes"
+	return response
 
 
 def get_file_internal(file, trigger_download=0):
@@ -469,9 +467,7 @@ def _download_cache_key(token):
 
 
 def _build_zip(manager, files, fileobj):
-	"""Write a ZIP_STORED archive of `files` to a seekable file object. Files are
-	streamed block by block so a worker never holds a whole file in memory, and
-	because `fileobj` is seekable zipfile always writes a valid central directory."""
+	"""Write a ZIP_STORED archive to a seekable file, streaming each file in."""
 	with zipfile.ZipFile(fileobj, "w", zipfile.ZIP_STORED, allowZip64=True) as zf:
 		for arcname, child in files:
 			info = zipfile.ZipInfo(arcname)
@@ -482,11 +478,8 @@ def _build_zip(manager, files, fileobj):
 
 
 def _write_archive(token, files):
-	"""Build the zip artifact into storage and return (storage_key, team, size).
-
-	On disk the archive is written straight into the site's private files. On S3
-	it is built to a local temp file first, then uploaded, so peak disk use is
-	bounded by one archive and nothing is streamed to S3 half-formed."""
+	"""Build the zip into storage; return (storage_key, team, size). S3 builds to
+	a temp file then uploads so nothing lands half-formed."""
 	manager = FileManager()
 	key = f"{ARCHIVE_DIR}/{token}.zip"
 	team = files[0][1].team
@@ -511,8 +504,7 @@ def _write_archive(token, files):
 
 
 def build_download_archive(token, entities, zip_name, user):
-	"""Background job: resolve the selection under the requesting user's
-	permissions, build the archive, and publish the result in the cache."""
+	"""Background job: build the archive as `user` and publish its state to cache."""
 	cache = frappe.cache()
 	cache_key = _download_cache_key(token)
 	frappe.set_user(user)
@@ -537,11 +529,8 @@ def build_download_archive(token, entities, zip_name, user):
 
 @frappe.whitelist(allow_guest=True)
 def download_folder(entities: str):
-	"""Kick off a background build of a ZIP for one or more entities and return a
-	capability token. The client polls `download_status` and then fetches the
-	finished archive from `download_archive` — a Range/resume-capable, infra-served
-	download that never holds a worker open for the whole (potentially multi-GB)
-	transfer, so large folders no longer time out into a corrupt half-zip.
+	"""Enqueue a zip build and return a token; client polls download_status then
+	fetches download_archive. Avoids timing out large folders into a corrupt zip.
 
 	:param entities: JSON list of File names (the user's selection)
 	"""
@@ -550,8 +539,7 @@ def download_folder(entities: str):
 	if not entities:
 		frappe.throw("Nothing to download", ValueError)
 
-	# Resolve once up front so a permission error surfaces immediately instead of
-	# failing inside the background job.
+	# resolve up front so a permission error surfaces here, not in the job
 	files = list(_collect_download_files(entities))
 	if not files:
 		frappe.throw("No downloadable files found", frappe.NotFound)

--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -1,5 +1,8 @@
 import json
+import os
 import re
+import secrets
+import tempfile
 import zipfile
 from io import BytesIO
 from pathlib import Path
@@ -292,6 +295,7 @@ def get_file_content(entity_name: str, trigger_download: bool = False, token: st
 			"status",
 			"file_url",
 			"team",
+			"mime_type",
 		],
 		as_dict=1,
 	)
@@ -307,14 +311,53 @@ def get_file_content(entity_name: str, trigger_download: bool = False, token: st
 	return get_file_internal(file, trigger_download)
 
 
+def _serve_resumable(manager, key, team, download_name, mime_type=None):
+	"""Hand the client a Range/resume-capable download that streams from storage
+	instead of through this worker. A dropped connection (flaky link) resumes
+	from where it stopped rather than restarting, and no worker is tied up for
+	the length of the transfer.
+
+	- S3: redirect to a short-lived presigned URL; S3 serves the bytes.
+	- Disk + nginx: X-Accel-Redirect to an internal location; nginx serves them.
+	- Disk otherwise: send_file streams off disk with conditional Range support.
+	"""
+	if manager.s3_enabled:
+		frappe.local.response["type"] = "redirect"
+		frappe.local.response["location"] = manager.presigned_url(team, key, download_name, mime_type)
+		return
+
+	xaccel_prefix = frappe.conf.get("drive_xaccel_prefix")
+	if xaccel_prefix:
+		response = Response(status=200)
+		response.headers["X-Accel-Redirect"] = f"{xaccel_prefix.rstrip('/')}/{key}"
+		response.headers["Content-Disposition"] = f'attachment; filename="{secure_filename(download_name)}"'
+		if mime_type:
+			response.headers["Content-Type"] = mime_type
+		return response
+
+	return send_file(
+		str(manager.site_folder / key),
+		mimetype=mime_type or "application/octet-stream",
+		as_attachment=True,
+		download_name=download_name,
+		conditional=True,
+		max_age=0,
+		environ=frappe.request.environ,
+	)
+
+
 def get_file_internal(file, trigger_download=0):
 	if not trigger_download and file.file_type == "Video" and frappe.request.headers.get("Range"):
 		return stream_file_content(file.name)
 
 	manager = FileManager()
+	if trigger_download:
+		return _serve_resumable(
+			manager, storage_key(file.file_url), file.team, file.file_name, file.get("mime_type")
+		)
 	return send_file(
 		manager.get_file(file),
-		as_attachment=trigger_download,
+		as_attachment=False,
 		conditional=True,
 		max_age=3600,
 		download_name=file.file_name,
@@ -376,27 +419,6 @@ def stream_file_content(entity_name: str):
 	return res
 
 
-class _ZipSink:
-	"""A non-seekable sink for `zipfile`. Because it exposes no `seek`/`tell`,
-	zipfile falls back to streaming-friendly data descriptors, letting us yield
-	archive bytes as they're produced instead of buffering the whole zip."""
-
-	def __init__(self):
-		self._chunks = bytearray()
-
-	def write(self, data):
-		self._chunks += data
-		return len(data)
-
-	def flush(self):
-		pass
-
-	def drain(self):
-		chunk = bytes(self._chunks)
-		del self._chunks[:]
-		return chunk
-
-
 def _iter_folder_files(entity_name, prefix=""):
 	"""Recursively yield (arcname, file) for downloadable files in a folder.
 
@@ -438,42 +460,88 @@ def _collect_download_files(entity_names):
 			yield entity.file_name, entity
 
 
-def _stream_zip(files):
-	"""Generator that yields a ZIP archive built one file at a time, so memory
-	stays flat regardless of the total size."""
-	manager = FileManager()
-	sink = _ZipSink()
-	with zipfile.ZipFile(sink, "w", zipfile.ZIP_STORED, allowZip64=True) as zf:
+DOWNLOAD_TTL = 60 * 60  # finished archives live for an hour
+ARCHIVE_DIR = "private/files/.drive-downloads"
+
+
+def _download_cache_key(token):
+	return f"drive-download:{token}"
+
+
+def _build_zip(manager, files, fileobj):
+	"""Write a ZIP_STORED archive of `files` to a seekable file object. Files are
+	streamed block by block so a worker never holds a whole file in memory, and
+	because `fileobj` is seekable zipfile always writes a valid central directory."""
+	with zipfile.ZipFile(fileobj, "w", zipfile.ZIP_STORED, allowZip64=True) as zf:
 		for arcname, child in files:
 			info = zipfile.ZipInfo(arcname)
 			info.compress_type = zipfile.ZIP_STORED
 			with zf.open(info, "w") as dest:
-				source = manager.get_file(child)
-				try:
-					while True:
-						block = source.read(4 * 1024 * 1024)
-						if not block:
-							break
-						dest.write(block)
-						data = sink.drain()
-						if data:
-							yield data
-				finally:
-					if hasattr(source, "close"):
-						source.close()
-			data = sink.drain()
-			if data:
-				yield data
-	yield sink.drain()
+				for block in manager.iter_blocks(child):
+					dest.write(block)
+
+
+def _write_archive(token, files):
+	"""Build the zip artifact into storage and return (storage_key, team, size).
+
+	On disk the archive is written straight into the site's private files. On S3
+	it is built to a local temp file first, then uploaded, so peak disk use is
+	bounded by one archive and nothing is streamed to S3 half-formed."""
+	manager = FileManager()
+	key = f"{ARCHIVE_DIR}/{token}.zip"
+	team = files[0][1].team
+	if manager.s3_enabled:
+		with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+			tmp_path = tmp.name
+		try:
+			with open(tmp_path, "wb") as fh:
+				_build_zip(manager, files, fh)
+			size = os.path.getsize(tmp_path)
+			s3_key = f".drive-downloads/{token}.zip"
+			manager.conn.upload_file(tmp_path, manager.get_bucket(team), s3_key)
+			return s3_key, team, size
+		finally:
+			os.remove(tmp_path)
+	else:
+		target = manager.site_folder / key
+		target.parent.mkdir(parents=True, exist_ok=True)
+		with open(target, "wb") as fh:
+			_build_zip(manager, files, fh)
+		return key, team, os.path.getsize(target)
+
+
+def build_download_archive(token, entities, zip_name, user):
+	"""Background job: resolve the selection under the requesting user's
+	permissions, build the archive, and publish the result in the cache."""
+	cache = frappe.cache()
+	cache_key = _download_cache_key(token)
+	frappe.set_user(user)
+	try:
+		files = list(_collect_download_files(entities))
+		if not files:
+			raise frappe.NotFound("No downloadable files found")
+		key, team, size = _write_archive(token, files)
+		cache.set_value(
+			cache_key,
+			{"status": "ready", "owner": user, "key": key, "team": team, "file_name": zip_name, "size": size},
+			expires_in_sec=DOWNLOAD_TTL,
+		)
+	except Exception as e:
+		frappe.log_error("Drive: archive build failed", e)
+		cache.set_value(
+			cache_key,
+			{"status": "failed", "owner": user, "error": str(e)},
+			expires_in_sec=DOWNLOAD_TTL,
+		)
 
 
 @frappe.whitelist(allow_guest=True)
 def download_folder(entities: str):
-	"""Stream a ZIP of one or more Drive entities (folders and/or files).
-
-	Replaces the old client-side JSZip flow, which loaded every file into
-	browser memory and hung on large folders. Here the server streams the
-	archive a file at a time via chunked transfer.
+	"""Kick off a background build of a ZIP for one or more entities and return a
+	capability token. The client polls `download_status` and then fetches the
+	finished archive from `download_archive` — a Range/resume-capable, infra-served
+	download that never holds a worker open for the whole (potentially multi-GB)
+	transfer, so large folders no longer time out into a corrupt half-zip.
 
 	:param entities: JSON list of File names (the user's selection)
 	"""
@@ -482,21 +550,55 @@ def download_folder(entities: str):
 	if not entities:
 		frappe.throw("Nothing to download", ValueError)
 
-	# Materialise the file list up front so a permission error surfaces as a
-	# clean HTTP error instead of a corrupt, half-streamed zip.
+	# Resolve once up front so a permission error surfaces immediately instead of
+	# failing inside the background job.
 	files = list(_collect_download_files(entities))
 	if not files:
 		frappe.throw("No downloadable files found", frappe.NotFound)
 
 	if len(entities) == 1:
-		title = frappe.get_value("File", entities[0], "file_name")
-		zip_name = f"{title}.zip"
+		zip_name = f"{frappe.get_value('File', entities[0], 'file_name')}.zip"
 	else:
 		zip_name = f"Drive Download {frappe.utils.now()}.zip"
 
-	response = Response(_stream_zip(files), mimetype="application/zip", direct_passthrough=True)
-	response.headers["Content-Disposition"] = f'attachment; filename="{secure_filename(zip_name)}"'
-	return response
+	token = secrets.token_urlsafe(24)
+	user = frappe.session.user
+	frappe.cache().set_value(
+		_download_cache_key(token), {"status": "building", "owner": user}, expires_in_sec=DOWNLOAD_TTL
+	)
+	frappe.enqueue(
+		build_download_archive,
+		queue="long",
+		timeout=3600,
+		token=token,
+		entities=entities,
+		zip_name=zip_name,
+		user=user,
+	)
+	return {"token": token, "file_name": zip_name}
+
+
+def _get_download_entry(token):
+	entry = frappe.cache().get_value(_download_cache_key(token))
+	if not entry or entry.get("owner") != frappe.session.user:
+		frappe.throw("Not found", frappe.DoesNotExistError)
+	return entry
+
+
+@frappe.whitelist(allow_guest=True)
+def download_status(token: str):
+	"""Poll the state of an archive build: building | ready | failed."""
+	entry = _get_download_entry(token)
+	return {"status": entry["status"], "error": entry.get("error"), "size": entry.get("size")}
+
+
+@frappe.whitelist(allow_guest=True)
+def download_archive(token: str):
+	"""Serve a finished archive as a Range/resume-capable download."""
+	entry = _get_download_entry(token)
+	if entry.get("status") != "ready":
+		frappe.throw("Not found", frappe.DoesNotExistError)
+	return _serve_resumable(FileManager(), entry["key"], entry.get("team"), entry["file_name"], "application/zip")
 
 
 @frappe.whitelist()

--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -585,7 +585,7 @@ def download_folder(entities: str):
 	)
 	cache.set_value(selection_key, token, expires_in_sec=BUILDING_TTL)
 	frappe.enqueue(
-		build_download_archive,
+		"suite.drive.api.files.build_download_archive",
 		queue="long",
 		timeout=3600,
 		token=token,

--- a/suite/drive/api/scripts.py
+++ b/suite/drive/api/scripts.py
@@ -12,7 +12,7 @@ from suite.drive.utils import (
 )
 from suite.drive.utils.files import FileManager
 from suite.drive.api.files import delete_entities
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 
 @frappe.whitelist()
@@ -119,3 +119,30 @@ def clear_deleted_files():
     for entity in result:
         doc = frappe.get_doc("File", entity, ignore_permissions=True)
         doc.delete()
+
+
+def clear_download_archives():
+    """Sweep stale folder-download zip artifacts. Cache entries pointing at them
+    expire on their own; this reclaims the bytes on disk and in S3."""
+    import os
+    import time
+
+    from suite.drive.api.files import ARCHIVE_DIR, DOWNLOAD_TTL
+
+    cutoff = time.time() - DOWNLOAD_TTL
+    manager = FileManager()
+
+    local_dir = manager.site_folder / ARCHIVE_DIR
+    if local_dir.exists():
+        for path in local_dir.iterdir():
+            if path.is_file() and path.stat().st_mtime < cutoff:
+                path.unlink(missing_ok=True)
+
+    if manager.s3_enabled:
+        cutoff_dt = datetime.now(timezone.utc) - timedelta(seconds=DOWNLOAD_TTL)
+        buckets = {manager.get_bucket(t) for t in manager.bucket_map} | {manager.bucket}
+        for bucket in filter(None, buckets):
+            objects = manager.conn.list_objects_v2(Bucket=bucket, Prefix=".drive-downloads/").get("Contents", [])
+            stale = [{"Key": o["Key"]} for o in objects if o["LastModified"] < cutoff_dt]
+            if stale:
+                manager.conn.delete_objects(Bucket=bucket, Delete={"Objects": stale})

--- a/suite/drive/api/scripts.py
+++ b/suite/drive/api/scripts.py
@@ -122,8 +122,7 @@ def clear_deleted_files():
 
 
 def clear_download_archives():
-    """Sweep stale folder-download zip artifacts. Cache entries pointing at them
-    expire on their own; this reclaims the bytes on disk and in S3."""
+    """Sweep expired folder-download zip artifacts from disk and S3."""
     import os
     import time
 

--- a/suite/drive/utils/files.py
+++ b/suite/drive/utils/files.py
@@ -11,6 +11,7 @@ import mimemapper
 from botocore.config import Config
 from botocore.exceptions import ClientError
 from PIL import Image, ImageOps
+from werkzeug.utils import secure_filename
 
 from suite.drive.locks.distributed_lock import DistributedLock
 
@@ -203,6 +204,34 @@ class FileManager:
             frappe.throw("Could not find this file.", frappe.DoesNotExistError)
 
         return buf
+
+    def presigned_url(self, team, key, download_name, mime_type=None, expires=3600):
+        """A short-lived S3 GET URL that streams the object directly to the client
+        with Range/resume support, so no worker is held for the transfer."""
+        params = {
+            "Bucket": self.get_bucket(team),
+            "Key": key,
+            "ResponseContentDisposition": f'attachment; filename="{secure_filename(download_name)}"',
+        }
+        if mime_type:
+            params["ResponseContentType"] = mime_type
+        return self.conn.generate_presigned_url("get_object", Params=params, ExpiresIn=expires)
+
+    def iter_blocks(self, entity, block_size=4 * 1024 * 1024):
+        """Yield a file's bytes lazily, without ever holding the whole file in
+        memory. S3 objects come from the team-aware StreamingBody; disk files are
+        read straight off the filesystem."""
+        if self.s3_enabled:
+            source = self.get_file(entity)
+            try:
+                while chunk := source.read(block_size):
+                    yield chunk
+            finally:
+                source.close()
+        else:
+            with open(self.site_folder / storage_key(entity.file_url), "rb") as fh:
+                while chunk := fh.read(block_size):
+                    yield chunk
 
     def write_file(self, path: str | Path, content: str):
         if self.s3_enabled:

--- a/suite/drive/utils/files.py
+++ b/suite/drive/utils/files.py
@@ -206,8 +206,7 @@ class FileManager:
         return buf
 
     def presigned_url(self, team, key, download_name, mime_type=None, expires=3600):
-        """A short-lived S3 GET URL that streams the object directly to the client
-        with Range/resume support, so no worker is held for the transfer."""
+        """Short-lived S3 GET URL, range-capable, served straight to the client."""
         params = {
             "Bucket": self.get_bucket(team),
             "Key": key,
@@ -218,9 +217,7 @@ class FileManager:
         return self.conn.generate_presigned_url("get_object", Params=params, ExpiresIn=expires)
 
     def iter_blocks(self, entity, block_size=4 * 1024 * 1024):
-        """Yield a file's bytes lazily, without ever holding the whole file in
-        memory. S3 objects come from the team-aware StreamingBody; disk files are
-        read straight off the filesystem."""
+        """Yield a file's bytes lazily so a worker never holds the whole file."""
         if self.s3_enabled:
             source = self.get_file(entity)
             try:

--- a/suite/drive/utils/files.py
+++ b/suite/drive/utils/files.py
@@ -1,9 +1,10 @@
 import os
+import shutil
+import unicodedata
 from contextlib import contextmanager
 from io import BytesIO
 from pathlib import Path
-import shutil
-from urllib.parse import unquote
+from urllib.parse import quote, unquote
 
 import boto3
 import frappe
@@ -11,458 +12,477 @@ import mimemapper
 from botocore.config import Config
 from botocore.exceptions import ClientError
 from PIL import Image, ImageOps
-from werkzeug.utils import secure_filename
+from werkzeug.http import dump_options_header
 
 from suite.drive.locks.distributed_lock import DistributedLock
 
-from . import get_home_folder, STATUS_ACTIVE
+from . import STATUS_ACTIVE, get_home_folder
 
 S3_URL_PREFIX = "/api/method/suite.drive.api.s3.fetch?path="
 
 
 class FileManager:
-    def __init__(self):
-        settings = frappe.get_single("Drive Disk Settings")
-        self.settings = settings
-        self.s3_enabled = settings.enabled
-        self.flat = settings.flat
-        self.bucket = settings.bucket
-        self.site_folder = Path(frappe.get_site_path())
+	def __init__(self):
+		settings = frappe.get_single("Drive Disk Settings")
+		self.settings = settings
+		self.s3_enabled = settings.enabled
+		self.flat = settings.flat
+		self.bucket = settings.bucket
+		self.site_folder = Path(frappe.get_site_path())
 
-        TEAMS = frappe.get_all("Drive Team", fields=["name", "s3_bucket", "prefix"])
-        self.bucket_map = {k["name"]: k["s3_bucket"] for k in TEAMS}
-        self.prefix_map = {k["name"]: k["prefix"] for k in TEAMS}
+		TEAMS = frappe.get_all("Drive Team", fields=["name", "s3_bucket", "prefix"])
+		self.bucket_map = {k["name"]: k["s3_bucket"] for k in TEAMS}
+		self.prefix_map = {k["name"]: k["prefix"] for k in TEAMS}
 
-        if self.s3_enabled:
-            self.conn = boto3.client(
-                "s3",
-                aws_access_key_id=settings.aws_key,
-                aws_secret_access_key=settings.get_password("aws_secret"),
-                endpoint_url=(settings.endpoint_url or None),
-                config=Config(signature_version=settings.signature_version),
-            )
+		if self.s3_enabled:
+			self.conn = boto3.client(
+				"s3",
+				aws_access_key_id=settings.aws_key,
+				aws_secret_access_key=settings.get_password("aws_secret"),
+				endpoint_url=(settings.endpoint_url or None),
+				config=Config(signature_version=settings.signature_version),
+			)
 
-    def _not_if_flat(func):
-        """
-        Decorator to skip the function if flat structure is enabled.
-        """
+	def _not_if_flat(func):
+		"""
+		Decorator to skip the function if flat structure is enabled.
+		"""
 
-        def wrapper(self, *args, **kwargs):
-            if self.flat:
-                return
-            return func(self, *args, **kwargs)
+		def wrapper(self, *args, **kwargs):
+			if self.flat:
+				return
+			return func(self, *args, **kwargs)
 
-        return wrapper
+		return wrapper
 
-    def get_bucket(self, team):
-        return self.bucket_map.get(team) or self.bucket
+	def get_bucket(self, team):
+		return self.bucket_map.get(team) or self.bucket
 
-    def get_prefix(self, team):
-        prefix = self.prefix_map.get(team)
-        if prefix is None:
-            return self.settings.root_folder
-        return prefix
+	def get_prefix(self, team):
+		prefix = self.prefix_map.get(team)
+		if prefix is None:
+			return self.settings.root_folder
+		return prefix
 
-    def can_create_thumbnail(self, file):
-        # Only images, videos and PDFs get thumbnails.
-        if not hasattr(file, "mime_type"):
-            return False
-        return file.mime_type.startswith(("image", "video")) or file.mime_type == "application/pdf"
+	def can_create_thumbnail(self, file):
+		# Only images, videos and PDFs get thumbnails.
+		if not hasattr(file, "mime_type"):
+			return False
+		return file.mime_type.startswith(("image", "video")) or file.mime_type == "application/pdf"
 
-    def upload_file(self, current_path: Path, file, create_thumbnail=True) -> None:
-        """
-        Moves the file from the current path to another path
-        """
-        if self.s3_enabled:
-            self.conn.upload_file(current_path, self.get_bucket(file.team), get_s3_key(file.file_url))
-            if create_thumbnail and self.can_create_thumbnail(file):
-                frappe.enqueue(
-                    self.upload_thumbnail,
-                    now=True,
-                    at_front=True,
-                    file=file,
-                    file_path=str(current_path),
-                )
-            else:
-                os.remove(current_path)
-        else:
-            os.rename(current_path, self.site_folder / storage_key(file.file_url))
-            if file and create_thumbnail and self.can_create_thumbnail(file):
-                frappe.enqueue(
-                    self.upload_thumbnail,
-                    now=True,
-                    at_front=True,
-                    file=file,
-                    file_path=str(self.site_folder / storage_key(file.file_url)),
-                )
+	def upload_file(self, current_path: Path, file, create_thumbnail=True) -> None:
+		"""
+		Moves the file from the current path to another path
+		"""
+		if self.s3_enabled:
+			self.conn.upload_file(current_path, self.get_bucket(file.team), get_s3_key(file.file_url))
+			if create_thumbnail and self.can_create_thumbnail(file):
+				frappe.enqueue(
+					self.upload_thumbnail,
+					now=True,
+					at_front=True,
+					file=file,
+					file_path=str(current_path),
+				)
+			else:
+				os.remove(current_path)
+		else:
+			os.rename(current_path, self.site_folder / storage_key(file.file_url))
+			if file and create_thumbnail and self.can_create_thumbnail(file):
+				frappe.enqueue(
+					self.upload_thumbnail,
+					now=True,
+					at_front=True,
+					file=file,
+					file_path=str(self.site_folder / storage_key(file.file_url)),
+				)
 
-    def upload_thumbnail(self, file, file_path: str):
-        """
-        Creates a thumbnail for the file on disk and then uploads to the relevant team directory
-        """
-        save_path = self.get_thumbnail_path(file.team, file.name).with_suffix(".png")
-        disk_path = str(self.site_folder / save_path)
+	def upload_thumbnail(self, file, file_path: str):
+		"""
+		Creates a thumbnail for the file on disk and then uploads to the relevant team directory
+		"""
+		save_path = self.get_thumbnail_path(file.team, file.name).with_suffix(".png")
+		disk_path = str(self.site_folder / save_path)
 
-        try:
-            with DistributedLock(file_path, exclusive=False):
-                if file.mime_type.startswith("image"):
-                    with Image.open(file_path).convert("RGB") as image:
-                        image = ImageOps.exif_transpose(image)
-                        image.thumbnail((512, 512))
-                        image.save(disk_path, format="webp")
-                elif file.mime_type.startswith("video"):
-                    import av
+		try:
+			with DistributedLock(file_path, exclusive=False):
+				if file.mime_type.startswith("image"):
+					with Image.open(file_path).convert("RGB") as image:
+						image = ImageOps.exif_transpose(image)
+						image.thumbnail((512, 512))
+						image.save(disk_path, format="webp")
+				elif file.mime_type.startswith("video"):
+					import av
 
-                    with av.open(file_path) as container:
-                        stream = container.streams.video[0]
-                        if stream.duration:
-                            container.seek(stream.duration // 2, stream=stream)
-                        image = next(container.decode(stream)).to_image()
-                        image.thumbnail((512, 512))
-                        image.save(disk_path, format="webp")
-                else:
-                    import pymupdf
+					with av.open(file_path) as container:
+						stream = container.streams.video[0]
+						if stream.duration:
+							container.seek(stream.duration // 2, stream=stream)
+						image = next(container.decode(stream)).to_image()
+						image.thumbnail((512, 512))
+						image.save(disk_path, format="webp")
+				else:
+					import pymupdf
 
-                    with pymupdf.open(file_path) as pdf:
-                        page = pdf.load_page(0)
-                        zoom = 512 / max(page.rect.width, page.rect.height)
-                        pix = page.get_pixmap(matrix=pymupdf.Matrix(zoom, zoom))
-                        Image.frombytes("RGB", (pix.width, pix.height), pix.samples).save(
-                            disk_path, format="webp"
-                        )
+					with pymupdf.open(file_path) as pdf:
+						page = pdf.load_page(0)
+						zoom = 512 / max(page.rect.width, page.rect.height)
+						pix = page.get_pixmap(matrix=pymupdf.Matrix(zoom, zoom))
+						Image.frombytes("RGB", (pix.width, pix.height), pix.samples).save(
+							disk_path, format="webp"
+						)
 
-                disk_path = Path(disk_path)
-                if self.s3_enabled:
-                    # Removes original file
-                    os.remove(file_path)
-                    self.conn.upload_file(
-                        disk_path, self.get_bucket(file.team), str(save_path.with_suffix(".thumbnail"))
-                    )
-                    disk_path.unlink()
-                else:
-                    final_path = disk_path.with_suffix(".thumbnail")
-                    disk_path.rename(final_path)
-        except BaseException as e:
-            frappe.log_error("Thumbnail failed", e)
-            if self.s3_enabled:
-                try:
-                    os.remove(file_path)
-                except FileNotFoundError:
-                    pass
+				disk_path = Path(disk_path)
+				if self.s3_enabled:
+					# Removes original file
+					os.remove(file_path)
+					self.conn.upload_file(
+						disk_path, self.get_bucket(file.team), str(save_path.with_suffix(".thumbnail"))
+					)
+					disk_path.unlink()
+				else:
+					final_path = disk_path.with_suffix(".thumbnail")
+					disk_path.rename(final_path)
+		except BaseException as e:
+			frappe.log_error("Thumbnail failed", e)
+			if self.s3_enabled:
+				try:
+					os.remove(file_path)
+				except FileNotFoundError:
+					pass
 
-    def get_disk_path(self, entity, root: dict = None, embed=False):
-        """
-        Helper function to get path of a file
-        """
-        if self.flat:
-            if not root:
-                root = get_home_folder(entity.team)
-            return Path(storage_key(root["file_url"])) / (Path("embeds") / entity.name if embed else entity.name)
-        else:
-            # perf: stupidly complicated because we use this both with a real entity and a dict
-            parent = (
-                Path(storage_key(frappe.get_value("File", entity.folder, "file_url") or ""))
-                if not hasattr(entity, "parent_path")
-                else Path(entity.parent_path)
-            )
-            if embed:
-                return parent / ".embeds" / entity.file_name
-            return parent / entity.file_name
+	def get_disk_path(self, entity, root: dict | None = None, embed=False):
+		"""
+		Helper function to get path of a file
+		"""
+		if self.flat:
+			if not root:
+				root = get_home_folder(entity.team)
+			return Path(storage_key(root["file_url"])) / (
+				Path("embeds") / entity.name if embed else entity.name
+			)
+		else:
+			# perf: stupidly complicated because we use this both with a real entity and a dict
+			parent = (
+				Path(storage_key(frappe.get_value("File", entity.folder, "file_url") or ""))
+				if not hasattr(entity, "parent_path")
+				else Path(entity.parent_path)
+			)
+			if embed:
+				return parent / ".embeds" / entity.file_name
+			return parent / entity.file_name
 
-    @_not_if_flat
-    def create_folder(self, entity, root):
-        """
-        Function to create a folder in the S3 bucket or on disk.
-        Only creates if flat structure is disabled.
-        """
-        path = self.get_disk_path(entity, root)
-        if self.s3_enabled:
-            self.conn.put_object(Bucket=self.get_bucket(entity.team), Key=str(path) + "/", Body="")
-        else:
-            (self.site_folder / path).mkdir()
-        return str(path) + "/"
+	@_not_if_flat
+	def create_folder(self, entity, root):
+		"""
+		Function to create a folder in the S3 bucket or on disk.
+		Only creates if flat structure is disabled.
+		"""
+		path = self.get_disk_path(entity, root)
+		if self.s3_enabled:
+			self.conn.put_object(Bucket=self.get_bucket(entity.team), Key=str(path) + "/", Body="")
+		else:
+			(self.site_folder / path).mkdir()
+		return str(path) + "/"
 
-    def get_file(self, entity, range_header=None, log=True):
-        """
-        Function to get a file, with an optional range header for S3 objects
-        """
-        file_url = storage_key(entity.file_url)
-        try:
-            if self.s3_enabled:
-                if range_header:
-                    buf = self.conn.get_object(Bucket=self.get_bucket(entity.team), Key=file_url, Range=range_header)[
-                        "Body"
-                    ]
-                else:
-                    buf = self.conn.get_object(Bucket=self.get_bucket(entity.team), Key=file_url)["Body"]
-            else:
-                with open(self.site_folder / file_url, "rb") as fh:
-                    buf = BytesIO(fh.read())
-        except (ClientError, FileNotFoundError, OSError) as e:
-            if log:
-                frappe.log_error("Drive: could not read file", e)
-            frappe.throw("Could not find this file.", frappe.DoesNotExistError)
+	def get_file(self, entity, range_header=None, log=True):
+		"""
+		Function to get a file, with an optional range header for S3 objects
+		"""
+		file_url = storage_key(entity.file_url)
+		try:
+			if self.s3_enabled:
+				if range_header:
+					buf = self.conn.get_object(
+						Bucket=self.get_bucket(entity.team), Key=file_url, Range=range_header
+					)["Body"]
+				else:
+					buf = self.conn.get_object(Bucket=self.get_bucket(entity.team), Key=file_url)["Body"]
+			else:
+				with open(self.site_folder / file_url, "rb") as fh:
+					buf = BytesIO(fh.read())
+		except (ClientError, FileNotFoundError, OSError) as e:
+			if log:
+				frappe.log_error("Drive: could not read file", e)
+			frappe.throw("Could not find this file.", frappe.DoesNotExistError)
 
-        return buf
+		return buf
 
-    def presigned_url(self, team, key, download_name, mime_type=None, expires=3600):
-        """Short-lived S3 GET URL, range-capable, served straight to the client."""
-        params = {
-            "Bucket": self.get_bucket(team),
-            "Key": key,
-            "ResponseContentDisposition": f'attachment; filename="{secure_filename(download_name)}"',
-        }
-        if mime_type:
-            params["ResponseContentType"] = mime_type
-        return self.conn.generate_presigned_url("get_object", Params=params, ExpiresIn=expires)
+	def presigned_url(self, team, key, download_name, mime_type=None, expires=3600):
+		"""Short-lived S3 GET URL, range-capable, served straight to the client."""
+		params = {
+			"Bucket": self.get_bucket(team),
+			"Key": key,
+			"ResponseContentDisposition": content_disposition(download_name),
+		}
+		if mime_type:
+			params["ResponseContentType"] = mime_type
+		return self.conn.generate_presigned_url("get_object", Params=params, ExpiresIn=expires)
 
-    def iter_blocks(self, entity, block_size=4 * 1024 * 1024):
-        """Yield a file's bytes lazily so a worker never holds the whole file."""
-        if self.s3_enabled:
-            source = self.get_file(entity)
-            try:
-                while chunk := source.read(block_size):
-                    yield chunk
-            finally:
-                source.close()
-        else:
-            with open(self.site_folder / storage_key(entity.file_url), "rb") as fh:
-                while chunk := fh.read(block_size):
-                    yield chunk
+	def iter_blocks(self, entity, block_size=4 * 1024 * 1024):
+		"""Yield a file's bytes lazily so a worker never holds the whole file."""
+		if self.s3_enabled:
+			source = self.get_file(entity)
+			try:
+				while chunk := source.read(block_size):
+					yield chunk
+			finally:
+				source.close()
+		else:
+			with open(self.site_folder / storage_key(entity.file_url), "rb") as fh:
+				while chunk := fh.read(block_size):
+					yield chunk
 
-    def write_file(self, path: str | Path, content: str):
-        if self.s3_enabled:
-            pass
-        else:
-            with open(self.site_folder / path, "w") as f:
-                f.write(content)
+	def write_file(self, path: str | Path, content: str):
+		if self.s3_enabled:
+			pass
+		else:
+			with open(self.site_folder / path, "w") as f:
+				f.write(content)
 
-    @contextmanager
-    def open_file(self, path):
-        """
-        Context manager that yields a file-like object.
-        - On disk: opens in binary mode, closes automatically.
-        - On S3: yields the botocore StreamingBody, closes automatically.
-        """
-        if self.s3_enabled:
-            obj = self.conn.get_object(Bucket=self.bucket, Key=path)
-            body = obj["Body"]
-            try:
-                yield body  # StreamingBody is already a file-like object
-            finally:
-                body.close()
-        else:
-            f = open(self.site_folder / path, "rb")
-            try:
-                yield f
-            finally:
-                f.close()
+	@contextmanager
+	def open_file(self, path):
+		"""
+		Context manager that yields a file-like object.
+		- On disk: opens in binary mode, closes automatically.
+		- On S3: yields the botocore StreamingBody, closes automatically.
+		"""
+		if self.s3_enabled:
+			obj = self.conn.get_object(Bucket=self.bucket, Key=path)
+			body = obj["Body"]
+			try:
+				yield body  # StreamingBody is already a file-like object
+			finally:
+				body.close()
+		else:
+			f = open(self.site_folder / path, "rb")
+			try:
+				yield f
+			finally:
+				f.close()
 
-    def fetch_new_files(self, team) -> dict[Path, tuple[str]]:
-        """
-        Traverse the site folder and return a list of all yet-uncreated files with information
-        Returns path, location (team or personal), file size, and modified
-        Ignores hidden files
-        """
-        if self.s3_enabled:
-            root_folder = Path(self.get_prefix(team))
-            objects = self.conn.list_objects_v2(Bucket=self.get_bucket(team)).get("Contents", [])
-            basic_files = {}
+	def fetch_new_files(self, team) -> dict[Path, tuple[str]]:
+		"""
+		Traverse the site folder and return a list of all yet-uncreated files with information
+		Returns path, location (team or personal), file size, and modified
+		Ignores hidden files
+		"""
+		if self.s3_enabled:
+			root_folder = Path(self.get_prefix(team))
+			objects = self.conn.list_objects_v2(Bucket=self.get_bucket(team)).get("Contents", [])
+			basic_files = {}
 
-            # Get files...
-            for obj in objects:
-                obj_path = Path(obj["Key"])
+			# Get files...
+			for obj in objects:
+				obj_path = Path(obj["Key"])
 
-                if (
-                    not obj_path.is_relative_to(root_folder)
-                    or obj_path == root_folder
-                    or any(str(p).startswith(".") for p in obj_path.parts)
-                ):
-                    continue
-                obj_path = obj_path.relative_to(root_folder)
-                basic_files[obj_path] = obj
+				if (
+					not obj_path.is_relative_to(root_folder)
+					or obj_path == root_folder
+					or any(str(p).startswith(".") for p in obj_path.parts)
+				):
+					continue
+				obj_path = obj_path.relative_to(root_folder)
+				basic_files[obj_path] = obj
 
-                # Used to "calculate" natural folders, folders created by Drive are already counted
-                # Don't count root folder
-                parent_path = obj_path.parent
-                if obj_path not in basic_files and parent_path != Path("."):
-                    basic_files[parent_path] = {
-                        "Key": str(parent_path),
-                        "Size": 0,
-                        "LastModified": obj["LastModified"],
-                        "Folder": True,
-                    }
+				# Used to "calculate" natural folders, folders created by Drive are already counted
+				# Don't count root folder
+				parent_path = obj_path.parent
+				if obj_path not in basic_files and parent_path != Path("."):
+					basic_files[parent_path] = {
+						"Key": str(parent_path),
+						"Size": 0,
+						"LastModified": obj["LastModified"],
+						"Folder": True,
+					}
 
-            files = {}
+			files = {}
 
-            for path, f in basic_files.items():
-                # Drive-created folders - registered S3 objects - have trailing slashes.
-                is_folder = f.get("Folder") or f["Key"].endswith("/")
-                exists = frappe.get_value(
-                    "File",
-                    {
-                        "file_url": f["Key"].rstrip("/") + ("/" if is_folder else ""),
-                        "status": STATUS_ACTIVE,
-                        "team": team,
-                        "is_folder": int(is_folder),
-                    },
-                    "name",
-                )
-                if exists:
-                    continue
+			for path, f in basic_files.items():
+				# Drive-created folders - registered S3 objects - have trailing slashes.
+				is_folder = f.get("Folder") or f["Key"].endswith("/")
+				exists = frappe.get_value(
+					"File",
+					{
+						"file_url": f["Key"].rstrip("/") + ("/" if is_folder else ""),
+						"status": STATUS_ACTIVE,
+						"team": team,
+						"is_folder": int(is_folder),
+					},
+					"name",
+				)
+				if exists:
+					continue
 
-                mime_type = "folder" if is_folder else mimemapper.get_mime_type(f["Key"], native_first=False)
-                # Team path is key, DB path is f["Key"]
-                files[path] = (f["Size"], f["LastModified"].timestamp(), mime_type, f["Key"])
-        else:
-            root_folder = self.site_folder / self.get_prefix(team)
+				mime_type = "folder" if is_folder else mimemapper.get_mime_type(f["Key"], native_first=False)
+				# Team path is key, DB path is f["Key"]
+				files[path] = (f["Size"], f["LastModified"].timestamp(), mime_type, f["Key"])
+		else:
+			root_folder = self.site_folder / self.get_prefix(team)
 
-            # ... and stitch them together with information
-            files = {}
-            for f in root_folder.glob("**/*"):
-                path = f.relative_to(self.site_folder)
-                exists = frappe.get_value(
-                    "File",
-                    {"file_url": str(path), "team": team, "status": STATUS_ACTIVE},
-                    "name",
-                )
-                if exists or any(p for p in f.parts if p.startswith(".")):
-                    continue
+			# ... and stitch them together with information
+			files = {}
+			for f in root_folder.glob("**/*"):
+				path = f.relative_to(self.site_folder)
+				exists = frappe.get_value(
+					"File",
+					{"file_url": str(path), "team": team, "status": STATUS_ACTIVE},
+					"name",
+				)
+				if exists or any(p for p in f.parts if p.startswith(".")):
+					continue
 
-                if f.is_dir():
-                    mime_type = "folder"
-                else:
-                    mime_type = mimemapper.get_mime_type(str(f), native_first=False)
+				if f.is_dir():
+					mime_type = "folder"
+				else:
+					mime_type = mimemapper.get_mime_type(str(f), native_first=False)
 
-                # Twice `path` for compatability with S3 format
-                files[path] = (f.stat().st_size, f.stat().st_mtime, mime_type, str(path))
+				# Twice `path` for compatability with S3 format
+				files[path] = (f.stat().st_size, f.stat().st_mtime, mime_type, str(path))
 
-        return files
+		return files
 
-    def get_thumbnail_path(self, team, name):
-        return Path(storage_key(get_home_folder(team)["file_url"])) / self.settings.thumbnail_prefix / (name + ".thumbnail")
+	def get_thumbnail_path(self, team, name):
+		return (
+			Path(storage_key(get_home_folder(team)["file_url"]))
+			/ self.settings.thumbnail_prefix
+			/ (name + ".thumbnail")
+		)
 
-    def get_thumbnail(self, team, name):
-        return self.get_file(
-            frappe._dict({"team": team, "file_url": str(self.get_thumbnail_path(team, name))}), log=False
-        )
+	def get_thumbnail(self, team, name):
+		return self.get_file(
+			frappe._dict({"team": team, "file_url": str(self.get_thumbnail_path(team, name))}), log=False
+		)
 
-    def __get_trash_path(self, entity):
-        root = get_home_folder(entity.team)
-        return Path(storage_key(root["file_url"])) / ".trash" / entity.file_name
+	def __get_trash_path(self, entity):
+		root = get_home_folder(entity.team)
+		return Path(storage_key(root["file_url"])) / ".trash" / entity.file_name
 
-    @_not_if_flat
-    def rename(self, entity):
-        if not entity.file_url or entity.mime_type == "frappe/slides":
-            return
-        new_path = self.get_disk_path(entity)
-        return self.move(entity, new_path)
+	@_not_if_flat
+	def rename(self, entity):
+		if not entity.file_url or entity.mime_type == "frappe/slides":
+			return
+		new_path = self.get_disk_path(entity)
+		return self.move(entity, new_path)
 
-    @_not_if_flat
-    def move_to_trash(self, entity):
-        if not entity.file_url or entity.mime_type in ["frappe/slides", "link"]:
-            return
+	@_not_if_flat
+	def move_to_trash(self, entity):
+		if not entity.file_url or entity.mime_type in ["frappe/slides", "link"]:
+			return
 
-        trash_path = self.__get_trash_path(entity)
-        try:
-            if self.s3_enabled:
-                bucket = self.get_bucket(entity.team)
-                self.conn.copy_object(
-                    Bucket=bucket,
-                    CopySource={"Bucket": bucket, "Key": storage_key(entity.file_url)},
-                    Key=str(trash_path),
-                )
-                self.conn.delete_object(Bucket=bucket, Key=storage_key(entity.file_url))
-            else:
-                full_trash_path = self.site_folder / trash_path
-                if full_trash_path.exists() and full_trash_path.is_dir():
-                    shutil.rmtree(full_trash_path)
+		trash_path = self.__get_trash_path(entity)
+		try:
+			if self.s3_enabled:
+				bucket = self.get_bucket(entity.team)
+				self.conn.copy_object(
+					Bucket=bucket,
+					CopySource={"Bucket": bucket, "Key": storage_key(entity.file_url)},
+					Key=str(trash_path),
+				)
+				self.conn.delete_object(Bucket=bucket, Key=storage_key(entity.file_url))
+			else:
+				full_trash_path = self.site_folder / trash_path
+				if full_trash_path.exists() and full_trash_path.is_dir():
+					shutil.rmtree(full_trash_path)
 
-                full_trash_path.parent.mkdir(exist_ok=True)
-                cur_path = self.site_folder / storage_key(entity.file_url)
-                if cur_path.is_dir():
-                    shutil.move(cur_path, full_trash_path)
-                else:
-                    cur_path.rename(full_trash_path)
-        except (FileNotFoundError, ClientError):
-            frappe.log_error(f"Moved {entity.name} to trash without it being on disk")
-            pass
+				full_trash_path.parent.mkdir(exist_ok=True)
+				cur_path = self.site_folder / storage_key(entity.file_url)
+				if cur_path.is_dir():
+					shutil.move(cur_path, full_trash_path)
+				else:
+					cur_path.rename(full_trash_path)
+		except (FileNotFoundError, ClientError):
+			frappe.log_error(f"Moved {entity.name} to trash without it being on disk")
+			pass
 
-    @_not_if_flat
-    def restore(self, entity):
-        """
-        Restore a file from the trash.
-        """
-        self.move(frappe._dict(file_url=self.__get_trash_path(entity), team=entity.team), entity.file_url)
+	@_not_if_flat
+	def restore(self, entity):
+		"""
+		Restore a file from the trash.
+		"""
+		self.move(frappe._dict(file_url=self.__get_trash_path(entity), team=entity.team), entity.file_url)
 
-    @_not_if_flat
-    def move(self, entity, new_path: str | Path):
-        """
-        Move a file on disk
-        """
-        # Callers pass new_path as either a bare key or a stored file_url;
-        # normalize both ends to the actual backend key.
-        src_key = storage_key(entity.file_url)
-        dest_key = storage_key(new_path)
-        try:
-            if self.s3_enabled:
-                bucket = self.get_bucket(entity.team)
-                self.conn.copy_object(
-                    Bucket=bucket,
-                    CopySource={"Bucket": bucket, "Key": src_key},
-                    Key=dest_key,
-                )
-                self.conn.delete_object(Bucket=bucket, Key=src_key)
-            else:
-                cur_path = self.site_folder / src_key
-                dest_path = self.site_folder / dest_key
-                if cur_path.is_dir():
-                    shutil.move(cur_path, dest_path)
-                else:
-                    cur_path.rename(dest_path)
-        except BaseException as e:
-            frappe.throw("This file doesn't exist on disk.")
-        return new_path
+	@_not_if_flat
+	def move(self, entity, new_path: str | Path):
+		"""
+		Move a file on disk
+		"""
+		# Callers pass new_path as either a bare key or a stored file_url;
+		# normalize both ends to the actual backend key.
+		src_key = storage_key(entity.file_url)
+		dest_key = storage_key(new_path)
+		try:
+			if self.s3_enabled:
+				bucket = self.get_bucket(entity.team)
+				self.conn.copy_object(
+					Bucket=bucket,
+					CopySource={"Bucket": bucket, "Key": src_key},
+					Key=dest_key,
+				)
+				self.conn.delete_object(Bucket=bucket, Key=src_key)
+			else:
+				cur_path = self.site_folder / src_key
+				dest_path = self.site_folder / dest_key
+				if cur_path.is_dir():
+					shutil.move(cur_path, dest_path)
+				else:
+					cur_path.rename(dest_path)
+		except BaseException:
+			frappe.throw("This file doesn't exist on disk.")
+		return new_path
 
-    def delete_file(self, entity):
-        thumbnail_path = self.get_thumbnail_path(entity.team, entity.name)
+	def delete_file(self, entity):
+		thumbnail_path = self.get_thumbnail_path(entity.team, entity.name)
 
-        if self.s3_enabled:
-            bucket = self.get_bucket(entity.team)
-            try:
-                self.conn.delete_object(Bucket=bucket, Key=storage_key(entity.file_url))
-                if thumbnail_path:
-                    self.conn.delete_object(Bucket=bucket, Key=str(thumbnail_path))
-            except:
-                pass
-        else:
-            try:
-                (self.site_folder / storage_key(entity.file_url)).unlink()
-                if thumbnail_path:
-                    (self.site_folder / thumbnail_path).unlink()
-            except FileNotFoundError:
-                pass
+		if self.s3_enabled:
+			bucket = self.get_bucket(entity.team)
+			try:
+				self.conn.delete_object(Bucket=bucket, Key=storage_key(entity.file_url))
+				if thumbnail_path:
+					self.conn.delete_object(Bucket=bucket, Key=str(thumbnail_path))
+			except Exception:
+				pass
+		else:
+			try:
+				(self.site_folder / storage_key(entity.file_url)).unlink()
+				if thumbnail_path:
+					(self.site_folder / thumbnail_path).unlink()
+			except FileNotFoundError:
+				pass
 
 
 # Utils
 def storage_key(file_url):
-    # file_url -> backend storage key, always relative so `base / key` can't
-    # reset to an absolute path (Path("a") / "/b" == Path("/b")).
-    file_url = str(file_url)
-    if file_url.startswith(S3_URL_PREFIX):
-        return unquote(file_url[len(S3_URL_PREFIX) :])
-    return file_url.lstrip("/")
+	# file_url -> backend storage key, always relative so `base / key` can't
+	# reset to an absolute path (Path("a") / "/b" == Path("/b")).
+	file_url = str(file_url)
+	if file_url.startswith(S3_URL_PREFIX):
+		return unquote(file_url[len(S3_URL_PREFIX) :])
+	return file_url.lstrip("/")
+
+
+def content_disposition(download_name):
+	"""RFC 6266 attachment header; non-ASCII names ride in RFC 5987 filename*
+	(`secure_filename` would strip them to nothing)."""
+	try:
+		download_name.encode("ascii")
+		names = {"filename": download_name}
+	except UnicodeEncodeError:
+		simple = unicodedata.normalize("NFKD", download_name).encode("ascii", "ignore").decode("ascii")
+		quoted = quote(download_name, safe="!#$&+-.^_`|~")
+		names = {"filename": simple, "filename*": f"UTF-8''{quoted}"}
+	return dump_options_header("attachment", names)
 
 
 def get_s3_key(file_url):
-    prefixes = ["/private/files/", "/files/"]
-    for prefix in prefixes:
-        if file_url.startswith(prefix):
-            return file_url[len(prefix) :]
-    return file_url
+	prefixes = ["/private/files/", "/files/"]
+	for prefix in prefixes:
+		if file_url.startswith(prefix):
+			return file_url[len(prefix) :]
+	return file_url
 
 
 def get_s3_url(path):
-    from urllib.parse import quote
+	from urllib.parse import quote
 
-    return S3_URL_PREFIX + quote(path)
+	return S3_URL_PREFIX + quote(path)

--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -272,6 +272,8 @@ scheduler_events = {
 		"suite.mail.doctype.contacts_exchange.contacts_exchange.clean_contacts_import_export_directories",
 	],
 	"hourly": [
+		# drive
+		"suite.drive.api.scripts.clear_download_archives",
 		# mail
 		"suite.mail.doctype.mail_exchange.mail_exchange.retry_stuck_mail_exchanges",
 		"suite.calendar.doctype.calendar_exchange.calendar_exchange.retry_stuck_calendar_exchanges",


### PR DESCRIPTION
Serve download bytes from storage (S3 presigned URL / nginx / disk) with HTTP Range support instead of streaming through a gunicorn worker.

- Fixes large folder zips truncating into a corrupt archive when the transfer outran the worker timeout.
- Fixes large single files restarting from zero on a dropped connection.

Folders build in a background job to a temp artifact; the client polls a capability token and downloads the finished, Content-Length'd archive. Artifacts expire hourly. Local-disk deploys can opt into nginx `X-Accel-Redirect` via `drive_xaccel_prefix`; otherwise `send_file` streams off disk with Range support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)