### PR TITLE
fix(sheets): let paste/copy target the inline cell editor while editing

### DIFF
--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -1917,6 +1917,10 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     // SheetEditor uses this to keep the editor alive across sheet-tab clicks
     // for cross-sheet range picking.
     isEditingFormula: () => editing && overlay.getValue().startsWith('='),
+    // Whether the in-cell overlay editor is open at all. The host uses this to
+    // hand clipboard ops (copy/cut/paste) to the textarea's native handling
+    // while editing, instead of hijacking them for grid-level cell ops.
+    isEditing: () => editing,
     getSelection: getSelRange,
     setSelection: setSelRange,
     getPreMousedownSel,

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -1233,6 +1233,7 @@ import { userInitials } from '../../utils/session.js'
 import { parseNumberFmt, buildNumberFmt, applyNumberFmt } from '../../utils/format-number.js'
 import { getTextWrap } from '../../utils/text-wrap.js'
 import { autoCloseKey } from '../../utils/formula-autoclose.js'
+import { isCanvasClipboardTarget } from '../../utils/clipboard-target.js'
 import { computeFillDown, computeFillRight } from '../../engine/fill-series.js'
 import { detectSeries }                       from '../../engine/patterns/index.js'
 import { adjustFormula }                    from '../../engine/formula-adjust.js'
