### PR TITLE
fix(mail): keep attachment blob URLs alive so Safari can download them

### DIFF
--- a/frontend/src/apps/mail/components/AttachmentCapsule.vue
+++ b/frontend/src/apps/mail/components/AttachmentCapsule.vue
@@ -55,8 +55,13 @@ const downloadAttachment = async () => {
 	if (!blobID) return
 
 	isDownloading.value = true
-	const url = await getAttachmentUrl(blobID, type)
-	downloadUrlAsFile(url, fileName || 'attachment')
-	isDownloading.value = false
+	try {
+		const url = await getAttachmentUrl(blobID, type)
+		downloadUrlAsFile(url, fileName || 'attachment')
+	} catch {
+		// the resource's onError already raised a toast; just stop spinning
+	} finally {
+		isDownloading.value = false
+	}
 }
 </script>

--- a/frontend/src/apps/mail/components/AttachmentViewer.vue
+++ b/frontend/src/apps/mail/components/AttachmentViewer.vue
@@ -172,7 +172,7 @@ import {
 import { Button } from 'frappe-ui'
 
 import { fetchAttachment, getAttachmentUrl } from '@/apps/mail/resources'
-import { getFileIcon } from '@/apps/mail/utils'
+import { getFileIcon, revokeObjectUrlAfterDownload } from '@/apps/mail/utils'
 import { useScreenSize } from '@/apps/mail/utils/composables'
 
 import type { Attachment } from '@/apps/mail/types'
@@ -196,12 +196,23 @@ const isVideo = computed(() => currentAttachment.value?.type?.startsWith('video/
 const isAudio = computed(() => currentAttachment.value?.type?.startsWith('audio/'))
 const canPrint = computed(() => isImage.value || isPDF.value)
 
+// Set to the preview URL a download was started from: Safari fetches the blob after
+// the click returns, so that URL has to outlive the viewer (see downloadUrlAsFile).
+const downloadedUrl = ref<string | null>(null)
+
+const releasePreview = () => {
+	if (!previewUrl.value) return
+
+	if (previewUrl.value === downloadedUrl.value) revokeObjectUrlAfterDownload(previewUrl.value)
+	else URL.revokeObjectURL(previewUrl.value)
+
+	downloadedUrl.value = null
+	previewUrl.value = null
+}
+
 const closeViewer = () => {
 	show.value = false
-	if (previewUrl.value) {
-		URL.revokeObjectURL(previewUrl.value)
-		previewUrl.value = null
-	}
+	releasePreview()
 }
 
 const previousAttachment = () => {
@@ -215,24 +226,30 @@ const nextAttachment = () => {
 const loadAttachment = async () => {
 	if (!currentAttachment.value?.blob_id) return
 
-	if (previewUrl.value) {
-		URL.revokeObjectURL(previewUrl.value)
-		previewUrl.value = null
-	}
+	releasePreview()
 
-	previewUrl.value = await getAttachmentUrl(
-		currentAttachment.value.blob_id,
-		currentAttachment.value.type,
-	)
+	try {
+		previewUrl.value = await getAttachmentUrl(
+			currentAttachment.value.blob_id,
+			currentAttachment.value.type,
+		)
+	} catch {
+		// the resource's onError already raised a toast; the viewer falls back to
+		// its "Failed to load attachment" state
+	}
 }
 
 const downloadAttachment = () => {
 	if (!currentAttachment.value?.blob_id || !previewUrl.value) return
 
 	isDownloading.value = true
+	// Not downloadUrlAsFile(): this URL is still bound to the <img>/<embed> on screen,
+	// so releasePreview() owns revoking it.
+	downloadedUrl.value = previewUrl.value
 	const link = document.createElement('a')
 	link.href = previewUrl.value
 	link.download = currentAttachment.value?.filename || 'attachment'
+	link.rel = 'noopener'
 	document.body.appendChild(link)
 	link.click()
 	document.body.removeChild(link)
@@ -307,5 +324,8 @@ const handleKeyDown = (event: KeyboardEvent) => {
 }
 
 onMounted(() => window.addEventListener('keydown', handleKeyDown))
-onUnmounted(() => window.removeEventListener('keydown', handleKeyDown))
+onUnmounted(() => {
+	window.removeEventListener('keydown', handleKeyDown)
+	releasePreview()
+})
 </script>

--- a/frontend/src/apps/mail/components/AttachmentViewer.vue
+++ b/frontend/src/apps/mail/components/AttachmentViewer.vue
@@ -249,7 +249,6 @@ const downloadAttachment = () => {
 	const link = document.createElement('a')
 	link.href = previewUrl.value
 	link.download = currentAttachment.value?.filename || 'attachment'
-	link.rel = 'noopener'
 	document.body.appendChild(link)
 	link.click()
 	document.body.removeChild(link)

--- a/frontend/src/apps/mail/components/ComposeMailEditor.vue
+++ b/frontend/src/apps/mail/components/ComposeMailEditor.vue
@@ -588,8 +588,17 @@ watch(
 const openAttachment = async (blob_id?: string, type?: string) => {
 	if (!blob_id) return
 
-	const url = await getAttachmentUrl(blob_id, type)
-	window.open(url, '_blank')
+	// Opened up front, while the click's user activation is still live: Safari blocks
+	// window.open() once the gesture has expired, which it has by the time the
+	// attachment has been fetched.
+	const tab = window.open('', '_blank')
+	try {
+		const url = await getAttachmentUrl(blob_id, type)
+		if (tab) tab.location.href = url
+		else window.open(url, '_blank')
+	} catch {
+		tab?.close()
+	}
 }
 
 // Custom Extensions

--- a/frontend/src/apps/mail/components/ComposeMailEditor.vue
+++ b/frontend/src/apps/mail/components/ComposeMailEditor.vue
@@ -590,14 +590,15 @@ const openAttachment = async (blob_id?: string, type?: string) => {
 
 	// Opened up front, while the click's user activation is still live: Safari blocks
 	// window.open() once the gesture has expired, which it has by the time the
-	// attachment has been fetched.
+	// attachment has been fetched. A null tab means the popup blocker got it —
+	// retrying after the fetch would hit the same block, so just say so.
 	const tab = window.open('', '_blank')
+	if (!tab) return raiseToast(__('Allow popups to open attachments.'), 'error')
+
 	try {
-		const url = await getAttachmentUrl(blob_id, type)
-		if (tab) tab.location.href = url
-		else window.open(url, '_blank')
+		tab.location.href = await getAttachmentUrl(blob_id, type)
 	} catch {
-		tab?.close()
+		tab.close()
 	}
 }
 

--- a/frontend/src/apps/mail/components/MailListItem.vue
+++ b/frontend/src/apps/mail/components/MailListItem.vue
@@ -256,17 +256,15 @@ const currentlyDownloading = ref<string[]>([])
 
 const downloadAttachment = async (attachment: Attachment) => {
 	currentlyDownloading.value.push(attachment.blob_id)
-	const url = await getAttachmentUrl(attachment.blob_id, attachment.type)
-	if (!url) {
+	try {
+		const url = await getAttachmentUrl(attachment.blob_id, attachment.type)
+		if (url) downloadUrlAsFile(url, attachment.filename || 'attachment')
+	} catch {
+		// the resource's onError already raised a toast; just stop spinning
+	} finally {
 		currentlyDownloading.value = currentlyDownloading.value.filter(
 			(id) => id !== attachment.blob_id,
 		)
-		return
 	}
-
-	downloadUrlAsFile(url, attachment.filename || 'attachment')
-	currentlyDownloading.value = currentlyDownloading.value.filter(
-		(id) => id !== attachment.blob_id,
-	)
 }
 </script>

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -850,6 +850,8 @@ const downloadAttachmentsAsZip = async (mail: Mail) => {
 	try {
 		const url = await getAttachmentsZipUrl(mailAttachments)
 		downloadUrlAsFile(url, `${mail.subject || 'attachments'}.zip`)
+	} catch {
+		// the resource's onError already raised a toast; just stop spinning
 	} finally {
 		downloadingZipMail.value = null
 	}

--- a/frontend/src/apps/mail/pages/dashboard/DomainView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/DomainView.vue
@@ -74,7 +74,7 @@ import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { Dialog, Dropdown, createResource, usePageMeta } from 'frappe-ui'
 
-import { raiseToast } from '@/apps/mail/utils'
+import { downloadUrlAsFile, raiseToast } from '@/apps/mail/utils'
 import DNSRecords from '@/apps/mail/components/DNSRecords.vue'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 
@@ -160,16 +160,7 @@ const downloadFile = (content: string, extension: string, mimeType: string) => {
 	const domainName = (domain.data as DomainData | undefined)?.name || domainId
 	const fileName = `${domainName.replace(/[^a-zA-Z0-9.-]+/g, '_')}.${extension}`
 	const blob = new Blob([content], { type: mimeType })
-	const url = URL.createObjectURL(blob)
-
-	const link = document.createElement('a')
-	link.href = url
-	link.download = fileName
-	document.body.appendChild(link)
-	link.click()
-	document.body.removeChild(link)
-
-	URL.revokeObjectURL(url)
+	downloadUrlAsFile(URL.createObjectURL(blob), fileName)
 }
 
 const downloadDNSZone = createResource({

--- a/frontend/src/apps/mail/utils/index.ts
+++ b/frontend/src/apps/mail/utils/index.ts
@@ -449,12 +449,24 @@ export const getIcon = (mailbox: MailboxData) => {
 export const getMailboxName = (mailbox: MailboxData) =>
 	mailbox._name === SCREENER_MAILBOX_NAME ? __('Screener') : mailbox._name
 
+// Safari reads the blob behind an `<a download>` asynchronously, after the click has
+// already returned, so revoking the object URL in the same tick silently cancels the
+// download. Chrome and Firefox snapshot the blob synchronously, which is why this only
+// shows up on Safari. Keep the URL alive long enough for the browser to read it, then
+// free the blob.
+const DOWNLOAD_URL_TTL = 60_000
+
+export const revokeObjectUrlAfterDownload = (url: string) => {
+	setTimeout(() => URL.revokeObjectURL(url), DOWNLOAD_URL_TTL)
+}
+
 export const downloadUrlAsFile = (url: string, filename: string) => {
 	const link = document.createElement('a')
 	link.href = url
 	link.download = filename
+	link.rel = 'noopener'
 	document.body.appendChild(link)
 	link.click()
 	document.body.removeChild(link)
-	URL.revokeObjectURL(url)
+	revokeObjectUrlAfterDownload(url)
 }

--- a/frontend/src/apps/mail/utils/index.ts
+++ b/frontend/src/apps/mail/utils/index.ts
@@ -464,7 +464,6 @@ export const downloadUrlAsFile = (url: string, filename: string) => {
 	const link = document.createElement('a')
 	link.href = url
 	link.download = filename
-	link.rel = 'noopener'
 	document.body.appendChild(link)
 	link.click()
 	document.body.removeChild(link)


### PR DESCRIPTION
`downloadUrlAsFile()` revoked the object URL in the same tick as the anchor click; Safari fetches the blob after the click returns, so the download never started. Revoke on a delay instead, and reset the download flags in `finally` so a failed fetch no longer leaves the attachment controls stuck spinning until a reload.

Not verified in Safari itself — reasoned from the code.

Closes #300