### PR TITLE
fix(mail): derive starred-view row state from the flagged message

### DIFF
--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -244,10 +244,16 @@ def get_threads(account: str, mailbox: str, limit: int, start: int = 0, filter_b
 		visible = visible_in_mailbox(conversation, mailbox, trash_mailbox, junk_mailbox)
 
 		# The summary row is derived from the thread's messages in the current mailbox (falling back
-		# to the whole conversation for cross-mailbox views like "starred").
-		in_mailbox = [
-			m for m in visible if any(mb["mailbox_id"] == mailbox for mb in m["mailboxes"])
-		] or visible
+		# to the whole conversation for cross-mailbox views). "starred" is a pseudo-mailbox no message
+		# carries the id of, so its rows follow the flagged message(s) instead — otherwise the row's
+		# state came from the conversation's newest message, which may not be the starred one: the row
+		# showed a hollow star and star/unstar targeted the wrong mail.
+		if mailbox == "starred":
+			in_mailbox = [m for m in visible if m["flagged"]] or visible
+		else:
+			in_mailbox = [
+				m for m in visible if any(mb["mailbox_id"] == mailbox for mb in m["mailboxes"])
+			] or visible
 
 		# The preview/date reflect the latest message in the conversation (the most recent activity)
 		# everywhere except Sent and Drafts, which show the latest message in the folder itself: a


### PR DESCRIPTION
In the Starred view, a starred thread's row rendered a hollow star. "starred" is a pseudo-mailbox no message carries the id of, so the representative-message pick in `get_threads()` never matched and fell back to the whole conversation — the row's identity/state fields (`flagged`, `seen`, `mailboxes`, ...) then came from the conversation's newest message, which may not be the starred one, and star/unstar actions targeted that wrong message. (Reported by Vibhav in #mail, 2026-07-29.)

When `mailbox == "starred"`, the representative is now picked from the thread's flagged messages (falling back to the whole conversation if none), so `current` becomes the latest flagged message. Preview/date/sender still follow the conversation's most recent activity, unchanged. `get_all_inbox_threads` (always a real inbox id) and the search path (per-mail results, no representative pick) don't share this pattern and are untouched.

![starred row shows hollow star](https://raw.githubusercontent.com/krantheman/suite/mail-raven-assets/starred-folder-hollow-star.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)