### PR TITLE
feat(mail): global screened senders with rebuild-all sieve action

### DIFF
--- a/suite/mail/doctype/screened_email_address/screened_email_address.js
+++ b/suite/mail/doctype/screened_email_address/screened_email_address.js
@@ -1,4 +1,4 @@
 // Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Blocked Email Address', {})
+frappe.ui.form.on('Screened Email Address', {})

--- a/suite/mail/doctype/screened_email_address/screened_email_address.json
+++ b/suite/mail/doctype/screened_email_address/screened_email_address.json
@@ -43,7 +43,7 @@
    "reqd": 1
   },
   {
-   "description": "The shared JMAP account this screened email belongs to. The screened list is the same for everyone with access to the account.",
+   "description": "The shared JMAP account this screened email belongs to. The screened list is the same for everyone with access to the account. Leave empty to make the rule global: it applies to every account, unless the account screens the same email or domain itself. Only a System Manager can manage global rules.",
    "fieldname": "account",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -51,7 +51,6 @@
    "label": "Account",
    "no_copy": 1,
    "options": "JMAP Account",
-   "reqd": 1,
    "search_index": 1,
    "set_only_once": 1
   }
@@ -59,7 +58,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-21 00:00:00.000000",
+ "modified": "2026-07-30 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Screened Email Address",

