### PR TITLE
feat(mail): redesign the Admin Dashboard

### DIFF
--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -21,7 +21,11 @@
 			:disable-collapse="isMobile"
 		>
 			<template #footer-items>
-				<QuotaBar v-if="user.data.is_jmap_configured" :is-collapsed="isSidebarCollapsed" />
+				<!-- Personal mailbox quota is meaningless while administering the server. -->
+				<QuotaBar
+					v-if="user.data.is_jmap_configured && !route.meta.isDashboard"
+					:is-collapsed="isSidebarCollapsed"
+				/>
 			</template>
 			<template #sidebar-item="{ item }">
 				<SidebarItem
@@ -106,6 +110,7 @@ import QuotaBar from '@/apps/mail/components/QuotaBar.vue'
 
 import type { MailboxData } from '@/apps/mail/types'
 
+import ArrowLeft from '~icons/lucide/arrow-left'
 import BookUser from '~icons/lucide/book-user'
 import Clock from '~icons/lucide/clock'
 import ContactRound from '~icons/lucide/contact-round'
@@ -113,6 +118,7 @@ import Crown from '~icons/lucide/crown'
 import Ellipsis from '~icons/lucide/ellipsis'
 import Flag from '~icons/lucide/flag'
 import Globe from '~icons/lucide/globe'
+import House from '~icons/lucide/house'
 import KeyRound from '~icons/lucide/key-round'
 import Lock from '~icons/lucide/lock'
 import LogOut from '~icons/lucide/log-out'
@@ -163,6 +169,23 @@ const subtitle = computed(() => {
 	return currentAccount._name
 })
 
+// Leave the dashboard for the active account's default mailbox (or the address
+// books when no mailbox exists yet). Shared by the header menu item and the
+// pinned "Back to Mail" sidebar item.
+const goToMailbox = () => {
+	const mailbox = mailboxes.data?.[0]?.id
+	if (mailbox)
+		router.push({
+			name: 'mail-mailbox',
+			params: { accountId: store.accountId, mailbox },
+		})
+	else
+		router.push({
+			name: 'mail-address-books',
+			params: { accountId: store.accountId },
+		})
+}
+
 const menuItems = computed(() => [
 	{
 		group: '',
@@ -174,19 +197,7 @@ const menuItems = computed(() => [
 			{
 				icon: Mailbox,
 				label: __('Mailbox'),
-				onClick: () => {
-					const mailbox = mailboxes.data?.[0]?.id
-					if (mailbox)
-						router.push({
-							name: 'mail-mailbox',
-							params: { accountId: store.accountId, mailbox },
-						})
-					else
-						router.push({
-							name: 'mail-address-books',
-							params: { accountId: store.accountId },
-						})
-				},
+				onClick: goToMailbox,
 				condition: () =>
 					user.data.is_suite_admin &&
 					user.data.is_jmap_configured &&
@@ -372,8 +383,10 @@ const dashboardItems = [
 			},
 		],
 	},
+	// Logs and Actions each held a group of one whose label repeated the item;
+	// a single System group keeps the nav shorter without losing meaning.
 	{
-		label: __('Observability'),
+		label: __('System'),
 		items: [
 			{
 				label: __('Logs'),
@@ -381,11 +394,6 @@ const dashboardItems = [
 				to: { name: 'mail-logs' },
 				activeFor: ['mail-logs', 'mail-log'],
 			},
-		],
-	},
-	{
-		label: __('Actions'),
-		items: [
 			{
 				label: __('Actions'),
 				icon: Wrench,
@@ -450,7 +458,24 @@ const screeningEnabled = computed(
 )
 
 const sidebarItems = computed(() => {
-	if (route.meta.isDashboard) return dashboardItems
+	if (route.meta.isDashboard) {
+		// A pinned, unlabelled group at the top of the nav: the exit back to the
+		// inbox (previously buried in the header dropdown) and the Overview home.
+		const pinned = [
+			{
+				label: __('Back to Mail'),
+				icon: ArrowLeft,
+				onClick: goToMailbox,
+			},
+			{
+				label: __('Overview'),
+				icon: House,
+				to: { name: 'mail-overview' },
+				activeFor: ['mail-overview'],
+			},
+		]
+		return [{ label: '', items: pinned }, ...dashboardItems]
+	}
 
 	// Screening is a roleless folder; it gets its own nameless group pinned to the top of the
 	// sidebar, separate from the default and custom mailboxes.

--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -461,12 +461,18 @@ const sidebarItems = computed(() => {
 	if (route.meta.isDashboard) {
 		// A pinned, unlabelled group at the top of the nav: the exit back to the
 		// inbox (previously buried in the header dropdown) and the Overview home.
+		// Admins without a JMAP account (e.g. System Managers) have no inbox to
+		// go back to, so the exit is omitted for them.
 		const pinned = [
-			{
-				label: __('Back to Mail'),
-				icon: ArrowLeft,
-				onClick: goToMailbox,
-			},
+			...(user.data?.is_jmap_configured
+				? [
+						{
+							label: __('Back to Mail'),
+							icon: ArrowLeft,
+							onClick: goToMailbox,
+						},
+					]
+				: []),
 			{
 				label: __('Overview'),
 				icon: House,

--- a/frontend/src/apps/mail/components/DNSRecords.vue
+++ b/frontend/src/apps/mail/components/DNSRecords.vue
@@ -1,5 +1,7 @@
 <template>
-	<div class="space-y-4 border-t p-4">
+	<!-- A category with zero records renders nothing: an empty table with a
+	     "Required" badge would read as missing setup data. -->
+	<div v-if="records.length" class="space-y-4 border-t p-4">
 		<div class="space-y-2">
 			<h3 class="flex items-center font-medium">
 				{{ title }}
@@ -20,8 +22,15 @@
 					<template #default="{ item }">
 						<ListRowItem>
 							<Tooltip :text="__('Click to copy')">
-								<div class="cursor-copy truncate" @click="copyToClipBoard(item)">
-									{{ item }}
+								<div
+									class="group/copy flex min-w-0 cursor-copy items-center gap-1.5"
+									@click="copyToClipBoard(item)"
+								>
+									<span class="truncate">{{ item }}</span>
+									<FeatherIcon
+										name="copy"
+										class="text-ink-gray-5 invisible h-3.5 w-3.5 shrink-0 group-hover/copy:visible"
+									/>
 								</div>
 							</Tooltip>
 						</ListRowItem>
@@ -33,7 +42,16 @@
 </template>
 
 <script setup lang="ts">
-import { Badge, ListHeader, ListRow, ListRowItem, ListRows, ListView, Tooltip } from 'frappe-ui'
+import {
+	Badge,
+	FeatherIcon,
+	ListHeader,
+	ListRow,
+	ListRowItem,
+	ListRows,
+	ListView,
+	Tooltip,
+} from 'frappe-ui'
 
 import { copyToClipBoard } from '@/apps/mail/utils'
 
@@ -42,7 +60,7 @@ const { title, description, records } = defineProps<{
 	description: string
 	records: Record<string, string>[]
 	badgeLabel?: string
-	badgeTheme?: 'green' | 'red' | 'gray' | 'orange' | 'blue'
+	badgeTheme?: 'green' | 'red' | 'gray' | 'amber' | 'orange' | 'blue'
 }>()
 
 const LIST_COLUMNS = [

--- a/frontend/src/apps/mail/components/DashboardCard.vue
+++ b/frontend/src/apps/mail/components/DashboardCard.vue
@@ -3,7 +3,14 @@
 		<div class="h-13 py-auto flex shrink-0 items-center justify-between border-b px-4">
 			<h2>{{ title }}</h2>
 			<slot name="actions">
-				<Button variant="ghost" :label="buttonLabel" @click="emit('action')" />
+				<!-- Default action renders only when the parent listens for @action,
+				     so read-only cards get a plain header with no extra markup. -->
+				<Button
+					v-if="hasActionListener"
+					variant="ghost"
+					:label="buttonLabel"
+					@click="emit('action')"
+				/>
 			</slot>
 		</div>
 		<slot />
@@ -11,9 +18,12 @@
 </template>
 
 <script setup lang="ts">
+import { computed, getCurrentInstance } from 'vue'
 import { Button } from 'frappe-ui'
 
 const { buttonLabel = __('Add') } = defineProps<{ title: string; buttonLabel?: string }>()
 
 const emit = defineEmits(['action'])
+
+const hasActionListener = computed(() => !!getCurrentInstance()?.vnode.props?.onAction)
 </script>

--- a/frontend/src/apps/mail/components/DashboardDetailHeader.vue
+++ b/frontend/src/apps/mail/components/DashboardDetailHeader.vue
@@ -1,0 +1,47 @@
+<template>
+	<div class="flex flex-wrap items-center gap-x-4 gap-y-3">
+		<div
+			class="bg-surface-gray-2 text-ink-gray-6 flex h-11 w-11 shrink-0 items-center justify-center rounded-lg"
+		>
+			<slot name="icon">
+				<span class="text-lg font-semibold uppercase">{{ initial }}</span>
+			</slot>
+		</div>
+		<div class="min-w-0 flex-1">
+			<div class="flex min-w-0 items-center gap-2">
+				<h1 class="text-ink-gray-9 truncate text-xl font-semibold leading-6">{{ title }}</h1>
+				<Badge v-if="badgeLabel" :label="badgeLabel" :theme="badgeTheme" />
+			</div>
+			<div
+				v-if="metaItems.length"
+				class="text-ink-gray-5 mt-1 flex min-w-0 flex-wrap items-center gap-x-1.5 text-sm"
+			>
+				<template v-for="(item, index) in metaItems" :key="index">
+					<span v-if="index" class="text-ink-gray-4">·</span>
+					<span class="truncate">{{ item }}</span>
+				</template>
+			</div>
+		</div>
+		<div class="flex shrink-0 items-center gap-2">
+			<slot name="actions" />
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { Badge } from 'frappe-ui'
+
+const { title, meta = [] } = defineProps<{
+	title: string
+	// Short facts shown under the title, separated by dots. Falsy entries are
+	// dropped so callers can pass optional fields without guarding each one.
+	meta?: (string | undefined | null)[]
+	badgeLabel?: string
+	badgeTheme?: 'green' | 'red' | 'gray' | 'amber' | 'blue' | 'violet'
+}>()
+
+const initial = computed(() => title.trim().charAt(0) || '?')
+
+const metaItems = computed(() => meta.filter(Boolean) as string[])
+</script>

--- a/frontend/src/apps/mail/components/DashboardLayout.vue
+++ b/frontend/src/apps/mail/components/DashboardLayout.vue
@@ -3,9 +3,9 @@
 		<header class="flex items-center border-b px-3 py-2.5 sm:px-5">
 			<Button v-if="isMobile" icon="menu" variant="ghost" @click="openSidebar" />
 			<Breadcrumbs :items="breadcrumbs" class="mx-2" />
-			<Badge v-if="badgeLabel" :label="badgeLabel" :theme="badgeTheme" />
+			<Badge v-if="badgeLabel && !loading" :label="badgeLabel" :theme="badgeTheme" />
 			<div class="ml-auto flex space-x-2">
-				<slot name="actions">
+				<slot v-if="!loading" name="actions">
 					<Button
 						v-if="buttonLabel"
 						:label="buttonLabel"
@@ -19,7 +19,12 @@
 			class="flex flex-1 flex-col overflow-y-auto"
 			:class="{ 'space-y-5 px-3 py-5 sm:px-5': !removeSpacing }"
 		>
-			<slot />
+			<!-- While the page resource loads, keep the chrome (header, breadcrumbs)
+			     and show a placeholder body instead of a blank pane. -->
+			<slot v-if="loading" name="loading">
+				<DashboardListSkeleton />
+			</slot>
+			<slot v-else />
 		</div>
 	</div>
 </template>
@@ -28,14 +33,16 @@
 import { Badge, Breadcrumbs, Button } from 'frappe-ui'
 
 import { useScreenSize, useSidebar } from '@/apps/mail/utils/composables'
+import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 
-const { removeSpacing = false } = defineProps<{
+const { removeSpacing = false, loading = false } = defineProps<{
 	breadcrumbs: { label: string; route?: string }[]
 	buttonLabel?: string
 	buttonAction?: () => void
 	badgeLabel?: string
-	badgeTheme?: 'green' | 'red' | 'gray' | 'orange' | 'blue'
+	badgeTheme?: 'green' | 'red' | 'gray' | 'amber' | 'orange' | 'blue' | 'violet'
 	removeSpacing?: boolean
+	loading?: boolean
 }>()
 
 const { isMobile } = useScreenSize()

--- a/frontend/src/apps/mail/components/DashboardListSkeleton.vue
+++ b/frontend/src/apps/mail/components/DashboardListSkeleton.vue
@@ -1,0 +1,25 @@
+<template>
+	<div class="flex flex-col" :aria-label="__('Loading')" role="status">
+		<div class="flex items-center gap-4 border-b py-2">
+			<Skeleton v-for="column in columns" :key="column" class="h-3 flex-1 rounded" />
+		</div>
+		<div v-for="row in rows" :key="row" class="flex items-center gap-4 py-3.5">
+			<Skeleton
+				v-for="column in columns"
+				:key="column"
+				class="h-3.5 flex-1 rounded"
+				:style="{ maxWidth: `${widthFor(row, column)}%` }"
+			/>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { Skeleton } from 'frappe-ui'
+
+const { rows = 8, columns = 4 } = defineProps<{ rows?: number; columns?: number }>()
+
+// Deterministic pseudo-random widths so the placeholder reads as text of
+// varying length instead of a uniform grid.
+const widthFor = (row: number, column: number) => 45 + ((row * 7 + column * 13) % 40)
+</script>

--- a/frontend/src/apps/mail/components/Modals/AddDomainModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddDomainModal.vue
@@ -8,6 +8,7 @@
 					label: __('Add Domain'),
 					variant: 'solid',
 					disabled: !domainName,
+					loading: addDomain.loading,
 					onClick: addDomain.submit,
 				},
 			],
@@ -35,7 +36,7 @@
 					type="textarea"
 				/>
 				<ErrorMessage
-					:message="addDomain.error?.messages[0] || addDomain.error?.message"
+					:message="addDomain.error && (addDomain.error?.messages?.[0] || addDomain.error?.message || __('Request failed.'))"
 				/>
 			</div>
 		</template>

--- a/frontend/src/apps/mail/components/Modals/AddDomainModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddDomainModal.vue
@@ -28,6 +28,7 @@
 					:label="__('Domain Name')"
 					placeholder="example.com"
 					autocomplete="off"
+					:description="__('After adding, copy the generated DNS records to your DNS provider.')"
 				/>
 				<FormControl
 					v-model="domainDescription"

--- a/frontend/src/apps/mail/components/Modals/AddGroupEmailModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddGroupEmailModal.vue
@@ -29,6 +29,9 @@
 						:open-on-click="true"
 					/>
 				</div>
+				<p class="text-ink-gray-4 -mt-2 text-xs">
+					{{ __('Mail sent to this address is delivered to this group.') }}
+				</p>
 				<FormControl
 					v-model="description"
 					:label="__('Description')"

--- a/frontend/src/apps/mail/components/Modals/AddGroupEmailModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddGroupEmailModal.vue
@@ -4,7 +4,13 @@
 		:options="{
 			title: __('Add Email Address'),
 			actions: [
-				{ label: __('Add'), variant: 'solid', disabled: !(username && domain), onClick: addEmail.submit },
+				{
+					label: __('Add'),
+					variant: 'solid',
+					disabled: !(username && domain),
+					loading: addEmail.loading,
+					onClick: addEmail.submit,
+				},
 			],
 		}"
 	>
@@ -28,7 +34,9 @@
 					:label="__('Description')"
 					:placeholder="__('Used as the display name for this address')"
 				/>
-				<ErrorMessage :message="addEmail.error?.messages?.[0] || addEmail.error?.message" />
+				<ErrorMessage
+					:message="addEmail.error && (addEmail.error?.messages?.[0] || addEmail.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/AddGroupMembersModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddGroupMembersModal.vue
@@ -4,7 +4,13 @@
 		:options="{
 			title: __('Add Members'),
 			actions: [
-				{ label: __('Add'), variant: 'solid', disabled: !accountIds.length, onClick: addMembers.submit },
+				{
+					label: __('Add'),
+					variant: 'solid',
+					disabled: !accountIds.length,
+					loading: addMembers.loading,
+					onClick: addMembers.submit,
+				},
 			],
 		}"
 	>
@@ -12,7 +18,9 @@
 			<div class="space-y-1.5">
 				<label class="text-ink-gray-5 block text-xs">{{ __('Accounts') }}</label>
 				<MultiSelect v-model="accountIds" :options="options" />
-				<ErrorMessage :message="addMembers.error?.messages?.[0] || addMembers.error?.message" />
+				<ErrorMessage
+					:message="addMembers.error && (addMembers.error?.messages?.[0] || addMembers.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/AddGroupModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddGroupModal.vue
@@ -8,6 +8,7 @@
 					label: __('Add Group'),
 					variant: 'solid',
 					disabled: !(name && domain),
+					loading: addGroup.loading,
 					onClick: addGroup.submit,
 				},
 			],
@@ -36,7 +37,9 @@
 					<label class="text-ink-gray-5 block text-xs">{{ __('Roles') }}</label>
 					<MultiSelect v-model="roleIds" :options="roleOptions" />
 				</div>
-				<ErrorMessage :message="addGroup.error?.messages?.[0] || addGroup.error?.message" />
+				<ErrorMessage
+					:message="addGroup.error && (addGroup.error?.messages?.[0] || addGroup.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/AddGroupModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddGroupModal.vue
@@ -21,6 +21,7 @@
 					:label="__('Name')"
 					placeholder="team"
 					autocomplete="off"
+					:description="__('Together with the domain, this forms the group\'s email address.')"
 				/>
 				<FormControl
 					v-model="domain"

--- a/frontend/src/apps/mail/components/Modals/AddMailingListEmailModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddMailingListEmailModal.vue
@@ -29,6 +29,9 @@
 						:open-on-click="true"
 					/>
 				</div>
+				<p class="text-ink-gray-4 -mt-2 text-xs">
+					{{ __('Mail sent to this address is distributed to the list\'s recipients.') }}
+				</p>
 				<FormControl
 					v-model="description"
 					:label="__('Description')"

--- a/frontend/src/apps/mail/components/Modals/AddMailingListEmailModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddMailingListEmailModal.vue
@@ -4,7 +4,13 @@
 		:options="{
 			title: __('Add Email Address'),
 			actions: [
-				{ label: __('Add'), variant: 'solid', disabled: !(username && domain), onClick: addEmail.submit },
+				{
+					label: __('Add'),
+					variant: 'solid',
+					disabled: !(username && domain),
+					loading: addEmail.loading,
+					onClick: addEmail.submit,
+				},
 			],
 		}"
 	>
@@ -28,7 +34,9 @@
 					:label="__('Description')"
 					:placeholder="__('Used as the display name for this address')"
 				/>
-				<ErrorMessage :message="addEmail.error?.messages?.[0] || addEmail.error?.message" />
+				<ErrorMessage
+					:message="addEmail.error && (addEmail.error?.messages?.[0] || addEmail.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/AddMailingListModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddMailingListModal.vue
@@ -16,7 +16,13 @@
 	>
 		<template #body-content>
 			<div class="space-y-4">
-				<FormControl v-model="name" :label="__('Name')" placeholder="announce" autocomplete="off" />
+				<FormControl
+					v-model="name"
+					:label="__('Name')"
+					placeholder="announce"
+					autocomplete="off"
+					:description="__('Together with the domain, this forms the list\'s email address.')"
+				/>
 				<FormControl v-model="domain" type="select" :label="__('Domain')" :options="domainOptions" />
 				<FormControl v-model="description" :label="__('Description')" type="textarea" />
 				<FormControl

--- a/frontend/src/apps/mail/components/Modals/AddMailingListModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddMailingListModal.vue
@@ -8,6 +8,7 @@
 					label: __('Add Mailing List'),
 					variant: 'solid',
 					disabled: !(name && domain),
+					loading: addList.loading,
 					onClick: addList.submit,
 				},
 			],
@@ -24,7 +25,9 @@
 					type="textarea"
 					:placeholder="__('One email address per line')"
 				/>
-				<ErrorMessage :message="addList.error?.messages?.[0] || addList.error?.message" />
+				<ErrorMessage
+					:message="addList.error && (addList.error?.messages?.[0] || addList.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/AddMailingListRecipientsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddMailingListRecipientsModal.vue
@@ -4,7 +4,13 @@
 		:options="{
 			title: __('Add Recipients'),
 			actions: [
-				{ label: __('Add'), variant: 'solid', disabled: !validEmails.length, onClick: addRecipients.submit },
+				{
+					label: __('Add'),
+					variant: 'solid',
+					disabled: !validEmails.length,
+					loading: addRecipients.loading,
+					onClick: addRecipients.submit,
+				},
 			],
 		}"
 	>
@@ -32,7 +38,9 @@
 						<template #prefix><FeatherIcon name="plus" class="h-4 w-4" /></template>
 					</Button>
 				</div>
-				<ErrorMessage :message="addRecipients.error?.messages?.[0] || addRecipients.error?.message" />
+				<ErrorMessage
+					:message="addRecipients.error && (addRecipients.error?.messages?.[0] || addRecipients.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/AddMemberEmailModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddMemberEmailModal.vue
@@ -4,7 +4,13 @@
 		:options="{
 			title: __('Add Email Address'),
 			actions: [
-				{ label: __('Add'), variant: 'solid', disabled: !(username && domain), onClick: addEmail.submit },
+				{
+					label: __('Add'),
+					variant: 'solid',
+					disabled: !(username && domain),
+					loading: addEmail.loading,
+					onClick: addEmail.submit,
+				},
 			],
 		}"
 	>
@@ -28,7 +34,9 @@
 					:label="__('Full Name')"
 					:placeholder="__('Used as the display name for this address')"
 				/>
-				<ErrorMessage :message="addEmail.error?.messages?.[0] || addEmail.error?.message" />
+				<ErrorMessage
+					:message="addEmail.error && (addEmail.error?.messages?.[0] || addEmail.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/AddMemberEmailModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddMemberEmailModal.vue
@@ -29,6 +29,9 @@
 						:open-on-click="true"
 					/>
 				</div>
+				<p class="text-ink-gray-4 -mt-2 text-xs">
+					{{ __('Mail sent to this address is delivered to this member\'s mailbox.') }}
+				</p>
 				<FormControl
 					v-model="description"
 					:label="__('Full Name')"

--- a/frontend/src/apps/mail/components/Modals/AddMemberGroupsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddMemberGroupsModal.vue
@@ -4,7 +4,13 @@
 		:options="{
 			title: __('Add to Groups'),
 			actions: [
-				{ label: __('Add'), variant: 'solid', disabled: !groupIds.length, onClick: addGroups.submit },
+				{
+					label: __('Add'),
+					variant: 'solid',
+					disabled: !groupIds.length,
+					loading: addGroups.loading,
+					onClick: addGroups.submit,
+				},
 			],
 		}"
 	>
@@ -12,7 +18,9 @@
 			<div class="space-y-1.5">
 				<label class="text-ink-gray-5 block text-xs">{{ __('Groups') }}</label>
 				<MultiSelect v-model="groupIds" :options="options" />
-				<ErrorMessage :message="addGroups.error?.messages?.[0] || addGroups.error?.message" />
+				<ErrorMessage
+					:message="addGroups.error && (addGroups.error?.messages?.[0] || addGroups.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/AddMemberMailingListsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddMemberMailingListsModal.vue
@@ -4,7 +4,13 @@
 		:options="{
 			title: __('Add to Mailing Lists'),
 			actions: [
-				{ label: __('Add'), variant: 'solid', disabled: !listIds.length, onClick: addLists.submit },
+				{
+					label: __('Add'),
+					variant: 'solid',
+					disabled: !listIds.length,
+					loading: addLists.loading,
+					onClick: addLists.submit,
+				},
 			],
 		}"
 	>
@@ -12,7 +18,9 @@
 			<div class="space-y-1.5">
 				<label class="text-ink-gray-5 block text-xs">{{ __('Mailing Lists') }}</label>
 				<MultiSelect v-model="listIds" :options="options" />
-				<ErrorMessage :message="addLists.error?.messages?.[0] || addLists.error?.message" />
+				<ErrorMessage
+					:message="addLists.error && (addLists.error?.messages?.[0] || addLists.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/AddMemberModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddMemberModal.vue
@@ -7,6 +7,7 @@
 				{
 					label: __(accountRequest.send_invite ? 'Invite Member' : 'Add Member'),
 					variant: 'solid',
+					loading: addMember.loading,
 					onClick: addMember.submit,
 				},
 			],
@@ -133,7 +134,9 @@
 						/>
 					</div>
 				</template>
-				<ErrorMessage :message="addMember.error?.messages[0]" />
+				<ErrorMessage
+					:message="addMember.error && (addMember.error?.messages?.[0] || addMember.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/AddMemberModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddMemberModal.vue
@@ -69,6 +69,7 @@
 					type="email"
 					:label="__('Backup Email')"
 					placeholder="johndoe@personal.com"
+					:description="__('Password resets and the invitation email are sent to this address.')"
 				/>
 				<FormControl
 					v-model="accountRequest.quota_gb"
@@ -97,6 +98,7 @@
 					v-model="accountRequest.expires_at"
 					:label="__('Expires At')"
 					type="datetime-local"
+					:description="__('The invitation link stops working after this time.')"
 				/>
 				<template v-else>
 					<FormControl
@@ -114,6 +116,7 @@
 						type="password"
 						:label="__('Password')"
 						placeholder="••••••••"
+						:description="__('The member can change this later in their account settings.')"
 					/>
 					<!-- Only set here when the account is created right away; an invited member picks
 					their own on the setup form. -->

--- a/frontend/src/apps/mail/components/Modals/AddOAuthClientModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddOAuthClientModal.vue
@@ -4,7 +4,13 @@
 		:options="{
 			title: __('Add OAuth Client'),
 			actions: [
-				{ label: __('Add OAuth Client'), variant: 'solid', disabled: !clientId, onClick: addClient.submit },
+				{
+					label: __('Add OAuth Client'),
+					variant: 'solid',
+					disabled: !clientId,
+					loading: addClient.loading,
+					onClick: addClient.submit,
+				},
 			],
 		}"
 	>
@@ -46,7 +52,9 @@
 					type="textarea"
 				/>
 				<FormControl v-model="expiresAt" type="datetime-local" :label="__('Expires At')" />
-				<ErrorMessage :message="addClient.error?.messages?.[0] || addClient.error?.message" />
+				<ErrorMessage
+					:message="addClient.error && (addClient.error?.messages?.[0] || addClient.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/AddOAuthClientModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddOAuthClientModal.vue
@@ -16,11 +16,19 @@
 	>
 		<template #body-content>
 			<div class="space-y-4">
-				<FormControl v-model="clientId" :label="__('Client ID')" autocomplete="off" />
+				<FormControl
+					v-model="clientId"
+					:label="__('Client ID')"
+					autocomplete="off"
+					:description="__('The unique identifier the application uses to identify itself.')"
+				/>
 				<FormControl v-model="description" :label="__('Description')" type="textarea" />
 
 				<div class="space-y-2">
 					<label class="text-ink-gray-5 block text-xs">{{ __('Contacts') }}</label>
+					<p class="text-ink-gray-4 text-xs">
+						{{ __('Email addresses responsible for this application.') }}
+					</p>
 					<div v-for="(row, index) in contacts" :key="index" class="flex items-center gap-2">
 						<FormControl v-model="row.value" type="email" placeholder="someone@example.com" class="w-full" />
 						<Button v-if="contacts.length > 1" variant="ghost" theme="red" @click="contacts.splice(index, 1)">
@@ -34,6 +42,9 @@
 
 				<div class="space-y-2">
 					<label class="text-ink-gray-5 block text-xs">{{ __('Redirect URIs') }}</label>
+					<p class="text-ink-gray-4 text-xs">
+						{{ __('Sign-ins are only redirected back to one of these URLs.') }}
+					</p>
 					<div v-for="(row, index) in redirectUris" :key="index" class="flex items-center gap-2">
 						<FormControl v-model="row.value" placeholder="https://app.example.com/callback" class="w-full" />
 						<Button v-if="redirectUris.length > 1" variant="ghost" theme="red" @click="redirectUris.splice(index, 1)">
@@ -45,13 +56,23 @@
 					</Button>
 				</div>
 
-				<FormControl v-model="secret" :label="__('Client Secret')" autocomplete="off" />
+				<FormControl
+					v-model="secret"
+					:label="__('Client Secret')"
+					autocomplete="off"
+					:description="__('Optional. Leave blank if the client authenticates without a secret.')"
+				/>
 				<FormControl
 					v-model="logo"
 					:label="__('Logo (URL or base64 encoded)')"
 					type="textarea"
 				/>
-				<FormControl v-model="expiresAt" type="datetime-local" :label="__('Expires At')" />
+				<FormControl
+					v-model="expiresAt"
+					type="datetime-local"
+					:label="__('Expires At')"
+					:description="__('The client can no longer be used after this time.')"
+				/>
 				<ErrorMessage
 					:message="addClient.error && (addClient.error?.messages?.[0] || addClient.error?.message || __('Request failed.'))"
 				/>

--- a/frontend/src/apps/mail/components/Modals/AddOAuthContactsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddOAuthContactsModal.vue
@@ -4,7 +4,13 @@
 		:options="{
 			title: __('Add Contacts'),
 			actions: [
-				{ label: __('Add'), variant: 'solid', disabled: !validContacts.length, onClick: addContacts.submit },
+				{
+					label: __('Add'),
+					variant: 'solid',
+					disabled: !validContacts.length,
+					loading: addContacts.loading,
+					onClick: addContacts.submit,
+				},
 			],
 		}"
 	>
@@ -32,7 +38,9 @@
 						<template #prefix><FeatherIcon name="plus" class="h-4 w-4" /></template>
 					</Button>
 				</div>
-				<ErrorMessage :message="addContacts.error?.messages?.[0] || addContacts.error?.message" />
+				<ErrorMessage
+					:message="addContacts.error && (addContacts.error?.messages?.[0] || addContacts.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/AddOAuthRedirectUrisModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddOAuthRedirectUrisModal.vue
@@ -3,7 +3,15 @@
 		v-model="show"
 		:options="{
 			title: __('Add Redirect URIs'),
-			actions: [{ label: __('Add'), variant: 'solid', disabled: !validUris.length, onClick: addUris.submit }],
+			actions: [
+				{
+					label: __('Add'),
+					variant: 'solid',
+					disabled: !validUris.length,
+					loading: addUris.loading,
+					onClick: addUris.submit,
+				},
+			],
 		}"
 	>
 		<template #body-content>
