### PR TITLE
fix(mail): single-line rows in All Inboxes, which has no reading pane

### DIFF
--- a/frontend/src/apps/mail/components/MailListItem.vue
+++ b/frontend/src/apps/mail/components/MailListItem.vue
@@ -4,6 +4,7 @@
 		:is-selected
 		:selectable
 		:selection-mode
+		:no-reading-pane
 		:unread="!mail.seen"
 		:hide-sender
 		:avatar-label="avatarLabel"
@@ -175,6 +176,7 @@ const {
 	selectable = true,
 	hideSender = false,
 	selectionMode = false,
+	noReadingPane = false,
 } = defineProps<{
 	mailbox: string
 	mail: Thread
@@ -190,6 +192,9 @@ const {
 	hideSender?: boolean
 	// Mobile selection mode — forwarded to MailRow.
 	selectionMode?: boolean
+	// Set by views with no reading pane (All Inboxes) — forwarded to MailRow, which then keeps the
+	// full-width row layout regardless of the reading-pane setting.
+	noReadingPane?: boolean
 }>()
 
 const emit = defineEmits([

--- a/frontend/src/apps/mail/components/MailRow.vue
+++ b/frontend/src/apps/mail/components/MailRow.vue
@@ -133,6 +133,7 @@ const {
 	subjectItalic = false,
 	previewItalic = false,
 	selectionMode = false,
+	noReadingPane = false,
 } = defineProps<{
 	// Renders the row as a link when set, and as a plain div when not — a thread opens, a stack expands.
 	to?: RouteLocationRaw
@@ -152,6 +153,9 @@ const {
 	// Mobile selection mode (a selection exists): rows swap avatars for checkboxes,
 	// hide trailing actions, and a tap toggles selection instead of navigating.
 	selectionMode?: boolean
+	// Set by views that render no reading pane (All Inboxes): the reading-pane setting can't cost
+	// them any width, so their rows always take the full-width layout on desktop.
+	noReadingPane?: boolean
 }>()
 
 const emit = defineEmits<{ setSelected: [selected: boolean] }>()
@@ -172,9 +176,11 @@ const onRowClick = (e: MouseEvent) => {
 	emit('setSelected', !isSelected)
 }
 
-// With the reading pane hidden the list has the window to itself, so a row lays out as one wide line
-// instead of a stacked block.
-const isFullWidth = computed(() => !(user.data.show_reading_pane || isMobile.value))
+// With the reading pane hidden — by the setting, or because the enclosing view has none — the list
+// has the window to itself, so a row lays out as one wide line instead of a stacked block.
+const isFullWidth = computed(
+	() => !isMobile.value && (noReadingPane || !user.data.show_reading_pane),
+)
 
 // A stack member's sender is worth dropping only in the stacked layout, where the sender owns a whole
 // line and repeating the same name down a run costs a third of every row's height. Full-width keeps it:

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -107,6 +107,7 @@
 								:mail
 								:is-selected="false"
 								:selectable="false"
+								no-reading-pane
 								class="border-l-transparent sm:border-l"
 								@set-seen="(seen: boolean) => handleSetSeen(mail, seen)"
 								@archive-thread="handleArchive(mail)"


### PR DESCRIPTION
Reported by Rushabh in #mail Raven (2026-07-30): All Inboxes renders tall three-line rows even though it has no reading pane.

**Cause:** `MailRow`'s `isFullWidth` keys off the global `show_reading_pane` setting, not off whether the enclosing view actually renders a pane — so with the setting on, the pane-less All Inboxes list stacked its rows as if a pane were eating two-thirds of the width.

**Fix:** a `no-reading-pane` prop threaded `AllInboxesView → MailListItem → MailRow`, folded into `isFullWidth`, so a pane-less view forces the single-line full-width layout on desktop. Mobile is untouched. All Inboxes is currently the only pane-less list — search and Screener render a pane when the setting is on — but any future one gets the same lever.

This is the interim half of Rushabh's ask; full split-view support in All Inboxes is tracked separately as an issue.

Before:
![before](https://raw.githubusercontent.com/krantheman/suite/mail-raven-assets/all-inboxes-pane-rows-no-pane.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)