### PR TITLE
feat(mail): honor global screened senders for remote images and auto-accept

### DIFF
--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -486,7 +486,7 @@ const { filterBySender } = useFilterBySender()
 const dayjs = inject('$dayjs')
 const user = inject('$user')
 const store = userStore()
-const { mailboxes, mailboxIds, identities, screenedAddresses } = store
+const { mailboxes, mailboxIds, identities, screenedAddresses, globalScreenedAddresses } = store
 
 // A sender is "blocked" when screened with the Reject action (their mail is discarded) — either by their
 // exact address or by an accepted/blocked '@domain' entry covering them.
@@ -502,9 +502,18 @@ const blockRemoteImagesEnabled = computed(
 		store.userResource?.data?.accounts?.find((a) => a.id === store.accountId)
 			?.block_remote_images ?? true,
 )
+// The screening rules in effect for the account: the admin-managed global rules overlaid with the
+// account's own, the account's rule winning when both screen the same address or domain — mirroring
+// the backend's `get_effective_screened_email_addresses`, which the automation sieve is built from.
+const effectiveScreenedAddresses = computed(() => {
+	const merged = new Map<string, ScreenedAddress>()
+	for (const a of globalScreenedAddresses.data ?? []) merged.set(a.email.toLowerCase(), a)
+	for (const a of screenedAddresses.data ?? []) merged.set(a.email.toLowerCase(), a)
+	return [...merged.values()]
+})
 const isScreenedIn = (email: string) =>
 	!!identities.data?.some((i: Identity) => i.email === email) ||
