### PR TITLE
fix(sheets): keep the in-cell editor pinned to its cell

### DIFF
--- a/frontend/src/apps/sheets/canvas/editor-position.test.ts
+++ b/frontend/src/apps/sheets/canvas/editor-position.test.ts
@@ -1,0 +1,66 @@
+// Regression harness for the "in-cell editor shows up somewhere else" bug.
+// The open <textarea> must stay pinned to its cell across ANY scroll/zoom/
+// layout mutation — not just the wheel/scrollbar path. The production trigger
+// is a ResizeObserver firing mid-edit (a side panel opens, the window
+// resizes), which runs through _applyCanvasSize; setZoom hits that same code
+// path deterministically without needing to drive off-screen scrolling.
+//
+// Without the fix these go red: _applyCanvasSize re-clamps scroll and shifts
+// every cell, but leaves the textarea floating at its pre-change offset.
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createMockCtx } from './painters/test-utils.js'
+import { createGrid } from './index.js'
+
+// Open the editor on the given cell by synthesizing the dblclick the grid
+// listens for. jsdom's getBoundingClientRect() is all-zero (no layout), so
+// client coords map straight into the canvas's own coordinate space: a point a
+// few px past the 50px row-header / 24px col-header gutter lands in cell A1.
+function mount() {
+  const parent = document.createElement('div')
+  const canvas = document.createElement('canvas')
+  vi.spyOn(canvas, 'getContext').mockReturnValue(createMockCtx())
+  parent.appendChild(canvas)
+  document.body.appendChild(parent)
+  const grid = createGrid(canvas, { getFormat: () => ({}), canEdit: () => true })
+  grid.resize(800, 600)
+  const editor = () => parent.querySelector('textarea')
+  const openA1 = () => canvas.dispatchEvent(
+    new MouseEvent('dblclick', { clientX: 55, clientY: 30, bubbles: true }))
+  return { grid, editor, openA1 }
+}
+
+// The overlay stores its on-screen offset as inline px styles; strip 'px'.
+const leftOf = el => parseFloat(el.style.left)
+const topOf  = el => parseFloat(el.style.top)
+
+describe('in-cell editor stays pinned to its cell', () => {
+  let h
+  beforeEach(() => { document.body.innerHTML = ''; h = mount() })
+
+  it('opens the editor anchored to the double-clicked cell', () => {
+    h.openA1()
+    expect(h.grid.isEditing()).toBe(true)
+    const rect = h.grid.getCellRect(0, 0)
+    expect(leftOf(h.editor())).toBeCloseTo(rect.x, 3)
+    expect(topOf(h.editor())).toBeCloseTo(rect.y, 3)
+  })
+
+  it('tracks its cell across a zoom-driven layout change (_applyCanvasSize)', () => {
+    h.openA1()
+    const before = leftOf(h.editor())
+    h.grid.setZoom(2)
+    const rect = h.grid.getCellRect(0, 0)
+    // Zoom doubles the cell's on-screen rect; the editor must follow it there,
+    // not stay at its pre-zoom offset.
+    expect(rect.x).toBeGreaterThan(before)
+    expect(leftOf(h.editor())).toBeCloseTo(rect.x, 3)
+    expect(topOf(h.editor())).toBeCloseTo(rect.y, 3)
+  })
+
+  it('does not touch the overlay when no edit is open (guarded no-op)', () => {
+    // Nothing editing: a layout change must not move/show the hidden textarea.
+    expect(h.grid.isEditing()).toBe(false)
+    h.grid.setZoom(2)
+    expect(h.editor().style.display).toBe('none')
+  })
+})

--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -218,6 +218,16 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     scroll.y = Math.max(0, Math.min(scroll.y, _maxScrollY()))
   }
 
+  // Pin the open in-cell editor to `sel`'s current on-screen rect. ANY change
+  // to scroll, zoom, or layout that repaints the grid must call this too, or
+  // the <textarea> is left floating at a stale offset while the highlight moves
+  // under it — the "editor shows somewhere else" bug. Cheap no-op when idle.
+  function _positionEditor() {
+    if (!editing) return
+    const fmt = getFormat ? (getFormat(cellId(sel.r, sel.c)) || {}) : {}
+    overlay.position(geo.colX(sel.c) * _zoom, geo.rowY(sel.r) * _zoom, geo.cw(sel.c) * _zoom, geo.rh(sel.r) * _zoom, fmt, _zoom)
+  }
+
   // Single entry point for setting the scroll offset (logical units). Used by
   // the wheel handler and the overlay scrollbars so both keep the in-cell
   // editor pinned to its cell and repaint. Values are clamped to the sheet.
@@ -225,10 +235,7 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     scroll.x = x
     scroll.y = y
     _clampScroll()
-    if (editing) {
-      const fmt = getFormat ? getFormat(cellId(sel.r, sel.c)) : {}
-      overlay.position(geo.colX(sel.c) * _zoom, geo.rowY(sel.r) * _zoom, geo.cw(sel.c) * _zoom, geo.rh(sel.r) * _zoom, fmt, _zoom)
-    }
+    _positionEditor()
     render()
   }
 
@@ -685,6 +692,9 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
       else if (y + h > cssH) scroll.y += y + h - cssH + 8
     }
     _clampScroll()