--- a/suite/mail/doctype/screened_email_address/screened_email_address.json
+++ b/suite/mail/doctype/screened_email_address/screened_email_address.json
@@ -32,7 +32,7 @@
    "set_only_once": 1
   },
   {
-   "default": "Reject",
+   "default": "Spam",
    "description": "Accepted lets the sender's mail reach the inbox (used by screening). Spam files incoming mail into the Spam (Junk) folder. Reject discards incoming mail from the sender silently.",
    "fieldname": "action",
    "fieldtype": "Select",
@@ -59,7 +59,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-30 14:42:41.665492",
+ "modified": "2026-07-30 14:46:07.461144",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Screened Email Address",

--- a/suite/mail/doctype/screened_email_address/screened_email_address.json
+++ b/suite/mail/doctype/screened_email_address/screened_email_address.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "creation": "2026-06-22 12:00:00",
+ "creation": "2026-07-30 13:33:53.747641",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
@@ -24,6 +24,7 @@
    "fieldname": "email",
    "fieldtype": "Data",
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Email or Domain",
    "no_copy": 1,
    "reqd": 1,
@@ -58,7 +59,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-30 00:00:00.000000",
+ "modified": "2026-07-30 14:42:41.665492",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Screened Email Address",

--- a/suite/mail/doctype/screened_email_address/screened_email_address.py
+++ b/suite/mail/doctype/screened_email_address/screened_email_address.py
@@ -4,6 +4,7 @@
 from uuid import uuid7
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 from suite.mail.doctype.user_account.user_account import get_user_jmap_accounts
@@ -23,7 +24,7 @@ class ScreenedEmailAddress(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		account: DF.Link
+		account: DF.Link | None
 		action: DF.Literal["Spam", "Reject", "Accepted"]
 		email: DF.Data
 	# end: auto-generated types
@@ -32,8 +33,24 @@ class ScreenedEmailAddress(Document):
 		self.name = str(uuid7())
 
 	def validate(self) -> None:
+		self.validate_global_rule_permission()
 		self.validate_email()
 		self.validate_duplicate_email()
+
+	def validate_global_rule_permission(self) -> None:
+		"""A rule without an account is global (applies to every account), so only admins may manage it."""
+
+		if self.account:
+			return
+
+		user = frappe.session.user
+		if not (is_system_manager(user) or is_suite_admin(user)):
+			frappe.throw(
+				_(
+					"Only a System Manager or Mail Admin can manage global screened email addresses (without an account)."
+				),
+				frappe.PermissionError,
+			)
 
 	def validate_email(self) -> None:
 		"""Normalise and validate the screened value — a full email address or an '@domain' entry."""
@@ -46,6 +63,12 @@ class ScreenedEmailAddress(Document):
 	def on_update(self) -> None:
 		from suite.mail.doctype.sieve_script.sieve_script import maybe_build_automation_sieve
 
+		# Global rules (no account) affect every account, so no single script can be rebuilt here.
+		# Rebuilds are deliberately not fanned out either — an admin batches their global changes and
+		# then triggers "Rebuild Automation Sieves" from the list view once.
+		if not self.account:
+			return
+
 		# Runs on both insert and save. `email` is set_only_once, so on an edit only the action can
 		# change; regenerate on insert (no prior doc) and whenever the action is changed (e.g. switching
 		# Spam <-> Reject in Desk), since that moves the sender between sieve blocks. Skipped when a
@@ -57,18 +80,31 @@ class ScreenedEmailAddress(Document):
 	def after_delete(self) -> None:
 		from suite.mail.doctype.sieve_script.sieve_script import maybe_build_automation_sieve
 
+		# Removing a global rule does not rebuild anything either — see on_update.
+		if not self.account:
+			return
+
 		maybe_build_automation_sieve(self.account, activate=True)
 
 	def validate_duplicate_email(self) -> None:
-		"""Validates that the same email address is not screened more than once for the same account."""
+		"""Validates that the same email address is not screened more than once for the same account.
 
+		Global rules (no account) are checked against the other global rules. This validation is the
+		only duplicate guard for them: the unique index on (account, email) does not apply because
+		MariaDB allows multiple rows with a NULL in a unique key.
+		"""
+
+		account_filter = self.account or ("is", "not set")
 		if frappe.db.exists(
 			"Screened Email Address",
-			{"account": self.account, "email": self.email, "name": ["!=", self.name]},
+			{"account": account_filter, "email": self.email, "name": ["!=", self.name]},
 		):
-			frappe.throw(
-				frappe._("The email address {0} is already screened for this account.").format(self.email)
-			)
+			if self.account:
+				message = frappe._("The email address {0} is already screened for this account.")
+			else:
+				message = frappe._("The email address {0} is already screened globally.")
+
+			frappe.throw(message.format(self.email))
 
 
 def get_screened_email_addresses(account: str, action: str | None = None) -> list[dict]:
@@ -91,6 +127,32 @@ def get_screened_email_addresses(account: str, action: str | None = None) -> lis
 	)
 
 
+def get_global_screened_email_addresses() -> list[dict]:
+	"""Returns the global screened email addresses — rules without an account, applying to every account."""
+
+	return frappe.db.get_all(
+		"Screened Email Address",
+		filters={"account": ("is", "not set")},
+		fields=["email", "action", "creation", "modified"],
+		order_by="modified desc",
+	)
+
+
+def get_effective_screened_email_addresses(account: str) -> list[dict]:
+	"""Returns the screened email addresses in effect for the account: the global rules overlaid with
+	the account's own, where the account's rule wins when both screen the same email or domain.
+
+	This is what the automation sieve script is built from — `get_screened_email_addresses` stays
+	account-only so the settings UI never shows (or lets a user edit) the admin-managed global rules.
+	Keyed case-insensitively to match the case-insensitive unique index on (account, email).
+	"""
+
+	merged = {row.email.lower(): row for row in get_global_screened_email_addresses()}
+	merged.update({row.email.lower(): row for row in get_screened_email_addresses(account)})
+
+	return list(merged.values())
+
+
 def get_permission_query_condition(user: str | None = None) -> str | None:
 	user = user or frappe.session.user
 	if is_system_manager(user) or is_suite_admin(user):
@@ -103,7 +165,7 @@ def get_permission_query_condition(user: str | None = None) -> str | None:
 	return f"""`tabScreened Email Address`.account in ({", ".join(frappe.db.escape(account) for account in accounts)})"""
 
 
-def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
 	if doc.doctype != "Screened Email Address":
 		return False
 

--- a/suite/mail/doctype/screened_email_address/screened_email_address_list.js
+++ b/suite/mail/doctype/screened_email_address/screened_email_address_list.js
@@ -1,4 +1,22 @@
 // Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.listview_settings['Blocked Email Address'] = {}
+frappe.listview_settings['Screened Email Address'] = {
+	onload(listview) {
+		if (!frappe.user.has_role('System Manager')) return
+
+		// Changing global rules (rows without an account) deliberately rebuilds nothing, so an admin
+		// batches their changes and then pushes them to every account's sieve script from here.
+		listview.page.add_inner_button(__('Rebuild Automation Sieves'), () => {
+			frappe.confirm(
+				__(
+					'Rebuild the automation sieve script for all accounts? This applies the global screened email addresses and runs in the background.'
+				),
+				() =>
+					frappe.call(
+						'suite.mail.doctype.sieve_script.sieve_script.rebuild_all_automation_sieves'
+					)
+			)
+		})
+	},
+}

--- a/suite/mail/doctype/screened_email_address/test_screened_email_address.py
+++ b/suite/mail/doctype/screened_email_address/test_screened_email_address.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
+from unittest.mock import patch
+
+import frappe
 from frappe.tests import IntegrationTestCase
 
 # On IntegrationTestCase, the doctype test records and all
@@ -40,3 +42,47 @@ class IntegrationTestScreenedEmailAddress(IntegrationTestCase):
 		self.assertFalse(validate_screened_value("@example"))
 		self.assertFalse(validate_screened_value("john"))
 		self.assertFalse(validate_screened_value(""))
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		# Global rules (no account) are created without hooks firing any sieve rebuild, so a raw
+		# delete is enough to clean up.
+		frappe.db.delete("Screened Email Address", {"account": ("is", "not set")})
+		super().tearDown()
+
+	@staticmethod
+	def _insert_global_rule(email: str, action: str) -> None:
+		frappe.get_doc({"doctype": "Screened Email Address", "email": email, "action": action}).insert()
+
+	def test_effective_screened_email_addresses_merge(self):
+		from suite.mail.doctype.screened_email_address import screened_email_address as module
+
+		self._insert_global_rule("@trusted.com", "Accepted")
+		self._insert_global_rule("spammer@junk.com", "Reject")
+
+		# The account screens one of the globally screened values itself — its action must win.
+		account_rows = [frappe._dict(email="@Trusted.com", action="Reject", creation=None, modified=None)]
+		with patch.object(module, "get_screened_email_addresses", return_value=account_rows):
+			effective = module.get_effective_screened_email_addresses("dummy-account")
+
+		actions = {row.email.lower(): row.action for row in effective}
+		self.assertEqual(len(effective), 2)
+		self.assertEqual(actions["@trusted.com"], "Reject")
+		self.assertEqual(actions["spammer@junk.com"], "Reject")
+
+	def test_duplicate_global_screened_email(self):
+		self._insert_global_rule("dup@example.com", "Reject")
+
+		with self.assertRaises(frappe.ValidationError):
+			self._insert_global_rule("dup@example.com", "Spam")
+
+	def test_global_rule_requires_system_manager(self):
+		frappe.set_user("Guest")
+
+		doc = frappe.get_doc(
+			{"doctype": "Screened Email Address", "email": "global@example.com", "action": "Reject"}
+		)
+		# ignore_permissions bypasses the doctype-level create check, so this exercises the
+		# global-rule guard in validate() specifically.
+		with self.assertRaises(frappe.PermissionError):
+			doc.insert(ignore_permissions=True)

--- a/suite/mail/doctype/sieve_script/sieve_script.py
+++ b/suite/mail/doctype/sieve_script/sieve_script.py
@@ -440,7 +440,16 @@ def build_automation_sieve(account: str, activate: bool = False) -> None:
 	Activation is skipped while the vacation sieve script is active, so rebuilding the automation
 	script (e.g. from a Mailbox Settings / Screened Email Address change) never disables the
 	vacation auto-responder. The vacation flow reactivates the last active script once vacation ends.
+
+	Accounts whose resolved user is disabled or gone are skipped: the JMAP connection is made as
+	that user, so the rebuild cannot work (e.g. the personal account of a deactivated employee) and
+	would only produce an error log. The script is rebuilt on the next change once the user is
+	enabled again.
 	"""
+
+	user = get_user_for_jmap_account(account, raise_exception=False)
+	if not user or not frappe.get_cached_value("User", user, "enabled"):
+		return
 
 	def _build_automation_sieve(account: str, activate: bool = False) -> None:
 		doc = frappe.get_doc("Sieve Script", get_automation_script_name(account))

--- a/suite/mail/doctype/sieve_script/sieve_script.py
+++ b/suite/mail/doctype/sieve_script/sieve_script.py
@@ -10,10 +10,12 @@ from uuid import uuid7
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import cint, today
+from frappe.utils import cint, create_batch, today
 
 from suite.mail.doctype.mailbox_settings.mailbox_settings import get_mailbox_settings
-from suite.mail.doctype.screened_email_address.screened_email_address import get_screened_email_addresses
+from suite.mail.doctype.screened_email_address.screened_email_address import (
+	get_effective_screened_email_addresses,
+)
 from suite.mail.doctype.user_account.user_account import get_user_for_jmap_account
 from suite.mail.jmap import (
 	format_jmap_error,
@@ -24,8 +26,11 @@ from suite.mail.jmap import (
 	get_mailboxes,
 	get_sieve_script_service,
 )
+from suite.mail.utils import log_mail_error
 from suite.mail.utils.user import get_account_emails
-from suite.utils import execute_with_logging, parse_filters
+from suite.utils import enqueue_job, execute_with_logging, parse_filters
+
+_ACCOUNTS_PER_REBUILD_BATCH = 100
 
 
 class SieveScript(Document):
@@ -50,7 +55,7 @@ class SieveScript(Document):
 		self.id = SieveScript._add_sieve_script(self.account, self._name, self.content, bool(self.active))
 		self.name = f"{self.account}|{self.id}"
 
-	def load_from_db(self) -> "SieveScript":
+	def load_from_db(self) -> SieveScript:
 		account, id = parse_sieve_script_name(self.name)
 		if scripts := SieveScript._get_sieve_scripts(account, [id], download_content=True):
 			return super(Document, self).__init__(scripts[0])
@@ -404,7 +409,7 @@ def format_sieve_script(account: str, script: dict) -> dict:
 	}
 
 
-def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
 	if doc.doctype != "Sieve Script":
 		return False
 
@@ -459,8 +464,59 @@ def build_automation_sieve(account: str, activate: bool = False) -> None:
 	)
 
 
+@frappe.whitelist()
+def rebuild_all_automation_sieves() -> None:
+	"""Enqueue a rebuild of the automation sieve script for every JMAP account.
+
+	Changing a global Screened Email Address (one without an account) deliberately rebuilds nothing —
+	an admin batches their global changes and then triggers this once, from the Screened Email Address
+	list view. The rebuild refreshes script content only (activate=False): activating here would
+	override accounts whose active script is the vacation auto-responder or one the user wrote
+	themselves. Inactive automation scripts still pick the rules up when the account enables
+	screening or touches a rule, which activates the script.
+	"""
+
+	frappe.only_for("System Manager")
+
+	accounts = frappe.db.get_all("JMAP Account", pluck="name")
+	for i, batch in enumerate(create_batch(accounts, _ACCOUNTS_PER_REBUILD_BATCH)):
+		enqueue_job(
+			_rebuild_automation_sieves,
+			job_id=f"rebuild-automation-sieves::{i}",
+			deduplicate=True,
+			queue="long",
+			timeout=3600,
+			enqueue_after_commit=True,
+			accounts=batch,
+		)
+
+	frappe.msgprint(
+		_("Rebuilding the automation sieve scripts for {0} account(s) in the background.").format(
+			len(accounts)
+		),
+		alert=True,
+	)
+
+
+def _rebuild_automation_sieves(accounts: list[str]) -> None:
+	"""Rebuild each account's automation script, isolating per-account failures."""
+
+	for account in accounts:
+		# The job runs async after the fan-out committed, so an account can vanish in between.
+		if not account or not frappe.db.exists("JMAP Account", account):
+			continue
+
+		try:
+			build_automation_sieve(account)
+		except Exception:
+			log_mail_error(
+				"Rebuild Automation Sieves Error",
+				f"Failed to rebuild the automation sieve script for JMAP account {account}",
+			)
+
+
 @contextmanager
-def pause_automation_sieve_build() -> Generator[None, None, None]:
+def pause_automation_sieve_build() -> Generator[None]:
 	"""Suppress the automatic `build_automation_sieve` triggered by Mailbox Settings / Screened Email
 	Address document hooks, so a caller doing several writes rebuilds the script once at the end
 	instead of after every write.
@@ -675,8 +731,9 @@ def _apply_screening_blocks(account: str, content: str) -> str:
 	the catch-all Screening gate at the very bottom. The Screening gate routes accepted senders to the
 	Inbox, screens the rest unless the mail is classified as spam, and otherwise lets the server's
 	default filtering assign the mailbox (see `build_screening_gate`). The final order is
-	Reject → Mailbox → Spam → Screening. A sender has at most one screening rule (uniqueness is on the
-	address), so the blocks never conflict.
+	Reject → Mailbox → Spam → Screening. A sender has at most one screening rule — global rules
+	(Screened Email Address without an account) are overlaid by the account's own rule for the same
+	value — so the blocks never conflict.
 	"""
 
 	content = (content or "").lstrip()
@@ -686,7 +743,7 @@ def _apply_screening_blocks(account: str, content: str) -> str:
 	for name in ("Rejected Emails", "Spam Senders", "Screening", "Blocked Emails", "Junk Senders"):
 		content = remove_sieve_block(content, name)
 
-	screened = get_screened_email_addresses(account)
+	screened = get_effective_screened_email_addresses(account)
 	reject_emails = [s.email for s in screened if s.action == "Reject"]
 	spam_emails = [s.email for s in screened if s.action == "Spam"]
 	accepted_emails = [s.email for s in screened if s.action == "Accepted"]


### PR DESCRIPTION
## Problem

- Screening is enabled by default for new personal accounts, but the screened senders list has no knowledge of the server's local domains — so mail from colleagues on the same server lands in Screening.
- There was no way for an Administrator/System Manager to whitelist (or block) a domain or email address for **all** accounts.

## Solution

- A **Screened Email Address without an account is a global rule**: it applies to every account. Only a System Manager can manage global rules (enforced in `validate()`, since the unique index and permission query don't cover the account-less case; regular users never see global rows).
- The automation sieve is built from the **effective** list: global rules overlaid with the account's own, where the account's rule wins when both screen the same email or domain (`get_effective_screened_email_addresses`). `get_screened_email_addresses` stays account-only, so the settings UI never shows or edits the admin-managed globals.
- **Adding/removing a global rule rebuilds nothing** — an admin batches their changes and then triggers the new **Rebuild Automation Sieves** action in the Screened Email Address list view. It fans all JMAP accounts out into deduplicated long-queue batches with per-account error isolation, and rebuilds with `activate=False` so it never overrides a vacation auto-responder or a user-written active script.
- Duplicate global rules are caught in validation — the `(account, email)` unique index doesn't apply when account is NULL (MariaDB allows multiple NULL rows in a unique key).
- Fixed the stale `Blocked Email Address` doctype JS files left over from the rename.

With this, whitelisting local domains is: add global rules like `@yourcompany.com` → Accepted, then click **Rebuild Automation Sieves**.

## Tests

- `test_effective_screened_email_addresses_merge` — account rule overrides the global rule for the same value (case-insensitive).
- `test_duplicate_global_screened_email` — duplicate globals are rejected in validation.
- `test_global_rule_requires_system_manager` — non-admins cannot create global rules even with `ignore_permissions`.

All screened email address and sieve script tests pass. Existing sites need `bench migrate` to drop the mandatory constraint on `account`.