### PR TITLE
feat(mail): show description on hover of SPF, DKIM and DMARC result

### DIFF
--- a/frontend/src/apps/mail/pages/MimeMessageView.vue
+++ b/frontend/src/apps/mail/pages/MimeMessageView.vue
@@ -23,7 +23,10 @@
 					>
 						<div class="text-ink-gray-5 w-full sm:w-1/4">{{ value.label }}</div>
 						<div class="flex w-full items-center break-words sm:w-3/4">
-							{{ value.value }}
+							<Tooltip v-if="value.description" :text="value.description">
+								<span>{{ value.value }}</span>
+							</Tooltip>
+							<template v-else>{{ value.value }}</template>
 						</div>
 					</div>
 				</div>
@@ -46,7 +49,7 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
 import { useRoute } from 'vue-router'
-import { Button, createResource } from 'frappe-ui'
+import { Button, Tooltip, createResource } from 'frappe-ui'
 
 import { copyToClipBoard } from '@/apps/mail/utils'
 
@@ -56,6 +59,7 @@ const message = ref('')
 interface MimeField {
 	label: string
 	value: string
+	description?: string
 }
 
 interface Mime {

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -668,7 +668,7 @@ def get_mime_message(name: str) -> dict:
 
 	result = {
 		"message": doc.message or doc.get_mime_message(),
-		"message_id": {"label": _("Message ID"), "value": doc.message_id},
+		"message_id": {"label": _("Message ID"), "value": f"<{doc.message_id}>"},
 		"created_at": {
 			"label": _("Created at"),
 			"value": _("{0} (Delivered after {1} seconds)").format(
@@ -687,11 +687,20 @@ def get_mime_message(name: str) -> dict:
 		result["spf"] = {
 			"label": _("SPF"),
 			"value": _("{0} with IP {1}").format(pass_or_fail[doc.spf_pass], doc.from_ip),
+			"description": doc.spf_description,
 		}
 	if doc.dkim_description:
-		result["dkim"] = {"label": _("DKIM"), "value": pass_or_fail[doc.dkim_pass]}
+		result["dkim"] = {
+			"label": _("DKIM"),
+			"value": pass_or_fail[doc.dkim_pass],
+			"description": doc.dkim_description,
+		}
 	if doc.dmarc_description:
-		result["dmarc"] = {"label": _("DMARC"), "value": pass_or_fail[doc.dmarc_pass]}
+		result["dmarc"] = {
+			"label": _("DMARC"),
+			"value": pass_or_fail[doc.dmarc_pass],
+			"description": doc.dmarc_description,
+		}
 
 	return result
 


### PR DESCRIPTION
Closes https://github.com/frappe/suite/issues/35

- Include the parsed `Authentication-Results` segment for each check (SPF, DKIM, DMARC) in the `get_mime_message` API response and show it as a tooltip on hover of the result in the MIME message view.
- Wrap the Message ID in angle brackets (`<message_id>`), as noted in the issue comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)