@@ -24,7 +32,9 @@
 						<template #prefix><FeatherIcon name="plus" class="h-4 w-4" /></template>
 					</Button>
 				</div>
-				<ErrorMessage :message="addUris.error?.messages?.[0] || addUris.error?.message" />
+				<ErrorMessage
+					:message="addUris.error && (addUris.error?.messages?.[0] || addUris.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/AddQueuedRecipientModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddQueuedRecipientModal.vue
@@ -3,13 +3,23 @@
 		v-model="show"
 		:options="{
 			title: __('Add Recipient'),
-			actions: [{ label: __('Add'), variant: 'solid', disabled: !email, onClick: addRecipient.submit }],
+			actions: [
+				{
+					label: __('Add'),
+					variant: 'solid',
+					disabled: !email,
+					loading: addRecipient.loading,
+					onClick: addRecipient.submit,
+				},
+			],
 		}"
 	>
 		<template #body-content>
 			<div class="space-y-4">
 				<FormControl v-model="email" :label="__('Email')" type="email" placeholder="someone@example.com" />
-				<ErrorMessage :message="addRecipient.error?.messages?.[0] || addRecipient.error?.message" />
+				<ErrorMessage
+					:message="addRecipient.error && (addRecipient.error?.messages?.[0] || addRecipient.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/AddRoleModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddRoleModal.vue
@@ -16,7 +16,12 @@
 	>
 		<template #body-content>
 			<div class="space-y-4">
-				<FormControl v-model="description" :label="__('Description')" autocomplete="off" />
+				<FormControl
+					v-model="description"
+					:label="__('Description')"
+					autocomplete="off"
+					:description="__('Shown as the role\'s name across the dashboard.')"
+				/>
 				<div class="space-y-1.5">
 					<label class="text-ink-gray-5 block text-xs">{{ __('Enabled Permissions') }}</label>
 					<MultiSelect v-model="enabledPermissions" :options="permissionOptions" />

--- a/frontend/src/apps/mail/components/Modals/AddRoleModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddRoleModal.vue
@@ -4,7 +4,13 @@
 		:options="{
 			title: __('Add Role'),
 			actions: [
-				{ label: __('Add Role'), variant: 'solid', disabled: !description, onClick: addRole.submit },
+				{
+					label: __('Add Role'),
+					variant: 'solid',
+					disabled: !description,
+					loading: addRole.loading,
+					onClick: addRole.submit,
+				},
 			],
 		}"
 	>
@@ -23,7 +29,9 @@
 					<label class="text-ink-gray-5 block text-xs">{{ __('Inherited Roles') }}</label>
 					<MultiSelect v-model="roleIds" :options="roleOptions" />
 				</div>
-				<ErrorMessage :message="addRole.error?.messages?.[0] || addRole.error?.message" />
+				<ErrorMessage
+					:message="addRole.error && (addRole.error?.messages?.[0] || addRole.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/ChangeMemberPasswordModal.vue
+++ b/frontend/src/apps/mail/components/Modals/ChangeMemberPasswordModal.vue
@@ -38,7 +38,10 @@ const confirmPassword = ref('')
 const errorMessage = computed(() =>
 	confirmPassword.value && confirmPassword.value !== newPassword.value
 		? __('Passwords do not match')
-		: changePassword.error?.messages?.[0],
+		: changePassword.error &&
+			(changePassword.error?.messages?.[0] ||
+				changePassword.error?.message ||
+				__('Request failed.')),
 )
 
 const dialogOptions = computed(() => ({
@@ -47,6 +50,7 @@ const dialogOptions = computed(() => ({
 		{
 			label: __('Confirm'),
 			variant: 'solid',
+			loading: changePassword.loading,
 			onClick: () => changePassword.submit(),
 			disabled: !newPassword.value.length || confirmPassword.value !== newPassword.value,
 		},

--- a/frontend/src/apps/mail/components/Modals/EditGroupModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditGroupModal.vue
@@ -3,7 +3,14 @@
 		v-model="show"
 		:options="{
 			title: __('Edit Group'),
-			actions: [{ label: __('Save'), variant: 'solid', onClick: updateGroup.submit }],
+			actions: [
+				{
+					label: __('Save'),
+					variant: 'solid',
+					loading: updateGroup.loading,
+					onClick: updateGroup.submit,
+				},
+			],
 		}"
 	>
 		<template #body-content>
@@ -21,7 +28,9 @@
 					<label class="text-ink-gray-5 block text-xs">{{ __('Time Zone') }}</label>
 					<Combobox v-model="timeZone" :options="timeZoneOptions" :placeholder="__('Select a time zone')" />
 				</div>
-				<ErrorMessage :message="updateGroup.error?.messages?.[0] || updateGroup.error?.message" />
+				<ErrorMessage
+					:message="updateGroup.error && (updateGroup.error?.messages?.[0] || updateGroup.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/EditGroupQuotaModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditGroupQuotaModal.vue
@@ -3,13 +3,22 @@
 		v-model="show"
 		:options="{
 			title: __('Edit Quota'),
-			actions: [{ label: __('Save'), variant: 'solid', onClick: updateQuota.submit }],
+			actions: [
+				{
+					label: __('Save'),
+					variant: 'solid',
+					loading: updateQuota.loading,
+					onClick: updateQuota.submit,
+				},
+			],
 		}"
 	>
 		<template #body-content>
 			<div class="space-y-4">
 				<FormControl v-model="quotaGb" type="number" :min="0" :label="__('Quota (GB, 0 = unlimited)')" />
-				<ErrorMessage :message="updateQuota.error?.messages?.[0] || updateQuota.error?.message" />
+				<ErrorMessage
+					:message="updateQuota.error && (updateQuota.error?.messages?.[0] || updateQuota.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/EditInviteModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditInviteModal.vue
@@ -63,6 +63,7 @@
 					v-model="accountRequest.doc.expires_at"
 					type="datetime-local"
 					:label="__('Expires At')"
+					:description="__('The invitation link stops working after this time.')"
 					:disabled="!isEditableInvite"
 				/>
 				<hr />

--- a/frontend/src/apps/mail/components/Modals/EditInviteModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditInviteModal.vue
@@ -18,6 +18,7 @@
 					label: __('Save'),
 					variant: 'solid',
 					disabled: !isEditableInvite || !accountRequest.isDirty,
+					loading: accountRequest.save?.loading,
 					onClick: saveInvite,
 				},
 			],
@@ -126,7 +127,7 @@ type MethodResource = { submit?: () => void; loading?: boolean }
 type AccountRequestResource = {
 	doc?: InviteDoc
 	isDirty: boolean
-	save?: { submit?: () => void }
+	save?: { submit?: () => void; loading?: boolean }
 	reload?: () => void
 	sendVerificationEmail?: MethodResource
 }
@@ -204,8 +205,8 @@ const getMailAccountRequest = () =>
 				raiseToast(__('Invite updated.'))
 				emit('reloadInvites')
 			},
-			onError: (error: { messages?: string[] }) => {
-				raiseToast(error.messages?.[0] || __('Failed to update invite.'), 'error')
+			onError: (error: { messages?: string[]; message?: string }) => {
+				raiseToast(error?.messages?.[0] || error?.message || __('Request failed.'), 'error')
 				accountRequest.value?.reload?.()
 			},
 		},
@@ -213,8 +214,8 @@ const getMailAccountRequest = () =>
 			sendVerificationEmail: {
 				method: 'send_verification_email',
 				onSuccess: () => raiseToast(__('Invitation email sent.')),
-				onError: (error: { messages?: string[] }) =>
-					raiseToast(error.messages?.[0] || __('Failed to send invitation email.'), 'error'),
+				onError: (error: { messages?: string[]; message?: string }) =>
+					raiseToast(error?.messages?.[0] || error?.message || __('Request failed.'), 'error'),
 			},
 		},
 	})

--- a/frontend/src/apps/mail/components/Modals/EditMailingListModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditMailingListModal.vue
@@ -3,13 +3,22 @@
 		v-model="show"
 		:options="{
 			title: __('Edit Mailing List'),
-			actions: [{ label: __('Save'), variant: 'solid', onClick: updateList.submit }],
+			actions: [
+				{
+					label: __('Save'),
+					variant: 'solid',
+					loading: updateList.loading,
+					onClick: updateList.submit,
+				},
+			],
 		}"
 	>
 		<template #body-content>
 			<div class="space-y-4">
 				<FormControl v-model="description" :label="__('Description')" />
-				<ErrorMessage :message="updateList.error?.messages?.[0] || updateList.error?.message" />
+				<ErrorMessage
+					:message="updateList.error && (updateList.error?.messages?.[0] || updateList.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/EditMemberModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditMemberModal.vue
@@ -3,7 +3,15 @@
 		v-model="show"
 		:options="{
 			title: __('Edit Member'),
-			actions: [{ label: __('Save'), variant: 'solid', disabled: !description, onClick: updateMember.submit }],
+			actions: [
+				{
+					label: __('Save'),
+					variant: 'solid',
+					disabled: !description,
+					loading: updateMember.loading,
+					onClick: updateMember.submit,
+				},
+			],
 		}"
 	>
 		<template #body-content>
@@ -18,7 +26,9 @@
 					<label class="text-ink-gray-5 block text-xs">{{ __('Time Zone') }}</label>
 					<Combobox v-model="timeZone" :options="timeZoneOptions" :placeholder="__('Select a time zone')" />
 				</div>
-				<ErrorMessage :message="updateMember.error?.messages?.[0] || updateMember.error?.message" />
+				<ErrorMessage
+					:message="updateMember.error && (updateMember.error?.messages?.[0] || updateMember.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/EditMemberQuotaModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditMemberQuotaModal.vue
@@ -3,7 +3,14 @@
 		v-model="show"
 		:options="{
 			title: __('Edit Quota'),
-			actions: [{ label: __('Save'), variant: 'solid', onClick: updateQuota.submit }],
+			actions: [
+				{
+					label: __('Save'),
+					variant: 'solid',
+					loading: updateQuota.loading,
+					onClick: updateQuota.submit,
+				},
+			],
 		}"
 	>
 		<template #body-content>
@@ -14,7 +21,9 @@
 					:min="0"
 					:label="__('Quota (GB, 0 = unlimited)')"
 				/>
-				<ErrorMessage :message="updateQuota.error?.messages?.[0] || updateQuota.error?.message" />
+				<ErrorMessage
+					:message="updateQuota.error && (updateQuota.error?.messages?.[0] || updateQuota.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/EditOAuthClientModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditOAuthClientModal.vue
@@ -24,7 +24,12 @@
 					:placeholder="__('Leave blank to keep unchanged')"
 				/>
 				<FormControl v-model="logo" :label="__('Logo (URL or base64 encoded)')" type="textarea" />
-				<FormControl v-model="expiresAt" type="datetime-local" :label="__('Expires At')" />
+				<FormControl
+					v-model="expiresAt"
+					type="datetime-local"
+					:label="__('Expires At')"
+					:description="__('The client can no longer be used after this time.')"
+				/>
 				<ErrorMessage
 					:message="updateClient.error && (updateClient.error?.messages?.[0] || updateClient.error?.message || __('Request failed.'))"
 				/>

