### PR TITLE
fix(sheets): paint link hover card with a literal fill (follow-up to #358)

### DIFF
--- a/frontend/src/apps/sheets/components/SheetEditor/LinkPreviewCard.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/LinkPreviewCard.vue
@@ -132,16 +132,18 @@ const style = computed(() => {
 .sn-lp-card {
 	transform-origin: top left;
 	animation: sn-lp-rise 120ms ease-out;
+	/* Paint the fill with a literal colour, NOT the bg-surface-white utility.
+	   That utility compiles to color-mix(in srgb, var(--surface-white,#fff) …);
+	   in the production runtime --surface-white resolves to an EMPTY value in
+	   this context, and an empty var defeats even the #fff fallback, so the
+	   color-mix is invalid and the whole background-color is dropped — the card
+	   goes transparent and the canvas cell text shows through. A literal colour
+	   can't collapse; !important + the scoped selector's specificity beat the
+	   utility's own !important declaration. */
+	background-color: #fff !important;
 }
-/* Opaque-fill fallback. The bg-surface-white utility compiles to a color-mix()
-   value, which browsers without color-mix() support (pre Chrome 111 / Safari
-   16.2 / Firefox 113) discard as invalid — leaving the card transparent so the
-   canvas cell text shows through. Where color-mix is unsupported, paint the
-   fill from the plain design token instead (equals #fff / dark #0f0f0f). */
-@supports not (background-color: color-mix(in srgb, red, blue)) {
-	.sn-lp-card {
-		background-color: var(--surface-white, #fff);
-	}
+[data-theme='dark'] .sn-lp-card {
+	background-color: #0f0f0f !important;
 }
 @keyframes sn-lp-rise {
 	from { transform: translateY(-4px) scale(0.98); opacity: 0; }


### PR DESCRIPTION
### Problem

The link preview hover card (shown when hovering a cell that contains a hyperlink) renders **transparent** in production, so the spreadsheet's cell text bleeds through the card body and it becomes unreadable. The card's drop-shadow still draws, so it looks like a floating shadow with no fill.

Follow-up to #358 — that change guarded on `@supports (color-mix())`, but the real cause is not color-mix support (see below), so it didn't resolve the issue.

### Root cause

The card's white fill comes from the `bg-surface-white` utility on the root element, which compiles to:

```css
background-color: color-mix(in srgb, var(--surface-white,#fff) …, transparent)
```

In the production runtime, `--surface-white` resolves to an **empty** value in this context. A `var()` uses its fallback only when the property is *unset* — an **empty** value substitutes empty, defeating the `#fff` fallback. That makes the `color-mix()` invalid, so the entire `background-color` declaration is dropped and the card has no fill. Its `shadow-2xl` compiles to plain hex, so the shadow keeps rendering. This reproduces on **every** browser (it is not a `color-mix()`-support problem), which is why the `@supports` guard in #358 — reusing the same `--surface-white` var — collapsed the same way.

Verified by loading the production CSS and forcing `--surface-white` empty: the card computes to `rgba(0,0,0,0)`; with the fix below it computes to `#fff` (light) / `#0f0f0f` (dark).

### Fix

Paint the fill with a **literal**, token-independent colour instead of the utility:

```css
.sn-lp-card { background-color: #fff !important; }
[data-theme='dark'] .sn-lp-card { background-color: #0f0f0f !important; }
```

`!important` plus the scoped selector's specificity beat the utility's own `!important` declaration (which, when its `color-mix()` is invalid, otherwise wins the cascade and computes to transparent). Scoped to the one component; no template or logic changes.