### PR TITLE
fix(sheets): stop filter/pivot range outline from displacing the grid

### DIFF
--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -1957,6 +1957,10 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
     // included here.
     getCellRect: (r, c) => ({ x: geo.colX(c) * _zoom, y: geo.rowY(r) * _zoom,
                               width: geo.cw(c) * _zoom, height: geo.rh(r) * _zoom }),
+    // Physical size of the visible grid viewport (the grid-wrap content box), in
+    // CSS px. Cached in _applyCanvasSize, so reading it is reflow-free — used by
+    // DOM overlays to clamp themselves to what's on screen.
+    getViewportSize: () => ({ w: _viewportW, h: _viewportH }),
     setDiffOverlay, setActiveDiffSheet,
     autoFitCol, autoFitRow, autoGrowRowFor,
     expandRows, getTotalRows, isNearBottom,

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -2719,7 +2719,11 @@ const filterHighlightStyle = computed(() => {
   const br = grid.getCellRect?.(r1, c1)
   if (!tl || !br) return null
   const zoom    = grid.getZoom?.() ?? 1
-  const { w: viewW, h: viewH } = grid.getViewportSize?.() ?? { w: Infinity, h: Infinity }
+  // `|| Infinity` treats a 0/undefined viewport (before the first layout) as
+  // "unclamped" — a 0 would otherwise collapse the overlay to nothing.
+  const vp    = grid.getViewportSize?.()
+  const viewW = vp?.w || Infinity
+  const viewH = vp?.h || Infinity
   return overlayRectStyle(tl, br, {
     headerX: ROW_HEADER_W * zoom,
     headerY: COL_HEADER_H * zoom,

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -560,9 +560,13 @@
 
         <!-- Filter by values -->
         <template v-if="filterPanel.mode === 'values'">
+          <!-- When a search is active these act on the *shown* matches only
+               (Google-Sheets behaviour). Relabel so it's obvious — otherwise
+               "Clear" during a search reads as "clear everything" and silently
+               leaves the hidden values checked. -->
           <div class="sn-fp-vlinks">
-            <Button variant="ghost" size="sm" label="Select all" @click="selectAllFilterValues" />
-            <Button variant="ghost" size="sm" label="Clear" @click="clearAllFilterValues" />
+            <Button variant="ghost" size="sm" :label="valueSearchActive ? 'Select shown' : 'Select all'" @click="selectAllFilterValues" />
+            <Button variant="ghost" size="sm" :label="valueSearchActive ? 'Clear shown'  : 'Clear'"      @click="clearAllFilterValues" />
             <span class="sn-fp-count">Displaying {{ filterPanel.valueSet.size }}</span>
           </div>
           <FormControl
@@ -1233,6 +1237,7 @@ import { userInitials } from '../../utils/session.js'
 import { parseNumberFmt, buildNumberFmt, applyNumberFmt } from '../../utils/format-number.js'
 import { getTextWrap } from '../../utils/text-wrap.js'
 import { autoCloseKey } from '../../utils/formula-autoclose.js'
+import { overlayRectStyle } from '../../utils/overlay-rect.js'
 import { isCanvasClipboardTarget } from '../../utils/clipboard-target.js'
 import { computeFillDown, computeFillRight } from '../../engine/fill-series.js'
 import { detectSeries }                       from '../../engine/patterns/index.js'
@@ -2019,6 +2024,10 @@ const filteredFilterValues = computed(() => {
   return filterPanel.allValues.filter(v => String(v).toLowerCase().includes(q))
 })
 
+// True while the value search box narrows the list — Select all / Clear then
+// act on the shown subset, so their labels change to say so.
+const valueSearchActive = computed(() => filterPanel.valueSearch.trim() !== '')
+
 function toggleFilterValue(v) {
   if (filterPanel.valueSet.has(v)) filterPanel.valueSet.delete(v)
   else                             filterPanel.valueSet.add(v)
@@ -2710,23 +2719,12 @@ const filterHighlightStyle = computed(() => {
   const br = grid.getCellRect?.(r1, c1)
   if (!tl || !br) return null
   const zoom    = grid.getZoom?.() ?? 1
-  const headerY = COL_HEADER_H * zoom
-  const headerX = ROW_HEADER_W * zoom
-  const right   = br.x + br.width
-  const bottom  = br.y + br.height
-  // No viewport clamp: when the range runs past the viewport the far borders
-  // sit off-screen and the grid-wrap's overflow:hidden clips them (no frame at
-  // the edge); the opaque scrollbar (z-index 16) covers any border landing in
-  // its gutter while it's visible.
-  if (bottom <= headerY || right <= headerX) return null
-  const top  = Math.max(tl.y, headerY)
-  const left = Math.max(tl.x, headerX)
-  return {
-    top:    top  + 'px',
-    left:   left + 'px',
-    width:  (right  - left) + 'px',
-    height: (bottom - top)  + 'px',
-  }
+  const { w: viewW, h: viewH } = grid.getViewportSize?.() ?? { w: Infinity, h: Infinity }
+  return overlayRectStyle(tl, br, {
+    headerX: ROW_HEADER_W * zoom,
+    headerY: COL_HEADER_H * zoom,
+    viewW, viewH,
+  })
 })
 
 // Per-sub-sheet peer dots — small colored circles next to each tab label
@@ -3280,6 +3278,13 @@ function _setupGridInstance() {
   grid.onRender(() => { renderVersion.value++ })
 }
 
+function _pinGridWrapScroll() {
+  const wrap = gridWrapRef.value
+  if (!wrap) return
+  if (wrap.scrollTop)  wrap.scrollTop = 0
+  if (wrap.scrollLeft) wrap.scrollLeft = 0
+}
+
 function _setupEventListeners() {
   canvasRef.value.addEventListener('contextmenu', _onCanvasContextMenu)
   // computeSelectionStats fires from the grid's onSelect callback on every
@@ -3291,6 +3296,12 @@ function _setupEventListeners() {
     grid.resize(width, height)
   })
   ro.observe(gridWrapRef.value)
+  // Safety net: the grid-wrap must never scroll natively — all scrolling flows
+  // through the canvas + custom scrollbars, so its scrollTop/Left are meant to
+  // stay 0. An overlay taller/wider than the viewport can still give it
+  // scrollable overflow, and a stray focus/scrollIntoView then scrolls it,
+  // dragging the canvas off-position. Pin it back the instant that happens.
+  gridWrapRef.value.addEventListener('scroll', _pinGridWrapScroll, { passive: true })
   window.addEventListener('keydown',      onGlobalKey)
   window.addEventListener('beforeunload', onBeforeUnloadGuard)
   document.addEventListener('paste',     onDocPaste)
@@ -3380,6 +3391,7 @@ onBeforeUnmount(() => {
     saveExisting(props.id, currentTitle.value, { keepalive: true })
   }
   window.removeEventListener('beforeunload', onBeforeUnloadGuard)
+  gridWrapRef.value?.removeEventListener('scroll', _pinGridWrapScroll)
   ro?.disconnect()
   grid?.destroy()
   window.removeEventListener('keydown', onGlobalKey)

--- a/frontend/src/apps/sheets/components/SheetEditor/usePivotIntegration.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/usePivotIntegration.js
@@ -2,6 +2,7 @@ import { ref, computed, watch } from 'vue'
 import { computePivotModel, computePivotModelAsync, pivotDrillDown, writePivotToSheet } from '../../engine/pivot.js'
 import { colLabel, cellId, parseCellId } from '../../utils/cells.js'
 import { COL_HEADER_H, ROW_HEADER_W } from '../../canvas/constants.js'
+import { overlayRectStyle } from '../../utils/overlay-rect.js'
 
 // Styling applied to the pivot's column header row (row 0) and Grand Total
 // row (last row). Matches the Google Sheets look the user asked for.
@@ -153,19 +154,12 @@ export function usePivotIntegration({
     const br = grid.getCellRect?.(ext.r1, ext.c1)
     if (!tl || !br) return null
     const zoom    = grid.getZoom?.() ?? 1
-    const headerY = COL_HEADER_H * zoom
-    const headerX = ROW_HEADER_W * zoom
-    const right   = br.x + br.width
-    const bottom  = br.y + br.height
-    if (bottom <= headerY || right <= headerX) return null
-    const top  = Math.max(tl.y, headerY)
-    const left = Math.max(tl.x, headerX)
-    return {
-      top:    top  + 'px',
-      left:   left + 'px',
-      width:  (right  - left) + 'px',
-      height: (bottom - top)  + 'px',
-    }
+    const { w: viewW, h: viewH } = grid.getViewportSize?.() ?? { w: Infinity, h: Infinity }
+    return overlayRectStyle(tl, br, {
+      headerX: ROW_HEADER_W * zoom,
+      headerY: COL_HEADER_H * zoom,
+      viewW, viewH,
+    })
   })
 
   const pivotBannerMenuOptions = [

--- a/frontend/src/apps/sheets/components/SheetEditor/usePivotIntegration.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/usePivotIntegration.js
@@ -154,7 +154,11 @@ export function usePivotIntegration({
     const br = grid.getCellRect?.(ext.r1, ext.c1)
     if (!tl || !br) return null
     const zoom    = grid.getZoom?.() ?? 1
-    const { w: viewW, h: viewH } = grid.getViewportSize?.() ?? { w: Infinity, h: Infinity }
+    // `|| Infinity` treats a 0/undefined viewport (before the first layout) as
+    // "unclamped" — a 0 would otherwise collapse the overlay to nothing.
+    const vp    = grid.getViewportSize?.()
+    const viewW = vp?.w || Infinity
+    const viewH = vp?.h || Infinity
     return overlayRectStyle(tl, br, {
       headerX: ROW_HEADER_W * zoom,
       headerY: COL_HEADER_H * zoom,

--- a/frontend/src/apps/sheets/utils/overlay-rect.js
+++ b/frontend/src/apps/sheets/utils/overlay-rect.js
@@ -1,0 +1,37 @@
+// Style for an absolutely-positioned outline drawn over a cell range inside the
+// grid-wrap (the filter-range and pivot highlights).
+//
+// The range can be far taller/wider than the viewport. Letting the div run its
+// true extent (tens of thousands of px on a large sheet) gives the
+// overflow:hidden grid-wrap scrollable overflow, and a stray focus /
+// scrollIntoView then scrolls it — dragging the whole <canvas> off-position.
+// That's the "grid jumps to the middle and freezes after filtering" bug.
+//
+// So we clamp the far edges to the viewport. The border on any edge pushed past
+// the viewport is dropped: it was clipped off-screen before the clamp anyway, so
+// hiding it keeps the outline looking identical (a frame open at the clipped
+// side) instead of drawing a spurious line at the viewport edge.
+//
+// `tl`/`br` are the top-left and bottom-right cell rects (canvas-local CSS px,
+// zoom already applied). Returns null when the range sits entirely under the
+// header gutter (nothing to draw).
+export function overlayRectStyle(tl, br, { headerX, headerY, viewW, viewH }) {
+  const right  = br.x + br.width
+  const bottom = br.y + br.height
+  if (bottom <= headerY || right <= headerX) return null
+
+  const top  = Math.max(tl.y, headerY)
+  const left = Math.max(tl.x, headerX)
+  const clampedRight  = Math.min(right,  viewW)
+  const clampedBottom = Math.min(bottom, viewH)
+
+  const style = {
+    top:    top  + 'px',
+    left:   left + 'px',
+    width:  Math.max(0, clampedRight  - left) + 'px',
+    height: Math.max(0, clampedBottom - top)  + 'px',
+  }
+  if (right  > viewW) style.borderRightWidth  = '0'
+  if (bottom > viewH) style.borderBottomWidth = '0'
+  return style
+}

--- a/frontend/src/apps/sheets/utils/overlay-rect.test.ts
+++ b/frontend/src/apps/sheets/utils/overlay-rect.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { overlayRectStyle } from './overlay-rect.js'
+
+// Header gutter + a 1000×600 viewport for all cases.
+const opts = { headerX: 50, headerY: 24, viewW: 1000, viewH: 600 }
+const cell = (x, y, width = 100, height = 24) => ({ x, y, width, height })
+
+describe('overlayRectStyle', () => {
+  it('draws a full frame for a range that fits inside the viewport', () => {
+    const s = overlayRectStyle(cell(200, 100), cell(400, 300), opts)
+    expect(s).toEqual({ top: '100px', left: '200px', width: '300px', height: '224px' })
+    // Both far edges are on-screen, so no border is dropped.
+    expect(s.borderRightWidth).toBeUndefined()
+    expect(s.borderBottomWidth).toBeUndefined()
+  })
+
+  it('clamps a range taller/wider than the viewport and drops the clipped borders', () => {
+    // br runs to (120000, 120000) — far past a 1000×600 viewport.
+    const s = overlayRectStyle(cell(50, 24), cell(118000, 118000, 200, 24), opts)
+    // Width/height are pinned to the viewport, never the true extent — this is
+    // what stops the grid-wrap from gaining scrollable overflow.
+    expect(s.width).toBe('950px')   // 1000 - left(50)
+    expect(s.height).toBe('576px')  // 600 - top(24)
+    expect(s.borderRightWidth).toBe('0')
+    expect(s.borderBottomWidth).toBe('0')
+  })
+
+  it('clamps only the axis that overflows', () => {
+    // Wide but short: overflows right only.
+    const s = overlayRectStyle(cell(100, 100), cell(5000, 200), opts)
+    expect(s.width).toBe('900px')   // clamped to viewW - left
+    expect(s.borderRightWidth).toBe('0')
+    expect(s.height).toBe('124px')  // unclamped
+    expect(s.borderBottomWidth).toBeUndefined()
+  })
+
+  it('keeps the top-left pinned to the header gutter when scrolled under it', () => {
+    // tl above/left of the gutter — the visible outline starts at the gutter.
+    const s = overlayRectStyle(cell(-300, -200), cell(400, 300), opts)
+    expect(s.top).toBe('24px')
+    expect(s.left).toBe('50px')
+  })
+
+  it('returns null when the range sits entirely under the header gutter', () => {
+    // Entirely left of the row-header gutter (right edge ≤ headerX).
+    expect(overlayRectStyle(cell(-300, 100), cell(-100, 200), opts)).toBeNull()
+    // Entirely above the column-header gutter (bottom edge ≤ headerY).
+    expect(overlayRectStyle(cell(200, -200), cell(400, -100), opts)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Problem

Applying a **filter** (or **pivot**) whose range is taller/wider than the visible viewport left the grid looking **frozen mid-sheet** — jammed a few rows down, the header row and top rows unreachable, a large blank area below, and the vertical scrollbar gone. On a ~700-row sheet, filtering a column reproduced it every time.

## Root cause

The green range-outline overlay (`filterHighlightStyle`, and the identical `pivotHighlightStyle`) was drawn at the **full range extent** — ~118,000px tall on a large sheet — inside the `overflow:hidden` `.sn-grid-wrap`.

`overflow:hidden` hides that div *visually* but still makes the container **programmatically scrollable** (measured `scrollHeight` 118,968 vs `clientHeight` 431). A focus / `scrollIntoView` after Apply then scrolled the wrap natively (`scrollTop` 249.5), dragging the statically-positioned `<canvas>` up ~250px. Nothing was actually hidden — the container just got scrolled, and no code reset it.

## Fix (defense-in-depth)

1. **Clamp the overlays to the viewport at the source** — a new shared `overlayRectStyle` helper caps the outline's far edges to the visible viewport and drops any border pushed off-screen, so it looks identical but never creates scrollable overflow. Wired into **both** the filter and pivot highlights (the pivot outline had the same latent bug). Backed by a new reflow-free `getViewportSize()` grid accessor.
2. **Scroll safety net** — pin `.sn-grid-wrap` scroll back to `0`. The wrap is never meant to scroll natively (all scrolling flows through the canvas + custom scrollbars), so this catches any *future* oversized overlay too.
3. **Fix a related filter footgun** — `Select all` / `Clear` in the value list silently act only on the search-filtered subset, so "search `blog` → Clear → check blog" kept everything *except* blog. The labels now switch to **"Select shown" / "Clear shown"** while a search is active, making the scope obvious.

## Testing

- New unit tests for `overlayRectStyle` (clamping, border-drop, header-gutter cases); full sheets suite (591 tests) green.
- Verified live on a 700-row sheet: header row visible, correct rows hidden, canvas positioned right (`canvasTop == wrapTop`), and wheel-scrolling works — for both "keep almost all values" (the case that froze) and "isolate one value".