### PR TITLE
fix(mail): resolve /mail to the inbox by role, not list position

### DIFF
--- a/frontend/src/apps/mail/router.ts
+++ b/frontend/src/apps/mail/router.ts
@@ -25,10 +25,15 @@ const handleSetupWizardEscape = () => {
 
 const buildDefaultRoute = (
 	accountId: string,
-	mailboxes: { data?: { id: string }[] },
+	mailboxes: { data?: { id: string; role?: string }[] },
 ): { name: string; params: Record<string, string> } => {
-	const firstMailbox = mailboxes.data?.[0]?.id
-	if (firstMailbox) return { name: 'mail-mailbox', params: { accountId, mailbox: firstMailbox } }
+	// Resolve the Inbox by role, not list position: the list is sorted by the
+	// user-orderable sort_order, so [0] can be any folder — including the
+	// Screener, whose redirect below would bounce '/mail' back to the screener
+	// view (from there the Inbox tab then appeared to do nothing).
+	const defaultMailbox = mailboxes.data?.find((m) => m.role === 'inbox') ?? mailboxes.data?.[0]
+	if (defaultMailbox)
+		return { name: 'mail-mailbox', params: { accountId, mailbox: defaultMailbox.id } }
 
 	return { name: 'mail-address-books', params: { accountId } }
 }


### PR DESCRIPTION
The router guard resolved `/mail` to `mailboxes.data[0]`, but the list is sorted by the user-orderable `sort_order`, so the first entry can be any folder. When the Screener sorted first, the guard's screener redirect turned `/mail` into `mail-screener` — from the Screener, the mobile Inbox tab then navigated to the route it was already on and appeared dead ("tabs become randomly unclickable").

Now the guard resolves the Inbox by `role === 'inbox'` (falling back to the first mailbox only if none exists), matching how the backend resolves it (`get_mailbox_id_by_role`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)