### PR TITLE
fix(mail): name everyone who writes through a relay address

### DIFF
--- a/frontend/src/apps/mail/components/MailListItem.vue
+++ b/frontend/src/apps/mail/components/MailListItem.vue
@@ -156,7 +156,8 @@ import { Badge, Popover, Tooltip } from 'frappe-ui'
 
 import { getAttachmentUrl } from '@/apps/mail/resources'
 import { downloadUrlAsFile, getFileIcon, getFormattedRecipients, getSenderInitial } from '@/apps/mail/utils'
-import { formatThreadParticipants, primaryParticipant } from '@/apps/mail/utils/participants'
+import { formatThreadParticipants, primaryParticipant, threadParticipants } from '@/apps/mail/utils/participants'
+import { useOwnEmails } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import AttachmentCapsule from '@/apps/mail/components/AttachmentCapsule.vue'
 import AttachmentViewer from '@/apps/mail/components/AttachmentViewer.vue'
@@ -202,6 +203,7 @@ const emit = defineEmits([
 
 const route = useRoute()
 const { mailboxIds } = userStore()
+const ownEmails = useOwnEmails()
 
 const to = computed(() => ({
 	name: 'mail-mail',
@@ -240,9 +242,12 @@ const isOutgoing = computed(() => {
 	return mailbox === mailboxIds.sent || mailbox === mailboxIds.drafts
 })
 
+// Read off the conversation the row already carries; empty for a search result, which has none.
+const participants = computed(() => threadParticipants(mail.messages, ownEmails.value))
+
 const header = computed(() => {
 	if (isOutgoing.value) return getFormattedRecipients(mail.recipients) || __('To:')
-	return formatThreadParticipants(mail.participants ?? []) || mail.from_name || mail.from_email
+	return formatThreadParticipants(participants.value) || mail.from_name || mail.from_email
 })
 
 // Gmail-style count of how many messages the conversation holds, shown once there's more than one.
@@ -250,7 +255,7 @@ const messageCount = computed(() => mail.messages?.length ?? 0)
 
 // The letter behind the avatar, for a contact with no picture: whoever the picture itself would be of.
 const avatarLabel = computed(() => {
-	const primary = primaryParticipant(mail.participants ?? [])
+	const primary = primaryParticipant(participants.value)
 	if (!primary) return getSenderInitial(mail)
 	return getSenderInitial({ from_name: primary.name, from_email: primary.email })
 })

--- a/frontend/src/apps/mail/components/StackListItem.vue
+++ b/frontend/src/apps/mail/components/StackListItem.vue
@@ -53,7 +53,8 @@ import { ChevronDown, ChevronRight, Layers2 } from 'lucide-vue-next'
 import { Badge } from 'frappe-ui'
 
 import { getSenderInitial } from '@/apps/mail/utils'
-import { formatThreadParticipants, primaryParticipant } from '@/apps/mail/utils/participants'
+import { formatThreadParticipants, primaryParticipant, threadParticipants } from '@/apps/mail/utils/participants'
+import { useOwnEmails } from '@/apps/mail/utils/composables'
 import MailRow from '@/apps/mail/components/MailRow.vue'
 import MailRowActions from '@/apps/mail/components/MailRowActions.vue'
 
@@ -82,18 +83,21 @@ const emit = defineEmits<{
 // The list is newest-first, so the run's first member is its latest — the row this stack stands in for.
 const latest = computed(() => threads[0])
 
-// Only threads with a lone sender stack (see stackKeyOf), and every member shares that sender, so the
+const ownEmails = useOwnEmails()
+const participants = computed(() => threadParticipants(latest.value.messages, ownEmails.value))
+
+// Only threads with a lone sending address stack (see stackKeyOf), and every member shares it, so the
 // stack is named exactly the way each of its members is — collapsed or expanded, the name holds.
 const sender = computed(
 	() =>
-		formatThreadParticipants(latest.value.participants ?? []) ||
+		formatThreadParticipants(participants.value) ||
 		latest.value.from_name ||
 		latest.value.from_email,
 )
 
 // The letter behind the avatar, for a contact with no picture: whoever the picture itself would be of.
 const avatarLabel = computed(() => {
-	const primary = primaryParticipant(latest.value.participants ?? [])
+	const primary = primaryParticipant(participants.value)
 	if (!primary) return getSenderInitial(latest.value)
 	return getSenderInitial({ from_name: primary.name, from_email: primary.email })
 })

--- a/frontend/src/apps/mail/types/index.ts
+++ b/frontend/src/apps/mail/types/index.ts
@@ -88,9 +88,8 @@ export interface Recipient {
 	display_name: string | null
 }
 
-// Everyone who has written in a thread, in the order they first wrote (see serialize_participants).
-// `is_self` is resolved server-side against the addresses of the account the thread belongs to —
-// not always the active one, since All Inboxes merges rows from every account the user owns.
+// Everyone who has written in a thread, in the order they first wrote. Derived from the thread's own
+// messages rather than served with it (see utils/participants), `is_self` included.
 export interface ThreadParticipant {
 	name: string
 	email: string
@@ -178,7 +177,6 @@ export interface Thread {
 	thread_id: string
 	from_name: string
 	from_email: string
-	participants?: ThreadParticipant[]
 	subject: string | null
 	preview: string | null
 	has_attachment: 0 | 1

--- a/frontend/src/apps/mail/utils/composables.ts
+++ b/frontend/src/apps/mail/utils/composables.ts
@@ -191,6 +191,17 @@ export interface BlockableSender {
 const showBlockSender = ref(false)
 const sendersToBlock = ref<BlockableSender[]>([])
 
+// The account's own addresses, lowercased — what a thread's senders are matched against to decide
+// which of them the row calls "me" (see utils/participants). Identities are per account, so a row
+// merged in from another account (All Inboxes, cross-account search) is resolved against the active
+// one: the cast it names is right either way, and only the "me" would go by its own name instead.
+export const useOwnEmails = () => {
+	const { identities } = userStore()
+	return computed(
+		() => new Set((identities.data ?? []).map((i: Identity) => i.email.toLowerCase())),
+	)
+}
+
 export const useBlockSender = () => {
 	const store = userStore()
 	const { userResource, identities, screenedAddresses } = store

--- a/frontend/src/apps/mail/utils/participants.test.ts
+++ b/frontend/src/apps/mail/utils/participants.test.ts
@@ -161,6 +161,27 @@ describe('formatThreadParticipants', () => {
 		expect(formatThreadParticipants(thread)).toBe('Brittany … Courtney, me')
 	})
 
+	it('keeps what follows an initial, which names nobody on its own', () => {
+		const thread = [
+			participant('Jay1987', 'noreply@discuss.frappe.io'),
+			participant('M Umair Sayed', 'noreply@discuss.frappe.io'),
+		]
+		expect(formatThreadParticipants(thread)).toBe('Jay1987, M Umair')
+		expect(
+			formatThreadParticipants([
+				participant('A. Sarfaraz Shaikh', 'sarfaraz@frappe.io'),
+				participant('Vibhav Katre', 'vibhav@frappe.io', true),
+			]),
+		).toBe('A. Sarfaraz, me')
+		// A lone initial is still all there is to go by.
+		expect(
+			formatThreadParticipants([
+				participant('M', 'noreply@discuss.frappe.io'),
+				participant('Jay1987', 'noreply@discuss.frappe.io'),
+			]),
+		).toBe('M, Jay1987')
+	})
+
 	it('falls back to the address of a sender who goes by no name', () => {
 		expect(formatThreadParticipants([participant('', 'noreply@frappe.io')])).toBe(
 			'noreply@frappe.io',

--- a/frontend/src/apps/mail/utils/participants.test.ts
+++ b/frontend/src/apps/mail/utils/participants.test.ts
@@ -40,6 +40,42 @@ describe('threadParticipants', () => {
 		expect(threadParticipants(thread, own).map((p) => p.is_self)).toEqual([false, true])
 	})
 
+	it('keeps everyone writing from one relay address', () => {
+		// Discourse sends every poster through noreply@, carrying the poster in the display name.
+		const thread = [
+			message('Jay1987', 'noreply@discuss.frappe.io'),
+			message('M Umair Sayed', 'noreply@discuss.frappe.io'),
+			message('Jay1987', 'noreply@discuss.frappe.io'),
+		]
+		expect(names(thread)).toEqual(['Jay1987', 'M Umair Sayed'])
+	})
+
+	it('treats one name written two ways as one writer', () => {
+		const thread = [
+			message('Jay1987', 'noreply@discuss.frappe.io'),
+			message('  jay1987 ', '  NoReply@Discuss.Frappe.io '),
+		]
+		expect(names(thread)).toEqual(['Jay1987'])
+	})
+
+	it('does not take a nameless message for a second writer', () => {
+		// It would be shown as the bare address, sat next to the names from that same address.
+		const thread = [
+			message('Jay1987', 'noreply@discuss.frappe.io'),
+			message('', 'noreply@discuss.frappe.io'),
+		]
+		expect(names(thread)).toEqual(['Jay1987'])
+	})
+
+	it('lets the first name adopt a nameless entry', () => {
+		const thread = [
+			message('', 'noreply@discuss.frappe.io'),
+			message('M Umair Sayed', 'noreply@discuss.frappe.io'),
+			message('Jay1987', 'noreply@discuss.frappe.io'),
+		]
+		expect(names(thread)).toEqual(['M Umair Sayed', 'Jay1987'])
+	})
+
 	it('keeps a nameless sender named after their address', () => {
 		const thread = [message('', 'noreply@frappe.io'), message('', 'alerts@uptimerobot.com')]
 		expect(threadParticipants(thread, own).map((p) => p.email)).toEqual([

--- a/frontend/src/apps/mail/utils/participants.test.ts
+++ b/frontend/src/apps/mail/utils/participants.test.ts
@@ -1,8 +1,8 @@
 import { beforeAll, describe, expect, it } from 'vitest'
 
-import { formatThreadParticipants } from './participants'
+import { formatThreadParticipants, threadParticipants } from './participants'
 
-import type { ThreadParticipant } from '@/apps/mail/types'
+import type { Mail, ThreadParticipant } from '@/apps/mail/types'
 
 // `__` is installed on window by the translation plugin at app boot; the util calls it at format time,
 // so standing it up before the first test is enough.
@@ -14,6 +14,50 @@ const participant = (name: string, email: string, is_self = false): ThreadPartic
 	name,
 	email,
 	is_self,
+})
+
+const message = (from_name: string, from_email: string) => ({ from_name, from_email }) as Mail
+
+const own = new Set(['vibhav@frappe.io'])
+
+describe('threadParticipants', () => {
+	const names = (messages: Mail[]) => threadParticipants(messages, own).map((p) => p.name)
+
+	it('lists senders in the order they first wrote', () => {
+		const thread = [
+			message('Sarfaraz Shaikh', 'sarfaraz@frappe.io'),
+			message('Vibhav Katre', 'vibhav@frappe.io'),
+			message('Sarfaraz Shaikh', 'sarfaraz@frappe.io'),
+		]
+		expect(names(thread)).toEqual(['Sarfaraz Shaikh', 'Vibhav Katre'])
+	})
+
+	it("flags the account's own addresses, however they are cased", () => {
+		const thread = [
+			message('Sarfaraz Shaikh', 'sarfaraz@frappe.io'),
+			message('Vibhav Katre', 'Vibhav@Frappe.io'),
+		]
+		expect(threadParticipants(thread, own).map((p) => p.is_self)).toEqual([false, true])
+	})
+
+	it('keeps a nameless sender named after their address', () => {
+		const thread = [message('', 'noreply@frappe.io'), message('', 'alerts@uptimerobot.com')]
+		expect(threadParticipants(thread, own).map((p) => p.email)).toEqual([
+			'noreply@frappe.io',
+			'alerts@uptimerobot.com',
+		])
+	})
+
+	it('skips messages with no sender', () => {
+		expect(names([message('Nobody', ''), message('Sarfaraz Shaikh', 'sarfaraz@frappe.io')])).toEqual(
+			['Sarfaraz Shaikh'],
+		)
+	})
+
+	it('has nothing to name for a row with no conversation behind it', () => {
+		// Search results are single messages; their rows fall back to the sender they carry.
+		expect(threadParticipants(undefined, own)).toEqual([])
+	})
 })
 
 describe('formatThreadParticipants', () => {

--- a/frontend/src/apps/mail/utils/participants.ts
+++ b/frontend/src/apps/mail/utils/participants.ts
@@ -69,6 +69,17 @@ export const threadParticipants = (
 
 const capitalizeFirst = (word: string) => word.charAt(0).toUpperCase() + word.slice(1)
 
+// "M", "M." — an initial standing before the name rather than being it.
+const isInitial = (word: string) => /^\p{L}\.?$/u.test(word)
+
+// The name a person goes by in a line of several: their first, except where that is an initial, which
+// names nobody — "M Umair Sayed" reads as "M Umair". Relay threads (a forum, an issue tracker) made
+// this worth handling: they name several people on rows that used to name one.
+const firstNameOf = (fullName: string) => {
+	const [first, second] = fullName.split(/\s+/)
+	return isInitial(first) && second ? `${first} ${second}` : first
+}
+
 /**
  * The participant a row's avatar stands for: the first person in the thread who isn't the user,
  * falling back to the user themselves for a thread only they have written in.
@@ -104,7 +115,7 @@ export const formatThreadParticipants = (participants: ThreadParticipant[]) => {
 		if (is_self) return __('me')
 		const fullName = name.trim()
 		if (!fullName) return email
-		return firstNameOnly ? fullName.split(/\s+/)[0] : fullName
+		return firstNameOnly ? firstNameOf(fullName) : fullName
 	}
 
 	// "me" is a word standing in for a name, so it reads lowercase inside the line ("Figma, me")

--- a/frontend/src/apps/mail/utils/participants.ts
+++ b/frontend/src/apps/mail/utils/participants.ts
@@ -5,14 +5,27 @@ import type { Mail, ThreadParticipant } from '@/apps/mail/types'
 const MAX_PARTICIPANTS_SHOWN = 3
 
 /**
- * Everyone who has written in a thread, in the order they first wrote, de-duplicated by address.
- * This is what the list row names, in place of the latest message's sender alone: a thread you have
- * replied to led with your own name, which read as though you had started it.
+ * Everyone who has written in a thread, in the order they first wrote, de-duplicated by name and
+ * address. This is what the list row names, in place of the latest message's sender alone: a thread
+ * you have replied to led with your own name, which read as though you had started it.
  *
  * It is derived here rather than served alongside the row because a row already carries its whole
  * conversation (see serialize_thread) — the names are in hand, and a second copy of them could only
  * disagree. Should the list payload ever be trimmed to one message per row, this moves back to the
  * server, which is the only thing that would still know the cast.
+ *
+ * De-duplicating by address alone hid everyone behind a relay. Discourse, GitHub, Jira and the like
+ * send every writer through one envelope address and put the person in the display name, so a forum
+ * thread five people had posted in was named after whoever posted first, its cast reachable only by
+ * opening it. On such a thread the address is transport and the name is the identity, which is why
+ * both make the key. The cost is that one writer whose client varies their display name ("Bob", "Bob
+ * Smith") takes two places in the row; correspondence rarely does this, and a name that is wrong is
+ * worse than a name repeated.
+ *
+ * A message carrying no display name is not taken for a second writer: it would be shown as the bare
+ * address, sat next to the names from that same address. It falls in with whoever else has written
+ * from there — and where it arrives first, the first name to follow adopts its entry, so the row
+ * reads "Umair" rather than "noreply@discuss.frappe.io, Umair".
  *
  * `ownEmails` is the account's own addresses, lowercased; the entries it matches are the ones the row
  * says "me" for. Search results are single messages with no conversation behind them, and name their
@@ -24,20 +37,31 @@ export const threadParticipants = (
 ): ThreadParticipant[] => {
 	const participants: ThreadParticipant[] = []
 	const seen = new Set<string>()
+	const addresses = new Set<string>()
 
 	for (const message of messages ?? []) {
 		const email = (message.from_email ?? '').trim()
 		if (!email) continue
 
 		const address = email.toLowerCase()
-		if (seen.has(address)) continue
+		const name = (message.from_name ?? '').trim()
+		const key = `${address}|${name.toLowerCase()}`
+		if (seen.has(key)) continue
 
-		seen.add(address)
-		participants.push({
-			name: (message.from_name ?? '').trim(),
-			email,
-			is_self: ownEmails.has(address),
-		})
+		if (!name) {
+			if (addresses.has(address)) continue
+		} else {
+			const unnamed = participants.find((p) => !p.name && p.email.toLowerCase() === address)
+			if (unnamed) {
+				unnamed.name = name
+				seen.add(key)
+				continue
+			}
+		}
+
+		seen.add(key)
+		addresses.add(address)
+		participants.push({ name, email, is_self: ownEmails.has(address) })
 	}
 
 	return participants

--- a/frontend/src/apps/mail/utils/participants.ts
+++ b/frontend/src/apps/mail/utils/participants.ts
@@ -1,8 +1,47 @@
-import type { ThreadParticipant } from '@/apps/mail/types'
+import type { Mail, ThreadParticipant } from '@/apps/mail/types'
 
 // Past this many names the middle of the list is dropped for an ellipsis, keeping the
 // thread's first sender and its two most recent — the ends identify a conversation.
 const MAX_PARTICIPANTS_SHOWN = 3
+
+/**
+ * Everyone who has written in a thread, in the order they first wrote, de-duplicated by address.
+ * This is what the list row names, in place of the latest message's sender alone: a thread you have
+ * replied to led with your own name, which read as though you had started it.
+ *
+ * It is derived here rather than served alongside the row because a row already carries its whole
+ * conversation (see serialize_thread) — the names are in hand, and a second copy of them could only
+ * disagree. Should the list payload ever be trimmed to one message per row, this moves back to the
+ * server, which is the only thing that would still know the cast.
+ *
+ * `ownEmails` is the account's own addresses, lowercased; the entries it matches are the ones the row
+ * says "me" for. Search results are single messages with no conversation behind them, and name their
+ * own sender rather than anyone here.
+ */
+export const threadParticipants = (
+	messages: Mail[] | undefined,
+	ownEmails: Set<string>,
+): ThreadParticipant[] => {
+	const participants: ThreadParticipant[] = []
+	const seen = new Set<string>()
+
+	for (const message of messages ?? []) {
+		const email = (message.from_email ?? '').trim()
+		if (!email) continue
+
+		const address = email.toLowerCase()
+		if (seen.has(address)) continue
+
+		seen.add(address)
+		participants.push({
+			name: (message.from_name ?? '').trim(),
+			email,
+			is_self: ownEmails.has(address),
+		})
+	}
+
+	return participants
+}
 
 const capitalizeFirst = (word: string) => word.charAt(0).toUpperCase() + word.slice(1)
 

--- a/frontend/src/apps/mail/utils/threadStacks.test.ts
+++ b/frontend/src/apps/mail/utils/threadStacks.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest'
 
 import { buildListRows, stackKeyOf } from './threadStacks'
 
-import type { Thread } from '@/apps/mail/types'
+import type { Mail, Thread } from '@/apps/mail/types'
 
-const participant = (email: string, is_self = false) => ({ name: '', email, is_self })
+const message = (from_email: string, from_name = '') => ({ from_email, from_name }) as Mail
 
 const thread = (overrides: Partial<Thread> = {}): Thread =>
 	({
@@ -13,7 +13,7 @@ const thread = (overrides: Partial<Thread> = {}): Thread =>
 		thread_id: 't1',
 		from_email: 'alerts@uptimerobot.com',
 		from_name: 'UptimeRobot',
-		participants: [participant('alerts@uptimerobot.com')],
+		messages: [message('alerts@uptimerobot.com', 'UptimeRobot')],
 		subject: 'Monitor is UP: preview.frappe.cloud/',
 		received_at: '2026-07-16 10:00:00',
 		seen: 0,
@@ -25,7 +25,7 @@ const answered = (overrides: Partial<Thread> = {}) =>
 	thread({
 		from_email: 'vibhav@frappe.io',
 		from_name: 'Vibhav Katre',
-		participants: [participant('alerts@uptimerobot.com'), participant('vibhav@frappe.io', true)],
+		messages: [message('alerts@uptimerobot.com'), message('vibhav@frappe.io', 'Vibhav Katre')],
 		...overrides,
 	})
 
@@ -57,34 +57,34 @@ describe('stackKeyOf', () => {
 	})
 
 	it('separates different senders', () => {
-		expect(stackKeyOf(thread({ participants: [participant('a@x.com')] }))).not.toBe(
-			stackKeyOf(thread({ participants: [participant('b@x.com')] })),
+		expect(stackKeyOf(thread({ messages: [message('a@x.com')] }))).not.toBe(
+			stackKeyOf(thread({ messages: [message('b@x.com')] })),
 		)
 	})
 
 	it('returns null once a second person has written, so the thread never stacks', () => {
 		// A thread with an answer in it is correspondence, not a flood — whoever wrote the answer.
 		expect(stackKeyOf(answered())).toBeNull()
-		const two = [participant('alerts@uptimerobot.com'), participant('neha@frappe.io')]
-		expect(stackKeyOf(thread({ participants: two }))).toBeNull()
+		const two = [message('alerts@uptimerobot.com'), message('neha@frappe.io')]
+		expect(stackKeyOf(thread({ messages: two }))).toBeNull()
 	})
 
 	it('is case- and whitespace-insensitive about the sender', () => {
-		expect(stackKeyOf(thread({ participants: [participant('  Alerts@UptimeRobot.com ')] }))).toBe(
-			stackKeyOf(thread({ participants: [participant('alerts@uptimerobot.com')] })),
+		expect(stackKeyOf(thread({ messages: [message('  Alerts@UptimeRobot.com ')] }))).toBe(
+			stackKeyOf(thread({ messages: [message('alerts@uptimerobot.com')] })),
 		)
 	})
 
 	it('falls back to the sender for rows with no thread behind them', () => {
-		// Search results are single messages: no participant list, so the sender is all there is to key on.
-		expect(stackKeyOf(thread({ participants: undefined, from_email: 'a@x.com' }))).not.toBe(
-			stackKeyOf(thread({ participants: undefined, from_email: 'b@x.com' })),
+		// Search results are single messages: no conversation, so the sender is all there is to key on.
+		expect(stackKeyOf(thread({ messages: undefined, from_email: 'a@x.com' }))).not.toBe(
+			stackKeyOf(thread({ messages: undefined, from_email: 'b@x.com' })),
 		)
-		expect(stackKeyOf(thread({ participants: undefined }))).toBe(stackKeyOf(thread()))
+		expect(stackKeyOf(thread({ messages: undefined }))).toBe(stackKeyOf(thread()))
 	})
 
 	it('returns null without a sender, so such threads never stack', () => {
-		expect(stackKeyOf(thread({ participants: [], from_email: '' }))).toBeNull()
+		expect(stackKeyOf(thread({ messages: [], from_email: '' }))).toBeNull()
 	})
 
 	it('separates the same sender across accounts', () => {
@@ -123,7 +123,7 @@ describe('buildListRows', () => {
 
 	it('breaks a run at a different sender and preserves order', () => {
 		const [a, b, c, d] = run(4)
-		const other = thread({ name: 'other', participants: [participant('hey@posthog.com')] })
+		const other = thread({ name: 'other', messages: [message('hey@posthog.com')] })
 		const rows = buildListRows([a, b, other, c, d], rowOptions)
 		expect(rows.map((r) => r.type)).toEqual(['thread', 'thread', 'thread', 'thread', 'thread'])
 		expect(rows.map((r) => r.key)).toEqual(['m0', 'm1', 'other', 'm2', 'm3'])
@@ -132,7 +132,7 @@ describe('buildListRows', () => {
 	it('never stacks threads more than one person has written in, however alike they are', () => {
 		// Same two people, same day, three in a row — still three conversations, never a pile.
 		const conversations = run(3, {
-			participants: [participant('neha@frappe.io'), participant('vibhav@frappe.io', true)],
+			messages: [message('neha@frappe.io'), message('vibhav@frappe.io', 'Vibhav')],
 		})
 		expect(buildListRows(conversations, rowOptions).map((r) => r.type)).toEqual([
 			'thread',
@@ -157,7 +157,7 @@ describe('buildListRows', () => {
 	})
 
 	it('never merges senderless threads with each other', () => {
-		const rows = buildListRows(run(3, { participants: [], from_email: '' }), rowOptions)
+		const rows = buildListRows(run(3, { messages: [], from_email: '' }), rowOptions)
 		expect(rows.map((r) => r.type)).toEqual(['thread', 'thread', 'thread'])
 	})
 
@@ -181,7 +181,7 @@ describe('buildListRows', () => {
 	})
 
 	it('detects runs that sit at either end of the list', () => {
-		const other = thread({ name: 'other', participants: [participant('hey@posthog.com')] })
+		const other = thread({ name: 'other', messages: [message('hey@posthog.com')] })
 		expect(buildListRows([...run(3), other], rowOptions).map((r) => r.type)).toEqual([
 			'stack',
 			'thread',

--- a/frontend/src/apps/mail/utils/threadStacks.test.ts
+++ b/frontend/src/apps/mail/utils/threadStacks.test.ts
@@ -6,6 +6,11 @@ import type { Mail, Thread } from '@/apps/mail/types'
 
 const message = (from_email: string, from_name = '') => ({ from_email, from_name }) as Mail
 
+// A relay (Discourse, GitHub, Jira) gives every poster the same address and its own display name, so
+// one notification thread names as many people as it had posters.
+const post = (from_name: string, from_email = 'notifications@github.com') =>
+	message(from_email, from_name)
+
 const thread = (overrides: Partial<Thread> = {}): Thread =>
 	({
 		name: 'm1',
@@ -62,11 +67,23 @@ describe('stackKeyOf', () => {
 		)
 	})
 
-	it('returns null once a second person has written, so the thread never stacks', () => {
+	it('returns null once a second address has written, so the thread never stacks', () => {
 		// A thread with an answer in it is correspondence, not a flood — whoever wrote the answer.
 		expect(stackKeyOf(answered())).toBeNull()
 		const two = [message('alerts@uptimerobot.com'), message('neha@frappe.io')]
 		expect(stackKeyOf(thread({ messages: two }))).toBeNull()
+	})
+
+	it('counts addresses rather than people, so a relay thread still stacks', () => {
+		// Three posters, one envelope address: a notification, not correspondence.
+		const posted = thread({
+			messages: [post('Sarfaraz Shaikh'), post('M Umair Sayed'), post('Jay1987')],
+		})
+		expect(stackKeyOf(posted)).toBe(stackKeyOf(thread({ messages: [post('Neha Sankhe')] })))
+		// Your own reply is a second address, and takes the thread out of the pile as it always did.
+		expect(
+			stackKeyOf(thread({ messages: [post('Jay1987'), message('vibhav@frappe.io', 'Vibhav')] })),
+		).toBeNull()
 	})
 
 	it('is case- and whitespace-insensitive about the sender', () => {
@@ -129,7 +146,7 @@ describe('buildListRows', () => {
 		expect(rows.map((r) => r.key)).toEqual(['m0', 'm1', 'other', 'm2', 'm3'])
 	})
 
-	it('never stacks threads more than one person has written in, however alike they are', () => {
+	it('never stacks threads more than one address has written in, however alike they are', () => {
 		// Same two people, same day, three in a row — still three conversations, never a pile.
 		const conversations = run(3, {
 			messages: [message('neha@frappe.io'), message('vibhav@frappe.io', 'Vibhav')],
@@ -139,6 +156,15 @@ describe('buildListRows', () => {
 			'thread',
 			'thread',
 		])
+	})
+
+	it('collapses a run of relay threads however many posted in each', () => {
+		const notifications = run(3, {
+			messages: [post('Sarfaraz Shaikh'), post('M Umair Sayed')],
+		})
+		const rows = buildListRows(notifications, rowOptions)
+		expect(rows).toHaveLength(1)
+		expect(rows[0].type === 'stack' && rows[0].threads).toHaveLength(3)
 	})
 
 	it('breaks a run where the user has replied to one of its threads', () => {

--- a/frontend/src/apps/mail/utils/threadStacks.ts
+++ b/frontend/src/apps/mail/utils/threadStacks.ts
@@ -8,16 +8,16 @@ import type { Thread } from '@/apps/mail/types'
 const MIN_STACK_SIZE = 3
 
 // The thread's lone sender, or null when more than one person has written in it. Search results are
-// single messages with no thread behind them and carry no participant list, so their sender is all
-// there is to go on.
+// single messages with no conversation behind them, so their sender is all there is to go on.
 const loneSenderOf = (thread: Thread): string | null => {
-	const emails = (thread.participants ?? [])
-		.map((p) => (p.email ?? '').trim().toLowerCase())
-		.filter(Boolean)
+	const emails = new Set(
+		(thread.messages ?? []).map((m) => (m.from_email ?? '').trim().toLowerCase()).filter(Boolean),
+	)
 
-	if (emails.length > 1) return null
+	if (emails.size > 1) return null
 
-	return emails[0] || (thread.from_email ?? '').trim().toLowerCase() || null
+	const [only] = emails
+	return only || (thread.from_email ?? '').trim().toLowerCase() || null
 }
 
 /**

--- a/frontend/src/apps/mail/utils/threadStacks.ts
+++ b/frontend/src/apps/mail/utils/threadStacks.ts
@@ -7,8 +7,14 @@ import type { Thread } from '@/apps/mail/types'
 // single stack row. Two in a row is normal correspondence, not a flood — hence three.
 const MIN_STACK_SIZE = 3
 
-// The thread's lone sender, or null when more than one person has written in it. Search results are
+// The thread's lone sending address, or null when more than one has written in it. Search results are
 // single messages with no conversation behind them, so their sender is all there is to go on.
+//
+// Distinct ADDRESSES, not the names the row goes by: a relay (Discourse, GitHub, Jira) gives every
+// writer the same address and its own display name, so one notification thread names as many people
+// as it had posters. Those are exactly the floods stacking exists to bury, and counting people here
+// would unstack them the moment a second one posted. What names the row and what identifies a flood
+// are different questions — the row wants people, the stack wants the machine sending them.
 const loneSenderOf = (thread: Thread): string | null => {
 	const emails = new Set(
 		(thread.messages ?? []).map((m) => (m.from_email ?? '').trim().toLowerCase()).filter(Boolean),
@@ -31,7 +37,7 @@ const loneSenderOf = (thread: Thread): string | null => {
  * loose enough to catch the real floods admits everything from a sender anyway, which is this rule with
  * extra machinery. So: one sender, nobody else in the thread, one day, three in a row.
  *
- * The moment a second person writes — you replying included — the thread is correspondence rather than
+ * The moment a second address writes — you replying included — the thread is correspondence rather than
  * a flood, and correspondence is never worth burying: it has an answer in it, and the row names a cast
  * a stack headed by one sender cannot stand for. Keying on the latest sender instead used to pile such
  * threads together under your own name, since the latest sender of anything you have answered is you.

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -235,7 +235,6 @@ def get_threads(account: str, mailbox: str, limit: int, start: int = 0, filter_b
 	# Sent and Drafts are about the message you wrote, so their rows follow the latest message in the
 	# folder itself; every other view follows the conversation's most recent activity.
 	outgoing_mailboxes = {ids_by_role[role] for role in ("sent", "drafts") if role in ids_by_role}
-	user_emails = {e.lower() for e in get_account_emails(account)}
 
 	threads = []
 	for conversation in conversations.values():
@@ -255,7 +254,7 @@ def get_threads(account: str, mailbox: str, limit: int, start: int = 0, filter_b
 		# draft reply must keep its own recipients and its "Draft" badge when the thread it answers
 		# receives a newer mail.
 		latest = in_mailbox[-1] if mailbox in outgoing_mailboxes else visible[-1]
-		threads.append(serialize_thread(in_mailbox, visible, latest, user_emails, first=conversation[0]))
+		threads.append(serialize_thread(in_mailbox, visible, latest, first=conversation[0]))
 
 	# Avatars for the list-view summary rows, and for each message in the nested threads.
 	add_user_images_to_emails(account, threads, is_thread=False)
@@ -403,7 +402,6 @@ def serialize_thread(
 	messages: list[dict],
 	thread_messages: list[dict],
 	latest: dict | None = None,
-	user_emails: set[str] | None = None,
 	first: dict | None = None,
 ) -> dict:
 	"""Serializes a thread for response.
@@ -414,10 +412,9 @@ def serialize_thread(
 	except `subject` which comes from `first`, the conversation's opening message (the thread's
 	original subject, without the "Re:" its replies carry — it defaults to the earliest message given,
 	which is only the true first when nothing has been filtered out). The conversation is serialized
-	under `messages` so the whole thread can be rendered without a separate fetch.
-
-	`user_emails` is the set of the account's own addresses (lowercased), used to flag which of the
-	thread's senders is the user themselves.
+	under `messages` so the whole thread can be rendered without a separate fetch. The row's cast is
+	read off that same list in the frontend (see utils/participants), which is why nothing here names
+	the thread's senders.
 	"""
 
 	first = first or thread_messages[0]
@@ -445,38 +442,9 @@ def serialize_thread(
 		**{field: current[field] for field in current_fields},
 		**{field: latest[field] for field in activity_fields},
 		"subject": first["subject"],
-		"participants": serialize_participants(thread_messages, user_emails or set()),
 		"attachments": serialize_attachments(latest.get("attachments", [])),
 		"messages": [serialize_mail(message) for message in thread_messages],
 	}
-
-
-def serialize_participants(thread_messages: list[dict], user_emails: set[str]) -> list[dict]:
-	"""The thread's senders, in the order they first wrote, de-duplicated by address.
-
-	This is what the list row names, in place of the latest message's sender alone: a thread you have
-	replied to led with your own name, which read as though you had started it. Each entry carries
-	`is_self` when the sender is one of the account's own addresses, so a row merged in from another
-	account (All Inboxes, cross-account search) is still resolved against the account that owns it.
-	"""
-
-	participants: list[dict] = []
-	seen: set[str] = set()
-	for message in thread_messages:
-		email = message.get("from_email") or ""
-		if not email or email.lower() in seen:
-			continue
-
-		seen.add(email.lower())
-		participants.append(
-			{
-				"name": message.get("from_name") or "",
-				"email": email,
-				"is_self": email.lower() in user_emails,
-			}
-		)
-
-	return participants
 
 
 def serialize_mail(mail: dict) -> dict:


### PR DESCRIPTION
A thread row's participants were built server-side and sent alongside the row, and de-duplicated by address alone. Discourse, GitHub and Jira send every writer through one envelope address and put the person in the display name, so a forum thread five people had posted in was named after whoever posted first — everyone else reachable only by opening it.

- **The list already carries the answer.** A row ships its whole conversation under `messages` (so opening a thread needs no second fetch), which means the names were in the payload twice. `serialize_participants` is gone; the rule now lives in `utils/participants.ts`, with `is_self` from the account's identities. If the list payload is ever trimmed to one message per row, it moves back.
- **The fix:** participants are keyed on name *and* address. A message with no display name isn't taken for a second writer.
- **Stacking counts distinct addresses**, not people, so notification floods still collapse however many posted in them.
- A leading initial keeps the word after it: "M Umair Sayed" was shortening to "M" in a multi-name row.

Tests: `threadParticipants` and the relay/stacking cases in `participants.test.ts` and `threadStacks.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)