### PR TITLE
feat(sheets): chart aggregation + color palettes

### DIFF
--- a/frontend/src/apps/sheets/components/SheetEditor/ChartDialog.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/ChartDialog.vue
@@ -62,6 +62,14 @@
             @update:model-value="onXAxisChange"
           />
 
+          <p class="cd-label" style="margin-top:14px">
+            {{ chartType === 'pie' ? 'Aggregate slices' : 'Aggregate' }}
+          </p>
+          <FormControl type="select" v-model="opts.aggregate" :options="CHART_AGGREGATIONS" />
+          <p v-if="opts.aggregate !== 'none'" class="cd-hint">
+            Rows sharing the same {{ chartType === 'pie' ? 'label' : 'X value' }} are grouped and summarised.
+          </p>
+
           <div class="cd-series-head" style="margin-top:14px">
             <p class="cd-label" style="margin:0">
               {{ chartType === 'pie' ? 'Values' : 'Series' }}
@@ -120,6 +128,44 @@
             <FormControl v-if="chartType === 'line' || chartType === 'area'" type="checkbox" v-model="opts.smooth"  label="Smooth curves" />
             <FormControl v-if="chartType === 'bar'  || chartType === 'area'" type="checkbox" v-model="opts.stacked" label="Stacked" />
           </div>
+
+          <div class="cd-colors-head" style="margin-top:14px">
+            <p class="cd-label" style="margin:0">Colors</p>
+            <Button v-if="hasCustomColors" size="sm" variant="ghost" label="Reset" @click="resetColors" />
+          </div>
+          <div class="cd-palettes">
+            <button
+              v-for="p in CHART_PALETTES"
+              :key="p.name"
+              type="button"
+              class="cd-palette"
+              :class="{ 'cd-palette--active': activePaletteName === p.name }"
+              :title="p.name"
+              @click="applyPalette(p)"
+            >
+              <span
+                v-for="(c, i) in p.colors.slice(0, 5)"
+                :key="i"
+                class="cd-palette-stop"
+                :style="{ background: c }"
+              />
+            </button>
+          </div>
+          <!-- Per-series overrides only make sense for cartesian charts, where
+               the colour array maps positionally to series. A pie maps colours
+               to slices (rows), not series, so the palette presets above are the
+               only meaningful control there. -->
+          <div v-if="chartType !== 'pie' && selectedSeries.length" class="cd-series-colors">
+            <label v-for="s in selectedSeries" :key="s.idx" class="cd-series-color">
+              <input
+                type="color"
+                class="cd-color-input"
+                :value="s.color"
+                @input="setSeriesColor(s.idx, $event.target.value)"
+              />
+              <span class="cd-series-color-label">{{ s.label }}</span>
+            </label>
+          </div>
         </div>
 
         <div class="cd-preview">
@@ -152,7 +198,7 @@ import { computed, defineAsyncComponent, reactive, ref, watch } from 'vue'
 import { Autocomplete, Button, Dialog, FormControl, FeatherIcon } from 'frappe-ui'
 // Lazy-load — same rationale as in ChartOverlay.
 const ChartView = defineAsyncComponent(() => import('./ChartView.vue'))
