### PR TITLE
fix(mail): stop clean_text splitting emails and URLs in previews

### DIFF
--- a/suite/tests/test_utils.py
+++ b/suite/tests/test_utils.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import unittest
+
+from suite.utils import clean_text
+
+
+class TestCleanText(unittest.TestCase):
+    def test_keeps_email_addresses_intact(self):
+        # "x@y.com" must not become "x@y. com" in list-row previews
+        self.assertEqual(clean_text("Contact x@y.com for help"), "Contact x@y.com for help")
+
+    def test_keeps_urls_intact(self):
+        self.assertEqual(clean_text("See https://frappe.io/docs now"), "See https://frappe.io/docs now")
+
+    def test_spaces_out_run_on_sentences(self):
+        self.assertEqual(clean_text("word.Next sentence,here!Go"), "word. Next sentence, here! Go")
+
+    def test_collapses_and_trims_whitespace(self):
+        self.assertEqual(clean_text("  hello   world  "), "hello world")
+
+    def test_strips_invisible_characters(self):
+        self.assertEqual(clean_text("zero​width"), "zerowidth")
+
+    def test_empty_input(self):
+        self.assertEqual(clean_text(""), "")

--- a/suite/utils/__init__.py
+++ b/suite/utils/__init__.py
@@ -145,7 +145,17 @@ def clean_text(text: str) -> str:
 
     text = unicodedata.normalize("NFKC", text)
     text = re.sub(INVISIBLE_CHARS, "", text)
-    text = re.sub(r"([,.!?])(?=\w)", r"\1 ", text)
+
+    # Space out run-on sentences ("word.Next" -> "word. Next"), but skip tokens
+    # containing "@" or "://" so emails and URLs stay intact ("x@y.com" must not
+    # become "x@y. com").
+    def space_out(match: re.Match) -> str:
+        token = match[0]
+        if "@" in token or "://" in token:
+            return token
+        return re.sub(r"([,.!?])(?=\w)", r"\1 ", token)
+
+    text = re.sub(r"\S+", space_out, text)
 
     return re.sub(r"\s+", " ", text).strip()
 


### PR DESCRIPTION
`clean_text` inserted a space after any punctuation followed by a word character, mangling emails and URLs in list-row previews:

- Before: `Contact x@y. com for help`, `See https://frappe. io/docs now`
- After: `Contact x@y.com for help`, `See https://frappe.io/docs now`

This hits every preview, not just plain-text mails: `convert_html_to_text` — the preview path for HTML bodies — also finishes with `clean_text`.

The sentence-spacing pass (`word.Next` → `word. Next`) now runs per whitespace-delimited token and skips tokens containing `@` or `://`. Added site-free unit tests in `suite/tests/test_utils.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)