### PR TITLE
fix(drive): prevent crash in NewLinkDialog when name is empty (#371)

### DIFF
--- a/frontend/src/apps/drive/components/NewLinkDialog.vue
+++ b/frontend/src/apps/drive/components/NewLinkDialog.vue
@@ -3,6 +3,7 @@
     {
       label: 'Create',
       variant: 'solid',
+      disabled: !file_name.trim() || !link.trim() || createLink.loading,
       loading: createLink.loading,
       onClick: createLink.submit,
     },
@@ -12,15 +13,13 @@
       <FormControl v-model="link" label="URL" type="url" @keydown.enter="createLink.submit"
         @keydown="createLink.error = null" />
     </div>
-    <div v-if="createLink.error" class="pt-4 text-base font-sm text-ink-red-6">
-      {{ createLink.error.messages[0] }}
-    </div>
+    <ErrorMessage v-if="createLink.error" class="pt-4" :message="createLink.error" />
   </Dialog>
 </template>
 
 <script setup>
 import { ref } from 'vue'
-import { Dialog, createResource, FormControl } from 'frappe-ui'
+import { Dialog, createResource, FormControl, ErrorMessage } from 'frappe-ui'
 import { useRoute } from 'vue-router'
 
 const route = useRoute()


### PR DESCRIPTION
Closes #371

### Summary of changes
- Replaced direct `createLink.error.messages[0]` access in `NewLinkDialog.vue` with Frappe UI's `<ErrorMessage>` component to safely render both client-side validation `Error` objects and server response errors without throwing `TypeError`.
- Disabled the 'Create' action button when Link Name or URL inputs are empty.
