### PR TITLE
fix(mail): return message timestamps in UTC, not system time

### DIFF
--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -56,6 +56,7 @@ from suite.mail.jmap import (
 )
 from suite.mail.store import get_email_address_index
 from suite.mail.utils import get_config, log_mail_error
+from suite.mail.utils.dt import to_utc_z
 from suite.mail.utils.user import get_account_emails, is_jmap_configured
 from suite.mail.utils.validation import normalize_screened_value, validate_screened_value
 from suite.utils import convert_html_to_text
@@ -387,7 +388,6 @@ def serialize_thread(messages: list[dict], thread_messages: list[dict], latest: 
 		"thread_id",
 		"from_name",
 		"from_email",
-		"received_at",
 		"recipients",
 		"draft",
 		"preview",
@@ -395,6 +395,8 @@ def serialize_thread(messages: list[dict], thread_messages: list[dict], latest: 
 	return {
 		**{field: current[field] for field in current_fields},
 		**{field: latest[field] for field in activity_fields},
+		# Message timestamps are held in system time (see `format_message`); the wire is UTC.
+		"received_at": to_utc_z(latest["received_at"]),
 		"subject": first["subject"],
 		"attachments": serialize_attachments(latest.get("attachments", [])),
 		"messages": [serialize_mail(message) for message in thread_messages],
@@ -414,7 +416,6 @@ def serialize_mail(mail: dict) -> dict:
 		"subject",
 		"html_body",
 		"preview",
-		"received_at",
 		"draft",
 		"seen",
 		"junk",
@@ -429,6 +430,8 @@ def serialize_mail(mail: dict) -> dict:
 	html = mail.get("html_body") or ""
 	return {
 		**{field: mail[field] for field in mail_fields},
+		# Message timestamps are held in system time (see `format_message`); the wire is UTC.
+		"received_at": to_utc_z(mail["received_at"]),
 		"text_body": "" if html else mail.get("text_body", ""),
 		"attachments": serialize_attachments(mail.get("attachments", [])),
 	}

--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -35,6 +35,7 @@ from suite.mail.utils import (
 	get_config,
 	log_mail_error,
 )
+from suite.mail.utils.dt import to_utc_z
 from suite.mail.utils.email_parser import EmailParser
 from suite.mail.utils.logger import get_push_logger
 from suite.mail.utils.user import get_account_emails, get_sync_state, update_sync_state
@@ -773,8 +774,6 @@ def search_messages(
 		"subject",
 		"preview",
 		"recipients",
-		"sent_at",
-		"received_at",
 		"from_name",
 		"from_email",
 		"thread_id",
@@ -782,9 +781,18 @@ def search_messages(
 		"attachments",
 		"seen",
 	]
+	# Held in system time (see `format_message`), but this projection is an API payload, and the wire
+	# is UTC.
+	datetime_fields = ["sent_at", "received_at"]
 
 	messages, total = fetch_messages(account, filter=filter, position=position, limit=limit, sort=sort)
-	return [{field: message[field] for field in fields} for message in messages], total
+	return [
+		{
+			**{field: message[field] for field in fields},
+			**{field: to_utc_z(message[field]) for field in datetime_fields},
+		}
+		for message in messages
+	], total
 
 
 def get_messages(account: str, ids: list[str]) -> list[dict]:


### PR DESCRIPTION
`format_message` converts Stalwart's UTC `receivedAt`/`sentAt` into the site's system timezone, and the mail APIs shipped that naive string as-is — the client parses it as browser-local, so every timestamp is off by (system tz − reader tz). Vienna reader on an Asia/Kolkata site sees mail dated 3.5 hours in the future.

Converts to the `...Z` UTC wire format the mail APIs already document at the three points message dicts become payloads: `serialize_thread`, `serialize_mail`, `search_messages`.

Closes #56