### PR TITLE
feat(mail): call the reading pane Split View and default it on

### DIFF
--- a/frontend/src/apps/mail/components/Settings/AppearanceSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/AppearanceSettings.vue
@@ -25,7 +25,7 @@
 			<template v-if="user.data.is_jmap_configured && !isMobile">
 				<SettingsRow
 					class="!py-0"
-					:title="__('Show Reading Pane')"
+					:title="__('Split View')"
 					:description="__('Preview emails alongside the message list.')"
 				>
 					<Switch

--- a/suite/mail/doctype/user_settings/user_settings.json
+++ b/suite/mail/doctype/user_settings/user_settings.json
@@ -127,12 +127,12 @@
    "options": "None\nDay\nMonth"
   },
   {
-   "default": "0",
+   "default": "1",
    "depends_on": "eval: doc.username",
-   "description": "Show a preview pane beside the email list for quick reading.",
+   "description": "Show a split view with an email preview beside the email list.",
    "fieldname": "show_reading_pane",
    "fieldtype": "Check",
-   "label": "Show Reading Pane"
+   "label": "Split View"
   },
   {
    "fieldname": "recovery_section",


### PR DESCRIPTION
Requested by Rushabh in the #mail Raven channel (2026-07-30).

- Renames the "Show Reading Pane" setting to "Split View" — label and description in the User Settings doctype and the Appearance settings page. The `show_reading_pane` fieldname is unchanged.
- Flips the field's default to `1`, so new accounts start with the split view on. Both creation paths (`create_user_settings` in `suite/mail/events.py` and `get_user_info` in `suite/mail/api/account.py`) use `frappe.new_doc`, so the doctype default applies as-is.
- Existing users are deliberately not migrated — they may have chosen their layout, so there is no patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)