### PR TITLE
feat(sheets): custom colours for data-validation list labels

### DIFF
--- a/frontend/src/apps/sheets/canvas/chip-geometry.js
+++ b/frontend/src/apps/sheets/canvas/chip-geometry.js
@@ -12,13 +12,19 @@ export const CHIP = {
   minH:     13,  // below this the row is too short for a pill — fall back to a plain arrow
 }
 
-// Soft pastel chip backgrounds, à la Sheets. A value's colour is derived from
-// the value itself, so the same option is always the same colour without any
-// per-option config in the rule. Dark cell text stays readable on all of them.
+// Soft pastel chip backgrounds, à la Sheets. Used as the *auto* colour when an
+// option has no colour of its own. Dark cell text stays readable on all of them.
 const CHIP_PALETTE = [
   '#FCE8E6', '#FEF7E0', '#E6F4EA', '#E8F0FE',
   '#F3E8FD', '#FEEFE3', '#E4F7FB', '#FDE7F3',
 ]
+
+// The auto colour for the i-th option in a list, cycling the palette. Slotting
+// by position (not by hashing the text) means adjacent options never collide on
+// the same colour, which is what made the old hash feel "random".
+export function chipPaletteColor(i) {
+  return CHIP_PALETTE[((i % CHIP_PALETTE.length) + CHIP_PALETTE.length) % CHIP_PALETTE.length]
+}
 
 // Canvas font string for a cell format. Mirrors the cell painter exactly so
 // text measured here for hit-testing matches what gets drawn.
@@ -30,12 +36,20 @@ export function chipFont(fmt = {}) {
   return `${style} ${weight} ${px}px ${family}`
 }
 
