### PR TITLE
fix(mail): anchor keyboard multi-selection instead of toggling rows

### DIFF
--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -575,6 +575,7 @@ import {
 	useSwipeNav,
 	useUndo,
 } from '@/apps/mail/utils/composables'
+import { rangeSelection } from '@/apps/mail/utils/rangeSelection'
 import { buildListRows } from '@/apps/mail/utils/threadStacks'
 import { useThreadActions } from '@/apps/mail/utils/useThreadActions'
 import { type MailboxRole, userStore } from '@/apps/mail/stores/user'
@@ -819,6 +820,12 @@ const moreSelectionOptions = computed(() => [
 ])
 const lastSelected = ref<string[]>()
 
+// An in-progress shift+arrow range: where it began (every thread that row stands for) and what was
+// already selected then. Held across steps so each one recomputes anchor..cursor (see rangeSelection)
+// instead of toggling the rows it passes — the toggle was asymmetric, shrinking the range from below
+// dropped both the row being left and the row being entered.
+const keyboardRange = ref<{ anchorIDs: string[]; base: string[] }>()
+
 const isAllSelected = computed(
 	() => threadIDs.value.length && selections.value.length === threadIDs.value.length,
 )
@@ -828,18 +835,14 @@ const isAllSelected = computed(
 // exactly the thing being asked for, at the worst moment. Nothing is concealed by staying collapsed:
 // the header or stack row shows its own checkbox ticked, and the toolbar counts individual threads.
 
-const toggleSelect = (
-	threadIDs: string[],
-	selected: boolean,
-	isKeyboardSelect: boolean = false,
-) => {
-	const allIDs = new Set([
-		...threadIDs,
-		...(isKeyboardSelect ? [] : getShiftSelectedIDs(threadIDs[0])),
-	])
+const toggleSelect = (threadIDs: string[], selected: boolean) => {
+	const allIDs = new Set([...threadIDs, ...getShiftSelectedIDs(threadIDs[0])])
 	if (selected) selections.value = [...new Set([...selections.value, ...allIDs])]
 	else selections.value = selections.value.filter((id) => !allIDs.has(id))
 	lastSelected.value = threadIDs
+	// Ticking a box is a fresh starting point: the next shift+arrow anchors here rather than extending
+	// a range the pointer has since moved away from.
+	keyboardRange.value = undefined
 }
 
 const getShiftSelectedIDs = (thread: string) => {
@@ -862,11 +865,13 @@ const toggleSelectAll = (selected: boolean) => {
 	if (selected) selections.value = [...threadIDs.value]
 	else selections.value = []
 	lastSelected.value = undefined
+	keyboardRange.value = undefined
 }
 
 const resetSelections = () => {
 	selections.value = []
 	lastSelected.value = undefined
+	keyboardRange.value = undefined
 }
 
 const isGroupSelected = (key: string) =>
@@ -1017,7 +1022,9 @@ const handleArrowNavigation = (e: KeyboardEvent, key: string) => {
 	e.preventDefault()
 
 	const offset = ['arrowup', 'k'].includes(key) ? -1 : 1
-	const prevIDs = focusedRow.value ? rowThreadIDs(focusedRow.value) : []
+	// Where a range would begin if this keypress starts one: the threads being stepped off — the open
+	// thread in the reading pane, everything the cursor's row stands for in the list.
+	const fromIDs = threadID ? [threadID] : focusedRow.value ? rowThreadIDs(focusedRow.value) : []
 
 	let newIDs: string[] = []
 
@@ -1044,10 +1051,17 @@ const handleArrowNavigation = (e: KeyboardEvent, key: string) => {
 
 	// Handle shift+arrow selection. A row carries every thread it stands for, so shifting onto a stack
 	// takes its whole run and onto a header takes the day — the same sets their checkboxes select.
-	if (!(isShiftPressed.value && newIDs.length)) return
+	// Moving without Shift ends the range, so the next one anchors where the cursor now is.
+	if (!isShiftPressed.value) return (keyboardRange.value = undefined)
+	if (!newIDs.length) return
 
-	const shouldSelect = !newIDs.every((id) => selections.value.includes(id))
-	toggleSelect([...prevIDs, ...newIDs], shouldSelect, true)
+	const { anchorIDs, base } = (keyboardRange.value ??= {
+		anchorIDs: fromIDs,
+		base: [...selections.value],
+	})
+	selections.value = rangeSelection(threadIDs.value, anchorIDs, newIDs, base)
+	// A shift+click afterwards extends from wherever the keyboard left the cursor.
+	lastSelected.value = newIDs
 }
 
 const handleKeyUp = (e: KeyboardEvent) => {

--- a/frontend/src/apps/mail/utils/rangeSelection.test.ts
+++ b/frontend/src/apps/mail/utils/rangeSelection.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { rangeSelection } from './rangeSelection'
+
+const order = ['t1', 't2', 't3', 't4', 't5']
+
+describe('rangeSelection', () => {
+	it('spans both ends of the range', () => {
+		expect(rangeSelection(order, ['t2'], ['t4'])).toEqual(['t2', 't3', 't4'])
+	})
+
+	it('reads the same in either direction', () => {
+		expect(rangeSelection(order, ['t4'], ['t2'])).toEqual(['t2', 't3', 't4'])
+	})
+
+	// The bug: walking up then back down used to drop two rows per step, because each step toggled the
+	// row it left as well as the row it entered. Recomputing from the anchor gives back exactly one.
+	it('gives back one row per step when the cursor walks back', () => {
+		const anchor = ['t4']
+		expect(rangeSelection(order, anchor, ['t3'])).toEqual(['t3', 't4'])
+		expect(rangeSelection(order, anchor, ['t2'])).toEqual(['t2', 't3', 't4'])
+		expect(rangeSelection(order, anchor, ['t3'])).toEqual(['t3', 't4'])
+		expect(rangeSelection(order, anchor, ['t4'])).toEqual(['t4'])
+	})
+
+	it('takes the whole run an end stands for', () => {
+		expect(rangeSelection(order, ['t3', 't4', 't5'], ['t2'])).toEqual(['t2', 't3', 't4', 't5'])
+	})
+
+	it('keeps what was already selected when the range began', () => {
+		expect(rangeSelection(order, ['t4'], ['t3'], ['t1'])).toEqual(['t1', 't3', 't4'])
+		// ...including rows inside the range, which shrinking must not clear.
+		expect(rangeSelection(order, ['t4'], ['t4'], ['t3'])).toEqual(['t3', 't4'])
+	})
+
+	it('ignores an end that is no longer loaded', () => {
+		expect(rangeSelection(order, ['gone'], ['t2'])).toEqual(['t2'])
+		expect(rangeSelection(order, ['gone'], ['also-gone'], ['t1'])).toEqual(['t1'])
+	})
+})

--- a/frontend/src/apps/mail/utils/rangeSelection.ts
+++ b/frontend/src/apps/mail/utils/rangeSelection.ts
@@ -1,0 +1,32 @@
+/**
+ * The selection a keyboard range spans, computed from its two ends rather than stepped into existence.
+ *
+ * Shift+arrow selects a range: one end is the anchor (the row the cursor sat on when the range began),
+ * the other is the row the cursor is on now, and everything between them is in. Recomputing the whole
+ * range on every step is what makes it symmetric — walking back the way you came drops exactly the row
+ * you left, where flipping rows one at a time on the way past unselected the row being left *and* the
+ * row being entered.
+ *
+ * Both ends are given as thread runs, not single ids, because a row can stand for several threads — a
+ * stack for its members, a date header for its day. Those runs are contiguous in `order` (the loaded
+ * threads in list order), so the range is simply the slice between the outermost indexes of the two.
+ *
+ * `base` is whatever was already selected when the range began. It rides through untouched, so
+ * shrinking the range gives back only what the range itself selected.
+ */
+export const rangeSelection = (
+	order: string[],
+	anchorIDs: string[],
+	cursorIDs: string[],
+	base: string[] = [],
+): string[] => {
+	// A row can outlive the loaded list (a mutation dropped it, a refresh replaced the window); ignore
+	// such an end rather than letting indexOf's -1 stretch the range to the top of the list.
+	const indexes = [...anchorIDs, ...cursorIDs]
+		.map((id) => order.indexOf(id))
+		.filter((index) => index !== -1)
+	if (!indexes.length) return [...new Set(base)]
+
+	const range = order.slice(Math.min(...indexes), Math.max(...indexes) + 1)
+	return [...new Set([...base, ...range])]
+}


### PR DESCRIPTION
Shift+arrow toggled the row being left along with the row being entered, so walking back down a keyboard selection removed two rows per step.

The range now keeps an anchor (plus whatever was selected when it began) and recomputes anchor..cursor on every step, so it grows and shrinks by one row in either direction.

Closes #161