--- a/frontend/src/apps/mail/components/Modals/EditOAuthClientModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditOAuthClientModal.vue
@@ -3,7 +3,14 @@
 		v-model="show"
 		:options="{
 			title: __('Edit OAuth Client'),
-			actions: [{ label: __('Save'), variant: 'solid', onClick: updateClient.submit }],
+			actions: [
+				{
+					label: __('Save'),
+					variant: 'solid',
+					loading: updateClient.loading,
+					onClick: updateClient.submit,
+				},
+			],
 		}"
 	>
 		<template #body-content>
@@ -18,7 +25,9 @@
 				/>
 				<FormControl v-model="logo" :label="__('Logo (URL or base64 encoded)')" type="textarea" />
 				<FormControl v-model="expiresAt" type="datetime-local" :label="__('Expires At')" />
-				<ErrorMessage :message="updateClient.error?.messages?.[0] || updateClient.error?.message" />
+				<ErrorMessage
+					:message="updateClient.error && (updateClient.error?.messages?.[0] || updateClient.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/EditQueuedMessageModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditQueuedMessageModal.vue
@@ -15,7 +15,12 @@
 	>
 		<template #body-content>
 			<div class="space-y-4">
-				<FormControl v-model="nextRetry" :label="__('Next Retry')" type="datetime-local" />
+				<FormControl
+					v-model="nextRetry"
+					:label="__('Next Retry')"
+					type="datetime-local"
+					:description="__('The next delivery attempt is scheduled for this time.')"
+				/>
 				<ErrorMessage
 					:message="updateMessage.error && (updateMessage.error?.messages?.[0] || updateMessage.error?.message || __('Request failed.'))"
 				/>

--- a/frontend/src/apps/mail/components/Modals/EditQueuedMessageModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditQueuedMessageModal.vue
@@ -3,13 +3,22 @@
 		v-model="show"
 		:options="{
 			title: __('Edit Queued Message'),
-			actions: [{ label: __('Save'), variant: 'solid', onClick: updateMessage.submit }],
+			actions: [
+				{
+					label: __('Save'),
+					variant: 'solid',
+					loading: updateMessage.loading,
+					onClick: updateMessage.submit,
+				},
+			],
 		}"
 	>
 		<template #body-content>
 			<div class="space-y-4">
 				<FormControl v-model="nextRetry" :label="__('Next Retry')" type="datetime-local" />
-				<ErrorMessage :message="updateMessage.error?.messages?.[0] || updateMessage.error?.message" />
+				<ErrorMessage
+					:message="updateMessage.error && (updateMessage.error?.messages?.[0] || updateMessage.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/EditQueuedRecipientModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditQueuedRecipientModal.vue
@@ -4,7 +4,14 @@
 		:options="{
 			title: __('Edit Recipient'),
 			size: '3xl',
-			actions: [{ label: __('Save'), variant: 'solid', onClick: updateRecipient.submit }],
+			actions: [
+				{
+					label: __('Save'),
+					variant: 'solid',
+					loading: updateRecipient.loading,
+					onClick: updateRecipient.submit,
+				},
+			],
 		}"
 	>
 		<template #body-content>
@@ -79,7 +86,9 @@
 					</div>
 				</section>
 
-				<ErrorMessage :message="updateRecipient.error?.messages?.[0] || updateRecipient.error?.message" />
+				<ErrorMessage
+					:message="updateRecipient.error && (updateRecipient.error?.messages?.[0] || updateRecipient.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/EditRoleModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditRoleModal.vue
@@ -3,13 +3,23 @@
 		v-model="show"
 		:options="{
 			title: __('Edit Role'),
-			actions: [{ label: __('Save'), variant: 'solid', disabled: !description, onClick: updateRole.submit }],
+			actions: [
+				{
+					label: __('Save'),
+					variant: 'solid',
+					disabled: !description,
+					loading: updateRole.loading,
+					onClick: updateRole.submit,
+				},
+			],
 		}"
 	>
 		<template #body-content>
 			<div class="space-y-4">
 				<FormControl v-model="description" :label="__('Description')" autocomplete="off" />
-				<ErrorMessage :message="updateRole.error?.messages?.[0] || updateRole.error?.message" />
+				<ErrorMessage
+					:message="updateRole.error && (updateRole.error?.messages?.[0] || updateRole.error?.message || __('Request failed.'))"
+				/>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Modals/EditRoleModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditRoleModal.vue
@@ -16,7 +16,12 @@
 	>
 		<template #body-content>
 			<div class="space-y-4">
-				<FormControl v-model="description" :label="__('Description')" autocomplete="off" />
+				<FormControl
+					v-model="description"
+					:label="__('Description')"
+					autocomplete="off"
+					:description="__('Shown as the role\'s name across the dashboard.')"
+				/>
 				<ErrorMessage
 					:message="updateRole.error && (updateRole.error?.messages?.[0] || updateRole.error?.message || __('Request failed.'))"
 				/>

--- a/frontend/src/apps/mail/components/Modals/RunActionModal.vue
+++ b/frontend/src/apps/mail/components/Modals/RunActionModal.vue
@@ -41,7 +41,11 @@
 					/>
 				</template>
 				<ErrorMessage
-					:message="validationError || runAction.error?.messages?.[0] || runAction.error?.message"
+					:message="
+						validationError ||
+						(runAction.error &&
+							(runAction.error?.messages?.[0] || runAction.error?.message || __('Request failed.')))
+					"
 				/>
 				<div v-if="result">
 					<label class="text-ink-gray-5 mb-1 block text-xs">{{ __('Result') }}</label>
@@ -90,7 +94,7 @@ const dialogOptions = computed(() => ({
 	size: '2xl',
 	actions: hasRun.value
 		? [{ label: __('Close'), variant: 'subtle', onClick: () => (show.value = false) }]
-		: [{ label: __('Run'), variant: 'solid', onClick: run }],
+		: [{ label: __('Run'), variant: 'solid', loading: runAction.loading, onClick: run }],
 }))
 
 const emptyValue = (field: ActionField): FieldValue =>

--- a/frontend/src/apps/mail/components/QuotaDonut.vue
+++ b/frontend/src/apps/mail/components/QuotaDonut.vue
@@ -1,0 +1,84 @@
+<template>
+	<div class="flex flex-1 items-center justify-center gap-8 p-6">
+		<div class="relative shrink-0">
+			<svg :width="DONUT_SIZE" :height="DONUT_SIZE" class="-rotate-90">
+				<circle
+					:cx="DONUT_SIZE / 2"
+					:cy="DONUT_SIZE / 2"
+					:r="DONUT_RADIUS"
+					fill="none"
+					stroke="var(--surface-gray-4)"
+					:stroke-width="DONUT_STROKE"
+				/>
+				<circle
+					v-if="!quota.unlimited && usedDashArc > 0"
+					:cx="DONUT_SIZE / 2"
+					:cy="DONUT_SIZE / 2"
+					:r="DONUT_RADIUS"
+					fill="none"
+					stroke="var(--surface-gray-10)"
+					:stroke-width="DONUT_STROKE"
+					stroke-linecap="round"
+					:stroke-dasharray="`${usedDashArc} ${DONUT_CIRCUMFERENCE}`"
+				/>
+			</svg>
+			<div class="absolute inset-0 flex flex-col items-center justify-center text-center">
+				<span class="text-lg font-semibold">{{ totalQuotaLabel }}</span>
+				<span class="text-ink-gray-5 text-xs">
+					{{ quota.unlimited ? __('Unlimited') : __('Total Quota') }}
+				</span>
+			</div>
+		</div>
+		<div class="space-y-4">
+			<div class="flex items-start gap-2">
+				<span class="bg-surface-gray-10 mt-1 h-3 w-3 shrink-0 rounded-sm" />
+				<div>
+					<p class="text-sm font-medium">{{ usedLabel }}</p>
+					<p class="text-ink-gray-5 text-xs">{{ __('Used') }}</p>
+				</div>
+			</div>
+			<div v-if="!quota.unlimited" class="flex items-start gap-2">
+				<span class="bg-surface-gray-4 mt-1 h-3 w-3 shrink-0 rounded-sm" />
+				<div>
+					<p class="text-sm font-medium">{{ availableLabel }}</p>
+					<p class="text-ink-gray-5 text-xs">{{ __('Available') }}</p>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { formatBytes } from '@/apps/mail/utils'
+
+import type { QuotaUsage } from '@/apps/mail/types'
+
+const { quota } = defineProps<{ quota: QuotaUsage }>()
+
+// Donut geometry.
+const DONUT_SIZE = 140
+const DONUT_STROKE = 12
+const DONUT_RADIUS = (DONUT_SIZE - DONUT_STROKE) / 2
+const DONUT_CIRCUMFERENCE = 2 * Math.PI * DONUT_RADIUS
+
+// Length of the "used" arc. Guarded against sub-pixel arcs (e.g. a few hundred bytes of a
+// multi-GB quota) that a round line cap would otherwise render as a misleading full dot.
+const usedDashArc = computed(() => {
+	const arc = DONUT_CIRCUMFERENCE * ((quota.used_percentage || 0) / 100)
+	return arc >= 1 ? arc : 0
+})
+
+const totalQuotaLabel = computed(() => (quota.unlimited ? '∞' : formatBytes(quota.total || 0)))
+
+const usedLabel = computed(() =>
+	quota.unlimited
+		? formatBytes(quota.used)
+		: `${formatBytes(quota.used)} (${quota.used_percentage.toFixed(1)}%)`,
+)
+
+const availableLabel = computed(
+	() => `${formatBytes(quota.available)} (${quota.available_percentage.toFixed(1)}%)`,
+)
+</script>

--- a/frontend/src/apps/mail/pages/dashboard/ActionsView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/ActionsView.vue
@@ -2,7 +2,6 @@
 	<DashboardLayout :breadcrumbs="[{ label: __('Actions') }]">
 		<div v-if="actions?.data" class="flex flex-col gap-5">
 			<DashboardCard v-for="group in groupedActions" :key="group.label" :title="group.label">
-				<template #actions><span /></template>
 				<div class="grid grid-cols-1 sm:grid-cols-2">
 					<div
 						v-for="(action, index) in group.items"
@@ -34,6 +33,7 @@
 				</div>
 			</DashboardCard>
 		</div>
+		<DashboardListSkeleton v-else :columns="2" />
 	</DashboardLayout>
 	<Dialog v-model="showConfirm" :options="confirmOptions" />
 	<RunActionModal v-model="showRun" :action="activeAction" :fields="activeFields" />
@@ -47,6 +47,7 @@ import { getSessionUser } from '@/boot/session'
 import { raiseToast } from '@/apps/mail/utils'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import DashboardCard from '@/apps/mail/components/DashboardCard.vue'
+import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 import RunActionModal from '@/apps/mail/components/Modals/RunActionModal.vue'
 
 type ActionOption = { value: string; label: string }
@@ -174,6 +175,10 @@ const runAction = createResource({
 	onSuccess: () => {
 		showConfirm.value = false
 		raiseToast(__('Action completed.'))
+	},
+	onError: (error: { messages?: string[] }) => {
+		showConfirm.value = false
+		raiseToast(error.messages?.[0] || __('Request failed.'), 'error')
 	},
 })
 

--- a/frontend/src/apps/mail/pages/dashboard/DeliveryTestView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/DeliveryTestView.vue
@@ -2,17 +2,22 @@
 	<DashboardLayout :breadcrumbs="[{ label: __('Delivery Test') }]">
 		<div class="flex flex-col gap-5">
 			<DashboardCard :title="__('Test SMTP Delivery')">
-				<template #actions><span /></template>
+				<p class="text-ink-gray-5 border-b px-5 py-3 text-sm">
+					{{
+						__(
+							'Trace a live SMTP delivery to any recipient or domain to diagnose DNS, connection and handshake issues.',
+						)
+					}}
+				</p>
 				<div class="flex items-end gap-3 p-5">
-					<div class="flex-1">
-						<label class="text-ink-gray-5 mb-1.5 block text-xs">{{ __('Recipient or domain') }}</label>
-						<FormControl
-							v-model="target"
-							placeholder="someone@example.com"
-							:disabled="running"
-							@keyup.enter="start"
-						/>
-					</div>
+					<FormControl
+						v-model="target"
+						class="w-full max-w-xl"
+						:label="__('Recipient or domain')"
+						placeholder="someone@example.com"
+						:disabled="running"
+						@keyup.enter="start"
+					/>
 					<Button v-if="!running" variant="solid" :label="__('Start Test')" :disabled="!target" @click="start" />
 					<Button v-else theme="red" :label="__('Stop')" @click="stop" />
 				</div>