-// Stable pastel background for a known option value.
-export function chipColor(value) {
+// Background colour for an option value. Resolution order:
+//   1. the rule's per-option custom colour (rule.colors[value]), if set;
+//   2. otherwise the auto palette slot for the option's position in the list.
+// `rule` is optional: without it (or for a value not among the options) we fall
+// back to hashing the text so callers with no rule context still get a colour.
+export function chipColor(value, rule) {
   const s = String(value)
+  const custom = rule?.colors?.[s]
+  if (custom) return custom
+  const i = rule?.options ? rule.options.indexOf(s) : -1
+  if (i >= 0) return chipPaletteColor(i)
   let h = 0
-  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0
-  return CHIP_PALETTE[h % CHIP_PALETTE.length]
+  for (let k = 0; k < s.length; k++) h = (h * 31 + s.charCodeAt(k)) >>> 0
+  return chipPaletteColor(h)
 }
 
 // Pill placement for `text` in a cell of width `cellW`: its x-offset from the

--- a/frontend/src/apps/sheets/canvas/chip-geometry.test.ts
+++ b/frontend/src/apps/sheets/canvas/chip-geometry.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { chipColor, chipPaletteColor } from './chip-geometry.js'
+
+describe('chipPaletteColor', () => {
+  it('cycles the palette by position', () => {
+    expect(chipPaletteColor(0)).toBe(chipPaletteColor(8))   // 8-colour palette wraps
+    expect(chipPaletteColor(0)).not.toBe(chipPaletteColor(1))
+  })
+
+  it('handles negative indices without going out of range', () => {
+    expect(chipPaletteColor(-1)).toBe(chipPaletteColor(7))
+  })
+})
+
+describe('chipColor', () => {
+  const rule = { type: 'list', options: ['Yes', 'No', 'Maybe'], colors: { Yes: '#22c55e' } }
+
+  it('uses the rule\'s custom colour when the option has one', () => {
+    expect(chipColor('Yes', rule)).toBe('#22c55e')
+  })
+
+  it('falls back to the palette slot for the option\'s position', () => {
+    expect(chipColor('No', rule)).toBe(chipPaletteColor(1))
+    expect(chipColor('Maybe', rule)).toBe(chipPaletteColor(2))
+  })
+
+  it('gives adjacent options distinct auto colours', () => {
+    expect(chipColor('No', rule)).not.toBe(chipColor('Maybe', rule))
+  })
+
+  it('hashes to a palette colour when there is no rule context', () => {
+    const c = chipColor('anything')
+    expect(c).toMatch(/^#[0-9A-F]{6}$/i)
+  })
+
+  it('hashes a value that is not among the options', () => {
+    expect(chipColor('Nope', rule)).toMatch(/^#[0-9A-F]{6}$/i)
+  })
+})

--- a/frontend/src/apps/sheets/canvas/index.js
+++ b/frontend/src/apps/sheets/canvas/index.js
@@ -7,7 +7,7 @@ import { cellId, colLabel, parseCellId } from '../utils/cells.js'
 import { AC_FUNS, AC_FUN_KEYS, parseAcToken, parseSignatureContext, describeSignature, shouldSuggestRange, detectAdjacentRange, isNumericText } from '../utils/formula-ac.js'
 import { autoCloseKey } from '../utils/formula-autoclose.js'
 import { isWrapText, getTextWrap, wrapLines, lineHeightFor } from '../utils/text-wrap.js'
-import { CHIP, chipMetrics, chipFont } from './chip-geometry.js'
+import { chipFont } from './chip-geometry.js'
 import { checkboxRect } from './checkbox-geometry.js'
 
 export { colLabel, cellId, parseCellId } from '../utils/cells.js'
@@ -44,6 +44,11 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
   let selEnd = { r: 0, c: 0 }
   let selMode    = 'cell'  // 'cell' | 'col' | 'row'
   let dragging   = false
+  // A plain single-click anywhere in a list-validated cell opens its dropdown.
+  // We record the candidate on mousedown and fire on mouseup, so a click that
+  // turns into a range-drag selects instead of opening, and a double-click
+  // (which edits) is excluded. Set to { hId, rule, r, c, downX, downY, pos }.
+  let _pendingListOpen = null
   let editing    = false
   let resizing   = null  // { col, startX, startW }
   let resizingRow = null  // { row, startY, startH }
@@ -1295,30 +1300,22 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
       }
     }
 
-    // Click on the dropdown caret of a list-validated cell → open dropdown.
-    // The caret zone tracks the chip when one is drawn (list rule + value),
-    // else it's the plain arrow box at the cell's right edge. Only list rules
-    // get a dropdown — number/length rules fall through to normal selection.
-    if (vrule?.type === 'list' && canEdit()) {
-      const x = geo.colX(h.c), y = geo.rowY(h.r)
-      const w = geo.cw(h.c), cellRight = x + w
-      const lx = (e.clientX - rect.left) / _zoom
-      const val = getValue(hId)
-      let caretL = cellRight - 14
-      if (val != null && String(val) !== '') {
-        const { offsetX, chipW } = chipMetrics(ctx, String(val), getFormat?.(hId) || {}, w)
-        caretL = x + offsetX + chipW - CHIP.caretW
-      }
-      if (lx >= caretL && lx <= cellRight) {
-        e.stopPropagation()   // prevent _onDocMouseDown from closing the just-opened panel
-        moveSel(h.r, h.c)
-        const pos = {
+    // A plain single-click anywhere in a list-validated cell opens its dropdown
+    // (not just a caret zone). Record the candidate here and open it on mouseup,
+    // so the click still falls through to select the cell / start a range-drag;
+    // a drag or a double-click (which edits) cancels the open. Modifier-clicks
+    // (shift/ctrl/cmd range ops) and non-list rules never open a dropdown.
+    if (vrule?.type === 'list' && canEdit() && e.detail === 1 &&
+        !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+      const x = geo.colX(h.c), y = geo.rowY(h.r), w = geo.cw(h.c)
+      _pendingListOpen = {
+        hId, rule: vrule, r: h.r, c: h.c,
+        downX: e.clientX, downY: e.clientY,
+        pos: {
           x: rect.left + x * _zoom,
           y: rect.top  + (y + geo.rh(h.r)) * _zoom,
           w: w * _zoom,
-        }
-        onDropdownClick?.(hId, vrule, pos)
-        return
+        },
       }
     }
 
@@ -1446,6 +1443,18 @@ export function createGrid(canvas, { onSelect, onCommit, onInput, onCancel, getF
       const t = picker.target
       picker = null
       t?.focus?.()
+    }
+    // A click that stayed on its origin list cell (no range-drag) opens the
+    // dropdown. A drag past a few px is a selection, so it cancels the open.
+    if (_pendingListOpen) {
+      const p = _pendingListOpen
+      _pendingListOpen = null
+      const moved = Math.hypot(e.clientX - p.downX, e.clientY - p.downY) > 4
+      if (!moved) {
+        const rect = canvas.getBoundingClientRect()
+        const h = geo.hitTest(e.clientX, e.clientY, rect)
+        if (h && h.r === p.r && h.c === p.c) onDropdownClick?.(p.hId, p.rule, p.pos)
+      }
     }
     dragging = false
   })

--- a/frontend/src/apps/sheets/canvas/painters/cell-painter.js
+++ b/frontend/src/apps/sheets/canvas/painters/cell-painter.js
@@ -86,7 +86,7 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
         // List rule → a Sheets-style dropdown affordance. With a value it's a
         // chip (which owns the cell text — the text pass skips it); empty,
         // it's a plain caret so you know it's a dropdown.
-        if (has) _drawValidationChip(x, y, w, h, String(val), fmt, !invalid)
+        if (has) _drawValidationChip(x, y, w, h, String(val), fmt, !invalid, rule)
         else     _drawDropdownArrow(x, y, w, h)
       } else if (rule.type === 'checkbox') {
         // Checkbox rule → a tickbox that owns the cell (the text pass skips
@@ -340,21 +340,36 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
     ctx.restore()
   }
 
+  // A soft, borderless chevron button on the cell's right edge — reads as a
+  // frappe-ui control rather than the old hard-bordered <select> box. Empty
+  // list cells get this; a cell with a value gets the same chevron inside its
+  // chip (see _drawChevron below).
   function _drawDropdownArrow(x, y, w, h) {
-    const aw = 14, ah = h - 2
+    const btn = 18
+    const bh  = Math.min(h - 4, CHIP.maxH)
+    if (bh < CHIP.minH) return   // row too short for a legible affordance
+    const bx = x + w - btn - 3
+    const by = y + (h - bh) / 2
     ctx.save()
-    ctx.strokeStyle = COLORS.gridLine || '#d0d0d0'
-    ctx.lineWidth = 1
-    ctx.strokeRect(x + w - aw, y + 1, aw - 1, ah)
-    ctx.fillStyle = '#666'
-    ctx.beginPath()
-    const mx = x + w - aw / 2, my = y + h / 2
-    ctx.moveTo(mx - 3, my - 1.5)
-    ctx.lineTo(mx + 3, my - 1.5)
-    ctx.lineTo(mx, my + 2.5)
-    ctx.closePath()
+    _roundRectPath(bx, by, btn, bh, 4)
+    ctx.fillStyle = COLORS.chipFill
     ctx.fill()
+    _drawChevron(bx + btn / 2, y + h / 2)
     ctx.restore()
+  }
+
+  // A small rounded chevron (⌄) centred on (cx, cy). Stroked, not a filled
+  // triangle, so it matches frappe-ui's FeatherIcon "chevron-down".
+  function _drawChevron(cx, cy) {
+    ctx.strokeStyle = COLORS.chipCaret
+    ctx.lineWidth = 1.5
+    ctx.lineJoin = 'round'
+    ctx.lineCap  = 'round'
+    ctx.beginPath()
+    ctx.moveTo(cx - 3.5, cy - 1.5)
+    ctx.lineTo(cx,       cy + 2)
+    ctx.lineTo(cx + 3.5, cy - 1.5)
+    ctx.stroke()
   }
 
   // Sheets-style checkbox: a rounded grey square centred in the cell. Checked
@@ -392,7 +407,7 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
   // Sheets-style dropdown chip: a rounded pill holding the cell value with a
   // caret on its right. Drawn in the bg pass; the matching click zone lives in
   // canvas/index.js (both measure through chip-geometry so they stay aligned).
-  function _drawValidationChip(x, y, w, h, text, fmt, valid) {
+  function _drawValidationChip(x, y, w, h, text, fmt, valid, rule) {
     const chipH = Math.min(h - 4, CHIP.maxH)
     if (chipH < CHIP.minH) { _drawDropdownArrow(x, y, w, h); return }  // row too short for a pill
     ctx.save()
@@ -401,10 +416,10 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
     const { offsetX, chipW } = chipMetrics(ctx, text, fmt, w)
     const chipX = x + offsetX
     const chipY = y + (h - chipH) / 2
-    // Pill — known options get a stable pastel colour; an out-of-list value
-    // stays neutral grey (it isn't one of the choices).
+    // Pill — a known option gets its custom colour (or the auto palette slot);
+    // an out-of-list value stays neutral grey (it isn't one of the choices).
     _roundRectPath(chipX, chipY, chipW, chipH, chipH / 2)
-    ctx.fillStyle = valid ? chipColor(text) : COLORS.chipFill
+    ctx.fillStyle = valid ? chipColor(text, rule) : COLORS.chipFill
     ctx.fill()
     // Value — ellipsised to the room left of the caret so a long option
     // doesn't get hard-clipped mid-glyph.
@@ -413,15 +428,8 @@ export function createCellPainter(ctx, { cw, rh, colX, rowY }) {
     ctx.textBaseline = 'middle'
     const textRoom = chipW - CHIP.innerPad - CHIP.caretW
     ctx.fillText(_ellipsize(text, textRoom), chipX + CHIP.innerPad, chipY + chipH / 2)
-    // Caret
-    const mx = chipX + chipW - CHIP.caretW / 2, my = chipY + chipH / 2
-    ctx.fillStyle = COLORS.chipCaret
-    ctx.beginPath()
-    ctx.moveTo(mx - 3, my - 1.5)
-    ctx.lineTo(mx + 3, my - 1.5)
-    ctx.lineTo(mx, my + 2.5)
-    ctx.closePath()
-    ctx.fill()
+    // Caret — same chevron as the empty-cell affordance, for consistency.
+    _drawChevron(chipX + chipW - CHIP.caretW / 2, chipY + chipH / 2)
     ctx.restore()
     if (!valid) _drawInvalidTriangle(x, y)
   }

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -917,12 +917,34 @@
             ]"
           />
 
-          <!-- List -->
-          <FormControl v-if="validationDialog.type === 'list'"
-            v-model="validationDialog.listRaw"
-            label="Items (comma-separated)"
-            placeholder="Yes, No, Maybe"
-          />
+          <!-- List — one row per item: a colour swatch, the label, and remove.
+               Paste a comma/newline list into any field to split it into rows. -->
+          <div v-if="validationDialog.type === 'list'" class="sn-vd-list" ref="vdListEl">
+            <label class="sn-vd-list-label">Items</label>
+            <div v-for="(item, i) in validationDialog.listItems" :key="i" class="sn-vd-item">
+              <ColorPicker
+                :model-value="item.color || ''"
+                allow-default default-label="Automatic colour"
+                :fallback="autoChipColor(i)" title="Label colour"
+                @update:model-value="item.color = $event">
+                <template #trigger="{ toggle, open }">
+                  <button type="button" class="sn-vd-swatch" :class="{ 'is-open': open }"
+                          :style="{ background: item.color || autoChipColor(i) }"
+                          title="Label colour" @click="toggle()" />
+                </template>
+              </ColorPicker>
+              <input class="sn-vd-item-input" v-model="item.label" placeholder="Item"
+                     @keydown.enter.prevent="addListItem(i)"
+                     @paste="onListPaste($event, i)" />
+              <button type="button" class="sn-vd-item-x" title="Remove item"
+                      @click="removeListItem(i)">
+                <FeatherIcon name="x" class="sn-vd-item-xg" />
+              </button>
+            </div>
+            <button type="button" class="sn-vd-add" @click="addListItem()">
+              <FeatherIcon name="plus" class="sn-vd-add-g" /> Add item
+            </button>
+          </div>
 
           <!-- Operator (number / text_length) -->
           <FormControl v-if="['number','text_length'].includes(validationDialog.type)"
@@ -1107,7 +1129,7 @@
            class="sn-dropdown-opt" :class="{ 'is-active': opt === dropdownPanel.value }"
            @mousedown.prevent="pickDropdownOption(opt)">
         <FeatherIcon name="check" class="sn-dropdown-check" :style="{ visibility: opt === dropdownPanel.value ? 'visible' : 'hidden' }" />
-        <span class="sn-dropdown-chip" :style="{ background: chipColor(opt) }">{{ opt }}</span>
+        <span class="sn-dropdown-chip" :style="{ background: chipColor(opt, dropdownPanel.rule) }">{{ opt }}</span>
       </div>
       <div v-if="dropdownPanel.value" class="sn-dropdown-opt sn-dropdown-clear"
            @mousedown.prevent="pickDropdownOption('')">
@@ -1253,7 +1275,7 @@ import { createSlicerEngine }  from '../../engine/slicers.js'
 import { createCommentsEngine }  from '../../engine/comments.js'
 import { createValidationEngine } from '../../engine/validation.js'
 import { createProtectionEngine } from '../../engine/protection.js'
-import { chipColor } from '../../canvas/chip-geometry.js'
+import { chipColor, chipPaletteColor } from '../../canvas/chip-geometry.js'
 import { createCondFormatEngine } from '../../engine/cond-format.js'
 import { detectHyperlink, isAutoLinkText } from '../../engine/links.js'
 import { fetchLinkPreview } from '../../services/linkPreview.js'
@@ -1664,14 +1686,15 @@ const commentPanel  = reactive({ open: false, id: '', x: 0, y: 0, thread: [], re
 const notesPanel = reactive({ open: false, rev: 0 })
 
 // ── Dropdown (validation) UI state ────────────────────────────────────────────
-const dropdownPanel    = reactive({ open: false, id: '', options: [], value: '', x: 0, y: 0, w: 120 })
+const dropdownPanel    = reactive({ open: false, id: '', options: [], rule: null, value: '', x: 0, y: 0, w: 120 })
+const vdListEl         = ref(null)
 const validationDialog = reactive({
   open: false,
   type:     'list',      // 'list' | 'number' | 'text_length'
   operator: 'between',   // 'between' | 'not_between' | 'gt' | 'gte' | 'lt' | 'lte' | 'eq' | 'neq'
   val1:     '',
   val2:     '',
-  listRaw:  '',
+  listItems: [],         // [{ label, color }] — color '' means auto (palette by position)
   message:  '',
   severity: 'reject',   // 'reject' blocks the edit; 'warn' allows it but flags the cell
 })
@@ -4433,10 +4456,47 @@ function openValidationDialog() {
   validationDialog.operator = e?.operator || 'between'
   validationDialog.val1     = String(e?.min ?? '')
   validationDialog.val2     = String(e?.max ?? '')
-  validationDialog.listRaw  = (e?.options || []).join(', ')
+  const opts   = e?.options || []
+  const colors = e?.colors  || {}
+  validationDialog.listItems = opts.length
+    ? opts.map(o => ({ label: o, color: colors[o] || '' }))
+    : [{ label: '', color: '' }]   // start with one empty row to type into
   validationDialog.message  = e?.message  || ''
   validationDialog.severity = e?.severity || 'reject'
   validationDialog.open     = true
+}
+
+// The auto (unset) chip colour for the item at position `i` — matches how the
+// painter slots colours by option order, so the dialog previews the real thing.
+function autoChipColor(i) { return chipPaletteColor(i) }
+
+function addListItem(afterIdx) {
+  const row = { label: '', color: '' }
+  if (afterIdx == null) validationDialog.listItems.push(row)
+  else validationDialog.listItems.splice(afterIdx + 1, 0, row)
+  focusListItem(afterIdx == null ? validationDialog.listItems.length - 1 : afterIdx + 1)
+}
+
+function removeListItem(i) {
+  validationDialog.listItems.splice(i, 1)
+  if (!validationDialog.listItems.length) validationDialog.listItems.push({ label: '', color: '' })
+}
+
+// Paste a comma/newline-separated list into a row → split it across rows, so
+// bulk entry ("Yes, No, Maybe") still works alongside per-item editing.
+function onListPaste(ev, i) {
+  const text = ev.clipboardData?.getData('text') || ''
+  if (!/[,\n]/.test(text)) return   // single value → let the default paste happen
+  ev.preventDefault()
+  const parts = text.split(/[,\n]/).map(s => s.trim()).filter(Boolean)
+  if (!parts.length) return
+  validationDialog.listItems[i].label = parts[0]
+  validationDialog.listItems.splice(i + 1, 0, ...parts.slice(1).map(label => ({ label, color: '' })))
+}
+
+async function focusListItem(i) {
+  await nextTick()
+  vdListEl.value?.querySelectorAll('.sn-vd-item-input')?.[i]?.focus()
 }
 
 function confirmValidation() {
@@ -4451,8 +4511,17 @@ function confirmValidation() {
   if (validationDialog.type === 'checkbox') {
     rule = { type: 'checkbox', message: msg }
   } else if (validationDialog.type === 'list') {
-    const options = validationDialog.listRaw.split(',').map(s => s.trim()).filter(Boolean)
+    // De-dupe by label (first wins), keeping only rows that have a colour set.
+    const options = []
+    const colors  = {}
+    for (const it of validationDialog.listItems) {
+      const label = it.label.trim()
+      if (!label || options.includes(label)) continue
+      options.push(label)
+      if (it.color) colors[label] = it.color
+    }
     rule = { type: 'list', options, message: msg, severity }
+    if (Object.keys(colors).length) rule.colors = colors
   } else {
     const op  = validationDialog.operator
     const v1  = parseFloat(validationDialog.val1)
@@ -4502,6 +4571,7 @@ function openDropdown(id, rule, pos = {}) {
   if (rule?.type !== 'list') return
   dropdownPanel.id      = id
   dropdownPanel.options = rule.options
+  dropdownPanel.rule    = rule
   dropdownPanel.value   = String(sheet.getCell(id, sheet.getCurrentSheet()) ?? '')
   dropdownPanel.x       = pos.x ?? 0
   dropdownPanel.y       = pos.y ?? 0
@@ -6067,6 +6137,21 @@ function toggleShowFormulas() {
 .sn-ac-badge { font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:.04em; color:var(--ink-cyan-6, #0891b2); background:var(--surface-cyan-1, #ecfeff); border-radius:3px; padding:1px 5px; }
 /* Validation dialog two-column value row */
 .sn-vd-vals  { display:grid; grid-template-columns:1fr 1fr; gap:12px; }
+
+/* Validation "List of items" per-item editor: swatch · label · remove */
+.sn-vd-list       { display:flex; flex-direction:column; gap:6px; }
+.sn-vd-list-label { font-size:12px; color:var(--ink-gray-5); }
+.sn-vd-item       { display:flex; align-items:center; gap:8px; }
+.sn-vd-swatch     { flex-shrink:0; width:28px; height:28px; border-radius:6px; border:1px solid var(--outline-gray-2); cursor:pointer; padding:0; }
+.sn-vd-swatch:hover, .sn-vd-swatch.is-open { box-shadow:0 0 0 2px var(--surface-base), 0 0 0 3.5px var(--outline-gray-4); }
+.sn-vd-item-input { flex:1; min-width:0; height:28px; padding:0 10px; font-size:13px; border:1px solid var(--outline-gray-2); border-radius:8px; color:var(--ink-gray-9); background:var(--surface-base); outline:none; }
+.sn-vd-item-input:focus { border-color:var(--outline-gray-4); }
+.sn-vd-item-x     { flex-shrink:0; display:inline-flex; align-items:center; justify-content:center; width:28px; height:28px; border-radius:6px; border:none; background:transparent; color:var(--ink-gray-5); cursor:pointer; }
+.sn-vd-item-x:hover { background:var(--surface-gray-2); color:var(--ink-gray-8); }
+.sn-vd-item-xg    { width:15px; height:15px; }
+.sn-vd-add        { align-self:flex-start; display:inline-flex; align-items:center; gap:5px; margin-top:2px; padding:4px 8px; font-size:13px; font-weight:500; color:var(--ink-gray-7); background:transparent; border:none; border-radius:6px; cursor:pointer; }
+.sn-vd-add:hover  { background:var(--surface-gray-2); color:var(--ink-gray-9); }
+.sn-vd-add-g      { width:14px; height:14px; }
 
 /* ── Bar 3 · Formatting toolbar ──────────────────────────────────────────── */
 .sn-toolbar { display:flex; align-items:center; gap:2px; height:44px; padding:0 15px; border-bottom:1px solid var(--outline-gray-2); background:var(--surface-base); flex-shrink:0; }


### PR DESCRIPTION
## What & why

A production user asked for **custom colours per label** in data-validation "List of items" rules — today the chip colours are derived by hashing the label text, so they look random and unrelated labels can collide on the same colour.

This adds a colour per item, and makes the *default* colours meaningful.

## Changes

**Custom colours**
- The validation dialog's "List of items" is now a per-item editor: each item is a row with a colour swatch (the existing frappe-ui `ColorPicker`), the label, and a remove button, plus an **Add item** button.
- Pasting a comma/newline-separated list into any field still splits it across rows, so bulk entry (`Yes, No, Maybe`) keeps working.
- Colours are stored on the list rule as `colors: { label → hex }` and ride through history / collab / save with the rest of the rule (it's a plain field on the deep-cloned rule — no serialization changes needed). Custom colours render on both the **in-cell chip** and the **dropdown panel**.

**Better default colours**
- An item left on "Automatic colour" now gets a palette slot by its **position** in the list (`chipPaletteColor(i)`), so adjacent options never collide. `chipColor(value, rule)` resolves custom → position-palette → (hash fallback when there's no rule context).

**Dropdown UX (same feature)**
- Clicking **anywhere in a list cell** opens the dropdown — not just the tiny caret. It's recorded on mousedown and fired on mouseup, so a range-drag still selects and a double-click still edits the cell as text; modifier-clicks never open it.
- The affordance is now a soft, borderless **chevron** (shared by the empty-cell arrow and the in-chip caret) instead of the old hard-bordered `<select>`-style box.

## Tests
- New `canvas/chip-geometry.test.ts` covers the colour resolver (custom wins, position-palette default, adjacent-distinct, hash fallback) and the palette-cycling helper.
- Full sheets frontend suite green (1333 tests) on the identical file contents.

## Notes
- Source-only (the built bundle is gitignored in suite; CI builds it).
- No z-index/stacking workaround is needed here: frappe-ui's Dialog overlay relies on DOM order (no explicit z-index), so the ColorPicker popover already stacks above the dialog — same as the existing conditional-format ColorPicker.