### PR TITLE
fix(mail): keep the composed mail across the mobile breakpoint

### DIFF
--- a/frontend/src/apps/mail/components/ComposeMailEditor.vue
+++ b/frontend/src/apps/mail/components/ComposeMailEditor.vue
@@ -307,12 +307,6 @@ const insertContacts = (insertInto: string) => {
 	showContactsModal.value = true
 }
 
-const showCcBcc = ref(!!mailDetails?.cc?.length || !!mailDetails?.bcc?.length)
-const toggleCcBcc = () => {
-	showCcBcc.value = !showCcBcc.value
-	if (showCcBcc.value) nextTick(() => ccInput.value?.setFocus())
-}
-
 const appendEmoji = (emoji: string) => {
 	textEditor.value.editor.commands.insertContent(emoji)
 	textEditor.value.editor.commands.focus()
@@ -341,21 +335,40 @@ const getDefaultFromEmail = () => {
 	)
 }
 
-const mail = reactive<ComposeMailData>({
-	name: mailDetails?.name || '',
-	id: mailDetails?.id || '',
-	from_email: getDefaultFromEmail(),
-	to: mailDetails?.to || [],
-	cc: mailDetails?.cc || [],
-	bcc: mailDetails?.bcc || [],
-	attachments: mailDetails?.attachments || [],
-	subject: mailDetails?.subject || '',
-	html_body: mailDetails?.html_body || '',
-	quoted_content: mailDetails?.quoted_content || '',
-	in_reply_to: mailDetails?.in_reply_to || '',
-	in_reply_to_id: mailDetails?.in_reply_to_id || '',
-	forwarded_from_id: mailDetails?.forwarded_from_id || '',
-})
+// The mail being written outlives this editor: its host swaps components when the window
+// crosses the mobile breakpoint (Dialog ⇄ slide-up sheet), which remounts the editor. So the
+// draft is published to the parent — which sits above that swap — and a remounted instance
+// picks the very same reactive object back up instead of opening blank.
+const draft = defineModel<ComposeMailData>('draft')
+
+const mail =
+	draft.value ??
+	reactive<ComposeMailData>({
+		name: mailDetails?.name || '',
+		id: mailDetails?.id || '',
+		from_email: getDefaultFromEmail(),
+		to: mailDetails?.to || [],
+		cc: mailDetails?.cc || [],
+		bcc: mailDetails?.bcc || [],
+		attachments: mailDetails?.attachments || [],
+		subject: mailDetails?.subject || '',
+		html_body: mailDetails?.html_body || '',
+		quoted_content: mailDetails?.quoted_content || '',
+		in_reply_to: mailDetails?.in_reply_to || '',
+		in_reply_to_id: mailDetails?.in_reply_to_id || '',
+		forwarded_from_id: mailDetails?.forwarded_from_id || '',
+	})
+
+draft.value = mail
+
+// Read off `mail` rather than the props, so a draft carried across the breakpoint reopens
+// with its Cc/Bcc rows showing — the toggle that reveals them hides itself once either is
+// filled, which would otherwise leave those recipients unreachable.
+const showCcBcc = ref(!!mail.cc?.length || !!mail.bcc?.length)
+const toggleCcBcc = () => {
+	showCcBcc.value = !showCcBcc.value
+	if (showCcBcc.value) nextTick(() => ccInput.value?.setFocus())
+}
 
 const originalMail = ref<ComposeMailData>()
 const updateOriginalMail = () => (originalMail.value = JSON.parse(JSON.stringify(mail)))

--- a/frontend/src/apps/mail/components/SendMail.vue
+++ b/frontend/src/apps/mail/components/SendMail.vue
@@ -12,6 +12,7 @@
 				v-if="show || !isMobile"
 				ref="composeMailEditor"
 				v-model="show"
+				v-model:draft="draft"
 				:mail-details
 				:reload-mails="() => emit('reloadMails')"
 				@discard-mail="emit('discardMail')"
@@ -21,7 +22,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, useTemplateRef } from 'vue'
+import { onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
 import { Dialog } from 'frappe-ui'
 
 import { useScreenSize } from '@/apps/mail/utils/composables'
@@ -37,6 +38,21 @@ const { mailDetails } = defineProps<{ mailDetails?: ComposeMailData }>()
 const emit = defineEmits(['reloadMails', 'discardMail'])
 
 const { isMobile } = useScreenSize()
+
+// Crossing the breakpoint swaps the wrapper above, and the editor is unmounted along with
+// it — so the mail being written is held here, outside the swap, and handed straight back
+// to the instance that takes its place. Released when the composer closes (and whenever it
+// is handed a different draft), so the next one opens fresh.
+const draft = ref<ComposeMailData>()
+
+watch(show, (val) => {
+	if (!val) draft.value = undefined
+})
+
+watch(
+	() => mailDetails,
+	() => (draft.value = undefined),
+)
 
 const editor = useTemplateRef('composeMailEditor')
 


### PR DESCRIPTION
Crossing 640px while composing swapped the composer's wrapper (`Dialog` ⇄ mobile sheet), unmounting the editor and with it the `mail` reactive holding everything typed — the replacement instance opened blank (the text survived only as an auto-saved draft, hence the reload trick).

The draft now lives in `SendMail`, above the swap, and is handed to whichever editor instance takes over; it's released when the composer closes so the next one opens fresh.

Closes #38