@@ -3945,14 +3946,13 @@ const { onGlobalKey } = useShortcuts({
 // ── Clipboard ─────────────────────────────────────────────────────────────────
 
 function _canvasActive() {
-  // The inline cell editor is a <textarea> mounted inside gridWrapRef, so a
-  // naive contains() check would treat "editing a cell" as "grid focused" and
-  // hijack Cmd+C/X/V for cell-level ops — breaking paste (and copy of a
-  // substring) inside the open editor. While editing, clipboard ops belong to
-  // the textarea's native handling.
-  if (grid?.isEditing?.()) return false
-  const ae = document.activeElement
-  return ae === canvasRef.value || ae === formulaInputRef.value || gridWrapRef.value?.contains(ae)
+  return isCanvasClipboardTarget({
+    activeEl:  document.activeElement,
+    canvasEl:  canvasRef.value,
+    formulaEl: formulaInputRef.value,
+    gridWrap:  gridWrapRef.value,
+    editing:   grid?.isEditing?.() ?? false,
+  })
 }
 
 // Returning to the tab or the sheet route leaves browser focus on <body>, not

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -3945,6 +3945,12 @@ const { onGlobalKey } = useShortcuts({
 // ── Clipboard ─────────────────────────────────────────────────────────────────
 
 function _canvasActive() {
+  // The inline cell editor is a <textarea> mounted inside gridWrapRef, so a
+  // naive contains() check would treat "editing a cell" as "grid focused" and
+  // hijack Cmd+C/X/V for cell-level ops — breaking paste (and copy of a
+  // substring) inside the open editor. While editing, clipboard ops belong to
+  // the textarea's native handling.
+  if (grid?.isEditing?.()) return false
   const ae = document.activeElement
   return ae === canvasRef.value || ae === formulaInputRef.value || gridWrapRef.value?.contains(ae)
 }

--- a/frontend/src/apps/sheets/utils/clipboard-target.js
+++ b/frontend/src/apps/sheets/utils/clipboard-target.js
@@ -1,0 +1,15 @@
+// Decide whether a document-level clipboard event (copy/cut/paste) is meant for
+// the grid — i.e. the host should intercept it and run a cell-level op — or
+// should be left to the browser's native handling.
+//
+// The subtlety: the inline cell editor is a <textarea> mounted INSIDE the grid
+// wrapper, so a plain "is the focused element inside gridWrap?" check treats an
+// open editor as "grid focused" and hijacks Cmd/Ctrl+C/X/V for cell ops —
+// breaking paste, and copy/cut of a selected substring, inside the editor.
+// While the editor is open, clipboard ops belong to the textarea.
+export function isCanvasClipboardTarget({ activeEl, canvasEl, formulaEl, gridWrap, editing }) {
+  if (editing) return false
+  return activeEl === canvasEl
+    || activeEl === formulaEl
+    || !!gridWrap?.contains(activeEl)
+}

--- a/frontend/src/apps/sheets/utils/clipboard-target.test.ts
+++ b/frontend/src/apps/sheets/utils/clipboard-target.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { isCanvasClipboardTarget } from './clipboard-target.js'
+
+describe('isCanvasClipboardTarget', () => {
+  const canvasEl  = { tag: 'canvas' }
+  const formulaEl = { tag: 'fx-input' }
+  const inner     = { tag: 'overlay-textarea' }   // lives inside the grid wrapper
+  const outside   = { tag: 'somewhere-else' }
+  const gridWrap  = { contains: (el: unknown) => el === canvasEl || el === inner }
+
+  const base = { canvasEl, formulaEl, gridWrap }
+
+  it('is false while a cell is being edited, even when the overlay is focused', () => {
+    // The open inline editor lives inside gridWrap, so contains() is true —
+    // but editing must win so the paste reaches the textarea.
+    expect(isCanvasClipboardTarget({ ...base, activeEl: inner, editing: true })).toBe(false)
+    // ...and true regardless of which element holds focus.
+    expect(isCanvasClipboardTarget({ ...base, activeEl: canvasEl, editing: true })).toBe(false)
+  })
+
+  it('is true when the canvas itself holds focus (not editing)', () => {
+    expect(isCanvasClipboardTarget({ ...base, activeEl: canvasEl, editing: false })).toBe(true)
+  })
+
+  it('is true when the formula bar holds focus (not editing)', () => {
+    expect(isCanvasClipboardTarget({ ...base, activeEl: formulaEl, editing: false })).toBe(true)
+  })
+
+  it('is true for any element inside the grid wrapper (not editing)', () => {
+    expect(isCanvasClipboardTarget({ ...base, activeEl: inner, editing: false })).toBe(true)
+  })
+
+  it('is false when focus is outside the grid entirely', () => {
+    expect(isCanvasClipboardTarget({ ...base, activeEl: outside, editing: false })).toBe(false)
+  })
+
+  it('does not throw when the grid wrapper is not mounted yet', () => {
+    expect(isCanvasClipboardTarget({ activeEl: outside, canvasEl: null, formulaEl: null, gridWrap: null, editing: false })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

Type a value into a cell, double-click (or F2) to edit it, then try to paste a different value over it — the paste does nothing. The same happens to copy/cut of a selected substring while editing: the selection is hijacked into a whole-cell operation.

## Root cause

The in-cell editor is a `<textarea>` mounted **inside** the grid wrapper element (`createOverlay(canvas.parentElement)`). The document-level clipboard handlers (`onDocCopy` / `onDocCut` / `onDocPaste`) decide whether an event is meant for the grid via `_canvasActive()`, which returned `true` whenever the focused element is contained in `gridWrapRef`.

While a cell is being edited, the focused textarea **is** inside `gridWrapRef`, so `_canvasActive()` returned `true`. The handlers then called `e.preventDefault()` and ran a **grid-level** cell paste/copy/cut — the event never reached the textarea, so:

- **Cmd/Ctrl+V** never landed in the open editor (the reported "can't paste over a cell I'm editing" bug), and
- **Cmd/Ctrl+C / Cmd/Ctrl+X** of a selected substring was turned into a whole-cell op.

## Fix

- Expose `grid.isEditing()` (mirrors the existing `isEditingFormula()`).
- Extract the "is this clipboard event meant for the grid?" decision into a pure `isCanvasClipboardTarget()` helper that returns `false` while the inline editor is open, so clipboard events fall through to the textarea's native handling. `_canvasActive()` now delegates to it.

The formula bar is unaffected: editing there never sets the grid's `editing` flag, so fx-bar clipboard still routes through the existing `formulaInputRef` branch.

## Testing

- `clipboard-target.test.ts` covers the decision matrix: editing wins over focus containment, canvas/fx-bar/in-wrap focus map to the grid when not editing, out-of-grid focus does not, and an unmounted wrapper doesn't throw. (Verified the editing case fails without the guard.)
- Verified in the built app: editing a non-empty cell then select-all + paste replaces the text in the editor and commits the pasted value; copy/cut of a substring inside the editor works natively; grid-to-grid copy/cut/paste and the "paste without first clicking a cell" refocus path are unchanged.