### PR TITLE
fix(mail): show an error page when the mail server is unavailable

### DIFF
--- a/frontend/src/apps/mail/components/MailServerUnavailableView.vue
+++ b/frontend/src/apps/mail/components/MailServerUnavailableView.vue
@@ -1,0 +1,24 @@
+<template>
+	<div
+		role="alert"
+		class="flex h-dvh flex-col items-center justify-center gap-4 bg-surface-base p-8 text-center"
+	>
+		<CloudOff class="h-10 w-10 text-ink-gray-5" />
+		<div class="flex flex-col gap-1.5">
+			<h1 class="text-2xl font-semibold text-ink-gray-9">{{ __('Mail server unavailable') }}</h1>
+			<p class="text-base text-ink-gray-6">
+				{{ __('The mail server is temporarily unavailable. Please try again in a few minutes.') }}
+			</p>
+		</div>
+		<Button variant="solid" @click="reloadPage">{{ __('Retry') }}</Button>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { CloudOff } from 'lucide-vue-next'
+import { Button } from 'frappe-ui'
+
+// A reload re-runs the boot fetches from scratch — if the server is back, the app
+// comes up normally; if not, the failing fetches land right back on this view.
+const reloadPage = () => window.location.reload()
+</script>

--- a/frontend/src/apps/mail/pages/MailLayout.vue
+++ b/frontend/src/apps/mail/pages/MailLayout.vue
@@ -1,6 +1,10 @@
 <template>
 	<FrappeUIProvider>
-		<component :is="Layout" class="mail-app-root">
+		<!-- Nothing in mail works without the mail server, so an outage replaces the whole
+		     route group (incl. noLayout pages) rather than decorating a UI whose every fetch
+		     would fail. -->
+		<MailServerUnavailableView v-if="mailServerUnavailable" class="mail-app-root" />
+		<component :is="Layout" v-else class="mail-app-root">
 			<router-view />
 		</component>
 		<InstallPrompt v-if="isMobile" />
@@ -12,6 +16,7 @@ import { computed, onMounted, onUnmounted, provide, watchEffect } from 'vue'
 import { useRoute } from 'vue-router'
 import { FrappeUIProvider } from 'frappe-ui'
 
+import { mailServerUnavailable } from '@/boot/config'
 import { shouldIgnoreKeypress } from '@/apps/mail/utils'
 import { useScreenSize, useTheme } from '@/apps/mail/utils/composables'
 import { showNotification } from '@/apps/mail/utils/push-notifications'
@@ -20,6 +25,7 @@ import dayjs from '@/apps/mail/utils/dayjs'
 import { userStore } from '@/apps/mail/stores/user'
 import DefaultLayout from '@/apps/mail/components/DefaultLayout.vue'
 import InstallPrompt from '@/apps/mail/components/InstallPrompt.vue'
+import MailServerUnavailableView from '@/apps/mail/components/MailServerUnavailableView.vue'
 
 import type { NotificationPayload } from '@/apps/mail/types'
 

