### PR TITLE
fix(mail): decide the layout tier once, at load

### DIFF
--- a/frontend/src/apps/mail/utils/composables.ts
+++ b/frontend/src/apps/mail/utils/composables.ts
@@ -1,4 +1,4 @@
-import { computed, onMounted, onUnmounted, reactive, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { createResource, toast } from 'frappe-ui'
 
@@ -7,22 +7,14 @@ import { userStore } from '@/apps/mail/stores/user'
 
 import type { COLOR_SCHEME, Identity, ScreenedAddress } from '@/apps/mail/types'
 
-export const useScreenSize = () => {
-	const size = reactive({ width: window.innerWidth, height: window.innerHeight })
+// Decided once, at load, and deliberately not reactive to resize. Mobile and desktop are
+// separate component trees here, not one tree restyled: crossing 640px mid-session swaps
+// them and unmounts whatever they were holding — a half-written mail vanished this way
+// (#38), and every other open surface has the same exposure. A resized window therefore
+// keeps the layout it started with until the page is reloaded.
+const isMobile = ref(window.innerWidth < 640)
 
-	const isMobile = computed(() => size.width < 640)
-
-	const onResize = () => {
-		size.width = window.innerWidth
-		size.height = window.innerHeight
-	}
-
-	onMounted(() => window.addEventListener('resize', onResize))
-
-	onUnmounted(() => window.removeEventListener('resize', onResize))
-
-	return { size, isMobile }
-}
+export const useScreenSize = () => ({ isMobile })
 
 const isSidebarOpen = ref(false)
 


### PR DESCRIPTION
Mobile and desktop are separate component trees, not one tree restyled, so crossing 640px mid-session swapped them and unmounted whatever they held.

That's how the mail in #38 vanished: the composer opened from the mobile FAB belongs to `MobileTabBar`, which is itself `v-if`'d on `isMobile`, so widening the window destroyed the tab bar, its `SendMail`, and the mail being written with them. Every other open surface has the same exposure.

`useScreenSize` now reads the tier once at load. A resized window keeps the layout it started with until reload, so nothing can be unmounted out from under it. No caller used the returned `size`, so the reactive object and its per-consumer resize listeners go too.

Two knock-on effects worth knowing:
- Tailwind's `sm:`/`max-sm:` utilities still track the viewport, so a mobile tree stretched wide picks up desktop styling on those classes. Cosmetic, no state loss.
- Rotating a phone to landscape (~844px) no longer flips to the desktop tree. Previously it did — and destroyed the composer by the same mechanism.

Supersedes #390, which held the draft in `SendMail` and so only survived desktop → mobile, where `SendMail` outlives the swap.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)