### PR TITLE
fix(mail): keep the quoted reply trail out of message previews

### DIFF
--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -1124,6 +1124,19 @@ def fetch_blobs(account: str, blobs: list[str] | list[tuple[str, str | None]]) -
         frappe.throw(_("Failed to fetch blob(s)."))
 
 
+def preview_from_html(html_body: str) -> str:
+    """Returns preview text for an HTML body, excluding the quoted reply trail."""
+
+    soup = BeautifulSoup(html_body, "html.parser")
+    # Strip the same quote containers the client collapses (see EmailContent.vue) so the
+    # preview surfaces the new content instead of "On ... wrote:" and everything below it.
+    for quote in soup.find_all(class_=["gmail_quote", "frappe_mail_quote"]):
+        quote.decompose()
+
+    # A message that is nothing but a quote would otherwise get a blank preview.
+    return convert_html_to_text(str(soup)) or convert_html_to_text(html_body)
+
+
 def format_message(account: str, mailbox_map: dict, message: dict) -> dict:
     """Returns a formatted message dictionary for the provided message data."""
 
@@ -1192,7 +1205,7 @@ def format_message(account: str, mailbox_map: dict, message: dict) -> dict:
         formatted_message[field] = value
 
     if html_body := formatted_message["html_body"]:
-        preview = convert_html_to_text(html_body)
+        preview = preview_from_html(html_body)
     elif text_body := formatted_message["text_body"]:
         preview = clean_text(text_body)
     else:

--- a/suite/mail/doctype/mail_message/test_mail_message.py
+++ b/suite/mail/doctype/mail_message/test_mail_message.py
@@ -17,4 +17,30 @@ class IntegrationTestMailMessage(IntegrationTestCase):
     Use this class for testing interactions between multiple components.
     """
 
-    pass
+    def test_preview_excludes_quoted_reply_trail(self):
+        from suite.mail.doctype.mail_message.mail_message import preview_from_html
+
+        # The quote containers the client collapses must not leak into the preview.
+        for quote_class in ["gmail_quote", "frappe_mail_quote"]:
+            html = (
+                "<div>Sounds good, see you then!</div>"
+                f'<div class="{quote_class}">On 28 Jul 2026 at 4:47 PM, x@y.com wrote: the original</div>'
+            )
+            self.assertEqual(preview_from_html(html), "Sounds good, see you then!")
+
+    def test_preview_excludes_nested_quotes(self):
+        from suite.mail.doctype.mail_message.mail_message import preview_from_html
+
+        html = (
+            "<p>Latest reply</p>"
+            '<div class="gmail_quote">Previous reply'
+            '<blockquote class="frappe_mail_quote">Original message</blockquote></div>'
+        )
+        self.assertEqual(preview_from_html(html), "Latest reply")
+
+    def test_preview_falls_back_to_full_body_for_quote_only_message(self):
+        from suite.mail.doctype.mail_message.mail_message import preview_from_html
+
+        # A forwarded/quote-only message must never end up with a blank preview.
+        html = '<div class="gmail_quote">On 28 Jul 2026, John wrote: the original</div>'
+        self.assertEqual(preview_from_html(html), "On 28 Jul 2026, John wrote: the original")


### PR DESCRIPTION
Reported by Vibhav in #mail (Raven, 2026-07-29); Sagar confirmed previews are plain text.

**Bug:** The collapsed one-line preview of a mail in list rows includes the quoted reply trail, burying the actual new content.

**Cause:** `format_message` built the preview with `convert_html_to_text(html_body)` over the full HTML body — quotes included — then truncated to 256 chars.

**Fix:** Strip the `.gmail_quote` / `.frappe_mail_quote` containers (the same ones `EmailContent.vue` collapses client-side) before converting to text. If a message is nothing but a quote, fall back to the unstripped conversion so the preview never goes blank.

Before: `Sounds good, see you then! On 28 Jul 2026 at 4:47 PM, x@y.com wrote: the original ...`
After: `Sounds good, see you then!`

The `text_body` path is untouched — plain-text bodies carry no quote markers, so stripping there would need fragile heuristics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)