### PR TITLE
fix(meet): serialize SFU recovery lifecycles

### DIFF
--- a/frontend/src/apps/meet/components/ParticipantTile.vue
+++ b/frontend/src/apps/meet/components/ParticipantTile.vue
@@ -157,7 +157,6 @@ import { Button } from "frappe-ui";
 import { type ComputedRef, computed, inject, type Ref, ref, watch } from "vue";
 import { useAudioStream } from "../composables/useAudioLevels";
 import { useMeetingContext } from "../composables/useMeetingContext";
-import { useNetworkQuality } from "../composables/useNetworkQuality";
 import WifiAlertIcon from "../icons/WifiAlertIcon.vue";
 import type { Participant } from "../utils/media/ParticipantManager";
 import AudioIndicator from "./AudioIndicator.vue";
@@ -237,7 +236,9 @@ const { stream } = useAudioStream(props.participant.user_id, {
 	currentUser: meetingCtx?.currentUser,
 });
 
-const { networkQuality } = useNetworkQuality();
+const networkQuality = computed(
+	() => meetingCtx?.networkQuality.value ?? "good",
+);
 
 const resolvedDisplayName = computed(() => {
 	return (

--- a/frontend/src/apps/meet/composables/useMeetingContext.ts
+++ b/frontend/src/apps/meet/composables/useMeetingContext.ts
@@ -1,4 +1,4 @@
-import type { InjectionKey } from "vue";
+import type { InjectionKey, Ref } from "vue";
 import { inject, provide } from "vue";
 import type { SFUMeetingManager } from "../utils/SFUMeetingManager";
 import type { ChatStore } from "./useChatStore";
@@ -9,6 +9,7 @@ import type { MediaState } from "./useMediaState";
 import type { ParticipantStore } from "./useParticipantStore";
 import type { RaiseHandStore } from "./useRaiseHandStore";
 import type { ReactionStore } from "./useReactionStore";
+import type { NetworkQuality } from "./useNetworkQuality";
 
 interface MeetingContext {
 	mediaState: MediaState;
@@ -23,6 +24,7 @@ interface MeetingContext {
 	processedStream: MediaStream | null;
 	isInMeeting: ReturnType<() => import("vue").ComputedRef<boolean>>;
 	onBackgroundEffectsChanged: () => void;
+	networkQuality: Ref<NetworkQuality>;
 }
 
 const MEETING_CONTEXT_KEY: InjectionKey<MeetingContext> =

--- a/frontend/src/apps/meet/composables/useNetworkQuality.ts
+++ b/frontend/src/apps/meet/composables/useNetworkQuality.ts
@@ -7,7 +7,7 @@ import {
 import type { SFUMeetingManager } from "../utils/SFUMeetingManager";
 import { getClientTelemetry } from "../utils/telemetry/ClientTelemetry";
 
-type NetworkQuality = "good" | "poor" | "critical";
+export type NetworkQuality = "good" | "poor" | "critical";
 
 interface NetworkStats {
 	rtt: number;
@@ -24,15 +24,15 @@ const CRITICAL_PACKET_LOSS_PERCENT = 18;
 const POOR_VIDEO_BITRATE_BPS = 350_000;
 const CRITICAL_VIDEO_BITRATE_BPS = 200_000;
 
-export function useNetworkQuality() {
+export function useNetworkQuality(
+	sfuManagerRef = inject<Ref<SFUMeetingManager | null>>("sfuManager"),
+) {
 	const networkQuality = ref<NetworkQuality>("good");
 	const isPolling = ref(false);
 	let pollInterval: ReturnType<typeof setInterval> | null = null;
 	const stallDetector = new StallDetector();
 
 	const pollIntervalMs = 3000;
-	const sfuManagerRef = inject<Ref<SFUMeetingManager | null>>("sfuManager");
-
 	const updateQuality = (stats: NetworkStats) => {
 		if (!stats.isValid) {
 			// If we can't get valid stats, assume network is good

--- a/frontend/src/apps/meet/pages/Meeting.vue
+++ b/frontend/src/apps/meet/pages/Meeting.vue
@@ -262,6 +262,7 @@ import {
 	useMeetingHandlers,
 } from "../composables/useMeetingHandlers";
 import { useNoiseCancellation } from "../composables/useNoiseCancellation";
+import { useNetworkQuality } from "../composables/useNetworkQuality";
 import { useParticipantStore } from "../composables/useParticipantStore";
 import { useRaiseHand } from "../composables/useRaiseHand";
 import { useRaiseHandStore } from "../composables/useRaiseHandStore";
@@ -473,6 +474,7 @@ const sfuConnection = useSFUConnection({
 		participantStore.activeSpeakerIds = participantIds;
 	},
 });
+const { networkQuality } = useNetworkQuality(sfuConnection.sfuManager);
 
 // --- Media Controls ---
 const mediaControls = useMediaControls({
@@ -568,6 +570,7 @@ provideMeetingContext({
 	processedStream: mediaState.processedStream,
 	isInMeeting: computed(() => true),
 	onBackgroundEffectsChanged: mediaControls.applyBackgroundEffectsToLocalStream,
+	networkQuality,
 });
 
 // Provide legacy injects for components not yet migrated to useMeetingContext

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -149,6 +149,7 @@ export class SFUMeetingManager {
 			const hadVideo = !!mediaHandler.videoProducer;
 			const hadAudio = !!mediaHandler.audioProducer;
 
+			await this.mediaManager.cancelPendingSubscriptions();
 			mediaHandler.cleanup();
 			this.consumerManager.clear();
 			this.mediaManager.processedConsumers.clear();

--- a/frontend/src/apps/meet/utils/media/ConsumerManager.ts
+++ b/frontend/src/apps/meet/utils/media/ConsumerManager.ts
@@ -96,6 +96,10 @@ export class ConsumerManager {
 			if (this.localCloseInProgress.has(consumer.id)) {
 				return;
 			}
+			if (!this.consumers.has(consumer.id)) {
+				return;
+			}
+			this.removeConsumer(consumer.id);
 			if (this.eventHandlers.onConsumerLost) {
 				this.eventHandlers.onConsumerLost({
 					consumerId: consumer.id,

--- a/frontend/src/apps/meet/utils/media/TransportManager.ts
+++ b/frontend/src/apps/meet/utils/media/TransportManager.ts
@@ -125,6 +125,10 @@ export class TransportManager {
 	activeVideoStrategy: string;
 	eventHandlers: EventHandlers;
 	e2eePolicy: E2EETransformPolicy;
+	private sendTransportCreation: Promise<TransportLike> | null = null;
+	private recvTransportCreation: Promise<TransportLike> | null = null;
+	private sendTransportGeneration = 0;
+	private recvTransportGeneration = 0;
 
 	constructor(e2eePolicy?: E2EETransformPolicy) {
 		this.sendTransport = null;
@@ -226,29 +230,45 @@ export class TransportManager {
 
 	async createSendTransport() {
 		if (this.sendTransport) return this.sendTransport;
-		this.e2eePolicy.assertContextReady("create send transport");
-		if (!this.device) await this.initializeDevice();
-		if (!this.device) throw new Error("Device failed to initialize");
-		const client = this.getClient();
-		const rawTransportParams = await client.createWebRtcTransport("send");
-		const shouldEnableLegacyInsertableStreams =
-			this.e2eePolicy.legacyInsertableStreamsEnabled;
+		if (this.sendTransportCreation) return this.sendTransportCreation;
 
-		const additionalSettings: Record<string, unknown> = {};
-		if (shouldEnableLegacyInsertableStreams) {
-			additionalSettings.encodedInsertableStreams = true;
+		const generation = this.sendTransportGeneration;
+		const creation = (async () => {
+			this.e2eePolicy.assertContextReady("create send transport");
+			if (!this.device) await this.initializeDevice();
+			const device = this.device;
+			if (!device) throw new Error("Device failed to initialize");
+			const client = this.getClient();
+			const rawTransportParams = await client.createWebRtcTransport("send");
+			const additionalSettings: Record<string, unknown> = {};
+			if (this.e2eePolicy.legacyInsertableStreamsEnabled) {
+				additionalSettings.encodedInsertableStreams = true;
+			}
+
+			const transport = device.createSendTransport({
+				id: rawTransportParams.id,
+				iceParameters: rawTransportParams.iceParameters,
+				iceCandidates: rawTransportParams.iceCandidates,
+				dtlsParameters: rawTransportParams.dtlsParameters,
+				additionalSettings,
+			});
+			if (generation !== this.sendTransportGeneration) {
+				transport.close();
+				throw new Error("Send transport creation was cancelled");
+			}
+			this.sendTransport = transport;
+			this.setupSendTransportHandlers();
+			return transport;
+		})();
+		this.sendTransportCreation = creation;
+
+		try {
+			return await creation;
+		} finally {
+			if (this.sendTransportCreation === creation) {
+				this.sendTransportCreation = null;
+			}
 		}
-
-		this.sendTransport = this.device.createSendTransport({
-			id: rawTransportParams.id,
-			iceParameters: rawTransportParams.iceParameters,
-			iceCandidates: rawTransportParams.iceCandidates,
-			dtlsParameters: rawTransportParams.dtlsParameters,
-			additionalSettings,
-		});
-		this.setupSendTransportHandlers();
-
-		return this.sendTransport;
 	}
 
 	setupSendTransportHandlers() {
@@ -303,48 +323,71 @@ export class TransportManager {
 
 	async createReceiveTransport() {
 		if (this.recvTransport) return this.recvTransport;
-		this.e2eePolicy.assertContextReady("create receive transport");
-		if (!this.device) await this.initializeDevice();
-		if (!this.device) throw new Error("Device failed to initialize");
-		const client = this.getClient();
-		const rawTransportParams = await client.createWebRtcTransport("recv");
-		const shouldEnableLegacyInsertableStreams =
-			this.e2eePolicy.legacyInsertableStreamsEnabled;
+		if (this.recvTransportCreation) return this.recvTransportCreation;
 
-		const additionalSettings: Record<string, unknown> = {};
-		if (shouldEnableLegacyInsertableStreams) {
-			additionalSettings.encodedInsertableStreams = true;
+		const generation = this.recvTransportGeneration;
+		const creation = (async () => {
+			this.e2eePolicy.assertContextReady("create receive transport");
+			if (!this.device) await this.initializeDevice();
+			const device = this.device;
+			if (!device) throw new Error("Device failed to initialize");
+			const client = this.getClient();
+			const rawTransportParams = await client.createWebRtcTransport("recv");
+			const additionalSettings: Record<string, unknown> = {};
+			if (this.e2eePolicy.legacyInsertableStreamsEnabled) {
+				additionalSettings.encodedInsertableStreams = true;
+			}
+
+			const transport = device.createRecvTransport({
+				id: rawTransportParams.id,
+				iceParameters: rawTransportParams.iceParameters,
+				iceCandidates: rawTransportParams.iceCandidates,
+				dtlsParameters: rawTransportParams.dtlsParameters,
+				additionalSettings,
+			});
+			if (generation !== this.recvTransportGeneration) {
+				transport.close();
+				throw new Error("Receive transport creation was cancelled");
+			}
+			this.recvTransport = transport;
+			this.setupReceiveTransportHandlers();
+			return transport;
+		})();
+		this.recvTransportCreation = creation;
+
+		try {
+			return await creation;
+		} finally {
+			if (this.recvTransportCreation === creation) {
+				this.recvTransportCreation = null;
+			}
 		}
-
-		this.recvTransport = this.device.createRecvTransport({
-			id: rawTransportParams.id,
-			iceParameters: rawTransportParams.iceParameters,
-			iceCandidates: rawTransportParams.iceCandidates,
-			dtlsParameters: rawTransportParams.dtlsParameters,
-			additionalSettings,
-		});
-		this.setupReceiveTransportHandlers();
-		return this.recvTransport;
 	}
 
 	closeReceiveTransport() {
-		if (!this.recvTransport) return;
+		this.recvTransportGeneration++;
+		this.recvTransportCreation = null;
+		const transport = this.recvTransport;
+		this.recvTransport = null;
+		if (!transport) return;
 		try {
-			this.recvTransport.close();
+			transport.close();
 		} catch (_e) {
 			/* ignore */
 		}
-		this.recvTransport = null;
 	}
 
 	closeSendTransport() {
-		if (!this.sendTransport) return;
+		this.sendTransportGeneration++;
+		this.sendTransportCreation = null;
+		const transport = this.sendTransport;
+		this.sendTransport = null;
+		if (!transport) return;
 		try {
-			this.sendTransport.close();
+			transport.close();
 		} catch (_e) {
 			/* ignore */
 		}
-		this.sendTransport = null;
 	}
 
 	setupReceiveTransportHandlers() {
@@ -784,20 +827,8 @@ export class TransportManager {
 	}
 
 	cleanup() {
-		if (this.sendTransport)
-			try {
-				this.sendTransport.close();
-			} catch (_e) {
-				/* ignore */
-			}
-		if (this.recvTransport)
-			try {
-				this.recvTransport.close();
-			} catch (_e) {
-				/* ignore */
-			}
-		this.sendTransport = null;
-		this.recvTransport = null;
+		this.closeSendTransport();
+		this.closeReceiveTransport();
 		this.device = null;
 	}
 }

--- a/frontend/src/apps/meet/utils/media/__tests__/ConsumerManager.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/ConsumerManager.test.ts
@@ -320,6 +320,7 @@ describe("consumer @close handling", () => {
 		cm.addConsumer(consumer);
 		fire("@close");
 
+		expect(cm.getConsumer("c1")).toBeUndefined();
 		expect(lost).toHaveBeenCalledWith({
 			consumerId: "c1",
 			participantId: "p1",
@@ -338,6 +339,7 @@ describe("consumer @close handling", () => {
 		cm.addConsumer(consumer);
 		fire("trackended");
 
+		expect(cm.getConsumer("c1")).toBeUndefined();
 		expect(lost).toHaveBeenCalledWith({
 			consumerId: "c1",
 			participantId: "p1",

--- a/frontend/src/apps/meet/utils/media/__tests__/TransportManager.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/TransportManager.test.ts
@@ -260,6 +260,75 @@ describe("emitTransportConnectionState", () => {
 	});
 });
 
+describe("transport creation", () => {
+	it("shares one receive transport across concurrent callers", async () => {
+		const manager = createManager();
+		const client = mockSfuClient();
+		client.createWebRtcTransport.mockResolvedValue({
+			id: "recv-tp",
+			iceParameters: {},
+			iceCandidates: [],
+			dtlsParameters: {},
+		});
+		const transport = {
+			id: "recv-tp",
+			on: vi.fn(),
+			close: vi.fn(),
+		} as never;
+		manager.sfuClient = client as never;
+		manager.device = {
+			createRecvTransport: vi.fn(() => transport),
+		} as never;
+
+		const [first, second] = await Promise.all([
+			manager.createReceiveTransport(),
+			manager.createReceiveTransport(),
+		]);
+
+		expect(client.createWebRtcTransport).toHaveBeenCalledTimes(1);
+		expect(first).toBe(transport);
+		expect(second).toBe(transport);
+	});
+
+	it("discards a receive transport that finishes after it was closed", async () => {
+		const manager = createManager();
+		const client = mockSfuClient();
+		let resolveTransport: (value: {
+			id: string;
+			iceParameters: Record<string, never>;
+			iceCandidates: never[];
+			dtlsParameters: Record<string, never>;
+		}) => void = () => {};
+		client.createWebRtcTransport.mockReturnValue(
+			new Promise((resolve) => {
+				resolveTransport = resolve;
+			}),
+		);
+		const transport = {
+			id: "stale-recv-tp",
+			on: vi.fn(),
+			close: vi.fn(),
+		} as never;
+		manager.sfuClient = client as never;
+		manager.device = {
+			createRecvTransport: vi.fn(() => transport),
+		} as never;
+
+		const creation = manager.createReceiveTransport();
+		manager.closeReceiveTransport();
+		resolveTransport({
+			id: "stale-recv-tp",
+			iceParameters: {},
+			iceCandidates: [],
+			dtlsParameters: {},
+		});
+
+		await expect(creation).rejects.toThrow("cancelled");
+		expect(transport.close).toHaveBeenCalledTimes(1);
+		expect(manager.recvTransport).toBeNull();
+	});
+});
+
 describe("restartAllTransportIce", () => {
 	it("reports a restarted send transport and no receive transport", async () => {
 		const manager = createManager();

--- a/frontend/src/apps/meet/utils/sfu/SFUConnectionManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUConnectionManager.ts
@@ -93,6 +93,8 @@ export class SFUConnectionManager {
 	private lastJoinUserData: unknown = null;
 	private lastJoinMediaState: Record<string, unknown> = {};
 	private activeRejoin: Promise<void> | null = null;
+	private activeReceiveReset: Promise<void> | null = null;
+	private lifecycleGeneration = 0;
 
 	constructor(options: ConnectionManagerOptions) {
 		this.sfuClient = options.sfuClient;
@@ -329,15 +331,31 @@ export class SFUConnectionManager {
 	}
 
 	async resetReceiveSide(): Promise<void> {
+		if (this.activeReceiveReset) return this.activeReceiveReset;
+
+		const generation = this.lifecycleGeneration;
+		this.activeReceiveReset = this.performReceiveReset(generation).finally(() => {
+			this.activeReceiveReset = null;
+		});
+		return this.activeReceiveReset;
+	}
+
+	private async performReceiveReset(generation: number): Promise<void> {
+		const pendingSubscriptions = this.mediaManager.cancelPendingSubscriptions();
 		this.transportManager.closeReceiveTransport();
 		this.mediaManager.consumerManager.clear();
 		this.mediaManager.processedConsumers.clear();
 		this.mediaManager.isScreenShareActive = false;
+		await pendingSubscriptions;
+		if (generation !== this.lifecycleGeneration) return;
 		if (!(await this.waitForE2EEContextIfRequired())) {
 			return;
 		}
-		await this.createReceiveTransport();
+		if (generation !== this.lifecycleGeneration) return;
+		if (!(await this.createReceiveTransport())) return;
+		if (generation !== this.lifecycleGeneration) return;
 		await this.requestExistingProducers();
+		if (generation !== this.lifecycleGeneration) return;
 		await this.flushBufferedProducers();
 	}
 
@@ -367,29 +385,40 @@ export class SFUConnectionManager {
 			throw new Error("Cannot rejoin before joining a meeting");
 		}
 		this.recoveryManager.reset();
+		const generation = this.lifecycleGeneration;
 
 		const rejoin = (async () => {
 			this.reportRecoveryState("rejoining", "signaling reconnected");
+			const pendingSubscriptions =
+				this.mediaManager.cancelPendingSubscriptions();
 			this.transportManager.closeReceiveTransport();
 			this.mediaManager.consumerManager.clear();
 			this.mediaManager.processedConsumers.clear();
 			this.mediaManager.isScreenShareActive = false;
+			await pendingSubscriptions;
+			if (generation !== this.lifecycleGeneration) return;
 
 			await this.sfuClient.joinRoom(
 				this.meetingId as string,
 				this.lastJoinUserData,
 				this.getCurrentRejoinMediaState(),
 			);
+			if (generation !== this.lifecycleGeneration) return;
 			if (!(await this.waitForE2EEContextIfRequired())) {
 				throw new Error("E2EE context is not ready after signaling reconnect");
 			}
+			if (generation !== this.lifecycleGeneration) return;
 
 			await this.transportManager.initializeDevice();
+			if (generation !== this.lifecycleGeneration) return;
 			if (!(await this.createReceiveTransport())) {
 				throw new Error("Failed to recreate receive transport after reconnect");
 			}
+			if (generation !== this.lifecycleGeneration) return;
 			await this.mediaManager.rebuildSendSide();
+			if (generation !== this.lifecycleGeneration) return;
 			await this.setupExistingParticipants();
+			if (generation !== this.lifecycleGeneration) return;
 			this.reportRecoveryState("healthy", "session rebuilt");
 		})()
 			.catch((error) => {
@@ -776,6 +805,7 @@ export class SFUConnectionManager {
 
 	async disconnect(): Promise<void> {
 		try {
+			this.lifecycleGeneration++;
 			this.recoveryManager.reset();
 			this.mediaManager.cleanup();
 			this.transportManager?.cleanup?.();
@@ -789,6 +819,7 @@ export class SFUConnectionManager {
 	}
 
 	reset(): void {
+		this.lifecycleGeneration++;
 		this.meetingId = null;
 		this.currentUser = { value: null };
 		this.eventHandlers = {};

--- a/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
@@ -79,6 +79,9 @@ export class SFUMediaManager {
 	private eventHandlers: MediaEventHandlers = {};
 	private getCurrentUserId: () => string | null;
 	private resubscribeAttempts: Map<string, number> = new Map();
+	private pendingSubscriptions: Map<string, Promise<unknown | null>> = new Map();
+	private resubscribeTimers = new Set<ReturnType<typeof setTimeout>>();
+	private subscriptionGeneration = 0;
 	private static readonly MAX_RESUBSCRIBE_ATTEMPTS = 3;
 	private static readonly RESUBSCRIBE_DELAY_MS = 250;
 
@@ -204,11 +207,16 @@ export class SFUMediaManager {
 		participantId: string,
 		metadata: Record<string, unknown> = {},
 	): Promise<unknown> {
+		const generation = this.subscriptionGeneration;
 		try {
 			const consumer = await this.transportManager.createConsumer(
 				producerId,
 				metadata,
 			);
+			if (generation !== this.subscriptionGeneration) {
+				consumer.close();
+				throw new Error("Consumer subscription was cancelled");
+			}
 
 			const enhancedConsumer = this.consumerManager.addConsumer(
 				consumer,
@@ -252,13 +260,30 @@ export class SFUMediaManager {
 			return null;
 		}
 
-		const result = await this.subscribeToProducer(producerId, participantId, {
+		const key = this.resubscribeKey(participantId, producerId);
+		const existing = this.consumerManager
+			.getConsumersByParticipant(participantId)
+			.find((entry) => entry.producerId === producerId);
+		if (existing) return existing;
+
+		const pending = this.pendingSubscriptions.get(key);
+		if (pending) return pending;
+
+		let subscription: Promise<unknown | null>;
+		subscription = this.subscribeToProducer(producerId, participantId, {
 			isScreen: !!isScreen,
-		});
-		this.resubscribeAttempts.delete(
-			this.resubscribeKey(participantId, producerId),
-		);
-		return result;
+		})
+			.then((result) => {
+				this.resubscribeAttempts.delete(key);
+				return result;
+			})
+			.finally(() => {
+				if (this.pendingSubscriptions.get(key) === subscription) {
+					this.pendingSubscriptions.delete(key);
+				}
+			});
+		this.pendingSubscriptions.set(key, subscription);
+		return subscription;
 	}
 
 	async handleConsumerLost(info: {
@@ -295,7 +320,8 @@ export class SFUMediaManager {
 		}
 		this.resubscribeAttempts.set(key, attempts + 1);
 
-		setTimeout(() => {
+		const timer = setTimeout(() => {
+			this.resubscribeTimers.delete(timer);
 			void this.subscribeToRemoteProducer({
 				producerId: info.producerId,
 				participantId: info.participantId,
@@ -308,10 +334,21 @@ export class SFUMediaManager {
 				});
 			});
 		}, SFUMediaManager.RESUBSCRIBE_DELAY_MS);
+		this.resubscribeTimers.add(timer);
 	}
 
 	private resubscribeKey(participantId: string, producerId: string): string {
 		return `${participantId}:${producerId}`;
+	}
+
+	async cancelPendingSubscriptions(): Promise<void> {
+		this.subscriptionGeneration++;
+		for (const timer of this.resubscribeTimers) clearTimeout(timer);
+		this.resubscribeTimers.clear();
+		this.resubscribeAttempts.clear();
+		const pending = Array.from(this.pendingSubscriptions.values());
+		this.pendingSubscriptions.clear();
+		await Promise.allSettled(pending);
 	}
 
 	async handleNewConsumer(consumer: ConsumerEntry): Promise<void> {
@@ -433,6 +470,7 @@ export class SFUMediaManager {
 	}
 
 	cleanup(): void {
+		void this.cancelPendingSubscriptions();
 		this.mediaHandler.cleanup();
 		this.processedConsumers.clear();
 		this.isScreenShareActive = false;

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFUConnectionManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFUConnectionManager.test.ts
@@ -8,6 +8,7 @@ function createManager({ e2eeRequired = false } = {}) {
 	const handlers = new Map<string, (data: unknown) => unknown>();
 	const sfuClient = {
 		connect: vi.fn().mockResolvedValue(undefined),
+		disconnect: vi.fn().mockResolvedValue(undefined),
 		getExistingProducers: vi.fn().mockResolvedValue([]),
 		getRoomParticipants: vi.fn().mockResolvedValue([]),
 		isE2EERequired: vi.fn(() => e2eeRequired),
@@ -17,6 +18,8 @@ function createManager({ e2eeRequired = false } = {}) {
 		}),
 	};
 	const mediaManager = {
+		cancelPendingSubscriptions: vi.fn(),
+		cleanup: vi.fn(),
 		rebuildSendSide: vi.fn().mockResolvedValue({}),
 		subscribeToRemoteProducer: vi.fn().mockResolvedValue(undefined),
 		processedConsumers: new Set<string>(),
@@ -30,6 +33,7 @@ function createManager({ e2eeRequired = false } = {}) {
 		setEventHandlers: vi.fn(),
 	};
 	const transportManager = {
+		cleanup: vi.fn(),
 		closeReceiveTransport: vi.fn(),
 		createReceiveTransport: vi.fn().mockResolvedValue(undefined),
 		initializeDevice: vi.fn().mockResolvedValue(undefined),
@@ -203,5 +207,34 @@ describe("SFUConnectionManager", () => {
 		handlers.get("reconnect")?.({});
 
 		expect(rejoin).toHaveBeenCalledTimes(1);
+	});
+
+	it("shares one receive reset across concurrent callers", async () => {
+		const { manager, mediaManager, sfuClient, transportManager } = createManager();
+
+		await Promise.all([manager.resetReceiveSide(), manager.resetReceiveSide()]);
+
+		expect(transportManager.closeReceiveTransport).toHaveBeenCalledTimes(1);
+		expect(mediaManager.cancelPendingSubscriptions).toHaveBeenCalledTimes(1);
+		expect(mediaManager.consumerManager.clear).toHaveBeenCalledTimes(1);
+		expect(transportManager.createReceiveTransport).toHaveBeenCalledTimes(1);
+		expect(sfuClient.getExistingProducers).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not resume receive recovery after disconnect", async () => {
+		const { manager, mediaManager, transportManager } = createManager();
+		let finishCancellation: () => void = () => {};
+		mediaManager.cancelPendingSubscriptions.mockReturnValue(
+			new Promise<void>((resolve) => {
+				finishCancellation = resolve;
+			}),
+		);
+
+		const reset = manager.resetReceiveSide();
+		await manager.disconnect();
+		finishCancellation();
+		await reset;
+
+		expect(transportManager.createReceiveTransport).not.toHaveBeenCalled();
 	});
 });

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
@@ -17,7 +17,10 @@ function createManager(
 	mediaManager: SFUMediaManager;
 	transportManager: MockTransportManager;
 	videoManager: { attachStream: ReturnType<typeof vi.fn> };
-	consumerManager: { addConsumer: ReturnType<typeof vi.fn> };
+	consumerManager: {
+		addConsumer: ReturnType<typeof vi.fn>;
+		getConsumersByParticipant: ReturnType<typeof vi.fn>;
+	};
 	participantManager: MockParticipantManager;
 } {
 	const transportManager: MockTransportManager = {
@@ -30,6 +33,7 @@ function createManager(
 			kind: "video",
 			track: { kind: "video" },
 			appData: { type: "camera" },
+			close: vi.fn(),
 		}),
 	};
 
@@ -38,6 +42,7 @@ function createManager(
 	};
 
 	const consumerManager = {
+		getConsumersByParticipant: vi.fn(() => []),
 		addConsumer: vi.fn((c) => ({
 			id: c.id,
 			producerId: c.producerId,
@@ -70,6 +75,53 @@ function createManager(
 		participantManager,
 	};
 }
+
+describe("SFUMediaManager.subscribeToRemoteProducer", () => {
+	it("shares one subscription across concurrent callers", async () => {
+		const { mediaManager, transportManager } = createManager();
+		const request = {
+			producerId: "producer-1",
+			participantId: "remote-1",
+			isScreen: false,
+		};
+
+		await Promise.all([
+			mediaManager.subscribeToRemoteProducer(request),
+			mediaManager.subscribeToRemoteProducer(request),
+		]);
+
+		expect(transportManager.createConsumer).toHaveBeenCalledTimes(1);
+	});
+
+	it("discards a subscription that finishes after receive teardown", async () => {
+		const { mediaManager, transportManager, consumerManager } = createManager();
+		let resolveConsumer: (consumer: Record<string, unknown>) => void = () => {};
+		transportManager.createConsumer.mockReturnValue(
+			new Promise((resolve) => {
+				resolveConsumer = resolve;
+			}),
+		);
+		const consumer = {
+			id: "stale-c1",
+			producerId: "producer-1",
+			kind: "video",
+			close: vi.fn(),
+		};
+
+		const subscription = mediaManager.subscribeToRemoteProducer({
+			producerId: "producer-1",
+			participantId: "remote-1",
+			isScreen: false,
+		});
+		const cancellation = mediaManager.cancelPendingSubscriptions();
+		resolveConsumer(consumer);
+
+		await expect(subscription).rejects.toThrow("cancelled");
+		await cancellation;
+		expect(consumer.close).toHaveBeenCalledTimes(1);
+		expect(consumerManager.addConsumer).not.toHaveBeenCalled();
+	});
+});
 
 describe("SFUMediaManager.rebuildSendSide", () => {
 	it("recreates the send transport and republishes live local tracks", async () => {
@@ -166,6 +218,16 @@ describe("SFUMediaManager.handleConsumerLost", () => {
 		await mediaManager.handleConsumerLost(baseInfo);
 
 		await vi.advanceTimersByTimeAsync(1000);
+		expect(transportManager.createConsumer).not.toHaveBeenCalled();
+	});
+
+	it("cancels a delayed re-subscription during teardown", async () => {
+		const { mediaManager, transportManager } = createManager();
+		await mediaManager.handleConsumerLost(baseInfo);
+		await mediaManager.cancelPendingSubscriptions();
+
+		await vi.advanceTimersByTimeAsync(1000);
+
 		expect(transportManager.createConsumer).not.toHaveBeenCalled();
 	});
 

--- a/suite/meet/sfu-server/src/mediasoup/ConsumerManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/ConsumerManager.ts
@@ -12,9 +12,14 @@ export class ConsumerManager {
 	private scoreListeners: Array<
 		(kind: 'audio' | 'video', score: number) => void
 	> = [];
+	private closeListeners: Array<(consumerData: ConsumerData) => void> = [];
 
 	onScore(listener: (kind: 'audio' | 'video', score: number) => void): void {
 		this.scoreListeners.push(listener);
+	}
+
+	onClose(listener: (consumerData: ConsumerData) => void): void {
+		this.closeListeners.push(listener);
 	}
 
 	async createConsumer(
@@ -54,19 +59,25 @@ export class ConsumerManager {
 			);
 		}
 
+		let createdConsumer: mediasoup.types.Consumer | undefined;
 		try {
 			const consumer = await transport.consume({
 				producerId,
 				rtpCapabilities,
 				paused: true, // Consumers should start paused by default
 			});
+			createdConsumer = consumer;
 
 			const consumerData: ConsumerData = {
 				roomId,
 				peerId,
+				transportId: transport.id,
 				consumer,
 			};
 			this.consumers.set(consumer.id, consumerData);
+			consumer.on('transportclose', () => {
+				this.removeConsumer(consumer.id, false);
+			});
 			consumer.on('score', (score) => {
 				for (const listener of this.scoreListeners) {
 					listener(consumer.kind, score.score);
@@ -115,6 +126,7 @@ export class ConsumerManager {
 				paused: consumer.paused,
 			};
 		} catch (consumeError) {
+			if (createdConsumer) this.removeConsumer(createdConsumer.id, true);
 			loggers.consumerManager.error('Failed to create consumer: %o', {
 				error: (consumeError as Error).message,
 				producerId,
@@ -128,22 +140,29 @@ export class ConsumerManager {
 	}
 
 	closeConsumer(consumerId: string): void {
+		this.removeConsumer(consumerId, true);
+	}
+
+	private removeConsumer(consumerId: string, close: boolean): void {
 		const consumerData = this.consumers.get(consumerId);
 		if (!consumerData) return;
 
 		const { consumer } = consumerData;
+		this.consumers.delete(consumerId);
 
-		try {
-			consumer.close();
-		} catch (error) {
-			loggers.consumerManager.warn(
-				'Error closing consumer %s: %s',
-				consumerId,
-				(error as Error).message,
-			);
+		if (close) {
+			try {
+				consumer.close();
+			} catch (error) {
+				loggers.consumerManager.warn(
+					'Error closing consumer %s: %s',
+					consumerId,
+					(error as Error).message,
+				);
+			}
 		}
 
-		this.consumers.delete(consumerId);
+		for (const listener of this.closeListeners) listener(consumerData);
 
 		loggers.consumerManager.info('Consumer closed: %s', consumerId);
 	}
@@ -277,17 +296,8 @@ export class ConsumerManager {
 	}
 
 	cleanup(): void {
-		for (const [consumerId, consumerData] of this.consumers) {
-			try {
-				consumerData.consumer.close();
-			} catch (error) {
-				loggers.consumerManager.warn(
-					'Error closing consumer %s: %s',
-					consumerId,
-					(error as Error).message,
-				);
-			}
+		for (const consumerId of Array.from(this.consumers.keys())) {
+			this.closeConsumer(consumerId);
 		}
-		this.consumers.clear();
 	}
 }

--- a/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
@@ -53,8 +53,15 @@ export class MediasoupManager {
 			lastOverallQuality?: 'good' | 'poor' | 'critical';
 		}
 	>();
+	private creatingConsumers = new Set<string>();
 
 	constructor() {
+		this.consumerManager.onClose(({ roomId, peerId, consumer }) => {
+			this.roomManager
+				.getRoom(roomId)
+				?.peers.get(peerId)
+				?.consumers.delete(consumer.id);
+		});
 		this.consumerManager.onScore((kind, score) => {
 			for (const listener of this.mediaScoreListeners) {
 				listener('recv', kind, score);
@@ -401,6 +408,15 @@ export class MediasoupManager {
 		}
 
 		const { roomId, peerId, transport } = transportData;
+		const consumerKey = `${roomId}:${peerId}:${producerId}`;
+		if (this.creatingConsumers.has(consumerKey)) {
+			throw new Error(
+				`Consumer for producer ${producerId} is already being created`,
+			);
+		}
+		const existingConsumer = this.consumerManager
+			.getConsumersByPeer(roomId, peerId)
+			.find((data) => data.consumer.producerId === producerId);
 
 		if (producerData.peerId === peerId) {
 			throw new Error(`Cannot consume own producer ${producerId}`);
@@ -418,17 +434,27 @@ export class MediasoupManager {
 			);
 		}
 
-		const result = await this.consumerManager.createConsumer(
-			transport,
-			producerData.producer,
-			producerId,
-			roomId,
-			peerId,
-			rtpCapabilities,
-		);
+		this.creatingConsumers.add(consumerKey);
+		let result: Awaited<ReturnType<ConsumerManager['createConsumer']>>;
+		try {
+			result = await this.consumerManager.createConsumer(
+				transport,
+				producerData.producer,
+				producerId,
+				roomId,
+				peerId,
+				rtpCapabilities,
+			);
+		} finally {
+			this.creatingConsumers.delete(consumerKey);
+		}
+		if (existingConsumer) {
+			this.consumerManager.closeConsumer(existingConsumer.consumer.id);
+		}
 
 		const peer = room.peers.get(peerId);
 		if (!peer) {
+			this.consumerManager.closeConsumer(result.id);
 			throw new Error(`Peer ${peerId} not found in room ${roomId}`);
 		}
 

--- a/suite/meet/sfu-server/src/mediasoup/TransportManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/TransportManager.ts
@@ -9,8 +9,17 @@ import type {
 } from '../types';
 import { loggers } from '../utils/logger';
 
+interface WebRtcTransportParams {
+	id: string;
+	iceParameters: IceParameters;
+	iceCandidates: IceCandidate[];
+	dtlsParameters: DtlsParameters;
+}
+
 export class TransportManager {
 	private transports = new Map<string, TransportData>();
+	private pendingTransports = new Map<string, Promise<WebRtcTransportParams>>();
+	private transportGenerations = new Map<string, number>();
 	private stateListeners: Array<
 		(event: {
 			protocol: 'ice' | 'dtls';
@@ -36,23 +45,59 @@ export class TransportManager {
 		webRtcServer: mediasoup.types.WebRtcServer,
 		direction: 'send' | 'recv',
 		options: WebRTCTransportOptions,
-	): Promise<{
-		id: string;
-		iceParameters: IceParameters;
-		iceCandidates: IceCandidate[];
-		dtlsParameters: DtlsParameters;
-	}> {
+	): Promise<WebRtcTransportParams> {
+		const key = `${roomId}:${peerId}:${direction}`;
+		const pending = this.pendingTransports.get(key);
+		if (pending) return pending;
+
+		const generation = this.transportGenerations.get(key) ?? 0;
+		let creation: Promise<WebRtcTransportParams>;
+		creation = this.replaceWebRtcTransport(
+			roomId,
+			peerId,
+			router,
+			webRtcServer,
+			direction,
+			options,
+			key,
+			generation,
+		).finally(() => {
+			if (this.pendingTransports.get(key) === creation) {
+				this.pendingTransports.delete(key);
+			}
+		});
+		this.pendingTransports.set(key, creation);
+		return creation;
+	}
+
+	private async replaceWebRtcTransport(
+		roomId: string,
+		peerId: string,
+		router: mediasoup.types.Router,
+		webRtcServer: mediasoup.types.WebRtcServer,
+		direction: 'send' | 'recv',
+		options: WebRTCTransportOptions,
+		key: string,
+		generation: number,
+	): Promise<WebRtcTransportParams> {
 		loggers.transportManager.info(
 			'Creating %s transport for peer %s',
 			direction,
 			peerId,
 		);
+		if (direction === 'recv') {
+			this.closePeerDirectionTransports(roomId, peerId, direction);
+		}
 
 		const transport = await router.createWebRtcTransport({
 			webRtcServer,
 			enableTcp: options.enableTcp,
 			initialAvailableOutgoingBitrate: options.initialAvailableOutgoingBitrate,
 		});
+		if ((this.transportGenerations.get(key) ?? 0) !== generation) {
+			transport.close();
+			throw new Error(`Transport creation for peer ${peerId} was cancelled`);
+		}
 		transport.on('icestatechange', (state) => {
 			this.emitState({ protocol: 'ice', direction, state });
 		});
@@ -60,13 +105,16 @@ export class TransportManager {
 			this.emitState({ protocol: 'dtls', direction, state });
 		});
 
-		const _transportKey = `${direction}-${Date.now()}`;
 		const transportData: TransportData = {
 			roomId,
 			peerId,
 			transport,
+			direction,
 		};
 		this.transports.set(transport.id, transportData);
+		transport.observer.on('close', () => {
+			this.transports.delete(transport.id);
+		});
 
 		loggers.transportManager.info(
 			'%s transport created for peer %s',
@@ -80,6 +128,24 @@ export class TransportManager {
 			iceCandidates: transport.iceCandidates,
 			dtlsParameters: transport.dtlsParameters,
 		};
+	}
+
+	private closePeerDirectionTransports(
+		roomId: string,
+		peerId: string,
+		direction: 'send' | 'recv',
+	): void {
+		for (const [transportId, transportData] of this.transports) {
+			if (
+				transportData.roomId !== roomId ||
+				transportData.peerId !== peerId ||
+				transportData.direction !== direction
+			) {
+				continue;
+			}
+			transportData.transport.close();
+			this.transports.delete(transportId);
+		}
 	}
 
 	private emitState(event: {
@@ -138,6 +204,14 @@ export class TransportManager {
 	}
 
 	closePeerTransports(roomId: string, peerId: string): void {
+		for (const direction of ['send', 'recv'] as const) {
+			const key = `${roomId}:${peerId}:${direction}`;
+			this.transportGenerations.set(
+				key,
+				(this.transportGenerations.get(key) ?? 0) + 1,
+			);
+			this.pendingTransports.delete(key);
+		}
 		for (const [transportId, transportData] of this.transports) {
 			if (transportData.roomId !== roomId || transportData.peerId !== peerId)
 				continue;
@@ -155,6 +229,13 @@ export class TransportManager {
 	}
 
 	cleanup(): void {
+		for (const key of this.pendingTransports.keys()) {
+			this.transportGenerations.set(
+				key,
+				(this.transportGenerations.get(key) ?? 0) + 1,
+			);
+		}
+		this.pendingTransports.clear();
 		for (const [transportId, transportData] of this.transports) {
 			try {
 				transportData.transport.close();

--- a/suite/meet/sfu-server/src/mediasoup/__tests__/ConsumerManager.test.ts
+++ b/suite/meet/sfu-server/src/mediasoup/__tests__/ConsumerManager.test.ts
@@ -1,0 +1,78 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import { ConsumerManager } from '../ConsumerManager';
+
+describe('ConsumerManager', () => {
+	it('removes consumer bookkeeping when its transport closes', async () => {
+		const manager = new ConsumerManager();
+		const consumer = Object.assign(new EventEmitter(), {
+			id: 'consumer-1',
+			kind: 'audio',
+			paused: false,
+			producerId: 'producer-1',
+			rtpParameters: {},
+			close: vi.fn(),
+			resume: vi.fn(),
+		});
+		const transport = {
+			id: 'transport-1',
+			closed: false,
+			dtlsState: 'connected',
+			consume: vi.fn().mockResolvedValue(consumer),
+		};
+		const onClose = vi.fn();
+		manager.onClose(onClose);
+
+		await manager.createConsumer(
+			transport as never,
+			{ closed: false } as never,
+			'producer-1',
+			'room-1',
+			'peer-1',
+			{} as never,
+		);
+		consumer.emit('transportclose');
+
+		expect(manager.getConsumerCount()).toBe(0);
+		expect(onClose).toHaveBeenCalledWith(
+			expect.objectContaining({
+				roomId: 'room-1',
+				peerId: 'peer-1',
+				transportId: 'transport-1',
+			}),
+		);
+	});
+
+	it('removes and closes a consumer when its initial resume fails', async () => {
+		const manager = new ConsumerManager();
+		const consumer = Object.assign(new EventEmitter(), {
+			id: 'consumer-1',
+			kind: 'audio',
+			paused: true,
+			producerId: 'producer-1',
+			rtpParameters: {},
+			close: vi.fn(),
+			resume: vi.fn().mockRejectedValue(new Error('resume failed')),
+		});
+		const transport = {
+			id: 'transport-1',
+			closed: false,
+			dtlsState: 'connected',
+			consume: vi.fn().mockResolvedValue(consumer),
+		};
+
+		await expect(
+			manager.createConsumer(
+				transport as never,
+				{ closed: false } as never,
+				'producer-1',
+				'room-1',
+				'peer-1',
+				{} as never,
+			),
+		).rejects.toThrow('resume failed');
+
+		expect(manager.getConsumerCount()).toBe(0);
+		expect(consumer.close).toHaveBeenCalledTimes(1);
+	});
+});

--- a/suite/meet/sfu-server/src/mediasoup/__tests__/MediasoupManager.test.ts
+++ b/suite/meet/sfu-server/src/mediasoup/__tests__/MediasoupManager.test.ts
@@ -74,3 +74,45 @@ describe('MediasoupManager.updateConsumerPreferences', () => {
 		expect(consumer.requestKeyFrame).not.toHaveBeenCalled();
 	});
 });
+
+describe('MediasoupManager.createConsumer', () => {
+	it('keeps an existing consumer when its replacement fails', async () => {
+		const mgr = new MediasoupManager();
+		const internals = mgr as unknown as {
+			transportManager: {
+				getTransportData: (transportId: string) => unknown;
+			};
+			producerManager: {
+				getProducerData: (producerId: string) => unknown;
+			};
+			roomManager: { getRoom: (roomId: string) => unknown };
+		};
+		const existing = { id: 'existing', producerId: 'producer-1' };
+		vi.spyOn(internals.transportManager, 'getTransportData').mockReturnValue({
+			roomId: 'room-1',
+			peerId: 'peer-1',
+			transport: {},
+		} as never);
+		vi.spyOn(internals.producerManager, 'getProducerData').mockReturnValue({
+			peerId: 'peer-2',
+			producer: { appData: {} },
+		} as never);
+		vi.spyOn(internals.roomManager, 'getRoom').mockReturnValue({
+			router: { canConsume: () => true },
+			peers: new Map(),
+		} as never);
+		vi.spyOn(mgr.consumerManager, 'getConsumersByPeer').mockReturnValue([
+			{ consumer: existing } as never,
+		]);
+		const closeConsumer = vi.spyOn(mgr.consumerManager, 'closeConsumer');
+		vi.spyOn(mgr.consumerManager, 'createConsumer').mockRejectedValue(
+			new Error('consume failed'),
+		);
+
+		await expect(
+			mgr.createConsumer('transport-1', 'producer-1', {} as never),
+		).rejects.toThrow('consume failed');
+
+		expect(closeConsumer).not.toHaveBeenCalled();
+	});
+});

--- a/suite/meet/sfu-server/src/mediasoup/__tests__/TransportManager.test.ts
+++ b/suite/meet/sfu-server/src/mediasoup/__tests__/TransportManager.test.ts
@@ -1,0 +1,118 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import { TransportManager } from '../TransportManager';
+
+function makeTransport(id: string) {
+	const observer = new EventEmitter();
+	return Object.assign(new EventEmitter(), {
+		id,
+		observer,
+		iceParameters: {},
+		iceCandidates: [],
+		dtlsParameters: {},
+		close: vi.fn(() => observer.emit('close')),
+	});
+}
+
+const options = {
+	enableTcp: true,
+	initialAvailableOutgoingBitrate: 1_000_000,
+};
+
+describe('TransportManager', () => {
+	it('shares one transport across concurrent receive creation requests', async () => {
+		const manager = new TransportManager();
+		const transport = makeTransport('recv-1');
+		const router = {
+			createWebRtcTransport: vi.fn().mockResolvedValue(transport),
+		};
+
+		const [first, second] = await Promise.all([
+			manager.createWebRtcTransport(
+				'room-1',
+				'peer-1',
+				router as never,
+				{} as never,
+				'recv',
+				options,
+			),
+			manager.createWebRtcTransport(
+				'room-1',
+				'peer-1',
+				router as never,
+				{} as never,
+				'recv',
+				options,
+			),
+		]);
+
+		expect(router.createWebRtcTransport).toHaveBeenCalledTimes(1);
+		expect(first.id).toBe('recv-1');
+		expect(second.id).toBe('recv-1');
+		expect(manager.getTransportCount()).toBe(1);
+	});
+
+	it('closes the previous receive transport when replacing it', async () => {
+		const manager = new TransportManager();
+		const first = makeTransport('recv-1');
+		const second = makeTransport('recv-2');
+		const router = {
+			createWebRtcTransport: vi
+				.fn()
+				.mockResolvedValueOnce(first)
+				.mockResolvedValueOnce(second),
+		};
+
+		await manager.createWebRtcTransport(
+			'room-1',
+			'peer-1',
+			router as never,
+			{} as never,
+			'recv',
+			options,
+		);
+		await manager.createWebRtcTransport(
+			'room-1',
+			'peer-1',
+			router as never,
+			{} as never,
+			'recv',
+			options,
+		);
+
+		expect(first.close).toHaveBeenCalledTimes(1);
+		expect(manager.getTransport('recv-1')).toBeUndefined();
+		expect(manager.getTransport('recv-2')).toBe(second);
+		expect(manager.getTransportCount()).toBe(1);
+	});
+
+	it('discards a transport that finishes after the peer was removed', async () => {
+		const manager = new TransportManager();
+		const transport = makeTransport('stale-recv');
+		let resolveTransport: (
+			transport: ReturnType<typeof makeTransport>,
+		) => void = () => {};
+		const router = {
+			createWebRtcTransport: vi.fn().mockReturnValue(
+				new Promise((resolve) => {
+					resolveTransport = resolve;
+				}),
+			),
+		};
+
+		const creation = manager.createWebRtcTransport(
+			'room-1',
+			'peer-1',
+			router as never,
+			{} as never,
+			'recv',
+			options,
+		);
+		manager.closePeerTransports('room-1', 'peer-1');
+		resolveTransport(transport);
+
+		await expect(creation).rejects.toThrow('cancelled');
+		expect(transport.close).toHaveBeenCalledTimes(1);
+		expect(manager.getTransportCount()).toBe(0);
+	});
+});

--- a/suite/meet/sfu-server/src/types/index.ts
+++ b/suite/meet/sfu-server/src/types/index.ts
@@ -389,6 +389,7 @@ export interface TransportData {
 	roomId: string;
 	peerId: string;
 	transport: WebRtcTransport;
+	direction?: 'send' | 'recv';
 }
 
 export interface ProducerData {
@@ -400,6 +401,7 @@ export interface ProducerData {
 export interface ConsumerData {
 	roomId: string;
 	peerId: string;
+	transportId: string;
 	consumer: Consumer;
 }
 


### PR DESCRIPTION
- track network quality for the meeting as a whole instead of for every tile
- request key frame couple times before a complete reset to avoid black stream momentarily