-import { CHART_TYPES } from '../../engine/charts.js'
+import { CHART_TYPES, CHART_PALETTES, ESPRESSO_PALETTE, CHART_AGGREGATIONS } from '../../engine/charts.js'
 
 const CHART_ICONS = {
   line:    'trending-up',
@@ -186,7 +232,7 @@ const title       = ref('')
 const hasHeader   = ref(true)
 const xCol        = ref(0)
 const yCols       = ref([])             // selected column indices
-const opts        = reactive({ showLegend: true, smooth: false, stacked: false, dataLabels: true, gridLines: true })
+const opts        = reactive({ showLegend: true, smooth: false, stacked: false, dataLabels: true, gridLines: true, colorScheme: undefined, aggregate: 'none' })
 
 // Resolved each `detect()` — the actual values backing the preview.
 const matrix      = ref([])
@@ -205,7 +251,7 @@ watch(show, (open) => {
     hasHeader.value  = c.hasHeader !== false
     xCol.value       = c.encoding?.x ?? 0
     yCols.value      = c.encoding?.y ? [...c.encoding.y] : []
-    Object.assign(opts, { showLegend: true, smooth: false, stacked: false, dataLabels: false, gridLines: true, ...c.options })
+    Object.assign(opts, { showLegend: true, smooth: false, stacked: false, dataLabels: false, gridLines: true, colorScheme: undefined, aggregate: 'none', ...c.options })
     detect()
   } else {
     rangeInput.value = props.initialRange || ''
@@ -214,7 +260,7 @@ watch(show, (open) => {
     hasHeader.value  = true
     xCol.value       = 0
     yCols.value      = []
-    Object.assign(opts, { showLegend: true, smooth: false, stacked: false, dataLabels: true, gridLines: true })
+    Object.assign(opts, { showLegend: true, smooth: false, stacked: false, dataLabels: true, gridLines: true, colorScheme: undefined, aggregate: 'none' })
     if (rangeInput.value) detect()
   }
 })
@@ -308,6 +354,61 @@ function selectNumericSeries() {
     .map(c => c.idx)
 }
 
+// ── Colors ─────────────────────────────────────────────────────────────────-
+//
+// `opts.colorScheme` is either undefined (→ default Espresso palette) or an
+// explicit hex array used verbatim as ECharts `color`. The array maps
+// positionally to series in encoding.y order, so series `pos` uses
+// colours[pos % len]. Editing one series materialises the palette into an
+// explicit array; picking a preset replaces it wholesale.
+
+const effectiveColors = computed(() =>
+  (opts.colorScheme && opts.colorScheme.length) ? opts.colorScheme : ESPRESSO_PALETTE,
+)
+const hasCustomColors = computed(() => Array.isArray(opts.colorScheme) && opts.colorScheme.length > 0)
+
+// Highlight the matching preset chip. With no override we're on the default
+// (Espresso); an explicit array highlights whichever preset it equals, or none
+// once the user hand-tweaks an individual series.
+const activePaletteName = computed(() => {
+  if (!hasCustomColors.value) return 'Espresso'
+  const cur = opts.colorScheme
+  const match = CHART_PALETTES.find(p =>
+    p.colors.length === cur.length
+    && p.colors.every((c, i) => c.toLowerCase() === String(cur[i]).toLowerCase()),
+  )
+  return match ? match.name : null
+})
+
+const selectedSeries = computed(() =>
+  yCols.value.map((idx, pos) => ({
+    idx,
+    label: columns.value.find(c => c.idx === idx)?.label || `Column ${_colLetter(idx)}`,
+    color: effectiveColors.value[pos % effectiveColors.value.length],
+  })),
+)
+
+function applyPalette(p) {
+  opts.colorScheme = [...p.colors]
+}
+
+function setSeriesColor(colIdx, hex) {
+  const pos = yCols.value.indexOf(colIdx)
+  if (pos < 0) return
+  const base = (opts.colorScheme && opts.colorScheme.length)
+    ? [...opts.colorScheme]
+    : [...ESPRESSO_PALETTE]
+  // Grow the array from the default palette so a high series index is still
+  // addressable without leaving holes.
+  while (base.length <= pos) base.push(ESPRESSO_PALETTE[base.length % ESPRESSO_PALETTE.length])
+  base[pos] = hex
+  opts.colorScheme = base
+}
+
+function resetColors() {
+  opts.colorScheme = undefined
+}
+
 // ── Master "select all visible" checkbox ──────────────────────────────────-
 //
 // "Visible" = whatever passes the current filter (and isn't the X-axis).
@@ -375,7 +476,11 @@ function onConfirm() {
     title:       title.value,
     hasHeader:   hasHeader.value,
     encoding:    { x: xCol.value, y: [...yCols.value] },
-    options:     { ...opts },
+    // JSON round-trip strips Vue reactivity — the engine's history snapshot
+    // deep-clones configs with structuredClone, which throws DataCloneError on
+    // any reactive proxy (e.g. options.colorScheme). This drops undefined keys,
+    // which is exactly what we want (a missing colorScheme → default palette).
+    options:     JSON.parse(JSON.stringify({ ...opts })),
   })
   show.value = false
 }