@@ -133,10 +138,11 @@ const detail = (event: TraceEvent) => {
 
 const dotClass = (type: string) => {
 	// Anchor suffix matches so incidental substrings (e.g. "lost" inside "ehloStart") don't misfire.
-	if (/Success(ful)?$/i.test(type)) return 'bg-green-500'
-	if (/NotFound$/.test(type)) return 'bg-amber-500'
+	// Semantic surface tokens (not raw palette colours) so the dots follow the theme.
+	if (/Success(ful)?$/i.test(type)) return 'bg-surface-green-7'
+	if (/NotFound$/.test(type)) return 'bg-surface-amber-7'
 	if (/(Error|Failed|Fatal|Timeout|Rejected|Denied|Lost|Refused)$/i.test(type) || TERMINAL_ERRORS.has(type))
-		return 'bg-red-500'
+		return 'bg-surface-red-7'
 	return 'bg-surface-gray-5'
 }
 

--- a/frontend/src/apps/mail/pages/dashboard/DkimSignatureView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/DkimSignatureView.vue
@@ -1,60 +1,67 @@
 <template>
 	<DashboardLayout :breadcrumbs="breadcrumbs" :loading="!signature.data">
-		<template #actions>
-			<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
+		<template #default>
+			<DashboardDetailHeader
+				:title="signature.data.domain || signatureId"
+				:meta="[signature.data.algorithm, signature.data.selector]"
+			>
+				<template #icon><FileKey2 class="h-5 w-5" /></template>
+				<template #actions>
+					<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
+				</template>
+			</DashboardDetailHeader>
+			<div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
+				<!-- Signature -->
+				<DashboardCard :title="__('Signature')">
+					<div>
+						<InformationField :label="__('Signature Type')" :value="signature.data.algorithm" />
+						<InformationField :label="__('Selector')" :value="signature.data.selector" />
+					</div>
+				</DashboardCard>
+
+				<!-- Rotation -->
+				<DashboardCard :title="__('Rotation')">
+					<div>
+						<InformationField :label="__('Stage')" :value="stageLabel" />
+						<InformationField :label="__('Created At')" :value="createdAt" />
+						<InformationField :label="__('Next Transition')" :value="nextTransition" />
+					</div>
+				</DashboardCard>
+
+				<!-- Options -->
+				<DashboardCard :title="__('Options')">
+					<div>
+						<InformationField :label="__('Signed Headers')" :value="signedHeaders" />
+						<InformationField :label="__('Canonicalization')" :value="signature.data.canonicalization" />
+						<InformationField :label="__('Expiration')" :value="signature.data.expiration" />
+						<InformationField :label="__('Request Reports')" :value="requestReports" />
+						<InformationField :label="__('Agent User ID')" :value="signature.data.auid" />
+					</div>
+				</DashboardCard>
+
+				<!-- Public Key -->
+				<DashboardCard :title="__('Public Key')">
+					<div class="p-4">
+						<Tooltip :text="__('Click to copy')" :disabled="!publicKey">
+							<div
+								class="group/copy flex items-start gap-1.5"
+								:class="{ 'cursor-copy': publicKey }"
+								@click="publicKey && copyToClipBoard(publicKey)"
+							>
+								<code class="text-ink-gray-7 block break-all font-mono text-xs">
+									{{ publicKey || '—' }}
+								</code>
+								<FeatherIcon
+									v-if="publicKey"
+									name="copy"
+									class="text-ink-gray-5 invisible h-3.5 w-3.5 shrink-0 group-hover/copy:visible"
+								/>
+							</div>
+						</Tooltip>
+					</div>
+				</DashboardCard>
+			</div>
 		</template>
-		<div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
-			<!-- Signature -->
-			<DashboardCard :title="__('Signature')">
-				<div>
-					<InformationField :label="__('Signature Type')" :value="signature.data.algorithm" />
-					<InformationField :label="__('Selector')" :value="signature.data.selector" />
-					<InformationField :label="__('Domain')" :value="signature.data.domain" />
-				</div>
-			</DashboardCard>
-
-			<!-- Rotation -->
-			<DashboardCard :title="__('Rotation')">
-				<div>
-					<InformationField :label="__('Stage')" :value="stageLabel" />
-					<InformationField :label="__('Created At')" :value="createdAt" />
-					<InformationField :label="__('Next Transition')" :value="nextTransition" />
-				</div>
-			</DashboardCard>
-
-			<!-- Options -->
-			<DashboardCard :title="__('Options')">
-				<div>
-					<InformationField :label="__('Signed Headers')" :value="signedHeaders" />
-					<InformationField :label="__('Canonicalization')" :value="signature.data.canonicalization" />
-					<InformationField :label="__('Expiration')" :value="signature.data.expiration" />
-					<InformationField :label="__('Request Reports')" :value="requestReports" />
-					<InformationField :label="__('Agent User ID')" :value="signature.data.auid" />
-				</div>
-			</DashboardCard>
-
-			<!-- Public Key -->
-			<DashboardCard :title="__('Public Key')">
-				<div class="p-4">
-					<Tooltip :text="__('Click to copy')" :disabled="!publicKey">
-						<div
-							class="group/copy flex items-start gap-1.5"
-							:class="{ 'cursor-copy': publicKey }"
-							@click="publicKey && copyToClipBoard(publicKey)"
-						>
-							<code class="text-ink-gray-7 block break-all font-mono text-xs">
-								{{ publicKey || '—' }}
-							</code>
-							<FeatherIcon
-								v-if="publicKey"
-								name="copy"
-								class="text-ink-gray-5 invisible h-3.5 w-3.5 shrink-0 group-hover/copy:visible"
-							/>
-						</div>
-					</Tooltip>
-				</div>
-			</DashboardCard>
-		</div>
 	</DashboardLayout>
 	<Dialog v-model="showDelete" :options="deleteDialogOptions" />
 </template>
@@ -63,9 +70,12 @@ import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { Dialog, Dropdown, FeatherIcon, Tooltip, createResource, usePageMeta } from 'frappe-ui'
 
+import FileKey2 from '~icons/lucide/file-key-2'
+
 import { copyToClipBoard, raiseToast } from '@/apps/mail/utils'
 import { formatDateTime } from '@/apps/mail/utils/datetime'
 import DashboardCard from '@/apps/mail/components/DashboardCard.vue'
+import DashboardDetailHeader from '@/apps/mail/components/DashboardDetailHeader.vue'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import InformationField from '@/apps/mail/components/InformationField.vue'
 

--- a/frontend/src/apps/mail/pages/dashboard/DkimSignatureView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/DkimSignatureView.vue
@@ -1,12 +1,11 @@
 <template>
-	<DashboardLayout v-if="signature.data" :breadcrumbs="breadcrumbs">
+	<DashboardLayout :breadcrumbs="breadcrumbs" :loading="!signature.data">
 		<template #actions>
 			<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
 		</template>
 		<div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
 			<!-- Signature -->
 			<DashboardCard :title="__('Signature')">
-				<template #actions><span /></template>
 				<div>
 					<InformationField :label="__('Signature Type')" :value="signature.data.algorithm" />
 					<InformationField :label="__('Selector')" :value="signature.data.selector" />
@@ -16,7 +15,6 @@
 
 			<!-- Rotation -->
 			<DashboardCard :title="__('Rotation')">
-				<template #actions><span /></template>
 				<div>
 					<InformationField :label="__('Stage')" :value="stageLabel" />
 					<InformationField :label="__('Created At')" :value="createdAt" />
@@ -26,7 +24,6 @@
 
 			<!-- Options -->
 			<DashboardCard :title="__('Options')">
-				<template #actions><span /></template>
 				<div>
 					<InformationField :label="__('Signed Headers')" :value="signedHeaders" />
 					<InformationField :label="__('Canonicalization')" :value="signature.data.canonicalization" />
@@ -38,11 +35,23 @@
 
 			<!-- Public Key -->
 			<DashboardCard :title="__('Public Key')">
-				<template #actions><span /></template>
 				<div class="p-4">
-					<code class="text-ink-gray-7 block break-all font-mono text-xs">
-						{{ signature.data.public_key || '—' }}
-					</code>
+					<Tooltip :text="__('Click to copy')" :disabled="!publicKey">
+						<div
+							class="group/copy flex items-start gap-1.5"
+							:class="{ 'cursor-copy': publicKey }"
+							@click="publicKey && copyToClipBoard(publicKey)"
+						>
+							<code class="text-ink-gray-7 block break-all font-mono text-xs">
+								{{ publicKey || '—' }}
+							</code>
+							<FeatherIcon
+								v-if="publicKey"
+								name="copy"
+								class="text-ink-gray-5 invisible h-3.5 w-3.5 shrink-0 group-hover/copy:visible"
+							/>
+						</div>
+					</Tooltip>
 				</div>
 			</DashboardCard>
 		</div>
@@ -52,9 +61,9 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { Dialog, Dropdown, createResource, usePageMeta } from 'frappe-ui'
+import { Dialog, Dropdown, FeatherIcon, Tooltip, createResource, usePageMeta } from 'frappe-ui'
 
-import { raiseToast } from '@/apps/mail/utils'
+import { copyToClipBoard, raiseToast } from '@/apps/mail/utils'
 import { formatDateTime } from '@/apps/mail/utils/datetime'
 import DashboardCard from '@/apps/mail/components/DashboardCard.vue'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
@@ -88,7 +97,10 @@ const signature = createResource({
 	auto: true,
 	makeParams: () => ({ signature_id: signatureId }),
 	cache: ['mailDkimSignature', signatureId],
-	onError: () => router.replace({ name: 'mail-dkim-signatures' }),
+	onError: (error: { messages?: string[] }) => {
+		raiseToast(error.messages?.[0] || __('DKIM signature not found.'), 'error')
+		router.replace({ name: 'mail-dkim-signatures' })
+	},
 })
 
 const data = computed(() => signature.data as DkimData | undefined)
@@ -102,6 +114,7 @@ const stageLabel = computed(() => {
 const createdAt = computed(() => formatDate(data.value?.created_at))
 const nextTransition = computed(() => formatDate(data.value?.next_transition))
 const signedHeaders = computed(() => (data.value?.signed_headers || []).join(', '))
+const publicKey = computed(() => data.value?.public_key || '')
 const requestReports = computed(() => (data.value?.request_reports ? __('Yes') : __('No')))
 
 const breadcrumbs = computed(() => [

--- a/frontend/src/apps/mail/pages/dashboard/DkimSignaturesView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/DkimSignaturesView.vue
@@ -26,6 +26,7 @@
 				<ListEmptyState v-else />
 			</ListRows>
 		</ListView>
+		<DashboardListSkeleton v-else />
 	</DashboardLayout>
 </template>
 <script setup lang="ts">
@@ -42,6 +43,7 @@ import {
 
 import { fromNow } from '@/apps/mail/utils/datetime'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
+import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 
 usePageMeta(() => ({ title: __('DKIM Signatures') }))
 
@@ -63,9 +65,12 @@ const LIST_COLUMNS = [
 const LIST_OPTIONS = {
 	selectable: false,
 	showTooltip: false,
-	emptyState: { description: __('No DKIM signatures found.') },
+	emptyState: {
+		title: __('No DKIM signatures yet'),
+		description: __('DKIM signatures are generated automatically when you add a domain.'),
+	},
 	getRowRoute: (row: DkimRow) => ({ name: 'mail-dkim-signature', params: { signatureId: row.id } }),
 }
 
-const formatCreatedAt = (createdAt?: string) => fromNow(createdAt) || '-'
+const formatCreatedAt = (createdAt?: string) => fromNow(createdAt) || '—'
 </script>

--- a/frontend/src/apps/mail/pages/dashboard/DomainView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/DomainView.vue
@@ -1,17 +1,25 @@
 <template>
-	<DashboardLayout
-		:breadcrumbs="BREADCRUMBS"
-		:badge-label="badge.label"
-		:badge-theme="badge.theme"
-		:loading="!domain.data"
-	>
-		<template #actions>
-			<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
-		</template>
+	<DashboardLayout :breadcrumbs="BREADCRUMBS" :loading="!domain.data">
 		<template #default>
-			<div class="bg-surface-blue-1 rounded-md border">
-				<div class="space-y-2 p-4">
-					<h3 class="font-medium">{{ BANNER.title }}</h3>
+			<DashboardDetailHeader
+				:title="domain.data.name"
+				:badge-label="badge.label"
+				:badge-theme="badge.theme"
+				:meta="[domain.data.description, addedAgo]"
+			>
+				<template #icon><Globe class="h-5 w-5" /></template>
+				<template #actions>
+					<Dropdown
+						:options="exportOptions"
+						:button="{ label: __('Export DNS'), iconLeft: 'download' }"
+					/>
+					<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
+				</template>
+			</DashboardDetailHeader>
+			<div class="bg-surface-blue-1 flex items-start gap-3 rounded-md border p-4">
+				<Info class="text-ink-blue-5 mt-0.5 h-4 w-4 shrink-0" />
+				<div class="space-y-1">
+					<h3 class="text-base font-medium">{{ BANNER.title }}</h3>
 					<p class="text-ink-gray-5 text-sm">{{ BANNER.message }}</p>
 					<p class="text-ink-gray-5 text-sm">{{ BANNER.subtitle }}</p>
 				</div>
@@ -75,8 +83,13 @@ import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { Dialog, Dropdown, createResource, usePageMeta } from 'frappe-ui'
 
+import Globe from '~icons/lucide/globe'
+import Info from '~icons/lucide/info'
+
 import { downloadUrlAsFile, raiseToast } from '@/apps/mail/utils'
+import { fromNow } from '@/apps/mail/utils/datetime'
 import DNSRecords from '@/apps/mail/components/DNSRecords.vue'
+import DashboardDetailHeader from '@/apps/mail/components/DashboardDetailHeader.vue'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 
 type DNSRecord = Record<string, string>
@@ -221,25 +234,26 @@ const confirmDialogOptions = computed(() => {
 	}
 })
 
+const addedAgo = computed(() => {
+	const createdAt = (domain.data as DomainData | undefined)?.created_at
+	return createdAt ? __('Added {0}', [fromNow(createdAt)]) : undefined
+})
+
+const exportOptions = [
+	{
+		group: '',
+		items: [
+			{ label: __('Zone File'), icon: 'file-text', onClick: downloadDNSZone.submit },
+			{ label: __('CSV'), icon: 'file-text', onClick: downloadDNSCsv.submit },
+			{ label: __('JSON'), icon: 'file-text', onClick: downloadDNSJson.submit },
+		],
+	},
+]
+
 const dropdownOptions = computed(() => [
 	{
 		group: '',
 		items: [
-			{
-				label: __('Export Zone File'),
-				icon: 'download',
-				onClick: downloadDNSZone.submit,
-			},
-			{
-				label: __('Export CSV'),
-				icon: 'download',
-				onClick: downloadDNSCsv.submit,
-			},
-			{
-				label: __('Export JSON'),
-				icon: 'download',
-				onClick: downloadDNSJson.submit,
-			},
 			{
 				label: __('Delete Domain'),
 				icon: 'trash-2',

--- a/frontend/src/apps/mail/pages/dashboard/DomainView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/DomainView.vue
@@ -1,9 +1,9 @@
 <template>
 	<DashboardLayout
-		v-if="domain?.data"
 		:breadcrumbs="BREADCRUMBS"
 		:badge-label="badge.label"
 		:badge-theme="badge.theme"
+		:loading="!domain.data"
 	>
 		<template #actions>
 			<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
@@ -13,10 +13,11 @@
 				<div class="space-y-2 p-4">
 					<h3 class="font-medium">{{ BANNER.title }}</h3>
 					<p class="text-ink-gray-5 text-sm">{{ BANNER.message }}</p>
+					<p class="text-ink-gray-5 text-sm">{{ BANNER.subtitle }}</p>
 				</div>
 			</div>
 			<div class="rounded-md border">
-				<h2 class="p-4">{{ __('DNS Records') }}</h2>
+				<h2 class="h-13 flex shrink-0 items-center px-4">{{ __('DNS Records') }}</h2>
 				<DNSRecords
 					:title="__('Email Deliverability')"
 					:description="
@@ -35,7 +36,7 @@
 					"
 					:records="inboundMailRoutingRecords"
 					:badge-label="__('Recommended')"
-					badge-theme="orange"
+					badge-theme="amber"
 				/>
 				<DNSRecords
 					:title="__('Service Configuration Records')"
@@ -110,7 +111,10 @@ const domain = createResource({
 	auto: true,
 	makeParams: () => ({ domain_id: domainId }),
 	cache: ['mailDomain', domainId],
-	onError: () => router.replace({ name: 'mail-domains' }),
+	onError: (error: { messages?: string[] }) => {
+		raiseToast(error.messages?.[0] || __('Domain not found.'), 'error')
+		router.replace({ name: 'mail-domains' })
+	},
 })
 
 const domainRecords = computed<DNSRecord[]>(
@@ -213,7 +217,7 @@ const confirmDialogOptions = computed(() => {
 		message: config.message,
 		size: 'xl',
 		icon: { name: 'alert-triangle', appearance: 'warning' },
-		actions: [{ label: __('Confirm'), variant: 'solid', onClick: config.action }],
+		actions: [{ label: __('Confirm'), variant: 'solid', theme: 'red', onClick: config.action }],
 	}
 })
 
@@ -254,15 +258,3 @@ const BANNER = {
 	subtitle: __('DNS changes may take up to 48 hours to propagate globally.'),
 }
 </script>
-
-<style scoped>
-.expand-enter-active,
-.expand-leave-active {
-	@apply max-h-full opacity-100 transition-all duration-700 ease-linear;
-}
-
-.expand-enter-from,
-.expand-leave-to {
-	@apply max-h-0 p-0 opacity-0;
-}
-</style>

--- a/frontend/src/apps/mail/pages/dashboard/DomainsView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/DomainsView.vue
@@ -4,26 +4,28 @@
 		:button-label="__('Add Domain')"
 		:button-action="() => (showAddDomain = true)"
 	>
-		<div class="flex items-center space-x-3">
+		<div class="flex items-center justify-between gap-3">
 			<FormControl v-model="search" :placeholder="__('Search')" class="w-80">
 				<template #prefix>
 					<FeatherIcon name="search" class="text-ink-gray-5 w-4" />
 				</template>
 			</FormControl>
-			<FormControl
-				v-model="status"
-				:placeholder="__('Status')"
-				class="w-40"
-				type="select"
-				:options="STATUS_OPTIONS"
-			/>
+			<div class="flex items-center gap-3">
+				<FormControl
+					v-model="status"
+					:placeholder="__('Status')"
+					class="w-40"
+					type="select"
+					:options="STATUS_OPTIONS"
+				/>
+			</div>
 		</div>
 		<ListView
 			v-if="domains?.data"
 			class="flex-1"
 			:columns="LIST_COLUMNS"
 			:rows="domains.data"
-			:options="LIST_OPTIONS"
+			:options="listOptions"
 			row-key="id"
 		>
 			<ListHeader />
@@ -51,11 +53,12 @@
 				<ListEmptyState v-else />
 			</ListRows>
 		</ListView>
+		<DashboardListSkeleton v-else />
 	</DashboardLayout>
 	<AddDomainModal v-model="showAddDomain" @reload-domains="domains.reload()" />
 </template>
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { watchDebounced } from '@vueuse/core'
 import {
 	Badge,
@@ -73,6 +76,7 @@ import {
 
 import { fromNow } from '@/apps/mail/utils/datetime'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
+import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 import AddDomainModal from '@/apps/mail/components/Modals/AddDomainModal.vue'
 
 usePageMeta(() => ({ title: __('Domains') }))
@@ -109,14 +113,31 @@ const LIST_COLUMNS = [
 	{ label: __('Created At'), key: 'created_at' },
 ]
 
-const LIST_OPTIONS = {
+// The empty state depends on why the list is empty: a filtered search that found
+// nothing should not present the first-run "add your first domain" pitch.
+const hasActiveFilters = computed(() => !!search.value || status.value !== 'All')
+
+const listOptions = computed(() => ({
 	selectable: false,
 	showTooltip: false,
-	emptyState: { description: __('No domains found.') },
+	emptyState: hasActiveFilters.value
+		? {
+				title: __('No matching domains'),
+				description: __('Try adjusting your search or filters.'),
+			}
+		: {
+				title: __('No domains yet'),
+				description: __('Add a domain to send and receive mail with your own addresses.'),
+				button: {
+					label: __('Add Domain'),
+					variant: 'solid',
+					onClick: () => (showAddDomain.value = true),
+				},
+			},
 	getRowRoute: (row: DomainRow) => ({ name: 'mail-domain', params: { domainId: row.id } }),
-}
+}))
 
-const formatCreatedAt = (createdAt?: string) => fromNow(createdAt) || '-'
+const formatCreatedAt = (createdAt?: string) => fromNow(createdAt) || '—'
 
 const STATUS_OPTIONS = [
 	{ label: __('All'), value: 'All' },

--- a/frontend/src/apps/mail/pages/dashboard/GroupView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/GroupView.vue
@@ -1,5 +1,5 @@
 <template>
-	<DashboardLayout v-if="member.data" :breadcrumbs="breadcrumbs">
+	<DashboardLayout :breadcrumbs="breadcrumbs" :loading="!member.data">
 		<template #actions>
 			<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
 		</template>
@@ -22,53 +22,7 @@
 
 			<!-- Quota Usage -->
 			<DashboardCard :title="__('Quota Usage')" :button-label="__('Edit')" @action="showEditQuota = true">
-				<div class="flex flex-1 items-center justify-center gap-8 p-6">
-					<div class="relative shrink-0">
-						<svg :width="DONUT_SIZE" :height="DONUT_SIZE" class="-rotate-90">
-							<circle
-								:cx="DONUT_SIZE / 2"
-								:cy="DONUT_SIZE / 2"
-								:r="DONUT_RADIUS"
-								fill="none"
-								stroke="var(--surface-gray-4)"
-								:stroke-width="DONUT_STROKE"
-							/>
-							<circle
-								v-if="!member.data.quota.unlimited && usedDashArc > 0"
-								:cx="DONUT_SIZE / 2"
-								:cy="DONUT_SIZE / 2"
-								:r="DONUT_RADIUS"
-								fill="none"
-								stroke="var(--surface-gray-10)"
-								:stroke-width="DONUT_STROKE"
-								stroke-linecap="round"
-								:stroke-dasharray="`${usedDashArc} ${DONUT_CIRCUMFERENCE}`"
-							/>
-						</svg>
-						<div class="absolute inset-0 flex flex-col items-center justify-center text-center">
-							<span class="text-lg font-semibold">{{ totalQuotaLabel }}</span>
-							<span class="text-ink-gray-5 text-xs">
-								{{ member.data.quota.unlimited ? __('Unlimited') : __('Total Quota') }}
-							</span>
-						</div>
-					</div>
-					<div class="space-y-4">
-						<div class="flex items-start gap-2">
-							<span class="bg-surface-gray-10 mt-1 h-3 w-3 shrink-0 rounded-sm" />
-							<div>
-								<p class="text-sm font-medium">{{ usedLabel }}</p>
-								<p class="text-ink-gray-5 text-xs">{{ __('Used') }}</p>
-							</div>
-						</div>
-						<div v-if="!member.data.quota.unlimited" class="flex items-start gap-2">
-							<span class="bg-surface-gray-4 mt-1 h-3 w-3 shrink-0 rounded-sm" />
-							<div>
-								<p class="text-sm font-medium">{{ availableLabel }}</p>
-								<p class="text-ink-gray-5 text-xs">{{ __('Available') }}</p>
-							</div>
-						</div>
-					</div>
-				</div>
+				<QuotaDonut :quota="member.data.quota" />
 			</DashboardCard>
 
 			<!-- Email Addresses -->
@@ -183,7 +137,7 @@ import {
 	usePageMeta,
 } from 'frappe-ui'
 
-import { formatBytes, raiseToast } from '@/apps/mail/utils'
+import { raiseToast } from '@/apps/mail/utils'
 import { formatDateTime } from '@/apps/mail/utils/datetime'
 import { useAccountOptions } from '@/apps/mail/composables/useAccountOptions'
 import AddGroupEmailModal from '@/apps/mail/components/Modals/AddGroupEmailModal.vue'
@@ -193,15 +147,10 @@ import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import EditGroupModal from '@/apps/mail/components/Modals/EditGroupModal.vue'
 import EditGroupQuotaModal from '@/apps/mail/components/Modals/EditGroupQuotaModal.vue'
 import InformationField from '@/apps/mail/components/InformationField.vue'
+import QuotaDonut from '@/apps/mail/components/QuotaDonut.vue'
 
-type QuotaUsage = {
-	total: number
-	used: number
-	available: number
-	used_percentage: number
-	available_percentage: number
-	unlimited: boolean
-}
+import type { QuotaUsage } from '@/apps/mail/types'
+
 type GroupData = {
 	id: string
 	name: string
@@ -234,7 +183,10 @@ const member = createResource({
 	auto: true,
 	makeParams: () => ({ group_id: groupId }),
 	cache: ['mailGroup', groupId],
-	onError: () => router.replace({ name: 'mail-groups' }),
+	onError: (error: { messages?: string[] }) => {
+		raiseToast(error.messages?.[0] || __('Group not found.'), 'error')
+		router.replace({ name: 'mail-groups' })
+	},
 })
 
 const data = computed(() => member.data as GroupData | undefined)
@@ -258,32 +210,6 @@ const breadcrumbs = computed(() => [
 	{ label: __('Groups'), route: '/mail/dashboard/groups' },
 	{ label: data.value?.email || groupId },
 ])
-
-// Quota donut geometry (mirrors MemberView.vue).
-const DONUT_SIZE = 140
-const DONUT_STROKE = 12
-const DONUT_RADIUS = (DONUT_SIZE - DONUT_STROKE) / 2
-const DONUT_CIRCUMFERENCE = 2 * Math.PI * DONUT_RADIUS
-
-const usedDashArc = computed(() => {
-	const pct = data.value?.quota.used_percentage || 0
-	const arc = DONUT_CIRCUMFERENCE * (pct / 100)
-	return arc >= 1 ? arc : 0
-})
-const totalQuotaLabel = computed(() =>
-	data.value?.quota.unlimited ? '∞' : formatBytes(data.value?.quota.total || 0),
-)
-const usedLabel = computed(() => {
-	const quota = data.value?.quota
-	if (!quota) return ''
-	if (quota.unlimited) return formatBytes(quota.used)
-	return `${formatBytes(quota.used)} (${quota.used_percentage.toFixed(1)}%)`
-})
-const availableLabel = computed(() => {
-	const quota = data.value?.quota
-	if (!quota) return ''
-	return `${formatBytes(quota.available)} (${quota.available_percentage.toFixed(1)}%)`
-})
 
 const toggleEmailEnabled = (entry: { email: string; enabled: boolean }, value: boolean) => {
 	entry.enabled = value // optimistic; reverted on error via reload

--- a/frontend/src/apps/mail/pages/dashboard/GroupView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/GroupView.vue
@@ -1,19 +1,21 @@
 <template>
 	<DashboardLayout :breadcrumbs="breadcrumbs" :loading="!member.data">
-		<template #actions>
-			<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
-		</template>
+		<DashboardDetailHeader
+			:title="member.data.email || member.data.name || groupId"
+			:meta="[member.data.description, memberCountLabel]"
+		>
+			<template #icon><Users class="h-5 w-5" /></template>
+			<template #actions>
+				<Button :label="__('Edit')" @click="showEdit = true" />
+				<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
+			</template>
+		</DashboardDetailHeader>
 
 		<div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
 			<!-- General Information -->
-			<DashboardCard
-				:title="__('General Information')"
-				:button-label="__('Edit')"
-				@action="showEdit = true"
-			>
+			<DashboardCard :title="__('General Information')">
 				<div>
 					<InformationField :label="__('Roles')" :value="roleLabels.join(', ')" />
-					<InformationField :label="__('Description')" :value="member.data.description" />
 					<InformationField :label="__('Locale')" :value="localeLabel(member.data.locale)" />
 					<InformationField :label="__('Time Zone')" :value="member.data.time_zone" />
 					<InformationField :label="__('Created At')" :value="createdAt" />
@@ -137,12 +139,15 @@ import {
 	usePageMeta,
 } from 'frappe-ui'
 
+import Users from '~icons/lucide/users'
+
 import { raiseToast } from '@/apps/mail/utils'
 import { formatDateTime } from '@/apps/mail/utils/datetime'
 import { useAccountOptions } from '@/apps/mail/composables/useAccountOptions'
 import AddGroupEmailModal from '@/apps/mail/components/Modals/AddGroupEmailModal.vue'
 import AddGroupMembersModal from '@/apps/mail/components/Modals/AddGroupMembersModal.vue'
 import DashboardCard from '@/apps/mail/components/DashboardCard.vue'
+import DashboardDetailHeader from '@/apps/mail/components/DashboardDetailHeader.vue'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import EditGroupModal from '@/apps/mail/components/Modals/EditGroupModal.vue'
 import EditGroupQuotaModal from '@/apps/mail/components/Modals/EditGroupQuotaModal.vue'
@@ -205,6 +210,11 @@ const filteredMembers = computed(() => {
 })
 
 const createdAt = computed(() => formatDateTime(data.value?.created_at))
+
+const memberCountLabel = computed(() => {
+	const count = data.value?.members.length ?? 0
+	return count === 1 ? __('1 member') : __('{0} members', [String(count)])
+})
 
 const breadcrumbs = computed(() => [
 	{ label: __('Groups'), route: '/mail/dashboard/groups' },

--- a/frontend/src/apps/mail/pages/dashboard/GroupsView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/GroupsView.vue
@@ -16,7 +16,7 @@
 			class="flex-1"
 			:columns="LIST_COLUMNS"
 			:rows="groups.data"
-			:options="LIST_OPTIONS"
+			:options="listOptions"
 			row-key="id"
 		>
 			<ListHeader />
@@ -37,11 +37,12 @@
 				<ListEmptyState v-else />
 			</ListRows>
 		</ListView>
+		<DashboardListSkeleton v-else :columns="3" />
 	</DashboardLayout>
 	<AddGroupModal v-model="showAddGroup" @reload="groups.reload()" />
 </template>
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { watchDebounced } from '@vueuse/core'
 import {
 	FeatherIcon,
@@ -58,6 +59,7 @@ import {
 
 import { fromNow } from '@/apps/mail/utils/datetime'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
+import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 import AddGroupModal from '@/apps/mail/components/Modals/AddGroupModal.vue'
 
 usePageMeta(() => ({ title: __('Groups') }))
@@ -82,12 +84,27 @@ const LIST_COLUMNS = [
 	{ label: __('Created At'), key: 'created_at' },
 ]
 
-const LIST_OPTIONS = {
+const hasActiveFilters = computed(() => !!search.value)
+
+const listOptions = computed(() => ({
 	selectable: false,
 	showTooltip: false,
-	emptyState: { description: __('No groups found.') },
+	emptyState: hasActiveFilters.value
+		? {
+				title: __('No matching groups'),
+				description: __('Try adjusting your search or filters.'),
+			}
+		: {
+				title: __('No groups yet'),
+				description: __('Create a group to give a team a shared address and mailbox.'),
+				button: {
+					label: __('Add Group'),
+					variant: 'solid',
+					onClick: () => (showAddGroup.value = true),
+				},
+			},
 	getRowRoute: (row: GroupRow) => ({ name: 'mail-group', params: { groupId: row.id } }),
-}
+}))
 
-const formatCreatedAt = (createdAt?: string) => fromNow(createdAt) || '-'
+const formatCreatedAt = (createdAt?: string) => fromNow(createdAt) || '—'
 </script>

--- a/frontend/src/apps/mail/pages/dashboard/InvitesView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/InvitesView.vue
@@ -1,26 +1,28 @@
 <template>
-	<div class="flex items-center space-x-3">
+	<div class="flex items-center justify-between gap-3">
 		<FormControl v-model="search" :placeholder="__('Search')" class="w-80">
 			<template #prefix>
 				<FeatherIcon name="search" class="text-ink-gray-5 w-4" />
 			</template>
 		</FormControl>
-		<FormControl
-			v-model="status"
-			:placeholder="__('Invitation Status')"
-			class="w-40"
-			type="select"
-			:options="STATUS_OPTIONS"
-		/>
+		<div class="flex items-center gap-3">
+			<FormControl
+				v-model="status"
+				:placeholder="__('Invitation Status')"
+				class="w-40"
+				type="select"
+				:options="STATUS_OPTIONS"
+			/>
+		</div>
 	</div>
 
 	<ListView
-		v-if="inviteRows"
+		v-if="invites.data"
 		ref="listView"
 		class="flex-1"
 		:columns="LIST_COLUMNS"
 		:rows="inviteRows"
-		:options="LIST_OPTIONS"
+		:options="listOptions"
 		row-key="name"
 	>
 		<ListHeader />
@@ -37,7 +39,7 @@
 						<template v-if="column.key === 'role'">
 							<Badge
 								:label="row.is_admin ? __('Admin') : __('User')"
-								:theme="row.is_admin ? 'orange' : 'blue'"
+								:theme="row.is_admin ? 'amber' : 'blue'"
 							/>
 						</template>
 						<Badge
@@ -61,6 +63,7 @@
 			</template>
 		</ListSelectBanner>
 	</ListView>
+	<DashboardListSkeleton v-else :columns="5" />
 
 	<EditInviteModal
 		v-if="selectedInvite"
@@ -91,6 +94,7 @@ import {
 } from 'frappe-ui'
 
 import { raiseToast } from '@/apps/mail/utils'
+import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 import EditInviteModal from '@/apps/mail/components/Modals/EditInviteModal.vue'
 
 type InviteStatus = 'All' | 'Pending' | 'Accepted' | 'Expired'
@@ -160,7 +164,7 @@ const DELETE_INVITES_OPTIONS = {
 	message: __(
 		'Are you sure you want to delete the selected invites? This will invalidate them for the recipients if pending.',
 	),
-	actions: [{ label: __('Confirm'), variant: 'solid', onClick: deleteInvites.submit }],
+	actions: [{ label: __('Confirm'), variant: 'solid', theme: 'red', onClick: deleteInvites.submit }],
 }
 
 const LIST_COLUMNS = [
@@ -171,15 +175,25 @@ const LIST_COLUMNS = [
 	{ label: __('Invitation Status'), key: 'status' },
 ]
 
-const LIST_OPTIONS = {
+const hasActiveFilters = computed(() => !!search.value || status.value !== 'All')
+
+const listOptions = computed(() => ({
 	showTooltip: false,
 	rowHeight: 50,
-	emptyState: { description: __('No invites found.') },
+	emptyState: hasActiveFilters.value
+		? {
+				title: __('No matching invites'),
+				description: __('Try adjusting your search or filters.'),
+			}
+		: {
+				title: __('No pending invites'),
+				description: __('Invitations you send will appear here until they are accepted.'),
+			},
 	onRowClick: (row: InviteRow) => {
 		selectedInvite.value = row.name
 		showEditInvite.value = true
 	},
-}
+}))
 
 const STATUS_OPTIONS = [
 	{ label: __('All'), value: 'All' },
@@ -189,5 +203,5 @@ const STATUS_OPTIONS = [
 ]
 
 const getTheme = (status: InviteStatusLabel) =>
-	status === 'Accepted' ? 'green' : status === 'Expired' ? 'gray' : 'orange'
+	status === 'Accepted' ? 'green' : status === 'Expired' ? 'gray' : 'amber'
 </script>

--- a/frontend/src/apps/mail/pages/dashboard/LogView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/LogView.vue
@@ -1,11 +1,19 @@
 <template>
 	<DashboardLayout :breadcrumbs="breadcrumbs" :loading="!log.data">
 		<template #default>
+			<DashboardDetailHeader
+				:title="data.event_label || data.event || logId"
+				:meta="[formatDate(data.timestamp), logId]"
+				:badge-label="data.level_label"
+				:badge-theme="levelTheme(data.level)"
+			>
+				<template #icon><ScrollText class="h-5 w-5" /></template>
+			</DashboardDetailHeader>
+
 			<div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
 				<DashboardCard :title="__('Log Entry')">
 					<InformationField :label="__('Timestamp')" :value="formatDate(data.timestamp)" />
 					<InformationField :label="__('Level')" :value="data.level_label" />
-					<InformationField :label="__('Event')" :value="data.event_label" />
 				</DashboardCard>
 				<DashboardCard :title="__('Details')">
 					<template #actions>
@@ -25,10 +33,13 @@ import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { Button, createResource, usePageMeta } from 'frappe-ui'
 
+import ScrollText from '~icons/lucide/scroll-text'
+
 import { copyToClipBoard, raiseToast } from '@/apps/mail/utils'
 import { formatDateTime } from '@/apps/mail/utils/datetime'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import DashboardCard from '@/apps/mail/components/DashboardCard.vue'
+import DashboardDetailHeader from '@/apps/mail/components/DashboardDetailHeader.vue'
 import InformationField from '@/apps/mail/components/InformationField.vue'
 
 type LogData = {
@@ -59,6 +70,16 @@ const log = createResource({
 
 const data = computed(() => log.data as LogData)
 const formatDate = (value?: string) => formatDateTime(value, 'MMM D YYYY, h:mm:ss A') || '—'
+
+// Mirrors the colours the server's TracingLevel enum assigns to each level.
+const LEVEL_THEMES: Record<string, 'red' | 'amber' | 'green' | 'blue' | 'violet'> = {
+	error: 'red',
+	warn: 'amber',
+	info: 'green',
+	debug: 'blue',
+	trace: 'violet',
+}
+const levelTheme = (level?: string) => LEVEL_THEMES[(level || '').toLowerCase()] || 'gray'
 
 const breadcrumbs = computed(() => [
 	{ label: __('Logs'), route: '/mail/dashboard/logs' },

--- a/frontend/src/apps/mail/pages/dashboard/LogView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/LogView.vue
@@ -1,15 +1,16 @@
 <template>
-	<DashboardLayout v-if="log?.data" :breadcrumbs="breadcrumbs">
+	<DashboardLayout :breadcrumbs="breadcrumbs" :loading="!log.data">
 		<template #default>
 			<div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
 				<DashboardCard :title="__('Log Entry')">
-					<template #actions><span /></template>
 					<InformationField :label="__('Timestamp')" :value="formatDate(data.timestamp)" />
 					<InformationField :label="__('Level')" :value="data.level_label" />
 					<InformationField :label="__('Event')" :value="data.event_label" />
 				</DashboardCard>
 				<DashboardCard :title="__('Details')">
-					<template #actions><span /></template>
+					<template #actions>
+						<Button variant="ghost" :label="__('Copy')" @click="copyToClipBoard(data.details || '')" />
+					</template>
 					<pre
 						class="bg-surface-gray-2 max-h-[60vh] overflow-auto rounded p-4 text-xs whitespace-pre-wrap"
 						>{{ data.details || '—' }}</pre
@@ -22,8 +23,9 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
-import { createResource, usePageMeta } from 'frappe-ui'
+import { Button, createResource, usePageMeta } from 'frappe-ui'
 
+import { copyToClipBoard, raiseToast } from '@/apps/mail/utils'
 import { formatDateTime } from '@/apps/mail/utils/datetime'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import DashboardCard from '@/apps/mail/components/DashboardCard.vue'
@@ -49,7 +51,10 @@ const log = createResource({
 	auto: true,
 	makeParams: () => ({ log_id: logId }),
 	cache: ['mailLog', logId],
-	onError: () => router.replace({ name: 'mail-logs' }),
+	onError: (error: { messages?: string[] }) => {
+		raiseToast(error.messages?.[0] || __('Log entry not found.'), 'error')
+		router.replace({ name: 'mail-logs' })
+	},
 })
 
 const data = computed(() => log.data as LogData)

--- a/frontend/src/apps/mail/pages/dashboard/LogsView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/LogsView.vue
@@ -1,7 +1,7 @@
 <template>
 	<DashboardLayout :breadcrumbs="[{ label: __('Logs') }]">
-		<div class="flex items-center space-x-3">
-			<FormControl v-model="search" :placeholder="__('Search logs')" class="w-80">
+		<div class="flex items-center justify-between gap-3">
+			<FormControl v-model="search" :placeholder="__('Search')" class="w-80">
 				<template #prefix><FeatherIcon name="search" class="text-ink-gray-5 w-4" /></template>
 			</FormControl>
 			<Button :label="__('Refresh')" @click="logs.reload()">
@@ -13,7 +13,7 @@
 			class="flex-1"
 			:columns="LIST_COLUMNS"
 			:rows="rows"
-			:options="LIST_OPTIONS"
+			:options="listOptions"
 			row-key="id"
 		>
 			<ListHeader />
@@ -46,6 +46,7 @@
 				<ListEmptyState v-else />
 			</ListRows>
 		</ListView>
+		<DashboardListSkeleton v-else />
 		<DashboardPager
 			:page="page"
 			:page-length="PAGE_LENGTH"
@@ -75,6 +76,7 @@ import {
 
 import { formatDateTime } from '@/apps/mail/utils/datetime'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
+import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 import DashboardPager from '@/apps/mail/components/DashboardPager.vue'
 
 type LogRow = {
@@ -145,11 +147,21 @@ const LIST_COLUMNS = [
 	{ label: __('Details'), key: 'details', width: 2 },
 ]
 
-const LIST_OPTIONS = {
+const hasActiveFilters = computed(() => !!search.value)
+
+const listOptions = computed(() => ({
 	selectable: false,
 	showTooltip: false,
 	rowHeight: 44,
-	emptyState: { description: __('No log entries found.') },
+	emptyState: hasActiveFilters.value
+		? {
+				title: __('No matching log entries'),
+				description: __('Try adjusting your search or filters.'),
+			}
+		: {
+				title: __('No log entries'),
+				description: __('Server events will appear here as they happen.'),
+			},
 	getRowRoute: (row: LogRow) => ({ name: 'mail-log', params: { logId: row.id } }),
-}
+}))
 </script>

--- a/frontend/src/apps/mail/pages/dashboard/MailingListView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/MailingListView.vue
@@ -1,21 +1,17 @@
 <template>
 	<DashboardLayout :breadcrumbs="breadcrumbs" :loading="!list.data">
-		<template #actions>
-			<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
-		</template>
+		<DashboardDetailHeader
+			:title="list.data.email || list.data.name || listId"
+			:meta="[list.data.description, recipientCountLabel]"
+		>
+			<template #icon><Megaphone class="h-5 w-5" /></template>
+			<template #actions>
+				<Button :label="__('Edit')" @click="showEdit = true" />
+				<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
+			</template>
+		</DashboardDetailHeader>
 
 		<div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
-			<!-- General Information -->
-			<DashboardCard
-				:title="__('General Information')"
-				:button-label="__('Edit')"
-				@action="showEdit = true"
-			>
-				<div>
-					<InformationField :label="__('Description')" :value="list.data.description" />
-				</div>
-			</DashboardCard>
-
 			<!-- Email Addresses -->
 			<DashboardCard :title="__('Email Addresses')" :button-label="__('Add')" @action="showAddEmail = true">
 				<div class="flex flex-col">
@@ -125,13 +121,15 @@ import {
 	usePageMeta,
 } from 'frappe-ui'
 
+import Megaphone from '~icons/lucide/megaphone'
+
 import { raiseToast } from '@/apps/mail/utils'
 import AddMailingListEmailModal from '@/apps/mail/components/Modals/AddMailingListEmailModal.vue'
 import AddMailingListRecipientsModal from '@/apps/mail/components/Modals/AddMailingListRecipientsModal.vue'
 import DashboardCard from '@/apps/mail/components/DashboardCard.vue'
+import DashboardDetailHeader from '@/apps/mail/components/DashboardDetailHeader.vue'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import EditMailingListModal from '@/apps/mail/components/Modals/EditMailingListModal.vue'
-import InformationField from '@/apps/mail/components/InformationField.vue'
 
 type ListData = {
 	id: string
@@ -171,6 +169,11 @@ const filteredRecipients = computed(() => {
 	const recipients = data.value?.recipients || []
 	const q = recipientSearch.value.trim().toLowerCase()
 	return q ? recipients.filter((r) => r.toLowerCase().includes(q)) : recipients
+})
+
+const recipientCountLabel = computed(() => {
+	const count = data.value?.recipients.length ?? 0
+	return count === 1 ? __('1 recipient') : __('{0} recipients', [String(count)])
 })
 
 const breadcrumbs = computed(() => [

--- a/frontend/src/apps/mail/pages/dashboard/MailingListView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/MailingListView.vue
@@ -1,5 +1,5 @@
 <template>
-	<DashboardLayout v-if="list.data" :breadcrumbs="breadcrumbs">
+	<DashboardLayout :breadcrumbs="breadcrumbs" :loading="!list.data">
 		<template #actions>
 			<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
 		</template>
@@ -159,7 +159,10 @@ const list = createResource({
 	auto: true,
 	makeParams: () => ({ list_id: listId }),
 	cache: ['mailMailingList', listId],
-	onError: () => router.replace({ name: 'mail-mailing-lists' }),
+	onError: (error: { messages?: string[] }) => {
+		raiseToast(error.messages?.[0] || __('Mailing list not found.'), 'error')
+		router.replace({ name: 'mail-mailing-lists' })
+	},
 })
 
 const data = computed(() => list.data as ListData | undefined)

--- a/frontend/src/apps/mail/pages/dashboard/MailingListsView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/MailingListsView.vue
@@ -16,7 +16,7 @@
 			class="flex-1"
 			:columns="LIST_COLUMNS"
 			:rows="lists.data"
-			:options="LIST_OPTIONS"
+			:options="listOptions"
 			row-key="id"
 		>
 			<ListHeader />
@@ -35,11 +35,12 @@
 				<ListEmptyState v-else />
 			</ListRows>
 		</ListView>
+		<DashboardListSkeleton v-else :columns="3" />
 	</DashboardLayout>
 	<AddMailingListModal v-model="showAdd" @reload="lists.reload()" />
 </template>
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { watchDebounced } from '@vueuse/core'
 import {
 	FeatherIcon,
@@ -55,6 +56,7 @@ import {
 } from 'frappe-ui'
 
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
+import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 import AddMailingListModal from '@/apps/mail/components/Modals/AddMailingListModal.vue'
 
 usePageMeta(() => ({ title: __('Mailing Lists') }))
@@ -79,10 +81,25 @@ const LIST_COLUMNS = [
 	{ label: __('Recipients'), key: 'recipient_count' },
 ]
 
-const LIST_OPTIONS = {
+const hasActiveFilters = computed(() => !!search.value)
+
+const listOptions = computed(() => ({
 	selectable: false,
 	showTooltip: false,
-	emptyState: { description: __('No mailing lists found.') },
+	emptyState: hasActiveFilters.value
+		? {
+				title: __('No matching mailing lists'),
+				description: __('Try adjusting your search or filters.'),
+			}
+		: {
+				title: __('No mailing lists yet'),
+				description: __('Create a mailing list to broadcast mail to many recipients at once.'),
+				button: {
+					label: __('Add Mailing List'),
+					variant: 'solid',
+					onClick: () => (showAdd.value = true),
+				},
+			},
 	getRowRoute: (row: ListRowType) => ({ name: 'mail-mailing-list', params: { listId: row.id } }),
-}
+}))
 </script>

--- a/frontend/src/apps/mail/pages/dashboard/MemberView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/MemberView.vue
@@ -1,27 +1,25 @@
 <template>
-	<DashboardLayout
-		:breadcrumbs="BREADCRUMBS"
-		:badge-label="badge.label"
-		:badge-theme="badge.theme"
-		:loading="!member.data"
-	>
-		<template #actions>
-			<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
-		</template>
+	<DashboardLayout :breadcrumbs="BREADCRUMBS" :loading="!member.data">
+		<DashboardDetailHeader
+			:title="member.data.description || member.data.name"
+			:badge-label="badge.label"
+			:badge-theme="badge.theme"
+			:meta="[member.data.name, member.data.is_admin ? __('Admin') : __('User')]"
+		>
+			<template #actions>
+				<Button :label="__('Edit')" @click="showEdit = true" />
+				<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
+			</template>
+		</DashboardDetailHeader>
 
 		<div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
 			<!-- General Information -->
-			<DashboardCard
-				:title="__('General Information')"
-				:button-label="__('Edit')"
-				@action="showEdit = true"
-			>
+			<DashboardCard :title="__('General Information')">
 				<div>
 					<InformationField
 						:label="__('Role')"
 						:value="member.data.is_admin ? __('Admin') : __('User')"
 					/>
-					<InformationField :label="__('Full Name')" :value="member.data.description" />
 					<InformationField :label="__('Locale')" :value="localeLabel(member.data.locale)" />
 					<InformationField :label="__('Time Zone')" :value="member.data.time_zone" />
 					<InformationField :label="__('Last Active')" :value="lastActive" />
@@ -195,6 +193,7 @@ import AddMemberGroupsModal from '@/apps/mail/components/Modals/AddMemberGroupsM
 import AddMemberMailingListsModal from '@/apps/mail/components/Modals/AddMemberMailingListsModal.vue'
 import ChangeMemberPasswordModal from '@/apps/mail/components/Modals/ChangeMemberPasswordModal.vue'
 import DashboardCard from '@/apps/mail/components/DashboardCard.vue'
+import DashboardDetailHeader from '@/apps/mail/components/DashboardDetailHeader.vue'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import EditMemberModal from '@/apps/mail/components/Modals/EditMemberModal.vue'
 import EditMemberQuotaModal from '@/apps/mail/components/Modals/EditMemberQuotaModal.vue'

--- a/frontend/src/apps/mail/pages/dashboard/MemberView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/MemberView.vue
@@ -1,9 +1,9 @@
 <template>
 	<DashboardLayout
-		v-if="member.data"
 		:breadcrumbs="BREADCRUMBS"
 		:badge-label="badge.label"
 		:badge-theme="badge.theme"
+		:loading="!member.data"
 	>
 		<template #actions>
 			<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
@@ -31,53 +31,7 @@
 
 			<!-- Quota Usage -->
 			<DashboardCard :title="__('Quota Usage')" :button-label="__('Edit')" @action="showEditQuota = true">
-				<div class="flex flex-1 items-center justify-center gap-8 p-6">
-					<div class="relative shrink-0">
-						<svg :width="DONUT_SIZE" :height="DONUT_SIZE" class="-rotate-90">
-							<circle
-								:cx="DONUT_SIZE / 2"
-								:cy="DONUT_SIZE / 2"
-								:r="DONUT_RADIUS"
-								fill="none"
-								stroke="var(--surface-gray-4)"
-								:stroke-width="DONUT_STROKE"
-							/>
-							<circle
-								v-if="!member.data.quota.unlimited && usedDashArc > 0"
-								:cx="DONUT_SIZE / 2"
-								:cy="DONUT_SIZE / 2"
-								:r="DONUT_RADIUS"
-								fill="none"
-								stroke="var(--surface-gray-10)"
-								:stroke-width="DONUT_STROKE"
-								stroke-linecap="round"
-								:stroke-dasharray="`${usedDashArc} ${DONUT_CIRCUMFERENCE}`"
-							/>
-						</svg>
-						<div class="absolute inset-0 flex flex-col items-center justify-center text-center">
-							<span class="text-lg font-semibold">{{ totalQuotaLabel }}</span>
-							<span class="text-ink-gray-5 text-xs">
-								{{ member.data.quota.unlimited ? __('Unlimited') : __('Total Quota') }}
-							</span>
-						</div>
-					</div>
-					<div class="space-y-4">
-						<div class="flex items-start gap-2">
-							<span class="bg-surface-gray-10 mt-1 h-3 w-3 shrink-0 rounded-sm" />
-							<div>
-								<p class="text-sm font-medium">{{ usedLabel }}</p>
-								<p class="text-ink-gray-5 text-xs">{{ __('Used') }}</p>
-							</div>
-						</div>
-						<div v-if="!member.data.quota.unlimited" class="flex items-start gap-2">
-							<span class="bg-surface-gray-4 mt-1 h-3 w-3 shrink-0 rounded-sm" />
-							<div>
-								<p class="text-sm font-medium">{{ availableLabel }}</p>
-								<p class="text-ink-gray-5 text-xs">{{ __('Available') }}</p>
-							</div>
-						</div>
-					</div>
-				</div>
+				<QuotaDonut :quota="member.data.quota" />
 			</DashboardCard>
 
 			<!-- Email Addresses -->
@@ -202,21 +156,21 @@
 	<Dialog v-model="showToggleEnabled" :options="TOGGLE_ENABLED_OPTIONS" />
 	<Dialog v-model="showDeleteMember" :options="DELETE_MEMBER_OPTIONS" />
 	<ChangeMemberPasswordModal v-model="showChangePassword" :member-id="memberId" />
-		<EditMemberModal v-if="data" v-model="showEdit" :member="data" @reload="member.reload()" />
-		<EditMemberQuotaModal v-if="data" v-model="showEditQuota" :member="data" @reload="member.reload()" />
-		<AddMemberEmailModal v-model="showAddEmail" :member-id="memberId" @reload="member.reload()" />
-		<AddMemberGroupsModal
-			v-model="showAddGroups"
-			:member-id="memberId"
-			:current-ids="currentGroupIds"
-			@reload="member.reload()"
-		/>
-		<AddMemberMailingListsModal
-			v-model="showAddLists"
-			:member-id="memberId"
-			:current-ids="currentListIds"
-			@reload="member.reload()"
-		/>
+	<EditMemberModal v-if="data" v-model="showEdit" :member="data" @reload="member.reload()" />
+	<EditMemberQuotaModal v-if="data" v-model="showEditQuota" :member="data" @reload="member.reload()" />
+	<AddMemberEmailModal v-model="showAddEmail" :member-id="memberId" @reload="member.reload()" />
+	<AddMemberGroupsModal
+		v-model="showAddGroups"
+		:member-id="memberId"
+		:current-ids="currentGroupIds"
+		@reload="member.reload()"
+	/>
+	<AddMemberMailingListsModal
+		v-model="showAddLists"
+		:member-id="memberId"
+		:current-ids="currentListIds"
+		@reload="member.reload()"
+	/>
 </template>
 
 <script setup lang="ts">
@@ -233,7 +187,7 @@ import {
 	usePageMeta,
 } from 'frappe-ui'
 
-import { formatBytes, raiseToast } from '@/apps/mail/utils'
+import { raiseToast } from '@/apps/mail/utils'
 import { formatDateTime } from '@/apps/mail/utils/datetime'
 import { useAccountOptions } from '@/apps/mail/composables/useAccountOptions'
 import AddMemberEmailModal from '@/apps/mail/components/Modals/AddMemberEmailModal.vue'
@@ -245,15 +199,10 @@ import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import EditMemberModal from '@/apps/mail/components/Modals/EditMemberModal.vue'
 import EditMemberQuotaModal from '@/apps/mail/components/Modals/EditMemberQuotaModal.vue'
 import InformationField from '@/apps/mail/components/InformationField.vue'
+import QuotaDonut from '@/apps/mail/components/QuotaDonut.vue'
 
-type QuotaUsage = {
-	total: number
-	used: number
-	available: number
-	used_percentage: number
-	available_percentage: number
-	unlimited: boolean
-}
+import type { QuotaUsage } from '@/apps/mail/types'
+
 type MemberData = {
 	name: string
 	full_name: string
@@ -290,7 +239,10 @@ const member = createResource({
 	auto: true,
 	makeParams: () => ({ member_id: memberId }),
 	cache: ['mailMember', memberId],
-	onError: () => router.replace({ name: 'mail-members' }),
+	onError: (error: { messages?: string[] }) => {
+		raiseToast(error.messages?.[0] || __('Member not found.'), 'error')
+		router.replace({ name: 'mail-members' })
+	},
 })
 
 const data = computed(() => member.data as MemberData | undefined)
@@ -357,37 +309,6 @@ const formatDate = (value?: string | null) => formatDateTime(value)
 
 const lastActive = computed(() => formatDate(data.value?.last_active) || __('Never'))
 const joinedOn = computed(() => formatDate(data.value?.joined_on))
-
-// Quota donut geometry.
-const DONUT_SIZE = 140
-const DONUT_STROKE = 12
-const DONUT_RADIUS = (DONUT_SIZE - DONUT_STROKE) / 2
-const DONUT_CIRCUMFERENCE = 2 * Math.PI * DONUT_RADIUS
-
-// Length of the "used" arc. Guarded against sub-pixel arcs (e.g. a few hundred bytes of a
-// multi-GB quota) that a round line cap would otherwise render as a misleading full dot.
-const usedDashArc = computed(() => {
-	const pct = data.value?.quota.used_percentage || 0
-	const arc = DONUT_CIRCUMFERENCE * (pct / 100)
-	return arc >= 1 ? arc : 0
-})
-
-const totalQuotaLabel = computed(() =>
-	data.value?.quota.unlimited ? '∞' : formatBytes(data.value?.quota.total || 0),
-)
-
-const usedLabel = computed(() => {
-	const quota = data.value?.quota
-	if (!quota) return ''
-	if (quota.unlimited) return formatBytes(quota.used)
-	return `${formatBytes(quota.used)} (${quota.used_percentage.toFixed(1)}%)`
-})
-
-const availableLabel = computed(() => {
-	const quota = data.value?.quota
-	if (!quota) return ''
-	return `${formatBytes(quota.available)} (${quota.available_percentage.toFixed(1)}%)`
-})
 
 const BREADCRUMBS = computed(() => [
 	{ label: __('Members'), route: '/mail/dashboard/members' },
@@ -468,7 +389,14 @@ const DELETE_MEMBER_OPTIONS = {
 	message: __('Are you sure you want to delete this member? This action cannot be undone.'),
 	size: 'xl',
 	icon: { name: 'alert-triangle', appearance: 'warning' },
-	actions: [{ label: __('Confirm'), variant: 'solid', onClick: () => deleteMember.submit() }],
+	actions: [
+		{
+			label: __('Confirm'),
+			variant: 'solid',
+			theme: 'red',
+			onClick: () => deleteMember.submit(),
+		},
+	],
 }
 
 const dropdownOptions = computed(() => [

--- a/frontend/src/apps/mail/pages/dashboard/MembersView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/MembersView.vue
@@ -13,7 +13,9 @@
 			]"
 		>
 			<template #tab-panel>
-				<div class="flex flex-1 flex-col space-y-5 overflow-y-auto p-5">
+				<!-- Match DashboardLayout's body spacing so the tabbed page doesn't sit
+				     at a different offset than its sibling pages. -->
+				<div class="flex flex-1 flex-col space-y-5 overflow-y-auto px-3 py-5 sm:px-5">
 					<UsersView v-if="tabIndex === 0" ref="usersView" />
 					<InvitesView v-else ref="invitesView" />
 				</div>

--- a/frontend/src/apps/mail/pages/dashboard/OAuthClientView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/OAuthClientView.vue
@@ -1,18 +1,20 @@
 <template>
 	<DashboardLayout :breadcrumbs="breadcrumbs" :loading="!client.data">
-		<template #actions>
-			<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
-		</template>
 		<template #default>
+			<DashboardDetailHeader
+				:title="client.data.description || client.data.client_id || clientId"
+				:meta="[client.data.client_id, redirectUriCountLabel]"
+			>
+				<template #icon><KeyRound class="h-5 w-5" /></template>
+				<template #actions>
+					<Button :label="__('Edit')" @click="showEdit = true" />
+					<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
+				</template>
+			</DashboardDetailHeader>
+
 			<div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
 				<!-- General Information -->
-				<DashboardCard
-					:title="__('General Information')"
-					:button-label="__('Edit')"
-					@action="showEdit = true"
-				>
-					<InformationField :label="__('Client ID')" :value="client.data.client_id" />
-					<InformationField :label="__('Description')" :value="client.data.description" />
+				<DashboardCard :title="__('General Information')">
 					<InformationField :label="__('Created At')" :value="createdAt" />
 					<InformationField :label="__('Expires At')" :value="expiresAt" />
 				</DashboardCard>
@@ -85,10 +87,13 @@ import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { Button, Dialog, Dropdown, FeatherIcon, createResource, usePageMeta } from 'frappe-ui'
 
+import KeyRound from '~icons/lucide/key-round'
+
 import { raiseToast } from '@/apps/mail/utils'
 import { formatDateTime } from '@/apps/mail/utils/datetime'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import DashboardCard from '@/apps/mail/components/DashboardCard.vue'
+import DashboardDetailHeader from '@/apps/mail/components/DashboardDetailHeader.vue'
 import InformationField from '@/apps/mail/components/InformationField.vue'
 import EditOAuthClientModal from '@/apps/mail/components/Modals/EditOAuthClientModal.vue'
 import AddOAuthContactsModal from '@/apps/mail/components/Modals/AddOAuthContactsModal.vue'
@@ -118,6 +123,11 @@ const client = createResource({
 const formatDate = (value?: string | null) => formatDateTime(value)
 const createdAt = computed(() => formatDate(client.data?.created_at))
 const expiresAt = computed(() => formatDate(client.data?.expires_at))
+
+const redirectUriCountLabel = computed(() => {
+	const count = client.data?.redirect_uris?.length ?? 0
+	return count === 1 ? __('1 redirect URI') : __('{0} redirect URIs', [String(count)])
+})
 
 const breadcrumbs = computed(() => [
 	{ label: __('OAuth Clients'), route: '/mail/dashboard/oauth-clients' },

--- a/frontend/src/apps/mail/pages/dashboard/OAuthClientView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/OAuthClientView.vue
@@ -1,5 +1,5 @@
 <template>
-	<DashboardLayout v-if="client?.data" :breadcrumbs="breadcrumbs">
+	<DashboardLayout :breadcrumbs="breadcrumbs" :loading="!client.data">
 		<template #actions>
 			<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
 		</template>
@@ -109,7 +109,10 @@ const client = createResource({
 	auto: true,
 	makeParams: () => ({ client_id: clientId }),
 	cache: ['mailOAuthClient', clientId],
-	onError: () => router.replace({ name: 'mail-oauth-clients' }),
+	onError: (error: { messages?: string[] }) => {
+		raiseToast(error.messages?.[0] || __('OAuth client not found.'), 'error')
+		router.replace({ name: 'mail-oauth-clients' })
+	},
 })
 
 const formatDate = (value?: string | null) => formatDateTime(value)

--- a/frontend/src/apps/mail/pages/dashboard/OAuthClientsView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/OAuthClientsView.vue
@@ -16,7 +16,7 @@
 			class="flex-1"
 			:columns="LIST_COLUMNS"
 			:rows="clients.data"
-			:options="LIST_OPTIONS"
+			:options="listOptions"
 			row-key="id"
 		>
 			<ListHeader />
@@ -37,11 +37,12 @@
 				<ListEmptyState v-else />
 			</ListRows>
 		</ListView>
+		<DashboardListSkeleton v-else :columns="3" />
 	</DashboardLayout>
 	<AddOAuthClientModal v-model="showAdd" @reload="clients.reload()" />
 </template>
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { watchDebounced } from '@vueuse/core'
 import {
 	FeatherIcon,
@@ -58,6 +59,7 @@ import {
 
 import { fromNow } from '@/apps/mail/utils/datetime'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
+import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 import AddOAuthClientModal from '@/apps/mail/components/Modals/AddOAuthClientModal.vue'
 
 usePageMeta(() => ({ title: __('OAuth Clients') }))
@@ -82,12 +84,27 @@ const LIST_COLUMNS = [
 	{ label: __('Created At'), key: 'created_at' },
 ]
 
-const LIST_OPTIONS = {
+const hasActiveFilters = computed(() => !!search.value)
+
+const listOptions = computed(() => ({
 	selectable: false,
 	showTooltip: false,
-	emptyState: { description: __('No OAuth clients found.') },
+	emptyState: hasActiveFilters.value
+		? {
+				title: __('No matching OAuth clients'),
+				description: __('Try adjusting your search or filters.'),
+			}
+		: {
+				title: __('No OAuth clients yet'),
+				description: __('OAuth clients let external apps authenticate with your mail server.'),
+				button: {
+					label: __('Add OAuth Client'),
+					variant: 'solid',
+					onClick: () => (showAdd.value = true),
+				},
+			},
 	getRowRoute: (row: ClientRow) => ({ name: 'mail-oauth-client', params: { clientId: row.id } }),
-}
+}))
 
-const formatCreatedAt = (createdAt?: string) => fromNow(createdAt) || '-'
+const formatCreatedAt = (createdAt?: string) => fromNow(createdAt) || '—'
 </script>

--- a/frontend/src/apps/mail/pages/dashboard/OverviewView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/OverviewView.vue
@@ -1,0 +1,236 @@
+<template>
+	<DashboardLayout :breadcrumbs="[{ label: __('Overview') }]" :loading="!overview.data">
+		<!-- KPI tiles: one glanceable number per section, each a link into it. -->
+		<div class="grid grid-cols-2 gap-4 sm:grid-cols-3 xl:grid-cols-6">
+			<RouterLink
+				v-for="stat in stats"
+				:key="stat.label"
+				:to="stat.to"
+				class="hover:bg-surface-gray-1 group flex flex-col gap-1 rounded-md border p-4 transition-colors"
+			>
+				<span class="text-ink-gray-5 flex items-center gap-1.5 text-sm">
+					<component :is="stat.icon" class="h-4 w-4" />
+					{{ stat.label }}
+				</span>
+				<span class="text-ink-gray-9 text-2xl font-semibold">{{ stat.value }}</span>
+				<span class="text-xs" :class="stat.subTone === 'warning' && stat.sub ? 'text-ink-amber-6' : 'text-ink-gray-5'">
+					{{ stat.sub || ' ' }}
+				</span>
+			</RouterLink>
+		</div>
+
+		<div class="grid grid-cols-1 gap-5 lg:grid-cols-5">
+			<!-- Recent activity -->
+			<DashboardCard :title="__('Recent Activity')" class="lg:col-span-3">
+				<template #actions>
+					<Button
+						variant="ghost"
+						:label="__('View Logs')"
+						@click="router.push({ name: 'mail-logs' })"
+					/>
+				</template>
+				<div v-if="recentLogs.length" class="flex flex-col">
+					<RouterLink
+						v-for="log in recentLogs"
+						:key="log.id"
+						:to="{ name: 'mail-log', params: { logId: log.id } }"
+						class="hover:bg-surface-gray-1 flex items-center gap-3 border-b px-5 py-3 last:border-b-0"
+					>
+						<Badge :label="log.level_label || log.level" :theme="levelTheme(log.level)" />
+						<div class="min-w-0 flex-1">
+							<p class="truncate text-sm">{{ log.event_label || log.event }}</p>
+							<p v-if="log.details" class="text-ink-gray-5 mt-0.5 truncate font-mono text-xs">
+								{{ log.details }}
+							</p>
+						</div>
+						<span class="text-ink-gray-5 shrink-0 text-xs">{{ fromNow(log.timestamp) }}</span>
+					</RouterLink>
+				</div>
+				<div v-else class="text-ink-gray-5 px-5 py-8 text-center text-sm">
+					{{ __('No recent log entries.') }}
+				</div>
+			</DashboardCard>
+
+			<!-- Quick actions -->
+			<DashboardCard :title="__('Quick Actions')" class="lg:col-span-2">
+				<div class="flex flex-col">
+					<RouterLink
+						v-for="action in QUICK_ACTIONS"
+						:key="action.label"
+						:to="action.to"
+						class="hover:bg-surface-gray-1 group flex items-center gap-3 border-b px-5 py-3 last:border-b-0"
+					>
+						<div
+							class="bg-surface-gray-2 text-ink-gray-6 flex h-8 w-8 shrink-0 items-center justify-center rounded-md"
+						>
+							<component :is="action.icon" class="h-4 w-4" />
+						</div>
+						<div class="min-w-0 flex-1">
+							<p class="text-sm font-medium">{{ action.label }}</p>
+							<p class="text-ink-gray-5 mt-0.5 truncate text-xs">{{ action.description }}</p>
+						</div>
+						<FeatherIcon
+							name="chevron-right"
+							class="text-ink-gray-4 h-4 w-4 shrink-0 transition-transform group-hover:translate-x-0.5"
+						/>
+					</RouterLink>
+				</div>
+			</DashboardCard>
+		</div>
+	</DashboardLayout>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { Badge, Button, FeatherIcon, createResource, usePageMeta } from 'frappe-ui'
+
+import { fromNow } from '@/apps/mail/utils/datetime'
+import DashboardCard from '@/apps/mail/components/DashboardCard.vue'
+import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
+
+import Clock from '~icons/lucide/clock'
+import Globe from '~icons/lucide/globe'
+import Mails from '~icons/lucide/mails'
+import Megaphone from '~icons/lucide/megaphone'
+import Radar from '~icons/lucide/radar'
+import ScrollText from '~icons/lucide/scroll-text'
+import UserPlus from '~icons/lucide/user-plus'
+import Users from '~icons/lucide/users'
+import UsersRound from '~icons/lucide/users-round'
+
+type CountWithDisabled = { total: number; disabled: number }
+type LogEntry = {
+	id: string
+	timestamp?: string
+	level?: string
+	level_label?: string
+	event?: string
+	event_label?: string
+	details?: string
+}
+type OverviewData = {
+	members: CountWithDisabled | null
+	pending_invites: number | null
+	domains: CountWithDisabled | null
+	groups: number | null
+	mailing_lists: number | null
+	queued_messages: number | null
+	recent_logs: LogEntry[]
+}
+
+usePageMeta(() => ({ title: __('Overview') }))
+
+const router = useRouter()
+
+const overview = createResource({
+	url: 'suite.mail.api.admin.get_overview',
+	auto: true,
+	cache: 'mailOverview',
+})
+
+const data = computed(() => overview.data as OverviewData | undefined)
+
+// A section whose backing store was unreachable reports null; show an em dash
+// rather than a fake zero.
+const count = (value: number | null | undefined) => (value == null ? '—' : String(value))
+
+const disabledSub = (value: CountWithDisabled | null | undefined) =>
+	value?.disabled ? __('{0} disabled', [String(value.disabled)]) : ''
+
+const stats = computed(() => [
+	{
+		label: __('Members'),
+		icon: Users,
+		value: count(data.value?.members?.total),
+		sub: disabledSub(data.value?.members),
+		subTone: 'muted',
+		to: { name: 'mail-members' },
+	},
+	{
+		label: __('Invites'),
+		icon: UserPlus,
+		value: count(data.value?.pending_invites),
+		sub: data.value?.pending_invites ? __('awaiting acceptance') : '',
+		subTone: 'muted',
+		to: { name: 'mail-invites' },
+	},
+	{
+		label: __('Domains'),
+		icon: Globe,
+		value: count(data.value?.domains?.total),
+		sub: disabledSub(data.value?.domains),
+		subTone: 'warning',
+		to: { name: 'mail-domains' },
+	},
+	{
+		label: __('Groups'),
+		icon: UsersRound,
+		value: count(data.value?.groups),
+		sub: '',
+		subTone: 'muted',
+		to: { name: 'mail-groups' },
+	},
+	{
+		label: __('Mailing Lists'),
+		icon: Megaphone,
+		value: count(data.value?.mailing_lists),
+		sub: '',
+		subTone: 'muted',
+		to: { name: 'mail-mailing-lists' },
+	},
+	{
+		label: __('Queued'),
+		icon: Clock,
+		value: count(data.value?.queued_messages),
+		sub: data.value?.queued_messages ? __('awaiting delivery') : '',
+		subTone: 'muted',
+		to: { name: 'mail-queued-messages' },
+	},
+])
+
+const recentLogs = computed(() => data.value?.recent_logs || [])
+
+// Mirrors the colours the server's TracingLevel enum assigns to each level.
+const LEVEL_THEMES: Record<string, string> = {
+	error: 'red',
+	warn: 'amber',
+	info: 'green',
+	debug: 'blue',
+	trace: 'violet',
+}
+const levelTheme = (level?: string) => LEVEL_THEMES[(level || '').toLowerCase()] || 'gray'
+
+const QUICK_ACTIONS = [
+	{
+		label: __('Add a domain'),
+		description: __('Connect a domain and set up its DNS records.'),
+		icon: Globe,
+		to: { name: 'mail-domains' },
+	},
+	{
+		label: __('Invite a member'),
+		description: __('Give someone a mailbox on your domains.'),
+		icon: UserPlus,
+		to: { name: 'mail-members' },
+	},
+	{
+		label: __('Run a delivery test'),
+		description: __('Trace a live SMTP delivery to diagnose issues.'),
+		icon: Radar,
+		to: { name: 'mail-delivery-test' },
+	},
+	{
+		label: __('Review the queue'),
+		description: __('Inspect and retry messages pending delivery.'),
+		icon: Mails,
+		to: { name: 'mail-queued-messages' },
+	},
+	{
+		label: __('Check server logs'),
+		description: __('Follow what the mail server is doing.'),
+		icon: ScrollText,
+		to: { name: 'mail-logs' },
+	},
+]
+</script>

--- a/frontend/src/apps/mail/pages/dashboard/QueuedMessageView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/QueuedMessageView.vue
@@ -1,12 +1,15 @@
 <template>
 	<DashboardLayout :breadcrumbs="breadcrumbs" :loading="!message.data">
-		<template #actions>
-			<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
-		</template>
 		<template #default>
+			<DashboardDetailHeader :title="data.id || messageId" :meta="[data.sender, queuedAgo]">
+				<template #icon><Mail class="h-5 w-5" /></template>
+				<template #actions>
+					<Button :label="__('Retry Now')" @click="retry.submit()" />
+					<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
+				</template>
+			</DashboardDetailHeader>
 			<div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
 				<DashboardCard :title="__('General Information')" :button-label="__('Edit')" @action="showEditMessage = true">
-					<InformationField :label="__('Sender')" :value="data.sender" />
 					<InformationField :label="__('Size')" :value="formatBytes(data.size || 0)" />
 					<InformationField :label="__('Priority')" :value="String(data.priority ?? '—')" />
 					<InformationField :label="__('Envelope ID')" :value="data.env_id" />
@@ -98,10 +101,13 @@ import {
 	usePageMeta,
 } from 'frappe-ui'
 
+import Mail from '~icons/lucide/mail'
+
 import { formatBytes, raiseToast } from '@/apps/mail/utils'
 import { formatDateTime, fromNow } from '@/apps/mail/utils/datetime'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import DashboardCard from '@/apps/mail/components/DashboardCard.vue'
+import DashboardDetailHeader from '@/apps/mail/components/DashboardDetailHeader.vue'
 import InformationField from '@/apps/mail/components/InformationField.vue'
 import AddQueuedRecipientModal from '@/apps/mail/components/Modals/AddQueuedRecipientModal.vue'
 import EditQueuedRecipientModal from '@/apps/mail/components/Modals/EditQueuedRecipientModal.vue'
@@ -198,6 +204,10 @@ const editRecipient = (r: Recipient) => {
 	showEditRecipient.value = true
 }
 
+const queuedAgo = computed(() =>
+	data.value?.created_at ? __('Queued {0}', [fromNow(data.value.created_at)]) : undefined,
+)
+
 const breadcrumbs = computed(() => [
 	{ label: __('Queued'), route: '/mail/dashboard/queued' },
 	{ label: data.value?.sender || messageId },
@@ -242,7 +252,7 @@ const cancelDialogOptions = computed(() => ({
 }))
 
 const dropdownOptions = computed(() => {
-	const items = [{ label: __('Retry Now'), icon: 'refresh-cw', onClick: retry.submit }]
+	const items: { label: string; icon: string; onClick: () => void }[] = []
 	if (data.value?.has_content) {
 		items.push({
 			label: __('View Source'),

--- a/frontend/src/apps/mail/pages/dashboard/QueuedMessageView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/QueuedMessageView.vue
@@ -1,5 +1,5 @@
 <template>
-	<DashboardLayout v-if="message?.data" :breadcrumbs="breadcrumbs">
+	<DashboardLayout :breadcrumbs="breadcrumbs" :loading="!message.data">
 		<template #actions>
 			<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
 		</template>
@@ -78,14 +78,25 @@
 				class="bg-surface-gray-2 max-h-[70vh] overflow-auto rounded p-4 text-xs whitespace-pre-wrap"
 				>{{ source.data.source }}</pre
 			>
-			<div v-else class="text-ink-gray-5 py-6 text-center text-sm">{{ __('Loading…') }}</div>
+			<div v-else class="flex justify-center py-6">
+				<LoadingIndicator class="text-ink-gray-5 h-4 w-4" />
+			</div>
 		</template>
 	</Dialog>
 </template>
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { Badge, Button, Dialog, Dropdown, FeatherIcon, createResource, usePageMeta } from 'frappe-ui'
+import {
+	Badge,
+	Button,
+	Dialog,
+	Dropdown,
+	FeatherIcon,
+	LoadingIndicator,
+	createResource,
+	usePageMeta,
+} from 'frappe-ui'
 
 import { formatBytes, raiseToast } from '@/apps/mail/utils'
 import { formatDateTime, fromNow } from '@/apps/mail/utils/datetime'
@@ -136,7 +147,10 @@ const message = createResource({
 	auto: true,
 	makeParams: () => ({ message_id: messageId }),
 	cache: ['mailQueuedMessage', messageId],
-	onError: () => router.replace({ name: 'mail-queued-messages' }),
+	onError: (error: { messages?: string[] }) => {
+		raiseToast(error.messages?.[0] || __('Message not found.'), 'error')
+		router.replace({ name: 'mail-queued-messages' })
+	},
 })
 
 const data = computed(() => message.data as MessageData)
@@ -153,6 +167,10 @@ const options = computed(
 const source = createResource({
 	url: 'suite.mail.api.admin.get_queued_message_source',
 	makeParams: () => ({ message_id: messageId }),
+	onError: (error: { messages?: string[] }) => {
+		showSource.value = false
+		raiseToast(error.messages?.[0] || __('Failed to load message source.'), 'error')
+	},
 })
 
 const STATUS_LABELS: Record<string, string> = {
@@ -166,7 +184,7 @@ const statusLabel = (type?: string) => STATUS_LABELS[type || ''] || type || __('
 const statusTheme = (type?: string) => {
 	if (type === 'Completed') return 'green'
 	if (type === 'PermanentFailure') return 'red'
-	if (type === 'TemporaryFailure') return 'orange'
+	if (type === 'TemporaryFailure') return 'amber'
 	return 'gray'
 }
 const recipientSummary = (r: Recipient) => {

--- a/frontend/src/apps/mail/pages/dashboard/QueuedMessagesView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/QueuedMessagesView.vue
@@ -2,10 +2,12 @@
 	<DashboardLayout :breadcrumbs="[{ label: __('Queued') }]">
 		<div class="flex items-center justify-between">
 			<div class="flex items-center space-x-3">
-				<FormControl v-model="search" :placeholder="__('Search')" class="w-72">
+				<FormControl v-model="search" :placeholder="__('Search')" class="w-80">
 					<template #prefix><FeatherIcon name="search" class="text-ink-gray-5 w-4" /></template>
 				</FormControl>
-				<FormControl v-model="sender" :placeholder="__('Sender')" class="w-56" />
+				<FormControl v-model="sender" :placeholder="__('Sender')" class="w-56">
+					<template #prefix><FeatherIcon name="user" class="text-ink-gray-5 w-4" /></template>
+				</FormControl>
 			</div>
 			<div class="flex items-center gap-2">
 				<Button :label="__('Retry All')" @click="showRetryAll = true" />
@@ -18,7 +20,7 @@
 			class="flex-1"
 			:columns="LIST_COLUMNS"
 			:rows="rows"
-			:options="LIST_OPTIONS"
+			:options="listOptions"
 			row-key="id"
 		>
 			<ListHeader />
@@ -48,6 +50,7 @@
 				</template>
 			</ListSelectBanner>
 		</ListView>
+		<DashboardListSkeleton v-else :columns="5" />
 		<DashboardPager :page="page" :page-length="PAGE_LENGTH" :total="total" @update:page="(p) => (page = p)" />
 	</DashboardLayout>
 	<Dialog v-model="showRetrySelected" :options="retrySelectedOptions" />
@@ -77,6 +80,7 @@ import {
 import { formatBytes, raiseToast } from '@/apps/mail/utils'
 import { fromNow as formatFromNow } from '@/apps/mail/utils/datetime'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
+import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 import DashboardPager from '@/apps/mail/components/DashboardPager.vue'
 
 type QueueRow = {
@@ -132,12 +136,22 @@ const LIST_COLUMNS = [
 	{ label: __('Size'), key: 'size' },
 ]
 
-const LIST_OPTIONS = {
+const hasActiveFilters = computed(() => !!search.value || !!sender.value)
+
+const listOptions = computed(() => ({
 	showTooltip: false,
 	rowHeight: 50,
-	emptyState: { description: __('No queued messages found.') },
+	emptyState: hasActiveFilters.value
+		? {
+				title: __('No matching messages'),
+				description: __('Try adjusting your search or filters.'),
+			}
+		: {
+				title: __('Queue is empty'),
+				description: __('Messages waiting for delivery will appear here.'),
+			},
 	getRowRoute: (row: QueueRow) => ({ name: 'mail-queued-message', params: { messageId: row.id } }),
-}
+}))
 
 const afterAction = (message: string) => {
 	messages.reload()
@@ -149,21 +163,37 @@ const retrySelected = createResource({
 	url: 'suite.mail.api.admin.retry_queued_messages',
 	makeParams: () => ({ ids: selectedIds() }),
 	onSuccess: () => ((showRetrySelected.value = false), afterAction(__('Messages scheduled for retry.'))),
+	onError: (error: { messages?: string[] }) => {
+		showRetrySelected.value = false
+		raiseToast(error.messages?.[0] || __('Request failed.'), 'error')
+	},
 })
 const cancelSelected = createResource({
 	url: 'suite.mail.api.admin.cancel_queued_messages',
 	makeParams: () => ({ ids: selectedIds() }),
 	onSuccess: () => ((showCancelSelected.value = false), afterAction(__('Messages cancelled.'))),
+	onError: (error: { messages?: string[] }) => {
+		showCancelSelected.value = false
+		raiseToast(error.messages?.[0] || __('Request failed.'), 'error')
+	},
 })
 const retryAll = createResource({
 	url: 'suite.mail.api.admin.retry_all_queued_messages',
 	makeParams: currentFilter,
 	onSuccess: () => ((showRetryAll.value = false), afterAction(__('All matching messages scheduled for retry.'))),
+	onError: (error: { messages?: string[] }) => {
+		showRetryAll.value = false
+		raiseToast(error.messages?.[0] || __('Request failed.'), 'error')
+	},
 })
 const cancelAll = createResource({
 	url: 'suite.mail.api.admin.cancel_all_queued_messages',
 	makeParams: currentFilter,
 	onSuccess: () => ((showCancelAll.value = false), afterAction(__('All matching messages cancelled.'))),
+	onError: (error: { messages?: string[] }) => {
+		showCancelAll.value = false
+		raiseToast(error.messages?.[0] || __('Request failed.'), 'error')
+	},
 })
 
 const retrySelectedOptions = computed(() => ({

--- a/frontend/src/apps/mail/pages/dashboard/ReportView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/ReportView.vue
@@ -1,12 +1,11 @@
 <template>
-	<DashboardLayout v-if="report?.data" :breadcrumbs="breadcrumbs">
+	<DashboardLayout :breadcrumbs="breadcrumbs" :loading="!report.data">
 		<template #actions>
 			<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
 		</template>
 		<template #default>
 			<div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
 				<DashboardCard :title="__('Report')">
-					<template #actions><span /></template>
 					<template v-if="direction === 'inbound'">
 						<InformationField :label="__('From')" :value="data.from" />
 						<InformationField :label="__('Subject')" :value="data.subject" />
@@ -26,7 +25,9 @@
 				</DashboardCard>
 
 				<DashboardCard :title="__('Details')">
-					<template #actions><span /></template>
+					<template #actions>
+						<Button variant="ghost" :label="__('Copy')" @click="copyToClipBoard(reportJson)" />
+					</template>
 					<pre
 						class="bg-surface-gray-2 max-h-[60vh] overflow-auto rounded p-4 text-xs whitespace-pre-wrap"
 						>{{ reportJson }}</pre
@@ -40,9 +41,9 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { Dialog, Dropdown, createResource, usePageMeta } from 'frappe-ui'
+import { Button, Dialog, Dropdown, createResource, usePageMeta } from 'frappe-ui'
 
-import { raiseToast } from '@/apps/mail/utils'
+import { copyToClipBoard, raiseToast } from '@/apps/mail/utils'
 import { formatDateTime } from '@/apps/mail/utils/datetime'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import DashboardCard from '@/apps/mail/components/DashboardCard.vue'
@@ -82,7 +83,10 @@ const report = createResource({
 	auto: true,
 	makeParams: () => ({ kind, direction, report_id: reportId }),
 	cache: ['mailReport', kind, direction, reportId],
-	onError: () => router.replace({ name: listRouteName.value }),
+	onError: (error: { messages?: string[] }) => {
+		raiseToast(error.messages?.[0] || __('Report not found.'), 'error')
+		router.replace({ name: listRouteName.value })
+	},
 })
 
 const data = computed(() => report.data as ReportData)

--- a/frontend/src/apps/mail/pages/dashboard/ReportView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/ReportView.vue
@@ -1,9 +1,13 @@
 <template>
 	<DashboardLayout :breadcrumbs="breadcrumbs" :loading="!report.data">
-		<template #actions>
-			<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
-		</template>
 		<template #default>
+			<DashboardDetailHeader :title="detailTitle" :meta="[data.domain || data.from, reportId]">
+				<template #icon><FileChartColumn class="h-5 w-5" /></template>
+				<template #actions>
+					<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
+				</template>
+			</DashboardDetailHeader>
+
 			<div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
 				<DashboardCard :title="__('Report')">
 					<template v-if="direction === 'inbound'">
@@ -43,10 +47,13 @@ import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { Button, Dialog, Dropdown, createResource, usePageMeta } from 'frappe-ui'
 
+import FileChartColumn from '~icons/lucide/file-chart-column'
+
 import { copyToClipBoard, raiseToast } from '@/apps/mail/utils'
 import { formatDateTime } from '@/apps/mail/utils/datetime'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import DashboardCard from '@/apps/mail/components/DashboardCard.vue'
+import DashboardDetailHeader from '@/apps/mail/components/DashboardDetailHeader.vue'
 import InformationField from '@/apps/mail/components/InformationField.vue'
 
 type ReportData = {
@@ -72,6 +79,10 @@ const listRouteName = computed(() => `mail-reports-${kind}-${direction}`)
 const listTitle = computed(() => {
 	const dir = direction === 'inbound' ? __('Inbound') : __('Outbound')
 	return `${dir} ${KIND_LABELS[kind] || kind} ${__('Reports')}`
+})
+const detailTitle = computed(() => {
+	const dir = direction === 'inbound' ? __('Inbound') : __('Outbound')
+	return `${dir} ${KIND_LABELS[kind] || kind} ${__('Report')}`
 })
 
 usePageMeta(() => ({ title: listTitle.value }))

--- a/frontend/src/apps/mail/pages/dashboard/ReportsView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/ReportsView.vue
@@ -1,7 +1,7 @@
 <template>
 	<DashboardLayout :breadcrumbs="[{ label: title }]">
 		<div v-if="supportsSearch" class="flex items-center space-x-3">
-			<FormControl v-model="search" :placeholder="searchPlaceholder" class="w-72">
+			<FormControl v-model="search" :placeholder="__('Search')" class="w-80">
 				<template #prefix><FeatherIcon name="search" class="text-ink-gray-5 w-4" /></template>
 			</FormControl>
 		</div>
@@ -39,6 +39,7 @@
 				</template>
 			</ListSelectBanner>
 		</ListView>
+		<DashboardListSkeleton v-else :columns="3" />
 		<DashboardPager :page="page" :page-length="PAGE_LENGTH" :total="total" @update:page="(p) => (page = p)" />
 	</DashboardLayout>
 	<Dialog v-model="showDelete" :options="deleteOptions" />
@@ -65,6 +66,7 @@ import {
 import { raiseToast } from '@/apps/mail/utils'
 import { fromNow as formatFromNow } from '@/apps/mail/utils/datetime'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
+import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 import DashboardPager from '@/apps/mail/components/DashboardPager.vue'
 
 type ReportRow = { id: string; [key: string]: string | undefined }
@@ -80,9 +82,6 @@ const listView = useTemplateRef<{ selections?: Set<string>; toggleAllRows?: () =
 const KIND_LABELS: Record<string, string> = { dmarc: 'DMARC', tls: 'TLS', arf: 'ARF' }
 // Only DMARC reports are searchable: a free-text match on the received ones, a domain match on ours.
 const supportsSearch = computed(() => kind === 'dmarc')
-const searchPlaceholder = computed(() =>
-	direction === 'inbound' ? __('Search by sender, recipient or domain') : __('Filter by domain'),
-)
 const title = computed(() => {
 	const dir = direction === 'inbound' ? __('Inbound') : __('Outbound')
 	return `${dir} ${KIND_LABELS[kind] || kind} ${__('Reports')}`
@@ -121,10 +120,20 @@ const columns = computed(() =>
 			],
 )
 
+const hasActiveFilters = computed(() => !!search.value)
+
 const listOptions = computed(() => ({
 	showTooltip: false,
 	rowHeight: 50,
-	emptyState: { description: __('No reports found.') },
+	emptyState: hasActiveFilters.value
+		? {
+				title: __('No matching reports'),
+				description: __('Try adjusting your search or filters.'),
+			}
+		: {
+				title: __('No reports yet'),
+				description: __('Reports received for your domains will appear here.'),
+			},
 	getRowRoute: (row: ReportRow) => ({ name: 'mail-report', params: { direction, kind, reportId: row.id } }),
 }))
 
@@ -136,6 +145,10 @@ const deleteReports = createResource({
 		reports.reload()
 		listView.value?.toggleAllRows?.()
 		raiseToast(__('Reports deleted.'))
+	},
+	onError: (error: { messages?: string[] }) => {
+		showDelete.value = false
+		raiseToast(error.messages?.[0] || __('Request failed.'), 'error')
 	},
 })
 

--- a/frontend/src/apps/mail/pages/dashboard/RoleView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/RoleView.vue
@@ -1,5 +1,5 @@
 <template>
-	<DashboardLayout v-if="role.data" :breadcrumbs="breadcrumbs">
+	<DashboardLayout :breadcrumbs="breadcrumbs" :loading="!role.data">
 		<template #actions>
 			<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
 		</template>
@@ -14,7 +14,6 @@
 				</DashboardCard>
 
 				<DashboardCard :title="__('Inherited Roles')">
-					<template #actions><span /></template>
 					<div class="p-4">
 						<MultiSelect
 							:model-value="roleIds"
@@ -25,7 +24,6 @@
 				</DashboardCard>
 
 				<DashboardCard :title="__('Enabled Permissions')">
-					<template #actions><span /></template>
 					<div class="p-4">
 						<MultiSelect
 							:model-value="enabledPermissions"
@@ -36,7 +34,6 @@
 				</DashboardCard>
 
 				<DashboardCard :title="__('Disabled Permissions')">
-					<template #actions><span /></template>
 					<div class="p-4">
 						<MultiSelect
 							:model-value="disabledPermissions"
@@ -87,7 +84,10 @@ const role = createResource({
 	auto: true,
 	makeParams: () => ({ role_id: roleId }),
 	cache: ['mailRole', roleId],
-	onError: () => router.replace({ name: 'mail-roles' }),
+	onError: (error: { messages?: string[] }) => {
+		raiseToast(error.messages?.[0] || __('Role not found.'), 'error')
+		router.replace({ name: 'mail-roles' })
+	},
 })
 
 // Keep the editable chip selections in sync whenever the role (re)loads.
@@ -125,6 +125,7 @@ const save = (field: 'enabled_permissions' | 'disabled_permissions' | 'role_ids'
 	createResource({
 		url: 'suite.mail.api.admin.update_role',
 		makeParams: () => ({ role_id: roleId, [field]: value }),
+		onSuccess: () => raiseToast(__('Role updated.')),
 		onError: (error: { messages?: string[] }) => {
 			role.reload()
 			raiseToast(error.messages?.[0] || __('Request failed.'), 'error')

--- a/frontend/src/apps/mail/pages/dashboard/RoleView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/RoleView.vue
@@ -1,20 +1,20 @@
 <template>
 	<DashboardLayout :breadcrumbs="breadcrumbs" :loading="!role.data">
-		<template #actions>
-			<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
-		</template>
 		<template #default>
-			<div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
-				<DashboardCard
-					:title="__('General Information')"
-					:button-label="__('Edit')"
-					@action="showEdit = true"
-				>
-					<InformationField :label="__('Description')" :value="role.data.description" />
-				</DashboardCard>
+			<DashboardDetailHeader :title="role.data.description || role.data.id" :meta="[role.data.id]">
+				<template #icon><ShieldCheck class="h-5 w-5" /></template>
+				<template #actions>
+					<Button :label="__('Edit')" @click="showEdit = true" />
+					<Dropdown :options="dropdownOptions" :button="{ icon: 'more-horizontal' }" />
+				</template>
+			</DashboardDetailHeader>
 
+			<div class="grid grid-cols-1 gap-5 xl:grid-cols-3">
 				<DashboardCard :title="__('Inherited Roles')">
 					<div class="p-4">
+						<p class="text-ink-gray-5 mb-3 text-sm">
+							{{ __('This role also grants everything the selected roles allow.') }}
+						</p>
 						<MultiSelect
 							:model-value="roleIds"
 							:options="roleOptions"
@@ -25,6 +25,9 @@
 
 				<DashboardCard :title="__('Enabled Permissions')">
 					<div class="p-4">
+						<p class="text-ink-gray-5 mb-3 text-sm">
+							{{ __('Granted to every account that holds this role.') }}
+						</p>
 						<MultiSelect
 							:model-value="enabledPermissions"
 							:options="permissionOptions"
@@ -35,6 +38,9 @@
 
 				<DashboardCard :title="__('Disabled Permissions')">
 					<div class="p-4">
+						<p class="text-ink-gray-5 mb-3 text-sm">
+							{{ __('Explicitly denied, even if an inherited role grants them.') }}
+						</p>
 						<MultiSelect
 							:model-value="disabledPermissions"
 							:options="permissionOptions"
@@ -51,12 +57,14 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { Dialog, Dropdown, MultiSelect, createResource, usePageMeta } from 'frappe-ui'
+import { Button, Dialog, Dropdown, MultiSelect, createResource, usePageMeta } from 'frappe-ui'
+
+import ShieldCheck from '~icons/lucide/shield-check'
 
 import { raiseToast } from '@/apps/mail/utils'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import DashboardCard from '@/apps/mail/components/DashboardCard.vue'
-import InformationField from '@/apps/mail/components/InformationField.vue'
+import DashboardDetailHeader from '@/apps/mail/components/DashboardDetailHeader.vue'
 import EditRoleModal from '@/apps/mail/components/Modals/EditRoleModal.vue'
 
 type RoleData = {

--- a/frontend/src/apps/mail/pages/dashboard/RolesView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/RolesView.vue
@@ -16,7 +16,7 @@
 			class="flex-1"
 			:columns="LIST_COLUMNS"
 			:rows="roles.data"
-			:options="LIST_OPTIONS"
+			:options="listOptions"
 			row-key="id"
 		>
 			<ListHeader />
@@ -35,11 +35,12 @@
 				<ListEmptyState v-else />
 			</ListRows>
 		</ListView>
+		<DashboardListSkeleton v-else :columns="3" />
 	</DashboardLayout>
 	<AddRoleModal v-model="showAdd" @reload="roles.reload()" />
 </template>
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { watchDebounced } from '@vueuse/core'
 import {
 	FeatherIcon,
@@ -55,6 +56,7 @@ import {
 } from 'frappe-ui'
 
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
+import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 import AddRoleModal from '@/apps/mail/components/Modals/AddRoleModal.vue'
 
 usePageMeta(() => ({ title: __('Roles') }))
@@ -79,10 +81,25 @@ const LIST_COLUMNS = [
 	{ label: __('Disabled Permissions'), key: 'disabled_count' },
 ]
 
-const LIST_OPTIONS = {
+const hasActiveFilters = computed(() => !!search.value)
+
+const listOptions = computed(() => ({
 	selectable: false,
 	showTooltip: false,
-	emptyState: { description: __('No roles found.') },
+	emptyState: hasActiveFilters.value
+		? {
+				title: __('No matching roles'),
+				description: __('Try adjusting your search or filters.'),
+			}
+		: {
+				title: __('No roles yet'),
+				description: __('Roles control which permissions members have.'),
+				button: {
+					label: __('Add Role'),
+					variant: 'solid',
+					onClick: () => (showAdd.value = true),
+				},
+			},
 	getRowRoute: (row: RoleRow) => ({ name: 'mail-role', params: { roleId: row.id } }),
-}
+}))
 </script>

--- a/frontend/src/apps/mail/pages/dashboard/UsersView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/UsersView.vue
@@ -1,32 +1,34 @@
 <template>
-	<div class="flex items-center space-x-3">
+	<div class="flex items-center justify-between gap-3">
 		<FormControl v-model="search" :placeholder="__('Search')" class="w-80">
 			<template #prefix>
 				<FeatherIcon name="search" class="text-ink-gray-5 w-4" />
 			</template>
 		</FormControl>
-		<FormControl
-			v-model="roleFilter"
-			:placeholder="__('Role')"
-			class="w-40"
-			type="select"
-			:options="ROLE_FILTER_OPTIONS"
-		/>
-		<FormControl
-			v-model="statusFilter"
-			:placeholder="__('Status')"
-			class="w-40"
-			type="select"
-			:options="STATUS_FILTER_OPTIONS"
-		/>
+		<div class="flex items-center gap-3">
+			<FormControl
+				v-model="roleFilter"
+				:placeholder="__('Role')"
+				class="w-40"
+				type="select"
+				:options="ROLE_FILTER_OPTIONS"
+			/>
+			<FormControl
+				v-model="statusFilter"
+				:placeholder="__('Status')"
+				class="w-40"
+				type="select"
+				:options="STATUS_FILTER_OPTIONS"
+			/>
+		</div>
 	</div>
 	<ListView
-		v-if="normalizedMembers"
+		v-if="members.data"
 		ref="listView"
 		class="flex-1"
 		:columns="LIST_COLUMNS"
 		:rows="normalizedMembers"
-		:options="LIST_OPTIONS"
+		:options="listOptions"
 		row-key="name"
 	>
 		<ListHeader />
@@ -37,7 +39,7 @@
 					:key="row.name"
 					v-slot="{ column, item }"
 					:row="row"
-					class="hover:bg-surface-gray-1 cursor-pointer rounded"
+					class="hover:!bg-surface-gray-1"
 				>
 					<ListRowItem :item="item">
 						<template v-if="column.key === 'user'">
@@ -52,7 +54,7 @@
 						<template v-else-if="column.key === 'role'">
 							<Badge
 								:label="row.is_admin ? __('Admin') : __('User')"
-								:theme="row.is_admin ? 'orange' : 'blue'"
+								:theme="row.is_admin ? 'amber' : 'blue'"
 							/>
 						</template>
 						<template v-else-if="column.key === 'status'">
@@ -96,6 +98,7 @@
 			</template>
 		</ListSelectBanner>
 	</ListView>
+	<DashboardListSkeleton v-else :columns="4" />
 	<Dialog v-model="showEnableMembers" :options="ENABLE_MEMBERS_OPTIONS" />
 	<Dialog v-model="showDisableMembers" :options="DISABLE_MEMBERS_OPTIONS" />
 	<Dialog v-model="showDeleteMembers" :options="DELETE_MEMBERS_OPTIONS" />
@@ -123,6 +126,7 @@ import {
 
 import { raiseToast } from '@/apps/mail/utils'
 import { fromNow } from '@/apps/mail/utils/datetime'
+import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 
 type MemberRow = {
 	name: string
@@ -202,15 +206,27 @@ const STATUS_FILTER_OPTIONS = [
 	{ label: __('Disabled'), value: 'disabled' },
 ]
 
-const LIST_OPTIONS = {
+const hasActiveFilters = computed(
+	() => !!search.value || roleFilter.value !== 'all' || statusFilter.value !== 'all',
+)
+
+const listOptions = computed(() => ({
 	showTooltip: false,
 	rowHeight: 50,
-	emptyState: { description: __('No members found.') },
+	emptyState: hasActiveFilters.value
+		? {
+				title: __('No matching members'),
+				description: __('Try adjusting your search or filters.'),
+			}
+		: {
+				title: __('No members found'),
+				description: __('Invite people to give them a mailbox on your domains.'),
+			},
 	getRowRoute: (row: MemberRow) => ({
 		name: 'mail-member',
 		params: { memberId: row.name },
 	}),
-}
+}))
 
 const enableMembers = createResource({
 	url: 'suite.mail.api.admin.enable_members',
@@ -278,6 +294,6 @@ const DELETE_MEMBERS_OPTIONS = {
 	message: __(
 		'Are you sure you want to delete the selected members? This action cannot be undone.',
 	),
-	actions: [{ label: __('Confirm'), variant: 'solid', onClick: deleteMembers.submit }],
+	actions: [{ label: __('Confirm'), variant: 'solid', theme: 'red', onClick: deleteMembers.submit }],
 }
 </script>

--- a/frontend/src/apps/mail/router.ts
+++ b/frontend/src/apps/mail/router.ts
@@ -78,7 +78,7 @@ function installMailGuard(r: Router) {
 		if (!user?.is_jmap_configured) {
 			if (!user?.is_suite_admin) window.location.replace('/desk')
 			if (to.meta.isDashboard) return
-			return { name: 'mail-domains' }
+			return { name: 'mail-overview' }
 		}
 
 		// Resolve active account.

--- a/frontend/src/apps/mail/routes.ts
+++ b/frontend/src/apps/mail/routes.ts
@@ -174,7 +174,8 @@ export const routes: RouteRecordRaw[] = [
 			},
 			{
 				path: 'dashboard',
-				redirect: { name: 'mail-domains' },
+				name: 'mail-overview',
+				component: () => import('@/apps/mail/pages/dashboard/OverviewView.vue'),
 				meta: { isDashboard: true },
 			},
 			{

--- a/frontend/src/apps/mail/types/index.ts
+++ b/frontend/src/apps/mail/types/index.ts
@@ -216,3 +216,12 @@ export interface NotificationPayload {
 		click_action?: string
 	}
 }
+
+export interface QuotaUsage {
+	total: number
+	used: number
+	available: number
+	used_percentage: number
+	available_percentage: number
+	unlimited: boolean
+}

--- a/suite/mail/api/admin.py
+++ b/suite/mail/api/admin.py
@@ -27,8 +27,8 @@ from suite.mail.stalwart import (
 	get_group_service,
 	get_log_labels,
 	get_log_service,
-	get_management_connection,
 	get_mailing_list_service,
+	get_management_connection,
 	get_oauth_client_service,
 	get_queue_metadata,
 	get_queued_message_service,
@@ -49,9 +49,9 @@ from suite.mail.utils.dns import parse_dns_zone_file
 from suite.mail.utils.dt import from_utc_z, to_utc_z
 from suite.mail.utils.logger import log_admin_action
 from suite.mail.utils.validation import is_subaddressed_email
-from suite.utils.rate_limiter import dynamic_rate_limit
 from suite.utils import execute_with_logging
 from suite.utils.dt import get_utc_now
+from suite.utils.rate_limiter import dynamic_rate_limit
 from suite.utils.user import is_suite_admin, is_system_manager, is_user_enabled
 
 
@@ -515,8 +515,14 @@ def get_member(member_id: str) -> dict:
 		account = get_account_service().get(
 			account_id,
 			properties=[
-				"emailAddress", "aliases", "quotas", "usedDiskQuota", "memberGroupIds", "description",
-				"locale", "timeZone",
+				"emailAddress",
+				"aliases",
+				"quotas",
+				"usedDiskQuota",
+				"memberGroupIds",
+				"description",
+				"locale",
+				"timeZone",
 			],
 		)
 		if not account:
@@ -530,7 +536,12 @@ def get_member(member_id: str) -> dict:
 		email_addresses = []
 		if primary := account.get("emailAddress"):
 			email_addresses.append(
-				{"email": primary, "description": account.get("description"), "is_primary": True, "enabled": True}
+				{
+					"email": primary,
+					"description": account.get("description"),
+					"is_primary": True,
+					"enabled": True,
+				}
 			)
 
 		aliases = account.get("aliases") or {}
@@ -831,7 +842,9 @@ def update_member(
 		execute_with_logging(
 			func=lambda: account_service.update(account_id, {"description": description}),
 			title=_("Failed to update description for {0}").format(member_id),
-			user_message=_("An error occurred while updating the description, check error logs for more details."),
+			user_message=_(
+				"An error occurred while updating the description, check error logs for more details."
+			),
 			with_context=False,
 			module="Mail",
 		)
@@ -875,7 +888,9 @@ def _add_alias(service, resource_id: str, email: str, description: str | None = 
 		return
 
 	aliases = _rebuild_aliases(obj, keep=lambda _e: True)
-	aliases.append(EmailAlias(name=local, domain_id=domain_id, description=(description or "").strip() or None))
+	aliases.append(
+		EmailAlias(name=local, domain_id=domain_id, description=(description or "").strip() or None)
+	)
 
 	execute_with_logging(
 		func=lambda: service.set_aliases(resource_id, aliases),
@@ -1011,7 +1026,10 @@ def remove_member_from_mailing_list(member_id: str, list_id: str) -> None:
 	account_service = get_account_service()
 	account = account_service.get(account_id, properties=["emailAddress", "aliases"])
 	domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
-	member_emails = {(account.get("emailAddress") or "").lower(), *[e.lower() for e in _alias_emails(account, domain_names)]}
+	member_emails = {
+		(account.get("emailAddress") or "").lower(),
+		*[e.lower() for e in _alias_emails(account, domain_names)],
+	}
 
 	service = get_mailing_list_service()
 	recipients = (service.get(list_id, properties=["recipients"]) or {}).get("recipients") or {}
@@ -1100,8 +1118,17 @@ def get_group(group_id: str) -> dict:
 	group = service.get(
 		group_id,
 		properties=[
-			"id", "name", "emailAddress", "description", "createdAt", "roles", "aliases", "quotas",
-			"usedDiskQuota", "locale", "timeZone",
+			"id",
+			"name",
+			"emailAddress",
+			"description",
+			"createdAt",
+			"roles",
+			"aliases",
+			"quotas",
+			"usedDiskQuota",
+			"locale",
+			"timeZone",
 		],
 	)
 	if not group:
@@ -1561,9 +1588,7 @@ def get_oauth_clients(search: str | None = None) -> list[dict]:
 
 	check_admin_permission("view oauth clients")
 
-	clients = get_oauth_client_service().get_all(
-		properties=["id", "clientId", "description", "createdAt"]
-	)
+	clients = get_oauth_client_service().get_all(properties=["id", "clientId", "description", "createdAt"])
 	rows = [
 		{
 			"id": c["id"],
@@ -1799,8 +1824,19 @@ def get_dkim_signature(signature_id: str) -> dict:
 	sig = get_dkim_signature_service().get(
 		signature_id,
 		properties=[
-			"id", "@type", "selector", "domainId", "createdAt", "stage", "nextTransitionAt",
-			"headers", "canonicalization", "expire", "report", "auid", "publicKey",
+			"id",
+			"@type",
+			"selector",
+			"domainId",
+			"createdAt",
+			"stage",
+			"nextTransitionAt",
+			"headers",
+			"canonicalization",
+			"expire",
+			"report",
+			"auid",
+			"publicKey",
 		],
 	)
 	if not sig:
@@ -2069,7 +2105,16 @@ def update_queued_recipient(
 	if notify_count is not None:
 		changed["notifyCount"] = cint(notify_count)
 	status = (
-		_status_object(status_type, error_type, error_message, smtp_command, hostname, response_code, enhanced_code, message)
+		_status_object(
+			status_type,
+			error_type,
+			error_message,
+			smtp_command,
+			hostname,
+			response_code,
+			enhanced_code,
+			message,
+		)
 		if status_type
 		else None
 	)
@@ -2078,7 +2123,9 @@ def update_queued_recipient(
 	new_email = (new_email or "").strip()
 	if new_email and new_email != email:
 		# Rename: rebuild the recipient (minus server-set fields) under the new key.
-		current = ((service.get(message_id, properties=["recipients"]) or {}).get("recipients") or {}).get(email)
+		current = ((service.get(message_id, properties=["recipients"]) or {}).get("recipients") or {}).get(
+			email
+		)
 		if current is None:
 			frappe.throw(_("Recipient not found"), frappe.DoesNotExistError)
 		obj = {k: v for k, v in current.items() if k not in ("flags", "queueName")}
@@ -2446,3 +2493,69 @@ def run_action(action_type: str, params: dict | None = None) -> dict:
 
 	params = {k: dict.fromkeys(v, True) if isinstance(v, list) else v for k, v in (params or {}).items()}
 	return get_action_service().run(action_type, params=params or None)
+
+
+@frappe.whitelist()
+def get_overview() -> dict:
+	"""Aggregate counts and recent activity for the dashboard landing page.
+
+	Each section is gathered independently and degrades to ``None`` (or an empty list) when its
+	backing store is unavailable, so one unreachable subsystem doesn't blank the whole page.
+	"""
+
+	check_admin_permission("view overview")
+
+	overview: dict = {
+		"members": None,
+		"pending_invites": None,
+		"domains": None,
+		"groups": None,
+		"mailing_lists": None,
+		"queued_messages": None,
+		"recent_logs": [],
+	}
+
+	with suppress(Exception):
+		USER = frappe.qb.DocType("User")
+		USER_SETTINGS = frappe.qb.DocType("User Settings")
+		rows = (
+			frappe.qb.from_(USER)
+			.join(USER_SETTINGS)
+			.on(USER.name == USER_SETTINGS.user)
+			.select(USER.enabled)
+			.where(USER_SETTINGS.username.isnotnull())
+		).run(as_dict=True)
+		overview["members"] = {
+			"total": len(rows),
+			"disabled": sum(1 for row in rows if not row.enabled),
+		}
+
+	with suppress(Exception):
+		overview["pending_invites"] = frappe.db.count(
+			"Mail Account Request",
+			{"is_verified": 0, "expires_at": [">", frappe.utils.now()]},
+		)
+
+	with suppress(Exception):
+		domains = get_stalwart_domains()
+		overview["domains"] = {
+			"total": len(domains),
+			"disabled": sum(1 for domain in domains if not domain["isEnabled"]),
+		}
+
+	with suppress(Exception):
+		overview["groups"] = len(get_group_service().get_all_groups(properties=["id"]))
+
+	with suppress(Exception):
+		overview["mailing_lists"] = len(get_mailing_list_service().get_all(properties=["id"]))
+
+	with suppress(Exception):
+		result = get_queued_message_service().list_page(filter=None, position=0, limit=1)
+		overview["queued_messages"] = result["total"]
+
+	with suppress(Exception):
+		result = get_log_service().list_page(filter=None, anchor=None, limit=6)
+		labels = get_log_labels()
+		overview["recent_logs"] = [_log_row(entry, labels) for entry in result["items"]]
+
+	return overview


### PR DESCRIPTION
## Overview

Redesigns Mail's Admin Dashboard end to end, following the Frappe UI patterns used across Frappe Cloud / CRM / Helpdesk.

### New Overview landing page

- `/mail/dashboard` is now a proper home instead of redirecting to Domains: six KPI tiles (Members, Invites, Domains, Groups, Mailing Lists, Queued), a Recent Activity feed from the server logs, and Quick Actions for common admin journeys.
- Backed by a new `get_overview` aggregate endpoint; each section degrades independently (`—`) if the mail server is unreachable, so a down server can't blank the page.

### Detail pages

- New `DashboardDetailHeader` component (avatar/icon, title, meta line, status badge) applied to all ten detail views.
- Primary actions surfaced as visible buttons (Edit, Retry Now, Export DNS) instead of everything hiding in a `···` menu; destructive actions stay in the overflow.
- Role permission cards get a three-column layout with helper text; the Domain setup banner becomes a compact callout.

### List pages & modals

- Skeleton loading states everywhere (no more blank panes), filter-aware empty states (first-run CTA vs. "no matches"), and consistent toolbars (search left, filters right).
- Error toasts on all mutations, red-themed destructive confirmations, `loading` bound on modal primary actions.
- Helper descriptions on non-obvious form fields (invite expiry, backup email routing, quota defaults, address composition, OAuth client semantics, alias delivery).

### Navigation

- Dashboard sidebar pins "Back to Mail" and "Overview" at the top; "Back to Mail" is hidden for admins without a configured JMAP account (e.g. System Managers), who have no inbox to return to.
- Observability and Actions merged into a single "System" group.

## Verification

- All 1019 frontend unit tests pass; production build clean.
- `get_overview` smoke-tested against a live Stalwart server.
- Every page screenshot-verified against live data.