### PR TITLE
fix(writer): Docs-like line spacing; print and export match the editor

### DIFF
--- a/e2e/drive-backed-apps/specs/drive/drive.spec.ts
+++ b/e2e/drive-backed-apps/specs/drive/drive.spec.ts
@@ -19,7 +19,7 @@ test.describe.serial("Drive critical paths", () => {
 		const { page } = owner;
 		const folderName = uniqueName(run.run_id, "folder");
 		const uploadedName = uniqueName(run.run_id, "upload", ".txt");
-		const renamedName = uniqueName(run.run_id, "renamed", ".txt");
+		const renamedName = uniqueName(run.run_id, "renamed with spaces", ".txt");
 		const uploadedLabel = uploadedName.replace(/\.txt$/, "");
 		const renamedLabel = renamedName.replace(/\.txt$/, "");
 
@@ -54,7 +54,11 @@ test.describe.serial("Drive critical paths", () => {
 		const renameInput = page
 			.getByTestId(`drive-entity-${uploaded.name}`)
 			.getByRole("textbox");
-		await renameInput.fill(renamedLabel);
+		await renameInput.fill("");
+		// Typed key by key: the row is a <button>, so a space must not activate it.
+		await renameInput.pressSequentially(renamedLabel);
+		await expect(renameInput).toHaveValue(renamedLabel);
+		await expect(page).toHaveURL(/\/drive\/?$/);
 		await renameInput.press("Enter");
 		await expect(page.getByTestId(`drive-entity-${uploaded.name}`)).toContainText(renamedLabel);
 

--- a/e2e/drive-backed-apps/specs/writer/spacing.spec.ts
+++ b/e2e/drive-backed-apps/specs/writer/spacing.spec.ts
@@ -1,0 +1,145 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../fixtures/test";
+import {
+	createWriterDocument,
+	openWriterDocument,
+	uniqueWriterTitle,
+	writerEditor,
+} from "../../helpers/writer";
+
+// Google Docs applies line spacing as a multiple of the font's natural line
+// height (~1.2em), not of the font size — the editor stores CSS but the popover
+// speaks Docs units, so "2" on a 15px paragraph is 2 * 1.2 * 15 = 36px.
+const NATURAL_LINE_HEIGHT = 1.2;
+const FONT_SIZE = 15;
+
+// The popover's three number inputs, in DOM order: line spacing, above, below.
+function spacingInputs(page: Page) {
+	return page.getByRole("spinbutton");
+}
+
+async function openSpacingPopover(page: Page) {
+	await page.getByRole("button", { name: "Custom Spacing" }).click();
+	await expect(spacingInputs(page)).toHaveCount(3);
+}
+
+function firstParagraph(page: Page) {
+	return writerEditor(page).locator("p").first();
+}
+
+function computed(locator: ReturnType<Page["locator"]>, property: string) {
+	return locator.evaluate(
+		(node, prop) => getComputedStyle(node).getPropertyValue(prop),
+		property,
+	);
+}
+
+test("line spacing uses Google Docs multiples and leaves paragraph spacing alone", async ({
+	owner,
+	run,
+}) => {
+	const { page } = owner;
+	const file = await createWriterDocument(
+		page.request,
+		uniqueWriterTitle(run.run_id, "spacing"),
+	);
+	await openWriterDocument(page, file.name);
+
+	const editor = writerEditor(page);
+	await editor.click();
+	await page.keyboard.type("First paragraph");
+	await page.keyboard.press("Enter");
+	await page.keyboard.type("Second paragraph");
+
+	// Selection stays on the second paragraph, which is what the popover edits.
+	const paragraph = editor.locator("p").nth(1);
+	await openSpacingPopover(page);
+
+	await spacingInputs(page).first().fill("2");
+	await expect
+		.poll(() => computed(paragraph, "line-height"))
+		.toBe(`${2 * NATURAL_LINE_HEIGHT * FONT_SIZE}px`);
+
+	await spacingInputs(page).nth(2).fill("20");
+	await expect.poll(() => computed(paragraph, "margin-bottom")).toBe("20px");
+
+	// Regression: changing the line spacing used to rewrite the margin
+	// attributes too, dropping the spacing that was just set.
+	await spacingInputs(page).first().fill("1.15");
+	await expect
+		.poll(() => computed(paragraph, "line-height"))
+		.toBe(`${1.15 * NATURAL_LINE_HEIGHT * FONT_SIZE}px`);
+	await expect.poll(() => computed(paragraph, "margin-bottom")).toBe("20px");
+});
+
+// printDoc() renders into a hidden iframe and then prints it. Keep that iframe
+// around and inert so the test can measure what the print sheet would show.
+async function keepPrintFrame(page: Page) {
+	await page.addInitScript(() => {
+		const create = document.createElement.bind(document);
+		document.createElement = ((tag: string, ...rest: unknown[]) => {
+			const el = create(tag, ...(rest as []));
+			if (String(tag).toLowerCase() === "iframe") {
+				el.addEventListener("load", () => {
+					const frame = el as HTMLIFrameElement;
+					const win = frame.contentWindow;
+					if (!win) return;
+					win.print = () => {};
+					win.document.execCommand = () => false;
+				});
+			}
+			return el;
+		}) as typeof document.createElement;
+
+		const removeChild = Node.prototype.removeChild;
+		Node.prototype.removeChild = function <T extends Node>(child: T): T {
+			if ((child as unknown as HTMLElement).id === "el-tiptap-iframe") return child;
+			return removeChild.call(this, child) as T;
+		};
+	});
+}
+
+test("printing keeps the paragraph spacing shown in the editor", async ({
+	owner,
+	run,
+}) => {
+	const { page } = owner;
+	await keepPrintFrame(page);
+	const file = await createWriterDocument(
+		page.request,
+		uniqueWriterTitle(run.run_id, "print-spacing"),
+	);
+	await openWriterDocument(page, file.name);
+
+	const editor = writerEditor(page);
+	await editor.click();
+	await page.keyboard.type("First paragraph");
+	await page.keyboard.press("Enter");
+	await page.keyboard.type("Second paragraph");
+
+	const editorSpacing = {
+		lineHeight: await computed(firstParagraph(page), "line-height"),
+		marginTop: await computed(editor.locator("p").nth(1), "margin-top"),
+		marginBottom: await computed(firstParagraph(page), "margin-bottom"),
+	};
+	// The editor gives paragraphs no margins of their own; only the settings do.
+	expect(editorSpacing.marginTop).toBe("0px");
+	expect(editorSpacing.marginBottom).toBe("0px");
+
+	await page.keyboard.press("ControlOrMeta+p");
+
+	// The print document used to miss the editor's prose classes and custom
+	// properties, so every paragraph picked up a ~1.14em margin instead.
+	const printed = page.frameLocator("#el-tiptap-iframe").locator(".ProseMirror p");
+	// The print iframe is deliberately 0x0, so wait on attachment, not visibility.
+	await printed.first().waitFor({ state: "attached" });
+	expect(await computed(printed.first(), "line-height")).toBe(
+		editorSpacing.lineHeight,
+	);
+	expect(await computed(printed.first(), "margin-bottom")).toBe(
+		editorSpacing.marginBottom,
+	);
+	expect(await computed(printed.nth(1), "margin-top")).toBe(
+		editorSpacing.marginTop,
+	);
+});

--- a/frontend/src/apps/drive/components/DriveListRow.vue
+++ b/frontend/src/apps/drive/components/DriveListRow.vue
@@ -120,7 +120,7 @@
               <div class="truncate text-base">{{ displayName(row) }}</div>
             </Tooltip>
           </InlineRenameInput>
-          <div class="flex flex-row grow justify-end gap-2 w-[20px]">
+          <div class="flex flex-row grow justify-end gap-2 w-[20px] pr-3">
             <LucideStar
               v-if="row.is_favourite && $route.name !== 'Favourites'"
               width="16"
@@ -233,7 +233,13 @@ const selectedName = computed(() => activeEntity.value?.name)
 // free) — so this only drives non-folder clicks. Suppressed during an active
 // selection so clicking elsewhere in the row doesn't navigate away (matches
 // the existing !selections.size click guard).
-const open = (row) => !row.is_folder && route.name !== 'Trash' && openEntity(row)
+// `!renamingEntity`: the rename input sits inside the row's <button>, so a
+// keystroke there must never activate the row.
+const open = (row) =>
+  !renamingEntity.value &&
+  !row.is_folder &&
+  route.name !== 'Trash' &&
+  openEntity(row)
 const routeFor = (row) =>
   row.is_folder && !props.selections.size
     ? { name: 'drive-Folder', params: { entityName: row.name } }

--- a/frontend/src/apps/drive/components/DriveListSkeleton.vue
+++ b/frontend/src/apps/drive/components/DriveListSkeleton.vue
@@ -1,22 +1,35 @@
 <template>
-  <div class="py-5 space-y-0.5">
-    <div v-for="i in 10" :key="i" class="flex items-center gap-3 px-3 py-2">
-      <Skeleton class="size-5 shrink-0 rounded" />
-      <Skeleton class="h-3.5 rounded" :style="{ width: nameWidths[i % nameWidths.length] }" />
-      <div class="ml-auto flex items-center gap-10">
-        <div class="flex items-center gap-2 w-28">
-          <Skeleton class="size-5 shrink-0 rounded-full" />
-          <Skeleton class="h-3 rounded w-16" />
-        </div>
-        <Skeleton class="h-3 rounded w-20" />
-        <Skeleton class="h-3 rounded w-12" />
-      </div>
+  <List
+    class="pt-3 flex flex-col flex-1 min-h-0 list-row-px-3"
+    :columns="columnTracks"
+    :row-height="40"
+    divider="inset"
+  >
+    <div class="flex-1 min-h-0 overflow-hidden px-2">
+      <ListRow v-for="i in 10" :key="i" class="pointer-events-none">
+        <ListCell />
+        <ListCell>
+          <Skeleton class="h-[16px] w-[16px] shrink-0 mr-2 rounded-sm" />
+          <Skeleton class="h-3.5 rounded" :style="{ width: nameWidths[i % nameWidths.length] }" />
+        </ListCell>
+        <ListCell>
+          <Skeleton class="size-5 shrink-0 mr-2 rounded-full" />
+          <Skeleton class="h-3 w-16 rounded" />
+        </ListCell>
+        <ListCell><Skeleton class="h-3 w-20 rounded" /></ListCell>
+        <ListCell><Skeleton class="h-3 w-12 rounded" /></ListCell>
+        <ListCell />
+      </ListRow>
     </div>
-  </div>
+  </List>
 </template>
 
 <script setup>
+import { List, ListRow, ListCell } from 'frappe-ui/list'
 import { Skeleton } from 'frappe-ui'
+import { useListColumns } from '@/apps/drive/data/listColumns'
+
+const columnTracks = useListColumns()
 
 const nameWidths = ['45%', '30%', '55%', '38%', '50%', '42%', '60%', '35%', '48%', '52%']
 </script>

--- a/frontend/src/apps/drive/components/DriveToolBar.vue
+++ b/frontend/src/apps/drive/components/DriveToolBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex px-5 pt-3 h-12">
+  <div class="flex items-center px-5 pt-3 h-12">
     <div v-if="selections?.length" class="my-auto w-[40%] text-base text-ink-gray-8">
       {{ selections.length }}
       {{ selections.length === 1 ? __('item') : __('items') }}

--- a/frontend/src/apps/drive/components/InlineRenameInput.vue
+++ b/frontend/src/apps/drive/components/InlineRenameInput.vue
@@ -14,6 +14,8 @@
     @mousedown.stop
     @dblclick.stop
     @keydown.stop
+    @keyup.stop
+    @keyup.space.prevent
     @keydown.enter.prevent="submit"
     @keydown.escape.prevent="cancel"
     @focus="selectBaseName"

--- a/frontend/src/apps/drive/components/ListView.vue
+++ b/frontend/src/apps/drive/components/ListView.vue
@@ -46,8 +46,7 @@
         </ListHeaderCellSort>
         <ListHeaderCell />
       </ListHeader>
-      <DriveListSkeleton v-if="!folderContents" />
-      <template v-else>
+      <template v-if="folderContents">
         <NoFilesSection v-if="!formattedRows.length" description="Nothing found - try something else?" />
         <template v-else-if="formattedRows[0]?.group">
           <ListGroup v-for="group in formattedRows" :key="group.group" :label="group.group" class="mt-3 first:mt-0">
@@ -99,11 +98,9 @@
 import { List, ListHeader, ListHeaderCell, ListHeaderCellSort, ListGroup, ListRow, ListCell } from 'frappe-ui/list'
 import { Checkbox, Skeleton, onOutsideClickDirective as vOnOutsideClick } from 'frappe-ui'
 import { activeEntity, setActiveEntity } from '@/apps/drive/data/selection'
-import { useRoute } from 'vue-router'
 import { computed, ref, watch } from 'vue'
 import ContextMenu from '@/apps/drive/components/ContextMenu.vue'
 import DriveListRow from './DriveListRow.vue'
-import DriveListSkeleton from './DriveListSkeleton.vue'
 import NoFilesSection from './NoFilesSection.vue'
 import { openEntity, isModKey } from '@/apps/drive/utils/files'
 import {
@@ -111,9 +108,9 @@ import {
   toggleFolder,
   refreshExpanded,
 } from '@/apps/drive/data/folderTree'
+import { useListColumns } from '@/apps/drive/data/listColumns'
 
 
-const route = useRoute()
 const props = defineProps({
   folderContents: Object,
   actionItems: Array,
@@ -167,18 +164,7 @@ const formattedRows = computed(() => {
     .filter((g) => g.rows.length)
 })
 
-// Name is flexible; Size widens on Attachments (no Owner/Modified column
-// hiding here — that logic was already dead in the previous implementation,
-// since it compared route.name to bare labels that never match the
-// `drive-`-prefixed route names).
-const columnTracks = computed(() => [
-  '16px',
-  'minmax(0,1fr)',
-  '10%',
-  '15%',
-  route.name === 'drive-Attachments' ? '25%' : '8%',
-  '5%',
-])
+const columnTracks = useListColumns()
 
 const visibleItems = computed(() => flattenRows(formattedRows.value))
 // Collapsing hides rows that may be selected — drop them from the selection so

--- a/frontend/src/apps/drive/components/Settings/StorageSettings.vue
+++ b/frontend/src/apps/drive/components/Settings/StorageSettings.vue
@@ -159,7 +159,8 @@ watch(
   showFileStorage,
   (val) =>
     storageBreakdown.fetch({
-      team: route.params.team || localStorage.getItem('recentTeam'),
+      // Same team as the sidebar bar: the one being browsed, else personal.
+      team: route.params.team || '',
       owned_only: val,
     }),
   { immediate: true }

--- a/frontend/src/apps/drive/data/listColumns.ts
+++ b/frontend/src/apps/drive/data/listColumns.ts
@@ -1,0 +1,16 @@
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+
+// Grid tracks shared by the list view and its loading skeleton, so the
+// placeholder rows land exactly where the real ones will.
+export function useListColumns() {
+  const route = useRoute()
+  return computed(() => [
+    '16px',
+    'minmax(0,1fr)',
+    '10%',
+    '15%',
+    route.name === 'drive-Attachments' ? '25%' : '8%',
+    '5%',
+  ])
+}

--- a/frontend/src/apps/drive/resources/files.js
+++ b/frontend/src/apps/drive/resources/files.js
@@ -115,6 +115,7 @@ export const getSlides = createResource({
       ...k,
       file_name: k.title,
       content_doctype: PRESENTATION_CONTENT_DOCTYPE,
+      content_docname: k.name,
       mime_type: 'frappe/slides',
       file_type: 'Presentation',
       path: k.name,

--- a/frontend/src/apps/drive/ui/drive/components/MoveDialog.vue
+++ b/frontend/src/apps/drive/ui/drive/components/MoveDialog.vue
@@ -169,24 +169,25 @@ const dialogType = defineModel()
 const open = ref(true)
 
 const route = useRoute()
-const tabIndex = ref(route.name == 'drive-Home' ? 0 : 1)
+// Open in the space being browsed — Teams only on a team-scoped route.
 const chosenTeam = ref(route.params.team || '')
+const tabIndex = ref(chosenTeam.value ? 1 : 0)
 
 // Reopen at the folder the user last moved into this session, so repeated moves
 // to the same place don't start from root each time. Only restore it when it
 // belongs to the team we're currently browsing — the dialog always respects the
 // current team context.
 const LAST_MOVE_KEY = 'drive:last-move-dest'
-const lastMoveParent = (() => {
+function lastMoveParent() {
   try {
     const saved = JSON.parse(sessionStorage.getItem(LAST_MOVE_KEY) || 'null')
     if (!saved || typeof saved !== 'object') return ''
-    if ((saved.team || '') !== chosenTeam.value) return ''
+    if ((saved.team || '') !== (chosenTeam.value || '')) return ''
     return saved.parent || ''
   } catch {
     return ''
   }
-})()
+}
 const tree = reactive({
   name: '',
   label: 'Home',
@@ -285,9 +286,13 @@ watch(
   [tabIndex, chosenTeam],
   ([newValue, team], [prev, _]) => {
     selected.value = ''
-    tree.loading = true
-    if ((newValue === 1 && !team) || (newValue === 0 && prev == newValue))
+    if (newValue === 1 && !team) {
+      tree.children = []
+      tree.loading = false
       return
+    }
+    tree.loading = true
+    if (newValue === 0 && prev == newValue) return
     tree.children = []
     switch (newValue) {
       case 0:
@@ -308,16 +313,15 @@ watch(
         })
         break
     }
+    // Re-applied on every tab/team switch, which resets `selected` above.
+    const remembered = lastMoveParent()
+    if (remembered) {
+      selected.value = remembered
+      selectedPerms.fetch()
+    }
   },
   { immediate: true },
 )
-
-// Preselect the last move destination (the immediate watch above resets to root
-// first). Breadcrumbs are filled in by selectedPerms.onSuccess.
-if (lastMoveParent) {
-  selected.value = lastMoveParent
-  selectedPerms.fetch({ entity_name: lastMoveParent })
-}
 
 // Breadcrumb logic
 const slicedBreadcrumbs = computed(() => {

--- a/frontend/src/apps/drive/ui/drive/js/utils.js
+++ b/frontend/src/apps/drive/ui/drive/js/utils.js
@@ -17,8 +17,8 @@ export function dynamicList(k) {
 export function getFileLink(entity, copy = true) {
   let link
   if (entity.file_type === 'Link') link = entity.file_url
-  else if (entity.file_type === 'Presentation') {
-    link = `${window.location.origin}/slides/presentation/${entity.content_docname || entity.name}`
+  else if (entity.content_doctype === 'Presentation') {
+    link = `${window.location.origin}/slides/presentation/${entity.content_docname}`
   } else if (entity.file_type === 'Document' || entity.file_type === 'Markdown') {
     link = `${window.location.origin}/writer/w/${entity.name}`
   } else {

--- a/frontend/src/apps/drive/utils/files.js
+++ b/frontend/src/apps/drive/utils/files.js
@@ -145,8 +145,8 @@ export const openEntity = (entity, new_tab = false) => {
       )
     )
       window.open(entity.file_url, '_blank')
-  } else if (entity.file_type === 'Presentation') {
-    window.location.href = '/slides/presentation/' + entity.file_url
+  } else if (isPresentation(entity)) {
+    window.location.href = '/slides/presentation/' + entity.content_docname
   } else if (
     entity.file_type === 'Document' ||
     entity.file_type === 'Markdown'

--- a/frontend/src/apps/drive/utils/openEntity.test.ts
+++ b/frontend/src/apps/drive/utils/openEntity.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+  getFileLink: vi.fn(() => 'http://localhost/drive/f/abc'),
+  open: vi.fn(),
+  confirm: vi.fn(() => true),
+}))
+
+vi.mock('@/apps/drive/router', () => ({ default: { push: mocks.routerPush } }))
+vi.mock('@/apps/drive/ui/drive/js/utils', () => ({ getFileLink: mocks.getFileLink }))
+vi.mock('@/apps/drive/resources/files', () => ({
+  getRecents: { data: [], setData: vi.fn() },
+  mutate: vi.fn(),
+  createDocument: {},
+  createSheet: {},
+  getDocuments: {},
+  getTeams: { data: {} },
+  getPublicTeams: { data: [] },
+}))
+vi.mock('@/apps/drive/data/breadcrumbs', () => ({ isHomeContext: () => true }))
+vi.mock('@/apps/drive/data/currentFolder', () => ({ currentFolder: { value: null } }))
+vi.mock('@/apps/drive/emitter', () => ({ default: { emit: vi.fn(), on: vi.fn() } }))
+vi.mock('@/apps/drive/utils/toasts.js', () => ({ toast: vi.fn() }))
+vi.mock('idb-keyval', () => ({ set: vi.fn() }))
+vi.mock('frappe-ui', () => ({ useFileUpload: () => ({}), toast: vi.fn() }))
+
+import { openEntity } from './files'
+
+const location = { href: '', origin: 'http://localhost' }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  location.href = ''
+  Object.defineProperty(window, 'location', { configurable: true, value: location })
+  window.open = mocks.open
+  window.confirm = mocks.confirm
+})
+
+const entity = (overrides: Record<string, unknown>) => ({
+  name: 'file-1',
+  file_name: 'Thing',
+  file_url: '/private/files/thing',
+  ...overrides,
+})
+
+describe('openEntity', () => {
+  it('routes a folder in-app', () => {
+    openEntity(entity({ name: 'folder-1', is_folder: true }))
+    expect(mocks.routerPush).toHaveBeenCalledWith({
+      name: 'drive-Folder',
+      params: { entityName: 'folder-1' },
+    })
+  })
+
+  it('opens a native presentation by its content docname', () => {
+    openEntity(
+      entity({
+        file_type: 'Presentation',
+        mime_type: 'frappe/slides',
+        content_doctype: 'Presentation',
+        content_docname: 'pres-9',
+      })
+    )
+    expect(location.href).toBe('/slides/presentation/pres-9')
+  })
+
+  it('previews an uploaded .pptx instead of opening Slides', () => {
+    openEntity(
+      entity({
+        file_type: 'Presentation',
+        mime_type:
+          'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+      })
+    )
+    expect(location.href).toBe('')
+    expect(mocks.routerPush).toHaveBeenCalledWith({
+      name: 'drive-File',
+      params: { entityName: 'file-1' },
+    })
+  })
+
+  it('opens a native sheet by its content docname', () => {
+    openEntity(
+      entity({
+        file_type: 'Spreadsheet',
+        content_doctype: 'Sheet',
+        content_docname: 'sheet-4',
+      })
+    )
+    expect(location.href).toBe('/sheets/sheet-4')
+  })
+
+  it('previews an uploaded spreadsheet instead of opening Sheets', () => {
+    openEntity(entity({ file_type: 'Spreadsheet', mime_type: 'text/csv' }))
+    expect(location.href).toBe('')
+    expect(mocks.routerPush).toHaveBeenCalledWith({
+      name: 'drive-File',
+      params: { entityName: 'file-1' },
+    })
+  })
+
+  it('opens a writer document', () => {
+    openEntity(
+      entity({
+        file_type: 'Document',
+        content_doctype: 'Writer Document',
+        content_docname: 'doc-2',
+      })
+    )
+    expect(location.href).toBe('/writer/w/file-1')
+  })
+
+  it('confirms before following a link entity', () => {
+    openEntity(entity({ file_type: 'Link', file_url: 'https://frappe.io/x' }))
+    expect(mocks.confirm).toHaveBeenCalled()
+    expect(mocks.open).toHaveBeenCalledWith('https://frappe.io/x', '_blank')
+  })
+
+  it('does not follow a link when the confirmation is declined', () => {
+    mocks.confirm.mockReturnValueOnce(false)
+    openEntity(entity({ file_type: 'Link', file_url: 'https://frappe.io/x' }))
+    expect(mocks.open).not.toHaveBeenCalled()
+  })
+
+  it('drills into a virtual attachments node', () => {
+    openEntity(
+      entity({
+        kind: 'virtual',
+        attached_to_doctype: 'ToDo',
+        attached_to_name: 'todo-1',
+      })
+    )
+    expect(mocks.routerPush).toHaveBeenCalledWith({
+      name: 'drive-Attachments',
+      params: { doctype: 'ToDo', docname: 'todo-1' },
+    })
+  })
+
+  it('opens in a new tab via the shared link builder', () => {
+    openEntity(entity({ file_type: 'PDF' }), true)
+    expect(mocks.open).toHaveBeenCalledWith('http://localhost/drive/f/abc', '_blank')
+    expect(mocks.routerPush).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/apps/writer/components/CoreEditor.vue
+++ b/frontend/src/apps/writer/components/CoreEditor.vue
@@ -83,6 +83,7 @@ import { bubbleMenuOptions } from './core-editor/bubble-menu'
 import { CoreEditorExtension } from '@/apps/writer/extensions/core-editor'
 import { PageBreakExtension } from '@/apps/writer/extensions/page-break'
 import CleanStyles from '@/apps/writer/extensions/clean-styles'
+import { cssLineHeight } from '@/apps/writer/utils/typography'
 import MediaDownload from '@/apps/writer/extensions/media-download'
 import OldCommentExtension from '@/apps/writer/extensions/old-comment'
 import { TabsExtension } from '@/apps/writer/extensions/tabs'
@@ -285,7 +286,7 @@ const editorStyle = computed(() => ({
   fontFamily:
     props.settings?.font_family && `var(--font-${props.settings.font_family})`,
   '--editor-font-size': `${props.settings?.font_size || 15}px`,
-  '--editor-line-height': props.settings?.line_height || 1.5,
+  '--editor-line-height': cssLineHeight(props.settings?.line_height),
   '--paragraph-spacing-before': `${props.settings?.paragraph_spacing_before || 0}px`,
   '--paragraph-spacing-after': `${props.settings?.paragraph_spacing_after || 0}px`,
 }))
@@ -423,13 +424,5 @@ onBeforeUnmount(() => {
 
 iframe {
   border: 1px solid var(--surface-gray-4) !important;
-}
-
-.prose-v3 p+p {
-  margin-top: var(--paragraph-spacing-before, 0);
-}
-
-.prose-v3 p {
-  margin-bottom: var(--paragraph-spacing-after, 0);
 }
 </style>

--- a/frontend/src/apps/writer/components/Dialogs.vue
+++ b/frontend/src/apps/writer/components/Dialogs.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- Mutation dialogs -->
   <ShareDialog v-if="dialog === 's'" v-model="dialog" :add-users="params || []" :file="entity" @success="() => resource.fetch()" />
-  <MoveDialog v-else-if="dialog === 'm'" :entities @complete="refresh" />
+  <MoveDialog v-else-if="dialog === 'm'" v-model="dialog" :entities @complete="refresh" />
   
   <!-- Confirmation dialogs -->
   <RemoveDialog v-if="dialog === 'remove'" v-model="dialog" :entities @success="$router.push({ name: 'writer-home' })" />

--- a/frontend/src/apps/writer/components/MarkdownEditor.vue
+++ b/frontend/src/apps/writer/components/MarkdownEditor.vue
@@ -9,6 +9,7 @@ import {
   RichTextKit,
   articleToolbar,
 } from 'frappe-ui/editor'
+import { cssLineHeight } from '@/apps/writer/utils/typography'
 
 const props = defineProps({
   document: Object,
@@ -44,7 +45,7 @@ const extensions = [RichTextKit]
                 :style="{
                   fontFamily: `var(--font-${settings?.font_family})`,
                   fontSize: `${settings?.font_size || 15}px`,
-                  lineHeight: settings?.line_height || 1.5,
+                  lineHeight: cssLineHeight(settings?.line_height),
                 }"
                 :editor
               />

--- a/frontend/src/apps/writer/components/SpacingDialog.vue
+++ b/frontend/src/apps/writer/components/SpacingDialog.vue
@@ -8,13 +8,13 @@
         <FormControl
           type="number"
           class="grow"
-          v-model.number="local.lineHeight"
+          v-model.number="local.lineSpacing"
           autocomplete="off"
-          min="0.75"
+          min="0.5"
           max="10"
-          step="0.2"
-          @update:modelValue="apply"
-          label="Line Height"
+          step="0.05"
+          @update:modelValue="applyLineSpacing"
+          label="Line spacing"
         />
         <div class="space-y-1">
           <FormLabel label="Paragraph Spacing" />
@@ -23,7 +23,7 @@
               type="number"
               autocomplete="off"
               v-model.number="local.spacingBefore"
-              @update:modelValue="apply"
+              @update:modelValue="applySpacing"
               placeholder="0"
               description="Above"
             />
@@ -31,7 +31,7 @@
               type="number"
               autocomplete="off"
               v-model.number="local.spacingAfter"
-              @update:modelValue="apply"
+              @update:modelValue="applySpacing"
               placeholder="0"
               description="Below"
             />
@@ -43,9 +43,14 @@
 </template>
 
 <script setup>
-import { ref, reactive, computed, watch } from 'vue'
+import { reactive, computed, watch } from 'vue'
 import { Popover } from 'frappe-ui'
 import { FormControl, FormLabel } from 'frappe-ui'
+import {
+  DEFAULT_LINE_HEIGHT,
+  toCssLineHeight,
+  toLineSpacing,
+} from '@/apps/writer/utils/typography'
 
 const props = defineProps({
   editor: Object,
@@ -69,40 +74,47 @@ const current = computed(() => {
   return {} // fallback
 })
 
-function parsePx(v, def) {
-  if (!v) return def
-  if (typeof v !== 'string') return v
-  return parseInt(v.replace('px', ''), 10) || def
+function parseNumber(value, fallback) {
+  const parsed = parseFloat(value)
+  return Number.isFinite(parsed) ? parsed : fallback
 }
 
-const local = reactive({
-  lineHeight: +(current.value.lineHeight || props.settings.line_height),
-  spacingAfter: parsePx(
-    current.value.marginBottom,
-    props.settings.paragraph_spacing_above,
-    current.value.marginTop,
-    props.settings.paragraph_spacing_above || 0,
-  ),
-  spacingBefore: parsePx(current.value.marginTop, props.settings.paragraph_spacing_below || 0),
-})
+// What the paragraph falls back to when it carries no override of its own.
+const defaults = computed(() => ({
+  lineHeight: parseNumber(props.settings?.line_height, DEFAULT_LINE_HEIGHT),
+  spacingBefore: parseNumber(props.settings?.paragraph_spacing_before, 0),
+  spacingAfter: parseNumber(props.settings?.paragraph_spacing_after, 0),
+}))
 
-watch(current, (cur) => {
-  local.lineHeight = cur.lineHeight ? +cur.lineHeight : props.settings.line_height
-  local.spacingAfter = parsePx(cur.spacingAfter, props.settings.paragraph_spacing_after || 0)
-  local.spacingBefore = parsePx(cur.spacingBefore, props.settings.paragraph_spacing_before || 0)
-})
+function fromAttrs(attrs) {
+  return {
+    lineSpacing: toLineSpacing(
+      parseNumber(attrs.lineHeight, defaults.value.lineHeight),
+    ),
+    spacingBefore: parseNumber(attrs.spacingBefore, defaults.value.spacingBefore),
+    spacingAfter: parseNumber(attrs.spacingAfter, defaults.value.spacingAfter),
+  }
+}
 
-function apply() {
+const local = reactive(fromAttrs(current.value))
+
+watch(current, (attrs) => Object.assign(local, fromAttrs(attrs)))
+
+function applyLineSpacing() {
+  if (!Number.isFinite(local.lineSpacing) || local.lineSpacing <= 0) return
+  const lineHeight = toCssLineHeight(local.lineSpacing)
   props.editor.commands.updateAttributes('paragraph', {
-    lineHeight: local.lineHeight === (props.settings.line_height || 1.5) ? null : local.lineHeight,
-    spacingAfter:
-      local.spacingAfter === (props.settings.paragraph_spacing_above || 0)
-        ? null
-        : `${local.spacingAfter}px`,
-    spacingBefore:
-      local.spacingBefore === props.settings.paragraph_spacing_below
-        ? null
-        : `${local.spacingBefore}px`,
+    lineHeight: lineHeight === defaults.value.lineHeight ? null : lineHeight,
   })
+}
+
+function applySpacing() {
+  const attrs = {}
+  for (const key of ['spacingBefore', 'spacingAfter']) {
+    if (!Number.isFinite(local[key])) continue
+    attrs[key] =
+      local[key] === defaults.value[key] ? null : `${local[key]}px`
+  }
+  props.editor.commands.updateAttributes('paragraph', attrs)
 }
 </script>

--- a/frontend/src/apps/writer/components/VersionsSidebar.vue
+++ b/frontend/src/apps/writer/components/VersionsSidebar.vue
@@ -120,7 +120,7 @@
             :style="{
               fontFamily: `var(--font-${settings?.font_family})`,
               fontSize: `${settings?.font_size || 15}px`,
-              lineHeight: settings?.line_height || 1.5,
+              lineHeight: cssLineHeight(settings?.line_height),
             }"
             :editor
           />
@@ -131,6 +131,7 @@
 </template>
 <script setup>
 import { COMMON_EXTENSIONS } from '@/apps/writer/utils'
+import { cssLineHeight } from '@/apps/writer/utils/typography'
 import { diff_match_patch } from 'diff-match-patch'
 import DiffTag from '@/apps/writer/extensions/diff-tag'
 const dmp = new diff_match_patch()

--- a/frontend/src/apps/writer/components/WriterSettings.vue
+++ b/frontend/src/apps/writer/components/WriterSettings.vue
@@ -28,12 +28,14 @@
                     description="Set the font size of the editor (px)."
                   />
                   <FormControl
-                    v-model="settings.line_height"
+                    v-model.number="lineSpacing"
                     type="number"
-                    label="Line height"
+                    label="Line spacing"
                     autocomplete="off"
+                    :min="0.5"
+                    :step="0.05"
                     placeholder="Automatic"
-                    description="Set the line height of the editor."
+                    description="A multiple of single spacing, like 1.15 or 1.5."
                   />
                   <div class="space-y-1.5">
                     <FormLabel label="Paragraph spacing" size="md" />
@@ -160,6 +162,7 @@
 import { computed, ref, reactive, watchEffect } from 'vue'
 import { Button, FormControl, Dialog, Tabs, FormLabel } from 'frappe-ui'
 import { FONT_FAMILIES, dynamicList } from '@/apps/writer/utils/'
+import { toCssLineHeight, toLineSpacing } from '@/apps/writer/utils/typography'
 import Form from '@/apps/writer/components/Form.vue'
 import FontSelect from './FontSelect.vue'
 import LucideFileText from '~icons/lucide/file-text'
@@ -210,6 +213,18 @@ const KEYS = computed(() => [
 ])
 
 const settings = reactive({})
+
+// Stored as a CSS line-height; shown as a Google Docs style multiple of single
+// spacing so the number behaves the way users expect.
+const lineSpacing = computed({
+  get: () =>
+    settings.line_height && settings.line_height !== 'global'
+      ? toLineSpacing(settings.line_height)
+      : '',
+  set: (value) => {
+    settings.line_height = value ? toCssLineHeight(value) : 'global'
+  },
+})
 
 const LOCAL_ONLY = [
   'print_header_left',

--- a/frontend/src/apps/writer/styles/editor.css
+++ b/frontend/src/apps/writer/styles/editor.css
@@ -8,6 +8,14 @@
   line-height: var(--editor-line-height, 1.5);
 }
 
+.prose-v3 p + p {
+  margin-top: var(--paragraph-spacing-before, 0);
+}
+
+.prose-v3 p {
+  margin-bottom: var(--paragraph-spacing-after, 0);
+}
+
 .prose strong,
 b {
   color: inherit !important;

--- a/frontend/src/apps/writer/utils/docxexporter.js
+++ b/frontend/src/apps/writer/utils/docxexporter.js
@@ -21,6 +21,7 @@ import {
   TextWrappingSide,
   VerticalAlign,
 } from 'docx'
+import { pxToTwips, toDocxLine } from '@/apps/writer/utils/typography'
 
 const CELL_PADDING = 240
 const TABLE_DXA = 8640
@@ -157,7 +158,19 @@ function inlineToRuns(node, inherited = {}) {
   return runs
 }
 
-function paragraphFromP(p, defaultFont) {
+// Mirror what the editor renders: spacing comes from the document settings, and
+// a paragraph's own inline style wins over them.
+function paragraphSpacing(el, defaults) {
+  const style = el?.style || {}
+  return {
+    before: style.marginTop ? pxToTwips(style.marginTop) : defaults.before,
+    after: style.marginBottom ? pxToTwips(style.marginBottom) : defaults.after,
+    line: style.lineHeight ? toDocxLine(style.lineHeight) : defaults.line,
+    lineRule: 'auto',
+  }
+}
+
+function paragraphFromP(p, defaultFont, spacing) {
   const runs = []
   p.childNodes.forEach((n) => runs.push(...inlineToRuns(n, { font: defaultFont })))
   if (!runs.length) runs.push(new TextRun({ text: '\u00A0', font: defaultFont }))
@@ -170,7 +183,7 @@ function paragraphFromP(p, defaultFont) {
   }
   return new Paragraph({
     alignment: alignMap[(p.style.textAlign || '').toLowerCase()],
-    spacing: { before: 120, after: 120 },
+    spacing: paragraphSpacing(p, spacing),
     children: runs,
   })
 }
@@ -187,7 +200,7 @@ function headingFromHx(hx, defaultFont) {
   })
 }
 
-function paragraphsFromUL(ul, defaultFont) {
+function paragraphsFromUL(ul, defaultFont, spacing) {
   const isTask = ul.getAttribute('data-type') === 'taskList'
   const out = []
 
@@ -209,7 +222,7 @@ function paragraphsFromUL(ul, defaultFont) {
       out.push(
         new Paragraph({
           indent: { left: 720 },
-          spacing: { before: 120, after: 120 },
+          spacing,
           children: [
             new TextRun({ text: checkbox, font: defaultFont, size: 28 }),
             ...(runs.length ? runs : [new TextRun({ text: '', font: defaultFont })]),
@@ -219,7 +232,7 @@ function paragraphsFromUL(ul, defaultFont) {
     } else {
       out.push(
         new Paragraph({
-          spacing: { before: 120, after: 120 },
+          spacing,
           children: runs.length ? runs : [new TextRun({ text: '', font: defaultFont })],
           numbering: { reference: 'bullets', level: 0 },
         }),
@@ -229,7 +242,7 @@ function paragraphsFromUL(ul, defaultFont) {
   return out
 }
 
-function paragraphsFromOL(ol, defaultFont) {
+function paragraphsFromOL(ol, defaultFont, spacing) {
   const out = []
   ol.querySelectorAll(':scope > li').forEach((li) => {
     const runs = []
@@ -243,7 +256,7 @@ function paragraphsFromOL(ol, defaultFont) {
     li.childNodes.forEach(collect)
     out.push(
       new Paragraph({
-        spacing: { before: 120, after: 120 },
+        spacing,
         children: runs.length ? runs : [new TextRun({ text: '', font: defaultFont })],
         numbering: { reference: 'numbers', level: 0 },
       }),
@@ -497,6 +510,13 @@ export async function downloadDocxFromHtml(html, filename, settings = {}) {
   const fontVar = fontMap[fontSetting] || fontSetting
   const defaultFont = cssFontToDocx(fontVar) || 'Inter'
 
+  const defaultSpacing = {
+    before: pxToTwips(settings?.paragraph_spacing_before),
+    after: pxToTwips(settings?.paragraph_spacing_after),
+    line: toDocxLine(settings?.line_height),
+    lineRule: 'auto',
+  }
+
   const numbering = {
     config: [
       {
@@ -547,9 +567,9 @@ export async function downloadDocxFromHtml(html, filename, settings = {}) {
     const el = node
     const tag = el.tagName.toLowerCase()
 
-    if (tag === 'p') children.push(paragraphFromP(el, defaultFont))
-    else if (tag === 'ul') children.push(...paragraphsFromUL(el, defaultFont))
-    else if (tag === 'ol') children.push(...paragraphsFromOL(el, defaultFont))
+    if (tag === 'p') children.push(paragraphFromP(el, defaultFont, defaultSpacing))
+    else if (tag === 'ul') children.push(...paragraphsFromUL(el, defaultFont, defaultSpacing))
+    else if (tag === 'ol') children.push(...paragraphsFromOL(el, defaultFont, defaultSpacing))
     else if (/^h[1-3]$/.test(tag)) children.push(headingFromHx(el, defaultFont))
     else if (tag === 'blockquote') children.push(...paragraphsFromBlockquote(el, defaultFont))
     else if (tag === 'pre') {
@@ -557,7 +577,7 @@ export async function downloadDocxFromHtml(html, filename, settings = {}) {
       el.childNodes.forEach((n) => runs.push(...inlineToRuns(n, { font: defaultFont })))
       children.push(
         new Paragraph({
-          spacing: { before: 120, after: 120 },
+          spacing: defaultSpacing,
           shading: { fill: '0D0D0D' },
           children: runs.length ? runs : [new TextRun({ text: '', font: defaultFont })],
         }),
@@ -586,7 +606,7 @@ export async function downloadDocxFromHtml(html, filename, settings = {}) {
         console.warn('Image fetch failed:', src, e)
       }
     } else {
-      children.push(paragraphFromP(el, defaultFont))
+      children.push(paragraphFromP(el, defaultFont, defaultSpacing))
     }
   }
 

--- a/frontend/src/apps/writer/utils/index.js
+++ b/frontend/src/apps/writer/utils/index.js
@@ -25,6 +25,7 @@ import { FontSize } from '@/apps/writer/extensions/font-size'
 import EmbedExtension from '@/apps/writer/extensions/embed-extension'
 import ExtendedParagraph from '@/apps/writer/extensions/extended-paragraph'
 import FontFamily from '@/apps/writer/extensions/font-family'
+import { cssLineHeight } from '@/apps/writer/utils/typography'
 
 function trimCommonPrefix(a, b) {
   let i = 0
@@ -254,6 +255,15 @@ export function printDoc(html, settings = {}) {
     nunito: 'var(--font-nunito)',
   }
   const fontFamily = fontMap[settings?.font_family]
+  // The print document reuses the editor stylesheet, so it needs the same
+  // custom properties the editor sets — otherwise paragraphs fall back to the
+  // prose defaults and print looser than what is on screen.
+  const editorVars = [
+    `--editor-font-size: ${settings?.font_size || 15}px`,
+    `--editor-line-height: ${cssLineHeight(settings?.line_height)}`,
+    `--paragraph-spacing-before: ${settings?.paragraph_spacing_before || 0}px`,
+    `--paragraph-spacing-after: ${settings?.paragraph_spacing_after || 0}px`,
+  ].join('; ')
   const content = `
             <!DOCTYPE html>
             <html>
@@ -309,7 +319,7 @@ export function printDoc(html, settings = {}) {
               </style>
               </head>
               <body>
-                <div class="ProseMirror prose-sm" style='padding-left: 40px; padding-right: 40px; padding-top: 20px; padding-bottom: 20px; margin: 0;'>
+                <div class="ProseMirror prose prose-sm prose-v3" style='padding-left: 40px; padding-right: 40px; padding-top: 20px; padding-bottom: 20px; margin: 0; ${editorVars}'>
                   ${highlightedHtml}
                 </div>
               </body>

--- a/frontend/src/apps/writer/utils/typography.ts
+++ b/frontend/src/apps/writer/utils/typography.ts
@@ -1,0 +1,39 @@
+/**
+ * Google Docs (and Word) treat line spacing as a multiple of the font's natural
+ * line height — roughly 1.2em — so "1.15" there lands near 1.38em. CSS
+ * line-height multiplies the font size directly, so the same number renders
+ * noticeably tighter.
+ *
+ * Settings and paragraph attributes keep storing CSS values; these convert at
+ * the UI boundary so the number a user types matches what Docs would do.
+ */
+const NORMAL_LINE_HEIGHT = 1.2
+
+export const DEFAULT_LINE_HEIGHT = 1.5
+
+export function toLineSpacing(cssLineHeight: number | string | null | undefined): number {
+  const css = Number(cssLineHeight) || DEFAULT_LINE_HEIGHT
+  return Math.round((css / NORMAL_LINE_HEIGHT) * 100) / 100
+}
+
+export function toCssLineHeight(spacing: number | string | null | undefined): number {
+  const multiple = Number(spacing)
+  if (!multiple || multiple <= 0) return DEFAULT_LINE_HEIGHT
+  return Math.round(multiple * NORMAL_LINE_HEIGHT * 1000) / 1000
+}
+
+/** A settings value can be unset or the string `global`; fall back to the default. */
+export function cssLineHeight(value: number | string | null | undefined): number {
+  const css = Number(value)
+  return css > 0 ? css : DEFAULT_LINE_HEIGHT
+}
+
+/** DOCX `spacing.line` is in 240ths of a single (natural) line. */
+export function toDocxLine(cssLineHeight: number | string | null | undefined): number {
+  return Math.round((240 * (Number(cssLineHeight) || DEFAULT_LINE_HEIGHT)) / NORMAL_LINE_HEIGHT)
+}
+
+/** CSS px → twips (1px = 0.75pt, 1pt = 20 twips). */
+export function pxToTwips(px: number | string | null | undefined): number {
+  return Math.round((parseFloat(String(px)) || 0) * 15)
+}

--- a/suite/drive/api/storage.py
+++ b/suite/drive/api/storage.py
@@ -10,6 +10,7 @@ DriveFile = frappe.qb.DocType("File")
 
 
 @frappe.whitelist()
+@default_team
 def storage_breakdown(team: str, owned_only: bool):
 	if team not in get_teams():
 		frappe.throw(_("You don't have access to this team."), frappe.PermissionError)


### PR DESCRIPTION
- Line spacing is now a multiple of the font's natural line height, like Google Docs — the stored CSS value and existing documents are unchanged.
- The spacing popover no longer clobbers paragraph margins when only line spacing changes (it wrote `undefinedpx` from mis-named settings keys).
- Print and DOCX export use the editor's spacing instead of the default prose margins / a fixed 6pt.
- Adds a Playwright spec for both the spacing math and print parity.

Also includes an earlier Drive commit on this branch (`ac2760881`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)