### PR TITLE
fix(drive): correct S3 presign region, push download status over socket

### DIFF
--- a/frontend/src/apps/drive/socket.js
+++ b/frontend/src/apps/drive/socket.js
@@ -1,6 +1,10 @@
 import { io } from 'socket.io-client'
 
+let socketInstance = null
+
 export function initSocket() {
+  if (socketInstance) return socketInstance
+
   let siteName = window.site_name || 'drive.localhost'
 
   let default_port = __SOCKETIO_PORT__
@@ -9,12 +13,18 @@ export function initSocket() {
   let host = window.location.hostname
 
   let url = `${protocol}://${host}${port}/${siteName}`
-  let socket = io(url, {
+  socketInstance = io(url, {
     withCredentials: true,
     reconnectionAttempts: 5,
   })
-  socket.on('connect_error', (data) => {
+  socketInstance.on('connect_error', (data) => {
     console.log(data)
   })
-  return socket
+  return socketInstance
+}
+
+// For non-component code (plain utils) that needs the same connection
+// DriveLayout already opened and `provide`d — call after the app has mounted.
+export function getSocket() {
+  return socketInstance
 }

--- a/frontend/src/apps/drive/utils/download.js
+++ b/frontend/src/apps/drive/utils/download.js
@@ -1,8 +1,11 @@
 // Folders build into a zip via a background job, then download; single files
-// download directly. Both are served range/resume-capable off storage.
+// download directly. Both are served range/resume-capable off storage. The
+// build's terminal state (ready/failed) arrives over the socket DriveLayout
+// already opened — no interval polling.
 
 import { call } from 'frappe-ui'
 import { toast } from '@/apps/drive/utils/toasts.js'
+import { getSocket } from '@/apps/drive/socket'
 
 export function entitiesDownload(entities, transfer = false) {
   if (entities.length === 1 && !entities[0].is_folder) {
@@ -17,37 +20,65 @@ export function entitiesDownload(entities, transfer = false) {
 
 async function prepareArchive(entities) {
   const names = JSON.stringify(entities.map((entity) => entity.name))
+  let token
   try {
-    const { token } = await call('suite.drive.api.files.download_folder', { entities: names })
-    toast('Preparing download…')
-    const result = await pollArchive(token)
-    if (result.status !== 'ready') {
-      toast({ title: result.error || 'Could not prepare this download', type: 'error' })
-      return
-    }
-    window.location.href = `/api/method/suite.drive.api.files.download_archive?token=${encodeURIComponent(
-      token
-    )}`
+    ;({ token } = await call('suite.drive.api.files.download_folder', { entities: names }))
   } catch (error) {
     toast({ title: error?.message || 'Download failed', type: 'error' })
+    return
   }
+
+  try {
+    await toast
+      .promise(waitForArchive(token), {
+        loading: 'Preparing download…',
+        success: 'Download prepared',
+        error: (error) => error?.message || 'Could not prepare this download',
+      })
+      .unwrap()
+  } catch {
+    return // toast.promise already rendered the error toast in place
+  }
+
+  window.location.href = `/api/method/suite.drive.api.files.download_archive?token=${encodeURIComponent(
+    token
+  )}`
 }
 
 // timeout must outlast the job's 1h timeout, or we give up on builds that
 // would still succeed
-function pollArchive(token, { interval = 2000, timeout = 70 * 60 * 1000 } = {}) {
-  const start = Date.now()
+function waitForArchive(token, { timeout = 70 * 60 * 1000 } = {}) {
   return new Promise((resolve, reject) => {
-    const tick = async () => {
-      try {
-        const res = await call('suite.drive.api.files.download_status', { token })
-        if (res.status === 'ready' || res.status === 'failed') return resolve(res)
-        if (Date.now() - start > timeout) return reject(new Error('Timed out preparing download'))
-        setTimeout(tick, interval)
-      } catch (error) {
-        reject(error)
-      }
+    const socket = getSocket()
+    let settled = false
+    let timer
+
+    const finish = (fn, value) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      socket?.off('drive-download-status', onStatus)
+      fn(value)
     }
-    tick()
+
+    const settle = (data) => {
+      if (data.status === 'ready') finish(resolve, data)
+      else finish(reject, new Error(data.error || 'Could not prepare this download'))
+    }
+
+    const onStatus = (data) => {
+      if (data.token === token) settle(data)
+    }
+    socket?.on('drive-download-status', onStatus)
+
+    // covers the build finishing between the enqueue call and this listener
+    // attaching, and the (rare) case the socket drops the event entirely
+    call('suite.drive.api.files.download_status', { token })
+      .then((res) => {
+        if (res.status === 'ready' || res.status === 'failed') settle(res)
+      })
+      .catch(() => {}) // the socket path still covers a transient failure here
+
+    timer = setTimeout(() => finish(reject, new Error('Timed out preparing download')), timeout)
   })
 }

--- a/frontend/src/apps/drive/utils/toasts.js
+++ b/frontend/src/apps/drive/utils/toasts.js
@@ -12,4 +12,6 @@ const toast = (obj) => {
     type,
   })
 }
+// passthrough: sonner's loading→success/error toast, updated in place by id
+toast.promise = fToast.promise
 export { toast }

--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -516,6 +516,12 @@ def _write_archive(token, files):
 		return key, team, os.path.getsize(target)
 
 
+def _publish_download_status(token, user, status, **extra):
+	"""Push the terminal build state over the user's realtime room so the
+	client can drop polling and just listen."""
+	frappe.publish_realtime("drive-download-status", {"token": token, "status": status, **extra}, user=user)
+
+
 def build_download_archive(token, entities, zip_name, user):
 	"""Background job: build the archive as `user` and publish its state to cache."""
 	cache = frappe.cache()
@@ -531,6 +537,7 @@ def build_download_archive(token, entities, zip_name, user):
 			{"status": "ready", "owner": user, "key": key, "team": team, "file_name": zip_name, "size": size},
 			expires_in_sec=DOWNLOAD_TTL,
 		)
+		_publish_download_status(token, user, "ready", size=size)
 	except Exception as e:
 		frappe.log_error("Drive: archive build failed", e)
 		cache.set_value(
@@ -538,6 +545,7 @@ def build_download_archive(token, entities, zip_name, user):
 			{"status": "failed", "owner": user, "error": str(e)},
 			expires_in_sec=DOWNLOAD_TTL,
 		)
+		_publish_download_status(token, user, "failed", error=str(e))
 
 
 @frappe.whitelist(allow_guest=True)

--- a/suite/drive/utils/files.py
+++ b/suite/drive/utils/files.py
@@ -210,14 +210,48 @@ class FileManager:
 
 	def presigned_url(self, team, key, download_name, mime_type=None, expires=3600):
 		"""Short-lived S3 GET URL, range-capable, served straight to the client."""
+		bucket = self.get_bucket(team)
 		params = {
-			"Bucket": self.get_bucket(team),
+			"Bucket": bucket,
 			"Key": key,
 			"ResponseContentDisposition": content_disposition(download_name),
 		}
 		if mime_type:
 			params["ResponseContentType"] = mime_type
-		return self.conn.generate_presigned_url("get_object", Params=params, ExpiresIn=expires)
+		return self._presign_client(bucket).generate_presigned_url(
+			"get_object", Params=params, ExpiresIn=expires
+		)
+
+	def _presign_client(self, bucket):
+		"""generate_presigned_url signs offline, so it never gets the automatic
+		region-redirect retry that a real S3 call (get_object, put_object, ...)
+		gets for free. Signed against the wrong region, S3 rejects the URL
+		outright with PermanentRedirect instead of serving the object. Detect
+		the bucket's real region once (get_bucket_location is itself
+		region-agnostic) and sign with a client that matches it."""
+		if self.settings.endpoint_url:
+			# custom/S3-compatible endpoints (e.g. MinIO) don't do AWS's
+			# multi-region redirect dance
+			return self.conn
+
+		cache_key = f"drive-s3-bucket-region:{bucket}"
+		region = frappe.cache().get_value(cache_key)
+		if not region:
+			try:
+				region = self.conn.get_bucket_location(Bucket=bucket).get("LocationConstraint") or "us-east-1"
+			except ClientError:
+				region = self.conn.meta.region_name or "us-east-1"
+			frappe.cache().set_value(cache_key, region, expires_in_sec=24 * 60 * 60)
+
+		if region == self.conn.meta.region_name:
+			return self.conn
+		return boto3.client(
+			"s3",
+			aws_access_key_id=self.settings.aws_key,
+			aws_secret_access_key=self.settings.get_password("aws_secret"),
+			region_name=region,
+			config=Config(signature_version=self.settings.signature_version),
+		)
 
 	def iter_blocks(self, entity, block_size=4 * 1024 * 1024):
 		"""Yield a file's bytes lazily so a worker never holds the whole file."""


### PR DESCRIPTION
## Summary
- `generate_presigned_url` signs offline and never gets boto3's automatic region-redirect retry that a real S3 call gets. Signed against the client's default region, S3 rejected the URL outright with `PermanentRedirect` for any bucket outside that region — hit in prod, since `drive.frappe.cloud` lives in `ap-south-1` and the client defaulted to `us-east-1`. Each bucket's real region is now detected via `get_bucket_location` (itself region-agnostic) and cached, and presigning uses a client that matches.
- Replaces the 2s `download_status` poll with a single socket subscription: `build_download_archive` publishes the terminal `ready`/`failed` state to the requesting user's realtime room, and the client just listens (with one immediate status check as a race guard for a build finishing before the listener attaches, plus the existing timeout as a fallback if the event is ever dropped).
- Swaps the manual "preparing" toast for `frappe-ui`'s `toast.promise` — one loading toast that morphs into success/error in place instead of hand-tracking an id across separate `toast()` calls.

Builds on #359 (already merged) — this branch is off `develop`.

## Test plan
- [x] Verified the region bug and fix live against prod's `ap-south-1` bucket via `bench console` (`get_bucket_location` + region-scoped presign)
- [ ] Download a folder locally end-to-end: confirm the "Preparing download…" toast appears once, updates in place to "Download prepared", and the archive downloads
- [ ] Force a build failure (e.g. delete the source file mid-build) and confirm the toast shows the error instead of hanging
- [ ] Confirm no more `download_status` polling in the network tab — only one socket event drives completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)