@@ -422,6 +527,7 @@ function _autoDetectRange() {
    `flex-shrink: 0` + bottom-alignment to keep it level with the Detect button. */
 .cd-header-toggle { flex-shrink: 0; }
 .cd-error         { font-size: 12px; color: var(--ink-red-5); margin: 4px 0 0; }
+.cd-hint          { font-size: 11px; color: var(--ink-gray-5); margin: 5px 0 0; line-height: 1.4; }
 
 .cd-type-grid {
   display: grid;
@@ -508,6 +614,30 @@ function _autoDetectRange() {
 }
 
 .cd-options { display: flex; flex-direction: column; gap: 4px; }
+
+.cd-colors-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 6px; }
+.cd-palettes { display: flex; flex-wrap: wrap; gap: 6px; }
+.cd-palette {
+  display: flex; overflow: hidden; cursor: pointer;
+  height: 24px; width: 56px; padding: 0;
+  background: none; border: 1px solid var(--outline-gray-2); border-radius: 6px;
+  transition: border-color .12s, box-shadow .12s;
+}
+.cd-palette:hover { border-color: var(--outline-gray-3); }
+.cd-palette--active { border-color: var(--outline-gray-4); box-shadow: 0 0 0 2px var(--surface-gray-3); }
+.cd-palette-stop { flex: 1; }
+
+.cd-series-colors { display: flex; flex-direction: column; gap: 4px; margin-top: 8px; }
+.cd-series-color { display: flex; align-items: center; gap: 8px; cursor: pointer; font-size: 13px; color: var(--ink-gray-8); min-width: 0; }
+.cd-color-input {
+  width: 22px; height: 22px; flex-shrink: 0; padding: 0;
+  background: none; border: 1px solid var(--outline-gray-2); border-radius: 5px; cursor: pointer;
+}
+/* Native color input renders an inset swatch with default chrome padding —
+   trim it so the whole control reads as one clean colour chip. */
+.cd-color-input::-webkit-color-swatch-wrapper { padding: 2px; }
+.cd-color-input::-webkit-color-swatch { border: none; border-radius: 3px; }
+.cd-series-color-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 .cd-preview { display: flex; flex-direction: column; min-width: 0; min-height: 0; }
 .cd-preview-frame {

--- a/frontend/src/apps/sheets/engine/chart-data.js
+++ b/frontend/src/apps/sheets/engine/chart-data.js
@@ -21,14 +21,69 @@ export function buildOption(config, matrix) {
 	if (!matrix?.length) return _emptyOption(config)
 	const { headerRow, dataRows } = _splitHeader(matrix, config.hasHeader !== false)
 	const encoding = _normaliseEncoding(config.encoding, matrix[0]?.length || 0)
+	// Group-and-aggregate by the X column when the user asks for it. With
+	// aggregation off this is a no-op and each row plots as-is (the original
+	// behaviour); with it on, rows sharing an X value collapse into one, which
+	// is what turns raw transactional data into a chart worth looking at.
+	const rows = _aggregate(dataRows, encoding, config.options?.aggregate)
 
 	switch (config.chartType) {
-		case 'pie':     return _pieOption(config, headerRow, dataRows, encoding)
-		case 'bar':     return _cartesianOption(config, headerRow, dataRows, encoding, 'bar')
-		case 'line':    return _cartesianOption(config, headerRow, dataRows, encoding, 'line')
-		case 'area':    return _cartesianOption(config, headerRow, dataRows, encoding, 'area')
-		case 'scatter': return _cartesianOption(config, headerRow, dataRows, encoding, 'scatter')
-		default:        return _cartesianOption(config, headerRow, dataRows, encoding, 'bar')
+		case 'pie':     return _pieOption(config, headerRow, rows, encoding)
+		case 'bar':     return _cartesianOption(config, headerRow, rows, encoding, 'bar')
+		case 'line':    return _cartesianOption(config, headerRow, rows, encoding, 'line')
+		case 'area':    return _cartesianOption(config, headerRow, rows, encoding, 'area')
+		case 'scatter': return _cartesianOption(config, headerRow, rows, encoding, 'scatter')
+		default:        return _cartesianOption(config, headerRow, rows, encoding, 'bar')
+	}
+}
+
+// ── Aggregation ───────────────────────────────────────────────────────────────
+
+// Collapse rows sharing the same X value into one, applying `aggFn` to each
+// series column. Returns synthetic rows keyed only at the X and Y indices the
+// encoding uses — enough for the option builders, which read nothing else.
+// Group order follows first appearance so the axis stays in data order.
+function _aggregate(dataRows, encoding, aggFn) {
+	if (!aggFn || aggFn === 'none') return dataRows
+	const groups = new Map()   // label → { keyVal, rows: [] }
+	for (const r of dataRows) {
+		const keyVal = r[encoding.x]
+		const key = _toLabel(keyVal)
+		let g = groups.get(key)
+		if (!g) { g = { keyVal, rows: [] }; groups.set(key, g) }
+		g.rows.push(r)
+	}
+	const width = Math.max(encoding.x, ...encoding.y, 0) + 1
+	const out = []
+	for (const g of groups.values()) {
+		const row = new Array(width).fill('')
+		row[encoding.x] = g.keyVal
+		for (const col of encoding.y) row[col] = _applyAgg(aggFn, g.rows, col)
+		out.push(row)
+	}
+	return out
+}
+
+// Apply one aggregation function over a group's values in column `col`.
+// `count` counts non-empty cells; the numeric functions ignore non-numeric
+// cells and fall back to 0 for an all-empty group.
+function _applyAgg(fn, rows, col) {
+	const nums = []
+	let nonEmpty = 0
+	for (const r of rows) {
+		const v = r[col]
+		if (v === '' || v == null) continue
+		nonEmpty++
+		const n = Number(v)
+		if (!isNaN(n)) nums.push(n)
+	}
+	switch (fn) {
+		case 'count': return nonEmpty
+		case 'avg':   return nums.length ? nums.reduce((a, b) => a + b, 0) / nums.length : 0
+		case 'min':   return nums.length ? nums.reduce((a, b) => (b < a ? b : a)) : 0
+		case 'max':   return nums.length ? nums.reduce((a, b) => (b > a ? b : a)) : 0
+		case 'sum':
+		default:      return nums.reduce((a, b) => a + b, 0)
 	}
 }
 
@@ -143,7 +198,7 @@ function _pieOption(config, headerRow, dataRows, encoding) {
 function _baseOption(config) {
 	const title = config.title?.trim()
 	return {
-		color: config.options?.colorScheme || ESPRESSO_PALETTE,
+		color: config.options?.colorScheme?.length ? config.options.colorScheme : ESPRESSO_PALETTE,
 		backgroundColor: 'transparent',
 		title: title ? {
 			text: title,

--- a/frontend/src/apps/sheets/engine/chart-data.test.ts
+++ b/frontend/src/apps/sheets/engine/chart-data.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { buildOption } from './chart-data.js'
+
+const cfg = (over = {}) => ({
+	chartType: 'bar',
+	title:     '',
+	hasHeader: true,
+	encoding:  { x: 0, y: [1] },
+	options:   {},
+	...over,
+})
+
+describe('buildOption — aggregation', () => {
+	// Repeated X values so grouping is observable: Apple 10+20, Banana 5+15.
+	const REPEATED = [
+		['Fruit', 'Qty'],
+		['Apple', 10],
+		['Apple', 20],
+		['Banana', 5],
+		['Banana', 15],
+	]
+	const agg = over => buildOption(cfg({ chartType: 'bar', encoding: { x: 0, y: [1] }, ...over }), REPEATED)
+
+	it('leaves rows untouched when aggregate is absent (default)', () => {
+		const opt = agg({})
+		expect(opt.xAxis.data).toEqual(['Apple', 'Apple', 'Banana', 'Banana'])
+		expect(opt.series[0].data).toEqual([10, 20, 5, 15])
+	})
+
+	it('leaves rows untouched when aggregate is "none"', () => {
+		const opt = agg({ options: { aggregate: 'none' } })
+		expect(opt.series[0].data).toEqual([10, 20, 5, 15])
+	})
+
+	it('collapses repeated X values with sum, preserving first-appearance order', () => {
+		const opt = agg({ options: { aggregate: 'sum' } })
+		expect(opt.xAxis.data).toEqual(['Apple', 'Banana'])
+		expect(opt.series[0].data).toEqual([30, 20])
+	})
+
+	it('supports avg / min / max / count', () => {
+		expect(agg({ options: { aggregate: 'avg' } }).series[0].data).toEqual([15, 10])
+		expect(agg({ options: { aggregate: 'min' } }).series[0].data).toEqual([10, 5])
+		expect(agg({ options: { aggregate: 'max' } }).series[0].data).toEqual([20, 15])
+		expect(agg({ options: { aggregate: 'count' } }).series[0].data).toEqual([2, 2])
+	})
+})

--- a/frontend/src/apps/sheets/engine/charts.js
+++ b/frontend/src/apps/sheets/engine/charts.js
@@ -104,10 +104,37 @@ export function isValidChartType(t) {
 	return CHART_TYPES.includes(t)
 }
 
+// Aggregation functions offered in the chart dialog. `none` (the default)
+// plots each source row as-is; the rest group rows by the X-axis value and
+// summarise each series column — see `_aggregate` in chart-data.js. Values are
+// the authoritative keys stored in a chart's `options.aggregate`.
+export const CHART_AGGREGATIONS = [
+	{ value: 'none',  label: 'None (plot each row)' },
+	{ value: 'sum',   label: 'Sum' },
+	{ value: 'avg',   label: 'Average' },
+	{ value: 'count', label: 'Count' },
+	{ value: 'min',   label: 'Min' },
+	{ value: 'max',   label: 'Max' },
+]
+
 // Espresso-aligned categorical palette. ECharts default greys clash with
 // the rest of the UI; this set matches the cyan accent already used in the
 // brand mark and the cursor palette.
 export const ESPRESSO_PALETTE = [
 	'#0E7490', '#A5F0FA', '#0891B2', '#67E8F9',
 	'#155E75', '#22D3EE', '#0C4A6E', '#7DD3FC',
+]
+
+// Curated categorical palettes offered in the chart dialog. Each is 8 stops so
+// it lines up with the default series cap. `colorScheme` in a chart's options,
+// when set, overrides the default (read in chart-data.js `_baseOption`); the
+// first entry here IS the default palette, so a chart with no colorScheme and
+// one explicitly set to Espresso render identically.
+export const CHART_PALETTES = [
+	{ name: 'Espresso', colors: ESPRESSO_PALETTE },
+	{ name: 'Ocean',    colors: ['#1E3A8A', '#3B82F6', '#0891B2', '#60A5FA', '#1E40AF', '#38BDF8', '#1D4ED8', '#93C5FD'] },
+	{ name: 'Forest',   colors: ['#166534', '#22C55E', '#65A30D', '#4ADE80', '#15803D', '#84CC16', '#14532D', '#BEF264'] },
+	{ name: 'Sunset',   colors: ['#B45309', '#F59E0B', '#DC2626', '#FB923C', '#92400E', '#FBBF24', '#7C2D12', '#FDBA74'] },
+	{ name: 'Berry',    colors: ['#9D174D', '#EC4899', '#7C3AED', '#F472B6', '#BE185D', '#A78BFA', '#831843', '#C4B5FD'] },
+	{ name: 'Slate',    colors: ['#334155', '#64748B', '#94A3B8', '#475569', '#1E293B', '#CBD5E1', '#0F172A', '#E2E8F0'] },
 ]


### PR DESCRIPTION
## What

Adds two capabilities to the Sheets chart dialog.

**Aggregation** — an "Aggregate" control that groups rows sharing an X value (or, for a pie chart, a slice label) and summarises them: **none** (default), **sum**, **average**, **min**, **max**, **count**. The grouping runs inside the chart data pipeline (`_aggregate` in `chart-data.js`), so every chart type honours it. A hint under the control explains the grouping while it's active.

**Colours** — preset colour **palettes** (`CHART_PALETTES`, Espresso as the default) plus **per-series colour overrides** for non-pie charts, with a Reset button once a custom colour is chosen.

## Scope

Frontend only, three files:
- `engine/charts.js` — `CHART_AGGREGATIONS` + `CHART_PALETTES` definitions
- `engine/chart-data.js` — `_aggregate()` group-and-summarise in the data pipeline
- `components/SheetEditor/ChartDialog.vue` — the Aggregate select, palette picker, and per-series colour inputs

No backend, doctype, or routing changes.

## Testing

- Frontend unit suite green (1322 tests).
- Aggregation verified across bar/line/pie: rows with a repeated X collapse into one summarised point; `none` leaves raw rows untouched.
- Palette selection + per-series overrides apply live; Reset restores the default Espresso palette.
