### PR TITLE
feat(mail): open threads in place in All Inboxes, with Split View and keyboard navigation

### DIFF
--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -515,7 +515,9 @@ const sidebarItems = computed(() => {
 			label: __('All Inboxes'),
 			icon: Mails,
 			to: { name: 'mail-all-inboxes' },
-			activeFor: ['mail-all-inboxes'],
+			// A thread opened from the merged list is its own route (it carries the
+			// thread's real account/mailbox params) but still belongs to this item.
+			activeFor: ['mail-all-inboxes', 'mail-all-inboxes-mail'],
 			suffix: allInboxesUnread.data ? String(allInboxesUnread.data) : '',
 		})
 	if (screenerItem && screeningEnabled.value) pinnedItems.push(screenerItem)

--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -93,7 +93,7 @@ import { Avatar, Button, Dropdown, Sidebar, SidebarItem } from 'frappe-ui'
 import { useAppSwitcher } from '@/composables/useAppSwitcher'
 import { FOLDER_ICON_COLOR_MAP } from '@/apps/mail/constants'
 import { getIcon, getMailboxName, toTitleCase } from '@/apps/mail/utils'
-import { useScreenSize, useSettings, useSidebar } from '@/apps/mail/utils/composables'
+import { useAccountSwitch, useScreenSize, useSettings, useSidebar } from '@/apps/mail/utils/composables'
 import { sessionStore } from '@/apps/mail/stores/session'
 import { userStore } from '@/apps/mail/stores/user'
 import MailLogo from '@/apps/mail/components/Icons/MailLogo.vue'
@@ -135,6 +135,7 @@ import Wrench from '~icons/lucide/wrench'
 const route = useRoute()
 const router = useRouter()
 const { isMobile } = useScreenSize()
+const { switchAccount } = useAccountSwitch()
 const { isSidebarOpen, closeSidebar } = useSidebar()
 const isSidebarCollapsed = useStorage('isSidebarCollapsed', false)
 const { logout, branding } = sessionStore()
@@ -231,17 +232,7 @@ const menuItems = computed(() => [
 						'div',
 						{
 							class: 'flex items-center gap-2 p-1.5 rounded hover:bg-surface-gray-2 cursor-pointer w-48 shrink-0',
-							onClick: async () => {
-								// Account-scoped routes carry an accountId, so swap it in place to stay in the
-								// same section. Account-agnostic routes (All Inboxes) have no accountId param —
-								// reusing their name would go nowhere, so route through the account shortcut,
-								// which the guard resolves to that account's default mailbox.
-								router.push(
-									route.params.accountId
-										? { name: route.name, params: { ...route.params, accountId: a.id } }
-										: { name: 'mail-account-shortcut', params: { accountId: a.id } },
-								)
-							},
+							onClick: () => switchAccount(a.id),
 						},
 						[
 							h(Avatar, { label: a._name, size: 'md' }),

--- a/frontend/src/apps/mail/components/AttachmentCapsule.vue
+++ b/frontend/src/apps/mail/components/AttachmentCapsule.vue
@@ -31,10 +31,12 @@ import { getAttachmentUrl } from '@/apps/mail/resources'
 import { downloadUrlAsFile, getFileIcon } from '@/apps/mail/utils'
 import { useScreenSize } from '@/apps/mail/utils/composables'
 
-const { fileName, blobID, type } = defineProps<{
+const { fileName, blobID, type, account } = defineProps<{
 	fileName: string
 	blobID?: string
 	type?: string
+	// The blob's owning account (merged lists / cross-account panes); active when unset.
+	account?: string
 }>()
 
 const { isMobile } = useScreenSize()
@@ -56,7 +58,7 @@ const downloadAttachment = async () => {
 
 	isDownloading.value = true
 	try {
-		const url = await getAttachmentUrl(blobID, type)
+		const url = await getAttachmentUrl(blobID, type, account)
 		downloadUrlAsFile(url, fileName || 'attachment')
 	} catch {
 		// the resource's onError already raised a toast; just stop spinning

--- a/frontend/src/apps/mail/components/AttachmentViewer.vue
+++ b/frontend/src/apps/mail/components/AttachmentViewer.vue
@@ -177,9 +177,11 @@ import { useScreenSize } from '@/apps/mail/utils/composables'
 
 import type { Attachment } from '@/apps/mail/types'
 
-const { attachments, initialIndex } = defineProps<{
+const { attachments, initialIndex, account } = defineProps<{
 	attachments?: Attachment[]
 	initialIndex?: number
+	// The blobs' owning account (merged lists / cross-account panes); active when unset.
+	account?: string
 }>()
 
 const { isMobile } = useScreenSize()
@@ -232,6 +234,7 @@ const loadAttachment = async () => {
 		previewUrl.value = await getAttachmentUrl(
 			currentAttachment.value.blob_id,
 			currentAttachment.value.type,
+			account,
 		)
 	} catch {
 		// the resource's onError already raised a toast; the viewer falls back to

--- a/frontend/src/apps/mail/components/ComposeMailEditor.vue
+++ b/frontend/src/apps/mail/components/ComposeMailEditor.vue
@@ -257,7 +257,7 @@ import {
 } from '@/apps/mail/utils'
 import { useScreenSize, useVisualViewport } from '@/apps/mail/utils/composables'
 import { CustomParagraphExtension } from '@/apps/mail/utils/text-editor'
-import { userStore } from '@/apps/mail/stores/user'
+import { injectAccountScope } from '@/apps/mail/utils/accountScope'
 import ComposeMailToolbar from '@/apps/mail/components/ComposeMailToolbar.vue'
 
 import type { Attachment, ComposeMailData, File as FileDoc, Identity, UserResource } from '@/apps/mail/types'
@@ -280,19 +280,20 @@ const {
 const emit = defineEmits(['discardMail', 'reply', 'replyAll', 'forward', 'popOut'])
 
 const router = useRouter()
-const store = userStore()
-// Read store.accountId live in makeParams; destructuring would snapshot the
-// unwrapped value and miss account switches while this editor stays mounted.
-const { identities } = store
+// The editor sends as the enclosing pane's account (the thread's owning account in
+// All Inboxes, the active one everywhere else): identities, the account's default
+// outgoing email and every create/draft call resolve through this scope.
+const scope = injectAccountScope()
+const { accountId: scopeAccountId, identities, mailboxIds } = scope
 
 const viewSentMessage = (threadID: string) =>
 	router.push({
 		name: 'mail-mail',
-		params: { accountId: store.accountId, mailbox: store.mailboxIds.sent, threadID },
+		params: { accountId: scopeAccountId.value, mailbox: mailboxIds.value.sent, threadID },
 	})
 
 const getIdentity = (email: string) =>
-	identities.data?.find((identity: Identity) => identity.email === email)
+	identities.value.data?.find((identity: Identity) => identity.email === email)
 
 // Editor
 
@@ -330,11 +331,9 @@ const editorHeight = useVisualViewport(
 const user = inject('$user') as UserResource
 
 const getDefaultFromEmail = () => {
-	const identityEmails = identities.data?.map((i: Identity) => i.email) ?? []
-	// The default outgoing email is now per-account; pick the active account's.
-	const defaultOutgoingEmail = user.data?.accounts?.find(
-		(a) => a.id === store.accountId,
-	)?.default_outgoing_email
+	const identityEmails = identities.value.data?.map((i: Identity) => i.email) ?? []
+	// The default outgoing email is per-account; pick the scope account's.
+	const defaultOutgoingEmail = scope.account.value?.default_outgoing_email
 
 	return (
 		identityEmails.find((e) => e === mailDetails?.from_email) ??
@@ -458,7 +457,7 @@ const onMailUpdateSuccess = ({
 const createMail = createResource({
 	url: 'suite.mail.api.mail.create_mail',
 	makeParams: ({ save_as_draft }: { save_as_draft: boolean }) => ({
-		account: store.accountId,
+		account: scopeAccountId.value,
 		...mail,
 		...processInlineImages(mail),
 		from_name: getIdentity(mail.from_email!)._name,
@@ -471,7 +470,7 @@ const createMail = createResource({
 const updateDraft = createResource({
 	url: 'suite.mail.api.mail.update_draft_mail',
 	makeParams: ({ submit }: { submit: boolean }) => ({
-		account: store.accountId,
+		account: scopeAccountId.value,
 		...mail,
 		...processInlineImages(mail),
 		from_name: getIdentity(mail.from_email!)._name,
@@ -483,7 +482,7 @@ const updateDraft = createResource({
 
 const deleteMail = createResource({
 	url: 'suite.mail.api.mail.delete_mail',
-	makeParams: () => ({ account: store.accountId, id: mail.id }),
+	makeParams: () => ({ account: scopeAccountId.value, id: mail.id }),
 	onSuccess: () => {
 		reloadMails()
 		raiseToast(__('Draft discarded.'))
@@ -599,7 +598,7 @@ const openAttachment = async (blob_id?: string, type?: string) => {
 	if (!tab) return raiseToast(__('Allow popups to open attachments.'), 'error')
 
 	try {
-		tab.location.href = await getAttachmentUrl(blob_id, type)
+		tab.location.href = await getAttachmentUrl(blob_id, type, scopeAccountId.value)
 	} catch {
 		tab.close()
 	}

--- a/frontend/src/apps/mail/components/MailActions.vue
+++ b/frontend/src/apps/mail/components/MailActions.vue
@@ -304,11 +304,18 @@ const setMailsSeen = createResource({
 	makeParams: ({ ids }: { ids: string[] }) => ({ account: scopeAccountId.value, ids, seen: false }),
 	onSuccess: (ids: string[]) => {
 		raiseToast(__('{0} marked as unread.', [ids.length === 1 ? __('Mail') : __('Mails')]))
-		router.push({
-			name: 'mail-mailbox',
-			params: { accountId: route.params.accountId, mailbox },
-			query: route.query,
-		})
+		// Leaving the thread is the point — staying would mark it read again. Return to whichever
+		// list we came from: hardcoding the mailbox route threw All Inboxes out of the merged view
+		// and into the owning account's mailbox, which read as the page reloading.
+		router.push(
+			route.name === 'mail-all-inboxes-mail'
+				? { name: 'mail-all-inboxes', query: route.query }
+				: {
+						name: 'mail-mailbox',
+						params: { accountId: route.params.accountId, mailbox },
+						query: route.query,
+					},
+		)
 		emit('syncUnseen', ids)
 	},
 })

--- a/frontend/src/apps/mail/components/MailActions.vue
+++ b/frontend/src/apps/mail/components/MailActions.vue
@@ -59,7 +59,7 @@ import {
 	raiseToast,
 } from '@/apps/mail/utils'
 import { useFilterBySender, useScreenSize, useUndo } from '@/apps/mail/utils/composables'
-import { userStore } from '@/apps/mail/stores/user'
+import { injectAccountScope } from '@/apps/mail/utils/accountScope'
 
 import type { ComposeMailData, Identity, Mail, ScreenedAddress } from '@/apps/mail/types'
 
@@ -94,10 +94,11 @@ const emit = defineEmits(['setFlagged', 'syncUnseen', 'moveMail', 'markMailSpam'
 const { isMobile } = useScreenSize()
 const route = useRoute()
 const router = useRouter()
-// Read store.accountId live in makeParams; destructuring would snapshot the
-// unwrapped value and miss account switches while this component stays mounted.
-const store = userStore()
-const { mailboxes, mailboxIds, identities, screenedAddresses } = store
+// Everything account-scoped resolves through the enclosing pane's scope — the
+// thread's owning account in All Inboxes, the active account otherwise. The
+// computed refs read live, so makeParams always sees the pane's current account.
+const { accountId: scopeAccountId, mailboxIds, identities, screenedAddresses } =
+	injectAccountScope()
 const { setUndoAction, undo } = useUndo()
 const { filterBySender } = useFilterBySender()
 const user = inject('$user')
@@ -105,7 +106,7 @@ const user = inject('$user')
 // A sender is "blocked" when screened with the Reject action (their mail is discarded) — either by their
 // exact address or by a '@domain' entry covering them.
 const isSenderBlocked = (email: string) =>
-	screenedAddresses.data?.some(
+	screenedAddresses.value.data?.some(
 		(a: ScreenedAddress) => a.action === 'Reject' && matchesScreenedValue(email, a.email),
 	)
 
@@ -114,13 +115,13 @@ const primaryActions = (mail: Mail): MailAction[] => [
 		label: __('Unstar'),
 		onClick: () => emit('setFlagged', mail.id, false),
 		icon: () => h(Star, { style: FLAGGED_STAR_STYLE }),
-		condition: !!mail.flagged && mailbox !== mailboxIds.trash && !isMobile.value,
+		condition: !!mail.flagged && mailbox !== mailboxIds.value.trash && !isMobile.value,
 	},
 	{
 		label: __('Star'),
 		onClick: () => emit('setFlagged', mail.id, true),
 		icon: Star,
-		condition: !mail.flagged && !mail.draft && mailbox !== mailboxIds.trash && !isMobile.value,
+		condition: !mail.flagged && !mail.draft && mailbox !== mailboxIds.value.trash && !isMobile.value,
 	},
 	{
 		label: __('Edit Draft'),
@@ -179,19 +180,19 @@ const moreActions = (mail: Mail): GroupedAction[] => [
 				label: __('Unstar'),
 				onClick: () => emit('setFlagged', mail.id, false),
 				icon: () => h(Star, { style: FLAGGED_STAR_STYLE }),
-				condition: () => !!mail.flagged && mailbox !== mailboxIds.trash,
+				condition: () => !!mail.flagged && mailbox !== mailboxIds.value.trash,
 			},
 			{
 				label: __('Star'),
 				onClick: () => emit('setFlagged', mail.id, true),
 				icon: Star,
-				condition: () => !mail.flagged && !mail.draft && mailbox !== mailboxIds.trash,
+				condition: () => !mail.flagged && !mail.draft && mailbox !== mailboxIds.value.trash,
 			},
 			{
 				label: __('Mark as Junk'),
 				onClick: () => emit('markMailSpam', mail, true),
 				icon: CircleAlert,
-				condition: () => mailbox !== mailboxIds.drafts && mail.junk === 0,
+				condition: () => mailbox !== mailboxIds.value.drafts && mail.junk === 0,
 			},
 			{
 				label: __('Mark as Not Junk'),
@@ -201,15 +202,15 @@ const moreActions = (mail: Mail): GroupedAction[] => [
 			},
 			{
 				label: __('Move to Trash'),
-				onClick: () => emit('moveMail', mail, mailboxIds.trash),
+				onClick: () => emit('moveMail', mail, mailboxIds.value.trash),
 				icon: Trash2,
-				condition: () => mailbox !== mailboxIds.trash,
+				condition: () => mailbox !== mailboxIds.value.trash,
 			},
 			{
 				label: __('Delete Message'),
 				onClick: () => emit('deleteMail', mail),
 				icon: Trash2,
-				condition: () => mailbox === mailboxIds.trash,
+				condition: () => mailbox === mailboxIds.value.trash,
 			},
 			{
 				label: thread.length === 1 ? __('Mark as Unread') : __('Mark Unread from Here'),
@@ -228,8 +229,8 @@ const moreActions = (mail: Mail): GroupedAction[] => [
 				onClick: () => handleBlockAddress(true),
 				icon: Ban,
 				condition: () =>
-					mailbox !== mailboxIds.screener &&
-					!identities.data.some((i: Identity) => i.email === mail.from_email) &&
+					mailbox !== mailboxIds.value.screener &&
+					!identities.value.data.some((i: Identity) => i.email === mail.from_email) &&
 					!isSenderBlocked(mail.from_email),
 			},
 			{
@@ -237,14 +238,14 @@ const moreActions = (mail: Mail): GroupedAction[] => [
 				onClick: () => handleBlockAddress(false),
 				icon: LockOpen,
 				condition: () =>
-					mailbox !== mailboxIds.screener && isSenderBlocked(mail.from_email),
+					mailbox !== mailboxIds.value.screener && isSenderBlocked(mail.from_email),
 			},
 			{
 				label: __('Mark Domain as Trusted'),
 				onClick: () => trustDomain.submit(),
 				icon: ShieldCheck,
 				condition: () =>
-					mailbox !== mailboxIds.screener &&
+					mailbox !== mailboxIds.value.screener &&
 					!mail.draft &&
 					!!mail.from_email &&
 					!isDomainTrusted(mail.from_email),
@@ -291,16 +292,16 @@ const downloadEmail = createResource({
 const moveMail = createResource({
 	url: 'suite.mail.api.mail.move_mails',
 	makeParams: (mailbox: string) => ({
-		account: store.accountId,
+		account: scopeAccountId.value,
 		ids: [mail.id],
 		mailbox,
-		clear_junk: mail.junk === 1 && mailbox !== mailboxIds.junk,
+		clear_junk: mail.junk === 1 && mailbox !== mailboxIds.value.junk,
 	}),
 })
 
 const setMailsSeen = createResource({
 	url: 'suite.mail.api.mail.set_mails_seen',
-	makeParams: ({ ids }: { ids: string[] }) => ({ account: store.accountId, ids, seen: false }),
+	makeParams: ({ ids }: { ids: string[] }) => ({ account: scopeAccountId.value, ids, seen: false }),
 	onSuccess: (ids: string[]) => {
 		raiseToast(__('{0} marked as unread.', [ids.length === 1 ? __('Mail') : __('Mails')]))
 		router.push({
@@ -326,7 +327,7 @@ const handleMarkUnreadFromHere = () => {
 // Accepted '@domain' entry — the same state that lets remote images load.
 const senderDomain = (email: string) => `@${(email ?? '').trim().toLowerCase().split('@').pop()}`
 const isDomainTrusted = (email: string) =>
-	!!screenedAddresses.data?.some(
+	!!screenedAddresses.value.data?.some(
 		(a: ScreenedAddress) =>
 			a.action === 'Accepted' && a.email.trim().toLowerCase() === senderDomain(email),
 	)
@@ -334,25 +335,25 @@ const isDomainTrusted = (email: string) =>
 const trustDomain = createResource({
 	url: 'suite.mail.api.mail.screen_email_addresses',
 	makeParams: () => ({
-		account: store.accountId,
+		account: scopeAccountId.value,
 		emails: [senderDomain(mail.from_email)],
 		action: 'Accepted',
 	}),
 	onSuccess: () => {
 		raiseToast(__('Domain marked as trusted.'))
-		screenedAddresses.reload()
+		screenedAddresses.value.reload()
 	},
 	onError: (error) => raiseToast(error.message, 'error'),
 })
 
 const blockEmailAddress = createResource({
 	url: 'suite.mail.api.mail.screen_email_address',
-	makeParams: () => ({ account: store.accountId, email: mail.from_email, action: 'Reject' }),
+	makeParams: () => ({ account: scopeAccountId.value, email: mail.from_email, action: 'Reject' }),
 })
 
 const unblockEmailAddress = createResource({
 	url: 'suite.mail.api.mail.unscreen_email_addresses',
-	makeParams: () => ({ account: store.accountId, emails: [mail.from_email] }),
+	makeParams: () => ({ account: scopeAccountId.value, emails: [mail.from_email] }),
 })
 
 // Optimistically reflect the sender's blocked state so the immediate toast isn't lying, mirroring the
@@ -360,14 +361,14 @@ const unblockEmailAddress = createResource({
 // sender); unblocking removes the exact-address entry — a '@domain' rule that also covers the sender is
 // left in place, just as the unscreen API leaves it. Returns a revert to restore the list on failure.
 const applyScreenOptimistic = (block: boolean) => {
-	const prev = screenedAddresses.data
+	const prev = screenedAddresses.value.data
 	if (!prev) return () => {}
 	const isExact = (a: ScreenedAddress) =>
 		!a.email.startsWith('@') && matchesScreenedValue(mail.from_email, a.email)
 	const kept = prev.filter((a: ScreenedAddress) => !isExact(a))
 	const blocked: ScreenedAddress = { email: mail.from_email, action: 'Reject', creation: '', modified: '' }
-	screenedAddresses.data = block ? [...kept, blocked] : kept
-	return () => (screenedAddresses.data = prev)
+	screenedAddresses.value.data = block ? [...kept, blocked] : kept
+	return () => (screenedAddresses.value.data = prev)
 }
 
 const handleBlockAddress = (block: boolean, isUndo = false) => {
@@ -379,7 +380,7 @@ const handleBlockAddress = (block: boolean, isUndo = false) => {
 			revert()
 			throw error
 		}
-		screenedAddresses.reload()
+		screenedAddresses.value.reload()
 	})()
 	const successMessage = block ? __('Sender blocked.') : __('Sender unblocked.')
 

--- a/frontend/src/apps/mail/components/MailGroupHeader.vue
+++ b/frontend/src/apps/mail/components/MailGroupHeader.vue
@@ -1,0 +1,60 @@
+<template>
+	<!-- The tooltip names the fold, since the chevron alone doesn't say which way it goes. It is
+	     empty — and so not shown — on the last group, which never folds. -->
+	<Tooltip :text="collapsible ? __(collapsed ? 'Expand' : 'Collapse') : ''">
+		<div
+			class="text-ink-gray-6 group flex items-center border-b border-l-transparent p-3.5 text-xs-semibold sm:border-l sm:px-5"
+			:class="{
+				'!bg-surface-blue-1': selected,
+				'sm:hover:bg-surface-gray-1': collapsible,
+				'!border-l-outline-blue-5': focused,
+			}"
+			:data-row-key="`group:${dateKey}`"
+			@click="emit('toggle')"
+		>
+			<!-- The mailbox list puts its "select the whole day" checkbox here. -->
+			<slot name="lead" />
+
+			<span class="select-none pt-[2px]">
+				{{ getFormattedDate(dateKey, monthly).toUpperCase() }}
+			</span>
+
+			<component :is="collapsed ? ChevronRight : ChevronDown" v-if="collapsible" class="icon ml-auto" />
+		</div>
+	</Tooltip>
+</template>
+
+<script setup lang="ts">
+import { ChevronDown, ChevronRight } from 'lucide-vue-next'
+import { Tooltip } from 'frappe-ui'
+
+import { getFormattedDate } from '@/apps/mail/utils'
+
+/**
+ * A date header in a thread list: the day (or month) it covers, a chevron that folds it, and whatever
+ * the list wants beside the date.
+ *
+ * Both lists draw the same header — same classes, same date span, same chevron — and this is the one
+ * navigable row neither gets from buildListRows, which is deliberately date-agnostic.
+ */
+
+defineProps<{
+	/** The group's key: 'YYYY-MM-DD', or 'YYYY-MM' when grouping by month. */
+	dateKey: string
+	/** Grouping by month rather than by day, which the date is formatted for. */
+	monthly: boolean
+	/** Currently folded. */
+	collapsed: boolean
+	/**
+	 * Whether this group can fold at all. The last one never can — it is where infinite scroll
+	 * appends, so hiding it would swallow newly loaded rows.
+	 */
+	collapsible: boolean
+	/** The keyboard cursor is on this header. */
+	focused: boolean
+	/** Every thread in the group is selected (the mailbox list's day checkbox). */
+	selected?: boolean
+}>()
+
+const emit = defineEmits<{ toggle: [] }>()
+</script>

--- a/frontend/src/apps/mail/components/MailListItem.vue
+++ b/frontend/src/apps/mail/components/MailListItem.vue
@@ -12,6 +12,7 @@
 		:datetime="mail.received_at"
 		:subject-italic="!mail.subject"
 		:preview-italic="!mail.preview"
+		:account-label="accountLabel"
 		@set-selected="(selected: boolean) => emit('setSelected', selected)"
 	>
 		<template #sender><span v-html="highlight(header)" /></template>
@@ -25,11 +26,6 @@
 			>
 				{{ messageCount }}
 			</span>
-			<!-- All Inboxes: which account received this mail. -->
-			<div v-if="accountLabel" class="text-ink-gray-4 flex shrink-0 items-center gap-1 text-xs">
-				<span aria-hidden="true">·</span>
-				<span>{{ __('in {0}', [accountLabel]) }}</span>
-			</div>
 			<Badge v-if="mail.draft" size="sm" :label="__('Draft')" theme="red" />
 		</template>
 

--- a/frontend/src/apps/mail/components/MailListItem.vue
+++ b/frontend/src/apps/mail/components/MailListItem.vue
@@ -154,8 +154,12 @@ import { Download, Loader } from 'lucide-vue-next'
 import { Badge, Popover, Tooltip } from 'frappe-ui'
 
 import { getAttachmentUrl } from '@/apps/mail/resources'
-import { downloadUrlAsFile, getFileIcon, getFormattedRecipients, getSenderInitial } from '@/apps/mail/utils'
-import { formatThreadParticipants, primaryParticipant, threadParticipants } from '@/apps/mail/utils/participants'
+import { downloadUrlAsFile, getFileIcon, getFormattedRecipients } from '@/apps/mail/utils'
+import {
+	threadAvatarLabel,
+	threadDisplayName,
+	threadParticipants,
+} from '@/apps/mail/utils/participants'
 import { useOwnEmails } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import AttachmentCapsule from '@/apps/mail/components/AttachmentCapsule.vue'
@@ -253,18 +257,13 @@ const participants = computed(() => threadParticipants(mail.messages, ownEmails.
 
 const header = computed(() => {
 	if (isOutgoing.value) return getFormattedRecipients(mail.recipients) || __('To:')
-	return formatThreadParticipants(participants.value) || mail.from_name || mail.from_email
+	return threadDisplayName(participants.value, mail)
 })
 
 // Gmail-style count of how many messages the conversation holds, shown once there's more than one.
 const messageCount = computed(() => mail.messages?.length ?? 0)
 
-// The letter behind the avatar, for a contact with no picture: whoever the picture itself would be of.
-const avatarLabel = computed(() => {
-	const primary = primaryParticipant(participants.value)
-	if (!primary) return getSenderInitial(mail)
-	return getSenderInitial({ from_name: primary.name, from_email: primary.email })
-})
+const avatarLabel = computed(() => threadAvatarLabel(participants.value, mail))
 
 // In search results, highlight the matched query term. Escape the text first (so any markup in the
 // content is neutralized), then wrap matches in <mark> — the only HTML we inject — for safe v-html.

--- a/frontend/src/apps/mail/components/MailListItem.vue
+++ b/frontend/src/apps/mail/components/MailListItem.vue
@@ -175,6 +175,7 @@ const {
 	selectable = true,
 	hideSender = false,
 	selectionMode = false,
+	threadRouteName = 'mail-mail',
 } = defineProps<{
 	mailbox: string
 	mail: Thread
@@ -190,6 +191,9 @@ const {
 	hideSender?: boolean
 	// Mobile selection mode — forwarded to MailRow.
 	selectionMode?: boolean
+	// Which route the row links to. All Inboxes points at its own thread route so opening a
+	// mail stays in the merged list instead of navigating into one account's mailbox.
+	threadRouteName?: string
 }>()
 
 const emit = defineEmits([
@@ -206,7 +210,7 @@ const { mailboxIds } = userStore()
 const ownEmails = useOwnEmails()
 
 const to = computed(() => ({
-	name: 'mail-mail',
+	name: threadRouteName,
 	params: {
 		accountId: accountId || route.params.accountId,
 		mailbox,

--- a/frontend/src/apps/mail/components/MailListItem.vue
+++ b/frontend/src/apps/mail/components/MailListItem.vue
@@ -4,6 +4,7 @@
 		:is-selected
 		:selectable
 		:selection-mode
+		:hide-avatar
 		:unread="!mail.seen"
 		:hide-sender
 		:avatar-label="avatarLabel"
@@ -176,6 +177,7 @@ const {
 	hideSender = false,
 	selectionMode = false,
 	threadRouteName = 'mail-mail',
+	hideAvatar = false,
 } = defineProps<{
 	mailbox: string
 	mail: Thread
@@ -194,6 +196,8 @@ const {
 	// Which route the row links to. All Inboxes points at its own thread route so opening a
 	// mail stays in the merged list instead of navigating into one account's mailbox.
 	threadRouteName?: string
+	// Forwarded to MailRow — see there.
+	hideAvatar?: boolean
 }>()
 
 const emit = defineEmits([

--- a/frontend/src/apps/mail/components/MailListItem.vue
+++ b/frontend/src/apps/mail/components/MailListItem.vue
@@ -66,6 +66,7 @@
 						:file-name="attachment.filename"
 						:blob-i-d="attachment.blob_id"
 						:type="attachment.type"
+						:account="accountId"
 						class="mr-2"
 						:class="isFullWidth ? 'max-w-32' : 'max-w-44 sm:max-w-20'"
 						@click.stop.prevent="openAttachment(idx)"
@@ -141,6 +142,7 @@
 			v-model="showAttachmentViewer"
 			:attachments="mail.attachments"
 			:initial-index="attachmentIndex"
+			:account="accountId"
 		/>
 	</MailRow>
 </template>
@@ -300,7 +302,7 @@ const currentlyDownloading = ref<string[]>([])
 const downloadAttachment = async (attachment: Attachment) => {
 	currentlyDownloading.value.push(attachment.blob_id)
 	try {
-		const url = await getAttachmentUrl(attachment.blob_id, attachment.type)
+		const url = await getAttachmentUrl(attachment.blob_id, attachment.type, accountId)
 		if (url) downloadUrlAsFile(url, attachment.filename || 'attachment')
 	} catch {
 		// the resource's onError already raised a toast; just stop spinning

--- a/frontend/src/apps/mail/components/MailRow.vue
+++ b/frontend/src/apps/mail/components/MailRow.vue
@@ -60,6 +60,16 @@
 						<slot name="sender" />
 					</h3>
 					<slot name="badges" />
+					<!-- In the stacked layout the account keeps the sender company; in the wide
+					     layout it moves out to sit by the date (below), so the sender column
+					     isn't spent on it. -->
+					<div
+						v-if="accountLabel && !isFullWidth"
+						class="text-ink-gray-4 flex shrink-0 items-center gap-1 text-xs"
+					>
+						<span aria-hidden="true">·</span>
+						<span>{{ __('in {0}', [accountLabel]) }}</span>
+					</div>
 				</div>
 				<MailDate v-if="!isFullWidth" :datetime :in-list="true" />
 			</div>
@@ -93,6 +103,13 @@
 			</div>
 
 			<slot name="extra" :is-full-width="isFullWidth" />
+		</div>
+
+		<div
+			v-if="isFullWidth && accountLabel"
+			class="text-ink-gray-4 ml-3 max-w-40 shrink-0 self-center truncate text-xs"
+		>
+			{{ __('in {0}', [accountLabel]) }}
 		</div>
 
 		<div v-if="isFullWidth" class="flex w-32 shrink-0 items-center justify-end space-x-4">
@@ -135,6 +152,7 @@ const {
 	previewItalic = false,
 	selectionMode = false,
 	hideAvatar = false,
+	accountLabel,
 } = defineProps<{
 	// Renders the row as a link when set, and as a plain div when not — a thread opens, a stack expands.
 	to?: RouteLocationRaw
@@ -157,6 +175,9 @@ const {
 	// Mobile selection mode (a selection exists): rows swap avatars for checkboxes,
 	// hide trailing actions, and a tap toggles selection instead of navigating.
 	selectionMode?: boolean
+	// Which account received the mail (merged lists). Rendered by the layout because its place
+	// depends on it: beside the sender in the stacked layout, out by the date in the wide one.
+	accountLabel?: string
 }>()
 
 const emit = defineEmits<{ setSelected: [selected: boolean] }>()

--- a/frontend/src/apps/mail/components/MailRow.vue
+++ b/frontend/src/apps/mail/components/MailRow.vue
@@ -45,7 +45,16 @@
 			/>
 		</div>
 
-		<div class="grow truncate" :class="isFullWidth ? 'flex items-center space-x-3' : 'space-y-1'">
+		<!-- The leading column set the row's height in the wide layout; without it (hideAvatar)
+		     rows shrank to their text and no longer lined up with the day headers. Hold that
+		     height here so the rhythm survives the column going away. -->
+		<div
+			class="grow truncate"
+			:class="[
+				isFullWidth ? 'flex items-center space-x-3' : 'space-y-1',
+				{ 'min-h-8': isFullWidth && !showLeading },
+			]"
+		>
 			<div
 				v-if="showSender"
 				class="flex items-center"

--- a/frontend/src/apps/mail/components/MailRow.vue
+++ b/frontend/src/apps/mail/components/MailRow.vue
@@ -69,12 +69,12 @@
 						<slot name="sender" />
 					</h3>
 					<slot name="badges" />
-					<!-- In the stacked layout the account keeps the sender company; in the wide
-					     layout it moves out to sit by the date (below), so the sender column
-					     isn't spent on it. -->
+					<!-- The account keeps the sender company in both layouts. It stays affordable
+					     in the sender column because only the odd accounts out are labelled, and
+					     by their short names. -->
 					<div
-						v-if="accountLabel && !isFullWidth"
-						class="text-ink-gray-4 flex shrink-0 items-center gap-1 text-xs"
+						v-if="accountLabel"
+						class="text-ink-blue-6 flex shrink-0 items-center gap-1 text-xs"
 					>
 						<span aria-hidden="true">·</span>
 						<span>{{ __('in {0}', [accountLabel]) }}</span>
@@ -112,13 +112,6 @@
 			</div>
 
 			<slot name="extra" :is-full-width="isFullWidth" />
-		</div>
-
-		<div
-			v-if="isFullWidth && accountLabel"
-			class="text-ink-gray-4 ml-3 max-w-40 shrink-0 self-center truncate text-xs"
-		>
-			{{ __('in {0}', [accountLabel]) }}
 		</div>
 
 		<div v-if="isFullWidth" class="flex w-32 shrink-0 items-center justify-end space-x-4">
@@ -184,8 +177,7 @@ const {
 	// Mobile selection mode (a selection exists): rows swap avatars for checkboxes,
 	// hide trailing actions, and a tap toggles selection instead of navigating.
 	selectionMode?: boolean
-	// Which account received the mail (merged lists). Rendered by the layout because its place
-	// depends on it: beside the sender in the stacked layout, out by the date in the wide one.
+	// Which account received the mail (merged lists), shown beside the sender.
 	accountLabel?: string
 }>()
 

--- a/frontend/src/apps/mail/components/MailRow.vue
+++ b/frontend/src/apps/mail/components/MailRow.vue
@@ -17,6 +17,7 @@
 		<!-- max-sm:justify-start pins the avatar/checkbox to the row's 14px padding
 		     axis; centered, the 40px column left them 2-4px "inside" it. -->
 		<div
+			v-if="showLeading"
 			class="flex shrink-0 items-center justify-center max-sm:w-10 max-sm:justify-start"
 			:class="isFullWidth ? 'h-8' : 'h-10 sm:-mt-1.5'"
 		>
@@ -35,7 +36,7 @@
 				<Check class="text-ink-base m-auto h-5 w-5 stroke-[4px]" />
 			</div>
 			<Avatar
-				v-show="!isSelected && (isMobile || !selectable)"
+				v-show="showAvatar"
 				:label="avatarLabel"
 				:image="avatarImage"
 				size="xl"
@@ -133,6 +134,7 @@ const {
 	subjectItalic = false,
 	previewItalic = false,
 	selectionMode = false,
+	hideAvatar = false,
 } = defineProps<{
 	// Renders the row as a link when set, and as a plain div when not — a thread opens, a stack expands.
 	to?: RouteLocationRaw
@@ -149,6 +151,9 @@ const {
 	datetime: string
 	subjectItalic?: boolean
 	previewItalic?: boolean
+	// Drops the sender avatar, and with it the whole leading column — the merged list is narrow
+	// beside the pane, and the reclaimed width goes to sender and subject. Mobile keeps it.
+	hideAvatar?: boolean
 	// Mobile selection mode (a selection exists): rows swap avatars for checkboxes,
 	// hide trailing actions, and a tap toggles selection instead of navigating.
 	selectionMode?: boolean
@@ -158,6 +163,12 @@ const emit = defineEmits<{ setSelected: [selected: boolean] }>()
 
 const user = inject('$user') as UserResource
 const { isMobile } = useScreenSize()
+
+const showAvatar = computed(() => !isSelected && (isMobile.value || !selectable) && !hideAvatar)
+// With no checkbox, no check circle and no avatar there is nothing left to reserve space for.
+const showLeading = computed(
+	() => (!isMobile.value && selectable) || isSelected || showAvatar.value,
+)
 
 const isHovered = ref(false)
 

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -323,6 +323,7 @@
 												:file-name="attachment.filename"
 												:blob-i-d="attachment.blob_id"
 												:type="attachment.type"
+												:account="scopeAccountId"
 												class="mb-2 mr-2"
 												@click.stop.prevent="
 													openAttachment(
@@ -375,6 +376,7 @@
 			v-model="showAttachmentViewer"
 			:attachments="attachments"
 			:initial-index="attachmentIndex"
+			:account="scopeAccountId"
 		/>
 	</div>
 
@@ -422,7 +424,7 @@ import {
 	shouldIgnoreKeypress,
 } from '@/apps/mail/utils'
 import { useFilterBySender, useScreenSize, useSettings, useTheme } from '@/apps/mail/utils/composables'
-import { userStore } from '@/apps/mail/stores/user'
+import { provideAccountScope } from '@/apps/mail/utils/accountScope'
 import AttachmentCapsule from '@/apps/mail/components/AttachmentCapsule.vue'
 import AttachmentViewer from '@/apps/mail/components/AttachmentViewer.vue'
 import ComposeMailEditor from '@/apps/mail/components/ComposeMailEditor.vue'
@@ -443,23 +445,30 @@ import type {
 	Identity,
 	Mail,
 	Mailbox,
+	MailboxData,
 	ScreenedAddress,
 } from '@/apps/mail/types'
 
-const { mailbox, threadID, threads, messages, canGoNext, readonly, slide } = defineProps<{
-	mailbox: string
-	threadID?: string
-	threads: string[]
-	messages?: Mail[]
-	canGoNext?: boolean
-	// Read-only thread (e.g. the Screener): renders the messages but hides every action — the thread
-	// toolbar, per-message actions, the block banner and the reply/forward bar — and never marks read.
-	readonly?: boolean
-	// Transition name for the mobile swipe paging ('page-next' / 'page-prev', styled in
-	// MailLayout); the owner arms it per swipe and clears it on slideDone, so other thread
-	// changes swap instantly.
-	slide?: string
-}>()
+const { mailbox, threadID, threads, messages, canGoNext, readonly, slide, account } =
+	defineProps<{
+		mailbox: string
+		threadID?: string
+		threads: string[]
+		messages?: Mail[]
+		canGoNext?: boolean
+		// The thread's owning account, when it isn't the active one (All Inboxes opens
+		// cross-account threads without switching): the pane and everything inside it —
+		// folder menus, reply identities, screened-sender banners — act as this account
+		// via the provided scope (see utils/accountScope).
+		account?: string
+		// Read-only thread (e.g. the Screener): renders the messages but hides every action — the thread
+		// toolbar, per-message actions, the block banner and the reply/forward bar — and never marks read.
+		readonly?: boolean
+		// Transition name for the mobile swipe paging ('page-next' / 'page-prev', styled in
+		// MailLayout); the owner arms it per swipe and clears it on slideDone, so other thread
+		// changes swap instantly.
+		slide?: string
+	}>()
 
 const emit = defineEmits([
 	'reloadMails',
@@ -485,26 +494,25 @@ const { openSettings } = useSettings()
 const { filterBySender } = useFilterBySender()
 const dayjs = inject('$dayjs')
 const user = inject('$user')
-const store = userStore()
-const { mailboxes, mailboxIds, identities, screenedAddresses } = store
+// The pane acts as the thread's owning account (the active one unless the `account`
+// prop says otherwise) — provided so ThreadHeader's folder menus and the reply
+// editors below resolve the same account.
+const scope = provideAccountScope(() => account)
+const { accountId: scopeAccountId, identities, screenedAddresses, mailboxIds } = scope
 
 // A sender is "blocked" when screened with the Reject action (their mail is discarded) — either by their
 // exact address or by an accepted/blocked '@domain' entry covering them.
 const isSenderBlocked = (email: string) =>
-	!!screenedAddresses.data?.some(
+	!!screenedAddresses.value.data?.some(
 		(a: ScreenedAddress) => a.action === 'Reject' && matchesScreenedValue(email, a.email),
 	)
 
 // Trusted senders — you, or anyone you've accepted — load images normally. For everyone else, the
 // account's "Block Remote Images" setting withholds remote images (read-tracking pixels) until you opt in.
-const blockRemoteImagesEnabled = computed(
-	() =>
-		store.userResource?.data?.accounts?.find((a) => a.id === store.accountId)
-			?.block_remote_images ?? true,
-)
+const blockRemoteImagesEnabled = computed(() => scope.account.value?.block_remote_images ?? true)
 const isScreenedIn = (email: string) =>
-	!!identities.data?.some((i: Identity) => i.email === email) ||
-	!!screenedAddresses.data?.some(
+	!!identities.value.data?.some((i: Identity) => i.email === email) ||
+	!!screenedAddresses.value.data?.some(
 		(a: ScreenedAddress) => a.action === 'Accepted' && matchesScreenedValue(email, a.email),
 	)
 const shouldBlockImages = (mail: { from_email: string }) =>
@@ -582,7 +590,7 @@ const thread = ref<Mail[]>([])
 
 const threadFallback = createResource({
 	url: 'suite.mail.api.mail.get_thread',
-	makeParams: () => ({ account: store.accountId, thread_id: threadID }),
+	makeParams: () => ({ account: scopeAccountId.value, thread_id: threadID }),
 	onSuccess: (mails: Mail[]) => {
 		// Thread no longer exists (e.g. deleted) — bail to the mailbox instead of a blank page.
 		if (!mails?.length) {
@@ -729,10 +737,10 @@ const filterRelevantMails = (mail: Mail) => {
 	if (mailbox === 'search') return true
 
 	const mailboxes = mail.mailboxes.map((m) => m.mailbox_id)
-	const trash = mailboxIds.trash
+	const trash = mailboxIds.value.trash
 	if (mailbox === trash) return mailboxes.includes(trash)
 
-	if (mailbox === mailboxIds.junk) return !!mail.junk
+	if (mailbox === mailboxIds.value.junk) return !!mail.junk
 
 	return !mailboxes.includes(trash) && !mail.junk
 }
@@ -777,10 +785,10 @@ onMounted(() => loadThread())
 
 const unblockEmailAddress = createResource({
 	url: 'suite.mail.api.mail.unscreen_email_addresses',
-	makeParams: (email) => ({ account: store.accountId, emails: [email] }),
+	makeParams: (email) => ({ account: scopeAccountId.value, emails: [email] }),
 	onSuccess: () => {
 		raiseToast(__('Sender unblocked.'))
-		screenedAddresses.reload()
+		screenedAddresses.value.reload()
 	},
 })
 
@@ -788,13 +796,13 @@ const unblockEmailAddress = createResource({
 const trustSender = createResource({
 	url: 'suite.mail.api.mail.screen_email_addresses',
 	makeParams: (email: string) => ({
-		account: store.accountId,
+		account: scopeAccountId.value,
 		emails: [email],
 		action: 'Accepted',
 	}),
 	onSuccess: () => {
 		raiseToast(__('Sender marked as trusted.'))
-		screenedAddresses.reload()
+		screenedAddresses.value.reload()
 	},
 })
 
@@ -858,7 +866,7 @@ const downloadAttachmentsAsZip = async (mail: Mail) => {
 
 	downloadingZipMail.value = mail.name
 	try {
-		const url = await getAttachmentsZipUrl(mailAttachments)
+		const url = await getAttachmentsZipUrl(mailAttachments, scopeAccountId.value)
 		downloadUrlAsFile(url, `${mail.subject || 'attachments'}.zip`)
 	} catch {
 		// the resource's onError already raised a toast; just stop spinning
@@ -978,7 +986,7 @@ const syncFlagged = (ids: string[], flagged: boolean) =>
 
 const syncMailboxMembership = (mailboxId: string, add: boolean) => {
 	if (add) {
-		const mb = mailboxes.data?.find((m) => m.id === mailboxId)
+		const mb = scope.mailboxes.value.data?.find((m: MailboxData) => m.id === mailboxId)
 		if (!mb) return
 		const entry: Mailbox = { mailbox: mb.name, mailbox_id: mb.id, mailbox_name: mb._name }
 		thread.value?.forEach((mail: Mail) => {
@@ -1055,7 +1063,7 @@ const getReplyAllRecipients = (mail: Mail) => {
 }
 
 const isUserEmail = (email: string) =>
-	identities.data.map((i: Identity) => i.email).includes(email)
+	identities.value.data?.map((i: Identity) => i.email).includes(email)
 
 const getBodyContent = (mail: Mail) => {
 	if (hasHtmlContent(mail.html_body)) return mail.html_body

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -566,7 +566,14 @@ const unseenMessage = computed(() =>
 const shouldShowUnseenMarker = (id: string) =>
 	isSomeSeen.value && firstUnseenMail.value && id == firstUnseenMail.value
 
-const goToMailbox = () => router.push({ name: 'mail-mailbox', params: { mailbox }, query: route.query })
+// Bail to the list the thread was opened from — the merged All Inboxes list on
+// its thread route, the mailbox list otherwise.
+const goToMailbox = () =>
+	router.push(
+		route.name === 'mail-all-inboxes-mail'
+			? { name: 'mail-all-inboxes', query: route.query }
+			: { name: 'mail-mailbox', params: { mailbox }, query: route.query },
+	)
 
 // The thread's messages normally arrive from the parent (loaded via `get_threads`). When the open
 // thread isn't in that list (e.g. a search result, or one on another page), fall back to fetching it

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -417,12 +417,12 @@ import {
 	getFormattedDate,
 	getFormattedRecipients,
 	getGroupedRecipients,
-	getSenderInitial,
 	hasHtmlContent,
 	matchesScreenedValue,
 	raiseToast,
 	shouldIgnoreKeypress,
 } from '@/apps/mail/utils'
+import { getSenderInitial } from '@/apps/mail/utils/participants'
 import { useFilterBySender, useScreenSize, useSettings, useTheme } from '@/apps/mail/utils/composables'
 import { provideAccountScope } from '@/apps/mail/utils/accountScope'
 import AttachmentCapsule from '@/apps/mail/components/AttachmentCapsule.vue'

--- a/frontend/src/apps/mail/components/Modals/ShortcutsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/ShortcutsModal.vue
@@ -94,8 +94,10 @@ const shortcutGroups = computed(() => [
 				[['G', __('then'), 'S'], __('Go to {0}', [mailboxName('sent')])],
 				[['G', __('then'), 'D'], __('Go to {0}', [mailboxName('drafts')])],
 				[['G', __('then'), 'J'], __('Go to {0}', [mailboxName('junk')])],
-				[['G', __('then'), 'A'], __('Go to {0}', [mailboxName('archive')])],
+				[['G', __('then'), 'E'], __('Go to {0}', [mailboxName('archive')])],
 				[['G', __('then'), 'T'], __('Go to {0}', [mailboxName('trash')])],
+				[['G', __('then'), 'A'], __('Go to All Inboxes')],
+				[['G', __('then'), 'R'], __('Go to Screener')],
 			],
 		},
 		{

--- a/frontend/src/apps/mail/components/StackListItem.vue
+++ b/frontend/src/apps/mail/components/StackListItem.vue
@@ -1,6 +1,8 @@
 <template>
 	<MailRow
 		:is-selected
+		:selectable
+		:hide-avatar
 		:unread="!!unreadCount"
 		:avatar-label="avatarLabel"
 		:avatar-image="latest.user_image"
@@ -65,10 +67,14 @@ import type { Thread } from '@/apps/mail/types'
 //
 // Its hover actions apply to every member at once, so each one names the count and every move it makes
 // is undoable.
-const { threads, expanded, isSelected } = defineProps<{
+const { threads, expanded, isSelected, selectable, hideAvatar } = defineProps<{
 	threads: Thread[]
 	expanded: boolean
 	isSelected: boolean
+	// Forwarded to MailRow, for lists without bulk selection / with the leading
+	// column reclaimed (the merged All Inboxes list) — see MailRow's props.
+	selectable?: boolean
+	hideAvatar?: boolean
 }>()
 
 const emit = defineEmits<{

--- a/frontend/src/apps/mail/components/StackListItem.vue
+++ b/frontend/src/apps/mail/components/StackListItem.vue
@@ -3,6 +3,7 @@
 		:is-selected
 		:selectable
 		:hide-avatar
+		:account-label="accountLabel"
 		:unread="!!unreadCount"
 		:avatar-label="avatarLabel"
 		:avatar-image="latest.user_image"
@@ -67,7 +68,7 @@ import type { Thread } from '@/apps/mail/types'
 //
 // Its hover actions apply to every member at once, so each one names the count and every move it makes
 // is undoable.
-const { threads, expanded, isSelected, selectable, hideAvatar } = defineProps<{
+const { threads, expanded, isSelected, selectable, hideAvatar, accountLabel } = defineProps<{
 	threads: Thread[]
 	expanded: boolean
 	isSelected: boolean
@@ -75,6 +76,8 @@ const { threads, expanded, isSelected, selectable, hideAvatar } = defineProps<{
 	// column reclaimed (the merged All Inboxes list) — see MailRow's props.
 	selectable?: boolean
 	hideAvatar?: boolean
+	// Which account received the run (merged lists) — a stack never mixes accounts.
+	accountLabel?: string
 }>()
 
 const emit = defineEmits<{

--- a/frontend/src/apps/mail/components/StackListItem.vue
+++ b/frontend/src/apps/mail/components/StackListItem.vue
@@ -55,8 +55,11 @@ import { computed } from 'vue'
 import { ChevronDown, ChevronRight, Layers2 } from 'lucide-vue-next'
 import { Badge } from 'frappe-ui'
 
-import { getSenderInitial } from '@/apps/mail/utils'
-import { formatThreadParticipants, primaryParticipant, threadParticipants } from '@/apps/mail/utils/participants'
+import {
+	threadAvatarLabel,
+	threadDisplayName,
+	threadParticipants,
+} from '@/apps/mail/utils/participants'
 import { useOwnEmails } from '@/apps/mail/utils/composables'
 import MailRow from '@/apps/mail/components/MailRow.vue'
 import MailRowActions from '@/apps/mail/components/MailRowActions.vue'
@@ -97,19 +100,9 @@ const participants = computed(() => threadParticipants(latest.value.messages, ow
 
 // Only threads with a lone sending address stack (see stackKeyOf), and every member shares it, so the
 // stack is named exactly the way each of its members is — collapsed or expanded, the name holds.
-const sender = computed(
-	() =>
-		formatThreadParticipants(participants.value) ||
-		latest.value.from_name ||
-		latest.value.from_email,
-)
+const sender = computed(() => threadDisplayName(participants.value, latest.value))
 
-// The letter behind the avatar, for a contact with no picture: whoever the picture itself would be of.
-const avatarLabel = computed(() => {
-	const primary = primaryParticipant(participants.value)
-	if (!primary) return getSenderInitial(latest.value)
-	return getSenderInitial({ from_name: primary.name, from_email: primary.email })
-})
+const avatarLabel = computed(() => threadAvatarLabel(participants.value, latest.value))
 
 const unreadCount = computed(() => threads.filter((t) => !t.seen).length)
 </script>

--- a/frontend/src/apps/mail/components/ThreadHeader.vue
+++ b/frontend/src/apps/mail/components/ThreadHeader.vue
@@ -5,7 +5,7 @@
 		<Button
 			variant="ghost"
 			class="mr-2 shrink-0 max-sm:-ml-2 max-sm:!h-8 max-sm:!w-8"
-			@click="$router.push({ name: 'mail-mailbox', params: { mailbox }, query: route.query })"
+			@click="$router.push(backRoute)"
 		>
 			<template #icon>
 				<ChevronLeft class="icon max-sm:!h-[18px] max-sm:!w-[18px]" />
@@ -149,6 +149,16 @@ const user = inject('$user')
 
 const mailbox = computed(() => route.params.mailbox as string)
 const threadID = computed(() => route.params.threadID as string)
+
+// Back returns to the list the thread was opened from: the merged All Inboxes
+// list on its thread route (whose mailbox param is the thread's real folder —
+// usually an account's Inbox, which is where back used to land), the mailbox
+// list otherwise.
+const backRoute = computed(() =>
+	route.name === 'mail-all-inboxes-mail'
+		? { name: 'mail-all-inboxes', query: route.query }
+		: { name: 'mail-mailbox', params: { mailbox: mailbox.value }, query: route.query },
+)
 
 const threadMailboxes = computed(() => {
 	if (!thread?.length) return []

--- a/frontend/src/apps/mail/components/ThreadHeader.vue
+++ b/frontend/src/apps/mail/components/ThreadHeader.vue
@@ -120,7 +120,7 @@ import { FLAGGED_STAR_STYLE, FOLDER_ICON_COLOR_MAP } from '@/apps/mail/constants
 import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 import { getIcon, getMailboxName } from '@/apps/mail/utils'
 import { useScreenSize } from '@/apps/mail/utils/composables'
-import { userStore } from '@/apps/mail/stores/user'
+import { injectAccountScope } from '@/apps/mail/utils/accountScope'
 
 import type { Mail, MailboxData } from '@/apps/mail/types'
 
@@ -143,7 +143,9 @@ const emit = defineEmits([
 
 const { isMobile } = useScreenSize()
 const route = useRoute()
-const { mailboxes, mailboxIds } = userStore()
+// Folder menus come from the pane's account scope — the thread's owning account
+// when All Inboxes opened it, the active account otherwise.
+const { mailboxes, mailboxIds } = injectAccountScope()
 
 const user = inject('$user')
 
@@ -208,11 +210,11 @@ const threadActions = computed((): Action[] => [
 		label: __('Archive (E)'),
 		onClick: () =>
 			emit(
-				mailbox.value === mailboxIds.sent ? 'addThreadToMailbox' : 'moveThread',
-				mailboxIds.archive,
+				mailbox.value === mailboxIds.value.sent ? 'addThreadToMailbox' : 'moveThread',
+				mailboxIds.value.archive,
 			),
 		icon: Archive,
-		condition: () => !threadMailboxes.value.includes(mailboxIds.archive),
+		condition: () => !threadMailboxes.value.includes(mailboxIds.value.archive),
 	},
 	{
 		label: __('Mark as Junk (!)'),
@@ -220,26 +222,26 @@ const threadActions = computed((): Action[] => [
 		icon: CircleAlert,
 		condition: () =>
 			!threadMailboxes.value.some((m: string) =>
-				[mailboxIds.junk, mailboxIds.drafts].includes(m),
+				[mailboxIds.value.junk, mailboxIds.value.drafts].includes(m),
 			),
 	},
 	{
 		label: __('Mark as Not Junk'),
 		onClick: () => emit('setSpamStatus', false),
 		icon: CircleCheck,
-		condition: () => threadMailboxes.value.includes(mailboxIds.junk),
+		condition: () => threadMailboxes.value.includes(mailboxIds.value.junk),
 	},
 	{
 		label: __('Move to Trash (Delete)'),
-		onClick: () => emit('moveThread', mailboxIds.trash),
+		onClick: () => emit('moveThread', mailboxIds.value.trash),
 		icon: Trash2,
-		condition: () => !threadMailboxes.value.includes(mailboxIds.trash),
+		condition: () => !threadMailboxes.value.includes(mailboxIds.value.trash),
 	},
 	{
 		label: __('Delete Thread (Shift+Delete)'),
 		onClick: () => emit('deleteThread'),
 		icon: Trash2,
-		condition: () => threadMailboxes.value.includes(mailboxIds.trash),
+		condition: () => threadMailboxes.value.includes(mailboxIds.value.trash),
 	},
 	{
 		label: __('Mark as Unread (U)'),
@@ -250,38 +252,38 @@ const threadActions = computed((): Action[] => [
 ])
 
 const showAddTo = computed(() =>
-	threadMailboxes.value.every((m) => ![mailboxIds.junk, mailboxIds.trash].includes(m)),
+	threadMailboxes.value.every((m) => ![mailboxIds.value.junk, mailboxIds.value.trash].includes(m)),
 )
 
 const addToOptions = computed(() =>
-	mailboxes.data
+	mailboxes.value.data
 		?.filter(
 			(m) =>
 				(!m.role || ['inbox', 'archive'].includes(m.role)) &&
-				m.id !== mailboxIds.screener &&
+				m.id !== mailboxIds.value.screener &&
 				!threadMailboxes.value.includes(m.id),
 		)
 		.map((m) => getMailboxOption(m, 'addThreadToMailbox')),
 )
 
 const removeFromOptions = computed(() =>
-	mailboxes.data
+	mailboxes.value.data
 		?.filter(
 			(m) =>
 				threadMailboxesUnion.value.includes(m.id) &&
-				![mailboxIds.sent, mailboxIds.drafts].includes(m.id),
+				![mailboxIds.value.sent, mailboxIds.value.drafts].includes(m.id),
 		)
 		.map((m) => getMailboxOption(m, 'removeThreadFromMailbox')),
 )
 
 const moveToOptions = computed(() => {
 	const excludedMailboxes = new Set([
-		mailboxIds.sent,
-		mailboxIds.drafts,
-		mailboxIds.screener,
+		mailboxIds.value.sent,
+		mailboxIds.value.drafts,
+		mailboxIds.value.screener,
 		...threadMailboxes.value,
 	])
-	return mailboxes.data
+	return mailboxes.value.data
 		?.filter((m) => !excludedMailboxes.has(m.id))
 		.map((m) => getMailboxOption(m, 'moveThread'))
 })

--- a/frontend/src/apps/mail/components/ThreadHeader.vue
+++ b/frontend/src/apps/mail/components/ThreadHeader.vue
@@ -255,9 +255,11 @@ const showAddTo = computed(() =>
 	threadMailboxes.value.every((m) => ![mailboxIds.value.junk, mailboxIds.value.trash].includes(m)),
 )
 
+// Default to [] rather than undefined: in All Inboxes the pane's mailbox resource belongs to the
+// row's account and is still loading on first paint, and AdaptiveDropdown requires an array.
 const addToOptions = computed(() =>
-	mailboxes.value.data
-		?.filter(
+	(mailboxes.value.data ?? [])
+		.filter(
 			(m) =>
 				(!m.role || ['inbox', 'archive'].includes(m.role)) &&
 				m.id !== mailboxIds.value.screener &&
@@ -267,8 +269,8 @@ const addToOptions = computed(() =>
 )
 
 const removeFromOptions = computed(() =>
-	mailboxes.value.data
-		?.filter(
+	(mailboxes.value.data ?? [])
+		.filter(
 			(m) =>
 				threadMailboxesUnion.value.includes(m.id) &&
 				![mailboxIds.value.sent, mailboxIds.value.drafts].includes(m.id),
@@ -283,8 +285,8 @@ const moveToOptions = computed(() => {
 		mailboxIds.value.screener,
 		...threadMailboxes.value,
 	])
-	return mailboxes.value.data
-		?.filter((m) => !excludedMailboxes.has(m.id))
+	return (mailboxes.value.data ?? [])
+		.filter((m) => !excludedMailboxes.has(m.id))
 		.map((m) => getMailboxOption(m, 'moveThread'))
 })
 

--- a/frontend/src/apps/mail/components/ThreadPane.vue
+++ b/frontend/src/apps/mail/components/ThreadPane.vue
@@ -1,0 +1,74 @@
+<template>
+	<!-- The list column. With Split View on it takes a third of the row and the pane the rest;
+	     otherwise it fills the width and the pane overlays it (or, on mobile, slides in over it). -->
+	<div
+		class="sticky top-16 flex flex-col border-r"
+		:class="!isMobile && showReadingPane ? 'w-1/3' : 'w-full'"
+	>
+		<slot name="list" />
+	</div>
+
+	<!-- The open thread, in place: a third/two-thirds split on desktop with Split View on, a
+	     full-bleed overlay otherwise.
+	     Mobile opens as a page push (iOS-style slide from the right): the pane stays mounted and
+	     slides via transform, so close animates too. visibility rides the same transition — it
+	     flips only after the slide-out ends, keeping the offscreen pane out of the focus order.
+	     Teleported to body on mobile (like the selection bar): inside the layout's isolate
+	     stacking context the remounting tab bar paints over the pane during the slide-out,
+	     whatever the pane's own z-index says. -->
+	<Teleport to="body" :disabled="!isMobile">
+		<div
+			class="bg-surface-base"
+			:class="{
+				'overflow-hidden': isMobile,
+				'w-2/3': !isMobile && showReadingPane,
+				'absolute bottom-0 left-0 right-0 top-0': !isMobile && !showReadingPane,
+				'fixed inset-0 z-20 pt-[env(safe-area-inset-top)] transition-[transform,visibility] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]':
+					isMobile,
+				'invisible translate-x-full': isMobile && !threadOpen,
+				hidden: !isMobile && !showReadingPane && !threadOpen,
+			}"
+			@touchstart.passive="emit('touchStart', $event)"
+			@touchend.passive="emit('touchEnd', $event)"
+		>
+			<!-- The swipe slide lives inside MailThread (its toolbar must not move), armed via
+			     `slide` per swipe and cleared on slide-done. The scroll wrapper must be h-full on
+			     desktop too, or the empty state's h-full collapses. -->
+			<div class="h-full overflow-y-auto">
+				<slot />
+			</div>
+		</div>
+	</Teleport>
+</template>
+
+<script setup lang="ts">
+import { useReadingPane, useScreenSize } from '@/apps/mail/utils/composables'
+
+/**
+ * The two halves of a thread list view: the list column, and the reading pane beside/over it.
+ *
+ * Both halves are sized from one setting and one "is a thread open" flag, which is exactly why they
+ * live in one component: every geometry rule here (`w-1/3` against `w-2/3`, overlay against split,
+ * the mobile slide) is a statement about the pair. Kept apart, the mailbox list and the merged All
+ * Inboxes list each grew their own copy and the copies drifted — the merged one shipped without the
+ * Teleport, so the mobile tab bar painted over its pane.
+ *
+ * The list content goes in `#list`, the thread in the default slot. Both are the caller's — this
+ * owns nothing but the frame.
+ */
+
+const { threadOpen } = defineProps<{
+	/** Whether a thread is open. Drives the mobile slide-in and the desktop hidden/overlay state. */
+	threadOpen: boolean
+}>()
+
+// Swipe-to-page on the open thread is per-view (what "next thread" means differs), so the pane only
+// forwards the touches. `.passive` stays on the listener here, where the native event is bound.
+const emit = defineEmits<{
+	touchStart: [TouchEvent]
+	touchEnd: [TouchEvent]
+}>()
+
+const { isMobile } = useScreenSize()
+const showReadingPane = useReadingPane()
+</script>

--- a/frontend/src/apps/mail/components/mobile/MobileProfileSheet.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileProfileSheet.vue
@@ -30,16 +30,13 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
 import { Check, LogOut, Settings } from 'lucide-vue-next'
 import { Avatar, BottomSheet } from 'frappe-ui'
 
-import { useProfileSheet, useSettings } from '@/apps/mail/utils/composables'
+import { useAccountSwitch, useProfileSheet, useSettings } from '@/apps/mail/utils/composables'
 import { sessionStore } from '@/apps/mail/stores/session'
 import { userStore } from '@/apps/mail/stores/user'
 
-const route = useRoute()
-const router = useRouter()
 const store = userStore()
 const { logout } = sessionStore()
 const { isProfileSheetOpen, closeProfileSheet } = useProfileSheet()
@@ -47,16 +44,12 @@ const { openSettings } = useSettings()
 
 const accounts = computed(() => store.userResource?.data?.accounts ?? [])
 
-// Same in-place accountId swap the sidebar's account submenu does; account-agnostic
-// routes (All Inboxes) go through the account shortcut instead.
+// Shared with the sidebar's account submenu — stays in place on account-scoped
+// routes and in All Inboxes (see useAccountSwitch).
+const { switchAccount: doSwitchAccount } = useAccountSwitch()
 const switchAccount = (accountId: string) => {
 	closeProfileSheet()
-	if (accountId === store.accountId) return
-	router.push(
-		route.params.accountId
-			? { name: route.name!, params: { ...route.params, accountId } }
-			: { name: 'mail-account-shortcut', params: { accountId } },
-	)
+	doSwitchAccount(accountId)
 }
 
 const openAppSettings = () => {

--- a/frontend/src/apps/mail/composables/mergeByReceivedAt.test.ts
+++ b/frontend/src/apps/mail/composables/mergeByReceivedAt.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Thread } from '@/apps/mail/types'
+
+import { mergeByReceivedAt } from './usePaginatedThreads'
+
+// Only received_at and thread_id matter to the merge.
+const thread = (thread_id: string, received_at: string) =>
+	({ thread_id, received_at }) as unknown as Thread
+
+const ids = (threads: Thread[]) => threads.map((t) => t.thread_id)
+
+describe('mergeByReceivedAt', () => {
+	it('prepends genuinely new mail', () => {
+		const fresh = [thread('new', '2026-07-30 10:00:00')]
+		const loaded = [thread('a', '2026-07-29 10:00:00'), thread('b', '2026-07-28 10:00:00')]
+		expect(ids(mergeByReceivedAt(fresh, loaded))).toEqual(['new', 'a', 'b'])
+	})
+
+	// The All Inboxes case: a second account's newest mail is older than the first account's oldest
+	// loaded row, so it belongs at the bottom — a prepend would open a stale date group above today's.
+	it('sorts an older fresh thread below the loaded rows', () => {
+		const fresh = [thread('old', '2026-07-26 10:00:00')]
+		const loaded = [thread('a', '2026-07-30 10:00:00'), thread('b', '2026-07-29 10:00:00')]
+		expect(ids(mergeByReceivedAt(fresh, loaded))).toEqual(['a', 'b', 'old'])
+	})
+
+	it('interleaves by date', () => {
+		const fresh = [thread('f1', '2026-07-30 10:00:00'), thread('f2', '2026-07-28 10:00:00')]
+		const loaded = [thread('l1', '2026-07-29 10:00:00'), thread('l2', '2026-07-27 10:00:00')]
+		expect(ids(mergeByReceivedAt(fresh, loaded))).toEqual(['f1', 'l1', 'f2', 'l2'])
+	})
+
+	it('keeps the fresh row first on a tie', () => {
+		const fresh = [thread('f', '2026-07-30 10:00:00')]
+		const loaded = [thread('l', '2026-07-30 10:00:00')]
+		expect(ids(mergeByReceivedAt(fresh, loaded))).toEqual(['f', 'l'])
+	})
+
+	it('handles either side being empty', () => {
+		const rows = [thread('a', '2026-07-30 10:00:00')]
+		expect(ids(mergeByReceivedAt([], rows))).toEqual(['a'])
+		expect(ids(mergeByReceivedAt(rows, []))).toEqual(['a'])
+		expect(mergeByReceivedAt([], [])).toEqual([])
+	})
+})

--- a/frontend/src/apps/mail/composables/useListRows.ts
+++ b/frontend/src/apps/mail/composables/useListRows.ts
@@ -1,0 +1,257 @@
+import { computed, ref, watch, type Ref } from 'vue'
+
+import dayjs from '@/apps/mail/utils/dayjs'
+import { useRowScroll } from '@/apps/mail/utils/listNavigation'
+import { buildListRows, type ListRow, type StackRow } from '@/apps/mail/utils/threadStacks'
+import { useScreenSize } from '@/apps/mail/utils/composables'
+import { userStore } from '@/apps/mail/stores/user'
+
+import type { Thread } from '@/apps/mail/types'
+
+/**
+ * A date header — the one navigable row a list draws itself rather than getting from buildListRows,
+ * which is deliberately date-agnostic.
+ */
+export type GroupRow = { type: 'group'; key: string; dateKey: string }
+
+/** Anything the keyboard cursor can land on: a thread row, a stack row, or a date header. */
+export type NavRow = ListRow | GroupRow
+
+export interface ListRowsOptions {
+	/** The loaded threads, newest first. */
+	threads: () => Thread[]
+	/** A thread row's key. The all-accounts views prefix it with the account. */
+	rowKey: (thread: Thread) => string
+	/** Whether runs of look-alike threads collapse into stack rows. On everywhere by default. */
+	stackingEnabled?: () => boolean
+	/** The open thread, if any — folding a row that hides it has to move the reading pane. */
+	openThreadID: () => string | undefined
+	/** Called when a fold is about to hide the open thread: leave the pane. */
+	onOpenThreadHidden: () => void
+	/** The scroll container, so the cursor can bring its row into view. */
+	container: Ref<HTMLElement | null>
+}
+
+/**
+ * The rows a thread list renders, and the keyboard cursor that walks them.
+ *
+ * Between the loaded threads and the rendered list sit three display layers, each of which can hide a
+ * thread: date groups (collapsible), stacks (a run of look-alike threads from one sender, collapsed
+ * into one row), and the mobile/desktop difference in whether headers exist at all. The cursor must
+ * only ever land on something actually on screen, and a fold must never leave the reading pane
+ * pointing at a row that is no longer rendered — which is why the rows, the folds and the cursor are
+ * one thing rather than three.
+ *
+ * All of it existed twice, near-verbatim, in the mailbox list and the merged All Inboxes list. The one
+ * piece that did NOT — rowForThread, which maps a thread to whatever row stands for it on screen — was
+ * re-solved in the merged view with an inline scan that could only find a thread's own row, so a step
+ * into a collapsed stack or a folded day lost the marker.
+ */
+export const useListRows = ({
+	threads,
+	rowKey,
+	stackingEnabled = () => true,
+	openThreadID,
+	onOpenThreadHidden,
+	container,
+}: ListRowsOptions) => {
+	const { isMobile } = useScreenSize()
+	const { userResource } = userStore()
+
+	const groupMessagesBy = computed(() => userResource.data?.group_messages_by)
+
+	// Date headers are a desktop affordance: on mobile both lists render one continuous run, so there
+	// is no header to click, nothing can be collapsed, and the cursor has no headers to walk. The
+	// collapse state is gated on the same thing, because only a header's own click can fill it.
+	const headersVisible = computed(() => groupMessagesBy.value !== 'None' && !isMobile.value)
+
+	// ── Date groups ─────────────────────────────────────────────────────────────────────────────────
+
+	const groupedThreads = computed<Record<string, Thread[]>>(() =>
+		threads().reduce((groups: Record<string, Thread[]>, thread: Thread) => {
+			const date = dayjs(thread.received_at).format(
+				groupMessagesBy.value === 'Day' ? 'YYYY-MM-DD' : 'YYYY-MM',
+			)
+			if (!groups[date]) groups[date] = []
+			groups[date].push(thread)
+			return groups
+		}, {}),
+	)
+
+	const getGroupThreads = (group: string) => groupedThreads.value[group]?.map((t) => t.thread_id)
+
+	// The last group never collapses — it's where infinite scroll appends, so hiding it would swallow
+	// newly loaded rows.
+	const isLastGroup = (key: string) => Object.keys(groupedThreads.value).at(-1) === key
+
+	const collapsedGroups = ref<string[]>([])
+
+	watch(groupMessagesBy, () => (collapsedGroups.value = []))
+
+	// ── Stacks ──────────────────────────────────────────────────────────────────────────────────────
+	//
+	// A run of adjacent look-alike threads from one sender collapses into a single row, so a chatty
+	// notification sender can't bury the rest of the list. This is a display layer over groupedThreads:
+	// runs are detected within a date group and never span one.
+
+	// The thread_ids of every member of every expanded stack. In-memory only — stacks re-collapse on a
+	// mailbox switch. Keyed by member id rather than by stack key so a run keeps its expanded state as
+	// it grows in either direction (appended by infinite scroll, prepended by a refresh), and so
+	// routing to a thread can expand its stack without having to locate the run first.
+	const expandedStacks = ref(new Set<string>())
+
+	const isRunExpanded = (run: Thread[]) => run.some((t) => expandedStacks.value.has(t.thread_id))
+
+	const groupedRows = computed<Record<string, ListRow[]>>(() =>
+		Object.fromEntries(
+			Object.entries(groupedThreads.value).map(([key, group]) => [
+				key,
+				buildListRows(group, {
+					rowKey,
+					isExpanded: isRunExpanded,
+					enabled: stackingEnabled(),
+				}),
+			]),
+		),
+	)
+
+	// ── The cursor ──────────────────────────────────────────────────────────────────────────────────
+
+	/**
+	 * The rows the list actually renders, in visual order. The cursor walks these rather than the flat
+	 * list of loaded threads, so it can never land on a row that isn't on screen: a collapsed stack is
+	 * a single stop (its members aren't rendered), and a collapsed date group contributes only its
+	 * header.
+	 */
+	const navigableRows = computed<NavRow[]>(() => {
+		const rows: NavRow[] = []
+		for (const [dateKey, groupRows] of Object.entries(groupedRows.value)) {
+			if (headersVisible.value) rows.push({ type: 'group', key: `group:${dateKey}`, dateKey })
+			if (headersVisible.value && collapsedGroups.value.includes(dateKey)) continue
+			rows.push(...groupRows)
+		}
+		return rows
+	})
+
+	/**
+	 * The keyboard cursor, as a row key. A row key rather than a thread id because the cursor can sit
+	 * on a stack row or a date header, neither of which is a thread — and one ref rather than two so
+	 * the cursor can never be in two places at once.
+	 */
+	const focusedRowKey = ref<string>()
+
+	const focusedRow = computed(() =>
+		navigableRows.value.find((row) => row.key === focusedRowKey.value),
+	)
+
+	const scrollRowIntoView = useRowScroll(container)
+
+	const focusRowKey = (key: string) => {
+		focusedRowKey.value = key
+		scrollRowIntoView(key)
+	}
+
+	const focusRow = (row?: NavRow) => {
+		if (row) focusRowKey(row.key)
+	}
+
+	/**
+	 * The row that stands for a thread on screen: its own row when rendered, the collapsed stack that
+	 * hides it, or — when its whole day is folded away — that day's header. Callers name a thread ("go
+	 * to the first mail", "open the thread that just loaded"); this is how that lands somewhere visible.
+	 */
+	const rowForThread = (threadID?: string): NavRow | undefined => {
+		if (!threadID) return
+
+		const row = navigableRows.value.find(
+			(row) =>
+				(row.type === 'thread' && row.thread.thread_id === threadID) ||
+				// Only a collapsed stack stands in for its members. An expanded one precedes its member
+				// rows, so without this guard every member would resolve to the stack row above it.
+				(row.type === 'stack' &&
+					!row.expanded &&
+					row.threads.some((t) => t.thread_id === threadID)),
+		)
+		if (row) return row
+
+		const dateKey = collapsedGroups.value.find((key) => getGroupThreads(key)?.includes(threadID))
+		return navigableRows.value.find((row) => row.key === `group:${dateKey}`)
+	}
+
+	const focusOnThread = (threadID?: string) => focusRow(rowForThread(threadID))
+
+	// ── Folding ─────────────────────────────────────────────────────────────────────────────────────
+
+	const toggleStack = (row: StackRow) => {
+		const ids = row.threads.map((t) => t.thread_id)
+		// The cursor follows the click, as it does when you open a mail. This also covers the fold: the
+		// members are about to be hidden, so the stack row that now stands for them is where the cursor
+		// belongs, and Enter-fold-Enter-unfold stays a round trip rather than a way to lose your place.
+		focusedRowKey.value = row.key
+		if (!row.expanded) return ids.forEach((id) => expandedStacks.value.add(id))
+
+		ids.forEach((id) => expandedStacks.value.delete(id))
+		// Don't leave the reading pane pointing at a row we just hid — the same reason
+		// toggleGroupCollapse leaves the thread when its group collapses.
+		const open = openThreadID()
+		if (open && ids.includes(open)) onOpenThreadHidden()
+	}
+
+	const toggleGroupCollapse = (key: string) => {
+		// The cursor follows the click, as it does when you open a mail: Enter and a click are the same
+		// gesture on the same row, and Enter can only mean that if the cursor is already there. Above the
+		// last-group guard, so clicking a header that can't fold still takes the cursor.
+		focusedRowKey.value = `group:${key}`
+		if (isLastGroup(key)) return
+
+		if (collapsedGroups.value.includes(key))
+			return (collapsedGroups.value = collapsedGroups.value.filter((d) => d !== key))
+
+		collapsedGroups.value.push(key)
+		// Collapsing keeps the group's selection where the list has one: "collapse a day, tick it,
+		// archive it" is a bulk move worth having, and the header's own checkbox goes on showing that the
+		// day is selected. Only the reading pane has to move, since it would otherwise point at a row
+		// that is no longer rendered.
+		const open = openThreadID()
+		if (open && getGroupThreads(key)?.includes(open)) onOpenThreadHidden()
+	}
+
+	/**
+	 * Bring a thread into view in the list, and put the cursor on it. A deep link or a step to the next
+	 * thread can land inside a collapsed stack or a folded day — surface it either way: an opened thread
+	 * is always visible in the list, and the cursor is left where keyboard navigation should resume.
+	 *
+	 * The focus is deferred a tick because the row may only just have been revealed by the two lines
+	 * above it, and because callers run this from a watcher whose immediate run fires mid-setup.
+	 */
+	const revealThread = (threadID: string) => {
+		expandedStacks.value.add(threadID)
+
+		setTimeout(() => focusOnThread(threadID))
+
+		for (const group of collapsedGroups.value) {
+			if (getGroupThreads(group)?.includes(threadID))
+				return (collapsedGroups.value = collapsedGroups.value.filter((d) => d !== group))
+		}
+	}
+
+	return {
+		groupMessagesBy,
+		groupedThreads,
+		getGroupThreads,
+		isLastGroup,
+		collapsedGroups,
+		expandedStacks,
+		groupedRows,
+		navigableRows,
+		focusedRowKey,
+		focusedRow,
+		focusRow,
+		focusRowKey,
+		rowForThread,
+		focusOnThread,
+		toggleStack,
+		toggleGroupCollapse,
+		revealThread,
+	}
+}

--- a/frontend/src/apps/mail/composables/useListRows.ts
+++ b/frontend/src/apps/mail/composables/useListRows.ts
@@ -1,7 +1,6 @@
-import { computed, ref, watch, type Ref } from 'vue'
+import { computed, nextTick, ref, watch, type Ref } from 'vue'
 
 import dayjs from '@/apps/mail/utils/dayjs'
-import { useRowScroll } from '@/apps/mail/utils/listNavigation'
 import { buildListRows, type ListRow, type StackRow } from '@/apps/mail/utils/threadStacks'
 import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
@@ -144,7 +143,20 @@ export const useListRows = ({
 		navigableRows.value.find((row) => row.key === focusedRowKey.value),
 	)
 
-	const scrollRowIntoView = useRowScroll(container)
+	/**
+	 * Scrolls the row marked `data-row-key` into the centre of the list. Skipped on mobile, where the
+	 * thread pane slides over the list and the jump would only show behind it. Waits a tick because
+	 * the row may have only just been revealed (a stack or day group expanding, a route change
+	 * landing); a no-op when nothing changed.
+	 */
+	const scrollRowIntoView = (key: string) => {
+		if (isMobile.value) return
+		nextTick(() => {
+			container.value
+				?.querySelector(`[data-row-key="${key}"]`)
+				?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+		})
+	}
 
 	const focusRowKey = (key: string) => {
 		focusedRowKey.value = key

--- a/frontend/src/apps/mail/composables/useListRows.ts
+++ b/frontend/src/apps/mail/composables/useListRows.ts
@@ -180,6 +180,22 @@ export const useListRows = ({
 
 	const focusOnThread = (threadID?: string) => focusRow(rowForThread(threadID))
 
+	/**
+	 * What a rendered row looks like in its list, as opposed to in itself: the cursor's left marker,
+	 * the tint on the row whose thread is open beside it, and the indent on a member of an expanded
+	 * stack. Four copies of these three rules — one per row type per list — is three too many.
+	 *
+	 * The open-row tint is desktop-only: on mobile the pane covers the list, so it would only ever be
+	 * seen once the reader had already left the thread it points at.
+	 */
+	const rowClasses = (row: ListRow) => ({
+		'border-l-transparent sm:border-l': true,
+		'!border-l-outline-blue-5': row.key === focusedRowKey.value,
+		'!bg-surface-blue-1':
+			row.type === 'thread' && row.thread.thread_id === openThreadID() && !isMobile.value,
+		'!pl-10 sm:!pl-12': row.type === 'thread' && !!row.inStack,
+	})
+
 	// ── Folding ─────────────────────────────────────────────────────────────────────────────────────
 
 	const toggleStack = (row: StackRow) => {
@@ -248,6 +264,7 @@ export const useListRows = ({
 		focusedRow,
 		focusRow,
 		focusRowKey,
+		rowClasses,
 		rowForThread,
 		focusOnThread,
 		toggleStack,

--- a/frontend/src/apps/mail/composables/useMailRemoval.ts
+++ b/frontend/src/apps/mail/composables/useMailRemoval.ts
@@ -1,0 +1,151 @@
+import { type Ref } from 'vue'
+
+import { raiseOptimisticToast } from '@/apps/mail/utils'
+import { useUndo } from '@/apps/mail/utils/composables'
+import { resummariseRow } from '@/apps/mail/utils/threadSummary'
+import { userStore } from '@/apps/mail/stores/user'
+
+import type { Mail, Thread } from '@/apps/mail/types'
+
+interface MailThreadInstance {
+	removeMailFromView: (mailId: string) => { emptied: boolean; rollback: () => void }
+}
+
+export interface MailRemovalOptions {
+	/** The loaded row the mail's thread belongs to, if it is in the loaded window. */
+	row: (mail: Mail) => Thread | undefined
+	/** The open reading pane, which drops the mail from its own view. */
+	mailThreadRef: Ref<MailThreadInstance | null>
+	/**
+	 * The mail was the last one its thread had to show, so the pane has nothing left: take it
+	 * elsewhere. Runs before the row is dropped, since where to go is read off the list.
+	 */
+	onEmptied: (mail: Mail) => void
+	/** Drop the thread's row from the list. Returns a closure putting it back where it was. */
+	removeRow: (mail: Mail, thread?: Thread) => () => void
+	/** The current mailbox id, but only in Sent or Drafts — see resummariseRow. */
+	outgoingMailbox?: () => string | undefined
+	/** Runs once the forward request lands, after the sidebar counts are reloaded. */
+	afterForward?: () => void
+}
+
+/**
+ * Per-message actions from the reading pane — move a single mail out of its thread, junk it, delete it.
+ *
+ * The mail leaves the pane at once: waiting for the request meant a click did nothing visible until the
+ * round-trip landed. Three things have to move with it, and all three had to be got right twice, once
+ * per list view, before this was shared — the same stale-row bug was then fixed in both copies within
+ * one commit:
+ *
+ * 1. the pane drops the message (removeMailFromView),
+ * 2. the row drops it from its own `messages`, which is where its message count and its participants
+ *    come from, and re-derives the summary fields describing the thread's latest message,
+ * 3. if that was the thread's last message, the pane goes elsewhere and the row leaves the list.
+ *
+ * A failure puts all of it back. Undo, when the caller supplies `undoReq`, restores the server state and
+ * replays the same UI restore — and if the undo itself fails, re-removes, so the UI never shows a mail
+ * the server still considers gone.
+ */
+export const useMailRemoval = ({
+	row,
+	mailThreadRef,
+	onEmptied,
+	removeRow,
+	outgoingMailbox,
+	afterForward,
+}: MailRemovalOptions) => {
+	const { mailboxes } = userStore()
+	const { setUndoAction, undo } = useUndo()
+
+	const runMailRemoval = (
+		mail: Mail,
+		req: () => Promise<unknown>,
+		success: string,
+		opts: {
+			undoReq?: () => Promise<unknown>
+			undoSuccess?: string
+			afterSuccess?: () => void
+		} = {},
+	) => {
+		const { emptied, rollback } = mailThreadRef.value?.removeMailFromView(mail.id) ?? {
+			emptied: false,
+			rollback: () => {},
+		}
+
+		const thread = row(mail)
+		const mailIndex = thread?.messages?.findIndex((m: Mail) => m.id === mail.id) ?? -1
+
+		// Drop the mail from the row's own conversation and re-summarise it. Returns the inverse.
+		const dropFromRow = () => {
+			if (!thread || mailIndex === -1) return () => {}
+			const index = thread.messages.findIndex((m: Mail) => m.id === mail.id)
+			if (index === -1) return () => {}
+			thread.messages.splice(index, 1)
+			const restoreSummary = resummariseRow(thread, outgoingMailbox?.())
+			return () => {
+				thread.messages.splice(mailIndex, 0, mail)
+				restoreSummary()
+			}
+		}
+
+		let restoreFromRow = dropFromRow()
+
+		let restoreRow: (() => void) | undefined
+		if (emptied) {
+			onEmptied(mail)
+			restoreRow = removeRow(mail, thread)
+		}
+
+		const restoreUi = () => {
+			rollback()
+			restoreFromRow()
+			restoreRow?.()
+		}
+
+		setUndoAction(undefined)
+		let forwardOk = false
+		const forwardPromise = (async () => {
+			try {
+				await req()
+				forwardOk = true
+				mailboxes.reload()
+				afterForward?.()
+				opts.afterSuccess?.()
+			} catch (error) {
+				restoreUi()
+				setUndoAction(undefined)
+				throw error
+			}
+		})()
+
+		if (!opts.undoReq) return raiseOptimisticToast(forwardPromise, success)
+
+		setUndoAction(() =>
+			void (async () => {
+				await forwardPromise.catch(() => {})
+				if (!forwardOk) return
+				restoreUi()
+				setUndoAction(undefined)
+				raiseOptimisticToast(
+					opts
+						.undoReq!()
+						.then(() => mailboxes.reload())
+						.catch((error) => {
+							// The undo didn't land server-side — re-remove so the UI matches the server
+							// instead of showing the mail (and its row) as restored. The pane stays where
+							// it is: it was already taken elsewhere once, and the reader has since asked
+							// to come back.
+							mailThreadRef.value?.removeMailFromView(mail.id)
+							restoreFromRow = dropFromRow()
+							if (emptied) restoreRow = removeRow(mail, thread)
+							throw error
+						}),
+					opts.undoSuccess ?? success,
+				)
+			})(),
+		)
+		raiseOptimisticToast(forwardPromise, success, undo)
+	}
+
+	return { runMailRemoval }
+}

--- a/frontend/src/apps/mail/composables/usePaginatedThreads.ts
+++ b/frontend/src/apps/mail/composables/usePaginatedThreads.ts
@@ -100,6 +100,15 @@ export const usePaginatedThreads = ({
 	const scrollListToTop = () => container.value?.scrollTo({ top: 0 })
 
 	/**
+	 * The thread `offset` steps from `from` (the open one by default), within what is loaded.
+	 * Undefined at either end, which is how a caller knows to load the next window instead — and for
+	 * a `from` that is no longer loaded, which reads as "the cursor is lost, do nothing" going up and
+	 * as the first thread going down.
+	 */
+	const threadByOffset = (offset: number, from: string | undefined = openThreadID()) =>
+		threadIDs.value[threadIDs.value.indexOf(from as string) + offset]
+
+	/**
 	 * For a reset resource's `transform`: snapshots the merge base (before this window replaces the
 	 * loaded list), reads the lookahead row, and trims it off.
 	 */
@@ -273,7 +282,7 @@ export const usePaginatedThreads = ({
 		if (!pendingEdgeThread) return
 		const { action, anchor } = pendingEdgeThread
 		// The successor of the anchor is now loaded (undefined only if nothing new arrived — then stop).
-		const id = threadIDs.value[threadIDs.value.indexOf(anchor as string) + 1]
+		const id = threadByOffset(1, anchor)
 		pendingEdgeThread = null
 		if (!id) return
 		onEdgeThread(id, action)
@@ -299,6 +308,7 @@ export const usePaginatedThreads = ({
 		isFetching,
 		canGoNext,
 		threadIDs,
+		threadByOffset,
 		scrollListToTop,
 		takeResetWindow,
 		beginReset,

--- a/frontend/src/apps/mail/composables/usePaginatedThreads.ts
+++ b/frontend/src/apps/mail/composables/usePaginatedThreads.ts
@@ -1,0 +1,314 @@
+import { computed, nextTick, ref, useTemplateRef } from 'vue'
+import { useIntersectionObserver } from '@vueuse/core'
+
+import type { Thread } from '@/apps/mail/types'
+
+/**
+ * Infinite scroll over a thread list, shared by the per-account mailbox list and the merged All
+ * Inboxes one.
+ *
+ * The accumulated list lives in the reset resource's `data` and is the single source of truth every
+ * consumer reads. Two fetch paths write it: the reset resource replaces it (always `start: 0`), the
+ * append resource pushes the next window onto it. They stay separate resources so createResource's
+ * replace-on-reload can never fight the append — which is why this owns the bookkeeping BETWEEN them
+ * (the epochs, the refresh merge, the removal suppression) rather than the resources themselves,
+ * whose urls, params and payload shapes differ per view.
+ *
+ * Both views had a line-for-line copy of all of it, comments included, and the copies had already
+ * drifted: the merged list was missing the removal suppression (a thread archived mid-refresh
+ * reappeared) and the edge crossing (prev/next in the reading pane stopped dead at the last loaded
+ * thread instead of paging).
+ *
+ * The caller must render `ref="mailList"` on the scroll container and `ref="loadMoreSentinel"` on a
+ * zero-height element after the last row, and must call `topUpIfShort` from a watcher on its rendered
+ * rows (see that function — the watcher has to sit below the rows it reads).
+ */
+
+/** Rows per window. Fetches ask for one more, to detect whether further rows exist without a total. */
+export const PAGE_LENGTH = 25
+
+// How long a row optimistically removed by an action stays suppressed. The server keeps returning it
+// until the mutation lands, so a refresh or append in that window would put it back.
+const REMOVAL_SUPPRESSION_MS = 15000
+
+/** The shape of a reset resource this reads and writes — createResource satisfies it. */
+export interface ThreadListResource {
+	data?: Thread[]
+	loading: boolean
+}
+
+export interface PaginatedThreadsOptions {
+	/** The active reset resource. A getter, since the search view swaps which one is active. */
+	resource: () => ThreadListResource
+	/** Triggers the append fetch. Its onSuccess must hand the rows to `appendThreads`. */
+	fetchMore: () => void
+	/** The open thread, if any — the anchor when the reading pane steps past the last loaded row. */
+	openThreadID: () => string | undefined
+	/**
+	 * Where to send a thread that only arrived because the cursor stepped off the loaded edge:
+	 * 'open' for the reading pane, 'focus' for the list cursor.
+	 */
+	onEdgeThread: (threadID: string, action: 'open' | 'focus') => void
+	/**
+	 * A row's identity, for the dedupe and the removal suppression. Defaults to the thread id; the
+	 * merged view keys by account + thread id, since one thread id can recur across accounts.
+	 */
+	threadKey?: (thread: Thread) => string
+}
+
+export const usePaginatedThreads = ({
+	resource,
+	fetchMore,
+	openThreadID,
+	onEdgeThread,
+	threadKey = (thread: Thread) => thread.thread_id,
+}: PaginatedThreadsOptions) => {
+	const container = useTemplateRef<HTMLElement>('mailList')
+	const sentinel = useTemplateRef<HTMLElement>('loadMoreSentinel')
+
+	const hasMore = ref(false) // lookahead: the last fetched window returned an extra row, so more exist
+	const loadingMore = ref(false) // an append fetch is in flight (drives the bottom spinner)
+	// Bumped on every reset/refresh; an in-flight append captures it and discards its result if it
+	// changed meanwhile, so a stale window can't land on a freshly reset list.
+	const epoch = ref(0)
+	let loadEpoch = 0 // epoch captured when the current append was triggered
+	// Refresh ("check for new mail") state: merges the newest window into the loaded list, preserving
+	// scroll — set while such a reload is in flight so its onSuccess prepends instead of replacing.
+	const refreshMode = ref(false)
+	let refreshEpoch = 0 // epoch captured when the refresh was triggered (dropped if a reset intervenes)
+	// The loaded list to merge the fresh window into. Captured at *response* time (in the resource
+	// transform, via takeResetWindow), not refresh-start, so it reflects any optimistic removals or
+	// undo-inserts made while the refresh was in flight.
+	let refreshSnapshot: Thread[] = []
+	// Rows optimistically removed by an action whose request is still in flight (see
+	// REMOVAL_SUPPRESSION_MS). The merges below skip them.
+	const recentlyRemoved = new Set<string>()
+
+	const list = () => resource().data ?? []
+
+	/** The loaded threads' ids, in list order — what the reading pane pages through. */
+	const threadIDs = computed(() => list().map((thread: Thread) => thread.thread_id))
+
+	/** Whether any fetch is in flight. Gates the Refresh affordance and a new refresh. */
+	const isFetching = computed(() => resource().loading || loadingMore.value)
+
+	// The reading pane's Next arrow can always advance while more threads remain to load (crossing the
+	// last loaded thread triggers an append). The Prev arrow is disabled at the first loaded thread,
+	// which is the first thread overall — we always start from the top.
+	const canGoNext = computed(() => hasMore.value)
+
+	const scrollListToTop = () => container.value?.scrollTo({ top: 0 })
+
+	/**
+	 * For a reset resource's `transform`: snapshots the merge base (before this window replaces the
+	 * loaded list), reads the lookahead row, and trims it off.
+	 */
+	const takeResetWindow = (rows: Thread[]): Thread[] => {
+		if (refreshMode.value) refreshSnapshot = list()
+		hasMore.value = rows.length > PAGE_LENGTH
+		return rows.slice(0, PAGE_LENGTH)
+	}
+
+	/**
+	 * Reset-to-top: the caller is about to refetch the first window, replacing the loaded list.
+	 * Bumping the epoch discards any append or refresh still in flight.
+	 */
+	const beginReset = () => {
+		refreshMode.value = false
+		epoch.value++
+	}
+
+	/**
+	 * Check for new mail without losing the reader's place: the caller is about to refetch the newest
+	 * window, which onResetSuccess will merge into the loaded list instead of replacing it.
+	 *
+	 * Returns false when a fetch is already in flight, which is the caller's cue to do nothing.
+	 * Bumping the epoch discards an append still in flight (appendThreads checks it) instead of
+	 * letting it land after the merge and clobber it. A new append can't start mid-refresh (loadMore
+	 * bails while the resource is loading), so this fully closes the refresh/append race.
+	 */
+	const beginRefresh = () => {
+		if (isFetching.value) return false
+		refreshMode.value = true
+		epoch.value++
+		refreshEpoch = epoch.value
+		return true
+	}
+
+	/**
+	 * Called when a first-window fetch resolves. Two modes:
+	 * - refresh: keep the loaded rows, prepend only threads not already loaded (new mail), and hold
+	 *   the reader's scroll position (re-anchored by the height the prepended rows added).
+	 * - reset: reveal the fresh first window and scroll to top (mailbox switch, filter, undo, …).
+	 * Either way, cancel any pending edge navigation.
+	 */
+	const onResetSuccess = () => {
+		pendingEdgeThread = null
+
+		if (refreshMode.value) {
+			refreshMode.value = false
+			// A reset (mailbox switch, filter, undo) raced in and bumped the epoch — drop this stale merge.
+			if (refreshEpoch !== epoch.value) return
+			// Anchor to the current scroll before merging. The window replaced `data` a beat ago but the
+			// DOM hasn't re-rendered yet, so these still reflect the list the reader is looking at.
+			const el = container.value
+			const prevTop = el?.scrollTop ?? 0
+			const prevHeight = el?.scrollHeight ?? 0
+			const freshWindow = list()
+			const existing = new Set(refreshSnapshot.map(threadKey))
+			const fresh = freshWindow.filter(
+				(thread: Thread) =>
+					!existing.has(threadKey(thread)) && !recentlyRemoved.has(threadKey(thread)),
+			)
+			resource().data = [...fresh, ...refreshSnapshot]
+			// Keep the reader where they were: shift scroll by the height the prepended rows added. If
+			// they were already at the top, leave them there so the new mail is visible.
+			nextTick(() => {
+				if (el && prevTop > 0) el.scrollTop = prevTop + (el.scrollHeight - prevHeight)
+			})
+			return
+		}
+
+		scrollListToTop()
+	}
+
+	/**
+	 * Appends the next window onto the loaded list, deduped by row key. `start = data.length` stays
+	 * correct across optimistic removals (the server list shifts left by the same rows we dropped); the
+	 * only skew is new mail inserted at the front, which the dedupe absorbs and the next reset reconciles.
+	 */
+	const appendThreads = (rows: Thread[]) => {
+		loadingMore.value = false
+		// Discard a stale window that resolved after a reset began (mailbox switch, refresh, undo, …).
+		if (loadEpoch !== epoch.value) return
+		const seen = new Set(list().map(threadKey))
+		const fresh = rows
+			.slice(0, PAGE_LENGTH)
+			.filter(
+				(thread) => !seen.has(threadKey(thread)) && !recentlyRemoved.has(threadKey(thread)),
+			)
+		// Stop auto-loading if the window added nothing new (offset stuck behind heavy front-inserted
+		// mail, or the server's fetch depth cap reached); the next reset reconciles. Guards against a
+		// tight reload loop while the sentinel stays in view.
+		hasMore.value = rows.length > PAGE_LENGTH && fresh.length > 0
+		resource().data = [...list(), ...fresh]
+		openPendingEdgeThread()
+	}
+
+	const loadMore = () => {
+		if (!hasMore.value || isFetching.value) return
+		loadingMore.value = true
+		loadEpoch = epoch.value
+		fetchMore()
+	}
+
+	// True while the sentinel is in view.
+	const sentinelVisible = ref(false)
+
+	// The height the list had reached the last time we topped it up, so a fill that adds nothing can be
+	// detected. Reset at the start of each fill episode.
+	let lastFillHeight = 0
+
+	useIntersectionObserver(
+		sentinel,
+		([entry]) => {
+			const entering = !!entry?.isIntersecting && !sentinelVisible.value
+			sentinelVisible.value = !!entry?.isIntersecting
+			if (entering) lastFillHeight = 0
+			if (sentinelVisible.value) loadMore()
+		},
+		{ root: container },
+	)
+
+	/**
+	 * Rescues the one case the observer cannot: the rendered list is too short to scroll, so the
+	 * sentinel can never leave and re-enter the viewport to fire again — infinite scroll would die with
+	 * nothing left to scroll. A window of 25 threads can collapse to a single stack row, so filling the
+	 * viewport can take several of them.
+	 *
+	 * Both guards are load-bearing. Stop once the list can scroll, because from there the user's own
+	 * scrolling drives the observer. And stop if a window added no height: its rows landed somewhere
+	 * they cannot be seen (a collapsed date group), so further windows would be just as invisible —
+	 * without this, collapsing a large group turns into a stampede that walks the entire mailbox 25
+	 * threads at a time.
+	 *
+	 * Call it from a watcher on the RENDERED rows, not on the loaded threads: a fill is judged by the
+	 * height the rows took, and rows also come and go as stacks and date groups fold. That watcher must
+	 * be declared below the rows it watches — `watch` evaluates its source at setup, and reading a
+	 * `<script setup>` computed from above its declaration is a temporal-dead-zone crash.
+	 */
+	const topUpIfShort = () => {
+		if (!sentinelVisible.value || !hasMore.value) return
+
+		nextTick(() => {
+			const el = container.value
+			if (!el || !sentinelVisible.value) return
+
+			const grew = el.scrollHeight > lastFillHeight
+			lastFillHeight = el.scrollHeight
+			if (el.scrollHeight <= el.clientHeight && grew) loadMore()
+		})
+	}
+
+	// Stepping past the last loaded thread loads the next window, then opens/focuses the newly appended
+	// thread once it arrives (openPendingEdgeThread, called from appendThreads). `anchor` is the thread
+	// we stepped off (the previously-last loaded), captured so we can resolve its successor after the
+	// append. There's no backward case — the first loaded thread is the first thread overall.
+	let pendingEdgeThread: { action: 'open' | 'focus'; anchor: string | undefined } | null = null
+
+	const loadMoreThenOpenEdge = (offset: number, action: 'open' | 'focus') => {
+		// One crossing at a time: ignore further edge steps until the append resolves, so key
+		// auto-repeat at the bottom of the list can't fire a burst of loads.
+		if (pendingEdgeThread || offset < 0 || !hasMore.value) return
+		// A focus crossing can only happen from the last navigable row, whose last thread is the last
+		// loaded one — so the tail anchors the successor without needing to map a row back to a thread.
+		pendingEdgeThread = {
+			action,
+			anchor: action === 'open' ? openThreadID() : threadIDs.value.at(-1),
+		}
+		loadMore()
+	}
+
+	function openPendingEdgeThread() {
+		if (!pendingEdgeThread) return
+		const { action, anchor } = pendingEdgeThread
+		// The successor of the anchor is now loaded (undefined only if nothing new arrived — then stop).
+		const id = threadIDs.value[threadIDs.value.indexOf(anchor as string) + 1]
+		pendingEdgeThread = null
+		if (!id) return
+		onEdgeThread(id, action)
+	}
+
+	/**
+	 * Suppress re-insertion of optimistically removed rows by an in-flight refresh/append, until the
+	 * server-side removal lands. Keys are in `threadKey` space.
+	 */
+	const suppressRemoved = (keys: string[]) =>
+		keys.forEach((key) => {
+			recentlyRemoved.add(key)
+			setTimeout(() => recentlyRemoved.delete(key), REMOVAL_SUPPRESSION_MS)
+		})
+
+	/** Lift the suppression: the rows are back (a removal failed, or was undone), so they must show. */
+	const unsuppressRemoved = (keys: string[]) => keys.forEach((key) => recentlyRemoved.delete(key))
+
+	return {
+		container,
+		hasMore,
+		loadingMore,
+		isFetching,
+		canGoNext,
+		threadIDs,
+		scrollListToTop,
+		takeResetWindow,
+		beginReset,
+		beginRefresh,
+		onResetSuccess,
+		appendThreads,
+		loadMore,
+		loadMoreThenOpenEdge,
+		topUpIfShort,
+		suppressRemoved,
+		unsuppressRemoved,
+	}
+}

--- a/frontend/src/apps/mail/composables/usePaginatedThreads.ts
+++ b/frontend/src/apps/mail/composables/usePaginatedThreads.ts
@@ -31,6 +31,20 @@ export const PAGE_LENGTH = 25
 // until the mutation lands, so a refresh or append in that window would put it back.
 const REMOVAL_SUPPRESSION_MS = 15000
 
+/**
+ * Merges two newest-first runs of threads into one, keeping newest-first order. Both inputs are
+ * already sorted (the server returns them that way), so this is a plain two-pointer merge; ties keep
+ * the fresh row first, matching the prepend this replaced.
+ */
+export const mergeByReceivedAt = (fresh: Thread[], loaded: Thread[]): Thread[] => {
+	const merged: Thread[] = []
+	let f = 0
+	let l = 0
+	while (f < fresh.length && l < loaded.length)
+		merged.push(fresh[f].received_at >= loaded[l].received_at ? fresh[f++] : loaded[l++])
+	return [...merged, ...fresh.slice(f), ...loaded.slice(l)]
+}
+
 /** The shape of a reset resource this reads and writes — createResource satisfies it. */
 export interface ThreadListResource {
 	data?: Thread[]
@@ -162,18 +176,31 @@ export const usePaginatedThreads = ({
 			// DOM hasn't re-rendered yet, so these still reflect the list the reader is looking at.
 			const el = container.value
 			const prevTop = el?.scrollTop ?? 0
-			const prevHeight = el?.scrollHeight ?? 0
+			// Anchor on the row that was at the top of the loaded list. Measuring how far *it* moves
+			// counts only what the merge inserted above the reader; a total-height delta would also
+			// count rows merged in below them and scroll the list out from under them.
+			const anchorKey = refreshSnapshot[0]?.thread_id
+			const anchorTop = () =>
+				anchorKey
+					? ((el?.querySelector(`[data-row-key="${anchorKey}"]`) as HTMLElement | null)
+							?.offsetTop ?? 0)
+					: 0
+			const prevAnchorTop = anchorTop()
 			const freshWindow = list()
 			const existing = new Set(refreshSnapshot.map(threadKey))
 			const fresh = freshWindow.filter(
 				(thread: Thread) =>
 					!existing.has(threadKey(thread)) && !recentlyRemoved.has(threadKey(thread)),
 			)
-			resource().data = [...fresh, ...refreshSnapshot]
-			// Keep the reader where they were: shift scroll by the height the prepended rows added. If
+			// Date-merge rather than blind prepend. A prepend assumes everything in the newest window
+			// that isn't loaded yet is newer than everything that is — true for one account, false for
+			// the merged list, where a second account's newest mail can be older than the first's oldest
+			// loaded row and would otherwise open a stale date group above today's.
+			resource().data = mergeByReceivedAt(fresh, refreshSnapshot)
+			// Keep the reader where they were: shift scroll by the height the merge added above them. If
 			// they were already at the top, leave them there so the new mail is visible.
 			nextTick(() => {
-				if (el && prevTop > 0) el.scrollTop = prevTop + (el.scrollHeight - prevHeight)
+				if (el && prevTop > 0) el.scrollTop = prevTop + (anchorTop() - prevAnchorTop)
 			})
 			return
 		}

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -829,6 +829,7 @@ const handleSyncUnseen = (ids: string[]) => {
 const mailThread = useTemplateRef<{
 	syncFlagged: (ids: string[], flagged: boolean) => void
 	syncMailboxMembership: (mailboxId: string, add: boolean) => void
+	removeMailFromView: (mailId: string) => { emptied: boolean; rollback: () => void }
 }>('mailThread')
 
 // The row's `flagged` drives the list star; the pane's stars read each message. Update both, or
@@ -901,30 +902,55 @@ const handleSetSpamStatus = (spam: boolean) => {
 	)
 }
 
-// Per-message actions from a message's own menu. The thread stays put; only its contents change,
-// so the list is refreshed rather than optimistically edited.
-const handleMailMove = (mail: Mail, target: string) => {
+// Per-message actions from a message's own menu. The mail leaves the pane at once — waiting for the
+// request meant a click did nothing visible until the round-trip landed. If it was the thread's last
+// mail the row goes too, and the pane closes; a failure puts all of it back.
+const runMailRemoval = (mail: Mail, request: () => Promise<unknown>, success: string) => {
+	const thread = openRow.value
+	const { emptied, rollback } = mailThread.value?.removeMailFromView(mail.id) ?? {
+		emptied: false,
+		rollback: () => {},
+	}
+
+	let restoreRow: (() => void) | undefined
+	if (emptied && thread) {
+		restoreRow = removeFromList(thread)
+		closeThread()
+	}
+
 	raiseOptimisticToast(
-		paneCall('move_mails', { ids: [mail.id], mailbox: target }).then(() => refreshThreads(false)),
+		request()
+			.then(() => refreshCounts())
+			.catch((error) => {
+				rollback()
+				restoreRow?.()
+				throw error
+			}),
+		success,
+	)
+}
+
+const handleMailMove = (mail: Mail, target: string) =>
+	runMailRemoval(
+		mail,
+		() => paneCall('move_mails', { ids: [mail.id], mailbox: target }),
 		__('Mail moved.'),
 	)
-}
 
-const handleMailSpam = (mail: Mail, spam: boolean) => {
-	raiseOptimisticToast(
-		paneCall('set_mails_spam_status', { ids: [mail.id], spam }).then(() => refreshThreads(false)),
+const handleMailSpam = (mail: Mail, spam: boolean) =>
+	runMailRemoval(
+		mail,
+		() => paneCall('set_mails_spam_status', { ids: [mail.id], spam }),
 		spam ? __('Mail marked as junk.') : __('Mail marked as not junk.'),
 	)
-}
 
-const handleMailDelete = (mail: Mail) => {
-	raiseOptimisticToast(
-		call('suite.mail.doctype.mail_message.mail_message.bulk_delete', {
-			names: [mail.name],
-		}).then(() => refreshThreads(false)),
+const handleMailDelete = (mail: Mail) =>
+	runMailRemoval(
+		mail,
+		() =>
+			call('suite.mail.doctype.mail_message.mail_message.bulk_delete', { names: [mail.name] }),
 		__('Mail deleted.'),
 	)
-}
 
 const closeThread = () => router.push({ name: 'mail-all-inboxes', query: route.query })
 

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -188,6 +188,7 @@
 					     The owning account scopes the pane (folder menus, reply identities) —
 					     opening a cross-account thread does NOT switch the active account. -->
 					<MailThread
+						ref="mailThread"
 						v-if="openRow || !threadID"
 						:slide="threadSlide"
 						@slide-done="threadSlide = ''"
@@ -199,7 +200,7 @@
 						@reload-mails="refreshThreads()"
 						@set-seen="(seen: boolean) => handleSetSeen(openRow!, seen)"
 						@set-flagged="
-							(_ids: string[], flagged: boolean) => handleSetFlagged(openRow!, flagged)
+							(ids: string[], flagged: boolean) => paneSetFlagged(ids, flagged)
 						"
 						@move-thread="(mailboxId: string) => moveOpenThread(mailboxId)"
 						@delete-thread="handleTrash(openRow!)"
@@ -281,7 +282,7 @@ import MailThread from '@/apps/mail/components/MailThread.vue'
 import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
 import StackListItem from '@/apps/mail/components/StackListItem.vue'
 
-import type { Mail, Thread, UserResource } from '@/apps/mail/types'
+import type { Mail, Mailbox, MailboxData, Thread, UserResource } from '@/apps/mail/types'
 
 const { isMobile } = useScreenSize()
 
@@ -825,11 +826,49 @@ const handleSyncUnseen = (ids: string[]) => {
 	refreshCounts()
 }
 
+const mailThread = useTemplateRef<{
+	syncFlagged: (ids: string[], flagged: boolean) => void
+	syncMailboxMembership: (mailboxId: string, add: boolean) => void
+}>('mailThread')
+
+// The row's `flagged` drives the list star; the pane's stars read each message. Update both, or
+// starring from the pane leaves its own star hollow until a refetch.
+const paneSetFlagged = (ids: string[], flagged: boolean) => {
+	if (openRow.value) handleSetFlagged(openRow.value, flagged)
+	mailThread.value?.syncFlagged(ids, flagged)
+}
+
+// Folder membership shows as tags on the row and in the pane. Neither refetches, so both have to be
+// told — mirroring syncListMailboxMembership plus MailThread's own syncMailboxMembership.
+const syncFolderTag = (mailboxId: string, add: boolean) => {
+	const mb = store.mailboxes.data?.find((m: MailboxData) => m.id === mailboxId)
+	const thread = openRow.value
+	if (!mb || !thread) return
+
+	const entry = { mailbox: mb.name, mailbox_id: mb.id, mailbox_name: mb._name }
+	const apply = (item: { mailboxes: Mailbox[] }) => {
+		if (add) {
+			if (!item.mailboxes.some((m) => m.mailbox_id === mailboxId)) item.mailboxes.push({ ...entry })
+		} else if (item.mailboxes.length > 1) {
+			item.mailboxes = item.mailboxes.filter((m) => m.mailbox_id !== mailboxId)
+		}
+	}
+	apply(thread)
+	thread.messages?.forEach(apply)
+	mailThread.value?.syncMailboxMembership(mailboxId, add)
+}
+
 const handleAddToMailbox = (mailboxId: string) => {
 	const thread = openRow.value
 	if (!thread) return
+	syncFolderTag(mailboxId, true)
 	raiseOptimisticToast(
-		paneCall('add_mails_to_mailbox', { ids: messageIdsOf(thread), mailbox_id: mailboxId }),
+		paneCall('add_mails_to_mailbox', { ids: messageIdsOf(thread), mailbox_id: mailboxId }).catch(
+			(error) => {
+				syncFolderTag(mailboxId, false)
+				throw error
+			},
+		),
 		__('Thread added to folder.'),
 	)
 }
@@ -837,8 +876,14 @@ const handleAddToMailbox = (mailboxId: string) => {
 const handleRemoveFromMailbox = (mailboxId: string) => {
 	const thread = openRow.value
 	if (!thread) return
+	syncFolderTag(mailboxId, false)
 	raiseOptimisticToast(
-		paneCall('remove_mails_from_mailbox', { ids: messageIdsOf(thread), mailbox_id: mailboxId }),
+		paneCall('remove_mails_from_mailbox', { ids: messageIdsOf(thread), mailbox_id: mailboxId }).catch(
+			(error) => {
+				syncFolderTag(mailboxId, true)
+				throw error
+			},
+		),
 		__('Thread removed from folder.'),
 	)
 }

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -79,33 +79,15 @@
 					<!-- Mail list -->
 					<div ref="mailList" class="h-full overflow-y-auto overscroll-contain max-sm:pb-20">
 						<div v-for="(rows, key) in groupedRows" :key="key">
-							<Tooltip
+							<MailGroupHeader
 								v-if="groupMessagesBy !== 'None' && !isMobile"
-								:text="
-									isLastGroup(key)
-										? ''
-										: __(collapsedGroups.includes(key) ? 'Expand' : 'Collapse')
-								"
-							>
-								<div
-									class="text-ink-gray-6 flex items-center border-b border-l-transparent p-3.5 text-xs-semibold sm:border-l sm:px-5"
-									:class="{
-										'sm:hover:bg-surface-gray-1': !isLastGroup(key),
-										'!border-l-outline-blue-5': focusedRowKey === `group:${key}`,
-									}"
-									:data-row-key="`group:${key}`"
-									@click="toggleGroupCollapse(key)"
-								>
-									<span class="select-none pt-[2px]">
-										{{ getFormattedDate(key, groupMessagesBy === 'Month').toUpperCase() }}
-									</span>
-									<component
-										:is="collapsedGroups.includes(key) ? ChevronRight : ChevronDown"
-										v-if="!isLastGroup(key)"
-										class="icon ml-auto"
-									/>
-								</div>
-							</Tooltip>
+								:date-key="key"
+								:monthly="groupMessagesBy === 'Month'"
+								:collapsed="collapsedGroups.includes(key)"
+								:collapsible="!isLastGroup(key)"
+								:focused="focusedRowKey === `group:${key}`"
+								@toggle="toggleGroupCollapse(key)"
+							/>
 							<template v-if="isMobile || !collapsedGroups.includes(key)">
 								<!-- A stack row stands in for a run of look-alike threads; when expanded, its
 								     members follow it as ordinary (indented) rows — the same model as the
@@ -120,8 +102,7 @@
 										:selectable="false"
 										:hide-avatar="!isMobile"
 										:account-label="shortAccountLabel(row.threads[0].account_name)"
-										class="border-l-transparent sm:border-l"
-										:class="{ '!border-l-outline-blue-5': focusedRowKey === row.key }"
+										:class="rowClasses(row)"
 										:data-row-key="row.key"
 										@toggle="toggleStack(row)"
 										@set-seen="(seen: boolean) => stackSetSeen(row.threads, seen)"
@@ -139,12 +120,7 @@
 										thread-route-name="mail-all-inboxes-mail"
 										:hide-avatar="!isMobile"
 										:hide-sender="row.inStack"
-										class="border-l-transparent sm:border-l"
-										:class="{
-											'!bg-surface-blue-1': row.thread.thread_id === threadID && !isMobile,
-											'!border-l-outline-blue-5': focusedRowKey === row.key,
-											'!pl-10 sm:!pl-12': row.inStack,
-										}"
+										:class="rowClasses(row)"
 										:data-row-key="row.key"
 										@set-seen="(seen: boolean) => handleSetSeen(row.thread, seen)"
 										@archive-thread="handleArchive(row.thread)"
@@ -223,11 +199,10 @@
 <script setup lang="ts">
 import { computed, inject, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { ChevronDown, ChevronRight, LoaderCircle, RefreshCw } from 'lucide-vue-next'
-import { Breadcrumbs, Button, Dropdown, Tooltip, call, createResource, usePageMeta } from 'frappe-ui'
+import { ChevronDown, LoaderCircle, RefreshCw } from 'lucide-vue-next'
+import { Breadcrumbs, Button, Dropdown, call, createResource, usePageMeta } from 'frappe-ui'
 
 import {
-	getFormattedDate,
 	isMac,
 	raiseOptimisticToast,
 	raiseToast,
@@ -254,6 +229,7 @@ import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
 import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 import LoadingBar from '@/apps/mail/components/LoadingBar.vue'
+import MailGroupHeader from '@/apps/mail/components/MailGroupHeader.vue'
 import MailListItem from '@/apps/mail/components/MailListItem.vue'
 import MailThread from '@/apps/mail/components/MailThread.vue'
 import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
@@ -396,6 +372,7 @@ const {
 	focusedRow,
 	focusRow,
 	focusOnThread,
+	rowClasses,
 	toggleStack,
 	toggleGroupCollapse,
 	revealThread,

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -912,6 +912,10 @@ const runMailRemoval = (mail: Mail, request: () => Promise<unknown>, success: st
 		rollback: () => {},
 	}
 
+	// The row's count and preview come from its own `messages`, so it has to lose the mail too.
+	const mailIndex = thread?.messages?.findIndex((m: Mail) => m.id === mail.id) ?? -1
+	if (thread && mailIndex !== -1) thread.messages.splice(mailIndex, 1)
+
 	let restoreRow: (() => void) | undefined
 	if (emptied && thread) {
 		restoreRow = removeFromList(thread)
@@ -923,6 +927,7 @@ const runMailRemoval = (mail: Mail, request: () => Promise<unknown>, success: st
 			.then(() => refreshCounts())
 			.catch((error) => {
 				rollback()
+				if (thread && mailIndex !== -1) thread.messages.splice(mailIndex, 0, mail)
 				restoreRow?.()
 				throw error
 			}),

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -216,6 +216,7 @@ import {
 	useGPrefix,
 } from '@/apps/mail/utils/listNavigation'
 import { useStoredFilter } from '@/apps/mail/utils/listFilter'
+import { useAccountScope } from '@/apps/mail/utils/accountScope'
 import { useScreenSize, useSwipeNav } from '@/apps/mail/utils/composables'
 import { useListRows } from '@/apps/mail/composables/useListRows'
 import { useMailRemoval } from '@/apps/mail/composables/useMailRemoval'
@@ -635,7 +636,7 @@ const mailThread = useTemplateRef<{
 // Folder membership shows as tags on the row and in the pane. Neither refetches, so both have to be
 // told — mirroring syncListMailboxMembership plus MailThread's own syncMailboxMembership.
 const syncFolderTag = (mailboxId: string, add: boolean) => {
-	const mb = store.mailboxes.data?.find((m: MailboxData) => m.id === mailboxId)
+	const mb = paneScope.mailboxes.value.data?.find((m: MailboxData) => m.id === mailboxId)
 	const thread = openRow.value
 	if (!mb || !thread) return
 
@@ -708,8 +709,13 @@ const { runMailRemoval } = useMailRemoval({
 	removeRow: (_mail, thread) => (thread ? removeFromList(thread) : () => {}),
 })
 
+// The pane's folder menus are scoped to the thread's own account, so its ids have to be resolved
+// there too — the active account's list won't contain them for a thread from another account, and
+// the lookup silently failing meant no folder tag appeared until a reload.
+const paneScope = useAccountScope(() => openRow.value?.account)
+
 const folderName = (mailboxId: string) =>
-	store.mailboxes.data?.find((m: MailboxData) => m.id === mailboxId)?._name
+	paneScope.mailboxes.value.data?.find((m: MailboxData) => m.id === mailboxId)?._name
 
 const handleMailMove = (mail: Mail, target: string) => {
 	const folder = folderName(target)

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -587,8 +587,7 @@ const toggleStack = (row: StackRow) => {
 
 	ids.forEach((id) => expandedStacks.value.delete(id))
 	// Don't leave the reading pane pointing at a row we just hid.
-	if (threadID && ids.includes(threadID))
-		router.push({ name: 'mail-all-inboxes', query: route.query })
+	if (threadID && ids.includes(threadID)) closeThread()
 }
 
 // What the cursor can land on, in render order: each day's header, then that day's rows — a
@@ -711,8 +710,7 @@ const toggleGroupCollapse = (key: string) => {
 
 	collapsedGroups.value.push(key)
 	// Don't leave the reading pane pointing at a row we just hid.
-	if (groupedThreads.value[key]?.some((t: Thread) => t.thread_id === threadID))
-		router.push({ name: 'mail-all-inboxes', query: route.query })
+	if (groupedThreads.value[key]?.some((t: Thread) => t.thread_id === threadID)) closeThread()
 }
 
 watch(groupMessagesBy, () => (collapsedGroups.value = []))

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -406,7 +406,8 @@ const isLoading = computed(() => !isLoaded.value && threads.loading)
 // store's mailboxes.onSuccess hook also refreshes the unified All Inboxes badge.
 const refreshCounts = () => store.mailboxes.reload()
 
-// The row's account, by its short name (the local part, unless two accounts share one).
+// The row's account, by its short name: blank for the personal account (the default — only
+// the odd ones out get labelled), the local part otherwise, unless two accounts share one.
 const shortAccountLabel = (name?: string | null) =>
 	name ? (store.accountShortNames[name] ?? name) : undefined
 
@@ -490,7 +491,12 @@ const handleKeyDown = (e: KeyboardEvent) => {
 		if (intent === 'last') return goToEdge(-1)
 		return
 	}
-	gPrefix.disarm()
+	// A letter after `g` is a mailbox jump, which MailLayout owns. Swallow it so `g j` doesn't
+	// also step the cursor — `j` is the one key in both that map and the navigation keys.
+	if (gPrefix.armed.value) {
+		gPrefix.disarm()
+		return
+	}
 
 	if (!isNavigationKey(key)) return
 	e.preventDefault()

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -217,7 +217,7 @@ import {
 } from '@/apps/mail/utils/listNavigation'
 import { useStoredFilter } from '@/apps/mail/utils/listFilter'
 import { useAccountScope } from '@/apps/mail/utils/accountScope'
-import { useScreenSize, useSwipeNav } from '@/apps/mail/utils/composables'
+import { useUndo, useScreenSize, useSwipeNav } from '@/apps/mail/utils/composables'
 import { useListRows } from '@/apps/mail/composables/useListRows'
 import { useMailRemoval } from '@/apps/mail/composables/useMailRemoval'
 import {
@@ -461,6 +461,12 @@ const handleThreadActions = (e: KeyboardEvent, key: string) => {
 
 const handleKeyDown = (e: KeyboardEvent) => {
 	const key = e.key.toLowerCase()
+	if ((e.metaKey || e.ctrlKey) && key === 'z' && !shouldIgnoreKeypress(e, true)) {
+		e.preventDefault()
+		gPrefix.disarm()
+		return undo()
+	}
+
 	if (shouldIgnoreKeypress(e)) return
 
 	// Escape backs out of the open thread, then clears the cursor.
@@ -702,6 +708,8 @@ const handleSetSpamStatus = (spam: boolean) => {
 // The merged list is inbox-scoped, so its rows always summarise from the whole conversation — never
 // from a folder, as Sent and Drafts do. No undo yet: the undo requests would have to be scoped to the
 // row's own account rather than the active one.
+const { setUndoAction, undo } = useUndo()
+
 const { runMailRemoval } = useMailRemoval({
 	row: () => openRow.value,
 	mailThreadRef: mailThread,
@@ -717,12 +725,22 @@ const paneScope = useAccountScope(() => openRow.value?.account)
 const folderName = (mailboxId: string) =>
 	paneScope.mailboxes.value.data?.find((m: MailboxData) => m.id === mailboxId)?._name
 
+const undoMail = (mail: Mail) => {
+	const snapshot = mailSnapshot(mail)
+	const account = openRow.value?.account
+	return {
+		undoReq: () => restoreMails(account!, [snapshot]),
+		undoSuccess: __('Mail restored.'),
+	}
+}
+
 const handleMailMove = (mail: Mail, target: string) => {
 	const folder = folderName(target)
 	runMailRemoval(
 		mail,
 		() => paneCall('move_mails', { ids: [mail.id], mailbox: target }),
 		folder ? __('Mail moved to {0}.', [folder]) : __('Mail moved.'),
+		undoMail(mail),
 	)
 }
 
@@ -731,6 +749,7 @@ const handleMailSpam = (mail: Mail, spam: boolean) =>
 		mail,
 		() => paneCall('set_mails_spam_status', { ids: [mail.id], spam }),
 		spam ? __('Mail marked as junk.') : __('Mail marked as not junk.'),
+		undoMail(mail),
 	)
 
 const handleMailDelete = (mail: Mail) =>
@@ -800,6 +819,30 @@ const handleSetFlagged = (thread: Thread, flagged: boolean, ids: string[] = [thr
 // The row is already dropped optimistically by the caller, so move on the server directly. On success just
 // refresh counts (the row and its server row are both gone, so the append offset stays aligned and scroll is
 // preserved). On failure, restore the row in place via the passed closure; rethrow so the toast reports the error.
+// Undo restores each mail's exact mailbox set and junk flag rather than guessing an inverse: a
+// thread that sat in two folders has to come back to both, and un-junking is not the same as moving.
+const mailSnapshot = (mail: Mail) => ({
+	id: mail.id,
+	mailbox_ids: mail.mailboxes.map((m) => m.mailbox_id),
+	junk: mail.junk,
+})
+
+const threadSnapshot = (thread: Thread) => (thread.messages ?? []).map(mailSnapshot)
+
+const restoreMails = (account: string, mails: ReturnType<typeof mailSnapshot>[]) =>
+	call('suite.mail.api.mail.set_mails_mailboxes', { account, mails }).then(refreshCounts)
+
+// Offered on the toast and on Cmd/Ctrl+Z, matching the mailbox list.
+const withUndo = (thread: Thread, restore: () => void) => {
+	const snapshot = threadSnapshot(thread)
+	const undoAction = () => {
+		restore()
+		raiseOptimisticToast(restoreMails(thread.account, snapshot), __('Thread restored.'))
+	}
+	setUndoAction(undoAction)
+	return undoAction
+}
+
 const moveThreadOut = (thread: Thread, mailbox: string, restore: () => void) =>
 	call('suite.mail.api.mail.move_mails', {
 		account: thread.account,
@@ -814,13 +857,21 @@ const moveThreadOut = (thread: Thread, mailbox: string, restore: () => void) =>
 const handleArchive = (thread: Thread) => {
 	if (!thread.archive) return raiseToast(__('No Archive folder for this account.'), 'error')
 	const restore = removeFromList(thread)
-	raiseOptimisticToast(moveThreadOut(thread, thread.archive!, restore), __('Thread archived.'))
+	raiseOptimisticToast(
+		moveThreadOut(thread, thread.archive!, restore),
+		__('Thread archived.'),
+		withUndo(thread, restore),
+	)
 }
 
 const handleTrash = (thread: Thread) => {
 	if (!thread.trash) return raiseToast(__('No Trash folder for this account.'), 'error')
 	const restore = removeFromList(thread)
-	raiseOptimisticToast(moveThreadOut(thread, thread.trash!, restore), __('Thread moved to Trash.'))
+	raiseOptimisticToast(
+		moveThreadOut(thread, thread.trash!, restore),
+		__('Thread moved to Trash.'),
+		withUndo(thread, restore),
+	)
 }
 
 // Stack actions. A stack's members share one account (it is part of the stack key), so a single

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -181,7 +181,8 @@
 					@reload-mails="refreshThreads()"
 					@set-seen="(seen: boolean) => handleSetSeen(openRow!, seen)"
 					@set-flagged="
-						(ids: string[], flagged: boolean) => paneSetFlagged(ids, flagged)
+						(ids: string[], flagged: boolean) =>
+							handleSetFlagged(openRow!, flagged, ids)
 					"
 					@move-thread="(mailboxId: string) => moveOpenThread(mailboxId)"
 					@delete-thread="handleTrash(openRow!)"
@@ -813,13 +814,6 @@ const mailThread = useTemplateRef<{
 	removeMailFromView: (mailId: string) => { emptied: boolean; rollback: () => void }
 }>('mailThread')
 
-// The row's `flagged` drives the list star; the pane's stars read each message. Update both, or
-// starring from the pane leaves its own star hollow until a refetch.
-const paneSetFlagged = (ids: string[], flagged: boolean) => {
-	if (openRow.value) handleSetFlagged(openRow.value, flagged)
-	mailThread.value?.syncFlagged(ids, flagged)
-}
-
 // Folder membership shows as tags on the row and in the pane. Neither refetches, so both have to be
 // told — mirroring syncListMailboxMembership plus MailThread's own syncMailboxMembership.
 const syncFolderTag = (mailboxId: string, add: boolean) => {
@@ -970,14 +964,33 @@ const handleSetSeen = (thread: Thread, seen: boolean) => {
 		})
 }
 
-const handleSetFlagged = (thread: Thread, flagged: boolean) => {
-	thread.flagged = flagged ? 1 : 0
+// Star/unstar, from a list row (which names no mails, so its own representative one) or from the
+// pane (which names the mails whose star was clicked — the whole thread from the header, one message
+// from its own star). The row's `flagged` drives the list star while the pane's stars read each
+// message, so BOTH have to be told: the pane's star stayed hollow when starring from the list, and
+// the list's star stayed hollow when starring from the pane. Only the ids actually sent to the
+// server are flipped locally, or a refetch would contradict whatever we lit up.
+const handleSetFlagged = (thread: Thread, flagged: boolean, ids: string[] = [thread.id]) => {
+	// The row stands for its representative mail (see serialize_thread), so it takes the star only
+	// when that mail is one of the ones being starred.
+	const rowChanged = ids.includes(thread.id)
+	const applyRow = (value: 0 | 1) => {
+		if (rowChanged) thread.flagged = value
+	}
+	const applyPane = (value: boolean) => {
+		if (threadID === thread.thread_id) mailThread.value?.syncFlagged(ids, value)
+	}
+
+	applyRow(flagged ? 1 : 0)
+	applyPane(flagged)
 	call('suite.mail.api.mail.set_flagged', {
 		account: thread.account,
-		ids: [thread.id],
+		ids,
 		flagged,
 	}).catch((error) => {
-		thread.flagged = flagged ? 0 : 1 // revert the optimistic update
+		// revert the optimistic update
+		applyRow(flagged ? 0 : 1)
+		applyPane(!flagged)
 		raiseToast(error?.messages?.[0] || error?.message, 'error')
 	})
 }

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -173,10 +173,13 @@
 					'overflow-hidden': isMobile,
 					'w-2/3': !isMobile && showSplitView,
 					'absolute bottom-0 left-0 right-0 top-0': !isMobile && !showSplitView,
-					'fixed inset-0 z-20 pt-[env(safe-area-inset-top)]': isMobile,
+					'fixed inset-0 z-20 pt-[env(safe-area-inset-top)] transition-[transform,visibility] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]':
+						isMobile,
 					'invisible translate-x-full': isMobile && !threadID,
 					hidden: !isMobile && !showSplitView && !threadID,
 				}"
+				@touchstart.passive="onThreadTouchStart"
+				@touchend.passive="onThreadTouchEnd"
 			>
 				<div class="h-full overflow-y-auto">
 					<!-- Rendered with no thread open too so its own "Select an email" placeholder
@@ -186,6 +189,8 @@
 					     opening a cross-account thread does NOT switch the active account. -->
 					<MailThread
 						v-if="openRow || !threadID"
+						:slide="threadSlide"
+						@slide-done="threadSlide = ''"
 						:account="openRow?.account"
 						:mailbox="openRow?.inbox || ''"
 						:thread-i-d="threadID"
@@ -265,7 +270,7 @@ import {
 	useRowScroll,
 } from '@/apps/mail/utils/listNavigation'
 import { buildListRows, type ListRow, type StackRow } from '@/apps/mail/utils/threadStacks'
-import { useScreenSize } from '@/apps/mail/utils/composables'
+import { useScreenSize, useSwipeNav } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
@@ -488,6 +493,22 @@ const openRow = computed(() =>
 // Prev/next paging within what is currently loaded, in the list's own order.
 const openThreadIDs = computed(() => (threads.data ?? []).map((t: Thread) => t.thread_id))
 
+// MailThread's slide name while a swipe navigation renders; cleared on its slide-done, and left
+// empty for every other thread change so taps and arrows keep swapping instantly.
+const threadSlide = ref('')
+let pendingThreadSlide = ''
+
+// Swipe on the open thread (mobile): left → next thread, right → previous.
+const { onTouchStart: onThreadTouchStart, onTouchEnd: onThreadTouchEnd } = useSwipeNav(
+	() => isMobile.value && !!threadID,
+	(offset) => {
+		// Arms the paging animation for this navigation only — openThread consumes it.
+		pendingThreadSlide = offset > 0 ? 'page-next' : 'page-prev'
+		stepOpenThread(offset)
+		pendingThreadSlide = ''
+	},
+)
+
 const stepOpenThread = (offset: number) => {
 	const next = stepFrom(openThreadIDs.value, threadID, offset)
 	if (next) openThread(next)
@@ -684,6 +705,7 @@ const goToEdge = (index: number) => {
 }
 
 const openThread = (nextThreadID: string) => {
+	threadSlide.value = pendingThreadSlide
 	const row = (threads.data ?? []).find((t: Thread) => t.thread_id === nextThreadID)
 	if (!row) return
 	router.push({

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -736,6 +736,7 @@ const handleRemoveFromMailbox = (mailboxId: string) => {
 const handleSetSpamStatus = (spam: boolean) => {
 	const thread = openRow.value
 	if (!thread) return
+	goToNextThreadOrClose(thread.thread_id)
 	const restore = removeFromList(thread)
 	raiseOptimisticToast(
 		paneCall('set_mails_spam_status', { ids: messageIdsOf(thread), spam }, thread.account).catch(
@@ -745,6 +746,7 @@ const handleSetSpamStatus = (spam: boolean) => {
 			},
 		),
 		spam ? __('Thread marked as junk.') : __('Thread marked as not junk.'),
+		withUndo(thread, restore),
 	)
 }
 

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -118,6 +118,7 @@
 									:is-selected="false"
 									:selectable="false"
 									:hide-avatar="!isMobile"
+									:account-label="shortAccountLabel(row.threads[0].account_name)"
 									class="border-l-transparent sm:border-l"
 									:class="{ '!border-l-outline-blue-5': focusedRowKey === row.key }"
 									:data-row-key="row.key"
@@ -130,7 +131,7 @@
 									v-else
 									:mailbox="row.thread.inbox || ''"
 									:account-id="row.thread.account"
-									:account-label="row.thread.account_name || undefined"
+									:account-label="shortAccountLabel(row.thread.account_name)"
 									:mail="row.thread"
 									:is-selected="false"
 									:selectable="false"
@@ -404,6 +405,10 @@ const isLoading = computed(() => !isLoaded.value && threads.loading)
 // After an action, refresh the sidebar counts: the active account's per-mailbox counts, which via the
 // store's mailboxes.onSuccess hook also refreshes the unified All Inboxes badge.
 const refreshCounts = () => store.mailboxes.reload()
+
+// The row's account, by its short name (the local part, unless two accounts share one).
+const shortAccountLabel = (name?: string | null) =>
+	name ? (store.accountShortNames[name] ?? name) : undefined
 
 // Reset-to-top: refetch only the first window, replacing the loaded list and scrolling to the top (via
 // onResetSuccess). Bumping `epoch` discards any append/refresh still in flight. Used on filter change.

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -175,11 +175,14 @@
 				}"
 			>
 				<div class="h-full overflow-y-auto">
-					<!-- Rendered with no thread open too (unlike a deep link whose row hasn't
-					     loaded, where the fallback fetch would hit the wrong account) so its own
-					     "Select an email" placeholder fills the pane, as in MailboxView. -->
+					<!-- Rendered with no thread open too so its own "Select an email" placeholder
+					     fills the pane, as in MailboxView. A deep link whose row isn't in the
+					     loaded window stays gated: the pane's action handlers act on the row.
+					     The owning account scopes the pane (folder menus, reply identities) —
+					     opening a cross-account thread does NOT switch the active account. -->
 					<MailThread
 						v-if="openRow || !threadID"
+						:account="openRow?.account"
 						:mailbox="openRow?.inbox || ''"
 						:thread-i-d="threadID"
 						:threads="openThreadIDs"
@@ -406,7 +409,7 @@ const isLoading = computed(() => !isLoaded.value && threads.loading)
 // store's mailboxes.onSuccess hook also refreshes the unified All Inboxes badge.
 const refreshCounts = () => store.mailboxes.reload()
 
-// The row's account, by its short name: blank for the personal account (the default — only
+// The row's account, by its short name: blank for the currently open account (only
 // the odd ones out get labelled), the local part otherwise, unless two accounts share one.
 const shortAccountLabel = (name?: string | null) =>
 	name ? (store.accountShortNames[name] ?? name) : undefined

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -112,12 +112,13 @@
 								:is-selected="false"
 								:selectable="false"
 								thread-route-name="mail-all-inboxes-mail"
+								:hide-avatar="!isMobile"
 								class="border-l-transparent sm:border-l"
 								:class="{
 									'!bg-surface-blue-1': mail.thread_id === threadID && !isMobile,
 									'!border-l-outline-blue-5': mail.thread_id === focusedThreadID,
 								}"
-								:data-thread-row="mail.thread_id"
+								:data-row-key="mail.thread_id"
 								@set-seen="(seen: boolean) => handleSetSeen(mail, seen)"
 								@archive-thread="handleArchive(mail)"
 								@trash-thread="handleTrash(mail)"
@@ -147,12 +148,15 @@
 				}"
 			>
 				<div class="h-full overflow-y-auto">
+					<!-- Rendered with no thread open too (unlike a deep link whose row hasn't
+					     loaded, where the fallback fetch would hit the wrong account) so its own
+					     "Select an email" placeholder fills the pane, as in MailboxView. -->
 					<MailThread
-						v-if="openRow"
-						:mailbox="openRow.inbox || ''"
+						v-if="openRow || !threadID"
+						:mailbox="openRow?.inbox || ''"
 						:thread-i-d="threadID"
 						:threads="openThreadIDs"
-						:messages="openRow.messages"
+						:messages="openRow?.messages"
 						@reload-mails="refreshThreads()"
 						@set-seen="(seen: boolean) => handleSetSeen(openRow!, seen)"
 						@set-flagged="
@@ -208,6 +212,7 @@ import {
 	navigationOffset,
 	stepFrom,
 	useGPrefix,
+	useRowScroll,
 } from '@/apps/mail/utils/listNavigation'
 import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
@@ -466,14 +471,23 @@ const handleKeyDown = (e: KeyboardEvent) => {
 // The keyboard cursor: a thread id, since the merged list has no stacks or day headers to land on.
 const focusedThreadID = ref<string>()
 
+const scrollThreadIntoView = useRowScroll(mailListRef, isMobile)
+
 const focusThread = (nextThreadID: string) => {
 	focusedThreadID.value = nextThreadID
-	nextTick(() => {
-		document
-			.querySelector(`[data-thread-row="${nextThreadID}"]`)
-			?.scrollIntoView({ block: 'nearest' })
-	})
+	scrollThreadIntoView(nextThreadID)
 }
+
+// The open thread keeps its row in view, as the mailbox list does: stepping
+// prev/next or deep-linking scrolls the merged list along, and the cursor
+// follows so keyboard navigation resumes from it.
+watch(
+	() => threadID,
+	(val) => {
+		if (val) setTimeout(() => focusThread(val))
+	},
+	{ immediate: true },
+)
 
 // `at()` so -1 reads as the last loaded thread. With a thread open the jump opens the edge one;
 // otherwise it just moves the cursor there, mirroring the mailbox list.

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -565,6 +565,7 @@ const moveOpenThread = (mailboxId: string) => {
 	raiseOptimisticToast(
 		moveThreadOut(row, mailboxId, restore),
 		folder ? __('Thread moved to {0}.', [folder]) : __('Thread moved.'),
+		withUndo(row, restore),
 	)
 }
 
@@ -663,7 +664,20 @@ const handleAddToMailbox = (mailboxId: string) => {
 	const thread = openRow.value
 	if (!thread) return
 	const folder = folderName(mailboxId)
+	const snapshot = threadSnapshot(thread)
 	syncFolderTag(mailboxId, true)
+
+	// Undo replays the exact membership rather than the inverse call: a mail that was already in
+	// the folder before an "add" must stay in it afterwards.
+	const undoAction = () => {
+		syncFolderTag(mailboxId, false)
+		raiseOptimisticToast(
+			restoreMails(thread.account, snapshot),
+			folder ? __('Removed from {0}.', [folder]) : __('Folder change undone.'),
+		)
+	}
+	setUndoAction(undoAction)
+
 	raiseOptimisticToast(
 		paneCall('add_mails_to_mailbox', { ids: messageIdsOf(thread), mailbox_id: mailboxId }).catch(
 			(error) => {
@@ -672,6 +686,7 @@ const handleAddToMailbox = (mailboxId: string) => {
 			},
 		),
 		folder ? __('Thread added to {0}.', [folder]) : __('Thread added to folder.'),
+		undoAction,
 	)
 }
 
@@ -679,7 +694,20 @@ const handleRemoveFromMailbox = (mailboxId: string) => {
 	const thread = openRow.value
 	if (!thread) return
 	const folder = folderName(mailboxId)
+	const snapshot = threadSnapshot(thread)
 	syncFolderTag(mailboxId, false)
+
+	// Undo replays the exact membership rather than the inverse call: a mail that was already in
+	// the folder before an "add" must stay in it afterwards.
+	const undoAction = () => {
+		syncFolderTag(mailboxId, true)
+		raiseOptimisticToast(
+			restoreMails(thread.account, snapshot),
+			folder ? __('Added back to {0}.', [folder]) : __('Folder change undone.'),
+		)
+	}
+	setUndoAction(undoAction)
+
 	raiseOptimisticToast(
 		paneCall('remove_mails_from_mailbox', { ids: messageIdsOf(thread), mailbox_id: mailboxId }).catch(
 			(error) => {
@@ -688,6 +716,7 @@ const handleRemoveFromMailbox = (mailboxId: string) => {
 			},
 		),
 		folder ? __('Thread removed from {0}.', [folder]) : __('Thread removed from folder.'),
+		undoAction,
 	)
 }
 

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -872,7 +872,7 @@ const handleSetFlagged = (thread: Thread, flagged: boolean, ids: string[] = [thr
 // falls back to closing the pane at the end of the list. Mirrors MailboxView.
 const goToNextThreadOrClose = (movedThreadID: string) => {
 	if (threadID !== movedThreadID) return
-	const ids = openThreadIDs.value
+	const ids = threadIDs.value
 	const next = ids.slice(ids.indexOf(movedThreadID) + 1).find((id) => id !== movedThreadID)
 	if (next) openThread(next)
 	else closeThread()

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -63,7 +63,7 @@
 							<Button
 								variant="ghost"
 								:tooltip="__('Refresh')"
-								:disabled="threads.loading || loadingMore"
+								:disabled="isFetching"
 								@click="refreshThreads()"
 							>
 								<template #icon>
@@ -176,7 +176,8 @@
 					:account="openRow?.account"
 					:mailbox="openRow?.inbox || ''"
 					:thread-i-d="threadID"
-					:threads="openThreadIDs"
+					:threads="threadIDs"
+					:can-go-next="canGoNext"
 					:messages="openRow?.messages"
 					@reload-mails="refreshThreads()"
 					@set-seen="(seen: boolean) => handleSetSeen(openRow!, seen)"
@@ -208,7 +209,7 @@
 				class="mt-3"
 				variant="ghost"
 				:label="__('Refresh')"
-				:disabled="threads.loading || loadingMore"
+				:disabled="isFetching"
 				@click="refreshThreads()"
 			>
 				<template #prefix>
@@ -220,9 +221,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, nextTick, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
+import { computed, inject, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { useIntersectionObserver } from '@vueuse/core'
 import {
 	ChevronDown,
 	ChevronRight,
@@ -243,6 +243,7 @@ import {
 	shouldIgnoreKeypress,
 } from '@/apps/mail/utils'
 import {
+	hasCursor,
 	isNavigationKey,
 	navigationOffset,
 	stepFrom,
@@ -252,6 +253,10 @@ import {
 } from '@/apps/mail/utils/listNavigation'
 import { buildListRows, type ListRow, type StackRow } from '@/apps/mail/utils/threadStacks'
 import { useScreenSize, useSwipeNav } from '@/apps/mail/utils/composables'
+import {
+	PAGE_LENGTH,
+	usePaginatedThreads,
+} from '@/apps/mail/composables/usePaginatedThreads'
 import { userStore } from '@/apps/mail/stores/user'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
@@ -284,64 +289,41 @@ const dayjs = inject('$dayjs')
 const store = userStore()
 
 // ── Infinite scroll ─────────────────────────────────────────────────────────────────────────────
-// The loaded list (threads.data) is the single source of truth. The reset resource replaces it (from
-// the top); the load-more resource appends the next window onto it. Rows are keyed by account +
-// thread_id since the same thread_id can recur across accounts in this merged view.
-const PAGE_LENGTH = 25
-const hasMore = ref(false) // lookahead: the last fetched window returned an extra row, so more exist
-const loadingMore = ref(false) // an append fetch is in flight (drives the bottom spinner)
-// Bumped on every reset/refresh; an in-flight append captures it and discards its result if it changed
-// meanwhile, so a stale window can't land on a freshly reset list.
-const epoch = ref(0)
-let loadEpoch = 0 // epoch captured when the current append was triggered
-// Refresh ("check for new mail") state: merges the newest window into the loaded list, preserving
-// scroll — set while such a reload is in flight so its onSuccess prepends instead of replacing.
-const refreshMode = ref(false)
-let refreshEpoch = 0 // epoch captured when the refresh was triggered (dropped if a reset intervenes)
-// The loaded list to merge the fresh window into. Captured at *response* time (in the resource
-// transform), not refresh-start, so it reflects any optimistic removals that happened while the
-// refresh was in flight — otherwise a thread archived mid-refresh would reappear.
-let refreshSnapshot: Thread[] = []
+// The loaded list (threads.data) is the single source of truth; usePaginatedThreads owns everything
+// around it — the epochs, the refresh merge, the sentinel, the edge crossing. Rows are keyed by
+// account + thread_id since the same thread_id can recur across accounts in this merged view.
+const threadKey = (thread: Thread) => `${thread.account}:${thread.thread_id}`
+
+const {
+	container: mailListRef,
+	hasMore,
+	loadingMore,
+	isFetching,
+	canGoNext,
+	threadIDs,
+	takeResetWindow,
+	beginReset,
+	beginRefresh,
+	onResetSuccess,
+	appendThreads,
+	loadMoreThenOpenEdge,
+	topUpIfShort,
+	suppressRemoved,
+	unsuppressRemoved,
+} = usePaginatedThreads({
+	resource: () => threads,
+	fetchMore: () => loadMoreThreads.reload(),
+	openThreadID: () => threadID,
+	// A step off the loaded edge opens the appended thread when the pane is showing, and otherwise
+	// just takes the cursor there — the merged list's row keys are thread ids, so the id is the key.
+	onEdgeThread: (id, action) => (action === 'open' ? openThread(id) : focusRowKey(id)),
+	threadKey,
+})
 
 const isLoaded = ref(false)
 const filter = ref<string | null>(
 	localStorage.getItem(`user:${user.data.name}:filter:all-inboxes`) || null,
 )
-
-const mailListRef = useTemplateRef('mailList')
-
-const threadKey = (thread: Thread) => `${thread.account}:${thread.thread_id}`
-
-const scrollListToTop = () => mailListRef.value?.scrollTo({ top: 0 })
-
-// Called when a first-window fetch resolves. Two modes:
-// - refresh: keep the loaded rows, prepend only threads not already loaded (new mail), and hold the
-//   scroll position (re-anchored by the height the prepended rows added).
-// - reset: reveal the fresh first window and scroll to top (filter change, initial load, …).
-const onResetSuccess = () => {
-	if (refreshMode.value) {
-		refreshMode.value = false
-		// A reset (filter change) raced in and bumped the epoch — drop this stale merge.
-		if (refreshEpoch !== epoch.value) return
-		// Anchor to the current scroll before merging. The window replaced `data` a beat ago but the DOM
-		// hasn't re-rendered yet, so these still reflect the loaded list the reader is looking at.
-		const el = mailListRef.value
-		const prevTop = el?.scrollTop ?? 0
-		const prevHeight = el?.scrollHeight ?? 0
-		const freshWindow = threads.data ?? []
-		const existing = new Set(refreshSnapshot.map(threadKey))
-		const fresh = freshWindow.filter((t: Thread) => !existing.has(threadKey(t)))
-		threads.data = [...fresh, ...refreshSnapshot]
-		// Keep the reader where they were: shift scroll by the height the prepended rows added. If they
-		// were already at the top, leave them there so the new mail is visible.
-		nextTick(() => {
-			if (el && prevTop > 0) el.scrollTop = prevTop + (el.scrollHeight - prevHeight)
-		})
-		return
-	}
-
-	scrollListToTop()
-}
 
 // Reset resource: always the first window, over-fetching one row (PAGE_LENGTH + 1) to detect whether
 // more exist without a total.
@@ -352,35 +334,13 @@ const threads = createResource({
 		start: 0,
 		filter_by: filter.value,
 	}),
-	transform: (rows: Thread[]) => {
-		// In refresh mode, snapshot the live loaded list now — before this window replaces it — so the
-		// merge in onResetSuccess reflects any optimistic removals made during the fetch.
-		if (refreshMode.value) refreshSnapshot = threads.data ?? []
-		hasMore.value = rows.length > PAGE_LENGTH
-		return rows.slice(0, PAGE_LENGTH)
-	},
+	transform: (rows: Thread[]) => takeResetWindow(rows),
 	onSuccess: () => {
 		onResetSuccess()
 		isLoaded.value = true
 	},
 	auto: true,
 })
-
-// Appends the next window onto the loaded list, deduped by account + thread_id. `start = data.length`
-// stays correct across optimistic removals (the server list shifts left by the same rows we dropped);
-// the only skew is new mail inserted at the front, which the dedupe absorbs and the next reset reconciles.
-const appendThreads = (rows: Thread[]) => {
-	loadingMore.value = false
-	// Discard a stale window that resolved after a reset/refresh began.
-	if (loadEpoch !== epoch.value) return
-	const seen = new Set((threads.data ?? []).map(threadKey))
-	const fresh = rows.slice(0, PAGE_LENGTH).filter((t) => !seen.has(threadKey(t)))
-	// Stop auto-loading if the window added nothing new (offset stuck behind heavy front-inserted mail,
-	// or the server's fetch depth cap reached); the next reset reconciles. Guards a tight reload loop
-	// while the sentinel stays in view.
-	hasMore.value = rows.length > PAGE_LENGTH && fresh.length > 0
-	threads.data = [...(threads.data ?? []), ...fresh]
-}
 
 const loadMoreThreads = createResource({
 	url: 'suite.mail.api.mail.get_all_inbox_threads',
@@ -392,32 +352,6 @@ const loadMoreThreads = createResource({
 	onSuccess: (rows: Thread[]) => appendThreads(rows),
 	onError: () => (loadingMore.value = false),
 })
-
-const loadMore = () => {
-	if (!hasMore.value || loadingMore.value || threads.loading) return
-	loadingMore.value = true
-	loadEpoch = epoch.value
-	loadMoreThreads.reload()
-}
-
-const loadMoreSentinel = useTemplateRef('loadMoreSentinel')
-// True while the sentinel is in view.
-const sentinelVisible = ref(false)
-
-// The height the list had reached the last time we topped it up, so a fill that adds nothing can
-// be detected. Reset at the start of each fill episode (see the watcher by groupedRows).
-let lastFillHeight = 0
-
-useIntersectionObserver(
-	loadMoreSentinel,
-	([entry]) => {
-		const entering = !!entry?.isIntersecting && !sentinelVisible.value
-		sentinelVisible.value = !!entry?.isIntersecting
-		if (entering) lastFillHeight = 0
-		if (sentinelVisible.value) loadMore()
-	},
-	{ root: mailListRef },
-)
 
 const isLoading = computed(() => !isLoaded.value && threads.loading)
 
@@ -433,8 +367,7 @@ const shortAccountLabel = (name?: string | null) =>
 // Reset-to-top: refetch only the first window, replacing the loaded list and scrolling to the top (via
 // onResetSuccess). Bumping `epoch` discards any append/refresh still in flight. Used on filter change.
 const resetThreads = () => {
-	refreshMode.value = false
-	epoch.value++
+	beginReset()
 	// A reset replaces the list with a fresh first window, so any prior collapse or stack expansion no
 	// longer maps to what's shown — clear them (else a group collapsed under one filter stays collapsed
 	// and hides its threads).
@@ -448,13 +381,7 @@ const resetThreads = () => {
 // threads not already loaded (see onResetSuccess), keeping scroll position and the loaded rows. Used by
 // the Refresh button, the periodic poll, and the new-mail socket.
 const refreshThreads = (reloadCounts = true) => {
-	if (threads.loading || loadingMore.value) return
-	refreshMode.value = true
-	// Bump the epoch so an append still in flight is discarded (appendThreads checks it) instead of
-	// landing after the merge and clobbering it. A new append can't start mid-refresh (loadMore bails
-	// while the resource is loading), so this fully closes the refresh/append race.
-	epoch.value++
-	refreshEpoch = epoch.value
+	if (!beginRefresh()) return
 	threads.reload()
 	if (reloadCounts) refreshCounts()
 }
@@ -468,9 +395,6 @@ const groupMessagesBy = computed(() => user.data.group_messages_by)
 const openRow = computed(() =>
 	threadID ? (threads.data ?? []).find((t: Thread) => t.thread_id === threadID) : undefined,
 )
-
-// Prev/next paging within what is currently loaded, in the list's own order.
-const openThreadIDs = computed(() => (threads.data ?? []).map((t: Thread) => t.thread_id))
 
 // MailThread's slide name while a swipe navigation renders; cleared on its slide-done, and left
 // empty for every other thread change so taps and arrows keep swapping instantly.
@@ -489,8 +413,10 @@ const { onTouchStart: onThreadTouchStart, onTouchEnd: onThreadTouchEnd } = useSw
 )
 
 const stepOpenThread = (offset: number) => {
-	const next = stepFrom(openThreadIDs.value, threadID, offset)
-	if (next) openThread(next)
+	const next = stepFrom(threadIDs.value, threadID, offset)
+	if (next) return openThread(next)
+	// At the last loaded thread, stepping further loads the next window and opens what arrives.
+	loadMoreThenOpenEdge(offset, 'open')
 }
 
 // Up/down/j/k walk the list, or the open thread when one is showing. The merged list is flat —
@@ -578,7 +504,12 @@ const handleKeyDown = (e: KeyboardEvent) => {
 
 	// With no thread open the keys move the cursor without opening anything, as the mailbox list
 	// does — Enter opens what the marker is on, or folds the day.
-	focusRow(stepFromKey(navigableRows.value, focusedRowKey.value, offset))
+	const rows = navigableRows.value
+	const next = stepFromKey(rows, focusedRowKey.value, offset)
+	if (next) return focusRow(next)
+	// Off the bottom of what is loaded: load the next window and take the cursor into it. Only from a
+	// row the cursor is actually on — a lost cursor restarts from the top instead (see stepFromKey).
+	if (hasCursor(rows, focusedRowKey.value)) loadMoreThenOpenEdge(offset, 'focus')
 }
 
 // Chatty senders collapse into stacks exactly as in the mailbox list — buildListRows keys runs by
@@ -677,7 +608,7 @@ watch(
 // otherwise it just moves the cursor there, mirroring the mailbox list.
 const goToEdge = (index: number) => {
 	if (threadID) {
-		const next = openThreadIDs.value.at(index)
+		const next = threadIDs.value.at(index)
 		return next && openThread(next)
 	}
 	focusRow(navigableRows.value.at(index))
@@ -723,28 +654,9 @@ const isLastGroup = (key: string) => Object.keys(groupedThreads.value).at(-1) ==
 
 const collapsedGroups = ref<string[]>([])
 
-// Rescues the one case the observer cannot: the rendered list is too short to scroll, so the
-// sentinel never leaves and re-enters the viewport to fire again — infinite scroll would die with
-// nothing left to scroll. A window of threads can collapse to a single stack row, so filling the
-// viewport can take several windows. This was unreachable before the merged list stacked.
-//
-// Both guards are load-bearing. Stop once the list can scroll, because from there the user's own
-// scrolling drives the observer. And stop if a window added no height: its rows landed somewhere
-// they cannot be seen (a collapsed day), so further windows would be just as invisible — without
-// this, collapsing a large group walks the whole list a window at a time.
-watch(groupedRows, () => {
-	if (!sentinelVisible.value || !hasMore.value) return
-
-	nextTick(() => {
-		const el = mailListRef.value
-		if (!el || !sentinelVisible.value) return
-
-		const grew = el.scrollHeight > lastFillHeight
-		lastFillHeight = el.scrollHeight
-		if (el.scrollHeight <= el.clientHeight && grew) loadMore()
-	})
-})
-
+// Keep infinite scroll alive while the rendered list is too short to scroll (see topUpIfShort). Must
+// stay below groupedRows: `watch` reads its source at setup.
+watch(groupedRows, topUpIfShort)
 
 const toggleGroupCollapse = (key: string) => {
 	// The cursor follows the click, as it does when you open a mail — above the
@@ -771,13 +683,22 @@ const messageIds = (thread: Thread) => (thread.messages ?? []).map((m) => m.id)
 // unmounts with an empty list and couldn't otherwise re-trigger a load). Returns a restore closure
 // that re-inserts the row at its original index (or falls back to resetThreads if we had to reset).
 const removeFromList = (thread: Thread) => {
-	const index = threads.data?.findIndex((t: Thread) => threadKey(t) === threadKey(thread)) ?? -1
-	threads.data = threads.data?.filter((t: Thread) => threadKey(t) !== threadKey(thread))
+	const key = threadKey(thread)
+	const index = threads.data?.findIndex((t: Thread) => threadKey(t) === key) ?? -1
+	threads.data = threads.data?.filter((t: Thread) => threadKey(t) !== key)
+	// The server keeps returning the row until the mutation lands, so hold it out of any refresh or
+	// append that resolves in the meantime — otherwise a thread archived mid-refresh reappears.
+	suppressRemoved([key])
+	// The row is back, so it must show again: lift the suppression before re-inserting it.
+	const restore = (put: () => void) => () => {
+		unsuppressRemoved([key])
+		put()
+	}
 	if (!threads.data?.length && hasMore.value) {
 		resetThreads()
-		return () => resetThreads()
+		return restore(() => resetThreads())
 	}
-	return () => threads.data?.splice(index, 0, thread)
+	return restore(() => threads.data?.splice(index, 0, thread))
 }
 
 // Each action is a stateless one-shot `call()` rather than a shared createResource: rows act on

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -88,7 +88,11 @@
 						>
 							<div
 								class="text-ink-gray-6 flex items-center border-b border-l-transparent p-3.5 text-xs-semibold sm:border-l sm:px-5"
-								:class="{ 'cursor-pointer': !isLastGroup(key) }"
+								:class="{
+									'cursor-pointer': !isLastGroup(key),
+									'!border-l-outline-blue-5': focusedRowKey === `group:${key}`,
+								}"
+								:data-row-key="`group:${key}`"
 								@click="toggleGroupCollapse(key)"
 							>
 								<span class="select-none pt-[2px]">
@@ -116,7 +120,7 @@
 								class="border-l-transparent sm:border-l"
 								:class="{
 									'!bg-surface-blue-1': mail.thread_id === threadID && !isMobile,
-									'!border-l-outline-blue-5': mail.thread_id === focusedThreadID,
+									'!border-l-outline-blue-5': focusedRowKey === mail.thread_id,
 								}"
 								:data-row-key="mail.thread_id"
 								@set-seen="(seen: boolean) => handleSetSeen(mail, seen)"
@@ -211,6 +215,7 @@ import {
 	isNavigationKey,
 	navigationOffset,
 	stepFrom,
+	stepFromKey,
 	useGPrefix,
 	useRowScroll,
 } from '@/apps/mail/utils/listNavigation'
@@ -436,14 +441,14 @@ const handleKeyDown = (e: KeyboardEvent) => {
 	if (key === 'escape') {
 		e.preventDefault()
 		if (threadID) return router.push({ name: 'mail-all-inboxes', query: route.query })
-		focusedThreadID.value = undefined
+		focusedRowKey.value = undefined
 		return
 	}
 
 	if (key === 'enter') {
-		if (!focusedThreadID.value) return
+		if (!focusedRowKey.value) return
 		e.preventDefault()
-		return openThread(focusedThreadID.value)
+		return activateFocusedRow()
 	}
 
 	// `g g` to the top, `G` to the bottom of what is loaded.
@@ -463,19 +468,49 @@ const handleKeyDown = (e: KeyboardEvent) => {
 	if (threadID) return stepOpenThread(offset)
 
 	// With no thread open the keys move the cursor without opening anything, as the mailbox list
-	// does — Enter opens what the marker is on.
-	const next = stepFrom(openThreadIDs.value, focusedThreadID.value, offset)
-	if (next) focusThread(next)
+	// does — Enter opens what the marker is on, or folds the day.
+	focusRow(stepFromKey(navigableRows.value, focusedRowKey.value, offset))
 }
 
-// The keyboard cursor: a thread id, since the merged list has no stacks or day headers to land on.
-const focusedThreadID = ref<string>()
+// What the cursor can land on, in render order: each day's header, then that day's threads unless
+// it is collapsed. Walking the loaded threads instead skipped the headers and — worse — stepped
+// onto threads hidden inside a collapsed day, where the marker simply vanished.
+type NavEntry =
+	| { type: 'group'; key: string; dateKey: string }
+	| { type: 'thread'; key: string; threadID: string }
 
-const scrollThreadIntoView = useRowScroll(mailListRef, isMobile)
+const navigableRows = computed<NavEntry[]>(() => {
+	const rows: NavEntry[] = []
+	for (const [dateKey, group] of Object.entries(groupedThreads.value)) {
+		if (groupMessagesBy.value !== 'None' && !isMobile.value)
+			rows.push({ type: 'group', key: `group:${dateKey}`, dateKey })
+		if (!isMobile.value && collapsedGroups.value.includes(dateKey)) continue
+		for (const thread of group)
+			rows.push({ type: 'thread', key: thread.thread_id, threadID: thread.thread_id })
+	}
+	return rows
+})
 
-const focusThread = (nextThreadID: string) => {
-	focusedThreadID.value = nextThreadID
-	scrollThreadIntoView(nextThreadID)
+// A thread's row key is its id, so the open-thread watcher can keep passing one straight in.
+const focusedRowKey = ref<string>()
+
+const scrollRowIntoView = useRowScroll(mailListRef, isMobile)
+
+const focusRowKey = (key: string) => {
+	focusedRowKey.value = key
+	scrollRowIntoView(key)
+}
+
+const focusRow = (row?: NavEntry) => {
+	if (row) focusRowKey(row.key)
+}
+
+// Enter opens a thread, or folds the day the marker is sitting on.
+const activateFocusedRow = () => {
+	const row = navigableRows.value.find((r) => r.key === focusedRowKey.value)
+	if (!row) return
+	if (row.type === 'thread') return openThread(row.threadID)
+	if (!isLastGroup(row.dateKey)) toggleGroupCollapse(row.dateKey)
 }
 
 // The open thread keeps its row in view, as the mailbox list does: stepping
@@ -484,7 +519,7 @@ const focusThread = (nextThreadID: string) => {
 watch(
 	() => threadID,
 	(val) => {
-		if (val) setTimeout(() => focusThread(val))
+		if (val) setTimeout(() => focusRowKey(val))
 	},
 	{ immediate: true },
 )
@@ -492,10 +527,11 @@ watch(
 // `at()` so -1 reads as the last loaded thread. With a thread open the jump opens the edge one;
 // otherwise it just moves the cursor there, mirroring the mailbox list.
 const goToEdge = (index: number) => {
-	const next = openThreadIDs.value.at(index)
-	if (!next) return
-	if (threadID) return openThread(next)
-	focusThread(next)
+	if (threadID) {
+		const next = openThreadIDs.value.at(index)
+		return next && openThread(next)
+	}
+	focusRow(navigableRows.value.at(index))
 }
 
 const openThread = (nextThreadID: string) => {

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -28,7 +28,11 @@
 		</div>
 
 		<template v-else-if="threads.data?.length">
-			<div ref="mailSidebar" class="sticky top-16 flex w-full flex-col border-r">
+			<div
+				ref="mailSidebar"
+				class="sticky top-16 flex flex-col border-r"
+				:class="!isMobile && showSplitView ? 'w-1/3' : 'w-full'"
+			>
 				<!-- Toolbar — mobile mirrors the mailbox one (h-12, semibold selector in a
 				     bottom sheet, no refresh: pull the tab or reopen instead). -->
 				<div v-if="isMobile" class="relative flex h-12 items-center border-b px-4">
@@ -107,7 +111,11 @@
 								:mail
 								:is-selected="false"
 								:selectable="false"
+								thread-route-name="mail-all-inboxes-mail"
 								class="border-l-transparent sm:border-l"
+								:class="{
+									'!bg-surface-blue-1': mail.thread_id === threadID && !isMobile,
+								}"
 								@set-seen="(seen: boolean) => handleSetSeen(mail, seen)"
 								@archive-thread="handleArchive(mail)"
 								@trash-thread="handleTrash(mail)"
@@ -121,6 +129,38 @@
 					<div v-if="loadingMore" class="flex justify-center py-3">
 						<LoaderCircle class="text-ink-gray-5 h-4 w-4 animate-spin" />
 					</div>
+				</div>
+			</div>
+			<!-- The open thread, in place. Same geometry as MailboxView: a third/two-thirds split
+			     on desktop with Split View on, a full-bleed overlay otherwise and on mobile. -->
+			<div
+				class="bg-surface-base"
+				:class="{
+					'overflow-hidden': isMobile,
+					'w-2/3': !isMobile && showSplitView,
+					'absolute bottom-0 left-0 right-0 top-0': !isMobile && !showSplitView,
+					'fixed inset-0 z-20 pt-[env(safe-area-inset-top)]': isMobile,
+					'invisible translate-x-full': isMobile && !threadID,
+					hidden: !isMobile && !showSplitView && !threadID,
+				}"
+			>
+				<div class="h-full overflow-y-auto">
+					<MailThread
+						v-if="openRow"
+						:mailbox="openRow.inbox || ''"
+						:thread-i-d="threadID"
+						:threads="openThreadIDs"
+						:messages="openRow.messages"
+						@reload-mails="refreshThreads()"
+						@set-seen="(seen: boolean) => handleSetSeen(openRow!, seen)"
+						@set-flagged="
+							(_ids: string[], flagged: boolean) => handleSetFlagged(openRow!, flagged)
+						"
+						@move-thread="(mailboxId: string) => moveOpenThread(mailboxId)"
+						@delete-thread="handleTrash(openRow!)"
+						@prev-thread="stepOpenThread(-1)"
+						@next-thread="stepOpenThread(1)"
+					/>
 				</div>
 			</div>
 		</template>
@@ -146,6 +186,7 @@
 
 <script setup lang="ts">
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useIntersectionObserver } from '@vueuse/core'
 import {
 	ChevronDown,
@@ -167,12 +208,23 @@ import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
 import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 import LoadingBar from '@/apps/mail/components/LoadingBar.vue'
 import MailListItem from '@/apps/mail/components/MailListItem.vue'
+import MailThread from '@/apps/mail/components/MailThread.vue'
 import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
 
 import type { Thread, UserResource } from '@/apps/mail/types'
 
 const { isMobile } = useScreenSize()
 
+// Set by the `mail-all-inboxes-mail` route when a thread is open. accountId is the thread's
+// owning account, not the active one — the merged list spans accounts.
+const { accountId, mailbox, threadID } = defineProps<{
+	accountId?: string
+	mailbox?: string
+	threadID?: string
+}>()
+
+const route = useRoute()
+const router = useRouter()
 const socket = inject('$socket')
 const user = inject('$user') as UserResource
 const dayjs = inject('$dayjs')
@@ -341,6 +393,44 @@ const refreshThreads = (reloadCounts = true) => {
 // Date grouping with collapsible headers (mirroring the per-mailbox view). The last group never
 // collapses — it's where infinite scroll appends, so hiding it would swallow newly loaded rows.
 const groupMessagesBy = computed(() => user.data.group_messages_by)
+
+// Split View is a user setting; the merged view honours it like the mailbox view does.
+const showSplitView = computed(() => !!user.data?.show_reading_pane)
+
+// The loaded row the open thread belongs to. Every mutation reads its account/archive/trash
+// off the row, so the pane acts on the owning account without consulting the active one.
+const openRow = computed(() =>
+	threadID ? (threads.data ?? []).find((t: Thread) => t.thread_id === threadID) : undefined,
+)
+
+// Prev/next paging within what is currently loaded, in the list's own order.
+const openThreadIDs = computed(() => (threads.data ?? []).map((t: Thread) => t.thread_id))
+
+const stepOpenThread = (offset: number) => {
+	const ids = openThreadIDs.value
+	const next = ids[ids.indexOf(threadID!) + offset]
+	if (next) openThread(next)
+}
+
+const openThread = (nextThreadID: string) => {
+	const row = (threads.data ?? []).find((t: Thread) => t.thread_id === nextThreadID)
+	if (!row) return
+	router.push({
+		name: 'mail-all-inboxes-mail',
+		params: { accountId: row.account, mailbox: row.inbox, threadID: nextThreadID },
+		query: route.query,
+	})
+}
+
+// Archive and Trash already have optimistic list removal; anything else is a plain move.
+const moveOpenThread = (mailboxId: string) => {
+	const row = openRow.value
+	if (!row) return
+	if (mailboxId === row.archive) return handleArchive(row)
+	if (mailboxId === row.trash) return handleTrash(row)
+	const restore = removeFromList(row)
+	raiseOptimisticToast(moveThreadOut(row, mailboxId, restore), __('Thread moved.'))
+}
 
 const groupedThreads = computed<Record<string, Thread[]>>(() =>
 	(threads.data ?? []).reduce((groups: Record<string, Thread[]>, thread: Thread) => {

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -198,6 +198,14 @@
 						"
 						@move-thread="(mailboxId: string) => moveOpenThread(mailboxId)"
 						@delete-thread="handleTrash(openRow!)"
+						@archive-thread="handleArchive(openRow!)"
+						@sync-unseen="handleSyncUnseen"
+						@add-thread-to-mailbox="handleAddToMailbox"
+						@remove-thread-from-mailbox="handleRemoveFromMailbox"
+						@set-spam-status="handleSetSpamStatus"
+						@move-mail="handleMailMove"
+						@mark-mail-spam="handleMailSpam"
+						@delete-mail="handleMailDelete"
 						@prev-thread="stepOpenThread(-1)"
 						@next-thread="stepOpenThread(1)"
 					/>
@@ -268,7 +276,7 @@ import MailThread from '@/apps/mail/components/MailThread.vue'
 import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
 import StackListItem from '@/apps/mail/components/StackListItem.vue'
 
-import type { Thread, UserResource } from '@/apps/mail/types'
+import type { Mail, Thread, UserResource } from '@/apps/mail/types'
 
 const { isMobile } = useScreenSize()
 
@@ -771,6 +779,86 @@ const removeFromList = (thread: Thread) => {
 // different accounts/threads and can be fired in rapid succession, so every invocation must be a
 // fully independent request. A shared resource carries a single reactive state slot (and one abort
 // controller); call() has no shared state, so concurrent row actions can never clobber one another.
+// The pane's remaining actions. Each names the row's own account rather than the active one — the
+// thread route carries accountId so the router has already switched, but passing it explicitly keeps
+// these correct if that ever stops being true. Mailbox ids come from the store, which is the row's
+// account for the same reason.
+const paneCall = (method: string, params: Record<string, unknown>) =>
+	call(`suite.mail.api.mail.${method}`, { account: openRow.value?.account, ...params })
+
+const messageIdsOf = (thread: Thread) => thread.messages?.map((m) => m.id) ?? [thread.id]
+
+// Marked unread from a message downwards: MailThread reports the ids, we mirror it in the list.
+const handleSyncUnseen = (ids: string[]) => {
+	const thread = openRow.value
+	if (!thread) return
+	let changed = false
+	thread.messages?.forEach((message) => {
+		if (ids.includes(message.id)) {
+			message.seen = 0
+			changed = true
+		}
+	})
+	if (changed) thread.seen = 0
+	refreshCounts()
+}
+
+const handleAddToMailbox = (mailboxId: string) => {
+	const thread = openRow.value
+	if (!thread) return
+	raiseOptimisticToast(
+		paneCall('add_mails_to_mailbox', { ids: messageIdsOf(thread), mailbox_id: mailboxId }),
+		__('Thread added to folder.'),
+	)
+}
+
+const handleRemoveFromMailbox = (mailboxId: string) => {
+	const thread = openRow.value
+	if (!thread) return
+	raiseOptimisticToast(
+		paneCall('remove_mails_from_mailbox', { ids: messageIdsOf(thread), mailbox_id: mailboxId }),
+		__('Thread removed from folder.'),
+	)
+}
+
+const handleSetSpamStatus = (spam: boolean) => {
+	const thread = openRow.value
+	if (!thread) return
+	const restore = removeFromList(thread)
+	raiseOptimisticToast(
+		paneCall('set_mails_spam_status', { ids: messageIdsOf(thread), spam }).catch((error) => {
+			restore()
+			throw error
+		}),
+		spam ? __('Thread marked as junk.') : __('Thread marked as not junk.'),
+	)
+}
+
+// Per-message actions from a message's own menu. The thread stays put; only its contents change,
+// so the list is refreshed rather than optimistically edited.
+const handleMailMove = (mail: Mail, target: string) => {
+	raiseOptimisticToast(
+		paneCall('move_mails', { ids: [mail.id], mailbox: target }).then(() => refreshThreads(false)),
+		__('Mail moved.'),
+	)
+}
+
+const handleMailSpam = (mail: Mail, spam: boolean) => {
+	raiseOptimisticToast(
+		paneCall('set_mails_spam_status', { ids: [mail.id], spam }).then(() => refreshThreads(false)),
+		spam ? __('Mail marked as junk.') : __('Mail marked as not junk.'),
+	)
+}
+
+const handleMailDelete = (mail: Mail) => {
+	raiseOptimisticToast(
+		call('suite.mail.doctype.mail_message.mail_message.bulk_delete', {
+			names: [mail.name],
+		}).then(() => refreshThreads(false)),
+		__('Mail deleted.'),
+	)
+}
+
 const closeThread = () => router.push({ name: 'mail-all-inboxes', query: route.query })
 
 const handleSetSeen = (thread: Thread, seen: boolean) => {

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -453,8 +453,13 @@ const handleThreadActions = (e: KeyboardEvent, key: string) => {
 		return true
 	}
 
-	// `!` (mark as junk) is absent on purpose: the merged row carries the account's Archive and
-	// Trash ids but not its Junk one (see Thread in types), so there is nothing to move it to.
+	// Junk needs no mailbox id of its own (set_mails_spam_status takes the account and the mails), so
+	// unlike a move it works from a merged row.
+	if (key === '!') {
+		e.preventDefault()
+		handleSetSpamStatus(true, thread)
+		return true
+	}
 
 	return false
 }
@@ -733,8 +738,8 @@ const handleRemoveFromMailbox = (mailboxId: string) => {
 	)
 }
 
-const handleSetSpamStatus = (spam: boolean) => {
-	const thread = openRow.value
+const handleSetSpamStatus = (spam: boolean, target?: Thread) => {
+	const thread = target ?? openRow.value
 	if (!thread) return
 	goToNextThreadOrClose(thread.thread_id)
 	const restore = removeFromList(thread)

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -200,7 +200,8 @@ import {
 } from 'lucide-vue-next'
 import { Breadcrumbs, Button, Dropdown, Tooltip, call, createResource, usePageMeta } from 'frappe-ui'
 
-import { getFormattedDate, raiseOptimisticToast, raiseToast } from '@/apps/mail/utils'
+import { getFormattedDate, raiseOptimisticToast, raiseToast, shouldIgnoreKeypress } from '@/apps/mail/utils'
+import { isNavigationKey, navigationOffset, stepFrom } from '@/apps/mail/utils/listNavigation'
 import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
@@ -407,8 +408,24 @@ const openRow = computed(() =>
 const openThreadIDs = computed(() => (threads.data ?? []).map((t: Thread) => t.thread_id))
 
 const stepOpenThread = (offset: number) => {
-	const ids = openThreadIDs.value
-	const next = ids[ids.indexOf(threadID!) + offset]
+	const next = stepFrom(openThreadIDs.value, threadID, offset)
+	if (next) openThread(next)
+}
+
+// Up/down/j/k walk the list, or the open thread when one is showing. The merged list is flat —
+// no stacks, no day headers, no selection — so a step is just the neighbouring row.
+const handleKeyDown = (e: KeyboardEvent) => {
+	const key = e.key.toLowerCase()
+	if (!isNavigationKey(key) || shouldIgnoreKeypress(e)) return
+
+	e.preventDefault()
+	const offset = navigationOffset(key)
+
+	if (threadID) return stepOpenThread(offset)
+
+	// With no thread open the keys still move through the list, opening as they go, which is what
+	// Split View makes useful: the pane follows the cursor.
+	const next = stepFrom(openThreadIDs.value, threadID, offset)
 	if (next) openThread(next)
 }
 
@@ -576,11 +593,13 @@ const onNewMail = () => refreshThreads()
 onMounted(() => {
 	reloadInterval.value = setInterval(onNewMail, 30000)
 	socket.on('new_mail_created', onNewMail)
+	window.addEventListener('keydown', handleKeyDown)
 })
 
 onUnmounted(() => {
 	if (reloadInterval.value) clearInterval(reloadInterval.value)
 	socket.off('new_mail_created', onNewMail)
+	window.removeEventListener('keydown', handleKeyDown)
 })
 </script>
 

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -28,196 +28,175 @@
 		</div>
 
 		<template v-else-if="threads.data?.length">
-			<div
-				ref="mailSidebar"
-				class="sticky top-16 flex flex-col border-r"
-				:class="!isMobile && showSplitView ? 'w-1/3' : 'w-full'"
+			<ThreadPane
+				:thread-open="!!threadID"
+				@touch-start="onThreadTouchStart"
+				@touch-end="onThreadTouchEnd"
 			>
-				<!-- Toolbar — mobile mirrors the mailbox one (h-12, semibold selector in a
-				     bottom sheet, no refresh: pull the tab or reopen instead). -->
-				<div v-if="isMobile" class="relative flex h-12 items-center border-b px-4">
-					<AdaptiveDropdown :options="FILTER_OPTIONS" :title="__('Filter')">
-						<button class="flex min-w-0 items-center gap-1.5 text-base !font-medium">
-							<span class="truncate">{{ title }}</span>
-							<ChevronDown class="text-ink-gray-5 h-4 w-4 shrink-0" />
-						</button>
-					</AdaptiveDropdown>
+				<template #list>
+					<!-- Toolbar — mobile mirrors the mailbox one (h-12, semibold selector in a
+					     bottom sheet, no refresh: pull the tab or reopen instead). -->
+					<div v-if="isMobile" class="relative flex h-12 items-center border-b px-4">
+						<AdaptiveDropdown :options="FILTER_OPTIONS" :title="__('Filter')">
+							<button class="flex min-w-0 items-center gap-1.5 text-base !font-medium">
+								<span class="truncate">{{ title }}</span>
+								<ChevronDown class="text-ink-gray-5 h-4 w-4 shrink-0" />
+							</button>
+						</AdaptiveDropdown>
 
-					<!-- Loading bar -->
-					<LoadingBar v-if="threads.loading" />
-				</div>
-				<div
-					v-else
-					class="relative flex items-center border-b border-l-transparent px-3.5 py-2.5 sm:border-l sm:px-5"
-				>
-					<Dropdown :options="FILTER_OPTIONS">
-						<button
-							class="text-ink-gray-8 hover:bg-surface-gray-2 -ml-2 flex min-w-0 items-center gap-1 rounded px-2 py-1"
-						>
-							<span class="truncate">{{ title }}</span>
-							<ChevronDown class="text-ink-gray-5 icon shrink-0" />
-						</button>
-					</Dropdown>
-					<div class="-mr-1.5 ml-auto flex items-center space-x-1.5 sm:space-x-3">
-						<Button
-							variant="ghost"
-							:tooltip="__('Refresh')"
-							:disabled="threads.loading || loadingMore"
-							@click="refreshThreads()"
-						>
-							<template #icon>
-								<RefreshCw class="icon" />
-							</template>
-						</Button>
+						<!-- Loading bar -->
+						<LoadingBar v-if="threads.loading" />
 					</div>
-
-					<!-- Loading bar -->
-					<LoadingBar v-if="threads.loading" />
-				</div>
-
-				<!-- Mail list -->
-				<div ref="mailList" class="h-full overflow-y-auto overscroll-contain max-sm:pb-20">
-					<div v-for="(rows, key) in groupedRows" :key="key">
-						<Tooltip
-							v-if="groupMessagesBy !== 'None' && !isMobile"
-							:text="
-								isLastGroup(key)
-									? ''
-									: __(collapsedGroups.includes(key) ? 'Expand' : 'Collapse')
-							"
-						>
-							<div
-								class="text-ink-gray-6 flex items-center border-b border-l-transparent p-3.5 text-xs-semibold sm:border-l sm:px-5"
-								:class="{
-									'sm:hover:bg-surface-gray-1': !isLastGroup(key),
-									'!border-l-outline-blue-5': focusedRowKey === `group:${key}`,
-								}"
-								:data-row-key="`group:${key}`"
-								@click="toggleGroupCollapse(key)"
+					<div
+						v-else
+						class="relative flex items-center border-b border-l-transparent px-3.5 py-2.5 sm:border-l sm:px-5"
+					>
+						<Dropdown :options="FILTER_OPTIONS">
+							<button
+								class="text-ink-gray-8 hover:bg-surface-gray-2 -ml-2 flex min-w-0 items-center gap-1 rounded px-2 py-1"
 							>
-								<span class="select-none pt-[2px]">
-									{{ getFormattedDate(key, groupMessagesBy === 'Month').toUpperCase() }}
-								</span>
-								<component
-									:is="collapsedGroups.includes(key) ? ChevronRight : ChevronDown"
-									v-if="!isLastGroup(key)"
-									class="icon ml-auto"
-								/>
-							</div>
-						</Tooltip>
-						<template v-if="isMobile || !collapsedGroups.includes(key)">
-							<!-- A stack row stands in for a run of look-alike threads; when expanded, its
-							     members follow it as ordinary (indented) rows — the same model as the
-							     mailbox list. No delete handler: Delete only shows once every member is
-							     already in Trash, which the merged inbox list can't reach. -->
-							<template v-for="row in rows" :key="row.key">
-								<StackListItem
-									v-if="row.type === 'stack'"
-									:threads="row.threads"
-									:expanded="row.expanded"
-									:is-selected="false"
-									:selectable="false"
-									:hide-avatar="!isMobile"
-									:account-label="shortAccountLabel(row.threads[0].account_name)"
-									class="border-l-transparent sm:border-l"
-									:class="{ '!border-l-outline-blue-5': focusedRowKey === row.key }"
-									:data-row-key="row.key"
-									@toggle="toggleStack(row)"
-									@set-seen="(seen: boolean) => stackSetSeen(row.threads, seen)"
-									@archive-threads="stackArchive(row.threads)"
-									@trash-threads="stackTrash(row.threads)"
-								/>
-								<MailListItem
-									v-else
-									:mailbox="row.thread.inbox || ''"
-									:account-id="row.thread.account"
-									:account-label="shortAccountLabel(row.thread.account_name)"
-									:mail="row.thread"
-									:is-selected="false"
-									:selectable="false"
-									thread-route-name="mail-all-inboxes-mail"
-									:hide-avatar="!isMobile"
-									:hide-sender="row.inStack"
-									class="border-l-transparent sm:border-l"
+								<span class="truncate">{{ title }}</span>
+								<ChevronDown class="text-ink-gray-5 icon shrink-0" />
+							</button>
+						</Dropdown>
+						<div class="-mr-1.5 ml-auto flex items-center space-x-1.5 sm:space-x-3">
+							<Button
+								variant="ghost"
+								:tooltip="__('Refresh')"
+								:disabled="threads.loading || loadingMore"
+								@click="refreshThreads()"
+							>
+								<template #icon>
+									<RefreshCw class="icon" />
+								</template>
+							</Button>
+						</div>
+
+						<!-- Loading bar -->
+						<LoadingBar v-if="threads.loading" />
+					</div>
+
+					<!-- Mail list -->
+					<div ref="mailList" class="h-full overflow-y-auto overscroll-contain max-sm:pb-20">
+						<div v-for="(rows, key) in groupedRows" :key="key">
+							<Tooltip
+								v-if="groupMessagesBy !== 'None' && !isMobile"
+								:text="
+									isLastGroup(key)
+										? ''
+										: __(collapsedGroups.includes(key) ? 'Expand' : 'Collapse')
+								"
+							>
+								<div
+									class="text-ink-gray-6 flex items-center border-b border-l-transparent p-3.5 text-xs-semibold sm:border-l sm:px-5"
 									:class="{
-										'!bg-surface-blue-1': row.thread.thread_id === threadID && !isMobile,
-										'!border-l-outline-blue-5': focusedRowKey === row.key,
-										'!pl-10 sm:!pl-12': row.inStack,
+										'sm:hover:bg-surface-gray-1': !isLastGroup(key),
+										'!border-l-outline-blue-5': focusedRowKey === `group:${key}`,
 									}"
-									:data-row-key="row.key"
-									@set-seen="(seen: boolean) => handleSetSeen(row.thread, seen)"
-									@archive-thread="handleArchive(row.thread)"
-									@trash-thread="handleTrash(row.thread)"
-									@set-flagged="(flagged: boolean) => handleSetFlagged(row.thread, flagged)"
-								/>
+									:data-row-key="`group:${key}`"
+									@click="toggleGroupCollapse(key)"
+								>
+									<span class="select-none pt-[2px]">
+										{{ getFormattedDate(key, groupMessagesBy === 'Month').toUpperCase() }}
+									</span>
+									<component
+										:is="collapsedGroups.includes(key) ? ChevronRight : ChevronDown"
+										v-if="!isLastGroup(key)"
+										class="icon ml-auto"
+									/>
+								</div>
+							</Tooltip>
+							<template v-if="isMobile || !collapsedGroups.includes(key)">
+								<!-- A stack row stands in for a run of look-alike threads; when expanded, its
+								     members follow it as ordinary (indented) rows — the same model as the
+								     mailbox list. No delete handler: Delete only shows once every member is
+								     already in Trash, which the merged inbox list can't reach. -->
+								<template v-for="row in rows" :key="row.key">
+									<StackListItem
+										v-if="row.type === 'stack'"
+										:threads="row.threads"
+										:expanded="row.expanded"
+										:is-selected="false"
+										:selectable="false"
+										:hide-avatar="!isMobile"
+										:account-label="shortAccountLabel(row.threads[0].account_name)"
+										class="border-l-transparent sm:border-l"
+										:class="{ '!border-l-outline-blue-5': focusedRowKey === row.key }"
+										:data-row-key="row.key"
+										@toggle="toggleStack(row)"
+										@set-seen="(seen: boolean) => stackSetSeen(row.threads, seen)"
+										@archive-threads="stackArchive(row.threads)"
+										@trash-threads="stackTrash(row.threads)"
+									/>
+									<MailListItem
+										v-else
+										:mailbox="row.thread.inbox || ''"
+										:account-id="row.thread.account"
+										:account-label="shortAccountLabel(row.thread.account_name)"
+										:mail="row.thread"
+										:is-selected="false"
+										:selectable="false"
+										thread-route-name="mail-all-inboxes-mail"
+										:hide-avatar="!isMobile"
+										:hide-sender="row.inStack"
+										class="border-l-transparent sm:border-l"
+										:class="{
+											'!bg-surface-blue-1': row.thread.thread_id === threadID && !isMobile,
+											'!border-l-outline-blue-5': focusedRowKey === row.key,
+											'!pl-10 sm:!pl-12': row.inStack,
+										}"
+										:data-row-key="row.key"
+										@set-seen="(seen: boolean) => handleSetSeen(row.thread, seen)"
+										@archive-thread="handleArchive(row.thread)"
+										@trash-thread="handleTrash(row.thread)"
+										@set-flagged="(flagged: boolean) => handleSetFlagged(row.thread, flagged)"
+									/>
+								</template>
 							</template>
-						</template>
+						</div>
+						<!-- Infinite-scroll sentinel: entering the viewport near the list bottom loads the next
+						     batch (appended, never refetching loaded rows). Sits after all groups. -->
+						<div ref="loadMoreSentinel" class="h-px" />
+						<div v-if="loadingMore" class="flex justify-center py-3">
+							<LoaderCircle class="text-ink-gray-5 h-4 w-4 animate-spin" />
+						</div>
 					</div>
-					<!-- Infinite-scroll sentinel: entering the viewport near the list bottom loads the next
-					     batch (appended, never refetching loaded rows). Sits after all groups. -->
-					<div ref="loadMoreSentinel" class="h-px" />
-					<div v-if="loadingMore" class="flex justify-center py-3">
-						<LoaderCircle class="text-ink-gray-5 h-4 w-4 animate-spin" />
-					</div>
-				</div>
-			</div>
-			<!-- The open thread, in place. Same geometry as MailboxView: a third/two-thirds split
-			     on desktop with Split View on, a full-bleed overlay otherwise and on mobile.
-			     Teleported to body on mobile for the same reason MailboxView does it: inside the
-			     layout's isolate stacking context the tab bar paints over the pane, whatever the
-			     pane's own z-index says. -->
-			<Teleport to="body" :disabled="!isMobile">
-			<div
-				class="bg-surface-base"
-				:class="{
-					'overflow-hidden': isMobile,
-					'w-2/3': !isMobile && showSplitView,
-					'absolute bottom-0 left-0 right-0 top-0': !isMobile && !showSplitView,
-					'fixed inset-0 z-20 pt-[env(safe-area-inset-top)] transition-[transform,visibility] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]':
-						isMobile,
-					'invisible translate-x-full': isMobile && !threadID,
-					hidden: !isMobile && !showSplitView && !threadID,
-				}"
-				@touchstart.passive="onThreadTouchStart"
-				@touchend.passive="onThreadTouchEnd"
-			>
-				<div class="h-full overflow-y-auto">
-					<!-- Rendered with no thread open too so its own "Select an email" placeholder
-					     fills the pane, as in MailboxView. A deep link whose row isn't in the
-					     loaded window stays gated: the pane's action handlers act on the row.
-					     The owning account scopes the pane (folder menus, reply identities) —
-					     opening a cross-account thread does NOT switch the active account. -->
-					<MailThread
-						ref="mailThread"
-						v-if="openRow || !threadID"
-						:slide="threadSlide"
-						@slide-done="threadSlide = ''"
-						:account="openRow?.account"
-						:mailbox="openRow?.inbox || ''"
-						:thread-i-d="threadID"
-						:threads="openThreadIDs"
-						:messages="openRow?.messages"
-						@reload-mails="refreshThreads()"
-						@set-seen="(seen: boolean) => handleSetSeen(openRow!, seen)"
-						@set-flagged="
-							(ids: string[], flagged: boolean) => paneSetFlagged(ids, flagged)
-						"
-						@move-thread="(mailboxId: string) => moveOpenThread(mailboxId)"
-						@delete-thread="handleTrash(openRow!)"
-						@archive-thread="handleArchive(openRow!)"
-						@sync-unseen="handleSyncUnseen"
-						@add-thread-to-mailbox="handleAddToMailbox"
-						@remove-thread-from-mailbox="handleRemoveFromMailbox"
-						@set-spam-status="handleSetSpamStatus"
-						@move-mail="handleMailMove"
-						@mark-mail-spam="handleMailSpam"
-						@delete-mail="handleMailDelete"
-						@prev-thread="stepOpenThread(-1)"
-						@next-thread="stepOpenThread(1)"
-					/>
-				</div>
-			</div>
-			</Teleport>
+				</template>
+
+				<!-- Rendered with no thread open too so its own "Select an email" placeholder
+				     fills the pane, as in MailboxView. A deep link whose row isn't in the
+				     loaded window stays gated: the pane's action handlers act on the row.
+				     The owning account scopes the pane (folder menus, reply identities) —
+				     opening a cross-account thread does NOT switch the active account. -->
+				<MailThread
+					ref="mailThread"
+					v-if="openRow || !threadID"
+					:slide="threadSlide"
+					@slide-done="threadSlide = ''"
+					:account="openRow?.account"
+					:mailbox="openRow?.inbox || ''"
+					:thread-i-d="threadID"
+					:threads="openThreadIDs"
+					:messages="openRow?.messages"
+					@reload-mails="refreshThreads()"
+					@set-seen="(seen: boolean) => handleSetSeen(openRow!, seen)"
+					@set-flagged="
+						(ids: string[], flagged: boolean) => paneSetFlagged(ids, flagged)
+					"
+					@move-thread="(mailboxId: string) => moveOpenThread(mailboxId)"
+					@delete-thread="handleTrash(openRow!)"
+					@archive-thread="handleArchive(openRow!)"
+					@sync-unseen="handleSyncUnseen"
+					@add-thread-to-mailbox="handleAddToMailbox"
+					@remove-thread-from-mailbox="handleRemoveFromMailbox"
+					@set-spam-status="handleSetSpamStatus"
+					@move-mail="handleMailMove"
+					@mark-mail-spam="handleMailSpam"
+					@delete-mail="handleMailDelete"
+					@prev-thread="stepOpenThread(-1)"
+					@next-thread="stepOpenThread(1)"
+				/>
+			</ThreadPane>
 		</template>
 
 		<!-- No mails -->
@@ -281,6 +260,7 @@ import MailListItem from '@/apps/mail/components/MailListItem.vue'
 import MailThread from '@/apps/mail/components/MailThread.vue'
 import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
 import StackListItem from '@/apps/mail/components/StackListItem.vue'
+import ThreadPane from '@/apps/mail/components/ThreadPane.vue'
 
 import type { Mail, Mailbox, MailboxData, Thread, UserResource } from '@/apps/mail/types'
 
@@ -481,9 +461,6 @@ const refreshThreads = (reloadCounts = true) => {
 // Date grouping with collapsible headers (mirroring the per-mailbox view). The last group never
 // collapses — it's where infinite scroll appends, so hiding it would swallow newly loaded rows.
 const groupMessagesBy = computed(() => user.data.group_messages_by)
-
-// Split View is a user setting; the merged view honours it like the mailbox view does.
-const showSplitView = computed(() => !!user.data?.show_reading_pane)
 
 // The loaded row the open thread belongs to. Every mutation reads its account/archive/trash
 // off the row, so the pane acts on the owning account without consulting the active one.

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -89,7 +89,7 @@
 							<div
 								class="text-ink-gray-6 flex items-center border-b border-l-transparent p-3.5 text-xs-semibold sm:border-l sm:px-5"
 								:class="{
-									'cursor-pointer': !isLastGroup(key),
+									'sm:hover:bg-surface-gray-1': !isLastGroup(key),
 									'!border-l-outline-blue-5': focusedRowKey === `group:${key}`,
 								}"
 								:data-row-key="`group:${key}`"
@@ -650,10 +650,18 @@ const isLastGroup = (key: string) => Object.keys(groupedThreads.value).at(-1) ==
 const collapsedGroups = ref<string[]>([])
 
 const toggleGroupCollapse = (key: string) => {
+	// The cursor follows the click, as it does when you open a mail — above the
+	// last-group guard, so clicking a header that can't fold still takes it.
+	focusedRowKey.value = `group:${key}`
 	if (isLastGroup(key)) return
+
 	if (collapsedGroups.value.includes(key))
-		collapsedGroups.value = collapsedGroups.value.filter((d) => d !== key)
-	else collapsedGroups.value.push(key)
+		return (collapsedGroups.value = collapsedGroups.value.filter((d) => d !== key))
+
+	collapsedGroups.value.push(key)
+	// Don't leave the reading pane pointing at a row we just hid.
+	if (groupedThreads.value[key]?.some((t: Thread) => t.thread_id === threadID))
+		router.push({ name: 'mail-all-inboxes', query: route.query })
 }
 
 watch(groupMessagesBy, () => (collapsedGroups.value = []))

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -524,7 +524,7 @@ const handleKeyDown = (e: KeyboardEvent) => {
 	// Escape backs out of the open thread, then clears the cursor.
 	if (key === 'escape') {
 		e.preventDefault()
-		if (threadID) return router.push({ name: 'mail-all-inboxes', query: route.query })
+		if (threadID) return closeThread()
 		focusedRowKey.value = undefined
 		return
 	}
@@ -739,8 +739,14 @@ const removeFromList = (thread: Thread) => {
 // different accounts/threads and can be fired in rapid succession, so every invocation must be a
 // fully independent request. A shared resource carries a single reactive state slot (and one abort
 // controller); call() has no shared state, so concurrent row actions can never clobber one another.
+const closeThread = () => router.push({ name: 'mail-all-inboxes', query: route.query })
+
 const handleSetSeen = (thread: Thread, seen: boolean) => {
 	if (thread.seen === (seen ? 1 : 0)) return
+
+	// Marking the open thread unread means "come back to this later", so leave the pane — staying
+	// in it would just mark it read again. Same exit as useThreadActions does for the mailbox list.
+	if (!seen && threadID === thread.thread_id) closeThread()
 	const applySeen = (value: 0 | 1) => {
 		thread.seen = value
 		thread.messages?.forEach((m) => (m.seen = value))

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -223,16 +223,7 @@
 <script setup lang="ts">
 import { computed, inject, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import {
-	ChevronDown,
-	ChevronRight,
-	LoaderCircle,
-	Mail as MailIcon,
-	Mails,
-	Paperclip,
-	RefreshCw,
-	Star,
-} from 'lucide-vue-next'
+import { ChevronDown, ChevronRight, LoaderCircle, RefreshCw } from 'lucide-vue-next'
 import { Breadcrumbs, Button, Dropdown, Tooltip, call, createResource, usePageMeta } from 'frappe-ui'
 
 import {
@@ -250,6 +241,7 @@ import {
 	stepFromKey,
 	useGPrefix,
 } from '@/apps/mail/utils/listNavigation'
+import { useStoredFilter } from '@/apps/mail/utils/listFilter'
 import { useScreenSize, useSwipeNav } from '@/apps/mail/utils/composables'
 import { useListRows } from '@/apps/mail/composables/useListRows'
 import { useMailRemoval } from '@/apps/mail/composables/useMailRemoval'
@@ -320,9 +312,13 @@ const {
 })
 
 const isLoaded = ref(false)
-const filter = ref<string | null>(
-	localStorage.getItem(`user:${user.data.name}:filter:all-inboxes`) || null,
-)
+
+// The remembered All/Unread/Starred/Has-attachments choice, its menu, and its title (see
+// useStoredFilter) — all shared with the mailbox list.
+const { filter, FILTER_OPTIONS, filterTitle: title } = useStoredFilter({
+	scope: () => 'all-inboxes',
+	onChange: () => resetThreads(),
+})
 
 // Reset resource: always the first window, over-fetching one row (PAGE_LENGTH + 1) to detect whether
 // more exist without a total.
@@ -891,33 +887,6 @@ const stackTrash = (threads: Thread[]) =>
 		threads[0].trash,
 		__('{0} threads moved to Trash.', [String(threads.length)]),
 	)
-
-// Filter
-const FILTER_OPTIONS = [
-	{ label: __('All'), icon: Mails, onClick: () => setFilter(null) },
-	{ label: __('Unread'), icon: MailIcon, onClick: () => setFilter('unread') },
-	{ label: __('Starred'), icon: Star, onClick: () => setFilter('starred') },
-	{ label: __('Has attachments'), icon: Paperclip, onClick: () => setFilter('has_attachments') },
-]
-
-const setFilter = (value: string | null) => {
-	filter.value = value
-	localStorage.setItem(`user:${user.data.name}:filter:all-inboxes`, value ?? '')
-	resetThreads()
-}
-
-const title = computed(() => {
-	switch (filter.value) {
-		case 'unread':
-			return __('Unread Mails')
-		case 'starred':
-			return __('Starred Mails')
-		case 'has_attachments':
-			return __('With Attachments')
-		default:
-			return __('All Mails')
-	}
-})
 
 const unreadPrefix = computed(() =>
 	store.allInboxesUnread.data ? `(${store.allInboxesUnread.data})` : '',

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -162,7 +162,11 @@
 				</div>
 			</div>
 			<!-- The open thread, in place. Same geometry as MailboxView: a third/two-thirds split
-			     on desktop with Split View on, a full-bleed overlay otherwise and on mobile. -->
+			     on desktop with Split View on, a full-bleed overlay otherwise and on mobile.
+			     Teleported to body on mobile for the same reason MailboxView does it: inside the
+			     layout's isolate stacking context the tab bar paints over the pane, whatever the
+			     pane's own z-index says. -->
+			<Teleport to="body" :disabled="!isMobile">
 			<div
 				class="bg-surface-base"
 				:class="{
@@ -199,6 +203,7 @@
 					/>
 				</div>
 			</div>
+			</Teleport>
 		</template>
 
 		<!-- No mails -->
@@ -236,7 +241,13 @@ import {
 } from 'lucide-vue-next'
 import { Breadcrumbs, Button, Dropdown, Tooltip, call, createResource, usePageMeta } from 'frappe-ui'
 
-import { getFormattedDate, raiseOptimisticToast, raiseToast, shouldIgnoreKeypress } from '@/apps/mail/utils'
+import {
+	getFormattedDate,
+	isMac,
+	raiseOptimisticToast,
+	raiseToast,
+	shouldIgnoreKeypress,
+} from '@/apps/mail/utils'
 import {
 	isNavigationKey,
 	navigationOffset,
@@ -468,6 +479,44 @@ const stepOpenThread = (offset: number) => {
 // no stacks, no day headers, no selection — so a step is just the neighbouring row.
 const gPrefix = useGPrefix()
 
+// Thread shortcuts, acting on the open thread or — with none open — the row under the cursor.
+// Each one goes through the row handlers, which read the account and its folder ids off the row
+// itself, so a shortcut in the merged list targets the owning account like a click does.
+// Returns true when it consumed the key.
+const actionTarget = computed(() => {
+	const key = threadID ?? focusedRowKey.value
+	return (threads.data ?? []).find((t: Thread) => t.thread_id === key)
+})
+
+const handleThreadActions = (e: KeyboardEvent, key: string) => {
+	const thread = actionTarget.value
+	if (!thread) return false
+
+	// Backspace on Mac, Delete elsewhere.
+	if (key === (isMac ? 'backspace' : 'delete')) {
+		e.preventDefault()
+		handleTrash(thread)
+		return true
+	}
+
+	if (key === 'u') {
+		e.preventDefault()
+		handleSetSeen(thread, e.shiftKey)
+		return true
+	}
+
+	if (key === 'e') {
+		e.preventDefault()
+		handleArchive(thread)
+		return true
+	}
+
+	// `!` (mark as junk) is absent on purpose: the merged row carries the account's Archive and
+	// Trash ids but not its Junk one (see Thread in types), so there is nothing to move it to.
+
+	return false
+}
+
 const handleKeyDown = (e: KeyboardEvent) => {
 	const key = e.key.toLowerCase()
 	if (shouldIgnoreKeypress(e)) return
@@ -500,6 +549,8 @@ const handleKeyDown = (e: KeyboardEvent) => {
 		gPrefix.disarm()
 		return
 	}
+
+	if (handleThreadActions(e, key)) return
 
 	if (!isNavigationKey(key)) return
 	e.preventDefault()

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -252,6 +252,7 @@ import {
 } from '@/apps/mail/utils/listNavigation'
 import { useScreenSize, useSwipeNav } from '@/apps/mail/utils/composables'
 import { useListRows } from '@/apps/mail/composables/useListRows'
+import { useMailRemoval } from '@/apps/mail/composables/useMailRemoval'
 import {
 	PAGE_LENGTH,
 	usePaginatedThreads,
@@ -624,8 +625,14 @@ const removeFromList = (thread: Thread) => {
 // thread route carries accountId so the router has already switched, but passing it explicitly keeps
 // these correct if that ever stops being true. Mailbox ids come from the store, which is the row's
 // account for the same reason.
-const paneCall = (method: string, params: Record<string, unknown>) =>
-	call(`suite.mail.api.mail.${method}`, { account: openRow.value?.account, ...params })
+const paneCall = (method: string, params: Record<string, unknown>) => {
+	const account = openRow.value?.account
+	// Every pane action reads its account off the row, so a deep-linked thread outside the loaded window
+	// has none to act within. Refuse rather than firing `account: undefined` at the server and having it
+	// fail silently — the caller's optimistic update rolls back and the toast says so.
+	if (!account) return Promise.reject(new Error(__('Thread is no longer in the list.')))
+	return call(`suite.mail.api.mail.${method}`, { account, ...params })
+}
 
 const messageIdsOf = (thread: Thread) => thread.messages?.map((m) => m.id) ?? [thread.id]
 
@@ -715,38 +722,16 @@ const handleSetSpamStatus = (spam: boolean) => {
 	)
 }
 
-// Per-message actions from a message's own menu. The mail leaves the pane at once — waiting for the
-// request meant a click did nothing visible until the round-trip landed. If it was the thread's last
-// mail the row goes too, and the pane closes; a failure puts all of it back.
-const runMailRemoval = (mail: Mail, request: () => Promise<unknown>, success: string) => {
-	const thread = openRow.value
-	const { emptied, rollback } = mailThread.value?.removeMailFromView(mail.id) ?? {
-		emptied: false,
-		rollback: () => {},
-	}
-
-	// The row's count and preview come from its own `messages`, so it has to lose the mail too.
-	const mailIndex = thread?.messages?.findIndex((m: Mail) => m.id === mail.id) ?? -1
-	if (thread && mailIndex !== -1) thread.messages.splice(mailIndex, 1)
-
-	let restoreRow: (() => void) | undefined
-	if (emptied && thread) {
-		restoreRow = removeFromList(thread)
-		closeThread()
-	}
-
-	raiseOptimisticToast(
-		request()
-			.then(() => refreshCounts())
-			.catch((error) => {
-				rollback()
-				if (thread && mailIndex !== -1) thread.messages.splice(mailIndex, 0, mail)
-				restoreRow?.()
-				throw error
-			}),
-		success,
-	)
-}
+// Per-message actions from a message's own menu, on the shared orchestration (see useMailRemoval).
+// The merged list is inbox-scoped, so its rows always summarise from the whole conversation — never
+// from a folder, as Sent and Drafts do. No undo yet: the undo requests would have to be scoped to the
+// row's own account rather than the active one.
+const { runMailRemoval } = useMailRemoval({
+	row: () => openRow.value,
+	mailThreadRef: mailThread,
+	onEmptied: () => closeThread(),
+	removeRow: (_mail, thread) => (thread ? removeFromList(thread) : () => {}),
+})
 
 const folderName = (mailboxId: string) =>
 	store.mailboxes.data?.find((m: MailboxData) => m.id === mailboxId)?._name

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -212,7 +212,6 @@ import {
 	hasCursor,
 	isNavigationKey,
 	navigationOffset,
-	stepFrom,
 	stepFromKey,
 	useGPrefix,
 } from '@/apps/mail/utils/listNavigation'
@@ -240,11 +239,13 @@ import type { Mail, Mailbox, MailboxData, Thread, UserResource } from '@/apps/ma
 
 const { isMobile } = useScreenSize()
 
-// Set by the `mail-all-inboxes-mail` route when a thread is open. accountId is the thread's
-// owning account, not the active one — the merged list spans accounts.
-const { accountId, mailbox, threadID } = defineProps<{
-	accountId?: string
-	mailbox?: string
+// The `mail-all-inboxes-mail` route also carries the open thread's owning accountId and mailbox, but
+// nothing here reads them: every row already carries its own account and folder ids, which is what the
+// pane and its actions target. They fall through as plain attributes, which this component (a fragment)
+// cannot inherit — so it inherits nothing.
+defineOptions({ inheritAttrs: false })
+
+const { threadID } = defineProps<{
 	threadID?: string
 }>()
 
@@ -268,6 +269,7 @@ const {
 	isFetching,
 	canGoNext,
 	threadIDs,
+	threadByOffset,
 	takeResetWindow,
 	beginReset,
 	beginRefresh,
@@ -408,7 +410,7 @@ const { onTouchStart: onThreadTouchStart, onTouchEnd: onThreadTouchEnd } = useSw
 )
 
 const stepOpenThread = (offset: number) => {
-	const next = stepFrom(threadIDs.value, threadID, offset)
+	const next = threadByOffset(offset)
 	if (next) return openThread(next)
 	// At the last loaded thread, stepping further loads the next window and opens what arrives.
 	loadMoreThenOpenEdge(offset, 'open')

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -560,6 +560,7 @@ const moveOpenThread = (mailboxId: string) => {
 	if (!row) return
 	if (mailboxId === row.archive) return handleArchive(row)
 	if (mailboxId === row.trash) return handleTrash(row)
+	goToNextThreadOrClose(row.thread_id)
 	const restore = removeFromList(row)
 	const folder = folderName(mailboxId)
 	raiseOptimisticToast(
@@ -608,13 +609,17 @@ const removeFromList = (thread: Thread) => {
 // thread route carries accountId so the router has already switched, but passing it explicitly keeps
 // these correct if that ever stops being true. Mailbox ids come from the store, which is the row's
 // account for the same reason.
-const paneCall = (method: string, params: Record<string, unknown>) => {
-	const account = openRow.value?.account
-	// Every pane action reads its account off the row, so a deep-linked thread outside the loaded window
-	// has none to act within. Refuse rather than firing `account: undefined` at the server and having it
-	// fail silently — the caller's optimistic update rolls back and the toast says so.
-	if (!account) return Promise.reject(new Error(__('Thread is no longer in the list.')))
-	return call(`suite.mail.api.mail.${method}`, { account, ...params })
+// `account` must be captured by the caller BEFORE its optimistic update, not resolved here: the
+// removals take the row out of the list first, and openRow is derived from that list — so by the
+// time the request fires the row it names is already gone. Falling back to openRow only covers the
+// actions that leave the row in place.
+//
+// A deep-linked thread outside the loaded window has no account to act within either; refuse rather
+// than firing `account: undefined` at the server and having it fail silently.
+const paneCall = (method: string, params: Record<string, unknown>, account?: string) => {
+	const acting = account ?? openRow.value?.account
+	if (!acting) return Promise.reject(new Error(__('Thread is no longer in the list.')))
+	return call(`suite.mail.api.mail.${method}`, { account: acting, ...params })
 }
 
 const messageIdsOf = (thread: Thread) => thread.messages?.map((m) => m.id) ?? [thread.id]
@@ -679,7 +684,11 @@ const handleAddToMailbox = (mailboxId: string) => {
 	setUndoAction(undoAction)
 
 	raiseOptimisticToast(
-		paneCall('add_mails_to_mailbox', { ids: messageIdsOf(thread), mailbox_id: mailboxId }).catch(
+		paneCall(
+			'add_mails_to_mailbox',
+			{ ids: messageIdsOf(thread), mailbox_id: mailboxId },
+			thread.account,
+		).catch(
 			(error) => {
 				syncFolderTag(mailboxId, false)
 				throw error
@@ -709,7 +718,11 @@ const handleRemoveFromMailbox = (mailboxId: string) => {
 	setUndoAction(undoAction)
 
 	raiseOptimisticToast(
-		paneCall('remove_mails_from_mailbox', { ids: messageIdsOf(thread), mailbox_id: mailboxId }).catch(
+		paneCall(
+			'remove_mails_from_mailbox',
+			{ ids: messageIdsOf(thread), mailbox_id: mailboxId },
+			thread.account,
+		).catch(
 			(error) => {
 				syncFolderTag(mailboxId, true)
 				throw error
@@ -725,10 +738,12 @@ const handleSetSpamStatus = (spam: boolean) => {
 	if (!thread) return
 	const restore = removeFromList(thread)
 	raiseOptimisticToast(
-		paneCall('set_mails_spam_status', { ids: messageIdsOf(thread), spam }).catch((error) => {
-			restore()
-			throw error
-		}),
+		paneCall('set_mails_spam_status', { ids: messageIdsOf(thread), spam }, thread.account).catch(
+			(error) => {
+				restore()
+				throw error
+			},
+		),
 		spam ? __('Thread marked as junk.') : __('Thread marked as not junk.'),
 	)
 }
@@ -754,9 +769,8 @@ const paneScope = useAccountScope(() => openRow.value?.account)
 const folderName = (mailboxId: string) =>
 	paneScope.mailboxes.value.data?.find((m: MailboxData) => m.id === mailboxId)?._name
 
-const undoMail = (mail: Mail) => {
+const undoMail = (mail: Mail, account?: string) => {
 	const snapshot = mailSnapshot(mail)
-	const account = openRow.value?.account
 	return {
 		undoReq: () => restoreMails(account!, [snapshot]),
 		undoSuccess: __('Mail restored.'),
@@ -764,22 +778,25 @@ const undoMail = (mail: Mail) => {
 }
 
 const handleMailMove = (mail: Mail, target: string) => {
+	const account = openRow.value?.account
 	const folder = folderName(target)
 	runMailRemoval(
 		mail,
-		() => paneCall('move_mails', { ids: [mail.id], mailbox: target }),
+		() => paneCall('move_mails', { ids: [mail.id], mailbox: target }, account),
 		folder ? __('Mail moved to {0}.', [folder]) : __('Mail moved.'),
-		undoMail(mail),
+		undoMail(mail, account),
 	)
 }
 
-const handleMailSpam = (mail: Mail, spam: boolean) =>
+const handleMailSpam = (mail: Mail, spam: boolean) => {
+	const account = openRow.value?.account
 	runMailRemoval(
 		mail,
-		() => paneCall('set_mails_spam_status', { ids: [mail.id], spam }),
+		() => paneCall('set_mails_spam_status', { ids: [mail.id], spam }, account),
 		spam ? __('Mail marked as junk.') : __('Mail marked as not junk.'),
-		undoMail(mail),
+		undoMail(mail, account),
 	)
+}
 
 const handleMailDelete = (mail: Mail) =>
 	runMailRemoval(
@@ -848,6 +865,17 @@ const handleSetFlagged = (thread: Thread, flagged: boolean, ids: string[] = [thr
 // The row is already dropped optimistically by the caller, so move on the server directly. On success just
 // refresh counts (the row and its server row are both gone, so the append offset stays aligned and scroll is
 // preserved). On failure, restore the row in place via the passed closure; rethrow so the toast reports the error.
+// Acting on the open thread from the pane should leave you on the next one, not on a thread that
+// is no longer in the list. Resolved before the row is removed, so the index is still meaningful;
+// falls back to closing the pane at the end of the list. Mirrors MailboxView.
+const goToNextThreadOrClose = (movedThreadID: string) => {
+	if (threadID !== movedThreadID) return
+	const ids = openThreadIDs.value
+	const next = ids.slice(ids.indexOf(movedThreadID) + 1).find((id) => id !== movedThreadID)
+	if (next) openThread(next)
+	else closeThread()
+}
+
 // Undo restores each mail's exact mailbox set and junk flag rather than guessing an inverse: a
 // thread that sat in two folders has to come back to both, and un-junking is not the same as moving.
 const mailSnapshot = (mail: Mail) => ({
@@ -885,6 +913,7 @@ const moveThreadOut = (thread: Thread, mailbox: string, restore: () => void) =>
 
 const handleArchive = (thread: Thread) => {
 	if (!thread.archive) return raiseToast(__('No Archive folder for this account.'), 'error')
+	goToNextThreadOrClose(thread.thread_id)
 	const restore = removeFromList(thread)
 	raiseOptimisticToast(
 		moveThreadOut(thread, thread.archive!, restore),
@@ -895,6 +924,7 @@ const handleArchive = (thread: Thread) => {
 
 const handleTrash = (thread: Thread) => {
 	if (!thread.trash) return raiseToast(__('No Trash folder for this account.'), 'error')
+	goToNextThreadOrClose(thread.thread_id)
 	const restore = removeFromList(thread)
 	raiseOptimisticToast(
 		moveThreadOut(thread, thread.trash!, restore),

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -606,27 +606,6 @@ const toggleStack = (row: StackRow) => {
 // hidden inside a collapsed day or stack, where the marker simply vanished.
 type NavEntry = { type: 'group'; key: string; dateKey: string } | ListRow
 
-// Rescues the one case the observer cannot: the rendered list is too short to scroll, so the
-// sentinel never leaves and re-enters the viewport to fire again — infinite scroll would die with
-// nothing left to scroll. A window of threads can collapse to a single stack row, so filling the
-// viewport can take several windows. This was unreachable before the merged list stacked.
-//
-// Both guards are load-bearing. Stop once the list can scroll, because from there the user's own
-// scrolling drives the observer. And stop if a window added no height: its rows landed somewhere
-// they cannot be seen (a collapsed day), so further windows would be just as invisible — without
-// this, collapsing a large group walks the whole list a window at a time.
-watch(groupedRows, () => {
-	if (!sentinelVisible.value || !hasMore.value) return
-
-	nextTick(() => {
-		const el = mailListRef.value
-		if (!el || !sentinelVisible.value) return
-
-		const grew = el.scrollHeight > lastFillHeight
-		lastFillHeight = el.scrollHeight
-		if (el.scrollHeight <= el.clientHeight && grew) loadMore()
-	})
-})
 
 const navigableRows = computed<NavEntry[]>(() => {
 	const rows: NavEntry[] = []
@@ -730,6 +709,29 @@ const groupedThreads = computed<Record<string, Thread[]>>(() =>
 const isLastGroup = (key: string) => Object.keys(groupedThreads.value).at(-1) === key
 
 const collapsedGroups = ref<string[]>([])
+
+// Rescues the one case the observer cannot: the rendered list is too short to scroll, so the
+// sentinel never leaves and re-enters the viewport to fire again — infinite scroll would die with
+// nothing left to scroll. A window of threads can collapse to a single stack row, so filling the
+// viewport can take several windows. This was unreachable before the merged list stacked.
+//
+// Both guards are load-bearing. Stop once the list can scroll, because from there the user's own
+// scrolling drives the observer. And stop if a window added no height: its rows landed somewhere
+// they cannot be seen (a collapsed day), so further windows would be just as invisible — without
+// this, collapsing a large group walks the whole list a window at a time.
+watch(groupedRows, () => {
+	if (!sentinelVisible.value || !hasMore.value) return
+
+	nextTick(() => {
+		const el = mailListRef.value
+		if (!el || !sentinelVisible.value) return
+
+		const grew = el.scrollHeight > lastFillHeight
+		lastFillHeight = el.scrollHeight
+		if (el.scrollHeight <= el.clientHeight && grew) loadMore()
+	})
+})
+
 
 const toggleGroupCollapse = (key: string) => {
 	// The cursor follows the click, as it does when you open a mail — above the

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -571,7 +571,7 @@ const moveOpenThread = (mailboxId: string) => {
 	raiseOptimisticToast(
 		moveThreadOut(row, mailboxId, restore),
 		folder ? __('Thread moved to {0}.', [folder]) : __('Thread moved.'),
-		withUndo(row, restore),
+		withUndo(row, restore, __('Thread moved back.')),
 	)
 }
 
@@ -683,7 +683,7 @@ const handleAddToMailbox = (mailboxId: string) => {
 		syncFolderTag(mailboxId, false)
 		raiseOptimisticToast(
 			restoreMails(thread.account, snapshot),
-			folder ? __('Removed from {0}.', [folder]) : __('Folder change undone.'),
+			folder ? __('Thread removed from {0}.', [folder]) : __('Thread removed from folder.'),
 		)
 	}
 	setUndoAction(undoAction)
@@ -715,10 +715,7 @@ const handleRemoveFromMailbox = (mailboxId: string) => {
 	// the folder before an "add" must stay in it afterwards.
 	const undoAction = () => {
 		syncFolderTag(mailboxId, true)
-		raiseOptimisticToast(
-			restoreMails(thread.account, snapshot),
-			folder ? __('Added back to {0}.', [folder]) : __('Folder change undone.'),
-		)
+		raiseOptimisticToast(restoreMails(thread.account, snapshot), __('Thread added back.'))
 	}
 	setUndoAction(undoAction)
 
@@ -750,8 +747,9 @@ const handleSetSpamStatus = (spam: boolean, target?: Thread) => {
 				throw error
 			},
 		),
-		spam ? __('Thread marked as junk.') : __('Thread marked as not junk.'),
-		withUndo(thread, restore),
+		__('Thread marked as {0}.', [spam ? __('Junk') : __('Not Junk')]),
+		// Undo flips the junk status back — name the resulting state, like the forward toast does.
+		withUndo(thread, restore, __('Thread marked as {0}.', [spam ? __('Not Junk') : __('Junk')])),
 	)
 }
 
@@ -776,12 +774,9 @@ const paneScope = useAccountScope(() => openRow.value?.account)
 const folderName = (mailboxId: string) =>
 	paneScope.mailboxes.value.data?.find((m: MailboxData) => m.id === mailboxId)?._name
 
-const undoMail = (mail: Mail, account?: string) => {
+const undoMail = (mail: Mail, account: string | undefined, undoSuccess: string) => {
 	const snapshot = mailSnapshot(mail)
-	return {
-		undoReq: () => restoreMails(account!, [snapshot]),
-		undoSuccess: __('Mail restored.'),
-	}
+	return { undoReq: () => restoreMails(account!, [snapshot]), undoSuccess }
 }
 
 const handleMailMove = (mail: Mail, target: string) => {
@@ -791,7 +786,7 @@ const handleMailMove = (mail: Mail, target: string) => {
 		mail,
 		() => paneCall('move_mails', { ids: [mail.id], mailbox: target }, account),
 		folder ? __('Mail moved to {0}.', [folder]) : __('Mail moved.'),
-		undoMail(mail, account),
+		undoMail(mail, account, __('Mail moved back.')),
 	)
 }
 
@@ -800,8 +795,9 @@ const handleMailSpam = (mail: Mail, spam: boolean) => {
 	runMailRemoval(
 		mail,
 		() => paneCall('set_mails_spam_status', { ids: [mail.id], spam }, account),
-		spam ? __('Mail marked as junk.') : __('Mail marked as not junk.'),
-		undoMail(mail, account),
+		spam ? __('Mail marked as Junk.') : __('Mail marked as Not Junk.'),
+		// Undo flips the junk status back — name the resulting state, like the forward toast does.
+		undoMail(mail, account, __('Mail marked as {0}.', [spam ? __('Not Junk') : __('Junk')])),
 	)
 }
 
@@ -826,16 +822,21 @@ const handleSetSeen = (thread: Thread, seen: boolean) => {
 		thread.messages?.forEach((m) => (m.seen = value))
 	}
 	applySeen(seen ? 1 : 0)
-	call('suite.mail.api.mail.set_mails_seen', {
-		account: thread.account,
-		ids: messageIds(thread),
-		seen,
-	})
-		.then(refreshCounts)
-		.catch((error) => {
-			applySeen(seen ? 0 : 1) // revert the optimistic update
-			raiseToast(error?.messages?.[0] || error?.message, 'error')
+	// Every caller here is an explicit user action (row action, pane menu, `u`); the silent
+	// mark-as-read on opening a thread is the pane's own and never reaches this.
+	raiseOptimisticToast(
+		call('suite.mail.api.mail.set_mails_seen', {
+			account: thread.account,
+			ids: messageIds(thread),
+			seen,
 		})
+			.then(refreshCounts)
+			.catch((error) => {
+				applySeen(seen ? 0 : 1) // revert the optimistic update
+				throw error
+			}),
+		__('Thread marked as {0}.', [seen ? __('read') : __('unread')]),
+	)
 }
 
 // Star/unstar, from a list row (which names no mails, so its own representative one) or from the
@@ -896,12 +897,14 @@ const threadSnapshot = (thread: Thread) => (thread.messages ?? []).map(mailSnaps
 const restoreMails = (account: string, mails: ReturnType<typeof mailSnapshot>[]) =>
 	call('suite.mail.api.mail.set_mails_mailboxes', { account, mails }).then(refreshCounts)
 
-// Offered on the toast and on Cmd/Ctrl+Z, matching the mailbox list.
-const withUndo = (thread: Thread, restore: () => void) => {
+// Offered on the toast and on Cmd/Ctrl+Z, matching the mailbox list. `undoSuccess` is the caller's,
+// because the mailbox list names the state the undo lands in ("Thread moved back.", "Thread marked
+// as Not Junk.") rather than confirming it generically.
+const withUndo = (thread: Thread, restore: () => void, undoSuccess: string) => {
 	const snapshot = threadSnapshot(thread)
 	const undoAction = () => {
 		restore()
-		raiseOptimisticToast(restoreMails(thread.account, snapshot), __('Thread restored.'))
+		raiseOptimisticToast(restoreMails(thread.account, snapshot), undoSuccess)
 	}
 	setUndoAction(undoAction)
 	return undoAction
@@ -925,7 +928,7 @@ const handleArchive = (thread: Thread) => {
 	raiseOptimisticToast(
 		moveThreadOut(thread, thread.archive!, restore),
 		__('Thread archived.'),
-		withUndo(thread, restore),
+		withUndo(thread, restore, __('Thread moved back.')),
 	)
 }
 
@@ -936,7 +939,7 @@ const handleTrash = (thread: Thread) => {
 	raiseOptimisticToast(
 		moveThreadOut(thread, thread.trash!, restore),
 		__('Thread moved to Trash.'),
-		withUndo(thread, restore),
+		withUndo(thread, restore, __('Thread moved back.')),
 	)
 }
 
@@ -952,16 +955,19 @@ const stackSetSeen = (threads: Thread[], seen: boolean) => {
 			t.messages?.forEach((m) => (m.seen = value))
 		})
 	applySeen(seen ? 1 : 0)
-	call('suite.mail.api.mail.set_mails_seen', {
-		account: threads[0].account,
-		ids: changed.flatMap(messageIds),
-		seen,
-	})
-		.then(refreshCounts)
-		.catch((error) => {
-			applySeen(seen ? 0 : 1) // revert the optimistic update
-			raiseToast(error?.messages?.[0] || error?.message, 'error')
+	raiseOptimisticToast(
+		call('suite.mail.api.mail.set_mails_seen', {
+			account: threads[0].account,
+			ids: changed.flatMap(messageIds),
+			seen,
 		})
+			.then(refreshCounts)
+			.catch((error) => {
+				applySeen(seen ? 0 : 1) // revert the optimistic update
+				throw error
+			}),
+		__('Threads marked as {0}.', [seen ? __('read') : __('unread')]),
+	)
 }
 
 // Restores run in reverse so each row splices back at the index captured when it was removed.
@@ -980,15 +986,12 @@ const stackMoveOut = (threads: Thread[], mailboxId: string | undefined, done: st
 	raiseOptimisticToast(promise, done)
 }
 
+// Plurals of the single-thread messages, as the mailbox list does — it never prefixes a count.
 const stackArchive = (threads: Thread[]) =>
-	stackMoveOut(threads, threads[0].archive, __('{0} threads archived.', [String(threads.length)]))
+	stackMoveOut(threads, threads[0].archive, __('Threads archived.'))
 
 const stackTrash = (threads: Thread[]) =>
-	stackMoveOut(
-		threads,
-		threads[0].trash,
-		__('{0} threads moved to Trash.', [String(threads.length)]),
-	)
+	stackMoveOut(threads, threads[0].trash, __('Threads moved to Trash.'))
 
 const unreadPrefix = computed(() =>
 	store.allInboxesUnread.data ? `(${store.allInboxesUnread.data})` : '',

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -723,7 +723,11 @@ const moveOpenThread = (mailboxId: string) => {
 	if (mailboxId === row.archive) return handleArchive(row)
 	if (mailboxId === row.trash) return handleTrash(row)
 	const restore = removeFromList(row)
-	raiseOptimisticToast(moveThreadOut(row, mailboxId, restore), __('Thread moved.'))
+	const folder = folderName(mailboxId)
+	raiseOptimisticToast(
+		moveThreadOut(row, mailboxId, restore),
+		folder ? __('Thread moved to {0}.', [folder]) : __('Thread moved.'),
+	)
 }
 
 const groupedThreads = computed<Record<string, Thread[]>>(() =>
@@ -862,6 +866,7 @@ const syncFolderTag = (mailboxId: string, add: boolean) => {
 const handleAddToMailbox = (mailboxId: string) => {
 	const thread = openRow.value
 	if (!thread) return
+	const folder = folderName(mailboxId)
 	syncFolderTag(mailboxId, true)
 	raiseOptimisticToast(
 		paneCall('add_mails_to_mailbox', { ids: messageIdsOf(thread), mailbox_id: mailboxId }).catch(
@@ -870,13 +875,14 @@ const handleAddToMailbox = (mailboxId: string) => {
 				throw error
 			},
 		),
-		__('Thread added to folder.'),
+		folder ? __('Thread added to {0}.', [folder]) : __('Thread added to folder.'),
 	)
 }
 
 const handleRemoveFromMailbox = (mailboxId: string) => {
 	const thread = openRow.value
 	if (!thread) return
+	const folder = folderName(mailboxId)
 	syncFolderTag(mailboxId, false)
 	raiseOptimisticToast(
 		paneCall('remove_mails_from_mailbox', { ids: messageIdsOf(thread), mailbox_id: mailboxId }).catch(
@@ -885,7 +891,7 @@ const handleRemoveFromMailbox = (mailboxId: string) => {
 				throw error
 			},
 		),
-		__('Thread removed from folder.'),
+		folder ? __('Thread removed from {0}.', [folder]) : __('Thread removed from folder.'),
 	)
 }
 
@@ -935,12 +941,17 @@ const runMailRemoval = (mail: Mail, request: () => Promise<unknown>, success: st
 	)
 }
 
-const handleMailMove = (mail: Mail, target: string) =>
+const folderName = (mailboxId: string) =>
+	store.mailboxes.data?.find((m: MailboxData) => m.id === mailboxId)?._name
+
+const handleMailMove = (mail: Mail, target: string) => {
+	const folder = folderName(target)
 	runMailRemoval(
 		mail,
 		() => paneCall('move_mails', { ids: [mail.id], mailbox: target }),
-		__('Mail moved.'),
+		folder ? __('Mail moved to {0}.', [folder]) : __('Mail moved.'),
 	)
+}
 
 const handleMailSpam = (mail: Mail, spam: boolean) =>
 	runMailRemoval(

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -406,10 +406,20 @@ const loadMore = () => {
 }
 
 const loadMoreSentinel = useTemplateRef('loadMoreSentinel')
+// True while the sentinel is in view.
+const sentinelVisible = ref(false)
+
+// The height the list had reached the last time we topped it up, so a fill that adds nothing can
+// be detected. Reset at the start of each fill episode (see the watcher by groupedRows).
+let lastFillHeight = 0
+
 useIntersectionObserver(
 	loadMoreSentinel,
 	([entry]) => {
-		if (entry?.isIntersecting) loadMore()
+		const entering = !!entry?.isIntersecting && !sentinelVisible.value
+		sentinelVisible.value = !!entry?.isIntersecting
+		if (entering) lastFillHeight = 0
+		if (sentinelVisible.value) loadMore()
 	},
 	{ root: mailListRef },
 )
@@ -595,6 +605,28 @@ const toggleStack = (row: StackRow) => {
 // Walking the loaded threads instead skipped the headers and — worse — stepped onto threads
 // hidden inside a collapsed day or stack, where the marker simply vanished.
 type NavEntry = { type: 'group'; key: string; dateKey: string } | ListRow
+
+// Rescues the one case the observer cannot: the rendered list is too short to scroll, so the
+// sentinel never leaves and re-enters the viewport to fire again — infinite scroll would die with
+// nothing left to scroll. A window of threads can collapse to a single stack row, so filling the
+// viewport can take several windows. This was unreachable before the merged list stacked.
+//
+// Both guards are load-bearing. Stop once the list can scroll, because from there the user's own
+// scrolling drives the observer. And stop if a window added no height: its rows landed somewhere
+// they cannot be seen (a collapsed day), so further windows would be just as invisible — without
+// this, collapsing a large group walks the whole list a window at a time.
+watch(groupedRows, () => {
+	if (!sentinelVisible.value || !hasMore.value) return
+
+	nextTick(() => {
+		const el = mailListRef.value
+		if (!el || !sentinelVisible.value) return
+
+		const grew = el.scrollHeight > lastFillHeight
+		lastFillHeight = el.scrollHeight
+		if (el.scrollHeight <= el.clientHeight && grew) loadMore()
+	})
+})
 
 const navigableRows = computed<NavEntry[]>(() => {
 	const rows: NavEntry[] = []

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -77,7 +77,7 @@
 
 				<!-- Mail list -->
 				<div ref="mailList" class="h-full overflow-y-auto overscroll-contain max-sm:pb-20">
-					<div v-for="(group, key) in groupedThreads" :key="key">
+					<div v-for="(rows, key) in groupedRows" :key="key">
 						<Tooltip
 							v-if="groupMessagesBy !== 'None' && !isMobile"
 							:text="
@@ -106,28 +106,50 @@
 							</div>
 						</Tooltip>
 						<template v-if="isMobile || !collapsedGroups.includes(key)">
-							<MailListItem
-								v-for="mail in group"
-								:key="`${mail.account}:${mail.thread_id}`"
-								:mailbox="mail.inbox || ''"
-								:account-id="mail.account"
-								:account-label="mail.account_name || undefined"
-								:mail
-								:is-selected="false"
-								:selectable="false"
-								thread-route-name="mail-all-inboxes-mail"
-								:hide-avatar="!isMobile"
-								class="border-l-transparent sm:border-l"
-								:class="{
-									'!bg-surface-blue-1': mail.thread_id === threadID && !isMobile,
-									'!border-l-outline-blue-5': focusedRowKey === mail.thread_id,
-								}"
-								:data-row-key="mail.thread_id"
-								@set-seen="(seen: boolean) => handleSetSeen(mail, seen)"
-								@archive-thread="handleArchive(mail)"
-								@trash-thread="handleTrash(mail)"
-								@set-flagged="(flagged: boolean) => handleSetFlagged(mail, flagged)"
-							/>
+							<!-- A stack row stands in for a run of look-alike threads; when expanded, its
+							     members follow it as ordinary (indented) rows — the same model as the
+							     mailbox list. No delete handler: Delete only shows once every member is
+							     already in Trash, which the merged inbox list can't reach. -->
+							<template v-for="row in rows" :key="row.key">
+								<StackListItem
+									v-if="row.type === 'stack'"
+									:threads="row.threads"
+									:expanded="row.expanded"
+									:is-selected="false"
+									:selectable="false"
+									:hide-avatar="!isMobile"
+									class="border-l-transparent sm:border-l"
+									:class="{ '!border-l-outline-blue-5': focusedRowKey === row.key }"
+									:data-row-key="row.key"
+									@toggle="toggleStack(row)"
+									@set-seen="(seen: boolean) => stackSetSeen(row.threads, seen)"
+									@archive-threads="stackArchive(row.threads)"
+									@trash-threads="stackTrash(row.threads)"
+								/>
+								<MailListItem
+									v-else
+									:mailbox="row.thread.inbox || ''"
+									:account-id="row.thread.account"
+									:account-label="row.thread.account_name || undefined"
+									:mail="row.thread"
+									:is-selected="false"
+									:selectable="false"
+									thread-route-name="mail-all-inboxes-mail"
+									:hide-avatar="!isMobile"
+									:hide-sender="row.inStack"
+									class="border-l-transparent sm:border-l"
+									:class="{
+										'!bg-surface-blue-1': row.thread.thread_id === threadID && !isMobile,
+										'!border-l-outline-blue-5': focusedRowKey === row.key,
+										'!pl-10 sm:!pl-12': row.inStack,
+									}"
+									:data-row-key="row.key"
+									@set-seen="(seen: boolean) => handleSetSeen(row.thread, seen)"
+									@archive-thread="handleArchive(row.thread)"
+									@trash-thread="handleTrash(row.thread)"
+									@set-flagged="(flagged: boolean) => handleSetFlagged(row.thread, flagged)"
+								/>
+							</template>
 						</template>
 					</div>
 					<!-- Infinite-scroll sentinel: entering the viewport near the list bottom loads the next
@@ -219,6 +241,7 @@ import {
 	useGPrefix,
 	useRowScroll,
 } from '@/apps/mail/utils/listNavigation'
+import { buildListRows, type ListRow, type StackRow } from '@/apps/mail/utils/threadStacks'
 import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
@@ -228,6 +251,7 @@ import LoadingBar from '@/apps/mail/components/LoadingBar.vue'
 import MailListItem from '@/apps/mail/components/MailListItem.vue'
 import MailThread from '@/apps/mail/components/MailThread.vue'
 import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
+import StackListItem from '@/apps/mail/components/StackListItem.vue'
 
 import type { Thread, UserResource } from '@/apps/mail/types'
 
@@ -386,9 +410,11 @@ const refreshCounts = () => store.mailboxes.reload()
 const resetThreads = () => {
 	refreshMode.value = false
 	epoch.value++
-	// A reset replaces the list with a fresh first window, so any prior collapse no longer maps to what's
-	// shown — clear it (else a group collapsed under one filter stays collapsed and hides its threads).
+	// A reset replaces the list with a fresh first window, so any prior collapse or stack expansion no
+	// longer maps to what's shown — clear them (else a group collapsed under one filter stays collapsed
+	// and hides its threads).
 	collapsedGroups.value = []
+	expandedStacks.value = new Set()
 	threads.reload()
 	refreshCounts()
 }
@@ -472,21 +498,47 @@ const handleKeyDown = (e: KeyboardEvent) => {
 	focusRow(stepFromKey(navigableRows.value, focusedRowKey.value, offset))
 }
 
-// What the cursor can land on, in render order: each day's header, then that day's threads unless
-// it is collapsed. Walking the loaded threads instead skipped the headers and — worse — stepped
-// onto threads hidden inside a collapsed day, where the marker simply vanished.
-type NavEntry =
-	| { type: 'group'; key: string; dateKey: string }
-	| { type: 'thread'; key: string; threadID: string }
+// Chatty senders collapse into stacks exactly as in the mailbox list — buildListRows keys runs by
+// account + day + sender, so a run never mixes accounts even here. Expansion is tracked by member
+// id (see MailboxView) so a run keeps its state as infinite scroll grows it.
+const expandedStacks = ref(new Set<string>())
+
+const isRunExpanded = (run: Thread[]) => run.some((t) => expandedStacks.value.has(t.thread_id))
+
+const groupedRows = computed<Record<string, ListRow[]>>(() =>
+	Object.fromEntries(
+		Object.entries(groupedThreads.value).map(([key, group]) => [
+			key,
+			buildListRows(group, { rowKey: (t: Thread) => t.thread_id, isExpanded: isRunExpanded }),
+		]),
+	),
+)
+
+const toggleStack = (row: StackRow) => {
+	// The cursor follows the click, and the fold: the stack row now stands for its hidden members.
+	focusedRowKey.value = row.key
+	const ids = row.threads.map((t) => t.thread_id)
+	if (!row.expanded) return ids.forEach((id) => expandedStacks.value.add(id))
+
+	ids.forEach((id) => expandedStacks.value.delete(id))
+	// Don't leave the reading pane pointing at a row we just hid.
+	if (threadID && ids.includes(threadID))
+		router.push({ name: 'mail-all-inboxes', query: route.query })
+}
+
+// What the cursor can land on, in render order: each day's header, then that day's rows — a
+// collapsed stack is a single stop (its members aren't rendered) — unless the day is collapsed.
+// Walking the loaded threads instead skipped the headers and — worse — stepped onto threads
+// hidden inside a collapsed day or stack, where the marker simply vanished.
+type NavEntry = { type: 'group'; key: string; dateKey: string } | ListRow
 
 const navigableRows = computed<NavEntry[]>(() => {
 	const rows: NavEntry[] = []
-	for (const [dateKey, group] of Object.entries(groupedThreads.value)) {
+	for (const [dateKey, groupRows] of Object.entries(groupedRows.value)) {
 		if (groupMessagesBy.value !== 'None' && !isMobile.value)
 			rows.push({ type: 'group', key: `group:${dateKey}`, dateKey })
 		if (!isMobile.value && collapsedGroups.value.includes(dateKey)) continue
-		for (const thread of group)
-			rows.push({ type: 'thread', key: thread.thread_id, threadID: thread.thread_id })
+		rows.push(...groupRows)
 	}
 	return rows
 })
@@ -505,21 +557,35 @@ const focusRow = (row?: NavEntry) => {
 	if (row) focusRowKey(row.key)
 }
 
-// Enter opens a thread, or folds the day the marker is sitting on.
+// Enter opens a thread, toggles the stack, or folds the day the marker is sitting on.
 const activateFocusedRow = () => {
 	const row = navigableRows.value.find((r) => r.key === focusedRowKey.value)
 	if (!row) return
-	if (row.type === 'thread') return openThread(row.threadID)
+	if (row.type === 'thread') return openThread(row.thread.thread_id)
+	if (row.type === 'stack') return toggleStack(row)
 	if (!isLastGroup(row.dateKey)) toggleGroupCollapse(row.dateKey)
 }
 
 // The open thread keeps its row in view, as the mailbox list does: stepping
 // prev/next or deep-linking scrolls the merged list along, and the cursor
-// follows so keyboard navigation resumes from it.
+// follows so keyboard navigation resumes from it. A step can land inside a
+// collapsed stack or a folded day — surface it, as the mailbox list does: an
+// opened thread is always visible in the list.
 watch(
 	() => threadID,
 	(val) => {
-		if (val) setTimeout(() => focusRowKey(val))
+		if (!val) return
+		expandedStacks.value.add(val)
+		// Deferred: the immediate run fires mid-setup, before collapsedGroups below exists.
+		setTimeout(() => {
+			for (const group of collapsedGroups.value) {
+				if (groupedThreads.value[group]?.some((t: Thread) => t.thread_id === val)) {
+					collapsedGroups.value = collapsedGroups.value.filter((d) => d !== group)
+					break
+				}
+			}
+			focusRowKey(val)
+		})
 	},
 	{ immediate: true },
 )
@@ -656,6 +722,56 @@ const handleTrash = (thread: Thread) => {
 	const restore = removeFromList(thread)
 	raiseOptimisticToast(moveThreadOut(thread, thread.trash!, restore), __('Thread moved to Trash.'))
 }
+
+// Stack actions. A stack's members share one account (it is part of the stack key), so a single
+// batched call covers the run — mirroring the mailbox's bulk handlers rather than firing one
+// request per member.
+const stackSetSeen = (threads: Thread[], seen: boolean) => {
+	const changed = threads.filter((t) => t.seen !== (seen ? 1 : 0))
+	if (!changed.length) return
+	const applySeen = (value: 0 | 1) =>
+		changed.forEach((t) => {
+			t.seen = value
+			t.messages?.forEach((m) => (m.seen = value))
+		})
+	applySeen(seen ? 1 : 0)
+	call('suite.mail.api.mail.set_mails_seen', {
+		account: threads[0].account,
+		ids: changed.flatMap(messageIds),
+		seen,
+	})
+		.then(refreshCounts)
+		.catch((error) => {
+			applySeen(seen ? 0 : 1) // revert the optimistic update
+			raiseToast(error?.messages?.[0] || error?.message, 'error')
+		})
+}
+
+// Restores run in reverse so each row splices back at the index captured when it was removed.
+const stackMoveOut = (threads: Thread[], mailboxId: string | undefined, done: string) => {
+	if (!mailboxId) return raiseToast(__('No such folder for this account.'), 'error')
+	const restores = threads.map(removeFromList)
+	const promise = call('suite.mail.api.mail.move_mails', {
+		account: threads[0].account,
+		ids: threads.flatMap(messageIds),
+		mailbox: mailboxId,
+		clear_junk: true,
+	}).then(refreshCounts, (error) => {
+		restores.reverse().forEach((restore) => restore())
+		throw error
+	})
+	raiseOptimisticToast(promise, done)
+}
+
+const stackArchive = (threads: Thread[]) =>
+	stackMoveOut(threads, threads[0].archive, __('{0} threads archived.', [String(threads.length)]))
+
+const stackTrash = (threads: Thread[]) =>
+	stackMoveOut(
+		threads,
+		threads[0].trash,
+		__('{0} threads moved to Trash.', [String(threads.length)]),
+	)
 
 // Filter
 const FILTER_OPTIONS = [

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -249,10 +249,9 @@ import {
 	stepFrom,
 	stepFromKey,
 	useGPrefix,
-	useRowScroll,
 } from '@/apps/mail/utils/listNavigation'
-import { buildListRows, type ListRow, type StackRow } from '@/apps/mail/utils/threadStacks'
 import { useScreenSize, useSwipeNav } from '@/apps/mail/utils/composables'
+import { useListRows } from '@/apps/mail/composables/useListRows'
 import {
 	PAGE_LENGTH,
 	usePaginatedThreads,
@@ -284,7 +283,6 @@ const route = useRoute()
 const router = useRouter()
 const socket = inject('$socket')
 const user = inject('$user') as UserResource
-const dayjs = inject('$dayjs')
 
 const store = userStore()
 
@@ -315,8 +313,8 @@ const {
 	fetchMore: () => loadMoreThreads.reload(),
 	openThreadID: () => threadID,
 	// A step off the loaded edge opens the appended thread when the pane is showing, and otherwise
-	// just takes the cursor there — the merged list's row keys are thread ids, so the id is the key.
-	onEdgeThread: (id, action) => (action === 'open' ? openThread(id) : focusRowKey(id)),
+	// just takes the cursor to it — onto whatever row stands for it (see rowForThread).
+	onEdgeThread: (id, action) => (action === 'open' ? openThread(id) : focusOnThread(id)),
 	threadKey,
 })
 
@@ -386,9 +384,32 @@ const refreshThreads = (reloadCounts = true) => {
 	if (reloadCounts) refreshCounts()
 }
 
-// Date grouping with collapsible headers (mirroring the per-mailbox view). The last group never
-// collapses — it's where infinite scroll appends, so hiding it would swallow newly loaded rows.
-const groupMessagesBy = computed(() => user.data.group_messages_by)
+// The rendered rows and the keyboard cursor: date groups, stacks, and the marker that walks them —
+// all shared with the mailbox list (see useListRows). Chatty senders stack here exactly as they do
+// there: buildListRows keys runs by account + day + sender, so a run never mixes accounts even in
+// this merged list.
+const {
+	groupMessagesBy,
+	isLastGroup,
+	collapsedGroups,
+	expandedStacks,
+	groupedRows,
+	navigableRows,
+	focusedRowKey,
+	focusedRow,
+	focusRow,
+	focusOnThread,
+	toggleStack,
+	toggleGroupCollapse,
+	revealThread,
+} = useListRows({
+	threads: () => threads.data ?? [],
+	// A thread's row key is its id, so the cursor can be pointed straight at a thread.
+	rowKey: (thread: Thread) => thread.thread_id,
+	openThreadID: () => threadID,
+	onOpenThreadHidden: () => closeThread(),
+	container: mailListRef,
+})
 
 // The loaded row the open thread belongs to. Every mutation reads its account/archive/trash
 // off the row, so the pane acts on the owning account without consulting the active one.
@@ -512,95 +533,20 @@ const handleKeyDown = (e: KeyboardEvent) => {
 	if (hasCursor(rows, focusedRowKey.value)) loadMoreThenOpenEdge(offset, 'focus')
 }
 
-// Chatty senders collapse into stacks exactly as in the mailbox list — buildListRows keys runs by
-// account + day + sender, so a run never mixes accounts even here. Expansion is tracked by member
-// id (see MailboxView) so a run keeps its state as infinite scroll grows it.
-const expandedStacks = ref(new Set<string>())
-
-const isRunExpanded = (run: Thread[]) => run.some((t) => expandedStacks.value.has(t.thread_id))
-
-const groupedRows = computed<Record<string, ListRow[]>>(() =>
-	Object.fromEntries(
-		Object.entries(groupedThreads.value).map(([key, group]) => [
-			key,
-			buildListRows(group, { rowKey: (t: Thread) => t.thread_id, isExpanded: isRunExpanded }),
-		]),
-	),
-)
-
-const toggleStack = (row: StackRow) => {
-	// The cursor follows the click, and the fold: the stack row now stands for its hidden members.
-	focusedRowKey.value = row.key
-	const ids = row.threads.map((t) => t.thread_id)
-	if (!row.expanded) return ids.forEach((id) => expandedStacks.value.add(id))
-
-	ids.forEach((id) => expandedStacks.value.delete(id))
-	// Don't leave the reading pane pointing at a row we just hid.
-	if (threadID && ids.includes(threadID)) closeThread()
-}
-
-// What the cursor can land on, in render order: each day's header, then that day's rows — a
-// collapsed stack is a single stop (its members aren't rendered) — unless the day is collapsed.
-// Walking the loaded threads instead skipped the headers and — worse — stepped onto threads
-// hidden inside a collapsed day or stack, where the marker simply vanished.
-type NavEntry = { type: 'group'; key: string; dateKey: string } | ListRow
-
-
-const navigableRows = computed<NavEntry[]>(() => {
-	const rows: NavEntry[] = []
-	for (const [dateKey, groupRows] of Object.entries(groupedRows.value)) {
-		if (groupMessagesBy.value !== 'None' && !isMobile.value)
-			rows.push({ type: 'group', key: `group:${dateKey}`, dateKey })
-		if (!isMobile.value && collapsedGroups.value.includes(dateKey)) continue
-		rows.push(...groupRows)
-	}
-	return rows
-})
-
-// A thread's row key is its id, so the open-thread watcher can keep passing one straight in.
-const focusedRowKey = ref<string>()
-
-const scrollRowIntoView = useRowScroll(mailListRef, isMobile)
-
-const focusRowKey = (key: string) => {
-	focusedRowKey.value = key
-	scrollRowIntoView(key)
-}
-
-const focusRow = (row?: NavEntry) => {
-	if (row) focusRowKey(row.key)
-}
-
 // Enter opens a thread, toggles the stack, or folds the day the marker is sitting on.
 const activateFocusedRow = () => {
-	const row = navigableRows.value.find((r) => r.key === focusedRowKey.value)
+	const row = focusedRow.value
 	if (!row) return
 	if (row.type === 'thread') return openThread(row.thread.thread_id)
 	if (row.type === 'stack') return toggleStack(row)
 	if (!isLastGroup(row.dateKey)) toggleGroupCollapse(row.dateKey)
 }
 
-// The open thread keeps its row in view, as the mailbox list does: stepping
-// prev/next or deep-linking scrolls the merged list along, and the cursor
-// follows so keyboard navigation resumes from it. A step can land inside a
-// collapsed stack or a folded day — surface it, as the mailbox list does: an
-// opened thread is always visible in the list.
+// The open thread keeps its row in view, as the mailbox list does: stepping prev/next or deep-linking
+// scrolls the merged list along, and the cursor follows so keyboard navigation resumes from it.
 watch(
 	() => threadID,
-	(val) => {
-		if (!val) return
-		expandedStacks.value.add(val)
-		// Deferred: the immediate run fires mid-setup, before collapsedGroups below exists.
-		setTimeout(() => {
-			for (const group of collapsedGroups.value) {
-				if (groupedThreads.value[group]?.some((t: Thread) => t.thread_id === val)) {
-					collapsedGroups.value = collapsedGroups.value.filter((d) => d !== group)
-					break
-				}
-			}
-			focusRowKey(val)
-		})
-	},
+	(val) => val && revealThread(val),
 	{ immediate: true },
 )
 
@@ -639,40 +585,9 @@ const moveOpenThread = (mailboxId: string) => {
 	)
 }
 
-const groupedThreads = computed<Record<string, Thread[]>>(() =>
-	(threads.data ?? []).reduce((groups: Record<string, Thread[]>, thread: Thread) => {
-		const date = dayjs(thread.received_at).format(
-			groupMessagesBy.value === 'Day' ? 'YYYY-MM-DD' : 'YYYY-MM',
-		)
-		if (!groups[date]) groups[date] = []
-		groups[date].push(thread)
-		return groups
-	}, {}),
-)
-
-const isLastGroup = (key: string) => Object.keys(groupedThreads.value).at(-1) === key
-
-const collapsedGroups = ref<string[]>([])
-
 // Keep infinite scroll alive while the rendered list is too short to scroll (see topUpIfShort). Must
 // stay below groupedRows: `watch` reads its source at setup.
 watch(groupedRows, topUpIfShort)
-
-const toggleGroupCollapse = (key: string) => {
-	// The cursor follows the click, as it does when you open a mail — above the
-	// last-group guard, so clicking a header that can't fold still takes it.
-	focusedRowKey.value = `group:${key}`
-	if (isLastGroup(key)) return
-
-	if (collapsedGroups.value.includes(key))
-		return (collapsedGroups.value = collapsedGroups.value.filter((d) => d !== key))
-
-	collapsedGroups.value.push(key)
-	// Don't leave the reading pane pointing at a row we just hid.
-	if (groupedThreads.value[key]?.some((t: Thread) => t.thread_id === threadID)) closeThread()
-}
-
-watch(groupMessagesBy, () => (collapsedGroups.value = []))
 
 // Per-item actions — each row carries its own account + that account's mailbox ids, so actions target
 // the correct JMAP account without touching the active-account state.

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -115,7 +115,9 @@
 								class="border-l-transparent sm:border-l"
 								:class="{
 									'!bg-surface-blue-1': mail.thread_id === threadID && !isMobile,
+									'!border-l-outline-blue-5': mail.thread_id === focusedThreadID,
 								}"
+								:data-thread-row="mail.thread_id"
 								@set-seen="(seen: boolean) => handleSetSeen(mail, seen)"
 								@archive-thread="handleArchive(mail)"
 								@trash-thread="handleTrash(mail)"
@@ -201,7 +203,12 @@ import {
 import { Breadcrumbs, Button, Dropdown, Tooltip, call, createResource, usePageMeta } from 'frappe-ui'
 
 import { getFormattedDate, raiseOptimisticToast, raiseToast, shouldIgnoreKeypress } from '@/apps/mail/utils'
-import { isNavigationKey, navigationOffset, stepFrom } from '@/apps/mail/utils/listNavigation'
+import {
+	isNavigationKey,
+	navigationOffset,
+	stepFrom,
+	useGPrefix,
+} from '@/apps/mail/utils/listNavigation'
 import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
@@ -414,19 +421,67 @@ const stepOpenThread = (offset: number) => {
 
 // Up/down/j/k walk the list, or the open thread when one is showing. The merged list is flat —
 // no stacks, no day headers, no selection — so a step is just the neighbouring row.
+const gPrefix = useGPrefix()
+
 const handleKeyDown = (e: KeyboardEvent) => {
 	const key = e.key.toLowerCase()
-	if (!isNavigationKey(key) || shouldIgnoreKeypress(e)) return
+	if (shouldIgnoreKeypress(e)) return
 
+	// Escape backs out of the open thread, then clears the cursor.
+	if (key === 'escape') {
+		e.preventDefault()
+		if (threadID) return router.push({ name: 'mail-all-inboxes', query: route.query })
+		focusedThreadID.value = undefined
+		return
+	}
+
+	if (key === 'enter') {
+		if (!focusedThreadID.value) return
+		e.preventDefault()
+		return openThread(focusedThreadID.value)
+	}
+
+	// `g g` to the top, `G` to the bottom of what is loaded.
+	if (key === 'g') {
+		e.preventDefault()
+		const intent = gPrefix.press(e.shiftKey)
+		if (intent === 'first') return goToEdge(0)
+		if (intent === 'last') return goToEdge(-1)
+		return
+	}
+	gPrefix.disarm()
+
+	if (!isNavigationKey(key)) return
 	e.preventDefault()
 	const offset = navigationOffset(key)
 
 	if (threadID) return stepOpenThread(offset)
 
-	// With no thread open the keys still move through the list, opening as they go, which is what
-	// Split View makes useful: the pane follows the cursor.
-	const next = stepFrom(openThreadIDs.value, threadID, offset)
-	if (next) openThread(next)
+	// With no thread open the keys move the cursor without opening anything, as the mailbox list
+	// does — Enter opens what the marker is on.
+	const next = stepFrom(openThreadIDs.value, focusedThreadID.value, offset)
+	if (next) focusThread(next)
+}
+
+// The keyboard cursor: a thread id, since the merged list has no stacks or day headers to land on.
+const focusedThreadID = ref<string>()
+
+const focusThread = (nextThreadID: string) => {
+	focusedThreadID.value = nextThreadID
+	nextTick(() => {
+		document
+			.querySelector(`[data-thread-row="${nextThreadID}"]`)
+			?.scrollIntoView({ block: 'nearest' })
+	})
+}
+
+// `at()` so -1 reads as the last loaded thread. With a thread open the jump opens the edge one;
+// otherwise it just moves the cursor there, mirroring the mailbox list.
+const goToEdge = (index: number) => {
+	const next = openThreadIDs.value.at(index)
+	if (!next) return
+	if (threadID) return openThread(next)
+	focusThread(next)
 }
 
 const openThread = (nextThreadID: string) => {

--- a/frontend/src/apps/mail/pages/MailLayout.vue
+++ b/frontend/src/apps/mail/pages/MailLayout.vue
@@ -8,21 +8,25 @@
 			<router-view />
 		</component>
 		<InstallPrompt v-if="isMobile" />
+		<ShortcutsModal v-model="showShortcuts" />
 	</FrappeUIProvider>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, provide, watchEffect } from 'vue'
+import { computed, onMounted, onUnmounted, provide, ref, watchEffect } from 'vue'
 import { useRoute } from 'vue-router'
 import { FrappeUIProvider } from 'frappe-ui'
 
 import { mailServerUnavailable } from '@/boot/config'
+import { useRouter } from 'vue-router'
 import { shouldIgnoreKeypress } from '@/apps/mail/utils'
+import { useGPrefix } from '@/apps/mail/utils/listNavigation'
 import { useScreenSize, useTheme } from '@/apps/mail/utils/composables'
 import { showNotification } from '@/apps/mail/utils/push-notifications'
 import { initSocket } from '@/apps/mail/socket'
 import dayjs from '@/apps/mail/utils/dayjs'
 import { userStore } from '@/apps/mail/stores/user'
+import ShortcutsModal from '@/apps/mail/components/Modals/ShortcutsModal.vue'
 import DefaultLayout from '@/apps/mail/components/DefaultLayout.vue'
 import InstallPrompt from '@/apps/mail/components/InstallPrompt.vue'
 import MailServerUnavailableView from '@/apps/mail/components/MailServerUnavailableView.vue'
@@ -44,7 +48,50 @@ import type { NotificationPayload } from '@/apps/mail/types'
  * Public pre-auth routes (login/signup/...) sit OUTSIDE this layout since they
  * do not need the $user/$dayjs/$socket injects.
  */
-const { userResource } = userStore()
+const { userResource, mailboxIds, accountId } = userStore()
+const router = useRouter()
+
+// `?` and the `g`+letter mailbox jumps belong to the whole non-admin app, not to whichever
+// list happens to be mounted: they were only reachable from a mailbox view before, so they
+// died in All Inboxes, the Screener and the settings pages. The admin dashboard sits under
+// its own layout and never sees these.
+const showShortcuts = ref(false)
+const gPrefix = useGPrefix()
+
+// `g` is also the prefix each list uses for its own g g / G jump to the ends. Both listeners
+// see the key and keep their own prefix state; this one only ever acts on a following letter,
+// so a `g g` falls through to the list untouched.
+const MAILBOX_KEYS: Record<string, () => string> = {
+	i: () => mailboxIds.inbox,
+	f: () => 'starred',
+	s: () => mailboxIds.sent,
+	d: () => mailboxIds.drafts,
+	j: () => mailboxIds.junk,
+	a: () => mailboxIds.archive,
+	t: () => mailboxIds.trash,
+}
+
+const handleGlobalShortcuts = (e: KeyboardEvent) => {
+	const key = e.key.toLowerCase()
+	if (shouldIgnoreKeypress(e)) return
+
+	if (e.key === '?') {
+		e.preventDefault()
+		showShortcuts.value = true
+		return
+	}
+
+	if (gPrefix.armed.value) {
+		const mailbox = MAILBOX_KEYS[key]?.()
+		gPrefix.disarm()
+		if (!mailbox) return
+		e.preventDefault()
+		router.push({ name: 'mail-mailbox', params: { accountId, mailbox } })
+		return
+	}
+
+	if (key === 'g') gPrefix.press(e.shiftKey)
+}
 const { dataTheme, cycleTheme } = useTheme()
 const { isMobile } = useScreenSize()
 const route = useRoute()
@@ -184,11 +231,13 @@ onMounted(() => {
 		showNotification(payload),
 	)
 	window.addEventListener('keydown', handleThemeShortcut)
+	window.addEventListener('keydown', handleGlobalShortcuts)
 	window.addEventListener('focusout', resetDocumentScroll)
 })
 
 onUnmounted(() => {
 	window.removeEventListener('keydown', handleThemeShortcut)
+	window.removeEventListener('keydown', handleGlobalShortcuts)
 	window.removeEventListener('focusout', resetDocumentScroll)
 })
 </script>

--- a/frontend/src/apps/mail/pages/MailLayout.vue
+++ b/frontend/src/apps/mail/pages/MailLayout.vue
@@ -18,7 +18,7 @@ import { useRoute } from 'vue-router'
 import { FrappeUIProvider } from 'frappe-ui'
 
 import { mailServerUnavailable } from '@/boot/config'
-import { useRouter } from 'vue-router'
+import { type RouteLocationRaw, useRouter } from 'vue-router'
 import { shouldIgnoreKeypress } from '@/apps/mail/utils'
 import { useGPrefix } from '@/apps/mail/utils/listNavigation'
 import { useScreenSize, useTheme } from '@/apps/mail/utils/composables'
@@ -61,14 +61,24 @@ const gPrefix = useGPrefix()
 // `g` is also the prefix each list uses for its own g g / G jump to the ends. Both listeners
 // see the key and keep their own prefix state; this one only ever acts on a following letter,
 // so a `g g` falls through to the list untouched.
-const MAILBOX_KEYS: Record<string, () => string> = {
-	i: () => mailboxIds.inbox,
-	f: () => 'starred',
-	s: () => mailboxIds.sent,
-	d: () => mailboxIds.drafts,
-	j: () => mailboxIds.junk,
-	a: () => mailboxIds.archive,
-	t: () => mailboxIds.trash,
+// `g` then a letter. Beyond the account's own folders this reaches the two views that are not
+// folders at all — the merged list and the Screener — so the map holds routes, not mailbox ids.
+//
+// `a` is All Inboxes (as in Gmail's All Mail), which pushes Archive to `e` — the letter that
+// already archives a thread, so one letter means archive throughout. The Screener takes `r` for
+// review: `s` is Sent, and `c` would collide with Contacts if that ever gets a jump.
+const mailboxRoute = (mailbox: string) => ({ name: 'mail-mailbox', params: { accountId, mailbox } })
+
+const GO_TO_KEYS: Record<string, () => RouteLocationRaw> = {
+	a: () => ({ name: 'mail-all-inboxes' }),
+	r: () => ({ name: 'mail-screener', params: { accountId } }),
+	i: () => mailboxRoute(mailboxIds.inbox),
+	f: () => mailboxRoute('starred'),
+	s: () => mailboxRoute(mailboxIds.sent),
+	d: () => mailboxRoute(mailboxIds.drafts),
+	j: () => mailboxRoute(mailboxIds.junk),
+	e: () => mailboxRoute(mailboxIds.archive),
+	t: () => mailboxRoute(mailboxIds.trash),
 }
 
 const handleGlobalShortcuts = (e: KeyboardEvent) => {
@@ -82,11 +92,11 @@ const handleGlobalShortcuts = (e: KeyboardEvent) => {
 	}
 
 	if (gPrefix.armed.value) {
-		const mailbox = MAILBOX_KEYS[key]?.()
+		const destination = GO_TO_KEYS[key]?.()
 		gPrefix.disarm()
-		if (!mailbox) return
+		if (!destination) return
 		e.preventDefault()
-		router.push({ name: 'mail-mailbox', params: { accountId, mailbox } })
+		router.push(destination)
 		return
 	}
 

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -1240,7 +1240,8 @@ const onResetSuccess = () => {
 // account, so each row opens in — and acts within — its own account (see the row-action wrappers).
 const isAllAccountsSearch = computed(() => mailbox === 'search' && route.query.all_accounts != null)
 
-// The row's account, by its short name (the local part, unless two accounts share one).
+// The row's account, by its short name: blank for the currently open account (only
+// the odd ones out get labelled), the local part otherwise, unless two accounts share one.
 const shortAccountLabel = (name?: string | null) =>
 	name ? (store.accountShortNames[name] ?? name) : undefined
 

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -251,42 +251,33 @@
 						class="h-full overflow-y-auto overscroll-contain max-sm:pb-20"
 					>
 						<div v-for="(group, key) in groupedThreads" :key="key">
-							<div
+							<MailGroupHeader
 								v-if="groupMessagesBy !== 'None' && !isMobile"
-								class="text-ink-gray-6 group flex items-center border-b border-l-transparent p-3.5 text-xs-semibold sm:border-l sm:px-5"
-								:class="{
-									'!bg-surface-blue-1': isGroupSelected(key),
-									'sm:hover:bg-surface-gray-1': !isLastGroup(key),
-									'!border-l-outline-blue-5': focusedRowKey === `group:${key}`,
-								}"
-								:data-row-key="`group:${key}`"
-								@click="toggleGroupCollapse(key)"
+								:date-key="key"
+								:monthly="groupMessagesBy === 'Month'"
+								:collapsed="collapsedGroups.includes(key)"
+								:collapsible="!isLastGroup(key)"
+								:focused="focusedRowKey === `group:${key}`"
+								:selected="isGroupSelected(key)"
+								@toggle="toggleGroupCollapse(key)"
 							>
 								<!-- Mobile: group select ("all of Today") appears only in selection mode. -->
-								<div
-									v-if="!isAllAccountsSearch && (!isMobile || mobileSelectionMode)"
-									class="pr-7.5 checkbox-hitbox -m-3 cursor-pointer py-3 pl-3"
-									@click.stop.prevent="
-										toggleSelect(getGroupThreads(key), !isGroupSelected(key))
-									"
-								>
-									<Checkbox
-										:model-value="isGroupSelected(key)"
-										size="md"
-										class="pointer-events-none"
-									/>
-								</div>
-
-								<span class="select-none pt-[2px]">
-									{{ getFormattedDate(key, groupMessagesBy === 'Month').toUpperCase() }}
-								</span>
-
-								<component
-									:is="collapsedGroups.includes(key) ? ChevronRight : ChevronDown"
-									v-if="!isLastGroup(key)"
-									class="icon ml-auto"
-								/>
-							</div>
+								<template #lead>
+									<div
+										v-if="!isAllAccountsSearch && (!isMobile || mobileSelectionMode)"
+										class="pr-7.5 checkbox-hitbox -m-3 cursor-pointer py-3 pl-3"
+										@click.stop.prevent="
+											toggleSelect(getGroupThreads(key), !isGroupSelected(key))
+										"
+									>
+										<Checkbox
+											:model-value="isGroupSelected(key)"
+											size="md"
+											class="pointer-events-none"
+										/>
+									</div>
+								</template>
+							</MailGroupHeader>
 							<template v-if="isMobile || !collapsedGroups.includes(key)">
 								<!-- A stack row stands in for a run of look-alike threads; when expanded, its
 								     members follow it as ordinary (indented) rows. -->
@@ -298,8 +289,7 @@
 										:threads="row.threads"
 										:expanded="row.expanded"
 										:is-selected="isStackSelected(row.threads)"
-										class="border-l-transparent sm:border-l"
-										:class="{ '!border-l-outline-blue-5': row.key === focusedRowKey }"
+										:class="rowClasses(row)"
 										:data-row-key="row.key"
 										@toggle="toggleStack(row)"
 										@set-seen="(seen: boolean) => stackSetSeen(row.threads, seen)"
@@ -326,13 +316,7 @@
 										:selection-mode="mobileSelectionMode"
 										:is-selected="selections.includes(row.thread.thread_id)"
 										:hide-sender="row.inStack"
-										class="border-l-transparent sm:border-l"
-										:class="{
-											'!bg-surface-blue-1':
-												row.thread.thread_id === threadID && !isMobile,
-											'!border-l-outline-blue-5': row.key === focusedRowKey,
-											'!pl-10 sm:!pl-12': row.inStack,
-										}"
+										:class="rowClasses(row)"
 										:data-row-key="row.key"
 										@set-seen="(seen: boolean) => rowSetSeen(row.thread, seen)"
 										@archive-thread="rowArchive(row.thread)"
@@ -494,7 +478,6 @@ import { useRoute, useRouter } from 'vue-router'
 import {
 	Archive,
 	ChevronDown,
-	ChevronRight,
 	CircleAlert,
 	CircleCheck,
 	Ellipsis,
@@ -523,7 +506,6 @@ import {
 } from 'frappe-ui'
 
 import {
-	getFormattedDate,
 	isMac,
 	raisePromiseToast,
 	raiseToast,
@@ -556,6 +538,7 @@ import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import LoadingBar from '@/apps/mail/components/LoadingBar.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
+import MailGroupHeader from '@/apps/mail/components/MailGroupHeader.vue'
 import MailListItem from '@/apps/mail/components/MailListItem.vue'
 import MailThread from '@/apps/mail/components/MailThread.vue'
 import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
@@ -647,6 +630,7 @@ const {
 	focusedRow,
 	focusRow,
 	focusOnThread,
+	rowClasses,
 	toggleStack,
 	toggleGroupCollapse,
 	revealThread,

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -504,8 +504,6 @@ import {
 	LoaderCircle,
 	Mail as MailIcon,
 	MailOpen,
-	Mails,
-	Paperclip,
 	RefreshCw,
 	Star,
 	StarOff,
@@ -546,6 +544,7 @@ import {
 	useSwipeNav,
 	useUndo,
 } from '@/apps/mail/utils/composables'
+import { useStoredFilter } from '@/apps/mail/utils/listFilter'
 import { useListRows } from '@/apps/mail/composables/useListRows'
 import {
 	PAGE_LENGTH,
@@ -1138,9 +1137,15 @@ watch(
 
 // Main data
 
-const filter = ref<string | null>(
-	localStorage.getItem(`user:${user.data.name}:filter:${mailbox}`) || null,
-)
+// The remembered All/Unread/Starred/Has-attachments choice, its menu, and its own title (see
+// useStoredFilter) — all shared with the merged All Inboxes list. Starred is not offered inside
+// Trash, nor inside the Starred list itself, where it would filter a list to itself.
+const { filter, reloadFilter, FILTER_OPTIONS, filterTitle } = useStoredFilter({
+	scope: () => mailbox,
+	onChange: () => resetThreads(false),
+	starrable: () => ![mailboxIds.trash, 'starred'].includes(mailbox),
+})
+
 const isMailboxLoaded = ref(false)
 
 // Reset resource for a mailbox: always the first window. Over-fetches one row (PAGE_LENGTH + 1) to
@@ -1321,7 +1326,7 @@ watch(
 
 		isMailboxLoaded.value = false
 		threadsResource.value.data = []
-		filter.value = localStorage.getItem(`user:${user.data.name}:filter:${mailbox}`) || null
+		reloadFilter()
 		focusedRowKey.value = undefined
 		collapsedGroups.value = []
 		// Stacks re-collapse on a mailbox switch. Note a *filter* change deliberately doesn't clear
@@ -1584,38 +1589,6 @@ const emptyMailboxOptions = computed(() => ({
 	],
 }))
 
-// Filter
-
-const FILTER_OPTIONS = [
-	{
-		label: __('All'),
-		icon: Mails,
-		onClick: () => setFilter(null),
-	},
-	{
-		label: __('Unread'),
-		icon: MailIcon,
-		onClick: () => setFilter('unread'),
-	},
-	{
-		label: __('Starred'),
-		icon: Star,
-		onClick: () => setFilter('starred'),
-		condition: () => ![mailboxIds.trash, 'starred'].includes(mailbox),
-	},
-	{
-		label: __('Has attachments'),
-		icon: Paperclip,
-		onClick: () => setFilter('has_attachments'),
-	},
-]
-
-const setFilter = (value: string | null) => {
-	filter.value = value
-	localStorage.setItem(`user:${user.data.name}:filter:${mailbox}`, value ?? '')
-	resetThreads(false)
-}
-
 // UI formatting
 
 const mailboxName = computed(() => {
@@ -1655,16 +1628,7 @@ const title = computed(() => {
 			: __('{0} results', [String(searchTotal.value)])
 	}
 
-	switch (filter.value) {
-		case 'unread':
-			return __('Unread Mails')
-		case 'starred':
-			return __('Starred Mails')
-		case 'has_attachments':
-			return __('With Attachments')
-		default:
-			return __('All Mails')
-	}
+	return filterTitle.value
 })
 
 // The search modal lives in HeaderActions but is opened from two places — its own button, and the

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -319,7 +319,7 @@
 									:mail="row.thread"
 									:account-id="isAllAccountsSearch ? row.thread.account : undefined"
 									:account-label="
-										isAllAccountsSearch ? row.thread.account_name : undefined
+										isAllAccountsSearch ? shortAccountLabel(row.thread.account_name) : undefined
 									"
 									:selectable="!isAllAccountsSearch"
 									:selection-mode="mobileSelectionMode"
@@ -1239,6 +1239,10 @@ const onResetSuccess = () => {
 // the query (kept out of the filter conditions on the server). The merged results carry their owning
 // account, so each row opens in — and acts within — its own account (see the row-action wrappers).
 const isAllAccountsSearch = computed(() => mailbox === 'search' && route.query.all_accounts != null)
+
+// The row's account, by its short name (the local part, unless two accounts share one).
+const shortAccountLabel = (name?: string | null) =>
+	name ? (store.accountShortNames[name] ?? name) : undefined
 
 // The mobile Search tab lands on this route with no query yet. There's nothing to fetch —
 // an empty filter would run an unbounded search — so the list area shows a hint instead

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -185,7 +185,7 @@
 								v-if="!selections.length"
 								variant="ghost"
 								:tooltip="__('Refresh')"
-								:disabled="threadsResource?.loading || loadingMore"
+								:disabled="isFetching"
 								@click="refreshThreads()"
 							>
 								<template #icon>
@@ -489,9 +489,8 @@
 
 </template>
 <script setup lang="ts">
-import { computed, inject, nextTick, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
+import { computed, inject, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { useIntersectionObserver } from '@vueuse/core'
 import {
 	Archive,
 	ChevronDown,
@@ -549,6 +548,10 @@ import {
 	useUndo,
 } from '@/apps/mail/utils/composables'
 import { buildListRows } from '@/apps/mail/utils/threadStacks'
+import {
+	PAGE_LENGTH,
+	usePaginatedThreads,
+} from '@/apps/mail/composables/usePaginatedThreads'
 import { useThreadActions } from '@/apps/mail/utils/useThreadActions'
 import { type MailboxRole, userStore } from '@/apps/mail/stores/user'
 import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
@@ -752,7 +755,6 @@ watch(
 // Selection
 
 const mailThreadRef = useTemplateRef('mailThread')
-const mailListRef = useTemplateRef('mailList')
 
 const selections = ref<string[]>([])
 
@@ -1108,29 +1110,35 @@ const selectActions = computed((): SelectAction[] => [
 
 // Search
 
-// Infinite-scroll state (shared by the threads and search resources — only one is active at a time)
-const PAGE_LENGTH = 25
-const hasMore = ref(false) // lookahead: the last fetched window returned an extra row, so more exist
-const loadingMore = ref(false) // an append fetch is in flight (drives the bottom spinner)
+// Infinite scroll (shared by the threads and search resources — only one is active at a time).
+// usePaginatedThreads owns the state between the reset and append fetches: the epochs, the refresh
+// merge, the removal suppression, the sentinel, the edge crossing. See there.
+const {
+	container: mailListRef,
+	hasMore,
+	loadingMore,
+	isFetching,
+	canGoNext,
+	threadIDs,
+	takeResetWindow,
+	beginReset,
+	beginRefresh,
+	onResetSuccess,
+	appendThreads,
+	loadMoreThenOpenEdge,
+	topUpIfShort,
+	suppressRemoved,
+	unsuppressRemoved,
+} = usePaginatedThreads({
+	resource: () => threadsResource.value,
+	fetchMore: () => (mailbox === 'search' ? loadMoreSearch : loadMoreThreads).reload(),
+	openThreadID: () => threadID,
+	onEdgeThread: (id, action) => (action === 'open' ? goToThread(id) : focusOnThread(id)),
+})
+
 // An optimistic removal emptied the list but more threads exist, so a refill is coming once the server
 // mutation lands. Keeps the loading state (not the empty state) during the gap before the refill fetch.
 const refillPending = ref(false)
-// Bumped on every reset-to-top; an in-flight append captures it and discards its result if it changed
-// meanwhile, so a stale window can't land on a freshly reset list.
-const epoch = ref(0)
-let loadEpoch = 0 // epoch captured when the current append was triggered
-// Refresh ("check for new mail") state: merges the newest window into the loaded list, preserving
-// scroll — set while such a reload is in flight so its onSuccess prepends instead of replacing.
-const refreshMode = ref(false)
-let refreshEpoch = 0 // epoch captured when the refresh was triggered (dropped if a reset intervenes)
-// The loaded list to merge the fresh window into. Captured at *response* time (in the resource
-// transform), not refresh-start, so it reflects any optimistic removals/undo-inserts that happened
-// while the refresh was in flight — otherwise a thread archived mid-refresh would reappear.
-let refreshSnapshot: Thread[] = []
-// Thread ids optimistically removed by an action whose request is still in flight. The server still
-// returns these for a moment, so a refresh/append landing in that window would re-insert the row; the
-// merges below skip them. Cleared on rollback (restoreThreadsToList) and after a short timeout.
-const recentlyRemoved = new Set<string>()
 // Current mailbox's record (carries total_threads/unread_threads); used by the periodic poll to
 // detect count changes and by the tab title's unread badge.
 const mailboxObj = computed(() => mailboxes.data?.find((m) => m.id === mailbox))
@@ -1169,42 +1177,6 @@ const screenerBanner = computed(() => {
 })
 const goToScreener = () => router.push({ name: 'mail-screener', params: { accountId } })
 
-const scrollListToTop = () => mailListRef.value?.scrollTo({ top: 0 })
-
-// Called when a first-window fetch resolves. Two modes:
-// - refresh: keep the loaded rows, prepend only threads not already loaded (new mail), and hold the
-//   reader's scroll position (re-anchored by the height the prepended rows added).
-// - reset: reveal the fresh first window and scroll to top (mailbox switch, filter, undo, …).
-// Either way, cancel any pending edge navigation.
-const onResetSuccess = () => {
-	pendingEdgeThread = null
-
-	if (refreshMode.value) {
-		refreshMode.value = false
-		// A reset (mailbox switch, filter, undo) raced in and bumped the epoch — drop this stale merge.
-		if (refreshEpoch !== epoch.value) return
-		// Anchor to the current scroll before merging. The window replaced `data` a beat ago but the DOM
-		// hasn't re-rendered yet, so these still reflect the loaded list the reader is looking at.
-		const el = mailListRef.value
-		const prevTop = el?.scrollTop ?? 0
-		const prevHeight = el?.scrollHeight ?? 0
-		const freshWindow = threadsResource.value.data ?? []
-		const existing = new Set(refreshSnapshot.map((t) => t.thread_id))
-		const fresh = freshWindow.filter(
-			(t: Thread) => !existing.has(t.thread_id) && !recentlyRemoved.has(t.thread_id),
-		)
-		threadsResource.value.data = [...fresh, ...refreshSnapshot]
-		// Keep the reader where they were: shift scroll by the height the prepended rows added. If they
-		// were already at the top, leave them there so the new mail is visible.
-		nextTick(() => {
-			if (el && prevTop > 0) el.scrollTop = prevTop + (el.scrollHeight - prevHeight)
-		})
-		return
-	}
-
-	scrollListToTop()
-}
-
 // Cross-account search: when the search dialog's "all accounts" toggle was on, the flag rides along in
 // the query (kept out of the filter conditions on the server). The merged results carry their owning
 // account, so each row opens in — and acts within — its own account (see the row-action wrappers).
@@ -1235,10 +1207,8 @@ const searchResults = createResource({
 		all_accounts: isAllAccountsSearch.value,
 	}),
 	transform: (data: [Thread[], number]) => {
-		if (refreshMode.value) refreshSnapshot = threadsResource.value.data ?? []
-		hasMore.value = data[0].length > PAGE_LENGTH
 		searchTotal.value = data[1] ?? 0
-		return data[0].slice(0, PAGE_LENGTH)
+		return takeResetWindow(data[0])
 	},
 	onSuccess: () => {
 		onResetSuccess()
@@ -1276,14 +1246,7 @@ const threads = createResource({
 		start: 0,
 		filter_by: filter.value,
 	}),
-	transform: (data: [Thread[], string]) => {
-		// In refresh mode, snapshot the live loaded list now — before this window replaces it — so the
-		// merge in onResetSuccess reflects any optimistic removals/undo-inserts made during the fetch.
-		if (refreshMode.value) refreshSnapshot = threadsResource.value.data ?? []
-		const rows = data[0]
-		hasMore.value = rows.length > PAGE_LENGTH
-		return rows.slice(0, PAGE_LENGTH)
-	},
+	transform: (data: [Thread[], string]) => takeResetWindow(data[0]),
 	onSuccess: (data: [Thread[], string]) => {
 		onResetSuccess()
 		if (mailbox === data[1]) isMailboxLoaded.value = true
@@ -1303,29 +1266,10 @@ const showDeleteBanner = computed(
 		(showReadingPane.value || !threadID),
 )
 
-// ── Infinite scroll ─────────────────────────────────────────────────────────────────────────────
-// Two fetch paths that both write `threadsResource.value.data` — the single accumulated list every
-// consumer reads: the reset resources above replace it (start:0); the append resources below push the
-// next window onto it. Kept separate so createResource's replace-on-reload never fights the append.
-
-// Appends the next window onto the loaded list, deduped by thread_id. `start = data.length` stays
-// correct across optimistic removals (the server list shifts left by the same rows we dropped); the
-// only skew is new mail inserted at the front, which the dedupe absorbs and the next reset reconciles.
-const appendThreads = (rows: Thread[]) => {
-	loadingMore.value = false
-	// Discard a stale window that resolved after a reset began (mailbox switch, refresh, undo, …).
-	if (loadEpoch !== epoch.value) return
-	const seen = new Set(threadsResource.value.data.map((t: Thread) => t.thread_id))
-	const fresh = rows
-		.slice(0, PAGE_LENGTH)
-		.filter((t) => !seen.has(t.thread_id) && !recentlyRemoved.has(t.thread_id))
-	// Stop auto-loading if the window added nothing new (offset stuck behind heavy front-inserted mail);
-	// the next reset (poll/refresh/socket) reconciles. Guards against a tight reload loop while the
-	// sentinel stays in view.
-	hasMore.value = rows.length > PAGE_LENGTH && fresh.length > 0
-	threadsResource.value.data = [...threadsResource.value.data, ...fresh]
-	openPendingEdgeThread()
-}
+// ── Append fetches ──────────────────────────────────────────────────────────────────────────────
+// The other half of the two fetch paths that write `threadsResource.value.data`: the reset resources
+// above replace it (start:0), these push the next window onto it (via appendThreads). Kept separate so
+// createResource's replace-on-reload never fights the append.
 
 const loadMoreThreads = createResource({
 	url: 'suite.mail.api.mail.get_threads',
@@ -1353,59 +1297,9 @@ const loadMoreSearch = createResource({
 	onError: () => (loadingMore.value = false),
 })
 
-const loadMore = () => {
-	if (!hasMore.value || loadingMore.value || threadsResource.value.loading) return
-	loadingMore.value = true
-	loadEpoch = epoch.value
-	;(mailbox === 'search' ? loadMoreSearch : loadMoreThreads).reload()
-}
-
-const loadMoreSentinel = useTemplateRef('loadMoreSentinel')
-
-// True while the sentinel is in view.
-const sentinelVisible = ref(false)
-
-// The height the list had reached the last time we topped it up, so a fill that adds nothing can be
-// detected. Reset at the start of each fill episode (see below).
-let lastFillHeight = 0
-
-useIntersectionObserver(
-	loadMoreSentinel,
-	([entry]) => {
-		const entering = !!entry?.isIntersecting && !sentinelVisible.value
-		sentinelVisible.value = !!entry?.isIntersecting
-		if (entering) lastFillHeight = 0
-		if (sentinelVisible.value) loadMore()
-	},
-	{ root: mailListRef },
-)
-
-// Rescues the one case the observer cannot: the rendered list is too short to scroll, so the sentinel
-// can never leave and re-enter the viewport to fire again — infinite scroll would die with nothing left
-// to scroll. A window of 25 threads can collapse to a single stack row, so filling the viewport can take
-// several of them.
-//
-// Both guards are load-bearing. Stop once the list can scroll, because from there the user's own
-// scrolling drives the observer. And stop if a window added no height: its rows landed somewhere they
-// cannot be seen (a collapsed date group), so further windows would be just as invisible — without this,
-// collapsing a large group turns into a stampede that walks the entire mailbox 25 threads at a time.
-watch(groupedRows, () => {
-	if (!sentinelVisible.value || !hasMore.value) return
-
-	nextTick(() => {
-		const el = mailListRef.value
-		if (!el || !sentinelVisible.value) return
-
-		const grew = el.scrollHeight > lastFillHeight
-		lastFillHeight = el.scrollHeight
-		if (el.scrollHeight <= el.clientHeight && grew) loadMore()
-	})
-})
-
-// The reading pane's Next arrow can always advance while more threads remain to load (crossing the
-// last loaded thread triggers an append). The Prev arrow is disabled at the first loaded thread, which
-// is the first thread overall (we always start from the top).
-const canGoNext = computed(() => hasMore.value)
+// Keep infinite scroll alive while the rendered list is too short to scroll (see topUpIfShort). Must
+// stay below groupedRows: `watch` evaluates its source at setup.
+watch(groupedRows, topUpIfShort)
 
 const isLoading = computed(() => {
 	// Search is one page: its header (input + filter chips) mounts immediately and stays put
@@ -1417,10 +1311,6 @@ const isLoading = computed(() => {
 	if (refillPending.value) return true
 	return !threadsResource.value.data.length && threadsResource.value?.loading
 })
-
-const threadIDs = computed(
-	() => threadsResource.value.data?.map((thread: Thread) => thread.thread_id) || [],
-)
 
 // Reset-to-top: refetch only the first window, replacing the loaded list and scrolling to the top
 // (via onResetSuccess). Bumping `epoch` discards any append/refresh still in flight. Used for
@@ -1434,8 +1324,7 @@ const resetThreads: (reloadMailboxes?: boolean, mailboxRoles?: MailboxRole[]) =>
 	// This reload supersedes any pending refill (its own, or an interrupting mailbox switch); from here
 	// the resource's `loading` drives isLoading, so the flag has done its job.
 	refillPending.value = false
-	refreshMode.value = false
-	epoch.value++
+	beginReset()
 	resetSelections()
 	// Clear the previous search's count so the header doesn't show a stale total while the new fetch runs.
 	if (mailbox === 'search') {
@@ -1455,16 +1344,7 @@ const resetThreads: (reloadMailboxes?: boolean, mailboxRoles?: MailboxRole[]) =>
 // threads not already loaded (see onResetSuccess), keeping scroll position and the loaded rows. Used by
 // the Refresh button, the periodic poll, and the new-mail socket. Selections are preserved.
 const refreshThreads = (reloadMailboxes = true) => {
-	if (threadsResource.value.loading || loadingMore.value) return
-
-	refreshMode.value = true
-	// Bump the epoch so an append still in flight is discarded (appendThreads checks it) instead of
-	// landing after the merge and clobbering it. A new append can't start mid-refresh (loadMore bails
-	// while the resource is loading), so this fully closes the refresh/append race. The merge base
-	// (refreshSnapshot) and scroll anchor are captured later, at response time, so they reflect the list
-	// as it actually is when the window arrives — not a stale start-of-refresh copy.
-	epoch.value++
-	refreshEpoch = epoch.value
+	if (!beginRefresh()) return
 	threadsResource.value.reload()
 	if (reloadMailboxes) mailboxes.reload()
 }
@@ -1486,10 +1366,7 @@ const removeThreadsFromList = (thread_ids: string[]): Thread[] => {
 		(thread: Thread) => !thread_ids.includes(thread.thread_id),
 	)
 	// Suppress re-insertion by an in-flight refresh/append until the server-side removal lands.
-	thread_ids.forEach((id) => {
-		recentlyRemoved.add(id)
-		setTimeout(() => recentlyRemoved.delete(id), 15000)
-	})
+	suppressRemoved(thread_ids)
 	// If this emptied the list but more exist, a refill is coming (refillIfEmpty, once the mutation
 	// lands) — flag it so the empty state doesn't flash in the meantime.
 	if (!threadsResource.value.data.length && hasMore.value) refillPending.value = true
@@ -1514,7 +1391,7 @@ const restoreThreadsToList = (restored: Thread[]) => {
 	// Rows are back (removal failed / undo), so no refill is coming — drop the pending-refill hold.
 	refillPending.value = false
 	// A restored thread should be visible again — lift any removal suppression.
-	restored.forEach((t: Thread) => recentlyRemoved.delete(t.thread_id))
+	unsuppressRemoved(restored.map((t: Thread) => t.thread_id))
 	const list = [...(threadsResource.value.data ?? [])]
 	const present = new Set(list.map((t: Thread) => t.thread_id))
 	for (const thread of restored) {
@@ -1595,23 +1472,6 @@ const goToThread = (threadID: string) => {
 		router.push({ name: 'mail-mail', params: { accountId, mailbox, threadID }, query: route.query })
 }
 
-// Stepping past the last loaded thread loads the next window, then opens/focuses the newly appended
-// thread once it arrives (`openPendingEdgeThread`, called from the append's onSuccess). `action`
-// distinguishes the reading view (open) from list keyboard focus (focus). `anchor` is the thread we
-// stepped off (the previously-last loaded), captured so we can resolve its successor after the append.
-// There's no backward case — the first loaded thread is the first thread overall.
-let pendingEdgeThread: { action: 'open' | 'focus'; anchor: string | undefined } | null = null
-
-const loadMoreThenOpenEdge = (offset: number, action: 'open' | 'focus') => {
-	// One crossing at a time: ignore further edge steps until the append resolves, so key auto-repeat
-	// at the bottom of the list can't fire a burst of loads.
-	if (pendingEdgeThread || offset < 0 || !hasMore.value) return
-	// A focus crossing can only happen from the last navigable row, whose last thread is the last loaded
-	// one — so the tail anchors the successor without needing to map a row back to a thread.
-	pendingEdgeThread = { action, anchor: action === 'open' ? threadID : threadIDs.value.at(-1) }
-	loadMore()
-}
-
 const goToThreadByOffset = (offset: number) => {
 	const next = getThreadByOffset(offset)
 	if (next) return goToThread(next)
@@ -1634,17 +1494,6 @@ const { onTouchStart: onThreadTouchStart, onTouchEnd: onThreadTouchEnd } = useSw
 // (and left empty for every other thread change, which should swap instantly).
 const threadSlide = ref('')
 let pendingThreadSlide = ''
-
-const openPendingEdgeThread = () => {
-	if (!pendingEdgeThread) return
-	const { action, anchor } = pendingEdgeThread
-	// The successor of the anchor is now loaded (undefined only if nothing new arrived — then stop).
-	const id = getThreadByOffset(1, anchor)
-	pendingEdgeThread = null
-	if (!id) return
-	if (action === 'open') goToThread(id)
-	else focusOnThread(id)
-}
 
 const goToNextThreadOrMailbox = (excludedThreads: string[] = []) => {
 	const idx = threadIDs.value.indexOf(threadID)

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -574,6 +574,7 @@ import {
 	isNavigationKey,
 	navigationOffset,
 	stepFromKey,
+	useGPrefix,
 } from '@/apps/mail/utils/listNavigation'
 import {
 	useMobileSelection,
@@ -885,8 +886,7 @@ const showShortcuts = ref(false)
 const modifier = computed(() => (isMac ? '⌘' : 'Ctrl'))
 
 const isShiftPressed = ref(false)
-const isGPressed = ref(false)
-const gPressTimeout = ref<ReturnType<typeof setTimeout>>()
+const gPrefix = useGPrefix()
 const reloadInterval = ref<ReturnType<typeof setInterval>>()
 
 const handleKeyDown = (e: KeyboardEvent) => {
@@ -896,21 +896,21 @@ const handleKeyDown = (e: KeyboardEvent) => {
 	// Handle Ctrl/Cmd+A (Select All)
 	if ((e.metaKey || e.ctrlKey) && key === 'a' && !shouldIgnoreKeypress(e, true)) {
 		e.preventDefault()
-		isGPressed.value = false
+		gPrefix.disarm()
 		return toggleSelectAll(true)
 	}
 
 	// Handle Ctrl/Cmd+Z (Undo)
 	if ((e.metaKey || e.ctrlKey) && key === 'z' && !shouldIgnoreKeypress(e, true)) {
 		e.preventDefault()
-		isGPressed.value = false
+		gPrefix.disarm()
 		return undo()
 	}
 
 	if (shouldIgnoreKeypress(e)) return
 
 	if (key === 'g') return handleGKeyPress(e)
-	if (isGPressed.value) return handleGMenuNavigation(e, key)
+	if (gPrefix.armed.value) return handleGMenuNavigation(e, key)
 	if (key === 'enter') return handleEnter(e)
 	if (key === 'escape') return handleEscape(e)
 	if (key === '?') return handleShowShortcuts(e)
@@ -921,27 +921,23 @@ const handleKeyDown = (e: KeyboardEvent) => {
 }
 
 const handleGKeyPress = (e: KeyboardEvent) => {
-	clearTimeout(gPressTimeout.value)
-
 	// The reading pane walks threads, so it names one; the list walks rows, so it takes the edge row —
 	// which is the day's header when one sits above the first mail.
-	if (e.shiftKey) {
+	const intent = gPrefix.press(e.shiftKey)
+
+	if (intent === 'last') {
 		if (threadID) return goToThread(threadIDs.value.at(-1))
 		return focusRow(navigableRows.value.at(-1))
 	}
 
-	if (isGPressed.value) {
-		isGPressed.value = false
+	if (intent === 'first') {
 		if (threadID) return goToThread(threadIDs.value[0])
 		return focusRow(navigableRows.value[0])
 	}
-
-	isGPressed.value = true
-	gPressTimeout.value = setTimeout(() => (isGPressed.value = false), 750)
 }
 
 const handleGMenuNavigation = (e: KeyboardEvent, key: string) => {
-	isGPressed.value = false
+	gPrefix.disarm()
 
 	const navigationMap: Record<string, string> = {
 		i: mailboxIds.inbox,

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -575,6 +575,7 @@ import {
 	navigationOffset,
 	stepFromKey,
 	useGPrefix,
+	useRowScroll,
 } from '@/apps/mail/utils/listNavigation'
 import {
 	useMobileSelection,
@@ -1729,19 +1730,7 @@ const rowForThread = (threadID?: string): NavRow | undefined => {
 
 const focusOnThread = (threadID?: string) => focusRow(rowForThread(threadID))
 
-const scrollIntoView = (rowKey: string) => {
-	// Centering the focused row is a keyboard-navigation affordance; on mobile it
-	// only made the list visibly jump behind the thread pane's slide-in.
-	if (isMobile.value) return
-
-	// The row may have only just been revealed by its stack or its day opening, so wait for the render
-	// before looking it up. A no-op when nothing changed.
-	nextTick(() => {
-		mailListRef.value
-			?.querySelector(`[data-row-key="${rowKey}"]`)
-			?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-	})
-}
+const scrollIntoView = useRowScroll(mailListRef, isMobile)
 
 // Actions
 

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -64,349 +64,317 @@
 		</div>
 
 		<template v-else-if="threadsResource?.data?.length || filter || mailbox === 'search'">
-			<div
-				ref="mailSidebar"
-				class="sticky top-16 flex flex-col border-r"
-				:class="!isMobile && showReadingPane ? 'w-1/3' : 'w-full'"
+			<ThreadPane
+				:thread-open="!!threadID"
+				@touch-start="onThreadTouchStart"
+				@touch-end="onThreadTouchEnd"
 			>
-				<!-- The search view's own header: the query (click to edit) + removable filter pills, above
-				     the results toolbar. It owns the query surface; the results below just read the route. -->
-				<SearchResultsHeader
-					v-if="mailbox === 'search'"
-					v-model:show-search="showSearchModal"
-					v-model:show-advanced="showSearchAdvanced"
-					v-model:edit-filter="searchEditFilter"
-				/>
-
-				<!-- Mobile header: title row (folders · mailbox + count · search · compose) over
-				     a toolbar row (filter selector on the left, filter/refresh pills on the
-				     right). In selection mode the toolbar row swaps to ✕ / count / Select All.
-				     Search skips both rows (SearchResultsHeader is the header there; the tab
-				     bar carries the "you are in search" cue), keeping only the selection
-				     toolbar and the loading bar — the border goes with the rows it underlines. -->
-				<div
-					v-if="isMobile"
-					class="relative shrink-0"
-					:class="{ 'border-b': mailbox !== 'search' || !!selections.length }"
-				>
-					<MobileTitleHeader
-						v-if="mailbox !== 'search'"
-						with-menu
-						:title="mailboxName"
-						:count="threadCount ? __('{0} threads', [threadCount]) : undefined"
+				<template #list>
+					<!-- The search view's own header: the query (click to edit) + removable filter pills, above
+					     the results toolbar. It owns the query surface; the results below just read the route. -->
+					<SearchResultsHeader
+						v-if="mailbox === 'search'"
+						v-model:show-search="showSearchModal"
+						v-model:show-advanced="showSearchAdvanced"
+						v-model:edit-filter="searchEditFilter"
 					/>
 
-					<!-- Trash/Junk auto-delete banner — below the title (its desktop slot above
-					     the whole header read as chrome on top of the page). Borderless: it
-					     reads as part of the header block, not a boxed-off strip. -->
-					<div v-if="showDeleteBanner && mailbox !== 'search'" class="space-x-1 px-4">
-						<span class="text-ink-gray-5">
-							{{ __('Items in this mailbox will be automatically deleted after 30 days.') }}
-						</span>
-						<Button
-							:label="__('Delete Now')"
-							variant="ghost"
-							@click="showEmptyMailbox = true"
-						/>
-					</div>
-
-					<!-- Both toolbar variants share h-12 so toggling selection mode doesn't shift the list. -->
-					<!-- px-1/gap-1 match the title row above, so the ✕ shares the hamburger's
-					     axis and the count text starts where the title does. -->
-					<div v-if="selections.length" class="flex h-12 items-center gap-1 px-1">
-						<Button variant="ghost" class="!h-10 !w-10 !rounded-full" @click="toggleSelectAll(false)">
-							<template #icon><X class="icon !h-5 !w-5" /></template>
-						</Button>
-						<span class="flex-1 truncate text-base !font-medium">
-							{{ __('{0} selected', [String(selections.length)]) }}
-						</span>
-						<button
-							class="text-ink-gray-8 text-md shrink-0 px-2 !font-medium"
-							@click="toggleSelectAll(!isAllSelected)"
-						>
-							{{ isAllSelected ? __('Unselect All') : __('Select All') }}
-						</button>
-					</div>
-					<div v-else-if="mailbox !== 'search'" class="flex h-12 items-center px-4">
-						<!-- The selector label carries the active filter ("Unread Mails", …);
-						     picking "All" in the sheet clears it, so no dismissal chip needed. -->
-						<AdaptiveDropdown :options="FILTER_OPTIONS" :title="__('Filter')">
-							<button class="flex min-w-0 items-center gap-1.5 text-base !font-medium">
-								<span class="truncate">{{ title }}</span>
-								<ChevronDown class="text-ink-gray-5 h-4 w-4 shrink-0" />
-							</button>
-						</AdaptiveDropdown>
-					</div>
-
-					<!-- Loading bar -->
-					<LoadingBar v-if="threadsResource?.loading" />
-				</div>
-
-				<!-- Toolbar/Actions -->
-				<div
-					v-else
-					class="relative flex items-center border-b border-l-transparent px-3.5 py-2.5 sm:border-l sm:px-5"
-				>
-					<div v-if="!isAllAccountsSearch" class="mr-5">
-						<Tooltip
-							:text="
-								isAllSelected
-									? __('Clear All (Esc)')
-									: __('Select All ({0}+A)', [modifier])
-							"
-						>
-							<div
-								class="checkbox-hitbox -m-3 cursor-pointer p-3"
-								@click.stop.prevent="toggleSelectAll(!isAllSelected)"
-							>
-								<Checkbox
-									:model-value="isAllSelected"
-									size="md"
-									class="pointer-events-none"
-								/>
-							</div>
-						</Tooltip>
-					</div>
-					<Dropdown
-						v-if="!selections.length && mailbox !== 'search'"
-						:options="FILTER_OPTIONS"
+					<!-- Mobile header: title row (folders · mailbox + count · search · compose) over
+					     a toolbar row (filter selector on the left, filter/refresh pills on the
+					     right). In selection mode the toolbar row swaps to ✕ / count / Select All.
+					     Search skips both rows (SearchResultsHeader is the header there; the tab
+					     bar carries the "you are in search" cue), keeping only the selection
+					     toolbar and the loading bar — the border goes with the rows it underlines. -->
+					<div
+						v-if="isMobile"
+						class="relative shrink-0"
+						:class="{ 'border-b': mailbox !== 'search' || !!selections.length }"
 					>
-						<button
-							class="text-ink-gray-8 hover:bg-surface-gray-2 -ml-2 flex min-w-0 items-center gap-1 rounded px-2 py-1"
+						<MobileTitleHeader
+							v-if="mailbox !== 'search'"
+							with-menu
+							:title="mailboxName"
+							:count="threadCount ? __('{0} threads', [threadCount]) : undefined"
+						/>
+
+						<!-- Trash/Junk auto-delete banner — below the title (its desktop slot above
+						     the whole header read as chrome on top of the page). Borderless: it
+						     reads as part of the header block, not a boxed-off strip. -->
+						<div v-if="showDeleteBanner && mailbox !== 'search'" class="space-x-1 px-4">
+							<span class="text-ink-gray-5">
+								{{ __('Items in this mailbox will be automatically deleted after 30 days.') }}
+							</span>
+							<Button
+								:label="__('Delete Now')"
+								variant="ghost"
+								@click="showEmptyMailbox = true"
+							/>
+						</div>
+
+						<!-- Both toolbar variants share h-12 so toggling selection mode doesn't shift the list. -->
+						<!-- px-1/gap-1 match the title row above, so the ✕ shares the hamburger's
+						     axis and the count text starts where the title does. -->
+						<div v-if="selections.length" class="flex h-12 items-center gap-1 px-1">
+							<Button variant="ghost" class="!h-10 !w-10 !rounded-full" @click="toggleSelectAll(false)">
+								<template #icon><X class="icon !h-5 !w-5" /></template>
+							</Button>
+							<span class="flex-1 truncate text-base !font-medium">
+								{{ __('{0} selected', [String(selections.length)]) }}
+							</span>
+							<button
+								class="text-ink-gray-8 text-md shrink-0 px-2 !font-medium"
+								@click="toggleSelectAll(!isAllSelected)"
+							>
+								{{ isAllSelected ? __('Unselect All') : __('Select All') }}
+							</button>
+						</div>
+						<div v-else-if="mailbox !== 'search'" class="flex h-12 items-center px-4">
+							<!-- The selector label carries the active filter ("Unread Mails", …);
+							     picking "All" in the sheet clears it, so no dismissal chip needed. -->
+							<AdaptiveDropdown :options="FILTER_OPTIONS" :title="__('Filter')">
+								<button class="flex min-w-0 items-center gap-1.5 text-base !font-medium">
+									<span class="truncate">{{ title }}</span>
+									<ChevronDown class="text-ink-gray-5 h-4 w-4 shrink-0" />
+								</button>
+							</AdaptiveDropdown>
+						</div>
+
+						<!-- Loading bar -->
+						<LoadingBar v-if="threadsResource?.loading" />
+					</div>
+
+					<!-- Toolbar/Actions -->
+					<div
+						v-else
+						class="relative flex items-center border-b border-l-transparent px-3.5 py-2.5 sm:border-l sm:px-5"
+					>
+						<div v-if="!isAllAccountsSearch" class="mr-5">
+							<Tooltip
+								:text="
+									isAllSelected
+										? __('Clear All (Esc)')
+										: __('Select All ({0}+A)', [modifier])
+								"
+							>
+								<div
+									class="checkbox-hitbox -m-3 cursor-pointer p-3"
+									@click.stop.prevent="toggleSelectAll(!isAllSelected)"
+								>
+									<Checkbox
+										:model-value="isAllSelected"
+										size="md"
+										class="pointer-events-none"
+									/>
+								</div>
+							</Tooltip>
+						</div>
+						<Dropdown
+							v-if="!selections.length && mailbox !== 'search'"
+							:options="FILTER_OPTIONS"
 						>
-							<span class="truncate">{{ title }}</span>
-							<ChevronDown class="text-ink-gray-5 icon shrink-0" />
-						</button>
-					</Dropdown>
-					<p v-else class="pb-[2px]">{{ title }}</p>
-					<div class="-mr-1.5 ml-auto flex items-center space-x-1.5 sm:space-x-3">
-						<Button
-							v-if="!selections.length"
-							variant="ghost"
-							:tooltip="__('Refresh')"
-							:disabled="threadsResource?.loading || loadingMore"
-							@click="refreshThreads()"
-						>
-							<template #icon>
-								<RefreshCw class="icon" />
+							<button
+								class="text-ink-gray-8 hover:bg-surface-gray-2 -ml-2 flex min-w-0 items-center gap-1 rounded px-2 py-1"
+							>
+								<span class="truncate">{{ title }}</span>
+								<ChevronDown class="text-ink-gray-5 icon shrink-0" />
+							</button>
+						</Dropdown>
+						<p v-else class="pb-[2px]">{{ title }}</p>
+						<div class="-mr-1.5 ml-auto flex items-center space-x-1.5 sm:space-x-3">
+							<Button
+								v-if="!selections.length"
+								variant="ghost"
+								:tooltip="__('Refresh')"
+								:disabled="threadsResource?.loading || loadingMore"
+								@click="refreshThreads()"
+							>
+								<template #icon>
+									<RefreshCw class="icon" />
+								</template>
+							</Button>
+							<template v-if="selections.length">
+								<Dropdown v-if="showReadingPane" :options="selectActions">
+									<Button variant="ghost" :tooltip="__('Actions')">
+										<template #icon>
+											<Ellipsis class="icon" />
+										</template>
+									</Button>
+								</Dropdown>
+								<template v-else>
+									<Button
+										v-for="action in selectActions.filter((a) => a.condition())"
+										:key="action.label"
+										:tooltip="action.label"
+										variant="ghost"
+										@click="action.onClick"
+									>
+										<template #icon>
+											<component :is="action.icon" class="icon" />
+										</template>
+									</Button>
+								</template>
 							</template>
-						</Button>
-						<template v-if="selections.length">
-							<Dropdown v-if="showReadingPane" :options="selectActions">
-								<Button variant="ghost" :tooltip="__('Actions')">
+
+							<Dropdown
+								v-if="!!selections.length && !['search', 'starred'].includes(mailbox)"
+								:options="moveToOptions"
+							>
+								<Button variant="ghost" :tooltip="__('Move To')">
 									<template #icon>
-										<Ellipsis class="icon" />
+										<component :is="FolderInput" class="icon" />
 									</template>
 								</Button>
 							</Dropdown>
-							<template v-else>
-								<Button
-									v-for="action in selectActions.filter((a) => a.condition())"
-									:key="action.label"
-									:tooltip="action.label"
-									variant="ghost"
-									@click="action.onClick"
-								>
+							<Dropdown v-if="showAddTo" :options="addToOptions">
+								<Button variant="ghost" :tooltip="__('Add To')">
 									<template #icon>
-										<component :is="action.icon" class="icon" />
+										<component :is="FolderPlus" class="icon" />
 									</template>
 								</Button>
-							</template>
-						</template>
-
-						<Dropdown
-							v-if="!!selections.length && !['search', 'starred'].includes(mailbox)"
-							:options="moveToOptions"
-						>
-							<Button variant="ghost" :tooltip="__('Move To')">
-								<template #icon>
-									<component :is="FolderInput" class="icon" />
-								</template>
-							</Button>
-						</Dropdown>
-						<Dropdown v-if="showAddTo" :options="addToOptions">
-							<Button variant="ghost" :tooltip="__('Add To')">
-								<template #icon>
-									<component :is="FolderPlus" class="icon" />
-								</template>
-							</Button>
-						</Dropdown>
-						<Dropdown v-if="showRemoveFrom" :options="removeFromOptions">
-							<Button variant="ghost" :tooltip="__('Remove From')">
-								<template #icon>
-									<component :is="FolderMinus" class="icon" />
-								</template>
-							</Button>
-						</Dropdown>
+							</Dropdown>
+							<Dropdown v-if="showRemoveFrom" :options="removeFromOptions">
+								<Button variant="ghost" :tooltip="__('Remove From')">
+									<template #icon>
+										<component :is="FolderMinus" class="icon" />
+									</template>
+								</Button>
+							</Dropdown>
+						</div>
+						<!-- Subtle loading bar: a segment sliding across the bottom outline (no layout shift) -->
+						<LoadingBar v-if="threadsResource?.loading" />
 					</div>
-					<!-- Subtle loading bar: a segment sliding across the bottom outline (no layout shift) -->
-					<LoadingBar v-if="threadsResource?.loading" />
-				</div>
 
-				<!-- Mail list -->
-				<div
-					v-if="threadsResource?.data?.length"
-					ref="mailList"
-					class="h-full overflow-y-auto overscroll-contain max-sm:pb-20"
-				>
-					<div v-for="(group, key) in groupedThreads" :key="key">
-						<div
-							v-if="groupMessagesBy !== 'None' && !isMobile"
-							class="text-ink-gray-6 group flex items-center border-b border-l-transparent p-3.5 text-xs-semibold sm:border-l sm:px-5"
-							:class="{
-								'!bg-surface-blue-1': isGroupSelected(key),
-								'sm:hover:bg-surface-gray-1': !isLastGroup(key),
-								'!border-l-outline-blue-5': focusedRowKey === `group:${key}`,
-							}"
-							:data-row-key="`group:${key}`"
-							@click="toggleGroupCollapse(key)"
-						>
-							<!-- Mobile: group select ("all of Today") appears only in selection mode. -->
+					<!-- Mail list -->
+					<div
+						v-if="threadsResource?.data?.length"
+						ref="mailList"
+						class="h-full overflow-y-auto overscroll-contain max-sm:pb-20"
+					>
+						<div v-for="(group, key) in groupedThreads" :key="key">
 							<div
-								v-if="!isAllAccountsSearch && (!isMobile || mobileSelectionMode)"
-								class="pr-7.5 checkbox-hitbox -m-3 cursor-pointer py-3 pl-3"
-								@click.stop.prevent="
-									toggleSelect(getGroupThreads(key), !isGroupSelected(key))
-								"
+								v-if="groupMessagesBy !== 'None' && !isMobile"
+								class="text-ink-gray-6 group flex items-center border-b border-l-transparent p-3.5 text-xs-semibold sm:border-l sm:px-5"
+								:class="{
+									'!bg-surface-blue-1': isGroupSelected(key),
+									'sm:hover:bg-surface-gray-1': !isLastGroup(key),
+									'!border-l-outline-blue-5': focusedRowKey === `group:${key}`,
+								}"
+								:data-row-key="`group:${key}`"
+								@click="toggleGroupCollapse(key)"
 							>
-								<Checkbox
-									:model-value="isGroupSelected(key)"
-									size="md"
-									class="pointer-events-none"
+								<!-- Mobile: group select ("all of Today") appears only in selection mode. -->
+								<div
+									v-if="!isAllAccountsSearch && (!isMobile || mobileSelectionMode)"
+									class="pr-7.5 checkbox-hitbox -m-3 cursor-pointer py-3 pl-3"
+									@click.stop.prevent="
+										toggleSelect(getGroupThreads(key), !isGroupSelected(key))
+									"
+								>
+									<Checkbox
+										:model-value="isGroupSelected(key)"
+										size="md"
+										class="pointer-events-none"
+									/>
+								</div>
+
+								<span class="select-none pt-[2px]">
+									{{ getFormattedDate(key, groupMessagesBy === 'Month').toUpperCase() }}
+								</span>
+
+								<component
+									:is="collapsedGroups.includes(key) ? ChevronRight : ChevronDown"
+									v-if="!isLastGroup(key)"
+									class="icon ml-auto"
 								/>
 							</div>
-
-							<span class="select-none pt-[2px]">
-								{{ getFormattedDate(key, groupMessagesBy === 'Month').toUpperCase() }}
-							</span>
-
-							<component
-								:is="collapsedGroups.includes(key) ? ChevronRight : ChevronDown"
-								v-if="!isLastGroup(key)"
-								class="icon ml-auto"
-							/>
-						</div>
-						<template v-if="isMobile || !collapsedGroups.includes(key)">
-							<!-- A stack row stands in for a run of look-alike threads; when expanded, its
-							     members follow it as ordinary (indented) rows. -->
-							<template v-for="row in groupedRows[key]" :key="row.key">
-								<!-- Stacks are disabled in search (see stackingEnabled), so unlike the thread
-								     rows below they never need the all-accounts cross-account handling. -->
-								<StackListItem
-									v-if="row.type === 'stack'"
-									:threads="row.threads"
-									:expanded="row.expanded"
-									:is-selected="isStackSelected(row.threads)"
-									class="border-l-transparent sm:border-l"
-									:class="{ '!border-l-outline-blue-5': row.key === focusedRowKey }"
-									:data-row-key="row.key"
-									@toggle="toggleStack(row)"
-									@set-seen="(seen: boolean) => stackSetSeen(row.threads, seen)"
-									@archive-threads="stackArchive(row.threads)"
-									@trash-threads="stackTrash(row.threads)"
-									@delete-threads="stackDelete(row.threads)"
-									@set-selected="
-										(selected: boolean) =>
-											toggleSelect(
-												row.threads.map((t) => t.thread_id),
-												selected,
-											)
-									"
-								/>
-								<MailListItem
-									v-else
-									:mailbox
-									:mail="row.thread"
-									:account-id="isAllAccountsSearch ? row.thread.account : undefined"
-									:account-label="
-										isAllAccountsSearch ? shortAccountLabel(row.thread.account_name) : undefined
-									"
-									:selectable="!isAllAccountsSearch"
-									:selection-mode="mobileSelectionMode"
-									:is-selected="selections.includes(row.thread.thread_id)"
-									:hide-sender="row.inStack"
-									class="border-l-transparent sm:border-l"
-									:class="{
-										'!bg-surface-blue-1':
-											row.thread.thread_id === threadID && !isMobile,
-										'!border-l-outline-blue-5': row.key === focusedRowKey,
-										'!pl-10 sm:!pl-12': row.inStack,
-									}"
-									:data-row-key="row.key"
-									@set-seen="(seen: boolean) => rowSetSeen(row.thread, seen)"
-									@archive-thread="rowArchive(row.thread)"
-									@trash-thread="rowTrash(row.thread)"
-									@delete-thread="junkOrDeleteThreads([row.thread.thread_id], false)"
-									@set-flagged="(flagged: boolean) => rowSetFlagged(row.thread, flagged)"
-									@set-selected="
-										(selected: boolean) =>
-											!isAllAccountsSearch &&
-											toggleSelect([row.thread.thread_id], selected)
-									"
-								/>
+							<template v-if="isMobile || !collapsedGroups.includes(key)">
+								<!-- A stack row stands in for a run of look-alike threads; when expanded, its
+								     members follow it as ordinary (indented) rows. -->
+								<template v-for="row in groupedRows[key]" :key="row.key">
+									<!-- Stacks are disabled in search (see stackingEnabled), so unlike the thread
+									     rows below they never need the all-accounts cross-account handling. -->
+									<StackListItem
+										v-if="row.type === 'stack'"
+										:threads="row.threads"
+										:expanded="row.expanded"
+										:is-selected="isStackSelected(row.threads)"
+										class="border-l-transparent sm:border-l"
+										:class="{ '!border-l-outline-blue-5': row.key === focusedRowKey }"
+										:data-row-key="row.key"
+										@toggle="toggleStack(row)"
+										@set-seen="(seen: boolean) => stackSetSeen(row.threads, seen)"
+										@archive-threads="stackArchive(row.threads)"
+										@trash-threads="stackTrash(row.threads)"
+										@delete-threads="stackDelete(row.threads)"
+										@set-selected="
+											(selected: boolean) =>
+												toggleSelect(
+													row.threads.map((t) => t.thread_id),
+													selected,
+												)
+										"
+									/>
+									<MailListItem
+										v-else
+										:mailbox
+										:mail="row.thread"
+										:account-id="isAllAccountsSearch ? row.thread.account : undefined"
+										:account-label="
+											isAllAccountsSearch ? shortAccountLabel(row.thread.account_name) : undefined
+										"
+										:selectable="!isAllAccountsSearch"
+										:selection-mode="mobileSelectionMode"
+										:is-selected="selections.includes(row.thread.thread_id)"
+										:hide-sender="row.inStack"
+										class="border-l-transparent sm:border-l"
+										:class="{
+											'!bg-surface-blue-1':
+												row.thread.thread_id === threadID && !isMobile,
+											'!border-l-outline-blue-5': row.key === focusedRowKey,
+											'!pl-10 sm:!pl-12': row.inStack,
+										}"
+										:data-row-key="row.key"
+										@set-seen="(seen: boolean) => rowSetSeen(row.thread, seen)"
+										@archive-thread="rowArchive(row.thread)"
+										@trash-thread="rowTrash(row.thread)"
+										@delete-thread="junkOrDeleteThreads([row.thread.thread_id], false)"
+										@set-flagged="(flagged: boolean) => rowSetFlagged(row.thread, flagged)"
+										@set-selected="
+											(selected: boolean) =>
+												!isAllAccountsSearch &&
+												toggleSelect([row.thread.thread_id], selected)
+										"
+									/>
+								</template>
 							</template>
-						</template>
+						</div>
+						<!-- Infinite-scroll sentinel: entering the viewport near the list bottom loads the next
+						     batch (appended, never refetching loaded rows). Sits after all groups so collapsing
+						     a group can't disable it. -->
+						<div ref="loadMoreSentinel" class="h-px" />
+						<div v-if="loadingMore" class="flex justify-center py-3">
+							<LoaderCircle class="text-ink-gray-5 h-4 w-4 animate-spin" />
+						</div>
 					</div>
-					<!-- Infinite-scroll sentinel: entering the viewport near the list bottom loads the next
-					     batch (appended, never refetching loaded rows). Sits after all groups so collapsing
-					     a group can't disable it. -->
-					<div ref="loadMoreSentinel" class="h-px" />
-					<div v-if="loadingMore" class="flex justify-center py-3">
-						<LoaderCircle class="text-ink-gray-5 h-4 w-4 animate-spin" />
+					<div v-else class="flex h-full items-center justify-center">
+						<!-- While the (still-mounted) search header's new query loads, this area is the
+						     loading surface — the empty message must not flash first. -->
+						<LoaderCircle
+							v-if="threadsResource?.loading"
+							class="text-ink-gray-5 h-5 w-5 animate-spin"
+						/>
+						<p v-else class="text-ink-gray-5">
+							{{
+								mailbox !== 'search'
+									? __('No mails found for the selected filter.')
+									: hasSearchQuery
+										? __('No results found for the given query.')
+										: __('Search your mail')
+							}}
+						</p>
 					</div>
-				</div>
-				<div v-else class="flex h-full items-center justify-center">
-					<!-- While the (still-mounted) search header's new query loads, this area is the
-					     loading surface — the empty message must not flash first. -->
-					<LoaderCircle
-						v-if="threadsResource?.loading"
-						class="text-ink-gray-5 h-5 w-5 animate-spin"
-					/>
-					<p v-else class="text-ink-gray-5">
-						{{
-							mailbox !== 'search'
-								? __('No mails found for the selected filter.')
-								: hasSearchQuery
-									? __('No results found for the given query.')
-									: __('Search your mail')
-						}}
-					</p>
-				</div>
-			</div>
-			<div class="flex cursor-col-resize justify-center" @mousedown="startResizing">
-				<div
-					ref="resizer"
-					class="group-hover:bg-surface-gray-8 h-full rounded-full transition-all duration-300 ease-in-out"
-				/>
-			</div>
+				</template>
 
-			<!-- Mail thread -->
-			<!-- Mobile opens as a page push (iOS-style slide from the right): the pane
-			     stays mounted and slides via transform, so close animates too.
-			     visibility rides the same transition — it flips only after the
-			     slide-out ends, keeping the offscreen pane out of the focus order.
-			     Teleported to body on mobile (like the selection bar): inside the
-			     layout's isolate stacking context the remounting tab bar would paint
-			     over the pane during the slide-out. -->
-			<Teleport to="body" :disabled="!isMobile">
-			<div
-				class="bg-surface-base"
-				:class="{
-					'overflow-hidden': isMobile,
-					'w-2/3': !isMobile && showReadingPane,
-					'absolute bottom-0 left-0 right-0 top-0': !isMobile && !showReadingPane,
-					'fixed inset-0 z-20 pt-[env(safe-area-inset-top)] transition-[transform,visibility] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]':
-						isMobile,
-					'invisible translate-x-full': isMobile && !threadID,
-					hidden: !isMobile && !showReadingPane && !threadID,
-				}"
-				@touchstart.passive="onThreadTouchStart"
-				@touchend.passive="onThreadTouchEnd"
-			>
-				<!-- The swipe slide lives inside MailThread (its toolbar must not move), armed
-				     via `slide` per swipe and cleared on slide-done. The scroll wrapper must be
-				     h-full on desktop too, or the empty state's h-full collapses. -->
-				<div class="h-full overflow-y-auto">
 				<MailThread
 					ref="mailThread"
 					:slide="threadSlide"
@@ -449,9 +417,7 @@
 					@prev-thread="goToThreadByOffset(-1)"
 					@next-thread="goToThreadByOffset(1)"
 				/>
-				</div>
-			</div>
-			</Teleport>
+			</ThreadPane>
 		</template>
 
 		<!-- No mails (the search view keeps its header and shows an inline message instead) -->
@@ -565,7 +531,6 @@ import {
 	raisePromiseToast,
 	raiseToast,
 	shouldIgnoreKeypress,
-	startResizing,
 	stripShortcutHint,
 } from '@/apps/mail/utils'
 import {
@@ -578,6 +543,7 @@ import {
 } from '@/apps/mail/utils/listNavigation'
 import {
 	useMobileSelection,
+	useReadingPane,
 	useScreenSize,
 	useSwipeNav,
 	useUndo,
@@ -595,6 +561,7 @@ import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.v
 import ScreenedEmailAddressModal from '@/apps/mail/components/Modals/ScreenedEmailAddressModal.vue'
 import SearchResultsHeader from '@/apps/mail/components/SearchResultsHeader.vue'
 import StackListItem from '@/apps/mail/components/StackListItem.vue'
+import ThreadPane from '@/apps/mail/components/ThreadPane.vue'
 
 import type { MailboxData, Thread, UserResource } from '@/apps/mail/types'
 import type { ListRow, StackRow } from '@/apps/mail/utils/threadStacks'
@@ -625,7 +592,10 @@ const { mailboxes, mailboxIds } = store
 
 // Appearance
 
-const showReadingPane = computed(() => !!user.data?.show_reading_pane)
+// Split View. Shared with ThreadPane, which sizes both halves of the split from it — this view also
+// reads it to decide whether the info banners survive an open thread, and how the toolbar's bulk
+// actions collapse (into a menu with the pane taking two thirds of the row, spelled out without).
+const showReadingPane = useReadingPane()
 const groupMessagesBy = computed(() => user.data.group_messages_by)
 
 // Thread Groups

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -538,7 +538,6 @@ import {
 	navigationOffset,
 	stepFromKey,
 	useGPrefix,
-	useRowScroll,
 } from '@/apps/mail/utils/listNavigation'
 import {
 	useMobileSelection,
@@ -547,7 +546,7 @@ import {
 	useSwipeNav,
 	useUndo,
 } from '@/apps/mail/utils/composables'
-import { buildListRows } from '@/apps/mail/utils/threadStacks'
+import { useListRows } from '@/apps/mail/composables/useListRows'
 import {
 	PAGE_LENGTH,
 	usePaginatedThreads,
@@ -567,12 +566,7 @@ import StackListItem from '@/apps/mail/components/StackListItem.vue'
 import ThreadPane from '@/apps/mail/components/ThreadPane.vue'
 
 import type { MailboxData, Thread, UserResource } from '@/apps/mail/types'
-import type { ListRow, StackRow } from '@/apps/mail/utils/threadStacks'
-
-// A date header, the one navigable row the list draws itself rather than getting from buildListRows —
-// which is deliberately date-agnostic, so this type belongs here rather than in threadStacks.
-type GroupRow = { type: 'group'; key: string; dateKey: string }
-type NavRow = ListRow | GroupRow
+import type { NavRow } from '@/apps/mail/composables/useListRows'
 
 const { accountId, mailbox, threadID } = defineProps<{
 	accountId: string
@@ -588,7 +582,6 @@ const { undo, setUndoAction } = useUndo()
 
 const socket = inject('$socket')
 const user = inject('$user') as UserResource
-const dayjs = inject('$dayjs')
 
 const store = userStore()
 const { mailboxes, mailboxIds } = store
@@ -599,51 +592,34 @@ const { mailboxes, mailboxIds } = store
 // reads it to decide whether the info banners survive an open thread, and how the toolbar's bulk
 // actions collapse (into a menu with the pane taking two thirds of the row, spelled out without).
 const showReadingPane = useReadingPane()
-const groupMessagesBy = computed(() => user.data.group_messages_by)
 
-// Thread Groups
+// Infinite scroll (shared by the threads and search resources — only one is active at a time).
+// usePaginatedThreads owns the state between the reset and append fetches: the epochs, the refresh
+// merge, the removal suppression, the sentinel, the edge crossing. See there.
+const {
+	container: mailListRef,
+	hasMore,
+	loadingMore,
+	isFetching,
+	canGoNext,
+	threadIDs,
+	takeResetWindow,
+	beginReset,
+	beginRefresh,
+	onResetSuccess,
+	appendThreads,
+	loadMoreThenOpenEdge,
+	topUpIfShort,
+	suppressRemoved,
+	unsuppressRemoved,
+} = usePaginatedThreads({
+	resource: () => threadsResource.value,
+	fetchMore: () => (mailbox === 'search' ? loadMoreSearch : loadMoreThreads).reload(),
+	openThreadID: () => threadID,
+	onEdgeThread: (id, action) => (action === 'open' ? goToThread(id) : focusOnThread(id)),
+})
 
-const groupedThreads = computed<Record<string, Thread[]>>(() =>
-	threadsResource.value?.data?.reduce((groups: Record<string, Thread[]>, thread: Thread) => {
-		const date = dayjs(thread.received_at).format(
-			groupMessagesBy.value === 'Day' ? 'YYYY-MM-DD' : 'YYYY-MM',
-		)
-		if (!groups[date]) groups[date] = []
-		groups[date].push(thread)
-		return groups
-	}, {}),
-)
-
-const isLastGroup = (key: string) => Object.keys(groupedThreads.value).at(-1) === key
-
-const collapsedGroups = ref<string[]>([])
-
-const toggleGroupCollapse = (key: string) => {
-	// The cursor follows the click, as it does when you open a mail: Enter and a click are the same
-	// gesture on the same row, and Enter can only mean that if the cursor is already there. Above the
-	// last-group guard, so clicking a header that can't fold still takes the cursor.
-	focusedRowKey.value = `group:${key}`
-	if (isLastGroup(key)) return
-
-	if (collapsedGroups.value.includes(key))
-		return (collapsedGroups.value = collapsedGroups.value.filter((d) => d !== key))
-
-	collapsedGroups.value.push(key)
-	// Collapsing keeps the group's selection: "collapse a day, tick it, archive it" is a bulk move
-	// worth having, and the header's own checkbox goes on showing that the day is selected. Only the
-	// reading pane has to move, since it would otherwise point at a row that is no longer rendered.
-	if (groupedThreads.value[key]?.some((thread) => thread.thread_id === threadID)) goToMailbox()
-}
-
-const getGroupThreads = (group: string) => groupedThreads.value[group]?.map((t) => t.thread_id)
-
-watch(groupMessagesBy, () => (collapsedGroups.value = []))
-
-// Thread Stacks
-//
-// A run of adjacent look-alike threads from one sender collapses into a single row, so a chatty
-// notification sender can't bury the rest of the mailbox. This is a display layer over groupedThreads:
-// runs are detected within a date group and never span one.
+// Rows and the cursor
 
 // Stacking earns its place only where mail arrives unasked-for and one sender can drown the rest. It is
 // off wherever the sender is not the signal, or where hiding rows would defeat the list itself:
@@ -657,48 +633,35 @@ const stackingEnabled = computed(
 	() => !['search', 'starred', mailboxIds.sent, mailboxIds.drafts].includes(mailbox),
 )
 
-// The thread_ids of every member of every expanded stack. In-memory only — stacks re-collapse on a
-// mailbox switch. Keyed by member id rather than by stack key so a run keeps its expanded state as it
-// grows in either direction (appended by infinite scroll, prepended by a refresh), and so routing to a
-// thread can expand its stack without having to locate the run first.
-const expandedStacks = ref(new Set<string>())
-
-const isRunExpanded = (run: Thread[]) => run.some((t) => expandedStacks.value.has(t.thread_id))
-
-const rowKeyOf = (mail: Thread) =>
-	isAllAccountsSearch.value ? `${mail.account}:${mail.name}` : mail.name
-
-const groupedRows = computed<Record<string, ListRow[]>>(() =>
-	Object.fromEntries(
-		Object.entries(groupedThreads.value ?? {}).map(([key, group]) => [
-			key,
-			buildListRows(group, {
-				rowKey: rowKeyOf,
-				isExpanded: isRunExpanded,
-				enabled: stackingEnabled.value,
-			}),
-		]),
-	),
-)
-
-// The rows the list actually renders, in visual order. The cursor walks these rather than the flat list
-// of loaded threads, so it can never land on a row that isn't on screen: a collapsed stack is a single
-// stop (its members aren't rendered), and a collapsed date group contributes only its header.
-//
-// Headers exist only when the user groups by day or month; with grouping off none are rendered, and
-// collapsedGroups is provably empty there because only a header's own click can fill it.
-const navigableRows = computed<NavRow[]>(() => {
-	const rows: NavRow[] = []
-	for (const [dateKey, groupRows] of Object.entries(groupedRows.value)) {
-		if (groupMessagesBy.value !== 'None')
-			rows.push({ type: 'group', key: `group:${dateKey}`, dateKey })
-		if (collapsedGroups.value.includes(dateKey)) continue
-		rows.push(...groupRows)
-	}
-	return rows
+// The date groups, the stacks and the keyboard cursor that walks them — all shared with the merged All
+// Inboxes list (see useListRows).
+const {
+	groupMessagesBy,
+	groupedThreads,
+	getGroupThreads,
+	isLastGroup,
+	collapsedGroups,
+	expandedStacks,
+	groupedRows,
+	navigableRows,
+	focusedRowKey,
+	focusedRow,
+	focusRow,
+	focusOnThread,
+	toggleStack,
+	toggleGroupCollapse,
+	revealThread,
+} = useListRows({
+	threads: () => threadsResource.value?.data ?? [],
+	// Rows are keyed by mail name, prefixed with the account in an all-accounts search — where two
+	// accounts' rows sit in one list and a name alone need not be unique.
+	rowKey: (mail: Thread) =>
+		isAllAccountsSearch.value ? `${mail.account}:${mail.name}` : mail.name,
+	stackingEnabled: () => stackingEnabled.value,
+	openThreadID: () => threadID,
+	onOpenThreadHidden: () => goToMailbox(),
+	container: mailListRef,
 })
-
-const focusedRow = computed(() => navigableRows.value.find((row) => row.key === focusedRowKey.value))
 
 // Every thread a row stands for: one for a thread row, the whole run for a stack, the whole day for a
 // header — mirroring exactly what each row's own checkbox selects.
@@ -709,46 +672,17 @@ const rowThreadIDs = (row: NavRow): string[] =>
 			? row.threads.map((t) => t.thread_id)
 			: (getGroupThreads(row.dateKey) ?? [])
 
-const toggleStack = (row: StackRow) => {
-	const ids = row.threads.map((t) => t.thread_id)
-	// The cursor follows the click, as it does when you open a mail. This also covers the fold: the
-	// members are about to be hidden, so the stack row that now stands for them is where the cursor
-	// belongs, and Enter-fold-Enter-unfold stays a round trip rather than a way to lose your place.
-	focusedRowKey.value = row.key
-	if (!row.expanded) return ids.forEach((id) => expandedStacks.value.add(id))
-
-	ids.forEach((id) => expandedStacks.value.delete(id))
-	// Don't leave the reading pane pointing at a row we just hid — the same reason toggleGroupCollapse
-	// leaves the thread when its group collapses.
-	if (threadID && ids.includes(threadID)) goToMailbox()
-}
-
 // Derived rather than stored, mirroring isGroupSelected: it can never drift from `selections`, and
 // every existing path that mutates them (Cmd+A, Esc, resetSelections, shift+arrow, a member's own
 // checkbox) keeps the stack checkbox honest for free.
 const isStackSelected = (threads: Thread[]) =>
 	threads.every((t) => selections.value.includes(t.thread_id))
 
-// The keyboard cursor, as a row key (see navigableRows). A row key rather than a thread id because the
-// cursor can sit on a stack row or a date header, neither of which is a thread — and one ref rather
-// than two so the cursor can never be in two places at once.
-const focusedRowKey = ref<string>()
-
+// A deep link or a step to the next thread can land inside a collapsed stack or a folded day — surface
+// it either way, and leave the cursor on it (see revealThread).
 watch(
 	() => threadID,
-	(val) => {
-		if (!val) return
-
-		// A deep link or a step to the next thread can land inside a collapsed stack — surface it, just
-		// as a collapsed date group opens below. An opened thread is always visible in the list.
-		expandedStacks.value.add(val)
-
-		setTimeout(() => focusOnThread(val))
-		for (const group of collapsedGroups.value) {
-			if (getGroupThreads(group).includes(val))
-				return (collapsedGroups.value = collapsedGroups.value.filter((d) => d !== group))
-		}
-	},
+	(val) => val && revealThread(val),
 	{ immediate: true },
 )
 
@@ -1109,32 +1043,6 @@ const selectActions = computed((): SelectAction[] => [
 ])
 
 // Search
-
-// Infinite scroll (shared by the threads and search resources — only one is active at a time).
-// usePaginatedThreads owns the state between the reset and append fetches: the epochs, the refresh
-// merge, the removal suppression, the sentinel, the edge crossing. See there.
-const {
-	container: mailListRef,
-	hasMore,
-	loadingMore,
-	isFetching,
-	canGoNext,
-	threadIDs,
-	takeResetWindow,
-	beginReset,
-	beginRefresh,
-	onResetSuccess,
-	appendThreads,
-	loadMoreThenOpenEdge,
-	topUpIfShort,
-	suppressRemoved,
-	unsuppressRemoved,
-} = usePaginatedThreads({
-	resource: () => threadsResource.value,
-	fetchMore: () => (mailbox === 'search' ? loadMoreSearch : loadMoreThreads).reload(),
-	openThreadID: () => threadID,
-	onEdgeThread: (id, action) => (action === 'open' ? goToThread(id) : focusOnThread(id)),
-})
 
 // An optimistic removal emptied the list but more threads exist, so a refill is coming once the server
 // mutation lands. Keeps the loading state (not the empty state) during the gap before the refill fetch.
@@ -1501,36 +1409,6 @@ const goToNextThreadOrMailbox = (excludedThreads: string[] = []) => {
 	if (next) goToThread(next)
 	else goToMailbox()
 }
-
-const focusRow = (row?: NavRow) => {
-	if (!row) return
-
-	focusedRowKey.value = row.key
-	scrollIntoView(row.key)
-}
-
-// The row that stands for a thread on screen: its own row when rendered, the collapsed stack that hides
-// it, or — when its whole day is folded away — that day's header. Callers name a thread ("go to the
-// first mail", "open the thread that just loaded"); this is how that lands somewhere visible.
-const rowForThread = (threadID?: string): NavRow | undefined => {
-	if (!threadID) return
-
-	const row = navigableRows.value.find(
-		(row) =>
-			(row.type === 'thread' && row.thread.thread_id === threadID) ||
-			// Only a collapsed stack stands in for its members. An expanded one precedes its member rows,
-			// so without this guard every member would resolve to the stack row above it.
-			(row.type === 'stack' && !row.expanded && row.threads.some((t) => t.thread_id === threadID)),
-	)
-	if (row) return row
-
-	const dateKey = collapsedGroups.value.find((key) => getGroupThreads(key)?.includes(threadID))
-	return navigableRows.value.find((row) => row.key === `group:${dateKey}`)
-}
-
-const focusOnThread = (threadID?: string) => focusRow(rowForThread(threadID))
-
-const scrollIntoView = useRowScroll(mailListRef, isMobile)
 
 // Actions
 

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -585,6 +585,7 @@ const {
 	isFetching,
 	canGoNext,
 	threadIDs,
+	threadByOffset,
 	takeResetWindow,
 	beginReset,
 	beginRefresh,
@@ -894,7 +895,7 @@ const handleArrowNavigation = (e: KeyboardEvent, key: string) => {
 	if (threadID) {
 		// The reading pane walks threads rather than rows: opening one always reveals it, so it can
 		// never land on something hidden (see the threadID watcher).
-		const next = getThreadByOffset(offset)
+		const next = threadByOffset(offset)
 		goToThreadByOffset(offset)
 		if (next) newIDs = [next]
 	} else {
@@ -1360,9 +1361,6 @@ onUnmounted(() => {
 const goToMailbox = () =>
 	router.push({ name: 'mail-mailbox', params: { accountId, mailbox }, query: route.query })
 
-const getThreadByOffset = (offset: number, currentThread: string = threadID!) =>
-	threadIDs.value[threadIDs.value.indexOf(currentThread) + offset]
-
 const goToThread = (threadID: string) => {
 	threadSlide.value = pendingThreadSlide
 	if (threadID)
@@ -1370,7 +1368,7 @@ const goToThread = (threadID: string) => {
 }
 
 const goToThreadByOffset = (offset: number) => {
-	const next = getThreadByOffset(offset)
+	const next = threadByOffset(offset)
 	if (next) return goToThread(next)
 	loadMoreThenOpenEdge(offset, 'open')
 }

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -570,6 +570,12 @@ import {
 	stripShortcutHint,
 } from '@/apps/mail/utils'
 import {
+	hasCursor,
+	isNavigationKey,
+	navigationOffset,
+	stepFromKey,
+} from '@/apps/mail/utils/listNavigation'
+import {
 	useMobileSelection,
 	useScreenSize,
 	useSwipeNav,
@@ -1011,12 +1017,11 @@ const handleThreadActions = (e: KeyboardEvent, key: string) => {
 }
 
 const handleArrowNavigation = (e: KeyboardEvent, key: string) => {
-	const navigationKeys = ['arrowup', 'arrowdown', 'j', 'k']
-	if (!navigationKeys.includes(key)) return
+	if (!isNavigationKey(key)) return
 
 	e.preventDefault()
 
-	const offset = ['arrowup', 'k'].includes(key) ? -1 : 1
+	const offset = navigationOffset(key)
 	const prevIDs = focusedRow.value ? rowThreadIDs(focusedRow.value) : []
 
 	let newIDs: string[] = []
@@ -1032,14 +1037,12 @@ const handleArrowNavigation = (e: KeyboardEvent, key: string) => {
 		if (next) newIDs = [next]
 	} else {
 		const rows = navigableRows.value
-		// A cursor whose row is gone — folded away, or removed by a mutation — restarts at the top.
-		const index = rows.findIndex((row) => row.key === focusedRowKey.value)
-		const next = index === -1 ? rows[0] : rows[index + offset]
+		const next = stepFromKey(rows, focusedRowKey.value, offset)
 
 		if (next) {
 			focusRow(next)
 			newIDs = rowThreadIDs(next)
-		} else if (index !== -1) loadMoreThenOpenEdge(offset, 'focus')
+		} else if (hasCursor(rows, focusedRowKey.value)) loadMoreThenOpenEdge(offset, 'focus')
 	}
 
 	// Handle shift+arrow selection. A row carries every thread it stands for, so shifting onto a stack

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -521,7 +521,6 @@
 	</div>
 	</Teleport>
 
-	<ShortcutsModal v-model="showShortcuts" />
 </template>
 <script setup lang="ts">
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
@@ -595,7 +594,6 @@ import MailThread from '@/apps/mail/components/MailThread.vue'
 import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
 import ScreenedEmailAddressModal from '@/apps/mail/components/Modals/ScreenedEmailAddressModal.vue'
 import SearchResultsHeader from '@/apps/mail/components/SearchResultsHeader.vue'
-import ShortcutsModal from '@/apps/mail/components/Modals/ShortcutsModal.vue'
 import StackListItem from '@/apps/mail/components/StackListItem.vue'
 
 import type { MailboxData, Thread, UserResource } from '@/apps/mail/types'
@@ -882,7 +880,6 @@ const isGroupSelected = (key: string) =>
 
 // Shortcuts
 
-const showShortcuts = ref(false)
 
 const modifier = computed(() => (isMac ? '⌘' : 'Ctrl'))
 
@@ -911,10 +908,14 @@ const handleKeyDown = (e: KeyboardEvent) => {
 	if (shouldIgnoreKeypress(e)) return
 
 	if (key === 'g') return handleGKeyPress(e)
-	if (gPrefix.armed.value) return handleGMenuNavigation(e, key)
+	// A letter after `g` is a mailbox jump, which MailLayout owns. Swallow it here so it can't
+	// also fire a thread-action shortcut sharing that letter.
+	if (gPrefix.armed.value) {
+		gPrefix.disarm()
+		return
+	}
 	if (key === 'enter') return handleEnter(e)
 	if (key === 'escape') return handleEscape(e)
-	if (key === '?') return handleShowShortcuts(e)
 
 	const hasSelection = selections.value.length > 0 || threadID
 	if (hasSelection) handleThreadActions(e, key)
@@ -935,31 +936,6 @@ const handleGKeyPress = (e: KeyboardEvent) => {
 		if (threadID) return goToThread(threadIDs.value[0])
 		return focusRow(navigableRows.value[0])
 	}
-}
-
-const handleGMenuNavigation = (e: KeyboardEvent, key: string) => {
-	gPrefix.disarm()
-
-	const navigationMap: Record<string, string> = {
-		i: mailboxIds.inbox,
-		f: 'starred',
-		s: mailboxIds.sent,
-		d: mailboxIds.drafts,
-		j: mailboxIds.junk,
-		a: mailboxIds.archive,
-		t: mailboxIds.trash,
-	}
-
-	const mailboxId = navigationMap[key]
-	if (mailboxId) {
-		e.preventDefault()
-		router.push({ name: 'mail-mailbox', params: { accountId, mailbox: mailboxId } })
-	}
-}
-
-const handleShowShortcuts = (e: KeyboardEvent) => {
-	e.preventDefault()
-	showShortcuts.value = true
 }
 
 // Enter means "act on the row I'm on": open a mail, or fold/unfold a stack or a day.

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -383,6 +383,7 @@ import {
 } from 'frappe-ui'
 
 import { raiseToast, shouldIgnoreKeypress } from '@/apps/mail/utils'
+import { isNavigationKey, navigationOffset } from '@/apps/mail/utils/listNavigation'
 import { useScreenSize, useSettings, useSwipeNav } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
@@ -503,11 +504,10 @@ const handleKeydown = (e: KeyboardEvent) => {
 		return
 	}
 
-	const offset =
-		key === 'arrowup' || key === 'k' ? -1 : key === 'arrowdown' || key === 'j' ? 1 : 0
-	if (!offset) return
+	if (!isNavigationKey(key)) return
 
 	e.preventDefault()
+	const offset = navigationOffset(key)
 	const list = senders.data ?? []
 	const cur = list.findIndex(
 		(s: ScreeningSender) => s.from_email === openSender.value!.from_email,

--- a/frontend/src/apps/mail/resources.ts
+++ b/frontend/src/apps/mail/resources.ts
@@ -7,15 +7,21 @@ import type { Attachment } from '@/apps/mail/types'
 
 const store = userStore()
 
+// Attachments belong to a specific account's blob store: callers inside a pane pass
+// the pane's owning account (a cross-account thread in All Inboxes); everything else
+// falls back to the active account.
 export const fetchAttachment = createResource({
 	url: 'suite.mail.api.mail.fetch_attachment',
-	makeParams: (blobID: string) => ({ account: store.accountId, blob_id: blobID }),
+	makeParams: ({ blobID, account }: { blobID: string; account?: string }) => ({
+		account: account || store.accountId,
+		blob_id: blobID,
+	}),
 	onError: (error) => raiseToast(error.message, 'error'),
 	cache: ['attachment'],
 })
 
-export const getAttachmentUrl = async (blobID: string, type?: string) => {
-	const attachment = await fetchAttachment.submit(blobID)
+export const getAttachmentUrl = async (blobID: string, type?: string, account?: string) => {
+	const attachment = await fetchAttachment.submit({ blobID, account })
 	const byteArray = new Uint8Array(attachment)
 	const blob = new Blob([byteArray], { type })
 	return URL.createObjectURL(blob)
@@ -23,8 +29,8 @@ export const getAttachmentUrl = async (blobID: string, type?: string) => {
 
 export const fetchAttachmentsAsZip = createResource({
 	url: 'suite.mail.api.mail.fetch_attachments_as_zip',
-	makeParams: (attachments: Attachment[]) => ({
-		account: store.accountId,
+	makeParams: ({ attachments, account }: { attachments: Attachment[]; account?: string }) => ({
+		account: account || store.accountId,
 		attachments: JSON.stringify(
 			attachments.map((a) => ({ blob_id: a.blob_id, filename: a.filename })),
 		),
@@ -32,8 +38,8 @@ export const fetchAttachmentsAsZip = createResource({
 	onError: (error) => raiseToast(error.message, 'error'),
 })
 
-export const getAttachmentsZipUrl = async (attachments: Attachment[]) => {
-	const zip = await fetchAttachmentsAsZip.submit(attachments)
+export const getAttachmentsZipUrl = async (attachments: Attachment[], account?: string) => {
+	const zip = await fetchAttachmentsAsZip.submit({ attachments, account })
 	const byteArray = new Uint8Array(zip)
 	const blob = new Blob([byteArray], { type: 'application/zip' })
 	return URL.createObjectURL(blob)

--- a/frontend/src/apps/mail/router.ts
+++ b/frontend/src/apps/mail/router.ts
@@ -81,8 +81,12 @@ function installMailGuard(r: Router) {
 			return { name: 'mail-domains' }
 		}
 
-		// Resolve active account.
-		resolveAccount(user?.accounts, to.params.accountId as string | undefined)
+		// Resolve active account. The merged All Inboxes thread route carries the thread's
+		// owning account purely to scope the pane (see utils/accountScope) — opening a
+		// thread there must not switch the active account out from under the merged list.
+		const routeAccountId =
+			to.name === 'mail-all-inboxes-mail' ? undefined : (to.params.accountId as string | undefined)
+		resolveAccount(user?.accounts, routeAccountId)
 		const accountId = userStore().accountId
 
 		// Wait for mailbox list. The fetch rejects when the mail server is temporarily down;

--- a/frontend/src/apps/mail/routes.ts
+++ b/frontend/src/apps/mail/routes.ts
@@ -91,6 +91,18 @@ export const routes: RouteRecordRaw[] = [
 				name: 'mail-all-inboxes',
 				component: () => import('@/apps/mail/pages/AllInboxesView.vue'),
 			},
+			// The merged view with a thread open, so opening a mail keeps you in All Inboxes
+			// instead of navigating into the owning account's mailbox. Same component as the
+			// list-only route above, mirroring how `mail-mail` reuses MailboxView, and the same
+			// three params as `mail-mail` so a row only swaps the route name. accountId is the
+			// row's own account: the merged list spans accounts, so the URL has to say which
+			// one the thread belongs to rather than relying on whichever is active.
+			{
+				path: 'all-inboxes/account/:accountId/mailbox/:mailbox/:threadID',
+				name: 'mail-all-inboxes-mail',
+				component: () => import('@/apps/mail/pages/AllInboxesView.vue'),
+				props: true,
+			},
 			{
 				path: 'account/:accountId/mailbox/:mailbox',
 				name: 'mail-mailbox',

--- a/frontend/src/apps/mail/stores/user.ts
+++ b/frontend/src/apps/mail/stores/user.ts
@@ -9,6 +9,28 @@ import type { UserAccount, UserResource } from '@/apps/mail/types'
 
 export type MailboxRole = 'inbox' | 'sent' | 'drafts' | 'trash' | 'junk' | 'archive' | 'important'
 
+/** Role → mailbox id map for a mailbox list (plus the named Screener). Shared with
+ * utils/accountScope, which derives the same map for a non-active account's list. */
+export const deriveMailboxIds = (
+	mailboxes?: { role?: MailboxRole; _name?: string; id: string }[],
+): Record<MailboxRole | 'screener', string> => {
+	const ids: Record<MailboxRole | 'screener', string> = {
+		inbox: '',
+		sent: '',
+		drafts: '',
+		trash: '',
+		junk: '',
+		archive: '',
+		important: '',
+		screener: '',
+	}
+	mailboxes?.forEach((m) => {
+		if (m.role) ids[m.role] = m.id
+		else if (m._name === SCREENER_MAILBOX_NAME) ids.screener = m.id
+	})
+	return ids
+}
+
 const ACCOUNT_STORAGE_KEY = 'mail-account-id'
 
 export const userStore = defineStore('mail-user', () => {
@@ -79,28 +101,14 @@ export const userStore = defineStore('mail-user', () => {
 		onSuccess: reloadAllInboxesUnread,
 	})
 
-	const mailboxIds = computed(() => {
-		const ids: Record<MailboxRole | 'screener', string> = {
-			inbox: '',
-			sent: '',
-			drafts: '',
-			trash: '',
-			junk: '',
-			archive: '',
-			important: '',
-			screener: '',
-		}
-		mailboxes.data?.forEach((m: { role?: MailboxRole; _name?: string; id: string }) => {
-			if (m.role) ids[m.role] = m.id
-			else if (m._name === SCREENER_MAILBOX_NAME) ids.screener = m.id
-		})
-		return ids
-	})
+	const mailboxIds = computed(() => deriveMailboxIds(mailboxes.data))
 
 	// Short display labels for the merged views (All Inboxes, all-accounts search), keyed by the
-	// account's full name: the address's local part tells the user's accounts apart in a fraction
-	// of the width, so rows keep the space for the sender. Accounts whose local parts collide
-	// keep the full address.
+	// account's full name. Only the odd ones out get labelled: the currently open account is
+	// where the reader already is, so its rows stay bare ('' here — the row hides an empty
+	// label) and ink scales with how much the reader actually needs it. The rest show the
+	// address's local part — enough to tell the accounts apart in a fraction of the width —
+	// falling back to the full address only when two accounts share a local part.
 	const accountShortNames = computed<Record<string, string>>(() => {
 		const accounts = userResource.data?.accounts ?? []
 		const shortOf = (name: string) => name.split('@')[0] || name
@@ -112,6 +120,7 @@ export const userStore = defineStore('mail-user', () => {
 		return Object.fromEntries(
 			accounts.map((account) => {
 				const name = account._name ?? ''
+				if (account.id === accountId.value) return [name, '']
 				return [name, counts[shortOf(name)] > 1 ? name : shortOf(name)]
 			}),
 		)

--- a/frontend/src/apps/mail/stores/user.ts
+++ b/frontend/src/apps/mail/stores/user.ts
@@ -97,6 +97,26 @@ export const userStore = defineStore('mail-user', () => {
 		return ids
 	})
 
+	// Short display labels for the merged views (All Inboxes, all-accounts search), keyed by the
+	// account's full name: the address's local part tells the user's accounts apart in a fraction
+	// of the width, so rows keep the space for the sender. Accounts whose local parts collide
+	// keep the full address.
+	const accountShortNames = computed<Record<string, string>>(() => {
+		const accounts = userResource.data?.accounts ?? []
+		const shortOf = (name: string) => name.split('@')[0] || name
+		const counts: Record<string, number> = {}
+		for (const account of accounts) {
+			const short = shortOf(account._name ?? '')
+			counts[short] = (counts[short] ?? 0) + 1
+		}
+		return Object.fromEntries(
+			accounts.map((account) => {
+				const name = account._name ?? ''
+				return [name, counts[shortOf(name)] > 1 ? name : shortOf(name)]
+			}),
+		)
+	})
+
 	const addressBooks = createResource({
 		url: 'suite.mail.api.contacts.get_address_books',
 		makeParams: () => ({ account: accountId.value }),
@@ -147,6 +167,7 @@ export const userStore = defineStore('mail-user', () => {
 		userResource,
 		mailboxes,
 		mailboxIds,
+		accountShortNames,
 		addressBooks,
 		identities,
 		domains,

--- a/frontend/src/apps/mail/utils/accountScope.ts
+++ b/frontend/src/apps/mail/utils/accountScope.ts
@@ -1,0 +1,94 @@
+import { computed, inject, provide, type ComputedRef, type InjectionKey } from 'vue'
+import { createResource } from 'frappe-ui'
+
+import { deriveMailboxIds, userStore, type MailboxRole } from '@/apps/mail/stores/user'
+
+import type { UserAccount } from '@/apps/mail/types'
+
+/**
+ * The account a thread pane acts as. The merged All Inboxes view opens threads from
+ * any account without switching the active one — switching flipped the whole sidebar,
+ * refetched five per-account resources and stranded the reader in another account —
+ * so everything account-scoped inside the pane resolves through this scope instead:
+ * mailbox ids for the folder menus, identities for reply addresses, screened senders
+ * for the blocked/trusted banners.
+ *
+ * A pane on the active account reuses the store's live resources. Other accounts get
+ * their own instances, fetched on first use and kept for the session — folder menus
+ * and identities don't need the poll-fresh counts the active list does.
+ */
+export interface AccountScope {
+	accountId: ComputedRef<string>
+	/** The account's record off the user resource (default_outgoing_email, block_remote_images, …). */
+	account: ComputedRef<UserAccount | undefined>
+	mailboxes: ComputedRef<ReturnType<typeof createResource>>
+	mailboxIds: ComputedRef<Record<MailboxRole | 'screener', string>>
+	identities: ComputedRef<ReturnType<typeof createResource>>
+	screenedAddresses: ComputedRef<ReturnType<typeof createResource>>
+}
+
+const scopedResources = new Map<
+	string,
+	Record<'mailboxes' | 'identities' | 'screenedAddresses', ReturnType<typeof createResource>>
+>()
+
+const resourcesFor = (account: string) => {
+	if (!scopedResources.has(account)) {
+		scopedResources.set(account, {
+			mailboxes: createResource({
+				url: 'suite.mail.api.mail.get_mailboxes',
+				params: { account },
+				cache: ['mailboxes', account],
+				auto: true,
+			}),
+			identities: createResource({
+				url: 'suite.mail.api.account.get_identities',
+				params: { account },
+				cache: ['identities', account],
+				auto: true,
+			}),
+			screenedAddresses: createResource({
+				url: 'suite.mail.api.mail.get_screened_addresses',
+				params: { account },
+				cache: ['screenedAddresses', account],
+				auto: true,
+			}),
+		})
+	}
+	return scopedResources.get(account)!
+}
+
+export const useAccountScope = (owner?: () => string | undefined): AccountScope => {
+	const store = userStore()
+	const accountId = computed(() => owner?.() || store.accountId)
+	const scoped = computed(() =>
+		accountId.value && accountId.value !== store.accountId
+			? resourcesFor(accountId.value)
+			: null,
+	)
+	return {
+		accountId,
+		account: computed(() =>
+			store.userResource?.data?.accounts?.find((a: UserAccount) => a.id === accountId.value),
+		),
+		mailboxes: computed(() => scoped.value?.mailboxes ?? store.mailboxes),
+		identities: computed(() => scoped.value?.identities ?? store.identities),
+		screenedAddresses: computed(() => scoped.value?.screenedAddresses ?? store.screenedAddresses),
+		mailboxIds: computed(() =>
+			scoped.value ? deriveMailboxIds(scoped.value.mailboxes.data) : store.mailboxIds,
+		),
+	}
+}
+
+const ACCOUNT_SCOPE: InjectionKey<AccountScope> = Symbol('mail-account-scope')
+
+/** Called by the pane root (MailThread); everything below it resolves this scope. */
+export const provideAccountScope = (owner: () => string | undefined): AccountScope => {
+	const scope = useAccountScope(owner)
+	provide(ACCOUNT_SCOPE, scope)
+	return scope
+}
+
+/** The enclosing pane's scope, or the active account for components outside one. */
+export const injectAccountScope = (): AccountScope =>
+	inject(ACCOUNT_SCOPE, () => useAccountScope(), true)

--- a/frontend/src/apps/mail/utils/composables.ts
+++ b/frontend/src/apps/mail/utils/composables.ts
@@ -1,5 +1,5 @@
 import { computed, onMounted, onUnmounted, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { createResource, toast } from 'frappe-ui'
 
 import { matchesScreenedValue, raiseOptimisticToast, raiseToast } from '@/apps/mail/utils'
@@ -15,6 +15,34 @@ import type { COLOR_SCHEME, Identity, ScreenedAddress } from '@/apps/mail/types'
 const isMobile = ref(window.innerWidth < 640)
 
 export const useScreenSize = () => ({ isMobile })
+
+/**
+ * Switching accounts stays in place wherever the view allows it — shared by the
+ * sidebar's account submenu and the mobile profile sheet. Account-scoped routes
+ * swap the accountId param in their own URL. The account-agnostic All Inboxes
+ * routes just re-resolve the active account (bouncing to the new account's inbox
+ * threw the reader out of the merged list, which spans every account anyway).
+ * Everything else goes through the account shortcut, which the guard resolves to
+ * the new account's default mailbox.
+ */
+export const useAccountSwitch = () => {
+	const route = useRoute()
+	const router = useRouter()
+	const store = userStore()
+
+	const switchAccount = (accountId: string) => {
+		if (accountId === store.accountId) return
+		if ((route.name as string)?.startsWith('mail-all-inboxes'))
+			return store.resolveAccount(store.userResource.data?.accounts, accountId)
+		router.push(
+			route.params.accountId
+				? { name: route.name!, params: { ...route.params, accountId } }
+				: { name: 'mail-account-shortcut', params: { accountId } },
+		)
+	}
+
+	return { switchAccount }
+}
 
 const isSidebarOpen = ref(false)
 

--- a/frontend/src/apps/mail/utils/composables.ts
+++ b/frontend/src/apps/mail/utils/composables.ts
@@ -17,6 +17,16 @@ const isMobile = ref(window.innerWidth < 640)
 export const useScreenSize = () => ({ isMobile })
 
 /**
+ * Split View: the reading pane sits beside the list rather than over it. One user setting, read the
+ * same way by every list view and by ThreadPane itself — the two halves of the split are sized from
+ * it, so they must never be able to disagree about it.
+ */
+export const useReadingPane = () => {
+	const { userResource } = userStore()
+	return computed(() => !!userResource.data?.show_reading_pane)
+}
+
+/**
  * Switching accounts stays in place wherever the view allows it — shared by the
  * sidebar's account submenu and the mobile profile sheet. Account-scoped routes
  * swap the accountId param in their own URL. The account-agnostic All Inboxes

--- a/frontend/src/apps/mail/utils/index.ts
+++ b/frontend/src/apps/mail/utils/index.ts
@@ -27,29 +27,6 @@ export const toTitleCase = (str: string) =>
 		})
 		.join(' ') || ''
 
-export function startResizing(event) {
-	const startX = event.clientX
-	const sidebar = document.getElementsByClassName('mailSidebar')[0]
-	const startWidth = sidebar.offsetWidth
-
-	const onMouseMove = (event) => {
-		const diff = event.clientX - startX
-		let newWidth = startWidth + diff
-		if (newWidth < 200) {
-			newWidth = 200
-		}
-		sidebar.style.width = newWidth + 'px'
-	}
-
-	const onMouseUp = () => {
-		document.removeEventListener('mousemove', onMouseMove)
-		document.removeEventListener('mouseup', onMouseUp)
-	}
-
-	document.addEventListener('mousemove', onMouseMove)
-	document.addEventListener('mouseup', onMouseUp)
-}
-
 export const formatBytes = (bytes: number) => {
 	if (!+bytes) return '0 Bytes'
 

--- a/frontend/src/apps/mail/utils/index.ts
+++ b/frontend/src/apps/mail/utils/index.ts
@@ -177,12 +177,6 @@ export const getFormattedDate = (date: Date | string, omitDate = false) => {
 	return dateObj.format(isCurrentYear ? 'D MMMM' : 'D MMMM YYYY')
 }
 
-export const getFirstAlphabet = (str?: string) => str?.match(/\p{L}/u)?.[0]
-
-// The letter on a sender's avatar: their name's first, or their address's when they go by no name.
-export const getSenderInitial = (sender: { from_name?: string; from_email?: string }) =>
-	getFirstAlphabet(sender.from_name) || getFirstAlphabet(sender.from_email)
-
 export const getTheme = (
 	status: 'Draft' | 'Queued' | 'In Progress' | 'Completed' | 'Failed' | 'Cancelled',
 ) => {

--- a/frontend/src/apps/mail/utils/listFilter.ts
+++ b/frontend/src/apps/mail/utils/listFilter.ts
@@ -1,0 +1,69 @@
+import { computed, ref } from 'vue'
+import { Mail as MailIcon, Mails, Paperclip, Star } from 'lucide-vue-next'
+
+import { userStore } from '@/apps/mail/stores/user'
+
+export interface StoredFilterOptions {
+	/**
+	 * What the remembered choice is remembered FOR — a mailbox id, or 'all-inboxes' for the merged
+	 * list. A getter, since the mailbox view switches mailbox without remounting.
+	 */
+	scope: () => string
+	/** Apply the new filter: refetch the first window. */
+	onChange: () => void
+	/**
+	 * Whether the Starred filter is offered. Off inside Trash and inside the Starred list itself,
+	 * where it would filter a list to itself.
+	 */
+	starrable?: () => boolean
+}
+
+/**
+ * The list filter — All / Unread / Starred / Has attachments — remembered per list, its menu, and the
+ * title the toolbar shows for it. All three were duplicated verbatim between the mailbox list and the
+ * merged All Inboxes list, down to the localStorage key's shape.
+ */
+export const useStoredFilter = ({ scope, onChange, starrable = () => true }: StoredFilterOptions) => {
+	const { userResource } = userStore()
+
+	const storageKey = () => `user:${userResource.data?.name}:filter:${scope()}`
+
+	const filter = ref<string | null>(localStorage.getItem(storageKey()) || null)
+
+	const setFilter = (value: string | null) => {
+		filter.value = value
+		localStorage.setItem(storageKey(), value ?? '')
+		onChange()
+	}
+
+	/** Re-read the remembered choice after the scope changed (a mailbox switch). */
+	const reloadFilter = () => (filter.value = localStorage.getItem(storageKey()) || null)
+
+	const FILTER_OPTIONS = [
+		{ label: __('All'), icon: Mails, onClick: () => setFilter(null) },
+		{ label: __('Unread'), icon: MailIcon, onClick: () => setFilter('unread') },
+		{ label: __('Starred'), icon: Star, onClick: () => setFilter('starred'), condition: starrable },
+		{
+			label: __('Has attachments'),
+			icon: Paperclip,
+			onClick: () => setFilter('has_attachments'),
+		},
+	]
+
+	/** What the toolbar's filter selector reads. Callers may show something else instead — a
+	 *  selection count, a result count — but this is the filter's own name for itself. */
+	const filterTitle = computed(() => {
+		switch (filter.value) {
+			case 'unread':
+				return __('Unread Mails')
+			case 'starred':
+				return __('Starred Mails')
+			case 'has_attachments':
+				return __('With Attachments')
+			default:
+				return __('All Mails')
+		}
+	})
+
+	return { filter, setFilter, reloadFilter, FILTER_OPTIONS, filterTitle }
+}

--- a/frontend/src/apps/mail/utils/listNavigation.ts
+++ b/frontend/src/apps/mail/utils/listNavigation.ts
@@ -1,3 +1,5 @@
+import { ref } from 'vue'
+
 // Shared pieces of keyboard list navigation, for the mailbox list and the merged All Inboxes
 // list. Only the parts that are genuinely identical live here: which keys navigate, which
 // direction each means, and how to step a cursor through a list.
@@ -40,3 +42,41 @@ export const stepFromKey = <T extends { key: string }>(
 /** Whether the cursor is currently on a known row — the ends need distinguishing from "lost". */
 export const hasCursor = <T extends { key: string }>(rows: T[], currentKey: string | undefined) =>
 	rows.some((row) => row.key === currentKey)
+
+/**
+ * The `g` prefix: `g g` jumps to the first entry, `G` to the last. A lone `g` arms for
+ * this long, then forgets — so `g`, pause, `g` is two separate presses, not a jump.
+ */
+export const G_PREFIX_WINDOW_MS = 750
+
+/**
+ * State machine for that prefix. `press` reports the intent and leaves acting on it to the
+ * caller, because "first" means the first row in one list and the first thread in another.
+ */
+export const useGPrefix = () => {
+	const armed = ref(false)
+	let timer: ReturnType<typeof setTimeout> | undefined
+
+	const disarm = () => {
+		clearTimeout(timer)
+		armed.value = false
+	}
+
+	const press = (shiftKey: boolean): 'first' | 'last' | 'armed' => {
+		// Shift+G is a jump in its own right, so it also clears any half-typed `g`.
+		if (shiftKey) {
+			disarm()
+			return 'last'
+		}
+		if (armed.value) {
+			disarm()
+			return 'first'
+		}
+		clearTimeout(timer)
+		armed.value = true
+		timer = setTimeout(() => (armed.value = false), G_PREFIX_WINDOW_MS)
+		return 'armed'
+	}
+
+	return { armed, press, disarm }
+}

--- a/frontend/src/apps/mail/utils/listNavigation.ts
+++ b/frontend/src/apps/mail/utils/listNavigation.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { nextTick, ref, type Ref } from 'vue'
 
 // Shared pieces of keyboard list navigation, for the mailbox list and the merged All Inboxes
 // list. Only the parts that are genuinely identical live here: which keys navigate, which
@@ -42,6 +42,23 @@ export const stepFromKey = <T extends { key: string }>(
 /** Whether the cursor is currently on a known row — the ends need distinguishing from "lost". */
 export const hasCursor = <T extends { key: string }>(rows: T[], currentKey: string | undefined) =>
 	rows.some((row) => row.key === currentKey)
+
+/**
+ * Scrolls the row marked `data-row-key` into the centre of the list — the shared
+ * affordance for the keyboard cursor and the open thread. Skipped on mobile,
+ * where the thread pane slides over the list and the jump would only show behind
+ * it. Waits a tick because the row may have only just been revealed (a stack or
+ * day group expanding, a route change landing); a no-op when nothing changed.
+ */
+export const useRowScroll =
+	(container: Ref<HTMLElement | null>, isMobile: Ref<boolean>) => (rowKey: string) => {
+		if (isMobile.value) return
+		nextTick(() => {
+			container.value
+				?.querySelector(`[data-row-key="${rowKey}"]`)
+				?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+		})
+	}
 
 /**
  * The `g` prefix: `g g` jumps to the first entry, `G` to the last. A lone `g` arms for

--- a/frontend/src/apps/mail/utils/listNavigation.ts
+++ b/frontend/src/apps/mail/utils/listNavigation.ts
@@ -1,0 +1,42 @@
+// Shared pieces of keyboard list navigation, for the mailbox list and the merged All Inboxes
+// list. Only the parts that are genuinely identical live here: which keys navigate, which
+// direction each means, and how to step a cursor through a list.
+//
+// The handlers themselves stay in the views, because what a step *does* differs — the mailbox
+// list steps over stacks and day headers and extends a shift-selection, the merged list steps
+// over flat rows and has no selection at all. Threading that through one function would take
+// more callbacks than it would save.
+
+/** Keys that move the cursor. Compared against a lowercased `event.key`. */
+export const NAVIGATION_KEYS = ['arrowup', 'arrowdown', 'j', 'k']
+
+export const isNavigationKey = (key: string) => NAVIGATION_KEYS.includes(key)
+
+/** Up/k walk backwards, down/j forwards. */
+export const navigationOffset = (key: string) => (['arrowup', 'k'].includes(key) ? -1 : 1)
+
+/**
+ * The next entry `offset` steps from `current`.
+ *
+ * A `current` that is no longer in the list — a row folded away, or removed by a mutation —
+ * restarts from the first entry rather than losing the cursor. Returns undefined at the ends,
+ * which is how a caller knows to load the next window instead.
+ */
+export const stepFrom = <T>(list: T[], current: T | undefined, offset: number): T | undefined => {
+	const index = current === undefined ? -1 : list.indexOf(current)
+	return index === -1 ? list[0] : list[index + offset]
+}
+
+/** As `stepFrom`, for lists of objects addressed by a string key. */
+export const stepFromKey = <T extends { key: string }>(
+	rows: T[],
+	currentKey: string | undefined,
+	offset: number,
+): T | undefined => {
+	const index = rows.findIndex((row) => row.key === currentKey)
+	return index === -1 ? rows[0] : rows[index + offset]
+}
+
+/** Whether the cursor is currently on a known row — the ends need distinguishing from "lost". */
+export const hasCursor = <T extends { key: string }>(rows: T[], currentKey: string | undefined) =>
+	rows.some((row) => row.key === currentKey)

--- a/frontend/src/apps/mail/utils/listNavigation.ts
+++ b/frontend/src/apps/mail/utils/listNavigation.ts
@@ -1,10 +1,9 @@
-import { nextTick, ref, type Ref } from 'vue'
+import { ref } from 'vue'
 
-import { useScreenSize } from '@/apps/mail/utils/composables'
-
-// Shared pieces of keyboard list navigation, for the mailbox list and the merged All Inboxes
-// list. Only the parts that are genuinely identical live here: which keys navigate, which
-// direction each means, and how to step a cursor through a list.
+// Shared pieces of keyboard list navigation, for the two thread lists and the screener. Only
+// what is genuinely identical lives here: which keys navigate, which direction each means, how
+// to step a cursor through a list, and the `g` prefix. Every export below has more than one
+// caller — anything that ended up with one has been inlined where it is used.
 //
 // The handlers themselves stay in the views, because what a step *does* differs — the mailbox
 // list steps over stacks and day headers and extends a shift-selection, the merged list steps
@@ -12,7 +11,7 @@ import { useScreenSize } from '@/apps/mail/utils/composables'
 // more callbacks than it would save.
 
 /** Keys that move the cursor. Compared against a lowercased `event.key`. */
-export const NAVIGATION_KEYS = ['arrowup', 'arrowdown', 'j', 'k']
+const NAVIGATION_KEYS = ['arrowup', 'arrowdown', 'j', 'k']
 
 export const isNavigationKey = (key: string) => NAVIGATION_KEYS.includes(key)
 
@@ -20,18 +19,12 @@ export const isNavigationKey = (key: string) => NAVIGATION_KEYS.includes(key)
 export const navigationOffset = (key: string) => (['arrowup', 'k'].includes(key) ? -1 : 1)
 
 /**
- * The next entry `offset` steps from `current`.
+ * The row `offset` steps from the one keyed `currentKey`.
  *
- * A `current` that is no longer in the list — a row folded away, or removed by a mutation —
- * restarts from the first entry rather than losing the cursor. Returns undefined at the ends,
- * which is how a caller knows to load the next window instead.
+ * A `currentKey` that is no longer in the list — a row folded away, or removed by a mutation —
+ * restarts from the first row rather than losing the cursor. Returns undefined at the ends, which
+ * is how a caller knows to load the next window instead (see `hasCursor` for telling the two apart).
  */
-export const stepFrom = <T>(list: T[], current: T | undefined, offset: number): T | undefined => {
-	const index = current === undefined ? -1 : list.indexOf(current)
-	return index === -1 ? list[0] : list[index + offset]
-}
-
-/** As `stepFrom`, for lists of objects addressed by a string key. */
 export const stepFromKey = <T extends { key: string }>(
 	rows: T[],
 	currentKey: string | undefined,
@@ -46,33 +39,10 @@ export const hasCursor = <T extends { key: string }>(rows: T[], currentKey: stri
 	rows.some((row) => row.key === currentKey)
 
 /**
- * Scrolls the row marked `data-row-key` into the centre of the list — the shared
- * affordance for the keyboard cursor and the open thread. Skipped on mobile,
- * where the thread pane slides over the list and the jump would only show behind
- * it. Waits a tick because the row may have only just been revealed (a stack or
- * day group expanding, a route change landing); a no-op when nothing changed.
- *
- * Mobile is read here rather than passed in: it is one process-wide value (see
- * useScreenSize), so every caller was handing over the same singleton.
- */
-export const useRowScroll = (container: Ref<HTMLElement | null>) => {
-	const { isMobile } = useScreenSize()
-
-	return (rowKey: string) => {
-		if (isMobile.value) return
-		nextTick(() => {
-			container.value
-				?.querySelector(`[data-row-key="${rowKey}"]`)
-				?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-		})
-	}
-}
-
-/**
  * The `g` prefix: `g g` jumps to the first entry, `G` to the last. A lone `g` arms for
  * this long, then forgets — so `g`, pause, `g` is two separate presses, not a jump.
  */
-export const G_PREFIX_WINDOW_MS = 750
+const G_PREFIX_WINDOW_MS = 750
 
 /**
  * State machine for that prefix. `press` reports the intent and leaves acting on it to the

--- a/frontend/src/apps/mail/utils/listNavigation.ts
+++ b/frontend/src/apps/mail/utils/listNavigation.ts
@@ -1,5 +1,7 @@
 import { nextTick, ref, type Ref } from 'vue'
 
+import { useScreenSize } from '@/apps/mail/utils/composables'
+
 // Shared pieces of keyboard list navigation, for the mailbox list and the merged All Inboxes
 // list. Only the parts that are genuinely identical live here: which keys navigate, which
 // direction each means, and how to step a cursor through a list.
@@ -49,9 +51,14 @@ export const hasCursor = <T extends { key: string }>(rows: T[], currentKey: stri
  * where the thread pane slides over the list and the jump would only show behind
  * it. Waits a tick because the row may have only just been revealed (a stack or
  * day group expanding, a route change landing); a no-op when nothing changed.
+ *
+ * Mobile is read here rather than passed in: it is one process-wide value (see
+ * useScreenSize), so every caller was handing over the same singleton.
  */
-export const useRowScroll =
-	(container: Ref<HTMLElement | null>, isMobile: Ref<boolean>) => (rowKey: string) => {
+export const useRowScroll = (container: Ref<HTMLElement | null>) => {
+	const { isMobile } = useScreenSize()
+
+	return (rowKey: string) => {
 		if (isMobile.value) return
 		nextTick(() => {
 			container.value
@@ -59,6 +66,7 @@ export const useRowScroll =
 				?.scrollIntoView({ behavior: 'smooth', block: 'center' })
 		})
 	}
+}
 
 /**
  * The `g` prefix: `g g` jumps to the first entry, `G` to the last. A lone `g` arms for

--- a/frontend/src/apps/mail/utils/participants.ts
+++ b/frontend/src/apps/mail/utils/participants.ts
@@ -67,6 +67,12 @@ export const threadParticipants = (
 	return participants
 }
 
+const getFirstAlphabet = (str?: string) => str?.match(/\p{L}/u)?.[0]
+
+/** The letter on a sender's avatar: their name's first, or their address's when they go by no name. */
+export const getSenderInitial = (sender: { from_name?: string; from_email?: string }) =>
+	getFirstAlphabet(sender.from_name) || getFirstAlphabet(sender.from_email)
+
 const capitalizeFirst = (word: string) => word.charAt(0).toUpperCase() + word.slice(1)
 
 // "M", "M." — an initial standing before the name rather than being it.
@@ -129,3 +135,23 @@ export const formatThreadParticipants = (participants: ThreadParticipant[]) => {
 	if (names.length <= MAX_PARTICIPANTS_SHOWN) return names.join(', ')
 	return `${names[0]} … ${names.slice(-2).join(', ')}`
 }
+
+/**
+ * The letter behind a thread row's avatar, for a contact with no picture: the initial of whoever the
+ * picture itself would be of (see primaryParticipant). `fallback` is the row's own sender, for a row
+ * with no conversation behind it to name anybody — a search result.
+ */
+export const threadAvatarLabel = (
+	participants: ThreadParticipant[],
+	fallback: { from_name?: string; from_email?: string },
+) => {
+	const primary = primaryParticipant(participants)
+	if (!primary) return getSenderInitial(fallback)
+	return getSenderInitial({ from_name: primary.name, from_email: primary.email })
+}
+
+/** The name(s) a thread row goes by, falling back to its own sender when it names nobody. */
+export const threadDisplayName = (
+	participants: ThreadParticipant[],
+	fallback: { from_name?: string; from_email?: string },
+) => formatThreadParticipants(participants) || fallback.from_name || fallback.from_email

--- a/frontend/src/apps/mail/utils/threadSummary.ts
+++ b/frontend/src/apps/mail/utils/threadSummary.ts
@@ -1,0 +1,57 @@
+import type { Thread } from '@/apps/mail/types'
+
+/**
+ * A list row carries denormalised summary fields describing its thread's most recent activity —
+ * derived server-side, in serialize_thread, from the latest message the view is allowed to show. When
+ * a message leaves the conversation optimistically (moved, junked, deleted from the reading pane) the
+ * row's own `messages` shrinks, but these fields go on describing the message that left: trashing a
+ * thread's newest mail left the row previewing it, dated to it, and named after its sender until the
+ * next refresh.
+ *
+ * This re-derives them from the conversation the row still has, and returns a closure putting the old
+ * ones back — the rollback has to restore the summary, not just re-insert the message.
+ *
+ * `outgoingMailbox` is the current mailbox id, and only for Sent and Drafts: those rows follow the
+ * latest message in the FOLDER rather than the conversation's most recent activity, so a draft reply
+ * keeps its own recipients and its "Draft" badge when the thread it answers receives a newer mail (see
+ * get_threads). Everywhere else the whole visible conversation is the right basis, so pass nothing.
+ *
+ * Two row fields are deliberately left alone:
+ * - `subject`, which comes from the conversation's OPENING message (serialize_thread's `first`, taken
+ *   from the whole conversation rather than from the visible subset the row carries). Removing a
+ *   thread's newest mail cannot change it, and the opening message may not be in `messages` at all.
+ * - `user_image`, whose row-level rule is not a message's: for a thread the user sent, the row shows
+ *   the RECIPIENT's avatar (add_user_images_to_emails with is_thread=False), which needs the account's
+ *   own addresses to resolve. A stale avatar until the next refresh beats guessing the wrong face.
+ */
+export const resummariseRow = (thread: Thread, outgoingMailbox?: string) => {
+	const before = {
+		from_name: thread.from_name,
+		from_email: thread.from_email,
+		received_at: thread.received_at,
+		recipients: thread.recipients,
+		draft: thread.draft,
+		preview: thread.preview,
+		attachments: thread.attachments,
+	}
+	const restore = () => void Object.assign(thread, before)
+
+	const messages = thread.messages ?? []
+	if (!messages.length) return restore
+
+	const inMailbox = outgoingMailbox
+		? messages.filter((m) => m.mailboxes.some((mb) => mb.mailbox_id === outgoingMailbox))
+		: []
+	// Falls back to the whole conversation rather than to nothing, exactly as the server does.
+	const latest = (inMailbox.length ? inMailbox : messages).at(-1)!
+
+	thread.from_name = latest.from_name
+	thread.from_email = latest.from_email
+	thread.received_at = latest.received_at
+	thread.recipients = latest.recipients
+	thread.draft = latest.draft
+	thread.preview = latest.preview
+	thread.attachments = latest.attachments
+
+	return restore
+}

--- a/frontend/src/apps/mail/utils/useThreadActions.ts
+++ b/frontend/src/apps/mail/utils/useThreadActions.ts
@@ -941,6 +941,13 @@ export function useThreadActions(deps: {
 			emptied: false,
 			rollback: () => {},
 		}
+		// The row renders its message count and participants from its own `messages`, so dropping the
+		// mail from the pane is not enough — without this a thread of three keeps saying three, and
+		// its preview keeps naming a sender that is no longer in it.
+		const row = threadsResource.value?.data?.find((t: Thread) => t.thread_id === mail.thread_id)
+		const mailIndex = row?.messages?.findIndex((m: Mail) => m.id === mail.id) ?? -1
+		if (row && mailIndex !== -1) row.messages.splice(mailIndex, 1)
+
 		let removed: Thread[] = []
 		if (emptied) {
 			goToNextThreadOrMailbox([mail.thread_id])
@@ -948,6 +955,7 @@ export function useThreadActions(deps: {
 		}
 		const restoreUi = () => {
 			rollback()
+			if (row && mailIndex !== -1) row.messages.splice(mailIndex, 0, mail)
 			if (removed.length) restoreThreadsToList(removed)
 		}
 

--- a/frontend/src/apps/mail/utils/useThreadActions.ts
+++ b/frontend/src/apps/mail/utils/useThreadActions.ts
@@ -5,6 +5,7 @@ import { createResource } from 'frappe-ui'
 import { FOLDER_ICON_COLOR_MAP } from '@/apps/mail/constants'
 import { getIcon, raiseOptimisticToast, raisePromiseToast, raiseToast } from '@/apps/mail/utils'
 import { useBlockSender, useUndo } from '@/apps/mail/utils/composables'
+import { useMailRemoval } from '@/apps/mail/composables/useMailRemoval'
 import { userStore } from '@/apps/mail/stores/user'
 
 import type { Mail, Mailbox, Thread } from '@/apps/mail/types'
@@ -927,79 +928,23 @@ export function useThreadActions(deps: {
 	}
 
 	// ── Per-message (single mail) actions from the reading pane ─────────────────────────────────────
-	// Optimistically drops the mail from the open thread's pane (via the exposed removeMailFromView); if
-	// that empties the thread's view, the pane closes and the thread row leaves the list — all before the
-	// request fires, mirroring the thread-level pattern. `undoReq` (when present) restores the server
-	// state for undo; `afterSuccess` runs once the forward request lands (e.g. the block-sender prompt).
-	const runMailRemoval = (
-		mail: Mail,
-		req: () => Promise<unknown>,
-		success: string,
-		opts: { undoReq?: () => Promise<unknown>; undoSuccess?: string; afterSuccess?: () => void } = {},
-	) => {
-		const { emptied, rollback } = mailThreadRef.value?.removeMailFromView(mail.id) ?? {
-			emptied: false,
-			rollback: () => {},
-		}
-		// The row renders its message count and participants from its own `messages`, so dropping the
-		// mail from the pane is not enough — without this a thread of three keeps saying three, and
-		// its preview keeps naming a sender that is no longer in it.
-		const row = threadsResource.value?.data?.find((t: Thread) => t.thread_id === mail.thread_id)
-		const mailIndex = row?.messages?.findIndex((m: Mail) => m.id === mail.id) ?? -1
-		if (row && mailIndex !== -1) row.messages.splice(mailIndex, 1)
-
-		let removed: Thread[] = []
-		if (emptied) {
-			goToNextThreadOrMailbox([mail.thread_id])
-			removed = removeThreadsFromList([mail.thread_id])
-		}
-		const restoreUi = () => {
-			rollback()
-			if (row && mailIndex !== -1) row.messages.splice(mailIndex, 0, mail)
-			if (removed.length) restoreThreadsToList(removed)
-		}
-
-		setUndoAction(undefined)
-		let forwardOk = false
-		const forwardPromise = (async () => {
-			try {
-				await req()
-				forwardOk = true
-				mailboxes.reload()
-				refillIfEmpty()
-				opts.afterSuccess?.()
-			} catch (error) {
-				restoreUi()
-				setUndoAction(undefined)
-				throw error
+	// The orchestration is shared with the merged All Inboxes list (see useMailRemoval); what differs is
+	// where the pane goes when a thread empties, and how a removed row is put back — Sent and Drafts
+	// also summarise their rows from the folder rather than the conversation.
+	const { runMailRemoval } = useMailRemoval({
+		row: (mail) => threadsResource.value?.data?.find((t: Thread) => t.thread_id === mail.thread_id),
+		mailThreadRef,
+		onEmptied: (mail) => goToNextThreadOrMailbox([mail.thread_id]),
+		removeRow: (mail) => {
+			const removed = removeThreadsFromList([mail.thread_id])
+			return () => {
+				if (removed.length) restoreThreadsToList(removed)
 			}
-		})()
-
-		if (!opts.undoReq) return raiseOptimisticToast(forwardPromise, success)
-
-		setUndoAction(() =>
-			void (async () => {
-				await forwardPromise.catch(() => {})
-				if (!forwardOk) return
-				restoreUi()
-				setUndoAction(undefined)
-				raiseOptimisticToast(
-					opts
-						.undoReq!()
-						.then(() => mailboxes.reload())
-						.catch((error) => {
-							// The undo didn't land server-side — re-remove so the UI matches the server
-							// instead of showing the mail (and its row) as restored.
-							mailThreadRef.value?.removeMailFromView(mail.id)
-							if (removed.length) removeThreadsFromList([mail.thread_id])
-							throw error
-						}),
-					opts.undoSuccess ?? success,
-				)
-			})(),
-		)
-		raiseOptimisticToast(forwardPromise, success, undo)
-	}
+		},
+		outgoingMailbox: () =>
+			[mailboxIds.sent, mailboxIds.drafts].includes(mailbox.value) ? mailbox.value : undefined,
+		afterForward: refillIfEmpty,
+	})
 
 	const mailSnapshot = (mail: Mail) => [
 		{ id: mail.id, mailbox_ids: mail.mailboxes.map((mb) => mb.mailbox_id), junk: mail.junk },

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -130,7 +130,11 @@ router.beforeEach(async (to) => {
   return true
 })
 
-router.afterEach((to) => {
+router.afterEach((to, _from, failure) => {
+  // A failed navigation (e.g. re-clicking the current folder, which vue-router reports
+  // as duplicated but still runs afterEach for) leaves the page untouched — resetting
+  // the title here would clobber the one the view set via usePageMeta.
+  if (failure) return
   setDocumentTitle(to)
   setFavicon(to)
   setPwaTags(to)


### PR DESCRIPTION
Opening a mail from All Inboxes navigated into the owning account's mailbox, so the merged view could never show a thread and Split View had nothing to attach to. Closes #412.

All Inboxes now has its own thread route and renders the thread beside the list at the same geometry `MailboxView` uses — a third/two-thirds split on desktop with Split View on, a full-bleed overlay otherwise and on mobile. The route carries the row's own `accountId`, because the merged list spans accounts and the URL has to say which one the thread belongs to rather than relying on whichever is active. Every mutation reads `account`/`archive`/`trash` off the row, so the pane acts on the owning account without switching the active one.

Keyboard navigation follows: a cursor that walks rendered rows (day headers included, skipping collapsed days), `Enter` to open or fold, `Esc` to back out, `g g`/`G` to the ends. `?` and the `g`+letter mailbox jumps moved to `MailLayout`, so they work anywhere on the non-admin side instead of only inside a mailbox list — `g a` now goes to All Inboxes, `g r` to the Screener, and Archive moved to `g e` to free `a`. Thread shortcuts work in the pane too: `e`, `u`, `!`, and Delete/Backspace, plus `Cmd/Ctrl+Z` to undo.

Every pane action is wired: archive, move to, add to / remove from folder, junk, star, mark unread, and the per-message move/junk/delete. Each updates the list optimistically and rolls back if the request fails; archive, move, junk and folder changes offer undo, which restores each mail's exact mailbox set and junk flag rather than guessing an inverse.

## Shared code

Rather than reimplement `MailboxView` slice by slice, the overlapping parts were extracted and both views were moved onto them: `usePaginatedThreads` (infinite scroll, the refresh merge, removal suppression), `useListRows` (date groups, stacks, the cursor), `useMailRemoval` (per-message removal), `ThreadPane`, `MailGroupHeader`, `listNavigation.ts`, `listFilter.ts` and `threadSummary.ts`. That removed ~675 lines from the two callers and is what most of this diff is.

Three fixes fell out of it, all in shared code and so applying to both views:

- A refresh prepended any thread in the newest window that wasn't loaded yet, assuming it must be newer than everything loaded. True for one account; false for the merged list, where a second account's newest mail can be older than the first's oldest loaded row — which opened a stale date group above today's. It now merges the two runs by `received_at`.
- `MailboxView` cleared the `g` prefix timer on `Shift+G` but not the armed flag, so a half-typed `g` swallowed the next keypress.
- The thread header's folder dropdowns passed `undefined` into `AdaptiveDropdown` while the mailbox resource was loading.

## Verification

`yarn build` clean, `yarn vitest run` passes (1088). Exercised in the browser on a two-account setup, including cross-account threads: open in place, next/prev, `j`/`k`/`Enter`/`Esc`, archive, move to, add/remove folder, junk, star, mark unread, and undo for each — plus the date grouping after a refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

