### PR TITLE
refactor: drop line-height overrides that fight the type tokens

### DIFF
--- a/frontend/src/apps/drive/components/Settings/StorageSettings.vue
+++ b/frontend/src/apps/drive/components/Settings/StorageSettings.vue
@@ -91,7 +91,7 @@
       <img :src="getIconUrl(i.file_type)" />
       <span class="text-ink-gray-8 text-sm truncate">{{ i.file_name }}</span>
 
-      <div class="text-ink-gray-8 text-sm ml-auto flex gap-2 h-10 leading-10">
+      <div class="text-ink-gray-8 text-sm ml-auto flex items-center gap-2 h-10">
         <Button
           v-if="hoveredRow === i.name"
           variant="ghost"

--- a/frontend/src/apps/drive/components/UploadTracker.vue
+++ b/frontend/src/apps/drive/components/UploadTracker.vue
@@ -40,7 +40,7 @@
           <div class="flex items-center justify-between w-full">
             <div class="flex justify-start items-center w-full max-w-[80%]">
               <LucideFile class="size-4 mr-2" />
-              <p class="truncate text-sm leading-6 col-span-1 row-span-1">
+              <p class="truncate text-sm col-span-1 row-span-1">
                 {{ upload.name }}
               </p>
             </div>

--- a/frontend/src/apps/drive/pages/Setup.vue
+++ b/frontend/src/apps/drive/pages/Setup.vue
@@ -10,8 +10,8 @@
             class="mx-auto w-full bg-surface-base px-4 py-8 sm:mt-6 sm:w-112 sm:rounded-2xl sm:px-6 sm:py-6 sm:shadow-2xl"
           >
             <div class="mb-7.5 text-center">
-              <p class="mb-2 text-4xl-semibold leading-6 text-ink-gray-9">Welcome to Drive</p>
-              <p class="break-words text-base leading-[21px] text-ink-gray-7">
+              <p class="mb-2 text-4xl-semibold text-ink-gray-9">Welcome to Drive</p>
+              <p class="break-words text-p-base text-ink-gray-7">
                 We're glad you're here.
               </p>
             </div>

--- a/frontend/src/apps/slides/composables/useThemeMenuOption.js
+++ b/frontend/src/apps/slides/composables/useThemeMenuOption.js
@@ -24,11 +24,11 @@ export function useThemeMenuOption() {
 		icon: h(SunMoon, { class: 'stroke-[1.5] !size-3.5' }),
 		onClick: cycleTheme,
 		slots: {
-			label: () => h('div', { class: 'min-w-20 truncate leading-none' }, 'Theme'),
+			label: () => h('div', { class: 'min-w-20 truncate' }, 'Theme'),
 			suffix: () =>
 				h(
 					'span',
-					{ class: 'flex w-16 items-center justify-end gap-2 leading-none text-ink-gray-5' },
+					{ class: 'flex w-16 items-center justify-end gap-2 text-ink-gray-5' },
 					[
 						h('span', activeTheme.value.label),
 						h(activeTheme.value.icon, { class: 'size-3.5 shrink-0 stroke-[1.5]' }),


### PR DESCRIPTION
frappe-ui's `text-*` utilities bake in a line-height, but a few spots in slides and drive layered a `leading-*` on top, either restating the token's value or overriding it for no reason. Drive's storage settings went further and used h-10 leading-10 to vertically center a row.

Drops the overrides and centers that row with items-center instead. Drive's setup screen swaps text-base leading-[21px] for text-p-base, which resolves to the same 21px.