### PR TITLE
fix(mail): show star state instantly on click and unlock subject selection

### DIFF
--- a/frontend/src/apps/mail/components/MailActions.vue
+++ b/frontend/src/apps/mail/components/MailActions.vue
@@ -49,6 +49,7 @@ import {
 } from 'lucide-vue-next'
 import { Button, createResource } from 'frappe-ui'
 
+import { FLAGGED_STAR_STYLE } from '@/apps/mail/constants'
 import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 
 import {
@@ -112,7 +113,7 @@ const primaryActions = (mail: Mail): MailAction[] => [
 	{
 		label: __('Unstar'),
 		onClick: () => emit('setFlagged', mail.id, false),
-		icon: () => h(Star, { style: 'fill: var(--ink-amber-6); color: var(--ink-amber-6)' }),
+		icon: () => h(Star, { style: FLAGGED_STAR_STYLE }),
 		condition: !!mail.flagged && mailbox !== mailboxIds.trash && !isMobile.value,
 	},
 	{
@@ -177,8 +178,7 @@ const moreActions = (mail: Mail): GroupedAction[] => [
 			{
 				label: __('Unstar'),
 				onClick: () => emit('setFlagged', mail.id, false),
-				icon: () =>
-					h(Star, { style: 'fill: var(--ink-amber-6); color: var(--ink-amber-6)' }),
+				icon: () => h(Star, { style: FLAGGED_STAR_STYLE }),
 				condition: () => !!mail.flagged && mailbox !== mailboxIds.trash,
 			},
 			{

--- a/frontend/src/apps/mail/components/MailRowActions.vue
+++ b/frontend/src/apps/mail/components/MailRowActions.vue
@@ -10,6 +10,7 @@
 		<button class="action-btn" @click.stop.prevent="emit('setFlagged', !flagged)">
 			<Star
 				class="icon text-ink-gray-5"
+				:class="{ flagged }"
 				:style="flagged ? 'fill: var(--ink-amber-6); color: var(--ink-amber-6)' : ''"
 			/>
 		</button>
@@ -24,6 +25,7 @@
 	>
 		<Star
 			class="text-ink-gray-5 h-5 w-5"
+			:class="{ flagged }"
 			:style="flagged ? 'fill: var(--ink-amber-6); color: var(--ink-amber-6)' : ''"
 		/>
 	</button>
@@ -125,9 +127,10 @@ const actions = computed(() =>
 }
 
 /* Hover-capable pointers only: on touch, :hover sticks after a tap and the
-   star would stay dark until something else is touched. */
+   star would stay dark until something else is touched. A flagged star is
+   exempt, or its amber wouldn't show until the pointer left the button. */
 @media (hover: hover) {
-	.action-btn:hover > * {
+	.action-btn:hover > :not(.flagged) {
 		color: var(--ink-gray-8) !important;
 		stroke-width: 2 !important;
 	}

--- a/frontend/src/apps/mail/components/MailRowActions.vue
+++ b/frontend/src/apps/mail/components/MailRowActions.vue
@@ -11,7 +11,7 @@
 			<Star
 				class="icon text-ink-gray-5"
 				:class="{ flagged }"
-				:style="flagged ? 'fill: var(--ink-amber-6); color: var(--ink-amber-6)' : ''"
+				:style="flagged ? FLAGGED_STAR_STYLE : ''"
 			/>
 		</button>
 	</Tooltip>
@@ -26,7 +26,7 @@
 		<Star
 			class="text-ink-gray-5 h-5 w-5"
 			:class="{ flagged }"
-			:style="flagged ? 'fill: var(--ink-amber-6); color: var(--ink-amber-6)' : ''"
+			:style="flagged ? FLAGGED_STAR_STYLE : ''"
 		/>
 	</button>
 </template>
@@ -36,6 +36,7 @@ import { computed } from 'vue'
 import { Archive, Mail, MailOpen, Star, Trash2 } from 'lucide-vue-next'
 import { Tooltip } from 'frappe-ui'
 
+import { FLAGGED_STAR_STYLE } from '@/apps/mail/constants'
 import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 

--- a/frontend/src/apps/mail/components/ThreadHeader.vue
+++ b/frontend/src/apps/mail/components/ThreadHeader.vue
@@ -13,7 +13,7 @@
 		</Button>
 		<template v-if="thread?.length">
 			<Tooltip v-if="!isMobile" :text="thread?.[0]?.subject">
-				<h2 class="mr-2 select-none truncate font-semibold leading-5">
+				<h2 class="mr-2 truncate font-semibold leading-5">
 					{{ thread?.[0]?.subject || __('[No subject]') }}
 				</h2>
 			</Tooltip>

--- a/frontend/src/apps/mail/components/ThreadHeader.vue
+++ b/frontend/src/apps/mail/components/ThreadHeader.vue
@@ -116,7 +116,7 @@ import {
 } from 'lucide-vue-next'
 import { Button, Tooltip } from 'frappe-ui'
 
-import { FOLDER_ICON_COLOR_MAP } from '@/apps/mail/constants'
+import { FLAGGED_STAR_STYLE, FOLDER_ICON_COLOR_MAP } from '@/apps/mail/constants'
 import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 import { getIcon, getMailboxName } from '@/apps/mail/utils'
 import { useScreenSize } from '@/apps/mail/utils/composables'
@@ -191,7 +191,7 @@ const threadActions = computed((): Action[] => [
 				thread.map((m) => m.id),
 				false,
 			),
-		icon: h(Star, { style: 'fill: var(--ink-amber-6); color: var(--ink-amber-6)' }),
+		icon: h(Star, { style: FLAGGED_STAR_STYLE }),
 		condition: () => thread.every((m) => m.flagged),
 	},
 	{

--- a/frontend/src/apps/mail/constants.ts
+++ b/frontend/src/apps/mail/constants.ts
@@ -40,3 +40,15 @@ export const FOLDER_COLOR_MAP = {
 	Red: 'bg-red-500',
 	Purple: 'bg-purple-500',
 }
+
+// The amber of a starred mail's star, wherever one is drawn.
+//
+// The mask/background half is not decoration: frappe-ui doesn't paint a lucide svg from its
+// own geometry, it masks the element with a lucide-static copy of the glyph and paints
+// through that with `background-color: currentColor`. The mask is the stroke-only outline,
+// so there is no interior for `fill` to land in and the star renders as an amber ring.
+// Clearing the mask hands rendering back to the real svg, whose fill and stroke then show —
+// and the background has to go with it, or it would paint the whole icon box amber.
+export const FLAGGED_STAR_STYLE =
+	'fill: var(--ink-amber-6); color: var(--ink-amber-6); ' +
+	'mask-image: none; -webkit-mask-image: none; background-color: transparent'


### PR DESCRIPTION
- Starring a row gave no feedback until the pointer left the button: the `.action-btn:hover` recolor's `!important` beat the star's inline amber ([recording](https://raw.githubusercontent.com/krantheman/suite/mail-raven-assets/star-no-feedback.mov) — reported by Vibhav in #mail Raven, 2026-07-29). The flagged glyph is now exempt from the hover recolor, so the amber fill shows the moment you click; all other states hover as before. Together with the starred-view state fix, starred rows now read as amber filled stars — addressing Vibhav's "fill might be more identifiable" comment.

- The thread subject on desktop had `select-none`, so it couldn't be selected with the mouse (reported by Michelle, 2026-07-28). Removed — the element has no click handler, and mobile's subject was already selectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)