--- a/frontend/src/apps/mail/router.ts
+++ b/frontend/src/apps/mail/router.ts
@@ -85,8 +85,10 @@ function installMailGuard(r: Router) {
 		resolveAccount(user?.accounts, to.params.accountId as string | undefined)
 		const accountId = userStore().accountId
 
-		// Wait for mailbox list.
-		await mailboxes.promise
+		// Wait for mailbox list. The fetch rejects when the mail server is temporarily down;
+		// swallow that so navigation still completes — otherwise the initial navigation aborts,
+		// the app never mounts and the user gets a blank page instead of the unavailable banner.
+		await mailboxes.promise?.catch(() => {})
 		const defaultRoute = buildDefaultRoute(accountId, mailboxes)
 
 		// Validate mailbox param for mailbox routes.
@@ -98,8 +100,11 @@ function installMailGuard(r: Router) {
 			if (screenerId && to.params.mailbox === screenerId)
 				return { name: 'mail-screener', params: { accountId } }
 
+			// With no mailbox list (fetch failed above) the param can't be validated — keep the
+			// requested route rather than bouncing the user off the URL they asked for.
 			const mailboxExists =
-				mailboxes.data?.some((m: { id: string }) => m.id === to.params.mailbox) ||
+				!mailboxes.data ||
+				mailboxes.data.some((m: { id: string }) => m.id === to.params.mailbox) ||
 				['starred', 'search'].includes(to.params.mailbox as string)
 			if (!mailboxExists) return defaultRoute
 		}

--- a/frontend/src/boot/config.ts
+++ b/frontend/src/boot/config.ts
@@ -1,4 +1,41 @@
-import { frappeRequest, setConfig } from 'frappe-ui'
+import { ref } from 'vue'
+import { frappeRequest, setConfig, toast } from 'frappe-ui'
+
+import { translate } from '@/boot/translation'
+
+/** Error shape thrown by frappe-ui's `frappeRequest` (the type is not re-exported). */
+type RequestError = Error & { exc_type?: string; messages?: string[] }
+
+// Raised by the backend (suite.mail.jmap.connection) whenever Stalwart — the server behind
+// mail, calendar and contacts — cannot be reached. Handled centrally here so every failing
+// resource collapses into ONE friendly toast instead of silent console errors.
+const MAIL_SERVER_UNAVAILABLE_EXC = 'MailServerUnavailableError'
+const MAIL_SERVER_UNAVAILABLE_TOAST_ID = 'mail-server-unavailable'
+
+/**
+ * True once any request has failed because the mail server is unreachable. The mail layout
+ * swaps the whole page for a "mail server unavailable" view from this — needed because outages
+ * during initial routing happen before any toast container is mounted, so a toast alone would
+ * be lost. Cleared only by a reload (the view's Retry), since a later unrelated request
+ * succeeding doesn't prove the mail server is back.
+ */
+export const mailServerUnavailable = ref(false)
+
+function handleMailServerUnavailable(error: RequestError) {
+  const message = translate(
+    'The mail server is temporarily unavailable. Please try again in a few minutes.',
+  )
+  // Rewrite the error so resource-level handlers that toast `error.message` /
+  // `error.messages[0]` show the friendly text instead of "url ExcType".
+  error.message = message
+  error.messages = [message]
+
+  if (mailServerUnavailable.value) return
+  mailServerUnavailable.value = true
+  // One toast on first detection, for surfaces that don't render a full-page state
+  // (e.g. calendar). The fixed id collapses concurrent failures into a single toast.
+  toast.error(message, { id: MAIL_SERVER_UNAVAILABLE_TOAST_ID })
+}
 
 /**
  * Unified frappe-ui resource configuration for the whole suite.
@@ -13,7 +50,14 @@ import { frappeRequest, setConfig } from 'frappe-ui'
  * Call `configureFrappeUI()` exactly once, before mounting the app.
  */
 export function configureFrappeUI() {
-  setConfig('resourceFetcher', frappeRequest)
+  setConfig('resourceFetcher', (options: Parameters<typeof frappeRequest>[0]) =>
+    frappeRequest(options).catch((error: RequestError) => {
+      if (error?.exc_type === MAIL_SERVER_UNAVAILABLE_EXC) {
+        handleMailServerUnavailable(error)
+      }
+      throw error
+    }),
+  )
 }
 
 /** Shared API base used by raw fetch/socket helpers that bypass frappe-ui. */

--- a/suite/mail/jmap/connection.py
+++ b/suite/mail/jmap/connection.py
@@ -5,6 +5,24 @@ from urllib.parse import urljoin
 
 import requests
 
+# Gateway statuses a reverse proxy returns when the JMAP server behind it is down or overloaded.
+UNAVAILABLE_STATUS_CODES = (502, 503, 504)
+
+
+class MailServerUnavailableError(Exception):
+	"""The JMAP server could not be reached (connection refused, DNS failure, timeout) or an
+	upstream gateway reported it down.
+
+	``http_status_code`` makes Frappe respond with 503 instead of a generic 500, so clients can
+	distinguish "the mail server is temporarily down" from an application bug and show a friendly
+	message. The original ``requests`` exception is always chained for diagnosis.
+	"""
+
+	http_status_code = 503
+
+	def __init__(self, message: str = "The mail server is temporarily unavailable.") -> None:
+		super().__init__(message)
+
 
 @dataclass
 class JMAPConnectionInfo:
@@ -95,9 +113,12 @@ class JMAPConnection:
 		"""Performs session discovery by sending a GET request to the JMAP server's well-known URL and storing the session information."""
 
 		url = urljoin(self.__info.url, "/.well-known/jmap")
-		response = self.__session.get(
-			url, headers={"Accept": "application/json"}, timeout=self.__info.timeout
-		)
+		try:
+			response = self.__session.get(
+				url, headers={"Accept": "application/json"}, timeout=self.__info.timeout
+			)
+		except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+			raise MailServerUnavailableError() from e
 		raise_for_status(response)
 
 		self.session = response.json()
@@ -170,16 +191,19 @@ class JMAPConnection:
 		"""Sends a request to the JMAP server with the specified parameters, and returns the response."""
 
 		headers = headers or {}
-		response = self.__session.request(
-			method=method,
-			url=url,
-			headers=headers,
-			json=json,
-			data=data,
-			params=params,
-			timeout=timeout or self.__info.timeout,
-			**kwargs,
-		)
+		try:
+			response = self.__session.request(
+				method=method,
+				url=url,
+				headers=headers,
+				json=json,
+				data=data,
+				params=params,
+				timeout=timeout or self.__info.timeout,
+				**kwargs,
+			)
+		except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+			raise MailServerUnavailableError() from e
 
 		raise_for_status(response)
 
@@ -190,7 +214,16 @@ class JMAPConnection:
 
 
 def raise_for_status(response: requests.Response) -> None:
-	"""Raises an HTTPError if the response status code indicates an error."""
+	"""Raises an HTTPError if the response status code indicates an error.
+
+	Gateway errors (502/503/504) mean the JMAP server behind a reverse proxy is down, not that
+	the request itself was bad, so they surface as MailServerUnavailableError instead.
+	"""
+
+	if response.status_code in UNAVAILABLE_STATUS_CODES:
+		raise MailServerUnavailableError() from requests.exceptions.HTTPError(
+			f"Request failed with status {response.status_code}: {response.text}", response=response
+		)
 
 	if not response.ok:
 		raise requests.exceptions.HTTPError(


### PR DESCRIPTION
Closes https://github.com/frappe/suite/issues/43

When Stalwart is temporarily down, every request failed with an opaque 500 that only surfaced in the browser console — and on initial load the mail app rendered a blank page, because the router guard's awaited mailbox fetch rejected and aborted the first navigation before the app ever mounted.

## Backend

- `JMAPConnection` (the single choke point for all Stalwart traffic — user JMAP and admin/management) now maps connection failures (connection refused, DNS, timeouts) and reverse-proxy gateway responses (502/503/504) to a new `MailServerUnavailableError`.
- The error carries `http_status_code = 503`, so Frappe responds with `503 Service Unavailable` + `exc_type` instead of a generic 500, making outages distinguishable from application bugs. The original `requests` exception is chained for diagnosis.
- Ordinary error statuses (4xx, plain 500 from Stalwart) still raise `HTTPError` unchanged.

## Frontend

- The suite-wide `resourceFetcher` (`boot/config.ts`) detects the `exc_type`, rewrites the error to a friendly translated message (so existing `onError` handlers that toast `error.message` / `error.messages[0]` show clean text), and sets a reactive `mailServerUnavailable` flag.
- Since nothing in mail works without the mail server, `MailLayout` swaps the entire route group (including `noLayout` pages) for a dedicated **"Mail server unavailable"** page with a Retry button, instead of decorating a UI whose every fetch would fail.
- Surfaces without a full-page state (e.g. calendar) get one deduped toast on first detection.
- The mail router guard now tolerates a rejected mailbox fetch, so the initial navigation completes and the app mounts to show the error page (previously: blank page). With no mailbox list to validate against, the requested route is kept rather than redirecting.

## Test plan

- Stop Stalwart, load `/mail` → the unavailable page renders (no blank page); Retry reloads.
- Stop Stalwart mid-session, perform any action → page swaps to the unavailable state.
- 400s from Stalwart still surface as before; `tsc`, the mail vitest suite (24 tests) and the production build pass.