### PR TITLE
fix(mail): focus subject input when its label is clicked

### DIFF
--- a/frontend/src/apps/mail/components/ComposeMailEditor.vue
+++ b/frontend/src/apps/mail/components/ComposeMailEditor.vue
@@ -114,8 +114,7 @@
 					<span class="text-ink-gray-4 text-sm">{{ __('Subject') }}</span>
 					<input
 						v-model="mail.subject"
-						:placeholder="__('Add a subject')"
-						class="placeholder:text-ink-gray-4 flex-1 cursor-text border-none bg-inherit text-base focus-visible:!ring-0"
+						class="flex-1 cursor-text border-none bg-inherit text-base focus-visible:!ring-0"
 					/>
 				</label>
 			</div>

--- a/frontend/src/apps/mail/components/ComposeMailEditor.vue
+++ b/frontend/src/apps/mail/components/ComposeMailEditor.vue
@@ -107,13 +107,17 @@
 						</template>
 					</div>
 				</div>
-				<div v-if="!mailDetails?.type || isMobile" class="flex items-center gap-2">
+				<label
+					v-if="!mailDetails?.type || isMobile"
+					class="flex cursor-text items-center gap-2"
+				>
 					<span class="text-ink-gray-4 text-sm">{{ __('Subject') }}</span>
 					<input
 						v-model="mail.subject"
-						class="flex-1 border-none bg-inherit text-base focus-visible:!ring-0"
+						:placeholder="__('Add a subject')"
+						class="placeholder:text-ink-gray-4 flex-1 cursor-text border-none bg-inherit text-base focus-visible:!ring-0"
 					/>
-				</div>
+				</label>
 			</div>
 		</template>
 		<template #editor="{ editor }">


### PR DESCRIPTION
The composer's subject row was a `<span>` next to a bare `<input>`, so clicking the "Subject" text did nothing and the field didn't read as editable.

Wrapped the row in a `<label>` (whole row is now a click target that focuses the input) and added a placeholder.

Closes #60