-	!!screenedAddresses.data?.some(
+	effectiveScreenedAddresses.value.some(
 		(a: ScreenedAddress) => a.action === 'Accepted' && matchesScreenedValue(email, a.email),
 	)
 const shouldBlockImages = (mail: { from_email: string }) =>

--- a/frontend/src/apps/mail/stores/user.ts
+++ b/frontend/src/apps/mail/stores/user.ts
@@ -43,6 +43,7 @@ export const userStore = defineStore('mail-user', () => {
 		addressBooks.fetch()
 		identities.fetch()
 		screenedAddresses.fetch()
+		globalScreenedAddresses.fetch()
 		sieveScripts.fetch()
 	}
 
@@ -117,6 +118,13 @@ export const userStore = defineStore('mail-user', () => {
 		cache: ['screenedAddresses', accountId.value],
 	})
 
+	// Global screened senders (admin-managed, no account) — overlaid under the account's own rules
+	// when deciding whether a sender is trusted for remote images. Not shown in the settings UI.
+	const globalScreenedAddresses = createResource({
+		url: 'suite.mail.api.mail.get_global_screened_addresses',
+		cache: 'globalScreenedAddresses',
+	})
+
 	const sieveScripts = createResource({
 		url: 'suite.mail.api.sieve.get_sieve_scripts',
 		makeParams: () => ({ account: accountId.value }),
@@ -136,6 +144,7 @@ export const userStore = defineStore('mail-user', () => {
 		addressBooks.reset()
 		identities.reset()
 		screenedAddresses.reset()
+		globalScreenedAddresses.reset()
 		sieveScripts.reset()
 		domains.reset()
 		allInboxesUnread.reset()
@@ -152,6 +161,7 @@ export const userStore = defineStore('mail-user', () => {
 		domains,
 		sieveScripts,
 		screenedAddresses,
+		globalScreenedAddresses,
 		allInboxesUnread,
 		reset,
 	}

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -37,6 +37,7 @@ from suite.mail.doctype.mailbox_settings.mailbox_settings import (
 	set_mailbox_settings,
 )
 from suite.mail.doctype.screened_email_address.screened_email_address import (
+	get_global_accepted_domains,
 	get_global_screened_email_addresses,
 	get_screened_email_addresses,
 )
@@ -1225,6 +1226,11 @@ def auto_accept_recipients(account: str, recipients: list) -> None:
 			return
 
 		emails = list({r.email for r in recipients if getattr(r, "email", None)})
+		if emails:
+			# Recipients whose domain a global Accepted rule already covers need no account-level
+			# rule — the global rule already lets their replies through.
+			accepted_domains = get_global_accepted_domains()
+			emails = [e for e in emails if e.split("@")[-1].lower() not in accepted_domains]
 		if emails:
 			_screen_email_addresses(account, emails, action="Accepted", override=False)
 	except Exception:

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -37,9 +37,10 @@ from suite.mail.doctype.mailbox_settings.mailbox_settings import (
 	set_mailbox_settings,
 )
 from suite.mail.doctype.screened_email_address.screened_email_address import (
-	get_global_accepted_domains,
+	get_global_accepted_values,
 	get_global_screened_email_addresses,
 	get_screened_email_addresses,
+	is_globally_accepted,
 )
 from suite.mail.doctype.sieve_script.sieve_script import (
 	SCREENER_MAILBOX_NAME,
@@ -1227,10 +1228,10 @@ def auto_accept_recipients(account: str, recipients: list) -> None:
 
 		emails = list({r.email for r in recipients if getattr(r, "email", None)})
 		if emails:
-			# Recipients whose domain a global Accepted rule already covers need no account-level
-			# rule — the global rule already lets their replies through.
-			accepted_domains = get_global_accepted_domains()
-			emails = [e for e in emails if e.split("@")[-1].lower() not in accepted_domains]
+			# Recipients a global Accepted rule already covers — their exact address or their
+			# domain — need no account-level rule: the global rule already lets their replies through.
+			accepted_values = get_global_accepted_values()
+			emails = [e for e in emails if not is_globally_accepted(e, accepted_values)]
 		if emails:
 			_screen_email_addresses(account, emails, action="Accepted", override=False)
 	except Exception:

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -37,6 +37,7 @@ from suite.mail.doctype.mailbox_settings.mailbox_settings import (
 	set_mailbox_settings,
 )
 from suite.mail.doctype.screened_email_address.screened_email_address import (
+	get_global_screened_email_addresses,
 	get_screened_email_addresses,
 )
 from suite.mail.doctype.sieve_script.sieve_script import (
@@ -1103,6 +1104,19 @@ def get_screened_addresses(account: str) -> list[dict]:
 	is_jmap_account_belongs_to_user(account, raise_exception=True)
 
 	return get_screened_email_addresses(account)
+
+
+@frappe.whitelist()
+def get_global_screened_addresses() -> list[dict]:
+	"""Returns the global screened email addresses — admin-managed rules applying to every account.
+
+	Read-only: the frontend overlays these under the account's own rules (the account's rule wins)
+	when deciding whether a sender is trusted for remote images, mirroring the merge the automation
+	sieve is built from. The settings UI keeps using `get_screened_addresses`, which stays
+	account-only so users never see or edit the global rules there.
+	"""
+
+	return get_global_screened_email_addresses()
 
 
 @frappe.whitelist()

--- a/suite/mail/doctype/screened_email_address/screened_email_address.py
+++ b/suite/mail/doctype/screened_email_address/screened_email_address.py
@@ -138,15 +138,29 @@ def get_global_screened_email_addresses() -> list[dict]:
 	)
 
 
-def get_global_accepted_domains() -> set[str]:
-	"""Returns the domains (lowercased, without the '@' prefix) covered by a global Accepted
-	'@domain' rule — senders from these domains already reach every account's inbox."""
+def get_global_accepted_values() -> set[str]:
+	"""Returns the values (lowercased) of the global Accepted rules — exact email addresses and
+	'@domain' entries (prefix kept) whose senders already reach every account's inbox."""
 
 	return {
-		row.email[1:].lower()
+		row.email.lower()
 		for row in get_global_screened_email_addresses()
-		if row.action == "Accepted" and row.email.startswith("@")
+		if row.action == "Accepted"
 	}
+
+
+def is_globally_accepted(email: str, accepted_values: set[str] | None = None) -> bool:
+	"""Whether the email is covered by a global Accepted rule — its exact address or its '@domain'.
+
+	Pass `accepted_values` (from `get_global_accepted_values`) when checking a batch, so the rules
+	are fetched once.
+	"""
+
+	if accepted_values is None:
+		accepted_values = get_global_accepted_values()
+
+	email = (email or "").lower()
+	return email in accepted_values or "@" + email.split("@")[-1] in accepted_values
 
 
 def get_effective_screened_email_addresses(account: str) -> list[dict]:

--- a/suite/mail/doctype/screened_email_address/screened_email_address.py
+++ b/suite/mail/doctype/screened_email_address/screened_email_address.py
@@ -138,6 +138,17 @@ def get_global_screened_email_addresses() -> list[dict]:
 	)
 
 
+def get_global_accepted_domains() -> set[str]:
+	"""Returns the domains (lowercased, without the '@' prefix) covered by a global Accepted
+	'@domain' rule — senders from these domains already reach every account's inbox."""
+
+	return {
+		row.email[1:].lower()
+		for row in get_global_screened_email_addresses()
+		if row.action == "Accepted" and row.email.startswith("@")
+	}
+
+
 def get_effective_screened_email_addresses(account: str) -> list[dict]:
 	"""Returns the screened email addresses in effect for the account: the global rules overlaid with
 	the account's own, where the account's rule wins when both screen the same email or domain.

--- a/suite/mail/doctype/screened_email_address/test_screened_email_address.py
+++ b/suite/mail/doctype/screened_email_address/test_screened_email_address.py
@@ -70,6 +70,19 @@ class IntegrationTestScreenedEmailAddress(IntegrationTestCase):
 		self.assertEqual(actions["@trusted.com"], "Reject")
 		self.assertEqual(actions["spammer@junk.com"], "Reject")
 
+	def test_global_accepted_domains(self):
+		from suite.mail.doctype.screened_email_address.screened_email_address import (
+			get_global_accepted_domains,
+		)
+
+		self._insert_global_rule("@Trusted.com", "Accepted")
+		self._insert_global_rule("@blocked.com", "Reject")
+		self._insert_global_rule("someone@accepted.com", "Accepted")
+
+		# Only Accepted '@domain' rules count — Reject domains and exact-address rules don't —
+		# and the domain comes back lowercased without the '@' prefix.
+		self.assertEqual(get_global_accepted_domains(), {"trusted.com"})
+
 	def test_duplicate_global_screened_email(self):
 		self._insert_global_rule("dup@example.com", "Reject")
 

--- a/suite/mail/doctype/screened_email_address/test_screened_email_address.py
+++ b/suite/mail/doctype/screened_email_address/test_screened_email_address.py
@@ -70,18 +70,28 @@ class IntegrationTestScreenedEmailAddress(IntegrationTestCase):
 		self.assertEqual(actions["@trusted.com"], "Reject")
 		self.assertEqual(actions["spammer@junk.com"], "Reject")
 
-	def test_global_accepted_domains(self):
+	def test_is_globally_accepted(self):
 		from suite.mail.doctype.screened_email_address.screened_email_address import (
-			get_global_accepted_domains,
+			get_global_accepted_values,
+			is_globally_accepted,
 		)
 
 		self._insert_global_rule("@Trusted.com", "Accepted")
 		self._insert_global_rule("@blocked.com", "Reject")
 		self._insert_global_rule("someone@accepted.com", "Accepted")
 
-		# Only Accepted '@domain' rules count — Reject domains and exact-address rules don't —
-		# and the domain comes back lowercased without the '@' prefix.
-		self.assertEqual(get_global_accepted_domains(), {"trusted.com"})
+		# Only Accepted rules count (Reject domains don't), lowercased with the '@' prefix kept.
+		self.assertEqual(get_global_accepted_values(), {"@trusted.com", "someone@accepted.com"})
+
+		# Covered: by domain rule (case-insensitively) or by exact address.
+		self.assertTrue(is_globally_accepted("anyone@trusted.com"))
+		self.assertTrue(is_globally_accepted("Anyone@Trusted.COM"))
+		self.assertTrue(is_globally_accepted("Someone@accepted.com"))
+
+		# Not covered: other senders from a domain with only an exact-address rule, or from a
+		# domain screened with Reject.
+		self.assertFalse(is_globally_accepted("other@accepted.com"))
+		self.assertFalse(is_globally_accepted("anyone@blocked.com"))
 
 	def test_duplicate_global_screened_email(self):
 		self._insert_global_rule("dup@example.com", "Reject")


### PR DESCRIPTION
Follow-up to #421, wiring the global screened senders into two places that only looked at account-level rules:

**Remote image loading**

The "Remote content hidden" banner ignored global rules — a sender accepted via a global rule (exact address or `@domain`) still had images blocked. The frontend now fetches the admin-managed global rules through a new read-only `get_global_screened_addresses` API and overlays them under the account's own rules (the account's rule wins on the same value, keyed case-insensitively), mirroring the backend's `get_effective_screened_email_addresses` that the automation sieve is built from.

- The settings UI keeps using `get_screened_addresses` (account-only), so global rules still never show up there.
- The merge reads the live `screenedAddresses` resource, so the optimistic updates from "Mark Sender as Trusted" and block/unblock still apply instantly.
- The "This sender is blocked" banner stays account-only: its copy says "your block list" and its Unblock button can only remove account rules.

**Auto-accept on send**

`auto_accept_recipients` now skips recipients already covered by a global Accepted rule — either their exact address or a `@domain` entry covering them — since the global rule already lets their replies through, making the account-level Accepted doc redundant. If every recipient is covered, no docs are created and the sieve rebuild is skipped entirely. Added `get_global_accepted_values()` / `is_globally_accepted()` with a test covering exact-address and case-insensitive domain matching, and that Reject rules don't count.

Verified with the full frontend test suite (1083 passing), a clean production build, and the `test_screened_email_address` module (6 passing).