### PR TITLE
fix(mail): surface JMAP errors from sieve script set calls

### DIFF
--- a/suite/mail/doctype/sieve_script/sieve_script.py
+++ b/suite/mail/doctype/sieve_script/sieve_script.py
@@ -16,6 +16,8 @@ from suite.mail.doctype.mailbox_settings.mailbox_settings import get_mailbox_set
 from suite.mail.doctype.screened_email_address.screened_email_address import get_screened_email_addresses
 from suite.mail.doctype.user_account.user_account import get_user_for_jmap_account
 from suite.mail.jmap import (
+	format_jmap_error,
+	get_jmap_set_error_message,
 	get_mailbox_id_by_name,
 	get_mailbox_id_by_role,
 	get_mailbox_name_by_id,
@@ -145,13 +147,13 @@ class SieveScript(Document):
 		}
 		response = service.create([sieve_script])
 
-		title = _("Sieve Script Creation Error")
-		if response.get("created"):
-			return response["created"][creation_id]["id"]
-		elif response.get("notCreated"):
-			frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
-		else:
-			frappe.throw(_(response["description"]), title=title)
+		if created := response.get("created"):
+			return created[creation_id]["id"]
+
+		frappe.throw(
+			get_jmap_set_error_message(response, "notCreated", creation_id),
+			title=_("Sieve Script Creation Error"),
+		)
 
 	@classmethod
 	def _fetch_sieve_scripts(
@@ -206,10 +208,7 @@ class SieveScript(Document):
 		response = service.validate(content)
 
 		if error := response.get("error"):
-			frappe.throw(
-				_("{0}: {1}").format(error.get("type"), error.get("description")),
-				title=_("Sieve Script Validation Error"),
-			)
+			frappe.throw(format_jmap_error(error), title=_("Sieve Script Validation Error"))
 
 	@classmethod
 	def _update_sieve_script(
@@ -239,12 +238,11 @@ class SieveScript(Document):
 		sieve_script = {"id": id, "name": name, "content": content, "is_active": bool(active)}
 		response = service.update([sieve_script], deactivate=deactivate)
 
-		title = _("Sieve Script Update Error")
 		if not response.get("updated"):
-			if response.get("notUpdated"):
-				frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
-			else:
-				frappe.throw(_(response["description"]), title=title)
+			frappe.throw(
+				get_jmap_set_error_message(response, "notUpdated", id),
+				title=_("Sieve Script Update Error"),
+			)
 
 	@classmethod
 	def _delete_sieve_scripts(cls, account: str, ids: list[str]) -> None:
@@ -253,14 +251,15 @@ class SieveScript(Document):
 		service = get_sieve_script_service(account)
 		response = service.delete(ids)
 
-		if response.get("notDestroyed"):
-			error_messages = []
-			for id, error in response["notDestroyed"].items():
-				error_messages.append(f"{id}: {error['description']}")
+		title = _("Sieve Script Deletion Error")
+		if not_destroyed := response.get("notDestroyed"):
+			error_messages = [f"{id}: {format_jmap_error(error)}" for id, error in not_destroyed.items()]
 			frappe.throw(
 				_("Sieve Script Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
-				title=_("Sieve Script Deletion Error"),
+				title=title,
 			)
+		elif error := response.get("error"):
+			frappe.throw(format_jmap_error(error), title=title)
 
 	def validate(self) -> None:
 		if self.read_only:

--- a/suite/mail/jmap/__init__.py
+++ b/suite/mail/jmap/__init__.py
@@ -464,3 +464,30 @@ def get_mailboxes_for_account(account: str) -> list[dict]:
 	"""Returns the list of mailboxes for the specified account."""
 
 	return get_mailboxes(account)
+
+
+def format_jmap_error(error: dict | None) -> str:
+	"""Returns a readable message for a JMAP error object.
+
+	Only `type` is mandatory on a JMAP error object; `description` is optional and may be null,
+	so never index into it directly.
+	"""
+
+	error = error or {}
+
+	return error.get("description") or error.get("type") or _("An unknown error occurred.")
+
+
+def get_jmap_set_error_message(response: dict, not_done_key: str, id: str) -> str:
+	"""Returns a readable message for a failed JMAP `set` call.
+
+	A `set` can fail per object (reported under `not_done_key`, keyed by the object id) or at the
+	method level (reported under `error`), and neither is guaranteed to be present — nor is the
+	per-object error guaranteed to be keyed by the id we asked about — so every source is probed
+	before falling back to a generic message.
+	"""
+
+	not_done = response.get(not_done_key) or {}
+	error = not_done.get(id) or next(iter(not_done.values()), None) or response.get("error")
+
+	return format_jmap_error(error)

--- a/suite/mail/jmap/services/sieve/sieve_script.py
+++ b/suite/mail/jmap/services/sieve/sieve_script.py
@@ -44,8 +44,13 @@ class SieveScriptService(CoreService):
 			response = self._create(payload, **kwargs)
 
 			if method_responses := response.get("methodResponses"):
-				result["created"].update(method_responses[0][1].get("created", {}))
-				if not_created := method_responses[0][1].get("notCreated", {}):
+				name, body = method_responses[0][0], method_responses[0][1]
+				if name == "error":
+					result["error"] = body
+					break
+
+				result["created"].update(body.get("created", {}))
+				if not_created := body.get("notCreated", {}):
 					result["notCreated"].update(not_created)
 
 		return result
@@ -95,8 +100,13 @@ class SieveScriptService(CoreService):
 			response = self._update(payload, **kwargs)
 
 			if method_responses := response.get("methodResponses"):
-				result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-				if not_updated := method_responses[0][1].get("notUpdated", {}):
+				name, body = method_responses[0][0], method_responses[0][1]
+				if name == "error":
+					result["error"] = body
+					break
+
+				result["updated"].extend(body.get("updated", {}).keys())
+				if not_updated := body.get("notUpdated", {}):
 					result["notUpdated"].update(not_updated)
 
 		return result
@@ -109,8 +119,13 @@ class SieveScriptService(CoreService):
 			response = self._delete(batch)
 
 			if method_responses := response.get("methodResponses"):
-				result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
-				if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
+				name, body = method_responses[0][0], method_responses[0][1]
+				if name == "error":
+					result["error"] = body
+					break
+
+				result["destroyed"].extend(body.get("destroyed", []))
+				if not_destroyed := body.get("notDestroyed", {}):
 					result["notDestroyed"].update(not_destroyed)
 
 		return result
@@ -170,6 +185,11 @@ class SieveScriptService(CoreService):
 		)
 
 		if method_responses := response.get("methodResponses"):
-			return method_responses[0][1]
+			name, body = method_responses[0][0], method_responses[0][1]
+
+			# A method-level error carries `{type, description}` directly, whereas a successful
+			# validate call reports the outcome in an `error` key. Normalise so callers only
+			# have to look at `error`, otherwise a failed call reads as a valid script.
+			return {"error": body} if name == "error" else body
 
 		return {}


### PR DESCRIPTION
## Problem

Saving a sieve script could crash with:

```
File "apps/suite/suite/mail/doctype/sieve_script/sieve_script.py", line 247, in _update_sieve_script
    frappe.throw(_(response["description"]), title=title)
KeyError: 'description'
```

A method-level JMAP error reply (`["error", {type, description}, "0"]`) was being read as a normal `SieveScript/set` response, so `create`/`update`/`delete` in `SieveScriptService` returned empty result buckets and silently dropped the error. The doctype then fell through to `frappe.throw(_(response["description"]))` on a dict that never carries a top-level `description` — so an actionable server error became a `KeyError`.

`SieveScript/validate` had the mirror of the same bug in the other direction: on a method-level error it returned `{type, description}`, which has no `error` key, so `_validate_sieve_script` read a failed call as a *valid* script.

Separately, the code assumed `description` is always present on a JMAP error. Per RFC 8620 only `type` is mandatory; `description` is optional and may be null.

## Changes

**`suite/mail/jmap/services/sieve/sieve_script.py`**
- `create` / `update` / `delete` detect an `error` method response and surface it as `result["error"]` instead of discarding it (and stop batching at that point).
- `validate` normalises a method-level error to `{"error": body}` so callers only have to look at `error`.

**`suite/mail/jmap/__init__.py`** — two shared helpers:
- `format_jmap_error` — falls back `description → type → generic message`.
- `get_jmap_set_error_message` — probes the per-object error (keyed by id, then any entry, since the server isn't obliged to key it by the id we sent), then the method-level error.

**`suite/mail/doctype/sieve_script/sieve_script.py`**
- Creation, update, deletion and validation paths all route through those helpers. The deletion path had the same latent crash on `error['description']` and ignored method-level errors entirely.

## Result

The automation-sieve save now reports the actual server error instead of masking it behind a `KeyError`.

## Not in scope

The same `response["description"]` / `notCreated[id]["description"]` pattern exists in `suite/calendar/doctype/calendar_event/calendar_event.py`, `suite/calendar/doctype/calendar/calendar.py` and `suite/mail/doctype/contact_card/contact_card.py`, and their services swallow method-level errors the same way. The new helpers are importable from `suite.mail.jmap` if we want those converted in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)