### PR TITLE
fix(mail): refresh threads when any mailbox count changes

### DIFF
--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -1247,7 +1247,12 @@ const onResetSuccess = () => {
 		const fresh = freshWindow.filter(
 			(t: Thread) => !existing.has(t.thread_id) && !recentlyRemoved.has(t.thread_id),
 		)
-		threadsResource.value.data = [...fresh, ...refreshSnapshot]
+		// Already-loaded threads take their fresh row (new reply's snippet, unread state, timestamp)
+		// but keep their position — updating in place, not re-sorting, so the list doesn't jump under
+		// the reader. Threads outside the fresh window keep their snapshot row unchanged.
+		const freshById = new Map(freshWindow.map((t: Thread) => [t.thread_id, t]))
+		const updatedSnapshot = refreshSnapshot.map((t) => freshById.get(t.thread_id) ?? t)
+		threadsResource.value.data = [...fresh, ...updatedSnapshot]
 		// Keep the reader where they were: shift scroll by the height the prepended rows added. If they
 		// were already at the top, leave them there so the new mail is visible.
 		nextTick(() => {
@@ -1598,12 +1603,20 @@ watch(
 )
 
 // Periodically refresh the mailbox list (keeps sidebar counts current), then merge in new threads only
-// when the mailbox's thread count actually changed — so a quiet mailbox isn't touched (and the reader
-// isn't disturbed) every 30s.
+// when the mailbox's counts actually changed — so a quiet mailbox isn't touched (and the reader isn't
+// disturbed) every 30s. Every count matters: a reply landing in an already-loaded thread moves only
+// total_emails (and unread_* if unread) while total_threads stays put, so comparing threads alone
+// would miss it and the list would go stale (issue #171).
+const mailboxCounts = () => {
+	const m = mailboxObj.value
+	if (!m) return undefined
+	return `${m.total_threads}:${m.unread_threads}:${m.total_emails}:${m.unread_emails}`
+}
+
 const pollForChanges = async () => {
-	const prevTotal = mailboxObj.value?.total_threads
+	const prevCounts = mailboxCounts()
 	await mailboxes.reload()
-	if (mailboxObj.value?.total_threads !== prevTotal) refreshThreads(false)
+	if (mailboxCounts() !== prevCounts) refreshThreads(false)
 }
 
 onMounted(() => {

--- a/frontend/src/apps/mail/types/index.ts
+++ b/frontend/src/apps/mail/types/index.ts
@@ -192,6 +192,8 @@ export interface MailboxData {
 	role: string | null
 	total_threads: number
 	unread_threads: number
+	total_emails: number
+	unread_emails: number
 	_name: string
 	subscribed: 0 | 1
 	icon?: string

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -82,7 +82,17 @@ def get_mailboxes(account: str) -> list[dict]:
 	if not mailboxes:
 		return []
 
-	fields = ["name", "id", "_name", "role", "total_threads", "unread_threads", "subscribed"]
+	fields = [
+		"name",
+		"id",
+		"_name",
+		"role",
+		"total_threads",
+		"unread_threads",
+		"total_emails",
+		"unread_emails",
+		"subscribed",
+	]
 
 	mailbox_settings = frappe.db.get_all(
 		"Mailbox Settings",


### PR DESCRIPTION
Fixes #171

## Problem

The 30-second poll in `MailboxView.vue` gated the thread-list refresh on `total_threads` alone. A reply arriving into an existing thread changes only `unread_threads`/`total_emails` — so the sidebar badge updated (from `get_mailboxes`) while `get_threads` was never invoked and the list went stale. Read-state changes from another device/session hit the same gap.

## Changes

- **`get_mailboxes`** now also serializes `total_emails` and `unread_emails` (already stored on the Mailbox doctype from JMAP's `totalEmails`/`unreadEmails`) — these change for *any* new message, including a read reply into a read thread, which no thread-level count can catch.
- **`pollForChanges`** compares a composite key of all four counts instead of `total_threads` alone.
- **Refresh merge** (`onResetSuccess`): already-loaded threads now take their fresh row (new snippet, unread state, timestamp) in place instead of being discarded by the prepend-only merge — without this, the refetch triggered by the poll fix would fetch the updated row and then throw it away. Rows keep their position (no re-sort), so the list doesn't jump under the reader. This also benefits the existing socket-driven refresh path, which had the same blind spot.

## Verification

- All 24 mail frontend tests pass; production Vite build compiles cleanly.
- Selections/keyboard focus are unaffected by the in-place row swap — they track `thread_id` strings and row keys, not object identity.

Known residual limitation: changes between two polls that net out to identical counts (e.g. one arrival + one deletion in the same 30s window) still won't trigger a refresh; catching that would need a JMAP state-token comparison, which is a larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)