### PR TITLE
fix(mail): resolve theme before first paint on pre-login screens

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,6 +12,47 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, user-scalable=no"
     />
+
+    <script>
+      // Resolve the theme BEFORE the first paint. The attributes above are rendered from
+      // User.desk_theme, which the server only knows for an authenticated session — a Guest
+      // always gets 'light', so the login/signup screens used to flash white on a dark
+      // machine. Mail also keeps its own preference (User Settings.color_scheme), which is
+      // only known once its boot data arrives. So for /mail: use the last mode applied on
+      // this device, else the OS preference for guests, else the server value. Other apps
+      // keep the server value untouched. Storage key mirrors composables.ts THEME_MODE_KEY.
+      ;(function () {
+        if (!/^\/mail(\/|$)/.test(location.pathname)) return
+
+        var root = document.documentElement
+        var modes = ['automatic', 'light', 'dark']
+        var stored = null
+        try {
+          stored = localStorage.getItem('mail-theme-mode')
+        } catch (e) {
+          // Storage can be unavailable (private mode / blocked cookies) — fall through.
+        }
+
+        var userID = document.cookie.match(/(?:^|;\s*)user_id=([^;]*)/)
+        var isGuest = !userID || decodeURIComponent(userID[1]) === 'Guest'
+        var server = root.getAttribute('data-theme-mode')
+        if (modes.indexOf(server) === -1) server = 'light'
+
+        var mode = modes.indexOf(stored) !== -1 ? stored : isGuest ? 'automatic' : server
+        var resolved = mode
+        if (mode === 'automatic') {
+          resolved = window.matchMedia('(prefers-color-scheme: dark)').matches
+            ? 'dark'
+            : 'light'
+        }
+
+        root.setAttribute('data-theme-mode', mode)
+        root.setAttribute('data-theme', resolved)
+        // Paints the browser's default canvas (and native widgets) dark too, so there is
+        // nothing white on screen before the stylesheet lands.
+        root.style.colorScheme = resolved
+      })()
+    </script>
   </head>
   <body>
     <div id="app" class="h-screen"></div>

--- a/frontend/src/apps/mail/pages/MailLayout.vue
+++ b/frontend/src/apps/mail/pages/MailLayout.vue
@@ -39,7 +39,7 @@ import type { NotificationPayload } from '@/apps/mail/types'
  * do not need the $user/$dayjs/$socket injects.
  */
 const { userResource } = userStore()
-const { dataTheme, cycleTheme } = useTheme()
+const { applyTheme, cycleTheme } = useTheme()
 const { isMobile } = useScreenSize()
 const route = useRoute()
 
@@ -52,7 +52,9 @@ const Layout = computed(() => {
 	return DefaultLayout
 })
 
-watchEffect(() => document.documentElement.setAttribute('data-theme', dataTheme.value))
+// Keeps <html data-theme> (and the mode remembered for the next load, so pre-login screens
+// don't flash — see index.html) in step with the user's color scheme.
+watchEffect(applyTheme)
 
 // Mark <body> while mail is mounted so the base styles below (see <style>) can reach frappe-ui
 // Dialogs/Dropdowns, which teleport to <body> — OUTSIDE .mail-app-root. Without this, their

--- a/frontend/src/apps/mail/utils/composables.ts
+++ b/frontend/src/apps/mail/utils/composables.ts
@@ -397,14 +397,60 @@ mediaQuery.addEventListener('change', () => (systemIsDark.value = mediaQuery.mat
 
 const COLOR_SCHEME_CYCLE = ['System Default', 'Light Mode', 'Dark Mode'] as const
 
+type ThemeMode = 'automatic' | 'light' | 'dark'
+
+const THEME_MODES: Record<COLOR_SCHEME, ThemeMode> = {
+	'System Default': 'automatic',
+	'Light Mode': 'light',
+	'Dark Mode': 'dark',
+}
+
+// The applied mode is mirrored here so the pre-paint script in index.html can restore it on
+// the next load — the server-rendered <html data-theme> only knows User.desk_theme, and only
+// for an authenticated session, so without this the login screens (and the frames before
+// boot data lands) flash light. Keep the key in sync with index.html.
+const THEME_MODE_KEY = 'mail-theme-mode'
+
+const readThemeMode = (): ThemeMode => {
+	try {
+		const stored = localStorage.getItem(THEME_MODE_KEY)
+		if (stored === 'automatic' || stored === 'light' || stored === 'dark') return stored
+	} catch {
+		// Storage can be unavailable (private mode / blocked cookies) — follow the OS.
+	}
+	return 'automatic'
+}
+
+// Read once, at load: from here on the user's own color scheme (once fetched) is the source
+// of truth, and this only fills the gap before it arrives.
+const storedThemeMode = readThemeMode()
+
 export const useTheme = () => {
 	const { userResource } = userStore()
 
-	const dataTheme = computed(() => {
-		const colorScheme = userResource.data?.color_scheme || 'System Default'
-		if (colorScheme === 'System Default') return systemIsDark.value ? 'dark' : 'light'
-		return colorScheme === 'Dark Mode' ? 'dark' : 'light'
+	const themeMode = computed<ThemeMode>(() => {
+		const colorScheme = userResource.data?.color_scheme
+		return colorScheme ? THEME_MODES[colorScheme] : storedThemeMode
 	})
+
+	const dataTheme = computed(() => {
+		if (themeMode.value === 'automatic') return systemIsDark.value ? 'dark' : 'light'
+		return themeMode.value
+	})
+
+	// Applied by MailLayout (the mounted mail root) on every change.
+	const applyTheme = () => {
+		const root = document.documentElement
+		root.setAttribute('data-theme', dataTheme.value)
+		root.setAttribute('data-theme-mode', themeMode.value)
+		root.style.colorScheme = dataTheme.value
+
+		try {
+			localStorage.setItem(THEME_MODE_KEY, themeMode.value)
+		} catch {
+			// Nothing to remember with — the next load just falls back to the OS.
+		}
+	}
 
 	const updateColorScheme = createResource({
 		url: 'frappe.client.set_value',
@@ -438,5 +484,5 @@ export const useTheme = () => {
 		})
 	}
 
-	return { dataTheme, cycleTheme }
+	return { dataTheme, applyTheme, cycleTheme }
 }


### PR DESCRIPTION
`<html data-theme>` is rendered from `User.desk_theme`, which the server only knows for an authenticated session — Guests always get `light`, so the login/signup/reset screens flashed white on a dark machine.

A blocking script in `<head>` now resolves the theme from the last mode applied on this device (localStorage), falling back to `prefers-color-scheme` for guests; the fetched `color_scheme` takes over once boot data lands. Other apps keep the server-rendered desk theme untouched.

Closes #1