### PR TITLE
fix(mail): skip stale accounts in automation sieve rebuild patch

### DIFF
--- a/suite/mail/patches/rebuild_automation_sieve_scripts.py
+++ b/suite/mail/patches/rebuild_automation_sieve_scripts.py
@@ -51,6 +51,10 @@ def _rebuild_automation_sieve_scripts(accounts: list[str]) -> None:
 	"""Rebuild each account's automation script inline, isolating per-account failures."""
 
 	for account in accounts:
+		# The job runs async after the fan-out committed, so an account can vanish in between.
+		if not account or not frappe.db.exists("JMAP Account", account):
+			continue
+
 		try:
 			# activate=False on purpose: this refreshes the script's content only. Activating here
 			# would override an account whose active script is the vacation auto-responder or one
@@ -72,12 +76,19 @@ def get_accounts_with_automation_rules() -> list[str]:
 	account has none, so rebuilding indiscriminately would conjure an empty script onto every
 	account on the site. Only mailboxes carrying a sender or subject condition contribute generated
 	content, and those are exactly the accounts either bug could have affected.
+
+	Joined to JMAP Account because Mailbox Settings carries stale rows from before the
+	shared-per-account reshape — account values in the legacy ``user@domain:accountid`` format, or
+	empty — and rebuilding those fails with "JMAP account does not exist".
 	"""
 
 	MAILBOX_SETTINGS = frappe.qb.DocType("Mailbox Settings")
+	JMAP_ACCOUNT = frappe.qb.DocType("JMAP Account")
 
 	return (
 		frappe.qb.from_(MAILBOX_SETTINGS)
+		.inner_join(JMAP_ACCOUNT)
+		.on(MAILBOX_SETTINGS.account == JMAP_ACCOUNT.name)
 		.where(
 			(MAILBOX_SETTINGS.emails_from.isnotnull() & (MAILBOX_SETTINGS.emails_from != ""))
 			| (MAILBOX_SETTINGS.subject_contains.isnotnull() & (MAILBOX_SETTINGS.subject_contains != ""))


### PR DESCRIPTION
## Problem

The `rebuild_automation_sieve_scripts` patch job failed on production with:

```
frappe.exceptions.ValidationError: JMAP account shadrak@frappe.io:fx does not exist.
```

`get_accounts_with_automation_rules()` selects `Mailbox Settings.account` blindly, but that table still carries stale rows from before the shared-per-account reshape — account values in the legacy `user@domain:accountid` format, plus some `NULL`s. Every such value fanned out to the rebuild job and failed with "JMAP account does not exist", producing one error log per stale row.

No data was missed: the valid accounts appeared in the list under their current names and were rebuilt; the legacy entries point at accounts that no longer exist.

## Fix

- Inner-join the account query to `JMAP Account` so only accounts that still exist are fanned out (drops both the legacy-format values and `NULL`s).
- Skip accounts that are empty or no longer exist at job execution time — the job runs async after the fan-out committed, so an account can be deleted in between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)