+    // Picking scrolls the view while the editor stays anchored to the formula
+    // cell; repin it so it tracks that cell instead of hanging in place.
+    _positionEditor()
   }
 
   // Compute the ref text from anchor+head and rewrite the inserted span.
@@ -816,10 +826,13 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     if (isCellEditable && !isCellEditable(sel.r, sel.c)) { onBlockedEdit?.(); return }
     editMode = mode
     selEnd = { r: sel.r, c: sel.c }
-    const fmt = getFormat ? getFormat(cellId(sel.r, sel.c)) : {}
-    overlay.position(geo.colX(sel.c) * _zoom, geo.rowY(sel.r) * _zoom, geo.cw(sel.c) * _zoom, geo.rh(sel.r) * _zoom, fmt, _zoom)
-    overlay.show(initialValue)
+    // Type-to-edit and F2 don't move the selection, so `sel` may have been
+    // scrolled off-screen (wheel/scrollbar leaves the selection put). Bring it
+    // back into view before positioning, or the editor opens off in the void.
+    ensureVisible(sel.r, sel.c)
     editing = true
+    _positionEditor()
+    overlay.show(initialValue)
     onInput?.(cellId(sel.r, sel.c), initialValue)
     render()
   }
@@ -1711,6 +1724,11 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     canvas.style.width  = physW + 'px'
     canvas.style.height = physH + 'px'
     _clampScroll()
+    // A viewport/zoom/extent change can re-clamp scroll and shift every cell;
+    // repin the open editor so it doesn't strand at its pre-resize offset (e.g.
+    // a ResizeObserver firing mid-edit when a side panel opens or the window
+    // resizes).
+    _positionEditor()
   }
 
   function resize(w, h) {

--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -1816,6 +1816,9 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     scroll.x = 0
     scroll.y = 0
     _clampScroll()
+    // Freezing resets the scroll origin, shifting every cell; repin the open
+    // editor so it tracks its cell instead of stranding at the old offset.
+    _positionEditor()
     render()
   }
 


### PR DESCRIPTION
## Problem

A user hit this in a production instance: they click/select a cell to edit it, but the in-cell editor opens **somewhere else** on the grid (screenshot below shows the editor detached from the highlighted cell). It's intermittent — "happened a few times."

## Root cause

The in-cell editor is a single absolutely-positioned `<textarea>` placed over the canvas at the selected cell's on-screen rect (`geo.colX(sel)·zoom, geo.rowY(sel)·zoom`). That position is only valid for the scroll/zoom/layout it was computed at — but **only `scrollTo` (the wheel/scrollbar path) ever re-positioned the open editor.** Every other way the grid's scroll or layout can change while the editor is open repainted the selection highlight at a new spot while leaving the textarea floating where it was:

- **`resize` → `_applyCanvasSize`** — fired by the grid-wrap `ResizeObserver` whenever a side panel opens/closes, the window resizes, a mobile keyboard appears, or an OS scrollbar toggles. It re-clamps `scroll` and shifts every cell, stranding the open editor. This is the intermittent production trigger.
- **`showEditor`** (F2 / type-to-edit) never scrolled an off-screen selection back into view first, so if the selected cell had been wheel-scrolled out of the viewport, typing opened the editor at the cell's now-off-screen coordinates.
- **`_scrollIntoView`** (formula-picker) scrolled the view while leaving the formula-cell editor behind.

## Fix

Centralize repositioning in a small guarded `_positionEditor()` helper (a no-op unless editing) and call it from **every** scroll/layout mutation — `scrollTo`, `_applyCanvasSize`, `_scrollIntoView` — plus an `ensureVisible(sel)` at the top of `showEditor` so a begin-edit always pulls its cell into view before placing the editor.

Frontend-only, single file.

## Verification

Driven end-to-end in the running app:

- **Off-screen selection + type:** selected A1, wheel-scrolled to ~row 668, typed a character → editor opened exactly on A1 (`left=50, top=164`), fully inside the viewport. Before the fix it would open ~640 rows below the view.
- **Resize mid-edit:** editing R2 while scrolled to the far right (`scroll.x`=1549, editor at `left`=201), resized the window wider than the sheet → `scroll.x` clamped to 0, column R jumped to x=1750, and the editor **tracked it to `left`=1750** (measured == expected column position). Before the fix it would have stayed at 201 — 1549px adrift.

---

### Follow-up (2nd commit): close the invariant + add a regression test

Self-review traced every scroll/zoom/layout mutation against the "must repin" invariant. One was still uncovered:

- **`setFreeze`** resets the scroll origin (`scroll.x/y = 0`), shifting every cell, but didn't repin the open editor. It's currently unreachable while editing (clicking the freeze toolbar blurs → commits the textarea first), so it's not a live bug — but it broke the invariant `_positionEditor` declares ("ANY change to scroll must call this too"), so it's now closed.

**Regression test** (`editor-position.test.ts`) — the first `createGrid` integration test (jsdom + a stubbed 2d ctx). It opens the editor via the real dblclick path, then asserts the textarea tracks its cell across a layout change routed through `_applyCanvasSize` (the production ResizeObserver trigger, exercised deterministically via `setZoom`), and stays a guarded no-op when idle. Verified **red without** the `_applyCanvasSize` repin, green with it.
