### PR TITLE
chore: format the tree with ruff and gate on it in CI

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,3 +4,9 @@
 
 # style(slides): convert service-worker.js to tab indentation
 6ed2aa9d8881c18ce4d581e20ca18eae8ad512ed
+
+# style: format the tree with ruff
+9ce1d354ccb0f4cdeeba16b21a1be46a934740e3
+
+# style: apply ruff lint autofixes
+c2ed307690147e4d91852cd8accd286f103b09eb

--- a/.github/workflows/suite-linter.yml
+++ b/.github/workflows/suite-linter.yml
@@ -38,6 +38,24 @@ jobs:
           pip install semgrep
           semgrep scan --config ./frappe-semgrep-rules/rules --config r/python.lang.correctness .
 
+  ruff-format:
+    name: Ruff Format Check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+          cache: pip
+
+      - name: Check formatting
+        run: |
+          pip install ruff==0.12.3
+          ruff format --check .
+
   deps-vulnerable-check:
     name: Vulnerable Dependency Check
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,5 +83,5 @@ typing-modules = ["frappe.types.DF"]
 
 [tool.ruff.format]
 quote-style = "double"
-indent-style = "tab"
+indent-style = "space"
 docstring-code-format = true

--- a/suite/api/account.py
+++ b/suite/api/account.py
@@ -7,16 +7,16 @@ from suite.mail.utils.user import is_jmap_configured
 @frappe.whitelist()
 @redis_cache(user=True)
 def get_logged_in_user() -> dict | None:
-	user = frappe.session.user
-	if user == "Guest":
-		return None
+    user = frappe.session.user
+    if user == "Guest":
+        return None
 
-	user_doc = frappe.get_doc("User", user)
-	return {
-		"name": user_doc.name,
-		"email": user_doc.email,
-		"full_name": user_doc.full_name,
-		"avatar": user_doc.user_image,
-		"roles": [role.role for role in user_doc.roles],
-		"is_jmap_configured": is_jmap_configured(user),
-	}
+    user_doc = frappe.get_doc("User", user)
+    return {
+        "name": user_doc.name,
+        "email": user_doc.email,
+        "full_name": user_doc.full_name,
+        "avatar": user_doc.user_image,
+        "roles": [role.role for role in user_doc.roles],
+        "is_jmap_configured": is_jmap_configured(user),
+    }

--- a/suite/calendar/api/__init__.py
+++ b/suite/calendar/api/__init__.py
@@ -5,163 +5,159 @@ from frappe import _
 
 from suite.calendar.doctype.calendar.calendar import fetch_calendars
 from suite.calendar.doctype.calendar_event.calendar_event import (
-	fetch_calendar_events,
-	update_calendar_event,
+    fetch_calendar_events,
+    update_calendar_event,
 )
 from suite.calendar.doctype.calendar_event.calendar_event import (
-	get_calendar_events as get_calendar_events_by_ids,
+    get_calendar_events as get_calendar_events_by_ids,
 )
 from suite.mail.jmap import get_calendar_event_service
 
 
 @frappe.whitelist()
 def get_calendars(account: str) -> list[dict[str, str]]:
-	"""Returns a list of the specified account's calendars."""
+    """Returns a list of the specified account's calendars."""
 
-	calendars = fetch_calendars(account)
+    calendars = fetch_calendars(account)
 
-	return [{key: cal[key] for key in ["name", "_name"]} for cal in calendars]
+    return [{key: cal[key] for key in ["name", "_name"]} for cal in calendars]
 
 
 @frappe.whitelist()
 def get_calendar_events(account: str, from_date: str, to_date: str, time_zone: str) -> list[dict]:
-	"""Fetches calendar events between from_date and to_date for the specified account."""
+    """Fetches calendar events between from_date and to_date for the specified account."""
 
-	events = fetch_calendar_events(
-		account,
-		{"after": from_date, "before": to_date},
-		limit=999,
-		time_zone=time_zone,
-		expand_recurrences=True,
-	)[0]
+    events = fetch_calendar_events(
+        account,
+        {"after": from_date, "before": to_date},
+        limit=999,
+        time_zone=time_zone,
+        expand_recurrences=True,
+    )[0]
 
-	enrich_events_with_master_data(account, events)
-	enrich_participants_with_avatars(events)
+    enrich_events_with_master_data(account, events)
+    enrich_participants_with_avatars(events)
 
-	return events
+    return events
 
 
 def enrich_events_with_master_data(account: str, events: list[dict]) -> None:
-	"""Attaches recurrence/master info to each event in-place.
+    """Attaches recurrence/master info to each event in-place.
 
-	Masters are resolved through baseEventId rather than a uid query: the uid filter runs on
-	the server's search index, which is updated asynchronously, so a query-based lookup misses
-	events created moments ago — leaving them without a master_id (so the frontend falls back
-	to the synthetic id, which cannot be updated or deleted) and with an unparsed
-	recurrence_rule string until the index catches up."""
+    Masters are resolved through baseEventId rather than a uid query: the uid filter runs on
+    the server's search index, which is updated asynchronously, so a query-based lookup misses
+    events created moments ago — leaving them without a master_id (so the frontend falls back
+    to the synthetic id, which cannot be updated or deleted) and with an unparsed
+    recurrence_rule string until the index catches up."""
 
-	if not events:
-		return
+    if not events:
+        return
 
-	base_ids = get_calendar_event_service(account).get_base_event_ids(
-		[event["id"] for event in events]
-	)
-	if not base_ids:
-		return
+    base_ids = get_calendar_event_service(account).get_base_event_ids([event["id"] for event in events])
+    if not base_ids:
+        return
 
-	masters = {
-		master["id"]: master
-		for master in get_calendar_events_by_ids(account, sorted(set(base_ids.values())))
-	}
+    masters = {
+        master["id"]: master for master in get_calendar_events_by_ids(account, sorted(set(base_ids.values())))
+    }
 
-	for event in events:
-		master = masters.get(base_ids.get(event["id"]))
-		if not master:
-			continue
+    for event in events:
+        master = masters.get(base_ids.get(event["id"]))
+        if not master:
+            continue
 
-		event.update(
-			{
-				"recurrence_rule": json.loads(master["recurrence_rule"]),
-				"master_id": master["id"],
-				"master_start": master["start"],
-				"master_duration": master["duration"],
-			}
-		)
+        event.update(
+            {
+                "recurrence_rule": json.loads(master["recurrence_rule"]),
+                "master_id": master["id"],
+                "master_start": master["start"],
+                "master_duration": master["duration"],
+            }
+        )
 
 
 def enrich_participants_with_avatars(events: list[dict]) -> None:
-	"""Attaches user_image to each participant in-place."""
-	unique_emails = list(
-		dict.fromkeys(
-			participant["email"]
-			for event in events
-			for participant in event["participants"]
-			if participant.get("email")
-		)
-	)
-	if not unique_emails:
-		return
+    """Attaches user_image to each participant in-place."""
+    unique_emails = list(
+        dict.fromkeys(
+            participant["email"]
+            for event in events
+            for participant in event["participants"]
+            if participant.get("email")
+        )
+    )
+    if not unique_emails:
+        return
 
-	user_data = frappe.db.get_all(
-		"User", filters={"name": ["in", list(unique_emails)]}, fields=["name", "user_image"]
-	)
-	# Only actual profile pictures — no Gravatar fallback, so participants
-	# without one render as initials in the frontend.
-	user_images = {u.name: u.user_image for u in user_data if u.user_image}
+    user_data = frappe.db.get_all(
+        "User", filters={"name": ["in", list(unique_emails)]}, fields=["name", "user_image"]
+    )
+    # Only actual profile pictures — no Gravatar fallback, so participants
+    # without one render as initials in the frontend.
+    user_images = {u.name: u.user_image for u in user_data if u.user_image}
 
-	for event in events:
-		for participant in event["participants"]:
-			email = participant.get("email")
-			if user_images.get(email):
-				participant["user_image"] = user_images[email]
+    for event in events:
+        for participant in event["participants"]:
+            email = participant.get("email")
+            if user_images.get(email):
+                participant["user_image"] = user_images[email]
 
 
 def _with_name(items: list[dict] | None) -> list[dict] | None:
-	"""Map the formatter's ``_name`` onto the ``name`` key CalendarEventService reads.
+    """Map the formatter's ``_name`` onto the ``name`` key CalendarEventService reads.
 
-	format_calendar_event emits locations and participants with ``_name`` (the desk field name) and
-	the frontend echoes that shape straight back. The service reads ``name``, so without this every
-	edit rewrote location names as null and replaced each participant's display name with their
-	email address - including on partial patches that never mentioned those fields.
-	"""
+    format_calendar_event emits locations and participants with ``_name`` (the desk field name) and
+    the frontend echoes that shape straight back. The service reads ``name``, so without this every
+    edit rewrote location names as null and replaced each participant's display name with their
+    email address - including on partial patches that never mentioned those fields.
+    """
 
-	if not items:
-		return items
+    if not items:
+        return items
 
-	return [
-		{**item, "name": item["_name"]} if "name" not in item and "_name" in item else item
-		for item in items
-	]
+    return [
+        {**item, "name": item["_name"]} if "name" not in item and "_name" in item else item for item in items
+    ]
 
 
 @frappe.whitelist()
 def edit_calendar_event(account: str, id: str, **kwargs) -> None:
-	events = get_calendar_events_by_ids(account, [id])
-	if not events:
-		frappe.throw(_("Calendar Event {0} not found.").format(frappe.bold(id)), frappe.DoesNotExistError)
+    events = get_calendar_events_by_ids(account, [id])
+    if not events:
+        frappe.throw(_("Calendar Event {0} not found.").format(frappe.bold(id)), frappe.DoesNotExistError)
 
-	event = events[0]
+    event = events[0]
 
-	def resolve(key):
-		return kwargs[key] if key in kwargs else event[key]
+    def resolve(key):
+        return kwargs[key] if key in kwargs else event[key]
 
-	calendar_ids = (
-		kwargs["calendar_ids"]
-		if "calendar_ids" in kwargs
-		else [calendar["calendar_id"] for calendar in event["calendars"]]
-	)
+    calendar_ids = (
+        kwargs["calendar_ids"]
+        if "calendar_ids" in kwargs
+        else [calendar["calendar_id"] for calendar in event["calendars"]]
+    )
 
-	update_calendar_event(
-		account,
-		id,
-		event["uid"],
-		event["organizer"],
-		calendar_ids,
-		resolve("status"),
-		resolve("draft"),
-		resolve("title"),
-		resolve("start"),
-		resolve("duration"),
-		resolve("time_zone"),
-		json.loads(resolve("recurrence_rule")),
-		resolve("show_without_time"),
-		resolve("privacy"),
-		resolve("free_busy_status"),
-		resolve("description"),
-		_with_name(resolve("locations")),
-		resolve("links"),
-		_with_name(resolve("participants")),
-		resolve("alerts"),
-		resolve("use_default_alerts"),
-		kwargs.get("send_scheduling_messages", False),
-	)
+    update_calendar_event(
+        account,
+        id,
+        event["uid"],
+        event["organizer"],
+        calendar_ids,
+        resolve("status"),
+        resolve("draft"),
+        resolve("title"),
+        resolve("start"),
+        resolve("duration"),
+        resolve("time_zone"),
+        json.loads(resolve("recurrence_rule")),
+        resolve("show_without_time"),
+        resolve("privacy"),
+        resolve("free_busy_status"),
+        resolve("description"),
+        _with_name(resolve("locations")),
+        resolve("links"),
+        _with_name(resolve("participants")),
+        resolve("alerts"),
+        resolve("use_default_alerts"),
+        kwargs.get("send_scheduling_messages", False),
+    )

--- a/suite/calendar/api/rsvp.py
+++ b/suite/calendar/api/rsvp.py
@@ -25,222 +25,222 @@ from suite.utils.dt import get_utc_now
 
 # response key -> (JSCalendar participationStatus, human label)
 RESPONSES: dict[str, tuple[str, str]] = {
-	"accept": ("accepted", "Yes"),
-	"tentative": ("tentative", "Maybe"),
-	"decline": ("declined", "No"),
+    "accept": ("accepted", "Yes"),
+    "tentative": ("tentative", "Maybe"),
+    "decline": ("declined", "No"),
 }
 
 
 def build_rsvp_links(
-	account: str,
-	event_id: str,
-	participant_uid: str,
-	participant_email: str,
-	expires_at: int | None = None,
+    account: str,
+    event_id: str,
+    participant_uid: str,
+    participant_email: str,
+    expires_at: int | None = None,
 ) -> dict[str, str]:
-	"""Returns {accept|tentative|decline: url} signed links for one participant."""
+    """Returns {accept|tentative|decline: url} signed links for one participant."""
 
-	return {
-		response: _rsvp_url(account, event_id, participant_uid, participant_email, response, expires_at)
-		for response in RESPONSES
-	}
+    return {
+        response: _rsvp_url(account, event_id, participant_uid, participant_email, response, expires_at)
+        for response in RESPONSES
+    }
 
 
 def resolve_rsvp(token: str) -> dict:
-	"""Verifies a token, records the response via JMAP, and returns the page result.
+    """Verifies a token, records the response via JMAP, and returns the page result.
 
-	Returns {success: bool, title: str, message: str} for the confirmation page.
-	"""
+    Returns {success: bool, title: str, message: str} for the confirmation page.
+    """
 
-	payload = _verify(token)
-	if not payload:
-		return _result(False, _("Invalid Link"), _("This response link is invalid or has expired."))
+    payload = _verify(token)
+    if not payload:
+        return _result(False, _("Invalid Link"), _("This response link is invalid or has expired."))
 
-	response = RESPONSES.get(payload.get("r"))
-	if not response:
-		return _result(False, _("Invalid Response"), _("This response link is not valid."))
+    response = RESPONSES.get(payload.get("r"))
+    if not response:
+        return _result(False, _("Invalid Response"), _("This response link is not valid."))
 
-	status = response[0]
+    status = response[0]
 
-	try:
-		service = _guest_calendar_service(payload["a"])
-		result = service.set_participation_status(payload["e"], payload["u"], status)
-		if not result.get("notUpdated"):
-			_notify_organizer(payload, status)
-		frappe.db.commit()
-	except Exception:
-		log_error("Calendar", title=_("Calendar RSVP failed"))
-		return _result(
-			False,
-			_("Something Went Wrong"),
-			_("We couldn't record your response. The event may no longer exist."),
-		)
+    try:
+        service = _guest_calendar_service(payload["a"])
+        result = service.set_participation_status(payload["e"], payload["u"], status)
+        if not result.get("notUpdated"):
+            _notify_organizer(payload, status)
+        frappe.db.commit()
+    except Exception:
+        log_error("Calendar", title=_("Calendar RSVP failed"))
+        return _result(
+            False,
+            _("Something Went Wrong"),
+            _("We couldn't record your response. The event may no longer exist."),
+        )
 
-	if result.get("notUpdated"):
-		return _result(
-			False,
-			_("Something Went Wrong"),
-			_("We couldn't record your response. The event may no longer exist."),
-		)
+    if result.get("notUpdated"):
+        return _result(
+            False,
+            _("Something Went Wrong"),
+            _("We couldn't record your response. The event may no longer exist."),
+        )
 
-	state, heading, sub = _confirmation_copy(payload["r"])
-	event = _fetch_event(service, payload["e"])
-	return {
-		"success": True,
-		"state": state,
-		"title": heading,
-		"message": sub,
-		# The title is organizer-supplied and lands in the guest RSVP page, which frappe renders
-		# through a Jinja environment built without autoescaping - so escape it here rather than
-		# relying on the template.
-		"event_title": escape_html((event or {}).get("title") or ""),
-		"event_when": _format_event_when(event) if event else "",
-	}
+    state, heading, sub = _confirmation_copy(payload["r"])
+    event = _fetch_event(service, payload["e"])
+    return {
+        "success": True,
+        "state": state,
+        "title": heading,
+        "message": sub,
+        # The title is organizer-supplied and lands in the guest RSVP page, which frappe renders
+        # through a Jinja environment built without autoescaping - so escape it here rather than
+        # relying on the template.
+        "event_title": escape_html((event or {}).get("title") or ""),
+        "event_when": _format_event_when(event) if event else "",
+    }
 
 
 def _notify_organizer(payload: dict, status: str) -> None:
-	"""Enqueues the organizer heads-up email for a just-recorded RSVP (best-effort).
+    """Enqueues the organizer heads-up email for a just-recorded RSVP (best-effort).
 
-	Runs after the response commits so the email reflects the stored state, and off the request
-	so a mail hiccup never breaks the guest's confirmation page.
-	"""
+    Runs after the response commits so the email reflects the stored state, and off the request
+    so a mail hiccup never breaks the guest's confirmation page.
+    """
 
-	frappe.enqueue(
-		"suite.calendar.doctype.calendar_event.invitations.notify_organizer_of_response",
-		queue="short",
-		enqueue_after_commit=True,
-		account=payload["a"],
-		event_id=payload["e"],
-		participant_email=payload["m"],
-		status=status,
-	)
+    frappe.enqueue(
+        "suite.calendar.doctype.calendar_event.invitations.notify_organizer_of_response",
+        queue="short",
+        enqueue_after_commit=True,
+        account=payload["a"],
+        event_id=payload["e"],
+        participant_email=payload["m"],
+        status=status,
+    )
 
 
 def _confirmation_copy(response_key: str) -> tuple[str, str, str]:
-	"""Returns (state, heading, sub) for a confirmed response, keyed by the RSVP response."""
+    """Returns (state, heading, sub) for a confirmed response, keyed by the RSVP response."""
 
-	return {
-		"accept": (
-			"yes",
-			_("You're going"),
-			_("Your response has been sent to the organizer. This event is now on your calendar."),
-		),
-		"tentative": (
-			"maybe",
-			_("Marked as maybe"),
-			_("Your response has been sent to the organizer. We'll hold a tentative spot on your calendar."),
-		),
-		"decline": (
-			"no",
-			_("You declined"),
-			_("Your response has been sent to the organizer. This event won't be added to your calendar."),
-		),
-	}[response_key]
+    return {
+        "accept": (
+            "yes",
+            _("You're going"),
+            _("Your response has been sent to the organizer. This event is now on your calendar."),
+        ),
+        "tentative": (
+            "maybe",
+            _("Marked as maybe"),
+            _("Your response has been sent to the organizer. We'll hold a tentative spot on your calendar."),
+        ),
+        "decline": (
+            "no",
+            _("You declined"),
+            _("Your response has been sent to the organizer. This event won't be added to your calendar."),
+        ),
+    }[response_key]
 
 
 def _fetch_event(service: CalendarEventService, event_id: str) -> dict | None:
-	"""Best-effort fetch of the event for the confirmation card; None if unavailable."""
+    """Best-effort fetch of the event for the confirmation card; None if unavailable."""
 
-	try:
-		events = service.get([event_id])
-		return events[0] if events else None
-	except Exception:
-		return None
+    try:
+        events = service.get([event_id])
+        return events[0] if events else None
+    except Exception:
+        return None
 
 
 def _format_event_when(event: dict) -> str:
-	"""Compact event start for the confirmation card, e.g. 'Tue, 14 Jul · 10:00 AM'."""
+    """Compact event start for the confirmation card, e.g. 'Tue, 14 Jul · 10:00 AM'."""
 
-	from suite.calendar.doctype.calendar_exchange.calendar_exchange import _parse_local_datetime
+    from suite.calendar.doctype.calendar_exchange.calendar_exchange import _parse_local_datetime
 
-	start = _parse_local_datetime(event.get("start"), event.get("timeZone"))
-	if not start:
-		return ""
+    start = _parse_local_datetime(event.get("start"), event.get("timeZone"))
+    if not start:
+        return ""
 
-	day = f"{start.strftime('%a')}, {start.day} {start.strftime('%b')}"
-	if event.get("showWithoutTime"):
-		return day
+    day = f"{start.strftime('%a')}, {start.day} {start.strftime('%b')}"
+    if event.get("showWithoutTime"):
+        return day
 
-	hour = start.hour % 12 or 12
-	meridiem = "AM" if start.hour < 12 else "PM"
-	return f"{day} · {hour}:{start.minute:02d} {meridiem}"
+    hour = start.hour % 12 or 12
+    meridiem = "AM" if start.hour < 12 else "PM"
+    return f"{day} · {hour}:{start.minute:02d} {meridiem}"
 
 
 def _guest_calendar_service(account: str) -> CalendarEventService:
-	"""Builds a CalendarEventService for the organizer's account without a logged-in user."""
+    """Builds a CalendarEventService for the organizer's account without a logged-in user."""
 
-	users = frappe.db.get_all("User Account", {"account": account}, pluck="user")
-	if not users:
-		frappe.throw(_("Calendar account not found."))
+    users = frappe.db.get_all("User Account", {"account": account}, pluck="user")
+    if not users:
+        frappe.throw(_("Calendar account not found."))
 
-	connection = get_jmap_connection(users[0], ignore_permissions=True)
-	return CalendarEventService(account, connection)
+    connection = get_jmap_connection(users[0], ignore_permissions=True)
+    return CalendarEventService(account, connection)
 
 
 def _rsvp_url(
-	account: str,
-	event_id: str,
-	participant_uid: str,
-	participant_email: str,
-	response: str,
-	expires_at: int | None,
+    account: str,
+    event_id: str,
+    participant_uid: str,
+    participant_email: str,
+    response: str,
+    expires_at: int | None,
 ) -> str:
-	payload = {"a": account, "e": event_id, "u": participant_uid, "m": participant_email, "r": response}
-	if expires_at:
-		payload["x"] = int(expires_at)
+    payload = {"a": account, "e": event_id, "u": participant_uid, "m": participant_email, "r": response}
+    if expires_at:
+        payload["x"] = int(expires_at)
 
-	token = _sign(payload)
-	return frappe.utils.get_url(f"/event_rsvp?token={token}")
+    token = _sign(payload)
+    return frappe.utils.get_url(f"/event_rsvp?token={token}")
 
 
 def _result(success: bool, title: str, message: str) -> dict:
-	return {"success": success, "title": title, "message": message}
+    return {"success": success, "title": title, "message": message}
 
 
 def _sign(payload: dict) -> str:
-	"""Returns a `<body>.<signature>` token, both URL-safe base64 (unpadded)."""
+    """Returns a `<body>.<signature>` token, both URL-safe base64 (unpadded)."""
 
-	body = _b64encode(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode())
-	signature = _b64encode(hmac.new(_secret(), body.encode(), hashlib.sha256).digest())
-	return f"{body}.{signature}"
+    body = _b64encode(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode())
+    signature = _b64encode(hmac.new(_secret(), body.encode(), hashlib.sha256).digest())
+    return f"{body}.{signature}"
 
 
 def _verify(token: str) -> dict | None:
-	"""Validates the signature and expiry. Returns the payload, or None on any failure."""
+    """Validates the signature and expiry. Returns the payload, or None on any failure."""
 
-	try:
-		body, signature = token.split(".", 1)
-		expected = _b64encode(hmac.new(_secret(), body.encode(), hashlib.sha256).digest())
-		if not hmac.compare_digest(signature, expected):
-			raise ValueError("signature mismatch")
-		payload = json.loads(_b64decode(body))
-	except Exception:
-		return None
+    try:
+        body, signature = token.split(".", 1)
+        expected = _b64encode(hmac.new(_secret(), body.encode(), hashlib.sha256).digest())
+        if not hmac.compare_digest(signature, expected):
+            raise ValueError("signature mismatch")
+        payload = json.loads(_b64decode(body))
+    except Exception:
+        return None
 
-	# Every token must carry an expiry. Reject a missing one outright so a link can never replay
-	# indefinitely (older links minted without an expiry are invalidated by this too).
-	# Compare in real UTC. now_datetime() is naive in the *site* timezone, and .timestamp() on a
-	# naive value resolves it against the *OS* timezone - so when the two differ the expiry was off
-	# by their offset, cutting links short or leaving them valid past the intended window.
-	expires_at = payload.get("x")
-	if not expires_at or get_utc_now().timestamp() > expires_at:
-		return None
+    # Every token must carry an expiry. Reject a missing one outright so a link can never replay
+    # indefinitely (older links minted without an expiry are invalidated by this too).
+    # Compare in real UTC. now_datetime() is naive in the *site* timezone, and .timestamp() on a
+    # naive value resolves it against the *OS* timezone - so when the two differ the expiry was off
+    # by their offset, cutting links short or leaving them valid past the intended window.
+    expires_at = payload.get("x")
+    if not expires_at or get_utc_now().timestamp() > expires_at:
+        return None
 
-	return payload
+    return payload
 
 
 def _secret() -> bytes:
-	# The site's encryption key is the only acceptable signing secret. Never fall back to a
-	# predictable value (site name) or an empty string — that would let anyone forge RSVP tokens.
-	key = frappe.local.conf.get("encryption_key")
-	if not key:
-		frappe.throw(_("Site encryption key is not configured; cannot sign RSVP links."))
-	return key.encode()
+    # The site's encryption key is the only acceptable signing secret. Never fall back to a
+    # predictable value (site name) or an empty string — that would let anyone forge RSVP tokens.
+    key = frappe.local.conf.get("encryption_key")
+    if not key:
+        frappe.throw(_("Site encryption key is not configured; cannot sign RSVP links."))
+    return key.encode()
 
 
 def _b64encode(data: bytes) -> str:
-	return base64.urlsafe_b64encode(data).decode().rstrip("=")
+    return base64.urlsafe_b64encode(data).decode().rstrip("=")
 
 
 def _b64decode(data: str) -> bytes:
-	return base64.urlsafe_b64decode(data + "=" * (-len(data) % 4))
+    return base64.urlsafe_b64decode(data + "=" * (-len(data) % 4))

--- a/suite/calendar/doctype/calendar/calendar.py
+++ b/suite/calendar/doctype/calendar/calendar.py
@@ -63,7 +63,7 @@ class Calendar(Document):
         )
         self.name = f"{self.account}|{self.id}"
 
-    def load_from_db(self) -> "Calendar":
+    def load_from_db(self) -> Calendar:
         account, id = parse_calendar_name(self.name)
         calendar = get_calendar(account, id)
         return super(Document, self).__init__(calendar)
@@ -336,7 +336,7 @@ def format_calendar(account: str, calendar: dict) -> dict:
     }
 
 
-def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
     if doc.doctype != "Calendar":
         return False
 

--- a/suite/calendar/doctype/calendar/calendar.py
+++ b/suite/calendar/doctype/calendar/calendar.py
@@ -16,328 +16,328 @@ from suite.utils import parse_filters
 
 
 class Calendar(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		from suite.calendar.doctype.calendar_rights.calendar_rights import CalendarRights
+        from suite.calendar.doctype.calendar_rights.calendar_rights import CalendarRights
 
-		_name: DF.Data
-		account: DF.Link
-		color: DF.Color | None
-		default: DF.Check
-		description: DF.SmallText | None
-		id: DF.Data | None
-		include_in_availability: DF.Literal["All", "Attending", "None"]
-		may_admin: DF.Check
-		may_delete: DF.Check
-		may_read_free_busy: DF.Check
-		may_read_items: DF.Check
-		may_rsvp: DF.Check
-		may_update_private: DF.Check
-		may_write_all: DF.Check
-		may_write_own: DF.Check
-		share_with: DF.Table[CalendarRights]
-		sort_order: DF.Int
-		subscribed: DF.Check
-		time_zone: DF.Autocomplete | None
-		visible: DF.Check
-	# end: auto-generated types
+        _name: DF.Data
+        account: DF.Link
+        color: DF.Color | None
+        default: DF.Check
+        description: DF.SmallText | None
+        id: DF.Data | None
+        include_in_availability: DF.Literal["All", "Attending", "None"]
+        may_admin: DF.Check
+        may_delete: DF.Check
+        may_read_free_busy: DF.Check
+        may_read_items: DF.Check
+        may_rsvp: DF.Check
+        may_update_private: DF.Check
+        may_write_all: DF.Check
+        may_write_own: DF.Check
+        share_with: DF.Table[CalendarRights]
+        sort_order: DF.Int
+        subscribed: DF.Check
+        time_zone: DF.Autocomplete | None
+        visible: DF.Check
+    # end: auto-generated types
 
-	def db_insert(self, *args, **kwargs) -> None:
-		self.id = add_calendar(
-			self.account,
-			self._name,
-			self.color,
-			self.description,
-			self.sort_order,
-			self.include_in_availability,
-			self.time_zone,
-			bool(self.subscribed),
-			bool(self.visible),
-			bool(self.default),
-		)
-		self.name = f"{self.account}|{self.id}"
+    def db_insert(self, *args, **kwargs) -> None:
+        self.id = add_calendar(
+            self.account,
+            self._name,
+            self.color,
+            self.description,
+            self.sort_order,
+            self.include_in_availability,
+            self.time_zone,
+            bool(self.subscribed),
+            bool(self.visible),
+            bool(self.default),
+        )
+        self.name = f"{self.account}|{self.id}"
 
-	def load_from_db(self) -> "Calendar":
-		account, id = parse_calendar_name(self.name)
-		calendar = get_calendar(account, id)
-		return super(Document, self).__init__(calendar)
+    def load_from_db(self) -> "Calendar":
+        account, id = parse_calendar_name(self.name)
+        calendar = get_calendar(account, id)
+        return super(Document, self).__init__(calendar)
 
-	def db_update(self) -> None:
-		account, id = parse_calendar_name(self.name)
-		update_calendar(
-			account,
-			id,
-			self._name,
-			self.color,
-			self.description,
-			self.sort_order,
-			self.include_in_availability,
-			self.time_zone,
-			bool(self.subscribed),
-			bool(self.visible),
-			bool(self.default),
-		)
-		self.reload()
+    def db_update(self) -> None:
+        account, id = parse_calendar_name(self.name)
+        update_calendar(
+            account,
+            id,
+            self._name,
+            self.color,
+            self.description,
+            self.sort_order,
+            self.include_in_availability,
+            self.time_zone,
+            bool(self.subscribed),
+            bool(self.visible),
+            bool(self.default),
+        )
+        self.reload()
 
-	def delete(self) -> None:
-		account, id = parse_calendar_name(self.name)
-		delete_calendars(account, [id])
+    def delete(self) -> None:
+        account, id = parse_calendar_name(self.name)
+        delete_calendars(account, [id])
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs) -> list:
-		filters = parse_filters(filters)
-		account = filters.get("account")
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs) -> list:
+        filters = parse_filters(filters)
+        account = filters.get("account")
 
-		if not account:
-			frappe.msgprint(_("Please select an account to view calendars."), alert=True)
-			return []
+        if not account:
+            frappe.msgprint(_("Please select an account to view calendars."), alert=True)
+            return []
 
-		calendars = fetch_calendars(account, limit=page_length)
+        calendars = fetch_calendars(account, limit=page_length)
 
-		if not calendars:
-			frappe.msgprint(_("No calendars found."), alert=True)
+        if not calendars:
+            frappe.msgprint(_("No calendars found."), alert=True)
 
-		return calendars
+        return calendars
 
-	@staticmethod
-	def get_count(filters=None, **kwargs) -> int:
-		filters = parse_filters(filters)
-		account = filters.get("account")
+    @staticmethod
+    def get_count(filters=None, **kwargs) -> int:
+        filters = parse_filters(filters)
+        account = filters.get("account")
 
-		if account:
-			if get_user_for_jmap_account(account, raise_exception=False):
-				return cint(frappe.cache.get_value(_get_total_cache_key(account)))
+        if account:
+            if get_user_for_jmap_account(account, raise_exception=False):
+                return cint(frappe.cache.get_value(_get_total_cache_key(account)))
 
-		return 0
+        return 0
 
-	@staticmethod
-	def get_stats(**kwargs) -> dict:
-		return {}
+    @staticmethod
+    def get_stats(**kwargs) -> dict:
+        return {}
 
 
 def _get_total_cache_key(account: str) -> str:
-	"""Returns a cache key for total calendar count for the given account."""
+    """Returns a cache key for total calendar count for the given account."""
 
-	return f"{account}:calendars:total"
+    return f"{account}:calendars:total"
 
 
 def parse_calendar_name(name: str) -> tuple[str, str]:
-	"""Splits a Calendar name `account|id` into its bare `account` and `id`."""
+    """Splits a Calendar name `account|id` into its bare `account` and `id`."""
 
-	validate_calendar_name_format(name)
-	account, id = name.split("|")
-	return account, id
+    validate_calendar_name_format(name)
+    account, id = name.split("|")
+    return account, id
 
 
 def validate_calendar_name_format(name: str) -> None:
-	"Validates that the calendar name is in the format 'account|id'."
+    "Validates that the calendar name is in the format 'account|id'."
 
-	parts = name.split("|")
-	if len(parts) != 2:
-		frappe.throw(_("Calendar name must be in the format 'account|id'."))
+    parts = name.split("|")
+    if len(parts) != 2:
+        frappe.throw(_("Calendar name must be in the format 'account|id'."))
 
 
 @frappe.whitelist()
 def bulk_delete(names: str | list[str]) -> None:
-	"""Deletes multiple calendars given their names."""
+    """Deletes multiple calendars given their names."""
 
-	if isinstance(names, str):
-		names = json.loads(names)
+    if isinstance(names, str):
+        names = json.loads(names)
 
-	accounts_map = {}
-	for name in names:
-		account, id = parse_calendar_name(name)
-		accounts_map.setdefault(account, []).append(id)
+    accounts_map = {}
+    for name in names:
+        account, id = parse_calendar_name(name)
+        accounts_map.setdefault(account, []).append(id)
 
-	for account, ids in accounts_map.items():
-		delete_calendars(account, ids)
+    for account, ids in accounts_map.items():
+        delete_calendars(account, ids)
 
-	frappe.msgprint(_("Calendars deleted successfully."), alert=True)
+    frappe.msgprint(_("Calendars deleted successfully."), alert=True)
 
 
 @frappe.whitelist()
 def add_calendar(
-	account: str,
-	name: str,
-	color: str | None = None,
-	description: str | None = None,
-	sort_order: int = 0,
-	include_in_availability: Literal["All", "Attending", "None"] = "All",
-	time_zone: str | None = None,
-	subscribed: bool = True,
-	visible: bool = True,
-	default: bool = False,
+    account: str,
+    name: str,
+    color: str | None = None,
+    description: str | None = None,
+    sort_order: int = 0,
+    include_in_availability: Literal["All", "Attending", "None"] = "All",
+    time_zone: str | None = None,
+    subscribed: bool = True,
+    visible: bool = True,
+    default: bool = False,
 ) -> str:
-	"""Adds a calendar for the given account with the specified parameters."""
+    """Adds a calendar for the given account with the specified parameters."""
 
-	creation_id = str(uuid7())
-	calendar = {
-		"creation_id": creation_id,
-		"name": name,
-		"color": color,
-		"description": description,
-		"sort_order": sort_order,
-		"include_in_availability": include_in_availability.lower(),
-		"time_zone": time_zone,
-		"is_subscribed": subscribed,
-		"is_visible": visible,
-		"is_default": default,
-	}
+    creation_id = str(uuid7())
+    calendar = {
+        "creation_id": creation_id,
+        "name": name,
+        "color": color,
+        "description": description,
+        "sort_order": sort_order,
+        "include_in_availability": include_in_availability.lower(),
+        "time_zone": time_zone,
+        "is_subscribed": subscribed,
+        "is_visible": visible,
+        "is_default": default,
+    }
 
-	service = get_calendar_service(account)
-	response = service.create([calendar])
+    service = get_calendar_service(account)
+    response = service.create([calendar])
 
-	title = _("Calendar Creation Error")
-	if response.get("created"):
-		return response["created"][creation_id]["id"]
-	elif response.get("notCreated"):
-		frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
-	else:
-		frappe.throw(_(response["description"]), title=title)
+    title = _("Calendar Creation Error")
+    if response.get("created"):
+        return response["created"][creation_id]["id"]
+    elif response.get("notCreated"):
+        frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
+    else:
+        frappe.throw(_(response["description"]), title=title)
 
 
 @frappe.whitelist()
 def get_calendar(account: str, id: str) -> dict:
-	"""Returns calendar details for the given account and id."""
+    """Returns calendar details for the given account and id."""
 
-	service = get_calendar_service(account)
-	if calendars := service.get([id]):
-		return format_calendar(account, calendars[0])
+    service = get_calendar_service(account)
+    if calendars := service.get([id]):
+        return format_calendar(account, calendars[0])
 
-	frappe.throw(
-		_("Calendar with ID {0} not found for account {1}").format(frappe.bold(id), frappe.bold(account)),
-		title=_("Calendar Not Found"),
-	)
+    frappe.throw(
+        _("Calendar with ID {0} not found for account {1}").format(frappe.bold(id), frappe.bold(account)),
+        title=_("Calendar Not Found"),
+    )
 
 
 @frappe.whitelist()
 def update_calendar(
-	account: str,
-	id: str,
-	name: str,
-	color: str | None = None,
-	description: str | None = None,
-	sort_order: int = 0,
-	include_in_availability: Literal["All", "Attending", "None"] = "All",
-	time_zone: str | None = None,
-	subscribed: bool = True,
-	visible: bool = True,
-	default: bool = False,
+    account: str,
+    id: str,
+    name: str,
+    color: str | None = None,
+    description: str | None = None,
+    sort_order: int = 0,
+    include_in_availability: Literal["All", "Attending", "None"] = "All",
+    time_zone: str | None = None,
+    subscribed: bool = True,
+    visible: bool = True,
+    default: bool = False,
 ) -> None:
-	"""Updates an existing calendar with the given parameters."""
+    """Updates an existing calendar with the given parameters."""
 
-	calendar = {
-		"id": id,
-		"name": name,
-		"color": color,
-		"description": description,
-		"sort_order": sort_order,
-		"include_in_availability": include_in_availability.lower(),
-		"time_zone": time_zone,
-		"is_subscribed": subscribed,
-		"is_visible": visible,
-		"is_default": default,
-	}
+    calendar = {
+        "id": id,
+        "name": name,
+        "color": color,
+        "description": description,
+        "sort_order": sort_order,
+        "include_in_availability": include_in_availability.lower(),
+        "time_zone": time_zone,
+        "is_subscribed": subscribed,
+        "is_visible": visible,
+        "is_default": default,
+    }
 
-	service = get_calendar_service(account)
-	response = service.update([calendar])
+    service = get_calendar_service(account)
+    response = service.update([calendar])
 
-	title = _("Calendar Update Error")
-	if not response.get("updated"):
-		if response.get("notUpdated"):
-			frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
-		else:
-			frappe.throw(_(response["description"]), title=title)
+    title = _("Calendar Update Error")
+    if not response.get("updated"):
+        if response.get("notUpdated"):
+            frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
+        else:
+            frappe.throw(_(response["description"]), title=title)
 
 
 @frappe.whitelist()
 def delete_calendars(account: str, ids: list[str], remove_events: bool = True) -> None:
-	"""Deletes calendars for the specified account and ID(s)."""
+    """Deletes calendars for the specified account and ID(s)."""
 
-	service = get_calendar_service(account)
-	response = service.delete(ids, remove_events=remove_events)
+    service = get_calendar_service(account)
+    response = service.delete(ids, remove_events=remove_events)
 
-	if response.get("notDestroyed"):
-		error_messages = []
-		for id, error in response["notDestroyed"].items():
-			error_messages.append(f"{id}: {error['description']}")
-		frappe.throw(
-			_("Calendar Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
-			title=_("Calendar Deletion Error"),
-		)
+    if response.get("notDestroyed"):
+        error_messages = []
+        for id, error in response["notDestroyed"].items():
+            error_messages.append(f"{id}: {error['description']}")
+        frappe.throw(
+            _("Calendar Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
+            title=_("Calendar Deletion Error"),
+        )
 
 
 @frappe.whitelist()
 def fetch_calendars(account: str, page: int = 1, limit: int = 10) -> list:
-	"""Returns a list of calendars for the given account."""
+    """Returns a list of calendars for the given account."""
 
-	service = get_calendar_service(account)
-	calendars = service.get()
-	formatted_calendars = [format_calendar(account, calendar) for calendar in calendars]
-	frappe.cache.set_value(_get_total_cache_key(account), len(calendars), expires_in_sec=600)
+    service = get_calendar_service(account)
+    calendars = service.get()
+    formatted_calendars = [format_calendar(account, calendar) for calendar in calendars]
+    frappe.cache.set_value(_get_total_cache_key(account), len(calendars), expires_in_sec=600)
 
-	start = (page - 1) * limit
-	end = start + limit
+    start = (page - 1) * limit
+    end = start + limit
 
-	return formatted_calendars[start:end]
+    return formatted_calendars[start:end]
 
 
 def format_calendar(account: str, calendar: dict) -> dict:
-	"""Formats calendar data for display."""
+    """Formats calendar data for display."""
 
-	share_with = []
-	for pid, r in calendar.get("shareWith", {}).items():
-		share_with.append(
-			{
-				"principal_id": pid,
-				"may_read_free_busy": cint(bool(r.get("mayReadFreeBusy", False))),
-				"may_read_items": cint(bool(r.get("mayReadItems", False))),
-				"may_write_all": cint(bool(r.get("mayWriteAll", False))),
-				"may_write_own": cint(bool(r.get("mayWriteOwn", False))),
-				"may_update_private": cint(bool(r.get("mayUpdatePrivate", False))),
-				"may_rsvp": cint(bool(r.get("mayRSVP", False))),
-				"may_admin": cint(bool(r.get("mayAdmin", False))),
-				"may_delete": cint(bool(r.get("mayDelete", False))),
-			}
-		)
+    share_with = []
+    for pid, r in calendar.get("shareWith", {}).items():
+        share_with.append(
+            {
+                "principal_id": pid,
+                "may_read_free_busy": cint(bool(r.get("mayReadFreeBusy", False))),
+                "may_read_items": cint(bool(r.get("mayReadItems", False))),
+                "may_write_all": cint(bool(r.get("mayWriteAll", False))),
+                "may_write_own": cint(bool(r.get("mayWriteOwn", False))),
+                "may_update_private": cint(bool(r.get("mayUpdatePrivate", False))),
+                "may_rsvp": cint(bool(r.get("mayRSVP", False))),
+                "may_admin": cint(bool(r.get("mayAdmin", False))),
+                "may_delete": cint(bool(r.get("mayDelete", False))),
+            }
+        )
 
-	rights = calendar.get("myRights") or {}
+    rights = calendar.get("myRights") or {}
 
-	return {
-		"name": f"{account}|{calendar['id']}",
-		"account": account,
-		"id": calendar["id"],
-		"_name": calendar["name"],
-		"description": calendar["description"],
-		"subscribed": cint(bool(calendar["isSubscribed"])),
-		"visible": cint(bool(calendar.get("isVisible"))),
-		"default": cint(bool(calendar.get("isDefault"))),
-		"color": calendar["color"],
-		"sort_order": cint(calendar["sortOrder"]),
-		"include_in_availability": calendar.get("includeInAvailability", "all").title(),
-		"time_zone": calendar["timeZone"],
-		"share_with": share_with,
-		"may_read_free_busy": cint(bool(rights.get("mayReadFreeBusy", False))),
-		"may_read_items": cint(bool(rights.get("mayReadItems", False))),
-		"may_write_all": cint(bool(rights.get("mayWriteAll", False))),
-		"may_write_own": cint(bool(rights.get("mayWriteOwn", False))),
-		"may_update_private": cint(bool(rights.get("mayUpdatePrivate", False))),
-		"may_rsvp": cint(bool(rights.get("mayRSVP", False))),
-		"may_admin": cint(bool(rights.get("mayAdmin", False))),
-		"may_delete": cint(bool(rights.get("mayDelete", False))),
-		"creation": today(),
-		"modified": today(),
-	}
+    return {
+        "name": f"{account}|{calendar['id']}",
+        "account": account,
+        "id": calendar["id"],
+        "_name": calendar["name"],
+        "description": calendar["description"],
+        "subscribed": cint(bool(calendar["isSubscribed"])),
+        "visible": cint(bool(calendar.get("isVisible"))),
+        "default": cint(bool(calendar.get("isDefault"))),
+        "color": calendar["color"],
+        "sort_order": cint(calendar["sortOrder"]),
+        "include_in_availability": calendar.get("includeInAvailability", "all").title(),
+        "time_zone": calendar["timeZone"],
+        "share_with": share_with,
+        "may_read_free_busy": cint(bool(rights.get("mayReadFreeBusy", False))),
+        "may_read_items": cint(bool(rights.get("mayReadItems", False))),
+        "may_write_all": cint(bool(rights.get("mayWriteAll", False))),
+        "may_write_own": cint(bool(rights.get("mayWriteOwn", False))),
+        "may_update_private": cint(bool(rights.get("mayUpdatePrivate", False))),
+        "may_rsvp": cint(bool(rights.get("mayRSVP", False))),
+        "may_admin": cint(bool(rights.get("mayAdmin", False))),
+        "may_delete": cint(bool(rights.get("mayDelete", False))),
+        "creation": today(),
+        "modified": today(),
+    }
 
 
 def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
-	if doc.doctype != "Calendar":
-		return False
+    if doc.doctype != "Calendar":
+        return False
 
-	return bool(get_user_for_jmap_account(doc.account, raise_exception=False))
+    return bool(get_user_for_jmap_account(doc.account, raise_exception=False))

--- a/suite/calendar/doctype/calendar/test_calendar.py
+++ b/suite/calendar/doctype/calendar/test_calendar.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestCalendar(IntegrationTestCase):
-	"""
-	Integration tests for Calendar.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for Calendar.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/calendar/doctype/calendar_event/calendar_event.py
+++ b/suite/calendar/doctype/calendar_event/calendar_event.py
@@ -171,7 +171,7 @@ class CalendarEvent(Document):
         self.name = f"{self.account}|{self.id}"
         self.reload()
 
-    def load_from_db(self) -> "CalendarEvent":
+    def load_from_db(self) -> CalendarEvent:
         account, id = parse_calendar_event_name(self.name)
         if events := get_calendar_events(account, [id]):
             return super(Document, self).__init__(events[0])
@@ -799,7 +799,7 @@ def _raise_if_not_destroyed(response: dict) -> None:
     )
 
 
-def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
     if doc.doctype != "Calendar Event":
         return False
 

--- a/suite/calendar/doctype/calendar_event/calendar_event.py
+++ b/suite/calendar/doctype/calendar_event/calendar_event.py
@@ -13,8 +13,8 @@ from frappe.utils import cint
 
 from suite.calendar.doctype.calendar.calendar import validate_calendar_name_format
 from suite.calendar.doctype.calendar_event.invitations import (
-	acting_as_organizer,
-	custom_event_invites_enabled,
+    acting_as_organizer,
+    custom_event_invites_enabled,
 )
 from suite.mail.doctype.user_account.user_account import get_user_for_jmap_account
 from suite.mail.jmap import get_calendar_event_service
@@ -23,784 +23,784 @@ from suite.utils.dt import convert_to_utc, parse_iso_datetime, utcnow
 
 
 class CalendarEvent(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		from suite.calendar.doctype.event_alert.event_alert import EventAlert
-		from suite.calendar.doctype.event_calendar.event_calendar import EventCalendar
-		from suite.calendar.doctype.event_link.event_link import EventLink
-		from suite.calendar.doctype.event_location.event_location import EventLocation
-		from suite.calendar.doctype.event_participant.event_participant import EventParticipant
+        from suite.calendar.doctype.event_alert.event_alert import EventAlert
+        from suite.calendar.doctype.event_calendar.event_calendar import EventCalendar
+        from suite.calendar.doctype.event_link.event_link import EventLink
+        from suite.calendar.doctype.event_location.event_location import EventLocation
+        from suite.calendar.doctype.event_participant.event_participant import EventParticipant
 
-		account: DF.Link
-		after: DF.Datetime | None
-		alerts: DF.Table[EventAlert]
-		before: DF.Datetime | None
-		calendars: DF.Table[EventCalendar]
-		created_utc: DF.Data | None
-		description: DF.SmallText | None
-		draft: DF.Check
-		duration: DF.Data | None
-		free_busy_status: DF.Literal["", "Busy", "Free"]
-		hide_attendees: DF.Check
-		id: DF.Data | None
-		links: DF.Table[EventLink]
-		locations: DF.Table[EventLocation]
-		may_invite_others: DF.Check
-		may_invite_self: DF.Check
-		organizer: DF.Data | None
-		origin: DF.Check
-		participants: DF.Table[EventParticipant]
-		privacy: DF.Literal["", "Public", "Private"]
-		recurrence_id: DF.Data | None
-		recurrence_id_time_zone: DF.Autocomplete | None
-		recurrence_rule: DF.JSON | None
-		send_scheduling_messages: DF.Check
-		sequence: DF.Int
-		show_without_time: DF.Check
-		start: DF.Data | None
-		status: DF.Literal["Tentative", "Confirmed", "Cancelled"]
-		time_zone: DF.Autocomplete | None
-		title: DF.Data | None
-		uid: DF.Data | None
-		updated_utc: DF.Data | None
-		use_default_alerts: DF.Check
-	# end: auto-generated types
+        account: DF.Link
+        after: DF.Datetime | None
+        alerts: DF.Table[EventAlert]
+        before: DF.Datetime | None
+        calendars: DF.Table[EventCalendar]
+        created_utc: DF.Data | None
+        description: DF.SmallText | None
+        draft: DF.Check
+        duration: DF.Data | None
+        free_busy_status: DF.Literal["", "Busy", "Free"]
+        hide_attendees: DF.Check
+        id: DF.Data | None
+        links: DF.Table[EventLink]
+        locations: DF.Table[EventLocation]
+        may_invite_others: DF.Check
+        may_invite_self: DF.Check
+        organizer: DF.Data | None
+        origin: DF.Check
+        participants: DF.Table[EventParticipant]
+        privacy: DF.Literal["", "Public", "Private"]
+        recurrence_id: DF.Data | None
+        recurrence_id_time_zone: DF.Autocomplete | None
+        recurrence_rule: DF.JSON | None
+        send_scheduling_messages: DF.Check
+        sequence: DF.Int
+        show_without_time: DF.Check
+        start: DF.Data | None
+        status: DF.Literal["Tentative", "Confirmed", "Cancelled"]
+        time_zone: DF.Autocomplete | None
+        title: DF.Data | None
+        uid: DF.Data | None
+        updated_utc: DF.Data | None
+        use_default_alerts: DF.Check
+    # end: auto-generated types
 
-	@property
-	def calendar_ids(self) -> list[str]:
-		"""Returns a list of calendar IDs associated with the event."""
+    @property
+    def calendar_ids(self) -> list[str]:
+        """Returns a list of calendar IDs associated with the event."""
 
-		calendar_ids = []
-		for calendar in self.calendars:
-			calendar_id = calendar.get("calendar_id")
-			if not calendar_id:
-				frappe.throw(_("Row #{0}: Calendar ID is required.").format(calendar.idx))
-			calendar_ids.append(calendar_id)
+        calendar_ids = []
+        for calendar in self.calendars:
+            calendar_id = calendar.get("calendar_id")
+            if not calendar_id:
+                frappe.throw(_("Row #{0}: Calendar ID is required.").format(calendar.idx))
+            calendar_ids.append(calendar_id)
 
-		return calendar_ids
+        return calendar_ids
 
-	@property
-	def formatted_recurrence_rule(self) -> dict | None:
-		"""Returns the formatted recurrence rule for the event."""
+    @property
+    def formatted_recurrence_rule(self) -> dict | None:
+        """Returns the formatted recurrence rule for the event."""
 
-		if self.recurrence_rule:
-			return json.loads(self.recurrence_rule)
+        if self.recurrence_rule:
+            return json.loads(self.recurrence_rule)
 
-	@property
-	def formatted_locations(self) -> list[dict] | None:
-		"""Returns the formatted locations for the event."""
+    @property
+    def formatted_locations(self) -> list[dict] | None:
+        """Returns the formatted locations for the event."""
 
-		if self.locations:
-			return [{"uid": l.uid, "name": l._name} for l in self.locations]
+        if self.locations:
+            return [{"uid": l.uid, "name": l._name} for l in self.locations]
 
-	@property
-	def formatted_links(self) -> list[dict] | None:
-		"""Returns the formatted links for the event."""
+    @property
+    def formatted_links(self) -> list[dict] | None:
+        """Returns the formatted links for the event."""
 
-		if self.links:
-			return [{"uid": l.uid, "href": l.href, "content_type": l.content_type} for l in self.links]
+        if self.links:
+            return [{"uid": l.uid, "href": l.href, "content_type": l.content_type} for l in self.links]
 
-	@property
-	def formatted_alerts(self) -> list[dict] | None:
-		"""Returns the formatted alerts for the event."""
+    @property
+    def formatted_alerts(self) -> list[dict] | None:
+        """Returns the formatted alerts for the event."""
 
-		if self.alerts and not self.use_default_alerts:
-			return [
-				{
-					"uid": a.uid,
-					"action": a.action,
-					"type": a.type,
-					"relative_to": a.relative_to,
-					"offset": a.offset,
-					"when": a.when,
-				}
-				for a in self.alerts
-			]
+        if self.alerts and not self.use_default_alerts:
+            return [
+                {
+                    "uid": a.uid,
+                    "action": a.action,
+                    "type": a.type,
+                    "relative_to": a.relative_to,
+                    "offset": a.offset,
+                    "when": a.when,
+                }
+                for a in self.alerts
+            ]
 
-	@property
-	def formatted_participants(self) -> list[dict] | None:
-		"""Returns the formatted participants for the event."""
+    @property
+    def formatted_participants(self) -> list[dict] | None:
+        """Returns the formatted participants for the event."""
 
-		if self.participants:
-			return [
-				{
-					"uid": p.uid,
-					"name": p._name,
-					"email": p.email,
-					"kind": p.kind,
-					"roles": json.loads(p.roles),
-					"schedule_id": p.schedule_id,
-					"send_to": json.loads(p.send_to),
-					"participation_status": p.participation_status,
-					"expect_reply": bool(p.expect_reply),
-					"description": p.description,
-					"comment": p.comment,
-				}
-				for p in self.participants
-			]
+        if self.participants:
+            return [
+                {
+                    "uid": p.uid,
+                    "name": p._name,
+                    "email": p.email,
+                    "kind": p.kind,
+                    "roles": json.loads(p.roles),
+                    "schedule_id": p.schedule_id,
+                    "send_to": json.loads(p.send_to),
+                    "participation_status": p.participation_status,
+                    "expect_reply": bool(p.expect_reply),
+                    "description": p.description,
+                    "comment": p.comment,
+                }
+                for p in self.participants
+            ]
 
-	def db_insert(self, *args, **kwargs) -> None:
-		self.id = add_calendar_event(
-			account=self.account,
-			organizer=self.organizer,
-			calendar_ids=self.calendar_ids,
-			status=self.status,
-			draft=bool(self.draft),
-			title=self.title,
-			start=self.start,
-			duration=self.duration,
-			time_zone=self.time_zone,
-			recurrence_rule=self.formatted_recurrence_rule,
-			show_without_time=bool(self.show_without_time),
-			privacy=self.privacy,
-			free_busy_status=self.free_busy_status,
-			description=self.description,
-			locations=self.formatted_locations,
-			links=self.formatted_links,
-			participants=self.formatted_participants,
-			alerts=self.formatted_alerts,
-			use_default_alerts=bool(self.use_default_alerts),
-			send_scheduling_messages=bool(self.send_scheduling_messages),
-		)
-		self.name = f"{self.account}|{self.id}"
-		self.reload()
+    def db_insert(self, *args, **kwargs) -> None:
+        self.id = add_calendar_event(
+            account=self.account,
+            organizer=self.organizer,
+            calendar_ids=self.calendar_ids,
+            status=self.status,
+            draft=bool(self.draft),
+            title=self.title,
+            start=self.start,
+            duration=self.duration,
+            time_zone=self.time_zone,
+            recurrence_rule=self.formatted_recurrence_rule,
+            show_without_time=bool(self.show_without_time),
+            privacy=self.privacy,
+            free_busy_status=self.free_busy_status,
+            description=self.description,
+            locations=self.formatted_locations,
+            links=self.formatted_links,
+            participants=self.formatted_participants,
+            alerts=self.formatted_alerts,
+            use_default_alerts=bool(self.use_default_alerts),
+            send_scheduling_messages=bool(self.send_scheduling_messages),
+        )
+        self.name = f"{self.account}|{self.id}"
+        self.reload()
 
-	def load_from_db(self) -> "CalendarEvent":
-		account, id = parse_calendar_event_name(self.name)
-		if events := get_calendar_events(account, [id]):
-			return super(Document, self).__init__(events[0])
+    def load_from_db(self) -> "CalendarEvent":
+        account, id = parse_calendar_event_name(self.name)
+        if events := get_calendar_events(account, [id]):
+            return super(Document, self).__init__(events[0])
 
-		frappe.throw(
-			_("Calendar Event with ID {0} not found in account {1}.").format(
-				frappe.bold(id), frappe.bold(account)
-			),
-			title=_("Calendar Event Not Found"),
-		)
+        frappe.throw(
+            _("Calendar Event with ID {0} not found in account {1}.").format(
+                frappe.bold(id), frappe.bold(account)
+            ),
+            title=_("Calendar Event Not Found"),
+        )
 
-	def db_update(self) -> None:
-		account, id = parse_calendar_event_name(self.name)
-		update_calendar_event(
-			account=account,
-			id=id,
-			uid=self.uid,
-			organizer=self.organizer,
-			calendar_ids=self.calendar_ids,
-			status=self.status,
-			draft=bool(self.draft),
-			title=self.title,
-			start=self.start,
-			duration=self.duration,
-			time_zone=self.time_zone,
-			recurrence_rule=self.formatted_recurrence_rule,
-			show_without_time=bool(self.show_without_time),
-			privacy=self.privacy,
-			free_busy_status=self.free_busy_status,
-			description=self.description,
-			locations=self.formatted_locations,
-			links=self.formatted_links,
-			participants=self.formatted_participants,
-			alerts=self.formatted_alerts,
-			use_default_alerts=bool(self.use_default_alerts),
-			send_scheduling_messages=bool(self.send_scheduling_messages),
-		)
-		self.reload()
+    def db_update(self) -> None:
+        account, id = parse_calendar_event_name(self.name)
+        update_calendar_event(
+            account=account,
+            id=id,
+            uid=self.uid,
+            organizer=self.organizer,
+            calendar_ids=self.calendar_ids,
+            status=self.status,
+            draft=bool(self.draft),
+            title=self.title,
+            start=self.start,
+            duration=self.duration,
+            time_zone=self.time_zone,
+            recurrence_rule=self.formatted_recurrence_rule,
+            show_without_time=bool(self.show_without_time),
+            privacy=self.privacy,
+            free_busy_status=self.free_busy_status,
+            description=self.description,
+            locations=self.formatted_locations,
+            links=self.formatted_links,
+            participants=self.formatted_participants,
+            alerts=self.formatted_alerts,
+            use_default_alerts=bool(self.use_default_alerts),
+            send_scheduling_messages=bool(self.send_scheduling_messages),
+        )
+        self.reload()
 
-	def delete(self) -> None:
-		account, id = parse_calendar_event_name(self.name)
-		if self.get("recurrence_id") and self.get("uid"):
-			# delete_instance needs the master event's JMAP id. uid is the iCalendar UID, which
-			# the server never resolves, so passing it made every instance delete raise.
-			master_id = get_calendar_event_service(account).get_base_event_ids([id]).get(id, id)
-			delete_calendar_event_instance(account, master_id, self.recurrence_id)
-		else:
-			delete_calendar_events(account, [id])
+    def delete(self) -> None:
+        account, id = parse_calendar_event_name(self.name)
+        if self.get("recurrence_id") and self.get("uid"):
+            # delete_instance needs the master event's JMAP id. uid is the iCalendar UID, which
+            # the server never resolves, so passing it made every instance delete raise.
+            master_id = get_calendar_event_service(account).get_base_event_ids([id]).get(id, id)
+            delete_calendar_event_instance(account, master_id, self.recurrence_id)
+        else:
+            delete_calendar_events(account, [id])
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs) -> list:
-		filters = parse_filters(filters)
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs) -> list:
+        filters = parse_filters(filters)
 
-		title = filters.get("title")
-		calendar = filters.get("calendar")
-		account = filters.get("account")
+        title = filters.get("title")
+        calendar = filters.get("calendar")
+        account = filters.get("account")
 
-		if not account:
-			frappe.msgprint(_("Please select an account to view calendar events."), alert=True)
-			return []
+        if not account:
+            frappe.msgprint(_("Please select an account to view calendar events."), alert=True)
+            return []
 
-		after = filters.get("after") and convert_to_utc(filters.get("after"), naive=True).strftime(
-			"%Y-%m-%dT%H:%M:%SZ"
-		)
-		before = filters.get("before") and convert_to_utc(filters.get("before"), naive=True).strftime(
-			"%Y-%m-%dT%H:%M:%SZ"
-		)
+        after = filters.get("after") and convert_to_utc(filters.get("after"), naive=True).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        before = filters.get("before") and convert_to_utc(filters.get("before"), naive=True).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
 
-		filter = {}
-		if title:
-			filter["title"] = title
-		if calendar:
-			validate_calendar_name_format(calendar)
-			filter["inCalendar"] = calendar.split("|")[1]
-		if after:
-			filter["after"] = after
-		if before:
-			filter["before"] = before
-		limit = cint(kwargs.get("start")) + page_length
-		events, total = fetch_calendar_events(account, filter, limit=limit)
-		frappe.cache.set_value(_get_total_cache_key(account), total, expires_in_sec=600)
+        filter = {}
+        if title:
+            filter["title"] = title
+        if calendar:
+            validate_calendar_name_format(calendar)
+            filter["inCalendar"] = calendar.split("|")[1]
+        if after:
+            filter["after"] = after
+        if before:
+            filter["before"] = before
+        limit = cint(kwargs.get("start")) + page_length
+        events, total = fetch_calendar_events(account, filter, limit=limit)
+        frappe.cache.set_value(_get_total_cache_key(account), total, expires_in_sec=600)
 
-		if not events:
-			frappe.msgprint(_("No calendar events found."), alert=True)
+        if not events:
+            frappe.msgprint(_("No calendar events found."), alert=True)
 
-		return events
+        return events
 
-	@staticmethod
-	def get_count(filters=None, **kwargs) -> int:
-		filters = parse_filters(filters)
-		account = filters.get("account")
+    @staticmethod
+    def get_count(filters=None, **kwargs) -> int:
+        filters = parse_filters(filters)
+        account = filters.get("account")
 
-		if account:
-			if get_user_for_jmap_account(account, raise_exception=False):
-				return cint(frappe.cache.get_value(_get_total_cache_key(account)))
+        if account:
+            if get_user_for_jmap_account(account, raise_exception=False):
+                return cint(frappe.cache.get_value(_get_total_cache_key(account)))
 
-		return 0
+        return 0
 
-	@staticmethod
-	def get_stats(**kwargs) -> dict:
-		return {}
+    @staticmethod
+    def get_stats(**kwargs) -> dict:
+        return {}
 
-	def validate(self) -> None:
-		self.validate_draft()
-		self.validate_calendars()
-		self.validate_send_scheduling_messages()
+    def validate(self) -> None:
+        self.validate_draft()
+        self.validate_calendars()
+        self.validate_send_scheduling_messages()
 
-	def validate_draft(self) -> None:
-		"""Validates that an existing event cannot be marked as draft."""
+    def validate_draft(self) -> None:
+        """Validates that an existing event cannot be marked as draft."""
 
-		if not self.is_new() and self.draft:
-			if self.has_value_changed("draft"):
-				frappe.throw(_("Cannot mark an existing event as draft."))
+        if not self.is_new() and self.draft:
+            if self.has_value_changed("draft"):
+                frappe.throw(_("Cannot mark an existing event as draft."))
 
-		if not self.draft:
-			if not self.start:
-				frappe.throw(_("Start time is required for non-draft events."))
-			if not self.duration:
-				frappe.throw(_("Duration is required for non-draft events."))
+        if not self.draft:
+            if not self.start:
+                frappe.throw(_("Start time is required for non-draft events."))
+            if not self.duration:
+                frappe.throw(_("Duration is required for non-draft events."))
 
-	def validate_calendars(self) -> None:
-		"""Validates that at least one calendar is associated with the event."""
+    def validate_calendars(self) -> None:
+        """Validates that at least one calendar is associated with the event."""
 
-		for c in self.calendars or []:
-			validate_calendar_name_format(c.calendar)
-			c.calendar_id = c.calendar.split("|")[1]
+        for c in self.calendars or []:
+            validate_calendar_name_format(c.calendar)
+            c.calendar_id = c.calendar.split("|")[1]
 
-	def validate_send_scheduling_messages(self) -> None:
-		"""Disables sending scheduling messages for draft events."""
+    def validate_send_scheduling_messages(self) -> None:
+        """Disables sending scheduling messages for draft events."""
 
-		if self.draft:
-			self.send_scheduling_messages = 0
+        if self.draft:
+            self.send_scheduling_messages = 0
 
 
 def _get_total_cache_key(account: str) -> str:
-	"""Returns a cache key for total calendar events count for the given account."""
+    """Returns a cache key for total calendar events count for the given account."""
 
-	return f"{account}:calendar_events:total"
+    return f"{account}:calendar_events:total"
 
 
 def parse_calendar_event_name(name: str) -> tuple[str, str]:
-	"""Splits a Calendar Event name `account|id` into its bare `account` and `id`."""
+    """Splits a Calendar Event name `account|id` into its bare `account` and `id`."""
 
-	account, id = name.split("|")
-	return account, id
+    account, id = name.split("|")
+    return account, id
 
 
 @frappe.whitelist()
 def bulk_delete(names: str | list[str]) -> None:
-	"""Deletes calendar events for the given list of names."""
+    """Deletes calendar events for the given list of names."""
 
-	if isinstance(names, str):
-		names = json.loads(names)
+    if isinstance(names, str):
+        names = json.loads(names)
 
-	accounts_map = {}
-	for name in names:
-		account, id = parse_calendar_event_name(name)
-		accounts_map.setdefault(account, []).append(id)
+    accounts_map = {}
+    for name in names:
+        account, id = parse_calendar_event_name(name)
+        accounts_map.setdefault(account, []).append(id)
 
-	for account, ids in accounts_map.items():
-		delete_calendar_events(account, ids)
+    for account, ids in accounts_map.items():
+        delete_calendar_events(account, ids)
 
-	frappe.msgprint(_("Calendar Events deleted successfully."), alert=True)
+    frappe.msgprint(_("Calendar Events deleted successfully."), alert=True)
 
 
 @frappe.whitelist()
 def add_calendar_event(
-	account: str,
-	organizer: str | None = None,
-	calendar_ids: list[str] | None = None,
-	status: Literal["Tentative", "Confirmed", "Cancelled"] = "Confirmed",
-	draft: bool = False,
-	title: str | None = None,
-	start: str | None = None,
-	duration: str | None = None,
-	time_zone: str | None = None,
-	recurrence_rule: dict | None = None,
-	show_without_time: bool = False,
-	privacy: str | None = None,
-	free_busy_status: str | None = None,
-	description: str | None = None,
-	locations: list[dict] | None = None,
-	links: list[dict] | None = None,
-	participants: list[dict] | None = None,
-	alerts: list[dict] | None = None,
-	use_default_alerts: bool = False,
-	send_scheduling_messages: bool = False,
+    account: str,
+    organizer: str | None = None,
+    calendar_ids: list[str] | None = None,
+    status: Literal["Tentative", "Confirmed", "Cancelled"] = "Confirmed",
+    draft: bool = False,
+    title: str | None = None,
+    start: str | None = None,
+    duration: str | None = None,
+    time_zone: str | None = None,
+    recurrence_rule: dict | None = None,
+    show_without_time: bool = False,
+    privacy: str | None = None,
+    free_busy_status: str | None = None,
+    description: str | None = None,
+    locations: list[dict] | None = None,
+    links: list[dict] | None = None,
+    participants: list[dict] | None = None,
+    alerts: list[dict] | None = None,
+    use_default_alerts: bool = False,
+    send_scheduling_messages: bool = False,
 ) -> str:
-	"""Adds a calendar event for the given account and returns the event ID."""
+    """Adds a calendar event for the given account and returns the event ID."""
 
-	uid = uuid7().hex
-	creation_id = str(uuid7())
-	event = {
-		"creation_id": creation_id,
-		"uid": uid,
-		"organizer": organizer,
-		"calendar_ids": calendar_ids,
-		"status": status.lower(),
-		"is_draft": draft,
-		"title": title,
-		"start": start,
-		"duration": duration,
-		"time_zone": time_zone,
-		"recurrence_rule": recurrence_rule,
-		"show_without_time": show_without_time,
-		"privacy": privacy.lower() if privacy else None,
-		"free_busy_status": free_busy_status.lower() if free_busy_status else None,
-		"description": description,
-		"locations": locations,
-		"links": links,
-		"participants": participants,
-		"alerts": alerts,
-		"use_default_alerts": use_default_alerts,
-	}
+    uid = uuid7().hex
+    creation_id = str(uuid7())
+    event = {
+        "creation_id": creation_id,
+        "uid": uid,
+        "organizer": organizer,
+        "calendar_ids": calendar_ids,
+        "status": status.lower(),
+        "is_draft": draft,
+        "title": title,
+        "start": start,
+        "duration": duration,
+        "time_zone": time_zone,
+        "recurrence_rule": recurrence_rule,
+        "show_without_time": show_without_time,
+        "privacy": privacy.lower() if privacy else None,
+        "free_busy_status": free_busy_status.lower() if free_busy_status else None,
+        "description": description,
+        "locations": locations,
+        "links": links,
+        "participants": participants,
+        "alerts": alerts,
+        "use_default_alerts": use_default_alerts,
+    }
 
-	use_custom_invites = (
-		send_scheduling_messages
-		and custom_event_invites_enabled()
-		and acting_as_organizer(account, organizer)
-	)
+    use_custom_invites = (
+        send_scheduling_messages
+        and custom_event_invites_enabled()
+        and acting_as_organizer(account, organizer)
+    )
 
-	service = get_calendar_event_service(account)
-	response = service.create(
-		[event], send_scheduling_messages=send_scheduling_messages and not use_custom_invites
-	)
+    service = get_calendar_event_service(account)
+    response = service.create(
+        [event], send_scheduling_messages=send_scheduling_messages and not use_custom_invites
+    )
 
-	title = _("Calendar Event Creation Error")
-	if response.get("created"):
-		event_id = response["created"][creation_id]["id"]
-		if use_custom_invites:
-			_enqueue_event_notification(account, "invite", event_id=event_id)
-		return event_id
-	elif response.get("notCreated"):
-		frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
-	else:
-		frappe.throw(_(response["description"]), title=title)
+    title = _("Calendar Event Creation Error")
+    if response.get("created"):
+        event_id = response["created"][creation_id]["id"]
+        if use_custom_invites:
+            _enqueue_event_notification(account, "invite", event_id=event_id)
+        return event_id
+    elif response.get("notCreated"):
+        frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
+    else:
+        frappe.throw(_(response["description"]), title=title)
 
 
 @frappe.whitelist()
 def fetch_calendar_events(
-	account: str,
-	filter: dict | None = None,
-	position: int = 0,
-	limit: int = 50,
-	sort: list[dict] | None = None,
-	time_zone: str | None = None,
-	expand_recurrences: bool = False,
+    account: str,
+    filter: dict | None = None,
+    position: int = 0,
+    limit: int = 50,
+    sort: list[dict] | None = None,
+    time_zone: str | None = None,
+    expand_recurrences: bool = False,
 ) -> list:
-	"""Returns a list of calendar events for the given account based on the provided filters."""
+    """Returns a list of calendar events for the given account based on the provided filters."""
 
-	calendar_events = []
-	service = get_calendar_event_service(account)
-	data = service.query(filter, position, limit, sort, time_zone, expand_recurrences)
+    calendar_events = []
+    service = get_calendar_event_service(account)
+    data = service.query(filter, position, limit, sort, time_zone, expand_recurrences)
 
-	ids = data.get("ids", [])
-	total = data.get("total", 0)
+    ids = data.get("ids", [])
+    total = data.get("total", 0)
 
-	calendar_events.extend(get_calendar_events(account, ids))
+    calendar_events.extend(get_calendar_events(account, ids))
 
-	return calendar_events[:limit], total
+    return calendar_events[:limit], total
 
 
 @frappe.whitelist()
 def get_calendar_events(account: str, ids: list[str]) -> list[dict]:
-	"""Returns a list of calendar events for the specified account and IDs."""
+    """Returns a list of calendar events for the specified account and IDs."""
 
-	service = get_calendar_event_service(account)
-	calendar_map = {c["id"]: c for c in service.calendars}
+    service = get_calendar_event_service(account)
+    calendar_map = {c["id"]: c for c in service.calendars}
 
-	events = {}
-	for event in service.get(ids):
-		event = format_calendar_event(account, calendar_map, event)
-		events[event["id"]] = event
+    events = {}
+    for event in service.get(ids):
+        event = format_calendar_event(account, calendar_map, event)
+        events[event["id"]] = event
 
-	return [events[id] for id in ids if id in events]
+    return [events[id] for id in ids if id in events]
 
 
 @frappe.whitelist()
 def update_calendar_event(
-	account: str,
-	id: str,
-	uid: str | None = None,
-	organizer: str | None = None,
-	calendar_ids: list[str] | None = None,
-	status: Literal["Tentative", "Confirmed", "Cancelled"] = "Confirmed",
-	draft: bool = False,
-	title: str | None = None,
-	start: str | None = None,
-	duration: str | None = None,
-	time_zone: str | None = None,
-	recurrence_rule: dict | None = None,
-	show_without_time: bool = False,
-	privacy: str | None = None,
-	free_busy_status: str | None = None,
-	description: str | None = None,
-	locations: list[dict] | None = None,
-	links: list[dict] | None = None,
-	participants: list[dict] | None = None,
-	alerts: list[dict] | None = None,
-	use_default_alerts: bool = False,
-	send_scheduling_messages: bool = False,
+    account: str,
+    id: str,
+    uid: str | None = None,
+    organizer: str | None = None,
+    calendar_ids: list[str] | None = None,
+    status: Literal["Tentative", "Confirmed", "Cancelled"] = "Confirmed",
+    draft: bool = False,
+    title: str | None = None,
+    start: str | None = None,
+    duration: str | None = None,
+    time_zone: str | None = None,
+    recurrence_rule: dict | None = None,
+    show_without_time: bool = False,
+    privacy: str | None = None,
+    free_busy_status: str | None = None,
+    description: str | None = None,
+    locations: list[dict] | None = None,
+    links: list[dict] | None = None,
+    participants: list[dict] | None = None,
+    alerts: list[dict] | None = None,
+    use_default_alerts: bool = False,
+    send_scheduling_messages: bool = False,
 ) -> None:
-	"""Updates a calendar event for the given account and event ID."""
+    """Updates a calendar event for the given account and event ID."""
 
-	event = {
-		"id": id,
-		"uid": uid,
-		"organizer": organizer,
-		"calendar_ids": calendar_ids,
-		"status": status.lower(),
-		"is_draft": draft,
-		"title": title,
-		"start": start,
-		"duration": duration,
-		"time_zone": time_zone,
-		"recurrence_rule": recurrence_rule,
-		"show_without_time": show_without_time,
-		"privacy": privacy.lower() if privacy else None,
-		"free_busy_status": free_busy_status.lower() if free_busy_status else None,
-		"description": description,
-		"locations": locations,
-		"links": links,
-		"participants": participants,
-		"alerts": alerts,
-		"use_default_alerts": use_default_alerts,
-	}
+    event = {
+        "id": id,
+        "uid": uid,
+        "organizer": organizer,
+        "calendar_ids": calendar_ids,
+        "status": status.lower(),
+        "is_draft": draft,
+        "title": title,
+        "start": start,
+        "duration": duration,
+        "time_zone": time_zone,
+        "recurrence_rule": recurrence_rule,
+        "show_without_time": show_without_time,
+        "privacy": privacy.lower() if privacy else None,
+        "free_busy_status": free_busy_status.lower() if free_busy_status else None,
+        "description": description,
+        "locations": locations,
+        "links": links,
+        "participants": participants,
+        "alerts": alerts,
+        "use_default_alerts": use_default_alerts,
+    }
 
-	use_custom_invites = (
-		send_scheduling_messages
-		and custom_event_invites_enabled()
-		and acting_as_organizer(account, organizer)
-	)
+    use_custom_invites = (
+        send_scheduling_messages
+        and custom_event_invites_enabled()
+        and acting_as_organizer(account, organizer)
+    )
 
-	previous_emails = None
-	if use_custom_invites:
-		previous_emails, event["sequence"] = _previous_invite_state(account, id)
+    previous_emails = None
+    if use_custom_invites:
+        previous_emails, event["sequence"] = _previous_invite_state(account, id)
 
-	service = get_calendar_event_service(account)
-	response = service.update(
-		[event], send_scheduling_messages=send_scheduling_messages and not use_custom_invites
-	)
+    service = get_calendar_event_service(account)
+    response = service.update(
+        [event], send_scheduling_messages=send_scheduling_messages and not use_custom_invites
+    )
 
-	title = _("Calendar Event Update Error")
-	if not response.get("updated"):
-		if response.get("notUpdated"):
-			frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
-		else:
-			frappe.throw(_(response["description"]), title=title)
+    title = _("Calendar Event Update Error")
+    if not response.get("updated"):
+        if response.get("notUpdated"):
+            frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
+        else:
+            frappe.throw(_(response["description"]), title=title)
 
-	if use_custom_invites:
-		_enqueue_event_notification(account, "update", event_id=id, previous_emails=previous_emails)
+    if use_custom_invites:
+        _enqueue_event_notification(account, "update", event_id=id, previous_emails=previous_emails)
 
 
 @frappe.whitelist()
 def update_calendar_event_instance(
-	account: str,
-	master_id: str,
-	recurrence_id: str,
-	patch: dict,
-	send_scheduling_messages: bool = False,
+    account: str,
+    master_id: str,
+    recurrence_id: str,
+    patch: dict,
+    send_scheduling_messages: bool = False,
 ) -> None:
-	"""Updates a specific instance of a recurring calendar event based on its master ID and recurrence ID."""
+    """Updates a specific instance of a recurring calendar event based on its master ID and recurrence ID."""
 
-	use_custom_invites = False
-	next_sequence = None
-	if send_scheduling_messages and custom_event_invites_enabled():
-		events = get_calendar_events(account, [master_id])
-		event = events[0] if events else None
-		organizer = event["organizer"] if event else None
-		use_custom_invites = acting_as_organizer(account, organizer)
-		if use_custom_invites:
-			next_sequence = cint(event.get("sequence") if event else 0) + 1
+    use_custom_invites = False
+    next_sequence = None
+    if send_scheduling_messages and custom_event_invites_enabled():
+        events = get_calendar_events(account, [master_id])
+        event = events[0] if events else None
+        organizer = event["organizer"] if event else None
+        use_custom_invites = acting_as_organizer(account, organizer)
+        if use_custom_invites:
+            next_sequence = cint(event.get("sequence") if event else 0) + 1
 
-	service = get_calendar_event_service(account)
-	response = service.update_instance(
-		master_id,
-		recurrence_id,
-		patch,
-		send_scheduling_messages=send_scheduling_messages and not use_custom_invites,
-		sequence=next_sequence,
-	)
+    service = get_calendar_event_service(account)
+    response = service.update_instance(
+        master_id,
+        recurrence_id,
+        patch,
+        send_scheduling_messages=send_scheduling_messages and not use_custom_invites,
+        sequence=next_sequence,
+    )
 
-	title = _("Calendar Event Instance Update Error")
-	if not response.get("updated"):
-		if response.get("notUpdated"):
-			frappe.throw(_(response["notUpdated"][master_id]["description"]), title=title)
-		else:
-			frappe.throw(_(response["description"]), title=title)
+    title = _("Calendar Event Instance Update Error")
+    if not response.get("updated"):
+        if response.get("notUpdated"):
+            frappe.throw(_(response["notUpdated"][master_id]["description"]), title=title)
+        else:
+            frappe.throw(_(response["description"]), title=title)
 
-	if use_custom_invites:
-		_enqueue_event_notification(account, "update", event_id=master_id)
+    if use_custom_invites:
+        _enqueue_event_notification(account, "update", event_id=master_id)
 
 
 @frappe.whitelist()
 def delete_calendar_events(account: str, ids: list[str], send_scheduling_messages: bool = False) -> None:
-	"""Deletes a calendar event for the given account by its ID."""
+    """Deletes a calendar event for the given account by its ID."""
 
-	service = get_calendar_event_service(account)
+    service = get_calendar_event_service(account)
 
-	use_custom_invites = send_scheduling_messages and custom_event_invites_enabled()
+    use_custom_invites = send_scheduling_messages and custom_event_invites_enabled()
 
-	# Snapshot organizer-owned events (with other participants) before deletion so we can send our
-	# own cancellations for them.
-	snapshots = _cancellable_snapshots(account, service, ids) if use_custom_invites else []
-	custom_ids = {snapshot["id"] for snapshot in snapshots}
+    # Snapshot organizer-owned events (with other participants) before deletion so we can send our
+    # own cancellations for them.
+    snapshots = _cancellable_snapshots(account, service, ids) if use_custom_invites else []
+    custom_ids = {snapshot["id"] for snapshot in snapshots}
 
-	# Suppress the JMAP server's own scheduling ONLY for the events we cancel ourselves. Anything
-	# the acting account does not organize keeps server scheduling on, so a non-organizer's delete
-	# still notifies the organizer instead of being silently dropped.
-	if custom_ids:
-		_raise_if_not_destroyed(service.delete(list(custom_ids), send_scheduling_messages=False))
-		if remaining := [id for id in ids if id not in custom_ids]:
-			_raise_if_not_destroyed(
-				service.delete(remaining, send_scheduling_messages=send_scheduling_messages)
-			)
-	else:
-		_raise_if_not_destroyed(service.delete(ids, send_scheduling_messages=send_scheduling_messages))
+    # Suppress the JMAP server's own scheduling ONLY for the events we cancel ourselves. Anything
+    # the acting account does not organize keeps server scheduling on, so a non-organizer's delete
+    # still notifies the organizer instead of being silently dropped.
+    if custom_ids:
+        _raise_if_not_destroyed(service.delete(list(custom_ids), send_scheduling_messages=False))
+        if remaining := [id for id in ids if id not in custom_ids]:
+            _raise_if_not_destroyed(
+                service.delete(remaining, send_scheduling_messages=send_scheduling_messages)
+            )
+    else:
+        _raise_if_not_destroyed(service.delete(ids, send_scheduling_messages=send_scheduling_messages))
 
-	for snapshot in snapshots:
-		_enqueue_event_notification(account, "cancel", event_snapshot=snapshot)
+    for snapshot in snapshots:
+        _enqueue_event_notification(account, "cancel", event_snapshot=snapshot)
 
 
 @frappe.whitelist()
 def delete_calendar_event_instance(
-	account: str, master_id: str, recurrence_id: str, send_scheduling_messages: bool = False
+    account: str, master_id: str, recurrence_id: str, send_scheduling_messages: bool = False
 ) -> None:
-	"""Deletes a specific instance of a recurring calendar event based on its master ID and recurrence ID."""
+    """Deletes a specific instance of a recurring calendar event based on its master ID and recurrence ID."""
 
-	service = get_calendar_event_service(account)
+    service = get_calendar_event_service(account)
 
-	snapshot = None
-	if send_scheduling_messages and custom_event_invites_enabled():
-		if snapshots := _cancellable_snapshots(account, service, [master_id]):
-			snapshot = snapshots[0]
+    snapshot = None
+    if send_scheduling_messages and custom_event_invites_enabled():
+        if snapshots := _cancellable_snapshots(account, service, [master_id]):
+            snapshot = snapshots[0]
 
-	# Suppress the server's own scheduling only when we send a custom cancel for this
-	# (organizer-owned) instance; otherwise let the server notify so nothing is dropped.
-	response = service.delete_instance(
-		master_id, recurrence_id, send_scheduling_messages=send_scheduling_messages and snapshot is None
-	)
+    # Suppress the server's own scheduling only when we send a custom cancel for this
+    # (organizer-owned) instance; otherwise let the server notify so nothing is dropped.
+    response = service.delete_instance(
+        master_id, recurrence_id, send_scheduling_messages=send_scheduling_messages and snapshot is None
+    )
 
-	title = _("Calendar Event Instance Deletion Error")
-	if not response.get("updated"):
-		if response.get("notUpdated"):
-			frappe.throw(_(response["notUpdated"][master_id]["description"]), title=title)
-		else:
-			frappe.throw(_(response["description"]), title=title)
+    title = _("Calendar Event Instance Deletion Error")
+    if not response.get("updated"):
+        if response.get("notUpdated"):
+            frappe.throw(_(response["notUpdated"][master_id]["description"]), title=title)
+        else:
+            frappe.throw(_(response["description"]), title=title)
 
-	if snapshot:
-		_enqueue_event_notification(account, "cancel", event_snapshot=snapshot, recurrence_id=recurrence_id)
+    if snapshot:
+        _enqueue_event_notification(account, "cancel", event_snapshot=snapshot, recurrence_id=recurrence_id)
 
 
 def format_calendar_event(account: str, calendar_map: dict, event: dict) -> dict:
-	"""Formats calendar event data for display."""
+    """Formats calendar event data for display."""
 
-	calendars = []
-	for calendar_id in event["calendarIds"].keys():
-		calendar = calendar_map.get(calendar_id) or {}
-		calendars.append(
-			{
-				"calendar": f"{account}|{calendar_id}",
-				"calendar_id": calendar_id,
-				"calendar_name": calendar.get("name"),
-				"color": calendar.get("color"),
-			}
-		)
+    calendars = []
+    for calendar_id in event["calendarIds"].keys():
+        calendar = calendar_map.get(calendar_id) or {}
+        calendars.append(
+            {
+                "calendar": f"{account}|{calendar_id}",
+                "calendar_id": calendar_id,
+                "calendar_name": calendar.get("name"),
+                "color": calendar.get("color"),
+            }
+        )
 
-	locations = [{"uid": uid, "_name": l.get("name")} for uid, l in event.get("locations", {}).items()]
-	links = [
-		{"uid": uid, "href": l.get("href"), "content_type": l.get("contentType")}
-		for uid, l in event.get("links", {}).items()
-	]
-	alerts = [
-		{
-			"uid": uid,
-			"action": a.get("action", "").title(),
-			"type": a.get("trigger", {}).get("@type", ""),
-			"relative_to": a.get("trigger", {}).get("relativeTo", "").title(),
-			"offset": a.get("trigger", {}).get("offset", "").upper(),
-			"when": a.get("trigger", {}).get("when", "").upper(),
-		}
-		for uid, a in event.get("alerts", {}).items()
-	]
+    locations = [{"uid": uid, "_name": l.get("name")} for uid, l in event.get("locations", {}).items()]
+    links = [
+        {"uid": uid, "href": l.get("href"), "content_type": l.get("contentType")}
+        for uid, l in event.get("links", {}).items()
+    ]
+    alerts = [
+        {
+            "uid": uid,
+            "action": a.get("action", "").title(),
+            "type": a.get("trigger", {}).get("@type", ""),
+            "relative_to": a.get("trigger", {}).get("relativeTo", "").title(),
+            "offset": a.get("trigger", {}).get("offset", "").upper(),
+            "when": a.get("trigger", {}).get("when", "").upper(),
+        }
+        for uid, a in event.get("alerts", {}).items()
+    ]
 
-	participants = []
-	for uid, p in event.get("participants", {}).items():
-		p["roles"] = p.get("roles") or {}
-		roles = {r.lower(): v for r, v in p.get("roles").items()}
-		participants.append(
-			{
-				"uid": uid,
-				"roles": roles,
-				"kind": p["kind"].title() if p.get("kind") else "",
-				"_name": p.get("name"),
-				"email": p.get("calendarAddress", "").replace("mailto:", "") or p.get("email", ""),
-				"schedule_id": p.get("scheduleId", ""),
-				"send_to": p.get("sendTo", {}),
-				"participation_status": p["participationStatus"].upper()
-				if p.get("participationStatus")
-				else "",
-				"expect_reply": cint(p.get("expectReply", False)),
-				"description": p.get("description", ""),
-				"comment": p.get("comment", ""),
-			}
-		)
+    participants = []
+    for uid, p in event.get("participants", {}).items():
+        p["roles"] = p.get("roles") or {}
+        roles = {r.lower(): v for r, v in p.get("roles").items()}
+        participants.append(
+            {
+                "uid": uid,
+                "roles": roles,
+                "kind": p["kind"].title() if p.get("kind") else "",
+                "_name": p.get("name"),
+                "email": p.get("calendarAddress", "").replace("mailto:", "") or p.get("email", ""),
+                "schedule_id": p.get("scheduleId", ""),
+                "send_to": p.get("sendTo", {}),
+                "participation_status": p["participationStatus"].upper()
+                if p.get("participationStatus")
+                else "",
+                "expect_reply": cint(p.get("expectReply", False)),
+                "description": p.get("description", ""),
+                "comment": p.get("comment", ""),
+            }
+        )
 
-	organizer = (
-		event.get("organizerCalendarAddress")
-		and event["organizerCalendarAddress"].lower().replace("mailto:", "")
-	) or ""
+    organizer = (
+        event.get("organizerCalendarAddress")
+        and event["organizerCalendarAddress"].lower().replace("mailto:", "")
+    ) or ""
 
-	created = event.get("created")
-	updated = event.get("updated")
-	created_utc = created or updated or utcnow()
-	updated_utc = updated or created or utcnow()
+    created = event.get("created")
+    updated = event.get("updated")
+    created_utc = created or updated or utcnow()
+    updated_utc = updated or created or utcnow()
 
-	return {
-		"name": f"{account}|{event['id']}",
-		"account": account,
-		"id": event["id"],
-		"uid": event["uid"],
-		"recurrence_id": event.get("recurrenceId"),
-		"organizer": organizer,
-		"calendars": calendars,
-		"status": (event.get("status") and event["status"].title()) or "Confirmed",
-		"draft": cint(event.get("isDraft") or False),
-		"title": event.get("title") or "",
-		"start": event.get("start") or "",
-		"duration": event.get("duration") or "",
-		"time_zone": event.get("timeZone") or "",
-		"recurrence_id_time_zone": event.get("recurrenceIdTimeZone") or "",
-		"recurrence_rule": json.dumps(event.get("recurrenceRule", {}), indent=2),
-		"show_without_time": cint(event.get("showWithoutTime") or False),
-		"privacy": (event.get("privacy") and event["privacy"].title()) or "",
-		"free_busy_status": (event.get("freeBusyStatus") and event["freeBusyStatus"].title()) or "",
-		"description": event.get("description") or "",
-		"locations": locations,
-		"links": links,
-		"participants": participants,
-		"alerts": alerts,
-		"use_default_alerts": cint(event.get("useDefaultAlerts") or False),
-		"created_utc": created_utc,
-		"updated_utc": updated_utc,
-		"origin": event.get("isOrigin") or False,
-		"may_invite_self": cint(event.get("mayInviteSelf") or False),
-		"may_invite_others": cint(event.get("mayInviteOthers") or False),
-		"hide_attendees": cint(event.get("hideAttendees") or False),
-		"creation": parse_iso_datetime(created_utc),
-		"modified": parse_iso_datetime(updated_utc),
-		"sequence": cint(event.get("sequence") or False),
-	}
+    return {
+        "name": f"{account}|{event['id']}",
+        "account": account,
+        "id": event["id"],
+        "uid": event["uid"],
+        "recurrence_id": event.get("recurrenceId"),
+        "organizer": organizer,
+        "calendars": calendars,
+        "status": (event.get("status") and event["status"].title()) or "Confirmed",
+        "draft": cint(event.get("isDraft") or False),
+        "title": event.get("title") or "",
+        "start": event.get("start") or "",
+        "duration": event.get("duration") or "",
+        "time_zone": event.get("timeZone") or "",
+        "recurrence_id_time_zone": event.get("recurrenceIdTimeZone") or "",
+        "recurrence_rule": json.dumps(event.get("recurrenceRule", {}), indent=2),
+        "show_without_time": cint(event.get("showWithoutTime") or False),
+        "privacy": (event.get("privacy") and event["privacy"].title()) or "",
+        "free_busy_status": (event.get("freeBusyStatus") and event["freeBusyStatus"].title()) or "",
+        "description": event.get("description") or "",
+        "locations": locations,
+        "links": links,
+        "participants": participants,
+        "alerts": alerts,
+        "use_default_alerts": cint(event.get("useDefaultAlerts") or False),
+        "created_utc": created_utc,
+        "updated_utc": updated_utc,
+        "origin": event.get("isOrigin") or False,
+        "may_invite_self": cint(event.get("mayInviteSelf") or False),
+        "may_invite_others": cint(event.get("mayInviteOthers") or False),
+        "hide_attendees": cint(event.get("hideAttendees") or False),
+        "creation": parse_iso_datetime(created_utc),
+        "modified": parse_iso_datetime(updated_utc),
+        "sequence": cint(event.get("sequence") or False),
+    }
 
 
 def _enqueue_event_notification(account: str, action: str, **kwargs) -> None:
-	"""Queues custom invitation/update/cancel emails to send after the event is committed.
+    """Queues custom invitation/update/cancel emails to send after the event is committed.
 
-	Extra kwargs are forwarded to notify_participants (event_id, event, previous_emails,
-	recurrence_id).
-	"""
+    Extra kwargs are forwarded to notify_participants (event_id, event, previous_emails,
+    recurrence_id).
+    """
 
-	frappe.enqueue(
-		"suite.calendar.doctype.calendar_event.invitations.notify_participants",
-		queue="short",
-		enqueue_after_commit=True,
-		account=account,
-		action=action,
-		**kwargs,
-	)
+    frappe.enqueue(
+        "suite.calendar.doctype.calendar_event.invitations.notify_participants",
+        queue="short",
+        enqueue_after_commit=True,
+        account=account,
+        action=action,
+        **kwargs,
+    )
 
 
 def _previous_invite_state(account: str, id: str) -> tuple[list[str], int]:
-	"""Returns (current participant emails, next SEQUENCE) for an event about to be updated.
+    """Returns (current participant emails, next SEQUENCE) for an event about to be updated.
 
-	The next sequence is the stored sequence + 1, so every organizer update strictly increases
-	SEQUENCE. Attendee clients (Outlook especially) ignore a re-sent REQUEST whose SEQUENCE has
-	not advanced, so we bump it ourselves rather than trusting the server to. Fetched in one
-	round-trip since the update path already needs the participant diff.
-	"""
+    The next sequence is the stored sequence + 1, so every organizer update strictly increases
+    SEQUENCE. Attendee clients (Outlook especially) ignore a re-sent REQUEST whose SEQUENCE has
+    not advanced, so we bump it ourselves rather than trusting the server to. Fetched in one
+    round-trip since the update path already needs the participant diff.
+    """
 
-	events = get_calendar_events(account, [id])
-	if not events:
-		return [], 1
+    events = get_calendar_events(account, [id])
+    if not events:
+        return [], 1
 
-	event = events[0]
-	emails = [p["email"] for p in event["participants"] if p.get("email")]
-	return emails, cint(event.get("sequence")) + 1
+    event = events[0]
+    emails = [p["email"] for p in event["participants"] if p.get("email")]
+    return emails, cint(event.get("sequence")) + 1
 
 
 def _cancellable_snapshots(account: str, service, ids: list[str]) -> list[dict]:
-	"""Returns raw event snapshots the acting organizer should send cancellations for.
+    """Returns raw event snapshots the acting organizer should send cancellations for.
 
-	Skips events the acting account doesn't organize, and events with no participants other
-	than the organizer. Captured before deletion so the cancel .ics can still be built.
-	"""
+    Skips events the acting account doesn't organize, and events with no participants other
+    than the organizer. Captured before deletion so the cancel .ics can still be built.
+    """
 
-	if not custom_event_invites_enabled():
-		return []
+    if not custom_event_invites_enabled():
+        return []
 
-	snapshots = []
-	for event in service.get(ids):
-		organizer = (event.get("organizerCalendarAddress") or "").lower().replace("mailto:", "")
-		if not acting_as_organizer(account, organizer):
-			continue
+    snapshots = []
+    for event in service.get(ids):
+        organizer = (event.get("organizerCalendarAddress") or "").lower().replace("mailto:", "")
+        if not acting_as_organizer(account, organizer):
+            continue
 
-		has_others = any(
-			((p.get("calendarAddress") or p.get("email") or "").lower().replace("mailto:", "")) != organizer
-			for p in (event.get("participants") or {}).values()
-		)
-		if has_others:
-			snapshots.append(event)
+        has_others = any(
+            ((p.get("calendarAddress") or p.get("email") or "").lower().replace("mailto:", "")) != organizer
+            for p in (event.get("participants") or {}).values()
+        )
+        if has_others:
+            snapshots.append(event)
 
-	return snapshots
+    return snapshots
 
 
 def _raise_if_not_destroyed(response: dict) -> None:
-	"""Raises a user-facing error listing any events the JMAP server refused to destroy."""
+    """Raises a user-facing error listing any events the JMAP server refused to destroy."""
 
-	if not response.get("notDestroyed"):
-		return
+    if not response.get("notDestroyed"):
+        return
 
-	messages = [f"{id}: {error['description']}" for id, error in response["notDestroyed"].items()]
-	frappe.throw(
-		_("Calendar Event Deletion Error(s):<br>{0}").format("<br>".join(messages)),
-		title=_("Calendar Event Deletion Error"),
-	)
+    messages = [f"{id}: {error['description']}" for id, error in response["notDestroyed"].items()]
+    frappe.throw(
+        _("Calendar Event Deletion Error(s):<br>{0}").format("<br>".join(messages)),
+        title=_("Calendar Event Deletion Error"),
+    )
 
 
 def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
-	if doc.doctype != "Calendar Event":
-		return False
+    if doc.doctype != "Calendar Event":
+        return False
 
-	return bool(get_user_for_jmap_account(doc.account, raise_exception=False))
+    return bool(get_user_for_jmap_account(doc.account, raise_exception=False))

--- a/suite/calendar/doctype/calendar_event/ics.py
+++ b/suite/calendar/doctype/calendar_event/ics.py
@@ -14,79 +14,79 @@ from frappe.utils import cint
 from icalendar import Calendar
 
 from suite.calendar.doctype.calendar_exchange.calendar_exchange import (
-	_build_components,
-	_parse_local_datetime,
-	jscalendar_to_vevent,
+    _build_components,
+    _parse_local_datetime,
+    jscalendar_to_vevent,
 )
 
 PRODID = "-//Frappe Mail//Calendar Invite//EN"
 
 
 def build_event_ics(event: dict, method: str = "REQUEST", recurrence_id: str | None = None) -> str:
-	"""Returns the iCalendar text for a JSCalendar event using the given iTIP method.
+    """Returns the iCalendar text for a JSCalendar event using the given iTIP method.
 
-	When `recurrence_id` is set, a single occurrence (tagged with RECURRENCE-ID) is emitted
-	instead of the whole series — used to cancel one instance of a recurring event.
-	"""
+    When `recurrence_id` is set, a single occurrence (tagged with RECURRENCE-ID) is emitted
+    instead of the whole series — used to cancel one instance of a recurring event.
+    """
 
-	cal = Calendar()
-	cal.add("prodid", PRODID)
-	cal.add("version", "2.0")
-	cal.add("method", method)
+    cal = Calendar()
+    cal.add("prodid", PRODID)
+    cal.add("version", "2.0")
+    cal.add("method", method)
 
-	if recurrence_id:
-		component = _instance_component(event, recurrence_id, method)
-		_stamp_outgoing(component, method)
-		cal.add_component(component)
-	else:
-		for component in _build_components(event):
-			if method == "CANCEL":
-				_mark_cancelled(component)
-			_stamp_outgoing(component, method)
-			cal.add_component(component)
+    if recurrence_id:
+        component = _instance_component(event, recurrence_id, method)
+        _stamp_outgoing(component, method)
+        cal.add_component(component)
+    else:
+        for component in _build_components(event):
+            if method == "CANCEL":
+                _mark_cancelled(component)
+            _stamp_outgoing(component, method)
+            cal.add_component(component)
 
-	return cal.to_ical().decode("utf-8")
+    return cal.to_ical().decode("utf-8")
 
 
 def _stamp_outgoing(component, method: str) -> None:
-	"""Stamps an outgoing iTIP component with a send-time DTSTAMP and the right SEQUENCE.
+    """Stamps an outgoing iTIP component with a send-time DTSTAMP and the right SEQUENCE.
 
-	DTSTAMP on a scheduling message marks when the message itself was produced (now), not the
-	event's last-modified time — clients use it to order re-sends. For a CANCEL we force
-	SEQUENCE one past the stored value so it strictly supersedes the REQUEST it cancels; plain
-	REQUESTs keep the sequence the organizer already bumped on the stored event.
-	"""
+    DTSTAMP on a scheduling message marks when the message itself was produced (now), not the
+    event's last-modified time — clients use it to order re-sends. For a CANCEL we force
+    SEQUENCE one past the stored value so it strictly supersedes the REQUEST it cancels; plain
+    REQUESTs keep the sequence the organizer already bumped on the stored event.
+    """
 
-	if "dtstamp" in component:
-		del component["dtstamp"]
-	component.add("dtstamp", datetime.now(UTC))
+    if "dtstamp" in component:
+        del component["dtstamp"]
+    component.add("dtstamp", datetime.now(UTC))
 
-	if method == "CANCEL":
-		bumped = cint(component.get("sequence")) + 1
-		if "sequence" in component:
-			del component["sequence"]
-		component.add("sequence", bumped)
+    if method == "CANCEL":
+        bumped = cint(component.get("sequence")) + 1
+        if "sequence" in component:
+            del component["sequence"]
+        component.add("sequence", bumped)
 
 
 def _instance_component(event: dict, recurrence_id: str, method: str):
-	"""Builds a single-occurrence VEVENT carrying RECURRENCE-ID (no RRULE/overrides)."""
+    """Builds a single-occurrence VEVENT carrying RECURRENCE-ID (no RRULE/overrides)."""
 
-	base = {k: v for k, v in event.items() if k not in ("recurrenceRule", "recurrenceOverrides")}
-	component = jscalendar_to_vevent(base)
+    base = {k: v for k, v in event.items() if k not in ("recurrenceRule", "recurrenceOverrides")}
+    component = jscalendar_to_vevent(base)
 
-	instance_dt = _parse_local_datetime(recurrence_id, event.get("timeZone"))
-	if instance_dt:
-		component.add("recurrence-id", instance_dt.date() if event.get("showWithoutTime") else instance_dt)
+    instance_dt = _parse_local_datetime(recurrence_id, event.get("timeZone"))
+    if instance_dt:
+        component.add("recurrence-id", instance_dt.date() if event.get("showWithoutTime") else instance_dt)
 
-	if method == "CANCEL":
-		_mark_cancelled(component)
+    if method == "CANCEL":
+        _mark_cancelled(component)
 
-	return component
+    return component
 
 
 def _mark_cancelled(component) -> None:
-	"""Forces STATUS:CANCELLED so recipients' clients remove the event on a CANCEL."""
+    """Forces STATUS:CANCELLED so recipients' clients remove the event on a CANCEL."""
 
-	if "status" in component:
-		del component["status"]
-	component.add("status", "CANCELLED")
+    if "status" in component:
+        del component["status"]
+    component.add("status", "CANCELLED")

--- a/suite/calendar/doctype/calendar_event/invitations.py
+++ b/suite/calendar/doctype/calendar_event/invitations.py
@@ -23,13 +23,13 @@ from frappe.utils import add_to_date, get_datetime, strip_html_tags
 
 from suite.calendar.doctype.calendar_event.ics import build_event_ics
 from suite.calendar.doctype.calendar_event.invite_templates import (
-	DEFAULT_SUBJECTS,
-	DEFAULT_TEMPLATES,
-	template_path,
+    DEFAULT_SUBJECTS,
+    DEFAULT_TEMPLATES,
+    template_path,
 )
 from suite.calendar.doctype.calendar_exchange.calendar_exchange import (
-	_parse_local_datetime,
-	is_conference_link,
+    _parse_local_datetime,
+    is_conference_link,
 )
 from suite.mail.doctype.mail_queue.mail_queue import MailQueue
 from suite.mail.doctype.user_account.user_account import get_user_for_jmap_account
@@ -46,9 +46,9 @@ RSVP_FALLBACK_DAYS = 30
 
 # JSCalendar participationStatus -> (button label, pill state) for the organizer notification email.
 RESPONSE_DISPLAY: dict[str, tuple[str, str]] = {
-	"accepted": ("Yes", "yes"),
-	"tentative": ("Maybe", "maybe"),
-	"declined": ("No", "no"),
+    "accepted": ("Yes", "yes"),
+    "tentative": ("Maybe", "maybe"),
+    "declined": ("No", "no"),
 }
 
 # The invite/update/cancel mails embed the logo as a CID part (built by hand in `_build_mime`).
@@ -61,413 +61,411 @@ EMAIL_FONT = "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helv
 
 
 def custom_event_invites_enabled() -> bool:
-	"""Returns True when Mail Settings is configured to send invites from the client."""
+    """Returns True when Mail Settings is configured to send invites from the client."""
 
-	return bool(frappe.get_cached_doc("Mail Settings").get("custom_event_invites"))
+    return bool(frappe.get_cached_doc("Mail Settings").get("custom_event_invites"))
 
 
 def acting_as_organizer(account: str, organizer: str | None) -> bool:
-	"""True when the organizer address is one of the acting account's own identities.
+    """True when the organizer address is one of the acting account's own identities.
 
-	Guards against firing invite blasts when an attendee (not the organizer) edits their
-	own response on a shared event — that case should fall back to server scheduling.
-	"""
+    Guards against firing invite blasts when an attendee (not the organizer) edits their
+    own response on a shared event — that case should fall back to server scheduling.
+    """
 
-	if not organizer:
-		return True
+    if not organizer:
+        return True
 
-	organizer = organizer.lower().replace("mailto:", "")
-	try:
-		return organizer in {i["email"] for i in get_identities(account)}
-	except Exception:
-		return False
+    organizer = organizer.lower().replace("mailto:", "")
+    try:
+        return organizer in {i["email"] for i in get_identities(account)}
+    except Exception:
+        return False
 
 
 def notify_participants(
-	account: str,
-	action: str,
-	event_id: str | None = None,
-	event_snapshot: dict | None = None,
-	previous_emails: list[str] | None = None,
-	recurrence_id: str | None = None,
+    account: str,
+    action: str,
+    event_id: str | None = None,
+    event_snapshot: dict | None = None,
+    previous_emails: list[str] | None = None,
+    recurrence_id: str | None = None,
 ) -> None:
-	"""Sends invite/update/cancel emails for an event's participants.
+    """Sends invite/update/cancel emails for an event's participants.
 
-	`action` is one of "invite", "update", "cancel". Pass `event_id` to fetch the current
-	event, or a pre-fetched `event_snapshot` (needed for cancellations after deletion).
-	For updates, `previous_emails` enables new -> invite / kept -> update / gone -> cancel;
-	omit it to send a plain update to everyone. `recurrence_id` scopes a cancellation to a
-	single occurrence of a recurring event.
+    `action` is one of "invite", "update", "cancel". Pass `event_id` to fetch the current
+    event, or a pre-fetched `event_snapshot` (needed for cancellations after deletion).
+    For updates, `previous_emails` enables new -> invite / kept -> update / gone -> cancel;
+    omit it to send a plain update to everyone. `recurrence_id` scopes a cancellation to a
+    single occurrence of a recurring event.
 
-	Note: the snapshot arg is named `event_snapshot`, not `event` — `event` is a reserved
-	kwarg of `frappe.enqueue` and would be swallowed before reaching this function.
-	"""
+    Note: the snapshot arg is named `event_snapshot`, not `event` — `event` is a reserved
+    kwarg of `frappe.enqueue` and would be swallowed before reaching this function.
+    """
 
-	event = event_snapshot
-	if event is None:
-		events = get_calendar_event_service(account).get([event_id])
-		if not events:
-			return
-		event = events[0]
+    event = event_snapshot
+    if event is None:
+        events = get_calendar_event_service(account).get([event_id])
+        if not events:
+            return
+        event = events[0]
 
-	organizer = (event.get("organizerCalendarAddress") or "").lower().replace("mailto:", "")
-	attendees = _attendees(event, organizer)
-	plan = _plan(action, set(attendees), previous_emails)
-	if not plan:
-		return
+    organizer = (event.get("organizerCalendarAddress") or "").lower().replace("mailto:", "")
+    attendees = _attendees(event, organizer)
+    plan = _plan(action, set(attendees), previous_emails)
+    if not plan:
+        return
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	expires_at = _rsvp_expiry(event)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    expires_at = _rsvp_expiry(event)
 
-	for email, kind in plan.items():
-		try:
-			_send(
-				account, user, event, organizer, email, attendees.get(email), kind, expires_at, recurrence_id
-			)
-		except Exception:
-			log_error("Calendar", title=_("Failed to send event {0} email to {1}").format(kind, email))
+    for email, kind in plan.items():
+        try:
+            _send(
+                account, user, event, organizer, email, attendees.get(email), kind, expires_at, recurrence_id
+            )
+        except Exception:
+            log_error("Calendar", title=_("Failed to send event {0} email to {1}").format(kind, email))
 
 
-def notify_organizer_of_response(
-	account: str, event_id: str, participant_email: str, status: str
-) -> None:
-	"""Emails the organizer that a guest responded to their invitation.
+def notify_organizer_of_response(account: str, event_id: str, participant_email: str, status: str) -> None:
+    """Emails the organizer that a guest responded to their invitation.
 
-	Guests RSVP through signed links, so their answer is written straight to the organizer's
-	copy over JMAP and no iTIP REPLY ever reaches the organizer — they'd only find out by opening
-	the event. This sends that heads-up from the site's default outgoing account (the organizer is
-	the recipient, not the sender), with Reply-To pointing at the responding guest.
+    Guests RSVP through signed links, so their answer is written straight to the organizer's
+    copy over JMAP and no iTIP REPLY ever reaches the organizer — they'd only find out by opening
+    the event. This sends that heads-up from the site's default outgoing account (the organizer is
+    the recipient, not the sender), with Reply-To pointing at the responding guest.
 
-	Runs as a background job off the unauthenticated RSVP request, so it acts as the account owner
-	to read the event over JMAP.
-	"""
+    Runs as a background job off the unauthenticated RSVP request, so it acts as the account owner
+    to read the event over JMAP.
+    """
 
-	display = RESPONSE_DISPLAY.get((status or "").lower())
-	if not display:
-		return
+    display = RESPONSE_DISPLAY.get((status or "").lower())
+    if not display:
+        return
 
-	# The RSVP request is unauthenticated (Guest), so resolve the account owner straight from the
-	# DB — get_user_for_jmap_account would reject Guest — then act as them to read the event.
-	owner = frappe.db.get_value("User Account", {"account": account}, "user")
-	if not owner:
-		return
+    # The RSVP request is unauthenticated (Guest), so resolve the account owner straight from the
+    # DB — get_user_for_jmap_account would reject Guest — then act as them to read the event.
+    owner = frappe.db.get_value("User Account", {"account": account}, "user")
+    if not owner:
+        return
 
-	original_user = frappe.session.user
-	frappe.set_user(owner)
-	try:
-		events = get_calendar_event_service(account).get([event_id])
-		if not events:
-			return
-		event = events[0]
+    original_user = frappe.session.user
+    frappe.set_user(owner)
+    try:
+        events = get_calendar_event_service(account).get([event_id])
+        if not events:
+            return
+        event = events[0]
 
-		organizer = (event.get("organizerCalendarAddress") or "").lower().replace("mailto:", "")
-		if not organizer:
-			return
+        organizer = (event.get("organizerCalendarAddress") or "").lower().replace("mailto:", "")
+        if not organizer:
+            return
 
-		organizer_name = _organizer_name(account, event, organizer)
-		responder = _display_name(event, participant_email) or participant_email
-		subject, html = _render_response(
-			event, organizer, organizer_name, participant_email, responder, display
-		)
+        organizer_name = _organizer_name(account, event, organizer)
+        responder = _display_name(event, participant_email) or participant_email
+        subject, html = _render_response(
+            event, organizer, organizer_name, participant_email, responder, display
+        )
 
-		frappe.sendmail(
-			recipients=[organizer],
-			subject=subject,
-			message=html,
-			reply_to=participant_email,
-			inline_images=_response_inline_images(),
-			now=True,
-		)
-	except Exception:
-		log_error("Calendar", title=_("Failed to notify organizer of RSVP for event {0}").format(event_id))
-	finally:
-		frappe.set_user(original_user)
+        frappe.sendmail(
+            recipients=[organizer],
+            subject=subject,
+            message=html,
+            reply_to=participant_email,
+            inline_images=_response_inline_images(),
+            now=True,
+        )
+    except Exception:
+        log_error("Calendar", title=_("Failed to notify organizer of RSVP for event {0}").format(event_id))
+    finally:
+        frappe.set_user(original_user)
 
 
 def _response_inline_images() -> list[dict]:
-	"""Returns the Calendar logo for the response email in frappe.sendmail's `embed=` format."""
+    """Returns the Calendar logo for the response email in frappe.sendmail's `embed=` format."""
 
-	logo = _image_bytes("public", "calendar", "images", "logo.png")
-	return [{"filename": RESPONSE_LOGO_EMBED, "filecontent": logo}] if logo else []
+    logo = _image_bytes("public", "calendar", "images", "logo.png")
+    return [{"filename": RESPONSE_LOGO_EMBED, "filecontent": logo}] if logo else []
 
 
 def _plan(action: str, current: set[str], previous_emails: list[str] | None) -> dict[str, str]:
-	"""Maps each recipient email to the email kind (invite/update/cancel) to send."""
+    """Maps each recipient email to the email kind (invite/update/cancel) to send."""
 
-	if action == "invite":
-		return {email: "invite" for email in current}
-	if action == "cancel":
-		return {email: "cancel" for email in current}
+    if action == "invite":
+        return {email: "invite" for email in current}
+    if action == "cancel":
+        return {email: "cancel" for email in current}
 
-	# action == "update"
-	if previous_emails is None:
-		return {email: "update" for email in current}
+    # action == "update"
+    if previous_emails is None:
+        return {email: "update" for email in current}
 
-	previous = set(previous_emails)
-	plan = {email: ("update" if email in previous else "invite") for email in current}
-	for email in previous - current:
-		plan[email] = "cancel"
-	return plan
+    previous = set(previous_emails)
+    plan = {email: ("update" if email in previous else "invite") for email in current}
+    for email in previous - current:
+        plan[email] = "cancel"
+    return plan
 
 
 def _send(
-	account: str,
-	user: str,
-	event: dict,
-	organizer: str,
-	email: str,
-	participant: dict | None,
-	kind: str,
-	expires_at: int,
-	recurrence_id: str | None = None,
+    account: str,
+    user: str,
+    event: dict,
+    organizer: str,
+    email: str,
+    participant: dict | None,
+    kind: str,
+    expires_at: int,
+    recurrence_id: str | None = None,
 ) -> None:
-	"""Renders and enqueues a single invitation/update/cancellation email."""
+    """Renders and enqueues a single invitation/update/cancellation email."""
 
-	from suite.calendar.api.rsvp import build_rsvp_links
+    from suite.calendar.api.rsvp import build_rsvp_links
 
-	method = "CANCEL" if kind == "cancel" else "REQUEST"
-	ics = build_event_ics(event, method=method, recurrence_id=recurrence_id)
+    method = "CANCEL" if kind == "cancel" else "REQUEST"
+    ics = build_event_ics(event, method=method, recurrence_id=recurrence_id)
 
-	links = None
-	if kind in ("invite", "update") and participant and participant.get("uid"):
-		links = build_rsvp_links(account, event["id"], participant["uid"], email, expires_at)
+    links = None
+    if kind in ("invite", "update") and participant and participant.get("uid"):
+        links = build_rsvp_links(account, event["id"], participant["uid"], email, expires_at)
 
-	from_name = _organizer_name(account, event, organizer)
-	subject, html = _render(kind, event, organizer, from_name, participant, links)
-	message = _build_mime(from_name, organizer, email, subject, html, ics, method)
+    from_name = _organizer_name(account, event, organizer)
+    subject, html = _render(kind, event, organizer, from_name, participant, links)
+    message = _build_mime(from_name, organizer, email, subject, html, ics, method)
 
-	MailQueue._create(
-		user=user,
-		account=account,
-		from_name=from_name,
-		from_email=organizer,
-		recipients=[{"name": (participant or {}).get("name"), "email": email, "type": "To"}],
-		raw_message=message,
-		via_api=True,
-		delivery_mode="Enqueue",
-	)
+    MailQueue._create(
+        user=user,
+        account=account,
+        from_name=from_name,
+        from_email=organizer,
+        recipients=[{"name": (participant or {}).get("name"), "email": email, "type": "To"}],
+        raw_message=message,
+        via_api=True,
+        delivery_mode="Enqueue",
+    )
 
 
 def _render(kind, event, organizer, organizer_name, participant, links) -> tuple[str, str]:
-	"""Returns (subject, html) from the on-disk template for the given action."""
+    """Returns (subject, html) from the on-disk template for the given action."""
 
-	context = _context(event, organizer, organizer_name, participant, links)
+    context = _context(event, organizer, organizer_name, participant, links)
 
-	subject = frappe.render_template(DEFAULT_SUBJECTS[kind], context, is_path=False)
-	html = frappe.render_template(template_path(DEFAULT_TEMPLATES[kind]), context, is_path=True)
-	return subject, html
+    subject = frappe.render_template(DEFAULT_SUBJECTS[kind], context, is_path=False)
+    html = frappe.render_template(template_path(DEFAULT_TEMPLATES[kind]), context, is_path=True)
+    return subject, html
 
 
 def _render_response(
-	event, organizer, organizer_name, responder_email, responder_name, display
+    event, organizer, organizer_name, responder_email, responder_name, display
 ) -> tuple[str, str]:
-	"""Returns (subject, html) for the organizer's RSVP notification email."""
+    """Returns (subject, html) for the organizer's RSVP notification email."""
 
-	label, state = display
-	context = _context(event, organizer, organizer_name, None, None)
-	context.update(
-		{
-			"responder_name": responder_name,
-			"responder_email": responder_email,
-			"response_label": label,
-			"response_state": state,
-			# Sent via frappe.sendmail, which inlines the logo from an `embed=` attribute.
-			"logo_src_attr": f'embed="{RESPONSE_LOGO_EMBED}"',
-		}
-	)
+    label, state = display
+    context = _context(event, organizer, organizer_name, None, None)
+    context.update(
+        {
+            "responder_name": responder_name,
+            "responder_email": responder_email,
+            "response_label": label,
+            "response_state": state,
+            # Sent via frappe.sendmail, which inlines the logo from an `embed=` attribute.
+            "logo_src_attr": f'embed="{RESPONSE_LOGO_EMBED}"',
+        }
+    )
 
-	subject = frappe.render_template(DEFAULT_SUBJECTS["response"], context, is_path=False)
-	html = frappe.render_template(template_path(DEFAULT_TEMPLATES["response"]), context, is_path=True)
-	return subject, html
+    subject = frappe.render_template(DEFAULT_SUBJECTS["response"], context, is_path=False)
+    html = frappe.render_template(template_path(DEFAULT_TEMPLATES["response"]), context, is_path=True)
+    return subject, html
 
 
 def _context(event, organizer, organizer_name, participant, links) -> dict:
-	"""Builds the Jinja render context shared by subject and body templates."""
+    """Builds the Jinja render context shared by subject and body templates."""
 
-	locations = [l.get("name") for l in (event.get("locations") or {}).values() if l.get("name")]
+    locations = [l.get("name") for l in (event.get("locations") or {}).values() if l.get("name")]
 
-	return {
-		"font": EMAIL_FONT,
-		"title": event.get("title") or "(No title)",
-		"when": _format_when(event),
-		# Timezone shown on its own line under the date; omitted for all-day events.
-		"timezone": "" if event.get("showWithoutTime") else (event.get("timeZone") or ""),
-		"location": "; ".join(locations),
-		"description": event.get("description") or "",
-		"organizer_name": organizer_name or organizer,
-		"organizer_display": f"{organizer_name} ({organizer})" if organizer_name else organizer,
-		"organizer_email": organizer,
-		"attendee_name": (participant or {}).get("name") or "",
-		"meet": _meet_link(event),
-		"rsvp": links,
-		# Invite/update/cancel go out as hand-built MIME with a CID logo part; the response email
-		# (frappe.sendmail) overrides this with an `embed=` reference. See `_render_response`.
-		"logo_src_attr": 'src="cid:eventlogo"',
-	}
+    return {
+        "font": EMAIL_FONT,
+        "title": event.get("title") or "(No title)",
+        "when": _format_when(event),
+        # Timezone shown on its own line under the date; omitted for all-day events.
+        "timezone": "" if event.get("showWithoutTime") else (event.get("timeZone") or ""),
+        "location": "; ".join(locations),
+        "description": event.get("description") or "",
+        "organizer_name": organizer_name or organizer,
+        "organizer_display": f"{organizer_name} ({organizer})" if organizer_name else organizer,
+        "organizer_email": organizer,
+        "attendee_name": (participant or {}).get("name") or "",
+        "meet": _meet_link(event),
+        "rsvp": links,
+        # Invite/update/cancel go out as hand-built MIME with a CID logo part; the response email
+        # (frappe.sendmail) overrides this with an `embed=` reference. See `_render_response`.
+        "logo_src_attr": 'src="cid:eventlogo"',
+    }
 
 
 def _meet_link(event: dict) -> dict | None:
-	"""Returns {url, label} for the event's first Frappe Meet link, or None.
+    """Returns {url, label} for the event's first Frappe Meet link, or None.
 
-	Powers the "Frappe Meet video call" card in the invite/update emails. Uses the same link
-	detection as the .ics CONFERENCE property so the card and the calendar entry never disagree.
-	"""
+    Powers the "Frappe Meet video call" card in the invite/update emails. Uses the same link
+    detection as the .ics CONFERENCE property so the card and the calendar entry never disagree.
+    """
 
-	for link in (event.get("links") or {}).values():
-		href = link.get("href") or ""
-		if is_conference_link(href):
-			return {"url": href, "label": re.sub(r"^https?://", "", href).rstrip("/")}
+    for link in (event.get("links") or {}).values():
+        href = link.get("href") or ""
+        if is_conference_link(href):
+            return {"url": href, "label": re.sub(r"^https?://", "", href).rstrip("/")}
 
-	return None
+    return None
 
 
 def _build_mime(from_name, organizer, to_email, subject, html, ics, method) -> str:
-	"""Builds a multipart/mixed iMIP message: HTML body (with inline logo), text/calendar, .ics.
+    """Builds a multipart/mixed iMIP message: HTML body (with inline logo), text/calendar, .ics.
 
-	The logo is embedded as an inline CID image rather than a remote URL, so it renders in
-	email clients without the recipient having to load external images (and works even when
-	the site isn't publicly reachable).
-	"""
+    The logo is embedded as an inline CID image rather than a remote URL, so it renders in
+    email clients without the recipient having to load external images (and works even when
+    the site isn't publicly reachable).
+    """
 
-	root = MIMEMultipart("mixed")
-	root["Subject"] = subject
-	root["From"] = formataddr((from_name, organizer)) if from_name else organizer
-	root["To"] = to_email
-	root["Date"] = formatdate(localtime=True)
-	root["Message-ID"] = make_msgid()
+    root = MIMEMultipart("mixed")
+    root["Subject"] = subject
+    root["From"] = formataddr((from_name, organizer)) if from_name else organizer
+    root["To"] = to_email
+    root["Date"] = formatdate(localtime=True)
+    root["Message-ID"] = make_msgid()
 
-	alternative = MIMEMultipart("alternative")
-	alternative.attach(MIMEText(strip_html_tags(html), "plain", "utf-8"))
-	alternative.attach(MIMEText(html, "html", "utf-8"))
+    alternative = MIMEMultipart("alternative")
+    alternative.attach(MIMEText(strip_html_tags(html), "plain", "utf-8"))
+    alternative.attach(MIMEText(html, "html", "utf-8"))
 
-	# Inline calendar part carries the iTIP method so clients can offer native controls.
-	inline_calendar = MIMEText(ics, "calendar", "utf-8")
-	inline_calendar.set_param("method", method)
-	inline_calendar.set_param("component", "VEVENT")
-	alternative.attach(inline_calendar)
+    # Inline calendar part carries the iTIP method so clients can offer native controls.
+    inline_calendar = MIMEText(ics, "calendar", "utf-8")
+    inline_calendar.set_param("method", method)
+    inline_calendar.set_param("component", "VEVENT")
+    alternative.attach(inline_calendar)
 
-	# Wrap the body with any inline images the templates reference by CID. The Calendar logo
-	# (`cid:eventlogo`) leads every email; the Frappe Meet logo (`cid:meetlogo`) is attached only
-	# when the body actually shows the Meet card, so no orphan image rides along otherwise.
-	inline_images = []
-	if logo := _image_bytes("public", "calendar", "images", "logo.png"):
-		inline_images.append(("eventlogo", logo))
-	if "cid:meetlogo" in html and (meet_logo := _image_bytes("public", "meet", "images", "meet.png")):
-		inline_images.append(("meetlogo", meet_logo))
+    # Wrap the body with any inline images the templates reference by CID. The Calendar logo
+    # (`cid:eventlogo`) leads every email; the Frappe Meet logo (`cid:meetlogo`) is attached only
+    # when the body actually shows the Meet card, so no orphan image rides along otherwise.
+    inline_images = []
+    if logo := _image_bytes("public", "calendar", "images", "logo.png"):
+        inline_images.append(("eventlogo", logo))
+    if "cid:meetlogo" in html and (meet_logo := _image_bytes("public", "meet", "images", "meet.png")):
+        inline_images.append(("meetlogo", meet_logo))
 
-	if inline_images:
-		related = MIMEMultipart("related")
-		related.attach(alternative)
-		for cid, data in inline_images:
-			image = MIMEImage(data, _subtype="png")
-			image.add_header("Content-ID", f"<{cid}>")
-			image.add_header("Content-Disposition", "inline", filename=f"{cid}.png")
-			related.attach(image)
-		root.attach(related)
-	else:
-		root.attach(alternative)
+    if inline_images:
+        related = MIMEMultipart("related")
+        related.attach(alternative)
+        for cid, data in inline_images:
+            image = MIMEImage(data, _subtype="png")
+            image.add_header("Content-ID", f"<{cid}>")
+            image.add_header("Content-Disposition", "inline", filename=f"{cid}.png")
+            related.attach(image)
+        root.attach(related)
+    else:
+        root.attach(alternative)
 
-	# A downloadable copy so any calendar app can import the event.
-	attachment = MIMEText(ics, "calendar", "utf-8")
-	attachment.set_param("method", method)
-	attachment.add_header("Content-Disposition", "attachment", filename="invite.ics")
-	root.attach(attachment)
+    # A downloadable copy so any calendar app can import the event.
+    attachment = MIMEText(ics, "calendar", "utf-8")
+    attachment.set_param("method", method)
+    attachment.add_header("Content-Disposition", "attachment", filename="invite.ics")
+    root.attach(attachment)
 
-	return root.as_string()
+    return root.as_string()
 
 
 _IMAGE_CACHE: dict[str, bytes] = {}
 
 
 def _image_bytes(*path_parts: str) -> bytes | None:
-	"""Returns an app public image's bytes for inline embedding, cached per process."""
+    """Returns an app public image's bytes for inline embedding, cached per process."""
 
-	key = "/".join(path_parts)
-	if key not in _IMAGE_CACHE:
-		try:
-			with open(frappe.get_app_path("suite", *path_parts), "rb") as f:
-				_IMAGE_CACHE[key] = f.read()
-		except OSError:
-			log_error("Calendar", title=_("Event invite image not found: {0}").format(key))
-			_IMAGE_CACHE[key] = b""
+    key = "/".join(path_parts)
+    if key not in _IMAGE_CACHE:
+        try:
+            with open(frappe.get_app_path("suite", *path_parts), "rb") as f:
+                _IMAGE_CACHE[key] = f.read()
+        except OSError:
+            log_error("Calendar", title=_("Event invite image not found: {0}").format(key))
+            _IMAGE_CACHE[key] = b""
 
-	return _IMAGE_CACHE[key] or None
+    return _IMAGE_CACHE[key] or None
 
 
 def _attendees(event: dict, organizer: str) -> dict[str, dict]:
-	"""Returns {email: {uid, name}} for every participant except the organizer."""
+    """Returns {email: {uid, name}} for every participant except the organizer."""
 
-	attendees = {}
-	for uid, participant in (event.get("participants") or {}).items():
-		email = (participant.get("calendarAddress") or "").lower().replace("mailto:", "")
-		email = email or (participant.get("email") or "").lower()
-		if email and email != organizer:
-			attendees[email] = {"uid": uid, "name": participant.get("name") or email}
+    attendees = {}
+    for uid, participant in (event.get("participants") or {}).items():
+        email = (participant.get("calendarAddress") or "").lower().replace("mailto:", "")
+        email = email or (participant.get("email") or "").lower()
+        if email and email != organizer:
+            attendees[email] = {"uid": uid, "name": participant.get("name") or email}
 
-	return attendees
+    return attendees
 
 
 def _format_when(event: dict) -> str:
-	"""Formats the event start for display, e.g. 'Monday, 21 Jul 2025, 10:00 AM'."""
+    """Formats the event start for display, e.g. 'Monday, 21 Jul 2025, 10:00 AM'."""
 
-	start = _parse_local_datetime(event.get("start"), event.get("timeZone"))
-	if not start:
-		return ""
+    start = _parse_local_datetime(event.get("start"), event.get("timeZone"))
+    if not start:
+        return ""
 
-	if event.get("showWithoutTime"):
-		return start.strftime("%A, %d %b %Y")
+    if event.get("showWithoutTime"):
+        return start.strftime("%A, %d %b %Y")
 
-	# The timezone is surfaced separately (context["timezone"]) so the template can put it on
-	# its own line under the date, matching the design.
-	return start.strftime("%A, %d %b %Y, %I:%M %p")
+    # The timezone is surfaced separately (context["timezone"]) so the template can put it on
+    # its own line under the date, matching the design.
+    return start.strftime("%A, %d %b %Y, %I:%M %p")
 
 
 def _display_name(event: dict, email: str) -> str:
-	"""Returns the participant display name for an email, if the event lists one."""
+    """Returns the participant display name for an email, if the event lists one."""
 
-	for participant in (event.get("participants") or {}).values():
-		address = (participant.get("calendarAddress") or participant.get("email") or "").lower()
-		if address.replace("mailto:", "") == email and participant.get("name"):
-			return participant["name"]
+    for participant in (event.get("participants") or {}).values():
+        address = (participant.get("calendarAddress") or participant.get("email") or "").lower()
+        if address.replace("mailto:", "") == email and participant.get("name"):
+            return participant["name"]
 
-	return ""
+    return ""
 
 
 def _organizer_name(account: str, event: dict, organizer: str) -> str | None:
-	"""Returns the organizer's display name, preferring the sending identity's name.
+    """Returns the organizer's display name, preferring the sending identity's name.
 
-	Falls back to a participant name, then None — never the bare email, so the From header
-	doesn't render as "alice@x.com <alice@x.com>".
-	"""
+    Falls back to a participant name, then None — never the bare email, so the From header
+    doesn't render as "alice@x.com <alice@x.com>".
+    """
 
-	try:
-		for identity in get_identities(account):
-			if identity["email"] == organizer:
-				name = (identity.get("_name") or "").strip()
-				return name if name and name.lower() != organizer else None
-	except Exception:
-		pass
+    try:
+        for identity in get_identities(account):
+            if identity["email"] == organizer:
+                name = (identity.get("_name") or "").strip()
+                return name if name and name.lower() != organizer else None
+    except Exception:
+        pass
 
-	name = _display_name(event, organizer).strip()
-	return name if name and name.lower() != organizer else None
+    name = _display_name(event, organizer).strip()
+    return name if name and name.lower() != organizer else None
 
 
 def _rsvp_expiry(event: dict) -> int:
-	"""Returns the RSVP link expiry as a unix timestamp.
+    """Returns the RSVP link expiry as a unix timestamp.
 
-	Normally the event start plus a grace period. Events with no usable start (e.g. malformed or
-	drafts) fall back to a fixed window from now, so every link expires — a token that never
-	expires is a standing replay of participation-status changes on the organizer's calendar.
-	"""
+    Normally the event start plus a grace period. Events with no usable start (e.g. malformed or
+    drafts) fall back to a fixed window from now, so every link expires — a token that never
+    expires is a standing replay of participation-status changes on the organizer's calendar.
+    """
 
-	start = _parse_local_datetime(event.get("start"), event.get("timeZone"))
-	expiry = (
-		add_to_date(start, days=RSVP_GRACE_DAYS)
-		if start
-		# get_utc_now() is offset-aware, so the timestamp below is a true UTC epoch - matching the
-		# start-derived branch, which is aware too. A naive now_datetime() would be resolved
-		# against the OS timezone instead of the site's.
-		else add_to_date(get_utc_now(), days=RSVP_FALLBACK_DAYS)
-	)
+    start = _parse_local_datetime(event.get("start"), event.get("timeZone"))
+    expiry = (
+        add_to_date(start, days=RSVP_GRACE_DAYS)
+        if start
+        # get_utc_now() is offset-aware, so the timestamp below is a true UTC epoch - matching the
+        # start-derived branch, which is aware too. A naive now_datetime() would be resolved
+        # against the OS timezone instead of the site's.
+        else add_to_date(get_utc_now(), days=RSVP_FALLBACK_DAYS)
+    )
 
-	return int(get_datetime(expiry).timestamp())
+    return int(get_datetime(expiry).timestamp())

--- a/suite/calendar/doctype/calendar_event/invite_templates.py
+++ b/suite/calendar/doctype/calendar_event/invite_templates.py
@@ -12,22 +12,22 @@ TEMPLATE_DIR = "templates/emails"
 # action -> template name (file under TEMPLATE_DIR without the .html extension). "response" is
 # the organizer-facing notification sent when a guest RSVPs; the rest go to the guests.
 DEFAULT_TEMPLATES = {
-	"invite": "event_invite",
-	"update": "event_update",
-	"cancel": "event_cancel",
-	"response": "event_response",
+    "invite": "event_invite",
+    "update": "event_update",
+    "cancel": "event_cancel",
+    "response": "event_response",
 }
 
 # action -> email subject (Jinja string rendered with the invite context)
 DEFAULT_SUBJECTS = {
-	"invite": "Invitation: {{ title }}",
-	"update": "Updated: {{ title }}",
-	"cancel": "Cancelled: {{ title }}",
-	"response": '{{ responder_name }} responded "{{ response_label }}": {{ title }}',
+    "invite": "Invitation: {{ title }}",
+    "update": "Updated: {{ title }}",
+    "cancel": "Cancelled: {{ title }}",
+    "response": '{{ responder_name }} responded "{{ response_label }}": {{ title }}',
 }
 
 
 def template_path(name: str) -> str:
-	"""Returns the app-relative Jinja path for an event email template name."""
+    """Returns the app-relative Jinja path for an event email template name."""
 
-	return f"{TEMPLATE_DIR}/{name}.html"
+    return f"{TEMPLATE_DIR}/{name}.html"

--- a/suite/calendar/doctype/calendar_event/test_calendar_event.py
+++ b/suite/calendar/doctype/calendar_event/test_calendar_event.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestCalendarEvent(IntegrationTestCase):
-	"""
-	Integration tests for CalendarEvent.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for CalendarEvent.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/calendar/doctype/calendar_exchange/calendar_exchange.py
+++ b/suite/calendar/doctype/calendar_exchange/calendar_exchange.py
@@ -15,35 +15,35 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder import Order
 from frappe.utils import (
-	add_to_date,
-	cint,
-	create_batch,
-	get_bench_path,
-	get_datetime,
-	get_files_path,
-	get_url,
-	now,
-	random_string,
-	time_diff_in_seconds,
+    add_to_date,
+    cint,
+    create_batch,
+    get_bench_path,
+    get_datetime,
+    get_files_path,
+    get_url,
+    now,
+    random_string,
+    time_diff_in_seconds,
 )
 
 from suite.mail.doctype.push_subscription.push_subscription import (
-	freeze_jmap_push_notifications,
-	unfreeze_jmap_push_notifications,
+    freeze_jmap_push_notifications,
+    unfreeze_jmap_push_notifications,
 )
 from suite.mail.doctype.user_account.user_account import is_jmap_account_belongs_to_user
 from suite.mail.jmap import get_jmap_connection
 from suite.mail.jmap.services.calendars.calendar import CalendarService
 from suite.mail.jmap.services.calendars.calendar_event import CalendarEventService
 from suite.mail.utils import (
-	get_calendar_export_directory,
-	get_calendar_import_directory,
-	get_config,
+    get_calendar_export_directory,
+    get_calendar_import_directory,
+    get_config,
 )
 from suite.mail.utils.logger import ExchangeLogger, get_exchange_logger
 from suite.mail.utils.user import (
-	get_user_email_address,
-	is_jmap_configured,
+    get_user_email_address,
+    is_jmap_configured,
 )
 from suite.utils import log_error, reconnect_on_failure
 from suite.utils.file import compress_directory, extract_compressed_file
@@ -52,47 +52,47 @@ from suite.utils.user import is_administrator
 
 # JSCalendar (RFC 8984) -> iCalendar (RFC 5545) value maps.
 STATUS_MAP: dict[str, str] = {
-	"confirmed": "CONFIRMED",
-	"tentative": "TENTATIVE",
-	"cancelled": "CANCELLED",
+    "confirmed": "CONFIRMED",
+    "tentative": "TENTATIVE",
+    "cancelled": "CANCELLED",
 }
 PRIVACY_MAP: dict[str, str] = {
-	"public": "PUBLIC",
-	"private": "PRIVATE",
-	"secret": "CONFIDENTIAL",
+    "public": "PUBLIC",
+    "private": "PRIVATE",
+    "secret": "CONFIDENTIAL",
 }
 FREE_BUSY_MAP: dict[str, str] = {
-	"free": "TRANSPARENT",
-	"busy": "OPAQUE",
+    "free": "TRANSPARENT",
+    "busy": "OPAQUE",
 }
 PARTICIPANT_ROLE_MAP: dict[str, str] = {
-	"chair": "CHAIR",
-	"required": "REQ-PARTICIPANT",
-	"attendee": "REQ-PARTICIPANT",
-	"optional": "OPT-PARTICIPANT",
-	"informational": "NON-PARTICIPANT",
+    "chair": "CHAIR",
+    "required": "REQ-PARTICIPANT",
+    "attendee": "REQ-PARTICIPANT",
+    "optional": "OPT-PARTICIPANT",
+    "informational": "NON-PARTICIPANT",
 }
 PARTSTAT_MAP: dict[str, str] = {
-	"needs-action": "NEEDS-ACTION",
-	"accepted": "ACCEPTED",
-	"declined": "DECLINED",
-	"tentative": "TENTATIVE",
-	"delegated": "DELEGATED",
+    "needs-action": "NEEDS-ACTION",
+    "accepted": "ACCEPTED",
+    "declined": "DECLINED",
+    "tentative": "TENTATIVE",
+    "delegated": "DELEGATED",
 }
 CUTYPE_MAP: dict[str, str] = {
-	"individual": "INDIVIDUAL",
-	"group": "GROUP",
-	"resource": "RESOURCE",
-	"location": "ROOM",
+    "individual": "INDIVIDUAL",
+    "group": "GROUP",
+    "resource": "RESOURCE",
+    "location": "ROOM",
 }
 WEEKDAY_MAP: dict[str, str] = {
-	"mo": "MO",
-	"tu": "TU",
-	"we": "WE",
-	"th": "TH",
-	"fr": "FR",
-	"sa": "SA",
-	"su": "SU",
+    "mo": "MO",
+    "tu": "TU",
+    "we": "WE",
+    "th": "TH",
+    "fr": "FR",
+    "sa": "SA",
+    "su": "SU",
 }
 
 # A link URL carrying this path marks a Frappe Meet room. Used both for the RFC 7986 CONFERENCE
@@ -102,1135 +102,1135 @@ CONFERENCE_LABEL = "Frappe Meet"
 
 
 def is_conference_link(href: str | None) -> bool:
-	"""True when a link URL points at a Frappe Meet room (a joinable video call)."""
+    """True when a link URL points at a Frappe Meet room (a joinable video call)."""
 
-	return MEET_LINK_MARKER in (href or "")
+    return MEET_LINK_MARKER in (href or "")
 
 
 # Server-managed / computed properties that must be dropped before re-creating an event,
 # otherwise the JMAP server rejects the "set" call with invalidProperties.
 SERVER_MANAGED_KEYS = (
-	"id",
-	"blobId",
-	"method",
-	"x-href",
-	"created",
-	"updated",
-	"isOrigin",
-	"mayInviteSelf",
-	"mayInviteOthers",
-	"hideAttendees",
+    "id",
+    "blobId",
+    "method",
+    "x-href",
+    "created",
+    "updated",
+    "isOrigin",
+    "mayInviteSelf",
+    "mayInviteOthers",
+    "hideAttendees",
 )
 
 
 class CalendarExchange(OwnerFromUser, Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
-
-	from typing import TYPE_CHECKING
-
-	if TYPE_CHECKING:
-		from frappe.types import DF
-
-		account: DF.Link
-		amended_from: DF.Link | None
-		completed_at: DF.Datetime | None
-		deduplicate_export: DF.Check
-		duration: DF.Float
-		export_archive_type: DF.Literal[".zip", ".tgz", ".tar.gz"]
-		export_filter: DF.JSON | None
-		export_format: DF.Literal["jmap", "ics"]
-		export_limit: DF.Int
-		export_sort: DF.Literal["", "Start (ASC)", "Start (DESC)"]
-		import_file: DF.Attach | None
-		import_format: DF.Literal["ics", "jmap"]
-		import_metadata: DF.JSON | None
-		operation: DF.Literal["", "Import", "Export"]
-		output: DF.Code | None
-		queued_at: DF.Datetime | None
-		retries: DF.Int
-		started_after: DF.Float
-		started_at: DF.Datetime | None
-		status: DF.Literal["Draft", "Queued", "In Progress", "Completed", "Failed", "Cancelled"]
-		user: DF.Link
-	# end: auto-generated types
-
-	@property
-	def max_import(self) -> int:
-		"""Returns the maximum number of events allowed for import."""
-
-		return cint(get_config("exchange_max_import"))
-
-	@property
-	def max_export(self) -> int:
-		"""Returns the maximum number of events allowed for export."""
-
-		return cint(get_config("exchange_max_export"))
-
-	@property
-	def export_filter_dict(self) -> dict:
-		"""Returns the export filter as a dictionary."""
-
-		if self.operation == "Export" and self.export_filter:
-			return json.loads(self.export_filter)
-		return {}
-
-	@property
-	def export_sort_clause(self) -> list[dict]:
-		"""Returns the export sort as a list of dictionaries."""
-
-		if self.operation != "Export":
-			return []
-		if self.export_sort == "Start (DESC)":
-			return [{"property": "start", "isAscending": False}]
-		return [{"property": "start", "isAscending": True}]
-
-	@property
-	def import_metadata_dict(self) -> dict:
-		"""Return the import metadata as a dictionary."""
-
-		if self.operation != "Import" or not self.import_metadata:
-			return {}
-
-		return json.loads(self.import_metadata)
-
-	@property
-	def target_calendar_ids(self) -> dict[str, bool] | None:
-		"""Returns the target calendar IDs for import, if specified."""
-
-		return self.import_metadata_dict.get("calendarIds")
-
-	def autoname(self) -> None:
-		self.name = str(uuid7())
-
-	def validate(self) -> None:
-		if self.is_new():
-			self.validate_account()
-
-		if self.operation == "Import":
-			self.validate_import()
-		elif self.operation == "Export":
-			self.validate_export()
-
-	def before_submit(self) -> None:
-		self.status = "Queued"
-		self.queued_at = now()
-
-	def on_submit(self) -> None:
-		self.process()
-
-	def before_cancel(self) -> None:
-		self.status = "Cancelled"
-
-	def validate_account(self) -> None:
-		"""Validate that the selected user can authenticate and has access to the account."""
-
-		if not is_jmap_configured(self.user):
-			frappe.throw(
-				_("User {0} does not have JMAP settings configured.").format(frappe.bold(self.user)),
-				frappe.PermissionError,
-			)
-
-		is_jmap_account_belongs_to_user(self.account, self.user, raise_exception=True)
-
-	def validate_import(self) -> None:
-		"""Validate the import parameters."""
-
-		if not self.import_format:
-			frappe.throw(_("Import Format is required."))
-		if not self.import_file:
-			frappe.throw(_("Import File is required."))
-
-		allowed_extensions = (".ics", ".zip", ".tgz", ".tar.gz")
-		if not self.import_file.endswith(allowed_extensions):
-			frappe.throw(
-				_("Only {0} files are supported for import.").format(
-					", ".join(f"<code>{ext}</code>" for ext in allowed_extensions)
-				)
-			)
-
-		self._resolve_import_file()
-
-		if self.import_metadata:
-			try:
-				self.import_metadata = json.dumps(json.loads(self.import_metadata), indent=4)
-			except json.JSONDecodeError:
-				frappe.throw(_("Metadata must be valid JSON."))
-
-	def _resolve_import_file(self) -> str:
-		"""Resolves ``import_file`` to an absolute path, refusing anything outside the site's files
-		directories.
-
-		``import_file`` is an ``Attach`` URL (e.g. ``/private/files/calendar.ics``) that the worker
-		joins onto the site path before copying/extracting it. Without this guard a crafted value
-		such as ``/private/files/../../../etc/passwd`` would let the job read a file anywhere on the
-		filesystem, so we canonicalize the path and confirm it stays within the uploads area."""
-
-		path = os.path.realpath(
-			os.path.join(get_bench_path(), f"sites/{frappe.local.site}{self.import_file}")
-		)
-		allowed_roots = (
-			os.path.realpath(get_files_path(is_private=1)),
-			os.path.realpath(get_files_path(is_private=0)),
-		)
-		if not any(path == root or path.startswith(root + os.sep) for root in allowed_roots):
-			frappe.throw(_("Invalid import file path."))
-
-		return path
-
-	def validate_export(self) -> None:
-		"""Validate the export parameters."""
-
-		if self.export_filter:
-			try:
-				self.export_filter = json.dumps(json.loads(self.export_filter), indent=4)
-			except json.JSONDecodeError:
-				frappe.throw(_("Export filter must be valid JSON."))
-
-		if not self.export_archive_type:
-			frappe.throw(_("Archive Type is required."))
-
-		if not self.export_sort:
-			self.export_sort = "Start (ASC)"
-
-		if self.export_limit:
-			export_limit = cint(self.export_limit)
-			if export_limit <= 0:
-				frappe.throw(_("Export Limit must be greater than zero."))
-			if export_limit > self.max_export:
-				frappe.throw(_("Export Limit cannot exceed {0}.").format(self.max_export))
-			self.export_limit = export_limit
-		else:
-			self.export_limit = self.max_export
-
-	def _get_logger(self) -> ExchangeLogger:
-		"""Returns a structured event logger bound to this exchange's context."""
-
-		return get_exchange_logger(
-			{
-				"req_id": random_string(10),
-				"exchange": self.name,
-				"kind": "calendar",
-				"operation": self.operation,
-				"user": self.user,
-				"account": self.account,
-			}
-		)
-
-	def process(self) -> None:
-		"""Enqueue the import or export based on the operation type."""
-
-		logger = self._get_logger()
-
-		if self.operation == "Import":
-			job_id = f"{self.name}:calendar:import"
-			frappe.enqueue_doc(
-				self.doctype,
-				self.name,
-				"_import",
-				queue="long",
-				timeout=cint(get_config("exchange_import_timeout")),
-				job_id=job_id,
-				deduplicate=True,
-				enqueue_after_commit=True,
-			)
-			logger.debug("import-enqueued", job_id=job_id, format=self.import_format)
-		elif self.operation == "Export":
-			job_id = f"{self.name}:calendar:export"
-			frappe.enqueue_doc(
-				self.doctype,
-				self.name,
-				"_export",
-				queue="long",
-				timeout=cint(get_config("exchange_export_timeout")),
-				job_id=job_id,
-				deduplicate=True,
-				enqueue_after_commit=True,
-			)
-			logger.debug("export-enqueued", job_id=job_id, format=self.export_format)
-
-	@frappe.whitelist()
-	def retry(self) -> None:
-		"""Retry the import or export."""
-
-		frappe.only_for("System Manager")
-
-		self._get_logger().info("retry-requested", status=self.status, retries=cint(self.retries))
-
-		if self.docstatus != 1:
-			frappe.throw(_("Only submitted calendar exchange can be retried."))
-		elif self.status not in ["Queued", "In Progress", "Failed"]:
-			frappe.throw(
-				_("Only calendar exchange with status 'Queued', 'In Progress', or 'Failed' can be retried.")
-			)
-
-		if self.operation == "Export":
-			if files := frappe.db.get_all(
-				"File",
-				{
-					"attached_to_doctype": self.doctype,
-					"attached_to_name": self.name,
-					"attached_to_field": "file",
-				},
-				pluck="name",
-			):
-				for file in files:
-					frappe.delete_doc("File", file)
-
-		self._db_set(status="Queued", queued_at=now())
-		self.process()
-
-	@reconnect_on_failure()
-	def _import(self) -> None:
-		"""Imports the calendar events."""
-
-		if self.operation != "Import":
-			return
-
-		logger = self._get_logger()
-		logger.info("import-started", format=self.import_format, import_file=self.import_file)
-
-		freeze_jmap_push_notifications(self.user)
-		self._mark_started()
-		self._log_output(_("Starting import from the uploaded {0} file.").format(self.import_format.upper()))
-
-		import_file = self._resolve_import_file()
-		base_dir = os.path.join(get_calendar_import_directory(), self.name)
-		os.makedirs(base_dir, exist_ok=True)
-
-		kwargs = {}
-		service = None
-		staging_calendar_id = None
-		try:
-			if self.import_format == "ics" and self.import_file.endswith(".ics"):
-				shutil.copy(import_file, os.path.join(base_dir, os.path.basename(import_file)))
-			else:
-				extract_compressed_file(import_file, base_dir)
-			logger.debug("import-source-prepared", base_dir=base_dir)
-			self._log_output(_("Prepared the source files for import."))
-
-			service = get_calendar_event_service(self.user, self.account)
-
-			if self.import_format == "ics":
-				events = self._load_ics_events(service, base_dir, logger)
-			else:
-				events = self._load_jmap_events(base_dir)
-
-			logger.info("import-events-loaded", events=len(events), max_import=self.max_import)
-			self._log_output(_("Found {0} event(s) to import.").format(len(events)))
-
-			if not events:
-				frappe.throw(_("No calendar events found for import."))
-			if len(events) > self.max_import:
-				frappe.throw(_("Import limit exceeded."))
-
-			# Stage everything into one throwaway calendar first, then move it to the destination
-			# calendar(s). A failure before the move leaves nothing scattered across the account: the
-			# staging calendar and every event in it are deleted on rollback.
-			staging_calendar_id = self._create_staging_calendar(service, logger)
-			targets, skipped, failed = self._create_events(service, events, staging_calendar_id, logger)
-
-			# The server rejecting every event is a failure, not a successful zero-import, and must
-			# trigger a rollback.
-			if not targets and failed > 0:
-				frappe.throw(_("Import failed: the server rejected all {0} event(s).").format(failed))
-
-			self._move_to_target_calendars(service, targets, logger)
-			self._discard_staging_calendar(service, staging_calendar_id, logger)
-			staging_calendar_id = None
-
-			created = len(targets)
-			logger.info("import-completed", created=created, skipped=skipped, failed=failed)
-			self._log_output(
-				_("Import completed. {0} created, {1} skipped (already present), {2} failed.").format(
-					created, skipped, failed
-				)
-			)
-			kwargs.update({"status": "Completed"})
-		except Exception:
-			logger.exception("import-failed")
-			self._log_output(_("Import failed. See the error details below."))
-			if staging_calendar_id and service:
-				self._rollback_staging_calendar(service, staging_calendar_id, logger)
-			kwargs.update(
-				{"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
-			)
-		finally:
-			shutil.rmtree(base_dir, ignore_errors=True)
-			unfreeze_jmap_push_notifications(self.user)
-
-		self._mark_completed(**kwargs)
-		self._notify_user(success=kwargs.get("status") == "Completed", action="Import")
-
-	@reconnect_on_failure()
-	def _export(self) -> None:
-		"""Exports the calendar events."""
-
-		if self.operation != "Export":
-			return
-
-		logger = self._get_logger()
-		logger.info("export-started", format=self.export_format, archive_type=self.export_archive_type)
-
-		self._mark_started()
-		self._log_output(_("Starting export to {0} format.").format(self.export_format.upper()))
-		out_dir = os.path.join(get_calendar_export_directory(), self.name)
-		os.makedirs(out_dir, exist_ok=True)
-
-		kwargs = {}
-		try:
-			service = get_calendar_event_service(self.user, self.account)
-
-			limit = min(self.max_export, cint(self.export_limit or self.max_export))
-			data = service.query(self.export_filter_dict, limit=limit, sort=self.export_sort_clause)
-			ids = data.get("ids", [])
-			total = data.get("total")
-			logger.info("export-query-resolved", total=total, fetched=len(ids), max_export=self.max_export)
-			self._log_output(
-				_("Found {0} event(s) matching the filter; exporting up to {1}.").format(
-					total if total is not None else len(ids), len(ids)
-				)
-			)
-
-			if not ids:
-				frappe.throw(_("No calendar events found for export."))
-
-			events = service.get(ids)
-
-			if self.deduplicate_export:
-				fetched = len(events)
-				unique: dict[str, dict] = {}
-				for e in events:
-					key = e.get("uid") or e.get("id")
-					if key not in unique:
-						unique[key] = e
-				events = list(unique.values())
-				logger.debug("export-deduplicated", fetched=fetched, unique=len(events))
-				self._log_output(
-					_("Removed {0} duplicate(s); {1} unique event(s) remain.").format(
-						fetched - len(events), len(events)
-					)
-				)
-
-			calendar_map = {c["id"]: c["name"] for c in service.calendars}
-			CalendarExportWriter.write(self.export_format, events, out_dir, calendar_map)
-			self._log_output(_("Wrote {0} event(s) to the export directory.").format(len(events)))
-
-			self._log_output(
-				_("Packaging exported events into a {0} archive.").format(self.export_archive_type)
-			)
-			self._attach_export(out_dir)
-
-			logger.info("export-completed", events=len(events))
-			self._log_output(_("Export completed successfully. {0} event(s) exported.").format(len(events)))
-			kwargs.update({"status": "Completed"})
-		except Exception:
-			logger.exception("export-failed")
-			self._log_output(_("Export failed. See the error details below."))
-			kwargs.update(
-				{"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
-			)
-		finally:
-			shutil.rmtree(out_dir, ignore_errors=True)
-
-		self._mark_completed(**kwargs)
-		self._notify_user(success=kwargs.get("status") == "Completed", action="Export")
-
-	def _load_ics_events(
-		self, service: CalendarEventService, base_dir: str, logger: ExchangeLogger
-	) -> list[dict]:
-		"""Uploads every .ics file and parses it into JSCalendar events via the JMAP server."""
-
-		ics_files = [
-			os.path.join(root, f)
-			for root, _dirs, files in os.walk(base_dir)
-			for f in files
-			if f.lower().endswith(".ics")
-		]
-		if not ics_files:
-			frappe.throw(_("No .ics files found."))
-
-		blob_to_file: dict[str, str] = {}
-		for path in ics_files:
-			with open(path, "rb") as f:
-				data = f.read()
-			blob_id = service.upload_blob(data, content_type="text/calendar; charset=utf-8").get("blobId")
-			if blob_id:
-				blob_to_file[blob_id] = path
-
-		response = service.parse(list(blob_to_file.keys()))
-
-		events: list[dict] = []
-		for parsed in (response.get("parsed") or {}).values():
-			for event in parsed or []:
-				events.append(event)
-
-		if not_parsable := response.get("notParsable"):
-			logger.warning("import-ics-not-parsable", count=len(not_parsable))
-			self._log_output(_("{0} file(s) could not be parsed and were skipped.").format(len(not_parsable)))
-
-		return events
-
-	def _load_jmap_events(self, base_dir: str) -> list[dict]:
-		"""Loads JSCalendar events from the events.json file in the import directory."""
-
-		path = os.path.join(base_dir, "events.json")
-		if not os.path.exists(path):
-			frappe.throw(_("events.json not found in the import directory."))
-
-		with open(path) as f:
-			events = json.load(f)
-
-		if not isinstance(events, list):
-			frappe.throw(_("events.json must contain a list of calendar events."))
-
-		return events
-
-	def _create_staging_calendar(self, service: CalendarEventService, logger: ExchangeLogger) -> str:
-		"""Creates a temporary calendar (named after this exchange) to stage the import into."""
-
-		self._log_output(_("Creating a temporary calendar to stage the import."))
-		response = CalendarService(service.account, service.connection).create(
-			[{"creation_id": str(uuid7()), "name": self.name, "is_subscribed": False, "is_visible": False}]
-		)
-		created = response.get("created") or {}
-		if not created:
-			frappe.throw(_("Failed to create the staging calendar: {0}").format(response.get("notCreated")))
-
-		staging_calendar_id = next(iter(created.values()))["id"]
-		logger.info("import-staging-calendar-created", calendar=staging_calendar_id)
-		return staging_calendar_id
-
-	def _create_events(
-		self,
-		service: CalendarEventService,
-		events: list[dict],
-		staging_calendar_id: str,
-		logger: ExchangeLogger,
-	) -> tuple[dict[str, dict[str, bool]], int, int]:
-		"""Creates the given JSCalendar events in the staging calendar, skipping any whose UID already
-		exists (idempotency).
-
-		Returns a ``(targets, skipped, failed)`` tuple, where ``targets`` maps each created event's ID
-		to the destination calendarIds it should ultimately land in. Failures within a batch are
-		recorded and the remaining batches continue, so a few malformed events do not abort the whole
-		import."""
-
-		# Idempotency: skip events whose UID is already present in the account.
-		uids = [e["uid"] for e in events if e.get("uid")]
-		existing_uids: set[str] = set()
-		if uids:
-			if existing_ids := service.get_master_ids(uids):
-				existing_uids = {e["uid"] for e in service.get(existing_ids) if e.get("uid")}
-
-		default_calendar_id: str | None = None
-
-		def resolve_calendar_ids(event: dict) -> dict:
-			nonlocal default_calendar_id
-
-			if self.target_calendar_ids:
-				return self.target_calendar_ids
-			if event.get("calendarIds"):
-				return event["calendarIds"]
-			if default_calendar_id is None:
-				default_calendar_id = CalendarService(service.account, service.connection).get_default(
-					raise_exception=True
-				)
-			return {default_calendar_id: True}
-
-		pending: list[dict] = []
-		skipped = 0
-		for event in events:
-			if event.get("uid") and event["uid"] in existing_uids:
-				skipped += 1
-				continue
-			pending.append(event)
-
-		targets: dict[str, dict[str, bool]] = {}
-		failed = 0
-		total = len(pending)
-		for batch in create_batch(pending, service.max_objects_in_set):
-			payload: dict[str, dict] = {}
-			creation_meta: dict[str, tuple[str, dict]] = {}
-			for event in batch:
-				# Resolve the destination before overwriting calendarIds with the staging calendar.
-				destination = resolve_calendar_ids(event)
-				event = {k: v for k, v in event.items() if k not in SERVER_MANAGED_KEYS}
-				event["@type"] = "Event"
-				event["calendarIds"] = {staging_calendar_id: True}
-
-				creation_id = str(uuid7())
-				payload[creation_id] = event
-				creation_meta[creation_id] = (event.get("uid", creation_id), destination)
-
-			response = service._create(payload, sendSchedulingMessages=False)
-			method_responses = response.get("methodResponses") or []
-			result = method_responses[0][1] if method_responses else {}
-
-			batch_failed = result.get("notCreated") or {}
-			failed += len(batch_failed)
-
-			for creation_id, info in (result.get("created") or {}).items():
-				targets[info["id"]] = creation_meta[creation_id][1]
-
-			for creation_id, error in batch_failed.items():
-				logger.warning(
-					"import-event-not-created",
-					uid=creation_meta.get(creation_id, (None,))[0],
-					reason=str(error),
-				)
-
-			self._log_output(_("Staged {0} of {1} event(s).").format(len(targets), total))
-
-		return targets, skipped, failed
-
-	def _move_to_target_calendars(
-		self, service: CalendarEventService, targets: dict[str, dict[str, bool]], logger: ExchangeLogger
-	) -> None:
-		"""Moves the staged events into their destination calendars, replacing the staging calendar.
-
-		This is the commit step: until it runs, every event lives only in the staging calendar, so a
-		failure up to this point rolls back cleanly."""
-
-		if not targets:
-			return
-
-		self._log_output(_("Moving {0} event(s) into the destination calendar(s).").format(len(targets)))
-		result = service.set_calendar_ids(targets)
-
-		if not_updated := result.get("notUpdated"):
-			logger.warning("import-event-not-moved", count=len(not_updated))
-			frappe.throw(
-				_("Failed to move {0} event(s) into the destination calendar(s).").format(len(not_updated))
-			)
-
-		logger.info("import-events-moved", events=len(result.get("updated", [])))
-
-	def _discard_staging_calendar(
-		self, service: CalendarEventService, staging_calendar_id: str, logger: ExchangeLogger
-	) -> None:
-		"""Deletes the now-empty staging calendar after a successful import. A failure here is logged
-		but not fatal: the events are already safely in their destination calendars."""
-
-		try:
-			CalendarService(service.account, service.connection).delete([staging_calendar_id])
-			logger.info("import-staging-calendar-removed", calendar=staging_calendar_id)
-		except Exception:
-			logger.warning("import-staging-calendar-remove-failed", calendar=staging_calendar_id)
-
-	def _rollback_staging_calendar(
-		self, service: CalendarEventService, staging_calendar_id: str, logger: ExchangeLogger
-	) -> None:
-		"""Deletes the staging calendar and every event still staged in it, undoing a failed import."""
-
-		self._log_output(_("Rolling back: removing the staging calendar and any staged events."))
-		try:
-			CalendarService(service.account, service.connection).delete(
-				[staging_calendar_id], remove_events=True
-			)
-			logger.info("import-rolled-back", calendar=staging_calendar_id)
-		except Exception:
-			logger.exception("import-rollback-failed", calendar=staging_calendar_id)
-
-	def _mark_started(self) -> None:
-		"""Marks the calendar exchange as started and updates the started_at and started_after fields."""
-
-		started_at = now()
-		self._db_set(
-			status="In Progress",
-			started_at=started_at,
-			started_after=time_diff_in_seconds(started_at, self.queued_at),
-			output="",
-		)
-
-	def _mark_completed(self, **kwargs) -> None:
-		"""Marks the calendar exchange as completed and updates the completed_at and duration fields."""
-
-		kwargs["completed_at"] = now()
-		kwargs["duration"] = time_diff_in_seconds(kwargs["completed_at"], self.started_at)
-
-		if kwargs["status"] == "Failed":
-			kwargs["retries"] = cint(self.retries) + 1
-
-		self._db_set(**kwargs)
-
-	def _attach_export(self, out_dir: str) -> None:
-		"""Attaches the exported file to the calendar exchange."""
-
-		archive = f"{self.name}{self.export_archive_type}"
-		url = f"/private/files/{archive}"
-		path = os.path.join(get_bench_path(), f"sites/{frappe.local.site}{url}")
-		compress_directory(out_dir, path)
-
-		file = frappe.new_doc("File")
-		file.is_private = 1
-		file.file_url = url
-		file.file_name = archive
-		file.attached_to_doctype = self.doctype
-		file.attached_to_name = self.name
-		file.attached_to_field = "file"
-		file.insert()
-
-		# https://github.com/frappe/frappe/issues/26615
-		frappe.db.set_value("File", file.name, {"file_url": url, "file_name": archive})
-
-	def _notify_user(self, success: bool, action: Literal["Import", "Export"]) -> None:
-		"""Sends notification email to the owner of the calendar exchange."""
-
-		if is_administrator(self.owner):
-			return
-		if not (email := get_user_email_address(self.owner)):
-			return
-
-		subject = _("Calendar Data {0} {1}").format(action, "Completed" if success else "Failed")
-		frappe.publish_realtime(
-			"calendar_exchange_completed",
-			{"action": action, "success": success, "message": subject},
-			user=self.user,
-		)
-		frappe.sendmail(
-			recipients=email,
-			subject=subject,
-			template="generic",
-			args={
-				"title": subject,
-				"description": _("View details for this exchange."),
-				"button": _("View {0}").format(action),
-				"link": get_url(f"/mail/calendar-exchanges/{self.name}"),
-			},
-			now=True,
-		)
-
-	def _log_output(self, message: str) -> None:
-		"""Appends a timestamped, user-friendly line to the `output` field and persists it.
-
-		These messages are surfaced in the UI so the user can follow the progress of the
-		background import/export as it happens."""
-
-		line = f"[{now()}] {message}"
-		self.output = f"{self.output}\n{line}" if self.output else line
-		self._db_set(output=self.output)
-
-	def _db_set(self, **kwargs) -> None:
-		"""Updates the document with the given key-value pairs."""
-
-		self.db_set(kwargs, notify=True, commit=True)
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        account: DF.Link
+        amended_from: DF.Link | None
+        completed_at: DF.Datetime | None
+        deduplicate_export: DF.Check
+        duration: DF.Float
+        export_archive_type: DF.Literal[".zip", ".tgz", ".tar.gz"]
+        export_filter: DF.JSON | None
+        export_format: DF.Literal["jmap", "ics"]
+        export_limit: DF.Int
+        export_sort: DF.Literal["", "Start (ASC)", "Start (DESC)"]
+        import_file: DF.Attach | None
+        import_format: DF.Literal["ics", "jmap"]
+        import_metadata: DF.JSON | None
+        operation: DF.Literal["", "Import", "Export"]
+        output: DF.Code | None
+        queued_at: DF.Datetime | None
+        retries: DF.Int
+        started_after: DF.Float
+        started_at: DF.Datetime | None
+        status: DF.Literal["Draft", "Queued", "In Progress", "Completed", "Failed", "Cancelled"]
+        user: DF.Link
+    # end: auto-generated types
+
+    @property
+    def max_import(self) -> int:
+        """Returns the maximum number of events allowed for import."""
+
+        return cint(get_config("exchange_max_import"))
+
+    @property
+    def max_export(self) -> int:
+        """Returns the maximum number of events allowed for export."""
+
+        return cint(get_config("exchange_max_export"))
+
+    @property
+    def export_filter_dict(self) -> dict:
+        """Returns the export filter as a dictionary."""
+
+        if self.operation == "Export" and self.export_filter:
+            return json.loads(self.export_filter)
+        return {}
+
+    @property
+    def export_sort_clause(self) -> list[dict]:
+        """Returns the export sort as a list of dictionaries."""
+
+        if self.operation != "Export":
+            return []
+        if self.export_sort == "Start (DESC)":
+            return [{"property": "start", "isAscending": False}]
+        return [{"property": "start", "isAscending": True}]
+
+    @property
+    def import_metadata_dict(self) -> dict:
+        """Return the import metadata as a dictionary."""
+
+        if self.operation != "Import" or not self.import_metadata:
+            return {}
+
+        return json.loads(self.import_metadata)
+
+    @property
+    def target_calendar_ids(self) -> dict[str, bool] | None:
+        """Returns the target calendar IDs for import, if specified."""
+
+        return self.import_metadata_dict.get("calendarIds")
+
+    def autoname(self) -> None:
+        self.name = str(uuid7())
+
+    def validate(self) -> None:
+        if self.is_new():
+            self.validate_account()
+
+        if self.operation == "Import":
+            self.validate_import()
+        elif self.operation == "Export":
+            self.validate_export()
+
+    def before_submit(self) -> None:
+        self.status = "Queued"
+        self.queued_at = now()
+
+    def on_submit(self) -> None:
+        self.process()
+
+    def before_cancel(self) -> None:
+        self.status = "Cancelled"
+
+    def validate_account(self) -> None:
+        """Validate that the selected user can authenticate and has access to the account."""
+
+        if not is_jmap_configured(self.user):
+            frappe.throw(
+                _("User {0} does not have JMAP settings configured.").format(frappe.bold(self.user)),
+                frappe.PermissionError,
+            )
+
+        is_jmap_account_belongs_to_user(self.account, self.user, raise_exception=True)
+
+    def validate_import(self) -> None:
+        """Validate the import parameters."""
+
+        if not self.import_format:
+            frappe.throw(_("Import Format is required."))
+        if not self.import_file:
+            frappe.throw(_("Import File is required."))
+
+        allowed_extensions = (".ics", ".zip", ".tgz", ".tar.gz")
+        if not self.import_file.endswith(allowed_extensions):
+            frappe.throw(
+                _("Only {0} files are supported for import.").format(
+                    ", ".join(f"<code>{ext}</code>" for ext in allowed_extensions)
+                )
+            )
+
+        self._resolve_import_file()
+
+        if self.import_metadata:
+            try:
+                self.import_metadata = json.dumps(json.loads(self.import_metadata), indent=4)
+            except json.JSONDecodeError:
+                frappe.throw(_("Metadata must be valid JSON."))
+
+    def _resolve_import_file(self) -> str:
+        """Resolves ``import_file`` to an absolute path, refusing anything outside the site's files
+        directories.
+
+        ``import_file`` is an ``Attach`` URL (e.g. ``/private/files/calendar.ics``) that the worker
+        joins onto the site path before copying/extracting it. Without this guard a crafted value
+        such as ``/private/files/../../../etc/passwd`` would let the job read a file anywhere on the
+        filesystem, so we canonicalize the path and confirm it stays within the uploads area."""
+
+        path = os.path.realpath(
+            os.path.join(get_bench_path(), f"sites/{frappe.local.site}{self.import_file}")
+        )
+        allowed_roots = (
+            os.path.realpath(get_files_path(is_private=1)),
+            os.path.realpath(get_files_path(is_private=0)),
+        )
+        if not any(path == root or path.startswith(root + os.sep) for root in allowed_roots):
+            frappe.throw(_("Invalid import file path."))
+
+        return path
+
+    def validate_export(self) -> None:
+        """Validate the export parameters."""
+
+        if self.export_filter:
+            try:
+                self.export_filter = json.dumps(json.loads(self.export_filter), indent=4)
+            except json.JSONDecodeError:
+                frappe.throw(_("Export filter must be valid JSON."))
+
+        if not self.export_archive_type:
+            frappe.throw(_("Archive Type is required."))
+
+        if not self.export_sort:
+            self.export_sort = "Start (ASC)"
+
+        if self.export_limit:
+            export_limit = cint(self.export_limit)
+            if export_limit <= 0:
+                frappe.throw(_("Export Limit must be greater than zero."))
+            if export_limit > self.max_export:
+                frappe.throw(_("Export Limit cannot exceed {0}.").format(self.max_export))
+            self.export_limit = export_limit
+        else:
+            self.export_limit = self.max_export
+
+    def _get_logger(self) -> ExchangeLogger:
+        """Returns a structured event logger bound to this exchange's context."""
+
+        return get_exchange_logger(
+            {
+                "req_id": random_string(10),
+                "exchange": self.name,
+                "kind": "calendar",
+                "operation": self.operation,
+                "user": self.user,
+                "account": self.account,
+            }
+        )
+
+    def process(self) -> None:
+        """Enqueue the import or export based on the operation type."""
+
+        logger = self._get_logger()
+
+        if self.operation == "Import":
+            job_id = f"{self.name}:calendar:import"
+            frappe.enqueue_doc(
+                self.doctype,
+                self.name,
+                "_import",
+                queue="long",
+                timeout=cint(get_config("exchange_import_timeout")),
+                job_id=job_id,
+                deduplicate=True,
+                enqueue_after_commit=True,
+            )
+            logger.debug("import-enqueued", job_id=job_id, format=self.import_format)
+        elif self.operation == "Export":
+            job_id = f"{self.name}:calendar:export"
+            frappe.enqueue_doc(
+                self.doctype,
+                self.name,
+                "_export",
+                queue="long",
+                timeout=cint(get_config("exchange_export_timeout")),
+                job_id=job_id,
+                deduplicate=True,
+                enqueue_after_commit=True,
+            )
+            logger.debug("export-enqueued", job_id=job_id, format=self.export_format)
+
+    @frappe.whitelist()
+    def retry(self) -> None:
+        """Retry the import or export."""
+
+        frappe.only_for("System Manager")
+
+        self._get_logger().info("retry-requested", status=self.status, retries=cint(self.retries))
+
+        if self.docstatus != 1:
+            frappe.throw(_("Only submitted calendar exchange can be retried."))
+        elif self.status not in ["Queued", "In Progress", "Failed"]:
+            frappe.throw(
+                _("Only calendar exchange with status 'Queued', 'In Progress', or 'Failed' can be retried.")
+            )
+
+        if self.operation == "Export":
+            if files := frappe.db.get_all(
+                "File",
+                {
+                    "attached_to_doctype": self.doctype,
+                    "attached_to_name": self.name,
+                    "attached_to_field": "file",
+                },
+                pluck="name",
+            ):
+                for file in files:
+                    frappe.delete_doc("File", file)
+
+        self._db_set(status="Queued", queued_at=now())
+        self.process()
+
+    @reconnect_on_failure()
+    def _import(self) -> None:
+        """Imports the calendar events."""
+
+        if self.operation != "Import":
+            return
+
+        logger = self._get_logger()
+        logger.info("import-started", format=self.import_format, import_file=self.import_file)
+
+        freeze_jmap_push_notifications(self.user)
+        self._mark_started()
+        self._log_output(_("Starting import from the uploaded {0} file.").format(self.import_format.upper()))
+
+        import_file = self._resolve_import_file()
+        base_dir = os.path.join(get_calendar_import_directory(), self.name)
+        os.makedirs(base_dir, exist_ok=True)
+
+        kwargs = {}
+        service = None
+        staging_calendar_id = None
+        try:
+            if self.import_format == "ics" and self.import_file.endswith(".ics"):
+                shutil.copy(import_file, os.path.join(base_dir, os.path.basename(import_file)))
+            else:
+                extract_compressed_file(import_file, base_dir)
+            logger.debug("import-source-prepared", base_dir=base_dir)
+            self._log_output(_("Prepared the source files for import."))
+
+            service = get_calendar_event_service(self.user, self.account)
+
+            if self.import_format == "ics":
+                events = self._load_ics_events(service, base_dir, logger)
+            else:
+                events = self._load_jmap_events(base_dir)
+
+            logger.info("import-events-loaded", events=len(events), max_import=self.max_import)
+            self._log_output(_("Found {0} event(s) to import.").format(len(events)))
+
+            if not events:
+                frappe.throw(_("No calendar events found for import."))
+            if len(events) > self.max_import:
+                frappe.throw(_("Import limit exceeded."))
+
+            # Stage everything into one throwaway calendar first, then move it to the destination
+            # calendar(s). A failure before the move leaves nothing scattered across the account: the
+            # staging calendar and every event in it are deleted on rollback.
+            staging_calendar_id = self._create_staging_calendar(service, logger)
+            targets, skipped, failed = self._create_events(service, events, staging_calendar_id, logger)
+
+            # The server rejecting every event is a failure, not a successful zero-import, and must
+            # trigger a rollback.
+            if not targets and failed > 0:
+                frappe.throw(_("Import failed: the server rejected all {0} event(s).").format(failed))
+
+            self._move_to_target_calendars(service, targets, logger)
+            self._discard_staging_calendar(service, staging_calendar_id, logger)
+            staging_calendar_id = None
+
+            created = len(targets)
+            logger.info("import-completed", created=created, skipped=skipped, failed=failed)
+            self._log_output(
+                _("Import completed. {0} created, {1} skipped (already present), {2} failed.").format(
+                    created, skipped, failed
+                )
+            )
+            kwargs.update({"status": "Completed"})
+        except Exception:
+            logger.exception("import-failed")
+            self._log_output(_("Import failed. See the error details below."))
+            if staging_calendar_id and service:
+                self._rollback_staging_calendar(service, staging_calendar_id, logger)
+            kwargs.update(
+                {"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
+            )
+        finally:
+            shutil.rmtree(base_dir, ignore_errors=True)
+            unfreeze_jmap_push_notifications(self.user)
+
+        self._mark_completed(**kwargs)
+        self._notify_user(success=kwargs.get("status") == "Completed", action="Import")
+
+    @reconnect_on_failure()
+    def _export(self) -> None:
+        """Exports the calendar events."""
+
+        if self.operation != "Export":
+            return
+
+        logger = self._get_logger()
+        logger.info("export-started", format=self.export_format, archive_type=self.export_archive_type)
+
+        self._mark_started()
+        self._log_output(_("Starting export to {0} format.").format(self.export_format.upper()))
+        out_dir = os.path.join(get_calendar_export_directory(), self.name)
+        os.makedirs(out_dir, exist_ok=True)
+
+        kwargs = {}
+        try:
+            service = get_calendar_event_service(self.user, self.account)
+
+            limit = min(self.max_export, cint(self.export_limit or self.max_export))
+            data = service.query(self.export_filter_dict, limit=limit, sort=self.export_sort_clause)
+            ids = data.get("ids", [])
+            total = data.get("total")
+            logger.info("export-query-resolved", total=total, fetched=len(ids), max_export=self.max_export)
+            self._log_output(
+                _("Found {0} event(s) matching the filter; exporting up to {1}.").format(
+                    total if total is not None else len(ids), len(ids)
+                )
+            )
+
+            if not ids:
+                frappe.throw(_("No calendar events found for export."))
+
+            events = service.get(ids)
+
+            if self.deduplicate_export:
+                fetched = len(events)
+                unique: dict[str, dict] = {}
+                for e in events:
+                    key = e.get("uid") or e.get("id")
+                    if key not in unique:
+                        unique[key] = e
+                events = list(unique.values())
+                logger.debug("export-deduplicated", fetched=fetched, unique=len(events))
+                self._log_output(
+                    _("Removed {0} duplicate(s); {1} unique event(s) remain.").format(
+                        fetched - len(events), len(events)
+                    )
+                )
+
+            calendar_map = {c["id"]: c["name"] for c in service.calendars}
+            CalendarExportWriter.write(self.export_format, events, out_dir, calendar_map)
+            self._log_output(_("Wrote {0} event(s) to the export directory.").format(len(events)))
+
+            self._log_output(
+                _("Packaging exported events into a {0} archive.").format(self.export_archive_type)
+            )
+            self._attach_export(out_dir)
+
+            logger.info("export-completed", events=len(events))
+            self._log_output(_("Export completed successfully. {0} event(s) exported.").format(len(events)))
+            kwargs.update({"status": "Completed"})
+        except Exception:
+            logger.exception("export-failed")
+            self._log_output(_("Export failed. See the error details below."))
+            kwargs.update(
+                {"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
+            )
+        finally:
+            shutil.rmtree(out_dir, ignore_errors=True)
+
+        self._mark_completed(**kwargs)
+        self._notify_user(success=kwargs.get("status") == "Completed", action="Export")
+
+    def _load_ics_events(
+        self, service: CalendarEventService, base_dir: str, logger: ExchangeLogger
+    ) -> list[dict]:
+        """Uploads every .ics file and parses it into JSCalendar events via the JMAP server."""
+
+        ics_files = [
+            os.path.join(root, f)
+            for root, _dirs, files in os.walk(base_dir)
+            for f in files
+            if f.lower().endswith(".ics")
+        ]
+        if not ics_files:
+            frappe.throw(_("No .ics files found."))
+
+        blob_to_file: dict[str, str] = {}
+        for path in ics_files:
+            with open(path, "rb") as f:
+                data = f.read()
+            blob_id = service.upload_blob(data, content_type="text/calendar; charset=utf-8").get("blobId")
+            if blob_id:
+                blob_to_file[blob_id] = path
+
+        response = service.parse(list(blob_to_file.keys()))
+
+        events: list[dict] = []
+        for parsed in (response.get("parsed") or {}).values():
+            for event in parsed or []:
+                events.append(event)
+
+        if not_parsable := response.get("notParsable"):
+            logger.warning("import-ics-not-parsable", count=len(not_parsable))
+            self._log_output(_("{0} file(s) could not be parsed and were skipped.").format(len(not_parsable)))
+
+        return events
+
+    def _load_jmap_events(self, base_dir: str) -> list[dict]:
+        """Loads JSCalendar events from the events.json file in the import directory."""
+
+        path = os.path.join(base_dir, "events.json")
+        if not os.path.exists(path):
+            frappe.throw(_("events.json not found in the import directory."))
+
+        with open(path) as f:
+            events = json.load(f)
+
+        if not isinstance(events, list):
+            frappe.throw(_("events.json must contain a list of calendar events."))
+
+        return events
+
+    def _create_staging_calendar(self, service: CalendarEventService, logger: ExchangeLogger) -> str:
+        """Creates a temporary calendar (named after this exchange) to stage the import into."""
+
+        self._log_output(_("Creating a temporary calendar to stage the import."))
+        response = CalendarService(service.account, service.connection).create(
+            [{"creation_id": str(uuid7()), "name": self.name, "is_subscribed": False, "is_visible": False}]
+        )
+        created = response.get("created") or {}
+        if not created:
+            frappe.throw(_("Failed to create the staging calendar: {0}").format(response.get("notCreated")))
+
+        staging_calendar_id = next(iter(created.values()))["id"]
+        logger.info("import-staging-calendar-created", calendar=staging_calendar_id)
+        return staging_calendar_id
+
+    def _create_events(
+        self,
+        service: CalendarEventService,
+        events: list[dict],
+        staging_calendar_id: str,
+        logger: ExchangeLogger,
+    ) -> tuple[dict[str, dict[str, bool]], int, int]:
+        """Creates the given JSCalendar events in the staging calendar, skipping any whose UID already
+        exists (idempotency).
+
+        Returns a ``(targets, skipped, failed)`` tuple, where ``targets`` maps each created event's ID
+        to the destination calendarIds it should ultimately land in. Failures within a batch are
+        recorded and the remaining batches continue, so a few malformed events do not abort the whole
+        import."""
+
+        # Idempotency: skip events whose UID is already present in the account.
+        uids = [e["uid"] for e in events if e.get("uid")]
+        existing_uids: set[str] = set()
+        if uids:
+            if existing_ids := service.get_master_ids(uids):
+                existing_uids = {e["uid"] for e in service.get(existing_ids) if e.get("uid")}
+
+        default_calendar_id: str | None = None
+
+        def resolve_calendar_ids(event: dict) -> dict:
+            nonlocal default_calendar_id
+
+            if self.target_calendar_ids:
+                return self.target_calendar_ids
+            if event.get("calendarIds"):
+                return event["calendarIds"]
+            if default_calendar_id is None:
+                default_calendar_id = CalendarService(service.account, service.connection).get_default(
+                    raise_exception=True
+                )
+            return {default_calendar_id: True}
+
+        pending: list[dict] = []
+        skipped = 0
+        for event in events:
+            if event.get("uid") and event["uid"] in existing_uids:
+                skipped += 1
+                continue
+            pending.append(event)
+
+        targets: dict[str, dict[str, bool]] = {}
+        failed = 0
+        total = len(pending)
+        for batch in create_batch(pending, service.max_objects_in_set):
+            payload: dict[str, dict] = {}
+            creation_meta: dict[str, tuple[str, dict]] = {}
+            for event in batch:
+                # Resolve the destination before overwriting calendarIds with the staging calendar.
+                destination = resolve_calendar_ids(event)
+                event = {k: v for k, v in event.items() if k not in SERVER_MANAGED_KEYS}
+                event["@type"] = "Event"
+                event["calendarIds"] = {staging_calendar_id: True}
+
+                creation_id = str(uuid7())
+                payload[creation_id] = event
+                creation_meta[creation_id] = (event.get("uid", creation_id), destination)
+
+            response = service._create(payload, sendSchedulingMessages=False)
+            method_responses = response.get("methodResponses") or []
+            result = method_responses[0][1] if method_responses else {}
+
+            batch_failed = result.get("notCreated") or {}
+            failed += len(batch_failed)
+
+            for creation_id, info in (result.get("created") or {}).items():
+                targets[info["id"]] = creation_meta[creation_id][1]
+
+            for creation_id, error in batch_failed.items():
+                logger.warning(
+                    "import-event-not-created",
+                    uid=creation_meta.get(creation_id, (None,))[0],
+                    reason=str(error),
+                )
+
+            self._log_output(_("Staged {0} of {1} event(s).").format(len(targets), total))
+
+        return targets, skipped, failed
+
+    def _move_to_target_calendars(
+        self, service: CalendarEventService, targets: dict[str, dict[str, bool]], logger: ExchangeLogger
+    ) -> None:
+        """Moves the staged events into their destination calendars, replacing the staging calendar.
+
+        This is the commit step: until it runs, every event lives only in the staging calendar, so a
+        failure up to this point rolls back cleanly."""
+
+        if not targets:
+            return
+
+        self._log_output(_("Moving {0} event(s) into the destination calendar(s).").format(len(targets)))
+        result = service.set_calendar_ids(targets)
+
+        if not_updated := result.get("notUpdated"):
+            logger.warning("import-event-not-moved", count=len(not_updated))
+            frappe.throw(
+                _("Failed to move {0} event(s) into the destination calendar(s).").format(len(not_updated))
+            )
+
+        logger.info("import-events-moved", events=len(result.get("updated", [])))
+
+    def _discard_staging_calendar(
+        self, service: CalendarEventService, staging_calendar_id: str, logger: ExchangeLogger
+    ) -> None:
+        """Deletes the now-empty staging calendar after a successful import. A failure here is logged
+        but not fatal: the events are already safely in their destination calendars."""
+
+        try:
+            CalendarService(service.account, service.connection).delete([staging_calendar_id])
+            logger.info("import-staging-calendar-removed", calendar=staging_calendar_id)
+        except Exception:
+            logger.warning("import-staging-calendar-remove-failed", calendar=staging_calendar_id)
+
+    def _rollback_staging_calendar(
+        self, service: CalendarEventService, staging_calendar_id: str, logger: ExchangeLogger
+    ) -> None:
+        """Deletes the staging calendar and every event still staged in it, undoing a failed import."""
+
+        self._log_output(_("Rolling back: removing the staging calendar and any staged events."))
+        try:
+            CalendarService(service.account, service.connection).delete(
+                [staging_calendar_id], remove_events=True
+            )
+            logger.info("import-rolled-back", calendar=staging_calendar_id)
+        except Exception:
+            logger.exception("import-rollback-failed", calendar=staging_calendar_id)
+
+    def _mark_started(self) -> None:
+        """Marks the calendar exchange as started and updates the started_at and started_after fields."""
+
+        started_at = now()
+        self._db_set(
+            status="In Progress",
+            started_at=started_at,
+            started_after=time_diff_in_seconds(started_at, self.queued_at),
+            output="",
+        )
+
+    def _mark_completed(self, **kwargs) -> None:
+        """Marks the calendar exchange as completed and updates the completed_at and duration fields."""
+
+        kwargs["completed_at"] = now()
+        kwargs["duration"] = time_diff_in_seconds(kwargs["completed_at"], self.started_at)
+
+        if kwargs["status"] == "Failed":
+            kwargs["retries"] = cint(self.retries) + 1
+
+        self._db_set(**kwargs)
+
+    def _attach_export(self, out_dir: str) -> None:
+        """Attaches the exported file to the calendar exchange."""
+
+        archive = f"{self.name}{self.export_archive_type}"
+        url = f"/private/files/{archive}"
+        path = os.path.join(get_bench_path(), f"sites/{frappe.local.site}{url}")
+        compress_directory(out_dir, path)
+
+        file = frappe.new_doc("File")
+        file.is_private = 1
+        file.file_url = url
+        file.file_name = archive
+        file.attached_to_doctype = self.doctype
+        file.attached_to_name = self.name
+        file.attached_to_field = "file"
+        file.insert()
+
+        # https://github.com/frappe/frappe/issues/26615
+        frappe.db.set_value("File", file.name, {"file_url": url, "file_name": archive})
+
+    def _notify_user(self, success: bool, action: Literal["Import", "Export"]) -> None:
+        """Sends notification email to the owner of the calendar exchange."""
+
+        if is_administrator(self.owner):
+            return
+        if not (email := get_user_email_address(self.owner)):
+            return
+
+        subject = _("Calendar Data {0} {1}").format(action, "Completed" if success else "Failed")
+        frappe.publish_realtime(
+            "calendar_exchange_completed",
+            {"action": action, "success": success, "message": subject},
+            user=self.user,
+        )
+        frappe.sendmail(
+            recipients=email,
+            subject=subject,
+            template="generic",
+            args={
+                "title": subject,
+                "description": _("View details for this exchange."),
+                "button": _("View {0}").format(action),
+                "link": get_url(f"/mail/calendar-exchanges/{self.name}"),
+            },
+            now=True,
+        )
+
+    def _log_output(self, message: str) -> None:
+        """Appends a timestamped, user-friendly line to the `output` field and persists it.
+
+        These messages are surfaced in the UI so the user can follow the progress of the
+        background import/export as it happens."""
+
+        line = f"[{now()}] {message}"
+        self.output = f"{self.output}\n{line}" if self.output else line
+        self._db_set(output=self.output)
+
+    def _db_set(self, **kwargs) -> None:
+        """Updates the document with the given key-value pairs."""
+
+        self.db_set(kwargs, notify=True, commit=True)
 
 
 class CalendarExportWriter:
-	@classmethod
-	def write(
-		cls,
-		format: Literal["jmap", "ics"],
-		events: list[dict],
-		out_dir: str,
-		calendar_map: dict[str, str],
-	) -> None:
-		"""Writes the exported events in the specified format."""
+    @classmethod
+    def write(
+        cls,
+        format: Literal["jmap", "ics"],
+        events: list[dict],
+        out_dir: str,
+        calendar_map: dict[str, str],
+    ) -> None:
+        """Writes the exported events in the specified format."""
 
-		writers = {
-			"jmap": cls._jmap,
-			"ics": cls._ics,
-		}
+        writers = {
+            "jmap": cls._jmap,
+            "ics": cls._ics,
+        }
 
-		if format not in writers:
-			frappe.throw(_("Unsupported export format: {0}").format(format))
+        if format not in writers:
+            frappe.throw(_("Unsupported export format: {0}").format(format))
 
-		writers[format](events, out_dir, calendar_map)
+        writers[format](events, out_dir, calendar_map)
 
-	@staticmethod
-	def _jmap(events: list[dict], out_dir: str, calendar_map: dict[str, str]) -> None:
-		"""Writes the raw JSCalendar events and the calendar map (fully round-trippable)."""
+    @staticmethod
+    def _jmap(events: list[dict], out_dir: str, calendar_map: dict[str, str]) -> None:
+        """Writes the raw JSCalendar events and the calendar map (fully round-trippable)."""
 
-		with open(os.path.join(out_dir, "events.json"), "w") as f:
-			json.dump(events, f, indent=4)
+        with open(os.path.join(out_dir, "events.json"), "w") as f:
+            json.dump(events, f, indent=4)
 
-		with open(os.path.join(out_dir, "calendars.json"), "w") as f:
-			json.dump(calendar_map, f, indent=4)
+        with open(os.path.join(out_dir, "calendars.json"), "w") as f:
+            json.dump(calendar_map, f, indent=4)
 
-	@staticmethod
-	def _ics(events: list[dict], out_dir: str, calendar_map: dict[str, str]) -> None:
-		"""Writes one VCALENDAR file per calendar, mirroring mbox's one-file-per-mailbox layout."""
+    @staticmethod
+    def _ics(events: list[dict], out_dir: str, calendar_map: dict[str, str]) -> None:
+        """Writes one VCALENDAR file per calendar, mirroring mbox's one-file-per-mailbox layout."""
 
-		from icalendar import Calendar
+        from icalendar import Calendar
 
-		def safe_name(name: str) -> str:
-			return (
-				"".join(c if c.isalnum() or c in (" ", "-", "_") else "_" for c in name).strip() or "calendar"
-			)
+        def safe_name(name: str) -> str:
+            return (
+                "".join(c if c.isalnum() or c in (" ", "-", "_") else "_" for c in name).strip() or "calendar"
+            )
 
-		# Group events by the calendars they belong to (an event can live in several).
-		by_calendar: dict[str, list[dict]] = {}
-		for event in events:
-			calendar_ids = list((event.get("calendarIds") or {}).keys()) or ["__default__"]
-			for calendar_id in calendar_ids:
-				by_calendar.setdefault(calendar_id, []).append(event)
+        # Group events by the calendars they belong to (an event can live in several).
+        by_calendar: dict[str, list[dict]] = {}
+        for event in events:
+            calendar_ids = list((event.get("calendarIds") or {}).keys()) or ["__default__"]
+            for calendar_id in calendar_ids:
+                by_calendar.setdefault(calendar_id, []).append(event)
 
-		used_names: set[str] = set()
-		for calendar_id, calendar_events in by_calendar.items():
-			calendar_name = calendar_map.get(calendar_id, "Calendar")
-			cal = Calendar()
-			cal.add("prodid", "-//Frappe Mail//Calendar Exchange//EN")
-			cal.add("version", "2.0")
-			cal.add("method", "PUBLISH")
+        used_names: set[str] = set()
+        for calendar_id, calendar_events in by_calendar.items():
+            calendar_name = calendar_map.get(calendar_id, "Calendar")
+            cal = Calendar()
+            cal.add("prodid", "-//Frappe Mail//Calendar Exchange//EN")
+            cal.add("version", "2.0")
+            cal.add("method", "PUBLISH")
 
-			for event in calendar_events:
-				categories = [
-					calendar_map[cid] for cid in (event.get("calendarIds") or {}) if cid in calendar_map
-				]
-				for component in _build_components(event, categories):
-					cal.add_component(component)
+            for event in calendar_events:
+                categories = [
+                    calendar_map[cid] for cid in (event.get("calendarIds") or {}) if cid in calendar_map
+                ]
+                for component in _build_components(event, categories):
+                    cal.add_component(component)
 
-			file_name = safe_name(calendar_name)
-			candidate = file_name
-			suffix = 1
-			while candidate in used_names:
-				suffix += 1
-				candidate = f"{file_name}_{suffix}"
-			used_names.add(candidate)
+            file_name = safe_name(calendar_name)
+            candidate = file_name
+            suffix = 1
+            while candidate in used_names:
+                suffix += 1
+                candidate = f"{file_name}_{suffix}"
+            used_names.add(candidate)
 
-			with open(os.path.join(out_dir, f"{candidate}.ics"), "wb") as f:
-				f.write(cal.to_ical())
+            with open(os.path.join(out_dir, f"{candidate}.ics"), "wb") as f:
+                f.write(cal.to_ical())
 
 
 def get_calendar_event_service(
-	user: str,
-	account: str,
-	ignore_permissions: bool = False,
+    user: str,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> CalendarEventService:
-	"""Returns a CalendarEventService configured with the longer exchange timeouts."""
+    """Returns a CalendarEventService configured with the longer exchange timeouts."""
 
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions, timeout=(60.0, 180.0))
-	return CalendarEventService(account, connection)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions, timeout=(60.0, 180.0))
+    return CalendarEventService(account, connection)
 
 
 def _parse_local_datetime(value: str | None, time_zone: str | None) -> datetime | None:
-	"""Parses a JSCalendar LocalDateTime string into a (possibly timezone-aware) datetime."""
+    """Parses a JSCalendar LocalDateTime string into a (possibly timezone-aware) datetime."""
 
-	if not value:
-		return None
+    if not value:
+        return None
 
-	dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
-	if dt.tzinfo is None and time_zone:
-		try:
-			dt = dt.replace(tzinfo=ZoneInfo(time_zone))
-		except Exception:
-			pass
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if dt.tzinfo is None and time_zone:
+        try:
+            dt = dt.replace(tzinfo=ZoneInfo(time_zone))
+        except Exception:
+            pass
 
-	return dt
+    return dt
 
 
 def _parse_duration(value: str | None, start: datetime | None) -> timedelta | None:
-	"""Parses an ISO 8601 duration string into a timedelta."""
+    """Parses an ISO 8601 duration string into a timedelta."""
 
-	if not value:
-		return None
+    if not value:
+        return None
 
-	try:
-		duration = isodate.parse_duration(value)
-	except Exception:
-		return None
+    try:
+        duration = isodate.parse_duration(value)
+    except Exception:
+        return None
 
-	if isinstance(duration, timedelta):
-		return duration
+    if isinstance(duration, timedelta):
+        return duration
 
-	# isodate.Duration (carries months/years): resolve against the start when available.
-	try:
-		return duration.totimedelta(start=start or datetime(2000, 1, 1))
-	except Exception:
-		return None
+    # isodate.Duration (carries months/years): resolve against the start when available.
+    try:
+        return duration.totimedelta(start=start or datetime(2000, 1, 1))
+    except Exception:
+        return None
 
 
 def _build_recurrence_rule(rule: dict) -> dict | None:
-	"""Converts a JSCalendar RecurrenceRule object into an iCalendar RRULE value dict."""
+    """Converts a JSCalendar RecurrenceRule object into an iCalendar RRULE value dict."""
 
-	if not rule:
-		return None
+    if not rule:
+        return None
 
-	recur: dict[str, list] = {}
+    recur: dict[str, list] = {}
 
-	if frequency := rule.get("frequency"):
-		recur["FREQ"] = [frequency.upper()]
-	if (interval := rule.get("interval")) and cint(interval) > 1:
-		recur["INTERVAL"] = [cint(interval)]
-	if count := rule.get("count"):
-		recur["COUNT"] = [cint(count)]
-	if until := rule.get("until"):
-		parsed = _parse_local_datetime(until, None)
-		if parsed:
-			recur["UNTIL"] = [parsed]
-	if first_day := rule.get("firstDayOfWeek"):
-		if mapped := WEEKDAY_MAP.get(first_day.lower()):
-			recur["WKST"] = [mapped]
+    if frequency := rule.get("frequency"):
+        recur["FREQ"] = [frequency.upper()]
+    if (interval := rule.get("interval")) and cint(interval) > 1:
+        recur["INTERVAL"] = [cint(interval)]
+    if count := rule.get("count"):
+        recur["COUNT"] = [cint(count)]
+    if until := rule.get("until"):
+        parsed = _parse_local_datetime(until, None)
+        if parsed:
+            recur["UNTIL"] = [parsed]
+    if first_day := rule.get("firstDayOfWeek"):
+        if mapped := WEEKDAY_MAP.get(first_day.lower()):
+            recur["WKST"] = [mapped]
 
-	if by_day := rule.get("byDay"):
-		days = []
-		for nday in by_day:
-			day = WEEKDAY_MAP.get((nday.get("day") or "").lower())
-			if not day:
-				continue
-			nth = nday.get("nthOfPeriod")
-			days.append(f"{nth}{day}" if nth else day)
-		if days:
-			recur["BYDAY"] = days
+    if by_day := rule.get("byDay"):
+        days = []
+        for nday in by_day:
+            day = WEEKDAY_MAP.get((nday.get("day") or "").lower())
+            if not day:
+                continue
+            nth = nday.get("nthOfPeriod")
+            days.append(f"{nth}{day}" if nth else day)
+        if days:
+            recur["BYDAY"] = days
 
-	scalar_map = {
-		"byMonthDay": "BYMONTHDAY",
-		"byMonth": "BYMONTH",
-		"byYearDay": "BYYEARDAY",
-		"byWeekNo": "BYWEEKNO",
-		"byHour": "BYHOUR",
-		"byMinute": "BYMINUTE",
-		"bySecond": "BYSECOND",
-		"bySetPosition": "BYSETPOS",
-	}
-	for js_key, ical_key in scalar_map.items():
-		if values := rule.get(js_key):
-			recur[ical_key] = list(values)
+    scalar_map = {
+        "byMonthDay": "BYMONTHDAY",
+        "byMonth": "BYMONTH",
+        "byYearDay": "BYYEARDAY",
+        "byWeekNo": "BYWEEKNO",
+        "byHour": "BYHOUR",
+        "byMinute": "BYMINUTE",
+        "bySecond": "BYSECOND",
+        "bySetPosition": "BYSETPOS",
+    }
+    for js_key, ical_key in scalar_map.items():
+        if values := rule.get(js_key):
+            recur[ical_key] = list(values)
 
-	return recur or None
+    return recur or None
 
 
 def _add_participants(component, participants: dict) -> None:
-	"""Adds ATTENDEE properties to a VEVENT from a JSCalendar participants map."""
+    """Adds ATTENDEE properties to a VEVENT from a JSCalendar participants map."""
 
-	from icalendar import vCalAddress
+    from icalendar import vCalAddress
 
-	for participant in (participants or {}).values():
-		address = participant.get("calendarAddress") or (
-			f"mailto:{participant['email']}" if participant.get("email") else None
-		)
-		if not address:
-			continue
+    for participant in (participants or {}).values():
+        address = participant.get("calendarAddress") or (
+            f"mailto:{participant['email']}" if participant.get("email") else None
+        )
+        if not address:
+            continue
 
-		attendee = vCalAddress(address)
-		if name := participant.get("name"):
-			attendee.params["CN"] = name
+        attendee = vCalAddress(address)
+        if name := participant.get("name"):
+            attendee.params["CN"] = name
 
-		roles = participant.get("roles") or {}
-		role = next((PARTICIPANT_ROLE_MAP[r] for r in roles if r in PARTICIPANT_ROLE_MAP), None)
-		if role:
-			attendee.params["ROLE"] = role
+        roles = participant.get("roles") or {}
+        role = next((PARTICIPANT_ROLE_MAP[r] for r in roles if r in PARTICIPANT_ROLE_MAP), None)
+        if role:
+            attendee.params["ROLE"] = role
 
-		if kind := participant.get("kind"):
-			if cutype := CUTYPE_MAP.get(kind.lower()):
-				attendee.params["CUTYPE"] = cutype
+        if kind := participant.get("kind"):
+            if cutype := CUTYPE_MAP.get(kind.lower()):
+                attendee.params["CUTYPE"] = cutype
 
-		if partstat := participant.get("participationStatus"):
-			if mapped := PARTSTAT_MAP.get(partstat.lower()):
-				attendee.params["PARTSTAT"] = mapped
+        if partstat := participant.get("participationStatus"):
+            if mapped := PARTSTAT_MAP.get(partstat.lower()):
+                attendee.params["PARTSTAT"] = mapped
 
-		attendee.params["RSVP"] = "TRUE" if participant.get("expectReply") else "FALSE"
+        attendee.params["RSVP"] = "TRUE" if participant.get("expectReply") else "FALSE"
 
-		component.add("attendee", attendee, encode=0)
+        component.add("attendee", attendee, encode=0)
 
 
 def _add_alarms(component, alerts: dict) -> None:
-	"""Adds VALARM sub-components to a VEVENT from a JSCalendar alerts map."""
+    """Adds VALARM sub-components to a VEVENT from a JSCalendar alerts map."""
 
-	from icalendar import Alarm
+    from icalendar import Alarm
 
-	for alert in (alerts or {}).values():
-		action = (alert.get("action") or "display").upper()
-		if action not in ("DISPLAY", "EMAIL", "AUDIO"):
-			action = "DISPLAY"
+    for alert in (alerts or {}).values():
+        action = (alert.get("action") or "display").upper()
+        if action not in ("DISPLAY", "EMAIL", "AUDIO"):
+            action = "DISPLAY"
 
-		trigger = alert.get("trigger") or {}
-		alarm = Alarm()
-		alarm.add("action", action)
+        trigger = alert.get("trigger") or {}
+        alarm = Alarm()
+        alarm.add("action", action)
 
-		trigger_type = trigger.get("@type")
-		if trigger_type == "AbsoluteTrigger" and trigger.get("when"):
-			when = _parse_local_datetime(trigger["when"], None)
-			if when:
-				alarm.add("trigger", when)
-		else:
-			offset = _parse_duration(trigger.get("offset", "-PT10M"), None)
-			if offset is None:
-				offset = timedelta(minutes=-10)
-			related = (trigger.get("relativeTo") or "start").upper()
-			alarm.add("trigger", offset, parameters={"RELATED": related})
+        trigger_type = trigger.get("@type")
+        if trigger_type == "AbsoluteTrigger" and trigger.get("when"):
+            when = _parse_local_datetime(trigger["when"], None)
+            if when:
+                alarm.add("trigger", when)
+        else:
+            offset = _parse_duration(trigger.get("offset", "-PT10M"), None)
+            if offset is None:
+                offset = timedelta(minutes=-10)
+            related = (trigger.get("relativeTo") or "start").upper()
+            alarm.add("trigger", offset, parameters={"RELATED": related})
 
-		# DISPLAY/EMAIL alarms require a description per RFC 5545.
-		alarm.add("description", component.get("summary") or "Reminder")
-		if action == "EMAIL":
-			alarm.add("summary", component.get("summary") or "Reminder")
+        # DISPLAY/EMAIL alarms require a description per RFC 5545.
+        alarm.add("description", component.get("summary") or "Reminder")
+        if action == "EMAIL":
+            alarm.add("summary", component.get("summary") or "Reminder")
 
-		component.add_component(alarm)
+        component.add_component(alarm)
 
 
 def jscalendar_to_vevent(event: dict, categories: list[str] | None = None):
-	"""Converts a single JSCalendar Event object into an iCalendar VEVENT component.
+    """Converts a single JSCalendar Event object into an iCalendar VEVENT component.
 
-	Recurrence overrides are NOT applied here; :func:`_build_components` handles those by
-	emitting the master event plus per-instance override components."""
+    Recurrence overrides are NOT applied here; :func:`_build_components` handles those by
+    emitting the master event plus per-instance override components."""
 
-	from icalendar import Event, vText, vUri
+    from icalendar import Event, vText, vUri
 
-	component = Event()
+    component = Event()
 
-	if uid := event.get("uid"):
-		component.add("uid", uid)
+    if uid := event.get("uid"):
+        component.add("uid", uid)
 
-	if title := event.get("title"):
-		component.add("summary", title)
-	if description := event.get("description"):
-		component.add("description", description)
+    if title := event.get("title"):
+        component.add("summary", title)
+    if description := event.get("description"):
+        component.add("description", description)
 
-	time_zone = event.get("timeZone")
-	start = _parse_local_datetime(event.get("start"), time_zone)
-	if start:
-		if event.get("showWithoutTime"):
-			component.add("dtstart", start.date())
-		else:
-			component.add("dtstart", start)
+    time_zone = event.get("timeZone")
+    start = _parse_local_datetime(event.get("start"), time_zone)
+    if start:
+        if event.get("showWithoutTime"):
+            component.add("dtstart", start.date())
+        else:
+            component.add("dtstart", start)
 
-	duration = _parse_duration(event.get("duration"), start)
-	if duration is not None:
-		if event.get("showWithoutTime"):
-			# All-day events use a DATE-valued DTEND (exclusive) for broad client compatibility.
-			if start:
-				component.add("dtend", (start + (duration or timedelta(days=1))).date())
-		else:
-			component.add("duration", duration)
+    duration = _parse_duration(event.get("duration"), start)
+    if duration is not None:
+        if event.get("showWithoutTime"):
+            # All-day events use a DATE-valued DTEND (exclusive) for broad client compatibility.
+            if start:
+                component.add("dtend", (start + (duration or timedelta(days=1))).date())
+        else:
+            component.add("duration", duration)
 
-	if (status := event.get("status")) and status.lower() in STATUS_MAP:
-		component.add("status", STATUS_MAP[status.lower()])
-	if (privacy := event.get("privacy")) and privacy.lower() in PRIVACY_MAP:
-		component.add("class", PRIVACY_MAP[privacy.lower()])
-	if (free_busy := event.get("freeBusyStatus")) and free_busy.lower() in FREE_BUSY_MAP:
-		component.add("transp", FREE_BUSY_MAP[free_busy.lower()])
+    if (status := event.get("status")) and status.lower() in STATUS_MAP:
+        component.add("status", STATUS_MAP[status.lower()])
+    if (privacy := event.get("privacy")) and privacy.lower() in PRIVACY_MAP:
+        component.add("class", PRIVACY_MAP[privacy.lower()])
+    if (free_busy := event.get("freeBusyStatus")) and free_busy.lower() in FREE_BUSY_MAP:
+        component.add("transp", FREE_BUSY_MAP[free_busy.lower()])
 
-	if organizer := event.get("organizerCalendarAddress"):
-		component.add("organizer", vText(organizer))
+    if organizer := event.get("organizerCalendarAddress"):
+        component.add("organizer", vText(organizer))
 
-	locations = [l.get("name") for l in (event.get("locations") or {}).values() if l.get("name")]
-	if locations:
-		component.add("location", "; ".join(locations))
+    locations = [l.get("name") for l in (event.get("locations") or {}).values() if l.get("name")]
+    if locations:
+        component.add("location", "; ".join(locations))
 
-	url_added = False
-	for link in (event.get("links") or {}).values():
-		href = link.get("href")
-		if not href:
-			continue
-		if not url_added:
-			component.add("url", href)
-			url_added = True
-		# RFC 7986 CONFERENCE lets Google/Apple/Outlook render a native "Join" button for the
-		# video call; a plain URL property gets buried. Emitted alongside URL, not instead of it.
-		if is_conference_link(href):
-			component.add(
-				"conference",
-				vUri(href),
-				parameters={"VALUE": "URI", "FEATURE": "VIDEO", "LABEL": CONFERENCE_LABEL},
-			)
+    url_added = False
+    for link in (event.get("links") or {}).values():
+        href = link.get("href")
+        if not href:
+            continue
+        if not url_added:
+            component.add("url", href)
+            url_added = True
+        # RFC 7986 CONFERENCE lets Google/Apple/Outlook render a native "Join" button for the
+        # video call; a plain URL property gets buried. Emitted alongside URL, not instead of it.
+        if is_conference_link(href):
+            component.add(
+                "conference",
+                vUri(href),
+                parameters={"VALUE": "URI", "FEATURE": "VIDEO", "LABEL": CONFERENCE_LABEL},
+            )
 
-	if categories:
-		component.add("categories", categories)
+    if categories:
+        component.add("categories", categories)
 
-	recurrence_rule = event.get("recurrenceRule")
-	if isinstance(recurrence_rule, list):
-		recurrence_rule = recurrence_rule[0] if recurrence_rule else None
-	if recur := _build_recurrence_rule(recurrence_rule):
-		component.add("rrule", recur)
+    recurrence_rule = event.get("recurrenceRule")
+    if isinstance(recurrence_rule, list):
+        recurrence_rule = recurrence_rule[0] if recurrence_rule else None
+    if recur := _build_recurrence_rule(recurrence_rule):
+        component.add("rrule", recur)
 
-	created = _parse_local_datetime(event.get("created"), None)
-	updated = _parse_local_datetime(event.get("updated"), None)
-	if created:
-		component.add("created", created)
-	if updated:
-		component.add("last-modified", updated)
-	component.add("dtstamp", updated or created or datetime.now(UTC))
+    created = _parse_local_datetime(event.get("created"), None)
+    updated = _parse_local_datetime(event.get("updated"), None)
+    if created:
+        component.add("created", created)
+    if updated:
+        component.add("last-modified", updated)
+    component.add("dtstamp", updated or created or datetime.now(UTC))
 
-	if (sequence := event.get("sequence")) is not None:
-		component.add("sequence", cint(sequence))
+    if (sequence := event.get("sequence")) is not None:
+        component.add("sequence", cint(sequence))
 
-	_add_participants(component, event.get("participants"))
-	_add_alarms(component, event.get("alerts"))
+    _add_participants(component, event.get("participants"))
+    _add_alarms(component, event.get("alerts"))
 
-	return component
+    return component
 
 
 def _build_components(event: dict, categories: list[str] | None = None) -> list:
-	"""Builds the VEVENT component(s) for an event: the master plus any recurrence overrides.
+    """Builds the VEVENT component(s) for an event: the master plus any recurrence overrides.
 
-	Excluded instances become EXDATE entries on the master; modified instances become separate
-	VEVENT components sharing the UID and carrying RECURRENCE-ID."""
+    Excluded instances become EXDATE entries on the master; modified instances become separate
+    VEVENT components sharing the UID and carrying RECURRENCE-ID."""
 
-	master = jscalendar_to_vevent(event, categories)
-	components = [master]
+    master = jscalendar_to_vevent(event, categories)
+    components = [master]
 
-	overrides = event.get("recurrenceOverrides") or {}
-	time_zone = event.get("timeZone")
-	excluded: list = []
+    overrides = event.get("recurrenceOverrides") or {}
+    time_zone = event.get("timeZone")
+    excluded: list = []
 
-	for recurrence_id, patch in overrides.items():
-		instance_dt = _parse_local_datetime(recurrence_id, time_zone)
-		if instance_dt is None:
-			continue
+    for recurrence_id, patch in overrides.items():
+        instance_dt = _parse_local_datetime(recurrence_id, time_zone)
+        if instance_dt is None:
+            continue
 
-		if patch.get("excluded"):
-			excluded.append(instance_dt.date() if event.get("showWithoutTime") else instance_dt)
-			continue
+        if patch.get("excluded"):
+            excluded.append(instance_dt.date() if event.get("showWithoutTime") else instance_dt)
+            continue
 
-		# A modified instance: merge the master with the patch, drop the recurrence machinery,
-		# and tag it with RECURRENCE-ID so clients reconcile it against the series.
-		merged = {k: v for k, v in event.items() if k not in ("recurrenceRule", "recurrenceOverrides")}
-		merged.update(patch)
-		override = jscalendar_to_vevent(merged, categories)
-		if event.get("showWithoutTime"):
-			override.add("recurrence-id", instance_dt.date())
-		else:
-			override.add("recurrence-id", instance_dt)
-		components.append(override)
+        # A modified instance: merge the master with the patch, drop the recurrence machinery,
+        # and tag it with RECURRENCE-ID so clients reconcile it against the series.
+        merged = {k: v for k, v in event.items() if k not in ("recurrenceRule", "recurrenceOverrides")}
+        merged.update(patch)
+        override = jscalendar_to_vevent(merged, categories)
+        if event.get("showWithoutTime"):
+            override.add("recurrence-id", instance_dt.date())
+        else:
+            override.add("recurrence-id", instance_dt)
+        components.append(override)
 
-	if excluded:
-		master.add("exdate", excluded)
+    if excluded:
+        master.add("exdate", excluded)
 
-	return components
+    return components
 
 
 def retry_stuck_calendar_exchanges() -> None:
-	"""Called by the scheduler to retry stuck calendar exchanges."""
+    """Called by the scheduler to retry stuck calendar exchanges."""
 
-	CE = frappe.qb.DocType("Calendar Exchange")
-	exchanges = (
-		frappe.qb.from_(CE)
-		.select(CE.name)
-		.where(
-			(CE.status.isin(["Queued", "In Progress"]))
-			& (CE.queued_at <= get_datetime(add_to_date(now(), days=-1)))
-		)
-		.orderby(CE.queued_at, order=Order.asc)
-	).run(pluck="name")
+    CE = frappe.qb.DocType("Calendar Exchange")
+    exchanges = (
+        frappe.qb.from_(CE)
+        .select(CE.name)
+        .where(
+            (CE.status.isin(["Queued", "In Progress"]))
+            & (CE.queued_at <= get_datetime(add_to_date(now(), days=-1)))
+        )
+        .orderby(CE.queued_at, order=Order.asc)
+    ).run(pluck="name")
 
-	# retry() throws for a document that no longer qualifies, and a scheduler job has no
-	# caller to surface that to - so isolate each one, or the first bad document silently
-	# strands every exchange queued behind it, run after run.
-	for exchange in exchanges:
-		try:
-			frappe.get_doc("Calendar Exchange", exchange).retry()
-		except Exception:
-			frappe.db.rollback()
-			log_error(
-				module="Calendar",
-				title=f"Failed to retry stuck Calendar Exchange {exchange}",
-				message=frappe.get_traceback(),
-			)
+    # retry() throws for a document that no longer qualifies, and a scheduler job has no
+    # caller to surface that to - so isolate each one, or the first bad document silently
+    # strands every exchange queued behind it, run after run.
+    for exchange in exchanges:
+        try:
+            frappe.get_doc("Calendar Exchange", exchange).retry()
+        except Exception:
+            frappe.db.rollback()
+            log_error(
+                module="Calendar",
+                title=f"Failed to retry stuck Calendar Exchange {exchange}",
+                message=frappe.get_traceback(),
+            )
 
 
 def clean_calendar_import_export_directories() -> None:
-	"""Called by the scheduler to clean up calendar import and export directories."""
+    """Called by the scheduler to clean up calendar import and export directories."""
 
-	for base in (get_calendar_import_directory(), get_calendar_export_directory()):
-		if not os.path.exists(base):
-			continue
+    for base in (get_calendar_import_directory(), get_calendar_export_directory()):
+        if not os.path.exists(base):
+            continue
 
-		for item in os.listdir(base):
-			path = os.path.join(base, item)
-			if os.path.isdir(path):
-				if frappe.db.exists("Calendar Exchange", {"name": item, "status": "In Progress"}):
-					continue
-				shutil.rmtree(path, ignore_errors=True)
-			else:
-				os.remove(path)
+        for item in os.listdir(base):
+            path = os.path.join(base, item)
+            if os.path.isdir(path):
+                if frappe.db.exists("Calendar Exchange", {"name": item, "status": "In Progress"}):
+                    continue
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                os.remove(path)

--- a/suite/calendar/doctype/calendar_exchange/test_calendar_exchange.py
+++ b/suite/calendar/doctype/calendar_exchange/test_calendar_exchange.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestCalendarExchange(IntegrationTestCase):
-	"""
-	Integration tests for CalendarExchange.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for CalendarExchange.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/calendar/doctype/calendar_rights/calendar_rights.py
+++ b/suite/calendar/doctype/calendar_rights/calendar_rights.py
@@ -6,14 +6,14 @@ from frappe.model.document import Document
 
 
 class CalendarRights(Document):
-	def db_insert(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_insert(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def load_from_db(self, *args, **kwargs):
-		raise NotImplementedError
+    def load_from_db(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def db_update(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_update(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def delete(self, *args, **kwargs):
-		raise NotImplementedError
+    def delete(self, *args, **kwargs):
+        raise NotImplementedError

--- a/suite/calendar/doctype/event_alert/event_alert.py
+++ b/suite/calendar/doctype/event_alert/event_alert.py
@@ -6,14 +6,14 @@ from frappe.model.document import Document
 
 
 class EventAlert(Document):
-	def db_insert(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_insert(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def load_from_db(self, *args, **kwargs):
-		raise NotImplementedError
+    def load_from_db(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def db_update(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_update(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def delete(self, *args, **kwargs):
-		raise NotImplementedError
+    def delete(self, *args, **kwargs):
+        raise NotImplementedError

--- a/suite/calendar/doctype/event_calendar/event_calendar.py
+++ b/suite/calendar/doctype/event_calendar/event_calendar.py
@@ -6,14 +6,14 @@ from frappe.model.document import Document
 
 
 class EventCalendar(Document):
-	def db_insert(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_insert(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def load_from_db(self, *args, **kwargs):
-		raise NotImplementedError
+    def load_from_db(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def db_update(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_update(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def delete(self, *args, **kwargs):
-		raise NotImplementedError
+    def delete(self, *args, **kwargs):
+        raise NotImplementedError

--- a/suite/calendar/doctype/event_link/event_link.py
+++ b/suite/calendar/doctype/event_link/event_link.py
@@ -6,14 +6,14 @@ from frappe.model.document import Document
 
 
 class EventLink(Document):
-	def db_insert(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_insert(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def load_from_db(self, *args, **kwargs):
-		raise NotImplementedError
+    def load_from_db(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def db_update(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_update(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def delete(self, *args, **kwargs):
-		raise NotImplementedError
+    def delete(self, *args, **kwargs):
+        raise NotImplementedError

--- a/suite/calendar/doctype/event_location/event_location.py
+++ b/suite/calendar/doctype/event_location/event_location.py
@@ -6,14 +6,14 @@ from frappe.model.document import Document
 
 
 class EventLocation(Document):
-	def db_insert(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_insert(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def load_from_db(self, *args, **kwargs):
-		raise NotImplementedError
+    def load_from_db(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def db_update(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_update(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def delete(self, *args, **kwargs):
-		raise NotImplementedError
+    def delete(self, *args, **kwargs):
+        raise NotImplementedError

--- a/suite/calendar/doctype/event_notification/event_notification.py
+++ b/suite/calendar/doctype/event_notification/event_notification.py
@@ -43,7 +43,7 @@ class EventNotification(Document):
             _("Event Notification are only created by the server, users cannot create them directly.")
         )
 
-    def load_from_db(self) -> "EventNotification":
+    def load_from_db(self) -> EventNotification:
         account, id = self.name.split("|")
         if notifications := get_event_notifications(account, [id]):
             return super(Document, self).__init__(notifications[0])
@@ -204,7 +204,7 @@ def format_event_notification(account: str, notification: dict) -> dict:
     }
 
 
-def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
     if doc.doctype != "Event Notification":
         return False
 

--- a/suite/calendar/doctype/event_notification/event_notification.py
+++ b/suite/calendar/doctype/event_notification/event_notification.py
@@ -14,198 +14,198 @@ from suite.utils.dt import parse_iso_datetime
 
 
 class EventNotification(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		account: DF.Link
-		calendar_event: DF.Link | None
-		calendar_event_id: DF.Data | None
-		changed_by_email: DF.Data | None
-		changed_by_name: DF.Data | None
-		changed_by_principal_id: DF.Data | None
-		changed_by_schedule_id: DF.Data | None
-		comment: DF.SmallText | None
-		created_utc: DF.Data | None
-		draft: DF.Check
-		event: DF.JSON | None
-		event_patch: DF.JSON | None
-		id: DF.Data | None
-		type: DF.Literal["", "Created", "Updated", "Destroyed"]
-	# end: auto-generated types
+        account: DF.Link
+        calendar_event: DF.Link | None
+        calendar_event_id: DF.Data | None
+        changed_by_email: DF.Data | None
+        changed_by_name: DF.Data | None
+        changed_by_principal_id: DF.Data | None
+        changed_by_schedule_id: DF.Data | None
+        comment: DF.SmallText | None
+        created_utc: DF.Data | None
+        draft: DF.Check
+        event: DF.JSON | None
+        event_patch: DF.JSON | None
+        id: DF.Data | None
+        type: DF.Literal["", "Created", "Updated", "Destroyed"]
+    # end: auto-generated types
 
-	def db_insert(self, *args, **kwargs) -> None:
-		frappe.throw(
-			_("Event Notification are only created by the server, users cannot create them directly.")
-		)
+    def db_insert(self, *args, **kwargs) -> None:
+        frappe.throw(
+            _("Event Notification are only created by the server, users cannot create them directly.")
+        )
 
-	def load_from_db(self) -> "EventNotification":
-		account, id = self.name.split("|")
-		if notifications := get_event_notifications(account, [id]):
-			return super(Document, self).__init__(notifications[0])
+    def load_from_db(self) -> "EventNotification":
+        account, id = self.name.split("|")
+        if notifications := get_event_notifications(account, [id]):
+            return super(Document, self).__init__(notifications[0])
 
-		frappe.throw(
-			_("Event Notification with ID {0} not found in account {1}.").format(
-				frappe.bold(id), frappe.bold(account)
-			),
-			title=_("Event Notification Not Found"),
-		)
+        frappe.throw(
+            _("Event Notification with ID {0} not found in account {1}.").format(
+                frappe.bold(id), frappe.bold(account)
+            ),
+            title=_("Event Notification Not Found"),
+        )
 
-	def db_update(self) -> None:
-		frappe.throw(_("Event Notification cannot be updated by the user."))
+    def db_update(self) -> None:
+        frappe.throw(_("Event Notification cannot be updated by the user."))
 
-	def delete(self) -> None:
-		account, id = self.name.split("|")
-		delete_event_notifications(account, [id])
+    def delete(self) -> None:
+        account, id = self.name.split("|")
+        delete_event_notifications(account, [id])
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs) -> list:
-		filters = parse_filters(filters)
-		account = filters.get("account")
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs) -> list:
+        filters = parse_filters(filters)
+        account = filters.get("account")
 
-		if not account:
-			frappe.msgprint(_("Please select an account to view event notifications."), alert=True)
-			return []
+        if not account:
+            frappe.msgprint(_("Please select an account to view event notifications."), alert=True)
+            return []
 
-		filter = {}
-		limit = cint(kwargs.get("start")) + page_length
-		notifications, total = fetch_event_notifications(account, filter, limit=limit)
-		frappe.cache.set_value(_get_total_cache_key(account), total, expires_in_sec=600)
+        filter = {}
+        limit = cint(kwargs.get("start")) + page_length
+        notifications, total = fetch_event_notifications(account, filter, limit=limit)
+        frappe.cache.set_value(_get_total_cache_key(account), total, expires_in_sec=600)
 
-		if not notifications:
-			frappe.msgprint(_("No event notifications found."), alert=True)
+        if not notifications:
+            frappe.msgprint(_("No event notifications found."), alert=True)
 
-		return notifications
+        return notifications
 
-	@staticmethod
-	def get_count(filters=None, **kwargs) -> int:
-		filters = parse_filters(filters)
-		account = filters.get("account")
+    @staticmethod
+    def get_count(filters=None, **kwargs) -> int:
+        filters = parse_filters(filters)
+        account = filters.get("account")
 
-		if account:
-			if get_user_for_jmap_account(account, raise_exception=False):
-				return cint(frappe.cache.get_value(_get_total_cache_key(account)))
+        if account:
+            if get_user_for_jmap_account(account, raise_exception=False):
+                return cint(frappe.cache.get_value(_get_total_cache_key(account)))
 
-		return 0
+        return 0
 
-	@staticmethod
-	def get_stats(**kwargs) -> dict:
-		return {}
+    @staticmethod
+    def get_stats(**kwargs) -> dict:
+        return {}
 
 
 def _get_total_cache_key(account: str) -> str:
-	"""Returns a cache key for total event notifications count for the given account."""
+    """Returns a cache key for total event notifications count for the given account."""
 
-	return f"{account}:event_notifications:total"
+    return f"{account}:event_notifications:total"
 
 
 @frappe.whitelist()
 def bulk_delete(names: str | list[str]) -> None:
-	"""Deletes multiple event notifications given their names."""
+    """Deletes multiple event notifications given their names."""
 
-	if isinstance(names, str):
-		names = json.loads(names)
+    if isinstance(names, str):
+        names = json.loads(names)
 
-	accounts_map = {}
-	for name in names:
-		account, id = name.split("|")
-		accounts_map.setdefault(account, []).append(id)
+    accounts_map = {}
+    for name in names:
+        account, id = name.split("|")
+        accounts_map.setdefault(account, []).append(id)
 
-	for account, ids in accounts_map.items():
-		delete_event_notifications(account, ids)
+    for account, ids in accounts_map.items():
+        delete_event_notifications(account, ids)
 
-	frappe.msgprint(_("Event Notifications deleted successfully."), alert=True)
+    frappe.msgprint(_("Event Notifications deleted successfully."), alert=True)
 
 
 @frappe.whitelist()
 def fetch_event_notifications(
-	account: str,
-	filter: dict | None = None,
-	position: int = 0,
-	limit: int = 50,
-	sort: list[dict] | None = None,
+    account: str,
+    filter: dict | None = None,
+    position: int = 0,
+    limit: int = 50,
+    sort: list[dict] | None = None,
 ) -> tuple[list[dict], int]:
-	"""Returns a list of event notifications and total count based on the provided filter."""
+    """Returns a list of event notifications and total count based on the provided filter."""
 
-	notifications = []
-	service = get_calendar_event_notification_service(account)
-	data = service.query(filter, position, limit, sort)
+    notifications = []
+    service = get_calendar_event_notification_service(account)
+    data = service.query(filter, position, limit, sort)
 
-	ids = data.get("ids", [])
-	total = data.get("total", 0)
+    ids = data.get("ids", [])
+    total = data.get("total", 0)
 
-	notifications.extend(get_event_notifications(account, ids))
+    notifications.extend(get_event_notifications(account, ids))
 
-	return notifications[:limit], total
+    return notifications[:limit], total
 
 
 @frappe.whitelist()
 def get_event_notifications(account: str, ids: list[str]) -> list[dict]:
-	"""Returns a list of event notifications for the specified account and IDs."""
+    """Returns a list of event notifications for the specified account and IDs."""
 
-	service = get_calendar_event_notification_service(account)
+    service = get_calendar_event_notification_service(account)
 
-	notifications = {}
-	for notification in service.get(ids):
-		notification = format_event_notification(account, notification)
-		notifications[notification["id"]] = notification
+    notifications = {}
+    for notification in service.get(ids):
+        notification = format_event_notification(account, notification)
+        notifications[notification["id"]] = notification
 
-	return [notifications[id] for id in ids if id in notifications]
+    return [notifications[id] for id in ids if id in notifications]
 
 
 @frappe.whitelist()
 def delete_event_notifications(account: str, ids: list[str]) -> None:
-	"""Deletes event notifications for the specified account and ID(s)."""
+    """Deletes event notifications for the specified account and ID(s)."""
 
-	service = get_calendar_event_notification_service(account)
-	response = service.delete(ids)
+    service = get_calendar_event_notification_service(account)
+    response = service.delete(ids)
 
-	if response.get("notDestroyed"):
-		error_messages = []
-		for id, error in response["notDestroyed"].items():
-			error_messages.append(f"{id}: {error['description']}")
-		frappe.throw(
-			_("Event Notification Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
-			title=_("Event Notification Deletion Error"),
-		)
+    if response.get("notDestroyed"):
+        error_messages = []
+        for id, error in response["notDestroyed"].items():
+            error_messages.append(f"{id}: {error['description']}")
+        frappe.throw(
+            _("Event Notification Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
+            title=_("Event Notification Deletion Error"),
+        )
 
 
 def format_event_notification(account: str, notification: dict) -> dict:
-	"""Formats event notification data for display."""
+    """Formats event notification data for display."""
 
-	calendar_event_id = notification.get("calendarEventId", "")
-	calendar_event = f"{account}|{calendar_event_id}" if calendar_event_id else None
-	changed_by = notification.get("changedBy", {})
-	event = json.dumps(notification.get("event", {}), indent=2)
-	event_patch = json.dumps(notification.get("eventPatch", {}), indent=2)
+    calendar_event_id = notification.get("calendarEventId", "")
+    calendar_event = f"{account}|{calendar_event_id}" if calendar_event_id else None
+    changed_by = notification.get("changedBy", {})
+    event = json.dumps(notification.get("event", {}), indent=2)
+    event_patch = json.dumps(notification.get("eventPatch", {}), indent=2)
 
-	return {
-		"name": f"{account}|{notification['id']}",
-		"account": account,
-		"id": notification["id"],
-		"draft": notification.get("isDraft", False),
-		"type": notification.get("type", "").title(),
-		"created_utc": notification["created"],
-		"comment": notification.get("comment", ""),
-		"calendar_event": calendar_event,
-		"calendar_event_id": calendar_event_id,
-		"changed_by_name": changed_by.get("name"),
-		"changed_by_email": changed_by.get("email"),
-		"changed_by_principal_id": changed_by.get("principalId"),
-		"changed_by_schedule_id": changed_by.get("scheduleId"),
-		"event": event,
-		"event_patch": event_patch,
-		"creation": parse_iso_datetime(notification["created"]),
-		"modified": parse_iso_datetime(notification["created"]),
-	}
+    return {
+        "name": f"{account}|{notification['id']}",
+        "account": account,
+        "id": notification["id"],
+        "draft": notification.get("isDraft", False),
+        "type": notification.get("type", "").title(),
+        "created_utc": notification["created"],
+        "comment": notification.get("comment", ""),
+        "calendar_event": calendar_event,
+        "calendar_event_id": calendar_event_id,
+        "changed_by_name": changed_by.get("name"),
+        "changed_by_email": changed_by.get("email"),
+        "changed_by_principal_id": changed_by.get("principalId"),
+        "changed_by_schedule_id": changed_by.get("scheduleId"),
+        "event": event,
+        "event_patch": event_patch,
+        "creation": parse_iso_datetime(notification["created"]),
+        "modified": parse_iso_datetime(notification["created"]),
+    }
 
 
 def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
-	if doc.doctype != "Event Notification":
-		return False
+    if doc.doctype != "Event Notification":
+        return False
 
-	return bool(get_user_for_jmap_account(doc.account, raise_exception=False))
+    return bool(get_user_for_jmap_account(doc.account, raise_exception=False))

--- a/suite/calendar/doctype/event_notification/test_event_notification.py
+++ b/suite/calendar/doctype/event_notification/test_event_notification.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestEventNotification(IntegrationTestCase):
-	"""
-	Integration tests for EventNotification.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for EventNotification.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/calendar/doctype/event_participant/event_participant.py
+++ b/suite/calendar/doctype/event_participant/event_participant.py
@@ -6,14 +6,14 @@ from frappe.model.document import Document
 
 
 class EventParticipant(Document):
-	def db_insert(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_insert(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def load_from_db(self, *args, **kwargs):
-		raise NotImplementedError
+    def load_from_db(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def db_update(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_update(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def delete(self, *args, **kwargs):
-		raise NotImplementedError
+    def delete(self, *args, **kwargs):
+        raise NotImplementedError

--- a/suite/calendar/www/calendar.py
+++ b/suite/calendar/www/calendar.py
@@ -2,4 +2,4 @@ no_cache = 1
 
 
 def get_context(context):
-	pass
+    pass

--- a/suite/drive/api/embed.py
+++ b/suite/drive/api/embed.py
@@ -9,33 +9,33 @@ from suite.drive.utils import WRITER_CONTENT_DOCTYPE, get_root_folder
 
 @frappe.whitelist(allow_guest=True)
 def get_file_content(embed_name: str, parent_entity_name: str):
-	"""
-	Give or stream embed content
-	"""
-	parent = frappe.get_value(
-		"File",
-		parent_entity_name,
-		["content_doctype", "file_name", "mime_type", "file_size", "owner", "file_url"],
-		as_dict=1,
-	)
+    """
+    Give or stream embed content
+    """
+    parent = frappe.get_value(
+        "File",
+        parent_entity_name,
+        ["content_doctype", "file_name", "mime_type", "file_size", "owner", "file_url"],
+        as_dict=1,
+    )
 
-	if parent.content_doctype != WRITER_CONTENT_DOCTYPE:
-		frappe.throw("This is not an embed.")
+    if parent.content_doctype != WRITER_CONTENT_DOCTYPE:
+        frappe.throw("This is not an embed.")
 
-	embed = frappe.get_cached_doc("File", embed_name)
+    embed = frappe.get_cached_doc("File", embed_name)
 
-	if embed.folder != parent_entity_name or not user_has_permission(embed_name, "read"):
-		raise frappe.PermissionError("You do not have permission to view this file")
+    if embed.folder != parent_entity_name or not user_has_permission(embed_name, "read"):
+        raise frappe.PermissionError("You do not have permission to view this file")
 
-	if not embed.file_url:
-		embed = frappe._dict(
-			file_url=str(
-				Path(
-					get_root_folder()["file_url"],
-					"embeds",
-					embed_name,
-				)
-			),
-			file_name=embed.file_name,
-		)
-	return get_file_internal(embed)
+    if not embed.file_url:
+        embed = frappe._dict(
+            file_url=str(
+                Path(
+                    get_root_folder()["file_url"],
+                    "embeds",
+                    embed_name,
+                )
+            ),
+            file_name=embed.file_name,
+        )
+    return get_file_internal(embed)

--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -19,24 +19,24 @@ from werkzeug.wsgi import wrap_file
 
 from suite.drive.api.storage import validate_quota
 from suite.drive.utils import (
-	ATTACHMENT_CONTENT_DOCTYPE,
-	STATUS_ACTIVE,
-	STATUS_TRASHED,
-	create_drive_file,
-	get_file_type,
-	get_new_file_name,
-	get_user_folder,
-	update_file_size,
-	validate_filename,
+    ATTACHMENT_CONTENT_DOCTYPE,
+    STATUS_ACTIVE,
+    STATUS_TRASHED,
+    create_drive_file,
+    get_file_type,
+    get_new_file_name,
+    get_user_folder,
+    update_file_size,
+    validate_filename,
 )
 from suite.drive.utils import get_root_folder as drive_root
 from suite.drive.utils.api import prettify_file
 from suite.drive.utils.files import (
-	FileManager,
-	content_disposition,
-	get_s3_key,
-	get_s3_url,
-	storage_key,
+    FileManager,
+    content_disposition,
+    get_s3_key,
+    get_s3_url,
+    storage_key,
 )
 from suite.drive.utils.users import mark_as_viewed
 
@@ -47,418 +47,418 @@ FORBIDDEN_DOWNLOAD_TYPES = ["Folder", "Link", "Document", "Presentation"]
 
 @frappe.whitelist(allow_guest=True)
 def upload_file(
-	total_file_size: int = 0,
-	file_modified: int | None = None,
-	fullpath: str | None = None,
-	parent: str | None = None,
-	embed: int = 0,
+    total_file_size: int = 0,
+    file_modified: int | None = None,
+    fullpath: str | None = None,
+    parent: str | None = None,
+    embed: int = 0,
 ):
-	"""
-	Accept chunked file contents via a multipart upload.
-	Store the file on disk, and insert a corresponding DriveFile doc.
-	Works with normal uploads, and embeds.
-	:return: DriveFile doc once the entire file has been uploaded
-	"""
-	checks = frappe.get_hooks("validate_drive_upload")
-	for check in checks:
-		res = frappe.call(check, file=frappe.request.files["file"], parent=parent, embed=embed)
-		if res is not None and res is not True:
-			frappe.throw(res or "This upload was cancelled by a validation check.", TypeError)
+    """
+    Accept chunked file contents via a multipart upload.
+    Store the file on disk, and insert a corresponding DriveFile doc.
+    Works with normal uploads, and embeds.
+    :return: DriveFile doc once the entire file has been uploaded
+    """
+    checks = frappe.get_hooks("validate_drive_upload")
+    for check in checks:
+        res = frappe.call(check, file=frappe.request.files["file"], parent=parent, embed=embed)
+        if res is not None and res is not True:
+            frappe.throw(res or "This upload was cancelled by a validation check.", TypeError)
 
-	parent = parent or get_user_folder().name
+    parent = parent or get_user_folder().name
 
-	if not user_has_permission(parent, "upload"):
-		frappe.throw("Ask the folder owner for upload access.", frappe.PermissionError)
+    if not user_has_permission(parent, "upload"):
+        frappe.throw("Ask the folder owner for upload access.", frappe.PermissionError)
 
-	if fullpath:
-		parent = ensure_path(fullpath, parent)
+    if fullpath:
+        parent = ensure_path(fullpath, parent)
 
-	# Support both chunked and non-chunked uploads
-	if frappe.form_dict.chunk_index:
-		current_chunk = int(frappe.form_dict.chunk_index)
-		total_chunks = int(frappe.form_dict.total_chunk_count)
-		offset = int(frappe.form_dict.chunk_byte_offset)
-	else:
-		offset = 0
-		current_chunk = 0
-		total_chunks = 1
+    # Support both chunked and non-chunked uploads
+    if frappe.form_dict.chunk_index:
+        current_chunk = int(frappe.form_dict.chunk_index)
+        total_chunks = int(frappe.form_dict.total_chunk_count)
+        offset = int(frappe.form_dict.chunk_byte_offset)
+    else:
+        offset = 0
+        current_chunk = 0
+        total_chunks = 1
 
-	file = frappe.request.files["file"]
-	file_name = get_new_file_name(file.filename, parent)
-	upload_session = frappe.form_dict.uuid
-	temp_path = get_upload_path(f"{upload_session}_{secure_filename(file_name)}")
-	with temp_path.open("ab") as f:
-		f.seek(offset)
-		f.write(file.stream.read())
-		if not f.tell() >= int(total_file_size) or current_chunk != total_chunks - 1:
-			return
+    file = frappe.request.files["file"]
+    file_name = get_new_file_name(file.filename, parent)
+    upload_session = frappe.form_dict.uuid
+    temp_path = get_upload_path(f"{upload_session}_{secure_filename(file_name)}")
+    with temp_path.open("ab") as f:
+        f.seek(offset)
+        f.write(file.stream.read())
+        if not f.tell() >= int(total_file_size) or current_chunk != total_chunks - 1:
+            return
 
-	# Validate that file size is matching
-	file_size = temp_path.stat().st_size
-	validate_quota(incoming_size=file_size)
+    # Validate that file size is matching
+    file_size = temp_path.stat().st_size
+    validate_quota(incoming_size=file_size)
 
-	mime_type = mimemapper.get_mime_type(str(temp_path), native_first=False)
-	file_type = get_file_type(mime_type)
-	manager = FileManager()
+    mime_type = mimemapper.get_mime_type(str(temp_path), native_first=False)
+    file_type = get_file_type(mime_type)
+    manager = FileManager()
 
-	drive_file = create_drive_file(
-		file_name,
-		parent,
-		file_type,
-		lambda file: "/" + str(manager.get_disk_path(file, embed)),
-		mime_type,
-		file_size,
-		int(file_modified) / 1000 if file_modified else None,
-	)
+    drive_file = create_drive_file(
+        file_name,
+        parent,
+        file_type,
+        lambda file: "/" + str(manager.get_disk_path(file, embed)),
+        mime_type,
+        file_size,
+        int(file_modified) / 1000 if file_modified else None,
+    )
 
-	# Upload and update parent folder size
-	manager.upload_file(temp_path, drive_file, not embed)
-	# Change path to be s3 compatible
-	if manager.s3_enabled:
-		drive_file.file_url = get_s3_url(get_s3_key(drive_file.file_url))
-		drive_file.save()
+    # Upload and update parent folder size
+    manager.upload_file(temp_path, drive_file, not embed)
+    # Change path to be s3 compatible
+    if manager.s3_enabled:
+        drive_file.file_url = get_s3_url(get_s3_key(drive_file.file_url))
+        drive_file.save()
 
-	try:
-		update_file_size(parent, file_size)
-	except Exception:
-		# Find a cleaner way to handle folder sizes as multiple simultaneous uploads will break this
-		pass
+    try:
+        update_file_size(parent, file_size)
+    except Exception:
+        # Find a cleaner way to handle folder sizes as multiple simultaneous uploads will break this
+        pass
 
-	frappe.publish_realtime("list-add", {"file": prettify_file(drive_file.as_dict())})
+    frappe.publish_realtime("list-add", {"file": prettify_file(drive_file.as_dict())})
 
-	return drive_file
+    return drive_file
 
 
 @frappe.whitelist(allow_guest=True)
 def get_thumbnail(entity_name: str):
-	drive_file = frappe.get_cached_doc("File", entity_name)
+    drive_file = frappe.get_cached_doc("File", entity_name)
 
-	# Permission first, so callers can't probe type/existence of files they can't read.
-	if not user_has_permission(drive_file, "read"):
-		frappe.throw("No permission", frappe.PermissionError)
+    # Permission first, so callers can't probe type/existence of files they can't read.
+    if not user_has_permission(drive_file, "read"):
+        frappe.throw("No permission", frappe.PermissionError)
 
-	# Thumbnails only exist for these types; bail before touching storage otherwise.
-	if drive_file.is_folder or drive_file.file_type not in ("Image", "Video", "PDF"):
-		return ""
+    # Thumbnails only exist for these types; bail before touching storage otherwise.
+    if drive_file.is_folder or drive_file.file_type not in ("Image", "Video", "PDF"):
+        return ""
 
-	try:
-		thumbnail = FileManager().get_thumbnail(entity_name)
-		thumbnail_data = BytesIO(thumbnail.read())
-		thumbnail.close()
-	except Exception:
-		return ""
+    try:
+        thumbnail = FileManager().get_thumbnail(entity_name)
+        thumbnail_data = BytesIO(thumbnail.read())
+        thumbnail.close()
+    except Exception:
+        return ""
 
-	response = Response(
-		wrap_file(frappe.request.environ, thumbnail_data),
-		direct_passthrough=True,
-	)
-	response.headers.set("Content-Type", "image/webp")
-	response.headers.set("Cache-Control", "private, max-age=3600")
-	response.headers.set("Content-Disposition", "inline", filename=entity_name)
-	return response
+    response = Response(
+        wrap_file(frappe.request.environ, thumbnail_data),
+        direct_passthrough=True,
+    )
+    response.headers.set("Content-Type", "image/webp")
+    response.headers.set("Cache-Control", "private, max-age=3600")
+    response.headers.set("Content-Disposition", "inline", filename=entity_name)
+    return response
 
 
 @frappe.whitelist()
 def create_folder(file_name: str, parent: str | None = None):
-	parent = parent or get_user_folder().name
+    parent = parent or get_user_folder().name
 
-	parent_doc = frappe.get_doc("File", parent)
-	if not user_has_permission(parent_doc, "upload"):
-		frappe.throw(
-			"You don't have permissions for this.",
-			frappe.PermissionError,
-		)
-	validate_filename(file_name, parent, "Folder", error=f"Folder '{file_name}' already exists.")
+    parent_doc = frappe.get_doc("File", parent)
+    if not user_has_permission(parent_doc, "upload"):
+        frappe.throw(
+            "You don't have permissions for this.",
+            frappe.PermissionError,
+        )
+    validate_filename(file_name, parent, "Folder", error=f"Folder '{file_name}' already exists.")
 
-	manager = FileManager()
-	path = manager.create_folder(
-		frappe._dict(
-			{
-				"file_name": file_name,
-				"parent_path": Path(storage_key(parent_doc.file_url or "")),
-			}
-		)
-	)
+    manager = FileManager()
+    path = manager.create_folder(
+        frappe._dict(
+            {
+                "file_name": file_name,
+                "parent_path": Path(storage_key(parent_doc.file_url or "")),
+            }
+        )
+    )
 
-	return create_drive_file(
-		file_name,
-		parent,
-		"Folder",
-		path,
-	)
+    return create_drive_file(
+        file_name,
+        parent,
+        "Folder",
+        path,
+    )
 
 
 def ensure_path(fullpath, parent=None):
-	"""
-	Walk through a folder path and ensure every part exists.
+    """
+    Walk through a folder path and ensure every part exists.
 
-	:param fullpath: Path string, e.g. "foo/bar/baz"
-	:param parent: Optional starting folder (defaults to the user folder)
-	:return: The name of the deepest folder
-	"""
-	parts = Path(fullpath).parts
-	current_parent = parent or get_user_folder().name
+    :param fullpath: Path string, e.g. "foo/bar/baz"
+    :param parent: Optional starting folder (defaults to the user folder)
+    :return: The name of the deepest folder
+    """
+    parts = Path(fullpath).parts
+    current_parent = parent or get_user_folder().name
 
-	for folder in parts[:-1]:
-		exists = frappe.db.get_value(
-			"File",
-			{
-				"file_name": folder,
-				"is_folder": 1,
-				"status": STATUS_ACTIVE,
-				"folder": current_parent,
-			},
-			"name",
-		)
-		if not exists:
-			# use the higher-level folder creation
-			doc = create_folder(folder, parent=current_parent)
-			current_parent = doc.name
-		else:
-			current_parent = exists
-	return current_parent
+    for folder in parts[:-1]:
+        exists = frappe.db.get_value(
+            "File",
+            {
+                "file_name": folder,
+                "is_folder": 1,
+                "status": STATUS_ACTIVE,
+                "folder": current_parent,
+            },
+            "name",
+        )
+        if not exists:
+            # use the higher-level folder creation
+            doc = create_folder(folder, parent=current_parent)
+            current_parent = doc.name
+        else:
+            current_parent = exists
+    return current_parent
 
 
 @frappe.whitelist()
 def create_link(file_name: str, link: str, parent: str | None = None):
-	parent = parent or get_user_folder().name
+    parent = parent or get_user_folder().name
 
-	if not user_has_permission(parent, "upload"):
-		frappe.throw(
-			"Cannot create link due to insufficient permissions.",
-			frappe.PermissionError,
-		)
+    if not user_has_permission(parent, "upload"):
+        frappe.throw(
+            "Cannot create link due to insufficient permissions.",
+            frappe.PermissionError,
+        )
 
-	validate_filename(file_name, parent, "Link", error=f"Link '{file_name}' already exists.")
+    validate_filename(file_name, parent, "Link", error=f"Link '{file_name}' already exists.")
 
-	drive_file = frappe.get_doc(
-		{
-			"doctype": "File",
-			"is_private": 1,
-			"file_name": file_name,
-			"file_url": link,
-			"file_type": "Link",
-			"file_modified": frappe.utils.now_datetime(),
-			"folder": parent,
-		}
-	)
-	drive_file.flags.file_created = True
-	drive_file.insert()
+    drive_file = frappe.get_doc(
+        {
+            "doctype": "File",
+            "is_private": 1,
+            "file_name": file_name,
+            "file_url": link,
+            "file_type": "Link",
+            "file_modified": frappe.utils.now_datetime(),
+            "folder": parent,
+        }
+    )
+    drive_file.flags.file_created = True
+    drive_file.insert()
 
-	return drive_file
+    return drive_file
 
 
 @frappe.whitelist(allow_guest=True)
 def create_auth_token(entity_name: str):
-	if not user_has_permission(entity_name, "read"):
-		raise frappe.PermissionError("You do not have permission to view this file")
-	token = frappe.get_doc(
-		{
-			"doctype": "Drive Token",
-			"file": entity_name,
-			"user": frappe.session.user,
-			"expiry": frappe.utils.add_to_date(None, minutes=5),
-		}
-	).insert(ignore_permissions=True)
-	return token.name
+    if not user_has_permission(entity_name, "read"):
+        raise frappe.PermissionError("You do not have permission to view this file")
+    token = frappe.get_doc(
+        {
+            "doctype": "Drive Token",
+            "file": entity_name,
+            "user": frappe.session.user,
+            "expiry": frappe.utils.add_to_date(None, minutes=5),
+        }
+    ).insert(ignore_permissions=True)
+    return token.name
 
 
 @frappe.whitelist(allow_guest=True)
 def get_file_content(entity_name: str, trigger_download: bool = False, token: str | None = None):
-	"""
-	Central function to get files.
-	"""
-	if token:
-		# Single-use capability minted by create_auth_token, for cookieless
-		# fetches (e.g. the Office Online preview).
-		auth = frappe.db.get_value("Drive Token", token, ["file", "expiry"], as_dict=True)
-		if not auth or auth.file != entity_name or frappe.utils.now_datetime() > auth.expiry:
-			raise frappe.PermissionError("You do not have permission to view this file")
-		frappe.delete_doc("Drive Token", token, ignore_permissions=True, force=True)
-	elif not user_has_permission(entity_name, "read"):
-		raise frappe.PermissionError("You do not have permission to view this file")
+    """
+    Central function to get files.
+    """
+    if token:
+        # Single-use capability minted by create_auth_token, for cookieless
+        # fetches (e.g. the Office Online preview).
+        auth = frappe.db.get_value("Drive Token", token, ["file", "expiry"], as_dict=True)
+        if not auth or auth.file != entity_name or frappe.utils.now_datetime() > auth.expiry:
+            raise frappe.PermissionError("You do not have permission to view this file")
+        frappe.delete_doc("Drive Token", token, ignore_permissions=True, force=True)
+    elif not user_has_permission(entity_name, "read"):
+        raise frappe.PermissionError("You do not have permission to view this file")
 
-	file = frappe.get_value(
-		"File",
-		{"name": entity_name},
-		[
-			"name",
-			"file_name",
-			"file_type",
-			"status",
-			"file_url",
-			"is_private",
-			"mime_type",
-		],
-		as_dict=1,
-	)
+    file = frappe.get_value(
+        "File",
+        {"name": entity_name},
+        [
+            "name",
+            "file_name",
+            "file_type",
+            "status",
+            "file_url",
+            "is_private",
+            "mime_type",
+        ],
+        as_dict=1,
+    )
 
-	if not file or file.file_type in FORBIDDEN_DOWNLOAD_TYPES or file.status != STATUS_ACTIVE:
-		frappe.throw("Not found", frappe.DoesNotExistError)
+    if not file or file.file_type in FORBIDDEN_DOWNLOAD_TYPES or file.status != STATUS_ACTIVE:
+        frappe.throw("Not found", frappe.DoesNotExistError)
 
-	if file.file_type == "Document":
-		frappe.local.response["type"] = "redirect"
-		frappe.local.response["location"] = "/drive/w/" + file.name
-		return
-	if not file.is_private:
-		# Public files (adopted framework uploads) are served straight off /files.
-		frappe.local.response["type"] = "redirect"
-		frappe.local.response["location"] = file.file_url
-		return
+    if file.file_type == "Document":
+        frappe.local.response["type"] = "redirect"
+        frappe.local.response["location"] = "/drive/w/" + file.name
+        return
+    if not file.is_private:
+        # Public files (adopted framework uploads) are served straight off /files.
+        frappe.local.response["type"] = "redirect"
+        frappe.local.response["location"] = file.file_url
+        return
 
-	return get_file_internal(file, trigger_download)
+    return get_file_internal(file, trigger_download)
 
 
 def _serve_resumable(manager, key, download_name, mime_type=None):
-	"""Range/resume-capable download served by storage, not this worker.
+    """Range/resume-capable download served by storage, not this worker.
 
-	S3 → presigned URL; disk+nginx → X-Accel-Redirect; disk → send_file.
-	"""
-	if manager.s3_enabled:
-		frappe.local.response["type"] = "redirect"
-		frappe.local.response["location"] = manager.presigned_url(key, download_name, mime_type)
-		return
+    S3 → presigned URL; disk+nginx → X-Accel-Redirect; disk → send_file.
+    """
+    if manager.s3_enabled:
+        frappe.local.response["type"] = "redirect"
+        frappe.local.response["location"] = manager.presigned_url(key, download_name, mime_type)
+        return
 
-	xaccel_prefix = frappe.conf.get("drive_xaccel_prefix")
-	if xaccel_prefix:
-		response = Response(status=200)
-		# header values must be latin-1 and nginx expects an encoded URI
-		response.headers["X-Accel-Redirect"] = f"{xaccel_prefix.rstrip('/')}/{quote(key)}"
-		response.headers["Content-Disposition"] = content_disposition(download_name)
-		if mime_type:
-			response.headers["Content-Type"] = mime_type
-		return response
+    xaccel_prefix = frappe.conf.get("drive_xaccel_prefix")
+    if xaccel_prefix:
+        response = Response(status=200)
+        # header values must be latin-1 and nginx expects an encoded URI
+        response.headers["X-Accel-Redirect"] = f"{xaccel_prefix.rstrip('/')}/{quote(key)}"
+        response.headers["Content-Disposition"] = content_disposition(download_name)
+        if mime_type:
+            response.headers["Content-Type"] = mime_type
+        return response
 
-	response = send_file(
-		str(manager.site_folder / key),
-		mimetype=mime_type or "application/octet-stream",
-		as_attachment=True,
-		download_name=download_name,
-		conditional=True,
-		max_age=0,
-		environ=frappe.request.environ,
-	)
-	# advertise ranges on the 200 too, so browsers resume rather than restart
-	response.headers["Accept-Ranges"] = "bytes"
-	return response
+    response = send_file(
+        str(manager.site_folder / key),
+        mimetype=mime_type or "application/octet-stream",
+        as_attachment=True,
+        download_name=download_name,
+        conditional=True,
+        max_age=0,
+        environ=frappe.request.environ,
+    )
+    # advertise ranges on the 200 too, so browsers resume rather than restart
+    response.headers["Accept-Ranges"] = "bytes"
+    return response
 
 
 def get_file_internal(file, trigger_download=0):
-	if not trigger_download and file.file_type == "Video" and frappe.request.headers.get("Range"):
-		return stream_file_content(file.name)
+    if not trigger_download and file.file_type == "Video" and frappe.request.headers.get("Range"):
+        return stream_file_content(file.name)
 
-	manager = FileManager()
-	if trigger_download:
-		return _serve_resumable(manager, storage_key(file.file_url), file.file_name, file.get("mime_type"))
-	return send_file(
-		manager.get_file(file),
-		as_attachment=False,
-		conditional=True,
-		max_age=3600,
-		download_name=file.file_name,
-		environ=frappe.request.environ,
-	)
+    manager = FileManager()
+    if trigger_download:
+        return _serve_resumable(manager, storage_key(file.file_url), file.file_name, file.get("mime_type"))
+    return send_file(
+        manager.get_file(file),
+        as_attachment=False,
+        conditional=True,
+        max_age=3600,
+        download_name=file.file_name,
+        environ=frappe.request.environ,
+    )
 
 
 @frappe.whitelist(allow_guest=True)
 def stream_file_content(entity_name: str):
-	"""
-	Stream file content and optionally trigger download
+    """
+    Stream file content and optionally trigger download
 
-	:param entity_name: Document-name of the file whose content is to be streamed
-	:param drive_entity: Drive Entity record object
-	"""
-	range_header = frappe.request.headers.get("Range")
-	if not range_header:
-		return get_file_content(entity_name)
-	entity = frappe.get_doc("File", entity_name)
-	if not user_has_permission(entity, "read"):
-		raise frappe.PermissionError("You do not have permission to view this file")
+    :param entity_name: Document-name of the file whose content is to be streamed
+    :param drive_entity: Drive Entity record object
+    """
+    range_header = frappe.request.headers.get("Range")
+    if not range_header:
+        return get_file_content(entity_name)
+    entity = frappe.get_doc("File", entity_name)
+    if not user_has_permission(entity, "read"):
+        raise frappe.PermissionError("You do not have permission to view this file")
 
-	if not entity.is_private:
-		frappe.local.response["type"] = "redirect"
-		frappe.local.response["location"] = entity.file_url
-		return
+    if not entity.is_private:
+        frappe.local.response["type"] = "redirect"
+        frappe.local.response["location"] = entity.file_url
+        return
 
-	size = entity.file_size
-	byte1, byte2 = 0, None
+    size = entity.file_size
+    byte1, byte2 = 0, None
 
-	m = re.search(r"(\d+)-(\d*)", range_header)
-	g = m.groups()
+    m = re.search(r"(\d+)-(\d*)", range_header)
+    g = m.groups()
 
-	if g[0]:
-		byte1 = int(g[0])
-	if g[1]:
-		byte2 = int(g[1])
+    if g[0]:
+        byte1 = int(g[0])
+    if g[1]:
+        byte2 = int(g[1])
 
-	length = size - byte1
+    length = size - byte1
 
-	max_length = 20 * 1024 * 1024  # 20 MB in bytes
-	if length > max_length:
-		length = max_length
+    max_length = 20 * 1024 * 1024  # 20 MB in bytes
+    if length > max_length:
+        length = max_length
 
-	if byte2 is not None:
-		length = byte2 - byte1
+    if byte2 is not None:
+        length = byte2 - byte1
 
-	manager = FileManager()
-	data = None
-	if manager.s3_enabled:
-		data = manager.get_file(entity, f"bytes={byte1}-{byte1 + length - 1}")
-	else:
-		with manager.open_file(entity.file_url) as f:
-			f.seek(byte1)
-			data = f.read(length)
+    manager = FileManager()
+    data = None
+    if manager.s3_enabled:
+        data = manager.get_file(entity, f"bytes={byte1}-{byte1 + length - 1}")
+    else:
+        with manager.open_file(entity.file_url) as f:
+            f.seek(byte1)
+            data = f.read(length)
 
-	res = Response(data, 206, mimetype=entity.mime_type, direct_passthrough=True)
-	res.headers.add("Content-Range", "bytes {0}-{1}/{2}".format(byte1, byte1 + length - 1, size))
-	return res
+    res = Response(data, 206, mimetype=entity.mime_type, direct_passthrough=True)
+    res.headers.add("Content-Range", "bytes {0}-{1}/{2}".format(byte1, byte1 + length - 1, size))
+    return res
 
 
 def _iter_folder_files(entity_name, prefix=""):
-	"""Recursively yield (arcname, file) for downloadable files in a folder.
+    """Recursively yield (arcname, file) for downloadable files in a folder.
 
-	Read is checked per child, not once at the top: access does not simply cascade
-	— a deny row anywhere below cuts it, and the Drive root is readable by every
-	logged-in user, so a single top-level check would hand out the whole tree.
+    Read is checked per child, not once at the top: access does not simply cascade
+    — a deny row anywhere below cuts it, and the Drive root is readable by every
+    logged-in user, so a single top-level check would hand out the whole tree.
 
-	Writer documents and links have no underlying blob, so they're skipped.
-	"""
-	children = frappe.get_all(
-		"File",
-		filters={"folder": entity_name, "status": STATUS_ACTIVE},
-		fields=["name", "file_name", "is_folder", "file_type", "file_url"],
-	)
-	for child in children:
-		if not user_has_permission(child.name, "read"):
-			continue
-		arcname = f"{prefix}{child.file_name}"
-		if child.is_folder:
-			yield from _iter_folder_files(child.name, prefix=f"{arcname}/")
-		elif child.file_type not in FORBIDDEN_DOWNLOAD_TYPES and child.file_url:
-			yield arcname, child
+    Writer documents and links have no underlying blob, so they're skipped.
+    """
+    children = frappe.get_all(
+        "File",
+        filters={"folder": entity_name, "status": STATUS_ACTIVE},
+        fields=["name", "file_name", "is_folder", "file_type", "file_url"],
+    )
+    for child in children:
+        if not user_has_permission(child.name, "read"):
+            continue
+        arcname = f"{prefix}{child.file_name}"
+        if child.is_folder:
+            yield from _iter_folder_files(child.name, prefix=f"{arcname}/")
+        elif child.file_type not in FORBIDDEN_DOWNLOAD_TYPES and child.file_url:
+            yield arcname, child
 
 
 def _collect_download_files(entity_names):
-	"""Expand the selected top-level entities into (arcname, file) pairs.
+    """Expand the selected top-level entities into (arcname, file) pairs.
 
-	Read is checked here and again per descendant in `_iter_folder_files`; a single
-	folder nests its contents under its own file name.
-	"""
-	for name in entity_names:
-		if not user_has_permission(name, "read"):
-			raise frappe.PermissionError("You do not have permission to download this file")
-		entity = frappe.get_value(
-			"File",
-			name,
-			["name", "file_name", "is_folder", "file_type", "file_url"],
-			as_dict=True,
-		)
-		if not entity:
-			continue
-		if entity.is_folder:
-			yield from _iter_folder_files(entity.name, prefix=f"{entity.file_name}/")
-		elif entity.file_type not in FORBIDDEN_DOWNLOAD_TYPES and entity.file_url:
-			yield entity.file_name, entity
+    Read is checked here and again per descendant in `_iter_folder_files`; a single
+    folder nests its contents under its own file name.
+    """
+    for name in entity_names:
+        if not user_has_permission(name, "read"):
+            raise frappe.PermissionError("You do not have permission to download this file")
+        entity = frappe.get_value(
+            "File",
+            name,
+            ["name", "file_name", "is_folder", "file_type", "file_url"],
+            as_dict=True,
+        )
+        if not entity:
+            continue
+        if entity.is_folder:
+            yield from _iter_folder_files(entity.name, prefix=f"{entity.file_name}/")
+        elif entity.file_type not in FORBIDDEN_DOWNLOAD_TYPES and entity.file_url:
+            yield entity.file_name, entity
 
 
 DOWNLOAD_TTL = 60 * 60  # finished archives live for an hour
@@ -469,352 +469,352 @@ ARCHIVE_DIR = "private/files/.drive-downloads"
 
 
 def _download_cache_key(token):
-	return f"drive-download:{token}"
+    return f"drive-download:{token}"
 
 
 def _build_zip(manager, files, fileobj):
-	"""Write a ZIP_STORED archive to a seekable file, streaming each file in."""
-	with zipfile.ZipFile(fileobj, "w", zipfile.ZIP_STORED, allowZip64=True) as zf:
-		for arcname, child in files:
-			info = zipfile.ZipInfo(arcname)
-			info.compress_type = zipfile.ZIP_STORED
-			with zf.open(info, "w") as dest:
-				for block in manager.iter_blocks(child):
-					dest.write(block)
+    """Write a ZIP_STORED archive to a seekable file, streaming each file in."""
+    with zipfile.ZipFile(fileobj, "w", zipfile.ZIP_STORED, allowZip64=True) as zf:
+        for arcname, child in files:
+            info = zipfile.ZipInfo(arcname)
+            info.compress_type = zipfile.ZIP_STORED
+            with zf.open(info, "w") as dest:
+                for block in manager.iter_blocks(child):
+                    dest.write(block)
 
 
 def _write_archive(token, files):
-	"""Build the zip into storage; return (storage_key, size). S3 builds to
-	a temp file then uploads so nothing lands half-formed."""
-	manager = FileManager()
-	key = f"{ARCHIVE_DIR}/{token}.zip"
-	if manager.s3_enabled:
-		with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
-			tmp_path = tmp.name
-		try:
-			with open(tmp_path, "wb") as fh:
-				_build_zip(manager, files, fh)
-			size = os.path.getsize(tmp_path)
-			s3_key = f".drive-downloads/{token}.zip"
-			manager.conn.upload_file(tmp_path, manager.bucket, s3_key)
-			return s3_key, size
-		finally:
-			os.remove(tmp_path)
-	else:
-		target = manager.site_folder / key
-		target.parent.mkdir(parents=True, exist_ok=True)
-		with open(target, "wb") as fh:
-			_build_zip(manager, files, fh)
-		return key, os.path.getsize(target)
+    """Build the zip into storage; return (storage_key, size). S3 builds to
+    a temp file then uploads so nothing lands half-formed."""
+    manager = FileManager()
+    key = f"{ARCHIVE_DIR}/{token}.zip"
+    if manager.s3_enabled:
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+            tmp_path = tmp.name
+        try:
+            with open(tmp_path, "wb") as fh:
+                _build_zip(manager, files, fh)
+            size = os.path.getsize(tmp_path)
+            s3_key = f".drive-downloads/{token}.zip"
+            manager.conn.upload_file(tmp_path, manager.bucket, s3_key)
+            return s3_key, size
+        finally:
+            os.remove(tmp_path)
+    else:
+        target = manager.site_folder / key
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with open(target, "wb") as fh:
+            _build_zip(manager, files, fh)
+        return key, os.path.getsize(target)
 
 
 def _publish_download_status(token, user, status, **extra):
-	"""Push the terminal build state over the user's realtime room so the
-	client can drop polling and just listen."""
-	frappe.publish_realtime("drive-download-status", {"token": token, "status": status, **extra}, user=user)
+    """Push the terminal build state over the user's realtime room so the
+    client can drop polling and just listen."""
+    frappe.publish_realtime("drive-download-status", {"token": token, "status": status, **extra}, user=user)
 
 
 def build_download_archive(token, entities, zip_name, user):
-	"""Background job: build the archive as `user` and publish its state to cache."""
-	cache = frappe.cache()
-	cache_key = _download_cache_key(token)
-	frappe.set_user(user)
-	try:
-		files = list(_collect_download_files(entities))
-		if not files:
-			raise frappe.NotFound("No downloadable files found")
-		key, size = _write_archive(token, files)
-		cache.set_value(
-			cache_key,
-			{"status": "ready", "owner": user, "key": key, "file_name": zip_name, "size": size},
-			expires_in_sec=DOWNLOAD_TTL,
-		)
-		_publish_download_status(token, user, "ready", size=size)
-	except Exception as e:
-		frappe.log_error("Drive: archive build failed", e)
-		cache.set_value(
-			cache_key,
-			{"status": "failed", "owner": user, "error": str(e)},
-			expires_in_sec=DOWNLOAD_TTL,
-		)
-		_publish_download_status(token, user, "failed", error=str(e))
+    """Background job: build the archive as `user` and publish its state to cache."""
+    cache = frappe.cache()
+    cache_key = _download_cache_key(token)
+    frappe.set_user(user)
+    try:
+        files = list(_collect_download_files(entities))
+        if not files:
+            raise frappe.NotFound("No downloadable files found")
+        key, size = _write_archive(token, files)
+        cache.set_value(
+            cache_key,
+            {"status": "ready", "owner": user, "key": key, "file_name": zip_name, "size": size},
+            expires_in_sec=DOWNLOAD_TTL,
+        )
+        _publish_download_status(token, user, "ready", size=size)
+    except Exception as e:
+        frappe.log_error("Drive: archive build failed", e)
+        cache.set_value(
+            cache_key,
+            {"status": "failed", "owner": user, "error": str(e)},
+            expires_in_sec=DOWNLOAD_TTL,
+        )
+        _publish_download_status(token, user, "failed", error=str(e))
 
 
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=10, seconds=10 * 60)
 def download_folder(entities: str):
-	"""Enqueue a zip build and return a token; client polls download_status then
-	fetches download_archive. Avoids timing out large folders into a corrupt zip.
+    """Enqueue a zip build and return a token; client polls download_status then
+    fetches download_archive. Avoids timing out large folders into a corrupt zip.
 
-	:param entities: JSON list of File names (the user's selection)
-	"""
-	if isinstance(entities, str):
-		entities = frappe.parse_json(entities)
-	if not entities:
-		frappe.throw("Nothing to download", ValueError)
+    :param entities: JSON list of File names (the user's selection)
+    """
+    if isinstance(entities, str):
+        entities = frappe.parse_json(entities)
+    if not entities:
+        frappe.throw("Nothing to download", ValueError)
 
-	# resolve up front so a permission error surfaces here, not in the job
-	files = list(_collect_download_files(entities))
-	if not files:
-		frappe.throw("No downloadable files found", frappe.NotFound)
+    # resolve up front so a permission error surfaces here, not in the job
+    files = list(_collect_download_files(entities))
+    if not files:
+        frappe.throw("No downloadable files found", frappe.NotFound)
 
-	cache = frappe.cache()
-	user = frappe.session.user
+    cache = frappe.cache()
+    user = frappe.session.user
 
-	# same selection already building or built → hand back that token instead of
-	# burning another job + artifact
-	selection_key = (
-		f"drive-download-sel:{user}:{hashlib.sha1(json.dumps(sorted(entities)).encode()).hexdigest()}"
-	)
-	existing = cache.get_value(selection_key)
-	if existing:
-		entry = cache.get_value(_download_cache_key(existing))
-		if entry and entry.get("status") in ("building", "ready"):
-			return {"token": existing, "file_name": entry["file_name"]}
+    # same selection already building or built → hand back that token instead of
+    # burning another job + artifact
+    selection_key = (
+        f"drive-download-sel:{user}:{hashlib.sha1(json.dumps(sorted(entities)).encode()).hexdigest()}"
+    )
+    existing = cache.get_value(selection_key)
+    if existing:
+        entry = cache.get_value(_download_cache_key(existing))
+        if entry and entry.get("status") in ("building", "ready"):
+            return {"token": existing, "file_name": entry["file_name"]}
 
-	if len(entities) == 1:
-		zip_name = f"{frappe.get_value('File', entities[0], 'file_name')}.zip"
-	else:
-		zip_name = f"Drive Download {frappe.utils.now()}.zip"
+    if len(entities) == 1:
+        zip_name = f"{frappe.get_value('File', entities[0], 'file_name')}.zip"
+    else:
+        zip_name = f"Drive Download {frappe.utils.now()}.zip"
 
-	token = secrets.token_urlsafe(24)
-	cache.set_value(
-		_download_cache_key(token),
-		{"status": "building", "owner": user, "file_name": zip_name},
-		expires_in_sec=BUILDING_TTL,
-	)
-	cache.set_value(selection_key, token, expires_in_sec=BUILDING_TTL)
-	frappe.enqueue(
-		"suite.drive.api.files.build_download_archive",
-		queue="long",
-		timeout=3600,
-		token=token,
-		entities=entities,
-		zip_name=zip_name,
-		user=user,
-	)
-	return {"token": token, "file_name": zip_name}
+    token = secrets.token_urlsafe(24)
+    cache.set_value(
+        _download_cache_key(token),
+        {"status": "building", "owner": user, "file_name": zip_name},
+        expires_in_sec=BUILDING_TTL,
+    )
+    cache.set_value(selection_key, token, expires_in_sec=BUILDING_TTL)
+    frappe.enqueue(
+        "suite.drive.api.files.build_download_archive",
+        queue="long",
+        timeout=3600,
+        token=token,
+        entities=entities,
+        zip_name=zip_name,
+        user=user,
+    )
+    return {"token": token, "file_name": zip_name}
 
 
 def _get_download_entry(token):
-	entry = frappe.cache().get_value(_download_cache_key(token))
-	if not entry or entry.get("owner") != frappe.session.user:
-		frappe.throw("Not found", frappe.DoesNotExistError)
-	return entry
+    entry = frappe.cache().get_value(_download_cache_key(token))
+    if not entry or entry.get("owner") != frappe.session.user:
+        frappe.throw("Not found", frappe.DoesNotExistError)
+    return entry
 
 
 @frappe.whitelist(allow_guest=True)
 def download_status(token: str):
-	"""Poll the state of an archive build: building | ready | failed."""
-	entry = _get_download_entry(token)
-	return {"status": entry["status"], "error": entry.get("error"), "size": entry.get("size")}
+    """Poll the state of an archive build: building | ready | failed."""
+    entry = _get_download_entry(token)
+    return {"status": entry["status"], "error": entry.get("error"), "size": entry.get("size")}
 
 
 @frappe.whitelist(allow_guest=True)
 def download_archive(token: str):
-	"""Serve a finished archive as a Range/resume-capable download."""
-	entry = _get_download_entry(token)
-	if entry.get("status") != "ready":
-		frappe.throw("Not found", frappe.DoesNotExistError)
-	return _serve_resumable(FileManager(), entry["key"], entry["file_name"], "application/zip")
+    """Serve a finished archive as a Range/resume-capable download."""
+    entry = _get_download_entry(token)
+    if entry.get("status") != "ready":
+        frappe.throw("Not found", frappe.DoesNotExistError)
+    return _serve_resumable(FileManager(), entry["key"], entry["file_name"], "application/zip")
 
 
 @frappe.whitelist()
 def set_favourite(entities: list | None = None, clear_all: bool = False):
-	"""
-	Favouite or unfavourite DriveEntities for specified user
+    """
+    Favouite or unfavourite DriveEntities for specified user
 
-	:param entities: List[dict] of document names and whether favorite
-	:raises ValueError: If decoded entity_names is not a list
-	"""
-	if clear_all:
-		return frappe.db.delete("Drive Favourite", {"user": frappe.session.user})
+    :param entities: List[dict] of document names and whether favorite
+    :raises ValueError: If decoded entity_names is not a list
+    """
+    if clear_all:
+        return frappe.db.delete("Drive Favourite", {"user": frappe.session.user})
 
-	if not isinstance(entities, list):
-		frappe.throw(f"Expected list but got {type(entities)}", ValueError)
+    if not isinstance(entities, list):
+        frappe.throw(f"Expected list but got {type(entities)}", ValueError)
 
-	for entity in entities:
-		existing_doc = frappe.db.exists(
-			{
-				"doctype": "Drive Favourite",
-				"entity": entity["name"],
-				"user": frappe.session.user,
-			}
-		)
-		if not entity.get("is_favourite"):
-			entity["is_favourite"] = not existing_doc
+    for entity in entities:
+        existing_doc = frappe.db.exists(
+            {
+                "doctype": "Drive Favourite",
+                "entity": entity["name"],
+                "user": frappe.session.user,
+            }
+        )
+        if not entity.get("is_favourite"):
+            entity["is_favourite"] = not existing_doc
 
-		if not isinstance(entity["is_favourite"], bool):
-			entity["is_favourite"] = json.loads(entity["is_favourite"])
+        if not isinstance(entity["is_favourite"], bool):
+            entity["is_favourite"] = json.loads(entity["is_favourite"])
 
-		if not entity["is_favourite"] and existing_doc:
-			frappe.delete_doc("Drive Favourite", existing_doc)
-		elif entity["is_favourite"] and not existing_doc:
-			frappe.get_doc(
-				{
-					"doctype": "Drive Favourite",
-					"entity": entity["name"],
-					"user": frappe.session.user,
-				}
-			).insert()
+        if not entity["is_favourite"] and existing_doc:
+            frappe.delete_doc("Drive Favourite", existing_doc)
+        elif entity["is_favourite"] and not existing_doc:
+            frappe.get_doc(
+                {
+                    "doctype": "Drive Favourite",
+                    "entity": entity["name"],
+                    "user": frappe.session.user,
+                }
+            ).insert()
 
 
 @frappe.whitelist()
 def remove_or_restore(entity_names: list[str] | str):
-	"""
-	To move entities to or restore entities from the trash
+    """
+    To move entities to or restore entities from the trash
 
-	:param entity_names: List of document-names
-	"""
-	if isinstance(entity_names, str):
-		entity_names = json.loads(entity_names)
-	if not isinstance(entity_names, list):
-		frappe.throw(f"Expected list but got {type(entity_names)}", ValueError)
-	manager = FileManager()
+    :param entity_names: List of document-names
+    """
+    if isinstance(entity_names, str):
+        entity_names = json.loads(entity_names)
+    if not isinstance(entity_names, list):
+        frappe.throw(f"Expected list but got {type(entity_names)}", ValueError)
+    manager = FileManager()
 
-	def depth_zero_toggle_status(doc):
-		if not user_has_permission(doc, "write"):
-			raise frappe.PermissionError("You do not have permission to remove this file")
-		if doc.status == STATUS_ACTIVE:
-			flag = STATUS_TRASHED
-			manager.move_to_trash(doc)
-		else:
-			validate_quota(doc.owner, doc.file_size)
-			# A trashed name is free — get_new_file_name only counts Active siblings —
-			# so something may have taken it. Restoring onto it would overwrite the
-			# newcomer's blob, or, for a folder, land inside it.
-			available = get_new_file_name(doc.file_name, doc.folder, doc.file_type, doc.name)
-			if available != doc.file_name:
-				doc.flags.drive_disk_rename = True
-				doc.file_name = available
-				if not manager.flat and not doc._not_in_disk():
-					doc.file_url = str(manager.get_disk_path(doc)) + ("/" if doc.is_folder else "")
-			manager.restore(doc)
-			flag = STATUS_ACTIVE
+    def depth_zero_toggle_status(doc):
+        if not user_has_permission(doc, "write"):
+            raise frappe.PermissionError("You do not have permission to remove this file")
+        if doc.status == STATUS_ACTIVE:
+            flag = STATUS_TRASHED
+            manager.move_to_trash(doc)
+        else:
+            validate_quota(doc.owner, doc.file_size)
+            # A trashed name is free — get_new_file_name only counts Active siblings —
+            # so something may have taken it. Restoring onto it would overwrite the
+            # newcomer's blob, or, for a folder, land inside it.
+            available = get_new_file_name(doc.file_name, doc.folder, doc.file_type, doc.name)
+            if available != doc.file_name:
+                doc.flags.drive_disk_rename = True
+                doc.file_name = available
+                if not manager.flat and not doc._not_in_disk():
+                    doc.file_url = str(manager.get_disk_path(doc)) + ("/" if doc.is_folder else "")
+            manager.restore(doc)
+            flag = STATUS_ACTIVE
 
-		doc.status = flag
-		doc.file_modified = frappe.utils.now_datetime()
-		# Only update parent folder size if parent exists (not root level)
-		if doc.folder:
-			folder_size = frappe.db.get_value("File", doc.folder, "file_size") or 0
-			frappe.db.set_value(
-				"File",
-				doc.folder,
-				"file_size",
-				folder_size + doc.file_size * (1 if flag == STATUS_ACTIVE else -1),
-			)
+        doc.status = flag
+        doc.file_modified = frappe.utils.now_datetime()
+        # Only update parent folder size if parent exists (not root level)
+        if doc.folder:
+            folder_size = frappe.db.get_value("File", doc.folder, "file_size") or 0
+            frappe.db.set_value(
+                "File",
+                doc.folder,
+                "file_size",
+                folder_size + doc.file_size * (1 if flag == STATUS_ACTIVE else -1),
+            )
 
-		doc.save()
+        doc.save()
 
-	for entity in entity_names:
-		depth_zero_toggle_status(frappe.get_doc("File", entity))
+    for entity in entity_names:
+        depth_zero_toggle_status(frappe.get_doc("File", entity))
 
 
 @frappe.whitelist()
 def delete_entities(entity_names: list[str] | None = None, clear_all: bool = False):
-	if clear_all:
-		entity_names = frappe.db.get_list(
-			"File", {"status": STATUS_TRASHED, "owner": frappe.session.user}, pluck="name"
-		)
-	elif isinstance(entity_names, str):
-		entity_names = json.loads(entity_names)
-	elif not isinstance(entity_names, list) or not entity_names:
-		frappe.throw(f"Expected non-empty list but got {type(entity_names)}", ValueError)
+    if clear_all:
+        entity_names = frappe.db.get_list(
+            "File", {"status": STATUS_TRASHED, "owner": frappe.session.user}, pluck="name"
+        )
+    elif isinstance(entity_names, str):
+        entity_names = json.loads(entity_names)
+    elif not isinstance(entity_names, list) or not entity_names:
+        frappe.throw(f"Expected non-empty list but got {type(entity_names)}", ValueError)
 
-	for entity in entity_names:
-		frappe.get_doc("File", entity).permanent_delete()
+    for entity in entity_names:
+        frappe.get_doc("File", entity).permanent_delete()
 
 
 @frappe.whitelist()
 def rename(entity_name: str, new_title: str):
-	drive_file = frappe.get_doc("File", entity_name)
-	return drive_file.rename(new_title)
+    drive_file = frappe.get_doc("File", entity_name)
+    return drive_file.rename(new_title)
 
 
 # Will be replaced after new JS composables refactor
 @frappe.whitelist()
 def update_access(entity_name: str, method: str, **kwargs):
-	drive_file = frappe.get_doc("File", entity_name)
-	kwargs.pop("cmd")
-	if not drive_file:
-		frappe.throw("Entity does not exist", ValueError)
-	if method == "share":
-		return drive_file.share(**kwargs)
-	elif method == "unshare":
-		return drive_file.unshare(user=kwargs.get("user"))
+    drive_file = frappe.get_doc("File", entity_name)
+    kwargs.pop("cmd")
+    if not drive_file:
+        frappe.throw("Entity does not exist", ValueError)
+    if method == "share":
+        return drive_file.share(**kwargs)
+    elif method == "unshare":
+        return drive_file.unshare(user=kwargs.get("user"))
 
 
 @frappe.whitelist()
 def remove_recents(entity_names: list[str] | None = None, clear_all: bool = False):
-	"""
-	Clear recent DriveEntities for specified user
+    """
+    Clear recent DriveEntities for specified user
 
-	:param entity_names: List of document-names
-	:type entity_names: list[str]
-	:raises ValueError: If decoded entity_names is not a list
-	"""
-	entity_names = entity_names or []
-	if clear_all:
-		return frappe.db.delete("Drive Entity Log", {"user": frappe.session.user})
-	elif not isinstance(entity_names, list):
-		frappe.throw(f"Expected list but got {type(entity_names)}", ValueError)
+    :param entity_names: List of document-names
+    :type entity_names: list[str]
+    :raises ValueError: If decoded entity_names is not a list
+    """
+    entity_names = entity_names or []
+    if clear_all:
+        return frappe.db.delete("Drive Entity Log", {"user": frappe.session.user})
+    elif not isinstance(entity_names, list):
+        frappe.throw(f"Expected list but got {type(entity_names)}", ValueError)
 
-	for entity in entity_names:
-		existing_doc = frappe.db.exists(
-			{
-				"doctype": "Drive Entity Log",
-				"entity_name": entity,
-				"user": frappe.session.user,
-			}
-		)
-		if existing_doc:
-			frappe.delete_doc("Drive Entity Log", existing_doc)
+    for entity in entity_names:
+        existing_doc = frappe.db.exists(
+            {
+                "doctype": "Drive Entity Log",
+                "entity_name": entity,
+                "user": frappe.session.user,
+            }
+        )
+        if existing_doc:
+            frappe.delete_doc("Drive Entity Log", existing_doc)
 
 
 @frappe.whitelist()
 def does_entity_exist(name: str | None = None, folder: str | None = None):
-	if not folder:
-		folder = get_user_folder().name
-	result = frappe.db.exists("File", {"folder": folder, "file_name": name})
-	return result
+    if not folder:
+        folder = get_user_folder().name
+    result = frappe.db.exists("File", {"folder": folder, "file_name": name})
+    return result
 
 
 @frappe.whitelist()
 def get_new_title(title: str, parent_name: str, folder: bool = False):
-	return get_new_file_name(title, parent_name, folder)
+    return get_new_file_name(title, parent_name, folder)
 
 
 @frappe.whitelist()
 def move(entity_names: list[str], new_parent: str | None = None):
-	"""
-	Move file or folder to the new parent folder
+    """
+    Move file or folder to the new parent folder
 
-	:param new_parent: Document-name of the new parent folder. Defaults to the user directory
-	:raises NotADirectoryError: If the new_parent is not a folder, or does not exist
-	:raises FileExistsError: If a file or folder with the same name already exists in the specified parent folder
-	:return: DriveEntity doc once file is moved
-	"""
-	if isinstance(entity_names, str):
-		entity_names = json.loads(entity_names)
-	if not entity_names or not isinstance(entity_names, list):
-		frappe.throw(f"Expected a non-empty list but got {type(entity_names)}", ValueError)
+    :param new_parent: Document-name of the new parent folder. Defaults to the user directory
+    :raises NotADirectoryError: If the new_parent is not a folder, or does not exist
+    :raises FileExistsError: If a file or folder with the same name already exists in the specified parent folder
+    :return: DriveEntity doc once file is moved
+    """
+    if isinstance(entity_names, str):
+        entity_names = json.loads(entity_names)
+    if not entity_names or not isinstance(entity_names, list):
+        frappe.throw(f"Expected a non-empty list but got {type(entity_names)}", ValueError)
 
-	for entity in entity_names:
-		doc = frappe.get_doc("File", entity)
-		res = doc.move(new_parent)
+    for entity in entity_names:
+        doc = frappe.get_doc("File", entity)
+        res = doc.move(new_parent)
 
-	return res
+    return res
 
 
 @frappe.whitelist()
 def search(query: str):
-	"""
-	Basic search implementation
-	"""
-	text = " ".join(k + "*" for k in query.split())
-	try:
-		result = frappe.db.sql(
-			"""
+    """
+    Basic search implementation
+    """
+    text = " ".join(k + "*" for k in query.split())
+    try:
+        result = frappe.db.sql(
+            """
         SELECT  `tabFile`.name,
                 `tabFile`.file_name,
                 `tabFile`.file_type,
@@ -831,97 +831,97 @@ def search(query: str):
         GROUP BY `tabFile`.`name`
         LIMIT 500
         """,
-			values={"text": text, "status": STATUS_ACTIVE},
-			as_dict=1,
-		)
-		return [r for r in result if user_has_permission(r.name, "read")][:50]
-	except Exception as e:
-		frappe.log_error(frappe.get_traceback(), "Frappe Drive Search Error")
-		return {"error": str(e)}
+            values={"text": text, "status": STATUS_ACTIVE},
+            as_dict=1,
+        )
+        return [r for r in result if user_has_permission(r.name, "read")][:50]
+    except Exception as e:
+        frappe.log_error(frappe.get_traceback(), "Frappe Drive Search Error")
+        return {"error": str(e)}
 
 
 @frappe.whitelist(allow_guest=True)
 def translate_old_name(old_name: str):
-	return frappe.get_value("File", {"old_name": old_name}, "name")
+    return frappe.get_value("File", {"old_name": old_name}, "name")
 
 
 @frappe.whitelist(allow_guest=True)
 def get_entity_type(entity_name: str):
-	if not user_has_permission(entity_name, "read"):
-		frappe.throw("You do not have permission to view this file.", frappe.PermissionError)
+    if not user_has_permission(entity_name, "read"):
+        frappe.throw("You do not have permission to view this file.", frappe.PermissionError)
 
-	entity = frappe.db.get_value(
-		"File",
-		{"status": STATUS_ACTIVE, "name": entity_name},
-		["name", "file_type"],
-		as_dict=1,
-	)
-	if entity.file_type == "Folder":
-		entity["type"] = "folder"
-	else:
-		entity["type"] = "file"
-	return entity
+    entity = frappe.db.get_value(
+        "File",
+        {"status": STATUS_ACTIVE, "name": entity_name},
+        ["name", "file_type"],
+        as_dict=1,
+    )
+    if entity.file_type == "Folder":
+        entity["type"] = "folder"
+    else:
+        entity["type"] = "file"
+    return entity
 
 
 @frappe.whitelist()
 def get_root_folder():
-	"""The shared Drive tree and the caller's private folder."""
-	return {"root": drive_root().name, "home": get_user_folder().name}
+    """The shared Drive tree and the caller's private folder."""
+    return {"root": drive_root().name, "home": get_user_folder().name}
 
 
 @frappe.whitelist(allow_guest=True)
 def redirect_to_original(file_id: str):
-	"""
-	Redirect Drive attachments to original files
-	"""
-	file = frappe.get_cached_doc("File", file_id)
-	if not user_has_permission(file_id, "read"):
-		frappe.throw("You do not have permission to view this file.", frappe.PermissionError)
-	if not file.content_doctype == ATTACHMENT_CONTENT_DOCTYPE:
-		frappe.throw("This is not an attachment", ValueError)
+    """
+    Redirect Drive attachments to original files
+    """
+    file = frappe.get_cached_doc("File", file_id)
+    if not user_has_permission(file_id, "read"):
+        frappe.throw("You do not have permission to view this file.", frappe.PermissionError)
+    if not file.content_doctype == ATTACHMENT_CONTENT_DOCTYPE:
+        frappe.throw("This is not an attachment", ValueError)
 
-	frappe.local.response["type"] = "redirect"
-	frappe.local.response["location"] = "/drive/g/" + file.content_docname
+    frappe.local.response["type"] = "redirect"
+    frappe.local.response["location"] = "/drive/g/" + file.content_docname
 
 
 @frappe.whitelist()
 def track_visit(entity_name: str):
-	entity = frappe.get_doc("File", entity_name)
-	mark_as_viewed(entity)
+    entity = frappe.get_doc("File", entity_name)
+    mark_as_viewed(entity)
 
 
 @frappe.whitelist()
 def get_docs_attached_to(file_name: str):
-	file = frappe.get_doc("File", file_name)
-	return frappe.get_list(
-		"File",
-		filters={"attached_to_doctype": ["is", "set"], "file_url": file.file_url},
-		fields=["attached_to_doctype", "attached_to_name"],
-	)
+    file = frappe.get_doc("File", file_name)
+    return frappe.get_list(
+        "File",
+        filters={"attached_to_doctype": ["is", "set"], "file_url": file.file_url},
+        fields=["attached_to_doctype", "attached_to_name"],
+    )
 
 
 def get_upload_path(file_name):
-	root_folder = frappe.get_single("Drive Disk Settings").root_folder or ""
-	uploads_path = Path(frappe.get_site_path("private/files"), root_folder, ".uploads")
-	uploads_path.mkdir(exist_ok=True)
-	return uploads_path / file_name
+    root_folder = frappe.get_single("Drive Disk Settings").root_folder or ""
+    uploads_path = Path(frappe.get_site_path("private/files"), root_folder, ".uploads")
+    uploads_path.mkdir(exist_ok=True)
+    return uploads_path / file_name
 
 
 @frappe.whitelist()
 def resolve_legacy_route(old_id: str):
-	"""Where a pre-migration team link should land now.
+    """Where a pre-migration team link should land now.
 
-	Teams became folders and their ids went with the doctype, so `/drive/t/<team>`
-	can only be answered from the mapping the migration left behind. Returns None
-	when there is nothing to point at, so the caller can 404 normally.
-	"""
-	entity = frappe.db.get_value("Drive Legacy Route", old_id, "entity")
-	if not entity:
-		return None
-	row = frappe.db.get_value("File", entity, ["name", "is_folder", "status"], as_dict=True)
-	if not row or row.status != STATUS_ACTIVE:
-		return None
-	if not user_has_permission(entity, "read"):
-		# don't confirm it exists to someone who cannot open it
-		return None
-	return {"name": row.name, "is_folder": bool(row.is_folder)}
+    Teams became folders and their ids went with the doctype, so `/drive/t/<team>`
+    can only be answered from the mapping the migration left behind. Returns None
+    when there is nothing to point at, so the caller can 404 normally.
+    """
+    entity = frappe.db.get_value("Drive Legacy Route", old_id, "entity")
+    if not entity:
+        return None
+    row = frappe.db.get_value("File", entity, ["name", "is_folder", "status"], as_dict=True)
+    if not row or row.status != STATUS_ACTIVE:
+        return None
+    if not user_has_permission(entity, "read"):
+        # don't confirm it exists to someone who cannot open it
+        return None
+    return {"name": row.name, "is_folder": bool(row.is_folder)}

--- a/suite/drive/api/list.py
+++ b/suite/drive/api/list.py
@@ -8,17 +8,17 @@ from pypika import functions as fn
 from suite.drive.utils import (
     FILE_FIELDS,
     GENERAL_USER,
-    ROOT_FOLDER,
     KIND_VIRTUAL,
     MIME_LIST_MAP,
+    ROOT_FOLDER,
     STATUS_ACTIVE,
     STATUS_TRASHED,
     USERS_FOLDER,
     entity_kind,
     get_principals,
-    principal_list,
     get_user_folder,
     hide_storage_key,
+    principal_list,
 )
 from suite.drive.utils.api import get_default_access
 

--- a/suite/drive/api/list.py
+++ b/suite/drive/api/list.py
@@ -6,19 +6,19 @@ from pypika import Criterion, CustomFunction, Order
 from pypika import functions as fn
 
 from suite.drive.utils import (
-	FILE_FIELDS,
-	GENERAL_USER,
-	ROOT_FOLDER,
-	KIND_VIRTUAL,
-	MIME_LIST_MAP,
-	STATUS_ACTIVE,
-	STATUS_TRASHED,
-	USERS_FOLDER,
-	entity_kind,
-	get_principals,
-	principal_list,
-	get_user_folder,
-	hide_storage_key,
+    FILE_FIELDS,
+    GENERAL_USER,
+    ROOT_FOLDER,
+    KIND_VIRTUAL,
+    MIME_LIST_MAP,
+    STATUS_ACTIVE,
+    STATUS_TRASHED,
+    USERS_FOLDER,
+    entity_kind,
+    get_principals,
+    principal_list,
+    get_user_folder,
+    hide_storage_key,
 )
 from suite.drive.utils.api import get_default_access
 
@@ -36,68 +36,68 @@ Binary = CustomFunction("BINARY", ["expression"])
 
 # Helper Functions for Filters
 def _apply_shared_filter(query, shared_type):
-	"""
-	Filters query to show shared files based on shared_type parameter.
-	- "with": files explicitly shared with the current user
-	- "public": publicly shared files
-	- False/None: no share join
-	"""
-	if not shared_type:
-		return query
+    """
+    Filters query to show shared files based on shared_type parameter.
+    - "with": files explicitly shared with the current user
+    - "public": publicly shared files
+    - False/None: no share join
+    """
+    if not shared_type:
+        return query
 
-	user = frappe.session.user if frappe.session.user != "Guest" else ""
-	if shared_type == "with":
-		# Every principal a share can name them by except the site-wide ones: a
-		# folder shared with a group is shared with them, and would otherwise be
-		# reachable but findable nowhere. $GENERAL and link rows are excluded, or
-		# everything shared site-wide would land here.
-		principals = [p for p in get_principals(user) if p and p != GENERAL_USER]
-		# Ownership is itself a permission row naming you, so without this your own
-		# folder and files come back as things shared with you.
-		match = DrivePermission.user.isin(principals) & (DriveFile.owner != user)
-	else:
-		match = DrivePermission.user == ""
-	cond = (DrivePermission.entity == DriveFile.name) & match & (DrivePermission.deny == 0)
-	# Structural folders are scaffolding, not something anyone shared.
-	cond = cond & DriveFile.name.notin([ROOT_FOLDER, USERS_FOLDER])
-	return query.right_join(DrivePermission).on(cond)
+    user = frappe.session.user if frappe.session.user != "Guest" else ""
+    if shared_type == "with":
+        # Every principal a share can name them by except the site-wide ones: a
+        # folder shared with a group is shared with them, and would otherwise be
+        # reachable but findable nowhere. $GENERAL and link rows are excluded, or
+        # everything shared site-wide would land here.
+        principals = [p for p in get_principals(user) if p and p != GENERAL_USER]
+        # Ownership is itself a permission row naming you, so without this your own
+        # folder and files come back as things shared with you.
+        match = DrivePermission.user.isin(principals) & (DriveFile.owner != user)
+    else:
+        match = DrivePermission.user == ""
+    cond = (DrivePermission.entity == DriveFile.name) & match & (DrivePermission.deny == 0)
+    # Structural folders are scaffolding, not something anyone shared.
+    cond = cond & DriveFile.name.notin([ROOT_FOLDER, USERS_FOLDER])
+    return query.right_join(DrivePermission).on(cond)
 
 
 def _apply_file_kinds_filter(query, file_kinds):
-	"""
-	Filters files by kind/mime type.
-	"""
-	file_kinds = json.loads(file_kinds) if isinstance(file_kinds, str) else file_kinds
-	if not file_kinds:
-		return query
+    """
+    Filters files by kind/mime type.
+    """
+    file_kinds = json.loads(file_kinds) if isinstance(file_kinds, str) else file_kinds
+    if not file_kinds:
+        return query
 
-	mime_types = []
-	for kind in file_kinds:
-		mime_types.extend(MIME_LIST_MAP.get(kind, []))
+    mime_types = []
+    for kind in file_kinds:
+        mime_types.extend(MIME_LIST_MAP.get(kind, []))
 
-	criterion = [DriveFile.mime_type == mime_type for mime_type in mime_types]
-	if "Folder" in file_kinds:
-		criterion.append(DriveFile.is_folder == 1)
+    criterion = [DriveFile.mime_type == mime_type for mime_type in mime_types]
+    if "Folder" in file_kinds:
+        criterion.append(DriveFile.is_folder == 1)
 
-	return query.where(Criterion.any(criterion))
+    return query.where(Criterion.any(criterion))
 
 
 # Data Aggregation Functions
 def _get_children_count(files):
-	"""
-	Returns a dict mapping folder names to their child count.
+    """
+    Returns a dict mapping folder names to their child count.
 
-	Counts what the caller can actually see. Access is inherited, so a child is
-	visible unless a deny row hides it and nothing nearer grants it back —
-	otherwise `Previous Teams` reports all 512 migrated teams to someone who can
-	open three of them.
-	"""
-	if not files:
-		return {}
-	names = [k["name"] for k in files]
-	principals = principal_list()
-	rows = frappe.db.sql(
-		f"""
+    Counts what the caller can actually see. Access is inherited, so a child is
+    visible unless a deny row hides it and nothing nearer grants it back —
+    otherwise `Previous Teams` reports all 512 migrated teams to someone who can
+    open three of them.
+    """
+    if not files:
+        return {}
+    names = [k["name"] for k in files]
+    principals = principal_list()
+    rows = frappe.db.sql(
+        f"""
 		select f.folder, count(*)
 		from `tabFile` f
 		where f.folder in %(names)s and f.status = %(active)s
@@ -115,414 +115,414 @@ def _get_children_count(files):
 		  )
 		group by f.folder
 		""",
-		{"names": names, "active": STATUS_ACTIVE},
-	)
-	return dict(rows)
+        {"names": names, "active": STATUS_ACTIVE},
+    )
+    return dict(rows)
 
 
 def _get_slide_counts(rows):
-	"""
-	Returns a dict mapping presentation docnames to their slide count.
-	"""
-	# Imported here as suite.slides imports from suite.drive.
-	from suite.slides.doctype.presentation.presentation import get_slide_counts
+    """
+    Returns a dict mapping presentation docnames to their slide count.
+    """
+    # Imported here as suite.slides imports from suite.drive.
+    from suite.slides.doctype.presentation.presentation import get_slide_counts
 
-	return get_slide_counts(
-		[
-			r["content_docname"]
-			for r in rows
-			if r.get("content_doctype") == "Presentation" and r.get("content_docname")
-		]
-	)
+    return get_slide_counts(
+        [
+            r["content_docname"]
+            for r in rows
+            if r.get("content_doctype") == "Presentation" and r.get("content_docname")
+        ]
+    )
 
 
 def _get_share_count(names):
-	"""
-	Returns a dict mapping file names to their share count.
-	Counts shares with individual users (excludes general shares and denies).
-	"""
-	if not names:
-		return {}
-	query = (
-		frappe.qb.from_(DriveFile)
-		.right_join(DrivePermission)
-		.on(DrivePermission.entity == DriveFile.name)
-		.where(
-			DrivePermission.entity.isin(names)
-			& (DrivePermission.user.notin(["", GENERAL_USER]))
-			& (DrivePermission.deny == 0)
-		)
-		.select(DriveFile.name, fn.Count("*").as_("share_count"))
-		.groupby(DriveFile.name)
-	)
-	return dict(query.run())
+    """
+    Returns a dict mapping file names to their share count.
+    Counts shares with individual users (excludes general shares and denies).
+    """
+    if not names:
+        return {}
+    query = (
+        frappe.qb.from_(DriveFile)
+        .right_join(DrivePermission)
+        .on(DrivePermission.entity == DriveFile.name)
+        .where(
+            DrivePermission.entity.isin(names)
+            & (DrivePermission.user.notin(["", GENERAL_USER]))
+            & (DrivePermission.deny == 0)
+        )
+        .select(DriveFile.name, fn.Count("*").as_("share_count"))
+        .groupby(DriveFile.name)
+    )
+    return dict(query.run())
 
 
 def _get_public_files(names):
-	"""
-	Returns a set of file names that are publicly shared.
-	"""
-	if not names:
-		return set()
-	query = (
-		frappe.qb.from_(DrivePermission)
-		.where(
-			(DrivePermission.entity.isin(names)) & (DrivePermission.user == "") & (DrivePermission.deny == 0)
-		)
-		.select(DrivePermission.entity)
-	)
-	return set(k[0] for k in query.run())
+    """
+    Returns a set of file names that are publicly shared.
+    """
+    if not names:
+        return set()
+    query = (
+        frappe.qb.from_(DrivePermission)
+        .where(
+            (DrivePermission.entity.isin(names)) & (DrivePermission.user == "") & (DrivePermission.deny == 0)
+        )
+        .select(DrivePermission.entity)
+    )
+    return set(k[0] for k in query.run())
 
 
 def _get_general_files(names):
-	"""
-	Returns a set of file names explicitly shared with all site users.
-	"""
-	if not names:
-		return set()
-	query = (
-		frappe.qb.from_(DrivePermission)
-		.where(
-			(DrivePermission.entity.isin(names))
-			& (DrivePermission.user == GENERAL_USER)
-			& (DrivePermission.deny == 0)
-		)
-		.select(DrivePermission.entity)
-	)
-	return set(k[0] for k in query.run())
+    """
+    Returns a set of file names explicitly shared with all site users.
+    """
+    if not names:
+        return set()
+    query = (
+        frappe.qb.from_(DrivePermission)
+        .where(
+            (DrivePermission.entity.isin(names))
+            & (DrivePermission.user == GENERAL_USER)
+            & (DrivePermission.deny == 0)
+        )
+        .select(DrivePermission.entity)
+    )
+    return set(k[0] for k in query.run())
 
 
 def _get_basic_query(search):
-	query = frappe.qb.from_(DriveFile).where(DriveFile.status == STATUS_ACTIVE)
-	if search:
-		query = query.where(DriveFile.file_name.like(f"%{search}%"))
-	return query
+    query = frappe.qb.from_(DriveFile).where(DriveFile.status == STATUS_ACTIVE)
+    if search:
+        query = query.where(DriveFile.file_name.like(f"%{search}%"))
+    return query
 
 
 @frappe.whitelist(allow_guest=True)
 def files(
-	entity_name: str | None = None,
-	order_by: str = "modified",
-	ascending: bool = True,
-	file_kinds: list[str] | str = [],
-	search: str = None,
-	start: int = 0,
-	limit: int = None,
+    entity_name: str | None = None,
+    order_by: str = "modified",
+    ascending: bool = True,
+    file_kinds: list[str] | str = [],
+    search: str = None,
+    start: int = 0,
+    limit: int = None,
 ):
-	"""
-	Returns active files in a folder. Pass `start`/`limit` to page through large
-	folders. When `search` is set, results span the whole tree (not just the
-	current folder).
-	"""
-	if not entity_name:
-		entity_name = get_user_folder().name
+    """
+    Returns active files in a folder. Pass `start`/`limit` to page through large
+    folders. When `search` is set, results span the whole tree (not just the
+    current folder).
+    """
+    if not entity_name:
+        entity_name = get_user_folder().name
 
-	entity = frappe.get_doc("File", entity_name)
+    entity = frappe.get_doc("File", entity_name)
 
-	if not user_has_permission(entity, "read"):
-		frappe.throw(
-			"You don't have access.",
-			frappe.exceptions.PermissionError,
-		)
+    if not user_has_permission(entity, "read"):
+        frappe.throw(
+            "You don't have access.",
+            frappe.exceptions.PermissionError,
+        )
 
-	query = _get_basic_query(search)
-	if not search:
-		# Folder browsing; search is tree-wide so it skips the folder filter.
-		query = query.where(DriveFile.folder == entity_name)
+    query = _get_basic_query(search)
+    if not search:
+        # Folder browsing; search is tree-wide so it skips the folder filter.
+        query = query.where(DriveFile.folder == entity_name)
 
-	return get_query_data(
-		query,
-		file_kinds=file_kinds,
-		entity_name=entity_name,
-		order_by=order_by,
-		ascending=ascending,
-		start=start,
-		limit=limit,
-	)
+    return get_query_data(
+        query,
+        file_kinds=file_kinds,
+        entity_name=entity_name,
+        order_by=order_by,
+        ascending=ascending,
+        start=start,
+        limit=limit,
+    )
 
 
 @frappe.whitelist()
 def shared(
-	shared_type: str = "with",
-	order_by: str = "modified",
-	ascending: bool = True,
-	file_kinds: list[str] | str = [],
-	search: str = None,
-	start: int = 0,
-	limit: int = None,
+    shared_type: str = "with",
+    order_by: str = "modified",
+    ascending: bool = True,
+    file_kinds: list[str] | str = [],
+    search: str = None,
+    start: int = 0,
+    limit: int = None,
 ):
-	"""
-	Returns shared files based on shared_type parameter.
-	- "with": files shared with current user
-	- "public": publicly shared files
-	"""
-	query = _get_basic_query(search)
+    """
+    Returns shared files based on shared_type parameter.
+    - "with": files shared with current user
+    - "public": publicly shared files
+    """
+    query = _get_basic_query(search)
 
-	return get_query_data(
-		query,
-		shared_type=shared_type,
-		file_kinds=file_kinds,
-		order_by=order_by,
-		ascending=ascending,
-		start=start,
-		limit=limit,
-	)
+    return get_query_data(
+        query,
+        shared_type=shared_type,
+        file_kinds=file_kinds,
+        order_by=order_by,
+        ascending=ascending,
+        start=start,
+        limit=limit,
+    )
 
 
 @frappe.whitelist()
 def favourites(
-	order_by: str = "modified",
-	ascending: bool = True,
-	file_kinds: list[str] | str = [],
-	search: str = None,
-	start: int = 0,
-	limit: int = None,
+    order_by: str = "modified",
+    ascending: bool = True,
+    file_kinds: list[str] | str = [],
+    search: str = None,
+    start: int = 0,
+    limit: int = None,
 ):
-	"""
-	Returns all files marked as favourite by the current user.
-	"""
-	query = _get_basic_query(search)
+    """
+    Returns all files marked as favourite by the current user.
+    """
+    query = _get_basic_query(search)
 
-	return get_query_data(
-		query,
-		favourites_only=True,
-		file_kinds=file_kinds,
-		order_by=order_by,
-		ascending=ascending,
-		start=start,
-		limit=limit,
-	)
+    return get_query_data(
+        query,
+        favourites_only=True,
+        file_kinds=file_kinds,
+        order_by=order_by,
+        ascending=ascending,
+        start=start,
+        limit=limit,
+    )
 
 
 @frappe.whitelist()
 def recents(
-	order_by: str = "modified",
-	ascending: bool = True,
-	file_kinds: list[str] | str = [],
-	search: str = None,
-	start: int = 0,
-	limit: int = None,
+    order_by: str = "modified",
+    ascending: bool = True,
+    file_kinds: list[str] | str = [],
+    search: str = None,
+    start: int = 0,
+    limit: int = None,
 ):
-	"""
-	Returns all files marked recently by the current user.
-	"""
-	query = _get_basic_query(search)
+    """
+    Returns all files marked recently by the current user.
+    """
+    query = _get_basic_query(search)
 
-	return get_query_data(
-		query,
-		recents_only=True,
-		file_kinds=file_kinds,
-		order_by=order_by,
-		ascending=ascending,
-		start=start,
-		limit=limit,
-	)
+    return get_query_data(
+        query,
+        recents_only=True,
+        file_kinds=file_kinds,
+        order_by=order_by,
+        ascending=ascending,
+        start=start,
+        limit=limit,
+    )
 
 
 @frappe.whitelist()
 def trash(
-	order_by: str = "modified",
-	ascending: bool = True,
-	file_kinds: list[str] | str = [],
-	search: str = None,
-	start: int = 0,
-	limit: int = None,
+    order_by: str = "modified",
+    ascending: bool = True,
+    file_kinds: list[str] | str = [],
+    search: str = None,
+    start: int = 0,
+    limit: int = None,
 ):
-	"""
-	Returns all deleted files (trash) for the current user.
-	"""
-	query = (
-		frappe.qb.from_(DriveFile)
-		.where(DriveFile.status == STATUS_TRASHED)
-		.where(DriveFile.owner == frappe.session.user)
-	)
-	if search:
-		query = query.where(DriveFile.file_name.like(f"%{search}%"))
+    """
+    Returns all deleted files (trash) for the current user.
+    """
+    query = (
+        frappe.qb.from_(DriveFile)
+        .where(DriveFile.status == STATUS_TRASHED)
+        .where(DriveFile.owner == frappe.session.user)
+    )
+    if search:
+        query = query.where(DriveFile.file_name.like(f"%{search}%"))
 
-	return get_query_data(
-		query,
-		file_kinds=file_kinds,
-		order_by=order_by,
-		ascending=ascending,
-		start=start,
-		limit=limit,
-	)
+    return get_query_data(
+        query,
+        file_kinds=file_kinds,
+        order_by=order_by,
+        ascending=ascending,
+        start=start,
+        limit=limit,
+    )
 
 
 ALLOWED_SORT_FIELDS = {
-	"name",
-	"file_name",
-	"file_size",
-	"file_type",
-	"creation",
-	"modified",
-	"owner",
+    "name",
+    "file_name",
+    "file_size",
+    "file_type",
+    "creation",
+    "modified",
+    "owner",
 }
 
 
 def get_query_data(
-	query,
-	favourites_only=False,
-	recents_only=False,
-	file_kinds=[],
-	entity_name=None,
-	shared_type=None,
-	order_by="modified",
-	ascending=True,
-	start=0,
-	limit=None,
+    query,
+    favourites_only=False,
+    recents_only=False,
+    file_kinds=[],
+    entity_name=None,
+    shared_type=None,
+    order_by="modified",
+    ascending=True,
+    start=0,
+    limit=None,
 ):
-	"""
-	Runs all the necessary commands to obtain files in the structure expected by Drive frontend.
-	"""
-	if order_by not in ALLOWED_SORT_FIELDS:
-		order_by = "modified"
+    """
+    Runs all the necessary commands to obtain files in the structure expected by Drive frontend.
+    """
+    if order_by not in ALLOWED_SORT_FIELDS:
+        order_by = "modified"
 
-	# Apply shared filter
-	query = _apply_shared_filter(query, shared_type)
-	query = query.select(*FILE_FIELDS)
+    # Apply shared filter
+    query = _apply_shared_filter(query, shared_type)
+    query = query.select(*FILE_FIELDS)
 
-	# Send owner display data with files so the list view doesn't need a separate users fetch
-	query = (
-		query.left_join(DriveUser)
-		.on(DriveUser.name == DriveFile.owner)
-		.select(DriveUser.full_name.as_("owner_full_name"), DriveUser.user_image.as_("owner_image"))
-	)
+    # Send owner display data with files so the list view doesn't need a separate users fetch
+    query = (
+        query.left_join(DriveUser)
+        .on(DriveUser.name == DriveFile.owner)
+        .select(DriveUser.full_name.as_("owner_full_name"), DriveUser.user_image.as_("owner_image"))
+    )
 
-	# Apply favourites filter
-	if favourites_only:
-		query = query.right_join(DriveFavourite)
-	else:
-		query = query.left_join(DriveFavourite)
+    # Apply favourites filter
+    if favourites_only:
+        query = query.right_join(DriveFavourite)
+    else:
+        query = query.left_join(DriveFavourite)
 
-	query = query.on(
-		(DriveFavourite.entity == DriveFile.name) & (DriveFavourite.user == frappe.session.user)
-	).select(DriveFavourite.name.as_("is_favourite"))
+    query = query.on(
+        (DriveFavourite.entity == DriveFile.name) & (DriveFavourite.user == frappe.session.user)
+    ).select(DriveFavourite.name.as_("is_favourite"))
 
-	# Apply recents filter
-	if recents_only:
-		query = (
-			query.right_join(Recents)
-			.on((Recents.entity_name == DriveFile.name) & (Recents.user == frappe.session.user))
-			.orderby(Recents.last_interaction, order=Order.desc)
-		)
-	else:
-		query = (
-			query.left_join(Recents)
-			.on((Recents.entity_name == DriveFile.name) & (Recents.user == frappe.session.user))
-			.orderby(DriveFile[order_by], order=Order.asc if ascending else Order.desc)
-		)
+    # Apply recents filter
+    if recents_only:
+        query = (
+            query.right_join(Recents)
+            .on((Recents.entity_name == DriveFile.name) & (Recents.user == frappe.session.user))
+            .orderby(Recents.last_interaction, order=Order.desc)
+        )
+    else:
+        query = (
+            query.left_join(Recents)
+            .on((Recents.entity_name == DriveFile.name) & (Recents.user == frappe.session.user))
+            .orderby(DriveFile[order_by], order=Order.asc if ascending else Order.desc)
+        )
 
-	query = query.select(Recents.last_interaction.as_("accessed"))
+    query = query.select(Recents.last_interaction.as_("accessed"))
 
-	# Apply file kind filter
-	query = _apply_file_kinds_filter(query, file_kinds)
+    # Apply file kind filter
+    query = _apply_file_kinds_filter(query, file_kinds)
 
-	# Page through large result sets (aggregation below is scoped to the page).
-	if limit:
-		query = query.limit(int(limit)).offset(int(start or 0))
+    # Page through large result sets (aggregation below is scoped to the page).
+    if limit:
+        query = query.limit(int(limit)).offset(int(start or 0))
 
-	res = query.run(as_dict=True)
+    res = query.run(as_dict=True)
 
-	default = get_default_access(entity_name) if entity_name else 0
+    default = get_default_access(entity_name) if entity_name else 0
 
-	# Deduplicate results
-	if shared_type:
-		added = set()
-		filtered_list = []
-		for r in res:
-			if r["name"] not in added:
-				filtered_list.append(r)
-			added.add(r["name"])
-		res = filtered_list
+    # Deduplicate results
+    if shared_type:
+        added = set()
+        filtered_list = []
+        for r in res:
+            if r["name"] not in added:
+                filtered_list.append(r)
+            added.add(r["name"])
+        res = filtered_list
 
-	# Get aggregated data, scoped to the files we're returning
-	names = [r["name"] for r in res]
-	children_count = _get_children_count(res)
-	slide_counts = _get_slide_counts(res)
-	share_count = _get_share_count(names)
-	public_files = _get_public_files(names)
-	general_files = _get_general_files(names)
+    # Get aggregated data, scoped to the files we're returning
+    names = [r["name"] for r in res]
+    children_count = _get_children_count(res)
+    slide_counts = _get_slide_counts(res)
+    share_count = _get_share_count(names)
+    public_files = _get_public_files(names)
+    general_files = _get_general_files(names)
 
-	# Enrich results with aggregated data and permissions; access is resolved
-	# per row (deny rows can hide a child of a readable folder), so filter on it.
-	for r in res:
-		name = r["name"]
-		r["child_count"] = children_count.get(name, 0)
-		if r.get("content_doctype") == "Presentation":
-			r["slide_count"] = slide_counts.get(r["content_docname"], 0)
-		if name in public_files:
-			r["share_count"] = -2
-		elif default > -1 and name in general_files:
-			r["share_count"] = -1
-		elif default == 0:
-			r["share_count"] = share_count.get(name, default)
-		else:
-			r["share_count"] = default
+    # Enrich results with aggregated data and permissions; access is resolved
+    # per row (deny rows can hide a child of a readable folder), so filter on it.
+    for r in res:
+        name = r["name"]
+        r["child_count"] = children_count.get(name, 0)
+        if r.get("content_doctype") == "Presentation":
+            r["slide_count"] = slide_counts.get(r["content_docname"], 0)
+        if name in public_files:
+            r["share_count"] = -2
+        elif default > -1 and name in general_files:
+            r["share_count"] = -1
+        elif default == 0:
+            r["share_count"] = share_count.get(name, default)
+        else:
+            r["share_count"] = default
 
-		r["kind"] = entity_kind(r)
-		hide_storage_key(r)
-		r |= get_user_access(name)
+        r["kind"] = entity_kind(r)
+        hide_storage_key(r)
+        r |= get_user_access(name)
 
-	return [r for r in res if r["read"]]
+    return [r for r in res if r["read"]]
 
 
 @frappe.whitelist()
 def get_attachments(doctype: str | None = None, docname: str | None = None):
-	"""
-	Returns all files that are attached to a document.
-	If either doctype or docname isn't specified, returns a list of folder-like objects
-	that represents the tree Doctype > Doc > Attachments.
-	"""
-	# filter_file scopes attachments by doctype-level read (coarse), so gate on
-	# the authoritative per-file check used when files are actually served — this
-	# lets a file's owner through while blocking users who only have generic read
-	# on the doctype but not the specific document.
-	if doctype and docname:
-		files = frappe.get_list(
-			"File", filters={"attached_to_doctype": doctype, "attached_to_name": docname}, pluck="name"
-		)
-		files = [f for f in files if user_has_permission(f, "read")]
-		query = frappe.qb.from_(DriveFile).where(DriveFile.name.isin(files or [""]))
-		return get_query_data(query)
+    """
+    Returns all files that are attached to a document.
+    If either doctype or docname isn't specified, returns a list of folder-like objects
+    that represents the tree Doctype > Doc > Attachments.
+    """
+    # filter_file scopes attachments by doctype-level read (coarse), so gate on
+    # the authoritative per-file check used when files are actually served — this
+    # lets a file's owner through while blocking users who only have generic read
+    # on the doctype but not the specific document.
+    if doctype and docname:
+        files = frappe.get_list(
+            "File", filters={"attached_to_doctype": doctype, "attached_to_name": docname}, pluck="name"
+        )
+        files = [f for f in files if user_has_permission(f, "read")]
+        query = frappe.qb.from_(DriveFile).where(DriveFile.name.isin(files or [""]))
+        return get_query_data(query)
 
-	titles = {}
-	if doctype:
-		names = frappe.get_list(
-			"File", filters={"attached_to_doctype": doctype}, fields=["name", "attached_to_name"]
-		)
-		doctypes_set = Counter(k["attached_to_name"] for k in names if user_has_permission(k["name"], "read"))
-		# Show each document by its title field rather than its raw name (ID).
-		title_field = frappe.get_meta(doctype).get_title_field()
-		if title_field != "name":
-			titles = dict(
-				frappe.get_all(
-					doctype,
-					filters={"name": ["in", list(doctypes_set) or [""]]},
-					fields=["name", title_field],
-					as_list=True,
-				)
-			)
-	else:
-		names = frappe.get_list(
-			"File",
-			filters={"attached_to_doctype": ["is", "set"]},
-			fields=["name", "attached_to_doctype"],
-		)
-		doctypes_set = Counter(
-			k["attached_to_doctype"] for k in names if user_has_permission(k["name"], "read")
-		)
+    titles = {}
+    if doctype:
+        names = frappe.get_list(
+            "File", filters={"attached_to_doctype": doctype}, fields=["name", "attached_to_name"]
+        )
+        doctypes_set = Counter(k["attached_to_name"] for k in names if user_has_permission(k["name"], "read"))
+        # Show each document by its title field rather than its raw name (ID).
+        title_field = frappe.get_meta(doctype).get_title_field()
+        if title_field != "name":
+            titles = dict(
+                frappe.get_all(
+                    doctype,
+                    filters={"name": ["in", list(doctypes_set) or [""]]},
+                    fields=["name", title_field],
+                    as_list=True,
+                )
+            )
+    else:
+        names = frappe.get_list(
+            "File",
+            filters={"attached_to_doctype": ["is", "set"]},
+            fields=["name", "attached_to_doctype"],
+        )
+        doctypes_set = Counter(
+            k["attached_to_doctype"] for k in names if user_has_permission(k["name"], "read")
+        )
 
-	return [
-		{
-			"name": name,
-			"file_name": titles.get(name) or name,
-			"is_folder": 1,
-			"file_type": "Folder",
-			"child_count": size,
-			"kind": KIND_VIRTUAL,
-			"attached_to_doctype": doctype or name,
-			"attached_to_name": name if doctype else None,
-		}
-		for name, size in doctypes_set.items()
-	]
+    return [
+        {
+            "name": name,
+            "file_name": titles.get(name) or name,
+            "is_folder": 1,
+            "file_type": "Folder",
+            "child_count": size,
+            "kind": KIND_VIRTUAL,
+            "attached_to_doctype": doctype or name,
+            "attached_to_name": name if doctype else None,
+        }
+        for name, size in doctypes_set.items()
+    ]

--- a/suite/drive/api/notifications.py
+++ b/suite/drive/api/notifications.py
@@ -4,144 +4,144 @@ from pypika import Order
 
 
 def get_link(entity):
-	if entity.file_type == "Document":
-		return "/writer/w/" + entity.name
-	type_ = {True: "f", bool(entity.is_folder): "d"}
-	return entity.file_url if entity.file_type == "Link" else f"/drive/{type_.get(True)}/{entity.name}/"
+    if entity.file_type == "Document":
+        return "/writer/w/" + entity.name
+    type_ = {True: "f", bool(entity.is_folder): "d"}
+    return entity.file_url if entity.file_type == "Link" else f"/drive/{type_.get(True)}/{entity.name}/"
 
 
 @frappe.whitelist()
 def get_notifications(only_unread: bool = False):
-	User = frappe.qb.DocType("User")
-	Notification = frappe.qb.DocType("Drive Notification")
-	fields = [
-		Notification.name,
-		Notification.to_user,
-		Notification.from_user,
-		Notification.read,
-		Notification.type,
-		Notification.message,
-		Notification.entity_type,
-		Notification.notif_doctype,
-		Notification.notif_doctype_name,
-		Notification.creation,
-		User.user_image,
-		User.full_name,
-	]
-	query = (
-		frappe.qb.from_(Notification)
-		.left_join(User)
-		.on(Notification.from_user == User.name)
-		.select(*fields)
-		.orderby(Notification.creation, order=Order.desc)
-	)
+    User = frappe.qb.DocType("User")
+    Notification = frappe.qb.DocType("Drive Notification")
+    fields = [
+        Notification.name,
+        Notification.to_user,
+        Notification.from_user,
+        Notification.read,
+        Notification.type,
+        Notification.message,
+        Notification.entity_type,
+        Notification.notif_doctype,
+        Notification.notif_doctype_name,
+        Notification.creation,
+        User.user_image,
+        User.full_name,
+    ]
+    query = (
+        frappe.qb.from_(Notification)
+        .left_join(User)
+        .on(Notification.from_user == User.name)
+        .select(*fields)
+        .orderby(Notification.creation, order=Order.desc)
+    )
 
-	if only_unread:
-		query = query.where(Notification.read == 0)
-	query = query.where(Notification.to_user == frappe.session.user)
-	result = query.run(as_dict=True)
-	return result
+    if only_unread:
+        query = query.where(Notification.read == 0)
+    query = query.where(Notification.to_user == frappe.session.user)
+    result = query.run(as_dict=True)
+    return result
 
 
 @frappe.whitelist()
 def get_unread_count():
-	"""
-	Return a count of records where user is current user and read is False
-	"""
-	return frappe.db.count("Drive Notification", filters={"to_user": frappe.session.user, "read": 0})
+    """
+    Return a count of records where user is current user and read is False
+    """
+    return frappe.db.count("Drive Notification", filters={"to_user": frappe.session.user, "read": 0})
 
 
 @frappe.whitelist()
 def mark_as_read(name: str | None = None, all: bool = False):
-	if all:
-		frappe.db.set_value(
-			"Drive Notification", {"to_user": frappe.session.user, "read": False}, "read", True
-		)
-		return
-	frappe.db.set_value("Drive Notification", name, "read", True)
-	return
+    if all:
+        frappe.db.set_value(
+            "Drive Notification", {"to_user": frappe.session.user, "read": False}, "read", True
+        )
+        return
+    frappe.db.set_value("Drive Notification", name, "read", True)
+    return
 
 
 def notify_mentions(entity_name, mentions, comment=False):
-	"""
-	Create a mention notification for each user mentioned
-	:param entity_name: ID of entity
-	:param document_name: ID of document containing mentions
-	"""
-	entity = frappe.get_doc("File", entity_name)
-	for mention in mentions:
-		create_notification(
-			frappe.session.user,
-			mention,
-			"Mention",
-			entity,
-			f"You were mentioned in a {'comment in:' if comment else 'document:'} {entity.file_name}",
-		)
+    """
+    Create a mention notification for each user mentioned
+    :param entity_name: ID of entity
+    :param document_name: ID of document containing mentions
+    """
+    entity = frappe.get_doc("File", entity_name)
+    for mention in mentions:
+        create_notification(
+            frappe.session.user,
+            mention,
+            "Mention",
+            entity,
+            f"You were mentioned in a {'comment in:' if comment else 'document:'} {entity.file_name}",
+        )
 
 
 def notify_share(entity_name, docperm_name):
-	"""
-	Create a share notification for each user
-	:param entity_name: ID of entity
-	:param document_name: ID of docshare containing share info
-	"""
-	entity = frappe.get_doc("File", entity_name)
-	docshare = frappe.get_doc("Drive Permission", docperm_name)
+    """
+    Create a share notification for each user
+    :param entity_name: ID of entity
+    :param document_name: ID of docshare containing share info
+    """
+    entity = frappe.get_doc("File", entity_name)
+    docshare = frappe.get_doc("Drive Permission", docperm_name)
 
-	author_full_name = frappe.db.get_value("User", {"name": docshare.owner}, ["full_name"])
-	entity_type = "document" if entity.file_type == "Document" else "folder" if entity.is_folder else "file"
-	link = get_link(entity)
-	message = f'{author_full_name} shared a {entity_type} with you: "{entity.file_name}"'
-	if not frappe.db.exists("User", docshare.user):
-		key = frappe.get_value("Drive User Invitation", {"email": docshare.user})
-		link = frappe.utils.get_url(
-			f"/api/method/suite.drive.api.product.accept_invite?key={key}&redirect={link}"
-		)
-	else:
-		create_notification(docshare.owner, docshare.user, "Share", entity, message)
-	send_share_email(docshare.user, message, link, entity_type)
+    author_full_name = frappe.db.get_value("User", {"name": docshare.owner}, ["full_name"])
+    entity_type = "document" if entity.file_type == "Document" else "folder" if entity.is_folder else "file"
+    link = get_link(entity)
+    message = f'{author_full_name} shared a {entity_type} with you: "{entity.file_name}"'
+    if not frappe.db.exists("User", docshare.user):
+        key = frappe.get_value("Drive User Invitation", {"email": docshare.user})
+        link = frappe.utils.get_url(
+            f"/api/method/suite.drive.api.product.accept_invite?key={key}&redirect={link}"
+        )
+    else:
+        create_notification(docshare.owner, docshare.user, "Share", entity, message)
+    send_share_email(docshare.user, message, link, entity_type)
 
 
 def create_notification(from_user: str, to_user: str, type: str, entity: str, message: str | None = None):
-	from suite.drive.api.permissions import get_user_access
+    from suite.drive.api.permissions import get_user_access
 
-	user_access = get_user_access(entity.name, to_user)
-	if user_access.get("read") == 0:
-		return
+    user_access = get_user_access(entity.name, to_user)
+    if user_access.get("read") == 0:
+        return
 
-	entity_type = "Document" if entity.file_type == "Document" else "Folder" if entity.is_folder else "File"
-	details = {
-		"from_user": from_user,
-		"to_user": to_user,
-		"type": type,
-		"entity_type": entity_type,
-		"notif_doctype": "File",
-		"notif_doctype_name": entity.name,
-		"message": message,
-	}
-	notif = frappe.db.exists("Drive Notification", details)
-	if notif:
-		return False
-	try:
-		frappe.get_doc({"doctype": "Drive Notification", **details}).insert()
-		return True
-	except Exception:
-		frappe.log_error(frappe.get_traceback(), "Frappe Drive Notification Error")
-		return False
+    entity_type = "Document" if entity.file_type == "Document" else "Folder" if entity.is_folder else "File"
+    details = {
+        "from_user": from_user,
+        "to_user": to_user,
+        "type": type,
+        "entity_type": entity_type,
+        "notif_doctype": "File",
+        "notif_doctype_name": entity.name,
+        "message": message,
+    }
+    notif = frappe.db.exists("Drive Notification", details)
+    if notif:
+        return False
+    try:
+        frappe.get_doc({"doctype": "Drive Notification", **details}).insert()
+        return True
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "Frappe Drive Notification Error")
+        return False
 
 
 def send_share_email(to, message, link, type_):
-	try:
-		frappe.sendmail(
-			recipients=to,
-			subject=f"Frappe Drive - {type_.capitalize()} Shared",
-			template="drive_share",
-			args={
-				"message": message,
-				"type": type_,
-				"link": link,
-			},
-			now=True,
-		)
-	except:
-		pass
+    try:
+        frappe.sendmail(
+            recipients=to,
+            subject=f"Frappe Drive - {type_.capitalize()} Shared",
+            template="drive_share",
+            args={
+                "message": message,
+                "type": type_,
+                "link": link,
+            },
+            now=True,
+        )
+    except:
+        pass

--- a/suite/drive/api/permissions.py
+++ b/suite/drive/api/permissions.py
@@ -2,241 +2,241 @@ import frappe
 from frappe.model.document import Document
 
 from suite.drive.utils import (
-	FILE_FIELDS,
-	GENERAL_USER,
-	GROUP_PREFIX,
-	PERMISSION_TYPES,
-	STATUS_ACTIVE,
-	entity_kind,
-	generate_upward_path,
-	get_valid_breadcrumbs,
-	hide_storage_key,
+    FILE_FIELDS,
+    GENERAL_USER,
+    GROUP_PREFIX,
+    PERMISSION_TYPES,
+    STATUS_ACTIVE,
+    entity_kind,
+    generate_upward_path,
+    get_valid_breadcrumbs,
+    hide_storage_key,
 )
 
 NO_ACCESS = {
-	"read": 0,
-	"comment": 0,
-	"share": 0,
-	"write": 0,
-	"upload": 0,
+    "read": 0,
+    "comment": 0,
+    "share": 0,
+    "write": 0,
+    "upload": 0,
 }
 
 
 def filter_access(path):
-	return {k: v for k, v in path[-1].items() if k in NO_ACCESS.keys()}
+    return {k: v for k, v in path[-1].items() if k in NO_ACCESS.keys()}
 
 
 @frappe.whitelist(allow_guest=True)
 def get_user_access(entity: str | Document | frappe._dict, user: str | None = None):
-	"""
-	Return the user specific permissions for an entity.
-	"""
-	if isinstance(entity, str):
-		entity = frappe.get_cached_doc("File", entity)
-	if not user:
-		user = frappe.session.user
+    """
+    Return the user specific permissions for an entity.
+    """
+    if isinstance(entity, str):
+        entity = frappe.get_cached_doc("File", entity)
+    if not user:
+        user = frappe.session.user
 
-	# Owners hold everything, bypassing any deny on the path.
-	if user != "Guest" and entity.owner == user:
-		return {**dict.fromkeys(PERMISSION_TYPES, 1), "type": "admin"}
+    # Owners hold everything, bypassing any deny on the path.
+    if user != "Guest" and entity.owner == user:
+        return {**dict.fromkeys(PERMISSION_TYPES, 1), "type": "admin"}
 
-	if entity.get("attached_to_doctype") and entity.get("attached_to_name"):
-		# Attachments follow their reference document; explicit Drive rows
-		# override it per type.
-		path = generate_upward_path(entity.name, user)
-		access = filter_access(path)
-		decided = set(path[-1]["decided"])
-		if decided != set(PERMISSION_TYPES):
-			access = {**_ref_doc_access(entity, user), **{t: access[t] for t in decided}}
-		return {**access, "type": "user" if access["write"] else "guest"}
+    if entity.get("attached_to_doctype") and entity.get("attached_to_name"):
+        # Attachments follow their reference document; explicit Drive rows
+        # override it per type.
+        path = generate_upward_path(entity.name, user)
+        access = filter_access(path)
+        decided = set(path[-1]["decided"])
+        if decided != set(PERMISSION_TYPES):
+            access = {**_ref_doc_access(entity, user), **{t: access[t] for t in decided}}
+        return {**access, "type": "user" if access["write"] else "guest"}
 
-	access = filter_access(generate_upward_path(entity.name, user))
-	return {**access, "type": "user" if access["write"] else "guest"}
+    access = filter_access(generate_upward_path(entity.name, user))
+    return {**access, "type": "user" if access["write"] else "guest"}
 
 
 def _ref_doc_access(entity, user):
-	"""Framework attachment semantics: write on the reference document gives
-	write, read gives read, public files are readable by anyone."""
-	public = not frappe.db.get_value("File", entity.name, "is_private")
-	write = read = False
-	if frappe.db.exists(entity.attached_to_doctype, entity.attached_to_name):
-		ref = frappe.get_doc(entity.attached_to_doctype, entity.attached_to_name)
-		write = bool(frappe.has_permission(ref.doctype, "write", doc=ref, user=user))
-		read = write or bool(frappe.has_permission(ref.doctype, "read", doc=ref, user=user))
-	return {
-		**NO_ACCESS,
-		"read": int(read or public),
-		"comment": int(write),
-		"write": int(write),
-	}
+    """Framework attachment semantics: write on the reference document gives
+    write, read gives read, public files are readable by anyone."""
+    public = not frappe.db.get_value("File", entity.name, "is_private")
+    write = read = False
+    if frappe.db.exists(entity.attached_to_doctype, entity.attached_to_name):
+        ref = frappe.get_doc(entity.attached_to_doctype, entity.attached_to_name)
+        write = bool(frappe.has_permission(ref.doctype, "write", doc=ref, user=user))
+        read = write or bool(frappe.has_permission(ref.doctype, "read", doc=ref, user=user))
+    return {
+        **NO_ACCESS,
+        "read": int(read or public),
+        "comment": int(write),
+        "write": int(write),
+    }
 
 
 @frappe.whitelist(allow_guest=True)
 def get_entity_with_permissions(entity_name: str):
-	"""
-	Return file data with permissions
-	"""
-	entity = frappe.get_all(
-		"File",
-		filters={"name": entity_name, "status": STATUS_ACTIVE},
-		fields=FILE_FIELDS,
-		limit=1,
-	)
-	if not entity:
-		# Mimic API v2 points
-		frappe.local.response.errors = [
-			{
-				"type": "PageDoesNotExistError",
-				"message": "We couldn't find what you're looking for.",
-			}
-		]
-		frappe.throw("We couldn't find what you're looking for.", frappe.PageDoesNotExistError)
-	entity = entity[0]
+    """
+    Return file data with permissions
+    """
+    entity = frappe.get_all(
+        "File",
+        filters={"name": entity_name, "status": STATUS_ACTIVE},
+        fields=FILE_FIELDS,
+        limit=1,
+    )
+    if not entity:
+        # Mimic API v2 points
+        frappe.local.response.errors = [
+            {
+                "type": "PageDoesNotExistError",
+                "message": "We couldn't find what you're looking for.",
+            }
+        ]
+        frappe.throw("We couldn't find what you're looking for.", frappe.PageDoesNotExistError)
+    entity = entity[0]
 
-	user_access = get_user_access(entity)
-	if not user_access.get("read"):
-		frappe.local.response.errors = [
-			{
-				"type": "PermissionError",
-				"message": "You don't have access to this file.",
-			}
-		]
-		frappe.throw("You don't have access to this file.", frappe.PermissionError)
+    user_access = get_user_access(entity)
+    if not user_access.get("read"):
+        frappe.local.response.errors = [
+            {
+                "type": "PermissionError",
+                "message": "You don't have access to this file.",
+            }
+        ]
+        frappe.throw("You don't have access to this file.", frappe.PermissionError)
 
-	owner_info = frappe.db.get_value("User", entity.owner, ["user_image", "full_name"], as_dict=True) or {}
-	breadcrumbs = {"breadcrumbs": get_valid_breadcrumbs(entity.name, user_access)}
-	favourite = frappe.db.get_value(
-		"Drive Favourite",
-		{
-			"entity": entity_name,
-			"user": frappe.session.user,
-		},
-		["entity as is_favourite"],
-	)
-	return_obj = entity | user_access | owner_info | breadcrumbs | {"is_favourite": favourite}
+    owner_info = frappe.db.get_value("User", entity.owner, ["user_image", "full_name"], as_dict=True) or {}
+    breadcrumbs = {"breadcrumbs": get_valid_breadcrumbs(entity.name, user_access)}
+    favourite = frappe.db.get_value(
+        "Drive Favourite",
+        {
+            "entity": entity_name,
+            "user": frappe.session.user,
+        },
+        ["entity as is_favourite"],
+    )
+    return_obj = entity | user_access | owner_info | breadcrumbs | {"is_favourite": favourite}
 
-	# General access marker: -2 public (link), -1 site users, 0 restricted.
-	default = 0
-	if get_user_access(entity, "Guest")["read"]:
-		default = -2
-	elif generate_upward_path(entity_name, GENERAL_USER)[-1]["read"]:
-		default = -1
-	return_obj["share_count"] = default
+    # General access marker: -2 public (link), -1 site users, 0 restricted.
+    default = 0
+    if get_user_access(entity, "Guest")["read"]:
+        default = -2
+    elif generate_upward_path(entity_name, GENERAL_USER)[-1]["read"]:
+        default = -1
+    return_obj["share_count"] = default
 
-	return_obj["kind"] = entity_kind(entity)
-	hide_storage_key(return_obj)
+    return_obj["kind"] = entity_kind(entity)
+    hide_storage_key(return_obj)
 
-	# To work with modern frappe-ui composables
-	frappe.response["data"] = return_obj
-	return return_obj
+    # To work with modern frappe-ui composables
+    frappe.response["data"] = return_obj
+    return return_obj
 
 
 @frappe.whitelist()
 def get_shared_with_list(entity: str):
-	"""
-	Return the list of users with whom this file or folder has been shared
+    """
+    Return the list of users with whom this file or folder has been shared
 
-	:param entity: Document-name of this file or folder
-	:raises PermissionError: If the user does not have edit permissions
-	:return: List of users, with permissions and last modified datetime
-	:rtype: list[frappe._dict]
-	"""
-	if not user_has_permission(entity, "share"):
-		raise frappe.PermissionError("You do not have permission to check the shares.")
+    :param entity: Document-name of this file or folder
+    :raises PermissionError: If the user does not have edit permissions
+    :return: List of users, with permissions and last modified datetime
+    :rtype: list[frappe._dict]
+    """
+    if not user_has_permission(entity, "share"):
+        raise frappe.PermissionError("You do not have permission to check the shares.")
 
-	permissions = frappe.db.get_all(
-		"Drive Permission",
-		filters=[["entity", "=", entity], ["user", "not in", ["", GENERAL_USER]], ["deny", "=", 0]],
-		order_by="user",
-		fields=["user", "read", "write", "comment", "upload", "share"],
-	)
-	for p in permissions:
-		if p.user.startswith(GROUP_PREFIX):
-			p.is_group = 1
-			p.full_name = p.user[len(GROUP_PREFIX) :]
+    permissions = frappe.db.get_all(
+        "Drive Permission",
+        filters=[["entity", "=", entity], ["user", "not in", ["", GENERAL_USER]], ["deny", "=", 0]],
+        order_by="user",
+        fields=["user", "read", "write", "comment", "upload", "share"],
+    )
+    for p in permissions:
+        if p.user.startswith(GROUP_PREFIX):
+            p.is_group = 1
+            p.full_name = p.user[len(GROUP_PREFIX) :]
 
-	owner = frappe.db.get_value("File", entity, "owner")
-	owner_info = frappe.db.get_value("User", owner, ["user_image", "full_name", "name as user"], as_dict=True)
-	if owner_info:
-		# the owner's User row can be gone; the file outlives them
-		permissions.insert(0, owner_info)
+    owner = frappe.db.get_value("File", entity, "owner")
+    owner_info = frappe.db.get_value("User", owner, ["user_image", "full_name", "name as user"], as_dict=True)
+    if owner_info:
+        # the owner's User row can be gone; the file outlives them
+        permissions.insert(0, owner_info)
 
-	for p in permissions:
-		if p.get("is_group"):
-			continue
-		user_info = frappe.db.get_value("User", p.user, ["user_image", "full_name", "email"], as_dict=True)
-		if user_info:
-			p.update(user_info)
-	return permissions
+    for p in permissions:
+        if p.get("is_group"):
+            continue
+        user_info = frappe.db.get_value("User", p.user, ["user_image", "full_name", "email"], as_dict=True)
+        if user_info:
+            p.update(user_info)
+    return permissions
 
 
 def exceeds_grant_ceiling(entity, requested, user=None):
-	"""Levels in `requested` the user doesn't hold, so can't hand out."""
-	user = user or frappe.session.user
-	if user == "Administrator" or "Suite Admin" in frappe.get_roles(user):
-		return []
-	granter = get_user_access(entity, user)
-	return [t for t in PERMISSION_TYPES if requested.get(t) and not granter.get(t)]
+    """Levels in `requested` the user doesn't hold, so can't hand out."""
+    user = user or frappe.session.user
+    if user == "Administrator" or "Suite Admin" in frappe.get_roles(user):
+        return []
+    granter = get_user_access(entity, user)
+    return [t for t in PERMISSION_TYPES if requested.get(t) and not granter.get(t)]
 
 
 def drive_permission_has_permission(doc, ptype="read", user=None):
-	user = user or frappe.session.user
-	if user == "Administrator" or "Suite Admin" in frappe.get_roles(user):
-		return True
-	if isinstance(doc, str):
-		doc = frappe.get_doc("Drive Permission", doc)
-	if ptype in ("read", "select"):
-		return doc.owner == user or doc.user == user
-	if not user_has_permission(doc.entity, "share", user):
-		return False
-	if ptype == "delete":
-		# Ownership is a permission row, so deleting one strips the owner's inherited
-		# access to descendants. `unshare` refuses it; a direct delete must too.
-		return doc.user == user or frappe.db.get_value("File", doc.entity, "owner") != doc.user
-	if doc.deny:
-		return True
-	return not exceeds_grant_ceiling(doc.entity, doc.as_dict(), user)
+    user = user or frappe.session.user
+    if user == "Administrator" or "Suite Admin" in frappe.get_roles(user):
+        return True
+    if isinstance(doc, str):
+        doc = frappe.get_doc("Drive Permission", doc)
+    if ptype in ("read", "select"):
+        return doc.owner == user or doc.user == user
+    if not user_has_permission(doc.entity, "share", user):
+        return False
+    if ptype == "delete":
+        # Ownership is a permission row, so deleting one strips the owner's inherited
+        # access to descendants. `unshare` refuses it; a direct delete must too.
+        return doc.user == user or frappe.db.get_value("File", doc.entity, "owner") != doc.user
+    if doc.deny:
+        return True
+    return not exceeds_grant_ceiling(doc.entity, doc.as_dict(), user)
 
 
 def drive_settings_has_permission(doc, ptype="read", user=None):
-	user = user or frappe.session.user
-	if user == "Administrator" or "Suite Admin" in frappe.get_roles(user):
-		return True
-	if user == "Guest":
-		return False
-	if isinstance(doc, str):
-		doc = frappe.get_doc("Drive Settings", doc)
-	return doc.user == user
+    user = user or frappe.session.user
+    if user == "Administrator" or "Suite Admin" in frappe.get_roles(user):
+        return True
+    if user == "Guest":
+        return False
+    if isinstance(doc, str):
+        doc = frappe.get_doc("Drive Settings", doc)
+    return doc.user == user
 
 
 def drive_invitation_has_permission(doc, ptype="read", user=None):
-	user = user or frappe.session.user
-	if user == "Administrator" or "Suite Admin" in frappe.get_roles(user):
-		return True
-	if isinstance(doc, str):
-		doc = frappe.get_doc("Drive User Invitation", doc)
-	return ptype in ("read", "select") and doc.email == user
+    user = user or frappe.session.user
+    if user == "Administrator" or "Suite Admin" in frappe.get_roles(user):
+        return True
+    if isinstance(doc, str):
+        doc = frappe.get_doc("Drive User Invitation", doc)
+    return ptype in ("read", "select") and doc.email == user
 
 
 def activity_log_has_permission(doc, ptype="read", user=None):
-	user = user or frappe.session.user
-	if user == "Administrator" or "Suite Admin" in frappe.get_roles(user):
-		return True
-	if isinstance(doc, str):
-		doc = frappe.get_doc("Drive Entity Activity Log", doc)
-	# History is as sensitive as the file: never writable from the client.
-	return ptype in ("read", "select") and bool(user_has_permission(doc.entity, "read", user))
+    user = user or frappe.session.user
+    if user == "Administrator" or "Suite Admin" in frappe.get_roles(user):
+        return True
+    if isinstance(doc, str):
+        doc = frappe.get_doc("Drive Entity Activity Log", doc)
+    # History is as sensitive as the file: never writable from the client.
+    return ptype in ("read", "select") and bool(user_has_permission(doc.entity, "read", user))
 
 
 def user_has_permission(doc, ptype, user=None):
-	if isinstance(doc, str):
-		doc = frappe.get_doc("File", doc)
-	if not user:
-		user = frappe.session.user
-	if user == "Administrator" or ptype == "create":
-		return True
-	if ptype not in PERMISSION_TYPES:
-		# Should ideally deflect to Framework
-		ptype = "write"
-	access = get_user_access(doc, user)
-	return bool(access.get(ptype))
+    if isinstance(doc, str):
+        doc = frappe.get_doc("File", doc)
+    if not user:
+        user = frappe.session.user
+    if user == "Administrator" or ptype == "create":
+        return True
+    if ptype not in PERMISSION_TYPES:
+        # Should ideally deflect to Framework
+        ptype = "write"
+    access = get_user_access(doc, user)
+    return bool(access.get(ptype))

--- a/suite/drive/api/product.py
+++ b/suite/drive/api/product.py
@@ -6,337 +6,337 @@ from frappe.utils import escape_html, split_emails, validate_email_address
 
 
 def access_app():
-	return True
+    return True
 
 
 @frappe.whitelist()
 def get_my_invites():
-	return frappe.db.get_list(
-		"Drive User Invitation",
-		fields=["creation", "status", "name"],
-		filters={"email": frappe.session.user, "status": ("in", ("Proposed", "Pending"))},
-	)
+    return frappe.db.get_list(
+        "Drive User Invitation",
+        fields=["creation", "status", "name"],
+        filters={"email": frappe.session.user, "status": ("in", ("Proposed", "Pending"))},
+    )
 
 
 @frappe.whitelist()
 def get_pending_invites():
-	if not is_drive_site_admin():
-		frappe.throw(_("You don't have the permissions for this action."), frappe.PermissionError)
+    if not is_drive_site_admin():
+        frappe.throw(_("You don't have the permissions for this action."), frappe.PermissionError)
 
-	invites = frappe.db.get_list(
-		"Drive User Invitation",
-		fields=["creation", "status", "email", "name", "owner"],
-		filters={"status": ("in", ("Proposed", "Pending"))},
-	)
-	for i in invites:
-		i["user_name"] = frappe.db.get_value("User", i["email"], "full_name")
-	return invites
+    invites = frappe.db.get_list(
+        "Drive User Invitation",
+        fields=["creation", "status", "email", "name", "owner"],
+        filters={"status": ("in", ("Proposed", "Pending"))},
+    )
+    for i in invites:
+        i["user_name"] = frappe.db.get_value("User", i["email"], "full_name")
+    return invites
 
 
 @frappe.whitelist(allow_guest=True)
 def signup(
-	account_request: str,
-	first_name: str,
-	password: str,
-	last_name: str | None = None,
+    account_request: str,
+    first_name: str,
+    password: str,
+    last_name: str | None = None,
 ):
-	if not password:
-		frappe.throw("Password is required.")
+    if not password:
+        frappe.throw("Password is required.")
 
-	account_request = frappe.get_doc("Account Request", account_request)
-	if not account_request.invite:
-		if frappe.get_website_settings("disable_signup"):
-			frappe.throw("Signing up is disabled on this site.", frappe.PermissionError)
+    account_request = frappe.get_doc("Account Request", account_request)
+    if not account_request.invite:
+        if frappe.get_website_settings("disable_signup"):
+            frappe.throw("Signing up is disabled on this site.", frappe.PermissionError)
 
-		if not account_request.login_count:
-			frappe.throw("Please verify the email first.")
+        if not account_request.login_count:
+            frappe.throw("Please verify the email first.")
 
-	create_user(account_request.email, first_name, password, last_name, True)
-	account_request.signed_up = 1
-	account_request.save(ignore_permissions=True)
-	if account_request.invite:
-		invite = frappe.get_doc("Drive User Invitation", account_request.invite)
-		invite.status = "Accepted"
-		invite.save(ignore_permissions=True)
-	return {"location": "/drive/"}
+    create_user(account_request.email, first_name, password, last_name, True)
+    account_request.signed_up = 1
+    account_request.save(ignore_permissions=True)
+    if account_request.invite:
+        invite = frappe.get_doc("Drive User Invitation", account_request.invite)
+        invite.status = "Accepted"
+        invite.save(ignore_permissions=True)
+    return {"location": "/drive/"}
 
 
 def create_user(email, first_name, password, last_name=None, login=False):
-	user = frappe.get_doc(
-		{
-			"doctype": "User",
-			"email": email,
-			"first_name": escape_html(first_name),
-			"last_name": escape_html(last_name),
-			"enabled": 1,
-			"user_type": "Website User",
-			"new_password": password,
-		}
-	)
+    user = frappe.get_doc(
+        {
+            "doctype": "User",
+            "email": email,
+            "first_name": escape_html(first_name),
+            "last_name": escape_html(last_name),
+            "enabled": 1,
+            "user_type": "Website User",
+            "new_password": password,
+        }
+    )
 
-	user.flags.no_welcome_mail = True
-	try:
-		user.insert(ignore_permissions=True)
-	except frappe.DuplicateEntryError:
-		frappe.throw("User already exists")
+    user.flags.no_welcome_mail = True
+    try:
+        user.insert(ignore_permissions=True)
+    except frappe.DuplicateEntryError:
+        frappe.throw("User already exists")
 
-	if login:
-		frappe.local.login_manager.login_as(user.email)
-	return user
+    if login:
+        frappe.local.login_manager.login_as(user.email)
+    return user
 
 
 @frappe.whitelist(allow_guest=True)
 def oauth_providers():
-	from frappe.utils.html_utils import get_icon_html
-	from frappe.utils.oauth import get_oauth2_authorize_url, get_oauth_keys
-	from frappe.utils.password import get_decrypted_password
+    from frappe.utils.html_utils import get_icon_html
+    from frappe.utils.oauth import get_oauth2_authorize_url, get_oauth_keys
+    from frappe.utils.password import get_decrypted_password
 
-	out = []
-	providers = frappe.get_all(
-		"Social Login Key",
-		filters={"enable_social_login": 1},
-		fields=["name", "client_id", "base_url", "provider_name", "icon"],
-		order_by="name",
-	)
+    out = []
+    providers = frappe.get_all(
+        "Social Login Key",
+        filters={"enable_social_login": 1},
+        fields=["name", "client_id", "base_url", "provider_name", "icon"],
+        order_by="name",
+    )
 
-	for provider in providers:
-		client_secret = get_decrypted_password("Social Login Key", provider.name, "client_secret")
-		if not client_secret:
-			continue
+    for provider in providers:
+        client_secret = get_decrypted_password("Social Login Key", provider.name, "client_secret")
+        if not client_secret:
+            continue
 
-		icon = None
-		if provider.icon:
-			if provider.provider_name == "Custom":
-				icon = get_icon_html(provider.icon, small=True)
-			else:
-				icon = f"<img src='{provider.icon}' alt={provider.provider_name}>"
+        icon = None
+        if provider.icon:
+            if provider.provider_name == "Custom":
+                icon = get_icon_html(provider.icon, small=True)
+            else:
+                icon = f"<img src='{provider.icon}' alt={provider.provider_name}>"
 
-		if provider.client_id and provider.base_url and get_oauth_keys(provider.name):
-			out.append(
-				{
-					"name": provider.name,
-					"provider_name": provider.provider_name,
-					"auth_url": get_oauth2_authorize_url(provider.name, "/drive"),
-					"icon": icon,
-				}
-			)
-	return out
+        if provider.client_id and provider.base_url and get_oauth_keys(provider.name):
+            out.append(
+                {
+                    "name": provider.name,
+                    "provider_name": provider.provider_name,
+                    "auth_url": get_oauth2_authorize_url(provider.name, "/drive"),
+                    "icon": icon,
+                }
+            )
+    return out
 
 
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=5, seconds=60)
 def send_otp(email: str, login: bool = False):
-	if signup_disabled():
-		frappe.throw("Signing up is disabled on this site.", frappe.PermissionError)
+    if signup_disabled():
+        frappe.throw("Signing up is disabled on this site.", frappe.PermissionError)
 
-	account_request = frappe.get_doc(
-		{
-			"doctype": "Account Request",
-			"email": email,
-			"signed_up": 0,
-		}
-	).insert(ignore_permissions=True)
-	account_request.set_otp()
-	try:
-		account_request.send_otp()
-	except Exception:
-		frappe.throw("Please setup an email account in Desk.")
-	return account_request.name
+    account_request = frappe.get_doc(
+        {
+            "doctype": "Account Request",
+            "email": email,
+            "signed_up": 0,
+        }
+    ).insert(ignore_permissions=True)
+    account_request.set_otp()
+    try:
+        account_request.send_otp()
+    except Exception:
+        frappe.throw("Please setup an email account in Desk.")
+    return account_request.name
 
 
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=5, seconds=60)
 def verify_otp(account_request: str, otp: str):
-	req = frappe.get_doc("Account Request", account_request)
-	if req.otp != otp:
-		frappe.throw("Invalid OTP")
-	req.login_count += 1
-	req.save(ignore_permissions=True)
+    req = frappe.get_doc("Account Request", account_request)
+    if req.otp != otp:
+        frappe.throw("Invalid OTP")
+    req.login_count += 1
+    req.save(ignore_permissions=True)
 
 
 @frappe.whitelist(allow_guest=True)
 def get_settings():
-	if frappe.session.user == "Guest":
-		return {}
-	try:
-		return frappe.get_cached_doc("Drive Settings", frappe.session.user)
-	except Exception:
-		return {}
+    if frappe.session.user == "Guest":
+        return {}
+    try:
+        return frappe.get_cached_doc("Drive Settings", frappe.session.user)
+    except Exception:
+        return {}
 
 
 @frappe.whitelist()
 def set_settings(updates: dict[str, int | str]):
-	try:
-		settings = frappe.get_doc("Drive Settings", frappe.session.user)
-	except Exception:
-		settings = frappe.get_doc({"doctype": "Drive Settings", "user": frappe.session.user})
-		settings.insert()
+    try:
+        settings = frappe.get_doc("Drive Settings", frappe.session.user)
+    except Exception:
+        settings = frappe.get_doc({"doctype": "Drive Settings", "user": frappe.session.user})
+        settings.insert()
 
-	if "single_click" in updates:
-		settings.single_click = int(updates["single_click"])
-	if "auto_detect_links" in updates:
-		settings.auto_detect_links = int(updates["auto_detect_links"])
-	settings.save()
+    if "single_click" in updates:
+        settings.single_click = int(updates["single_click"])
+    if "auto_detect_links" in updates:
+        settings.auto_detect_links = int(updates["auto_detect_links"])
+    settings.save()
 
 
 @frappe.whitelist()
 def invite_users(emails: str):
-	if not is_drive_site_admin():
-		frappe.throw(_("You don't have the permissions for this action."), frappe.PermissionError)
-	create_invites(emails)
+    if not is_drive_site_admin():
+        frappe.throw(_("You don't have the permissions for this action."), frappe.PermissionError)
+    create_invites(emails)
 
 
 def create_invites(emails: str, auto: bool = False):
-	if not emails:
-		return
+    if not emails:
+        return
 
-	email_string = validate_email_address(emails, throw=False)
-	email_list = split_emails(email_string)
-	if not email_list:
-		return
+    email_string = validate_email_address(emails, throw=False)
+    email_list = split_emails(email_string)
+    if not email_list:
+        return
 
-	existing_invites = frappe.db.get_list(
-		"Drive User Invitation",
-		filters={"email": ["in", email_list], "status": "Pending"},
-		pluck="email",
-	)
+    existing_invites = frappe.db.get_list(
+        "Drive User Invitation",
+        filters={"email": ["in", email_list], "status": "Pending"},
+        pluck="email",
+    )
 
-	new_invites = list(set(email_list) - set(existing_invites))
-	for email in new_invites:
-		invite = frappe.new_doc("Drive User Invitation")
-		invite.email = email
-		invite.status = "Automatic" if auto else "Pending"
-		invite.insert(ignore_permissions=True)
+    new_invites = list(set(email_list) - set(existing_invites))
+    for email in new_invites:
+        invite = frappe.new_doc("Drive User Invitation")
+        invite.email = email
+        invite.status = "Automatic" if auto else "Pending"
+        invite.insert(ignore_permissions=True)
 
 
 @frappe.whitelist()
 def get_users():
-	"""All enabled site users, for sharing and user management."""
-	if frappe.session.user == "Guest":
-		frappe.throw(_("You don't have the permissions for this action."), frappe.PermissionError)
-	return frappe.get_all(
-		doctype="User",
-		filters=[
-			["enabled", "=", 1],
-			["name", "not in", ["Guest", "Administrator"]],
-		],
-		fields=[
-			"name",
-			"email",
-			"full_name",
-			"user_image",
-		],
-	)
+    """All enabled site users, for sharing and user management."""
+    if frappe.session.user == "Guest":
+        frappe.throw(_("You don't have the permissions for this action."), frappe.PermissionError)
+    return frappe.get_all(
+        doctype="User",
+        filters=[
+            ["enabled", "=", 1],
+            ["name", "not in", ["Guest", "Administrator"]],
+        ],
+        fields=[
+            "name",
+            "email",
+            "full_name",
+            "user_image",
+        ],
+    )
 
 
 @frappe.whitelist()
 def get_user_groups():
-	"""Shareable user groups, with how many people each one carries."""
-	if frappe.session.user == "Guest":
-		frappe.throw(_("You don't have the permissions for this action."), frappe.PermissionError)
+    """Shareable user groups, with how many people each one carries."""
+    if frappe.session.user == "Guest":
+        frappe.throw(_("You don't have the permissions for this action."), frappe.PermissionError)
 
-	counts = frappe._dict(
-		frappe.db.sql(
-			"""SELECT parent, COUNT(DISTINCT user) FROM `tabUser Group Member`
+    counts = frappe._dict(
+        frappe.db.sql(
+            """SELECT parent, COUNT(DISTINCT user) FROM `tabUser Group Member`
 			WHERE parenttype = 'User Group' GROUP BY parent"""
-		)
-	)
-	return [
-		{"name": g, "member_count": counts.get(g, 0)}
-		for g in frappe.get_all("User Group", pluck="name", order_by="name")
-	]
+        )
+    )
+    return [
+        {"name": g, "member_count": counts.get(g, 0)}
+        for g in frappe.get_all("User Group", pluck="name", order_by="name")
+    ]
 
 
 @frappe.whitelist(allow_guest=True)
 def accept_invite(key: str, redirect: bool | str = True):
-	try:
-		invitation = frappe.get_doc("Drive User Invitation", key)
-	except Exception:
-		frappe.throw("Could not find invitation.")
+    try:
+        invitation = frappe.get_doc("Drive User Invitation", key)
+    except Exception:
+        frappe.throw("Could not find invitation.")
 
-	return invitation.accept(redirect)
+    return invitation.accept(redirect)
 
 
 @frappe.whitelist()
 def reject_invite(key: str):
-	try:
-		invitation = frappe.get_doc("Drive User Invitation", key)
-	except Exception:
-		frappe.throw("Could not find invitation.")
+    try:
+        invitation = frappe.get_doc("Drive User Invitation", key)
+    except Exception:
+        frappe.throw("Could not find invitation.")
 
-	invitation.status = "Expired"
-	invitation.save(ignore_permissions=True)
+    invitation.status = "Expired"
+    invitation.save(ignore_permissions=True)
 
 
 @frappe.whitelist(allow_guest=True)
 def get_translations():
-	if frappe.session.user != "Guest":
-		language = frappe.db.get_value("User", frappe.session.user, "language")
-		if not language:
-			language = frappe.db.get_single_value("System Settings", "language")
-	else:
-		language = frappe.db.get_single_value("System Settings", "language")
+    if frappe.session.user != "Guest":
+        language = frappe.db.get_value("User", frappe.session.user, "language")
+        if not language:
+            language = frappe.db.get_single_value("System Settings", "language")
+    else:
+        language = frappe.db.get_single_value("System Settings", "language")
 
-	return get_all_translations(language)
+    return get_all_translations(language)
 
 
 def is_drive_site_admin():
-	return frappe.has_permission("Drive Disk Settings", "write")
+    return frappe.has_permission("Drive Disk Settings", "write")
 
 
 @frappe.whitelist()
 def is_site_admin():
-	return {"is_admin": is_drive_site_admin()}
+    return {"is_admin": is_drive_site_admin()}
 
 
 @frappe.whitelist(allow_guest=True)
 def disk_settings(**kwargs):
-	settings = frappe.get_single("Drive Disk Settings")
-	if not is_drive_site_admin():
-		# Return only safe values
-		return {"preview_size": settings.preview_size, "enabled": settings.enabled}
+    settings = frappe.get_single("Drive Disk Settings")
+    if not is_drive_site_admin():
+        # Return only safe values
+        return {"preview_size": settings.preview_size, "enabled": settings.enabled}
 
-	if frappe.request.method == "GET":
-		return settings
+    if frappe.request.method == "GET":
+        return settings
 
-	field_map = {
-		"root_folder": None,
-		"aws_key": None,
-		"aws_secret": None,
-		"bucket": None,
-		"endpoint_url": None,
-		"signature_version": "s3v4",
-	}
-	settings.enabled = 1
-	for field, value in kwargs.items():
-		if field in field_map and value:
-			setattr(settings, field, value)
-		elif field == "backend_type":
-			# If backend is s3, enable it. Otherwise, disable.
-			settings.enabled = 1 if value == "s3" else 0
-	settings.save()
+    field_map = {
+        "root_folder": None,
+        "aws_key": None,
+        "aws_secret": None,
+        "bucket": None,
+        "endpoint_url": None,
+        "signature_version": "s3v4",
+    }
+    settings.enabled = 1
+    for field, value in kwargs.items():
+        if field in field_map and value:
+            setattr(settings, field, value)
+        elif field == "backend_type":
+            # If backend is s3, enable it. Otherwise, disable.
+            settings.enabled = 1 if value == "s3" else 0
+    settings.save()
 
 
 WHITELISTED_DOMAINS = [
-	"https://gameplan.frappe.cloud",
-	"https://frappecloud.com",
-	"https://frappe.io",
-	"https://cloud.frappe.io",
+    "https://gameplan.frappe.cloud",
+    "https://frappecloud.com",
+    "https://frappe.io",
+    "https://cloud.frappe.io",
 ]
 
 
 def after_request(request):
-	try:
-		if request.path.startswith("/drive/") or request.path.startswith("/api/method/"):
-			frappe.local.response_headers["Content-Security-Policy"] = (
-				f"frame-ancestors {' '.join(WHITELISTED_DOMAINS)} 'self'"
-			)
-			if "X-Frame-Options" in frappe.local.response_headers:
-				del frappe.local.response_headers["X-Frame-Options"]
-	except Exception:
-		pass
+    try:
+        if request.path.startswith("/drive/") or request.path.startswith("/api/method/"):
+            frappe.local.response_headers["Content-Security-Policy"] = (
+                f"frame-ancestors {' '.join(WHITELISTED_DOMAINS)} 'self'"
+            )
+            if "X-Frame-Options" in frappe.local.response_headers:
+                del frappe.local.response_headers["X-Frame-Options"]
+    except Exception:
+        pass
 
 
 @frappe.whitelist(allow_guest=True)
 def signup_disabled():
-	return frappe.get_website_settings("disable_signup")
+    return frappe.get_website_settings("disable_signup")

--- a/suite/drive/api/s3.py
+++ b/suite/drive/api/s3.py
@@ -1,5 +1,6 @@
 import frappe
 from frappe import _
+
 from suite.drive.api.files import get_file_content, get_s3_url
 
 

--- a/suite/drive/api/scripts.py
+++ b/suite/drive/api/scripts.py
@@ -5,135 +5,135 @@ import frappe
 from suite.drive.api.files import delete_entities
 from suite.drive.api.product import is_drive_site_admin
 from suite.drive.utils import (
-	STATUS_REMOVED,
-	STATUS_TRASHED,
-	create_drive_file,
-	get_file_type,
-	get_root_folder,
-	update_file_size,
+    STATUS_REMOVED,
+    STATUS_TRASHED,
+    create_drive_file,
+    get_file_type,
+    get_root_folder,
+    update_file_size,
 )
 from suite.drive.utils.files import FileManager
 
 
 @frappe.whitelist()
 def sync_preview(json: bool = True):
-	manager = FileManager()
-	files = manager.fetch_new_files()
-	sorted_files = sorted(files.items(), key=lambda p: len(p[0].parts))
-	# For just checking, strip the root folder
-	if json:
-		return map(lambda x: (str(x[0]), x[1]), sorted_files)
-	return sorted_files
+    manager = FileManager()
+    files = manager.fetch_new_files()
+    sorted_files = sorted(files.items(), key=lambda p: len(p[0].parts))
+    # For just checking, strip the root folder
+    if json:
+        return map(lambda x: (str(x[0]), x[1]), sorted_files)
+    return sorted_files
 
 
 @frappe.whitelist()
 def sync_from_disk():
-	"""
-	One-way sync from disk to Drive. Ignores hidden files.
-	"""
-	if not is_drive_site_admin():
-		frappe.throw(
-			"You do not have permission to sync files from disk.",
-			frappe.PermissionError,
-		)
+    """
+    One-way sync from disk to Drive. Ignores hidden files.
+    """
+    if not is_drive_site_admin():
+        frappe.throw(
+            "You do not have permission to sync files from disk.",
+            frappe.PermissionError,
+        )
 
-	sorted_files = sync_preview(json=False)
-	files_added = []
-	root_folder = get_root_folder().name
+    sorted_files = sync_preview(json=False)
+    files_added = []
+    root_folder = get_root_folder().name
 
-	def get_or_create_parent(parent_path, owner):
-		if not parent_path:
-			return root_folder
-		# Check if the parent folder exists
-		parent = frappe.get_value(
-			"File",
-			{"file_url": (parent_path + "/") if parent_path else ""},
-			"name",
-		)
-		if parent:
-			return parent
+    def get_or_create_parent(parent_path, owner):
+        if not parent_path:
+            return root_folder
+        # Check if the parent folder exists
+        parent = frappe.get_value(
+            "File",
+            {"file_url": (parent_path + "/") if parent_path else ""},
+            "name",
+        )
+        if parent:
+            return parent
 
-		# If not, recursively create its own parent first
-		grandparent_path = "/".join(parent_path.strip("/").split("/")[:-1])
-		grandparent = get_or_create_parent(grandparent_path, owner)
+        # If not, recursively create its own parent first
+        grandparent_path = "/".join(parent_path.strip("/").split("/")[:-1])
+        grandparent = get_or_create_parent(grandparent_path, owner)
 
-		# Now create this parent folder
-		new_parent = create_drive_file(
-			file_name=parent_path.strip("/").split("/")[-1],
-			parent=grandparent,
-			file_type="Folder",
-			entity_path=lambda _: str(parent_path) + "/",
-			mime_type="folder",
-			file_size=0,
-			owner=owner,
-		)
-		return new_parent.name
+        # Now create this parent folder
+        new_parent = create_drive_file(
+            file_name=parent_path.strip("/").split("/")[-1],
+            parent=grandparent,
+            file_type="Folder",
+            entity_path=lambda _: str(parent_path) + "/",
+            mime_type="folder",
+            file_size=0,
+            owner=owner,
+        )
+        return new_parent.name
 
-	for file, (file_size, file_modified, mime_type, actual_path) in sorted_files:
-		parent_path = str(file.parent).strip("./")
-		parent = get_or_create_parent(parent_path, frappe.session.user)
+    for file, (file_size, file_modified, mime_type, actual_path) in sorted_files:
+        parent_path = str(file.parent).strip("./")
+        parent = get_or_create_parent(parent_path, frappe.session.user)
 
-		files_added.append(
-			create_drive_file(
-				file.name,
-				parent,
-				"Folder" if mime_type == "folder" else get_file_type(mime_type),
-				lambda _: actual_path if mime_type != "folder" else actual_path.strip("/") + "/",
-				mime_type=mime_type,
-				file_modified=file_modified,
-				file_size=file_size,
-				owner=frappe.session.user,
-			)
-		)
-		update_file_size(parent, file_size)
+        files_added.append(
+            create_drive_file(
+                file.name,
+                parent,
+                "Folder" if mime_type == "folder" else get_file_type(mime_type),
+                lambda _: actual_path if mime_type != "folder" else actual_path.strip("/") + "/",
+                mime_type=mime_type,
+                file_modified=file_modified,
+                file_size=file_size,
+                owner=frappe.session.user,
+            )
+        )
+        update_file_size(parent, file_size)
 
-	return files_added
+    return files_added
 
 
 def auto_delete_from_trash():
-	days_before = (date.today() - timedelta(days=30)).isoformat()
-	result = frappe.db.get_all(
-		"File",
-		filters={"status": STATUS_TRASHED, "file_modified": ["<", days_before]},
-		fields=["name"],
-	)
-	delete_entities(result)
+    days_before = (date.today() - timedelta(days=30)).isoformat()
+    result = frappe.db.get_all(
+        "File",
+        filters={"status": STATUS_TRASHED, "file_modified": ["<", days_before]},
+        fields=["name"],
+    )
+    delete_entities(result)
 
 
 def clear_deleted_files():
-	days_before = (date.today() - timedelta(days=30)).isoformat()
-	result = frappe.db.get_all(
-		"File",
-		filters={"status": STATUS_REMOVED, "modified": ["<", days_before]},
-		fields=["name"],
-	)
-	for entity in result:
-		doc = frappe.get_doc("File", entity, ignore_permissions=True)
-		doc.delete()
+    days_before = (date.today() - timedelta(days=30)).isoformat()
+    result = frappe.db.get_all(
+        "File",
+        filters={"status": STATUS_REMOVED, "modified": ["<", days_before]},
+        fields=["name"],
+    )
+    for entity in result:
+        doc = frappe.get_doc("File", entity, ignore_permissions=True)
+        doc.delete()
 
 
 def clear_download_archives():
-	"""Sweep expired folder-download zip artifacts from disk and S3."""
-	import os
-	import time
+    """Sweep expired folder-download zip artifacts from disk and S3."""
+    import os
+    import time
 
-	from suite.drive.api.files import ARCHIVE_DIR, DOWNLOAD_TTL
+    from suite.drive.api.files import ARCHIVE_DIR, DOWNLOAD_TTL
 
-	cutoff = time.time() - DOWNLOAD_TTL
-	manager = FileManager()
+    cutoff = time.time() - DOWNLOAD_TTL
+    manager = FileManager()
 
-	local_dir = manager.site_folder / ARCHIVE_DIR
-	if local_dir.exists():
-		for path in local_dir.iterdir():
-			if path.is_file() and path.stat().st_mtime < cutoff:
-				path.unlink(missing_ok=True)
+    local_dir = manager.site_folder / ARCHIVE_DIR
+    if local_dir.exists():
+        for path in local_dir.iterdir():
+            if path.is_file() and path.stat().st_mtime < cutoff:
+                path.unlink(missing_ok=True)
 
-	if manager.s3_enabled:
-		cutoff_dt = datetime.now(UTC) - timedelta(seconds=DOWNLOAD_TTL)
-		for bucket in filter(None, {manager.bucket}):
-			objects = manager.conn.list_objects_v2(Bucket=bucket, Prefix=".drive-downloads/").get(
-				"Contents", []
-			)
-			stale = [{"Key": o["Key"]} for o in objects if o["LastModified"] < cutoff_dt]
-			if stale:
-				manager.conn.delete_objects(Bucket=bucket, Delete={"Objects": stale})
+    if manager.s3_enabled:
+        cutoff_dt = datetime.now(UTC) - timedelta(seconds=DOWNLOAD_TTL)
+        for bucket in filter(None, {manager.bucket}):
+            objects = manager.conn.list_objects_v2(Bucket=bucket, Prefix=".drive-downloads/").get(
+                "Contents", []
+            )
+            stale = [{"Key": o["Key"]} for o in objects if o["LastModified"] < cutoff_dt]
+            if stale:
+                manager.conn.delete_objects(Bucket=bucket, Delete={"Objects": stale})

--- a/suite/drive/api/storage.py
+++ b/suite/drive/api/storage.py
@@ -9,70 +9,70 @@ DriveFile = frappe.qb.DocType("File")
 
 
 def get_quota(user: str | None = None):
-	"""Effective quota in bytes: the user's override, else the site default. 0 = unlimited."""
-	user = user or frappe.session.user
-	quota = frappe.get_value("Drive Settings", user, "quota") or frappe.db.get_single_value(
-		"Drive Disk Settings", "quota"
-	)
-	return (quota or 0) * MEGA_BYTE
+    """Effective quota in bytes: the user's override, else the site default. 0 = unlimited."""
+    user = user or frappe.session.user
+    quota = frappe.get_value("Drive Settings", user, "quota") or frappe.db.get_single_value(
+        "Drive Disk Settings", "quota"
+    )
+    return (quota or 0) * MEGA_BYTE
 
 
 @frappe.whitelist()
 def storage_breakdown(owned_only: bool = True):
-	if not owned_only and "Suite Admin" not in frappe.get_roles() and frappe.session.user != "Administrator":
-		frappe.throw(_("Only admins can view site-wide storage."), frappe.PermissionError)
+    if not owned_only and "Suite Admin" not in frappe.get_roles() and frappe.session.user != "Administrator":
+        frappe.throw(_("Only admins can view site-wide storage."), frappe.PermissionError)
 
-	limit = get_quota()
-	filters = {
-		"is_folder": False,
-		"status": STATUS_ACTIVE,
-	}
-	if limit:
-		filters["file_size"] = [">=", limit / 200]
-	if owned_only:
-		filters["owner"] = frappe.session.user
+    limit = get_quota()
+    filters = {
+        "is_folder": False,
+        "status": STATUS_ACTIVE,
+    }
+    if limit:
+        filters["file_size"] = [">=", limit / 200]
+    if owned_only:
+        filters["owner"] = frappe.session.user
 
-	entities = frappe.db.get_list(
-		"File",
-		filters=filters,
-		order_by="file_size desc",
-		fields=["name", "file_name", "owner", "file_size", "file_type"],
-	)
+    entities = frappe.db.get_list(
+        "File",
+        filters=filters,
+        order_by="file_size desc",
+        fields=["name", "file_name", "owner", "file_size", "file_type"],
+    )
 
-	query = (
-		frappe.qb.from_(DriveFile)
-		.select(DriveFile.file_type, fn.Sum(DriveFile.file_size).as_("file_size"))
-		.where((DriveFile.is_folder == 0) & (DriveFile.status == STATUS_ACTIVE))
-	)
-	if owned_only:
-		query = query.where(DriveFile.owner == frappe.session.user)
+    query = (
+        frappe.qb.from_(DriveFile)
+        .select(DriveFile.file_type, fn.Sum(DriveFile.file_size).as_("file_size"))
+        .where((DriveFile.is_folder == 0) & (DriveFile.status == STATUS_ACTIVE))
+    )
+    if owned_only:
+        query = query.where(DriveFile.owner == frappe.session.user)
 
-	return {
-		"limit": limit,
-		"total": query.groupby(DriveFile.file_type).run(as_dict=True),
-		"entities": entities,
-	}
+    return {
+        "limit": limit,
+        "total": query.groupby(DriveFile.file_type).run(as_dict=True),
+        "entities": entities,
+    }
 
 
 @frappe.whitelist()
 def storage_bar_data():
-	return get_storage_usage()
+    return get_storage_usage()
 
 
 def get_storage_usage(user: str | None = None):
-	user = user or frappe.session.user
-	query = (
-		frappe.qb.from_(DriveFile)
-		.where((DriveFile.is_folder == 0) & (DriveFile.owner == user) & (DriveFile.status == STATUS_ACTIVE))
-		.select(fn.Coalesce(fn.Sum(DriveFile.file_size), 0).as_("total_size"))
-	)
-	result = query.run(as_dict=True)[0]
-	result["limit"] = get_quota(user)
-	return result
+    user = user or frappe.session.user
+    query = (
+        frappe.qb.from_(DriveFile)
+        .where((DriveFile.is_folder == 0) & (DriveFile.owner == user) & (DriveFile.status == STATUS_ACTIVE))
+        .select(fn.Coalesce(fn.Sum(DriveFile.file_size), 0).as_("total_size"))
+    )
+    result = query.run(as_dict=True)[0]
+    result["limit"] = get_quota(user)
+    return result
 
 
 def validate_quota(user: str | None = None, incoming_size: int = 0):
-	"""Throw if adding `incoming_size` bytes would push the user past their quota."""
-	usage = get_storage_usage(user)
-	if usage["limit"] and (usage["limit"] - usage["total_size"]) < incoming_size:
-		frappe.throw(_("You're out of storage!"), ValueError)
+    """Throw if adding `incoming_size` bytes would push the user past their quota."""
+    usage = get_storage_usage(user)
+    if usage["limit"] and (usage["limit"] - usage["total_size"]) < incoming_size:
+        frappe.throw(_("You're out of storage!"), ValueError)

--- a/suite/drive/api/tests/test_files.py
+++ b/suite/drive/api/tests/test_files.py
@@ -8,21 +8,21 @@ from werkzeug.test import EnvironBuilder
 from werkzeug.wrappers import Request
 
 from suite.drive.api.files import (
-	create_auth_token,
-	get_file_content,
-	move,
-	remove_or_restore,
-	rename,
-	update_access,
-	upload_file,
+    create_auth_token,
+    get_file_content,
+    move,
+    remove_or_restore,
+    rename,
+    update_access,
+    upload_file,
 )
 from suite.drive.api.permissions import get_user_access, user_has_permission
 from suite.drive.utils import (
-	GENERAL_USER,
-	STATUS_ACTIVE,
-	STATUS_TRASHED,
-	create_drive_file,
-	get_user_folder,
+    GENERAL_USER,
+    STATUS_ACTIVE,
+    STATUS_TRASHED,
+    create_drive_file,
+    get_user_folder,
 )
 from suite.drive.utils.files import FileManager
 from suite.tests.utils import ensure_user
@@ -33,217 +33,217 @@ MEMBER = "drive-files-member@example.com"
 
 
 class TestDriveFilesAPI(IntegrationTestCase):
-	@classmethod
-	def setUpClass(cls):
-		super().setUpClass()
-		ensure_user(OWNER)
-		ensure_user(OTHER_USER)
-		ensure_user(MEMBER)
-		with cls.set_user(OWNER):
-			cls.home = get_user_folder(OWNER).name
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        ensure_user(OWNER)
+        ensure_user(OTHER_USER)
+        ensure_user(MEMBER)
+        with cls.set_user(OWNER):
+            cls.home = get_user_folder(OWNER).name
 
-	def setUp(self):
-		frappe.flags.mute_drive_activity_log = True
-		with self.set_user(OWNER):
-			self.folder = create_drive_file(frappe.generate_hash(8), self.home, "Folder", "")
-			self.file = create_drive_file(
-				f"{frappe.generate_hash(8)}.txt",
-				self.folder.name,
-				"Text",
-				f"/drive-test/{frappe.generate_hash(8)}.txt",
-				"text/plain",
-				12,
-			)
+    def setUp(self):
+        frappe.flags.mute_drive_activity_log = True
+        with self.set_user(OWNER):
+            self.folder = create_drive_file(frappe.generate_hash(8), self.home, "Folder", "")
+            self.file = create_drive_file(
+                f"{frappe.generate_hash(8)}.txt",
+                self.folder.name,
+                "Text",
+                f"/drive-test/{frappe.generate_hash(8)}.txt",
+                "text/plain",
+                12,
+            )
 
-	def tearDown(self):
-		frappe.flags.mute_drive_activity_log = False
-		super().tearDown()
+    def tearDown(self):
+        frappe.flags.mute_drive_activity_log = False
+        super().tearDown()
 
-	@contextmanager
-	def upload_request(self, content, filename, session, chunk=None):
-		builder = EnvironBuilder(
-			path="/api/method/suite.drive.api.files.upload_file",
-			method="POST",
-			data={"file": (BytesIO(content), filename)},
-		)
-		frappe.local.request = Request(builder.get_environ())
-		values = {
-			"uuid": session,
-			"chunk_index": "" if chunk is None else str(chunk[0]),
-			"total_chunk_count": "" if chunk is None else str(chunk[1]),
-			"chunk_byte_offset": "" if chunk is None else str(chunk[2]),
-		}
-		frappe.form_dict.update(values)
-		try:
-			yield
-		finally:
-			for key in values:
-				frappe.form_dict.pop(key, None)
-			del frappe.local.request
+    @contextmanager
+    def upload_request(self, content, filename, session, chunk=None):
+        builder = EnvironBuilder(
+            path="/api/method/suite.drive.api.files.upload_file",
+            method="POST",
+            data={"file": (BytesIO(content), filename)},
+        )
+        frappe.local.request = Request(builder.get_environ())
+        values = {
+            "uuid": session,
+            "chunk_index": "" if chunk is None else str(chunk[0]),
+            "total_chunk_count": "" if chunk is None else str(chunk[1]),
+            "chunk_byte_offset": "" if chunk is None else str(chunk[2]),
+        }
+        frappe.form_dict.update(values)
+        try:
+            yield
+        finally:
+            for key in values:
+                frappe.form_dict.pop(key, None)
+            del frappe.local.request
 
-	def upload(self, content, filename="upload.txt", session=None, chunk=None, total_size=None):
-		session = session or frappe.generate_hash(12)
-		with (
-			self.upload_request(content, filename, session, chunk),
-			patch("suite.drive.api.files.validate_quota"),
-			patch("suite.drive.api.files.frappe.publish_realtime"),
-		):
-			return upload_file(
-				total_file_size=total_size if total_size is not None else len(content),
-				parent=self.folder.name,
-			)
+    def upload(self, content, filename="upload.txt", session=None, chunk=None, total_size=None):
+        session = session or frappe.generate_hash(12)
+        with (
+            self.upload_request(content, filename, session, chunk),
+            patch("suite.drive.api.files.validate_quota"),
+            patch("suite.drive.api.files.frappe.publish_realtime"),
+        ):
+            return upload_file(
+                total_file_size=total_size if total_size is not None else len(content),
+                parent=self.folder.name,
+            )
 
-	def test_owner_can_read_and_unrelated_user_cannot(self):
-		with self.set_user(OWNER):
-			self.assertTrue(user_has_permission(self.file, "read"))
-		with self.set_user(OTHER_USER):
-			self.assertFalse(user_has_permission(self.file, "read"))
-			with self.assertRaises(frappe.PermissionError):
-				get_file_content(self.file.name)
+    def test_owner_can_read_and_unrelated_user_cannot(self):
+        with self.set_user(OWNER):
+            self.assertTrue(user_has_permission(self.file, "read"))
+        with self.set_user(OTHER_USER):
+            self.assertFalse(user_has_permission(self.file, "read"))
+            with self.assertRaises(frappe.PermissionError):
+                get_file_content(self.file.name)
 
-	def test_site_share_and_guest_public_access(self):
-		# Inside a user folder, other site users are denied by default.
-		with self.set_user(MEMBER):
-			self.assertFalse(user_has_permission(self.file, "read"))
+    def test_site_share_and_guest_public_access(self):
+        # Inside a user folder, other site users are denied by default.
+        with self.set_user(MEMBER):
+            self.assertFalse(user_has_permission(self.file, "read"))
 
-		# A $GENERAL share opens it to site users, but not guests.
-		with self.set_user(OWNER):
-			self.file.share(user=GENERAL_USER, read=True)
-		with self.set_user(MEMBER):
-			self.assertTrue(user_has_permission(self.file, "read"))
-		with self.set_user("Guest"):
-			self.assertFalse(user_has_permission(self.file, "read"))
+        # A $GENERAL share opens it to site users, but not guests.
+        with self.set_user(OWNER):
+            self.file.share(user=GENERAL_USER, read=True)
+        with self.set_user(MEMBER):
+            self.assertTrue(user_has_permission(self.file, "read"))
+        with self.set_user("Guest"):
+            self.assertFalse(user_has_permission(self.file, "read"))
 
-		# A public share opens it to guests too.
-		with self.set_user(OWNER):
-			self.file.share(read=True)
-		with self.set_user("Guest"):
-			self.assertTrue(user_has_permission(self.file, "read"))
+        # A public share opens it to guests too.
+        with self.set_user(OWNER):
+            self.file.share(read=True)
+        with self.set_user("Guest"):
+            self.assertTrue(user_has_permission(self.file, "read"))
 
-	def test_upload_persists_local_file_and_denies_non_member(self):
-		with self.set_user(OWNER):
-			uploaded = self.upload(b"local file contents")
-			with FileManager().get_file(uploaded) as stored:
-				self.assertEqual(stored.read(), b"local file contents")
+    def test_upload_persists_local_file_and_denies_non_member(self):
+        with self.set_user(OWNER):
+            uploaded = self.upload(b"local file contents")
+            with FileManager().get_file(uploaded) as stored:
+                self.assertEqual(stored.read(), b"local file contents")
 
-		with (
-			self.set_user(OTHER_USER),
-			self.upload_request(b"denied", "denied.txt", frappe.generate_hash(12)),
-		):
-			with self.assertRaises(frappe.PermissionError):
-				upload_file(total_file_size=6, parent=self.folder.name)
+        with (
+            self.set_user(OTHER_USER),
+            self.upload_request(b"denied", "denied.txt", frappe.generate_hash(12)),
+        ):
+            with self.assertRaises(frappe.PermissionError):
+                upload_file(total_file_size=6, parent=self.folder.name)
 
-	def test_ordered_chunks_are_assembled_byte_for_byte(self):
-		session = frappe.generate_hash(12)
-		with self.set_user(OWNER):
-			self.assertIsNone(self.upload(b"hello ", session=session, chunk=(0, 2, 0), total_size=11))
-			uploaded = self.upload(b"world", session=session, chunk=(1, 2, 6), total_size=11)
-			with FileManager().get_file(uploaded) as stored:
-				self.assertEqual(stored.read(), b"hello world")
+    def test_ordered_chunks_are_assembled_byte_for_byte(self):
+        session = frappe.generate_hash(12)
+        with self.set_user(OWNER):
+            self.assertIsNone(self.upload(b"hello ", session=session, chunk=(0, 2, 0), total_size=11))
+            uploaded = self.upload(b"world", session=session, chunk=(1, 2, 6), total_size=11)
+            with FileManager().get_file(uploaded) as stored:
+                self.assertEqual(stored.read(), b"hello world")
 
-	def test_local_and_s3_file_manager_reads_have_the_same_boundary(self):
-		with self.set_user(OWNER):
-			uploaded = self.upload(b"storage boundary")
-			with FileManager().get_file(uploaded) as stored:
-				self.assertEqual(stored.read(), b"storage boundary")
+    def test_local_and_s3_file_manager_reads_have_the_same_boundary(self):
+        with self.set_user(OWNER):
+            uploaded = self.upload(b"storage boundary")
+            with FileManager().get_file(uploaded) as stored:
+                self.assertEqual(stored.read(), b"storage boundary")
 
-		manager = FileManager()
-		manager.s3_enabled = True
-		manager.conn = Mock()
-		manager.conn.get_object.return_value = {"Body": BytesIO(b"storage boundary")}
-		self.assertEqual(manager.get_file(uploaded).read(), b"storage boundary")
-		manager.conn.get_object.assert_called_once_with(
-			Bucket=manager.bucket,
-			Key=uploaded.file_url.lstrip("/"),
-		)
+        manager = FileManager()
+        manager.s3_enabled = True
+        manager.conn = Mock()
+        manager.conn.get_object.return_value = {"Body": BytesIO(b"storage boundary")}
+        self.assertEqual(manager.get_file(uploaded).read(), b"storage boundary")
+        manager.conn.get_object.assert_called_once_with(
+            Bucket=manager.bucket,
+            Key=uploaded.file_url.lstrip("/"),
+        )
 
-	def test_direct_and_inherited_shares_grant_read_access(self):
-		with self.set_user(OWNER):
-			self.file.share(user=OTHER_USER, read=True)
-		with self.set_user(OTHER_USER):
-			self.assertEqual(get_user_access(self.file.name)["read"], 1)
+    def test_direct_and_inherited_shares_grant_read_access(self):
+        with self.set_user(OWNER):
+            self.file.share(user=OTHER_USER, read=True)
+        with self.set_user(OTHER_USER):
+            self.assertEqual(get_user_access(self.file.name)["read"], 1)
 
-		with self.set_user(OWNER):
-			self.file.unshare(OTHER_USER)
-			self.folder.share(user=OTHER_USER, read=True)
-		with self.set_user(OTHER_USER):
-			self.assertEqual(get_user_access(self.file.name)["read"], 1)
+        with self.set_user(OWNER):
+            self.file.unshare(OTHER_USER)
+            self.folder.share(user=OTHER_USER, read=True)
+        with self.set_user(OTHER_USER):
+            self.assertEqual(get_user_access(self.file.name)["read"], 1)
 
-	def test_sharing_api_adds_and_removes_permission(self):
-		with self.set_user(OWNER):
-			update_access(self.file.name, "share", cmd="share", user=OTHER_USER, read=True)
-			self.assertTrue(
-				frappe.db.exists(
-					"Drive Permission", {"entity": self.file.name, "user": OTHER_USER, "read": 1}
-				)
-			)
-			update_access(self.file.name, "unshare", cmd="unshare", user=OTHER_USER)
-			self.assertFalse(
-				frappe.db.exists("Drive Permission", {"entity": self.file.name, "user": OTHER_USER})
-			)
+    def test_sharing_api_adds_and_removes_permission(self):
+        with self.set_user(OWNER):
+            update_access(self.file.name, "share", cmd="share", user=OTHER_USER, read=True)
+            self.assertTrue(
+                frappe.db.exists(
+                    "Drive Permission", {"entity": self.file.name, "user": OTHER_USER, "read": 1}
+                )
+            )
+            update_access(self.file.name, "unshare", cmd="unshare", user=OTHER_USER)
+            self.assertFalse(
+                frappe.db.exists("Drive Permission", {"entity": self.file.name, "user": OTHER_USER})
+            )
 
-	def test_download_token_is_single_use_sequentially(self):
-		with self.set_user(OWNER):
-			token = create_auth_token(self.file.name)
+    def test_download_token_is_single_use_sequentially(self):
+        with self.set_user(OWNER):
+            token = create_auth_token(self.file.name)
 
-		with (
-			self.set_user("Guest"),
-			patch(
-				"suite.drive.api.files.get_file_internal", return_value=b"file contents"
-			) as get_file_internal,
-		):
-			self.assertEqual(get_file_content(self.file.name, token=token), b"file contents")
-			get_file_internal.assert_called_once()
-			self.assertFalse(frappe.db.exists("Drive Token", token))
-			with self.assertRaises(frappe.PermissionError):
-				get_file_content(self.file.name, token=token)
+        with (
+            self.set_user("Guest"),
+            patch(
+                "suite.drive.api.files.get_file_internal", return_value=b"file contents"
+            ) as get_file_internal,
+        ):
+            self.assertEqual(get_file_content(self.file.name, token=token), b"file contents")
+            get_file_internal.assert_called_once()
+            self.assertFalse(frappe.db.exists("Drive Token", token))
+            with self.assertRaises(frappe.PermissionError):
+                get_file_content(self.file.name, token=token)
 
-	def test_trash_and_restore_preserve_status(self):
-		with (
-			self.set_user(OWNER),
-			patch("suite.drive.api.files.validate_quota"),
-			patch("suite.drive.api.files.FileManager.move_to_trash") as move_to_trash,
-			patch("suite.drive.api.files.FileManager.restore") as restore,
-		):
-			remove_or_restore([self.file.name])
-			self.assertEqual(frappe.db.get_value("File", self.file.name, "status"), STATUS_TRASHED)
-			move_to_trash.assert_called_once()
+    def test_trash_and_restore_preserve_status(self):
+        with (
+            self.set_user(OWNER),
+            patch("suite.drive.api.files.validate_quota"),
+            patch("suite.drive.api.files.FileManager.move_to_trash") as move_to_trash,
+            patch("suite.drive.api.files.FileManager.restore") as restore,
+        ):
+            remove_or_restore([self.file.name])
+            self.assertEqual(frappe.db.get_value("File", self.file.name, "status"), STATUS_TRASHED)
+            move_to_trash.assert_called_once()
 
-			remove_or_restore([self.file.name])
-			self.assertEqual(frappe.db.get_value("File", self.file.name, "status"), STATUS_ACTIVE)
-			restore.assert_called_once()
+            remove_or_restore([self.file.name])
+            self.assertEqual(frappe.db.get_value("File", self.file.name, "status"), STATUS_ACTIVE)
+            restore.assert_called_once()
 
-	def test_unrelated_user_cannot_trash_file(self):
-		with (
-			self.set_user(OTHER_USER),
-			patch("suite.drive.api.files.FileManager.move_to_trash") as move_to_trash,
-		):
-			with self.assertRaises(frappe.PermissionError):
-				remove_or_restore([self.file.name])
-			move_to_trash.assert_not_called()
+    def test_unrelated_user_cannot_trash_file(self):
+        with (
+            self.set_user(OTHER_USER),
+            patch("suite.drive.api.files.FileManager.move_to_trash") as move_to_trash,
+        ):
+            with self.assertRaises(frappe.PermissionError):
+                remove_or_restore([self.file.name])
+            move_to_trash.assert_not_called()
 
-	def test_owner_can_rename_and_move_uploaded_file(self):
-		with self.set_user(OWNER):
-			uploaded = self.upload(b"move me", "before.txt")
-			destination = create_drive_file(frappe.generate_hash(8), self.home, "Folder", "")
+    def test_owner_can_rename_and_move_uploaded_file(self):
+        with self.set_user(OWNER):
+            uploaded = self.upload(b"move me", "before.txt")
+            destination = create_drive_file(frappe.generate_hash(8), self.home, "Folder", "")
 
-			rename(uploaded.name, "after.txt")
-			uploaded.reload()
-			self.assertEqual(uploaded.file_name, "after.txt")
-			with FileManager().get_file(uploaded) as stored:
-				self.assertEqual(stored.read(), b"move me")
+            rename(uploaded.name, "after.txt")
+            uploaded.reload()
+            self.assertEqual(uploaded.file_name, "after.txt")
+            with FileManager().get_file(uploaded) as stored:
+                self.assertEqual(stored.read(), b"move me")
 
-			move([uploaded.name], new_parent=destination.name)
-			uploaded.reload()
-			self.assertEqual(uploaded.folder, destination.name)
-			with FileManager().get_file(uploaded) as stored:
-				self.assertEqual(stored.read(), b"move me")
+            move([uploaded.name], new_parent=destination.name)
+            uploaded.reload()
+            self.assertEqual(uploaded.folder, destination.name)
+            with FileManager().get_file(uploaded) as stored:
+                self.assertEqual(stored.read(), b"move me")
 
-	def test_unrelated_user_cannot_rename_or_move_file(self):
-		with self.set_user(OWNER):
-			destination = create_drive_file(frappe.generate_hash(8), self.home, "Folder", "")
-		with self.set_user(OTHER_USER):
-			with self.assertRaises(frappe.PermissionError):
-				rename(self.file.name, "forbidden.txt")
-			with self.assertRaises(frappe.PermissionError):
-				move([self.file.name], new_parent=destination.name)
+    def test_unrelated_user_cannot_rename_or_move_file(self):
+        with self.set_user(OWNER):
+            destination = create_drive_file(frappe.generate_hash(8), self.home, "Folder", "")
+        with self.set_user(OTHER_USER):
+            with self.assertRaises(frappe.PermissionError):
+                rename(self.file.name, "forbidden.txt")
+            with self.assertRaises(frappe.PermissionError):
+                move([self.file.name], new_parent=destination.name)

--- a/suite/drive/doctype/account_request/account_request.py
+++ b/suite/drive/doctype/account_request/account_request.py
@@ -14,31 +14,31 @@ from suite.utils import generate_otp
 
 
 class AccountRequest(Document):
-	def before_insert(self):
-		self.request_key = random_string(32)
+    def before_insert(self):
+        self.request_key = random_string(32)
 
-		self.ip_address = frappe.local.request_ip
-		geo_location = get_country_info() or {}
-		self.geo_location = json.dumps(geo_location, indent=1, sort_keys=True)
-		self.state = geo_location.get("regionName")
+        self.ip_address = frappe.local.request_ip
+        geo_location = get_country_info() or {}
+        self.geo_location = json.dumps(geo_location, indent=1, sort_keys=True)
+        self.state = geo_location.get("regionName")
 
-	def validate(self):
-		self.email = self.email.strip()
+    def validate(self):
+        self.email = self.email.strip()
 
-	def set_otp(self):
-		self.otp = generate_otp(length=6)
-		self.otp_generated_at = frappe.utils.now_datetime()
-		self.save(ignore_permissions=True)
+    def set_otp(self):
+        self.otp = generate_otp(length=6)
+        self.otp_generated_at = frappe.utils.now_datetime()
+        self.save(ignore_permissions=True)
 
-	def send_otp(self):
-		frappe.sendmail(
-			recipients=self.email,
-			subject="Frappe Drive - OTP",
-			template="otp",
-			args={"otp": self.otp},
-			now=True,
-		)
+    def send_otp(self):
+        frappe.sendmail(
+            recipients=self.email,
+            subject="Frappe Drive - OTP",
+            template="otp",
+            args={"otp": self.otp},
+            now=True,
+        )
 
-	@property
-	def full_name(self):
-		return " ".join(filter(None, [self.first_name, self.last_name]))
+    @property
+    def full_name(self):
+        return " ".join(filter(None, [self.first_name, self.last_name]))

--- a/suite/drive/doctype/drive_entity_log/drive_entity_log.py
+++ b/suite/drive/doctype/drive_entity_log/drive_entity_log.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe.model.document import Document
+
 from suite.drive.api.permissions import user_has_permission
 
 

--- a/suite/drive/doctype/drive_favourite/drive_favourite.py
+++ b/suite/drive/doctype/drive_favourite/drive_favourite.py
@@ -2,9 +2,10 @@
 # For license information, please see license.txt
 
 # import frappe
-from suite.drive.api.permissions import user_has_permission
-from frappe.model.document import Document
 import frappe
+from frappe.model.document import Document
+
+from suite.drive.api.permissions import user_has_permission
 
 
 class DriveFavourite(Document):

--- a/suite/drive/doctype/drive_legacy_route/drive_legacy_route.py
+++ b/suite/drive/doctype/drive_legacy_route/drive_legacy_route.py
@@ -5,4 +5,4 @@ from frappe.model.document import Document
 
 
 class DriveLegacyRoute(Document):
-	pass
+    pass

--- a/suite/drive/doctype/drive_settings/drive_settings.py
+++ b/suite/drive/doctype/drive_settings/drive_settings.py
@@ -8,14 +8,14 @@ PRIVILEGED_FIELDS = ("quota", "user_folder")
 
 
 class DriveSettings(Document):
-	def validate(self):
-		if self.flags.ignore_permissions or frappe.session.user == "Administrator":
-			return
-		if "Suite Admin" in frappe.get_roles():
-			return
+    def validate(self):
+        if self.flags.ignore_permissions or frappe.session.user == "Administrator":
+            return
+        if "Suite Admin" in frappe.get_roles():
+            return
 
-		before = self.get_doc_before_save()
-		for field in PRIVILEGED_FIELDS:
-			previous = before.get(field) if before else None
-			if (self.get(field) or None) != (previous or None):
-				frappe.throw(f"{field} is managed by Drive.", frappe.PermissionError)
+        before = self.get_doc_before_save()
+        for field in PRIVILEGED_FIELDS:
+            previous = before.get(field) if before else None
+            if (self.get(field) or None) != (previous or None):
+                frappe.throw(f"{field} is managed by Drive.", frappe.PermissionError)

--- a/suite/drive/doctype/drive_user_invitation/drive_user_invitation.py
+++ b/suite/drive/doctype/drive_user_invitation/drive_user_invitation.py
@@ -9,95 +9,95 @@ EXPIRY_DAYS = 1
 
 
 class DriveUserInvitation(Document):
-	def has_expired(self):
-		return get_datetime(self.creation) < get_datetime(add_days(now(), -EXPIRY_DAYS))
+    def has_expired(self):
+        return get_datetime(self.creation) < get_datetime(add_days(now(), -EXPIRY_DAYS))
 
-	def before_insert(self):
-		validate_email_address(self.email, True)
+    def before_insert(self):
+        validate_email_address(self.email, True)
 
-	def after_insert(self):
-		if self.status == "Pending":
-			try:
-				self.invite_via_email()
-			except BaseException as e:
-				frappe.log_error(f"Failed to send invite email: {e}")
-				pass
-		elif self.status == "Proposed":
-			admins = frappe.get_all(
-				"Has Role", filters={"role": "Suite Admin", "parenttype": "User"}, pluck="parent"
-			)
-			for admin in admins:
-				frappe.get_doc(
-					{
-						"doctype": "Drive Notification",
-						"to_user": admin,
-						"type": "Site",
-						"message": f"A person ({self.email}) from your domain has joined Frappe Drive",
-					}
-				).insert(ignore_permissions=True)
-			frappe.db.commit()
+    def after_insert(self):
+        if self.status == "Pending":
+            try:
+                self.invite_via_email()
+            except BaseException as e:
+                frappe.log_error(f"Failed to send invite email: {e}")
+                pass
+        elif self.status == "Proposed":
+            admins = frappe.get_all(
+                "Has Role", filters={"role": "Suite Admin", "parenttype": "User"}, pluck="parent"
+            )
+            for admin in admins:
+                frappe.get_doc(
+                    {
+                        "doctype": "Drive Notification",
+                        "to_user": admin,
+                        "type": "Site",
+                        "message": f"A person ({self.email}) from your domain has joined Frappe Drive",
+                    }
+                ).insert(ignore_permissions=True)
+            frappe.db.commit()
 
-	def invite_via_email(self):
-		frappe.sendmail(
-			recipients=self.email,
-			subject="Frappe Drive - Invitation",
-			template="drive_invitation",
-			args={
-				"invite_link": frappe.utils.get_url(
-					f"/api/method/suite.drive.api.product.accept_invite?key={self.name}"
-				),
-				"user": frappe.session.user,
-			},
-			now=True,
-		)
+    def invite_via_email(self):
+        frappe.sendmail(
+            recipients=self.email,
+            subject="Frappe Drive - Invitation",
+            template="drive_invitation",
+            args={
+                "invite_link": frappe.utils.get_url(
+                    f"/api/method/suite.drive.api.product.accept_invite?key={self.name}"
+                ),
+                "user": frappe.session.user,
+            },
+            now=True,
+        )
 
-	def accept(self, redirect=True):
-		if self.status not in ["Pending", "Automatic"]:
-			frappe.throw("This key has already been used")
-		if self.status == "Expired" or self.has_expired():
-			self.status = "Expired"
-			self.save(ignore_permissions=True)
-			frappe.db.commit()
-			frappe.throw("Invalid or expired key")
+    def accept(self, redirect=True):
+        if self.status not in ["Pending", "Automatic"]:
+            frappe.throw("This key has already been used")
+        if self.status == "Expired" or self.has_expired():
+            self.status = "Expired"
+            self.save(ignore_permissions=True)
+            frappe.db.commit()
+            frappe.throw("Invalid or expired key")
 
-		exists = frappe.db.exists(
-			"Account Request",
-			{
-				"email": self.email,
-				"signed_up": 1,
-			},
-		)
+        exists = frappe.db.exists(
+            "Account Request",
+            {
+                "email": self.email,
+                "signed_up": 1,
+            },
+        )
 
-		if redirect:
-			frappe.local.response["type"] = "redirect"
+        if redirect:
+            frappe.local.response["type"] = "redirect"
 
-		if not exists:
-			# If the user does not have an account, redirect to sign up
-			req = frappe.get_doc(
-				{
-					"doctype": "Account Request",
-					"email": self.email,
-					"invite": self.name,
-					"login_count": 1,
-				}
-			).insert(ignore_permissions=True)
-			frappe.db.commit()
-			user_exists = frappe.db.exists("User", self.email)
+        if not exists:
+            # If the user does not have an account, redirect to sign up
+            req = frappe.get_doc(
+                {
+                    "doctype": "Account Request",
+                    "email": self.email,
+                    "invite": self.name,
+                    "login_count": 1,
+                }
+            ).insert(ignore_permissions=True)
+            frappe.db.commit()
+            user_exists = frappe.db.exists("User", self.email)
 
-			if not user_exists:
-				url = f"/drive/signup?e={self.email}&r={req.name}"
-				if isinstance(redirect, str):
-					url += f"&redirect-to={redirect}"
-				frappe.local.response["location"] = url
-				return
+            if not user_exists:
+                url = f"/drive/signup?e={self.email}&r={req.name}"
+                if isinstance(redirect, str):
+                    url += f"&redirect-to={redirect}"
+                frappe.local.response["location"] = url
+                return
 
-		self.status = "Accepted"
-		self.accepted_at = frappe.utils.now()
-		self.save(ignore_permissions=True)
-		frappe.db.commit()
+        self.status = "Accepted"
+        self.accepted_at = frappe.utils.now()
+        self.save(ignore_permissions=True)
+        frappe.db.commit()
 
-		if frappe.session.user == "Guest":
-			frappe.local.login_manager.login_as(self.email)
+        if frappe.session.user == "Guest":
+            frappe.local.login_manager.login_as(self.email)
 
-		frappe.local.response["location"] = "/drive/"
-		return "/drive/"
+        frappe.local.response["location"] = "/drive/"
+        return "/drive/"

--- a/suite/drive/e2e_api.py
+++ b/suite/drive/e2e_api.py
@@ -13,186 +13,186 @@ RUN_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,39}$")
 
 
 def _validate_run_id(run_id: str) -> str:
-	run_id = (run_id or "").strip().lower()
-	if not RUN_ID_PATTERN.fullmatch(run_id):
-		frappe.throw("run_id must contain 1-40 lowercase letters, numbers, or hyphens")
-	return run_id
+    run_id = (run_id or "").strip().lower()
+    if not RUN_ID_PATTERN.fullmatch(run_id):
+        frappe.throw("run_id must contain 1-40 lowercase letters, numbers, or hyphens")
+    return run_id
 
 
 def _user_emails(run_id: str, user_count: int = USER_COUNT) -> list[str]:
-	run_id = _validate_run_id(run_id)
-	if user_count < USER_COUNT or user_count > MAX_USER_COUNT or user_count % 2:
-		frappe.throw(f"user_count must be an even number between {USER_COUNT} and {MAX_USER_COUNT}")
-	return [f"drive-writer-e2e-{run_id}-{number}@example.test" for number in range(1, user_count + 1)]
+    run_id = _validate_run_id(run_id)
+    if user_count < USER_COUNT or user_count > MAX_USER_COUNT or user_count % 2:
+        frappe.throw(f"user_count must be an even number between {USER_COUNT} and {MAX_USER_COUNT}")
+    return [f"drive-writer-e2e-{run_id}-{number}@example.test" for number in range(1, user_count + 1)]
 
 
 def _existing_user_emails(run_id: str) -> list[str]:
-	run_id = _validate_run_id(run_id)
-	return frappe.get_all(
-		"User",
-		filters={"name": ["like", f"drive-writer-e2e-{run_id}-%@example.test"]},
-		pluck="name",
-		order_by="name",
-	)
+    run_id = _validate_run_id(run_id)
+    return frappe.get_all(
+        "User",
+        filters={"name": ["like", f"drive-writer-e2e-{run_id}-%@example.test"]},
+        pluck="name",
+        order_by="name",
+    )
 
 
 def _user_result(email: str, password: str | None = None) -> dict:
-	result = {
-		"email": email,
-		"user": email,
-		"drive_settings": frappe.db.get_value("Drive Settings", {"user": email}, "name"),
-		"user_folder": frappe.db.get_value("Drive Settings", email, "user_folder"),
-	}
-	if password is not None:
-		result["password"] = password
-	return result
+    result = {
+        "email": email,
+        "user": email,
+        "drive_settings": frappe.db.get_value("Drive Settings", {"user": email}, "name"),
+        "user_folder": frappe.db.get_value("Drive Settings", email, "user_folder"),
+    }
+    if password is not None:
+        result["password"] = password
+    return result
 
 
 def _user_files(email: str) -> list[str]:
-	"""The user's folder and everything under it, plus anything they own."""
-	folder = frappe.db.get_value("Drive Settings", email, "user_folder")
-	names = frappe.get_all("File", filters={"owner": email}, pluck="name")
-	if folder:
-		names.append(folder)
-		frontier = [folder]
-		while frontier:
-			children = frappe.get_all("File", filters={"folder": ["in", frontier]}, pluck="name")
-			frontier = [c for c in children if c not in names]
-			names.extend(frontier)
-	return list(dict.fromkeys(names))
+    """The user's folder and everything under it, plus anything they own."""
+    folder = frappe.db.get_value("Drive Settings", email, "user_folder")
+    names = frappe.get_all("File", filters={"owner": email}, pluck="name")
+    if folder:
+        names.append(folder)
+        frontier = [folder]
+        while frontier:
+            children = frappe.get_all("File", filters={"folder": ["in", frontier]}, pluck="name")
+            frontier = [c for c in children if c not in names]
+            names.extend(frontier)
+    return list(dict.fromkeys(names))
 
 
 def _delete_user_drive_data(email: str) -> None:
-	files = _user_files(email)
+    files = _user_files(email)
 
-	if files:
-		writer_documents = frappe.get_all(
-			"File",
-			filters={"name": ["in", files], "content_doctype": "Writer Document"},
-			pluck="content_docname",
-		)
-		for document in set(filter(None, writer_documents)):
-			frappe.db.delete("Writer Version", {"doc": document})
-			frappe.db.delete("Writer Document", {"name": document})
+    if files:
+        writer_documents = frappe.get_all(
+            "File",
+            filters={"name": ["in", files], "content_doctype": "Writer Document"},
+            pluck="content_docname",
+        )
+        for document in set(filter(None, writer_documents)):
+            frappe.db.delete("Writer Version", {"doc": document})
+            frappe.db.delete("Writer Document", {"name": document})
 
-		sheets = frappe.get_all(
-			"File",
-			filters={"name": ["in", files], "content_doctype": "Sheet"},
-			pluck="content_docname",
-		)
-		for sheet in set(filter(None, sheets)):
-			# Sheet Op Log and Sheet Snapshot both carry a User link (actor) that
-			# blocks the User delete below.
-			frappe.db.delete("Sheet Op Log", {"sheet": sheet})
-			frappe.db.delete("Sheet Snapshot", {"sheet": sheet})
-			frappe.db.delete("Sheet", {"name": sheet})
+        sheets = frappe.get_all(
+            "File",
+            filters={"name": ["in", files], "content_doctype": "Sheet"},
+            pluck="content_docname",
+        )
+        for sheet in set(filter(None, sheets)):
+            # Sheet Op Log and Sheet Snapshot both carry a User link (actor) that
+            # blocks the User delete below.
+            frappe.db.delete("Sheet Op Log", {"sheet": sheet})
+            frappe.db.delete("Sheet Snapshot", {"sheet": sheet})
+            frappe.db.delete("Sheet", {"name": sheet})
 
-		presentations = frappe.get_all(
-			"File",
-			filters={"name": ["in", files], "content_doctype": "Presentation"},
-			pluck="content_docname",
-		)
-		for presentation in set(filter(None, presentations)):
-			frappe.db.delete("Presentation", {"name": presentation})
+        presentations = frappe.get_all(
+            "File",
+            filters={"name": ["in", files], "content_doctype": "Presentation"},
+            pluck="content_docname",
+        )
+        for presentation in set(filter(None, presentations)):
+            frappe.db.delete("Presentation", {"name": presentation})
 
-		for doctype, field in (
-			("Drive Permission", "entity"),
-			("Drive Favourite", "entity"),
-			("Drive Entity Log", "entity_name"),
-			("Drive Entity Activity Log", "entity"),
-			("Drive Token", "file"),
-		):
-			frappe.db.delete(doctype, {field: ["in", files]})
+        for doctype, field in (
+            ("Drive Permission", "entity"),
+            ("Drive Favourite", "entity"),
+            ("Drive Entity Log", "entity_name"),
+            ("Drive Entity Activity Log", "entity"),
+            ("Drive Token", "file"),
+        ):
+            frappe.db.delete(doctype, {field: ["in", files]})
 
-	frappe.db.delete("Drive Permission", {"user": email})
-	frappe.db.delete("Drive Favourite", {"user": email})
-	frappe.db.delete("Drive Entity Log", {"user": email})
-	frappe.db.delete("Drive Token", {"user": email})
-	frappe.db.delete("Drive Notification", {"from_user": email})
-	frappe.db.delete("Drive Notification", {"to_user": email})
-	frappe.db.delete("Drive User Invitation", {"email": email})
+    frappe.db.delete("Drive Permission", {"user": email})
+    frappe.db.delete("Drive Favourite", {"user": email})
+    frappe.db.delete("Drive Entity Log", {"user": email})
+    frappe.db.delete("Drive Token", {"user": email})
+    frappe.db.delete("Drive Notification", {"from_user": email})
+    frappe.db.delete("Drive Notification", {"to_user": email})
+    frappe.db.delete("Drive User Invitation", {"email": email})
 
-	if files:
-		frappe.db.delete("File", {"name": ["in", files]})
+    if files:
+        frappe.db.delete("File", {"name": ["in", files]})
 
-	frappe.db.delete("Drive Settings", {"user": email})
+    frappe.db.delete("Drive Settings", {"user": email})
 
 
 def _create_user_drive_data(email: str) -> None:
-	from suite.drive.utils import get_user_folder
+    from suite.drive.utils import get_user_folder
 
-	get_user_folder(email)
+    get_user_folder(email)
 
 
 @whitelist_for_tests(methods=["POST"])
 def provision_users(run_id: str, password: str = DEFAULT_PASSWORD, user_count: int = USER_COUNT) -> dict:
-	"""Create isolated owner/collaborator pairs for each E2E worker."""
-	emails = _user_emails(run_id, user_count)
-	if not password:
-		frappe.throw("password is required")
+    """Create isolated owner/collaborator pairs for each E2E worker."""
+    emails = _user_emails(run_id, user_count)
+    if not password:
+        frappe.throw("password is required")
 
-	existing = [email for email in emails if frappe.db.exists("User", email)]
-	if existing:
-		frappe.throw(f"E2E users already exist for run_id {run_id}: {', '.join(existing)}")
+    existing = [email for email in emails if frappe.db.exists("User", email)]
+    if existing:
+        frappe.throw(f"E2E users already exist for run_id {run_id}: {', '.join(existing)}")
 
-	for number, email in enumerate(emails, 1):
-		user = frappe.get_doc(
-			{
-				"doctype": "User",
-				"email": email,
-				"first_name": f"Drive Writer E2E {number}",
-				"enabled": 1,
-				"send_welcome_email": 0,
-				"new_password": password,
-			}
-		)
-		user.flags.skip_drive_setup = True
-		user.insert(ignore_permissions=True)
-		user.reload()
-		user.add_roles("Suite User")
-		_create_user_drive_data(email)
+    for number, email in enumerate(emails, 1):
+        user = frappe.get_doc(
+            {
+                "doctype": "User",
+                "email": email,
+                "first_name": f"Drive Writer E2E {number}",
+                "enabled": 1,
+                "send_welcome_email": 0,
+                "new_password": password,
+            }
+        )
+        user.flags.skip_drive_setup = True
+        user.insert(ignore_permissions=True)
+        user.reload()
+        user.add_roles("Suite User")
+        _create_user_drive_data(email)
 
-	return {"run_id": run_id, "users": [_user_result(email, password) for email in emails]}
+    return {"run_id": run_id, "users": [_user_result(email, password) for email in emails]}
 
 
 @whitelist_for_tests(methods=["POST"])
 def create_user_group(run_id: str, name: str, members: str) -> dict:
-	"""Group named for this run, so cleanup_users can find it again."""
-	group = f"{_validate_run_id(run_id)}-{name}"
-	emails = [e for e in (members or "").split(",") if e]
-	if frappe.db.exists("User Group", group):
-		frappe.delete_doc("User Group", group, ignore_permissions=True, force=True)
+    """Group named for this run, so cleanup_users can find it again."""
+    group = f"{_validate_run_id(run_id)}-{name}"
+    emails = [e for e in (members or "").split(",") if e]
+    if frappe.db.exists("User Group", group):
+        frappe.delete_doc("User Group", group, ignore_permissions=True, force=True)
 
-	doc = frappe.get_doc({"doctype": "User Group", "__newname": group})
-	for email in emails:
-		doc.append("user_group_members", {"user": email})
-	doc.insert(ignore_permissions=True)
+    doc = frappe.get_doc({"doctype": "User Group", "__newname": group})
+    for email in emails:
+        doc.append("user_group_members", {"user": email})
+    doc.insert(ignore_permissions=True)
 
-	from suite.drive.utils import clear_user_group_cache
+    from suite.drive.utils import clear_user_group_cache
 
-	clear_user_group_cache()
-	frappe.db.commit()
-	return {"name": group, "member_count": len(emails)}
+    clear_user_group_cache()
+    frappe.db.commit()
+    return {"name": group, "member_count": len(emails)}
 
 
 @whitelist_for_tests(methods=["POST"])
 def cleanup_users(run_id: str) -> dict:
-	"""Delete only users and personal Drive/Writer data named by this run ID."""
-	emails = _existing_user_emails(run_id)
-	deleted = []
+    """Delete only users and personal Drive/Writer data named by this run ID."""
+    emails = _existing_user_emails(run_id)
+    deleted = []
 
-	for group in frappe.get_all(
-		"User Group", filters={"name": ["like", f"{_validate_run_id(run_id)}-%"]}, pluck="name"
-	):
-		frappe.db.delete("Drive Permission", {"user": f"$GROUP:{group}"})
-		frappe.delete_doc("User Group", group, ignore_permissions=True, force=True)
+    for group in frappe.get_all(
+        "User Group", filters={"name": ["like", f"{_validate_run_id(run_id)}-%"]}, pluck="name"
+    ):
+        frappe.db.delete("Drive Permission", {"user": f"$GROUP:{group}"})
+        frappe.delete_doc("User Group", group, ignore_permissions=True, force=True)
 
-	for email in emails:
-		if not frappe.db.exists("User", email):
-			continue
+    for email in emails:
+        if not frappe.db.exists("User", email):
+            continue
 
-		_delete_user_drive_data(email)
-		frappe.delete_doc("User", email, ignore_permissions=True)
-		deleted.append(email)
+        _delete_user_drive_data(email)
+        frappe.delete_doc("User", email, ignore_permissions=True)
+        deleted.append(email)
 
-	return {"run_id": run_id, "deleted_users": deleted}
+    return {"run_id": run_id, "deleted_users": deleted}

--- a/suite/drive/install.py
+++ b/suite/drive/install.py
@@ -5,30 +5,26 @@ from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 
 def ensure_custom_fields():
-	"""Create Drive's `File` custom fields (status, content_doctype, ...).
+    """Create Drive's `File` custom fields (status, content_doctype, ...).
 
-	They ship as fixtures, which Frappe syncs only AFTER after_install runs. But
-	inside the suite app Drive overrides the core File class app-wide, so a File
-	created during ANY module's after_install (e.g. Mail's default folders) runs
-	through Drive's hooks and needs these columns to already exist. Create them up
-	front. Idempotent: create_custom_fields updates fields in place on re-run.
-	"""
-	path = frappe.get_app_path("suite", "fixtures", "custom_field.json")
-	with open(path) as f:
-		fields = json.load(f)
+    They ship as fixtures, which Frappe syncs only AFTER after_install runs. But
+    inside the suite app Drive overrides the core File class app-wide, so a File
+    created during ANY module's after_install (e.g. Mail's default folders) runs
+    through Drive's hooks and needs these columns to already exist. Create them up
+    front. Idempotent: create_custom_fields updates fields in place on re-run.
+    """
+    path = frappe.get_app_path("suite", "fixtures", "custom_field.json")
+    with open(path) as f:
+        fields = json.load(f)
 
-	grouped = {}
-	for df in fields:
-		grouped.setdefault(df["dt"], []).append(df)
+    grouped = {}
+    for df in fields:
+        grouped.setdefault(df["dt"], []).append(df)
 
-	create_custom_fields(grouped, ignore_validate=True)
+    create_custom_fields(grouped, ignore_validate=True)
 
 
 def after_install():
-	index_check = frappe.db.sql(
-		"""SHOW INDEX FROM `tabFile` WHERE Key_name = 'drive_file_name_fts_idx'"""
-	)
-	if not index_check:
-		frappe.db.sql(
-			"""ALTER TABLE `tabFile` ADD FULLTEXT INDEX drive_file_name_fts_idx (file_name)"""
-		)
+    index_check = frappe.db.sql("""SHOW INDEX FROM `tabFile` WHERE Key_name = 'drive_file_name_fts_idx'""")
+    if not index_check:
+        frappe.db.sql("""ALTER TABLE `tabFile` ADD FULLTEXT INDEX drive_file_name_fts_idx (file_name)""")

--- a/suite/drive/locks/distributed_lock.py
+++ b/suite/drive/locks/distributed_lock.py
@@ -6,7 +6,7 @@ class FileLockedError(Exception):
     pass
 
 
-class DistributedLock(object):
+class DistributedLock:
     def __init__(self, path, exclusive, ttl=60):
         self.path = path
         self.exclusive = exclusive

--- a/suite/drive/overrides/file.py
+++ b/suite/drive/overrides/file.py
@@ -9,27 +9,27 @@ from frappe.utils import get_files_path, now
 from suite.drive.api.activity import create_new_activity_log
 from suite.drive.api.files import get_file_type
 from suite.drive.api.permissions import (
-	exceeds_grant_ceiling,
-	get_entity_with_permissions,
-	get_user_access,
-	user_has_permission,
+    exceeds_grant_ceiling,
+    get_entity_with_permissions,
+    get_user_access,
+    user_has_permission,
 )
 from suite.drive.api.product import create_invites
 from suite.drive.utils import (
-	ATTACHMENT_CONTENT_DOCTYPE,
-	GENERAL_USER,
-	GROUP_PREFIX,
-	ROOT_FOLDER,
-	STATUS_ACTIVE,
-	STATUS_REMOVED,
-	STATUS_TRASHED,
-	WRITER_CONTENT_DOCTYPE,
-	generate_upward_path,
-	get_new_file_name,
-	get_user_folder,
-	principal_list,
-	update_file_size,
-	validate_filename,
+    ATTACHMENT_CONTENT_DOCTYPE,
+    GENERAL_USER,
+    GROUP_PREFIX,
+    ROOT_FOLDER,
+    STATUS_ACTIVE,
+    STATUS_REMOVED,
+    STATUS_TRASHED,
+    WRITER_CONTENT_DOCTYPE,
+    generate_upward_path,
+    get_new_file_name,
+    get_user_folder,
+    principal_list,
+    update_file_size,
+    validate_filename,
 )
 from suite.drive.utils.files import S3_URL_PREFIX, FileManager, get_s3_url, storage_key
 
@@ -39,562 +39,562 @@ FRAMEWORK_FOLDERS = ("Home", "Home/Attachments")
 
 
 class File(FrappeFile):
-	"""Every File is Drive-managed. Files created by Drive itself (marked with
-	`flags.file_created` before insert) skip the framework's storage flow, which
-	Drive owns; framework uploads keep it and are adopted into the tree by
-	`after_file_upload`."""
+    """Every File is Drive-managed. Files created by Drive itself (marked with
+    `flags.file_created` before insert) skip the framework's storage flow, which
+    Drive owns; framework uploads keep it and are adopted into the tree by
+    `after_file_upload`."""
 
-	def validate(self):
-		if self.is_new() and not self.flags.file_created:
-			return super().validate()
-		# Blob-backed Drive files must be private: they're served only through
-		# Drive's permission layer, never the public /files/ path. Folders, links
-		# and content-doctype files have no on-disk blob, and adopted framework
-		# uploads keep their framework URL and privacy, so they're exempt.
-		if (
-			not self.is_folder
-			and not self._not_in_disk()
-			and not self.attached_to_doctype
-			and not self.is_private
-		):
-			frappe.throw("Drive files must be private.", frappe.ValidationError)
-		# file_name is coupled to the blob path; only rename()/move() may change it.
-		if not self.is_new() and self.has_value_changed("file_name") and not self.flags.drive_disk_rename:
-			frappe.throw(
-				"Rename Drive files from the Drive interface, not the File form.",
-				frappe.ValidationError,
-			)
+    def validate(self):
+        if self.is_new() and not self.flags.file_created:
+            return super().validate()
+        # Blob-backed Drive files must be private: they're served only through
+        # Drive's permission layer, never the public /files/ path. Folders, links
+        # and content-doctype files have no on-disk blob, and adopted framework
+        # uploads keep their framework URL and privacy, so they're exempt.
+        if (
+            not self.is_folder
+            and not self._not_in_disk()
+            and not self.attached_to_doctype
+            and not self.is_private
+        ):
+            frappe.throw("Drive files must be private.", frappe.ValidationError)
+        # file_name is coupled to the blob path; only rename()/move() may change it.
+        if not self.is_new() and self.has_value_changed("file_name") and not self.flags.drive_disk_rename:
+            frappe.throw(
+                "Rename Drive files from the Drive interface, not the File form.",
+                frappe.ValidationError,
+            )
 
-	def before_insert(self):
-		# Drive's upload flow owns storage; framework uploads keep core's flow.
-		if not self.flags.file_created:
-			return super().before_insert()
+    def before_insert(self):
+        # Drive's upload flow owns storage; framework uploads keep core's flow.
+        if not self.flags.file_created:
+            return super().before_insert()
 
-	def autoname(self):
-		if not self.flags.file_created:
-			return super().autoname()
-		self.name = getattr(self, "_name", None) or frappe.generate_hash(length=10)
+    def autoname(self):
+        if not self.flags.file_created:
+            return super().autoname()
+        self.name = getattr(self, "_name", None) or frappe.generate_hash(length=10)
 
-	def after_insert(self):
-		if not self.flags.file_created or frappe.flags.get("mute_drive_activity_log"):
-			return
-		full_name = frappe.db.get_value("User", frappe.session.user, "full_name")
-		create_new_activity_log(
-			entity=self.name,
-			activity_type="create",
-			activity_message=f"{full_name} created {self.file_name}",
-			document_field="file_name",
-			field_new_value=self.file_name,
-		)
+    def after_insert(self):
+        if not self.flags.file_created or frappe.flags.get("mute_drive_activity_log"):
+            return
+        full_name = frappe.db.get_value("User", frappe.session.user, "full_name")
+        create_new_activity_log(
+            entity=self.name,
+            activity_type="create",
+            activity_message=f"{full_name} created {self.file_name}",
+            document_field="file_name",
+            field_new_value=self.file_name,
+        )
 
-	def on_trash(self):
-		# frappe protects Home and Attachments the same way
-		if self.name == ROOT_FOLDER:
-			frappe.throw("Cannot delete the Drive root folder.", frappe.PermissionError)
-		super().on_trash()
+    def on_trash(self):
+        # frappe protects Home and Attachments the same way
+        if self.name == ROOT_FOLDER:
+            frappe.throw("Cannot delete the Drive root folder.", frappe.PermissionError)
+        super().on_trash()
 
-	def after_delete(self):
-		if self.is_folder:
-			for child_name in frappe.get_all("File", filters={"folder": self.name}, pluck="name"):
-				frappe.delete_doc("File", child_name, ignore_permissions=True)
+    def after_delete(self):
+        if self.is_folder:
+            for child_name in frappe.get_all("File", filters={"folder": self.name}, pluck="name"):
+                frappe.delete_doc("File", child_name, ignore_permissions=True)
 
-		frappe.db.delete("Drive Favourite", {"entity": self.name})
-		frappe.db.delete("Drive Entity Log", {"entity_name": self.name})
-		frappe.db.delete("Drive Permission", {"entity": self.name})
-		frappe.db.delete("Drive Notification", {"notif_doctype_name": self.name})
-		frappe.db.delete("Drive Entity Activity Log", {"entity": self.name})
+        frappe.db.delete("Drive Favourite", {"entity": self.name})
+        frappe.db.delete("Drive Entity Log", {"entity_name": self.name})
+        frappe.db.delete("Drive Permission", {"entity": self.name})
+        frappe.db.delete("Drive Notification", {"notif_doctype_name": self.name})
+        frappe.db.delete("Drive Entity Activity Log", {"entity": self.name})
 
-		if (
-			self.content_doctype
-			and self.content_docname
-			and self.content_doctype != ATTACHMENT_CONTENT_DOCTYPE
-			and frappe.db.exists(self.content_doctype, self.content_docname)
-		):
-			frappe.delete_doc(self.content_doctype, self.content_docname, ignore_permissions=True)
+        if (
+            self.content_doctype
+            and self.content_docname
+            and self.content_doctype != ATTACHMENT_CONTENT_DOCTYPE
+            and frappe.db.exists(self.content_doctype, self.content_docname)
+        ):
+            frappe.delete_doc(self.content_doctype, self.content_docname, ignore_permissions=True)
 
-	def on_rollback(self):
-		if not self.flags.file_created or not self.file_url:
-			return
-		path = Path(get_files_path(self.file_url, private=True))
-		if not path.exists():
-			return
-		if self.is_folder:
-			shutil.rmtree(path)
-		else:
-			path.unlink()
+    def on_rollback(self):
+        if not self.flags.file_created or not self.file_url:
+            return
+        path = Path(get_files_path(self.file_url, private=True))
+        if not path.exists():
+            return
+        if self.is_folder:
+            shutil.rmtree(path)
+        else:
+            path.unlink()
 
-	def _not_in_disk(self):
-		content_without_storage = bool(
-			self.content_doctype and self.content_doctype != WRITER_CONTENT_DOCTYPE
-		)
-		return self.file_type == "Link" or not self.file_url or content_without_storage
+    def _not_in_disk(self):
+        content_without_storage = bool(
+            self.content_doctype and self.content_doctype != WRITER_CONTENT_DOCTYPE
+        )
+        return self.file_type == "Link" or not self.file_url or content_without_storage
 
-	# Drive methods
-	def _update_modified(func):
-		"""Used for functions that meaningfuly "modify" a file"""
+    # Drive methods
+    def _update_modified(func):
+        """Used for functions that meaningfuly "modify" a file"""
 
-		def decorator(self, *args, **kwargs):
-			# Legacy code
-			res = func(self, *args, **kwargs)
-			self.db_set("file_modified", now())
-			return res
+        def decorator(self, *args, **kwargs):
+            # Legacy code
+            res = func(self, *args, **kwargs)
+            self.db_set("file_modified", now())
+            return res
 
-		return decorator
+        return decorator
 
-	@frappe.whitelist()
-	def share(
-		self,
-		user: str | None = None,
-		read: bool | None = None,
-		comment: bool | None = None,
-		share: bool | None = None,
-		upload: bool | None = None,
-		write: bool | None = None,
-		deny: bool = False,
-	):
-		if not user_has_permission(self, "share"):
-			frappe.throw("Not permitted to share", frappe.PermissionError)
+    @frappe.whitelist()
+    def share(
+        self,
+        user: str | None = None,
+        read: bool | None = None,
+        comment: bool | None = None,
+        share: bool | None = None,
+        upload: bool | None = None,
+        write: bool | None = None,
+        deny: bool = False,
+    ):
+        if not user_has_permission(self, "share"):
+            frappe.throw("Not permitted to share", frappe.PermissionError)
 
-		# General rows ("" = anyone with the link, $GENERAL = site users) are
-		# mutually exclusive — replace wholesale.
-		user = user or ""
-		if user in ("", GENERAL_USER):
-			self._clear_general()
-		elif user.startswith(GROUP_PREFIX):
-			if not frappe.db.exists("User Group", user[len(GROUP_PREFIX) :]):
-				frappe.throw(f"No such group: {user[len(GROUP_PREFIX) :]}", frappe.DoesNotExistError)
-		elif not frappe.db.exists("User", user):
-			create_invites(user, auto=True)
+        # General rows ("" = anyone with the link, $GENERAL = site users) are
+        # mutually exclusive — replace wholesale.
+        user = user or ""
+        if user in ("", GENERAL_USER):
+            self._clear_general()
+        elif user.startswith(GROUP_PREFIX):
+            if not frappe.db.exists("User Group", user[len(GROUP_PREFIX) :]):
+                frappe.throw(f"No such group: {user[len(GROUP_PREFIX) :]}", frappe.DoesNotExistError)
+        elif not frappe.db.exists("User", user):
+            create_invites(user, auto=True)
 
-		permission = frappe.db.get_value("Drive Permission", {"entity": self.name, "user": user})
-		if not permission:
-			permission = frappe.new_doc("Drive Permission")
-			permission.update({"user": user, "entity": self.name})
-		else:
-			permission = frappe.get_doc("Drive Permission", permission)
-		permission.deny = int(deny)
+        permission = frappe.db.get_value("Drive Permission", {"entity": self.name, "user": user})
+        if not permission:
+            permission = frappe.new_doc("Drive Permission")
+            permission.update({"user": user, "entity": self.name})
+        else:
+            permission = frappe.get_doc("Drive Permission", permission)
+        permission.deny = int(deny)
 
-		levels = [
-			["read", read],
-			["comment", comment],
-			["share", share],
-			["upload", upload],
-			["write", write],
-		]
-		permission.update({l[0]: l[1] for l in levels if l[1] is not None})
+        levels = [
+            ["read", read],
+            ["comment", comment],
+            ["share", share],
+            ["upload", upload],
+            ["write", write],
+        ]
+        permission.update({l[0]: l[1] for l in levels if l[1] is not None})
 
-		# Against the resulting row, not just the levels named: clearing `deny` starts
-		# granting whatever bits the row still carries.
-		if not deny:
-			for level in exceeds_grant_ceiling(self, permission.as_dict()):
-				frappe.throw(
-					f"You cannot grant '{level}' access that you don't have yourself.",
-					frappe.PermissionError,
-				)
+        # Against the resulting row, not just the levels named: clearing `deny` starts
+        # granting whatever bits the row still carries.
+        if not deny:
+            for level in exceeds_grant_ceiling(self, permission.as_dict()):
+                frappe.throw(
+                    f"You cannot grant '{level}' access that you don't have yourself.",
+                    frappe.PermissionError,
+                )
 
-		permission.save(ignore_permissions=True)
+        permission.save(ignore_permissions=True)
 
-	@frappe.whitelist()
-	def unshare(self, user: str | None = None):
-		if not user_has_permission(self, "share"):
-			frappe.throw("Not permitted to unshare", frappe.PermissionError)
+    @frappe.whitelist()
+    def unshare(self, user: str | None = None):
+        if not user_has_permission(self, "share"):
+            frappe.throw("Not permitted to unshare", frappe.PermissionError)
 
-		absolute_path = generate_upward_path(self.name)
-		for i in absolute_path:
-			if i["owner"] == user:
-				frappe.throw("User owns parent folder", frappe.PermissionError)
+        absolute_path = generate_upward_path(self.name)
+        for i in absolute_path:
+            if i["owner"] == user:
+                frappe.throw("User owns parent folder", frappe.PermissionError)
 
-		if user in ("", GENERAL_USER):
-			self._clear_general()
-			# Dropping this file's own general rows is enough unless read is
-			# inherited from a folder above (e.g. anything inside Site); then
-			# restricting still needs an explicit deny to cut the inheritance.
-			if get_user_access(self, "Guest")["read"]:
-				self._insert_deny("")
-			if generate_upward_path(self.name, GENERAL_USER)[-1]["read"]:
-				self._insert_deny(GENERAL_USER)
-		else:
-			perm_name = frappe.db.get_value(
-				"Drive Permission",
-				{
-					"user": user,
-					"entity": self.name,
-				},
-			)
-			if perm_name:
-				frappe.delete_doc("Drive Permission", perm_name, ignore_permissions=True)
+        if user in ("", GENERAL_USER):
+            self._clear_general()
+            # Dropping this file's own general rows is enough unless read is
+            # inherited from a folder above (e.g. anything inside Site); then
+            # restricting still needs an explicit deny to cut the inheritance.
+            if get_user_access(self, "Guest")["read"]:
+                self._insert_deny("")
+            if generate_upward_path(self.name, GENERAL_USER)[-1]["read"]:
+                self._insert_deny(GENERAL_USER)
+        else:
+            perm_name = frappe.db.get_value(
+                "Drive Permission",
+                {
+                    "user": user,
+                    "entity": self.name,
+                },
+            )
+            if perm_name:
+                frappe.delete_doc("Drive Permission", perm_name, ignore_permissions=True)
 
-	def _clear_general(self):
-		for name in frappe.get_all(
-			"Drive Permission",
-			filters={"entity": self.name, "user": ["in", ["", GENERAL_USER]]},
-			pluck="name",
-		):
-			frappe.delete_doc("Drive Permission", name, ignore_permissions=True)
+    def _clear_general(self):
+        for name in frappe.get_all(
+            "Drive Permission",
+            filters={"entity": self.name, "user": ["in", ["", GENERAL_USER]]},
+            pluck="name",
+        ):
+            frappe.delete_doc("Drive Permission", name, ignore_permissions=True)
 
-	def _insert_deny(self, user: str):
-		frappe.get_doc(
-			{
-				"doctype": "Drive Permission",
-				"entity": self.name,
-				"user": user,
-				"deny": 1,
-				"read": 1,
-				"comment": 1,
-				"share": 1,
-				"upload": 1,
-				"write": 1,
-			}
-		).insert(ignore_permissions=True)
+    def _insert_deny(self, user: str):
+        frappe.get_doc(
+            {
+                "doctype": "Drive Permission",
+                "entity": self.name,
+                "user": user,
+                "deny": 1,
+                "read": 1,
+                "comment": 1,
+                "share": 1,
+                "upload": 1,
+                "write": 1,
+            }
+        ).insert(ignore_permissions=True)
 
-	@_update_modified
-	def move(self, new_parent=None):
-		"""
-		Move file to a new folder.
-		"""
-		new_parent = new_parent or get_user_folder().name
+    @_update_modified
+    def move(self, new_parent=None):
+        """
+        Move file to a new folder.
+        """
+        new_parent = new_parent or get_user_folder().name
 
-		if new_parent == self.name:
-			frappe.throw(
-				"Cannot move into itself",
-				ValueError,
-			)
-		elif not user_has_permission(new_parent, "upload") or not user_has_permission(self, "write"):
-			frappe.throw("You don't have permission to move this file.", frappe.PermissionError)
+        if new_parent == self.name:
+            frappe.throw(
+                "Cannot move into itself",
+                ValueError,
+            )
+        elif not user_has_permission(new_parent, "upload") or not user_has_permission(self, "write"):
+            frappe.throw("You don't have permission to move this file.", frappe.PermissionError)
 
-		if not frappe.db.get_value("File", new_parent, "is_folder"):
-			frappe.throw(
-				"Can only move into folders",
-				NotADirectoryError,
-			)
-		if any(p["name"] == self.name for p in generate_upward_path(new_parent)):
-			frappe.throw(
-				"Cannot move into itself",
-				ValueError,
-			)
+        if not frappe.db.get_value("File", new_parent, "is_folder"):
+            frappe.throw(
+                "Can only move into folders",
+                NotADirectoryError,
+            )
+        if any(p["name"] == self.name for p in generate_upward_path(new_parent)):
+            frappe.throw(
+                "Cannot move into itself",
+                ValueError,
+            )
 
-		# Sanctioned rename: move() owns the disk move below, so let validate
-		# through even though file_name may change on a name collision.
-		self.flags.drive_disk_rename = True
+        # Sanctioned rename: move() owns the disk move below, so let validate
+        # through even though file_name may change on a name collision.
+        self.flags.drive_disk_rename = True
 
-		if new_parent != self.folder:
-			old_folder_name = frappe.db.get_value("File", self.folder, "file_name")
-			new_folder_name = frappe.db.get_value("File", new_parent, "file_name")
-			full_name = frappe.db.get_value("User", frappe.session.user, "full_name")
-			create_new_activity_log(
-				entity=self.name,
-				activity_type="move",
-				activity_message=f"{full_name} moved {self.file_name} to {new_folder_name}",
-				document_field="folder",
-				field_old_value=old_folder_name,
-				field_new_value=new_folder_name,
-			)
+        if new_parent != self.folder:
+            old_folder_name = frappe.db.get_value("File", self.folder, "file_name")
+            new_folder_name = frappe.db.get_value("File", new_parent, "file_name")
+            full_name = frappe.db.get_value("User", frappe.session.user, "full_name")
+            create_new_activity_log(
+                entity=self.name,
+                activity_type="move",
+                activity_message=f"{full_name} moved {self.file_name} to {new_folder_name}",
+                document_field="folder",
+                field_old_value=old_folder_name,
+                field_new_value=new_folder_name,
+            )
 
-			update_file_size(self.folder, -self.file_size)
-			update_file_size(new_parent, +self.file_size)
-			self.folder = new_parent
-			self.file_name = get_new_file_name(self.file_name, new_parent, self.is_folder, self.name)
+            update_file_size(self.folder, -self.file_size)
+            update_file_size(new_parent, +self.file_size)
+            self.folder = new_parent
+            self.file_name = get_new_file_name(self.file_name, new_parent, self.is_folder, self.name)
 
-		# Update all the children's paths. Flat storage keys by id, so nothing on
-		# disk or in any file_url depends on where a file sits in the tree.
-		if not self._not_in_disk() and not self.manager.flat:
-			# folder keys carry a trailing slash, the way create_folder writes them
-			new_path = str(self.manager.get_disk_path(self)) + ("/" if self.is_folder else "")
-			self.manager.move(self, new_path)
-			self.recursive_path_move(self.file_url, new_path)
-			self.file_url = new_path
-		self.save()
+        # Update all the children's paths. Flat storage keys by id, so nothing on
+        # disk or in any file_url depends on where a file sits in the tree.
+        if not self._not_in_disk() and not self.manager.flat:
+            # folder keys carry a trailing slash, the way create_folder writes them
+            new_path = str(self.manager.get_disk_path(self)) + ("/" if self.is_folder else "")
+            self.manager.move(self, new_path)
+            self.recursive_path_move(self.file_url, new_path)
+            self.file_url = new_path
+        self.save()
 
-		return frappe.get_value("File", new_parent, ["file_name", "name", "folder"], as_dict=True)
+        return frappe.get_value("File", new_parent, ["file_name", "name", "folder"], as_dict=True)
 
-	def toggle_favourite(self):
-		existing_doc = frappe.db.exists(
-			{
-				"doctype": "Drive Favourite",
-				"entity": self.name,
-				"user": frappe.session.user,
-			}
-		)
-		if existing_doc:
-			frappe.delete_doc("Drive Favourite", existing_doc)
-			return False
-		else:
-			frappe.get_doc(
-				{
-					"doctype": "Drive Favourite",
-					"entity": self.name,
-					"user": frappe.session.user,
-				}
-			).insert()
-			return True
+    def toggle_favourite(self):
+        existing_doc = frappe.db.exists(
+            {
+                "doctype": "Drive Favourite",
+                "entity": self.name,
+                "user": frappe.session.user,
+            }
+        )
+        if existing_doc:
+            frappe.delete_doc("Drive Favourite", existing_doc)
+            return False
+        else:
+            frappe.get_doc(
+                {
+                    "doctype": "Drive Favourite",
+                    "entity": self.name,
+                    "user": frappe.session.user,
+                }
+            ).insert()
+            return True
 
-	@frappe.whitelist()
-	@_update_modified
-	def rename(self, new_file_name: str):
-		"""
-		Rename file or folder
-		"""
-		if not user_has_permission(self, "write"):
-			frappe.throw("You cannot rename this file", frappe.PermissionError)
+    @frappe.whitelist()
+    @_update_modified
+    def rename(self, new_file_name: str):
+        """
+        Rename file or folder
+        """
+        if not user_has_permission(self, "write"):
+            frappe.throw("You cannot rename this file", frappe.PermissionError)
 
-		if new_file_name == self.file_name:
-			return self
-		validate_filename(new_file_name, self.folder, self.file_type)
+        if new_file_name == self.file_name:
+            return self
+        validate_filename(new_file_name, self.folder, self.file_type)
 
-		full_name = frappe.db.get_value("User", {"name": frappe.session.user}, ["full_name"])
-		message = f"{full_name} renamed {self.file_name} to {new_file_name}"
-		create_new_activity_log(
-			entity=self.name,
-			activity_type="rename",
-			activity_message=message,
-			document_field="file_name",
-			field_old_value=self.file_name,
-			field_new_value=new_file_name,
-		)
-		if len(new_file_name) > 140:
-			frappe.throw("Your file_name can't be more than 140 characters.")
+        full_name = frappe.db.get_value("User", {"name": frappe.session.user}, ["full_name"])
+        message = f"{full_name} renamed {self.file_name} to {new_file_name}"
+        create_new_activity_log(
+            entity=self.name,
+            activity_type="rename",
+            activity_message=message,
+            document_field="file_name",
+            field_old_value=self.file_name,
+            field_new_value=new_file_name,
+        )
+        if len(new_file_name) > 140:
+            frappe.throw("Your file_name can't be more than 140 characters.")
 
-		# Sanctioned rename: this method owns the disk move, so let validate through.
-		self.flags.drive_disk_rename = True
-		self.file_name = new_file_name
-		# Flat storage keys by id, so a name has no bearing on any path.
-		if not self.manager.flat:
-			path = self.manager.rename(self)
-			if self.file_url and not self._not_in_disk():
-				self.recursive_path_move(self.file_url, path)
+        # Sanctioned rename: this method owns the disk move, so let validate through.
+        self.flags.drive_disk_rename = True
+        self.file_name = new_file_name
+        # Flat storage keys by id, so a name has no bearing on any path.
+        if not self.manager.flat:
+            path = self.manager.rename(self)
+            if self.file_url and not self._not_in_disk():
+                self.recursive_path_move(self.file_url, path)
 
-		self.save()
+        self.save()
 
-	def permanent_delete(self):
-		write_access = user_has_permission(self, "write")
-		parent_write_access = user_has_permission(self.folder, "write")
-		if not (write_access or parent_write_access):
-			frappe.throw("Not permitted", frappe.PermissionError)
+    def permanent_delete(self):
+        write_access = user_has_permission(self, "write")
+        parent_write_access = user_has_permission(self.folder, "write")
+        if not (write_access or parent_write_access):
+            frappe.throw("Not permitted", frappe.PermissionError)
 
-		self.status = STATUS_REMOVED
-		if self.is_folder:
-			for child in self.get_children():
-				child.permanent_delete()
-		self.save()
+        self.status = STATUS_REMOVED
+        if self.is_folder:
+            for child in self.get_children():
+                child.permanent_delete()
+        self.save()
 
-	# Utils
-	@property
-	def manager(self):
-		return FileManager()
+    # Utils
+    @property
+    def manager(self):
+        return FileManager()
 
-	def recursive_path_move(self, old, new):
-		"""Repoint this subtree at `new`.
+    def recursive_path_move(self, old, new):
+        """Repoint this subtree at `new`.
 
-		On disk the parent's own move carried the children with it, so only the
-		urls need rewriting. S3 has no directories — moving the folder moved one
-		marker object and nothing else — so every descendant's blob has to be
-		copied across itself, or the whole subtree becomes unreadable.
-		"""
-		if new:
-			self.file_url = new
-		manager = self.manager
-		for child in self.get_children():
-			if child._not_in_disk():
-				continue
-			child_key = Path(storage_key(child.file_url))
-			if not child_key.is_relative_to(storage_key(old)):
-				# an adopted framework upload, or anything the relocation left where it
-				# was: its blob was never under this folder, so moving us doesn't move it
-				continue
-			new_child_url = str(Path(storage_key(new)) / child_key.relative_to(storage_key(old)))
-			if child.file_url.startswith(S3_URL_PREFIX):
-				new_child_url = get_s3_url(new_child_url)
-			elif child.file_url.startswith("/"):
-				new_child_url = "/" + new_child_url
-			# a trashed child's blob is in the trash, not at its file_url — that url is
-			# only where a restore would put it back, so repoint it and move nothing
-			if manager.s3_enabled and child.status != STATUS_TRASHED:
-				manager.move(child, new_child_url)
-			child.recursive_path_move(child.file_url, new_child_url)
-		self.save()
+        On disk the parent's own move carried the children with it, so only the
+        urls need rewriting. S3 has no directories — moving the folder moved one
+        marker object and nothing else — so every descendant's blob has to be
+        copied across itself, or the whole subtree becomes unreadable.
+        """
+        if new:
+            self.file_url = new
+        manager = self.manager
+        for child in self.get_children():
+            if child._not_in_disk():
+                continue
+            child_key = Path(storage_key(child.file_url))
+            if not child_key.is_relative_to(storage_key(old)):
+                # an adopted framework upload, or anything the relocation left where it
+                # was: its blob was never under this folder, so moving us doesn't move it
+                continue
+            new_child_url = str(Path(storage_key(new)) / child_key.relative_to(storage_key(old)))
+            if child.file_url.startswith(S3_URL_PREFIX):
+                new_child_url = get_s3_url(new_child_url)
+            elif child.file_url.startswith("/"):
+                new_child_url = "/" + new_child_url
+            # a trashed child's blob is in the trash, not at its file_url — that url is
+            # only where a restore would put it back, so repoint it and move nothing
+            if manager.s3_enabled and child.status != STATUS_TRASHED:
+                manager.move(child, new_child_url)
+            child.recursive_path_move(child.file_url, new_child_url)
+        self.save()
 
-	def get_children(self):
-		"""Returns a generator that yields child Documents.
+    def get_children(self):
+        """Returns a generator that yields child Documents.
 
-		get_all, not get_list: this is an internal tree walk, authorized at the entry
-		point. Permission-filtering it would silently skip children the caller cannot
-		see — leaving them orphaned on a move, or Active inside a deleted folder.
-		"""
-		child_names = frappe.get_all(self.doctype, filters={"folder": self.name}, pluck="name")
-		for name in child_names:
-			yield frappe.get_doc(self.doctype, name)
+        get_all, not get_list: this is an internal tree walk, authorized at the entry
+        point. Permission-filtering it would silently skip children the caller cannot
+        see — leaving them orphaned on a move, or Active inside a deleted folder.
+        """
+        child_names = frappe.get_all(self.doctype, filters={"folder": self.name}, pluck="name")
+        for name in child_names:
+            yield frappe.get_doc(self.doctype, name)
 
-	# ------------------------------------------------------------------
-	# Content-app SDK
-	#
-	# Apps that keep their content in their own doctype (Writer, Slides, ...)
-	# back each document with a Drive File (`content_doctype`/`content_docname`)
-	# and delegate permissions to it. These classmethods, plus the module-level
-	# `content_*` helpers below, are their single entry point into Drive.
-	# ------------------------------------------------------------------
+    # ------------------------------------------------------------------
+    # Content-app SDK
+    #
+    # Apps that keep their content in their own doctype (Writer, Slides, ...)
+    # back each document with a Drive File (`content_doctype`/`content_docname`)
+    # and delegate permissions to it. These classmethods, plus the module-level
+    # `content_*` helpers below, are their single entry point into Drive.
+    # ------------------------------------------------------------------
 
-	@classmethod
-	def get_for_doc(cls, doctype: str, docname: str) -> str | None:
-		"""Name of the Drive File backing a content document, if any."""
-		return frappe.db.get_value("File", {"content_doctype": doctype, "content_docname": docname}, "name")
+    @classmethod
+    def get_for_doc(cls, doctype: str, docname: str) -> str | None:
+        """Name of the Drive File backing a content document, if any."""
+        return frappe.db.get_value("File", {"content_doctype": doctype, "content_docname": docname}, "name")
 
-	@classmethod
-	def create_for_doc(
-		cls,
-		doc,
-		parent: str | None = None,
-		mime_type: str | None = None,
-		file_type: str | None = None,
-	):
-		"""Create the Drive File backing `doc`, in `parent` or the session
-		user's private folder."""
-		from suite.drive.utils import create_file
+    @classmethod
+    def create_for_doc(
+        cls,
+        doc,
+        parent: str | None = None,
+        mime_type: str | None = None,
+        file_type: str | None = None,
+    ):
+        """Create the Drive File backing `doc`, in `parent` or the session
+        user's private folder."""
+        from suite.drive.utils import create_file
 
-		if not parent:
-			parent = get_user_folder().name
+        if not parent:
+            parent = get_user_folder().name
 
-		return create_file(
-			title=doc.get_title() or "Untitled",
-			parent=parent,
-			mime_type=mime_type,
-			file_type=file_type,
-			content_doctype=doc.doctype,
-			content_docname=doc.name,
-		)
+        return create_file(
+            title=doc.get_title() or "Untitled",
+            parent=parent,
+            mime_type=mime_type,
+            file_type=file_type,
+            content_doctype=doc.doctype,
+            content_docname=doc.name,
+        )
 
-	def is_public(self) -> bool:
-		"""Whether anyone with the link can read this file."""
-		return bool(user_has_permission(self, "read", "Guest"))
+    def is_public(self) -> bool:
+        """Whether anyone with the link can read this file."""
+        return bool(user_has_permission(self, "read", "Guest"))
 
 
 def content_has_permission(doc, ptype="read", user=None):
-	"""`has_permission` hook for content doctypes: delegate to the backing
-	Drive File; documents without one stay owner-only."""
-	user = user or frappe.session.user
-	if user == "Administrator" or ptype == "create":
-		return True
+    """`has_permission` hook for content doctypes: delegate to the backing
+    Drive File; documents without one stay owner-only."""
+    user = user or frappe.session.user
+    if user == "Administrator" or ptype == "create":
+        return True
 
-	file = File.get_for_doc(doc.doctype, doc.name)
-	if not file:
-		return doc.owner == user
-	return bool(user_has_permission(file, ptype, user))
+    file = File.get_for_doc(doc.doctype, doc.name)
+    if not file:
+        return doc.owner == user
+    return bool(user_has_permission(file, ptype, user))
 
 
 def content_query_conditions(doctype: str, user: str | None, extra: str | None = None) -> str:
-	"""`permission_query_conditions` body for content doctypes: owned OR
-	directly shared via Drive, OR'd with `extra`. Folder-inherited and public
-	grants need Drive's recursive path traversal, impractical in SQL — left to
-	`has_permission`."""
-	user = user or frappe.session.user
-	if user == "Administrator":
-		return ""
+    """`permission_query_conditions` body for content doctypes: owned OR
+    directly shared via Drive, OR'd with `extra`. Folder-inherited and public
+    grants need Drive's recursive path traversal, impractical in SQL — left to
+    `has_permission`."""
+    user = user or frappe.session.user
+    if user == "Administrator":
+        return ""
 
-	table = f"`tab{doctype}`"
-	user_lit = frappe.db.escape(user)
-	clauses = [
-		f"{table}.owner = {user_lit}",
-		f"{table}.name IN ("
-		f"SELECT `tabFile`.content_docname FROM `tabFile` "
-		f"INNER JOIN `tabDrive Permission` ON `tabDrive Permission`.entity = `tabFile`.name "
-		f"WHERE `tabFile`.content_doctype = {frappe.db.escape(doctype)} "
-		f"AND `tabDrive Permission`.user IN ({principal_list(user)}) "
-		f"AND `tabDrive Permission`.`read` = 1 AND `tabDrive Permission`.`deny` = 0)",
-	]
-	if extra:
-		clauses.append(extra)
-	return "(" + " OR ".join(clauses) + ")"
+    table = f"`tab{doctype}`"
+    user_lit = frappe.db.escape(user)
+    clauses = [
+        f"{table}.owner = {user_lit}",
+        f"{table}.name IN ("
+        f"SELECT `tabFile`.content_docname FROM `tabFile` "
+        f"INNER JOIN `tabDrive Permission` ON `tabDrive Permission`.entity = `tabFile`.name "
+        f"WHERE `tabFile`.content_doctype = {frappe.db.escape(doctype)} "
+        f"AND `tabDrive Permission`.user IN ({principal_list(user)}) "
+        f"AND `tabDrive Permission`.`read` = 1 AND `tabDrive Permission`.`deny` = 0)",
+    ]
+    if extra:
+        clauses.append(extra)
+    return "(" + " OR ".join(clauses) + ")"
 
 
 def sync_content_file(doc, event):
-	"""`doc_events` handler for content doctypes: mirror a content document's
-	name and trashed-state onto its backing Drive File, and delete the File when
-	the document is hard-deleted. Every content app gets this by mutating through
-	the ORM (`doc.save()` / `frappe.delete_doc`) — the same front door Writer and
-	Slides use — so no app needs its own Drive-sync calls."""
-	file = File.get_for_doc(doc.doctype, doc.name)
-	if not file:
-		return
+    """`doc_events` handler for content doctypes: mirror a content document's
+    name and trashed-state onto its backing Drive File, and delete the File when
+    the document is hard-deleted. Every content app gets this by mutating through
+    the ORM (`doc.save()` / `frappe.delete_doc`) — the same front door Writer and
+    Slides use — so no app needs its own Drive-sync calls."""
+    file = File.get_for_doc(doc.doctype, doc.name)
+    if not file:
+        return
 
-	drive_file = frappe.get_doc("File", file)
-	if event == "on_trash":
-		drive_file.permanent_delete()
-		return
+    drive_file = frappe.get_doc("File", file)
+    if event == "on_trash":
+        drive_file.permanent_delete()
+        return
 
-	# The File is created with an already-deduped name (create_for_doc), so the
-	# on_update that fires during that same insert must not touch it again.
-	if doc.flags.in_insert:
-		return
+    # The File is created with an already-deduped name (create_for_doc), so the
+    # on_update that fires during that same insert must not touch it again.
+    if doc.flags.in_insert:
+        return
 
-	before = doc.get_doc_before_save()
+    before = doc.get_doc_before_save()
 
-	# Mirror soft-trash: content docs carrying a `trashed` flag (e.g. Sheet) drop
-	# out of — or return to — the Drive listing in lockstep. Apps without the
-	# field (Writer/Slides) hard-delete instead, handled by on_trash above.
-	# Only on an actual transition of the flag: Drive's own trash (remove_or_restore)
-	# moves the File without touching the content doc, so re-deriving the status
-	# from `doc.trashed` on every save would silently undo it.
-	if doc.meta.has_field("trashed"):
-		if before and bool(before.trashed) != bool(doc.trashed):
-			if doc.trashed and drive_file.status == STATUS_ACTIVE:
-				drive_file.db_set("status", STATUS_TRASHED, update_modified=False)
-			elif not doc.trashed and drive_file.status == STATUS_TRASHED:
-				# Restoring: an active sibling may have taken this file's name while
-				# it was trashed, so dedupe before it re-enters the active namespace
-				# (get_new_file_name counts only active files, so the file being
-				# restored is never counted against itself).
-				drive_file.db_set(
-					{
-						"file_name": get_new_file_name(
-							drive_file.file_name, drive_file.folder, drive_file.file_type
-						),
-						"status": STATUS_ACTIVE,
-					},
-					update_modified=False,
-				)
-		if doc.trashed:
-			return
+    # Mirror soft-trash: content docs carrying a `trashed` flag (e.g. Sheet) drop
+    # out of — or return to — the Drive listing in lockstep. Apps without the
+    # field (Writer/Slides) hard-delete instead, handled by on_trash above.
+    # Only on an actual transition of the flag: Drive's own trash (remove_or_restore)
+    # moves the File without touching the content doc, so re-deriving the status
+    # from `doc.trashed` on every save would silently undo it.
+    if doc.meta.has_field("trashed"):
+        if before and bool(before.trashed) != bool(doc.trashed):
+            if doc.trashed and drive_file.status == STATUS_ACTIVE:
+                drive_file.db_set("status", STATUS_TRASHED, update_modified=False)
+            elif not doc.trashed and drive_file.status == STATUS_TRASHED:
+                # Restoring: an active sibling may have taken this file's name while
+                # it was trashed, so dedupe before it re-enters the active namespace
+                # (get_new_file_name counts only active files, so the file being
+                # restored is never counted against itself).
+                drive_file.db_set(
+                    {
+                        "file_name": get_new_file_name(
+                            drive_file.file_name, drive_file.folder, drive_file.file_type
+                        ),
+                        "status": STATUS_ACTIVE,
+                    },
+                    update_modified=False,
+                )
+        if doc.trashed:
+            return
 
-	# Rename to follow the title, but only on an actual title change: a content
-	# edit shouldn't rename the File, and re-running the dedup on every save would
-	# churn the "(n)" suffix as sibling counts shift.
-	if before and before.get_title() == doc.get_title():
-		return
-	desired_name = doc.get_title() or drive_file.file_name
-	if desired_name == drive_file.file_name:
-		return
-	drive_file.rename(get_new_file_name(desired_name, drive_file.folder, drive_file.file_type))
+    # Rename to follow the title, but only on an actual title change: a content
+    # edit shouldn't rename the File, and re-running the dedup on every save would
+    # churn the "(n)" suffix as sibling counts shift.
+    if before and before.get_title() == doc.get_title():
+        return
+    desired_name = doc.get_title() or drive_file.file_name
+    if desired_name == drive_file.file_name:
+        return
+    drive_file.rename(get_new_file_name(desired_name, drive_file.folder, drive_file.file_type))
 
 
 @frappe.whitelist()
 def get_file_for_doc(doctype: str, docname: str):
-	"""The Drive File (with the caller's access) backing a content document."""
-	file = File.get_for_doc(doctype, docname)
-	if not file:
-		frappe.throw(f"This {doctype} is not backed by a Drive file")
-	return get_entity_with_permissions(file)
+    """The Drive File (with the caller's access) backing a content document."""
+    file = File.get_for_doc(doctype, docname)
+    if not file:
+        frappe.throw(f"This {doctype} is not backed by a Drive file")
+    return get_entity_with_permissions(file)
 
 
 def after_file_upload(doc):
-	# frappe handler.upload_file reassigns `doc` to our return value, so always return it.
-	# Guests can't own a user folder; their uploads stay in the framework folders.
-	if (doc.folder and doc.folder not in FRAMEWORK_FOLDERS) or frappe.session.user == "Guest":
-		return doc
+    # frappe handler.upload_file reassigns `doc` to our return value, so always return it.
+    # Guests can't own a user folder; their uploads stay in the framework folders.
+    if (doc.folder and doc.folder not in FRAMEWORK_FOLDERS) or frappe.session.user == "Guest":
+        return doc
 
-	if frappe.form_dict.library_file_name:
-		library_doc = frappe.get_doc("File", frappe.form_dict.library_file_name)
-		doc.is_private = 1
-		doc.folder = get_user_folder().name
-		doc.file_type = library_doc.file_type
-		doc.file_size = library_doc.file_size
-		doc.modified = library_doc.modified
-		doc.content_doctype = ATTACHMENT_CONTENT_DOCTYPE
-		doc.content_docname = frappe.form_dict.library_file_name
-	else:
-		# Adopt any framework upload — attachment or loose — into the uploader's
-		# private folder; the blob stays where the framework wrote it.
-		doc.folder = get_user_folder().name
-		if not doc.mime_type:
-			doc.mime_type = mimemapper.get_mime_type(doc.file_name, native_first=False)
-		doc.file_type = get_file_type(doc.mime_type)
+    if frappe.form_dict.library_file_name:
+        library_doc = frappe.get_doc("File", frappe.form_dict.library_file_name)
+        doc.is_private = 1
+        doc.folder = get_user_folder().name
+        doc.file_type = library_doc.file_type
+        doc.file_size = library_doc.file_size
+        doc.modified = library_doc.modified
+        doc.content_doctype = ATTACHMENT_CONTENT_DOCTYPE
+        doc.content_docname = frappe.form_dict.library_file_name
+    else:
+        # Adopt any framework upload — attachment or loose — into the uploader's
+        # private folder; the blob stays where the framework wrote it.
+        doc.folder = get_user_folder().name
+        if not doc.mime_type:
+            doc.mime_type = mimemapper.get_mime_type(doc.file_name, native_first=False)
+        doc.file_type = get_file_type(doc.mime_type)
 
-	return doc
+    return doc

--- a/suite/drive/patches/add_search_index.py
+++ b/suite/drive/patches/add_search_index.py
@@ -3,10 +3,6 @@ import frappe
 
 def execute():
     """Ensure the FULLTEXT index used by search exists on migrated sites."""
-    index_check = frappe.db.sql(
-        """SHOW INDEX FROM `tabFile` WHERE Key_name = 'drive_file_name_fts_idx'"""
-    )
+    index_check = frappe.db.sql("""SHOW INDEX FROM `tabFile` WHERE Key_name = 'drive_file_name_fts_idx'""")
     if not index_check:
-        frappe.db.sql(
-            """ALTER TABLE `tabFile` ADD FULLTEXT INDEX drive_file_name_fts_idx (file_name)"""
-        )
+        frappe.db.sql("""ALTER TABLE `tabFile` ADD FULLTEXT INDEX drive_file_name_fts_idx (file_name)""")

--- a/suite/drive/patches/dedupe_drive_permissions.py
+++ b/suite/drive/patches/dedupe_drive_permissions.py
@@ -2,32 +2,30 @@ import frappe
 
 
 def execute():
-	"""One row per (entity, user); resolution assumes it when ranking by
-	specificity. Keep the most permissive of any duplicates, preferring a deny."""
-	duplicates = frappe.db.sql(
-		"""SELECT entity, user FROM `tabDrive Permission`
+    """One row per (entity, user); resolution assumes it when ranking by
+    specificity. Keep the most permissive of any duplicates, preferring a deny."""
+    duplicates = frappe.db.sql(
+        """SELECT entity, user FROM `tabDrive Permission`
 		GROUP BY entity, user HAVING COUNT(*) > 1""",
-		as_dict=True,
-	)
-	for row in duplicates:
-		names = frappe.get_all(
-			"Drive Permission",
-			filters={"entity": row.entity, "user": row.user},
-			fields=["name", "deny", "read", "comment", "share", "upload", "write"],
-			order_by="deny desc, creation",
-		)
-		keep, rest = names[0], names[1:]
-		for other in rest:
-			if other.deny == keep.deny:
-				for t in ("read", "comment", "share", "upload", "write"):
-					if other.get(t):
-						frappe.db.set_value("Drive Permission", keep.name, t, 1, update_modified=False)
-			frappe.delete_doc("Drive Permission", other.name, ignore_permissions=True, force=True)
+        as_dict=True,
+    )
+    for row in duplicates:
+        names = frappe.get_all(
+            "Drive Permission",
+            filters={"entity": row.entity, "user": row.user},
+            fields=["name", "deny", "read", "comment", "share", "upload", "write"],
+            order_by="deny desc, creation",
+        )
+        keep, rest = names[0], names[1:]
+        for other in rest:
+            if other.deny == keep.deny:
+                for t in ("read", "comment", "share", "upload", "write"):
+                    if other.get(t):
+                        frappe.db.set_value("Drive Permission", keep.name, t, 1, update_modified=False)
+            frappe.delete_doc("Drive Permission", other.name, ignore_permissions=True, force=True)
 
-	if not frappe.db.sql(
-		"""SHOW INDEX FROM `tabDrive Permission` WHERE Key_name = 'unique_entity_user'"""
-	):
-		frappe.db.sql_ddl(
-			"""ALTER TABLE `tabDrive Permission`
+    if not frappe.db.sql("""SHOW INDEX FROM `tabDrive Permission` WHERE Key_name = 'unique_entity_user'"""):
+        frappe.db.sql_ddl(
+            """ALTER TABLE `tabDrive Permission`
 			ADD UNIQUE INDEX `unique_entity_user` (`entity`, `user`)"""
-		)
+        )

--- a/suite/drive/patches/drop_team_doctypes.py
+++ b/suite/drive/patches/drop_team_doctypes.py
@@ -2,21 +2,21 @@ import frappe
 
 
 def execute():
-	"""Drop the Drive Team doctypes and every leftover team column, after
-	remove_teams has restructured the tree."""
-	frappe.delete_doc_if_exists("Custom Field", "File-team")
-	frappe.delete_doc_if_exists("DocType", "Drive Team Member")
-	frappe.delete_doc_if_exists("DocType", "Drive Team")
-	# deleting a DocType leaves its table behind
-	frappe.db.sql_ddl("DROP TABLE IF EXISTS `tabDrive Team Member`")
-	frappe.db.sql_ddl("DROP TABLE IF EXISTS `tabDrive Team`")
+    """Drop the Drive Team doctypes and every leftover team column, after
+    remove_teams has restructured the tree."""
+    frappe.delete_doc_if_exists("Custom Field", "File-team")
+    frappe.delete_doc_if_exists("DocType", "Drive Team Member")
+    frappe.delete_doc_if_exists("DocType", "Drive Team")
+    # deleting a DocType leaves its table behind
+    frappe.db.sql_ddl("DROP TABLE IF EXISTS `tabDrive Team Member`")
+    frappe.db.sql_ddl("DROP TABLE IF EXISTS `tabDrive Team`")
 
-	for table, column in [
-		("File", "team"),
-		("Drive Permission", "team"),
-		("Drive User Invitation", "team"),
-		("Drive User Invitation", "as_guest"),
-		("Writer Template", "team"),
-	]:
-		if frappe.db.has_column(table, column):
-			frappe.db.sql_ddl(f"ALTER TABLE `tab{table}` DROP COLUMN `{column}`")
+    for table, column in [
+        ("File", "team"),
+        ("Drive Permission", "team"),
+        ("Drive User Invitation", "team"),
+        ("Drive User Invitation", "as_guest"),
+        ("Writer Template", "team"),
+    ]:
+        if frappe.db.has_column(table, column):
+            frappe.db.sql_ddl(f"ALTER TABLE `tab{table}` DROP COLUMN `{column}`")

--- a/suite/drive/patches/index_file_folder.py
+++ b/suite/drive/patches/index_file_folder.py
@@ -2,12 +2,12 @@ import frappe
 
 
 def execute():
-	"""Every Drive listing and tree walk filters on `File.folder`, which core leaves
-	unindexed. `team` is indexed only for the collapse's per-team lookup;
-	drop_team_doctypes discards it with the column."""
-	for column in ("folder", "team"):
-		if not frappe.db.has_column("File", column):
-			continue
-		if frappe.db.sql("show index from `tabFile` where Column_name = %s", column):
-			continue
-		frappe.db.sql_ddl(f"ALTER TABLE `tabFile` ADD INDEX `{column}` (`{column}`)")
+    """Every Drive listing and tree walk filters on `File.folder`, which core leaves
+    unindexed. `team` is indexed only for the collapse's per-team lookup;
+    drop_team_doctypes discards it with the column."""
+    for column in ("folder", "team"):
+        if not frappe.db.has_column("File", column):
+            continue
+        if frappe.db.sql("show index from `tabFile` where Column_name = %s", column):
+            continue
+        frappe.db.sql_ddl(f"ALTER TABLE `tabFile` ADD INDEX `{column}` (`{column}`)")

--- a/suite/drive/patches/integrate_with_framework.py
+++ b/suite/drive/patches/integrate_with_framework.py
@@ -6,7 +6,13 @@ import json
 
 import frappe
 from suite.drive.install import ensure_custom_fields
-from suite.drive.utils import MIME_LIST_MAP, PRESENTATION_CONTENT_DOCTYPE, STATUS_ACTIVE, STATUS_TRASHED, WRITER_CONTENT_DOCTYPE
+from suite.drive.utils import (
+    MIME_LIST_MAP,
+    PRESENTATION_CONTENT_DOCTYPE,
+    STATUS_ACTIVE,
+    STATUS_TRASHED,
+    WRITER_CONTENT_DOCTYPE,
+)
 from suite.drive.utils.files import get_s3_url
 
 LEGACY_DOCTYPE = "Drive File"
@@ -34,7 +40,9 @@ def execute(files=None):
 
     frappe.flags.mute_drive_activity_log = True
     try:
-        root_files = files or frappe.get_all(LEGACY_DOCTYPE, filters={"parent_entity": ["is", "not set"]}, pluck="name")
+        root_files = files or frappe.get_all(
+            LEGACY_DOCTYPE, filters={"parent_entity": ["is", "not set"]}, pluck="name"
+        )
 
         is_remote = frappe.get_single("Drive Disk Settings").enabled
         failures = []

--- a/suite/drive/patches/integrate_with_framework.py
+++ b/suite/drive/patches/integrate_with_framework.py
@@ -5,6 +5,7 @@ Create framework `File` records from legacy `Drive File` rows.
 import json
 
 import frappe
+
 from suite.drive.install import ensure_custom_fields
 from suite.drive.utils import (
     MIME_LIST_MAP,

--- a/suite/drive/patches/migrate_s3_url_prefix.py
+++ b/suite/drive/patches/migrate_s3_url_prefix.py
@@ -11,7 +11,7 @@ def execute():
         fields=["name", "file_url"],
     )
     for f in files:
-        new_url = NEW_PREFIX + f["file_url"][len(OLD_PREFIX):]
+        new_url = NEW_PREFIX + f["file_url"][len(OLD_PREFIX) :]
         frappe.db.set_value("File", f["name"], "file_url", new_url, update_modified=False)
 
     if files:

--- a/suite/drive/patches/new_writer.py
+++ b/suite/drive/patches/new_writer.py
@@ -42,7 +42,9 @@ def execute():
                     content = reply.get("content")
                     owner = reply.get("ownerEmail")
                     created_at = datetime.fromtimestamp(reply.get("createdAt", 0) / 1000)
-                    reply_doc = frappe.get_doc({"doctype": "Drive Comment", "content": content, "name": str(uuid4())})
+                    reply_doc = frappe.get_doc(
+                        {"doctype": "Drive Comment", "content": content, "name": str(uuid4())}
+                    )
                     comment.append("replies", reply_doc)
                     reply_doc.insert(ignore_permissions=True)
                     MAP[reply_doc.name] = (owner, created_at)

--- a/suite/drive/patches/remove_teams.py
+++ b/suite/drive/patches/remove_teams.py
@@ -4,436 +4,435 @@ from collections import Counter
 import frappe
 
 from suite.drive.utils import (
-	GENERAL_USER,
-	GROUP_PREFIX,
-	PERMISSION_TYPES,
-	STATUS_ACTIVE,
-	STATUS_TRASHED,
-	_deny_general_read,
-	get_new_file_name,
-	get_previous_teams_folder,
-	get_root_folder,
-	get_users_folder,
-	grant_owner_access,
+    GENERAL_USER,
+    GROUP_PREFIX,
+    PERMISSION_TYPES,
+    STATUS_ACTIVE,
+    STATUS_TRASHED,
+    _deny_general_read,
+    get_new_file_name,
+    get_previous_teams_folder,
+    get_root_folder,
+    get_users_folder,
+    grant_owner_access,
 )
 from suite.drive.utils.files import TRASH_PREFIX, FileManager, storage_key
 
 
 def execute():
-	"""Collapse Drive Teams into Drive's tree.
+    """Collapse Drive Teams into Drive's tree.
 
-	Files are not moved: storage stays flat and every existing file_url keeps
-	working. Only thumbnails and trashed blobs move, because their location is
-	computed from the root rather than stored, and the root has changed.
-	"""
-	# Both are captured before the collapse rewrites the homes and before
-	# drop_team_doctypes discards `team`; the sweep runs later and cannot re-derive
-	# either, so they travel with the job.
-	sidecars = _team_prefixes()
-	trashed = _trashed_by_team()
-	if frappe.db.exists("DocType", "Drive Team"):
-		_collapse_teams()
+    Files are not moved: storage stays flat and every existing file_url keeps
+    working. Only thumbnails and trashed blobs move, because their location is
+    computed from the root rather than stored, and the root has changed.
+    """
+    # Both are captured before the collapse rewrites the homes and before
+    # drop_team_doctypes discards `team`; the sweep runs later and cannot re-derive
+    # either, so they travel with the job.
+    sidecars = _team_prefixes()
+    trashed = _trashed_by_team()
+    if frappe.db.exists("DocType", "Drive Team"):
+        _collapse_teams()
 
-	if not sidecars:
-		return
-	# Enqueued, not inline: this is thousands of S3 round trips and the tree is
-	# already correct without it — only thumbnails and trashed blobs are waiting.
-	frappe.enqueue(
-		"suite.drive.patches.remove_teams.sweep_sidecars",
-		queue="long",
-		timeout=4 * 60 * 60,
-		sidecars=sidecars,
-		trashed=trashed,
-	)
-	print(f"Drive: queued the sidecar sweep for {len(sidecars)} old prefix(es)")
+    if not sidecars:
+        return
+    # Enqueued, not inline: this is thousands of S3 round trips and the tree is
+    # already correct without it — only thumbnails and trashed blobs are waiting.
+    frappe.enqueue(
+        "suite.drive.patches.remove_teams.sweep_sidecars",
+        queue="long",
+        timeout=4 * 60 * 60,
+        sidecars=sidecars,
+        trashed=trashed,
+    )
+    print(f"Drive: queued the sidecar sweep for {len(sidecars)} old prefix(es)")
 
 
 def _remember_route(team, entity):
-	"""Old links point at /drive/t/<team>, and the team id dies with the doctype.
-	Keep the mapping so those links can still be resolved."""
-	if frappe.db.exists("Drive Legacy Route", team):
-		return
-	frappe.get_doc(
-		{"doctype": "Drive Legacy Route", "old_id": team, "entity": entity}
-	).insert(ignore_permissions=True)
+    """Old links point at /drive/t/<team>, and the team id dies with the doctype.
+    Keep the mapping so those links can still be resolved."""
+    if frappe.db.exists("Drive Legacy Route", team):
+        return
+    frappe.get_doc({"doctype": "Drive Legacy Route", "old_id": team, "entity": entity}).insert(
+        ignore_permissions=True
+    )
 
 
 def _trashed_by_team():
-	"""{team: {file_name: id}} — trashed blobs were keyed by name, per team."""
-	if not frappe.db.has_column("File", "team"):
-		return {}
-	out = {}
-	for row in frappe.get_all(
-		"File",
-		filters={"status": STATUS_TRASHED},
-		fields=["name", "file_name", "team"],
-		limit_page_length=0,
-	):
-		out.setdefault(row.team, {})[row.file_name] = row.name
-	return out
+    """{team: {file_name: id}} — trashed blobs were keyed by name, per team."""
+    if not frappe.db.has_column("File", "team"):
+        return {}
+    out = {}
+    for row in frappe.get_all(
+        "File",
+        filters={"status": STATUS_TRASHED},
+        fields=["name", "file_name", "team"],
+        limit_page_length=0,
+    ):
+        out.setdefault(row.team, {})[row.file_name] = row.name
+    return out
 
 
 def _team_prefixes():
-	"""{team: old storage prefix}, while the team homes are still folder-less."""
-	if not frappe.db.has_column("File", "team"):
-		return {}
-	rows = frappe.get_all(
-		"File",
-		filters={"folder": ("is", "not set"), "team": ("is", "set")},
-		fields=["team", "file_url"],
-		limit_page_length=0,
-	)
-	return {r.team: storage_key(r.file_url).rstrip("/") for r in rows if r.file_url}
+    """{team: old storage prefix}, while the team homes are still folder-less."""
+    if not frappe.db.has_column("File", "team"):
+        return {}
+    rows = frappe.get_all(
+        "File",
+        filters={"folder": ("is", "not set"), "team": ("is", "set")},
+        fields=["team", "file_url"],
+        limit_page_length=0,
+    )
+    return {r.team: storage_key(r.file_url).rstrip("/") for r in rows if r.file_url}
 
 
 def _collapse_teams():
-	"""Personal team roots become user folders under `Users`; the rest move into
-	`Drive/Previous Teams`, membership rewritten as Drive Permission rows.
+    """Personal team roots become user folders under `Users`; the rest move into
+    `Drive/Previous Teams`, membership rewritten as Drive Permission rows.
 
-	`Users` carries no grant, so user folders are private. `Previous Teams` inherits
-	`Drive`'s $GENERAL read, so each migrated team gets a $GENERAL deny and is
-	reachable only by its old members. A public team keeps $GENERAL read."""
-	previous_teams = get_previous_teams_folder()
-	roots = {get_root_folder().name, previous_teams.name, get_users_folder().name}
-	groups = {}
+    `Users` carries no grant, so user folders are private. `Previous Teams` inherits
+    `Drive`'s $GENERAL read, so each migrated team gets a $GENERAL deny and is
+    reachable only by its old members. A public team keeps $GENERAL read."""
+    previous_teams = get_previous_teams_folder()
+    roots = {get_root_folder().name, previous_teams.name, get_users_folder().name}
+    groups = {}
 
-	teams = frappe.get_all("Drive Team", fields=["name", "title", "owner", "personal", "public", "quota"])
-	print(f"Drive: collapsing {len(teams)} team(s)")
-	for done, team in enumerate(teams, 1):
-		if done % 100 == 0:
-			print(f"  {done}/{len(teams)}")
-		home = frappe.db.get_value("File", {"team": team.name, "folder": ("is", "not set")}, "name")
-		if not home or home in roots:
-			continue
-		_remember_route(team.name, home)
-		members = frappe.get_all(
-			"Drive Team Member",
-			filters={"parenttype": "Drive Team", "parent": team.name},
-			fields=["user", "access_level"],
-		)
-		# Nothing matches a deleted user, and `Drive Settings.user` is a Link — a user
-		# folder for one aborts the migration.
-		members = [m for m in members if m.user and m.user != team.owner]
-		members = [m for m in members if frappe.db.exists("User", m.user)]
-		owned = bool(team.owner) and frappe.db.exists("User", team.owner)
+    teams = frappe.get_all("Drive Team", fields=["name", "title", "owner", "personal", "public", "quota"])
+    print(f"Drive: collapsing {len(teams)} team(s)")
+    for done, team in enumerate(teams, 1):
+        if done % 100 == 0:
+            print(f"  {done}/{len(teams)}")
+        home = frappe.db.get_value("File", {"team": team.name, "folder": ("is", "not set")}, "name")
+        if not home or home in roots:
+            continue
+        _remember_route(team.name, home)
+        members = frappe.get_all(
+            "Drive Team Member",
+            filters={"parenttype": "Drive Team", "parent": team.name},
+            fields=["user", "access_level"],
+        )
+        # Nothing matches a deleted user, and `Drive Settings.user` is a Link — a user
+        # folder for one aborts the migration.
+        members = [m for m in members if m.user and m.user != team.owner]
+        members = [m for m in members if frappe.db.exists("User", m.user)]
+        owned = bool(team.owner) and frappe.db.exists("User", team.owner)
 
-		if team.personal and owned and not frappe.db.get_value("Drive Settings", team.owner, "user_folder"):
-			_to_user_folder(home, team)
-			_grant_members(home, members)
-			continue
+        if team.personal and owned and not frappe.db.get_value("Drive Settings", team.owner, "user_folder"):
+            _to_user_folder(home, team)
+            _grant_members(home, members)
+            continue
 
-		_to_shared_folder(previous_teams, home, team, owned)
-		# own row too, so it stays private if moved out of `Previous Teams`
-		if team.public:
-			_grant(home, GENERAL_USER, {"read": 1})
-		else:
-			_deny_general_read(home)
+        _to_shared_folder(previous_teams, home, team, owned)
+        # own row too, so it stays private if moved out of `Previous Teams`
+        if team.public:
+            _grant(home, GENERAL_USER, {"read": 1})
+        else:
+            _deny_general_read(home)
 
-		# A team was a group of people, so it becomes one: members are granted
-		# through a User Group, not fanned out per user. Keeps one row where the
-		# team had one, and later membership changes still apply.
-		team_groups = _user_groups_for(team, members)
-		if team_groups:
-			groups[team.name] = team_groups[0]
-			_grant_group(home, team_groups)
-			# Also on the container, or the folder is readable but unreachable: the
-			# $GENERAL deny there hides it from the listing, so members would have no
-			# way to browse to their own team. A group row outranks $GENERAL on the
-			# same node, and listing filters children by read, so each person sees
-			# only the teams they were in.
-			_grant(previous_teams.name, GROUP_PREFIX + team_groups[0], {"read": 1})
-		else:
-			_grant_members(home, members)
+        # A team was a group of people, so it becomes one: members are granted
+        # through a User Group, not fanned out per user. Keeps one row where the
+        # team had one, and later membership changes still apply.
+        team_groups = _user_groups_for(team, members)
+        if team_groups:
+            groups[team.name] = team_groups[0]
+            _grant_group(home, team_groups)
+            # Also on the container, or the folder is readable but unreachable: the
+            # $GENERAL deny there hides it from the listing, so members would have no
+            # way to browse to their own team. A group row outranks $GENERAL on the
+            # same node, and listing filters children by read, so each person sees
+            # only the teams they were in.
+            _grant(previous_teams.name, GROUP_PREFIX + team_groups[0], {"read": 1})
+        else:
+            _grant_members(home, members)
 
-	_expand_team_rows(groups)
-	_drop_obsolete_revoke_rows()
+    _expand_team_rows(groups)
+    _drop_obsolete_revoke_rows()
 
 
 LEVEL_LABEL = {0: "", 1: " (Members)", 2: " (Managers)"}
 
 
 def _user_groups_for(team, members):
-	"""`User Group`s mirroring the team: one holding everyone, plus one per higher
-	access level. Returns {access_level: group name}, empty when nobody is left.
+    """`User Group`s mirroring the team: one holding everyone, plus one per higher
+    access level. Returns {access_level: group name}, empty when nobody is left.
 
-	The all-members group is what a `team=1` permission row resolves to, since such
-	a row granted the whole team at its own access level.
-	"""
-	everyone = {m.user for m in members}
-	if team.owner and frappe.db.exists("User", team.owner):
-		everyone.add(team.owner)
-	if not everyone:
-		return {}
+    The all-members group is what a `team=1` permission row resolves to, since such
+    a row granted the whole team at its own access level.
+    """
+    everyone = {m.user for m in members}
+    if team.owner and frappe.db.exists("User", team.owner):
+        everyone.add(team.owner)
+    if not everyone:
+        return {}
 
-	buckets = {0: sorted(everyone)}
-	for level in (1, 2):
-		at_level = sorted(m.user for m in members if (m.access_level or 0) >= level)
-		if at_level:
-			buckets[level] = at_level
+    buckets = {0: sorted(everyone)}
+    for level in (1, 2):
+        at_level = sorted(m.user for m in members if (m.access_level or 0) >= level)
+        if at_level:
+            buckets[level] = at_level
 
-	title = team.title or team.name
-	out = {}
-	for level, users in buckets.items():
-		name = get_new_group_name(title + LEVEL_LABEL[level])
-		group = frappe.get_doc({"doctype": "User Group", "__newname": name})
-		for user in users:
-			group.append("user_group_members", {"user": user})
-		group.insert(ignore_permissions=True)
-		out[level] = group.name
-	return out
+    title = team.title or team.name
+    out = {}
+    for level, users in buckets.items():
+        name = get_new_group_name(title + LEVEL_LABEL[level])
+        group = frappe.get_doc({"doctype": "User Group", "__newname": name})
+        for user in users:
+            group.append("user_group_members", {"user": user})
+        group.insert(ignore_permissions=True)
+        out[level] = group.name
+    return out
 
 
 def get_new_group_name(title):
-	"""User Group names are the primary key, so a title collision needs a suffix."""
-	base = (title or "Team").strip()[:100] or "Team"
-	if not frappe.db.exists("User Group", base):
-		return base
-	for n in range(1, 1000):
-		candidate = f"{base} ({n})"
-		if not frappe.db.exists("User Group", candidate):
-			return candidate
-	return f"{base} {frappe.generate_hash(length=6)}"
+    """User Group names are the primary key, so a title collision needs a suffix."""
+    base = (title or "Team").strip()[:100] or "Team"
+    if not frappe.db.exists("User Group", base):
+        return base
+    for n in range(1, 1000):
+        candidate = f"{base} ({n})"
+        if not frappe.db.exists("User Group", candidate):
+            return candidate
+    return f"{base} {frappe.generate_hash(length=6)}"
 
 
 def _grant_group(entity, groups):
-	"""One row per access level, never per member — the Frappe team is 114 people,
-	and a row each would put 114 rows on every entity it can reach.
+    """One row per access level, never per member — the Frappe team is 114 people,
+    and a row each would put 114 rows on every entity it can reach.
 
-	Grants at different levels overlap by design: a manager sits in both the
-	all-members group and the managers group, and resolution takes the union of
-	same-tier group rows, so the wider grant wins per permission type.
-	"""
-	for level, group in groups.items():
-		_grant(entity, GROUP_PREFIX + group, _access_for(level))
+    Grants at different levels overlap by design: a manager sits in both the
+    all-members group and the managers group, and resolution takes the union of
+    same-tier group rows, so the wider grant wins per permission type.
+    """
+    for level, group in groups.items():
+        _grant(entity, GROUP_PREFIX + group, _access_for(level))
 
 
 def _access_for(access_level):
-	if not access_level:
-		return {"read": 1}
-	perms = {"read": 1, "comment": 1, "upload": 1}
-	if access_level == 2:
-		perms.update({"write": 1, "share": 1})
-	return perms
+    if not access_level:
+        return {"read": 1}
+    perms = {"read": 1, "comment": 1, "upload": 1}
+    if access_level == 2:
+        perms.update({"write": 1, "share": 1})
+    return perms
 
 
 def _to_user_folder(home, team):
-	frappe.db.set_value(
-		"File",
-		home,
-		{"folder": get_users_folder().name, "file_name": team.owner, "owner": team.owner},
-		update_modified=False,
-	)
-	grant_owner_access(home, team.owner)
+    frappe.db.set_value(
+        "File",
+        home,
+        {"folder": get_users_folder().name, "file_name": team.owner, "owner": team.owner},
+        update_modified=False,
+    )
+    grant_owner_access(home, team.owner)
 
-	if not frappe.db.exists("Drive Settings", team.owner):
-		frappe.get_doc({"doctype": "Drive Settings", "user": team.owner}).insert(ignore_permissions=True)
-	frappe.db.set_value(
-		"Drive Settings",
-		team.owner,
-		{"user_folder": home, "quota": team.quota or 0},
-		update_modified=False,
-	)
+    if not frappe.db.exists("Drive Settings", team.owner):
+        frappe.get_doc({"doctype": "Drive Settings", "user": team.owner}).insert(ignore_permissions=True)
+    frappe.db.set_value(
+        "Drive Settings",
+        team.owner,
+        {"user_folder": home, "quota": team.quota or 0},
+        update_modified=False,
+    )
 
 
 def _to_shared_folder(root, home, team, owned):
-	values = {
-		"folder": root.name,
-		"file_name": get_new_file_name(team.title or team.name, root.name),
-		"is_folder": 1,
-		"file_type": "Folder",
-		"status": STATUS_ACTIVE,
-	}
-	if owned:
-		values["owner"] = team.owner
-	frappe.db.set_value("File", home, values, update_modified=False)
-	if owned:
-		grant_owner_access(home, team.owner)
+    values = {
+        "folder": root.name,
+        "file_name": get_new_file_name(team.title or team.name, root.name),
+        "is_folder": 1,
+        "file_type": "Folder",
+        "status": STATUS_ACTIVE,
+    }
+    if owned:
+        values["owner"] = team.owner
+    frappe.db.set_value("File", home, values, update_modified=False)
+    if owned:
+        grant_owner_access(home, team.owner)
 
 
 def _grant_members(entity, members):
-	for m in members:
-		if frappe.db.exists("Drive Permission", {"entity": entity, "user": m.user}):
-			continue
-		perms = (
-			{"read": 1}
-			if not m.access_level
-			else {
-				"read": 1,
-				"comment": 1,
-				"upload": 1,
-				**({"write": 1, "share": 1} if m.access_level == 2 else {}),
-			}
-		)
-		frappe.get_doc({"doctype": "Drive Permission", "entity": entity, "user": m.user, **perms}).insert(
-			ignore_permissions=True
-		)
+    for m in members:
+        if frappe.db.exists("Drive Permission", {"entity": entity, "user": m.user}):
+            continue
+        perms = (
+            {"read": 1}
+            if not m.access_level
+            else {
+                "read": 1,
+                "comment": 1,
+                "upload": 1,
+                **({"write": 1, "share": 1} if m.access_level == 2 else {}),
+            }
+        )
+        frappe.get_doc({"doctype": "Drive Permission", "entity": entity, "user": m.user, **perms}).insert(
+            ignore_permissions=True
+        )
 
 
 def _grant(entity, user, perms):
-	if frappe.db.exists("Drive Permission", {"entity": entity, "user": user}):
-		return
-	frappe.get_doc({"doctype": "Drive Permission", "entity": entity, "user": user, **perms}).insert(
-		ignore_permissions=True
-	)
+    if frappe.db.exists("Drive Permission", {"entity": entity, "user": user}):
+        return
+    frappe.get_doc({"doctype": "Drive Permission", "entity": entity, "user": user, **perms}).insert(
+        ignore_permissions=True
+    )
 
 
 def _expand_team_rows(groups):
-	"""team=1 rows granted the row's team (stored in `user`) access to an entity.
-	The team now has a User Group, so one group row replaces what would otherwise
-	be a row per member — a 114-member team fanned out to 114 rows per entity.
-	All-zero team rows were revoke attempts, which nothing grants any more."""
-	for row in frappe.get_all("Drive Permission", filters={"team": 1}, fields=["*"]):
-		perms = {t: row.get(t) or 0 for t in PERMISSION_TYPES}
-		if not any(perms.values()):
-			continue
-		group = groups.get(row.user)
-		if group:
-			_grant(row.entity, GROUP_PREFIX + group, perms)
-			continue
-		# a personal team, or one with nobody left in it: no group to grant through
-		for m in frappe.get_all(
-			"Drive Team Member",
-			filters={"parenttype": "Drive Team", "parent": row.user},
-			fields=["user"],
-		):
-			if m.user and frappe.db.exists("User", m.user):
-				_grant(row.entity, m.user, perms)
-	# nothing links to a Drive Permission, and it has no delete-time logic
-	frappe.db.delete("Drive Permission", {"team": 1})
+    """team=1 rows granted the row's team (stored in `user`) access to an entity.
+    The team now has a User Group, so one group row replaces what would otherwise
+    be a row per member — a 114-member team fanned out to 114 rows per entity.
+    All-zero team rows were revoke attempts, which nothing grants any more."""
+    for row in frappe.get_all("Drive Permission", filters={"team": 1}, fields=["*"]):
+        perms = {t: row.get(t) or 0 for t in PERMISSION_TYPES}
+        if not any(perms.values()):
+            continue
+        group = groups.get(row.user)
+        if group:
+            _grant(row.entity, GROUP_PREFIX + group, perms)
+            continue
+        # a personal team, or one with nobody left in it: no group to grant through
+        for m in frappe.get_all(
+            "Drive Team Member",
+            filters={"parenttype": "Drive Team", "parent": row.user},
+            fields=["user"],
+        ):
+            if m.user and frappe.db.exists("User", m.user):
+                _grant(row.entity, m.user, perms)
+    # nothing links to a Drive Permission, and it has no delete-time logic
+    frappe.db.delete("Drive Permission", {"team": 1})
 
 
 def _drop_obsolete_revoke_rows():
-	"""Link rows granting nothing were revoke attempts; nothing grants that way now."""
-	frappe.db.delete("Drive Permission", {"user": "", "deny": 0, **dict.fromkeys(PERMISSION_TYPES, 0)})
+    """Link rows granting nothing were revoke attempts; nothing grants that way now."""
+    frappe.db.delete("Drive Permission", {"user": "", "deny": 0, **dict.fromkeys(PERMISSION_TYPES, 0)})
 
 
 def sweep_sidecars(sidecars=None, trashed=None):
-	"""Move thumbnails and trashed blobs onto the new root.
+    """Move thumbnails and trashed blobs onto the new root.
 
-	Both are located from the root rather than stored — `<root>/thumbnails/<id>` and
-	`<root>/.trash/<id>` — and the root moved from each team's own prefix to Drive's,
-	so the objects have to follow or they are simply not found.
+    Both are located from the root rather than stored — `<root>/thumbnails/<id>` and
+    `<root>/.trash/<id>` — and the root moved from each team's own prefix to Drive's,
+    so the objects have to follow or they are simply not found.
 
-	Runs as a job; safe to re-run by hand if it failed:
+    Runs as a job; safe to re-run by hand if it failed:
 
-	    bench --site <site> execute suite.drive.patches.remove_teams.sweep_sidecars
+        bench --site <site> execute suite.drive.patches.remove_teams.sweep_sidecars
 
-	With no arguments it re-derives the prefixes, which only works while `team` is
-	still on File. Idempotent either way: anything already at the destination is
-	skipped and the originals are left alone.
-	"""
-	sidecars = sidecars or _team_prefixes()
-	trashed = trashed or _trashed_by_team()
-	if not sidecars:
-		print("Drive: no old prefixes to sweep")
-		return
-	try:
-		moved, failed = _carry_sidecars(sidecars, trashed)
-	except Exception as e:
-		print(f"Drive: could not reach storage, sidecars not moved ({type(e).__name__}: {e})")
-		raise
+    With no arguments it re-derives the prefixes, which only works while `team` is
+    still on File. Idempotent either way: anything already at the destination is
+    skipped and the originals are left alone.
+    """
+    sidecars = sidecars or _team_prefixes()
+    trashed = trashed or _trashed_by_team()
+    if not sidecars:
+        print("Drive: no old prefixes to sweep")
+        return
+    try:
+        moved, failed = _carry_sidecars(sidecars, trashed)
+    except Exception as e:
+        print(f"Drive: could not reach storage, sidecars not moved ({type(e).__name__}: {e})")
+        raise
 
-	for kind, n in sorted(moved.items()):
-		print(f"Drive: moved {n} {kind}")
-	for key, reason in failed[:20]:
-		print(f"Drive: could not move {key}: {reason}")
-	if len(failed) > 20:
-		print(f"Drive: ... and {len(failed) - 20} more")
+    for kind, n in sorted(moved.items()):
+        print(f"Drive: moved {n} {kind}")
+    for key, reason in failed[:20]:
+        print(f"Drive: could not move {key}: {reason}")
+    if len(failed) > 20:
+        print(f"Drive: ... and {len(failed) - 20} more")
 
 
 def _carry_sidecars(sidecars, trashed):
-	manager = FileManager()
-	root = storage_key(get_root_folder().file_url).rstrip("/")
-	prefix = manager.settings.thumbnail_prefix or "thumbnails"
+    manager = FileManager()
+    root = storage_key(get_root_folder().file_url).rstrip("/")
+    prefix = manager.settings.thumbnail_prefix or "thumbnails"
 
-	# One listing, not one per prefix and a head_object per object: on S3 that is
-	# ~10 paginated calls instead of thousands of round trips.
-	existing = _all_keys(manager, sidecars, root, prefix)
+    # One listing, not one per prefix and a head_object per object: on S3 that is
+    # ~10 paginated calls instead of thousands of round trips.
+    existing = _all_keys(manager, sidecars, root, prefix)
 
-	moved, failed = Counter(), []
-	for team, base in sidecars.items():
-		if not base or base == root:
-			continue
-		for key in existing.get(f"{base}/{prefix}", ()):
-			name = key.rsplit("/", 1)[-1]
-			dest = f"{root}/{prefix}/{name}"
-			if name and dest not in existing.get(f"{root}/{prefix}", ()):
-				_carry(manager, key, dest, moved, failed)
-		for key in existing.get(f"{base}/{TRASH_PREFIX}", ()):
-			entity = trashed.get(team, {}).get(key.rsplit("/", 1)[-1])
-			dest = f"{root}/{TRASH_PREFIX}/{entity}"
-			if entity and dest not in existing.get(f"{root}/{TRASH_PREFIX}", ()):
-				_carry(manager, key, dest, moved, failed)
-	return moved, failed
+    moved, failed = Counter(), []
+    for team, base in sidecars.items():
+        if not base or base == root:
+            continue
+        for key in existing.get(f"{base}/{prefix}", ()):
+            name = key.rsplit("/", 1)[-1]
+            dest = f"{root}/{prefix}/{name}"
+            if name and dest not in existing.get(f"{root}/{prefix}", ()):
+                _carry(manager, key, dest, moved, failed)
+        for key in existing.get(f"{base}/{TRASH_PREFIX}", ()):
+            entity = trashed.get(team, {}).get(key.rsplit("/", 1)[-1])
+            dest = f"{root}/{TRASH_PREFIX}/{entity}"
+            if entity and dest not in existing.get(f"{root}/{TRASH_PREFIX}", ()):
+                _carry(manager, key, dest, moved, failed)
+    return moved, failed
 
 
 def _all_keys(manager, sidecars, root, prefix):
-	"""{directory: {keys}} for every sidecar directory we care about."""
-	wanted = {f"{root}/{prefix}", f"{root}/{TRASH_PREFIX}"}
-	for base in sidecars.values():
-		if base:
-			wanted |= {f"{base}/{prefix}", f"{base}/{TRASH_PREFIX}"}
+    """{directory: {keys}} for every sidecar directory we care about."""
+    wanted = {f"{root}/{prefix}", f"{root}/{TRASH_PREFIX}"}
+    for base in sidecars.values():
+        if base:
+            wanted |= {f"{base}/{prefix}", f"{base}/{TRASH_PREFIX}"}
 
-	out = {}
-	if manager.s3_enabled:
-		token = None
-		while True:
-			kwargs = {"Bucket": manager.bucket}
-			if token:
-				kwargs["ContinuationToken"] = token
-			page = manager.conn.list_objects_v2(**kwargs)
-			for o in page.get("Contents", []):
-				key = o["Key"]
-				parent = key.rsplit("/", 1)[0] if "/" in key else ""
-				if parent in wanted:
-					out.setdefault(parent, set()).add(key)
-			if not page.get("IsTruncated"):
-				break
-			token = page.get("NextContinuationToken")
-		return out
+    out = {}
+    if manager.s3_enabled:
+        token = None
+        while True:
+            kwargs = {"Bucket": manager.bucket}
+            if token:
+                kwargs["ContinuationToken"] = token
+            page = manager.conn.list_objects_v2(**kwargs)
+            for o in page.get("Contents", []):
+                key = o["Key"]
+                parent = key.rsplit("/", 1)[0] if "/" in key else ""
+                if parent in wanted:
+                    out.setdefault(parent, set()).add(key)
+            if not page.get("IsTruncated"):
+                break
+            token = page.get("NextContinuationToken")
+        return out
 
-	for directory in wanted:
-		folder = _local(manager, directory)
-		if folder.is_dir():
-			out[directory] = {f"{directory}/{f.name}" for f in folder.iterdir() if f.is_file()}
-	return out
+    for directory in wanted:
+        folder = _local(manager, directory)
+        if folder.is_dir():
+            out[directory] = {f"{directory}/{f.name}" for f in folder.iterdir() if f.is_file()}
+    return out
 
 
 def _carry(manager, src, dest, moved, failed):
-	"""The caller has already checked the destination against the listing, so this
-	does not probe storage again — that probe was the bulk of the round trips."""
-	kind = "trashed blob(s)" if TRASH_PREFIX in dest else "thumbnail(s)"
-	if src == dest:
-		return
-	try:
-		_copy(manager, src, dest)
-		moved[kind] += 1
-	except Exception as e:
-		failed.append((src, f"{type(e).__name__}: {e}"))
-
+    """The caller has already checked the destination against the listing, so this
+    does not probe storage again — that probe was the bulk of the round trips."""
+    kind = "trashed blob(s)" if TRASH_PREFIX in dest else "thumbnail(s)"
+    if src == dest:
+        return
+    try:
+        _copy(manager, src, dest)
+        moved[kind] += 1
+    except Exception as e:
+        failed.append((src, f"{type(e).__name__}: {e}"))
 
 
 def _local(manager, key):
-	"""Upgraded sites store `?path=/<team>/<id>`, and `base / "/abs"` discards
-	`base` — strip it so a local path can't escape the site folder."""
-	return manager.site_folder / key.lstrip("/")
+    """Upgraded sites store `?path=/<team>/<id>`, and `base / "/abs"` discards
+    `base` — strip it so a local path can't escape the site folder."""
+    return manager.site_folder / key.lstrip("/")
 
 
 def _copy(manager, src, dest):
-	if manager.s3_enabled:
-		manager.conn.copy_object(
-			Bucket=manager.bucket, CopySource={"Bucket": manager.bucket, "Key": src}, Key=dest
-		)
-		if _size(manager, dest) != _size(manager, src):
-			raise OSError(f"copy of {src} did not verify")
-	else:
-		src_path = _local(manager, src)
-		dest_path = _local(manager, dest)
-		dest_path.parent.mkdir(parents=True, exist_ok=True)
-		shutil.copy2(src_path, dest_path)
-		if dest_path.stat().st_size != src_path.stat().st_size:
-			raise OSError(f"copy of {src} did not verify")
+    if manager.s3_enabled:
+        manager.conn.copy_object(
+            Bucket=manager.bucket, CopySource={"Bucket": manager.bucket, "Key": src}, Key=dest
+        )
+        if _size(manager, dest) != _size(manager, src):
+            raise OSError(f"copy of {src} did not verify")
+    else:
+        src_path = _local(manager, src)
+        dest_path = _local(manager, dest)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src_path, dest_path)
+        if dest_path.stat().st_size != src_path.stat().st_size:
+            raise OSError(f"copy of {src} did not verify")
 
 
 def _size(manager, key):
-	return manager.conn.head_object(Bucket=manager.bucket, Key=key)["ContentLength"]
+    return manager.conn.head_object(Bucket=manager.bucket, Key=key)["ContentLength"]

--- a/suite/drive/patches/switch_drive_roles_to_suite_roles.py
+++ b/suite/drive/patches/switch_drive_roles_to_suite_roles.py
@@ -5,117 +5,117 @@ from frappe.utils import now
 
 # (old Drive role -> shared Suite role) that access has been consolidated onto.
 ROLE_MAP = {
-	"Drive User": "Suite User",
-	"Drive Admin": "Suite Admin",
+    "Drive User": "Suite User",
+    "Drive Admin": "Suite Admin",
 }
 
 
 def execute() -> None:
-	"""Move existing Drive role assignments onto the shared Suite roles.
+    """Move existing Drive role assignments onto the shared Suite roles.
 
-	Drive access moved from the app-specific "Drive User"/"Drive Admin" roles to
-	the suite-wide "Suite User"/"Suite Admin" roles. Both Drive roles carried desk
-	access, as do the Suite roles now, so holders stay System Users and their
-	``user_type`` needs no recompute — the assignments are simply swapped. Users
-	currently holding a Drive role gain the matching Suite role (if they don't have
-	it already), then the stale Drive assignments are dropped. The Drive Role docs
-	themselves are left in place; deleting a role cascades through core.
-	"""
+    Drive access moved from the app-specific "Drive User"/"Drive Admin" roles to
+    the suite-wide "Suite User"/"Suite Admin" roles. Both Drive roles carried desk
+    access, as do the Suite roles now, so holders stay System Users and their
+    ``user_type`` needs no recompute — the assignments are simply swapped. Users
+    currently holding a Drive role gain the matching Suite role (if they don't have
+    it already), then the stale Drive assignments are dropped. The Drive Role docs
+    themselves are left in place; deleting a role cascades through core.
+    """
 
-	for suite_role in set(ROLE_MAP.values()):
-		if not frappe.db.exists("Role", suite_role):
-			frappe.get_doc({"doctype": "Role", "role_name": suite_role, "desk_access": 1}).insert(
-				ignore_permissions=True
-			)
+    for suite_role in set(ROLE_MAP.values()):
+        if not frappe.db.exists("Role", suite_role):
+            frappe.get_doc({"doctype": "Role", "role_name": suite_role, "desk_access": 1}).insert(
+                ignore_permissions=True
+            )
 
-	users_by_drive_role = {}
-	for drive_role in ROLE_MAP:
-		users = set(
-			frappe.get_all(
-				"Has Role",
-				filters={"parenttype": "User", "role": drive_role},
-				pluck="parent",
-			)
-		)
-		users.discard("Administrator")
-		users_by_drive_role[drive_role] = users
+    users_by_drive_role = {}
+    for drive_role in ROLE_MAP:
+        users = set(
+            frappe.get_all(
+                "Has Role",
+                filters={"parenttype": "User", "role": drive_role},
+                pluck="parent",
+            )
+        )
+        users.discard("Administrator")
+        users_by_drive_role[drive_role] = users
 
-	_grant_suite_roles(users_by_drive_role)
+    _grant_suite_roles(users_by_drive_role)
 
-	frappe.db.delete("Has Role", {"parenttype": "User", "role": ("in", list(ROLE_MAP.keys()))})
+    frappe.db.delete("Has Role", {"parenttype": "User", "role": ("in", list(ROLE_MAP.keys()))})
 
 
 def _grant_suite_roles(users_by_drive_role: dict[str, set[str]]) -> None:
-	"""Bulk-insert the matching Suite role for each Drive-role holder.
+    """Bulk-insert the matching Suite role for each Drive-role holder.
 
-	The Suite roles carry desk access, but every user being migrated already holds
-	a desk-access Drive role and is therefore already a System User, so inserting
-	the child rows directly (rather than via ``User.add_roles``, an N+1 on migrate)
-	does not leave ``user_type`` stale.
+    The Suite roles carry desk access, but every user being migrated already holds
+    a desk-access Drive role and is therefore already a System User, so inserting
+    the child rows directly (rather than via ``User.add_roles``, an N+1 on migrate)
+    does not leave ``user_type`` stale.
 
-	Each user's existing roles and max ``idx`` are read once, up front, and the
-	per-user ``idx`` is then bumped locally as rows are appended. Doing it in a
-	single pass — rather than re-querying per role — means a user who holds both
-	Drive roles gets consecutive ``idx`` values across the two grants instead of a
-	collision, without depending on the just-inserted rows being visible mid-loop.
-	"""
+    Each user's existing roles and max ``idx`` are read once, up front, and the
+    per-user ``idx`` is then bumped locally as rows are appended. Doing it in a
+    single pass — rather than re-querying per role — means a user who holds both
+    Drive roles gets consecutive ``idx`` values across the two grants instead of a
+    collision, without depending on the just-inserted rows being visible mid-loop.
+    """
 
-	all_users = set().union(*users_by_drive_role.values())
-	if not all_users:
-		return
+    all_users = set().union(*users_by_drive_role.values())
+    if not all_users:
+        return
 
-	existing = frappe.get_all(
-		"Has Role",
-		filters={"parenttype": "User", "parent": ("in", list(all_users))},
-		fields=["parent", "role", "idx"],
-	)
-	roles_by_user = defaultdict(set)
-	next_idx = defaultdict(int)
-	for row in existing:
-		roles_by_user[row.parent].add(row.role)
-		next_idx[row.parent] = max(next_idx[row.parent], row.idx)
+    existing = frappe.get_all(
+        "Has Role",
+        filters={"parenttype": "User", "parent": ("in", list(all_users))},
+        fields=["parent", "role", "idx"],
+    )
+    roles_by_user = defaultdict(set)
+    next_idx = defaultdict(int)
+    for row in existing:
+        roles_by_user[row.parent].add(row.role)
+        next_idx[row.parent] = max(next_idx[row.parent], row.idx)
 
-	timestamp = now()
-	rows = []
-	for drive_role, suite_role in ROLE_MAP.items():
-		for user in users_by_drive_role[drive_role]:
-			if suite_role in roles_by_user[user]:
-				continue
-			roles_by_user[user].add(suite_role)
-			next_idx[user] += 1
-			rows.append(
-				(
-					frappe.generate_hash(length=10),
-					user,
-					"User",
-					"roles",
-					suite_role,
-					"Administrator",
-					timestamp,
-					timestamp,
-					"Administrator",
-					next_idx[user],
-					0,
-				)
-			)
+    timestamp = now()
+    rows = []
+    for drive_role, suite_role in ROLE_MAP.items():
+        for user in users_by_drive_role[drive_role]:
+            if suite_role in roles_by_user[user]:
+                continue
+            roles_by_user[user].add(suite_role)
+            next_idx[user] += 1
+            rows.append(
+                (
+                    frappe.generate_hash(length=10),
+                    user,
+                    "User",
+                    "roles",
+                    suite_role,
+                    "Administrator",
+                    timestamp,
+                    timestamp,
+                    "Administrator",
+                    next_idx[user],
+                    0,
+                )
+            )
 
-	if not rows:
-		return
+    if not rows:
+        return
 
-	frappe.db.bulk_insert(
-		"Has Role",
-		fields=[
-			"name",
-			"parent",
-			"parenttype",
-			"parentfield",
-			"role",
-			"owner",
-			"creation",
-			"modified",
-			"modified_by",
-			"idx",
-			"docstatus",
-		],
-		values=rows,
-	)
+    frappe.db.bulk_insert(
+        "Has Role",
+        fields=[
+            "name",
+            "parent",
+            "parenttype",
+            "parentfield",
+            "role",
+            "owner",
+            "creation",
+            "modified",
+            "modified_by",
+            "idx",
+            "docstatus",
+        ],
+        values=rows,
+    )

--- a/suite/drive/patches/team_restructure.py
+++ b/suite/drive/patches/team_restructure.py
@@ -64,7 +64,7 @@ def execute():
     frappe.db.commit()
 
     for k in entities:
-        if not k.get("old_name") in translate:
+        if k.get("old_name") not in translate:
             continue
         name = translate[k["old_name"]]
         frappe.db.set_value("Drive File", name, "owner", k["owner"], update_modified=False)

--- a/suite/drive/tests/test_storage_helpers.py
+++ b/suite/drive/tests/test_storage_helpers.py
@@ -11,68 +11,68 @@ from suite.drive.utils.files import FileManager, get_s3_key, get_s3_url, storage
 
 
 class TestStorageHelpers(unittest.TestCase):
-	def test_writer_container_is_disk_managed(self):
-		writer = frappe._dict(
-			file_type="Document",
-			file_url="team/writer-document",
-			content_doctype=WRITER_CONTENT_DOCTYPE,
-		)
-		self.assertFalse(File._not_in_disk(writer))
+    def test_writer_container_is_disk_managed(self):
+        writer = frappe._dict(
+            file_type="Document",
+            file_url="team/writer-document",
+            content_doctype=WRITER_CONTENT_DOCTYPE,
+        )
+        self.assertFalse(File._not_in_disk(writer))
 
-	def test_other_content_references_are_not_disk_managed(self):
-		reference = frappe._dict(
-			file_type="Document",
-			file_url="team/reference",
-			content_doctype="Presentation",
-		)
-		self.assertTrue(File._not_in_disk(reference))
+    def test_other_content_references_are_not_disk_managed(self):
+        reference = frappe._dict(
+            file_type="Document",
+            file_url="team/reference",
+            content_doctype="Presentation",
+        )
+        self.assertTrue(File._not_in_disk(reference))
 
-	def test_writer_container_follows_rename_trash_and_restore(self):
-		with TemporaryDirectory() as site_folder:
-			manager = object.__new__(FileManager)
-			manager.s3_enabled = False
-			manager.flat = False  # this exercises the mirrored-tree path
-			manager.site_folder = Path(site_folder)
-			entity = frappe._dict(
-				name="w1a2b3c4d5",
-				file_name="Renamed document",
-				file_url="root/Original document",
-				mime_type="frappe_doc",
-				content_doctype=WRITER_CONTENT_DOCTYPE,
-				parent_path=Path("root"),
-			)
-			embed = manager.site_folder / entity.file_url / ".embeds" / "image.png"
-			embed.parent.mkdir(parents=True)
-			embed.write_bytes(b"embed")
+    def test_writer_container_follows_rename_trash_and_restore(self):
+        with TemporaryDirectory() as site_folder:
+            manager = object.__new__(FileManager)
+            manager.s3_enabled = False
+            manager.flat = False  # this exercises the mirrored-tree path
+            manager.site_folder = Path(site_folder)
+            entity = frappe._dict(
+                name="w1a2b3c4d5",
+                file_name="Renamed document",
+                file_url="root/Original document",
+                mime_type="frappe_doc",
+                content_doctype=WRITER_CONTENT_DOCTYPE,
+                parent_path=Path("root"),
+            )
+            embed = manager.site_folder / entity.file_url / ".embeds" / "image.png"
+            embed.parent.mkdir(parents=True)
+            embed.write_bytes(b"embed")
 
-			entity.file_url = str(manager.rename(entity))
-			renamed_embed = manager.site_folder / entity.file_url / ".embeds" / "image.png"
-			self.assertEqual(renamed_embed.read_bytes(), b"embed")
+            entity.file_url = str(manager.rename(entity))
+            renamed_embed = manager.site_folder / entity.file_url / ".embeds" / "image.png"
+            self.assertEqual(renamed_embed.read_bytes(), b"embed")
 
-			with patch("suite.drive.utils.files.get_root_folder", return_value={"file_url": "root"}):
-				manager.move_to_trash(entity)
-				self.assertFalse(renamed_embed.exists())
-				manager.restore(entity)
+            with patch("suite.drive.utils.files.get_root_folder", return_value={"file_url": "root"}):
+                manager.move_to_trash(entity)
+                self.assertFalse(renamed_embed.exists())
+                manager.restore(entity)
 
-			self.assertEqual(renamed_embed.read_bytes(), b"embed")
+            self.assertEqual(renamed_embed.read_bytes(), b"embed")
 
-	def test_s3_url_roundtrip(self):
-		# get_s3_url builds a stored file_url; storage_key must recover the key.
-		for key in [
-			"abc/def.png",
-			"team one/sub folder/file name.pdf",
-			"résumé/spaced key.txt",
-			"a/b+c?d=e&f.bin",
-		]:
-			self.assertEqual(storage_key(get_s3_url(key)), key)
+    def test_s3_url_roundtrip(self):
+        # get_s3_url builds a stored file_url; storage_key must recover the key.
+        for key in [
+            "abc/def.png",
+            "team one/sub folder/file name.pdf",
+            "résumé/spaced key.txt",
+            "a/b+c?d=e&f.bin",
+        ]:
+            self.assertEqual(storage_key(get_s3_url(key)), key)
 
-	def test_storage_key_is_always_relative(self):
-		# Never returns a leading slash, so `Path(base) / key` can't reset.
-		for url in ["/private/files/x", "/files/y", "//z", "https://ext/u"]:
-			self.assertFalse(storage_key(url).startswith("/"))
+    def test_storage_key_is_always_relative(self):
+        # Never returns a leading slash, so `Path(base) / key` can't reset.
+        for url in ["/private/files/x", "/files/y", "//z", "https://ext/u"]:
+            self.assertFalse(storage_key(url).startswith("/"))
 
-	def test_get_s3_key_strips_disk_prefix(self):
-		self.assertEqual(get_s3_key("/private/files/a/b.png"), "a/b.png")
-		self.assertEqual(get_s3_key("/files/a/b.png"), "a/b.png")
-		# Already a bare key: unchanged.
-		self.assertEqual(get_s3_key("a/b.png"), "a/b.png")
+    def test_get_s3_key_strips_disk_prefix(self):
+        self.assertEqual(get_s3_key("/private/files/a/b.png"), "a/b.png")
+        self.assertEqual(get_s3_key("/files/a/b.png"), "a/b.png")
+        # Already a bare key: unchanged.
+        self.assertEqual(get_s3_key("a/b.png"), "a/b.png")

--- a/suite/drive/utils/__init__.py
+++ b/suite/drive/utils/__init__.py
@@ -46,275 +46,275 @@ PERMISSION_TYPES = ["read", "comment", "share", "upload", "write"]
 
 
 def entity_kind(row):
-	"""Classify a real `File` listing row. See `kind` above.
+    """Classify a real `File` listing row. See `kind` above.
 
-	`virtual` nodes are built in `list.get_attachments` and never reach here.
-	"""
-	if row.get("content_doctype") == ATTACHMENT_CONTENT_DOCTYPE:
-		return KIND_READONLY
-	return KIND_NATIVE
+    `virtual` nodes are built in `list.get_attachments` and never reach here.
+    """
+    if row.get("content_doctype") == ATTACHMENT_CONTENT_DOCTYPE:
+        return KIND_READONLY
+    return KIND_NATIVE
 
 
 MIME_LIST_MAP = {
-	"Image": [
-		"image/png",
-		"image/jpeg",
-		"image/svg+xml",
-		"image/heic",
-		"image/heif",
-		"image/avif",
-		"image/webp",
-		"image/tiff",
-		"image/gif",
-	],
-	"PDF": ["application/pdf"],
-	"Text": [
-		"text/plain",
-	],
-	"XML Data": ["application/xml"],
-	"Document": [
-		"application/msword",
-		"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-		"application/vnd.oasis.opendocument.text",
-		"application/vnd.apple.pages",
-		"application/x-abiword",
-		"frappe_doc",
-	],
-	"Frappe Document": [
-		"frappe_doc",
-	],
-	"Spreadsheet": [
-		"frappe/sheet",
-		"application/vnd.ms-excel",
-		"link/googlesheets",
-		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-		"application/vnd.oasis.opendocument.spreadsheet",
-		"text/csv",
-		"application/vnd.apple.numbers",
-	],
-	"Presentation": [
-		"frappe/slides",
-		"application/vnd.ms-powerpoint",
-		"application/vnd.openxmlformats-officedocument.presentationml.presentation",
-		"application/vnd.oasis.opendocument.presentation",
-		"application/vnd.apple.keynote",
-	],
-	"Code": [
-		"text/x-python",
-		"text/html",
-		"text/css",
-		"text/javascript",
-		"application/javascript",
-		"text/rich-text",
-		"text/x-shellscript",
-		"text/markdown",
-		"application/json",
-		"application/x-httpd-php",
-		"application/x-python-script",
-		"application/x-sql",
-		"text/x-perl",
-		"text/x-csrc",
-		"text/x-sh",
-	],
-	"Audio": ["audio/mpeg", "audio/wav", "audio/x-midi", "audio/ogg", "audio/mp4", "audio/mp3"],
-	"Video": ["video/mp4", "video/webm", "video/ogg", "video/quicktime", "video/x-matroska"],
-	"Book": ["application/epub+zip", "application/x-mobipocket-ebook"],
-	"Application": [
-		"application/octet-stream",
-		"application/x-sh",
-		"application/vnd.microsoft.portable-executable",
-	],
-	"Archive": [
-		"application/zip",
-		"application/x-rar-compressed",
-		"application/x-tar",
-		"application/gzip",
-		"application/x-bzip2",
-	],
+    "Image": [
+        "image/png",
+        "image/jpeg",
+        "image/svg+xml",
+        "image/heic",
+        "image/heif",
+        "image/avif",
+        "image/webp",
+        "image/tiff",
+        "image/gif",
+    ],
+    "PDF": ["application/pdf"],
+    "Text": [
+        "text/plain",
+    ],
+    "XML Data": ["application/xml"],
+    "Document": [
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.oasis.opendocument.text",
+        "application/vnd.apple.pages",
+        "application/x-abiword",
+        "frappe_doc",
+    ],
+    "Frappe Document": [
+        "frappe_doc",
+    ],
+    "Spreadsheet": [
+        "frappe/sheet",
+        "application/vnd.ms-excel",
+        "link/googlesheets",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.oasis.opendocument.spreadsheet",
+        "text/csv",
+        "application/vnd.apple.numbers",
+    ],
+    "Presentation": [
+        "frappe/slides",
+        "application/vnd.ms-powerpoint",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.oasis.opendocument.presentation",
+        "application/vnd.apple.keynote",
+    ],
+    "Code": [
+        "text/x-python",
+        "text/html",
+        "text/css",
+        "text/javascript",
+        "application/javascript",
+        "text/rich-text",
+        "text/x-shellscript",
+        "text/markdown",
+        "application/json",
+        "application/x-httpd-php",
+        "application/x-python-script",
+        "application/x-sql",
+        "text/x-perl",
+        "text/x-csrc",
+        "text/x-sh",
+    ],
+    "Audio": ["audio/mpeg", "audio/wav", "audio/x-midi", "audio/ogg", "audio/mp4", "audio/mp3"],
+    "Video": ["video/mp4", "video/webm", "video/ogg", "video/quicktime", "video/x-matroska"],
+    "Book": ["application/epub+zip", "application/x-mobipocket-ebook"],
+    "Application": [
+        "application/octet-stream",
+        "application/x-sh",
+        "application/vnd.microsoft.portable-executable",
+    ],
+    "Archive": [
+        "application/zip",
+        "application/x-rar-compressed",
+        "application/x-tar",
+        "application/gzip",
+        "application/x-bzip2",
+    ],
 }
 
 
 FILE_FIELDS = [
-	"name",
-	"file_name",
-	"folder",
-	"file_url",
-	"file_size",
-	"file_type",
-	"is_folder",
-	"content_doctype",
-	"content_docname",
-	"creation",
-	fn.Coalesce(Field("file_modified"), DriveFile.modified).as_("modified"),
-	"owner",
-	"attached_to_doctype",
-	"attached_to_name",
+    "name",
+    "file_name",
+    "folder",
+    "file_url",
+    "file_size",
+    "file_type",
+    "is_folder",
+    "content_doctype",
+    "content_docname",
+    "creation",
+    fn.Coalesce(Field("file_modified"), DriveFile.modified).as_("modified"),
+    "owner",
+    "attached_to_doctype",
+    "attached_to_name",
 ]
 
 
 def hide_storage_key(row):
-	"""Blank file_url unless the client needs it as a real URL.
+    """Blank file_url unless the client needs it as a real URL.
 
-	For managed files it's the raw storage key, which leaks the owner's path;
-	only Link/Presentation files use it client-side.
-	"""
-	if row.get("file_type") not in ("Link", "Presentation"):
-		row["file_url"] = None
-	return row
+    For managed files it's the raw storage key, which leaks the owner's path;
+    only Link/Presentation files use it client-side.
+    """
+    if row.get("file_type") not in ("Link", "Presentation"):
+        row["file_url"] = None
+    return row
 
 
 def get_root_folder():
-	"""Shared Drive content, the tree the "Site" listing shows. Carries $GENERAL
-	read; `Users` beside it stays private."""
-	root = _pinned_root(ROOT_FOLDER)
-	_ensure_general_read(root.name)
-	return root
+    """Shared Drive content, the tree the "Site" listing shows. Carries $GENERAL
+    read; `Users` beside it stays private."""
+    root = _pinned_root(ROOT_FOLDER)
+    _ensure_general_read(root.name)
+    return root
 
 
 def _ensure_general_read(entity):
-	if frappe.db.exists("Drive Permission", {"entity": entity, "user": GENERAL_USER}):
-		return
-	frappe.get_doc({"doctype": "Drive Permission", "entity": entity, "user": GENERAL_USER, "read": 1}).insert(
-		ignore_permissions=True
-	)
+    if frappe.db.exists("Drive Permission", {"entity": entity, "user": GENERAL_USER}):
+        return
+    frappe.get_doc({"doctype": "Drive Permission", "entity": entity, "user": GENERAL_USER, "read": 1}).insert(
+        ignore_permissions=True
+    )
 
 
 def get_users_folder():
-	"""Private user folders. A root beside `Drive`, not inside it, so nothing granted
-	on the shared tree reaches in. Carries no grant."""
-	return _pinned_root(USERS_FOLDER)
+    """Private user folders. A root beside `Drive`, not inside it, so nothing granted
+    on the shared tree reaches in. Carries no grant."""
+    return _pinned_root(USERS_FOLDER)
 
 
 def _pinned_root(file_name):
-	"""Folder-less `File`s, siblings of frappe's `Home` rather than children, so no
-	framework node sits on a Drive permission path.
+    """Folder-less `File`s, siblings of frappe's `Home` rather than children, so no
+    framework node sits on a Drive permission path.
 
-	Pinned by name, never derived: a site upgraded from the old app has one
-	folder-less File per team, so any "find the root" query picks a team folder.
-	"""
-	root = frappe.db.get_value("File", file_name, ["name", "file_url"], as_dict=1)
-	if not root:
-		root = _create_root_folder(file_name)
-	return root if root.file_url else _init_root_storage(root, file_name)
+    Pinned by name, never derived: a site upgraded from the old app has one
+    folder-less File per team, so any "find the root" query picks a team folder.
+    """
+    root = frappe.db.get_value("File", file_name, ["name", "file_url"], as_dict=1)
+    if not root:
+        root = _create_root_folder(file_name)
+    return root if root.file_url else _init_root_storage(root, file_name)
 
 
 def _create_root_folder(file_name):
-	root = frappe.get_doc(
-		{
-			"doctype": "File",
-			"file_name": file_name,
-			"is_folder": 1,
-			"is_private": 1,
-			"file_type": "Folder",
-		}
-	)
-	# `folder` stays unset: `set_folder_name` would reparent under `Home`, but it
-	# only runs on the framework's before_insert path, which file_created skips.
-	root._name = file_name
-	root.flags.file_created = True
-	root.insert(ignore_permissions=True)
-	return frappe._dict(name=root.name, file_url=root.file_url)
+    root = frappe.get_doc(
+        {
+            "doctype": "File",
+            "file_name": file_name,
+            "is_folder": 1,
+            "is_private": 1,
+            "file_type": "Folder",
+        }
+    )
+    # `folder` stays unset: `set_folder_name` would reparent under `Home`, but it
+    # only runs on the framework's before_insert path, which file_created skips.
+    root._name = file_name
+    root.flags.file_created = True
+    root.insert(ignore_permissions=True)
+    return frappe._dict(name=root.name, file_url=root.file_url)
 
 
 def _init_root_storage(root, file_name):
-	"""A root's prefix comes from settings, not a parent. Two logical roots, one
-	storage prefix — `Users` is just a directory beside the shared tree."""
-	from suite.drive.utils.files import get_s3_url
+    """A root's prefix comes from settings, not a parent. Two logical roots, one
+    storage prefix — `Users` is just a directory beside the shared tree."""
+    from suite.drive.utils.files import get_s3_url
 
-	settings = frappe.get_single("Drive Disk Settings")
-	prefix = settings.root_folder or ""
-	if file_name != ROOT_FOLDER:
-		prefix = f"{prefix}/{file_name}" if prefix else file_name
+    settings = frappe.get_single("Drive Disk Settings")
+    prefix = settings.root_folder or ""
+    if file_name != ROOT_FOLDER:
+        prefix = f"{prefix}/{file_name}" if prefix else file_name
 
-	disk_path = Path(frappe.get_site_path("private/files")) / prefix
-	disk_path.mkdir(exist_ok=True, parents=True)
-	if file_name == ROOT_FOLDER:
-		# scaffolding is shared, and keyed off the Drive root everywhere
-		(disk_path / ".uploads").mkdir(exist_ok=True)
-		(disk_path / settings.thumbnail_prefix).mkdir(exist_ok=True)
+    disk_path = Path(frappe.get_site_path("private/files")) / prefix
+    disk_path.mkdir(exist_ok=True, parents=True)
+    if file_name == ROOT_FOLDER:
+        # scaffolding is shared, and keyed off the Drive root everywhere
+        (disk_path / ".uploads").mkdir(exist_ok=True)
+        (disk_path / settings.thumbnail_prefix).mkdir(exist_ok=True)
 
-	root.file_url = get_s3_url(prefix) if settings.enabled else "/private/files/" + prefix
-	frappe.db.set_value("File", root.name, "file_url", root.file_url, update_modified=False)
-	return root
+    root.file_url = get_s3_url(prefix) if settings.enabled else "/private/files/" + prefix
+    frappe.db.set_value("File", root.name, "file_url", root.file_url, update_modified=False)
+    return root
 
 
 def get_previous_teams_folder():
-	"""Landing area for migrated teams, inside `Drive`. Teams were private, so this
-	denies the root's inherited $GENERAL read; each team below re-grants to its own
-	members from a nearer node. They reach it via "Shared with me"."""
-	root = get_root_folder()
-	existing = frappe.db.get_value(
-		"File",
-		{"folder": root.name, "file_name": PREVIOUS_TEAMS_FOLDER, "is_folder": 1},
-		["name", "file_url"],
-		as_dict=1,
-	)
-	if existing:
-		_deny_general_read(existing.name)
-		return existing
+    """Landing area for migrated teams, inside `Drive`. Teams were private, so this
+    denies the root's inherited $GENERAL read; each team below re-grants to its own
+    members from a nearer node. They reach it via "Shared with me"."""
+    root = get_root_folder()
+    existing = frappe.db.get_value(
+        "File",
+        {"folder": root.name, "file_name": PREVIOUS_TEAMS_FOLDER, "is_folder": 1},
+        ["name", "file_url"],
+        as_dict=1,
+    )
+    if existing:
+        _deny_general_read(existing.name)
+        return existing
 
-	from suite.drive.utils.files import FileManager
+    from suite.drive.utils.files import FileManager
 
-	manager = FileManager()
-	folder = create_drive_file(PREVIOUS_TEAMS_FOLDER, root.name, "Folder", lambda f: manager.create_folder(f))
-	_deny_general_read(folder.name)
-	return frappe._dict(name=folder.name, file_url=folder.file_url)
+    manager = FileManager()
+    folder = create_drive_file(PREVIOUS_TEAMS_FOLDER, root.name, "Folder", lambda f: manager.create_folder(f))
+    _deny_general_read(folder.name)
+    return frappe._dict(name=folder.name, file_url=folder.file_url)
 
 
 def _deny_general_read(entity):
-	if frappe.db.exists("Drive Permission", {"entity": entity, "user": GENERAL_USER}):
-		return
-	frappe.get_doc(
-		{"doctype": "Drive Permission", "entity": entity, "user": GENERAL_USER, "deny": 1, "read": 1}
-	).insert(ignore_permissions=True)
+    if frappe.db.exists("Drive Permission", {"entity": entity, "user": GENERAL_USER}):
+        return
+    frappe.get_doc(
+        {"doctype": "Drive Permission", "entity": entity, "user": GENERAL_USER, "deny": 1, "read": 1}
+    ).insert(ignore_permissions=True)
 
 
 def get_user_folder(user=None):
-	"""The user's private folder under the root; created on first use."""
-	user = user or frappe.session.user
-	name = frappe.db.get_value("Drive Settings", user, "user_folder")
-	if name:
-		folder = frappe.db.get_value("File", name, ["name", "file_url"], as_dict=1)
-		if folder:
-			return folder
+    """The user's private folder under the root; created on first use."""
+    user = user or frappe.session.user
+    name = frappe.db.get_value("Drive Settings", user, "user_folder")
+    if name:
+        folder = frappe.db.get_value("File", name, ["name", "file_url"], as_dict=1)
+        if folder:
+            return folder
 
-	if not frappe.db.exists("Drive Settings", user):
-		try:
-			frappe.get_doc({"doctype": "Drive Settings", "user": user}).insert(ignore_permissions=True)
-		except frappe.DuplicateEntryError:
-			pass
+    if not frappe.db.exists("Drive Settings", user):
+        try:
+            frappe.get_doc({"doctype": "Drive Settings", "user": user}).insert(ignore_permissions=True)
+        except frappe.DuplicateEntryError:
+            pass
 
-	name = frappe.db.get_value("Drive Settings", user, "user_folder", for_update=True)
-	if name:
-		folder = frappe.db.get_value("File", name, ["name", "file_url"], as_dict=1)
-		if folder:
-			return folder
+    name = frappe.db.get_value("Drive Settings", user, "user_folder", for_update=True)
+    if name:
+        folder = frappe.db.get_value("File", name, ["name", "file_url"], as_dict=1)
+        if folder:
+            return folder
 
-	from suite.drive.utils.files import FileManager
+    from suite.drive.utils.files import FileManager
 
-	manager = FileManager()
-	root = get_users_folder()
-	folder = create_drive_file(
-		user,
-		root.name,
-		"Folder",
-		lambda f: manager.create_folder(f),
-		owner=user,
-	)
-	grant_owner_access(folder.name, user)
+    manager = FileManager()
+    root = get_users_folder()
+    folder = create_drive_file(
+        user,
+        root.name,
+        "Folder",
+        lambda f: manager.create_folder(f),
+        owner=user,
+    )
+    grant_owner_access(folder.name, user)
 
-	if not frappe.db.exists("Drive Settings", user):
-		frappe.get_doc({"doctype": "Drive Settings", "user": user}).insert(ignore_permissions=True)
-	frappe.db.set_value("Drive Settings", user, "user_folder", folder.name, update_modified=False)
-	return frappe._dict(name=folder.name, file_url=folder.file_url)
+    if not frappe.db.exists("Drive Settings", user):
+        frappe.get_doc({"doctype": "Drive Settings", "user": user}).insert(ignore_permissions=True)
+    frappe.db.set_value("Drive Settings", user, "user_folder", folder.name, update_modified=False)
+    return frappe._dict(name=folder.name, file_url=folder.file_url)
 
 
 def get_ancestors_of(entity_name):
-	"""
-	Return all parent nodes till the root node
-	"""
-	result = frappe.db.sql(
-		"""
+    """
+    Return all parent nodes till the root node
+    """
+    result = frappe.db.sql(
+        """
         WITH RECURSIVE generated_path as (
         SELECT
             `tabFile`.name,
@@ -331,100 +331,100 @@ def get_ancestors_of(entity_name):
         JOIN `tabFile` as t ON t.name = gp.folder)
         SELECT name FROM generated_path;
     """,
-		values={"entity_name": entity_name},
-		as_dict=0,
-	)
-	flattened_list = [item for sublist in result for item in sublist]
-	flattened_list.pop(0)
-	return flattened_list
+        values={"entity_name": entity_name},
+        as_dict=0,
+    )
+    flattened_list = [item for sublist in result for item in sublist]
+    flattened_list.pop(0)
+    return flattened_list
 
 
 def grant_owner_access(entity, user):
-	"""Ownership of a folder is stored as a row like any other grant, so it
-	inherits down the tree and a deny below can still narrow it."""
-	if frappe.db.exists("Drive Permission", {"entity": entity, "user": user}):
-		return
-	frappe.get_doc(
-		{
-			"doctype": "Drive Permission",
-			"entity": entity,
-			"user": user,
-			**dict.fromkeys(PERMISSION_TYPES, 1),
-		}
-	).insert(ignore_permissions=True)
+    """Ownership of a folder is stored as a row like any other grant, so it
+    inherits down the tree and a deny below can still narrow it."""
+    if frappe.db.exists("Drive Permission", {"entity": entity, "user": user}):
+        return
+    frappe.get_doc(
+        {
+            "doctype": "Drive Permission",
+            "entity": entity,
+            "user": user,
+            **dict.fromkeys(PERMISSION_TYPES, 1),
+        }
+    ).insert(ignore_permissions=True)
 
 
 def get_principals(user=None):
-	"""Everything a `Drive Permission.user` row can name the caller by, most
-	specific first: themselves, their user groups, any logged-in user, anyone
-	with the link. Guests are only ever the last."""
-	user = user or frappe.session.user
-	if user == "Guest":
-		return [""]
+    """Everything a `Drive Permission.user` row can name the caller by, most
+    specific first: themselves, their user groups, any logged-in user, anyone
+    with the link. Guests are only ever the last."""
+    user = user or frappe.session.user
+    if user == "Guest":
+        return [""]
 
-	groups = frappe.cache().hget("drive_user_groups", user, generator=lambda: _user_groups(user))
-	return [user, *(GROUP_PREFIX + g for g in groups), GENERAL_USER, ""]
+    groups = frappe.cache().hget("drive_user_groups", user, generator=lambda: _user_groups(user))
+    return [user, *(GROUP_PREFIX + g for g in groups), GENERAL_USER, ""]
 
 
 def _user_groups(user):
-	return frappe.get_all(
-		"User Group Member",
-		filters={"parenttype": "User Group", "user": user},
-		pluck="parent",
-		distinct=True,
-	)
+    return frappe.get_all(
+        "User Group Member",
+        filters={"parenttype": "User Group", "user": user},
+        pluck="parent",
+        distinct=True,
+    )
 
 
 def clear_user_group_cache(doc=None, method=None):
-	frappe.cache().delete_key("drive_user_groups")
+    frappe.cache().delete_key("drive_user_groups")
 
 
 def principal_list(user=None):
-	return ", ".join(frappe.db.escape(p) for p in get_principals(user))
+    return ", ".join(frappe.db.escape(p) for p in get_principals(user))
 
 
 def dribble_access(path):
-	"""Resolve access at the leaf of `path`: per permission type the nearest row
-	decides (grant → 1, deny → 0). Nothing is granted by default. `decided`
-	lists the types an explicit row settled."""
-	decided = {}
-	for node in path[::-1]:
-		for row in node.get("perms", ()):
-			for t in PERMISSION_TYPES:
-				if row[t] and t not in decided:
-					decided[t] = 0 if row["deny"] else 1
-	access = dict.fromkeys(PERMISSION_TYPES, 0)
-	access.update(decided)
-	access["decided"] = list(decided)
-	return access
+    """Resolve access at the leaf of `path`: per permission type the nearest row
+    decides (grant → 1, deny → 0). Nothing is granted by default. `decided`
+    lists the types an explicit row settled."""
+    decided = {}
+    for node in path[::-1]:
+        for row in node.get("perms", ()):
+            for t in PERMISSION_TYPES:
+                if row[t] and t not in decided:
+                    decided[t] = 0 if row["deny"] else 1
+    access = dict.fromkeys(PERMISSION_TYPES, 0)
+    access.update(decided)
+    access["decided"] = list(decided)
+    return access
 
 
 def generate_upward_path(entity_name, user=None):
-	"""
-	Given an ID traverse upwards till the root node
-	Stops when parent_drive_file IS NULL
-	"""
-	if user is None:
-		user = frappe.session.user
-	principals = get_principals(user)
-	user_lit = frappe.db.escape(user)
-	perm_filter = "p.user IN ({})".format(", ".join(frappe.db.escape(p) for p in principals))
+    """
+    Given an ID traverse upwards till the root node
+    Stops when parent_drive_file IS NULL
+    """
+    if user is None:
+        user = frappe.session.user
+    principals = get_principals(user)
+    user_lit = frappe.db.escape(user)
+    perm_filter = "p.user IN ({})".format(", ".join(frappe.db.escape(p) for p in principals))
 
-	# Nearest folder wins; within a folder the most specific principal wins, and
-	# among equally specific group rows a deny beats a grant.
-	groups = [p for p in principals if p.startswith(GROUP_PREFIX)]
-	group_when = ""
-	if groups:
-		group_lit = ", ".join(frappe.db.escape(g) for g in groups)
-		group_when = f"WHEN p.user IN ({group_lit}) THEN 1"
-	tier = f"""CASE
+    # Nearest folder wins; within a folder the most specific principal wins, and
+    # among equally specific group rows a deny beats a grant.
+    groups = [p for p in principals if p.startswith(GROUP_PREFIX)]
+    group_when = ""
+    if groups:
+        group_lit = ", ".join(frappe.db.escape(g) for g in groups)
+        group_when = f"WHEN p.user IN ({group_lit}) THEN 1"
+    tier = f"""CASE
 			WHEN p.user = {user_lit} THEN 0
 			{group_when}
 			WHEN p.user = '{GENERAL_USER}' THEN 2
 			ELSE 3 END"""
 
-	result = frappe.db.sql(
-		f"""WITH RECURSIVE
+    result = frappe.db.sql(
+        f"""WITH RECURSIVE
             generated_path as (
                 SELECT
                     `tabFile`.file_name,
@@ -465,201 +465,201 @@ def generate_upward_path(entity_name, user=None):
         ON gp.name = p.entity AND {perm_filter}
         ORDER BY gp.level DESC, {tier}, p.deny DESC;
     """,
-		values={"entity_name": entity_name},
-		as_dict=1,
-	)
+        values={"entity_name": entity_name},
+        as_dict=1,
+    )
 
-	nodes = []
-	for row in result:
-		if not nodes or nodes[-1]["name"] != row["name"]:
-			nodes.append(
-				{
-					"file_name": row["file_name"],
-					"name": row["name"],
-					"owner": row["owner"],
-					"folder": row["folder"],
-					"perms": [],
-				}
-			)
-		if row["perm_user"] is not None:
-			nodes[-1]["perms"].append(row)
+    nodes = []
+    for row in result:
+        if not nodes or nodes[-1]["name"] != row["name"]:
+            nodes.append(
+                {
+                    "file_name": row["file_name"],
+                    "name": row["name"],
+                    "owner": row["owner"],
+                    "folder": row["folder"],
+                    "perms": [],
+                }
+            )
+        if row["perm_user"] is not None:
+            nodes[-1]["perms"].append(row)
 
-	return [{**node, **dribble_access(nodes[: i + 1])} for i, node in enumerate(nodes)]
+    return [{**node, **dribble_access(nodes[: i + 1])} for i, node in enumerate(nodes)]
 
 
 def get_valid_breadcrumbs(entity_name, user_access):
-	"""
-	Determine user access and generate upward path (breadcrumbs).
-	"""
-	# Admins see the entire path; others get the contiguous readable suffix.
-	path = generate_upward_path(entity_name)
-	if user_access.get("type") not in ["admin", "user"]:
-		lose_access = next((i for i, k in enumerate(path[::-1]) if not k["read"]), 0)
-		path = path[-lose_access:]
-	return _name_own_drive(path)
+    """
+    Determine user access and generate upward path (breadcrumbs).
+    """
+    # Admins see the entire path; others get the contiguous readable suffix.
+    path = generate_upward_path(entity_name)
+    if user_access.get("type") not in ["admin", "user"]:
+        lose_access = next((i for i, k in enumerate(path[::-1]) if not k["read"]), 0)
+        path = path[-lose_access:]
+    return _name_own_drive(path)
 
 
 def _name_own_drive(path):
-	"""Your own files hang off `Users/<your id>`, which reads back to you as a
-	container you have never seen and your own address as a folder. Show the one
-	crumb you know it by instead."""
-	if len(path) < 2 or path[0]["name"] != USERS_FOLDER:
-		return path
-	if path[1]["file_name"] != frappe.session.user:
-		# somebody else's drive: leave it spelled out
-		return path
-	return [{**path[1], "file_name": HOME_LABEL}, *path[2:]]
+    """Your own files hang off `Users/<your id>`, which reads back to you as a
+    container you have never seen and your own address as a folder. Show the one
+    crumb you know it by instead."""
+    if len(path) < 2 or path[0]["name"] != USERS_FOLDER:
+        return path
+    if path[1]["file_name"] != frappe.session.user:
+        # somebody else's drive: leave it spelled out
+        return path
+    return [{**path[1], "file_name": HOME_LABEL}, *path[2:]]
 
 
 def get_file_type(mime_type):
-	try:
-		return next(k for (k, v) in MIME_LIST_MAP.items() if mime_type in v)
-	except StopIteration:
-		return "Unknown"
+    try:
+        return next(k for (k, v) in MIME_LIST_MAP.items() if mime_type in v)
+    except StopIteration:
+        return "Unknown"
 
 
 def update_file_size(entity, delta):
-	doc = frappe.get_doc("File", entity)
-	while doc.folder:
-		doc.file_size += delta
-		doc.save(ignore_permissions=True)
-		doc = frappe.get_doc("File", doc.folder)
-	# Update root
-	doc.file_size += delta
-	doc.save(ignore_permissions=True)
+    doc = frappe.get_doc("File", entity)
+    while doc.folder:
+        doc.file_size += delta
+        doc.save(ignore_permissions=True)
+        doc = frappe.get_doc("File", doc.folder)
+    # Update root
+    doc.file_size += delta
+    doc.save(ignore_permissions=True)
 
 
 def if_folder_exists(folder_name, parent):
-	values = {
-		"file_name": folder_name,
-		"is_folder": 1,
-		"is_private": 1,
-		"status": STATUS_ACTIVE,
-		"folder": parent,
-	}
-	existing_folder = frappe.db.get_value(
-		"File", values, ["name", "file_name", "is_folder", "status"], as_dict=1
-	)
+    values = {
+        "file_name": folder_name,
+        "is_folder": 1,
+        "is_private": 1,
+        "status": STATUS_ACTIVE,
+        "folder": parent,
+    }
+    existing_folder = frappe.db.get_value(
+        "File", values, ["name", "file_name", "is_folder", "status"], as_dict=1
+    )
 
-	if existing_folder:
-		return existing_folder.name
-	else:
-		d = frappe.get_doc({"doctype": "File", **values, "file_modified": frappe.utils.now_datetime()})
-		d.flags.file_created = True
-		d.insert()
-		return d.name
+    if existing_folder:
+        return existing_folder.name
+    else:
+        d = frappe.get_doc({"doctype": "File", **values, "file_modified": frappe.utils.now_datetime()})
+        d.flags.file_created = True
+        d.insert()
+        return d.name
 
 
 def create_drive_file(
-	file_name,
-	parent,
-	file_type,
-	entity_path,
-	mime_type=None,
-	file_size=0,
-	file_modified=None,
-	content_doctype=None,
-	content_docname=None,
-	owner=None,
+    file_name,
+    parent,
+    file_type,
+    entity_path,
+    mime_type=None,
+    file_size=0,
+    file_modified=None,
+    content_doctype=None,
+    content_docname=None,
+    owner=None,
 ):
-	values = {
-		"doctype": "File",
-		"is_private": 1,
-		"file_name": file_name,
-		"folder": parent,
-		"file_size": file_size,
-		"file_type": file_type,
-		"mime_type": mime_type,
-		"is_folder": file_type == "Folder",
-		"file_modified": (datetime.fromtimestamp(file_modified) if file_modified else frappe.utils.now()),
-	}
-	if content_doctype:
-		values["content_doctype"] = content_doctype
-		values["content_docname"] = content_docname
-	drive_file = frappe.get_doc(values)
-	drive_file.flags.file_created = True
-	drive_file.insert(ignore_permissions=True)
-	path = entity_path(drive_file) if callable(entity_path) else entity_path
-	drive_file.file_url = str(path) if path else ""
-	drive_file.save(ignore_permissions=True)
-	if owner:
-		drive_file.db_set("owner", owner, update_modified=False)
-	return drive_file
+    values = {
+        "doctype": "File",
+        "is_private": 1,
+        "file_name": file_name,
+        "folder": parent,
+        "file_size": file_size,
+        "file_type": file_type,
+        "mime_type": mime_type,
+        "is_folder": file_type == "Folder",
+        "file_modified": (datetime.fromtimestamp(file_modified) if file_modified else frappe.utils.now()),
+    }
+    if content_doctype:
+        values["content_doctype"] = content_doctype
+        values["content_docname"] = content_docname
+    drive_file = frappe.get_doc(values)
+    drive_file.flags.file_created = True
+    drive_file.insert(ignore_permissions=True)
+    path = entity_path(drive_file) if callable(entity_path) else entity_path
+    drive_file.file_url = str(path) if path else ""
+    drive_file.save(ignore_permissions=True)
+    if owner:
+        drive_file.db_set("owner", owner, update_modified=False)
+    return drive_file
 
 
 def get_new_file_name(file_name: str, parent_name: str, type: str = False, entity: str | None = None):
-	entity_title, entity_ext = os.path.splitext(file_name)
+    entity_title, entity_ext = os.path.splitext(file_name)
 
-	filters = {
-		"status": STATUS_ACTIVE,
-		"folder": parent_name,
-		"file_name": ["like", f"{entity_title}%{entity_ext}"],
-	}
+    filters = {
+        "status": STATUS_ACTIVE,
+        "folder": parent_name,
+        "file_name": ["like", f"{entity_title}%{entity_ext}"],
+    }
 
-	if type:
-		filters["file_type"] = type
+    if type:
+        filters["file_type"] = type
 
-	sibling_entity_titles = frappe.db.get_list(
-		"File",
-		filters=filters,
-		fields=["file_name", "name"],
-	)
-	if (
-		not sibling_entity_titles
-		or (sibling_entity_titles[0].name == entity)
-		or not any(k["file_name"] == file_name for k in sibling_entity_titles)
-	):
-		return file_name
-	return f"{entity_title} ({len(sibling_entity_titles)}){entity_ext}"
+    sibling_entity_titles = frappe.db.get_list(
+        "File",
+        filters=filters,
+        fields=["file_name", "name"],
+    )
+    if (
+        not sibling_entity_titles
+        or (sibling_entity_titles[0].name == entity)
+        or not any(k["file_name"] == file_name for k in sibling_entity_titles)
+    ):
+        return file_name
+    return f"{entity_title} ({len(sibling_entity_titles)}){entity_ext}"
 
 
 def validate_filename(file_name, parent, type, error=None):
-	suggested_name = get_new_file_name(file_name, parent, type)
-	if suggested_name != file_name:
-		if not error:
-			error = f"{file_name} exists."
-		frappe.throw(
-			f"{error} Try {suggested_name}",
-			frappe.ValidationError,
-		)
+    suggested_name = get_new_file_name(file_name, parent, type)
+    if suggested_name != file_name:
+        if not error:
+            error = f"{file_name} exists."
+        frappe.throw(
+            f"{error} Try {suggested_name}",
+            frappe.ValidationError,
+        )
 
 
 def map_ff_to_drive_type(file):
-	if file.is_folder:
-		return "Folder"
-	mime_type = mimemapper.get_mime_type(file.file_type) if file.file_type else ""
-	try:
-		return next(k for (k, v) in MIME_LIST_MAP.items() if mime_type in v)
-	except StopIteration:
-		return "Unknown"
+    if file.is_folder:
+        return "Folder"
+    mime_type = mimemapper.get_mime_type(file.file_type) if file.file_type else ""
+    try:
+        return next(k for (k, v) in MIME_LIST_MAP.items() if mime_type in v)
+    except StopIteration:
+        return "Unknown"
 
 
 def get_upload_path(base_path, file_name):
-	uploads_path = Path(frappe.get_site_path(base_path), ".uploads")
-	if not os.path.exists(uploads_path):
-		uploads_path.mkdir()
-	return uploads_path / file_name
+    uploads_path = Path(frappe.get_site_path(base_path), ".uploads")
+    if not os.path.exists(uploads_path):
+        uploads_path.mkdir()
+    return uploads_path / file_name
 
 
 def create_file(
-	title="Untitled",
-	parent=None,
-	path=None,
-	mime_type=None,
-	file_type=None,
-	content_doctype=None,
-	content_docname=None,
+    title="Untitled",
+    parent=None,
+    path=None,
+    mime_type=None,
+    file_type=None,
+    content_doctype=None,
+    content_docname=None,
 ):
-	"""Convenience wrapper for external apps (e.g. Slides, Writer) to create a Drive file."""
-	if not parent:
-		parent = get_user_folder().name
+    """Convenience wrapper for external apps (e.g. Slides, Writer) to create a Drive file."""
+    if not parent:
+        parent = get_user_folder().name
 
-	return create_drive_file(
-		title,
-		parent,
-		file_type or "Unknown",
-		lambda _: path,
-		mime_type=mime_type,
-		content_doctype=content_doctype,
-		content_docname=content_docname,
-	)
+    return create_drive_file(
+        title,
+        parent,
+        file_type or "Unknown",
+        lambda _: path,
+        mime_type=mime_type,
+        content_doctype=content_doctype,
+        content_docname=content_docname,
+    )

--- a/suite/drive/utils/api.py
+++ b/suite/drive/utils/api.py
@@ -3,17 +3,17 @@ from suite.drive.utils import GENERAL_USER, generate_upward_path
 
 
 def get_default_access(entity):
-	# General access marker: -2 public (link), -1 site users, 0 restricted.
-	default = 0
-	if entity:
-		name = entity if isinstance(entity, str) else entity.get("name")
-		if get_user_access(entity, "Guest")["read"]:
-			default = -2
-		elif generate_upward_path(name, GENERAL_USER)[-1]["read"]:
-			default = -1
-	return default
+    # General access marker: -2 public (link), -1 site users, 0 restricted.
+    default = 0
+    if entity:
+        name = entity if isinstance(entity, str) else entity.get("name")
+        if get_user_access(entity, "Guest")["read"]:
+            default = -2
+        elif generate_upward_path(name, GENERAL_USER)[-1]["read"]:
+            default = -1
+    return default
 
 
 def prettify_file(f: dict):
-	f["share_count"] = get_default_access(f)
-	return f
+    f["share_count"] = get_default_access(f)
+    return f

--- a/suite/drive/utils/files.py
+++ b/suite/drive/utils/files.py
@@ -24,498 +24,498 @@ TRASH_PREFIX = ".trash"
 
 
 class FileManager:
-	def __init__(self):
-		settings = frappe.get_single("Drive Disk Settings")
-		self.settings = settings
-		self.s3_enabled = settings.enabled
-		# not settings.flat: the Single may predate the field, and the doctype
-		# overrides __getattribute__ so a missing row raises instead of defaulting
-		self.flat = getattr(settings, "flat", 0)
-		self.bucket = settings.bucket
-		self.site_folder = Path(frappe.get_site_path())
+    def __init__(self):
+        settings = frappe.get_single("Drive Disk Settings")
+        self.settings = settings
+        self.s3_enabled = settings.enabled
+        # not settings.flat: the Single may predate the field, and the doctype
+        # overrides __getattribute__ so a missing row raises instead of defaulting
+        self.flat = getattr(settings, "flat", 0)
+        self.bucket = settings.bucket
+        self.site_folder = Path(frappe.get_site_path())
 
-		if self.s3_enabled:
-			self.conn = boto3.client(
-				"s3",
-				aws_access_key_id=settings.aws_key,
-				aws_secret_access_key=settings.get_password("aws_secret"),
-				endpoint_url=(settings.endpoint_url or None),
-				config=Config(signature_version=settings.signature_version),
-			)
+        if self.s3_enabled:
+            self.conn = boto3.client(
+                "s3",
+                aws_access_key_id=settings.aws_key,
+                aws_secret_access_key=settings.get_password("aws_secret"),
+                endpoint_url=(settings.endpoint_url or None),
+                config=Config(signature_version=settings.signature_version),
+            )
 
-	def get_prefix(self):
-		return self.settings.root_folder or ""
+    def get_prefix(self):
+        return self.settings.root_folder or ""
 
-	def _not_if_flat(func):
-		"""Flat storage has no directories and no per-file paths, so anything that
-		rearranges them is a no-op."""
+    def _not_if_flat(func):
+        """Flat storage has no directories and no per-file paths, so anything that
+        rearranges them is a no-op."""
 
-		def wrapper(self, *args, **kwargs):
-			if self.flat:
-				return
-			return func(self, *args, **kwargs)
+        def wrapper(self, *args, **kwargs):
+            if self.flat:
+                return
+            return func(self, *args, **kwargs)
 
-		return wrapper
+        return wrapper
 
-	def can_create_thumbnail(self, file):
-		# Only images, videos and PDFs get thumbnails.
-		if not hasattr(file, "mime_type"):
-			return False
-		return file.mime_type.startswith(("image", "video")) or file.mime_type == "application/pdf"
+    def can_create_thumbnail(self, file):
+        # Only images, videos and PDFs get thumbnails.
+        if not hasattr(file, "mime_type"):
+            return False
+        return file.mime_type.startswith(("image", "video")) or file.mime_type == "application/pdf"
 
-	def upload_file(self, current_path: Path, file, create_thumbnail=True) -> None:
-		"""
-		Moves the file from the current path to another path
-		"""
-		if self.s3_enabled:
-			self.conn.upload_file(current_path, self.bucket, get_s3_key(file.file_url))
-			if create_thumbnail and self.can_create_thumbnail(file):
-				frappe.enqueue(
-					self.upload_thumbnail,
-					now=True,
-					at_front=True,
-					file=file,
-					file_path=str(current_path),
-				)
-			else:
-				os.remove(current_path)
-		else:
-			os.rename(current_path, self.site_folder / storage_key(file.file_url))
-			if file and create_thumbnail and self.can_create_thumbnail(file):
-				frappe.enqueue(
-					self.upload_thumbnail,
-					now=True,
-					at_front=True,
-					file=file,
-					file_path=str(self.site_folder / storage_key(file.file_url)),
-				)
+    def upload_file(self, current_path: Path, file, create_thumbnail=True) -> None:
+        """
+        Moves the file from the current path to another path
+        """
+        if self.s3_enabled:
+            self.conn.upload_file(current_path, self.bucket, get_s3_key(file.file_url))
+            if create_thumbnail and self.can_create_thumbnail(file):
+                frappe.enqueue(
+                    self.upload_thumbnail,
+                    now=True,
+                    at_front=True,
+                    file=file,
+                    file_path=str(current_path),
+                )
+            else:
+                os.remove(current_path)
+        else:
+            os.rename(current_path, self.site_folder / storage_key(file.file_url))
+            if file and create_thumbnail and self.can_create_thumbnail(file):
+                frappe.enqueue(
+                    self.upload_thumbnail,
+                    now=True,
+                    at_front=True,
+                    file=file,
+                    file_path=str(self.site_folder / storage_key(file.file_url)),
+                )
 
-	def upload_thumbnail(self, file, file_path: str):
-		"""
-		Creates a thumbnail for the file on disk and then uploads to the thumbnail directory
-		"""
-		save_path = self.get_thumbnail_path(file.name).with_suffix(".png")
-		disk_path = str(self.site_folder / save_path)
+    def upload_thumbnail(self, file, file_path: str):
+        """
+        Creates a thumbnail for the file on disk and then uploads to the thumbnail directory
+        """
+        save_path = self.get_thumbnail_path(file.name).with_suffix(".png")
+        disk_path = str(self.site_folder / save_path)
 
-		try:
-			with DistributedLock(file_path, exclusive=False):
-				if file.mime_type.startswith("image"):
-					with Image.open(file_path).convert("RGB") as image:
-						image = ImageOps.exif_transpose(image)
-						image.thumbnail((512, 512))
-						image.save(disk_path, format="webp")
-				elif file.mime_type.startswith("video"):
-					import av
+        try:
+            with DistributedLock(file_path, exclusive=False):
+                if file.mime_type.startswith("image"):
+                    with Image.open(file_path).convert("RGB") as image:
+                        image = ImageOps.exif_transpose(image)
+                        image.thumbnail((512, 512))
+                        image.save(disk_path, format="webp")
+                elif file.mime_type.startswith("video"):
+                    import av
 
-					with av.open(file_path) as container:
-						stream = container.streams.video[0]
-						if stream.duration:
-							container.seek(stream.duration // 2, stream=stream)
-						image = next(container.decode(stream)).to_image()
-						image.thumbnail((512, 512))
-						image.save(disk_path, format="webp")
-				else:
-					import pymupdf
+                    with av.open(file_path) as container:
+                        stream = container.streams.video[0]
+                        if stream.duration:
+                            container.seek(stream.duration // 2, stream=stream)
+                        image = next(container.decode(stream)).to_image()
+                        image.thumbnail((512, 512))
+                        image.save(disk_path, format="webp")
+                else:
+                    import pymupdf
 
-					with pymupdf.open(file_path) as pdf:
-						page = pdf.load_page(0)
-						zoom = 512 / max(page.rect.width, page.rect.height)
-						pix = page.get_pixmap(matrix=pymupdf.Matrix(zoom, zoom))
-						Image.frombytes("RGB", (pix.width, pix.height), pix.samples).save(
-							disk_path, format="webp"
-						)
+                    with pymupdf.open(file_path) as pdf:
+                        page = pdf.load_page(0)
+                        zoom = 512 / max(page.rect.width, page.rect.height)
+                        pix = page.get_pixmap(matrix=pymupdf.Matrix(zoom, zoom))
+                        Image.frombytes("RGB", (pix.width, pix.height), pix.samples).save(
+                            disk_path, format="webp"
+                        )
 
-				disk_path = Path(disk_path)
-				if self.s3_enabled:
-					# Removes original file
-					os.remove(file_path)
-					self.conn.upload_file(disk_path, self.bucket, str(save_path.with_suffix(".thumbnail")))
-					disk_path.unlink()
-				else:
-					final_path = disk_path.with_suffix(".thumbnail")
-					disk_path.rename(final_path)
-		except BaseException as e:
-			frappe.log_error("Thumbnail failed", e)
-			if self.s3_enabled:
-				try:
-					os.remove(file_path)
-				except FileNotFoundError:
-					pass
+                disk_path = Path(disk_path)
+                if self.s3_enabled:
+                    # Removes original file
+                    os.remove(file_path)
+                    self.conn.upload_file(disk_path, self.bucket, str(save_path.with_suffix(".thumbnail")))
+                    disk_path.unlink()
+                else:
+                    final_path = disk_path.with_suffix(".thumbnail")
+                    disk_path.rename(final_path)
+        except BaseException as e:
+            frappe.log_error("Thumbnail failed", e)
+            if self.s3_enabled:
+                try:
+                    os.remove(file_path)
+                except FileNotFoundError:
+                    pass
 
-	def get_disk_path(self, entity, embed=False):
-		"""
-		Helper function to get path of a file
-		"""
-		if self.flat:
-			# One namespace under the root, keyed by id — no tree, no team, so a
-			# rename or move never touches storage.
-			root = Path(storage_key(get_root_folder()["file_url"]))
-			return root / ("embeds" if embed else "") / entity.name
+    def get_disk_path(self, entity, embed=False):
+        """
+        Helper function to get path of a file
+        """
+        if self.flat:
+            # One namespace under the root, keyed by id — no tree, no team, so a
+            # rename or move never touches storage.
+            root = Path(storage_key(get_root_folder()["file_url"]))
+            return root / ("embeds" if embed else "") / entity.name
 
-		# perf: stupidly complicated because we use this both with a real entity and a dict
-		parent = (
-			Path(storage_key(frappe.get_value("File", entity.folder, "file_url") or ""))
-			if not hasattr(entity, "parent_path")
-			else Path(entity.parent_path)
-		)
-		name = escape_component(entity.file_name)
-		if embed:
-			return parent / ".embeds" / name
-		return parent / name
+        # perf: stupidly complicated because we use this both with a real entity and a dict
+        parent = (
+            Path(storage_key(frappe.get_value("File", entity.folder, "file_url") or ""))
+            if not hasattr(entity, "parent_path")
+            else Path(entity.parent_path)
+        )
+        name = escape_component(entity.file_name)
+        if embed:
+            return parent / ".embeds" / name
+        return parent / name
 
-	@_not_if_flat
-	def create_folder(self, entity):
-		"""
-		Function to create a folder in the S3 bucket or on disk.
-		"""
-		path = self.get_disk_path(entity)
-		if self.s3_enabled:
-			self.conn.put_object(Bucket=self.bucket, Key=str(path) + "/", Body="")
-		else:
-			(self.site_folder / path).mkdir(exist_ok=True)
-		return str(path) + "/"
+    @_not_if_flat
+    def create_folder(self, entity):
+        """
+        Function to create a folder in the S3 bucket or on disk.
+        """
+        path = self.get_disk_path(entity)
+        if self.s3_enabled:
+            self.conn.put_object(Bucket=self.bucket, Key=str(path) + "/", Body="")
+        else:
+            (self.site_folder / path).mkdir(exist_ok=True)
+        return str(path) + "/"
 
-	def get_file(self, entity, range_header=None, log=True):
-		"""
-		Function to get a file, with an optional range header for S3 objects
-		"""
-		file_url = storage_key(entity.file_url)
-		try:
-			if self.s3_enabled:
-				if range_header:
-					buf = self.conn.get_object(Bucket=self.bucket, Key=file_url, Range=range_header)["Body"]
-				else:
-					buf = self.conn.get_object(Bucket=self.bucket, Key=file_url)["Body"]
-			else:
-				with open(self.site_folder / file_url, "rb") as fh:
-					buf = BytesIO(fh.read())
-		except (ClientError, FileNotFoundError, OSError) as e:
-			if log:
-				frappe.log_error("Drive: could not read file", e)
-			frappe.throw("Could not find this file.", frappe.DoesNotExistError)
+    def get_file(self, entity, range_header=None, log=True):
+        """
+        Function to get a file, with an optional range header for S3 objects
+        """
+        file_url = storage_key(entity.file_url)
+        try:
+            if self.s3_enabled:
+                if range_header:
+                    buf = self.conn.get_object(Bucket=self.bucket, Key=file_url, Range=range_header)["Body"]
+                else:
+                    buf = self.conn.get_object(Bucket=self.bucket, Key=file_url)["Body"]
+            else:
+                with open(self.site_folder / file_url, "rb") as fh:
+                    buf = BytesIO(fh.read())
+        except (ClientError, FileNotFoundError, OSError) as e:
+            if log:
+                frappe.log_error("Drive: could not read file", e)
+            frappe.throw("Could not find this file.", frappe.DoesNotExistError)
 
-		return buf
+        return buf
 
-	def presigned_url(self, key, download_name, mime_type=None, expires=3600):
-		"""Short-lived S3 GET URL, range-capable, served straight to the client."""
-		bucket = self.bucket
-		params = {
-			"Bucket": bucket,
-			"Key": key,
-			"ResponseContentDisposition": content_disposition(download_name),
-		}
-		if mime_type:
-			params["ResponseContentType"] = mime_type
-		return self._presign_client(bucket).generate_presigned_url(
-			"get_object", Params=params, ExpiresIn=expires
-		)
+    def presigned_url(self, key, download_name, mime_type=None, expires=3600):
+        """Short-lived S3 GET URL, range-capable, served straight to the client."""
+        bucket = self.bucket
+        params = {
+            "Bucket": bucket,
+            "Key": key,
+            "ResponseContentDisposition": content_disposition(download_name),
+        }
+        if mime_type:
+            params["ResponseContentType"] = mime_type
+        return self._presign_client(bucket).generate_presigned_url(
+            "get_object", Params=params, ExpiresIn=expires
+        )
 
-	def _presign_client(self, bucket):
-		"""generate_presigned_url signs offline, so it never gets the automatic
-		region-redirect retry that a real S3 call (get_object, put_object, ...)
-		gets for free. Signed against the wrong region, S3 rejects the URL
-		outright with PermanentRedirect instead of serving the object. Detect
-		the bucket's real region once (get_bucket_location is itself
-		region-agnostic) and sign with a client that matches it."""
-		if self.settings.endpoint_url:
-			# custom/S3-compatible endpoints (e.g. MinIO) don't do AWS's
-			# multi-region redirect dance
-			return self.conn
+    def _presign_client(self, bucket):
+        """generate_presigned_url signs offline, so it never gets the automatic
+        region-redirect retry that a real S3 call (get_object, put_object, ...)
+        gets for free. Signed against the wrong region, S3 rejects the URL
+        outright with PermanentRedirect instead of serving the object. Detect
+        the bucket's real region once (get_bucket_location is itself
+        region-agnostic) and sign with a client that matches it."""
+        if self.settings.endpoint_url:
+            # custom/S3-compatible endpoints (e.g. MinIO) don't do AWS's
+            # multi-region redirect dance
+            return self.conn
 
-		cache_key = f"drive-s3-bucket-region:{bucket}"
-		region = frappe.cache().get_value(cache_key)
-		if not region:
-			try:
-				region = self.conn.get_bucket_location(Bucket=bucket).get("LocationConstraint") or "us-east-1"
-			except ClientError:
-				region = self.conn.meta.region_name or "us-east-1"
-			frappe.cache().set_value(cache_key, region, expires_in_sec=24 * 60 * 60)
+        cache_key = f"drive-s3-bucket-region:{bucket}"
+        region = frappe.cache().get_value(cache_key)
+        if not region:
+            try:
+                region = self.conn.get_bucket_location(Bucket=bucket).get("LocationConstraint") or "us-east-1"
+            except ClientError:
+                region = self.conn.meta.region_name or "us-east-1"
+            frappe.cache().set_value(cache_key, region, expires_in_sec=24 * 60 * 60)
 
-		if region == self.conn.meta.region_name:
-			return self.conn
-		return boto3.client(
-			"s3",
-			aws_access_key_id=self.settings.aws_key,
-			aws_secret_access_key=self.settings.get_password("aws_secret"),
-			region_name=region,
-			config=Config(signature_version=self.settings.signature_version),
-		)
+        if region == self.conn.meta.region_name:
+            return self.conn
+        return boto3.client(
+            "s3",
+            aws_access_key_id=self.settings.aws_key,
+            aws_secret_access_key=self.settings.get_password("aws_secret"),
+            region_name=region,
+            config=Config(signature_version=self.settings.signature_version),
+        )
 
-	def iter_blocks(self, entity, block_size=4 * 1024 * 1024):
-		"""Yield a file's bytes lazily so a worker never holds the whole file."""
-		if self.s3_enabled:
-			source = self.get_file(entity)
-			try:
-				while chunk := source.read(block_size):
-					yield chunk
-			finally:
-				source.close()
-		else:
-			with open(self.site_folder / storage_key(entity.file_url), "rb") as fh:
-				while chunk := fh.read(block_size):
-					yield chunk
+    def iter_blocks(self, entity, block_size=4 * 1024 * 1024):
+        """Yield a file's bytes lazily so a worker never holds the whole file."""
+        if self.s3_enabled:
+            source = self.get_file(entity)
+            try:
+                while chunk := source.read(block_size):
+                    yield chunk
+            finally:
+                source.close()
+        else:
+            with open(self.site_folder / storage_key(entity.file_url), "rb") as fh:
+                while chunk := fh.read(block_size):
+                    yield chunk
 
-	def write_file(self, path: str | Path, content: str):
-		if self.s3_enabled:
-			pass
-		else:
-			with open(self.site_folder / path, "w") as f:
-				f.write(content)
+    def write_file(self, path: str | Path, content: str):
+        if self.s3_enabled:
+            pass
+        else:
+            with open(self.site_folder / path, "w") as f:
+                f.write(content)
 
-	@contextmanager
-	def open_file(self, path):
-		"""
-		Context manager that yields a file-like object.
-		- On disk: opens in binary mode, closes automatically.
-		- On S3: yields the botocore StreamingBody, closes automatically.
-		"""
-		if self.s3_enabled:
-			obj = self.conn.get_object(Bucket=self.bucket, Key=path)
-			body = obj["Body"]
-			try:
-				yield body  # StreamingBody is already a file-like object
-			finally:
-				body.close()
-		else:
-			f = open(self.site_folder / path, "rb")
-			try:
-				yield f
-			finally:
-				f.close()
+    @contextmanager
+    def open_file(self, path):
+        """
+        Context manager that yields a file-like object.
+        - On disk: opens in binary mode, closes automatically.
+        - On S3: yields the botocore StreamingBody, closes automatically.
+        """
+        if self.s3_enabled:
+            obj = self.conn.get_object(Bucket=self.bucket, Key=path)
+            body = obj["Body"]
+            try:
+                yield body  # StreamingBody is already a file-like object
+            finally:
+                body.close()
+        else:
+            f = open(self.site_folder / path, "rb")
+            try:
+                yield f
+            finally:
+                f.close()
 
-	def fetch_new_files(self) -> dict[Path, tuple[str]]:
-		"""
-		Traverse the site folder and return a list of all yet-uncreated files with information
-		Returns path, file size, and modified
-		Ignores hidden files
-		"""
-		if self.s3_enabled:
-			root_folder = Path(self.get_prefix())
-			objects = self.conn.list_objects_v2(Bucket=self.bucket).get("Contents", [])
-			basic_files = {}
+    def fetch_new_files(self) -> dict[Path, tuple[str]]:
+        """
+        Traverse the site folder and return a list of all yet-uncreated files with information
+        Returns path, file size, and modified
+        Ignores hidden files
+        """
+        if self.s3_enabled:
+            root_folder = Path(self.get_prefix())
+            objects = self.conn.list_objects_v2(Bucket=self.bucket).get("Contents", [])
+            basic_files = {}
 
-			# Get files...
-			for obj in objects:
-				obj_path = Path(obj["Key"])
+            # Get files...
+            for obj in objects:
+                obj_path = Path(obj["Key"])
 
-				if (
-					not obj_path.is_relative_to(root_folder)
-					or obj_path == root_folder
-					or any(str(p).startswith(".") for p in obj_path.parts)
-				):
-					continue
-				obj_path = obj_path.relative_to(root_folder)
-				basic_files[obj_path] = obj
+                if (
+                    not obj_path.is_relative_to(root_folder)
+                    or obj_path == root_folder
+                    or any(str(p).startswith(".") for p in obj_path.parts)
+                ):
+                    continue
+                obj_path = obj_path.relative_to(root_folder)
+                basic_files[obj_path] = obj
 
-				# Used to "calculate" natural folders, folders created by Drive are already counted
-				# Don't count root folder
-				parent_path = obj_path.parent
-				if obj_path not in basic_files and parent_path != Path("."):
-					basic_files[parent_path] = {
-						"Key": str(parent_path),
-						"Size": 0,
-						"LastModified": obj["LastModified"],
-						"Folder": True,
-					}
+                # Used to "calculate" natural folders, folders created by Drive are already counted
+                # Don't count root folder
+                parent_path = obj_path.parent
+                if obj_path not in basic_files and parent_path != Path("."):
+                    basic_files[parent_path] = {
+                        "Key": str(parent_path),
+                        "Size": 0,
+                        "LastModified": obj["LastModified"],
+                        "Folder": True,
+                    }
 
-			files = {}
+            files = {}
 
-			for path, f in basic_files.items():
-				# Drive-created folders - registered S3 objects - have trailing slashes.
-				is_folder = f.get("Folder") or f["Key"].endswith("/")
-				exists = frappe.get_value(
-					"File",
-					{
-						"file_url": f["Key"].rstrip("/") + ("/" if is_folder else ""),
-						"status": STATUS_ACTIVE,
-						"is_folder": int(is_folder),
-					},
-					"name",
-				)
-				if exists:
-					continue
+            for path, f in basic_files.items():
+                # Drive-created folders - registered S3 objects - have trailing slashes.
+                is_folder = f.get("Folder") or f["Key"].endswith("/")
+                exists = frappe.get_value(
+                    "File",
+                    {
+                        "file_url": f["Key"].rstrip("/") + ("/" if is_folder else ""),
+                        "status": STATUS_ACTIVE,
+                        "is_folder": int(is_folder),
+                    },
+                    "name",
+                )
+                if exists:
+                    continue
 
-				mime_type = "folder" if is_folder else mimemapper.get_mime_type(f["Key"], native_first=False)
-				# Relative path is key, DB path is f["Key"]
-				files[path] = (f["Size"], f["LastModified"].timestamp(), mime_type, f["Key"])
-		else:
-			root_folder = self.site_folder / "private" / "files" / self.get_prefix()
+                mime_type = "folder" if is_folder else mimemapper.get_mime_type(f["Key"], native_first=False)
+                # Relative path is key, DB path is f["Key"]
+                files[path] = (f["Size"], f["LastModified"].timestamp(), mime_type, f["Key"])
+        else:
+            root_folder = self.site_folder / "private" / "files" / self.get_prefix()
 
-			# ... and stitch them together with information
-			files = {}
-			for f in root_folder.glob("**/*"):
-				path = f.relative_to(self.site_folder)
-				exists = frappe.get_value(
-					"File",
-					{"file_url": str(path), "status": STATUS_ACTIVE},
-					"name",
-				)
-				if exists or any(p for p in f.parts if p.startswith(".")):
-					continue
+            # ... and stitch them together with information
+            files = {}
+            for f in root_folder.glob("**/*"):
+                path = f.relative_to(self.site_folder)
+                exists = frappe.get_value(
+                    "File",
+                    {"file_url": str(path), "status": STATUS_ACTIVE},
+                    "name",
+                )
+                if exists or any(p for p in f.parts if p.startswith(".")):
+                    continue
 
-				if f.is_dir():
-					mime_type = "folder"
-				else:
-					mime_type = mimemapper.get_mime_type(str(f), native_first=False)
+                if f.is_dir():
+                    mime_type = "folder"
+                else:
+                    mime_type = mimemapper.get_mime_type(str(f), native_first=False)
 
-				# Twice `path` for compatability with S3 format
-				files[path] = (f.stat().st_size, f.stat().st_mtime, mime_type, str(path))
+                # Twice `path` for compatability with S3 format
+                files[path] = (f.stat().st_size, f.stat().st_mtime, mime_type, str(path))
 
-		return files
+        return files
 
-	def get_thumbnail_path(self, name):
-		return (
-			Path(storage_key(get_root_folder()["file_url"]))
-			/ self.settings.thumbnail_prefix
-			/ (name + ".thumbnail")
-		)
+    def get_thumbnail_path(self, name):
+        return (
+            Path(storage_key(get_root_folder()["file_url"]))
+            / self.settings.thumbnail_prefix
+            / (name + ".thumbnail")
+        )
 
-	def get_thumbnail(self, name):
-		return self.get_file(frappe._dict({"file_url": str(self.get_thumbnail_path(name))}), log=False)
+    def get_thumbnail(self, name):
+        return self.get_file(frappe._dict({"file_url": str(self.get_thumbnail_path(name))}), log=False)
 
-	def __get_trash_path(self, entity):
-		"""Keyed by id, not file_name: trash is one flat directory under a single
-		root now, and two teams could each trash a `readme.md`."""
-		root = get_root_folder()
-		return Path(storage_key(root["file_url"])) / TRASH_PREFIX / entity.name
+    def __get_trash_path(self, entity):
+        """Keyed by id, not file_name: trash is one flat directory under a single
+        root now, and two teams could each trash a `readme.md`."""
+        root = get_root_folder()
+        return Path(storage_key(root["file_url"])) / TRASH_PREFIX / entity.name
 
-	@_not_if_flat
-	def rename(self, entity):
-		if not entity.file_url or entity.mime_type == "frappe/slides":
-			return
-		new_path = self.get_disk_path(entity)
-		return self.move(entity, new_path)
+    @_not_if_flat
+    def rename(self, entity):
+        if not entity.file_url or entity.mime_type == "frappe/slides":
+            return
+        new_path = self.get_disk_path(entity)
+        return self.move(entity, new_path)
 
-	@_not_if_flat
-	def move_to_trash(self, entity):
-		if not entity.file_url or entity.mime_type in ["frappe/slides", "link"]:
-			return
+    @_not_if_flat
+    def move_to_trash(self, entity):
+        if not entity.file_url or entity.mime_type in ["frappe/slides", "link"]:
+            return
 
-		trash_path = self.__get_trash_path(entity)
-		try:
-			if self.s3_enabled:
-				bucket = self.bucket
-				self.conn.copy_object(
-					Bucket=bucket,
-					CopySource={"Bucket": bucket, "Key": storage_key(entity.file_url)},
-					Key=str(trash_path),
-				)
-				self.conn.delete_object(Bucket=bucket, Key=storage_key(entity.file_url))
-			else:
-				full_trash_path = self.site_folder / trash_path
-				if full_trash_path.exists() and full_trash_path.is_dir():
-					shutil.rmtree(full_trash_path)
+        trash_path = self.__get_trash_path(entity)
+        try:
+            if self.s3_enabled:
+                bucket = self.bucket
+                self.conn.copy_object(
+                    Bucket=bucket,
+                    CopySource={"Bucket": bucket, "Key": storage_key(entity.file_url)},
+                    Key=str(trash_path),
+                )
+                self.conn.delete_object(Bucket=bucket, Key=storage_key(entity.file_url))
+            else:
+                full_trash_path = self.site_folder / trash_path
+                if full_trash_path.exists() and full_trash_path.is_dir():
+                    shutil.rmtree(full_trash_path)
 
-				full_trash_path.parent.mkdir(exist_ok=True)
-				cur_path = self.site_folder / storage_key(entity.file_url)
-				if cur_path.is_dir():
-					shutil.move(cur_path, full_trash_path)
-				else:
-					cur_path.rename(full_trash_path)
-		except (FileNotFoundError, ClientError):
-			frappe.log_error(f"Moved {entity.name} to trash without it being on disk")
-			pass
+                full_trash_path.parent.mkdir(exist_ok=True)
+                cur_path = self.site_folder / storage_key(entity.file_url)
+                if cur_path.is_dir():
+                    shutil.move(cur_path, full_trash_path)
+                else:
+                    cur_path.rename(full_trash_path)
+        except (FileNotFoundError, ClientError):
+            frappe.log_error(f"Moved {entity.name} to trash without it being on disk")
+            pass
 
-	@_not_if_flat
-	def restore(self, entity):
-		"""
-		Restore a file from the trash.
-		"""
-		self.move(frappe._dict(file_url=self.__get_trash_path(entity)), entity.file_url)
+    @_not_if_flat
+    def restore(self, entity):
+        """
+        Restore a file from the trash.
+        """
+        self.move(frappe._dict(file_url=self.__get_trash_path(entity)), entity.file_url)
 
-	@_not_if_flat
-	def move(self, entity, new_path: str | Path):
-		"""
-		Move a file on disk
-		"""
-		# Callers pass new_path as either a bare key or a stored file_url;
-		# normalize both ends to the actual backend key.
-		src_key = storage_key(entity.file_url)
-		dest_key = storage_key(new_path)
-		try:
-			if self.s3_enabled:
-				bucket = self.bucket
-				self.conn.copy_object(
-					Bucket=bucket,
-					CopySource={"Bucket": bucket, "Key": src_key},
-					Key=dest_key,
-				)
-				self.conn.delete_object(Bucket=bucket, Key=src_key)
-			else:
-				cur_path = self.site_folder / src_key
-				dest_path = self.site_folder / dest_key
-				if cur_path.is_dir():
-					shutil.move(cur_path, dest_path)
-				else:
-					cur_path.rename(dest_path)
-		except BaseException:
-			frappe.throw("This file doesn't exist on disk.")
-		return new_path
+    @_not_if_flat
+    def move(self, entity, new_path: str | Path):
+        """
+        Move a file on disk
+        """
+        # Callers pass new_path as either a bare key or a stored file_url;
+        # normalize both ends to the actual backend key.
+        src_key = storage_key(entity.file_url)
+        dest_key = storage_key(new_path)
+        try:
+            if self.s3_enabled:
+                bucket = self.bucket
+                self.conn.copy_object(
+                    Bucket=bucket,
+                    CopySource={"Bucket": bucket, "Key": src_key},
+                    Key=dest_key,
+                )
+                self.conn.delete_object(Bucket=bucket, Key=src_key)
+            else:
+                cur_path = self.site_folder / src_key
+                dest_path = self.site_folder / dest_key
+                if cur_path.is_dir():
+                    shutil.move(cur_path, dest_path)
+                else:
+                    cur_path.rename(dest_path)
+        except BaseException:
+            frappe.throw("This file doesn't exist on disk.")
+        return new_path
 
-	def delete_file(self, entity):
-		thumbnail_path = self.get_thumbnail_path(entity.name)
+    def delete_file(self, entity):
+        thumbnail_path = self.get_thumbnail_path(entity.name)
 
-		if self.s3_enabled:
-			bucket = self.bucket
-			try:
-				self.conn.delete_object(Bucket=bucket, Key=storage_key(entity.file_url))
-				if thumbnail_path:
-					self.conn.delete_object(Bucket=bucket, Key=str(thumbnail_path))
-			except Exception:
-				pass
-		else:
-			try:
-				(self.site_folder / storage_key(entity.file_url)).unlink()
-				if thumbnail_path:
-					(self.site_folder / thumbnail_path).unlink()
-			except FileNotFoundError:
-				pass
+        if self.s3_enabled:
+            bucket = self.bucket
+            try:
+                self.conn.delete_object(Bucket=bucket, Key=storage_key(entity.file_url))
+                if thumbnail_path:
+                    self.conn.delete_object(Bucket=bucket, Key=str(thumbnail_path))
+            except Exception:
+                pass
+        else:
+            try:
+                (self.site_folder / storage_key(entity.file_url)).unlink()
+                if thumbnail_path:
+                    (self.site_folder / thumbnail_path).unlink()
+            except FileNotFoundError:
+                pass
 
 
 # Utils
 def escape_component(file_name):
-	"""A name is one path component, but `/` is legal in a name and would forge a
-	directory level. Escape it rather than renaming the user's file — `%` first, or
-	a name containing a literal `%2F` would decode back into a separator."""
-	return (file_name or "").replace("%", "%25").replace("/", "%2F").replace("\\", "%5C")
+    """A name is one path component, but `/` is legal in a name and would forge a
+    directory level. Escape it rather than renaming the user's file — `%` first, or
+    a name containing a literal `%2F` would decode back into a separator."""
+    return (file_name or "").replace("%", "%25").replace("/", "%2F").replace("\\", "%5C")
 
 
 def unescape_component(component):
-	return component.replace("%5C", "\\").replace("%2F", "/").replace("%25", "%")
+    return component.replace("%5C", "\\").replace("%2F", "/").replace("%25", "%")
 
 
 def storage_key(file_url):
-	# file_url -> backend storage key. NOT always relative: upgraded sites stored
-	# `?path=/<team>/<id>` and that slash is part of the S3 key. Callers building a
-	# local path must lstrip("/") — `Path("a") / "/b" == Path("/b")`.
-	file_url = str(file_url)
-	if file_url.startswith(S3_URL_PREFIX):
-		return unquote(file_url[len(S3_URL_PREFIX) :])
-	return file_url.lstrip("/")
+    # file_url -> backend storage key. NOT always relative: upgraded sites stored
+    # `?path=/<team>/<id>` and that slash is part of the S3 key. Callers building a
+    # local path must lstrip("/") — `Path("a") / "/b" == Path("/b")`.
+    file_url = str(file_url)
+    if file_url.startswith(S3_URL_PREFIX):
+        return unquote(file_url[len(S3_URL_PREFIX) :])
+    return file_url.lstrip("/")
 
 
 def content_disposition(download_name):
-	"""RFC 6266 attachment header; non-ASCII names ride in RFC 5987 filename*
-	(`secure_filename` would strip them to nothing)."""
-	try:
-		download_name.encode("ascii")
-		names = {"filename": download_name}
-	except UnicodeEncodeError:
-		simple = unicodedata.normalize("NFKD", download_name).encode("ascii", "ignore").decode("ascii")
-		quoted = quote(download_name, safe="!#$&+-.^_`|~")
-		names = {"filename": simple, "filename*": f"UTF-8''{quoted}"}
-	return dump_options_header("attachment", names)
+    """RFC 6266 attachment header; non-ASCII names ride in RFC 5987 filename*
+    (`secure_filename` would strip them to nothing)."""
+    try:
+        download_name.encode("ascii")
+        names = {"filename": download_name}
+    except UnicodeEncodeError:
+        simple = unicodedata.normalize("NFKD", download_name).encode("ascii", "ignore").decode("ascii")
+        quoted = quote(download_name, safe="!#$&+-.^_`|~")
+        names = {"filename": simple, "filename*": f"UTF-8''{quoted}"}
+    return dump_options_header("attachment", names)
 
 
 def get_s3_key(file_url):
-	prefixes = ["/private/files/", "/files/"]
-	for prefix in prefixes:
-		if file_url.startswith(prefix):
-			return file_url[len(prefix) :]
-	return file_url
+    prefixes = ["/private/files/", "/files/"]
+    for prefix in prefixes:
+        if file_url.startswith(prefix):
+            return file_url[len(prefix) :]
+    return file_url
 
 
 def get_s3_url(path):
-	from urllib.parse import quote
+    from urllib.parse import quote
 
-	return S3_URL_PREFIX + quote(path)
+    return S3_URL_PREFIX + quote(path)

--- a/suite/drive/utils/overrides.py
+++ b/suite/drive/utils/overrides.py
@@ -5,79 +5,79 @@ from suite.drive.utils import principal_list
 
 
 def filter_file(user=None):
-	"""Replaces the framework's File query conditions (skipped because of the
-	`ignore_file_permissions` hook). Conservative: owner, direct Drive grants,
-	public files, DocShares, and readable attachments — folder-inherited access
-	needs Drive's recursive path traversal, impractical in SQL, so it's left to
-	`has_permission`."""
-	user = user or frappe.session.user
-	roles = frappe.get_roles(user)
-	if user == "Administrator" or "Suite Admin" in roles:
-		return ""
+    """Replaces the framework's File query conditions (skipped because of the
+    `ignore_file_permissions` hook). Conservative: owner, direct Drive grants,
+    public files, DocShares, and readable attachments — folder-inherited access
+    needs Drive's recursive path traversal, impractical in SQL, so it's left to
+    `has_permission`."""
+    user = user or frappe.session.user
+    roles = frappe.get_roles(user)
+    if user == "Administrator" or "Suite Admin" in roles:
+        return ""
 
-	escaped = frappe.db.escape(user)
-	clauses = [
-		"`tabFile`.`is_private` = 0",
-		f"`tabFile`.`owner` = {escaped}",
-		f"`tabFile`.`name` IN (SELECT `entity` FROM `tabDrive Permission`"
-		f" WHERE `user` IN ({principal_list(user)}) AND `read` = 1 AND `deny` = 0)",
-		f"`tabFile`.`name` IN (SELECT `share_name` FROM `tabDocShare`"
-		f" WHERE `share_doctype` = 'File' AND `user` = {escaped} AND `read` = 1)",
-	]
-	if SYSTEM_USER_ROLE in roles:
-		readable = ", ".join(frappe.db.escape(dt) for dt in get_doctypes_with_read(user)) or "''"
-		clauses.append(f"`tabFile`.`attached_to_doctype` IN ({readable})")
-	return "(" + " OR ".join(clauses) + ")"
+    escaped = frappe.db.escape(user)
+    clauses = [
+        "`tabFile`.`is_private` = 0",
+        f"`tabFile`.`owner` = {escaped}",
+        f"`tabFile`.`name` IN (SELECT `entity` FROM `tabDrive Permission`"
+        f" WHERE `user` IN ({principal_list(user)}) AND `read` = 1 AND `deny` = 0)",
+        f"`tabFile`.`name` IN (SELECT `share_name` FROM `tabDocShare`"
+        f" WHERE `share_doctype` = 'File' AND `user` = {escaped} AND `read` = 1)",
+    ]
+    if SYSTEM_USER_ROLE in roles:
+        readable = ", ".join(frappe.db.escape(dt) for dt in get_doctypes_with_read(user)) or "''"
+        clauses.append(f"`tabFile`.`attached_to_doctype` IN ({readable})")
+    return "(" + " OR ".join(clauses) + ")"
 
 
 def common_filters(func):
-	def decorator(user):
-		user = user or frappe.session.user
-		if user == "Administrator" or "Suite Admin" in frappe.get_roles(user):
-			return ""
-		return func(user)
+    def decorator(user):
+        user = user or frappe.session.user
+        if user == "Administrator" or "Suite Admin" in frappe.get_roles(user):
+            return ""
+        return func(user)
 
-	return decorator
+    return decorator
 
 
 @common_filters
 def filter_drive_permission(user):
-	user = frappe.db.escape(user)
-	return f"""(`tabDrive Permission`.`owner` = {user} or `tabDrive Permission`.user = {user})"""
+    user = frappe.db.escape(user)
+    return f"""(`tabDrive Permission`.`owner` = {user} or `tabDrive Permission`.user = {user})"""
 
 
 @common_filters
 def filter_drive_settings(user):
-	return f"(`tabDrive Settings`.`user` = {frappe.db.escape(user)})"
+    return f"(`tabDrive Settings`.`user` = {frappe.db.escape(user)})"
 
 
 @common_filters
 def filter_drive_invitation(user):
-	return f"(`tabDrive User Invitation`.`email` = {frappe.db.escape(user)})"
+    return f"(`tabDrive User Invitation`.`email` = {frappe.db.escape(user)})"
 
 
 @common_filters
 def filter_activity_log(user):
-	escaped = frappe.db.escape(user)
-	return (
-		f"(`tabDrive Entity Activity Log`.`entity` IN ("
-		f"SELECT `name` FROM `tabFile` WHERE `owner` = {escaped}"
-		f" UNION SELECT `entity` FROM `tabDrive Permission`"
-		f" WHERE `user` IN ({principal_list(user)}) AND `read` = 1 AND `deny` = 0))"
-	)
+    escaped = frappe.db.escape(user)
+    return (
+        f"(`tabDrive Entity Activity Log`.`entity` IN ("
+        f"SELECT `name` FROM `tabFile` WHERE `owner` = {escaped}"
+        f" UNION SELECT `entity` FROM `tabDrive Permission`"
+        f" WHERE `user` IN ({principal_list(user)}) AND `read` = 1 AND `deny` = 0))"
+    )
 
 
 @common_filters
 def filter_drive_favourite(user):
-	return f"""(`tabDrive Favourite`.`user` = {frappe.db.escape(user)})"""
+    return f"""(`tabDrive Favourite`.`user` = {frappe.db.escape(user)})"""
 
 
 @common_filters
 def filter_drive_recent(user):
-	return f"""(`tabDrive Entity Log`.`user` = {frappe.db.escape(user)})"""
+    return f"""(`tabDrive Entity Log`.`user` = {frappe.db.escape(user)})"""
 
 
 @common_filters
 def filter_drive_notif(user):
-	user = frappe.db.escape(user)
-	return f"(`tabDrive Notification`.to_user = {user} or `tabDrive Notification`.from_user = {user})"
+    user = frappe.db.escape(user)
+    return f"(`tabDrive Notification`.to_user = {user} or `tabDrive Notification`.from_user = {user})"

--- a/suite/drive/utils/users.py
+++ b/suite/drive/utils/users.py
@@ -7,86 +7,86 @@ from frappe.utils import now
 
 
 def mark_as_viewed(entity):
-	if (
-		frappe.session.user == "Guest"
-		or not frappe.has_permission(doctype="Drive Entity Log", ptype="create", user=frappe.session.user)
-		or entity.is_folder
-	):
-		return
+    if (
+        frappe.session.user == "Guest"
+        or not frappe.has_permission(doctype="Drive Entity Log", ptype="create", user=frappe.session.user)
+        or entity.is_folder
+    ):
+        return
 
-	entity_log = frappe.db.get_value(
-		"Drive Entity Log", {"entity_name": entity.name, "user": frappe.session.user}
-	)
-	if entity_log:
-		frappe.db.set_value(
-			"Drive Entity Log",
-			entity_log,
-			"last_interaction",
-			now(),
-			update_modified=False,
-		)
-		return
-	doc = frappe.new_doc("Drive Entity Log")
-	doc.entity_name = entity.name
-	doc.user = frappe.session.user
-	doc.last_interaction = now()
-	doc.insert()
-	return doc
+    entity_log = frappe.db.get_value(
+        "Drive Entity Log", {"entity_name": entity.name, "user": frappe.session.user}
+    )
+    if entity_log:
+        frappe.db.set_value(
+            "Drive Entity Log",
+            entity_log,
+            "last_interaction",
+            now(),
+            update_modified=False,
+        )
+        return
+    doc = frappe.new_doc("Drive Entity Log")
+    doc.entity_name = entity.name
+    doc.user = frappe.session.user
+    doc.last_interaction = now()
+    doc.insert()
+    return doc
 
 
 def get_country_info():
-	ip = frappe.local.request_ip
+    ip = frappe.local.request_ip
 
-	def _get_country_info():
-		fields = [
-			"status",
-			"message",
-			"continent",
-			"continentCode",
-			"country",
-			"countryCode",
-			"region",
-			"regionName",
-			"city",
-			"district",
-			"zip",
-			"lat",
-			"lon",
-			"timezone",
-			"offset",
-			"currency",
-			"isp",
-			"org",
-			"as",
-			"asname",
-			"reverse",
-			"mobile",
-			"proxy",
-			"hosting",
-			"query",
-		]
+    def _get_country_info():
+        fields = [
+            "status",
+            "message",
+            "continent",
+            "continentCode",
+            "country",
+            "countryCode",
+            "region",
+            "regionName",
+            "city",
+            "district",
+            "zip",
+            "lat",
+            "lon",
+            "timezone",
+            "offset",
+            "currency",
+            "isp",
+            "org",
+            "as",
+            "asname",
+            "reverse",
+            "mobile",
+            "proxy",
+            "hosting",
+            "query",
+        ]
 
-		try:
-			res = requests.get(f"https://pro.ip-api.com/json/{ip}?fields={','.join(fields)}")
-			data = res.json()
-			if data.get("status") != "fail":
-				return data
-		except Exception:
-			pass
+        try:
+            res = requests.get(f"https://pro.ip-api.com/json/{ip}?fields={','.join(fields)}")
+            data = res.json()
+            if data.get("status") != "fail":
+                return data
+        except Exception:
+            pass
 
-		return {}
+        return {}
 
-	return frappe.cache().hget("ip_country_map", ip, generator=_get_country_info)
+    return frappe.cache().hget("ip_country_map", ip, generator=_get_country_info)
 
 
 def create_drive_settings(user, method: str | None = None) -> None:
-	"""Create Drive Settings and the private user folder for a newly created User."""
-	from suite.drive.utils import get_user_folder
+    """Create Drive Settings and the private user folder for a newly created User."""
+    from suite.drive.utils import get_user_folder
 
-	if user.flags.get("skip_drive_setup"):
-		return
+    if user.flags.get("skip_drive_setup"):
+        return
 
-	if not user.name or user.name in ("Guest", "Administrator"):
-		return
+    if not user.name or user.name in ("Guest", "Administrator"):
+        return
 
-	get_user_folder(user.name)
+    get_user_folder(user.name)

--- a/suite/drive/www/drive.py
+++ b/suite/drive/www/drive.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import frappe
 
 no_cache = 1

--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -14,12 +14,12 @@ app_license = "agpl-3.0"
 # Apps screen / App switcher
 # ============================================================================
 add_to_apps_screen = [
-	{
-		"name": "suite",
-		"logo": "/assets/suite/frontend/logo.svg",
-		"title": "Frappe Suite",
-		"route": "/suite",
-	},
+    {
+        "name": "suite",
+        "logo": "/assets/suite/frontend/logo.svg",
+        "title": "Frappe Suite",
+        "route": "/suite",
+    },
 ]
 
 # ============================================================================
@@ -45,70 +45,70 @@ sqlite_search = ["suite.writer.search.WriterSearch"]
 # Both the bare prefix and the sub-path are mapped so deep links + launcher
 # links (which use the bare prefix) both hit the SPA on first load.
 website_route_rules = [
-	{"from_route": "/suite/<path:app_path>", "to_route": "suite"},
-	{"from_route": "/drive", "to_route": "suite"},
-	{"from_route": "/drive/<path:app_path>", "to_route": "suite"},
-	{"from_route": "/slides", "to_route": "suite"},
-	{"from_route": "/slides/<path:app_path>", "to_route": "suite"},
-	{"from_route": "/sheets", "to_route": "suite"},
-	{"from_route": "/sheets/<path:app_path>", "to_route": "suite"},
-	{"from_route": "/writer", "to_route": "suite"},
-	{"from_route": "/writer/<path:app_path>", "to_route": "suite"},
-	{"from_route": "/mail", "to_route": "suite"},
-	{"from_route": "/mail/<path:app_path>", "to_route": "suite"},
-	{"from_route": "/meet", "to_route": "suite"},
-	{"from_route": "/meet/<path:app_path>", "to_route": "suite"},
-	{"from_route": "/calendar", "to_route": "suite"},
-	{"from_route": "/calendar/<path:app_path>", "to_route": "suite"},
+    {"from_route": "/suite/<path:app_path>", "to_route": "suite"},
+    {"from_route": "/drive", "to_route": "suite"},
+    {"from_route": "/drive/<path:app_path>", "to_route": "suite"},
+    {"from_route": "/slides", "to_route": "suite"},
+    {"from_route": "/slides/<path:app_path>", "to_route": "suite"},
+    {"from_route": "/sheets", "to_route": "suite"},
+    {"from_route": "/sheets/<path:app_path>", "to_route": "suite"},
+    {"from_route": "/writer", "to_route": "suite"},
+    {"from_route": "/writer/<path:app_path>", "to_route": "suite"},
+    {"from_route": "/mail", "to_route": "suite"},
+    {"from_route": "/mail/<path:app_path>", "to_route": "suite"},
+    {"from_route": "/meet", "to_route": "suite"},
+    {"from_route": "/meet/<path:app_path>", "to_route": "suite"},
+    {"from_route": "/calendar", "to_route": "suite"},
+    {"from_route": "/calendar/<path:app_path>", "to_route": "suite"},
 ]
 
 # mail — website redirects
 website_redirects = [
-	{
-		"source": "/auth/validate",
-		"target": "/api/method/suite.mail.api.auth.validate",
-		"redirect_http_status": 307,
-	},
-	{
-		"source": "/outbound/upload",
-		"target": "/api/method/suite.mail.api.outbound.upload_attachment",
-		"redirect_http_status": 307,
-	},
-	{
-		"source": "/outbound/send",
-		"target": "/api/method/suite.mail.api.outbound.send",
-		"redirect_http_status": 307,
-	},
-	{
-		"source": "/outbound/send-raw",
-		"target": "/api/method/suite.mail.api.outbound.send_raw",
-		"redirect_http_status": 307,
-	},
-	{
-		"source": "/inbound/blob",
-		"target": "/api/method/suite.mail.api.inbound.fetch_blob",
-		"redirect_http_status": 307,
-	},
-	{
-		"source": "/inbound/pull",
-		"target": "/api/method/suite.mail.api.inbound.pull",
-		"redirect_http_status": 307,
-	},
-	{
-		"source": "/inbound/pull-raw",
-		"target": "/api/method/suite.mail.api.inbound.pull_raw",
-		"redirect_http_status": 307,
-	},
-	{
-		"source": "/spamd/scan",
-		"target": "/api/method/suite.mail.api.spamd.scan",
-		"redirect_http_status": 307,
-	},
-	{
-		"source": "/spamd/score",
-		"target": "/api/method/suite.mail.api.spamd.get_spam_score",
-		"redirect_http_status": 307,
-	},
+    {
+        "source": "/auth/validate",
+        "target": "/api/method/suite.mail.api.auth.validate",
+        "redirect_http_status": 307,
+    },
+    {
+        "source": "/outbound/upload",
+        "target": "/api/method/suite.mail.api.outbound.upload_attachment",
+        "redirect_http_status": 307,
+    },
+    {
+        "source": "/outbound/send",
+        "target": "/api/method/suite.mail.api.outbound.send",
+        "redirect_http_status": 307,
+    },
+    {
+        "source": "/outbound/send-raw",
+        "target": "/api/method/suite.mail.api.outbound.send_raw",
+        "redirect_http_status": 307,
+    },
+    {
+        "source": "/inbound/blob",
+        "target": "/api/method/suite.mail.api.inbound.fetch_blob",
+        "redirect_http_status": 307,
+    },
+    {
+        "source": "/inbound/pull",
+        "target": "/api/method/suite.mail.api.inbound.pull",
+        "redirect_http_status": 307,
+    },
+    {
+        "source": "/inbound/pull-raw",
+        "target": "/api/method/suite.mail.api.inbound.pull_raw",
+        "redirect_http_status": 307,
+    },
+    {
+        "source": "/spamd/scan",
+        "target": "/api/method/suite.mail.api.spamd.scan",
+        "redirect_http_status": 307,
+    },
+    {
+        "source": "/spamd/score",
+        "target": "/api/method/suite.mail.api.spamd.get_spam_score",
+        "redirect_http_status": 307,
+    },
 ]
 
 # Framework File permission logic is fully replaced by Drive's
@@ -118,188 +118,188 @@ ignore_file_permissions = True
 # Permissions — permission_query_conditions (deep-merged union; no key clashes)
 # ============================================================================
 permission_query_conditions = {
-	# drive
-	"File": "suite.drive.utils.overrides.filter_file",
-	"Drive Permission": "suite.drive.utils.overrides.filter_drive_permission",
-	"Drive Settings": "suite.drive.utils.overrides.filter_drive_settings",
-	"Drive User Invitation": "suite.drive.utils.overrides.filter_drive_invitation",
-	"Drive Entity Activity Log": "suite.drive.utils.overrides.filter_activity_log",
-	"Drive Favourite": "suite.drive.utils.overrides.filter_drive_favourite",
-	"Drive Entity Log": "suite.drive.utils.overrides.filter_drive_recent",
-	"Drive Notification": "suite.drive.utils.overrides.filter_drive_notif",
-	# slides
-	"Presentation": "suite.slides.doctype.presentation.presentation.get_permission_query_conditions",
-	# writer
-	"Writer Template": "suite.writer.overrides.filter_templates",
-	"Writer Document": "suite.writer.overrides.document_query_conditions",
-	"Writer Version": "suite.writer.overrides.version_query_conditions",
-	# sheets
-	"Sheet Op Log": "suite.sheets.permissions.sheet_op_log_query",
-	"Sheet Snapshot": "suite.sheets.permissions.sheet_snapshot_query",
-	# meet
-	"Meet Room": "suite.meet.doctype.meet_room.meet_room.get_permission_query_conditions",
-	# mail
-	"JMAP Account": "suite.mail.doctype.jmap_account.jmap_account.get_permission_query_condition",
-	"Mail Sync History": "suite.mail.doctype.mail_sync_history.mail_sync_history.get_permission_query_condition",
-	"Mailbox Settings": "suite.mail.doctype.mailbox_settings.mailbox_settings.get_permission_query_condition",
-	"Screened Email Address": "suite.mail.doctype.screened_email_address.screened_email_address.get_permission_query_condition",
+    # drive
+    "File": "suite.drive.utils.overrides.filter_file",
+    "Drive Permission": "suite.drive.utils.overrides.filter_drive_permission",
+    "Drive Settings": "suite.drive.utils.overrides.filter_drive_settings",
+    "Drive User Invitation": "suite.drive.utils.overrides.filter_drive_invitation",
+    "Drive Entity Activity Log": "suite.drive.utils.overrides.filter_activity_log",
+    "Drive Favourite": "suite.drive.utils.overrides.filter_drive_favourite",
+    "Drive Entity Log": "suite.drive.utils.overrides.filter_drive_recent",
+    "Drive Notification": "suite.drive.utils.overrides.filter_drive_notif",
+    # slides
+    "Presentation": "suite.slides.doctype.presentation.presentation.get_permission_query_conditions",
+    # writer
+    "Writer Template": "suite.writer.overrides.filter_templates",
+    "Writer Document": "suite.writer.overrides.document_query_conditions",
+    "Writer Version": "suite.writer.overrides.version_query_conditions",
+    # sheets
+    "Sheet Op Log": "suite.sheets.permissions.sheet_op_log_query",
+    "Sheet Snapshot": "suite.sheets.permissions.sheet_snapshot_query",
+    # meet
+    "Meet Room": "suite.meet.doctype.meet_room.meet_room.get_permission_query_conditions",
+    # mail
+    "JMAP Account": "suite.mail.doctype.jmap_account.jmap_account.get_permission_query_condition",
+    "Mail Sync History": "suite.mail.doctype.mail_sync_history.mail_sync_history.get_permission_query_condition",
+    "Mailbox Settings": "suite.mail.doctype.mailbox_settings.mailbox_settings.get_permission_query_condition",
+    "Screened Email Address": "suite.mail.doctype.screened_email_address.screened_email_address.get_permission_query_condition",
 }
 
 # ============================================================================
 # Permissions — has_permission (deep-merged union; no key clashes)
 # ============================================================================
 has_permission = {
-	# drive
-	"File": "suite.drive.api.permissions.user_has_permission",
-	"Drive Permission": "suite.drive.api.permissions.drive_permission_has_permission",
-	"Drive Entity Activity Log": "suite.drive.api.permissions.activity_log_has_permission",
-	"Drive Settings": "suite.drive.api.permissions.drive_settings_has_permission",
-	"Drive User Invitation": "suite.drive.api.permissions.drive_invitation_has_permission",
-	# slides
-	"Presentation": "suite.slides.doctype.presentation.presentation.has_permission",
-	# writer
-	"Writer Document": "suite.drive.overrides.file.content_has_permission",
-	"Writer Version": "suite.writer.overrides.version_has_permission",
-	"Writer Template": "suite.writer.overrides.template_has_permission",
-	# sheets
-	"Sheet Op Log": "suite.sheets.permissions.sheet_op_log_has_permission",
-	"Sheet Snapshot": "suite.sheets.permissions.sheet_snapshot_has_permission",
-	# meet
-	"Meet Room": "suite.meet.doctype.meet_room.meet_room.has_permission",
-	# mail
-	"JMAP Account": "suite.mail.doctype.jmap_account.jmap_account.has_permission",
-	"Address Book": "suite.mail.doctype.address_book.address_book.has_permission",
-	"Calendar": "suite.calendar.doctype.calendar.calendar.has_permission",
-	"Calendar Event": "suite.calendar.doctype.calendar_event.calendar_event.has_permission",
-	"Contact Card": "suite.mail.doctype.contact_card.contact_card.has_permission",
-	"Event Notification": "suite.calendar.doctype.event_notification.event_notification.has_permission",
-	"Identity": "suite.mail.doctype.identity.identity.has_permission",
-	"Mail Sync History": "suite.mail.doctype.mail_sync_history.mail_sync_history.has_permission",
-	"Mailbox": "suite.mail.doctype.mailbox.mailbox.has_permission",
-	"Mailbox Settings": "suite.mail.doctype.mailbox_settings.mailbox_settings.has_permission",
-	"Participant Identity": "suite.mail.doctype.participant_identity.participant_identity.has_permission",
-	"Push Subscription": "suite.mail.doctype.push_subscription.push_subscription.has_permission",
-	"Quota": "suite.mail.doctype.quota.quota.has_permission",
-	"Screened Email Address": "suite.mail.doctype.screened_email_address.screened_email_address.has_permission",
-	"Sieve Script": "suite.mail.doctype.sieve_script.sieve_script.has_permission",
-	"Vacation Response": "suite.mail.doctype.vacation_response.vacation_response.has_permission",
+    # drive
+    "File": "suite.drive.api.permissions.user_has_permission",
+    "Drive Permission": "suite.drive.api.permissions.drive_permission_has_permission",
+    "Drive Entity Activity Log": "suite.drive.api.permissions.activity_log_has_permission",
+    "Drive Settings": "suite.drive.api.permissions.drive_settings_has_permission",
+    "Drive User Invitation": "suite.drive.api.permissions.drive_invitation_has_permission",
+    # slides
+    "Presentation": "suite.slides.doctype.presentation.presentation.has_permission",
+    # writer
+    "Writer Document": "suite.drive.overrides.file.content_has_permission",
+    "Writer Version": "suite.writer.overrides.version_has_permission",
+    "Writer Template": "suite.writer.overrides.template_has_permission",
+    # sheets
+    "Sheet Op Log": "suite.sheets.permissions.sheet_op_log_has_permission",
+    "Sheet Snapshot": "suite.sheets.permissions.sheet_snapshot_has_permission",
+    # meet
+    "Meet Room": "suite.meet.doctype.meet_room.meet_room.has_permission",
+    # mail
+    "JMAP Account": "suite.mail.doctype.jmap_account.jmap_account.has_permission",
+    "Address Book": "suite.mail.doctype.address_book.address_book.has_permission",
+    "Calendar": "suite.calendar.doctype.calendar.calendar.has_permission",
+    "Calendar Event": "suite.calendar.doctype.calendar_event.calendar_event.has_permission",
+    "Contact Card": "suite.mail.doctype.contact_card.contact_card.has_permission",
+    "Event Notification": "suite.calendar.doctype.event_notification.event_notification.has_permission",
+    "Identity": "suite.mail.doctype.identity.identity.has_permission",
+    "Mail Sync History": "suite.mail.doctype.mail_sync_history.mail_sync_history.has_permission",
+    "Mailbox": "suite.mail.doctype.mailbox.mailbox.has_permission",
+    "Mailbox Settings": "suite.mail.doctype.mailbox_settings.mailbox_settings.has_permission",
+    "Participant Identity": "suite.mail.doctype.participant_identity.participant_identity.has_permission",
+    "Push Subscription": "suite.mail.doctype.push_subscription.push_subscription.has_permission",
+    "Quota": "suite.mail.doctype.quota.quota.has_permission",
+    "Screened Email Address": "suite.mail.doctype.screened_email_address.screened_email_address.has_permission",
+    "Sieve Script": "suite.mail.doctype.sieve_script.sieve_script.has_permission",
+    "Vacation Response": "suite.mail.doctype.vacation_response.vacation_response.has_permission",
 }
 
 # ============================================================================
 # Override standard doctype classes (drive)
 # ============================================================================
 override_doctype_class = {
-	"File": "suite.drive.overrides.file.File",
+    "File": "suite.drive.overrides.file.File",
 }
 
 # ============================================================================
 # Override whitelisted methods (mail)
 # ============================================================================
 override_whitelisted_methods = {
-	"frappe.core.doctype.user.user.update_password": "suite.mail.events.update_password",
-	# Auth
-	"mail.api.auth.validate": "suite.mail.api.auth.validate",
-	# Outbound
-	"mail.api.outbound.upload_attachment": "suite.mail.api.outbound.upload_attachment",
-	"mail.api.outbound.send": "suite.mail.api.outbound.send",
-	"mail.api.outbound.send_raw": "suite.mail.api.outbound.send_raw",
-	# Inbound
-	"mail.api.inbound.fetch_blob": "suite.mail.api.inbound.fetch_blob",
-	"mail.api.inbound.pull": "suite.mail.api.inbound.pull",
-	"mail.api.inbound.pull_raw": "suite.mail.api.inbound.pull_raw",
-	# SpamD
-	"mail.api.spamd.scan": "suite.mail.api.spamd.scan",
-	"mail.api.spamd.get_spam_score": "suite.mail.api.spamd.get_spam_score",
-	# writer — embed URLs baked into documents created by the standalone app
-	"writer.api.embed.get": "suite.writer.api.embed.get",
+    "frappe.core.doctype.user.user.update_password": "suite.mail.events.update_password",
+    # Auth
+    "mail.api.auth.validate": "suite.mail.api.auth.validate",
+    # Outbound
+    "mail.api.outbound.upload_attachment": "suite.mail.api.outbound.upload_attachment",
+    "mail.api.outbound.send": "suite.mail.api.outbound.send",
+    "mail.api.outbound.send_raw": "suite.mail.api.outbound.send_raw",
+    # Inbound
+    "mail.api.inbound.fetch_blob": "suite.mail.api.inbound.fetch_blob",
+    "mail.api.inbound.pull": "suite.mail.api.inbound.pull",
+    "mail.api.inbound.pull_raw": "suite.mail.api.inbound.pull_raw",
+    # SpamD
+    "mail.api.spamd.scan": "suite.mail.api.spamd.scan",
+    "mail.api.spamd.get_spam_score": "suite.mail.api.spamd.get_spam_score",
+    # writer — embed URLs baked into documents created by the standalone app
+    "writer.api.embed.get": "suite.writer.api.embed.get",
 }
 
 # ============================================================================
 # Document Events (deep-merged; per-doctype/per-event handler lists combined)
 # ============================================================================
 doc_events = {
-	"User Group": {
-		"on_update": "suite.drive.utils.clear_user_group_cache",
-		"on_trash": "suite.drive.utils.clear_user_group_cache",
-	},
-	"Presentation": {
-		"on_update": ["suite.drive.overrides.file.sync_content_file"],
-		"on_trash": ["suite.drive.overrides.file.sync_content_file"],
-	},
-	"Sheet": {
-		# Same content-app wiring as Presentation: on_update mirrors title +
-		# soft-trash onto the backing Drive File, on_trash removes it on hard
-		# delete. Sheets routes its rename and trash/restore through doc.save so
-		# these fire; the high-frequency cell-data autosave stays on db.set_value
-		# (Drive doesn't track cell data) and deliberately fires nothing.
-		"on_update": ["suite.drive.overrides.file.sync_content_file"],
-		"on_trash": ["suite.drive.overrides.file.sync_content_file"],
-	},
-	"User": {
-		# Roles are assigned before insert so they are present when Frappe's
-		# User.validate runs — assigning them after insert triggers a spurious
-		# "No Roles Specified" warning and leaves user_type mis-resolved.
-		"before_insert": [
-			"suite.utils.user.assign_suite_role",
-		],
-		"after_insert": [
-			"suite.drive.utils.users.create_drive_settings",
-			"suite.mail.events.create_user_settings",
-		],
-		"on_update": [
-			"suite.mail.events.update_account_password",
-			"suite.mail.events.clear_sessions_on_disable",
-			"suite.mail.events.apply_disabled_account_role",
-			"suite.mail.events.remove_disabled_account_role",
-		],
-		"on_trash": [
-			"suite.mail.events.delete_account",
-			"suite.mail.events.delete_user_accounts",
-			"suite.mail.events.delete_user_settings",
-		],
-	},
+    "User Group": {
+        "on_update": "suite.drive.utils.clear_user_group_cache",
+        "on_trash": "suite.drive.utils.clear_user_group_cache",
+    },
+    "Presentation": {
+        "on_update": ["suite.drive.overrides.file.sync_content_file"],
+        "on_trash": ["suite.drive.overrides.file.sync_content_file"],
+    },
+    "Sheet": {
+        # Same content-app wiring as Presentation: on_update mirrors title +
+        # soft-trash onto the backing Drive File, on_trash removes it on hard
+        # delete. Sheets routes its rename and trash/restore through doc.save so
+        # these fire; the high-frequency cell-data autosave stays on db.set_value
+        # (Drive doesn't track cell data) and deliberately fires nothing.
+        "on_update": ["suite.drive.overrides.file.sync_content_file"],
+        "on_trash": ["suite.drive.overrides.file.sync_content_file"],
+    },
+    "User": {
+        # Roles are assigned before insert so they are present when Frappe's
+        # User.validate runs — assigning them after insert triggers a spurious
+        # "No Roles Specified" warning and leaves user_type mis-resolved.
+        "before_insert": [
+            "suite.utils.user.assign_suite_role",
+        ],
+        "after_insert": [
+            "suite.drive.utils.users.create_drive_settings",
+            "suite.mail.events.create_user_settings",
+        ],
+        "on_update": [
+            "suite.mail.events.update_account_password",
+            "suite.mail.events.clear_sessions_on_disable",
+            "suite.mail.events.apply_disabled_account_role",
+            "suite.mail.events.remove_disabled_account_role",
+        ],
+        "on_trash": [
+            "suite.mail.events.delete_account",
+            "suite.mail.events.delete_user_accounts",
+            "suite.mail.events.delete_user_settings",
+        ],
+    },
 }
 
 # ============================================================================
 # Scheduled Tasks (per-frequency lists combined; cron keys de-duplicated)
 # ============================================================================
 scheduler_events = {
-	"daily": [
-		# drive
-		"suite.drive.api.scripts.auto_delete_from_trash",
-		"suite.drive.api.scripts.clear_deleted_files",
-		# sheets
-		"suite.sheets.versioning.tasks.rollup_snapshots",
-		"suite.sheets.versioning.tasks.truncate_op_log",
-		"suite.sheets.trash.purge_trashed_sheets",
-		# mail
-		"suite.mail.doctype.jmap_account.jmap_account.delete_orphaned_jmap_accounts",
-		"suite.mail.doctype.mail_exchange.mail_exchange.clean_import_export_directories",
-		"suite.mail.doctype.push_subscription.push_subscription.renew_expiring_push_subscriptions",
-		"suite.calendar.doctype.calendar_exchange.calendar_exchange.clean_calendar_import_export_directories",
-		"suite.mail.doctype.contacts_exchange.contacts_exchange.clean_contacts_import_export_directories",
-	],
-	"hourly": [
-		# drive
-		"suite.drive.api.scripts.clear_download_archives",
-		# mail
-		"suite.mail.doctype.mail_exchange.mail_exchange.retry_stuck_mail_exchanges",
-		"suite.calendar.doctype.calendar_exchange.calendar_exchange.retry_stuck_calendar_exchanges",
-		"suite.mail.doctype.contacts_exchange.contacts_exchange.retry_stuck_contacts_exchanges",
-	],
-	"hourly_long": [
-		# mail
-		"suite.mail.doctype.mail_message.mail_message.schedule_fetch_changes",
-	],
-	"cron": {
-		"*/5 * * * *": [
-			# mail
-			"suite.mail.doctype.server_job.server_job.retry_failed_jobs",
-			"suite.mail.doctype.server_deployment.server_deployment.retry_failed_deployments",
-			"suite.mail.doctype.server_ansible_play.server_ansible_play.retry_failed_ansible_plays",
-			"suite.mail.doctype.mail_queue.mail_queue.enqueue_process_pending_emails",
-		],
-	},
+    "daily": [
+        # drive
+        "suite.drive.api.scripts.auto_delete_from_trash",
+        "suite.drive.api.scripts.clear_deleted_files",
+        # sheets
+        "suite.sheets.versioning.tasks.rollup_snapshots",
+        "suite.sheets.versioning.tasks.truncate_op_log",
+        "suite.sheets.trash.purge_trashed_sheets",
+        # mail
+        "suite.mail.doctype.jmap_account.jmap_account.delete_orphaned_jmap_accounts",
+        "suite.mail.doctype.mail_exchange.mail_exchange.clean_import_export_directories",
+        "suite.mail.doctype.push_subscription.push_subscription.renew_expiring_push_subscriptions",
+        "suite.calendar.doctype.calendar_exchange.calendar_exchange.clean_calendar_import_export_directories",
+        "suite.mail.doctype.contacts_exchange.contacts_exchange.clean_contacts_import_export_directories",
+    ],
+    "hourly": [
+        # drive
+        "suite.drive.api.scripts.clear_download_archives",
+        # mail
+        "suite.mail.doctype.mail_exchange.mail_exchange.retry_stuck_mail_exchanges",
+        "suite.calendar.doctype.calendar_exchange.calendar_exchange.retry_stuck_calendar_exchanges",
+        "suite.mail.doctype.contacts_exchange.contacts_exchange.retry_stuck_contacts_exchanges",
+    ],
+    "hourly_long": [
+        # mail
+        "suite.mail.doctype.mail_message.mail_message.schedule_fetch_changes",
+    ],
+    "cron": {
+        "*/5 * * * *": [
+            # mail
+            "suite.mail.doctype.server_job.server_job.retry_failed_jobs",
+            "suite.mail.doctype.server_deployment.server_deployment.retry_failed_deployments",
+            "suite.mail.doctype.server_ansible_play.server_ansible_play.retry_failed_ansible_plays",
+            "suite.mail.doctype.mail_queue.mail_queue.enqueue_process_pending_emails",
+        ],
+    },
 }
 
 # ============================================================================
@@ -321,16 +321,16 @@ after_request = "suite.drive.api.product.after_request"
 # Fixtures (concatenated; identical entries de-duplicated)
 # ============================================================================
 fixtures = [
-	# drive
-	{"dt": "Custom Field", "filters": [["dt", "=", "File"]]},
-	{"dt": "Property Setter", "filters": [["doc_type", "=", "File"]]},
-	{"dt": "Role", "filters": [["role_name", "like", "Drive %"]]},
-	# slides
-	{"dt": "Presentation", "filters": [["is_template", "=", "1"]]},
-	# meet
-	{"dt": "Role", "filters": [["role_name", "like", "Meet %"]]},
-	# mail / calendar
-	{"dt": "Role", "filters": [["role_name", "like", "Suite %"]]},
+    # drive
+    {"dt": "Custom Field", "filters": [["dt", "=", "File"]]},
+    {"dt": "Property Setter", "filters": [["doc_type", "=", "File"]]},
+    {"dt": "Role", "filters": [["role_name", "like", "Drive %"]]},
+    # slides
+    {"dt": "Presentation", "filters": [["is_template", "=", "1"]]},
+    # meet
+    {"dt": "Role", "filters": [["role_name", "like", "Meet %"]]},
+    # mail / calendar
+    {"dt": "Role", "filters": [["role_name", "like", "Suite %"]]},
 ]
 
 # ============================================================================
@@ -341,23 +341,23 @@ signup_form_template = "templates/signup.html"
 
 # mail — link integrity on delete
 ignore_links_on_delete = [
-	# drive
-	"Drive Settings",
-	# mail
-	"Mail Account Request",
-	"Mail Domain Request",
-	"Server Job",
-	"Server Ansible Play",
-	"Server Deployment",
-	"JMAP Account",
-	"User Account",
-	"Screened Email Address",
-	"Mail Exchange",
-	"Mail Queue",
-	"Mail Signature",
-	"Mail Sync History",
-	"Mailbox Settings",
-	"User Settings",
+    # drive
+    "Drive Settings",
+    # mail
+    "Mail Account Request",
+    "Mail Domain Request",
+    "Server Job",
+    "Server Ansible Play",
+    "Server Deployment",
+    "JMAP Account",
+    "User Account",
+    "Screened Email Address",
+    "Mail Exchange",
+    "Mail Queue",
+    "Mail Signature",
+    "Mail Sync History",
+    "Mailbox Settings",
+    "User Settings",
 ]
 
 # mail — log retention (only definer; kept as dict)
@@ -371,48 +371,48 @@ require_type_annotated_api_methods = True
 # ============================================================================
 # drive
 ALLOWED_PATHS = [
-	"/api/method/create-site-migration",
-	"/api/method/find-my-sites",
-	"/api/method/frappe.realtime.get_user_info",
-	"/api/method/frappe.realtime.can_subscribe_doc",
-	"/api/method/frappe.realtime.can_subscribe_doctype",
-	"/api/method/frappe.realtime.has_permission",
-	"/api/method/frappe.www.login.login_via_frappe",
-	"/api/method/frappe.integrations.oauth2.authorize",
-	"/api/method/frappe.integrations.oauth2.approve",
-	"/api/method/frappe.integrations.oauth2.get_token",
-	"/api/method/frappe.integrations.oauth2.openid_profile",
-	"/api/method/frappe.website.doctype.web_page_view.web_page_view.make_view_log",
-	"/api/method/ping",
-	"/api/method/login",
-	"/api/method/logout",
-	"/api/method/upload_file",
-	"/api/method/frappe.search.web_search",
-	"/api/method/frappe.email.queue.unsubscribe",
-	"/api/method/frappe.website.doctype.web_form.web_form.accept",
-	"/api/method/frappe.core.doctype.user.user.test_password_strength",
-	"/api/method/frappe.core.doctype.user.user.update_password",
+    "/api/method/create-site-migration",
+    "/api/method/find-my-sites",
+    "/api/method/frappe.realtime.get_user_info",
+    "/api/method/frappe.realtime.can_subscribe_doc",
+    "/api/method/frappe.realtime.can_subscribe_doctype",
+    "/api/method/frappe.realtime.has_permission",
+    "/api/method/frappe.www.login.login_via_frappe",
+    "/api/method/frappe.integrations.oauth2.authorize",
+    "/api/method/frappe.integrations.oauth2.approve",
+    "/api/method/frappe.integrations.oauth2.get_token",
+    "/api/method/frappe.integrations.oauth2.openid_profile",
+    "/api/method/frappe.website.doctype.web_page_view.web_page_view.make_view_log",
+    "/api/method/ping",
+    "/api/method/login",
+    "/api/method/logout",
+    "/api/method/upload_file",
+    "/api/method/frappe.search.web_search",
+    "/api/method/frappe.email.queue.unsubscribe",
+    "/api/method/frappe.website.doctype.web_form.web_form.accept",
+    "/api/method/frappe.core.doctype.user.user.test_password_strength",
+    "/api/method/frappe.core.doctype.user.user.update_password",
 ]
 
 ALLOWED_WILDCARD_PATHS = [
-	"/api/method/frappe.integrations.oauth2_logins.",
-	"/api/method/suite.mail.api.",
-	# mail — backward-compatible prefix for the standalone `mail` app's
-	# endpoints still called by Frappe Framework (see override_whitelisted_methods).
-	"/api/method/mail.api.",
-	"/api/method/suite.calendar.api.",
-	"/api/method/suite.meet.api.",
-	"/api/method/suite.drive.api.",
-	"/api/method/suite.writer.api.",
-	# writer — backward-compatible prefix for embed URLs stored in old documents
-	# (see override_whitelisted_methods).
-	"/api/method/writer.api.",
-	"/api/method/suite.slides.api.",
-	"/api/method/suite.sheets.api.",
+    "/api/method/frappe.integrations.oauth2_logins.",
+    "/api/method/suite.mail.api.",
+    # mail — backward-compatible prefix for the standalone `mail` app's
+    # endpoints still called by Frappe Framework (see override_whitelisted_methods).
+    "/api/method/mail.api.",
+    "/api/method/suite.calendar.api.",
+    "/api/method/suite.meet.api.",
+    "/api/method/suite.drive.api.",
+    "/api/method/suite.writer.api.",
+    # writer — backward-compatible prefix for embed URLs stored in old documents
+    # (see override_whitelisted_methods).
+    "/api/method/writer.api.",
+    "/api/method/suite.slides.api.",
+    "/api/method/suite.sheets.api.",
 ]
 
 DENIED_PATHS = []
 
 DENIED_WILDCARD_PATHS = [
-	"/api/",
+    "/api/",
 ]

--- a/suite/mail/ansible.py
+++ b/suite/mail/ansible.py
@@ -31,7 +31,7 @@ class Ansible:
         self._create_play_record()
 
     @classmethod
-    def from_play(cls, play_name: str) -> "Ansible":
+    def from_play(cls, play_name: str) -> Ansible:
         """Create an Ansible instance from an existing Server Ansible Play record."""
 
         pdoc = frappe.get_doc("Server Ansible Play", play_name)
@@ -126,7 +126,7 @@ class Ansible:
 
         return plays[0]
 
-    def run(self, quiet: bool = True) -> "ServerAnsiblePlay":
+    def run(self, quiet: bool = True) -> ServerAnsiblePlay:
         """Run the playbook using ansible-runner and track its progress."""
 
         server = frappe.get_doc("Mail Server", self.server)

--- a/suite/mail/ansible.py
+++ b/suite/mail/ansible.py
@@ -13,346 +13,346 @@ from frappe.utils import now, time_diff_in_seconds
 from suite.utils import reconnect_on_failure
 
 if TYPE_CHECKING:
-	from suite.mail.doctype.server_ansible_play.server_ansible_play import ServerAnsiblePlay
+    from suite.mail.doctype.server_ansible_play.server_ansible_play import ServerAnsiblePlay
 
 
 class Ansible:
-	"""Ansible class to run playbooks and track their progress."""
-
-	def __init__(
-		self,
-		server: str,
-		playbook: str,
-		variables: dict[str | Any] | None = None,
-	) -> None:
-		self.server = server
-		self.playbook = playbook
-		self.variables = variables or {}
-		self._create_play_record()
-
-	@classmethod
-	def from_play(cls, play_name: str) -> "Ansible":
-		"""Create an Ansible instance from an existing Server Ansible Play record."""
-
-		pdoc = frappe.get_doc("Server Ansible Play", play_name)
-
-		self = cls.__new__(cls)
-		self.play = pdoc.name
-		self.server = pdoc.server
-		self.playbook = pdoc.playbook
-
-		self.variables = {}
-		for variable in pdoc.variables:
-			try:
-				self.variables[variable.key_] = json.loads(variable.value)
-			except (TypeError, json.JSONDecodeError):
-				self.variables[variable.key_] = variable.value
-
-		self.tasks = {}
-		if tasks := frappe.db.get_all(
-			"Server Ansible Play Task",
-			filters={"play": self.play},
-			fields=["task", "name"],
-			order_by="creation asc",
-			as_list=True,
-		):
-			self.tasks = frappe._dict(tasks)
-		return self
-
-	@property
-	def playbook_path(self) -> str:
-		"""Returns the absolute path to the playbook."""
-
-		return os.path.join(
-			frappe.get_app_path("suite", "mail", "utils", "ansible", "playbooks"), self.playbook
-		)
-
-	def _create_play_record(self) -> None:
-		"""Creates a Server Ansible Play record and associated Server Ansible Play Task records."""
-
-		if hasattr(self, "play") and self.play:
-			return
-
-		play = self._get_play()
-
-		pdoc = frappe.new_doc("Server Ansible Play")
-		pdoc.server = self.server
-		pdoc.play = play["name"]
-		pdoc.playbook = self.playbook
-
-		for key, value in self.variables.items():
-			if isinstance(value, int | bool):
-				value = str(value)
-			elif isinstance(value, list | dict):
-				value = json.dumps(value, indent=4)
-			elif not isinstance(value, str):
-				frappe.throw(_("Variable value cannot be of type {0}").format(type(value)))
-
-			pdoc.append("variables", {"key_": key, "value": value})
-
-		pdoc.insert(ignore_permissions=True)
-		self.play = pdoc.name
-
-		self._create_task_records(play=play)
-
-	def _create_task_records(self, play: dict | None = None) -> None:
-		"""Creates Server Ansible Play Task records for each task in the play."""
-
-		if not hasattr(self, "play") or not self.play:
-			frappe.throw(_("Play record must be created before creating task records."))
-		elif hasattr(self, "tasks") and self.tasks:
-			return
-		play = play or self._get_play()
-
-		self.tasks = {}
-		for task in play["tasks"]:
-			tdoc = frappe.new_doc("Server Ansible Play Task")
-			tdoc.play = self.play
-			tdoc.task = task["name"]
-			tdoc.insert(ignore_permissions=True)
-			self.tasks[tdoc.task] = tdoc.name
-
-	def _get_play(self) -> dict:
-		"""Returns the first play from the playbook."""
-
-		if not os.path.exists(self.playbook_path):
-			frappe.throw(_("Playbook {0} does not exist").format(self.playbook))
-
-		with open(self.playbook_path) as f:
-			try:
-				plays = yaml.safe_load(f)
-			except yaml.YAMLError as e:
-				frappe.throw(_("Error parsing playbook {0}: {1}").format(self.playbook, str(e)))
-
-		return plays[0]
-
-	def run(self, quiet: bool = True) -> "ServerAnsiblePlay":
-		"""Run the playbook using ansible-runner and track its progress."""
-
-		server = frappe.get_doc("Mail Server", self.server)
-		cluster = frappe.get_doc("Mail Cluster", server.cluster)
-
-		private_key_file = tempfile.NamedTemporaryFile(delete=False)
-		private_key_file.write(cluster.get_password("ssh_private_key").encode())
-		private_key_file.close()
-
-		inventory = (
-			f"{server.hostname} "
-			f"ansible_user={server.ssh_user} "
-			f"ansible_port={server.ssh_port} "
-			f"ansible_ssh_private_key_file={private_key_file.name}"
-		)
-
-		runner = None
-		try:
-			runner = ansible_runner.run(
-				playbook=self.playbook_path,
-				inventory=inventory,
-				extravars=self.variables,
-				event_handler=self.event_handler,
-				quiet=quiet,
-			)
-		finally:
-			if os.path.exists(private_key_file.name):
-				os.remove(private_key_file.name)
-
-		pdoc = frappe.get_doc("Server Ansible Play", self.play)
-		if pdoc.status in ("Pending", "Running"):
-			self._fail_play_and_pending_tasks(self._get_runner_error_log(runner))
-
-		return frappe.get_doc("Server Ansible Play", self.play)
-
-	def _get_runner_error_log(self, runner: Any | None) -> str:
-		"""Builds a readable error log when ansible-runner exits before final task events."""
-
-		details: list[str] = [
-			"Ansible play ended before completing task execution.",
-			"No terminal play status event was received from ansible-runner.",
-		]
-
-		if not runner:
-			return "\n".join(details)
-
-		status = getattr(runner, "status", None)
-		rc = getattr(runner, "rc", None)
-		if status is not None:
-			details.append(f"runner_status: {status}")
-		if rc is not None:
-			details.append(f"runner_rc: {rc}")
-
-		for attr, label in (("stderr", "stderr"), ("stdout", "stdout"), ("errored", "errored")):
-			value = getattr(runner, attr, None)
-			if value:
-				details.append(f"{label}: {self._stringify_runner_value(value)}")
-
-		return "\n".join(details)
-
-	def _stringify_runner_value(self, value: Any) -> str:
-		"""Converts ansible-runner values to readable text for error logs."""
-
-		if isinstance(value, str):
-			return value.strip() or "<empty>"
-		if isinstance(value, bytes):
-			return value.decode(errors="replace").strip() or "<empty>"
-		if isinstance(value, Iterable) and not isinstance(value, dict):
-			return "\n".join(str(v) for v in value)
-		return str(value)
-
-	@reconnect_on_failure()
-	def _fail_play_and_pending_tasks(self, error_log: str) -> None:
-		"""Marks the play and any non-finished tasks as failed with a common error log."""
-
-		ended_at = now()
-		pdoc = frappe.get_doc("Server Ansible Play", self.play)
-		started_at = pdoc.started_at or ended_at
-		started_after = pdoc.started_after
-		if not pdoc.started_at:
-			started_after = time_diff_in_seconds(started_at, pdoc.creation)
-
-		duration = time_diff_in_seconds(ended_at, started_at)
-		pdoc._db_set(
-			status="Failed",
-			started_at=started_at,
-			started_after=started_after,
-			ended_at=ended_at,
-			duration=duration,
-			error_log=error_log,
-			commit=True,
-			notify=True,
-		)
-
-		for task_name in self.tasks.values():
-			tdoc = frappe.get_doc("Server Ansible Play Task", task_name)
-			if tdoc.status in ("Success", "Failed", "Unreachable", "Skipped"):
-				continue
-
-			task_started_at = tdoc.started_at or started_at
-			tdoc._db_set(
-				status="Failed",
-				started_at=task_started_at,
-				ended_at=ended_at,
-				duration=time_diff_in_seconds(ended_at, task_started_at),
-				exception=error_log,
-				commit=True,
-				notify=True,
-			)
-
-	def event_handler(self, event: dict) -> None:
-		"""Handle events from ansible-runner and update the play and task records accordingly."""
-
-		if event_type := event.get("event"):
-			if hasattr(self, event_type):
-				method = getattr(self, event_type)
-				if callable(method):
-					method(event.get("event_data"))
-
-	def playbook_on_start(self, event_data: dict) -> None:
-		"""Called when the playbook starts."""
-
-		self.update_play(status="Running")
-
-	def playbook_on_task_start(self, event_data: dict) -> None:
-		"""Called when a task starts."""
-
-		self.update_task(status="Running", task=event_data)
-
-	def runner_on_ok(self, event_data: dict) -> None:
-		"""Called when a task completes successfully."""
-
-		self.update_task(status="Success", result=event_data)
-
-	def runner_on_failed(self, event_data: dict) -> None:
-		"""Called when a task fails."""
-
-		self.update_task(status="Failed", result=event_data)
-
-	def runner_on_unreachable(self, event_data: dict) -> None:
-		"""Called when a host is unreachable."""
-
-		self.update_task(status="Unreachable", result=event_data)
-
-	def runner_on_skipped(self, event_data: dict) -> None:
-		"""Called when a task is skipped."""
-
-		self.update_task(status="Skipped", result=event_data)
-
-	def playbook_on_stats(self, event_data: dict) -> None:
-		"""Called when the playbook finishes. Update the play record with final stats."""
-
-		stats = {}
-		for key in ["changed", "dark", "failures", "ignored", "ok", "processed", "rescued", "skipped"]:
-			stats[key] = event_data.get(key, {}).get(self.server, 0)
-		stats["unreachable"] = stats.pop("dark", 0)
-		self.update_play(stats=stats)
-
-	@reconnect_on_failure()
-	def update_play(self, status: str | None = None, stats: dict | None = None) -> None:
-		"""Updates the Server Ansible Play record with the given status and stats."""
-
-		if not status and not stats:
-			return
-
-		pdoc = frappe.get_doc("Server Ansible Play", self.play)
-
-		if stats:
-			ended_at = now()
-			duration = time_diff_in_seconds(ended_at, pdoc.started_at)
-			status = "Failed" if stats["failures"] or stats["unreachable"] else "Success"
-			kwargs = {**stats, "status": status, "ended_at": ended_at, "duration": duration}
-			pdoc._db_set(commit=True, notify=True, **kwargs)
-		else:
-			started_at = now()
-			started_after = time_diff_in_seconds(started_at, pdoc.creation)
-			pdoc._db_set(
-				status=status, started_at=started_at, started_after=started_after, commit=True, notify=True
-			)
-
-	@reconnect_on_failure()
-	def update_task(self, status: str, task: dict | None = None, result: dict | None = None) -> None:
-		"""Updates the Server Ansible Play Task record with the given status, task, and result."""
-
-		if not any([task, result]):
-			return
-
-		if task:
-			name = task["task"]
-			parsed = frappe._dict()
-		else:
-			name = result["task"]
-			parsed = frappe._dict(result.get("res") or {})
-
-		task_name = self.tasks.get(name)
-		if not task_name:
-			return
-
-		tdoc = frappe.get_doc("Server Ansible Play Task", task_name)
-
-		kwargs = {"status": status}
-		if parsed:
-			kwargs.update({"stdout": parsed.stdout, "stderr": parsed.stderr, "exception": parsed.msg})
-			for key in ("stdout", "stdout_lines", "stderr", "stderr_lines", "msg"):
-				result["res"].pop(key, None)
-
-			kwargs["result"] = json.dumps(result, indent=4)
-
-		if status == "Running":
-			kwargs.update({"started_at": now()})
-		elif status in ("Success", "Failed", "Unreachable", "Skipped"):
-			ended_at = now()
-			duration = time_diff_in_seconds(ended_at, tdoc.started_at)
-			kwargs.update({"ended_at": ended_at, "duration": duration})
-
-		tdoc._db_set(commit=True, notify=True, **kwargs)
-		self._publish_play_progress(tdoc.name)
-
-	def _publish_play_progress(self, task: str) -> None:
-		"""Publish the play progress to the user via real-time updates."""
-
-		task_list = list(self.tasks.values())
-		frappe.publish_realtime(
-			"ansible_play_progress",
-			{"progress": task_list.index(task), "total": len(task_list), "play": self.play},
-			doctype="Server Ansible Play",
-			docname=self.play,
-			user=frappe.session.user,
-		)
+    """Ansible class to run playbooks and track their progress."""
+
+    def __init__(
+        self,
+        server: str,
+        playbook: str,
+        variables: dict[str | Any] | None = None,
+    ) -> None:
+        self.server = server
+        self.playbook = playbook
+        self.variables = variables or {}
+        self._create_play_record()
+
+    @classmethod
+    def from_play(cls, play_name: str) -> "Ansible":
+        """Create an Ansible instance from an existing Server Ansible Play record."""
+
+        pdoc = frappe.get_doc("Server Ansible Play", play_name)
+
+        self = cls.__new__(cls)
+        self.play = pdoc.name
+        self.server = pdoc.server
+        self.playbook = pdoc.playbook
+
+        self.variables = {}
+        for variable in pdoc.variables:
+            try:
+                self.variables[variable.key_] = json.loads(variable.value)
+            except (TypeError, json.JSONDecodeError):
+                self.variables[variable.key_] = variable.value
+
+        self.tasks = {}
+        if tasks := frappe.db.get_all(
+            "Server Ansible Play Task",
+            filters={"play": self.play},
+            fields=["task", "name"],
+            order_by="creation asc",
+            as_list=True,
+        ):
+            self.tasks = frappe._dict(tasks)
+        return self
+
+    @property
+    def playbook_path(self) -> str:
+        """Returns the absolute path to the playbook."""
+
+        return os.path.join(
+            frappe.get_app_path("suite", "mail", "utils", "ansible", "playbooks"), self.playbook
+        )
+
+    def _create_play_record(self) -> None:
+        """Creates a Server Ansible Play record and associated Server Ansible Play Task records."""
+
+        if hasattr(self, "play") and self.play:
+            return
+
+        play = self._get_play()
+
+        pdoc = frappe.new_doc("Server Ansible Play")
+        pdoc.server = self.server
+        pdoc.play = play["name"]
+        pdoc.playbook = self.playbook
+
+        for key, value in self.variables.items():
+            if isinstance(value, int | bool):
+                value = str(value)
+            elif isinstance(value, list | dict):
+                value = json.dumps(value, indent=4)
+            elif not isinstance(value, str):
+                frappe.throw(_("Variable value cannot be of type {0}").format(type(value)))
+
+            pdoc.append("variables", {"key_": key, "value": value})
+
+        pdoc.insert(ignore_permissions=True)
+        self.play = pdoc.name
+
+        self._create_task_records(play=play)
+
+    def _create_task_records(self, play: dict | None = None) -> None:
+        """Creates Server Ansible Play Task records for each task in the play."""
+
+        if not hasattr(self, "play") or not self.play:
+            frappe.throw(_("Play record must be created before creating task records."))
+        elif hasattr(self, "tasks") and self.tasks:
+            return
+        play = play or self._get_play()
+
+        self.tasks = {}
+        for task in play["tasks"]:
+            tdoc = frappe.new_doc("Server Ansible Play Task")
+            tdoc.play = self.play
+            tdoc.task = task["name"]
+            tdoc.insert(ignore_permissions=True)
+            self.tasks[tdoc.task] = tdoc.name
+
+    def _get_play(self) -> dict:
+        """Returns the first play from the playbook."""
+
+        if not os.path.exists(self.playbook_path):
+            frappe.throw(_("Playbook {0} does not exist").format(self.playbook))
+
+        with open(self.playbook_path) as f:
+            try:
+                plays = yaml.safe_load(f)
+            except yaml.YAMLError as e:
+                frappe.throw(_("Error parsing playbook {0}: {1}").format(self.playbook, str(e)))
+
+        return plays[0]
+
+    def run(self, quiet: bool = True) -> "ServerAnsiblePlay":
+        """Run the playbook using ansible-runner and track its progress."""
+
+        server = frappe.get_doc("Mail Server", self.server)
+        cluster = frappe.get_doc("Mail Cluster", server.cluster)
+
+        private_key_file = tempfile.NamedTemporaryFile(delete=False)
+        private_key_file.write(cluster.get_password("ssh_private_key").encode())
+        private_key_file.close()
+
+        inventory = (
+            f"{server.hostname} "
+            f"ansible_user={server.ssh_user} "
+            f"ansible_port={server.ssh_port} "
+            f"ansible_ssh_private_key_file={private_key_file.name}"
+        )
+
+        runner = None
+        try:
+            runner = ansible_runner.run(
+                playbook=self.playbook_path,
+                inventory=inventory,
+                extravars=self.variables,
+                event_handler=self.event_handler,
+                quiet=quiet,
+            )
+        finally:
+            if os.path.exists(private_key_file.name):
+                os.remove(private_key_file.name)
+
+        pdoc = frappe.get_doc("Server Ansible Play", self.play)
+        if pdoc.status in ("Pending", "Running"):
+            self._fail_play_and_pending_tasks(self._get_runner_error_log(runner))
+
+        return frappe.get_doc("Server Ansible Play", self.play)
+
+    def _get_runner_error_log(self, runner: Any | None) -> str:
+        """Builds a readable error log when ansible-runner exits before final task events."""
+
+        details: list[str] = [
+            "Ansible play ended before completing task execution.",
+            "No terminal play status event was received from ansible-runner.",
+        ]
+
+        if not runner:
+            return "\n".join(details)
+
+        status = getattr(runner, "status", None)
+        rc = getattr(runner, "rc", None)
+        if status is not None:
+            details.append(f"runner_status: {status}")
+        if rc is not None:
+            details.append(f"runner_rc: {rc}")
+
+        for attr, label in (("stderr", "stderr"), ("stdout", "stdout"), ("errored", "errored")):
+            value = getattr(runner, attr, None)
+            if value:
+                details.append(f"{label}: {self._stringify_runner_value(value)}")
+
+        return "\n".join(details)
+
+    def _stringify_runner_value(self, value: Any) -> str:
+        """Converts ansible-runner values to readable text for error logs."""
+
+        if isinstance(value, str):
+            return value.strip() or "<empty>"
+        if isinstance(value, bytes):
+            return value.decode(errors="replace").strip() or "<empty>"
+        if isinstance(value, Iterable) and not isinstance(value, dict):
+            return "\n".join(str(v) for v in value)
+        return str(value)
+
+    @reconnect_on_failure()
+    def _fail_play_and_pending_tasks(self, error_log: str) -> None:
+        """Marks the play and any non-finished tasks as failed with a common error log."""
+
+        ended_at = now()
+        pdoc = frappe.get_doc("Server Ansible Play", self.play)
+        started_at = pdoc.started_at or ended_at
+        started_after = pdoc.started_after
+        if not pdoc.started_at:
+            started_after = time_diff_in_seconds(started_at, pdoc.creation)
+
+        duration = time_diff_in_seconds(ended_at, started_at)
+        pdoc._db_set(
+            status="Failed",
+            started_at=started_at,
+            started_after=started_after,
+            ended_at=ended_at,
+            duration=duration,
+            error_log=error_log,
+            commit=True,
+            notify=True,
+        )
+
+        for task_name in self.tasks.values():
+            tdoc = frappe.get_doc("Server Ansible Play Task", task_name)
+            if tdoc.status in ("Success", "Failed", "Unreachable", "Skipped"):
+                continue
+
+            task_started_at = tdoc.started_at or started_at
+            tdoc._db_set(
+                status="Failed",
+                started_at=task_started_at,
+                ended_at=ended_at,
+                duration=time_diff_in_seconds(ended_at, task_started_at),
+                exception=error_log,
+                commit=True,
+                notify=True,
+            )
+
+    def event_handler(self, event: dict) -> None:
+        """Handle events from ansible-runner and update the play and task records accordingly."""
+
+        if event_type := event.get("event"):
+            if hasattr(self, event_type):
+                method = getattr(self, event_type)
+                if callable(method):
+                    method(event.get("event_data"))
+
+    def playbook_on_start(self, event_data: dict) -> None:
+        """Called when the playbook starts."""
+
+        self.update_play(status="Running")
+
+    def playbook_on_task_start(self, event_data: dict) -> None:
+        """Called when a task starts."""
+
+        self.update_task(status="Running", task=event_data)
+
+    def runner_on_ok(self, event_data: dict) -> None:
+        """Called when a task completes successfully."""
+
+        self.update_task(status="Success", result=event_data)
+
+    def runner_on_failed(self, event_data: dict) -> None:
+        """Called when a task fails."""
+
+        self.update_task(status="Failed", result=event_data)
+
+    def runner_on_unreachable(self, event_data: dict) -> None:
+        """Called when a host is unreachable."""
+
+        self.update_task(status="Unreachable", result=event_data)
+
+    def runner_on_skipped(self, event_data: dict) -> None:
+        """Called when a task is skipped."""
+
+        self.update_task(status="Skipped", result=event_data)
+
+    def playbook_on_stats(self, event_data: dict) -> None:
+        """Called when the playbook finishes. Update the play record with final stats."""
+
+        stats = {}
+        for key in ["changed", "dark", "failures", "ignored", "ok", "processed", "rescued", "skipped"]:
+            stats[key] = event_data.get(key, {}).get(self.server, 0)
+        stats["unreachable"] = stats.pop("dark", 0)
+        self.update_play(stats=stats)
+
+    @reconnect_on_failure()
+    def update_play(self, status: str | None = None, stats: dict | None = None) -> None:
+        """Updates the Server Ansible Play record with the given status and stats."""
+
+        if not status and not stats:
+            return
+
+        pdoc = frappe.get_doc("Server Ansible Play", self.play)
+
+        if stats:
+            ended_at = now()
+            duration = time_diff_in_seconds(ended_at, pdoc.started_at)
+            status = "Failed" if stats["failures"] or stats["unreachable"] else "Success"
+            kwargs = {**stats, "status": status, "ended_at": ended_at, "duration": duration}
+            pdoc._db_set(commit=True, notify=True, **kwargs)
+        else:
+            started_at = now()
+            started_after = time_diff_in_seconds(started_at, pdoc.creation)
+            pdoc._db_set(
+                status=status, started_at=started_at, started_after=started_after, commit=True, notify=True
+            )
+
+    @reconnect_on_failure()
+    def update_task(self, status: str, task: dict | None = None, result: dict | None = None) -> None:
+        """Updates the Server Ansible Play Task record with the given status, task, and result."""
+
+        if not any([task, result]):
+            return
+
+        if task:
+            name = task["task"]
+            parsed = frappe._dict()
+        else:
+            name = result["task"]
+            parsed = frappe._dict(result.get("res") or {})
+
+        task_name = self.tasks.get(name)
+        if not task_name:
+            return
+
+        tdoc = frappe.get_doc("Server Ansible Play Task", task_name)
+
+        kwargs = {"status": status}
+        if parsed:
+            kwargs.update({"stdout": parsed.stdout, "stderr": parsed.stderr, "exception": parsed.msg})
+            for key in ("stdout", "stdout_lines", "stderr", "stderr_lines", "msg"):
+                result["res"].pop(key, None)
+
+            kwargs["result"] = json.dumps(result, indent=4)
+
+        if status == "Running":
+            kwargs.update({"started_at": now()})
+        elif status in ("Success", "Failed", "Unreachable", "Skipped"):
+            ended_at = now()
+            duration = time_diff_in_seconds(ended_at, tdoc.started_at)
+            kwargs.update({"ended_at": ended_at, "duration": duration})
+
+        tdoc._db_set(commit=True, notify=True, **kwargs)
+        self._publish_play_progress(tdoc.name)
+
+    def _publish_play_progress(self, task: str) -> None:
+        """Publish the play progress to the user via real-time updates."""
+
+        task_list = list(self.tasks.values())
+        frappe.publish_realtime(
+            "ansible_play_progress",
+            {"progress": task_list.index(task), "total": len(task_list), "play": self.play},
+            doctype="Server Ansible Play",
+            docname=self.play,
+            user=frappe.session.user,
+        )

--- a/suite/mail/api/__init__.py
+++ b/suite/mail/api/__init__.py
@@ -4,40 +4,40 @@ from frappe.translate import get_all_translations
 
 @frappe.whitelist(allow_guest=True)
 def get_signup_settings() -> dict:
-	"""Returns client signup settings."""
+    """Returns client signup settings."""
 
-	return {
-		"allow_signup": frappe.db.get_single_value("Mail Settings", "allow_signup"),
-	}
+    return {
+        "allow_signup": frappe.db.get_single_value("Mail Settings", "allow_signup"),
+    }
 
 
 @frappe.whitelist(allow_guest=True)
 def get_signup_domains() -> list:
-	"""Returns signup domains."""
+    """Returns signup domains."""
 
-	from suite.mail.doctype.mail_settings.mail_settings import get_signup_domains as _get_signup_domains
+    from suite.mail.doctype.mail_settings.mail_settings import get_signup_domains as _get_signup_domains
 
-	return _get_signup_domains()
+    return _get_signup_domains()
 
 
 @frappe.whitelist(allow_guest=True)
 def get_branding() -> dict:
-	"""Returns branding information."""
+    """Returns branding information."""
 
-	return {
-		"brand_name": frappe.db.get_single_value("Website Settings", "app_name"),
-		"brand_html": frappe.db.get_single_value("Website Settings", "brand_html"),
-		"favicon": frappe.db.get_single_value("Website Settings", "favicon"),
-	}
+    return {
+        "brand_name": frappe.db.get_single_value("Website Settings", "app_name"),
+        "brand_html": frappe.db.get_single_value("Website Settings", "brand_html"),
+        "favicon": frappe.db.get_single_value("Website Settings", "favicon"),
+    }
 
 
 @frappe.whitelist(allow_guest=True)
 def get_translations() -> dict:
-	"""Returns translations for the current user's language."""
+    """Returns translations for the current user's language."""
 
-	if frappe.session.user != "Guest":
-		language = frappe.db.get_value("User", frappe.session.user, "language")
-	else:
-		language = frappe.db.get_single_value("System Settings", "language")
+    if frappe.session.user != "Guest":
+        language = frappe.db.get_value("User", frappe.session.user, "language")
+    else:
+        language = frappe.db.get_single_value("System Settings", "language")
 
-	return get_all_translations(language)
+    return get_all_translations(language)

--- a/suite/mail/api/account.py
+++ b/suite/mail/api/account.py
@@ -17,609 +17,609 @@ from suite.mail.utils.dns import parse_dns_zone_file
 from suite.mail.utils.logger import log_admin_action
 from suite.utils.rate_limiter import dynamic_rate_limit
 from suite.mail.utils.user import (
-	has_user_settings,
-	is_jmap_configured,
+    has_user_settings,
+    is_jmap_configured,
 )
 from suite.utils import convert_html_to_text, user_context
 from suite.utils.user import is_suite_admin, is_system_manager
 
 # SRV service label -> (protocol, connection security). See RFC 6186.
 _SRV_SERVICE_MAP = {
-	"_submissions": ("SMTP", "SSL/TLS"),
-	"_submission": ("SMTP", "STARTTLS"),
-	"_imaps": ("IMAP", "SSL/TLS"),
-	"_imap": ("IMAP", "STARTTLS"),
-	"_pop3s": ("POP3", "SSL/TLS"),
-	"_pop3": ("POP3", "STARTTLS"),
+    "_submissions": ("SMTP", "SSL/TLS"),
+    "_submission": ("SMTP", "STARTTLS"),
+    "_imaps": ("IMAP", "SSL/TLS"),
+    "_imap": ("IMAP", "STARTTLS"),
+    "_pop3s": ("POP3", "SSL/TLS"),
+    "_pop3": ("POP3", "STARTTLS"),
 }
 
 
 @frappe.whitelist(allow_guest=True)
 @dynamic_rate_limit()
 def validate_email_assigned(email: str) -> None:
-	"""Checks if email is already assigned"""
+    """Checks if email is already assigned"""
 
-	if frappe.db.exists("User", {"email": email}):
-		frappe.throw(_("Username already taken."))
+    if frappe.db.exists("User", {"email": email}):
+        frappe.throw(_("Username already taken."))
 
 
 @frappe.whitelist(allow_guest=True)
 @dynamic_rate_limit()
 def signup(
-	username: str,
-	domain: str,
-	email: str,
-	password: str,
-	first_name: str,
-	last_name: str | None = None,
+    username: str,
+    domain: str,
+    email: str,
+    password: str,
+    first_name: str,
+    last_name: str | None = None,
 ) -> None:
-	"""Create a new Mail Account for signup"""
+    """Create a new Mail Account for signup"""
 
-	if not frappe.db.get_single_value("Mail Settings", "allow_signup"):
-		frappe.throw(_("Signup is disabled."))
+    if not frappe.db.get_single_value("Mail Settings", "allow_signup"):
+        frappe.throw(_("Signup is disabled."))
 
-	if domain not in get_signup_domains():
-		frappe.throw(_("Domain {0} is not allowed for signup.").format(domain))
+    if domain not in get_signup_domains():
+        frappe.throw(_("Domain {0} is not allowed for signup.").format(domain))
 
-	with user_context("Administrator"):
-		add_member(
-			username=username,
-			domain=domain,
-			is_admin=False,
-			send_invite=False,
-			backup_email=email,
-			first_name=first_name,
-			last_name=last_name,
-			password=password,
-		)
+    with user_context("Administrator"):
+        add_member(
+            username=username,
+            domain=domain,
+            is_admin=False,
+            send_invite=False,
+            backup_email=email,
+            first_name=first_name,
+            last_name=last_name,
+            password=password,
+        )
 
 
 @frappe.whitelist(allow_guest=True)
 @dynamic_rate_limit()
 def resend_otp(account_request: str) -> None:
-	"""Resend OTP to the user"""
+    """Resend OTP to the user"""
 
-	account_request = frappe.get_doc("Mail Account Request", account_request)
-	account_request.set_otp()
-	account_request.save(ignore_permissions=True)
-	account_request.send_verification_email()
+    account_request = frappe.get_doc("Mail Account Request", account_request)
+    account_request.set_otp()
+    account_request.save(ignore_permissions=True)
+    account_request.send_verification_email()
 
 
 @frappe.whitelist(allow_guest=True)
 @dynamic_rate_limit()
 def verify_otp(account_request: str, otp: str) -> str:
-	"""Verify the OTP and return the request key"""
+    """Verify the OTP and return the request key"""
 
-	otp_hash = frappe.cache.get_value(f"account_request_otp_hash:{account_request}", expires=True)
-	if not otp_hash or otp_hash != frappe.utils.sha256_hash(otp):
-		frappe.throw(_("Invalid OTP. Please try again."))
+    otp_hash = frappe.cache.get_value(f"account_request_otp_hash:{account_request}", expires=True)
+    if not otp_hash or otp_hash != frappe.utils.sha256_hash(otp):
+        frappe.throw(_("Invalid OTP. Please try again."))
 
-	frappe.cache.delete_value(f"account_request_otp_hash:{account_request}")
-	return frappe.db.get_value("Mail Account Request", account_request, "request_key")
+    frappe.cache.delete_value(f"account_request_otp_hash:{account_request}")
+    return frappe.db.get_value("Mail Account Request", account_request, "request_key")
 
 
 @frappe.whitelist(allow_guest=True)
 @dynamic_rate_limit()
 def get_account_request(request_key: str) -> dict | None:
-	"""Return the account request details"""
+    """Return the account request details"""
 
-	if account_request := frappe.db.get_value(
-		"Mail Account Request",
-		{"request_key": request_key},
-		["backup_email", "is_verified", "expires_at", "account"],
-		as_dict=True,
-	):
-		is_expired = 0
-		if expires_at := account_request["expires_at"]:
-			is_expired = cint(get_datetime(expires_at) < now_datetime())
-		account_request.pop("expires_at")
-		account_request["is_expired"] = is_expired
-		return account_request
+    if account_request := frappe.db.get_value(
+        "Mail Account Request",
+        {"request_key": request_key},
+        ["backup_email", "is_verified", "expires_at", "account"],
+        as_dict=True,
+    ):
+        is_expired = 0
+        if expires_at := account_request["expires_at"]:
+            is_expired = cint(get_datetime(expires_at) < now_datetime())
+        account_request.pop("expires_at")
+        account_request["is_expired"] = is_expired
+        return account_request
 
 
 @frappe.whitelist(allow_guest=True)
 @dynamic_rate_limit()
 def get_account_setup_options(request_key: str) -> dict:
-	"""Returns the locale and time zone choices for the invite setup form.
+    """Returns the locale and time zone choices for the invite setup form.
 
-	Gated on a pending request key: the choices come from the Stalwart schema, so they are not served
-	to arbitrary callers.
-	"""
+    Gated on a pending request key: the choices come from the Stalwart schema, so they are not served
+    to arbitrary callers.
+    """
 
-	from suite.mail.stalwart import get_account_metadata
+    from suite.mail.stalwart import get_account_metadata
 
-	account_request = frappe.db.get_value(
-		"Mail Account Request",
-		{"request_key": request_key},
-		["is_verified", "expires_at"],
-		as_dict=True,
-	)
-	if (
-		not account_request
-		or account_request.is_verified
-		or (account_request.expires_at and get_datetime(account_request.expires_at) < now_datetime())
-	):
-		frappe.throw(_("This request has expired. Please create a new one."))
+    account_request = frappe.db.get_value(
+        "Mail Account Request",
+        {"request_key": request_key},
+        ["is_verified", "expires_at"],
+        as_dict=True,
+    )
+    if (
+        not account_request
+        or account_request.is_verified
+        or (account_request.expires_at and get_datetime(account_request.expires_at) < now_datetime())
+    ):
+        frappe.throw(_("This request has expired. Please create a new one."))
 
-	return get_account_metadata()
+    return get_account_metadata()
 
 
 @frappe.whitelist(allow_guest=True)
 @dynamic_rate_limit()
 def create_account(
-	request_key: str,
-	first_name: str,
-	last_name: str,
-	password: str,
-	locale: str | None = None,
-	time_zone: str | None = None,
+    request_key: str,
+    first_name: str,
+    last_name: str,
+    password: str,
+    locale: str | None = None,
+    time_zone: str | None = None,
 ) -> None:
-	"""Create a new mail account"""
+    """Create a new mail account"""
 
-	account_request = frappe.get_last_doc("Mail Account Request", {"request_key": request_key})
-	account_request.validate_expired()
-	account_request.is_verified = 1
-	account_request.save(ignore_permissions=True)
+    account_request = frappe.get_last_doc("Mail Account Request", {"request_key": request_key})
+    account_request.validate_expired()
+    account_request.is_verified = 1
+    account_request.save(ignore_permissions=True)
 
-	if account_request.account:
-		# Account setup (JMAP account sync, archive mailbox, sieve) resolves ownership
-		# against the session user, which is Guest on this endpoint — run it elevated,
-		# same as signup().
-		with user_context("Administrator"):
-			account_request.create_account(first_name, last_name, password, locale, time_zone)
+    if account_request.account:
+        # Account setup (JMAP account sync, archive mailbox, sieve) resolves ownership
+        # against the session user, which is Guest on this endpoint — run it elevated,
+        # same as signup().
+        with user_context("Administrator"):
+            account_request.create_account(first_name, last_name, password, locale, time_zone)
 
 
 @frappe.whitelist(allow_guest=True)
 def get_user_info() -> dict | None:
-	"""Returns user information."""
+    """Returns user information."""
 
-	user = frappe.session.user
-	if user == "Guest":
-		return None
+    user = frappe.session.user
+    if user == "Guest":
+        return None
 
-	if not has_user_settings(user):
-		user_settings = frappe.new_doc("User Settings")
-		user_settings.user = user
-		user_settings.insert(ignore_permissions=True)
+    if not has_user_settings(user):
+        user_settings = frappe.new_doc("User Settings")
+        user_settings.user = user
+        user_settings.insert(ignore_permissions=True)
 
-	USER = frappe.qb.DocType("User")
-	USER_SETTINGS = frappe.qb.DocType("User Settings")
+    USER = frappe.qb.DocType("User")
+    USER_SETTINGS = frappe.qb.DocType("User Settings")
 
-	result = (
-		frappe.qb.from_(USER)
-		.join(USER_SETTINGS)
-		.on(USER.name == USER_SETTINGS.user)
-		.select(
-			USER.name,
-			USER.email,
-			USER.enabled,
-			USER.user_image,
-			USER.full_name,
-			USER.first_name,
-			USER.last_name,
-			USER.user_type,
-			USER.username,
-			USER.api_key,
-			USER.time_zone,
-			USER_SETTINGS.color_scheme,
-			USER_SETTINGS.group_messages_by,
-			USER_SETTINGS.show_reading_pane,
-			USER_SETTINGS.name.as_("user_settings"),
-		)
-		.where(USER.name == user)
-	).run(as_dict=True)
+    result = (
+        frappe.qb.from_(USER)
+        .join(USER_SETTINGS)
+        .on(USER.name == USER_SETTINGS.user)
+        .select(
+            USER.name,
+            USER.email,
+            USER.enabled,
+            USER.user_image,
+            USER.full_name,
+            USER.first_name,
+            USER.last_name,
+            USER.user_type,
+            USER.username,
+            USER.api_key,
+            USER.time_zone,
+            USER_SETTINGS.color_scheme,
+            USER_SETTINGS.group_messages_by,
+            USER_SETTINGS.show_reading_pane,
+            USER_SETTINGS.name.as_("user_settings"),
+        )
+        .where(USER.name == user)
+    ).run(as_dict=True)
 
-	if not result:
-		return None
+    if not result:
+        return None
 
-	data = result[0]
+    data = result[0]
 
-	# The APIs speak UTC, so the interface needs a zone to render those timestamps in. The User's own
-	# choice wins; sites that never set one fall back to the system zone.
-	data.time_zone = data.time_zone or get_system_timezone()
+    # The APIs speak UTC, so the interface needs a zone to render those timestamps in. The User's own
+    # choice wins; sites that never set one fall back to the system zone.
+    data.time_zone = data.time_zone or get_system_timezone()
 
-	data.is_suite_admin = is_suite_admin(user)
-	data.is_system_manager = is_system_manager(user)
-	data.is_jmap_configured = is_jmap_configured(user)
-	data.accounts = frappe.db.get_all("User Account", {"user": user}, ["account"])
+    data.is_suite_admin = is_suite_admin(user)
+    data.is_system_manager = is_system_manager(user)
+    data.is_jmap_configured = is_jmap_configured(user)
+    data.accounts = frappe.db.get_all("User Account", {"user": user}, ["account"])
 
-	settings_by_account = {
-		s["name"]: s
-		for s in frappe.get_all(
-			"JMAP Account",
-			filters={"name": ["in", [account["account"] for account in data.accounts]]},
-			fields=[
-				"name",
-				"_name",
-				"is_personal",
-				"default_outgoing_email",
-				"on_mark_as_junk",
-				"enable_screening",
-				"block_remote_images",
-			],
-		)
-	}
-	for account in data.accounts:
-		settings = settings_by_account.get(account["account"])
-		account["id"] = account["account"]
-		account["_name"] = settings["_name"] if settings else None
-		account["is_personal"] = bool(settings["is_personal"]) if settings else False
-		account["jmap_account"] = settings["name"] if settings else None
-		account["default_outgoing_email"] = settings["default_outgoing_email"] if settings else None
-		account["on_mark_as_junk"] = settings["on_mark_as_junk"] if settings else "Junk Sender's Mail"
-		account["enable_screening"] = bool(settings["enable_screening"]) if settings else False
-		account["block_remote_images"] = bool(settings["block_remote_images"]) if settings else True
+    settings_by_account = {
+        s["name"]: s
+        for s in frappe.get_all(
+            "JMAP Account",
+            filters={"name": ["in", [account["account"] for account in data.accounts]]},
+            fields=[
+                "name",
+                "_name",
+                "is_personal",
+                "default_outgoing_email",
+                "on_mark_as_junk",
+                "enable_screening",
+                "block_remote_images",
+            ],
+        )
+    }
+    for account in data.accounts:
+        settings = settings_by_account.get(account["account"])
+        account["id"] = account["account"]
+        account["_name"] = settings["_name"] if settings else None
+        account["is_personal"] = bool(settings["is_personal"]) if settings else False
+        account["jmap_account"] = settings["name"] if settings else None
+        account["default_outgoing_email"] = settings["default_outgoing_email"] if settings else None
+        account["on_mark_as_junk"] = settings["on_mark_as_junk"] if settings else "Junk Sender's Mail"
+        account["enable_screening"] = bool(settings["enable_screening"]) if settings else False
+        account["block_remote_images"] = bool(settings["block_remote_images"]) if settings else True
 
-	data.user_image = data.user_image or get_avatar_url(user)
+    data.user_image = data.user_image or get_avatar_url(user)
 
-	return data
+    return data
 
 
 @frappe.whitelist()
 def get_mail_client_config() -> list[dict]:
-	"""Returns the SMTP/IMAP/POP endpoints for connecting third-party mail clients.
+    """Returns the SMTP/IMAP/POP endpoints for connecting third-party mail clients.
 
-	Resolution order:
-	1. Master switch off -> nothing.
-	2. Endpoints entered by the admin in Mail Settings.
-	3. Fallback: parse the user's domain DNS SRV records (if Stalwart is configured).
-	"""
+    Resolution order:
+    1. Master switch off -> nothing.
+    2. Endpoints entered by the admin in Mail Settings.
+    3. Fallback: parse the user's domain DNS SRV records (if Stalwart is configured).
+    """
 
-	settings = frappe.get_cached_doc("Mail Settings")
-	if not settings.show_mail_client_config:
-		return []
+    settings = frappe.get_cached_doc("Mail Settings")
+    if not settings.show_mail_client_config:
+        return []
 
-	if settings.mail_client_configurations:
-		return [
-			{
-				"protocol": row.protocol,
-				"hostname": row.hostname,
-				"port": row.port,
-				"connection_security": row.connection_security,
-			}
-			for row in settings.mail_client_configurations
-		]
+    if settings.mail_client_configurations:
+        return [
+            {
+                "protocol": row.protocol,
+                "hostname": row.hostname,
+                "port": row.port,
+                "connection_security": row.connection_security,
+            }
+            for row in settings.mail_client_configurations
+        ]
 
-	if is_stalwart_configured():
-		return _get_client_config_from_dns()
+    if is_stalwart_configured():
+        return _get_client_config_from_dns()
 
-	return []
+    return []
 
 
 def _get_client_config_from_dns() -> list[dict]:
-	"""Derives mail-client endpoints from the domain DNS SRV records.
+    """Derives mail-client endpoints from the domain DNS SRV records.
 
-	Best-effort: on any failure (Stalwart unreachable, malformed zone file) the error is
-	logged and an empty list is returned so the Advanced tab degrades gracefully.
-	"""
+    Best-effort: on any failure (Stalwart unreachable, malformed zone file) the error is
+    logged and an empty list is returned so the Advanced tab degrades gracefully.
+    """
 
-	try:
-		domains = get_domains()
-		if not domains:
-			return []
+    try:
+        domains = get_domains()
+        if not domains:
+            return []
 
-		config = []
+        config = []
 
-		# Every domain on the cluster points at the same mail server, so their SRV records
-		# resolve to identical client endpoints. Any one domain's zone is enough.
-		domain = domains[0]
+        # Every domain on the cluster points at the same mail server, so their SRV records
+        # resolve to identical client endpoints. Any one domain's zone is enough.
+        domain = domains[0]
 
-		for record in parse_dns_zone_file(domain["dnsZoneFile"]):
-			if record["type"] != "SRV":
-				continue
+        for record in parse_dns_zone_file(domain["dnsZoneFile"]):
+            if record["type"] != "SRV":
+                continue
 
-			mapping = _SRV_SERVICE_MAP.get(record["name"].split(".")[0])
-			if not mapping:
-				continue
+            mapping = _SRV_SERVICE_MAP.get(record["name"].split(".")[0])
+            if not mapping:
+                continue
 
-			# SRV rdata: <priority> <weight> <port> <target>. "." target means not offered.
-			parts = record["value"].split()
-			if len(parts) < 4 or parts[3] == ".":
-				continue
+            # SRV rdata: <priority> <weight> <port> <target>. "." target means not offered.
+            parts = record["value"].split()
+            if len(parts) < 4 or parts[3] == ".":
+                continue
 
-			protocol, connection_security = mapping
-			config.append(
-				{
-					"protocol": protocol,
-					"hostname": parts[3].rstrip("."),
-					"port": cint(parts[2]),
-					"connection_security": connection_security,
-				}
-			)
+            protocol, connection_security = mapping
+            config.append(
+                {
+                    "protocol": protocol,
+                    "hostname": parts[3].rstrip("."),
+                    "port": cint(parts[2]),
+                    "connection_security": connection_security,
+                }
+            )
 
-		return config
-	except Exception:
-		log_mail_error(
-			title=_("Failed to derive mail client config from DNS"), message=frappe.get_traceback()
-		)
-		return []
+        return config
+    except Exception:
+        log_mail_error(
+            title=_("Failed to derive mail client config from DNS"), message=frappe.get_traceback()
+        )
+        return []
 
 
 def get_backup_email(user: str) -> str:
-	"""Return backup email for a user or the user's email if backup doesn't exist"""
+    """Return backup email for a user or the user's email if backup doesn't exist"""
 
-	if backup_email := frappe.db.get_value("User Settings", {"user": user}, "backup_email"):
-		return backup_email
+    if backup_email := frappe.db.get_value("User Settings", {"user": user}, "backup_email"):
+        return backup_email
 
-	if frappe.db.exists("User", user):
-		return frappe.db.get_value("User", user, "email")
+    if frappe.db.exists("User", user):
+        return frappe.db.get_value("User", user, "email")
 
-	frappe.throw(_("User {0} does not exist.").format(frappe.bold(user)))
+    frappe.throw(_("User {0} does not exist.").format(frappe.bold(user)))
 
 
 def set_reset_password_key(email: str) -> str:
-	"""Generate and store a reset password key for a user"""
+    """Generate and store a reset password key for a user"""
 
-	key = frappe.generate_hash()
-	hashed_key = sha256_hash(key)
-	frappe.db.set_value(
-		"User",
-		email,
-		{"reset_password_key": hashed_key, "last_reset_password_key_generated_on": now_datetime()},
-	)
-	return key
+    key = frappe.generate_hash()
+    hashed_key = sha256_hash(key)
+    frappe.db.set_value(
+        "User",
+        email,
+        {"reset_password_key": hashed_key, "last_reset_password_key_generated_on": now_datetime()},
+    )
+    return key
 
 
 def censor_email(email: str) -> str:
-	"""Censor the email address to protect privacy"""
+    """Censor the email address to protect privacy"""
 
-	username, domain = email.split("@")
-	censored_username = username[0] + "*" * (len(username) - 1)
-	return f"{censored_username}@{domain}"
+    username, domain = email.split("@")
+    censored_username = username[0] + "*" * (len(username) - 1)
+    return f"{censored_username}@{domain}"
 
 
 @frappe.whitelist(allow_guest=True)
 @dynamic_rate_limit()
 def send_reset_password_link(user: str) -> str:
-	"""Send reset password link to the user"""
+    """Send reset password link to the user"""
 
-	# Only an admin resetting somebody else's password is an administrative act; this same endpoint
-	# backs the public "forgot password" form, and a user asking for their own link is not audited.
-	if frappe.session.user != user:
-		log_admin_action("send reset password link", user)
+    # Only an admin resetting somebody else's password is an administrative act; this same endpoint
+    # backs the public "forgot password" form, and a user asking for their own link is not audited.
+    if frappe.session.user != user:
+        log_admin_action("send reset password link", user)
 
-	email = get_backup_email(user)
-	key = set_reset_password_key(user)
+    email = get_backup_email(user)
+    key = set_reset_password_key(user)
 
-	frappe.sendmail(
-		recipients=email,
-		subject=_("Reset Password"),
-		template="reset_password",
-		args={"link": get_url("/mail/reset-password/" + key)},
-		now=True,
-	)
+    frappe.sendmail(
+        recipients=email,
+        subject=_("Reset Password"),
+        template="reset_password",
+        args={"link": get_url("/mail/reset-password/" + key)},
+        now=True,
+    )
 
-	if email == user:
-		return email
+    if email == user:
+        return email
 
-	return censor_email(email)
+    return censor_email(email)
 
 
 @frappe.whitelist(allow_guest=True)
 def get_user_for_reset_password_key(key: str) -> str:
-	"""Return the user for a reset password key"""
+    """Return the user for a reset password key"""
 
-	hashed_key = sha256_hash(key)
-	return frappe.db.get_value("User", {"reset_password_key": hashed_key}, "name")
+    hashed_key = sha256_hash(key)
+    return frappe.db.get_value("User", {"reset_password_key": hashed_key}, "name")
 
 
 @frappe.whitelist()
 def create_mail_import(
-	account: str,
-	format: Literal["eml", "jmap", "mbox", "maildir", "maildir-nested"],
-	file: str,
-	mailbox: str | None = None,
-	seen: bool = False,
+    account: str,
+    format: Literal["eml", "jmap", "mbox", "maildir", "maildir-nested"],
+    file: str,
+    mailbox: str | None = None,
+    seen: bool = False,
 ) -> None:
-	"""Creates mail exchange of operation import"""
+    """Creates mail exchange of operation import"""
 
-	doc = frappe.new_doc("Mail Exchange")
-	doc.user = frappe.session.user
-	doc.account = account
-	doc.operation = "Import"
-	doc.import_format = format
-	doc.import_file = file
-	if format in ["eml", "maildir", "mbox"] and mailbox:
-		doc.import_metadata = json.dumps({"mailboxIds": {mailbox: True}, "keywords": {"$seen": seen}})
-	doc.insert()
-	doc.submit()
+    doc = frappe.new_doc("Mail Exchange")
+    doc.user = frappe.session.user
+    doc.account = account
+    doc.operation = "Import"
+    doc.import_format = format
+    doc.import_file = file
+    if format in ["eml", "maildir", "mbox"] and mailbox:
+        doc.import_metadata = json.dumps({"mailboxIds": {mailbox: True}, "keywords": {"$seen": seen}})
+    doc.insert()
+    doc.submit()
 
 
 @frappe.whitelist()
 def create_mail_export(
-	account: str,
-	format: Literal["jmap", "mbox", "maildir", "maildir-nested"],
-	archive_type: Literal[".zip", ".tgz", ".tar.gz"],
-	sort: Literal["Received At (ASC)", "Received At (DESC)"],
-	limit: int | None = None,
-	filter: dict | None = None,
+    account: str,
+    format: Literal["jmap", "mbox", "maildir", "maildir-nested"],
+    archive_type: Literal[".zip", ".tgz", ".tar.gz"],
+    sort: Literal["Received At (ASC)", "Received At (DESC)"],
+    limit: int | None = None,
+    filter: dict | None = None,
 ) -> None:
-	"""Creates mail exchange of operation export"""
+    """Creates mail exchange of operation export"""
 
-	doc = frappe.new_doc("Mail Exchange")
-	doc.user = frappe.session.user
-	doc.account = account
-	doc.operation = "Export"
-	doc.export_format = format
-	doc.export_archive_type = archive_type
-	doc.export_sort = sort
-	doc.export_limit = limit
-	if filter:
-		filter = {k: v for k, v in filter.items() if v}
-		if filter:
-			doc.export_filter = json.dumps(normalize_filter(filter))
-	doc.insert()
-	doc.submit()
+    doc = frappe.new_doc("Mail Exchange")
+    doc.user = frappe.session.user
+    doc.account = account
+    doc.operation = "Export"
+    doc.export_format = format
+    doc.export_archive_type = archive_type
+    doc.export_sort = sort
+    doc.export_limit = limit
+    if filter:
+        filter = {k: v for k, v in filter.items() if v}
+        if filter:
+            doc.export_filter = json.dumps(normalize_filter(filter))
+    doc.insert()
+    doc.submit()
 
 
 @frappe.whitelist()
 def create_calendar_import(
-	account: str,
-	format: Literal["ics", "jmap"],
-	file: str,
-	calendar: str | None = None,
+    account: str,
+    format: Literal["ics", "jmap"],
+    file: str,
+    calendar: str | None = None,
 ) -> None:
-	"""Creates calendar exchange of operation import"""
+    """Creates calendar exchange of operation import"""
 
-	doc = frappe.new_doc("Calendar Exchange")
-	doc.user = frappe.session.user
-	doc.account = account
-	doc.operation = "Import"
-	doc.import_format = format
-	doc.import_file = file
-	if calendar:
-		doc.import_metadata = json.dumps({"calendarIds": {calendar: True}})
-	doc.insert()
-	doc.submit()
+    doc = frappe.new_doc("Calendar Exchange")
+    doc.user = frappe.session.user
+    doc.account = account
+    doc.operation = "Import"
+    doc.import_format = format
+    doc.import_file = file
+    if calendar:
+        doc.import_metadata = json.dumps({"calendarIds": {calendar: True}})
+    doc.insert()
+    doc.submit()
 
 
 @frappe.whitelist()
 def create_calendar_export(
-	account: str,
-	format: Literal["ics", "jmap"],
-	archive_type: Literal[".zip", ".tgz", ".tar.gz"],
-	sort: Literal["Start (ASC)", "Start (DESC)"],
-	limit: int | None = None,
-	filter: dict | None = None,
+    account: str,
+    format: Literal["ics", "jmap"],
+    archive_type: Literal[".zip", ".tgz", ".tar.gz"],
+    sort: Literal["Start (ASC)", "Start (DESC)"],
+    limit: int | None = None,
+    filter: dict | None = None,
 ) -> None:
-	"""Creates calendar exchange of operation export"""
+    """Creates calendar exchange of operation export"""
 
-	doc = frappe.new_doc("Calendar Exchange")
-	doc.user = frappe.session.user
-	doc.account = account
-	doc.operation = "Export"
-	doc.export_format = format
-	doc.export_archive_type = archive_type
-	doc.export_sort = sort
-	doc.export_limit = limit
-	if filter:
-		filter = {k: v for k, v in filter.items() if v}
-		if normalized := normalize_calendar_filter(filter):
-			doc.export_filter = json.dumps(normalized)
-	doc.insert()
-	doc.submit()
+    doc = frappe.new_doc("Calendar Exchange")
+    doc.user = frappe.session.user
+    doc.account = account
+    doc.operation = "Export"
+    doc.export_format = format
+    doc.export_archive_type = archive_type
+    doc.export_sort = sort
+    doc.export_limit = limit
+    if filter:
+        filter = {k: v for k, v in filter.items() if v}
+        if normalized := normalize_calendar_filter(filter):
+            doc.export_filter = json.dumps(normalized)
+    doc.insert()
+    doc.submit()
 
 
 def normalize_calendar_filter(filter: dict) -> dict:
-	"""Normalize a calendar export filter into a JMAP CalendarEvent/query FilterCondition."""
+    """Normalize a calendar export filter into a JMAP CalendarEvent/query FilterCondition."""
 
-	from suite.utils.dt import convert_to_utc
+    from suite.utils.dt import convert_to_utc
 
-	normalized = {}
-	if title := filter.get("title"):
-		normalized["title"] = title
-	if in_calendar := filter.get("inCalendar"):
-		normalized["inCalendar"] = in_calendar
-	for key in ("after", "before"):
-		if value := filter.get(key):
-			normalized[key] = convert_to_utc(value, naive=True).strftime("%Y-%m-%dT%H:%M:%SZ")
+    normalized = {}
+    if title := filter.get("title"):
+        normalized["title"] = title
+    if in_calendar := filter.get("inCalendar"):
+        normalized["inCalendar"] = in_calendar
+    for key in ("after", "before"):
+        if value := filter.get(key):
+            normalized[key] = convert_to_utc(value, naive=True).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-	return normalized
+    return normalized
 
 
 @frappe.whitelist()
 def create_contacts_import(
-	account: str,
-	format: Literal["vcf", "jmap"],
-	file: str,
-	address_book: str | None = None,
+    account: str,
+    format: Literal["vcf", "jmap"],
+    file: str,
+    address_book: str | None = None,
 ) -> None:
-	"""Creates contacts exchange of operation import"""
+    """Creates contacts exchange of operation import"""
 
-	doc = frappe.new_doc("Contacts Exchange")
-	doc.user = frappe.session.user
-	doc.account = account
-	doc.operation = "Import"
-	doc.import_format = format
-	doc.import_file = file
-	if address_book:
-		doc.import_metadata = json.dumps({"addressBookIds": {address_book: True}})
-	doc.insert()
-	doc.submit()
+    doc = frappe.new_doc("Contacts Exchange")
+    doc.user = frappe.session.user
+    doc.account = account
+    doc.operation = "Import"
+    doc.import_format = format
+    doc.import_file = file
+    if address_book:
+        doc.import_metadata = json.dumps({"addressBookIds": {address_book: True}})
+    doc.insert()
+    doc.submit()
 
 
 @frappe.whitelist()
 def create_contacts_export(
-	account: str,
-	format: Literal["jmap", "vcf"],
-	archive_type: Literal[".zip", ".tgz", ".tar.gz"],
-	limit: int | None = None,
-	filter: dict | None = None,
+    account: str,
+    format: Literal["jmap", "vcf"],
+    archive_type: Literal[".zip", ".tgz", ".tar.gz"],
+    limit: int | None = None,
+    filter: dict | None = None,
 ) -> None:
-	"""Creates contacts exchange of operation export"""
+    """Creates contacts exchange of operation export"""
 
-	doc = frappe.new_doc("Contacts Exchange")
-	doc.user = frappe.session.user
-	doc.account = account
-	doc.operation = "Export"
-	doc.export_format = format
-	doc.export_archive_type = archive_type
-	doc.export_limit = limit
-	if filter:
-		filter = {k: v for k, v in filter.items() if v}
-		if normalized := normalize_contacts_filter(filter):
-			doc.export_filter = json.dumps(normalized)
-	doc.insert()
-	doc.submit()
+    doc = frappe.new_doc("Contacts Exchange")
+    doc.user = frappe.session.user
+    doc.account = account
+    doc.operation = "Export"
+    doc.export_format = format
+    doc.export_archive_type = archive_type
+    doc.export_limit = limit
+    if filter:
+        filter = {k: v for k, v in filter.items() if v}
+        if normalized := normalize_contacts_filter(filter):
+            doc.export_filter = json.dumps(normalized)
+    doc.insert()
+    doc.submit()
 
 
 def normalize_contacts_filter(filter: dict) -> dict:
-	"""Normalize a contacts export filter into a JMAP ContactCard/query FilterCondition."""
+    """Normalize a contacts export filter into a JMAP ContactCard/query FilterCondition."""
 
-	normalized = {}
-	if text := filter.get("text"):
-		normalized["text"] = text
-	if name := filter.get("name"):
-		normalized["name"] = name
-	if email := filter.get("email"):
-		normalized["email"] = email
-	if in_address_book := filter.get("inAddressBook"):
-		normalized["inAddressBook"] = in_address_book
+    normalized = {}
+    if text := filter.get("text"):
+        normalized["text"] = text
+    if name := filter.get("name"):
+        normalized["name"] = name
+    if email := filter.get("email"):
+        normalized["email"] = email
+    if in_address_book := filter.get("inAddressBook"):
+        normalized["inAddressBook"] = in_address_book
 
-	return normalized
+    return normalized
 
 
 @frappe.whitelist()
 def is_push_notification_relay_enabled() -> bool:
-	return frappe.db.get_single_value("Push Notification Settings", "enable_push_notification_relay")
+    return frappe.db.get_single_value("Push Notification Settings", "enable_push_notification_relay")
 
 
 @frappe.whitelist()
 def get_quota(account: str) -> dict:
-	"""Return quota usage for the user"""
+    """Return quota usage for the user"""
 
-	result = {
-		"disk_quota": 0,
-		"used_quota": 0,
-		"used_percentage": 0,
-	}
+    result = {
+        "disk_quota": 0,
+        "used_quota": 0,
+        "used_percentage": 0,
+    }
 
-	for quota in frappe.db.get_all("Quota", {"account": account}):
-		if scope := quota["scope"]:
-			if scope == "account":
-				result["disk_quota"] = quota["hard_limit"]
-				result["used_quota"] = quota["used"]
+    for quota in frappe.db.get_all("Quota", {"account": account}):
+        if scope := quota["scope"]:
+            if scope == "account":
+                result["disk_quota"] = quota["hard_limit"]
+                result["used_quota"] = quota["used"]
 
-				if result["disk_quota"] > 0:
-					result["used_percentage"] = (result["used_quota"] / result["disk_quota"]) * 100
+                if result["disk_quota"] > 0:
+                    result["used_percentage"] = (result["used_quota"] / result["disk_quota"]) * 100
 
-				break
+                break
 
-	return result
+    return result
 
 
 @frappe.whitelist()
 def get_identities(account: str) -> list[dict]:
-	"""Return the email identities for the user"""
+    """Return the email identities for the user"""
 
-	return fetch_identities(account, page=1, limit=100)
+    return fetch_identities(account, page=1, limit=100)
 
 
 @frappe.whitelist()
 def set_signature(identity: str, signature: str) -> None:
-	"""Set the email signature for an identity"""
+    """Set the email signature for an identity"""
 
-	doc = frappe.get_doc("Identity", identity)
-	doc.html_signature = signature
-	doc.text_signature = convert_html_to_text(signature)
-	doc.db_update()
+    doc = frappe.get_doc("Identity", identity)
+    doc.html_signature = signature
+    doc.text_signature = convert_html_to_text(signature)
+    doc.db_update()

--- a/suite/mail/api/account.py
+++ b/suite/mail/api/account.py
@@ -15,12 +15,12 @@ from suite.mail.stalwart import get_domains
 from suite.mail.utils import is_stalwart_configured, log_mail_error
 from suite.mail.utils.dns import parse_dns_zone_file
 from suite.mail.utils.logger import log_admin_action
-from suite.utils.rate_limiter import dynamic_rate_limit
 from suite.mail.utils.user import (
     has_user_settings,
     is_jmap_configured,
 )
 from suite.utils import convert_html_to_text, user_context
+from suite.utils.rate_limiter import dynamic_rate_limit
 from suite.utils.user import is_suite_admin, is_system_manager
 
 # SRV service label -> (protocol, connection security). See RFC 6186.

--- a/suite/mail/api/admin.py
+++ b/suite/mail/api/admin.py
@@ -12,29 +12,29 @@ from pypika import Case, Order
 
 from suite.mail.api.utils import get_avatar_url
 from suite.mail.doctype.mail_account_request.mail_account_request import (
-	STALWART_DEFAULT_ADMIN_ROLES,
-	STALWART_DEFAULT_USER_ROLES,
+    STALWART_DEFAULT_ADMIN_ROLES,
+    STALWART_DEFAULT_USER_ROLES,
 )
 from suite.mail.doctype.user_account.user_account import get_user_personal_jmap_account
 from suite.mail.stalwart import (
-	add_account_role,
-	get_account_metadata,
-	get_account_service,
-	get_action_service,
-	get_action_types,
-	get_dkim_signature_service,
-	get_domain_service,
-	get_group_service,
-	get_log_labels,
-	get_log_service,
-	get_mailing_list_service,
-	get_management_connection,
-	get_oauth_client_service,
-	get_queue_metadata,
-	get_queued_message_service,
-	get_report_service,
-	get_role_service,
-	remove_account_role,
+    add_account_role,
+    get_account_metadata,
+    get_account_service,
+    get_action_service,
+    get_action_types,
+    get_dkim_signature_service,
+    get_domain_service,
+    get_group_service,
+    get_log_labels,
+    get_log_service,
+    get_mailing_list_service,
+    get_management_connection,
+    get_oauth_client_service,
+    get_queue_metadata,
+    get_queued_message_service,
+    get_report_service,
+    get_role_service,
+    remove_account_role,
 )
 from suite.mail.stalwart import get_domains as get_stalwart_domains
 from suite.mail.stalwart import get_permissions as get_stalwart_permissions
@@ -56,658 +56,658 @@ from suite.utils.user import is_suite_admin, is_system_manager, is_user_enabled
 
 
 def check_admin_permission(action: str, target: Any = None) -> str:
-	"""Ensure the session user is an enabled Suite Admin or System Manager, returning the user.
+    """Ensure the session user is an enabled Suite Admin or System Manager, returning the user.
 
-	The enabled check is defense-in-depth: a disabled admin holding a still-valid session (or an
-	API key) must not be able to perform admin actions, e.g. re-enable their own account via
-	enable_members. Throws frappe.PermissionError otherwise.
+    The enabled check is defense-in-depth: a disabled admin holding a still-valid session (or an
+    API key) must not be able to perform admin actions, e.g. re-enable their own account via
+    enable_members. Throws frappe.PermissionError otherwise.
 
-	Every action that changes something is also written to the admin log with ``target`` (the object
-	acted on), so a shared inbox of administrators stays accountable. Reads are not logged: each
-	dashboard page issues several and they change nothing.
-	"""
+    Every action that changes something is also written to the admin log with ``target`` (the object
+    acted on), so a shared inbox of administrators stays accountable. Reads are not logged: each
+    dashboard page issues several and they change nothing.
+    """
 
-	user = frappe.session.user
-	if (not is_suite_admin(user) and not is_system_manager(user)) or not is_user_enabled(user):
-		frappe.throw(
-			_("User {0} does not have permission to {1}.").format(frappe.bold(user), action),
-			frappe.PermissionError,
-		)
+    user = frappe.session.user
+    if (not is_suite_admin(user) and not is_system_manager(user)) or not is_user_enabled(user):
+        frappe.throw(
+            _("User {0} does not have permission to {1}.").format(frappe.bold(user), action),
+            frappe.PermissionError,
+        )
 
-	if not action.startswith("view "):
-		log_admin_action(action, target)
+    if not action.startswith("view "):
+        log_admin_action(action, target)
 
-	return user
+    return user
 
 
 def check_member_target(member_id: str) -> str:
-	"""Ensure ``member_id`` is a mail member the session user may act on, returning it.
+    """Ensure ``member_id`` is a mail member the session user may act on, returning it.
 
-	The member endpoints save the target User with ``ignore_permissions=True``, which bypasses the
-	framework's own guard against editing Administrator and other standard users. Without this check
-	a Suite Admin - a role ordinary members get when created with ``is_admin`` - could name any User
-	at all and, via change_member_password, take over the Administrator account.
+    The member endpoints save the target User with ``ignore_permissions=True``, which bypasses the
+    framework's own guard against editing Administrator and other standard users. Without this check
+    a Suite Admin - a role ordinary members get when created with ``is_admin`` - could name any User
+    at all and, via change_member_password, take over the Administrator account.
 
-	So the target must be a real mail member (the same predicate get_members lists on), never a
-	standard user, and never a System Manager unless the caller is one too.
-	"""
+    So the target must be a real mail member (the same predicate get_members lists on), never a
+    standard user, and never a System Manager unless the caller is one too.
+    """
 
-	if not member_id or member_id in frappe.STANDARD_USERS:
-		frappe.throw(_("{0} is not a mail member.").format(frappe.bold(member_id)), frappe.PermissionError)
+    if not member_id or member_id in frappe.STANDARD_USERS:
+        frappe.throw(_("{0} is not a mail member.").format(frappe.bold(member_id)), frappe.PermissionError)
 
-	if not frappe.db.exists("User Settings", {"user": member_id, "username": ["is", "set"]}):
-		frappe.throw(_("{0} is not a mail member.").format(frappe.bold(member_id)), frappe.PermissionError)
+    if not frappe.db.exists("User Settings", {"user": member_id, "username": ["is", "set"]}):
+        frappe.throw(_("{0} is not a mail member.").format(frappe.bold(member_id)), frappe.PermissionError)
 
-	if is_system_manager(member_id) and not is_system_manager(frappe.session.user):
-		frappe.throw(
-			_("You do not have permission to act on {0}.").format(frappe.bold(member_id)),
-			frappe.PermissionError,
-		)
+    if is_system_manager(member_id) and not is_system_manager(frappe.session.user):
+        frappe.throw(
+            _("You do not have permission to act on {0}.").format(frappe.bold(member_id)),
+            frappe.PermissionError,
+        )
 
-	return member_id
+    return member_id
 
 
 def _get_stalwart_domain(domain_id: str) -> dict:
-	"""Helper function to get a domain by ID from Stalwart, throwing a DoesNotExistError if not found."""
+    """Helper function to get a domain by ID from Stalwart, throwing a DoesNotExistError if not found."""
 
-	domains = get_stalwart_domains()
-	domain = next((d for d in domains if d["id"] == domain_id), None)
+    domains = get_stalwart_domains()
+    domain = next((d for d in domains if d["id"] == domain_id), None)
 
-	if not domain:
-		frappe.throw(_("Domain not found"), frappe.DoesNotExistError)
+    if not domain:
+        frappe.throw(_("Domain not found"), frappe.DoesNotExistError)
 
-	return domain
+    return domain
 
 
 @frappe.whitelist()
 @dynamic_rate_limit()
 def add_domain(name: str, description: str | None = None) -> str:
-	"""Adds a new domain to Stalwart with the specified name and description, returning the new domain's ID."""
+    """Adds a new domain to Stalwart with the specified name and description, returning the new domain's ID."""
 
-	check_admin_permission("add domains", name)
+    check_admin_permission("add domains", name)
 
-	for domain in get_stalwart_domains():
-		if domain["name"].lower() == name.lower():
-			frappe.throw(_("Domain {0} already exists.").format(name))
+    for domain in get_stalwart_domains():
+        if domain["name"].lower() == name.lower():
+            frappe.throw(_("Domain {0} already exists.").format(name))
 
-	domain_id = execute_with_logging(
-		func=lambda: get_domain_service().create(Domain(name=name, description=description)),
-		title=_("Failed to add domain {0}").format(name),
-		user_message=_("An error occurred while adding the domain, check error logs for more details."),
-		with_context=False,
-		module="Mail",
-	)
+    domain_id = execute_with_logging(
+        func=lambda: get_domain_service().create(Domain(name=name, description=description)),
+        title=_("Failed to add domain {0}").format(name),
+        user_message=_("An error occurred while adding the domain, check error logs for more details."),
+        with_context=False,
+        module="Mail",
+    )
 
-	get_stalwart_domains.clear_cache()
-	return domain_id
+    get_stalwart_domains.clear_cache()
+    return domain_id
 
 
 @frappe.whitelist()
 def get_domains(txt: str | None = None, is_enabled: bool | None = None) -> list[dict]:
-	"""Returns the list of domains configured in Stalwart, with optional filtering by name/description and enabled status"""
+    """Returns the list of domains configured in Stalwart, with optional filtering by name/description and enabled status"""
 
-	check_admin_permission("view domains")
+    check_admin_permission("view domains")
 
-	result = []
+    result = []
 
-	with suppress(Exception):
-		for domain in get_stalwart_domains():
-			if txt and (
-				txt.lower() not in domain["name"].lower()
-				and txt.lower() not in (domain.get("description") or "").lower()
-			):
-				continue
+    with suppress(Exception):
+        for domain in get_stalwart_domains():
+            if txt and (
+                txt.lower() not in domain["name"].lower()
+                and txt.lower() not in (domain.get("description") or "").lower()
+            ):
+                continue
 
-			if is_enabled is not None and domain["isEnabled"] != bool(is_enabled):
-				continue
+            if is_enabled is not None and domain["isEnabled"] != bool(is_enabled):
+                continue
 
-			result.append(
-				{
-					"id": domain["id"],
-					"name": domain["name"],
-					"description": domain.get("description", ""),
-					"is_enabled": domain["isEnabled"],
-					"created_at": domain["createdAt"],
-				}
-			)
+            result.append(
+                {
+                    "id": domain["id"],
+                    "name": domain["name"],
+                    "description": domain.get("description", ""),
+                    "is_enabled": domain["isEnabled"],
+                    "created_at": domain["createdAt"],
+                }
+            )
 
-	return result
+    return result
 
 
 @frappe.whitelist()
 def get_domain(domain_id: str) -> dict:
-	"""Returns the details of a domain, including its DNS records parsed from the zone file"""
+    """Returns the details of a domain, including its DNS records parsed from the zone file"""
 
-	check_admin_permission("view domains")
+    check_admin_permission("view domains")
 
-	def infer_category(record: dict) -> str:
-		"""Infers the category of the DNS record based on its type and name."""
+    def infer_category(record: dict) -> str:
+        """Infers the category of the DNS record based on its type and name."""
 
-		t = record["type"]
-		name = record["name"]
+        t = record["type"]
+        name = record["name"]
 
-		if t == "MX":
-			return "Receiving"
+        if t == "MX":
+            return "Receiving"
 
-		if t == "TXT":
-			value = record["value"] or ""
-			if name.startswith("_dmarc"):
-				return "DMARC"
-			if "spf1" in value:
-				return "Sending"
-			if "domainkey" in name:
-				return "DKIM"
-			if name.startswith("_smtp._tls"):
-				return "TLS Reporting"
-			return "TXT"
+        if t == "TXT":
+            value = record["value"] or ""
+            if name.startswith("_dmarc"):
+                return "DMARC"
+            if "spf1" in value:
+                return "Sending"
+            if "domainkey" in name:
+                return "DKIM"
+            if name.startswith("_smtp._tls"):
+                return "TLS Reporting"
+            return "TXT"
 
-		if t == "CNAME":
-			if "autoconfig" in name:
-				return "Auto-config"
-			if "autodiscover" in name:
-				return "Auto-discover"
-			return "Alias"
+        if t == "CNAME":
+            if "autoconfig" in name:
+                return "Auto-config"
+            if "autodiscover" in name:
+                return "Auto-discover"
+            return "Alias"
 
-		if t == "SRV":
-			if "_imap" in name or "_pop3" in name:
-				return "Receiving"
-			if "_submission" in name or "_submissions" in name:
-				return "Sending"
-			return "Server"
+        if t == "SRV":
+            if "_imap" in name or "_pop3" in name:
+                return "Receiving"
+            if "_submission" in name or "_submissions" in name:
+                return "Sending"
+            return "Server"
 
-		return "Other"
+        return "Other"
 
-	def is_mandatory(record: dict) -> bool:
-		"""Define which DNS records are required."""
+    def is_mandatory(record: dict) -> bool:
+        """Define which DNS records are required."""
 
-		category = record["category"]
-		value = record["value"]
+        category = record["category"]
+        value = record["value"]
 
-		if category == "Sending" and "spf1" in value:
-			return True
-		if category == "DMARC":
-			return True
-		if category == "DKIM":
-			return True
-		if record["type"] == "MX":
-			return False
+        if category == "Sending" and "spf1" in value:
+            return True
+        if category == "DMARC":
+            return True
+        if category == "DKIM":
+            return True
+        if record["type"] == "MX":
+            return False
 
-		return False
+        return False
 
-	domain = _get_stalwart_domain(domain_id)
+    domain = _get_stalwart_domain(domain_id)
 
-	default_ttl = get_config("default_dns_ttl")
-	dns_records = parse_dns_zone_file(domain["dnsZoneFile"])
-	for record in dns_records:
-		if not record["ttl"]:
-			record["ttl"] = default_ttl
-		record["category"] = infer_category(record)
-		record["mandatory"] = is_mandatory(record)
+    default_ttl = get_config("default_dns_ttl")
+    dns_records = parse_dns_zone_file(domain["dnsZoneFile"])
+    for record in dns_records:
+        if not record["ttl"]:
+            record["ttl"] = default_ttl
+        record["category"] = infer_category(record)
+        record["mandatory"] = is_mandatory(record)
 
-	return {
-		"id": domain["id"],
-		"name": domain["name"],
-		"description": domain.get("description", ""),
-		"is_enabled": domain["isEnabled"],
-		"created_at": domain["createdAt"],
-		"dns_records": dns_records,
-	}
+    return {
+        "id": domain["id"],
+        "name": domain["name"],
+        "description": domain.get("description", ""),
+        "is_enabled": domain["isEnabled"],
+        "created_at": domain["createdAt"],
+        "dns_records": dns_records,
+    }
 
 
 @frappe.whitelist()
 def delete_domain(domain_id: str) -> None:
-	"""Deletes a domain identified by Stalwart domain ID."""
+    """Deletes a domain identified by Stalwart domain ID."""
 
-	check_admin_permission("delete domains", domain_id)
+    check_admin_permission("delete domains", domain_id)
 
-	execute_with_logging(
-		func=lambda: get_domain_service().delete([domain_id]),
-		title=_("Failed to delete domain with ID {0}").format(domain_id),
-		user_message=_("An error occurred while deleting the domain, check error logs for more details."),
-		with_context=False,
-		module="Mail",
-	)
+    execute_with_logging(
+        func=lambda: get_domain_service().delete([domain_id]),
+        title=_("Failed to delete domain with ID {0}").format(domain_id),
+        user_message=_("An error occurred while deleting the domain, check error logs for more details."),
+        with_context=False,
+        module="Mail",
+    )
 
-	get_stalwart_domains.clear_cache()
+    get_stalwart_domains.clear_cache()
 
 
 @frappe.whitelist()
 def get_enabled_domains() -> list[str]:
-	"""Returns the list of enabled domains"""
+    """Returns the list of enabled domains"""
 
-	check_admin_permission("view domains")
+    check_admin_permission("view domains")
 
-	try:
-		return list(set([d["name"] for d in get_stalwart_domains() if d["isEnabled"]]))
-	except Exception:
-		return []
+    try:
+        return list(set([d["name"] for d in get_stalwart_domains() if d["isEnabled"]]))
+    except Exception:
+        return []
 
 
 @frappe.whitelist()
 def get_domain_dns_zone(domain_id: str) -> str:
-	"""Returns the DNS zone file of the domain"""
+    """Returns the DNS zone file of the domain"""
 
-	check_admin_permission("view domains")
+    check_admin_permission("view domains")
 
-	domain = _get_stalwart_domain(domain_id)
-	return domain["dnsZoneFile"]
+    domain = _get_stalwart_domain(domain_id)
+    return domain["dnsZoneFile"]
 
 
 @frappe.whitelist()
 def get_domain_dns_csv(domain_id: str) -> str:
-	"""Returns the DNS records of the domain as a CSV string"""
+    """Returns the DNS records of the domain as a CSV string"""
 
-	check_admin_permission("view domains")
+    check_admin_permission("view domains")
 
-	domain = _get_stalwart_domain(domain_id)
-	dns_records = parse_dns_zone_file(domain["dnsZoneFile"])
+    domain = _get_stalwart_domain(domain_id)
+    dns_records = parse_dns_zone_file(domain["dnsZoneFile"])
 
-	fieldnames = ["name", "ttl", "class", "type", "value"]
+    fieldnames = ["name", "ttl", "class", "type", "value"]
 
-	output = io.StringIO()
-	writer = csv.DictWriter(output, fieldnames=fieldnames)
-	writer.writeheader()
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=fieldnames)
+    writer.writeheader()
 
-	for record in dns_records:
-		writer.writerow(record)
+    for record in dns_records:
+        writer.writerow(record)
 
-	return output.getvalue()
+    return output.getvalue()
 
 
 @frappe.whitelist()
 def get_domain_dns_json(domain_id: str) -> str:
-	"""Returns the DNS records of the domain as a JSON object"""
+    """Returns the DNS records of the domain as a JSON object"""
 
-	check_admin_permission("view domains")
+    check_admin_permission("view domains")
 
-	domain = _get_stalwart_domain(domain_id)
-	dns_records = parse_dns_zone_file(domain["dnsZoneFile"])
-	return json.dumps(dns_records, indent=4)
+    domain = _get_stalwart_domain(domain_id)
+    dns_records = parse_dns_zone_file(domain["dnsZoneFile"])
+    return json.dumps(dns_records, indent=4)
 
 
 @frappe.whitelist()
 @dynamic_rate_limit()
 def add_member(
-	username: str,
-	domain: str,
-	is_admin: bool,
-	send_invite: bool,
-	backup_email: str,
-	first_name: str | None = None,
-	last_name: str | None = None,
-	password: str | None = None,
-	expires_at: str | None = None,
-	aliases: list | None = None,
-	groups: list | None = None,
-	mailing_lists: list | None = None,
-	quota_gb: float | None = None,
-	locale: str | None = None,
-	time_zone: str | None = None,
+    username: str,
+    domain: str,
+    is_admin: bool,
+    send_invite: bool,
+    backup_email: str,
+    first_name: str | None = None,
+    last_name: str | None = None,
+    password: str | None = None,
+    expires_at: str | None = None,
+    aliases: list | None = None,
+    groups: list | None = None,
+    mailing_lists: list | None = None,
+    quota_gb: float | None = None,
+    locale: str | None = None,
+    time_zone: str | None = None,
 ) -> None:
-	"""Create a new Mail Account Request for adding a member.
+    """Create a new Mail Account Request for adding a member.
 
-	``username``/``domain`` are the primary address (becomes the User); ``aliases`` are additional
-	full email addresses attached as aliases to the same account. ``groups`` and ``mailing_lists``
-	are ids the account joins once it is created — right away when invites are off, on verification
-	otherwise. ``quota_gb`` is the account's disk quota, where ``0`` means unlimited and ``None``
-	falls back to the configured default.
+    ``username``/``domain`` are the primary address (becomes the User); ``aliases`` are additional
+    full email addresses attached as aliases to the same account. ``groups`` and ``mailing_lists``
+    are ids the account joins once it is created — right away when invites are off, on verification
+    otherwise. ``quota_gb`` is the account's disk quota, where ``0`` means unlimited and ``None``
+    falls back to the configured default.
 
-	``locale`` and ``time_zone``, like the name and password, only apply when the account is created
-	right away; an invited member picks their own on the setup form.
-	"""
+    ``locale`` and ``time_zone``, like the name and password, only apply when the account is created
+    right away; an invited member picks their own on the setup form.
+    """
 
-	account_request = frappe.new_doc("Mail Account Request")
-	account_request.account = f"{username}@{domain}"
-	account_request.aliases = "\n".join(_listify(aliases))
-	account_request.groups = "\n".join(str(g) for g in _listify(groups))
-	account_request.mailing_lists = "\n".join(str(ml) for ml in _listify(mailing_lists))
-	if quota_gb is not None:
-		account_request.quota_gb = flt(quota_gb)
-	account_request.is_admin = cint(is_admin)
-	account_request.invited_by = frappe.session.user
-	account_request.backup_email = backup_email
-	account_request.send_invite = cint(send_invite)
-	# Arrives as UTC like every other timestamp; the doctype field holds system time.
-	account_request.expires_at = from_utc_z(expires_at)
-	# Insert first: create permission on Mail Account Request is what gates this endpoint, so the
-	# action is only authorized (and worth recording) once the request exists.
-	account_request.insert()
-	log_admin_action("add members", account_request.account)
+    account_request = frappe.new_doc("Mail Account Request")
+    account_request.account = f"{username}@{domain}"
+    account_request.aliases = "\n".join(_listify(aliases))
+    account_request.groups = "\n".join(str(g) for g in _listify(groups))
+    account_request.mailing_lists = "\n".join(str(ml) for ml in _listify(mailing_lists))
+    if quota_gb is not None:
+        account_request.quota_gb = flt(quota_gb)
+    account_request.is_admin = cint(is_admin)
+    account_request.invited_by = frappe.session.user
+    account_request.backup_email = backup_email
+    account_request.send_invite = cint(send_invite)
+    # Arrives as UTC like every other timestamp; the doctype field holds system time.
+    account_request.expires_at = from_utc_z(expires_at)
+    # Insert first: create permission on Mail Account Request is what gates this endpoint, so the
+    # action is only authorized (and worth recording) once the request exists.
+    account_request.insert()
+    log_admin_action("add members", account_request.account)
 
-	if not send_invite:
-		account_request.force_verify_and_create_account(first_name, last_name, password, locale, time_zone)
+    if not send_invite:
+        account_request.force_verify_and_create_account(first_name, last_name, password, locale, time_zone)
 
 
 @frappe.whitelist()
 def get_members(
-	search: str | None = None, is_admin: bool | None = None, is_enabled: bool | None = None
+    search: str | None = None, is_admin: bool | None = None, is_enabled: bool | None = None
 ) -> list:
-	check_admin_permission("view members")
+    check_admin_permission("view members")
 
-	USER = frappe.qb.DocType("User")
-	HAS_ROLE = frappe.qb.DocType("Has Role")
-	USER_SETTINGS = frappe.qb.DocType("User Settings")
+    USER = frappe.qb.DocType("User")
+    HAS_ROLE = frappe.qb.DocType("Has Role")
+    USER_SETTINGS = frappe.qb.DocType("User Settings")
 
-	admin_case = Case().when(HAS_ROLE.role == "Suite Admin", 1).else_(0)
-	is_admin_expr = Max(admin_case)
+    admin_case = Case().when(HAS_ROLE.role == "Suite Admin", 1).else_(0)
+    is_admin_expr = Max(admin_case)
 
-	query = (
-		frappe.qb.from_(USER)
-		.left_join(HAS_ROLE)
-		.on(USER.name == HAS_ROLE.parent)
-		.left_join(USER_SETTINGS)
-		.on(USER.name == USER_SETTINGS.user)
-		.select(
-			USER.name,
-			USER.full_name,
-			USER.user_image,
-			USER.last_active,
-			USER.enabled,
-			is_admin_expr.as_("is_admin"),
-		)
-		.where(USER_SETTINGS.username.isnotnull())
-		.groupby(USER.name)
-	)
+    query = (
+        frappe.qb.from_(USER)
+        .left_join(HAS_ROLE)
+        .on(USER.name == HAS_ROLE.parent)
+        .left_join(USER_SETTINGS)
+        .on(USER.name == USER_SETTINGS.user)
+        .select(
+            USER.name,
+            USER.full_name,
+            USER.user_image,
+            USER.last_active,
+            USER.enabled,
+            is_admin_expr.as_("is_admin"),
+        )
+        .where(USER_SETTINGS.username.isnotnull())
+        .groupby(USER.name)
+    )
 
-	if is_enabled is not None:
-		query = query.where(USER.enabled == (1 if is_enabled else 0))
+    if is_enabled is not None:
+        query = query.where(USER.enabled == (1 if is_enabled else 0))
 
-	if search:
-		query = query.where(USER.name.like(f"%{search}%") | USER.full_name.like(f"%{search}%"))
+    if search:
+        query = query.where(USER.name.like(f"%{search}%") | USER.full_name.like(f"%{search}%"))
 
-	if is_admin is not None:
-		query = query.having(is_admin_expr == (1 if is_admin else 0))
+    if is_admin is not None:
+        query = query.having(is_admin_expr == (1 if is_admin else 0))
 
-	users = (
-		query.orderby(is_admin_expr, order=Order.desc).orderby(USER.name, order=Order.asc).run(as_dict=True)
-	)
+    users = (
+        query.orderby(is_admin_expr, order=Order.desc).orderby(USER.name, order=Order.asc).run(as_dict=True)
+    )
 
-	for user in users:
-		if not user.get("user_image"):
-			user["user_image"] = get_avatar_url(user["name"])
+    for user in users:
+        if not user.get("user_image"):
+            user["user_image"] = get_avatar_url(user["name"])
 
-		user["is_admin"] = bool(user.get("is_admin"))
-		user["enabled"] = bool(user.get("enabled"))
-		# Stored in system time; the API speaks UTC, like every other timestamp it returns.
-		user["last_active"] = to_utc_z(user.get("last_active"))
+        user["is_admin"] = bool(user.get("is_admin"))
+        user["enabled"] = bool(user.get("enabled"))
+        # Stored in system time; the API speaks UTC, like every other timestamp it returns.
+        user["last_active"] = to_utc_z(user.get("last_active"))
 
-	return users
+    return users
 
 
 def _build_quota_usage(total: int, used: int) -> dict:
-	"""Normalizes raw disk-quota byte counts into the shape the member page renders.
+    """Normalizes raw disk-quota byte counts into the shape the member page renders.
 
-	A total of 0 (Stalwart omits maxDiskQuota) means unlimited storage, so percentages and the
-	available figure are meaningless and reported as such.
-	"""
+    A total of 0 (Stalwart omits maxDiskQuota) means unlimited storage, so percentages and the
+    available figure are meaningless and reported as such.
+    """
 
-	total = max(total or 0, 0)
-	used = max(used or 0, 0)
+    total = max(total or 0, 0)
+    used = max(used or 0, 0)
 
-	if total <= 0:
-		return {
-			"total": 0,
-			"used": used,
-			"available": 0,
-			"used_percentage": 0,
-			"available_percentage": 0,
-			"unlimited": True,
-		}
+    if total <= 0:
+        return {
+            "total": 0,
+            "used": used,
+            "available": 0,
+            "used_percentage": 0,
+            "available_percentage": 0,
+            "unlimited": True,
+        }
 
-	available = max(total - used, 0)
-	used_percentage = min((used / total) * 100, 100)
+    available = max(total - used, 0)
+    used_percentage = min((used / total) * 100, 100)
 
-	return {
-		"total": total,
-		"used": used,
-		"available": available,
-		"used_percentage": used_percentage,
-		"available_percentage": 100 - used_percentage,
-		"unlimited": False,
-	}
+    return {
+        "total": total,
+        "used": used,
+        "available": available,
+        "used_percentage": used_percentage,
+        "available_percentage": 100 - used_percentage,
+        "unlimited": False,
+    }
 
 
 @frappe.whitelist()
 def get_member(member_id: str) -> dict:
-	"""Returns a member's profile along with their Stalwart quota usage and email addresses.
+    """Returns a member's profile along with their Stalwart quota usage and email addresses.
 
-	Quota and email addresses are read live from the member's personal Stalwart account via the CLI;
-	when the member has no personal account configured, those sections come back empty rather than
-	failing the whole page.
-	"""
+    Quota and email addresses are read live from the member's personal Stalwart account via the CLI;
+    when the member has no personal account configured, those sections come back empty rather than
+    failing the whole page.
+    """
 
-	check_admin_permission("view members")
+    check_admin_permission("view members")
 
-	user = frappe.db.get_value(
-		"User",
-		member_id,
-		["name", "full_name", "user_image", "last_active", "enabled", "creation"],
-		as_dict=True,
-	)
-	if not user:
-		frappe.throw(_("Member not found"), frappe.DoesNotExistError)
+    user = frappe.db.get_value(
+        "User",
+        member_id,
+        ["name", "full_name", "user_image", "last_active", "enabled", "creation"],
+        as_dict=True,
+    )
+    if not user:
+        frappe.throw(_("Member not found"), frappe.DoesNotExistError)
 
-	is_admin = bool(frappe.db.exists("Has Role", {"parent": member_id, "role": "Suite Admin"}))
+    is_admin = bool(frappe.db.exists("Has Role", {"parent": member_id, "role": "Suite Admin"}))
 
-	result = {
-		"name": user.name,
-		"full_name": user.full_name,
-		"user_image": user.user_image or get_avatar_url(user.name),
-		"description": user.full_name,
-		# Both are stored in system time; the API speaks UTC.
-		"last_active": to_utc_z(user.last_active),
-		"joined_on": to_utc_z(user.creation),
-		"enabled": bool(user.enabled),
-		"is_admin": is_admin,
-		"email_addresses": [],
-		"groups": [],
-		"mailing_lists": [],
-		"quota": _build_quota_usage(0, 0),
-		"locale": None,
-		"time_zone": None,
-	}
+    result = {
+        "name": user.name,
+        "full_name": user.full_name,
+        "user_image": user.user_image or get_avatar_url(user.name),
+        "description": user.full_name,
+        # Both are stored in system time; the API speaks UTC.
+        "last_active": to_utc_z(user.last_active),
+        "joined_on": to_utc_z(user.creation),
+        "enabled": bool(user.enabled),
+        "is_admin": is_admin,
+        "email_addresses": [],
+        "groups": [],
+        "mailing_lists": [],
+        "quota": _build_quota_usage(0, 0),
+        "locale": None,
+        "time_zone": None,
+    }
 
-	account_id = get_user_personal_jmap_account(member_id)
-	if not account_id:
-		return result
+    account_id = get_user_personal_jmap_account(member_id)
+    if not account_id:
+        return result
 
-	with suppress(Exception):
-		account = get_account_service().get(
-			account_id,
-			properties=[
-				"emailAddress",
-				"aliases",
-				"quotas",
-				"usedDiskQuota",
-				"memberGroupIds",
-				"description",
-				"locale",
-				"timeZone",
-			],
-		)
-		if not account:
-			return result
+    with suppress(Exception):
+        account = get_account_service().get(
+            account_id,
+            properties=[
+                "emailAddress",
+                "aliases",
+                "quotas",
+                "usedDiskQuota",
+                "memberGroupIds",
+                "description",
+                "locale",
+                "timeZone",
+            ],
+        )
+        if not account:
+            return result
 
-		result["locale"] = account.get("locale")
-		result["time_zone"] = account.get("timeZone")
+        result["locale"] = account.get("locale")
+        result["time_zone"] = account.get("timeZone")
 
-		# Each address carries a description used as its Identity display name: the primary uses the
-		# account description, each alias its own.
-		email_addresses = []
-		if primary := account.get("emailAddress"):
-			email_addresses.append(
-				{
-					"email": primary,
-					"description": account.get("description"),
-					"is_primary": True,
-					"enabled": True,
-				}
-			)
+        # Each address carries a description used as its Identity display name: the primary uses the
+        # account description, each alias its own.
+        email_addresses = []
+        if primary := account.get("emailAddress"):
+            email_addresses.append(
+                {
+                    "email": primary,
+                    "description": account.get("description"),
+                    "is_primary": True,
+                    "enabled": True,
+                }
+            )
 
-		aliases = account.get("aliases") or {}
-		if aliases:
-			domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
-			for alias in aliases.values():
-				name = alias.get("name")
-				domain_name = domain_names.get(alias.get("domainId"))
-				if name and domain_name:
-					email_addresses.append(
-						{
-							"email": f"{name}@{domain_name}",
-							"description": alias.get("description"),
-							"is_primary": False,
-							"enabled": bool(alias.get("enabled", True)),
-						}
-					)
+        aliases = account.get("aliases") or {}
+        if aliases:
+            domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
+            for alias in aliases.values():
+                name = alias.get("name")
+                domain_name = domain_names.get(alias.get("domainId"))
+                if name and domain_name:
+                    email_addresses.append(
+                        {
+                            "email": f"{name}@{domain_name}",
+                            "description": alias.get("description"),
+                            "is_primary": False,
+                            "enabled": bool(alias.get("enabled", True)),
+                        }
+                    )
 
-		emails = [entry["email"] for entry in email_addresses]
-		result["email_addresses"] = email_addresses
-		result["quota"] = _build_quota_usage(
-			(account.get("quotas") or {}).get("maxDiskQuota") or 0,
-			account.get("usedDiskQuota") or 0,
-		)
+        emails = [entry["email"] for entry in email_addresses]
+        result["email_addresses"] = email_addresses
+        result["quota"] = _build_quota_usage(
+            (account.get("quotas") or {}).get("maxDiskQuota") or 0,
+            account.get("usedDiskQuota") or 0,
+        )
 
-		# Groups the account belongs to (membership lives on the account's memberGroupIds).
-		group_ids = _keys(account.get("memberGroupIds"))
-		if group_ids:
-			group_map = {
-				g["id"]: g
-				for g in get_group_service().get_all_groups(properties=["id", "name", "emailAddress"])
-			}
-			result["groups"] = [
-				{"id": gid, "name": group_map[gid].get("name"), "email": group_map[gid].get("emailAddress")}
-				for gid in group_ids
-				if gid in group_map
-			]
+        # Groups the account belongs to (membership lives on the account's memberGroupIds).
+        group_ids = _keys(account.get("memberGroupIds"))
+        if group_ids:
+            group_map = {
+                g["id"]: g
+                for g in get_group_service().get_all_groups(properties=["id", "name", "emailAddress"])
+            }
+            result["groups"] = [
+                {"id": gid, "name": group_map[gid].get("name"), "email": group_map[gid].get("emailAddress")}
+                for gid in group_ids
+                if gid in group_map
+            ]
 
-		# Mailing lists that include the member as a recipient. Recipients are email addresses
-		# (internal or external), so match against the member's own addresses, not the account id.
-		member_emails = {email.lower() for email in emails}
-		result["mailing_lists"] = [
-			{"id": ml["id"], "name": ml.get("name"), "email": ml.get("emailAddress")}
-			for ml in get_mailing_list_service().get_all(
-				properties=["id", "name", "emailAddress", "recipients"]
-			)
-			if member_emails & {recipient.lower() for recipient in _keys(ml.get("recipients"))}
-		]
+        # Mailing lists that include the member as a recipient. Recipients are email addresses
+        # (internal or external), so match against the member's own addresses, not the account id.
+        member_emails = {email.lower() for email in emails}
+        result["mailing_lists"] = [
+            {"id": ml["id"], "name": ml.get("name"), "email": ml.get("emailAddress")}
+            for ml in get_mailing_list_service().get_all(
+                properties=["id", "name", "emailAddress", "recipients"]
+            )
+            if member_emails & {recipient.lower() for recipient in _keys(ml.get("recipients"))}
+        ]
 
-	return result
+    return result
 
 
 @frappe.whitelist()
 def get_account_requests(
-	search: str | None = None, status: Literal["All", "Pending", "Accepted", "Expired"] = "All"
+    search: str | None = None, status: Literal["All", "Pending", "Accepted", "Expired"] = "All"
 ) -> list[dict]:
-	"""Returns the list of account invites"""
+    """Returns the list of account invites"""
 
-	check_admin_permission("view account requests")
+    check_admin_permission("view account requests")
 
-	ACC_REQ = frappe.qb.DocType("Mail Account Request")
-	query = (
-		frappe.qb.from_(ACC_REQ)
-		.select(
-			ACC_REQ.name,
-			ACC_REQ.account,
-			ACC_REQ.is_admin,
-			ACC_REQ.backup_email,
-			ACC_REQ.invited_by,
-			ACC_REQ.is_verified,
-		)
-		.orderby(ACC_REQ.creation, order=Order.desc)
-	)
+    ACC_REQ = frappe.qb.DocType("Mail Account Request")
+    query = (
+        frappe.qb.from_(ACC_REQ)
+        .select(
+            ACC_REQ.name,
+            ACC_REQ.account,
+            ACC_REQ.is_admin,
+            ACC_REQ.backup_email,
+            ACC_REQ.invited_by,
+            ACC_REQ.is_verified,
+        )
+        .orderby(ACC_REQ.creation, order=Order.desc)
+    )
 
-	if search:
-		query = query.where(ACC_REQ.account.like(f"%{search}%"))
+    if search:
+        query = query.where(ACC_REQ.account.like(f"%{search}%"))
 
-	if status == "Pending":
-		query = query.where((ACC_REQ.is_verified == 0) & (ACC_REQ.expires_at > frappe.utils.now()))
-	elif status == "Accepted":
-		query = query.where(ACC_REQ.is_verified == 1)
-	elif status == "Expired":
-		query = query.where((ACC_REQ.is_verified == 0) & (ACC_REQ.expires_at <= frappe.utils.now()))
+    if status == "Pending":
+        query = query.where((ACC_REQ.is_verified == 0) & (ACC_REQ.expires_at > frappe.utils.now()))
+    elif status == "Accepted":
+        query = query.where(ACC_REQ.is_verified == 1)
+    elif status == "Expired":
+        query = query.where((ACC_REQ.is_verified == 0) & (ACC_REQ.expires_at <= frappe.utils.now()))
 
-	invites = query.run(as_dict=True)
+    invites = query.run(as_dict=True)
 
-	return invites
+    return invites
 
 
 @frappe.whitelist()
 def delete_account_requests(names: list) -> None:
-	"""Delete Mail Account Requests"""
+    """Delete Mail Account Requests"""
 
-	check_admin_permission("delete account requests", names)
+    check_admin_permission("delete account requests", names)
 
-	for d in names:
-		frappe.delete_doc("Mail Account Request", d)
+    for d in names:
+        frappe.delete_doc("Mail Account Request", d)
 
 
 @frappe.whitelist()
 def delete_members(names: list) -> None:
-	"""Delete member users. The User on_trash hooks cascade to their Stalwart account and settings."""
+    """Delete member users. The User on_trash hooks cascade to their Stalwart account and settings."""
 
-	user = check_admin_permission("delete members", names)
+    user = check_admin_permission("delete members", names)
 
-	if user in names:
-		frappe.throw(_("You cannot delete your own account."))
+    if user in names:
+        frappe.throw(_("You cannot delete your own account."))
 
-	for name in names:
-		check_member_target(name)
-		frappe.delete_doc("User", name)
+    for name in names:
+        check_member_target(name)
+        frappe.delete_doc("User", name)
 
 
 @frappe.whitelist()
 def disable_members(names: list) -> None:
-	"""Disable member users. Disabled users can no longer log in and their sessions are cleared."""
+    """Disable member users. Disabled users can no longer log in and their sessions are cleared."""
 
-	user = check_admin_permission("disable members", names)
+    user = check_admin_permission("disable members", names)
 
-	if user in names:
-		frappe.throw(_("You cannot disable your own account."))
+    if user in names:
+        frappe.throw(_("You cannot disable your own account."))
 
-	for name in names:
-		check_member_target(name)
-		member = frappe.get_doc("User", name)
-		if not member.enabled:
-			continue
+    for name in names:
+        check_member_target(name)
+        member = frappe.get_doc("User", name)
+        if not member.enabled:
+            continue
 
-		member.enabled = 0
-		member.save(ignore_permissions=True)
+        member.enabled = 0
+        member.save(ignore_permissions=True)
 
 
 @frappe.whitelist()
 def enable_members(names: list) -> None:
-	"""Enable member users. The configured disabled account role is removed and the users can log in again."""
+    """Enable member users. The configured disabled account role is removed and the users can log in again."""
 
-	check_admin_permission("enable members", names)
+    check_admin_permission("enable members", names)
 
-	for name in names:
-		check_member_target(name)
-		member = frappe.get_doc("User", name)
-		if member.enabled:
-			continue
+    for name in names:
+        check_member_target(name)
+        member = frappe.get_doc("User", name)
+        if member.enabled:
+            continue
 
-		member.enabled = 1
-		member.save(ignore_permissions=True)
+        member.enabled = 1
+        member.save(ignore_permissions=True)
 
 
 @frappe.whitelist()
 @dynamic_rate_limit()
 def change_member_password(member_id: str, new_password: str) -> None:
-	"""Set a member's password directly.
+    """Set a member's password directly.
 
-	Saving the User with `new_password` set triggers the update_account_password hook, which
-	propagates the new password to the member's Stalwart account.
-	"""
+    Saving the User with `new_password` set triggers the update_account_password hook, which
+    propagates the new password to the member's Stalwart account.
+    """
 
-	check_admin_permission("change member password", member_id)
-	check_member_target(member_id)
+    check_admin_permission("change member password", member_id)
+    check_member_target(member_id)
 
-	if not new_password:
-		frappe.throw(_("New password is required."))
+    if not new_password:
+        frappe.throw(_("New password is required."))
 
-	member = frappe.get_doc("User", member_id)
-	member.new_password = new_password
-	member.save(ignore_permissions=True)
+    member = frappe.get_doc("User", member_id)
+    member.new_password = new_password
+    member.save(ignore_permissions=True)
 
 
 # ---------------------------------------------------------------------------
@@ -718,323 +718,323 @@ _GB = 1024**3
 
 
 def _member_account(member_id: str) -> str | None:
-	"""Returns the member's personal Stalwart account id, or None if they have none."""
+    """Returns the member's personal Stalwart account id, or None if they have none."""
 
-	return get_user_personal_jmap_account(member_id, raise_exception=False)
+    return get_user_personal_jmap_account(member_id, raise_exception=False)
 
 
 def _require_member_account(member_id: str) -> str:
-	account_id = _member_account(member_id)
-	if not account_id:
-		frappe.throw(_("This member does not have a mail account."))
+    account_id = _member_account(member_id)
+    if not account_id:
+        frappe.throw(_("This member does not have a mail account."))
 
-	return account_id
+    return account_id
 
 
 def _alias_emails(account: dict, domain_names: dict) -> list[str]:
-	"""Builds the account's alias email addresses from its raw ``aliases`` map."""
+    """Builds the account's alias email addresses from its raw ``aliases`` map."""
 
-	emails = []
-	for alias in (account.get("aliases") or {}).values():
-		name = alias.get("name")
-		domain = domain_names.get(alias.get("domainId"))
-		if name and domain:
-			emails.append(f"{name}@{domain}")
+    emails = []
+    for alias in (account.get("aliases") or {}).values():
+        name = alias.get("name")
+        domain = domain_names.get(alias.get("domainId"))
+        if name and domain:
+            emails.append(f"{name}@{domain}")
 
-	return emails
+    return emails
 
 
 def _rebuild_aliases(account: dict, *, keep: callable) -> list[EmailAlias]:
-	"""Rebuilds the account's alias objects, keeping those for which ``keep(email)`` is True."""
+    """Rebuilds the account's alias objects, keeping those for which ``keep(email)`` is True."""
 
-	domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
-	aliases = []
-	for alias in (account.get("aliases") or {}).values():
-		domain = domain_names.get(alias.get("domainId"))
-		email = f"{alias.get('name')}@{domain}" if domain else None
-		if email and not keep(email.lower()):
-			continue
+    domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
+    aliases = []
+    for alias in (account.get("aliases") or {}).values():
+        domain = domain_names.get(alias.get("domainId"))
+        email = f"{alias.get('name')}@{domain}" if domain else None
+        if email and not keep(email.lower()):
+            continue
 
-		aliases.append(
-			EmailAlias(
-				name=alias["name"],
-				domain_id=alias["domainId"],
-				enabled=alias.get("enabled", True),
-				description=alias.get("description"),
-			)
-		)
+        aliases.append(
+            EmailAlias(
+                name=alias["name"],
+                domain_id=alias["domainId"],
+                enabled=alias.get("enabled", True),
+                description=alias.get("description"),
+            )
+        )
 
-	return aliases
+    return aliases
 
 
 def _locale_patch(locale: str | None, time_zone: str | None) -> dict:
-	"""Builds the account patch for the locale and time zone, skipping whatever was not passed.
+    """Builds the account patch for the locale and time zone, skipping whatever was not passed.
 
-	The two differ on the server: a locale is required, so an empty one leaves it alone, while the
-	time zone is nullable and an empty one clears it back to "unset".
-	"""
+    The two differ on the server: a locale is required, so an empty one leaves it alone, while the
+    time zone is nullable and an empty one clears it back to "unset".
+    """
 
-	patch = {}
-	if locale:
-		patch["locale"] = locale
-	if time_zone is not None:
-		patch["timeZone"] = time_zone or None
-	return patch
+    patch = {}
+    if locale:
+        patch["locale"] = locale
+    if time_zone is not None:
+        patch["timeZone"] = time_zone or None
+    return patch
 
 
 @frappe.whitelist()
 def get_account_options() -> dict:
-	"""Returns the locale and time zone choices for editing a member or group."""
+    """Returns the locale and time zone choices for editing a member or group."""
 
-	check_admin_permission("view account options")
-	return get_account_metadata()
+    check_admin_permission("view account options")
+    return get_account_metadata()
 
 
 @frappe.whitelist()
 def update_member(
-	member_id: str,
-	role: str | None = None,
-	description: str | None = None,
-	quota_gb: float | None = None,
-	locale: str | None = None,
-	time_zone: str | None = None,
+    member_id: str,
+    role: str | None = None,
+    description: str | None = None,
+    quota_gb: float | None = None,
+    locale: str | None = None,
+    time_zone: str | None = None,
 ) -> None:
-	"""Updates a member's role, display name, quota, locale and time zone on Frappe and Stalwart."""
+    """Updates a member's role, display name, quota, locale and time zone on Frappe and Stalwart."""
 
-	check_admin_permission("update members", member_id)
-	check_member_target(member_id)
+    check_admin_permission("update members", member_id)
+    check_member_target(member_id)
 
-	member = frappe.get_doc("User", member_id)
+    member = frappe.get_doc("User", member_id)
 
-	if role is not None:
-		if role == "admin":
-			member.append_roles("Suite Admin")
-		else:
-			member.set("roles", [r for r in member.get("roles") if r.role != "Suite Admin"])
+    if role is not None:
+        if role == "admin":
+            member.append_roles("Suite Admin")
+        else:
+            member.set("roles", [r for r in member.get("roles") if r.role != "Suite Admin"])
 
-	description = (description or "").strip()
-	if description:
-		first, _sep, last = description.partition(" ")
-		member.first_name = first
-		member.last_name = last or None
+    description = (description or "").strip()
+    if description:
+        first, _sep, last = description.partition(" ")
+        member.first_name = first
+        member.last_name = last or None
 
-	member.save(ignore_permissions=True)
+    member.save(ignore_permissions=True)
 
-	account_id = _member_account(member_id)
-	account_service = get_account_service()
+    account_id = _member_account(member_id)
+    account_service = get_account_service()
 
-	# Role: the base "User" Stalwart role always stays; only the admin-only roles are toggled.
-	if role is not None:
-		extra_roles = list(set(STALWART_DEFAULT_ADMIN_ROLES) - set(STALWART_DEFAULT_USER_ROLES))
-		toggle = add_account_role if role == "admin" else remove_account_role
-		execute_with_logging(
-			func=lambda: [toggle(member_id, r) for r in extra_roles],
-			title=_("Failed to update roles for {0}").format(member_id),
-			user_message=_("An error occurred while updating the role, check error logs for more details."),
-			with_context=False,
-			module="Mail",
-		)
+    # Role: the base "User" Stalwart role always stays; only the admin-only roles are toggled.
+    if role is not None:
+        extra_roles = list(set(STALWART_DEFAULT_ADMIN_ROLES) - set(STALWART_DEFAULT_USER_ROLES))
+        toggle = add_account_role if role == "admin" else remove_account_role
+        execute_with_logging(
+            func=lambda: [toggle(member_id, r) for r in extra_roles],
+            title=_("Failed to update roles for {0}").format(member_id),
+            user_message=_("An error occurred while updating the role, check error logs for more details."),
+            with_context=False,
+            module="Mail",
+        )
 
-	if not account_id:
-		return
+    if not account_id:
+        return
 
-	if description:
-		execute_with_logging(
-			func=lambda: account_service.update(account_id, {"description": description}),
-			title=_("Failed to update description for {0}").format(member_id),
-			user_message=_(
-				"An error occurred while updating the description, check error logs for more details."
-			),
-			with_context=False,
-			module="Mail",
-		)
+    if description:
+        execute_with_logging(
+            func=lambda: account_service.update(account_id, {"description": description}),
+            title=_("Failed to update description for {0}").format(member_id),
+            user_message=_(
+                "An error occurred while updating the description, check error logs for more details."
+            ),
+            with_context=False,
+            module="Mail",
+        )
 
-	if quota_gb is not None:
-		quota_bytes = cint(float(quota_gb) * _GB)
-		execute_with_logging(
-			func=lambda: account_service.update(account_id, {"quotas/maxDiskQuota": quota_bytes}),
-			title=_("Failed to update quota for {0}").format(member_id),
-			user_message=_("An error occurred while updating the quota, check error logs for more details."),
-			with_context=False,
-			module="Mail",
-		)
+    if quota_gb is not None:
+        quota_bytes = cint(float(quota_gb) * _GB)
+        execute_with_logging(
+            func=lambda: account_service.update(account_id, {"quotas/maxDiskQuota": quota_bytes}),
+            title=_("Failed to update quota for {0}").format(member_id),
+            user_message=_("An error occurred while updating the quota, check error logs for more details."),
+            with_context=False,
+            module="Mail",
+        )
 
-	if patch := _locale_patch(locale, time_zone):
-		execute_with_logging(
-			func=lambda: account_service.update(account_id, patch),
-			title=_("Failed to update locale for {0}").format(member_id),
-			user_message=_("An error occurred while updating the locale, check error logs for more details."),
-			with_context=False,
-			module="Mail",
-		)
+    if patch := _locale_patch(locale, time_zone):
+        execute_with_logging(
+            func=lambda: account_service.update(account_id, patch),
+            title=_("Failed to update locale for {0}").format(member_id),
+            user_message=_("An error occurred while updating the locale, check error logs for more details."),
+            with_context=False,
+            module="Mail",
+        )
 
 
 def _add_alias(service, resource_id: str, email: str, description: str | None = None) -> None:
-	"""Adds ``email`` as an alias (with optional description) to the given account or mailing list."""
+    """Adds ``email`` as an alias (with optional description) to the given account or mailing list."""
 
-	email = (email or "").strip().lower()
-	validate_email_address(email, throw=True)
-	is_subaddressed_email(email, raise_exception=True)
+    email = (email or "").strip().lower()
+    validate_email_address(email, throw=True)
+    is_subaddressed_email(email, raise_exception=True)
 
-	local, _sep, domain = email.partition("@")
-	domain_id = get_domain_service().get_by_name(domain, raise_exception=True)["id"]
+    local, _sep, domain = email.partition("@")
+    domain_id = get_domain_service().get_by_name(domain, raise_exception=True)["id"]
 
-	obj = service.get(resource_id, properties=["emailAddress", "aliases"])
-	if email == (obj.get("emailAddress") or "").lower():
-		frappe.throw(_("{0} is already the primary address.").format(email))
+    obj = service.get(resource_id, properties=["emailAddress", "aliases"])
+    if email == (obj.get("emailAddress") or "").lower():
+        frappe.throw(_("{0} is already the primary address.").format(email))
 
-	domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
-	if email in {e.lower() for e in _alias_emails(obj, domain_names)}:
-		return
+    domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
+    if email in {e.lower() for e in _alias_emails(obj, domain_names)}:
+        return
 
-	aliases = _rebuild_aliases(obj, keep=lambda _e: True)
-	aliases.append(
-		EmailAlias(name=local, domain_id=domain_id, description=(description or "").strip() or None)
-	)
+    aliases = _rebuild_aliases(obj, keep=lambda _e: True)
+    aliases.append(
+        EmailAlias(name=local, domain_id=domain_id, description=(description or "").strip() or None)
+    )
 
-	execute_with_logging(
-		func=lambda: service.set_aliases(resource_id, aliases),
-		title=_("Failed to add email {0}").format(email),
-		user_message=_("An error occurred while adding the email, check error logs for more details."),
-		with_context=False,
-		module="Mail",
-	)
+    execute_with_logging(
+        func=lambda: service.set_aliases(resource_id, aliases),
+        title=_("Failed to add email {0}").format(email),
+        user_message=_("An error occurred while adding the email, check error logs for more details."),
+        with_context=False,
+        module="Mail",
+    )
 
 
 def _remove_alias(service, resource_id: str, email: str) -> None:
-	"""Removes the alias ``email`` from the given account or mailing list (the primary cannot be removed)."""
+    """Removes the alias ``email`` from the given account or mailing list (the primary cannot be removed)."""
 
-	email = (email or "").strip().lower()
-	obj = service.get(resource_id, properties=["emailAddress", "aliases"])
-	if email == (obj.get("emailAddress") or "").lower():
-		frappe.throw(_("The primary address cannot be removed."))
+    email = (email or "").strip().lower()
+    obj = service.get(resource_id, properties=["emailAddress", "aliases"])
+    if email == (obj.get("emailAddress") or "").lower():
+        frappe.throw(_("The primary address cannot be removed."))
 
-	aliases = _rebuild_aliases(obj, keep=lambda e: e != email)
+    aliases = _rebuild_aliases(obj, keep=lambda e: e != email)
 
-	execute_with_logging(
-		func=lambda: service.set_aliases(resource_id, aliases),
-		title=_("Failed to remove email {0}").format(email),
-		user_message=_("An error occurred while removing the email, check error logs for more details."),
-		with_context=False,
-		module="Mail",
-	)
+    execute_with_logging(
+        func=lambda: service.set_aliases(resource_id, aliases),
+        title=_("Failed to remove email {0}").format(email),
+        user_message=_("An error occurred while removing the email, check error logs for more details."),
+        with_context=False,
+        module="Mail",
+    )
 
 
 def _set_alias_enabled(service, resource_id: str, email: str, enabled: bool) -> None:
-	"""Enables or disables the alias ``email`` (the primary address is always enabled)."""
+    """Enables or disables the alias ``email`` (the primary address is always enabled)."""
 
-	email = (email or "").strip().lower()
-	obj = service.get(resource_id, properties=["emailAddress", "aliases"])
-	if not obj or email == (obj.get("emailAddress") or "").lower():
-		return
+    email = (email or "").strip().lower()
+    obj = service.get(resource_id, properties=["emailAddress", "aliases"])
+    if not obj or email == (obj.get("emailAddress") or "").lower():
+        return
 
-	domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
-	aliases = []
-	for alias in (obj.get("aliases") or {}).values():
-		domain = domain_names.get(alias.get("domainId"))
-		alias_email = f"{alias.get('name')}@{domain}" if domain else None
-		is_target = bool(alias_email) and alias_email.lower() == email
-		aliases.append(
-			EmailAlias(
-				name=alias["name"],
-				domain_id=alias["domainId"],
-				enabled=enabled if is_target else alias.get("enabled", True),
-				description=alias.get("description"),
-			)
-		)
+    domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
+    aliases = []
+    for alias in (obj.get("aliases") or {}).values():
+        domain = domain_names.get(alias.get("domainId"))
+        alias_email = f"{alias.get('name')}@{domain}" if domain else None
+        is_target = bool(alias_email) and alias_email.lower() == email
+        aliases.append(
+            EmailAlias(
+                name=alias["name"],
+                domain_id=alias["domainId"],
+                enabled=enabled if is_target else alias.get("enabled", True),
+                description=alias.get("description"),
+            )
+        )
 
-	execute_with_logging(
-		func=lambda: service.set_aliases(resource_id, aliases),
-		title=_("Failed to update email {0}").format(email),
-		user_message=_("An error occurred while updating the email, check error logs for more details."),
-		with_context=False,
-		module="Mail",
-	)
+    execute_with_logging(
+        func=lambda: service.set_aliases(resource_id, aliases),
+        title=_("Failed to update email {0}").format(email),
+        user_message=_("An error occurred while updating the email, check error logs for more details."),
+        with_context=False,
+        module="Mail",
+    )
 
 
 @frappe.whitelist()
 def add_member_email(member_id: str, email: str, description: str | None = None) -> None:
-	"""Adds an email address to the member's account as an alias with an optional description."""
+    """Adds an email address to the member's account as an alias with an optional description."""
 
-	check_admin_permission("update members", f"{member_id} ({email})")
-	_add_alias(get_account_service(), _require_member_account(member_id), email, description)
+    check_admin_permission("update members", f"{member_id} ({email})")
+    _add_alias(get_account_service(), _require_member_account(member_id), email, description)
 
 
 @frappe.whitelist()
 def remove_member_email(member_id: str, email: str) -> None:
-	"""Removes an alias email address from the member's account (the primary cannot be removed)."""
+    """Removes an alias email address from the member's account (the primary cannot be removed)."""
 
-	check_admin_permission("update members", f"{member_id} ({email})")
-	_remove_alias(get_account_service(), _require_member_account(member_id), email)
+    check_admin_permission("update members", f"{member_id} ({email})")
+    _remove_alias(get_account_service(), _require_member_account(member_id), email)
 
 
 @frappe.whitelist()
 def set_member_email_enabled(member_id: str, email: str, enabled: int) -> None:
-	"""Enables or disables one of the member's alias email addresses."""
+    """Enables or disables one of the member's alias email addresses."""
 
-	check_admin_permission("update members", f"{member_id} ({email})")
-	_set_alias_enabled(get_account_service(), _require_member_account(member_id), email, bool(cint(enabled)))
+    check_admin_permission("update members", f"{member_id} ({email})")
+    _set_alias_enabled(get_account_service(), _require_member_account(member_id), email, bool(cint(enabled)))
 
 
 @frappe.whitelist()
 def add_member_to_groups(member_id: str, group_ids: list) -> None:
-	"""Adds the member to the given groups."""
+    """Adds the member to the given groups."""
 
-	check_admin_permission("update members", member_id)
-	account_id = _require_member_account(member_id)
+    check_admin_permission("update members", member_id)
+    account_id = _require_member_account(member_id)
 
-	service = get_group_service()
-	for group_id in _listify(group_ids):
-		service.add_members(group_id, [account_id])
+    service = get_group_service()
+    for group_id in _listify(group_ids):
+        service.add_members(group_id, [account_id])
 
 
 @frappe.whitelist()
 def remove_member_from_group(member_id: str, group_id: str) -> None:
-	"""Removes the member from the given group."""
+    """Removes the member from the given group."""
 
-	check_admin_permission("update members", f"{member_id} ({group_id})")
-	account_id = _require_member_account(member_id)
-	get_group_service().remove_members(group_id, [account_id])
+    check_admin_permission("update members", f"{member_id} ({group_id})")
+    account_id = _require_member_account(member_id)
+    get_group_service().remove_members(group_id, [account_id])
 
 
 @frappe.whitelist()
 def add_member_to_mailing_lists(member_id: str, list_ids: list) -> None:
-	"""Adds the member's primary address as a recipient of the given mailing lists."""
+    """Adds the member's primary address as a recipient of the given mailing lists."""
 
-	check_admin_permission("update members", member_id)
-	account_id = _require_member_account(member_id)
+    check_admin_permission("update members", member_id)
+    account_id = _require_member_account(member_id)
 
-	account_service = get_account_service()
-	email = (account_service.get(account_id, properties=["emailAddress"]) or {}).get("emailAddress")
-	if not email:
-		return
+    account_service = get_account_service()
+    email = (account_service.get(account_id, properties=["emailAddress"]) or {}).get("emailAddress")
+    if not email:
+        return
 
-	service = get_mailing_list_service()
-	for list_id in _listify(list_ids):
-		recipients = dict((service.get(list_id, properties=["recipients"]) or {}).get("recipients") or {})
-		recipients[email] = True
-		service.update(list_id, {"recipients": recipients})
+    service = get_mailing_list_service()
+    for list_id in _listify(list_ids):
+        recipients = dict((service.get(list_id, properties=["recipients"]) or {}).get("recipients") or {})
+        recipients[email] = True
+        service.update(list_id, {"recipients": recipients})
 
 
 @frappe.whitelist()
 def remove_member_from_mailing_list(member_id: str, list_id: str) -> None:
-	"""Removes all of the member's addresses from the given mailing list's recipients."""
+    """Removes all of the member's addresses from the given mailing list's recipients."""
 
-	check_admin_permission("update members", f"{member_id} ({list_id})")
-	account_id = _require_member_account(member_id)
+    check_admin_permission("update members", f"{member_id} ({list_id})")
+    account_id = _require_member_account(member_id)
 
-	account_service = get_account_service()
-	account = account_service.get(account_id, properties=["emailAddress", "aliases"])
-	domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
-	member_emails = {
-		(account.get("emailAddress") or "").lower(),
-		*[e.lower() for e in _alias_emails(account, domain_names)],
-	}
+    account_service = get_account_service()
+    account = account_service.get(account_id, properties=["emailAddress", "aliases"])
+    domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
+    member_emails = {
+        (account.get("emailAddress") or "").lower(),
+        *[e.lower() for e in _alias_emails(account, domain_names)],
+    }
 
-	service = get_mailing_list_service()
-	recipients = (service.get(list_id, properties=["recipients"]) or {}).get("recipients") or {}
-	remaining = {r: v for r, v in recipients.items() if r.lower() not in member_emails}
-	service.update(list_id, {"recipients": remaining})
+    service = get_mailing_list_service()
+    recipients = (service.get(list_id, properties=["recipients"]) or {}).get("recipients") or {}
+    remaining = {r: v for r, v in recipients.items() if r.lower() not in member_emails}
+    service.update(list_id, {"recipients": remaining})
 
 
 # ---------------------------------------------------------------------------
@@ -1043,42 +1043,42 @@ def remove_member_from_mailing_list(member_id: str, list_id: str) -> None:
 
 
 def _listify(value) -> list:
-	"""Coerces a whitelisted argument (which may arrive as a JSON string) into a list."""
+    """Coerces a whitelisted argument (which may arrive as a JSON string) into a list."""
 
-	if value is None:
-		return []
-	if isinstance(value, str):
-		value = frappe.parse_json(value)
-	return list(value or [])
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = frappe.parse_json(value)
+    return list(value or [])
 
 
 def _keys(value) -> list[str]:
-	"""Returns the keys of a JMAP id-keyed map, or the list as-is."""
+    """Returns the keys of a JMAP id-keyed map, or the list as-is."""
 
-	return list(value.keys()) if isinstance(value, dict) else list(value or [])
+    return list(value.keys()) if isinstance(value, dict) else list(value or [])
 
 
 def _search(rows: list[dict], search: str | None, fields: tuple[str, ...]) -> list[dict]:
-	"""Filters rows whose given fields contain the search text (case-insensitive)."""
+    """Filters rows whose given fields contain the search text (case-insensitive)."""
 
-	if not search:
-		return rows
+    if not search:
+        return rows
 
-	needle = search.lower()
-	return [r for r in rows if any(needle in (str(r.get(f) or "")).lower() for f in fields)]
+    needle = search.lower()
+    return [r for r in rows if any(needle in (str(r.get(f) or "")).lower() for f in fields)]
 
 
 @frappe.whitelist()
 def get_accounts(search: str | None = None) -> list[dict]:
-	"""Returns Stalwart user accounts (id + email) for member/recipient pickers."""
+    """Returns Stalwart user accounts (id + email) for member/recipient pickers."""
 
-	check_admin_permission("view accounts")
+    check_admin_permission("view accounts")
 
-	accounts = get_account_service().get_all(
-		filter={"@type": "User"}, properties=["id", "name", "emailAddress"]
-	)
-	rows = [{"id": a["id"], "name": a.get("name"), "email": a.get("emailAddress")} for a in accounts]
-	return _search(rows, search, ("name", "email"))
+    accounts = get_account_service().get_all(
+        filter={"@type": "User"}, properties=["id", "name", "emailAddress"]
+    )
+    rows = [{"id": a["id"], "name": a.get("name"), "email": a.get("emailAddress")} for a in accounts]
+    return _search(rows, search, ("name", "email"))
 
 
 # ---------------------------------------------------------------------------
@@ -1088,206 +1088,206 @@ def get_accounts(search: str | None = None) -> list[dict]:
 
 @frappe.whitelist()
 def get_groups(search: str | None = None) -> list[dict]:
-	"""Returns all groups."""
+    """Returns all groups."""
 
-	check_admin_permission("view groups")
+    check_admin_permission("view groups")
 
-	groups = get_group_service().get_all_groups(
-		properties=["id", "name", "emailAddress", "description", "createdAt"]
-	)
-	rows = [
-		{
-			"id": g["id"],
-			"name": g.get("name"),
-			"email": g.get("emailAddress"),
-			"description": g.get("description"),
-			"created_at": g.get("createdAt"),
-		}
-		for g in groups
-	]
-	return _search(rows, search, ("name", "email", "description"))
+    groups = get_group_service().get_all_groups(
+        properties=["id", "name", "emailAddress", "description", "createdAt"]
+    )
+    rows = [
+        {
+            "id": g["id"],
+            "name": g.get("name"),
+            "email": g.get("emailAddress"),
+            "description": g.get("description"),
+            "created_at": g.get("createdAt"),
+        }
+        for g in groups
+    ]
+    return _search(rows, search, ("name", "email", "description"))
 
 
 @frappe.whitelist()
 def get_group(group_id: str) -> dict:
-	"""Returns a group with its members and assigned role ids."""
+    """Returns a group with its members and assigned role ids."""
 
-	check_admin_permission("view groups")
+    check_admin_permission("view groups")
 
-	service = get_group_service()
-	group = service.get(
-		group_id,
-		properties=[
-			"id",
-			"name",
-			"emailAddress",
-			"description",
-			"createdAt",
-			"roles",
-			"aliases",
-			"quotas",
-			"usedDiskQuota",
-			"locale",
-			"timeZone",
-		],
-	)
-	if not group:
-		frappe.throw(_("Group not found"), frappe.DoesNotExistError)
+    service = get_group_service()
+    group = service.get(
+        group_id,
+        properties=[
+            "id",
+            "name",
+            "emailAddress",
+            "description",
+            "createdAt",
+            "roles",
+            "aliases",
+            "quotas",
+            "usedDiskQuota",
+            "locale",
+            "timeZone",
+        ],
+    )
+    if not group:
+        frappe.throw(_("Group not found"), frappe.DoesNotExistError)
 
-	# Email addresses mirror the member page: primary uses the group description, aliases their own.
-	email_addresses = []
-	if primary := group.get("emailAddress"):
-		email_addresses.append(
-			{"email": primary, "description": group.get("description"), "is_primary": True, "enabled": True}
-		)
+    # Email addresses mirror the member page: primary uses the group description, aliases their own.
+    email_addresses = []
+    if primary := group.get("emailAddress"):
+        email_addresses.append(
+            {"email": primary, "description": group.get("description"), "is_primary": True, "enabled": True}
+        )
 
-	aliases = group.get("aliases") or {}
-	if aliases:
-		domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
-		for alias in aliases.values():
-			name = alias.get("name")
-			domain_name = domain_names.get(alias.get("domainId"))
-			if name and domain_name:
-				email_addresses.append(
-					{
-						"email": f"{name}@{domain_name}",
-						"description": alias.get("description"),
-						"is_primary": False,
-						"enabled": bool(alias.get("enabled", True)),
-					}
-				)
+    aliases = group.get("aliases") or {}
+    if aliases:
+        domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
+        for alias in aliases.values():
+            name = alias.get("name")
+            domain_name = domain_names.get(alias.get("domainId"))
+            if name and domain_name:
+                email_addresses.append(
+                    {
+                        "email": f"{name}@{domain_name}",
+                        "description": alias.get("description"),
+                        "is_primary": False,
+                        "enabled": bool(alias.get("enabled", True)),
+                    }
+                )
 
-	members = service.get_members(group_id, properties=["id", "name", "emailAddress"])
+    members = service.get_members(group_id, properties=["id", "name", "emailAddress"])
 
-	return {
-		"id": group["id"],
-		"name": group.get("name"),
-		"email": group.get("emailAddress"),
-		"description": group.get("description"),
-		"created_at": group.get("createdAt"),
-		"role_ids": _keys((group.get("roles") or {}).get("roleIds")),
-		"locale": group.get("locale"),
-		"time_zone": group.get("timeZone"),
-		"email_addresses": email_addresses,
-		"members": [{"id": m["id"], "name": m.get("name"), "email": m.get("emailAddress")} for m in members],
-		"quota": _build_quota_usage(
-			(group.get("quotas") or {}).get("maxDiskQuota") or 0,
-			group.get("usedDiskQuota") or 0,
-		),
-	}
+    return {
+        "id": group["id"],
+        "name": group.get("name"),
+        "email": group.get("emailAddress"),
+        "description": group.get("description"),
+        "created_at": group.get("createdAt"),
+        "role_ids": _keys((group.get("roles") or {}).get("roleIds")),
+        "locale": group.get("locale"),
+        "time_zone": group.get("timeZone"),
+        "email_addresses": email_addresses,
+        "members": [{"id": m["id"], "name": m.get("name"), "email": m.get("emailAddress")} for m in members],
+        "quota": _build_quota_usage(
+            (group.get("quotas") or {}).get("maxDiskQuota") or 0,
+            group.get("usedDiskQuota") or 0,
+        ),
+    }
 
 
 @frappe.whitelist()
 @dynamic_rate_limit()
 def add_group(
-	name: str,
-	domain: str,
-	description: str | None = None,
-	members: list | None = None,
-	roles: list | None = None,
+    name: str,
+    domain: str,
+    description: str | None = None,
+    members: list | None = None,
+    roles: list | None = None,
 ) -> str:
-	"""Creates a group and returns its id. ``members`` and ``roles`` are account/role ids."""
+    """Creates a group and returns its id. ``members`` and ``roles`` are account/role ids."""
 
-	check_admin_permission("add groups", f"{name}@{domain}")
+    check_admin_permission("add groups", f"{name}@{domain}")
 
-	member_ids = _listify(members)
-	role_ids = _listify(roles)
+    member_ids = _listify(members)
+    role_ids = _listify(roles)
 
-	def _create() -> str:
-		domain_id = get_domain_service().get_by_name(domain, raise_exception=True)["id"]
-		service = get_group_service()
-		group_id = service.create(
-			Group(name=name, domain_id=domain_id, description=description, role_ids=role_ids or None)
-		)
-		if member_ids:
-			service.add_members(group_id, member_ids)
-		return group_id
+    def _create() -> str:
+        domain_id = get_domain_service().get_by_name(domain, raise_exception=True)["id"]
+        service = get_group_service()
+        group_id = service.create(
+            Group(name=name, domain_id=domain_id, description=description, role_ids=role_ids or None)
+        )
+        if member_ids:
+            service.add_members(group_id, member_ids)
+        return group_id
 
-	return execute_with_logging(
-		func=_create,
-		title=_("Failed to add group {0}").format(name),
-		user_message=_("An error occurred while adding the group, check error logs for more details."),
-		with_context=False,
-		module="Mail",
-	)
+    return execute_with_logging(
+        func=_create,
+        title=_("Failed to add group {0}").format(name),
+        user_message=_("An error occurred while adding the group, check error logs for more details."),
+        with_context=False,
+        module="Mail",
+    )
 
 
 @frappe.whitelist()
 def update_group(
-	group_id: str,
-	description: str | None = None,
-	roles: list | None = None,
-	quota_gb: float | None = None,
-	locale: str | None = None,
-	time_zone: str | None = None,
+    group_id: str,
+    description: str | None = None,
+    roles: list | None = None,
+    quota_gb: float | None = None,
+    locale: str | None = None,
+    time_zone: str | None = None,
 ) -> None:
-	"""Updates a group's description (full name), roles, quota, locale and time zone."""
+    """Updates a group's description (full name), roles, quota, locale and time zone."""
 
-	check_admin_permission("update groups", group_id)
+    check_admin_permission("update groups", group_id)
 
-	patch = _locale_patch(locale, time_zone)
-	if description is not None:
-		patch["description"] = description
-	if roles is not None:
-		role_ids = _listify(roles)
-		patch["roles"] = (
-			UserRoles(type=RoleType.CUSTOM, roles=CustomRoles(role_ids=role_ids)).to_dict()
-			if role_ids
-			else {"@type": "Default"}
-		)
-	if quota_gb is not None:
-		patch["quotas/maxDiskQuota"] = cint(float(quota_gb) * _GB)
+    patch = _locale_patch(locale, time_zone)
+    if description is not None:
+        patch["description"] = description
+    if roles is not None:
+        role_ids = _listify(roles)
+        patch["roles"] = (
+            UserRoles(type=RoleType.CUSTOM, roles=CustomRoles(role_ids=role_ids)).to_dict()
+            if role_ids
+            else {"@type": "Default"}
+        )
+    if quota_gb is not None:
+        patch["quotas/maxDiskQuota"] = cint(float(quota_gb) * _GB)
 
-	if patch:
-		get_group_service().update(group_id, patch)
+    if patch:
+        get_group_service().update(group_id, patch)
 
 
 @frappe.whitelist()
 def add_group_email(group_id: str, email: str, description: str | None = None) -> None:
-	"""Adds an alias email address to the group with an optional description."""
+    """Adds an alias email address to the group with an optional description."""
 
-	check_admin_permission("update groups", f"{group_id} ({email})")
-	_add_alias(get_account_service(), group_id, email, description)
+    check_admin_permission("update groups", f"{group_id} ({email})")
+    _add_alias(get_account_service(), group_id, email, description)
 
 
 @frappe.whitelist()
 def remove_group_email(group_id: str, email: str) -> None:
-	"""Removes an alias email address from the group (the primary cannot be removed)."""
+    """Removes an alias email address from the group (the primary cannot be removed)."""
 
-	check_admin_permission("update groups", f"{group_id} ({email})")
-	_remove_alias(get_account_service(), group_id, email)
+    check_admin_permission("update groups", f"{group_id} ({email})")
+    _remove_alias(get_account_service(), group_id, email)
 
 
 @frappe.whitelist()
 def set_group_email_enabled(group_id: str, email: str, enabled: int) -> None:
-	"""Enables or disables one of the group's alias email addresses."""
+    """Enables or disables one of the group's alias email addresses."""
 
-	check_admin_permission("update groups", f"{group_id} ({email})")
-	_set_alias_enabled(get_account_service(), group_id, email, bool(cint(enabled)))
+    check_admin_permission("update groups", f"{group_id} ({email})")
+    _set_alias_enabled(get_account_service(), group_id, email, bool(cint(enabled)))
 
 
 @frappe.whitelist()
 def add_group_members(group_id: str, account_ids: list) -> None:
-	"""Adds the given accounts to the group."""
+    """Adds the given accounts to the group."""
 
-	check_admin_permission("update groups", group_id)
-	get_group_service().add_members(group_id, _listify(account_ids))
+    check_admin_permission("update groups", group_id)
+    get_group_service().add_members(group_id, _listify(account_ids))
 
 
 @frappe.whitelist()
 def remove_group_member(group_id: str, account_id: str) -> None:
-	"""Removes the given account from the group."""
+    """Removes the given account from the group."""
 
-	check_admin_permission("update groups", f"{group_id} ({account_id})")
-	get_group_service().remove_members(group_id, [account_id])
+    check_admin_permission("update groups", f"{group_id} ({account_id})")
+    get_group_service().remove_members(group_id, [account_id])
 
 
 @frappe.whitelist()
 def delete_groups(ids: list) -> None:
-	"""Deletes the given groups."""
+    """Deletes the given groups."""
 
-	check_admin_permission("delete groups", ids)
-	get_group_service().delete(_listify(ids))
+    check_admin_permission("delete groups", ids)
+    get_group_service().delete(_listify(ids))
 
 
 # ---------------------------------------------------------------------------
@@ -1297,168 +1297,168 @@ def delete_groups(ids: list) -> None:
 
 @frappe.whitelist()
 def get_mailing_lists(search: str | None = None) -> list[dict]:
-	"""Returns all mailing lists."""
+    """Returns all mailing lists."""
 
-	check_admin_permission("view mailing lists")
+    check_admin_permission("view mailing lists")
 
-	lists = get_mailing_list_service().get_all(
-		properties=["id", "name", "emailAddress", "description", "recipients"]
-	)
-	rows = [
-		{
-			"id": ml["id"],
-			"name": ml.get("name"),
-			"email": ml.get("emailAddress"),
-			"description": ml.get("description"),
-			"recipient_count": len(_keys(ml.get("recipients"))),
-		}
-		for ml in lists
-	]
-	return _search(rows, search, ("name", "email", "description"))
+    lists = get_mailing_list_service().get_all(
+        properties=["id", "name", "emailAddress", "description", "recipients"]
+    )
+    rows = [
+        {
+            "id": ml["id"],
+            "name": ml.get("name"),
+            "email": ml.get("emailAddress"),
+            "description": ml.get("description"),
+            "recipient_count": len(_keys(ml.get("recipients"))),
+        }
+        for ml in lists
+    ]
+    return _search(rows, search, ("name", "email", "description"))
 
 
 @frappe.whitelist()
 def get_mailing_list(list_id: str) -> dict:
-	"""Returns a mailing list with its email addresses and recipients."""
+    """Returns a mailing list with its email addresses and recipients."""
 
-	check_admin_permission("view mailing lists")
+    check_admin_permission("view mailing lists")
 
-	ml = get_mailing_list_service().get(
-		list_id,
-		properties=["id", "name", "emailAddress", "description", "aliases", "recipients"],
-	)
-	if not ml:
-		frappe.throw(_("Mailing list not found"), frappe.DoesNotExistError)
+    ml = get_mailing_list_service().get(
+        list_id,
+        properties=["id", "name", "emailAddress", "description", "aliases", "recipients"],
+    )
+    if not ml:
+        frappe.throw(_("Mailing list not found"), frappe.DoesNotExistError)
 
-	# Email addresses mirror the member/group pages: primary uses the description, aliases their own.
-	email_addresses = []
-	if primary := ml.get("emailAddress"):
-		email_addresses.append(
-			{"email": primary, "description": ml.get("description"), "is_primary": True, "enabled": True}
-		)
-	aliases = ml.get("aliases") or {}
-	if aliases:
-		domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
-		for alias in aliases.values():
-			name = alias.get("name")
-			domain_name = domain_names.get(alias.get("domainId"))
-			if name and domain_name:
-				email_addresses.append(
-					{
-						"email": f"{name}@{domain_name}",
-						"description": alias.get("description"),
-						"is_primary": False,
-						"enabled": bool(alias.get("enabled", True)),
-					}
-				)
+    # Email addresses mirror the member/group pages: primary uses the description, aliases their own.
+    email_addresses = []
+    if primary := ml.get("emailAddress"):
+        email_addresses.append(
+            {"email": primary, "description": ml.get("description"), "is_primary": True, "enabled": True}
+        )
+    aliases = ml.get("aliases") or {}
+    if aliases:
+        domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
+        for alias in aliases.values():
+            name = alias.get("name")
+            domain_name = domain_names.get(alias.get("domainId"))
+            if name and domain_name:
+                email_addresses.append(
+                    {
+                        "email": f"{name}@{domain_name}",
+                        "description": alias.get("description"),
+                        "is_primary": False,
+                        "enabled": bool(alias.get("enabled", True)),
+                    }
+                )
 
-	return {
-		"id": ml["id"],
-		"name": ml.get("name"),
-		"email": ml.get("emailAddress"),
-		"description": ml.get("description"),
-		"email_addresses": email_addresses,
-		# Recipients are email addresses (internal accounts or external).
-		"recipients": _keys(ml.get("recipients")),
-	}
+    return {
+        "id": ml["id"],
+        "name": ml.get("name"),
+        "email": ml.get("emailAddress"),
+        "description": ml.get("description"),
+        "email_addresses": email_addresses,
+        # Recipients are email addresses (internal accounts or external).
+        "recipients": _keys(ml.get("recipients")),
+    }
 
 
 @frappe.whitelist()
 @dynamic_rate_limit()
 def add_mailing_list(
-	name: str, domain: str, recipients: list | None = None, description: str | None = None
+    name: str, domain: str, recipients: list | None = None, description: str | None = None
 ) -> str:
-	"""Creates a mailing list and returns its id."""
+    """Creates a mailing list and returns its id."""
 
-	check_admin_permission("add mailing lists", f"{name}@{domain}")
+    check_admin_permission("add mailing lists", f"{name}@{domain}")
 
-	recipient_list = _listify(recipients)
+    recipient_list = _listify(recipients)
 
-	def _create() -> str:
-		domain_id = get_domain_service().get_by_name(domain, raise_exception=True)["id"]
-		return get_mailing_list_service().create(
-			MailingList(
-				name=name, domain_id=domain_id, recipients=recipient_list or None, description=description
-			)
-		)
+    def _create() -> str:
+        domain_id = get_domain_service().get_by_name(domain, raise_exception=True)["id"]
+        return get_mailing_list_service().create(
+            MailingList(
+                name=name, domain_id=domain_id, recipients=recipient_list or None, description=description
+            )
+        )
 
-	return execute_with_logging(
-		func=_create,
-		title=_("Failed to add mailing list {0}").format(name),
-		user_message=_("An error occurred while adding the mailing list, check error logs for more details."),
-		with_context=False,
-		module="Mail",
-	)
+    return execute_with_logging(
+        func=_create,
+        title=_("Failed to add mailing list {0}").format(name),
+        user_message=_("An error occurred while adding the mailing list, check error logs for more details."),
+        with_context=False,
+        module="Mail",
+    )
 
 
 @frappe.whitelist()
 def update_mailing_list(list_id: str, description: str | None = None) -> None:
-	"""Updates a mailing list's description."""
+    """Updates a mailing list's description."""
 
-	check_admin_permission("update mailing lists", list_id)
+    check_admin_permission("update mailing lists", list_id)
 
-	if description is not None:
-		get_mailing_list_service().update(list_id, {"description": description})
+    if description is not None:
+        get_mailing_list_service().update(list_id, {"description": description})
 
 
 @frappe.whitelist()
 def add_mailing_list_email(list_id: str, email: str, description: str | None = None) -> None:
-	"""Adds an alias email address to the mailing list."""
+    """Adds an alias email address to the mailing list."""
 
-	check_admin_permission("update mailing lists", f"{list_id} ({email})")
-	_add_alias(get_mailing_list_service(), list_id, email, description)
+    check_admin_permission("update mailing lists", f"{list_id} ({email})")
+    _add_alias(get_mailing_list_service(), list_id, email, description)
 
 
 @frappe.whitelist()
 def remove_mailing_list_email(list_id: str, email: str) -> None:
-	"""Removes an alias email address from the mailing list (the primary cannot be removed)."""
+    """Removes an alias email address from the mailing list (the primary cannot be removed)."""
 
-	check_admin_permission("update mailing lists", f"{list_id} ({email})")
-	_remove_alias(get_mailing_list_service(), list_id, email)
+    check_admin_permission("update mailing lists", f"{list_id} ({email})")
+    _remove_alias(get_mailing_list_service(), list_id, email)
 
 
 @frappe.whitelist()
 def set_mailing_list_email_enabled(list_id: str, email: str, enabled: int) -> None:
-	"""Enables or disables one of the mailing list's alias email addresses."""
+    """Enables or disables one of the mailing list's alias email addresses."""
 
-	check_admin_permission("update mailing lists", f"{list_id} ({email})")
-	_set_alias_enabled(get_mailing_list_service(), list_id, email, bool(cint(enabled)))
+    check_admin_permission("update mailing lists", f"{list_id} ({email})")
+    _set_alias_enabled(get_mailing_list_service(), list_id, email, bool(cint(enabled)))
 
 
 @frappe.whitelist()
 def add_mailing_list_recipients(list_id: str, recipients: list) -> None:
-	"""Adds recipient email addresses to the mailing list."""
+    """Adds recipient email addresses to the mailing list."""
 
-	check_admin_permission("update mailing lists", list_id)
+    check_admin_permission("update mailing lists", list_id)
 
-	service = get_mailing_list_service()
-	current = dict((service.get(list_id, properties=["recipients"]) or {}).get("recipients") or {})
-	for email in _listify(recipients):
-		email = (email or "").strip()
-		if email:
-			current[email] = True
+    service = get_mailing_list_service()
+    current = dict((service.get(list_id, properties=["recipients"]) or {}).get("recipients") or {})
+    for email in _listify(recipients):
+        email = (email or "").strip()
+        if email:
+            current[email] = True
 
-	service.update(list_id, {"recipients": current})
+    service.update(list_id, {"recipients": current})
 
 
 @frappe.whitelist()
 def remove_mailing_list_recipient(list_id: str, email: str) -> None:
-	"""Removes a recipient email address from the mailing list."""
+    """Removes a recipient email address from the mailing list."""
 
-	check_admin_permission("update mailing lists", f"{list_id} ({email})")
+    check_admin_permission("update mailing lists", f"{list_id} ({email})")
 
-	service = get_mailing_list_service()
-	current = (service.get(list_id, properties=["recipients"]) or {}).get("recipients") or {}
-	remaining = {r: v for r, v in current.items() if r.lower() != (email or "").strip().lower()}
-	service.update(list_id, {"recipients": remaining})
+    service = get_mailing_list_service()
+    current = (service.get(list_id, properties=["recipients"]) or {}).get("recipients") or {}
+    remaining = {r: v for r, v in current.items() if r.lower() != (email or "").strip().lower()}
+    service.update(list_id, {"recipients": remaining})
 
 
 @frappe.whitelist()
 def delete_mailing_lists(ids: list) -> None:
-	"""Deletes the given mailing lists."""
+    """Deletes the given mailing lists."""
 
-	check_admin_permission("delete mailing lists", ids)
-	get_mailing_list_service().delete(_listify(ids))
+    check_admin_permission("delete mailing lists", ids)
+    get_mailing_list_service().delete(_listify(ids))
 
 
 # ---------------------------------------------------------------------------
@@ -1468,113 +1468,113 @@ def delete_mailing_lists(ids: list) -> None:
 
 @frappe.whitelist()
 def get_roles_list(search: str | None = None) -> list[dict]:
-	"""Returns all roles with permission counts."""
+    """Returns all roles with permission counts."""
 
-	check_admin_permission("view roles")
+    check_admin_permission("view roles")
 
-	roles = get_role_service().get_all()
-	rows = [
-		{
-			"id": r["id"],
-			"description": r.get("description"),
-			"enabled_count": len(_keys(r.get("enabledPermissions"))),
-			"disabled_count": len(_keys(r.get("disabledPermissions"))),
-		}
-		for r in roles
-	]
-	return _search(rows, search, ("description",))
+    roles = get_role_service().get_all()
+    rows = [
+        {
+            "id": r["id"],
+            "description": r.get("description"),
+            "enabled_count": len(_keys(r.get("enabledPermissions"))),
+            "disabled_count": len(_keys(r.get("disabledPermissions"))),
+        }
+        for r in roles
+    ]
+    return _search(rows, search, ("description",))
 
 
 @frappe.whitelist()
 def get_role(role_id: str) -> dict:
-	"""Returns a role with its permissions and inherited role ids."""
+    """Returns a role with its permissions and inherited role ids."""
 
-	check_admin_permission("view roles")
+    check_admin_permission("view roles")
 
-	role = get_role_service().get(role_id)
-	if not role:
-		frappe.throw(_("Role not found"), frappe.DoesNotExistError)
+    role = get_role_service().get(role_id)
+    if not role:
+        frappe.throw(_("Role not found"), frappe.DoesNotExistError)
 
-	return {
-		"id": role["id"],
-		"description": role.get("description"),
-		"enabled_permissions": _keys(role.get("enabledPermissions")),
-		"disabled_permissions": _keys(role.get("disabledPermissions")),
-		"role_ids": _keys(role.get("roleIds")),
-	}
+    return {
+        "id": role["id"],
+        "description": role.get("description"),
+        "enabled_permissions": _keys(role.get("enabledPermissions")),
+        "disabled_permissions": _keys(role.get("disabledPermissions")),
+        "role_ids": _keys(role.get("roleIds")),
+    }
 
 
 @frappe.whitelist()
 def get_permissions() -> list[dict]:
-	"""Returns the assignable permissions as ``{value, label}`` for the role editor."""
+    """Returns the assignable permissions as ``{value, label}`` for the role editor."""
 
-	check_admin_permission("view roles")
-	return get_stalwart_permissions()
+    check_admin_permission("view roles")
+    return get_stalwart_permissions()
 
 
 @frappe.whitelist()
 @dynamic_rate_limit()
 def add_role(
-	description: str,
-	enabled_permissions: list | None = None,
-	disabled_permissions: list | None = None,
-	role_ids: list | None = None,
+    description: str,
+    enabled_permissions: list | None = None,
+    disabled_permissions: list | None = None,
+    role_ids: list | None = None,
 ) -> str:
-	"""Creates a role and returns its id."""
+    """Creates a role and returns its id."""
 
-	check_admin_permission("add roles", description)
+    check_admin_permission("add roles", description)
 
-	def _create() -> str:
-		return get_role_service().create(
-			Role(
-				description=description,
-				enabled_permissions=_listify(enabled_permissions),
-				disabled_permissions=_listify(disabled_permissions),
-				role_ids=_listify(role_ids),
-			)
-		)
+    def _create() -> str:
+        return get_role_service().create(
+            Role(
+                description=description,
+                enabled_permissions=_listify(enabled_permissions),
+                disabled_permissions=_listify(disabled_permissions),
+                role_ids=_listify(role_ids),
+            )
+        )
 
-	return execute_with_logging(
-		func=_create,
-		title=_("Failed to add role {0}").format(description),
-		user_message=_("An error occurred while adding the role, check error logs for more details."),
-		with_context=False,
-		module="Mail",
-	)
+    return execute_with_logging(
+        func=_create,
+        title=_("Failed to add role {0}").format(description),
+        user_message=_("An error occurred while adding the role, check error logs for more details."),
+        with_context=False,
+        module="Mail",
+    )
 
 
 @frappe.whitelist()
 def update_role(
-	role_id: str,
-	description: str | None = None,
-	enabled_permissions: list | None = None,
-	disabled_permissions: list | None = None,
-	role_ids: list | None = None,
+    role_id: str,
+    description: str | None = None,
+    enabled_permissions: list | None = None,
+    disabled_permissions: list | None = None,
+    role_ids: list | None = None,
 ) -> None:
-	"""Updates a role's description/permissions/inherited roles."""
+    """Updates a role's description/permissions/inherited roles."""
 
-	check_admin_permission("update roles", role_id)
+    check_admin_permission("update roles", role_id)
 
-	patch = {}
-	if description is not None:
-		patch["description"] = description
-	if enabled_permissions is not None:
-		patch["enabledPermissions"] = {p: True for p in _listify(enabled_permissions)}
-	if disabled_permissions is not None:
-		patch["disabledPermissions"] = {p: True for p in _listify(disabled_permissions)}
-	if role_ids is not None:
-		patch["roleIds"] = {rid: True for rid in _listify(role_ids)}
+    patch = {}
+    if description is not None:
+        patch["description"] = description
+    if enabled_permissions is not None:
+        patch["enabledPermissions"] = {p: True for p in _listify(enabled_permissions)}
+    if disabled_permissions is not None:
+        patch["disabledPermissions"] = {p: True for p in _listify(disabled_permissions)}
+    if role_ids is not None:
+        patch["roleIds"] = {rid: True for rid in _listify(role_ids)}
 
-	if patch:
-		get_role_service().update(role_id, patch)
+    if patch:
+        get_role_service().update(role_id, patch)
 
 
 @frappe.whitelist()
 def delete_roles(ids: list) -> None:
-	"""Deletes the given roles."""
+    """Deletes the given roles."""
 
-	check_admin_permission("delete roles", ids)
-	get_role_service().delete(_listify(ids))
+    check_admin_permission("delete roles", ids)
+    get_role_service().delete(_listify(ids))
 
 
 # ---------------------------------------------------------------------------
@@ -1584,197 +1584,197 @@ def delete_roles(ids: list) -> None:
 
 @frappe.whitelist()
 def get_oauth_clients(search: str | None = None) -> list[dict]:
-	"""Returns all OAuth clients."""
+    """Returns all OAuth clients."""
 
-	check_admin_permission("view oauth clients")
+    check_admin_permission("view oauth clients")
 
-	clients = get_oauth_client_service().get_all(properties=["id", "clientId", "description", "createdAt"])
-	rows = [
-		{
-			"id": c["id"],
-			"client_id": c.get("clientId"),
-			"description": c.get("description"),
-			"created_at": c.get("createdAt"),
-		}
-		for c in clients
-	]
-	return _search(rows, search, ("client_id", "description"))
+    clients = get_oauth_client_service().get_all(properties=["id", "clientId", "description", "createdAt"])
+    rows = [
+        {
+            "id": c["id"],
+            "client_id": c.get("clientId"),
+            "description": c.get("description"),
+            "created_at": c.get("createdAt"),
+        }
+        for c in clients
+    ]
+    return _search(rows, search, ("client_id", "description"))
 
 
 @frappe.whitelist()
 def get_oauth_client(client_id: str) -> dict:
-	"""Returns an OAuth client with its redirect URIs and contacts."""
+    """Returns an OAuth client with its redirect URIs and contacts."""
 
-	check_admin_permission("view oauth clients")
+    check_admin_permission("view oauth clients")
 
-	client = get_oauth_client_service().get(
-		client_id,
-		properties=[
-			"id",
-			"clientId",
-			"description",
-			"createdAt",
-			"expiresAt",
-			"redirectUris",
-			"contacts",
-			"logo",
-		],
-	)
-	if not client:
-		frappe.throw(_("OAuth client not found"), frappe.DoesNotExistError)
+    client = get_oauth_client_service().get(
+        client_id,
+        properties=[
+            "id",
+            "clientId",
+            "description",
+            "createdAt",
+            "expiresAt",
+            "redirectUris",
+            "contacts",
+            "logo",
+        ],
+    )
+    if not client:
+        frappe.throw(_("OAuth client not found"), frappe.DoesNotExistError)
 
-	return {
-		"id": client["id"],
-		"client_id": client.get("clientId"),
-		"description": client.get("description"),
-		"created_at": client.get("createdAt"),
-		"expires_at": client.get("expiresAt"),
-		"redirect_uris": _keys(client.get("redirectUris")),
-		"contacts": _keys(client.get("contacts")),
-		"logo": client.get("logo"),
-	}
+    return {
+        "id": client["id"],
+        "client_id": client.get("clientId"),
+        "description": client.get("description"),
+        "created_at": client.get("createdAt"),
+        "expires_at": client.get("expiresAt"),
+        "redirect_uris": _keys(client.get("redirectUris")),
+        "contacts": _keys(client.get("contacts")),
+        "logo": client.get("logo"),
+    }
 
 
 @frappe.whitelist()
 @dynamic_rate_limit()
 def add_oauth_client(
-	client_id: str,
-	description: str | None = None,
-	contacts: list | None = None,
-	redirect_uris: list | None = None,
-	secret: str | None = None,
-	logo: str | None = None,
-	expires_at: str | None = None,
+    client_id: str,
+    description: str | None = None,
+    contacts: list | None = None,
+    redirect_uris: list | None = None,
+    secret: str | None = None,
+    logo: str | None = None,
+    expires_at: str | None = None,
 ) -> str:
-	"""Creates an OAuth client and returns its id."""
+    """Creates an OAuth client and returns its id."""
 
-	check_admin_permission("add oauth clients", client_id)
+    check_admin_permission("add oauth clients", client_id)
 
-	uris = _listify(redirect_uris)
-	contact_list = _listify(contacts)
-	expires = to_utc_z(expires_at)
+    uris = _listify(redirect_uris)
+    contact_list = _listify(contacts)
+    expires = to_utc_z(expires_at)
 
-	def _create() -> str:
-		return get_oauth_client_service().create(
-			OAuthClient(
-				client_id=client_id,
-				description=description,
-				contacts=contact_list or None,
-				redirect_uris=uris or None,
-				secret=(secret or "").strip() or None,
-				logo=(logo or "").strip() or None,
-				expires_at=expires,
-			)
-		)
+    def _create() -> str:
+        return get_oauth_client_service().create(
+            OAuthClient(
+                client_id=client_id,
+                description=description,
+                contacts=contact_list or None,
+                redirect_uris=uris or None,
+                secret=(secret or "").strip() or None,
+                logo=(logo or "").strip() or None,
+                expires_at=expires,
+            )
+        )
 
-	return execute_with_logging(
-		func=_create,
-		title=_("Failed to add OAuth client {0}").format(client_id),
-		user_message=_("An error occurred while adding the OAuth client, check error logs for more details."),
-		with_context=False,
-		module="Mail",
-	)
+    return execute_with_logging(
+        func=_create,
+        title=_("Failed to add OAuth client {0}").format(client_id),
+        user_message=_("An error occurred while adding the OAuth client, check error logs for more details."),
+        with_context=False,
+        module="Mail",
+    )
 
 
 @frappe.whitelist()
 def update_oauth_client(
-	oauth_client_id: str,
-	client_id: str | None = None,
-	description: str | None = None,
-	redirect_uris: list | None = None,
-	contacts: list | None = None,
-	secret: str | None = None,
-	logo: str | None = None,
-	expires_at: str | None = None,
+    oauth_client_id: str,
+    client_id: str | None = None,
+    description: str | None = None,
+    redirect_uris: list | None = None,
+    contacts: list | None = None,
+    secret: str | None = None,
+    logo: str | None = None,
+    expires_at: str | None = None,
 ) -> None:
-	"""Updates an OAuth client's clientId, description, redirect URIs, contacts, secret, logo and expiry."""
+    """Updates an OAuth client's clientId, description, redirect URIs, contacts, secret, logo and expiry."""
 
-	check_admin_permission("update oauth clients", oauth_client_id)
+    check_admin_permission("update oauth clients", oauth_client_id)
 
-	patch = {}
-	if client_id is not None and client_id.strip():
-		patch["clientId"] = client_id.strip()
-	if description is not None:
-		patch["description"] = description
-	if redirect_uris is not None:
-		patch["redirectUris"] = {uri: True for uri in _listify(redirect_uris)}
-	if contacts is not None:
-		patch["contacts"] = {contact: True for contact in _listify(contacts)}
-	# A blank secret leaves the existing one untouched (it is never read back).
-	if secret is not None and secret.strip():
-		patch["secret"] = secret.strip()
-	if logo is not None:
-		patch["logo"] = logo.strip() or None
-	if expires_at is not None:
-		# Blank clears the expiry.
-		patch["expiresAt"] = to_utc_z(expires_at)
+    patch = {}
+    if client_id is not None and client_id.strip():
+        patch["clientId"] = client_id.strip()
+    if description is not None:
+        patch["description"] = description
+    if redirect_uris is not None:
+        patch["redirectUris"] = {uri: True for uri in _listify(redirect_uris)}
+    if contacts is not None:
+        patch["contacts"] = {contact: True for contact in _listify(contacts)}
+    # A blank secret leaves the existing one untouched (it is never read back).
+    if secret is not None and secret.strip():
+        patch["secret"] = secret.strip()
+    if logo is not None:
+        patch["logo"] = logo.strip() or None
+    if expires_at is not None:
+        # Blank clears the expiry.
+        patch["expiresAt"] = to_utc_z(expires_at)
 
-	if patch:
-		get_oauth_client_service().update(oauth_client_id, patch)
+    if patch:
+        get_oauth_client_service().update(oauth_client_id, patch)
 
 
 @frappe.whitelist()
 def add_oauth_client_contacts(client_id: str, contacts: list) -> None:
-	"""Adds contact email addresses to the OAuth client."""
+    """Adds contact email addresses to the OAuth client."""
 
-	check_admin_permission("update oauth clients", client_id)
+    check_admin_permission("update oauth clients", client_id)
 
-	service = get_oauth_client_service()
-	current = dict((service.get(client_id, properties=["contacts"]) or {}).get("contacts") or {})
-	for contact in _listify(contacts):
-		contact = (contact or "").strip()
-		if contact:
-			current[contact] = True
+    service = get_oauth_client_service()
+    current = dict((service.get(client_id, properties=["contacts"]) or {}).get("contacts") or {})
+    for contact in _listify(contacts):
+        contact = (contact or "").strip()
+        if contact:
+            current[contact] = True
 
-	service.update(client_id, {"contacts": current})
+    service.update(client_id, {"contacts": current})
 
 
 @frappe.whitelist()
 def remove_oauth_client_contact(client_id: str, contact: str) -> None:
-	"""Removes a contact email address from the OAuth client."""
+    """Removes a contact email address from the OAuth client."""
 
-	check_admin_permission("update oauth clients", f"{client_id} ({contact})")
+    check_admin_permission("update oauth clients", f"{client_id} ({contact})")
 
-	service = get_oauth_client_service()
-	current = (service.get(client_id, properties=["contacts"]) or {}).get("contacts") or {}
-	remaining = {c: v for c, v in current.items() if c.lower() != (contact or "").strip().lower()}
-	service.update(client_id, {"contacts": remaining})
+    service = get_oauth_client_service()
+    current = (service.get(client_id, properties=["contacts"]) or {}).get("contacts") or {}
+    remaining = {c: v for c, v in current.items() if c.lower() != (contact or "").strip().lower()}
+    service.update(client_id, {"contacts": remaining})
 
 
 @frappe.whitelist()
 def add_oauth_client_redirect_uris(client_id: str, redirect_uris: list) -> None:
-	"""Adds redirect URIs to the OAuth client."""
+    """Adds redirect URIs to the OAuth client."""
 
-	check_admin_permission("update oauth clients", client_id)
+    check_admin_permission("update oauth clients", client_id)
 
-	service = get_oauth_client_service()
-	current = dict((service.get(client_id, properties=["redirectUris"]) or {}).get("redirectUris") or {})
-	for uri in _listify(redirect_uris):
-		uri = (uri or "").strip()
-		if uri:
-			current[uri] = True
+    service = get_oauth_client_service()
+    current = dict((service.get(client_id, properties=["redirectUris"]) or {}).get("redirectUris") or {})
+    for uri in _listify(redirect_uris):
+        uri = (uri or "").strip()
+        if uri:
+            current[uri] = True
 
-	service.update(client_id, {"redirectUris": current})
+    service.update(client_id, {"redirectUris": current})
 
 
 @frappe.whitelist()
 def remove_oauth_client_redirect_uri(client_id: str, uri: str) -> None:
-	"""Removes a redirect URI from the OAuth client."""
+    """Removes a redirect URI from the OAuth client."""
 
-	check_admin_permission("update oauth clients", f"{client_id} ({uri})")
+    check_admin_permission("update oauth clients", f"{client_id} ({uri})")
 
-	service = get_oauth_client_service()
-	current = (service.get(client_id, properties=["redirectUris"]) or {}).get("redirectUris") or {}
-	remaining = {u: v for u, v in current.items() if u != (uri or "").strip()}
-	service.update(client_id, {"redirectUris": remaining})
+    service = get_oauth_client_service()
+    current = (service.get(client_id, properties=["redirectUris"]) or {}).get("redirectUris") or {}
+    remaining = {u: v for u, v in current.items() if u != (uri or "").strip()}
+    service.update(client_id, {"redirectUris": remaining})
 
 
 @frappe.whitelist()
 def delete_oauth_clients(ids: list) -> None:
-	"""Deletes the given OAuth clients."""
+    """Deletes the given OAuth clients."""
 
-	check_admin_permission("delete oauth clients", ids)
-	get_oauth_client_service().delete(_listify(ids))
+    check_admin_permission("delete oauth clients", ids)
+    get_oauth_client_service().delete(_listify(ids))
 
 
 # ---------------------------------------------------------------------------
@@ -1783,89 +1783,89 @@ def delete_oauth_clients(ids: list) -> None:
 
 # Maps Stalwart's DKIM signature @type to a human-readable algorithm label.
 _DKIM_ALGORITHMS = {
-	"Dkim1RsaSha256": "RSA-SHA256",
-	"Dkim1Ed25519Sha256": "Ed25519-SHA256",
+    "Dkim1RsaSha256": "RSA-SHA256",
+    "Dkim1Ed25519Sha256": "Ed25519-SHA256",
 }
 
 
 @frappe.whitelist()
 def get_dkim_signatures(domain_id: str | None = None) -> list[dict]:
-	"""Returns DKIM signatures, optionally scoped to a single domain."""
+    """Returns DKIM signatures, optionally scoped to a single domain."""
 
-	check_admin_permission("view dkim signatures")
+    check_admin_permission("view dkim signatures")
 
-	service = get_dkim_signature_service()
-	properties = ["id", "@type", "selector", "domainId", "createdAt"]
-	signatures = (
-		service.get_all_by_domain(domain_id, properties=properties)
-		if domain_id
-		else service.get_all(properties=properties)
-	)
+    service = get_dkim_signature_service()
+    properties = ["id", "@type", "selector", "domainId", "createdAt"]
+    signatures = (
+        service.get_all_by_domain(domain_id, properties=properties)
+        if domain_id
+        else service.get_all(properties=properties)
+    )
 
-	domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
-	return [
-		{
-			"id": s["id"],
-			"algorithm": _DKIM_ALGORITHMS.get(s.get("@type"), s.get("@type")),
-			"domain": domain_names.get(s.get("domainId")),
-			"selector": s.get("selector"),
-			"created_at": s.get("createdAt"),
-		}
-		for s in signatures
-	]
+    domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
+    return [
+        {
+            "id": s["id"],
+            "algorithm": _DKIM_ALGORITHMS.get(s.get("@type"), s.get("@type")),
+            "domain": domain_names.get(s.get("domainId")),
+            "selector": s.get("selector"),
+            "created_at": s.get("createdAt"),
+        }
+        for s in signatures
+    ]
 
 
 @frappe.whitelist()
 def get_dkim_signature(signature_id: str) -> dict:
-	"""Returns a single DKIM signature's details (read-only; never the private key)."""
+    """Returns a single DKIM signature's details (read-only; never the private key)."""
 
-	check_admin_permission("view dkim signatures")
+    check_admin_permission("view dkim signatures")
 
-	sig = get_dkim_signature_service().get(
-		signature_id,
-		properties=[
-			"id",
-			"@type",
-			"selector",
-			"domainId",
-			"createdAt",
-			"stage",
-			"nextTransitionAt",
-			"headers",
-			"canonicalization",
-			"expire",
-			"report",
-			"auid",
-			"publicKey",
-		],
-	)
-	if not sig:
-		frappe.throw(_("DKIM signature not found"), frappe.DoesNotExistError)
+    sig = get_dkim_signature_service().get(
+        signature_id,
+        properties=[
+            "id",
+            "@type",
+            "selector",
+            "domainId",
+            "createdAt",
+            "stage",
+            "nextTransitionAt",
+            "headers",
+            "canonicalization",
+            "expire",
+            "report",
+            "auid",
+            "publicKey",
+        ],
+    )
+    if not sig:
+        frappe.throw(_("DKIM signature not found"), frappe.DoesNotExistError)
 
-	domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
-	return {
-		"id": sig["id"],
-		"algorithm": _DKIM_ALGORITHMS.get(sig.get("@type"), sig.get("@type")),
-		"selector": sig.get("selector"),
-		"domain": domain_names.get(sig.get("domainId")),
-		"signed_headers": _keys(sig.get("headers")),
-		"canonicalization": sig.get("canonicalization"),
-		"expiration": sig.get("expire"),
-		"request_reports": bool(sig.get("report")),
-		"auid": sig.get("auid"),
-		"public_key": sig.get("publicKey"),
-		"stage": sig.get("stage"),
-		"created_at": sig.get("createdAt"),
-		"next_transition": sig.get("nextTransitionAt"),
-	}
+    domain_names = {d["id"]: d["name"] for d in get_stalwart_domains()}
+    return {
+        "id": sig["id"],
+        "algorithm": _DKIM_ALGORITHMS.get(sig.get("@type"), sig.get("@type")),
+        "selector": sig.get("selector"),
+        "domain": domain_names.get(sig.get("domainId")),
+        "signed_headers": _keys(sig.get("headers")),
+        "canonicalization": sig.get("canonicalization"),
+        "expiration": sig.get("expire"),
+        "request_reports": bool(sig.get("report")),
+        "auid": sig.get("auid"),
+        "public_key": sig.get("publicKey"),
+        "stage": sig.get("stage"),
+        "created_at": sig.get("createdAt"),
+        "next_transition": sig.get("nextTransitionAt"),
+    }
 
 
 @frappe.whitelist()
 def delete_dkim_signatures(ids: list) -> None:
-	"""Deletes the given DKIM signatures."""
+    """Deletes the given DKIM signatures."""
 
-	check_admin_permission("delete dkim signatures", ids)
-	get_dkim_signature_service().delete(_listify(ids))
+    check_admin_permission("delete dkim signatures", ids)
+    get_dkim_signature_service().delete(_listify(ids))
 
 
 # ---------------------------------------------------------------------------
@@ -1874,367 +1874,367 @@ def delete_dkim_signatures(ids: list) -> None:
 
 
 def _set_keys(value) -> list[str]:
-	"""Returns the members of a JMAP ``set`` property, whether it arrives as a map or a list."""
+    """Returns the members of a JMAP ``set`` property, whether it arrives as a map or a list."""
 
-	if isinstance(value, dict):
-		return sorted(value.keys())
-	return _listify(value)
+    if isinstance(value, dict):
+        return sorted(value.keys())
+    return _listify(value)
 
 
 def _queue_row(message: dict) -> dict:
-	"""Maps a queued message to its list-row shape."""
+    """Maps a queued message to its list-row shape."""
 
-	recipients = list((message.get("recipients") or {}).keys())
-	return {
-		"id": message["id"],
-		"sender": message.get("returnPath"),
-		"recipients": recipients,
-		"recipient_count": len(recipients),
-		"size": message.get("size"),
-		"next_retry": message.get("nextRetry"),
-		"created_at": message.get("createdAt"),
-	}
+    recipients = list((message.get("recipients") or {}).keys())
+    return {
+        "id": message["id"],
+        "sender": message.get("returnPath"),
+        "recipients": recipients,
+        "recipient_count": len(recipients),
+        "size": message.get("size"),
+        "next_retry": message.get("nextRetry"),
+        "created_at": message.get("createdAt"),
+    }
 
 
 def _queue_filter(search: str | None, to: str | None, sender: str | None) -> dict | None:
-	"""Builds a queue query filter from the provided, non-empty criteria."""
+    """Builds a queue query filter from the provided, non-empty criteria."""
 
-	filter = {}
-	if search:
-		filter["text"] = search
-	if to:
-		filter["to"] = to
-	if sender:
-		filter["returnPath"] = sender
-	return filter or None
+    filter = {}
+    if search:
+        filter["text"] = search
+    if to:
+        filter["to"] = to
+    if sender:
+        filter["returnPath"] = sender
+    return filter or None
 
 
 @frappe.whitelist()
 def get_queued_messages(
-	search: str | None = None,
-	to: str | None = None,
-	sender: str | None = None,
-	page: int = 1,
-	page_length: int = 50,
+    search: str | None = None,
+    to: str | None = None,
+    sender: str | None = None,
+    page: int = 1,
+    page_length: int = 50,
 ) -> dict:
-	"""Returns a page of messages pending outbound delivery with the total count."""
+    """Returns a page of messages pending outbound delivery with the total count."""
 
-	check_admin_permission("view queued messages")
+    check_admin_permission("view queued messages")
 
-	page, page_length = cint(page) or 1, cint(page_length) or 50
-	result = get_queued_message_service().list_page(
-		filter=_queue_filter(search, to, sender),
-		position=(page - 1) * page_length,
-		limit=page_length,
-		properties=["id", "returnPath", "recipients", "size", "nextRetry", "createdAt"],
-	)
-	return {"messages": [_queue_row(m) for m in result["items"]], "total": result["total"]}
+    page, page_length = cint(page) or 1, cint(page_length) or 50
+    result = get_queued_message_service().list_page(
+        filter=_queue_filter(search, to, sender),
+        position=(page - 1) * page_length,
+        limit=page_length,
+        properties=["id", "returnPath", "recipients", "size", "nextRetry", "createdAt"],
+    )
+    return {"messages": [_queue_row(m) for m in result["items"]], "total": result["total"]}
 
 
 def _recipient_detail(email: str, recipient: dict) -> dict:
-	"""Flattens a queued recipient (status/expiry unions included) into an editable row shape."""
+    """Flattens a queued recipient (status/expiry unions included) into an editable row shape."""
 
-	status = recipient.get("status") or {}
-	expires = recipient.get("expires") or {}
-	return {
-		"email": email,
-		"orcpt": recipient.get("orcpt"),
-		"status_type": status.get("@type"),
-		"error_type": status.get("errorType"),
-		"error_message": status.get("errorMessage"),
-		"smtp_command": status.get("errorCommand"),
-		"hostname": status.get("responseHostname"),
-		"response_code": status.get("responseCode"),
-		"enhanced_code": status.get("responseEnhanced"),
-		"message": status.get("responseMessage"),
-		"next_retry": recipient.get("retryDue"),
-		"retry_count": recipient.get("retryCount"),
-		"next_notification": recipient.get("notifyDue"),
-		"notify_count": recipient.get("notifyCount"),
-		"expiry_type": expires.get("@type"),
-		"expires_at": expires.get("expiresAt"),
-		"expires_attempts": expires.get("expiresAttempts"),
-	}
+    status = recipient.get("status") or {}
+    expires = recipient.get("expires") or {}
+    return {
+        "email": email,
+        "orcpt": recipient.get("orcpt"),
+        "status_type": status.get("@type"),
+        "error_type": status.get("errorType"),
+        "error_message": status.get("errorMessage"),
+        "smtp_command": status.get("errorCommand"),
+        "hostname": status.get("responseHostname"),
+        "response_code": status.get("responseCode"),
+        "enhanced_code": status.get("responseEnhanced"),
+        "message": status.get("responseMessage"),
+        "next_retry": recipient.get("retryDue"),
+        "retry_count": recipient.get("retryCount"),
+        "next_notification": recipient.get("notifyDue"),
+        "notify_count": recipient.get("notifyCount"),
+        "expiry_type": expires.get("@type"),
+        "expires_at": expires.get("expiresAt"),
+        "expires_attempts": expires.get("expiresAttempts"),
+    }
 
 
 def _message_flags(message: dict) -> list[dict]:
-	"""Returns the message flags as ``{value, label}`` using the server's flag labels."""
+    """Returns the message flags as ``{value, label}`` using the server's flag labels."""
 
-	labels = {f["value"]: f["label"] for f in get_queue_metadata()["message_flags"]}
-	return [{"value": flag, "label": labels.get(flag, flag)} for flag in _set_keys(message.get("flags"))]
+    labels = {f["value"]: f["label"] for f in get_queue_metadata()["message_flags"]}
+    return [{"value": flag, "label": labels.get(flag, flag)} for flag in _set_keys(message.get("flags"))]
 
 
 @frappe.whitelist()
 def get_queued_message(message_id: str) -> dict:
-	"""Returns a queued message with its per-recipient delivery status."""
+    """Returns a queued message with its per-recipient delivery status."""
 
-	check_admin_permission("view queued messages")
+    check_admin_permission("view queued messages")
 
-	message = get_queued_message_service().get(message_id)
-	if not message:
-		frappe.throw(_("Queued message not found"), frappe.DoesNotExistError)
+    message = get_queued_message_service().get(message_id)
+    if not message:
+        frappe.throw(_("Queued message not found"), frappe.DoesNotExistError)
 
-	recipients = [_recipient_detail(email, r) for email, r in (message.get("recipients") or {}).items()]
-	return {
-		"id": message["id"],
-		"sender": message.get("returnPath"),
-		"size": message.get("size"),
-		"priority": message.get("priority"),
-		"env_id": message.get("envId"),
-		"flags": _message_flags(message),
-		"next_retry": message.get("nextRetry"),
-		"next_notify": message.get("nextNotify"),
-		"received_from_ip": message.get("receivedFromIp"),
-		"received_via_port": message.get("receivedViaPort"),
-		"created_at": message.get("createdAt"),
-		"recipients": recipients,
-		"has_content": bool(message.get("blobId")),
-	}
+    recipients = [_recipient_detail(email, r) for email, r in (message.get("recipients") or {}).items()]
+    return {
+        "id": message["id"],
+        "sender": message.get("returnPath"),
+        "size": message.get("size"),
+        "priority": message.get("priority"),
+        "env_id": message.get("envId"),
+        "flags": _message_flags(message),
+        "next_retry": message.get("nextRetry"),
+        "next_notify": message.get("nextNotify"),
+        "received_from_ip": message.get("receivedFromIp"),
+        "received_via_port": message.get("receivedViaPort"),
+        "created_at": message.get("createdAt"),
+        "recipients": recipients,
+        "has_content": bool(message.get("blobId")),
+    }
 
 
 @frappe.whitelist()
 def get_queue_recipient_options() -> dict:
-	"""Returns the option lists (status types, error types, expiry types) for editing recipients."""
+    """Returns the option lists (status types, error types, expiry types) for editing recipients."""
 
-	check_admin_permission("view queued messages")
-	meta = get_queue_metadata()
-	return {
-		"status_types": meta["status_types"],
-		"error_types": meta["error_types"],
-		"expiry_types": meta["expiry_types"],
-	}
+    check_admin_permission("view queued messages")
+    meta = get_queue_metadata()
+    return {
+        "status_types": meta["status_types"],
+        "error_types": meta["error_types"],
+        "expiry_types": meta["expiry_types"],
+    }
 
 
 def _utc_datetime(value: str | None) -> str | None:
-	"""Normalizes a timestamp the API was called with to the UTCDateTime Stalwart stores."""
+    """Normalizes a timestamp the API was called with to the UTCDateTime Stalwart stores."""
 
-	return to_utc_z(value)
+    return to_utc_z(value)
 
 
 def _status_object(
-	status_type: str,
-	error_type: str | None,
-	error_message: str | None,
-	smtp_command: str | None,
-	hostname: str | None,
-	response_code: str | int | None,
-	enhanced_code: str | None,
-	message: str | None,
+    status_type: str,
+    error_type: str | None,
+    error_message: str | None,
+    smtp_command: str | None,
+    hostname: str | None,
+    response_code: str | int | None,
+    enhanced_code: str | None,
+    message: str | None,
 ) -> dict:
-	"""Builds a recipient status union member from the edited fields."""
+    """Builds a recipient status union member from the edited fields."""
 
-	status = {"@type": status_type}
-	response = {
-		"responseHostname": hostname or None,
-		"responseCode": cint(response_code) if str(response_code or "").strip() else None,
-		"responseEnhanced": enhanced_code or None,
-		"responseMessage": message or None,
-	}
-	if status_type in ("TemporaryFailure", "PermanentFailure"):
-		status.update(
-			{
-				"errorType": error_type or None,
-				"errorMessage": error_message or None,
-				"errorCommand": smtp_command or None,
-				**response,
-			}
-		)
-	elif status_type == "Completed":
-		status.update(response)
+    status = {"@type": status_type}
+    response = {
+        "responseHostname": hostname or None,
+        "responseCode": cint(response_code) if str(response_code or "").strip() else None,
+        "responseEnhanced": enhanced_code or None,
+        "responseMessage": message or None,
+    }
+    if status_type in ("TemporaryFailure", "PermanentFailure"):
+        status.update(
+            {
+                "errorType": error_type or None,
+                "errorMessage": error_message or None,
+                "errorCommand": smtp_command or None,
+                **response,
+            }
+        )
+    elif status_type == "Completed":
+        status.update(response)
 
-	# The whole status node is replaced, so absent keys are cleared; dropping None-valued keys also
-	# avoids sending null for the non-nullable errorType enum.
-	return {key: value for key, value in status.items() if value is not None}
+    # The whole status node is replaced, so absent keys are cleared; dropping None-valued keys also
+    # avoids sending null for the non-nullable errorType enum.
+    return {key: value for key, value in status.items() if value is not None}
 
 
 def _expires_object(expiry_type: str, expires_at: str | None, expires_attempts: str | int | None) -> dict:
-	"""Builds a queue-expiry union member from the edited fields."""
+    """Builds a queue-expiry union member from the edited fields."""
 
-	if expiry_type == "Attempts":
-		return {"@type": "Attempts", "expiresAttempts": cint(expires_attempts)}
-	return {"@type": "Ttl", "expiresAt": _utc_datetime(expires_at)}
+    if expiry_type == "Attempts":
+        return {"@type": "Attempts", "expiresAttempts": cint(expires_attempts)}
+    return {"@type": "Ttl", "expiresAt": _utc_datetime(expires_at)}
 
 
 @frappe.whitelist()
 def update_queued_message(message_id: str, next_retry: str | None = None) -> None:
-	"""Updates a queued message's next retry time."""
+    """Updates a queued message's next retry time."""
 
-	check_admin_permission("update queued messages", message_id)
+    check_admin_permission("update queued messages", message_id)
 
-	if next_retry is not None:
-		get_queued_message_service().update(message_id, {"nextRetry": _utc_datetime(next_retry)})
+    if next_retry is not None:
+        get_queued_message_service().update(message_id, {"nextRetry": _utc_datetime(next_retry)})
 
 
 @frappe.whitelist()
 def update_queued_recipient(
-	message_id: str,
-	email: str,
-	new_email: str | None = None,
-	orcpt: str | None = None,
-	status_type: str | None = None,
-	error_type: str | None = None,
-	error_message: str | None = None,
-	smtp_command: str | None = None,
-	hostname: str | None = None,
-	response_code: str | None = None,
-	enhanced_code: str | None = None,
-	message: str | None = None,
-	next_retry: str | None = None,
-	retry_count: str | None = None,
-	next_notification: str | None = None,
-	notify_count: str | None = None,
-	expiry_type: str | None = None,
-	expires_at: str | None = None,
-	expires_attempts: str | None = None,
+    message_id: str,
+    email: str,
+    new_email: str | None = None,
+    orcpt: str | None = None,
+    status_type: str | None = None,
+    error_type: str | None = None,
+    error_message: str | None = None,
+    smtp_command: str | None = None,
+    hostname: str | None = None,
+    response_code: str | None = None,
+    enhanced_code: str | None = None,
+    message: str | None = None,
+    next_retry: str | None = None,
+    retry_count: str | None = None,
+    next_notification: str | None = None,
+    notify_count: str | None = None,
+    expiry_type: str | None = None,
+    expires_at: str | None = None,
+    expires_attempts: str | None = None,
 ) -> None:
-	"""Updates a single recipient of a queued message (renames the address if ``new_email`` differs)."""
+    """Updates a single recipient of a queued message (renames the address if ``new_email`` differs)."""
 
-	check_admin_permission("update queued messages", f"{message_id} ({email})")
-	service = get_queued_message_service()
+    check_admin_permission("update queued messages", f"{message_id} ({email})")
+    service = get_queued_message_service()
 
-	# Scalar edits keyed by their JMAP property; a ``None`` argument means "leave unchanged".
-	changed = {}
-	if orcpt is not None:
-		changed["orcpt"] = orcpt or None
-	if next_retry is not None:
-		changed["retryDue"] = _utc_datetime(next_retry)
-	if retry_count is not None:
-		changed["retryCount"] = cint(retry_count)
-	if next_notification is not None:
-		changed["notifyDue"] = _utc_datetime(next_notification)
-	if notify_count is not None:
-		changed["notifyCount"] = cint(notify_count)
-	status = (
-		_status_object(
-			status_type,
-			error_type,
-			error_message,
-			smtp_command,
-			hostname,
-			response_code,
-			enhanced_code,
-			message,
-		)
-		if status_type
-		else None
-	)
-	expires = _expires_object(expiry_type, expires_at, expires_attempts) if expiry_type else None
+    # Scalar edits keyed by their JMAP property; a ``None`` argument means "leave unchanged".
+    changed = {}
+    if orcpt is not None:
+        changed["orcpt"] = orcpt or None
+    if next_retry is not None:
+        changed["retryDue"] = _utc_datetime(next_retry)
+    if retry_count is not None:
+        changed["retryCount"] = cint(retry_count)
+    if next_notification is not None:
+        changed["notifyDue"] = _utc_datetime(next_notification)
+    if notify_count is not None:
+        changed["notifyCount"] = cint(notify_count)
+    status = (
+        _status_object(
+            status_type,
+            error_type,
+            error_message,
+            smtp_command,
+            hostname,
+            response_code,
+            enhanced_code,
+            message,
+        )
+        if status_type
+        else None
+    )
+    expires = _expires_object(expiry_type, expires_at, expires_attempts) if expiry_type else None
 
-	new_email = (new_email or "").strip()
-	if new_email and new_email != email:
-		# Rename: rebuild the recipient (minus server-set fields) under the new key.
-		current = ((service.get(message_id, properties=["recipients"]) or {}).get("recipients") or {}).get(
-			email
-		)
-		if current is None:
-			frappe.throw(_("Recipient not found"), frappe.DoesNotExistError)
-		obj = {k: v for k, v in current.items() if k not in ("flags", "queueName")}
-		obj.update(changed)
-		if status is not None:
-			obj["status"] = status
-		if expires is not None:
-			obj["expires"] = expires
-		service.update(message_id, {f"recipients/{email}": None, f"recipients/{new_email}": obj})
-		return
+    new_email = (new_email or "").strip()
+    if new_email and new_email != email:
+        # Rename: rebuild the recipient (minus server-set fields) under the new key.
+        current = ((service.get(message_id, properties=["recipients"]) or {}).get("recipients") or {}).get(
+            email
+        )
+        if current is None:
+            frappe.throw(_("Recipient not found"), frappe.DoesNotExistError)
+        obj = {k: v for k, v in current.items() if k not in ("flags", "queueName")}
+        obj.update(changed)
+        if status is not None:
+            obj["status"] = status
+        if expires is not None:
+            obj["expires"] = expires
+        service.update(message_id, {f"recipients/{email}": None, f"recipients/{new_email}": obj})
+        return
 
-	patch = {f"recipients/{email}/{prop}": value for prop, value in changed.items()}
-	if status is not None:
-		patch[f"recipients/{email}/status"] = status
-	if expires is not None:
-		patch[f"recipients/{email}/expires"] = expires
-	if patch:
-		service.update(message_id, patch)
+    patch = {f"recipients/{email}/{prop}": value for prop, value in changed.items()}
+    if status is not None:
+        patch[f"recipients/{email}/status"] = status
+    if expires is not None:
+        patch[f"recipients/{email}/expires"] = expires
+    if patch:
+        service.update(message_id, patch)
 
 
 @frappe.whitelist()
 def add_queued_recipient(message_id: str, email: str) -> None:
-	"""Adds a recipient (pending delivery) to a queued message."""
+    """Adds a recipient (pending delivery) to a queued message."""
 
-	from datetime import timedelta
+    from datetime import timedelta
 
-	check_admin_permission("update queued messages", f"{message_id} ({email})")
+    check_admin_permission("update queued messages", f"{message_id} ({email})")
 
-	email = (email or "").strip()
-	if not email:
-		frappe.throw(_("Recipient email is required."))
+    email = (email or "").strip()
+    if not email:
+        frappe.throw(_("Recipient email is required."))
 
-	now = get_utc_now()
-	recipient = {
-		"status": {"@type": "Scheduled"},
-		"retryDue": to_utc_z(now),
-		"notifyDue": to_utc_z(now),
-		"expires": {"@type": "Ttl", "expiresAt": to_utc_z(now + timedelta(days=5))},
-	}
-	get_queued_message_service().update(message_id, {f"recipients/{email}": recipient})
+    now = get_utc_now()
+    recipient = {
+        "status": {"@type": "Scheduled"},
+        "retryDue": to_utc_z(now),
+        "notifyDue": to_utc_z(now),
+        "expires": {"@type": "Ttl", "expiresAt": to_utc_z(now + timedelta(days=5))},
+    }
+    get_queued_message_service().update(message_id, {f"recipients/{email}": recipient})
 
 
 @frappe.whitelist()
 def remove_queued_recipient(message_id: str, email: str) -> None:
-	"""Removes a recipient from a queued message."""
+    """Removes a recipient from a queued message."""
 
-	check_admin_permission("update queued messages", f"{message_id} ({email})")
-	get_queued_message_service().update(message_id, {f"recipients/{email}": None})
+    check_admin_permission("update queued messages", f"{message_id} ({email})")
+    get_queued_message_service().update(message_id, {f"recipients/{email}": None})
 
 
 @frappe.whitelist()
 def get_queued_message_source(message_id: str) -> dict:
-	"""Returns the raw RFC822 source of a queued message."""
+    """Returns the raw RFC822 source of a queued message."""
 
-	from urllib.parse import urljoin
+    from urllib.parse import urljoin
 
-	check_admin_permission("view queued messages")
+    check_admin_permission("view queued messages")
 
-	connection = get_queued_message_service().connection
-	message = get_queued_message_service().get(message_id, properties=["id", "blobId"])
-	blob_id = (message or {}).get("blobId")
-	if not blob_id:
-		frappe.throw(_("Queued message content is not available"), frappe.DoesNotExistError)
+    connection = get_queued_message_service().connection
+    message = get_queued_message_service().get(message_id, properties=["id", "blobId"])
+    blob_id = (message or {}).get("blobId")
+    if not blob_id:
+        frappe.throw(_("Queued message content is not available"), frappe.DoesNotExistError)
 
-	account_id = connection.primary_accounts["urn:stalwart:jmap"]
-	url = urljoin(
-		get_config("server_url"),
-		f"/jmap/download/{account_id}/{blob_id}/message.eml?accept=message/rfc822",
-	)
-	content = connection.request(method="GET", url=url, return_json=False)
-	return {"source": content.decode(errors="replace") if isinstance(content, bytes) else content}
+    account_id = connection.primary_accounts["urn:stalwart:jmap"]
+    url = urljoin(
+        get_config("server_url"),
+        f"/jmap/download/{account_id}/{blob_id}/message.eml?accept=message/rfc822",
+    )
+    content = connection.request(method="GET", url=url, return_json=False)
+    return {"source": content.decode(errors="replace") if isinstance(content, bytes) else content}
 
 
 @frappe.whitelist()
 def retry_queued_messages(ids: list) -> None:
-	"""Schedules the given queued messages for immediate delivery."""
+    """Schedules the given queued messages for immediate delivery."""
 
-	check_admin_permission("retry queued messages", ids)
-	get_queued_message_service().retry(_listify(ids))
+    check_admin_permission("retry queued messages", ids)
+    get_queued_message_service().retry(_listify(ids))
 
 
 @frappe.whitelist()
 def cancel_queued_messages(ids: list) -> None:
-	"""Cancels (deletes) the given queued messages."""
+    """Cancels (deletes) the given queued messages."""
 
-	check_admin_permission("cancel queued messages", ids)
-	get_queued_message_service().delete(_listify(ids))
+    check_admin_permission("cancel queued messages", ids)
+    get_queued_message_service().delete(_listify(ids))
 
 
 @frappe.whitelist()
 def retry_all_queued_messages(
-	search: str | None = None, to: str | None = None, sender: str | None = None
+    search: str | None = None, to: str | None = None, sender: str | None = None
 ) -> None:
-	"""Schedules every message matching the current filter for immediate delivery."""
+    """Schedules every message matching the current filter for immediate delivery."""
 
-	check_admin_permission("retry queued messages", "all")
-	service = get_queued_message_service()
-	service.retry(service.query(filter=_queue_filter(search, to, sender))["ids"])
+    check_admin_permission("retry queued messages", "all")
+    service = get_queued_message_service()
+    service.retry(service.query(filter=_queue_filter(search, to, sender))["ids"])
 
 
 @frappe.whitelist()
 def cancel_all_queued_messages(
-	search: str | None = None, to: str | None = None, sender: str | None = None
+    search: str | None = None, to: str | None = None, sender: str | None = None
 ) -> None:
-	"""Cancels (deletes) every message matching the current filter."""
+    """Cancels (deletes) every message matching the current filter."""
 
-	check_admin_permission("cancel queued messages", "all")
-	service = get_queued_message_service()
-	service.delete(service.query(filter=_queue_filter(search, to, sender))["ids"])
+    check_admin_permission("cancel queued messages", "all")
+    service = get_queued_message_service()
+    service.delete(service.query(filter=_queue_filter(search, to, sender))["ids"])
 
 
 # ---------------------------------------------------------------------------
@@ -2244,43 +2244,43 @@ def cancel_all_queued_messages(
 
 @frappe.whitelist(methods=["GET"])
 def stream_delivery_test(target: str):
-	"""Proxies Stalwart's live SMTP delivery trace for ``target`` as a Server-Sent Events stream.
+    """Proxies Stalwart's live SMTP delivery trace for ``target`` as a Server-Sent Events stream.
 
-	Stalwart sends no CORS headers and authenticates the trace with a short-lived token, so the
-	browser cannot connect directly. This mints the token server-side and relays the event stream
-	over the same origin instead.
-	"""
+    Stalwart sends no CORS headers and authenticates the trace with a short-lived token, so the
+    browser cannot connect directly. This mints the token server-side and relays the event stream
+    over the same origin instead.
+    """
 
-	from urllib.parse import quote, urljoin
+    from urllib.parse import quote, urljoin
 
-	import requests
-	from werkzeug.wrappers import Response
+    import requests
+    from werkzeug.wrappers import Response
 
-	check_admin_permission("run delivery test", target)
+    check_admin_permission("run delivery test", target)
 
-	connection = get_management_connection()
-	server_url, verify_ssl = get_config(("server_url", "verify_ssl"))
-	token = connection.request(
-		method="GET", url=urljoin(server_url, "/api/token/delivery"), return_json=False
-	)
-	token = token.decode() if isinstance(token, bytes) else token
+    connection = get_management_connection()
+    server_url, verify_ssl = get_config(("server_url", "verify_ssl"))
+    token = connection.request(
+        method="GET", url=urljoin(server_url, "/api/token/delivery"), return_json=False
+    )
+    token = token.decode() if isinstance(token, bytes) else token
 
-	url = urljoin(server_url, f"/api/live/delivery/{quote(target)}?token={quote(token)}")
-	upstream = requests.get(url, stream=True, verify=bool(verify_ssl), timeout=(10, 300))
+    url = urljoin(server_url, f"/api/live/delivery/{quote(target)}?token={quote(token)}")
+    upstream = requests.get(url, stream=True, verify=bool(verify_ssl), timeout=(10, 300))
 
-	def relay():
-		try:
-			for chunk in upstream.iter_content(chunk_size=None):
-				if chunk:
-					yield chunk
-		finally:
-			upstream.close()
+    def relay():
+        try:
+            for chunk in upstream.iter_content(chunk_size=None):
+                if chunk:
+                    yield chunk
+        finally:
+            upstream.close()
 
-	return Response(
-		relay(),
-		mimetype="text/event-stream",
-		headers={"Cache-Control": "no-store", "X-Accel-Buffering": "no"},
-	)
+    return Response(
+        relay(),
+        mimetype="text/event-stream",
+        headers={"Cache-Control": "no-store", "X-Accel-Buffering": "no"},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -2289,105 +2289,105 @@ def stream_delivery_test(target: str):
 
 
 def _report_row(direction: str, report: dict) -> dict:
-	"""Maps a report to its list-row shape (columns differ by direction)."""
+    """Maps a report to its list-row shape (columns differ by direction)."""
 
-	if direction == "inbound":
-		return {
-			"id": report["id"],
-			"from": report.get("from"),
-			"subject": report.get("subject"),
-			"received_at": report.get("receivedAt"),
-		}
-	return {
-		"id": report["id"],
-		"domain": report.get("domain"),
-		"created_at": report.get("createdAt"),
-		"deliver_at": report.get("deliverAt"),
-	}
+    if direction == "inbound":
+        return {
+            "id": report["id"],
+            "from": report.get("from"),
+            "subject": report.get("subject"),
+            "received_at": report.get("receivedAt"),
+        }
+    return {
+        "id": report["id"],
+        "domain": report.get("domain"),
+        "created_at": report.get("createdAt"),
+        "deliver_at": report.get("deliverAt"),
+    }
 
 
 def _report_filter(kind: str, direction: str, search: str | None) -> dict | None:
-	"""Maps the search box onto the filter DMARC reports support; other kinds are unfiltered.
+    """Maps the search box onto the filter DMARC reports support; other kinds are unfiltered.
 
-	Only DMARC is searchable, and each direction takes a different filter: received reports take
-	Stalwart's free-text ``text`` filter (matching the sender/recipient addresses and the reported
-	domain, not the subject), while the reports Stalwart generates take an exact ``domain`` match.
-	Anything else is rejected as ``unsupportedFilter``.
-	"""
+    Only DMARC is searchable, and each direction takes a different filter: received reports take
+    Stalwart's free-text ``text`` filter (matching the sender/recipient addresses and the reported
+    domain, not the subject), while the reports Stalwart generates take an exact ``domain`` match.
+    Anything else is rejected as ``unsupportedFilter``.
+    """
 
-	search = (search or "").strip()
-	if not search or kind != "dmarc":
-		return None
-	return {"text": search} if direction == "inbound" else {"domain": search}
+    search = (search or "").strip()
+    if not search or kind != "dmarc":
+        return None
+    return {"text": search} if direction == "inbound" else {"domain": search}
 
 
 @frappe.whitelist()
 def get_reports(
-	kind: str,
-	direction: str,
-	search: str | None = None,
-	page: int = 1,
-	page_length: int = 50,
+    kind: str,
+    direction: str,
+    search: str | None = None,
+    page: int = 1,
+    page_length: int = 50,
 ) -> dict:
-	"""Returns a page of ``kind`` reports (dmarc/tls/arf) in the given direction (inbound/outbound)."""
+    """Returns a page of ``kind`` reports (dmarc/tls/arf) in the given direction (inbound/outbound)."""
 
-	check_admin_permission("view reports")
+    check_admin_permission("view reports")
 
-	page, page_length = cint(page) or 1, cint(page_length) or 50
-	result = get_report_service(kind, direction).list_page(
-		filter=_report_filter(kind, direction, search), position=(page - 1) * page_length, limit=page_length
-	)
-	return {"reports": [_report_row(direction, r) for r in result["items"]], "total": result["total"]}
+    page, page_length = cint(page) or 1, cint(page_length) or 50
+    result = get_report_service(kind, direction).list_page(
+        filter=_report_filter(kind, direction, search), position=(page - 1) * page_length, limit=page_length
+    )
+    return {"reports": [_report_row(direction, r) for r in result["items"]], "total": result["total"]}
 
 
 @frappe.whitelist()
 def get_report(kind: str, direction: str, report_id: str) -> dict:
-	"""Returns a single report's metadata plus its parsed report body."""
+    """Returns a single report's metadata plus its parsed report body."""
 
-	check_admin_permission("view reports")
+    check_admin_permission("view reports")
 
-	report = get_report_service(kind, direction).get(report_id)
-	if not report:
-		frappe.throw(_("Report not found"), frappe.DoesNotExistError)
+    report = get_report_service(kind, direction).get(report_id)
+    if not report:
+        frappe.throw(_("Report not found"), frappe.DoesNotExistError)
 
-	meta = {"id": report["id"], "kind": kind, "direction": direction, "report": report.get("report")}
-	if direction == "inbound":
-		meta.update(
-			{
-				"from": report.get("from"),
-				"subject": report.get("subject"),
-				"to": _set_keys(report.get("to")),
-				"received_at": report.get("receivedAt"),
-				"expires_at": report.get("expiresAt"),
-			}
-		)
-	else:
-		meta.update(
-			{
-				"domain": report.get("domain"),
-				"created_at": report.get("createdAt"),
-				"deliver_at": report.get("deliverAt"),
-			}
-		)
-		if kind == "dmarc":
-			# `policyIdentifier` is a u64 hash that overflows JS's safe integer range, so send it as
-			# a string to keep the browser from rounding it.
-			identifier = report.get("policyIdentifier")
-			meta.update(
-				{
-					"rua": _set_keys(report.get("rua")),
-					"policy_identifier": str(identifier) if identifier is not None else None,
-				}
-			)
-	return meta
+    meta = {"id": report["id"], "kind": kind, "direction": direction, "report": report.get("report")}
+    if direction == "inbound":
+        meta.update(
+            {
+                "from": report.get("from"),
+                "subject": report.get("subject"),
+                "to": _set_keys(report.get("to")),
+                "received_at": report.get("receivedAt"),
+                "expires_at": report.get("expiresAt"),
+            }
+        )
+    else:
+        meta.update(
+            {
+                "domain": report.get("domain"),
+                "created_at": report.get("createdAt"),
+                "deliver_at": report.get("deliverAt"),
+            }
+        )
+        if kind == "dmarc":
+            # `policyIdentifier` is a u64 hash that overflows JS's safe integer range, so send it as
+            # a string to keep the browser from rounding it.
+            identifier = report.get("policyIdentifier")
+            meta.update(
+                {
+                    "rua": _set_keys(report.get("rua")),
+                    "policy_identifier": str(identifier) if identifier is not None else None,
+                }
+            )
+    return meta
 
 
 @frappe.whitelist()
 def delete_reports(kind: str, direction: str, ids: list) -> None:
-	"""Deletes the given reports."""
+    """Deletes the given reports."""
 
-	check_admin_permission("delete reports", ids)
-	get_report_service(kind, direction).delete(_listify(ids))
+    check_admin_permission("delete reports", ids)
+    get_report_service(kind, direction).delete(_listify(ids))
 
 
 # ---------------------------------------------------------------------------
@@ -2396,63 +2396,63 @@ def delete_reports(kind: str, direction: str, ids: list) -> None:
 
 
 def _log_row(entry: dict, labels: dict) -> dict:
-	"""Maps a log entry to its row/detail shape, resolved against the schema's display labels.
+    """Maps a log entry to its row/detail shape, resolved against the schema's display labels.
 
-	The raw ``level``/``event`` identifiers are kept so the UI can still key off them (e.g. to colour
-	a level); ``labels`` comes from :func:`get_log_labels` and falls back to the identifier itself for
-	anything the server's enums do not describe.
-	"""
+    The raw ``level``/``event`` identifiers are kept so the UI can still key off them (e.g. to colour
+    a level); ``labels`` comes from :func:`get_log_labels` and falls back to the identifier itself for
+    anything the server's enums do not describe.
+    """
 
-	level, event = entry.get("level"), entry.get("event")
-	return {
-		"id": entry["id"],
-		"timestamp": entry.get("timestamp"),
-		"level": level,
-		"level_label": labels["levels"].get(level, level),
-		"event": event,
-		"event_label": labels["events"].get(event, event),
-		"details": entry.get("details"),
-	}
+    level, event = entry.get("level"), entry.get("event")
+    return {
+        "id": entry["id"],
+        "timestamp": entry.get("timestamp"),
+        "level": level,
+        "level_label": labels["levels"].get(level, level),
+        "event": event,
+        "event_label": labels["events"].get(event, event),
+        "details": entry.get("details"),
+    }
 
 
 @frappe.whitelist()
 def get_logs(search: str | None = None, anchor: str | None = None, page_length: int = 100) -> dict:
-	"""Returns a page of server log entries (most recent first), starting after ``anchor``.
+    """Returns a page of server log entries (most recent first), starting after ``anchor``.
 
-	The log store only supports cursor pagination, so pages are walked one at a time using the
-	``next_anchor`` returned here instead of jumping to an arbitrary offset; ``next_anchor`` is
-	``None`` on the last page. ``total`` is how many entries the server retains and, unlike the other
-	listings, is not narrowed by ``search``.
-	"""
+    The log store only supports cursor pagination, so pages are walked one at a time using the
+    ``next_anchor`` returned here instead of jumping to an arbitrary offset; ``next_anchor`` is
+    ``None`` on the last page. ``total`` is how many entries the server retains and, unlike the other
+    listings, is not narrowed by ``search``.
+    """
 
-	check_admin_permission("view logs")
+    check_admin_permission("view logs")
 
-	page_length = cint(page_length) or 100
-	result = get_log_service().list_page(
-		filter={"text": search} if search else None,
-		anchor=anchor,
-		limit=page_length,
-	)
-	labels = get_log_labels()
-	logs = [_log_row(e, labels) for e in result["items"]]
-	return {
-		"logs": logs,
-		"total": result["total"],
-		"next_anchor": logs[-1]["id"] if len(logs) == page_length else None,
-	}
+    page_length = cint(page_length) or 100
+    result = get_log_service().list_page(
+        filter={"text": search} if search else None,
+        anchor=anchor,
+        limit=page_length,
+    )
+    labels = get_log_labels()
+    logs = [_log_row(e, labels) for e in result["items"]]
+    return {
+        "logs": logs,
+        "total": result["total"],
+        "next_anchor": logs[-1]["id"] if len(logs) == page_length else None,
+    }
 
 
 @frappe.whitelist()
 def get_log(log_id: str) -> dict:
-	"""Returns a single log entry."""
+    """Returns a single log entry."""
 
-	check_admin_permission("view logs")
+    check_admin_permission("view logs")
 
-	entry = get_log_service().get(log_id)
-	if not entry:
-		frappe.throw(_("Log entry not found"), frappe.DoesNotExistError)
+    entry = get_log_service().get(log_id)
+    if not entry:
+        frappe.throw(_("Log entry not found"), frappe.DoesNotExistError)
 
-	return _log_row(entry, get_log_labels())
+    return _log_row(entry, get_log_labels())
 
 
 # ---------------------------------------------------------------------------
@@ -2467,95 +2467,95 @@ ADMINISTRATOR_ONLY_ACTIONS = frozenset({"PauseMtaQueue"})
 
 @frappe.whitelist()
 def get_actions() -> list[dict]:
-	"""Returns the executable server management actions (``{value, label, schema_name}``).
+    """Returns the executable server management actions (``{value, label, schema_name}``).
 
-	Each one carries ``administrator_only`` so the UI can lock what ``run_action`` would refuse.
-	"""
+    Each one carries ``administrator_only`` so the UI can lock what ``run_action`` would refuse.
+    """
 
-	check_admin_permission("view actions")
-	return [{**a, "administrator_only": a["value"] in ADMINISTRATOR_ONLY_ACTIONS} for a in get_action_types()]
+    check_admin_permission("view actions")
+    return [{**a, "administrator_only": a["value"] in ADMINISTRATOR_ONLY_ACTIONS} for a in get_action_types()]
 
 
 @frappe.whitelist()
 def run_action(action_type: str, params: dict | None = None) -> dict:
-	"""Executes a server management action and returns its result (empty for parameterless actions).
+    """Executes a server management action and returns its result (empty for parameterless actions).
 
-	Inputs the schema types as a JMAP ``set`` (e.g. the recipients of a spam classification) arrive as
-	a list and are encoded here, since the server rejects a plain list for them.
-	"""
+    Inputs the schema types as a JMAP ``set`` (e.g. the recipients of a spam classification) arrive as
+    a list and are encoded here, since the server rejects a plain list for them.
+    """
 
-	user = check_admin_permission("run actions", action_type)
-	if action_type in ADMINISTRATOR_ONLY_ACTIONS and user != "Administrator":
-		frappe.throw(
-			_("Only the Administrator can run this action."),
-			frappe.PermissionError,
-		)
+    user = check_admin_permission("run actions", action_type)
+    if action_type in ADMINISTRATOR_ONLY_ACTIONS and user != "Administrator":
+        frappe.throw(
+            _("Only the Administrator can run this action."),
+            frappe.PermissionError,
+        )
 
-	params = {k: dict.fromkeys(v, True) if isinstance(v, list) else v for k, v in (params or {}).items()}
-	return get_action_service().run(action_type, params=params or None)
+    params = {k: dict.fromkeys(v, True) if isinstance(v, list) else v for k, v in (params or {}).items()}
+    return get_action_service().run(action_type, params=params or None)
 
 
 @frappe.whitelist()
 def get_overview() -> dict:
-	"""Aggregate counts and recent activity for the dashboard landing page.
+    """Aggregate counts and recent activity for the dashboard landing page.
 
-	Each section is gathered independently and degrades to ``None`` (or an empty list) when its
-	backing store is unavailable, so one unreachable subsystem doesn't blank the whole page.
-	"""
+    Each section is gathered independently and degrades to ``None`` (or an empty list) when its
+    backing store is unavailable, so one unreachable subsystem doesn't blank the whole page.
+    """
 
-	check_admin_permission("view overview")
+    check_admin_permission("view overview")
 
-	overview: dict = {
-		"members": None,
-		"pending_invites": None,
-		"domains": None,
-		"groups": None,
-		"mailing_lists": None,
-		"queued_messages": None,
-		"recent_logs": [],
-	}
+    overview: dict = {
+        "members": None,
+        "pending_invites": None,
+        "domains": None,
+        "groups": None,
+        "mailing_lists": None,
+        "queued_messages": None,
+        "recent_logs": [],
+    }
 
-	with suppress(Exception):
-		USER = frappe.qb.DocType("User")
-		USER_SETTINGS = frappe.qb.DocType("User Settings")
-		rows = (
-			frappe.qb.from_(USER)
-			.join(USER_SETTINGS)
-			.on(USER.name == USER_SETTINGS.user)
-			.select(USER.enabled)
-			.where(USER_SETTINGS.username.isnotnull())
-		).run(as_dict=True)
-		overview["members"] = {
-			"total": len(rows),
-			"disabled": sum(1 for row in rows if not row.enabled),
-		}
+    with suppress(Exception):
+        USER = frappe.qb.DocType("User")
+        USER_SETTINGS = frappe.qb.DocType("User Settings")
+        rows = (
+            frappe.qb.from_(USER)
+            .join(USER_SETTINGS)
+            .on(USER.name == USER_SETTINGS.user)
+            .select(USER.enabled)
+            .where(USER_SETTINGS.username.isnotnull())
+        ).run(as_dict=True)
+        overview["members"] = {
+            "total": len(rows),
+            "disabled": sum(1 for row in rows if not row.enabled),
+        }
 
-	with suppress(Exception):
-		overview["pending_invites"] = frappe.db.count(
-			"Mail Account Request",
-			{"is_verified": 0, "expires_at": [">", frappe.utils.now()]},
-		)
+    with suppress(Exception):
+        overview["pending_invites"] = frappe.db.count(
+            "Mail Account Request",
+            {"is_verified": 0, "expires_at": [">", frappe.utils.now()]},
+        )
 
-	with suppress(Exception):
-		domains = get_stalwart_domains()
-		overview["domains"] = {
-			"total": len(domains),
-			"disabled": sum(1 for domain in domains if not domain["isEnabled"]),
-		}
+    with suppress(Exception):
+        domains = get_stalwart_domains()
+        overview["domains"] = {
+            "total": len(domains),
+            "disabled": sum(1 for domain in domains if not domain["isEnabled"]),
+        }
 
-	with suppress(Exception):
-		overview["groups"] = len(get_group_service().get_all_groups(properties=["id"]))
+    with suppress(Exception):
+        overview["groups"] = len(get_group_service().get_all_groups(properties=["id"]))
 
-	with suppress(Exception):
-		overview["mailing_lists"] = len(get_mailing_list_service().get_all(properties=["id"]))
+    with suppress(Exception):
+        overview["mailing_lists"] = len(get_mailing_list_service().get_all(properties=["id"]))
 
-	with suppress(Exception):
-		result = get_queued_message_service().list_page(filter=None, position=0, limit=1)
-		overview["queued_messages"] = result["total"]
+    with suppress(Exception):
+        result = get_queued_message_service().list_page(filter=None, position=0, limit=1)
+        overview["queued_messages"] = result["total"]
 
-	with suppress(Exception):
-		result = get_log_service().list_page(filter=None, anchor=None, limit=6)
-		labels = get_log_labels()
-		overview["recent_logs"] = [_log_row(entry, labels) for entry in result["items"]]
+    with suppress(Exception):
+        result = get_log_service().list_page(filter=None, anchor=None, limit=6)
+        labels = get_log_labels()
+        overview["recent_logs"] = [_log_row(entry, labels) for entry in result["items"]]
 
-	return overview
+    return overview

--- a/suite/mail/api/auth.py
+++ b/suite/mail/api/auth.py
@@ -2,8 +2,8 @@ import frappe
 from frappe import _
 
 from suite.mail.doctype.user_account.user_account import get_user_jmap_accounts
-from suite.utils.rate_limiter import dynamic_rate_limit
 from suite.mail.utils.user import get_account_emails, is_jmap_configured
+from suite.utils.rate_limiter import dynamic_rate_limit
 
 
 @frappe.whitelist(methods=["POST"])

--- a/suite/mail/api/auth.py
+++ b/suite/mail/api/auth.py
@@ -9,33 +9,33 @@ from suite.mail.utils.user import get_account_emails, is_jmap_configured
 @frappe.whitelist(methods=["POST"])
 @dynamic_rate_limit()
 def validate(email: str) -> None:
-	"""Validates if the email is associated with the user."""
+    """Validates if the email is associated with the user."""
 
-	validate_user()
-	validate_email_ownership(email)
+    validate_user()
+    validate_email_ownership(email)
 
 
 def validate_user() -> None:
-	"""Validates if the user has permission to access the app."""
+    """Validates if the user has permission to access the app."""
 
-	is_jmap_configured(frappe.session.user, raise_exception=True)
+    is_jmap_configured(frappe.session.user, raise_exception=True)
 
 
 def validate_email_ownership(email: str) -> None:
-	"""Validates if the email is associated with any account of the user."""
+    """Validates if the email is associated with any account of the user."""
 
-	email = email.strip().lower()
-	if not email:
-		frappe.throw(_("Email address is required."), frappe.MandatoryError)
+    email = email.strip().lower()
+    if not email:
+        frappe.throw(_("Email address is required."), frappe.MandatoryError)
 
-	accounts = get_user_jmap_accounts()
-	for account in accounts:
-		if email in get_account_emails(account):
-			return
+    accounts = get_user_jmap_accounts()
+    for account in accounts:
+        if email in get_account_emails(account):
+            return
 
-	frappe.throw(
-		_("Email address '{0}' is not associated with any account of the user '{1}'.").format(
-			email, frappe.bold(frappe.session.user)
-		),
-		frappe.PermissionError,
-	)
+    frappe.throw(
+        _("Email address '{0}' is not associated with any account of the user '{1}'.").format(
+            email, frappe.bold(frappe.session.user)
+        ),
+        frappe.PermissionError,
+    )

--- a/suite/mail/api/contacts.py
+++ b/suite/mail/api/contacts.py
@@ -13,123 +13,123 @@ from suite.mail.store import Entity, get_data_store
 
 @frappe.whitelist()
 def get_address_books(account: str) -> list[dict]:
-	"""Returns the address books for the given account."""
+    """Returns the address books for the given account."""
 
-	if not (address_books := fetch_address_books(account, 1, 50)):
-		return []
+    if not (address_books := fetch_address_books(account, 1, 50)):
+        return []
 
-	fields = ["name", "id", "_name", "default"]
-	return [{f: d[f] for f in fields} for d in address_books]
+    fields = ["name", "id", "_name", "default"]
+    return [{f: d[f] for f in fields} for d in address_books]
 
 
 @frappe.whitelist()
 def get_contact_cards(account: str, filter: dict | None = None, limit: int = 50) -> list[dict]:
-	"""Returns the contact cards for the given account."""
+    """Returns the contact cards for the given account."""
 
-	if filter:
-		filter = {k: v for k, v in filter.items() if v}
+    if filter:
+        filter = {k: v for k, v in filter.items() if v}
 
-	if not (contact_cards := fetch_contact_cards(account, filter, 0, limit)[0]):
-		return []
+    if not (contact_cards := fetch_contact_cards(account, filter, 0, limit)[0]):
+        return []
 
-	fields = ["id", "full_name", "kind", "emails"]
-	return [{f: d[f].capitalize() if f == "kind" and d[f] else d[f] for f in fields} for d in contact_cards]
+    fields = ["id", "full_name", "kind", "emails"]
+    return [{f: d[f].capitalize() if f == "kind" and d[f] else d[f] for f in fields} for d in contact_cards]
 
 
 @frappe.whitelist()
 def get_contacts(account: str, filter: dict | None = None, limit: int = 50) -> list[dict]:
-	"""Returns the emails contacts for the given account."""
+    """Returns the emails contacts for the given account."""
 
-	contacts = []
-	contact_cards = get_contact_cards(account, filter, limit)
+    contacts = []
+    contact_cards = get_contact_cards(account, filter, limit)
 
-	for card in contact_cards:
-		if emails := card.get("emails"):
-			for email in emails:
-				contacts.append({"full_name": card.get("full_name"), "email": email.get("address")})
+    for card in contact_cards:
+        if emails := card.get("emails"):
+            for email in emails:
+                contacts.append({"full_name": card.get("full_name"), "email": email.get("address")})
 
-	enrich_contacts_with_user_images(contacts)
+    enrich_contacts_with_user_images(contacts)
 
-	return contacts
+    return contacts
 
 
 @frappe.whitelist()
 def get_contacts_from_cache(account: str, limit: int = 1000) -> list[dict]:
-	"""Returns all contact cards for the given account from the cache."""
+    """Returns all contact cards for the given account from the cache."""
 
-	get_user_for_jmap_account(account, raise_exception=True)
+    get_user_for_jmap_account(account, raise_exception=True)
 
-	store = get_data_store(account)
-	data = store.scan(Entity.CONTACT_CARD, prefix="", limit=limit)
+    store = get_data_store(account)
+    data = store.scan(Entity.CONTACT_CARD, prefix="", limit=limit)
 
-	contacts = []
-	for contact_card in data.values():
-		for email in contact_card.get("emails") or []:
-			contacts.append(
-				{
-					"id": contact_card.get("id"),
-					"email": email.get("address"),
-					"full_name": contact_card.get("full_name"),
-				}
-			)
+    contacts = []
+    for contact_card in data.values():
+        for email in contact_card.get("emails") or []:
+            contacts.append(
+                {
+                    "id": contact_card.get("id"),
+                    "email": email.get("address"),
+                    "full_name": contact_card.get("full_name"),
+                }
+            )
 
-	return contacts
+    return contacts
 
 
 def enrich_contacts_with_user_images(contacts: list[dict]) -> list[dict]:
-	"""Enriches the given contacts with user images."""
+    """Enriches the given contacts with user images."""
 
-	unique_emails = set(contact.get("email") for contact in contacts if contact.get("email"))
+    unique_emails = set(contact.get("email") for contact in contacts if contact.get("email"))
 
-	user_image_map = {}
-	if unique_emails:
-		user_data = frappe.get_all(
-			"User", filters={"name": ["in", list(unique_emails)]}, fields=["name", "user_image"]
-		)
-		user_image_map = {u.name: u.user_image for u in user_data if u.user_image}
+    user_image_map = {}
+    if unique_emails:
+        user_data = frappe.get_all(
+            "User", filters={"name": ["in", list(unique_emails)]}, fields=["name", "user_image"]
+        )
+        user_image_map = {u.name: u.user_image for u in user_data if u.user_image}
 
-	for contact in contacts:
-		email = contact.get("email")
-		contact["user_image"] = user_image_map.get(email) or get_avatar_url(email) if email else None
+    for contact in contacts:
+        email = contact.get("email")
+        contact["user_image"] = user_image_map.get(email) or get_avatar_url(email) if email else None
 
 
 @frappe.whitelist()
 def get_address_book_contact_count(account: str, address_book: str) -> int:
-	"""Returns the total no. of contacts for the given address book."""
+    """Returns the total no. of contacts for the given address book."""
 
-	return fetch_contact_cards(account, {"inAddressBook": address_book}, 0, 1)[1]
+    return fetch_contact_cards(account, {"inAddressBook": address_book}, 0, 1)[1]
 
 
 def create_contacts_if_not_exists(account: str, recipients: list[dict] | str) -> None:
-	"""Creates contacts for the given recipients if they do not exist."""
+    """Creates contacts for the given recipients if they do not exist."""
 
-	if not frappe.db.get_value("JMAP Account", account, "create_contacts_after_email_submit"):
-		return
+    if not frappe.db.get_value("JMAP Account", account, "create_contacts_after_email_submit"):
+        return
 
-	if isinstance(recipients, str):
-		recipients = json.loads(recipients)
+    if isinstance(recipients, str):
+        recipients = json.loads(recipients)
 
-	emails = set([recipient.get("email") for recipient in recipients if recipient.get("email")])
+    emails = set([recipient.get("email") for recipient in recipients if recipient.get("email")])
 
-	new_emails = []
-	for email in emails:
-		if not (fetch_contact_cards(account, {"email": email}, 0, 1)[0]):
-			new_emails.append(email)
+    new_emails = []
+    for email in emails:
+        if not (fetch_contact_cards(account, {"email": email}, 0, 1)[0]):
+            new_emails.append(email)
 
-	contact_cards = []
-	for email in new_emails:
-		contact_card = {
-			"address_book_ids": [get_default_address_book_id(account)],
-			"full_name": extract_name_from_email(email),
-			"kind": "Individual",
-			"emails": [{"address": email, "type": "Personal"}],
-		}
-		contact_cards.append(contact_card)
+    contact_cards = []
+    for email in new_emails:
+        contact_card = {
+            "address_book_ids": [get_default_address_book_id(account)],
+            "full_name": extract_name_from_email(email),
+            "kind": "Individual",
+            "emails": [{"address": email, "type": "Personal"}],
+        }
+        contact_cards.append(contact_card)
 
-	bulk_add_contact_cards(account, contact_cards)
+    bulk_add_contact_cards(account, contact_cards)
 
 
 def extract_name_from_email(email: str) -> str:
-	"""Extracts a name from the given email address."""
+    """Extracts a name from the given email address."""
 
-	return re.sub(r"\b\w", lambda m: m.group().upper(), re.sub(r"[._-]", " ", email.split("@")[0]))
+    return re.sub(r"\b\w", lambda m: m.group().upper(), re.sub(r"[._-]", " ", email.split("@")[0]))

--- a/suite/mail/api/inbound.py
+++ b/suite/mail/api/inbound.py
@@ -17,207 +17,207 @@ from suite.utils.rate_limiter import dynamic_rate_limit
 from suite.utils.dt import convert_to_utc
 
 if TYPE_CHECKING:
-	from suite.mail.doctype.mail_sync_history.mail_sync_history import MailSyncHistory
+    from suite.mail.doctype.mail_sync_history.mail_sync_history import MailSyncHistory
 
 
 @frappe.whitelist(methods=["GET"])
 @dynamic_rate_limit()
 def fetch_blob(blob_id: str, as_bytes: bool = False) -> str | bytes:
-	"""Fetches the blob for the given blob_id."""
+    """Fetches the blob for the given blob_id."""
 
-	ctx = {
-		"req_id": random_string(10),
-		"ip": frappe.request.remote_addr,
-	}
-	logger = get_inbound_logger(ctx)
+    ctx = {
+        "req_id": random_string(10),
+        "ip": frappe.request.remote_addr,
+    }
+    logger = get_inbound_logger(ctx)
 
-	logger.debug("fetch-blob-started", blob_id=blob_id)
+    logger.debug("fetch-blob-started", blob_id=blob_id)
 
-	validate_user()
+    validate_user()
 
-	try:
-		account = get_user_personal_jmap_account(frappe.session.user, raise_exception=True)
+    try:
+        account = get_user_personal_jmap_account(frappe.session.user, raise_exception=True)
 
-		from suite.mail.doctype.mail_message.mail_message import fetch_blob as _fetch_blob
+        from suite.mail.doctype.mail_message.mail_message import fetch_blob as _fetch_blob
 
-		blob = _fetch_blob(account, blob_id)
-		return blob if as_bytes else base64.b64encode(blob).decode("utf-8")
+        blob = _fetch_blob(account, blob_id)
+        return blob if as_bytes else base64.b64encode(blob).decode("utf-8")
 
-	except frappe.exceptions.ValidationError:
-		raise
+    except frappe.exceptions.ValidationError:
+        raise
 
-	except Exception:
-		logger.exception("fetch-blob-failed")
-		frappe.throw(_("Failed to fetch blob. Please check the error logs for details."))
+    except Exception:
+        logger.exception("fetch-blob-failed")
+        frappe.throw(_("Failed to fetch blob. Please check the error logs for details."))
 
 
 @frappe.whitelist(methods=["GET"])
 @dynamic_rate_limit()
 def pull(
-	mailbox: str | None = None, limit: int = 50, last_received_at: str | None = None
+    mailbox: str | None = None, limit: int = 50, last_received_at: str | None = None
 ) -> dict[str, list[dict] | str]:
-	"""Returns the emails for the given mailbox."""
+    """Returns the emails for the given mailbox."""
 
-	ctx = {
-		"req_id": random_string(10),
-		"ip": frappe.request.remote_addr,
-	}
-	logger = get_inbound_logger(ctx)
+    ctx = {
+        "req_id": random_string(10),
+        "ip": frappe.request.remote_addr,
+    }
+    logger = get_inbound_logger(ctx)
 
-	logger.debug("pull-started", mailbox=mailbox, limit=limit, last_received_at=last_received_at)
+    logger.debug("pull-started", mailbox=mailbox, limit=limit, last_received_at=last_received_at)
 
-	validate_user()
-	validate_max_sync_limit(limit)
+    validate_user()
+    validate_max_sync_limit(limit)
 
-	try:
-		result = []
-		source = get_source()
-		mailbox = mailbox or "inbox"
-		last_received_at = convert_to_system_timezone(last_received_at)
-		account = get_user_personal_jmap_account(frappe.session.user, raise_exception=True)
-		sync_history = get_mail_sync_history(account, source)
-		result = get_mails(account, mailbox, limit, last_received_at or sync_history.last_received_at)
-		update_mail_sync_history(sync_history, result["last_received_at"], result["last_received_mail"])
-		result["last_received_at"] = convert_to_utc(result["last_received_at"])
+    try:
+        result = []
+        source = get_source()
+        mailbox = mailbox or "inbox"
+        last_received_at = convert_to_system_timezone(last_received_at)
+        account = get_user_personal_jmap_account(frappe.session.user, raise_exception=True)
+        sync_history = get_mail_sync_history(account, source)
+        result = get_mails(account, mailbox, limit, last_received_at or sync_history.last_received_at)
+        update_mail_sync_history(sync_history, result["last_received_at"], result["last_received_mail"])
+        result["last_received_at"] = convert_to_utc(result["last_received_at"])
 
-		return result
+        return result
 
-	except frappe.exceptions.ValidationError:
-		raise
+    except frappe.exceptions.ValidationError:
+        raise
 
-	except Exception:
-		logger.exception("pull-failed")
-		frappe.throw(_("Failed to fetch emails. Please check the error logs for details."))
+    except Exception:
+        logger.exception("pull-failed")
+        frappe.throw(_("Failed to fetch emails. Please check the error logs for details."))
 
 
 @frappe.whitelist(methods=["GET"])
 @dynamic_rate_limit()
 def pull_raw(
-	mailbox: str | None = None, limit: int = 50, last_received_at: str | None = None
+    mailbox: str | None = None, limit: int = 50, last_received_at: str | None = None
 ) -> dict[str, list[str] | str]:
-	"""Returns the raw emails for the given mailbox."""
+    """Returns the raw emails for the given mailbox."""
 
-	ctx = {
-		"req_id": random_string(10),
-		"ip": frappe.request.remote_addr,
-	}
-	logger = get_inbound_logger(ctx)
+    ctx = {
+        "req_id": random_string(10),
+        "ip": frappe.request.remote_addr,
+    }
+    logger = get_inbound_logger(ctx)
 
-	logger.debug("pull-raw-started", mailbox=mailbox, limit=limit, last_received_at=last_received_at)
+    logger.debug("pull-raw-started", mailbox=mailbox, limit=limit, last_received_at=last_received_at)
 
-	validate_user()
-	validate_max_sync_limit(limit)
+    validate_user()
+    validate_max_sync_limit(limit)
 
-	try:
-		result = []
-		source = get_source()
-		mailbox = mailbox or "inbox"
-		last_received_at = convert_to_system_timezone(last_received_at)
-		account = get_user_personal_jmap_account(frappe.session.user, raise_exception=True)
-		sync_history = get_mail_sync_history(account, source)
-		result = get_raw_mails(account, mailbox, limit, last_received_at or sync_history.last_received_at)
-		update_mail_sync_history(sync_history, result["last_received_at"], result["last_received_mail"])
-		result["last_received_at"] = convert_to_utc(result["last_received_at"])
+    try:
+        result = []
+        source = get_source()
+        mailbox = mailbox or "inbox"
+        last_received_at = convert_to_system_timezone(last_received_at)
+        account = get_user_personal_jmap_account(frappe.session.user, raise_exception=True)
+        sync_history = get_mail_sync_history(account, source)
+        result = get_raw_mails(account, mailbox, limit, last_received_at or sync_history.last_received_at)
+        update_mail_sync_history(sync_history, result["last_received_at"], result["last_received_mail"])
+        result["last_received_at"] = convert_to_utc(result["last_received_at"])
 
-		return result
+        return result
 
-	except frappe.exceptions.ValidationError:
-		raise
+    except frappe.exceptions.ValidationError:
+        raise
 
-	except Exception:
-		logger.exception("pull-raw-failed")
-		frappe.throw(_("Failed to fetch raw emails. Please check the error logs for details."))
+    except Exception:
+        logger.exception("pull-raw-failed")
+        frappe.throw(_("Failed to fetch raw emails. Please check the error logs for details."))
 
 
 def validate_max_sync_limit(limit: int) -> None:
-	"""Validates if the limit is within the maximum limit."""
+    """Validates if the limit is within the maximum limit."""
 
-	max_sync = cint(get_config("max_email_sync"))
+    max_sync = cint(get_config("max_email_sync"))
 
-	if limit > max_sync:
-		frappe.throw(_("Cannot fetch more than {0} emails at a time.").format(max_sync))
+    if limit > max_sync:
+        frappe.throw(_("Cannot fetch more than {0} emails at a time.").format(max_sync))
 
 
 def get_source() -> str:
-	"""Returns the source of the request."""
+    """Returns the source of the request."""
 
-	return frappe.request.headers.get("X-Site") or frappe.local.request_ip
+    return frappe.request.headers.get("X-Site") or frappe.local.request_ip
 
 
 def convert_to_system_timezone(last_received_at: str) -> datetime | None:
-	"""Converts the last_received_at to system timezone."""
+    """Converts the last_received_at to system timezone."""
 
-	if last_received_at:
-		dt = datetime.fromisoformat(last_received_at)
-		dt_utc = dt.astimezone(UTC)
-		return convert_utc_to_system_timezone(dt_utc)
+    if last_received_at:
+        dt = datetime.fromisoformat(last_received_at)
+        dt_utc = dt.astimezone(UTC)
+        return convert_utc_to_system_timezone(dt_utc)
 
 
 def get_mails(
-	account: str, mailbox: str, limit: int, last_received_at: str | datetime | None = None
+    account: str, mailbox: str, limit: int, last_received_at: str | datetime | None = None
 ) -> dict[str, list[dict] | str]:
-	"""Returns the emails for the given mailbox."""
+    """Returns the emails for the given mailbox."""
 
-	mailbox_id = get_mailbox_id_by_role(account, mailbox, raise_exception=True)
+    mailbox_id = get_mailbox_id_by_role(account, mailbox, raise_exception=True)
 
-	filter = {"inMailbox": mailbox_id}
-	if last_received_at:
-		dt = (
-			last_received_at
-			if isinstance(last_received_at, datetime)
-			else datetime.fromisoformat(last_received_at)
-		)
-		dt_utc = dt.astimezone(UTC)
-		filter["after"] = dt_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+    filter = {"inMailbox": mailbox_id}
+    if last_received_at:
+        dt = (
+            last_received_at
+            if isinstance(last_received_at, datetime)
+            else datetime.fromisoformat(last_received_at)
+        )
+        dt_utc = dt.astimezone(UTC)
+        filter["after"] = dt_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-	sort = [{"property": "receivedAt", "isAscending": True}]
-	messages, _total = fetch_messages(account, filter, limit=limit, sort=sort)
-	last_received_at = messages[-1]["received_at"] if messages else now()
-	last_received_mail = messages[-1]["name"] if messages else None
+    sort = [{"property": "receivedAt", "isAscending": True}]
+    messages, _total = fetch_messages(account, filter, limit=limit, sort=sort)
+    last_received_at = messages[-1]["received_at"] if messages else now()
+    last_received_mail = messages[-1]["name"] if messages else None
 
-	for message in messages:
-		for field in ["sent_at", "received_at"]:
-			message[field] = convert_to_utc(message[field])
+    for message in messages:
+        for field in ["sent_at", "received_at"]:
+            message[field] = convert_to_utc(message[field])
 
-		for field in ["creation", "modified"]:
-			message.pop(field, None)
+        for field in ["creation", "modified"]:
+            message.pop(field, None)
 
-	return {
-		"mails": messages,
-		"last_received_at": last_received_at,
-		"last_received_mail": last_received_mail,
-	}
+    return {
+        "mails": messages,
+        "last_received_at": last_received_at,
+        "last_received_mail": last_received_mail,
+    }
 
 
 def get_raw_mails(
-	account: str, mailbox: str, limit: int, last_received_at: str | datetime | None = None
+    account: str, mailbox: str, limit: int, last_received_at: str | datetime | None = None
 ) -> dict[str, list[str] | str]:
-	"""Returns the raw emails for the given mailbox."""
+    """Returns the raw emails for the given mailbox."""
 
-	result = get_mails(account, mailbox, limit, last_received_at)
+    result = get_mails(account, mailbox, limit, last_received_at)
 
-	mails = []
-	for messages in create_batch(result["mails"], 20):
-		for _blob_id, blob in fetch_blobs(account, [message["blob_id"] for message in messages]).items():
-			mails.append(blob.decode("utf-8"))
+    mails = []
+    for messages in create_batch(result["mails"], 20):
+        for _blob_id, blob in fetch_blobs(account, [message["blob_id"] for message in messages]).items():
+            mails.append(blob.decode("utf-8"))
 
-	result["mails"] = mails
-	return result
+    result["mails"] = mails
+    return result
 
 
 def update_mail_sync_history(
-	sync_history: "MailSyncHistory",
-	last_received_at: str,
-	last_received_mail: str | None = None,
+    sync_history: "MailSyncHistory",
+    last_received_at: str,
+    last_received_mail: str | None = None,
 ) -> None:
-	"""Update the last_received_at in the Mail Sync History."""
+    """Update the last_received_at in the Mail Sync History."""
 
-	kwargs = {
-		"last_received_at": last_received_at or now(),
-	}
+    kwargs = {
+        "last_received_at": last_received_at or now(),
+    }
 
-	if last_received_mail:
-		kwargs["last_received_mail"] = last_received_mail
+    if last_received_mail:
+        kwargs["last_received_mail"] = last_received_mail
 
-	frappe.db.set_value(sync_history.doctype, sync_history.name, kwargs)
-	frappe.db.commit()
+    frappe.db.set_value(sync_history.doctype, sync_history.name, kwargs)
+    frappe.db.commit()

--- a/suite/mail/api/inbound.py
+++ b/suite/mail/api/inbound.py
@@ -13,8 +13,8 @@ from suite.mail.doctype.user_account.user_account import get_user_personal_jmap_
 from suite.mail.jmap import get_mailbox_id_by_role
 from suite.mail.utils import get_config
 from suite.mail.utils.logger import get_inbound_logger
-from suite.utils.rate_limiter import dynamic_rate_limit
 from suite.utils.dt import convert_to_utc
+from suite.utils.rate_limiter import dynamic_rate_limit
 
 if TYPE_CHECKING:
     from suite.mail.doctype.mail_sync_history.mail_sync_history import MailSyncHistory
@@ -206,7 +206,7 @@ def get_raw_mails(
 
 
 def update_mail_sync_history(
-    sync_history: "MailSyncHistory",
+    sync_history: MailSyncHistory,
     last_received_at: str,
     last_received_mail: str | None = None,
 ) -> None:

--- a/suite/mail/api/jmap.py
+++ b/suite/mail/api/jmap.py
@@ -6,10 +6,10 @@ from frappe.utils import random_string
 
 from suite.mail.doctype.mail_message.mail_message import enqueue_fetch_changes
 from suite.mail.doctype.push_subscription.push_subscription import (
-	decrypt_jmap_push_payload,
-	get_push_subscription_keys,
-	is_jmap_push_notifications_frozen,
-	verify_push_subscription,
+    decrypt_jmap_push_payload,
+    get_push_subscription_keys,
+    is_jmap_push_notifications_frozen,
+    verify_push_subscription,
 )
 from suite.mail.jmap import invalidate_jmap_identities_cache, invalidate_jmap_mailboxes_cache
 from suite.mail.utils.logger import get_push_logger
@@ -17,98 +17,98 @@ from suite.mail.utils.logger import get_push_logger
 
 @frappe.whitelist(methods=["POST"], allow_guest=True)
 def push_notification() -> dict:
-	"""Handle JMAP Push Notification."""
+    """Handle JMAP Push Notification."""
 
-	ctx = {
-		"req_id": random_string(10),
-		"ip": frappe.request.remote_addr,
-	}
-	logger = get_push_logger(ctx)
+    ctx = {
+        "req_id": random_string(10),
+        "ip": frappe.request.remote_addr,
+    }
+    logger = get_push_logger(ctx)
 
-	try:
-		logger.debug("push-received")
+    try:
+        logger.debug("push-received")
 
-		user = frappe.request.args.get("user")
-		if not user:
-			logger.warning("missing-user")
-			return {"status": "error", "message": _("Missing user query parameter.")}
+        user = frappe.request.args.get("user")
+        if not user:
+            logger.warning("missing-user")
+            return {"status": "error", "message": _("Missing user query parameter.")}
 
-		user = unquote(user)
-		ctx["user"] = user
+        user = unquote(user)
+        ctx["user"] = user
 
-		if is_jmap_push_notifications_frozen(user):
-			logger.warning("push-frozen")
-			return {
-				"status": "frozen",
-				"message": _("Push notifications are currently frozen for this user."),
-			}
+        if is_jmap_push_notifications_frozen(user):
+            logger.warning("push-frozen")
+            return {
+                "status": "frozen",
+                "message": _("Push notifications are currently frozen for this user."),
+            }
 
-		keys = get_push_subscription_keys()
-		content_encoding = frappe.request.headers.get("Content-Encoding", "")
+        keys = get_push_subscription_keys()
+        content_encoding = frappe.request.headers.get("Content-Encoding", "")
 
-		if keys:
-			logger.debug("encrypted-payload-expected")
+        if keys:
+            logger.debug("encrypted-payload-expected")
 
-			if content_encoding != "aes128gcm":
-				logger.warning("invalid-content-encoding", encoding=content_encoding)
-				return {
-					"status": "error",
-					"message": _("Invalid Content-Encoding. Expected 'aes128gcm'."),
-				}
+            if content_encoding != "aes128gcm":
+                logger.warning("invalid-content-encoding", encoding=content_encoding)
+                return {
+                    "status": "error",
+                    "message": _("Invalid Content-Encoding. Expected 'aes128gcm'."),
+                }
 
-			logger.debug("decrypting-payload")
-			request_data = decrypt_jmap_push_payload(frappe.request.get_data())
-		else:
-			logger.debug("using-plain-json-payload")
-			request_data = frappe.request.get_json()
+            logger.debug("decrypting-payload")
+            request_data = decrypt_jmap_push_payload(frappe.request.get_data())
+        else:
+            logger.debug("using-plain-json-payload")
+            request_data = frappe.request.get_json()
 
-		event_type = request_data.get("@type")
-		ctx["type"] = event_type
-		logger.debug("push-type-received")
+        event_type = request_data.get("@type")
+        ctx["type"] = event_type
+        logger.debug("push-type-received")
 
-		if event_type == "PushVerification":
-			logger.info("verifying-subscription")
+        if event_type == "PushVerification":
+            logger.info("verifying-subscription")
 
-			verify_push_subscription(
-				user,
-				request_data["pushSubscriptionId"],
-				request_data["verificationCode"],
-			)
+            verify_push_subscription(
+                user,
+                request_data["pushSubscriptionId"],
+                request_data["verificationCode"],
+            )
 
-			logger.info("subscription-verified")
-			return {"status": "verified"}
+            logger.info("subscription-verified")
+            return {"status": "verified"}
 
-		elif event_type == "StateChange":
-			logger.debug("state-change-received")
+        elif event_type == "StateChange":
+            logger.debug("state-change-received")
 
-			for account, changes in request_data.get("changed", {}).items():
-				ctx["account"] = account
+            for account, changes in request_data.get("changed", {}).items():
+                ctx["account"] = account
 
-				for entity, state in changes.items():
-					if entity == "Email":
-						logger.debug("queueing-email-sync", entity=entity, state=state)
-						enqueue_fetch_changes(user, account, state, ctx=ctx)
+                for entity, state in changes.items():
+                    if entity == "Email":
+                        logger.debug("queueing-email-sync", entity=entity, state=state)
+                        enqueue_fetch_changes(user, account, state, ctx=ctx)
 
-					elif entity == "Mailbox":
-						logger.debug("invalidating-mailbox-cache", entity=entity, state=state)
-						invalidate_jmap_mailboxes_cache(account)
+                    elif entity == "Mailbox":
+                        logger.debug("invalidating-mailbox-cache", entity=entity, state=state)
+                        invalidate_jmap_mailboxes_cache(account)
 
-					elif entity == "Identity":
-						logger.debug("invalidating-identity-cache", entity=entity, state=state)
-						invalidate_jmap_identities_cache(account)
+                    elif entity == "Identity":
+                        logger.debug("invalidating-identity-cache", entity=entity, state=state)
+                        invalidate_jmap_identities_cache(account)
 
-					else:
-						logger.warning("unhandled-state-change-entity", entity=entity)
+                    else:
+                        logger.warning("unhandled-state-change-entity", entity=entity)
 
-			return {"status": "processed"}
+            return {"status": "processed"}
 
-		else:
-			logger.warning("unknown-push-type")
-			return {
-				"status": "error",
-				"message": _("Invalid Push Notification @type = {0}").format(event_type),
-			}
+        else:
+            logger.warning("unknown-push-type")
+            return {
+                "status": "error",
+                "message": _("Invalid Push Notification @type = {0}").format(event_type),
+            }
 
-	except Exception:
-		logger.exception("failed-to-process", traceback=frappe.get_traceback())
-		return {"status": "error", "message": _("Failed to handle JMAP Push Notification.")}
+    except Exception:
+        logger.exception("failed-to-process", traceback=frappe.get_traceback())
+        return {"status": "error", "message": _("Failed to handle JMAP Push Notification.")}

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -14,48 +14,48 @@ from frappe.utils import cint, format_datetime, random_string
 from suite.mail.api.contacts import create_contacts_if_not_exists
 from suite.mail.api.utils import get_avatar_url
 from suite.mail.doctype.mail_message.mail_message import (
-	add_messages_to_mailbox,
-	delete_messages,
-	empty_mailbox,
-	fetch_blob,
-	fetch_blobs,
-	fetch_thread,
-	fetch_threads,
-	get_messages,
-	move_messages_to_mailbox,
-	remove_messages_from_mailbox,
-	search_messages,
-	set_flagged_status,
-	set_messages_mailboxes,
-	set_seen_status,
-	set_spam_status,
+    add_messages_to_mailbox,
+    delete_messages,
+    empty_mailbox,
+    fetch_blob,
+    fetch_blobs,
+    fetch_thread,
+    fetch_threads,
+    get_messages,
+    move_messages_to_mailbox,
+    remove_messages_from_mailbox,
+    search_messages,
+    set_flagged_status,
+    set_messages_mailboxes,
+    set_seen_status,
+    set_spam_status,
 )
 from suite.mail.doctype.mail_queue.mail_queue import MailQueue
 from suite.mail.doctype.mailbox.mailbox import add_mailbox, delete_mailboxes
 from suite.mail.doctype.mailbox_settings.mailbox_settings import (
-	automation_rules_to_settings,
-	set_mailbox_settings,
+    automation_rules_to_settings,
+    set_mailbox_settings,
 )
 from suite.mail.doctype.screened_email_address.screened_email_address import (
-	get_global_accepted_values,
-	get_global_screened_email_addresses,
-	get_screened_email_addresses,
-	is_globally_accepted,
+    get_global_accepted_values,
+    get_global_screened_email_addresses,
+    get_screened_email_addresses,
+    is_globally_accepted,
 )
 from suite.mail.doctype.sieve_script.sieve_script import (
-	SCREENER_MAILBOX_NAME,
-	build_automation_sieve,
-	pause_automation_sieve_build,
+    SCREENER_MAILBOX_NAME,
+    build_automation_sieve,
+    pause_automation_sieve_build,
 )
 from suite.mail.doctype.user_account.user_account import (
-	get_user_for_jmap_account,
-	is_jmap_account_belongs_to_user,
+    get_user_for_jmap_account,
+    is_jmap_account_belongs_to_user,
 )
 from suite.mail.jmap import (
-	get_email_service,
-	get_mailbox_id_by_name,
-	get_mailbox_id_by_role,
-	get_mailbox_service,
+    get_email_service,
+    get_mailbox_id_by_name,
+    get_mailbox_id_by_role,
+    get_mailbox_service,
 )
 from suite.mail.store import get_email_address_index
 from suite.mail.utils import get_config, log_mail_error
@@ -75,1441 +75,1439 @@ ALL_INBOX_MAX_FETCH = 500
 
 @frappe.whitelist()
 def get_mailboxes(account: str) -> list[dict]:
-	"""Serializes and returns the user's mailboxes."""
+    """Serializes and returns the user's mailboxes."""
 
-	user = frappe.session.user
-	if not is_jmap_configured(user):
-		return []
+    user = frappe.session.user
+    if not is_jmap_configured(user):
+        return []
 
-	mailboxes = get_user_mailboxes(account)
-	if not mailboxes:
-		return []
+    mailboxes = get_user_mailboxes(account)
+    if not mailboxes:
+        return []
 
-	fields = ["name", "id", "_name", "role", "total_threads", "unread_threads", "subscribed"]
+    fields = ["name", "id", "_name", "role", "total_threads", "unread_threads", "subscribed"]
 
-	mailbox_settings = frappe.db.get_all(
-		"Mailbox Settings",
-		filters={
-			"account": account,
-			"mailbox_id": ["in", [m["id"] for m in mailboxes]],
-		},
-		fields=[
-			"mailbox_id",
-			"icon",
-			"color",
-			"disable_push_notification",
-			"emails_from",
-			"subject_contains",
-			"match_if",
-			"mark_as_read",
-			"add_star",
-		],
-	)
+    mailbox_settings = frappe.db.get_all(
+        "Mailbox Settings",
+        filters={
+            "account": account,
+            "mailbox_id": ["in", [m["id"] for m in mailboxes]],
+        },
+        fields=[
+            "mailbox_id",
+            "icon",
+            "color",
+            "disable_push_notification",
+            "emails_from",
+            "subject_contains",
+            "match_if",
+            "mark_as_read",
+            "add_star",
+        ],
+    )
 
-	settings_map = {
-		s.mailbox_id: {
-			"icon": s.icon,
-			"color": s.color,
-			"disable_push_notification": s.disable_push_notification,
-			# The automation rules backup, surfaced so the UI reads it instead of parsing the sieve.
-			# None when the mailbox has no automation, so the UI shows defaults.
-			"automation_rules": (
-				{
-					"emails_from": s.emails_from or "",
-					"subject_contains": s.subject_contains or "",
-					"match_if": s.match_if or "any",
-					"mark_as_read": bool(s.mark_as_read),
-					"add_star": bool(s.add_star),
-				}
-				if (s.emails_from or s.subject_contains)
-				else None
-			),
-		}
-		for s in mailbox_settings
-	}
+    settings_map = {
+        s.mailbox_id: {
+            "icon": s.icon,
+            "color": s.color,
+            "disable_push_notification": s.disable_push_notification,
+            # The automation rules backup, surfaced so the UI reads it instead of parsing the sieve.
+            # None when the mailbox has no automation, so the UI shows defaults.
+            "automation_rules": (
+                {
+                    "emails_from": s.emails_from or "",
+                    "subject_contains": s.subject_contains or "",
+                    "match_if": s.match_if or "any",
+                    "mark_as_read": bool(s.mark_as_read),
+                    "add_star": bool(s.add_star),
+                }
+                if (s.emails_from or s.subject_contains)
+                else None
+            ),
+        }
+        for s in mailbox_settings
+    }
 
-	result = []
-	for mailbox in mailboxes:
-		mailbox_data = {field: mailbox[field] for field in fields}
-		mailbox_data.update(settings_map.get(mailbox["id"], {}))
-		result.append(mailbox_data)
+    result = []
+    for mailbox in mailboxes:
+        mailbox_data = {field: mailbox[field] for field in fields}
+        mailbox_data.update(settings_map.get(mailbox["id"], {}))
+        result.append(mailbox_data)
 
-	return result
+    return result
 
 
 def get_user_mailboxes(account: str) -> list[dict]:
-	"""Returns the user's mailboxes."""
+    """Returns the user's mailboxes."""
 
-	return frappe.get_all("Mailbox", filters={"account": account})
+    return frappe.get_all("Mailbox", filters={"account": account})
 
 
 def add_user_images_to_emails(account: str, mails: list[dict], is_thread: bool = False) -> list[dict]:
-	"""Append avatar URLs to the given list of emails."""
+    """Append avatar URLs to the given list of emails."""
 
-	if not mails:
-		return mails
+    if not mails:
+        return mails
 
-	email_map: dict[str, str] = {}
-	rcpt_order = {"To": 0, "Cc": 1, "Bcc": 2}
-	user_emails = {e.lower() for e in get_account_emails(account)}
+    email_map: dict[str, str] = {}
+    rcpt_order = {"To": 0, "Cc": 1, "Bcc": 2}
+    user_emails = {e.lower() for e in get_account_emails(account)}
 
-	for mail in mails:
-		name = mail["name"]
-		if not name:
-			continue
+    for mail in mails:
+        name = mail["name"]
+        if not name:
+            continue
 
-		from_email = (mail.get("from_email") or "").lower()
+        from_email = (mail.get("from_email") or "").lower()
 
-		if not from_email:
-			continue
+        if not from_email:
+            continue
 
-		selected_email = from_email
+        selected_email = from_email
 
-		if not is_thread and from_email in user_emails:
-			recipients = sorted(mail["recipients"], key=lambda r: rcpt_order[r["type"] or 99])
+        if not is_thread and from_email in user_emails:
+            recipients = sorted(mail["recipients"], key=lambda r: rcpt_order[r["type"] or 99])
 
-			for rcpt in recipients:
-				rcpt_email = (rcpt.get("email") or "").lower()
-				if rcpt_email and rcpt_email not in user_emails:
-					selected_email = rcpt_email
-					break
+            for rcpt in recipients:
+                rcpt_email = (rcpt.get("email") or "").lower()
+                if rcpt_email and rcpt_email not in user_emails:
+                    selected_email = rcpt_email
+                    break
 
-		email_map[name] = selected_email
+        email_map[name] = selected_email
 
-	unique_emails = {e for e in email_map.values() if e}
+    unique_emails = {e for e in email_map.values() if e}
 
-	user_image_map = {}
-	if unique_emails:
-		user_data = frappe.db.get_all(
-			"User",
-			filters={"name": ["in", list(unique_emails)]},
-			fields=["name", "user_image"],
-		)
-		user_image_map = {u.name: u.user_image for u in user_data if u.user_image}
+    user_image_map = {}
+    if unique_emails:
+        user_data = frappe.db.get_all(
+            "User",
+            filters={"name": ["in", list(unique_emails)]},
+            fields=["name", "user_image"],
+        )
+        user_image_map = {u.name: u.user_image for u in user_data if u.user_image}
 
-	images = {email: user_image_map.get(email) or get_avatar_url(email) for email in unique_emails}
+    images = {email: user_image_map.get(email) or get_avatar_url(email) for email in unique_emails}
 
-	for mail in mails:
-		email = email_map.get(mail["name"])
-		mail["user_image"] = images.get(email) if email else None
+    for mail in mails:
+        email = email_map.get(mail["name"])
+        mail["user_image"] = images.get(email) if email else None
 
-	return mails
+    return mails
 
 
 @frappe.whitelist()
 def get_threads(account: str, mailbox: str, limit: int, start: int = 0, filter_by: str | None = None) -> list:
-	"""Returns a page of threads from the selected mailbox for the account."""
+    """Returns a page of threads from the selected mailbox for the account."""
 
-	if mailbox == "starred":
-		conditions = [
-			{
-				"inMailboxOtherThan": [
-					get_mailbox_id_by_role(account, "junk", create_if_not_exists=True, raise_exception=True),
-					get_mailbox_id_by_role(account, "trash", create_if_not_exists=True, raise_exception=True),
-				]
-			},
-			{"someInThreadHaveKeyword": "$flagged"},
-		]
-	else:
-		conditions = [{"inMailbox": mailbox}]
+    if mailbox == "starred":
+        conditions = [
+            {
+                "inMailboxOtherThan": [
+                    get_mailbox_id_by_role(account, "junk", create_if_not_exists=True, raise_exception=True),
+                    get_mailbox_id_by_role(account, "trash", create_if_not_exists=True, raise_exception=True),
+                ]
+            },
+            {"someInThreadHaveKeyword": "$flagged"},
+        ]
+    else:
+        conditions = [{"inMailbox": mailbox}]
 
-	filter_map = {
-		"starred": {"someInThreadHaveKeyword": "$flagged"},
-		"unread": {"notKeyword": "$seen"},
-		"has_attachments": {"hasAttachment": True},
-	}
-	if filter_by in filter_map and not (mailbox == "starred" and filter_by == "starred"):
-		conditions.append(filter_map[filter_by])
+    filter_map = {
+        "starred": {"someInThreadHaveKeyword": "$flagged"},
+        "unread": {"notKeyword": "$seen"},
+        "has_attachments": {"hasAttachment": True},
+    }
+    if filter_by in filter_map and not (mailbox == "starred" and filter_by == "starred"):
+        conditions.append(filter_map[filter_by])
 
-	if len(conditions) == 1:
-		filter = conditions[0]
-	else:
-		filter = {"operator": "AND", "conditions": conditions}
+    if len(conditions) == 1:
+        filter = conditions[0]
+    else:
+        filter = {"operator": "AND", "conditions": conditions}
 
-	conversations = fetch_threads(account, filter, start, limit)
+    conversations = fetch_threads(account, filter, start, limit)
 
-	# Four roles are needed below, so they come off one cached mailbox list rather than a lookup each:
-	# every `get_mailbox_id_by_role` resolves the account's user and connection again on the way in.
-	ids_by_role = {
-		(m.get("role") or "").lower(): m["id"] for m in get_mailbox_service(account).mailboxes
-	}
-	trash_mailbox = ids_by_role.get("trash")
-	junk_mailbox = ids_by_role.get("junk")
-	# Sent and Drafts are about the message you wrote, so their rows follow the latest message in the
-	# folder itself; every other view follows the conversation's most recent activity.
-	outgoing_mailboxes = {ids_by_role[role] for role in ("sent", "drafts") if role in ids_by_role}
+    # Four roles are needed below, so they come off one cached mailbox list rather than a lookup each:
+    # every `get_mailbox_id_by_role` resolves the account's user and connection again on the way in.
+    ids_by_role = {(m.get("role") or "").lower(): m["id"] for m in get_mailbox_service(account).mailboxes}
+    trash_mailbox = ids_by_role.get("trash")
+    junk_mailbox = ids_by_role.get("junk")
+    # Sent and Drafts are about the message you wrote, so their rows follow the latest message in the
+    # folder itself; every other view follows the conversation's most recent activity.
+    outgoing_mailboxes = {ids_by_role[role] for role in ("sent", "drafts") if role in ids_by_role}
 
-	threads = []
-	for conversation in conversations.values():
-		if not conversation:
-			continue
+    threads = []
+    for conversation in conversations.values():
+        if not conversation:
+            continue
 
-		visible = visible_in_mailbox(conversation, mailbox, trash_mailbox, junk_mailbox)
+        visible = visible_in_mailbox(conversation, mailbox, trash_mailbox, junk_mailbox)
 
-		# The summary row is derived from the thread's messages in the current mailbox (falling back
-		# to the whole conversation for cross-mailbox views like "starred").
-		in_mailbox = [
-			m for m in visible if any(mb["mailbox_id"] == mailbox for mb in m["mailboxes"])
-		] or visible
+        # The summary row is derived from the thread's messages in the current mailbox (falling back
+        # to the whole conversation for cross-mailbox views like "starred").
+        in_mailbox = [
+            m for m in visible if any(mb["mailbox_id"] == mailbox for mb in m["mailboxes"])
+        ] or visible
 
-		# The preview/date reflect the latest message in the conversation (the most recent activity)
-		# everywhere except Sent and Drafts, which show the latest message in the folder itself: a
-		# draft reply must keep its own recipients and its "Draft" badge when the thread it answers
-		# receives a newer mail.
-		latest = in_mailbox[-1] if mailbox in outgoing_mailboxes else visible[-1]
-		threads.append(serialize_thread(in_mailbox, visible, latest, first=conversation[0]))
+        # The preview/date reflect the latest message in the conversation (the most recent activity)
+        # everywhere except Sent and Drafts, which show the latest message in the folder itself: a
+        # draft reply must keep its own recipients and its "Draft" badge when the thread it answers
+        # receives a newer mail.
+        latest = in_mailbox[-1] if mailbox in outgoing_mailboxes else visible[-1]
+        threads.append(serialize_thread(in_mailbox, visible, latest, first=conversation[0]))
 
-	# Avatars for the list-view summary rows, and for each message in the nested threads.
-	add_user_images_to_emails(account, threads, is_thread=False)
-	add_user_images_to_emails(account, [m for thread in threads for m in thread["messages"]], is_thread=True)
+    # Avatars for the list-view summary rows, and for each message in the nested threads.
+    add_user_images_to_emails(account, threads, is_thread=False)
+    add_user_images_to_emails(account, [m for thread in threads for m in thread["messages"]], is_thread=True)
 
-	return threads, mailbox
+    return threads, mailbox
 
 
 def visible_in_mailbox(messages: list[dict], mailbox: str, trash: str | None, junk: str | None) -> list[dict]:
-	"""The thread's messages a mailbox view is allowed to show, oldest to newest.
+    """The thread's messages a mailbox view is allowed to show, oldest to newest.
 
-	Mirrors the thread pane's `filterRelevantMails`: junked and trashed messages appear only in their
-	own folders. The summary row is derived from this rather than from the whole conversation so that
-	it describes the thread the way opening it would — a spam reply was adding a stranger to a row's
-	participants, raising its message count, and lending it its preview and date, all for a message
-	the pane then refused to render.
+    Mirrors the thread pane's `filterRelevantMails`: junked and trashed messages appear only in their
+    own folders. The summary row is derived from this rather than from the whole conversation so that
+    it describes the thread the way opening it would — a spam reply was adding a stranger to a row's
+    participants, raising its message count, and lending it its preview and date, all for a message
+    the pane then refused to render.
 
-	Falls back to the whole conversation rather than to nothing, so a thread is never a blank row.
-	"""
+    Falls back to the whole conversation rather than to nothing, so a thread is never a blank row.
+    """
 
-	def is_trashed(message: dict) -> bool:
-		return any(mb["mailbox_id"] == trash for mb in message["mailboxes"])
+    def is_trashed(message: dict) -> bool:
+        return any(mb["mailbox_id"] == trash for mb in message["mailboxes"])
 
-	if trash and mailbox == trash:
-		return [m for m in messages if is_trashed(m)] or messages
+    if trash and mailbox == trash:
+        return [m for m in messages if is_trashed(m)] or messages
 
-	if junk and mailbox == junk:
-		return [m for m in messages if m.get("junk")] or messages
+    if junk and mailbox == junk:
+        return [m for m in messages if m.get("junk")] or messages
 
-	return [m for m in messages if not is_trashed(m) and not m.get("junk")] or messages
+    return [m for m in messages if not is_trashed(m) and not m.get("junk")] or messages
 
 
 def get_user_jmap_accounts() -> list[dict]:
-	"""Return the current user's JMAP accounts (id + display name), personal first.
+    """Return the current user's JMAP accounts (id + display name), personal first.
 
-	Ordered personal-first, then by name, so the merged All Inboxes list has a stable tie-break when
-	two accounts have threads at the same timestamp.
-	"""
+    Ordered personal-first, then by name, so the merged All Inboxes list has a stable tie-break when
+    two accounts have threads at the same timestamp.
+    """
 
-	account_names = frappe.db.get_all("User Account", {"user": frappe.session.user}, pluck="account")
-	if not account_names:
-		return []
+    account_names = frappe.db.get_all("User Account", {"user": frappe.session.user}, pluck="account")
+    if not account_names:
+        return []
 
-	accounts = frappe.db.get_all(
-		"JMAP Account",
-		filters={"name": ["in", account_names]},
-		fields=["name", "_name", "is_personal"],
-	)
-	accounts.sort(key=lambda a: (not a["is_personal"], a["_name"] or ""))
-	return accounts
+    accounts = frappe.db.get_all(
+        "JMAP Account",
+        filters={"name": ["in", account_names]},
+        fields=["name", "_name", "is_personal"],
+    )
+    accounts.sort(key=lambda a: (not a["is_personal"], a["_name"] or ""))
+    return accounts
 
 
 @frappe.whitelist()
 def get_all_inbox_threads(limit: int, start: int = 0, filter_by: str | None = None) -> list:
-	"""Returns a merged, newest-first page of Inbox threads across all of the user's accounts.
+    """Returns a merged, newest-first page of Inbox threads across all of the user's accounts.
 
-	Each thread is tagged with its owning account (`account`, `account_name`) and that account's
-	Inbox/Archive/Trash mailbox ids, so the client can open it in — and act on it within — the correct
-	JMAP account. Every account is over-fetched to `start + limit` (the deepest global position this
-	page can reach), the results are merged, sorted newest-first, then sliced to the requested window.
-	"""
+    Each thread is tagged with its owning account (`account`, `account_name`) and that account's
+    Inbox/Archive/Trash mailbox ids, so the client can open it in — and act on it within — the correct
+    JMAP account. Every account is over-fetched to `start + limit` (the deepest global position this
+    page can reach), the results are merged, sorted newest-first, then sliced to the requested window.
+    """
 
-	accounts = get_user_jmap_accounts()
-	if not accounts:
-		return []
+    accounts = get_user_jmap_accounts()
+    if not accounts:
+        return []
 
-	# Clamp user input before it fans out across accounts: limit to a sane page size, and start so the
-	# per-account fetch (start + limit) can never exceed ALL_INBOX_MAX_FETCH — bounding both the JMAP
-	# fetch per account and the in-memory merge, regardless of what the client sends.
-	limit = min(max(cint(limit), 1), ALL_INBOX_MAX_LIMIT)
-	start = min(max(cint(start), 0), ALL_INBOX_MAX_FETCH - limit)
-	per_account_limit = start + limit
+    # Clamp user input before it fans out across accounts: limit to a sane page size, and start so the
+    # per-account fetch (start + limit) can never exceed ALL_INBOX_MAX_FETCH — bounding both the JMAP
+    # fetch per account and the in-memory merge, regardless of what the client sends.
+    limit = min(max(cint(limit), 1), ALL_INBOX_MAX_LIMIT)
+    start = min(max(cint(start), 0), ALL_INBOX_MAX_FETCH - limit)
+    per_account_limit = start + limit
 
-	merged: list[dict] = []
-	for account in accounts:
-		account_id = account["name"]
-		inbox_id = get_mailbox_id_by_role(account_id, "inbox")
-		if not inbox_id:
-			continue
+    merged: list[dict] = []
+    for account in accounts:
+        account_id = account["name"]
+        inbox_id = get_mailbox_id_by_role(account_id, "inbox")
+        if not inbox_id:
+            continue
 
-		threads, _mailbox = get_threads(account_id, inbox_id, per_account_limit, 0, filter_by)
-		if not threads:
-			continue
+        threads, _mailbox = get_threads(account_id, inbox_id, per_account_limit, 0, filter_by)
+        if not threads:
+            continue
 
-		# Attach once per account (role lookups are cached) so per-item actions can target the right
-		# mailbox without another round trip.
-		archive_id = get_mailbox_id_by_role(account_id, "archive")
-		trash_id = get_mailbox_id_by_role(account_id, "trash")
-		for thread in threads:
-			thread["account"] = account_id
-			thread["account_name"] = account["_name"]
-			thread["inbox"] = inbox_id
-			thread["archive"] = archive_id
-			thread["trash"] = trash_id
-		merged.extend(threads)
+        # Attach once per account (role lookups are cached) so per-item actions can target the right
+        # mailbox without another round trip.
+        archive_id = get_mailbox_id_by_role(account_id, "archive")
+        trash_id = get_mailbox_id_by_role(account_id, "trash")
+        for thread in threads:
+            thread["account"] = account_id
+            thread["account_name"] = account["_name"]
+            thread["inbox"] = inbox_id
+            thread["archive"] = archive_id
+            thread["trash"] = trash_id
+        merged.extend(threads)
 
-	merged.sort(key=lambda thread: thread["received_at"], reverse=True)
-	return merged[start : start + limit]
+    merged.sort(key=lambda thread: thread["received_at"], reverse=True)
+    return merged[start : start + limit]
 
 
 @frappe.whitelist()
 def get_all_inbox_unread_count() -> int:
-	"""Returns the total unread Inbox thread count across all of the user's accounts (sidebar badge).
+    """Returns the total unread Inbox thread count across all of the user's accounts (sidebar badge).
 
-	Mailbox is a JMAP-backed virtual DocType, so it can't be queried across accounts with a table
-	filter. Each account's Inbox unread count is fetched live via the mailbox service (a fresh
-	Mailbox/get, bypassing the 1-hour `.mailboxes` cache) — the same source the per-account inbox
-	badge uses — and summed.
-	"""
+    Mailbox is a JMAP-backed virtual DocType, so it can't be queried across accounts with a table
+    filter. Each account's Inbox unread count is fetched live via the mailbox service (a fresh
+    Mailbox/get, bypassing the 1-hour `.mailboxes` cache) — the same source the per-account inbox
+    badge uses — and summed.
+    """
 
-	total = 0
-	for account in get_user_jmap_accounts():
-		for mailbox in get_mailbox_service(account["name"]).get():
-			if (mailbox.get("role") or "").lower() == "inbox":
-				total += cint(mailbox.get("unreadThreads"))
-				break
+    total = 0
+    for account in get_user_jmap_accounts():
+        for mailbox in get_mailbox_service(account["name"]).get():
+            if (mailbox.get("role") or "").lower() == "inbox":
+                total += cint(mailbox.get("unreadThreads"))
+                break
 
-	return total
+    return total
 
 
 @frappe.whitelist()
 def get_thread(account: str, thread_id: str) -> list[dict]:
-	"""Returns the full list of messages in a thread, for threads not present in the mailbox list
-	(e.g. search results or a thread on another page)."""
+    """Returns the full list of messages in a thread, for threads not present in the mailbox list
+    (e.g. search results or a thread on another page)."""
 
-	mails = [serialize_mail(m) for m in fetch_thread(account, thread_id)]
-	return add_user_images_to_emails(account, mails, is_thread=True)
+    mails = [serialize_mail(m) for m in fetch_thread(account, thread_id)]
+    return add_user_images_to_emails(account, mails, is_thread=True)
 
 
 @frappe.whitelist()
 def get_attachment(account: str, blob_id: str, filename: str | None = None) -> None:
-	"""Fetches and returns the attachment."""
+    """Fetches and returns the attachment."""
 
-	if not blob_id:
-		frappe.throw(_("Blob ID is required."))
+    if not blob_id:
+        frappe.throw(_("Blob ID is required."))
 
-	content = fetch_blob(account, blob_id, filename)
+    content = fetch_blob(account, blob_id, filename)
 
-	frappe.local.response.filename = filename or blob_id
-	frappe.local.response.filecontent = content
-	frappe.local.response.type = "download"
+    frappe.local.response.filename = filename or blob_id
+    frappe.local.response.filecontent = content
+    frappe.local.response.type = "download"
 
 
 def serialize_thread(
-	messages: list[dict],
-	thread_messages: list[dict],
-	latest: dict | None = None,
-	first: dict | None = None,
+    messages: list[dict],
+    thread_messages: list[dict],
+    latest: dict | None = None,
+    first: dict | None = None,
 ) -> dict:
-	"""Serializes a thread for response.
+    """Serializes a thread for response.
 
-	Both `messages` (the thread's messages within the current mailbox) and `thread_messages` (the
-	conversation this view can show — see `visible_in_mailbox`) are expected ordered oldest to newest.
-	The list-view summary fields are derived from `latest` (defaulting to the latest of `messages`),
-	except `subject` which comes from `first`, the conversation's opening message (the thread's
-	original subject, without the "Re:" its replies carry — it defaults to the earliest message given,
-	which is only the true first when nothing has been filtered out). The conversation is serialized
-	under `messages` so the whole thread can be rendered without a separate fetch. The row's cast is
-	read off that same list in the frontend (see utils/participants), which is why nothing here names
-	the thread's senders.
-	"""
+    Both `messages` (the thread's messages within the current mailbox) and `thread_messages` (the
+    conversation this view can show — see `visible_in_mailbox`) are expected ordered oldest to newest.
+    The list-view summary fields are derived from `latest` (defaulting to the latest of `messages`),
+    except `subject` which comes from `first`, the conversation's opening message (the thread's
+    original subject, without the "Re:" its replies carry — it defaults to the earliest message given,
+    which is only the true first when nothing has been filtered out). The conversation is serialized
+    under `messages` so the whole thread can be rendered without a separate fetch. The row's cast is
+    read off that same list in the frontend (see utils/participants), which is why nothing here names
+    the thread's senders.
+    """
 
-	first = first or thread_messages[0]
-	latest = latest or messages[-1]
-	# The row's identity + state come from the thread's representative message in the CURRENT mailbox
-	# (`messages` is scoped to it), so its folder tags and junk/flag/seen reflect THIS view — not a
-	# sibling message that was moved to Junk/Trash/Sent. The activity fields (preview/date/sender) still
-	# come from `latest` (most recent activity across the whole conversation). For single-mailbox threads
-	# `current` and `latest` are the same message, so nothing changes.
-	current = messages[-1]
+    first = first or thread_messages[0]
+    latest = latest or messages[-1]
+    # The row's identity + state come from the thread's representative message in the CURRENT mailbox
+    # (`messages` is scoped to it), so its folder tags and junk/flag/seen reflect THIS view — not a
+    # sibling message that was moved to Junk/Trash/Sent. The activity fields (preview/date/sender) still
+    # come from `latest` (most recent activity across the whole conversation). For single-mailbox threads
+    # `current` and `latest` are the same message, so nothing changes.
+    current = messages[-1]
 
-	# From the current-mailbox message: identity + state (so star/junk actions target the right mail).
-	current_fields = ["name", "id", "mailboxes", "seen", "junk", "flagged"]
-	# From the most recent activity: what the row displays.
-	activity_fields = [
-		"thread_id",
-		"from_name",
-		"from_email",
-		"received_at",
-		"recipients",
-		"draft",
-		"preview",
-	]
-	return {
-		**{field: current[field] for field in current_fields},
-		**{field: latest[field] for field in activity_fields},
-		"subject": first["subject"],
-		"attachments": serialize_attachments(latest.get("attachments", [])),
-		"messages": [serialize_mail(message) for message in thread_messages],
-	}
+    # From the current-mailbox message: identity + state (so star/junk actions target the right mail).
+    current_fields = ["name", "id", "mailboxes", "seen", "junk", "flagged"]
+    # From the most recent activity: what the row displays.
+    activity_fields = [
+        "thread_id",
+        "from_name",
+        "from_email",
+        "received_at",
+        "recipients",
+        "draft",
+        "preview",
+    ]
+    return {
+        **{field: current[field] for field in current_fields},
+        **{field: latest[field] for field in activity_fields},
+        "subject": first["subject"],
+        "attachments": serialize_attachments(latest.get("attachments", [])),
+        "messages": [serialize_mail(message) for message in thread_messages],
+    }
 
 
 def serialize_mail(mail: dict) -> dict:
-	"""Serializes mail for response."""
+    """Serializes mail for response."""
 
-	mail_fields = [
-		"name",
-		"message_id",
-		"id",
-		"thread_id",
-		"from_name",
-		"from_email",
-		"subject",
-		"html_body",
-		"preview",
-		"received_at",
-		"draft",
-		"seen",
-		"junk",
-		"flagged",
-		"mailboxes",
-		"recipients",
-		"reply_to",
-	]
+    mail_fields = [
+        "name",
+        "message_id",
+        "id",
+        "thread_id",
+        "from_name",
+        "from_email",
+        "subject",
+        "html_body",
+        "preview",
+        "received_at",
+        "draft",
+        "seen",
+        "junk",
+        "flagged",
+        "mailboxes",
+        "recipients",
+        "reply_to",
+    ]
 
-	# text_body is only rendered as a fallback when html_body is empty (the UI renders
-	# `html_body || text_body`), so omit the redundant copy whenever there's HTML.
-	html = mail.get("html_body") or ""
-	return {
-		**{field: mail[field] for field in mail_fields},
-		"text_body": "" if html else mail.get("text_body", ""),
-		"attachments": serialize_attachments(mail.get("attachments", [])),
-	}
+    # text_body is only rendered as a fallback when html_body is empty (the UI renders
+    # `html_body || text_body`), so omit the redundant copy whenever there's HTML.
+    html = mail.get("html_body") or ""
+    return {
+        **{field: mail[field] for field in mail_fields},
+        "text_body": "" if html else mail.get("text_body", ""),
+        "attachments": serialize_attachments(mail.get("attachments", [])),
+    }
 
 
 def serialize_attachments(attachments: list[dict]) -> list[dict]:
-	"""Serializes attachment for response."""
+    """Serializes attachment for response."""
 
-	attachment_fields = ["filename", "type", "size", "blob_id", "disposition", "cid", "url"]
+    attachment_fields = ["filename", "type", "size", "blob_id", "disposition", "cid", "url"]
 
-	return [
-		{field: attachment[field] for field in attachment_fields}
-		for attachment in attachments
-		if attachment.get("filename")
-	]
+    return [
+        {field: attachment[field] for field in attachment_fields}
+        for attachment in attachments
+        if attachment.get("filename")
+    ]
 
 
 @frappe.whitelist()
 def fetch_attachment(account: str, blob_id: str) -> bytes:
-	"""Returns the content of an attachment."""
+    """Returns the content of an attachment."""
 
-	return fetch_blob(account, blob_id)
+    return fetch_blob(account, blob_id)
 
 
 @frappe.whitelist()
 def fetch_attachments_as_zip(account: str, attachments: list[dict] | str) -> bytes:
-	"""Returns the provided attachments bundled into a ZIP archive."""
+    """Returns the provided attachments bundled into a ZIP archive."""
 
-	if isinstance(attachments, str):
-		attachments = frappe.parse_json(attachments)
+    if isinstance(attachments, str):
+        attachments = frappe.parse_json(attachments)
 
-	attachments = [a for a in (attachments or []) if a.get("blob_id")]
-	if not attachments:
-		frappe.throw(_("No attachments to download."))
+    attachments = [a for a in (attachments or []) if a.get("blob_id")]
+    if not attachments:
+        frappe.throw(_("No attachments to download."))
 
-	blobs = [(a["blob_id"], a.get("filename")) for a in attachments]
-	contents = fetch_blobs(account, blobs)
+    blobs = [(a["blob_id"], a.get("filename")) for a in attachments]
+    contents = fetch_blobs(account, blobs)
 
-	buffer = io.BytesIO()
-	used_names = {}
-	with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
-		for attachment in attachments:
-			content = contents.get(attachment["blob_id"])
-			if content is None:
-				continue
+    buffer = io.BytesIO()
+    used_names = {}
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        for attachment in attachments:
+            content = contents.get(attachment["blob_id"])
+            if content is None:
+                continue
 
-			filename = _get_unique_filename(attachment.get("filename") or "attachment", used_names)
-			zf.writestr(filename, content)
+            filename = _get_unique_filename(attachment.get("filename") or "attachment", used_names)
+            zf.writestr(filename, content)
 
-	return buffer.getvalue()
+    return buffer.getvalue()
 
 
 def _get_unique_filename(filename: str, used_names: dict[str, int]) -> str:
-	"""Returns a unique filename, appending a counter to duplicates (e.g. "file (1).pdf")."""
+    """Returns a unique filename, appending a counter to duplicates (e.g. "file (1).pdf")."""
 
-	if filename not in used_names:
-		used_names[filename] = 0
-		return filename
+    if filename not in used_names:
+        used_names[filename] = 0
+        return filename
 
-	used_names[filename] += 1
-	name, ext = os.path.splitext(filename)
-	return f"{name} ({used_names[filename]}){ext}"
+    used_names[filename] += 1
+    name, ext = os.path.splitext(filename)
+    return f"{name} ({used_names[filename]}){ext}"
 
 
 @frappe.whitelist()
 def fetch_mail_as_eml(name: str) -> bytes:
-	"""Returns the MIME message content of the mail as bytes for EML download."""
+    """Returns the MIME message content of the mail as bytes for EML download."""
 
-	doc = frappe.get_doc("Mail Message", name)
-	doc.check_permission(permtype="read")
+    doc = frappe.get_doc("Mail Message", name)
+    doc.check_permission(permtype="read")
 
-	content = doc.message or doc.get_mime_message()
-	if isinstance(content, str):
-		return content.encode("utf-8")
-	return content
+    content = doc.message or doc.get_mime_message()
+    if isinstance(content, str):
+        return content.encode("utf-8")
+    return content
 
 
 @frappe.whitelist()
 def create_mail(
-	account: str,
-	from_email: str,
-	to: list[dict],
-	cc: list[dict],
-	bcc: list[dict],
-	subject: str | None,
-	html_body: str | None,
-	from_name: str = "",
-	attachments: list[dict] | None = None,
-	in_reply_to: str | None = None,
-	in_reply_to_id: str | None = None,
-	forwarded_from_id: str | None = None,
-	save_as_draft: bool = False,
+    account: str,
+    from_email: str,
+    to: list[dict],
+    cc: list[dict],
+    bcc: list[dict],
+    subject: str | None,
+    html_body: str | None,
+    from_name: str = "",
+    attachments: list[dict] | None = None,
+    in_reply_to: str | None = None,
+    in_reply_to_id: str | None = None,
+    forwarded_from_id: str | None = None,
+    save_as_draft: bool = False,
 ) -> dict:
-	"""Creates new mail queue."""
+    """Creates new mail queue."""
 
-	doc_attachments = []
-	for d in attachments or []:
-		cid = d.get("cid") or random_string(10)
-		doc_attachments.append(
-			{
-				"file_url": d.get("file_url", ""),
-				"blob_id": d.get("blob_id", ""),
-				"filename": d.get("file_name") or d.get("filename", ""),
-				"type": d.get("type", ""),
-				"size": d.get("size", ""),
-				"disposition": d.get("disposition"),
-				"cid": cid,
-			}
-		)
+    doc_attachments = []
+    for d in attachments or []:
+        cid = d.get("cid") or random_string(10)
+        doc_attachments.append(
+            {
+                "file_url": d.get("file_url", ""),
+                "blob_id": d.get("blob_id", ""),
+                "filename": d.get("file_name") or d.get("filename", ""),
+                "type": d.get("type", ""),
+                "size": d.get("size", ""),
+                "disposition": d.get("disposition"),
+                "cid": cid,
+            }
+        )
 
-	recipients = []
-	for type, emails in [("To", to), ("Cc", cc), ("Bcc", bcc)]:
-		recipients += [
-			{"type": type, "email": email.get("email"), "display_name": email.get("display_name")}
-			for email in emails
-		]
+    recipients = []
+    for type, emails in [("To", to), ("Cc", cc), ("Bcc", bcc)]:
+        recipients += [
+            {"type": type, "email": email.get("email"), "display_name": email.get("display_name")}
+            for email in emails
+        ]
 
-	doc = MailQueue._create(
-		user=get_user_for_jmap_account(account, raise_exception=True),
-		account=account,
-		from_email=from_email,
-		from_name=from_name,
-		subject=subject,
-		html_body=html_body,
-		in_reply_to=in_reply_to,
-		in_reply_to_id=in_reply_to_id,
-		forwarded_from_id=forwarded_from_id,
-		attachments=doc_attachments,
-		recipients=recipients,
-		save_as_draft=save_as_draft,
-	)
+    doc = MailQueue._create(
+        user=get_user_for_jmap_account(account, raise_exception=True),
+        account=account,
+        from_email=from_email,
+        from_name=from_name,
+        subject=subject,
+        html_body=html_body,
+        in_reply_to=in_reply_to,
+        in_reply_to_id=in_reply_to_id,
+        forwarded_from_id=forwarded_from_id,
+        attachments=doc_attachments,
+        recipients=recipients,
+        save_as_draft=save_as_draft,
+    )
 
-	if not save_as_draft and doc.status == "Submitted":
-		create_contacts_if_not_exists(account, doc.recipients)
-		auto_accept_recipients(account, doc.recipients)
+    if not save_as_draft and doc.status == "Submitted":
+        create_contacts_if_not_exists(account, doc.recipients)
+        auto_accept_recipients(account, doc.recipients)
 
-	return {"id": doc.id, "status": doc.status, "error": doc.error_message, "thread_id": doc.thread_id}
+    return {"id": doc.id, "status": doc.status, "error": doc.error_message, "thread_id": doc.thread_id}
 
 
 @frappe.whitelist()
 def update_draft_mail(
-	account: str,
-	id: str,
-	from_email: str,
-	to: list[dict],
-	cc: list[dict],
-	bcc: list[dict],
-	subject: str | None,
-	html_body: str | None,
-	from_name: str = "",
-	attachments: list[dict] | None = None,
-	submit: bool = False,
+    account: str,
+    id: str,
+    from_email: str,
+    to: list[dict],
+    cc: list[dict],
+    bcc: list[dict],
+    subject: str | None,
+    html_body: str | None,
+    from_name: str = "",
+    attachments: list[dict] | None = None,
+    submit: bool = False,
 ) -> dict:
-	"""Creates new mail queue from existing draft message."""
+    """Creates new mail queue from existing draft message."""
 
-	message = frappe.get_doc("Mail Message", f"{account}|{id}")
-	message.check_permission(permtype="write")
+    message = frappe.get_doc("Mail Message", f"{account}|{id}")
+    message.check_permission(permtype="write")
 
-	message.from_email = from_email
-	message.from_name = from_name
-	message.subject = subject
+    message.from_email = from_email
+    message.from_name = from_name
+    message.subject = subject
 
-	_attachments = {a.cid: a for a in message.attachments if a.cid}
-	message.attachments = []
+    _attachments = {a.cid: a for a in message.attachments if a.cid}
+    message.attachments = []
 
-	for d in attachments or []:
-		if file_url := d.get("file_url"):
-			message.append(
-				"attachments",
-				{
-					"file_url": file_url,
-					"filename": d.get("filename", ""),
-					"disposition": d.get("disposition"),
-					"cid": d.get("cid") or random_string(10),
-				},
-			)
-		else:
-			existing_attachment = _attachments.get(d["cid"])
-			if not existing_attachment:
-				frappe.throw(_("Attachment with cid {0} not found in the current draft.").format(d["cid"]))
+    for d in attachments or []:
+        if file_url := d.get("file_url"):
+            message.append(
+                "attachments",
+                {
+                    "file_url": file_url,
+                    "filename": d.get("filename", ""),
+                    "disposition": d.get("disposition"),
+                    "cid": d.get("cid") or random_string(10),
+                },
+            )
+        else:
+            existing_attachment = _attachments.get(d["cid"])
+            if not existing_attachment:
+                frappe.throw(_("Attachment with cid {0} not found in the current draft.").format(d["cid"]))
 
-			message.append(
-				"attachments",
-				{
-					"blob_id": existing_attachment.blob_id,
-					"type": existing_attachment.type,
-					"size": existing_attachment.size,
-					"filename": existing_attachment.filename,
-					"disposition": existing_attachment.disposition,
-					"cid": d["cid"],
-				},
-			)
+            message.append(
+                "attachments",
+                {
+                    "blob_id": existing_attachment.blob_id,
+                    "type": existing_attachment.type,
+                    "size": existing_attachment.size,
+                    "filename": existing_attachment.filename,
+                    "disposition": existing_attachment.disposition,
+                    "cid": d["cid"],
+                },
+            )
 
-	message.html_body = html_body
-	message.text_body = convert_html_to_text(message.html_body)
+    message.html_body = html_body
+    message.text_body = convert_html_to_text(message.html_body)
 
-	message.recipients = []
-	for type, emails in [("To", to), ("Cc", cc), ("Bcc", bcc)]:
-		for email in emails:
-			message.append(
-				"recipients",
-				{"type": type, "email": email.get("email"), "display_name": email.get("display_name")},
-			)
+    message.recipients = []
+    for type, emails in [("To", to), ("Cc", cc), ("Bcc", bcc)]:
+        for email in emails:
+            message.append(
+                "recipients",
+                {"type": type, "email": email.get("email"), "display_name": email.get("display_name")},
+            )
 
-	queue = message.submit() if submit else message.save_draft()
+    queue = message.submit() if submit else message.save_draft()
 
-	if submit and queue.status == "Submitted":
-		create_contacts_if_not_exists(account, message.recipients)
-		auto_accept_recipients(account, message.recipients)
+    if submit and queue.status == "Submitted":
+        create_contacts_if_not_exists(account, message.recipients)
+        auto_accept_recipients(account, message.recipients)
 
-	return {
-		"id": queue.id,
-		"status": queue.status,
-		"error": queue.error_message,
-		"thread_id": queue.thread_id,
-	}
+    return {
+        "id": queue.id,
+        "status": queue.status,
+        "error": queue.error_message,
+        "thread_id": queue.thread_id,
+    }
 
 
 @frappe.whitelist()
 def delete_mail(account: str, id: str) -> None:
-	"""Deletes the given mail."""
+    """Deletes the given mail."""
 
-	delete_messages(account, [id])
+    delete_messages(account, [id])
 
 
 @frappe.whitelist()
 def get_mime_message(name: str) -> dict:
-	"""Fetches mail mime message and related data."""
+    """Fetches mail mime message and related data."""
 
-	doc = frappe.get_doc("Mail Message", name)
-	doc.check_permission(permtype="read")
+    doc = frappe.get_doc("Mail Message", name)
+    doc.check_permission(permtype="read")
 
-	def get_mail_recipients(recipient_type):
-		return ", ".join([d.email for d in doc.recipients if d.type == recipient_type])
+    def get_mail_recipients(recipient_type):
+        return ", ".join([d.email for d in doc.recipients if d.type == recipient_type])
 
-	pass_or_fail = {1: _("'Pass'"), 0: _("'Fail'")}
+    pass_or_fail = {1: _("'Pass'"), 0: _("'Fail'")}
 
-	result = {
-		"message": doc.message or doc.get_mime_message(),
-		"message_id": {"label": _("Message ID"), "value": f"<{doc.message_id}>"},
-		"created_at": {
-			"label": _("Created at"),
-			"value": _("{0} (Delivered after {1} seconds)").format(
-				format_datetime(doc.sent_at, "E, MMM d, yyyy 'at' h:mm a"),
-				round(doc.received_after),
-			),
-		},
-		"subject": {"label": _("Subject"), "value": doc.subject},
-		"from": {"label": _("From"), "value": f"{doc.from_name} <{doc.from_email}>"},
-		"to": {"label": _("To"), "value": get_mail_recipients("To")},
-		"cc": {"label": _("CC"), "value": get_mail_recipients("Cc")},
-		"bcc": {"label": _("BCC"), "value": get_mail_recipients("Bcc")},
-	}
+    result = {
+        "message": doc.message or doc.get_mime_message(),
+        "message_id": {"label": _("Message ID"), "value": f"<{doc.message_id}>"},
+        "created_at": {
+            "label": _("Created at"),
+            "value": _("{0} (Delivered after {1} seconds)").format(
+                format_datetime(doc.sent_at, "E, MMM d, yyyy 'at' h:mm a"),
+                round(doc.received_after),
+            ),
+        },
+        "subject": {"label": _("Subject"), "value": doc.subject},
+        "from": {"label": _("From"), "value": f"{doc.from_name} <{doc.from_email}>"},
+        "to": {"label": _("To"), "value": get_mail_recipients("To")},
+        "cc": {"label": _("CC"), "value": get_mail_recipients("Cc")},
+        "bcc": {"label": _("BCC"), "value": get_mail_recipients("Bcc")},
+    }
 
-	if doc.spf_description:
-		result["spf"] = {
-			"label": _("SPF"),
-			"value": _("{0} with IP {1}").format(pass_or_fail[doc.spf_pass], doc.from_ip),
-			"description": doc.spf_description,
-		}
-	if doc.dkim_description:
-		result["dkim"] = {
-			"label": _("DKIM"),
-			"value": pass_or_fail[doc.dkim_pass],
-			"description": doc.dkim_description,
-		}
-	if doc.dmarc_description:
-		result["dmarc"] = {
-			"label": _("DMARC"),
-			"value": pass_or_fail[doc.dmarc_pass],
-			"description": doc.dmarc_description,
-		}
+    if doc.spf_description:
+        result["spf"] = {
+            "label": _("SPF"),
+            "value": _("{0} with IP {1}").format(pass_or_fail[doc.spf_pass], doc.from_ip),
+            "description": doc.spf_description,
+        }
+    if doc.dkim_description:
+        result["dkim"] = {
+            "label": _("DKIM"),
+            "value": pass_or_fail[doc.dkim_pass],
+            "description": doc.dkim_description,
+        }
+    if doc.dmarc_description:
+        result["dmarc"] = {
+            "label": _("DMARC"),
+            "value": pass_or_fail[doc.dmarc_pass],
+            "description": doc.dmarc_description,
+        }
 
-	return result
+    return result
 
 
 @frappe.whitelist()
 def set_flagged(account: str, ids: list[str], flagged: bool) -> dict:
-	"""Sets flagged for mails."""
+    """Sets flagged for mails."""
 
-	set_flagged_status(account, ids, flagged)
+    set_flagged_status(account, ids, flagged)
 
-	return {"ids": ids, "flagged": flagged}
+    return {"ids": ids, "flagged": flagged}
 
 
 @frappe.whitelist()
 def set_mails_seen(account: str, ids: list[str], seen: bool) -> list[str]:
-	"""Sets seen status for the given mails."""
+    """Sets seen status for the given mails."""
 
-	set_seen_status(account, ids, seen)
+    set_seen_status(account, ids, seen)
 
-	return ids
+    return ids
 
 
 @frappe.whitelist()
 def move_mails(account: str, ids: list[str], mailbox: str, clear_junk: bool = False) -> None:
-	"""Sets mailbox for mails."""
+    """Sets mailbox for mails."""
 
-	if clear_junk:
-		set_spam_status(account, ids, spam=False)
-	move_messages_to_mailbox(account, ids, mailbox)
+    if clear_junk:
+        set_spam_status(account, ids, spam=False)
+    move_messages_to_mailbox(account, ids, mailbox)
 
 
 @frappe.whitelist()
 def add_mails_to_mailbox(account: str, ids: list[str], mailbox_id: str) -> None:
-	"""Adds mails to a mailbox without removing them from their existing mailboxes."""
+    """Adds mails to a mailbox without removing them from their existing mailboxes."""
 
-	add_messages_to_mailbox(account, ids, mailbox_id)
+    add_messages_to_mailbox(account, ids, mailbox_id)
 
 
 @frappe.whitelist()
 def remove_mails_from_mailbox(account: str, ids: list[str], mailbox_id: str) -> None:
-	"""Removes mails from a mailbox without deleting them."""
+    """Removes mails from a mailbox without deleting them."""
 
-	remove_messages_from_mailbox(account, ids, mailbox_id)
+    remove_messages_from_mailbox(account, ids, mailbox_id)
 
 
 def _screen_senders(account: str, ids: list[str], action: str | None) -> None:
-	"""Screen the senders of the given mails with `action` (Spam/Accepted/Reject), in the same request as
-	the mail change — so marking junk/not-junk (and undoing it) updates the sender's rule atomically."""
+    """Screen the senders of the given mails with `action` (Spam/Accepted/Reject), in the same request as
+    the mail change — so marking junk/not-junk (and undoing it) updates the sender's rule atomically."""
 
-	if not action:
-		return
+    if not action:
+        return
 
-	from_emails = [m["from_email"] for m in get_messages(account, ids) if m.get("from_email")]
-	if from_emails:
-		_screen_email_addresses(account, from_emails, action=action)
+    from_emails = [m["from_email"] for m in get_messages(account, ids) if m.get("from_email")]
+    if from_emails:
+        _screen_email_addresses(account, from_emails, action=action)
 
 
 @frappe.whitelist()
 def set_mails_mailboxes(account: str, mails: list[dict], screen_action: str | None = None) -> None:
-	"""Restores each mail's exact mailbox membership and junk status (used to undo a move), optionally
-	re-screening the senders with `screen_action` to reverse a junk/not-junk's screening on undo."""
+    """Restores each mail's exact mailbox membership and junk status (used to undo a move), optionally
+    re-screening the senders with `screen_action` to reverse a junk/not-junk's screening on undo."""
 
-	set_messages_mailboxes(account, mails)
-	_screen_senders(account, [m["id"] for m in mails], screen_action)
+    set_messages_mailboxes(account, mails)
+    _screen_senders(account, [m["id"] for m in mails], screen_action)
 
 
 @frappe.whitelist()
 def set_mails_spam_status(
-	account: str, ids: list[str], spam: bool, screen_action: str | None = None
+    account: str, ids: list[str], spam: bool, screen_action: str | None = None
 ) -> list[str]:
-	"""Sets spam status of the given mails, optionally screening their senders with `screen_action`
-	(Spam on Junk, Accepted on Not Junk) in the same call."""
+    """Sets spam status of the given mails, optionally screening their senders with `screen_action`
+    (Spam on Junk, Accepted on Not Junk) in the same call."""
 
-	set_spam_status(account, ids, spam)
-	_screen_senders(account, ids, screen_action)
+    set_spam_status(account, ids, spam)
+    _screen_senders(account, ids, screen_action)
 
-	return ids
+    return ids
 
 
 @frappe.whitelist()
 def empty_user_mailbox(account: str, mailbox: str) -> None:
-	"""Empties the given mailbox."""
+    """Empties the given mailbox."""
 
-	empty_mailbox(account, mailbox)
+    empty_mailbox(account, mailbox)
 
 
 @frappe.whitelist()
 def search_mails(
-	account: str,
-	filter: dict | None = None,
-	limit: int = 5,
-	start: int = 0,
-	all_accounts: bool = False,
+    account: str,
+    filter: dict | None = None,
+    limit: int = 5,
+    start: int = 0,
+    all_accounts: bool = False,
 ) -> tuple[list[dict], int]:
-	"""Returns search results for the given query.
+    """Returns search results for the given query.
 
-	By default the search is scoped to `account`. When `all_accounts` is truthy the query fans out
-	across every JMAP account the user owns and the results are merged newest-first, so a mail can be
-	found without remembering which account it landed in. Either way each result is tagged with its
-	owning account (and that account's Inbox/Archive/Trash mailbox ids) so the client can open — and
-	act on — it in the correct account.
-	"""
+    By default the search is scoped to `account`. When `all_accounts` is truthy the query fans out
+    across every JMAP account the user owns and the results are merged newest-first, so a mail can be
+    found without remembering which account it landed in. Either way each result is tagged with its
+    owning account (and that account's Inbox/Archive/Trash mailbox ids) so the client can open — and
+    act on — it in the correct account.
+    """
 
-	if not filter:
-		return ([], 0)
+    if not filter:
+        return ([], 0)
 
-	# `filter` may arrive carrying the search-page query blob (see MailboxView), which includes the
-	# out-of-band `all_accounts` flag — drop it so it never becomes a bogus JMAP search condition.
-	filter = {k: v for k, v in filter.items() if k != "all_accounts"}
+    # `filter` may arrive carrying the search-page query blob (see MailboxView), which includes the
+    # out-of-band `all_accounts` flag — drop it so it never becomes a bogus JMAP search condition.
+    filter = {k: v for k, v in filter.items() if k != "all_accounts"}
 
-	# The flag crosses the wire as a bool, an int, or a "true"/"1" string depending on the caller, so
-	# normalize all truthy forms (cint("true") would be 0).
-	if str(all_accounts).lower() in ("1", "true"):
-		return _search_all_accounts(filter, limit=limit, start=start)
+    # The flag crosses the wire as a bool, an int, or a "true"/"1" string depending on the caller, so
+    # normalize all truthy forms (cint("true") would be 0).
+    if str(all_accounts).lower() in ("1", "true"):
+        return _search_all_accounts(filter, limit=limit, start=start)
 
-	normalized_filter = normalize_filter(filter)
-	mails, total = search_messages(account, normalized_filter, position=start, limit=limit)
-	add_user_images_to_emails(account, mails)
-	_tag_search_results(account, mails)
+    normalized_filter = normalize_filter(filter)
+    mails, total = search_messages(account, normalized_filter, position=start, limit=limit)
+    add_user_images_to_emails(account, mails)
+    _tag_search_results(account, mails)
 
-	return mails, total
+    return mails, total
 
 
 def _search_all_accounts(filter: dict, limit: int, start: int) -> tuple[list[dict], int]:
-	"""Search across every JMAP account the user owns, returning a merged newest-first page.
+    """Search across every JMAP account the user owns, returning a merged newest-first page.
 
-	Mirrors the All Inboxes fan-out (`get_all_inbox_threads`): each account is over-fetched to the
-	deepest global position this page can reach (`start + limit`, clamped), the results are tagged,
-	merged, sorted newest-first, then sliced to the requested window. `total` is the summed match
-	count across accounts.
-	"""
+    Mirrors the All Inboxes fan-out (`get_all_inbox_threads`): each account is over-fetched to the
+    deepest global position this page can reach (`start + limit`, clamped), the results are tagged,
+    merged, sorted newest-first, then sliced to the requested window. `total` is the summed match
+    count across accounts.
+    """
 
-	accounts = get_user_jmap_accounts()
-	if not accounts:
-		return ([], 0)
+    accounts = get_user_jmap_accounts()
+    if not accounts:
+        return ([], 0)
 
-	# Clamp user input before it fans out across accounts (see the All Inboxes bounds): limit to a sane
-	# page size, and start so the per-account fetch (start + limit) can never exceed ALL_INBOX_MAX_FETCH.
-	limit = min(max(cint(limit), 1), ALL_INBOX_MAX_LIMIT)
-	start = min(max(cint(start), 0), ALL_INBOX_MAX_FETCH - limit)
-	per_account_limit = start + limit
+    # Clamp user input before it fans out across accounts (see the All Inboxes bounds): limit to a sane
+    # page size, and start so the per-account fetch (start + limit) can never exceed ALL_INBOX_MAX_FETCH.
+    limit = min(max(cint(limit), 1), ALL_INBOX_MAX_LIMIT)
+    start = min(max(cint(start), 0), ALL_INBOX_MAX_FETCH - limit)
+    per_account_limit = start + limit
 
-	# Mailbox ids are account-specific, so a "Look In" folder filter can't carry across accounts.
-	filter = {k: v for k, v in filter.items() if k != "inMailbox"}
-	normalized_filter = normalize_filter(filter)
+    # Mailbox ids are account-specific, so a "Look In" folder filter can't carry across accounts.
+    filter = {k: v for k, v in filter.items() if k != "inMailbox"}
+    normalized_filter = normalize_filter(filter)
 
-	merged: list[dict] = []
-	total = 0
-	for account in accounts:
-		account_id = account["name"]
-		mails, account_total = search_messages(
-			account_id, normalized_filter, position=0, limit=per_account_limit
-		)
-		total += account_total
-		if not mails:
-			continue
+    merged: list[dict] = []
+    total = 0
+    for account in accounts:
+        account_id = account["name"]
+        mails, account_total = search_messages(
+            account_id, normalized_filter, position=0, limit=per_account_limit
+        )
+        total += account_total
+        if not mails:
+            continue
 
-		add_user_images_to_emails(account_id, mails)
-		_tag_search_results(account_id, mails, account_name=account["_name"])
-		merged.extend(mails)
+        add_user_images_to_emails(account_id, mails)
+        _tag_search_results(account_id, mails, account_name=account["_name"])
+        merged.extend(mails)
 
-	merged.sort(key=lambda mail: mail["received_at"], reverse=True)
-	return merged[start : start + limit], total
+    merged.sort(key=lambda mail: mail["received_at"], reverse=True)
+    return merged[start : start + limit], total
 
 
 def _tag_search_results(account: str, mails: list[dict], account_name: str | None = None) -> None:
-	"""Tag each result with its owning account and that account's Inbox/Archive/Trash mailbox ids.
+    """Tag each result with its owning account and that account's Inbox/Archive/Trash mailbox ids.
 
-	Lets the client open a result in — and run per-row actions against — the correct JMAP account,
-	which matters when results are merged across accounts (the `all_accounts` search path)."""
+    Lets the client open a result in — and run per-row actions against — the correct JMAP account,
+    which matters when results are merged across accounts (the `all_accounts` search path)."""
 
-	if not mails:
-		return
+    if not mails:
+        return
 
-	if account_name is None:
-		account_name = frappe.db.get_value("JMAP Account", account, "_name")
+    if account_name is None:
+        account_name = frappe.db.get_value("JMAP Account", account, "_name")
 
-	inbox_id = get_mailbox_id_by_role(account, "inbox")
-	archive_id = get_mailbox_id_by_role(account, "archive")
-	trash_id = get_mailbox_id_by_role(account, "trash")
+    inbox_id = get_mailbox_id_by_role(account, "inbox")
+    archive_id = get_mailbox_id_by_role(account, "archive")
+    trash_id = get_mailbox_id_by_role(account, "trash")
 
-	for mail in mails:
-		mail["account"] = account
-		mail["account_name"] = account_name
-		mail["inbox"] = inbox_id
-		mail["archive"] = archive_id
-		mail["trash"] = trash_id
+    for mail in mails:
+        mail["account"] = account
+        mail["account_name"] = account_name
+        mail["inbox"] = inbox_id
+        mail["archive"] = archive_id
+        mail["trash"] = trash_id
 
 
 def normalize_filter(filter: dict) -> dict:
-	"""Normalize and transform filter parameters for email search."""
+    """Normalize and transform filter parameters for email search."""
 
-	filter = filter.copy()
+    filter = filter.copy()
 
-	if filter.get("hasAttachment") in ["true", "false"]:
-		filter["hasAttachment"] = filter["hasAttachment"] == "true"
+    if filter.get("hasAttachment") in ["true", "false"]:
+        filter["hasAttachment"] = filter["hasAttachment"] == "true"
 
-	if filter.get("isRead"):
-		key = "hasKeyword" if filter["isRead"] == "true" else "notKeyword"
-		filter[key] = "$seen"
-		del filter["isRead"]
+    if filter.get("isRead"):
+        key = "hasKeyword" if filter["isRead"] == "true" else "notKeyword"
+        filter[key] = "$seen"
+        del filter["isRead"]
 
-	for date_key in ["after", "before"]:
-		if filter.get(date_key):
-			filter[date_key] = parse_date_to_utc_iso(filter[date_key])
+    for date_key in ["after", "before"]:
+        if filter.get(date_key):
+            filter[date_key] = parse_date_to_utc_iso(filter[date_key])
 
-	return {"operator": "AND", "conditions": [{k: v} for k, v in filter.items()]}
+    return {"operator": "AND", "conditions": [{k: v} for k, v in filter.items()]}
 
 
 def parse_date_to_utc_iso(date_str: str) -> str:
-	"""Parse date string and convert to ISO format with UTC timezone."""
-	return datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=UTC).isoformat()
+    """Parse date string and convert to ISO format with UTC timezone."""
+    return datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=UTC).isoformat()
 
 
 @frappe.whitelist()
 def get_avatar(email: str, size: int = 128, strict: bool = False) -> None:
-	"""Fetch and return avatar for the given email."""
+    """Fetch and return avatar for the given email."""
 
-	if not email:
-		frappe.throw(_("Email is required to fetch avatar."))
+    if not email:
+        frappe.throw(_("Email is required to fetch avatar."))
 
-	email = email.strip().lower()
-	email_hash = hashlib.md5(email.encode()).hexdigest()
+    email = email.strip().lower()
+    email_hash = hashlib.md5(email.encode()).hexdigest()
 
-	cache_key = f"avatar:{email_hash}:{size}"
+    cache_key = f"avatar:{email_hash}:{size}"
 
-	# 1. Try cache
-	avatar = frappe.cache.get_value(cache_key)
+    # 1. Try cache
+    avatar = frappe.cache.get_value(cache_key)
 
-	if not avatar:
-		# 2. Try Gravatar (opt-in: avoids leaking emails to a third party when disabled)
-		if get_config("enable_gravatar"):
-			default = get_config("default_gravatar")
-			try:
-				res = requests.get(
-					f"https://secure.gravatar.com/avatar/{email_hash}",
-					params={"d": default, "s": size},
-					timeout=3,
-				)
-				if res.ok:
-					avatar = res.content
-			except requests.RequestException:
-				pass
+    if not avatar:
+        # 2. Try Gravatar (opt-in: avoids leaking emails to a third party when disabled)
+        if get_config("enable_gravatar"):
+            default = get_config("default_gravatar")
+            try:
+                res = requests.get(
+                    f"https://secure.gravatar.com/avatar/{email_hash}",
+                    params={"d": default, "s": size},
+                    timeout=3,
+                )
+                if res.ok:
+                    avatar = res.content
+            except requests.RequestException:
+                pass
 
-		# 3. Handle missing gravatar
-		if not avatar:
-			if strict:
-				frappe.throw(_("Avatar not found."), frappe.DoesNotExistError)
+        # 3. Handle missing gravatar
+        if not avatar:
+            if strict:
+                frappe.throw(_("Avatar not found."), frappe.DoesNotExistError)
 
-			generator = pydenticon.Generator(
-				5,
-				5,
-				foreground=[
-					"#1abc9c",
-					"#2ecc71",
-					"#3498db",
-					"#9b59b6",
-					"#e74c3c",
-				],
-				background="#ffffff",
-			)
-			avatar = generator.generate(email_hash, size, size, output_format="png")
+            generator = pydenticon.Generator(
+                5,
+                5,
+                foreground=[
+                    "#1abc9c",
+                    "#2ecc71",
+                    "#3498db",
+                    "#9b59b6",
+                    "#e74c3c",
+                ],
+                background="#ffffff",
+            )
+            avatar = generator.generate(email_hash, size, size, output_format="png")
 
-		# Cache the avatar for future requests
-		frappe.cache.set_value(cache_key, avatar, expires_in_sec=AVATAR_CACHE_TTL)
+        # Cache the avatar for future requests
+        frappe.cache.set_value(cache_key, avatar, expires_in_sec=AVATAR_CACHE_TTL)
 
-	frappe.local.response.filename = f"{email_hash}.png"
-	frappe.local.response.filecontent = avatar
-	frappe.local.response.mimetype = "image/png"
-	frappe.local.response.type = "binary"
+    frappe.local.response.filename = f"{email_hash}.png"
+    frappe.local.response.filecontent = avatar
+    frappe.local.response.mimetype = "image/png"
+    frappe.local.response.type = "binary"
 
 
 @frappe.whitelist()
 def search_email_addresses(account: str, text: str, limit: int = 10) -> list[dict]:
-	"""Search the account's local address index for names/emails matching `text`."""
+    """Search the account's local address index for names/emails matching `text`."""
 
-	get_user_for_jmap_account(account, raise_exception=True)
+    get_user_for_jmap_account(account, raise_exception=True)
 
-	return get_email_address_index(account).search_email_addresses(text, limit=cint(limit))
+    return get_email_address_index(account).search_email_addresses(text, limit=cint(limit))
 
 
 @frappe.whitelist()
 def create_mailbox(
-	account: str,
-	name: str,
-	parent: str | None = None,
-	icon: str | None = None,
-	color: str | None = None,
-	disable_push_notification: bool = False,
-	automation_rules: dict | None = None,
+    account: str,
+    name: str,
+    parent: str | None = None,
+    icon: str | None = None,
+    color: str | None = None,
+    disable_push_notification: bool = False,
+    automation_rules: dict | None = None,
 ) -> str:
-	"""Creates a new mailbox and initializes its settings for the given account."""
+    """Creates a new mailbox and initializes its settings for the given account."""
 
-	with pause_automation_sieve_build():
-		mailbox_id = add_mailbox(account, name, None, parent)
-		set_mailbox_settings(
-			account,
-			mailbox_id,
-			icon=icon,
-			color=color,
-			disable_push_notification=disable_push_notification,
-			**automation_rules_to_settings(automation_rules),
-		)
+    with pause_automation_sieve_build():
+        mailbox_id = add_mailbox(account, name, None, parent)
+        set_mailbox_settings(
+            account,
+            mailbox_id,
+            icon=icon,
+            color=color,
+            disable_push_notification=disable_push_notification,
+            **automation_rules_to_settings(automation_rules),
+        )
 
-	build_automation_sieve(account, activate=True)
+    build_automation_sieve(account, activate=True)
 
 
 @frappe.whitelist()
 def update_mailbox(
-	account: str,
-	id: str,
-	name: str,
-	old_name: str,
-	role: str | None = None,
-	parent: str | None = None,
-	icon: str | None = None,
-	color: str | None = None,
-	disable_push_notification: bool = False,
-	automation_rules: dict | None = None,
+    account: str,
+    id: str,
+    name: str,
+    old_name: str,
+    role: str | None = None,
+    parent: str | None = None,
+    icon: str | None = None,
+    color: str | None = None,
+    disable_push_notification: bool = False,
+    automation_rules: dict | None = None,
 ) -> None:
-	"""Updates Mailbox Settings for the given mailbox ID."""
+    """Updates Mailbox Settings for the given mailbox ID."""
 
-	is_jmap_account_belongs_to_user(account, raise_exception=True)
+    is_jmap_account_belongs_to_user(account, raise_exception=True)
 
-	with pause_automation_sieve_build():
-		set_mailbox_settings(
-			account,
-			id,
-			_name=name,
-			role=role,
-			parent=parent,
-			icon=icon,
-			color=color,
-			disable_push_notification=disable_push_notification,
-			**automation_rules_to_settings(automation_rules),
-		)
+    with pause_automation_sieve_build():
+        set_mailbox_settings(
+            account,
+            id,
+            _name=name,
+            role=role,
+            parent=parent,
+            icon=icon,
+            color=color,
+            disable_push_notification=disable_push_notification,
+            **automation_rules_to_settings(automation_rules),
+        )
 
-	build_automation_sieve(account, activate=True)
+    build_automation_sieve(account, activate=True)
 
 
 @frappe.whitelist()
 def delete_mailbox(account: str, id: str, name: str) -> None:
-	"""Deletes the mailbox with the given mailbox ID, followed by its settings."""
+    """Deletes the mailbox with the given mailbox ID, followed by its settings."""
 
-	delete_mailboxes(account, [id])
-	frappe.db.delete("Mailbox Settings", {"account": account, "mailbox_id": id})
-	build_automation_sieve(account, activate=True)
+    delete_mailboxes(account, [id])
+    frappe.db.delete("Mailbox Settings", {"account": account, "mailbox_id": id})
+    build_automation_sieve(account, activate=True)
 
 
 @frappe.whitelist()
 def get_screened_addresses(account: str) -> list[dict]:
-	"""Returns the screened email addresses (each with its `action`) for the given account."""
+    """Returns the screened email addresses (each with its `action`) for the given account."""
 
-	is_jmap_account_belongs_to_user(account, raise_exception=True)
+    is_jmap_account_belongs_to_user(account, raise_exception=True)
 
-	return get_screened_email_addresses(account)
+    return get_screened_email_addresses(account)
 
 
 @frappe.whitelist()
 def get_global_screened_addresses() -> list[dict]:
-	"""Returns the global screened email addresses — admin-managed rules applying to every account.
+    """Returns the global screened email addresses — admin-managed rules applying to every account.
 
-	Read-only: the frontend overlays these under the account's own rules (the account's rule wins)
-	when deciding whether a sender is trusted for remote images, mirroring the merge the automation
-	sieve is built from. The settings UI keeps using `get_screened_addresses`, which stays
-	account-only so users never see or edit the global rules there.
-	"""
+    Read-only: the frontend overlays these under the account's own rules (the account's rule wins)
+    when deciding whether a sender is trusted for remote images, mirroring the merge the automation
+    sieve is built from. The settings UI keeps using `get_screened_addresses`, which stays
+    account-only so users never see or edit the global rules there.
+    """
 
-	return get_global_screened_email_addresses()
+    return get_global_screened_email_addresses()
 
 
 @frappe.whitelist()
 def screen_email_address(account: str, email: str, action: str = "Reject") -> None:
-	"""Screens a single email address for the given account with the given action.
+    """Screens a single email address for the given account with the given action.
 
-	`action` is Reject, Spam, or Accepted. Used by explicit user actions, so it overrides any
-	existing rule for the sender.
-	"""
+    `action` is Reject, Spam, or Accepted. Used by explicit user actions, so it overrides any
+    existing rule for the sender.
+    """
 
-	is_jmap_account_belongs_to_user(account, raise_exception=True)
+    is_jmap_account_belongs_to_user(account, raise_exception=True)
 
-	_screen_email_addresses(account, [email], action)
+    _screen_email_addresses(account, [email], action)
 
 
 @frappe.whitelist()
 def screen_email_addresses(
-	account: str, emails: list[str], action: str = "Reject", override: bool = True
+    account: str, emails: list[str], action: str = "Reject", override: bool = True
 ) -> None:
-	"""Screens multiple email addresses for the given account in a single request.
+    """Screens multiple email addresses for the given account in a single request.
 
-	`action` is Reject (discard incoming mail silently), Spam (file into Junk), or Accepted (let it
-	reach the inbox; used by screening). New addresses are inserted in one batched query via
-	`bulk_insert` (no per-document hooks); the sieve script is regenerated once at the end.
+    `action` is Reject (discard incoming mail silently), Spam (file into Junk), or Accepted (let it
+    reach the inbox; used by screening). New addresses are inserted in one batched query via
+    `bulk_insert` (no per-document hooks); the sieve script is regenerated once at the end.
 
-	A sender has at most one screening rule (uniqueness is on the address). `override` controls what
-	happens when a rule already exists: explicit user actions (default `True`) overwrite it, while
-	automated flows like auto-junk pass `override=False` so they never clobber a manual decision.
-	"""
+    A sender has at most one screening rule (uniqueness is on the address). `override` controls what
+    happens when a rule already exists: explicit user actions (default `True`) overwrite it, while
+    automated flows like auto-junk pass `override=False` so they never clobber a manual decision.
+    """
 
-	is_jmap_account_belongs_to_user(account, raise_exception=True)
+    is_jmap_account_belongs_to_user(account, raise_exception=True)
 
-	_screen_email_addresses(account, emails, action, override)
+    _screen_email_addresses(account, emails, action, override)
 
 
 def _screen_email_addresses(
-	account: str, emails: list[str], action: str = "Reject", override: bool = True
+    account: str, emails: list[str], action: str = "Reject", override: bool = True
 ) -> None:
-	"""Core screening logic on the resolved account handle. Also called internally (the mark-as-junk
-	flow and auto-accept already hold the handle), so it isn't whitelisted."""
+    """Core screening logic on the resolved account handle. Also called internally (the mark-as-junk
+    flow and auto-accept already hold the handle), so it isn't whitelisted."""
 
-	if action not in ("Spam", "Reject", "Accepted"):
-		frappe.throw(_("Invalid screening action: {0}").format(action))
+    if action not in ("Spam", "Reject", "Accepted"):
+        frappe.throw(_("Invalid screening action: {0}").format(action))
 
-	# Normalise + validate here too: bulk_insert below bypasses the doctype's validate hook, and this
-	# is the choke point every screening flow (settings UI, mark-as-junk, auto-accept) funnels through.
-	emails = [normalize_screened_value(email) for email in emails]
-	emails = [email for email in dict.fromkeys(emails) if email]  # de-duplicate, drop empties
-	if not emails:
-		return
+    # Normalise + validate here too: bulk_insert below bypasses the doctype's validate hook, and this
+    # is the choke point every screening flow (settings UI, mark-as-junk, auto-accept) funnels through.
+    emails = [normalize_screened_value(email) for email in emails]
+    emails = [email for email in dict.fromkeys(emails) if email]  # de-duplicate, drop empties
+    if not emails:
+        return
 
-	for email in emails:
-		validate_screened_value(email, raise_exception=True)
+    for email in emails:
+        validate_screened_value(email, raise_exception=True)
 
-	existing = {
-		row.email: row
-		for row in frappe.db.get_all(
-			"Screened Email Address",
-			filters={"account": account, "email": ["in", emails]},
-			fields=["name", "email", "action"],
-		)
-	}
+    existing = {
+        row.email: row
+        for row in frappe.db.get_all(
+            "Screened Email Address",
+            filters={"account": account, "email": ["in", emails]},
+            fields=["name", "email", "action"],
+        )
+    }
 
-	docs = []
-	changed = False
-	for email in emails:
-		row = existing.get(email)
-		if row:
-			if override and row.action != action:
-				frappe.db.set_value(
-					"Screened Email Address", row.name, "action", action, update_modified=True
-				)
-				changed = True
-			continue
-		# bulk_insert bypasses before_insert, so set the shared account (the key) explicitly.
-		doc = frappe.get_doc(
-			{
-				"doctype": "Screened Email Address",
-				"account": account,
-				"email": email,
-				"action": action,
-			}
-		)
-		doc.set_new_name()
-		docs.append(doc)
+    docs = []
+    changed = False
+    for email in emails:
+        row = existing.get(email)
+        if row:
+            if override and row.action != action:
+                frappe.db.set_value(
+                    "Screened Email Address", row.name, "action", action, update_modified=True
+                )
+                changed = True
+            continue
+        # bulk_insert bypasses before_insert, so set the shared account (the key) explicitly.
+        doc = frappe.get_doc(
+            {
+                "doctype": "Screened Email Address",
+                "account": account,
+                "email": email,
+                "action": action,
+            }
+        )
+        doc.set_new_name()
+        docs.append(doc)
 
-	if docs:
-		bulk_insert("Screened Email Address", docs, ignore_duplicates=True)
-		changed = True
+    if docs:
+        bulk_insert("Screened Email Address", docs, ignore_duplicates=True)
+        changed = True
 
-	if changed:
-		build_automation_sieve(account, activate=True)
+    if changed:
+        build_automation_sieve(account, activate=True)
 
 
 def auto_accept_recipients(account: str, recipients: list) -> None:
-	"""When screening is enabled, allowlist the people you email so their replies reach the inbox.
+    """When screening is enabled, allowlist the people you email so their replies reach the inbox.
 
-	Non-overriding, so it never un-rejects a sender you deliberately blocked. Failures are logged and
-	swallowed — auto-accept must never block sending.
-	"""
+    Non-overriding, so it never un-rejects a sender you deliberately blocked. Failures are logged and
+    swallowed — auto-accept must never block sending.
+    """
 
-	from suite.mail.doctype.sieve_script.sieve_script import is_screening_enabled
+    from suite.mail.doctype.sieve_script.sieve_script import is_screening_enabled
 
-	try:
-		if not is_screening_enabled(account):
-			return
+    try:
+        if not is_screening_enabled(account):
+            return
 
-		emails = list({r.email for r in recipients if getattr(r, "email", None)})
-		if emails:
-			# Recipients a global Accepted rule already covers — their exact address or their
-			# domain — need no account-level rule: the global rule already lets their replies through.
-			accepted_values = get_global_accepted_values()
-			emails = [e for e in emails if not is_globally_accepted(e, accepted_values)]
-		if emails:
-			_screen_email_addresses(account, emails, action="Accepted", override=False)
-	except Exception:
-		log_mail_error(
-			_("Screening Auto-Accept Error"),
-			_("Failed to auto-accept recipients for account {0}").format(account),
-		)
+        emails = list({r.email for r in recipients if getattr(r, "email", None)})
+        if emails:
+            # Recipients a global Accepted rule already covers — their exact address or their
+            # domain — need no account-level rule: the global rule already lets their replies through.
+            accepted_values = get_global_accepted_values()
+            emails = [e for e in emails if not is_globally_accepted(e, accepted_values)]
+        if emails:
+            _screen_email_addresses(account, emails, action="Accepted", override=False)
+    except Exception:
+        log_mail_error(
+            _("Screening Auto-Accept Error"),
+            _("Failed to auto-accept recipients for account {0}").format(account),
+        )
 
 
 @frappe.whitelist()
 def unscreen_email_addresses(account: str, emails: list[str]) -> None:
-	"""Removes screening rules by deleting Screened Email Address records and regenerating the sieve.
+    """Removes screening rules by deleting Screened Email Address records and regenerating the sieve.
 
-	Scoped to the shared account (not the per-user handle), so a rule added by any user on a
-	shared account can be removed. `frappe.db.delete` bypasses the doctype's `after_delete` hook, so
-	the screening sieve blocks are rebuilt explicitly here.
-	"""
+    Scoped to the shared account (not the per-user handle), so a rule added by any user on a
+    shared account can be removed. `frappe.db.delete` bypasses the doctype's `after_delete` hook, so
+    the screening sieve blocks are rebuilt explicitly here.
+    """
 
-	is_jmap_account_belongs_to_user(account, raise_exception=True)
+    is_jmap_account_belongs_to_user(account, raise_exception=True)
 
-	if not emails:
-		return
+    if not emails:
+        return
 
-	deleted = frappe.db.get_all(
-		"Screened Email Address",
-		filters={"account": account, "email": ["in", emails]},
-		pluck="name",
-	)
-	if not deleted:
-		return
+    deleted = frappe.db.get_all(
+        "Screened Email Address",
+        filters={"account": account, "email": ["in", emails]},
+        pluck="name",
+    )
+    if not deleted:
+        return
 
-	frappe.db.delete("Screened Email Address", {"name": ["in", deleted]})
-	build_automation_sieve(account, activate=True)
+    frappe.db.delete("Screened Email Address", {"name": ["in", deleted]})
+    build_automation_sieve(account, activate=True)
 
 
 # --- Screener (the screening folder view) ---------------------------------------------------------
 
 
 def _screening_message_ids(account: str, from_email: str | None = None) -> list[str]:
-	"""Return ids of Screening-folder messages, optionally only those from a given sender."""
+    """Return ids of Screening-folder messages, optionally only those from a given sender."""
 
-	screening_id = get_mailbox_id_by_name(account, SCREENER_MAILBOX_NAME)
-	if not screening_id:
-		add_mailbox(account, SCREENER_MAILBOX_NAME)
-		return []
+    screening_id = get_mailbox_id_by_name(account, SCREENER_MAILBOX_NAME)
+    if not screening_id:
+        add_mailbox(account, SCREENER_MAILBOX_NAME)
+        return []
 
-	conditions = [{"inMailbox": screening_id}]
-	if from_email:
-		conditions.append({"from": from_email})
-	filter = conditions[0] if len(conditions) == 1 else {"operator": "AND", "conditions": conditions}
+    conditions = [{"inMailbox": screening_id}]
+    if from_email:
+        conditions.append({"from": from_email})
+    filter = conditions[0] if len(conditions) == 1 else {"operator": "AND", "conditions": conditions}
 
-	service = get_email_service(account)
+    service = get_email_service(account)
 
-	return service.query(filter, limit=service.max_objects_in_get).get("ids", [])
+    return service.query(filter, limit=service.max_objects_in_get).get("ids", [])
 
 
 @frappe.whitelist()
 def get_screening_senders(account: str) -> list[dict]:
-	"""Return one row per unique sender in the Screening folder, newest sender first.
+    """Return one row per unique sender in the Screening folder, newest sender first.
 
-	The Screener groups by sender rather than by conversation: each row is the latest mail from that
-	sender, with a count of how many of their messages are waiting and how many are unread.
-	"""
+    The Screener groups by sender rather than by conversation: each row is the latest mail from that
+    sender, with a count of how many of their messages are waiting and how many are unread.
+    """
 
-	screening_id = get_mailbox_id_by_name(account, SCREENER_MAILBOX_NAME)
-	if not screening_id:
-		add_mailbox(account, SCREENER_MAILBOX_NAME)
-		return []
+    screening_id = get_mailbox_id_by_name(account, SCREENER_MAILBOX_NAME)
+    if not screening_id:
+        add_mailbox(account, SCREENER_MAILBOX_NAME)
+        return []
 
-	messages, _total = search_messages(
-		account,
-		{"inMailbox": screening_id},
-		position=0,
-		limit=SCREENING_FETCH_LIMIT,
-		sort=[{"property": "receivedAt", "isAscending": False}],
-	)
+    messages, _total = search_messages(
+        account,
+        {"inMailbox": screening_id},
+        position=0,
+        limit=SCREENING_FETCH_LIMIT,
+        sort=[{"property": "receivedAt", "isAscending": False}],
+    )
 
-	senders: dict[str, dict] = {}
-	for message in messages:  # newest first
-		email = (message.get("from_email") or "").lower()
-		if not email:
-			continue
+    senders: dict[str, dict] = {}
+    for message in messages:  # newest first
+        email = (message.get("from_email") or "").lower()
+        if not email:
+            continue
 
-		sender = senders.get(email)
-		if not sender:
-			# The first (newest) message for this sender becomes the summary row.
-			senders[email] = {
-				"from_email": message["from_email"],
-				"from_name": message["from_name"],
-				"subject": message["subject"],
-				"preview": message["preview"],
-				"received_at": message["received_at"],
-				"count": 1,
-				"unread": 0 if message["seen"] else 1,
-			}
-		else:
-			sender["count"] += 1
-			if not message["seen"]:
-				sender["unread"] += 1
+        sender = senders.get(email)
+        if not sender:
+            # The first (newest) message for this sender becomes the summary row.
+            senders[email] = {
+                "from_email": message["from_email"],
+                "from_name": message["from_name"],
+                "subject": message["subject"],
+                "preview": message["preview"],
+                "received_at": message["received_at"],
+                "count": 1,
+                "unread": 0 if message["seen"] else 1,
+            }
+        else:
+            sender["count"] += 1
+            if not message["seen"]:
+                sender["unread"] += 1
 
-	return list(senders.values())
+    return list(senders.values())
 
 
 @frappe.whitelist()
 def get_screening_sender_mails(account: str, from_email: str) -> list[dict]:
-	"""Return all Screening-folder messages from a single sender, oldest to newest (with bodies)."""
+    """Return all Screening-folder messages from a single sender, oldest to newest (with bodies)."""
 
-	ids = _screening_message_ids(account, from_email)
-	if not ids:
-		return []
+    ids = _screening_message_ids(account, from_email)
+    if not ids:
+        return []
 
-	# The JMAP `from` filter is a tokenized text match, so it can also return other senders whose From
-	# header shares tokens. Keep only exact-address matches (mirrors how get_screening_senders groups).
-	target = from_email.lower()
-	mails = [serialize_mail(m) for m in get_messages(account, ids)]
-	mails = [m for m in mails if (m.get("from_email") or "").lower() == target]
-	mails.sort(key=lambda m: m["received_at"])
-	return add_user_images_to_emails(account, mails, is_thread=True)
+    # The JMAP `from` filter is a tokenized text match, so it can also return other senders whose From
+    # header shares tokens. Keep only exact-address matches (mirrors how get_screening_senders groups).
+    target = from_email.lower()
+    mails = [serialize_mail(m) for m in get_messages(account, ids)]
+    mails = [m for m in mails if (m.get("from_email") or "").lower() == target]
+    mails.sort(key=lambda m: m["received_at"])
+    return add_user_images_to_emails(account, mails, is_thread=True)
 
 
 @frappe.whitelist()
 def allow_screening_senders(account: str, from_emails: list[str]) -> None:
-	"""Allow senders in: accept them (future mail reaches the inbox) and move their screened mail there."""
+    """Allow senders in: accept them (future mail reaches the inbox) and move their screened mail there."""
 
-	if not from_emails:
-		return
+    if not from_emails:
+        return
 
-	_screen_email_addresses(account, from_emails, action="Accepted")
+    _screen_email_addresses(account, from_emails, action="Accepted")
 
-	inbox_id = get_mailbox_id_by_role(account, "inbox", raise_exception=True)
-	for from_email in from_emails:
-		ids = _screening_message_ids(account, from_email)
-		if ids:
-			move_mails(account, ids, inbox_id, clear_junk=True)
+    inbox_id = get_mailbox_id_by_role(account, "inbox", raise_exception=True)
+    for from_email in from_emails:
+        ids = _screening_message_ids(account, from_email)
+        if ids:
+            move_mails(account, ids, inbox_id, clear_junk=True)
 
 
 @frappe.whitelist()
 def move_screening_mails_to_inbox(account: str) -> None:
-	"""Move every Screening-folder message to the Inbox (offered when screening is turned off)."""
+    """Move every Screening-folder message to the Inbox (offered when screening is turned off)."""
 
-	ids = _screening_message_ids(account)
-	if not ids:
-		return
+    ids = _screening_message_ids(account)
+    if not ids:
+        return
 
-	inbox_id = get_mailbox_id_by_role(account, "inbox", raise_exception=True)
-	move_mails(account, ids, inbox_id, clear_junk=True)
+    inbox_id = get_mailbox_id_by_role(account, "inbox", raise_exception=True)
+    move_mails(account, ids, inbox_id, clear_junk=True)
 
 
 @frappe.whitelist()
 def screen_out_senders(account: str, from_emails: list[str]) -> None:
-	"""Screen senders out: mark them Spam (future mail to Junk) and move their screened mail to Junk."""
+    """Screen senders out: mark them Spam (future mail to Junk) and move their screened mail to Junk."""
 
-	if not from_emails:
-		return
+    if not from_emails:
+        return
 
-	_screen_email_addresses(account, from_emails, action="Spam")
+    _screen_email_addresses(account, from_emails, action="Spam")
 
-	for from_email in from_emails:
-		ids = _screening_message_ids(account, from_email)
-		if ids:
-			set_mails_spam_status(account, ids, spam=True)
+    for from_email in from_emails:
+        ids = _screening_message_ids(account, from_email)
+        if ids:
+            set_mails_spam_status(account, ids, spam=True)
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
 def upload_file():
-	from mimetypes import guess_type
-	from pathlib import Path
+    from mimetypes import guess_type
+    from pathlib import Path
 
-	from frappe import is_whitelisted
-	from frappe.core.doctype.file.utils import get_safe_file_name
-	from frappe.handler import ALLOWED_MIMETYPES, check_write_permission
-	from frappe.utils import cint, get_files_path
-	from frappe.utils.image import optimize_image
+    from frappe import is_whitelisted
+    from frappe.core.doctype.file.utils import get_safe_file_name
+    from frappe.handler import ALLOWED_MIMETYPES, check_write_permission
+    from frappe.utils import cint, get_files_path
+    from frappe.utils.image import optimize_image
 
-	if frappe.session.user == "Guest":
-		if frappe.get_system_settings("allow_guests_to_upload_files"):
-			ignore_permissions = True
-			# Kept in step with frappe.handler.upload_file: the file is saved with
-			# ignore_permissions, so this allowlist is the only thing stopping a guest attaching
-			# to an arbitrary doctype on a site that enables guest uploads.
-			if guest_allowed_docs := frappe.get_system_settings("allowed_doctypes_for_guest_uploads"):
-				target_doctype = frappe.form_dict.doctype
-				allowed_docs = [doc.strip() for doc in guest_allowed_docs.splitlines() if doc.strip()]
-				if allowed_docs and target_doctype not in allowed_docs:
-					frappe.throw(
-						_("Guests are not allowed to upload files for {0} Doctype").format(target_doctype),
-						frappe.PermissionError,
-					)
-		else:
-			raise frappe.PermissionError
-	else:
-		ignore_permissions = False
+    if frappe.session.user == "Guest":
+        if frappe.get_system_settings("allow_guests_to_upload_files"):
+            ignore_permissions = True
+            # Kept in step with frappe.handler.upload_file: the file is saved with
+            # ignore_permissions, so this allowlist is the only thing stopping a guest attaching
+            # to an arbitrary doctype on a site that enables guest uploads.
+            if guest_allowed_docs := frappe.get_system_settings("allowed_doctypes_for_guest_uploads"):
+                target_doctype = frappe.form_dict.doctype
+                allowed_docs = [doc.strip() for doc in guest_allowed_docs.splitlines() if doc.strip()]
+                if allowed_docs and target_doctype not in allowed_docs:
+                    frappe.throw(
+                        _("Guests are not allowed to upload files for {0} Doctype").format(target_doctype),
+                        frappe.PermissionError,
+                    )
+        else:
+            raise frappe.PermissionError
+    else:
+        ignore_permissions = False
 
-	files = frappe.request.files
-	# Default to private, as upstream does. Reading the key directly yields None when it is absent,
-	# which cint()s to 0 and would publish mail attachments to the world-readable files tree.
-	is_private = frappe.form_dict.get("is_private", 1)
-	doctype = frappe.form_dict.doctype
-	docname = frappe.form_dict.docname
-	fieldname = frappe.form_dict.fieldname
-	file_url = frappe.form_dict.file_url
-	folder = frappe.form_dict.folder or "Home"
-	method = frappe.form_dict.method
-	filename = frappe.form_dict.file_name
-	optimize = frappe.form_dict.optimize
-	content = None
+    files = frappe.request.files
+    # Default to private, as upstream does. Reading the key directly yields None when it is absent,
+    # which cint()s to 0 and would publish mail attachments to the world-readable files tree.
+    is_private = frappe.form_dict.get("is_private", 1)
+    doctype = frappe.form_dict.doctype
+    docname = frappe.form_dict.docname
+    fieldname = frappe.form_dict.fieldname
+    file_url = frappe.form_dict.file_url
+    folder = frappe.form_dict.folder or "Home"
+    method = frappe.form_dict.method
+    filename = frappe.form_dict.file_name
+    optimize = frappe.form_dict.optimize
+    content = None
 
-	if library_file := frappe.form_dict.get("library_file_name"):
-		frappe.has_permission("File", doc=library_file, throw=True)
-		doc = frappe.get_value(
-			"File",
-			frappe.form_dict.library_file_name,
-			["is_private", "file_url", "file_name"],
-			as_dict=True,
-		)
-		is_private = doc.is_private
-		file_url = doc.file_url
-		filename = doc.file_name
+    if library_file := frappe.form_dict.get("library_file_name"):
+        frappe.has_permission("File", doc=library_file, throw=True)
+        doc = frappe.get_value(
+            "File",
+            frappe.form_dict.library_file_name,
+            ["is_private", "file_url", "file_name"],
+            as_dict=True,
+        )
+        is_private = doc.is_private
+        file_url = doc.file_url
+        filename = doc.file_name
 
-	if not ignore_permissions:
-		check_write_permission(doctype, docname)
+    if not ignore_permissions:
+        check_write_permission(doctype, docname)
 
-	if "file" in files:
-		file = files["file"]
-		filename = file.filename
+    if "file" in files:
+        file = files["file"]
+        filename = file.filename
 
-		if frappe.form_dict.get("chunk_index") is not None:
-			current_chunk = int(frappe.form_dict.chunk_index)
-			total_chunks = int(frappe.form_dict.total_chunk_count)
-			offset = int(frappe.form_dict.chunk_byte_offset)
-		else:
-			offset = 0
-			current_chunk = 0
-			total_chunks = 1
+        if frappe.form_dict.get("chunk_index") is not None:
+            current_chunk = int(frappe.form_dict.chunk_index)
+            total_chunks = int(frappe.form_dict.total_chunk_count)
+            offset = int(frappe.form_dict.chunk_byte_offset)
+        else:
+            offset = 0
+            current_chunk = 0
+            total_chunks = 1
 
-		temp_path = Path(get_files_path(".temp-" + get_safe_file_name(filename), is_private=is_private))
-		with temp_path.open("ab" if current_chunk > 0 else "wb") as f:
-			total_file_size = frappe.form_dict.total_file_size or 0
-			f.seek(offset)
-			f.write(file.stream.read())
-			if not f.tell() >= int(total_file_size) or current_chunk != total_chunks - 1:
-				return
+        temp_path = Path(get_files_path(".temp-" + get_safe_file_name(filename), is_private=is_private))
+        with temp_path.open("ab" if current_chunk > 0 else "wb") as f:
+            total_file_size = frappe.form_dict.total_file_size or 0
+            f.seek(offset)
+            f.write(file.stream.read())
+            if not f.tell() >= int(total_file_size) or current_chunk != total_chunks - 1:
+                return
 
-		content = temp_path.read_bytes()
-		temp_path.unlink()
-		content_type = guess_type(filename)[0]
-		if optimize and content_type and content_type.startswith("image/"):
-			args = {"content": content, "content_type": content_type}
-			if frappe.form_dict.max_width:
-				args["max_width"] = int(frappe.form_dict.max_width)
-			if frappe.form_dict.max_height:
-				args["max_height"] = int(frappe.form_dict.max_height)
-			content = optimize_image(**args)
+        content = temp_path.read_bytes()
+        temp_path.unlink()
+        content_type = guess_type(filename)[0]
+        if optimize and content_type and content_type.startswith("image/"):
+            args = {"content": content, "content_type": content_type}
+            if frappe.form_dict.max_width:
+                args["max_width"] = int(frappe.form_dict.max_width)
+            if frappe.form_dict.max_height:
+                args["max_height"] = int(frappe.form_dict.max_height)
+            content = optimize_image(**args)
 
-	frappe.local.uploaded_file_url = file_url
-	frappe.local.uploaded_file = content
-	frappe.local.uploaded_filename = filename
+    frappe.local.uploaded_file_url = file_url
+    frappe.local.uploaded_file = content
+    frappe.local.uploaded_filename = filename
 
-	if content is not None and (frappe.session.user == "Guest"):
-		filetype = guess_type(filename)[0]
-		if filetype not in ALLOWED_MIMETYPES:
-			frappe.throw(_("You can only upload JPG, PNG, GIF, PDF, TXT, CSV or Microsoft documents."))
+    if content is not None and (frappe.session.user == "Guest"):
+        filetype = guess_type(filename)[0]
+        if filetype not in ALLOWED_MIMETYPES:
+            frappe.throw(_("You can only upload JPG, PNG, GIF, PDF, TXT, CSV or Microsoft documents."))
 
-	if method:
-		method = frappe.get_attr(method)
-		is_whitelisted(method)
-		return method()
-	else:
-		return frappe.get_doc(
-			{
-				"doctype": "File",
-				"attached_to_doctype": doctype,
-				"attached_to_name": docname,
-				"attached_to_field": fieldname,
-				"folder": folder,
-				"file_name": filename,
-				"file_url": file_url,
-				"is_private": cint(is_private),
-				"content": content,
-			}
-		).save(ignore_permissions=ignore_permissions)
+    if method:
+        method = frappe.get_attr(method)
+        is_whitelisted(method)
+        return method()
+    else:
+        return frappe.get_doc(
+            {
+                "doctype": "File",
+                "attached_to_doctype": doctype,
+                "attached_to_name": docname,
+                "attached_to_field": fieldname,
+                "folder": folder,
+                "file_name": filename,
+                "file_url": file_url,
+                "is_private": cint(is_private),
+                "content": content,
+            }
+        ).save(ignore_permissions=ignore_permissions)

--- a/suite/mail/api/outbound.py
+++ b/suite/mail/api/outbound.py
@@ -11,8 +11,8 @@ from werkzeug.utils import secure_filename
 from suite.mail.api.auth import validate_user
 from suite.mail.doctype.mail_queue.mail_queue import MailQueue
 from suite.mail.doctype.user_account.user_account import (
-	get_user_for_jmap_account,
-	get_user_personal_jmap_account,
+    get_user_for_jmap_account,
+    get_user_personal_jmap_account,
 )
 from suite.mail.utils import get_config, get_messages_directory
 from suite.mail.utils.logger import get_outbound_logger
@@ -22,292 +22,292 @@ from suite.utils.rate_limiter import dynamic_rate_limit
 @frappe.whitelist(methods=["POST"])
 @dynamic_rate_limit()
 def upload_attachment() -> dict:
-	"""Upload an attachment to the Frappe Mail folder."""
+    """Upload an attachment to the Frappe Mail folder."""
 
-	ctx = {
-		"req_id": random_string(10),
-		"ip": frappe.request.remote_addr,
-	}
-	logger = get_outbound_logger(ctx)
+    ctx = {
+        "req_id": random_string(10),
+        "ip": frappe.request.remote_addr,
+    }
+    logger = get_outbound_logger(ctx)
 
-	logger.debug("upload-attachment-started")
-	validate_user()
+    logger.debug("upload-attachment-started")
+    validate_user()
 
-	try:
-		if file := frappe.request.files.get("file"):
-			if not isinstance(file, FileStorage):
-				frappe.throw(_("Invalid file type."))
+    try:
+        if file := frappe.request.files.get("file"):
+            if not isinstance(file, FileStorage):
+                frappe.throw(_("Invalid file type."))
 
-			kwargs = {
-				"dt": None,
-				"dn": None,
-				"is_private": 1,
-				"fname": file.filename,
-				"folder": "Home/Frappe Mail",
-				"content": file.stream.read(),
-			}
-			doc = save_file(**kwargs)
+            kwargs = {
+                "dt": None,
+                "dn": None,
+                "is_private": 1,
+                "fname": file.filename,
+                "folder": "Home/Frappe Mail",
+                "content": file.stream.read(),
+            }
+            doc = save_file(**kwargs)
 
-			return {
-				"file_name": doc.file_name,
-				"file_type": doc.file_type,
-				"file_size": doc.file_size,
-				"file_url": doc.file_url,
-			}
+            return {
+                "file_name": doc.file_name,
+                "file_type": doc.file_type,
+                "file_size": doc.file_size,
+                "file_url": doc.file_url,
+            }
 
-	except frappe.exceptions.ValidationError:
-		raise
+    except frappe.exceptions.ValidationError:
+        raise
 
-	except Exception:
-		logger.exception("upload-attachment-failed")
-		frappe.throw(_("Failed to upload attachment. Please check the error logs for details."))
+    except Exception:
+        logger.exception("upload-attachment-failed")
+        frappe.throw(_("Failed to upload attachment. Please check the error logs for details."))
 
-	frappe.throw(_("No file found in the request."), frappe.MandatoryError)
+    frappe.throw(_("No file found in the request."), frappe.MandatoryError)
 
 
 @frappe.whitelist(methods=["POST"])
 @dynamic_rate_limit()
 def send(
-	from_: str,
-	subject: str,
-	to: str | list[str] | None = None,
-	cc: str | list[str] | None = None,
-	bcc: str | list[str] | None = None,
-	html: str | None = None,
-	text: str | None = None,
-	reply_to: str | list[str] | None = None,
-	in_reply_to: str | None = None,
-	headers: dict | None = None,
-	attachments: list[dict] | None = None,
-	is_newsletter: bool = False,
-	save_as_draft: bool = False,
-	priority: str | None = None,
+    from_: str,
+    subject: str,
+    to: str | list[str] | None = None,
+    cc: str | list[str] | None = None,
+    bcc: str | list[str] | None = None,
+    html: str | None = None,
+    text: str | None = None,
+    reply_to: str | list[str] | None = None,
+    in_reply_to: str | None = None,
+    headers: dict | None = None,
+    attachments: list[dict] | None = None,
+    is_newsletter: bool = False,
+    save_as_draft: bool = False,
+    priority: str | None = None,
 ) -> str:
-	"""Send Mail."""
+    """Send Mail."""
 
-	ctx = {
-		"req_id": random_string(10),
-		"ip": frappe.request.remote_addr,
-	}
-	logger = get_outbound_logger(ctx)
+    ctx = {
+        "req_id": random_string(10),
+        "ip": frappe.request.remote_addr,
+    }
+    logger = get_outbound_logger(ctx)
 
-	logger.debug("send-started", is_newsletter=is_newsletter, save_as_draft=save_as_draft)
-	account = get_user_personal_jmap_account(frappe.session.user, raise_exception=True)
+    logger.debug("send-started", is_newsletter=is_newsletter, save_as_draft=save_as_draft)
+    account = get_user_personal_jmap_account(frappe.session.user, raise_exception=True)
 
-	try:
-		from_name, from_email = parseaddr(from_)
-		doc = MailQueue._create(
-			user=get_user_for_jmap_account(account, raise_exception=True),
-			account=account,
-			from_name=from_name,
-			from_email=from_email,
-			subject=subject,
-			reply_to=format_reply_to(reply_to),
-			headers=headers,
-			recipients=format_recipients(to, cc, bcc),
-			attachments=attachments,
-			html_body=html,
-			text_body=text,
-			via_api=True,
-			newsletter=is_newsletter,
-			priority=priority,
-			in_reply_to=in_reply_to,
-			save_as_draft=save_as_draft,
-			destroy_after_submit=False,
-			delivery_mode="Batch" if is_newsletter else "Enqueue",
-		)
+    try:
+        from_name, from_email = parseaddr(from_)
+        doc = MailQueue._create(
+            user=get_user_for_jmap_account(account, raise_exception=True),
+            account=account,
+            from_name=from_name,
+            from_email=from_email,
+            subject=subject,
+            reply_to=format_reply_to(reply_to),
+            headers=headers,
+            recipients=format_recipients(to, cc, bcc),
+            attachments=attachments,
+            html_body=html,
+            text_body=text,
+            via_api=True,
+            newsletter=is_newsletter,
+            priority=priority,
+            in_reply_to=in_reply_to,
+            save_as_draft=save_as_draft,
+            destroy_after_submit=False,
+            delivery_mode="Batch" if is_newsletter else "Enqueue",
+        )
 
-		return doc.name
+        return doc.name
 
-	except frappe.exceptions.ValidationError:
-		raise
+    except frappe.exceptions.ValidationError:
+        raise
 
-	except Exception:
-		logger.exception("send-failed")
-		frappe.throw(_("Failed to send email. Please check the error logs for details."))
+    except Exception:
+        logger.exception("send-failed")
+        frappe.throw(_("Failed to send email. Please check the error logs for details."))
 
 
 @frappe.whitelist(methods=["POST"])
 @dynamic_rate_limit()
 def send_raw(
-	from_: str,
-	to: str | list[str],
-	raw_message: str | None = None,
-	is_newsletter: bool = False,
-	priority: str | None = None,
+    from_: str,
+    to: str | list[str],
+    raw_message: str | None = None,
+    is_newsletter: bool = False,
+    priority: str | None = None,
 ) -> str:
-	"""Send raw email. Supports both single-shot and chunked upload."""
+    """Send raw email. Supports both single-shot and chunked upload."""
 
-	ctx = {
-		"req_id": random_string(10),
-		"ip": frappe.request.remote_addr,
-	}
-	logger = get_outbound_logger(ctx)
+    ctx = {
+        "req_id": random_string(10),
+        "ip": frappe.request.remote_addr,
+    }
+    logger = get_outbound_logger(ctx)
 
-	logger.debug("send-raw-started", is_newsletter=is_newsletter, has_raw_message=bool(raw_message))
+    logger.debug("send-raw-started", is_newsletter=is_newsletter, has_raw_message=bool(raw_message))
 
-	try:
-		chunk_index = frappe.form_dict.get("chunk_index")
-		total_chunks = frappe.form_dict.get("total_chunk_count")
-		upload_session = frappe.form_dict.get("uuid")
+    try:
+        chunk_index = frappe.form_dict.get("chunk_index")
+        total_chunks = frappe.form_dict.get("total_chunk_count")
+        upload_session = frappe.form_dict.get("uuid")
 
-		if chunk_index is not None and total_chunks is not None and upload_session:
-			return _handle_chunked_upload(
-				from_, to, is_newsletter, int(chunk_index), int(total_chunks), str(upload_session), priority
-			)
+        if chunk_index is not None and total_chunks is not None and upload_session:
+            return _handle_chunked_upload(
+                from_, to, is_newsletter, int(chunk_index), int(total_chunks), str(upload_session), priority
+            )
 
-		raw_message = raw_message or get_message_from_files()
-		if not raw_message:
-			frappe.throw(_("The raw message is required."), frappe.MandatoryError)
+        raw_message = raw_message or get_message_from_files()
+        if not raw_message:
+            frappe.throw(_("The raw message is required."), frappe.MandatoryError)
 
-		max_message_size = _get_max_message_payload_size()
-		if len(raw_message.encode("utf-8")) > max_message_size:
-			frappe.throw(
-				_("The raw message exceeds the maximum allowed size of {0} MB.").format(
-					max_message_size // (1024 * 1024)
-				)
-			)
+        max_message_size = _get_max_message_payload_size()
+        if len(raw_message.encode("utf-8")) > max_message_size:
+            frappe.throw(
+                _("The raw message exceeds the maximum allowed size of {0} MB.").format(
+                    max_message_size // (1024 * 1024)
+                )
+            )
 
-		return _enqueue_mail(from_, to, raw_message, is_newsletter, priority)
+        return _enqueue_mail(from_, to, raw_message, is_newsletter, priority)
 
-	except frappe.exceptions.ValidationError:
-		raise
+    except frappe.exceptions.ValidationError:
+        raise
 
-	except Exception:
-		logger.exception("send-raw-failed")
-		frappe.throw(_("Failed to send raw email. Please check the error logs for details."))
+    except Exception:
+        logger.exception("send-raw-failed")
+        frappe.throw(_("Failed to send raw email. Please check the error logs for details."))
 
 
 def get_message_from_files() -> str | None:
-	"""Extracts message from uploaded file in single upload mode."""
+    """Extracts message from uploaded file in single upload mode."""
 
-	files = frappe._dict(frappe.request.files)
+    files = frappe._dict(frappe.request.files)
 
-	if files and files.get("raw_message"):
-		return files["raw_message"].read().decode("utf-8")
+    if files and files.get("raw_message"):
+        return files["raw_message"].read().decode("utf-8")
 
 
 def format_recipients(
-	to: str | list[str] | None = None, cc: str | list[str] | None = None, bcc: str | list[str] | None = None
+    to: str | list[str] | None = None, cc: str | list[str] | None = None, bcc: str | list[str] | None = None
 ) -> list[dict]:
-	"""Formats the recipients for the mail queue."""
+    """Formats the recipients for the mail queue."""
 
-	recipients = []
+    recipients = []
 
-	if to:
-		recipients.extend(_normalize_recipients(to, "To"))
-	if cc:
-		recipients.extend(_normalize_recipients(cc, "Cc"))
-	if bcc:
-		recipients.extend(_normalize_recipients(bcc, "Bcc"))
+    if to:
+        recipients.extend(_normalize_recipients(to, "To"))
+    if cc:
+        recipients.extend(_normalize_recipients(cc, "Cc"))
+    if bcc:
+        recipients.extend(_normalize_recipients(bcc, "Bcc"))
 
-	return recipients
+    return recipients
 
 
 def format_reply_to(reply_to: str | list[str] | None) -> list[dict]:
-	"""Formats the reply_to field for the mail queue."""
+    """Formats the reply_to field for the mail queue."""
 
-	if not reply_to:
-		return []
-	return _normalize_recipients(reply_to)
+    if not reply_to:
+        return []
+    return _normalize_recipients(reply_to)
 
 
 def _handle_chunked_upload(
-	from_: str,
-	to: str | list[str],
-	is_newsletter: bool,
-	chunk_index: int,
-	total_chunks: int,
-	session_id: str,
-	priority: str | None = None,
+    from_: str,
+    to: str | list[str],
+    is_newsletter: bool,
+    chunk_index: int,
+    total_chunks: int,
+    session_id: str,
+    priority: str | None = None,
 ) -> str:
-	"""Handle chunked uploads for large emails."""
+    """Handle chunked uploads for large emails."""
 
-	file = frappe.request.files.get("raw_message")
-	if not file:
-		frappe.throw(_("No file part named 'raw_message' found."))
+    file = frappe.request.files.get("raw_message")
+    if not file:
+        frappe.throw(_("No file part named 'raw_message' found."))
 
-	upload_dir = get_messages_directory()
-	filename = secure_filename(f"{session_id}.eml")
-	temp_path = os.path.join(upload_dir, filename)
-	offset = int(frappe.form_dict.get("chunk_byte_offset", 0))
+    upload_dir = get_messages_directory()
+    filename = secure_filename(f"{session_id}.eml")
+    temp_path = os.path.join(upload_dir, filename)
+    offset = int(frappe.form_dict.get("chunk_byte_offset", 0))
 
-	with open(temp_path, "ab") as f:
-		f.seek(offset)
-		f.write(file.stream.read())
+    with open(temp_path, "ab") as f:
+        f.seek(offset)
+        f.write(file.stream.read())
 
-	current_size = os.path.getsize(temp_path)
-	max_message_size = _get_max_message_payload_size()
-	if current_size > max_message_size:
-		os.remove(temp_path)
-		frappe.throw(
-			_("The raw message exceeds the maximum allowed size of {0} MB.").format(
-				max_message_size // (1024 * 1024)
-			)
-		)
+    current_size = os.path.getsize(temp_path)
+    max_message_size = _get_max_message_payload_size()
+    if current_size > max_message_size:
+        os.remove(temp_path)
+        frappe.throw(
+            _("The raw message exceeds the maximum allowed size of {0} MB.").format(
+                max_message_size // (1024 * 1024)
+            )
+        )
 
-	if chunk_index < total_chunks - 1:
-		return f"Chunk {chunk_index + 1} of {total_chunks} received."
+    if chunk_index < total_chunks - 1:
+        return f"Chunk {chunk_index + 1} of {total_chunks} received."
 
-	with open(temp_path, "rb") as f:
-		raw_message = f.read().decode("utf-8")
+    with open(temp_path, "rb") as f:
+        raw_message = f.read().decode("utf-8")
 
-	os.remove(temp_path)
+    os.remove(temp_path)
 
-	return _enqueue_mail(from_, to, raw_message, is_newsletter, priority)
+    return _enqueue_mail(from_, to, raw_message, is_newsletter, priority)
 
 
 def _normalize_recipients(
-	recipients: str | list[str] | None, recipient_type: str | None = None
+    recipients: str | list[str] | None, recipient_type: str | None = None
 ) -> list[dict]:
-	"""Helper to normalize recipients into a list of dicts."""
+    """Helper to normalize recipients into a list of dicts."""
 
-	if isinstance(recipients, str):
-		recipients = [recipients]
+    if isinstance(recipients, str):
+        recipients = [recipients]
 
-	result = []
-	for recipient in recipients:
-		name, email = parseaddr(recipient)
-		recipient_dict = {"name": name, "email": email}
-		if recipient_type:
-			recipient_dict["type"] = recipient_type
-		result.append(recipient_dict)
+    result = []
+    for recipient in recipients:
+        name, email = parseaddr(recipient)
+        recipient_dict = {"name": name, "email": email}
+        if recipient_type:
+            recipient_dict["type"] = recipient_type
+        result.append(recipient_dict)
 
-	return result
+    return result
 
 
 def _get_max_message_payload_size() -> int:
-	"""Returns the maximum message payload size from configuration."""
+    """Returns the maximum message payload size from configuration."""
 
-	return cint(get_config("max_message_payload_size_mb")) * 1024 * 1024
+    return cint(get_config("max_message_payload_size_mb")) * 1024 * 1024
 
 
 def _enqueue_mail(
-	from_: str,
-	to: str | list[str],
-	raw_message: str,
-	is_newsletter: bool = False,
-	priority: str | None = None,
+    from_: str,
+    to: str | list[str],
+    raw_message: str,
+    is_newsletter: bool = False,
+    priority: str | None = None,
 ) -> str:
-	"""Enqueue mail in MailQueue."""
+    """Enqueue mail in MailQueue."""
 
-	from_name, from_email = parseaddr(from_)
-	if not raw_message:
-		frappe.throw(_("The raw message is required."), frappe.MandatoryError)
+    from_name, from_email = parseaddr(from_)
+    if not raw_message:
+        frappe.throw(_("The raw message is required."), frappe.MandatoryError)
 
-	account = get_user_personal_jmap_account(frappe.session.user, raise_exception=True)
+    account = get_user_personal_jmap_account(frappe.session.user, raise_exception=True)
 
-	doc = MailQueue._create(
-		user=get_user_for_jmap_account(account, raise_exception=True),
-		account=account,
-		from_name=from_name,
-		from_email=from_email,
-		recipients=format_recipients(to),
-		via_api=True,
-		newsletter=is_newsletter,
-		priority=priority,
-		raw_message=raw_message,
-		delivery_mode="Batch" if is_newsletter else "Enqueue",
-	)
+    doc = MailQueue._create(
+        user=get_user_for_jmap_account(account, raise_exception=True),
+        account=account,
+        from_name=from_name,
+        from_email=from_email,
+        recipients=format_recipients(to),
+        via_api=True,
+        newsletter=is_newsletter,
+        priority=priority,
+        raw_message=raw_message,
+        delivery_mode="Batch" if is_newsletter else "Enqueue",
+    )
 
-	return doc.name
+    return doc.name

--- a/suite/mail/api/sieve.py
+++ b/suite/mail/api/sieve.py
@@ -6,51 +6,51 @@ from suite.mail.doctype.sieve_script.sieve_script import SieveScript, build_auto
 
 @frappe.whitelist()
 def get_sieve_scripts(account: str) -> list[dict]:
-	"""Return the sieve scripts for the account"""
+    """Return the sieve scripts for the account"""
 
-	ids = [d["id"] for d in SieveScript._fetch_sieve_scripts(account)[0]]
-	return SieveScript._get_sieve_scripts(account, ids, True)
+    ids = [d["id"] for d in SieveScript._fetch_sieve_scripts(account)[0]]
+    return SieveScript._get_sieve_scripts(account, ids, True)
 
 
 @frappe.whitelist()
 def create_sieve_script(account: str, _name: str, content: str, active: bool) -> None:
-	"""Create a sieve script for the account"""
+    """Create a sieve script for the account"""
 
-	SieveScript._add_sieve_script(account, _name, content, active)
+    SieveScript._add_sieve_script(account, _name, content, active)
 
 
 @frappe.whitelist()
 def update_sieve_script(account: str, id: str, _name: str, content: str, active: bool = False) -> None:
-	"""Update a sieve script for the account"""
+    """Update a sieve script for the account"""
 
-	SieveScript._update_sieve_script(account, id, _name, content, active)
+    SieveScript._update_sieve_script(account, id, _name, content, active)
 
 
 @frappe.whitelist()
 def delete_sieve_script(account: str, id: str) -> None:
-	"""Delete a sieve script for the account"""
+    """Delete a sieve script for the account"""
 
-	SieveScript._delete_sieve_scripts(account, [id])
+    SieveScript._delete_sieve_scripts(account, [id])
 
 
 @frappe.whitelist()
 def create_automation_script(account: str, active: bool = False) -> None:
-	"""Create (and optionally activate) the frappe_mail_automation sieve script for the account.
+    """Create (and optionally activate) the frappe_mail_automation sieve script for the account.
 
-	Backs the "Enable Folder Automation" action. Delegates to `build_automation_sieve`, which creates
-	the script if it doesn't exist and regenerates all four sections from their persistent backups
-	(Mailbox Settings + Screened Email Address).
-	"""
+    Backs the "Enable Folder Automation" action. Delegates to `build_automation_sieve`, which creates
+    the script if it doesn't exist and regenerates all four sections from their persistent backups
+    (Mailbox Settings + Screened Email Address).
+    """
 
-	build_automation_sieve(account, activate=active)
+    build_automation_sieve(account, activate=active)
 
 
 @frappe.whitelist()
 def rebuild_automation_script_for_account(account: str) -> None:
-	"""Rebuild the frappe_mail_automation script from its backups for the session account.
+    """Rebuild the frappe_mail_automation script from its backups for the session account.
 
-	Backs the manual "Rebuild Automation" action, for when the script was deleted or edited by a
-	third-party client.
-	"""
+    Backs the manual "Rebuild Automation" action, for when the script was deleted or edited by a
+    third-party client.
+    """
 
-	build_automation_sieve(account)
+    build_automation_sieve(account)

--- a/suite/mail/api/spamd.py
+++ b/suite/mail/api/spamd.py
@@ -10,48 +10,48 @@ from suite.utils.rate_limiter import dynamic_rate_limit
 @frappe.whitelist(methods=["POST"])
 @dynamic_rate_limit()
 def scan(message: str | None = None) -> dict:
-	"""Returns the spam score, spamd response and scanning mode of the message"""
+    """Returns the spam score, spamd response and scanning mode of the message"""
 
-	message = message or get_message_from_files()
-	if not message:
-		frappe.throw(_("The message is required."), frappe.MandatoryError)
+    message = message or get_message_from_files()
+    if not message:
+        frappe.throw(_("The message is required."), frappe.MandatoryError)
 
-	message = get_unescaped_message(message)
-	spam_log = create_spam_check_log(message)
-	return {
-		"spam_score": spam_log.spam_score,
-		"spamd_response": spam_log.spamd_response,
-		"scanning_mode": spam_log.scanning_mode,
-	}
+    message = get_unescaped_message(message)
+    spam_log = create_spam_check_log(message)
+    return {
+        "spam_score": spam_log.spam_score,
+        "spamd_response": spam_log.spamd_response,
+        "scanning_mode": spam_log.scanning_mode,
+    }
 
 
 @frappe.whitelist(methods=["POST"])
 @dynamic_rate_limit()
 def get_spam_score(message: str | None = None) -> float:
-	"""Returns the spam score of the message"""
+    """Returns the spam score of the message"""
 
-	message = message or get_message_from_files()
-	if not message:
-		frappe.throw(_("The message is required."), frappe.MandatoryError)
+    message = message or get_message_from_files()
+    if not message:
+        frappe.throw(_("The message is required."), frappe.MandatoryError)
 
-	message = get_unescaped_message(message)
-	spam_log = create_spam_check_log(message)
-	return spam_log.spam_score
+    message = get_unescaped_message(message)
+    spam_log = create_spam_check_log(message)
+    return spam_log.spam_score
 
 
 def get_message_from_files() -> str | None:
-	"""Returns the message from the files"""
+    """Returns the message from the files"""
 
-	files = frappe._dict(frappe.request.files)
+    files = frappe._dict(frappe.request.files)
 
-	if files and files.get("message"):
-		return files["message"].read().decode("utf-8")
+    if files and files.get("message"):
+        return files["message"].read().decode("utf-8")
 
 
 def get_unescaped_message(message: str | bytes) -> str:
-	"""Returns the unescaped message"""
+    """Returns the unescaped message"""
 
-	if isinstance(message, bytes):
-		message = message.decode("utf-8")
+    if isinstance(message, bytes):
+        message = message.decode("utf-8")
 
-	return unescape(message)
+    return unescape(message)

--- a/suite/mail/api/utils.py
+++ b/suite/mail/api/utils.py
@@ -4,13 +4,13 @@ from suite.mail.utils import get_config
 
 
 def get_avatar_url(email: str) -> str | None:
-	"""Returns the Gravatar avatar URL for the given email, or None if Gravatar is disabled.
+    """Returns the Gravatar avatar URL for the given email, or None if Gravatar is disabled.
 
-	Gravatar is a third-party service, so the lookup is opt-in via the "Enable Gravatar" Mail
-	Setting. When disabled, callers fall back to showing initials instead.
-	"""
+    Gravatar is a third-party service, so the lookup is opt-in via the "Enable Gravatar" Mail
+    Setting. When disabled, callers fall back to showing initials instead.
+    """
 
-	if not get_config("enable_gravatar"):
-		return None
+    if not get_config("enable_gravatar"):
+        return None
 
-	return f"/api/method/suite.mail.api.mail.get_avatar?email={quote(email, safe='')}"
+    return f"/api/method/suite.mail.api.mail.get_avatar?email={quote(email, safe='')}"

--- a/suite/mail/doctype/address_book/address_book.py
+++ b/suite/mail/doctype/address_book/address_book.py
@@ -47,7 +47,7 @@ class AddressBook(Document):
         )
         self.name = f"{self.account}|{self.id}"
 
-    def load_from_db(self) -> "AddressBook":
+    def load_from_db(self) -> AddressBook:
         account, id = parse_address_book_name(self.name)
         address_book = get_address_book(account, id)
         return super(Document, self).__init__(address_book)
@@ -286,7 +286,7 @@ def format_address_book(account: str, address_book: dict) -> dict:
     }
 
 
-def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
     if doc.doctype != "Address Book":
         return False
 

--- a/suite/mail/doctype/address_book/address_book.py
+++ b/suite/mail/doctype/address_book/address_book.py
@@ -15,279 +15,279 @@ from suite.utils import parse_filters
 
 
 class AddressBook(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		_name: DF.Data
-		account: DF.Link
-		default: DF.Check
-		description: DF.SmallText | None
-		id: DF.Data | None
-		may_admin: DF.Check
-		may_delete: DF.Check
-		may_read: DF.Check
-		may_write: DF.Check
-		sort_order: DF.Int
-		subscribed: DF.Check
-	# end: auto-generated types
+        _name: DF.Data
+        account: DF.Link
+        default: DF.Check
+        description: DF.SmallText | None
+        id: DF.Data | None
+        may_admin: DF.Check
+        may_delete: DF.Check
+        may_read: DF.Check
+        may_write: DF.Check
+        sort_order: DF.Int
+        subscribed: DF.Check
+    # end: auto-generated types
 
-	def db_insert(self, *args, **kwargs) -> None:
-		self.id = add_address_book(
-			self.account,
-			self._name,
-			self.description,
-			self.sort_order,
-			bool(self.default),
-			bool(self.subscribed),
-		)
-		self.name = f"{self.account}|{self.id}"
+    def db_insert(self, *args, **kwargs) -> None:
+        self.id = add_address_book(
+            self.account,
+            self._name,
+            self.description,
+            self.sort_order,
+            bool(self.default),
+            bool(self.subscribed),
+        )
+        self.name = f"{self.account}|{self.id}"
 
-	def load_from_db(self) -> "AddressBook":
-		account, id = parse_address_book_name(self.name)
-		address_book = get_address_book(account, id)
-		return super(Document, self).__init__(address_book)
+    def load_from_db(self) -> "AddressBook":
+        account, id = parse_address_book_name(self.name)
+        address_book = get_address_book(account, id)
+        return super(Document, self).__init__(address_book)
 
-	def db_update(self) -> None:
-		account, id = parse_address_book_name(self.name)
-		update_address_book(
-			account,
-			id,
-			self._name,
-			self.description,
-			self.sort_order,
-			bool(self.default),
-			bool(self.subscribed),
-		)
-		self.reload()
+    def db_update(self) -> None:
+        account, id = parse_address_book_name(self.name)
+        update_address_book(
+            account,
+            id,
+            self._name,
+            self.description,
+            self.sort_order,
+            bool(self.default),
+            bool(self.subscribed),
+        )
+        self.reload()
 
-	def delete(self) -> None:
-		account, id = parse_address_book_name(self.name)
-		delete_address_books(account, [id])
+    def delete(self) -> None:
+        account, id = parse_address_book_name(self.name)
+        delete_address_books(account, [id])
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs) -> list:
-		filters = parse_filters(filters)
-		id = filters.get("id")
-		account = filters.get("account")
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs) -> list:
+        filters = parse_filters(filters)
+        id = filters.get("id")
+        account = filters.get("account")
 
-		if not account:
-			frappe.msgprint(_("Please select an account to view address books."), alert=True)
-			return []
+        if not account:
+            frappe.msgprint(_("Please select an account to view address books."), alert=True)
+            return []
 
-		address_books = []
-		if id:
-			if address_book := get_address_book(account, id, raise_exception=False):
-				address_books.append(address_book)
-		else:
-			address_books = fetch_address_books(account, limit=page_length)
+        address_books = []
+        if id:
+            if address_book := get_address_book(account, id, raise_exception=False):
+                address_books.append(address_book)
+        else:
+            address_books = fetch_address_books(account, limit=page_length)
 
-		if not address_books:
-			frappe.msgprint(_("No address book found."), alert=True)
+        if not address_books:
+            frappe.msgprint(_("No address book found."), alert=True)
 
-		return address_books
+        return address_books
 
-	@staticmethod
-	def get_count(filters=None, **kwargs) -> int:
-		filters = parse_filters(filters)
-		account = filters.get("account")
+    @staticmethod
+    def get_count(filters=None, **kwargs) -> int:
+        filters = parse_filters(filters)
+        account = filters.get("account")
 
-		if account:
-			if get_user_for_jmap_account(account, raise_exception=False):
-				return cint(frappe.cache.get_value(_get_total_cache_key(account)))
+        if account:
+            if get_user_for_jmap_account(account, raise_exception=False):
+                return cint(frappe.cache.get_value(_get_total_cache_key(account)))
 
-		return 0
+        return 0
 
-	@staticmethod
-	def get_stats(**kwargs) -> dict:
-		return {}
+    @staticmethod
+    def get_stats(**kwargs) -> dict:
+        return {}
 
 
 def parse_address_book_name(name: str) -> tuple[str, str]:
-	"""Splits an Address Book name `account|id` into its bare `account` and `id`."""
+    """Splits an Address Book name `account|id` into its bare `account` and `id`."""
 
-	validate_address_book_name_format(name)
-	account, id = name.split("|")
-	return account, id
+    validate_address_book_name_format(name)
+    account, id = name.split("|")
+    return account, id
 
 
 def validate_address_book_name_format(name: str) -> None:
-	"""Validates that the address book name is in the format 'account|id'."""
+    """Validates that the address book name is in the format 'account|id'."""
 
-	parts = name.split("|")
-	if len(parts) != 2:
-		frappe.throw(_("Address Book name must be in the format 'account|id'."))
+    parts = name.split("|")
+    if len(parts) != 2:
+        frappe.throw(_("Address Book name must be in the format 'account|id'."))
 
 
 def _get_total_cache_key(account: str) -> str:
-	"""Returns a cache key for total address books count for the given account."""
+    """Returns a cache key for total address books count for the given account."""
 
-	return f"{account}:address_books:total"
+    return f"{account}:address_books:total"
 
 
 @frappe.whitelist()
 def bulk_delete(names: str | list[str]) -> None:
-	"""Deletes multiple address books given their names."""
+    """Deletes multiple address books given their names."""
 
-	if isinstance(names, str):
-		names = json.loads(names)
+    if isinstance(names, str):
+        names = json.loads(names)
 
-	accounts_map = {}
-	for name in names:
-		account, id = parse_address_book_name(name)
-		accounts_map.setdefault(account, []).append(id)
+    accounts_map = {}
+    for name in names:
+        account, id = parse_address_book_name(name)
+        accounts_map.setdefault(account, []).append(id)
 
-	for account, ids in accounts_map.items():
-		delete_address_books(account, ids)
+    for account, ids in accounts_map.items():
+        delete_address_books(account, ids)
 
-	frappe.msgprint(_("Address Books deleted successfully."), alert=True)
+    frappe.msgprint(_("Address Books deleted successfully."), alert=True)
 
 
 @frappe.whitelist()
 def add_address_book(
-	account: str,
-	name: str,
-	description: str | None = None,
-	sort_order: int = 0,
-	default: bool = False,
-	subscribed: bool = True,
+    account: str,
+    name: str,
+    description: str | None = None,
+    sort_order: int = 0,
+    default: bool = False,
+    subscribed: bool = True,
 ) -> str:
-	"""Adds a address book for the given account with the specified parameters."""
+    """Adds a address book for the given account with the specified parameters."""
 
-	creation_id = str(uuid7())
-	address_book = {
-		"creation_id": creation_id,
-		"name": name,
-		"description": description,
-		"sort_order": sort_order,
-		"is_default": default,
-		"is_subscribed": subscribed,
-	}
+    creation_id = str(uuid7())
+    address_book = {
+        "creation_id": creation_id,
+        "name": name,
+        "description": description,
+        "sort_order": sort_order,
+        "is_default": default,
+        "is_subscribed": subscribed,
+    }
 
-	service = get_address_book_service(account)
-	response = service.create([address_book])
+    service = get_address_book_service(account)
+    response = service.create([address_book])
 
-	title = _("Address Book Creation Error")
-	if response.get("created"):
-		return response["created"][creation_id]["id"]
-	elif response.get("notCreated"):
-		frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
-	else:
-		frappe.throw(_(response["description"]), title=title)
+    title = _("Address Book Creation Error")
+    if response.get("created"):
+        return response["created"][creation_id]["id"]
+    elif response.get("notCreated"):
+        frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
+    else:
+        frappe.throw(_(response["description"]), title=title)
 
 
 @frappe.whitelist()
 def get_address_book(account: str, id: str, raise_exception: bool = True) -> dict | None:
-	"""Returns address book details for the given account and id."""
+    """Returns address book details for the given account and id."""
 
-	service = get_address_book_service(account)
-	if address_books := service.get([id]):
-		return format_address_book(account, address_books[0])
+    service = get_address_book_service(account)
+    if address_books := service.get([id]):
+        return format_address_book(account, address_books[0])
 
-	if raise_exception:
-		frappe.throw(
-			_("Address Book with ID {0} not found in account {1}.").format(
-				frappe.bold(id), frappe.bold(account)
-			),
-			title=_("Address Book Not Found"),
-		)
+    if raise_exception:
+        frappe.throw(
+            _("Address Book with ID {0} not found in account {1}.").format(
+                frappe.bold(id), frappe.bold(account)
+            ),
+            title=_("Address Book Not Found"),
+        )
 
 
 @frappe.whitelist()
 def update_address_book(
-	account: str,
-	id: str,
-	name: str,
-	description: str | None = None,
-	sort_order: int = 0,
-	default: bool = False,
-	subscribed: bool = True,
+    account: str,
+    id: str,
+    name: str,
+    description: str | None = None,
+    sort_order: int = 0,
+    default: bool = False,
+    subscribed: bool = True,
 ) -> None:
-	"""Updates an existing address book with the given parameters."""
+    """Updates an existing address book with the given parameters."""
 
-	address_book = {
-		"id": id,
-		"name": name,
-		"description": description,
-		"sort_order": sort_order,
-		"is_default": default,
-		"is_subscribed": subscribed,
-	}
+    address_book = {
+        "id": id,
+        "name": name,
+        "description": description,
+        "sort_order": sort_order,
+        "is_default": default,
+        "is_subscribed": subscribed,
+    }
 
-	service = get_address_book_service(account)
-	response = service.update([address_book])
+    service = get_address_book_service(account)
+    response = service.update([address_book])
 
-	title = _("Address Book Update Error")
-	if not response.get("updated"):
-		if response.get("notUpdated"):
-			frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
-		else:
-			frappe.throw(_(response["description"]), title=title)
+    title = _("Address Book Update Error")
+    if not response.get("updated"):
+        if response.get("notUpdated"):
+            frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
+        else:
+            frappe.throw(_(response["description"]), title=title)
 
 
 @frappe.whitelist()
 def delete_address_books(account: str, ids: list[str]) -> None:
-	"""Deletes address books for the given account and list of address book IDs."""
+    """Deletes address books for the given account and list of address book IDs."""
 
-	service = get_address_book_service(account)
-	response = service.delete(ids, remove_contents=True)
+    service = get_address_book_service(account)
+    response = service.delete(ids, remove_contents=True)
 
-	if response.get("notDestroyed"):
-		error_messages = []
-		for id, error in response["notDestroyed"].items():
-			error_messages.append(f"{id}: {error['description']}")
-		frappe.throw(
-			_("Address Book Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
-			title=_("Address Book Deletion Error"),
-		)
+    if response.get("notDestroyed"):
+        error_messages = []
+        for id, error in response["notDestroyed"].items():
+            error_messages.append(f"{id}: {error['description']}")
+        frappe.throw(
+            _("Address Book Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
+            title=_("Address Book Deletion Error"),
+        )
 
 
 @frappe.whitelist()
 def fetch_address_books(account: str, page: int = 1, limit: int = 10) -> list:
-	"""Returns a list of address books for the given account."""
+    """Returns a list of address books for the given account."""
 
-	service = get_address_book_service(account)
-	address_books = service.get()
-	formatted_address_books = [format_address_book(account, book) for book in address_books]
-	sorted_address_books = sorted(formatted_address_books, key=lambda x: x["sort_order"])
-	frappe.cache.set_value(_get_total_cache_key(account), len(address_books), expires_in_sec=600)
+    service = get_address_book_service(account)
+    address_books = service.get()
+    formatted_address_books = [format_address_book(account, book) for book in address_books]
+    sorted_address_books = sorted(formatted_address_books, key=lambda x: x["sort_order"])
+    frappe.cache.set_value(_get_total_cache_key(account), len(address_books), expires_in_sec=600)
 
-	start = (page - 1) * limit
-	end = start + limit
+    start = (page - 1) * limit
+    end = start + limit
 
-	return sorted_address_books[start:end]
+    return sorted_address_books[start:end]
 
 
 def format_address_book(account: str, address_book: dict) -> dict:
-	"""Formats address book data for display."""
+    """Formats address book data for display."""
 
-	sort_order = cint(address_book["sortOrder"])
-	rights = address_book.get("myRights") or {}
+    sort_order = cint(address_book["sortOrder"])
+    rights = address_book.get("myRights") or {}
 
-	return {
-		"name": f"{account}|{address_book['id']}",
-		"account": account,
-		"id": address_book["id"],
-		"_name": address_book["name"],
-		"sort_order": sort_order,
-		"description": address_book["description"],
-		"default": cint(bool(address_book["isDefault"])),
-		"subscribed": cint(bool(address_book["isSubscribed"])),
-		"may_read": cint(rights.get("mayRead", False)),
-		"may_write": cint(rights.get("mayWrite", False)),
-		"may_admin": cint(rights.get("mayAdmin", False)),
-		"may_delete": cint(rights.get("mayDelete", False)),
-		"creation": today(),
-		"modified": today(),
-	}
+    return {
+        "name": f"{account}|{address_book['id']}",
+        "account": account,
+        "id": address_book["id"],
+        "_name": address_book["name"],
+        "sort_order": sort_order,
+        "description": address_book["description"],
+        "default": cint(bool(address_book["isDefault"])),
+        "subscribed": cint(bool(address_book["isSubscribed"])),
+        "may_read": cint(rights.get("mayRead", False)),
+        "may_write": cint(rights.get("mayWrite", False)),
+        "may_admin": cint(rights.get("mayAdmin", False)),
+        "may_delete": cint(rights.get("mayDelete", False)),
+        "creation": today(),
+        "modified": today(),
+    }
 
 
 def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
-	if doc.doctype != "Address Book":
-		return False
+    if doc.doctype != "Address Book":
+        return False
 
-	return bool(get_user_for_jmap_account(doc.account, raise_exception=False))
+    return bool(get_user_for_jmap_account(doc.account, raise_exception=False))

--- a/suite/mail/doctype/address_book/test_address_book.py
+++ b/suite/mail/doctype/address_book/test_address_book.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestAddressBook(IntegrationTestCase):
-	"""
-	Integration tests for AddressBook.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for AddressBook.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/contact_card/contact_card.py
+++ b/suite/mail/doctype/contact_card/contact_card.py
@@ -130,7 +130,7 @@ class ContactCard(Document):
         )
         self.name = f"{self.account}|{self.id}"
 
-    def load_from_db(self) -> "ContactCard":
+    def load_from_db(self) -> ContactCard:
         account, id = parse_contact_card_name(self.name)
         if contact_cards := get_contact_cards(account, [id]):
             return super(Document, self).__init__(contact_cards[0])
@@ -638,7 +638,7 @@ def format_contact_card(account: str, address_book_map: dict, contact_card: dict
     }
 
 
-def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
     if doc.doctype != "Contact Card":
         return False
 

--- a/suite/mail/doctype/contact_card/contact_card.py
+++ b/suite/mail/doctype/contact_card/contact_card.py
@@ -19,627 +19,627 @@ from suite.utils.dt import parse_iso_datetime
 
 
 class ContactCard(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		from suite.mail.doctype.contact_card_address.contact_card_address import ContactCardAddress
-		from suite.mail.doctype.contact_card_address_book.contact_card_address_book import (
-			ContactCardAddressBook,
-		)
-		from suite.mail.doctype.contact_card_email.contact_card_email import ContactCardEmail
-		from suite.mail.doctype.contact_card_phone.contact_card_phone import ContactCardPhone
+        from suite.mail.doctype.contact_card_address.contact_card_address import ContactCardAddress
+        from suite.mail.doctype.contact_card_address_book.contact_card_address_book import (
+            ContactCardAddressBook,
+        )
+        from suite.mail.doctype.contact_card_email.contact_card_email import ContactCardEmail
+        from suite.mail.doctype.contact_card_phone.contact_card_phone import ContactCardPhone
 
-		account: DF.Link
-		address_books: DF.Table[ContactCardAddressBook]
-		addresses: DF.Table[ContactCardAddress]
-		created_at: DF.Data | None
-		email: DF.Data | None
-		emails: DF.Table[ContactCardEmail]
-		full_name: DF.Data | None
-		id: DF.Data | None
-		kind: DF.Data | None
-		name_breakup: DF.JSON | None
-		phone: DF.Data | None
-		phones: DF.Table[ContactCardPhone]
-		uid: DF.Data | None
-		updated_at: DF.Data | None
-	# end: auto-generated types
+        account: DF.Link
+        address_books: DF.Table[ContactCardAddressBook]
+        addresses: DF.Table[ContactCardAddress]
+        created_at: DF.Data | None
+        email: DF.Data | None
+        emails: DF.Table[ContactCardEmail]
+        full_name: DF.Data | None
+        id: DF.Data | None
+        kind: DF.Data | None
+        name_breakup: DF.JSON | None
+        phone: DF.Data | None
+        phones: DF.Table[ContactCardPhone]
+        uid: DF.Data | None
+        updated_at: DF.Data | None
+    # end: auto-generated types
 
-	@property
-	def address_book_ids(self) -> list[str]:
-		"""Returns a list of address book IDs associated with this contact card."""
+    @property
+    def address_book_ids(self) -> list[str]:
+        """Returns a list of address book IDs associated with this contact card."""
 
-		address_book_ids = []
-		for address_book in self.address_books:
-			address_book_id = address_book.get("address_book_id")
-			if not address_book_id:
-				frappe.throw(_("Row #{0}: Address Book ID is required.").format(address_book.idx))
-			address_book_ids.append(address_book_id)
+        address_book_ids = []
+        for address_book in self.address_books:
+            address_book_id = address_book.get("address_book_id")
+            if not address_book_id:
+                frappe.throw(_("Row #{0}: Address Book ID is required.").format(address_book.idx))
+            address_book_ids.append(address_book_id)
 
-		return address_book_ids
+        return address_book_ids
 
-	@property
-	def formatted_emails(self) -> list[dict] | None:
-		"""Returns emails in the format required by JMAP API."""
+    @property
+    def formatted_emails(self) -> list[dict] | None:
+        """Returns emails in the format required by JMAP API."""
 
-		if self.emails:
-			emails = []
-			for email in self.emails:
-				emails.append(
-					{
-						"type": email.type,
-						"label": email.label,
-						"address": email.address,
-					}
-				)
+        if self.emails:
+            emails = []
+            for email in self.emails:
+                emails.append(
+                    {
+                        "type": email.type,
+                        "label": email.label,
+                        "address": email.address,
+                    }
+                )
 
-			return emails
+            return emails
 
-	@property
-	def formatted_phones(self) -> list[dict] | None:
-		"""Returns phones in the format required by JMAP API."""
+    @property
+    def formatted_phones(self) -> list[dict] | None:
+        """Returns phones in the format required by JMAP API."""
 
-		if self.phones:
-			phones = []
-			for phone in self.phones:
-				phones.append(
-					{
-						"type": phone.type,
-						"label": phone.label,
-						"number": phone.number,
-					}
-				)
+        if self.phones:
+            phones = []
+            for phone in self.phones:
+                phones.append(
+                    {
+                        "type": phone.type,
+                        "label": phone.label,
+                        "number": phone.number,
+                    }
+                )
 
-			return phones
+            return phones
 
-	@property
-	def formatted_addresses(self) -> list[dict] | None:
-		"""Returns addresses in the format required by JMAP API."""
+    @property
+    def formatted_addresses(self) -> list[dict] | None:
+        """Returns addresses in the format required by JMAP API."""
 
-		if self.addresses:
-			addresses = []
-			for address in self.addresses:
-				addresses.append(
-					{
-						"type": address.type,
-						"street": address.street,
-						"locality": address.locality,
-						"region": address.region,
-						"country": address.country,
-						"postcode": address.postcode,
-						"time_zone": address.time_zone,
-					}
-				)
+        if self.addresses:
+            addresses = []
+            for address in self.addresses:
+                addresses.append(
+                    {
+                        "type": address.type,
+                        "street": address.street,
+                        "locality": address.locality,
+                        "region": address.region,
+                        "country": address.country,
+                        "postcode": address.postcode,
+                        "time_zone": address.time_zone,
+                    }
+                )
 
-			return addresses
+            return addresses
 
-	def db_insert(self, *args, **kwargs) -> None:
-		self.id = add_contact_card(
-			self.account,
-			self.address_book_ids,
-			self.full_name,
-			self.formatted_emails,
-			self.formatted_phones,
-			self.formatted_addresses,
-			self.kind,
-		)
-		self.name = f"{self.account}|{self.id}"
+    def db_insert(self, *args, **kwargs) -> None:
+        self.id = add_contact_card(
+            self.account,
+            self.address_book_ids,
+            self.full_name,
+            self.formatted_emails,
+            self.formatted_phones,
+            self.formatted_addresses,
+            self.kind,
+        )
+        self.name = f"{self.account}|{self.id}"
 
-	def load_from_db(self) -> "ContactCard":
-		account, id = parse_contact_card_name(self.name)
-		if contact_cards := get_contact_cards(account, [id]):
-			return super(Document, self).__init__(contact_cards[0])
+    def load_from_db(self) -> "ContactCard":
+        account, id = parse_contact_card_name(self.name)
+        if contact_cards := get_contact_cards(account, [id]):
+            return super(Document, self).__init__(contact_cards[0])
 
-		frappe.throw(
-			_("Contact Card with ID {0} not found in account {1}.").format(
-				frappe.bold(id), frappe.bold(account)
-			),
-			title=_("Contact Card Not Found"),
-		)
+        frappe.throw(
+            _("Contact Card with ID {0} not found in account {1}.").format(
+                frappe.bold(id), frappe.bold(account)
+            ),
+            title=_("Contact Card Not Found"),
+        )
 
-	def db_update(self) -> None:
-		account, id = parse_contact_card_name(self.name)
-		update_contact_card(
-			account,
-			id,
-			self.address_book_ids,
-			self.full_name,
-			self.formatted_emails,
-			self.formatted_phones,
-			self.formatted_addresses,
-			self.kind,
-		)
-		self.reload()
+    def db_update(self) -> None:
+        account, id = parse_contact_card_name(self.name)
+        update_contact_card(
+            account,
+            id,
+            self.address_book_ids,
+            self.full_name,
+            self.formatted_emails,
+            self.formatted_phones,
+            self.formatted_addresses,
+            self.kind,
+        )
+        self.reload()
 
-	def delete(self) -> None:
-		account, id = parse_contact_card_name(self.name)
-		delete_contact_cards(account, [id])
+    def delete(self) -> None:
+        account, id = parse_contact_card_name(self.name)
+        delete_contact_cards(account, [id])
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs) -> list:
-		filters = parse_filters(filters)
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs) -> list:
+        filters = parse_filters(filters)
 
-		id = filters.get("id")
-		account = filters.get("account")
+        id = filters.get("id")
+        account = filters.get("account")
 
-		if not account:
-			frappe.msgprint(_("Please select an account to view contact cards."), alert=True)
-			return []
+        if not account:
+            frappe.msgprint(_("Please select an account to view contact cards."), alert=True)
+            return []
 
-		if id:
-			contact_cards = get_contact_cards(account, [id])
-			total = len(contact_cards)
-		else:
-			if address_book := filters.get("address_book"):
-				validate_address_book_name_format(address_book)
-				filters["address_book"] = address_book.split("|")[1]
+        if id:
+            contact_cards = get_contact_cards(account, [id])
+            total = len(contact_cards)
+        else:
+            if address_book := filters.get("address_book"):
+                validate_address_book_name_format(address_book)
+                filters["address_book"] = address_book.split("|")[1]
 
-			filter = {
-				prop: value
-				for field, prop in {
-					"address_book": "inAddressBook",
-					"full_name": "name",
-					"email": "email",
-					"phone": "phone",
-				}.items()
-				if (value := filters.get(field))
-			}
-			limit = cint(kwargs.get("start")) + page_length
-			contact_cards, total = fetch_contact_cards(account, filter, limit=limit)
+            filter = {
+                prop: value
+                for field, prop in {
+                    "address_book": "inAddressBook",
+                    "full_name": "name",
+                    "email": "email",
+                    "phone": "phone",
+                }.items()
+                if (value := filters.get(field))
+            }
+            limit = cint(kwargs.get("start")) + page_length
+            contact_cards, total = fetch_contact_cards(account, filter, limit=limit)
 
-		frappe.cache.set_value(_get_total_cache_key(account), total, expires_in_sec=600)
+        frappe.cache.set_value(_get_total_cache_key(account), total, expires_in_sec=600)
 
-		if not contact_cards:
-			frappe.msgprint(_("No contact card found."), alert=True)
+        if not contact_cards:
+            frappe.msgprint(_("No contact card found."), alert=True)
 
-		return contact_cards
+        return contact_cards
 
-	@staticmethod
-	def get_count(filters=None, **kwargs) -> int:
-		filters = parse_filters(filters)
-		account = filters.get("account")
+    @staticmethod
+    def get_count(filters=None, **kwargs) -> int:
+        filters = parse_filters(filters)
+        account = filters.get("account")
 
-		if account:
-			if get_user_for_jmap_account(account, raise_exception=False):
-				return cint(frappe.cache.get_value(_get_total_cache_key(account)))
+        if account:
+            if get_user_for_jmap_account(account, raise_exception=False):
+                return cint(frappe.cache.get_value(_get_total_cache_key(account)))
 
-		return 0
+        return 0
 
-	@staticmethod
-	def get_stats(**kwargs) -> dict:
-		return {}
+    @staticmethod
+    def get_stats(**kwargs) -> dict:
+        return {}
 
-	def validate(self) -> None:
-		self.validate_address_books()
+    def validate(self) -> None:
+        self.validate_address_books()
 
-	def validate_address_books(self) -> None:
-		"""Validates that at least one address book is associated with the contact card."""
+    def validate_address_books(self) -> None:
+        """Validates that at least one address book is associated with the contact card."""
 
-		if not self.address_books:
-			frappe.throw(_("A contact card must belong to at least one address book."))
+        if not self.address_books:
+            frappe.throw(_("A contact card must belong to at least one address book."))
 
-		for ab in self.address_books:
-			validate_address_book_name_format(ab.address_book)
-			ab.address_book_id = ab.address_book.split("|")[1]
+        for ab in self.address_books:
+            validate_address_book_name_format(ab.address_book)
+            ab.address_book_id = ab.address_book.split("|")[1]
 
 
 def parse_contact_card_name(name: str) -> tuple[str, str]:
-	"""Splits a Contact Card name `account|id` into its bare `account` and `id`."""
+    """Splits a Contact Card name `account|id` into its bare `account` and `id`."""
 
-	account, id = name.split("|")
-	return account, id
+    account, id = name.split("|")
+    return account, id
 
 
 @frappe.whitelist()
 def bulk_delete(names: str | list[str]) -> None:
-	"""Delete multiple Contact Cards based on their names."""
+    """Delete multiple Contact Cards based on their names."""
 
-	if isinstance(names, str):
-		names = json.loads(names)
+    if isinstance(names, str):
+        names = json.loads(names)
 
-	accounts_map = {}
-	for name in names:
-		account, id = parse_contact_card_name(name)
-		accounts_map.setdefault(account, []).append(id)
+    accounts_map = {}
+    for name in names:
+        account, id = parse_contact_card_name(name)
+        accounts_map.setdefault(account, []).append(id)
 
-	for account, ids in accounts_map.items():
-		delete_contact_cards(account, ids)
+    for account, ids in accounts_map.items():
+        delete_contact_cards(account, ids)
 
-	frappe.msgprint(_("Contact Cards deleted successfully."), alert=True)
+    frappe.msgprint(_("Contact Cards deleted successfully."), alert=True)
 
 
 @frappe.whitelist()
 def add_contact_card(
-	account: str,
-	address_book_ids: list[str],
-	full_name: str | None = None,
-	emails: list[dict] | None = None,
-	phones: list[dict] | None = None,
-	addresses: list[dict] | None = None,
-	kind: str | None = None,
+    account: str,
+    address_book_ids: list[str],
+    full_name: str | None = None,
+    emails: list[dict] | None = None,
+    phones: list[dict] | None = None,
+    addresses: list[dict] | None = None,
+    kind: str | None = None,
 ) -> str:
-	"""Adds a contact card for the given account with the specified parameters."""
+    """Adds a contact card for the given account with the specified parameters."""
 
-	creation_id = str(uuid7())
-	contact_card = {
-		"creation_id": creation_id,
-		"address_book_ids": address_book_ids,
-		"full_name": full_name,
-		"emails": emails,
-		"phones": phones,
-		"addresses": addresses,
-		"kind": kind or "individual",
-	}
+    creation_id = str(uuid7())
+    contact_card = {
+        "creation_id": creation_id,
+        "address_book_ids": address_book_ids,
+        "full_name": full_name,
+        "emails": emails,
+        "phones": phones,
+        "addresses": addresses,
+        "kind": kind or "individual",
+    }
 
-	service = get_contact_card_service(account)
-	response = service.create([contact_card])
+    service = get_contact_card_service(account)
+    response = service.create([contact_card])
 
-	title = _("Contact Card Creation Error")
-	if response.get("created"):
-		return response["created"][creation_id]["id"]
-	elif response.get("notCreated"):
-		frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
-	else:
-		frappe.throw(_(response["description"]), title=title)
+    title = _("Contact Card Creation Error")
+    if response.get("created"):
+        return response["created"][creation_id]["id"]
+    elif response.get("notCreated"):
+        frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
+    else:
+        frappe.throw(_(response["description"]), title=title)
 
 
 @frappe.whitelist()
 def bulk_add_contact_cards(account: str, contact_cards: list[dict], raise_exception: bool = True) -> None:
-	"""Adds multiple contact cards for the given account and returns their IDs."""
+    """Adds multiple contact cards for the given account and returns their IDs."""
 
-	service = get_contact_card_service(account)
+    service = get_contact_card_service(account)
 
-	for card in contact_cards:
-		if not card.get("creation_id"):
-			card["creation_id"] = str(uuid7())
+    for card in contact_cards:
+        if not card.get("creation_id"):
+            card["creation_id"] = str(uuid7())
 
-	response = service.create(contact_cards)
+    response = service.create(contact_cards)
 
-	title = _("Contact Card Creation Error")
-	if response.get("notCreated"):
-		if raise_exception:
-			frappe.throw(_("One or more contact cards failed to create"), title=title)
+    title = _("Contact Card Creation Error")
+    if response.get("notCreated"):
+        if raise_exception:
+            frappe.throw(_("One or more contact cards failed to create"), title=title)
 
 
 @frappe.whitelist()
 def fetch_contact_cards(
-	account: str,
-	filter: dict | None = None,
-	position: int = 0,
-	limit: int = 50,
-	sort: list[dict] | None = None,
+    account: str,
+    filter: dict | None = None,
+    position: int = 0,
+    limit: int = 50,
+    sort: list[dict] | None = None,
 ) -> tuple[list[dict], int]:
-	"""Returns a list of contact cards and total count based on the provided filter."""
+    """Returns a list of contact cards and total count based on the provided filter."""
 
-	contact_cards = []
-	service = get_contact_card_service(account)
-	data = service.query(filter, position, limit, sort)
+    contact_cards = []
+    service = get_contact_card_service(account)
+    data = service.query(filter, position, limit, sort)
 
-	ids = data.get("ids", [])
-	total = data.get("total", 0)
+    ids = data.get("ids", [])
+    total = data.get("total", 0)
 
-	contact_cards.extend(get_contact_cards(account, ids))
+    contact_cards.extend(get_contact_cards(account, ids))
 
-	return contact_cards[:limit], total
+    return contact_cards[:limit], total
 
 
 @frappe.whitelist()
 def get_contact_cards(account: str, ids: list[str]) -> list[dict]:
-	"""Returns a list of contact cards for the provided IDs in the same order as ids."""
+    """Returns a list of contact cards for the provided IDs in the same order as ids."""
 
-	# Ownership has to be settled before the cache is read, not just before the fetch: the only
-	# check used to sit inside the "ids_to_fetch" branch, so a request whose ids were all cached
-	# returned another account's contacts without ever being authorized.
-	get_user_for_jmap_account(account, raise_exception=True)
+    # Ownership has to be settled before the cache is read, not just before the fetch: the only
+    # check used to sit inside the "ids_to_fetch" branch, so a request whose ids were all cached
+    # returned another account's contacts without ever being authorized.
+    get_user_for_jmap_account(account, raise_exception=True)
 
-	cached_contact_cards = _get_cached_contact_cards(account, ids)
+    cached_contact_cards = _get_cached_contact_cards(account, ids)
 
-	contact_cards = {}
-	ids_to_fetch = []
-	for id in ids:
-		if cached_contact_card := cached_contact_cards.get(id):
-			contact_cards[id] = cached_contact_card
-		else:
-			ids_to_fetch.append(id)
+    contact_cards = {}
+    ids_to_fetch = []
+    for id in ids:
+        if cached_contact_card := cached_contact_cards.get(id):
+            contact_cards[id] = cached_contact_card
+        else:
+            ids_to_fetch.append(id)
 
-	if ids_to_fetch:
-		service = get_contact_card_service(account)
-		cards = service.get(ids_to_fetch)
-		address_book_map = {ab["id"]: ab["name"] for ab in service.address_books}
+    if ids_to_fetch:
+        service = get_contact_card_service(account)
+        cards = service.get(ids_to_fetch)
+        address_book_map = {ab["id"]: ab["name"] for ab in service.address_books}
 
-		contact_cards_to_cache = {}
-		for card in cards:
-			contact_card = format_contact_card(account, address_book_map, card)
-			contact_cards_to_cache[contact_card["id"]] = contact_card
-			contact_cards[contact_card["id"]] = contact_card
+        contact_cards_to_cache = {}
+        for card in cards:
+            contact_card = format_contact_card(account, address_book_map, card)
+            contact_cards_to_cache[contact_card["id"]] = contact_card
+            contact_cards[contact_card["id"]] = contact_card
 
-		if contact_cards_to_cache:
-			_cache_contact_cards(account, contact_cards_to_cache)
+        if contact_cards_to_cache:
+            _cache_contact_cards(account, contact_cards_to_cache)
 
-	return [contact_cards[id] for id in ids if id in contact_cards]
+    return [contact_cards[id] for id in ids if id in contact_cards]
 
 
 @frappe.whitelist()
 def update_contact_card(
-	account: str,
-	id: str,
-	address_book_ids: list[str],
-	full_name: str | None = None,
-	emails: list[dict] | None = None,
-	phones: list[dict] | None = None,
-	addresses: list[dict] | None = None,
-	kind: str | None = None,
+    account: str,
+    id: str,
+    address_book_ids: list[str],
+    full_name: str | None = None,
+    emails: list[dict] | None = None,
+    phones: list[dict] | None = None,
+    addresses: list[dict] | None = None,
+    kind: str | None = None,
 ) -> None:
-	"""Updates an existing contact card with the given parameters."""
+    """Updates an existing contact card with the given parameters."""
 
-	contact_card = {
-		"id": id,
-		"address_book_ids": address_book_ids,
-		"full_name": full_name,
-		"emails": emails,
-		"phones": phones,
-		"addresses": addresses,
-		"kind": kind or "individual",
-	}
+    contact_card = {
+        "id": id,
+        "address_book_ids": address_book_ids,
+        "full_name": full_name,
+        "emails": emails,
+        "phones": phones,
+        "addresses": addresses,
+        "kind": kind or "individual",
+    }
 
-	service = get_contact_card_service(account)
-	response = service.update([contact_card])
+    service = get_contact_card_service(account)
+    response = service.update([contact_card])
 
-	title = _("Contact Card Update Error")
-	if not response.get("updated"):
-		if response.get("notUpdated"):
-			frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
-		else:
-			frappe.throw(_(response["description"]), title=title)
+    title = _("Contact Card Update Error")
+    if not response.get("updated"):
+        if response.get("notUpdated"):
+            frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
+        else:
+            frappe.throw(_(response["description"]), title=title)
 
-	_remove_cached_contact_cards(account, [id])
+    _remove_cached_contact_cards(account, [id])
 
 
 def contact_card_update_address_books(
-	account: str,
-	ids: list[str],
-	add_address_book_id: str | None = None,
-	remove_address_book_id: str | None = None,
-	move_to_address_book_id: str | None = None,
+    account: str,
+    ids: list[str],
+    add_address_book_id: str | None = None,
+    remove_address_book_id: str | None = None,
+    move_to_address_book_id: str | None = None,
 ) -> None:
-	"""
-	Updates addressBookIds for the provided contact cards.
+    """
+    Updates addressBookIds for the provided contact cards.
 
-	Behavior:
-	- add_address_book_id: adds the contact to an address book
-	- remove_address_book_id: removes the contact from an address book
-	- add + remove: moves contact between address books (patch-based)
-	- move_to_address_book_id: replaces addressBookIds entirely
-	"""
+    Behavior:
+    - add_address_book_id: adds the contact to an address book
+    - remove_address_book_id: removes the contact from an address book
+    - add + remove: moves contact between address books (patch-based)
+    - move_to_address_book_id: replaces addressBookIds entirely
+    """
 
-	service = get_contact_card_service(account)
-	response = service.update_address_book_ids(
-		ids, add_address_book_id, remove_address_book_id, move_to_address_book_id
-	)
+    service = get_contact_card_service(account)
+    response = service.update_address_book_ids(
+        ids, add_address_book_id, remove_address_book_id, move_to_address_book_id
+    )
 
-	title = _("Contact Card Update Error")
-	if not response.get("updated"):
-		if response.get("notUpdated"):
-			frappe.throw(_(response["notUpdated"][ids[0]]["description"]), title=title)
-		else:
-			frappe.throw(_(response["description"]), title=title)
+    title = _("Contact Card Update Error")
+    if not response.get("updated"):
+        if response.get("notUpdated"):
+            frappe.throw(_(response["notUpdated"][ids[0]]["description"]), title=title)
+        else:
+            frappe.throw(_(response["description"]), title=title)
 
-	_remove_cached_contact_cards(account, ids)
+    _remove_cached_contact_cards(account, ids)
 
 
 @frappe.whitelist()
 def contact_card_add_to_address_book(account: str, ids: list[str], address_book_id: str) -> None:
-	"""Adds the provided contact cards to an address book."""
+    """Adds the provided contact cards to an address book."""
 
-	return contact_card_update_address_books(account, ids, add_address_book_id=address_book_id)
+    return contact_card_update_address_books(account, ids, add_address_book_id=address_book_id)
 
 
 @frappe.whitelist()
 def contact_card_remove_from_address_book(
-	account: str,
-	ids: list[str],
-	address_book_id: str,
+    account: str,
+    ids: list[str],
+    address_book_id: str,
 ) -> None:
-	"""Removes the provided contact cards from an address book."""
+    """Removes the provided contact cards from an address book."""
 
-	return contact_card_update_address_books(account, ids, remove_address_book_id=address_book_id)
+    return contact_card_update_address_books(account, ids, remove_address_book_id=address_book_id)
 
 
 @frappe.whitelist()
 def contact_card_move_between_address_books(
-	account: str, ids: list[str], from_address_book_id: str, to_address_book_id: str
+    account: str, ids: list[str], from_address_book_id: str, to_address_book_id: str
 ) -> None:
-	"""Moves contact cards from one address book to another."""
+    """Moves contact cards from one address book to another."""
 
-	return contact_card_update_address_books(
-		account,
-		ids,
-		add_address_book_id=to_address_book_id,
-		remove_address_book_id=from_address_book_id,
-	)
+    return contact_card_update_address_books(
+        account,
+        ids,
+        add_address_book_id=to_address_book_id,
+        remove_address_book_id=from_address_book_id,
+    )
 
 
 @frappe.whitelist()
 def contact_card_move_to_address_book(
-	account: str,
-	ids: list[str],
-	address_book_id: str,
+    account: str,
+    ids: list[str],
+    address_book_id: str,
 ) -> None:
-	"""Moves contact cards to the given address book, replacing all others."""
+    """Moves contact cards to the given address book, replacing all others."""
 
-	return contact_card_update_address_books(account, ids, move_to_address_book_id=address_book_id)
+    return contact_card_update_address_books(account, ids, move_to_address_book_id=address_book_id)
 
 
 @frappe.whitelist()
 def delete_contact_cards(account: str, ids: list[str]) -> None:
-	"""Deletes contact cards for the given account by its IDs."""
+    """Deletes contact cards for the given account by its IDs."""
 
-	service = get_contact_card_service(account)
-	service.delete(ids)
-	_remove_cached_contact_cards(account, ids)
+    service = get_contact_card_service(account)
+    service.delete(ids)
+    _remove_cached_contact_cards(account, ids)
 
 
 def _get_total_cache_key(account: str) -> str:
-	"""Returns a cache key for total contact cards count for the given account."""
+    """Returns a cache key for total contact cards count for the given account."""
 
-	return f"{account}:contact_cards:total"
+    return f"{account}:contact_cards:total"
 
 
 def _get_cached_contact_cards(account: str, ids: list[str]) -> dict[str, dict | None]:
-	"""Returns a dictionary of cached contact cards for the given account and IDs."""
+    """Returns a dictionary of cached contact cards for the given account and IDs."""
 
-	store = get_data_store(account)
-	return store.get_many(Entity.CONTACT_CARD, keys=ids)
+    store = get_data_store(account)
+    return store.get_many(Entity.CONTACT_CARD, keys=ids)
 
 
 def _cache_contact_cards(account: str, contact_cards: dict[str, dict]) -> None:
-	"""Caches contact cards for the given account, and indexes their addresses for search."""
+    """Caches contact cards for the given account, and indexes their addresses for search."""
 
-	store = get_data_store(account)
-	store.set_many(Entity.CONTACT_CARD, items=contact_cards)
+    store = get_data_store(account)
+    store.set_many(Entity.CONTACT_CARD, items=contact_cards)
 
-	# Feed contact addresses into the shared address index; never let indexing break caching.
-	try:
-		get_email_address_index(account).index_addresses(_contact_addresses(contact_cards.values()))
-	except Exception:
-		log_mail_error(
-			_("Failed to index contact addresses for search"), frappe.get_traceback(with_context=True)
-		)
+    # Feed contact addresses into the shared address index; never let indexing break caching.
+    try:
+        get_email_address_index(account).index_addresses(_contact_addresses(contact_cards.values()))
+    except Exception:
+        log_mail_error(
+            _("Failed to index contact addresses for search"), frappe.get_traceback(with_context=True)
+        )
 
 
 def _remove_cached_contact_cards(account: str, ids: list[str]) -> None:
-	"""Removes cached contact cards for the given account and IDs.
+    """Removes cached contact cards for the given account and IDs.
 
-	Addresses are left in the search index on purpose: it is cumulative, and an address from a
-	removed contact is almost always still valid elsewhere.
-	"""
+    Addresses are left in the search index on purpose: it is cumulative, and an address from a
+    removed contact is almost always still valid elsewhere.
+    """
 
-	store = get_data_store(account)
-	store.delete_many(Entity.CONTACT_CARD, keys=ids)
+    store = get_data_store(account)
+    store.delete_many(Entity.CONTACT_CARD, keys=ids)
 
 
 def _contact_addresses(contact_cards: list[dict]) -> list[dict]:
-	"""Flatten cached contact cards into {name, email} address dicts, one per email address."""
+    """Flatten cached contact cards into {name, email} address dicts, one per email address."""
 
-	addresses = []
-	for contact_card in contact_cards:
-		name = contact_card.get("full_name")
-		for email in contact_card.get("emails") or []:
-			addresses.append({"name": name, "email": email.get("address")})
+    addresses = []
+    for contact_card in contact_cards:
+        name = contact_card.get("full_name")
+        for email in contact_card.get("emails") or []:
+            addresses.append({"name": name, "email": email.get("address")})
 
-	return addresses
+    return addresses
 
 
 def format_contact_card(account: str, address_book_map: dict, contact_card: dict) -> dict:
-	"""Formats contact card data for display."""
+    """Formats contact card data for display."""
 
-	full_name = None
-	if contact_name := contact_card.get("name"):
-		if components := contact_name.get("components"):
-			if contact_name.get("full"):
-				full_name = contact_name["full"]
-			elif contact_name.get("isOrdered", False):
-				full_name = " ".join([component["value"] for component in components])
-			else:
-				given = next(
-					(component["value"] for component in components if component["kind"] == "given"),
-					"",
-				)
-				surname = next(
-					(component["value"] for component in components if component["kind"] == "surname"),
-					"",
-				)
-				full_name = f"{given} {surname}".strip()
+    full_name = None
+    if contact_name := contact_card.get("name"):
+        if components := contact_name.get("components"):
+            if contact_name.get("full"):
+                full_name = contact_name["full"]
+            elif contact_name.get("isOrdered", False):
+                full_name = " ".join([component["value"] for component in components])
+            else:
+                given = next(
+                    (component["value"] for component in components if component["kind"] == "given"),
+                    "",
+                )
+                surname = next(
+                    (component["value"] for component in components if component["kind"] == "surname"),
+                    "",
+                )
+                full_name = f"{given} {surname}".strip()
 
-	address_books = []
-	for address_book_id in contact_card["addressBookIds"].keys():
-		address_books.append(
-			{
-				"address_book": f"{account}|{address_book_id}",
-				"address_book_id": address_book_id,
-				"address_book_name": address_book_map.get(address_book_id),
-			}
-		)
+    address_books = []
+    for address_book_id in contact_card["addressBookIds"].keys():
+        address_books.append(
+            {
+                "address_book": f"{account}|{address_book_id}",
+                "address_book_id": address_book_id,
+                "address_book_name": address_book_map.get(address_book_id),
+            }
+        )
 
-	emails = []
-	for email in contact_card.get("emails", {}).values():
-		address = email.get("address")
-		contexts = email.get("contexts", {})
-		type = next(context for context in contexts.keys()) if contexts else None
-		emails.append(
-			{
-				"type": type,
-				"address": address,
-				"label": email.get("label"),
-				"contexts": json.dumps(contexts, indent=4),
-			}
-		)
+    emails = []
+    for email in contact_card.get("emails", {}).values():
+        address = email.get("address")
+        contexts = email.get("contexts", {})
+        type = next(context for context in contexts.keys()) if contexts else None
+        emails.append(
+            {
+                "type": type,
+                "address": address,
+                "label": email.get("label"),
+                "contexts": json.dumps(contexts, indent=4),
+            }
+        )
 
-	phones = []
-	for phone in contact_card.get("phones", {}).values():
-		number = phone.get("number")
-		contexts = phone.get("contexts", {})
-		type = next(context for context in contexts.keys()) if contexts else None
-		phones.append(
-			{
-				"type": type,
-				"number": number,
-				"label": phone.get("label"),
-				"contexts": json.dumps(contexts, indent=4),
-			}
-		)
+    phones = []
+    for phone in contact_card.get("phones", {}).values():
+        number = phone.get("number")
+        contexts = phone.get("contexts", {})
+        type = next(context for context in contexts.keys()) if contexts else None
+        phones.append(
+            {
+                "type": type,
+                "number": number,
+                "label": phone.get("label"),
+                "contexts": json.dumps(contexts, indent=4),
+            }
+        )
 
-	addresses = []
-	for address in contact_card.get("addresses", {}).values():
-		time_zone = address.get("timeZone")
-		contexts = address.get("contexts", {})
-		component_map = {c["kind"]: c["value"] for c in address.get("components", [])}
+    addresses = []
+    for address in contact_card.get("addresses", {}).values():
+        time_zone = address.get("timeZone")
+        contexts = address.get("contexts", {})
+        component_map = {c["kind"]: c["value"] for c in address.get("components", [])}
 
-		addresses.append(
-			{
-				"type": next(iter(contexts), None),
-				"street": component_map.get("name"),
-				"locality": component_map.get("locality"),
-				"region": component_map.get("region"),
-				"postcode": component_map.get("postcode"),
-				"country": component_map.get("country"),
-				"time_zone": time_zone,
-				"contexts": json.dumps(contexts, indent=4),
-			}
-		)
+        addresses.append(
+            {
+                "type": next(iter(contexts), None),
+                "street": component_map.get("name"),
+                "locality": component_map.get("locality"),
+                "region": component_map.get("region"),
+                "postcode": component_map.get("postcode"),
+                "country": component_map.get("country"),
+                "time_zone": time_zone,
+                "contexts": json.dumps(contexts, indent=4),
+            }
+        )
 
-	creation = modified = None
-	if contact_card.get("created"):
-		creation = parse_iso_datetime(contact_card["created"], as_str=True)
-	if contact_card.get("updated"):
-		modified = parse_iso_datetime(contact_card["updated"], as_str=True)
+    creation = modified = None
+    if contact_card.get("created"):
+        creation = parse_iso_datetime(contact_card["created"], as_str=True)
+    if contact_card.get("updated"):
+        modified = parse_iso_datetime(contact_card["updated"], as_str=True)
 
-	return {
-		"name": f"{account}|{contact_card['id']}",
-		"account": account,
-		"id": contact_card["id"],
-		"uid": contact_card.get("uid"),
-		"kind": contact_card.get("kind"),
-		"name_breakup": json.dumps(contact_card.get("name", {}), indent=4),
-		"full_name": full_name,
-		"address_books": address_books,
-		"emails": emails,
-		"phones": phones,
-		"addresses": addresses,
-		"created_at": contact_card.get("created"),
-		"updated_at": contact_card.get("updated"),
-		"creation": creation or modified or today(),
-		"modified": modified or creation or today(),
-	}
+    return {
+        "name": f"{account}|{contact_card['id']}",
+        "account": account,
+        "id": contact_card["id"],
+        "uid": contact_card.get("uid"),
+        "kind": contact_card.get("kind"),
+        "name_breakup": json.dumps(contact_card.get("name", {}), indent=4),
+        "full_name": full_name,
+        "address_books": address_books,
+        "emails": emails,
+        "phones": phones,
+        "addresses": addresses,
+        "created_at": contact_card.get("created"),
+        "updated_at": contact_card.get("updated"),
+        "creation": creation or modified or today(),
+        "modified": modified or creation or today(),
+    }
 
 
 def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
-	if doc.doctype != "Contact Card":
-		return False
+    if doc.doctype != "Contact Card":
+        return False
 
-	return bool(get_user_for_jmap_account(doc.account, raise_exception=False))
+    return bool(get_user_for_jmap_account(doc.account, raise_exception=False))

--- a/suite/mail/doctype/contact_card/test_contact_card.py
+++ b/suite/mail/doctype/contact_card/test_contact_card.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestContactCard(IntegrationTestCase):
-	"""
-	Integration tests for ContactCard.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for ContactCard.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/contact_card_address/contact_card_address.py
+++ b/suite/mail/doctype/contact_card_address/contact_card_address.py
@@ -6,26 +6,26 @@ from frappe.model.document import Document
 
 
 class ContactCardAddress(Document):
-	def db_insert(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_insert(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def load_from_db(self):
-		raise NotImplementedError
+    def load_from_db(self):
+        raise NotImplementedError
 
-	def db_update(self):
-		raise NotImplementedError
+    def db_update(self):
+        raise NotImplementedError
 
-	def delete(self):
-		raise NotImplementedError
+    def delete(self):
+        raise NotImplementedError
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs):
-		pass
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs):
+        pass
 
-	@staticmethod
-	def get_count(filters=None, **kwargs):
-		pass
+    @staticmethod
+    def get_count(filters=None, **kwargs):
+        pass
 
-	@staticmethod
-	def get_stats(**kwargs):
-		pass
+    @staticmethod
+    def get_stats(**kwargs):
+        pass

--- a/suite/mail/doctype/contact_card_address_book/contact_card_address_book.py
+++ b/suite/mail/doctype/contact_card_address_book/contact_card_address_book.py
@@ -6,26 +6,26 @@ from frappe.model.document import Document
 
 
 class ContactCardAddressBook(Document):
-	def db_insert(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_insert(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def load_from_db(self):
-		raise NotImplementedError
+    def load_from_db(self):
+        raise NotImplementedError
 
-	def db_update(self):
-		raise NotImplementedError
+    def db_update(self):
+        raise NotImplementedError
 
-	def delete(self):
-		raise NotImplementedError
+    def delete(self):
+        raise NotImplementedError
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs):
-		pass
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs):
+        pass
 
-	@staticmethod
-	def get_count(filters=None, **kwargs):
-		pass
+    @staticmethod
+    def get_count(filters=None, **kwargs):
+        pass
 
-	@staticmethod
-	def get_stats(**kwargs):
-		pass
+    @staticmethod
+    def get_stats(**kwargs):
+        pass

--- a/suite/mail/doctype/contact_card_email/contact_card_email.py
+++ b/suite/mail/doctype/contact_card_email/contact_card_email.py
@@ -6,26 +6,26 @@ from frappe.model.document import Document
 
 
 class ContactCardEmail(Document):
-	def db_insert(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_insert(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def load_from_db(self):
-		raise NotImplementedError
+    def load_from_db(self):
+        raise NotImplementedError
 
-	def db_update(self):
-		raise NotImplementedError
+    def db_update(self):
+        raise NotImplementedError
 
-	def delete(self):
-		raise NotImplementedError
+    def delete(self):
+        raise NotImplementedError
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs):
-		pass
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs):
+        pass
 
-	@staticmethod
-	def get_count(filters=None, **kwargs):
-		pass
+    @staticmethod
+    def get_count(filters=None, **kwargs):
+        pass
 
-	@staticmethod
-	def get_stats(**kwargs):
-		pass
+    @staticmethod
+    def get_stats(**kwargs):
+        pass

--- a/suite/mail/doctype/contact_card_phone/contact_card_phone.py
+++ b/suite/mail/doctype/contact_card_phone/contact_card_phone.py
@@ -6,26 +6,26 @@ from frappe.model.document import Document
 
 
 class ContactCardPhone(Document):
-	def db_insert(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_insert(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def load_from_db(self):
-		raise NotImplementedError
+    def load_from_db(self):
+        raise NotImplementedError
 
-	def db_update(self):
-		raise NotImplementedError
+    def db_update(self):
+        raise NotImplementedError
 
-	def delete(self):
-		raise NotImplementedError
+    def delete(self):
+        raise NotImplementedError
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs):
-		pass
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs):
+        pass
 
-	@staticmethod
-	def get_count(filters=None, **kwargs):
-		pass
+    @staticmethod
+    def get_count(filters=None, **kwargs):
+        pass
 
-	@staticmethod
-	def get_stats(**kwargs):
-		pass
+    @staticmethod
+    def get_stats(**kwargs):
+        pass

--- a/suite/mail/doctype/contacts_exchange/contacts_exchange.py
+++ b/suite/mail/doctype/contacts_exchange/contacts_exchange.py
@@ -12,35 +12,35 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder import Order
 from frappe.utils import (
-	add_to_date,
-	cint,
-	create_batch,
-	get_bench_path,
-	get_datetime,
-	get_files_path,
-	get_url,
-	now,
-	random_string,
-	time_diff_in_seconds,
+    add_to_date,
+    cint,
+    create_batch,
+    get_bench_path,
+    get_datetime,
+    get_files_path,
+    get_url,
+    now,
+    random_string,
+    time_diff_in_seconds,
 )
 
 from suite.mail.doctype.push_subscription.push_subscription import (
-	freeze_jmap_push_notifications,
-	unfreeze_jmap_push_notifications,
+    freeze_jmap_push_notifications,
+    unfreeze_jmap_push_notifications,
 )
 from suite.mail.doctype.user_account.user_account import is_jmap_account_belongs_to_user
 from suite.mail.jmap import get_jmap_connection
 from suite.mail.jmap.services.contacts.address_book import AddressBookService
 from suite.mail.jmap.services.contacts.contact_card import ContactCardService
 from suite.mail.utils import (
-	get_config,
-	get_contacts_export_directory,
-	get_contacts_import_directory,
+    get_config,
+    get_contacts_export_directory,
+    get_contacts_import_directory,
 )
 from suite.mail.utils.logger import ExchangeLogger, get_exchange_logger
 from suite.mail.utils.user import (
-	get_user_email_address,
-	is_jmap_configured,
+    get_user_email_address,
+    is_jmap_configured,
 )
 from suite.utils import log_error, reconnect_on_failure
 from suite.utils.file import compress_directory, extract_compressed_file
@@ -55,831 +55,831 @@ N_COMPONENT_ORDER = ("surname", "given", "given2", "title", "generation")
 # otherwise the JMAP server rejects the "set" call with invalidProperties. "vCard" is the raw
 # source echoed back by ContactCard/parse, not a settable Card property.
 SERVER_MANAGED_KEYS = (
-	"id",
-	"blobId",
-	"vCard",
+    "id",
+    "blobId",
+    "vCard",
 )
 
 
 class ContactsExchange(OwnerFromUser, Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
-
-	from typing import TYPE_CHECKING
-
-	if TYPE_CHECKING:
-		from frappe.types import DF
-
-		account: DF.Link
-		amended_from: DF.Link | None
-		completed_at: DF.Datetime | None
-		deduplicate_export: DF.Check
-		duration: DF.Float
-		export_archive_type: DF.Literal[".zip", ".tgz", ".tar.gz"]
-		export_filter: DF.JSON | None
-		export_format: DF.Literal["jmap", "vcf"]
-		export_limit: DF.Int
-		import_file: DF.Attach | None
-		import_format: DF.Literal["vcf", "jmap"]
-		import_metadata: DF.JSON | None
-		operation: DF.Literal["", "Import", "Export"]
-		output: DF.Code | None
-		queued_at: DF.Datetime | None
-		retries: DF.Int
-		started_after: DF.Float
-		started_at: DF.Datetime | None
-		status: DF.Literal["Draft", "Queued", "In Progress", "Completed", "Failed", "Cancelled"]
-		user: DF.Link
-	# end: auto-generated types
-
-	@property
-	def max_import(self) -> int:
-		"""Returns the maximum number of contacts allowed for import."""
-
-		return cint(get_config("exchange_max_import"))
-
-	@property
-	def max_export(self) -> int:
-		"""Returns the maximum number of contacts allowed for export."""
-
-		return cint(get_config("exchange_max_export"))
-
-	@property
-	def export_filter_dict(self) -> dict:
-		"""Returns the export filter as a dictionary."""
-
-		if self.operation == "Export" and self.export_filter:
-			return json.loads(self.export_filter)
-		return {}
-
-	@property
-	def import_metadata_dict(self) -> dict:
-		"""Return the import metadata as a dictionary."""
-
-		if self.operation != "Import" or not self.import_metadata:
-			return {}
-
-		return json.loads(self.import_metadata)
-
-	@property
-	def target_address_book_ids(self) -> dict[str, bool] | None:
-		"""Returns the target address book IDs for import, if specified."""
-
-		return self.import_metadata_dict.get("addressBookIds")
-
-	def autoname(self) -> None:
-		self.name = str(uuid7())
-
-	def validate(self) -> None:
-		if self.is_new():
-			self.validate_account()
-
-		if self.operation == "Import":
-			self.validate_import()
-		elif self.operation == "Export":
-			self.validate_export()
-
-	def before_submit(self) -> None:
-		self.status = "Queued"
-		self.queued_at = now()
-
-	def on_submit(self) -> None:
-		self.process()
-
-	def before_cancel(self) -> None:
-		self.status = "Cancelled"
-
-	def validate_account(self) -> None:
-		"""Validate that the selected user can authenticate and has access to the account."""
-
-		if not is_jmap_configured(self.user):
-			frappe.throw(
-				_("User {0} does not have JMAP settings configured.").format(frappe.bold(self.user)),
-				frappe.PermissionError,
-			)
-
-		is_jmap_account_belongs_to_user(self.account, self.user, raise_exception=True)
-
-	def validate_import(self) -> None:
-		"""Validate the import parameters."""
-
-		if not self.import_format:
-			frappe.throw(_("Import Format is required."))
-		if not self.import_file:
-			frappe.throw(_("Import File is required."))
-
-		allowed_extensions = (".vcf", ".zip", ".tgz", ".tar.gz")
-		if not self.import_file.endswith(allowed_extensions):
-			frappe.throw(
-				_("Only {0} files are supported for import.").format(
-					", ".join(f"<code>{ext}</code>" for ext in allowed_extensions)
-				)
-			)
-
-		# Reject early any import_file that resolves outside the site's uploads (path traversal).
-		self._resolve_import_file()
-
-		if self.import_metadata:
-			try:
-				self.import_metadata = json.dumps(json.loads(self.import_metadata), indent=4)
-			except json.JSONDecodeError:
-				frappe.throw(_("Metadata must be valid JSON."))
-
-	def _resolve_import_file(self) -> str:
-		"""Resolves ``import_file`` to an absolute path, refusing anything outside the site's files
-		directories.
-
-		``import_file`` is an ``Attach`` URL (e.g. ``/private/files/contacts.vcf``) that the worker
-		joins onto the site path before copying/extracting it. Without this guard a crafted value
-		such as ``/private/files/../../../etc/passwd`` would let the job read a file anywhere on the
-		filesystem, so we canonicalize the path and confirm it stays within the uploads area."""
-
-		path = os.path.realpath(
-			os.path.join(get_bench_path(), f"sites/{frappe.local.site}{self.import_file}")
-		)
-		allowed_roots = (
-			os.path.realpath(get_files_path(is_private=1)),
-			os.path.realpath(get_files_path(is_private=0)),
-		)
-		if not any(path == root or path.startswith(root + os.sep) for root in allowed_roots):
-			frappe.throw(_("Invalid import file path."))
-
-		return path
-
-	def validate_export(self) -> None:
-		"""Validate the export parameters."""
-
-		if self.export_filter:
-			try:
-				self.export_filter = json.dumps(json.loads(self.export_filter), indent=4)
-			except json.JSONDecodeError:
-				frappe.throw(_("Export filter must be valid JSON."))
-
-		if not self.export_archive_type:
-			frappe.throw(_("Archive Type is required."))
-
-		if self.export_limit:
-			export_limit = cint(self.export_limit)
-			if export_limit <= 0:
-				frappe.throw(_("Export Limit must be greater than zero."))
-			if export_limit > self.max_export:
-				frappe.throw(_("Export Limit cannot exceed {0}.").format(self.max_export))
-			self.export_limit = export_limit
-		else:
-			self.export_limit = self.max_export
-
-	def _get_logger(self) -> ExchangeLogger:
-		"""Returns a structured event logger bound to this exchange's context."""
-
-		return get_exchange_logger(
-			{
-				"req_id": random_string(10),
-				"exchange": self.name,
-				"kind": "contacts",
-				"operation": self.operation,
-				"user": self.user,
-				"account": self.account,
-			}
-		)
-
-	def process(self) -> None:
-		"""Enqueue the import or export based on the operation type."""
-
-		logger = self._get_logger()
-
-		if self.operation == "Import":
-			job_id = f"{self.name}:contacts:import"
-			frappe.enqueue_doc(
-				self.doctype,
-				self.name,
-				"_import",
-				queue="long",
-				timeout=cint(get_config("exchange_import_timeout")),
-				job_id=job_id,
-				deduplicate=True,
-				enqueue_after_commit=True,
-			)
-			logger.debug("import-enqueued", job_id=job_id, format=self.import_format)
-		elif self.operation == "Export":
-			job_id = f"{self.name}:contacts:export"
-			frappe.enqueue_doc(
-				self.doctype,
-				self.name,
-				"_export",
-				queue="long",
-				timeout=cint(get_config("exchange_export_timeout")),
-				job_id=job_id,
-				deduplicate=True,
-				enqueue_after_commit=True,
-			)
-			logger.debug("export-enqueued", job_id=job_id, format=self.export_format)
-
-	@frappe.whitelist()
-	def retry(self) -> None:
-		"""Retry the import or export."""
-
-		frappe.only_for("System Manager")
-
-		self._get_logger().info("retry-requested", status=self.status, retries=cint(self.retries))
-
-		if self.docstatus != 1:
-			frappe.throw(_("Only submitted contacts exchange can be retried."))
-		elif self.status not in ["Queued", "In Progress", "Failed"]:
-			frappe.throw(
-				_("Only contacts exchange with status 'Queued', 'In Progress', or 'Failed' can be retried.")
-			)
-
-		if self.operation == "Export":
-			if files := frappe.db.get_all(
-				"File",
-				{
-					"attached_to_doctype": self.doctype,
-					"attached_to_name": self.name,
-					"attached_to_field": "file",
-				},
-				pluck="name",
-			):
-				for file in files:
-					frappe.delete_doc("File", file)
-
-		self._db_set(status="Queued", queued_at=now())
-		self.process()
-
-	@reconnect_on_failure()
-	def _import(self) -> None:
-		"""Imports the contact cards."""
-
-		if self.operation != "Import":
-			return
-
-		logger = self._get_logger()
-		logger.info("import-started", format=self.import_format, import_file=self.import_file)
-
-		freeze_jmap_push_notifications(self.user)
-		self._mark_started()
-		self._log_output(_("Starting import from the uploaded {0} file.").format(self.import_format.upper()))
-
-		import_file = self._resolve_import_file()
-		base_dir = os.path.join(get_contacts_import_directory(), self.name)
-		os.makedirs(base_dir, exist_ok=True)
-
-		kwargs = {}
-		service = None
-		staging_address_book_id = None
-		try:
-			if self.import_format == "vcf" and self.import_file.endswith(".vcf"):
-				shutil.copy(import_file, os.path.join(base_dir, os.path.basename(import_file)))
-			else:
-				extract_compressed_file(import_file, base_dir)
-			logger.debug("import-source-prepared", base_dir=base_dir)
-			self._log_output(_("Prepared the source files for import."))
-
-			service = get_contact_card_service(self.user, self.account)
-			self._validate_target_address_books(service)
-
-			if self.import_format == "vcf":
-				cards = self._load_vcf_cards(service, base_dir, logger)
-			else:
-				cards = self._load_jmap_cards(base_dir)
-
-			logger.info("import-cards-loaded", cards=len(cards), max_import=self.max_import)
-			self._log_output(_("Found {0} contact(s) to import.").format(len(cards)))
-
-			if not cards:
-				frappe.throw(_("No contacts found for import."))
-			if len(cards) > self.max_import:
-				frappe.throw(_("Import limit exceeded."))
-
-			# Stage everything into one throwaway address book first, then move it to the destination
-			# address book(s). A failure before the move leaves nothing scattered across the account: the
-			# staging address book and every card in it are deleted on rollback.
-			staging_address_book_id = self._create_staging_address_book(service, logger)
-			targets, skipped, failed = self._create_cards(service, cards, staging_address_book_id, logger)
-
-			# The server rejecting every card (e.g. an invalid target address book) is a failure,
-			# not a successful zero-import.
-			if not targets and failed > 0:
-				frappe.throw(_("Import failed: the server rejected all {0} contact(s).").format(failed))
-
-			self._move_to_target_address_books(service, targets, logger)
-			self._discard_staging_address_book(service, staging_address_book_id, logger)
-			staging_address_book_id = None
-
-			created = len(targets)
-			logger.info("import-completed", created=created, skipped=skipped, failed=failed)
-			self._log_output(
-				_("Import completed. {0} created, {1} skipped (already present), {2} failed.").format(
-					created, skipped, failed
-				)
-			)
-			kwargs.update({"status": "Completed"})
-		except Exception:
-			logger.exception("import-failed")
-			self._log_output(_("Import failed. See the error details below."))
-			if staging_address_book_id and service:
-				self._rollback_staging_address_book(service, staging_address_book_id, logger)
-			kwargs.update(
-				{"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
-			)
-		finally:
-			shutil.rmtree(base_dir, ignore_errors=True)
-			unfreeze_jmap_push_notifications(self.user)
-
-		self._mark_completed(**kwargs)
-		self._notify_user(success=kwargs.get("status") == "Completed", action="Import")
-
-	@reconnect_on_failure()
-	def _export(self) -> None:
-		"""Exports the contact cards."""
-
-		if self.operation != "Export":
-			return
-
-		logger = self._get_logger()
-		logger.info("export-started", format=self.export_format, archive_type=self.export_archive_type)
-
-		self._mark_started()
-		self._log_output(_("Starting export to {0} format.").format(self.export_format.upper()))
-		out_dir = os.path.join(get_contacts_export_directory(), self.name)
-		os.makedirs(out_dir, exist_ok=True)
-
-		kwargs = {}
-		try:
-			service = get_contact_card_service(self.user, self.account)
-
-			limit = min(self.max_export, cint(self.export_limit or self.max_export))
-			data = service.query(self.export_filter_dict, limit=limit)
-			ids = data.get("ids", [])
-			total = data.get("total")
-			logger.info("export-query-resolved", total=total, fetched=len(ids), max_export=self.max_export)
-			self._log_output(
-				_("Found {0} contact(s) matching the filter; exporting up to {1}.").format(
-					total if total is not None else len(ids), len(ids)
-				)
-			)
-
-			if not ids:
-				frappe.throw(_("No contacts found for export."))
-
-			cards = service.get(ids)
-
-			if self.deduplicate_export:
-				fetched = len(cards)
-				unique: dict[str, dict] = {}
-				for c in cards:
-					key = c.get("uid") or c.get("id")
-					if key not in unique:
-						unique[key] = c
-				cards = list(unique.values())
-				logger.debug("export-deduplicated", fetched=fetched, unique=len(cards))
-				self._log_output(
-					_("Removed {0} duplicate(s); {1} unique contact(s) remain.").format(
-						fetched - len(cards), len(cards)
-					)
-				)
-
-			# Only include address books actually referenced by the exported cards, so a filtered
-			# export doesn't leak the account's other address books into addressbooks.json.
-			referenced_ids = {book_id for card in cards for book_id in (card.get("addressBookIds") or {})}
-			address_book_map = {
-				b["id"]: b["name"] for b in service.address_books if b["id"] in referenced_ids
-			}
-			ContactsExportWriter.write(self.export_format, cards, out_dir, address_book_map)
-			self._log_output(_("Wrote {0} contact(s) to the export directory.").format(len(cards)))
-
-			self._log_output(
-				_("Packaging exported contacts into a {0} archive.").format(self.export_archive_type)
-			)
-			self._attach_export(out_dir)
-
-			logger.info("export-completed", cards=len(cards))
-			self._log_output(_("Export completed successfully. {0} contact(s) exported.").format(len(cards)))
-			kwargs.update({"status": "Completed"})
-		except Exception:
-			logger.exception("export-failed")
-			self._log_output(_("Export failed. See the error details below."))
-			kwargs.update(
-				{"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
-			)
-		finally:
-			shutil.rmtree(out_dir, ignore_errors=True)
-
-		self._mark_completed(**kwargs)
-		self._notify_user(success=kwargs.get("status") == "Completed", action="Export")
-
-	def _load_vcf_cards(
-		self, service: ContactCardService, base_dir: str, logger: ExchangeLogger
-	) -> list[dict]:
-		"""Splits the uploaded .vcf file(s) into individual vCards and converts them to JSContact.
-
-		``ContactCard/parse`` returns a single Card per blob (the first vCard it finds), so a file
-		holding many contacts must be split into one blob per vCard for all of them to be imported.
-		Falls back to a local parser for any vCard the server can't parse, or for the whole set if
-		the server does not implement ``ContactCard/parse``."""
-
-		vcf_files = [
-			os.path.join(root, f)
-			for root, _dirs, files in os.walk(base_dir)
-			for f in files
-			if f.lower().endswith(".vcf")
-		]
-		if not vcf_files:
-			frappe.throw(_("No .vcf files found."))
-
-		vcards: list[str] = []
-		for path in vcf_files:
-			vcards.extend(_split_vcards(_read_text(path)))
-		if not vcards:
-			frappe.throw(_("No vCards found in the uploaded file(s)."))
-		# Reject early, before uploading a blob per vCard, if the file already exceeds the limit.
-		if len(vcards) > self.max_import:
-			frappe.throw(_("Import limit exceeded."))
-
-		cards: list[dict] = []
-		try:
-			# One blob per vCard so the server parses (and returns) every contact, not just the first.
-			uploads = service.upload_blobs_concurrently(
-				[(vcard.encode("utf-8"), "text/vcard; charset=utf-8") for vcard in vcards]
-			)
-			blob_to_vcard: dict[str, str] = {}
-			for vcard, upload in zip(vcards, uploads, strict=False):
-				if blob_id := (upload or {}).get("blobId"):
-					blob_to_vcard[blob_id] = vcard
-
-			response = service.parse(list(blob_to_vcard.keys()))
-
-			for value in (response.get("parsed") or {}).values():
-				if isinstance(value, list):
-					cards.extend(card for card in value if card)
-				elif value:
-					cards.append(value)
-
-			# Anything the server couldn't parse gets a second chance through the local parser.
-			unparsed = list((response.get("notParsable") or {}).keys()) + list(
-				(response.get("notFound") or {}).keys()
-			)
-			for blob_id in unparsed:
-				if vcard := blob_to_vcard.get(blob_id):
-					cards.extend(parse_vcards(vcard))
-			if unparsed:
-				logger.warning("import-vcf-not-parsable", count=len(unparsed))
-				self._log_output(_("{0} vCard(s) were parsed locally as a fallback.").format(len(unparsed)))
-		except Exception:
-			# The JMAP server does not support ContactCard/parse; parse every vCard locally instead.
-			logger.warning("import-vcf-parse-unsupported")
-			self._log_output(_("Server-side parsing is unavailable; parsing vCards locally."))
-			cards = []
-			for vcard in vcards:
-				cards.extend(parse_vcards(vcard))
-
-		return cards
-
-	def _validate_target_address_books(self, service: ContactCardService) -> None:
-		"""Validates that the client-supplied target address book(s) exist in this account.
-
-		``target_address_book_ids`` comes from the import metadata and is passed straight to
-		``ContactCard/set``. A deleted or foreign book would make the server reject every card, so
-		fail fast with a clear error instead of silently completing with zero imports."""
-
-		target = self.target_address_book_ids
-		if not target:
-			return
-
-		known = {book["id"] for book in service.address_books}
-		if invalid := [book_id for book_id in target if book_id not in known]:
-			frappe.throw(
-				_("Target address book(s) not found in this account: {0}").format(", ".join(invalid))
-			)
-
-	def _load_jmap_cards(self, base_dir: str) -> list[dict]:
-		"""Loads JSContact cards from the cards.json file in the import directory."""
-
-		path = os.path.join(base_dir, "cards.json")
-		if not os.path.exists(path):
-			frappe.throw(_("cards.json not found in the import directory."))
-
-		with open(path) as f:
-			cards = json.load(f)
-
-		if not isinstance(cards, list):
-			frappe.throw(_("cards.json must contain a list of contact cards."))
-
-		return cards
-
-	def _create_staging_address_book(self, service: ContactCardService, logger: ExchangeLogger) -> str:
-		"""Creates a temporary address book (named after this exchange) to stage the import into."""
-
-		self._log_output(_("Creating a temporary address book to stage the import."))
-		response = AddressBookService(service.account, service.connection).create(
-			[{"creation_id": str(uuid7()), "name": self.name, "is_subscribed": False}]
-		)
-		created = response.get("created") or {}
-		if not created:
-			frappe.throw(
-				_("Failed to create the staging address book: {0}").format(response.get("notCreated"))
-			)
-
-		staging_address_book_id = next(iter(created.values()))["id"]
-		logger.info("import-staging-address-book-created", address_book=staging_address_book_id)
-		return staging_address_book_id
-
-	def _create_cards(
-		self,
-		service: ContactCardService,
-		cards: list[dict],
-		staging_address_book_id: str,
-		logger: ExchangeLogger,
-	) -> tuple[dict[str, dict[str, bool]], int, int]:
-		"""Creates the given JSContact cards in the staging address book, skipping any whose UID already
-		exists (idempotency).
-
-		Returns a ``(targets, skipped, failed)`` tuple, where ``targets`` maps each created card's ID to
-		the destination addressBookIds it should ultimately land in. Failures within a batch are recorded
-		and the remaining batches continue, so a few malformed cards do not abort the whole import."""
-
-		# Idempotency: skip cards whose UID is already present in the account.
-		uids = [c["uid"] for c in cards if c.get("uid")]
-		existing_uids: set[str] = set()
-		if uids:
-			if existing_ids := service.get_master_ids(uids):
-				existing_uids = {c["uid"] for c in service.get(existing_ids) if c.get("uid")}
-
-		default_address_book_id: str | None = None
-
-		def resolve_address_book_ids(card: dict) -> dict:
-			nonlocal default_address_book_id
-
-			if self.target_address_book_ids:
-				return self.target_address_book_ids
-			if card.get("addressBookIds"):
-				return card["addressBookIds"]
-			if default_address_book_id is None:
-				default_address_book_id = AddressBookService(service.account, service.connection).get_default(
-					raise_exception=True
-				)
-			return {default_address_book_id: True}
-
-		pending: list[dict] = []
-		skipped = 0
-		for card in cards:
-			if card.get("uid") and card["uid"] in existing_uids:
-				skipped += 1
-				continue
-			pending.append(card)
-
-		targets: dict[str, dict[str, bool]] = {}
-		failed = 0
-		total = len(pending)
-		for batch in create_batch(pending, service.max_objects_in_set):
-			payload: dict[str, dict] = {}
-			creation_meta: dict[str, tuple[str, dict]] = {}
-			for card in batch:
-				# Resolve the destination before overwriting addressBookIds with the staging book.
-				destination = resolve_address_book_ids(card)
-				card = {k: v for k, v in card.items() if k not in SERVER_MANAGED_KEYS}
-				card["@type"] = "Card"
-				card.setdefault("version", "1.0")
-				card["addressBookIds"] = {staging_address_book_id: True}
-
-				creation_id = str(uuid7())
-				payload[creation_id] = card
-				creation_meta[creation_id] = (card.get("uid", creation_id), destination)
-
-			response = service._create(payload)
-			method_responses = response.get("methodResponses") or []
-			result = method_responses[0][1] if method_responses else {}
-
-			batch_failed = result.get("notCreated") or {}
-			failed += len(batch_failed)
-
-			for creation_id, info in (result.get("created") or {}).items():
-				targets[info["id"]] = creation_meta[creation_id][1]
-
-			for creation_id, error in batch_failed.items():
-				logger.warning(
-					"import-card-not-created",
-					uid=creation_meta.get(creation_id, (None,))[0],
-					reason=str(error),
-				)
-
-			self._log_output(_("Staged {0} of {1} contact(s).").format(len(targets), total))
-
-		return targets, skipped, failed
-
-	def _move_to_target_address_books(
-		self, service: ContactCardService, targets: dict[str, dict[str, bool]], logger: ExchangeLogger
-	) -> None:
-		"""Moves the staged cards into their destination address books, replacing the staging book.
-
-		This is the commit step: until it runs, every card lives only in the staging address book, so a
-		failure up to this point rolls back cleanly."""
-
-		if not targets:
-			return
-
-		self._log_output(
-			_("Moving {0} contact(s) into the destination address book(s).").format(len(targets))
-		)
-		result = service.set_address_book_ids(targets)
-
-		if not_updated := result.get("notUpdated"):
-			logger.warning("import-card-not-moved", count=len(not_updated))
-			frappe.throw(
-				_("Failed to move {0} contact(s) into the destination address book(s).").format(
-					len(not_updated)
-				)
-			)
-
-		logger.info("import-cards-moved", cards=len(result.get("updated", [])))
-
-	def _discard_staging_address_book(
-		self, service: ContactCardService, staging_address_book_id: str, logger: ExchangeLogger
-	) -> None:
-		"""Deletes the now-empty staging address book after a successful import. A failure here is logged
-		but not fatal: the cards are already safely in their destination address books."""
-
-		try:
-			AddressBookService(service.account, service.connection).delete([staging_address_book_id])
-			logger.info("import-staging-address-book-removed", address_book=staging_address_book_id)
-		except Exception:
-			logger.warning("import-staging-address-book-remove-failed", address_book=staging_address_book_id)
-
-	def _rollback_staging_address_book(
-		self, service: ContactCardService, staging_address_book_id: str, logger: ExchangeLogger
-	) -> None:
-		"""Deletes the staging address book and every card still staged in it, undoing a failed import."""
-
-		self._log_output(_("Rolling back: removing the staging address book and any staged contacts."))
-		try:
-			AddressBookService(service.account, service.connection).delete(
-				[staging_address_book_id], remove_contents=True
-			)
-			logger.info("import-rolled-back", address_book=staging_address_book_id)
-		except Exception:
-			logger.exception("import-rollback-failed", address_book=staging_address_book_id)
-
-	def _mark_started(self) -> None:
-		"""Marks the contacts exchange as started and updates the started_at and started_after fields."""
-
-		started_at = now()
-		self._db_set(
-			status="In Progress",
-			started_at=started_at,
-			started_after=time_diff_in_seconds(started_at, self.queued_at),
-			output="",
-		)
-
-	def _mark_completed(self, **kwargs) -> None:
-		"""Marks the contacts exchange as completed and updates the completed_at and duration fields."""
-
-		kwargs["completed_at"] = now()
-		kwargs["duration"] = time_diff_in_seconds(kwargs["completed_at"], self.started_at)
-
-		if kwargs["status"] == "Failed":
-			kwargs["retries"] = cint(self.retries) + 1
-
-		self._db_set(**kwargs)
-
-	def _attach_export(self, out_dir: str) -> None:
-		"""Attaches the exported file to the contacts exchange."""
-
-		archive = f"{self.name}{self.export_archive_type}"
-		url = f"/private/files/{archive}"
-		path = os.path.join(get_bench_path(), f"sites/{frappe.local.site}{url}")
-		compress_directory(out_dir, path)
-
-		file = frappe.new_doc("File")
-		file.is_private = 1
-		file.file_url = url
-		file.file_name = archive
-		file.attached_to_doctype = self.doctype
-		file.attached_to_name = self.name
-		file.attached_to_field = "file"
-		file.insert()
-
-		# https://github.com/frappe/frappe/issues/26615
-		frappe.db.set_value("File", file.name, {"file_url": url, "file_name": archive})
-
-	def _notify_user(self, success: bool, action: Literal["Import", "Export"]) -> None:
-		"""Sends notification email to the owner of the contacts exchange."""
-
-		if is_administrator(self.owner):
-			return
-		if not (email := get_user_email_address(self.owner)):
-			return
-
-		subject = _("Contacts Data {0} {1}").format(action, "Completed" if success else "Failed")
-		frappe.publish_realtime(
-			"contacts_exchange_completed",
-			{"action": action, "success": success, "message": subject},
-			user=self.user,
-		)
-		frappe.sendmail(
-			recipients=email,
-			subject=subject,
-			template="generic",
-			args={
-				"title": subject,
-				"description": _("View details for this exchange."),
-				"button": _("View {0}").format(action),
-				"link": get_url(f"/mail/contacts-exchanges/{self.name}"),
-			},
-			now=True,
-		)
-
-	def _log_output(self, message: str) -> None:
-		"""Appends a timestamped, user-friendly line to the `output` field and persists it.
-
-		These messages are surfaced in the UI so the user can follow the progress of the
-		background import/export as it happens."""
-
-		line = f"[{now()}] {message}"
-		self.output = f"{self.output}\n{line}" if self.output else line
-		self._db_set(output=self.output)
-
-	def _db_set(self, **kwargs) -> None:
-		"""Updates the document with the given key-value pairs."""
-
-		self.db_set(kwargs, notify=True, commit=True)
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        account: DF.Link
+        amended_from: DF.Link | None
+        completed_at: DF.Datetime | None
+        deduplicate_export: DF.Check
+        duration: DF.Float
+        export_archive_type: DF.Literal[".zip", ".tgz", ".tar.gz"]
+        export_filter: DF.JSON | None
+        export_format: DF.Literal["jmap", "vcf"]
+        export_limit: DF.Int
+        import_file: DF.Attach | None
+        import_format: DF.Literal["vcf", "jmap"]
+        import_metadata: DF.JSON | None
+        operation: DF.Literal["", "Import", "Export"]
+        output: DF.Code | None
+        queued_at: DF.Datetime | None
+        retries: DF.Int
+        started_after: DF.Float
+        started_at: DF.Datetime | None
+        status: DF.Literal["Draft", "Queued", "In Progress", "Completed", "Failed", "Cancelled"]
+        user: DF.Link
+    # end: auto-generated types
+
+    @property
+    def max_import(self) -> int:
+        """Returns the maximum number of contacts allowed for import."""
+
+        return cint(get_config("exchange_max_import"))
+
+    @property
+    def max_export(self) -> int:
+        """Returns the maximum number of contacts allowed for export."""
+
+        return cint(get_config("exchange_max_export"))
+
+    @property
+    def export_filter_dict(self) -> dict:
+        """Returns the export filter as a dictionary."""
+
+        if self.operation == "Export" and self.export_filter:
+            return json.loads(self.export_filter)
+        return {}
+
+    @property
+    def import_metadata_dict(self) -> dict:
+        """Return the import metadata as a dictionary."""
+
+        if self.operation != "Import" or not self.import_metadata:
+            return {}
+
+        return json.loads(self.import_metadata)
+
+    @property
+    def target_address_book_ids(self) -> dict[str, bool] | None:
+        """Returns the target address book IDs for import, if specified."""
+
+        return self.import_metadata_dict.get("addressBookIds")
+
+    def autoname(self) -> None:
+        self.name = str(uuid7())
+
+    def validate(self) -> None:
+        if self.is_new():
+            self.validate_account()
+
+        if self.operation == "Import":
+            self.validate_import()
+        elif self.operation == "Export":
+            self.validate_export()
+
+    def before_submit(self) -> None:
+        self.status = "Queued"
+        self.queued_at = now()
+
+    def on_submit(self) -> None:
+        self.process()
+
+    def before_cancel(self) -> None:
+        self.status = "Cancelled"
+
+    def validate_account(self) -> None:
+        """Validate that the selected user can authenticate and has access to the account."""
+
+        if not is_jmap_configured(self.user):
+            frappe.throw(
+                _("User {0} does not have JMAP settings configured.").format(frappe.bold(self.user)),
+                frappe.PermissionError,
+            )
+
+        is_jmap_account_belongs_to_user(self.account, self.user, raise_exception=True)
+
+    def validate_import(self) -> None:
+        """Validate the import parameters."""
+
+        if not self.import_format:
+            frappe.throw(_("Import Format is required."))
+        if not self.import_file:
+            frappe.throw(_("Import File is required."))
+
+        allowed_extensions = (".vcf", ".zip", ".tgz", ".tar.gz")
+        if not self.import_file.endswith(allowed_extensions):
+            frappe.throw(
+                _("Only {0} files are supported for import.").format(
+                    ", ".join(f"<code>{ext}</code>" for ext in allowed_extensions)
+                )
+            )
+
+        # Reject early any import_file that resolves outside the site's uploads (path traversal).
+        self._resolve_import_file()
+
+        if self.import_metadata:
+            try:
+                self.import_metadata = json.dumps(json.loads(self.import_metadata), indent=4)
+            except json.JSONDecodeError:
+                frappe.throw(_("Metadata must be valid JSON."))
+
+    def _resolve_import_file(self) -> str:
+        """Resolves ``import_file`` to an absolute path, refusing anything outside the site's files
+        directories.
+
+        ``import_file`` is an ``Attach`` URL (e.g. ``/private/files/contacts.vcf``) that the worker
+        joins onto the site path before copying/extracting it. Without this guard a crafted value
+        such as ``/private/files/../../../etc/passwd`` would let the job read a file anywhere on the
+        filesystem, so we canonicalize the path and confirm it stays within the uploads area."""
+
+        path = os.path.realpath(
+            os.path.join(get_bench_path(), f"sites/{frappe.local.site}{self.import_file}")
+        )
+        allowed_roots = (
+            os.path.realpath(get_files_path(is_private=1)),
+            os.path.realpath(get_files_path(is_private=0)),
+        )
+        if not any(path == root or path.startswith(root + os.sep) for root in allowed_roots):
+            frappe.throw(_("Invalid import file path."))
+
+        return path
+
+    def validate_export(self) -> None:
+        """Validate the export parameters."""
+
+        if self.export_filter:
+            try:
+                self.export_filter = json.dumps(json.loads(self.export_filter), indent=4)
+            except json.JSONDecodeError:
+                frappe.throw(_("Export filter must be valid JSON."))
+
+        if not self.export_archive_type:
+            frappe.throw(_("Archive Type is required."))
+
+        if self.export_limit:
+            export_limit = cint(self.export_limit)
+            if export_limit <= 0:
+                frappe.throw(_("Export Limit must be greater than zero."))
+            if export_limit > self.max_export:
+                frappe.throw(_("Export Limit cannot exceed {0}.").format(self.max_export))
+            self.export_limit = export_limit
+        else:
+            self.export_limit = self.max_export
+
+    def _get_logger(self) -> ExchangeLogger:
+        """Returns a structured event logger bound to this exchange's context."""
+
+        return get_exchange_logger(
+            {
+                "req_id": random_string(10),
+                "exchange": self.name,
+                "kind": "contacts",
+                "operation": self.operation,
+                "user": self.user,
+                "account": self.account,
+            }
+        )
+
+    def process(self) -> None:
+        """Enqueue the import or export based on the operation type."""
+
+        logger = self._get_logger()
+
+        if self.operation == "Import":
+            job_id = f"{self.name}:contacts:import"
+            frappe.enqueue_doc(
+                self.doctype,
+                self.name,
+                "_import",
+                queue="long",
+                timeout=cint(get_config("exchange_import_timeout")),
+                job_id=job_id,
+                deduplicate=True,
+                enqueue_after_commit=True,
+            )
+            logger.debug("import-enqueued", job_id=job_id, format=self.import_format)
+        elif self.operation == "Export":
+            job_id = f"{self.name}:contacts:export"
+            frappe.enqueue_doc(
+                self.doctype,
+                self.name,
+                "_export",
+                queue="long",
+                timeout=cint(get_config("exchange_export_timeout")),
+                job_id=job_id,
+                deduplicate=True,
+                enqueue_after_commit=True,
+            )
+            logger.debug("export-enqueued", job_id=job_id, format=self.export_format)
+
+    @frappe.whitelist()
+    def retry(self) -> None:
+        """Retry the import or export."""
+
+        frappe.only_for("System Manager")
+
+        self._get_logger().info("retry-requested", status=self.status, retries=cint(self.retries))
+
+        if self.docstatus != 1:
+            frappe.throw(_("Only submitted contacts exchange can be retried."))
+        elif self.status not in ["Queued", "In Progress", "Failed"]:
+            frappe.throw(
+                _("Only contacts exchange with status 'Queued', 'In Progress', or 'Failed' can be retried.")
+            )
+
+        if self.operation == "Export":
+            if files := frappe.db.get_all(
+                "File",
+                {
+                    "attached_to_doctype": self.doctype,
+                    "attached_to_name": self.name,
+                    "attached_to_field": "file",
+                },
+                pluck="name",
+            ):
+                for file in files:
+                    frappe.delete_doc("File", file)
+
+        self._db_set(status="Queued", queued_at=now())
+        self.process()
+
+    @reconnect_on_failure()
+    def _import(self) -> None:
+        """Imports the contact cards."""
+
+        if self.operation != "Import":
+            return
+
+        logger = self._get_logger()
+        logger.info("import-started", format=self.import_format, import_file=self.import_file)
+
+        freeze_jmap_push_notifications(self.user)
+        self._mark_started()
+        self._log_output(_("Starting import from the uploaded {0} file.").format(self.import_format.upper()))
+
+        import_file = self._resolve_import_file()
+        base_dir = os.path.join(get_contacts_import_directory(), self.name)
+        os.makedirs(base_dir, exist_ok=True)
+
+        kwargs = {}
+        service = None
+        staging_address_book_id = None
+        try:
+            if self.import_format == "vcf" and self.import_file.endswith(".vcf"):
+                shutil.copy(import_file, os.path.join(base_dir, os.path.basename(import_file)))
+            else:
+                extract_compressed_file(import_file, base_dir)
+            logger.debug("import-source-prepared", base_dir=base_dir)
+            self._log_output(_("Prepared the source files for import."))
+
+            service = get_contact_card_service(self.user, self.account)
+            self._validate_target_address_books(service)
+
+            if self.import_format == "vcf":
+                cards = self._load_vcf_cards(service, base_dir, logger)
+            else:
+                cards = self._load_jmap_cards(base_dir)
+
+            logger.info("import-cards-loaded", cards=len(cards), max_import=self.max_import)
+            self._log_output(_("Found {0} contact(s) to import.").format(len(cards)))
+
+            if not cards:
+                frappe.throw(_("No contacts found for import."))
+            if len(cards) > self.max_import:
+                frappe.throw(_("Import limit exceeded."))
+
+            # Stage everything into one throwaway address book first, then move it to the destination
+            # address book(s). A failure before the move leaves nothing scattered across the account: the
+            # staging address book and every card in it are deleted on rollback.
+            staging_address_book_id = self._create_staging_address_book(service, logger)
+            targets, skipped, failed = self._create_cards(service, cards, staging_address_book_id, logger)
+
+            # The server rejecting every card (e.g. an invalid target address book) is a failure,
+            # not a successful zero-import.
+            if not targets and failed > 0:
+                frappe.throw(_("Import failed: the server rejected all {0} contact(s).").format(failed))
+
+            self._move_to_target_address_books(service, targets, logger)
+            self._discard_staging_address_book(service, staging_address_book_id, logger)
+            staging_address_book_id = None
+
+            created = len(targets)
+            logger.info("import-completed", created=created, skipped=skipped, failed=failed)
+            self._log_output(
+                _("Import completed. {0} created, {1} skipped (already present), {2} failed.").format(
+                    created, skipped, failed
+                )
+            )
+            kwargs.update({"status": "Completed"})
+        except Exception:
+            logger.exception("import-failed")
+            self._log_output(_("Import failed. See the error details below."))
+            if staging_address_book_id and service:
+                self._rollback_staging_address_book(service, staging_address_book_id, logger)
+            kwargs.update(
+                {"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
+            )
+        finally:
+            shutil.rmtree(base_dir, ignore_errors=True)
+            unfreeze_jmap_push_notifications(self.user)
+
+        self._mark_completed(**kwargs)
+        self._notify_user(success=kwargs.get("status") == "Completed", action="Import")
+
+    @reconnect_on_failure()
+    def _export(self) -> None:
+        """Exports the contact cards."""
+
+        if self.operation != "Export":
+            return
+
+        logger = self._get_logger()
+        logger.info("export-started", format=self.export_format, archive_type=self.export_archive_type)
+
+        self._mark_started()
+        self._log_output(_("Starting export to {0} format.").format(self.export_format.upper()))
+        out_dir = os.path.join(get_contacts_export_directory(), self.name)
+        os.makedirs(out_dir, exist_ok=True)
+
+        kwargs = {}
+        try:
+            service = get_contact_card_service(self.user, self.account)
+
+            limit = min(self.max_export, cint(self.export_limit or self.max_export))
+            data = service.query(self.export_filter_dict, limit=limit)
+            ids = data.get("ids", [])
+            total = data.get("total")
+            logger.info("export-query-resolved", total=total, fetched=len(ids), max_export=self.max_export)
+            self._log_output(
+                _("Found {0} contact(s) matching the filter; exporting up to {1}.").format(
+                    total if total is not None else len(ids), len(ids)
+                )
+            )
+
+            if not ids:
+                frappe.throw(_("No contacts found for export."))
+
+            cards = service.get(ids)
+
+            if self.deduplicate_export:
+                fetched = len(cards)
+                unique: dict[str, dict] = {}
+                for c in cards:
+                    key = c.get("uid") or c.get("id")
+                    if key not in unique:
+                        unique[key] = c
+                cards = list(unique.values())
+                logger.debug("export-deduplicated", fetched=fetched, unique=len(cards))
+                self._log_output(
+                    _("Removed {0} duplicate(s); {1} unique contact(s) remain.").format(
+                        fetched - len(cards), len(cards)
+                    )
+                )
+
+            # Only include address books actually referenced by the exported cards, so a filtered
+            # export doesn't leak the account's other address books into addressbooks.json.
+            referenced_ids = {book_id for card in cards for book_id in (card.get("addressBookIds") or {})}
+            address_book_map = {
+                b["id"]: b["name"] for b in service.address_books if b["id"] in referenced_ids
+            }
+            ContactsExportWriter.write(self.export_format, cards, out_dir, address_book_map)
+            self._log_output(_("Wrote {0} contact(s) to the export directory.").format(len(cards)))
+
+            self._log_output(
+                _("Packaging exported contacts into a {0} archive.").format(self.export_archive_type)
+            )
+            self._attach_export(out_dir)
+
+            logger.info("export-completed", cards=len(cards))
+            self._log_output(_("Export completed successfully. {0} contact(s) exported.").format(len(cards)))
+            kwargs.update({"status": "Completed"})
+        except Exception:
+            logger.exception("export-failed")
+            self._log_output(_("Export failed. See the error details below."))
+            kwargs.update(
+                {"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
+            )
+        finally:
+            shutil.rmtree(out_dir, ignore_errors=True)
+
+        self._mark_completed(**kwargs)
+        self._notify_user(success=kwargs.get("status") == "Completed", action="Export")
+
+    def _load_vcf_cards(
+        self, service: ContactCardService, base_dir: str, logger: ExchangeLogger
+    ) -> list[dict]:
+        """Splits the uploaded .vcf file(s) into individual vCards and converts them to JSContact.
+
+        ``ContactCard/parse`` returns a single Card per blob (the first vCard it finds), so a file
+        holding many contacts must be split into one blob per vCard for all of them to be imported.
+        Falls back to a local parser for any vCard the server can't parse, or for the whole set if
+        the server does not implement ``ContactCard/parse``."""
+
+        vcf_files = [
+            os.path.join(root, f)
+            for root, _dirs, files in os.walk(base_dir)
+            for f in files
+            if f.lower().endswith(".vcf")
+        ]
+        if not vcf_files:
+            frappe.throw(_("No .vcf files found."))
+
+        vcards: list[str] = []
+        for path in vcf_files:
+            vcards.extend(_split_vcards(_read_text(path)))
+        if not vcards:
+            frappe.throw(_("No vCards found in the uploaded file(s)."))
+        # Reject early, before uploading a blob per vCard, if the file already exceeds the limit.
+        if len(vcards) > self.max_import:
+            frappe.throw(_("Import limit exceeded."))
+
+        cards: list[dict] = []
+        try:
+            # One blob per vCard so the server parses (and returns) every contact, not just the first.
+            uploads = service.upload_blobs_concurrently(
+                [(vcard.encode("utf-8"), "text/vcard; charset=utf-8") for vcard in vcards]
+            )
+            blob_to_vcard: dict[str, str] = {}
+            for vcard, upload in zip(vcards, uploads, strict=False):
+                if blob_id := (upload or {}).get("blobId"):
+                    blob_to_vcard[blob_id] = vcard
+
+            response = service.parse(list(blob_to_vcard.keys()))
+
+            for value in (response.get("parsed") or {}).values():
+                if isinstance(value, list):
+                    cards.extend(card for card in value if card)
+                elif value:
+                    cards.append(value)
+
+            # Anything the server couldn't parse gets a second chance through the local parser.
+            unparsed = list((response.get("notParsable") or {}).keys()) + list(
+                (response.get("notFound") or {}).keys()
+            )
+            for blob_id in unparsed:
+                if vcard := blob_to_vcard.get(blob_id):
+                    cards.extend(parse_vcards(vcard))
+            if unparsed:
+                logger.warning("import-vcf-not-parsable", count=len(unparsed))
+                self._log_output(_("{0} vCard(s) were parsed locally as a fallback.").format(len(unparsed)))
+        except Exception:
+            # The JMAP server does not support ContactCard/parse; parse every vCard locally instead.
+            logger.warning("import-vcf-parse-unsupported")
+            self._log_output(_("Server-side parsing is unavailable; parsing vCards locally."))
+            cards = []
+            for vcard in vcards:
+                cards.extend(parse_vcards(vcard))
+
+        return cards
+
+    def _validate_target_address_books(self, service: ContactCardService) -> None:
+        """Validates that the client-supplied target address book(s) exist in this account.
+
+        ``target_address_book_ids`` comes from the import metadata and is passed straight to
+        ``ContactCard/set``. A deleted or foreign book would make the server reject every card, so
+        fail fast with a clear error instead of silently completing with zero imports."""
+
+        target = self.target_address_book_ids
+        if not target:
+            return
+
+        known = {book["id"] for book in service.address_books}
+        if invalid := [book_id for book_id in target if book_id not in known]:
+            frappe.throw(
+                _("Target address book(s) not found in this account: {0}").format(", ".join(invalid))
+            )
+
+    def _load_jmap_cards(self, base_dir: str) -> list[dict]:
+        """Loads JSContact cards from the cards.json file in the import directory."""
+
+        path = os.path.join(base_dir, "cards.json")
+        if not os.path.exists(path):
+            frappe.throw(_("cards.json not found in the import directory."))
+
+        with open(path) as f:
+            cards = json.load(f)
+
+        if not isinstance(cards, list):
+            frappe.throw(_("cards.json must contain a list of contact cards."))
+
+        return cards
+
+    def _create_staging_address_book(self, service: ContactCardService, logger: ExchangeLogger) -> str:
+        """Creates a temporary address book (named after this exchange) to stage the import into."""
+
+        self._log_output(_("Creating a temporary address book to stage the import."))
+        response = AddressBookService(service.account, service.connection).create(
+            [{"creation_id": str(uuid7()), "name": self.name, "is_subscribed": False}]
+        )
+        created = response.get("created") or {}
+        if not created:
+            frappe.throw(
+                _("Failed to create the staging address book: {0}").format(response.get("notCreated"))
+            )
+
+        staging_address_book_id = next(iter(created.values()))["id"]
+        logger.info("import-staging-address-book-created", address_book=staging_address_book_id)
+        return staging_address_book_id
+
+    def _create_cards(
+        self,
+        service: ContactCardService,
+        cards: list[dict],
+        staging_address_book_id: str,
+        logger: ExchangeLogger,
+    ) -> tuple[dict[str, dict[str, bool]], int, int]:
+        """Creates the given JSContact cards in the staging address book, skipping any whose UID already
+        exists (idempotency).
+
+        Returns a ``(targets, skipped, failed)`` tuple, where ``targets`` maps each created card's ID to
+        the destination addressBookIds it should ultimately land in. Failures within a batch are recorded
+        and the remaining batches continue, so a few malformed cards do not abort the whole import."""
+
+        # Idempotency: skip cards whose UID is already present in the account.
+        uids = [c["uid"] for c in cards if c.get("uid")]
+        existing_uids: set[str] = set()
+        if uids:
+            if existing_ids := service.get_master_ids(uids):
+                existing_uids = {c["uid"] for c in service.get(existing_ids) if c.get("uid")}
+
+        default_address_book_id: str | None = None
+
+        def resolve_address_book_ids(card: dict) -> dict:
+            nonlocal default_address_book_id
+
+            if self.target_address_book_ids:
+                return self.target_address_book_ids
+            if card.get("addressBookIds"):
+                return card["addressBookIds"]
+            if default_address_book_id is None:
+                default_address_book_id = AddressBookService(service.account, service.connection).get_default(
+                    raise_exception=True
+                )
+            return {default_address_book_id: True}
+
+        pending: list[dict] = []
+        skipped = 0
+        for card in cards:
+            if card.get("uid") and card["uid"] in existing_uids:
+                skipped += 1
+                continue
+            pending.append(card)
+
+        targets: dict[str, dict[str, bool]] = {}
+        failed = 0
+        total = len(pending)
+        for batch in create_batch(pending, service.max_objects_in_set):
+            payload: dict[str, dict] = {}
+            creation_meta: dict[str, tuple[str, dict]] = {}
+            for card in batch:
+                # Resolve the destination before overwriting addressBookIds with the staging book.
+                destination = resolve_address_book_ids(card)
+                card = {k: v for k, v in card.items() if k not in SERVER_MANAGED_KEYS}
+                card["@type"] = "Card"
+                card.setdefault("version", "1.0")
+                card["addressBookIds"] = {staging_address_book_id: True}
+
+                creation_id = str(uuid7())
+                payload[creation_id] = card
+                creation_meta[creation_id] = (card.get("uid", creation_id), destination)
+
+            response = service._create(payload)
+            method_responses = response.get("methodResponses") or []
+            result = method_responses[0][1] if method_responses else {}
+
+            batch_failed = result.get("notCreated") or {}
+            failed += len(batch_failed)
+
+            for creation_id, info in (result.get("created") or {}).items():
+                targets[info["id"]] = creation_meta[creation_id][1]
+
+            for creation_id, error in batch_failed.items():
+                logger.warning(
+                    "import-card-not-created",
+                    uid=creation_meta.get(creation_id, (None,))[0],
+                    reason=str(error),
+                )
+
+            self._log_output(_("Staged {0} of {1} contact(s).").format(len(targets), total))
+
+        return targets, skipped, failed
+
+    def _move_to_target_address_books(
+        self, service: ContactCardService, targets: dict[str, dict[str, bool]], logger: ExchangeLogger
+    ) -> None:
+        """Moves the staged cards into their destination address books, replacing the staging book.
+
+        This is the commit step: until it runs, every card lives only in the staging address book, so a
+        failure up to this point rolls back cleanly."""
+
+        if not targets:
+            return
+
+        self._log_output(
+            _("Moving {0} contact(s) into the destination address book(s).").format(len(targets))
+        )
+        result = service.set_address_book_ids(targets)
+
+        if not_updated := result.get("notUpdated"):
+            logger.warning("import-card-not-moved", count=len(not_updated))
+            frappe.throw(
+                _("Failed to move {0} contact(s) into the destination address book(s).").format(
+                    len(not_updated)
+                )
+            )
+
+        logger.info("import-cards-moved", cards=len(result.get("updated", [])))
+
+    def _discard_staging_address_book(
+        self, service: ContactCardService, staging_address_book_id: str, logger: ExchangeLogger
+    ) -> None:
+        """Deletes the now-empty staging address book after a successful import. A failure here is logged
+        but not fatal: the cards are already safely in their destination address books."""
+
+        try:
+            AddressBookService(service.account, service.connection).delete([staging_address_book_id])
+            logger.info("import-staging-address-book-removed", address_book=staging_address_book_id)
+        except Exception:
+            logger.warning("import-staging-address-book-remove-failed", address_book=staging_address_book_id)
+
+    def _rollback_staging_address_book(
+        self, service: ContactCardService, staging_address_book_id: str, logger: ExchangeLogger
+    ) -> None:
+        """Deletes the staging address book and every card still staged in it, undoing a failed import."""
+
+        self._log_output(_("Rolling back: removing the staging address book and any staged contacts."))
+        try:
+            AddressBookService(service.account, service.connection).delete(
+                [staging_address_book_id], remove_contents=True
+            )
+            logger.info("import-rolled-back", address_book=staging_address_book_id)
+        except Exception:
+            logger.exception("import-rollback-failed", address_book=staging_address_book_id)
+
+    def _mark_started(self) -> None:
+        """Marks the contacts exchange as started and updates the started_at and started_after fields."""
+
+        started_at = now()
+        self._db_set(
+            status="In Progress",
+            started_at=started_at,
+            started_after=time_diff_in_seconds(started_at, self.queued_at),
+            output="",
+        )
+
+    def _mark_completed(self, **kwargs) -> None:
+        """Marks the contacts exchange as completed and updates the completed_at and duration fields."""
+
+        kwargs["completed_at"] = now()
+        kwargs["duration"] = time_diff_in_seconds(kwargs["completed_at"], self.started_at)
+
+        if kwargs["status"] == "Failed":
+            kwargs["retries"] = cint(self.retries) + 1
+
+        self._db_set(**kwargs)
+
+    def _attach_export(self, out_dir: str) -> None:
+        """Attaches the exported file to the contacts exchange."""
+
+        archive = f"{self.name}{self.export_archive_type}"
+        url = f"/private/files/{archive}"
+        path = os.path.join(get_bench_path(), f"sites/{frappe.local.site}{url}")
+        compress_directory(out_dir, path)
+
+        file = frappe.new_doc("File")
+        file.is_private = 1
+        file.file_url = url
+        file.file_name = archive
+        file.attached_to_doctype = self.doctype
+        file.attached_to_name = self.name
+        file.attached_to_field = "file"
+        file.insert()
+
+        # https://github.com/frappe/frappe/issues/26615
+        frappe.db.set_value("File", file.name, {"file_url": url, "file_name": archive})
+
+    def _notify_user(self, success: bool, action: Literal["Import", "Export"]) -> None:
+        """Sends notification email to the owner of the contacts exchange."""
+
+        if is_administrator(self.owner):
+            return
+        if not (email := get_user_email_address(self.owner)):
+            return
+
+        subject = _("Contacts Data {0} {1}").format(action, "Completed" if success else "Failed")
+        frappe.publish_realtime(
+            "contacts_exchange_completed",
+            {"action": action, "success": success, "message": subject},
+            user=self.user,
+        )
+        frappe.sendmail(
+            recipients=email,
+            subject=subject,
+            template="generic",
+            args={
+                "title": subject,
+                "description": _("View details for this exchange."),
+                "button": _("View {0}").format(action),
+                "link": get_url(f"/mail/contacts-exchanges/{self.name}"),
+            },
+            now=True,
+        )
+
+    def _log_output(self, message: str) -> None:
+        """Appends a timestamped, user-friendly line to the `output` field and persists it.
+
+        These messages are surfaced in the UI so the user can follow the progress of the
+        background import/export as it happens."""
+
+        line = f"[{now()}] {message}"
+        self.output = f"{self.output}\n{line}" if self.output else line
+        self._db_set(output=self.output)
+
+    def _db_set(self, **kwargs) -> None:
+        """Updates the document with the given key-value pairs."""
+
+        self.db_set(kwargs, notify=True, commit=True)
 
 
 class ContactsExportWriter:
-	@classmethod
-	def write(
-		cls,
-		format: Literal["jmap", "vcf"],
-		cards: list[dict],
-		out_dir: str,
-		address_book_map: dict[str, str],
-	) -> None:
-		"""Writes the exported cards in the specified format."""
+    @classmethod
+    def write(
+        cls,
+        format: Literal["jmap", "vcf"],
+        cards: list[dict],
+        out_dir: str,
+        address_book_map: dict[str, str],
+    ) -> None:
+        """Writes the exported cards in the specified format."""
 
-		writers = {
-			"jmap": cls._jmap,
-			"vcf": cls._vcf,
-		}
+        writers = {
+            "jmap": cls._jmap,
+            "vcf": cls._vcf,
+        }
 
-		if format not in writers:
-			frappe.throw(_("Unsupported export format: {0}").format(format))
+        if format not in writers:
+            frappe.throw(_("Unsupported export format: {0}").format(format))
 
-		writers[format](cards, out_dir, address_book_map)
+        writers[format](cards, out_dir, address_book_map)
 
-	@staticmethod
-	def _jmap(cards: list[dict], out_dir: str, address_book_map: dict[str, str]) -> None:
-		"""Writes the raw JSContact cards and the address book map (fully round-trippable)."""
+    @staticmethod
+    def _jmap(cards: list[dict], out_dir: str, address_book_map: dict[str, str]) -> None:
+        """Writes the raw JSContact cards and the address book map (fully round-trippable)."""
 
-		with open(os.path.join(out_dir, "cards.json"), "w") as f:
-			json.dump(cards, f, indent=4)
+        with open(os.path.join(out_dir, "cards.json"), "w") as f:
+            json.dump(cards, f, indent=4)
 
-		with open(os.path.join(out_dir, "addressbooks.json"), "w") as f:
-			json.dump(address_book_map, f, indent=4)
+        with open(os.path.join(out_dir, "addressbooks.json"), "w") as f:
+            json.dump(address_book_map, f, indent=4)
 
-	@staticmethod
-	def _vcf(cards: list[dict], out_dir: str, address_book_map: dict[str, str]) -> None:
-		"""Writes one .vcf file per address book, mirroring mbox's one-file-per-mailbox layout."""
+    @staticmethod
+    def _vcf(cards: list[dict], out_dir: str, address_book_map: dict[str, str]) -> None:
+        """Writes one .vcf file per address book, mirroring mbox's one-file-per-mailbox layout."""
 
-		def safe_name(name: str) -> str:
-			return (
-				"".join(c if c.isalnum() or c in (" ", "-", "_") else "_" for c in name).strip()
-				or "addressbook"
-			)
+        def safe_name(name: str) -> str:
+            return (
+                "".join(c if c.isalnum() or c in (" ", "-", "_") else "_" for c in name).strip()
+                or "addressbook"
+            )
 
-		# Group cards by the address books they belong to (a card can live in several).
-		by_book: dict[str, list[dict]] = {}
-		for card in cards:
-			book_ids = list((card.get("addressBookIds") or {}).keys()) or ["__default__"]
-			for book_id in book_ids:
-				by_book.setdefault(book_id, []).append(card)
+        # Group cards by the address books they belong to (a card can live in several).
+        by_book: dict[str, list[dict]] = {}
+        for card in cards:
+            book_ids = list((card.get("addressBookIds") or {}).keys()) or ["__default__"]
+            for book_id in book_ids:
+                by_book.setdefault(book_id, []).append(card)
 
-		used_names: set[str] = set()
-		for book_id, book_cards in by_book.items():
-			book_name = address_book_map.get(book_id, "Contacts")
-			categories = [book_name] if book_id in address_book_map else None
+        used_names: set[str] = set()
+        for book_id, book_cards in by_book.items():
+            book_name = address_book_map.get(book_id, "Contacts")
+            categories = [book_name] if book_id in address_book_map else None
 
-			vcards = [card_to_vcard(card, categories) for card in book_cards]
+            vcards = [card_to_vcard(card, categories) for card in book_cards]
 
-			file_name = safe_name(book_name)
-			candidate = file_name
-			suffix = 1
-			while candidate in used_names:
-				suffix += 1
-				candidate = f"{file_name}_{suffix}"
-			used_names.add(candidate)
+            file_name = safe_name(book_name)
+            candidate = file_name
+            suffix = 1
+            while candidate in used_names:
+                suffix += 1
+                candidate = f"{file_name}_{suffix}"
+            used_names.add(candidate)
 
-			with open(os.path.join(out_dir, f"{candidate}.vcf"), "w", encoding="utf-8") as f:
-				f.write("\r\n".join(vcards))
-				f.write("\r\n")
+            with open(os.path.join(out_dir, f"{candidate}.vcf"), "w", encoding="utf-8") as f:
+                f.write("\r\n".join(vcards))
+                f.write("\r\n")
 
 
 def get_contact_card_service(
-	user: str,
-	account: str,
-	ignore_permissions: bool = False,
+    user: str,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> ContactCardService:
-	"""Returns a ContactCardService configured with the longer exchange timeouts."""
+    """Returns a ContactCardService configured with the longer exchange timeouts."""
 
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions, timeout=(60.0, 180.0))
-	return ContactCardService(account, connection)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions, timeout=(60.0, 180.0))
+    return ContactCardService(account, connection)
 
 
 # ---------------------------------------------------------------------------
@@ -888,487 +888,487 @@ def get_contact_card_service(
 
 # JSContact context -> vCard TYPE parameter value.
 _CONTEXT_TYPE_MAP = {
-	"work": "work",
-	"private": "home",
-	"home": "home",
+    "work": "work",
+    "private": "home",
+    "home": "home",
 }
 
 
 def _vcard_escape(value: str) -> str:
-	"""Escapes a value for use in a vCard property, per RFC 6350."""
+    """Escapes a value for use in a vCard property, per RFC 6350."""
 
-	if value is None:
-		return ""
-	return str(value).replace("\\", "\\\\").replace("\n", "\\n").replace(",", "\\,").replace(";", "\\;")
+    if value is None:
+        return ""
+    return str(value).replace("\\", "\\\\").replace("\n", "\\n").replace(",", "\\,").replace(";", "\\;")
 
 
 def _fold_line(line: str) -> str:
-	"""Folds a vCard content line at 75 octets, continuing with a leading space (RFC 6350)."""
+    """Folds a vCard content line at 75 octets, continuing with a leading space (RFC 6350)."""
 
-	encoded = line.encode("utf-8")
-	if len(encoded) <= 75:
-		return line
+    encoded = line.encode("utf-8")
+    if len(encoded) <= 75:
+        return line
 
-	chunks = []
-	start = 0
-	limit = 75
-	while start < len(encoded):
-		end = min(start + limit, len(encoded))
-		# Do not split in the middle of a multi-byte UTF-8 sequence.
-		while end < len(encoded) and (encoded[end] & 0xC0) == 0x80:
-			end -= 1
-		chunks.append(encoded[start:end].decode("utf-8"))
-		start = end
-		limit = 74  # continuation lines carry a leading space, so one less octet of content
+    chunks = []
+    start = 0
+    limit = 75
+    while start < len(encoded):
+        end = min(start + limit, len(encoded))
+        # Do not split in the middle of a multi-byte UTF-8 sequence.
+        while end < len(encoded) and (encoded[end] & 0xC0) == 0x80:
+            end -= 1
+        chunks.append(encoded[start:end].decode("utf-8"))
+        start = end
+        limit = 74  # continuation lines carry a leading space, so one less octet of content
 
-	return "\r\n ".join(chunks)
+    return "\r\n ".join(chunks)
 
 
 def _contexts_to_types(contexts: dict | None) -> list[str]:
-	"""Maps a JSContact ``contexts`` map to vCard TYPE parameter values."""
+    """Maps a JSContact ``contexts`` map to vCard TYPE parameter values."""
 
-	types = []
-	for context in contexts or {}:
-		if mapped := _CONTEXT_TYPE_MAP.get(context.lower()):
-			if mapped not in types:
-				types.append(mapped)
-	return types
+    types = []
+    for context in contexts or {}:
+        if mapped := _CONTEXT_TYPE_MAP.get(context.lower()):
+            if mapped not in types:
+                types.append(mapped)
+    return types
 
 
 def _name_components(name: dict | None) -> dict[str, list[str]]:
-	"""Groups a JSContact Name's components by kind."""
+    """Groups a JSContact Name's components by kind."""
 
-	grouped: dict[str, list[str]] = {}
-	for component in (name or {}).get("components") or []:
-		kind = component.get("kind")
-		value = component.get("value")
-		if kind and value:
-			grouped.setdefault(kind, []).append(value)
-	return grouped
+    grouped: dict[str, list[str]] = {}
+    for component in (name or {}).get("components") or []:
+        kind = component.get("kind")
+        value = component.get("value")
+        if kind and value:
+            grouped.setdefault(kind, []).append(value)
+    return grouped
 
 
 def card_to_vcard(card: dict, categories: list[str] | None = None) -> str:
-	"""Converts a single JSContact Card into a vCard 4.0 string."""
+    """Converts a single JSContact Card into a vCard 4.0 string."""
 
-	lines = ["BEGIN:VCARD", "VERSION:4.0"]
+    lines = ["BEGIN:VCARD", "VERSION:4.0"]
 
-	def add(prop: str, value: str, params: str = "") -> None:
-		if value in (None, ""):
-			return
-		lines.append(_fold_line(f"{prop}{params}:{value}"))
+    def add(prop: str, value: str, params: str = "") -> None:
+        if value in (None, ""):
+            return
+        lines.append(_fold_line(f"{prop}{params}:{value}"))
 
-	if uid := card.get("uid"):
-		add("UID", _vcard_escape(uid))
+    if uid := card.get("uid"):
+        add("UID", _vcard_escape(uid))
 
-	kind = card.get("kind")
-	if kind and kind != "individual":
-		add("KIND", _vcard_escape(kind))
+    kind = card.get("kind")
+    if kind and kind != "individual":
+        add("KIND", _vcard_escape(kind))
 
-	name = card.get("name") or {}
-	if full := name.get("full"):
-		add("FN", _vcard_escape(full))
+    name = card.get("name") or {}
+    if full := name.get("full"):
+        add("FN", _vcard_escape(full))
 
-	grouped = _name_components(name)
-	if grouped:
-		n_value = ";".join(
-			",".join(_vcard_escape(v) for v in grouped.get(kind, [])) for kind in N_COMPONENT_ORDER
-		)
-		add("N", n_value)
-	elif full:
-		add("N", f"{_vcard_escape(full)};;;;")
+    grouped = _name_components(name)
+    if grouped:
+        n_value = ";".join(
+            ",".join(_vcard_escape(v) for v in grouped.get(kind, [])) for kind in N_COMPONENT_ORDER
+        )
+        add("N", n_value)
+    elif full:
+        add("N", f"{_vcard_escape(full)};;;;")
 
-	for nick in (card.get("nickNames") or {}).values():
-		add("NICKNAME", _vcard_escape(nick.get("name")))
+    for nick in (card.get("nickNames") or {}).values():
+        add("NICKNAME", _vcard_escape(nick.get("name")))
 
-	for org in (card.get("organizations") or {}).values():
-		parts = [org.get("name") or ""]
-		parts.extend(unit.get("name") or "" for unit in org.get("units") or [])
-		add("ORG", ";".join(_vcard_escape(p) for p in parts))
+    for org in (card.get("organizations") or {}).values():
+        parts = [org.get("name") or ""]
+        parts.extend(unit.get("name") or "" for unit in org.get("units") or [])
+        add("ORG", ";".join(_vcard_escape(p) for p in parts))
 
-	for title in (card.get("titles") or {}).values():
-		prop = "ROLE" if title.get("kind") == "role" else "TITLE"
-		add(prop, _vcard_escape(title.get("name")))
+    for title in (card.get("titles") or {}).values():
+        prop = "ROLE" if title.get("kind") == "role" else "TITLE"
+        add(prop, _vcard_escape(title.get("name")))
 
-	for email in (card.get("emails") or {}).values():
-		types = _contexts_to_types(email.get("contexts"))
-		params = f";TYPE={','.join(types)}" if types else ""
-		add("EMAIL", _vcard_escape(email.get("address")), params)
+    for email in (card.get("emails") or {}).values():
+        types = _contexts_to_types(email.get("contexts"))
+        params = f";TYPE={','.join(types)}" if types else ""
+        add("EMAIL", _vcard_escape(email.get("address")), params)
 
-	for phone in (card.get("phones") or {}).values():
-		types = _contexts_to_types(phone.get("contexts"))
-		types.extend(f for f in (phone.get("features") or {}) if f not in types)
-		params = f";TYPE={','.join(types)}" if types else ""
-		add("TEL", _vcard_escape(phone.get("number")), params)
+    for phone in (card.get("phones") or {}).values():
+        types = _contexts_to_types(phone.get("contexts"))
+        types.extend(f for f in (phone.get("features") or {}) if f not in types)
+        params = f";TYPE={','.join(types)}" if types else ""
+        add("TEL", _vcard_escape(phone.get("number")), params)
 
-	for address in (card.get("addresses") or {}).values():
-		types = _contexts_to_types(address.get("contexts"))
-		params = f";TYPE={','.join(types)}" if types else ""
-		add("ADR", _address_to_vcard(address), params)
+    for address in (card.get("addresses") or {}).values():
+        types = _contexts_to_types(address.get("contexts"))
+        params = f";TYPE={','.join(types)}" if types else ""
+        add("ADR", _address_to_vcard(address), params)
 
-	for note in (card.get("notes") or {}).values():
-		add("NOTE", _vcard_escape(note.get("note")))
+    for note in (card.get("notes") or {}).values():
+        add("NOTE", _vcard_escape(note.get("note")))
 
-	for url in (card.get("urls") or card.get("links") or {}).values():
-		add("URL", _vcard_escape(url.get("uri") or url.get("url") or url.get("href")))
+    for url in (card.get("urls") or card.get("links") or {}).values():
+        add("URL", _vcard_escape(url.get("uri") or url.get("url") or url.get("href")))
 
-	for anniversary in (card.get("anniversaries") or {}).values():
-		if date := _anniversary_date(anniversary.get("date")):
-			prop = "BDAY" if anniversary.get("kind") == "birth" else "ANNIVERSARY"
-			add(prop, date)
+    for anniversary in (card.get("anniversaries") or {}).values():
+        if date := _anniversary_date(anniversary.get("date")):
+            prop = "BDAY" if anniversary.get("kind") == "birth" else "ANNIVERSARY"
+            add(prop, date)
 
-	for photo in (card.get("photos") or card.get("media") or {}).values():
-		if photo.get("kind") in (None, "photo") and (uri := photo.get("uri")):
-			add("PHOTO", uri)
+    for photo in (card.get("photos") or card.get("media") or {}).values():
+        if photo.get("kind") in (None, "photo") and (uri := photo.get("uri")):
+            add("PHOTO", uri)
 
-	keywords = list((card.get("categories") or card.get("keywords") or {}).keys())
-	if categories:
-		keywords = list(dict.fromkeys(keywords + categories))
-	if keywords:
-		add("CATEGORIES", ",".join(_vcard_escape(k) for k in keywords))
+    keywords = list((card.get("categories") or card.get("keywords") or {}).keys())
+    if categories:
+        keywords = list(dict.fromkeys(keywords + categories))
+    if keywords:
+        add("CATEGORIES", ",".join(_vcard_escape(k) for k in keywords))
 
-	for member in card.get("members") or {}:
-		add("MEMBER", member if member.startswith("urn:") else f"urn:uuid:{member}")
+    for member in card.get("members") or {}:
+        add("MEMBER", member if member.startswith("urn:") else f"urn:uuid:{member}")
 
-	lines.append("END:VCARD")
-	return "\r\n".join(lines)
+    lines.append("END:VCARD")
+    return "\r\n".join(lines)
 
 
 def _address_to_vcard(address: dict) -> str:
-	"""Builds a vCard ADR value (POBox;Ext;Street;Locality;Region;Postcode;Country) from a JSContact address."""
+    """Builds a vCard ADR value (POBox;Ext;Street;Locality;Region;Postcode;Country) from a JSContact address."""
 
-	grouped: dict[str, list[str]] = {}
-	for component in address.get("components") or []:
-		kind = component.get("kind")
-		value = component.get("value")
-		if kind and value:
-			grouped.setdefault(kind, []).append(value)
+    grouped: dict[str, list[str]] = {}
+    for component in address.get("components") or []:
+        kind = component.get("kind")
+        value = component.get("value")
+        if kind and value:
+            grouped.setdefault(kind, []).append(value)
 
-	def get(*kinds: str) -> str:
-		for kind in kinds:
-			if kind in grouped:
-				return ",".join(_vcard_escape(v) for v in grouped[kind])
-		return ""
+    def get(*kinds: str) -> str:
+        for kind in kinds:
+            if kind in grouped:
+                return ",".join(_vcard_escape(v) for v in grouped[kind])
+        return ""
 
-	return ";".join(
-		[
-			get("postOfficeBox"),
-			get("apartment", "floor", "room"),
-			get("name", "street"),
-			get("locality"),
-			get("region"),
-			get("postcode"),
-			get("country"),
-		]
-	)
+    return ";".join(
+        [
+            get("postOfficeBox"),
+            get("apartment", "floor", "room"),
+            get("name", "street"),
+            get("locality"),
+            get("region"),
+            get("postcode"),
+            get("country"),
+        ]
+    )
 
 
 def _anniversary_date(date: dict | str | None) -> str | None:
-	"""Renders a JSContact anniversary date as a vCard date string."""
+    """Renders a JSContact anniversary date as a vCard date string."""
 
-	if not date:
-		return None
-	if isinstance(date, str):
-		return date
-	if utc := date.get("utc"):
-		return utc
-	year = date.get("year")
-	month = date.get("month")
-	day = date.get("day")
-	if year and month and day:
-		return f"{int(year):04d}{int(month):02d}{int(day):02d}"
-	return None
+    if not date:
+        return None
+    if isinstance(date, str):
+        return date
+    if utc := date.get("utc"):
+        return utc
+    year = date.get("year")
+    month = date.get("month")
+    day = date.get("day")
+    if year and month and day:
+        return f"{int(year):04d}{int(month):02d}{int(day):02d}"
+    return None
 
 
 def _read_text(path: str) -> str:
-	"""Reads a text file, tolerating a UTF-8 BOM and falling back to latin-1 on decode errors."""
+    """Reads a text file, tolerating a UTF-8 BOM and falling back to latin-1 on decode errors."""
 
-	with open(path, "rb") as f:
-		data = f.read()
-	try:
-		return data.decode("utf-8-sig")
-	except UnicodeDecodeError:
-		return data.decode("latin-1")
+    with open(path, "rb") as f:
+        data = f.read()
+    try:
+        return data.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        return data.decode("latin-1")
 
 
 def _vcard_unescape(value: str) -> str:
-	"""Reverses vCard value escaping."""
+    """Reverses vCard value escaping."""
 
-	out = []
-	i = 0
-	while i < len(value):
-		char = value[i]
-		if char == "\\" and i + 1 < len(value):
-			nxt = value[i + 1]
-			out.append({"n": "\n", "N": "\n"}.get(nxt, nxt))
-			i += 2
-			continue
-		out.append(char)
-		i += 1
-	return "".join(out)
+    out = []
+    i = 0
+    while i < len(value):
+        char = value[i]
+        if char == "\\" and i + 1 < len(value):
+            nxt = value[i + 1]
+            out.append({"n": "\n", "N": "\n"}.get(nxt, nxt))
+            i += 2
+            continue
+        out.append(char)
+        i += 1
+    return "".join(out)
 
 
 def _split_escaped(value: str, sep: str) -> list[str]:
-	"""Splits a vCard value on ``sep`` while honouring backslash escaping."""
+    """Splits a vCard value on ``sep`` while honouring backslash escaping."""
 
-	parts = []
-	current = []
-	i = 0
-	while i < len(value):
-		char = value[i]
-		if char == "\\" and i + 1 < len(value):
-			current.append(value[i : i + 2])
-			i += 2
-			continue
-		if char == sep:
-			parts.append("".join(current))
-			current = []
-			i += 1
-			continue
-		current.append(char)
-		i += 1
-	parts.append("".join(current))
-	return parts
+    parts = []
+    current = []
+    i = 0
+    while i < len(value):
+        char = value[i]
+        if char == "\\" and i + 1 < len(value):
+            current.append(value[i : i + 2])
+            i += 2
+            continue
+        if char == sep:
+            parts.append("".join(current))
+            current = []
+            i += 1
+            continue
+        current.append(char)
+        i += 1
+    parts.append("".join(current))
+    return parts
 
 
 def _split_vcards(text: str) -> list[str]:
-	"""Splits a vCard document into its individual ``BEGIN:VCARD``…``END:VCARD`` blocks.
+    """Splits a vCard document into its individual ``BEGIN:VCARD``…``END:VCARD`` blocks.
 
-	Line folding within each card is preserved so the blocks can be re-uploaded verbatim."""
+    Line folding within each card is preserved so the blocks can be re-uploaded verbatim."""
 
-	blocks: list[str] = []
-	current: list[str] = []
-	in_card = False
-	for line in text.replace("\r\n", "\n").replace("\r", "\n").split("\n"):
-		marker = line.strip().upper()
-		if marker == "BEGIN:VCARD":
-			in_card = True
-			current = [line]
-		elif marker == "END:VCARD":
-			if in_card:
-				current.append(line)
-				blocks.append("\r\n".join(current))
-			in_card = False
-			current = []
-		elif in_card:
-			current.append(line)
+    blocks: list[str] = []
+    current: list[str] = []
+    in_card = False
+    for line in text.replace("\r\n", "\n").replace("\r", "\n").split("\n"):
+        marker = line.strip().upper()
+        if marker == "BEGIN:VCARD":
+            in_card = True
+            current = [line]
+        elif marker == "END:VCARD":
+            if in_card:
+                current.append(line)
+                blocks.append("\r\n".join(current))
+            in_card = False
+            current = []
+        elif in_card:
+            current.append(line)
 
-	return blocks
+    return blocks
 
 
 def parse_vcards(text: str) -> list[dict]:
-	"""Parses a vCard document (one or more cards) into JSContact Card dicts.
+    """Parses a vCard document (one or more cards) into JSContact Card dicts.
 
-	This is the local fallback used when the JMAP server does not implement ``ContactCard/parse``.
-	It covers the common properties (FN, N, NICKNAME, ORG, TITLE, EMAIL, TEL, ADR, NOTE, URL, BDAY,
-	ANNIVERSARY, CATEGORIES, KIND, MEMBER, UID); anything else is ignored."""
+    This is the local fallback used when the JMAP server does not implement ``ContactCard/parse``.
+    It covers the common properties (FN, N, NICKNAME, ORG, TITLE, EMAIL, TEL, ADR, NOTE, URL, BDAY,
+    ANNIVERSARY, CATEGORIES, KIND, MEMBER, UID); anything else is ignored."""
 
-	# Unfold continuation lines (a line beginning with a space/tab continues the previous one).
-	unfolded: list[str] = []
-	for raw_line in text.replace("\r\n", "\n").replace("\r", "\n").split("\n"):
-		if raw_line[:1] in (" ", "\t") and unfolded:
-			unfolded[-1] += raw_line[1:]
-		else:
-			unfolded.append(raw_line)
+    # Unfold continuation lines (a line beginning with a space/tab continues the previous one).
+    unfolded: list[str] = []
+    for raw_line in text.replace("\r\n", "\n").replace("\r", "\n").split("\n"):
+        if raw_line[:1] in (" ", "\t") and unfolded:
+            unfolded[-1] += raw_line[1:]
+        else:
+            unfolded.append(raw_line)
 
-	cards: list[dict] = []
-	card: dict | None = None
-	for line in unfolded:
-		if not line.strip():
-			continue
+    cards: list[dict] = []
+    card: dict | None = None
+    for line in unfolded:
+        if not line.strip():
+            continue
 
-		upper = line.strip().upper()
-		if upper == "BEGIN:VCARD":
-			card = {"@type": "Card", "version": "1.0"}
-			continue
-		if upper == "END:VCARD":
-			if card is not None:
-				_finalize_card(card)
-				cards.append(card)
-			card = None
-			continue
-		if card is None:
-			continue
+        upper = line.strip().upper()
+        if upper == "BEGIN:VCARD":
+            card = {"@type": "Card", "version": "1.0"}
+            continue
+        if upper == "END:VCARD":
+            if card is not None:
+                _finalize_card(card)
+                cards.append(card)
+            card = None
+            continue
+        if card is None:
+            continue
 
-		if ":" not in line:
-			continue
+        if ":" not in line:
+            continue
 
-		name_part, value = line.split(":", 1)
-		segments = _split_escaped(name_part, ";")
-		prop = segments[0].split(".")[-1].upper()  # strip any group prefix (e.g. "item1.EMAIL")
-		params = _parse_params(segments[1:])
+        name_part, value = line.split(":", 1)
+        segments = _split_escaped(name_part, ";")
+        prop = segments[0].split(".")[-1].upper()  # strip any group prefix (e.g. "item1.EMAIL")
+        params = _parse_params(segments[1:])
 
-		_apply_vcard_property(card, prop, value, params)
+        _apply_vcard_property(card, prop, value, params)
 
-	return cards
+    return cards
 
 
 def _parse_params(segments: list[str]) -> dict[str, list[str]]:
-	"""Parses vCard property parameters into a ``{name: [values]}`` map."""
+    """Parses vCard property parameters into a ``{name: [values]}`` map."""
 
-	params: dict[str, list[str]] = {}
-	for segment in segments:
-		if "=" in segment:
-			key, raw = segment.split("=", 1)
-			values = [v.strip().strip('"') for v in raw.split(",") if v.strip()]
-		else:
-			key, values = "TYPE", [segment.strip().strip('"')]
-		params.setdefault(key.upper(), []).extend(values)
-	return params
+    params: dict[str, list[str]] = {}
+    for segment in segments:
+        if "=" in segment:
+            key, raw = segment.split("=", 1)
+            values = [v.strip().strip('"') for v in raw.split(",") if v.strip()]
+        else:
+            key, values = "TYPE", [segment.strip().strip('"')]
+        params.setdefault(key.upper(), []).extend(values)
+    return params
 
 
 def _types_to_contexts(params: dict[str, list[str]]) -> dict[str, bool]:
-	"""Maps vCard TYPE parameter values to a JSContact ``contexts`` map."""
+    """Maps vCard TYPE parameter values to a JSContact ``contexts`` map."""
 
-	reverse = {"work": "work", "home": "private"}
-	contexts = {}
-	for value in params.get("TYPE", []):
-		if context := reverse.get(value.lower()):
-			contexts[context] = True
-	return contexts
+    reverse = {"work": "work", "home": "private"}
+    contexts = {}
+    for value in params.get("TYPE", []):
+        if context := reverse.get(value.lower()):
+            contexts[context] = True
+    return contexts
 
 
 def _apply_vcard_property(card: dict, prop: str, value: str, params: dict[str, list[str]]) -> None:
-	"""Applies a single parsed vCard property to the JSContact card being built."""
+    """Applies a single parsed vCard property to the JSContact card being built."""
 
-	if prop == "UID":
-		card["uid"] = _vcard_unescape(value).replace("urn:uuid:", "")
-	elif prop == "KIND":
-		card["kind"] = _vcard_unescape(value).lower()
-	elif prop == "FN":
-		card.setdefault("name", {})["full"] = _vcard_unescape(value)
-	elif prop == "N":
-		components = []
-		fields = _split_escaped(value, ";")
-		for kind, raw in zip(N_COMPONENT_ORDER, fields, strict=False):
-			for item in _split_escaped(raw, ","):
-				if item:
-					components.append({"kind": kind, "value": _vcard_unescape(item)})
-		if components:
-			card.setdefault("name", {})["components"] = components
-	elif prop == "NICKNAME":
-		for item in _split_escaped(value, ","):
-			if item:
-				card.setdefault("nickNames", {})[str(uuid7())] = {"name": _vcard_unescape(item)}
-	elif prop == "ORG":
-		parts = [_vcard_unescape(p) for p in _split_escaped(value, ";")]
-		org = {"name": parts[0]} if parts else {}
-		if len(parts) > 1:
-			org["units"] = [{"name": unit} for unit in parts[1:] if unit]
-		if org:
-			card.setdefault("organizations", {})[str(uuid7())] = org
-	elif prop in ("TITLE", "ROLE"):
-		card.setdefault("titles", {})[str(uuid7())] = {
-			"name": _vcard_unescape(value),
-			"kind": "role" if prop == "ROLE" else "title",
-		}
-	elif prop == "EMAIL":
-		entry = {"address": _vcard_unescape(value)}
-		if contexts := _types_to_contexts(params):
-			entry["contexts"] = contexts
-		card.setdefault("emails", {})[str(uuid7())] = entry
-	elif prop == "TEL":
-		entry = {"number": _vcard_unescape(value)}
-		if contexts := _types_to_contexts(params):
-			entry["contexts"] = contexts
-		card.setdefault("phones", {})[str(uuid7())] = entry
-	elif prop == "ADR":
-		if address := _vcard_to_address(value, params):
-			card.setdefault("addresses", {})[str(uuid7())] = address
-	elif prop == "NOTE":
-		card.setdefault("notes", {})[str(uuid7())] = {"note": _vcard_unescape(value)}
-	elif prop == "URL":
-		card.setdefault("links", {})[str(uuid7())] = {"uri": _vcard_unescape(value)}
-	elif prop in ("BDAY", "ANNIVERSARY"):
-		card.setdefault("anniversaries", {})[str(uuid7())] = {
-			"kind": "birth" if prop == "BDAY" else "wedding",
-			"date": _vcard_unescape(value),
-		}
-	elif prop == "CATEGORIES":
-		for item in _split_escaped(value, ","):
-			if item:
-				card.setdefault("categories", {})[_vcard_unescape(item)] = True
-	elif prop == "MEMBER":
-		card.setdefault("members", {})[_vcard_unescape(value).replace("urn:uuid:", "")] = True
+    if prop == "UID":
+        card["uid"] = _vcard_unescape(value).replace("urn:uuid:", "")
+    elif prop == "KIND":
+        card["kind"] = _vcard_unescape(value).lower()
+    elif prop == "FN":
+        card.setdefault("name", {})["full"] = _vcard_unescape(value)
+    elif prop == "N":
+        components = []
+        fields = _split_escaped(value, ";")
+        for kind, raw in zip(N_COMPONENT_ORDER, fields, strict=False):
+            for item in _split_escaped(raw, ","):
+                if item:
+                    components.append({"kind": kind, "value": _vcard_unescape(item)})
+        if components:
+            card.setdefault("name", {})["components"] = components
+    elif prop == "NICKNAME":
+        for item in _split_escaped(value, ","):
+            if item:
+                card.setdefault("nickNames", {})[str(uuid7())] = {"name": _vcard_unescape(item)}
+    elif prop == "ORG":
+        parts = [_vcard_unescape(p) for p in _split_escaped(value, ";")]
+        org = {"name": parts[0]} if parts else {}
+        if len(parts) > 1:
+            org["units"] = [{"name": unit} for unit in parts[1:] if unit]
+        if org:
+            card.setdefault("organizations", {})[str(uuid7())] = org
+    elif prop in ("TITLE", "ROLE"):
+        card.setdefault("titles", {})[str(uuid7())] = {
+            "name": _vcard_unescape(value),
+            "kind": "role" if prop == "ROLE" else "title",
+        }
+    elif prop == "EMAIL":
+        entry = {"address": _vcard_unescape(value)}
+        if contexts := _types_to_contexts(params):
+            entry["contexts"] = contexts
+        card.setdefault("emails", {})[str(uuid7())] = entry
+    elif prop == "TEL":
+        entry = {"number": _vcard_unescape(value)}
+        if contexts := _types_to_contexts(params):
+            entry["contexts"] = contexts
+        card.setdefault("phones", {})[str(uuid7())] = entry
+    elif prop == "ADR":
+        if address := _vcard_to_address(value, params):
+            card.setdefault("addresses", {})[str(uuid7())] = address
+    elif prop == "NOTE":
+        card.setdefault("notes", {})[str(uuid7())] = {"note": _vcard_unescape(value)}
+    elif prop == "URL":
+        card.setdefault("links", {})[str(uuid7())] = {"uri": _vcard_unescape(value)}
+    elif prop in ("BDAY", "ANNIVERSARY"):
+        card.setdefault("anniversaries", {})[str(uuid7())] = {
+            "kind": "birth" if prop == "BDAY" else "wedding",
+            "date": _vcard_unescape(value),
+        }
+    elif prop == "CATEGORIES":
+        for item in _split_escaped(value, ","):
+            if item:
+                card.setdefault("categories", {})[_vcard_unescape(item)] = True
+    elif prop == "MEMBER":
+        card.setdefault("members", {})[_vcard_unescape(value).replace("urn:uuid:", "")] = True
 
 
 def _vcard_to_address(value: str, params: dict[str, list[str]]) -> dict | None:
-	"""Builds a JSContact address from a vCard ADR value."""
+    """Builds a JSContact address from a vCard ADR value."""
 
-	fields = _split_escaped(value, ";")
-	# ADR structure: POBox;Ext;Street;Locality;Region;Postcode;Country
-	kinds = ["postOfficeBox", "apartment", "name", "locality", "region", "postcode", "country"]
-	components = []
-	for kind, raw in zip(kinds, fields, strict=False):
-		for item in _split_escaped(raw, ","):
-			if item:
-				components.append({"kind": kind, "value": _vcard_unescape(item)})
+    fields = _split_escaped(value, ";")
+    # ADR structure: POBox;Ext;Street;Locality;Region;Postcode;Country
+    kinds = ["postOfficeBox", "apartment", "name", "locality", "region", "postcode", "country"]
+    components = []
+    for kind, raw in zip(kinds, fields, strict=False):
+        for item in _split_escaped(raw, ","):
+            if item:
+                components.append({"kind": kind, "value": _vcard_unescape(item)})
 
-	if not components:
-		return None
+    if not components:
+        return None
 
-	address = {"components": components}
-	reverse = {"work": "work", "home": "private"}
-	contexts = {reverse[v.lower()]: True for v in params.get("TYPE", []) if v.lower() in reverse}
-	if contexts:
-		address["contexts"] = contexts
-	return address
+    address = {"components": components}
+    reverse = {"work": "work", "home": "private"}
+    contexts = {reverse[v.lower()]: True for v in params.get("TYPE", []) if v.lower() in reverse}
+    if contexts:
+        address["contexts"] = contexts
+    return address
 
 
 def _finalize_card(card: dict) -> None:
-	"""Ensures a parsed card has a UID and a display name so it round-trips cleanly."""
+    """Ensures a parsed card has a UID and a display name so it round-trips cleanly."""
 
-	if not card.get("uid"):
-		card["uid"] = str(uuid7())
-	name = card.get("name") or {}
-	if not name.get("full") and name.get("components"):
-		full = " ".join(
-			c["value"] for c in name["components"] if c.get("kind") in ("given", "surname") and c.get("value")
-		)
-		if full:
-			card.setdefault("name", {})["full"] = full
+    if not card.get("uid"):
+        card["uid"] = str(uuid7())
+    name = card.get("name") or {}
+    if not name.get("full") and name.get("components"):
+        full = " ".join(
+            c["value"] for c in name["components"] if c.get("kind") in ("given", "surname") and c.get("value")
+        )
+        if full:
+            card.setdefault("name", {})["full"] = full
 
 
 def retry_stuck_contacts_exchanges() -> None:
-	"""Called by the scheduler to retry stuck contacts exchanges."""
+    """Called by the scheduler to retry stuck contacts exchanges."""
 
-	CE = frappe.qb.DocType("Contacts Exchange")
-	exchanges = (
-		frappe.qb.from_(CE)
-		.select(CE.name)
-		.where(
-			(CE.status.isin(["Queued", "In Progress"]))
-			& (CE.queued_at <= get_datetime(add_to_date(now(), days=-1)))
-		)
-		.orderby(CE.queued_at, order=Order.asc)
-	).run(pluck="name")
+    CE = frappe.qb.DocType("Contacts Exchange")
+    exchanges = (
+        frappe.qb.from_(CE)
+        .select(CE.name)
+        .where(
+            (CE.status.isin(["Queued", "In Progress"]))
+            & (CE.queued_at <= get_datetime(add_to_date(now(), days=-1)))
+        )
+        .orderby(CE.queued_at, order=Order.asc)
+    ).run(pluck="name")
 
-	# retry() throws for a document that no longer qualifies, and a scheduler job has no
-	# caller to surface that to - so isolate each one, or the first bad document silently
-	# strands every exchange queued behind it, run after run.
-	for exchange in exchanges:
-		try:
-			frappe.get_doc("Contacts Exchange", exchange).retry()
-		except Exception:
-			frappe.db.rollback()
-			log_error(
-				module="Mail",
-				title=f"Failed to retry stuck Contacts Exchange {exchange}",
-				message=frappe.get_traceback(),
-			)
+    # retry() throws for a document that no longer qualifies, and a scheduler job has no
+    # caller to surface that to - so isolate each one, or the first bad document silently
+    # strands every exchange queued behind it, run after run.
+    for exchange in exchanges:
+        try:
+            frappe.get_doc("Contacts Exchange", exchange).retry()
+        except Exception:
+            frappe.db.rollback()
+            log_error(
+                module="Mail",
+                title=f"Failed to retry stuck Contacts Exchange {exchange}",
+                message=frappe.get_traceback(),
+            )
 
 
 def clean_contacts_import_export_directories() -> None:
-	"""Called by the scheduler to clean up contacts import and export directories."""
+    """Called by the scheduler to clean up contacts import and export directories."""
 
-	for base in (get_contacts_import_directory(), get_contacts_export_directory()):
-		if not os.path.exists(base):
-			continue
+    for base in (get_contacts_import_directory(), get_contacts_export_directory()):
+        if not os.path.exists(base):
+            continue
 
-		for item in os.listdir(base):
-			path = os.path.join(base, item)
-			if os.path.isdir(path):
-				if frappe.db.exists("Contacts Exchange", {"name": item, "status": "In Progress"}):
-					continue
-				shutil.rmtree(path, ignore_errors=True)
-			else:
-				os.remove(path)
+        for item in os.listdir(base):
+            path = os.path.join(base, item)
+            if os.path.isdir(path):
+                if frappe.db.exists("Contacts Exchange", {"name": item, "status": "In Progress"}):
+                    continue
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                os.remove(path)

--- a/suite/mail/doctype/contacts_exchange/test_contacts_exchange.py
+++ b/suite/mail/doctype/contacts_exchange/test_contacts_exchange.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestContactsExchange(IntegrationTestCase):
-	"""
-	Integration tests for ContactsExchange.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for ContactsExchange.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/dns_record/dns_provider.py
+++ b/suite/mail/doctype/dns_record/dns_provider.py
@@ -71,7 +71,7 @@ class DNSProvider:
         self.zone_id = zone_id
         self.private_zone = private_zone
 
-    def get_client(self, config: dict) -> "Client":
+    def get_client(self, config: dict) -> Client:
         """Internal helper to return a configured Lexicon client."""
 
         from lexicon.client import Client

--- a/suite/mail/doctype/dns_record/dns_provider.py
+++ b/suite/mail/doctype/dns_record/dns_provider.py
@@ -2,188 +2,188 @@ from enum import Enum
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
-	from lexicon.client import Client
+    from lexicon.client import Client
 
 
 class DNSProviderEnum(str, Enum):
-	AMAZON_ROUTE53 = "AmazonRoute53"
-	DIGITALOCEAN = "DigitalOcean"
-	CLOUDFLARE = "Cloudflare"
-	HETZNER = "Hetzner"
-	LINODE = "Linode"
-	NAMECHEAP = "Namecheap"
-	GODADDY = "GoDaddy"
+    AMAZON_ROUTE53 = "AmazonRoute53"
+    DIGITALOCEAN = "DigitalOcean"
+    CLOUDFLARE = "Cloudflare"
+    HETZNER = "Hetzner"
+    LINODE = "Linode"
+    NAMECHEAP = "Namecheap"
+    GODADDY = "GoDaddy"
 
 
 DNSProviderLiteral = Literal[
-	DNSProviderEnum.AMAZON_ROUTE53,
-	DNSProviderEnum.DIGITALOCEAN,
-	DNSProviderEnum.CLOUDFLARE,
-	DNSProviderEnum.HETZNER,
-	DNSProviderEnum.LINODE,
-	DNSProviderEnum.NAMECHEAP,
-	DNSProviderEnum.GODADDY,
+    DNSProviderEnum.AMAZON_ROUTE53,
+    DNSProviderEnum.DIGITALOCEAN,
+    DNSProviderEnum.CLOUDFLARE,
+    DNSProviderEnum.HETZNER,
+    DNSProviderEnum.LINODE,
+    DNSProviderEnum.NAMECHEAP,
+    DNSProviderEnum.GODADDY,
 ]
 
 
 DNS_PROVIDER_MAP = {
-	DNSProviderEnum.AMAZON_ROUTE53: "route53",
-	DNSProviderEnum.DIGITALOCEAN: "digitalocean",
-	DNSProviderEnum.CLOUDFLARE: "cloudflare",
-	DNSProviderEnum.HETZNER: "hetzner",
-	DNSProviderEnum.LINODE: "linode",
-	DNSProviderEnum.NAMECHEAP: "namecheap",
-	DNSProviderEnum.GODADDY: "godaddy",
+    DNSProviderEnum.AMAZON_ROUTE53: "route53",
+    DNSProviderEnum.DIGITALOCEAN: "digitalocean",
+    DNSProviderEnum.CLOUDFLARE: "cloudflare",
+    DNSProviderEnum.HETZNER: "hetzner",
+    DNSProviderEnum.LINODE: "linode",
+    DNSProviderEnum.NAMECHEAP: "namecheap",
+    DNSProviderEnum.GODADDY: "godaddy",
 }
 
 
 class DNSProvider:
-	"""A DNS provider utility wrapper using Lexicon to interact with major DNS services."""
+    """A DNS provider utility wrapper using Lexicon to interact with major DNS services."""
 
-	def __init__(
-		self,
-		provider: DNSProviderLiteral,
-		domain: str,
-		access_key: str | None = None,
-		access_secret: str | None = None,
-		auth_key: str | None = None,
-		auth_secret: str | None = None,
-		username: str | None = None,
-		token: str | None = None,
-		client_ip: str | None = None,
-		zone_id: str | None = None,
-		private_zone: bool = False,
-	) -> None:
-		"""Initializes the DNSProvider with credentials and domain."""
+    def __init__(
+        self,
+        provider: DNSProviderLiteral,
+        domain: str,
+        access_key: str | None = None,
+        access_secret: str | None = None,
+        auth_key: str | None = None,
+        auth_secret: str | None = None,
+        username: str | None = None,
+        token: str | None = None,
+        client_ip: str | None = None,
+        zone_id: str | None = None,
+        private_zone: bool = False,
+    ) -> None:
+        """Initializes the DNSProvider with credentials and domain."""
 
-		if provider not in DNS_PROVIDER_MAP:
-			raise ValueError(f"Unsupported DNS Provider: {provider}")
+        if provider not in DNS_PROVIDER_MAP:
+            raise ValueError(f"Unsupported DNS Provider: {provider}")
 
-		self.provider = DNS_PROVIDER_MAP[provider]
-		self.domain = domain
-		self.__access_key = access_key
-		self.__access_secret = access_secret
-		self.__auth_key = auth_key
-		self.__auth_secret = auth_secret
-		self.__username = username
-		self.__token = token
-		self.client_ip = client_ip
-		self.zone_id = zone_id
-		self.private_zone = private_zone
+        self.provider = DNS_PROVIDER_MAP[provider]
+        self.domain = domain
+        self.__access_key = access_key
+        self.__access_secret = access_secret
+        self.__auth_key = auth_key
+        self.__auth_secret = auth_secret
+        self.__username = username
+        self.__token = token
+        self.client_ip = client_ip
+        self.zone_id = zone_id
+        self.private_zone = private_zone
 
-	def get_client(self, config: dict) -> "Client":
-		"""Internal helper to return a configured Lexicon client."""
+    def get_client(self, config: dict) -> "Client":
+        """Internal helper to return a configured Lexicon client."""
 
-		from lexicon.client import Client
+        from lexicon.client import Client
 
-		config.update(
-			{
-				"provider_name": self.provider,
-				"domain": self.domain,
-				"auth_access_key": self.__access_key,
-				"auth_access_secret": self.__access_secret,
-				"auth_key": self.__auth_key,
-				"auth_secret": self.__auth_secret,
-				"auth_username": self.__username,
-				"auth_token": self.__token,
-				"auth_client_ip": self.client_ip,
-				"zone_id": self.zone_id,
-				"private_zone": self.private_zone,
-			}
-		)
-		client = Client(config)
-		return client
+        config.update(
+            {
+                "provider_name": self.provider,
+                "domain": self.domain,
+                "auth_access_key": self.__access_key,
+                "auth_access_secret": self.__access_secret,
+                "auth_key": self.__auth_key,
+                "auth_secret": self.__auth_secret,
+                "auth_username": self.__username,
+                "auth_token": self.__token,
+                "auth_client_ip": self.client_ip,
+                "zone_id": self.zone_id,
+                "private_zone": self.private_zone,
+            }
+        )
+        client = Client(config)
+        return client
 
-	def create_dns_record(self, type: str, host: str, value: str, ttl: int, priority: int = 0) -> bool:
-		"""Creates a new DNS record."""
+    def create_dns_record(self, type: str, host: str, value: str, ttl: int, priority: int = 0) -> bool:
+        """Creates a new DNS record."""
 
-		config = {
-			"action": "create",
-			"type": type,
-			"name": host,
-			"content": value,
-			"ttl": ttl,
-			"priority": priority,
-		}
-		client = self.get_client(config)
-		return client.execute()
+        config = {
+            "action": "create",
+            "type": type,
+            "name": host,
+            "content": value,
+            "ttl": ttl,
+            "priority": priority,
+        }
+        client = self.get_client(config)
+        return client.execute()
 
-	def read_dns_records(self, type: str, host: str | None = None) -> list[dict]:
-		"""Fetches DNS records matching type and optional host."""
+    def read_dns_records(self, type: str, host: str | None = None) -> list[dict]:
+        """Fetches DNS records matching type and optional host."""
 
-		config = {
-			"action": "list",
-		}
-		if type:
-			config["type"] = type
-		if host:
-			config["name"] = host
+        config = {
+            "action": "list",
+        }
+        if type:
+            config["type"] = type
+        if host:
+            config["name"] = host
 
-		client = self.get_client(config)
-		return client.execute()
+        client = self.get_client(config)
+        return client.execute()
 
-	def update_dns_record(
-		self,
-		type: str,
-		host: str,
-		value: str,
-		ttl: int,
-		priority: int = 0,
-		record_id: int | str | None = None,
-	) -> bool:
-		"""Updates an existing DNS record."""
+    def update_dns_record(
+        self,
+        type: str,
+        host: str,
+        value: str,
+        ttl: int,
+        priority: int = 0,
+        record_id: int | str | None = None,
+    ) -> bool:
+        """Updates an existing DNS record."""
 
-		if not record_id:
-			records = self.read_dns_records(type=type, host=host)
-			if not records:
-				raise ValueError(f"No record found for {host}")
+        if not record_id:
+            records = self.read_dns_records(type=type, host=host)
+            if not records:
+                raise ValueError(f"No record found for {host}")
 
-			record_id = records[0]["id"]
+            record_id = records[0]["id"]
 
-		config = {
-			"action": "update",
-			"type": type,
-			"name": host,
-			"content": value,
-			"ttl": ttl,
-			"priority": priority,
-			"identifier": record_id,
-		}
-		client = self.get_client(config)
-		return client.execute()
+        config = {
+            "action": "update",
+            "type": type,
+            "name": host,
+            "content": value,
+            "ttl": ttl,
+            "priority": priority,
+            "identifier": record_id,
+        }
+        client = self.get_client(config)
+        return client.execute()
 
-	def delete_dns_record(self, type: str, host: str, delete_all: bool = False) -> bool:
-		"""Deletes DNS record(s) for a given type and host."""
+    def delete_dns_record(self, type: str, host: str, delete_all: bool = False) -> bool:
+        """Deletes DNS record(s) for a given type and host."""
 
-		records = self.read_dns_records(type=type, host=host)
-		if not records:
-			return True
+        records = self.read_dns_records(type=type, host=host)
+        if not records:
+            return True
 
-		success = True
+        success = True
 
-		for record in records if delete_all else [records[0]]:
-			config = {
-				"action": "delete",
-				"type": type,
-				"name": host,
-				"identifier": record["id"],
-			}
-			client = self.get_client(config)
-			try:
-				client.execute()
-			except Exception:
-				success = False
+        for record in records if delete_all else [records[0]]:
+            config = {
+                "action": "delete",
+                "type": type,
+                "name": host,
+                "identifier": record["id"],
+            }
+            client = self.get_client(config)
+            try:
+                client.execute()
+            except Exception:
+                success = False
 
-		return success
+        return success
 
-	def create_or_update_dns_record(
-		self, type: str, host: str, value: str, ttl: int, priority: int = 0
-	) -> bool:
-		"""Creates a new record if none exists; otherwise, updates the first matching record."""
+    def create_or_update_dns_record(
+        self, type: str, host: str, value: str, ttl: int, priority: int = 0
+    ) -> bool:
+        """Creates a new record if none exists; otherwise, updates the first matching record."""
 
-		records = self.read_dns_records(type=type, host=host)
-		if records:
-			record_id = records[0]["id"]
-			return self.update_dns_record(type, host, value, ttl, priority, record_id=record_id)
-		else:
-			return self.create_dns_record(type, host, value, ttl, priority)
+        records = self.read_dns_records(type=type, host=host)
+        if records:
+            record_id = records[0]["id"]
+            return self.update_dns_record(type, host, value, ttl, priority, record_id=record_id)
+        else:
+            return self.create_dns_record(type, host, value, ttl, priority)

--- a/suite/mail/doctype/dns_record/dns_record.py
+++ b/suite/mail/doctype/dns_record/dns_record.py
@@ -15,196 +15,196 @@ from suite.utils import enqueue_job, user_context
 
 
 class DNSRecord(Document):
-	@cached_property
-	def fqdn(self) -> str:
-		"""Returns the Fully Qualified Domain Name"""
+    @cached_property
+    def fqdn(self) -> str:
+        """Returns the Fully Qualified Domain Name"""
 
-		root_domain_name = frappe.db.get_single_value("Mail Settings", "root_domain_name")
-		if not root_domain_name:
-			frappe.throw(_("Please set the Root Domain Name in Mail Settings."))
+        root_domain_name = frappe.db.get_single_value("Mail Settings", "root_domain_name")
+        if not root_domain_name:
+            frappe.throw(_("Please set the Root Domain Name in Mail Settings."))
 
-		return f"{self.host}.{root_domain_name}"
+        return f"{self.host}.{root_domain_name}"
 
-	def validate(self) -> None:
-		if self.is_new():
-			self.validate_duplicate_record()
+    def validate(self) -> None:
+        if self.is_new():
+            self.validate_duplicate_record()
 
-		self.validate_ttl()
+        self.validate_ttl()
 
-	def on_update(self) -> None:
-		if self.has_value_changed("value") or self.has_value_changed("ttl"):
-			if frappe.flags.do_not_enqueue:
-				self.create_or_update_record_in_dns_provider()
-				self.reload()
-			else:
-				frappe.enqueue_doc(
-					self.doctype,
-					self.name,
-					"create_or_update_record_in_dns_provider",
-					queue="short",
-					enqueue_after_commit=True,
-					at_front=True,
-				)
+    def on_update(self) -> None:
+        if self.has_value_changed("value") or self.has_value_changed("ttl"):
+            if frappe.flags.do_not_enqueue:
+                self.create_or_update_record_in_dns_provider()
+                self.reload()
+            else:
+                frappe.enqueue_doc(
+                    self.doctype,
+                    self.name,
+                    "create_or_update_record_in_dns_provider",
+                    queue="short",
+                    enqueue_after_commit=True,
+                    at_front=True,
+                )
 
-	def on_trash(self) -> None:
-		self.delete_record_from_dns_provider()
+    def on_trash(self) -> None:
+        self.delete_record_from_dns_provider()
 
-	def validate_duplicate_record(self) -> None:
-		"""Validates if a duplicate DNS Record exists"""
+    def validate_duplicate_record(self) -> None:
+        """Validates if a duplicate DNS Record exists"""
 
-		if frappe.db.exists(
-			"DNS Record",
-			{"host": self.host, "type": self.type, "name": ["!=", self.name]},
-		):
-			frappe.throw(
-				_("DNS Record with the same host and type already exists."),
-				title=_("Duplicate Record"),
-			)
+        if frappe.db.exists(
+            "DNS Record",
+            {"host": self.host, "type": self.type, "name": ["!=", self.name]},
+        ):
+            frappe.throw(
+                _("DNS Record with the same host and type already exists."),
+                title=_("Duplicate Record"),
+            )
 
-	def validate_ttl(self) -> None:
-		"""Validates the TTL value"""
+    def validate_ttl(self) -> None:
+        """Validates the TTL value"""
 
-		self.ttl = self.ttl or cint(get_config("default_dns_ttl"))
+        self.ttl = self.ttl or cint(get_config("default_dns_ttl"))
 
-	@frappe.whitelist()
-	def sync_dns_record(self) -> None:
-		"""Syncs the DNS Record"""
+    @frappe.whitelist()
+    def sync_dns_record(self) -> None:
+        """Syncs the DNS Record"""
 
-		self.create_or_update_record_in_dns_provider()
+        self.create_or_update_record_in_dns_provider()
 
-	def create_or_update_record_in_dns_provider(self) -> None:
-		"""Creates or Updates the DNS Record in the DNS Provider"""
+    def create_or_update_record_in_dns_provider(self) -> None:
+        """Creates or Updates the DNS Record in the DNS Provider"""
 
-		result = False
-		dns_provider = get_dns_provider()
+        result = False
+        dns_provider = get_dns_provider()
 
-		if dns_provider:
-			result = dns_provider.create_or_update_dns_record(
-				type=self.type,
-				host=self.host,
-				value=self.value,
-				ttl=self.ttl,
-				priority=self.priority,
-			)
+        if dns_provider:
+            result = dns_provider.create_or_update_dns_record(
+                type=self.type,
+                host=self.host,
+                value=self.value,
+                ttl=self.ttl,
+                priority=self.priority,
+            )
 
-		self._db_set(is_verified=cint(result), last_checked_at=now(), notify=True)
+        self._db_set(is_verified=cint(result), last_checked_at=now(), notify=True)
 
-	def delete_record_from_dns_provider(self) -> None:
-		"""Deletes the DNS Record from the DNS Provider"""
+    def delete_record_from_dns_provider(self) -> None:
+        """Deletes the DNS Record from the DNS Provider"""
 
-		dns_provider = get_dns_provider()
+        dns_provider = get_dns_provider()
 
-		if not dns_provider:
-			return
+        if not dns_provider:
+            return
 
-		dns_provider.delete_dns_record(type=self.type, host=self.host)
+        dns_provider.delete_dns_record(type=self.type, host=self.host)
 
-	@frappe.whitelist()
-	def verify_dns_record(self, save: bool = False) -> None:
-		"""Verifies the DNS Record"""
+    @frappe.whitelist()
+    def verify_dns_record(self, save: bool = False) -> None:
+        """Verifies the DNS Record"""
 
-		self.is_verified = 0
-		self.last_checked_at = now()
-		if verify_dns_record(self.fqdn, self.type, self.value):
-			self.is_verified = 1
-			frappe.msgprint(
-				_("Verified {0}:{1} record.").format(frappe.bold(self.fqdn), frappe.bold(self.type)),
-				indicator="green",
-				alert=True,
-			)
-		else:
-			frappe.msgprint(
-				_("Could not verify {0}:{1} record.").format(frappe.bold(self.fqdn), frappe.bold(self.type)),
-				indicator="orange",
-				alert=True,
-			)
+        self.is_verified = 0
+        self.last_checked_at = now()
+        if verify_dns_record(self.fqdn, self.type, self.value):
+            self.is_verified = 1
+            frappe.msgprint(
+                _("Verified {0}:{1} record.").format(frappe.bold(self.fqdn), frappe.bold(self.type)),
+                indicator="green",
+                alert=True,
+            )
+        else:
+            frappe.msgprint(
+                _("Could not verify {0}:{1} record.").format(frappe.bold(self.fqdn), frappe.bold(self.type)),
+                indicator="orange",
+                alert=True,
+            )
 
-		if save:
-			self.save()
+        if save:
+            self.save()
 
-	def _db_set(
-		self,
-		update_modified: bool = True,
-		commit: bool = False,
-		notify: bool = False,
-		**kwargs,
-	) -> None:
-		"""Updates the document with the given key-value pairs."""
+    def _db_set(
+        self,
+        update_modified: bool = True,
+        commit: bool = False,
+        notify: bool = False,
+        **kwargs,
+    ) -> None:
+        """Updates the document with the given key-value pairs."""
 
-		self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
+        self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
 
 
 def create_or_update_dns_record(
-	host: str,
-	type: str,
-	value: str,
-	ttl: int | None = None,
-	priority: int | None = None,
-	category: str | None = None,
-	do_not_enqueue: bool = False,
+    host: str,
+    type: str,
+    value: str,
+    ttl: int | None = None,
+    priority: int | None = None,
+    category: str | None = None,
+    do_not_enqueue: bool = False,
 ) -> "DNSRecord":
-	"""Creates or updates a DNS Record"""
+    """Creates or updates a DNS Record"""
 
-	if do_not_enqueue:
-		frappe.flags.do_not_enqueue = True
+    if do_not_enqueue:
+        frappe.flags.do_not_enqueue = True
 
-	if dns_record := frappe.db.exists("DNS Record", {"host": host, "type": type}):
-		dns_record = frappe.get_doc("DNS Record", dns_record)
-	else:
-		dns_record = frappe.new_doc("DNS Record")
-		dns_record.host = host
-		dns_record.type = type
+    if dns_record := frappe.db.exists("DNS Record", {"host": host, "type": type}):
+        dns_record = frappe.get_doc("DNS Record", dns_record)
+    else:
+        dns_record = frappe.new_doc("DNS Record")
+        dns_record.host = host
+        dns_record.type = type
 
-	dns_record.value = value
-	dns_record.ttl = ttl
-	dns_record.priority = priority
-	dns_record.category = category
-	dns_record.save(ignore_permissions=True)
+    dns_record.value = value
+    dns_record.ttl = ttl
+    dns_record.priority = priority
+    dns_record.category = category
+    dns_record.save(ignore_permissions=True)
 
-	return dns_record
+    return dns_record
 
 
 def verify_all_dns_records() -> None:
-	"""Verifies all DNS Records"""
+    """Verifies all DNS Records"""
 
-	dns_records = frappe.db.get_all("DNS Record", filters={}, pluck="name")
-	for dns_record in dns_records:
-		dns_record = frappe.get_doc("DNS Record", dns_record)
-		dns_record.verify_dns_record(save=True)
+    dns_records = frappe.db.get_all("DNS Record", filters={}, pluck="name")
+    for dns_record in dns_records:
+        dns_record = frappe.get_doc("DNS Record", dns_record)
+        dns_record.verify_dns_record(save=True)
 
 
 @frappe.whitelist()
 def enqueue_verify_all_dns_records() -> None:
-	"Called by the scheduler to enqueue the `verify_all_dns_records` job."
+    "Called by the scheduler to enqueue the `verify_all_dns_records` job."
 
-	frappe.only_for("System Manager")
+    frappe.only_for("System Manager")
 
-	with user_context("Administrator"):
-		enqueue_job(verify_all_dns_records, queue="long", deduplicate=True)
+    with user_context("Administrator"):
+        enqueue_job(verify_all_dns_records, queue="long", deduplicate=True)
 
 
 def get_dns_provider(mail_settings: str | None = None) -> DNSProvider | None:
-	"""Returns an instance of the DNS Provider"""
+    """Returns an instance of the DNS Provider"""
 
-	mail_settings = mail_settings or frappe.get_single("Mail Settings")
+    mail_settings = mail_settings or frappe.get_single("Mail Settings")
 
-	if not mail_settings.dns_provider:
-		return
+    if not mail_settings.dns_provider:
+        return
 
-	return DNSProvider(
-		provider=mail_settings.dns_provider,
-		domain=mail_settings.root_domain_name,
-		access_key=mail_settings.dns_provider_access_key,
-		access_secret=password_or_none(mail_settings, "dns_provider_access_secret"),
-		auth_key=mail_settings.dns_provider_key,
-		auth_secret=password_or_none(mail_settings, "dns_provider_secret"),
-		username=mail_settings.dns_provider_username,
-		token=password_or_none(mail_settings, "dns_provider_token"),
-		client_ip=mail_settings.dns_provider_client_ip,
-		zone_id=mail_settings.dns_provider_zone_id,
-		private_zone=bool(mail_settings.dns_provider_private_zone),
-	)
+    return DNSProvider(
+        provider=mail_settings.dns_provider,
+        domain=mail_settings.root_domain_name,
+        access_key=mail_settings.dns_provider_access_key,
+        access_secret=password_or_none(mail_settings, "dns_provider_access_secret"),
+        auth_key=mail_settings.dns_provider_key,
+        auth_secret=password_or_none(mail_settings, "dns_provider_secret"),
+        username=mail_settings.dns_provider_username,
+        token=password_or_none(mail_settings, "dns_provider_token"),
+        client_ip=mail_settings.dns_provider_client_ip,
+        zone_id=mail_settings.dns_provider_zone_id,
+        private_zone=bool(mail_settings.dns_provider_private_zone),
+    )
 
 
 def on_doctype_update() -> None:
-	frappe.db.add_unique("DNS Record", ["host", "type"])
+    frappe.db.add_unique("DNS Record", ["host", "type"])

--- a/suite/mail/doctype/dns_record/dns_record.py
+++ b/suite/mail/doctype/dns_record/dns_record.py
@@ -142,7 +142,7 @@ def create_or_update_dns_record(
     priority: int | None = None,
     category: str | None = None,
     do_not_enqueue: bool = False,
-) -> "DNSRecord":
+) -> DNSRecord:
     """Creates or updates a DNS Record"""
 
     if do_not_enqueue:

--- a/suite/mail/doctype/dns_record/test_dns_record.py
+++ b/suite/mail/doctype/dns_record/test_dns_record.py
@@ -6,4 +6,4 @@ from frappe.tests.utils import FrappeTestCase
 
 
 class TestDNSRecord(FrappeTestCase):
-	pass
+    pass

--- a/suite/mail/doctype/email_address/email_address.py
+++ b/suite/mail/doctype/email_address/email_address.py
@@ -6,26 +6,26 @@ from frappe.model.document import Document
 
 
 class EmailAddress(Document):
-	def db_insert(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_insert(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def load_from_db(self):
-		raise NotImplementedError
+    def load_from_db(self):
+        raise NotImplementedError
 
-	def db_update(self):
-		raise NotImplementedError
+    def db_update(self):
+        raise NotImplementedError
 
-	def delete(self):
-		raise NotImplementedError
+    def delete(self):
+        raise NotImplementedError
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs):
-		pass
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs):
+        pass
 
-	@staticmethod
-	def get_count(filters=None, **kwargs):
-		pass
+    @staticmethod
+    def get_count(filters=None, **kwargs):
+        pass
 
-	@staticmethod
-	def get_stats(**kwargs):
-		pass
+    @staticmethod
+    def get_stats(**kwargs):
+        pass

--- a/suite/mail/doctype/identity/identity.py
+++ b/suite/mail/doctype/identity/identity.py
@@ -15,294 +15,294 @@ from suite.utils import parse_filters
 
 
 class Identity(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		from suite.mail.doctype.email_address.email_address import EmailAddress
+        from suite.mail.doctype.email_address.email_address import EmailAddress
 
-		_name: DF.Data | None
-		account: DF.Link
-		bcc: DF.Table[EmailAddress]
-		email: DF.Data
-		html_signature: DF.HTMLEditor | None
-		id: DF.Data | None
-		may_delete: DF.Check
-		reply_to: DF.Table[EmailAddress]
-		text_signature: DF.Code | None
-	# end: auto-generated types
+        _name: DF.Data | None
+        account: DF.Link
+        bcc: DF.Table[EmailAddress]
+        email: DF.Data
+        html_signature: DF.HTMLEditor | None
+        id: DF.Data | None
+        may_delete: DF.Check
+        reply_to: DF.Table[EmailAddress]
+        text_signature: DF.Code | None
+    # end: auto-generated types
 
-	@property
-	def _bcc(self) -> list[dict]:
-		"""Returns the BCC list in the JMAP required format."""
+    @property
+    def _bcc(self) -> list[dict]:
+        """Returns the BCC list in the JMAP required format."""
 
-		bcc = []
-		for b in self.bcc:
-			bcc.append({"name": b.display_name, "email": b.email})
-		return bcc
+        bcc = []
+        for b in self.bcc:
+            bcc.append({"name": b.display_name, "email": b.email})
+        return bcc
 
-	@property
-	def _reply_to(self) -> list[dict]:
-		"""Returns the Reply-To list in the JMAP required format."""
+    @property
+    def _reply_to(self) -> list[dict]:
+        """Returns the Reply-To list in the JMAP required format."""
 
-		reply_to = []
-		for r in self.reply_to:
-			reply_to.append({"name": r.display_name, "email": r.email})
-		return reply_to
+        reply_to = []
+        for r in self.reply_to:
+            reply_to.append({"name": r.display_name, "email": r.email})
+        return reply_to
 
-	def db_insert(self, *args, **kwargs) -> None:
-		self.id = add_identity(
-			self.account,
-			self.email,
-			self._name,
-			self._reply_to,
-			self._bcc,
-			self.text_signature,
-			self.html_signature,
-		)
-		self.name = f"{self.account}|{self.id}"
+    def db_insert(self, *args, **kwargs) -> None:
+        self.id = add_identity(
+            self.account,
+            self.email,
+            self._name,
+            self._reply_to,
+            self._bcc,
+            self.text_signature,
+            self.html_signature,
+        )
+        self.name = f"{self.account}|{self.id}"
 
-	def load_from_db(self) -> "Identity":
-		account, id = parse_identity_name(self.name)
-		identity = get_identity(account, id)
-		return super(Document, self).__init__(identity)
+    def load_from_db(self) -> "Identity":
+        account, id = parse_identity_name(self.name)
+        identity = get_identity(account, id)
+        return super(Document, self).__init__(identity)
 
-	def db_update(self) -> None:
-		account, id = parse_identity_name(self.name)
-		update_identity(
-			account,
-			id,
-			self._name,
-			self._reply_to,
-			self._bcc,
-			self.text_signature,
-			self.html_signature,
-		)
-		self.reload()
+    def db_update(self) -> None:
+        account, id = parse_identity_name(self.name)
+        update_identity(
+            account,
+            id,
+            self._name,
+            self._reply_to,
+            self._bcc,
+            self.text_signature,
+            self.html_signature,
+        )
+        self.reload()
 
-	def delete(self) -> None:
-		account, id = parse_identity_name(self.name)
-		delete_identities(account, [id])
+    def delete(self) -> None:
+        account, id = parse_identity_name(self.name)
+        delete_identities(account, [id])
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs) -> list:
-		filters = parse_filters(filters)
-		id = filters.get("id")
-		account = filters.get("account")
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs) -> list:
+        filters = parse_filters(filters)
+        id = filters.get("id")
+        account = filters.get("account")
 
-		if not account:
-			frappe.msgprint(_("Please select an account to view identities."), alert=True)
-			return []
+        if not account:
+            frappe.msgprint(_("Please select an account to view identities."), alert=True)
+            return []
 
-		identities = []
-		if id:
-			if identity := get_identity(account, id, raise_exception=False):
-				identities.append(identity)
-		else:
-			identities = fetch_identities(account, limit=page_length)
+        identities = []
+        if id:
+            if identity := get_identity(account, id, raise_exception=False):
+                identities.append(identity)
+        else:
+            identities = fetch_identities(account, limit=page_length)
 
-		if not identities:
-			frappe.msgprint(_("No identities found."), alert=True)
+        if not identities:
+            frappe.msgprint(_("No identities found."), alert=True)
 
-		return identities
+        return identities
 
-	@staticmethod
-	def get_count(filters=None, **kwargs) -> int:
-		filters = parse_filters(filters)
-		account = filters.get("account")
+    @staticmethod
+    def get_count(filters=None, **kwargs) -> int:
+        filters = parse_filters(filters)
+        account = filters.get("account")
 
-		if account:
-			if get_user_for_jmap_account(account, raise_exception=False):
-				return cint(frappe.cache.get_value(_get_total_cache_key(account)))
+        if account:
+            if get_user_for_jmap_account(account, raise_exception=False):
+                return cint(frappe.cache.get_value(_get_total_cache_key(account)))
 
-		return 0
+        return 0
 
-	@staticmethod
-	def get_stats(**kwargs) -> dict:
-		return {}
+    @staticmethod
+    def get_stats(**kwargs) -> dict:
+        return {}
 
 
 def _get_total_cache_key(account: str) -> str:
-	"""Returns a cache key for total identities count for the given account."""
+    """Returns a cache key for total identities count for the given account."""
 
-	return f"{account}:identities:total"
+    return f"{account}:identities:total"
 
 
 def parse_identity_name(name: str) -> tuple[str, str]:
-	"""Splits an Identity name `account|id` into its bare `account` and `id`."""
+    """Splits an Identity name `account|id` into its bare `account` and `id`."""
 
-	account, id = name.split("|")
-	return account, id
+    account, id = name.split("|")
+    return account, id
 
 
 @frappe.whitelist()
 def bulk_delete(names: str | list[str]) -> None:
-	"""Deletes multiple identities given their names."""
+    """Deletes multiple identities given their names."""
 
-	if isinstance(names, str):
-		names = json.loads(names)
+    if isinstance(names, str):
+        names = json.loads(names)
 
-	accounts_map = {}
-	for name in names:
-		account, id = parse_identity_name(name)
-		accounts_map.setdefault(account, []).append(id)
+    accounts_map = {}
+    for name in names:
+        account, id = parse_identity_name(name)
+        accounts_map.setdefault(account, []).append(id)
 
-	for account, ids in accounts_map.items():
-		delete_identities(account, ids)
+    for account, ids in accounts_map.items():
+        delete_identities(account, ids)
 
-	frappe.msgprint(_("Identities deleted successfully."), alert=True)
+    frappe.msgprint(_("Identities deleted successfully."), alert=True)
 
 
 @frappe.whitelist()
 def add_identity(
-	account: str,
-	email: str,
-	name: str | None = None,
-	reply_to: list[dict] | None = None,
-	bcc: list[dict] | None = None,
-	text_signature: str | None = None,
-	html_signature: str | None = None,
+    account: str,
+    email: str,
+    name: str | None = None,
+    reply_to: list[dict] | None = None,
+    bcc: list[dict] | None = None,
+    text_signature: str | None = None,
+    html_signature: str | None = None,
 ) -> str:
-	"""Adds an identity for the given account with the specified parameters."""
+    """Adds an identity for the given account with the specified parameters."""
 
-	creation_id = str(uuid7())
-	identity = {
-		"creation_id": creation_id,
-		"email": email,
-		"name": name,
-		"reply_to": reply_to,
-		"bcc": bcc,
-		"text_signature": text_signature,
-		"html_signature": html_signature,
-	}
+    creation_id = str(uuid7())
+    identity = {
+        "creation_id": creation_id,
+        "email": email,
+        "name": name,
+        "reply_to": reply_to,
+        "bcc": bcc,
+        "text_signature": text_signature,
+        "html_signature": html_signature,
+    }
 
-	service = get_identity_service(account)
-	response = service.create([identity])
+    service = get_identity_service(account)
+    response = service.create([identity])
 
-	title = _("Identity Creation Error")
-	if response.get("created"):
-		return response["created"][creation_id]["id"]
-	elif response.get("notCreated"):
-		frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
-	else:
-		frappe.throw(_(response["description"]), title=title)
+    title = _("Identity Creation Error")
+    if response.get("created"):
+        return response["created"][creation_id]["id"]
+    elif response.get("notCreated"):
+        frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
+    else:
+        frappe.throw(_(response["description"]), title=title)
 
 
 @frappe.whitelist()
 def get_identity(account: str, id: str, raise_exception: bool = True) -> dict | None:
-	"""Returns identity details for the given account and id."""
+    """Returns identity details for the given account and id."""
 
-	service = get_identity_service(account)
-	if identities := service.get([id]):
-		return format_identity(account, identities[0])
+    service = get_identity_service(account)
+    if identities := service.get([id]):
+        return format_identity(account, identities[0])
 
-	if raise_exception:
-		frappe.throw(
-			_("Identity with ID {0} not found in account {1}.").format(frappe.bold(id), frappe.bold(account)),
-			title=_("Identity Not Found"),
-		)
+    if raise_exception:
+        frappe.throw(
+            _("Identity with ID {0} not found in account {1}.").format(frappe.bold(id), frappe.bold(account)),
+            title=_("Identity Not Found"),
+        )
 
 
 @frappe.whitelist()
 def update_identity(
-	account: str,
-	id: str,
-	name: str | None = None,
-	reply_to: list[dict] | None = None,
-	bcc: list[dict] | None = None,
-	text_signature: str | None = None,
-	html_signature: str | None = None,
+    account: str,
+    id: str,
+    name: str | None = None,
+    reply_to: list[dict] | None = None,
+    bcc: list[dict] | None = None,
+    text_signature: str | None = None,
+    html_signature: str | None = None,
 ) -> None:
-	"""Updates an existing identity with the given parameters."""
+    """Updates an existing identity with the given parameters."""
 
-	identity = {
-		"id": id,
-		"name": name,
-		"reply_to": reply_to,
-		"bcc": bcc,
-		"text_signature": text_signature,
-		"html_signature": html_signature,
-	}
+    identity = {
+        "id": id,
+        "name": name,
+        "reply_to": reply_to,
+        "bcc": bcc,
+        "text_signature": text_signature,
+        "html_signature": html_signature,
+    }
 
-	service = get_identity_service(account)
-	response = service.update([identity])
+    service = get_identity_service(account)
+    response = service.update([identity])
 
-	if not response.get("updated"):
-		title = _("Identity Update Error")
-		if response.get("notUpdated"):
-			frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
-		else:
-			frappe.throw(_(response["description"]), title=title)
+    if not response.get("updated"):
+        title = _("Identity Update Error")
+        if response.get("notUpdated"):
+            frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
+        else:
+            frappe.throw(_(response["description"]), title=title)
 
 
 @frappe.whitelist()
 def delete_identities(account: str, ids: list[str]) -> None:
-	"""Deletes identities for the given account and list of identity IDs."""
+    """Deletes identities for the given account and list of identity IDs."""
 
-	service = get_identity_service(account, ignore_permissions=True)
-	response = service.delete(ids)
+    service = get_identity_service(account, ignore_permissions=True)
+    response = service.delete(ids)
 
-	if response.get("notDestroyed"):
-		error_messages = []
-		for id, error in response["notDestroyed"].items():
-			error_messages.append(f"{id}: {error['description']}")
-		frappe.throw(
-			_("Identity Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
-			title=_("Identity Deletion Error"),
-		)
+    if response.get("notDestroyed"):
+        error_messages = []
+        for id, error in response["notDestroyed"].items():
+            error_messages.append(f"{id}: {error['description']}")
+        frappe.throw(
+            _("Identity Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
+            title=_("Identity Deletion Error"),
+        )
 
 
 @frappe.whitelist()
 def fetch_identities(account: str, page: int = 1, limit: int = 10) -> list:
-	"""Returns a list of identities for the given account."""
+    """Returns a list of identities for the given account."""
 
-	service = get_identity_service(account, ignore_permissions=True)
-	identities = service.get()
+    service = get_identity_service(account, ignore_permissions=True)
+    identities = service.get()
 
-	formatted_identities = [format_identity(account, identity) for identity in identities]
-	frappe.cache.set_value(_get_total_cache_key(account), len(identities), expires_in_sec=600)
+    formatted_identities = [format_identity(account, identity) for identity in identities]
+    frappe.cache.set_value(_get_total_cache_key(account), len(identities), expires_in_sec=600)
 
-	start = (page - 1) * limit
-	end = start + limit
+    start = (page - 1) * limit
+    end = start + limit
 
-	return formatted_identities[start:end]
+    return formatted_identities[start:end]
 
 
 def format_identity(account: str, identity: dict) -> dict:
-	"""Formats identity data for display."""
+    """Formats identity data for display."""
 
-	bcc = []
-	for b in identity["bcc"] or []:
-		bcc.append({"display_name": b["name"], "email": b["email"].lower()})
+    bcc = []
+    for b in identity["bcc"] or []:
+        bcc.append({"display_name": b["name"], "email": b["email"].lower()})
 
-	reply_to = []
-	for r in identity["replyTo"] or []:
-		reply_to.append({"display_name": r["name"], "email": r["email"].lower()})
+    reply_to = []
+    for r in identity["replyTo"] or []:
+        reply_to.append({"display_name": r["name"], "email": r["email"].lower()})
 
-	return {
-		"name": f"{account}|{identity['id']}",
-		"account": account,
-		"id": identity["id"],
-		"_name": identity["name"],
-		"email": identity["email"].lower(),
-		"bcc": bcc,
-		"reply_to": reply_to,
-		"html_signature": identity["htmlSignature"],
-		"text_signature": identity["textSignature"],
-		"may_delete": cint(identity["mayDelete"]),
-		"owner": frappe.session.user,
-		"modified_by": frappe.session.user,
-		"creation": today(),
-		"modified": today(),
-	}
+    return {
+        "name": f"{account}|{identity['id']}",
+        "account": account,
+        "id": identity["id"],
+        "_name": identity["name"],
+        "email": identity["email"].lower(),
+        "bcc": bcc,
+        "reply_to": reply_to,
+        "html_signature": identity["htmlSignature"],
+        "text_signature": identity["textSignature"],
+        "may_delete": cint(identity["mayDelete"]),
+        "owner": frappe.session.user,
+        "modified_by": frappe.session.user,
+        "creation": today(),
+        "modified": today(),
+    }
 
 
 def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
-	if doc.doctype != "Identity":
-		return False
+    if doc.doctype != "Identity":
+        return False
 
-	return bool(get_user_for_jmap_account(doc.account, raise_exception=False))
+    return bool(get_user_for_jmap_account(doc.account, raise_exception=False))

--- a/suite/mail/doctype/identity/identity.py
+++ b/suite/mail/doctype/identity/identity.py
@@ -66,7 +66,7 @@ class Identity(Document):
         )
         self.name = f"{self.account}|{self.id}"
 
-    def load_from_db(self) -> "Identity":
+    def load_from_db(self) -> Identity:
         account, id = parse_identity_name(self.name)
         identity = get_identity(account, id)
         return super(Document, self).__init__(identity)
@@ -301,7 +301,7 @@ def format_identity(account: str, identity: dict) -> dict:
     }
 
 
-def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
     if doc.doctype != "Identity":
         return False
 

--- a/suite/mail/doctype/identity/test_identity.py
+++ b/suite/mail/doctype/identity/test_identity.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestIdentity(IntegrationTestCase):
-	"""
-	Integration tests for Identity.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for Identity.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/jmap_account/jmap_account.py
+++ b/suite/mail/doctype/jmap_account/jmap_account.py
@@ -76,7 +76,7 @@ class JMAPAccount(Document):
         return self.flags.get("user") or frappe.session.user
 
     @property
-    def core_service(self) -> "CoreService" | None:
+    def core_service(self) -> CoreService | None:
         """Return the JMAP core service for the account, or None if there is an error."""
 
         if self.flags.in_delete or not self.name:
@@ -413,7 +413,7 @@ def get_permission_query_condition(user: str | None = None) -> str | None:
     return f"""`tabJMAP Account`.name in ({", ".join(frappe.db.escape(account) for account in accounts)})"""
 
 
-def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
     if doc.doctype != "JMAP Account":
         return False
 

--- a/suite/mail/doctype/jmap_account/jmap_account.py
+++ b/suite/mail/doctype/jmap_account/jmap_account.py
@@ -9,22 +9,22 @@ from frappe.model.document import Document
 from frappe.utils import cint
 
 from suite.mail.jmap import (
-	get_core_service,
-	get_mailbox_id_by_role,
-	invalidate_jmap_identities_cache,
-	invalidate_jmap_mailboxes_cache,
+    get_core_service,
+    get_mailbox_id_by_role,
+    invalidate_jmap_identities_cache,
+    invalidate_jmap_mailboxes_cache,
 )
 from suite.mail.store import (
-	Entity,
-	get_account_namespace,
-	get_blob_store,
-	get_data_store,
-	rebuild_email_address_index,
+    Entity,
+    get_account_namespace,
+    get_blob_store,
+    get_data_store,
+    rebuild_email_address_index,
 )
 from suite.store import destroy_namespace, get_search_base_path
 
 if TYPE_CHECKING:
-	from suite.mail.jmap.services.core import CoreService
+    from suite.mail.jmap.services.core import CoreService
 
 from suite.mail.doctype.sieve_script.sieve_script import build_automation_sieve, maybe_build_automation_sieve
 from suite.mail.doctype.user_account.user_account import get_user_jmap_accounts
@@ -35,395 +35,395 @@ from suite.utils.user import is_suite_admin, is_system_manager
 
 
 class JMAPAccount(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		_name: DF.Data
-		account_id: DF.Data
-		block_remote_images: DF.Check
-		create_contacts_after_email_submit: DF.Check
-		default_outgoing_email: DF.Data | None
-		destroy_email_after_submit: DF.Check
-		destroy_newsletter_after_submit: DF.Check
-		enable_screening: DF.Check
-		is_personal: DF.Check
-		is_readonly: DF.Check
-		keep_forwarded_email_in_thread: DF.Check
-		last_active_sieve_script_id: DF.Data | None
-		on_mark_as_junk: DF.Literal["Junk Sender's Mail", "Ask to Block Sender"]
-	# end: auto-generated types
+        _name: DF.Data
+        account_id: DF.Data
+        block_remote_images: DF.Check
+        create_contacts_after_email_submit: DF.Check
+        default_outgoing_email: DF.Data | None
+        destroy_email_after_submit: DF.Check
+        destroy_newsletter_after_submit: DF.Check
+        enable_screening: DF.Check
+        is_personal: DF.Check
+        is_readonly: DF.Check
+        keep_forwarded_email_in_thread: DF.Check
+        last_active_sieve_script_id: DF.Data | None
+        on_mark_as_junk: DF.Literal["Junk Sender's Mail", "Ask to Block Sender"]
+    # end: auto-generated types
 
-	"""Per-account settings shared across every user that has JMAP access to the account.
+    """Per-account settings shared across every user that has JMAP access to the account.
 
 	The document is named by the bare JMAP account ID. Cache-related fields and actions
 	operate on the *session user's* local store for the account, since the cache is kept
 	per (user, account).
 	"""
 
-	@property
-	def _user(self) -> str:
-		"""The user whose JMAP connection backs per-user operations on this shared account.
+    @property
+    def _user(self) -> str:
+        """The user whose JMAP connection backs per-user operations on this shared account.
 
-		Uses the creating user during insert (set via flags) and the session user otherwise,
-		so cache lookups reflect the user currently viewing the document.
-		"""
+        Uses the creating user during insert (set via flags) and the session user otherwise,
+        so cache lookups reflect the user currently viewing the document.
+        """
 
-		return self.flags.get("user") or frappe.session.user
+        return self.flags.get("user") or frappe.session.user
 
-	@property
-	def core_service(self) -> "CoreService" | None:
-		"""Return the JMAP core service for the account, or None if there is an error."""
+    @property
+    def core_service(self) -> "CoreService" | None:
+        """Return the JMAP core service for the account, or None if there is an error."""
 
-		if self.flags.in_delete or not self.name:
-			return None
+        if self.flags.in_delete or not self.name:
+            return None
 
-		try:
-			return get_core_service(self.name)
-		except Exception:
-			frappe.msgprint(f"Error getting JMAP core service for account {self.name}")
-			return None
+        try:
+            return get_core_service(self.name)
+        except Exception:
+            frappe.msgprint(f"Error getting JMAP core service for account {self.name}")
+            return None
 
-	@property
-	def has_cached_jmap_identities(self) -> int:
-		"""Check if there are cached JMAP identities for the account."""
+    @property
+    def has_cached_jmap_identities(self) -> int:
+        """Check if there are cached JMAP identities for the account."""
 
-		service = self.core_service
-		if not service:
-			return 0
+        service = self.core_service
+        if not service:
+            return 0
 
-		return cint(bool(service.cache.get("identities")))
+        return cint(bool(service.cache.get("identities")))
 
-	@property
-	def has_cached_jmap_mailboxes(self) -> int:
-		"""Check if there are cached JMAP mailboxes for the account."""
+    @property
+    def has_cached_jmap_mailboxes(self) -> int:
+        """Check if there are cached JMAP mailboxes for the account."""
 
-		service = self.core_service
-		if not service:
-			return 0
+        service = self.core_service
+        if not service:
+            return 0
 
-		return cint(bool(service.cache.get("mailboxes")))
+        return cint(bool(service.cache.get("mailboxes")))
 
-	@property
-	def total_cached_blobs(self) -> int:
-		"""Get the total number of cached blobs for the account."""
+    @property
+    def total_cached_blobs(self) -> int:
+        """Get the total number of cached blobs for the account."""
 
-		return get_blob_store(self.name).count()
+        return get_blob_store(self.name).count()
 
-	@property
-	def total_cached_mail_messages(self) -> int:
-		"""Get the total number of cached mail messages for the account."""
+    @property
+    def total_cached_mail_messages(self) -> int:
+        """Get the total number of cached mail messages for the account."""
 
-		return get_data_store(self.name).count(Entity.EMAIL)
+        return get_data_store(self.name).count(Entity.EMAIL)
 
-	@property
-	def total_cached_contact_cards(self) -> int:
-		"""Get the total number of cached contact cards for the account."""
+    @property
+    def total_cached_contact_cards(self) -> int:
+        """Get the total number of cached contact cards for the account."""
 
-		return get_data_store(self.name).count(Entity.CONTACT_CARD)
+        return get_data_store(self.name).count(Entity.CONTACT_CARD)
 
-	def validate(self) -> None:
-		self.validate_default_outgoing_email()
+    def validate(self) -> None:
+        self.validate_default_outgoing_email()
 
-	def validate_default_outgoing_email(self) -> None:
-		"""Keep the default outgoing email valid: fall back to the account's first identity
-		when the chosen one isn't one of the account's identities."""
+    def validate_default_outgoing_email(self) -> None:
+        """Keep the default outgoing email valid: fall back to the account's first identity
+        when the chosen one isn't one of the account's identities."""
 
-		if not self.default_outgoing_email or frappe.flags.in_migrate:
-			return
+        if not self.default_outgoing_email or frappe.flags.in_migrate:
+            return
 
-		try:
-			emails = get_account_emails(self._user, self.name)
-		except Exception:
-			return
+        try:
+            emails = get_account_emails(self._user, self.name)
+        except Exception:
+            return
 
-		if self.default_outgoing_email not in emails:
-			frappe.throw(
-				_("Default Outgoing Email {0} is not one of the account's identities.").format(
-					frappe.bold(self.default_outgoing_email)
-				)
-			)
+        if self.default_outgoing_email not in emails:
+            frappe.throw(
+                _("Default Outgoing Email {0} is not one of the account's identities.").format(
+                    frappe.bold(self.default_outgoing_email)
+                )
+            )
 
-	def after_insert(self) -> None:
-		maybe_create_archive_mailbox(self.name)
+    def after_insert(self) -> None:
+        maybe_create_archive_mailbox(self.name)
 
-	def on_update(self) -> None:
-		if frappe.flags.in_migrate:
-			return
+    def on_update(self) -> None:
+        if frappe.flags.in_migrate:
+            return
 
-		if self.has_value_changed("enable_screening"):
-			maybe_build_automation_sieve(self.name, activate=self.enable_screening)
+        if self.has_value_changed("enable_screening"):
+            maybe_build_automation_sieve(self.name, activate=self.enable_screening)
 
-	def after_delete(self) -> None:
-		"""Clear all caches related to the account when the settings are deleted."""
+    def after_delete(self) -> None:
+        """Clear all caches related to the account when the settings are deleted."""
 
-		self.clear_cached_jmap_identities()
-		self.clear_cached_jmap_mailboxes()
-		self.clear_cached_mail_messages()
-		self.clear_cached_contact_cards()
-		self.clear_cached_blobs()
-		self.clear_search_indexes()
+        self.clear_cached_jmap_identities()
+        self.clear_cached_jmap_mailboxes()
+        self.clear_cached_mail_messages()
+        self.clear_cached_contact_cards()
+        self.clear_cached_blobs()
+        self.clear_search_indexes()
 
-	@frappe.whitelist()
-	def clear_cached_jmap_identities(self) -> None:
-		"""Clear all cached JMAP identities for the current account."""
+    @frappe.whitelist()
+    def clear_cached_jmap_identities(self) -> None:
+        """Clear all cached JMAP identities for the current account."""
 
-		if self.has_clear_cache_permission():
-			invalidate_jmap_identities_cache(self.name)
+        if self.has_clear_cache_permission():
+            invalidate_jmap_identities_cache(self.name)
 
-	@frappe.whitelist()
-	def clear_cached_jmap_mailboxes(self) -> None:
-		"""Clear all cached JMAP mailboxes for the current account."""
+    @frappe.whitelist()
+    def clear_cached_jmap_mailboxes(self) -> None:
+        """Clear all cached JMAP mailboxes for the current account."""
 
-		if self.has_clear_cache_permission():
-			invalidate_jmap_mailboxes_cache(self.name)
+        if self.has_clear_cache_permission():
+            invalidate_jmap_mailboxes_cache(self.name)
 
-	@frappe.whitelist()
-	def clear_cached_blobs(self) -> None:
-		"""Clear all cached JMAP blobs for the current account."""
+    @frappe.whitelist()
+    def clear_cached_blobs(self) -> None:
+        """Clear all cached JMAP blobs for the current account."""
 
-		if not self.has_clear_cache_permission():
-			return
+        if not self.has_clear_cache_permission():
+            return
 
-		get_blob_store(self.name).delete_all()
+        get_blob_store(self.name).delete_all()
 
-	@frappe.whitelist()
-	def clear_cached_mail_messages(self) -> None:
-		"""Clear all cached mail messages for the current account."""
+    @frappe.whitelist()
+    def clear_cached_mail_messages(self) -> None:
+        """Clear all cached mail messages for the current account."""
 
-		if not self.has_clear_cache_permission():
-			return
+        if not self.has_clear_cache_permission():
+            return
 
-		get_data_store(self.name).delete_all(Entity.EMAIL)
+        get_data_store(self.name).delete_all(Entity.EMAIL)
 
-	@frappe.whitelist()
-	def clear_cached_contact_cards(self) -> None:
-		"""Clear all cached contact cards for the current account."""
+    @frappe.whitelist()
+    def clear_cached_contact_cards(self) -> None:
+        """Clear all cached contact cards for the current account."""
 
-		if not self.has_clear_cache_permission():
-			return
+        if not self.has_clear_cache_permission():
+            return
 
-		get_data_store(self.name).delete_all(Entity.CONTACT_CARD)
+        get_data_store(self.name).delete_all(Entity.CONTACT_CARD)
 
-	@frappe.whitelist()
-	def clear_search_indexes(self) -> None:
-		"""Delete all search indexes belonging to the current account.
+    @frappe.whitelist()
+    def clear_search_indexes(self) -> None:
+        """Delete all search indexes belonging to the current account.
 
-		Removes only the account's namespace, leaving other accounts' indexes intact.
-		"""
+        Removes only the account's namespace, leaving other accounts' indexes intact.
+        """
 
-		if not self.has_clear_cache_permission():
-			return
+        if not self.has_clear_cache_permission():
+            return
 
-		destroy_namespace(get_search_base_path(), get_account_namespace(self.name))
+        destroy_namespace(get_search_base_path(), get_account_namespace(self.name))
 
-	@frappe.whitelist()
-	def rebuild_search_index(self) -> None:
-		"""Rebuild the account's email-address index from its cached messages and contact cards."""
+    @frappe.whitelist()
+    def rebuild_search_index(self) -> None:
+        """Rebuild the account's email-address index from its cached messages and contact cards."""
 
-		if not self.has_clear_cache_permission():
-			return
+        if not self.has_clear_cache_permission():
+            return
 
-		rebuild_email_address_index(self.name)
+        rebuild_email_address_index(self.name)
 
-	def has_clear_cache_permission(self) -> bool:
-		"""Check if the session user has permission to clear cache."""
+    def has_clear_cache_permission(self) -> bool:
+        """Check if the session user has permission to clear cache."""
 
-		if has_permission(self, "write"):
-			return True
+        if has_permission(self, "write"):
+            return True
 
-		frappe.throw(
-			_("You do not have permission to clear the cache for this account."), frappe.PermissionError
-		)
+        frappe.throw(
+            _("You do not have permission to clear the cache for this account."), frappe.PermissionError
+        )
 
-	def _db_set(
-		self,
-		update_modified: bool = True,
-		commit: bool = False,
-		notify: bool = False,
-		**kwargs,
-	) -> None:
-		"""Updates the document with the given key-value pairs."""
+    def _db_set(
+        self,
+        update_modified: bool = True,
+        commit: bool = False,
+        notify: bool = False,
+        **kwargs,
+    ) -> None:
+        """Updates the document with the given key-value pairs."""
 
-		self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
+        self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
 
 
 def delete_orphaned_jmap_accounts() -> None:
-	"""Delete JMAP Accounts that are no longer linked to any user.
+    """Delete JMAP Accounts that are no longer linked to any user.
 
-	JMAP Account settings are shared by account ID across every user with access, so a JMAP
-	Account is only orphaned once the last user's User Account link is gone.
-	"""
+    JMAP Account settings are shared by account ID across every user with access, so a JMAP
+    Account is only orphaned once the last user's User Account link is gone.
+    """
 
-	linked_accounts = frappe.db.get_all("User Account", distinct=True, pluck="account")
-	orphaned_accounts = frappe.db.get_all(
-		"JMAP Account", filters={"name": ["not in", linked_accounts]}, pluck="name"
-	)
+    linked_accounts = frappe.db.get_all("User Account", distinct=True, pluck="account")
+    orphaned_accounts = frappe.db.get_all(
+        "JMAP Account", filters={"name": ["not in", linked_accounts]}, pluck="name"
+    )
 
-	for account in orphaned_accounts:
-		frappe.delete_doc("JMAP Account", account, ignore_permissions=True, delete_permanently=True)
+    for account in orphaned_accounts:
+        frappe.delete_doc("JMAP Account", account, ignore_permissions=True, delete_permanently=True)
 
 
 def sync_jmap_accounts(user: str, accounts: dict[str, dict]) -> None:
-	"""Ensure a shared JMAP Account document exists for each of the user's accounts.
+    """Ensure a shared JMAP Account document exists for each of the user's accounts.
 
-	Settings are shared by account ID across every user with access, so documents for
-	accounts the user can no longer see are intentionally left untouched.
+    Settings are shared by account ID across every user with access, so documents for
+    accounts the user can no longer see are intentionally left untouched.
 
-	Serialized per user with a distributed lock: this runs on every User Settings save,
-	including session-state changes that can fire concurrently from multiple tabs or jobs.
-	Without it, two overlapping runs would both read an empty User Account set and each
-	insert a link, leaving duplicate (user, account) rows (the doctype has no unique key).
-	If the lock can't be acquired, another run is already syncing the same session snapshot,
-	so skipping is safe.
-	"""
+    Serialized per user with a distributed lock: this runs on every User Settings save,
+    including session-state changes that can fire concurrently from multiple tabs or jobs.
+    Without it, two overlapping runs would both read an empty User Account set and each
+    insert a link, leaving duplicate (user, account) rows (the doctype has no unique key).
+    If the lock can't be acquired, another run is already syncing the same session snapshot,
+    so skipping is safe.
+    """
 
-	lockname = f"sync_jmap_accounts:{user}"
-	identifier = acquire_lock(lockname, acquire_timeout=0)
-	if not identifier:
-		return
+    lockname = f"sync_jmap_accounts:{user}"
+    identifier = acquire_lock(lockname, acquire_timeout=0)
+    if not identifier:
+        return
 
-	try:
-		frappe.flags.skip_automation_sieve_build = True
-		frappe.flags.skip_archive_mailbox_creation = True
+    try:
+        frappe.flags.skip_automation_sieve_build = True
+        frappe.flags.skip_archive_mailbox_creation = True
 
-		new_accounts = _ensure_jmap_account_docs(user, accounts)
-		_sync_user_accounts(user, set(accounts.keys()))
+        new_accounts = _ensure_jmap_account_docs(user, accounts)
+        _sync_user_accounts(user, set(accounts.keys()))
 
-		# Reached over JMAP as ``user``, not as whoever triggered the save: these accounts are only
-		# ever linked to ``user``, so an admin setting up a member's account (or any other user
-		# saving someone else's settings) would otherwise resolve the account to nobody and fail
-		# with "JMAP account <id> does not belong to the user <admin>".
-		with user_context(user):
-			for account in new_accounts:
-				create_archive_mailbox(account)
-				build_automation_sieve(account, activate=True)
-	finally:
-		release_lock(lockname, identifier)
+        # Reached over JMAP as ``user``, not as whoever triggered the save: these accounts are only
+        # ever linked to ``user``, so an admin setting up a member's account (or any other user
+        # saving someone else's settings) would otherwise resolve the account to nobody and fail
+        # with "JMAP account <id> does not belong to the user <admin>".
+        with user_context(user):
+            for account in new_accounts:
+                create_archive_mailbox(account)
+                build_automation_sieve(account, activate=True)
+    finally:
+        release_lock(lockname, identifier)
 
 
 def _ensure_jmap_account_docs(user: str, accounts: dict[str, dict]) -> list[str]:
-	"""Create the shared JMAP Account document for each account that doesn't have one yet.
+    """Create the shared JMAP Account document for each account that doesn't have one yet.
 
-	Returns the list of newly created account IDs. Existing documents are left untouched.
-	"""
+    Returns the list of newly created account IDs. Existing documents are left untouched.
+    """
 
-	new_accounts = []
-	for account_id, details in accounts.items():
-		if frappe.db.exists("JMAP Account", account_id):
-			continue
+    new_accounts = []
+    for account_id, details in accounts.items():
+        if frappe.db.exists("JMAP Account", account_id):
+            continue
 
-		doc = frappe.new_doc("JMAP Account")
-		doc._name = details["name"]
-		doc.account_id = account_id
-		doc.is_personal = details["isPersonal"]
-		doc.is_readonly = details["isReadOnly"]
+        doc = frappe.new_doc("JMAP Account")
+        doc._name = details["name"]
+        doc.account_id = account_id
+        doc.is_personal = details["isPersonal"]
+        doc.is_readonly = details["isReadOnly"]
 
-		# Screening is opt-in for shared/team accounts, but on by default for personal
-		# ones. Account owners can still toggle it manually afterwards.
-		doc.enable_screening = doc.is_personal
+        # Screening is opt-in for shared/team accounts, but on by default for personal
+        # ones. Account owners can still toggle it manually afterwards.
+        doc.enable_screening = doc.is_personal
 
-		# Carry the user so after_insert / validate can reach JMAP for this account.
-		doc.flags.user = user
+        # Carry the user so after_insert / validate can reach JMAP for this account.
+        doc.flags.user = user
 
-		doc.flags.ignore_links = True
+        doc.flags.ignore_links = True
 
-		try:
-			doc.insert(ignore_permissions=True)
-		except frappe.DuplicateEntryError:
-			continue
+        try:
+            doc.insert(ignore_permissions=True)
+        except frappe.DuplicateEntryError:
+            continue
 
-		new_accounts.append(doc.name)
+        new_accounts.append(doc.name)
 
-	return new_accounts
+    return new_accounts
 
 
 def _sync_user_accounts(user: str, account_ids: set[str]) -> None:
-	"""Reconcile the user's User Account links with the given set of account IDs.
+    """Reconcile the user's User Account links with the given set of account IDs.
 
-	Guards against duplicate (user, account) links at two levels alongside the DB unique index:
-	pre-existing duplicates are collapsed to a single row, and inserts tolerate the index
-	rejecting a link that a concurrent sync created first.
-	"""
+    Guards against duplicate (user, account) links at two levels alongside the DB unique index:
+    pre-existing duplicates are collapsed to a single row, and inserts tolerate the index
+    rejecting a link that a concurrent sync created first.
+    """
 
-	user_account_map = {}
-	duplicate_names = []
-	for user_account in frappe.db.get_all("User Account", {"user": user}, ["name", "account"]):
-		if user_account.account in user_account_map:
-			duplicate_names.append(user_account.name)
-		else:
-			user_account_map[user_account.account] = user_account.name
+    user_account_map = {}
+    duplicate_names = []
+    for user_account in frappe.db.get_all("User Account", {"user": user}, ["name", "account"]):
+        if user_account.account in user_account_map:
+            duplicate_names.append(user_account.name)
+        else:
+            user_account_map[user_account.account] = user_account.name
 
-	existing_account_ids = set(user_account_map.keys())
+    existing_account_ids = set(user_account_map.keys())
 
-	accounts_to_add = account_ids - existing_account_ids
-	accounts_to_remove = existing_account_ids - account_ids
+    accounts_to_add = account_ids - existing_account_ids
+    accounts_to_remove = existing_account_ids - account_ids
 
-	if accounts_to_add:
-		user_settings = frappe.get_doc("User Settings", {"user": user})
-		for account_id in accounts_to_add:
-			doc = frappe.new_doc("User Account")
-			doc.user = user
-			doc.account = account_id
-			doc.user_settings = user_settings.name
-			try:
-				doc.insert(ignore_permissions=True)
-			except frappe.UniqueValidationError:
-				continue
+    if accounts_to_add:
+        user_settings = frappe.get_doc("User Settings", {"user": user})
+        for account_id in accounts_to_add:
+            doc = frappe.new_doc("User Account")
+            doc.user = user
+            doc.account = account_id
+            doc.user_settings = user_settings.name
+            try:
+                doc.insert(ignore_permissions=True)
+            except frappe.UniqueValidationError:
+                continue
 
-	names_to_remove = duplicate_names + [user_account_map[account] for account in accounts_to_remove]
-	if names_to_remove:
-		frappe.db.delete("User Account", {"name": ["in", names_to_remove]})
+    names_to_remove = duplicate_names + [user_account_map[account] for account in accounts_to_remove]
+    if names_to_remove:
+        frappe.db.delete("User Account", {"name": ["in", names_to_remove]})
 
 
 def maybe_create_archive_mailbox(account: str) -> None:
-	"""Create the archive mailbox for the account if it does not already exist."""
+    """Create the archive mailbox for the account if it does not already exist."""
 
-	if frappe.flags.get("skip_archive_mailbox_creation"):
-		return
+    if frappe.flags.get("skip_archive_mailbox_creation"):
+        return
 
-	create_archive_mailbox(account)
+    create_archive_mailbox(account)
 
 
 def create_archive_mailbox(account: str) -> None:
-	"""Create the archive mailbox for the account if it does not already exist."""
+    """Create the archive mailbox for the account if it does not already exist."""
 
-	execute_with_logging(
-		lambda: get_mailbox_id_by_role(account, "archive", create_if_not_exists=True),
-		title=_("Archive Mailbox Creation Error"),
-		user_message=_("Failed to create archive mailbox for account {0}").format(frappe.bold(account)),
-		with_context=False,
-		module="Mail",
-	)
+    execute_with_logging(
+        lambda: get_mailbox_id_by_role(account, "archive", create_if_not_exists=True),
+        title=_("Archive Mailbox Creation Error"),
+        user_message=_("Failed to create archive mailbox for account {0}").format(frappe.bold(account)),
+        with_context=False,
+        module="Mail",
+    )
 
 
 def get_permission_query_condition(user: str | None = None) -> str | None:
-	user = user or frappe.session.user
-	if is_system_manager(user) or is_suite_admin(user):
-		return ""
+    user = user or frappe.session.user
+    if is_system_manager(user) or is_suite_admin(user):
+        return ""
 
-	accounts = get_user_jmap_accounts(user)
-	if not accounts:
-		return "1=0"
+    accounts = get_user_jmap_accounts(user)
+    if not accounts:
+        return "1=0"
 
-	return f"""`tabJMAP Account`.name in ({", ".join(frappe.db.escape(account) for account in accounts)})"""
+    return f"""`tabJMAP Account`.name in ({", ".join(frappe.db.escape(account) for account in accounts)})"""
 
 
 def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
-	if doc.doctype != "JMAP Account":
-		return False
+    if doc.doctype != "JMAP Account":
+        return False
 
-	user = user or frappe.session.user
+    user = user or frappe.session.user
 
-	if is_system_manager(user) or is_suite_admin(user):
-		return True
+    if is_system_manager(user) or is_suite_admin(user):
+        return True
 
-	accounts = get_user_jmap_accounts(user)
-	if not accounts:
-		return False
+    accounts = get_user_jmap_accounts(user)
+    if not accounts:
+        return False
 
-	return doc.name in accounts
+    return doc.name in accounts

--- a/suite/mail/doctype/jmap_account/test_jmap_account.py
+++ b/suite/mail/doctype/jmap_account/test_jmap_account.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestJMAPAccount(IntegrationTestCase):
-	"""
-	Integration tests for JMAP Account.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for JMAP Account.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/mail_account_request/mail_account_request.py
+++ b/suite/mail/doctype/mail_account_request/mail_account_request.py
@@ -8,15 +8,15 @@ import frappe
 from frappe import Any, _
 from frappe.model.document import Document
 from frappe.utils import (
-	add_to_date,
-	cint,
-	flt,
-	get_datetime,
-	get_url,
-	now,
-	now_datetime,
-	random_string,
-	validate_email_address,
+    add_to_date,
+    cint,
+    flt,
+    get_datetime,
+    get_url,
+    now,
+    now_datetime,
+    random_string,
+    validate_email_address,
 )
 
 from suite.mail.stalwart import create_account, create_app_password, get_roles
@@ -31,453 +31,453 @@ STALWART_DEFAULT_ADMIN_ROLES = ["User", "Tenant Administrator"]
 
 
 def _lines(value: str | None) -> list[str]:
-	"""Splits a newline-separated field into its entries, dropping blanks and duplicates."""
+    """Splits a newline-separated field into its entries, dropping blanks and duplicates."""
 
-	return list(dict.fromkeys(line.strip() for line in (value or "").split("\n") if line.strip()))
+    return list(dict.fromkeys(line.strip() for line in (value or "").split("\n") if line.strip()))
 
 
 class MailAccountRequest(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
-
-	from typing import TYPE_CHECKING
-
-	if TYPE_CHECKING:
-		from frappe.types import DF
-
-		account: DF.Data
-		aliases: DF.SmallText | None
-		backup_email: DF.Data
-		expires_at: DF.Datetime | None
-		groups: DF.SmallText | None
-		invited_by: DF.Link
-		ip_address: DF.Data | None
-		is_admin: DF.Check
-		is_verified: DF.Check
-		mailing_lists: DF.SmallText | None
-		quota_gb: DF.Float | None
-		request_key: DF.Data | None
-		roles: DF.SmallText | None
-		send_invite: DF.Check
-	# end: auto-generated types
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        account: DF.Data
+        aliases: DF.SmallText | None
+        backup_email: DF.Data
+        expires_at: DF.Datetime | None
+        groups: DF.SmallText | None
+        invited_by: DF.Link
+        ip_address: DF.Data | None
+        is_admin: DF.Check
+        is_verified: DF.Check
+        mailing_lists: DF.SmallText | None
+        quota_gb: DF.Float | None
+        request_key: DF.Data | None
+        roles: DF.SmallText | None
+        send_invite: DF.Check
+    # end: auto-generated types
 
-	def autoname(self) -> None:
-		self.name = str(uuid7())
+    def autoname(self) -> None:
+        self.name = str(uuid7())
 
-	@property
-	def is_expired(self) -> bool:
-		return self.expires_at and get_datetime(self.expires_at) < now_datetime()
+    @property
+    def is_expired(self) -> bool:
+        return self.expires_at and get_datetime(self.expires_at) < now_datetime()
 
-	@property
-	def _roles(self) -> list[str]:
-		"""Returns the list of roles for the account request."""
+    @property
+    def _roles(self) -> list[str]:
+        """Returns the list of roles for the account request."""
 
-		roles = []
+        roles = []
 
-		if self.roles:
-			roles = [r.strip() for r in self.roles.split("\n")]
+        if self.roles:
+            roles = [r.strip() for r in self.roles.split("\n")]
 
-		else:
-			if self.is_admin:
-				roles = STALWART_DEFAULT_ADMIN_ROLES
-			else:
-				roles = STALWART_DEFAULT_USER_ROLES
+        else:
+            if self.is_admin:
+                roles = STALWART_DEFAULT_ADMIN_ROLES
+            else:
+                roles = STALWART_DEFAULT_USER_ROLES
 
-		return list(set(roles))
+        return list(set(roles))
 
-	@property
-	def domain(self) -> str:
-		"""Returns the domain of the primary account."""
+    @property
+    def domain(self) -> str:
+        """Returns the domain of the primary account."""
 
-		return self.account.split("@", 1)[1] if self.account and "@" in self.account else ""
+        return self.account.split("@", 1)[1] if self.account and "@" in self.account else ""
 
-	@property
-	def _aliases(self) -> list[str]:
-		"""Returns the additional email addresses to attach as aliases to the account."""
+    @property
+    def _aliases(self) -> list[str]:
+        """Returns the additional email addresses to attach as aliases to the account."""
 
-		if not self.aliases:
-			return []
+        if not self.aliases:
+            return []
 
-		return [alias.strip() for alias in self.aliases.split("\n") if alias.strip()]
+        return [alias.strip() for alias in self.aliases.split("\n") if alias.strip()]
 
-	@property
-	def _groups(self) -> list[str]:
-		"""Returns the ids of the groups the account is added to on creation."""
+    @property
+    def _groups(self) -> list[str]:
+        """Returns the ids of the groups the account is added to on creation."""
 
-		return _lines(self.groups)
+        return _lines(self.groups)
 
-	@property
-	def _mailing_lists(self) -> list[str]:
-		"""Returns the ids of the mailing lists the account is added to on creation."""
+    @property
+    def _mailing_lists(self) -> list[str]:
+        """Returns the ids of the mailing lists the account is added to on creation."""
 
-		return _lines(self.mailing_lists)
+        return _lines(self.mailing_lists)
 
-	@property
-	def _quota(self) -> int:
-		"""Returns the disk quota in bytes to create the account with.
+    @property
+    def _quota(self) -> int:
+        """Returns the disk quota in bytes to create the account with.
 
-		An unset quota falls back to the configured default, which ``get_config`` resolves from Mail
-		Settings first and the site config second. An explicit ``0`` means unlimited and is left alone.
-		"""
+        An unset quota falls back to the configured default, which ``get_config`` resolves from Mail
+        Settings first and the site config second. An explicit ``0`` means unlimited and is left alone.
+        """
 
-		quota_gb = self.quota_gb if self.quota_gb is not None else get_config("default_disk_quota_gb")
-		return cint(flt(quota_gb) * 1024**3)
+        quota_gb = self.quota_gb if self.quota_gb is not None else get_config("default_disk_quota_gb")
+        return cint(flt(quota_gb) * 1024**3)
 
-	def before_insert(self) -> None:
-		is_stalwart_configured(raise_exception=True)
-		self.validate_backup_email()
-		self.set_request_key()
-		self.set_expires_at()
-		self.set_ip_address()
-		self.validate_invited_by()
-		self.validate_account()
-		self.validate_aliases()
-		self.validate_roles()
-		self.validate_groups()
-		self.validate_mailing_lists()
+    def before_insert(self) -> None:
+        is_stalwart_configured(raise_exception=True)
+        self.validate_backup_email()
+        self.set_request_key()
+        self.set_expires_at()
+        self.set_ip_address()
+        self.validate_invited_by()
+        self.validate_account()
+        self.validate_aliases()
+        self.validate_roles()
+        self.validate_groups()
+        self.validate_mailing_lists()
 
-	def after_insert(self) -> None:
-		if self.send_invite:
-			self.send_verification_email()
+    def after_insert(self) -> None:
+        if self.send_invite:
+            self.send_verification_email()
 
-	def validate_backup_email(self) -> None:
-		"""Validates the backup email."""
+    def validate_backup_email(self) -> None:
+        """Validates the backup email."""
 
-		if not self.backup_email:
-			frappe.throw(_("Backup Email is required."))
+        if not self.backup_email:
+            frappe.throw(_("Backup Email is required."))
 
-		self.backup_email = self.backup_email.strip().lower()
-		validate_email_address(self.backup_email, throw=True)
+        self.backup_email = self.backup_email.strip().lower()
+        validate_email_address(self.backup_email, throw=True)
 
-	def set_request_key(self) -> None:
-		"""Sets a random key for the request."""
+    def set_request_key(self) -> None:
+        """Sets a random key for the request."""
 
-		self.request_key = random_string(32)
+        self.request_key = random_string(32)
 
-	def set_expires_at(self) -> None:
-		"""Sets the expiry date of the account request."""
+    def set_expires_at(self) -> None:
+        """Sets the expiry date of the account request."""
 
-		if not self.expires_at:
-			self.expires_at = add_to_date(now(), days=1)
+        if not self.expires_at:
+            self.expires_at = add_to_date(now(), days=1)
 
-	def set_ip_address(self) -> None:
-		"""Sets the IP address of the request."""
+    def set_ip_address(self) -> None:
+        """Sets the IP address of the request."""
 
-		self.ip_address = frappe.local.request_ip
+        self.ip_address = frappe.local.request_ip
 
-	def validate_invited_by(self) -> None:
-		"""Validates the invited_by."""
+    def validate_invited_by(self) -> None:
+        """Validates the invited_by."""
 
-		user = frappe.session.user
+        user = frappe.session.user
 
-		if is_system_manager(user):
-			self.invited_by = self.invited_by or user
-		else:
-			self.invited_by = user
+        if is_system_manager(user):
+            self.invited_by = self.invited_by or user
+        else:
+            self.invited_by = user
 
-	def validate_account(self) -> None:
-		"""Validates the primary account email."""
+    def validate_account(self) -> None:
+        """Validates the primary account email."""
 
-		self.account = self.account.strip().lower()
-		validate_email_address(self.account, throw=True)
-		is_subaddressed_email(self.account, raise_exception=True)
+        self.account = self.account.strip().lower()
+        validate_email_address(self.account, throw=True)
+        is_subaddressed_email(self.account, raise_exception=True)
 
-		if frappe.db.exists("User", {"email": self.account}):
-			frappe.throw(_("User with email {0} already exists.").format(frappe.bold(self.account)))
+        if frappe.db.exists("User", {"email": self.account}):
+            frappe.throw(_("User with email {0} already exists.").format(frappe.bold(self.account)))
 
-	def validate_aliases(self) -> None:
-		"""Validates the additional email aliases and normalizes them.
+    def validate_aliases(self) -> None:
+        """Validates the additional email aliases and normalizes them.
 
-		Each alias must be a valid, non-subaddressed email on a domain that exists on the server.
-		Blanks, duplicates and any alias equal to the primary account are dropped.
-		"""
+        Each alias must be a valid, non-subaddressed email on a domain that exists on the server.
+        Blanks, duplicates and any alias equal to the primary account are dropped.
+        """
 
-		if not self.aliases:
-			return
+        if not self.aliases:
+            return
 
-		from suite.mail.stalwart import get_domains
+        from suite.mail.stalwart import get_domains
 
-		server_domains = {domain["name"] for domain in get_domains()}
+        server_domains = {domain["name"] for domain in get_domains()}
 
-		seen = set()
-		cleaned = []
-		for alias in self.aliases.split("\n"):
-			alias = alias.strip().lower()
-			if not alias or alias == self.account or alias in seen:
-				continue
+        seen = set()
+        cleaned = []
+        for alias in self.aliases.split("\n"):
+            alias = alias.strip().lower()
+            if not alias or alias == self.account or alias in seen:
+                continue
 
-			validate_email_address(alias, throw=True)
-			is_subaddressed_email(alias, raise_exception=True)
+            validate_email_address(alias, throw=True)
+            is_subaddressed_email(alias, raise_exception=True)
 
-			domain = alias.split("@", 1)[1]
-			if domain not in server_domains:
-				frappe.throw(_("Alias domain {0} does not exist on the server.").format(frappe.bold(domain)))
+            domain = alias.split("@", 1)[1]
+            if domain not in server_domains:
+                frappe.throw(_("Alias domain {0} does not exist on the server.").format(frappe.bold(domain)))
 
-			seen.add(alias)
-			cleaned.append(alias)
+            seen.add(alias)
+            cleaned.append(alias)
 
-		self.aliases = "\n".join(cleaned)
+        self.aliases = "\n".join(cleaned)
 
-	def validate_roles(self) -> None:
-		"""Validates the roles."""
+    def validate_roles(self) -> None:
+        """Validates the roles."""
 
-		roles_to_assign = self._roles
-		server_roles_map = {r["description"]: r["id"] for r in get_roles()}
+        roles_to_assign = self._roles
+        server_roles_map = {r["description"]: r["id"] for r in get_roles()}
 
-		for role in roles_to_assign:
-			if role not in server_roles_map:
-				frappe.throw(_("Role {0} does not exists on the server.").format(frappe.bold(role)))
+        for role in roles_to_assign:
+            if role not in server_roles_map:
+                frappe.throw(_("Role {0} does not exists on the server.").format(frappe.bold(role)))
 
-		self.roles = "\n".join(roles_to_assign)
+        self.roles = "\n".join(roles_to_assign)
 
-	def validate_groups(self) -> None:
-		"""Validates the groups the account will join and normalizes them."""
+    def validate_groups(self) -> None:
+        """Validates the groups the account will join and normalizes them."""
 
-		if not self.groups:
-			return
+        if not self.groups:
+            return
 
-		from suite.mail.stalwart import get_group_service
+        from suite.mail.stalwart import get_group_service
 
-		server_group_ids = {str(g["id"]) for g in get_group_service().get_all_groups(properties=["id"])}
+        server_group_ids = {str(g["id"]) for g in get_group_service().get_all_groups(properties=["id"])}
 
-		for group_id in self._groups:
-			if group_id not in server_group_ids:
-				frappe.throw(_("Group {0} does not exist on the server.").format(frappe.bold(group_id)))
+        for group_id in self._groups:
+            if group_id not in server_group_ids:
+                frappe.throw(_("Group {0} does not exist on the server.").format(frappe.bold(group_id)))
 
-		self.groups = "\n".join(self._groups)
+        self.groups = "\n".join(self._groups)
 
-	def validate_mailing_lists(self) -> None:
-		"""Validates the mailing lists the account will be a recipient of and normalizes them."""
+    def validate_mailing_lists(self) -> None:
+        """Validates the mailing lists the account will be a recipient of and normalizes them."""
 
-		if not self.mailing_lists:
-			return
+        if not self.mailing_lists:
+            return
 
-		from suite.mail.stalwart import get_mailing_list_service
+        from suite.mail.stalwart import get_mailing_list_service
 
-		server_list_ids = {str(ml["id"]) for ml in get_mailing_list_service().get_all(properties=["id"])}
+        server_list_ids = {str(ml["id"]) for ml in get_mailing_list_service().get_all(properties=["id"])}
 
-		for list_id in self._mailing_lists:
-			if list_id not in server_list_ids:
-				frappe.throw(_("Mailing list {0} does not exist on the server.").format(frappe.bold(list_id)))
+        for list_id in self._mailing_lists:
+            if list_id not in server_list_ids:
+                frappe.throw(_("Mailing list {0} does not exist on the server.").format(frappe.bold(list_id)))
 
-		self.mailing_lists = "\n".join(self._mailing_lists)
+        self.mailing_lists = "\n".join(self._mailing_lists)
 
-	def validate_expired(self) -> None:
-		"""Forbids action if the request has expired."""
+    def validate_expired(self) -> None:
+        """Forbids action if the request has expired."""
 
-		if self.is_expired:
-			frappe.throw(_("This request has expired. Please create a new one."))
+        if self.is_expired:
+            frappe.throw(_("This request has expired. Please create a new one."))
 
-	@frappe.whitelist()
-	def send_verification_email(self) -> None:
-		"""Send verification email to the user."""
+    @frappe.whitelist()
+    def send_verification_email(self) -> None:
+        """Send verification email to the user."""
 
-		self.validate_expired()
-		self.validate_backup_email()
+        self.validate_expired()
+        self.validate_backup_email()
 
-		if self.invited_by:
-			subject = _("You have been invited by {0} to join Frappe Mail").format(self.invited_by)
-			template = "generic"
-			args = {
-				"title": _("You have been invited by {0} to join Frappe Mail.").format(self.invited_by),
-				"description": _("Please confirm your email address by clicking the button below."),
-				"button": _("Verify Account"),
-				"link": get_url("/mail/signup/" + self.request_key),
-			}
-
-			frappe.sendmail(
-				recipients=self.backup_email,
-				subject=subject,
-				template=template,
-				args=args,
-				now=True,
-			)
-			frappe.msgprint(_("Verification email sent successfully."), indicator="green", alert=True)
-
-			# Sending an invite link is worth recording, but only when an administrator did it: the
-			# signup OTP flow reaches this as Guest and is not part of the admin trail.
-			if is_suite_admin(frappe.session.user) or is_system_manager(frappe.session.user):
-				log_admin_action("send invite email", self.account)
-
-	@frappe.whitelist()
-	def force_verify_and_create_account(
-		self,
-		first_name: str,
-		last_name: str,
-		password: str,
-		locale: str | None = None,
-		time_zone: str | None = None,
-	) -> None:
-		"""Force verify and create account for invited user."""
-
-		user = frappe.session.user
-		if not is_system_manager(user) and not is_suite_admin(user):
-			frappe.throw(_("You are not authorized to perform this action."))
-
-		if self.is_verified:
-			frappe.throw(_("This account request is already verified."))
-
-		self.db_set("is_verified", 1)
-		self.create_account(first_name, last_name, password, locale, time_zone)
-
-	def create_account(
-		self,
-		first_name: str,
-		last_name: str,
-		password: str,
-		locale: str | None = None,
-		time_zone: str | None = None,
-	) -> None:
-		"""Create mail account for the user.
-
-		``locale`` and ``time_zone`` come from whoever completes the request — the admin on a forced
-		creation, the invited user on the setup form — and fall back to the server defaults when blank.
-		"""
-
-		if not self.is_verified:
-			frappe.throw(_("Account request is not verified. Please verify your email first."))
-
-		if not password:
-			frappe.throw(_("Password is required to create account."))
-
-		self.validate_expired()
-
-		is_stalwart_configured(raise_exception=True)
-		self.validate_account()
-
-		# Step - 1: Create Account on Stalwart
-		account_id = execute_with_logging(
-			func=lambda: create_account(
-				name=self.account.split("@")[0],
-				domain=self.domain,
-				password=password,
-				description=f"{first_name} {last_name}" if last_name else first_name,
-				aliases=self._aliases,
-				groups=[],
-				roles=self._roles,
-				quota=self._quota,
-				locale=locale,
-				timezone=time_zone,
-			),
-			title="Failed to create account on Stalwart",
-			user_message=_("Failed to create account on the server, check error log for details."),
-			module="Mail",
-		)
-
-		# Step - 2: Create App Password on Stalwart
-		app_password = execute_with_logging(
-			func=lambda: create_app_password(self.account),
-			title="Failed to create app password on Stalwart",
-			user_message=_("Failed to create app password on the server, check error log for details."),
-			module="Mail",
-		)
-
-		# Step - 3: Create User
-		user = execute_with_logging(
-			func=lambda: create_user(
-				self.account,
-				first_name,
-				last_name,
-				password,
-				["Suite User", "Suite Admin"] if self.is_admin else ["Suite User"],
-			),
-			title="Failed to create user",
-			user_message=_("Failed to create user, check error log for details."),
-			module="Mail",
-		)
-
-		# Step - 4: Update User Settings
-		execute_with_logging(
-			func=lambda: self._update_user_settings(user, app_password),
-			title="Failed to update user settings",
-			user_message=_("Failed to update user settings, check error log for details."),
-			module="Mail",
-		)
-
-		# Step - 5: Create Push Subscription
-		if frappe.utils.get_url().startswith("https"):
-			execute_with_logging(
-				func=lambda: self._create_push_subscription(user),
-				title="Failed to create push subscription",
-				module="Mail",
-			)
-
-		# Step - 6: Join the groups and mailing lists picked when the request was created. Logged but
-		# not thrown: the account already exists, so a stale group or list must not fail the signup.
-		if account_id and self._groups:
-			execute_with_logging(
-				func=lambda: self._join_groups(account_id),
-				title="Failed to add account to groups on Stalwart",
-				module="Mail",
-			)
-
-		if self._mailing_lists:
-			execute_with_logging(
-				func=lambda: self._join_mailing_lists(),
-				title="Failed to add account to mailing lists on Stalwart",
-				module="Mail",
-			)
-
-	def _join_groups(self, account_id: str) -> None:
-		"""Adds the created account to each of the requested groups."""
-
-		from suite.mail.stalwart import get_group_service
-
-		service = get_group_service()
-		for group_id in self._groups:
-			service.add_members(group_id, [account_id])
-
-	def _join_mailing_lists(self) -> None:
-		"""Adds the account's primary address as a recipient of each requested mailing list."""
-
-		from suite.mail.stalwart import get_mailing_list_service
-
-		service = get_mailing_list_service()
-		for list_id in self._mailing_lists:
-			recipients = dict((service.get(list_id, properties=["recipients"]) or {}).get("recipients") or {})
-			recipients[self.account] = True
-			service.update(list_id, {"recipients": recipients})
-
-	def _update_user_settings(self, user: str, app_password: str) -> None:
-		"""Updates the user settings with the app password and backup email."""
-
-		user_settings = frappe.get_doc("User Settings", {"user": user})
-		user_settings.username = self.account
-		user_settings.app_password = app_password
-		user_settings.backup_email = self.backup_email
-		user_settings.save(ignore_permissions=True)
-
-	def _create_push_subscription(self, user: str) -> None:
-		"""Creates a push subscription for the user."""
-
-		ps = frappe.new_doc("Push Subscription")
-		ps.user = user
-		ps.insert(ignore_permissions=True)
+        if self.invited_by:
+            subject = _("You have been invited by {0} to join Frappe Mail").format(self.invited_by)
+            template = "generic"
+            args = {
+                "title": _("You have been invited by {0} to join Frappe Mail.").format(self.invited_by),
+                "description": _("Please confirm your email address by clicking the button below."),
+                "button": _("Verify Account"),
+                "link": get_url("/mail/signup/" + self.request_key),
+            }
+
+            frappe.sendmail(
+                recipients=self.backup_email,
+                subject=subject,
+                template=template,
+                args=args,
+                now=True,
+            )
+            frappe.msgprint(_("Verification email sent successfully."), indicator="green", alert=True)
+
+            # Sending an invite link is worth recording, but only when an administrator did it: the
+            # signup OTP flow reaches this as Guest and is not part of the admin trail.
+            if is_suite_admin(frappe.session.user) or is_system_manager(frappe.session.user):
+                log_admin_action("send invite email", self.account)
+
+    @frappe.whitelist()
+    def force_verify_and_create_account(
+        self,
+        first_name: str,
+        last_name: str,
+        password: str,
+        locale: str | None = None,
+        time_zone: str | None = None,
+    ) -> None:
+        """Force verify and create account for invited user."""
+
+        user = frappe.session.user
+        if not is_system_manager(user) and not is_suite_admin(user):
+            frappe.throw(_("You are not authorized to perform this action."))
+
+        if self.is_verified:
+            frappe.throw(_("This account request is already verified."))
+
+        self.db_set("is_verified", 1)
+        self.create_account(first_name, last_name, password, locale, time_zone)
+
+    def create_account(
+        self,
+        first_name: str,
+        last_name: str,
+        password: str,
+        locale: str | None = None,
+        time_zone: str | None = None,
+    ) -> None:
+        """Create mail account for the user.
+
+        ``locale`` and ``time_zone`` come from whoever completes the request — the admin on a forced
+        creation, the invited user on the setup form — and fall back to the server defaults when blank.
+        """
+
+        if not self.is_verified:
+            frappe.throw(_("Account request is not verified. Please verify your email first."))
+
+        if not password:
+            frappe.throw(_("Password is required to create account."))
+
+        self.validate_expired()
+
+        is_stalwart_configured(raise_exception=True)
+        self.validate_account()
+
+        # Step - 1: Create Account on Stalwart
+        account_id = execute_with_logging(
+            func=lambda: create_account(
+                name=self.account.split("@")[0],
+                domain=self.domain,
+                password=password,
+                description=f"{first_name} {last_name}" if last_name else first_name,
+                aliases=self._aliases,
+                groups=[],
+                roles=self._roles,
+                quota=self._quota,
+                locale=locale,
+                timezone=time_zone,
+            ),
+            title="Failed to create account on Stalwart",
+            user_message=_("Failed to create account on the server, check error log for details."),
+            module="Mail",
+        )
+
+        # Step - 2: Create App Password on Stalwart
+        app_password = execute_with_logging(
+            func=lambda: create_app_password(self.account),
+            title="Failed to create app password on Stalwart",
+            user_message=_("Failed to create app password on the server, check error log for details."),
+            module="Mail",
+        )
+
+        # Step - 3: Create User
+        user = execute_with_logging(
+            func=lambda: create_user(
+                self.account,
+                first_name,
+                last_name,
+                password,
+                ["Suite User", "Suite Admin"] if self.is_admin else ["Suite User"],
+            ),
+            title="Failed to create user",
+            user_message=_("Failed to create user, check error log for details."),
+            module="Mail",
+        )
+
+        # Step - 4: Update User Settings
+        execute_with_logging(
+            func=lambda: self._update_user_settings(user, app_password),
+            title="Failed to update user settings",
+            user_message=_("Failed to update user settings, check error log for details."),
+            module="Mail",
+        )
+
+        # Step - 5: Create Push Subscription
+        if frappe.utils.get_url().startswith("https"):
+            execute_with_logging(
+                func=lambda: self._create_push_subscription(user),
+                title="Failed to create push subscription",
+                module="Mail",
+            )
+
+        # Step - 6: Join the groups and mailing lists picked when the request was created. Logged but
+        # not thrown: the account already exists, so a stale group or list must not fail the signup.
+        if account_id and self._groups:
+            execute_with_logging(
+                func=lambda: self._join_groups(account_id),
+                title="Failed to add account to groups on Stalwart",
+                module="Mail",
+            )
+
+        if self._mailing_lists:
+            execute_with_logging(
+                func=lambda: self._join_mailing_lists(),
+                title="Failed to add account to mailing lists on Stalwart",
+                module="Mail",
+            )
+
+    def _join_groups(self, account_id: str) -> None:
+        """Adds the created account to each of the requested groups."""
+
+        from suite.mail.stalwart import get_group_service
+
+        service = get_group_service()
+        for group_id in self._groups:
+            service.add_members(group_id, [account_id])
+
+    def _join_mailing_lists(self) -> None:
+        """Adds the account's primary address as a recipient of each requested mailing list."""
+
+        from suite.mail.stalwart import get_mailing_list_service
+
+        service = get_mailing_list_service()
+        for list_id in self._mailing_lists:
+            recipients = dict((service.get(list_id, properties=["recipients"]) or {}).get("recipients") or {})
+            recipients[self.account] = True
+            service.update(list_id, {"recipients": recipients})
+
+    def _update_user_settings(self, user: str, app_password: str) -> None:
+        """Updates the user settings with the app password and backup email."""
+
+        user_settings = frappe.get_doc("User Settings", {"user": user})
+        user_settings.username = self.account
+        user_settings.app_password = app_password
+        user_settings.backup_email = self.backup_email
+        user_settings.save(ignore_permissions=True)
+
+    def _create_push_subscription(self, user: str) -> None:
+        """Creates a push subscription for the user."""
+
+        ps = frappe.new_doc("Push Subscription")
+        ps.user = user
+        ps.insert(ignore_permissions=True)
 
 
 def create_user(
-	email: str,
-	first_name: str,
-	last_name: str | None = None,
-	password: str | None = None,
-	roles: list[str] | None = None,
+    email: str,
+    first_name: str,
+    last_name: str | None = None,
+    password: str | None = None,
+    roles: list[str] | None = None,
 ) -> str:
-	"""Creates a User document"""
+    """Creates a User document"""
 
-	if frappe.db.exists("User", {"email": email}):
-		frappe.throw(_("User with email {0} already exists.").format(frappe.bold(email)))
+    if frappe.db.exists("User", {"email": email}):
+        frappe.throw(_("User with email {0} already exists.").format(frappe.bold(email)))
 
-	user = frappe.new_doc("User")
-	user.first_name = first_name
-	user.last_name = last_name
-	user.username = email
-	user.email = email
-	user.owner = email
-	user.send_welcome_email = 0
-	if roles:
-		user.append_roles(*roles)
-	if password:
-		user.new_password = password
-	user.insert(ignore_permissions=True)
+    user = frappe.new_doc("User")
+    user.first_name = first_name
+    user.last_name = last_name
+    user.username = email
+    user.email = email
+    user.owner = email
+    user.send_welcome_email = 0
+    if roles:
+        user.append_roles(*roles)
+    if password:
+        user.new_password = password
+    user.insert(ignore_permissions=True)
 
-	return user.name
+    return user.name

--- a/suite/mail/doctype/mail_account_request/test_mail_account_request.py
+++ b/suite/mail/doctype/mail_account_request/test_mail_account_request.py
@@ -12,18 +12,18 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class UnitTestMailAccountRequest(UnitTestCase):
-	"""
-	Unit tests for MailAccountRequest.
-	Use this class for testing individual functions and methods.
-	"""
+    """
+    Unit tests for MailAccountRequest.
+    Use this class for testing individual functions and methods.
+    """
 
-	pass
+    pass
 
 
 class IntegrationTestMailAccountRequest(IntegrationTestCase):
-	"""
-	Integration tests for MailAccountRequest.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for MailAccountRequest.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/mail_client_configuration/mail_client_configuration.py
+++ b/suite/mail/doctype/mail_client_configuration/mail_client_configuration.py
@@ -6,21 +6,21 @@ from frappe.model.document import Document
 
 
 class MailClientConfiguration(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		connection_security: DF.Literal["SSL/TLS", "STARTTLS", "None"]
-		hostname: DF.Data
-		parent: DF.Data
-		parentfield: DF.Data
-		parenttype: DF.Data
-		port: DF.Int
-		protocol: DF.Literal["SMTP", "IMAP", "POP3"]
-	# end: auto-generated types
+        connection_security: DF.Literal["SSL/TLS", "STARTTLS", "None"]
+        hostname: DF.Data
+        parent: DF.Data
+        parentfield: DF.Data
+        parenttype: DF.Data
+        port: DF.Int
+        protocol: DF.Literal["SMTP", "IMAP", "POP3"]
+    # end: auto-generated types
 
-	pass
+    pass

--- a/suite/mail/doctype/mail_cluster/mail_cluster.py
+++ b/suite/mail/doctype/mail_cluster/mail_cluster.py
@@ -13,227 +13,227 @@ from frappe.utils import random_string
 from suite.mail.utils.dns import get_dns_record
 
 ALLOWED_STORE_TYPES = {
-	"data_store": ["RocksDb", "Sqlite", "FoundationDb", "PostgreSql", "MySql"],
-	"blob_store": ["Default", "RocksDb", "S3", "Azure", "FileSystem"],
-	"search_store": ["Default", "RocksDb", "ElasticSearch", "Meilisearch"],
-	"in_memory_store": ["Default", "RocksDb", "Redis", "RedisCluster"],
+    "data_store": ["RocksDb", "Sqlite", "FoundationDb", "PostgreSql", "MySql"],
+    "blob_store": ["Default", "RocksDb", "S3", "Azure", "FileSystem"],
+    "search_store": ["Default", "RocksDb", "ElasticSearch", "Meilisearch"],
+    "in_memory_store": ["Default", "RocksDb", "Redis", "RedisCluster"],
 }
 
 
 class MailCluster(Document):
-	@property
-	def data_store_config(self) -> str:
-		if not self.data_store:
-			return "{}"
+    @property
+    def data_store_config(self) -> str:
+        if not self.data_store:
+            return "{}"
 
-		try:
-			store = frappe.get_doc("Mail Cluster Store", self.data_store)
-			return json.dumps(store.config, indent=4)
-		except Exception:
-			return "{}"
+        try:
+            store = frappe.get_doc("Mail Cluster Store", self.data_store)
+            return json.dumps(store.config, indent=4)
+        except Exception:
+            return "{}"
 
-	@property
-	def blob_store_config(self) -> str:
-		if not self.blob_store:
-			return '{"@type": "Default"}'
+    @property
+    def blob_store_config(self) -> str:
+        if not self.blob_store:
+            return '{"@type": "Default"}'
 
-		try:
-			store = frappe.get_doc("Mail Cluster Store", self.blob_store)
-			return json.dumps(store.config, indent=4)
-		except Exception:
-			return '{"@type": "Default"}'
+        try:
+            store = frappe.get_doc("Mail Cluster Store", self.blob_store)
+            return json.dumps(store.config, indent=4)
+        except Exception:
+            return '{"@type": "Default"}'
 
-	@property
-	def search_store_config(self) -> str:
-		if not self.search_store:
-			return '{"@type": "Default"}'
+    @property
+    def search_store_config(self) -> str:
+        if not self.search_store:
+            return '{"@type": "Default"}'
 
-		try:
-			store = frappe.get_doc("Mail Cluster Store", self.search_store)
-			return json.dumps(store.config, indent=4)
-		except Exception:
-			return '{"@type": "Default"}'
+        try:
+            store = frappe.get_doc("Mail Cluster Store", self.search_store)
+            return json.dumps(store.config, indent=4)
+        except Exception:
+            return '{"@type": "Default"}'
 
-	@property
-	def in_memory_store_config(self) -> str:
-		if not self.in_memory_store:
-			return '{"@type": "Default"}'
+    @property
+    def in_memory_store_config(self) -> str:
+        if not self.in_memory_store:
+            return '{"@type": "Default"}'
 
-		try:
-			store = frappe.get_doc("Mail Cluster Store", self.in_memory_store)
-			return json.dumps(store.config, indent=4)
-		except Exception:
-			return '{"@type": "Default"}'
+        try:
+            store = frappe.get_doc("Mail Cluster Store", self.in_memory_store)
+            return json.dumps(store.config, indent=4)
+        except Exception:
+            return '{"@type": "Default"}'
 
-	def autoname(self) -> None:
-		self.hostname = self.hostname.lower()
-		self.name = self.hostname
+    def autoname(self) -> None:
+        self.hostname = self.hostname.lower()
+        self.name = self.hostname
 
-	def before_insert(self) -> None:
-		self.generate_ssh_keypair()
-		self.initialize_defaults()
+    def before_insert(self) -> None:
+        self.generate_ssh_keypair()
+        self.initialize_defaults()
 
-	def validate(self) -> None:
-		self.validate_enabled()
-		self.validate_hostname()
-		self.validate_default_domain()
-		self.validate_recovery_admin_password()
-		self.validate_base_url()
-		self.validate_stores()
+    def validate(self) -> None:
+        self.validate_enabled()
+        self.validate_hostname()
+        self.validate_default_domain()
+        self.validate_recovery_admin_password()
+        self.validate_base_url()
+        self.validate_stores()
 
-	def on_trash(self) -> None:
-		if frappe.session.user != "Administrator":
-			frappe.throw(_("Only Administrator can delete Mail Cluster."))
+    def on_trash(self) -> None:
+        if frappe.session.user != "Administrator":
+            frappe.throw(_("Only Administrator can delete Mail Cluster."))
 
-	def generate_ssh_keypair(self, save: bool = False) -> None:
-		"""Generates an SSH key pair for the cluster."""
+    def generate_ssh_keypair(self, save: bool = False) -> None:
+        """Generates an SSH key pair for the cluster."""
 
-		key = paramiko.RSAKey.generate(4096)
-		private_io = io.StringIO()
-		key.write_private_key(private_io)
-		self.ssh_private_key = private_io.getvalue()
-		self.ssh_public_key = f"{key.get_name()} {key.get_base64()} frappe-mail-cluster"
+        key = paramiko.RSAKey.generate(4096)
+        private_io = io.StringIO()
+        key.write_private_key(private_io)
+        self.ssh_private_key = private_io.getvalue()
+        self.ssh_public_key = f"{key.get_name()} {key.get_base64()} frappe-mail-cluster"
 
-		if save:
-			self.save()
+        if save:
+            self.save()
 
-	@frappe.whitelist()
-	def initialize_defaults(self) -> None:
-		"""Initializes the default values."""
+    @frappe.whitelist()
+    def initialize_defaults(self) -> None:
+        """Initializes the default values."""
 
-		self._initialize_data_store()
+        self._initialize_data_store()
 
-	def validate_enabled(self) -> None:
-		"""Validates the enabled status of the cluster."""
+    def validate_enabled(self) -> None:
+        """Validates the enabled status of the cluster."""
 
-		if self.enabled:
-			return
+        if self.enabled:
+            return
 
-		if server := frappe.db.exists("Mail Server", {"enabled": 1, "cluster": self.name}):
-			frappe.throw(
-				_("Mail Server {0} is enabled. Please disable it first.").format(frappe.bold(server))
-			)
+        if server := frappe.db.exists("Mail Server", {"enabled": 1, "cluster": self.name}):
+            frappe.throw(
+                _("Mail Server {0} is enabled. Please disable it first.").format(frappe.bold(server))
+            )
 
-	def validate_hostname(self) -> None:
-		"""Validates the cluster and fetches the IP addresses."""
+    def validate_hostname(self) -> None:
+        """Validates the cluster and fetches the IP addresses."""
 
-		if self.is_new() and frappe.db.exists("Mail Cluster", self.hostname):
-			frappe.throw(_("Mail Cluster {0} already exists.").format(frappe.bold(self.hostname)))
+        if self.is_new() and frappe.db.exists("Mail Cluster", self.hostname):
+            frappe.throw(_("Mail Cluster {0} already exists.").format(frappe.bold(self.hostname)))
 
-		self.ipv4_addresses = "\n".join([r.address for r in get_dns_record(self.hostname, "A") or []])
-		self.ipv6_addresses = "\n".join([r.address for r in get_dns_record(self.hostname, "AAAA") or []])
+        self.ipv4_addresses = "\n".join([r.address for r in get_dns_record(self.hostname, "A") or []])
+        self.ipv6_addresses = "\n".join([r.address for r in get_dns_record(self.hostname, "AAAA") or []])
 
-	def validate_default_domain(self) -> None:
-		"""Validates the default domain of the cluster."""
+    def validate_default_domain(self) -> None:
+        """Validates the default domain of the cluster."""
 
-		if not self.default_domain:
-			self.default_domain = self.hostname
+        if not self.default_domain:
+            self.default_domain = self.hostname
 
-	def validate_recovery_admin_password(self) -> None:
-		"""Validates the recovery admin password."""
+    def validate_recovery_admin_password(self) -> None:
+        """Validates the recovery admin password."""
 
-		if self.recovery_admin_password:
-			if len(self.recovery_admin_password) < 16:
-				frappe.throw(_("Password must be at least 16 characters long."))
-		else:
-			self.recovery_admin_password = random_string(length=20)
+        if self.recovery_admin_password:
+            if len(self.recovery_admin_password) < 16:
+                frappe.throw(_("Password must be at least 16 characters long."))
+        else:
+            self.recovery_admin_password = random_string(length=20)
 
-	def validate_base_url(self) -> None:
-		"""Validates the base URL of the cluster."""
+    def validate_base_url(self) -> None:
+        """Validates the base URL of the cluster."""
 
-		if not self.base_url:
-			self.base_url = f"https://{self.hostname}/"
+        if not self.base_url:
+            self.base_url = f"https://{self.hostname}/"
 
-	def validate_stores(self) -> None:
-		"""Validates the data stores of the cluster."""
+    def validate_stores(self) -> None:
+        """Validates the data stores of the cluster."""
 
-		def validate_store(store_field: str) -> None:
-			store = self.get(store_field)
+        def validate_store(store_field: str) -> None:
+            store = self.get(store_field)
 
-			if store_field == "data_store" and not store:
-				frappe.throw(_("Data Store is required."))
+            if store_field == "data_store" and not store:
+                frappe.throw(_("Data Store is required."))
 
-			if not store or (store_field != "data_store" and store == self.data_store):
-				default_store = frappe.db.get_value("Mail Cluster Store", {"type": "Default"}, "name")
-				if not default_store:
-					doc = frappe.new_doc("Mail Cluster Store")
-					doc.type = "Default"
-					doc.insert()
-					default_store = doc.name
+            if not store or (store_field != "data_store" and store == self.data_store):
+                default_store = frappe.db.get_value("Mail Cluster Store", {"type": "Default"}, "name")
+                if not default_store:
+                    doc = frappe.new_doc("Mail Cluster Store")
+                    doc.type = "Default"
+                    doc.insert()
+                    default_store = doc.name
 
-				self.set(store_field, default_store)
-				return
+                self.set(store_field, default_store)
+                return
 
-			store_type = frappe.db.get_value("Mail Cluster Store", store, "type")
-			allowed_types = ALLOWED_STORE_TYPES[store_field]
+            store_type = frappe.db.get_value("Mail Cluster Store", store, "type")
+            allowed_types = ALLOWED_STORE_TYPES[store_field]
 
-			if store_type not in allowed_types:
-				frappe.throw(
-					_("{0} type must be one of {1}.").format(
-						self.meta.get_field(store_field).label,
-						", ".join(allowed_types),
-					)
-				)
+            if store_type not in allowed_types:
+                frappe.throw(
+                    _("{0} type must be one of {1}.").format(
+                        self.meta.get_field(store_field).label,
+                        ", ".join(allowed_types),
+                    )
+                )
 
-		validate_store("data_store")
+        validate_store("data_store")
 
-		for field in ["blob_store", "search_store", "in_memory_store"]:
-			validate_store(field)
+        for field in ["blob_store", "search_store", "in_memory_store"]:
+            validate_store(field)
 
-	def _initialize_data_store(self) -> None:
-		"""Initializes the data store for the cluster."""
+    def _initialize_data_store(self) -> None:
+        """Initializes the data store for the cluster."""
 
-		if not self.data_store:
-			store = frappe.new_doc("Mail Cluster Store")
-			store.type = "RocksDb"
-			store.path = "/etc/stalwart/data"
-			store.blob_size = 16834
-			store.buffer_size = 134217728
-			store.pool_workers = 1
-			store.insert()
+        if not self.data_store:
+            store = frappe.new_doc("Mail Cluster Store")
+            store.type = "RocksDb"
+            store.path = "/etc/stalwart/data"
+            store.blob_size = 16834
+            store.buffer_size = 134217728
+            store.pool_workers = 1
+            store.insert()
 
-			self.data_store = store.name
+            self.data_store = store.name
 
-	@frappe.whitelist()
-	def get_recovery_admin_password(self) -> str:
-		"""Returns the admin password of the cluster."""
+    @frappe.whitelist()
+    def get_recovery_admin_password(self) -> str:
+        """Returns the admin password of the cluster."""
 
-		frappe.only_for("System Manager")
-		return self.get_password("recovery_admin_password")
+        frappe.only_for("System Manager")
+        return self.get_password("recovery_admin_password")
 
-	def get_bootstrap_operations(self, hostname: str = "{{ hostname }}") -> list[dict]:
-		"""Returns the bootstrap operations for the cluster."""
+    def get_bootstrap_operations(self, hostname: str = "{{ hostname }}") -> list[dict]:
+        """Returns the bootstrap operations for the cluster."""
 
-		operations = [
-			{
-				"@type": "update",
-				"object": "Bootstrap",
-				"id": "singleton",
-				"value": {
-					# required
-					"serverHostname": hostname,
-					"defaultDomain": self.default_domain,
-					# optional
-					"requestTlsCertificate": True,
-					"generateDkimKeys": True,
-					"dataStore": json.loads(self.data_store_config),
-					"blobStore": json.loads(self.blob_store_config),
-					"searchStore": json.loads(self.search_store_config),
-					"inMemoryStore": json.loads(self.in_memory_store_config),
-					"directory": {"@type": "Internal"},
-					"tracer": {
-						"@type": "Log",
-						"ansi": True,
-						"enable": True,
-						"eventsPolicy": "exclude",
-						"level": "info",
-						"prefix": "stalwart",
-						"rotate": "daily",
-						"path": "/etc/stalwart/logs",
-					},
-					"dnsServer": {"@type": "Manual"},
-				},
-			}
-		]
+        operations = [
+            {
+                "@type": "update",
+                "object": "Bootstrap",
+                "id": "singleton",
+                "value": {
+                    # required
+                    "serverHostname": hostname,
+                    "defaultDomain": self.default_domain,
+                    # optional
+                    "requestTlsCertificate": True,
+                    "generateDkimKeys": True,
+                    "dataStore": json.loads(self.data_store_config),
+                    "blobStore": json.loads(self.blob_store_config),
+                    "searchStore": json.loads(self.search_store_config),
+                    "inMemoryStore": json.loads(self.in_memory_store_config),
+                    "directory": {"@type": "Internal"},
+                    "tracer": {
+                        "@type": "Log",
+                        "ansi": True,
+                        "enable": True,
+                        "eventsPolicy": "exclude",
+                        "level": "info",
+                        "prefix": "stalwart",
+                        "rotate": "daily",
+                        "path": "/etc/stalwart/logs",
+                    },
+                    "dnsServer": {"@type": "Manual"},
+                },
+            }
+        ]
 
-		return operations
+        return operations

--- a/suite/mail/doctype/mail_cluster/test_mail_cluster.py
+++ b/suite/mail/doctype/mail_cluster/test_mail_cluster.py
@@ -6,4 +6,4 @@ from frappe.tests.utils import FrappeTestCase
 
 
 class TestMailCluster(FrappeTestCase):
-	pass
+    pass

--- a/suite/mail/doctype/mail_cluster_store/mail_cluster_store.py
+++ b/suite/mail/doctype/mail_cluster_store/mail_cluster_store.py
@@ -11,210 +11,210 @@ from frappe.utils import cint, flt
 
 
 class MailClusterStore(Document):
-	def autoname(self) -> None:
-		self.name = str(uuid7())
+    def autoname(self) -> None:
+        self.name = str(uuid7())
 
-	@property
-	def config(self) -> dict:
-		"""Returns the configuration for the cluster store."""
+    @property
+    def config(self) -> dict:
+        """Returns the configuration for the cluster store."""
 
-		if not self.type:
-			return {}
+        if not self.type:
+            return {}
 
-		config = {"@type": self.type}
+        config = {"@type": self.type}
 
-		if self.type == "RocksDb":
-			config.update(
-				{
-					"path": self.path,
-					"blobSize": cint(self.blob_size),
-					"bufferSize": cint(self.buffer_size),
-					"poolWorkers": cint(self.pool_workers),
-				}
-			)
+        if self.type == "RocksDb":
+            config.update(
+                {
+                    "path": self.path,
+                    "blobSize": cint(self.blob_size),
+                    "bufferSize": cint(self.buffer_size),
+                    "poolWorkers": cint(self.pool_workers),
+                }
+            )
 
-		elif self.type == "Sqlite":
-			config.update(
-				{
-					"path": self.path,
-					"poolWorkers": cint(self.pool_workers),
-					"poolMaxConnections": cint(self.pool_max_connections),
-				}
-			)
+        elif self.type == "Sqlite":
+            config.update(
+                {
+                    "path": self.path,
+                    "poolWorkers": cint(self.pool_workers),
+                    "poolMaxConnections": cint(self.pool_max_connections),
+                }
+            )
 
-		elif self.type == "FoundationDb":
-			config.update(
-				{
-					"clusterFile": self.cluster_file,
-					"datacenterId": self.datacenter_id,
-					"machineId": self.machine_id,
-					"transactionRetryDelay": cint(flt(self.transaction_retry_delay, 1) * 1000),
-					"transactionTimeout": cint(flt(self.transaction_timeout, 1) * 1000),
-					"transactionRetryLimit": cint(self.transaction_retry_limit),
-				}
-			)
+        elif self.type == "FoundationDb":
+            config.update(
+                {
+                    "clusterFile": self.cluster_file,
+                    "datacenterId": self.datacenter_id,
+                    "machineId": self.machine_id,
+                    "transactionRetryDelay": cint(flt(self.transaction_retry_delay, 1) * 1000),
+                    "transactionTimeout": cint(flt(self.transaction_timeout, 1) * 1000),
+                    "transactionRetryLimit": cint(self.transaction_retry_limit),
+                }
+            )
 
-		elif self.type == "PostgreSql":
-			config.update(
-				{
-					"timeout": cint(flt(self.timeout, 1) * 1000),
-					"useTls": bool(self.use_tls),
-					"allowInvalidCerts": bool(self.allow_invalid_certs),
-					"poolMaxConnections": cint(self.pool_max_connections),
-					"poolRecyclingMethod": self.pool_recycling_method,
-					"host": self.host,
-					"port": cint(self.port),
-					"database": self.database,
-					"authUsername": self.auth_username,
-					"authSecret": {"@type": "Value", "secret": self.get_password("auth_secret")}
-					if self.auth_secret
-					else None,
-					"options": self.options,
-				}
-			)
+        elif self.type == "PostgreSql":
+            config.update(
+                {
+                    "timeout": cint(flt(self.timeout, 1) * 1000),
+                    "useTls": bool(self.use_tls),
+                    "allowInvalidCerts": bool(self.allow_invalid_certs),
+                    "poolMaxConnections": cint(self.pool_max_connections),
+                    "poolRecyclingMethod": self.pool_recycling_method,
+                    "host": self.host,
+                    "port": cint(self.port),
+                    "database": self.database,
+                    "authUsername": self.auth_username,
+                    "authSecret": {"@type": "Value", "secret": self.get_password("auth_secret")}
+                    if self.auth_secret
+                    else None,
+                    "options": self.options,
+                }
+            )
 
-		elif self.type == "MySql":
-			config.update(
-				{
-					"timeout": cint(flt(self.timeout, 1) * 1000),
-					"useTls": bool(self.use_tls),
-					"allowInvalidCerts": bool(self.allow_invalid_certs),
-					"maxAllowedPacket": cint(self.max_allowed_packet) if self.max_allowed_packet else None,
-					"poolMaxConnections": cint(self.pool_max_connections),
-					"poolMinConnections": cint(self.pool_min_connections),
-					"host": self.host,
-					"port": cint(self.port),
-					"database": self.database,
-					"authUsername": self.auth_username,
-					"authSecret": {"@type": "Value", "secret": self.get_password("auth_secret")}
-					if self.auth_secret
-					else None,
-				}
-			)
+        elif self.type == "MySql":
+            config.update(
+                {
+                    "timeout": cint(flt(self.timeout, 1) * 1000),
+                    "useTls": bool(self.use_tls),
+                    "allowInvalidCerts": bool(self.allow_invalid_certs),
+                    "maxAllowedPacket": cint(self.max_allowed_packet) if self.max_allowed_packet else None,
+                    "poolMaxConnections": cint(self.pool_max_connections),
+                    "poolMinConnections": cint(self.pool_min_connections),
+                    "host": self.host,
+                    "port": cint(self.port),
+                    "database": self.database,
+                    "authUsername": self.auth_username,
+                    "authSecret": {"@type": "Value", "secret": self.get_password("auth_secret")}
+                    if self.auth_secret
+                    else None,
+                }
+            )
 
-		elif self.type == "S3":
-			config.update(
-				{
-					"region": self.region,
-					"bucket": self.bucket,
-					"accessKey": self.access_key,
-					"secretKey": {"@type": "Value", "secret": self.get_password("secret_key")}
-					if self.secret_key
-					else None,
-					"securityToken": {"@type": "Value", "secret": self.get_password("security_token")}
-					if self.security_token
-					else None,
-					"sessionToken": {"@type": "Value", "secret": self.get_password("session_token")}
-					if self.session_token
-					else None,
-					"profile": self.profile,
-					"timeout": cint(flt(self.timeout, 1) * 1000),
-					"maxRetries": cint(self.max_retries),
-					"keyPrefix": self.key_prefix,
-					"allowInvalidCerts": bool(self.allow_invalid_certs),
-					"verifyAfterWrite": bool(self.verify_after_write),
-				}
-			)
+        elif self.type == "S3":
+            config.update(
+                {
+                    "region": self.region,
+                    "bucket": self.bucket,
+                    "accessKey": self.access_key,
+                    "secretKey": {"@type": "Value", "secret": self.get_password("secret_key")}
+                    if self.secret_key
+                    else None,
+                    "securityToken": {"@type": "Value", "secret": self.get_password("security_token")}
+                    if self.security_token
+                    else None,
+                    "sessionToken": {"@type": "Value", "secret": self.get_password("session_token")}
+                    if self.session_token
+                    else None,
+                    "profile": self.profile,
+                    "timeout": cint(flt(self.timeout, 1) * 1000),
+                    "maxRetries": cint(self.max_retries),
+                    "keyPrefix": self.key_prefix,
+                    "allowInvalidCerts": bool(self.allow_invalid_certs),
+                    "verifyAfterWrite": bool(self.verify_after_write),
+                }
+            )
 
-		elif self.type == "Azure":
-			config.update(
-				{
-					"storageAccount": self.storage_account,
-					"container": self.container,
-					"accessKey": {"@type": "Value", "secret": self.get_password("access_key")}
-					if self.access_key
-					else None,
-					"sasToken": {"@type": "Value", "secret": self.get_password("sas_token")}
-					if self.sas_token
-					else None,
-					"timeout": cint(flt(self.timeout, 1) * 1000),
-					"maxRetries": cint(self.max_retries),
-					"keyPrefix": self.key_prefix,
-				}
-			)
+        elif self.type == "Azure":
+            config.update(
+                {
+                    "storageAccount": self.storage_account,
+                    "container": self.container,
+                    "accessKey": {"@type": "Value", "secret": self.get_password("access_key")}
+                    if self.access_key
+                    else None,
+                    "sasToken": {"@type": "Value", "secret": self.get_password("sas_token")}
+                    if self.sas_token
+                    else None,
+                    "timeout": cint(flt(self.timeout, 1) * 1000),
+                    "maxRetries": cint(self.max_retries),
+                    "keyPrefix": self.key_prefix,
+                }
+            )
 
-		elif self.type == "FileSystem":
-			config.update(
-				{
-					"path": self.path,
-					"depth": cint(self.depth),
-				}
-			)
+        elif self.type == "FileSystem":
+            config.update(
+                {
+                    "path": self.path,
+                    "depth": cint(self.depth),
+                }
+            )
 
-		elif self.type == "ElasticSearch":
-			http_auth = frappe.get_doc("Mail Cluster Store HTTP Auth", self.http_auth)
-			config.update(
-				{
-					"url": self.url,
-					"numReplicas": cint(self.num_replicas),
-					"numShards": cint(self.num_shards),
-					"includeSource": bool(self.include_source),
-					"timeout": cint(flt(self.timeout, 1) * 1000),
-					"allowInvalidCerts": bool(self.allow_invalid_certs),
-					"httpAuth": http_auth.config,
-					"httpHeaders": json.loads(self.http_headers) if self.http_headers else {},
-				}
-			)
+        elif self.type == "ElasticSearch":
+            http_auth = frappe.get_doc("Mail Cluster Store HTTP Auth", self.http_auth)
+            config.update(
+                {
+                    "url": self.url,
+                    "numReplicas": cint(self.num_replicas),
+                    "numShards": cint(self.num_shards),
+                    "includeSource": bool(self.include_source),
+                    "timeout": cint(flt(self.timeout, 1) * 1000),
+                    "allowInvalidCerts": bool(self.allow_invalid_certs),
+                    "httpAuth": http_auth.config,
+                    "httpHeaders": json.loads(self.http_headers) if self.http_headers else {},
+                }
+            )
 
-		elif self.type == "Meilisearch":
-			http_auth = frappe.get_doc("Mail Cluster Store HTTP Auth", self.http_auth)
-			config.update(
-				{
-					"url": self.url,
-					"pollInterval": cint(flt(self.poll_interval, 1) * 1000),
-					"maxRetries": cint(self.max_retries),
-					"failOnTimeout": bool(self.fail_on_timeout),
-					"timeout": cint(flt(self.timeout, 1) * 1000),
-					"allowInvalidCerts": bool(self.allow_invalid_certs),
-					"httpAuth": http_auth.config,
-					"httpHeaders": json.loads(self.http_headers) if self.http_headers else {},
-				}
-			)
+        elif self.type == "Meilisearch":
+            http_auth = frappe.get_doc("Mail Cluster Store HTTP Auth", self.http_auth)
+            config.update(
+                {
+                    "url": self.url,
+                    "pollInterval": cint(flt(self.poll_interval, 1) * 1000),
+                    "maxRetries": cint(self.max_retries),
+                    "failOnTimeout": bool(self.fail_on_timeout),
+                    "timeout": cint(flt(self.timeout, 1) * 1000),
+                    "allowInvalidCerts": bool(self.allow_invalid_certs),
+                    "httpAuth": http_auth.config,
+                    "httpHeaders": json.loads(self.http_headers) if self.http_headers else {},
+                }
+            )
 
-		elif self.type == "Redis":
-			config.update(
-				{
-					"url": self.url,
-					"timeout": cint(flt(self.timeout, 1) * 1000),
-					"poolMaxConnections": cint(self.pool_max_connections),
-					"poolTimeoutCreate": cint(flt(self.pool_timeout_create, 1) * 1000),
-					"poolTimeoutWait": cint(flt(self.pool_timeout_wait, 1) * 1000),
-					"poolTimeoutRecycle": cint(flt(self.pool_timeout_recycle, 1) * 1000),
-				}
-			)
+        elif self.type == "Redis":
+            config.update(
+                {
+                    "url": self.url,
+                    "timeout": cint(flt(self.timeout, 1) * 1000),
+                    "poolMaxConnections": cint(self.pool_max_connections),
+                    "poolTimeoutCreate": cint(flt(self.pool_timeout_create, 1) * 1000),
+                    "poolTimeoutWait": cint(flt(self.pool_timeout_wait, 1) * 1000),
+                    "poolTimeoutRecycle": cint(flt(self.pool_timeout_recycle, 1) * 1000),
+                }
+            )
 
-		elif self.type == "RedisCluster":
-			config.update(
-				{
-					"urls": json.loads(self.urls) if self.urls else [],
-					"timeout": cint(flt(self.timeout, 1) * 1000),
-					"authUsername": self.auth_username,
-					"authSecret": {"@type": "Value", "secret": self.get_password("auth_secret")}
-					if self.auth_secret
-					else None,
-					"maxRetryWait": cint(flt(self.max_retry_wait, 1) * 1000),
-					"minRetryWait": cint(flt(self.min_retry_wait, 1) * 1000),
-					"maxRetries": cint(self.max_retries),
-					"readFromReplicas": bool(self.read_from_replicas),
-					"protocolVersion": self.protocol_version,
-					"poolMaxConnections": cint(self.pool_max_connections),
-					"poolTimeoutCreate": cint(flt(self.pool_timeout_create, 1) * 1000),
-					"poolTimeoutWait": cint(flt(self.pool_timeout_wait, 1) * 1000),
-					"poolTimeoutRecycle": cint(flt(self.pool_timeout_recycle, 1) * 1000),
-				}
-			)
+        elif self.type == "RedisCluster":
+            config.update(
+                {
+                    "urls": json.loads(self.urls) if self.urls else [],
+                    "timeout": cint(flt(self.timeout, 1) * 1000),
+                    "authUsername": self.auth_username,
+                    "authSecret": {"@type": "Value", "secret": self.get_password("auth_secret")}
+                    if self.auth_secret
+                    else None,
+                    "maxRetryWait": cint(flt(self.max_retry_wait, 1) * 1000),
+                    "minRetryWait": cint(flt(self.min_retry_wait, 1) * 1000),
+                    "maxRetries": cint(self.max_retries),
+                    "readFromReplicas": bool(self.read_from_replicas),
+                    "protocolVersion": self.protocol_version,
+                    "poolMaxConnections": cint(self.pool_max_connections),
+                    "poolTimeoutCreate": cint(flt(self.pool_timeout_create, 1) * 1000),
+                    "poolTimeoutWait": cint(flt(self.pool_timeout_wait, 1) * 1000),
+                    "poolTimeoutRecycle": cint(flt(self.pool_timeout_recycle, 1) * 1000),
+                }
+            )
 
-		return config
+        return config
 
-	def validate(self) -> None:
-		if not self.description:
-			self.description = self.type
+    def validate(self) -> None:
+        if not self.description:
+            self.description = self.type
 
-		self.validate_singleton_default()
+        self.validate_singleton_default()
 
-	def validate_singleton_default(self) -> None:
-		"""Validates that only one Default store exists."""
+    def validate_singleton_default(self) -> None:
+        """Validates that only one Default store exists."""
 
-		if self.type in ["Default"]:
-			if frappe.db.exists("Mail Cluster Store", {"type": self.type, "name": ["!=", self.name]}):
-				frappe.throw(_("Only one {0} store is allowed.").format(self.type))
+        if self.type in ["Default"]:
+            if frappe.db.exists("Mail Cluster Store", {"type": self.type, "name": ["!=", self.name]}):
+                frappe.throw(_("Only one {0} store is allowed.").format(self.type))

--- a/suite/mail/doctype/mail_cluster_store/test_mail_cluster_store.py
+++ b/suite/mail/doctype/mail_cluster_store/test_mail_cluster_store.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestMailClusterStore(IntegrationTestCase):
-	"""
-	Integration tests for MailClusterStore.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for MailClusterStore.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/mail_cluster_store_http_auth/mail_cluster_store_http_auth.py
+++ b/suite/mail/doctype/mail_cluster_store_http_auth/mail_cluster_store_http_auth.py
@@ -7,28 +7,28 @@ from frappe.model.document import Document
 
 
 class MailClusterStoreHTTPAuth(Document):
-	def autoname(self) -> None:
-		self.name = str(uuid7())
+    def autoname(self) -> None:
+        self.name = str(uuid7())
 
-	@property
-	def config(self) -> dict:
-		"""Returns the configuration for the HTTP Auth cluster store."""
+    @property
+    def config(self) -> dict:
+        """Returns the configuration for the HTTP Auth cluster store."""
 
-		config = {}
+        config = {}
 
-		if self.type == "Basic":
-			config.update(
-				{
-					"username": self.username,
-					"secret": self.get_password("secret") if self.secret else None,
-				}
-			)
+        if self.type == "Basic":
+            config.update(
+                {
+                    "username": self.username,
+                    "secret": self.get_password("secret") if self.secret else None,
+                }
+            )
 
-		elif self.type == "Bearer":
-			config["bearerToken"] = self.get_password("bearer_token") if self.bearer_token else None
+        elif self.type == "Bearer":
+            config["bearerToken"] = self.get_password("bearer_token") if self.bearer_token else None
 
-		return config
+        return config
 
-	def validate(self) -> None:
-		if not self.description:
-			self.description = self.type
+    def validate(self) -> None:
+        if not self.description:
+            self.description = self.type

--- a/suite/mail/doctype/mail_cluster_store_http_auth/test_mail_cluster_store_http_auth.py
+++ b/suite/mail/doctype/mail_cluster_store_http_auth/test_mail_cluster_store_http_auth.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestMailClusterStoreHTTPAuth(IntegrationTestCase):
-	"""
-	Integration tests for MailClusterStoreHTTPAuth.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for MailClusterStoreHTTPAuth.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/mail_exchange/mail_exchange.py
+++ b/suite/mail/doctype/mail_exchange/mail_exchange.py
@@ -20,38 +20,38 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder import Order
 from frappe.utils import (
-	add_to_date,
-	cint,
-	create_batch,
-	get_bench_path,
-	get_datetime,
-	get_files_path,
-	get_url,
-	now,
-	random_string,
-	time_diff_in_seconds,
+    add_to_date,
+    cint,
+    create_batch,
+    get_bench_path,
+    get_datetime,
+    get_files_path,
+    get_url,
+    now,
+    random_string,
+    time_diff_in_seconds,
 )
 
 from suite.mail.doctype.push_subscription.push_subscription import (
-	freeze_jmap_push_notifications,
-	unfreeze_jmap_push_notifications,
+    freeze_jmap_push_notifications,
+    unfreeze_jmap_push_notifications,
 )
 from suite.mail.doctype.user_account.user_account import is_jmap_account_belongs_to_user
 from suite.mail.jmap import get_jmap_connection
 from suite.mail.jmap.services.mail.email import EmailService
 from suite.mail.jmap.services.mail.mailbox import MailboxService
 from suite.mail.utils import (
-	get_config,
-	get_mail_export_directory,
-	get_mail_import_directory,
-	get_mbox_files,
+    get_config,
+    get_mail_export_directory,
+    get_mail_import_directory,
+    get_mbox_files,
 )
 from suite.mail.utils.logger import ExchangeLogger, get_exchange_logger
 from suite.mail.utils.user import clear_sync_state, get_user_email_address, is_jmap_configured
 from suite.mail.utils.validation import (
-	validate_jmap_structure,
-	validate_maildir_or_maildirpp,
-	validate_nested_maildir_tree,
+    validate_jmap_structure,
+    validate_maildir_or_maildirpp,
+    validate_nested_maildir_tree,
 )
 from suite.utils import log_error, reconnect_on_failure
 from suite.utils.dt import parse_iso_datetime
@@ -60,1228 +60,1228 @@ from suite.utils.permissions import OwnerFromUser
 from suite.utils.user import is_administrator
 
 MAILDIR_FLAG_MAP: dict[str, str] = {
-	"$seen": "S",
-	"$flagged": "F",
-	"$answered": "R",
-	"$draft": "D",
+    "$seen": "S",
+    "$flagged": "F",
+    "$answered": "R",
+    "$draft": "D",
 }
 
 
 @dataclass(slots=True)
 class ImportEmailMeta:
-	blob_path: str
-	mailbox_ids: set[str]
-	keywords: set[str]
-	received_at: datetime
+    blob_path: str
+    mailbox_ids: set[str]
+    keywords: set[str]
+    received_at: datetime
 
 
 def _safe_blob_id(blob_id: str) -> str:
-	"""Returns ``blob_id`` if it names a file directly inside ``blobs/``, else throws.
+    """Returns ``blob_id`` if it names a file directly inside ``blobs/``, else throws.
 
-	The id comes from the ``emails.json`` inside the uploaded archive, and the importer joins it onto
-	the extraction directory before opening it. A value like ``../../../../etc/passwd`` would
-	otherwise escape that directory and be imported as an email, so only bare filenames are allowed.
-	"""
+    The id comes from the ``emails.json`` inside the uploaded archive, and the importer joins it onto
+    the extraction directory before opening it. A value like ``../../../../etc/passwd`` would
+    otherwise escape that directory and be imported as an email, so only bare filenames are allowed.
+    """
 
-	if (
-		not blob_id
-		or blob_id in (".", "..")
-		or os.path.isabs(blob_id)
-		or os.path.basename(blob_id) != blob_id
-	):
-		frappe.throw(_("Invalid blobId {0} in the import metadata.").format(frappe.bold(str(blob_id))))
+    if (
+        not blob_id
+        or blob_id in (".", "..")
+        or os.path.isabs(blob_id)
+        or os.path.basename(blob_id) != blob_id
+    ):
+        frappe.throw(_("Invalid blobId {0} in the import metadata.").format(frappe.bold(str(blob_id))))
 
-	return blob_id
+    return blob_id
 
 
 @dataclass(slots=True)
 class ExportEmail:
-	id: str
-	sender: dict[str, str]
-	blob_id: str
-	keywords: set[str]
-	mailbox_ids: set[str]
-	message_id: str
-	received_at: datetime
-	raw: bytes
+    id: str
+    sender: dict[str, str]
+    blob_id: str
+    keywords: set[str]
+    mailbox_ids: set[str]
+    message_id: str
+    received_at: datetime
+    raw: bytes
 
 
 class ImportMetadataLoader:
-	@classmethod
-	def load(
-		cls,
-		format: Literal["eml", "jmap", "mbox", "maildir", "maildir-nested"],
-		base_dir: str,
-		mailbox_map: dict[str, str],
-		metadata: dict,
-	) -> list[ImportEmailMeta]:
-		"""Loads import metadata based on the specified format."""
-
-		loaders = {
-			"eml": cls._from_eml,
-			"jmap": cls._from_jmap,
-			"mbox": cls._from_mbox,
-			"maildir": cls._from_maildir,
-			"maildir-nested": cls._from_nested_maildir,
-		}
-
-		if format not in loaders:
-			frappe.throw(_("Unsupported import format: {0}").format(format))
+    @classmethod
+    def load(
+        cls,
+        format: Literal["eml", "jmap", "mbox", "maildir", "maildir-nested"],
+        base_dir: str,
+        mailbox_map: dict[str, str],
+        metadata: dict,
+    ) -> list[ImportEmailMeta]:
+        """Loads import metadata based on the specified format."""
+
+        loaders = {
+            "eml": cls._from_eml,
+            "jmap": cls._from_jmap,
+            "mbox": cls._from_mbox,
+            "maildir": cls._from_maildir,
+            "maildir-nested": cls._from_nested_maildir,
+        }
+
+        if format not in loaders:
+            frappe.throw(_("Unsupported import format: {0}").format(format))
 
-		return loaders[format](base_dir, mailbox_map, metadata)
+        return loaders[format](base_dir, mailbox_map, metadata)
 
-	@staticmethod
-	def _load_json_metadata(base_dir: str) -> list[str]:
-		"""Loads email metadata from emails.json file."""
+    @staticmethod
+    def _load_json_metadata(base_dir: str) -> list[str]:
+        """Loads email metadata from emails.json file."""
 
-		path = os.path.join(base_dir, "emails.json")
-		if not os.path.exists(path):
-			frappe.throw(_("emails.json not found in the import directory."))
-
-		with open(path) as f:
-			return json.load(f)
-
-	@staticmethod
-	def _from_eml(base_dir: str, mailbox_map: dict[str, str], metadata: dict) -> list[ImportEmailMeta]:
-		"""Loads import metadata for EML format."""
-
-		mailbox_ids = set(metadata.get("mailboxIds", {}).keys())
-		if not mailbox_ids:
-			frappe.throw(_("mailboxIds are required in Metadata for EML format."))
-
-		keywords = set(metadata.get("keywords", {}).keys() or [])
+        path = os.path.join(base_dir, "emails.json")
+        if not os.path.exists(path):
+            frappe.throw(_("emails.json not found in the import directory."))
+
+        with open(path) as f:
+            return json.load(f)
+
+    @staticmethod
+    def _from_eml(base_dir: str, mailbox_map: dict[str, str], metadata: dict) -> list[ImportEmailMeta]:
+        """Loads import metadata for EML format."""
+
+        mailbox_ids = set(metadata.get("mailboxIds", {}).keys())
+        if not mailbox_ids:
+            frappe.throw(_("mailboxIds are required in Metadata for EML format."))
+
+        keywords = set(metadata.get("keywords", {}).keys() or [])
 
-		if metadata_received_at := metadata.get("receivedAt"):
-			metadata_received_at = parse_iso_datetime(metadata_received_at, as_str=False)
+        if metadata_received_at := metadata.get("receivedAt"):
+            metadata_received_at = parse_iso_datetime(metadata_received_at, as_str=False)
 
-		files = [f for f in os.listdir(base_dir) if f.lower().endswith(".eml")]
-		if not files:
-			frappe.throw(_("No .eml files found"))
+        files = [f for f in os.listdir(base_dir) if f.lower().endswith(".eml")]
+        if not files:
+            frappe.throw(_("No .eml files found"))
 
-		result: list[ImportEmailMeta] = []
-		parser = BytesHeaderParser()
+        result: list[ImportEmailMeta] = []
+        parser = BytesHeaderParser()
 
-		for fname in files:
-			received_at = metadata_received_at
+        for fname in files:
+            received_at = metadata_received_at
 
-			if not received_at:
-				with open(os.path.join(base_dir, fname), "rb") as f:
-					msg: Message = parser.parse(f)
+            if not received_at:
+                with open(os.path.join(base_dir, fname), "rb") as f:
+                    msg: Message = parser.parse(f)
 
-				received_at = extract_received_or_sent(msg)
+                received_at = extract_received_or_sent(msg)
 
-			result.append(
-				ImportEmailMeta(
-					fname,
-					mailbox_ids,
-					keywords,
-					received_at,
-				)
-			)
+            result.append(
+                ImportEmailMeta(
+                    fname,
+                    mailbox_ids,
+                    keywords,
+                    received_at,
+                )
+            )
 
-		return result
+        return result
 
-	@classmethod
-	def _from_jmap(cls, base_dir: str, *args, **kwargs) -> list[ImportEmailMeta]:
-		"""Loads import metadata for JMAP format."""
+    @classmethod
+    def _from_jmap(cls, base_dir: str, *args, **kwargs) -> list[ImportEmailMeta]:
+        """Loads import metadata for JMAP format."""
 
-		validate_jmap_structure(base_dir, ["emails.json"], raise_exception=True)
+        validate_jmap_structure(base_dir, ["emails.json"], raise_exception=True)
 
-		result: list[ImportEmailMeta] = []
-		for meta in cls._load_json_metadata(base_dir):
-			result.append(
-				ImportEmailMeta(
-					blob_path=os.path.join("blobs", _safe_blob_id(meta["blobId"])),
-					mailbox_ids=set(meta["mailboxIds"].keys()),
-					keywords=set(meta.get("keywords", {}).keys() or []),
-					received_at=parse_iso_datetime(meta["receivedAt"], as_str=False),
-				)
-			)
+        result: list[ImportEmailMeta] = []
+        for meta in cls._load_json_metadata(base_dir):
+            result.append(
+                ImportEmailMeta(
+                    blob_path=os.path.join("blobs", _safe_blob_id(meta["blobId"])),
+                    mailbox_ids=set(meta["mailboxIds"].keys()),
+                    keywords=set(meta.get("keywords", {}).keys() or []),
+                    received_at=parse_iso_datetime(meta["receivedAt"], as_str=False),
+                )
+            )
 
-		return result
+        return result
 
-	@staticmethod
-	def _from_mbox(base_dir: str, mailbox_map: dict[str, str], metadata: dict) -> list[ImportEmailMeta]:
-		"""Loads import metadata for MBOX format."""
+    @staticmethod
+    def _from_mbox(base_dir: str, mailbox_map: dict[str, str], metadata: dict) -> list[ImportEmailMeta]:
+        """Loads import metadata for MBOX format."""
 
-		mbox_files = get_mbox_files(base_dir)
-		if not mbox_files:
-			frappe.throw(_("No .mbox files found"))
+        mbox_files = get_mbox_files(base_dir)
+        if not mbox_files:
+            frappe.throw(_("No .mbox files found"))
 
-		mailbox_ids = set(metadata.get("mailboxIds", {}).keys())
-		if not mailbox_ids:
-			frappe.throw(_("mailboxIds are required in Metadata for MBOX format."))
+        mailbox_ids = set(metadata.get("mailboxIds", {}).keys())
+        if not mailbox_ids:
+            frappe.throw(_("mailboxIds are required in Metadata for MBOX format."))
 
-		keywords = set(metadata.get("keywords", {}).keys() or [])
+        keywords = set(metadata.get("keywords", {}).keys() or [])
 
-		if metadata_received_at := metadata.get("receivedAt"):
-			metadata_received_at = parse_iso_datetime(metadata_received_at, as_str=False)
+        if metadata_received_at := metadata.get("receivedAt"):
+            metadata_received_at = parse_iso_datetime(metadata_received_at, as_str=False)
 
-		by_message_id: dict[str, ImportEmailMeta] = {}
+        by_message_id: dict[str, ImportEmailMeta] = {}
 
-		for mbox_path in mbox_files:
-			with closing(mailbox.mbox(mbox_path, factory=None)) as mbox:
-				for key, msg in mbox.items():
-					msg_id = (msg.get("Message-ID") or key).strip().lower()
+        for mbox_path in mbox_files:
+            with closing(mailbox.mbox(mbox_path, factory=None)) as mbox:
+                for key, msg in mbox.items():
+                    msg_id = (msg.get("Message-ID") or key).strip().lower()
 
-					if msg_id in by_message_id:
-						continue
+                    if msg_id in by_message_id:
+                        continue
 
-					received_at = metadata_received_at or extract_received_or_sent(msg)
+                    received_at = metadata_received_at or extract_received_or_sent(msg)
 
-					blob = f"{uuid7()}.eml"
-					with open(os.path.join(base_dir, blob), "wb") as f:
-						f.write(msg.as_bytes(unixfrom=True))
+                    blob = f"{uuid7()}.eml"
+                    with open(os.path.join(base_dir, blob), "wb") as f:
+                        f.write(msg.as_bytes(unixfrom=True))
 
-					by_message_id[msg_id] = ImportEmailMeta(
-						blob_path=blob,
-						mailbox_ids=mailbox_ids,
-						keywords=keywords,
-						received_at=received_at,
-					)
+                    by_message_id[msg_id] = ImportEmailMeta(
+                        blob_path=blob,
+                        mailbox_ids=mailbox_ids,
+                        keywords=keywords,
+                        received_at=received_at,
+                    )
 
-		return list(by_message_id.values())
+        return list(by_message_id.values())
 
-	@staticmethod
-	def _parse_maildir_flags(filename: str, seen_by_default: bool) -> set[str]:
-		"""Parses Maildir flags from the filename and returns the corresponding keywords."""
+    @staticmethod
+    def _parse_maildir_flags(filename: str, seen_by_default: bool) -> set[str]:
+        """Parses Maildir flags from the filename and returns the corresponding keywords."""
 
-		reverse_map = {v: k for k, v in MAILDIR_FLAG_MAP.items()}
-		keywords: set[str] = set()
+        reverse_map = {v: k for k, v in MAILDIR_FLAG_MAP.items()}
+        keywords: set[str] = set()
 
-		if seen_by_default:
-			keywords.add("$seen")
+        if seen_by_default:
+            keywords.add("$seen")
 
-		if ":2," not in filename:
-			return keywords
+        if ":2," not in filename:
+            return keywords
 
-		flags = filename.split(":2,", 1)[1]
-		for f in flags:
-			if kw := reverse_map.get(f):
-				keywords.add(kw)
+        flags = filename.split(":2,", 1)[1]
+        for f in flags:
+            if kw := reverse_map.get(f):
+                keywords.add(kw)
 
-		if "S" not in flags:
-			keywords.discard("$seen")
+        if "S" not in flags:
+            keywords.discard("$seen")
 
-		return keywords
+        return keywords
 
-	@classmethod
-	def _from_maildir(
-		cls, base_dir: str, mailbox_map: dict[str, str], metadata: dict
-	) -> list[ImportEmailMeta]:
-		"""Loads import metadata for Maildir format."""
+    @classmethod
+    def _from_maildir(
+        cls, base_dir: str, mailbox_map: dict[str, str], metadata: dict
+    ) -> list[ImportEmailMeta]:
+        """Loads import metadata for Maildir format."""
 
-		validate_maildir_or_maildirpp(base_dir, raise_exception=True)
+        validate_maildir_or_maildirpp(base_dir, raise_exception=True)
 
-		mailbox_ids = set(metadata.get("mailboxIds", {}).keys())
-		if not mailbox_ids:
-			frappe.throw(_("mailboxIds are required in Metadata for Maildir format."))
+        mailbox_ids = set(metadata.get("mailboxIds", {}).keys())
+        if not mailbox_ids:
+            frappe.throw(_("mailboxIds are required in Metadata for Maildir format."))
 
-		if metadata_received_at := metadata.get("receivedAt"):
-			metadata_received_at = parse_iso_datetime(metadata_received_at, as_str=False)
+        if metadata_received_at := metadata.get("receivedAt"):
+            metadata_received_at = parse_iso_datetime(metadata_received_at, as_str=False)
 
-		result: list[ImportEmailMeta] = []
+        result: list[ImportEmailMeta] = []
 
-		for subdir in ("cur", "new"):
-			path = os.path.join(base_dir, subdir)
-			if not os.path.isdir(path):
-				continue
+        for subdir in ("cur", "new"):
+            path = os.path.join(base_dir, subdir)
+            if not os.path.isdir(path):
+                continue
 
-			for fname in os.listdir(path):
-				keywords = cls._parse_maildir_flags(fname, subdir == "cur")
+            for fname in os.listdir(path):
+                keywords = cls._parse_maildir_flags(fname, subdir == "cur")
 
-				received_at = metadata_received_at
-				if not received_at:
-					with open(os.path.join(path, fname), "rb") as f:
-						msg: Message = message_from_binary_file(f)
+                received_at = metadata_received_at
+                if not received_at:
+                    with open(os.path.join(path, fname), "rb") as f:
+                        msg: Message = message_from_binary_file(f)
 
-					received_at = extract_received_or_sent(msg)
+                    received_at = extract_received_or_sent(msg)
 
-				result.append(
-					ImportEmailMeta(
-						blob_path=os.path.join(subdir, fname),
-						mailbox_ids=mailbox_ids,
-						keywords=keywords,
-						received_at=received_at,
-					)
-				)
+                result.append(
+                    ImportEmailMeta(
+                        blob_path=os.path.join(subdir, fname),
+                        mailbox_ids=mailbox_ids,
+                        keywords=keywords,
+                        received_at=received_at,
+                    )
+                )
 
-		return result
+        return result
 
-	@classmethod
-	def _from_nested_maildir(
-		cls, base_dir: str, mailbox_map: dict[str, str], metadata: dict
-	) -> list[ImportEmailMeta]:
-		"""Loads import metadata for Nested Maildir format."""
+    @classmethod
+    def _from_nested_maildir(
+        cls, base_dir: str, mailbox_map: dict[str, str], metadata: dict
+    ) -> list[ImportEmailMeta]:
+        """Loads import metadata for Nested Maildir format."""
 
-		validate_nested_maildir_tree(base_dir, raise_exception=True)
+        validate_nested_maildir_tree(base_dir, raise_exception=True)
 
-		if metadata_received_at := metadata.get("receivedAt"):
-			metadata_received_at = parse_iso_datetime(metadata_received_at, as_str=False)
+        if metadata_received_at := metadata.get("receivedAt"):
+            metadata_received_at = parse_iso_datetime(metadata_received_at, as_str=False)
 
-		result: list[ImportEmailMeta] = []
+        result: list[ImportEmailMeta] = []
 
-		path_to_id = {v: k for k, v in mailbox_map.items()}
+        path_to_id = {v: k for k, v in mailbox_map.items()}
 
-		def resolve_mailbox_path(dir_path: str) -> str:
-			"""Resolves the mailbox path from the directory path."""
+        def resolve_mailbox_path(dir_path: str) -> str:
+            """Resolves the mailbox path from the directory path."""
 
-			rel = os.path.relpath(dir_path, base_dir)
-			if rel == ".":
-				return ""
+            rel = os.path.relpath(dir_path, base_dir)
+            if rel == ".":
+                return ""
 
-			parts = []
-			for part in rel.split(os.sep):
-				if not part.startswith("."):
-					continue
-				parts.append(part[1:].replace("_", " "))
+            parts = []
+            for part in rel.split(os.sep):
+                if not part.startswith("."):
+                    continue
+                parts.append(part[1:].replace("_", " "))
 
-			return "/".join(parts)
+            return "/".join(parts)
 
-		for root, dirs, _files in os.walk(base_dir):
-			if not {"cur", "new"} & set(dirs):
-				continue
+        for root, dirs, _files in os.walk(base_dir):
+            if not {"cur", "new"} & set(dirs):
+                continue
 
-			mailbox_path = resolve_mailbox_path(root)
-			if not mailbox_path:
-				continue
+            mailbox_path = resolve_mailbox_path(root)
+            if not mailbox_path:
+                continue
 
-			mailbox_id = path_to_id.get(mailbox_path)
-			if not mailbox_id:
-				frappe.throw(_("Mailbox not found for folder {0}").format(mailbox_path))
+            mailbox_id = path_to_id.get(mailbox_path)
+            if not mailbox_id:
+                frappe.throw(_("Mailbox not found for folder {0}").format(mailbox_path))
 
-			for subdir in ("cur", "new"):
-				path = os.path.join(root, subdir)
-				if not os.path.isdir(path):
-					continue
+            for subdir in ("cur", "new"):
+                path = os.path.join(root, subdir)
+                if not os.path.isdir(path):
+                    continue
 
-				for fname in os.listdir(path):
-					if fname.startswith("."):
-						continue
+                for fname in os.listdir(path):
+                    if fname.startswith("."):
+                        continue
 
-					file_path = os.path.join(path, fname)
+                    file_path = os.path.join(path, fname)
 
-					received_at = metadata_received_at
-					if not received_at:
-						with open(file_path, "rb") as f:
-							msg: Message = message_from_binary_file(f)
+                    received_at = metadata_received_at
+                    if not received_at:
+                        with open(file_path, "rb") as f:
+                            msg: Message = message_from_binary_file(f)
 
-						received_at = extract_received_or_sent(msg)
+                        received_at = extract_received_or_sent(msg)
 
-					keywords = cls._parse_maildir_flags(fname, subdir == "cur")
-					rel_blob = os.path.relpath(file_path, base_dir)
-					result.append(ImportEmailMeta(rel_blob, {mailbox_id}, keywords, received_at))
+                    keywords = cls._parse_maildir_flags(fname, subdir == "cur")
+                    rel_blob = os.path.relpath(file_path, base_dir)
+                    result.append(ImportEmailMeta(rel_blob, {mailbox_id}, keywords, received_at))
 
-		return result
+        return result
 
 
 class ExportWriter:
-	@classmethod
-	def write(
-		cls,
-		format: Literal["jmap", "mbox", "maildir", "maildir-nested"],
-		emails: list[ExportEmail],
-		out_dir: str,
-		mailbox_map: dict[str, str],
-	) -> None:
-		"""Writes the exported emails in the specified format."""
+    @classmethod
+    def write(
+        cls,
+        format: Literal["jmap", "mbox", "maildir", "maildir-nested"],
+        emails: list[ExportEmail],
+        out_dir: str,
+        mailbox_map: dict[str, str],
+    ) -> None:
+        """Writes the exported emails in the specified format."""
 
-		writers = {
-			"jmap": cls._jmap,
-			"mbox": cls._mbox,
-			"maildir": cls._maildir,
-			"maildir-nested": cls._maildir_nested,
-		}
+        writers = {
+            "jmap": cls._jmap,
+            "mbox": cls._mbox,
+            "maildir": cls._maildir,
+            "maildir-nested": cls._maildir_nested,
+        }
 
-		if format not in writers:
-			frappe.throw(_("Unsupported export format: {0}").format(format))
+        if format not in writers:
+            frappe.throw(_("Unsupported export format: {0}").format(format))
 
-		writers[format](emails, out_dir, mailbox_map)
+        writers[format](emails, out_dir, mailbox_map)
 
-	@staticmethod
-	def write_meta(metadata: list[dict], out_dir: str) -> None:
-		"""Writes the exported email metadata in emails.json file."""
+    @staticmethod
+    def write_meta(metadata: list[dict], out_dir: str) -> None:
+        """Writes the exported email metadata in emails.json file."""
 
-		_metadata: list[dict] = []
-		for meta in metadata:
-			_metadata.append(
-				{
-					"id": meta["id"],
-					"blobId": meta["blobId"],
-					"keywords": meta["keywords"],
-					"mailboxIds": meta["mailboxIds"],
-					"messageId": meta["messageId"],
-					"receivedAt": meta["receivedAt"],
-				}
-			)
+        _metadata: list[dict] = []
+        for meta in metadata:
+            _metadata.append(
+                {
+                    "id": meta["id"],
+                    "blobId": meta["blobId"],
+                    "keywords": meta["keywords"],
+                    "mailboxIds": meta["mailboxIds"],
+                    "messageId": meta["messageId"],
+                    "receivedAt": meta["receivedAt"],
+                }
+            )
 
-		with open(os.path.join(out_dir, "emails.json"), "w") as f:
-			json.dump(_metadata, f, indent=4)
+        with open(os.path.join(out_dir, "emails.json"), "w") as f:
+            json.dump(_metadata, f, indent=4)
 
-	@staticmethod
-	def _jmap(emails: list[ExportEmail], out_dir: str, *args, **kwargs) -> None:
-		"""Writes the exported emails in JMAP format."""
+    @staticmethod
+    def _jmap(emails: list[ExportEmail], out_dir: str, *args, **kwargs) -> None:
+        """Writes the exported emails in JMAP format."""
 
-		blobs = os.path.join(out_dir, "blobs")
-		os.makedirs(blobs, exist_ok=True)
-		for e in emails:
-			with open(os.path.join(blobs, e.blob_id), "wb") as f:
-				f.write(e.raw)
+        blobs = os.path.join(out_dir, "blobs")
+        os.makedirs(blobs, exist_ok=True)
+        for e in emails:
+            with open(os.path.join(blobs, e.blob_id), "wb") as f:
+                f.write(e.raw)
 
-	@staticmethod
-	def _mbox(emails: list[ExportEmail], out_dir: str, mailbox_map: dict[str, str]) -> None:
-		"""Writes the exported emails in MBOX format."""
+    @staticmethod
+    def _mbox(emails: list[ExportEmail], out_dir: str, mailbox_map: dict[str, str]) -> None:
+        """Writes the exported emails in MBOX format."""
 
-		def from_line(sender: dict[str, str], received_at: datetime) -> bytes:
-			"""Generates the From line for MBOX format."""
+        def from_line(sender: dict[str, str], received_at: datetime) -> bytes:
+            """Generates the From line for MBOX format."""
 
-			addr = sender.get("email", "unknown")
-			return f"From {addr} {received_at.ctime()}\n".encode()
+            addr = sender.get("email", "unknown")
+            return f"From {addr} {received_at.ctime()}\n".encode()
 
-		for e in emails:
-			line = from_line(e.sender, e.received_at)
-			for m_id in e.mailbox_ids:
-				path = os.path.join(out_dir, f"{mailbox_map[m_id]}.mbox")
-				with open(path, "ab") as f:
-					f.write(line)
-					f.write(e.raw)
-					if not e.raw.endswith(b"\n"):
-						f.write(b"\n")
+        for e in emails:
+            line = from_line(e.sender, e.received_at)
+            for m_id in e.mailbox_ids:
+                path = os.path.join(out_dir, f"{mailbox_map[m_id]}.mbox")
+                with open(path, "ab") as f:
+                    f.write(line)
+                    f.write(e.raw)
+                    if not e.raw.endswith(b"\n"):
+                        f.write(b"\n")
 
-	@staticmethod
-	def _maildir(emails: list[ExportEmail], out_dir: str, *args, **kwargs) -> None:
-		"""Writes the exported emails in Maildir format."""
+    @staticmethod
+    def _maildir(emails: list[ExportEmail], out_dir: str, *args, **kwargs) -> None:
+        """Writes the exported emails in Maildir format."""
 
-		for dir in ("tmp", "new", "cur"):
-			os.makedirs(os.path.join(out_dir, dir), exist_ok=True)
+        for dir in ("tmp", "new", "cur"):
+            os.makedirs(os.path.join(out_dir, dir), exist_ok=True)
 
-		for e in emails:
-			flags = "".join(sorted(MAILDIR_FLAG_MAP[k] for k in e.keywords if k in MAILDIR_FLAG_MAP))
-			target = "cur" if "$seen" in e.keywords else "new"
-			name = f"{uuid7()}:2,{flags}" if target == "cur" else str(uuid7())
-			with open(os.path.join(out_dir, target, name), "wb") as f:
-				f.write(e.raw)
+        for e in emails:
+            flags = "".join(sorted(MAILDIR_FLAG_MAP[k] for k in e.keywords if k in MAILDIR_FLAG_MAP))
+            target = "cur" if "$seen" in e.keywords else "new"
+            name = f"{uuid7()}:2,{flags}" if target == "cur" else str(uuid7())
+            with open(os.path.join(out_dir, target, name), "wb") as f:
+                f.write(e.raw)
 
-	@staticmethod
-	def _maildir_nested(emails: list[ExportEmail], out_dir: str, mailbox_map: dict[str, str]) -> None:
-		"""Writes the exported emails in Nested Maildir format."""
+    @staticmethod
+    def _maildir_nested(emails: list[ExportEmail], out_dir: str, mailbox_map: dict[str, str]) -> None:
+        """Writes the exported emails in Nested Maildir format."""
 
-		def mailbox_to_root(mailbox_name: str) -> str:
-			"""Converts mailbox name to nested Maildir root path."""
+        def mailbox_to_root(mailbox_name: str) -> str:
+            """Converts mailbox name to nested Maildir root path."""
 
-			parts = mailbox_name.split("/")
-			path = out_dir
+            parts = mailbox_name.split("/")
+            path = out_dir
 
-			for part in parts:
-				safe = part.replace(" ", "_")
-				path = os.path.join(path, f".{safe}")
+            for part in parts:
+                safe = part.replace(" ", "_")
+                path = os.path.join(path, f".{safe}")
 
-			return path
+            return path
 
-		for e in emails:
-			flags = "".join(sorted(MAILDIR_FLAG_MAP[k] for k in e.keywords if k in MAILDIR_FLAG_MAP))
-			target = "cur" if "$seen" in e.keywords else "new"
+        for e in emails:
+            flags = "".join(sorted(MAILDIR_FLAG_MAP[k] for k in e.keywords if k in MAILDIR_FLAG_MAP))
+            target = "cur" if "$seen" in e.keywords else "new"
 
-			for m_id in e.mailbox_ids:
-				mailbox_name = mailbox_map[m_id]
-				maildir_root = mailbox_to_root(mailbox_name)
+            for m_id in e.mailbox_ids:
+                mailbox_name = mailbox_map[m_id]
+                maildir_root = mailbox_to_root(mailbox_name)
 
-				for d in ("new", "cur"):
-					os.makedirs(os.path.join(maildir_root, d), exist_ok=True)
+                for d in ("new", "cur"):
+                    os.makedirs(os.path.join(maildir_root, d), exist_ok=True)
 
-				filename = f"{uuid7()}:2,{flags}" if target == "cur" else str(uuid7())
-				with open(os.path.join(maildir_root, target, filename), "wb") as f:
-					f.write(e.raw)
+                filename = f"{uuid7()}:2,{flags}" if target == "cur" else str(uuid7())
+                with open(os.path.join(maildir_root, target, filename), "wb") as f:
+                    f.write(e.raw)
 
 
 class MailExchange(OwnerFromUser, Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
-
-	from typing import TYPE_CHECKING
-
-	if TYPE_CHECKING:
-		from frappe.types import DF
-
-		account: DF.Link
-		amended_from: DF.Link | None
-		completed_at: DF.Datetime | None
-		deduplicate_export: DF.Check
-		duration: DF.Float
-		export_archive_type: DF.Literal[".zip", ".tgz", ".tar.gz"]
-		export_filter: DF.JSON | None
-		export_format: DF.Literal["jmap", "mbox", "maildir", "maildir-nested"]
-		export_limit: DF.Int
-		export_sort: DF.Literal["", "Received At (ASC)", "Received At (DESC)"]
-		import_file: DF.Attach | None
-		import_format: DF.Literal["eml", "jmap", "mbox", "maildir", "maildir-nested"]
-		import_metadata: DF.JSON | None
-		operation: DF.Literal["", "Import", "Export"]
-		output: DF.Code | None
-		queued_at: DF.Datetime | None
-		retries: DF.Int
-		started_after: DF.Float
-		started_at: DF.Datetime | None
-		status: DF.Literal["Draft", "Queued", "In Progress", "Completed", "Failed", "Cancelled"]
-		user: DF.Link
-	# end: auto-generated types
-
-	@property
-	def max_import(self) -> int:
-		"""Returns the maximum number of emails allowed for import."""
-
-		return cint(get_config("exchange_max_import"))
-
-	@property
-	def max_export(self) -> int:
-		"""Returns the maximum number of emails allowed for export."""
-
-		return cint(get_config("exchange_max_export"))
-
-	@property
-	def export_filter_dict(self) -> dict:
-		"""Returns the export filter as a dictionary."""
-
-		if self.operation == "Export" and self.export_filter:
-			return json.loads(self.export_filter)
-		return {}
-
-	@property
-	def export_sort_clause(self) -> list[dict]:
-		"""Returns the export sort as a list of dictionaries."""
-
-		if self.operation != "Export":
-			return []
-		if self.export_sort == "Received At (DESC)":
-			return [{"property": "receivedAt", "isAscending": False}]
-		return [{"property": "receivedAt", "isAscending": True}]
-
-	@property
-	def import_metadata_dict(self) -> dict:
-		"""Return the import metadata as a filtered dictionary."""
-
-		if self.operation != "Import" or not self.import_metadata:
-			return {}
-
-		def filter_truthy_items(key: str) -> dict:
-			return {k: True for k, v in metadata.get(key, {}).items() if v}
-
-		metadata = json.loads(self.import_metadata)
-		return {
-			"mailboxIds": filter_truthy_items("mailboxIds"),
-			"keywords": filter_truthy_items("keywords"),
-			"receivedAt": metadata.get("receivedAt"),
-		}
-
-	def autoname(self) -> None:
-		self.name = str(uuid7())
-
-	def validate(self) -> None:
-		if self.is_new():
-			self.validate_account()
-
-		if self.operation == "Import":
-			self.validate_import()
-		elif self.operation == "Export":
-			self.validate_export()
-
-	def before_submit(self) -> None:
-		self.status = "Queued"
-		self.queued_at = now()
-
-	def on_submit(self) -> None:
-		self.process()
-
-	def before_cancel(self) -> None:
-		self.status = "Cancelled"
-
-	def validate_account(self) -> None:
-		"""Validate that the selected user can authenticate and has access to the account."""
-
-		if not is_jmap_configured(self.user):
-			frappe.throw(
-				_("User {0} does not have JMAP settings configured.").format(frappe.bold(self.user)),
-				frappe.PermissionError,
-			)
-
-		is_jmap_account_belongs_to_user(self.account, self.user, raise_exception=True)
-
-	def validate_import(self) -> None:
-		"""Validate the import parameters."""
-
-		if not self.import_format:
-			frappe.throw(_("Import Format is required."))
-		if not self.import_file:
-			frappe.throw(_("Import File is required."))
-
-		allowed_extensions = (".eml", ".zip", ".tgz", ".tar.gz")
-		if not self.import_file.endswith(allowed_extensions):
-			frappe.throw(
-				_("Only {0} files are supported for import.").format(
-					", ".join(f"<code>{ext}</code>" for ext in allowed_extensions)
-				)
-			)
-
-		self._resolve_import_file()
-
-		if self.import_format in ("eml", "mbox", "maildir"):
-			meta = self.import_metadata_dict
-			if not meta.get("mailboxIds"):
-				frappe.throw(_("mailboxIds are required in Metadata for EML, MBOX, and Maildir formats."))
-		else:
-			self.import_metadata = json.dumps({})
-
-	def _resolve_import_file(self) -> str:
-		"""Resolves ``import_file`` to an absolute path, refusing anything outside the site's files
-		directories.
-
-		``import_file`` is an ``Attach`` URL (e.g. ``/private/files/mail.zip``) that the worker joins
-		onto the site path before copying/extracting it. Without this guard a crafted value such as
-		``/private/files/../../../etc/passwd`` would let the job read a file anywhere on the
-		filesystem, so we canonicalize the path and confirm it stays within the uploads area."""
-
-		path = os.path.realpath(
-			os.path.join(get_bench_path(), f"sites/{frappe.local.site}{self.import_file}")
-		)
-		allowed_roots = (
-			os.path.realpath(get_files_path(is_private=1)),
-			os.path.realpath(get_files_path(is_private=0)),
-		)
-		if not any(path == root or path.startswith(root + os.sep) for root in allowed_roots):
-			frappe.throw(_("Invalid import file path."))
-
-		return path
-
-	def validate_export(self) -> None:
-		"""Validate the export parameters."""
-
-		if self.export_filter:
-			try:
-				self.export_filter = json.dumps(json.loads(self.export_filter), indent=4)
-			except json.JSONDecodeError:
-				frappe.throw(_("Export filter must be valid JSON."))
-
-		if not self.export_archive_type:
-			frappe.throw(_("Archive Type is required."))
-
-		if not self.export_sort:
-			self.export_sort = "Received At (ASC)"
-
-		if self.export_limit:
-			export_limit = cint(self.export_limit)
-			if export_limit <= 0:
-				frappe.throw(_("Export Limit must be greater than zero."))
-			if export_limit > self.max_export:
-				frappe.throw(_("Export Limit cannot exceed {0}.").format(self.max_export))
-			self.export_limit = export_limit
-		else:
-			self.export_limit = self.max_export
-
-	def _get_logger(self) -> ExchangeLogger:
-		"""Returns a structured event logger bound to this exchange's context."""
-
-		return get_exchange_logger(
-			{
-				"req_id": random_string(10),
-				"exchange": self.name,
-				"key": "mail",
-				"operation": self.operation,
-				"user": self.user,
-				"account": self.account,
-			}
-		)
-
-	def process(self) -> None:
-		"""Enqueue the import or export based on the operation type."""
-
-		logger = self._get_logger()
-
-		if self.operation == "Import":
-			job_id = f"{self.name}:mail:import"
-			frappe.enqueue_doc(
-				self.doctype,
-				self.name,
-				"_import",
-				queue="long",
-				timeout=cint(get_config("exchange_import_timeout")),
-				job_id=job_id,
-				deduplicate=True,
-				enqueue_after_commit=True,
-			)
-			logger.debug("import-enqueued", job_id=job_id, format=self.import_format)
-		elif self.operation == "Export":
-			job_id = f"{self.name}:mail:export"
-			frappe.enqueue_doc(
-				self.doctype,
-				self.name,
-				"_export",
-				queue="long",
-				timeout=cint(get_config("exchange_export_timeout")),
-				job_id=job_id,
-				deduplicate=True,
-				enqueue_after_commit=True,
-			)
-			logger.debug("export-enqueued", job_id=job_id, format=self.export_format)
-
-	@frappe.whitelist()
-	def retry(self) -> None:
-		"""Retry the import or export."""
-
-		frappe.only_for("System Manager")
-
-		self._get_logger().info("retry-requested", status=self.status, retries=cint(self.retries))
-
-		if self.docstatus != 1:
-			frappe.throw(_("Only submitted mail exchange can be retried."))
-		elif self.status not in ["Queued", "In Progress", "Failed"]:
-			frappe.throw(
-				_("Only mail exchange with status 'Queued', 'In Progress', or 'Failed' can be retried.")
-			)
-
-		if self.operation == "Export":
-			if files := frappe.db.get_all(
-				"File",
-				{
-					"attached_to_doctype": self.doctype,
-					"attached_to_name": self.name,
-					"attached_to_field": "file",
-				},
-				pluck="name",
-			):
-				for file in files:
-					frappe.delete_doc("File", file)
-
-		self._db_set(status="Queued", queued_at=now())
-		self.process()
-
-	@reconnect_on_failure()
-	def _import(self) -> None:
-		"""Imports the mail data."""
-
-		if self.operation != "Import":
-			return
-
-		logger = self._get_logger()
-		logger.info("import-started", format=self.import_format, import_file=self.import_file)
-
-		freeze_jmap_push_notifications(self.user)
-		self._mark_started()
-		self._log_output(_("Starting import from the uploaded {0} file.").format(self.import_format.upper()))
-
-		import_file = self._resolve_import_file()
-		base_dir = os.path.join(get_mail_import_directory(), self.name)
-		os.makedirs(base_dir, exist_ok=True)
-
-		kwargs = {}
-		service = None
-		staging_mailbox_id = None
-		try:
-			if self.import_format == "eml" and self.import_file.endswith(".eml"):
-				shutil.copy(import_file, os.path.join(base_dir, os.path.basename(import_file)))
-			else:
-				extract_compressed_file(import_file, base_dir)
-			logger.debug("import-source-prepared", base_dir=base_dir)
-			self._log_output(_("Prepared the source files for import."))
-
-			service = get_email_service(self.user, self.account)
-
-			mailbox_map = {}
-			if self.import_format == "maildir-nested":
-				mailbox_map = self._build_mailbox_map(service.mailboxes)
-
-			meta = ImportMetadataLoader.load(
-				self.import_format, base_dir, mailbox_map, self.import_metadata_dict
-			)
-			logger.info("import-metadata-loaded", emails=len(meta), max_import=self.max_import)
-			self._log_output(_("Found {0} email(s) to import.").format(len(meta)))
-
-			if not meta:
-				frappe.throw(_("No emails found for import."))
-			if len(meta) > self.max_import:
-				frappe.throw(_("Import limit exceeded."))
-
-			# Stage everything into one throwaway mailbox first, then move it to the destination
-			# mailbox(es). A failure before the move leaves nothing scattered across the account: the
-			# staging mailbox and every email in it are deleted on rollback.
-			staging_mailbox_id = self._create_staging_mailbox(service, logger)
-			imported = self._import_batches(service, base_dir, meta, staging_mailbox_id, logger)
-			self._move_to_target_mailboxes(service, imported, logger)
-			self._discard_staging_mailbox(service, staging_mailbox_id, logger)
-			staging_mailbox_id = None
-
-			clear_sync_state(self.account, type="email")
-
-			logger.info("import-completed", emails=len(imported))
-			self._log_output(_("Import completed successfully. {0} email(s) imported.").format(len(imported)))
-			kwargs.update({"status": "Completed"})
-		except Exception:
-			logger.exception("import-failed")
-			self._log_output(_("Import failed. See the error details below."))
-			if staging_mailbox_id and service:
-				self._rollback_staging_mailbox(service, staging_mailbox_id, logger)
-			kwargs.update(
-				{"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
-			)
-		finally:
-			shutil.rmtree(base_dir, ignore_errors=True)
-			unfreeze_jmap_push_notifications(self.user)
-
-		self._mark_completed(**kwargs)
-		self._notify_user(success=kwargs.get("status") == "Completed", action="Import")
-
-	@reconnect_on_failure()
-	def _export(self) -> None:
-		"""Exports the mail data."""
-
-		if self.operation != "Export":
-			return
-
-		logger = self._get_logger()
-		logger.info("export-started", format=self.export_format, archive_type=self.export_archive_type)
-
-		self._mark_started()
-		self._log_output(_("Starting export to {0} format.").format(self.export_format.upper()))
-		out_dir = os.path.join(get_mail_export_directory(), self.name)
-		os.makedirs(out_dir, exist_ok=True)
-
-		kwargs = {}
-		try:
-			service = get_email_service(self.user, self.account)
-			total = service.query(self.export_filter_dict, limit=1)["total"]
-			limit = min(total, cint(self.export_limit or total))
-			logger.info("export-query-resolved", total=total, limit=limit, max_export=self.max_export)
-			self._log_output(
-				_("Found {0} email(s) matching the filter; exporting up to {1}.").format(total, limit)
-			)
-
-			if limit > self.max_export:
-				frappe.throw(_("Export limit exceeded."))
-
-			ids = service.query(self.export_filter_dict, sort=self.export_sort_clause, limit=limit)["ids"]
-			if not ids:
-				frappe.throw(_("No emails found for export."))
-
-			properties = ["id", "from", "blobId", "keywords", "mailboxIds", "messageId", "receivedAt"]
-			emails = service.get(ids, properties=properties)
-
-			if self.deduplicate_export:
-				fetched = len(emails)
-				unique_emails = {}
-				for e in emails:
-					# messageId is String[]|null - mail with no Message-ID header comes back null.
-					# Fall back to the email id so those are not all collapsed into one bucket.
-					key = (e.get("messageId") or [e["id"]])[0]
-					if key not in unique_emails:
-						unique_emails[key] = e
-				emails = list(unique_emails.values())
-				logger.debug("export-deduplicated", fetched=fetched, unique=len(emails))
-				self._log_output(
-					_("Removed {0} duplicate(s); {1} unique email(s) remain.").format(
-						fetched - len(emails), len(emails)
-					)
-				)
-
-			mailbox_map = {}
-			if self.export_format == "mbox":
-				mailbox_map = {m["id"]: m["name"] for m in service.mailboxes}
-			elif self.export_format == "maildir-nested":
-				mailbox_map = self._build_mailbox_map(service.mailboxes)
-
-			self._export_batches(service, emails, out_dir, mailbox_map, logger)
-
-			self._log_output(
-				_("Packaging exported emails into a {0} archive.").format(self.export_archive_type)
-			)
-			self._attach_export(out_dir)
-
-			logger.info("export-completed", emails=len(emails))
-			self._log_output(_("Export completed successfully. {0} email(s) exported.").format(len(emails)))
-			kwargs.update({"status": "Completed"})
-		except Exception:
-			logger.exception("export-failed")
-			self._log_output(_("Export failed. See the error details below."))
-			kwargs.update(
-				{"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
-			)
-		finally:
-			shutil.rmtree(out_dir, ignore_errors=True)
-
-		self._mark_completed(**kwargs)
-		self._notify_user(success=kwargs.get("status") == "Completed", action="Export")
-
-	def _mark_started(self) -> None:
-		"""Marks the mail exchange as started and updates the started_at and started_after fields."""
-
-		started_at = now()
-		self._db_set(
-			status="In Progress",
-			started_at=started_at,
-			started_after=time_diff_in_seconds(started_at, self.queued_at),
-			output="",
-		)
-
-	def _mark_completed(self, **kwargs) -> None:
-		"""Marks the mail exchange as completed and updates the completed_at and duration fields."""
-
-		kwargs["completed_at"] = now()
-		kwargs["duration"] = time_diff_in_seconds(kwargs["completed_at"], self.started_at)
-
-		if kwargs["status"] == "Failed":
-			kwargs["retries"] = cint(self.retries) + 1
-
-		self._db_set(**kwargs)
-
-	def _create_staging_mailbox(self, service: EmailService, logger: ExchangeLogger) -> str:
-		"""Creates a temporary mailbox (named after this exchange) to stage the import into."""
-
-		self._log_output(_("Creating a temporary folder to stage the import."))
-		response = MailboxService(service.account, service.connection).create(
-			[{"creation_id": str(uuid7()), "name": self.name, "is_subscribed": False}]
-		)
-		created = response.get("created") or {}
-		if not created:
-			frappe.throw(_("Failed to create the staging folder: {0}").format(response.get("notCreated")))
-
-		staging_mailbox_id = next(iter(created.values()))["id"]
-		logger.info("import-staging-mailbox-created", mailbox=staging_mailbox_id)
-		return staging_mailbox_id
-
-	def _import_batches(
-		self,
-		service: EmailService,
-		base_dir: str,
-		metadata: list[ImportEmailMeta],
-		staging_mailbox_id: str,
-		logger: ExchangeLogger,
-	) -> dict[str, dict[str, bool]]:
-		"""Imports emails into the staging mailbox in batches, returning a map of each created email's
-		ID to the destination mailboxIds it should ultimately land in."""
-
-		total = len(metadata)
-		imported: dict[str, dict[str, bool]] = {}
-		batch_size = service.max_objects_in_set
-		for batch in create_batch(metadata, batch_size):
-			blobs: list[tuple[bytes, str]] = []
-			for meta in batch:
-				with open(os.path.join(base_dir, meta.blob_path), "rb") as f:
-					blobs.append((f.read(), "message/rfc822"))
-
-			responses = service.upload_blobs_concurrently(blobs)
-			emails = {}
-			targets: dict[str, dict[str, bool]] = {}
-			for i, resp in enumerate(responses):
-				meta = batch[i]
-				emails[f"e{i}"] = {
-					"blobId": resp["blobId"],
-					"mailboxIds": {staging_mailbox_id: True},
-					"keywords": {k: True for k in meta.keywords or []},
-					"receivedAt": meta.received_at.isoformat(),
-				}
-				targets[f"e{i}"] = {mid: True for mid in meta.mailbox_ids}
-
-			response = service._call(
-				capabilities=service.capabilities,
-				method_calls=[
-					[
-						f"{service.type}/import",
-						{"accountId": service.account, "emails": emails},
-						"0",
-					]
-				],
-			)
-			method_responses = response.get("methodResponses") or []
-			result = method_responses[0][1] if method_responses else {}
-
-			for creation_id, info in (result.get("created") or {}).items():
-				imported[info["id"]] = targets.get(creation_id, {})
-			for creation_id, error in (result.get("notCreated") or {}).items():
-				logger.warning("import-email-not-created", creation_id=creation_id, reason=str(error))
-
-			logger.debug("import-batch-processed", batch=len(batch), imported=len(imported), total=total)
-			self._log_output(_("Staged {0} of {1} email(s).").format(len(imported), total))
-
-		# `metadata` is non-empty here (an empty import is rejected upstream), so an empty `imported`
-		# means the server rejected every email — a failure that must roll back. Guarding on `total`
-		# keeps this from ever misreporting an empty input as "rejected all 0". Unlike calendar/contacts
-		# there is no idempotency-skip, so `not imported` already means "all rejected".
-		if total and not imported:
-			frappe.throw(_("Import failed: the server rejected all {0} email(s).").format(total))
-
-		return imported
-
-	def _move_to_target_mailboxes(
-		self, service: EmailService, imported: dict[str, dict[str, bool]], logger: ExchangeLogger
-	) -> None:
-		"""Moves the staged emails into their destination mailboxes, replacing the staging mailbox.
-
-		This is the commit step: until it runs, every email lives only in the staging mailbox, so a
-		failure up to this point rolls back cleanly."""
-
-		self._log_output(_("Moving {0} email(s) into the destination folder(s).").format(len(imported)))
-		emails = [{"id": email_id, "mailbox_ids": mailbox_ids} for email_id, mailbox_ids in imported.items()]
-		result = service.update(emails, replace_mailboxes=True)
-
-		if not_updated := result.get("notUpdated"):
-			logger.warning("import-email-not-moved", count=len(not_updated))
-			frappe.throw(
-				_("Failed to move {0} email(s) into the destination folder(s).").format(len(not_updated))
-			)
-
-		logger.info("import-emails-moved", emails=len(result.get("updated", [])))
-
-	def _discard_staging_mailbox(
-		self, service: EmailService, staging_mailbox_id: str, logger: ExchangeLogger
-	) -> None:
-		"""Deletes the now-empty staging mailbox after a successful import. A failure here is logged
-		but not fatal: the emails are already safely in their destination folders."""
-
-		try:
-			MailboxService(service.account, service.connection).delete([staging_mailbox_id])
-			logger.info("import-staging-mailbox-removed", mailbox=staging_mailbox_id)
-		except Exception:
-			logger.warning("import-staging-mailbox-remove-failed", mailbox=staging_mailbox_id)
-
-	def _rollback_staging_mailbox(
-		self, service: EmailService, staging_mailbox_id: str, logger: ExchangeLogger
-	) -> None:
-		"""Deletes the staging mailbox and every email still staged in it, undoing a failed import."""
-
-		self._log_output(_("Rolling back: removing the staging folder and any staged emails."))
-		try:
-			MailboxService(service.account, service.connection).delete(
-				[staging_mailbox_id], remove_emails=True
-			)
-			logger.info("import-rolled-back", mailbox=staging_mailbox_id)
-		except Exception:
-			logger.exception("import-rollback-failed", mailbox=staging_mailbox_id)
-
-	def _export_batches(
-		self,
-		service: EmailService,
-		emails: list[dict],
-		out_dir: str,
-		mailbox_map: dict[str, str],
-		logger: ExchangeLogger,
-	) -> None:
-		"""Exports emails in batches using the EmailService."""
-
-		if self.export_format == "jmap":
-			ExportWriter.write_meta(emails, out_dir)
-
-		total = len(emails)
-		exported = 0
-		batch_size = cint(get_config("exchange_export_batch_size"))
-		for batch in create_batch(emails, batch_size):
-			blobs = [(e["blobId"], None) for e in batch if e.get("blobId")]
-			data = service.download_blobs_concurrently(blobs)
-
-			export_emails = []
-			for e in batch:
-				if e.get("blobId") not in data:
-					logger.warning("export-blob-missing", id=e.get("id"), blob_id=e.get("blobId"))
-					continue
-
-				export_emails.append(
-					ExportEmail(
-						id=e["id"],
-						sender=(e.get("from") or [{}])[0],
-						blob_id=e["blobId"],
-						keywords=set(e["keywords"].keys()),
-						mailbox_ids=set(e["mailboxIds"].keys()),
-						message_id=(e.get("messageId") or [""])[0],
-						received_at=datetime.fromisoformat(e["receivedAt"]),
-						raw=data[e["blobId"]],
-					)
-				)
-
-			ExportWriter.write(self.export_format, export_emails, out_dir, mailbox_map)
-
-			exported += len(export_emails)
-			logger.debug("export-batch-written", batch=len(export_emails), exported=exported, total=total)
-			self._log_output(_("Exported {0} of {1} email(s).").format(exported, total))
-
-	def _build_mailbox_map(self, mailboxes: list[dict]) -> dict[str, str]:
-		"""Builds a mapping of mailbox IDs to their full paths."""
-
-		by_id = {m["id"]: m for m in mailboxes}
-		result: dict[str, str] = {}
-
-		def resolve_path(mailbox_id: str) -> str:
-			if mailbox_id in result:
-				return result[mailbox_id]
-
-			mailbox = by_id[mailbox_id]
-			name = mailbox["name"]
-			parent_id = mailbox.get("parentId")
-
-			if parent_id:
-				parent_path = resolve_path(parent_id)
-				path = f"{parent_path}/{name}"
-			else:
-				path = name
-
-			result[mailbox_id] = path
-			return path
-
-		for mailbox_id in by_id:
-			resolve_path(mailbox_id)
-
-		return result
-
-	def _attach_export(self, out_dir: str) -> None:
-		"""Attaches the exported file to the mail exchange."""
-
-		archive = f"{self.name}{self.export_archive_type}"
-		url = f"/private/files/{archive}"
-		path = os.path.join(get_bench_path(), f"sites/{frappe.local.site}{url}")
-		compress_directory(out_dir, path)
-
-		file = frappe.new_doc("File")
-		file.is_private = 1
-		file.file_url = url
-		file.file_name = archive
-		file.attached_to_doctype = self.doctype
-		file.attached_to_name = self.name
-		file.attached_to_field = "file"
-		file.insert()
-
-		# https://github.com/frappe/frappe/issues/26615
-		frappe.db.set_value("File", file.name, {"file_url": url, "file_name": archive})
-
-	def _notify_user(self, success: bool, action: Literal["Import", "Export"]) -> None:
-		"""Sends notification email to the owner of the mail exchange."""
-
-		if is_administrator(self.owner):
-			return
-		if not (email := get_user_email_address(self.owner)):
-			return
-
-		subject = _("Mail Data {0} {1}").format(action, "Completed" if success else "Failed")
-		frappe.publish_realtime(
-			"mail_exchange_completed",
-			{"action": action, "success": success, "message": subject},
-			user=self.user,
-		)
-		frappe.sendmail(
-			recipients=email,
-			subject=subject,
-			template="generic",
-			args={
-				"title": subject,
-				"description": _("View details for this exchange."),
-				"button": _("View {0}").format(action),
-				"link": get_url(f"/mail/mail-exchanges/{self.name}"),
-			},
-			now=True,
-		)
-
-	def _log_output(self, message: str) -> None:
-		"""Appends a timestamped, user-friendly line to the `output` field and persists it.
-
-		These messages are surfaced in the UI so the user can follow the progress of the
-		background import/export as it happens."""
-
-		line = f"[{now()}] {message}"
-		self.output = f"{self.output}\n{line}" if self.output else line
-		self._db_set(output=self.output)
-
-	def _db_set(self, **kwargs) -> None:
-		"""Updates the document with the given key-value pairs."""
-
-		self.db_set(kwargs, notify=True, commit=True)
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        account: DF.Link
+        amended_from: DF.Link | None
+        completed_at: DF.Datetime | None
+        deduplicate_export: DF.Check
+        duration: DF.Float
+        export_archive_type: DF.Literal[".zip", ".tgz", ".tar.gz"]
+        export_filter: DF.JSON | None
+        export_format: DF.Literal["jmap", "mbox", "maildir", "maildir-nested"]
+        export_limit: DF.Int
+        export_sort: DF.Literal["", "Received At (ASC)", "Received At (DESC)"]
+        import_file: DF.Attach | None
+        import_format: DF.Literal["eml", "jmap", "mbox", "maildir", "maildir-nested"]
+        import_metadata: DF.JSON | None
+        operation: DF.Literal["", "Import", "Export"]
+        output: DF.Code | None
+        queued_at: DF.Datetime | None
+        retries: DF.Int
+        started_after: DF.Float
+        started_at: DF.Datetime | None
+        status: DF.Literal["Draft", "Queued", "In Progress", "Completed", "Failed", "Cancelled"]
+        user: DF.Link
+    # end: auto-generated types
+
+    @property
+    def max_import(self) -> int:
+        """Returns the maximum number of emails allowed for import."""
+
+        return cint(get_config("exchange_max_import"))
+
+    @property
+    def max_export(self) -> int:
+        """Returns the maximum number of emails allowed for export."""
+
+        return cint(get_config("exchange_max_export"))
+
+    @property
+    def export_filter_dict(self) -> dict:
+        """Returns the export filter as a dictionary."""
+
+        if self.operation == "Export" and self.export_filter:
+            return json.loads(self.export_filter)
+        return {}
+
+    @property
+    def export_sort_clause(self) -> list[dict]:
+        """Returns the export sort as a list of dictionaries."""
+
+        if self.operation != "Export":
+            return []
+        if self.export_sort == "Received At (DESC)":
+            return [{"property": "receivedAt", "isAscending": False}]
+        return [{"property": "receivedAt", "isAscending": True}]
+
+    @property
+    def import_metadata_dict(self) -> dict:
+        """Return the import metadata as a filtered dictionary."""
+
+        if self.operation != "Import" or not self.import_metadata:
+            return {}
+
+        def filter_truthy_items(key: str) -> dict:
+            return {k: True for k, v in metadata.get(key, {}).items() if v}
+
+        metadata = json.loads(self.import_metadata)
+        return {
+            "mailboxIds": filter_truthy_items("mailboxIds"),
+            "keywords": filter_truthy_items("keywords"),
+            "receivedAt": metadata.get("receivedAt"),
+        }
+
+    def autoname(self) -> None:
+        self.name = str(uuid7())
+
+    def validate(self) -> None:
+        if self.is_new():
+            self.validate_account()
+
+        if self.operation == "Import":
+            self.validate_import()
+        elif self.operation == "Export":
+            self.validate_export()
+
+    def before_submit(self) -> None:
+        self.status = "Queued"
+        self.queued_at = now()
+
+    def on_submit(self) -> None:
+        self.process()
+
+    def before_cancel(self) -> None:
+        self.status = "Cancelled"
+
+    def validate_account(self) -> None:
+        """Validate that the selected user can authenticate and has access to the account."""
+
+        if not is_jmap_configured(self.user):
+            frappe.throw(
+                _("User {0} does not have JMAP settings configured.").format(frappe.bold(self.user)),
+                frappe.PermissionError,
+            )
+
+        is_jmap_account_belongs_to_user(self.account, self.user, raise_exception=True)
+
+    def validate_import(self) -> None:
+        """Validate the import parameters."""
+
+        if not self.import_format:
+            frappe.throw(_("Import Format is required."))
+        if not self.import_file:
+            frappe.throw(_("Import File is required."))
+
+        allowed_extensions = (".eml", ".zip", ".tgz", ".tar.gz")
+        if not self.import_file.endswith(allowed_extensions):
+            frappe.throw(
+                _("Only {0} files are supported for import.").format(
+                    ", ".join(f"<code>{ext}</code>" for ext in allowed_extensions)
+                )
+            )
+
+        self._resolve_import_file()
+
+        if self.import_format in ("eml", "mbox", "maildir"):
+            meta = self.import_metadata_dict
+            if not meta.get("mailboxIds"):
+                frappe.throw(_("mailboxIds are required in Metadata for EML, MBOX, and Maildir formats."))
+        else:
+            self.import_metadata = json.dumps({})
+
+    def _resolve_import_file(self) -> str:
+        """Resolves ``import_file`` to an absolute path, refusing anything outside the site's files
+        directories.
+
+        ``import_file`` is an ``Attach`` URL (e.g. ``/private/files/mail.zip``) that the worker joins
+        onto the site path before copying/extracting it. Without this guard a crafted value such as
+        ``/private/files/../../../etc/passwd`` would let the job read a file anywhere on the
+        filesystem, so we canonicalize the path and confirm it stays within the uploads area."""
+
+        path = os.path.realpath(
+            os.path.join(get_bench_path(), f"sites/{frappe.local.site}{self.import_file}")
+        )
+        allowed_roots = (
+            os.path.realpath(get_files_path(is_private=1)),
+            os.path.realpath(get_files_path(is_private=0)),
+        )
+        if not any(path == root or path.startswith(root + os.sep) for root in allowed_roots):
+            frappe.throw(_("Invalid import file path."))
+
+        return path
+
+    def validate_export(self) -> None:
+        """Validate the export parameters."""
+
+        if self.export_filter:
+            try:
+                self.export_filter = json.dumps(json.loads(self.export_filter), indent=4)
+            except json.JSONDecodeError:
+                frappe.throw(_("Export filter must be valid JSON."))
+
+        if not self.export_archive_type:
+            frappe.throw(_("Archive Type is required."))
+
+        if not self.export_sort:
+            self.export_sort = "Received At (ASC)"
+
+        if self.export_limit:
+            export_limit = cint(self.export_limit)
+            if export_limit <= 0:
+                frappe.throw(_("Export Limit must be greater than zero."))
+            if export_limit > self.max_export:
+                frappe.throw(_("Export Limit cannot exceed {0}.").format(self.max_export))
+            self.export_limit = export_limit
+        else:
+            self.export_limit = self.max_export
+
+    def _get_logger(self) -> ExchangeLogger:
+        """Returns a structured event logger bound to this exchange's context."""
+
+        return get_exchange_logger(
+            {
+                "req_id": random_string(10),
+                "exchange": self.name,
+                "key": "mail",
+                "operation": self.operation,
+                "user": self.user,
+                "account": self.account,
+            }
+        )
+
+    def process(self) -> None:
+        """Enqueue the import or export based on the operation type."""
+
+        logger = self._get_logger()
+
+        if self.operation == "Import":
+            job_id = f"{self.name}:mail:import"
+            frappe.enqueue_doc(
+                self.doctype,
+                self.name,
+                "_import",
+                queue="long",
+                timeout=cint(get_config("exchange_import_timeout")),
+                job_id=job_id,
+                deduplicate=True,
+                enqueue_after_commit=True,
+            )
+            logger.debug("import-enqueued", job_id=job_id, format=self.import_format)
+        elif self.operation == "Export":
+            job_id = f"{self.name}:mail:export"
+            frappe.enqueue_doc(
+                self.doctype,
+                self.name,
+                "_export",
+                queue="long",
+                timeout=cint(get_config("exchange_export_timeout")),
+                job_id=job_id,
+                deduplicate=True,
+                enqueue_after_commit=True,
+            )
+            logger.debug("export-enqueued", job_id=job_id, format=self.export_format)
+
+    @frappe.whitelist()
+    def retry(self) -> None:
+        """Retry the import or export."""
+
+        frappe.only_for("System Manager")
+
+        self._get_logger().info("retry-requested", status=self.status, retries=cint(self.retries))
+
+        if self.docstatus != 1:
+            frappe.throw(_("Only submitted mail exchange can be retried."))
+        elif self.status not in ["Queued", "In Progress", "Failed"]:
+            frappe.throw(
+                _("Only mail exchange with status 'Queued', 'In Progress', or 'Failed' can be retried.")
+            )
+
+        if self.operation == "Export":
+            if files := frappe.db.get_all(
+                "File",
+                {
+                    "attached_to_doctype": self.doctype,
+                    "attached_to_name": self.name,
+                    "attached_to_field": "file",
+                },
+                pluck="name",
+            ):
+                for file in files:
+                    frappe.delete_doc("File", file)
+
+        self._db_set(status="Queued", queued_at=now())
+        self.process()
+
+    @reconnect_on_failure()
+    def _import(self) -> None:
+        """Imports the mail data."""
+
+        if self.operation != "Import":
+            return
+
+        logger = self._get_logger()
+        logger.info("import-started", format=self.import_format, import_file=self.import_file)
+
+        freeze_jmap_push_notifications(self.user)
+        self._mark_started()
+        self._log_output(_("Starting import from the uploaded {0} file.").format(self.import_format.upper()))
+
+        import_file = self._resolve_import_file()
+        base_dir = os.path.join(get_mail_import_directory(), self.name)
+        os.makedirs(base_dir, exist_ok=True)
+
+        kwargs = {}
+        service = None
+        staging_mailbox_id = None
+        try:
+            if self.import_format == "eml" and self.import_file.endswith(".eml"):
+                shutil.copy(import_file, os.path.join(base_dir, os.path.basename(import_file)))
+            else:
+                extract_compressed_file(import_file, base_dir)
+            logger.debug("import-source-prepared", base_dir=base_dir)
+            self._log_output(_("Prepared the source files for import."))
+
+            service = get_email_service(self.user, self.account)
+
+            mailbox_map = {}
+            if self.import_format == "maildir-nested":
+                mailbox_map = self._build_mailbox_map(service.mailboxes)
+
+            meta = ImportMetadataLoader.load(
+                self.import_format, base_dir, mailbox_map, self.import_metadata_dict
+            )
+            logger.info("import-metadata-loaded", emails=len(meta), max_import=self.max_import)
+            self._log_output(_("Found {0} email(s) to import.").format(len(meta)))
+
+            if not meta:
+                frappe.throw(_("No emails found for import."))
+            if len(meta) > self.max_import:
+                frappe.throw(_("Import limit exceeded."))
+
+            # Stage everything into one throwaway mailbox first, then move it to the destination
+            # mailbox(es). A failure before the move leaves nothing scattered across the account: the
+            # staging mailbox and every email in it are deleted on rollback.
+            staging_mailbox_id = self._create_staging_mailbox(service, logger)
+            imported = self._import_batches(service, base_dir, meta, staging_mailbox_id, logger)
+            self._move_to_target_mailboxes(service, imported, logger)
+            self._discard_staging_mailbox(service, staging_mailbox_id, logger)
+            staging_mailbox_id = None
+
+            clear_sync_state(self.account, type="email")
+
+            logger.info("import-completed", emails=len(imported))
+            self._log_output(_("Import completed successfully. {0} email(s) imported.").format(len(imported)))
+            kwargs.update({"status": "Completed"})
+        except Exception:
+            logger.exception("import-failed")
+            self._log_output(_("Import failed. See the error details below."))
+            if staging_mailbox_id and service:
+                self._rollback_staging_mailbox(service, staging_mailbox_id, logger)
+            kwargs.update(
+                {"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
+            )
+        finally:
+            shutil.rmtree(base_dir, ignore_errors=True)
+            unfreeze_jmap_push_notifications(self.user)
+
+        self._mark_completed(**kwargs)
+        self._notify_user(success=kwargs.get("status") == "Completed", action="Import")
+
+    @reconnect_on_failure()
+    def _export(self) -> None:
+        """Exports the mail data."""
+
+        if self.operation != "Export":
+            return
+
+        logger = self._get_logger()
+        logger.info("export-started", format=self.export_format, archive_type=self.export_archive_type)
+
+        self._mark_started()
+        self._log_output(_("Starting export to {0} format.").format(self.export_format.upper()))
+        out_dir = os.path.join(get_mail_export_directory(), self.name)
+        os.makedirs(out_dir, exist_ok=True)
+
+        kwargs = {}
+        try:
+            service = get_email_service(self.user, self.account)
+            total = service.query(self.export_filter_dict, limit=1)["total"]
+            limit = min(total, cint(self.export_limit or total))
+            logger.info("export-query-resolved", total=total, limit=limit, max_export=self.max_export)
+            self._log_output(
+                _("Found {0} email(s) matching the filter; exporting up to {1}.").format(total, limit)
+            )
+
+            if limit > self.max_export:
+                frappe.throw(_("Export limit exceeded."))
+
+            ids = service.query(self.export_filter_dict, sort=self.export_sort_clause, limit=limit)["ids"]
+            if not ids:
+                frappe.throw(_("No emails found for export."))
+
+            properties = ["id", "from", "blobId", "keywords", "mailboxIds", "messageId", "receivedAt"]
+            emails = service.get(ids, properties=properties)
+
+            if self.deduplicate_export:
+                fetched = len(emails)
+                unique_emails = {}
+                for e in emails:
+                    # messageId is String[]|null - mail with no Message-ID header comes back null.
+                    # Fall back to the email id so those are not all collapsed into one bucket.
+                    key = (e.get("messageId") or [e["id"]])[0]
+                    if key not in unique_emails:
+                        unique_emails[key] = e
+                emails = list(unique_emails.values())
+                logger.debug("export-deduplicated", fetched=fetched, unique=len(emails))
+                self._log_output(
+                    _("Removed {0} duplicate(s); {1} unique email(s) remain.").format(
+                        fetched - len(emails), len(emails)
+                    )
+                )
+
+            mailbox_map = {}
+            if self.export_format == "mbox":
+                mailbox_map = {m["id"]: m["name"] for m in service.mailboxes}
+            elif self.export_format == "maildir-nested":
+                mailbox_map = self._build_mailbox_map(service.mailboxes)
+
+            self._export_batches(service, emails, out_dir, mailbox_map, logger)
+
+            self._log_output(
+                _("Packaging exported emails into a {0} archive.").format(self.export_archive_type)
+            )
+            self._attach_export(out_dir)
+
+            logger.info("export-completed", emails=len(emails))
+            self._log_output(_("Export completed successfully. {0} email(s) exported.").format(len(emails)))
+            kwargs.update({"status": "Completed"})
+        except Exception:
+            logger.exception("export-failed")
+            self._log_output(_("Export failed. See the error details below."))
+            kwargs.update(
+                {"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
+            )
+        finally:
+            shutil.rmtree(out_dir, ignore_errors=True)
+
+        self._mark_completed(**kwargs)
+        self._notify_user(success=kwargs.get("status") == "Completed", action="Export")
+
+    def _mark_started(self) -> None:
+        """Marks the mail exchange as started and updates the started_at and started_after fields."""
+
+        started_at = now()
+        self._db_set(
+            status="In Progress",
+            started_at=started_at,
+            started_after=time_diff_in_seconds(started_at, self.queued_at),
+            output="",
+        )
+
+    def _mark_completed(self, **kwargs) -> None:
+        """Marks the mail exchange as completed and updates the completed_at and duration fields."""
+
+        kwargs["completed_at"] = now()
+        kwargs["duration"] = time_diff_in_seconds(kwargs["completed_at"], self.started_at)
+
+        if kwargs["status"] == "Failed":
+            kwargs["retries"] = cint(self.retries) + 1
+
+        self._db_set(**kwargs)
+
+    def _create_staging_mailbox(self, service: EmailService, logger: ExchangeLogger) -> str:
+        """Creates a temporary mailbox (named after this exchange) to stage the import into."""
+
+        self._log_output(_("Creating a temporary folder to stage the import."))
+        response = MailboxService(service.account, service.connection).create(
+            [{"creation_id": str(uuid7()), "name": self.name, "is_subscribed": False}]
+        )
+        created = response.get("created") or {}
+        if not created:
+            frappe.throw(_("Failed to create the staging folder: {0}").format(response.get("notCreated")))
+
+        staging_mailbox_id = next(iter(created.values()))["id"]
+        logger.info("import-staging-mailbox-created", mailbox=staging_mailbox_id)
+        return staging_mailbox_id
+
+    def _import_batches(
+        self,
+        service: EmailService,
+        base_dir: str,
+        metadata: list[ImportEmailMeta],
+        staging_mailbox_id: str,
+        logger: ExchangeLogger,
+    ) -> dict[str, dict[str, bool]]:
+        """Imports emails into the staging mailbox in batches, returning a map of each created email's
+        ID to the destination mailboxIds it should ultimately land in."""
+
+        total = len(metadata)
+        imported: dict[str, dict[str, bool]] = {}
+        batch_size = service.max_objects_in_set
+        for batch in create_batch(metadata, batch_size):
+            blobs: list[tuple[bytes, str]] = []
+            for meta in batch:
+                with open(os.path.join(base_dir, meta.blob_path), "rb") as f:
+                    blobs.append((f.read(), "message/rfc822"))
+
+            responses = service.upload_blobs_concurrently(blobs)
+            emails = {}
+            targets: dict[str, dict[str, bool]] = {}
+            for i, resp in enumerate(responses):
+                meta = batch[i]
+                emails[f"e{i}"] = {
+                    "blobId": resp["blobId"],
+                    "mailboxIds": {staging_mailbox_id: True},
+                    "keywords": {k: True for k in meta.keywords or []},
+                    "receivedAt": meta.received_at.isoformat(),
+                }
+                targets[f"e{i}"] = {mid: True for mid in meta.mailbox_ids}
+
+            response = service._call(
+                capabilities=service.capabilities,
+                method_calls=[
+                    [
+                        f"{service.type}/import",
+                        {"accountId": service.account, "emails": emails},
+                        "0",
+                    ]
+                ],
+            )
+            method_responses = response.get("methodResponses") or []
+            result = method_responses[0][1] if method_responses else {}
+
+            for creation_id, info in (result.get("created") or {}).items():
+                imported[info["id"]] = targets.get(creation_id, {})
+            for creation_id, error in (result.get("notCreated") or {}).items():
+                logger.warning("import-email-not-created", creation_id=creation_id, reason=str(error))
+
+            logger.debug("import-batch-processed", batch=len(batch), imported=len(imported), total=total)
+            self._log_output(_("Staged {0} of {1} email(s).").format(len(imported), total))
+
+        # `metadata` is non-empty here (an empty import is rejected upstream), so an empty `imported`
+        # means the server rejected every email — a failure that must roll back. Guarding on `total`
+        # keeps this from ever misreporting an empty input as "rejected all 0". Unlike calendar/contacts
+        # there is no idempotency-skip, so `not imported` already means "all rejected".
+        if total and not imported:
+            frappe.throw(_("Import failed: the server rejected all {0} email(s).").format(total))
+
+        return imported
+
+    def _move_to_target_mailboxes(
+        self, service: EmailService, imported: dict[str, dict[str, bool]], logger: ExchangeLogger
+    ) -> None:
+        """Moves the staged emails into their destination mailboxes, replacing the staging mailbox.
+
+        This is the commit step: until it runs, every email lives only in the staging mailbox, so a
+        failure up to this point rolls back cleanly."""
+
+        self._log_output(_("Moving {0} email(s) into the destination folder(s).").format(len(imported)))
+        emails = [{"id": email_id, "mailbox_ids": mailbox_ids} for email_id, mailbox_ids in imported.items()]
+        result = service.update(emails, replace_mailboxes=True)
+
+        if not_updated := result.get("notUpdated"):
+            logger.warning("import-email-not-moved", count=len(not_updated))
+            frappe.throw(
+                _("Failed to move {0} email(s) into the destination folder(s).").format(len(not_updated))
+            )
+
+        logger.info("import-emails-moved", emails=len(result.get("updated", [])))
+
+    def _discard_staging_mailbox(
+        self, service: EmailService, staging_mailbox_id: str, logger: ExchangeLogger
+    ) -> None:
+        """Deletes the now-empty staging mailbox after a successful import. A failure here is logged
+        but not fatal: the emails are already safely in their destination folders."""
+
+        try:
+            MailboxService(service.account, service.connection).delete([staging_mailbox_id])
+            logger.info("import-staging-mailbox-removed", mailbox=staging_mailbox_id)
+        except Exception:
+            logger.warning("import-staging-mailbox-remove-failed", mailbox=staging_mailbox_id)
+
+    def _rollback_staging_mailbox(
+        self, service: EmailService, staging_mailbox_id: str, logger: ExchangeLogger
+    ) -> None:
+        """Deletes the staging mailbox and every email still staged in it, undoing a failed import."""
+
+        self._log_output(_("Rolling back: removing the staging folder and any staged emails."))
+        try:
+            MailboxService(service.account, service.connection).delete(
+                [staging_mailbox_id], remove_emails=True
+            )
+            logger.info("import-rolled-back", mailbox=staging_mailbox_id)
+        except Exception:
+            logger.exception("import-rollback-failed", mailbox=staging_mailbox_id)
+
+    def _export_batches(
+        self,
+        service: EmailService,
+        emails: list[dict],
+        out_dir: str,
+        mailbox_map: dict[str, str],
+        logger: ExchangeLogger,
+    ) -> None:
+        """Exports emails in batches using the EmailService."""
+
+        if self.export_format == "jmap":
+            ExportWriter.write_meta(emails, out_dir)
+
+        total = len(emails)
+        exported = 0
+        batch_size = cint(get_config("exchange_export_batch_size"))
+        for batch in create_batch(emails, batch_size):
+            blobs = [(e["blobId"], None) for e in batch if e.get("blobId")]
+            data = service.download_blobs_concurrently(blobs)
+
+            export_emails = []
+            for e in batch:
+                if e.get("blobId") not in data:
+                    logger.warning("export-blob-missing", id=e.get("id"), blob_id=e.get("blobId"))
+                    continue
+
+                export_emails.append(
+                    ExportEmail(
+                        id=e["id"],
+                        sender=(e.get("from") or [{}])[0],
+                        blob_id=e["blobId"],
+                        keywords=set(e["keywords"].keys()),
+                        mailbox_ids=set(e["mailboxIds"].keys()),
+                        message_id=(e.get("messageId") or [""])[0],
+                        received_at=datetime.fromisoformat(e["receivedAt"]),
+                        raw=data[e["blobId"]],
+                    )
+                )
+
+            ExportWriter.write(self.export_format, export_emails, out_dir, mailbox_map)
+
+            exported += len(export_emails)
+            logger.debug("export-batch-written", batch=len(export_emails), exported=exported, total=total)
+            self._log_output(_("Exported {0} of {1} email(s).").format(exported, total))
+
+    def _build_mailbox_map(self, mailboxes: list[dict]) -> dict[str, str]:
+        """Builds a mapping of mailbox IDs to their full paths."""
+
+        by_id = {m["id"]: m for m in mailboxes}
+        result: dict[str, str] = {}
+
+        def resolve_path(mailbox_id: str) -> str:
+            if mailbox_id in result:
+                return result[mailbox_id]
+
+            mailbox = by_id[mailbox_id]
+            name = mailbox["name"]
+            parent_id = mailbox.get("parentId")
+
+            if parent_id:
+                parent_path = resolve_path(parent_id)
+                path = f"{parent_path}/{name}"
+            else:
+                path = name
+
+            result[mailbox_id] = path
+            return path
+
+        for mailbox_id in by_id:
+            resolve_path(mailbox_id)
+
+        return result
+
+    def _attach_export(self, out_dir: str) -> None:
+        """Attaches the exported file to the mail exchange."""
+
+        archive = f"{self.name}{self.export_archive_type}"
+        url = f"/private/files/{archive}"
+        path = os.path.join(get_bench_path(), f"sites/{frappe.local.site}{url}")
+        compress_directory(out_dir, path)
+
+        file = frappe.new_doc("File")
+        file.is_private = 1
+        file.file_url = url
+        file.file_name = archive
+        file.attached_to_doctype = self.doctype
+        file.attached_to_name = self.name
+        file.attached_to_field = "file"
+        file.insert()
+
+        # https://github.com/frappe/frappe/issues/26615
+        frappe.db.set_value("File", file.name, {"file_url": url, "file_name": archive})
+
+    def _notify_user(self, success: bool, action: Literal["Import", "Export"]) -> None:
+        """Sends notification email to the owner of the mail exchange."""
+
+        if is_administrator(self.owner):
+            return
+        if not (email := get_user_email_address(self.owner)):
+            return
+
+        subject = _("Mail Data {0} {1}").format(action, "Completed" if success else "Failed")
+        frappe.publish_realtime(
+            "mail_exchange_completed",
+            {"action": action, "success": success, "message": subject},
+            user=self.user,
+        )
+        frappe.sendmail(
+            recipients=email,
+            subject=subject,
+            template="generic",
+            args={
+                "title": subject,
+                "description": _("View details for this exchange."),
+                "button": _("View {0}").format(action),
+                "link": get_url(f"/mail/mail-exchanges/{self.name}"),
+            },
+            now=True,
+        )
+
+    def _log_output(self, message: str) -> None:
+        """Appends a timestamped, user-friendly line to the `output` field and persists it.
+
+        These messages are surfaced in the UI so the user can follow the progress of the
+        background import/export as it happens."""
+
+        line = f"[{now()}] {message}"
+        self.output = f"{self.output}\n{line}" if self.output else line
+        self._db_set(output=self.output)
+
+    def _db_set(self, **kwargs) -> None:
+        """Updates the document with the given key-value pairs."""
+
+        self.db_set(kwargs, notify=True, commit=True)
 
 
 def get_email_service(
-	user: str,
-	account: str,
-	ignore_permissions: bool = False,
+    user: str,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> EmailService:
-	"""Returns a EmailService configured with the longer exchange timeouts."""
+    """Returns a EmailService configured with the longer exchange timeouts."""
 
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions, timeout=(60.0, 180.0))
-	return EmailService(account, connection)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions, timeout=(60.0, 180.0))
+    return EmailService(account, connection)
 
 
 def extract_received_or_sent(msg: Message) -> datetime:
-	"""
-	Extracts the received date from the email headers.
-	If the Received header is not available or invalid, it falls back to the Date header.
-	Ensures the resulting datetime is not in the future.
-	Raises an exception if neither header is valid.
-	"""
+    """
+    Extracts the received date from the email headers.
+    If the Received header is not available or invalid, it falls back to the Date header.
+    Ensures the resulting datetime is not in the future.
+    Raises an exception if neither header is valid.
+    """
 
-	now = datetime.now(UTC)
+    now = datetime.now(UTC)
 
-	if received_headers := msg.get_all("Received", []):
-		last_received = received_headers[-1]
+    if received_headers := msg.get_all("Received", []):
+        last_received = received_headers[-1]
 
-		if ";" in last_received:
-			date_part = last_received.rsplit(";", 1)[-1].strip()
-			try:
-				dt = parsedate_to_datetime(date_part)
-				if dt.tzinfo is None:
-					dt = dt.replace(tzinfo=UTC)
+        if ";" in last_received:
+            date_part = last_received.rsplit(";", 1)[-1].strip()
+            try:
+                dt = parsedate_to_datetime(date_part)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=UTC)
 
-				if dt <= now:
-					return dt
-			except Exception:
-				pass
+                if dt <= now:
+                    return dt
+            except Exception:
+                pass
 
-	if sent_date := msg.get("Date"):
-		try:
-			dt = parsedate_to_datetime(sent_date)
-			if dt.tzinfo is None:
-				dt = dt.replace(tzinfo=UTC)
+    if sent_date := msg.get("Date"):
+        try:
+            dt = parsedate_to_datetime(sent_date)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=UTC)
 
-			if dt <= now:
-				return dt
-		except Exception:
-			pass
+            if dt <= now:
+                return dt
+        except Exception:
+            pass
 
-	frappe.throw(_("Email must have a valid non-future Received or Date header."))
+    frappe.throw(_("Email must have a valid non-future Received or Date header."))
 
 
 def retry_stuck_mail_exchanges() -> None:
-	"""Called by the scheduler to retry stuck mail exchanges."""
+    """Called by the scheduler to retry stuck mail exchanges."""
 
-	ME = frappe.qb.DocType("Mail Exchange")
-	exchanges = (
-		frappe.qb.from_(ME)
-		.select(ME.name)
-		.where(
-			(ME.status.isin(["Queued", "In Progress"]))
-			& (ME.queued_at <= get_datetime(add_to_date(now(), days=-1)))
-		)
-		.orderby(ME.queued_at, order=Order.asc)
-	).run(pluck="name")
+    ME = frappe.qb.DocType("Mail Exchange")
+    exchanges = (
+        frappe.qb.from_(ME)
+        .select(ME.name)
+        .where(
+            (ME.status.isin(["Queued", "In Progress"]))
+            & (ME.queued_at <= get_datetime(add_to_date(now(), days=-1)))
+        )
+        .orderby(ME.queued_at, order=Order.asc)
+    ).run(pluck="name")
 
-	# retry() throws for a document that no longer qualifies, and a scheduler job has no
-	# caller to surface that to - so isolate each one, or the first bad document silently
-	# strands every exchange queued behind it, run after run.
-	for exchange in exchanges:
-		try:
-			frappe.get_doc("Mail Exchange", exchange).retry()
-		except Exception:
-			frappe.db.rollback()
-			log_error(
-				module="Mail",
-				title=f"Failed to retry stuck Mail Exchange {exchange}",
-				message=frappe.get_traceback(),
-			)
+    # retry() throws for a document that no longer qualifies, and a scheduler job has no
+    # caller to surface that to - so isolate each one, or the first bad document silently
+    # strands every exchange queued behind it, run after run.
+    for exchange in exchanges:
+        try:
+            frappe.get_doc("Mail Exchange", exchange).retry()
+        except Exception:
+            frappe.db.rollback()
+            log_error(
+                module="Mail",
+                title=f"Failed to retry stuck Mail Exchange {exchange}",
+                message=frappe.get_traceback(),
+            )
 
 
 def clean_import_export_directories() -> None:
-	"""Called by the scheduler to clean up import and export directories."""
+    """Called by the scheduler to clean up import and export directories."""
 
-	for base in (get_mail_import_directory(), get_mail_export_directory()):
-		if not os.path.exists(base):
-			continue
+    for base in (get_mail_import_directory(), get_mail_export_directory()):
+        if not os.path.exists(base):
+            continue
 
-		for item in os.listdir(base):
-			path = os.path.join(base, item)
-			if os.path.isdir(path):
-				if frappe.db.exists("Mail Exchange", {"name": item, "status": "In Progress"}):
-					continue
-				shutil.rmtree(path, ignore_errors=True)
-			else:
-				os.remove(path)
+        for item in os.listdir(base):
+            path = os.path.join(base, item)
+            if os.path.isdir(path):
+                if frappe.db.exists("Mail Exchange", {"name": item, "status": "In Progress"}):
+                    continue
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                os.remove(path)

--- a/suite/mail/doctype/mail_exchange/test_mail_exchange.py
+++ b/suite/mail/doctype/mail_exchange/test_mail_exchange.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestMailExchange(IntegrationTestCase):
-	"""
-	Integration tests for MailExchange.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for MailExchange.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -240,7 +240,7 @@ class MailMessage(Document):
     def db_insert(self, *args, **kwargs) -> None:
         raise NotImplementedError
 
-    def load_from_db(self) -> "MailMessage":
+    def load_from_db(self) -> MailMessage:
         account, id = self.name.split("|")
         if messages := get_messages(account, ids=[id]):
             return super(Document, self).__init__(messages[0])
@@ -351,13 +351,13 @@ class MailMessage(Document):
             )
 
     @frappe.whitelist()
-    def save_draft(self) -> "MailQueue":
+    def save_draft(self) -> MailQueue:
         """Save the Mail Message as a draft."""
 
         return self._update_or_submit_draft(save_as_draft=True)
 
     @frappe.whitelist()
-    def submit(self) -> "MailQueue":
+    def submit(self) -> MailQueue:
         """Submit the draft Mail Message."""
 
         return self._update_or_submit_draft(save_as_draft=False)
@@ -401,7 +401,7 @@ class MailMessage(Document):
         self.reload()
 
     @frappe.whitelist()
-    def reply(self) -> "MailQueue":
+    def reply(self) -> MailQueue:
         """Reply to the Mail Message."""
 
         recipients = []
@@ -426,7 +426,7 @@ class MailMessage(Document):
         return self._reply(recipients)
 
     @frappe.whitelist()
-    def reply_all(self) -> "MailQueue":
+    def reply_all(self) -> MailQueue:
         """Reply to all recipients of the Mail Message."""
 
         recipients = []
@@ -458,7 +458,7 @@ class MailMessage(Document):
         return self._reply(recipients)
 
     @frappe.whitelist()
-    def forward(self) -> "MailQueue":
+    def forward(self) -> MailQueue:
         """Forward the Mail Message."""
 
         self.validate_draft()
@@ -583,7 +583,7 @@ class MailMessage(Document):
         ]:
             self.__dict__.pop(property, None)
 
-    def _update_or_submit_draft(self, save_as_draft: bool = True) -> "MailQueue":
+    def _update_or_submit_draft(self, save_as_draft: bool = True) -> MailQueue:
         """Update or submit the draft Mail Message."""
 
         if not self.draft:
@@ -625,7 +625,7 @@ class MailMessage(Document):
             delivery_mode="Immediate",
         )
 
-    def _reply(self, recipients: list[dict]) -> "MailQueue":
+    def _reply(self, recipients: list[dict]) -> MailQueue:
         """Returns a unsaved MailQueue object for replying to the Mail Message."""
 
         self.validate_draft()
@@ -676,7 +676,7 @@ def bulk_delete(names: str | list[str]) -> None:
 
 
 @frappe.whitelist()
-def reply(source_name: str, target_doc=None) -> "MailQueue":
+def reply(source_name: str, target_doc=None) -> MailQueue:
     """Reply to the Mail Message."""
 
     source_doc = frappe.get_doc("Mail Message", source_name)
@@ -684,7 +684,7 @@ def reply(source_name: str, target_doc=None) -> "MailQueue":
 
 
 @frappe.whitelist()
-def reply_all(source_name: str, target_doc=None) -> "MailQueue":
+def reply_all(source_name: str, target_doc=None) -> MailQueue:
     """Reply to all recipients of the Mail Message."""
 
     source_doc = frappe.get_doc("Mail Message", source_name)
@@ -692,7 +692,7 @@ def reply_all(source_name: str, target_doc=None) -> "MailQueue":
 
 
 @frappe.whitelist()
-def forward(source_name: str, target_doc=None) -> "MailQueue":
+def forward(source_name: str, target_doc=None) -> MailQueue:
     """Forward the Mail Message."""
 
     source_doc = frappe.get_doc("Mail Message", source_name)

--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -15,13 +15,13 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.push_notification import PushNotification
 from frappe.utils import (
-	add_to_date,
-	cint,
-	escape_html,
-	get_datetime,
-	now,
-	random_string,
-	time_diff_in_seconds,
+    add_to_date,
+    cint,
+    escape_html,
+    get_datetime,
+    now,
+    random_string,
+    time_diff_in_seconds,
 )
 
 from suite.mail.doctype.mail_queue.mail_queue import MailQueue
@@ -32,8 +32,8 @@ from suite.mail.jmap.services.mail.email import EmailService
 from suite.mail.jmap.services.mail.mailbox import MailboxService
 from suite.mail.store import Entity, get_blob_store, get_data_store, get_email_address_index
 from suite.mail.utils import (
-	get_config,
-	log_mail_error,
+    get_config,
+    log_mail_error,
 )
 from suite.mail.utils.email_parser import EmailParser
 from suite.mail.utils.logger import get_push_logger
@@ -46,1509 +46,1509 @@ PREVIEW_MAX_LENGTH = 256
 
 
 class MailMessage(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
-
-	from typing import TYPE_CHECKING
-
-	if TYPE_CHECKING:
-		from frappe.types import DF
-
-		from suite.mail.doctype.email_address.email_address import EmailAddress
-		from suite.mail.doctype.mail_message_mailbox.mail_message_mailbox import MailMessageMailbox
-		from suite.mail.doctype.mail_message_part.mail_message_part import MailMessagePart
-		from suite.mail.doctype.mail_message_recipient.mail_message_recipient import MailMessageRecipient
-
-		_bcc: DF.Data | None
-		_cc: DF.Data | None
-		_from: DF.Data | None
-		_html_body: DF.Table[MailMessagePart]
-		_text_body: DF.Table[MailMessagePart]
-		_to: DF.Data | None
-		account: DF.Link
-		after: DF.Datetime | None
-		answered: DF.Check
-		attachments: DF.Table[MailMessagePart]
-		before: DF.Datetime | None
-		blob_id: DF.Data | None
-		body: DF.Data | None
-		draft: DF.Check
-		flagged: DF.Check
-		forwarded: DF.Check
-		from_email: DF.Data | None
-		from_name: DF.Data | None
-		has_attachment: DF.Check
-		has_keyword: DF.Data | None
-		html_body: DF.Code | None
-		id: DF.Data | None
-		in_mailbox: DF.Data | None
-		in_reply_to: DF.Data | None
-		junk: DF.Check
-		keywords: DF.JSON | None
-		mailboxes: DF.Table[MailMessageMailbox]
-		max_size: DF.Int
-		message_id: DF.Data | None
-		min_size: DF.Int
-		not_keyword: DF.Data | None
-		preview: DF.Code | None
-		received_after: DF.Float
-		received_at: DF.Datetime | None
-		recipients: DF.Table[MailMessageRecipient]
-		reply_to: DF.Table[EmailAddress]
-		seen: DF.Check
-		sender_email: DF.Data | None
-		sender_name: DF.Data | None
-		sent_at: DF.Datetime | None
-		size: DF.Int
-		subject: DF.SmallText | None
-		text: DF.Data | None
-		text_body: DF.Code | None
-		thread_id: DF.Data | None
-	# end: auto-generated types
-
-	@property
-	def to(self) -> list[dict[str, str | None]]:
-		"""Returns the recipients in the To field."""
-
-		return self._get_recipients("To")
-
-	@property
-	def cc(self) -> list[dict[str, str | None]]:
-		"""Returns the recipients in the Cc field."""
-
-		return self._get_recipients("Cc")
-
-	@property
-	def bcc(self) -> list[dict[str, str | None]]:
-		"""Returns the recipients in the Bcc field."""
-
-		return self._get_recipients("Bcc")
-
-	@property
-	def spf_pass(self) -> int:
-		"""Returns SPF pass status."""
-
-		return cint(self.authentication_results.get("spf_pass"))
-
-	@property
-	def dkim_pass(self) -> int:
-		"""Returns DKIM pass status."""
-
-		return cint(self.authentication_results.get("dkim_pass"))
-
-	@property
-	def dmarc_pass(self) -> int:
-		"""Returns DMARC pass status."""
-
-		return cint(self.authentication_results.get("dmarc_pass"))
-
-	@property
-	def spf_description(self) -> str | None:
-		"""Returns SPF description."""
-
-		return self.authentication_results.get("spf_description")
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        from suite.mail.doctype.email_address.email_address import EmailAddress
+        from suite.mail.doctype.mail_message_mailbox.mail_message_mailbox import MailMessageMailbox
+        from suite.mail.doctype.mail_message_part.mail_message_part import MailMessagePart
+        from suite.mail.doctype.mail_message_recipient.mail_message_recipient import MailMessageRecipient
+
+        _bcc: DF.Data | None
+        _cc: DF.Data | None
+        _from: DF.Data | None
+        _html_body: DF.Table[MailMessagePart]
+        _text_body: DF.Table[MailMessagePart]
+        _to: DF.Data | None
+        account: DF.Link
+        after: DF.Datetime | None
+        answered: DF.Check
+        attachments: DF.Table[MailMessagePart]
+        before: DF.Datetime | None
+        blob_id: DF.Data | None
+        body: DF.Data | None
+        draft: DF.Check
+        flagged: DF.Check
+        forwarded: DF.Check
+        from_email: DF.Data | None
+        from_name: DF.Data | None
+        has_attachment: DF.Check
+        has_keyword: DF.Data | None
+        html_body: DF.Code | None
+        id: DF.Data | None
+        in_mailbox: DF.Data | None
+        in_reply_to: DF.Data | None
+        junk: DF.Check
+        keywords: DF.JSON | None
+        mailboxes: DF.Table[MailMessageMailbox]
+        max_size: DF.Int
+        message_id: DF.Data | None
+        min_size: DF.Int
+        not_keyword: DF.Data | None
+        preview: DF.Code | None
+        received_after: DF.Float
+        received_at: DF.Datetime | None
+        recipients: DF.Table[MailMessageRecipient]
+        reply_to: DF.Table[EmailAddress]
+        seen: DF.Check
+        sender_email: DF.Data | None
+        sender_name: DF.Data | None
+        sent_at: DF.Datetime | None
+        size: DF.Int
+        subject: DF.SmallText | None
+        text: DF.Data | None
+        text_body: DF.Code | None
+        thread_id: DF.Data | None
+    # end: auto-generated types
+
+    @property
+    def to(self) -> list[dict[str, str | None]]:
+        """Returns the recipients in the To field."""
+
+        return self._get_recipients("To")
+
+    @property
+    def cc(self) -> list[dict[str, str | None]]:
+        """Returns the recipients in the Cc field."""
+
+        return self._get_recipients("Cc")
+
+    @property
+    def bcc(self) -> list[dict[str, str | None]]:
+        """Returns the recipients in the Bcc field."""
+
+        return self._get_recipients("Bcc")
+
+    @property
+    def spf_pass(self) -> int:
+        """Returns SPF pass status."""
+
+        return cint(self.authentication_results.get("spf_pass"))
+
+    @property
+    def dkim_pass(self) -> int:
+        """Returns DKIM pass status."""
+
+        return cint(self.authentication_results.get("dkim_pass"))
+
+    @property
+    def dmarc_pass(self) -> int:
+        """Returns DMARC pass status."""
+
+        return cint(self.authentication_results.get("dmarc_pass"))
+
+    @property
+    def spf_description(self) -> str | None:
+        """Returns SPF description."""
+
+        return self.authentication_results.get("spf_description")
 
-	@property
-	def dkim_description(self) -> str | None:
-		"""Returns DKIM description."""
+    @property
+    def dkim_description(self) -> str | None:
+        """Returns DKIM description."""
 
-		return self.authentication_results.get("dkim_description")
+        return self.authentication_results.get("dkim_description")
 
-	@property
-	def dmarc_description(self) -> str | None:
-		"""Returns DMARC description."""
+    @property
+    def dmarc_description(self) -> str | None:
+        """Returns DMARC description."""
 
-		return self.authentication_results.get("dmarc_description")
+        return self.authentication_results.get("dmarc_description")
 
-	@cached_property
-	def from_ip(self) -> str | None:
-		"""Returns the IP address of the sender."""
+    @cached_property
+    def from_ip(self) -> str | None:
+        """Returns the IP address of the sender."""
 
-		if not self.parsed_message:
-			return
+        if not self.parsed_message:
+            return
 
-		if header := self.parsed_message.get_header("Received"):
-			ip_pattern = re.compile(r"\[(?P<ip>[\d\.]+|[a-fA-F0-9:]+)")
-			ip_match = ip_pattern.search(header)
-			return ip_match.group("ip") if ip_match else None
+        if header := self.parsed_message.get_header("Received"):
+            ip_pattern = re.compile(r"\[(?P<ip>[\d\.]+|[a-fA-F0-9:]+)")
+            ip_match = ip_pattern.search(header)
+            return ip_match.group("ip") if ip_match else None
 
-	@cached_property
-	def from_host(self) -> str | None:
-		"""Returns the host of the sender."""
+    @cached_property
+    def from_host(self) -> str | None:
+        """Returns the host of the sender."""
 
-		if not self.parsed_message:
-			return
+        if not self.parsed_message:
+            return
 
-		if header := self.parsed_message.get_header("Received"):
-			host_pattern = re.compile(r"from\s+(?P<host>[^\s]+)")
-			host_match = host_pattern.search(header)
-			return host_match.group("host") if host_match else None
+        if header := self.parsed_message.get_header("Received"):
+            host_pattern = re.compile(r"from\s+(?P<host>[^\s]+)")
+            host_match = host_pattern.search(header)
+            return host_match.group("host") if host_match else None
 
-	@cached_property
-	def spam_score(self) -> float:
-		"""Returns the spam score of the email."""
-
-		if not self.parsed_message:
-			return 0.0
-
-		if header := self.parsed_message.get_header("X-Spam-Status"):
-			score_pattern = re.compile(r"score=(-?\d+\.?\d*)")
-			score_match = score_pattern.search(header)
-			return float(score_match.group(1)) if score_match else 0.0
-
-	@property
-	def message(self) -> str | None:
-		"""Returns the message content if available."""
-
-		cached_blobs = _get_cached_blobs(self.account, [self.blob_id])
-		if content := cached_blobs.get(self.blob_id):
-			return content.decode("utf-8")
-
-	@cached_property
-	def parsed_message(self) -> EmailParser | None:
-		"""Returns the parsed Mail Message."""
-
-		if self.message:
-			return EmailParser(self.message)
-
-	@cached_property
-	def authentication_results(self) -> dict[str, int | str]:
-		"""Returns the authentication results of the email."""
-
-		if not self.parsed_message:
-			return {}
-
-		return self.parsed_message.get_authentication_results()
-
-	@cached_property
-	def email_type(self) -> str:
-		"""Returns the type of email (Sent or Received)."""
-
-		email_type = "Received"
-		account_addresses = get_account_emails(self.account)
-
-		if self.from_email in account_addresses or (
-			hasattr(self, "sender_email") and self.sender_email in account_addresses
-		):
-			email_type = "Sent"
-
-		return email_type
-
-	def autoname(self) -> None:
-		self.name = f"{self.account}|{uuid7()!s}"
-
-	def db_insert(self, *args, **kwargs) -> None:
-		raise NotImplementedError
-
-	def load_from_db(self) -> "MailMessage":
-		account, id = self.name.split("|")
-		if messages := get_messages(account, ids=[id]):
-			return super(Document, self).__init__(messages[0])
-
-		frappe.throw(_("Message not found or you do not have permission to view it."))
-
-	def db_update(self) -> None:
-		raise NotImplementedError
-
-	def delete(self) -> None:
-		account, id = self.name.split("|")
-		delete_messages(account, [id])
-
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs) -> list:
-		filters = parse_filters(filters)
-
-		id = filters.get("id")
-		account = filters.get("account")
-
-		if not account:
-			frappe.msgprint(_("Please select an account to view messages."), alert=True)
-			return []
-
-		if not get_user_for_jmap_account(account, allow_system_manager=False, raise_exception=False):
-			frappe.msgprint(_("You do not have permission to view messages for this account."), alert=True)
-			return []
-
-		if id:
-			messages = get_messages(account, ids=[id])
-			total = len(messages)
-		else:
-			filter = {
-				prop: value
-				for field, prop in {
-					"in_mailbox": "inMailbox",
-					"_from": "from",
-					"_to": "to",
-					"_cc": "cc",
-					"_bcc": "bcc",
-					"text": "text",
-					"body": "body",
-					"subject": "subject",
-					"min_size": "minSize",
-					"max_size": "maxSize",
-					"has_keyword": "hasKeyword",
-					"not_keyword": "notKeyword",
-				}.items()
-				if (value := filters.get(field))
-			}
-
-			if filters.get("has_attachment"):
-				filter["hasAttachment"] = True
-
-			for field in ("before", "after"):
-				if value := filters.get(field):
-					filter[field] = to_iso8601_z(convert_to_utc(value))
-
-			limit = cint(kwargs.get("start")) + page_length
-			messages, total = fetch_messages(account, filter, limit=limit)
-
-		frappe.cache.set_value(_get_total_cache_key(account), total, expires_in_sec=600)
-
-		fields_to_remove = [
-			"mailboxes",
-			"reply_to",
-			"recipients",
-			"preview",
-			"html_body",
-			"text_body",
-			"attachments",
-			"keywords",
-			"_html_body",
-			"_text_body",
-		]
-		for message in messages:
-			for field in fields_to_remove:
-				message.pop(field, None)
-
-		if not messages:
-			frappe.msgprint(_("No messages found."), alert=True)
-
-		return messages
-
-	@staticmethod
-	def get_count(filters=None, **kwargs) -> int:
-		filters = parse_filters(filters)
-		account = filters.get("account")
-
-		if account:
-			if get_user_for_jmap_account(account, allow_system_manager=False, raise_exception=False):
-				return cint(frappe.cache.get_value(_get_total_cache_key(account)))
-
-		return 0
-
-	@staticmethod
-	def get_stats(**kwargs) -> dict:
-		return {}
-
-	def validate_draft(self) -> None:
-		"""Raise an exception if the message is a draft."""
-
-		if self.draft:
-			frappe.throw(
-				_("Mail Message {0} is a draft. Please send it before performing this action.").format(
-					frappe.bold(self.name)
-				)
-			)
-
-	@frappe.whitelist()
-	def save_draft(self) -> "MailQueue":
-		"""Save the Mail Message as a draft."""
-
-		return self._update_or_submit_draft(save_as_draft=True)
-
-	@frappe.whitelist()
-	def submit(self) -> "MailQueue":
-		"""Submit the draft Mail Message."""
-
-		return self._update_or_submit_draft(save_as_draft=False)
-
-	@frappe.whitelist()
-	def move_to_mailbox(self, mailbox_id: str) -> None:
-		"""Move the Mail Message to a specified mailbox."""
-
-		self.validate_draft()
-		move_messages_to_mailbox(self.account, [self.id], mailbox_id)
-		self.reload()
-
-	@frappe.whitelist()
-	def add_to_mailbox(self, mailbox_id: str) -> None:
-		"""Add the Mail Message to a specified mailbox."""
-
-		self.validate_draft()
-		add_messages_to_mailbox(self.account, [self.id], mailbox_id)
-		self.reload()
-
-	@frappe.whitelist()
-	def remove_from_mailbox(self, mailbox_id: str) -> None:
-		"""Remove the Mail Message from a specified mailbox."""
-
-		self.validate_draft()
-		remove_messages_from_mailbox(self.account, [self.id], mailbox_id)
-		self.reload()
-
-	@frappe.whitelist()
-	def set_seen(self, seen: bool) -> None:
-		"""Set the Mail Message as seen or unseen."""
-
-		set_seen_status(self.account, [self.id], seen)
-		self.reload()
-
-	@frappe.whitelist()
-	def set_flagged(self, flagged: bool) -> None:
-		"""Set the Mail Message as flagged or unflagged."""
-
-		set_flagged_status(self.account, [self.id], flagged)
-		self.reload()
-
-	@frappe.whitelist()
-	def reply(self) -> "MailQueue":
-		"""Reply to the Mail Message."""
-
-		recipients = []
-
-		if self.email_type == "Sent":
-			# To = original To
-			for rcpt in self.recipients:
-				if rcpt.type == "To":
-					recipients.append(
-						{"type": rcpt.type, "display_name": rcpt.display_name, "email": rcpt.email}
-					)
-
-		elif self.email_type == "Received":
-			# To = Reply-To if present, else From
-			if self.reply_to:
-				recipients.extend(
-					{"type": "To", "display_name": rt.display_name, "email": rt.email} for rt in self.reply_to
-				)
-			else:
-				recipients.append({"type": "To", "display_name": self.from_name, "email": self.from_email})
-
-		return self._reply(recipients)
-
-	@frappe.whitelist()
-	def reply_all(self) -> "MailQueue":
-		"""Reply to all recipients of the Mail Message."""
-
-		recipients = []
-
-		if self.email_type == "Sent":
-			# To = original To
-			# Cc = original Cc
-			for rcpt in self.recipients:
-				if rcpt.type in ["To", "Cc"]:
-					recipients.append(
-						{"type": rcpt.type, "display_name": rcpt.display_name, "email": rcpt.email}
-					)
-
-		elif self.email_type == "Received":
-			# To = Reply-To if present, else From
-			if self.reply_to:
-				recipients.extend(
-					{"type": "To", "display_name": rt.display_name, "email": rt.email} for rt in self.reply_to
-				)
-			else:
-				recipients.append({"type": "To", "display_name": self.from_name, "email": self.from_email})
-
-			# Cc = (original To + original Cc) minus account addresses
-			account_addresses = get_account_emails(self.account)
-			for rcpt in self.recipients:
-				if rcpt.type in ["To", "Cc"] and rcpt.email not in account_addresses:
-					recipients.append({"type": "Cc", "display_name": rcpt.display_name, "email": rcpt.email})
-
-		return self._reply(recipients)
-
-	@frappe.whitelist()
-	def forward(self) -> "MailQueue":
-		"""Forward the Mail Message."""
-
-		self.validate_draft()
-
-		formatted_sent_at = get_datetime(self.sent_at).strftime("%a, %B %-d, %Y at %-I:%M %p")
-		forward_html_body = (
-			"<p>---------- Forwarded message ---------</p>"
-			'<table border="0" cellpadding="0" cellspacing="10">'
-			f"<tr><td><b>From:</b></td><td>{escape_html(formataddr([self.from_name, self.from_email]))}</td></tr>"
-			f"<tr><td><b>Date:</b></td><td>{formatted_sent_at}</td></tr>"
-			f"<tr><td><b>Subject:</b></td><td>{escape_html(self.subject or '')}</td></tr>"
-		)
-		forward_text_body = (
-			"---------- Forwarded message ---------\n"
-			f"From: {formataddr([self.from_name, self.from_email])}\n"
-			f"Date: {formatted_sent_at}\n"
-			f"Subject: {self.subject or ''}\n"
-		)
-
-		if to := ", ".join(
-			[formataddr([rcpt["name"], rcpt["email"]]) for rcpt in self._get_recipients("To")]
-		):
-			forward_html_body += f"<tr><td><b>To:</b></td><td>{escape_html(to)}</td></tr>"
-			forward_text_body += f"To: {to}\n"
-		if cc := ", ".join(
-			[formataddr([rcpt["name"], rcpt["email"]]) for rcpt in self._get_recipients("Cc")]
-		):
-			forward_html_body += f"<tr><td><b>Cc:</b></td><td>{escape_html(cc)}</td></tr>"
-			forward_text_body += f"Cc: {cc}\n"
-
-		original_html_body = self.html_body or ""
-		original_text_body = self.text_body or ""
-
-		quoted_html_body = f'<blockquote style="border-left:2px solid #ccc; margin-left:0; padding-left:1em;">{original_html_body}</blockquote>'
-		quoted_text_body = "\n> ".join(original_text_body.strip().splitlines())
-
-		forward_html_body += f"</table><br/> {quoted_html_body}"
-		forward_html_body = BeautifulSoup(forward_html_body, "html.parser").prettify()
-		forward_text_body += f"\n\n> {quoted_text_body}"
-
-		attachments = [
-			{
-				"file_url": a.file_url,
-				"blob_id": a.blob_id,
-				"type": a.type,
-				"size": a.size,
-				"filename": a.filename,
-				"disposition": a.disposition,
-				"cid": a.cid,
-			}
-			for a in self.attachments
-		]
-
-		for body_part in self._html_body + self._text_body:
-			if body_part.disposition == "inline":
-				attachments.append(
-					{
-						"blob_id": body_part.blob_id,
-						"type": body_part.type,
-						"size": body_part.size,
-						"filename": body_part.filename,
-						"disposition": body_part.disposition,
-						"cid": body_part.cid,
-					}
-				)
-
-		subject = None
-		if self.subject:
-			subject = f"Fwd: {self.subject}" if not self.subject.lower().startswith("fwd:") else self.subject
-
-		return MailQueue._create(
-			user=get_user_for_jmap_account(self.account, raise_exception=True),
-			account=self.account,
-			subject=subject,
-			html_body=forward_html_body,
-			text_body=forward_text_body,
-			attachments=attachments,
-			forwarded_from_id=self.id,
-			do_not_save=True,
-		)
-
-	@frappe.whitelist()
-	def get_mime_message(self) -> str:
-		"""Returns the MIME message content."""
-
-		if not self.blob_id:
-			frappe.throw(_("Mail Message does not have a blob ID."))
-
-		self.clear_cached_properties()
-		return fetch_blob(self.account, self.blob_id).decode("utf-8")
-
-	@frappe.whitelist()
-	def load_attachments(self, include_inline: bool = True, include_regular: bool = True) -> None:
-		"""Load attachments to cache."""
-
-		if not any([self.attachments, self._html_body, self._text_body]):
-			return
-
-		blobs = []
-		for attachment in self.attachments:
-			if (include_inline and attachment.disposition == "inline") or (
-				include_regular and attachment.disposition == "attachment"
-			):
-				blobs.append((attachment.blob_id, attachment.filename))
-
-		if include_inline:
-			for body_part in self._html_body + self._text_body:
-				if body_part.disposition == "inline":
-					blobs.append((body_part.blob_id, body_part.filename))
-
-		fetch_blobs(self.account, blobs)
-
-	def clear_cached_properties(self) -> None:
-		"""Clear cached properties to avoid stale data."""
-
-		for property in [
-			"from_ip",
-			"from_host",
-			"spam_score",
-			"parsed_message",
-			"authentication_results",
-		]:
-			self.__dict__.pop(property, None)
-
-	def _update_or_submit_draft(self, save_as_draft: bool = True) -> "MailQueue":
-		"""Update or submit the draft Mail Message."""
-
-		if not self.draft:
-			frappe.throw(_("Mail Message {0} is not a draft.").format(frappe.bold(self.name)))
-
-		recipients = [
-			{"type": rcpt.type, "display_name": rcpt.display_name, "email": rcpt.email}
-			for rcpt in self.recipients
-		]
-		reply_to = [{"display_name": rt.display_name, "email": rt.email} for rt in self.reply_to]
-		attachments = [
-			{
-				"file_url": a.file_url,
-				"blob_id": a.blob_id,
-				"type": a.type,
-				"size": a.size,
-				"filename": a.filename,
-				"disposition": a.disposition,
-				"cid": a.cid,
-			}
-			for a in self.attachments
-		]
-
-		return MailQueue._create(
-			user=get_user_for_jmap_account(self.account, raise_exception=True),
-			account=self.account,
-			from_name=self.from_name,
-			from_email=self.from_email,
-			subject=self.subject,
-			reply_to=reply_to,
-			recipients=recipients,
-			attachments=attachments,
-			html_body=self.html_body,
-			text_body=self.text_body,
-			message_id=self.message_id,
-			id=self.id,
-			in_reply_to=self.in_reply_to,
-			save_as_draft=save_as_draft,
-			delivery_mode="Immediate",
-		)
-
-	def _reply(self, recipients: list[dict]) -> "MailQueue":
-		"""Returns a unsaved MailQueue object for replying to the Mail Message."""
-
-		self.validate_draft()
-
-		subject = None
-		if self.subject:
-			subject = f"Re: {self.subject}" if not self.subject.lower().startswith("re:") else self.subject
-
-		return MailQueue._create(
-			user=get_user_for_jmap_account(self.account, raise_exception=True),
-			account=self.account,
-			subject=subject,
-			recipients=recipients,
-			in_reply_to=self.message_id,
-			in_reply_to_id=self.id,
-			do_not_save=True,
-		)
-
-	def _get_recipients(self, type: Literal["To", "Cc", "Bcc"] | None = None) -> list[dict[str, str | None]]:
-		"""Returns the recipients."""
-
-		recipients = []
-		for rcpt in self.recipients:
-			if type and rcpt.type != type:
-				continue
-
-			recipients.append({"name": rcpt.display_name, "email": rcpt.email})
-
-		return recipients
+    @cached_property
+    def spam_score(self) -> float:
+        """Returns the spam score of the email."""
+
+        if not self.parsed_message:
+            return 0.0
+
+        if header := self.parsed_message.get_header("X-Spam-Status"):
+            score_pattern = re.compile(r"score=(-?\d+\.?\d*)")
+            score_match = score_pattern.search(header)
+            return float(score_match.group(1)) if score_match else 0.0
+
+    @property
+    def message(self) -> str | None:
+        """Returns the message content if available."""
+
+        cached_blobs = _get_cached_blobs(self.account, [self.blob_id])
+        if content := cached_blobs.get(self.blob_id):
+            return content.decode("utf-8")
+
+    @cached_property
+    def parsed_message(self) -> EmailParser | None:
+        """Returns the parsed Mail Message."""
+
+        if self.message:
+            return EmailParser(self.message)
+
+    @cached_property
+    def authentication_results(self) -> dict[str, int | str]:
+        """Returns the authentication results of the email."""
+
+        if not self.parsed_message:
+            return {}
+
+        return self.parsed_message.get_authentication_results()
+
+    @cached_property
+    def email_type(self) -> str:
+        """Returns the type of email (Sent or Received)."""
+
+        email_type = "Received"
+        account_addresses = get_account_emails(self.account)
+
+        if self.from_email in account_addresses or (
+            hasattr(self, "sender_email") and self.sender_email in account_addresses
+        ):
+            email_type = "Sent"
+
+        return email_type
+
+    def autoname(self) -> None:
+        self.name = f"{self.account}|{uuid7()!s}"
+
+    def db_insert(self, *args, **kwargs) -> None:
+        raise NotImplementedError
+
+    def load_from_db(self) -> "MailMessage":
+        account, id = self.name.split("|")
+        if messages := get_messages(account, ids=[id]):
+            return super(Document, self).__init__(messages[0])
+
+        frappe.throw(_("Message not found or you do not have permission to view it."))
+
+    def db_update(self) -> None:
+        raise NotImplementedError
+
+    def delete(self) -> None:
+        account, id = self.name.split("|")
+        delete_messages(account, [id])
+
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs) -> list:
+        filters = parse_filters(filters)
+
+        id = filters.get("id")
+        account = filters.get("account")
+
+        if not account:
+            frappe.msgprint(_("Please select an account to view messages."), alert=True)
+            return []
+
+        if not get_user_for_jmap_account(account, allow_system_manager=False, raise_exception=False):
+            frappe.msgprint(_("You do not have permission to view messages for this account."), alert=True)
+            return []
+
+        if id:
+            messages = get_messages(account, ids=[id])
+            total = len(messages)
+        else:
+            filter = {
+                prop: value
+                for field, prop in {
+                    "in_mailbox": "inMailbox",
+                    "_from": "from",
+                    "_to": "to",
+                    "_cc": "cc",
+                    "_bcc": "bcc",
+                    "text": "text",
+                    "body": "body",
+                    "subject": "subject",
+                    "min_size": "minSize",
+                    "max_size": "maxSize",
+                    "has_keyword": "hasKeyword",
+                    "not_keyword": "notKeyword",
+                }.items()
+                if (value := filters.get(field))
+            }
+
+            if filters.get("has_attachment"):
+                filter["hasAttachment"] = True
+
+            for field in ("before", "after"):
+                if value := filters.get(field):
+                    filter[field] = to_iso8601_z(convert_to_utc(value))
+
+            limit = cint(kwargs.get("start")) + page_length
+            messages, total = fetch_messages(account, filter, limit=limit)
+
+        frappe.cache.set_value(_get_total_cache_key(account), total, expires_in_sec=600)
+
+        fields_to_remove = [
+            "mailboxes",
+            "reply_to",
+            "recipients",
+            "preview",
+            "html_body",
+            "text_body",
+            "attachments",
+            "keywords",
+            "_html_body",
+            "_text_body",
+        ]
+        for message in messages:
+            for field in fields_to_remove:
+                message.pop(field, None)
+
+        if not messages:
+            frappe.msgprint(_("No messages found."), alert=True)
+
+        return messages
+
+    @staticmethod
+    def get_count(filters=None, **kwargs) -> int:
+        filters = parse_filters(filters)
+        account = filters.get("account")
+
+        if account:
+            if get_user_for_jmap_account(account, allow_system_manager=False, raise_exception=False):
+                return cint(frappe.cache.get_value(_get_total_cache_key(account)))
+
+        return 0
+
+    @staticmethod
+    def get_stats(**kwargs) -> dict:
+        return {}
+
+    def validate_draft(self) -> None:
+        """Raise an exception if the message is a draft."""
+
+        if self.draft:
+            frappe.throw(
+                _("Mail Message {0} is a draft. Please send it before performing this action.").format(
+                    frappe.bold(self.name)
+                )
+            )
+
+    @frappe.whitelist()
+    def save_draft(self) -> "MailQueue":
+        """Save the Mail Message as a draft."""
+
+        return self._update_or_submit_draft(save_as_draft=True)
+
+    @frappe.whitelist()
+    def submit(self) -> "MailQueue":
+        """Submit the draft Mail Message."""
+
+        return self._update_or_submit_draft(save_as_draft=False)
+
+    @frappe.whitelist()
+    def move_to_mailbox(self, mailbox_id: str) -> None:
+        """Move the Mail Message to a specified mailbox."""
+
+        self.validate_draft()
+        move_messages_to_mailbox(self.account, [self.id], mailbox_id)
+        self.reload()
+
+    @frappe.whitelist()
+    def add_to_mailbox(self, mailbox_id: str) -> None:
+        """Add the Mail Message to a specified mailbox."""
+
+        self.validate_draft()
+        add_messages_to_mailbox(self.account, [self.id], mailbox_id)
+        self.reload()
+
+    @frappe.whitelist()
+    def remove_from_mailbox(self, mailbox_id: str) -> None:
+        """Remove the Mail Message from a specified mailbox."""
+
+        self.validate_draft()
+        remove_messages_from_mailbox(self.account, [self.id], mailbox_id)
+        self.reload()
+
+    @frappe.whitelist()
+    def set_seen(self, seen: bool) -> None:
+        """Set the Mail Message as seen or unseen."""
+
+        set_seen_status(self.account, [self.id], seen)
+        self.reload()
+
+    @frappe.whitelist()
+    def set_flagged(self, flagged: bool) -> None:
+        """Set the Mail Message as flagged or unflagged."""
+
+        set_flagged_status(self.account, [self.id], flagged)
+        self.reload()
+
+    @frappe.whitelist()
+    def reply(self) -> "MailQueue":
+        """Reply to the Mail Message."""
+
+        recipients = []
+
+        if self.email_type == "Sent":
+            # To = original To
+            for rcpt in self.recipients:
+                if rcpt.type == "To":
+                    recipients.append(
+                        {"type": rcpt.type, "display_name": rcpt.display_name, "email": rcpt.email}
+                    )
+
+        elif self.email_type == "Received":
+            # To = Reply-To if present, else From
+            if self.reply_to:
+                recipients.extend(
+                    {"type": "To", "display_name": rt.display_name, "email": rt.email} for rt in self.reply_to
+                )
+            else:
+                recipients.append({"type": "To", "display_name": self.from_name, "email": self.from_email})
+
+        return self._reply(recipients)
+
+    @frappe.whitelist()
+    def reply_all(self) -> "MailQueue":
+        """Reply to all recipients of the Mail Message."""
+
+        recipients = []
+
+        if self.email_type == "Sent":
+            # To = original To
+            # Cc = original Cc
+            for rcpt in self.recipients:
+                if rcpt.type in ["To", "Cc"]:
+                    recipients.append(
+                        {"type": rcpt.type, "display_name": rcpt.display_name, "email": rcpt.email}
+                    )
+
+        elif self.email_type == "Received":
+            # To = Reply-To if present, else From
+            if self.reply_to:
+                recipients.extend(
+                    {"type": "To", "display_name": rt.display_name, "email": rt.email} for rt in self.reply_to
+                )
+            else:
+                recipients.append({"type": "To", "display_name": self.from_name, "email": self.from_email})
+
+            # Cc = (original To + original Cc) minus account addresses
+            account_addresses = get_account_emails(self.account)
+            for rcpt in self.recipients:
+                if rcpt.type in ["To", "Cc"] and rcpt.email not in account_addresses:
+                    recipients.append({"type": "Cc", "display_name": rcpt.display_name, "email": rcpt.email})
+
+        return self._reply(recipients)
+
+    @frappe.whitelist()
+    def forward(self) -> "MailQueue":
+        """Forward the Mail Message."""
+
+        self.validate_draft()
+
+        formatted_sent_at = get_datetime(self.sent_at).strftime("%a, %B %-d, %Y at %-I:%M %p")
+        forward_html_body = (
+            "<p>---------- Forwarded message ---------</p>"
+            '<table border="0" cellpadding="0" cellspacing="10">'
+            f"<tr><td><b>From:</b></td><td>{escape_html(formataddr([self.from_name, self.from_email]))}</td></tr>"
+            f"<tr><td><b>Date:</b></td><td>{formatted_sent_at}</td></tr>"
+            f"<tr><td><b>Subject:</b></td><td>{escape_html(self.subject or '')}</td></tr>"
+        )
+        forward_text_body = (
+            "---------- Forwarded message ---------\n"
+            f"From: {formataddr([self.from_name, self.from_email])}\n"
+            f"Date: {formatted_sent_at}\n"
+            f"Subject: {self.subject or ''}\n"
+        )
+
+        if to := ", ".join(
+            [formataddr([rcpt["name"], rcpt["email"]]) for rcpt in self._get_recipients("To")]
+        ):
+            forward_html_body += f"<tr><td><b>To:</b></td><td>{escape_html(to)}</td></tr>"
+            forward_text_body += f"To: {to}\n"
+        if cc := ", ".join(
+            [formataddr([rcpt["name"], rcpt["email"]]) for rcpt in self._get_recipients("Cc")]
+        ):
+            forward_html_body += f"<tr><td><b>Cc:</b></td><td>{escape_html(cc)}</td></tr>"
+            forward_text_body += f"Cc: {cc}\n"
+
+        original_html_body = self.html_body or ""
+        original_text_body = self.text_body or ""
+
+        quoted_html_body = f'<blockquote style="border-left:2px solid #ccc; margin-left:0; padding-left:1em;">{original_html_body}</blockquote>'
+        quoted_text_body = "\n> ".join(original_text_body.strip().splitlines())
+
+        forward_html_body += f"</table><br/> {quoted_html_body}"
+        forward_html_body = BeautifulSoup(forward_html_body, "html.parser").prettify()
+        forward_text_body += f"\n\n> {quoted_text_body}"
+
+        attachments = [
+            {
+                "file_url": a.file_url,
+                "blob_id": a.blob_id,
+                "type": a.type,
+                "size": a.size,
+                "filename": a.filename,
+                "disposition": a.disposition,
+                "cid": a.cid,
+            }
+            for a in self.attachments
+        ]
+
+        for body_part in self._html_body + self._text_body:
+            if body_part.disposition == "inline":
+                attachments.append(
+                    {
+                        "blob_id": body_part.blob_id,
+                        "type": body_part.type,
+                        "size": body_part.size,
+                        "filename": body_part.filename,
+                        "disposition": body_part.disposition,
+                        "cid": body_part.cid,
+                    }
+                )
+
+        subject = None
+        if self.subject:
+            subject = f"Fwd: {self.subject}" if not self.subject.lower().startswith("fwd:") else self.subject
+
+        return MailQueue._create(
+            user=get_user_for_jmap_account(self.account, raise_exception=True),
+            account=self.account,
+            subject=subject,
+            html_body=forward_html_body,
+            text_body=forward_text_body,
+            attachments=attachments,
+            forwarded_from_id=self.id,
+            do_not_save=True,
+        )
+
+    @frappe.whitelist()
+    def get_mime_message(self) -> str:
+        """Returns the MIME message content."""
+
+        if not self.blob_id:
+            frappe.throw(_("Mail Message does not have a blob ID."))
+
+        self.clear_cached_properties()
+        return fetch_blob(self.account, self.blob_id).decode("utf-8")
+
+    @frappe.whitelist()
+    def load_attachments(self, include_inline: bool = True, include_regular: bool = True) -> None:
+        """Load attachments to cache."""
+
+        if not any([self.attachments, self._html_body, self._text_body]):
+            return
+
+        blobs = []
+        for attachment in self.attachments:
+            if (include_inline and attachment.disposition == "inline") or (
+                include_regular and attachment.disposition == "attachment"
+            ):
+                blobs.append((attachment.blob_id, attachment.filename))
+
+        if include_inline:
+            for body_part in self._html_body + self._text_body:
+                if body_part.disposition == "inline":
+                    blobs.append((body_part.blob_id, body_part.filename))
+
+        fetch_blobs(self.account, blobs)
+
+    def clear_cached_properties(self) -> None:
+        """Clear cached properties to avoid stale data."""
+
+        for property in [
+            "from_ip",
+            "from_host",
+            "spam_score",
+            "parsed_message",
+            "authentication_results",
+        ]:
+            self.__dict__.pop(property, None)
+
+    def _update_or_submit_draft(self, save_as_draft: bool = True) -> "MailQueue":
+        """Update or submit the draft Mail Message."""
+
+        if not self.draft:
+            frappe.throw(_("Mail Message {0} is not a draft.").format(frappe.bold(self.name)))
+
+        recipients = [
+            {"type": rcpt.type, "display_name": rcpt.display_name, "email": rcpt.email}
+            for rcpt in self.recipients
+        ]
+        reply_to = [{"display_name": rt.display_name, "email": rt.email} for rt in self.reply_to]
+        attachments = [
+            {
+                "file_url": a.file_url,
+                "blob_id": a.blob_id,
+                "type": a.type,
+                "size": a.size,
+                "filename": a.filename,
+                "disposition": a.disposition,
+                "cid": a.cid,
+            }
+            for a in self.attachments
+        ]
+
+        return MailQueue._create(
+            user=get_user_for_jmap_account(self.account, raise_exception=True),
+            account=self.account,
+            from_name=self.from_name,
+            from_email=self.from_email,
+            subject=self.subject,
+            reply_to=reply_to,
+            recipients=recipients,
+            attachments=attachments,
+            html_body=self.html_body,
+            text_body=self.text_body,
+            message_id=self.message_id,
+            id=self.id,
+            in_reply_to=self.in_reply_to,
+            save_as_draft=save_as_draft,
+            delivery_mode="Immediate",
+        )
+
+    def _reply(self, recipients: list[dict]) -> "MailQueue":
+        """Returns a unsaved MailQueue object for replying to the Mail Message."""
+
+        self.validate_draft()
+
+        subject = None
+        if self.subject:
+            subject = f"Re: {self.subject}" if not self.subject.lower().startswith("re:") else self.subject
+
+        return MailQueue._create(
+            user=get_user_for_jmap_account(self.account, raise_exception=True),
+            account=self.account,
+            subject=subject,
+            recipients=recipients,
+            in_reply_to=self.message_id,
+            in_reply_to_id=self.id,
+            do_not_save=True,
+        )
+
+    def _get_recipients(self, type: Literal["To", "Cc", "Bcc"] | None = None) -> list[dict[str, str | None]]:
+        """Returns the recipients."""
+
+        recipients = []
+        for rcpt in self.recipients:
+            if type and rcpt.type != type:
+                continue
+
+            recipients.append({"name": rcpt.display_name, "email": rcpt.email})
+
+        return recipients
 
 
 @frappe.whitelist()
 def bulk_delete(names: str | list[str]) -> None:
-	"""Delete multiple Mail Messages based on their names."""
+    """Delete multiple Mail Messages based on their names."""
 
-	if isinstance(names, str):
-		names = json.loads(names)
+    if isinstance(names, str):
+        names = json.loads(names)
 
-	accounts_map = {}
-	for name in names:
-		account, id = name.split("|")
-		accounts_map.setdefault(account, []).append(id)
+    accounts_map = {}
+    for name in names:
+        account, id = name.split("|")
+        accounts_map.setdefault(account, []).append(id)
 
-	for account, ids in accounts_map.items():
-		delete_messages(account, ids)
+    for account, ids in accounts_map.items():
+        delete_messages(account, ids)
 
-	frappe.msgprint(_("Mail Messages deleted successfully."), alert=True)
+    frappe.msgprint(_("Mail Messages deleted successfully."), alert=True)
 
 
 @frappe.whitelist()
 def reply(source_name: str, target_doc=None) -> "MailQueue":
-	"""Reply to the Mail Message."""
+    """Reply to the Mail Message."""
 
-	source_doc = frappe.get_doc("Mail Message", source_name)
-	return source_doc.reply()
+    source_doc = frappe.get_doc("Mail Message", source_name)
+    return source_doc.reply()
 
 
 @frappe.whitelist()
 def reply_all(source_name: str, target_doc=None) -> "MailQueue":
-	"""Reply to all recipients of the Mail Message."""
+    """Reply to all recipients of the Mail Message."""
 
-	source_doc = frappe.get_doc("Mail Message", source_name)
-	return source_doc.reply_all()
+    source_doc = frappe.get_doc("Mail Message", source_name)
+    return source_doc.reply_all()
 
 
 @frappe.whitelist()
 def forward(source_name: str, target_doc=None) -> "MailQueue":
-	"""Forward the Mail Message."""
+    """Forward the Mail Message."""
 
-	source_doc = frappe.get_doc("Mail Message", source_name)
-	return source_doc.forward()
+    source_doc = frappe.get_doc("Mail Message", source_name)
+    return source_doc.forward()
 
 
 def fetch_messages(
-	account: str,
-	filter: dict | None = None,
-	position: int = 0,
-	limit: int = 50,
-	sort: list[dict] | None = None,
+    account: str,
+    filter: dict | None = None,
+    position: int = 0,
+    limit: int = 50,
+    sort: list[dict] | None = None,
 ) -> tuple[list[dict], int]:
-	"""Returns a list of messages and total count based on the provided filter."""
+    """Returns a list of messages and total count based on the provided filter."""
 
-	messages = []
-	service = get_email_service(account)
-	data = service.query(filter, position, limit, sort)
+    messages = []
+    service = get_email_service(account)
+    data = service.query(filter, position, limit, sort)
 
-	ids = data.get("ids", [])
-	total = data.get("total", 0)
+    ids = data.get("ids", [])
+    total = data.get("total", 0)
 
-	messages.extend(get_messages(account, ids=ids))
+    messages.extend(get_messages(account, ids=ids))
 
-	return messages[:limit], total
+    return messages[:limit], total
 
 
 def fetch_threads(
-	account: str, filter: dict | None = None, position: int = 0, limit: int = 50
+    account: str, filter: dict | None = None, position: int = 0, limit: int = 50
 ) -> dict[str, list[dict]]:
-	"""Returns a page of threads matching the filter.
+    """Returns a page of threads matching the filter.
 
-	Each thread ID is mapped to the full list of messages in that thread (the entire conversation
-	across all mailboxes), ordered oldest to newest.
-	"""
+    Each thread ID is mapped to the full list of messages in that thread (the entire conversation
+    across all mailboxes), ordered oldest to newest.
+    """
 
-	service = get_email_service(account)
-	thread_email_ids = service.query_thread(filter, position, limit, fetch_all=True)
-	if not thread_email_ids:
-		return {}
+    service = get_email_service(account)
+    thread_email_ids = service.query_thread(filter, position, limit, fetch_all=True)
+    if not thread_email_ids:
+        return {}
 
-	# Fetch every message in the page's threads once, then group them back by thread.
-	threads: dict[str, list[dict]] = {thread_id: [] for thread_id in thread_email_ids}
-	email_ids = [email_id for ids in thread_email_ids.values() for email_id in ids]
-	for message in get_messages(account, email_ids):
-		if message["thread_id"] in threads:
-			threads[message["thread_id"]].append(message)
+    # Fetch every message in the page's threads once, then group them back by thread.
+    threads: dict[str, list[dict]] = {thread_id: [] for thread_id in thread_email_ids}
+    email_ids = [email_id for ids in thread_email_ids.values() for email_id in ids]
+    for message in get_messages(account, email_ids):
+        if message["thread_id"] in threads:
+            threads[message["thread_id"]].append(message)
 
-	# Order each conversation oldest to newest so callers don't have to re-sort.
-	return {
-		thread_id: sorted(messages, key=lambda message: message["received_at"])
-		for thread_id, messages in threads.items()
-	}
+    # Order each conversation oldest to newest so callers don't have to re-sort.
+    return {
+        thread_id: sorted(messages, key=lambda message: message["received_at"])
+        for thread_id, messages in threads.items()
+    }
 
 
 def fetch_thread(account: str, thread_id: str, sort: Literal["asc", "desc"] = "asc") -> list[dict]:
-	"""Returns a list of messages in a thread based on the provided thread ID."""
+    """Returns a list of messages in a thread based on the provided thread ID."""
 
-	service = get_thread_service(account)
-	result = service.get([thread_id])
-	ids = result.get(thread_id, [])
-	messages = get_messages(account, ids=ids)
+    service = get_thread_service(account)
+    result = service.get([thread_id])
+    ids = result.get(thread_id, [])
+    messages = get_messages(account, ids=ids)
 
-	return sorted(messages, key=lambda m: m["received_at"], reverse=(sort == "desc"))
+    return sorted(messages, key=lambda m: m["received_at"], reverse=(sort == "desc"))
 
 
 def search_messages(
-	account: str, filter: dict, position: int = 0, limit: int = 20, sort: list[dict] | None = None
+    account: str, filter: dict, position: int = 0, limit: int = 20, sort: list[dict] | None = None
 ) -> tuple[list[dict], int]:
-	"""Returns a list of messages and total count based on the provided search filter."""
+    """Returns a list of messages and total count based on the provided search filter."""
 
-	if not account or not filter:
-		frappe.throw(_("Account and filter are required."))
+    if not account or not filter:
+        frappe.throw(_("Account and filter are required."))
 
-	fields = [
-		"name",
-		"id",
-		"subject",
-		"preview",
-		"recipients",
-		"sent_at",
-		"received_at",
-		"from_name",
-		"from_email",
-		"thread_id",
-		"mailboxes",
-		"attachments",
-		"seen",
-	]
+    fields = [
+        "name",
+        "id",
+        "subject",
+        "preview",
+        "recipients",
+        "sent_at",
+        "received_at",
+        "from_name",
+        "from_email",
+        "thread_id",
+        "mailboxes",
+        "attachments",
+        "seen",
+    ]
 
-	messages, total = fetch_messages(account, filter=filter, position=position, limit=limit, sort=sort)
-	return [{field: message[field] for field in fields} for message in messages], total
+    messages, total = fetch_messages(account, filter=filter, position=position, limit=limit, sort=sort)
+    return [{field: message[field] for field in fields} for message in messages], total
 
 
 def get_messages(account: str, ids: list[str]) -> list[dict]:
-	"""Returns a list of messages for the provided IDs in the same order as ids."""
+    """Returns a list of messages for the provided IDs in the same order as ids."""
 
-	get_user_for_jmap_account(account, allow_system_manager=False, raise_exception=True)
+    get_user_for_jmap_account(account, allow_system_manager=False, raise_exception=True)
 
-	cached_messages = _get_cached_messages(account, ids)
+    cached_messages = _get_cached_messages(account, ids)
 
-	messages = {}
-	ids_to_fetch = []
-	for id in ids:
-		if cached_message := cached_messages.get(id):
-			messages[id] = cached_message
-		else:
-			ids_to_fetch.append(id)
+    messages = {}
+    ids_to_fetch = []
+    for id in ids:
+        if cached_message := cached_messages.get(id):
+            messages[id] = cached_message
+        else:
+            ids_to_fetch.append(id)
 
-	if ids_to_fetch:
-		service = get_email_service(account)
-		emails = service.get(ids_to_fetch)
-		mailbox_map = {mb["id"]: mb["name"] for mb in service.mailboxes}
+    if ids_to_fetch:
+        service = get_email_service(account)
+        emails = service.get(ids_to_fetch)
+        mailbox_map = {mb["id"]: mb["name"] for mb in service.mailboxes}
 
-		messages_to_cache = {}
-		for email in emails:
-			message = format_message(account, mailbox_map, email)
-			messages_to_cache[message["id"]] = message
-			messages[message["id"]] = message
+        messages_to_cache = {}
+        for email in emails:
+            message = format_message(account, mailbox_map, email)
+            messages_to_cache[message["id"]] = message
+            messages[message["id"]] = message
 
-		if messages_to_cache:
-			_cache_messages(account, messages_to_cache)
+        if messages_to_cache:
+            _cache_messages(account, messages_to_cache)
 
-	return [messages[id] for id in ids if id in messages]
+    return [messages[id] for id in ids if id in messages]
 
 
 def get_message_ids(
-	account: str, thread_ids: list[str], mailbox_id: str | list[str] | None = None
+    account: str, thread_ids: list[str], mailbox_id: str | list[str] | None = None
 ) -> list[str]:
-	"""Returns the message IDs for the given threads."""
+    """Returns the message IDs for the given threads."""
 
-	if not account or not thread_ids:
-		frappe.throw(_("Account and Thread IDs are required."))
+    if not account or not thread_ids:
+        frappe.throw(_("Account and Thread IDs are required."))
 
-	try:
-		thread_service = get_thread_service(account)
-		result = thread_service.get(thread_ids)
-		ids = [id for _thread_id, ids in result.items() for id in ids]
+    try:
+        thread_service = get_thread_service(account)
+        result = thread_service.get(thread_ids)
+        ids = [id for _thread_id, ids in result.items() for id in ids]
 
-		if not mailbox_id:
-			return ids
+        if not mailbox_id:
+            return ids
 
-		email_service = get_email_service(account)
-		emails = email_service.get(ids, properties=["id", "mailboxIds"])
-		if isinstance(mailbox_id, str):
-			return [email["id"] for email in emails if mailbox_id in email["mailboxIds"]]
-		else:
-			return [email["id"] for email in emails if not set(mailbox_id).isdisjoint(email["mailboxIds"])]
+        email_service = get_email_service(account)
+        emails = email_service.get(ids, properties=["id", "mailboxIds"])
+        if isinstance(mailbox_id, str):
+            return [email["id"] for email in emails if mailbox_id in email["mailboxIds"]]
+        else:
+            return [email["id"] for email in emails if not set(mailbox_id).isdisjoint(email["mailboxIds"])]
 
-	except Exception:
-		log_mail_error(_("Failed to fetch message IDs."), frappe.get_traceback(with_context=True))
-		frappe.throw(_("Failed to fetch message IDs."))
+    except Exception:
+        log_mail_error(_("Failed to fetch message IDs."), frappe.get_traceback(with_context=True))
+        frappe.throw(_("Failed to fetch message IDs."))
 
 
 def delete_messages(account: str, ids: list[str]) -> None:
-	"""Delete messages from the server and remove them from the cache."""
+    """Delete messages from the server and remove them from the cache."""
 
-	if not account or not ids:
-		frappe.throw(_("Account and Mail IDs are required."))
+    if not account or not ids:
+        frappe.throw(_("Account and Mail IDs are required."))
 
-	try:
-		service = get_email_service(account)
-		service.delete(ids)
-		_remove_cached_messages(account, ids)
-	except Exception:
-		log_mail_error(
-			_("Failed to delete mail(s)"),
-			frappe.get_traceback(with_context=True),
-		)
-		frappe.throw(_("Failed to delete mail(s)."))
+    try:
+        service = get_email_service(account)
+        service.delete(ids)
+        _remove_cached_messages(account, ids)
+    except Exception:
+        log_mail_error(
+            _("Failed to delete mail(s)"),
+            frappe.get_traceback(with_context=True),
+        )
+        frappe.throw(_("Failed to delete mail(s)."))
 
 
 def empty_mailbox(account: str, mailbox_id: str) -> None:
-	"""Empty the specified mailbox by deleting all messages in it."""
+    """Empty the specified mailbox by deleting all messages in it."""
 
-	if not account or not mailbox_id:
-		frappe.throw(_("Account and Mailbox ID are required."))
+    if not account or not mailbox_id:
+        frappe.throw(_("Account and Mailbox ID are required."))
 
-	try:
-		service = get_email_service(account)
+    try:
+        service = get_email_service(account)
 
-		while True:
-			result = service.query({"inMailbox": mailbox_id}, position=0, limit=service.max_objects_in_get)
+        while True:
+            result = service.query({"inMailbox": mailbox_id}, position=0, limit=service.max_objects_in_get)
 
-			ids = result["ids"]
-			if not ids:
-				break
+            ids = result["ids"]
+            if not ids:
+                break
 
-			service.delete(ids)
-			_remove_cached_messages(account, ids)
-	except Exception:
-		log_mail_error(
-			_("Failed to empty mailbox"),
-			frappe.get_traceback(with_context=True),
-		)
-		frappe.throw(_("Failed to empty mailbox."))
+            service.delete(ids)
+            _remove_cached_messages(account, ids)
+    except Exception:
+        log_mail_error(
+            _("Failed to empty mailbox"),
+            frappe.get_traceback(with_context=True),
+        )
+        frappe.throw(_("Failed to empty mailbox."))
 
 
 def move_messages_to_mailbox(account: str, ids: list[str], mailbox_id: str) -> None:
-	"""Move messages to a different mailbox."""
+    """Move messages to a different mailbox."""
 
-	if not account or not ids or not mailbox_id:
-		frappe.throw(_("Accounts, Mail IDs, and Mailbox ID are required."))
+    if not account or not ids or not mailbox_id:
+        frappe.throw(_("Accounts, Mail IDs, and Mailbox ID are required."))
 
-	try:
-		emails = [{"id": id, "mailbox_ids": {mailbox_id: True}} for id in ids]
-		service = get_email_service(account)
-		service.update(emails, replace_mailboxes=True)
-		_remove_cached_messages(account, ids)
-	except Exception:
-		log_mail_error(
-			_("Failed to move mail(s) to mailbox"),
-			frappe.get_traceback(with_context=True),
-		)
-		frappe.throw(_("Failed to move mail(s) to mailbox."))
+    try:
+        emails = [{"id": id, "mailbox_ids": {mailbox_id: True}} for id in ids]
+        service = get_email_service(account)
+        service.update(emails, replace_mailboxes=True)
+        _remove_cached_messages(account, ids)
+    except Exception:
+        log_mail_error(
+            _("Failed to move mail(s) to mailbox"),
+            frappe.get_traceback(with_context=True),
+        )
+        frappe.throw(_("Failed to move mail(s) to mailbox."))
 
 
 def set_messages_mailboxes(account: str, mails: list[dict]) -> None:
-	"""Restore each message to an exact mailbox membership and junk status (used to undo a move)."""
+    """Restore each message to an exact mailbox membership and junk status (used to undo a move)."""
 
-	if not account or not mails:
-		frappe.throw(_("Account and Mails are required."))
+    if not account or not mails:
+        frappe.throw(_("Account and Mails are required."))
 
-	try:
-		emails = []
-		for mail in mails:
-			junk = bool(mail.get("junk"))
-			emails.append(
-				{
-					"id": mail["id"],
-					"mailbox_ids": {mailbox_id: True for mailbox_id in mail["mailbox_ids"]},
-					"keywords": {"$junk": junk, "$notjunk": not junk},
-				}
-			)
-		service = get_email_service(account)
-		service.update(emails, replace_keywords=False, replace_mailboxes=True)
-		_remove_cached_messages(account, [mail["id"] for mail in mails])
-	except Exception:
-		log_mail_error(
-			_("Failed to restore mailbox membership for mail(s)"),
-			frappe.get_traceback(with_context=True),
-		)
-		frappe.throw(_("Failed to restore mailbox membership for mail(s)."))
+    try:
+        emails = []
+        for mail in mails:
+            junk = bool(mail.get("junk"))
+            emails.append(
+                {
+                    "id": mail["id"],
+                    "mailbox_ids": {mailbox_id: True for mailbox_id in mail["mailbox_ids"]},
+                    "keywords": {"$junk": junk, "$notjunk": not junk},
+                }
+            )
+        service = get_email_service(account)
+        service.update(emails, replace_keywords=False, replace_mailboxes=True)
+        _remove_cached_messages(account, [mail["id"] for mail in mails])
+    except Exception:
+        log_mail_error(
+            _("Failed to restore mailbox membership for mail(s)"),
+            frappe.get_traceback(with_context=True),
+        )
+        frappe.throw(_("Failed to restore mailbox membership for mail(s)."))
 
 
 def add_messages_to_mailbox(account: str, ids: list[str], mailbox_id: str) -> None:
-	"""Add messages to a mailbox without removing them from existing mailboxes."""
+    """Add messages to a mailbox without removing them from existing mailboxes."""
 
-	if not account or not ids or not mailbox_id:
-		frappe.throw(_("Accounts, Mail IDs, and Mailbox ID are required."))
+    if not account or not ids or not mailbox_id:
+        frappe.throw(_("Accounts, Mail IDs, and Mailbox ID are required."))
 
-	try:
-		emails = [{"id": id, "mailbox_ids": {mailbox_id: True}} for id in ids]
-		service = get_email_service(account)
-		service.update(emails, replace_mailboxes=False)
-		_remove_cached_messages(account, ids)
-	except Exception:
-		log_mail_error(
-			_("Failed to add mail(s) to mailbox"),
-			frappe.get_traceback(with_context=True),
-		)
-		frappe.throw(_("Failed to add mail(s) to mailbox."))
+    try:
+        emails = [{"id": id, "mailbox_ids": {mailbox_id: True}} for id in ids]
+        service = get_email_service(account)
+        service.update(emails, replace_mailboxes=False)
+        _remove_cached_messages(account, ids)
+    except Exception:
+        log_mail_error(
+            _("Failed to add mail(s) to mailbox"),
+            frappe.get_traceback(with_context=True),
+        )
+        frappe.throw(_("Failed to add mail(s) to mailbox."))
 
 
 def remove_messages_from_mailbox(account: str, ids: list[str], mailbox_id: str) -> None:
-	"""Remove messages from a mailbox without deleting them."""
+    """Remove messages from a mailbox without deleting them."""
 
-	if not account or not ids or not mailbox_id:
-		frappe.throw(_("Accounts, Mail IDs, and Mailbox ID are required."))
+    if not account or not ids or not mailbox_id:
+        frappe.throw(_("Accounts, Mail IDs, and Mailbox ID are required."))
 
-	try:
-		emails = [{"id": id, "mailbox_ids": {mailbox_id: False}} for id in ids]
-		service = get_email_service(account)
-		service.update(emails, replace_mailboxes=False)
-		_remove_cached_messages(account, ids)
-	except Exception:
-		log_mail_error(
-			_("Failed to remove mail(s) from mailbox"),
-			frappe.get_traceback(with_context=True),
-		)
-		frappe.throw(_("Failed to remove mail(s) from mailbox."))
+    try:
+        emails = [{"id": id, "mailbox_ids": {mailbox_id: False}} for id in ids]
+        service = get_email_service(account)
+        service.update(emails, replace_mailboxes=False)
+        _remove_cached_messages(account, ids)
+    except Exception:
+        log_mail_error(
+            _("Failed to remove mail(s) from mailbox"),
+            frappe.get_traceback(with_context=True),
+        )
+        frappe.throw(_("Failed to remove mail(s) from mailbox."))
 
 
 def set_seen_status(account: str, ids: list[str], seen: bool = True) -> None:
-	"""Set the seen status for messages."""
+    """Set the seen status for messages."""
 
-	if not account or not ids:
-		frappe.throw(_("Account and Mail IDs are required."))
+    if not account or not ids:
+        frappe.throw(_("Account and Mail IDs are required."))
 
-	try:
-		emails = [{"id": id, "keywords": {"$seen": seen}} for id in ids]
-		service = get_email_service(account)
-		service.update(emails, replace_keywords=False)
+    try:
+        emails = [{"id": id, "keywords": {"$seen": seen}} for id in ids]
+        service = get_email_service(account)
+        service.update(emails, replace_keywords=False)
 
-		messages_to_cache = {}
-		for message_id, message in _get_cached_messages(account, ids).items():
-			if message:
-				keywords = json.loads(message["keywords"])
-				keywords["$seen"] = bool(seen)
+        messages_to_cache = {}
+        for message_id, message in _get_cached_messages(account, ids).items():
+            if message:
+                keywords = json.loads(message["keywords"])
+                keywords["$seen"] = bool(seen)
 
-				message["seen"] = cint(seen)
-				message["keywords"] = json.dumps(keywords, indent=4)
+                message["seen"] = cint(seen)
+                message["keywords"] = json.dumps(keywords, indent=4)
 
-				messages_to_cache[message_id] = message
+                messages_to_cache[message_id] = message
 
-		if messages_to_cache:
-			_cache_messages(account, messages_to_cache)
+        if messages_to_cache:
+            _cache_messages(account, messages_to_cache)
 
-	except Exception:
-		log_mail_error(
-			_("Failed to set seen status for mail(s)"),
-			frappe.get_traceback(with_context=True),
-		)
-		frappe.throw(_("Failed to set seen status for mail(s)."))
+    except Exception:
+        log_mail_error(
+            _("Failed to set seen status for mail(s)"),
+            frappe.get_traceback(with_context=True),
+        )
+        frappe.throw(_("Failed to set seen status for mail(s)."))
 
 
 def set_flagged_status(account: str, ids: list[str], flagged: bool = True) -> None:
-	"""Set the flagged status for messages."""
+    """Set the flagged status for messages."""
 
-	if not account or not ids:
-		frappe.throw(_("Account and Mail IDs are required."))
+    if not account or not ids:
+        frappe.throw(_("Account and Mail IDs are required."))
 
-	try:
-		emails = [{"id": id, "keywords": {"$flagged": flagged}} for id in ids]
-		service = get_email_service(account)
-		service.update(emails, replace_keywords=False)
+    try:
+        emails = [{"id": id, "keywords": {"$flagged": flagged}} for id in ids]
+        service = get_email_service(account)
+        service.update(emails, replace_keywords=False)
 
-		messages_to_cache = {}
-		for message_id, message in _get_cached_messages(account, ids).items():
-			if message:
-				keywords = json.loads(message["keywords"])
-				keywords["$flagged"] = bool(flagged)
+        messages_to_cache = {}
+        for message_id, message in _get_cached_messages(account, ids).items():
+            if message:
+                keywords = json.loads(message["keywords"])
+                keywords["$flagged"] = bool(flagged)
 
-				message["flagged"] = cint(flagged)
-				message["keywords"] = json.dumps(keywords, indent=4)
+                message["flagged"] = cint(flagged)
+                message["keywords"] = json.dumps(keywords, indent=4)
 
-				messages_to_cache[message_id] = message
+                messages_to_cache[message_id] = message
 
-		if messages_to_cache:
-			_cache_messages(account, messages_to_cache)
+        if messages_to_cache:
+            _cache_messages(account, messages_to_cache)
 
-	except Exception:
-		log_mail_error(
-			_("Failed to set flagged status for mail(s)"),
-			frappe.get_traceback(with_context=True),
-		)
-		frappe.throw(_("Failed to set flagged status for mail(s)."))
+    except Exception:
+        log_mail_error(
+            _("Failed to set flagged status for mail(s)"),
+            frappe.get_traceback(with_context=True),
+        )
+        frappe.throw(_("Failed to set flagged status for mail(s)."))
 
 
 def set_spam_status(account: str, ids: list[str], spam: bool = True) -> None:
-	"""Set the spam status for messages."""
+    """Set the spam status for messages."""
 
-	if not account or not ids:
-		frappe.throw(_("Account and Mail IDs are required."))
+    if not account or not ids:
+        frappe.throw(_("Account and Mail IDs are required."))
 
-	user = get_user_for_jmap_account(account, allow_system_manager=False, raise_exception=True)
+    user = get_user_for_jmap_account(account, allow_system_manager=False, raise_exception=True)
 
-	try:
-		connection = get_jmap_connection(user)
-		email_service = EmailService(account, connection)
-		mailbox_service = MailboxService(account, connection)
+    try:
+        connection = get_jmap_connection(user)
+        email_service = EmailService(account, connection)
+        mailbox_service = MailboxService(account, connection)
 
-		mailbox_id = mailbox_service.get_mailbox_id_by_role(
-			"junk" if spam else "inbox", create_if_not_exists=True, raise_exception=True
-		)
-		emails = [
-			{"id": id, "mailbox_ids": {mailbox_id: True}, "keywords": {"$junk": spam, "$notjunk": not spam}}
-			for id in ids
-		]
-		email_service.update(emails, replace_keywords=False, replace_mailboxes=True)
+        mailbox_id = mailbox_service.get_mailbox_id_by_role(
+            "junk" if spam else "inbox", create_if_not_exists=True, raise_exception=True
+        )
+        emails = [
+            {"id": id, "mailbox_ids": {mailbox_id: True}, "keywords": {"$junk": spam, "$notjunk": not spam}}
+            for id in ids
+        ]
+        email_service.update(emails, replace_keywords=False, replace_mailboxes=True)
 
-		_remove_cached_messages(account, ids)
-	except Exception:
-		log_mail_error(
-			_("Failed to set spam status for mail(s)"),
-			frappe.get_traceback(with_context=True),
-		)
-		frappe.throw(_("Failed to set spam status for mail(s)."))
+        _remove_cached_messages(account, ids)
+    except Exception:
+        log_mail_error(
+            _("Failed to set spam status for mail(s)"),
+            frappe.get_traceback(with_context=True),
+        )
+        frappe.throw(_("Failed to set spam status for mail(s)."))
 
 
 def fetch_blob(account: str, blob_id: str, name: str | None = None) -> bytes:
-	"""Fetch the content of a blob."""
+    """Fetch the content of a blob."""
 
-	return fetch_blobs(account, [(blob_id, name)])[blob_id]
+    return fetch_blobs(account, [(blob_id, name)])[blob_id]
 
 
 def fetch_blobs(account: str, blobs: list[str] | list[tuple[str, str | None]]) -> dict[str, bytes]:
-	"""Fetch blobs for the provided blob IDs."""
+    """Fetch blobs for the provided blob IDs."""
 
-	if not account:
-		frappe.throw(_("Account is required."))
+    if not account:
+        frappe.throw(_("Account is required."))
 
-	get_user_for_jmap_account(account, allow_system_manager=False, raise_exception=True)
+    get_user_for_jmap_account(account, allow_system_manager=False, raise_exception=True)
 
-	if isinstance(blobs, list) and all(isinstance(b, str) for b in blobs):
-		blobs = [(blob_id, None) for blob_id in blobs]
+    if isinstance(blobs, list) and all(isinstance(b, str) for b in blobs):
+        blobs = [(blob_id, None) for blob_id in blobs]
 
-	cached_blobs = _get_cached_blobs(account, [blob_id for blob_id, _name in blobs])
+    cached_blobs = _get_cached_blobs(account, [blob_id for blob_id, _name in blobs])
 
-	result = {}
-	blobs_to_fetch = []
-	for blob_id, _name in blobs:
-		if cached_content := cached_blobs.get(blob_id):
-			result[blob_id] = cached_content
-		else:
-			blobs_to_fetch.append((blob_id, _name))
+    result = {}
+    blobs_to_fetch = []
+    for blob_id, _name in blobs:
+        if cached_content := cached_blobs.get(blob_id):
+            result[blob_id] = cached_content
+        else:
+            blobs_to_fetch.append((blob_id, _name))
 
-	if not blobs_to_fetch:
-		return result
+    if not blobs_to_fetch:
+        return result
 
-	try:
-		service = get_email_service(account)
-		fetched_blobs = service.download_blobs_concurrently(blobs_to_fetch)
+    try:
+        service = get_email_service(account)
+        fetched_blobs = service.download_blobs_concurrently(blobs_to_fetch)
 
-		blobs_to_cache = {}
-		for blob_id, content in fetched_blobs.items():
-			blobs_to_cache[blob_id] = content
-			result[blob_id] = content
+        blobs_to_cache = {}
+        for blob_id, content in fetched_blobs.items():
+            blobs_to_cache[blob_id] = content
+            result[blob_id] = content
 
-		if blobs_to_cache:
-			_cache_blobs(account, blobs_to_cache)
+        if blobs_to_cache:
+            _cache_blobs(account, blobs_to_cache)
 
-		return result
-	except Exception:
-		log_mail_error(
-			_("Failed to fetch blob(s)"),
-			frappe.get_traceback(with_context=True),
-		)
-		frappe.throw(_("Failed to fetch blob(s)."))
+        return result
+    except Exception:
+        log_mail_error(
+            _("Failed to fetch blob(s)"),
+            frappe.get_traceback(with_context=True),
+        )
+        frappe.throw(_("Failed to fetch blob(s)."))
 
 
 def format_message(account: str, mailbox_map: dict, message: dict) -> dict:
-	"""Returns a formatted message dictionary for the provided message data."""
+    """Returns a formatted message dictionary for the provided message data."""
 
-	def convert_img_src_from_cid_to_url(html_body: str, cid: str, url: str) -> str:
-		"""Convert img src from cid to URL in the HTML body."""
+    def convert_img_src_from_cid_to_url(html_body: str, cid: str, url: str) -> str:
+        """Convert img src from cid to URL in the HTML body."""
 
-		soup = BeautifulSoup(html_body, "html.parser")
-		for img in soup.find_all("img", src=f"cid:{cid}"):
-			img["data-cid"] = cid
-			img["src"] = url
+        soup = BeautifulSoup(html_body, "html.parser")
+        for img in soup.find_all("img", src=f"cid:{cid}"):
+            img["data-cid"] = cid
+            img["src"] = url
 
-		return str(soup)
+        return str(soup)
 
-	# Ref: https://github.com/stalwartlabs/stalwart/discussions/2891
-	try:
-		received_at = parse_iso_datetime(message["receivedAt"])
-	except Exception:
-		message["receivedAt"] = message["sentAt"] or to_iso8601_z(get_datetime())
-		received_at = parse_iso_datetime(message["receivedAt"])
+    # Ref: https://github.com/stalwartlabs/stalwart/discussions/2891
+    try:
+        received_at = parse_iso_datetime(message["receivedAt"])
+    except Exception:
+        message["receivedAt"] = message["sentAt"] or to_iso8601_z(get_datetime())
+        received_at = parse_iso_datetime(message["receivedAt"])
 
-	if not message["sentAt"]:
-		message["sentAt"] = message["receivedAt"]
+    if not message["sentAt"]:
+        message["sentAt"] = message["receivedAt"]
 
-	sent_at = parse_iso_datetime(message["sentAt"])
-	formatted_message = {
-		"account": account,
-		"sent_at": sent_at,
-		"creation": sent_at,
-		"id": message["id"],
-		"size": message["size"],
-		"modified": received_at,
-		"received_at": received_at,
-		"blob_id": message["blobId"],
-		"subject": message["subject"],
-		"thread_id": message["threadId"],
-		"name": f"{account}|{message['id']}",
-		"has_attachment": cint(message["hasAttachment"]),
-		"keywords": json.dumps(message["keywords"], indent=4),
-		"received_after": time_diff_in_seconds(received_at, sent_at),
-	}
+    sent_at = parse_iso_datetime(message["sentAt"])
+    formatted_message = {
+        "account": account,
+        "sent_at": sent_at,
+        "creation": sent_at,
+        "id": message["id"],
+        "size": message["size"],
+        "modified": received_at,
+        "received_at": received_at,
+        "blob_id": message["blobId"],
+        "subject": message["subject"],
+        "thread_id": message["threadId"],
+        "name": f"{account}|{message['id']}",
+        "has_attachment": cint(message["hasAttachment"]),
+        "keywords": json.dumps(message["keywords"], indent=4),
+        "received_after": time_diff_in_seconds(received_at, sent_at),
+    }
 
-	for key in ["sender", "from"]:
-		formatted_message[f"{key}_name"] = message[key][0]["name"] if message[key] else None
-		formatted_message[f"{key}_email"] = message[key][0]["email"] if message[key] else None
+    for key in ["sender", "from"]:
+        formatted_message[f"{key}_name"] = message[key][0]["name"] if message[key] else None
+        formatted_message[f"{key}_email"] = message[key][0]["email"] if message[key] else None
 
-	formatted_message["reply_to"] = []
-	if reply_to := message["replyTo"]:
-		for rt in reply_to:
-			formatted_message["reply_to"].append({"display_name": rt["name"], "email": rt["email"]})
+    formatted_message["reply_to"] = []
+    if reply_to := message["replyTo"]:
+        for rt in reply_to:
+            formatted_message["reply_to"].append({"display_name": rt["name"], "email": rt["email"]})
 
-	formatted_message["recipients"] = []
-	for key in ["to", "cc", "bcc"]:
-		if rcpts := message[key]:
-			titled_key = key.title()
-			for rcpt in rcpts:
-				formatted_message["recipients"].append(
-					{"type": titled_key, "display_name": rcpt["name"], "email": rcpt["email"]}
-				)
+    formatted_message["recipients"] = []
+    for key in ["to", "cc", "bcc"]:
+        if rcpts := message[key]:
+            titled_key = key.title()
+            for rcpt in rcpts:
+                formatted_message["recipients"].append(
+                    {"type": titled_key, "display_name": rcpt["name"], "email": rcpt["email"]}
+                )
 
-	for key, field in {"htmlBody": "html_body", "textBody": "text_body"}.items():
-		value = (
-			message.get("bodyValues", {}).get(message[key][0]["partId"], {}).get("value")
-			if message.get(key)
-			else None
-		)
-		formatted_message[field] = value
+    for key, field in {"htmlBody": "html_body", "textBody": "text_body"}.items():
+        value = (
+            message.get("bodyValues", {}).get(message[key][0]["partId"], {}).get("value")
+            if message.get(key)
+            else None
+        )
+        formatted_message[field] = value
 
-	if html_body := formatted_message["html_body"]:
-		preview = convert_html_to_text(html_body)
-	elif text_body := formatted_message["text_body"]:
-		preview = clean_text(text_body)
-	else:
-		preview = message.get("preview") or ""
-	formatted_message["preview"] = preview[:PREVIEW_MAX_LENGTH]
+    if html_body := formatted_message["html_body"]:
+        preview = convert_html_to_text(html_body)
+    elif text_body := formatted_message["text_body"]:
+        preview = clean_text(text_body)
+    else:
+        preview = message.get("preview") or ""
+    formatted_message["preview"] = preview[:PREVIEW_MAX_LENGTH]
 
-	formatted_message["mailboxes"] = []
-	for mailbox_id, value in message["mailboxIds"].items():
-		if value:
-			formatted_message["mailboxes"].append(
-				{
-					"mailbox": f"{account}|{mailbox_id}",
-					"mailbox_id": mailbox_id,
-					"mailbox_name": mailbox_map.get(mailbox_id),
-				}
-			)
+    formatted_message["mailboxes"] = []
+    for mailbox_id, value in message["mailboxIds"].items():
+        if value:
+            formatted_message["mailboxes"].append(
+                {
+                    "mailbox": f"{account}|{mailbox_id}",
+                    "mailbox_id": mailbox_id,
+                    "mailbox_name": mailbox_map.get(mailbox_id),
+                }
+            )
 
-	for key in ["draft", "junk", "seen", "flagged", "answered", "forwarded"]:
-		formatted_message[key] = cint(message["keywords"].get(f"${key}", False))
+    for key in ["draft", "junk", "seen", "flagged", "answered", "forwarded"]:
+        formatted_message[key] = cint(message["keywords"].get(f"${key}", False))
 
-	for key, field in {"messageId": "message_id", "inReplyTo": "in_reply_to"}.items():
-		formatted_message[field] = message[key][0] if message[key] else None
+    for key, field in {"messageId": "message_id", "inReplyTo": "in_reply_to"}.items():
+        formatted_message[field] = message[key][0] if message[key] else None
 
-	for key, field in {
-		"attachments": "attachments",
-		"htmlBody": "_html_body",
-		"textBody": "_text_body",
-	}.items():
-		formatted_message[field] = []
-		for p in message[key]:
-			formatted_message[field].append(
-				{
-					"part_id": p["partId"],
-					"blob_id": p["blobId"],
-					"size": p["size"],
-					"filename": p["name"],
-					"type": p["type"],
-					"charset": p["charset"],
-					"disposition": p["disposition"],
-					"cid": p["cid"] or random_string(10),
-					"language": str(p["language"]),
-					"location": p["location"],
-				}
-			)
+    for key, field in {
+        "attachments": "attachments",
+        "htmlBody": "_html_body",
+        "textBody": "_text_body",
+    }.items():
+        formatted_message[field] = []
+        for p in message[key]:
+            formatted_message[field].append(
+                {
+                    "part_id": p["partId"],
+                    "blob_id": p["blobId"],
+                    "size": p["size"],
+                    "filename": p["name"],
+                    "type": p["type"],
+                    "charset": p["charset"],
+                    "disposition": p["disposition"],
+                    "cid": p["cid"] or random_string(10),
+                    "language": str(p["language"]),
+                    "location": p["location"],
+                }
+            )
 
-	for attachment in formatted_message["attachments"]:
-		if blob_id := attachment["blob_id"]:
-			params = f"account={account}&blob_id={blob_id}"
-			if filename := attachment["filename"]:
-				params += f"&filename={quote(filename)}"
-			attachment["url"] = f"/api/method/suite.mail.api.mail.get_attachment?{params}"
+    for attachment in formatted_message["attachments"]:
+        if blob_id := attachment["blob_id"]:
+            params = f"account={account}&blob_id={blob_id}"
+            if filename := attachment["filename"]:
+                params += f"&filename={quote(filename)}"
+            attachment["url"] = f"/api/method/suite.mail.api.mail.get_attachment?{params}"
 
-			if attachment["cid"] and formatted_message["html_body"]:
-				formatted_message["html_body"] = convert_img_src_from_cid_to_url(
-					formatted_message["html_body"],
-					attachment["cid"],
-					attachment["url"],
-				)
+            if attachment["cid"] and formatted_message["html_body"]:
+                formatted_message["html_body"] = convert_img_src_from_cid_to_url(
+                    formatted_message["html_body"],
+                    attachment["cid"],
+                    attachment["url"],
+                )
 
-	return formatted_message
+    return formatted_message
 
 
 def _get_total_cache_key(account: str) -> str:
-	"""Returns cache key for total messages."""
+    """Returns cache key for total messages."""
 
-	return f"jmap:message:{account}:total"
+    return f"jmap:message:{account}:total"
 
 
 def _get_cached_messages(account: str, ids: list[str]) -> dict[str, dict | None]:
-	"""Returns a dictionary of cached messages for the provided IDs."""
+    """Returns a dictionary of cached messages for the provided IDs."""
 
-	store = get_data_store(account)
-	return store.get_many(Entity.EMAIL, keys=ids)
+    store = get_data_store(account)
+    return store.get_many(Entity.EMAIL, keys=ids)
 
 
 def _cache_messages(account: str, messages: dict[str, dict]) -> None:
-	"""Store messages in cache with the message ID as the key, and index their addresses for search."""
+    """Store messages in cache with the message ID as the key, and index their addresses for search."""
 
-	store = get_data_store(account)
-	store.set_many(Entity.EMAIL, items=messages)
+    store = get_data_store(account)
+    store.set_many(Entity.EMAIL, items=messages)
 
-	# Feed sender/recipient addresses into the shared address index; never let indexing break caching.
-	try:
-		get_email_address_index(account).index_addresses(_message_addresses(messages.values()))
-	except Exception:
-		log_mail_error(
-			_("Failed to index message addresses for search"), frappe.get_traceback(with_context=True)
-		)
+    # Feed sender/recipient addresses into the shared address index; never let indexing break caching.
+    try:
+        get_email_address_index(account).index_addresses(_message_addresses(messages.values()))
+    except Exception:
+        log_mail_error(
+            _("Failed to index message addresses for search"), frappe.get_traceback(with_context=True)
+        )
 
 
 def _remove_cached_messages(account: str, ids: list[str]) -> None:
-	"""Remove messages from cache for the provided IDs.
+    """Remove messages from cache for the provided IDs.
 
-	Addresses are left in the search index on purpose: it is cumulative, and an address seen in an
-	evicted message is almost always still valid elsewhere.
-	"""
+    Addresses are left in the search index on purpose: it is cumulative, and an address seen in an
+    evicted message is almost always still valid elsewhere.
+    """
 
-	store = get_data_store(account)
-	store.delete_many(Entity.EMAIL, keys=ids)
+    store = get_data_store(account)
+    store.delete_many(Entity.EMAIL, keys=ids)
 
 
 def _message_addresses(messages: list[dict]) -> list[dict]:
-	"""Flatten cached messages into {name, email} address dicts (sender + recipients)."""
+    """Flatten cached messages into {name, email} address dicts (sender + recipients)."""
 
-	addresses = []
-	for message in messages:
-		addresses.append({"name": message.get("from_name"), "email": message.get("from_email")})
-		for recipient in message.get("recipients") or []:
-			addresses.append({"name": recipient.get("display_name"), "email": recipient.get("email")})
+    addresses = []
+    for message in messages:
+        addresses.append({"name": message.get("from_name"), "email": message.get("from_email")})
+        for recipient in message.get("recipients") or []:
+            addresses.append({"name": recipient.get("display_name"), "email": recipient.get("email")})
 
-	return addresses
+    return addresses
 
 
 def _get_cached_blobs(account: str, blob_ids: list[str]) -> dict[str, bytes | None]:
-	"""Returns a dictionary of cached blobs for the provided blob IDs."""
+    """Returns a dictionary of cached blobs for the provided blob IDs."""
 
-	store = get_blob_store(account)
-	return store.get_many(keys=blob_ids)
+    store = get_blob_store(account)
+    return store.get_many(keys=blob_ids)
 
 
 def _cache_blobs(account: str, blobs: dict[str, bytes]) -> None:
-	"""Store blobs in cache with the blob ID as the key."""
+    """Store blobs in cache with the blob ID as the key."""
 
-	store = get_blob_store(account)
-	store.set_many(items=blobs)
+    store = get_blob_store(account)
+    store.set_many(items=blobs)
 
 
 def fetch_changes(user: str, account: str, email_state: str | None = None, ctx: dict | None = None) -> None:
-	"""Fetch changes from the server and remove MailMessage documents from the cache."""
+    """Fetch changes from the server and remove MailMessage documents from the cache."""
 
-	ctx = ctx or {}
-	logger = get_push_logger(ctx)
+    ctx = ctx or {}
+    logger = get_push_logger(ctx)
 
-	current_state = get_sync_state(account, type="email")
+    current_state = get_sync_state(account, type="email")
 
-	ctx["current_state"] = current_state
-	ctx["email_state"] = email_state
+    ctx["current_state"] = current_state
+    ctx["email_state"] = email_state
 
-	if not current_state:
-		logger.info("initializing-email-sync-state")
-		return update_sync_state(account, type="email", state=email_state)
+    if not current_state:
+        logger.info("initializing-email-sync-state")
+        return update_sync_state(account, type="email", state=email_state)
 
-	elif email_state == current_state:
-		logger.debug("email-state-unchanged")
-		return
+    elif email_state == current_state:
+        logger.debug("email-state-unchanged")
+        return
 
-	try:
-		logger.debug("fetching-changes-from-server")
+    try:
+        logger.debug("fetching-changes-from-server")
 
-		connection = get_jmap_connection(user)
-		email_service = EmailService(account, connection)
-		mailbox_service = MailboxService(account, connection)
+        connection = get_jmap_connection(user)
+        email_service = EmailService(account, connection)
+        mailbox_service = MailboxService(account, connection)
 
-		result = email_service.changes(current_state)
+        result = email_service.changes(current_state)
 
-		if created_ids := result["created"]:
-			logger.info("new-messages-created", count=len(created_ids))
+        if created_ids := result["created"]:
+            logger.info("new-messages-created", count=len(created_ids))
 
-			if messages := get_messages(account, ids=created_ids):
-				subscribed_mailboxes = set([m["id"] for m in mailbox_service.mailboxes if m["isSubscribed"]])
-				logger.debug("resolved-subscribed-mailboxes", subscribed_mailboxes=subscribed_mailboxes)
+            if messages := get_messages(account, ids=created_ids):
+                subscribed_mailboxes = set([m["id"] for m in mailbox_service.mailboxes if m["isSubscribed"]])
+                logger.debug("resolved-subscribed-mailboxes", subscribed_mailboxes=subscribed_mailboxes)
 
-				disabled_mailboxes = set(
-					frappe.db.get_all(
-						"Mailbox Settings",
-						{"account": account, "disable_push_notification": 1},
-						pluck="mailbox_id",
-					)
-				) | {
-					m["id"]
-					for m in mailbox_service.mailboxes
-					if m["role"] in ["sent", "drafts", "junk", "trash", "archive"]
-					or m["name"] == SCREENER_MAILBOX_NAME
-				}
-				logger.debug("resolved-disabled-mailboxes", disabled_mailboxes=disabled_mailboxes)
+                disabled_mailboxes = set(
+                    frappe.db.get_all(
+                        "Mailbox Settings",
+                        {"account": account, "disable_push_notification": 1},
+                        pluck="mailbox_id",
+                    )
+                ) | {
+                    m["id"]
+                    for m in mailbox_service.mailboxes
+                    if m["role"] in ["sent", "drafts", "junk", "trash", "archive"]
+                    or m["name"] == SCREENER_MAILBOX_NAME
+                }
+                logger.debug("resolved-disabled-mailboxes", disabled_mailboxes=disabled_mailboxes)
 
-				notify_candidates = []
-				mailboxes_to_reload = set()
+                notify_candidates = []
+                mailboxes_to_reload = set()
 
-				for message in messages:
-					if message["draft"] or message["seen"]:
-						continue
+                for message in messages:
+                    if message["draft"] or message["seen"]:
+                        continue
 
-					mailbox_id = None
-					is_candidate = False
+                    mailbox_id = None
+                    is_candidate = False
 
-					for mailbox in message["mailboxes"]:
-						if mailbox["mailbox_id"] not in subscribed_mailboxes:
-							continue
+                    for mailbox in message["mailboxes"]:
+                        if mailbox["mailbox_id"] not in subscribed_mailboxes:
+                            continue
 
-						mailboxes_to_reload.add(mailbox["mailbox_id"])
+                        mailboxes_to_reload.add(mailbox["mailbox_id"])
 
-						if not is_candidate and mailbox["mailbox_id"] not in disabled_mailboxes:
-							mailbox_id = mailbox["mailbox_id"]
-							is_candidate = True
+                        if not is_candidate and mailbox["mailbox_id"] not in disabled_mailboxes:
+                            mailbox_id = mailbox["mailbox_id"]
+                            is_candidate = True
 
-					if is_candidate:
-						notify_candidates.append((mailbox_id, message))
+                    if is_candidate:
+                        notify_candidates.append((mailbox_id, message))
 
-				logger.debug("computed-notify-candidates", notify_candidates_count=len(notify_candidates))
+                logger.debug("computed-notify-candidates", notify_candidates_count=len(notify_candidates))
 
-				max_push_notifications = cint(get_config("max_push_notifications"))
-				recent_messages = notify_candidates[:max_push_notifications]
+                max_push_notifications = cint(get_config("max_push_notifications"))
+                recent_messages = notify_candidates[:max_push_notifications]
 
-				logger.debug("capped-notify-candidates", recent_notify_candidates_count=len(recent_messages))
+                logger.debug("capped-notify-candidates", recent_notify_candidates_count=len(recent_messages))
 
-				pn = PushNotification("mail")
+                pn = PushNotification("mail")
 
-				if pn.is_enabled():
-					logger.info("sending-push-notifications", count=len(recent_messages))
+                if pn.is_enabled():
+                    logger.info("sending-push-notifications", count=len(recent_messages))
 
-					url = frappe.utils.get_url()
-					for mailbox_id, message in recent_messages:
-						pn.send_notification_to_user(
-							user,
-							message["from_name"] or message["from_email"],
-							message["subject"] or _("[No subject]"),
-							f"{url}/mail/account/{account}/mailbox/{mailbox_id}/{message['thread_id']}",
-							f"{url}/assets/suite/mail/frontend/manifest/manifest-icon-192.maskable.png",
-						)
-				else:
-					logger.debug("push-notifications-disabled")
+                    url = frappe.utils.get_url()
+                    for mailbox_id, message in recent_messages:
+                        pn.send_notification_to_user(
+                            user,
+                            message["from_name"] or message["from_email"],
+                            message["subject"] or _("[No subject]"),
+                            f"{url}/mail/account/{account}/mailbox/{mailbox_id}/{message['thread_id']}",
+                            f"{url}/assets/suite/mail/frontend/manifest/manifest-icon-192.maskable.png",
+                        )
+                else:
+                    logger.debug("push-notifications-disabled")
 
-				if mailboxes_to_reload:
-					frappe.publish_realtime("new_mail_created", list(mailboxes_to_reload), user=user)
+                if mailboxes_to_reload:
+                    frappe.publish_realtime("new_mail_created", list(mailboxes_to_reload), user=user)
 
-		if updated_ids := result["updated"]:
-			logger.info("messages-updated", count=len(updated_ids))
-			_remove_cached_messages(account, updated_ids)
+        if updated_ids := result["updated"]:
+            logger.info("messages-updated", count=len(updated_ids))
+            _remove_cached_messages(account, updated_ids)
 
-		if destroyed_ids := result["destroyed"]:
-			logger.info("messages-deleted", count=len(destroyed_ids))
-			_remove_cached_messages(account, destroyed_ids)
+        if destroyed_ids := result["destroyed"]:
+            logger.info("messages-deleted", count=len(destroyed_ids))
+            _remove_cached_messages(account, destroyed_ids)
 
-		new_state = result["newState"]
+        new_state = result["newState"]
 
-		ctx["new_state"] = new_state
-		logger.debug("updating-email-sync-state")
+        ctx["new_state"] = new_state
+        logger.debug("updating-email-sync-state")
 
-		update_sync_state(account, type="email", state=new_state)
+        update_sync_state(account, type="email", state=new_state)
 
-		if result["hasMoreChanges"]:
-			logger.debug("more-changes-to-fetch")
-			ctx.pop("current_state", None)
-			ctx.pop("email_state", None)
-			ctx.pop("new_state", None)
+        if result["hasMoreChanges"]:
+            logger.debug("more-changes-to-fetch")
+            ctx.pop("current_state", None)
+            ctx.pop("email_state", None)
+            ctx.pop("new_state", None)
 
-			fetch_changes(user, account, ctx=ctx)
+            fetch_changes(user, account, ctx=ctx)
 
-	except Exception:
-		logger.error("fetch-changes-failed")
-		log_mail_error(
-			_("Failed to fetch changes"),
-			frappe.get_traceback(with_context=True),
-		)
+    except Exception:
+        logger.error("fetch-changes-failed")
+        log_mail_error(
+            _("Failed to fetch changes"),
+            frappe.get_traceback(with_context=True),
+        )
 
 
 def locked_fetch_changes(
-	user: str, account: str, email_state: str | None, lock_id: str, ctx: dict | None = None
+    user: str, account: str, email_state: str | None, lock_id: str, ctx: dict | None = None
 ) -> None:
-	"""Fetch changes for the specified account with a lock to prevent concurrent execution."""
+    """Fetch changes for the specified account with a lock to prevent concurrent execution."""
 
-	ctx = ctx or {}
-	logger = get_push_logger(ctx)
+    ctx = ctx or {}
+    logger = get_push_logger(ctx)
 
-	try:
-		logger.debug("starting-fetch-changes")
-		fetch_changes(user, account, email_state, ctx=ctx)
-	finally:
-		logger.debug("releasing-fetch-changes-lock")
-		release_lock(f"fetch_changes:{user}:{account}", lock_id)
+    try:
+        logger.debug("starting-fetch-changes")
+        fetch_changes(user, account, email_state, ctx=ctx)
+    finally:
+        logger.debug("releasing-fetch-changes-lock")
+        release_lock(f"fetch_changes:{user}:{account}", lock_id)
 
 
 def enqueue_fetch_changes(
-	user: str, account: str, email_state: str | None = None, ctx: dict | None = None
+    user: str, account: str, email_state: str | None = None, ctx: dict | None = None
 ) -> None:
-	"""Enqueue the fetch_changes job for the specified account."""
+    """Enqueue the fetch_changes job for the specified account."""
 
-	ctx = ctx or {}
-	logger = get_push_logger(ctx)
+    ctx = ctx or {}
+    logger = get_push_logger(ctx)
 
-	logger.debug("enqueueing-fetch-changes")
+    logger.debug("enqueueing-fetch-changes")
 
-	lockname = f"fetch_changes:{user}:{account}"
-	identifier = acquire_lock(lockname, acquire_timeout=0)
+    lockname = f"fetch_changes:{user}:{account}"
+    identifier = acquire_lock(lockname, acquire_timeout=0)
 
-	if not identifier:
-		logger.debug("fetch-changes-lock-not-acquired")
-		return
+    if not identifier:
+        logger.debug("fetch-changes-lock-not-acquired")
+        return
 
-	ctx["lock_id"] = identifier
+    ctx["lock_id"] = identifier
 
-	with user_context("Administrator"):
-		logger.debug("fetch-changes-lock-acquired")
-		enqueue_job(
-			locked_fetch_changes,
-			user=user,
-			account=account,
-			email_state=email_state,
-			lock_id=identifier,
-			ctx=ctx,
-			queue="short",
-			enqueue_after_commit=True,
-		)
+    with user_context("Administrator"):
+        logger.debug("fetch-changes-lock-acquired")
+        enqueue_job(
+            locked_fetch_changes,
+            user=user,
+            account=account,
+            email_state=email_state,
+            lock_id=identifier,
+            ctx=ctx,
+            queue="short",
+            enqueue_after_commit=True,
+        )
 
 
 def schedule_fetch_changes() -> None:
-	"""Schedule fetch_changes for every (user, account) whose email state hasn't been
-	updated in the last 3 hours.
+    """Schedule fetch_changes for every (user, account) whose email state hasn't been
+    updated in the last 3 hours.
 
-	JMAP Account is now shared per account ID, so the set of accounts to sync is
-	derived from each JMAP-configured user's accounts, and the last-update timestamp is
-	read from that user's per-account data store."""
+    JMAP Account is now shared per account ID, so the set of accounts to sync is
+    derived from each JMAP-configured user's accounts, and the last-update timestamp is
+    read from that user's per-account data store."""
 
-	USER = frappe.qb.DocType("User")
-	USER_SETTINGS = frappe.qb.DocType("User Settings")
+    USER = frappe.qb.DocType("User")
+    USER_SETTINGS = frappe.qb.DocType("User Settings")
 
-	threshold = get_datetime(add_to_date(now(), hours=-3))
+    threshold = get_datetime(add_to_date(now(), hours=-3))
 
-	users = (
-		frappe.qb.from_(USER_SETTINGS)
-		.join(USER)
-		.on(USER.name == USER_SETTINGS.user)
-		.select(USER_SETTINGS.user)
-		.where(
-			(USER.enabled == 1)
-			& (USER_SETTINGS.username != "")
-			& (USER_SETTINGS.username.isnotnull())
-			& (USER_SETTINGS.skip_schedule_fetch_changes == 0)
-		)
-	).run(pluck="user")
+    users = (
+        frappe.qb.from_(USER_SETTINGS)
+        .join(USER)
+        .on(USER.name == USER_SETTINGS.user)
+        .select(USER_SETTINGS.user)
+        .where(
+            (USER.enabled == 1)
+            & (USER_SETTINGS.username != "")
+            & (USER_SETTINGS.username.isnotnull())
+            & (USER_SETTINGS.skip_schedule_fetch_changes == 0)
+        )
+    ).run(pluck="user")
 
-	if not users:
-		return
+    if not users:
+        return
 
-	selected_user_accounts = []
-	for user in users:
-		try:
-			accounts = get_user_jmap_accounts(user, raise_exception=True)
-		except Exception:
-			continue
+    selected_user_accounts = []
+    for user in users:
+        try:
+            accounts = get_user_jmap_accounts(user, raise_exception=True)
+        except Exception:
+            continue
 
-		for account in accounts:
-			store = get_data_store(account)
-			last_update = store.get(Entity.STATE, "email_state_last_update")
-			if not last_update or get_datetime(last_update) < threshold:
-				selected_user_accounts.append((user, account))
+        for account in accounts:
+            store = get_data_store(account)
+            last_update = store.get(Entity.STATE, "email_state_last_update")
+            if not last_update or get_datetime(last_update) < threshold:
+                selected_user_accounts.append((user, account))
 
-	if not selected_user_accounts:
-		return
+    if not selected_user_accounts:
+        return
 
-	req_id = random_string(10)
-	logger = get_push_logger({"req_id": req_id})
+    req_id = random_string(10)
+    logger = get_push_logger({"req_id": req_id})
 
-	logger.info("scheduling-fetch-changes", account_count=len(selected_user_accounts))
+    logger.info("scheduling-fetch-changes", account_count=len(selected_user_accounts))
 
-	for idx, (user, account) in enumerate(selected_user_accounts, start=1):
-		ctx = {"req_id": f"{req_id}-{idx}", "account": account}
-		enqueue_fetch_changes(user, account, ctx=ctx)
+    for idx, (user, account) in enumerate(selected_user_accounts, start=1):
+        ctx = {"req_id": f"{req_id}-{idx}", "account": account}
+        enqueue_fetch_changes(user, account, ctx=ctx)

--- a/suite/mail/doctype/mail_message/test_mail_message.py
+++ b/suite/mail/doctype/mail_message/test_mail_message.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestMailMessage(IntegrationTestCase):
-	"""
-	Integration tests for MailMessage.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for MailMessage.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/mail_message_mailbox/mail_message_mailbox.py
+++ b/suite/mail/doctype/mail_message_mailbox/mail_message_mailbox.py
@@ -6,26 +6,26 @@ from frappe.model.document import Document
 
 
 class MailMessageMailbox(Document):
-	def db_insert(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_insert(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def load_from_db(self):
-		raise NotImplementedError
+    def load_from_db(self):
+        raise NotImplementedError
 
-	def db_update(self):
-		raise NotImplementedError
+    def db_update(self):
+        raise NotImplementedError
 
-	def delete(self):
-		raise NotImplementedError
+    def delete(self):
+        raise NotImplementedError
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs):
-		pass
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs):
+        pass
 
-	@staticmethod
-	def get_count(filters=None, **kwargs):
-		pass
+    @staticmethod
+    def get_count(filters=None, **kwargs):
+        pass
 
-	@staticmethod
-	def get_stats(**kwargs):
-		pass
+    @staticmethod
+    def get_stats(**kwargs):
+        pass

--- a/suite/mail/doctype/mail_message_part/mail_message_part.py
+++ b/suite/mail/doctype/mail_message_part/mail_message_part.py
@@ -6,26 +6,26 @@ from frappe.model.document import Document
 
 
 class MailMessagePart(Document):
-	def db_insert(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_insert(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def load_from_db(self):
-		raise NotImplementedError
+    def load_from_db(self):
+        raise NotImplementedError
 
-	def db_update(self):
-		raise NotImplementedError
+    def db_update(self):
+        raise NotImplementedError
 
-	def delete(self):
-		raise NotImplementedError
+    def delete(self):
+        raise NotImplementedError
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs):
-		pass
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs):
+        pass
 
-	@staticmethod
-	def get_count(filters=None, **kwargs):
-		pass
+    @staticmethod
+    def get_count(filters=None, **kwargs):
+        pass
 
-	@staticmethod
-	def get_stats(**kwargs):
-		pass
+    @staticmethod
+    def get_stats(**kwargs):
+        pass

--- a/suite/mail/doctype/mail_message_recipient/mail_message_recipient.py
+++ b/suite/mail/doctype/mail_message_recipient/mail_message_recipient.py
@@ -6,26 +6,26 @@ from frappe.model.document import Document
 
 
 class MailMessageRecipient(Document):
-	def db_insert(self, *args, **kwargs):
-		raise NotImplementedError
+    def db_insert(self, *args, **kwargs):
+        raise NotImplementedError
 
-	def load_from_db(self):
-		raise NotImplementedError
+    def load_from_db(self):
+        raise NotImplementedError
 
-	def db_update(self):
-		raise NotImplementedError
+    def db_update(self):
+        raise NotImplementedError
 
-	def delete(self):
-		raise NotImplementedError
+    def delete(self):
+        raise NotImplementedError
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs):
-		pass
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs):
+        pass
 
-	@staticmethod
-	def get_count(filters=None, **kwargs):
-		pass
+    @staticmethod
+    def get_count(filters=None, **kwargs):
+        pass
 
-	@staticmethod
-	def get_stats(**kwargs):
-		pass
+    @staticmethod
+    def get_stats(**kwargs):
+        pass

--- a/suite/mail/doctype/mail_queue/mail_queue.py
+++ b/suite/mail/doctype/mail_queue/mail_queue.py
@@ -142,7 +142,7 @@ class MailQueue(OwnerFromUser, Document):
         return file
 
     @staticmethod
-    def _create(do_not_save: bool = False, **kwargs) -> "MailQueue":
+    def _create(do_not_save: bool = False, **kwargs) -> MailQueue:
         """Create a new MailQueue document."""
 
         kwargs = frappe._dict(kwargs)

--- a/suite/mail/doctype/mail_queue/mail_queue.py
+++ b/suite/mail/doctype/mail_queue/mail_queue.py
@@ -17,26 +17,26 @@ from frappe.core.doctype.file.utils import find_file_by_url
 from frappe.model.document import Document
 from frappe.query_builder import Case, Order
 from frappe.utils import (
-	add_to_date,
-	cint,
-	create_batch,
-	get_datetime,
-	get_datetime_str,
-	now,
-	now_datetime,
-	random_string,
-	time_diff_in_seconds,
-	validate_email_address,
+    add_to_date,
+    cint,
+    create_batch,
+    get_datetime,
+    get_datetime_str,
+    now,
+    now_datetime,
+    random_string,
+    time_diff_in_seconds,
+    validate_email_address,
 )
 
 from suite.mail.doctype.user_account.user_account import is_jmap_account_belongs_to_user
 from suite.mail.jmap import get_email_service, get_identities, get_jmap_connection
 from suite.mail.jmap.models import (
-	EmailAddress,
-	EmailAttachment,
-	EmailCreateModel,
-	EmailHeader,
-	EmailRecipient,
+    EmailAddress,
+    EmailAttachment,
+    EmailCreateModel,
+    EmailHeader,
+    EmailRecipient,
 )
 from suite.mail.jmap.services.mail.email import EmailService
 from suite.mail.jmap.services.mail.mailbox import MailboxService
@@ -48,911 +48,911 @@ from suite.utils.user import is_administrator
 
 
 class MailQueue(OwnerFromUser, Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
-
-	from typing import TYPE_CHECKING
-
-	if TYPE_CHECKING:
-		from frappe.types import DF
-
-		_response: DF.JSON | None
-		account: DF.Link
-		attachments: DF.JSON | None
-		blob_id: DF.Data | None
-		delivery_mode: DF.Literal["Immediate", "Enqueue", "Batch"]
-		destroy_after_submit: DF.Check
-		drafted_at: DF.Datetime | None
-		error_log: DF.Code | None
-		forwarded_from_id: DF.Data | None
-		from_email: DF.Data | None
-		from_ip: DF.Data | None
-		from_name: DF.Data | None
-		headers: DF.JSON | None
-		html_body: DF.Code | None
-		id: DF.Data | None
-		in_reply_to: DF.Data | None
-		in_reply_to_id: DF.Data | None
-		mailbox_id: DF.Data | None
-		max_retries: DF.Int
-		message_id: DF.Data | None
-		newsletter: DF.Check
-		next_retry_after: DF.Datetime | None
-		priority: DF.Literal["", "Low", "Normal", "High"]
-		queued_at: DF.Datetime | None
-		raw_message: DF.Code | None
-		recipients: DF.JSON | None
-		reply_to: DF.JSON | None
-		retries: DF.Int
-		save_as_draft: DF.Check
-		sent_at: DF.Datetime | None
-		size: DF.Int
-		status: DF.Literal[
-			"", "Pending", "Queued", "Failed", "Drafted", "Failed to Draft", "Submitted", "Failed to Submit"
-		]
-		subject: DF.SmallText | None
-		submitted_at: DF.Datetime | None
-		text_body: DF.Code | None
-		thread_id: DF.Data | None
-		user: DF.Link
-		via_api: DF.Check
-	# end: auto-generated types
-
-	@staticmethod
-	def clear_old_logs(days: int = 3) -> None:
-		MQ = frappe.qb.DocType("Mail Queue")
-		(
-			frappe.qb.from_(MQ)
-			.where(
-				(MQ.status.isin(["Drafted", "Submitted"]))
-				& (MQ.creation < get_datetime(add_to_date(now(), days=-days)))
-			)
-			.delete()
-		).run()
-
-	@staticmethod
-	def _get_file(
-		name: str | None = None,
-		file_url: str | None = None,
-		user: str | None = None,
-		check_permission: bool = True,
-	) -> File:
-		"""Returns the File document for the given name or file URL."""
-
-		if not name and not file_url:
-			frappe.throw(_("Either name or file URL is required."))
-
-		file = None
-		if name:
-			file = frappe.get_doc("File", name)
-		elif file_url:
-			file = find_file_by_url(file_url)
-
-		if not file:
-			frappe.throw(_("File <code>{0}</code> not found.").format(name or file_url))
-
-		if check_permission:
-			if not has_file_permission(file, "read", user=user):
-				frappe.throw(
-					_("User {0} do not have permission to access the file <code>{1}</code>.").format(
-						frappe.bold(user or frappe.session.user), name or file_url
-					)
-				)
-
-		return file
-
-	@staticmethod
-	def _create(do_not_save: bool = False, **kwargs) -> "MailQueue":
-		"""Create a new MailQueue document."""
-
-		kwargs = frappe._dict(kwargs)
-
-		doc = frappe.new_doc("Mail Queue")
-		doc.user = kwargs.user
-		doc.account = kwargs.account
-		doc.from_name = kwargs.from_name
-		doc.from_email = kwargs.from_email
-		doc.subject = kwargs.subject
-
-		for field in ["reply_to", "headers", "recipients", "attachments"]:
-			if kwargs.get(field):
-				setattr(doc, field, json.dumps(kwargs[field]))
-
-		doc.html_body = kwargs.html_body
-		doc.text_body = kwargs.text_body
-		doc.forwarded_from_id = kwargs.forwarded_from_id
-		doc.message_id = kwargs.message_id
-		doc.id = kwargs.id
-		doc.via_api = cint(kwargs.via_api)
-		doc.newsletter = cint(kwargs.newsletter)
-		doc.priority = kwargs.priority
-		doc.sent_at = kwargs.sent_at
-		doc.in_reply_to = kwargs.in_reply_to
-		doc.in_reply_to_id = kwargs.in_reply_to_id
-		doc.save_as_draft = cint(kwargs.save_as_draft)
-		doc.destroy_after_submit = cint(kwargs.destroy_after_submit)
-		doc.delivery_mode = kwargs.delivery_mode or "Immediate"
-		doc.raw_message = kwargs.raw_message
-
-		if not do_not_save:
-			if frappe.flags.read_only:
-				if not doc.name:
-					doc.set_new_name()
-
-				doc.delivery_mode = "Immediate"
-				doc.validate()
-				doc._process()
-
-				if doc.status in ["Failed", "Failed to Draft", "Failed to Submit"]:
-					error_message = doc.error_message or "Request Failed"
-					frappe.throw(error_message)
-			else:
-				doc.insert()
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        _response: DF.JSON | None
+        account: DF.Link
+        attachments: DF.JSON | None
+        blob_id: DF.Data | None
+        delivery_mode: DF.Literal["Immediate", "Enqueue", "Batch"]
+        destroy_after_submit: DF.Check
+        drafted_at: DF.Datetime | None
+        error_log: DF.Code | None
+        forwarded_from_id: DF.Data | None
+        from_email: DF.Data | None
+        from_ip: DF.Data | None
+        from_name: DF.Data | None
+        headers: DF.JSON | None
+        html_body: DF.Code | None
+        id: DF.Data | None
+        in_reply_to: DF.Data | None
+        in_reply_to_id: DF.Data | None
+        mailbox_id: DF.Data | None
+        max_retries: DF.Int
+        message_id: DF.Data | None
+        newsletter: DF.Check
+        next_retry_after: DF.Datetime | None
+        priority: DF.Literal["", "Low", "Normal", "High"]
+        queued_at: DF.Datetime | None
+        raw_message: DF.Code | None
+        recipients: DF.JSON | None
+        reply_to: DF.JSON | None
+        retries: DF.Int
+        save_as_draft: DF.Check
+        sent_at: DF.Datetime | None
+        size: DF.Int
+        status: DF.Literal[
+            "", "Pending", "Queued", "Failed", "Drafted", "Failed to Draft", "Submitted", "Failed to Submit"
+        ]
+        subject: DF.SmallText | None
+        submitted_at: DF.Datetime | None
+        text_body: DF.Code | None
+        thread_id: DF.Data | None
+        user: DF.Link
+        via_api: DF.Check
+    # end: auto-generated types
+
+    @staticmethod
+    def clear_old_logs(days: int = 3) -> None:
+        MQ = frappe.qb.DocType("Mail Queue")
+        (
+            frappe.qb.from_(MQ)
+            .where(
+                (MQ.status.isin(["Drafted", "Submitted"]))
+                & (MQ.creation < get_datetime(add_to_date(now(), days=-days)))
+            )
+            .delete()
+        ).run()
+
+    @staticmethod
+    def _get_file(
+        name: str | None = None,
+        file_url: str | None = None,
+        user: str | None = None,
+        check_permission: bool = True,
+    ) -> File:
+        """Returns the File document for the given name or file URL."""
+
+        if not name and not file_url:
+            frappe.throw(_("Either name or file URL is required."))
+
+        file = None
+        if name:
+            file = frappe.get_doc("File", name)
+        elif file_url:
+            file = find_file_by_url(file_url)
+
+        if not file:
+            frappe.throw(_("File <code>{0}</code> not found.").format(name or file_url))
+
+        if check_permission:
+            if not has_file_permission(file, "read", user=user):
+                frappe.throw(
+                    _("User {0} do not have permission to access the file <code>{1}</code>.").format(
+                        frappe.bold(user or frappe.session.user), name or file_url
+                    )
+                )
+
+        return file
+
+    @staticmethod
+    def _create(do_not_save: bool = False, **kwargs) -> "MailQueue":
+        """Create a new MailQueue document."""
+
+        kwargs = frappe._dict(kwargs)
+
+        doc = frappe.new_doc("Mail Queue")
+        doc.user = kwargs.user
+        doc.account = kwargs.account
+        doc.from_name = kwargs.from_name
+        doc.from_email = kwargs.from_email
+        doc.subject = kwargs.subject
+
+        for field in ["reply_to", "headers", "recipients", "attachments"]:
+            if kwargs.get(field):
+                setattr(doc, field, json.dumps(kwargs[field]))
+
+        doc.html_body = kwargs.html_body
+        doc.text_body = kwargs.text_body
+        doc.forwarded_from_id = kwargs.forwarded_from_id
+        doc.message_id = kwargs.message_id
+        doc.id = kwargs.id
+        doc.via_api = cint(kwargs.via_api)
+        doc.newsletter = cint(kwargs.newsletter)
+        doc.priority = kwargs.priority
+        doc.sent_at = kwargs.sent_at
+        doc.in_reply_to = kwargs.in_reply_to
+        doc.in_reply_to_id = kwargs.in_reply_to_id
+        doc.save_as_draft = cint(kwargs.save_as_draft)
+        doc.destroy_after_submit = cint(kwargs.destroy_after_submit)
+        doc.delivery_mode = kwargs.delivery_mode or "Immediate"
+        doc.raw_message = kwargs.raw_message
+
+        if not do_not_save:
+            if frappe.flags.read_only:
+                if not doc.name:
+                    doc.set_new_name()
+
+                doc.delivery_mode = "Immediate"
+                doc.validate()
+                doc._process()
+
+                if doc.status in ["Failed", "Failed to Draft", "Failed to Submit"]:
+                    error_message = doc.error_message or "Request Failed"
+                    frappe.throw(error_message)
+            else:
+                doc.insert()
 
-		return doc
+        return doc
 
-	@property
-	def _priority(self) -> int:
-		"""Returns the MT-Priority value based on the priority field."""
-
-		mt_priority_map = {
-			"Low": -4,
-			"Normal": 0,
-			"High": 4,
-		}
-		return mt_priority_map.get(self.priority, 0)
-
-	@property
-	def identity(self) -> dict:
-		"""Returns the identity used to send the email."""
+    @property
+    def _priority(self) -> int:
+        """Returns the MT-Priority value based on the priority field."""
+
+        mt_priority_map = {
+            "Low": -4,
+            "Normal": 0,
+            "High": 4,
+        }
+        return mt_priority_map.get(self.priority, 0)
+
+    @property
+    def identity(self) -> dict:
+        """Returns the identity used to send the email."""
 
-		identity = {}
+        identity = {}
 
-		if self.from_email:
-			for i in get_identities(self.account):
-				if self.from_email.lower() == i.get("email").lower():
-					identity = i
-					break
-
-		return identity
-
-	@property
-	def to(self) -> list[dict[str, str | None]]:
-		"""Returns the recipients in the To field."""
-
-		return self._get_recipients("To")
-
-	@property
-	def cc(self) -> list[dict[str, str | None]]:
-		"""Returns the recipients in the Cc field."""
-
-		return self._get_recipients("Cc")
-
-	@property
-	def bcc(self) -> list[dict[str, str | None]]:
-		"""Returns the recipients in the Bcc field."""
-
-		return self._get_recipients("Bcc")
-
-	@property
-	def received_after(self) -> float:
-		"""Returns the time difference in seconds between creation and sent time."""
-
-		if self.sent_at and self.creation:
-			time_diff = time_diff_in_seconds(self.creation, self.sent_at)
-			if time_diff > 0:
-				return time_diff
-
-		return 0.0
-
-	@property
-	def queued_after(self) -> float:
-		"""Returns the time difference in seconds between queued and creation time."""
-
-		return time_diff_in_seconds(self.queued_at, self.creation) if self.queued_at else 0.0
-
-	@property
-	def drafted_after(self) -> float:
-		"""Returns the time difference in seconds between drafted and creation time."""
-
-		return time_diff_in_seconds(self.drafted_at, self.creation) if self.drafted_at else 0.0
-
-	@property
-	def submitted_after(self) -> float:
-		"""Returns the time difference in seconds between submitted and creation time."""
-
-		return time_diff_in_seconds(self.submitted_at, self.creation) if self.submitted_at else 0.0
-
-	@property
-	def message(self) -> str | None:
-		"""Returns the message content if available."""
-
-		from suite.mail.doctype.mail_message.mail_message import _get_cached_blobs
-
-		if self.blob_id:
-			blobs = _get_cached_blobs(self.account, [self.blob_id])
-			if content := blobs.get(self.blob_id):
-				return content.decode("utf-8")
-
-	@property
-	def response(self) -> str | None:
-		"""Returns the indented JSON response."""
-
-		_response = json_loads(self._response)
-		return json.dumps(_response, indent=4) if _response else None
-
-	@property
-	def error_message(self) -> str | None:
-		"""Returns the error message."""
-
-		if not self._response or self.status not in ["Failed to Draft", "Failed to Submit"]:
-			return None
-
-		response = json_loads(self._response)
-
-		data = None
-		if self.status == "Failed to Draft":
-			data = response["methodResponses"][0][1].get("notCreated", {}).get(f"draft-{self.name}")
-		elif self.status == "Failed to Submit":
-			data = response["methodResponses"][-1][1].get("notCreated", {}).get(f"submit-{self.name}")
-
-		if data:
-			message = f"{data['type']}: {data['description']}"
-
-			if data.get("properties"):
-				message += f" ({', '.join(data['properties'])})"
-
-			return message
-
-	def autoname(self) -> None:
-		self.name = str(uuid7())
-
-	def validate(self) -> None:
-		if self.is_new():
-			self.validate_status()
-			self.validate_account()
-			self.validate_raw_message()
-			self.validate_from_email()
-			self.validate_from_name()
-			self.validate_destroy_after_submit()
-			self.validate_delivery_mode()
-			self.validate_reply_to()
-			self.validate_headers()
-			self.validate_recipients()
-			self.validate_attachments()
-			self.validate_message_id()
-			self.validate_from_ip()
-			self.validate_sent_at()
-			self.validate_priority()
-			self.validate_in_reply_to()
-			self.validate_in_reply_to_id()
-			self.validate_forwarded_in_reply_to()
-
-	def after_insert(self) -> None:
-		if self.delivery_mode == "Immediate":
-			self._process()
-		elif self.delivery_mode == "Enqueue":
-			frappe.enqueue_doc(self.doctype, self.name, "_process", queue="short", enqueue_after_commit=True)
-
-	def validate_status(self) -> None:
-		"""Validates the status."""
-
-		if self.delivery_mode == "Immediate":
-			self.status = None
-			self.queued_at = None
-		elif self.delivery_mode == "Enqueue":
-			self.status = "Queued"
-			self.queued_at = now()
-		elif self.delivery_mode == "Batch":
-			self.status = "Pending"
-			self.queued_at = None
-
-	def validate_account(self) -> None:
-		"""Validates the JMAP account."""
-
-		if not is_jmap_configured(self.user):
-			frappe.throw(
-				_("User {0} does not have JMAP settings configured.").format(frappe.bold(self.user)),
-				frappe.PermissionError,
-			)
-
-		is_jmap_account_belongs_to_user(self.account, self.user, raise_exception=True)
-
-	def validate_raw_message(self) -> None:
-		"""Validates the raw message."""
-
-		if not self.raw_message:
-			return
-
-		self.from_name = None
-		self.from_email = None
-		self.subject = None
-		self.reply_to = None
-		self.headers = None
-		self.html_body = None
-		self.text_body = None
-		self.attachments = None
-		self.message_id = None
-		self.sent_at = None
-		self.in_reply_to = None
-
-		message = message_from_string(self.raw_message)
-		if from_header := message.get("From"):
-			self.from_name, self.from_email = parseaddr(from_header)
-
-		if message_id := message.get("Message-ID"):
-			self.message_id = message_id.strip("<>")
-
-		if not json_loads(self.recipients):
-			recipients = []
-			for rcpt_type in ["To", "Cc", "Bcc"]:
-				if _rcpt := message.get(rcpt_type):
-					for rcpt in _rcpt.split(","):
-						recipients.append(
-							{
-								"type": rcpt_type,
-								"display_name": parseaddr(rcpt)[0],
-								"email": parseaddr(rcpt)[1],
-							}
-						)
-
-			self.recipients = json.dumps(recipients)
-
-		if date_header := message.get("Date"):
-			self.sent_at = get_datetime_str(parsedate_to_datetime(date_header))
-		if in_reply_to := message.get("In-Reply-To"):
-			self.in_reply_to = in_reply_to.strip("<>")
-
-	def validate_from_email(self) -> None:
-		"""Validates the from email."""
-
-		if self.from_email:
-			if not self.identity:
-				frappe.throw(
-					_(
-						"The From Email {0} is not a valid identity. Please add it as an identity or use a different email address."
-					).format(self.from_email)
-				)
-		else:
-			frappe.throw(_("From Email is required."))
-
-	def validate_from_name(self) -> None:
-		"""Validates the from name."""
-
-		self.from_name = self.from_name or self.identity["_name"]
-
-	def validate_destroy_after_submit(self) -> None:
-		"""Validates the destroy after submit setting."""
-
-		if self.save_as_draft or self.destroy_after_submit:
-			return
-
-		if self.newsletter:
-			if frappe.db.get_value("JMAP Account", self.account, "destroy_newsletter_after_submit"):
-				self.destroy_after_submit = 1
-		elif frappe.db.get_value("JMAP Account", self.account, "destroy_email_after_submit"):
-			self.destroy_after_submit = 1
-
-	def validate_delivery_mode(self) -> None:
-		"""Validates the delivery mode."""
-
-		if self.delivery_mode:
-			if self.delivery_mode not in ["Immediate", "Enqueue", "Batch"]:
-				frappe.throw(_("Invalid delivery mode: {0}").format(self.delivery_mode))
-		else:
-			self.delivery_mode = "Immediate"
-
-	def validate_reply_to(self) -> None:
-		"""Validates the reply to."""
-
-		if self.raw_message:
-			return
-
-		if not json_loads(self.reply_to):
-			if reply_to := self.identity["reply_to"]:
-				self.reply_to = json.dumps(reply_to)
-
-	def validate_headers(self) -> None:
-		"""Validates the headers."""
-
-		standard_headers = {
-			"from",
-			"to",
-			"cc",
-			"bcc",
-			"subject",
-			"date",
-			"message-id",
-			"in-reply-to",
-			"references",
-			"reply-to",
-			"user-agent",
-			"sender",
-			"return-path",
-			"mime-version",
-			"content-type",
-			"content-transfer-encoding",
-			"content-language",
-			"x-mailer",
-			"x-priority",
-			"x-mail-queue",
-		}
-
-		headers = {}
-		for key, value in json_loads(self.headers, default={}).items():
-			if key.lower() in standard_headers:
-				frappe.throw(
-					_(
-						"The header <b>{0}</b> is a standard email header and cannot be overridden. Please use custom headers prefixed with <code>X-</code>."
-					).format(key)
-				)
-
-			headers[key] = value
-
-		self.headers = json.dumps(headers)
-
-	def validate_recipients(self) -> None:
-		"""Validates the recipients."""
-
-		recipients = []
-		for rcpt in json_loads(self.recipients, default=[]):
-			if not rcpt["type"] or not rcpt["email"]:
-				continue
-
-			validate_email_address(rcpt["email"], throw=True)
-
-			recipients.append(
-				{
-					"type": rcpt["type"],
-					"display_name": rcpt.get("display_name"),
-					"email": rcpt["email"],
-				}
-			)
-
-		if not recipients and not self.save_as_draft:
-			frappe.throw(_("Please add at least one recipient."))
-
-		self.recipients = json.dumps(recipients)
-
-	def validate_attachments(self) -> None:
-		"""Validates the attachments."""
-
-		user = self.user if is_administrator(frappe.session.user) else frappe.session.user
-
-		normalized = []
-		seen_blob_ids = set()
-
-		for a in json_loads(self.attachments, default=[]):
-			disposition = a["disposition"]
-			cid = a.get("cid", random_string(length=10))
-
-			if blob_id := a.get("blob_id"):
-				if blob_id in seen_blob_ids:
-					continue
-
-				if not a.get("type"):
-					frappe.throw(_("type is required for blob attachments."))
-
-				normalized.append(
-					{
-						"blob_id": blob_id,
-						"type": a["type"],
-						"size": a["size"],
-						"filename": a["filename"],
-						"disposition": disposition,
-						"cid": cid,
-					}
-				)
-				seen_blob_ids.add(blob_id)
-
-			elif file_url := a.get("file_url"):
-				if file_url.startswith("/private/files"):
-					MailQueue._get_file(file_url=file_url, user=user, check_permission=True)
-				elif not file_url.startswith("/files"):
-					frappe.throw(
-						_(
-							"Invalid file URL: {0}. File URLs must start with '/files/' or '/private/files/'."
-						).format(file_url)
-					)
-
-				normalized.append(
-					{
-						"file_url": file_url,
-						"filename": a.get("filename") or Path(file_url).name,
-						"disposition": disposition,
-						"cid": cid,
-					}
-				)
-
-			else:
-				frappe.throw(_("Either blob_id or file_url is required for attachments."))
-
-		self.attachments = json.dumps(normalized)
-
-	def validate_message_id(self) -> None:
-		"""Validates the message ID."""
-
-		if not self.message_id:
-			self.message_id = make_msgid(domain=self.from_email.split("@")[-1]).strip("<>")
-
-	def validate_from_ip(self) -> None:
-		"""Validates the from IP address."""
-
-		self.from_ip = frappe.local.request_ip
-
-	def validate_sent_at(self) -> None:
-		"""Validates the sent at date."""
-
-		self.sent_at = self.sent_at or now()
-
-	def validate_priority(self) -> None:
-		"""Validates the priority."""
-
-		if self.priority:
-			return
-
-		if self.newsletter:
-			self.priority = "Low"
-		elif self.received_after <= 5:
-			self.priority = "High"
-		else:
-			self.priority = "Normal"
-
-	def validate_in_reply_to(self) -> None:
-		"""Validates the In Reply To (Message ID)."""
-
-		if self.in_reply_to:
-			self.in_reply_to = self.in_reply_to.strip("<>")
-
-	def validate_in_reply_to_id(self) -> None:
-		"""Validates the In Reply To ID."""
-
-		if self.in_reply_to and not self.in_reply_to_id:
-			try:
-				service = get_email_service(self.account)
-				result = service.query({"header": ["Message-ID", self.in_reply_to]})
-				if ids := result["ids"]:
-					self.in_reply_to_id = ids[0]
-			except Exception:
-				self.in_reply_to_id = None
-				log_mail_error(_("Failed to fetch In Reply To ID"), frappe.get_traceback(with_context=True))
-
-	def validate_forwarded_in_reply_to(self) -> None:
-		"""Threads a forwarded email with the original.
-
-		When the account has "Keep Forwarded Email In Thread" enabled, sets the
-		In-Reply-To (Message-ID) of the forwarded email to the original's Message-ID
-		so the mail server assigns it the same thread as the original. The
-		In-Reply-To ID is intentionally left untouched: a forward should mark the
-		original as ``$forwarded`` (via ``forwarded_from_id``), not ``$answered``.
-		"""
-
-		if not self.forwarded_from_id or self.in_reply_to:
-			return
-
-		if not frappe.db.get_value("JMAP Account", self.account, "keep_forwarded_email_in_thread"):
-			return
-
-		try:
-			service = get_email_service(self.account)
-			emails = service.get([self.forwarded_from_id], properties=["messageId"])
-			# JMAP returns messageId as a list of Message-ID strings (RFC 5322 msg-id values).
-			if emails and (message_ids := emails[0].get("messageId")):
-				self.in_reply_to = message_ids[0].strip("<>")
-		except Exception:
-			log_mail_error(
-				_("Failed to fetch forwarded email Message-ID"), frappe.get_traceback(with_context=True)
-			)
-
-	@frappe.whitelist()
-	def retry(self) -> None:
-		"""Retries Create, Update or Submit the Email."""
-
-		frappe.only_for("System Manager")
-
-		if self.status not in ["Failed", "Failed to Draft", "Failed to Submit"]:
-			frappe.throw(_("Cannot retry a mail with status {0}").format(self.status))
-
-		self._process()
-
-	@frappe.whitelist()
-	def get_mime_message(self) -> str:
-		"""Returns the MIME message content."""
-
-		if not self.blob_id:
-			frappe.throw(_("Email does not have a blob ID."))
-
-		from suite.mail.doctype.mail_message.mail_message import fetch_blob
-
-		return fetch_blob(self.account, self.blob_id).decode("utf-8")
-
-	def _process(self) -> None:
-		"""Create, Update or Submit the Email."""
-
-		kwargs = {}
-
-		try:
-			connection = get_jmap_connection(self.user)
-			email_service = EmailService(self.account, connection)
-			mailbox_service = MailboxService(self.account, connection)
-
-			draft_mailbox_id = mailbox_service.get_mailbox_id_by_role(
-				"drafts", create_if_not_exists=True, raise_exception=True
-			)
-			sent_mailbox_id = mailbox_service.get_mailbox_id_by_role(
-				"sent", create_if_not_exists=True, raise_exception=True
-			)
-
-			headers: list[EmailHeader] = []
-			reply_to: list[EmailAddress] = []
-			attachments: list[EmailAttachment] = []
-
-			if not self.raw_message:
-				headers = [
-					EmailHeader(name=key, value=value)
-					for key, value in json_loads(self.headers, default={}).items()
-				]
-				reply_to = [
-					EmailAddress(name=r["display_name"], email=r["email"].lower())
-					for r in json_loads(self.reply_to, default=[])
-				]
-
-				_attachments = []
-				for a in json_loads(self.attachments, default=[]):
-					blob_id = a.get("blob_id")
-					if not blob_id:
-						file = MailQueue._get_file(file_url=a["file_url"], check_permission=False)
-						content = file.get_content()
-						content_type = guess_type(file.file_name)[0]
-						blob = email_service.upload_blob(content, content_type)
-						a.update({"type": blob["type"], "size": blob["size"], "blob_id": blob["blobId"]})
-					_attachments.append(a)
-
-				kwargs["attachments"] = json.dumps(_attachments)
-				attachments = [
-					EmailAttachment(
-						name=a["filename"],
-						type=a["type"],
-						cid=a["cid"],
-						blob_id=a["blob_id"],
-						disposition=a["disposition"],
-					)
-					for a in _attachments
-				]
-
-			recipients = [
-				EmailRecipient(type=r["type"].lower(), name=r["display_name"], email=r["email"].lower())
-				for r in json_loads(self.recipients)
-			]
-
-			email = EmailCreateModel(
-				creation_id=self.name,
-				from_email=self.from_email,
-				recipients=recipients,
-				from_name=self.from_name,
-				subject=self.subject,
-				sent_at=self.sent_at,
-				message_id=self.message_id,
-				reply_to=reply_to,
-				in_reply_to=self.in_reply_to,
-				headers=headers,
-				text_body=self.text_body,
-				html_body=self.html_body,
-				attachments=attachments,
-				raw_message=self.raw_message,
-				existing_id=self.id,
-				save_as_draft=(self.save_as_draft),
-				priority=self._priority,
-				destroy_after_submit=bool(self.destroy_after_submit),
-				forwarded_id=self.forwarded_from_id,
-				reply_to_id=self.in_reply_to_id,
-			)
-
-			response = email_service.create([email])
-
-			kwargs.update({"status": "Failed", "_response": json.dumps(response)})
-			if data := response["methodResponses"][0][1].get("created", {}).get(f"draft-{self.name}"):
-				kwargs.update(
-					{
-						"status": "Drafted",
-						"id": data["id"],
-						"blob_id": data["blobId"],
-						"size": data["size"],
-						"drafted_at": now(),
-						"thread_id": data["threadId"],
-						"mailbox_id": draft_mailbox_id,
-					}
-				)
-			elif response["methodResponses"][0][1].get("notCreated", {}).get(f"draft-{self.name}"):
-				retries = cint(self.retries) + 1
-				kwargs.update(
-					{
-						"status": "Failed to Draft",
-						"retries": retries,
-						"next_retry_after": get_next_retry_after(retries),
-					}
-				)
-
-			if not self.save_as_draft:
-				idx = 2 if self.raw_message and self.id else 1
-				if response["methodResponses"][idx][1].get("created", {}).get(f"submit-{self.name}"):
-					kwargs.update(
-						{
-							"status": "Submitted",
-							"submitted_at": now(),
-							"mailbox_id": sent_mailbox_id,
-						}
-					)
-				elif response["methodResponses"][idx][1].get("notCreated", {}).get(f"submit-{self.name}"):
-					retries = cint(self.retries) + 1
-					kwargs.update(
-						{
-							"status": "Failed to Submit",
-							"retries": retries,
-							"next_retry_after": get_next_retry_after(retries),
-						}
-					)
-		except Exception:
-			retries = cint(self.retries) + 1
-			kwargs.update(
-				{
-					"status": "Failed",
-					"retries": retries,
-					"next_retry_after": get_next_retry_after(retries),
-					"error_log": frappe.get_traceback(with_context=True),
-				}
-			)
-
-		if frappe.flags.read_only:
-			for key, value in kwargs.items():
-				setattr(self, key, value)
-		else:
-			self._db_set(notify=True, **kwargs)
-
-	def _get_recipients(self, type: Literal["To", "Cc", "Bcc"] | None = None) -> list[dict[str, str | None]]:
-		"""Returns the recipients."""
-
-		recipients = []
-		for rcpt in json_loads(self.recipients, default=[]):
-			if type and rcpt["type"] != type:
-				continue
-
-			recipients.append({"name": rcpt["display_name"], "email": rcpt["email"]})
-
-		return recipients
-
-	def _db_set(
-		self,
-		update_modified: bool = True,
-		commit: bool = False,
-		notify: bool = False,
-		**kwargs,
-	) -> None:
-		"""Updates the document with the given key-value pairs."""
-
-		self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
+        if self.from_email:
+            for i in get_identities(self.account):
+                if self.from_email.lower() == i.get("email").lower():
+                    identity = i
+                    break
+
+        return identity
+
+    @property
+    def to(self) -> list[dict[str, str | None]]:
+        """Returns the recipients in the To field."""
+
+        return self._get_recipients("To")
+
+    @property
+    def cc(self) -> list[dict[str, str | None]]:
+        """Returns the recipients in the Cc field."""
+
+        return self._get_recipients("Cc")
+
+    @property
+    def bcc(self) -> list[dict[str, str | None]]:
+        """Returns the recipients in the Bcc field."""
+
+        return self._get_recipients("Bcc")
+
+    @property
+    def received_after(self) -> float:
+        """Returns the time difference in seconds between creation and sent time."""
+
+        if self.sent_at and self.creation:
+            time_diff = time_diff_in_seconds(self.creation, self.sent_at)
+            if time_diff > 0:
+                return time_diff
+
+        return 0.0
+
+    @property
+    def queued_after(self) -> float:
+        """Returns the time difference in seconds between queued and creation time."""
+
+        return time_diff_in_seconds(self.queued_at, self.creation) if self.queued_at else 0.0
+
+    @property
+    def drafted_after(self) -> float:
+        """Returns the time difference in seconds between drafted and creation time."""
+
+        return time_diff_in_seconds(self.drafted_at, self.creation) if self.drafted_at else 0.0
+
+    @property
+    def submitted_after(self) -> float:
+        """Returns the time difference in seconds between submitted and creation time."""
+
+        return time_diff_in_seconds(self.submitted_at, self.creation) if self.submitted_at else 0.0
+
+    @property
+    def message(self) -> str | None:
+        """Returns the message content if available."""
+
+        from suite.mail.doctype.mail_message.mail_message import _get_cached_blobs
+
+        if self.blob_id:
+            blobs = _get_cached_blobs(self.account, [self.blob_id])
+            if content := blobs.get(self.blob_id):
+                return content.decode("utf-8")
+
+    @property
+    def response(self) -> str | None:
+        """Returns the indented JSON response."""
+
+        _response = json_loads(self._response)
+        return json.dumps(_response, indent=4) if _response else None
+
+    @property
+    def error_message(self) -> str | None:
+        """Returns the error message."""
+
+        if not self._response or self.status not in ["Failed to Draft", "Failed to Submit"]:
+            return None
+
+        response = json_loads(self._response)
+
+        data = None
+        if self.status == "Failed to Draft":
+            data = response["methodResponses"][0][1].get("notCreated", {}).get(f"draft-{self.name}")
+        elif self.status == "Failed to Submit":
+            data = response["methodResponses"][-1][1].get("notCreated", {}).get(f"submit-{self.name}")
+
+        if data:
+            message = f"{data['type']}: {data['description']}"
+
+            if data.get("properties"):
+                message += f" ({', '.join(data['properties'])})"
+
+            return message
+
+    def autoname(self) -> None:
+        self.name = str(uuid7())
+
+    def validate(self) -> None:
+        if self.is_new():
+            self.validate_status()
+            self.validate_account()
+            self.validate_raw_message()
+            self.validate_from_email()
+            self.validate_from_name()
+            self.validate_destroy_after_submit()
+            self.validate_delivery_mode()
+            self.validate_reply_to()
+            self.validate_headers()
+            self.validate_recipients()
+            self.validate_attachments()
+            self.validate_message_id()
+            self.validate_from_ip()
+            self.validate_sent_at()
+            self.validate_priority()
+            self.validate_in_reply_to()
+            self.validate_in_reply_to_id()
+            self.validate_forwarded_in_reply_to()
+
+    def after_insert(self) -> None:
+        if self.delivery_mode == "Immediate":
+            self._process()
+        elif self.delivery_mode == "Enqueue":
+            frappe.enqueue_doc(self.doctype, self.name, "_process", queue="short", enqueue_after_commit=True)
+
+    def validate_status(self) -> None:
+        """Validates the status."""
+
+        if self.delivery_mode == "Immediate":
+            self.status = None
+            self.queued_at = None
+        elif self.delivery_mode == "Enqueue":
+            self.status = "Queued"
+            self.queued_at = now()
+        elif self.delivery_mode == "Batch":
+            self.status = "Pending"
+            self.queued_at = None
+
+    def validate_account(self) -> None:
+        """Validates the JMAP account."""
+
+        if not is_jmap_configured(self.user):
+            frappe.throw(
+                _("User {0} does not have JMAP settings configured.").format(frappe.bold(self.user)),
+                frappe.PermissionError,
+            )
+
+        is_jmap_account_belongs_to_user(self.account, self.user, raise_exception=True)
+
+    def validate_raw_message(self) -> None:
+        """Validates the raw message."""
+
+        if not self.raw_message:
+            return
+
+        self.from_name = None
+        self.from_email = None
+        self.subject = None
+        self.reply_to = None
+        self.headers = None
+        self.html_body = None
+        self.text_body = None
+        self.attachments = None
+        self.message_id = None
+        self.sent_at = None
+        self.in_reply_to = None
+
+        message = message_from_string(self.raw_message)
+        if from_header := message.get("From"):
+            self.from_name, self.from_email = parseaddr(from_header)
+
+        if message_id := message.get("Message-ID"):
+            self.message_id = message_id.strip("<>")
+
+        if not json_loads(self.recipients):
+            recipients = []
+            for rcpt_type in ["To", "Cc", "Bcc"]:
+                if _rcpt := message.get(rcpt_type):
+                    for rcpt in _rcpt.split(","):
+                        recipients.append(
+                            {
+                                "type": rcpt_type,
+                                "display_name": parseaddr(rcpt)[0],
+                                "email": parseaddr(rcpt)[1],
+                            }
+                        )
+
+            self.recipients = json.dumps(recipients)
+
+        if date_header := message.get("Date"):
+            self.sent_at = get_datetime_str(parsedate_to_datetime(date_header))
+        if in_reply_to := message.get("In-Reply-To"):
+            self.in_reply_to = in_reply_to.strip("<>")
+
+    def validate_from_email(self) -> None:
+        """Validates the from email."""
+
+        if self.from_email:
+            if not self.identity:
+                frappe.throw(
+                    _(
+                        "The From Email {0} is not a valid identity. Please add it as an identity or use a different email address."
+                    ).format(self.from_email)
+                )
+        else:
+            frappe.throw(_("From Email is required."))
+
+    def validate_from_name(self) -> None:
+        """Validates the from name."""
+
+        self.from_name = self.from_name or self.identity["_name"]
+
+    def validate_destroy_after_submit(self) -> None:
+        """Validates the destroy after submit setting."""
+
+        if self.save_as_draft or self.destroy_after_submit:
+            return
+
+        if self.newsletter:
+            if frappe.db.get_value("JMAP Account", self.account, "destroy_newsletter_after_submit"):
+                self.destroy_after_submit = 1
+        elif frappe.db.get_value("JMAP Account", self.account, "destroy_email_after_submit"):
+            self.destroy_after_submit = 1
+
+    def validate_delivery_mode(self) -> None:
+        """Validates the delivery mode."""
+
+        if self.delivery_mode:
+            if self.delivery_mode not in ["Immediate", "Enqueue", "Batch"]:
+                frappe.throw(_("Invalid delivery mode: {0}").format(self.delivery_mode))
+        else:
+            self.delivery_mode = "Immediate"
+
+    def validate_reply_to(self) -> None:
+        """Validates the reply to."""
+
+        if self.raw_message:
+            return
+
+        if not json_loads(self.reply_to):
+            if reply_to := self.identity["reply_to"]:
+                self.reply_to = json.dumps(reply_to)
+
+    def validate_headers(self) -> None:
+        """Validates the headers."""
+
+        standard_headers = {
+            "from",
+            "to",
+            "cc",
+            "bcc",
+            "subject",
+            "date",
+            "message-id",
+            "in-reply-to",
+            "references",
+            "reply-to",
+            "user-agent",
+            "sender",
+            "return-path",
+            "mime-version",
+            "content-type",
+            "content-transfer-encoding",
+            "content-language",
+            "x-mailer",
+            "x-priority",
+            "x-mail-queue",
+        }
+
+        headers = {}
+        for key, value in json_loads(self.headers, default={}).items():
+            if key.lower() in standard_headers:
+                frappe.throw(
+                    _(
+                        "The header <b>{0}</b> is a standard email header and cannot be overridden. Please use custom headers prefixed with <code>X-</code>."
+                    ).format(key)
+                )
+
+            headers[key] = value
+
+        self.headers = json.dumps(headers)
+
+    def validate_recipients(self) -> None:
+        """Validates the recipients."""
+
+        recipients = []
+        for rcpt in json_loads(self.recipients, default=[]):
+            if not rcpt["type"] or not rcpt["email"]:
+                continue
+
+            validate_email_address(rcpt["email"], throw=True)
+
+            recipients.append(
+                {
+                    "type": rcpt["type"],
+                    "display_name": rcpt.get("display_name"),
+                    "email": rcpt["email"],
+                }
+            )
+
+        if not recipients and not self.save_as_draft:
+            frappe.throw(_("Please add at least one recipient."))
+
+        self.recipients = json.dumps(recipients)
+
+    def validate_attachments(self) -> None:
+        """Validates the attachments."""
+
+        user = self.user if is_administrator(frappe.session.user) else frappe.session.user
+
+        normalized = []
+        seen_blob_ids = set()
+
+        for a in json_loads(self.attachments, default=[]):
+            disposition = a["disposition"]
+            cid = a.get("cid", random_string(length=10))
+
+            if blob_id := a.get("blob_id"):
+                if blob_id in seen_blob_ids:
+                    continue
+
+                if not a.get("type"):
+                    frappe.throw(_("type is required for blob attachments."))
+
+                normalized.append(
+                    {
+                        "blob_id": blob_id,
+                        "type": a["type"],
+                        "size": a["size"],
+                        "filename": a["filename"],
+                        "disposition": disposition,
+                        "cid": cid,
+                    }
+                )
+                seen_blob_ids.add(blob_id)
+
+            elif file_url := a.get("file_url"):
+                if file_url.startswith("/private/files"):
+                    MailQueue._get_file(file_url=file_url, user=user, check_permission=True)
+                elif not file_url.startswith("/files"):
+                    frappe.throw(
+                        _(
+                            "Invalid file URL: {0}. File URLs must start with '/files/' or '/private/files/'."
+                        ).format(file_url)
+                    )
+
+                normalized.append(
+                    {
+                        "file_url": file_url,
+                        "filename": a.get("filename") or Path(file_url).name,
+                        "disposition": disposition,
+                        "cid": cid,
+                    }
+                )
+
+            else:
+                frappe.throw(_("Either blob_id or file_url is required for attachments."))
+
+        self.attachments = json.dumps(normalized)
+
+    def validate_message_id(self) -> None:
+        """Validates the message ID."""
+
+        if not self.message_id:
+            self.message_id = make_msgid(domain=self.from_email.split("@")[-1]).strip("<>")
+
+    def validate_from_ip(self) -> None:
+        """Validates the from IP address."""
+
+        self.from_ip = frappe.local.request_ip
+
+    def validate_sent_at(self) -> None:
+        """Validates the sent at date."""
+
+        self.sent_at = self.sent_at or now()
+
+    def validate_priority(self) -> None:
+        """Validates the priority."""
+
+        if self.priority:
+            return
+
+        if self.newsletter:
+            self.priority = "Low"
+        elif self.received_after <= 5:
+            self.priority = "High"
+        else:
+            self.priority = "Normal"
+
+    def validate_in_reply_to(self) -> None:
+        """Validates the In Reply To (Message ID)."""
+
+        if self.in_reply_to:
+            self.in_reply_to = self.in_reply_to.strip("<>")
+
+    def validate_in_reply_to_id(self) -> None:
+        """Validates the In Reply To ID."""
+
+        if self.in_reply_to and not self.in_reply_to_id:
+            try:
+                service = get_email_service(self.account)
+                result = service.query({"header": ["Message-ID", self.in_reply_to]})
+                if ids := result["ids"]:
+                    self.in_reply_to_id = ids[0]
+            except Exception:
+                self.in_reply_to_id = None
+                log_mail_error(_("Failed to fetch In Reply To ID"), frappe.get_traceback(with_context=True))
+
+    def validate_forwarded_in_reply_to(self) -> None:
+        """Threads a forwarded email with the original.
+
+        When the account has "Keep Forwarded Email In Thread" enabled, sets the
+        In-Reply-To (Message-ID) of the forwarded email to the original's Message-ID
+        so the mail server assigns it the same thread as the original. The
+        In-Reply-To ID is intentionally left untouched: a forward should mark the
+        original as ``$forwarded`` (via ``forwarded_from_id``), not ``$answered``.
+        """
+
+        if not self.forwarded_from_id or self.in_reply_to:
+            return
+
+        if not frappe.db.get_value("JMAP Account", self.account, "keep_forwarded_email_in_thread"):
+            return
+
+        try:
+            service = get_email_service(self.account)
+            emails = service.get([self.forwarded_from_id], properties=["messageId"])
+            # JMAP returns messageId as a list of Message-ID strings (RFC 5322 msg-id values).
+            if emails and (message_ids := emails[0].get("messageId")):
+                self.in_reply_to = message_ids[0].strip("<>")
+        except Exception:
+            log_mail_error(
+                _("Failed to fetch forwarded email Message-ID"), frappe.get_traceback(with_context=True)
+            )
+
+    @frappe.whitelist()
+    def retry(self) -> None:
+        """Retries Create, Update or Submit the Email."""
+
+        frappe.only_for("System Manager")
+
+        if self.status not in ["Failed", "Failed to Draft", "Failed to Submit"]:
+            frappe.throw(_("Cannot retry a mail with status {0}").format(self.status))
+
+        self._process()
+
+    @frappe.whitelist()
+    def get_mime_message(self) -> str:
+        """Returns the MIME message content."""
+
+        if not self.blob_id:
+            frappe.throw(_("Email does not have a blob ID."))
+
+        from suite.mail.doctype.mail_message.mail_message import fetch_blob
+
+        return fetch_blob(self.account, self.blob_id).decode("utf-8")
+
+    def _process(self) -> None:
+        """Create, Update or Submit the Email."""
+
+        kwargs = {}
+
+        try:
+            connection = get_jmap_connection(self.user)
+            email_service = EmailService(self.account, connection)
+            mailbox_service = MailboxService(self.account, connection)
+
+            draft_mailbox_id = mailbox_service.get_mailbox_id_by_role(
+                "drafts", create_if_not_exists=True, raise_exception=True
+            )
+            sent_mailbox_id = mailbox_service.get_mailbox_id_by_role(
+                "sent", create_if_not_exists=True, raise_exception=True
+            )
+
+            headers: list[EmailHeader] = []
+            reply_to: list[EmailAddress] = []
+            attachments: list[EmailAttachment] = []
+
+            if not self.raw_message:
+                headers = [
+                    EmailHeader(name=key, value=value)
+                    for key, value in json_loads(self.headers, default={}).items()
+                ]
+                reply_to = [
+                    EmailAddress(name=r["display_name"], email=r["email"].lower())
+                    for r in json_loads(self.reply_to, default=[])
+                ]
+
+                _attachments = []
+                for a in json_loads(self.attachments, default=[]):
+                    blob_id = a.get("blob_id")
+                    if not blob_id:
+                        file = MailQueue._get_file(file_url=a["file_url"], check_permission=False)
+                        content = file.get_content()
+                        content_type = guess_type(file.file_name)[0]
+                        blob = email_service.upload_blob(content, content_type)
+                        a.update({"type": blob["type"], "size": blob["size"], "blob_id": blob["blobId"]})
+                    _attachments.append(a)
+
+                kwargs["attachments"] = json.dumps(_attachments)
+                attachments = [
+                    EmailAttachment(
+                        name=a["filename"],
+                        type=a["type"],
+                        cid=a["cid"],
+                        blob_id=a["blob_id"],
+                        disposition=a["disposition"],
+                    )
+                    for a in _attachments
+                ]
+
+            recipients = [
+                EmailRecipient(type=r["type"].lower(), name=r["display_name"], email=r["email"].lower())
+                for r in json_loads(self.recipients)
+            ]
+
+            email = EmailCreateModel(
+                creation_id=self.name,
+                from_email=self.from_email,
+                recipients=recipients,
+                from_name=self.from_name,
+                subject=self.subject,
+                sent_at=self.sent_at,
+                message_id=self.message_id,
+                reply_to=reply_to,
+                in_reply_to=self.in_reply_to,
+                headers=headers,
+                text_body=self.text_body,
+                html_body=self.html_body,
+                attachments=attachments,
+                raw_message=self.raw_message,
+                existing_id=self.id,
+                save_as_draft=(self.save_as_draft),
+                priority=self._priority,
+                destroy_after_submit=bool(self.destroy_after_submit),
+                forwarded_id=self.forwarded_from_id,
+                reply_to_id=self.in_reply_to_id,
+            )
+
+            response = email_service.create([email])
+
+            kwargs.update({"status": "Failed", "_response": json.dumps(response)})
+            if data := response["methodResponses"][0][1].get("created", {}).get(f"draft-{self.name}"):
+                kwargs.update(
+                    {
+                        "status": "Drafted",
+                        "id": data["id"],
+                        "blob_id": data["blobId"],
+                        "size": data["size"],
+                        "drafted_at": now(),
+                        "thread_id": data["threadId"],
+                        "mailbox_id": draft_mailbox_id,
+                    }
+                )
+            elif response["methodResponses"][0][1].get("notCreated", {}).get(f"draft-{self.name}"):
+                retries = cint(self.retries) + 1
+                kwargs.update(
+                    {
+                        "status": "Failed to Draft",
+                        "retries": retries,
+                        "next_retry_after": get_next_retry_after(retries),
+                    }
+                )
+
+            if not self.save_as_draft:
+                idx = 2 if self.raw_message and self.id else 1
+                if response["methodResponses"][idx][1].get("created", {}).get(f"submit-{self.name}"):
+                    kwargs.update(
+                        {
+                            "status": "Submitted",
+                            "submitted_at": now(),
+                            "mailbox_id": sent_mailbox_id,
+                        }
+                    )
+                elif response["methodResponses"][idx][1].get("notCreated", {}).get(f"submit-{self.name}"):
+                    retries = cint(self.retries) + 1
+                    kwargs.update(
+                        {
+                            "status": "Failed to Submit",
+                            "retries": retries,
+                            "next_retry_after": get_next_retry_after(retries),
+                        }
+                    )
+        except Exception:
+            retries = cint(self.retries) + 1
+            kwargs.update(
+                {
+                    "status": "Failed",
+                    "retries": retries,
+                    "next_retry_after": get_next_retry_after(retries),
+                    "error_log": frappe.get_traceback(with_context=True),
+                }
+            )
+
+        if frappe.flags.read_only:
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+        else:
+            self._db_set(notify=True, **kwargs)
+
+    def _get_recipients(self, type: Literal["To", "Cc", "Bcc"] | None = None) -> list[dict[str, str | None]]:
+        """Returns the recipients."""
+
+        recipients = []
+        for rcpt in json_loads(self.recipients, default=[]):
+            if type and rcpt["type"] != type:
+                continue
+
+            recipients.append({"name": rcpt["display_name"], "email": rcpt["email"]})
+
+        return recipients
+
+    def _db_set(
+        self,
+        update_modified: bool = True,
+        commit: bool = False,
+        notify: bool = False,
+        **kwargs,
+    ) -> None:
+        """Updates the document with the given key-value pairs."""
+
+        self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
 
 
 @frappe.whitelist()
 def bulk_retry(names: str | list[str]) -> None:
-	"""Retries the emails with the given names."""
+    """Retries the emails with the given names."""
 
-	frappe.only_for("System Manager")
+    frappe.only_for("System Manager")
 
-	if isinstance(names, str):
-		names = json.loads(names)
+    if isinstance(names, str):
+        names = json.loads(names)
 
-	for name in names:
-		doc = frappe.get_doc("Mail Queue", name)
-		if doc.status in ["Failed", "Failed to Draft", "Failed to Submit"]:
-			doc.retry()
+    for name in names:
+        doc = frappe.get_doc("Mail Queue", name)
+        if doc.status in ["Failed", "Failed to Draft", "Failed to Submit"]:
+            doc.retry()
 
-	frappe.msgprint(
-		_("Successfully retried {0} emails.").format(frappe.bold(len(names))),
-		indicator="green",
-		alert=True,
-	)
+    frappe.msgprint(
+        _("Successfully retried {0} emails.").format(frappe.bold(len(names))),
+        indicator="green",
+        alert=True,
+    )
 
 
 def json_loads(data: str | None, default: Any = None) -> list | dict | None:
-	"""Loads the given JSON data and returns it as a list or dict."""
+    """Loads the given JSON data and returns it as a list or dict."""
 
-	if data:
-		return json.loads(data)
+    if data:
+        return json.loads(data)
 
-	return default
+    return default
 
 
 def get_next_retry_after(retries: int) -> str:
-	"""Returns the next retry after datetime."""
+    """Returns the next retry after datetime."""
 
-	next_retry_after_minutes = retries * (retries + 1)  # 2, 6, 12, 20, 30 ...
-	return add_to_date(now(), minutes=next_retry_after_minutes)
+    next_retry_after_minutes = retries * (retries + 1)  # 2, 6, 12, 20, 30 ...
+    return add_to_date(now(), minutes=next_retry_after_minutes)
 
 
 def process_pending_emails(mails: list[str]) -> None:
-	"""Process pending emails."""
+    """Process pending emails."""
 
-	failed_mails = []
-	total_count = len(mails)
+    failed_mails = []
+    total_count = len(mails)
 
-	for mail in mails:
-		doc: MailQueue = frappe.get_doc("Mail Queue", mail)
-		doc._process()
+    for mail in mails:
+        doc: MailQueue = frappe.get_doc("Mail Queue", mail)
+        doc._process()
 
-		if doc.status in ["Failed", "Failed to Draft", "Failed to Submit"]:
-			failed_mails.append(mail)
+        if doc.status in ["Failed", "Failed to Draft", "Failed to Submit"]:
+            failed_mails.append(mail)
 
-			retries = len(failed_mails)
-			failure_ratio = retries / total_count
+            retries = len(failed_mails)
+            failure_ratio = retries / total_count
 
-			if failure_ratio > 0.33 and retries > 50:
-				frappe.throw(
-					_(
-						"Email processing aborted: {retries} out of {total_count} emails failed "
-						"({failure_rate:.2%} failure rate). Please investigate the issue before retrying."
-					).format(retries=retries, total_count=total_count, failure_rate=failure_ratio)
-				)
+            if failure_ratio > 0.33 and retries > 50:
+                frappe.throw(
+                    _(
+                        "Email processing aborted: {retries} out of {total_count} emails failed "
+                        "({failure_rate:.2%} failure rate). Please investigate the issue before retrying."
+                    ).format(retries=retries, total_count=total_count, failure_rate=failure_ratio)
+                )
 
 
 def enqueue_process_pending_emails(batch_size: int | None = None, max_batch_size: int | None = None) -> None:
-	"""Enqueue process pending emails."""
+    """Enqueue process pending emails."""
 
-	batch_size = batch_size or cint(get_config("process_pending_emails_batch_size"))
-	max_batch_size = max_batch_size or cint(get_config("process_pending_emails_max_batch_size"))
+    batch_size = batch_size or cint(get_config("process_pending_emails_batch_size"))
+    max_batch_size = max_batch_size or cint(get_config("process_pending_emails_max_batch_size"))
 
-	if batch_size > max_batch_size:
-		batch_size = max_batch_size
+    if batch_size > max_batch_size:
+        batch_size = max_batch_size
 
-	MQ = frappe.qb.DocType("Mail Queue")
+    MQ = frappe.qb.DocType("Mail Queue")
 
-	priority_order = Case()
-	priority_order.when(MQ.priority == "High", 1)
-	priority_order.when(MQ.priority == "Normal", 2)
-	priority_order.when(MQ.priority == "Low", 3)
-	priority_order.else_(4)
+    priority_order = Case()
+    priority_order.when(MQ.priority == "High", 1)
+    priority_order.when(MQ.priority == "Normal", 2)
+    priority_order.when(MQ.priority == "Low", 3)
+    priority_order.else_(4)
 
-	mails = (
-		frappe.qb.from_(MQ)
-		.select(MQ.name)
-		.where(
-			(MQ.status == "Pending")
-			| (
-				(MQ.retries > 0)
-				& (MQ.retries < MQ.max_retries)
-				& (MQ.next_retry_after <= now_datetime())
-				& (MQ.status.isin(["Failed", "Failed to Draft", "Failed to Submit"]))
-			)
-			| ((MQ.status == "Queued") & (MQ.queued_at <= get_datetime(add_to_date(now(), minutes=-30))))
-		)
-		.orderby(priority_order, MQ.creation, MQ.retries, order=Order.asc)
-		.limit(max_batch_size)
-	).run(pluck="name")
+    mails = (
+        frappe.qb.from_(MQ)
+        .select(MQ.name)
+        .where(
+            (MQ.status == "Pending")
+            | (
+                (MQ.retries > 0)
+                & (MQ.retries < MQ.max_retries)
+                & (MQ.next_retry_after <= now_datetime())
+                & (MQ.status.isin(["Failed", "Failed to Draft", "Failed to Submit"]))
+            )
+            | ((MQ.status == "Queued") & (MQ.queued_at <= get_datetime(add_to_date(now(), minutes=-30))))
+        )
+        .orderby(priority_order, MQ.creation, MQ.retries, order=Order.asc)
+        .limit(max_batch_size)
+    ).run(pluck="name")
 
-	if not mails:
-		return
+    if not mails:
+        return
 
-	try:
-		(
-			frappe.qb.update(MQ)
-			.set(MQ.status, "Queued")
-			.set(MQ.queued_at, now())
-			.where((MQ.name.isin(mails)) & (MQ.status.notin(["Drafted", "Submitted"])))
-		).run()
+    try:
+        (
+            frappe.qb.update(MQ)
+            .set(MQ.status, "Queued")
+            .set(MQ.queued_at, now())
+            .where((MQ.name.isin(mails)) & (MQ.status.notin(["Drafted", "Submitted"])))
+        ).run()
 
-		for i, batch in enumerate(create_batch(mails, batch_size), start=1):
-			frappe.enqueue(
-				process_pending_emails,
-				queue="long",
-				timeout=cint(get_config("process_pending_emails_timeout")),
-				job_name=f"process_pending_emails_{i}_{len(batch)}",
-				enqueue_after_commit=False,
-				mails=batch,
-			)
+        for i, batch in enumerate(create_batch(mails, batch_size), start=1):
+            frappe.enqueue(
+                process_pending_emails,
+                queue="long",
+                timeout=cint(get_config("process_pending_emails_timeout")),
+                job_name=f"process_pending_emails_{i}_{len(batch)}",
+                enqueue_after_commit=False,
+                mails=batch,
+            )
 
-		# Recursively process next batch if the limit was reached.
-		if len(mails) == max_batch_size:
-			enqueue_process_pending_emails(batch_size, max_batch_size)
+        # Recursively process next batch if the limit was reached.
+        if len(mails) == max_batch_size:
+            enqueue_process_pending_emails(batch_size, max_batch_size)
 
-	except Exception:
-		log_mail_error(_("Failed - Enqueue Process Pending Emails"), frappe.get_traceback(with_context=True))
+    except Exception:
+        log_mail_error(_("Failed - Enqueue Process Pending Emails"), frappe.get_traceback(with_context=True))

--- a/suite/mail/doctype/mail_queue/test_mail_queue.py
+++ b/suite/mail/doctype/mail_queue/test_mail_queue.py
@@ -12,18 +12,18 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class UnitTestMailQueue(UnitTestCase):
-	"""
-	Unit tests for MailQueue.
-	Use this class for testing individual functions and methods.
-	"""
+    """
+    Unit tests for MailQueue.
+    Use this class for testing individual functions and methods.
+    """
 
-	pass
+    pass
 
 
 class IntegrationTestMailQueue(IntegrationTestCase):
-	"""
-	Integration tests for MailQueue.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for MailQueue.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/mail_server/mail_server.py
+++ b/suite/mail/doctype/mail_server/mail_server.py
@@ -17,210 +17,212 @@ from suite.mail.utils.dns import get_dns_record
 
 
 class MailServer(Document):
-	@property
-	def ssh_public_key(self) -> str | None:
-		"""Returns the SSH public key of the cluster."""
+    @property
+    def ssh_public_key(self) -> str | None:
+        """Returns the SSH public key of the cluster."""
 
-		return frappe.db.get_value("Mail Cluster", self.cluster, "ssh_public_key")
+        return frappe.db.get_value("Mail Cluster", self.cluster, "ssh_public_key")
 
-	def autoname(self) -> None:
-		self.hostname = self.hostname.lower()
-		self.name = self.hostname
+    def autoname(self) -> None:
+        self.hostname = self.hostname.lower()
+        self.name = self.hostname
 
-	def validate(self) -> None:
-		self.validate_hostname()
-		self.validate_cluster()
-		self.set_bootstrap_ndjson()
+    def validate(self) -> None:
+        self.validate_hostname()
+        self.validate_cluster()
+        self.set_bootstrap_ndjson()
 
-	def on_trash(self) -> None:
-		if frappe.session.user != "Administrator":
-			frappe.throw(_("Only Administrator can delete Mail Server."))
+    def on_trash(self) -> None:
+        if frappe.session.user != "Administrator":
+            frappe.throw(_("Only Administrator can delete Mail Server."))
 
-	def validate_hostname(self) -> None:
-		"""Validates the server and fetches the IP addresses."""
+    def validate_hostname(self) -> None:
+        """Validates the server and fetches the IP addresses."""
 
-		if self.is_new() and frappe.db.exists("Mail Server", self.hostname):
-			frappe.throw(_("Mail Server {0} already exists.").format(frappe.bold(self.hostname)))
+        if self.is_new() and frappe.db.exists("Mail Server", self.hostname):
+            frappe.throw(_("Mail Server {0} already exists.").format(frappe.bold(self.hostname)))
 
-		self.ipv4_addresses = "\n".join([r.address for r in get_dns_record(self.hostname, "A") or []])
-		self.ipv6_addresses = "\n".join([r.address for r in get_dns_record(self.hostname, "AAAA") or []])
+        self.ipv4_addresses = "\n".join([r.address for r in get_dns_record(self.hostname, "A") or []])
+        self.ipv6_addresses = "\n".join([r.address for r in get_dns_record(self.hostname, "AAAA") or []])
 
-	def validate_cluster(self) -> None:
-		"""Validates the cluster."""
+    def validate_cluster(self) -> None:
+        """Validates the cluster."""
 
-		if not frappe.db.get_value("Mail Cluster", self.cluster, "enabled"):
-			frappe.throw(_("Mail Cluster {0} is disabled.").format(frappe.bold(self.cluster)))
+        if not frappe.db.get_value("Mail Cluster", self.cluster, "enabled"):
+            frappe.throw(_("Mail Cluster {0} is disabled.").format(frappe.bold(self.cluster)))
 
-	def set_bootstrap_ndjson(self) -> None:
-		"""Sets the bootstrap NDJSON for the server."""
+    def set_bootstrap_ndjson(self) -> None:
+        """Sets the bootstrap NDJSON for the server."""
 
-		if not self.bootstrap_ndjson:
-			self.bootstrap_ndjson = self._generate_bootstrap_ndjson()
+        if not self.bootstrap_ndjson:
+            self.bootstrap_ndjson = self._generate_bootstrap_ndjson()
 
-	@frappe.whitelist()
-	def regenerate_bootstrap_ndjson(self) -> None:
-		"""Regenerates the bootstrap NDJSON for the server."""
+    @frappe.whitelist()
+    def regenerate_bootstrap_ndjson(self) -> None:
+        """Regenerates the bootstrap NDJSON for the server."""
 
-		frappe.only_for("System Manager")
-		self.bootstrap_ndjson = self._generate_bootstrap_ndjson()
-		self._db_set(bootstrap_ndjson=self.bootstrap_ndjson, notify=True)
-		frappe.msgprint(_("Bootstrap NDJSON regenerated."), indicator="green", alert=True)
+        frappe.only_for("System Manager")
+        self.bootstrap_ndjson = self._generate_bootstrap_ndjson()
+        self._db_set(bootstrap_ndjson=self.bootstrap_ndjson, notify=True)
+        frappe.msgprint(_("Bootstrap NDJSON regenerated."), indicator="green", alert=True)
 
-	def _generate_bootstrap_ndjson(self) -> str:
-		"""Generates the bootstrap NDJSON for the server."""
+    def _generate_bootstrap_ndjson(self) -> str:
+        """Generates the bootstrap NDJSON for the server."""
 
-		cluster = frappe.get_doc("Mail Cluster", self.cluster)
-		operations = cluster.get_bootstrap_operations(self.hostname)
+        cluster = frappe.get_doc("Mail Cluster", self.cluster)
+        operations = cluster.get_bootstrap_operations(self.hostname)
 
-		return "\n".join([json.dumps(op) for op in operations])
+        return "\n".join([json.dumps(op) for op in operations])
 
-	@frappe.whitelist()
-	def verify_ssh_connection(self) -> None:
-		"""Verifies the SSH connection to the server."""
+    @frappe.whitelist()
+    def verify_ssh_connection(self) -> None:
+        """Verifies the SSH connection to the server."""
 
-		frappe.only_for("System Manager")
-		success, message = self._verify_ssh_connection()
+        frappe.only_for("System Manager")
+        success, message = self._verify_ssh_connection()
 
-		if success:
-			self._db_set(ssh_verified=1, notify=True)
-			frappe.msgprint(message, indicator="green", alert=True)
-		else:
-			self._db_set(ssh_verified=0, notify=True)
-			frappe.msgprint(message, indicator="red", alert=False)
+        if success:
+            self._db_set(ssh_verified=1, notify=True)
+            frappe.msgprint(message, indicator="green", alert=True)
+        else:
+            self._db_set(ssh_verified=0, notify=True)
+            frappe.msgprint(message, indicator="red", alert=False)
 
-	def _verify_ssh_connection(self) -> tuple[bool, str]:
-		"""Verifies the SSH connection to the server."""
+    def _verify_ssh_connection(self) -> tuple[bool, str]:
+        """Verifies the SSH connection to the server."""
 
-		sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-		sock.settimeout(5)
-		try:
-			sock.connect((self.hostname, self.ssh_port))
-		except Exception as e:
-			return False, _("Could not connect to {0}:{1}. Error: {2}").format(
-				self.hostname, self.ssh_port, str(e)
-			)
-		finally:
-			sock.close()
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(5)
+        try:
+            sock.connect((self.hostname, self.ssh_port))
+        except Exception as e:
+            return False, _("Could not connect to {0}:{1}. Error: {2}").format(
+                self.hostname, self.ssh_port, str(e)
+            )
+        finally:
+            sock.close()
 
-		cluster = frappe.get_doc("Mail Cluster", self.cluster)
-		try:
-			client = paramiko.SSHClient()
-			client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-			key = paramiko.RSAKey.from_private_key(io.StringIO(cluster.get_password("ssh_private_key")))
-			client.connect(
-				hostname=self.hostname, port=self.ssh_port, username=self.ssh_user, pkey=key, timeout=10
-			)
-			client.close()
-			return True, _("SSH connection successful.")
-		except Exception as e:
-			return False, _("SSH connection failed. Error: {0}").format(str(e))
+        cluster = frappe.get_doc("Mail Cluster", self.cluster)
+        try:
+            client = paramiko.SSHClient()
+            client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            key = paramiko.RSAKey.from_private_key(io.StringIO(cluster.get_password("ssh_private_key")))
+            client.connect(
+                hostname=self.hostname, port=self.ssh_port, username=self.ssh_user, pkey=key, timeout=10
+            )
+            client.close()
+            return True, _("SSH connection successful.")
+        except Exception as e:
+            return False, _("SSH connection failed. Error: {0}").format(str(e))
 
-	@frappe.whitelist()
-	def install_ansible(self) -> None:
-		"""Installs Ansible on the Mail Server."""
+    @frappe.whitelist()
+    def install_ansible(self) -> None:
+        """Installs Ansible on the Mail Server."""
 
-		frappe.only_for("System Manager")
+        frappe.only_for("System Manager")
 
-		if not self.ssh_verified:
-			frappe.throw(_("Please verify the SSH connection before installing Ansible."))
+        if not self.ssh_verified:
+            frappe.throw(_("Please verify the SSH connection before installing Ansible."))
 
-		self._install_ansible()
-		frappe.msgprint(_("Install of Ansible initiated."), indicator="green", alert=True)
+        self._install_ansible()
+        frappe.msgprint(_("Install of Ansible initiated."), indicator="green", alert=True)
 
-	def _install_ansible(self) -> None:
-		"""Installs Ansible on the Mail Server."""
+    def _install_ansible(self) -> None:
+        """Installs Ansible on the Mail Server."""
 
-		script_path = os.path.join(frappe.get_app_path("suite", "mail", "utils", "ansible"), "install_ansible.sh")
-		with open(script_path) as f:
-			script_content = f.read()
+        script_path = os.path.join(
+            frappe.get_app_path("suite", "mail", "utils", "ansible"), "install_ansible.sh"
+        )
+        with open(script_path) as f:
+            script_content = f.read()
 
-		job = frappe.new_doc("Server Job")
-		job.status = "Pending"
-		job.server = self.name
-		job.job = "Install Ansible"
-		job.append("commands", {"command": script_content})
-		job.insert(ignore_permissions=True)
+        job = frappe.new_doc("Server Job")
+        job.status = "Pending"
+        job.server = self.name
+        job.job = "Install Ansible"
+        job.append("commands", {"command": script_content})
+        job.insert(ignore_permissions=True)
 
-	@frappe.whitelist()
-	def install_docker(self) -> None:
-		"""Installs Docker on the Mail Server."""
+    @frappe.whitelist()
+    def install_docker(self) -> None:
+        """Installs Docker on the Mail Server."""
 
-		frappe.only_for("System Manager")
+        frappe.only_for("System Manager")
 
-		if not self.ssh_verified:
-			frappe.throw(_("Please verify the SSH connection before installing Docker."))
+        if not self.ssh_verified:
+            frappe.throw(_("Please verify the SSH connection before installing Docker."))
 
-		self._install_docker()
-		frappe.msgprint(_("Install of Docker initiated."), indicator="green", alert=True)
+        self._install_docker()
+        frappe.msgprint(_("Install of Docker initiated."), indicator="green", alert=True)
 
-	def _install_docker(self) -> None:
-		"""Installs Docker on the Mail Server."""
+    def _install_docker(self) -> None:
+        """Installs Docker on the Mail Server."""
 
-		play = frappe.new_doc("Server Ansible Play")
-		play.status = "Pending"
-		play.server = self.name
-		play.play = "Install Docker"
-		play.playbook = "install-docker.yml"
-		play.insert(ignore_permissions=True)
+        play = frappe.new_doc("Server Ansible Play")
+        play.status = "Pending"
+        play.server = self.name
+        play.play = "Install Docker"
+        play.playbook = "install-docker.yml"
+        play.insert(ignore_permissions=True)
 
-	@frappe.whitelist()
-	def install_stalwart(self) -> None:
-		"""Installs Stalwart on the Mail Server."""
+    @frappe.whitelist()
+    def install_stalwart(self) -> None:
+        """Installs Stalwart on the Mail Server."""
 
-		frappe.only_for("System Manager")
+        frappe.only_for("System Manager")
 
-		if not self.ssh_verified:
-			frappe.throw(_("Please verify the SSH connection before installing Stalwart."))
+        if not self.ssh_verified:
+            frappe.throw(_("Please verify the SSH connection before installing Stalwart."))
 
-		self._install_stalwart()
-		frappe.msgprint(_("Install of Stalwart initiated."), indicator="green", alert=True)
+        self._install_stalwart()
+        frappe.msgprint(_("Install of Stalwart initiated."), indicator="green", alert=True)
 
-	def _install_stalwart(self) -> None:
-		"""Installs Stalwart on the Mail Server."""
+    def _install_stalwart(self) -> None:
+        """Installs Stalwart on the Mail Server."""
 
-		deployment = frappe.new_doc("Server Deployment")
-		deployment.status = "Pending"
-		deployment.server = self.name
-		deployment.max_retries = 0
-		deployment.insert(ignore_permissions=True)
+        deployment = frappe.new_doc("Server Deployment")
+        deployment.status = "Pending"
+        deployment.server = self.name
+        deployment.max_retries = 0
+        deployment.insert(ignore_permissions=True)
 
-	def _get_stalwart_env(
-		self,
-		recovery_mode: bool = False,
-		role: str | None = None,
-		push_shard: str | None = None,
-		as_dict: bool = False,
-	) -> str | dict:
-		"""Returns the environment variables for Stalwart."""
+    def _get_stalwart_env(
+        self,
+        recovery_mode: bool = False,
+        role: str | None = None,
+        push_shard: str | None = None,
+        as_dict: bool = False,
+    ) -> str | dict:
+        """Returns the environment variables for Stalwart."""
 
-		cluster = frappe.get_doc("Mail Cluster", self.cluster)
-		env = {
-			"STALWART_HOSTNAME": self.hostname,
-			"STALWART_RECOVERY_MODE": cint(recovery_mode),
-			"STALWART_RECOVERY_MODE_PORT": cint(self.recovery_http_port),
-			"STALWART_RECOVERY_MODE_LOG_LEVEL": "debug",
-			"STALWART_RECOVERY_ADMIN": f"{cluster.recovery_admin_user}:{cluster.get_password('recovery_admin_password')}",
-		}
+        cluster = frappe.get_doc("Mail Cluster", self.cluster)
+        env = {
+            "STALWART_HOSTNAME": self.hostname,
+            "STALWART_RECOVERY_MODE": cint(recovery_mode),
+            "STALWART_RECOVERY_MODE_PORT": cint(self.recovery_http_port),
+            "STALWART_RECOVERY_MODE_LOG_LEVEL": "debug",
+            "STALWART_RECOVERY_ADMIN": f"{cluster.recovery_admin_user}:{cluster.get_password('recovery_admin_password')}",
+        }
 
-		if cluster.base_url:
-			env["STALWART_PUBLIC_URL"] = cluster.base_url
-		if role:
-			env["STALWART_ROLE"] = role
-		if push_shard:
-			env["STALWART_PUSH_SHARD"] = push_shard
+        if cluster.base_url:
+            env["STALWART_PUBLIC_URL"] = cluster.base_url
+        if role:
+            env["STALWART_ROLE"] = role
+        if push_shard:
+            env["STALWART_PUSH_SHARD"] = push_shard
 
-		if as_dict:
-			return env
+        if as_dict:
+            return env
 
-		return "\n".join([f"{key}={value}" for key, value in env.items()])
+        return "\n".join([f"{key}={value}" for key, value in env.items()])
 
-	def _db_set(
-		self,
-		update_modified: bool = True,
-		commit: bool = False,
-		notify: bool = False,
-		**kwargs,
-	) -> None:
-		"""Updates the document with the given key-value pairs."""
+    def _db_set(
+        self,
+        update_modified: bool = True,
+        commit: bool = False,
+        notify: bool = False,
+        **kwargs,
+    ) -> None:
+        """Updates the document with the given key-value pairs."""
 
-		self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
+        self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)

--- a/suite/mail/doctype/mail_server/test_mail_server.py
+++ b/suite/mail/doctype/mail_server/test_mail_server.py
@@ -6,4 +6,4 @@ from frappe.tests.utils import FrappeTestCase
 
 
 class TestMailServer(FrappeTestCase):
-	pass
+    pass

--- a/suite/mail/doctype/mail_settings/mail_settings.py
+++ b/suite/mail/doctype/mail_settings/mail_settings.py
@@ -14,294 +14,294 @@ from suite.mail.utils import is_stalwart_configured
 
 
 class MailSettings(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		from suite.mail.doctype.mail_client_configuration.mail_client_configuration import (
-			MailClientConfiguration,
-		)
+        from suite.mail.doctype.mail_client_configuration.mail_client_configuration import (
+            MailClientConfiguration,
+        )
 
-		admin_log_file_count: DF.Int
-		admin_log_level: DF.Literal["ERROR", "WARNING", "INFO", "DEBUG"]
-		admin_log_max_file_size: DF.Int
-		allow_signup: DF.Check
-		ansible_play_timeout: DF.Int
-		custom_event_invites: DF.Check
-		default_disk_quota_gb: DF.Int
-		default_dns_ttl: DF.Int
-		default_gravatar: DF.Literal["404"]
-		disabled_account_role: DF.Data | None
-		dns_provider: DF.Literal[
-			"", "AmazonRoute53", "DigitalOcean", "Cloudflare", "Hetzner", "Linode", "Namecheap", "GoDaddy"
-		]
-		dns_provider_access_key: DF.Data | None
-		dns_provider_access_secret: DF.Password | None
-		dns_provider_client_ip: DF.Data | None
-		dns_provider_key: DF.Data | None
-		dns_provider_private_zone: DF.Check
-		dns_provider_secret: DF.Password | None
-		dns_provider_token: DF.Password | None
-		dns_provider_username: DF.Data | None
-		dns_provider_zone_id: DF.Data | None
-		enable_gravatar: DF.Check
-		enable_jmap_push_encryption: DF.Check
-		exchange_export_batch_size: DF.Int
-		exchange_export_timeout: DF.Int
-		exchange_import_timeout: DF.Int
-		exchange_log_file_count: DF.Int
-		exchange_log_level: DF.Literal["ERROR", "WARNING", "INFO", "DEBUG"]
-		exchange_log_max_file_size: DF.Int
-		exchange_max_export: DF.Int
-		exchange_max_import: DF.Int
-		inbound_log_file_count: DF.Int
-		inbound_log_level: DF.Literal["ERROR", "WARNING", "INFO", "DEBUG"]
-		inbound_log_max_file_size: DF.Int
-		jmap_push_auth: DF.Password | None
-		jmap_push_p256dh: DF.Data | None
-		jmap_push_private_key: DF.Password | None
-		mail_client_configurations: DF.Table[MailClientConfiguration]
-		max_email_sync: DF.Int
-		max_message_payload_size_mb: DF.Int
-		max_push_notifications: DF.Int
-		outbound_log_file_count: DF.Int
-		outbound_log_level: DF.Literal["ERROR", "WARNING", "INFO", "DEBUG"]
-		outbound_log_max_file_size: DF.Int
-		password: DF.Password | None
-		process_pending_emails_batch_size: DF.Int
-		process_pending_emails_max_batch_size: DF.Int
-		process_pending_emails_timeout: DF.Int
-		push_log_file_count: DF.Int
-		push_log_level: DF.Literal["ERROR", "WARNING", "INFO", "DEBUG"]
-		push_log_max_file_size: DF.Int
-		root_domain_name: DF.Data | None
-		scan_message_timeout: DF.Int
-		server_deployment_timeout: DF.Int
-		server_job_timeout: DF.Int
-		server_url: DF.Data | None
-		show_mail_client_config: DF.Check
-		signup_domains: DF.SmallText | None
-		spamd_host: DF.Data | None
-		spamd_hybrid_scanning_threshold: DF.Float
-		spamd_port: DF.Int
-		spamd_scanning_mode: DF.Literal["Exclude Attachments", "Include Attachments", "Hybrid Approach"]
-		stalwart_cli_command_timeout: DF.Int
-		stalwart_cli_version: DF.Data
-		stalwart_version: DF.Data
-		username: DF.Data | None
-		verify_ssl: DF.Check
-	# end: auto-generated types
+        admin_log_file_count: DF.Int
+        admin_log_level: DF.Literal["ERROR", "WARNING", "INFO", "DEBUG"]
+        admin_log_max_file_size: DF.Int
+        allow_signup: DF.Check
+        ansible_play_timeout: DF.Int
+        custom_event_invites: DF.Check
+        default_disk_quota_gb: DF.Int
+        default_dns_ttl: DF.Int
+        default_gravatar: DF.Literal["404"]
+        disabled_account_role: DF.Data | None
+        dns_provider: DF.Literal[
+            "", "AmazonRoute53", "DigitalOcean", "Cloudflare", "Hetzner", "Linode", "Namecheap", "GoDaddy"
+        ]
+        dns_provider_access_key: DF.Data | None
+        dns_provider_access_secret: DF.Password | None
+        dns_provider_client_ip: DF.Data | None
+        dns_provider_key: DF.Data | None
+        dns_provider_private_zone: DF.Check
+        dns_provider_secret: DF.Password | None
+        dns_provider_token: DF.Password | None
+        dns_provider_username: DF.Data | None
+        dns_provider_zone_id: DF.Data | None
+        enable_gravatar: DF.Check
+        enable_jmap_push_encryption: DF.Check
+        exchange_export_batch_size: DF.Int
+        exchange_export_timeout: DF.Int
+        exchange_import_timeout: DF.Int
+        exchange_log_file_count: DF.Int
+        exchange_log_level: DF.Literal["ERROR", "WARNING", "INFO", "DEBUG"]
+        exchange_log_max_file_size: DF.Int
+        exchange_max_export: DF.Int
+        exchange_max_import: DF.Int
+        inbound_log_file_count: DF.Int
+        inbound_log_level: DF.Literal["ERROR", "WARNING", "INFO", "DEBUG"]
+        inbound_log_max_file_size: DF.Int
+        jmap_push_auth: DF.Password | None
+        jmap_push_p256dh: DF.Data | None
+        jmap_push_private_key: DF.Password | None
+        mail_client_configurations: DF.Table[MailClientConfiguration]
+        max_email_sync: DF.Int
+        max_message_payload_size_mb: DF.Int
+        max_push_notifications: DF.Int
+        outbound_log_file_count: DF.Int
+        outbound_log_level: DF.Literal["ERROR", "WARNING", "INFO", "DEBUG"]
+        outbound_log_max_file_size: DF.Int
+        password: DF.Password | None
+        process_pending_emails_batch_size: DF.Int
+        process_pending_emails_max_batch_size: DF.Int
+        process_pending_emails_timeout: DF.Int
+        push_log_file_count: DF.Int
+        push_log_level: DF.Literal["ERROR", "WARNING", "INFO", "DEBUG"]
+        push_log_max_file_size: DF.Int
+        root_domain_name: DF.Data | None
+        scan_message_timeout: DF.Int
+        server_deployment_timeout: DF.Int
+        server_job_timeout: DF.Int
+        server_url: DF.Data | None
+        show_mail_client_config: DF.Check
+        signup_domains: DF.SmallText | None
+        spamd_host: DF.Data | None
+        spamd_hybrid_scanning_threshold: DF.Float
+        spamd_port: DF.Int
+        spamd_scanning_mode: DF.Literal["Exclude Attachments", "Include Attachments", "Hybrid Approach"]
+        stalwart_cli_command_timeout: DF.Int
+        stalwart_cli_version: DF.Data
+        stalwart_version: DF.Data
+        username: DF.Data | None
+        verify_ssl: DF.Check
+    # end: auto-generated types
 
-	def validate(self) -> None:
-		if not frappe.flags.in_migrate:
-			self.validate_root_domain_name()
-			self.validate_dns_provider()
-			self.validate_jmap_push_subscription_keys()
-			self.validate_signup()
+    def validate(self) -> None:
+        if not frappe.flags.in_migrate:
+            self.validate_root_domain_name()
+            self.validate_dns_provider()
+            self.validate_jmap_push_subscription_keys()
+            self.validate_signup()
 
-	def on_update(self) -> None:
-		self.clear_cache()
-		frappe.clear_document_cache(self.doctype)
+    def on_update(self) -> None:
+        self.clear_cache()
+        frappe.clear_document_cache(self.doctype)
 
-		if self.has_value_changed("root_domain_name"):
-			self.handle_root_domain_change()
+        if self.has_value_changed("root_domain_name"):
+            self.handle_root_domain_change()
 
-	def validate_root_domain_name(self) -> None:
-		"""Validates the Root Domain Name."""
+    def validate_root_domain_name(self) -> None:
+        """Validates the Root Domain Name."""
 
-		if self.root_domain_name:
-			self.root_domain_name = self.root_domain_name.lower()
+        if self.root_domain_name:
+            self.root_domain_name = self.root_domain_name.lower()
 
-	def validate_dns_provider(self) -> None:
-		"""Validates the DNS Provider."""
+    def validate_dns_provider(self) -> None:
+        """Validates the DNS Provider."""
 
-		if not self.dns_provider:
-			return
+        if not self.dns_provider:
+            return
 
-		if not self.root_domain_name:
-			frappe.throw(_("Please set the Root Domain Name before configuring the DNS Provider."))
+        if not self.root_domain_name:
+            frappe.throw(_("Please set the Root Domain Name before configuring the DNS Provider."))
 
-		match self.dns_provider:
-			case "AmazonRoute53":
-				if not self.dns_provider_access_key or not self.dns_provider_access_secret:
-					frappe.throw(_("Please set the DNS Provider Access Key and Secret."))
+        match self.dns_provider:
+            case "AmazonRoute53":
+                if not self.dns_provider_access_key or not self.dns_provider_access_secret:
+                    frappe.throw(_("Please set the DNS Provider Access Key and Secret."))
 
-			case "DigitalOcean" | "Cloudflare" | "Hetzner" | "Linode" | "Namecheap":
-				if not self.dns_provider_token:
-					frappe.throw(_("Please set the DNS Provider Token."))
-				elif self.dns_provider == "Namecheap":
-					if not self.dns_provider_username or not self.dns_provider_client_ip:
-						frappe.throw(_("Please set the DNS Provider Username and Client IP."))
+            case "DigitalOcean" | "Cloudflare" | "Hetzner" | "Linode" | "Namecheap":
+                if not self.dns_provider_token:
+                    frappe.throw(_("Please set the DNS Provider Token."))
+                elif self.dns_provider == "Namecheap":
+                    if not self.dns_provider_username or not self.dns_provider_client_ip:
+                        frappe.throw(_("Please set the DNS Provider Username and Client IP."))
 
-			case "GoDaddy":
-				if not self.dns_provider_key or not self.dns_provider_secret:
-					frappe.throw(_("Please set the DNS Provider Key and Secret."))
+            case "GoDaddy":
+                if not self.dns_provider_key or not self.dns_provider_secret:
+                    frappe.throw(_("Please set the DNS Provider Key and Secret."))
 
-		verify_dns_provider = (
-			self.has_value_changed("root_domain_name")
-			or self.has_value_changed("dns_provider")
-			or self.has_value_changed("dns_provider_access_key")
-			or self.has_value_changed("dns_provider_access_secret")
-			or self.has_value_changed("dns_provider_token")
-			or self.has_value_changed("dns_provider_username")
-			or self.has_value_changed("dns_provider_client_ip")
-			or self.has_value_changed("dns_provider_key")
-			or self.has_value_changed("dns_provider_secret")
-		)
+        verify_dns_provider = (
+            self.has_value_changed("root_domain_name")
+            or self.has_value_changed("dns_provider")
+            or self.has_value_changed("dns_provider_access_key")
+            or self.has_value_changed("dns_provider_access_secret")
+            or self.has_value_changed("dns_provider_token")
+            or self.has_value_changed("dns_provider_username")
+            or self.has_value_changed("dns_provider_client_ip")
+            or self.has_value_changed("dns_provider_key")
+            or self.has_value_changed("dns_provider_secret")
+        )
 
-		if verify_dns_provider:
-			dns_provider = get_dns_provider(self)
-			dns_provider.read_dns_records("MX")
+        if verify_dns_provider:
+            dns_provider = get_dns_provider(self)
+            dns_provider.read_dns_records("MX")
 
-	def validate_signup(self) -> None:
-		"""Validates the Signup."""
+    def validate_signup(self) -> None:
+        """Validates the Signup."""
 
-		if not self.allow_signup:
-			self.signup_domains = ""
-			return
+        if not self.allow_signup:
+            self.signup_domains = ""
+            return
 
-		is_stalwart_configured(raise_exception=True)
+        is_stalwart_configured(raise_exception=True)
 
-		if not self.signup_domains:
-			frappe.throw(_("Please add at least one Signup Domain."))
+        if not self.signup_domains:
+            frappe.throw(_("Please add at least one Signup Domain."))
 
-		signup_domains = self.signup_domains.split("\n")
+        signup_domains = self.signup_domains.split("\n")
 
-		if not signup_domains:
-			frappe.throw(_("Invalid Signup Domains format. Please provide one domain per line."))
+        if not signup_domains:
+            frappe.throw(_("Invalid Signup Domains format. Please provide one domain per line."))
 
-		valid_signup_domains = []
-		for domain in signup_domains:
-			domain = domain.strip().lower()
-			if domain:
-				get_domain_service().get_by_name(domain, raise_exception=True)
-				valid_signup_domains.append(domain)
+        valid_signup_domains = []
+        for domain in signup_domains:
+            domain = domain.strip().lower()
+            if domain:
+                get_domain_service().get_by_name(domain, raise_exception=True)
+                valid_signup_domains.append(domain)
 
-		self.signup_domains = "\n".join(valid_signup_domains)
+        self.signup_domains = "\n".join(valid_signup_domains)
 
-	def validate_jmap_push_subscription_keys(self) -> None:
-		"""Validates site-level JMAP push subscription encryption keys."""
+    def validate_jmap_push_subscription_keys(self) -> None:
+        """Validates site-level JMAP push subscription encryption keys."""
 
-		p256dh = (self.jmap_push_p256dh or "").strip()
-		auth = (self.get_password("jmap_push_auth") if self.jmap_push_auth else "").strip()
-		private_key = (
-			self.get_password("jmap_push_private_key") if self.jmap_push_private_key else ""
-		).strip()
+        p256dh = (self.jmap_push_p256dh or "").strip()
+        auth = (self.get_password("jmap_push_auth") if self.jmap_push_auth else "").strip()
+        private_key = (
+            self.get_password("jmap_push_private_key") if self.jmap_push_private_key else ""
+        ).strip()
 
-		set_count = sum([bool(p256dh), bool(auth), bool(private_key)])
-		if set_count not in (0, 3):
-			frappe.throw(
-				_(
-					"JMAP Push Subscription keys are incomplete. Use Actions → Generate JMAP Push Keys to regenerate them."
-				)
-			)
+        set_count = sum([bool(p256dh), bool(auth), bool(private_key)])
+        if set_count not in (0, 3):
+            frappe.throw(
+                _(
+                    "JMAP Push Subscription keys are incomplete. Use Actions → Generate JMAP Push Keys to regenerate them."
+                )
+            )
 
-		if self.enable_jmap_push_encryption and set_count != 3:
-			frappe.throw(
-				_(
-					"Push encryption is enabled but the JMAP Push Subscription keys are not configured. Use Actions → Generate JMAP Push Keys to generate them, or disable Enable Push Encryption."
-				)
-			)
+        if self.enable_jmap_push_encryption and set_count != 3:
+            frappe.throw(
+                _(
+                    "Push encryption is enabled but the JMAP Push Subscription keys are not configured. Use Actions → Generate JMAP Push Keys to generate them, or disable Enable Push Encryption."
+                )
+            )
 
-		if set_count == 0:
-			return
+        if set_count == 0:
+            return
 
-		for value, label in (
-			(p256dh, _("P256DH")),
-			(private_key, _("Private Key")),
-			(auth, _("Auth")),
-		):
-			if not self._is_urlsafe_base64(value):
-				frappe.throw(
-					_("The JMAP Push Subscription {0} key must be URL-safe base64 encoded.").format(
-						frappe.bold(label)
-					)
-				)
+        for value, label in (
+            (p256dh, _("P256DH")),
+            (private_key, _("Private Key")),
+            (auth, _("Auth")),
+        ):
+            if not self._is_urlsafe_base64(value):
+                frappe.throw(
+                    _("The JMAP Push Subscription {0} key must be URL-safe base64 encoded.").format(
+                        frappe.bold(label)
+                    )
+                )
 
-		try:
-			from cryptography.hazmat.primitives.asymmetric import ec
-			from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+        try:
+            from cryptography.hazmat.primitives.asymmetric import ec
+            from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
-			def _b64decode(s: str) -> bytes:
-				return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+            def _b64decode(s: str) -> bytes:
+                return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
 
-			priv_bytes = _b64decode(private_key)
-			priv = ec.derive_private_key(int.from_bytes(priv_bytes, "big"), ec.SECP256R1())
-			computed_pub = priv.public_key().public_bytes(Encoding.X962, PublicFormat.UncompressedPoint)
-			expected_pub = _b64decode(p256dh)
-			if computed_pub != expected_pub:
-				frappe.throw(
-					_("The JMAP Push Subscription Private Key does not correspond to the P256DH public key.")
-				)
-		except frappe.exceptions.ValidationError:
-			raise
-		except Exception as e:
-			frappe.throw(_("Invalid JMAP Push Subscription keys: {0}").format(str(e)))
+            priv_bytes = _b64decode(private_key)
+            priv = ec.derive_private_key(int.from_bytes(priv_bytes, "big"), ec.SECP256R1())
+            computed_pub = priv.public_key().public_bytes(Encoding.X962, PublicFormat.UncompressedPoint)
+            expected_pub = _b64decode(p256dh)
+            if computed_pub != expected_pub:
+                frappe.throw(
+                    _("The JMAP Push Subscription Private Key does not correspond to the P256DH public key.")
+                )
+        except frappe.exceptions.ValidationError:
+            raise
+        except Exception as e:
+            frappe.throw(_("Invalid JMAP Push Subscription keys: {0}").format(str(e)))
 
-	@frappe.whitelist()
-	def generate_jmap_push_keys(self) -> None:
-		"""Generates new JMAP push subscription encryption keys and saves them."""
+    @frappe.whitelist()
+    def generate_jmap_push_keys(self) -> None:
+        """Generates new JMAP push subscription encryption keys and saves them."""
 
-		self._generate_jmap_push_keys()
-		frappe.msgprint(_("JMAP Push keys generated successfully."), alert=True)
+        self._generate_jmap_push_keys()
+        frappe.msgprint(_("JMAP Push keys generated successfully."), alert=True)
 
-	def _generate_jmap_push_keys(self) -> None:
-		"""Generates a new ECDH P-256 key pair and auth secret for JMAP push encryption and saves them."""
+    def _generate_jmap_push_keys(self) -> None:
+        """Generates a new ECDH P-256 key pair and auth secret for JMAP push encryption and saves them."""
 
-		from cryptography.hazmat.primitives.asymmetric import ec
-		from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+        from cryptography.hazmat.primitives.asymmetric import ec
+        from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
-		private_key = ec.generate_private_key(ec.SECP256R1())
-		private_key_bytes = private_key.private_numbers().private_value.to_bytes(32, "big")
-		public_key_bytes = private_key.public_key().public_bytes(
-			Encoding.X962, PublicFormat.UncompressedPoint
-		)
-		auth_bytes = os.urandom(16)
+        private_key = ec.generate_private_key(ec.SECP256R1())
+        private_key_bytes = private_key.private_numbers().private_value.to_bytes(32, "big")
+        public_key_bytes = private_key.public_key().public_bytes(
+            Encoding.X962, PublicFormat.UncompressedPoint
+        )
+        auth_bytes = os.urandom(16)
 
-		self.jmap_push_p256dh = base64.urlsafe_b64encode(public_key_bytes).decode()
-		self.jmap_push_private_key = base64.urlsafe_b64encode(private_key_bytes).decode()
-		self.jmap_push_auth = base64.urlsafe_b64encode(auth_bytes).decode()
+        self.jmap_push_p256dh = base64.urlsafe_b64encode(public_key_bytes).decode()
+        self.jmap_push_private_key = base64.urlsafe_b64encode(private_key_bytes).decode()
+        self.jmap_push_auth = base64.urlsafe_b64encode(auth_bytes).decode()
 
-		self.flags.ignore_mandatory = True
-		self.flags.ignore_validate = True
-		self.save()
+        self.flags.ignore_mandatory = True
+        self.flags.ignore_validate = True
+        self.save()
 
-	@staticmethod
-	def _is_urlsafe_base64(value: str) -> bool:
-		"""Returns True if the given value is URL-safe base64 encoded."""
+    @staticmethod
+    def _is_urlsafe_base64(value: str) -> bool:
+        """Returns True if the given value is URL-safe base64 encoded."""
 
-		try:
-			padding = "=" * (-len(value) % 4)
-			base64.urlsafe_b64decode(f"{value}{padding}".encode())
-			return True
-		except Exception:
-			return False
+        try:
+            padding = "=" * (-len(value) % 4)
+            base64.urlsafe_b64decode(f"{value}{padding}".encode())
+            return True
+        except Exception:
+            return False
 
-	def handle_root_domain_change(self) -> None:
-		"""Resets DNS Record verification and notifies user after root domain change."""
+    def handle_root_domain_change(self) -> None:
+        """Resets DNS Record verification and notifies user after root domain change."""
 
-		frappe.db.set_value("DNS Record", {"is_verified": 1}, "is_verified", 0)
+        frappe.db.set_value("DNS Record", {"is_verified": 1}, "is_verified", 0)
 
-		if self.has_value_changed("root_domain_name"):
-			dns_record_list_link = f'<a href="/app/dns-record">{_("DNS Records")}</a>'
-			frappe.msgprint(
-				_("Please verify the {0} for the new {1}.").format(
-					dns_record_list_link, frappe.bold("Root Domain Name")
-				)
-			)
+        if self.has_value_changed("root_domain_name"):
+            dns_record_list_link = f'<a href="/app/dns-record">{_("DNS Records")}</a>'
+            frappe.msgprint(
+                _("Please verify the {0} for the new {1}.").format(
+                    dns_record_list_link, frappe.bold("Root Domain Name")
+                )
+            )
 
-	def clear_cache(self) -> None:
-		"""Clears the Cache."""
+    def clear_cache(self) -> None:
+        """Clears the Cache."""
 
-		frappe.cache.delete_value("mail-settings")
+        frappe.cache.delete_value("mail-settings")
 
 
 def get_signup_domains() -> list:
-	"""Returns the signup domains."""
+    """Returns the signup domains."""
 
-	settings = frappe.get_cached_doc("Mail Settings")
-	return settings.signup_domains.split("\n") if settings.signup_domains else []
+    settings = frappe.get_cached_doc("Mail Settings")
+    return settings.signup_domains.split("\n") if settings.signup_domains else []

--- a/suite/mail/doctype/mail_settings/test_mail_settings.py
+++ b/suite/mail/doctype/mail_settings/test_mail_settings.py
@@ -12,18 +12,18 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class UnitTestMailSettings(UnitTestCase):
-	"""
-	Unit tests for MailSettings.
-	Use this class for testing individual functions and methods.
-	"""
+    """
+    Unit tests for MailSettings.
+    Use this class for testing individual functions and methods.
+    """
 
-	pass
+    pass
 
 
 class IntegrationTestMailSettings(IntegrationTestCase):
-	"""
-	Integration tests for MailSettings.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for MailSettings.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/mail_signature/mail_signature.py
+++ b/suite/mail/doctype/mail_signature/mail_signature.py
@@ -8,4 +8,4 @@ from suite.utils.permissions import OwnerFromUser
 
 
 class MailSignature(OwnerFromUser, Document):
-	pass
+    pass

--- a/suite/mail/doctype/mail_signature/test_mail_signature.py
+++ b/suite/mail/doctype/mail_signature/test_mail_signature.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestMailSignature(IntegrationTestCase):
-	"""
-	Integration tests for MailSignature.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for MailSignature.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/mail_sync_history/mail_sync_history.py
+++ b/suite/mail/doctype/mail_sync_history/mail_sync_history.py
@@ -50,7 +50,7 @@ def create_mail_sync_history(
     source: str,
     last_received_at: str | None = None,
     commit: bool = False,
-) -> "MailSyncHistory":
+) -> MailSyncHistory:
     """Create a Mail Sync History."""
 
     doc = frappe.new_doc("Mail Sync History")
@@ -65,7 +65,7 @@ def create_mail_sync_history(
     return doc
 
 
-def get_mail_sync_history(account: str, source: str) -> "MailSyncHistory":
+def get_mail_sync_history(account: str, source: str) -> MailSyncHistory:
     """Returns the Mail Sync History for the given account and source."""
 
     if name := frappe.db.exists("Mail Sync History", {"account": account, "source": source}):
@@ -86,7 +86,7 @@ def get_permission_query_condition(user: str | None = None) -> str | None:
     return f"""`tabMail Sync History`.account in ({", ".join(frappe.db.escape(account) for account in accounts)})"""
 
 
-def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
     if doc.doctype != "Mail Sync History":
         return False
 

--- a/suite/mail/doctype/mail_sync_history/mail_sync_history.py
+++ b/suite/mail/doctype/mail_sync_history/mail_sync_history.py
@@ -12,91 +12,91 @@ from suite.utils.user import is_suite_admin, is_system_manager
 
 
 class MailSyncHistory(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		account: DF.Link
-		last_received_at: DF.Datetime | None
-		last_received_mail: DF.Data | None
-		source: DF.Data
-	# end: auto-generated types
+        account: DF.Link
+        last_received_at: DF.Datetime | None
+        last_received_mail: DF.Data | None
+        source: DF.Data
+    # end: auto-generated types
 
-	"""Per-source inbound-pull watermark, shared per JMAP account ID — every user with
+    """Per-source inbound-pull watermark, shared per JMAP account ID — every user with
 	access to the account shares the same last-received state for a given source."""
 
-	def autoname(self) -> None:
-		self.name = str(uuid7())
+    def autoname(self) -> None:
+        self.name = str(uuid7())
 
-	def before_insert(self) -> None:
-		self.validate_duplicate()
+    def before_insert(self) -> None:
+        self.validate_duplicate()
 
-	def validate_duplicate(self) -> None:
-		"""Validate if the Mail Sync History already exists."""
+    def validate_duplicate(self) -> None:
+        """Validate if the Mail Sync History already exists."""
 
-		if frappe.db.exists(
-			"Mail Sync History",
-			{"account": self.account, "source": self.source},
-		):
-			frappe.throw(_("Mail Sync History already exists for this account and source."))
+        if frappe.db.exists(
+            "Mail Sync History",
+            {"account": self.account, "source": self.source},
+        ):
+            frappe.throw(_("Mail Sync History already exists for this account and source."))
 
 
 def create_mail_sync_history(
-	account: str,
-	source: str,
-	last_received_at: str | None = None,
-	commit: bool = False,
+    account: str,
+    source: str,
+    last_received_at: str | None = None,
+    commit: bool = False,
 ) -> "MailSyncHistory":
-	"""Create a Mail Sync History."""
+    """Create a Mail Sync History."""
 
-	doc = frappe.new_doc("Mail Sync History")
-	doc.account = account
-	doc.source = source
-	doc.last_received_at = last_received_at
-	doc.insert(ignore_permissions=True)
+    doc = frappe.new_doc("Mail Sync History")
+    doc.account = account
+    doc.source = source
+    doc.last_received_at = last_received_at
+    doc.insert(ignore_permissions=True)
 
-	if commit:
-		frappe.db.commit()
+    if commit:
+        frappe.db.commit()
 
-	return doc
+    return doc
 
 
 def get_mail_sync_history(account: str, source: str) -> "MailSyncHistory":
-	"""Returns the Mail Sync History for the given account and source."""
+    """Returns the Mail Sync History for the given account and source."""
 
-	if name := frappe.db.exists("Mail Sync History", {"account": account, "source": source}):
-		return frappe.get_doc("Mail Sync History", name)
+    if name := frappe.db.exists("Mail Sync History", {"account": account, "source": source}):
+        return frappe.get_doc("Mail Sync History", name)
 
-	return create_mail_sync_history(account, source, commit=True)
+    return create_mail_sync_history(account, source, commit=True)
 
 
 def get_permission_query_condition(user: str | None = None) -> str | None:
-	user = user or frappe.session.user
-	if is_system_manager(user) or is_suite_admin(user):
-		return ""
+    user = user or frappe.session.user
+    if is_system_manager(user) or is_suite_admin(user):
+        return ""
 
-	accounts = get_user_jmap_accounts(user)
-	if not accounts:
-		return "1=0"
+    accounts = get_user_jmap_accounts(user)
+    if not accounts:
+        return "1=0"
 
-	return f"""`tabMail Sync History`.account in ({", ".join(frappe.db.escape(account) for account in accounts)})"""
+    return f"""`tabMail Sync History`.account in ({", ".join(frappe.db.escape(account) for account in accounts)})"""
 
 
 def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
-	if doc.doctype != "Mail Sync History":
-		return False
+    if doc.doctype != "Mail Sync History":
+        return False
 
-	user = user or frappe.session.user
+    user = user or frappe.session.user
 
-	if is_system_manager(user) or is_suite_admin(user):
-		return True
+    if is_system_manager(user) or is_suite_admin(user):
+        return True
 
-	accounts = get_user_jmap_accounts(user)
-	if not accounts:
-		return False
+    accounts = get_user_jmap_accounts(user)
+    if not accounts:
+        return False
 
-	return doc.account in accounts
+    return doc.account in accounts

--- a/suite/mail/doctype/mail_sync_history/test_mail_sync_history.py
+++ b/suite/mail/doctype/mail_sync_history/test_mail_sync_history.py
@@ -6,4 +6,4 @@ from frappe.tests.utils import FrappeTestCase
 
 
 class TestMailSyncHistory(FrappeTestCase):
-	pass
+    pass

--- a/suite/mail/doctype/mailbox/mailbox.py
+++ b/suite/mail/doctype/mailbox/mailbox.py
@@ -57,7 +57,7 @@ class Mailbox(Document):
         )
         self.name = f"{self.account}|{self.id}"
 
-    def load_from_db(self) -> "Mailbox":
+    def load_from_db(self) -> Mailbox:
         account, id = parse_mailbox_name(self.name)
         mailbox = get_mailbox(account, id)
         return super(Document, self).__init__(mailbox)
@@ -423,7 +423,7 @@ def get_sort_order(role: str | None = None) -> int:
     return role_order.index(role)
 
 
-def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
     if doc.doctype != "Mailbox":
         return False
 

--- a/suite/mail/doctype/mailbox/mailbox.py
+++ b/suite/mail/doctype/mailbox/mailbox.py
@@ -19,412 +19,412 @@ REBALANCE_MAILBOX_WINDOW = 10
 
 
 class Mailbox(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		_name: DF.Data
-		_parent: DF.Link | None
-		account: DF.Link
-		id: DF.Data | None
-		may_add_items: DF.Check
-		may_create_child: DF.Check
-		may_delete: DF.Check
-		may_read_items: DF.Check
-		may_remove_items: DF.Check
-		may_rename: DF.Check
-		may_set_keywords: DF.Check
-		may_set_seen: DF.Check
-		may_submit: DF.Check
-		parent_id: DF.Data | None
-		role: DF.Literal["", "inbox", "important", "sent", "drafts", "junk", "archive", "trash"]
-		sort_order: DF.Int
-		subscribed: DF.Check
-		total_emails: DF.Int
-		total_threads: DF.Int
-		unread_emails: DF.Int
-		unread_threads: DF.Int
-	# end: auto-generated types
+        _name: DF.Data
+        _parent: DF.Link | None
+        account: DF.Link
+        id: DF.Data | None
+        may_add_items: DF.Check
+        may_create_child: DF.Check
+        may_delete: DF.Check
+        may_read_items: DF.Check
+        may_remove_items: DF.Check
+        may_rename: DF.Check
+        may_set_keywords: DF.Check
+        may_set_seen: DF.Check
+        may_submit: DF.Check
+        parent_id: DF.Data | None
+        role: DF.Literal["", "inbox", "important", "sent", "drafts", "junk", "archive", "trash"]
+        sort_order: DF.Int
+        subscribed: DF.Check
+        total_emails: DF.Int
+        total_threads: DF.Int
+        unread_emails: DF.Int
+        unread_threads: DF.Int
+    # end: auto-generated types
 
-	def db_insert(self, *args, **kwargs) -> None:
-		parent = self._parent.split("|")[1] if self._parent else None
-		self.id = add_mailbox(
-			self.account, self._name, self.role, parent, self.sort_order, bool(self.subscribed)
-		)
-		self.name = f"{self.account}|{self.id}"
+    def db_insert(self, *args, **kwargs) -> None:
+        parent = self._parent.split("|")[1] if self._parent else None
+        self.id = add_mailbox(
+            self.account, self._name, self.role, parent, self.sort_order, bool(self.subscribed)
+        )
+        self.name = f"{self.account}|{self.id}"
 
-	def load_from_db(self) -> "Mailbox":
-		account, id = parse_mailbox_name(self.name)
-		mailbox = get_mailbox(account, id)
-		return super(Document, self).__init__(mailbox)
+    def load_from_db(self) -> "Mailbox":
+        account, id = parse_mailbox_name(self.name)
+        mailbox = get_mailbox(account, id)
+        return super(Document, self).__init__(mailbox)
 
-	def db_update(self) -> None:
-		account, id = parse_mailbox_name(self.name)
-		parent = self._parent.split("|")[1] if self._parent else None
-		update_mailbox(account, id, self._name, self.role, parent, self.sort_order, bool(self.subscribed))
-		self.reload()
+    def db_update(self) -> None:
+        account, id = parse_mailbox_name(self.name)
+        parent = self._parent.split("|")[1] if self._parent else None
+        update_mailbox(account, id, self._name, self.role, parent, self.sort_order, bool(self.subscribed))
+        self.reload()
 
-	def delete(self) -> None:
-		account, id = parse_mailbox_name(self.name)
-		delete_mailboxes(account, [id])
+    def delete(self) -> None:
+        account, id = parse_mailbox_name(self.name)
+        delete_mailboxes(account, [id])
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs) -> list:
-		filters = parse_filters(filters)
-		id = filters.get("id")
-		account = filters.get("account")
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs) -> list:
+        filters = parse_filters(filters)
+        id = filters.get("id")
+        account = filters.get("account")
 
-		if not account:
-			frappe.msgprint(_("Please select an account to view mailboxes."), alert=True)
-			return []
+        if not account:
+            frappe.msgprint(_("Please select an account to view mailboxes."), alert=True)
+            return []
 
-		mailboxes = []
-		if id:
-			if mailbox := get_mailbox(account, id, raise_exception=False):
-				mailboxes.append(mailbox)
-		else:
-			mailboxes = fetch_mailboxes(account, limit=page_length)
+        mailboxes = []
+        if id:
+            if mailbox := get_mailbox(account, id, raise_exception=False):
+                mailboxes.append(mailbox)
+        else:
+            mailboxes = fetch_mailboxes(account, limit=page_length)
 
-		if not mailboxes:
-			frappe.msgprint(_("No mailboxes found."), alert=True)
+        if not mailboxes:
+            frappe.msgprint(_("No mailboxes found."), alert=True)
 
-		return mailboxes
+        return mailboxes
 
-	@staticmethod
-	def get_count(filters=None, **kwargs) -> int:
-		filters = parse_filters(filters)
-		account = filters.get("account")
+    @staticmethod
+    def get_count(filters=None, **kwargs) -> int:
+        filters = parse_filters(filters)
+        account = filters.get("account")
 
-		if account:
-			if get_user_for_jmap_account(account, raise_exception=False):
-				return cint(frappe.cache.get_value(_get_total_cache_key(account)))
+        if account:
+            if get_user_for_jmap_account(account, raise_exception=False):
+                return cint(frappe.cache.get_value(_get_total_cache_key(account)))
 
-		return 0
+        return 0
 
-	@staticmethod
-	def get_stats(**kwargs) -> dict:
-		return {}
+    @staticmethod
+    def get_stats(**kwargs) -> dict:
+        return {}
 
 
 def _get_total_cache_key(account: str) -> str:
-	"""Returns a cache key for total mailbox count for the given account."""
+    """Returns a cache key for total mailbox count for the given account."""
 
-	return f"{account}:mailboxes:total"
+    return f"{account}:mailboxes:total"
 
 
 def parse_mailbox_name(name: str) -> tuple[str, str]:
-	"""Splits a Mailbox name `account|id` into its bare `account` and `id`."""
+    """Splits a Mailbox name `account|id` into its bare `account` and `id`."""
 
-	account, id = name.split("|")
-	return account, id
+    account, id = name.split("|")
+    return account, id
 
 
 @frappe.whitelist()
 def bulk_delete(names: str | list[str]) -> None:
-	"""Deletes multiple mailboxes given their names."""
+    """Deletes multiple mailboxes given their names."""
 
-	if isinstance(names, str):
-		names = json.loads(names)
+    if isinstance(names, str):
+        names = json.loads(names)
 
-	accounts_map = {}
-	for name in names:
-		account, id = parse_mailbox_name(name)
-		accounts_map.setdefault(account, []).append(id)
+    accounts_map = {}
+    for name in names:
+        account, id = parse_mailbox_name(name)
+        accounts_map.setdefault(account, []).append(id)
 
-	for account, ids in accounts_map.items():
-		delete_mailboxes(account, ids)
+    for account, ids in accounts_map.items():
+        delete_mailboxes(account, ids)
 
-	frappe.msgprint(_("Mailboxes deleted successfully."), alert=True)
+    frappe.msgprint(_("Mailboxes deleted successfully."), alert=True)
 
 
 @frappe.whitelist()
 def add_mailbox(
-	account: str,
-	name: str,
-	role: str | None = None,
-	parent: str | None = None,
-	sort_order: int = 0,
-	subscribed: bool = True,
+    account: str,
+    name: str,
+    role: str | None = None,
+    parent: str | None = None,
+    sort_order: int = 0,
+    subscribed: bool = True,
 ) -> str:
-	"""Adds a mailbox for the given account with the specified parameters."""
+    """Adds a mailbox for the given account with the specified parameters."""
 
-	creation_id = str(uuid7())
-	mailbox = {
-		"creation_id": creation_id,
-		"name": name,
-		"role": role,
-		"parent_id": parent,
-		"sort_order": sort_order,
-		"is_subscribed": subscribed,
-	}
+    creation_id = str(uuid7())
+    mailbox = {
+        "creation_id": creation_id,
+        "name": name,
+        "role": role,
+        "parent_id": parent,
+        "sort_order": sort_order,
+        "is_subscribed": subscribed,
+    }
 
-	service = get_mailbox_service(account)
-	response = service.create([mailbox])
+    service = get_mailbox_service(account)
+    response = service.create([mailbox])
 
-	title = _("Mailbox Creation Error")
-	if response.get("created"):
-		service.invalidate_cache(service.account, key="mailboxes")
-		return response["created"][creation_id]["id"]
-	elif response.get("notCreated"):
-		frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
-	else:
-		frappe.throw(_(response["description"]), title=title)
+    title = _("Mailbox Creation Error")
+    if response.get("created"):
+        service.invalidate_cache(service.account, key="mailboxes")
+        return response["created"][creation_id]["id"]
+    elif response.get("notCreated"):
+        frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
+    else:
+        frappe.throw(_(response["description"]), title=title)
 
 
 @frappe.whitelist()
 def get_mailbox(account: str, id: str, raise_exception: bool = False) -> dict | None:
-	"""Returns mailbox details for the given account and id."""
+    """Returns mailbox details for the given account and id."""
 
-	service = get_mailbox_service(account)
-	if mailboxes := service.get([id]):
-		return format_mailbox(account, mailboxes[0])
+    service = get_mailbox_service(account)
+    if mailboxes := service.get([id]):
+        return format_mailbox(account, mailboxes[0])
 
-	if raise_exception:
-		frappe.throw(
-			_("Mailbox with ID {0} not found in account {1}.").format(frappe.bold(id), frappe.bold(account)),
-			title=_("Mailbox Not Found"),
-		)
+    if raise_exception:
+        frappe.throw(
+            _("Mailbox with ID {0} not found in account {1}.").format(frappe.bold(id), frappe.bold(account)),
+            title=_("Mailbox Not Found"),
+        )
 
 
 @frappe.whitelist()
 def update_mailbox(
-	account: str,
-	id: str,
-	name: str,
-	role: str | None = None,
-	parent: str | None = None,
-	sort_order: int = 0,
-	subscribed: bool = True,
+    account: str,
+    id: str,
+    name: str,
+    role: str | None = None,
+    parent: str | None = None,
+    sort_order: int = 0,
+    subscribed: bool = True,
 ) -> None:
-	"""Updates an existing mailbox with the given parameters."""
+    """Updates an existing mailbox with the given parameters."""
 
-	title = _("Mailbox Update Error")
-	if parent and id == parent:
-		frappe.throw(_("Mailbox cannot be a parent of itself."), title=title)
+    title = _("Mailbox Update Error")
+    if parent and id == parent:
+        frappe.throw(_("Mailbox cannot be a parent of itself."), title=title)
 
-	mailbox = {
-		"id": id,
-		"name": name,
-		"role": role,
-		"parent_id": parent,
-		"sort_order": sort_order,
-		"is_subscribed": subscribed,
-	}
+    mailbox = {
+        "id": id,
+        "name": name,
+        "role": role,
+        "parent_id": parent,
+        "sort_order": sort_order,
+        "is_subscribed": subscribed,
+    }
 
-	service = get_mailbox_service(account)
-	response = service.update([mailbox])
+    service = get_mailbox_service(account)
+    response = service.update([mailbox])
 
-	if not response.get("updated"):
-		if response.get("notUpdated"):
-			frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
-		else:
-			frappe.throw(_(response["description"]), title=title)
+    if not response.get("updated"):
+        if response.get("notUpdated"):
+            frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
+        else:
+            frappe.throw(_(response["description"]), title=title)
 
-	service.invalidate_cache(service.account, key="mailboxes")
+    service.invalidate_cache(service.account, key="mailboxes")
 
 
 @frappe.whitelist()
 def delete_mailboxes(account: str, ids: list[str], remove_emails: bool = True) -> None:
-	"""Deletes a mailbox for the given account by its ID."""
+    """Deletes a mailbox for the given account by its ID."""
 
-	service = get_mailbox_service(account)
-	response = service.delete(ids, remove_emails=remove_emails)
+    service = get_mailbox_service(account)
+    response = service.delete(ids, remove_emails=remove_emails)
 
-	if response.get("notDestroyed"):
-		error_messages = []
-		for id, error in response["notDestroyed"].items():
-			error_messages.append(f"{id}: {error['description']}")
-		frappe.throw(
-			_("Mailbox Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
-			title=_("Mailbox Deletion Error"),
-		)
+    if response.get("notDestroyed"):
+        error_messages = []
+        for id, error in response["notDestroyed"].items():
+            error_messages.append(f"{id}: {error['description']}")
+        frappe.throw(
+            _("Mailbox Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
+            title=_("Mailbox Deletion Error"),
+        )
 
-	# Drop the stale list so later lookups (e.g. sieve regeneration) don't see the deleted mailbox.
-	service.invalidate_cache(service.account, key="mailboxes")
+    # Drop the stale list so later lookups (e.g. sieve regeneration) don't see the deleted mailbox.
+    service.invalidate_cache(service.account, key="mailboxes")
 
 
 @frappe.whitelist()
 def fetch_mailboxes(account: str, page: int = 1, limit: int = 10) -> list:
-	"""Returns a list of mailboxes for the given account."""
+    """Returns a list of mailboxes for the given account."""
 
-	service = get_mailbox_service(account)
-	mailboxes = service.get()
-	formatted_mailboxes = [format_mailbox(account, mailbox) for mailbox in mailboxes]
-	sorted_mailboxes = sorted(
-		formatted_mailboxes, key=lambda m: (m["sort_order"], get_sort_order(m["role"]), m["_name"], m["id"])
-	)
-	frappe.cache.set_value(_get_total_cache_key(account), len(mailboxes), expires_in_sec=600)
+    service = get_mailbox_service(account)
+    mailboxes = service.get()
+    formatted_mailboxes = [format_mailbox(account, mailbox) for mailbox in mailboxes]
+    sorted_mailboxes = sorted(
+        formatted_mailboxes, key=lambda m: (m["sort_order"], get_sort_order(m["role"]), m["_name"], m["id"])
+    )
+    frappe.cache.set_value(_get_total_cache_key(account), len(mailboxes), expires_in_sec=600)
 
-	start = (page - 1) * limit
-	end = start + limit
+    start = (page - 1) * limit
+    end = start + limit
 
-	return sorted_mailboxes[start:end]
+    return sorted_mailboxes[start:end]
 
 
 @frappe.whitelist()
 def update_mailbox_position(
-	account: str, target_mailbox_id: str, prior_mailbox_id: str | None = None
+    account: str, target_mailbox_id: str, prior_mailbox_id: str | None = None
 ) -> None:
-	"""Updates the position of the target mailbox to be after the prior mailbox."""
+    """Updates the position of the target mailbox to be after the prior mailbox."""
 
-	def get_updates(
-		mailboxes: list[dict], target_mailbox_id: str, prior_mailbox_id: str | None
-	) -> dict[str, int]:
-		"""Returns the sort order updates required to move the target mailbox after the prior mailbox."""
+    def get_updates(
+        mailboxes: list[dict], target_mailbox_id: str, prior_mailbox_id: str | None
+    ) -> dict[str, int]:
+        """Returns the sort order updates required to move the target mailbox after the prior mailbox."""
 
-		index = {m["id"]: i for i, m in enumerate(mailboxes)}
+        index = {m["id"]: i for i, m in enumerate(mailboxes)}
 
-		if target_mailbox_id not in index:
-			frappe.throw(_("Target mailbox ID {0} not found.").format(frappe.bold(target_mailbox_id)))
+        if target_mailbox_id not in index:
+            frappe.throw(_("Target mailbox ID {0} not found.").format(frappe.bold(target_mailbox_id)))
 
-		mailboxes.pop(index[target_mailbox_id])
-		index = {m["id"]: i for i, m in enumerate(mailboxes)}
+        mailboxes.pop(index[target_mailbox_id])
+        index = {m["id"]: i for i, m in enumerate(mailboxes)}
 
-		# Prior mailbox is None, place at start
-		if prior_mailbox_id is None:
-			lower = None
-			upper = mailboxes[0]["sortOrder"] if mailboxes else None
-			insert_index = 0
+        # Prior mailbox is None, place at start
+        if prior_mailbox_id is None:
+            lower = None
+            upper = mailboxes[0]["sortOrder"] if mailboxes else None
+            insert_index = 0
 
-		# Prior mailbox is specified, place after it
-		else:
-			if prior_mailbox_id not in index:
-				frappe.throw(_("Prior mailbox ID {0} not found.").format(frappe.bold(prior_mailbox_id)))
+        # Prior mailbox is specified, place after it
+        else:
+            if prior_mailbox_id not in index:
+                frappe.throw(_("Prior mailbox ID {0} not found.").format(frappe.bold(prior_mailbox_id)))
 
-			prior_index = index[prior_mailbox_id]
-			lower = mailboxes[prior_index]["sortOrder"]
-			insert_index = prior_index + 1
-			upper = mailboxes[insert_index]["sortOrder"] if insert_index < len(mailboxes) else None
+            prior_index = index[prior_mailbox_id]
+            lower = mailboxes[prior_index]["sortOrder"]
+            insert_index = prior_index + 1
+            upper = mailboxes[insert_index]["sortOrder"] if insert_index < len(mailboxes) else None
 
-		# Case - 1: Both lower and upper bounds exist and have enough gap, create in between
-		if lower is not None and upper is not None and upper - lower > MINIMUM_MAILBOX_GAP:
-			new_sort = (lower + upper) // 2
-			return {target_mailbox_id: new_sort}
+        # Case - 1: Both lower and upper bounds exist and have enough gap, create in between
+        if lower is not None and upper is not None and upper - lower > MINIMUM_MAILBOX_GAP:
+            new_sort = (lower + upper) // 2
+            return {target_mailbox_id: new_sort}
 
-		# Case - 2: Only lower bound exists, place after it
-		if lower is not None and upper is None:
-			return {target_mailbox_id: lower + DEFAULT_MAILBOX_GAP}
+        # Case - 2: Only lower bound exists, place after it
+        if lower is not None and upper is None:
+            return {target_mailbox_id: lower + DEFAULT_MAILBOX_GAP}
 
-		# Case - 3: Only upper bound exists, place before it
-		if lower is None and upper is not None:
-			return {target_mailbox_id: upper - DEFAULT_MAILBOX_GAP}
+        # Case - 3: Only upper bound exists, place before it
+        if lower is None and upper is not None:
+            return {target_mailbox_id: upper - DEFAULT_MAILBOX_GAP}
 
-		# Case - 4: Neither bound exists, place at start
-		if lower is None and upper is None:
-			return {target_mailbox_id: 0}
+        # Case - 4: Neither bound exists, place at start
+        if lower is None and upper is None:
+            return {target_mailbox_id: 0}
 
-		# If there is no gap, rebalance
-		start = max(0, insert_index - REBALANCE_MAILBOX_WINDOW)
-		end = min(len(mailboxes), insert_index + REBALANCE_MAILBOX_WINDOW)
+        # If there is no gap, rebalance
+        start = max(0, insert_index - REBALANCE_MAILBOX_WINDOW)
+        end = min(len(mailboxes), insert_index + REBALANCE_MAILBOX_WINDOW)
 
-		window = mailboxes[start:end]
+        window = mailboxes[start:end]
 
-		base = window[0]["sortOrder"]
-		base = (base // DEFAULT_MAILBOX_GAP) * DEFAULT_MAILBOX_GAP
+        base = window[0]["sortOrder"]
+        base = (base // DEFAULT_MAILBOX_GAP) * DEFAULT_MAILBOX_GAP
 
-		updates: dict[str, int] = {}
-		current = base
+        updates: dict[str, int] = {}
+        current = base
 
-		target_slot = insert_index - start
+        target_slot = insert_index - start
 
-		for i, m in enumerate(window):
-			if i == target_slot:
-				current += DEFAULT_MAILBOX_GAP
+        for i, m in enumerate(window):
+            if i == target_slot:
+                current += DEFAULT_MAILBOX_GAP
 
-			current += DEFAULT_MAILBOX_GAP
-			if m["sortOrder"] != current:
-				updates[m["id"]] = current
+            current += DEFAULT_MAILBOX_GAP
+            if m["sortOrder"] != current:
+                updates[m["id"]] = current
 
-		target_sort_order = base + DEFAULT_MAILBOX_GAP * (target_slot + 1)
-		updates[target_mailbox_id] = target_sort_order
+        target_sort_order = base + DEFAULT_MAILBOX_GAP * (target_slot + 1)
+        updates[target_mailbox_id] = target_sort_order
 
-		return updates
+        return updates
 
-	service = get_mailbox_service(account)
-	mailboxes = sorted(
-		service.get(), key=lambda m: (m["sortOrder"], get_sort_order(m["role"]), m["name"], m["id"])
-	)
-	updates = get_updates(mailboxes, target_mailbox_id, prior_mailbox_id)
+    service = get_mailbox_service(account)
+    mailboxes = sorted(
+        service.get(), key=lambda m: (m["sortOrder"], get_sort_order(m["role"]), m["name"], m["id"])
+    )
+    updates = get_updates(mailboxes, target_mailbox_id, prior_mailbox_id)
 
-	result = {"updated": [], "notUpdated": {}}
-	for batch in service.batch_dict(updates, service.max_objects_in_set):
-		response = service._call(
-			capabilities=service.capabilities,
-			method_calls=[
-				[
-					f"{service.type}/set",
-					{
-						"accountId": service.account,
-						"update": {k: {"sortOrder": v} for k, v in batch.items()},
-					},
-					"0",
-				]
-			],
-		)
+    result = {"updated": [], "notUpdated": {}}
+    for batch in service.batch_dict(updates, service.max_objects_in_set):
+        response = service._call(
+            capabilities=service.capabilities,
+            method_calls=[
+                [
+                    f"{service.type}/set",
+                    {
+                        "accountId": service.account,
+                        "update": {k: {"sortOrder": v} for k, v in batch.items()},
+                    },
+                    "0",
+                ]
+            ],
+        )
 
-		if method_responses := response.get("methodResponses"):
-			result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-			if not_updated := method_responses[0][1].get("notUpdated", {}):
-				result["notUpdated"].update(not_updated)
+        if method_responses := response.get("methodResponses"):
+            result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+            if not_updated := method_responses[0][1].get("notUpdated", {}):
+                result["notUpdated"].update(not_updated)
 
-	title = _("Mailbox Position Update Error")
-	if not result.get("updated"):
-		frappe.throw(_(result["description"]), title=title)
+    title = _("Mailbox Position Update Error")
+    if not result.get("updated"):
+        frappe.throw(_(result["description"]), title=title)
 
 
 def format_mailbox(account: str, mailbox: dict) -> dict:
-	"""Formats mailbox data for display."""
+    """Formats mailbox data for display."""
 
-	sort_order = cint(mailbox["sortOrder"])
-	if _parent := mailbox["parentId"]:
-		_parent = f"{account}|{_parent}"
-	rights = mailbox.get("myRights") or {}
+    sort_order = cint(mailbox["sortOrder"])
+    if _parent := mailbox["parentId"]:
+        _parent = f"{account}|{_parent}"
+    rights = mailbox.get("myRights") or {}
 
-	return {
-		"name": f"{account}|{mailbox['id']}",
-		"account": account,
-		"id": mailbox["id"],
-		"_name": mailbox["name"],
-		"_parent": _parent,
-		"parent_id": mailbox["parentId"],
-		"role": mailbox["role"],
-		"sort_order": sort_order,
-		"subscribed": bool(mailbox["isSubscribed"]),
-		"total_emails": cint(mailbox["totalEmails"]),
-		"unread_emails": cint(mailbox["unreadEmails"]),
-		"total_threads": cint(mailbox["totalThreads"]),
-		"unread_threads": cint(mailbox["unreadThreads"]),
-		"may_read_items": cint(rights.get("mayReadItems", False)),
-		"may_add_items": cint(rights.get("mayAddItems", False)),
-		"may_remove_items": cint(rights.get("mayRemoveItems", False)),
-		"may_set_seen": cint(rights.get("maySetSeen", False)),
-		"may_set_keywords": cint(rights.get("maySetKeywords", False)),
-		"may_create_child": cint(rights.get("mayCreateChild", False)),
-		"may_rename": cint(rights.get("mayRename", False)),
-		"may_delete": cint(rights.get("mayDelete", False)),
-		"may_submit": cint(rights.get("maySubmit", False)),
-		"creation": today(),
-		"modified": today(),
-	}
+    return {
+        "name": f"{account}|{mailbox['id']}",
+        "account": account,
+        "id": mailbox["id"],
+        "_name": mailbox["name"],
+        "_parent": _parent,
+        "parent_id": mailbox["parentId"],
+        "role": mailbox["role"],
+        "sort_order": sort_order,
+        "subscribed": bool(mailbox["isSubscribed"]),
+        "total_emails": cint(mailbox["totalEmails"]),
+        "unread_emails": cint(mailbox["unreadEmails"]),
+        "total_threads": cint(mailbox["totalThreads"]),
+        "unread_threads": cint(mailbox["unreadThreads"]),
+        "may_read_items": cint(rights.get("mayReadItems", False)),
+        "may_add_items": cint(rights.get("mayAddItems", False)),
+        "may_remove_items": cint(rights.get("mayRemoveItems", False)),
+        "may_set_seen": cint(rights.get("maySetSeen", False)),
+        "may_set_keywords": cint(rights.get("maySetKeywords", False)),
+        "may_create_child": cint(rights.get("mayCreateChild", False)),
+        "may_rename": cint(rights.get("mayRename", False)),
+        "may_delete": cint(rights.get("mayDelete", False)),
+        "may_submit": cint(rights.get("maySubmit", False)),
+        "creation": today(),
+        "modified": today(),
+    }
 
 
 def get_sort_order(role: str | None = None) -> int:
-	"""Returns the sort order for the mailbox based on its role."""
+    """Returns the sort order for the mailbox based on its role."""
 
-	role_order = ["inbox", "important", "sent", "drafts", "junk", "archive", "trash"]
+    role_order = ["inbox", "important", "sent", "drafts", "junk", "archive", "trash"]
 
-	if not role or role not in role_order:
-		return len(role_order) + 1
+    if not role or role not in role_order:
+        return len(role_order) + 1
 
-	return role_order.index(role)
+    return role_order.index(role)
 
 
 def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
-	if doc.doctype != "Mailbox":
-		return False
+    if doc.doctype != "Mailbox":
+        return False
 
-	return bool(get_user_for_jmap_account(doc.account, raise_exception=False))
+    return bool(get_user_for_jmap_account(doc.account, raise_exception=False))

--- a/suite/mail/doctype/mailbox/test_mailbox.py
+++ b/suite/mail/doctype/mailbox/test_mailbox.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestMailbox(IntegrationTestCase):
-	"""
-	Integration tests for Mailbox.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for Mailbox.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/mailbox_settings/mailbox_settings.py
+++ b/suite/mail/doctype/mailbox_settings/mailbox_settings.py
@@ -167,7 +167,7 @@ def get_permission_query_condition(user: str | None = None) -> str | None:
     return f"""`tabMailbox Settings`.account in ({", ".join(frappe.db.escape(account) for account in accounts)})"""
 
 
-def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
     if doc.doctype != "Mailbox Settings":
         return False
 

--- a/suite/mail/doctype/mailbox_settings/mailbox_settings.py
+++ b/suite/mail/doctype/mailbox_settings/mailbox_settings.py
@@ -16,168 +16,168 @@ AUTOMATION_FIELDS = ("emails_from", "subject_contains", "match_if", "mark_as_rea
 
 
 class MailboxSettings(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		account: DF.Link
-		add_star: DF.Check
-		color: DF.Literal["Gray", "Blue", "Green", "Amber", "Red", "Purple"]
-		disable_push_notification: DF.Check
-		emails_from: DF.SmallText | None
-		mailbox_id: DF.Data
-		mark_as_read: DF.Check
-		match_if: DF.Literal["any", "all"]
-		subject_contains: DF.SmallText | None
-	# end: auto-generated types
+        account: DF.Link
+        add_star: DF.Check
+        color: DF.Literal["Gray", "Blue", "Green", "Amber", "Red", "Purple"]
+        disable_push_notification: DF.Check
+        emails_from: DF.SmallText | None
+        mailbox_id: DF.Data
+        mark_as_read: DF.Check
+        match_if: DF.Literal["any", "all"]
+        subject_contains: DF.SmallText | None
+    # end: auto-generated types
 
-	"""Per-mailbox settings, shared per JMAP account ID — every user with access to the
+    """Per-mailbox settings, shared per JMAP account ID — every user with access to the
 	account sees the same mailbox icons, colors, and push-notification preferences."""
 
-	def autoname(self) -> None:
-		self.name = str(uuid7())
+    def autoname(self) -> None:
+        self.name = str(uuid7())
 
-	def validate(self) -> None:
-		self.validate_duplicate()
+    def validate(self) -> None:
+        self.validate_duplicate()
 
-	def on_update(self) -> None:
-		# Regenerate the automation sieve when a folder's automation rules change through the document
-		# lifecycle (e.g. a save from Desk). The high-volume API path writes via db_set — which bypasses
-		# this hook — and rebuilds explicitly once after its structural writes. Skipped during migrate
-		# (no JMAP round-trips) and when a caller paused builds for a bulk write.
-		if frappe.flags.in_migrate or frappe.flags.get("skip_automation_sieve_build"):
-			return
+    def on_update(self) -> None:
+        # Regenerate the automation sieve when a folder's automation rules change through the document
+        # lifecycle (e.g. a save from Desk). The high-volume API path writes via db_set — which bypasses
+        # this hook — and rebuilds explicitly once after its structural writes. Skipped during migrate
+        # (no JMAP round-trips) and when a caller paused builds for a bulk write.
+        if frappe.flags.in_migrate or frappe.flags.get("skip_automation_sieve_build"):
+            return
 
-		if any(self.has_value_changed(field) for field in AUTOMATION_FIELDS):
-			from suite.mail.doctype.sieve_script.sieve_script import maybe_build_automation_sieve
+        if any(self.has_value_changed(field) for field in AUTOMATION_FIELDS):
+            from suite.mail.doctype.sieve_script.sieve_script import maybe_build_automation_sieve
 
-			# Activate the automation script so the new rules take effect (unless vacation is active).
-			maybe_build_automation_sieve(self.account, activate=True)
+            # Activate the automation script so the new rules take effect (unless vacation is active).
+            maybe_build_automation_sieve(self.account, activate=True)
 
-	def validate_duplicate(self) -> None:
-		"""Checks for duplicate Mailbox Settings for the same account and mailbox ID."""
+    def validate_duplicate(self) -> None:
+        """Checks for duplicate Mailbox Settings for the same account and mailbox ID."""
 
-		existing = frappe.db.exists(
-			"Mailbox Settings",
-			{
-				"name": ["!=", self.name],
-				"account": self.account,
-				"mailbox_id": self.mailbox_id,
-			},
-		)
+        existing = frappe.db.exists(
+            "Mailbox Settings",
+            {
+                "name": ["!=", self.name],
+                "account": self.account,
+                "mailbox_id": self.mailbox_id,
+            },
+        )
 
-		if existing:
-			frappe.throw(
-				_("Mailbox Settings for account {0} with mailbox ID {1} already exists.").format(
-					frappe.bold(self.account), frappe.bold(self.mailbox_id)
-				),
-				title=_("Duplicate Mailbox Settings"),
-			)
+        if existing:
+            frappe.throw(
+                _("Mailbox Settings for account {0} with mailbox ID {1} already exists.").format(
+                    frappe.bold(self.account), frappe.bold(self.mailbox_id)
+                ),
+                title=_("Duplicate Mailbox Settings"),
+            )
 
-	def _db_set(
-		self,
-		update_modified: bool = True,
-		commit: bool = False,
-		notify: bool = False,
-		**kwargs,
-	) -> None:
-		"""Updates the document with the given key-value pairs."""
+    def _db_set(
+        self,
+        update_modified: bool = True,
+        commit: bool = False,
+        notify: bool = False,
+        **kwargs,
+    ) -> None:
+        """Updates the document with the given key-value pairs."""
 
-		self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
+        self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
 
 
 def get_mailbox_settings(
-	account: str, mailbox_id: str, raise_exception: bool = True
+    account: str, mailbox_id: str, raise_exception: bool = True
 ) -> MailboxSettings | None:
-	"""Fetches the Mailbox Settings for a given account and mailbox ID."""
+    """Fetches the Mailbox Settings for a given account and mailbox ID."""
 
-	if settings := frappe.db.get_value("Mailbox Settings", {"account": account, "mailbox_id": mailbox_id}):
-		return frappe.get_doc("Mailbox Settings", settings)
+    if settings := frappe.db.get_value("Mailbox Settings", {"account": account, "mailbox_id": mailbox_id}):
+        return frappe.get_doc("Mailbox Settings", settings)
 
-	if raise_exception:
-		frappe.throw(
-			_("Mailbox Settings for account {0} with mailbox ID {1} not found.").format(
-				frappe.bold(account), frappe.bold(mailbox_id)
-			)
-		)
+    if raise_exception:
+        frappe.throw(
+            _("Mailbox Settings for account {0} with mailbox ID {1} not found.").format(
+                frappe.bold(account), frappe.bold(mailbox_id)
+            )
+        )
 
 
 def automation_rules_to_settings(rules: dict | None) -> dict:
-	"""Flatten a rule dict (or None) into the Mailbox Settings automation fields.
+    """Flatten a rule dict (or None) into the Mailbox Settings automation fields.
 
-	A falsy `rules` clears the fields, so removing a mailbox's automation in the UI also clears its
-	backup.
-	"""
+    A falsy `rules` clears the fields, so removing a mailbox's automation in the UI also clears its
+    backup.
+    """
 
-	rules = rules or {}
-	return {
-		"emails_from": rules.get("emails_from") or "",
-		"subject_contains": rules.get("subject_contains") or "",
-		"match_if": rules.get("match_if") or "any",
-		"mark_as_read": 1 if rules.get("mark_as_read") else 0,
-		"add_star": 1 if rules.get("add_star") else 0,
-	}
+    rules = rules or {}
+    return {
+        "emails_from": rules.get("emails_from") or "",
+        "subject_contains": rules.get("subject_contains") or "",
+        "match_if": rules.get("match_if") or "any",
+        "mark_as_read": 1 if rules.get("mark_as_read") else 0,
+        "add_star": 1 if rules.get("add_star") else 0,
+    }
 
 
 def set_mailbox_settings(account: str, mailbox_id: str, **kwargs) -> None:
-	"""Sets the Mailbox Settings for a given account and mailbox ID. Creates a new document if it doesn't exist."""
+    """Sets the Mailbox Settings for a given account and mailbox ID. Creates a new document if it doesn't exist."""
 
-	settings = get_mailbox_settings(account, mailbox_id, raise_exception=False)
+    settings = get_mailbox_settings(account, mailbox_id, raise_exception=False)
 
-	if not settings:
-		settings = frappe.new_doc("Mailbox Settings")
-		settings.account = account
-		settings.mailbox_id = mailbox_id
-		settings.insert()
+    if not settings:
+        settings = frappe.new_doc("Mailbox Settings")
+        settings.account = account
+        settings.mailbox_id = mailbox_id
+        settings.insert()
 
-	mailbox_fields = ["subscribed", "parent", "_name", "role", "sort_order"]
-	filtered_kwargs = {k: v for k, v in kwargs.items() if k not in mailbox_fields}
+    mailbox_fields = ["subscribed", "parent", "_name", "role", "sort_order"]
+    filtered_kwargs = {k: v for k, v in kwargs.items() if k not in mailbox_fields}
 
-	if filtered_kwargs:
-		settings._db_set(**filtered_kwargs)
+    if filtered_kwargs:
+        settings._db_set(**filtered_kwargs)
 
-	if any(field in kwargs for field in mailbox_fields):
-		mailbox = frappe.get_doc("Mailbox", f"{account}|{mailbox_id}")
-		for field in mailbox_fields:
-			if field in kwargs:
-				setattr(mailbox, field, kwargs[field])
-		mailbox.save()
+    if any(field in kwargs for field in mailbox_fields):
+        mailbox = frappe.get_doc("Mailbox", f"{account}|{mailbox_id}")
+        for field in mailbox_fields:
+            if field in kwargs:
+                setattr(mailbox, field, kwargs[field])
+        mailbox.save()
 
 
 def on_doctype_update() -> None:
-	# Mailbox settings are shared per account, so uniqueness is on (account, mailbox_id).
-	frappe.db.add_unique(
-		"Mailbox Settings", ["account", "mailbox_id"], constraint_name="unique_account_mailbox"
-	)
+    # Mailbox settings are shared per account, so uniqueness is on (account, mailbox_id).
+    frappe.db.add_unique(
+        "Mailbox Settings", ["account", "mailbox_id"], constraint_name="unique_account_mailbox"
+    )
 
 
 def get_permission_query_condition(user: str | None = None) -> str | None:
-	user = user or frappe.session.user
-	if is_system_manager(user) or is_suite_admin(user):
-		return ""
+    user = user or frappe.session.user
+    if is_system_manager(user) or is_suite_admin(user):
+        return ""
 
-	accounts = get_user_jmap_accounts(user)
-	if not accounts:
-		return "1=0"
+    accounts = get_user_jmap_accounts(user)
+    if not accounts:
+        return "1=0"
 
-	return f"""`tabMailbox Settings`.account in ({", ".join(frappe.db.escape(account) for account in accounts)})"""
+    return f"""`tabMailbox Settings`.account in ({", ".join(frappe.db.escape(account) for account in accounts)})"""
 
 
 def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
-	if doc.doctype != "Mailbox Settings":
-		return False
+    if doc.doctype != "Mailbox Settings":
+        return False
 
-	user = user or frappe.session.user
+    user = user or frappe.session.user
 
-	if is_system_manager(user) or is_suite_admin(user):
-		return True
+    if is_system_manager(user) or is_suite_admin(user):
+        return True
 
-	accounts = get_user_jmap_accounts(user)
-	if not accounts:
-		return False
+    accounts = get_user_jmap_accounts(user)
+    if not accounts:
+        return False
 
-	return doc.account in accounts
+    return doc.account in accounts

--- a/suite/mail/doctype/mailbox_settings/test_mailbox_settings.py
+++ b/suite/mail/doctype/mailbox_settings/test_mailbox_settings.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestMailboxSettings(IntegrationTestCase):
-	"""
-	Integration tests for MailboxSettings.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for MailboxSettings.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/participant_identity/participant_identity.py
+++ b/suite/mail/doctype/participant_identity/participant_identity.py
@@ -45,7 +45,7 @@ class ParticipantIdentity(Document):
         )
         self.name = f"{self.account}|{self.id}"
 
-    def load_from_db(self) -> "ParticipantIdentity":
+    def load_from_db(self) -> ParticipantIdentity:
         account, id = self.name.split("|")
         identity = get_participant_identity(account, id)
         return super(Document, self).__init__(identity)
@@ -229,7 +229,7 @@ def format_participant_identity(account: str, identity: dict) -> dict:
     }
 
 
-def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
     if doc.doctype != "Participant Identity":
         return False
 

--- a/suite/mail/doctype/participant_identity/participant_identity.py
+++ b/suite/mail/doctype/participant_identity/participant_identity.py
@@ -15,222 +15,222 @@ from suite.utils import parse_filters
 
 
 class ParticipantIdentity(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		_name: DF.Data | None
-		account: DF.Link
-		default: DF.Check
-		email: DF.Data
-		id: DF.Data | None
-	# end: auto-generated types
+        _name: DF.Data | None
+        account: DF.Link
+        default: DF.Check
+        email: DF.Data
+        id: DF.Data | None
+    # end: auto-generated types
 
-	@property
-	def calendar_address(self) -> str:
-		"""Returns the calendar address in mailto format."""
+    @property
+    def calendar_address(self) -> str:
+        """Returns the calendar address in mailto format."""
 
-		return f"mailto:{self.email.lower()}"
+        return f"mailto:{self.email.lower()}"
 
-	def db_insert(self, *args, **kwargs) -> None:
-		self.id = add_participant_identity(
-			self.account,
-			self._name,
-			self.email,
-			bool(self.default),
-		)
-		self.name = f"{self.account}|{self.id}"
+    def db_insert(self, *args, **kwargs) -> None:
+        self.id = add_participant_identity(
+            self.account,
+            self._name,
+            self.email,
+            bool(self.default),
+        )
+        self.name = f"{self.account}|{self.id}"
 
-	def load_from_db(self) -> "ParticipantIdentity":
-		account, id = self.name.split("|")
-		identity = get_participant_identity(account, id)
-		return super(Document, self).__init__(identity)
+    def load_from_db(self) -> "ParticipantIdentity":
+        account, id = self.name.split("|")
+        identity = get_participant_identity(account, id)
+        return super(Document, self).__init__(identity)
 
-	def db_update(self) -> None:
-		update_participant_identity(
-			self.account,
-			self.id,
-			self._name,
-			self.email,
-			bool(self.default),
-		)
-		self.reload()
+    def db_update(self) -> None:
+        update_participant_identity(
+            self.account,
+            self.id,
+            self._name,
+            self.email,
+            bool(self.default),
+        )
+        self.reload()
 
-	def delete(self) -> None:
-		account, id = self.name.split("|")
-		delete_participant_identities(account, [id])
+    def delete(self) -> None:
+        account, id = self.name.split("|")
+        delete_participant_identities(account, [id])
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs) -> list:
-		filters = parse_filters(filters)
-		account = filters.get("account")
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs) -> list:
+        filters = parse_filters(filters)
+        account = filters.get("account")
 
-		if not account:
-			frappe.msgprint(_("Please select an account to view participant identities."), alert=True)
-			return []
+        if not account:
+            frappe.msgprint(_("Please select an account to view participant identities."), alert=True)
+            return []
 
-		identities = fetch_participant_identities(account, limit=page_length)
+        identities = fetch_participant_identities(account, limit=page_length)
 
-		if not identities:
-			frappe.msgprint(_("No participant identities found."), alert=True)
+        if not identities:
+            frappe.msgprint(_("No participant identities found."), alert=True)
 
-		return identities
+        return identities
 
-	@staticmethod
-	def get_count(filters=None, **kwargs) -> int:
-		filters = parse_filters(filters)
-		account = filters.get("account")
+    @staticmethod
+    def get_count(filters=None, **kwargs) -> int:
+        filters = parse_filters(filters)
+        account = filters.get("account")
 
-		if account:
-			if get_user_for_jmap_account(account, raise_exception=False):
-				return cint(frappe.cache.get_value(_get_total_cache_key(account)))
+        if account:
+            if get_user_for_jmap_account(account, raise_exception=False):
+                return cint(frappe.cache.get_value(_get_total_cache_key(account)))
 
-		return 0
+        return 0
 
-	@staticmethod
-	def get_stats(**kwargs) -> dict:
-		return {}
+    @staticmethod
+    def get_stats(**kwargs) -> dict:
+        return {}
 
 
 def _get_total_cache_key(account: str) -> str:
-	"""Returns a cache key for total participant identities count for the given account."""
+    """Returns a cache key for total participant identities count for the given account."""
 
-	return f"{account}:participant_identities:total"
+    return f"{account}:participant_identities:total"
 
 
 @frappe.whitelist()
 def bulk_delete(names: str | list[str]) -> None:
-	"""Deletes participant identities for the given list of names."""
+    """Deletes participant identities for the given list of names."""
 
-	if isinstance(names, str):
-		names = json.loads(names)
+    if isinstance(names, str):
+        names = json.loads(names)
 
-	accounts_map = {}
-	for name in names:
-		account, id = name.split("|")
-		accounts_map.setdefault(account, []).append(id)
+    accounts_map = {}
+    for name in names:
+        account, id = name.split("|")
+        accounts_map.setdefault(account, []).append(id)
 
-	for account, ids in accounts_map.items():
-		delete_participant_identities(account, ids)
+    for account, ids in accounts_map.items():
+        delete_participant_identities(account, ids)
 
-	frappe.msgprint(_("Participant Identities deleted successfully."), alert=True)
+    frappe.msgprint(_("Participant Identities deleted successfully."), alert=True)
 
 
 @frappe.whitelist()
 def add_participant_identity(account: str, name: str, email: str, default: bool = False) -> str:
-	"""Adds a participant identity for the given account and returns the identity ID."""
+    """Adds a participant identity for the given account and returns the identity ID."""
 
-	creation_id = str(uuid7())
-	participant_identity = {
-		"creation_id": creation_id,
-		"name": name,
-		"email": email,
-		"is_default": default,
-	}
+    creation_id = str(uuid7())
+    participant_identity = {
+        "creation_id": creation_id,
+        "name": name,
+        "email": email,
+        "is_default": default,
+    }
 
-	service = get_participant_identity_service(account)
-	response = service.create([participant_identity])
+    service = get_participant_identity_service(account)
+    response = service.create([participant_identity])
 
-	title = _("Participant Identity Creation Error")
-	if response.get("created"):
-		return response["created"][creation_id]["id"]
-	elif response.get("notCreated"):
-		frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
-	else:
-		frappe.throw(_(response["description"]), title=title)
+    title = _("Participant Identity Creation Error")
+    if response.get("created"):
+        return response["created"][creation_id]["id"]
+    elif response.get("notCreated"):
+        frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
+    else:
+        frappe.throw(_(response["description"]), title=title)
 
 
 @frappe.whitelist()
 def get_participant_identity(account: str, id: str) -> dict:
-	"""Returns participant identity details for the given account and identity ID."""
+    """Returns participant identity details for the given account and identity ID."""
 
-	service = get_participant_identity_service(account)
-	if identities := service.get([id]):
-		return format_participant_identity(account, identities[0])
+    service = get_participant_identity_service(account)
+    if identities := service.get([id]):
+        return format_participant_identity(account, identities[0])
 
-	frappe.throw(
-		_("Participant Identity with ID {0} not found in account {1}.").format(
-			frappe.bold(id), frappe.bold(account)
-		),
-		title=_("Participant Identity Not Found"),
-	)
+    frappe.throw(
+        _("Participant Identity with ID {0} not found in account {1}.").format(
+            frappe.bold(id), frappe.bold(account)
+        ),
+        title=_("Participant Identity Not Found"),
+    )
 
 
 @frappe.whitelist()
 def update_participant_identity(account: str, id: str, name: str, email: str, default: bool = False) -> None:
-	"""Updates an existing participant identity with the given parameters."""
+    """Updates an existing participant identity with the given parameters."""
 
-	participant_identity = {
-		"id": id,
-		"name": name,
-		"email": email,
-		"is_default": default,
-	}
+    participant_identity = {
+        "id": id,
+        "name": name,
+        "email": email,
+        "is_default": default,
+    }
 
-	service = get_participant_identity_service(account)
-	response = service.update([participant_identity])
+    service = get_participant_identity_service(account)
+    response = service.update([participant_identity])
 
-	if not response.get("updated"):
-		title = _("Participant Identity Update Error")
-		if response.get("notUpdated"):
-			frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
-		else:
-			frappe.throw(_(response["description"]), title=title)
+    if not response.get("updated"):
+        title = _("Participant Identity Update Error")
+        if response.get("notUpdated"):
+            frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
+        else:
+            frappe.throw(_(response["description"]), title=title)
 
 
 @frappe.whitelist()
 def delete_participant_identities(account: str, ids: list[str]) -> None:
-	"""Deletes participant identities for the specified account and ID(s)."""
+    """Deletes participant identities for the specified account and ID(s)."""
 
-	service = get_participant_identity_service(account)
-	response = service.delete(ids)
+    service = get_participant_identity_service(account)
+    response = service.delete(ids)
 
-	if response.get("notDestroyed"):
-		error_messages = []
-		for id, error in response["notDestroyed"].items():
-			error_messages.append(f"{id}: {error['description']}")
-		frappe.throw(
-			_("Participant Identity Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
-			title=_("Participant Identity Deletion Error"),
-		)
+    if response.get("notDestroyed"):
+        error_messages = []
+        for id, error in response["notDestroyed"].items():
+            error_messages.append(f"{id}: {error['description']}")
+        frappe.throw(
+            _("Participant Identity Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
+            title=_("Participant Identity Deletion Error"),
+        )
 
 
 @frappe.whitelist()
 def fetch_participant_identities(account: str, page: int = 1, limit: int = 10) -> list:
-	"""Fetches and returns all participant identities for the given account."""
+    """Fetches and returns all participant identities for the given account."""
 
-	service = get_participant_identity_service(account)
-	identities = service.get()
-	formatted_identities = [format_participant_identity(account, identity) for identity in identities]
-	frappe.cache.set_value(_get_total_cache_key(account), len(identities), expires_in_sec=600)
+    service = get_participant_identity_service(account)
+    identities = service.get()
+    formatted_identities = [format_participant_identity(account, identity) for identity in identities]
+    frappe.cache.set_value(_get_total_cache_key(account), len(identities), expires_in_sec=600)
 
-	start = (page - 1) * limit
-	end = start + limit
+    start = (page - 1) * limit
+    end = start + limit
 
-	return formatted_identities[start:end]
+    return formatted_identities[start:end]
 
 
 def format_participant_identity(account: str, identity: dict) -> dict:
-	"""Formats participant identity data for display."""
+    """Formats participant identity data for display."""
 
-	return {
-		"name": f"{account}|{identity['id']}",
-		"account": account,
-		"id": identity["id"],
-		"default": cint(bool(identity["isDefault"])),
-		"_name": identity["name"],
-		"email": identity["calendarAddress"].split("mailto:")[-1].lower(),
-		"creation": today(),
-		"modified": today(),
-	}
+    return {
+        "name": f"{account}|{identity['id']}",
+        "account": account,
+        "id": identity["id"],
+        "default": cint(bool(identity["isDefault"])),
+        "_name": identity["name"],
+        "email": identity["calendarAddress"].split("mailto:")[-1].lower(),
+        "creation": today(),
+        "modified": today(),
+    }
 
 
 def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
-	if doc.doctype != "Participant Identity":
-		return False
+    if doc.doctype != "Participant Identity":
+        return False
 
-	return bool(get_user_for_jmap_account(doc.account, raise_exception=False))
+    return bool(get_user_for_jmap_account(doc.account, raise_exception=False))

--- a/suite/mail/doctype/participant_identity/test_participant_identity.py
+++ b/suite/mail/doctype/participant_identity/test_participant_identity.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestParticipantIdentity(IntegrationTestCase):
-	"""
-	Integration tests for ParticipantIdentity.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for ParticipantIdentity.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -43,7 +43,7 @@ class PushSubscription(Document):
         )
         self.name = f"{self.user}|{self.id}"
 
-    def load_from_db(self) -> "PushSubscription":
+    def load_from_db(self) -> PushSubscription:
         user, id = self.name.split("|")
         subscription = get_push_subscription(user, id)
         return super(Document, self).__init__(subscription)
@@ -536,7 +536,7 @@ def is_jmap_push_notifications_frozen(user: str) -> bool:
     return frappe.cache.hget("frozen_jmap_push_notifications", user) is True
 
 
-def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
     if doc.doctype != "Push Subscription":
         return False
 

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -23,538 +23,538 @@ RENEW_THRESHOLD_DAYS = 3
 
 
 class PushSubscription(Document):
-	@property
-	def _types(self) -> list[str]:
-		"""Returns the types of push subscriptions as a list."""
+    @property
+    def _types(self) -> list[str]:
+        """Returns the types of push subscriptions as a list."""
 
-		types = []
-		if self.types:
-			types = json.loads(self.types)
+        types = []
+        if self.types:
+            types = json.loads(self.types)
 
-		return types
+        return types
 
-	def db_insert(self, *args, **kwargs) -> None:
-		self.id = _add_push_subscription(
-			self.user,
-			self.device_client_id,
-			self.url,
-			self._types,
-			ignore_permissions=bool(self.flags.ignore_permissions),
-		)
-		self.name = f"{self.user}|{self.id}"
+    def db_insert(self, *args, **kwargs) -> None:
+        self.id = _add_push_subscription(
+            self.user,
+            self.device_client_id,
+            self.url,
+            self._types,
+            ignore_permissions=bool(self.flags.ignore_permissions),
+        )
+        self.name = f"{self.user}|{self.id}"
 
-	def load_from_db(self) -> "PushSubscription":
-		user, id = self.name.split("|")
-		subscription = get_push_subscription(user, id)
-		return super(Document, self).__init__(subscription)
+    def load_from_db(self) -> "PushSubscription":
+        user, id = self.name.split("|")
+        subscription = get_push_subscription(user, id)
+        return super(Document, self).__init__(subscription)
 
-	def db_update(self) -> None:
-		raise NotImplementedError
+    def db_update(self) -> None:
+        raise NotImplementedError
 
-	def delete(self) -> None:
-		user, id = self.name.split("|")
-		delete_push_subscriptions(user, [id])
+    def delete(self) -> None:
+        user, id = self.name.split("|")
+        delete_push_subscriptions(user, [id])
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs) -> list:
-		filters = parse_filters(filters)
-		id = filters.get("id")
-		user = filters.get("user")
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs) -> list:
+        filters = parse_filters(filters)
+        id = filters.get("id")
+        user = filters.get("user")
 
-		if not user:
-			frappe.msgprint(_("Please select a user to view push subscriptions."), alert=True)
-			return []
+        if not user:
+            frappe.msgprint(_("Please select a user to view push subscriptions."), alert=True)
+            return []
 
-		subscriptions = []
-		if id:
-			if subscription := get_push_subscription(user, id, raise_exception=False):
-				subscriptions.append(subscription)
-		else:
-			subscriptions = fetch_push_subscriptions(user, limit=page_length)
+        subscriptions = []
+        if id:
+            if subscription := get_push_subscription(user, id, raise_exception=False):
+                subscriptions.append(subscription)
+        else:
+            subscriptions = fetch_push_subscriptions(user, limit=page_length)
 
-		if not subscriptions:
-			frappe.msgprint(_("No push subscriptions found."), alert=True)
+        if not subscriptions:
+            frappe.msgprint(_("No push subscriptions found."), alert=True)
 
-		return subscriptions
+        return subscriptions
 
-	@staticmethod
-	def get_count(filters=None, **kwargs) -> int:
-		filters = parse_filters(filters)
-		user = filters.get("user")
+    @staticmethod
+    def get_count(filters=None, **kwargs) -> int:
+        filters = parse_filters(filters)
+        user = filters.get("user")
 
-		if user and has_permission_for_user(user, raise_exception=False):
-			return cint(frappe.cache.get_value(_get_total_cache_key(user)))
+        if user and has_permission_for_user(user, raise_exception=False):
+            return cint(frappe.cache.get_value(_get_total_cache_key(user)))
 
-		return 0
+        return 0
 
-	@staticmethod
-	def get_stats(**kwargs) -> dict:
-		return {}
+    @staticmethod
+    def get_stats(**kwargs) -> dict:
+        return {}
 
-	def validate(self) -> None:
-		self.validate_url()
+    def validate(self) -> None:
+        self.validate_url()
 
-	def validate_url(self) -> None:
-		"""Validates the URL to ensure it starts with 'https://'."""
+    def validate_url(self) -> None:
+        """Validates the URL to ensure it starts with 'https://'."""
 
-		if self.url and not self.url.startswith("https"):
-			frappe.throw(_("The URL must start with 'https://'."))
+        if self.url and not self.url.startswith("https"):
+            frappe.throw(_("The URL must start with 'https://'."))
 
-	@frappe.whitelist()
-	def renew(self) -> None:
-		"""Renews the push subscription subscription."""
+    @frappe.whitelist()
+    def renew(self) -> None:
+        """Renews the push subscription subscription."""
 
-		renew_push_subscription(self.user, self.id)
+        renew_push_subscription(self.user, self.id)
 
 
 def _get_total_cache_key(user: str) -> str:
-	"""Returns a cache key for total push subscriptions count for the given user."""
+    """Returns a cache key for total push subscriptions count for the given user."""
 
-	return f"{user}:push_subscriptions:total"
+    return f"{user}:push_subscriptions:total"
 
 
 @frappe.whitelist()
 def bulk_delete(names: str | list[str]) -> None:
-	"""Deletes multiple push subscriptions given their names."""
+    """Deletes multiple push subscriptions given their names."""
 
-	if isinstance(names, str):
-		names = json.loads(names)
+    if isinstance(names, str):
+        names = json.loads(names)
 
-	user_ids_map = {}
-	for name in names:
-		user, id = name.split("|")
-		user_ids_map.setdefault(user, []).append(id)
+    user_ids_map = {}
+    for name in names:
+        user, id = name.split("|")
+        user_ids_map.setdefault(user, []).append(id)
 
-	for user, ids in user_ids_map.items():
-		delete_push_subscriptions(user, ids)
+    for user, ids in user_ids_map.items():
+        delete_push_subscriptions(user, ids)
 
-	frappe.msgprint(_("Push Subscriptions deleted successfully."), alert=True)
+    frappe.msgprint(_("Push Subscriptions deleted successfully."), alert=True)
 
 
 @frappe.whitelist()
 def add_push_subscription(
-	user: str,
-	device_client_id: str | None = None,
-	url: str | None = None,
-	types: list[str] | None = None,
+    user: str,
+    device_client_id: str | None = None,
+    url: str | None = None,
+    types: list[str] | None = None,
 ) -> str:
-	"""Adds a push subscription subscription for the given user and returns the subscription ID."""
+    """Adds a push subscription subscription for the given user and returns the subscription ID."""
 
-	return _add_push_subscription(user, device_client_id, url, types)
+    return _add_push_subscription(user, device_client_id, url, types)
 
 
 def _add_push_subscription(
-	user: str,
-	device_client_id: str | None = None,
-	url: str | None = None,
-	types: list[str] | None = None,
-	ignore_permissions: bool = False,
+    user: str,
+    device_client_id: str | None = None,
+    url: str | None = None,
+    types: list[str] | None = None,
+    ignore_permissions: bool = False,
 ) -> str:
-	"""Internal worker for :func:`add_push_subscription`.
+    """Internal worker for :func:`add_push_subscription`.
 
-	``ignore_permissions`` is deliberately kept off the whitelisted wrapper: frappe binds request
-	parameters onto a whitelisted function's named arguments, so exposing it would let any caller
-	turn off the ownership check and register an attacker-controlled callback URL against another
-	user's account.
-	"""
+    ``ignore_permissions`` is deliberately kept off the whitelisted wrapper: frappe binds request
+    parameters onto a whitelisted function's named arguments, so exposing it would let any caller
+    turn off the ownership check and register an attacker-controlled callback URL against another
+    user's account.
+    """
 
-	if not ignore_permissions:
-		has_permission_for_user(user, raise_exception=True)
+    if not ignore_permissions:
+        has_permission_for_user(user, raise_exception=True)
 
-	device_client_id = device_client_id or generate_uuid_style_hash(
-		f"frappe-{frappe.local.site.replace('.', '-')}-{user}"
-	)
-	url = url or f"{frappe.utils.get_url()}/api/method/suite.mail.api.jmap.push_notification?user={user}"
-	types = types or None
+    device_client_id = device_client_id or generate_uuid_style_hash(
+        f"frappe-{frappe.local.site.replace('.', '-')}-{user}"
+    )
+    url = url or f"{frappe.utils.get_url()}/api/method/suite.mail.api.jmap.push_notification?user={user}"
+    types = types or None
 
-	creation_id = str(uuid7())
-	push_subscription = {
-		"creation_id": creation_id,
-		"device_client_id": device_client_id,
-		"url": url,
-		"types": types,
-		"keys": get_push_subscription_keys(),
-	}
+    creation_id = str(uuid7())
+    push_subscription = {
+        "creation_id": creation_id,
+        "device_client_id": device_client_id,
+        "url": url,
+        "types": types,
+        "keys": get_push_subscription_keys(),
+    }
 
-	service = get_push_subscription_service(user, ignore_permissions=ignore_permissions)
-	response = service.create([push_subscription])
+    service = get_push_subscription_service(user, ignore_permissions=ignore_permissions)
+    response = service.create([push_subscription])
 
-	title = _("Push Subscription Creation Error")
-	if response.get("created"):
-		return response["created"][creation_id]["id"]
-	elif response.get("notCreated"):
-		frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
-	else:
-		frappe.throw(_(response["description"]), title=title)
+    title = _("Push Subscription Creation Error")
+    if response.get("created"):
+        return response["created"][creation_id]["id"]
+    elif response.get("notCreated"):
+        frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
+    else:
+        frappe.throw(_(response["description"]), title=title)
 
 
 @frappe.whitelist()
 def get_push_subscription(user: str, id: str, raise_exception: bool = True) -> dict | None:
-	"""Returns push subscription details for the given name in the format 'user|id'."""
+    """Returns push subscription details for the given name in the format 'user|id'."""
 
-	has_permission_for_user(user, raise_exception=raise_exception)
+    has_permission_for_user(user, raise_exception=raise_exception)
 
-	service = get_push_subscription_service(user)
-	if subscriptions := service.get([id]):
-		return format_push_subscription(user, subscriptions[0])
+    service = get_push_subscription_service(user)
+    if subscriptions := service.get([id]):
+        return format_push_subscription(user, subscriptions[0])
 
-	if raise_exception:
-		frappe.throw(
-			_("Push Subscription with ID {0} not found for user {1}.").format(
-				frappe.bold(id), frappe.bold(user)
-			),
-			title=_("Push Subscription Not Found"),
-		)
+    if raise_exception:
+        frappe.throw(
+            _("Push Subscription with ID {0} not found for user {1}.").format(
+                frappe.bold(id), frappe.bold(user)
+            ),
+            title=_("Push Subscription Not Found"),
+        )
 
 
 def verify_push_subscription(user: str, id: str, verification_code: str) -> None:
-	"""Verifies a push subscription for the given user, subscription ID, and verification code."""
+    """Verifies a push subscription for the given user, subscription ID, and verification code."""
 
-	if not frappe.db.exists("User", {"name": user, "enabled": 1}):
-		frappe.throw(_("User does not exist or is disabled."))
+    if not frappe.db.exists("User", {"name": user, "enabled": 1}):
+        frappe.throw(_("User does not exist or is disabled."))
 
-	is_jmap_configured(user, raise_exception=True)
+    is_jmap_configured(user, raise_exception=True)
 
-	push_subscription = {"id": id, "verification_code": verification_code}
+    push_subscription = {"id": id, "verification_code": verification_code}
 
-	service = get_push_subscription_service(user, ignore_permissions=True)
-	response = service.update([push_subscription])
+    service = get_push_subscription_service(user, ignore_permissions=True)
+    response = service.update([push_subscription])
 
-	title = _("Push Subscription Renewal Error")
-	if not response.get("updated"):
-		if response.get("notUpdated"):
-			frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
-		else:
-			frappe.throw(_(response["description"]), title=title)
+    title = _("Push Subscription Renewal Error")
+    if not response.get("updated"):
+        if response.get("notUpdated"):
+            frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
+        else:
+            frappe.throw(_(response["description"]), title=title)
 
 
 @frappe.whitelist()
 def renew_push_subscription(user: str, id: str) -> None:
-	"""Renews a push subscription subscription for the given user and subscription ID."""
+    """Renews a push subscription subscription for the given user and subscription ID."""
 
-	has_permission_for_user(user, raise_exception=True)
+    has_permission_for_user(user, raise_exception=True)
 
-	service = get_push_subscription_service(user)
-	response = service.update([{"id": id}])
+    service = get_push_subscription_service(user)
+    response = service.update([{"id": id}])
 
-	title = _("Push Subscription Renewal Error")
-	if not response.get("updated"):
-		if response.get("notUpdated"):
-			frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
-		else:
-			frappe.throw(_(response["description"]), title=title)
+    title = _("Push Subscription Renewal Error")
+    if not response.get("updated"):
+        if response.get("notUpdated"):
+            frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
+        else:
+            frappe.throw(_(response["description"]), title=title)
 
 
 def renew_expiring_push_subscriptions() -> None:
-	"""Renews soon-to-expire push subscriptions for all JMAP configured users.
+    """Renews soon-to-expire push subscriptions for all JMAP configured users.
 
-	Scheduled to run daily. A subscription is renewed when its expiry is within
-	``RENEW_THRESHOLD_DAYS`` of the run; subscriptions without an expiry or expiring
-	later are left untouched.
-	"""
+    Scheduled to run daily. A subscription is renewed when its expiry is within
+    ``RENEW_THRESHOLD_DAYS`` of the run; subscriptions without an expiry or expiring
+    later are left untouched.
+    """
 
-	if not frappe.utils.get_url().startswith("https://"):
-		return
+    if not frappe.utils.get_url().startswith("https://"):
+        return
 
-	cutoff = get_utc_now() + timedelta(days=RENEW_THRESHOLD_DAYS)
+    cutoff = get_utc_now() + timedelta(days=RENEW_THRESHOLD_DAYS)
 
-	for user in frappe.db.get_all("User Settings", {"enabled": 1, "username": ["!=", ""]}, pluck="user"):
-		try:
-			service = get_push_subscription_service(user, ignore_permissions=True)
+    for user in frappe.db.get_all("User Settings", {"enabled": 1, "username": ["!=", ""]}, pluck="user"):
+        try:
+            service = get_push_subscription_service(user, ignore_permissions=True)
 
-			expiring_ids = []
-			for subscription in service.get():
-				expires = subscription.get("expires")
-				if expires and parse_iso_datetime(expires, as_str=False) <= cutoff:
-					expiring_ids.append(subscription["id"])
+            expiring_ids = []
+            for subscription in service.get():
+                expires = subscription.get("expires")
+                if expires and parse_iso_datetime(expires, as_str=False) <= cutoff:
+                    expiring_ids.append(subscription["id"])
 
-			if not expiring_ids:
-				continue
+            if not expiring_ids:
+                continue
 
-			response = service.update([{"id": id} for id in expiring_ids])
-			if not_updated := response.get("notUpdated"):
-				errors = "<br>".join(f"{id}: {error['description']}" for id, error in not_updated.items())
-				log_mail_error(
-					_("Push Subscription Renewal Failed"),
-					_("Failed to renew push subscriptions for user {0}:<br>{1}").format(user, errors),
-				)
-		except Exception as e:
-			log_mail_error(
-				_("Push Subscription Renewal Failed"),
-				_("Failed to renew push subscriptions for user {0}: {1}").format(user, str(e)),
-			)
+            response = service.update([{"id": id} for id in expiring_ids])
+            if not_updated := response.get("notUpdated"):
+                errors = "<br>".join(f"{id}: {error['description']}" for id, error in not_updated.items())
+                log_mail_error(
+                    _("Push Subscription Renewal Failed"),
+                    _("Failed to renew push subscriptions for user {0}:<br>{1}").format(user, errors),
+                )
+        except Exception as e:
+            log_mail_error(
+                _("Push Subscription Renewal Failed"),
+                _("Failed to renew push subscriptions for user {0}: {1}").format(user, str(e)),
+            )
 
 
 @frappe.whitelist()
 def delete_push_subscriptions(user: str, ids: list[str]) -> None:
-	"""Deletes push subscriptions for the given user and list of subscription IDs."""
+    """Deletes push subscriptions for the given user and list of subscription IDs."""
 
-	has_permission_for_user(user, raise_exception=True)
+    has_permission_for_user(user, raise_exception=True)
 
-	service = get_push_subscription_service(user)
-	response = service.delete(ids)
+    service = get_push_subscription_service(user)
+    response = service.delete(ids)
 
-	if response.get("notDestroyed"):
-		error_messages = []
-		for id, error in response["notDestroyed"].items():
-			error_messages.append(f"{id}: {error['description']}")
-		frappe.throw(
-			_("Push Subscription Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
-			title=_("Push Subscription Deletion Error"),
-		)
+    if response.get("notDestroyed"):
+        error_messages = []
+        for id, error in response["notDestroyed"].items():
+            error_messages.append(f"{id}: {error['description']}")
+        frappe.throw(
+            _("Push Subscription Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
+            title=_("Push Subscription Deletion Error"),
+        )
 
 
 @frappe.whitelist()
 def fetch_push_subscriptions(user: str, page: int = 1, limit: int = 10) -> list:
-	"""Fetches push subscriptions for the given user with pagination."""
+    """Fetches push subscriptions for the given user with pagination."""
 
-	has_permission_for_user(user, raise_exception=True)
+    has_permission_for_user(user, raise_exception=True)
 
-	service = get_push_subscription_service(user)
-	subscriptions = service.get()
-	formatted_subscriptions = [format_push_subscription(user, sub) for sub in subscriptions]
-	frappe.cache.set_value(_get_total_cache_key(user), len(subscriptions), expires_in_sec=600)
+    service = get_push_subscription_service(user)
+    subscriptions = service.get()
+    formatted_subscriptions = [format_push_subscription(user, sub) for sub in subscriptions]
+    frappe.cache.set_value(_get_total_cache_key(user), len(subscriptions), expires_in_sec=600)
 
-	start = (page - 1) * limit
-	end = start + limit
+    start = (page - 1) * limit
+    end = start + limit
 
-	return formatted_subscriptions[start:end]
+    return formatted_subscriptions[start:end]
 
 
 def format_push_subscription(user: str, push_subscription: dict) -> dict:
-	"""Formats push subscription data for display."""
+    """Formats push subscription data for display."""
 
-	expires = parse_iso_datetime(push_subscription["expires"]) if push_subscription.get("expires") else None
-	types = push_subscription.get("types") or []
-	return {
-		"user": user,
-		"id": push_subscription["id"],
-		"name": f"{user}|{push_subscription['id']}",
-		"device_client_id": push_subscription["deviceClientId"],
-		"expires": expires,
-		"types": json.dumps(types, indent=4),
-		"creation": today(),
-		"modified": today(),
-	}
+    expires = parse_iso_datetime(push_subscription["expires"]) if push_subscription.get("expires") else None
+    types = push_subscription.get("types") or []
+    return {
+        "user": user,
+        "id": push_subscription["id"],
+        "name": f"{user}|{push_subscription['id']}",
+        "device_client_id": push_subscription["deviceClientId"],
+        "expires": expires,
+        "types": json.dumps(types, indent=4),
+        "creation": today(),
+        "modified": today(),
+    }
 
 
 def get_push_subscription_keys() -> dict | None:
-	"""Returns the JMAP push subscription encryption keys from Mail Settings, or None if encryption is disabled or the keys are not configured."""
+    """Returns the JMAP push subscription encryption keys from Mail Settings, or None if encryption is disabled or the keys are not configured."""
 
-	settings = frappe.get_cached_doc("Mail Settings")
-	if not settings.get("enable_jmap_push_encryption"):
-		return None
+    settings = frappe.get_cached_doc("Mail Settings")
+    if not settings.get("enable_jmap_push_encryption"):
+        return None
 
-	p256dh = (settings.get("jmap_push_p256dh") or "").strip()
-	auth = (settings.get_password("jmap_push_auth") if settings.get("jmap_push_auth") else "").strip()
+    p256dh = (settings.get("jmap_push_p256dh") or "").strip()
+    auth = (settings.get_password("jmap_push_auth") if settings.get("jmap_push_auth") else "").strip()
 
-	if p256dh and auth:
-		return {"p256dh": p256dh, "auth": auth}
+    if p256dh and auth:
+        return {"p256dh": p256dh, "auth": auth}
 
 
 def _decode_encrypted_push_body(raw_body: bytes) -> bytes:
-	"""Returns the raw aes128gcm ciphertext from a push request body."""
+    """Returns the raw aes128gcm ciphertext from a push request body."""
 
-	_B64URL_BYTES = frozenset(b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=")
+    _B64URL_BYTES = frozenset(b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=")
 
-	stripped = raw_body.strip()
-	if not stripped or any(byte not in _B64URL_BYTES for byte in stripped):
-		return raw_body
+    stripped = raw_body.strip()
+    if not stripped or any(byte not in _B64URL_BYTES for byte in stripped):
+        return raw_body
 
-	try:
-		return base64.urlsafe_b64decode(stripped + b"=" * (-len(stripped) % 4))
-	except Exception:
-		return raw_body
+    try:
+        return base64.urlsafe_b64decode(stripped + b"=" * (-len(stripped) % 4))
+    except Exception:
+        return raw_body
 
 
 def decrypt_jmap_push_payload(raw_body: bytes) -> dict:
-	"""Decrypts the JMAP push notification payload using the encryption keys from Mail Settings and returns the decrypted data as a dictionary."""
+    """Decrypts the JMAP push notification payload using the encryption keys from Mail Settings and returns the decrypted data as a dictionary."""
 
-	import struct
+    import struct
 
-	from cryptography.hazmat.primitives.asymmetric import ec
-	from cryptography.hazmat.primitives.asymmetric.ec import ECDH
-	from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-	from cryptography.hazmat.primitives.hashes import SHA256
-	from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-	from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives.asymmetric.ec import ECDH
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+    from cryptography.hazmat.primitives.hashes import SHA256
+    from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
-	def _b64decode(s: str) -> bytes:
-		s = s.strip()
-		return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+    def _b64decode(s: str) -> bytes:
+        s = s.strip()
+        return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
 
-	settings = frappe.get_cached_doc("Mail Settings")
+    settings = frappe.get_cached_doc("Mail Settings")
 
-	private_key_b64 = (
-		settings.get_password("jmap_push_private_key") if settings.get("jmap_push_private_key") else ""
-	).strip()
+    private_key_b64 = (
+        settings.get_password("jmap_push_private_key") if settings.get("jmap_push_private_key") else ""
+    ).strip()
 
-	auth_b64 = (settings.get_password("jmap_push_auth") if settings.get("jmap_push_auth") else "").strip()
+    auth_b64 = (settings.get_password("jmap_push_auth") if settings.get("jmap_push_auth") else "").strip()
 
-	if not private_key_b64 or not auth_b64:
-		frappe.throw(_("JMAP Push Subscription decryption keys are not configured in Mail Settings."))
+    if not private_key_b64 or not auth_b64:
+        frappe.throw(_("JMAP Push Subscription decryption keys are not configured in Mail Settings."))
 
-	try:
-		auth_bytes = _b64decode(auth_b64)
-		priv_bytes = _b64decode(private_key_b64)
-	except Exception:
-		frappe.throw(_("Invalid base64 encoding in JMAP push keys."))
+    try:
+        auth_bytes = _b64decode(auth_b64)
+        priv_bytes = _b64decode(private_key_b64)
+    except Exception:
+        frappe.throw(_("Invalid base64 encoding in JMAP push keys."))
 
-	if len(priv_bytes) != 32:
-		frappe.throw(_("Invalid JMAP push private key length (must be 32 bytes)."))
+    if len(priv_bytes) != 32:
+        frappe.throw(_("Invalid JMAP push private key length (must be 32 bytes)."))
 
-	try:
-		private_key = ec.derive_private_key(int.from_bytes(priv_bytes, "big"), ec.SECP256R1())
-	except Exception:
-		frappe.throw(_("Failed to construct EC private key."))
+    try:
+        private_key = ec.derive_private_key(int.from_bytes(priv_bytes, "big"), ec.SECP256R1())
+    except Exception:
+        frappe.throw(_("Failed to construct EC private key."))
 
-	raw_body = _decode_encrypted_push_body(raw_body)
+    raw_body = _decode_encrypted_push_body(raw_body)
 
-	if len(raw_body) < 21:
-		frappe.throw(_("Encrypted push payload is too short."))
+    if len(raw_body) < 21:
+        frappe.throw(_("Encrypted push payload is too short."))
 
-	salt = raw_body[:16]
-	rs = struct.unpack_from(">I", raw_body, 16)[0]
-	idlen = raw_body[20]
+    salt = raw_body[:16]
+    rs = struct.unpack_from(">I", raw_body, 16)[0]
+    idlen = raw_body[20]
 
-	if rs <= 0:
-		frappe.throw(_("Invalid record size in encrypted payload."))
+    if rs <= 0:
+        frappe.throw(_("Invalid record size in encrypted payload."))
 
-	if len(raw_body) < 21 + idlen:
-		frappe.throw(_("Malformed encrypted payload (invalid key length)."))
+    if len(raw_body) < 21 + idlen:
+        frappe.throw(_("Malformed encrypted payload (invalid key length)."))
 
-	sender_pub_bytes = raw_body[21 : 21 + idlen]
-	ciphertext_data = raw_body[21 + idlen :]
+    sender_pub_bytes = raw_body[21 : 21 + idlen]
+    ciphertext_data = raw_body[21 + idlen :]
 
-	if not ciphertext_data:
-		frappe.throw(_("Encrypted payload missing ciphertext data."))
+    if not ciphertext_data:
+        frappe.throw(_("Encrypted payload missing ciphertext data."))
 
-	try:
-		sender_pub = ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256R1(), sender_pub_bytes)
-	except Exception:
-		frappe.throw(_("Invalid sender public key in encrypted payload."))
+    try:
+        sender_pub = ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256R1(), sender_pub_bytes)
+    except Exception:
+        frappe.throw(_("Invalid sender public key in encrypted payload."))
 
-	try:
-		shared_secret = private_key.exchange(ECDH(), sender_pub)
-	except Exception:
-		frappe.throw(_("ECDH key exchange failed."))
+    try:
+        shared_secret = private_key.exchange(ECDH(), sender_pub)
+    except Exception:
+        frappe.throw(_("ECDH key exchange failed."))
 
-	receiver_pub_bytes = private_key.public_key().public_bytes(Encoding.X962, PublicFormat.UncompressedPoint)
+    receiver_pub_bytes = private_key.public_key().public_bytes(Encoding.X962, PublicFormat.UncompressedPoint)
 
-	auth_info = b"WebPush: info\x00" + receiver_pub_bytes + sender_pub_bytes
+    auth_info = b"WebPush: info\x00" + receiver_pub_bytes + sender_pub_bytes
 
-	try:
-		ikm = HKDF(
-			algorithm=SHA256(),
-			length=32,
-			salt=auth_bytes,
-			info=auth_info,
-		).derive(shared_secret)
+    try:
+        ikm = HKDF(
+            algorithm=SHA256(),
+            length=32,
+            salt=auth_bytes,
+            info=auth_info,
+        ).derive(shared_secret)
 
-		cek = HKDF(
-			algorithm=SHA256(),
-			length=16,
-			salt=salt,
-			info=b"Content-Encoding: aes128gcm\x00",
-		).derive(ikm)
+        cek = HKDF(
+            algorithm=SHA256(),
+            length=16,
+            salt=salt,
+            info=b"Content-Encoding: aes128gcm\x00",
+        ).derive(ikm)
 
-		nonce_base = HKDF(
-			algorithm=SHA256(),
-			length=12,
-			salt=salt,
-			info=b"Content-Encoding: nonce\x00",
-		).derive(ikm)
-	except Exception:
-		frappe.throw(_("Key derivation failed."))
+        nonce_base = HKDF(
+            algorithm=SHA256(),
+            length=12,
+            salt=salt,
+            info=b"Content-Encoding: nonce\x00",
+        ).derive(ikm)
+    except Exception:
+        frappe.throw(_("Key derivation failed."))
 
-	if len(nonce_base) != 12:
-		frappe.throw(_("Invalid nonce base length derived."))
+    if len(nonce_base) != 12:
+        frappe.throw(_("Invalid nonce base length derived."))
 
-	aesgcm = AESGCM(cek)
+    aesgcm = AESGCM(cek)
 
-	plaintext = bytearray()
-	seq = 0
-	pos = 0
+    plaintext = bytearray()
+    seq = 0
+    pos = 0
 
-	MAX_PLAINTEXT_SIZE = 1024 * 1024
+    MAX_PLAINTEXT_SIZE = 1024 * 1024
 
-	while pos < len(ciphertext_data):
-		record = ciphertext_data[pos : pos + rs]
-		pos += rs
+    while pos < len(ciphertext_data):
+        record = ciphertext_data[pos : pos + rs]
+        pos += rs
 
-		if not record:
-			break
+        if not record:
+            break
 
-		# Nonce = nonce_base XOR seq (12 bytes)
-		seq_bytes = seq.to_bytes(12, "big")
-		nonce = bytes(a ^ b for a, b in zip(nonce_base, seq_bytes, strict=False))
+        # Nonce = nonce_base XOR seq (12 bytes)
+        seq_bytes = seq.to_bytes(12, "big")
+        nonce = bytes(a ^ b for a, b in zip(nonce_base, seq_bytes, strict=False))
 
-		try:
-			decrypted = aesgcm.decrypt(nonce, record, None)
-		except Exception:
-			frappe.throw(_("Failed to decrypt push payload (authentication failed)."))
+        try:
+            decrypted = aesgcm.decrypt(nonce, record, None)
+        except Exception:
+            frappe.throw(_("Failed to decrypt push payload (authentication failed)."))
 
-		i = len(decrypted) - 1
-		while i >= 0 and decrypted[i] == 0x00:
-			i -= 1
+        i = len(decrypted) - 1
+        while i >= 0 and decrypted[i] == 0x00:
+            i -= 1
 
-		if i < 0:
-			frappe.throw(_("Invalid padding in decrypted record."))
+        if i < 0:
+            frappe.throw(_("Invalid padding in decrypted record."))
 
-		pad_delimiter = decrypted[i]
-		if pad_delimiter not in (0x01, 0x02):
-			frappe.throw(_("Invalid padding delimiter in decrypted record."))
+        pad_delimiter = decrypted[i]
+        if pad_delimiter not in (0x01, 0x02):
+            frappe.throw(_("Invalid padding delimiter in decrypted record."))
 
-		plaintext.extend(decrypted[:i])
+        plaintext.extend(decrypted[:i])
 
-		if len(plaintext) > MAX_PLAINTEXT_SIZE:
-			frappe.throw(_("Decrypted payload exceeds maximum allowed size."))
+        if len(plaintext) > MAX_PLAINTEXT_SIZE:
+            frappe.throw(_("Decrypted payload exceeds maximum allowed size."))
 
-		seq += 1
+        seq += 1
 
-	try:
-		return json.loads(bytes(plaintext))
-	except json.JSONDecodeError:
-		frappe.throw(_("Decrypted push payload is not valid JSON."))
+    try:
+        return json.loads(bytes(plaintext))
+    except json.JSONDecodeError:
+        frappe.throw(_("Decrypted push payload is not valid JSON."))
 
 
 def freeze_jmap_push_notifications(user: str) -> None:
-	"""Freezes JMAP push notifications for the given user."""
+    """Freezes JMAP push notifications for the given user."""
 
-	frappe.cache.hset("frozen_jmap_push_notifications", user, True)
+    frappe.cache.hset("frozen_jmap_push_notifications", user, True)
 
 
 def unfreeze_jmap_push_notifications(user: str) -> None:
-	"""Unfreezes JMAP push notifications for the given user."""
+    """Unfreezes JMAP push notifications for the given user."""
 
-	frappe.cache.hdel("frozen_jmap_push_notifications", user)
+    frappe.cache.hdel("frozen_jmap_push_notifications", user)
 
 
 def is_jmap_push_notifications_frozen(user: str) -> bool:
-	"""Returns True if JMAP push notifications are frozen for the given user."""
+    """Returns True if JMAP push notifications are frozen for the given user."""
 
-	return frappe.cache.hget("frozen_jmap_push_notifications", user) is True
+    return frappe.cache.hget("frozen_jmap_push_notifications", user) is True
 
 
 def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
-	if doc.doctype != "Push Subscription":
-		return False
+    if doc.doctype != "Push Subscription":
+        return False
 
-	return has_permission_for_user(doc.user, raise_exception=False)
+    return has_permission_for_user(doc.user, raise_exception=False)
 
 
 def has_permission_for_user(user: str, raise_exception: bool = True) -> bool:
-	"""Checks if the current session user has permission to manage push subscriptions for the given user."""
+    """Checks if the current session user has permission to manage push subscriptions for the given user."""
 
-	if user != frappe.session.user and not is_system_manager(frappe.session.user):
-		if raise_exception:
-			frappe.throw(
-				_("You do not have permission to add a push subscription for user {0}.").format(
-					frappe.bold(user)
-				),
-				frappe.PermissionError,
-			)
+    if user != frappe.session.user and not is_system_manager(frappe.session.user):
+        if raise_exception:
+            frappe.throw(
+                _("You do not have permission to add a push subscription for user {0}.").format(
+                    frappe.bold(user)
+                ),
+                frappe.PermissionError,
+            )
 
-		return False
+        return False
 
-	return True
+    return True

--- a/suite/mail/doctype/push_subscription/test_push_subscription.py
+++ b/suite/mail/doctype/push_subscription/test_push_subscription.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestPushSubscription(IntegrationTestCase):
-	"""
-	Integration tests for PushSubscription.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for PushSubscription.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/quota/quota.py
+++ b/suite/mail/doctype/quota/quota.py
@@ -14,144 +14,144 @@ from suite.utils import parse_filters
 
 
 class Quota(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		_name: DF.Data | None
-		account: DF.Link
-		description: DF.SmallText | None
-		hard_limit: DF.Int
-		id: DF.Data | None
-		resource_type: DF.Data | None
-		scope: DF.Data | None
-		soft_limit: DF.Int
-		types: DF.JSON | None
-		used: DF.Int
-		warn_limit: DF.Int
-	# end: auto-generated types
+        _name: DF.Data | None
+        account: DF.Link
+        description: DF.SmallText | None
+        hard_limit: DF.Int
+        id: DF.Data | None
+        resource_type: DF.Data | None
+        scope: DF.Data | None
+        soft_limit: DF.Int
+        types: DF.JSON | None
+        used: DF.Int
+        warn_limit: DF.Int
+    # end: auto-generated types
 
-	def db_insert(self, *args, **kwargs) -> None:
-		raise NotImplementedError
+    def db_insert(self, *args, **kwargs) -> None:
+        raise NotImplementedError
 
-	def load_from_db(self) -> "Quota":
-		account, id = parse_quota_name(self.name)
-		quota = get_quota(account, id)
-		return super(Document, self).__init__(quota)
+    def load_from_db(self) -> "Quota":
+        account, id = parse_quota_name(self.name)
+        quota = get_quota(account, id)
+        return super(Document, self).__init__(quota)
 
-	def db_update(self) -> None:
-		raise NotImplementedError
+    def db_update(self) -> None:
+        raise NotImplementedError
 
-	def delete(self) -> None:
-		raise NotImplementedError
+    def delete(self) -> None:
+        raise NotImplementedError
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs) -> list:
-		filters = parse_filters(filters)
-		id = filters.get("id")
-		account = filters.get("account")
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs) -> list:
+        filters = parse_filters(filters)
+        id = filters.get("id")
+        account = filters.get("account")
 
-		if not account:
-			frappe.msgprint(_("Please select an account to view quotas."), alert=True)
-			return []
+        if not account:
+            frappe.msgprint(_("Please select an account to view quotas."), alert=True)
+            return []
 
-		quotas = []
-		if id:
-			if quota := get_quota(account, id, raise_exception=False):
-				quotas.append(quota)
-		else:
-			quotas = fetch_quotas(account, limit=page_length)
+        quotas = []
+        if id:
+            if quota := get_quota(account, id, raise_exception=False):
+                quotas.append(quota)
+        else:
+            quotas = fetch_quotas(account, limit=page_length)
 
-		if not quotas:
-			frappe.msgprint(_("No quotas found."), alert=True)
+        if not quotas:
+            frappe.msgprint(_("No quotas found."), alert=True)
 
-		return quotas
+        return quotas
 
-	@staticmethod
-	def get_count(filters=None, **kwargs) -> int:
-		filters = parse_filters(filters)
-		account = filters.get("account")
+    @staticmethod
+    def get_count(filters=None, **kwargs) -> int:
+        filters = parse_filters(filters)
+        account = filters.get("account")
 
-		if account:
-			if get_user_for_jmap_account(account, raise_exception=False):
-				return cint(frappe.cache.get_value(_get_total_cache_key(account)))
+        if account:
+            if get_user_for_jmap_account(account, raise_exception=False):
+                return cint(frappe.cache.get_value(_get_total_cache_key(account)))
 
-		return 0
+        return 0
 
-	@staticmethod
-	def get_stats(**kwargs) -> dict:
-		return {}
+    @staticmethod
+    def get_stats(**kwargs) -> dict:
+        return {}
 
 
 def _get_total_cache_key(account: str) -> str:
-	"""Returns a cache key for total quota count for the given account."""
+    """Returns a cache key for total quota count for the given account."""
 
-	return f"{account}:quotas:total"
+    return f"{account}:quotas:total"
 
 
 def parse_quota_name(name: str) -> tuple[str, str]:
-	"""Splits a Quota name `account|id` into its bare `account` and `id`."""
+    """Splits a Quota name `account|id` into its bare `account` and `id`."""
 
-	account, id = name.split("|")
-	return account, id
+    account, id = name.split("|")
+    return account, id
 
 
 @frappe.whitelist()
 def get_quota(account: str, id: str, raise_exception: bool = True) -> dict | None:
-	"""Returns quota details for the given account and id."""
+    """Returns quota details for the given account and id."""
 
-	service = get_quota_service(account)
+    service = get_quota_service(account)
 
-	if quotas := service.get([id]):
-		return format_quota(account, quotas[0])
+    if quotas := service.get([id]):
+        return format_quota(account, quotas[0])
 
-	if raise_exception:
-		frappe.throw(
-			_("Quota with ID {0} not found in account {1}.").format(frappe.bold(id), frappe.bold(account)),
-			title=_("Quota Not Found"),
-		)
+    if raise_exception:
+        frappe.throw(
+            _("Quota with ID {0} not found in account {1}.").format(frappe.bold(id), frappe.bold(account)),
+            title=_("Quota Not Found"),
+        )
 
 
 @frappe.whitelist()
 def fetch_quotas(account: str, page: int = 1, limit: int = 10) -> list:
-	"""Returns a list of quotas for the given account."""
+    """Returns a list of quotas for the given account."""
 
-	service = get_quota_service(account)
-	quotas = service.get()
-	formatted_quotas = [format_quota(account, quota) for quota in quotas]
-	frappe.cache.set_value(_get_total_cache_key(account), len(quotas), expires_in_sec=600)
+    service = get_quota_service(account)
+    quotas = service.get()
+    formatted_quotas = [format_quota(account, quota) for quota in quotas]
+    frappe.cache.set_value(_get_total_cache_key(account), len(quotas), expires_in_sec=600)
 
-	start = (page - 1) * limit
-	end = start + limit
+    start = (page - 1) * limit
+    end = start + limit
 
-	return formatted_quotas[start:end]
+    return formatted_quotas[start:end]
 
 
 def format_quota(account: str, quota: dict) -> dict:
-	"""Formats quota data for display."""
+    """Formats quota data for display."""
 
-	return {
-		"name": f"{account}|{quota['id']}",
-		"account": account,
-		"id": quota["id"],
-		"_name": quota["name"],
-		"resource_type": quota["resourceType"],
-		"used": cint(quota["used"]),
-		"warn_limit": cint(quota["warnLimit"]),
-		"soft_limit": cint(quota["softLimit"]),
-		"hard_limit": cint(quota["hardLimit"]),
-		"scope": quota["scope"],
-		"description": quota["description"],
-		"types": json.dumps(quota.get("types", []), indent=4, sort_keys=True),
-	}
+    return {
+        "name": f"{account}|{quota['id']}",
+        "account": account,
+        "id": quota["id"],
+        "_name": quota["name"],
+        "resource_type": quota["resourceType"],
+        "used": cint(quota["used"]),
+        "warn_limit": cint(quota["warnLimit"]),
+        "soft_limit": cint(quota["softLimit"]),
+        "hard_limit": cint(quota["hardLimit"]),
+        "scope": quota["scope"],
+        "description": quota["description"],
+        "types": json.dumps(quota.get("types", []), indent=4, sort_keys=True),
+    }
 
 
 def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
-	if doc.doctype != "Quota":
-		return False
+    if doc.doctype != "Quota":
+        return False
 
-	return bool(get_user_for_jmap_account(doc.account, raise_exception=False))
+    return bool(get_user_for_jmap_account(doc.account, raise_exception=False))

--- a/suite/mail/doctype/quota/quota.py
+++ b/suite/mail/doctype/quota/quota.py
@@ -38,7 +38,7 @@ class Quota(Document):
     def db_insert(self, *args, **kwargs) -> None:
         raise NotImplementedError
 
-    def load_from_db(self) -> "Quota":
+    def load_from_db(self) -> Quota:
         account, id = parse_quota_name(self.name)
         quota = get_quota(account, id)
         return super(Document, self).__init__(quota)
@@ -150,7 +150,7 @@ def format_quota(account: str, quota: dict) -> dict:
     }
 
 
-def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
     if doc.doctype != "Quota":
         return False
 

--- a/suite/mail/doctype/quota/test_quota.py
+++ b/suite/mail/doctype/quota/test_quota.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestQuota(IntegrationTestCase):
-	"""
-	Integration tests for Quota.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for Quota.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/screened_email_address/screened_email_address.py
+++ b/suite/mail/doctype/screened_email_address/screened_email_address.py
@@ -16,201 +16,197 @@ SPAM = "Spam"  # file the incoming mail into the Spam (Junk) folder
 
 
 class ScreenedEmailAddress(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		account: DF.Link | None
-		action: DF.Literal["Spam", "Reject", "Accepted"]
-		email: DF.Data
-	# end: auto-generated types
+        account: DF.Link | None
+        action: DF.Literal["Spam", "Reject", "Accepted"]
+        email: DF.Data
+    # end: auto-generated types
 
-	def autoname(self) -> None:
-		self.name = str(uuid7())
+    def autoname(self) -> None:
+        self.name = str(uuid7())
 
-	def validate(self) -> None:
-		self.validate_global_rule_permission()
-		self.validate_email()
-		self.validate_duplicate_email()
+    def validate(self) -> None:
+        self.validate_global_rule_permission()
+        self.validate_email()
+        self.validate_duplicate_email()
 
-	def validate_global_rule_permission(self) -> None:
-		"""A rule without an account is global (applies to every account), so only admins may manage it."""
+    def validate_global_rule_permission(self) -> None:
+        """A rule without an account is global (applies to every account), so only admins may manage it."""
 
-		if self.account:
-			return
+        if self.account:
+            return
 
-		user = frappe.session.user
-		if not (is_system_manager(user) or is_suite_admin(user)):
-			frappe.throw(
-				_(
-					"Only a System Manager or Mail Admin can manage global screened email addresses (without an account)."
-				),
-				frappe.PermissionError,
-			)
+        user = frappe.session.user
+        if not (is_system_manager(user) or is_suite_admin(user)):
+            frappe.throw(
+                _(
+                    "Only a System Manager or Mail Admin can manage global screened email addresses (without an account)."
+                ),
+                frappe.PermissionError,
+            )
 
-	def validate_email(self) -> None:
-		"""Normalise and validate the screened value — a full email address or an '@domain' entry."""
+    def validate_email(self) -> None:
+        """Normalise and validate the screened value — a full email address or an '@domain' entry."""
 
-		from suite.mail.utils.validation import normalize_screened_value, validate_screened_value
+        from suite.mail.utils.validation import normalize_screened_value, validate_screened_value
 
-		self.email = normalize_screened_value(self.email)
-		validate_screened_value(self.email, raise_exception=True)
+        self.email = normalize_screened_value(self.email)
+        validate_screened_value(self.email, raise_exception=True)
 
-	def on_update(self) -> None:
-		from suite.mail.doctype.sieve_script.sieve_script import maybe_build_automation_sieve
+    def on_update(self) -> None:
+        from suite.mail.doctype.sieve_script.sieve_script import maybe_build_automation_sieve
 
-		# Global rules (no account) affect every account, so no single script can be rebuilt here.
-		# Rebuilds are deliberately not fanned out either — an admin batches their global changes and
-		# then triggers "Rebuild Automation Sieves" from the list view once.
-		if not self.account:
-			return
+        # Global rules (no account) affect every account, so no single script can be rebuilt here.
+        # Rebuilds are deliberately not fanned out either — an admin batches their global changes and
+        # then triggers "Rebuild Automation Sieves" from the list view once.
+        if not self.account:
+            return
 
-		# Runs on both insert and save. `email` is set_only_once, so on an edit only the action can
-		# change; regenerate on insert (no prior doc) and whenever the action is changed (e.g. switching
-		# Spam <-> Reject in Desk), since that moves the sender between sieve blocks. Skipped when a
-		# caller paused builds for a bulk write (it rebuilds once at the end instead).
-		if self.has_value_changed("action"):
-			# Activate the automation script so the screening rule takes effect (unless vacation is active).
-			maybe_build_automation_sieve(self.account, activate=True)
+        # Runs on both insert and save. `email` is set_only_once, so on an edit only the action can
+        # change; regenerate on insert (no prior doc) and whenever the action is changed (e.g. switching
+        # Spam <-> Reject in Desk), since that moves the sender between sieve blocks. Skipped when a
+        # caller paused builds for a bulk write (it rebuilds once at the end instead).
+        if self.has_value_changed("action"):
+            # Activate the automation script so the screening rule takes effect (unless vacation is active).
+            maybe_build_automation_sieve(self.account, activate=True)
 
-	def after_delete(self) -> None:
-		from suite.mail.doctype.sieve_script.sieve_script import maybe_build_automation_sieve
+    def after_delete(self) -> None:
+        from suite.mail.doctype.sieve_script.sieve_script import maybe_build_automation_sieve
 
-		# Removing a global rule does not rebuild anything either — see on_update.
-		if not self.account:
-			return
+        # Removing a global rule does not rebuild anything either — see on_update.
+        if not self.account:
+            return
 
-		maybe_build_automation_sieve(self.account, activate=True)
+        maybe_build_automation_sieve(self.account, activate=True)
 
-	def validate_duplicate_email(self) -> None:
-		"""Validates that the same email address is not screened more than once for the same account.
+    def validate_duplicate_email(self) -> None:
+        """Validates that the same email address is not screened more than once for the same account.
 
-		Global rules (no account) are checked against the other global rules. This validation is the
-		only duplicate guard for them: the unique index on (account, email) does not apply because
-		MariaDB allows multiple rows with a NULL in a unique key.
-		"""
+        Global rules (no account) are checked against the other global rules. This validation is the
+        only duplicate guard for them: the unique index on (account, email) does not apply because
+        MariaDB allows multiple rows with a NULL in a unique key.
+        """
 
-		account_filter = self.account or ("is", "not set")
-		if frappe.db.exists(
-			"Screened Email Address",
-			{"account": account_filter, "email": self.email, "name": ["!=", self.name]},
-		):
-			if self.account:
-				message = frappe._("The email address {0} is already screened for this account.")
-			else:
-				message = frappe._("The email address {0} is already screened globally.")
+        account_filter = self.account or ("is", "not set")
+        if frappe.db.exists(
+            "Screened Email Address",
+            {"account": account_filter, "email": self.email, "name": ["!=", self.name]},
+        ):
+            if self.account:
+                message = frappe._("The email address {0} is already screened for this account.")
+            else:
+                message = frappe._("The email address {0} is already screened globally.")
 
-			frappe.throw(message.format(self.email))
+            frappe.throw(message.format(self.email))
 
 
 def get_screened_email_addresses(account: str, action: str | None = None) -> list[dict]:
-	"""Returns the screened email addresses (with their action) for the given account.
+    """Returns the screened email addresses (with their action) for the given account.
 
-	Keyed on `account` so every user with access to a shared account sees the same list. Pass
-	`action` to restrict to a single action (e.g. only the Reject rules). `creation` and `modified`
-	are included so the settings UI can sort by when a rule was added or last changed (default order).
-	"""
+    Keyed on `account` so every user with access to a shared account sees the same list. Pass
+    `action` to restrict to a single action (e.g. only the Reject rules). `creation` and `modified`
+    are included so the settings UI can sort by when a rule was added or last changed (default order).
+    """
 
-	filters = {"account": account}
-	if action:
-		filters["action"] = action
+    filters = {"account": account}
+    if action:
+        filters["action"] = action
 
-	return frappe.db.get_all(
-		"Screened Email Address",
-		filters=filters,
-		fields=["email", "action", "creation", "modified"],
-		order_by="modified desc",
-	)
+    return frappe.db.get_all(
+        "Screened Email Address",
+        filters=filters,
+        fields=["email", "action", "creation", "modified"],
+        order_by="modified desc",
+    )
 
 
 def get_global_screened_email_addresses() -> list[dict]:
-	"""Returns the global screened email addresses — rules without an account, applying to every account."""
+    """Returns the global screened email addresses — rules without an account, applying to every account."""
 
-	return frappe.db.get_all(
-		"Screened Email Address",
-		filters={"account": ("is", "not set")},
-		fields=["email", "action", "creation", "modified"],
-		order_by="modified desc",
-	)
+    return frappe.db.get_all(
+        "Screened Email Address",
+        filters={"account": ("is", "not set")},
+        fields=["email", "action", "creation", "modified"],
+        order_by="modified desc",
+    )
 
 
 def get_global_accepted_values() -> set[str]:
-	"""Returns the values (lowercased) of the global Accepted rules — exact email addresses and
-	'@domain' entries (prefix kept) whose senders already reach every account's inbox."""
+    """Returns the values (lowercased) of the global Accepted rules — exact email addresses and
+    '@domain' entries (prefix kept) whose senders already reach every account's inbox."""
 
-	return {
-		row.email.lower()
-		for row in get_global_screened_email_addresses()
-		if row.action == "Accepted"
-	}
+    return {row.email.lower() for row in get_global_screened_email_addresses() if row.action == "Accepted"}
 
 
 def is_globally_accepted(email: str, accepted_values: set[str] | None = None) -> bool:
-	"""Whether the email is covered by a global Accepted rule — its exact address or its '@domain'.
+    """Whether the email is covered by a global Accepted rule — its exact address or its '@domain'.
 
-	Pass `accepted_values` (from `get_global_accepted_values`) when checking a batch, so the rules
-	are fetched once.
-	"""
+    Pass `accepted_values` (from `get_global_accepted_values`) when checking a batch, so the rules
+    are fetched once.
+    """
 
-	if accepted_values is None:
-		accepted_values = get_global_accepted_values()
+    if accepted_values is None:
+        accepted_values = get_global_accepted_values()
 
-	email = (email or "").lower()
-	return email in accepted_values or "@" + email.split("@")[-1] in accepted_values
+    email = (email or "").lower()
+    return email in accepted_values or "@" + email.split("@")[-1] in accepted_values
 
 
 def get_effective_screened_email_addresses(account: str) -> list[dict]:
-	"""Returns the screened email addresses in effect for the account: the global rules overlaid with
-	the account's own, where the account's rule wins when both screen the same email or domain.
+    """Returns the screened email addresses in effect for the account: the global rules overlaid with
+    the account's own, where the account's rule wins when both screen the same email or domain.
 
-	This is what the automation sieve script is built from — `get_screened_email_addresses` stays
-	account-only so the settings UI never shows (or lets a user edit) the admin-managed global rules.
-	Keyed case-insensitively to match the case-insensitive unique index on (account, email).
-	"""
+    This is what the automation sieve script is built from — `get_screened_email_addresses` stays
+    account-only so the settings UI never shows (or lets a user edit) the admin-managed global rules.
+    Keyed case-insensitively to match the case-insensitive unique index on (account, email).
+    """
 
-	merged = {row.email.lower(): row for row in get_global_screened_email_addresses()}
-	merged.update({row.email.lower(): row for row in get_screened_email_addresses(account)})
+    merged = {row.email.lower(): row for row in get_global_screened_email_addresses()}
+    merged.update({row.email.lower(): row for row in get_screened_email_addresses(account)})
 
-	return list(merged.values())
+    return list(merged.values())
 
 
 def get_permission_query_condition(user: str | None = None) -> str | None:
-	user = user or frappe.session.user
-	if is_system_manager(user) or is_suite_admin(user):
-		return ""
+    user = user or frappe.session.user
+    if is_system_manager(user) or is_suite_admin(user):
+        return ""
 
-	accounts = get_user_jmap_accounts(user)
-	if not accounts:
-		return "1=0"
+    accounts = get_user_jmap_accounts(user)
+    if not accounts:
+        return "1=0"
 
-	return f"""`tabScreened Email Address`.account in ({", ".join(frappe.db.escape(account) for account in accounts)})"""
+    return f"""`tabScreened Email Address`.account in ({", ".join(frappe.db.escape(account) for account in accounts)})"""
 
 
 def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
-	if doc.doctype != "Screened Email Address":
-		return False
+    if doc.doctype != "Screened Email Address":
+        return False
 
-	user = user or frappe.session.user
+    user = user or frappe.session.user
 
-	if is_system_manager(user) or is_suite_admin(user):
-		return True
+    if is_system_manager(user) or is_suite_admin(user):
+        return True
 
-	accounts = get_user_jmap_accounts(user)
-	if not accounts:
-		return False
+    accounts = get_user_jmap_accounts(user)
+    if not accounts:
+        return False
 
-	return doc.account in accounts
+    return doc.account in accounts
 
 
 def on_doctype_update() -> None:
-	# Screening list is shared per account, so uniqueness is on (account, email) — one rule
-	# per address regardless of action.
-	frappe.db.add_unique(
-		"Screened Email Address",
-		["account", "email"],
-		constraint_name="unique_account_screened_email",
-	)
+    # Screening list is shared per account, so uniqueness is on (account, email) — one rule
+    # per address regardless of action.
+    frappe.db.add_unique(
+        "Screened Email Address",
+        ["account", "email"],
+        constraint_name="unique_account_screened_email",
+    )

--- a/suite/mail/doctype/screened_email_address/test_screened_email_address.py
+++ b/suite/mail/doctype/screened_email_address/test_screened_email_address.py
@@ -14,98 +14,98 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestScreenedEmailAddress(IntegrationTestCase):
-	"""
-	Integration tests for ScreenedEmailAddress.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for ScreenedEmailAddress.
+    Use this class for testing interactions between multiple components.
+    """
 
-	def test_normalize_screened_value(self):
-		from suite.mail.utils.validation import normalize_screened_value
+    def test_normalize_screened_value(self):
+        from suite.mail.utils.validation import normalize_screened_value
 
-		# Trims whitespace and leaves a plain email address untouched.
-		self.assertEqual(normalize_screened_value("  john@example.com  "), "john@example.com")
-		# Lowercases the domain of a '@domain' entry so it collapses to a single rule.
-		self.assertEqual(normalize_screened_value("@Frappe.io"), "@frappe.io")
-		self.assertEqual(normalize_screened_value(" @Example.COM "), "@example.com")
+        # Trims whitespace and leaves a plain email address untouched.
+        self.assertEqual(normalize_screened_value("  john@example.com  "), "john@example.com")
+        # Lowercases the domain of a '@domain' entry so it collapses to a single rule.
+        self.assertEqual(normalize_screened_value("@Frappe.io"), "@frappe.io")
+        self.assertEqual(normalize_screened_value(" @Example.COM "), "@example.com")
 
-	def test_validate_screened_value(self):
-		from suite.mail.utils.validation import validate_screened_value
+    def test_validate_screened_value(self):
+        from suite.mail.utils.validation import validate_screened_value
 
-		# Valid: full email addresses and '@domain' entries.
-		self.assertTrue(validate_screened_value("john@example.com"))
-		self.assertTrue(validate_screened_value("@example.com"))
-		self.assertTrue(validate_screened_value("@sub.example.co.uk"))
+        # Valid: full email addresses and '@domain' entries.
+        self.assertTrue(validate_screened_value("john@example.com"))
+        self.assertTrue(validate_screened_value("@example.com"))
+        self.assertTrue(validate_screened_value("@sub.example.co.uk"))
 
-		# Invalid: bare domains, bare '@', local parts, and blanks.
-		self.assertFalse(validate_screened_value("example.com"))
-		self.assertFalse(validate_screened_value("@"))
-		self.assertFalse(validate_screened_value("@example"))
-		self.assertFalse(validate_screened_value("john"))
-		self.assertFalse(validate_screened_value(""))
+        # Invalid: bare domains, bare '@', local parts, and blanks.
+        self.assertFalse(validate_screened_value("example.com"))
+        self.assertFalse(validate_screened_value("@"))
+        self.assertFalse(validate_screened_value("@example"))
+        self.assertFalse(validate_screened_value("john"))
+        self.assertFalse(validate_screened_value(""))
 
-	def tearDown(self):
-		frappe.set_user("Administrator")
-		# Global rules (no account) are created without hooks firing any sieve rebuild, so a raw
-		# delete is enough to clean up.
-		frappe.db.delete("Screened Email Address", {"account": ("is", "not set")})
-		super().tearDown()
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        # Global rules (no account) are created without hooks firing any sieve rebuild, so a raw
+        # delete is enough to clean up.
+        frappe.db.delete("Screened Email Address", {"account": ("is", "not set")})
+        super().tearDown()
 
-	@staticmethod
-	def _insert_global_rule(email: str, action: str) -> None:
-		frappe.get_doc({"doctype": "Screened Email Address", "email": email, "action": action}).insert()
+    @staticmethod
+    def _insert_global_rule(email: str, action: str) -> None:
+        frappe.get_doc({"doctype": "Screened Email Address", "email": email, "action": action}).insert()
 
-	def test_effective_screened_email_addresses_merge(self):
-		from suite.mail.doctype.screened_email_address import screened_email_address as module
+    def test_effective_screened_email_addresses_merge(self):
+        from suite.mail.doctype.screened_email_address import screened_email_address as module
 
-		self._insert_global_rule("@trusted.com", "Accepted")
-		self._insert_global_rule("spammer@junk.com", "Reject")
+        self._insert_global_rule("@trusted.com", "Accepted")
+        self._insert_global_rule("spammer@junk.com", "Reject")
 
-		# The account screens one of the globally screened values itself — its action must win.
-		account_rows = [frappe._dict(email="@Trusted.com", action="Reject", creation=None, modified=None)]
-		with patch.object(module, "get_screened_email_addresses", return_value=account_rows):
-			effective = module.get_effective_screened_email_addresses("dummy-account")
+        # The account screens one of the globally screened values itself — its action must win.
+        account_rows = [frappe._dict(email="@Trusted.com", action="Reject", creation=None, modified=None)]
+        with patch.object(module, "get_screened_email_addresses", return_value=account_rows):
+            effective = module.get_effective_screened_email_addresses("dummy-account")
 
-		actions = {row.email.lower(): row.action for row in effective}
-		self.assertEqual(len(effective), 2)
-		self.assertEqual(actions["@trusted.com"], "Reject")
-		self.assertEqual(actions["spammer@junk.com"], "Reject")
+        actions = {row.email.lower(): row.action for row in effective}
+        self.assertEqual(len(effective), 2)
+        self.assertEqual(actions["@trusted.com"], "Reject")
+        self.assertEqual(actions["spammer@junk.com"], "Reject")
 
-	def test_is_globally_accepted(self):
-		from suite.mail.doctype.screened_email_address.screened_email_address import (
-			get_global_accepted_values,
-			is_globally_accepted,
-		)
+    def test_is_globally_accepted(self):
+        from suite.mail.doctype.screened_email_address.screened_email_address import (
+            get_global_accepted_values,
+            is_globally_accepted,
+        )
 
-		self._insert_global_rule("@Trusted.com", "Accepted")
-		self._insert_global_rule("@blocked.com", "Reject")
-		self._insert_global_rule("someone@accepted.com", "Accepted")
+        self._insert_global_rule("@Trusted.com", "Accepted")
+        self._insert_global_rule("@blocked.com", "Reject")
+        self._insert_global_rule("someone@accepted.com", "Accepted")
 
-		# Only Accepted rules count (Reject domains don't), lowercased with the '@' prefix kept.
-		self.assertEqual(get_global_accepted_values(), {"@trusted.com", "someone@accepted.com"})
+        # Only Accepted rules count (Reject domains don't), lowercased with the '@' prefix kept.
+        self.assertEqual(get_global_accepted_values(), {"@trusted.com", "someone@accepted.com"})
 
-		# Covered: by domain rule (case-insensitively) or by exact address.
-		self.assertTrue(is_globally_accepted("anyone@trusted.com"))
-		self.assertTrue(is_globally_accepted("Anyone@Trusted.COM"))
-		self.assertTrue(is_globally_accepted("Someone@accepted.com"))
+        # Covered: by domain rule (case-insensitively) or by exact address.
+        self.assertTrue(is_globally_accepted("anyone@trusted.com"))
+        self.assertTrue(is_globally_accepted("Anyone@Trusted.COM"))
+        self.assertTrue(is_globally_accepted("Someone@accepted.com"))
 
-		# Not covered: other senders from a domain with only an exact-address rule, or from a
-		# domain screened with Reject.
-		self.assertFalse(is_globally_accepted("other@accepted.com"))
-		self.assertFalse(is_globally_accepted("anyone@blocked.com"))
+        # Not covered: other senders from a domain with only an exact-address rule, or from a
+        # domain screened with Reject.
+        self.assertFalse(is_globally_accepted("other@accepted.com"))
+        self.assertFalse(is_globally_accepted("anyone@blocked.com"))
 
-	def test_duplicate_global_screened_email(self):
-		self._insert_global_rule("dup@example.com", "Reject")
+    def test_duplicate_global_screened_email(self):
+        self._insert_global_rule("dup@example.com", "Reject")
 
-		with self.assertRaises(frappe.ValidationError):
-			self._insert_global_rule("dup@example.com", "Spam")
+        with self.assertRaises(frappe.ValidationError):
+            self._insert_global_rule("dup@example.com", "Spam")
 
-	def test_global_rule_requires_system_manager(self):
-		frappe.set_user("Guest")
+    def test_global_rule_requires_system_manager(self):
+        frappe.set_user("Guest")
 
-		doc = frappe.get_doc(
-			{"doctype": "Screened Email Address", "email": "global@example.com", "action": "Reject"}
-		)
-		# ignore_permissions bypasses the doctype-level create check, so this exercises the
-		# global-rule guard in validate() specifically.
-		with self.assertRaises(frappe.PermissionError):
-			doc.insert(ignore_permissions=True)
+        doc = frappe.get_doc(
+            {"doctype": "Screened Email Address", "email": "global@example.com", "action": "Reject"}
+        )
+        # ignore_permissions bypasses the doctype-level create check, so this exercises the
+        # global-rule guard in validate() specifically.
+        with self.assertRaises(frappe.PermissionError):
+            doc.insert(ignore_permissions=True)

--- a/suite/mail/doctype/server_ansible_play/server_ansible_play.py
+++ b/suite/mail/doctype/server_ansible_play/server_ansible_play.py
@@ -15,192 +15,192 @@ from suite.mail.utils import get_config
 
 
 class ServerAnsiblePlay(Document):
-	def autoname(self) -> None:
-		self.name = str(uuid7())
+    def autoname(self) -> None:
+        self.name = str(uuid7())
 
-	def validate(self) -> None:
-		self.validate_status()
-		self.validate_server()
-		self.validate_playbook()
+    def validate(self) -> None:
+        self.validate_status()
+        self.validate_server()
+        self.validate_playbook()
 
-	def after_insert(self) -> None:
-		if frappe.flags.do_not_enqueue:
-			self.execute()
-		else:
-			frappe.enqueue_doc(
-				self.doctype,
-				self.name,
-				"execute",
-				queue="long",
-				timeout=cint(get_config("ansible_play_timeout")),
-				enqueue_after_commit=True,
-			)
+    def after_insert(self) -> None:
+        if frappe.flags.do_not_enqueue:
+            self.execute()
+        else:
+            frappe.enqueue_doc(
+                self.doctype,
+                self.name,
+                "execute",
+                queue="long",
+                timeout=cint(get_config("ansible_play_timeout")),
+                enqueue_after_commit=True,
+            )
 
-	def validate_status(self) -> None:
-		"""Sets the status to 'Pending' if not set."""
+    def validate_status(self) -> None:
+        """Sets the status to 'Pending' if not set."""
 
-		if not self.status:
-			self.status = "Pending"
+        if not self.status:
+            self.status = "Pending"
 
-	def validate_server(self) -> None:
-		"""Validate if the mail server is enabled."""
+    def validate_server(self) -> None:
+        """Validate if the mail server is enabled."""
 
-		if not frappe.db.get_value("Mail Server", self.server, "enabled"):
-			frappe.throw(_("Mail Server {0} is disabled").format(self.server))
-		elif not frappe.db.get_value("Mail Server", self.server, "ssh_verified"):
-			frappe.throw(_("Please verify SSH connection for Mail Server {0}").format(self.server))
+        if not frappe.db.get_value("Mail Server", self.server, "enabled"):
+            frappe.throw(_("Mail Server {0} is disabled").format(self.server))
+        elif not frappe.db.get_value("Mail Server", self.server, "ssh_verified"):
+            frappe.throw(_("Please verify SSH connection for Mail Server {0}").format(self.server))
 
-	def validate_playbook(self) -> None:
-		"""Validate if the playbook path is valid."""
+    def validate_playbook(self) -> None:
+        """Validate if the playbook path is valid."""
 
-		if not self.playbook:
-			frappe.throw(_("Playbook is required"))
-		elif not os.path.isfile(self._get_playbook_path()):
-			frappe.throw(_("Playbook {0} does not exist.").format(self.playbook))
+        if not self.playbook:
+            frappe.throw(_("Playbook is required"))
+        elif not os.path.isfile(self._get_playbook_path()):
+            frappe.throw(_("Playbook {0} does not exist.").format(self.playbook))
 
-	def execute(self) -> None:
-		"""Executes the Ansible playbook."""
+    def execute(self) -> None:
+        """Executes the Ansible playbook."""
 
-		if self.status == "Running":
-			frappe.throw(_("Ansible play is already running."))
+        if self.status == "Running":
+            frappe.throw(_("Ansible play is already running."))
 
-		try:
-			self.validate_server()
-			ansible = Ansible.from_play(self.name)
-			ansible._create_task_records()
-			ansible.run()
+        try:
+            self.validate_server()
+            ansible = Ansible.from_play(self.name)
+            ansible._create_task_records()
+            ansible.run()
 
-			self.reload()
-			if self.status == "Failed":
-				self._db_set(retries=cint(self.retries) + 1, notify=True)
+            self.reload()
+            if self.status == "Failed":
+                self._db_set(retries=cint(self.retries) + 1, notify=True)
 
-		except Exception:
-			error_log = frappe.get_traceback(with_context=True)
-			kwargs = {
-				"status": "Failed",
-				"retries": cint(self.retries) + 1,
-				"error_log": error_log,
-			}
+        except Exception:
+            error_log = frappe.get_traceback(with_context=True)
+            kwargs = {
+                "status": "Failed",
+                "retries": cint(self.retries) + 1,
+                "error_log": error_log,
+            }
 
-			if self.started_at:
-				ended_at = now()
-				kwargs.update(
-					{
-						"ended_at": ended_at,
-						"duration": time_diff_in_seconds(ended_at, self.started_at),
-					}
-				)
+            if self.started_at:
+                ended_at = now()
+                kwargs.update(
+                    {
+                        "ended_at": ended_at,
+                        "duration": time_diff_in_seconds(ended_at, self.started_at),
+                    }
+                )
 
-			self._db_set(notify=True, **kwargs)
-			self._mark_pending_tasks_as_failed(error_log)
+            self._db_set(notify=True, **kwargs)
+            self._mark_pending_tasks_as_failed(error_log)
 
-	@frappe.whitelist()
-	def retry(self) -> None:
-		"""Retries a failed ansible play."""
+    @frappe.whitelist()
+    def retry(self) -> None:
+        """Retries a failed ansible play."""
 
-		frappe.only_for("System Manager")
+        frappe.only_for("System Manager")
 
-		if self.status != "Failed":
-			frappe.throw(_("Only failed ansible plays can be retried."))
+        if self.status != "Failed":
+            frappe.throw(_("Only failed ansible plays can be retried."))
 
-		kwargs = {
-			"status": "Pending",
-			"started_at": None,
-			"started_after": 0,
-			"ended_at": None,
-			"duration": 0,
-			"ok": 0,
-			"changed": 0,
-			"failures": 0,
-			"unreachable": 0,
-			"skipped": 0,
-			"rescued": 0,
-			"ignored": 0,
-			"processed": 0,
-			"error_log": None,
-		}
-		self._db_set(notify=True, **kwargs)
+        kwargs = {
+            "status": "Pending",
+            "started_at": None,
+            "started_after": 0,
+            "ended_at": None,
+            "duration": 0,
+            "ok": 0,
+            "changed": 0,
+            "failures": 0,
+            "unreachable": 0,
+            "skipped": 0,
+            "rescued": 0,
+            "ignored": 0,
+            "processed": 0,
+            "error_log": None,
+        }
+        self._db_set(notify=True, **kwargs)
 
-		frappe.db.set_value(
-			"Server Ansible Play Task",
-			{"play": self.name},
-			{
-				"status": "Pending",
-				"started_at": None,
-				"ended_at": None,
-				"duration": 0,
-				"stdout": None,
-				"stderr": None,
-				"exception": None,
-				"result": None,
-			},
-		)
+        frappe.db.set_value(
+            "Server Ansible Play Task",
+            {"play": self.name},
+            {
+                "status": "Pending",
+                "started_at": None,
+                "ended_at": None,
+                "duration": 0,
+                "stdout": None,
+                "stderr": None,
+                "exception": None,
+                "result": None,
+            },
+        )
 
-		frappe.enqueue_doc(
-			self.doctype,
-			self.name,
-			"execute",
-			queue="long",
-			timeout=cint(get_config("ansible_play_timeout")),
-			enqueue_after_commit=True,
-		)
+        frappe.enqueue_doc(
+            self.doctype,
+            self.name,
+            "execute",
+            queue="long",
+            timeout=cint(get_config("ansible_play_timeout")),
+            enqueue_after_commit=True,
+        )
 
-	def _get_playbook_path(self) -> str:
-		"""Returns the absolute path of the playbook."""
+    def _get_playbook_path(self) -> str:
+        """Returns the absolute path of the playbook."""
 
-		return os.path.join(
-			frappe.get_app_path("suite", "mail", "utils", "ansible", "playbooks"), self.playbook
-		)
+        return os.path.join(
+            frappe.get_app_path("suite", "mail", "utils", "ansible", "playbooks"), self.playbook
+        )
 
-	def _db_set(
-		self,
-		update_modified: bool = True,
-		commit: bool = False,
-		notify: bool = False,
-		**kwargs,
-	) -> None:
-		"""Updates the document with the given key-value pairs."""
+    def _db_set(
+        self,
+        update_modified: bool = True,
+        commit: bool = False,
+        notify: bool = False,
+        **kwargs,
+    ) -> None:
+        """Updates the document with the given key-value pairs."""
 
-		self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
+        self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
 
-	def _mark_pending_tasks_as_failed(self, error_log: str) -> None:
-		"""Marks unresolved task rows as failed when play-level execution aborts."""
+    def _mark_pending_tasks_as_failed(self, error_log: str) -> None:
+        """Marks unresolved task rows as failed when play-level execution aborts."""
 
-		for task in frappe.get_all(
-			"Server Ansible Play Task",
-			filters={"play": self.name, "status": ["in", ["Pending", "Running"]]},
-			fields=["name", "started_at"],
-		):
-			ended_at = now()
-			started_at = task.started_at or ended_at
-			frappe.db.set_value(
-				"Server Ansible Play Task",
-				task.name,
-				{
-					"status": "Failed",
-					"started_at": started_at,
-					"ended_at": ended_at,
-					"duration": time_diff_in_seconds(ended_at, started_at),
-					"exception": error_log,
-				},
-				update_modified=True,
-			)
+        for task in frappe.get_all(
+            "Server Ansible Play Task",
+            filters={"play": self.name, "status": ["in", ["Pending", "Running"]]},
+            fields=["name", "started_at"],
+        ):
+            ended_at = now()
+            started_at = task.started_at or ended_at
+            frappe.db.set_value(
+                "Server Ansible Play Task",
+                task.name,
+                {
+                    "status": "Failed",
+                    "started_at": started_at,
+                    "ended_at": ended_at,
+                    "duration": time_diff_in_seconds(ended_at, started_at),
+                    "exception": error_log,
+                },
+                update_modified=True,
+            )
 
 
 def retry_failed_ansible_plays() -> None:
-	"""Called by the scheduler to retry failed ansible plays."""
+    """Called by the scheduler to retry failed ansible plays."""
 
-	PLAY = frappe.qb.DocType("Server Ansible Play")
-	plays = (
-		frappe.qb.from_(PLAY)
-		.select(PLAY.name)
-		.where((PLAY.status == "Failed") & (PLAY.retries > 0) & (PLAY.retries < PLAY.max_retries))
-		.orderby(PLAY.creation, order=Order.asc)
-	).run(pluck="name")
+    PLAY = frappe.qb.DocType("Server Ansible Play")
+    plays = (
+        frappe.qb.from_(PLAY)
+        .select(PLAY.name)
+        .where((PLAY.status == "Failed") & (PLAY.retries > 0) & (PLAY.retries < PLAY.max_retries))
+        .orderby(PLAY.creation, order=Order.asc)
+    ).run(pluck="name")
 
-	if not plays:
-		return
+    if not plays:
+        return
 
-	for play in plays:
-		doc = frappe.get_doc("Server Ansible Play", play)
-		doc.retry()
+    for play in plays:
+        doc = frappe.get_doc("Server Ansible Play", play)
+        doc.retry()

--- a/suite/mail/doctype/server_ansible_play/test_server_ansible_play.py
+++ b/suite/mail/doctype/server_ansible_play/test_server_ansible_play.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestServerAnsiblePlay(IntegrationTestCase):
-	"""
-	Integration tests for ServerAnsiblePlay.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for ServerAnsiblePlay.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/server_ansible_play_task/server_ansible_play_task.py
+++ b/suite/mail/doctype/server_ansible_play_task/server_ansible_play_task.py
@@ -9,34 +9,34 @@ from frappe.model.document import Document
 
 
 class ServerAnsiblePlayTask(Document):
-	def autoname(self) -> None:
-		self.name = str(uuid7())
+    def autoname(self) -> None:
+        self.name = str(uuid7())
 
-	def validate(self) -> None:
-		self.validate_unique_task()
+    def validate(self) -> None:
+        self.validate_unique_task()
 
-	def validate_unique_task(self) -> None:
-		"""Validates that the task is unique within the play."""
+    def validate_unique_task(self) -> None:
+        """Validates that the task is unique within the play."""
 
-		if frappe.db.exists(
-			"Server Ansible Play Task", {"play": self.play, "task": self.task, "name": ["!=", self.name]}
-		):
-			frappe.throw(
-				_("Task {0} already exists in play {1}").format(self.task, self.play),
-				frappe.DuplicateEntryError,
-			)
+        if frappe.db.exists(
+            "Server Ansible Play Task", {"play": self.play, "task": self.task, "name": ["!=", self.name]}
+        ):
+            frappe.throw(
+                _("Task {0} already exists in play {1}").format(self.task, self.play),
+                frappe.DuplicateEntryError,
+            )
 
-	def _db_set(
-		self,
-		update_modified: bool = True,
-		commit: bool = False,
-		notify: bool = False,
-		**kwargs,
-	) -> None:
-		"""Updates the document with the given key-value pairs."""
+    def _db_set(
+        self,
+        update_modified: bool = True,
+        commit: bool = False,
+        notify: bool = False,
+        **kwargs,
+    ) -> None:
+        """Updates the document with the given key-value pairs."""
 
-		self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
+        self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
 
 
 def on_doctype_update() -> None:
-	frappe.db.add_unique("Server Ansible Play Task", ["play", "task"])
+    frappe.db.add_unique("Server Ansible Play Task", ["play", "task"])

--- a/suite/mail/doctype/server_ansible_play_task/test_server_ansible_play_task.py
+++ b/suite/mail/doctype/server_ansible_play_task/test_server_ansible_play_task.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestServerAnsiblePlayTask(IntegrationTestCase):
-	"""
-	Integration tests for ServerAnsiblePlayTask.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for ServerAnsiblePlayTask.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/server_ansible_play_variable/server_ansible_play_variable.py
+++ b/suite/mail/doctype/server_ansible_play_variable/server_ansible_play_variable.py
@@ -6,4 +6,4 @@ from frappe.model.document import Document
 
 
 class ServerAnsiblePlayVariable(Document):
-	pass
+    pass

--- a/suite/mail/doctype/server_deployment/server_deployment.py
+++ b/suite/mail/doctype/server_deployment/server_deployment.py
@@ -15,290 +15,294 @@ from suite.mail.utils import get_config, get_stalwart_cli_version, get_stalwart_
 
 
 class ServerDeployment(Document):
-	@property
-	def docker_compose(self) -> str | None:
-		"""Returns the docker-compose.yml content."""
+    @property
+    def docker_compose(self) -> str | None:
+        """Returns the docker-compose.yml content."""
 
-		if self.services:
-			docker_compose = "services:\n"
-			for service in self.services:
-				docker_compose += f"  {service.service}:\n"
-				docker_compose += f"    image: {service.image}\n"
-				docker_compose += f"    container_name: {service.container}\n"
-				docker_compose += f"    restart: {service.restart}\n"
-				docker_compose += f"    network_mode: {service.network_mode}\n"
+        if self.services:
+            docker_compose = "services:\n"
+            for service in self.services:
+                docker_compose += f"  {service.service}:\n"
+                docker_compose += f"    image: {service.image}\n"
+                docker_compose += f"    container_name: {service.container}\n"
+                docker_compose += f"    restart: {service.restart}\n"
+                docker_compose += f"    network_mode: {service.network_mode}\n"
 
-				if service.service == "stalwart":
-					docker_compose += "    env_file:\n"
-					docker_compose += "      - ./stalwart.env\n"
+                if service.service == "stalwart":
+                    docker_compose += "    env_file:\n"
+                    docker_compose += "      - ./stalwart.env\n"
 
-				depends_on = json.loads(service.depends_on) if service.depends_on else []
-				if depends_on:
-					docker_compose += "    depends_on:\n"
-					for dependency in depends_on:
-						docker_compose += f"      - {dependency}\n"
+                depends_on = json.loads(service.depends_on) if service.depends_on else []
+                if depends_on:
+                    docker_compose += "    depends_on:\n"
+                    for dependency in depends_on:
+                        docker_compose += f"      - {dependency}\n"
 
-				ports = json.loads(service.ports) if service.ports else []
-				if ports:
-					docker_compose += "    ports:\n"
-					for port in ports:
-						docker_compose += f'      - "{port}"\n'
+                ports = json.loads(service.ports) if service.ports else []
+                if ports:
+                    docker_compose += "    ports:\n"
+                    for port in ports:
+                        docker_compose += f'      - "{port}"\n'
 
-				volumes = json.loads(service.volumes) if service.volumes else []
-				if volumes:
-					docker_compose += "    volumes:\n"
-					for volume in volumes:
-						docker_compose += f"      - {volume}\n"
+                volumes = json.loads(service.volumes) if service.volumes else []
+                if volumes:
+                    docker_compose += "    volumes:\n"
+                    for volume in volumes:
+                        docker_compose += f"      - {volume}\n"
 
-			return docker_compose
+            return docker_compose
 
-	def autoname(self) -> None:
-		self.name = str(uuid7())
+    def autoname(self) -> None:
+        self.name = str(uuid7())
 
-	def validate(self) -> None:
-		self.validate_status()
-		self.validate_server()
-		self.validate_services()
+    def validate(self) -> None:
+        self.validate_status()
+        self.validate_server()
+        self.validate_services()
 
-	def after_insert(self) -> None:
-		if frappe.flags.do_not_enqueue:
-			self.execute()
-		else:
-			frappe.enqueue_doc(
-				self.doctype,
-				self.name,
-				"execute",
-				queue="long",
-				timeout=cint(get_config("server_deployment_timeout")),
-				enqueue_after_commit=True,
-			)
+    def after_insert(self) -> None:
+        if frappe.flags.do_not_enqueue:
+            self.execute()
+        else:
+            frappe.enqueue_doc(
+                self.doctype,
+                self.name,
+                "execute",
+                queue="long",
+                timeout=cint(get_config("server_deployment_timeout")),
+                enqueue_after_commit=True,
+            )
 
-	def validate_status(self) -> None:
-		"""Sets the status to 'Pending' if not set."""
+    def validate_status(self) -> None:
+        """Sets the status to 'Pending' if not set."""
 
-		if not self.status:
-			self.status = "Pending"
+        if not self.status:
+            self.status = "Pending"
 
-	def validate_server(self) -> None:
-		"""Validate if the mail server is enabled."""
+    def validate_server(self) -> None:
+        """Validate if the mail server is enabled."""
 
-		if not frappe.db.get_value("Mail Server", self.server, "enabled"):
-			frappe.throw(_("Mail Server {0} is disabled").format(self.server))
-		elif not frappe.db.get_value("Mail Server", self.server, "ssh_verified"):
-			frappe.throw(_("Please verify SSH connection for Mail Server {0}").format(self.server))
+        if not frappe.db.get_value("Mail Server", self.server, "enabled"):
+            frappe.throw(_("Mail Server {0} is disabled").format(self.server))
+        elif not frappe.db.get_value("Mail Server", self.server, "ssh_verified"):
+            frappe.throw(_("Please verify SSH connection for Mail Server {0}").format(self.server))
 
-	def validate_services(self) -> None:
-		"""Validates and prepares the services for deployment."""
+    def validate_services(self) -> None:
+        """Validates and prepares the services for deployment."""
 
-		server_hostname = frappe.db.get_value("Mail Server", self.server, "hostname")
-		services = {
-			"stalwart": {
-				"image": f"stalwartlabs/stalwart:{get_stalwart_version()}",
-				"container": f"stalwart_{server_hostname}",
-				"restart": "unless-stopped",
-				"network_mode": "host",
-				"depends_on": json.dumps([], indent=4),
-				"ports": json.dumps([], indent=4),
-				"volumes": json.dumps(["{{ stalwart_root }}:/etc/stalwart"], indent=4),
-			}
-		}
+        server_hostname = frappe.db.get_value("Mail Server", self.server, "hostname")
+        services = {
+            "stalwart": {
+                "image": f"stalwartlabs/stalwart:{get_stalwart_version()}",
+                "container": f"stalwart_{server_hostname}",
+                "restart": "unless-stopped",
+                "network_mode": "host",
+                "depends_on": json.dumps([], indent=4),
+                "ports": json.dumps([], indent=4),
+                "volumes": json.dumps(["{{ stalwart_root }}:/etc/stalwart"], indent=4),
+            }
+        }
 
-		for service in self.services:
-			services[service.service] = {
-				"image": service.image,
-				"container": service.container,
-				"restart": service.restart,
-				"network_mode": service.network_mode,
-				"depends_on": json.dumps(
-					json.loads(service.depends_on) if service.depends_on else [], indent=4
-				),
-				"ports": json.dumps(json.loads(service.ports) if service.ports else [], indent=4),
-				"volumes": json.dumps(json.loads(service.volumes) if service.volumes else [], indent=4),
-			}
+        for service in self.services:
+            services[service.service] = {
+                "image": service.image,
+                "container": service.container,
+                "restart": service.restart,
+                "network_mode": service.network_mode,
+                "depends_on": json.dumps(
+                    json.loads(service.depends_on) if service.depends_on else [], indent=4
+                ),
+                "ports": json.dumps(json.loads(service.ports) if service.ports else [], indent=4),
+                "volumes": json.dumps(json.loads(service.volumes) if service.volumes else [], indent=4),
+            }
 
-		self.services = []
-		for name, service in services.items():
-			service["service"] = name
-			self.append("services", service)
+        self.services = []
+        for name, service in services.items():
+            service["service"] = name
+            self.append("services", service)
 
-	def execute(self) -> None:
-		"""Executes the deployment."""
+    def execute(self) -> None:
+        """Executes the deployment."""
 
-		kwargs = {}
-		started_at = now()
-		self._db_set(
-			status="Running",
-			started_at=started_at,
-			started_after=time_diff_in_seconds(started_at, self.creation),
-			error_log=None,
-			commit=True,
-			notify=True,
-		)
+        kwargs = {}
+        started_at = now()
+        self._db_set(
+            status="Running",
+            started_at=started_at,
+            started_after=time_diff_in_seconds(started_at, self.creation),
+            error_log=None,
+            commit=True,
+            notify=True,
+        )
 
-		try:
-			self.validate_server()
-			server = frappe.get_doc("Mail Server", self.server)
-			cluster = frappe.get_doc("Mail Cluster", server.cluster)
+        try:
+            self.validate_server()
+            server = frappe.get_doc("Mail Server", self.server)
+            cluster = frappe.get_doc("Mail Cluster", server.cluster)
 
-			variables = {
-				"server_hostname": server.hostname,
-				"stalwart_env": server._get_stalwart_env(recovery_mode=False, as_dict=False),
-				"stalwart_bootstrap_plan": server.bootstrap_ndjson,
-				"stalwart_cli_version": get_stalwart_cli_version(),
-				"recovery_admin_user": cluster.recovery_admin_user,
-				"recovery_admin_password": cluster.get_password("recovery_admin_password"),
-				"docker_compose": self.docker_compose,
-			}
-			play = frappe.new_doc("Server Ansible Play")
-			play.status = "Pending"
-			play.server = self.server
-			play.deployment = self.name
-			play.max_retries = 0
-			play.play = "Deploy Mail Server"
-			play.playbook = "deploy-mail-server.yml"
+            variables = {
+                "server_hostname": server.hostname,
+                "stalwart_env": server._get_stalwart_env(recovery_mode=False, as_dict=False),
+                "stalwart_bootstrap_plan": server.bootstrap_ndjson,
+                "stalwart_cli_version": get_stalwart_cli_version(),
+                "recovery_admin_user": cluster.recovery_admin_user,
+                "recovery_admin_password": cluster.get_password("recovery_admin_password"),
+                "docker_compose": self.docker_compose,
+            }
+            play = frappe.new_doc("Server Ansible Play")
+            play.status = "Pending"
+            play.server = self.server
+            play.deployment = self.name
+            play.max_retries = 0
+            play.play = "Deploy Mail Server"
+            play.playbook = "deploy-mail-server.yml"
 
-			for key, value in variables.items():
-				if isinstance(value, int | bool):
-					value = str(value)
-				elif isinstance(value, list | dict):
-					value = json.dumps(value, indent=4)
+            for key, value in variables.items():
+                if isinstance(value, int | bool):
+                    value = str(value)
+                elif isinstance(value, list | dict):
+                    value = json.dumps(value, indent=4)
 
-				play.append("variables", {"key_": key, "value": value})
+                play.append("variables", {"key_": key, "value": value})
 
-			frappe.flags.do_not_enqueue = True
-			play.insert(ignore_permissions=True)
+            frappe.flags.do_not_enqueue = True
+            play.insert(ignore_permissions=True)
 
-			kwargs.update(
-				{
-					"status": play.status,
-					"error_log": play.error_log,
-				}
-			)
+            kwargs.update(
+                {
+                    "status": play.status,
+                    "error_log": play.error_log,
+                }
+            )
 
-			if kwargs["status"] == "Failed":
-				kwargs["retries"] = cint(self.retries) + 1
+            if kwargs["status"] == "Failed":
+                kwargs["retries"] = cint(self.retries) + 1
 
-		except Exception:
-			retries = cint(self.retries) + 1
-			kwargs.update(
-				{
-					"status": "Failed",
-					"retries": retries,
-					"error_log": frappe.get_traceback(with_context=True),
-				}
-			)
+        except Exception:
+            retries = cint(self.retries) + 1
+            kwargs.update(
+                {
+                    "status": "Failed",
+                    "retries": retries,
+                    "error_log": frappe.get_traceback(with_context=True),
+                }
+            )
 
-		ended_at = now()
-		self._db_set(
-			ended_at=ended_at, duration=time_diff_in_seconds(ended_at, started_at), notify=True, **kwargs
-		)
+        ended_at = now()
+        self._db_set(
+            ended_at=ended_at, duration=time_diff_in_seconds(ended_at, started_at), notify=True, **kwargs
+        )
 
-	@frappe.whitelist()
-	def fc_filebeat_stream_setup(self) -> None:
-		"""Creates a Server Job to setup Filebeat stream for Frappe Cloud."""
+    @frappe.whitelist()
+    def fc_filebeat_stream_setup(self) -> None:
+        """Creates a Server Job to setup Filebeat stream for Frappe Cloud."""
 
-		frappe.only_for("System Manager")
+        frappe.only_for("System Manager")
 
-		script_path = os.path.join(frappe.get_app_path("suite", "mail", "utils", "fc"), "filebeat_stream_setup.sh")
-		with open(script_path) as f:
-			script_content = f.read()
+        script_path = os.path.join(
+            frappe.get_app_path("suite", "mail", "utils", "fc"), "filebeat_stream_setup.sh"
+        )
+        with open(script_path) as f:
+            script_content = f.read()
 
-		script_content = script_content.replace("{{ server }}", self.server)
+        script_content = script_content.replace("{{ server }}", self.server)
 
-		job = frappe.new_doc("Server Job")
-		job.status = "Pending"
-		job.server = self.server
-		job.job = "Filebeat Stream Setup (FC)"
-		job.append("commands", {"command": script_content})
-		job.insert(ignore_permissions=True)
+        job = frappe.new_doc("Server Job")
+        job.status = "Pending"
+        job.server = self.server
+        job.job = "Filebeat Stream Setup (FC)"
+        job.append("commands", {"command": script_content})
+        job.insert(ignore_permissions=True)
 
-		frappe.msgprint(_("Filebeat stream setup job has been created."), indicator="green", alert=True)
+        frappe.msgprint(_("Filebeat stream setup job has been created."), indicator="green", alert=True)
 
-	@frappe.whitelist()
-	def fc_post_deploy_ssl_setup(self, contact_email: str) -> None:
-		"""Creates a Server Job to setup SSL post deployment for Frappe Cloud."""
+    @frappe.whitelist()
+    def fc_post_deploy_ssl_setup(self, contact_email: str) -> None:
+        """Creates a Server Job to setup SSL post deployment for Frappe Cloud."""
 
-		frappe.only_for("System Manager")
+        frappe.only_for("System Manager")
 
-		container_name = None
-		for service in self.services:
-			if service.service == "stalwart":
-				container_name = service.container
-				break
+        container_name = None
+        for service in self.services:
+            if service.service == "stalwart":
+                container_name = service.container
+                break
 
-		if not container_name:
-			frappe.throw(_("Stalwart service not found in deployment {0}").format(self.name))
+        if not container_name:
+            frappe.throw(_("Stalwart service not found in deployment {0}").format(self.name))
 
-		script_path = os.path.join(frappe.get_app_path("suite", "mail", "utils", "fc"), "post_deploy_ssl_setup.sh")
-		with open(script_path) as f:
-			script_content = f.read()
+        script_path = os.path.join(
+            frappe.get_app_path("suite", "mail", "utils", "fc"), "post_deploy_ssl_setup.sh"
+        )
+        with open(script_path) as f:
+            script_content = f.read()
 
-		script_content = (
-			script_content.replace("{{ server }}", self.server)
-			.replace("{{ https_port }}", str(self.https_port))
-			.replace("{{ contact_email }}", contact_email)
-			.replace("{{ container_name }}", container_name)
-		)
+        script_content = (
+            script_content.replace("{{ server }}", self.server)
+            .replace("{{ https_port }}", str(self.https_port))
+            .replace("{{ contact_email }}", contact_email)
+            .replace("{{ container_name }}", container_name)
+        )
 
-		job = frappe.new_doc("Server Job")
-		job.status = "Pending"
-		job.server = self.server
-		job.job = "Post Deployment SSL Setup (FC)"
-		job.append("commands", {"command": script_content})
-		job.insert(ignore_permissions=True)
+        job = frappe.new_doc("Server Job")
+        job.status = "Pending"
+        job.server = self.server
+        job.job = "Post Deployment SSL Setup (FC)"
+        job.append("commands", {"command": script_content})
+        job.insert(ignore_permissions=True)
 
-		frappe.msgprint(_("SSL setup job has been created."), indicator="green", alert=True)
+        frappe.msgprint(_("SSL setup job has been created."), indicator="green", alert=True)
 
-	@frappe.whitelist()
-	def retry(self) -> None:
-		"""Retries a failed deployment."""
+    @frappe.whitelist()
+    def retry(self) -> None:
+        """Retries a failed deployment."""
 
-		frappe.only_for("System Manager")
+        frappe.only_for("System Manager")
 
-		if self.status != "Failed":
-			frappe.throw(_("Only failed deployments can be retried."))
+        if self.status != "Failed":
+            frappe.throw(_("Only failed deployments can be retried."))
 
-		self._db_set(status="Pending", notify=True)
+        self._db_set(status="Pending", notify=True)
 
-		frappe.enqueue_doc(
-			self.doctype,
-			self.name,
-			"execute",
-			queue="long",
-			timeout=cint(get_config("server_deployment_timeout")),
-			enqueue_after_commit=True,
-		)
+        frappe.enqueue_doc(
+            self.doctype,
+            self.name,
+            "execute",
+            queue="long",
+            timeout=cint(get_config("server_deployment_timeout")),
+            enqueue_after_commit=True,
+        )
 
-	def _db_set(
-		self,
-		update_modified: bool = True,
-		commit: bool = False,
-		notify: bool = False,
-		**kwargs,
-	) -> None:
-		"""Updates the document with the given key-value pairs."""
+    def _db_set(
+        self,
+        update_modified: bool = True,
+        commit: bool = False,
+        notify: bool = False,
+        **kwargs,
+    ) -> None:
+        """Updates the document with the given key-value pairs."""
 
-		self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
+        self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
 
 
 def retry_failed_deployments() -> None:
-	"""Called by the scheduler to retry failed deployments."""
+    """Called by the scheduler to retry failed deployments."""
 
-	DEPLOYMENT = frappe.qb.DocType("Server Deployment")
-	deployments = (
-		frappe.qb.from_(DEPLOYMENT)
-		.select(DEPLOYMENT.name)
-		.where(
-			(DEPLOYMENT.status == "Failed")
-			& (DEPLOYMENT.retries > 0)
-			& (DEPLOYMENT.retries < DEPLOYMENT.max_retries)
-		)
-		.orderby(DEPLOYMENT.creation, order=Order.asc)
-	).run(pluck="name")
+    DEPLOYMENT = frappe.qb.DocType("Server Deployment")
+    deployments = (
+        frappe.qb.from_(DEPLOYMENT)
+        .select(DEPLOYMENT.name)
+        .where(
+            (DEPLOYMENT.status == "Failed")
+            & (DEPLOYMENT.retries > 0)
+            & (DEPLOYMENT.retries < DEPLOYMENT.max_retries)
+        )
+        .orderby(DEPLOYMENT.creation, order=Order.asc)
+    ).run(pluck="name")
 
-	if not deployments:
-		return
+    if not deployments:
+        return
 
-	for deployment in deployments:
-		doc = frappe.get_doc("Server Deployment", deployment)
-		doc.retry()
+    for deployment in deployments:
+        doc = frappe.get_doc("Server Deployment", deployment)
+        doc.retry()

--- a/suite/mail/doctype/server_deployment/test_server_deployment.py
+++ b/suite/mail/doctype/server_deployment/test_server_deployment.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestServerDeployment(IntegrationTestCase):
-	"""
-	Integration tests for ServerDeployment.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for ServerDeployment.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/server_deployment_service/server_deployment_service.py
+++ b/suite/mail/doctype/server_deployment_service/server_deployment_service.py
@@ -6,4 +6,4 @@ from frappe.model.document import Document
 
 
 class ServerDeploymentService(Document):
-	pass
+    pass

--- a/suite/mail/doctype/server_deployment_service/test_server_deployment_service.py
+++ b/suite/mail/doctype/server_deployment_service/test_server_deployment_service.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestServerDeploymentService(IntegrationTestCase):
-	"""
-	Integration tests for ServerDeploymentService.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for ServerDeploymentService.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/server_job/server_job.py
+++ b/suite/mail/doctype/server_job/server_job.py
@@ -15,189 +15,189 @@ from suite.mail.utils import get_config
 
 
 class ServerJob(Document):
-	def autoname(self) -> None:
-		self.name = str(uuid7())
+    def autoname(self) -> None:
+        self.name = str(uuid7())
 
-	def validate(self) -> None:
-		self.validate_status()
-		self.validate_server()
-		self.validate_commands()
+    def validate(self) -> None:
+        self.validate_status()
+        self.validate_server()
+        self.validate_commands()
 
-	def after_insert(self) -> None:
-		if frappe.flags.do_not_enqueue:
-			self.execute()
-		else:
-			frappe.enqueue_doc(
-				self.doctype,
-				self.name,
-				"execute",
-				queue="long",
-				timeout=cint(get_config("server_job_timeout")),
-				enqueue_after_commit=True,
-			)
+    def after_insert(self) -> None:
+        if frappe.flags.do_not_enqueue:
+            self.execute()
+        else:
+            frappe.enqueue_doc(
+                self.doctype,
+                self.name,
+                "execute",
+                queue="long",
+                timeout=cint(get_config("server_job_timeout")),
+                enqueue_after_commit=True,
+            )
 
-	def validate_status(self) -> None:
-		"""Sets the status to 'Pending' if not set."""
+    def validate_status(self) -> None:
+        """Sets the status to 'Pending' if not set."""
 
-		if not self.status:
-			self.status = "Pending"
+        if not self.status:
+            self.status = "Pending"
 
-	def validate_server(self) -> None:
-		"""Validate if the mail server is enabled."""
+    def validate_server(self) -> None:
+        """Validate if the mail server is enabled."""
 
-		if not frappe.db.get_value("Mail Server", self.server, "enabled"):
-			frappe.throw(_("Mail Server {0} is disabled").format(self.server))
-		elif not frappe.db.get_value("Mail Server", self.server, "ssh_verified"):
-			frappe.throw(_("Please verify SSH connection for Mail Server {0}").format(self.server))
+        if not frappe.db.get_value("Mail Server", self.server, "enabled"):
+            frappe.throw(_("Mail Server {0} is disabled").format(self.server))
+        elif not frappe.db.get_value("Mail Server", self.server, "ssh_verified"):
+            frappe.throw(_("Please verify SSH connection for Mail Server {0}").format(self.server))
 
-	def validate_commands(self) -> None:
-		"""Validates that at least one command is provided."""
+    def validate_commands(self) -> None:
+        """Validates that at least one command is provided."""
 
-		if not self.commands:
-			frappe.throw(_("Please add at least one command to execute."))
+        if not self.commands:
+            frappe.throw(_("Please add at least one command to execute."))
 
-	def execute(self) -> None:
-		"""Executes the commands on the Mail Server via SSH."""
+    def execute(self) -> None:
+        """Executes the commands on the Mail Server via SSH."""
 
-		started_at = now()
-		self._db_set(
-			status="Running",
-			started_at=started_at,
-			ended_at=None,
-			started_after=time_diff_in_seconds(started_at, self.creation),
-			duration=0,
-			success=0,
-			failed=0,
-			error_log=None,
-			commit=True,
-			notify=True,
-		)
-		frappe.db.set_value(
-			"Server Job Command",
-			{"parenttype": self.doctype, "parent": self.name},
-			{
-				"status": "Pending",
-				"started_at": None,
-				"ended_at": None,
-				"duration": 0,
-				"exit_code": 0,
-				"stdout": None,
-				"stderr": None,
-			},
-		)
+        started_at = now()
+        self._db_set(
+            status="Running",
+            started_at=started_at,
+            ended_at=None,
+            started_after=time_diff_in_seconds(started_at, self.creation),
+            duration=0,
+            success=0,
+            failed=0,
+            error_log=None,
+            commit=True,
+            notify=True,
+        )
+        frappe.db.set_value(
+            "Server Job Command",
+            {"parenttype": self.doctype, "parent": self.name},
+            {
+                "status": "Pending",
+                "started_at": None,
+                "ended_at": None,
+                "duration": 0,
+                "exit_code": 0,
+                "stdout": None,
+                "stderr": None,
+            },
+        )
 
-		kwargs = {}
-		success_count = 0
-		failed_count = 0
-		try:
-			self.validate_server()
+        kwargs = {}
+        success_count = 0
+        failed_count = 0
+        try:
+            self.validate_server()
 
-			server = frappe.get_doc("Mail Server", self.server)
-			cluster = frappe.get_doc("Mail Cluster", server.cluster)
-			key = paramiko.RSAKey.from_private_key(io.StringIO(cluster.get_password("ssh_private_key")))
+            server = frappe.get_doc("Mail Server", self.server)
+            cluster = frappe.get_doc("Mail Cluster", server.cluster)
+            key = paramiko.RSAKey.from_private_key(io.StringIO(cluster.get_password("ssh_private_key")))
 
-			client = paramiko.SSHClient()
-			client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-			client.connect(
-				hostname=server.hostname, port=server.ssh_port, username=server.ssh_user, pkey=key, timeout=30
-			)
+            client = paramiko.SSHClient()
+            client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            client.connect(
+                hostname=server.hostname, port=server.ssh_port, username=server.ssh_user, pkey=key, timeout=30
+            )
 
-			for command in self.commands:
-				cmd_started_at = now()
-				command._db_set(status="Running", started_at=cmd_started_at, commit=True)
+            for command in self.commands:
+                cmd_started_at = now()
+                command._db_set(status="Running", started_at=cmd_started_at, commit=True)
 
-				_stdin, stdout, stderr = client.exec_command(command.command)
-				exit_code = stdout.channel.recv_exit_status()
+                _stdin, stdout, stderr = client.exec_command(command.command)
+                exit_code = stdout.channel.recv_exit_status()
 
-				cmd_ended_at = now()
-				command._db_set(
-					status="Success" if exit_code == 0 else "Failed",
-					ended_at=cmd_ended_at,
-					exit_code=exit_code,
-					stdout=stdout.read().decode(),
-					stderr=stderr.read().decode(),
-					duration=time_diff_in_seconds(cmd_ended_at, cmd_started_at),
-					commit=True,
-				)
+                cmd_ended_at = now()
+                command._db_set(
+                    status="Success" if exit_code == 0 else "Failed",
+                    ended_at=cmd_ended_at,
+                    exit_code=exit_code,
+                    stdout=stdout.read().decode(),
+                    stderr=stderr.read().decode(),
+                    duration=time_diff_in_seconds(cmd_ended_at, cmd_started_at),
+                    commit=True,
+                )
 
-				if exit_code == 0:
-					success_count += 1
-				elif not command.ignore_errors:
-					failed_count += 1
-					frappe.throw(
-						_("Command '{0}' failed with exit code {1}").format(
-							f"{command.command[:20]} ...", exit_code
-						)
-					)
+                if exit_code == 0:
+                    success_count += 1
+                elif not command.ignore_errors:
+                    failed_count += 1
+                    frappe.throw(
+                        _("Command '{0}' failed with exit code {1}").format(
+                            f"{command.command[:20]} ...", exit_code
+                        )
+                    )
 
-			client.close()
-			kwargs["status"] = "Success"
+            client.close()
+            kwargs["status"] = "Success"
 
-		except Exception:
-			kwargs.update(
-				{
-					"status": "Failed",
-					"retries": cint(self.retries) + 1,
-					"error_log": frappe.get_traceback(with_context=True),
-				}
-			)
+        except Exception:
+            kwargs.update(
+                {
+                    "status": "Failed",
+                    "retries": cint(self.retries) + 1,
+                    "error_log": frappe.get_traceback(with_context=True),
+                }
+            )
 
-		ended_at = now()
-		self._db_set(
-			ended_at=ended_at,
-			duration=time_diff_in_seconds(ended_at, started_at),
-			success=success_count,
-			failed=failed_count,
-			notify=True,
-			**kwargs,
-		)
+        ended_at = now()
+        self._db_set(
+            ended_at=ended_at,
+            duration=time_diff_in_seconds(ended_at, started_at),
+            success=success_count,
+            failed=failed_count,
+            notify=True,
+            **kwargs,
+        )
 
-	@frappe.whitelist()
-	def retry(self) -> None:
-		"""Retries a failed job."""
+    @frappe.whitelist()
+    def retry(self) -> None:
+        """Retries a failed job."""
 
-		frappe.only_for("System Manager")
+        frappe.only_for("System Manager")
 
-		if self.status != "Failed":
-			frappe.throw(_("Only failed jobs can be retried."))
+        if self.status != "Failed":
+            frappe.throw(_("Only failed jobs can be retried."))
 
-		self._db_set(status="Pending", notify=True)
+        self._db_set(status="Pending", notify=True)
 
-		frappe.enqueue_doc(
-			self.doctype,
-			self.name,
-			"execute",
-			queue="long",
-			timeout=cint(get_config("server_job_timeout")),
-			enqueue_after_commit=True,
-		)
+        frappe.enqueue_doc(
+            self.doctype,
+            self.name,
+            "execute",
+            queue="long",
+            timeout=cint(get_config("server_job_timeout")),
+            enqueue_after_commit=True,
+        )
 
-	def _db_set(
-		self,
-		update_modified: bool = True,
-		commit: bool = False,
-		notify: bool = False,
-		**kwargs,
-	) -> None:
-		"""Updates the document with the given key-value pairs."""
+    def _db_set(
+        self,
+        update_modified: bool = True,
+        commit: bool = False,
+        notify: bool = False,
+        **kwargs,
+    ) -> None:
+        """Updates the document with the given key-value pairs."""
 
-		self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
+        self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
 
 
 def retry_failed_jobs() -> None:
-	"""Called by the scheduler to retry failed jobs."""
+    """Called by the scheduler to retry failed jobs."""
 
-	JOB = frappe.qb.DocType("Server Job")
-	jobs = (
-		frappe.qb.from_(JOB)
-		.select(JOB.name)
-		.where((JOB.status == "Failed") & (JOB.retries > 0) & (JOB.retries < JOB.max_retries))
-		.orderby(JOB.creation, order=Order.asc)
-	).run(pluck="name")
+    JOB = frappe.qb.DocType("Server Job")
+    jobs = (
+        frappe.qb.from_(JOB)
+        .select(JOB.name)
+        .where((JOB.status == "Failed") & (JOB.retries > 0) & (JOB.retries < JOB.max_retries))
+        .orderby(JOB.creation, order=Order.asc)
+    ).run(pluck="name")
 
-	if not jobs:
-		return
+    if not jobs:
+        return
 
-	for job in jobs:
-		doc = frappe.get_doc("Server Job", job)
-		doc.retry()
+    for job in jobs:
+        doc = frappe.get_doc("Server Job", job)
+        doc.retry()

--- a/suite/mail/doctype/server_job/test_server_job.py
+++ b/suite/mail/doctype/server_job/test_server_job.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestServerJob(IntegrationTestCase):
-	"""
-	Integration tests for ServerJob.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for ServerJob.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/server_job_command/server_job_command.py
+++ b/suite/mail/doctype/server_job_command/server_job_command.py
@@ -6,13 +6,13 @@ from frappe.model.document import Document
 
 
 class ServerJobCommand(Document):
-	def _db_set(
-		self,
-		update_modified: bool = True,
-		commit: bool = False,
-		notify: bool = False,
-		**kwargs,
-	) -> None:
-		"""Updates the document with the given key-value pairs."""
+    def _db_set(
+        self,
+        update_modified: bool = True,
+        commit: bool = False,
+        notify: bool = False,
+        **kwargs,
+    ) -> None:
+        """Updates the document with the given key-value pairs."""
 
-		self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
+        self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)

--- a/suite/mail/doctype/server_job_command/test_server_job_command.py
+++ b/suite/mail/doctype/server_job_command/test_server_job_command.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestServerJobCommand(IntegrationTestCase):
-	"""
-	Integration tests for ServerJobCommand.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for ServerJobCommand.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/sieve_script/sieve_script.py
+++ b/suite/mail/doctype/sieve_script/sieve_script.py
@@ -14,17 +14,17 @@ from frappe.utils import cint, create_batch, today
 
 from suite.mail.doctype.mailbox_settings.mailbox_settings import get_mailbox_settings
 from suite.mail.doctype.screened_email_address.screened_email_address import (
-	get_effective_screened_email_addresses,
+    get_effective_screened_email_addresses,
 )
 from suite.mail.doctype.user_account.user_account import get_user_for_jmap_account
 from suite.mail.jmap import (
-	format_jmap_error,
-	get_jmap_set_error_message,
-	get_mailbox_id_by_name,
-	get_mailbox_id_by_role,
-	get_mailbox_name_by_id,
-	get_mailboxes,
-	get_sieve_script_service,
+    format_jmap_error,
+    get_jmap_set_error_message,
+    get_mailbox_id_by_name,
+    get_mailbox_id_by_role,
+    get_mailbox_name_by_id,
+    get_mailboxes,
+    get_sieve_script_service,
 )
 from suite.mail.utils import log_mail_error
 from suite.mail.utils.user import get_account_emails
@@ -34,386 +34,386 @@ _ACCOUNTS_PER_REBUILD_BATCH = 100
 
 
 class SieveScript(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		_name: DF.Data
-		account: DF.Link
-		active: DF.Check
-		blob_id: DF.Data | None
-		content: DF.Code
-		id: DF.Data | None
-		read_only: DF.Check
-	# end: auto-generated types
+        _name: DF.Data
+        account: DF.Link
+        active: DF.Check
+        blob_id: DF.Data | None
+        content: DF.Code
+        id: DF.Data | None
+        read_only: DF.Check
+    # end: auto-generated types
 
-	def db_insert(self, *args, **kwargs) -> None:
-		self.id = SieveScript._add_sieve_script(self.account, self._name, self.content, bool(self.active))
-		self.name = f"{self.account}|{self.id}"
+    def db_insert(self, *args, **kwargs) -> None:
+        self.id = SieveScript._add_sieve_script(self.account, self._name, self.content, bool(self.active))
+        self.name = f"{self.account}|{self.id}"
 
-	def load_from_db(self) -> SieveScript:
-		account, id = parse_sieve_script_name(self.name)
-		if scripts := SieveScript._get_sieve_scripts(account, [id], download_content=True):
-			return super(Document, self).__init__(scripts[0])
+    def load_from_db(self) -> SieveScript:
+        account, id = parse_sieve_script_name(self.name)
+        if scripts := SieveScript._get_sieve_scripts(account, [id], download_content=True):
+            return super(Document, self).__init__(scripts[0])
 
-		frappe.throw(
-			_("Sieve Script with ID {0} not found in account {1}.").format(
-				frappe.bold(id), frappe.bold(account)
-			),
-			title=_("Sieve Script Not Found"),
-		)
+        frappe.throw(
+            _("Sieve Script with ID {0} not found in account {1}.").format(
+                frappe.bold(id), frappe.bold(account)
+            ),
+            title=_("Sieve Script Not Found"),
+        )
 
-	def db_update(self) -> None:
-		account, id = parse_sieve_script_name(self.name)
-		SieveScript._update_sieve_script(account, id, self._name, self.content, bool(self.active))
-		self.reload()
+    def db_update(self) -> None:
+        account, id = parse_sieve_script_name(self.name)
+        SieveScript._update_sieve_script(account, id, self._name, self.content, bool(self.active))
+        self.reload()
 
-	def delete(self) -> None:
-		account, id = parse_sieve_script_name(self.name)
+    def delete(self) -> None:
+        account, id = parse_sieve_script_name(self.name)
 
-		if self.active:
-			frappe.throw(_("Cannot delete an active sieve script. Please deactivate it first."))
+        if self.active:
+            frappe.throw(_("Cannot delete an active sieve script. Please deactivate it first."))
 
-		SieveScript._delete_sieve_scripts(account, [id])
+        SieveScript._delete_sieve_scripts(account, [id])
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs) -> list:
-		filters = parse_filters(filters)
-		id = filters.get("id")
-		account = filters.get("account")
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs) -> list:
+        filters = parse_filters(filters)
+        id = filters.get("id")
+        account = filters.get("account")
 
-		if not account:
-			frappe.msgprint(_("Please select an account to view the Sieve Scripts."), alert=True)
-			return []
+        if not account:
+            frappe.msgprint(_("Please select an account to view the Sieve Scripts."), alert=True)
+            return []
 
-		scripts = []
-		if id:
-			scripts = SieveScript._get_sieve_scripts(account, [id])
-			total = len(scripts)
-		else:
-			filter = {}
-			if value := filters.get("_name"):
-				filter["name"] = value
-			if value := filters.get("active"):
-				filter["isActive"] = bool(cint(value))
+        scripts = []
+        if id:
+            scripts = SieveScript._get_sieve_scripts(account, [id])
+            total = len(scripts)
+        else:
+            filter = {}
+            if value := filters.get("_name"):
+                filter["name"] = value
+            if value := filters.get("active"):
+                filter["isActive"] = bool(cint(value))
 
-			limit = cint(kwargs.get("start")) + page_length
-			scripts, total = SieveScript._fetch_sieve_scripts(account, filter, limit=limit)
+            limit = cint(kwargs.get("start")) + page_length
+            scripts, total = SieveScript._fetch_sieve_scripts(account, filter, limit=limit)
 
-		frappe.cache.set_value(_get_total_cache_key(account), total, expires_in_sec=600)
+        frappe.cache.set_value(_get_total_cache_key(account), total, expires_in_sec=600)
 
-		if not scripts:
-			frappe.msgprint(_("No sieve scripts found."), alert=True)
+        if not scripts:
+            frappe.msgprint(_("No sieve scripts found."), alert=True)
 
-		return scripts
+        return scripts
 
-	@staticmethod
-	def get_count(filters=None, **kwargs) -> int:
-		filters = parse_filters(filters)
-		account = filters.get("account")
+    @staticmethod
+    def get_count(filters=None, **kwargs) -> int:
+        filters = parse_filters(filters)
+        account = filters.get("account")
 
-		if account:
-			if get_user_for_jmap_account(account, raise_exception=False):
-				return cint(frappe.cache.get_value(_get_total_cache_key(account)))
+        if account:
+            if get_user_for_jmap_account(account, raise_exception=False):
+                return cint(frappe.cache.get_value(_get_total_cache_key(account)))
 
-		return 0
+        return 0
 
-	@staticmethod
-	def get_stats(**kwargs) -> dict:
-		return {}
+    @staticmethod
+    def get_stats(**kwargs) -> dict:
+        return {}
 
-	@classmethod
-	def _add_sieve_script(
-		cls,
-		account: str,
-		name: str,
-		content: str,
-		active: bool = False,
-	) -> str:
-		"""Adds a sieve script for the given account with the specified parameters."""
+    @classmethod
+    def _add_sieve_script(
+        cls,
+        account: str,
+        name: str,
+        content: str,
+        active: bool = False,
+    ) -> str:
+        """Adds a sieve script for the given account with the specified parameters."""
 
-		if not content or not content.strip():
-			frappe.throw(_("Sieve script content cannot be empty."))
+        if not content or not content.strip():
+            frappe.throw(_("Sieve script content cannot be empty."))
 
-		if name == AUTOMATION_SCRIPT_NAME and not frappe.flags.allow_automation_script_creation:
-			frappe.throw(_("Not allowed to create automation script."))
+        if name == AUTOMATION_SCRIPT_NAME and not frappe.flags.allow_automation_script_creation:
+            frappe.throw(_("Not allowed to create automation script."))
 
-		creation_id = str(uuid7())
-		service = get_sieve_script_service(account)
-		sieve_script = {
-			"creation_id": creation_id,
-			"name": name,
-			"content": content,
-			"is_active": active,
-		}
-		response = service.create([sieve_script])
+        creation_id = str(uuid7())
+        service = get_sieve_script_service(account)
+        sieve_script = {
+            "creation_id": creation_id,
+            "name": name,
+            "content": content,
+            "is_active": active,
+        }
+        response = service.create([sieve_script])
 
-		if created := response.get("created"):
-			return created[creation_id]["id"]
+        if created := response.get("created"):
+            return created[creation_id]["id"]
 
-		frappe.throw(
-			get_jmap_set_error_message(response, "notCreated", creation_id),
-			title=_("Sieve Script Creation Error"),
-		)
+        frappe.throw(
+            get_jmap_set_error_message(response, "notCreated", creation_id),
+            title=_("Sieve Script Creation Error"),
+        )
 
-	@classmethod
-	def _fetch_sieve_scripts(
-		cls,
-		account: str,
-		filter: dict | None = None,
-		position: int = 0,
-		limit: int = 50,
-	) -> tuple[list, int]:
-		"""Returns a list of sieve scripts for the given account."""
+    @classmethod
+    def _fetch_sieve_scripts(
+        cls,
+        account: str,
+        filter: dict | None = None,
+        position: int = 0,
+        limit: int = 50,
+    ) -> tuple[list, int]:
+        """Returns a list of sieve scripts for the given account."""
 
-		scripts = []
-		service = get_sieve_script_service(account)
-		data = service.query(filter, position, limit)
+        scripts = []
+        service = get_sieve_script_service(account)
+        data = service.query(filter, position, limit)
 
-		ids = data.get("ids", [])
-		total = data.get("total", 0)
+        ids = data.get("ids", [])
+        total = data.get("total", 0)
 
-		scripts.extend(SieveScript._get_sieve_scripts(account, ids))
+        scripts.extend(SieveScript._get_sieve_scripts(account, ids))
 
-		return scripts[:limit], total
+        return scripts[:limit], total
 
-	@classmethod
-	def _get_sieve_scripts(cls, account: str, ids: list[str], download_content: bool = False) -> list[dict]:
-		"""Returns a list of sieve scripts for the provided IDs in the same order as ids."""
+    @classmethod
+    def _get_sieve_scripts(cls, account: str, ids: list[str], download_content: bool = False) -> list[dict]:
+        """Returns a list of sieve scripts for the provided IDs in the same order as ids."""
 
-		sieve_scripts = {}
-		service = get_sieve_script_service(account)
-		scripts = service.get(ids)
+        sieve_scripts = {}
+        service = get_sieve_script_service(account)
+        scripts = service.get(ids)
 
-		if download_content:
-			blobs = [(s["blobId"], None) for s in scripts if s["blobId"]]
-			data = service.download_blobs_concurrently(blobs)
+        if download_content:
+            blobs = [(s["blobId"], None) for s in scripts if s["blobId"]]
+            data = service.download_blobs_concurrently(blobs)
 
-			for script in scripts:
-				script["content"] = data.get(script["blobId"], b"").decode("utf-8")
+            for script in scripts:
+                script["content"] = data.get(script["blobId"], b"").decode("utf-8")
 
-		for script in scripts:
-			script = format_sieve_script(account, script)
-			sieve_scripts[script["id"]] = script
+        for script in scripts:
+            script = format_sieve_script(account, script)
+            sieve_scripts[script["id"]] = script
 
-		return [sieve_scripts[id] for id in ids if id in sieve_scripts]
+        return [sieve_scripts[id] for id in ids if id in sieve_scripts]
 
-	@classmethod
-	def _validate_sieve_script(cls, account: str, content: str) -> None:
-		"""Validates a sieve script for the given account."""
+    @classmethod
+    def _validate_sieve_script(cls, account: str, content: str) -> None:
+        """Validates a sieve script for the given account."""
 
-		if not content or not content.strip():
-			frappe.throw(_("Sieve script content cannot be empty."))
+        if not content or not content.strip():
+            frappe.throw(_("Sieve script content cannot be empty."))
 
-		service = get_sieve_script_service(account)
-		response = service.validate(content)
+        service = get_sieve_script_service(account)
+        response = service.validate(content)
 
-		if error := response.get("error"):
-			frappe.throw(format_jmap_error(error), title=_("Sieve Script Validation Error"))
+        if error := response.get("error"):
+            frappe.throw(format_jmap_error(error), title=_("Sieve Script Validation Error"))
 
-	@classmethod
-	def _update_sieve_script(
-		cls,
-		account: str,
-		id: str,
-		name: str,
-		content: str,
-		active: bool = False,
-	) -> None:
-		"""Updates a sieve script for the given account and ID with the specified parameters."""
+    @classmethod
+    def _update_sieve_script(
+        cls,
+        account: str,
+        id: str,
+        name: str,
+        content: str,
+        active: bool = False,
+    ) -> None:
+        """Updates a sieve script for the given account and ID with the specified parameters."""
 
-		if not content or not content.strip():
-			frappe.throw(_("Sieve script content cannot be empty."))
+        if not content or not content.strip():
+            frappe.throw(_("Sieve script content cannot be empty."))
 
-		service = get_sieve_script_service(account)
-		scripts = service.get([id])
+        service = get_sieve_script_service(account)
+        scripts = service.get([id])
 
-		if not scripts:
-			frappe.throw(
-				_("Sieve Script with ID {0} not found.").format(frappe.bold(id)),
-				title=_("Sieve Script Not Found"),
-			)
+        if not scripts:
+            frappe.throw(
+                _("Sieve Script with ID {0} not found.").format(frappe.bold(id)),
+                title=_("Sieve Script Not Found"),
+            )
 
-		script = scripts[0]
-		deactivate = script["isActive"] and not active
-		sieve_script = {"id": id, "name": name, "content": content, "is_active": bool(active)}
-		response = service.update([sieve_script], deactivate=deactivate)
+        script = scripts[0]
+        deactivate = script["isActive"] and not active
+        sieve_script = {"id": id, "name": name, "content": content, "is_active": bool(active)}
+        response = service.update([sieve_script], deactivate=deactivate)
 
-		if not response.get("updated"):
-			frappe.throw(
-				get_jmap_set_error_message(response, "notUpdated", id),
-				title=_("Sieve Script Update Error"),
-			)
+        if not response.get("updated"):
+            frappe.throw(
+                get_jmap_set_error_message(response, "notUpdated", id),
+                title=_("Sieve Script Update Error"),
+            )
 
-	@classmethod
-	def _delete_sieve_scripts(cls, account: str, ids: list[str]) -> None:
-		"""Deletes sieve scripts for the given list of IDs and account."""
+    @classmethod
+    def _delete_sieve_scripts(cls, account: str, ids: list[str]) -> None:
+        """Deletes sieve scripts for the given list of IDs and account."""
 
-		service = get_sieve_script_service(account)
-		response = service.delete(ids)
+        service = get_sieve_script_service(account)
+        response = service.delete(ids)
 
-		title = _("Sieve Script Deletion Error")
-		if not_destroyed := response.get("notDestroyed"):
-			error_messages = [f"{id}: {format_jmap_error(error)}" for id, error in not_destroyed.items()]
-			frappe.throw(
-				_("Sieve Script Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
-				title=title,
-			)
-		elif error := response.get("error"):
-			frappe.throw(format_jmap_error(error), title=title)
+        title = _("Sieve Script Deletion Error")
+        if not_destroyed := response.get("notDestroyed"):
+            error_messages = [f"{id}: {format_jmap_error(error)}" for id, error in not_destroyed.items()]
+            frappe.throw(
+                _("Sieve Script Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
+                title=title,
+            )
+        elif error := response.get("error"):
+            frappe.throw(format_jmap_error(error), title=title)
 
-	def validate(self) -> None:
-		if self.read_only:
-			frappe.throw(
-				_("The '{0}' sieve script cannot be modified.").format(self._name),
-				title=_("Read-Only Sieve Script"),
-			)
+    def validate(self) -> None:
+        if self.read_only:
+            frappe.throw(
+                _("The '{0}' sieve script cannot be modified.").format(self._name),
+                title=_("Read-Only Sieve Script"),
+            )
 
-	@frappe.whitelist()
-	def validate_script(self) -> None:
-		"""Validates the sieve script content."""
+    @frappe.whitelist()
+    def validate_script(self) -> None:
+        """Validates the sieve script content."""
 
-		account, _id = parse_sieve_script_name(self.name)
-		self._validate_sieve_script(account, self.content)
-		frappe.msgprint(_("Sieve script is valid."), indicator="green", alert=True)
+        account, _id = parse_sieve_script_name(self.name)
+        self._validate_sieve_script(account, self.content)
+        frappe.msgprint(_("Sieve script is valid."), indicator="green", alert=True)
 
 
 def _get_total_cache_key(account: str) -> str:
-	"""Returns a cache key for total sieve scripts count for the given account."""
+    """Returns a cache key for total sieve scripts count for the given account."""
 
-	return f"{account}:sieve_scripts:total"
+    return f"{account}:sieve_scripts:total"
 
 
 def parse_sieve_script_name(name: str) -> tuple[str, str]:
-	"""Splits a Sieve Script name `account|id` into its bare `account` and `id`."""
+    """Splits a Sieve Script name `account|id` into its bare `account` and `id`."""
 
-	account, id = name.split("|")
-	return account, id
+    account, id = name.split("|")
+    return account, id
 
 
 @frappe.whitelist()
 def bulk_delete(names: str | list[str]) -> None:
-	"""Deletes multiple sieve scripts given their names."""
+    """Deletes multiple sieve scripts given their names."""
 
-	if isinstance(names, str):
-		names = json.loads(names)
+    if isinstance(names, str):
+        names = json.loads(names)
 
-	accounts_map = {}
-	for name in names:
-		account, id = parse_sieve_script_name(name)
-		accounts_map.setdefault(account, []).append(id)
+    accounts_map = {}
+    for name in names:
+        account, id = parse_sieve_script_name(name)
+        accounts_map.setdefault(account, []).append(id)
 
-	for account, ids in accounts_map.items():
-		# SieveScript.delete() refuses to remove the active script, and validate() protects the
-		# read-only ones. Going straight to _delete_sieve_scripts skipped both, so one bulk call
-		# could drop the account's active script and silently disable all of its filtering.
-		for script in SieveScript._get_sieve_scripts(account, ids):
-			if script.get("active"):
-				frappe.throw(
-					_("Cannot delete the active sieve script {0}. Please deactivate it first.").format(
-						frappe.bold(script.get("_name") or script["id"])
-					)
-				)
-			if script.get("read_only"):
-				frappe.throw(
-					_("The '{0}' sieve script cannot be deleted.").format(
-						frappe.bold(script.get("_name") or script["id"])
-					),
-					title=_("Read-Only Sieve Script"),
-				)
+    for account, ids in accounts_map.items():
+        # SieveScript.delete() refuses to remove the active script, and validate() protects the
+        # read-only ones. Going straight to _delete_sieve_scripts skipped both, so one bulk call
+        # could drop the account's active script and silently disable all of its filtering.
+        for script in SieveScript._get_sieve_scripts(account, ids):
+            if script.get("active"):
+                frappe.throw(
+                    _("Cannot delete the active sieve script {0}. Please deactivate it first.").format(
+                        frappe.bold(script.get("_name") or script["id"])
+                    )
+                )
+            if script.get("read_only"):
+                frappe.throw(
+                    _("The '{0}' sieve script cannot be deleted.").format(
+                        frappe.bold(script.get("_name") or script["id"])
+                    ),
+                    title=_("Read-Only Sieve Script"),
+                )
 
-		SieveScript._delete_sieve_scripts(account, ids)
+        SieveScript._delete_sieve_scripts(account, ids)
 
-	frappe.msgprint(_("Sieve Scripts deleted successfully."), alert=True)
+    frappe.msgprint(_("Sieve Scripts deleted successfully."), alert=True)
 
 
 def get_active_sieve_script_id(account: str) -> str | None:
-	"""Returns the ID of the currently active sieve script for the given account, if any."""
+    """Returns the ID of the currently active sieve script for the given account, if any."""
 
-	service = get_sieve_script_service(account)
-	query_result = service.query({"isActive": True})
+    service = get_sieve_script_service(account)
+    query_result = service.query({"isActive": True})
 
-	if query_result.get("ids") and len(query_result["ids"]) > 0:
-		return query_result["ids"][0]
+    if query_result.get("ids") and len(query_result["ids"]) > 0:
+        return query_result["ids"][0]
 
 
 def is_vacation_script_active(account: str) -> bool:
-	"""Whether the account's currently active sieve script is the read-only vacation script.
+    """Whether the account's currently active sieve script is the read-only vacation script.
 
-	Used to keep the automation sieve from being activated over an active vacation auto-responder.
-	"""
+    Used to keep the automation sieve from being activated over an active vacation auto-responder.
+    """
 
-	active_id = get_active_sieve_script_id(account)
-	if not active_id:
-		return False
+    active_id = get_active_sieve_script_id(account)
+    if not active_id:
+        return False
 
-	scripts = SieveScript._get_sieve_scripts(account, [active_id])
-	return bool(scripts) and bool(scripts[0].get("read_only"))
+    scripts = SieveScript._get_sieve_scripts(account, [active_id])
+    return bool(scripts) and bool(scripts[0].get("read_only"))
 
 
 def activate_last_active_sieve_script(account: str) -> None:
-	"""Activates the last active sieve script for the given account, if any, and clears the last active sieve script setting."""
+    """Activates the last active sieve script for the given account, if any, and clears the last active sieve script setting."""
 
-	sieve_script_id = frappe.db.get_value("JMAP Account", account, "last_active_sieve_script_id")
-	if not sieve_script_id:
-		return
+    sieve_script_id = frappe.db.get_value("JMAP Account", account, "last_active_sieve_script_id")
+    if not sieve_script_id:
+        return
 
-	if sieve_scripts := SieveScript._get_sieve_scripts(account, [sieve_script_id], download_content=True):
-		sieve_script = sieve_scripts[0]
+    if sieve_scripts := SieveScript._get_sieve_scripts(account, [sieve_script_id], download_content=True):
+        sieve_script = sieve_scripts[0]
 
-		if (sieve_script.get("_name") or "").lower() != "vacation" and not sieve_script["active"]:
-			SieveScript._update_sieve_script(
-				account,
-				sieve_script_id,
-				sieve_script["_name"],
-				sieve_script["content"],
-				active=True,
-			)
+        if (sieve_script.get("_name") or "").lower() != "vacation" and not sieve_script["active"]:
+            SieveScript._update_sieve_script(
+                account,
+                sieve_script_id,
+                sieve_script["_name"],
+                sieve_script["content"],
+                active=True,
+            )
 
-	set_last_active_sieve_script_id(account, None)
+    set_last_active_sieve_script_id(account, None)
 
 
 def set_last_active_sieve_script_id(account: str, sieve_script_id: str | None = None) -> None:
-	"""Sets the given sieve script ID as the last active sieve script for the given account."""
+    """Sets the given sieve script ID as the last active sieve script for the given account."""
 
-	get_user_for_jmap_account(account, raise_exception=True)
-	frappe.db.set_value(
-		"JMAP Account",
-		account,
-		"last_active_sieve_script_id",
-		sieve_script_id,
-		update_modified=False,
-	)
+    get_user_for_jmap_account(account, raise_exception=True)
+    frappe.db.set_value(
+        "JMAP Account",
+        account,
+        "last_active_sieve_script_id",
+        sieve_script_id,
+        update_modified=False,
+    )
 
 
 def format_sieve_script(account: str, script: dict) -> dict:
-	"""Format the sieve script for display."""
+    """Format the sieve script for display."""
 
-	read_only = script["name"].lower() == "vacation"
+    read_only = script["name"].lower() == "vacation"
 
-	return {
-		"name": f"{account}|{script['id']}",
-		"account": account,
-		"id": script["id"],
-		"_name": script["name"],
-		"active": cint(script["isActive"]),
-		"blob_id": script["blobId"],
-		"content": script.get("content") or "",
-		"read_only": read_only,
-		"creation": today(),
-		"modified": today(),
-	}
+    return {
+        "name": f"{account}|{script['id']}",
+        "account": account,
+        "id": script["id"],
+        "_name": script["name"],
+        "active": cint(script["isActive"]),
+        "blob_id": script["blobId"],
+        "content": script.get("content") or "",
+        "read_only": read_only,
+        "creation": today(),
+        "modified": today(),
+    }
 
 
 def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
-	if doc.doctype != "Sieve Script":
-		return False
+    if doc.doctype != "Sieve Script":
+        return False
 
-	return bool(get_user_for_jmap_account(doc.account, raise_exception=False))
+    return bool(get_user_for_jmap_account(doc.account, raise_exception=False))
 
 
 # Frappe Mail Automation Sieve Script
@@ -421,554 +421,554 @@ def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
 SCREENER_MAILBOX_NAME = "Screener"
 AUTOMATION_SCRIPT_NAME = "frappe_mail_automation"
 AUTOMATION_SCRIPT_REQUIRE = (
-	'require ["fileinto", "imap4flags", "spamtest", "relational", "comparator-i;ascii-numeric"];'
+    'require ["fileinto", "imap4flags", "spamtest", "relational", "comparator-i;ascii-numeric"];'
 )
 
 
 def maybe_build_automation_sieve(account: str, activate: bool = False) -> None:
-	"""Build the automation sieve from a document hook unless a caller paused builds for a bulk write."""
+    """Build the automation sieve from a document hook unless a caller paused builds for a bulk write."""
 
-	if frappe.flags.get("skip_automation_sieve_build"):
-		return
+    if frappe.flags.get("skip_automation_sieve_build"):
+        return
 
-	build_automation_sieve(account, activate=activate)
+    build_automation_sieve(account, activate=activate)
 
 
 def build_automation_sieve(account: str, activate: bool = False) -> None:
-	"""Build the automation sieve script for the given account and optionally activate it.
+    """Build the automation sieve script for the given account and optionally activate it.
 
-	Activation is skipped while the vacation sieve script is active, so rebuilding the automation
-	script (e.g. from a Mailbox Settings / Screened Email Address change) never disables the
-	vacation auto-responder. The vacation flow reactivates the last active script once vacation ends.
+    Activation is skipped while the vacation sieve script is active, so rebuilding the automation
+    script (e.g. from a Mailbox Settings / Screened Email Address change) never disables the
+    vacation auto-responder. The vacation flow reactivates the last active script once vacation ends.
 
-	Accounts whose resolved user is disabled or gone are skipped: the JMAP connection is made as
-	that user, so the rebuild cannot work (e.g. the personal account of a deactivated employee) and
-	would only produce an error log. The script is rebuilt on the next change once the user is
-	enabled again.
-	"""
+    Accounts whose resolved user is disabled or gone are skipped: the JMAP connection is made as
+    that user, so the rebuild cannot work (e.g. the personal account of a deactivated employee) and
+    would only produce an error log. The script is rebuilt on the next change once the user is
+    enabled again.
+    """
 
-	user = get_user_for_jmap_account(account, raise_exception=False)
-	if not user or not frappe.get_cached_value("User", user, "enabled"):
-		return
+    user = get_user_for_jmap_account(account, raise_exception=False)
+    if not user or not frappe.get_cached_value("User", user, "enabled"):
+        return
 
-	def _build_automation_sieve(account: str, activate: bool = False) -> None:
-		doc = frappe.get_doc("Sieve Script", get_automation_script_name(account))
-		doc.content = _build_automation_content(account)
+    def _build_automation_sieve(account: str, activate: bool = False) -> None:
+        doc = frappe.get_doc("Sieve Script", get_automation_script_name(account))
+        doc.content = _build_automation_content(account)
 
-		# Activate the automation script unless vacation is active. `doc.active` is the freshly loaded
-		# state (load_from_db just fetched it), and only one script can be active at a time — so an
-		# already-active automation script means vacation isn't, and we skip the vacation lookup. That
-		# keeps the hot document-save path (where automation is already active) free of the two extra
-		# JMAP round-trips `is_vacation_script_active` would otherwise make.
-		if activate and not doc.active and not is_vacation_script_active(account):
-			doc.active = True
+        # Activate the automation script unless vacation is active. `doc.active` is the freshly loaded
+        # state (load_from_db just fetched it), and only one script can be active at a time — so an
+        # already-active automation script means vacation isn't, and we skip the vacation lookup. That
+        # keeps the hot document-save path (where automation is already active) free of the two extra
+        # JMAP round-trips `is_vacation_script_active` would otherwise make.
+        if activate and not doc.active and not is_vacation_script_active(account):
+            doc.active = True
 
-		doc.save()
+        doc.save()
 
-	execute_with_logging(
-		lambda: _build_automation_sieve(account, activate=activate),
-		title="Failed to build automation sieve script",
-		with_context=False,
-		module="Mail",
-	)
+    execute_with_logging(
+        lambda: _build_automation_sieve(account, activate=activate),
+        title="Failed to build automation sieve script",
+        with_context=False,
+        module="Mail",
+    )
 
 
 @frappe.whitelist()
 def rebuild_all_automation_sieves() -> None:
-	"""Enqueue a rebuild of the automation sieve script for every JMAP account.
+    """Enqueue a rebuild of the automation sieve script for every JMAP account.
 
-	Changing a global Screened Email Address (one without an account) deliberately rebuilds nothing —
-	an admin batches their global changes and then triggers this once, from the Screened Email Address
-	list view. The rebuild refreshes script content only (activate=False): activating here would
-	override accounts whose active script is the vacation auto-responder or one the user wrote
-	themselves. Inactive automation scripts still pick the rules up when the account enables
-	screening or touches a rule, which activates the script.
-	"""
+    Changing a global Screened Email Address (one without an account) deliberately rebuilds nothing —
+    an admin batches their global changes and then triggers this once, from the Screened Email Address
+    list view. The rebuild refreshes script content only (activate=False): activating here would
+    override accounts whose active script is the vacation auto-responder or one the user wrote
+    themselves. Inactive automation scripts still pick the rules up when the account enables
+    screening or touches a rule, which activates the script.
+    """
 
-	frappe.only_for("System Manager")
+    frappe.only_for("System Manager")
 
-	accounts = frappe.db.get_all("JMAP Account", pluck="name")
-	for i, batch in enumerate(create_batch(accounts, _ACCOUNTS_PER_REBUILD_BATCH)):
-		enqueue_job(
-			_rebuild_automation_sieves,
-			job_id=f"rebuild-automation-sieves::{i}",
-			deduplicate=True,
-			queue="long",
-			timeout=3600,
-			enqueue_after_commit=True,
-			accounts=batch,
-		)
+    accounts = frappe.db.get_all("JMAP Account", pluck="name")
+    for i, batch in enumerate(create_batch(accounts, _ACCOUNTS_PER_REBUILD_BATCH)):
+        enqueue_job(
+            _rebuild_automation_sieves,
+            job_id=f"rebuild-automation-sieves::{i}",
+            deduplicate=True,
+            queue="long",
+            timeout=3600,
+            enqueue_after_commit=True,
+            accounts=batch,
+        )
 
-	frappe.msgprint(
-		_("Rebuilding the automation sieve scripts for {0} account(s) in the background.").format(
-			len(accounts)
-		),
-		alert=True,
-	)
+    frappe.msgprint(
+        _("Rebuilding the automation sieve scripts for {0} account(s) in the background.").format(
+            len(accounts)
+        ),
+        alert=True,
+    )
 
 
 def _rebuild_automation_sieves(accounts: list[str]) -> None:
-	"""Rebuild each account's automation script, isolating per-account failures."""
+    """Rebuild each account's automation script, isolating per-account failures."""
 
-	for account in accounts:
-		# The job runs async after the fan-out committed, so an account can vanish in between.
-		if not account or not frappe.db.exists("JMAP Account", account):
-			continue
+    for account in accounts:
+        # The job runs async after the fan-out committed, so an account can vanish in between.
+        if not account or not frappe.db.exists("JMAP Account", account):
+            continue
 
-		try:
-			build_automation_sieve(account)
-		except Exception:
-			log_mail_error(
-				"Rebuild Automation Sieves Error",
-				f"Failed to rebuild the automation sieve script for JMAP account {account}",
-			)
+        try:
+            build_automation_sieve(account)
+        except Exception:
+            log_mail_error(
+                "Rebuild Automation Sieves Error",
+                f"Failed to rebuild the automation sieve script for JMAP account {account}",
+            )
 
 
 @contextmanager
 def pause_automation_sieve_build() -> Generator[None]:
-	"""Suppress the automatic `build_automation_sieve` triggered by Mailbox Settings / Screened Email
-	Address document hooks, so a caller doing several writes rebuilds the script once at the end
-	instead of after every write.
+    """Suppress the automatic `build_automation_sieve` triggered by Mailbox Settings / Screened Email
+    Address document hooks, so a caller doing several writes rebuilds the script once at the end
+    instead of after every write.
 
-	Use it around bulk writes, then call `build_automation_sieve` yourself once::
+    Use it around bulk writes, then call `build_automation_sieve` yourself once::
 
-	    with pause_automation_sieve_build():
-	            ...several saves...
-	    build_automation_sieve(account)
-	"""
+        with pause_automation_sieve_build():
+                ...several saves...
+        build_automation_sieve(account)
+    """
 
-	previous = frappe.flags.get("skip_automation_sieve_build")
-	frappe.flags.skip_automation_sieve_build = True
-	try:
-		yield
-	finally:
-		frappe.flags.skip_automation_sieve_build = previous
+    previous = frappe.flags.get("skip_automation_sieve_build")
+    frappe.flags.skip_automation_sieve_build = True
+    try:
+        yield
+    finally:
+        frappe.flags.skip_automation_sieve_build = previous
 
 
 def get_automation_script_name(account: str) -> str:
-	"""Returns the name of the automation sieve script for the given account. If it doesn't exist, it creates a new one."""
+    """Returns the name of the automation sieve script for the given account. If it doesn't exist, it creates a new one."""
 
-	scripts = SieveScript._fetch_sieve_scripts(account, {"name": AUTOMATION_SCRIPT_NAME}, limit=1)
-	if scripts and scripts[0]:
-		return scripts[0][0]["name"]
+    scripts = SieveScript._fetch_sieve_scripts(account, {"name": AUTOMATION_SCRIPT_NAME}, limit=1)
+    if scripts and scripts[0]:
+        return scripts[0][0]["name"]
 
-	frappe.flags.allow_automation_script_creation = True
-	script_id = SieveScript._add_sieve_script(
-		account, AUTOMATION_SCRIPT_NAME, content=AUTOMATION_SCRIPT_REQUIRE, active=False
-	)
+    frappe.flags.allow_automation_script_creation = True
+    script_id = SieveScript._add_sieve_script(
+        account, AUTOMATION_SCRIPT_NAME, content=AUTOMATION_SCRIPT_REQUIRE, active=False
+    )
 
-	return f"{account}|{script_id}"
+    return f"{account}|{script_id}"
 
 
 def _build_automation_content(account: str) -> str:
-	content = AUTOMATION_SCRIPT_REQUIRE + "\n"
+    content = AUTOMATION_SCRIPT_REQUIRE + "\n"
 
-	# Mailbox section: one block per mailbox that has automation rules in Mailbox Settings.
-	for mailbox in get_mailboxes(account):
-		rules = get_mailbox_automation_rules(account, mailbox["id"])
-		if not rules:
-			continue
+    # Mailbox section: one block per mailbox that has automation rules in Mailbox Settings.
+    for mailbox in get_mailboxes(account):
+        rules = get_mailbox_automation_rules(account, mailbox["id"])
+        if not rules:
+            continue
 
-		mailbox_path = get_mailbox_path(account, mailbox["_name"], raise_exception=True)
-		block = rule_object_to_sieve(rules, mailbox_path)
-		if block:
-			content = append_sieve_block(content, f"Mailbox: {mailbox['_name']}", block)
+        mailbox_path = get_mailbox_path(account, mailbox["_name"], raise_exception=True)
+        block = rule_object_to_sieve(rules, mailbox_path)
+        if block:
+            content = append_sieve_block(content, f"Mailbox: {mailbox['_name']}", block)
 
-	# Reject / Spam / Screening sections, layered on top of the mailbox rules.
-	content = _apply_screening_blocks(account, content)
+    # Reject / Spam / Screening sections, layered on top of the mailbox rules.
+    content = _apply_screening_blocks(account, content)
 
-	return content.rstrip() + "\n"
+    return content.rstrip() + "\n"
 
 
 def get_mailbox_automation_rules(account: str, mailbox_id: str) -> dict | None:
-	"""Return the persisted automation rules for a mailbox as a rule dict, or None if it has none.
+    """Return the persisted automation rules for a mailbox as a rule dict, or None if it has none.
 
-	This is the backup that the frappe_mail_automation Sieve script is generated from, so the script
-	can be rebuilt even if a third-party client deletes it. A mailbox is considered to have no
-	automation when neither a sender nor a subject condition is set.
-	"""
+    This is the backup that the frappe_mail_automation Sieve script is generated from, so the script
+    can be rebuilt even if a third-party client deletes it. A mailbox is considered to have no
+    automation when neither a sender nor a subject condition is set.
+    """
 
-	settings = get_mailbox_settings(account, mailbox_id, raise_exception=False)
-	if not settings or not (settings.emails_from or settings.subject_contains):
-		return None
+    settings = get_mailbox_settings(account, mailbox_id, raise_exception=False)
+    if not settings or not (settings.emails_from or settings.subject_contains):
+        return None
 
-	return {
-		"emails_from": settings.emails_from or "",
-		"subject_contains": settings.subject_contains or "",
-		"match_if": settings.match_if or "any",
-		"mark_as_read": bool(settings.mark_as_read),
-		"add_star": bool(settings.add_star),
-	}
+    return {
+        "emails_from": settings.emails_from or "",
+        "subject_contains": settings.subject_contains or "",
+        "match_if": settings.match_if or "any",
+        "mark_as_read": bool(settings.mark_as_read),
+        "add_star": bool(settings.add_star),
+    }
 
 
 def get_mailbox_path(account: str, mailbox_name: str, raise_exception: bool = False) -> str | None:
-	"""Returns the mailbox path for the given mailbox name in the given account."""
+    """Returns the mailbox path for the given mailbox name in the given account."""
 
-	mailboxes = get_mailboxes(account)
-	by_id = {mailbox["id"]: mailbox for mailbox in mailboxes}
-	by_name = {mailbox["_name"]: mailbox for mailbox in mailboxes}
+    mailboxes = get_mailboxes(account)
+    by_id = {mailbox["id"]: mailbox for mailbox in mailboxes}
+    by_name = {mailbox["_name"]: mailbox for mailbox in mailboxes}
 
-	if mailbox_name not in by_name:
-		if raise_exception:
-			frappe.throw(
-				_("Mailbox '{0}' not found in account '{1}'.").format(
-					frappe.bold(mailbox_name), frappe.bold(account)
-				),
-				title=_("Mailbox Not Found"),
-			)
-		return None
+    if mailbox_name not in by_name:
+        if raise_exception:
+            frappe.throw(
+                _("Mailbox '{0}' not found in account '{1}'.").format(
+                    frappe.bold(mailbox_name), frappe.bold(account)
+                ),
+                title=_("Mailbox Not Found"),
+            )
+        return None
 
-	path_parts = []
-	current = by_name[mailbox_name]
-	# Walk by id, not by name: JMAP only requires a name to be unique among siblings, so resolving
-	# the parent by name picked the wrong mailbox when two share a leaf name - and looped forever
-	# when a mailbox sat under a same-named parent. `seen` also guards a malformed parent chain.
-	seen = set()
+    path_parts = []
+    current = by_name[mailbox_name]
+    # Walk by id, not by name: JMAP only requires a name to be unique among siblings, so resolving
+    # the parent by name picked the wrong mailbox when two share a leaf name - and looped forever
+    # when a mailbox sat under a same-named parent. `seen` also guards a malformed parent chain.
+    seen = set()
 
-	while current:
-		if current["id"] in seen:
-			if raise_exception:
-				frappe.throw(
-					_("Mailbox '{0}' in account '{1}' has a circular parent chain.").format(
-						frappe.bold(mailbox_name), frappe.bold(account)
-					),
-					title=_("Invalid Mailbox Hierarchy"),
-				)
-			return None
+    while current:
+        if current["id"] in seen:
+            if raise_exception:
+                frappe.throw(
+                    _("Mailbox '{0}' in account '{1}' has a circular parent chain.").format(
+                        frappe.bold(mailbox_name), frappe.bold(account)
+                    ),
+                    title=_("Invalid Mailbox Hierarchy"),
+                )
+            return None
 
-		seen.add(current["id"])
-		path_parts.append(current["_name"])
+        seen.add(current["id"])
+        path_parts.append(current["_name"])
 
-		parent_id = current.get("parent_id")
-		if not parent_id:
-			break
+        parent_id = current.get("parent_id")
+        if not parent_id:
+            break
 
-		current = by_id.get(parent_id)
+        current = by_id.get(parent_id)
 
-		if current is None:
-			if raise_exception:
-				frappe.throw(
-					_("Parent mailbox with ID '{0}' not found in account '{1}'.").format(
-						frappe.bold(parent_id), frappe.bold(account)
-					),
-					title=_("Parent Mailbox Not Found"),
-				)
-			return None
+        if current is None:
+            if raise_exception:
+                frappe.throw(
+                    _("Parent mailbox with ID '{0}' not found in account '{1}'.").format(
+                        frappe.bold(parent_id), frappe.bold(account)
+                    ),
+                    title=_("Parent Mailbox Not Found"),
+                )
+            return None
 
-	return "/".join(reversed(path_parts))
+    return "/".join(reversed(path_parts))
 
 
 def rule_object_to_sieve(automation: dict, mailbox_path: str) -> str:
-	"""Converts automation rules to Sieve script format.
+    """Converts automation rules to Sieve script format.
 
-	Args:
-	        automation: Dictionary containing automation rules with keys:
-	                - emails_from: comma-separated email addresses
-	                - subject_contains: comma-separated keywords
-	                - mark_as_read: boolean
-	                - add_star: boolean
-	                - match_if: 'any' or 'all'
-	        mailbox_path: Full mailbox path to file emails into
+    Args:
+            automation: Dictionary containing automation rules with keys:
+                    - emails_from: comma-separated email addresses
+                    - subject_contains: comma-separated keywords
+                    - mark_as_read: boolean
+                    - add_star: boolean
+                    - match_if: 'any' or 'all'
+            mailbox_path: Full mailbox path to file emails into
 
-	Returns:
-	        Sieve script as a string
-	"""
+    Returns:
+            Sieve script as a string
+    """
 
-	emails_from = [
-		email.strip() for email in (automation.get("emails_from") or "").split(",") if email.strip()
-	]
-	subject_contains = [
-		keyword.strip()
-		for keyword in (automation.get("subject_contains") or "").split(",")
-		if keyword.strip()
-	]
+    emails_from = [
+        email.strip() for email in (automation.get("emails_from") or "").split(",") if email.strip()
+    ]
+    subject_contains = [
+        keyword.strip()
+        for keyword in (automation.get("subject_contains") or "").split(",")
+        if keyword.strip()
+    ]
 
-	if not emails_from and not subject_contains:
-		return ""
+    if not emails_from and not subject_contains:
+        return ""
 
-	script_parts = [""]
-	conditions = []
+    script_parts = [""]
+    conditions = []
 
-	if emails_from:
-		email_list = ", ".join(f'"{_escape_sieve_string(email)}"' for email in emails_from)
-		conditions.append(f'address :matches "from" [{email_list}]')
+    if emails_from:
+        email_list = ", ".join(f'"{_escape_sieve_string(email)}"' for email in emails_from)
+        conditions.append(f'address :matches "from" [{email_list}]')
 
-	if subject_contains:
-		keyword_list = ", ".join(f'"{_escape_sieve_string(keyword)}"' for keyword in subject_contains)
-		conditions.append(f'header :contains "subject" [{keyword_list}]')
+    if subject_contains:
+        keyword_list = ", ".join(f'"{_escape_sieve_string(keyword)}"' for keyword in subject_contains)
+        conditions.append(f'header :contains "subject" [{keyword_list}]')
 
-	match_if = automation.get("match_if", "any")
-	operator = "allof" if match_if == "all" else "anyof"
+    match_if = automation.get("match_if", "any")
+    operator = "allof" if match_if == "all" else "anyof"
 
-	if len(conditions) == 1:
-		script_parts.append(f"if {conditions[0]} {{")
-	else:
-		script_parts.append(f"if {operator} (")
-		for i, condition in enumerate(conditions):
-			if i < len(conditions) - 1:
-				script_parts.append(f"  {condition},")
-			else:
-				script_parts.append(f"  {condition}")
-		script_parts.append(") {")
+    if len(conditions) == 1:
+        script_parts.append(f"if {conditions[0]} {{")
+    else:
+        script_parts.append(f"if {operator} (")
+        for i, condition in enumerate(conditions):
+            if i < len(conditions) - 1:
+                script_parts.append(f"  {condition},")
+            else:
+                script_parts.append(f"  {condition}")
+        script_parts.append(") {")
 
-	if automation.get("mark_as_read"):
-		script_parts.append('  addflag "\\\\Seen";')
+    if automation.get("mark_as_read"):
+        script_parts.append('  addflag "\\\\Seen";')
 
-	if automation.get("add_star"):
-		script_parts.append('  addflag "\\\\Flagged";')
+    if automation.get("add_star"):
+        script_parts.append('  addflag "\\\\Flagged";')
 
-	script_parts.append(f'  fileinto "{mailbox_path}";')
-	script_parts.append("  stop;")
-	script_parts.append("}")
+    script_parts.append(f'  fileinto "{mailbox_path}";')
+    script_parts.append("  stop;")
+    script_parts.append("}")
 
-	return "\n".join(script_parts)
+    return "\n".join(script_parts)
 
 
 def append_sieve_block(script: str, block_name: str, sieve_block: str) -> str:
-	"""Append a labeled Sieve filter block to the script."""
+    """Append a labeled Sieve filter block to the script."""
 
-	return script.rstrip() + "\n" + f"\n# {block_name}{sieve_block}"
+    return script.rstrip() + "\n" + f"\n# {block_name}{sieve_block}"
 
 
 def _apply_screening_blocks(account: str, content: str) -> str:
-	"""Layer the Reject/Spam/Screening sieve blocks onto `content` and return the result.
+    """Layer the Reject/Spam/Screening sieve blocks onto `content` and return the result.
 
-	Rebuilt from the Screened Email Address list (+ JMAP Account) in one pass. The blocks are
-	ordered by precedence: Reject (discard) sits at the very top, right after `require`, so it wins
-	outright. The mailbox automation rules come next, so an explicit mailbox rule can still route mail.
-	Spam (file to Junk) and the Screening gate are fallbacks below the mailbox rules — Spam first, then
-	the catch-all Screening gate at the very bottom. The Screening gate routes accepted senders to the
-	Inbox, screens the rest unless the mail is classified as spam, and otherwise lets the server's
-	default filtering assign the mailbox (see `build_screening_gate`). The final order is
-	Reject → Mailbox → Spam → Screening. A sender has at most one screening rule — global rules
-	(Screened Email Address without an account) are overlaid by the account's own rule for the same
-	value — so the blocks never conflict.
-	"""
+    Rebuilt from the Screened Email Address list (+ JMAP Account) in one pass. The blocks are
+    ordered by precedence: Reject (discard) sits at the very top, right after `require`, so it wins
+    outright. The mailbox automation rules come next, so an explicit mailbox rule can still route mail.
+    Spam (file to Junk) and the Screening gate are fallbacks below the mailbox rules — Spam first, then
+    the catch-all Screening gate at the very bottom. The Screening gate routes accepted senders to the
+    Inbox, screens the rest unless the mail is classified as spam, and otherwise lets the server's
+    default filtering assign the mailbox (see `build_screening_gate`). The final order is
+    Reject → Mailbox → Spam → Screening. A sender has at most one screening rule — global rules
+    (Screened Email Address without an account) are overlaid by the account's own rule for the same
+    value — so the blocks never conflict.
+    """
 
-	content = (content or "").lstrip()
+    content = (content or "").lstrip()
 
-	# Remove any existing screening blocks, including the legacy block names from the pre-merge
-	# "Blocked Email Address" / "Junk Email Address" doctypes, so old scripts get cleaned up.
-	for name in ("Rejected Emails", "Spam Senders", "Screening", "Blocked Emails", "Junk Senders"):
-		content = remove_sieve_block(content, name)
+    # Remove any existing screening blocks, including the legacy block names from the pre-merge
+    # "Blocked Email Address" / "Junk Email Address" doctypes, so old scripts get cleaned up.
+    for name in ("Rejected Emails", "Spam Senders", "Screening", "Blocked Emails", "Junk Senders"):
+        content = remove_sieve_block(content, name)
 
-	screened = get_effective_screened_email_addresses(account)
-	reject_emails = [s.email for s in screened if s.action == "Reject"]
-	spam_emails = [s.email for s in screened if s.action == "Spam"]
-	accepted_emails = [s.email for s in screened if s.action == "Accepted"]
+    screened = get_effective_screened_email_addresses(account)
+    reject_emails = [s.email for s in screened if s.action == "Reject"]
+    spam_emails = [s.email for s in screened if s.action == "Spam"]
+    accepted_emails = [s.email for s in screened if s.action == "Accepted"]
 
-	# Reject is the most aggressive action and must win outright, so it sits at the very top — right
-	# after the require statement(s), above the mailbox rules.
-	reject_block = _build_screening_block("Rejected Emails", reject_emails, ["  discard;", "  stop;"])
-	if reject_block:
-		require_pattern = r"^(require\s+\[.*?\];\s*)+"
-		match = re.match(require_pattern, content, flags=re.DOTALL)
-		if match:
-			insert_pos = match.end()
-			content = content[:insert_pos] + "\n" + reject_block + content[insert_pos:]
-		else:
-			content = reject_block + content
+    # Reject is the most aggressive action and must win outright, so it sits at the very top — right
+    # after the require statement(s), above the mailbox rules.
+    reject_block = _build_screening_block("Rejected Emails", reject_emails, ["  discard;", "  stop;"])
+    if reject_block:
+        require_pattern = r"^(require\s+\[.*?\];\s*)+"
+        match = re.match(require_pattern, content, flags=re.DOTALL)
+        if match:
+            insert_pos = match.end()
+            content = content[:insert_pos] + "\n" + reject_block + content[insert_pos:]
+        else:
+            content = reject_block + content
 
-	# Spam goes below the mailbox rules (so an explicit mailbox rule can still claim the mail) but above
-	# the Screening gate.
-	if spam_emails:
-		junk_mailbox_path = get_junk_mailbox_path(account)
-		spam_block = _build_screening_block(
-			"Spam Senders",
-			spam_emails,
-			# Flag as junk ($junk keyword) as well as filing into Junk, so the mail is marked junk — not
-			# just located there — matching what marking a mail as junk does.
-			['  addflag "$junk";', f'  fileinto "{junk_mailbox_path}";', "  stop;"],
-		)
-		if spam_block:
-			content = content.rstrip() + "\n\n" + spam_block.rstrip() + "\n"
+    # Spam goes below the mailbox rules (so an explicit mailbox rule can still claim the mail) but above
+    # the Screening gate.
+    if spam_emails:
+        junk_mailbox_path = get_junk_mailbox_path(account)
+        spam_block = _build_screening_block(
+            "Spam Senders",
+            spam_emails,
+            # Flag as junk ($junk keyword) as well as filing into Junk, so the mail is marked junk — not
+            # just located there — matching what marking a mail as junk does.
+            ['  addflag "$junk";', f'  fileinto "{junk_mailbox_path}";', "  stop;"],
+        )
+        if spam_block:
+            content = content.rstrip() + "\n\n" + spam_block.rstrip() + "\n"
 
-	# Append the Screening gate last — the catch-all fallback, below every other block.
-	if is_screening_enabled(account):
-		gate = build_screening_gate(account, accepted_emails)
-		content = content.rstrip() + "\n\n" + gate.rstrip() + "\n"
+    # Append the Screening gate last — the catch-all fallback, below every other block.
+    if is_screening_enabled(account):
+        gate = build_screening_gate(account, accepted_emails)
+        content = content.rstrip() + "\n\n" + gate.rstrip() + "\n"
 
-	return content.rstrip() + "\n"
+    return content.rstrip() + "\n"
 
 
 def remove_sieve_block(script: str, block_name: str) -> str:
-	"""Remove an entire Sieve filter block, identified by its `# <block_name>` comment header.
+    """Remove an entire Sieve filter block, identified by its `# <block_name>` comment header.
 
-	A block runs from its header line up to the next block's `# ` header (or the end of the script), so
-	this removes blocks that contain more than one `stop;` — such as the Screening gate's `if`/`elsif` —
-	just as reliably as single-action blocks.
-	"""
+    A block runs from its header line up to the next block's `# ` header (or the end of the script), so
+    this removes blocks that contain more than one `stop;` — such as the Screening gate's `if`/`elsif` —
+    just as reliably as single-action blocks.
+    """
 
-	pattern = rf"^# {re.escape(block_name)}\n.*?(?=^# |\Z)"
-	result = re.sub(pattern, "", script, flags=re.DOTALL | re.MULTILINE)
-	result = re.sub(r"\n{3,}", "\n\n", result)
-	result = result.rstrip() + "\n"
+    pattern = rf"^# {re.escape(block_name)}\n.*?(?=^# |\Z)"
+    result = re.sub(pattern, "", script, flags=re.DOTALL | re.MULTILINE)
+    result = re.sub(r"\n{3,}", "\n\n", result)
+    result = result.rstrip() + "\n"
 
-	return result
+    return result
 
 
 def _escape_sieve_string(value: str) -> str:
-	"""Escape a value for embedding in a Sieve quoted string (RFC 5228): backslash then double-quote.
+    """Escape a value for embedding in a Sieve quoted string (RFC 5228): backslash then double-quote.
 
-	Line breaks are dropped as well, so a value carrying a newline cannot terminate the statement it
-	is embedded in.
-	"""
+    Line breaks are dropped as well, so a value carrying a newline cannot terminate the statement it
+    is embedded in.
+    """
 
-	value = value.replace("\r", "").replace("\n", "")
-	return value.replace("\\", "\\\\").replace('"', '\\"')
+    value = value.replace("\r", "").replace("\n", "")
+    return value.replace("\\", "\\\\").replace('"', '\\"')
 
 
 def _sender_match_condition(value: str) -> str | None:
-	"""Return the Sieve `address` test that matches a screened value, or None when it is blank.
+    """Return the Sieve `address` test that matches a screened value, or None when it is blank.
 
-	A `@domain` entry matches every sender from that domain (`address :domain :is "from" "example.com"`);
-	anything else is matched as a full address (`address :is "from" "john@example.com"`). Values are
-	escaped before being embedded so a stray quote or backslash can't corrupt the generated script.
-	"""
+    A `@domain` entry matches every sender from that domain (`address :domain :is "from" "example.com"`);
+    anything else is matched as a full address (`address :is "from" "john@example.com"`). Values are
+    escaped before being embedded so a stray quote or backslash can't corrupt the generated script.
+    """
 
-	from suite.mail.utils.validation import is_domain_entry
+    from suite.mail.utils.validation import is_domain_entry
 
-	value = (value or "").strip()
-	if not value:
-		return None
+    value = (value or "").strip()
+    if not value:
+        return None
 
-	if is_domain_entry(value):
-		domain = value[1:].strip()
-		return f'address :domain :is "from" "{_escape_sieve_string(domain)}"' if domain else None
+    if is_domain_entry(value):
+        domain = value[1:].strip()
+        return f'address :domain :is "from" "{_escape_sieve_string(domain)}"' if domain else None
 
-	return f'address :is "from" "{_escape_sieve_string(value)}"'
+    return f'address :is "from" "{_escape_sieve_string(value)}"'
 
 
 def _build_screening_block(block_name: str, emails: list[str], action_lines: list[str]) -> str:
-	"""Build a labeled sieve block matching the given senders and running `action_lines`.
+    """Build a labeled sieve block matching the given senders and running `action_lines`.
 
-	Returns an empty string when there are no senders to match.
-	"""
+    Returns an empty string when there are no senders to match.
+    """
 
-	conditions = [c for c in (_sender_match_condition(e) for e in emails) if c]
-	if not conditions:
-		return ""
+    conditions = [c for c in (_sender_match_condition(e) for e in emails) if c]
+    if not conditions:
+        return ""
 
-	if len(conditions) == 1:
-		condition_block = f"if {conditions[0]} {{"
-	else:
-		joined = ",\n  ".join(conditions)
-		condition_block = f"if anyof (\n  {joined}\n) {{"
+    if len(conditions) == 1:
+        condition_block = f"if {conditions[0]} {{"
+    else:
+        joined = ",\n  ".join(conditions)
+        condition_block = f"if anyof (\n  {joined}\n) {{"
 
-	return "\n".join([f"# {block_name}", condition_block, *action_lines, "}", "\n"])
+    return "\n".join([f"# {block_name}", condition_block, *action_lines, "}", "\n"])
 
 
 def get_junk_mailbox_path(account: str) -> str:
-	"""Return the mailbox path of the account's Junk mailbox (for sieve `fileinto`)."""
+    """Return the mailbox path of the account's Junk mailbox (for sieve `fileinto`)."""
 
-	mailbox_id = get_mailbox_id_by_role(account, "junk", create_if_not_exists=True, raise_exception=True)
-	mailbox_name = get_mailbox_name_by_id(account, mailbox_id, raise_exception=True)
+    mailbox_id = get_mailbox_id_by_role(account, "junk", create_if_not_exists=True, raise_exception=True)
+    mailbox_name = get_mailbox_name_by_id(account, mailbox_id, raise_exception=True)
 
-	return get_mailbox_path(account, mailbox_name, raise_exception=True)
+    return get_mailbox_path(account, mailbox_name, raise_exception=True)
 
 
 def get_inbox_mailbox_path(account: str) -> str:
-	"""Return the mailbox path of the account's Inbox mailbox (for sieve `fileinto`)."""
+    """Return the mailbox path of the account's Inbox mailbox (for sieve `fileinto`)."""
 
-	mailbox_id = get_mailbox_id_by_role(account, "inbox", create_if_not_exists=True, raise_exception=True)
-	mailbox_name = get_mailbox_name_by_id(account, mailbox_id, raise_exception=True)
+    mailbox_id = get_mailbox_id_by_role(account, "inbox", create_if_not_exists=True, raise_exception=True)
+    mailbox_name = get_mailbox_name_by_id(account, mailbox_id, raise_exception=True)
 
-	return get_mailbox_path(account, mailbox_name, raise_exception=True)
+    return get_mailbox_path(account, mailbox_name, raise_exception=True)
 
 
 def is_screening_enabled(account: str) -> bool:
-	"""Whether Hey-style screening is enabled for the account (JMAP Account.enable_screening)."""
+    """Whether Hey-style screening is enabled for the account (JMAP Account.enable_screening)."""
 
-	return bool(frappe.db.get_value("JMAP Account", account, "enable_screening"))
+    return bool(frappe.db.get_value("JMAP Account", account, "enable_screening"))
 
 
 def build_screening_gate(account: str, accepted_emails: list[str]) -> str:
-	"""Build the screening gate — the catch-all fallback that is the last block in the script.
+    """Build the screening gate — the catch-all fallback that is the last block in the script.
 
-	It routes mail that no earlier block (Reject, Spam, or a mailbox automation rule) already claimed:
+    It routes mail that no earlier block (Reject, Spam, or a mailbox automation rule) already claimed:
 
-	- Accepted senders — and the account's own identity emails, which are always trusted — are
-	  delivered straight to the Inbox, so accepted mail always reaches the inbox regardless of its
-	  spam score.
-	- Otherwise, mail the server has not classified as spam is filed into Screening.
-	- Otherwise (an unrecognised sender whose mail is classified as spam) nothing is done, so the
-	  server's default filtering assigns the mailbox (e.g. Junk once the spam score exceeds the
-	  configured threshold).
+    - Accepted senders — and the account's own identity emails, which are always trusted — are
+      delivered straight to the Inbox, so accepted mail always reaches the inbox regardless of its
+      spam score.
+    - Otherwise, mail the server has not classified as spam is filed into Screening.
+    - Otherwise (an unrecognised sender whose mail is classified as spam) nothing is done, so the
+      server's default filtering assigns the mailbox (e.g. Junk once the spam score exceeds the
+      configured threshold).
 
-	Spam classification is read with the `spamtest` extension (RFC 5235), not the `X-Spam-Status`
-	header: Stalwart injects the verdict into the Sieve runtime before the user's script runs, but only
-	stamps the header afterwards, so the header is not visible here. `spamtest` returns a 0-10 value
-	(Ham -> 1, Spam -> 10), so `:value "ge" "2"` treats anything above ham as spam.
-	"""
+    Spam classification is read with the `spamtest` extension (RFC 5235), not the `X-Spam-Status`
+    header: Stalwart injects the verdict into the Sieve runtime before the user's script runs, but only
+    stamps the header afterwards, so the header is not visible here. `spamtest` returns a 0-10 value
+    (Ham -> 1, Spam -> 10), so `:value "ge" "2"` treats anything above ham as spam.
+    """
 
-	screening_mailbox_path = get_screening_mailbox_path(account)
+    screening_mailbox_path = get_screening_mailbox_path(account)
 
-	try:
-		own_emails = get_account_emails(account)
-	except Exception:
-		own_emails = []
+    try:
+        own_emails = get_account_emails(account)
+    except Exception:
+        own_emails = []
 
-	trusted = list(dict.fromkeys(e.strip() for e in [*accepted_emails, *own_emails] if e and e.strip()))
+    trusted = list(dict.fromkeys(e.strip() for e in [*accepted_emails, *own_emails] if e and e.strip()))
 
-	# `accepted_emails` may hold `@domain` entries, so build one address test per trusted value (own
-	# identity emails are always plain addresses). Accepted mail is let through to the Inbox when the
-	# sender matches any trusted value, so the tests are OR-ed.
-	conditions = [c for c in (_sender_match_condition(e) for e in trusted) if c]
+    # `accepted_emails` may hold `@domain` entries, so build one address test per trusted value (own
+    # identity emails are always plain addresses). Accepted mail is let through to the Inbox when the
+    # sender matches any trusted value, so the tests are OR-ed.
+    conditions = [c for c in (_sender_match_condition(e) for e in trusted) if c]
 
-	if len(conditions) == 1:
-		accepted_test = conditions[0]
-	elif conditions:
-		joined = ",\n  ".join(conditions)
-		accepted_test = f"anyof (\n  {joined}\n)"
-	else:
-		accepted_test = None
+    if len(conditions) == 1:
+        accepted_test = conditions[0]
+    elif conditions:
+        joined = ",\n  ".join(conditions)
+        accepted_test = f"anyof (\n  {joined}\n)"
+    else:
+        accepted_test = None
 
-	# Mail the server has not classified as spam (spamtest value below 2, i.e. ham or unchecked) is
-	# screened; spam falls through to the server's default filtering.
-	not_spam_test = 'not spamtest :value "ge" :comparator "i;ascii-numeric" "2"'
+    # Mail the server has not classified as spam (spamtest value below 2, i.e. ham or unchecked) is
+    # screened; spam falls through to the server's default filtering.
+    not_spam_test = 'not spamtest :value "ge" :comparator "i;ascii-numeric" "2"'
 
-	lines = ["# Screening"]
-	if accepted_test:
-		# Resolve the Inbox path only when there is an accepted branch to file into — accounts with no
-		# trusted senders yet never reach it, so this avoids the extra lookups (and the risk of an inbox
-		# lookup/creation failure breaking a gate that does not even need the Inbox path).
-		inbox_mailbox_path = get_inbox_mailbox_path(account)
-		lines += [
-			f"if {accepted_test} {{",
-			f'  fileinto "{inbox_mailbox_path}";',
-			"  stop;",
-			"}",
-			f"elsif {not_spam_test} {{",
-		]
-	else:
-		# Nothing trusted yet → screen every non-spam sender (only reached after the Reject/Spam blocks).
-		lines.append(f"if {not_spam_test} {{")
+    lines = ["# Screening"]
+    if accepted_test:
+        # Resolve the Inbox path only when there is an accepted branch to file into — accounts with no
+        # trusted senders yet never reach it, so this avoids the extra lookups (and the risk of an inbox
+        # lookup/creation failure breaking a gate that does not even need the Inbox path).
+        inbox_mailbox_path = get_inbox_mailbox_path(account)
+        lines += [
+            f"if {accepted_test} {{",
+            f'  fileinto "{inbox_mailbox_path}";',
+            "  stop;",
+            "}",
+            f"elsif {not_spam_test} {{",
+        ]
+    else:
+        # Nothing trusted yet → screen every non-spam sender (only reached after the Reject/Spam blocks).
+        lines.append(f"if {not_spam_test} {{")
 
-	lines += [
-		f'  fileinto "{screening_mailbox_path}";',
-		"  stop;",
-		"}",
-		"\n",
-	]
+    lines += [
+        f'  fileinto "{screening_mailbox_path}";',
+        "  stop;",
+        "}",
+        "\n",
+    ]
 
-	return "\n".join(lines)
+    return "\n".join(lines)
 
 
 def get_screening_mailbox_path(account: str) -> str:
-	"""Return the mailbox path of the account's Screening mailbox, creating it if missing.
+    """Return the mailbox path of the account's Screening mailbox, creating it if missing.
 
-	Screening is not a standard JMAP role, so it is a plain named mailbox looked up by name.
-	"""
+    Screening is not a standard JMAP role, so it is a plain named mailbox looked up by name.
+    """
 
-	from suite.mail.doctype.mailbox.mailbox import add_mailbox
-	from suite.mail.jmap.services.core import CoreService
+    from suite.mail.doctype.mailbox.mailbox import add_mailbox
+    from suite.mail.jmap.services.core import CoreService
 
-	# The mailbox list lives in a per-process TTL cache, so a negative lookup can be stale — another
-	# worker may already have created the Screener. Refresh from the server before deciding to create,
-	# so we never try to recreate an existing mailbox (which JMAP rejects with "already exists").
-	CoreService.invalidate_cache(account, key="mailboxes")
-	if not get_mailbox_id_by_name(account, SCREENER_MAILBOX_NAME):
-		add_mailbox(account, SCREENER_MAILBOX_NAME)
-		CoreService.invalidate_cache(account, key="mailboxes")
+    # The mailbox list lives in a per-process TTL cache, so a negative lookup can be stale — another
+    # worker may already have created the Screener. Refresh from the server before deciding to create,
+    # so we never try to recreate an existing mailbox (which JMAP rejects with "already exists").
+    CoreService.invalidate_cache(account, key="mailboxes")
+    if not get_mailbox_id_by_name(account, SCREENER_MAILBOX_NAME):
+        add_mailbox(account, SCREENER_MAILBOX_NAME)
+        CoreService.invalidate_cache(account, key="mailboxes")
 
-	return get_mailbox_path(account, SCREENER_MAILBOX_NAME, raise_exception=True)
+    return get_mailbox_path(account, SCREENER_MAILBOX_NAME, raise_exception=True)

--- a/suite/mail/doctype/sieve_script/test_sieve_script.py
+++ b/suite/mail/doctype/sieve_script/test_sieve_script.py
@@ -12,85 +12,85 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestSieveScript(IntegrationTestCase):
-	"""
-	Integration tests for SieveScript.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for SieveScript.
+    Use this class for testing interactions between multiple components.
+    """
 
-	def test_sender_match_condition(self):
-		from suite.mail.doctype.sieve_script.sieve_script import _sender_match_condition
+    def test_sender_match_condition(self):
+        from suite.mail.doctype.sieve_script.sieve_script import _sender_match_condition
 
-		# A plain email matches the full From address.
-		self.assertEqual(
-			_sender_match_condition("john@example.com"),
-			'address :is "from" "john@example.com"',
-		)
-		# A '@domain' entry matches every sender from that domain via the :domain address part.
-		self.assertEqual(
-			_sender_match_condition("@example.com"),
-			'address :domain :is "from" "example.com"',
-		)
-		# Blank / bare '@' values produce no condition.
-		self.assertIsNone(_sender_match_condition(""))
-		self.assertIsNone(_sender_match_condition("   "))
-		self.assertIsNone(_sender_match_condition("@"))
+        # A plain email matches the full From address.
+        self.assertEqual(
+            _sender_match_condition("john@example.com"),
+            'address :is "from" "john@example.com"',
+        )
+        # A '@domain' entry matches every sender from that domain via the :domain address part.
+        self.assertEqual(
+            _sender_match_condition("@example.com"),
+            'address :domain :is "from" "example.com"',
+        )
+        # Blank / bare '@' values produce no condition.
+        self.assertIsNone(_sender_match_condition(""))
+        self.assertIsNone(_sender_match_condition("   "))
+        self.assertIsNone(_sender_match_condition("@"))
 
-	def test_build_screening_block_with_domain(self):
-		from suite.mail.doctype.sieve_script.sieve_script import _build_screening_block
+    def test_build_screening_block_with_domain(self):
+        from suite.mail.doctype.sieve_script.sieve_script import _build_screening_block
 
-		# A mix of an address and a domain OR-es both address tests inside a single anyof block.
-		block = _build_screening_block(
-			"Rejected Emails", ["spammer@bad.com", "@bad-domain.io"], ["  discard;", "  stop;"]
-		)
-		self.assertIn('address :is "from" "spammer@bad.com"', block)
-		self.assertIn('address :domain :is "from" "bad-domain.io"', block)
-		self.assertIn("if anyof (", block)
-		self.assertIn("# Rejected Emails", block)
+        # A mix of an address and a domain OR-es both address tests inside a single anyof block.
+        block = _build_screening_block(
+            "Rejected Emails", ["spammer@bad.com", "@bad-domain.io"], ["  discard;", "  stop;"]
+        )
+        self.assertIn('address :is "from" "spammer@bad.com"', block)
+        self.assertIn('address :domain :is "from" "bad-domain.io"', block)
+        self.assertIn("if anyof (", block)
+        self.assertIn("# Rejected Emails", block)
 
-	def test_remove_sieve_block_removes_multi_stop_block(self):
-		from suite.mail.doctype.sieve_script.sieve_script import remove_sieve_block
+    def test_remove_sieve_block_removes_multi_stop_block(self):
+        from suite.mail.doctype.sieve_script.sieve_script import remove_sieve_block
 
-		# The Screening gate is an if/elsif block with two `stop;` statements; removal must strip the
-		# whole thing, not just up to the first `stop;`.
-		script = (
-			'require ["fileinto"];\n\n'
-			"# Screening\n"
-			'if address :is "from" "boss@work.com" {\n'
-			'  fileinto "INBOX";\n'
-			"  stop;\n"
-			"}\n"
-			'elsif not spamtest :value "ge" :comparator "i;ascii-numeric" "2" {\n'
-			'  fileinto "Screener";\n'
-			"  stop;\n"
-			"}\n"
-		)
+        # The Screening gate is an if/elsif block with two `stop;` statements; removal must strip the
+        # whole thing, not just up to the first `stop;`.
+        script = (
+            'require ["fileinto"];\n\n'
+            "# Screening\n"
+            'if address :is "from" "boss@work.com" {\n'
+            '  fileinto "INBOX";\n'
+            "  stop;\n"
+            "}\n"
+            'elsif not spamtest :value "ge" :comparator "i;ascii-numeric" "2" {\n'
+            '  fileinto "Screener";\n'
+            "  stop;\n"
+            "}\n"
+        )
 
-		result = remove_sieve_block(script, "Screening")
+        result = remove_sieve_block(script, "Screening")
 
-		self.assertNotIn("# Screening", result)
-		self.assertNotIn("elsif", result)
-		self.assertNotIn("Screener", result)
-		self.assertIn('require ["fileinto"];', result)
+        self.assertNotIn("# Screening", result)
+        self.assertNotIn("elsif", result)
+        self.assertNotIn("Screener", result)
+        self.assertIn('require ["fileinto"];', result)
 
-	def test_remove_sieve_block_preserves_following_block(self):
-		from suite.mail.doctype.sieve_script.sieve_script import remove_sieve_block
+    def test_remove_sieve_block_preserves_following_block(self):
+        from suite.mail.doctype.sieve_script.sieve_script import remove_sieve_block
 
-		script = (
-			"# Rejected Emails\n"
-			'if address :is "from" "x@bad.com" {\n'
-			"  discard;\n"
-			"  stop;\n"
-			"}\n\n"
-			"# Mailbox: Work\n"
-			'if address :is "from" "team@work.com" {\n'
-			'  fileinto "Work";\n'
-			"  stop;\n"
-			"}\n"
-		)
+        script = (
+            "# Rejected Emails\n"
+            'if address :is "from" "x@bad.com" {\n'
+            "  discard;\n"
+            "  stop;\n"
+            "}\n\n"
+            "# Mailbox: Work\n"
+            'if address :is "from" "team@work.com" {\n'
+            '  fileinto "Work";\n'
+            "  stop;\n"
+            "}\n"
+        )
 
-		result = remove_sieve_block(script, "Rejected Emails")
+        result = remove_sieve_block(script, "Rejected Emails")
 
-		self.assertNotIn("# Rejected Emails", result)
-		self.assertNotIn("x@bad.com", result)
-		self.assertIn("# Mailbox: Work", result)
-		self.assertIn("team@work.com", result)
+        self.assertNotIn("# Rejected Emails", result)
+        self.assertNotIn("x@bad.com", result)
+        self.assertIn("# Mailbox: Work", result)
+        self.assertIn("team@work.com", result)

--- a/suite/mail/doctype/spam_check_log/spam_check_log.py
+++ b/suite/mail/doctype/spam_check_log/spam_check_log.py
@@ -17,150 +17,150 @@ from suite.mail.utils.dns import get_host_by_ip
 
 
 class SpamCheckLog(Document):
-	@staticmethod
-	def clear_old_logs(days=7) -> None:
-		log = frappe.qb.DocType("Spam Check Log")
-		frappe.db.delete(log, filters=(log.creation < get_datetime(add_to_date(now(), days=-days))))
+    @staticmethod
+    def clear_old_logs(days=7) -> None:
+        log = frappe.qb.DocType("Spam Check Log")
+        frappe.db.delete(log, filters=(log.creation < get_datetime(add_to_date(now(), days=-days))))
 
-	def autoname(self) -> None:
-		self.name = str(uuid7())
+    def autoname(self) -> None:
+        self.name = str(uuid7())
 
-	def validate(self) -> None:
-		if self.is_new():
-			self.set_source_ip_address()
-			self.set_source_host()
-			self.scan_message()
+    def validate(self) -> None:
+        if self.is_new():
+            self.set_source_ip_address()
+            self.set_source_host()
+            self.scan_message()
 
-	def set_source_ip_address(self) -> None:
-		"""Sets the source IP address"""
+    def set_source_ip_address(self) -> None:
+        """Sets the source IP address"""
 
-		self.source_ip_address = frappe.local.request_ip
+        self.source_ip_address = frappe.local.request_ip
 
-	def set_source_host(self) -> None:
-		"""Sets the source host"""
+    def set_source_host(self) -> None:
+        """Sets the source host"""
 
-		self.source_host = get_host_by_ip(self.source_ip_address)
+        self.source_host = get_host_by_ip(self.source_ip_address)
 
-	def scan_message(self) -> None:
-		"""Scans the message for spam"""
+    def scan_message(self) -> None:
+        """Scans the message for spam"""
 
-		config = get_config()
-		spamd_host = config.get("spamd_host")
-		spamd_port = config.get("spamd_port")
+        config = get_config()
+        spamd_host = config.get("spamd_host")
+        spamd_port = config.get("spamd_port")
 
-		if not all([spamd_host, spamd_port]):
-			frappe.throw(_("Configure SpamAssassin (spamd) host and port to enable spam detection."))
+        if not all([spamd_host, spamd_port]):
+            frappe.throw(_("Configure SpamAssassin (spamd) host and port to enable spam detection."))
 
-		scanning_mode = config.get("spamd_scanning_mode", "Hybrid Approach")
-		hybrid_scanning_threshold = config.get("spamd_hybrid_scanning_threshold", 2.0)
+        scanning_mode = config.get("spamd_scanning_mode", "Hybrid Approach")
+        hybrid_scanning_threshold = config.get("spamd_hybrid_scanning_threshold", 2.0)
 
-		response = None
-		self.started_at = now()
+        response = None
+        self.started_at = now()
 
-		if scanning_mode == "Hybrid Approach":
-			message_without_attachments = get_message_without_attachments(self.message)
-			initial_response = scan_message(spamd_host, spamd_port, message_without_attachments)
-			initial_spam_score = extract_spam_score(initial_response)
+        if scanning_mode == "Hybrid Approach":
+            message_without_attachments = get_message_without_attachments(self.message)
+            initial_response = scan_message(spamd_host, spamd_port, message_without_attachments)
+            initial_spam_score = extract_spam_score(initial_response)
 
-			if initial_spam_score < hybrid_scanning_threshold:
-				response = initial_response
+            if initial_spam_score < hybrid_scanning_threshold:
+                response = initial_response
 
-		elif scanning_mode == "Exclude Attachments":
-			self.message = get_message_without_attachments(self.message)
+        elif scanning_mode == "Exclude Attachments":
+            self.message = get_message_without_attachments(self.message)
 
-		response = response or scan_message(spamd_host, spamd_port, self.message)
-		self.spamd_response = response
-		self.scanning_mode = scanning_mode
-		self.hybrid_scanning_threshold = hybrid_scanning_threshold
-		self.spam_score = extract_spam_score(response)
-		self.completed_at = now()
-		self.duration = time_diff_in_seconds(self.completed_at, self.started_at)
+        response = response or scan_message(spamd_host, spamd_port, self.message)
+        self.spamd_response = response
+        self.scanning_mode = scanning_mode
+        self.hybrid_scanning_threshold = hybrid_scanning_threshold
+        self.spam_score = extract_spam_score(response)
+        self.completed_at = now()
+        self.duration = time_diff_in_seconds(self.completed_at, self.started_at)
 
 
 def create_spam_check_log(message: str) -> SpamCheckLog:
-	"""Creates a Spam Check Log document"""
+    """Creates a Spam Check Log document"""
 
-	doc = frappe.new_doc("Spam Check Log")
-	doc.message = message
-	doc.insert(ignore_permissions=True)
+    doc = frappe.new_doc("Spam Check Log")
+    doc.message = message
+    doc.insert(ignore_permissions=True)
 
-	return doc
+    return doc
 
 
 def get_message_without_attachments(message: str) -> str:
-	"""Returns the message without attachments"""
+    """Returns the message without attachments"""
 
-	parsed_message = message_from_string(message)
-	message_without_attachments = MIMEMultipart()
+    parsed_message = message_from_string(message)
+    message_without_attachments = MIMEMultipart()
 
-	for header, value in parsed_message.items():
-		message_without_attachments[header] = value
+    for header, value in parsed_message.items():
+        message_without_attachments[header] = value
 
-	for part in parsed_message.walk():
-		if part.get_content_maintype() == "multipart":
-			continue
-		if part.get("Content-Disposition") is None:
-			message_without_attachments.attach(part)
+    for part in parsed_message.walk():
+        if part.get_content_maintype() == "multipart":
+            continue
+        if part.get("Content-Disposition") is None:
+            message_without_attachments.attach(part)
 
-	return message_without_attachments.as_string()
+    return message_without_attachments.as_string()
 
 
 def scan_message(host: str, port: int, message: str) -> str:
-	"""Scans the message for spam"""
+    """Scans the message for spam"""
 
-	try:
-		with socket.create_connection((host, port), timeout=60) as sock:
-			sock.settimeout(get_config("scan_message_timeout"))
-			command = "SYMBOLS SPAMC/1.5\r\n\r\n"
-			sock.sendall(command.encode("utf-8"))
-			sock.sendall(message.encode("utf-8"))
-			sock.shutdown(socket.SHUT_WR)
+    try:
+        with socket.create_connection((host, port), timeout=60) as sock:
+            sock.settimeout(get_config("scan_message_timeout"))
+            command = "SYMBOLS SPAMC/1.5\r\n\r\n"
+            sock.sendall(command.encode("utf-8"))
+            sock.sendall(message.encode("utf-8"))
+            sock.shutdown(socket.SHUT_WR)
 
-			response = ""
-			while True:
-				try:
-					data = sock.recv(4096)
-					if not data:
-						break
-					response += data.decode("utf-8")
-				except TimeoutError:
-					frappe.throw(
-						_("Timed out waiting for response from SpamAssassin."),
-						title=_("Spam Detection Failed"),
-					)
+            response = ""
+            while True:
+                try:
+                    data = sock.recv(4096)
+                    if not data:
+                        break
+                    response += data.decode("utf-8")
+                except TimeoutError:
+                    frappe.throw(
+                        _("Timed out waiting for response from SpamAssassin."),
+                        title=_("Spam Detection Failed"),
+                    )
 
-	except ConnectionRefusedError:
-		frappe.throw(
-			_("Could not connect to SpamAssassin (spamd). Please ensure it's running on {0}:{1}").format(
-				host, port
-			),
-			title=_("Spam Detection Failed"),
-		)
+    except ConnectionRefusedError:
+        frappe.throw(
+            _("Could not connect to SpamAssassin (spamd). Please ensure it's running on {0}:{1}").format(
+                host, port
+            ),
+            title=_("Spam Detection Failed"),
+        )
 
-	if not response:
-		error_steps = [
-			_("1. Ensure the correct IP address is allowed to connect to SpamAssassin."),
-			_(
-				"2. Verify that the SpamAssassin service is running and accepting connections on port {0}."
-			).format(port),
-			_("3. Review SpamAssassin logs for any unauthorized connection attempts or permission errors."),
-		]
-		formatted_error_steps = "".join(f"<hr/>{step}" for step in error_steps)
-		frappe.throw(
-			_(
-				"SpamAssassin did not return the expected response. This may indicate a permission issue or an unauthorized connection. Please check the following: {0}"
-			).format(formatted_error_steps),
-			title=_("Spam Detection Failed"),
-			wide=True,
-		)
+    if not response:
+        error_steps = [
+            _("1. Ensure the correct IP address is allowed to connect to SpamAssassin."),
+            _(
+                "2. Verify that the SpamAssassin service is running and accepting connections on port {0}."
+            ).format(port),
+            _("3. Review SpamAssassin logs for any unauthorized connection attempts or permission errors."),
+        ]
+        formatted_error_steps = "".join(f"<hr/>{step}" for step in error_steps)
+        frappe.throw(
+            _(
+                "SpamAssassin did not return the expected response. This may indicate a permission issue or an unauthorized connection. Please check the following: {0}"
+            ).format(formatted_error_steps),
+            title=_("Spam Detection Failed"),
+            wide=True,
+        )
 
-	return response
+    return response
 
 
 def extract_spam_score(spamd_response: str) -> float:
-	"""Extracts the spam score from the spamd response"""
+    """Extracts the spam score from the spamd response"""
 
-	if match := re.search(r"Spam:.*?;\s*(-?\d+\.\d+)\s*/", spamd_response):
-		return float(match.group(1))
+    if match := re.search(r"Spam:.*?;\s*(-?\d+\.\d+)\s*/", spamd_response):
+        return float(match.group(1))
 
-	frappe.throw(_("Spam score not found in output."), title=_("Spam Detection Failed"))
+    frappe.throw(_("Spam score not found in output."), title=_("Spam Detection Failed"))

--- a/suite/mail/doctype/spam_check_log/test_spam_check_log.py
+++ b/suite/mail/doctype/spam_check_log/test_spam_check_log.py
@@ -6,4 +6,4 @@ from frappe.tests.utils import FrappeTestCase
 
 
 class TestSpamCheckLog(FrappeTestCase):
-	pass
+    pass

--- a/suite/mail/doctype/user_account/test_user_account.py
+++ b/suite/mail/doctype/user_account/test_user_account.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestUserAccount(IntegrationTestCase):
-	"""
-	Integration tests for UserAccount.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for UserAccount.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/user_account/user_account.py
+++ b/suite/mail/doctype/user_account/user_account.py
@@ -14,112 +14,112 @@ from suite.utils.user import is_administrator, is_system_manager
 
 
 class UserAccount(OwnerFromUser, Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		account: DF.Link
-		user: DF.Link
-		user_settings: DF.Link
-	# end: auto-generated types
+        account: DF.Link
+        user: DF.Link
+        user_settings: DF.Link
+    # end: auto-generated types
 
-	def autoname(self) -> None:
-		self.name = str(uuid7())
+    def autoname(self) -> None:
+        self.name = str(uuid7())
 
 
 @request_cache
 def get_user_for_jmap_account(
-	account: str, allow_system_manager: bool = True, raise_exception: bool = False
+    account: str, allow_system_manager: bool = True, raise_exception: bool = False
 ) -> str | None:
-	"""Returns the user for the given JMAP account ID. If no user is found, it returns None. If raise_exception is True, it raises an exception if the account does not belong to any user."""
+    """Returns the user for the given JMAP account ID. If no user is found, it returns None. If raise_exception is True, it raises an exception if the account does not belong to any user."""
 
-	if frappe.db.exists("JMAP Account", account):
-		account_users = frappe.db.get_all("User Account", {"account": account}, pluck="user")
+    if frappe.db.exists("JMAP Account", account):
+        account_users = frappe.db.get_all("User Account", {"account": account}, pluck="user")
 
-		if account_users:
-			user = frappe.session.user
+        if account_users:
+            user = frappe.session.user
 
-			if user in account_users:
-				return user
+            if user in account_users:
+                return user
 
-			elif is_administrator(user) or (allow_system_manager and is_system_manager(user)):
-				return account_users[0]
+            elif is_administrator(user) or (allow_system_manager and is_system_manager(user)):
+                return account_users[0]
 
-			elif raise_exception:
-				frappe.throw(
-					_("JMAP account {0} does not belong to the user {1}.").format(
-						frappe.bold(account), frappe.bold(user)
-					)
-				)
+            elif raise_exception:
+                frappe.throw(
+                    _("JMAP account {0} does not belong to the user {1}.").format(
+                        frappe.bold(account), frappe.bold(user)
+                    )
+                )
 
-		elif raise_exception:
-			frappe.throw(_("JMAP account {0} does not belong to any user.").format(frappe.bold(account)))
+        elif raise_exception:
+            frappe.throw(_("JMAP account {0} does not belong to any user.").format(frappe.bold(account)))
 
-	elif raise_exception:
-		frappe.throw(_("JMAP account {0} does not exist.").format(frappe.bold(account)))
+    elif raise_exception:
+        frappe.throw(_("JMAP account {0} does not exist.").format(frappe.bold(account)))
 
 
 @request_cache
 def get_user_jmap_accounts(user: str | None = None, raise_exception: bool = False) -> list[str]:
-	"""Returns the list of JMAP accounts for the given user. If no user is provided, it defaults to the current session user.
+    """Returns the list of JMAP accounts for the given user. If no user is provided, it defaults to the current session user.
 
-	Cached per request: the returned list is shared, so callers must treat it as read-only.
-	"""
+    Cached per request: the returned list is shared, so callers must treat it as read-only.
+    """
 
-	user = user or frappe.session.user
-	accounts = frappe.db.get_all("User Account", {"user": user}, pluck="account")
+    user = user or frappe.session.user
+    accounts = frappe.db.get_all("User Account", {"user": user}, pluck="account")
 
-	if not accounts and raise_exception:
-		frappe.throw(_("User {0} does not have any JMAP accounts configured.").format(frappe.bold(user)))
+    if not accounts and raise_exception:
+        frappe.throw(_("User {0} does not have any JMAP accounts configured.").format(frappe.bold(user)))
 
-	return accounts
+    return accounts
 
 
 def is_jmap_account_belongs_to_user(
-	account: str, user: str | None = None, raise_exception: bool = False
+    account: str, user: str | None = None, raise_exception: bool = False
 ) -> bool:
-	"""Checks if the given JMAP account ID belongs to the specified user. If no user is provided, it defaults to the current session user."""
+    """Checks if the given JMAP account ID belongs to the specified user. If no user is provided, it defaults to the current session user."""
 
-	user = user or frappe.session.user
-	exists = bool(frappe.db.exists("User Account", {"user": user, "account": account}))
+    user = user or frappe.session.user
+    exists = bool(frappe.db.exists("User Account", {"user": user, "account": account}))
 
-	if raise_exception and not exists:
-		frappe.throw(
-			_("JMAP account {0} does not belong to the user {1}.").format(
-				frappe.bold(account), frappe.bold(user)
-			)
-		)
+    if raise_exception and not exists:
+        frappe.throw(
+            _("JMAP account {0} does not belong to the user {1}.").format(
+                frappe.bold(account), frappe.bold(user)
+            )
+        )
 
-	return exists
+    return exists
 
 
 def get_user_personal_jmap_account(user: str | None = None, raise_exception: bool = False) -> str | None:
-	"""Returns the personal JMAP account ID for the given user. If no user is provided, it defaults to the current session user."""
+    """Returns the personal JMAP account ID for the given user. If no user is provided, it defaults to the current session user."""
 
-	user = user or frappe.session.user
-	user_accounts = get_user_jmap_accounts(user, raise_exception=raise_exception)
-	personal_accounts = frappe.db.get_all(
-		"JMAP Account", {"is_personal": True, "name": ("in", user_accounts)}, pluck="name"
-	)
+    user = user or frappe.session.user
+    user_accounts = get_user_jmap_accounts(user, raise_exception=raise_exception)
+    personal_accounts = frappe.db.get_all(
+        "JMAP Account", {"is_personal": True, "name": ("in", user_accounts)}, pluck="name"
+    )
 
-	if personal_accounts:
-		if len(personal_accounts) > 1:
-			if raise_exception:
-				frappe.throw(
-					_("User {0} has multiple personal JMAP accounts configured.").format(frappe.bold(user))
-				)
-		else:
-			return personal_accounts[0]
+    if personal_accounts:
+        if len(personal_accounts) > 1:
+            if raise_exception:
+                frappe.throw(
+                    _("User {0} has multiple personal JMAP accounts configured.").format(frappe.bold(user))
+                )
+        else:
+            return personal_accounts[0]
 
-	elif raise_exception:
-		frappe.throw(
-			_("User {0} does not have a personal JMAP account configured.").format(frappe.bold(user))
-		)
+    elif raise_exception:
+        frappe.throw(
+            _("User {0} does not have a personal JMAP account configured.").format(frappe.bold(user))
+        )
 
 
 def on_doctype_update() -> None:
-	frappe.db.add_unique("User Account", ["user", "account"], constraint_name="unique_user_account")
+    frappe.db.add_unique("User Account", ["user", "account"], constraint_name="unique_user_account")

--- a/suite/mail/doctype/user_settings/test_user_settings.py
+++ b/suite/mail/doctype/user_settings/test_user_settings.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestUserSettings(IntegrationTestCase):
-	"""
-	Integration tests for UserSettings.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for UserSettings.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/user_settings/user_settings.py
+++ b/suite/mail/doctype/user_settings/user_settings.py
@@ -18,125 +18,125 @@ from suite.utils.permissions import OwnerFromUser
 
 
 class UserSettings(OwnerFromUser, Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		app_password: DF.Password | None
-		backup_email: DF.Data | None
-		color_scheme: DF.Literal["System Default", "Light Mode", "Dark Mode"]
-		group_messages_by: DF.Literal["None", "Day", "Month"]
-		show_reading_pane: DF.Check
-		skip_schedule_fetch_changes: DF.Check
-		user: DF.Link
-		username: DF.Data | None
-	# end: auto-generated types
+        app_password: DF.Password | None
+        backup_email: DF.Data | None
+        color_scheme: DF.Literal["System Default", "Light Mode", "Dark Mode"]
+        group_messages_by: DF.Literal["None", "Day", "Month"]
+        show_reading_pane: DF.Check
+        skip_schedule_fetch_changes: DF.Check
+        user: DF.Link
+        username: DF.Data | None
+    # end: auto-generated types
 
-	@property
-	def server_url(self) -> str | None:
-		"""Returns the server URL from the configuration."""
+    @property
+    def server_url(self) -> str | None:
+        """Returns the server URL from the configuration."""
 
-		config = get_config()
-		return config.get("server_url")
+        config = get_config()
+        return config.get("server_url")
 
-	@cached_property
-	def session(self) -> dict:
-		"""Returns the JMAP session for the user."""
+    @cached_property
+    def session(self) -> dict:
+        """Returns the JMAP session for the user."""
 
-		return get_jmap_session_manager(self.user).get_session() or {}
+        return get_jmap_session_manager(self.user).get_session() or {}
 
-	@property
-	def session_state(self) -> str | None:
-		"""Returns the state of the JMAP session for the user."""
+    @property
+    def session_state(self) -> str | None:
+        """Returns the state of the JMAP session for the user."""
 
-		return self.session.get("state")
+        return self.session.get("state")
 
-	@property
-	def session_last_update(self) -> str | None:
-		"""Returns the last update timestamp of the JMAP session for the user in the user's timezone."""
+    @property
+    def session_last_update(self) -> str | None:
+        """Returns the last update timestamp of the JMAP session for the user in the user's timezone."""
 
-		timestamp = self.session.get("timestamp")
-		if timestamp:
-			return timestamp_to_datetime(timestamp, as_str=True)
+        timestamp = self.session.get("timestamp")
+        if timestamp:
+            return timestamp_to_datetime(timestamp, as_str=True)
 
-	@property
-	def jmap_session(self) -> str:
-		"""Returns the JMAP session for the user as a JSON string."""
+    @property
+    def jmap_session(self) -> str:
+        """Returns the JMAP session for the user as a JSON string."""
 
-		return json.dumps(self.session, indent=4)
+        return json.dumps(self.session, indent=4)
 
-	@property
-	def connection(self) -> JMAPConnection | None:
-		"""Returns a JMAP connection for the user if the username and app password are set, otherwise returns None."""
+    @property
+    def connection(self) -> JMAPConnection | None:
+        """Returns a JMAP connection for the user if the username and app password are set, otherwise returns None."""
 
-		if self.username and self.get_password("app_password"):
-			server_url, verify_ssl = get_config(("server_url", "verify_ssl"))
+        if self.username and self.get_password("app_password"):
+            server_url, verify_ssl = get_config(("server_url", "verify_ssl"))
 
-			try:
-				return JMAPConnection(
-					JMAPConnectionInfo(
-						server_url,
-						self.username,
-						self.get_password("app_password"),
-						verify_ssl=bool(verify_ssl),
-					)
-				)
-			except Exception:
-				pass
+            try:
+                return JMAPConnection(
+                    JMAPConnectionInfo(
+                        server_url,
+                        self.username,
+                        self.get_password("app_password"),
+                        verify_ssl=bool(verify_ssl),
+                    )
+                )
+            except Exception:
+                pass
 
-	def autoname(self) -> None:
-		self.name = str(uuid7())
+    def autoname(self) -> None:
+        self.name = str(uuid7())
 
-	def validate(self) -> None:
-		if not self.username or frappe.flags.in_migrate:
-			return
+    def validate(self) -> None:
+        if not self.username or frappe.flags.in_migrate:
+            return
 
-		self.validate_jmap_settings()
+        self.validate_jmap_settings()
 
-	def on_update(self) -> None:
-		if connection := self.connection:
-			sync_jmap_accounts(self.user, connection.accounts)
+    def on_update(self) -> None:
+        if connection := self.connection:
+            sync_jmap_accounts(self.user, connection.accounts)
 
-	def validate_jmap_settings(self) -> None:
-		"""Validate the JMAP settings by connecting to the JMAP server."""
+    def validate_jmap_settings(self) -> None:
+        """Validate the JMAP settings by connecting to the JMAP server."""
 
-		if not self.username or self.flags.skip_jmap_validation:
-			return
+        if not self.username or self.flags.skip_jmap_validation:
+            return
 
-		if not self.get_password("app_password"):
-			frappe.throw(_("App Password is required to validate JMAP settings."))
+        if not self.get_password("app_password"):
+            frappe.throw(_("App Password is required to validate JMAP settings."))
 
-		if not self.connection:
-			frappe.throw(
-				_(
-					"Unable to connect to the JMAP server with the provided username and app password. Please check your settings."
-				)
-			)
+        if not self.connection:
+            frappe.throw(
+                _(
+                    "Unable to connect to the JMAP server with the provided username and app password. Please check your settings."
+                )
+            )
 
-	@frappe.whitelist()
-	def clear_jmap_session(self) -> None:
-		"""Clears the JMAP session for the user."""
+    @frappe.whitelist()
+    def clear_jmap_session(self) -> None:
+        """Clears the JMAP session for the user."""
 
-		get_jmap_session_manager(self.user).clear_session()
+        get_jmap_session_manager(self.user).clear_session()
 
-	@frappe.whitelist()
-	def show_app_password(self) -> str:
-		"""Returns the app password of the user."""
+    @frappe.whitelist()
+    def show_app_password(self) -> str:
+        """Returns the app password of the user."""
 
-		frappe.only_for("Administrator")
-		return self.get_password("app_password")
+        frappe.only_for("Administrator")
+        return self.get_password("app_password")
 
-	def _db_set(
-		self,
-		update_modified: bool = True,
-		commit: bool = False,
-		notify: bool = False,
-		**kwargs,
-	) -> None:
-		"""Updates the document with the given key-value pairs."""
+    def _db_set(
+        self,
+        update_modified: bool = True,
+        commit: bool = False,
+        notify: bool = False,
+        **kwargs,
+    ) -> None:
+        """Updates the document with the given key-value pairs."""
 
-		self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
+        self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)

--- a/suite/mail/doctype/vacation_response/test_vacation_response.py
+++ b/suite/mail/doctype/vacation_response/test_vacation_response.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestVacationResponse(IntegrationTestCase):
-	"""
-	Integration tests for VacationResponse.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for VacationResponse.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/mail/doctype/vacation_response/vacation_response.py
+++ b/suite/mail/doctype/vacation_response/vacation_response.py
@@ -10,9 +10,9 @@ from frappe.utils import cint, today
 from frappe.utils.data import convert_utc_to_system_timezone, get_datetime
 
 from suite.mail.doctype.sieve_script.sieve_script import (
-	activate_last_active_sieve_script,
-	get_active_sieve_script_id,
-	set_last_active_sieve_script_id,
+    activate_last_active_sieve_script,
+    get_active_sieve_script_id,
+    set_last_active_sieve_script_id,
 )
 from suite.mail.doctype.user_account.user_account import get_user_for_jmap_account
 from suite.mail.jmap import get_vacation_response_service
@@ -21,145 +21,145 @@ from suite.utils.dt import convert_to_utc
 
 
 class VacationResponse(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		account: DF.Link | None
-		enabled: DF.Check
-		from_date: DF.Datetime | None
-		html_body: DF.TextEditor | None
-		subject: DF.Data | None
-		text_body: DF.Code | None
-		to_date: DF.Datetime | None
-		user: DF.Link | None
-	# end: auto-generated types
+        account: DF.Link | None
+        enabled: DF.Check
+        from_date: DF.Datetime | None
+        html_body: DF.TextEditor | None
+        subject: DF.Data | None
+        text_body: DF.Code | None
+        to_date: DF.Datetime | None
+        user: DF.Link | None
+    # end: auto-generated types
 
-	def db_insert(self, *args, **kwargs) -> None:
-		raise NotImplementedError
+    def db_insert(self, *args, **kwargs) -> None:
+        raise NotImplementedError
 
-	@frappe.whitelist()
-	def load_from_db(self) -> "VacationResponse":
-		if not self.get("account"):
-			frappe.msgprint(_("Please select an account to view vacation response details."), alert=True)
-			return super(Document, self).__init__({"creation": today(), "modified": today()})
+    @frappe.whitelist()
+    def load_from_db(self) -> "VacationResponse":
+        if not self.get("account"):
+            frappe.msgprint(_("Please select an account to view vacation response details."), alert=True)
+            return super(Document, self).__init__({"creation": today(), "modified": today()})
 
-		vr = get_vacation_response(self.account)
-		return super(Document, self).__init__(vr)
+        vr = get_vacation_response(self.account)
+        return super(Document, self).__init__(vr)
 
-	def on_update(self) -> None:
-		if not self.get("account"):
-			return
+    def on_update(self) -> None:
+        if not self.get("account"):
+            return
 
-		update_vacation_response(
-			self.account,
-			self.enabled,
-			self.from_date,
-			self.to_date,
-			self.subject,
-			self.text_body,
-			self.html_body,
-		)
-		self.reload()
+        update_vacation_response(
+            self.account,
+            self.enabled,
+            self.from_date,
+            self.to_date,
+            self.subject,
+            self.text_body,
+            self.html_body,
+        )
+        self.reload()
 
-	def delete(self) -> None:
-		pass
+    def delete(self) -> None:
+        pass
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs) -> list:
-		pass
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs) -> list:
+        pass
 
-	@staticmethod
-	def get_count(filters=None, **kwargs):
-		pass
+    @staticmethod
+    def get_count(filters=None, **kwargs):
+        pass
 
-	@staticmethod
-	def get_stats(**kwargs) -> dict:
-		return {}
+    @staticmethod
+    def get_stats(**kwargs) -> dict:
+        return {}
 
 
 @frappe.whitelist()
 def get_vacation_response(account: str) -> dict:
-	"""Returns the vacation response settings for the given account."""
+    """Returns the vacation response settings for the given account."""
 
-	service = get_vacation_response_service(account)
-	vr = service.get()
-	return format_vacation_response(account, vr)
+    service = get_vacation_response_service(account)
+    vr = service.get()
+    return format_vacation_response(account, vr)
 
 
 @frappe.whitelist()
 def update_vacation_response(
-	account: str,
-	enabled: bool | int,
-	from_date: datetime | str | None = None,
-	to_date: datetime | str | None = None,
-	subject: str | None = None,
-	text_body: str | None = None,
-	html_body: str | None = None,
+    account: str,
+    enabled: bool | int,
+    from_date: datetime | str | None = None,
+    to_date: datetime | str | None = None,
+    subject: str | None = None,
+    text_body: str | None = None,
+    html_body: str | None = None,
 ) -> None:
-	"""Updates the vacation response settings for the given account."""
+    """Updates the vacation response settings for the given account."""
 
-	enabled = bool(enabled)
-	from_date = convert_to_utc(from_date).isoformat() if from_date else None
-	to_date = convert_to_utc(to_date).isoformat() if to_date else None
+    enabled = bool(enabled)
+    from_date = convert_to_utc(from_date).isoformat() if from_date else None
+    to_date = convert_to_utc(to_date).isoformat() if to_date else None
 
-	if enabled and (from_date and to_date) and (from_date >= to_date):
-		frappe.throw(_("To Date must be after From Date."))
+    if enabled and (from_date and to_date) and (from_date >= to_date):
+        frappe.throw(_("To Date must be after From Date."))
 
-	if not convert_html_to_text(html_body):
-		html_body = None
+    if not convert_html_to_text(html_body):
+        html_body = None
 
-	current_active_sieve_script_id = get_active_sieve_script_id(account)
+    current_active_sieve_script_id = get_active_sieve_script_id(account)
 
-	service = get_vacation_response_service(account)
-	previous_vacation_response = service.get()
-	vacation_update_result = service.update(
-		{
-			"is_enabled": bool(enabled),
-			"from_date": from_date,
-			"to_date": to_date,
-			"subject": subject,
-			"text_body": text_body,
-			"html_body": html_body,
-		}
-	)
+    service = get_vacation_response_service(account)
+    previous_vacation_response = service.get()
+    vacation_update_result = service.update(
+        {
+            "is_enabled": bool(enabled),
+            "from_date": from_date,
+            "to_date": to_date,
+            "subject": subject,
+            "text_body": text_body,
+            "html_body": html_body,
+        }
+    )
 
-	if vacation_update_result.get("updated"):
-		if enabled:
-			if not previous_vacation_response.get("isEnabled"):
-				set_last_active_sieve_script_id(account, current_active_sieve_script_id)
-		else:
-			activate_last_active_sieve_script(account)
+    if vacation_update_result.get("updated"):
+        if enabled:
+            if not previous_vacation_response.get("isEnabled"):
+                set_last_active_sieve_script_id(account, current_active_sieve_script_id)
+        else:
+            activate_last_active_sieve_script(account)
 
 
 def format_vacation_response(account: str, vr: dict) -> dict:
-	"""Formats the vacation response data."""
+    """Formats the vacation response data."""
 
-	from_date = vr.get("fromDate", None)
-	local_from_date = convert_utc_to_system_timezone(get_datetime(from_date)) if from_date else None
+    from_date = vr.get("fromDate", None)
+    local_from_date = convert_utc_to_system_timezone(get_datetime(from_date)) if from_date else None
 
-	to_date = vr.get("toDate", None)
-	local_to_date = convert_utc_to_system_timezone(get_datetime(to_date)) if to_date else None
+    to_date = vr.get("toDate", None)
+    local_to_date = convert_utc_to_system_timezone(get_datetime(to_date)) if to_date else None
 
-	return {
-		"account": account,
-		"enabled": cint(vr.get("isEnabled")),
-		"from_date": local_from_date,
-		"to_date": local_to_date,
-		"subject": vr.get("subject"),
-		"text_body": vr.get("textBody"),
-		"html_body": vr.get("htmlBody"),
-		"creation": today(),
-		"modified": today(),
-	}
+    return {
+        "account": account,
+        "enabled": cint(vr.get("isEnabled")),
+        "from_date": local_from_date,
+        "to_date": local_to_date,
+        "subject": vr.get("subject"),
+        "text_body": vr.get("textBody"),
+        "html_body": vr.get("htmlBody"),
+        "creation": today(),
+        "modified": today(),
+    }
 
 
 def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
-	if doc.doctype != "Vacation Response" or not doc.get("account"):
-		return False
+    if doc.doctype != "Vacation Response" or not doc.get("account"):
+        return False
 
-	return bool(get_user_for_jmap_account(doc.account, raise_exception=False))
+    return bool(get_user_for_jmap_account(doc.account, raise_exception=False))

--- a/suite/mail/doctype/vacation_response/vacation_response.py
+++ b/suite/mail/doctype/vacation_response/vacation_response.py
@@ -43,7 +43,7 @@ class VacationResponse(Document):
         raise NotImplementedError
 
     @frappe.whitelist()
-    def load_from_db(self) -> "VacationResponse":
+    def load_from_db(self) -> VacationResponse:
         if not self.get("account"):
             frappe.msgprint(_("Please select an account to view vacation response details."), alert=True)
             return super(Document, self).__init__({"creation": today(), "modified": today()})
@@ -158,7 +158,7 @@ def format_vacation_response(account: str, vr: dict) -> dict:
     }
 
 
-def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
     if doc.doctype != "Vacation Response" or not doc.get("account"):
         return False
 

--- a/suite/mail/events.py
+++ b/suite/mail/events.py
@@ -16,177 +16,177 @@ from suite.utils import execute_with_logging
 
 
 def create_user_settings(doc: Document, method: str | None = None) -> None:
-	"""Create User Settings for the new user if not already present."""
+    """Create User Settings for the new user if not already present."""
 
-	if not frappe.db.exists("User Settings", {"user": doc.name}):
-		settings = frappe.new_doc("User Settings")
-		settings.user = doc.name
-		settings.insert(ignore_permissions=True, ignore_mandatory=True)
+    if not frappe.db.exists("User Settings", {"user": doc.name}):
+        settings = frappe.new_doc("User Settings")
+        settings.user = doc.name
+        settings.insert(ignore_permissions=True, ignore_mandatory=True)
 
 
 def delete_user_accounts(doc: Document, method: str | None = None) -> None:
-	"""Delete User Accounts when the user is deleted."""
+    """Delete User Accounts when the user is deleted."""
 
-	for account in frappe.db.get_all("User Account", filters={"user": doc.name}, pluck="name"):
-		frappe.delete_doc("User Account", account, ignore_permissions=True, delete_permanently=True)
+    for account in frappe.db.get_all("User Account", filters={"user": doc.name}, pluck="name"):
+        frappe.delete_doc("User Account", account, ignore_permissions=True, delete_permanently=True)
 
 
 def delete_user_settings(doc: Document, method: str | None = None) -> None:
-	"""Delete User Settings when the user is deleted."""
+    """Delete User Settings when the user is deleted."""
 
-	for settings in frappe.db.get_all("User Settings", filters={"user": doc.name}, pluck="name"):
-		frappe.delete_doc("User Settings", settings, ignore_permissions=True, delete_permanently=True)
+    for settings in frappe.db.get_all("User Settings", filters={"user": doc.name}, pluck="name"):
+        frappe.delete_doc("User Settings", settings, ignore_permissions=True, delete_permanently=True)
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
 def update_password(
-	new_password: str, logout_all_sessions: int = 0, key: str | None = None, old_password: str | None = None
+    new_password: str, logout_all_sessions: int = 0, key: str | None = None, old_password: str | None = None
 ) -> Any:
-	"""Override the default update_password whitelisted method to update the password on Stalwart server when the user updates their password."""
+    """Override the default update_password whitelisted method to update the password on Stalwart server when the user updates their password."""
 
-	frappe.flags.in_update_password = True
+    frappe.flags.in_update_password = True
 
-	if not is_stalwart_configured(raise_exception=False):
-		return update_frappe_password(
-			new_password=new_password,
-			logout_all_sessions=logout_all_sessions,
-			key=key,
-			old_password=old_password,
-		)
+    if not is_stalwart_configured(raise_exception=False):
+        return update_frappe_password(
+            new_password=new_password,
+            logout_all_sessions=logout_all_sessions,
+            key=key,
+            old_password=old_password,
+        )
 
-	result = _get_user_for_update_password(key, old_password)
-	user = result.get("user")
+    result = _get_user_for_update_password(key, old_password)
+    user = result.get("user")
 
-	result = update_frappe_password(
-		new_password=new_password, logout_all_sessions=logout_all_sessions, key=key, old_password=old_password
-	)
+    result = update_frappe_password(
+        new_password=new_password, logout_all_sessions=logout_all_sessions, key=key, old_password=old_password
+    )
 
-	if user and is_jmap_configured(user):
-		execute_with_logging(
-			lambda: update_stalwart_password(user, new_password=new_password),
-			title="Failed to update password on Stalwart server",
-			with_context=False,
-			module="Mail",
-		)
+    if user and is_jmap_configured(user):
+        execute_with_logging(
+            lambda: update_stalwart_password(user, new_password=new_password),
+            title="Failed to update password on Stalwart server",
+            with_context=False,
+            module="Mail",
+        )
 
-	return result
+    return result
 
 
 def update_account_password(doc: Document, method: str | None = None) -> None:
-	"""Updates the password on Stalwart server when the user updates their password."""
+    """Updates the password on Stalwart server when the user updates their password."""
 
-	if (
-		frappe.flags.in_update_password
-		or doc.flags.in_insert
-		or not doc.enabled
-		or not is_stalwart_configured(raise_exception=False)
-		or not is_jmap_configured(doc.name)
-	):
-		return
+    if (
+        frappe.flags.in_update_password
+        or doc.flags.in_insert
+        or not doc.enabled
+        or not is_stalwart_configured(raise_exception=False)
+        or not is_jmap_configured(doc.name)
+    ):
+        return
 
-	user = doc.name
-	new_password = doc._User__new_password
+    user = doc.name
+    new_password = doc._User__new_password
 
-	if not new_password:
-		return
+    if not new_password:
+        return
 
-	execute_with_logging(
-		lambda: update_stalwart_password(user, new_password=new_password),
-		title="Failed to update password on Stalwart server",
-		with_context=False,
-		module="Mail",
-	)
+    execute_with_logging(
+        lambda: update_stalwart_password(user, new_password=new_password),
+        title="Failed to update password on Stalwart server",
+        with_context=False,
+        module="Mail",
+    )
 
 
 def clear_sessions_on_disable(doc: Document, method: str | None = None) -> None:
-	"""Log the user out everywhere when they are disabled.
+    """Log the user out everywhere when they are disabled.
 
-	Clears both the user's Frappe sessions and their cached JMAP session so a disabled user
-	loses access immediately instead of continuing on an existing session until it expires.
-	"""
+    Clears both the user's Frappe sessions and their cached JMAP session so a disabled user
+    loses access immediately instead of continuing on an existing session until it expires.
+    """
 
-	if doc.flags.in_insert or doc.enabled or not doc.has_value_changed("enabled"):
-		return
+    if doc.flags.in_insert or doc.enabled or not doc.has_value_changed("enabled"):
+        return
 
-	from frappe.sessions import clear_sessions
+    from frappe.sessions import clear_sessions
 
-	from suite.mail.jmap import get_jmap_session_manager
+    from suite.mail.jmap import get_jmap_session_manager
 
-	clear_sessions(user=doc.name, force=True)
-	get_jmap_session_manager(doc.name).clear_session()
+    clear_sessions(user=doc.name, force=True)
+    get_jmap_session_manager(doc.name).clear_session()
 
 
 def apply_disabled_account_role(doc: Document, method: str | None = None) -> None:
-	"""Apply the configured Stalwart role to the user's mail account when the user is disabled.
+    """Apply the configured Stalwart role to the user's mail account when the user is disabled.
 
-	The role is created manually on Stalwart with the desired allowed/disabled permissions, so
-	applying it effectively restricts the disabled user's mail access. No-op if no role is configured.
-	"""
+    The role is created manually on Stalwart with the desired allowed/disabled permissions, so
+    applying it effectively restricts the disabled user's mail access. No-op if no role is configured.
+    """
 
-	if (
-		doc.flags.in_insert
-		or doc.enabled
-		or not doc.has_value_changed("enabled")
-		or not is_stalwart_configured(raise_exception=False)
-		or not is_jmap_configured(doc.name)
-	):
-		return
+    if (
+        doc.flags.in_insert
+        or doc.enabled
+        or not doc.has_value_changed("enabled")
+        or not is_stalwart_configured(raise_exception=False)
+        or not is_jmap_configured(doc.name)
+    ):
+        return
 
-	role = get_config("disabled_account_role")
-	if not role:
-		return
+    role = get_config("disabled_account_role")
+    if not role:
+        return
 
-	execute_with_logging(
-		lambda: add_stalwart_account_role(doc.name, role),
-		title="Failed to apply disabled account role on Stalwart server",
-		with_context=False,
-		module="Mail",
-	)
+    execute_with_logging(
+        lambda: add_stalwart_account_role(doc.name, role),
+        title="Failed to apply disabled account role on Stalwart server",
+        with_context=False,
+        module="Mail",
+    )
 
 
 def remove_disabled_account_role(doc: Document, method: str | None = None) -> None:
-	"""Remove the configured Stalwart disabled account role when the user is re-enabled.
+    """Remove the configured Stalwart disabled account role when the user is re-enabled.
 
-	This reverses apply_disabled_account_role so the user regains their mail access on enable.
-	No-op if no role is configured.
-	"""
+    This reverses apply_disabled_account_role so the user regains their mail access on enable.
+    No-op if no role is configured.
+    """
 
-	if (
-		doc.flags.in_insert
-		or not doc.enabled
-		or not doc.has_value_changed("enabled")
-		or not is_stalwart_configured(raise_exception=False)
-		or not is_jmap_configured(doc.name)
-	):
-		return
+    if (
+        doc.flags.in_insert
+        or not doc.enabled
+        or not doc.has_value_changed("enabled")
+        or not is_stalwart_configured(raise_exception=False)
+        or not is_jmap_configured(doc.name)
+    ):
+        return
 
-	role = get_config("disabled_account_role")
-	if not role:
-		return
+    role = get_config("disabled_account_role")
+    if not role:
+        return
 
-	execute_with_logging(
-		lambda: remove_stalwart_account_role(doc.name, role),
-		title="Failed to remove disabled account role on Stalwart server",
-		with_context=False,
-		module="Mail",
-	)
+    execute_with_logging(
+        lambda: remove_stalwart_account_role(doc.name, role),
+        title="Failed to remove disabled account role on Stalwart server",
+        with_context=False,
+        module="Mail",
+    )
 
 
 def delete_account(doc: Document, method: str | None = None) -> None:
-	if not is_stalwart_configured(raise_exception=False) or not is_jmap_configured(doc.name):
-		return
+    if not is_stalwart_configured(raise_exception=False) or not is_jmap_configured(doc.name):
+        return
 
-	user = doc.name
-	execute_with_logging(
-		lambda: delete_stalwart_account(user),
-		title="Failed to delete account on Stalwart server",
-		with_context=False,
-		module="Mail",
-	)
+    user = doc.name
+    execute_with_logging(
+        lambda: delete_stalwart_account(user),
+        title="Failed to delete account on Stalwart server",
+        with_context=False,
+        module="Mail",
+    )
 
-	# The cached JMAP session carries the account's ids. Left behind, a user recreated on the same
-	# address would inherit the deleted account's ids and every call would be scoped to an account
-	# the server no longer considers theirs.
-	from suite.mail.jmap import get_jmap_session_manager
+    # The cached JMAP session carries the account's ids. Left behind, a user recreated on the same
+    # address would inherit the deleted account's ids and every call would be scoped to an account
+    # the server no longer considers theirs.
+    from suite.mail.jmap import get_jmap_session_manager
 
-	get_jmap_session_manager(user).clear_session()
+    get_jmap_session_manager(user).clear_session()

--- a/suite/mail/install.py
+++ b/suite/mail/install.py
@@ -5,98 +5,98 @@ from suite.suite_core.doctype.rate_limit.rate_limit import create_rate_limit
 
 
 def after_install() -> None:
-	add_rate_limits()
-	create_new_folder("Frappe Mail", "Home")
-	generate_jmap_push_keys()
+    add_rate_limits()
+    create_new_folder("Frappe Mail", "Home")
+    generate_jmap_push_keys()
 
 
 def after_migrate() -> None:
-	pass
+    pass
 
 
 def add_rate_limits() -> None:
-	"""Add rate limits."""
+    """Add rate limits."""
 
-	rate_limits = [
-		# suite.mail.api.account
-		{"method_path": "suite.mail.api.account.signup", "limit": 5, "seconds": 60 * 60},
-		{"method_path": "suite.mail.api.account.resend_otp", "limit": 5, "seconds": 60 * 60},
-		{"method_path": "suite.mail.api.account.verify_otp", "limit": 5, "seconds": 60 * 60},
-		{"method_path": "suite.mail.api.account.get_account_request", "limit": 5, "seconds": 60 * 60},
-		{"method_path": "suite.mail.api.account.get_account_setup_options", "limit": 5, "seconds": 60 * 60},
-		{"method_path": "suite.mail.api.account.create_account", "limit": 10, "seconds": 60 * 60},
-		{"method_path": "suite.mail.api.account.send_reset_password_link", "limit": 5, "seconds": 60 * 60},
-		{"method_path": "suite.mail.api.account.validate_email_assigned", "limit": 10, "seconds": 60 * 60},
-		# suite.mail.api.admin
-		{"method_path": "suite.mail.api.admin.add_domain", "limit": 10, "seconds": 24 * 60 * 60},
-		{"method_path": "suite.mail.api.admin.add_member", "limit": 10, "seconds": 60 * 60},
-		{"method_path": "suite.mail.api.admin.add_group", "limit": 20, "seconds": 60 * 60},
-		{"method_path": "suite.mail.api.admin.add_mailing_list", "limit": 20, "seconds": 60 * 60},
-		{"method_path": "suite.mail.api.admin.add_role", "limit": 20, "seconds": 60 * 60},
-		{"method_path": "suite.mail.api.admin.add_oauth_client", "limit": 20, "seconds": 60 * 60},
-		# suite.mail.api.inbound
-		{"method_path": "suite.mail.api.inbound.fetch_blob", "limit": 60, "seconds": 60},
-		{"method_path": "suite.mail.api.inbound.pull", "limit": 10, "seconds": 60},
-		{"method_path": "suite.mail.api.inbound.pull_raw", "limit": 10, "seconds": 60},
-		# suite.mail.api.outbound
-		{"method_path": "suite.mail.api.outbound.upload_attachment", "limit": 60, "seconds": 60},
-		{"method_path": "suite.mail.api.outbound.send", "limit": 300, "seconds": 60},
-		{"method_path": "suite.mail.api.outbound.send_raw", "limit": 300, "seconds": 120},
-		# suite.mail.api.outbound — priority-based limits (per minute)
-		{
-			"method_path": "suite.mail.api.outbound.send",
-			"key": "priority",
-			"value": "Low",
-			"limit": 100,
-			"seconds": 60,
-		},
-		{
-			"method_path": "suite.mail.api.outbound.send",
-			"key": "priority",
-			"value": "Normal",
-			"limit": 50,
-			"seconds": 60,
-		},
-		{
-			"method_path": "suite.mail.api.outbound.send",
-			"key": "priority",
-			"value": "High",
-			"limit": 10,
-			"seconds": 60,
-		},
-		{
-			"method_path": "suite.mail.api.outbound.send_raw",
-			"key": "priority",
-			"value": "Low",
-			"limit": 100,
-			"seconds": 60,
-		},
-		{
-			"method_path": "suite.mail.api.outbound.send_raw",
-			"key": "priority",
-			"value": "Normal",
-			"limit": 50,
-			"seconds": 60,
-		},
-		{
-			"method_path": "suite.mail.api.outbound.send_raw",
-			"key": "priority",
-			"value": "High",
-			"limit": 10,
-			"seconds": 60,
-		},
-		# suite.mail.api.spamd
-		{"method_path": "suite.mail.api.spamd.scan", "limit": 60, "seconds": 60},
-		{"method_path": "suite.mail.api.spamd.get_spam_score", "limit": 60, "seconds": 60},
-	]
+    rate_limits = [
+        # suite.mail.api.account
+        {"method_path": "suite.mail.api.account.signup", "limit": 5, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.account.resend_otp", "limit": 5, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.account.verify_otp", "limit": 5, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.account.get_account_request", "limit": 5, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.account.get_account_setup_options", "limit": 5, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.account.create_account", "limit": 10, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.account.send_reset_password_link", "limit": 5, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.account.validate_email_assigned", "limit": 10, "seconds": 60 * 60},
+        # suite.mail.api.admin
+        {"method_path": "suite.mail.api.admin.add_domain", "limit": 10, "seconds": 24 * 60 * 60},
+        {"method_path": "suite.mail.api.admin.add_member", "limit": 10, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.admin.add_group", "limit": 20, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.admin.add_mailing_list", "limit": 20, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.admin.add_role", "limit": 20, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.admin.add_oauth_client", "limit": 20, "seconds": 60 * 60},
+        # suite.mail.api.inbound
+        {"method_path": "suite.mail.api.inbound.fetch_blob", "limit": 60, "seconds": 60},
+        {"method_path": "suite.mail.api.inbound.pull", "limit": 10, "seconds": 60},
+        {"method_path": "suite.mail.api.inbound.pull_raw", "limit": 10, "seconds": 60},
+        # suite.mail.api.outbound
+        {"method_path": "suite.mail.api.outbound.upload_attachment", "limit": 60, "seconds": 60},
+        {"method_path": "suite.mail.api.outbound.send", "limit": 300, "seconds": 60},
+        {"method_path": "suite.mail.api.outbound.send_raw", "limit": 300, "seconds": 120},
+        # suite.mail.api.outbound — priority-based limits (per minute)
+        {
+            "method_path": "suite.mail.api.outbound.send",
+            "key": "priority",
+            "value": "Low",
+            "limit": 100,
+            "seconds": 60,
+        },
+        {
+            "method_path": "suite.mail.api.outbound.send",
+            "key": "priority",
+            "value": "Normal",
+            "limit": 50,
+            "seconds": 60,
+        },
+        {
+            "method_path": "suite.mail.api.outbound.send",
+            "key": "priority",
+            "value": "High",
+            "limit": 10,
+            "seconds": 60,
+        },
+        {
+            "method_path": "suite.mail.api.outbound.send_raw",
+            "key": "priority",
+            "value": "Low",
+            "limit": 100,
+            "seconds": 60,
+        },
+        {
+            "method_path": "suite.mail.api.outbound.send_raw",
+            "key": "priority",
+            "value": "Normal",
+            "limit": 50,
+            "seconds": 60,
+        },
+        {
+            "method_path": "suite.mail.api.outbound.send_raw",
+            "key": "priority",
+            "value": "High",
+            "limit": 10,
+            "seconds": 60,
+        },
+        # suite.mail.api.spamd
+        {"method_path": "suite.mail.api.spamd.scan", "limit": 60, "seconds": 60},
+        {"method_path": "suite.mail.api.spamd.get_spam_score", "limit": 60, "seconds": 60},
+    ]
 
-	for rl in rate_limits:
-		create_rate_limit(**rl)
+    for rl in rate_limits:
+        create_rate_limit(**rl)
 
 
 def generate_jmap_push_keys() -> None:
-	"""Generates new JMAP push subscription encryption keys and saves them in Mail Settings."""
+    """Generates new JMAP push subscription encryption keys and saves them in Mail Settings."""
 
-	settings = frappe.get_single("Mail Settings")
-	if not settings.jmap_push_p256dh or not settings.jmap_push_private_key or not settings.jmap_push_auth:
-		settings._generate_jmap_push_keys()
+    settings = frappe.get_single("Mail Settings")
+    if not settings.jmap_push_p256dh or not settings.jmap_push_private_key or not settings.jmap_push_auth:
+        settings._generate_jmap_push_keys()

--- a/suite/mail/jmap/__init__.py
+++ b/suite/mail/jmap/__init__.py
@@ -33,461 +33,461 @@ from suite.utils.user import is_system_manager
 
 @request_cache
 def get_jmap_connection(
-	user: str, ignore_permissions: bool = False, timeout: tuple[float, float] = (30.0, 60.0)
+    user: str, ignore_permissions: bool = False, timeout: tuple[float, float] = (30.0, 60.0)
 ) -> JMAPConnection:
-	"""Returns a JMAPConnection instance for the specified user, using the user's settings for connection details.
+    """Returns a JMAPConnection instance for the specified user, using the user's settings for connection details.
 
-	Cached per request so the many service factories that resolve a connection for the same
-	user reuse one instance (and skip the repeated password decryption / session lookup).
-	"""
+    Cached per request so the many service factories that resolve a connection for the same
+    user reuse one instance (and skip the repeated password decryption / session lookup).
+    """
 
-	if not ignore_permissions:
-		if user != frappe.session.user and not is_system_manager(frappe.session.user):
-			frappe.throw(
-				_("You do not have permission to access the JMAPConnection for user {0}.").format(
-					frappe.bold(user)
-				),
-				frappe.PermissionError,
-			)
+    if not ignore_permissions:
+        if user != frappe.session.user and not is_system_manager(frappe.session.user):
+            frappe.throw(
+                _("You do not have permission to access the JMAPConnection for user {0}.").format(
+                    frappe.bold(user)
+                ),
+                frappe.PermissionError,
+            )
 
-	if not frappe.get_cached_value("User", user, "enabled"):
-		frappe.throw(_("User {0} does not exist or is disabled.").format(frappe.bold(user)))
+    if not frappe.get_cached_value("User", user, "enabled"):
+        frappe.throw(_("User {0} does not exist or is disabled.").format(frappe.bold(user)))
 
-	settings = frappe.db.exists("User Settings", {"user": user, "username": ["!=", None]})
-	if not settings:
-		frappe.throw(_("User {0} does not have JMAP settings configured.").format(frappe.bold(user)))
+    settings = frappe.db.exists("User Settings", {"user": user, "username": ["!=", None]})
+    if not settings:
+        frappe.throw(_("User {0} does not have JMAP settings configured.").format(frappe.bold(user)))
 
-	user_settings = frappe.get_cached_doc("User Settings", settings)
-	server_url, verify_ssl = get_config(("server_url", "verify_ssl"))
+    user_settings = frappe.get_cached_doc("User Settings", settings)
+    server_url, verify_ssl = get_config(("server_url", "verify_ssl"))
 
-	return JMAPConnection(
-		JMAPConnectionInfo(
-			server_url,
-			user_settings.username,
-			user_settings.get_password("app_password"),
-			timeout,
-			verify_ssl=bool(verify_ssl),
-		),
-		session_manager=get_jmap_session_manager(user),
-		user=user,
-	)
+    return JMAPConnection(
+        JMAPConnectionInfo(
+            server_url,
+            user_settings.username,
+            user_settings.get_password("app_password"),
+            timeout,
+            verify_ssl=bool(verify_ssl),
+        ),
+        session_manager=get_jmap_session_manager(user),
+        user=user,
+    )
 
 
 def get_jmap_session_manager(user) -> JMAPSessionManager:
-	"""Returns a JMAPSessionManager instance for the specified user, using the data store for session management."""
+    """Returns a JMAPSessionManager instance for the specified user, using the data store for session management."""
 
-	return JMAPSessionManager(
-		get_session=lambda: frappe.cache.hget("jmap:sessions", user),
-		set_session=lambda session: frappe.cache.hset("jmap:sessions", user, session),
-		clear_session=lambda: frappe.cache.hdel("jmap:sessions", user),
-	)
+    return JMAPSessionManager(
+        get_session=lambda: frappe.cache.hget("jmap:sessions", user),
+        set_session=lambda session: frappe.cache.hset("jmap:sessions", user, session),
+        clear_session=lambda: frappe.cache.hdel("jmap:sessions", user),
+    )
 
 
 def get_address_book_service(
-	account: str,
-	ignore_permissions: bool = False,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> AddressBookService:
-	"""Returns an instance of AddressBookService for the specified account."""
+    """Returns an instance of AddressBookService for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return AddressBookService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return AddressBookService(account, connection)
 
 
 def get_core_service(
-	account: str,
-	ignore_permissions: bool = False,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> CoreService:
-	"""Returns an instance of CoreService for the specified account."""
+    """Returns an instance of CoreService for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return CoreService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return CoreService(account, connection)
 
 
 def get_blob_service(
-	account: str,
-	ignore_permissions: bool = False,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> BlobService:
-	"""Returns an instance of BlobService for handling blob-related operations for the specified account."""
+    """Returns an instance of BlobService for handling blob-related operations for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return BlobService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return BlobService(account, connection)
 
 
 def get_calendar_event_notification_service(
-	account: str,
-	ignore_permissions: bool = False,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> CalendarEventNotificationService:
-	"""Returns an instance of CalendarEventNotificationService for handling calendar event notification-related operations for the specified account."""
+    """Returns an instance of CalendarEventNotificationService for handling calendar event notification-related operations for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return CalendarEventNotificationService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return CalendarEventNotificationService(account, connection)
 
 
 def get_calendar_event_service(
-	account: str,
-	ignore_permissions: bool = False,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> CalendarEventService:
-	"""Returns an instance of CalendarEventService for handling calendar event-related operations for the specified account."""
+    """Returns an instance of CalendarEventService for handling calendar event-related operations for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return CalendarEventService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return CalendarEventService(account, connection)
 
 
 def get_calendar_service(
-	account: str,
-	ignore_permissions: bool = False,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> CalendarService:
-	"""Returns an instance of CalendarService for handling calendar-related operations for the specified account."""
+    """Returns an instance of CalendarService for handling calendar-related operations for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return CalendarService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return CalendarService(account, connection)
 
 
 def get_contact_card_service(
-	account: str,
-	ignore_permissions: bool = False,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> ContactCardService:
-	"""Returns an instance of ContactCardService for handling contact card-related operations for the specified account."""
+    """Returns an instance of ContactCardService for handling contact card-related operations for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return ContactCardService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return ContactCardService(account, connection)
 
 
 def get_email_service(
-	account: str,
-	ignore_permissions: bool = False,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> EmailService:
-	"""Returns an instance of EmailService for handling email-related operations for the specified account."""
+    """Returns an instance of EmailService for handling email-related operations for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return EmailService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return EmailService(account, connection)
 
 
 def get_email_submission_service(
-	account: str,
-	ignore_permissions: bool = False,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> EmailSubmissionService:
-	"""Returns an instance of EmailSubmissionService for handling email submission-related operations for the specified account."""
+    """Returns an instance of EmailSubmissionService for handling email submission-related operations for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return EmailSubmissionService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return EmailSubmissionService(account, connection)
 
 
 def get_identity_service(
-	account: str,
-	ignore_permissions: bool = False,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> IdentityService:
-	"""Returns an instance of IdentityService for handling identity-related operations for the specified account."""
+    """Returns an instance of IdentityService for handling identity-related operations for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return IdentityService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return IdentityService(account, connection)
 
 
 def get_mailbox_service(
-	account: str,
-	ignore_permissions: bool = False,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> MailboxService:
-	"""Returns an instance of MailboxService for handling mailbox-related operations for the specified account."""
+    """Returns an instance of MailboxService for handling mailbox-related operations for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return MailboxService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return MailboxService(account, connection)
 
 
 def get_participant_identity_service(
-	account: str,
-	ignore_permissions: bool = False,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> ParticipantIdentityService:
-	"""Returns an instance of ParticipantIdentityService for handling participant identity-related operations for the specified account."""
+    """Returns an instance of ParticipantIdentityService for handling participant identity-related operations for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return ParticipantIdentityService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return ParticipantIdentityService(account, connection)
 
 
 def get_principal_service(
-	account: str,
-	ignore_permissions: bool = False,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> PrincipalService:
-	"""Returns an instance of PrincipalService for handling principal-related operations for the specified account."""
+    """Returns an instance of PrincipalService for handling principal-related operations for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return PrincipalService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return PrincipalService(account, connection)
 
 
 def get_push_subscription_service(
-	user: str,
-	ignore_permissions: bool = False,
+    user: str,
+    ignore_permissions: bool = False,
 ) -> PushSubscriptionService:
-	"""Returns an instance of PushSubscriptionService for handling push subscription-related operations for the specified user."""
+    """Returns an instance of PushSubscriptionService for handling push subscription-related operations for the specified user."""
 
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return PushSubscriptionService(connection)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return PushSubscriptionService(connection)
 
 
 def get_quota_service(
-	account: str,
-	ignore_permissions: bool = False,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> QuotaService:
-	"""Returns an instance of QuotaService for handling quota-related operations for the specified account."""
+    """Returns an instance of QuotaService for handling quota-related operations for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return QuotaService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return QuotaService(account, connection)
 
 
 def get_sieve_script_service(
-	account: str,
-	ignore_permissions: bool = False,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> SieveScriptService:
-	"""Returns an instance of SieveScriptService for handling sieve script-related operations for the specified account."""
+    """Returns an instance of SieveScriptService for handling sieve script-related operations for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return SieveScriptService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return SieveScriptService(account, connection)
 
 
 def get_thread_service(
-	account: str,
-	ignore_permissions: bool = False,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> ThreadService:
-	"""Returns an instance of ThreadService for handling thread-related operations for the specified account."""
+    """Returns an instance of ThreadService for handling thread-related operations for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return ThreadService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return ThreadService(account, connection)
 
 
 def get_vacation_response_service(
-	account: str,
-	ignore_permissions: bool = False,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> VacationResponseService:
-	"""Returns an instance of VacationResponseService for handling vacation response-related operations for the specified account."""
+    """Returns an instance of VacationResponseService for handling vacation response-related operations for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return VacationResponseService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return VacationResponseService(account, connection)
 
 
 def get_websocket_service(
-	account: str,
-	ignore_permissions: bool = False,
+    account: str,
+    ignore_permissions: bool = False,
 ) -> WebSocketService:
-	"""Returns an instance of WebSocketService for handling WebSocket-related operations for the specified account."""
+    """Returns an instance of WebSocketService for handling WebSocket-related operations for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
-	return WebSocketService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    return WebSocketService(account, connection)
 
 
 def invalidate_jmap_identities_cache(account: str) -> None:
-	"""Invalidates the JMAP identities cache for the specified account."""
+    """Invalidates the JMAP identities cache for the specified account."""
 
-	store = get_data_store(account)
-	store.delete_all(Entity.IDENTITY)
+    store = get_data_store(account)
+    store.delete_all(Entity.IDENTITY)
 
 
 def invalidate_jmap_mailboxes_cache(account: str) -> None:
-	"""Invalidates the JMAP mailboxes cache for the specified account."""
+    """Invalidates the JMAP mailboxes cache for the specified account."""
 
-	store = get_data_store(account)
-	store.delete_all(Entity.MAILBOX)
+    store = get_data_store(account)
+    store.delete_all(Entity.MAILBOX)
 
 
 def get_identities(account: str) -> list[dict]:
-	"""Returns the list of identities for the specified account."""
+    """Returns the list of identities for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user)
-	service = IdentityService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user)
+    service = IdentityService(account, connection)
 
-	identities = [
-		{
-			"name": f"{account}|{i['id']}",
-			"account": account,
-			"user": user,
-			"id": i["id"],
-			"_name": i["name"],
-			"email": i["email"].lower(),
-			"bcc": [{"display_name": b["name"], "email": b["email"].lower()} for b in i.get("bcc") or []],
-			"reply_to": [
-				{"display_name": r["name"], "email": r["email"].lower()} for r in i.get("replyTo") or []
-			],
-			"html_signature": i["htmlSignature"],
-			"text_signature": i["textSignature"],
-			"may_delete": cint(i["mayDelete"]),
-		}
-		for i in service.identities
-	]
+    identities = [
+        {
+            "name": f"{account}|{i['id']}",
+            "account": account,
+            "user": user,
+            "id": i["id"],
+            "_name": i["name"],
+            "email": i["email"].lower(),
+            "bcc": [{"display_name": b["name"], "email": b["email"].lower()} for b in i.get("bcc") or []],
+            "reply_to": [
+                {"display_name": r["name"], "email": r["email"].lower()} for r in i.get("replyTo") or []
+            ],
+            "html_signature": i["htmlSignature"],
+            "text_signature": i["textSignature"],
+            "may_delete": cint(i["mayDelete"]),
+        }
+        for i in service.identities
+    ]
 
-	return identities
+    return identities
 
 
 def get_identity_id_by_email(account: str, email: str, raise_exception: bool = False) -> str | None:
-	"""Returns the identity ID for the specified email address, or None if not found."""
+    """Returns the identity ID for the specified email address, or None if not found."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user)
-	service = IdentityService(account, connection)
-	return service.get_identity_id_by_email(email, raise_exception=raise_exception)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user)
+    service = IdentityService(account, connection)
+    return service.get_identity_id_by_email(email, raise_exception=raise_exception)
 
 
 def get_mailboxes(account: str) -> list[dict]:
-	"""Returns the list of mailboxes for the specified account."""
+    """Returns the list of mailboxes for the specified account."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user)
-	service = MailboxService(account, connection)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user)
+    service = MailboxService(account, connection)
 
-	mailboxes = [
-		{
-			"name": f"{account}|{m['id']}",
-			"account": account,
-			"user": user,
-			"id": m["id"],
-			"role": m["role"],
-			"_name": m["name"],
-			"_parent": f"{account}|{m['parentId']}" if m.get("parentId") else None,
-			"parent_id": m["parentId"],
-			"subscribed": m["isSubscribed"],
-		}
-		for m in service.mailboxes
-	]
+    mailboxes = [
+        {
+            "name": f"{account}|{m['id']}",
+            "account": account,
+            "user": user,
+            "id": m["id"],
+            "role": m["role"],
+            "_name": m["name"],
+            "_parent": f"{account}|{m['parentId']}" if m.get("parentId") else None,
+            "parent_id": m["parentId"],
+            "subscribed": m["isSubscribed"],
+        }
+        for m in service.mailboxes
+    ]
 
-	return mailboxes
+    return mailboxes
 
 
 def get_mailbox_id_by_role(
-	account: str,
-	role: str,
-	create_if_not_exists: bool = False,
-	raise_exception: bool = False,
+    account: str,
+    role: str,
+    create_if_not_exists: bool = False,
+    raise_exception: bool = False,
 ) -> str | None:
-	"""Returns the mailbox ID for the specified role, or None if not found. Optionally creates the mailbox if it does not exist."""
+    """Returns the mailbox ID for the specified role, or None if not found. Optionally creates the mailbox if it does not exist."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user)
-	service = MailboxService(account, connection)
-	return service.get_mailbox_id_by_role(
-		role, create_if_not_exists=create_if_not_exists, raise_exception=raise_exception
-	)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user)
+    service = MailboxService(account, connection)
+    return service.get_mailbox_id_by_role(
+        role, create_if_not_exists=create_if_not_exists, raise_exception=raise_exception
+    )
 
 
 def get_mailbox_role_by_id(account: str, id: str, raise_exception: bool = False) -> str | None:
-	"""Returns the mailbox role for the specified mailbox ID, or None if not found."""
+    """Returns the mailbox role for the specified mailbox ID, or None if not found."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user)
-	service = MailboxService(account, connection)
-	return service.get_mailbox_role_by_id(id, raise_exception=raise_exception)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user)
+    service = MailboxService(account, connection)
+    return service.get_mailbox_role_by_id(id, raise_exception=raise_exception)
 
 
 def get_mailbox_name_by_id(account: str, id: str, raise_exception: bool = False) -> str | None:
-	"""Returns the mailbox name for the specified mailbox ID, or None if not found."""
+    """Returns the mailbox name for the specified mailbox ID, or None if not found."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user)
-	service = MailboxService(account, connection)
-	return service.get_mailbox_name_by_id(id, raise_exception=raise_exception)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user)
+    service = MailboxService(account, connection)
+    return service.get_mailbox_name_by_id(id, raise_exception=raise_exception)
 
 
 def get_mailbox_id_by_name(account: str, name: str, raise_exception: bool = False) -> str | None:
-	"""Returns the mailbox ID for the specified mailbox name, or None if not found."""
+    """Returns the mailbox ID for the specified mailbox name, or None if not found."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user)
-	service = MailboxService(account, connection)
-	return service.get_mailbox_id_by_name(name, raise_exception=raise_exception)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user)
+    service = MailboxService(account, connection)
+    return service.get_mailbox_id_by_name(name, raise_exception=raise_exception)
 
 
 def get_default_address_book_id(account: str, raise_exception: bool = False) -> str | None:
-	"""Returns the ID of the default address book for the specified account, or None if not found."""
+    """Returns the ID of the default address book for the specified account, or None if not found."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user)
-	service = AddressBookService(account, connection)
-	return service.get_default(raise_exception=raise_exception)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user)
+    service = AddressBookService(account, connection)
+    return service.get_default(raise_exception=raise_exception)
 
 
 def get_default_calendar_id(account: str, raise_exception: bool = False) -> str | None:
-	"""Returns the ID of the default calendar for the specified account, or None if not found."""
+    """Returns the ID of the default calendar for the specified account, or None if not found."""
 
-	user = get_user_for_jmap_account(account, raise_exception=True)
-	connection = get_jmap_connection(user)
-	service = CalendarService(account, connection)
-	return service.get_default(raise_exception=raise_exception)
+    user = get_user_for_jmap_account(account, raise_exception=True)
+    connection = get_jmap_connection(user)
+    service = CalendarService(account, connection)
+    return service.get_default(raise_exception=raise_exception)
 
 
 @frappe.whitelist()
 def get_user_accounts(user: str) -> list[str]:
-	"""Returns a list of account names for the specified user."""
+    """Returns a list of account names for the specified user."""
 
-	if user != frappe.session.user and not is_system_manager(frappe.session.user):
-		frappe.throw(
-			_("Not permitted to view accounts for user {0}.").format(frappe.bold(user)),
-			frappe.PermissionError,
-		)
+    if user != frappe.session.user and not is_system_manager(frappe.session.user):
+        frappe.throw(
+            _("Not permitted to view accounts for user {0}.").format(frappe.bold(user)),
+            frappe.PermissionError,
+        )
 
-	from suite.mail.doctype.user_account.user_account import get_user_jmap_accounts
+    from suite.mail.doctype.user_account.user_account import get_user_jmap_accounts
 
-	return get_user_jmap_accounts(user)
+    return get_user_jmap_accounts(user)
 
 
 @frappe.whitelist()
 def get_user_account_ids(user: str) -> list[str]:
-	"""Returns the JMAP account IDs the specified user has access to."""
+    """Returns the JMAP account IDs the specified user has access to."""
 
-	if user != frappe.session.user and not is_system_manager(frappe.session.user):
-		frappe.throw(
-			_("Not permitted to view accounts for user {0}.").format(frappe.bold(user)),
-			frappe.PermissionError,
-		)
+    if user != frappe.session.user and not is_system_manager(frappe.session.user):
+        frappe.throw(
+            _("Not permitted to view accounts for user {0}.").format(frappe.bold(user)),
+            frappe.PermissionError,
+        )
 
-	from suite.mail.doctype.user_account.user_account import get_user_jmap_accounts
+    from suite.mail.doctype.user_account.user_account import get_user_jmap_accounts
 
-	return get_user_jmap_accounts(user)
+    return get_user_jmap_accounts(user)
 
 
 @frappe.whitelist()
 def get_mailboxes_for_account(account: str) -> list[dict]:
-	"""Returns the list of mailboxes for the specified account."""
+    """Returns the list of mailboxes for the specified account."""
 
-	return get_mailboxes(account)
+    return get_mailboxes(account)
 
 
 def format_jmap_error(error: dict | None) -> str:
-	"""Returns a readable message for a JMAP error object.
+    """Returns a readable message for a JMAP error object.
 
-	Only `type` is mandatory on a JMAP error object; `description` is optional and may be null,
-	so never index into it directly.
-	"""
+    Only `type` is mandatory on a JMAP error object; `description` is optional and may be null,
+    so never index into it directly.
+    """
 
-	error = error or {}
+    error = error or {}
 
-	return error.get("description") or error.get("type") or _("An unknown error occurred.")
+    return error.get("description") or error.get("type") or _("An unknown error occurred.")
 
 
 def get_jmap_set_error_message(response: dict, not_done_key: str, id: str) -> str:
-	"""Returns a readable message for a failed JMAP `set` call.
+    """Returns a readable message for a failed JMAP `set` call.
 
-	A `set` can fail per object (reported under `not_done_key`, keyed by the object id) or at the
-	method level (reported under `error`), and neither is guaranteed to be present — nor is the
-	per-object error guaranteed to be keyed by the id we asked about — so every source is probed
-	before falling back to a generic message.
-	"""
+    A `set` can fail per object (reported under `not_done_key`, keyed by the object id) or at the
+    method level (reported under `error`), and neither is guaranteed to be present — nor is the
+    per-object error guaranteed to be keyed by the id we asked about — so every source is probed
+    before falling back to a generic message.
+    """
 
-	not_done = response.get(not_done_key) or {}
-	error = not_done.get(id) or next(iter(not_done.values()), None) or response.get("error")
+    not_done = response.get(not_done_key) or {}
+    error = not_done.get(id) or next(iter(not_done.values()), None) or response.get("error")
 
-	return format_jmap_error(error)
+    return format_jmap_error(error)

--- a/suite/mail/jmap/connection.py
+++ b/suite/mail/jmap/connection.py
@@ -10,222 +10,222 @@ UNAVAILABLE_STATUS_CODES = (502, 503, 504)
 
 
 class MailServerUnavailableError(Exception):
-	"""The JMAP server could not be reached (connection refused, DNS failure, timeout) or an
-	upstream gateway reported it down.
+    """The JMAP server could not be reached (connection refused, DNS failure, timeout) or an
+    upstream gateway reported it down.
 
-	``http_status_code`` makes Frappe respond with 503 instead of a generic 500, so clients can
-	distinguish "the mail server is temporarily down" from an application bug and show a friendly
-	message. The original ``requests`` exception is always chained for diagnosis.
-	"""
+    ``http_status_code`` makes Frappe respond with 503 instead of a generic 500, so clients can
+    distinguish "the mail server is temporarily down" from an application bug and show a friendly
+    message. The original ``requests`` exception is always chained for diagnosis.
+    """
 
-	http_status_code = 503
+    http_status_code = 503
 
-	def __init__(self, message: str = "The mail server is temporarily unavailable.") -> None:
-		super().__init__(message)
+    def __init__(self, message: str = "The mail server is temporarily unavailable.") -> None:
+        super().__init__(message)
 
 
 @dataclass
 class JMAPConnectionInfo:
-	"""
-	Data class for storing JMAP connection information.
+    """
+    Data class for storing JMAP connection information.
 
-	Properties:
-	- url: The base URL of the JMAP server.
-	- username: The username for authentication.
-	- password: The password for authentication.
-	- timeout: A tuple specifying the connection and read timeouts for requests (default: (30.0, 60.0)).
-	- verify_ssl: Whether to verify the server's SSL certificate (default: True). Disable only for local
-	  development against a server with a self-signed certificate.
-	"""
+    Properties:
+    - url: The base URL of the JMAP server.
+    - username: The username for authentication.
+    - password: The password for authentication.
+    - timeout: A tuple specifying the connection and read timeouts for requests (default: (30.0, 60.0)).
+    - verify_ssl: Whether to verify the server's SSL certificate (default: True). Disable only for local
+      development against a server with a self-signed certificate.
+    """
 
-	url: str
-	username: str
-	password: str
-	timeout: tuple[float, float] = (30.0, 60.0)
-	verify_ssl: bool = True
+    url: str
+    username: str
+    password: str
+    timeout: tuple[float, float] = (30.0, 60.0)
+    verify_ssl: bool = True
 
 
 class JMAPSessionManager:
-	"""Manages the JMAP session information, allowing for retrieval, storage, and clearing of session data."""
+    """Manages the JMAP session information, allowing for retrieval, storage, and clearing of session data."""
 
-	def __init__(self, get_session: callable, set_session: callable, clear_session: callable) -> None:
-		"""Initializes the SessionManager with the provided functions for getting, setting, and clearing session data."""
+    def __init__(self, get_session: callable, set_session: callable, clear_session: callable) -> None:
+        """Initializes the SessionManager with the provided functions for getting, setting, and clearing session data."""
 
-		if not callable(get_session) or not callable(set_session) or not callable(clear_session):
-			raise ValueError("All parameters must be callable functions.")
+        if not callable(get_session) or not callable(set_session) or not callable(clear_session):
+            raise ValueError("All parameters must be callable functions.")
 
-		self._get_session = get_session
-		self._set_session = set_session
-		self._clear_session = clear_session
+        self._get_session = get_session
+        self._set_session = set_session
+        self._clear_session = clear_session
 
-	def get_session(self) -> Any | None:
-		"""Retrieves the current session data, if available."""
+    def get_session(self) -> Any | None:
+        """Retrieves the current session data, if available."""
 
-		return self._get_session()
+        return self._get_session()
 
-	def set_session(self, session: dict) -> None:
-		"""Sets the session data."""
+    def set_session(self, session: dict) -> None:
+        """Sets the session data."""
 
-		self._set_session(session)
+        self._set_session(session)
 
-	def clear_session(self) -> None:
-		"""Clears the session data."""
+    def clear_session(self) -> None:
+        """Clears the session data."""
 
-		self._clear_session()
+        self._clear_session()
 
 
 class JMAPConnection:
-	"""Manages the connection to a JMAP server, including discovery of server capabilities and sending requests."""
+    """Manages the connection to a JMAP server, including discovery of server capabilities and sending requests."""
 
-	def __init__(
-		self,
-		info: JMAPConnectionInfo,
-		session_manager: JMAPSessionManager | None = None,
-		user: str | None = None,
-	) -> None:
-		"""Initializes the JMAPConnection with the provided connection information.
+    def __init__(
+        self,
+        info: JMAPConnectionInfo,
+        session_manager: JMAPSessionManager | None = None,
+        user: str | None = None,
+    ) -> None:
+        """Initializes the JMAPConnection with the provided connection information.
 
-		``user`` is the Frappe user the connection is authenticated as, retained so callers can
-		resync per-user state (e.g. JMAP Accounts) when the server session state changes.
-		"""
+        ``user`` is the Frappe user the connection is authenticated as, retained so callers can
+        resync per-user state (e.g. JMAP Accounts) when the server session state changes.
+        """
 
-		self.__info = info
-		self.__session = requests.Session()
-		self.__session.auth = (self.__info.username, self.__info.password)
-		self.__session.verify = self.__info.verify_ssl
-		self.__session_manager = session_manager
-		self.user = user
+        self.__info = info
+        self.__session = requests.Session()
+        self.__session.auth = (self.__info.username, self.__info.password)
+        self.__session.verify = self.__info.verify_ssl
+        self.__session_manager = session_manager
+        self.user = user
 
-		self._initialize_session()
+        self._initialize_session()
 
-	def _initialize_session(self) -> dict:
-		"""Initializes the session by attempting to retrieve it from the session manager or performing session discovery."""
+    def _initialize_session(self) -> dict:
+        """Initializes the session by attempting to retrieve it from the session manager or performing session discovery."""
 
-		if self.__session_manager:
-			session = self.__session_manager.get_session()
-			if session:
-				self.session = session
-				return
+        if self.__session_manager:
+            session = self.__session_manager.get_session()
+            if session:
+                self.session = session
+                return
 
-		self._session_discovery()
+        self._session_discovery()
 
-	def _session_discovery(self) -> None:
-		"""Performs session discovery by sending a GET request to the JMAP server's well-known URL and storing the session information."""
+    def _session_discovery(self) -> None:
+        """Performs session discovery by sending a GET request to the JMAP server's well-known URL and storing the session information."""
 
-		url = urljoin(self.__info.url, "/.well-known/jmap")
-		try:
-			response = self.__session.get(
-				url, headers={"Accept": "application/json"}, timeout=self.__info.timeout
-			)
-		except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
-			raise MailServerUnavailableError() from e
-		raise_for_status(response)
+        url = urljoin(self.__info.url, "/.well-known/jmap")
+        try:
+            response = self.__session.get(
+                url, headers={"Accept": "application/json"}, timeout=self.__info.timeout
+            )
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+            raise MailServerUnavailableError() from e
+        raise_for_status(response)
 
-		self.session = response.json()
-		self.session["timestamp"] = time.time()
+        self.session = response.json()
+        self.session["timestamp"] = time.time()
 
-		if self.__session_manager:
-			self.__session_manager.set_session(self.session)
+        if self.__session_manager:
+            self.__session_manager.set_session(self.session)
 
-	@property
-	def capabilities(self) -> dict:
-		"""Returns the capabilities of the JMAP server."""
+    @property
+    def capabilities(self) -> dict:
+        """Returns the capabilities of the JMAP server."""
 
-		return self.session["capabilities"]
+        return self.session["capabilities"]
 
-	@property
-	def api_url(self) -> str:
-		"""Returns the API URL of the JMAP server."""
+    @property
+    def api_url(self) -> str:
+        """Returns the API URL of the JMAP server."""
 
-		return self.session["apiUrl"]
+        return self.session["apiUrl"]
 
-	@property
-	def accounts(self) -> dict:
-		"""Returns the accounts for the logged-in user."""
+    @property
+    def accounts(self) -> dict:
+        """Returns the accounts for the logged-in user."""
 
-		return self.session["accounts"]
+        return self.session["accounts"]
 
-	@property
-	def primary_accounts(self) -> dict:
-		"""Returns the primary accounts for the logged-in user."""
+    @property
+    def primary_accounts(self) -> dict:
+        """Returns the primary accounts for the logged-in user."""
 
-		return self.session["primaryAccounts"]
+        return self.session["primaryAccounts"]
 
-	@property
-	def download_url(self) -> str:
-		"""Returns the download URL for the JMAP server."""
+    @property
+    def download_url(self) -> str:
+        """Returns the download URL for the JMAP server."""
 
-		return self.session["downloadUrl"]
+        return self.session["downloadUrl"]
 
-	@property
-	def upload_url(self) -> str:
-		"""Returns the upload URL for the JMAP server."""
+    @property
+    def upload_url(self) -> str:
+        """Returns the upload URL for the JMAP server."""
 
-		return self.session["uploadUrl"]
+        return self.session["uploadUrl"]
 
-	@property
-	def event_source_url(self) -> str:
-		"""Returns the event source URL for the JMAP server."""
+    @property
+    def event_source_url(self) -> str:
+        """Returns the event source URL for the JMAP server."""
 
-		return self.session["eventSourceUrl"]
+        return self.session["eventSourceUrl"]
 
-	@property
-	def state(self) -> str:
-		"""Returns the state of the JMAP server."""
+    @property
+    def state(self) -> str:
+        """Returns the state of the JMAP server."""
 
-		return self.session["state"]
+        return self.session["state"]
 
-	def request(
-		self,
-		method: str,
-		url: str,
-		*,
-		headers: dict | None = None,
-		json: dict | None = None,
-		data: bytes | str | None = None,
-		params: dict | None = None,
-		timeout: float | None = None,
-		return_json: bool = True,
-		**kwargs,
-	) -> dict | bytes:
-		"""Sends a request to the JMAP server with the specified parameters, and returns the response."""
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict | None = None,
+        json: dict | None = None,
+        data: bytes | str | None = None,
+        params: dict | None = None,
+        timeout: float | None = None,
+        return_json: bool = True,
+        **kwargs,
+    ) -> dict | bytes:
+        """Sends a request to the JMAP server with the specified parameters, and returns the response."""
 
-		headers = headers or {}
-		try:
-			response = self.__session.request(
-				method=method,
-				url=url,
-				headers=headers,
-				json=json,
-				data=data,
-				params=params,
-				timeout=timeout or self.__info.timeout,
-				**kwargs,
-			)
-		except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
-			raise MailServerUnavailableError() from e
+        headers = headers or {}
+        try:
+            response = self.__session.request(
+                method=method,
+                url=url,
+                headers=headers,
+                json=json,
+                data=data,
+                params=params,
+                timeout=timeout or self.__info.timeout,
+                **kwargs,
+            )
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+            raise MailServerUnavailableError() from e
 
-		raise_for_status(response)
+        raise_for_status(response)
 
-		if return_json:
-			return response.json()
+        if return_json:
+            return response.json()
 
-		return response.content
+        return response.content
 
 
 def raise_for_status(response: requests.Response) -> None:
-	"""Raises an HTTPError if the response status code indicates an error.
+    """Raises an HTTPError if the response status code indicates an error.
 
-	Gateway errors (502/503/504) mean the JMAP server behind a reverse proxy is down, not that
-	the request itself was bad, so they surface as MailServerUnavailableError instead.
-	"""
+    Gateway errors (502/503/504) mean the JMAP server behind a reverse proxy is down, not that
+    the request itself was bad, so they surface as MailServerUnavailableError instead.
+    """
 
-	if response.status_code in UNAVAILABLE_STATUS_CODES:
-		raise MailServerUnavailableError() from requests.exceptions.HTTPError(
-			f"Request failed with status {response.status_code}: {response.text}", response=response
-		)
+    if response.status_code in UNAVAILABLE_STATUS_CODES:
+        raise MailServerUnavailableError() from requests.exceptions.HTTPError(
+            f"Request failed with status {response.status_code}: {response.text}", response=response
+        )
 
-	if not response.ok:
-		raise requests.exceptions.HTTPError(
-			f"Request failed with status {response.status_code}: {response.text}", response=response
-		)
+    if not response.ok:
+        raise requests.exceptions.HTTPError(
+            f"Request failed with status {response.status_code}: {response.text}", response=response
+        )

--- a/suite/mail/jmap/models/__init__.py
+++ b/suite/mail/jmap/models/__init__.py
@@ -4,135 +4,135 @@ from typing import Literal
 
 @dataclass
 class EmailAddress:
-	name: str
-	email: str
+    name: str
+    email: str
 
 
 @dataclass
 class EmailRecipient(EmailAddress):
-	type: Literal["to", "cc", "bcc"]
+    type: Literal["to", "cc", "bcc"]
 
 
 @dataclass
 class EmailHeader:
-	name: str
-	value: str
+    name: str
+    value: str
 
 
 @dataclass
 class EmailAttachment:
-	name: str
-	type: str
-	cid: str
-	blob_id: str
-	disposition: Literal["attachment", "inline"]
+    name: str
+    type: str
+    cid: str
+    blob_id: str
+    disposition: Literal["attachment", "inline"]
 
 
 @dataclass
 class EmailCreateModel:
-	creation_id: str
-	from_email: str
-	recipients: list[EmailRecipient]
-	from_name: str | None = None
-	subject: str | None = None
-	sent_at: str | None = None
-	message_id: str | None = None
-	reply_to: list[EmailAddress] | None = None
-	in_reply_to: str | None = None
-	headers: list[EmailHeader] | None = None
-	text_body: str | None = None
-	html_body: str | None = None
-	attachments: list[EmailAttachment] | None = None
-	raw_message: str | None = None
-	existing_id: str | None = None
-	save_as_draft: bool = False
-	priority: int = 0
-	destroy_after_submit: bool = False
-	forwarded_id: str | None = None
-	reply_to_id: str | None = None
+    creation_id: str
+    from_email: str
+    recipients: list[EmailRecipient]
+    from_name: str | None = None
+    subject: str | None = None
+    sent_at: str | None = None
+    message_id: str | None = None
+    reply_to: list[EmailAddress] | None = None
+    in_reply_to: str | None = None
+    headers: list[EmailHeader] | None = None
+    text_body: str | None = None
+    html_body: str | None = None
+    attachments: list[EmailAttachment] | None = None
+    raw_message: str | None = None
+    existing_id: str | None = None
+    save_as_draft: bool = False
+    priority: int = 0
+    destroy_after_submit: bool = False
+    forwarded_id: str | None = None
+    reply_to_id: str | None = None
 
 
 @dataclass
 class DataSourceObject:
-	"""
-	Dataclass to represent a data source object for uploads.
-	Exactly one of `as_text`, `as_base64`, or `blob_id` must be provided.
+    """
+    Dataclass to represent a data source object for uploads.
+    Exactly one of `as_text`, `as_base64`, or `blob_id` must be provided.
 
-	Parameters:
-	- as_text: The data as a UTF-8 string.
-	- as_base64: The data as a Base64-encoded string.
-	- blob_id: The ID of the blob.
-	- offset: The offset within the blob.
-	- length: The length of the data within the blob.
-	"""
+    Parameters:
+    - as_text: The data as a UTF-8 string.
+    - as_base64: The data as a Base64-encoded string.
+    - blob_id: The ID of the blob.
+    - offset: The offset within the blob.
+    - length: The length of the data within the blob.
+    """
 
-	as_text: str | None = None
-	as_base64: str | None = None
-	blob_id: str | None = None
-	offset: int | None = None
-	length: int | None = None
+    as_text: str | None = None
+    as_base64: str | None = None
+    blob_id: str | None = None
+    offset: int | None = None
+    length: int | None = None
 
-	def __post_init__(self) -> None:
-		inline_count = sum(v is not None for v in (self.as_text, self.as_base64))
-		blob_used = self.blob_id is not None
+    def __post_init__(self) -> None:
+        inline_count = sum(v is not None for v in (self.as_text, self.as_base64))
+        blob_used = self.blob_id is not None
 
-		if blob_used and inline_count > 0:
-			raise ValueError("DataSourceObject cannot have both blob_id and inline data.")
+        if blob_used and inline_count > 0:
+            raise ValueError("DataSourceObject cannot have both blob_id and inline data.")
 
-		if not blob_used and inline_count != 1:
-			raise ValueError(
-				"DataSourceObject must have exactly one of as_text or as_base64 when blob_id is not used."
-			)
+        if not blob_used and inline_count != 1:
+            raise ValueError(
+                "DataSourceObject must have exactly one of as_text or as_base64 when blob_id is not used."
+            )
 
-		if blob_used:
-			if self.offset is not None and self.offset < 0:
-				raise ValueError("Offset must be a non-negative integer.")
+        if blob_used:
+            if self.offset is not None and self.offset < 0:
+                raise ValueError("Offset must be a non-negative integer.")
 
-			if self.length is not None and self.length < 0:
-				raise ValueError("Length must be a non-negative integer.")
+            if self.length is not None and self.length < 0:
+                raise ValueError("Length must be a non-negative integer.")
 
-			if self.offset is None:
-				self.offset = 0
+            if self.offset is None:
+                self.offset = 0
 
-	def to_json(self) -> dict:
-		"""Convert the DataSourceObject to a JSON-serializable dictionary."""
+    def to_json(self) -> dict:
+        """Convert the DataSourceObject to a JSON-serializable dictionary."""
 
-		if self.as_text is not None:
-			return {"data:asText": self.as_text}
+        if self.as_text is not None:
+            return {"data:asText": self.as_text}
 
-		if self.as_base64 is not None:
-			return {"data:asBase64": self.as_base64}
+        if self.as_base64 is not None:
+            return {"data:asBase64": self.as_base64}
 
-		obj = {"blobId": self.blob_id}
+        obj = {"blobId": self.blob_id}
 
-		if self.offset is not None:
-			obj["offset"] = self.offset
+        if self.offset is not None:
+            obj["offset"] = self.offset
 
-		if self.length is not None:
-			obj["length"] = self.length
+        if self.length is not None:
+            obj["length"] = self.length
 
-		return obj
+        return obj
 
 
 @dataclass
 class UploadObject:
-	"""
-	Dataclass to represent an upload object for Blob/upload.
+    """
+    Dataclass to represent an upload object for Blob/upload.
 
-	Parameters:
-	- data: A list of DataSourceObject instances representing the data to be uploaded.
-	- type: The MIME type of the data being uploaded (e.g., "text/plain", "image/jpeg").
-	"""
+    Parameters:
+    - data: A list of DataSourceObject instances representing the data to be uploaded.
+    - type: The MIME type of the data being uploaded (e.g., "text/plain", "image/jpeg").
+    """
 
-	data: list[DataSourceObject]
-	type: str | None = None
+    data: list[DataSourceObject]
+    type: str | None = None
 
-	def to_json(self) -> dict:
-		"""Convert the UploadObject to a JSON-serializable dictionary."""
+    def to_json(self) -> dict:
+        """Convert the UploadObject to a JSON-serializable dictionary."""
 
-		obj = {"data": [d.to_json() for d in self.data]}
+        obj = {"data": [d.to_json() for d in self.data]}
 
-		if self.type is not None:
-			obj["type"] = self.type
+        if self.type is not None:
+            obj["type"] = self.type
 
-		return obj
+        return obj

--- a/suite/mail/jmap/services/blob/blob.py
+++ b/suite/mail/jmap/services/blob/blob.py
@@ -5,60 +5,60 @@ from suite.mail.jmap.services.core import CoreService
 
 
 class BlobService(CoreService):
-	"""Service for handling blob-related functionality based on the JMAP server capabilities."""
+    """Service for handling blob-related functionality based on the JMAP server capabilities."""
 
-	type: ClassVar[str] = "Blob"
-	capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:blob"]
+    type: ClassVar[str] = "Blob"
+    capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:blob"]
 
-	def __post_init__(self) -> None:
-		"""Post-initialization to check if the JMAP server supports the Blob capability and raise an error if not."""
+    def __post_init__(self) -> None:
+        """Post-initialization to check if the JMAP server supports the Blob capability and raise an error if not."""
 
-		super().__post_init__()
+        super().__post_init__()
 
-		if "urn:ietf:params:jmap:blob" not in self.connection.capabilities:
-			raise NotImplementedError("The JMAP server does not support the Blob capability.")
+        if "urn:ietf:params:jmap:blob" not in self.connection.capabilities:
+            raise NotImplementedError("The JMAP server does not support the Blob capability.")
 
-	@property
-	def primary_account_id(self) -> str:
-		"""Returns the primary account ID for the logged-in user."""
+    @property
+    def primary_account_id(self) -> str:
+        """Returns the primary account ID for the logged-in user."""
 
-		return self.connection.primary_accounts["urn:ietf:params:jmap:blob"]
+        return self.connection.primary_accounts["urn:ietf:params:jmap:blob"]
 
-	def upload(self, blobs: dict[str, UploadObject]) -> dict:
-		"""Public method to upload blobs, handling batching if the number of blobs exceeds the server's maximum allowed in a single 'set' call."""
+    def upload(self, blobs: dict[str, UploadObject]) -> dict:
+        """Public method to upload blobs, handling batching if the number of blobs exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"created": {}, "notCreated": {}}
-		for batch in self.batch_dict(blobs, self.max_objects_in_set):
-			payload = {creation_id: upload.to_json() for creation_id, upload in batch.items()}
-			response = self._exec("upload", create=payload)
+        result = {"created": {}, "notCreated": {}}
+        for batch in self.batch_dict(blobs, self.max_objects_in_set):
+            payload = {creation_id: upload.to_json() for creation_id, upload in batch.items()}
+            response = self._exec("upload", create=payload)
 
-			if method_responses := response.get("methodResponses"):
-				result["created"].update(method_responses[0][1].get("created", {}))
-				if not_created := method_responses[0][1].get("notCreated", {}):
-					result["notCreated"].update(not_created)
+            if method_responses := response.get("methodResponses"):
+                result["created"].update(method_responses[0][1].get("created", {}))
+                if not_created := method_responses[0][1].get("notCreated", {}):
+                    result["notCreated"].update(not_created)
 
-		return result
+        return result
 
-	def get(self, ids: list[str], properties: list[str]) -> list[dict]:
-		"""Public method to retrieve blobs by their IDs, handling batching if the number of IDs exceeds the server's maximum allowed in a single 'get' call."""
+    def get(self, ids: list[str], properties: list[str]) -> list[dict]:
+        """Public method to retrieve blobs by their IDs, handling batching if the number of IDs exceeds the server's maximum allowed in a single 'get' call."""
 
-		results = []
-		for batch in self.create_batches(ids, self.max_objects_in_get):
-			response = self._get(batch, properties=properties)
+        results = []
+        for batch in self.create_batches(ids, self.max_objects_in_get):
+            response = self._get(batch, properties=properties)
 
-			if method_responses := response.get("methodResponses"):
-				results.extend(method_responses[0][1].get("list", []))
+            if method_responses := response.get("methodResponses"):
+                results.extend(method_responses[0][1].get("list", []))
 
-		return results
+        return results
 
-	def lookup(self, ids: list[str], type_names: list[str]) -> list[dict]:
-		"""Public method to look up blobs by their IDs and type names, handling batching if the number of IDs exceeds the server's maximum allowed in a single 'lookup' call."""
+    def lookup(self, ids: list[str], type_names: list[str]) -> list[dict]:
+        """Public method to look up blobs by their IDs and type names, handling batching if the number of IDs exceeds the server's maximum allowed in a single 'lookup' call."""
 
-		results = []
-		for batch in self.create_batches(ids, self.max_objects_in_get):
-			response = self._exec("lookup", ids=batch, typeNames=type_names)
+        results = []
+        for batch in self.create_batches(ids, self.max_objects_in_get):
+            response = self._exec("lookup", ids=batch, typeNames=type_names)
 
-			if method_responses := response.get("methodResponses"):
-				results.extend(method_responses[0][1].get("list", []))
+            if method_responses := response.get("methodResponses"):
+                results.extend(method_responses[0][1].get("list", []))
 
-		return results
+        return results

--- a/suite/mail/jmap/services/calendars/calendar.py
+++ b/suite/mail/jmap/services/calendars/calendar.py
@@ -4,119 +4,119 @@ from suite.mail.jmap.services.calendars.calendars import CalendarsService
 
 
 class CalendarService(CalendarsService):
-	"""Service for handling calendar-related functionality based on the JMAP server capabilities."""
+    """Service for handling calendar-related functionality based on the JMAP server capabilities."""
 
-	type: ClassVar[str] = "Calendar"
+    type: ClassVar[str] = "Calendar"
 
-	def create(self, calendars: list[dict]) -> dict:
-		"""Public method to create calendars, handling batching if the number of calendars exceeds the server's maximum allowed in a single 'set' call."""
+    def create(self, calendars: list[dict]) -> dict:
+        """Public method to create calendars, handling batching if the number of calendars exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"created": {}, "notCreated": {}}
-		for batch in self.create_batches(calendars, self.max_objects_in_set):
-			payload = {}
-			kwargs = {}
-			for calendar in batch:
-				payload[calendar["creation_id"]] = {
-					"name": calendar["name"],
-					"color": calendar.get("color"),
-					"description": calendar.get("description"),
-					"sortOrder": int(calendar.get("sort_order") or 0),
-					"timeZone": calendar.get("time_zone"),
-					"isSubscribed": bool(calendar.get("is_subscribed") or False),
-					"isVisible": bool(calendar.get("is_visible", True)),
-					"includeInAvailability": calendar.get("include_in_availability") or "all",
-				}
+        result = {"created": {}, "notCreated": {}}
+        for batch in self.create_batches(calendars, self.max_objects_in_set):
+            payload = {}
+            kwargs = {}
+            for calendar in batch:
+                payload[calendar["creation_id"]] = {
+                    "name": calendar["name"],
+                    "color": calendar.get("color"),
+                    "description": calendar.get("description"),
+                    "sortOrder": int(calendar.get("sort_order") or 0),
+                    "timeZone": calendar.get("time_zone"),
+                    "isSubscribed": bool(calendar.get("is_subscribed") or False),
+                    "isVisible": bool(calendar.get("is_visible", True)),
+                    "includeInAvailability": calendar.get("include_in_availability") or "all",
+                }
 
-				if bool(calendar.get("is_default") or False):
-					kwargs["onSuccessSetIsDefault"] = f"#{calendar['creation_id']}"
+                if bool(calendar.get("is_default") or False):
+                    kwargs["onSuccessSetIsDefault"] = f"#{calendar['creation_id']}"
 
-			response = self._create(payload, **kwargs)
+            response = self._create(payload, **kwargs)
 
-			if method_responses := response.get("methodResponses"):
-				result["created"].update(method_responses[0][1].get("created", {}))
-				if not_created := method_responses[0][1].get("notCreated", {}):
-					result["notCreated"].update(not_created)
+            if method_responses := response.get("methodResponses"):
+                result["created"].update(method_responses[0][1].get("created", {}))
+                if not_created := method_responses[0][1].get("notCreated", {}):
+                    result["notCreated"].update(not_created)
 
-		return result
+        return result
 
-	def get(self, ids: list[str] | None = None) -> list[dict]:
-		"""Public method to get calendars, handling batching if a list of ids is provided."""
+    def get(self, ids: list[str] | None = None) -> list[dict]:
+        """Public method to get calendars, handling batching if a list of ids is provided."""
 
-		results = []
-		if ids:
-			for batch in self.create_batches(ids, self.max_objects_in_get):
-				response = self._get(batch)
+        results = []
+        if ids:
+            for batch in self.create_batches(ids, self.max_objects_in_get):
+                response = self._get(batch)
 
-				if method_responses := response.get("methodResponses"):
-					results.extend(method_responses[0][1].get("list", []))
-		else:
-			response = self._get()
-			if method_responses := response.get("methodResponses"):
-				results.extend(method_responses[0][1].get("list", []))
+                if method_responses := response.get("methodResponses"):
+                    results.extend(method_responses[0][1].get("list", []))
+        else:
+            response = self._get()
+            if method_responses := response.get("methodResponses"):
+                results.extend(method_responses[0][1].get("list", []))
 
-		return results
+        return results
 
-	def update(self, calendars: list[dict]) -> dict:
-		"""Public method to update calendars, handling batching if the number of calendars exceeds the server's maximum allowed in a single 'set' call."""
+    def update(self, calendars: list[dict]) -> dict:
+        """Public method to update calendars, handling batching if the number of calendars exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"updated": [], "notUpdated": {}}
-		for batch in self.create_batches(calendars, self.max_objects_in_set):
-			payload = {}
-			kwargs = {}
-			for calendar in batch:
-				payload[calendar["id"]] = {
-					"name": calendar["name"],
-					"color": calendar.get("color"),
-					"description": calendar.get("description"),
-					"sortOrder": int(calendar.get("sort_order") or 0),
-					"timeZone": calendar.get("time_zone"),
-					"isSubscribed": bool(calendar.get("is_subscribed") or False),
-					"isVisible": bool(calendar.get("is_visible", True)),
-					"includeInAvailability": calendar.get("include_in_availability") or "all",
-				}
+        result = {"updated": [], "notUpdated": {}}
+        for batch in self.create_batches(calendars, self.max_objects_in_set):
+            payload = {}
+            kwargs = {}
+            for calendar in batch:
+                payload[calendar["id"]] = {
+                    "name": calendar["name"],
+                    "color": calendar.get("color"),
+                    "description": calendar.get("description"),
+                    "sortOrder": int(calendar.get("sort_order") or 0),
+                    "timeZone": calendar.get("time_zone"),
+                    "isSubscribed": bool(calendar.get("is_subscribed") or False),
+                    "isVisible": bool(calendar.get("is_visible", True)),
+                    "includeInAvailability": calendar.get("include_in_availability") or "all",
+                }
 
-				if bool(calendar.get("is_default") or False):
-					kwargs["onSuccessSetIsDefault"] = calendar["id"]
+                if bool(calendar.get("is_default") or False):
+                    kwargs["onSuccessSetIsDefault"] = calendar["id"]
 
-			response = self._update(payload, **kwargs)
+            response = self._update(payload, **kwargs)
 
-			if method_responses := response.get("methodResponses"):
-				result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-				if not_updated := method_responses[0][1].get("notUpdated", {}):
-					result["notUpdated"].update(not_updated)
+            if method_responses := response.get("methodResponses"):
+                result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+                if not_updated := method_responses[0][1].get("notUpdated", {}):
+                    result["notUpdated"].update(not_updated)
 
-		return result
+        return result
 
-	def delete(self, ids: list[str], remove_events: bool = False) -> dict:
-		"""Public method to delete calendars, handling batching if the number of calendar ids exceeds the server's maximum allowed in a single 'set' call."""
+    def delete(self, ids: list[str], remove_events: bool = False) -> dict:
+        """Public method to delete calendars, handling batching if the number of calendar ids exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"destroyed": [], "notDestroyed": {}}
-		for batch in self.create_batches(ids, self.max_objects_in_set):
-			response = self._delete(batch, onDestroyRemoveEvents=remove_events)
+        result = {"destroyed": [], "notDestroyed": {}}
+        for batch in self.create_batches(ids, self.max_objects_in_set):
+            response = self._delete(batch, onDestroyRemoveEvents=remove_events)
 
-			if method_responses := response.get("methodResponses"):
-				result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
-				if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
-					result["notDestroyed"].update(not_destroyed)
+            if method_responses := response.get("methodResponses"):
+                result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
+                if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
+                    result["notDestroyed"].update(not_destroyed)
 
-		return result
+        return result
 
-	def changes(self, since_state: str) -> dict:
-		"""Public method to get calendar changes since a given state."""
+    def changes(self, since_state: str) -> dict:
+        """Public method to get calendar changes since a given state."""
 
-		response = self._changes(since_state)
+        response = self._changes(since_state)
 
-		if method_responses := response.get("methodResponses"):
-			return method_responses[0][1]
+        if method_responses := response.get("methodResponses"):
+            return method_responses[0][1]
 
-		return {}
+        return {}
 
-	def get_default(self, raise_exception: bool = False) -> str | None:
-		"""Returns the ID of the default calendar, or None if no default calendar is found. If raise_exception is True, raises a ValueError if no default calendar is found."""
+    def get_default(self, raise_exception: bool = False) -> str | None:
+        """Returns the ID of the default calendar, or None if no default calendar is found. If raise_exception is True, raises a ValueError if no default calendar is found."""
 
-		for calendar in self.calendars:
-			if calendar.get("isDefault"):
-				return calendar["id"]
+        for calendar in self.calendars:
+            if calendar.get("isDefault"):
+                return calendar["id"]
 
-		if raise_exception:
-			raise ValueError("No default calendar found.")
+        if raise_exception:
+            raise ValueError("No default calendar found.")

--- a/suite/mail/jmap/services/calendars/calendar_event.py
+++ b/suite/mail/jmap/services/calendars/calendar_event.py
@@ -8,539 +8,539 @@ from suite.utils.dt import utcnow
 
 
 class CalendarEventService(CalendarsService):
-	"""Service for handling calendar event-related functionality based on the JMAP server capabilities."""
-
-	type: ClassVar[str] = "CalendarEvent"
-
-	def create(self, events: list[dict], send_scheduling_messages: bool = False) -> dict:
-		"""
-		Public method to create calendar events, handling batching if the number of events exceeds the server's maximum allowed in a single 'set' call.
-		If send_scheduling_messages is True, includes the sendSchedulingMessages flag in the request payload to indicate that scheduling messages should be sent for the created events.
-		"""
-
-		result = {"created": {}, "notCreated": {}}
-		for batch in self.create_batches(events, self.max_objects_in_set):
-			payload = {}
-			for event in batch:
-				timestamp = utcnow()
-
-				calendar_ids = event.get("calendar_ids")
-				if not calendar_ids:
-					calendar_ids = [
-						CalendarService(self.account, self.connection).get_default(raise_exception=True)
-					]
-
-				organizer = event.get("organizer")
-				if not organizer:
-					organizer = ParticipantIdentityService(self.account, self.connection).get_default(
-						raise_exception=True
-					)
-
-				organizer = organizer.lower()
-				if not organizer.startswith("mailto:"):
-					organizer = f"mailto:{organizer}"
-
-				payload[event["creation_id"]] = {
-					"@type": "Event",
-					"uid": event["uid"],
-					"organizerCalendarAddress": organizer,
-					"calendarIds": {id: True for id in calendar_ids},
-					"status": event.get("status"),
-					"isDraft": bool(event.get("is_draft") or False),
-					"title": event.get("title"),
-					"start": event.get("start"),
-					"duration": event.get("duration"),
-					"timeZone": event.get("time_zone"),
-					"recurrenceRule": event.get("recurrence_rule") or None,
-					"showWithoutTime": bool(event.get("show_without_time") or False),
-					"privacy": event.get("privacy"),
-					"freeBusyStatus": event.get("free_busy_status"),
-					"description": event.get("description"),
-					"locations": self._get_locations_map(event.get("locations")),
-					"links": self._get_links_map(event.get("links")),
-					"participants": self._get_participants_map(event.get("participants")),
-					"alerts": self._get_alerts_map(event.get("alerts")),
-					"useDefaultAlerts": bool(event.get("use_default_alerts") or False),
-					"created": timestamp,
-					"updated": timestamp,
-				}
-
-			response = self._create(payload, sendSchedulingMessages=send_scheduling_messages)
-
-			if method_responses := response.get("methodResponses"):
-				result["created"].update(method_responses[0][1].get("created", {}))
-				if not_created := method_responses[0][1].get("notCreated", {}):
-					result["notCreated"].update(not_created)
-
-		return result
-
-	def get(self, ids: list[str] | None = None) -> list[dict]:
-		"""Public method to get calendar events, handling batching if a list of ids is provided."""
-
-		results = []
-		if ids:
-			for batch in self.create_batches(ids, self.max_objects_in_get):
-				response = self._get(batch)
-
-				if method_responses := response.get("methodResponses"):
-					results.extend(method_responses[0][1].get("list", []))
-		else:
-			response = self._get()
-			if method_responses := response.get("methodResponses"):
-				results.extend(method_responses[0][1].get("list", []))
-
-		return results
-
-	def update(self, events: list[dict], send_scheduling_messages: bool = False) -> dict:
-		"""
-		Public method to update calendar events, handling batching if the number of events exceeds the server's maximum allowed in a single 'set' call.
-		If send_scheduling_messages is True, includes the sendSchedulingMessages flag in the request payload to indicate that scheduling messages should be sent for the updated events.
-		"""
-
-		result = {"updated": [], "notUpdated": {}}
-		for batch in self.create_batches(events, self.max_objects_in_set):
-			payload = {}
-			for event in batch:
-				calendar_ids = event.get("calendar_ids")
-				if not calendar_ids:
-					calendar_ids = [
-						CalendarService(self.account, self.connection).get_default(raise_exception=True)
-					]
-
-				payload[event["id"]] = {
-					"@type": "Event",
-					"calendarIds": {id: True for id in calendar_ids},
-					"privacy": event.get("privacy"),
-					"freeBusyStatus": event.get("free_busy_status"),
-					"alerts": self._get_alerts_map(event.get("alerts")),
-				}
-
-				organizer = event.get("organizer")
-
-				if organizer:
-					organizer = organizer.lower()
-
-					if not organizer.startswith("mailto:"):
-						organizer = f"mailto:{organizer}"
-
-				payload[event["id"]].update(
-					{
-						"uid": event["uid"],
-						"organizerCalendarAddress": organizer,
-						"status": event.get("status"),
-						"isDraft": bool(event.get("is_draft") or False),
-						"title": event.get("title"),
-						"start": event.get("start"),
-						"duration": event.get("duration"),
-						"timeZone": event.get("time_zone"),
-						"recurrenceRule": event.get("recurrence_rule") or None,
-						"showWithoutTime": bool(event.get("show_without_time") or False),
-						"description": event.get("description"),
-						"locations": self._get_locations_map(event.get("locations")),
-						"links": self._get_links_map(event.get("links")),
-						"participants": self._get_participants_map(event.get("participants")),
-						"useDefaultAlerts": bool(event.get("use_default_alerts") or False),
-						"updated": utcnow(),
-					}
-				)
-
-				# The caller may force a SEQUENCE bump (iTIP) so attendee clients apply the update
-				# instead of ignoring it as a duplicate. Only set it when provided; otherwise leave
-				# the server-managed value alone.
-				if (sequence := event.get("sequence")) is not None:
-					payload[event["id"]]["sequence"] = int(sequence)
-
-			response = self._update(payload, sendSchedulingMessages=send_scheduling_messages)
-
-			if method_responses := response.get("methodResponses"):
-				result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-				if not_updated := method_responses[0][1].get("notUpdated", {}):
-					result["notUpdated"].update(not_updated)
-
-		return result
-
-	def set_calendar_ids(self, mapping: dict[str, dict[str, bool]]) -> dict:
-		"""Replaces the calendarIds of each given event with the provided map, batching to stay within
-		the server's per-'set' limit.
-
-		Used by the import rollback flow to move events out of the staging calendar into their final
-		calendar(s) once every event has been created; only calendarIds is touched, so the rest of the
-		event is left untouched."""
-
-		# `updated` is server-managed for CalendarEvent (it is stripped on create; see the exchange's
-		# SERVER_MANAGED_KEYS), so patch calendarIds only and let the server set the timestamp itself.
-		result = {"updated": [], "notUpdated": {}}
-		for batch in self.create_batches(list(mapping.items()), self.max_objects_in_set):
-			payload = {id: {"calendarIds": calendar_ids} for id, calendar_ids in batch}
-
-			response = self._update(payload)
-
-			if method_responses := response.get("methodResponses"):
-				result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-				if not_updated := method_responses[0][1].get("notUpdated", {}):
-					result["notUpdated"].update(not_updated)
-
-		return result
-
-	def delete(self, ids: list[str], send_scheduling_messages: bool = False) -> dict:
-		"""Public method to delete calendar events, handling batching if the number of events exceeds the server's maximum allowed in a single 'set' call.
-		If send_scheduling_messages is True, the JMAP server sends cancellation scheduling messages for the destroyed events; pass False to suppress them (e.g. when the client sends its own cancellations)."""
-
-		result = {"destroyed": [], "notDestroyed": {}}
-		for batch in self.create_batches(ids, self.max_objects_in_set):
-			response = self._delete(batch, sendSchedulingMessages=send_scheduling_messages)
-
-			if method_responses := response.get("methodResponses"):
-				result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
-				if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
-					result["notDestroyed"].update(not_destroyed)
-
-		return result
-
-	def query(
-		self,
-		filter: dict | None = None,
-		position: int = 0,
-		limit: int = 50,
-		sort: list[dict] | None = None,
-		time_zone: str | None = None,
-		expand_recurrences: bool = False,
-	) -> dict:
-		"""Public method to query calendar events, handling batching if the number of results exceeds the server's maximum allowed in a single 'query' call."""
-
-		ids = []
-		total = None
-		batch_size = min(limit, self.max_objects_in_get)
-		sort = sort or [{"property": "start", "isAscending": True}]
-
-		while len(ids) < limit:
-			current_batch_size = min(batch_size, limit - len(ids))
-
-			response = self._query(
-				filter,
-				position,
-				current_batch_size,
-				sort,
-				calculate_total=total is None,
-				timeZone=time_zone,
-				expandRecurrences=expand_recurrences,
-			)
-
-			method_responses = response.get("methodResponses")
-			if not method_responses:
-				break
-
-			query_response = method_responses[0][1]
-			batch_ids = query_response.get("ids", [])
-			ids.extend(batch_ids)
-
-			if total is None:
-				total = query_response.get("total")
-
-			if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
-				break
-
-			position += len(batch_ids)
-
-		return {"ids": ids[:limit], "total": total}
-
-	def changes(self, since_state: str) -> dict:
-		"""Public method to get calendar event changes since a given state."""
-
-		response = self._changes(since_state)
-
-		if method_responses := response.get("methodResponses"):
-			return method_responses[0][1]
-
-		return {}
-
-	def parse(self, blob_ids: list[str]) -> dict:
-		"""Public method to parse calendar event blobs, handling batching if the number of blob ids exceeds the server's maximum allowed in a single 'get' call."""
-
-		result = {"parsed": {}, "notFound": {}, "notParsable": {}}
-		for batch in self.create_batches(blob_ids, self.max_objects_in_get):
-			response = self._call(
-				self.capabilities,
-				[
-					[
-						f"{self.type}/parse",
-						{
-							"accountId": self.account,
-							"blobIds": batch,
-						},
-						"0",
-					]
-				],
-			)
-
-			if method_responses := response.get("methodResponses"):
-				result["parsed"].update(method_responses[0][1].get("parsed", {}))
-				if not_found := method_responses[0][1].get("notFound", {}):
-					result["notFound"].update(not_found)
-				if not_parsable := method_responses[0][1].get("notParsable", {}):
-					result["notParsable"].update(not_parsable)
-
-		return result
-
-	def get_base_event_ids(self, ids: list[str]) -> dict[str, str]:
-		"""Public method to map event ids (including synthetic ids from recurrence-expanded queries)
-		to the id of the real event they belong to.
-
-		Resolved via a lightweight get requesting only baseEventId, which the server derives
-		directly from the id itself — unlike a uid query, it does not depend on the search index
-		(updated asynchronously), so it works immediately after an event is created."""
-
-		base_ids = {}
-		for batch in self.create_batches(ids, self.max_objects_in_get):
-			response = self._get(batch, properties=["id", "baseEventId"])
-
-			if method_responses := response.get("methodResponses"):
-				for event in method_responses[0][1].get("list", []):
-					base_ids[event["id"]] = event.get("baseEventId") or event["id"]
-
-		return base_ids
-
-	def get_master_ids(self, uids: list[str]) -> list[str]:
-		"""Public method to get master event IDs for a list of UIDs."""
-
-		return self.query(
-			{
-				"operator": "OR",
-				"conditions": [{"uid": uid} for uid in uids],
-			},
-			position=0,
-			limit=len(uids),
-			expand_recurrences=False,
-		).get("ids", [])
-
-	def update_instance(
-		self,
-		id: str,
-		recurrence_id: str,
-		patch: dict,
-		send_scheduling_messages: bool = False,
-		sequence: int | None = None,
-	) -> dict:
-		"""Public method to update a specific instance of a recurring calendar event based on its ID and recurrence ID by applying the provided patch to the master event's recurrence overrides."""
-
-		if not id or not recurrence_id:
-			raise ValueError("Both 'id' and 'recurrence_id' are required.")
-		if not patch:
-			raise ValueError("Patch data is required to update an instance.")
-
-		events = self.get([id])
-		if not events:
-			raise ValueError(f"Event with id '{id}' not found.")
-
-		event = events[0]
-		recurrence_overrides = event.get("recurrenceOverrides", {}) or {}
-
-		def _mailto(value: str) -> str:
-			value = value.lower()
-			return value if value.startswith("mailto:") else f"mailto:{value}"
-
-		FIELD_MAP = {
-			"calendar_ids": ("calendarIds", lambda v: {i: True for i in v}),
-			"privacy": ("privacy", None),
-			"free_busy_status": ("freeBusyStatus", None),
-			"alerts": ("alerts", self._get_alerts_map),
-			"organizer": ("organizerCalendarAddress", _mailto),
-			"uid": ("uid", None),
-			"status": ("status", None),
-			"title": ("title", None),
-			"start": ("start", None),
-			"duration": ("duration", None),
-			"time_zone": ("timeZone", None),
-			"recurrence_rule": ("recurrenceRule", None),
-			"show_without_time": ("showWithoutTime", lambda v: bool(v)),
-			"description": ("description", None),
-			"locations": ("locations", self._get_locations_map),
-			"links": ("links", self._get_links_map),
-			"participants": ("participants", self._get_participants_map),
-			"use_default_alerts": ("useDefaultAlerts", lambda v: bool(v)),
-		}
-
-		out = {}
-		for key, (target, transform) in FIELD_MAP.items():
-			if key in patch:
-				value = patch[key]
-				out[target] = transform(value) if transform else value
-
-		payload = {id: {}}
-
-		if recurrence_id in recurrence_overrides:
-			payload[id].update({f"recurrenceOverrides/{recurrence_id}/{k}": v for k, v in out.items()})
-		else:
-			recurrence_overrides[recurrence_id] = out
-			payload = {id: {"recurrenceOverrides": recurrence_overrides}}
-
-		payload[id]["updated"] = utcnow()
-
-		# Bump the master SEQUENCE (iTIP) so attendees' clients accept the re-sent series.
-		if sequence is not None:
-			payload[id]["sequence"] = int(sequence)
-
-		response = self._update(payload, sendSchedulingMessages=send_scheduling_messages)
-
-		result = {"updated": [], "notUpdated": {}}
-		if method_responses := response.get("methodResponses"):
-			result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-			if not_updated := method_responses[0][1].get("notUpdated", {}):
-				result["notUpdated"].update(not_updated)
-
-		return result
-
-	def set_participation_status(
-		self,
-		id: str,
-		participant_uid: str,
-		participation_status: str,
-		send_scheduling_messages: bool = False,
-	) -> dict:
-		"""Patches a single participant's participationStatus without rewriting the event.
-
-		Used by the RSVP link endpoint, where a guest updates only their own response on the
-		organizer's copy of the event.
-		"""
-
-		if not id or not participant_uid:
-			raise ValueError("Both 'id' and 'participant_uid' are required.")
-
-		payload = {
-			id: {
-				f"participants/{participant_uid}/participationStatus": participation_status.lower(),
-				"updated": utcnow(),
-			}
-		}
-
-		response = self._update(payload, sendSchedulingMessages=send_scheduling_messages)
-
-		result = {"updated": [], "notUpdated": {}}
-		if method_responses := response.get("methodResponses"):
-			result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-			if not_updated := method_responses[0][1].get("notUpdated", {}):
-				result["notUpdated"].update(not_updated)
-
-		return result
-
-	def delete_instance(self, id: str, recurrence_id: str, send_scheduling_messages: bool = False) -> dict:
-		"""Public method to delete a specific instance of a recurring calendar event based on its ID and recurrence ID by marking it as excluded in the master event's recurrence overrides.
-		If send_scheduling_messages is True, the JMAP server sends a cancellation for the excluded instance; pass False to suppress it (e.g. when the client sends its own)."""
-
-		if not id or not recurrence_id:
-			raise ValueError("Both 'id' and 'recurrence_id' are required.")
-
-		events = self.get([id])
-		if not events:
-			raise ValueError(f"Event with id '{id}' not found.")
-
-		event = events[0]
-		recurrence_overrides = event.get("recurrenceOverrides", {}) or {}
-		recurrence_overrides.setdefault(recurrence_id, {}).update({"excluded": True})
-
-		response = self._update(
-			{id: {"recurrenceOverrides": recurrence_overrides, "updated": utcnow()}},
-			sendSchedulingMessages=send_scheduling_messages,
-		)
-
-		result = {"updated": [], "notUpdated": {}}
-		if method_responses := response.get("methodResponses"):
-			result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-			if not_updated := method_responses[0][1].get("notUpdated", {}):
-				result["notUpdated"].update(not_updated)
-
-		return result
-
-	@staticmethod
-	def _get_locations_map(locations: list[dict] | None = None) -> dict[str, dict] | None:
-		if locations:
-			locations_map = {}
-			for location in locations:
-				uid = location.get("uid") or str(uuid7())
-				locations_map[uid] = {
-					"@type": "Location",
-					"name": location.get("name"),
-				}
-
-			return locations_map
-
-	@staticmethod
-	def _get_links_map(links: list[dict] | None = None) -> dict[str, dict] | None:
-		if links:
-			links_map = {}
-			for link in links:
-				uid = link.get("uid") or str(uuid7())
-				links_map[uid] = {
-					"@type": "Link",
-					"href": link.get("href"),
-					"contentType": link.get("content_type"),
-				}
-
-			return links_map
-
-	@staticmethod
-	def _get_alerts_map(alerts: list[dict] | None = None) -> dict[str, dict] | None:
-		if alerts:
-			alerts_map = {}
-			for alert in alerts:
-				if alert["type"] == "OffsetTrigger":
-					trigger = {
-						"@type": "OffsetTrigger",
-						"relativeTo": alert["relative_to"].lower(),
-						"offset": alert["offset"].upper(),
-					}
-				elif alert["type"] == "AbsoluteTrigger":
-					trigger = {
-						"@type": "AbsoluteTrigger",
-						"when": alert["when"].upper(),
-					}
-				else:
-					continue
-
-				uid = alert.get("uid") or str(uuid7())
-				alerts_map[uid] = {
-					"@type": "Alert",
-					"action": alert["action"].lower(),
-					"trigger": trigger,
-				}
-
-			return alerts_map
-
-	@staticmethod
-	def _get_participants_map(participants: list[dict] | None = None) -> dict[str, dict] | None:
-		"""Helper method to construct the 'participants' property map for a calendar event based on the provided list of participant dictionaries."""
-
-		if participants:
-			participants_map = {}
-			participants_emails = []
-			for participant in participants:
-				email = participant["email"].lower()
-				uid = participant.get("uid") or str(uuid7())
-				expect_reply = participant.get("expect_reply", False)
-				calendar_address = f"mailto:{email}" if email else None
-
-				if expect_reply:
-					send_to = (
-						participant.get("send_to") or {"imip": calendar_address} if calendar_address else None
-					)
-					schedule_id = participant.get("schedule_id") or calendar_address
-				else:
-					send_to = None
-					schedule_id = None
-
-				participants_map[uid] = {
-					"@type": "Participant",
-					"name": participant.get("name") or email,
-					"sendTo": send_to,
-					"scheduleId": schedule_id,
-					"calendarAddress": calendar_address,
-					"kind": participant.get("kind", "").lower() or None,
-					"description": participant.get("description") or None,
-					"roles": participant.get("roles") or None,
-					"participationStatus": participant.get("participation_status", "").lower() or None,
-					"expectReply": expect_reply,
-					"comment": participant.get("comment") or None,
-				}
-				participants_emails.append(email)
-
-			return participants_map
+    """Service for handling calendar event-related functionality based on the JMAP server capabilities."""
+
+    type: ClassVar[str] = "CalendarEvent"
+
+    def create(self, events: list[dict], send_scheduling_messages: bool = False) -> dict:
+        """
+        Public method to create calendar events, handling batching if the number of events exceeds the server's maximum allowed in a single 'set' call.
+        If send_scheduling_messages is True, includes the sendSchedulingMessages flag in the request payload to indicate that scheduling messages should be sent for the created events.
+        """
+
+        result = {"created": {}, "notCreated": {}}
+        for batch in self.create_batches(events, self.max_objects_in_set):
+            payload = {}
+            for event in batch:
+                timestamp = utcnow()
+
+                calendar_ids = event.get("calendar_ids")
+                if not calendar_ids:
+                    calendar_ids = [
+                        CalendarService(self.account, self.connection).get_default(raise_exception=True)
+                    ]
+
+                organizer = event.get("organizer")
+                if not organizer:
+                    organizer = ParticipantIdentityService(self.account, self.connection).get_default(
+                        raise_exception=True
+                    )
+
+                organizer = organizer.lower()
+                if not organizer.startswith("mailto:"):
+                    organizer = f"mailto:{organizer}"
+
+                payload[event["creation_id"]] = {
+                    "@type": "Event",
+                    "uid": event["uid"],
+                    "organizerCalendarAddress": organizer,
+                    "calendarIds": {id: True for id in calendar_ids},
+                    "status": event.get("status"),
+                    "isDraft": bool(event.get("is_draft") or False),
+                    "title": event.get("title"),
+                    "start": event.get("start"),
+                    "duration": event.get("duration"),
+                    "timeZone": event.get("time_zone"),
+                    "recurrenceRule": event.get("recurrence_rule") or None,
+                    "showWithoutTime": bool(event.get("show_without_time") or False),
+                    "privacy": event.get("privacy"),
+                    "freeBusyStatus": event.get("free_busy_status"),
+                    "description": event.get("description"),
+                    "locations": self._get_locations_map(event.get("locations")),
+                    "links": self._get_links_map(event.get("links")),
+                    "participants": self._get_participants_map(event.get("participants")),
+                    "alerts": self._get_alerts_map(event.get("alerts")),
+                    "useDefaultAlerts": bool(event.get("use_default_alerts") or False),
+                    "created": timestamp,
+                    "updated": timestamp,
+                }
+
+            response = self._create(payload, sendSchedulingMessages=send_scheduling_messages)
+
+            if method_responses := response.get("methodResponses"):
+                result["created"].update(method_responses[0][1].get("created", {}))
+                if not_created := method_responses[0][1].get("notCreated", {}):
+                    result["notCreated"].update(not_created)
+
+        return result
+
+    def get(self, ids: list[str] | None = None) -> list[dict]:
+        """Public method to get calendar events, handling batching if a list of ids is provided."""
+
+        results = []
+        if ids:
+            for batch in self.create_batches(ids, self.max_objects_in_get):
+                response = self._get(batch)
+
+                if method_responses := response.get("methodResponses"):
+                    results.extend(method_responses[0][1].get("list", []))
+        else:
+            response = self._get()
+            if method_responses := response.get("methodResponses"):
+                results.extend(method_responses[0][1].get("list", []))
+
+        return results
+
+    def update(self, events: list[dict], send_scheduling_messages: bool = False) -> dict:
+        """
+        Public method to update calendar events, handling batching if the number of events exceeds the server's maximum allowed in a single 'set' call.
+        If send_scheduling_messages is True, includes the sendSchedulingMessages flag in the request payload to indicate that scheduling messages should be sent for the updated events.
+        """
+
+        result = {"updated": [], "notUpdated": {}}
+        for batch in self.create_batches(events, self.max_objects_in_set):
+            payload = {}
+            for event in batch:
+                calendar_ids = event.get("calendar_ids")
+                if not calendar_ids:
+                    calendar_ids = [
+                        CalendarService(self.account, self.connection).get_default(raise_exception=True)
+                    ]
+
+                payload[event["id"]] = {
+                    "@type": "Event",
+                    "calendarIds": {id: True for id in calendar_ids},
+                    "privacy": event.get("privacy"),
+                    "freeBusyStatus": event.get("free_busy_status"),
+                    "alerts": self._get_alerts_map(event.get("alerts")),
+                }
+
+                organizer = event.get("organizer")
+
+                if organizer:
+                    organizer = organizer.lower()
+
+                    if not organizer.startswith("mailto:"):
+                        organizer = f"mailto:{organizer}"
+
+                payload[event["id"]].update(
+                    {
+                        "uid": event["uid"],
+                        "organizerCalendarAddress": organizer,
+                        "status": event.get("status"),
+                        "isDraft": bool(event.get("is_draft") or False),
+                        "title": event.get("title"),
+                        "start": event.get("start"),
+                        "duration": event.get("duration"),
+                        "timeZone": event.get("time_zone"),
+                        "recurrenceRule": event.get("recurrence_rule") or None,
+                        "showWithoutTime": bool(event.get("show_without_time") or False),
+                        "description": event.get("description"),
+                        "locations": self._get_locations_map(event.get("locations")),
+                        "links": self._get_links_map(event.get("links")),
+                        "participants": self._get_participants_map(event.get("participants")),
+                        "useDefaultAlerts": bool(event.get("use_default_alerts") or False),
+                        "updated": utcnow(),
+                    }
+                )
+
+                # The caller may force a SEQUENCE bump (iTIP) so attendee clients apply the update
+                # instead of ignoring it as a duplicate. Only set it when provided; otherwise leave
+                # the server-managed value alone.
+                if (sequence := event.get("sequence")) is not None:
+                    payload[event["id"]]["sequence"] = int(sequence)
+
+            response = self._update(payload, sendSchedulingMessages=send_scheduling_messages)
+
+            if method_responses := response.get("methodResponses"):
+                result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+                if not_updated := method_responses[0][1].get("notUpdated", {}):
+                    result["notUpdated"].update(not_updated)
+
+        return result
+
+    def set_calendar_ids(self, mapping: dict[str, dict[str, bool]]) -> dict:
+        """Replaces the calendarIds of each given event with the provided map, batching to stay within
+        the server's per-'set' limit.
+
+        Used by the import rollback flow to move events out of the staging calendar into their final
+        calendar(s) once every event has been created; only calendarIds is touched, so the rest of the
+        event is left untouched."""
+
+        # `updated` is server-managed for CalendarEvent (it is stripped on create; see the exchange's
+        # SERVER_MANAGED_KEYS), so patch calendarIds only and let the server set the timestamp itself.
+        result = {"updated": [], "notUpdated": {}}
+        for batch in self.create_batches(list(mapping.items()), self.max_objects_in_set):
+            payload = {id: {"calendarIds": calendar_ids} for id, calendar_ids in batch}
+
+            response = self._update(payload)
+
+            if method_responses := response.get("methodResponses"):
+                result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+                if not_updated := method_responses[0][1].get("notUpdated", {}):
+                    result["notUpdated"].update(not_updated)
+
+        return result
+
+    def delete(self, ids: list[str], send_scheduling_messages: bool = False) -> dict:
+        """Public method to delete calendar events, handling batching if the number of events exceeds the server's maximum allowed in a single 'set' call.
+        If send_scheduling_messages is True, the JMAP server sends cancellation scheduling messages for the destroyed events; pass False to suppress them (e.g. when the client sends its own cancellations)."""
+
+        result = {"destroyed": [], "notDestroyed": {}}
+        for batch in self.create_batches(ids, self.max_objects_in_set):
+            response = self._delete(batch, sendSchedulingMessages=send_scheduling_messages)
+
+            if method_responses := response.get("methodResponses"):
+                result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
+                if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
+                    result["notDestroyed"].update(not_destroyed)
+
+        return result
+
+    def query(
+        self,
+        filter: dict | None = None,
+        position: int = 0,
+        limit: int = 50,
+        sort: list[dict] | None = None,
+        time_zone: str | None = None,
+        expand_recurrences: bool = False,
+    ) -> dict:
+        """Public method to query calendar events, handling batching if the number of results exceeds the server's maximum allowed in a single 'query' call."""
+
+        ids = []
+        total = None
+        batch_size = min(limit, self.max_objects_in_get)
+        sort = sort or [{"property": "start", "isAscending": True}]
+
+        while len(ids) < limit:
+            current_batch_size = min(batch_size, limit - len(ids))
+
+            response = self._query(
+                filter,
+                position,
+                current_batch_size,
+                sort,
+                calculate_total=total is None,
+                timeZone=time_zone,
+                expandRecurrences=expand_recurrences,
+            )
+
+            method_responses = response.get("methodResponses")
+            if not method_responses:
+                break
+
+            query_response = method_responses[0][1]
+            batch_ids = query_response.get("ids", [])
+            ids.extend(batch_ids)
+
+            if total is None:
+                total = query_response.get("total")
+
+            if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
+                break
+
+            position += len(batch_ids)
+
+        return {"ids": ids[:limit], "total": total}
+
+    def changes(self, since_state: str) -> dict:
+        """Public method to get calendar event changes since a given state."""
+
+        response = self._changes(since_state)
+
+        if method_responses := response.get("methodResponses"):
+            return method_responses[0][1]
+
+        return {}
+
+    def parse(self, blob_ids: list[str]) -> dict:
+        """Public method to parse calendar event blobs, handling batching if the number of blob ids exceeds the server's maximum allowed in a single 'get' call."""
+
+        result = {"parsed": {}, "notFound": {}, "notParsable": {}}
+        for batch in self.create_batches(blob_ids, self.max_objects_in_get):
+            response = self._call(
+                self.capabilities,
+                [
+                    [
+                        f"{self.type}/parse",
+                        {
+                            "accountId": self.account,
+                            "blobIds": batch,
+                        },
+                        "0",
+                    ]
+                ],
+            )
+
+            if method_responses := response.get("methodResponses"):
+                result["parsed"].update(method_responses[0][1].get("parsed", {}))
+                if not_found := method_responses[0][1].get("notFound", {}):
+                    result["notFound"].update(not_found)
+                if not_parsable := method_responses[0][1].get("notParsable", {}):
+                    result["notParsable"].update(not_parsable)
+
+        return result
+
+    def get_base_event_ids(self, ids: list[str]) -> dict[str, str]:
+        """Public method to map event ids (including synthetic ids from recurrence-expanded queries)
+        to the id of the real event they belong to.
+
+        Resolved via a lightweight get requesting only baseEventId, which the server derives
+        directly from the id itself — unlike a uid query, it does not depend on the search index
+        (updated asynchronously), so it works immediately after an event is created."""
+
+        base_ids = {}
+        for batch in self.create_batches(ids, self.max_objects_in_get):
+            response = self._get(batch, properties=["id", "baseEventId"])
+
+            if method_responses := response.get("methodResponses"):
+                for event in method_responses[0][1].get("list", []):
+                    base_ids[event["id"]] = event.get("baseEventId") or event["id"]
+
+        return base_ids
+
+    def get_master_ids(self, uids: list[str]) -> list[str]:
+        """Public method to get master event IDs for a list of UIDs."""
+
+        return self.query(
+            {
+                "operator": "OR",
+                "conditions": [{"uid": uid} for uid in uids],
+            },
+            position=0,
+            limit=len(uids),
+            expand_recurrences=False,
+        ).get("ids", [])
+
+    def update_instance(
+        self,
+        id: str,
+        recurrence_id: str,
+        patch: dict,
+        send_scheduling_messages: bool = False,
+        sequence: int | None = None,
+    ) -> dict:
+        """Public method to update a specific instance of a recurring calendar event based on its ID and recurrence ID by applying the provided patch to the master event's recurrence overrides."""
+
+        if not id or not recurrence_id:
+            raise ValueError("Both 'id' and 'recurrence_id' are required.")
+        if not patch:
+            raise ValueError("Patch data is required to update an instance.")
+
+        events = self.get([id])
+        if not events:
+            raise ValueError(f"Event with id '{id}' not found.")
+
+        event = events[0]
+        recurrence_overrides = event.get("recurrenceOverrides", {}) or {}
+
+        def _mailto(value: str) -> str:
+            value = value.lower()
+            return value if value.startswith("mailto:") else f"mailto:{value}"
+
+        FIELD_MAP = {
+            "calendar_ids": ("calendarIds", lambda v: {i: True for i in v}),
+            "privacy": ("privacy", None),
+            "free_busy_status": ("freeBusyStatus", None),
+            "alerts": ("alerts", self._get_alerts_map),
+            "organizer": ("organizerCalendarAddress", _mailto),
+            "uid": ("uid", None),
+            "status": ("status", None),
+            "title": ("title", None),
+            "start": ("start", None),
+            "duration": ("duration", None),
+            "time_zone": ("timeZone", None),
+            "recurrence_rule": ("recurrenceRule", None),
+            "show_without_time": ("showWithoutTime", lambda v: bool(v)),
+            "description": ("description", None),
+            "locations": ("locations", self._get_locations_map),
+            "links": ("links", self._get_links_map),
+            "participants": ("participants", self._get_participants_map),
+            "use_default_alerts": ("useDefaultAlerts", lambda v: bool(v)),
+        }
+
+        out = {}
+        for key, (target, transform) in FIELD_MAP.items():
+            if key in patch:
+                value = patch[key]
+                out[target] = transform(value) if transform else value
+
+        payload = {id: {}}
+
+        if recurrence_id in recurrence_overrides:
+            payload[id].update({f"recurrenceOverrides/{recurrence_id}/{k}": v for k, v in out.items()})
+        else:
+            recurrence_overrides[recurrence_id] = out
+            payload = {id: {"recurrenceOverrides": recurrence_overrides}}
+
+        payload[id]["updated"] = utcnow()
+
+        # Bump the master SEQUENCE (iTIP) so attendees' clients accept the re-sent series.
+        if sequence is not None:
+            payload[id]["sequence"] = int(sequence)
+
+        response = self._update(payload, sendSchedulingMessages=send_scheduling_messages)
+
+        result = {"updated": [], "notUpdated": {}}
+        if method_responses := response.get("methodResponses"):
+            result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+            if not_updated := method_responses[0][1].get("notUpdated", {}):
+                result["notUpdated"].update(not_updated)
+
+        return result
+
+    def set_participation_status(
+        self,
+        id: str,
+        participant_uid: str,
+        participation_status: str,
+        send_scheduling_messages: bool = False,
+    ) -> dict:
+        """Patches a single participant's participationStatus without rewriting the event.
+
+        Used by the RSVP link endpoint, where a guest updates only their own response on the
+        organizer's copy of the event.
+        """
+
+        if not id or not participant_uid:
+            raise ValueError("Both 'id' and 'participant_uid' are required.")
+
+        payload = {
+            id: {
+                f"participants/{participant_uid}/participationStatus": participation_status.lower(),
+                "updated": utcnow(),
+            }
+        }
+
+        response = self._update(payload, sendSchedulingMessages=send_scheduling_messages)
+
+        result = {"updated": [], "notUpdated": {}}
+        if method_responses := response.get("methodResponses"):
+            result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+            if not_updated := method_responses[0][1].get("notUpdated", {}):
+                result["notUpdated"].update(not_updated)
+
+        return result
+
+    def delete_instance(self, id: str, recurrence_id: str, send_scheduling_messages: bool = False) -> dict:
+        """Public method to delete a specific instance of a recurring calendar event based on its ID and recurrence ID by marking it as excluded in the master event's recurrence overrides.
+        If send_scheduling_messages is True, the JMAP server sends a cancellation for the excluded instance; pass False to suppress it (e.g. when the client sends its own)."""
+
+        if not id or not recurrence_id:
+            raise ValueError("Both 'id' and 'recurrence_id' are required.")
+
+        events = self.get([id])
+        if not events:
+            raise ValueError(f"Event with id '{id}' not found.")
+
+        event = events[0]
+        recurrence_overrides = event.get("recurrenceOverrides", {}) or {}
+        recurrence_overrides.setdefault(recurrence_id, {}).update({"excluded": True})
+
+        response = self._update(
+            {id: {"recurrenceOverrides": recurrence_overrides, "updated": utcnow()}},
+            sendSchedulingMessages=send_scheduling_messages,
+        )
+
+        result = {"updated": [], "notUpdated": {}}
+        if method_responses := response.get("methodResponses"):
+            result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+            if not_updated := method_responses[0][1].get("notUpdated", {}):
+                result["notUpdated"].update(not_updated)
+
+        return result
+
+    @staticmethod
+    def _get_locations_map(locations: list[dict] | None = None) -> dict[str, dict] | None:
+        if locations:
+            locations_map = {}
+            for location in locations:
+                uid = location.get("uid") or str(uuid7())
+                locations_map[uid] = {
+                    "@type": "Location",
+                    "name": location.get("name"),
+                }
+
+            return locations_map
+
+    @staticmethod
+    def _get_links_map(links: list[dict] | None = None) -> dict[str, dict] | None:
+        if links:
+            links_map = {}
+            for link in links:
+                uid = link.get("uid") or str(uuid7())
+                links_map[uid] = {
+                    "@type": "Link",
+                    "href": link.get("href"),
+                    "contentType": link.get("content_type"),
+                }
+
+            return links_map
+
+    @staticmethod
+    def _get_alerts_map(alerts: list[dict] | None = None) -> dict[str, dict] | None:
+        if alerts:
+            alerts_map = {}
+            for alert in alerts:
+                if alert["type"] == "OffsetTrigger":
+                    trigger = {
+                        "@type": "OffsetTrigger",
+                        "relativeTo": alert["relative_to"].lower(),
+                        "offset": alert["offset"].upper(),
+                    }
+                elif alert["type"] == "AbsoluteTrigger":
+                    trigger = {
+                        "@type": "AbsoluteTrigger",
+                        "when": alert["when"].upper(),
+                    }
+                else:
+                    continue
+
+                uid = alert.get("uid") or str(uuid7())
+                alerts_map[uid] = {
+                    "@type": "Alert",
+                    "action": alert["action"].lower(),
+                    "trigger": trigger,
+                }
+
+            return alerts_map
+
+    @staticmethod
+    def _get_participants_map(participants: list[dict] | None = None) -> dict[str, dict] | None:
+        """Helper method to construct the 'participants' property map for a calendar event based on the provided list of participant dictionaries."""
+
+        if participants:
+            participants_map = {}
+            participants_emails = []
+            for participant in participants:
+                email = participant["email"].lower()
+                uid = participant.get("uid") or str(uuid7())
+                expect_reply = participant.get("expect_reply", False)
+                calendar_address = f"mailto:{email}" if email else None
+
+                if expect_reply:
+                    send_to = (
+                        participant.get("send_to") or {"imip": calendar_address} if calendar_address else None
+                    )
+                    schedule_id = participant.get("schedule_id") or calendar_address
+                else:
+                    send_to = None
+                    schedule_id = None
+
+                participants_map[uid] = {
+                    "@type": "Participant",
+                    "name": participant.get("name") or email,
+                    "sendTo": send_to,
+                    "scheduleId": schedule_id,
+                    "calendarAddress": calendar_address,
+                    "kind": participant.get("kind", "").lower() or None,
+                    "description": participant.get("description") or None,
+                    "roles": participant.get("roles") or None,
+                    "participationStatus": participant.get("participation_status", "").lower() or None,
+                    "expectReply": expect_reply,
+                    "comment": participant.get("comment") or None,
+                }
+                participants_emails.append(email)
+
+            return participants_map

--- a/suite/mail/jmap/services/calendars/calendar_event_notification.py
+++ b/suite/mail/jmap/services/calendars/calendar_event_notification.py
@@ -4,80 +4,80 @@ from suite.mail.jmap.services.calendars.calendars import CalendarsService
 
 
 class CalendarEventNotificationService(CalendarsService):
-	"""Service for handling calendar event notification-related functionality based on the JMAP server capabilities."""
+    """Service for handling calendar event notification-related functionality based on the JMAP server capabilities."""
 
-	type: ClassVar[str] = "CalendarEventNotification"
+    type: ClassVar[str] = "CalendarEventNotification"
 
-	def get(self, ids: list[str] | None = None) -> list[dict]:
-		"""Public method to get calendar event notifications, handling batching if a list of ids is provided."""
+    def get(self, ids: list[str] | None = None) -> list[dict]:
+        """Public method to get calendar event notifications, handling batching if a list of ids is provided."""
 
-		results = []
-		if ids:
-			for batch in self.create_batches(ids, self.max_objects_in_get):
-				response = self._get(batch)
+        results = []
+        if ids:
+            for batch in self.create_batches(ids, self.max_objects_in_get):
+                response = self._get(batch)
 
-				if method_responses := response.get("methodResponses"):
-					results.extend(method_responses[0][1].get("list", []))
-		else:
-			response = self._get()
-			if method_responses := response.get("methodResponses"):
-				results.extend(method_responses[0][1].get("list", []))
+                if method_responses := response.get("methodResponses"):
+                    results.extend(method_responses[0][1].get("list", []))
+        else:
+            response = self._get()
+            if method_responses := response.get("methodResponses"):
+                results.extend(method_responses[0][1].get("list", []))
 
-		return results
+        return results
 
-	def delete(self, ids: list[str]) -> dict:
-		"""Public method to delete calendar event notifications, handling batching if the number of ids exceeds the server's maximum allowed in a single 'set' call."""
+    def delete(self, ids: list[str]) -> dict:
+        """Public method to delete calendar event notifications, handling batching if the number of ids exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"destroyed": [], "notDestroyed": {}}
-		for batch in self.create_batches(ids, self.max_objects_in_set):
-			response = self._delete(batch)
+        result = {"destroyed": [], "notDestroyed": {}}
+        for batch in self.create_batches(ids, self.max_objects_in_set):
+            response = self._delete(batch)
 
-			if method_responses := response.get("methodResponses"):
-				result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
-				if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
-					result["notDestroyed"].update(not_destroyed)
+            if method_responses := response.get("methodResponses"):
+                result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
+                if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
+                    result["notDestroyed"].update(not_destroyed)
 
-		return result
+        return result
 
-	def query(
-		self, filter: dict | None = None, position: int = 0, limit: int = 50, sort: list[dict] | None = None
-	) -> dict:
-		"""Public method to query calendar event notifications, handling batching if the number of results exceeds the server's maximum allowed in a single 'query' call."""
+    def query(
+        self, filter: dict | None = None, position: int = 0, limit: int = 50, sort: list[dict] | None = None
+    ) -> dict:
+        """Public method to query calendar event notifications, handling batching if the number of results exceeds the server's maximum allowed in a single 'query' call."""
 
-		ids = []
-		total = None
-		batch_size = min(limit, self.max_objects_in_get)
-		sort = sort or [{"property": "created", "isAscending": True}]
+        ids = []
+        total = None
+        batch_size = min(limit, self.max_objects_in_get)
+        sort = sort or [{"property": "created", "isAscending": True}]
 
-		while len(ids) < limit:
-			current_batch_size = min(batch_size, limit - len(ids))
+        while len(ids) < limit:
+            current_batch_size = min(batch_size, limit - len(ids))
 
-			response = self._query(filter, position, current_batch_size, sort, calculate_total=total is None)
+            response = self._query(filter, position, current_batch_size, sort, calculate_total=total is None)
 
-			method_responses = response.get("methodResponses")
-			if not method_responses:
-				break
+            method_responses = response.get("methodResponses")
+            if not method_responses:
+                break
 
-			query_response = method_responses[0][1]
-			batch_ids = query_response.get("ids", [])
-			ids.extend(batch_ids)
+            query_response = method_responses[0][1]
+            batch_ids = query_response.get("ids", [])
+            ids.extend(batch_ids)
 
-			if total is None:
-				total = query_response.get("total")
+            if total is None:
+                total = query_response.get("total")
 
-			if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
-				break
+            if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
+                break
 
-			position += len(batch_ids)
+            position += len(batch_ids)
 
-		return {"ids": ids[:limit], "total": total}
+        return {"ids": ids[:limit], "total": total}
 
-	def changes(self, since_state: str) -> dict:
-		"""Public method to get changes to calendar event notifications since a given state."""
+    def changes(self, since_state: str) -> dict:
+        """Public method to get changes to calendar event notifications since a given state."""
 
-		response = self._changes(since_state)
+        response = self._changes(since_state)
 
-		if method_responses := response.get("methodResponses"):
-			return method_responses[0][1]
+        if method_responses := response.get("methodResponses"):
+            return method_responses[0][1]
 
-		return {}
+        return {}

--- a/suite/mail/jmap/services/calendars/calendars.py
+++ b/suite/mail/jmap/services/calendars/calendars.py
@@ -4,20 +4,20 @@ from suite.mail.jmap.services.core import CoreService
 
 
 class CalendarsService(CoreService):
-	"""Service for handling calendar-related functionality based on the JMAP server capabilities."""
+    """Service for handling calendar-related functionality based on the JMAP server capabilities."""
 
-	capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:calendars"]
+    capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:calendars"]
 
-	def __post_init__(self) -> None:
-		"""Post-initialization to check if the JMAP server supports the Calendars capability and raise an error if not."""
+    def __post_init__(self) -> None:
+        """Post-initialization to check if the JMAP server supports the Calendars capability and raise an error if not."""
 
-		super().__post_init__()
+        super().__post_init__()
 
-		if "urn:ietf:params:jmap:calendars" not in self.connection.capabilities:
-			raise NotImplementedError("The JMAP server does not support the Calendars capability.")
+        if "urn:ietf:params:jmap:calendars" not in self.connection.capabilities:
+            raise NotImplementedError("The JMAP server does not support the Calendars capability.")
 
-	@property
-	def primary_account_id(self) -> str:
-		"""Returns the primary account ID for the logged-in user."""
+    @property
+    def primary_account_id(self) -> str:
+        """Returns the primary account ID for the logged-in user."""
 
-		return self.connection.primary_accounts["urn:ietf:params:jmap:calendars"]
+        return self.connection.primary_accounts["urn:ietf:params:jmap:calendars"]

--- a/suite/mail/jmap/services/calendars/participant_identity.py
+++ b/suite/mail/jmap/services/calendars/participant_identity.py
@@ -4,110 +4,110 @@ from suite.mail.jmap.services.calendars.calendars import CalendarsService
 
 
 class ParticipantIdentityService(CalendarsService):
-	"""Service for handling participant identity-related functionality based on the JMAP server capabilities."""
+    """Service for handling participant identity-related functionality based on the JMAP server capabilities."""
 
-	type: ClassVar[str] = "ParticipantIdentity"
+    type: ClassVar[str] = "ParticipantIdentity"
 
-	def create(self, participant_identities: list[dict]) -> dict:
-		"""Public method to create participant identities, handling batching if the number of participant identities exceeds the server's maximum allowed in a single 'set' call."""
+    def create(self, participant_identities: list[dict]) -> dict:
+        """Public method to create participant identities, handling batching if the number of participant identities exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"created": {}, "notCreated": {}}
-		for batch in self.create_batches(participant_identities, self.max_objects_in_set):
-			payload = {}
-			kwargs = {}
-			for participant_identity in batch:
-				payload[participant_identity["creation_id"]] = {
-					"name": participant_identity["name"],
-					"calendarAddress": f"mailto:{participant_identity['email']}",
-				}
+        result = {"created": {}, "notCreated": {}}
+        for batch in self.create_batches(participant_identities, self.max_objects_in_set):
+            payload = {}
+            kwargs = {}
+            for participant_identity in batch:
+                payload[participant_identity["creation_id"]] = {
+                    "name": participant_identity["name"],
+                    "calendarAddress": f"mailto:{participant_identity['email']}",
+                }
 
-				if bool(participant_identity.get("is_default") or False):
-					kwargs["onSuccessSetIsDefault"] = f"#{participant_identity['creation_id']}"
+                if bool(participant_identity.get("is_default") or False):
+                    kwargs["onSuccessSetIsDefault"] = f"#{participant_identity['creation_id']}"
 
-			response = self._create(payload, **kwargs)
+            response = self._create(payload, **kwargs)
 
-			if method_responses := response.get("methodResponses"):
-				result["created"].update(method_responses[0][1].get("created", {}))
-				if not_created := method_responses[0][1].get("notCreated", {}):
-					result["notCreated"].update(not_created)
+            if method_responses := response.get("methodResponses"):
+                result["created"].update(method_responses[0][1].get("created", {}))
+                if not_created := method_responses[0][1].get("notCreated", {}):
+                    result["notCreated"].update(not_created)
 
-		return result
+        return result
 
-	def get(self, ids: list[str] | None = None) -> list[dict]:
-		"""Public method to get participant identities, handling batching if a list of ids is provided."""
+    def get(self, ids: list[str] | None = None) -> list[dict]:
+        """Public method to get participant identities, handling batching if a list of ids is provided."""
 
-		results = []
-		if ids:
-			for batch in self.create_batches(ids, self.max_objects_in_get):
-				response = self._get(batch)
+        results = []
+        if ids:
+            for batch in self.create_batches(ids, self.max_objects_in_get):
+                response = self._get(batch)
 
-				if method_responses := response.get("methodResponses"):
-					results.extend(method_responses[0][1].get("list", []))
-		else:
-			response = self._get()
-			if method_responses := response.get("methodResponses"):
-				results.extend(method_responses[0][1].get("list", []))
+                if method_responses := response.get("methodResponses"):
+                    results.extend(method_responses[0][1].get("list", []))
+        else:
+            response = self._get()
+            if method_responses := response.get("methodResponses"):
+                results.extend(method_responses[0][1].get("list", []))
 
-		return results
+        return results
 
-	def update(self, participant_identities: list[dict]) -> dict:
-		"""Public method to update participant identities, handling batching if the number of participant identities exceeds the server's maximum allowed in a single 'set' call."""
+    def update(self, participant_identities: list[dict]) -> dict:
+        """Public method to update participant identities, handling batching if the number of participant identities exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"updated": [], "notUpdated": {}}
-		for batch in self.create_batches(participant_identities, self.max_objects_in_set):
-			payload = {}
-			kwargs = {}
-			for participant_identity in batch:
-				payload[participant_identity["id"]] = {
-					"name": participant_identity["name"],
-					"calendarAddress": f"mailto:{participant_identity['email']}",
-				}
+        result = {"updated": [], "notUpdated": {}}
+        for batch in self.create_batches(participant_identities, self.max_objects_in_set):
+            payload = {}
+            kwargs = {}
+            for participant_identity in batch:
+                payload[participant_identity["id"]] = {
+                    "name": participant_identity["name"],
+                    "calendarAddress": f"mailto:{participant_identity['email']}",
+                }
 
-				if bool(participant_identity.get("is_default") or False):
-					kwargs["onSuccessSetIsDefault"] = participant_identity["id"]
+                if bool(participant_identity.get("is_default") or False):
+                    kwargs["onSuccessSetIsDefault"] = participant_identity["id"]
 
-			response = self._update(payload, **kwargs)
+            response = self._update(payload, **kwargs)
 
-			if method_responses := response.get("methodResponses"):
-				result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-				if not_updated := method_responses[0][1].get("notUpdated", {}):
-					result["notUpdated"].update(not_updated)
+            if method_responses := response.get("methodResponses"):
+                result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+                if not_updated := method_responses[0][1].get("notUpdated", {}):
+                    result["notUpdated"].update(not_updated)
 
-		return result
+        return result
 
-	def delete(self, ids: list[str]) -> dict:
-		"""Public method to delete participant identities, handling batching if the number of participant identities exceeds the server's maximum allowed in a single 'set' call."""
+    def delete(self, ids: list[str]) -> dict:
+        """Public method to delete participant identities, handling batching if the number of participant identities exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"destroyed": [], "notDestroyed": {}}
-		for batch in self.create_batches(ids, self.max_objects_in_set):
-			response = self._delete(batch)
+        result = {"destroyed": [], "notDestroyed": {}}
+        for batch in self.create_batches(ids, self.max_objects_in_set):
+            response = self._delete(batch)
 
-			if method_responses := response.get("methodResponses"):
-				result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
-				if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
-					result["notDestroyed"].update(not_destroyed)
+            if method_responses := response.get("methodResponses"):
+                result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
+                if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
+                    result["notDestroyed"].update(not_destroyed)
 
-		return result
+        return result
 
-	def changes(self, since_state: str) -> dict:
-		"""Public method to get changes to participant identities since a given state, handling batching if the number of changes exceeds the server's maximum allowed in a single 'changes' call."""
+    def changes(self, since_state: str) -> dict:
+        """Public method to get changes to participant identities since a given state, handling batching if the number of changes exceeds the server's maximum allowed in a single 'changes' call."""
 
-		response = self._changes(since_state)
+        response = self._changes(since_state)
 
-		if method_responses := response.get("methodResponses"):
-			return method_responses[0][1]
+        if method_responses := response.get("methodResponses"):
+            return method_responses[0][1]
 
-		return {}
+        return {}
 
-	def get_default(self, raise_exception: bool = False) -> str | None:
-		"""
-		Returns the email address of the default participant identity, or None if no default participant identity is found.
-		If raise_exception is True, raises a ValueError if no default participant identity is found.
-		"""
+    def get_default(self, raise_exception: bool = False) -> str | None:
+        """
+        Returns the email address of the default participant identity, or None if no default participant identity is found.
+        If raise_exception is True, raises a ValueError if no default participant identity is found.
+        """
 
-		for identity in self.participant_identities:
-			if identity.get("isDefault", False):
-				return identity["calendarAddress"].lower().replace("mailto:", "")
+        for identity in self.participant_identities:
+            if identity.get("isDefault", False):
+                return identity["calendarAddress"].lower().replace("mailto:", "")
 
-		if raise_exception:
-			raise ValueError("No default participant identity found.")
+        if raise_exception:
+            raise ValueError("No default participant identity found.")

--- a/suite/mail/jmap/services/contacts/address_book.py
+++ b/suite/mail/jmap/services/contacts/address_book.py
@@ -4,101 +4,101 @@ from suite.mail.jmap.services.contacts.contacts import ContactsService
 
 
 class AddressBookService(ContactsService):
-	"""Service for handling address book-related functionality based on the JMAP server capabilities."""
+    """Service for handling address book-related functionality based on the JMAP server capabilities."""
 
-	type: ClassVar[str] = "AddressBook"
+    type: ClassVar[str] = "AddressBook"
 
-	def create(self, address_books: list[dict]) -> dict:
-		"""Public method to create address books, handling batching if the number of address books exceeds the server's maximum allowed in a single 'set' call."""
+    def create(self, address_books: list[dict]) -> dict:
+        """Public method to create address books, handling batching if the number of address books exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"created": {}, "notCreated": {}}
-		for batch in self.create_batches(address_books, self.max_objects_in_set):
-			payload = {}
-			kwargs = {}
-			for address_book in batch:
-				payload[address_book["creation_id"]] = {
-					"name": address_book["name"],
-					"description": address_book.get("description"),
-					"sortOrder": int(address_book.get("sort_order") or 0),
-					"isSubscribed": bool(address_book.get("is_subscribed") or False),
-				}
+        result = {"created": {}, "notCreated": {}}
+        for batch in self.create_batches(address_books, self.max_objects_in_set):
+            payload = {}
+            kwargs = {}
+            for address_book in batch:
+                payload[address_book["creation_id"]] = {
+                    "name": address_book["name"],
+                    "description": address_book.get("description"),
+                    "sortOrder": int(address_book.get("sort_order") or 0),
+                    "isSubscribed": bool(address_book.get("is_subscribed") or False),
+                }
 
-				if bool(address_book.get("is_default") or False):
-					kwargs["onSuccessSetIsDefault"] = f"#{address_book['creation_id']}"
+                if bool(address_book.get("is_default") or False):
+                    kwargs["onSuccessSetIsDefault"] = f"#{address_book['creation_id']}"
 
-			response = self._create(payload, **kwargs)
+            response = self._create(payload, **kwargs)
 
-			if method_responses := response.get("methodResponses"):
-				result["created"].update(method_responses[0][1].get("created", {}))
-				if not_created := method_responses[0][1].get("notCreated", {}):
-					result["notCreated"].update(not_created)
+            if method_responses := response.get("methodResponses"):
+                result["created"].update(method_responses[0][1].get("created", {}))
+                if not_created := method_responses[0][1].get("notCreated", {}):
+                    result["notCreated"].update(not_created)
 
-		return result
+        return result
 
-	def get(self, ids: list[str] | None = None) -> list[dict]:
-		"""Public method to get address books, handling batching if a list of ids is provided."""
+    def get(self, ids: list[str] | None = None) -> list[dict]:
+        """Public method to get address books, handling batching if a list of ids is provided."""
 
-		results = []
-		if ids:
-			for batch in self.create_batches(ids, self.max_objects_in_get):
-				response = self._get(batch)
+        results = []
+        if ids:
+            for batch in self.create_batches(ids, self.max_objects_in_get):
+                response = self._get(batch)
 
-				if method_responses := response.get("methodResponses"):
-					results.extend(method_responses[0][1].get("list", []))
-		else:
-			response = self._get()
-			if method_responses := response.get("methodResponses"):
-				results.extend(method_responses[0][1].get("list", []))
+                if method_responses := response.get("methodResponses"):
+                    results.extend(method_responses[0][1].get("list", []))
+        else:
+            response = self._get()
+            if method_responses := response.get("methodResponses"):
+                results.extend(method_responses[0][1].get("list", []))
 
-		return results
+        return results
 
-	def update(self, address_books: list[dict]) -> dict:
-		"""Public method to update address books, handling batching if the number of address books exceeds the server's maximum allowed in a single 'set' call."""
+    def update(self, address_books: list[dict]) -> dict:
+        """Public method to update address books, handling batching if the number of address books exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"updated": [], "notUpdated": {}}
-		for batch in self.create_batches(address_books, self.max_objects_in_set):
-			payload = {}
-			kwargs = {}
-			for address_book in batch:
-				payload[address_book["id"]] = {
-					"name": address_book["name"],
-					"description": address_book.get("description"),
-					"sortOrder": int(address_book.get("sort_order") or 0),
-					"isSubscribed": bool(address_book.get("is_subscribed") or False),
-				}
+        result = {"updated": [], "notUpdated": {}}
+        for batch in self.create_batches(address_books, self.max_objects_in_set):
+            payload = {}
+            kwargs = {}
+            for address_book in batch:
+                payload[address_book["id"]] = {
+                    "name": address_book["name"],
+                    "description": address_book.get("description"),
+                    "sortOrder": int(address_book.get("sort_order") or 0),
+                    "isSubscribed": bool(address_book.get("is_subscribed") or False),
+                }
 
-				if bool(address_book.get("is_default") or False):
-					kwargs["onSuccessSetIsDefault"] = address_book["id"]
+                if bool(address_book.get("is_default") or False):
+                    kwargs["onSuccessSetIsDefault"] = address_book["id"]
 
-			response = self._update(payload, **kwargs)
+            response = self._update(payload, **kwargs)
 
-			if method_responses := response.get("methodResponses"):
-				result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-				if not_updated := method_responses[0][1].get("notUpdated", {}):
-					result["notUpdated"].update(not_updated)
+            if method_responses := response.get("methodResponses"):
+                result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+                if not_updated := method_responses[0][1].get("notUpdated", {}):
+                    result["notUpdated"].update(not_updated)
 
-		return result
+        return result
 
-	def delete(self, ids: list[str], remove_contents: bool = False) -> dict:
-		"""Public method to delete address books, handling batching if the number of address book IDs exceeds the server's maximum allowed in a single 'set' call."""
+    def delete(self, ids: list[str], remove_contents: bool = False) -> dict:
+        """Public method to delete address books, handling batching if the number of address book IDs exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"destroyed": [], "notDestroyed": {}}
-		for batch in self.create_batches(ids, self.max_objects_in_set):
-			response = self._delete(batch, onDestroyRemoveContents=remove_contents)
+        result = {"destroyed": [], "notDestroyed": {}}
+        for batch in self.create_batches(ids, self.max_objects_in_set):
+            response = self._delete(batch, onDestroyRemoveContents=remove_contents)
 
-			if method_responses := response.get("methodResponses"):
-				result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
-				if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
-					result["notDestroyed"].update(not_destroyed)
+            if method_responses := response.get("methodResponses"):
+                result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
+                if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
+                    result["notDestroyed"].update(not_destroyed)
 
-		return result
+        return result
 
-	def get_default(self, raise_exception: bool = False) -> str | None:
-		"""Returns the ID of the default address book, or None if no default address book is found. If raise_exception is True, raises a ValueError if no default address book is found."""
+    def get_default(self, raise_exception: bool = False) -> str | None:
+        """Returns the ID of the default address book, or None if no default address book is found. If raise_exception is True, raises a ValueError if no default address book is found."""
 
-		for address_book in self.address_books:
-			if address_book.get("isDefault"):
-				return address_book["id"]
+        for address_book in self.address_books:
+            if address_book.get("isDefault"):
+                return address_book["id"]
 
-		if raise_exception:
-			raise ValueError("No default address book found.")
+        if raise_exception:
+            raise ValueError("No default address book found.")

--- a/suite/mail/jmap/services/contacts/contact_card.py
+++ b/suite/mail/jmap/services/contacts/contact_card.py
@@ -6,416 +6,416 @@ from suite.utils.dt import utcnow
 
 
 class ContactCardService(ContactsService):
-	"""Service for handling contact card-related functionality based on the JMAP server capabilities."""
-
-	type: ClassVar[str] = "ContactCard"
-
-	def create(self, contact_cards: list[dict]) -> dict:
-		"""Public method to create contact cards, handling batching if the number of contact cards exceeds the server's maximum allowed in a single 'set' call."""
-
-		result = {"created": {}, "notCreated": {}}
-		for batch in self.create_batches(contact_cards, self.max_objects_in_set):
-			payload = {}
-			timestamp = utcnow()
-			for contact_card in batch:
-				payload[contact_card["creation_id"]] = {
-					"@type": "Card",
-					"version": "1.0",
-					"uid": contact_card["creation_id"],
-					"kind": contact_card.get("kind", "individual"),
-					"name": self._get_name_map(contact_card.get("full_name")),
-					"emails": self._get_emails_map(contact_card.get("emails")),
-					"phones": self._get_phones_map(contact_card.get("phones")),
-					"addresses": self._get_addresses_map(contact_card.get("addresses")),
-					"addressBookIds": {id: True for id in contact_card["address_book_ids"]},
-					"created": timestamp,
-					"updated": timestamp,
-				}
-
-			response = self._create(payload)
-
-			if method_responses := response.get("methodResponses"):
-				result["created"].update(method_responses[0][1].get("created", {}))
-				if not_created := method_responses[0][1].get("notCreated", {}):
-					result["notCreated"].update(not_created)
-
-		return result
-
-	def get(self, ids: list[str] | None = None, properties: list[str] | None = None) -> list[dict]:
-		"""Public method to get contact cards, handling batching if a list of ids is provided and allowing for optional properties to be specified."""
-
-		properties = properties or [
-			# --- JMAP-specific ---
-			"id",
-			"addressBookIds",
-			"blobId",
-			# --- JSContact core fields ---
-			"uid",
-			"kind",
-			"prodId",
-			"version",
-			"created",
-			"updated",
-			"fullName",
-			"name",
-			"nickNames",
-			"categories",
-			"notes",
-			"anniversaries",
-			"urls",
-			"relatedTo",
-			"organizations",
-			"titles",
-			"roles",
-			"emails",
-			"phones",
-			"addresses",
-			"onlineServices",
-			"preferredLanguages",
-			"speakToAs",
-			"gender",
-			"timeZones",
-			"photos",
-			"members",
-			"preferredContactChannels",
-			"localizations",
-			"extensions",
-		]
-
-		results = []
-		if ids:
-			for batch in self.create_batches(ids, self.max_objects_in_get):
-				response = self._get(batch, properties=properties)
-
-				if method_responses := response.get("methodResponses"):
-					results.extend(method_responses[0][1].get("list", []))
-		else:
-			response = self._get(properties=properties)
-			if method_responses := response.get("methodResponses"):
-				results.extend(method_responses[0][1].get("list", []))
-
-		return results
-
-	def update(self, contact_cards: list[dict]) -> dict:
-		"""Public method to update contact cards, handling batching if the number of contact cards exceeds the server's maximum allowed in a single 'set' call."""
-
-		result = {"updated": [], "notUpdated": {}}
-		for batch in self.create_batches(contact_cards, self.max_objects_in_set):
-			payload = {}
-			for contact_card in batch:
-				payload[contact_card["id"]] = {
-					"kind": contact_card.get("kind", "individual"),
-					"name": self._get_name_map(contact_card.get("full_name")),
-					"emails": self._get_emails_map(contact_card.get("emails")),
-					"phones": self._get_phones_map(contact_card.get("phones")),
-					"addresses": self._get_addresses_map(contact_card.get("addresses")),
-					"addressBookIds": {id: True for id in contact_card["address_book_ids"]},
-					"updated": utcnow(),
-				}
+    """Service for handling contact card-related functionality based on the JMAP server capabilities."""
+
+    type: ClassVar[str] = "ContactCard"
+
+    def create(self, contact_cards: list[dict]) -> dict:
+        """Public method to create contact cards, handling batching if the number of contact cards exceeds the server's maximum allowed in a single 'set' call."""
+
+        result = {"created": {}, "notCreated": {}}
+        for batch in self.create_batches(contact_cards, self.max_objects_in_set):
+            payload = {}
+            timestamp = utcnow()
+            for contact_card in batch:
+                payload[contact_card["creation_id"]] = {
+                    "@type": "Card",
+                    "version": "1.0",
+                    "uid": contact_card["creation_id"],
+                    "kind": contact_card.get("kind", "individual"),
+                    "name": self._get_name_map(contact_card.get("full_name")),
+                    "emails": self._get_emails_map(contact_card.get("emails")),
+                    "phones": self._get_phones_map(contact_card.get("phones")),
+                    "addresses": self._get_addresses_map(contact_card.get("addresses")),
+                    "addressBookIds": {id: True for id in contact_card["address_book_ids"]},
+                    "created": timestamp,
+                    "updated": timestamp,
+                }
+
+            response = self._create(payload)
+
+            if method_responses := response.get("methodResponses"):
+                result["created"].update(method_responses[0][1].get("created", {}))
+                if not_created := method_responses[0][1].get("notCreated", {}):
+                    result["notCreated"].update(not_created)
+
+        return result
+
+    def get(self, ids: list[str] | None = None, properties: list[str] | None = None) -> list[dict]:
+        """Public method to get contact cards, handling batching if a list of ids is provided and allowing for optional properties to be specified."""
+
+        properties = properties or [
+            # --- JMAP-specific ---
+            "id",
+            "addressBookIds",
+            "blobId",
+            # --- JSContact core fields ---
+            "uid",
+            "kind",
+            "prodId",
+            "version",
+            "created",
+            "updated",
+            "fullName",
+            "name",
+            "nickNames",
+            "categories",
+            "notes",
+            "anniversaries",
+            "urls",
+            "relatedTo",
+            "organizations",
+            "titles",
+            "roles",
+            "emails",
+            "phones",
+            "addresses",
+            "onlineServices",
+            "preferredLanguages",
+            "speakToAs",
+            "gender",
+            "timeZones",
+            "photos",
+            "members",
+            "preferredContactChannels",
+            "localizations",
+            "extensions",
+        ]
+
+        results = []
+        if ids:
+            for batch in self.create_batches(ids, self.max_objects_in_get):
+                response = self._get(batch, properties=properties)
+
+                if method_responses := response.get("methodResponses"):
+                    results.extend(method_responses[0][1].get("list", []))
+        else:
+            response = self._get(properties=properties)
+            if method_responses := response.get("methodResponses"):
+                results.extend(method_responses[0][1].get("list", []))
+
+        return results
+
+    def update(self, contact_cards: list[dict]) -> dict:
+        """Public method to update contact cards, handling batching if the number of contact cards exceeds the server's maximum allowed in a single 'set' call."""
+
+        result = {"updated": [], "notUpdated": {}}
+        for batch in self.create_batches(contact_cards, self.max_objects_in_set):
+            payload = {}
+            for contact_card in batch:
+                payload[contact_card["id"]] = {
+                    "kind": contact_card.get("kind", "individual"),
+                    "name": self._get_name_map(contact_card.get("full_name")),
+                    "emails": self._get_emails_map(contact_card.get("emails")),
+                    "phones": self._get_phones_map(contact_card.get("phones")),
+                    "addresses": self._get_addresses_map(contact_card.get("addresses")),
+                    "addressBookIds": {id: True for id in contact_card["address_book_ids"]},
+                    "updated": utcnow(),
+                }
 
-			response = self._update(payload)
+            response = self._update(payload)
 
-			if method_responses := response.get("methodResponses"):
-				result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-				if not_updated := method_responses[0][1].get("notUpdated", {}):
-					result["notUpdated"].update(not_updated)
-
-		return result
-
-	def delete(self, ids: list[str]) -> dict:
-		"""Public method to delete contact cards, handling batching if the number of ids exceeds the server's maximum allowed in a single 'set' call."""
-
-		result = {"destroyed": [], "notDestroyed": {}}
-		for batch in self.create_batches(ids, self.max_objects_in_set):
-			response = self._delete(batch)
+            if method_responses := response.get("methodResponses"):
+                result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+                if not_updated := method_responses[0][1].get("notUpdated", {}):
+                    result["notUpdated"].update(not_updated)
+
+        return result
+
+    def delete(self, ids: list[str]) -> dict:
+        """Public method to delete contact cards, handling batching if the number of ids exceeds the server's maximum allowed in a single 'set' call."""
+
+        result = {"destroyed": [], "notDestroyed": {}}
+        for batch in self.create_batches(ids, self.max_objects_in_set):
+            response = self._delete(batch)
 
-			if method_responses := response.get("methodResponses"):
-				result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
-				if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
-					result["notDestroyed"].update(not_destroyed)
+            if method_responses := response.get("methodResponses"):
+                result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
+                if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
+                    result["notDestroyed"].update(not_destroyed)
 
-		return result
-
-	def query(
-		self, filter: dict | None = None, position: int = 0, limit: int = 50, sort: list[dict] | None = None
-	) -> dict:
-		"""Public method to query contact cards, handling batching if the number of results exceeds the server's maximum allowed in a single 'query' call."""
+        return result
+
+    def query(
+        self, filter: dict | None = None, position: int = 0, limit: int = 50, sort: list[dict] | None = None
+    ) -> dict:
+        """Public method to query contact cards, handling batching if the number of results exceeds the server's maximum allowed in a single 'query' call."""
 
-		ids = []
-		total = None
-		batch_size = min(limit, self.max_objects_in_get)
-
-		while len(ids) < limit:
-			current_batch_size = min(batch_size, limit - len(ids))
-
-			response = self._query(filter, position, current_batch_size, sort, calculate_total=total is None)
-
-			method_responses = response.get("methodResponses")
-			if not method_responses:
-				break
-
-			query_response = method_responses[0][1]
-			batch_ids = query_response.get("ids", [])
-			ids.extend(batch_ids)
-
-			if total is None:
-				total = query_response.get("total")
-
-			if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
-				break
-
-			position += len(batch_ids)
+        ids = []
+        total = None
+        batch_size = min(limit, self.max_objects_in_get)
+
+        while len(ids) < limit:
+            current_batch_size = min(batch_size, limit - len(ids))
+
+            response = self._query(filter, position, current_batch_size, sort, calculate_total=total is None)
+
+            method_responses = response.get("methodResponses")
+            if not method_responses:
+                break
+
+            query_response = method_responses[0][1]
+            batch_ids = query_response.get("ids", [])
+            ids.extend(batch_ids)
+
+            if total is None:
+                total = query_response.get("total")
+
+            if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
+                break
+
+            position += len(batch_ids)
 
-		return {"ids": ids[:limit], "total": total}
-
-	def changes(self, since_state: str) -> dict:
-		"""Public method to get contact card changes since a given state."""
-
-		response = self._changes(since_state)
-
-		if method_responses := response.get("methodResponses"):
-			return method_responses[0][1]
-
-		return {}
-
-	def parse(self, blob_ids: list[str]) -> dict:
-		"""Public method to parse vCard blobs into JSContact Cards via the JMAP 'ContactCard/parse' method.
-
-		The number of blob ids allowed per 'ContactCard/parse' call is capped well below
-		'maxObjectsInGet' and is not advertised in the session capabilities, so we start from the
-		general object limit and halve the batch whenever the server responds with 'requestTooLarge',
-		reusing the largest size that succeeds for the remaining blobs. Any other error is raised so
-		the caller can fall back to local parsing."""
-
-		result = {"parsed": {}, "notFound": {}, "notParsable": {}}
-
-		remaining = list(blob_ids)
-		batch_size = min(len(remaining), self.max_objects_in_get) or 1
-		while remaining:
-			batch = remaining[:batch_size]
-			response = self._call(
-				self.capabilities,
-				[
-					[
-						f"{self.type}/parse",
-						{
-							"accountId": self.account,
-							"blobIds": batch,
-						},
-						"0",
-					]
-				],
-			)
-
-			method_responses = response.get("methodResponses")
-			if not method_responses:
-				break
-
-			name, body = method_responses[0][0], method_responses[0][1]
-			if name == "error":
-				if body.get("type") == "requestTooLarge" and batch_size > 1:
-					batch_size = max(1, batch_size // 2)
-					continue
-				raise RuntimeError(f"ContactCard/parse failed: {body}")
-
-			result["parsed"].update(body.get("parsed", {}))
-			if not_found := body.get("notFound", {}):
-				result["notFound"].update(not_found)
-			if not_parsable := body.get("notParsable", {}):
-				result["notParsable"].update(not_parsable)
-
-			remaining = remaining[batch_size:]
-
-		return result
-
-	def get_master_ids(self, uids: list[str]) -> list[str]:
-		"""Public method to get contact card IDs for a list of UIDs.
-
-		The UIDs are batched into separate OR queries so the filter stays within server limits, and
-		each batch is fully paginated using the reported ``total``. We cannot rely on the generic
-		``query`` helper here: it stops as soon as a page returns fewer IDs than requested, but a
-		server may cap a query page below that, which would silently drop matches after the first
-		page and let a re-run create duplicate cards."""
-
-		if not uids:
-			return []
-
-		ids: list[str] = []
-		for batch in self.create_batches(uids, self.max_objects_in_get):
-			filter = {"operator": "OR", "conditions": [{"uid": uid} for uid in batch]}
-			position = 0
-			total = None
-			while True:
-				response = self._query(filter, position, len(batch), calculate_total=total is None)
-
-				method_responses = response.get("methodResponses")
-				if not method_responses:
-					break
-
-				query_response = method_responses[0][1]
-				page = query_response.get("ids", [])
-				ids.extend(page)
-
-				if total is None:
-					total = query_response.get("total")
-
-				position += len(page)
-				if not page or (total is not None and position >= total):
-					break
-
-		return ids
-
-	def update_address_book_ids(
-		self,
-		ids: list[str],
-		add_address_book_id: str | None = None,
-		remove_address_book_id: str | None = None,
-		move_to_address_book_id: str | None = None,
-	) -> dict:
-		"""
-		Updates addressBookIds for the provided contact cards.
-
-		Behavior:
-		- add_address_book_id: adds the contact to an address book
-		- remove_address_book_id: removes the contact from an address book
-		- add + remove: moves contact between address books (patch-based)
-		- move_to_address_book_id: replaces addressBookIds entirely
-		"""
-
-		if move_to_address_book_id and (add_address_book_id or remove_address_book_id):
-			raise ValueError(
-				"Cannot specify 'move_to_address_book_id' together with 'add_address_book_id' or 'remove_address_book_id'."
-			)
-
-		if not any([add_address_book_id, remove_address_book_id, move_to_address_book_id]):
-			raise ValueError(
-				"At least one of 'add_address_book_id', 'remove_address_book_id', or 'move_to_address_book_id' must be specified."
-			)
-
-		result = {"updated": [], "notUpdated": {}}
-		for batch in self.create_batches(ids, self.max_objects_in_set):
-			if move_to_address_book_id:
-				payload = {"addressBookIds": {move_to_address_book_id: True}, "updated": utcnow()}
-			else:
-				payload = {"updated": utcnow()}
-
-				if add_address_book_id:
-					payload[f"addressBookIds/{add_address_book_id}"] = True
-				if remove_address_book_id:
-					payload[f"addressBookIds/{remove_address_book_id}"] = None
-
-			response = self._call(
-				self.capabilities,
-				[
-					[
-						f"{self.type}/set",
-						{
-							"accountId": self.account,
-							"update": {id: payload for id in batch},
-						},
-						"0",
-					]
-				],
-			)
-
-			if method_responses := response.get("methodResponses"):
-				result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-				if not_updated := method_responses[0][1].get("notUpdated", {}):
-					result["notUpdated"].update(not_updated)
-
-		return result
-
-	def set_address_book_ids(self, mapping: dict[str, dict[str, bool]]) -> dict:
-		"""Replaces the addressBookIds of each given card with the provided map, batching to stay within
-		the server's per-'set' limit.
-
-		Used by the import rollback flow to move cards out of the staging address book into their final
-		address book(s) once every card has been created; only addressBookIds is touched, so the rest of
-		the card is left untouched."""
-
-		# Mirror set_calendar_ids: patch addressBookIds only and let the server manage the `updated`
-		# timestamp, so we never depend on `updated` being client-writable for ContactCard.
-		result = {"updated": [], "notUpdated": {}}
-		for batch in self.create_batches(list(mapping.items()), self.max_objects_in_set):
-			payload = {id: {"addressBookIds": book_ids} for id, book_ids in batch}
-
-			response = self._update(payload)
-
-			if method_responses := response.get("methodResponses"):
-				result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-				if not_updated := method_responses[0][1].get("notUpdated", {}):
-					result["notUpdated"].update(not_updated)
-
-		return result
-
-	@staticmethod
-	def _get_name_map(full_name: str | None = None) -> dict:
-		"""Helper method to construct the 'name' property map for a contact card based on the provided full name."""
-
-		if full_name:
-			given, surname = full_name.split(" ", 1) if " " in full_name else (full_name, None)
-			return {
-				"@type": "Name",
-				"full": full_name,
-				"components": [{"kind": "given", "value": given}, {"kind": "surname", "value": surname}],
-				"isOrdered": True,
-			}
-
-		return {}
-
-	@staticmethod
-	def _get_emails_map(emails: list[dict] | None = None) -> dict[str, dict] | None:
-		"""Helper method to construct the 'emails' property map for a contact card based on the provided list of email dictionaries."""
-
-		if emails:
-			emails_map = {}
-			for email in emails:
-				emails_map[str(uuid7())] = {
-					"address": email["address"],
-					"label": email.get("label"),
-					"contexts": {email["type"]: True},
-				}
-
-			return emails_map
-
-	@staticmethod
-	def _get_phones_map(phones: list[dict] | None = None) -> dict[str, dict] | None:
-		"""Helper method to construct the 'phones' property map for a contact card based on the provided list of phone dictionaries."""
-
-		if phones:
-			phones_map = {}
-			for phone in phones:
-				phones_map[str(uuid7())] = {
-					"number": phone["number"],
-					"label": phone.get("label"),
-					"contexts": {phone["type"]: True},
-				}
-
-			return phones_map
-
-	@staticmethod
-	def _get_addresses_map(addresses: list[dict] | None = None) -> dict[str, dict] | None:
-		"""Helper method to construct the 'addresses' property map for a contact card based on the provided list of address dictionaries."""
-
-		if addresses:
-			counter = 0
-			addresses_map = {}
-			for address in addresses:
-				components = []
-				for field, key in {
-					"street": "name",
-					"locality": "locality",
-					"region": "region",
-					"postcode": "postcode",
-					"country": "country",
-				}.items():
-					components.append({"kind": key, "value": address.get(field)})
-
-				addresses_map[f"{counter}"] = {
-					"components": components,
-					"timeZone": address.get("time_zone"),
-					"contexts": {address["type"]: True},
-				}
-				counter += 1
-
-			return addresses_map
+        return {"ids": ids[:limit], "total": total}
+
+    def changes(self, since_state: str) -> dict:
+        """Public method to get contact card changes since a given state."""
+
+        response = self._changes(since_state)
+
+        if method_responses := response.get("methodResponses"):
+            return method_responses[0][1]
+
+        return {}
+
+    def parse(self, blob_ids: list[str]) -> dict:
+        """Public method to parse vCard blobs into JSContact Cards via the JMAP 'ContactCard/parse' method.
+
+        The number of blob ids allowed per 'ContactCard/parse' call is capped well below
+        'maxObjectsInGet' and is not advertised in the session capabilities, so we start from the
+        general object limit and halve the batch whenever the server responds with 'requestTooLarge',
+        reusing the largest size that succeeds for the remaining blobs. Any other error is raised so
+        the caller can fall back to local parsing."""
+
+        result = {"parsed": {}, "notFound": {}, "notParsable": {}}
+
+        remaining = list(blob_ids)
+        batch_size = min(len(remaining), self.max_objects_in_get) or 1
+        while remaining:
+            batch = remaining[:batch_size]
+            response = self._call(
+                self.capabilities,
+                [
+                    [
+                        f"{self.type}/parse",
+                        {
+                            "accountId": self.account,
+                            "blobIds": batch,
+                        },
+                        "0",
+                    ]
+                ],
+            )
+
+            method_responses = response.get("methodResponses")
+            if not method_responses:
+                break
+
+            name, body = method_responses[0][0], method_responses[0][1]
+            if name == "error":
+                if body.get("type") == "requestTooLarge" and batch_size > 1:
+                    batch_size = max(1, batch_size // 2)
+                    continue
+                raise RuntimeError(f"ContactCard/parse failed: {body}")
+
+            result["parsed"].update(body.get("parsed", {}))
+            if not_found := body.get("notFound", {}):
+                result["notFound"].update(not_found)
+            if not_parsable := body.get("notParsable", {}):
+                result["notParsable"].update(not_parsable)
+
+            remaining = remaining[batch_size:]
+
+        return result
+
+    def get_master_ids(self, uids: list[str]) -> list[str]:
+        """Public method to get contact card IDs for a list of UIDs.
+
+        The UIDs are batched into separate OR queries so the filter stays within server limits, and
+        each batch is fully paginated using the reported ``total``. We cannot rely on the generic
+        ``query`` helper here: it stops as soon as a page returns fewer IDs than requested, but a
+        server may cap a query page below that, which would silently drop matches after the first
+        page and let a re-run create duplicate cards."""
+
+        if not uids:
+            return []
+
+        ids: list[str] = []
+        for batch in self.create_batches(uids, self.max_objects_in_get):
+            filter = {"operator": "OR", "conditions": [{"uid": uid} for uid in batch]}
+            position = 0
+            total = None
+            while True:
+                response = self._query(filter, position, len(batch), calculate_total=total is None)
+
+                method_responses = response.get("methodResponses")
+                if not method_responses:
+                    break
+
+                query_response = method_responses[0][1]
+                page = query_response.get("ids", [])
+                ids.extend(page)
+
+                if total is None:
+                    total = query_response.get("total")
+
+                position += len(page)
+                if not page or (total is not None and position >= total):
+                    break
+
+        return ids
+
+    def update_address_book_ids(
+        self,
+        ids: list[str],
+        add_address_book_id: str | None = None,
+        remove_address_book_id: str | None = None,
+        move_to_address_book_id: str | None = None,
+    ) -> dict:
+        """
+        Updates addressBookIds for the provided contact cards.
+
+        Behavior:
+        - add_address_book_id: adds the contact to an address book
+        - remove_address_book_id: removes the contact from an address book
+        - add + remove: moves contact between address books (patch-based)
+        - move_to_address_book_id: replaces addressBookIds entirely
+        """
+
+        if move_to_address_book_id and (add_address_book_id or remove_address_book_id):
+            raise ValueError(
+                "Cannot specify 'move_to_address_book_id' together with 'add_address_book_id' or 'remove_address_book_id'."
+            )
+
+        if not any([add_address_book_id, remove_address_book_id, move_to_address_book_id]):
+            raise ValueError(
+                "At least one of 'add_address_book_id', 'remove_address_book_id', or 'move_to_address_book_id' must be specified."
+            )
+
+        result = {"updated": [], "notUpdated": {}}
+        for batch in self.create_batches(ids, self.max_objects_in_set):
+            if move_to_address_book_id:
+                payload = {"addressBookIds": {move_to_address_book_id: True}, "updated": utcnow()}
+            else:
+                payload = {"updated": utcnow()}
+
+                if add_address_book_id:
+                    payload[f"addressBookIds/{add_address_book_id}"] = True
+                if remove_address_book_id:
+                    payload[f"addressBookIds/{remove_address_book_id}"] = None
+
+            response = self._call(
+                self.capabilities,
+                [
+                    [
+                        f"{self.type}/set",
+                        {
+                            "accountId": self.account,
+                            "update": {id: payload for id in batch},
+                        },
+                        "0",
+                    ]
+                ],
+            )
+
+            if method_responses := response.get("methodResponses"):
+                result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+                if not_updated := method_responses[0][1].get("notUpdated", {}):
+                    result["notUpdated"].update(not_updated)
+
+        return result
+
+    def set_address_book_ids(self, mapping: dict[str, dict[str, bool]]) -> dict:
+        """Replaces the addressBookIds of each given card with the provided map, batching to stay within
+        the server's per-'set' limit.
+
+        Used by the import rollback flow to move cards out of the staging address book into their final
+        address book(s) once every card has been created; only addressBookIds is touched, so the rest of
+        the card is left untouched."""
+
+        # Mirror set_calendar_ids: patch addressBookIds only and let the server manage the `updated`
+        # timestamp, so we never depend on `updated` being client-writable for ContactCard.
+        result = {"updated": [], "notUpdated": {}}
+        for batch in self.create_batches(list(mapping.items()), self.max_objects_in_set):
+            payload = {id: {"addressBookIds": book_ids} for id, book_ids in batch}
+
+            response = self._update(payload)
+
+            if method_responses := response.get("methodResponses"):
+                result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+                if not_updated := method_responses[0][1].get("notUpdated", {}):
+                    result["notUpdated"].update(not_updated)
+
+        return result
+
+    @staticmethod
+    def _get_name_map(full_name: str | None = None) -> dict:
+        """Helper method to construct the 'name' property map for a contact card based on the provided full name."""
+
+        if full_name:
+            given, surname = full_name.split(" ", 1) if " " in full_name else (full_name, None)
+            return {
+                "@type": "Name",
+                "full": full_name,
+                "components": [{"kind": "given", "value": given}, {"kind": "surname", "value": surname}],
+                "isOrdered": True,
+            }
+
+        return {}
+
+    @staticmethod
+    def _get_emails_map(emails: list[dict] | None = None) -> dict[str, dict] | None:
+        """Helper method to construct the 'emails' property map for a contact card based on the provided list of email dictionaries."""
+
+        if emails:
+            emails_map = {}
+            for email in emails:
+                emails_map[str(uuid7())] = {
+                    "address": email["address"],
+                    "label": email.get("label"),
+                    "contexts": {email["type"]: True},
+                }
+
+            return emails_map
+
+    @staticmethod
+    def _get_phones_map(phones: list[dict] | None = None) -> dict[str, dict] | None:
+        """Helper method to construct the 'phones' property map for a contact card based on the provided list of phone dictionaries."""
+
+        if phones:
+            phones_map = {}
+            for phone in phones:
+                phones_map[str(uuid7())] = {
+                    "number": phone["number"],
+                    "label": phone.get("label"),
+                    "contexts": {phone["type"]: True},
+                }
+
+            return phones_map
+
+    @staticmethod
+    def _get_addresses_map(addresses: list[dict] | None = None) -> dict[str, dict] | None:
+        """Helper method to construct the 'addresses' property map for a contact card based on the provided list of address dictionaries."""
+
+        if addresses:
+            counter = 0
+            addresses_map = {}
+            for address in addresses:
+                components = []
+                for field, key in {
+                    "street": "name",
+                    "locality": "locality",
+                    "region": "region",
+                    "postcode": "postcode",
+                    "country": "country",
+                }.items():
+                    components.append({"kind": key, "value": address.get(field)})
+
+                addresses_map[f"{counter}"] = {
+                    "components": components,
+                    "timeZone": address.get("time_zone"),
+                    "contexts": {address["type"]: True},
+                }
+                counter += 1
+
+            return addresses_map

--- a/suite/mail/jmap/services/contacts/contacts.py
+++ b/suite/mail/jmap/services/contacts/contacts.py
@@ -4,20 +4,20 @@ from suite.mail.jmap.services.core import CoreService
 
 
 class ContactsService(CoreService):
-	"""Service for handling contact-related functionality based on the JMAP server capabilities."""
+    """Service for handling contact-related functionality based on the JMAP server capabilities."""
 
-	capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:contacts"]
+    capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:contacts"]
 
-	def __post_init__(self) -> None:
-		"""Post-initialization to check if the JMAP server supports the Contacts capability and raise an error if not."""
+    def __post_init__(self) -> None:
+        """Post-initialization to check if the JMAP server supports the Contacts capability and raise an error if not."""
 
-		super().__post_init__()
+        super().__post_init__()
 
-		if "urn:ietf:params:jmap:contacts" not in self.connection.capabilities:
-			raise NotImplementedError("The JMAP server does not support the Contacts capability.")
+        if "urn:ietf:params:jmap:contacts" not in self.connection.capabilities:
+            raise NotImplementedError("The JMAP server does not support the Contacts capability.")
 
-	@property
-	def primary_account_id(self) -> str:
-		"""Returns the primary account ID for the logged-in user."""
+    @property
+    def primary_account_id(self) -> str:
+        """Returns the primary account ID for the logged-in user."""
 
-		return self.connection.primary_accounts["urn:ietf:params:jmap:contacts"]
+        return self.connection.primary_accounts["urn:ietf:params:jmap:contacts"]

--- a/suite/mail/jmap/services/core.py
+++ b/suite/mail/jmap/services/core.py
@@ -9,436 +9,436 @@ from suite.mail.jmap.connection import JMAPConnection
 
 
 class CoreServiceHelper:
-	"""Helper class for CoreService, providing utility methods for batch processing."""
+    """Helper class for CoreService, providing utility methods for batch processing."""
 
-	@staticmethod
-	def create_batches(items: list[Any], size: int) -> Iterator[list[Any]]:
-		"""Helper method to create batches of items for processing."""
+    @staticmethod
+    def create_batches(items: list[Any], size: int) -> Iterator[list[Any]]:
+        """Helper method to create batches of items for processing."""
 
-		for i in range(0, len(items), size):
-			yield items[i : i + size]
+        for i in range(0, len(items), size):
+            yield items[i : i + size]
 
-	@staticmethod
-	def batch_dict(d: dict[str, Any], batch_size: int) -> list[dict[str, Any]]:
-		"""Helper method to split a dictionary into smaller dictionaries of a specified batch size."""
+    @staticmethod
+    def batch_dict(d: dict[str, Any], batch_size: int) -> list[dict[str, Any]]:
+        """Helper method to split a dictionary into smaller dictionaries of a specified batch size."""
 
-		keys = list(d.keys())
-		return [{k: d[k] for k in keys[i : i + batch_size]} for i in range(0, len(keys), batch_size)]
+        keys = list(d.keys())
+        return [{k: d[k] for k in keys[i : i + batch_size]} for i in range(0, len(keys), batch_size)]
 
 
 class CallIdGenerator:
-	"""Utility class to generate unique call IDs for JMAP method calls."""
+    """Utility class to generate unique call IDs for JMAP method calls."""
 
-	def __init__(self, start: int = 0) -> None:
-		"""Initializes the CallIdGenerator with an optional starting value for the call ID counter."""
+    def __init__(self, start: int = 0) -> None:
+        """Initializes the CallIdGenerator with an optional starting value for the call ID counter."""
 
-		self._value = start
+        self._value = start
 
-	def next(self) -> str:
-		"""Generates the next unique call ID as a string, incrementing the internal counter for each call."""
+    def next(self) -> str:
+        """Generates the next unique call ID as a string, incrementing the internal counter for each call."""
 
-		val = str(self._value)
-		self._value += 1
-		return val
+        val = str(self._value)
+        self._value += 1
+        return val
 
 
 class CoreService(CoreServiceHelper):
-	"""Core service for JMAP operations, providing common functionality and properties."""
+    """Core service for JMAP operations, providing common functionality and properties."""
 
-	_cache = TTLCache(maxsize=1_00_000, ttl=1 * 60 * 60)
+    _cache = TTLCache(maxsize=1_00_000, ttl=1 * 60 * 60)
 
-	capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core"]
+    capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core"]
 
-	def __init__(self, account: str, connection: JMAPConnection) -> None:
-		"""Initializes the CoreService with the provided account ID and JMAP connection.
+    def __init__(self, account: str, connection: JMAPConnection) -> None:
+        """Initializes the CoreService with the provided account ID and JMAP connection.
 
-		The connection carries the authenticated user; only the JMAP ``account`` is needed
-		to scope requests (and as the cache key, since account data is shared across the users
-		who have access to it)."""
+        The connection carries the authenticated user; only the JMAP ``account`` is needed
+        to scope requests (and as the cache key, since account data is shared across the users
+        who have access to it)."""
 
-		self.account = account
-		self.connection = connection
+        self.account = account
+        self.connection = connection
 
-	def __post_init__(self) -> None:
-		"""Post-initialization to check if the JMAP server supports the required capabilities and raise an error if not."""
+    def __post_init__(self) -> None:
+        """Post-initialization to check if the JMAP server supports the required capabilities and raise an error if not."""
 
-		if "urn:ietf:params:jmap:core" not in self.connection.capabilities:
-			raise NotImplementedError("The JMAP server does not support the Core capability.")
+        if "urn:ietf:params:jmap:core" not in self.connection.capabilities:
+            raise NotImplementedError("The JMAP server does not support the Core capability.")
 
-	@classmethod
-	def invalidate_cache(
-		cls, account: str | None = None, key: Literal["identities", "mailboxes"] | None = None
-	) -> None:
-		"""Invalidates the cache for a specific account and key, or for all accounts and keys if no parameters are provided."""
+    @classmethod
+    def invalidate_cache(
+        cls, account: str | None = None, key: Literal["identities", "mailboxes"] | None = None
+    ) -> None:
+        """Invalidates the cache for a specific account and key, or for all accounts and keys if no parameters are provided."""
 
-		if account:
-			if key:
-				if account in cls._cache and key in cls._cache[account]:
-					del cls._cache[account][key]  # Remove the specific key from the account's cache
-			else:
-				cls._cache.pop(account, None)  # Remove the entire cache for the specified account
-		else:
-			if key:
-				for account_cache in cls._cache.values():  # Remove the specific key from all account caches
-					account_cache.pop(key, None)
-			else:
-				cls._cache.clear()  # Clear the entire cache for all accounts and keys
+        if account:
+            if key:
+                if account in cls._cache and key in cls._cache[account]:
+                    del cls._cache[account][key]  # Remove the specific key from the account's cache
+            else:
+                cls._cache.pop(account, None)  # Remove the entire cache for the specified account
+        else:
+            if key:
+                for account_cache in cls._cache.values():  # Remove the specific key from all account caches
+                    account_cache.pop(key, None)
+            else:
+                cls._cache.clear()  # Clear the entire cache for all accounts and keys
 
-	@property
-	def _type(self) -> str:
-		"""Returns the type of objects managed by this service, based on the 'type' class variable defined in subclasses."""
+    @property
+    def _type(self) -> str:
+        """Returns the type of objects managed by this service, based on the 'type' class variable defined in subclasses."""
 
-		if not hasattr(self, "type") or not isinstance(self.type, str):
-			raise NotImplementedError(
-				"Subclasses of CoreService must define a 'type' class variable of type str."
-			)
+        if not hasattr(self, "type") or not isinstance(self.type, str):
+            raise NotImplementedError(
+                "Subclasses of CoreService must define a 'type' class variable of type str."
+            )
 
-		return self.type
+        return self.type
 
-	@property
-	def cache(self) -> dict:
-		"""Returns the cache for the current account, creating a new cache entry if it does not exist."""
+    @property
+    def cache(self) -> dict:
+        """Returns the cache for the current account, creating a new cache entry if it does not exist."""
 
-		if self.account in self._cache:
-			return self._cache[self.account]
+        if self.account in self._cache:
+            return self._cache[self.account]
 
-		self._cache[self.account] = {}
+        self._cache[self.account] = {}
 
-		return self._cache[self.account]
+        return self._cache[self.account]
 
-	@property
-	def core(self) -> dict:
-		"""Returns the core capabilities of the JMAP server."""
+    @property
+    def core(self) -> dict:
+        """Returns the core capabilities of the JMAP server."""
 
-		return self.connection.capabilities["urn:ietf:params:jmap:core"]
+        return self.connection.capabilities["urn:ietf:params:jmap:core"]
 
-	@property
-	def max_calls_in_request(self) -> int:
-		"""Returns the maximum number of method calls allowed in a single JMAP request."""
+    @property
+    def max_calls_in_request(self) -> int:
+        """Returns the maximum number of method calls allowed in a single JMAP request."""
 
-		return self.core.get("maxCallsInRequest") or 16
+        return self.core.get("maxCallsInRequest") or 16
 
-	@property
-	def max_size_upload(self) -> int:
-		"""Returns the maximum size of an upload allowed by the JMAP server, in bytes."""
+    @property
+    def max_size_upload(self) -> int:
+        """Returns the maximum size of an upload allowed by the JMAP server, in bytes."""
 
-		return self.core.get("maxSizeUpload") or 50_000_000
+        return self.core.get("maxSizeUpload") or 50_000_000
 
-	@property
-	def max_concurrent_upload(self) -> int:
-		"""Returns the maximum number of concurrent uploads allowed by the JMAP server."""
+    @property
+    def max_concurrent_upload(self) -> int:
+        """Returns the maximum number of concurrent uploads allowed by the JMAP server."""
 
-		return self.core.get("maxConcurrentUpload") or 4
+        return self.core.get("maxConcurrentUpload") or 4
 
-	@property
-	def max_size_request(self) -> int:
-		"""Returns the maximum size of a JMAP request allowed by the server, in bytes."""
+    @property
+    def max_size_request(self) -> int:
+        """Returns the maximum size of a JMAP request allowed by the server, in bytes."""
 
-		return self.core.get("maxSizeRequest") or 10_000_000
+        return self.core.get("maxSizeRequest") or 10_000_000
 
-	@property
-	def max_concurrent_requests(self) -> int:
-		"""Returns the maximum number of concurrent requests allowed by the JMAP server."""
+    @property
+    def max_concurrent_requests(self) -> int:
+        """Returns the maximum number of concurrent requests allowed by the JMAP server."""
 
-		return self.core.get("maxConcurrentRequests") or 4
+        return self.core.get("maxConcurrentRequests") or 4
 
-	@property
-	def max_objects_in_get(self) -> int:
-		"""Returns the maximum number of objects that can be retrieved in a single JMAP 'get' method call."""
+    @property
+    def max_objects_in_get(self) -> int:
+        """Returns the maximum number of objects that can be retrieved in a single JMAP 'get' method call."""
 
-		return self.core.get("maxObjectsInGet") or 500
+        return self.core.get("maxObjectsInGet") or 500
 
-	@property
-	def max_objects_in_set(self) -> int:
-		"""Returns the maximum number of objects that can be created, updated, or destroyed in a single JMAP 'set' method call."""
+    @property
+    def max_objects_in_set(self) -> int:
+        """Returns the maximum number of objects that can be created, updated, or destroyed in a single JMAP 'set' method call."""
 
-		return self.core.get("maxObjectsInSet") or 500
+        return self.core.get("maxObjectsInSet") or 500
 
-	@property
-	def account_ids(self) -> list[str]:
-		"""Returns the list of account IDs for the logged-in user."""
+    @property
+    def account_ids(self) -> list[str]:
+        """Returns the list of account IDs for the logged-in user."""
 
-		return list(self.connection.accounts.keys())
+        return list(self.connection.accounts.keys())
 
-	@property
-	def has_multiple_accounts(self) -> bool:
-		"""Returns True if the user has multiple accounts, False otherwise."""
+    @property
+    def has_multiple_accounts(self) -> bool:
+        """Returns True if the user has multiple accounts, False otherwise."""
 
-		return len(self.account_ids) > 1
+        return len(self.account_ids) > 1
 
-	@property
-	def primary_account_id(self) -> str:
-		"""Returns the primary account ID for the logged-in user."""
+    @property
+    def primary_account_id(self) -> str:
+        """Returns the primary account ID for the logged-in user."""
 
-		return self.connection.primary_accounts["urn:ietf:params:jmap:mail"]
+        return self.connection.primary_accounts["urn:ietf:params:jmap:mail"]
 
-	@property
-	def personal_account_id(self) -> str | None:
-		"""Returns the personal account ID for the logged-in user, if any, or None if no personal account is found."""
+    @property
+    def personal_account_id(self) -> str | None:
+        """Returns the personal account ID for the logged-in user, if any, or None if no personal account is found."""
 
-		for account, details in self.connection.accounts.items():
-			if details.get("isPersonal"):
-				return account
+        for account, details in self.connection.accounts.items():
+            if details.get("isPersonal"):
+                return account
 
-	@property
-	def identities(self) -> list[dict]:
-		"""Returns the list of identities for the account, using caching to optimize performance."""
+    @property
+    def identities(self) -> list[dict]:
+        """Returns the list of identities for the account, using caching to optimize performance."""
 
-		if identities := self.cache.get("identities"):
-			return identities
+        if identities := self.cache.get("identities"):
+            return identities
 
-		from suite.mail.jmap.services.mail.identity import IdentityService
+        from suite.mail.jmap.services.mail.identity import IdentityService
 
-		identities = IdentityService(self.account, self.connection).get()
-		self.cache["identities"] = identities
+        identities = IdentityService(self.account, self.connection).get()
+        self.cache["identities"] = identities
 
-		return identities
+        return identities
 
-	@property
-	def mailboxes(self) -> list[dict]:
-		"""Returns the list of mailboxes for the account, using caching to optimize performance."""
+    @property
+    def mailboxes(self) -> list[dict]:
+        """Returns the list of mailboxes for the account, using caching to optimize performance."""
 
-		if mailboxes := self.cache.get("mailboxes"):
-			return mailboxes
+        if mailboxes := self.cache.get("mailboxes"):
+            return mailboxes
 
-		from suite.mail.jmap.services.mail.mailbox import MailboxService
+        from suite.mail.jmap.services.mail.mailbox import MailboxService
 
-		mailboxes = MailboxService(self.account, self.connection).get()
-		self.cache["mailboxes"] = mailboxes
+        mailboxes = MailboxService(self.account, self.connection).get()
+        self.cache["mailboxes"] = mailboxes
 
-		return mailboxes
+        return mailboxes
 
-	@cached_property
-	def address_books(self) -> list[dict]:
-		"""Returns the list of address books for the account, using caching to optimize performance."""
+    @cached_property
+    def address_books(self) -> list[dict]:
+        """Returns the list of address books for the account, using caching to optimize performance."""
 
-		from suite.mail.jmap.services.contacts.address_book import AddressBookService
+        from suite.mail.jmap.services.contacts.address_book import AddressBookService
 
-		return AddressBookService(self.account, self.connection).get()
+        return AddressBookService(self.account, self.connection).get()
 
-	@cached_property
-	def calendars(self) -> list[dict]:
-		"""Returns the list of calendars for the account, using caching to optimize performance."""
+    @cached_property
+    def calendars(self) -> list[dict]:
+        """Returns the list of calendars for the account, using caching to optimize performance."""
 
-		from suite.mail.jmap.services.calendars.calendar import CalendarService
+        from suite.mail.jmap.services.calendars.calendar import CalendarService
 
-		return CalendarService(self.account, self.connection).get()
+        return CalendarService(self.account, self.connection).get()
 
-	@cached_property
-	def participant_identities(self) -> list[dict]:
-		"""Returns the list of participant identities for the account, using caching to optimize performance."""
+    @cached_property
+    def participant_identities(self) -> list[dict]:
+        """Returns the list of participant identities for the account, using caching to optimize performance."""
 
-		from suite.mail.jmap.services.calendars.participant_identity import ParticipantIdentityService
+        from suite.mail.jmap.services.calendars.participant_identity import ParticipantIdentityService
 
-		return ParticipantIdentityService(self.account, self.connection).get()
+        return ParticipantIdentityService(self.account, self.connection).get()
 
-	def validate_capabilities(self, required_capabilities: list[str], raise_exception: bool = False) -> bool:
-		"""Validates that the required capabilities are supported by the JMAP server."""
+    def validate_capabilities(self, required_capabilities: list[str], raise_exception: bool = False) -> bool:
+        """Validates that the required capabilities are supported by the JMAP server."""
 
-		capabilities = self.connection.capabilities
+        capabilities = self.connection.capabilities
 
-		for capability in required_capabilities:
-			if capability not in capabilities:
-				if raise_exception:
-					raise ValueError(
-						f"Required capability '{capability}' is not supported by the JMAP server."
-					)
+        for capability in required_capabilities:
+            if capability not in capabilities:
+                if raise_exception:
+                    raise ValueError(
+                        f"Required capability '{capability}' is not supported by the JMAP server."
+                    )
 
-				return False
+                return False
 
-		return True
+        return True
 
-	def validate_method_calls(
-		self, method_calls: list[list[str | dict]], raise_exception: bool = False
-	) -> bool:
-		"""Validates the format and content of the method calls in a JMAP request."""
+    def validate_method_calls(
+        self, method_calls: list[list[str | dict]], raise_exception: bool = False
+    ) -> bool:
+        """Validates the format and content of the method calls in a JMAP request."""
 
-		if not method_calls or len(method_calls) > self.max_calls_in_request:
-			if raise_exception:
-				raise ValueError("Invalid number of method calls.")
-			return False
+        if not method_calls or len(method_calls) > self.max_calls_in_request:
+            if raise_exception:
+                raise ValueError("Invalid number of method calls.")
+            return False
 
-		call_ids = []
-		for method_call in method_calls:
-			if not isinstance(method_call, list) or len(method_call) != 3:
-				if raise_exception:
-					raise ValueError("Invalid method call format.")
-				return False
+        call_ids = []
+        for method_call in method_calls:
+            if not isinstance(method_call, list) or len(method_call) != 3:
+                if raise_exception:
+                    raise ValueError("Invalid method call format.")
+                return False
 
-			if (
-				not isinstance(method_call[0], str)
-				or not isinstance(method_call[1], dict)
-				or not isinstance(method_call[2], str)
-			):
-				if raise_exception:
-					raise ValueError("Invalid method call format.")
-				return False
+            if (
+                not isinstance(method_call[0], str)
+                or not isinstance(method_call[1], dict)
+                or not isinstance(method_call[2], str)
+            ):
+                if raise_exception:
+                    raise ValueError("Invalid method call format.")
+                return False
 
-			if method_call[2] in call_ids:
-				if raise_exception:
-					raise ValueError("Duplicate method call ID.")
-				return False
+            if method_call[2] in call_ids:
+                if raise_exception:
+                    raise ValueError("Duplicate method call ID.")
+                return False
 
-			call_ids.append(method_call[2])
+            call_ids.append(method_call[2])
 
-		return True
+        return True
 
-	def _call(self, capabilities: list[str], method_calls: list[list[str | dict]], **kwargs) -> dict:
-		"""Sends a JMAP request to the server with the specified capabilities and method calls."""
+    def _call(self, capabilities: list[str], method_calls: list[list[str | dict]], **kwargs) -> dict:
+        """Sends a JMAP request to the server with the specified capabilities and method calls."""
 
-		self.validate_capabilities(capabilities, raise_exception=True)
-		self.validate_method_calls(method_calls, raise_exception=True)
+        self.validate_capabilities(capabilities, raise_exception=True)
+        self.validate_method_calls(method_calls, raise_exception=True)
 
-		payload = {"using": capabilities, "methodCalls": method_calls}
+        payload = {"using": capabilities, "methodCalls": method_calls}
 
-		response = self.connection.request(
-			method="POST",
-			url=self.connection.api_url,
-			headers={"Content-Type": "application/json"},
-			json=payload,
-			return_json=True,
-			**kwargs,
-		)
+        response = self.connection.request(
+            method="POST",
+            url=self.connection.api_url,
+            headers={"Content-Type": "application/json"},
+            json=payload,
+            return_json=True,
+            **kwargs,
+        )
 
-		session_state = response["sessionState"]
-		if self.connection.state != session_state:
-			self.connection._session_discovery()
-			self._sync_accounts_on_state_change()
+        session_state = response["sessionState"]
+        if self.connection.state != session_state:
+            self.connection._session_discovery()
+            self._sync_accounts_on_state_change()
 
-		return response
+        return response
 
-	def _sync_accounts_on_state_change(self) -> None:
-		"""Resync the user's JMAP Accounts after the JMAP session state changes.
+    def _sync_accounts_on_state_change(self) -> None:
+        """Resync the user's JMAP Accounts after the JMAP session state changes.
 
-		The session state only changes when the set of accounts available to the user changes
-		on the JMAP server, so a change here means the local JMAP Account documents and User
-		Account links may be stale and need reconciling against the freshly discovered session.
-		"""
+        The session state only changes when the set of accounts available to the user changes
+        on the JMAP server, so a change here means the local JMAP Account documents and User
+        Account links may be stale and need reconciling against the freshly discovered session.
+        """
 
-		if not self.connection.user:
-			return
+        if not self.connection.user:
+            return
 
-		# Lazy import to avoid a circular dependency (jmap_account -> suite.mail.jmap -> core).
-		from suite.mail.doctype.jmap_account.jmap_account import sync_jmap_accounts
+        # Lazy import to avoid a circular dependency (jmap_account -> suite.mail.jmap -> core).
+        from suite.mail.doctype.jmap_account.jmap_account import sync_jmap_accounts
 
-		sync_jmap_accounts(self.connection.user, self.connection.accounts)
+        sync_jmap_accounts(self.connection.user, self.connection.accounts)
 
-	def _exec(self, action: Literal["get", "set", "query", "changes", "upload", "lookup"], **payload) -> dict:
-		payload = {**{k: v for k, v in payload.items() if v is not None}}
+    def _exec(self, action: Literal["get", "set", "query", "changes", "upload", "lookup"], **payload) -> dict:
+        payload = {**{k: v for k, v in payload.items() if v is not None}}
 
-		if self._type != "PushSubscription":
-			payload["accountId"] = self.account
+        if self._type != "PushSubscription":
+            payload["accountId"] = self.account
 
-		return self._call(
-			capabilities=self.capabilities,
-			method_calls=[[f"{self._type}/{action}", payload, "0"]],
-		)
+        return self._call(
+            capabilities=self.capabilities,
+            method_calls=[[f"{self._type}/{action}", payload, "0"]],
+        )
 
-	def _create(self, create: dict, **kwargs) -> dict:
-		"""Internal method to create objects of the specified type using the JMAP 'set' method."""
+    def _create(self, create: dict, **kwargs) -> dict:
+        """Internal method to create objects of the specified type using the JMAP 'set' method."""
 
-		return self._exec("set", create=create, **kwargs)
+        return self._exec("set", create=create, **kwargs)
 
-	def _get(self, ids: list[str] | None = None, properties: list[str] | None = None, **kwargs) -> dict:
-		"""Internal method to get objects of the specified type using the JMAP 'get' method, optionally filtering by a list of IDs."""
+    def _get(self, ids: list[str] | None = None, properties: list[str] | None = None, **kwargs) -> dict:
+        """Internal method to get objects of the specified type using the JMAP 'get' method, optionally filtering by a list of IDs."""
 
-		return self._exec("get", ids=ids, properties=properties, **kwargs)
+        return self._exec("get", ids=ids, properties=properties, **kwargs)
 
-	def _update(self, update: dict, **kwargs) -> dict:
-		"""Internal method to update objects of the specified type using the JMAP 'set' method."""
+    def _update(self, update: dict, **kwargs) -> dict:
+        """Internal method to update objects of the specified type using the JMAP 'set' method."""
 
-		return self._exec("set", update=update, **kwargs)
+        return self._exec("set", update=update, **kwargs)
 
-	def _delete(self, destroy: list[str], **kwargs) -> dict:
-		"""Internal method to delete objects of the specified type using the JMAP 'set' method, filtering by a list of IDs."""
+    def _delete(self, destroy: list[str], **kwargs) -> dict:
+        """Internal method to delete objects of the specified type using the JMAP 'set' method, filtering by a list of IDs."""
 
-		return self._exec("set", destroy=destroy, **kwargs)
+        return self._exec("set", destroy=destroy, **kwargs)
 
-	def _query(
-		self,
-		filter: dict | None = None,
-		position: int = 0,
-		limit: int = 50,
-		sort: list[dict] | None = None,
-		calculate_total: bool = True,
-		**kwargs,
-	) -> dict:
-		"""Internal method to query objects of the specified type using the JMAP 'query' method, with support for filtering, sorting, and pagination."""
+    def _query(
+        self,
+        filter: dict | None = None,
+        position: int = 0,
+        limit: int = 50,
+        sort: list[dict] | None = None,
+        calculate_total: bool = True,
+        **kwargs,
+    ) -> dict:
+        """Internal method to query objects of the specified type using the JMAP 'query' method, with support for filtering, sorting, and pagination."""
 
-		return self._exec(
-			"query",
-			filter=filter,
-			position=position,
-			limit=limit,
-			sort=sort,
-			calculateTotal=calculate_total,
-			**kwargs,
-		)
+        return self._exec(
+            "query",
+            filter=filter,
+            position=position,
+            limit=limit,
+            sort=sort,
+            calculateTotal=calculate_total,
+            **kwargs,
+        )
 
-	def _changes(self, since_state: str) -> dict:
-		"""Internal method to get changes of the specified type since a given state using the JMAP 'changes' method."""
+    def _changes(self, since_state: str) -> dict:
+        """Internal method to get changes of the specified type since a given state using the JMAP 'changes' method."""
 
-		return self._exec("changes", sinceState=since_state)
+        return self._exec("changes", sinceState=since_state)
 
-	def upload_blob(self, blob: bytes | str, content_type: str = "message/rfc822") -> dict:
-		"""Uploads a blob to the JMAP server using the upload URL, and returns the response containing the blob ID and other metadata."""
+    def upload_blob(self, blob: bytes | str, content_type: str = "message/rfc822") -> dict:
+        """Uploads a blob to the JMAP server using the upload URL, and returns the response containing the blob ID and other metadata."""
 
-		upload_url = self.connection.upload_url.format(accountId=self.account)
-		return self.connection.request(
-			method="POST",
-			url=upload_url,
-			headers={"Content-Type": content_type},
-			data=blob,
-			return_json=True,
-		)
+        upload_url = self.connection.upload_url.format(accountId=self.account)
+        return self.connection.request(
+            method="POST",
+            url=upload_url,
+            headers={"Content-Type": content_type},
+            data=blob,
+            return_json=True,
+        )
 
-	def upload_blobs_concurrently(self, blobs: list[tuple[bytes | str, str]]) -> list[dict]:
-		"""Uploads multiple blobs concurrently to the JMAP server, given a list of tuples containing the blob data and content type, and returns a list of responses containing the blob IDs and other metadata."""
+    def upload_blobs_concurrently(self, blobs: list[tuple[bytes | str, str]]) -> list[dict]:
+        """Uploads multiple blobs concurrently to the JMAP server, given a list of tuples containing the blob data and content type, and returns a list of responses containing the blob IDs and other metadata."""
 
-		count = len(blobs)
-		if count == 0:
-			return []
+        count = len(blobs)
+        if count == 0:
+            return []
 
-		results = [None] * count
+        results = [None] * count
 
-		if count == 1:
-			blob, content_type = blobs[0]
-			return [self.upload_blob(blob, content_type)]
+        if count == 1:
+            blob, content_type = blobs[0]
+            return [self.upload_blob(blob, content_type)]
 
-		with ThreadPoolExecutor(max_workers=self.max_concurrent_upload) as executor:
-			future_to_index = {}
+        with ThreadPoolExecutor(max_workers=self.max_concurrent_upload) as executor:
+            future_to_index = {}
 
-			for index, (blob, content_type) in enumerate(blobs):
-				future = executor.submit(self.upload_blob, blob, content_type)
-				future_to_index[future] = index
+            for index, (blob, content_type) in enumerate(blobs):
+                future = executor.submit(self.upload_blob, blob, content_type)
+                future_to_index[future] = index
 
-			for future in as_completed(future_to_index):
-				index = future_to_index[future]
-				results[index] = future.result()
+            for future in as_completed(future_to_index):
+                index = future_to_index[future]
+                results[index] = future.result()
 
-		return results
+        return results
 
-	def download_blob(self, blob_id: str, name: str | None = None) -> bytes:
-		"""Downloads a blob from the JMAP server using the download URL, given the blob ID and an optional name for the downloaded file, and returns the content of the blob as bytes."""
+    def download_blob(self, blob_id: str, name: str | None = None) -> bytes:
+        """Downloads a blob from the JMAP server using the download URL, given the blob ID and an optional name for the downloaded file, and returns the content of the blob as bytes."""
 
-		name = name or "blob"
-		download_url = self.connection.download_url.format(
-			accountId=self.account, blobId=blob_id, name=name, type="application/octet-stream"
-		)
-		return self.connection.request(method="GET", url=download_url, return_json=False)
+        name = name or "blob"
+        download_url = self.connection.download_url.format(
+            accountId=self.account, blobId=blob_id, name=name, type="application/octet-stream"
+        )
+        return self.connection.request(method="GET", url=download_url, return_json=False)
 
-	def download_blobs_concurrently(self, blobs: list[tuple[str, str | None]]) -> dict[str, bytes]:
-		"""Downloads multiple blobs concurrently from the JMAP server, given a list of tuples containing blob IDs and optional names, and returns a dictionary mapping blob IDs to their downloaded content."""
+    def download_blobs_concurrently(self, blobs: list[tuple[str, str | None]]) -> dict[str, bytes]:
+        """Downloads multiple blobs concurrently from the JMAP server, given a list of tuples containing blob IDs and optional names, and returns a dictionary mapping blob IDs to their downloaded content."""
 
-		if len(blobs) == 1:
-			blob_id, name = blobs[0]
-			return {blob_id: self.download_blob(blob_id, name)}
+        if len(blobs) == 1:
+            blob_id, name = blobs[0]
+            return {blob_id: self.download_blob(blob_id, name)}
 
-		results = {}
-		with ThreadPoolExecutor(max_workers=5) as executor:
-			futures = {executor.submit(self.download_blob, blob_id, name): blob_id for blob_id, name in blobs}
-			for future in as_completed(futures):
-				blob_id = futures[future]
-				results[blob_id] = future.result()
+        results = {}
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            futures = {executor.submit(self.download_blob, blob_id, name): blob_id for blob_id, name in blobs}
+            for future in as_completed(futures):
+                blob_id = futures[future]
+                results[blob_id] = future.result()
 
-		return results
+        return results

--- a/suite/mail/jmap/services/mail/email.py
+++ b/suite/mail/jmap/services/mail/email.py
@@ -12,548 +12,548 @@ from suite.utils.dt import convert_to_utc
 
 
 class EmailService(MailService):
-	"""Service for handling email-related functionality based on the JMAP server capabilities."""
-
-	type: ClassVar[str] = "Email"
-
-	def create(self, emails: list[EmailCreateModel]) -> dict:
-		"""
-		Public method to create email drafts and optionally submit them, handling batching if the number of emails exceeds the server's maximum allowed in a single 'set' call.
-		Returns a dictionary containing the results of draft creation and submission.
-		"""
-
-		method_calls = []
-
-		call_id_gen = CallIdGenerator()
-
-		draft_calls, draft_refs = self._create(emails, call_id_gen)
-		method_calls.extend(draft_calls)
-
-		submission_service = EmailSubmissionService(self.account, self.connection)
-		submission_calls = submission_service._create(emails, draft_refs, call_id_gen)
-		method_calls.extend(submission_calls)
-
-		if submission_calls:
-			return submission_service._call(submission_service.capabilities, method_calls=method_calls)
-
-		return self._call(self.capabilities, method_calls=method_calls)
-
-	def get(self, ids: list[str], properties: list[str] | None = None) -> list[dict]:
-		"""Public method to get emails, handling batching if a list of ids is provided and allowing optional specification of properties to retrieve."""
-
-		properties = properties or [
-			"id",
-			"blobId",
-			"threadId",
-			"mailboxIds",
-			"keywords",
-			"size",
-			"receivedAt",
-			"sentAt",
-			"hasAttachment",
-			"subject",
-			"preview",
-			"from",
-			"to",
-			"cc",
-			"bcc",
-			"replyTo",
-			"sender",
-			"messageId",
-			"inReplyTo",
-			"references",
-			"htmlBody",
-			"textBody",
-			"bodyValues",
-			"attachments",
-		]
-
-		results = []
-		if ids:
-			for batch in self.create_batches(ids, self.max_objects_in_get):
-				response = self._get(batch, properties=properties, fetchAllBodyValues=True)
-
-				if method_responses := response.get("methodResponses"):
-					results.extend(method_responses[0][1].get("list", []))
-		else:
-			response = self._get(properties=properties, fetchAllBodyValues=True)
-			if method_responses := response.get("methodResponses"):
-				results.extend(method_responses[0][1].get("list", []))
-
-		return results
-
-	def update(
-		self, emails: list[dict], replace_keywords: bool = False, replace_mailboxes: bool = False
-	) -> dict:
-		"""Public method to update emails, handling batching if the number of emails exceeds the server's maximum allowed in a single 'set' call. Allows updating of keywords and mailboxIds."""
-
-		result = {"updated": [], "notUpdated": {}}
-		for batch in self.create_batches(emails, self.max_objects_in_set):
-			payload = {}
-			for email in batch:
-				payload[email["id"]] = {}
-
-				if keywords := email.get("keywords", {}):
-					if replace_keywords:
-						payload[email["id"]]["keywords"] = keywords
-					else:
-						payload[email["id"]].update({f"keywords/{k}": v for k, v in keywords.items()})
-
-				if mailbox_ids := email.get("mailbox_ids", {}):
-					if replace_mailboxes:
-						payload[email["id"]]["mailboxIds"] = mailbox_ids
-					else:
-						payload[email["id"]].update({f"mailboxIds/{k}": v for k, v in mailbox_ids.items()})
-
-				if not payload[email["id"]]:
-					raise ValueError(
-						"At least one of 'keywords' or 'mailbox_ids' must be provided for update."
-					)
-
-			response = self._update(payload)
-
-			if method_responses := response.get("methodResponses"):
-				result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-				if not_updated := method_responses[0][1].get("notUpdated", {}):
-					result["notUpdated"].update(not_updated)
+    """Service for handling email-related functionality based on the JMAP server capabilities."""
+
+    type: ClassVar[str] = "Email"
+
+    def create(self, emails: list[EmailCreateModel]) -> dict:
+        """
+        Public method to create email drafts and optionally submit them, handling batching if the number of emails exceeds the server's maximum allowed in a single 'set' call.
+        Returns a dictionary containing the results of draft creation and submission.
+        """
+
+        method_calls = []
+
+        call_id_gen = CallIdGenerator()
+
+        draft_calls, draft_refs = self._create(emails, call_id_gen)
+        method_calls.extend(draft_calls)
+
+        submission_service = EmailSubmissionService(self.account, self.connection)
+        submission_calls = submission_service._create(emails, draft_refs, call_id_gen)
+        method_calls.extend(submission_calls)
+
+        if submission_calls:
+            return submission_service._call(submission_service.capabilities, method_calls=method_calls)
+
+        return self._call(self.capabilities, method_calls=method_calls)
+
+    def get(self, ids: list[str], properties: list[str] | None = None) -> list[dict]:
+        """Public method to get emails, handling batching if a list of ids is provided and allowing optional specification of properties to retrieve."""
+
+        properties = properties or [
+            "id",
+            "blobId",
+            "threadId",
+            "mailboxIds",
+            "keywords",
+            "size",
+            "receivedAt",
+            "sentAt",
+            "hasAttachment",
+            "subject",
+            "preview",
+            "from",
+            "to",
+            "cc",
+            "bcc",
+            "replyTo",
+            "sender",
+            "messageId",
+            "inReplyTo",
+            "references",
+            "htmlBody",
+            "textBody",
+            "bodyValues",
+            "attachments",
+        ]
+
+        results = []
+        if ids:
+            for batch in self.create_batches(ids, self.max_objects_in_get):
+                response = self._get(batch, properties=properties, fetchAllBodyValues=True)
+
+                if method_responses := response.get("methodResponses"):
+                    results.extend(method_responses[0][1].get("list", []))
+        else:
+            response = self._get(properties=properties, fetchAllBodyValues=True)
+            if method_responses := response.get("methodResponses"):
+                results.extend(method_responses[0][1].get("list", []))
+
+        return results
+
+    def update(
+        self, emails: list[dict], replace_keywords: bool = False, replace_mailboxes: bool = False
+    ) -> dict:
+        """Public method to update emails, handling batching if the number of emails exceeds the server's maximum allowed in a single 'set' call. Allows updating of keywords and mailboxIds."""
+
+        result = {"updated": [], "notUpdated": {}}
+        for batch in self.create_batches(emails, self.max_objects_in_set):
+            payload = {}
+            for email in batch:
+                payload[email["id"]] = {}
+
+                if keywords := email.get("keywords", {}):
+                    if replace_keywords:
+                        payload[email["id"]]["keywords"] = keywords
+                    else:
+                        payload[email["id"]].update({f"keywords/{k}": v for k, v in keywords.items()})
+
+                if mailbox_ids := email.get("mailbox_ids", {}):
+                    if replace_mailboxes:
+                        payload[email["id"]]["mailboxIds"] = mailbox_ids
+                    else:
+                        payload[email["id"]].update({f"mailboxIds/{k}": v for k, v in mailbox_ids.items()})
+
+                if not payload[email["id"]]:
+                    raise ValueError(
+                        "At least one of 'keywords' or 'mailbox_ids' must be provided for update."
+                    )
+
+            response = self._update(payload)
+
+            if method_responses := response.get("methodResponses"):
+                result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+                if not_updated := method_responses[0][1].get("notUpdated", {}):
+                    result["notUpdated"].update(not_updated)
 
-		return result
-
-	def delete(self, ids: list[str]) -> dict:
-		"""Public method to delete emails, handling batching if the number of ids exceeds the server's maximum allowed in a single 'set' call."""
-
-		result = {"destroyed": [], "notDestroyed": {}}
-		for batch in self.create_batches(ids, self.max_objects_in_set):
-			response = self._delete(batch)
-
-			if method_responses := response.get("methodResponses"):
-				result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
-				if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
-					result["notDestroyed"].update(not_destroyed)
-
-		return result
-
-	def query(
-		self, filter: dict | None = None, position: int = 0, limit: int = 50, sort: list[dict] | None = None
-	) -> dict:
-		"""Public method to query emails, handling batching if the number of results exceeds the server's maximum allowed in a single 'query' call."""
-
-		ids = []
-		total = None
-		batch_size = min(limit, self.max_objects_in_get)
-		sort = sort or [{"property": "receivedAt", "isAscending": False}]
-
-		while len(ids) < limit:
-			current_batch_size = min(batch_size, limit - len(ids))
-
-			response = self._query(filter, position, current_batch_size, sort, calculate_total=total is None)
-
-			method_responses = response.get("methodResponses")
-			if not method_responses:
-				break
-
-			query_response = method_responses[0][1]
-			batch_ids = query_response.get("ids", [])
-			ids.extend(batch_ids)
-
-			if total is None:
-				total = query_response.get("total")
-
-			if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
-				break
-
-			position += len(batch_ids)
-
-		return {"ids": ids[:limit], "total": total}
-
-	def changes(self, since_state: str) -> dict:
-		"""Public method to get changes to emails since a given state."""
-
-		response = self._changes(since_state)
-
-		if method_responses := response.get("methodResponses"):
-			return method_responses[0][1]
-
-		return {}
-
-	def search(self, text: str, limit: int = 50, separate_requests: bool = False) -> list[str]:
-		"""Public method to search for emails matching the given text in subject, to, cc, bcc, body or text."""
-
-		ids: list[str] = []
-
-		def collect_ids(response) -> None:
-			"""Helper function to collect unique email IDs from the method responses."""
-
-			for _method, result, _call_id in response.get("methodResponses", []):
-				for id in result.get("ids", []):
-					if id not in ids:
-						ids.append(id)
-
-		filters = [
-			{"subject": text},
-			{"to": text},
-			{"cc": text},
-			{"bcc": text},
-			{"body": text},
-			{"text": text},
-		]
-
-		method_calls = [
-			[
-				f"{self._type}/query",
-				{
-					"accountId": self.account,
-					"filter": f,
-					"position": 0,
-					"limit": limit,
-					"sort": [{"property": "receivedAt", "isAscending": False}],
-					"calculateTotal": False,
-				},
-				str(i),
-			]
-			for i, f in enumerate(filters)
-		]
-
-		if separate_requests:
-			for call in method_calls:
-				collect_ids(self._call(self.capabilities, method_calls=[call]))
-		else:
-			collect_ids(self._call(self.capabilities, method_calls=method_calls))
-
-		return ids[:limit]
-
-	def query_thread(
-		self, filter: dict | None = None, position: int = 0, limit: int = 50, fetch_all: bool = False
-	) -> list[str] | dict[str, list[str]]:
-		"""Public method to query email threads, returning either a list of thread IDs or a mapping of thread IDs to email IDs of threads matching the filter."""
-
-		method_calls = [
-			[
-				"Email/query",
-				{
-					"accountId": self.account,
-					"filter": filter or {},
-					"sort": [{"property": "receivedAt", "isAscending": False}],
-					"collapseThreads": True,
-					"position": position,
-					"limit": limit,
-				},
-				"0",
-			]
-		]
-
-		if fetch_all:
-			method_calls.extend(
-				[
-					[
-						"Email/get",
-						{
-							"accountId": self.account,
-							"#ids": {
-								"resultOf": "0",
-								"name": "Email/query",
-								"path": "/ids",
-							},
-							"properties": ["threadId"],
-						},
-						"1",
-					],
-					[
-						"Thread/get",
-						{
-							"accountId": self.account,
-							"#ids": {
-								"resultOf": "1",
-								"name": "Email/get",
-								"path": "/list/*/threadId",
-							},
-							"properties": ["id", "emailIds"],
-						},
-						"2",
-					],
-				]
-			)
-
-		response = self._call(self.capabilities, method_calls=method_calls)
-		method_responses = response.get("methodResponses", [])
-
-		if not fetch_all:
-			if not method_responses:
-				return []
-
-			return method_responses[0][1].get("ids", [])
-
-		if len(method_responses) < 3:
-			return {}
-
-		return {thread["id"]: thread.get("emailIds", []) for thread in method_responses[2][1].get("list", [])}
-
-	def get_email_suggestions(self, text: str, limit: int = 5, separate_requests: bool = False) -> list[str]:
-		"""
-		Get email suggestions based on the given text.
-
-		Args:
-		        text (str): The text to search for in email addresses.
-		        limit (int): The maximum number of suggestions to return.
-		        separate_requests (bool): Whether to make separate requests for each filter.
-
-		Returns:
-		        list[str]: A list of email addresses matching the given text.
-		"""
-
-		ids: list[str] = []
-		addresses: list[str] = []
-
-		def collect_ids(response) -> None:
-			"""Helper function to collect unique email IDs from the method responses."""
-
-			for _method, result, _call_id in response.get("methodResponses", []):
-				for id in result.get("ids", []):
-					if id not in ids:
-						ids.append(id)
-
-		filters = [
-			{"from": text},
-			{"to": text},
-			{"cc": text},
-			{"bcc": text},
-		]
-
-		method_calls = [
-			[
-				f"{self._type}/query",
-				{
-					"accountId": self.account,
-					"filter": f,
-					"position": 0,
-					"limit": limit,
-					"sort": [{"property": "receivedAt", "isAscending": False}],
-					"calculateTotal": False,
-				},
-				str(i),
-			]
-			for i, f in enumerate(filters)
-		]
-
-		if separate_requests:
-			for call in method_calls:
-				collect_ids(self._call(self.capabilities, method_calls=[call]))
-		else:
-			collect_ids(self._call(self.capabilities, method_calls=method_calls))
-
-		if not ids:
-			return addresses
-
-		emails = self.get(ids, properties=["from", "to", "cc", "bcc"])
-
-		for email in emails:
-			for field in ("from", "to", "cc", "bcc"):
-				for addr in email.get(field) or []:
-					email_address = addr.get("email")
-					if (
-						email_address
-						and text.lower() in email_address.lower()
-						and email_address not in addresses
-					):
-						addresses.append(email_address)
-
-		return addresses[:limit]
-
-	def _create(self, emails: list[EmailCreateModel], call_id_gen: CallIdGenerator) -> tuple[list, dict]:
-		"""Helper method to create email drafts for the given list of EmailCreateModel instances and return the method calls for the JMAP request along with a mapping of creation IDs to draft references."""
-
-		method_calls = []
-		draft_refs = {}
-
-		mailbox_service = MailboxService(self.account, self.connection)
-		draft_mailbox_id = mailbox_service.get_mailbox_id_by_role(
-			"drafts", create_if_not_exists=True, raise_exception=True
-		)
-
-		for email in emails:
-			draft_ref = f"draft-{email.creation_id}"
-			draft_refs[email.creation_id] = draft_ref
-
-			# --------------------------------------------------
-			# RAW MESSAGE → Email/import
-			# --------------------------------------------------
-
-			if email.raw_message:
-				blob = self.upload_blob(email.raw_message.encode("utf-8"), content_type="message/rfc822")
-
-				method_calls.append(
-					[
-						f"{self.type}/import",
-						{
-							"accountId": self.account,
-							"emails": {
-								draft_ref: {
-									"blobId": blob["blobId"],
-									"mailboxIds": {draft_mailbox_id: True},
-									"keywords": {"$draft": True, "$seen": True},
-								}
-							},
-						},
-						call_id_gen.next(),
-					]
-				)
-
-				# Destroy old email if existing_id is provided.
-				if email.existing_id:
-					method_calls.append(
-						[
-							f"{self.type}/set",
-							{
-								"accountId": self.account,
-								"destroy": [email.existing_id],
-							},
-							call_id_gen.next(),
-						]
-					)
-
-			# --------------------------------------------------
-			# NORMAL DRAFT → Email/set
-			# --------------------------------------------------
-
-			else:
-				payload = {
-					"accountId": self.account,
-					"create": {draft_ref: self._get_draft(email, draft_mailbox_id)},
-				}
-
-				if email.existing_id:
-					payload["destroy"] = [email.existing_id]
-
-				method_calls.append([f"{self.type}/set", payload, call_id_gen.next()])
-
-		return method_calls, draft_refs
-
-	@staticmethod
-	def _get_recipients(
-		recipients: list[EmailRecipient], kind: Literal["to", "cc", "bcc"]
-	) -> list[dict[str, str | None]]:
-		"""Helper function to filter recipients by type and format them for the JMAP payload."""
-
-		return [{"name": r.name, "email": r.email} for r in recipients if r.type == kind]
-
-	@staticmethod
-	def _get_draft(email: EmailCreateModel, draft_mailbox_id: str) -> dict:
-		"""Helper function to build the draft payload for the email creation."""
-
-		draft = {
-			"mailboxIds": {draft_mailbox_id: True},
-			"keywords": {"$draft": True, "$seen": True},
-			"from": [{"name": email.from_name, "email": email.from_email}],
-		}
-
-		# Add TO/CC/BCC
-		if email.recipients:
-			for kind in ("to", "cc", "bcc"):
-				if rcpts := EmailService._get_recipients(email.recipients, kind):
-					draft[kind] = rcpts
-
-		if email.subject:
-			draft["subject"] = email.subject
-
-		# Headers
-		if email.sent_at:
-			draft["sentAt"] = convert_to_utc(email.sent_at).isoformat()
-		if email.message_id:
-			draft["header:Message-ID"] = f"<{email.message_id}>"
-
-		draft.update(
-			{
-				"header:User-Agent": f"Frappe Mail v{__version__} (Frappe v{frappe.__version__})",
-				"header:X-Mailer": "Frappe Mail",
-				"header:X-Mail-Queue": str(email.creation_id),
-			}
-		)
-
-		if email.reply_to:
-			draft["header:Reply-To"] = ", ".join(f'"{r.name}" <{r.email}>' for r in email.reply_to)
-
-		if email.in_reply_to:
-			draft["header:In-Reply-To"] = f"<{email.in_reply_to}>"
-
-		if email.headers:
-			for header in email.headers:
-				draft[f"header:{header.name}"] = header.value
-
-		# Body parts
-		draft["bodyValues"] = {}
-
-		text_part = html_part = None
-
-		if email.text_body:
-			text_part = {"partId": "text", "type": "text/plain"}
-			draft["bodyValues"]["text"] = {
-				"value": email.text_body,
-				"charset": "utf-8",
-				"isTruncated": False,
-			}
-
-		if email.html_body:
-			html_part = {"partId": "html", "type": "text/html"}
-			draft["bodyValues"]["html"] = {
-				"value": email.html_body,
-				"charset": "utf-8",
-				"isTruncated": False,
-			}
-
-		# Attachments
-		attachments = email.attachments or []
-		inline_attachments = [a for a in attachments if a.disposition == "inline"]
-		regular_attachments = [a for a in attachments if a.disposition != "inline"]
-		body_parts = [p for p in (text_part, html_part) if p]
-
-		if inline_attachments and body_parts:
-			# Inline images are referenced from the HTML body via `cid:` URLs. Build an
-			# explicit MIME structure that nests them inside a `multipart/related` container
-			# (next to the body) instead of letting them become plain siblings of the body in
-			# `multipart/mixed`. Some providers (e.g. AWS) treat every `multipart/mixed` part
-			# as a regular attachment and reject inline images by extension, whereas clients
-			# like Gmail wrap them in `multipart/related` so they are recognized as inline.
-			body_root = (
-				{"type": "multipart/alternative", "subParts": body_parts}
-				if len(body_parts) > 1
-				else body_parts[0]
-			)
-
-			body_structure = {
-				"type": "multipart/related",
-				"subParts": [body_root, *(EmailService._get_body_part(a) for a in inline_attachments)],
-			}
-
-			if regular_attachments:
-				body_structure = {
-					"type": "multipart/mixed",
-					"subParts": [
-						body_structure,
-						*(EmailService._get_body_part(a) for a in regular_attachments),
-					],
-				}
-
-			draft["bodyStructure"] = body_structure
-		else:
-			# No inline images: let the server assemble the structure from the convenience
-			# properties (`multipart/alternative` for the body, `multipart/mixed` for attachments).
-			if text_part:
-				draft["textBody"] = [text_part]
-			if html_part:
-				draft["htmlBody"] = [html_part]
-			if attachments:
-				draft["attachments"] = [EmailService._get_body_part(a) for a in attachments]
-
-		return draft
-
-	@staticmethod
-	def _get_body_part(attachment: EmailAttachment) -> dict[str, str]:
-		"""Helper function to build an EmailBodyPart payload for an attachment."""
-
-		return {
-			"name": attachment.name,
-			"type": attachment.type,
-			"cid": attachment.cid,
-			"blobId": attachment.blob_id,
-			"disposition": attachment.disposition,
-		}
+        return result
+
+    def delete(self, ids: list[str]) -> dict:
+        """Public method to delete emails, handling batching if the number of ids exceeds the server's maximum allowed in a single 'set' call."""
+
+        result = {"destroyed": [], "notDestroyed": {}}
+        for batch in self.create_batches(ids, self.max_objects_in_set):
+            response = self._delete(batch)
+
+            if method_responses := response.get("methodResponses"):
+                result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
+                if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
+                    result["notDestroyed"].update(not_destroyed)
+
+        return result
+
+    def query(
+        self, filter: dict | None = None, position: int = 0, limit: int = 50, sort: list[dict] | None = None
+    ) -> dict:
+        """Public method to query emails, handling batching if the number of results exceeds the server's maximum allowed in a single 'query' call."""
+
+        ids = []
+        total = None
+        batch_size = min(limit, self.max_objects_in_get)
+        sort = sort or [{"property": "receivedAt", "isAscending": False}]
+
+        while len(ids) < limit:
+            current_batch_size = min(batch_size, limit - len(ids))
+
+            response = self._query(filter, position, current_batch_size, sort, calculate_total=total is None)
+
+            method_responses = response.get("methodResponses")
+            if not method_responses:
+                break
+
+            query_response = method_responses[0][1]
+            batch_ids = query_response.get("ids", [])
+            ids.extend(batch_ids)
+
+            if total is None:
+                total = query_response.get("total")
+
+            if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
+                break
+
+            position += len(batch_ids)
+
+        return {"ids": ids[:limit], "total": total}
+
+    def changes(self, since_state: str) -> dict:
+        """Public method to get changes to emails since a given state."""
+
+        response = self._changes(since_state)
+
+        if method_responses := response.get("methodResponses"):
+            return method_responses[0][1]
+
+        return {}
+
+    def search(self, text: str, limit: int = 50, separate_requests: bool = False) -> list[str]:
+        """Public method to search for emails matching the given text in subject, to, cc, bcc, body or text."""
+
+        ids: list[str] = []
+
+        def collect_ids(response) -> None:
+            """Helper function to collect unique email IDs from the method responses."""
+
+            for _method, result, _call_id in response.get("methodResponses", []):
+                for id in result.get("ids", []):
+                    if id not in ids:
+                        ids.append(id)
+
+        filters = [
+            {"subject": text},
+            {"to": text},
+            {"cc": text},
+            {"bcc": text},
+            {"body": text},
+            {"text": text},
+        ]
+
+        method_calls = [
+            [
+                f"{self._type}/query",
+                {
+                    "accountId": self.account,
+                    "filter": f,
+                    "position": 0,
+                    "limit": limit,
+                    "sort": [{"property": "receivedAt", "isAscending": False}],
+                    "calculateTotal": False,
+                },
+                str(i),
+            ]
+            for i, f in enumerate(filters)
+        ]
+
+        if separate_requests:
+            for call in method_calls:
+                collect_ids(self._call(self.capabilities, method_calls=[call]))
+        else:
+            collect_ids(self._call(self.capabilities, method_calls=method_calls))
+
+        return ids[:limit]
+
+    def query_thread(
+        self, filter: dict | None = None, position: int = 0, limit: int = 50, fetch_all: bool = False
+    ) -> list[str] | dict[str, list[str]]:
+        """Public method to query email threads, returning either a list of thread IDs or a mapping of thread IDs to email IDs of threads matching the filter."""
+
+        method_calls = [
+            [
+                "Email/query",
+                {
+                    "accountId": self.account,
+                    "filter": filter or {},
+                    "sort": [{"property": "receivedAt", "isAscending": False}],
+                    "collapseThreads": True,
+                    "position": position,
+                    "limit": limit,
+                },
+                "0",
+            ]
+        ]
+
+        if fetch_all:
+            method_calls.extend(
+                [
+                    [
+                        "Email/get",
+                        {
+                            "accountId": self.account,
+                            "#ids": {
+                                "resultOf": "0",
+                                "name": "Email/query",
+                                "path": "/ids",
+                            },
+                            "properties": ["threadId"],
+                        },
+                        "1",
+                    ],
+                    [
+                        "Thread/get",
+                        {
+                            "accountId": self.account,
+                            "#ids": {
+                                "resultOf": "1",
+                                "name": "Email/get",
+                                "path": "/list/*/threadId",
+                            },
+                            "properties": ["id", "emailIds"],
+                        },
+                        "2",
+                    ],
+                ]
+            )
+
+        response = self._call(self.capabilities, method_calls=method_calls)
+        method_responses = response.get("methodResponses", [])
+
+        if not fetch_all:
+            if not method_responses:
+                return []
+
+            return method_responses[0][1].get("ids", [])
+
+        if len(method_responses) < 3:
+            return {}
+
+        return {thread["id"]: thread.get("emailIds", []) for thread in method_responses[2][1].get("list", [])}
+
+    def get_email_suggestions(self, text: str, limit: int = 5, separate_requests: bool = False) -> list[str]:
+        """
+        Get email suggestions based on the given text.
+
+        Args:
+                text (str): The text to search for in email addresses.
+                limit (int): The maximum number of suggestions to return.
+                separate_requests (bool): Whether to make separate requests for each filter.
+
+        Returns:
+                list[str]: A list of email addresses matching the given text.
+        """
+
+        ids: list[str] = []
+        addresses: list[str] = []
+
+        def collect_ids(response) -> None:
+            """Helper function to collect unique email IDs from the method responses."""
+
+            for _method, result, _call_id in response.get("methodResponses", []):
+                for id in result.get("ids", []):
+                    if id not in ids:
+                        ids.append(id)
+
+        filters = [
+            {"from": text},
+            {"to": text},
+            {"cc": text},
+            {"bcc": text},
+        ]
+
+        method_calls = [
+            [
+                f"{self._type}/query",
+                {
+                    "accountId": self.account,
+                    "filter": f,
+                    "position": 0,
+                    "limit": limit,
+                    "sort": [{"property": "receivedAt", "isAscending": False}],
+                    "calculateTotal": False,
+                },
+                str(i),
+            ]
+            for i, f in enumerate(filters)
+        ]
+
+        if separate_requests:
+            for call in method_calls:
+                collect_ids(self._call(self.capabilities, method_calls=[call]))
+        else:
+            collect_ids(self._call(self.capabilities, method_calls=method_calls))
+
+        if not ids:
+            return addresses
+
+        emails = self.get(ids, properties=["from", "to", "cc", "bcc"])
+
+        for email in emails:
+            for field in ("from", "to", "cc", "bcc"):
+                for addr in email.get(field) or []:
+                    email_address = addr.get("email")
+                    if (
+                        email_address
+                        and text.lower() in email_address.lower()
+                        and email_address not in addresses
+                    ):
+                        addresses.append(email_address)
+
+        return addresses[:limit]
+
+    def _create(self, emails: list[EmailCreateModel], call_id_gen: CallIdGenerator) -> tuple[list, dict]:
+        """Helper method to create email drafts for the given list of EmailCreateModel instances and return the method calls for the JMAP request along with a mapping of creation IDs to draft references."""
+
+        method_calls = []
+        draft_refs = {}
+
+        mailbox_service = MailboxService(self.account, self.connection)
+        draft_mailbox_id = mailbox_service.get_mailbox_id_by_role(
+            "drafts", create_if_not_exists=True, raise_exception=True
+        )
+
+        for email in emails:
+            draft_ref = f"draft-{email.creation_id}"
+            draft_refs[email.creation_id] = draft_ref
+
+            # --------------------------------------------------
+            # RAW MESSAGE → Email/import
+            # --------------------------------------------------
+
+            if email.raw_message:
+                blob = self.upload_blob(email.raw_message.encode("utf-8"), content_type="message/rfc822")
+
+                method_calls.append(
+                    [
+                        f"{self.type}/import",
+                        {
+                            "accountId": self.account,
+                            "emails": {
+                                draft_ref: {
+                                    "blobId": blob["blobId"],
+                                    "mailboxIds": {draft_mailbox_id: True},
+                                    "keywords": {"$draft": True, "$seen": True},
+                                }
+                            },
+                        },
+                        call_id_gen.next(),
+                    ]
+                )
+
+                # Destroy old email if existing_id is provided.
+                if email.existing_id:
+                    method_calls.append(
+                        [
+                            f"{self.type}/set",
+                            {
+                                "accountId": self.account,
+                                "destroy": [email.existing_id],
+                            },
+                            call_id_gen.next(),
+                        ]
+                    )
+
+            # --------------------------------------------------
+            # NORMAL DRAFT → Email/set
+            # --------------------------------------------------
+
+            else:
+                payload = {
+                    "accountId": self.account,
+                    "create": {draft_ref: self._get_draft(email, draft_mailbox_id)},
+                }
+
+                if email.existing_id:
+                    payload["destroy"] = [email.existing_id]
+
+                method_calls.append([f"{self.type}/set", payload, call_id_gen.next()])
+
+        return method_calls, draft_refs
+
+    @staticmethod
+    def _get_recipients(
+        recipients: list[EmailRecipient], kind: Literal["to", "cc", "bcc"]
+    ) -> list[dict[str, str | None]]:
+        """Helper function to filter recipients by type and format them for the JMAP payload."""
+
+        return [{"name": r.name, "email": r.email} for r in recipients if r.type == kind]
+
+    @staticmethod
+    def _get_draft(email: EmailCreateModel, draft_mailbox_id: str) -> dict:
+        """Helper function to build the draft payload for the email creation."""
+
+        draft = {
+            "mailboxIds": {draft_mailbox_id: True},
+            "keywords": {"$draft": True, "$seen": True},
+            "from": [{"name": email.from_name, "email": email.from_email}],
+        }
+
+        # Add TO/CC/BCC
+        if email.recipients:
+            for kind in ("to", "cc", "bcc"):
+                if rcpts := EmailService._get_recipients(email.recipients, kind):
+                    draft[kind] = rcpts
+
+        if email.subject:
+            draft["subject"] = email.subject
+
+        # Headers
+        if email.sent_at:
+            draft["sentAt"] = convert_to_utc(email.sent_at).isoformat()
+        if email.message_id:
+            draft["header:Message-ID"] = f"<{email.message_id}>"
+
+        draft.update(
+            {
+                "header:User-Agent": f"Frappe Mail v{__version__} (Frappe v{frappe.__version__})",
+                "header:X-Mailer": "Frappe Mail",
+                "header:X-Mail-Queue": str(email.creation_id),
+            }
+        )
+
+        if email.reply_to:
+            draft["header:Reply-To"] = ", ".join(f'"{r.name}" <{r.email}>' for r in email.reply_to)
+
+        if email.in_reply_to:
+            draft["header:In-Reply-To"] = f"<{email.in_reply_to}>"
+
+        if email.headers:
+            for header in email.headers:
+                draft[f"header:{header.name}"] = header.value
+
+        # Body parts
+        draft["bodyValues"] = {}
+
+        text_part = html_part = None
+
+        if email.text_body:
+            text_part = {"partId": "text", "type": "text/plain"}
+            draft["bodyValues"]["text"] = {
+                "value": email.text_body,
+                "charset": "utf-8",
+                "isTruncated": False,
+            }
+
+        if email.html_body:
+            html_part = {"partId": "html", "type": "text/html"}
+            draft["bodyValues"]["html"] = {
+                "value": email.html_body,
+                "charset": "utf-8",
+                "isTruncated": False,
+            }
+
+        # Attachments
+        attachments = email.attachments or []
+        inline_attachments = [a for a in attachments if a.disposition == "inline"]
+        regular_attachments = [a for a in attachments if a.disposition != "inline"]
+        body_parts = [p for p in (text_part, html_part) if p]
+
+        if inline_attachments and body_parts:
+            # Inline images are referenced from the HTML body via `cid:` URLs. Build an
+            # explicit MIME structure that nests them inside a `multipart/related` container
+            # (next to the body) instead of letting them become plain siblings of the body in
+            # `multipart/mixed`. Some providers (e.g. AWS) treat every `multipart/mixed` part
+            # as a regular attachment and reject inline images by extension, whereas clients
+            # like Gmail wrap them in `multipart/related` so they are recognized as inline.
+            body_root = (
+                {"type": "multipart/alternative", "subParts": body_parts}
+                if len(body_parts) > 1
+                else body_parts[0]
+            )
+
+            body_structure = {
+                "type": "multipart/related",
+                "subParts": [body_root, *(EmailService._get_body_part(a) for a in inline_attachments)],
+            }
+
+            if regular_attachments:
+                body_structure = {
+                    "type": "multipart/mixed",
+                    "subParts": [
+                        body_structure,
+                        *(EmailService._get_body_part(a) for a in regular_attachments),
+                    ],
+                }
+
+            draft["bodyStructure"] = body_structure
+        else:
+            # No inline images: let the server assemble the structure from the convenience
+            # properties (`multipart/alternative` for the body, `multipart/mixed` for attachments).
+            if text_part:
+                draft["textBody"] = [text_part]
+            if html_part:
+                draft["htmlBody"] = [html_part]
+            if attachments:
+                draft["attachments"] = [EmailService._get_body_part(a) for a in attachments]
+
+        return draft
+
+    @staticmethod
+    def _get_body_part(attachment: EmailAttachment) -> dict[str, str]:
+        """Helper function to build an EmailBodyPart payload for an attachment."""
+
+        return {
+            "name": attachment.name,
+            "type": attachment.type,
+            "cid": attachment.cid,
+            "blobId": attachment.blob_id,
+            "disposition": attachment.disposition,
+        }

--- a/suite/mail/jmap/services/mail/identity.py
+++ b/suite/mail/jmap/services/mail/identity.py
@@ -4,101 +4,101 @@ from suite.mail.jmap.services.mail.mail import MailService
 
 
 class IdentityService(MailService):
-	"""Service for handling identity-related functionality based on the JMAP server capabilities."""
+    """Service for handling identity-related functionality based on the JMAP server capabilities."""
 
-	type: ClassVar[str] = "Identity"
-	capabilities: ClassVar[list[str]] = [
-		"urn:ietf:params:jmap:core",
-		"urn:ietf:params:jmap:mail",
-		"urn:ietf:params:jmap:submission",
-	]
+    type: ClassVar[str] = "Identity"
+    capabilities: ClassVar[list[str]] = [
+        "urn:ietf:params:jmap:core",
+        "urn:ietf:params:jmap:mail",
+        "urn:ietf:params:jmap:submission",
+    ]
 
-	def create(self, identities: list[dict]) -> dict:
-		"""Public method to create identities, handling batching if the number of identities exceeds the server's maximum allowed in a single 'set' call."""
+    def create(self, identities: list[dict]) -> dict:
+        """Public method to create identities, handling batching if the number of identities exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"created": {}, "notCreated": {}}
-		for batch in self.create_batches(identities, self.max_objects_in_set):
-			payload = {}
-			for identity in batch:
-				payload[identity["creation_id"]] = {
-					"email": identity["email"],
-					"name": identity.get("name"),
-					"replyTo": identity.get("reply_to"),
-					"bcc": identity.get("bcc"),
-					"textSignature": identity.get("text_signature"),
-					"htmlSignature": identity.get("html_signature"),
-				}
+        result = {"created": {}, "notCreated": {}}
+        for batch in self.create_batches(identities, self.max_objects_in_set):
+            payload = {}
+            for identity in batch:
+                payload[identity["creation_id"]] = {
+                    "email": identity["email"],
+                    "name": identity.get("name"),
+                    "replyTo": identity.get("reply_to"),
+                    "bcc": identity.get("bcc"),
+                    "textSignature": identity.get("text_signature"),
+                    "htmlSignature": identity.get("html_signature"),
+                }
 
-			response = self._create(payload)
+            response = self._create(payload)
 
-			if method_responses := response.get("methodResponses"):
-				result["created"].update(method_responses[0][1].get("created", {}))
-				if not_created := method_responses[0][1].get("notCreated", {}):
-					result["notCreated"].update(not_created)
+            if method_responses := response.get("methodResponses"):
+                result["created"].update(method_responses[0][1].get("created", {}))
+                if not_created := method_responses[0][1].get("notCreated", {}):
+                    result["notCreated"].update(not_created)
 
-		return result
+        return result
 
-	def get(self, ids: list[str] | None = None) -> list[dict]:
-		"""Public method to get identities, handling batching if a list of ids is provided."""
+    def get(self, ids: list[str] | None = None) -> list[dict]:
+        """Public method to get identities, handling batching if a list of ids is provided."""
 
-		results = []
-		if ids:
-			for batch in self.create_batches(ids, self.max_objects_in_get):
-				response = self._get(batch)
+        results = []
+        if ids:
+            for batch in self.create_batches(ids, self.max_objects_in_get):
+                response = self._get(batch)
 
-				if method_responses := response.get("methodResponses"):
-					results.extend(method_responses[0][1].get("list", []))
-		else:
-			response = self._get()
-			if method_responses := response.get("methodResponses"):
-				results.extend(method_responses[0][1].get("list", []))
+                if method_responses := response.get("methodResponses"):
+                    results.extend(method_responses[0][1].get("list", []))
+        else:
+            response = self._get()
+            if method_responses := response.get("methodResponses"):
+                results.extend(method_responses[0][1].get("list", []))
 
-		return results
+        return results
 
-	def update(self, identities: list[dict]) -> dict:
-		"""Public method to update identities, handling batching if the number of identities exceeds the server's maximum allowed in a single 'set' call."""
+    def update(self, identities: list[dict]) -> dict:
+        """Public method to update identities, handling batching if the number of identities exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"updated": [], "notUpdated": {}}
-		for batch in self.create_batches(identities, self.max_objects_in_set):
-			payload = {}
-			for identity in batch:
-				payload[identity["id"]] = {
-					"name": identity.get("name"),
-					"replyTo": identity.get("reply_to"),
-					"bcc": identity.get("bcc"),
-					"textSignature": identity.get("text_signature"),
-					"htmlSignature": identity.get("html_signature"),
-				}
+        result = {"updated": [], "notUpdated": {}}
+        for batch in self.create_batches(identities, self.max_objects_in_set):
+            payload = {}
+            for identity in batch:
+                payload[identity["id"]] = {
+                    "name": identity.get("name"),
+                    "replyTo": identity.get("reply_to"),
+                    "bcc": identity.get("bcc"),
+                    "textSignature": identity.get("text_signature"),
+                    "htmlSignature": identity.get("html_signature"),
+                }
 
-			response = self._update(payload)
+            response = self._update(payload)
 
-			if method_responses := response.get("methodResponses"):
-				result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-				if not_updated := method_responses[0][1].get("notUpdated", {}):
-					result["notUpdated"].update(not_updated)
+            if method_responses := response.get("methodResponses"):
+                result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+                if not_updated := method_responses[0][1].get("notUpdated", {}):
+                    result["notUpdated"].update(not_updated)
 
-		return result
+        return result
 
-	def delete(self, ids: list[str]) -> dict:
-		"""Public method to delete identities, handling batching if the number of IDs exceeds the server's maximum allowed in a single 'set' call."""
+    def delete(self, ids: list[str]) -> dict:
+        """Public method to delete identities, handling batching if the number of IDs exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"destroyed": [], "notDestroyed": {}}
-		for batch in self.create_batches(ids, self.max_objects_in_set):
-			response = self._delete(batch)
+        result = {"destroyed": [], "notDestroyed": {}}
+        for batch in self.create_batches(ids, self.max_objects_in_set):
+            response = self._delete(batch)
 
-			if method_responses := response.get("methodResponses"):
-				result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
-				if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
-					result["notDestroyed"].update(not_destroyed)
+            if method_responses := response.get("methodResponses"):
+                result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
+                if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
+                    result["notDestroyed"].update(not_destroyed)
 
-		return result
+        return result
 
-	def get_identity_id_by_email(self, email: str, raise_exception: bool = False) -> str | None:
-		"""Returns the identity ID for the given email, or raises an exception if not found and raise_exception is True."""
+    def get_identity_id_by_email(self, email: str, raise_exception: bool = False) -> str | None:
+        """Returns the identity ID for the given email, or raises an exception if not found and raise_exception is True."""
 
-		for identity in self.identities:
-			if identity["email"].lower() == email.lower():
-				return identity["id"]
+        for identity in self.identities:
+            if identity["email"].lower() == email.lower():
+                return identity["id"]
 
-		if raise_exception:
-			raise ValueError(f"No identity found for email: {email}")
+        if raise_exception:
+            raise ValueError(f"No identity found for email: {email}")

--- a/suite/mail/jmap/services/mail/mail.py
+++ b/suite/mail/jmap/services/mail/mail.py
@@ -4,20 +4,20 @@ from suite.mail.jmap.services.core import CoreService
 
 
 class MailService(CoreService):
-	"""Service for handling mail-related functionality based on the JMAP server capabilities."""
+    """Service for handling mail-related functionality based on the JMAP server capabilities."""
 
-	capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"]
+    capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"]
 
-	def __post_init__(self) -> None:
-		"""Post-initialization to check if the JMAP server supports the Mail capability and raise an error if not."""
+    def __post_init__(self) -> None:
+        """Post-initialization to check if the JMAP server supports the Mail capability and raise an error if not."""
 
-		super().__post_init__()
+        super().__post_init__()
 
-		if "urn:ietf:params:jmap:mail" not in self.connection.capabilities:
-			raise NotImplementedError("The JMAP server does not support the Mail capability.")
+        if "urn:ietf:params:jmap:mail" not in self.connection.capabilities:
+            raise NotImplementedError("The JMAP server does not support the Mail capability.")
 
-	@property
-	def primary_account_id(self) -> str:
-		"""Returns the primary account ID for the logged-in user."""
+    @property
+    def primary_account_id(self) -> str:
+        """Returns the primary account ID for the logged-in user."""
 
-		return self.connection.primary_accounts["urn:ietf:params:jmap:mail"]
+        return self.connection.primary_accounts["urn:ietf:params:jmap:mail"]

--- a/suite/mail/jmap/services/mail/mailbox.py
+++ b/suite/mail/jmap/services/mail/mailbox.py
@@ -5,153 +5,153 @@ from suite.mail.jmap.services.mail.mail import MailService
 
 
 class MailboxService(MailService):
-	"""Service for handling mailbox-related operations based on the JMAP server capabilities."""
+    """Service for handling mailbox-related operations based on the JMAP server capabilities."""
 
-	type: ClassVar[str] = "Mailbox"
+    type: ClassVar[str] = "Mailbox"
 
-	def create(self, mailboxes: list[dict]) -> dict:
-		"""Public method to create mailboxes, handling batching if the number of mailboxes exceeds the server's maximum allowed in a single 'set' call."""
+    def create(self, mailboxes: list[dict]) -> dict:
+        """Public method to create mailboxes, handling batching if the number of mailboxes exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"created": {}, "notCreated": {}}
-		for batch in self.create_batches(mailboxes, self.max_objects_in_set):
-			payload = {}
-			for mailbox in batch:
-				payload[mailbox["creation_id"]] = {
-					"name": mailbox["name"],
-					"role": mailbox.get("role") or None,
-					"parentId": mailbox.get("parent_id") or None,
-					"sortOrder": int(mailbox.get("sort_order") or 0),
-					"isSubscribed": bool(mailbox.get("is_subscribed") or False),
-				}
+        result = {"created": {}, "notCreated": {}}
+        for batch in self.create_batches(mailboxes, self.max_objects_in_set):
+            payload = {}
+            for mailbox in batch:
+                payload[mailbox["creation_id"]] = {
+                    "name": mailbox["name"],
+                    "role": mailbox.get("role") or None,
+                    "parentId": mailbox.get("parent_id") or None,
+                    "sortOrder": int(mailbox.get("sort_order") or 0),
+                    "isSubscribed": bool(mailbox.get("is_subscribed") or False),
+                }
 
-			response = self._create(payload)
+            response = self._create(payload)
 
-			if method_responses := response.get("methodResponses"):
-				result["created"].update(method_responses[0][1].get("created", {}))
-				if not_created := method_responses[0][1].get("notCreated", {}):
-					result["notCreated"].update(not_created)
+            if method_responses := response.get("methodResponses"):
+                result["created"].update(method_responses[0][1].get("created", {}))
+                if not_created := method_responses[0][1].get("notCreated", {}):
+                    result["notCreated"].update(not_created)
 
-		return result
+        return result
 
-	def get(self, ids: list[str] | None = None) -> list[dict]:
-		"""Public method to get mailboxes, handling batching if a list of ids is provided."""
+    def get(self, ids: list[str] | None = None) -> list[dict]:
+        """Public method to get mailboxes, handling batching if a list of ids is provided."""
 
-		results = []
-		if ids:
-			for batch in self.create_batches(ids, self.max_objects_in_get):
-				response = self._get(batch)
+        results = []
+        if ids:
+            for batch in self.create_batches(ids, self.max_objects_in_get):
+                response = self._get(batch)
 
-				if method_responses := response.get("methodResponses"):
-					results.extend(method_responses[0][1].get("list", []))
-		else:
-			response = self._get()
-			if method_responses := response.get("methodResponses"):
-				results.extend(method_responses[0][1].get("list", []))
+                if method_responses := response.get("methodResponses"):
+                    results.extend(method_responses[0][1].get("list", []))
+        else:
+            response = self._get()
+            if method_responses := response.get("methodResponses"):
+                results.extend(method_responses[0][1].get("list", []))
 
-		return results
+        return results
 
-	def update(self, mailboxes: list[dict]) -> dict:
-		"""Public method to update mailboxes, handling batching if the number of mailboxes exceeds the server's maximum allowed in a single 'set' call."""
+    def update(self, mailboxes: list[dict]) -> dict:
+        """Public method to update mailboxes, handling batching if the number of mailboxes exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"updated": [], "notUpdated": {}}
-		for batch in self.create_batches(mailboxes, self.max_objects_in_set):
-			payload = {}
-			for mailbox in batch:
-				payload[mailbox["id"]] = {
-					"name": mailbox["name"],
-					"role": mailbox.get("role") or None,
-					"parentId": mailbox.get("parent_id") or None,
-					"sortOrder": int(mailbox.get("sort_order") or 0),
-					"isSubscribed": bool(mailbox.get("is_subscribed") or False),
-				}
+        result = {"updated": [], "notUpdated": {}}
+        for batch in self.create_batches(mailboxes, self.max_objects_in_set):
+            payload = {}
+            for mailbox in batch:
+                payload[mailbox["id"]] = {
+                    "name": mailbox["name"],
+                    "role": mailbox.get("role") or None,
+                    "parentId": mailbox.get("parent_id") or None,
+                    "sortOrder": int(mailbox.get("sort_order") or 0),
+                    "isSubscribed": bool(mailbox.get("is_subscribed") or False),
+                }
 
-			response = self._update(payload)
+            response = self._update(payload)
 
-			if method_responses := response.get("methodResponses"):
-				result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-				if not_updated := method_responses[0][1].get("notUpdated", {}):
-					result["notUpdated"].update(not_updated)
+            if method_responses := response.get("methodResponses"):
+                result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+                if not_updated := method_responses[0][1].get("notUpdated", {}):
+                    result["notUpdated"].update(not_updated)
 
-		return result
+        return result
 
-	def delete(self, ids: list[str], remove_emails: bool = False) -> dict:
-		"""Public method to delete mailboxes, handling batching if the number of mailbox IDs exceeds the server's maximum allowed in a single 'set' call."""
+    def delete(self, ids: list[str], remove_emails: bool = False) -> dict:
+        """Public method to delete mailboxes, handling batching if the number of mailbox IDs exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"destroyed": [], "notDestroyed": {}}
-		for batch in self.create_batches(ids, self.max_objects_in_set):
-			response = self._delete(batch, onDestroyRemoveEmails=remove_emails)
+        result = {"destroyed": [], "notDestroyed": {}}
+        for batch in self.create_batches(ids, self.max_objects_in_set):
+            response = self._delete(batch, onDestroyRemoveEmails=remove_emails)
 
-			if method_responses := response.get("methodResponses"):
-				result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
-				if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
-					result["notDestroyed"].update(not_destroyed)
+            if method_responses := response.get("methodResponses"):
+                result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
+                if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
+                    result["notDestroyed"].update(not_destroyed)
 
-		return result
+        return result
 
-	def get_mailbox_id_by_role(
-		self, role: str, create_if_not_exists: bool = False, raise_exception: bool = False
-	) -> str | None:
-		"""Return the mailbox ID for a given role, optionally creating it if missing."""
+    def get_mailbox_id_by_role(
+        self, role: str, create_if_not_exists: bool = False, raise_exception: bool = False
+    ) -> str | None:
+        """Return the mailbox ID for a given role, optionally creating it if missing."""
 
-		def find_id(role: str) -> str | None:
-			role = role.lower()
-			for mailbox in self.mailboxes:
-				mailbox_role = (mailbox.get("role") or "").lower()
-				if mailbox_role == role:
-					return mailbox["id"]
+        def find_id(role: str) -> str | None:
+            role = role.lower()
+            for mailbox in self.mailboxes:
+                mailbox_role = (mailbox.get("role") or "").lower()
+                if mailbox_role == role:
+                    return mailbox["id"]
 
-		if mailbox_id := find_id(role):
-			return mailbox_id
+        if mailbox_id := find_id(role):
+            return mailbox_id
 
-		if not create_if_not_exists:
-			if raise_exception:
-				raise ValueError(f"No mailbox found with role '{role}'")
+        if not create_if_not_exists:
+            if raise_exception:
+                raise ValueError(f"No mailbox found with role '{role}'")
 
-			return None
+            return None
 
-		creation_id = str(uuid7())
-		mailbox = {
-			"creation_id": creation_id,
-			"name": role.title(),
-			"role": role,
-			"is_subscribed": True,
-		}
-		response = self.create([mailbox])
+        creation_id = str(uuid7())
+        mailbox = {
+            "creation_id": creation_id,
+            "name": role.title(),
+            "role": role,
+            "is_subscribed": True,
+        }
+        response = self.create([mailbox])
 
-		if response.get("notCreated"):
-			if raise_exception:
-				raise ValueError(f"Failed to create mailbox with role '{role}'")
+        if response.get("notCreated"):
+            if raise_exception:
+                raise ValueError(f"Failed to create mailbox with role '{role}'")
 
-		self.invalidate_cache(self.account, key="mailboxes")
+        self.invalidate_cache(self.account, key="mailboxes")
 
-		return find_id(role)
+        return find_id(role)
 
-	def get_mailbox_role_by_id(self, id: str, raise_exception: bool = False) -> str | None:
-		"""Returns the mailbox role for the given ID."""
+    def get_mailbox_role_by_id(self, id: str, raise_exception: bool = False) -> str | None:
+        """Returns the mailbox role for the given ID."""
 
-		for mailbox in self.mailboxes:
-			if mailbox["id"] == id:
-				return mailbox["role"]
+        for mailbox in self.mailboxes:
+            if mailbox["id"] == id:
+                return mailbox["role"]
 
-		if raise_exception:
-			raise ValueError(f"No mailbox found with ID '{id}'")
+        if raise_exception:
+            raise ValueError(f"No mailbox found with ID '{id}'")
 
-	def get_mailbox_name_by_id(self, id: str, raise_exception: bool = False) -> str | None:
-		"""Returns the mailbox name for the given ID."""
+    def get_mailbox_name_by_id(self, id: str, raise_exception: bool = False) -> str | None:
+        """Returns the mailbox name for the given ID."""
 
-		for mailbox in self.mailboxes:
-			if id and mailbox["id"] == id:
-				return mailbox["name"]
+        for mailbox in self.mailboxes:
+            if id and mailbox["id"] == id:
+                return mailbox["name"]
 
-		if raise_exception:
-			raise ValueError(f"No mailbox found with ID '{id}'")
+        if raise_exception:
+            raise ValueError(f"No mailbox found with ID '{id}'")
 
-	def get_mailbox_id_by_name(self, name: str, raise_exception: bool = False) -> str | None:
-		"""Returns the mailbox ID for the given name."""
+    def get_mailbox_id_by_name(self, name: str, raise_exception: bool = False) -> str | None:
+        """Returns the mailbox ID for the given name."""
 
-		for mailbox in self.mailboxes:
-			if name and mailbox["name"] == name:
-				return mailbox["id"]
+        for mailbox in self.mailboxes:
+            if name and mailbox["name"] == name:
+                return mailbox["id"]
 
-		if raise_exception:
-			raise ValueError(f"No mailbox found with name '{name}'")
+        if raise_exception:
+            raise ValueError(f"No mailbox found with name '{name}'")

--- a/suite/mail/jmap/services/mail/submission/email_submission.py
+++ b/suite/mail/jmap/services/mail/submission/email_submission.py
@@ -8,135 +8,135 @@ from suite.mail.jmap.services.mail.mailbox import MailboxService
 
 
 class EmailSubmissionService(CoreService):
-	"""Service for handling email submission-related functionality based on the JMAP server capabilities."""
+    """Service for handling email submission-related functionality based on the JMAP server capabilities."""
 
-	type: ClassVar[str] = "EmailSubmission"
-	capabilities: ClassVar[list[str]] = [
-		"urn:ietf:params:jmap:core",
-		"urn:ietf:params:jmap:mail",
-		"urn:ietf:params:jmap:submission",
-	]
+    type: ClassVar[str] = "EmailSubmission"
+    capabilities: ClassVar[list[str]] = [
+        "urn:ietf:params:jmap:core",
+        "urn:ietf:params:jmap:mail",
+        "urn:ietf:params:jmap:submission",
+    ]
 
-	def __post_init__(self) -> None:
-		"""Post-initialization to check if the JMAP server supports the Mail and EmailSubmission capability and raise an error if not."""
+    def __post_init__(self) -> None:
+        """Post-initialization to check if the JMAP server supports the Mail and EmailSubmission capability and raise an error if not."""
 
-		super().__post_init__()
+        super().__post_init__()
 
-		if "urn:ietf:params:jmap:mail" not in self.connection.capabilities:
-			raise NotImplementedError("The JMAP server does not support the Mail capability.")
+        if "urn:ietf:params:jmap:mail" not in self.connection.capabilities:
+            raise NotImplementedError("The JMAP server does not support the Mail capability.")
 
-		if "urn:ietf:params:jmap:submission" not in self.connection.capabilities:
-			raise NotImplementedError("The JMAP server does not support the EmailSubmission capability.")
+        if "urn:ietf:params:jmap:submission" not in self.connection.capabilities:
+            raise NotImplementedError("The JMAP server does not support the EmailSubmission capability.")
 
-	@property
-	def primary_account_id(self) -> str:
-		"""Returns the primary account ID for the logged-in user."""
+    @property
+    def primary_account_id(self) -> str:
+        """Returns the primary account ID for the logged-in user."""
 
-		return self.connection.primary_accounts["urn:ietf:params:jmap:submission"]
+        return self.connection.primary_accounts["urn:ietf:params:jmap:submission"]
 
-	def _create(
-		self, emails: list[EmailCreateModel], draft_refs: dict[str, str], call_id_gen: CallIdGenerator
-	) -> list:
-		"""Creates email submissions for the given list of EmailCreateModel instances and returns the method calls for the JMAP request."""
+    def _create(
+        self, emails: list[EmailCreateModel], draft_refs: dict[str, str], call_id_gen: CallIdGenerator
+    ) -> list:
+        """Creates email submissions for the given list of EmailCreateModel instances and returns the method calls for the JMAP request."""
 
-		method_calls = []
+        method_calls = []
 
-		identity_service = IdentityService(self.account, self.connection)
-		mailbox_service = MailboxService(self.account, self.connection)
+        identity_service = IdentityService(self.account, self.connection)
+        mailbox_service = MailboxService(self.account, self.connection)
 
-		draft_mailbox_id = mailbox_service.get_mailbox_id_by_role(
-			"drafts", create_if_not_exists=True, raise_exception=True
-		)
-		sent_mailbox_id = mailbox_service.get_mailbox_id_by_role(
-			"sent", create_if_not_exists=True, raise_exception=True
-		)
+        draft_mailbox_id = mailbox_service.get_mailbox_id_by_role(
+            "drafts", create_if_not_exists=True, raise_exception=True
+        )
+        sent_mailbox_id = mailbox_service.get_mailbox_id_by_role(
+            "sent", create_if_not_exists=True, raise_exception=True
+        )
 
-		create_payload = {}
-		on_success_update = {}
-		on_success_destroy = []
+        create_payload = {}
+        on_success_update = {}
+        on_success_destroy = []
 
-		for email in emails:
-			if email.save_as_draft:
-				continue
+        for email in emails:
+            if email.save_as_draft:
+                continue
 
-			# -----------------------------
-			# Get Identity
-			# -----------------------------
+            # -----------------------------
+            # Get Identity
+            # -----------------------------
 
-			identity_id = identity_service.get_identity_id_by_email(email.from_email, raise_exception=True)
+            identity_id = identity_service.get_identity_id_by_email(email.from_email, raise_exception=True)
 
-			# -----------------------------
-			# CREATE Submission
-			# -----------------------------
+            # -----------------------------
+            # CREATE Submission
+            # -----------------------------
 
-			draft_ref = draft_refs[email.creation_id]
-			submit_ref = f"submit-{email.creation_id}"
+            draft_ref = draft_refs[email.creation_id]
+            submit_ref = f"submit-{email.creation_id}"
 
-			create_payload[submit_ref] = {
-				"identityId": identity_id,
-				"emailId": f"#{draft_ref}",
-				"envelope": {
-					"mailFrom": {
-						"email": email.from_email,
-						"parameters": {
-							"RET": "FULL",
-							"ENVID": email.creation_id,
-							"MT-PRIORITY": str(email.priority),
-						},
-					},
-					"rcptTo": [
-						{
-							"email": rcpt,
-							"parameters": {
-								"NOTIFY": "DELAY,FAILURE",
-								"ORCPT": f"rfc822;{rcpt}",
-							},
-						}
-						for rcpt in sorted({r.email for r in email.recipients})
-					],
-				},
-			}
+            create_payload[submit_ref] = {
+                "identityId": identity_id,
+                "emailId": f"#{draft_ref}",
+                "envelope": {
+                    "mailFrom": {
+                        "email": email.from_email,
+                        "parameters": {
+                            "RET": "FULL",
+                            "ENVID": email.creation_id,
+                            "MT-PRIORITY": str(email.priority),
+                        },
+                    },
+                    "rcptTo": [
+                        {
+                            "email": rcpt,
+                            "parameters": {
+                                "NOTIFY": "DELAY,FAILURE",
+                                "ORCPT": f"rfc822;{rcpt}",
+                            },
+                        }
+                        for rcpt in sorted({r.email for r in email.recipients})
+                    ],
+                },
+            }
 
-			# -----------------------------
-			# Success Handlers
-			# -----------------------------
+            # -----------------------------
+            # Success Handlers
+            # -----------------------------
 
-			if email.destroy_after_submit:
-				# No Mailbox updates, just destroy the draft email after successful submission.
-				on_success_destroy.append(f"#{submit_ref}")
+            if email.destroy_after_submit:
+                # No Mailbox updates, just destroy the draft email after successful submission.
+                on_success_destroy.append(f"#{submit_ref}")
 
-			else:
-				# Move the draft email to the Sent mailbox and update keywords after successful submission.
-				on_success_update[f"#{submit_ref}"] = {
-					f"mailboxIds/{draft_mailbox_id}": None,
-					f"mailboxIds/{sent_mailbox_id}": True,
-					"keywords/$draft": None,
-					"keywords/$seen": True,
-				}
+            else:
+                # Move the draft email to the Sent mailbox and update keywords after successful submission.
+                on_success_update[f"#{submit_ref}"] = {
+                    f"mailboxIds/{draft_mailbox_id}": None,
+                    f"mailboxIds/{sent_mailbox_id}": True,
+                    "keywords/$draft": None,
+                    "keywords/$seen": True,
+                }
 
-			# -----------------------------
-			# Forward / Reply Keywords
-			# -----------------------------
+            # -----------------------------
+            # Forward / Reply Keywords
+            # -----------------------------
 
-			for target_id, keyword in [
-				(email.forwarded_id, "$forwarded"),
-				(email.reply_to_id, "$answered"),
-			]:
-				if target_id:
-					on_success_update.setdefault(target_id, {})[f"keywords/{keyword}"] = True
+            for target_id, keyword in [
+                (email.forwarded_id, "$forwarded"),
+                (email.reply_to_id, "$answered"),
+            ]:
+                if target_id:
+                    on_success_update.setdefault(target_id, {})[f"keywords/{keyword}"] = True
 
-		if create_payload:
-			payload = {
-				"accountId": self.account,
-				"create": create_payload,
-			}
+        if create_payload:
+            payload = {
+                "accountId": self.account,
+                "create": create_payload,
+            }
 
-			if on_success_update:
-				payload["onSuccessUpdateEmail"] = on_success_update
+            if on_success_update:
+                payload["onSuccessUpdateEmail"] = on_success_update
 
-			if on_success_destroy:
-				payload["onSuccessDestroyEmail"] = on_success_destroy
+            if on_success_destroy:
+                payload["onSuccessDestroyEmail"] = on_success_destroy
 
-			method_calls.append(["EmailSubmission/set", payload, call_id_gen.next()])
+            method_calls.append(["EmailSubmission/set", payload, call_id_gen.next()])
 
-		return method_calls
+        return method_calls

--- a/suite/mail/jmap/services/mail/thread.py
+++ b/suite/mail/jmap/services/mail/thread.py
@@ -4,25 +4,25 @@ from suite.mail.jmap.services.mail.mail import MailService
 
 
 class ThreadService(MailService):
-	"""Service for handling thread-related functionality based on the JMAP server capabilities."""
+    """Service for handling thread-related functionality based on the JMAP server capabilities."""
 
-	type: ClassVar[str] = "Thread"
+    type: ClassVar[str] = "Thread"
 
-	def get(self, ids: list[str] | None = None) -> dict[str, list]:
-		"""Public method to get threads, handling batching if a list of ids is provided."""
+    def get(self, ids: list[str] | None = None) -> dict[str, list]:
+        """Public method to get threads, handling batching if a list of ids is provided."""
 
-		result = {}
-		if ids:
-			for batch in self.create_batches(ids, self.max_objects_in_get):
-				response = self._get(batch, properties=["emailIds"])
+        result = {}
+        if ids:
+            for batch in self.create_batches(ids, self.max_objects_in_get):
+                response = self._get(batch, properties=["emailIds"])
 
-				if method_responses := response.get("methodResponses"):
-					if threads := method_responses[0][1].get("list", []):
-						result.update({thread["id"]: thread["emailIds"] for thread in threads})
-		else:
-			response = self._get(properties=["emailIds"])
-			if method_responses := response.get("methodResponses"):
-				if threads := method_responses[0][1].get("list", []):
-					result.update({thread["id"]: thread["emailIds"] for thread in threads})
+                if method_responses := response.get("methodResponses"):
+                    if threads := method_responses[0][1].get("list", []):
+                        result.update({thread["id"]: thread["emailIds"] for thread in threads})
+        else:
+            response = self._get(properties=["emailIds"])
+            if method_responses := response.get("methodResponses"):
+                if threads := method_responses[0][1].get("list", []):
+                    result.update({thread["id"]: thread["emailIds"] for thread in threads})
 
-		return result
+        return result

--- a/suite/mail/jmap/services/principals/principal.py
+++ b/suite/mail/jmap/services/principals/principal.py
@@ -4,130 +4,130 @@ from suite.mail.jmap.services.calendars.calendars import CalendarsService
 
 
 class PrincipalService(CalendarsService):
-	"""Service for handling principal-related functionality based on the JMAP server capabilities."""
+    """Service for handling principal-related functionality based on the JMAP server capabilities."""
 
-	type: ClassVar[str] = "Principal"
-	capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:principals"]
+    type: ClassVar[str] = "Principal"
+    capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:principals"]
 
-	def __post_init__(self) -> None:
-		"""Post-initialization to check if the JMAP server supports the Principals capability and raise an error if not."""
+    def __post_init__(self) -> None:
+        """Post-initialization to check if the JMAP server supports the Principals capability and raise an error if not."""
 
-		super().__post_init__()
+        super().__post_init__()
 
-		if "urn:ietf:params:jmap:principals" not in self.connection.capabilities:
-			raise NotImplementedError("The JMAP server does not support the Principals capability.")
+        if "urn:ietf:params:jmap:principals" not in self.connection.capabilities:
+            raise NotImplementedError("The JMAP server does not support the Principals capability.")
 
-	@property
-	def primary_account_id(self) -> str:
-		"""Returns the primary account ID for the logged-in user."""
+    @property
+    def primary_account_id(self) -> str:
+        """Returns the primary account ID for the logged-in user."""
 
-		return self.connection.primary_accounts["urn:ietf:params:jmap:principals"]
+        return self.connection.primary_accounts["urn:ietf:params:jmap:principals"]
 
-	def get(self, ids: list[str] | None = None) -> list[dict]:
-		"""Public method to get principals, handling batching if a list of ids is provided."""
+    def get(self, ids: list[str] | None = None) -> list[dict]:
+        """Public method to get principals, handling batching if a list of ids is provided."""
 
-		results = []
-		if ids:
-			for batch in self.create_batches(ids, self.max_objects_in_get):
-				response = self._get(batch)
+        results = []
+        if ids:
+            for batch in self.create_batches(ids, self.max_objects_in_get):
+                response = self._get(batch)
 
-				if method_responses := response.get("methodResponses"):
-					results.extend(method_responses[0][1].get("list", []))
-		else:
-			response = self._get()
-			if method_responses := response.get("methodResponses"):
-				results.extend(method_responses[0][1].get("list", []))
+                if method_responses := response.get("methodResponses"):
+                    results.extend(method_responses[0][1].get("list", []))
+        else:
+            response = self._get()
+            if method_responses := response.get("methodResponses"):
+                results.extend(method_responses[0][1].get("list", []))
 
-		return results
+        return results
 
-	def update(self, principals: list[dict]) -> dict:
-		"""Public method to update principals, handling batching if the number of principals exceeds the server's maximum allowed in a single 'set' call."""
+    def update(self, principals: list[dict]) -> dict:
+        """Public method to update principals, handling batching if the number of principals exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"updated": [], "notUpdated": {}}
-		for batch in self.create_batches(principals, self.max_objects_in_set):
-			payload = {}
-			for principal in batch:
-				payload[principal["id"]] = {
-					"name": principal.get("name") or None,
-					"description": principal.get("description") or None,
-					"timeZone": principal.get("time_zone") or None,
-				}
+        result = {"updated": [], "notUpdated": {}}
+        for batch in self.create_batches(principals, self.max_objects_in_set):
+            payload = {}
+            for principal in batch:
+                payload[principal["id"]] = {
+                    "name": principal.get("name") or None,
+                    "description": principal.get("description") or None,
+                    "timeZone": principal.get("time_zone") or None,
+                }
 
-			response = self._update(payload)
+            response = self._update(payload)
 
-			if method_responses := response.get("methodResponses"):
-				result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-				if not_updated := method_responses[0][1].get("notUpdated", {}):
-					result["notUpdated"].update(not_updated)
+            if method_responses := response.get("methodResponses"):
+                result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+                if not_updated := method_responses[0][1].get("notUpdated", {}):
+                    result["notUpdated"].update(not_updated)
 
-		return result
+        return result
 
-	def query(
-		self, filter: dict | None = None, position: int = 0, limit: int = 50, sort: list[dict] | None = None
-	) -> dict:
-		"""Public method to query principals, handling batching if the number of results exceeds the server's maximum allowed in a single 'query' call."""
+    def query(
+        self, filter: dict | None = None, position: int = 0, limit: int = 50, sort: list[dict] | None = None
+    ) -> dict:
+        """Public method to query principals, handling batching if the number of results exceeds the server's maximum allowed in a single 'query' call."""
 
-		ids = []
-		total = None
-		batch_size = min(limit, self.max_objects_in_get)
+        ids = []
+        total = None
+        batch_size = min(limit, self.max_objects_in_get)
 
-		while len(ids) < limit:
-			current_batch_size = min(batch_size, limit - len(ids))
+        while len(ids) < limit:
+            current_batch_size = min(batch_size, limit - len(ids))
 
-			response = self._query(filter, position, current_batch_size, sort, calculate_total=total is None)
+            response = self._query(filter, position, current_batch_size, sort, calculate_total=total is None)
 
-			method_responses = response.get("methodResponses")
-			if not method_responses:
-				break
+            method_responses = response.get("methodResponses")
+            if not method_responses:
+                break
 
-			query_response = method_responses[0][1]
-			batch_ids = query_response.get("ids", [])
-			ids.extend(batch_ids)
+            query_response = method_responses[0][1]
+            batch_ids = query_response.get("ids", [])
+            ids.extend(batch_ids)
 
-			if total is None:
-				total = query_response.get("total")
+            if total is None:
+                total = query_response.get("total")
 
-			if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
-				break
+            if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
+                break
 
-			position += len(batch_ids)
+            position += len(batch_ids)
 
-		return {"ids": ids[:limit], "total": total}
+        return {"ids": ids[:limit], "total": total}
 
-	def changes(self, since_state: str) -> dict:
-		"""Public method to get principal changes since a given state."""
+    def changes(self, since_state: str) -> dict:
+        """Public method to get principal changes since a given state."""
 
-		response = self._changes(since_state)
+        response = self._changes(since_state)
 
-		if method_responses := response.get("methodResponses"):
-			return method_responses[0][1]
+        if method_responses := response.get("methodResponses"):
+            return method_responses[0][1]
 
-		return {}
+        return {}
 
-	def get_availability(
-		self,
-		principal_id: str,
-		utc_start: str,
-		utc_end: str,
-		show_details: bool = False,
-		event_properties: list[str] | None = None,
-	) -> dict:
-		"""Public method to get principal availability, allowing for optional details and event properties to be specified."""
+    def get_availability(
+        self,
+        principal_id: str,
+        utc_start: str,
+        utc_end: str,
+        show_details: bool = False,
+        event_properties: list[str] | None = None,
+    ) -> dict:
+        """Public method to get principal availability, allowing for optional details and event properties to be specified."""
 
-		payload = {
-			"accountId": self.account,
-			"id": principal_id,
-			"start": utc_start,
-			"end": utc_end,
-			"showDetails": show_details,
-		}
+        payload = {
+            "accountId": self.account,
+            "id": principal_id,
+            "start": utc_start,
+            "end": utc_end,
+            "showDetails": show_details,
+        }
 
-		if show_details and event_properties:
-			payload["eventProperties"] = event_properties
+        if show_details and event_properties:
+            payload["eventProperties"] = event_properties
 
-		response = self._call(self.capabilities, [[f"{self.type}/getAvailability", payload, "0"]])
+        response = self._call(self.capabilities, [[f"{self.type}/getAvailability", payload, "0"]])
 
-		if method_responses := response.get("methodResponses"):
-			return method_responses[0][1]
+        if method_responses := response.get("methodResponses"):
+            return method_responses[0][1]
 
-		return {}
+        return {}

--- a/suite/mail/jmap/services/push_subscription.py
+++ b/suite/mail/jmap/services/push_subscription.py
@@ -3,95 +3,95 @@ from typing import TYPE_CHECKING, ClassVar
 from suite.mail.jmap.services.core import CoreService
 
 if TYPE_CHECKING:
-	from suite.mail.jmap.connection import JMAPConnection
+    from suite.mail.jmap.connection import JMAPConnection
 
 
 class PushSubscriptionService(CoreService):
-	"""Service for handling push subscription-related functionality based on the JMAP server capabilities."""
+    """Service for handling push subscription-related functionality based on the JMAP server capabilities."""
 
-	type: ClassVar[str] = "PushSubscription"
+    type: ClassVar[str] = "PushSubscription"
 
-	def __init__(self, connection: "JMAPConnection") -> None:
-		"""Initializes the PushSubscriptionService with the provided JMAP connection."""
+    def __init__(self, connection: "JMAPConnection") -> None:
+        """Initializes the PushSubscriptionService with the provided JMAP connection."""
 
-		self.connection = connection
-		# PushSubscription is user-scoped, not account-scoped (requests omit accountId); key the
-		# cache by the connection's user so subscriptions for different users don't collide.
-		self.account = connection.user
+        self.connection = connection
+        # PushSubscription is user-scoped, not account-scoped (requests omit accountId); key the
+        # cache by the connection's user so subscriptions for different users don't collide.
+        self.account = connection.user
 
-	def create(self, subscriptions: list[dict]) -> dict:
-		"""Public method to create push subscriptions, handling batching if the number of subscriptions exceeds the server's maximum allowed in a single 'set' call."""
+    def create(self, subscriptions: list[dict]) -> dict:
+        """Public method to create push subscriptions, handling batching if the number of subscriptions exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"created": {}, "notCreated": {}}
-		for batch in self.create_batches(subscriptions, self.max_objects_in_set):
-			payload = {}
-			for subscription in batch:
-				payload[subscription["creation_id"]] = {
-					"deviceClientId": subscription["device_client_id"],
-					"url": subscription["url"],
-					"keys": subscription.get("keys") or None,
-					"types": subscription["types"],
-				}
+        result = {"created": {}, "notCreated": {}}
+        for batch in self.create_batches(subscriptions, self.max_objects_in_set):
+            payload = {}
+            for subscription in batch:
+                payload[subscription["creation_id"]] = {
+                    "deviceClientId": subscription["device_client_id"],
+                    "url": subscription["url"],
+                    "keys": subscription.get("keys") or None,
+                    "types": subscription["types"],
+                }
 
-			response = self._create(payload)
+            response = self._create(payload)
 
-			if method_responses := response.get("methodResponses"):
-				result["created"].update(method_responses[0][1].get("created", {}))
-				if not_created := method_responses[0][1].get("notCreated", {}):
-					result["notCreated"].update(not_created)
+            if method_responses := response.get("methodResponses"):
+                result["created"].update(method_responses[0][1].get("created", {}))
+                if not_created := method_responses[0][1].get("notCreated", {}):
+                    result["notCreated"].update(not_created)
 
-		return result
+        return result
 
-	def get(self, ids: list[str] | None = None) -> list[dict]:
-		"""Public method to get push subscriptions, handling batching if a list of ids is provided."""
+    def get(self, ids: list[str] | None = None) -> list[dict]:
+        """Public method to get push subscriptions, handling batching if a list of ids is provided."""
 
-		results = []
-		if ids:
-			for batch in self.create_batches(ids, self.max_objects_in_get):
-				response = self._get(batch)
+        results = []
+        if ids:
+            for batch in self.create_batches(ids, self.max_objects_in_get):
+                response = self._get(batch)
 
-				if method_responses := response.get("methodResponses"):
-					results.extend(method_responses[0][1].get("list", []))
-		else:
-			response = self._get()
-			if method_responses := response.get("methodResponses"):
-				results.extend(method_responses[0][1].get("list", []))
+                if method_responses := response.get("methodResponses"):
+                    results.extend(method_responses[0][1].get("list", []))
+        else:
+            response = self._get()
+            if method_responses := response.get("methodResponses"):
+                results.extend(method_responses[0][1].get("list", []))
 
-		return results
+        return results
 
-	def update(self, subscriptions: list[dict]) -> dict:
-		"""Public method to update push subscriptions, handling batching if the number of subscriptions exceeds the server's maximum allowed in a single 'set' call."""
+    def update(self, subscriptions: list[dict]) -> dict:
+        """Public method to update push subscriptions, handling batching if the number of subscriptions exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"updated": [], "notUpdated": {}}
-		for batch in self.create_batches(subscriptions, self.max_objects_in_set):
-			payload = {}
-			for subscription in batch:
-				payload[subscription["id"]] = {}
+        result = {"updated": [], "notUpdated": {}}
+        for batch in self.create_batches(subscriptions, self.max_objects_in_set):
+            payload = {}
+            for subscription in batch:
+                payload[subscription["id"]] = {}
 
-				if verification_code := subscription.get("verification_code"):
-					payload[subscription["id"]]["verificationCode"] = verification_code
-				else:
-					payload[subscription["id"]]["expires"] = subscription.get("expires")
+                if verification_code := subscription.get("verification_code"):
+                    payload[subscription["id"]]["verificationCode"] = verification_code
+                else:
+                    payload[subscription["id"]]["expires"] = subscription.get("expires")
 
-			response = self._update(payload)
+            response = self._update(payload)
 
-			if method_responses := response.get("methodResponses"):
-				result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-				if not_updated := method_responses[0][1].get("notUpdated", {}):
-					result["notUpdated"].update(not_updated)
+            if method_responses := response.get("methodResponses"):
+                result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+                if not_updated := method_responses[0][1].get("notUpdated", {}):
+                    result["notUpdated"].update(not_updated)
 
-		return result
+        return result
 
-	def delete(self, ids: list[str]) -> dict:
-		"""Public method to delete push subscriptions, handling batching if the number of IDs exceeds the server's maximum allowed in a single 'set' call."""
+    def delete(self, ids: list[str]) -> dict:
+        """Public method to delete push subscriptions, handling batching if the number of IDs exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"destroyed": [], "notDestroyed": {}}
-		for batch in self.create_batches(ids, self.max_objects_in_set):
-			response = self._delete(batch)
+        result = {"destroyed": [], "notDestroyed": {}}
+        for batch in self.create_batches(ids, self.max_objects_in_set):
+            response = self._delete(batch)
 
-			if method_responses := response.get("methodResponses"):
-				result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
-				if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
-					result["notDestroyed"].update(not_destroyed)
+            if method_responses := response.get("methodResponses"):
+                result["destroyed"].extend(method_responses[0][1].get("destroyed", []))
+                if not_destroyed := method_responses[0][1].get("notDestroyed", {}):
+                    result["notDestroyed"].update(not_destroyed)
 
-		return result
+        return result

--- a/suite/mail/jmap/services/push_subscription.py
+++ b/suite/mail/jmap/services/push_subscription.py
@@ -11,7 +11,7 @@ class PushSubscriptionService(CoreService):
 
     type: ClassVar[str] = "PushSubscription"
 
-    def __init__(self, connection: "JMAPConnection") -> None:
+    def __init__(self, connection: JMAPConnection) -> None:
         """Initializes the PushSubscriptionService with the provided JMAP connection."""
 
         self.connection = connection

--- a/suite/mail/jmap/services/quota/quota.py
+++ b/suite/mail/jmap/services/quota/quota.py
@@ -4,80 +4,80 @@ from suite.mail.jmap.services.core import CoreService
 
 
 class QuotaService(CoreService):
-	"""Service for handling quota-related functionality based on the JMAP server capabilities."""
+    """Service for handling quota-related functionality based on the JMAP server capabilities."""
 
-	type: ClassVar[str] = "Quota"
-	capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:quota"]
+    type: ClassVar[str] = "Quota"
+    capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:quota"]
 
-	def __post_init__(self) -> None:
-		"""Post-initialization to check if the JMAP server supports the Quota capability and raise an error if not."""
+    def __post_init__(self) -> None:
+        """Post-initialization to check if the JMAP server supports the Quota capability and raise an error if not."""
 
-		super().__post_init__()
+        super().__post_init__()
 
-		if "urn:ietf:params:jmap:quota" not in self.connection.capabilities:
-			raise NotImplementedError("The JMAP server does not support the Quota capability.")
+        if "urn:ietf:params:jmap:quota" not in self.connection.capabilities:
+            raise NotImplementedError("The JMAP server does not support the Quota capability.")
 
-	@property
-	def primary_account_id(self) -> str:
-		"""Returns the primary account ID for the logged-in user."""
+    @property
+    def primary_account_id(self) -> str:
+        """Returns the primary account ID for the logged-in user."""
 
-		return self.connection.primary_accounts["urn:ietf:params:jmap:quota"]
+        return self.connection.primary_accounts["urn:ietf:params:jmap:quota"]
 
-	def get(self, ids: list[str] | None = None) -> list[dict]:
-		"""Public method to get quotas, handling batching if a list of ids is provided."""
+    def get(self, ids: list[str] | None = None) -> list[dict]:
+        """Public method to get quotas, handling batching if a list of ids is provided."""
 
-		results = []
-		if ids:
-			for batch in self.create_batches(ids, self.max_objects_in_get):
-				response = self._get(batch)
+        results = []
+        if ids:
+            for batch in self.create_batches(ids, self.max_objects_in_get):
+                response = self._get(batch)
 
-				if method_responses := response.get("methodResponses"):
-					results.extend(method_responses[0][1].get("list", []))
-		else:
-			response = self._get()
-			if method_responses := response.get("methodResponses"):
-				results.extend(method_responses[0][1].get("list", []))
+                if method_responses := response.get("methodResponses"):
+                    results.extend(method_responses[0][1].get("list", []))
+        else:
+            response = self._get()
+            if method_responses := response.get("methodResponses"):
+                results.extend(method_responses[0][1].get("list", []))
 
-		return results
+        return results
 
-	def query(
-		self, filter: dict | None = None, position: int = 0, limit: int = 50, sort: list[dict] | None = None
-	) -> dict:
-		"""Public method to query quotas, handling batching if the number of results exceeds the server's maximum allowed in a single 'query' call."""
+    def query(
+        self, filter: dict | None = None, position: int = 0, limit: int = 50, sort: list[dict] | None = None
+    ) -> dict:
+        """Public method to query quotas, handling batching if the number of results exceeds the server's maximum allowed in a single 'query' call."""
 
-		ids = []
-		total = None
-		batch_size = min(limit, self.max_objects_in_get)
+        ids = []
+        total = None
+        batch_size = min(limit, self.max_objects_in_get)
 
-		while len(ids) < limit:
-			current_batch_size = min(batch_size, limit - len(ids))
+        while len(ids) < limit:
+            current_batch_size = min(batch_size, limit - len(ids))
 
-			response = self._query(filter, position, current_batch_size, sort, calculate_total=total is None)
+            response = self._query(filter, position, current_batch_size, sort, calculate_total=total is None)
 
-			method_responses = response.get("methodResponses")
-			if not method_responses:
-				break
+            method_responses = response.get("methodResponses")
+            if not method_responses:
+                break
 
-			query_response = method_responses[0][1]
-			batch_ids = query_response.get("ids", [])
-			ids.extend(batch_ids)
+            query_response = method_responses[0][1]
+            batch_ids = query_response.get("ids", [])
+            ids.extend(batch_ids)
 
-			if total is None:
-				total = query_response.get("total")
+            if total is None:
+                total = query_response.get("total")
 
-			if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
-				break
+            if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
+                break
 
-			position += len(batch_ids)
+            position += len(batch_ids)
 
-		return {"ids": ids[:limit], "total": total}
+        return {"ids": ids[:limit], "total": total}
 
-	def changes(self, since_state: str) -> dict:
-		"""Public method to get quota changes since a given state."""
+    def changes(self, since_state: str) -> dict:
+        """Public method to get quota changes since a given state."""
 
-		response = self._changes(since_state)
+        response = self._changes(since_state)
 
-		if method_responses := response.get("methodResponses"):
-			return method_responses[0][1]
+        if method_responses := response.get("methodResponses"):
+            return method_responses[0][1]
 
-		return {}
+        return {}

--- a/suite/mail/jmap/services/sieve/sieve_script.py
+++ b/suite/mail/jmap/services/sieve/sieve_script.py
@@ -4,192 +4,192 @@ from suite.mail.jmap.services.core import CoreService
 
 
 class SieveScriptService(CoreService):
-	"""Service for handling sieve script-related functionality based on the JMAP server capabilities."""
+    """Service for handling sieve script-related functionality based on the JMAP server capabilities."""
 
-	type: ClassVar[str] = "SieveScript"
-	capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:sieve"]
+    type: ClassVar[str] = "SieveScript"
+    capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:sieve"]
 
-	def __post_init__(self) -> None:
-		"""Post-initialization to check if the JMAP server supports the Sieve capability and raise an error if not."""
+    def __post_init__(self) -> None:
+        """Post-initialization to check if the JMAP server supports the Sieve capability and raise an error if not."""
 
-		super().__post_init__()
+        super().__post_init__()
 
-		if "urn:ietf:params:jmap:sieve" not in self.connection.capabilities:
-			raise NotImplementedError("The JMAP server does not support the Sieve capability.")
+        if "urn:ietf:params:jmap:sieve" not in self.connection.capabilities:
+            raise NotImplementedError("The JMAP server does not support the Sieve capability.")
 
-	@property
-	def primary_account_id(self) -> str:
-		"""Returns the primary account ID for the logged-in user."""
+    @property
+    def primary_account_id(self) -> str:
+        """Returns the primary account ID for the logged-in user."""
 
-		return self.connection.primary_accounts["urn:ietf:params:jmap:sieve"]
+        return self.connection.primary_accounts["urn:ietf:params:jmap:sieve"]
 
-	def create(self, sieve_scripts: list[dict]) -> dict:
-		"""Public method to create sieve scripts, handling batching if the number of sieve scripts exceeds the server's maximum allowed in a single 'set' call."""
+    def create(self, sieve_scripts: list[dict]) -> dict:
+        """Public method to create sieve scripts, handling batching if the number of sieve scripts exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"created": {}, "notCreated": {}}
-		for batch in self.create_batches(sieve_scripts, self.max_objects_in_set):
-			payload = {}
-			kwargs = {}
-			for sieve_script in batch:
-				content = sieve_script["content"]
-				blob = self.upload_blob(content.encode("utf-8"), "application/sieve")
-				payload[sieve_script["creation_id"]] = {
-					"name": sieve_script["name"],
-					"blobId": blob["blobId"],
-				}
+        result = {"created": {}, "notCreated": {}}
+        for batch in self.create_batches(sieve_scripts, self.max_objects_in_set):
+            payload = {}
+            kwargs = {}
+            for sieve_script in batch:
+                content = sieve_script["content"]
+                blob = self.upload_blob(content.encode("utf-8"), "application/sieve")
+                payload[sieve_script["creation_id"]] = {
+                    "name": sieve_script["name"],
+                    "blobId": blob["blobId"],
+                }
 
-				if bool(sieve_script.get("is_active") or False):
-					kwargs["onSuccessActivateScript"] = f"#{sieve_script['creation_id']}"
+                if bool(sieve_script.get("is_active") or False):
+                    kwargs["onSuccessActivateScript"] = f"#{sieve_script['creation_id']}"
 
-			response = self._create(payload, **kwargs)
+            response = self._create(payload, **kwargs)
 
-			if method_responses := response.get("methodResponses"):
-				name, body = method_responses[0][0], method_responses[0][1]
-				if name == "error":
-					result["error"] = body
-					break
+            if method_responses := response.get("methodResponses"):
+                name, body = method_responses[0][0], method_responses[0][1]
+                if name == "error":
+                    result["error"] = body
+                    break
 
-				result["created"].update(body.get("created", {}))
-				if not_created := body.get("notCreated", {}):
-					result["notCreated"].update(not_created)
+                result["created"].update(body.get("created", {}))
+                if not_created := body.get("notCreated", {}):
+                    result["notCreated"].update(not_created)
 
-		return result
+        return result
 
-	def get(self, ids: list[str] | None = None) -> list[dict]:
-		"""Public method to get sieve scripts, handling batching if a list of ids is provided."""
+    def get(self, ids: list[str] | None = None) -> list[dict]:
+        """Public method to get sieve scripts, handling batching if a list of ids is provided."""
 
-		results = []
-		if ids:
-			for batch in self.create_batches(ids, self.max_objects_in_get):
-				response = self._get(batch)
+        results = []
+        if ids:
+            for batch in self.create_batches(ids, self.max_objects_in_get):
+                response = self._get(batch)
 
-				if method_responses := response.get("methodResponses"):
-					results.extend(method_responses[0][1].get("list", []))
-		else:
-			response = self._get()
-			if method_responses := response.get("methodResponses"):
-				results.extend(method_responses[0][1].get("list", []))
+                if method_responses := response.get("methodResponses"):
+                    results.extend(method_responses[0][1].get("list", []))
+        else:
+            response = self._get()
+            if method_responses := response.get("methodResponses"):
+                results.extend(method_responses[0][1].get("list", []))
 
-		return results
+        return results
 
-	def update(self, sieve_scripts: list[dict], deactivate: bool = False) -> dict:
-		"""Public method to update sieve scripts, handling batching if the number of sieve scripts exceeds the server's maximum allowed in a single 'set' call. Allows for optional deactivation of scripts."""
+    def update(self, sieve_scripts: list[dict], deactivate: bool = False) -> dict:
+        """Public method to update sieve scripts, handling batching if the number of sieve scripts exceeds the server's maximum allowed in a single 'set' call. Allows for optional deactivation of scripts."""
 
-		result = {"updated": [], "notUpdated": {}}
-		for batch in self.create_batches(sieve_scripts, self.max_objects_in_set):
-			payload = {}
-			kwargs = {}
-			for sieve_script in batch:
-				content = sieve_script["content"]
-				blob = self.upload_blob(content.encode("utf-8"), "application/sieve")
-				payload[sieve_script["id"]] = {
-					"name": sieve_script["name"],
-					"blobId": blob["blobId"],
-				}
+        result = {"updated": [], "notUpdated": {}}
+        for batch in self.create_batches(sieve_scripts, self.max_objects_in_set):
+            payload = {}
+            kwargs = {}
+            for sieve_script in batch:
+                content = sieve_script["content"]
+                blob = self.upload_blob(content.encode("utf-8"), "application/sieve")
+                payload[sieve_script["id"]] = {
+                    "name": sieve_script["name"],
+                    "blobId": blob["blobId"],
+                }
 
-				if bool(sieve_script.get("is_active") or False):
-					kwargs["onSuccessActivateScript"] = sieve_script["id"]
-				if deactivate:
-					kwargs["onSuccessDeactivateScript"] = True
+                if bool(sieve_script.get("is_active") or False):
+                    kwargs["onSuccessActivateScript"] = sieve_script["id"]
+                if deactivate:
+                    kwargs["onSuccessDeactivateScript"] = True
 
-			if len(kwargs) > 1:
-				raise ValueError(
-					"Cannot specify both 'onSuccessActivateScript' and 'onSuccessDeactivateScript' at the same time."
-				)
+            if len(kwargs) > 1:
+                raise ValueError(
+                    "Cannot specify both 'onSuccessActivateScript' and 'onSuccessDeactivateScript' at the same time."
+                )
 
-			response = self._update(payload, **kwargs)
+            response = self._update(payload, **kwargs)
 
-			if method_responses := response.get("methodResponses"):
-				name, body = method_responses[0][0], method_responses[0][1]
-				if name == "error":
-					result["error"] = body
-					break
+            if method_responses := response.get("methodResponses"):
+                name, body = method_responses[0][0], method_responses[0][1]
+                if name == "error":
+                    result["error"] = body
+                    break
 
-				result["updated"].extend(body.get("updated", {}).keys())
-				if not_updated := body.get("notUpdated", {}):
-					result["notUpdated"].update(not_updated)
+                result["updated"].extend(body.get("updated", {}).keys())
+                if not_updated := body.get("notUpdated", {}):
+                    result["notUpdated"].update(not_updated)
 
-		return result
+        return result
 
-	def delete(self, ids: list[str]) -> dict:
-		"""Public method to delete sieve scripts, handling batching if the number of ids exceeds the server's maximum allowed in a single 'set' call."""
+    def delete(self, ids: list[str]) -> dict:
+        """Public method to delete sieve scripts, handling batching if the number of ids exceeds the server's maximum allowed in a single 'set' call."""
 
-		result = {"destroyed": [], "notDestroyed": {}}
-		for batch in self.create_batches(ids, self.max_objects_in_set):
-			response = self._delete(batch)
+        result = {"destroyed": [], "notDestroyed": {}}
+        for batch in self.create_batches(ids, self.max_objects_in_set):
+            response = self._delete(batch)
 
-			if method_responses := response.get("methodResponses"):
-				name, body = method_responses[0][0], method_responses[0][1]
-				if name == "error":
-					result["error"] = body
-					break
+            if method_responses := response.get("methodResponses"):
+                name, body = method_responses[0][0], method_responses[0][1]
+                if name == "error":
+                    result["error"] = body
+                    break
 
-				result["destroyed"].extend(body.get("destroyed", []))
-				if not_destroyed := body.get("notDestroyed", {}):
-					result["notDestroyed"].update(not_destroyed)
+                result["destroyed"].extend(body.get("destroyed", []))
+                if not_destroyed := body.get("notDestroyed", {}):
+                    result["notDestroyed"].update(not_destroyed)
 
-		return result
+        return result
 
-	def query(self, filter: dict | None = None, position: int = 0, limit: int = 50) -> dict:
-		"""Public method to query sieve scripts, handling batching if the number of results exceeds the server's maximum allowed in a single 'query' call."""
+    def query(self, filter: dict | None = None, position: int = 0, limit: int = 50) -> dict:
+        """Public method to query sieve scripts, handling batching if the number of results exceeds the server's maximum allowed in a single 'query' call."""
 
-		_filter = {}
-		filter = filter or {}
-		for key in ["name", "isActive"]:
-			if key in filter and filter[key] is not None:
-				_filter[key] = filter[key]
+        _filter = {}
+        filter = filter or {}
+        for key in ["name", "isActive"]:
+            if key in filter and filter[key] is not None:
+                _filter[key] = filter[key]
 
-		ids = []
-		total = None
-		batch_size = min(limit, self.max_objects_in_get)
+        ids = []
+        total = None
+        batch_size = min(limit, self.max_objects_in_get)
 
-		while len(ids) < limit:
-			current_batch_size = min(batch_size, limit - len(ids))
+        while len(ids) < limit:
+            current_batch_size = min(batch_size, limit - len(ids))
 
-			response = self._query(_filter, position, current_batch_size, calculate_total=total is None)
+            response = self._query(_filter, position, current_batch_size, calculate_total=total is None)
 
-			method_responses = response.get("methodResponses")
-			if not method_responses:
-				break
+            method_responses = response.get("methodResponses")
+            if not method_responses:
+                break
 
-			query_response = method_responses[0][1]
-			batch_ids = query_response.get("ids", [])
-			ids.extend(batch_ids)
+            query_response = method_responses[0][1]
+            batch_ids = query_response.get("ids", [])
+            ids.extend(batch_ids)
 
-			if total is None:
-				total = query_response.get("total")
+            if total is None:
+                total = query_response.get("total")
 
-			if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
-				break
+            if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
+                break
 
-			position += len(batch_ids)
+            position += len(batch_ids)
 
-		return {"ids": ids[:limit], "total": total}
+        return {"ids": ids[:limit], "total": total}
 
-	def validate(self, content: str) -> dict:
-		"""Public method to validate a sieve script's content."""
+    def validate(self, content: str) -> dict:
+        """Public method to validate a sieve script's content."""
 
-		blob = self.upload_blob(content.encode("utf-8"), "application/sieve")
-		response = self._call(
-			self.capabilities,
-			[
-				[
-					f"{self.type}/validate",
-					{
-						"accountId": self.account,
-						"blobId": blob["blobId"],
-					},
-					"0",
-				]
-			],
-		)
+        blob = self.upload_blob(content.encode("utf-8"), "application/sieve")
+        response = self._call(
+            self.capabilities,
+            [
+                [
+                    f"{self.type}/validate",
+                    {
+                        "accountId": self.account,
+                        "blobId": blob["blobId"],
+                    },
+                    "0",
+                ]
+            ],
+        )
 
-		if method_responses := response.get("methodResponses"):
-			name, body = method_responses[0][0], method_responses[0][1]
+        if method_responses := response.get("methodResponses"):
+            name, body = method_responses[0][0], method_responses[0][1]
 
-			# A method-level error carries `{type, description}` directly, whereas a successful
-			# validate call reports the outcome in an `error` key. Normalise so callers only
-			# have to look at `error`, otherwise a failed call reads as a valid script.
-			return {"error": body} if name == "error" else body
+            # A method-level error carries `{type, description}` directly, whereas a successful
+            # validate call reports the outcome in an `error` key. Normalise so callers only
+            # have to look at `error`, otherwise a failed call reads as a valid script.
+            return {"error": body} if name == "error" else body
 
-		return {}
+        return {}

--- a/suite/mail/jmap/services/vacationresponse/vacation_response.py
+++ b/suite/mail/jmap/services/vacationresponse/vacation_response.py
@@ -4,57 +4,57 @@ from suite.mail.jmap.services.core import CoreService
 
 
 class VacationResponseService(CoreService):
-	"""Service for handling vacation response related functionality based on the JMAP server capabilities."""
+    """Service for handling vacation response related functionality based on the JMAP server capabilities."""
 
-	type: ClassVar[str] = "VacationResponse"
+    type: ClassVar[str] = "VacationResponse"
 
-	capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:vacationresponse"]
+    capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:vacationresponse"]
 
-	def __post_init__(self) -> None:
-		"""Post-initialization to check if the JMAP server supports the Vacation Response capability and raise an error if not."""
+    def __post_init__(self) -> None:
+        """Post-initialization to check if the JMAP server supports the Vacation Response capability and raise an error if not."""
 
-		super().__post_init__()
+        super().__post_init__()
 
-		if "urn:ietf:params:jmap:vacationresponse" not in self.connection.capabilities:
-			raise NotImplementedError("The JMAP server does not support the Vacation Response capability.")
+        if "urn:ietf:params:jmap:vacationresponse" not in self.connection.capabilities:
+            raise NotImplementedError("The JMAP server does not support the Vacation Response capability.")
 
-	@property
-	def primary_account_id(self) -> str:
-		"""Returns the primary account ID for the logged-in user."""
+    @property
+    def primary_account_id(self) -> str:
+        """Returns the primary account ID for the logged-in user."""
 
-		return self.connection.primary_accounts["urn:ietf:params:jmap:vacationresponse"]
+        return self.connection.primary_accounts["urn:ietf:params:jmap:vacationresponse"]
 
-	def get(self) -> dict:
-		"""Public method to get the vacation response settings, returning a simplified dictionary with the relevant information."""
+    def get(self) -> dict:
+        """Public method to get the vacation response settings, returning a simplified dictionary with the relevant information."""
 
-		response = self._get()
+        response = self._get()
 
-		if method_responses := response.get("methodResponses"):
-			if vacation_responses := method_responses[0][1].get("list"):
-				return vacation_responses[0]
+        if method_responses := response.get("methodResponses"):
+            if vacation_responses := method_responses[0][1].get("list"):
+                return vacation_responses[0]
 
-		return {}
+        return {}
 
-	def update(self, settings: dict) -> dict:
-		"""Public method to update the vacation response settings, returning the updated settings as a simplified dictionary."""
+    def update(self, settings: dict) -> dict:
+        """Public method to update the vacation response settings, returning the updated settings as a simplified dictionary."""
 
-		payload = {
-			"singleton": {
-				"isEnabled": settings.get("is_enabled", False),
-				"fromDate": settings.get("from_date"),
-				"toDate": settings.get("to_date"),
-				"subject": settings.get("subject"),
-				"textBody": settings.get("text_body"),
-				"htmlBody": settings.get("html_body"),
-			}
-		}
+        payload = {
+            "singleton": {
+                "isEnabled": settings.get("is_enabled", False),
+                "fromDate": settings.get("from_date"),
+                "toDate": settings.get("to_date"),
+                "subject": settings.get("subject"),
+                "textBody": settings.get("text_body"),
+                "htmlBody": settings.get("html_body"),
+            }
+        }
 
-		response = self._update(payload)
+        response = self._update(payload)
 
-		result = {"updated": [], "notUpdated": {}}
-		if method_responses := response.get("methodResponses"):
-			result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-			if not_updated := method_responses[0][1].get("notUpdated", {}):
-				result["notUpdated"].update(not_updated)
+        result = {"updated": [], "notUpdated": {}}
+        if method_responses := response.get("methodResponses"):
+            result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
+            if not_updated := method_responses[0][1].get("notUpdated", {}):
+                result["notUpdated"].update(not_updated)
 
-		return result
+        return result

--- a/suite/mail/jmap/services/websocket/websocket.py
+++ b/suite/mail/jmap/services/websocket/websocket.py
@@ -4,45 +4,45 @@ from suite.mail.jmap.services.core import CoreService
 
 
 class WebSocketService(CoreService):
-	"""Service for handling WebSocket-related functionality based on the JMAP server capabilities."""
+    """Service for handling WebSocket-related functionality based on the JMAP server capabilities."""
 
-	type: ClassVar[str] = "WebSocket"
-	capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:websocket"]
+    type: ClassVar[str] = "WebSocket"
+    capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:websocket"]
 
-	def __post_init__(self) -> None:
-		"""Post-initialization to check if the JMAP server supports WebSocket and raise an error if not."""
+    def __post_init__(self) -> None:
+        """Post-initialization to check if the JMAP server supports WebSocket and raise an error if not."""
 
-		super().__post_init__()
+        super().__post_init__()
 
-		if not self.supports_websocket:
-			raise NotImplementedError("The JMAP server does not support WebSocket.")
+        if not self.supports_websocket:
+            raise NotImplementedError("The JMAP server does not support WebSocket.")
 
-	@property
-	def primary_account_id(self) -> str:
-		"""Returns the primary account ID for the logged-in user."""
+    @property
+    def primary_account_id(self) -> str:
+        """Returns the primary account ID for the logged-in user."""
 
-		return self.connection.primary_accounts["urn:ietf:params:jmap:websocket"]
+        return self.connection.primary_accounts["urn:ietf:params:jmap:websocket"]
 
-	@property
-	def websocket(self) -> dict:
-		"""Returns the WebSocket capabilities of the JMAP server."""
+    @property
+    def websocket(self) -> dict:
+        """Returns the WebSocket capabilities of the JMAP server."""
 
-		return self.connection.capabilities.get("urn:ietf:params:jmap:websocket") or {}
+        return self.connection.capabilities.get("urn:ietf:params:jmap:websocket") or {}
 
-	@property
-	def supports_websocket(self) -> bool:
-		"""Returns True if the JMAP server supports WebSocket, False otherwise."""
+    @property
+    def supports_websocket(self) -> bool:
+        """Returns True if the JMAP server supports WebSocket, False otherwise."""
 
-		return bool(self.websocket)
+        return bool(self.websocket)
 
-	@property
-	def websocket_url(self) -> str | None:
-		"""Returns the WebSocket URL of the JMAP server, or None if not supported."""
+    @property
+    def websocket_url(self) -> str | None:
+        """Returns the WebSocket URL of the JMAP server, or None if not supported."""
 
-		return self.websocket.get("url")
+        return self.websocket.get("url")
 
-	@property
-	def websocket_supports_push(self) -> bool:
-		"""Returns True if the JMAP server supports WebSocket push, False otherwise."""
+    @property
+    def websocket_supports_push(self) -> bool:
+        """Returns True if the JMAP server supports WebSocket push, False otherwise."""
 
-		return self.websocket.get("supportsPush", False)
+        return self.websocket.get("supportsPush", False)

--- a/suite/mail/patches/backfill_screened_email_address_account.py
+++ b/suite/mail/patches/backfill_screened_email_address_account.py
@@ -4,74 +4,74 @@ DOCTYPE = "Screened Email Address"
 
 
 def execute() -> None:
-	"""Backfill `account` from the legacy `account_id` column on Screened Email Address.
+    """Backfill `account` from the legacy `account_id` column on Screened Email Address.
 
-	The `account_id` -> `account` refactor dropped `account_id` from the doctype but leaves
-	the orphaned DB column behind, so existing rows have an empty `account`. Copy the value
-	over, first dropping rows that would duplicate an existing `(email, account)` pair — the
-	same de-duplication the controller enforces on save.
+    The `account_id` -> `account` refactor dropped `account_id` from the doctype but leaves
+    the orphaned DB column behind, so existing rows have an empty `account`. Copy the value
+    over, first dropping rows that would duplicate an existing `(email, account)` pair — the
+    same de-duplication the controller enforces on save.
 
-	Only rows with a present `account_id` are touched: those without one have no value to
-	backfill from (`account` is `reqd`), so they're left untouched rather than mishandled as
-	de-dup candidates. `account_id` was `reqd` before the refactor, so such rows shouldn't
-	exist, but the guard keeps the de-dup and backfill sets identical.
+    Only rows with a present `account_id` are touched: those without one have no value to
+    backfill from (`account` is `reqd`), so they're left untouched rather than mishandled as
+    de-dup candidates. `account_id` was `reqd` before the refactor, so such rows shouldn't
+    exist, but the guard keeps the de-dup and backfill sets identical.
 
-	Idempotent: once the orphaned column is gone (or every row is backfilled) this is a no-op.
-	"""
+    Idempotent: once the orphaned column is gone (or every row is backfilled) this is a no-op.
+    """
 
-	if not frappe.db.has_column(DOCTYPE, "account_id"):
-		return
+    if not frappe.db.has_column(DOCTYPE, "account_id"):
+        return
 
-	delete_duplicates()
-	backfill_account()
+    delete_duplicates()
+    backfill_account()
 
 
 def delete_duplicates() -> None:
-	"""Drop empty-`account` rows whose (email, account_id) is already covered by a sibling."""
+    """Drop empty-`account` rows whose (email, account_id) is already covered by a sibling."""
 
-	s = frappe.qb.DocType(DOCTYPE).as_("s")
-	t = frappe.qb.DocType(DOCTYPE).as_("t")
+    s = frappe.qb.DocType(DOCTYPE).as_("s")
+    t = frappe.qb.DocType(DOCTYPE).as_("t")
 
-	# A sibling covers the row when it shares its (email, account_id) and outranks it: either a
-	# row already populated with that account, or an earlier still-empty row (smaller `name`
-	# wins, matching the original loop's "keep first").
-	populated_sibling = is_present(t.account) & (t.account == s.account_id)
-	earlier_empty_sibling = is_empty(t.account) & (t.account_id == s.account_id) & (t.name < s.name)
+    # A sibling covers the row when it shares its (email, account_id) and outranks it: either a
+    # row already populated with that account, or an earlier still-empty row (smaller `name`
+    # wins, matching the original loop's "keep first").
+    populated_sibling = is_present(t.account) & (t.account == s.account_id)
+    earlier_empty_sibling = is_empty(t.account) & (t.account_id == s.account_id) & (t.name < s.name)
 
-	victims = (
-		frappe.qb.from_(s)
-		.join(t)
-		.on((t.email == s.email) & (t.name != s.name) & (populated_sibling | earlier_empty_sibling))
-		.where(is_empty(s.account) & is_present(s.account_id))
-		.select(s.name)
-		.distinct()
-		.run(pluck="name")
-	)
+    victims = (
+        frappe.qb.from_(s)
+        .join(t)
+        .on((t.email == s.email) & (t.name != s.name) & (populated_sibling | earlier_empty_sibling))
+        .where(is_empty(s.account) & is_present(s.account_id))
+        .select(s.name)
+        .distinct()
+        .run(pluck="name")
+    )
 
-	if victims:
-		table = frappe.qb.DocType(DOCTYPE)
-		frappe.qb.from_(table).delete().where(table.name.isin(victims)).run()
+    if victims:
+        table = frappe.qb.DocType(DOCTYPE)
+        frappe.qb.from_(table).delete().where(table.name.isin(victims)).run()
 
 
 def backfill_account() -> None:
-	"""Set `account` = `account_id` on the surviving empty-`account` rows."""
+    """Set `account` = `account_id` on the surviving empty-`account` rows."""
 
-	table = frappe.qb.DocType(DOCTYPE)
-	(
-		frappe.qb.update(table)
-		.set(table.account, table.account_id)
-		.where(is_empty(table.account) & is_present(table.account_id))
-		.run()
-	)
+    table = frappe.qb.DocType(DOCTYPE)
+    (
+        frappe.qb.update(table)
+        .set(table.account, table.account_id)
+        .where(is_empty(table.account) & is_present(table.account_id))
+        .run()
+    )
 
 
 def is_empty(field):
-	"""Match a column that is NULL or the empty string."""
+    """Match a column that is NULL or the empty string."""
 
-	return field.isnull() | (field == "")
+    return field.isnull() | (field == "")
 
 
 def is_present(field):
-	"""Match a column that is neither NULL nor the empty string."""
+    """Match a column that is neither NULL nor the empty string."""
 
-	return field.isnotnull() & (field != "")
+    return field.isnotnull() & (field != "")

--- a/suite/mail/patches/capture_user_outgoing_settings.py
+++ b/suite/mail/patches/capture_user_outgoing_settings.py
@@ -4,27 +4,27 @@ CACHE_KEY = "migrate:user_outgoing_settings"
 
 
 def execute() -> None:
-	"""Capture the per-user Outgoing settings before they are dropped from User Settings.
+    """Capture the per-user Outgoing settings before they are dropped from User Settings.
 
-	The fields move to JMAP Account (per-account). This patch runs pre_model_sync
-	(the User Settings columns still exist); the values are stashed in cache and applied
-	to JMAP Account by migrate_outgoing_settings_to_account in post_model_sync (once
-	the new columns exist). The fields are already gone from the doctype meta but the
-	columns still exist in the table, so the query builder references them by column name.
-	"""
+    The fields move to JMAP Account (per-account). This patch runs pre_model_sync
+    (the User Settings columns still exist); the values are stashed in cache and applied
+    to JMAP Account by migrate_outgoing_settings_to_account in post_model_sync (once
+    the new columns exist). The fields are already gone from the doctype meta but the
+    columns still exist in the table, so the query builder references them by column name.
+    """
 
-	if not frappe.db.has_column("User Settings", "default_outgoing_email"):
-		return
+    if not frappe.db.has_column("User Settings", "default_outgoing_email"):
+        return
 
-	US = frappe.qb.DocType("User Settings")
-	rows = (
-		frappe.qb.from_(US).select(
-			US.user,
-			US.default_outgoing_email,
-			US.create_contacts_after_email_submit,
-			US.destroy_email_after_submit,
-			US.destroy_newsletter_after_submit,
-		)
-	).run(as_dict=True)
+    US = frappe.qb.DocType("User Settings")
+    rows = (
+        frappe.qb.from_(US).select(
+            US.user,
+            US.default_outgoing_email,
+            US.create_contacts_after_email_submit,
+            US.destroy_email_after_submit,
+            US.destroy_newsletter_after_submit,
+        )
+    ).run(as_dict=True)
 
-	frappe.cache.set_value(CACHE_KEY, frappe.as_json({r["user"]: r for r in rows}))
+    frappe.cache.set_value(CACHE_KEY, frappe.as_json({r["user"]: r for r in rows}))

--- a/suite/mail/patches/configure_exchange_log.py
+++ b/suite/mail/patches/configure_exchange_log.py
@@ -1,21 +1,21 @@
 import frappe
 
 CONFIG_KEY_FIELD_MAP = {
-	# Exchange
-	"exchange_log_file_count": None,
-	"exchange_log_level": None,
-	"exchange_log_max_file_size": None,
+    # Exchange
+    "exchange_log_file_count": None,
+    "exchange_log_level": None,
+    "exchange_log_max_file_size": None,
 }
 
 
 def execute() -> None:
-	meta = frappe.get_meta("Mail Settings")
-	settings = frappe.get_doc("Mail Settings")
+    meta = frappe.get_meta("Mail Settings")
+    settings = frappe.get_doc("Mail Settings")
 
-	for key, field in CONFIG_KEY_FIELD_MAP.items():
-		value = meta.get_field(field or key).default
-		if value is not None:
-			setattr(settings, field or key, value)
+    for key, field in CONFIG_KEY_FIELD_MAP.items():
+        value = meta.get_field(field or key).default
+        if value is not None:
+            setattr(settings, field or key, value)
 
-	settings.flags.ignore_mandatory = 1
-	settings.save()
+    settings.flags.ignore_mandatory = 1
+    settings.save()

--- a/suite/mail/patches/configure_inbound_outbound_log.py
+++ b/suite/mail/patches/configure_inbound_outbound_log.py
@@ -1,25 +1,25 @@
 import frappe
 
 CONFIG_KEY_FIELD_MAP = {
-	# Inbound
-	"inbound_log_file_count": None,
-	"inbound_log_level": None,
-	"inbound_log_max_file_size": None,
-	# Outbound
-	"outbound_log_file_count": None,
-	"outbound_log_level": None,
-	"outbound_log_max_file_size": None,
+    # Inbound
+    "inbound_log_file_count": None,
+    "inbound_log_level": None,
+    "inbound_log_max_file_size": None,
+    # Outbound
+    "outbound_log_file_count": None,
+    "outbound_log_level": None,
+    "outbound_log_max_file_size": None,
 }
 
 
 def execute() -> None:
-	meta = frappe.get_meta("Mail Settings")
-	settings = frappe.get_doc("Mail Settings")
+    meta = frappe.get_meta("Mail Settings")
+    settings = frappe.get_doc("Mail Settings")
 
-	for key, field in CONFIG_KEY_FIELD_MAP.items():
-		value = meta.get_field(field or key).default
-		if value is not None:
-			setattr(settings, field or key, value)
+    for key, field in CONFIG_KEY_FIELD_MAP.items():
+        value = meta.get_field(field or key).default
+        if value is not None:
+            setattr(settings, field or key, value)
 
-	settings.flags.ignore_mandatory = 1
-	settings.save()
+    settings.flags.ignore_mandatory = 1
+    settings.save()

--- a/suite/mail/patches/configure_mail_cluster.py
+++ b/suite/mail/patches/configure_mail_cluster.py
@@ -5,25 +5,25 @@ from suite.utils import execute_with_logging
 
 
 def execute() -> None:
-	def _configure(cluster) -> None:
-		doc = frappe.get_doc("Mail Cluster", cluster)
-		doc.default_domain = doc.default_domain or doc.hostname
+    def _configure(cluster) -> None:
+        doc = frappe.get_doc("Mail Cluster", cluster)
+        doc.default_domain = doc.default_domain or doc.hostname
 
-		if not doc.recovery_admin_user:
-			if hasattr(doc, "fallback_admin_user") and doc.fallback_admin_user:
-				doc.recovery_admin_user = doc.fallback_admin_user
+        if not doc.recovery_admin_user:
+            if hasattr(doc, "fallback_admin_user") and doc.fallback_admin_user:
+                doc.recovery_admin_user = doc.fallback_admin_user
 
-		if not doc.recovery_admin_password:
-			if hasattr(doc, "fallback_admin_password") and doc.fallback_admin_password:
-				if password := doc.get_password("fallback_admin_password"):
-					doc.recovery_admin_password = password
+        if not doc.recovery_admin_password:
+            if hasattr(doc, "fallback_admin_password") and doc.fallback_admin_password:
+                if password := doc.get_password("fallback_admin_password"):
+                    doc.recovery_admin_password = password
 
-		doc._initialize_data_store()
-		doc.save()
+        doc._initialize_data_store()
+        doc.save()
 
-	for cluster in frappe.db.get_all("Mail Cluster", {}, pluck="name"):
-		execute_with_logging(
-			func=lambda: _configure(cluster),
-			title=_("Failed to configure Mail Cluster {0}").format(frappe.bold(cluster)),
-			module="Mail",
-		)
+    for cluster in frappe.db.get_all("Mail Cluster", {}, pluck="name"):
+        execute_with_logging(
+            func=lambda: _configure(cluster),
+            title=_("Failed to configure Mail Cluster {0}").format(frappe.bold(cluster)),
+            module="Mail",
+        )

--- a/suite/mail/patches/configure_mail_server.py
+++ b/suite/mail/patches/configure_mail_server.py
@@ -5,15 +5,15 @@ from suite.utils import execute_with_logging
 
 
 def execute() -> None:
-	def _configure(server) -> None:
-		doc = frappe.get_doc("Mail Server", server)
-		doc.recovery_http_port = doc.recovery_http_port or 8080
-		doc.bootstrap_ndjson = doc.bootstrap_ndjson or doc._generate_bootstrap_ndjson()
-		doc.save()
+    def _configure(server) -> None:
+        doc = frappe.get_doc("Mail Server", server)
+        doc.recovery_http_port = doc.recovery_http_port or 8080
+        doc.bootstrap_ndjson = doc.bootstrap_ndjson or doc._generate_bootstrap_ndjson()
+        doc.save()
 
-	for server in frappe.db.get_all("Mail Server", {}, pluck="name"):
-		execute_with_logging(
-			func=lambda: _configure(server),
-			title=_("Failed to configure Mail Server {0}").format(frappe.bold(server)),
-			module="Mail",
-		)
+    for server in frappe.db.get_all("Mail Server", {}, pluck="name"):
+        execute_with_logging(
+            func=lambda: _configure(server),
+            title=_("Failed to configure Mail Server {0}").format(frappe.bold(server)),
+            module="Mail",
+        )

--- a/suite/mail/patches/configure_mail_settings.py
+++ b/suite/mail/patches/configure_mail_settings.py
@@ -1,59 +1,59 @@
 import frappe
 
 CONFIG_KEY_FIELD_MAP = {
-	# JMAP
-	"server_url": None,
-	"username": None,
-	"password": None,
-	# SpamAssassin
-	"spamd_host": None,
-	"spamd_port": None,
-	"spamd_scanning_mode": None,
-	"spamd_hybrid_scanning_threshold": None,
-	# Defaults
-	"default_dns_ttl": None,
-	"default_mail_quota": "default_disk_quota_gb",
-	"gravatar_default_avatar": "default_gravatar",
-	"stalwart_version": None,
-	"stalwart_cli_version": None,
-	# Logs
-	"push_log_file_count": None,
-	"push_log_level": None,
-	"push_log_max_size": "push_log_max_file_size",
-	# Limits
-	"exchange_max_export": None,
-	"exchange_max_import": None,
-	"exchange_export_batch_size": None,
-	"max_email_sync": None,
-	"max_message_payload_size": "max_message_payload_size_mb",
-	"max_push_notifications": None,
-	"process_pending_emails_batch_size": None,
-	"process_pending_emails_max_batch_size": None,
-	# Timeouts
-	"ansible_play_timeout": None,
-	"server_job_timeout": None,
-	"server_deployment_timeout": None,
-	"scan_message_timeout": None,
-	"process_pending_emails_timeout": None,
-	"stalwart_cli_command_timeout": None,
-	"exchange_export_timeout": None,
-	"exchange_import_timeout": None,
+    # JMAP
+    "server_url": None,
+    "username": None,
+    "password": None,
+    # SpamAssassin
+    "spamd_host": None,
+    "spamd_port": None,
+    "spamd_scanning_mode": None,
+    "spamd_hybrid_scanning_threshold": None,
+    # Defaults
+    "default_dns_ttl": None,
+    "default_mail_quota": "default_disk_quota_gb",
+    "gravatar_default_avatar": "default_gravatar",
+    "stalwart_version": None,
+    "stalwart_cli_version": None,
+    # Logs
+    "push_log_file_count": None,
+    "push_log_level": None,
+    "push_log_max_size": "push_log_max_file_size",
+    # Limits
+    "exchange_max_export": None,
+    "exchange_max_import": None,
+    "exchange_export_batch_size": None,
+    "max_email_sync": None,
+    "max_message_payload_size": "max_message_payload_size_mb",
+    "max_push_notifications": None,
+    "process_pending_emails_batch_size": None,
+    "process_pending_emails_max_batch_size": None,
+    # Timeouts
+    "ansible_play_timeout": None,
+    "server_job_timeout": None,
+    "server_deployment_timeout": None,
+    "scan_message_timeout": None,
+    "process_pending_emails_timeout": None,
+    "stalwart_cli_command_timeout": None,
+    "exchange_export_timeout": None,
+    "exchange_import_timeout": None,
 }
 
 
 def execute() -> None:
-	mail_conf = frappe.conf.mail or {}
+    mail_conf = frappe.conf.mail or {}
 
-	meta = frappe.get_meta("Mail Settings")
-	settings = frappe.get_doc("Mail Settings")
+    meta = frappe.get_meta("Mail Settings")
+    settings = frappe.get_doc("Mail Settings")
 
-	for key, field in CONFIG_KEY_FIELD_MAP.items():
-		value = mail_conf.get(key) or meta.get_field(field or key).default
-		if value is not None:
-			if key == "default_mail_quota":
-				value = int(int(value) // 1024**3)
+    for key, field in CONFIG_KEY_FIELD_MAP.items():
+        value = mail_conf.get(key) or meta.get_field(field or key).default
+        if value is not None:
+            if key == "default_mail_quota":
+                value = int(int(value) // 1024**3)
 
-			setattr(settings, field or key, value)
+            setattr(settings, field or key, value)
 
-	settings.flags.ignore_mandatory = 1
-	settings.save()
+    settings.flags.ignore_mandatory = 1
+    settings.save()

--- a/suite/mail/patches/copy_sync_history_account_id_to_account.py
+++ b/suite/mail/patches/copy_sync_history_account_id_to_account.py
@@ -3,20 +3,20 @@ from frappe.query_builder.functions import Coalesce
 
 
 def execute() -> None:
-	"""Copy the legacy `Mail Sync History.account_id` value into the new `account` Link field.
+    """Copy the legacy `Mail Sync History.account_id` value into the new `account` Link field.
 
-	`account_id` (Data) was replaced by `account` (Link to "JMAP Account"). Since JMAP Account
-	is named by its `account_id`, the stored ID is already a valid link target. Runs post_model_sync:
-	the `account` column has been synced and the dropped `account_id` field survives as an orphaned
-	column (Frappe never drops columns on migrate). No-op on fresh installs and on re-run.
-	"""
+    `account_id` (Data) was replaced by `account` (Link to "JMAP Account"). Since JMAP Account
+    is named by its `account_id`, the stored ID is already a valid link target. Runs post_model_sync:
+    the `account` column has been synced and the dropped `account_id` field survives as an orphaned
+    column (Frappe never drops columns on migrate). No-op on fresh installs and on re-run.
+    """
 
-	if not frappe.db.has_column("Mail Sync History", "account_id"):
-		return
+    if not frappe.db.has_column("Mail Sync History", "account_id"):
+        return
 
-	MSH = frappe.qb.DocType("Mail Sync History")
-	(
-		frappe.qb.update(MSH)
-		.set(MSH.account, MSH.account_id)
-		.where((Coalesce(MSH.account, "") == "") & (Coalesce(MSH.account_id, "") != ""))
-	).run()
+    MSH = frappe.qb.DocType("Mail Sync History")
+    (
+        frappe.qb.update(MSH)
+        .set(MSH.account, MSH.account_id)
+        .where((Coalesce(MSH.account, "") == "") & (Coalesce(MSH.account_id, "") != ""))
+    ).run()

--- a/suite/mail/patches/create_push_subscriptions.py
+++ b/suite/mail/patches/create_push_subscriptions.py
@@ -8,24 +8,24 @@ from suite.mail.utils import log_mail_error
 
 
 def execute() -> None:
-	if not frappe.utils.get_url().startswith("https://"):
-		return
+    if not frappe.utils.get_url().startswith("https://"):
+        return
 
-	for user in frappe.db.get_all("User Settings", {"username": ["!=", ""]}, pluck="user"):
-		try:
-			service = get_push_subscription_service(user, ignore_permissions=True)
+    for user in frappe.db.get_all("User Settings", {"username": ["!=", ""]}, pluck="user"):
+        try:
+            service = get_push_subscription_service(user, ignore_permissions=True)
 
-			subscriptions = service.get()
-			if ids := [s["id"] for s in subscriptions]:
-				service.delete(ids)
+            subscriptions = service.get()
+            if ids := [s["id"] for s in subscriptions]:
+                service.delete(ids)
 
-			ps = frappe.new_doc("Push Subscription")
-			ps.user = user
-			ps.insert(ignore_permissions=True)
-		except Exception as e:
-			log_mail_error(
-				_("Push Subscription Creation Failed"),
-				_("Failed to create push subscription for user {0}: {1}").format(user, str(e)),
-			)
+            ps = frappe.new_doc("Push Subscription")
+            ps.user = user
+            ps.insert(ignore_permissions=True)
+        except Exception as e:
+            log_mail_error(
+                _("Push Subscription Creation Failed"),
+                _("Failed to create push subscription for user {0}: {1}").format(user, str(e)),
+            )
 
-		time.sleep(0.1)
+        time.sleep(0.1)

--- a/suite/mail/patches/create_suite_user_role.py
+++ b/suite/mail/patches/create_suite_user_role.py
@@ -7,107 +7,105 @@ ROLE = "Suite User"
 # role via Frappe's `if_owner`. `if_owner` keys off the standard `owner` field, so existing
 # records must have `owner` aligned with their `user` field (see `suite.utils.permissions`).
 OWNER_SCOPED_DOCTYPES = (
-	"Mail Exchange",
-	"Mail Queue",
-	"User Account",
-	"User Settings",
-	"Contacts Exchange",
-	"Calendar Exchange",
-	"Mail Signature",
+    "Mail Exchange",
+    "Mail Queue",
+    "User Account",
+    "User Settings",
+    "Contacts Exchange",
+    "Calendar Exchange",
+    "Mail Signature",
 )
 
 
 def execute() -> None:
-	"""Grant the Suite User role to existing users and align record ownership.
+    """Grant the Suite User role to existing users and align record ownership.
 
-	The non-virtual Mail/Calendar doctypes moved from the blanket "All" role to an
-	owner-scoped "Suite User" role. Existing users therefore need the role assigned
-	explicitly, and existing records need `owner` pinned to their `user` field, otherwise
-	users would lose access to their own records on upgrade. Mail users are identified by
-	having a User Settings or User Account record.
+    The non-virtual Mail/Calendar doctypes moved from the blanket "All" role to an
+    owner-scoped "Suite User" role. Existing users therefore need the role assigned
+    explicitly, and existing records need `owner` pinned to their `user` field, otherwise
+    users would lose access to their own records on upgrade. Mail users are identified by
+    having a User Settings or User Account record.
 
-	The role itself is shipped as a fixture (see ``suite/fixtures/role.json``), but fixtures
-	sync only after post_model_sync patches, so it is created here first if still missing.
-	"""
+    The role itself is shipped as a fixture (see ``suite/fixtures/role.json``), but fixtures
+    sync only after post_model_sync patches, so it is created here first if still missing.
+    """
 
-	if not frappe.db.exists("Role", ROLE):
-		frappe.get_doc({"doctype": "Role", "role_name": ROLE, "desk_access": 1}).insert(
-			ignore_permissions=True
-		)
+    if not frappe.db.exists("Role", ROLE):
+        frappe.get_doc({"doctype": "Role", "role_name": ROLE, "desk_access": 1}).insert(
+            ignore_permissions=True
+        )
 
-	users = set(frappe.get_all("User Settings", pluck="user"))
-	users |= set(frappe.get_all("User Account", pluck="user"))
-	users.discard(None)
-	users.discard("Administrator")
+    users = set(frappe.get_all("User Settings", pluck="user"))
+    users |= set(frappe.get_all("User Account", pluck="user"))
+    users.discard(None)
+    users.discard("Administrator")
 
-	_assign_role(users)
+    _assign_role(users)
 
-	for doctype in OWNER_SCOPED_DOCTYPES:
-		table = f"tab{doctype}"
-		frappe.db.sql(
-			f"UPDATE `{table}` SET `owner` = `user` WHERE `user` IS NOT NULL AND `owner` != `user`"
-		)
+    for doctype in OWNER_SCOPED_DOCTYPES:
+        table = f"tab{doctype}"
+        frappe.db.sql(f"UPDATE `{table}` SET `owner` = `user` WHERE `user` IS NOT NULL AND `owner` != `user`")
 
 
 def _assign_role(users: set[str]) -> None:
-	"""Grant ROLE to ``users`` with one bulk insert into ``Has Role``.
+    """Grant ROLE to ``users`` with one bulk insert into ``Has Role``.
 
-	Going through ``User.add_roles`` would fetch and save every User document (an N+1 on
-	migrate). ROLE carries desk access, and the bulk insert does not recompute
-	``user_type``; that is fine because every enabled user already holds a desk-access role
-	(Drive/Suite) and is therefore already a System User. A single query both skips users who
-	already hold the role and finds the next ``idx`` per user; caches are cleared at the end
-	of the migrate.
-	"""
+    Going through ``User.add_roles`` would fetch and save every User document (an N+1 on
+    migrate). ROLE carries desk access, and the bulk insert does not recompute
+    ``user_type``; that is fine because every enabled user already holds a desk-access role
+    (Drive/Suite) and is therefore already a System User. A single query both skips users who
+    already hold the role and finds the next ``idx`` per user; caches are cleared at the end
+    of the migrate.
+    """
 
-	if not users:
-		return
+    if not users:
+        return
 
-	existing = frappe.get_all(
-		"Has Role",
-		filters={"parenttype": "User", "parent": ("in", list(users))},
-		fields=["parent", "role", "idx"],
-	)
-	already_has = {row.parent for row in existing if row.role == ROLE}
-	next_idx = {}
-	for row in existing:
-		next_idx[row.parent] = max(next_idx.get(row.parent, 0), row.idx)
+    existing = frappe.get_all(
+        "Has Role",
+        filters={"parenttype": "User", "parent": ("in", list(users))},
+        fields=["parent", "role", "idx"],
+    )
+    already_has = {row.parent for row in existing if row.role == ROLE}
+    next_idx = {}
+    for row in existing:
+        next_idx[row.parent] = max(next_idx.get(row.parent, 0), row.idx)
 
-	timestamp = now()
-	rows = [
-		(
-			frappe.generate_hash(length=10),
-			user,
-			"User",
-			"roles",
-			ROLE,
-			"Administrator",
-			timestamp,
-			timestamp,
-			"Administrator",
-			next_idx.get(user, 0) + 1,
-			0,
-		)
-		for user in users
-		if user not in already_has
-	]
-	if not rows:
-		return
+    timestamp = now()
+    rows = [
+        (
+            frappe.generate_hash(length=10),
+            user,
+            "User",
+            "roles",
+            ROLE,
+            "Administrator",
+            timestamp,
+            timestamp,
+            "Administrator",
+            next_idx.get(user, 0) + 1,
+            0,
+        )
+        for user in users
+        if user not in already_has
+    ]
+    if not rows:
+        return
 
-	frappe.db.bulk_insert(
-		"Has Role",
-		fields=[
-			"name",
-			"parent",
-			"parenttype",
-			"parentfield",
-			"role",
-			"owner",
-			"creation",
-			"modified",
-			"modified_by",
-			"idx",
-			"docstatus",
-		],
-		values=rows,
-	)
+    frappe.db.bulk_insert(
+        "Has Role",
+        fields=[
+            "name",
+            "parent",
+            "parenttype",
+            "parentfield",
+            "role",
+            "owner",
+            "creation",
+            "modified",
+            "modified_by",
+            "idx",
+            "docstatus",
+        ],
+        values=rows,
+    )

--- a/suite/mail/patches/delete_client_module.py
+++ b/suite/mail/patches/delete_client_module.py
@@ -2,14 +2,14 @@ import frappe
 
 
 def execute() -> None:
-	"""Delete the Client module after its DocTypes were moved to Mail.
+    """Delete the Client module after its DocTypes were moved to Mail.
 
-	On upgraded sites the relocated DocTypes (and the Client workspace sidebar)
-	may still be stored with ``module = "Client"``. The controllers now live only
-	under ``suite.mail.doctype.*`` and the ``suite/client`` package is gone, so
-	the stale module must be retagged before anything tries to resolve it. These
-	are plain DB updates and never load the relocated controllers.
-	"""
-	frappe.db.set_value("DocType", {"module": "Client"}, "module", "Mail", update_modified=False)
-	frappe.db.set_value("Workspace Sidebar", {"module": "Client"}, "module", "Mail", update_modified=False)
-	frappe.db.delete("Module Def", {"name": "Client", "app_name": "suite"})
+    On upgraded sites the relocated DocTypes (and the Client workspace sidebar)
+    may still be stored with ``module = "Client"``. The controllers now live only
+    under ``suite.mail.doctype.*`` and the ``suite/client`` package is gone, so
+    the stale module must be retagged before anything tries to resolve it. These
+    are plain DB updates and never load the relocated controllers.
+    """
+    frappe.db.set_value("DocType", {"module": "Client"}, "module", "Mail", update_modified=False)
+    frappe.db.set_value("Workspace Sidebar", {"module": "Client"}, "module", "Mail", update_modified=False)
+    frappe.db.delete("Module Def", {"name": "Client", "app_name": "suite"})

--- a/suite/mail/patches/delete_server_module.py
+++ b/suite/mail/patches/delete_server_module.py
@@ -2,14 +2,14 @@ import frappe
 
 
 def execute() -> None:
-	"""Delete the Server module after its DocTypes were moved to Mail.
+    """Delete the Server module after its DocTypes were moved to Mail.
 
-	On upgraded sites the relocated DocTypes (and the Server workspace sidebar)
-	may still be stored with ``module = "Server"``. The controllers now live only
-	under ``suite.mail.doctype.*`` and the ``suite/server`` package is gone, so
-	the stale module must be retagged before anything tries to resolve it. These
-	are plain DB updates and never load the relocated controllers.
-	"""
-	frappe.db.set_value("DocType", {"module": "Server"}, "module", "Mail", update_modified=False)
-	frappe.db.set_value("Workspace Sidebar", {"module": "Server"}, "module", "Mail", update_modified=False)
-	frappe.db.delete("Module Def", {"name": "Server", "app_name": "suite"})
+    On upgraded sites the relocated DocTypes (and the Server workspace sidebar)
+    may still be stored with ``module = "Server"``. The controllers now live only
+    under ``suite.mail.doctype.*`` and the ``suite/server`` package is gone, so
+    the stale module must be retagged before anything tries to resolve it. These
+    are plain DB updates and never load the relocated controllers.
+    """
+    frappe.db.set_value("DocType", {"module": "Server"}, "module", "Mail", update_modified=False)
+    frappe.db.set_value("Workspace Sidebar", {"module": "Server"}, "module", "Mail", update_modified=False)
+    frappe.db.delete("Module Def", {"name": "Server", "app_name": "suite"})

--- a/suite/mail/patches/destroy_data_store.py
+++ b/suite/mail/patches/destroy_data_store.py
@@ -2,6 +2,6 @@ from suite.mail.store import destroy_data_store
 
 
 def execute() -> None:
-	"""Destroy the on-disk data store so it is rebuilt lazily from JMAP on next access."""
+    """Destroy the on-disk data store so it is rebuilt lazily from JMAP on next access."""
 
-	destroy_data_store()
+    destroy_data_store()

--- a/suite/mail/patches/enable_screening_for_personal_accounts.py
+++ b/suite/mail/patches/enable_screening_for_personal_accounts.py
@@ -1,105 +1,105 @@
 import frappe
 
 from suite.mail.doctype.sieve_script.sieve_script import (
-	AUTOMATION_SCRIPT_NAME,
-	SieveScript,
-	build_automation_sieve,
-	get_active_sieve_script_id,
+    AUTOMATION_SCRIPT_NAME,
+    SieveScript,
+    build_automation_sieve,
+    get_active_sieve_script_id,
 )
 from suite.mail.utils import log_mail_error
 
 
 def execute() -> None:
-	"""Turn screening on by default for existing personal accounts that haven't customised filtering.
+    """Turn screening on by default for existing personal accounts that haven't customised filtering.
 
-	Screening now defaults to on for newly created *personal* accounts (JMAP Account.enable_screening),
-	but personal accounts created before that may still have it off. This backfills them, limited to
-	*personal* accounts (a user's own account, not a shared or delegated one) that don't have a custom
-	Sieve script active — if the account's active script is one the user wrote themselves, they've taken
-	over their own filtering and we leave it untouched. Our own scripts (the frappe_mail_automation
-	script and the read-only vacation auto-responder) don't count as custom, and neither does having
-	no active script at all.
+    Screening now defaults to on for newly created *personal* accounts (JMAP Account.enable_screening),
+    but personal accounts created before that may still have it off. This backfills them, limited to
+    *personal* accounts (a user's own account, not a shared or delegated one) that don't have a custom
+    Sieve script active — if the account's active script is one the user wrote themselves, they've taken
+    over their own filtering and we leave it untouched. Our own scripts (the frappe_mail_automation
+    script and the read-only vacation auto-responder) don't count as custom, and neither does having
+    no active script at all.
 
-	Enabling screening means the automation Sieve must be rebuilt so its screening gate is emitted,
-	which needs a live JMAP session — not reliably reachable during `bench migrate` — so the work is
-	deferred to a background job. It also self-heals: accounts already screening or already carrying a
-	custom active script are skipped, so a re-run is a no-op for them.
-	"""
+    Enabling screening means the automation Sieve must be rebuilt so its screening gate is emitted,
+    which needs a live JMAP session — not reliably reachable during `bench migrate` — so the work is
+    deferred to a background job. It also self-heals: accounts already screening or already carrying a
+    custom active script are skipped, so a re-run is a no-op for them.
+    """
 
-	frappe.enqueue(enable_screening_for_personal_accounts, queue="long", enqueue_after_commit=True)
+    frappe.enqueue(enable_screening_for_personal_accounts, queue="long", enqueue_after_commit=True)
 
 
 def enable_screening_for_personal_accounts() -> None:
-	"""Enable screening and rebuild the automation Sieve for each eligible personal account."""
+    """Enable screening and rebuild the automation Sieve for each eligible personal account."""
 
-	for account in get_eligible_personal_accounts():
-		try:
-			if has_custom_sieve_script_active(account):
-				continue
+    for account in get_eligible_personal_accounts():
+        try:
+            if has_custom_sieve_script_active(account):
+                continue
 
-			# Set the flag first so build_automation_sieve() sees screening as enabled and emits the gate.
-			frappe.db.set_value("JMAP Account", account, "enable_screening", 1, update_modified=False)
-			build_automation_sieve(account, activate=True)
-			frappe.db.commit()
-		except Exception:
-			frappe.db.rollback()
-			log_mail_error(
-				"Enable Screening Patch Error",
-				f"Failed to enable screening for JMAP account {account}",
-			)
+            # Set the flag first so build_automation_sieve() sees screening as enabled and emits the gate.
+            frappe.db.set_value("JMAP Account", account, "enable_screening", 1, update_modified=False)
+            build_automation_sieve(account, activate=True)
+            frappe.db.commit()
+        except Exception:
+            frappe.db.rollback()
+            log_mail_error(
+                "Enable Screening Patch Error",
+                f"Failed to enable screening for JMAP account {account}",
+            )
 
 
 def get_eligible_personal_accounts() -> list[str]:
-	"""Deduplicated personal accounts to backfill, scoped to users who still schedule-fetch.
+    """Deduplicated personal accounts to backfill, scoped to users who still schedule-fetch.
 
-	A JMAP Account is shared across every user with access to it, so User Account links it to one
-	or more users. We only want personal accounts (is_personal) that don't already have screening
-	on (enable_screening = 0), and only for enabled users who have JMAP configured (username set)
-	and whose User Settings leaves scheduled change fetching on (skip_schedule_fetch_changes = 0)
-	— enabling screening relies on that periodic fetch to keep the Screening folder current, so
-	disabled users, unconfigured users, and users who opted out are left alone.
+    A JMAP Account is shared across every user with access to it, so User Account links it to one
+    or more users. We only want personal accounts (is_personal) that don't already have screening
+    on (enable_screening = 0), and only for enabled users who have JMAP configured (username set)
+    and whose User Settings leaves scheduled change fetching on (skip_schedule_fetch_changes = 0)
+    — enabling screening relies on that periodic fetch to keep the Screening folder current, so
+    disabled users, unconfigured users, and users who opted out are left alone.
 
-	`.distinct()` collapses the per-user User Account rows down to one entry per account.
-	"""
+    `.distinct()` collapses the per-user User Account rows down to one entry per account.
+    """
 
-	USER = frappe.qb.DocType("User")
-	USER_SETTINGS = frappe.qb.DocType("User Settings")
-	USER_ACCOUNT = frappe.qb.DocType("User Account")
-	JMAP_ACCOUNT = frappe.qb.DocType("JMAP Account")
+    USER = frappe.qb.DocType("User")
+    USER_SETTINGS = frappe.qb.DocType("User Settings")
+    USER_ACCOUNT = frappe.qb.DocType("User Account")
+    JMAP_ACCOUNT = frappe.qb.DocType("JMAP Account")
 
-	return (
-		frappe.qb.from_(USER_ACCOUNT)
-		.join(USER_SETTINGS)
-		.on(USER_ACCOUNT.user_settings == USER_SETTINGS.name)
-		.join(USER)
-		.on(USER_SETTINGS.user == USER.name)
-		.join(JMAP_ACCOUNT)
-		.on(USER_ACCOUNT.account == JMAP_ACCOUNT.name)
-		.where(USER.enabled == 1)
-		.where(USER_SETTINGS.username.isnotnull() & (USER_SETTINGS.username != ""))
-		.where(USER_SETTINGS.skip_schedule_fetch_changes == 0)
-		.where(JMAP_ACCOUNT.is_personal == 1)
-		.where(JMAP_ACCOUNT.enable_screening == 0)
-		.select(USER_ACCOUNT.account)
-		.distinct()
-	).run(pluck="account")
+    return (
+        frappe.qb.from_(USER_ACCOUNT)
+        .join(USER_SETTINGS)
+        .on(USER_ACCOUNT.user_settings == USER_SETTINGS.name)
+        .join(USER)
+        .on(USER_SETTINGS.user == USER.name)
+        .join(JMAP_ACCOUNT)
+        .on(USER_ACCOUNT.account == JMAP_ACCOUNT.name)
+        .where(USER.enabled == 1)
+        .where(USER_SETTINGS.username.isnotnull() & (USER_SETTINGS.username != ""))
+        .where(USER_SETTINGS.skip_schedule_fetch_changes == 0)
+        .where(JMAP_ACCOUNT.is_personal == 1)
+        .where(JMAP_ACCOUNT.enable_screening == 0)
+        .select(USER_ACCOUNT.account)
+        .distinct()
+    ).run(pluck="account")
 
 
 def has_custom_sieve_script_active(account: str) -> bool:
-	"""Whether the account's currently active Sieve script is one the user wrote themselves.
+    """Whether the account's currently active Sieve script is one the user wrote themselves.
 
-	The frappe_mail_automation script and the read-only vacation auto-responder are ours, not custom;
-	so is having no active script at all. Anything else active means the user manages their own
-	filtering and screening should not be forced on.
-	"""
+    The frappe_mail_automation script and the read-only vacation auto-responder are ours, not custom;
+    so is having no active script at all. Anything else active means the user manages their own
+    filtering and screening should not be forced on.
+    """
 
-	active_id = get_active_sieve_script_id(account)
-	if not active_id:
-		return False
+    active_id = get_active_sieve_script_id(account)
+    if not active_id:
+        return False
 
-	scripts = SieveScript._get_sieve_scripts(account, [active_id])
-	if not scripts:
-		return False
+    scripts = SieveScript._get_sieve_scripts(account, [active_id])
+    if not scripts:
+        return False
 
-	script = scripts[0]
-	return script.get("_name") != AUTOMATION_SCRIPT_NAME and not script.get("read_only")
+    script = scripts[0]
+    return script.get("_name") != AUTOMATION_SCRIPT_NAME and not script.get("read_only")

--- a/suite/mail/patches/generate_ssh_keypair_for_cluster.py
+++ b/suite/mail/patches/generate_ssh_keypair_for_cluster.py
@@ -5,9 +5,9 @@ from suite.mail.utils import log_mail_error
 
 
 def execute() -> None:
-	clusters = frappe.db.get_all("Mail Cluster", {"ssh_public_key": ["in", ["", None]]}, pluck="name")
-	for cluster in clusters:
-		try:
-			frappe.get_doc("Mail Cluster", cluster).generate_ssh_keypair(save=True)
-		except Exception:
-			log_mail_error(_("Failed to generate SSH keypair"), frappe.get_traceback(with_context=False))
+    clusters = frappe.db.get_all("Mail Cluster", {"ssh_public_key": ["in", ["", None]]}, pluck="name")
+    for cluster in clusters:
+        try:
+            frappe.get_doc("Mail Cluster", cluster).generate_ssh_keypair(save=True)
+        except Exception:
+            log_mail_error(_("Failed to generate SSH keypair"), frappe.get_traceback(with_context=False))

--- a/suite/mail/patches/migrate_cache_to_mail_namespace.py
+++ b/suite/mail/patches/migrate_cache_to_mail_namespace.py
@@ -6,49 +6,49 @@ from suite.store import get_blob_base_path, get_data_base_path
 
 
 def execute() -> None:
-	"""Relocate pre-namespace cache directories into the ``mail`` namespace.
+    """Relocate pre-namespace cache directories into the ``mail`` namespace.
 
-	Before stores were namespaced, each JMAP account's data/blob cache lived directly at
-	``<base>/<account>``; it now lives at ``<base>/mail/<account>``. The leaf directory name is
-	unchanged, so migrating is just moving every existing top-level account directory under a
-	``mail/`` subdirectory. Both bases were used only by mail before this change, so every
-	top-level directory is a mail account cache.
+    Before stores were namespaced, each JMAP account's data/blob cache lived directly at
+    ``<base>/<account>``; it now lives at ``<base>/mail/<account>``. The leaf directory name is
+    unchanged, so migrating is just moving every existing top-level account directory under a
+    ``mail/`` subdirectory. Both bases were used only by mail before this change, so every
+    top-level directory is a mail account cache.
 
-	Best-effort: caches rebuild lazily from JMAP, so anything already migrated (or any stray
-	file such as an interrupted blob-store temp file) is left as-is.
-	"""
+    Best-effort: caches rebuild lazily from JMAP, so anything already migrated (or any stray
+    file such as an interrupted blob-store temp file) is left as-is.
+    """
 
-	for base_path in (get_data_base_path(), get_blob_base_path()):
-		_migrate_base(base_path)
+    for base_path in (get_data_base_path(), get_blob_base_path()):
+        _migrate_base(base_path)
 
 
 def _migrate_base(base_path: str) -> None:
-	"""Move each top-level account directory in `base_path` into its ``mail`` subdirectory."""
+    """Move each top-level account directory in `base_path` into its ``mail`` subdirectory."""
 
-	if not os.path.isdir(base_path):
-		return
+    if not os.path.isdir(base_path):
+        return
 
-	target = os.path.join(base_path, MAIL_NAMESPACE)
+    target = os.path.join(base_path, MAIL_NAMESPACE)
 
-	# Snapshot the listing first: the moves add entries to `base_path`, which must not perturb
-	# the iteration.
-	for name in os.listdir(base_path):
-		if name == MAIL_NAMESPACE:
-			continue
+    # Snapshot the listing first: the moves add entries to `base_path`, which must not perturb
+    # the iteration.
+    for name in os.listdir(base_path):
+        if name == MAIL_NAMESPACE:
+            continue
 
-		source = os.path.join(base_path, name)
+        source = os.path.join(base_path, name)
 
-		# Only per-account directories move; leave stray files and symlinks untouched.
-		if os.path.islink(source) or not os.path.isdir(source):
-			continue
+        # Only per-account directories move; leave stray files and symlinks untouched.
+        if os.path.islink(source) or not os.path.isdir(source):
+            continue
 
-		os.makedirs(target, exist_ok=True)
-		destination = os.path.join(target, name)
+        os.makedirs(target, exist_ok=True)
+        destination = os.path.join(target, name)
 
-		# Already migrated for this account: the namespaced copy is authoritative, so drop the
-		# stale pre-namespace directory rather than overwrite it.
-		if os.path.exists(destination):
-			shutil.rmtree(source, ignore_errors=True)
-			continue
+        # Already migrated for this account: the namespaced copy is authoritative, so drop the
+        # stale pre-namespace directory rather than overwrite it.
+        if os.path.exists(destination):
+            shutil.rmtree(source, ignore_errors=True)
+            continue
 
-		os.rename(source, destination)
+        os.rename(source, destination)

--- a/suite/mail/patches/migrate_search_index_to_mail_namespace.py
+++ b/suite/mail/patches/migrate_search_index_to_mail_namespace.py
@@ -3,17 +3,17 @@ from suite.store import get_search_base_path
 
 
 def execute() -> None:
-	"""Relocate pre-namespace search indexes into the ``mail`` namespace.
+    """Relocate pre-namespace search indexes into the ``mail`` namespace.
 
-	Search indexes were namespaced after the data/blob stores, so the earlier
-	``migrate_cache_to_mail_namespace`` patch (which had already run) never touched them. Each
-	account's index lived directly at ``<search-base>/<account>/<entity>`` and now lives at
-	``<search-base>/mail/<account>/<entity>``. As with the other stores the leaf directory name is
-	unchanged, so migrating is just moving every top-level account directory under a ``mail/``
-	subdirectory — the same move `_migrate_base` performs for the data and blob bases.
+    Search indexes were namespaced after the data/blob stores, so the earlier
+    ``migrate_cache_to_mail_namespace`` patch (which had already run) never touched them. Each
+    account's index lived directly at ``<search-base>/<account>/<entity>`` and now lives at
+    ``<search-base>/mail/<account>/<entity>``. As with the other stores the leaf directory name is
+    unchanged, so migrating is just moving every top-level account directory under a ``mail/``
+    subdirectory — the same move `_migrate_base` performs for the data and blob bases.
 
-	Best-effort: indexes rebuild lazily from cached data, so anything already migrated (or any
-	stray file) is left as-is.
-	"""
+    Best-effort: indexes rebuild lazily from cached data, so anything already migrated (or any
+    stray file) is left as-is.
+    """
 
-	_migrate_base(get_search_base_path())
+    _migrate_base(get_search_base_path())

--- a/suite/mail/patches/rebuild_automation_sieve_scripts.py
+++ b/suite/mail/patches/rebuild_automation_sieve_scripts.py
@@ -9,90 +9,90 @@ _ACCOUNTS_PER_BATCH = 20
 
 
 def execute() -> None:
-	"""Regenerate the automation Sieve script for accounts whose stored copy may be wrong.
+    """Regenerate the automation Sieve script for accounts whose stored copy may be wrong.
 
-	Two generation bugs are fixed alongside this patch, and both leave incorrect content sitting on
-	the Stalwart server:
+    Two generation bugs are fixed alongside this patch, and both leave incorrect content sitting on
+    the Stalwart server:
 
-	- Rule text (``emails_from`` / ``subject_contains``) was interpolated into the script without
-	  escaping. A value carrying a double quote produced a script the server rejected, so the
-	  ``SieveScript/set`` failed, the error was swallowed, and the account kept its previous script —
-	  the user's rule silently never took effect.
-	- Mailbox paths were resolved by walking parents by name. Where two mailboxes share a leaf name
-	  that resolved the wrong parent, so ``fileinto`` was generated against the wrong folder.
+    - Rule text (``emails_from`` / ``subject_contains``) was interpolated into the script without
+      escaping. A value carrying a double quote produced a script the server rejected, so the
+      ``SieveScript/set`` failed, the error was swallowed, and the account kept its previous script —
+      the user's rule silently never took effect.
+    - Mailbox paths were resolved by walking parents by name. Where two mailboxes share a leaf name
+      that resolved the wrong parent, so ``fileinto`` was generated against the wrong folder.
 
-	Nothing rebuilds these scripts on a schedule — ``build_automation_sieve`` only runs when a user
-	touches a folder, a rule, or screening — so an affected account would keep the bad script
-	indefinitely. Rebuilding is idempotent, so a re-run is a no-op for accounts already correct.
+    Nothing rebuilds these scripts on a schedule — ``build_automation_sieve`` only runs when a user
+    touches a folder, a rule, or screening — so an affected account would keep the bad script
+    indefinitely. Rebuilding is idempotent, so a re-run is a no-op for accounts already correct.
 
-	Deferred to a background job: regeneration needs a live JMAP session per account, which is not
-	reliably reachable during ``bench migrate``.
-	"""
+    Deferred to a background job: regeneration needs a live JMAP session per account, which is not
+    reliably reachable during ``bench migrate``.
+    """
 
-	frappe.enqueue(rebuild_automation_sieve_scripts, queue="long", enqueue_after_commit=True)
+    frappe.enqueue(rebuild_automation_sieve_scripts, queue="long", enqueue_after_commit=True)
 
 
 def rebuild_automation_sieve_scripts() -> None:
-	"""Fan the affected accounts out into long-queue batches."""
+    """Fan the affected accounts out into long-queue batches."""
 
-	accounts = get_accounts_with_automation_rules()
-	for i, batch in enumerate(create_batch(accounts, _ACCOUNTS_PER_BATCH)):
-		enqueue_job(
-			_rebuild_automation_sieve_scripts,
-			job_id=f"rebuild-automation-sieve-scripts::{i}",
-			deduplicate=True,
-			queue="long",
-			timeout=3600,
-			accounts=batch,
-		)
+    accounts = get_accounts_with_automation_rules()
+    for i, batch in enumerate(create_batch(accounts, _ACCOUNTS_PER_BATCH)):
+        enqueue_job(
+            _rebuild_automation_sieve_scripts,
+            job_id=f"rebuild-automation-sieve-scripts::{i}",
+            deduplicate=True,
+            queue="long",
+            timeout=3600,
+            accounts=batch,
+        )
 
 
 def _rebuild_automation_sieve_scripts(accounts: list[str]) -> None:
-	"""Rebuild each account's automation script inline, isolating per-account failures."""
+    """Rebuild each account's automation script inline, isolating per-account failures."""
 
-	for account in accounts:
-		# The job runs async after the fan-out committed, so an account can vanish in between.
-		if not account or not frappe.db.exists("JMAP Account", account):
-			continue
+    for account in accounts:
+        # The job runs async after the fan-out committed, so an account can vanish in between.
+        if not account or not frappe.db.exists("JMAP Account", account):
+            continue
 
-		try:
-			# activate=False on purpose: this refreshes the script's content only. Activating here
-			# would override an account whose active script is the vacation auto-responder or one
-			# the user wrote themselves.
-			build_automation_sieve(account)
-			frappe.db.commit()
-		except Exception:
-			frappe.db.rollback()
-			log_mail_error(
-				"Rebuild Automation Sieve Patch Error",
-				f"Failed to rebuild the automation sieve script for JMAP account {account}",
-			)
+        try:
+            # activate=False on purpose: this refreshes the script's content only. Activating here
+            # would override an account whose active script is the vacation auto-responder or one
+            # the user wrote themselves.
+            build_automation_sieve(account)
+            frappe.db.commit()
+        except Exception:
+            frappe.db.rollback()
+            log_mail_error(
+                "Rebuild Automation Sieve Patch Error",
+                f"Failed to rebuild the automation sieve script for JMAP account {account}",
+            )
 
 
 def get_accounts_with_automation_rules() -> list[str]:
-	"""Accounts that have at least one mailbox automation rule, deduplicated.
+    """Accounts that have at least one mailbox automation rule, deduplicated.
 
-	Scoped deliberately. ``get_automation_script_name`` *creates* the automation script when an
-	account has none, so rebuilding indiscriminately would conjure an empty script onto every
-	account on the site. Only mailboxes carrying a sender or subject condition contribute generated
-	content, and those are exactly the accounts either bug could have affected.
+    Scoped deliberately. ``get_automation_script_name`` *creates* the automation script when an
+    account has none, so rebuilding indiscriminately would conjure an empty script onto every
+    account on the site. Only mailboxes carrying a sender or subject condition contribute generated
+    content, and those are exactly the accounts either bug could have affected.
 
-	Joined to JMAP Account because Mailbox Settings carries stale rows from before the
-	shared-per-account reshape — account values in the legacy ``user@domain:accountid`` format, or
-	empty — and rebuilding those fails with "JMAP account does not exist".
-	"""
+    Joined to JMAP Account because Mailbox Settings carries stale rows from before the
+    shared-per-account reshape — account values in the legacy ``user@domain:accountid`` format, or
+    empty — and rebuilding those fails with "JMAP account does not exist".
+    """
 
-	MAILBOX_SETTINGS = frappe.qb.DocType("Mailbox Settings")
-	JMAP_ACCOUNT = frappe.qb.DocType("JMAP Account")
+    MAILBOX_SETTINGS = frappe.qb.DocType("Mailbox Settings")
+    JMAP_ACCOUNT = frappe.qb.DocType("JMAP Account")
 
-	return (
-		frappe.qb.from_(MAILBOX_SETTINGS)
-		.inner_join(JMAP_ACCOUNT)
-		.on(MAILBOX_SETTINGS.account == JMAP_ACCOUNT.name)
-		.where(
-			(MAILBOX_SETTINGS.emails_from.isnotnull() & (MAILBOX_SETTINGS.emails_from != ""))
-			| (MAILBOX_SETTINGS.subject_contains.isnotnull() & (MAILBOX_SETTINGS.subject_contains != ""))
-		)
-		.select(MAILBOX_SETTINGS.account)
-		.distinct()
-	).run(pluck="account")
+    return (
+        frappe.qb.from_(MAILBOX_SETTINGS)
+        .inner_join(JMAP_ACCOUNT)
+        .on(MAILBOX_SETTINGS.account == JMAP_ACCOUNT.name)
+        .where(
+            (MAILBOX_SETTINGS.emails_from.isnotnull() & (MAILBOX_SETTINGS.emails_from != ""))
+            | (MAILBOX_SETTINGS.subject_contains.isnotnull() & (MAILBOX_SETTINGS.subject_contains != ""))
+        )
+        .select(MAILBOX_SETTINGS.account)
+        .distinct()
+    ).run(pluck="account")

--- a/suite/mail/patches/rebuild_email_address_indexes.py
+++ b/suite/mail/patches/rebuild_email_address_indexes.py
@@ -2,10 +2,10 @@ from suite.mail.store import rebuild_all_email_address_indexes
 
 
 def execute() -> None:
-	"""Build the email-address search index from data already cached for each JMAP account.
+    """Build the email-address search index from data already cached for each JMAP account.
 
-	The index is new, so existing caches predate it. This fans the accounts out into long-queue
-	background jobs (rather than indexing inline during migrate), each rebuilding from the cache.
-	"""
+    The index is new, so existing caches predate it. This fans the accounts out into long-queue
+    background jobs (rather than indexing inline during migrate), each rebuilding from the cache.
+    """
 
-	rebuild_all_email_address_indexes()
+    rebuild_all_email_address_indexes()

--- a/suite/mail/patches/rebuild_rate_limit_unique_constraint.py
+++ b/suite/mail/patches/rebuild_rate_limit_unique_constraint.py
@@ -2,16 +2,16 @@ import frappe
 
 
 def execute() -> None:
-	"""Drop the existing `unique_rate_limit` constraint so it is recreated with the
-	new `value` column (see Rate Limit.on_doctype_update) during model sync."""
+    """Drop the existing `unique_rate_limit` constraint so it is recreated with the
+    new `value` column (see Rate Limit.on_doctype_update) during model sync."""
 
-	table = "tabRate Limit"
-	constraint = "unique_rate_limit"
+    table = "tabRate Limit"
+    constraint = "unique_rate_limit"
 
-	exists = frappe.db.sql(
-		"""select CONSTRAINT_NAME from information_schema.TABLE_CONSTRAINTS
+    exists = frappe.db.sql(
+        """select CONSTRAINT_NAME from information_schema.TABLE_CONSTRAINTS
 		where table_name = %s and constraint_type = 'UNIQUE' and CONSTRAINT_NAME = %s""",
-		(table, constraint),
-	)
-	if exists:
-		frappe.db.sql_ddl(f"alter table `{table}` drop index `{constraint}`")
+        (table, constraint),
+    )
+    if exists:
+        frappe.db.sql_ddl(f"alter table `{table}` drop index `{constraint}`")

--- a/suite/mail/patches/remove_mail_admin_role.py
+++ b/suite/mail/patches/remove_mail_admin_role.py
@@ -2,11 +2,11 @@ import frappe
 
 
 def execute() -> None:
-	frappe.db.delete(
-		"Has Role",
-		{
-			"role": "Mail Admin",
-			"parenttype": "User",
-			"parent": ("!=", "Administrator"),
-		},
-	)
+    frappe.db.delete(
+        "Has Role",
+        {
+            "role": "Mail Admin",
+            "parenttype": "User",
+            "parent": ("!=", "Administrator"),
+        },
+    )

--- a/suite/mail/patches/remove_mail_user_role.py
+++ b/suite/mail/patches/remove_mail_user_role.py
@@ -2,10 +2,10 @@ import frappe
 
 
 def execute() -> None:
-	frappe.db.delete(
-		"Has Role",
-		{
-			"role": "Mail User",
-			"parenttype": "User",
-		},
-	)
+    frappe.db.delete(
+        "Has Role",
+        {
+            "role": "Mail User",
+            "parenttype": "User",
+        },
+    )

--- a/suite/mail/patches/rename_account_settings_to_jmap_account.py
+++ b/suite/mail/patches/rename_account_settings_to_jmap_account.py
@@ -2,16 +2,16 @@ import frappe
 
 
 def execute() -> None:
-	"""Rename the legacy "Account Settings" DocType to "JMAP Account".
+    """Rename the legacy "Account Settings" DocType to "JMAP Account".
 
-	Runs pre_model_sync (after refactor_account_settings has reshaped the documents by
-	account ID, while the table is still named "Account Settings") so the existing table
-	and DocType record are renamed before the new "JMAP Account" schema is synced. No-op
-	on fresh installs, where the DocType is created directly as "JMAP Account".
-	"""
+    Runs pre_model_sync (after refactor_account_settings has reshaped the documents by
+    account ID, while the table is still named "Account Settings") so the existing table
+    and DocType record are renamed before the new "JMAP Account" schema is synced. No-op
+    on fresh installs, where the DocType is created directly as "JMAP Account".
+    """
 
-	if not frappe.db.exists("DocType", "Account Settings"):
-		return
+    if not frappe.db.exists("DocType", "Account Settings"):
+        return
 
-	frappe.rename_doc("DocType", "Account Settings", "JMAP Account", force=True)
-	frappe.clear_cache(doctype="JMAP Account")
+    frappe.rename_doc("DocType", "Account Settings", "JMAP Account", force=True)
+    frappe.clear_cache(doctype="JMAP Account")

--- a/suite/mail/patches/rename_mail_admin_to_suite_admin.py
+++ b/suite/mail/patches/rename_mail_admin_to_suite_admin.py
@@ -2,13 +2,13 @@ import frappe
 
 
 def execute() -> None:
-	"""Rename the "Mail Admin" role to "Suite Admin".
+    """Rename the "Mail Admin" role to "Suite Admin".
 
-	The admin role is now suite-wide. ``rename_doc`` cascades the change to the ``Has Role``
-	and ``DocPerm`` rows that link to it, so existing assignments are preserved. The role is
-	shipped as a fixture, but fixtures sync only after post_model_sync patches, so renaming
-	here first avoids ending up with both "Mail Admin" and "Suite Admin".
-	"""
+    The admin role is now suite-wide. ``rename_doc`` cascades the change to the ``Has Role``
+    and ``DocPerm`` rows that link to it, so existing assignments are preserved. The role is
+    shipped as a fixture, but fixtures sync only after post_model_sync patches, so renaming
+    here first avoids ending up with both "Mail Admin" and "Suite Admin".
+    """
 
-	if frappe.db.exists("Role", "Mail Admin") and not frappe.db.exists("Role", "Suite Admin"):
-		frappe.rename_doc("Role", "Mail Admin", "Suite Admin", force=True)
+    if frappe.db.exists("Role", "Mail Admin") and not frappe.db.exists("Role", "Suite Admin"):
+        frappe.rename_doc("Role", "Mail Admin", "Suite Admin", force=True)

--- a/suite/mail/patches/rename_user_settings.py
+++ b/suite/mail/patches/rename_user_settings.py
@@ -4,6 +4,6 @@ import frappe
 
 
 def execute() -> None:
-	for settings in frappe.db.get_all("User Settings", pluck="name"):
-		doc = frappe.get_doc("User Settings", settings)
-		doc.rename(str(uuid7()), force=True)
+    for settings in frappe.db.get_all("User Settings", pluck="name"):
+        doc = frappe.get_doc("User Settings", settings)
+        doc.rename(str(uuid7()), force=True)

--- a/suite/mail/patches/sync_jmap_accounts_for_configured_users.py
+++ b/suite/mail/patches/sync_jmap_accounts_for_configured_users.py
@@ -5,81 +5,81 @@ from suite.mail.utils import log_mail_error
 
 
 def execute() -> None:
-	"""Create the User Account links and populate the new JMAP Account identity fields.
+    """Create the User Account links and populate the new JMAP Account identity fields.
 
-	The Account Settings -> JMAP Account rename (rename_account_settings_to_jmap_account)
-	keeps every row and its configured values (screening, remote-image blocking, junk
-	handling, outgoing settings, last active sieve) intact. But the rename also introduced
-	identity fields (account_id, _name, is_personal, is_readonly) that are empty on existing
-	rows, and the per-user "User Account" links don't exist yet.
+    The Account Settings -> JMAP Account rename (rename_account_settings_to_jmap_account)
+    keeps every row and its configured values (screening, remote-image blocking, junk
+    handling, outgoing settings, last active sieve) intact. But the rename also introduced
+    identity fields (account_id, _name, is_personal, is_readonly) that are empty on existing
+    rows, and the per-user "User Account" links don't exist yet.
 
-	Existing rows are already named by the bare account ID (the shared-per-account reshape
-	shipped in an earlier release), so account_id is backfilled from the doc name inline: this
-	keeps each row the canonical, valid document for its account, which is what stops
-	sync_jmap_accounts from creating a fresh, empty duplicate and wiping the user's config.
+    Existing rows are already named by the bare account ID (the shared-per-account reshape
+    shipped in an earlier release), so account_id is backfilled from the doc name inline: this
+    keeps each row the canonical, valid document for its account, which is what stops
+    sync_jmap_accounts from creating a fresh, empty duplicate and wiping the user's config.
 
-	The rest needs a live JMAP session, which isn't reliably reachable during `bench migrate`,
-	so it's deferred to a background job: reconnect per configured user (username set), run
-	sync_jmap_accounts to create the User Account links and add docs for any brand-new
-	accounts, then backfill the session-derived identity fields on the pre-existing docs
-	without touching their configuration.
-	"""
+    The rest needs a live JMAP session, which isn't reliably reachable during `bench migrate`,
+    so it's deferred to a background job: reconnect per configured user (username set), run
+    sync_jmap_accounts to create the User Account links and add docs for any brand-new
+    accounts, then backfill the session-derived identity fields on the pre-existing docs
+    without touching their configuration.
+    """
 
-	backfill_account_id_from_name()
+    backfill_account_id_from_name()
 
-	frappe.enqueue(sync_configured_users, queue="long", enqueue_after_commit=True)
+    frappe.enqueue(sync_configured_users, queue="long", enqueue_after_commit=True)
 
 
 def backfill_account_id_from_name() -> None:
-	"""Set account_id = name on rows where it's blank; the doc name is already the account ID."""
+    """Set account_id = name on rows where it's blank; the doc name is already the account ID."""
 
-	JMAP_ACCOUNT = frappe.qb.DocType("JMAP Account")
-	(
-		frappe.qb.update(JMAP_ACCOUNT)
-		.set(JMAP_ACCOUNT.account_id, JMAP_ACCOUNT.name)
-		.where((JMAP_ACCOUNT.account_id.isnull()) | (JMAP_ACCOUNT.account_id == ""))
-	).run()
+    JMAP_ACCOUNT = frappe.qb.DocType("JMAP Account")
+    (
+        frappe.qb.update(JMAP_ACCOUNT)
+        .set(JMAP_ACCOUNT.account_id, JMAP_ACCOUNT.name)
+        .where((JMAP_ACCOUNT.account_id.isnull()) | (JMAP_ACCOUNT.account_id == ""))
+    ).run()
 
 
 def sync_configured_users() -> None:
-	"""Run sync_jmap_accounts for every user that has JMAP configured (username set)."""
+    """Run sync_jmap_accounts for every user that has JMAP configured (username set)."""
 
-	users = frappe.get_all("User Settings", filters={"username": ["is", "set"]}, pluck="user")
+    users = frappe.get_all("User Settings", filters={"username": ["is", "set"]}, pluck="user")
 
-	for user in users:
-		try:
-			connection = frappe.get_doc("User Settings", {"user": user}).connection
-			if not connection:
-				continue
+    for user in users:
+        try:
+            connection = frappe.get_doc("User Settings", {"user": user}).connection
+            if not connection:
+                continue
 
-			accounts = connection.accounts
-			sync_jmap_accounts(user, accounts)
-			backfill_identity_fields(accounts)
-			frappe.db.commit()
-		except Exception:
-			frappe.db.rollback()
-			log_mail_error("JMAP Account Sync Error", f"Failed to sync JMAP accounts for user {user}")
+            accounts = connection.accounts
+            sync_jmap_accounts(user, accounts)
+            backfill_identity_fields(accounts)
+            frappe.db.commit()
+        except Exception:
+            frappe.db.rollback()
+            log_mail_error("JMAP Account Sync Error", f"Failed to sync JMAP accounts for user {user}")
 
 
 def backfill_identity_fields(accounts: dict[str, dict]) -> None:
-	"""Populate the session-derived identity fields on existing JMAP Account docs.
+    """Populate the session-derived identity fields on existing JMAP Account docs.
 
-	sync_jmap_accounts only sets these when it inserts a new doc, so pre-existing (renamed)
-	docs need them filled in here. Configured values are left untouched.
-	"""
+    sync_jmap_accounts only sets these when it inserts a new doc, so pre-existing (renamed)
+    docs need them filled in here. Configured values are left untouched.
+    """
 
-	for account_id, details in accounts.items():
-		if not frappe.db.exists("JMAP Account", account_id):
-			continue
+    for account_id, details in accounts.items():
+        if not frappe.db.exists("JMAP Account", account_id):
+            continue
 
-		frappe.db.set_value(
-			"JMAP Account",
-			account_id,
-			{
-				"account_id": account_id,
-				"_name": details["name"],
-				"is_personal": details["isPersonal"],
-				"is_readonly": details["isReadOnly"],
-			},
-			update_modified=False,
-		)
+        frappe.db.set_value(
+            "JMAP Account",
+            account_id,
+            {
+                "account_id": account_id,
+                "_name": details["name"],
+                "is_personal": details["isPersonal"],
+                "is_readonly": details["isReadOnly"],
+            },
+            update_modified=False,
+        )

--- a/suite/mail/stalwart/__init__.py
+++ b/suite/mail/stalwart/__init__.py
@@ -7,16 +7,16 @@ from frappe.utils.caching import redis_cache
 
 from suite.mail.doctype.user_account.user_account import get_user_personal_jmap_account
 from suite.mail.stalwart.account import (
-	DEFAULT_LOCALE,
-	Account,
-	AccountService,
-	Credential,
-	CustomRoles,
-	EmailAlias,
-	PasswordCredential,
-	RoleType,
-	StorageQuota,
-	UserRoles,
+    DEFAULT_LOCALE,
+    Account,
+    AccountService,
+    Credential,
+    CustomRoles,
+    EmailAlias,
+    PasswordCredential,
+    RoleType,
+    StorageQuota,
+    UserRoles,
 )
 from suite.mail.stalwart.actions import Action, ActionService
 from suite.mail.stalwart.app_password import AppPassword, AppPasswordService
@@ -28,41 +28,41 @@ from suite.mail.stalwart.mailing_list import MailingList, MailingListService
 from suite.mail.stalwart.oauth import OAuthClient, OAuthClientService
 from suite.mail.stalwart.queue import QueuedMessageService
 from suite.mail.stalwart.reports import (
-	ArfExternalReportService,
-	DmarcExternalReportService,
-	DmarcInternalReportService,
-	TlsExternalReportService,
-	TlsInternalReportService,
+    ArfExternalReportService,
+    DmarcExternalReportService,
+    DmarcInternalReportService,
+    TlsExternalReportService,
+    TlsInternalReportService,
 )
 from suite.mail.stalwart.role import Role, RoleService
 from suite.mail.stalwart.service import ManagementService
 from suite.utils.dt import utcnow
 
 __all__ = [
-	"Account",
-	"AccountService",
-	"Action",
-	"ActionService",
-	"AppPassword",
-	"AppPasswordService",
-	"ArfExternalReportService",
-	"DmarcExternalReportService",
-	"DmarcInternalReportService",
-	"Domain",
-	"DomainService",
-	"Group",
-	"GroupService",
-	"LogService",
-	"MailingList",
-	"MailingListService",
-	"ManagementService",
-	"OAuthClient",
-	"OAuthClientService",
-	"QueuedMessageService",
-	"Role",
-	"RoleService",
-	"TlsExternalReportService",
-	"TlsInternalReportService",
+    "Account",
+    "AccountService",
+    "Action",
+    "ActionService",
+    "AppPassword",
+    "AppPasswordService",
+    "ArfExternalReportService",
+    "DmarcExternalReportService",
+    "DmarcInternalReportService",
+    "Domain",
+    "DomainService",
+    "Group",
+    "GroupService",
+    "LogService",
+    "MailingList",
+    "MailingListService",
+    "ManagementService",
+    "OAuthClient",
+    "OAuthClientService",
+    "QueuedMessageService",
+    "Role",
+    "RoleService",
+    "TlsExternalReportService",
+    "TlsInternalReportService",
 ]
 
 
@@ -70,90 +70,90 @@ __all__ = [
 
 
 def get_account_service() -> AccountService:
-	"""Returns an AccountService bound to the admin management connection."""
+    """Returns an AccountService bound to the admin management connection."""
 
-	return AccountService(get_management_connection())
+    return AccountService(get_management_connection())
 
 
 def get_group_service() -> GroupService:
-	"""Returns a GroupService bound to the admin management connection."""
+    """Returns a GroupService bound to the admin management connection."""
 
-	return GroupService(get_management_connection())
+    return GroupService(get_management_connection())
 
 
 def get_domain_service() -> DomainService:
-	"""Returns a DomainService bound to the admin management connection."""
+    """Returns a DomainService bound to the admin management connection."""
 
-	return DomainService(get_management_connection())
+    return DomainService(get_management_connection())
 
 
 def get_dkim_signature_service() -> DkimSignatureService:
-	"""Returns a DkimSignatureService bound to the admin management connection."""
+    """Returns a DkimSignatureService bound to the admin management connection."""
 
-	return DkimSignatureService(get_management_connection())
+    return DkimSignatureService(get_management_connection())
 
 
 def get_role_service() -> RoleService:
-	"""Returns a RoleService bound to the admin management connection."""
+    """Returns a RoleService bound to the admin management connection."""
 
-	return RoleService(get_management_connection())
+    return RoleService(get_management_connection())
 
 
 def get_mailing_list_service() -> MailingListService:
-	"""Returns a MailingListService bound to the admin management connection."""
+    """Returns a MailingListService bound to the admin management connection."""
 
-	return MailingListService(get_management_connection())
+    return MailingListService(get_management_connection())
 
 
 def get_oauth_client_service() -> OAuthClientService:
-	"""Returns an OAuthClientService bound to the admin management connection."""
+    """Returns an OAuthClientService bound to the admin management connection."""
 
-	return OAuthClientService(get_management_connection())
+    return OAuthClientService(get_management_connection())
 
 
 def get_app_password_service(account: str) -> AppPasswordService:
-	"""App passwords are account-scoped, so the returned service authenticates as ``account``."""
+    """App passwords are account-scoped, so the returned service authenticates as ``account``."""
 
-	return AppPasswordService(get_account_management_connection(account))
+    return AppPasswordService(get_account_management_connection(account))
 
 
 def get_queued_message_service() -> QueuedMessageService:
-	"""Returns a QueuedMessageService bound to the admin management connection."""
+    """Returns a QueuedMessageService bound to the admin management connection."""
 
-	return QueuedMessageService(get_management_connection())
+    return QueuedMessageService(get_management_connection())
 
 
 def get_log_service() -> LogService:
-	"""Returns a LogService bound to the admin management connection."""
+    """Returns a LogService bound to the admin management connection."""
 
-	return LogService(get_management_connection())
+    return LogService(get_management_connection())
 
 
 def get_action_service() -> ActionService:
-	"""Returns an ActionService bound to the admin management connection."""
+    """Returns an ActionService bound to the admin management connection."""
 
-	return ActionService(get_management_connection())
+    return ActionService(get_management_connection())
 
 
 # Report kinds keyed by ``(kind, direction)`` → service factory. ``direction`` is ``inbound`` for
 # reports received from other servers and ``outbound`` for reports Stalwart generates and sends.
 _REPORT_SERVICES = {
-	("dmarc", "inbound"): DmarcExternalReportService,
-	("dmarc", "outbound"): DmarcInternalReportService,
-	("tls", "inbound"): TlsExternalReportService,
-	("tls", "outbound"): TlsInternalReportService,
-	("arf", "inbound"): ArfExternalReportService,
+    ("dmarc", "inbound"): DmarcExternalReportService,
+    ("dmarc", "outbound"): DmarcInternalReportService,
+    ("tls", "inbound"): TlsExternalReportService,
+    ("tls", "outbound"): TlsInternalReportService,
+    ("arf", "inbound"): ArfExternalReportService,
 }
 
 
 def get_report_service(kind: str, direction: str) -> ManagementService:
-	"""Returns the report service for ``(kind, direction)``, or throws if the pair is unsupported."""
+    """Returns the report service for ``(kind, direction)``, or throws if the pair is unsupported."""
 
-	service = _REPORT_SERVICES.get((kind, direction))
-	if not service:
-		frappe.throw(_("Unsupported report type: {0} {1}").format(kind, direction))
+    service = _REPORT_SERVICES.get((kind, direction))
+    if not service:
+        frappe.throw(_("Unsupported report type: {0} {1}").format(kind, direction))
 
-	return service(get_management_connection())
+    return service(get_management_connection())
 
 
 # --- cached lookups + resolvers --------------------------------------------
@@ -161,291 +161,291 @@ def get_report_service(kind: str, direction: str) -> ManagementService:
 
 @redis_cache(ttl=60)
 def get_domains() -> list[dict]:
-	"""Returns all domains on the server (cached briefly)."""
+    """Returns all domains on the server (cached briefly)."""
 
-	return get_domain_service().get_all(
-		properties=["id", "name", "description", "isEnabled", "createdAt", "dnsZoneFile"]
-	)
+    return get_domain_service().get_all(
+        properties=["id", "name", "description", "isEnabled", "createdAt", "dnsZoneFile"]
+    )
 
 
 @redis_cache(ttl=3600)
 def get_permissions() -> list[dict]:
-	"""Returns all assignable permissions as ``{value, label}`` from the Stalwart server schema.
+    """Returns all assignable permissions as ``{value, label}`` from the Stalwart server schema.
 
-	The management API only carries raw permission keys; the server's schema endpoint provides the
-	human-readable labels (version-accurate), so we read them from there.
-	"""
+    The management API only carries raw permission keys; the server's schema endpoint provides the
+    human-readable labels (version-accurate), so we read them from there.
+    """
 
-	from suite.mail.utils import get_config
+    from suite.mail.utils import get_config
 
-	schema = get_management_connection().request(
-		method="GET", url=urljoin(get_config("server_url"), "/api/schema"), return_json=True
-	)
-	permissions = (schema.get("enums") or {}).get("Permission") or []
-	return [{"value": p["name"], "label": p.get("label") or p["name"]} for p in permissions]
+    schema = get_management_connection().request(
+        method="GET", url=urljoin(get_config("server_url"), "/api/schema"), return_json=True
+    )
+    permissions = (schema.get("enums") or {}).get("Permission") or []
+    return [{"value": p["name"], "label": p.get("label") or p["name"]} for p in permissions]
 
 
 @redis_cache(ttl=3600)
 def get_action_types() -> list[dict]:
-	"""Returns the executable server actions as ``{value, label, schema_name, options}`` from the schema.
+    """Returns the executable server actions as ``{value, label, schema_name, options}`` from the schema.
 
-	``schema_name`` is set only for actions that take extra input (e.g. DMARC troubleshooting and
-	spam classification); parameterless actions leave it ``None``. ``options`` holds the choices for
-	each enum input of that schema, so a select can be rendered without restating the server's enums —
-	which matters because the server is the only authority on the exact accepted values.
-	"""
+    ``schema_name`` is set only for actions that take extra input (e.g. DMARC troubleshooting and
+    spam classification); parameterless actions leave it ``None``. ``options`` holds the choices for
+    each enum input of that schema, so a select can be rendered without restating the server's enums —
+    which matters because the server is the only authority on the exact accepted values.
+    """
 
-	from suite.mail.utils import get_config
+    from suite.mail.utils import get_config
 
-	schema = get_management_connection().request(
-		method="GET", url=urljoin(get_config("server_url"), "/api/schema"), return_json=True
-	)
-	enums = schema.get("enums") or {}
-	fields = schema.get("fields") or {}
+    schema = get_management_connection().request(
+        method="GET", url=urljoin(get_config("server_url"), "/api/schema"), return_json=True
+    )
+    enums = schema.get("enums") or {}
+    fields = schema.get("fields") or {}
 
-	def choice(variant: dict) -> dict:
-		# A few enum variants ship with an empty label and the description folded into the name
-		# ("bit8Mime - 8-bit MIME message content"); the name is still the only accepted value.
-		name = variant["name"]
-		label = variant.get("label") or (name.split(" - ", 1)[1] if " - " in name else name)
-		return {"value": name, "label": label}
+    def choice(variant: dict) -> dict:
+        # A few enum variants ship with an empty label and the description folded into the name
+        # ("bit8Mime - 8-bit MIME message content"); the name is still the only accepted value.
+        name = variant["name"]
+        label = variant.get("label") or (name.split(" - ", 1)[1] if " - " in name else name)
+        return {"value": name, "label": label}
 
-	def enum_options(schema_name: str | None) -> dict:
-		properties = (fields.get(schema_name) or {}).get("properties") or {}
-		options = {}
-		for name, spec in properties.items():
-			type = spec.get("type") or {}
-			if spec.get("update") == "serverSet" or type.get("type") != "enum":
-				continue
-			options[name] = [choice(v) for v in enums.get(type.get("enumName")) or []]
-		return options
+    def enum_options(schema_name: str | None) -> dict:
+        properties = (fields.get(schema_name) or {}).get("properties") or {}
+        options = {}
+        for name, spec in properties.items():
+            type = spec.get("type") or {}
+            if spec.get("update") == "serverSet" or type.get("type") != "enum":
+                continue
+            options[name] = [choice(v) for v in enums.get(type.get("enumName")) or []]
+        return options
 
-	variants = (schema.get("schemas") or {}).get("x:Action", {}).get("variants") or []
-	return [
-		{
-			"value": v["name"],
-			"label": v.get("label") or v["name"],
-			"schema_name": v.get("schemaName"),
-			"options": enum_options(v.get("schemaName")),
-		}
-		for v in variants
-	]
+    variants = (schema.get("schemas") or {}).get("x:Action", {}).get("variants") or []
+    return [
+        {
+            "value": v["name"],
+            "label": v.get("label") or v["name"],
+            "schema_name": v.get("schemaName"),
+            "options": enum_options(v.get("schemaName")),
+        }
+        for v in variants
+    ]
 
 
 @redis_cache(ttl=3600)
 def get_account_metadata() -> dict:
-	"""Returns the locale and time zone choices for an account, each as ``{value, label}``.
+    """Returns the locale and time zone choices for an account, each as ``{value, label}``.
 
-	The locale label leads with the code so it stays scannable, and keeps the schema's description
-	after it because the picker matches on the label — which is what makes searching by language
-	rather than by code work.
-	"""
+    The locale label leads with the code so it stays scannable, and keeps the schema's description
+    after it because the picker matches on the label — which is what makes searching by language
+    rather than by code work.
+    """
 
-	from suite.mail.utils import get_config
+    from suite.mail.utils import get_config
 
-	schema = get_management_connection().request(
-		method="GET", url=urljoin(get_config("server_url"), "/api/schema"), return_json=True
-	)
-	enums = schema.get("enums") or {}
-	return {
-		"locales": [
-			{"value": v["name"], "label": f"{v['name']} · {v['label']}" if v.get("label") else v["name"]}
-			for v in enums.get("Locale") or []
-		],
-		# The time zone label is only the id with its underscores spaced out, so the id itself reads
-		# better and matches what the member and group pages show.
-		"time_zones": [{"value": v["name"], "label": v["name"]} for v in enums.get("TimeZone") or []],
-	}
+    schema = get_management_connection().request(
+        method="GET", url=urljoin(get_config("server_url"), "/api/schema"), return_json=True
+    )
+    enums = schema.get("enums") or {}
+    return {
+        "locales": [
+            {"value": v["name"], "label": f"{v['name']} · {v['label']}" if v.get("label") else v["name"]}
+            for v in enums.get("Locale") or []
+        ],
+        # The time zone label is only the id with its underscores spaced out, so the id itself reads
+        # better and matches what the member and group pages show.
+        "time_zones": [{"value": v["name"], "label": v["name"]} for v in enums.get("TimeZone") or []],
+    }
 
 
 @redis_cache(ttl=3600)
 def get_log_labels() -> dict:
-	"""Returns the display labels for log entries as ``{"events": {...}, "levels": {...}}``.
+    """Returns the display labels for log entries as ``{"events": {...}, "levels": {...}}``.
 
-	Log entries carry raw identifiers (``smtp.dmarc-fail``, ``warn``); the schema's ``EventType`` and
-	``TracingLevel`` enums hold the human labels for them, so they stay version-accurate rather than
-	being duplicated here.
-	"""
+    Log entries carry raw identifiers (``smtp.dmarc-fail``, ``warn``); the schema's ``EventType`` and
+    ``TracingLevel`` enums hold the human labels for them, so they stay version-accurate rather than
+    being duplicated here.
+    """
 
-	from suite.mail.utils import get_config
+    from suite.mail.utils import get_config
 
-	schema = get_management_connection().request(
-		method="GET", url=urljoin(get_config("server_url"), "/api/schema"), return_json=True
-	)
+    schema = get_management_connection().request(
+        method="GET", url=urljoin(get_config("server_url"), "/api/schema"), return_json=True
+    )
 
-	def labels(items: list[dict]) -> dict:
-		return {i["name"]: i.get("label") or i["name"] for i in items}
+    def labels(items: list[dict]) -> dict:
+        return {i["name"]: i.get("label") or i["name"] for i in items}
 
-	enums = schema.get("enums") or {}
-	return {"events": labels(enums.get("EventType") or []), "levels": labels(enums.get("TracingLevel") or [])}
+    enums = schema.get("enums") or {}
+    return {"events": labels(enums.get("EventType") or []), "levels": labels(enums.get("TracingLevel") or [])}
 
 
 @redis_cache(ttl=3600)
 def get_queue_metadata() -> dict:
-	"""Returns the enum/variant option lists used to render and edit queued messages.
+    """Returns the enum/variant option lists used to render and edit queued messages.
 
-	All values come from the server schema so labels stay version-accurate: message flags, recipient
-	status types, delivery error types and expiry types (each as ``{value, label}``).
-	"""
+    All values come from the server schema so labels stay version-accurate: message flags, recipient
+    status types, delivery error types and expiry types (each as ``{value, label}``).
+    """
 
-	from suite.mail.utils import get_config
+    from suite.mail.utils import get_config
 
-	schema = get_management_connection().request(
-		method="GET", url=urljoin(get_config("server_url"), "/api/schema"), return_json=True
-	)
+    schema = get_management_connection().request(
+        method="GET", url=urljoin(get_config("server_url"), "/api/schema"), return_json=True
+    )
 
-	def options(items: list[dict]) -> list[dict]:
-		return [{"value": i["name"], "label": i.get("label") or i["name"]} for i in items]
+    def options(items: list[dict]) -> list[dict]:
+        return [{"value": i["name"], "label": i.get("label") or i["name"]} for i in items]
 
-	enums = schema.get("enums") or {}
-	schemas = schema.get("schemas") or {}
-	return {
-		"message_flags": options(enums.get("MessageFlag") or []),
-		"status_types": options((schemas.get("x:RecipientStatus") or {}).get("variants") or []),
-		"error_types": options(enums.get("DeliveryErrorType") or []),
-		"expiry_types": options((schemas.get("x:QueueExpiry") or {}).get("variants") or []),
-	}
+    enums = schema.get("enums") or {}
+    schemas = schema.get("schemas") or {}
+    return {
+        "message_flags": options(enums.get("MessageFlag") or []),
+        "status_types": options((schemas.get("x:RecipientStatus") or {}).get("variants") or []),
+        "error_types": options(enums.get("DeliveryErrorType") or []),
+        "expiry_types": options((schemas.get("x:QueueExpiry") or {}).get("variants") or []),
+    }
 
 
 @redis_cache(ttl=3600)
 def get_roles(description: str | None = None) -> list[dict]:
-	"""Returns roles on the server, optionally filtered by description (cached)."""
+    """Returns roles on the server, optionally filtered by description (cached)."""
 
-	filter = {"description": description} if description else None
-	return get_role_service().get_all(filter=filter, properties=["id", "description"])
+    filter = {"description": description} if description else None
+    return get_role_service().get_all(filter=filter, properties=["id", "description"])
 
 
 def resolve_domain_id(name: str, raise_exception: bool = True) -> str | None:
-	"""Resolves a domain name to its Stalwart id."""
+    """Resolves a domain name to its Stalwart id."""
 
-	domain = get_domain_service().get_by_name(name, raise_exception=raise_exception)
-	return domain["id"] if domain else None
+    domain = get_domain_service().get_by_name(name, raise_exception=raise_exception)
+    return domain["id"] if domain else None
 
 
 def resolve_role_ids(descriptions: list[str] | None) -> list[str]:
-	if not descriptions:
-		return []
+    if not descriptions:
+        return []
 
-	role_map = {r["description"]: r["id"] for r in get_roles()}
+    role_map = {r["description"]: r["id"] for r in get_roles()}
 
-	role_ids = []
-	for description in descriptions:
-		role_id = role_map.get(description)
-		if not role_id:
-			frappe.throw(_("Role {0} does not exist on the Stalwart server.").format(description))
+    role_ids = []
+    for description in descriptions:
+        role_id = role_map.get(description)
+        if not role_id:
+            frappe.throw(_("Role {0} does not exist on the Stalwart server.").format(description))
 
-		role_ids.append(role_id)
+        role_ids.append(role_id)
 
-	return role_ids
+    return role_ids
 
 
 def _resolve_alias(alias: str) -> tuple[str, str]:
-	"""Splits a full email address into its local-part and domain."""
+    """Splits a full email address into its local-part and domain."""
 
-	alias = (alias or "").strip()
-	name, _, domain = alias.partition("@")
-	if not name or not domain:
-		frappe.throw(_("Alias must be a complete email address: {0}").format(alias))
+    alias = (alias or "").strip()
+    name, _, domain = alias.partition("@")
+    if not name or not domain:
+        frappe.throw(_("Alias must be a complete email address: {0}").format(alias))
 
-	return name, domain
+    return name, domain
 
 
 # --- high-level conveniences used by hooks, doctypes and admin APIs --------
 
 
 def create_account(
-	name: str,
-	domain: str,
-	password: str | None = None,
-	description: str | None = None,
-	aliases: list[str] | None = None,
-	groups: list[str] | None = None,
-	roles: list[str] | None = None,
-	quota: int | None = None,
-	locale: str | None = None,
-	timezone: str | None = None,
+    name: str,
+    domain: str,
+    password: str | None = None,
+    description: str | None = None,
+    aliases: list[str] | None = None,
+    groups: list[str] | None = None,
+    roles: list[str] | None = None,
+    quota: int | None = None,
+    locale: str | None = None,
+    timezone: str | None = None,
 ) -> str:
-	"""Creates a user account, resolving domain/group/role names to ids."""
+    """Creates a user account, resolving domain/group/role names to ids."""
 
-	account_service = get_account_service()
-	domain_service = get_domain_service()
+    account_service = get_account_service()
+    domain_service = get_domain_service()
 
-	domain_id = domain_service.get_by_name(domain, raise_exception=True)["id"]
+    domain_id = domain_service.get_by_name(domain, raise_exception=True)["id"]
 
-	email_aliases = []
-	domain_ids = {domain: domain_id}
-	for alias in aliases or []:
-		if not alias:
-			continue
+    email_aliases = []
+    domain_ids = {domain: domain_id}
+    for alias in aliases or []:
+        if not alias:
+            continue
 
-		alias_name, alias_domain = _resolve_alias(alias)
-		if alias_domain not in domain_ids:
-			domain_ids[alias_domain] = domain_service.get_by_name(alias_domain, raise_exception=True)["id"]
+        alias_name, alias_domain = _resolve_alias(alias)
+        if alias_domain not in domain_ids:
+            domain_ids[alias_domain] = domain_service.get_by_name(alias_domain, raise_exception=True)["id"]
 
-		email_aliases.append(EmailAlias(name=alias_name, domain_id=domain_ids[alias_domain]))
+        email_aliases.append(EmailAlias(name=alias_name, domain_id=domain_ids[alias_domain]))
 
-	member_group_ids = [
-		account_service.get_by_name(group, raise_exception=True)["id"] for group in groups or [] if group
-	]
+    member_group_ids = [
+        account_service.get_by_name(group, raise_exception=True)["id"] for group in groups or [] if group
+    ]
 
-	role_ids = resolve_role_ids(roles)
-	user_roles = (
-		UserRoles(type=RoleType.CUSTOM, roles=CustomRoles(role_ids=role_ids))
-		if role_ids
-		else UserRoles(type=RoleType.USER)
-	)
+    role_ids = resolve_role_ids(roles)
+    user_roles = (
+        UserRoles(type=RoleType.CUSTOM, roles=CustomRoles(role_ids=role_ids))
+        if role_ids
+        else UserRoles(type=RoleType.USER)
+    )
 
-	account = Account(
-		name=name,
-		domain_id=domain_id,
-		credentials=[Credential(password=PasswordCredential(secret=password or random_string(12)))],
-		member_group_ids=member_group_ids or None,
-		roles=user_roles,
-		quotas=StorageQuota(max_disk_quota=quota) if quota is not None else StorageQuota(),
-		aliases=email_aliases or None,
-		description=description,
-		locale=locale or DEFAULT_LOCALE,
-		timezone=timezone,
-	)
+    account = Account(
+        name=name,
+        domain_id=domain_id,
+        credentials=[Credential(password=PasswordCredential(secret=password or random_string(12)))],
+        member_group_ids=member_group_ids or None,
+        roles=user_roles,
+        quotas=StorageQuota(max_disk_quota=quota) if quota is not None else StorageQuota(),
+        aliases=email_aliases or None,
+        description=description,
+        locale=locale or DEFAULT_LOCALE,
+        timezone=timezone,
+    )
 
-	return account_service.create(account)
+    return account_service.create(account)
 
 
 def create_app_password(account: str, description: str | None = None) -> str:
-	"""Creates an app password for ``account`` and returns the generated secret."""
+    """Creates an app password for ``account`` and returns the generated secret."""
 
-	description = description or f"App Password for {frappe.local.site} - {utcnow()}"
-	return get_app_password_service(account).create(AppPassword(description=description))
+    description = description or f"App Password for {frappe.local.site} - {utcnow()}"
+    return get_app_password_service(account).create(AppPassword(description=description))
 
 
 def update_password(user: str | None = None, new_password: str | None = None) -> None:
-	"""Sets the password of the user's personal Stalwart account (no-op if they have none)."""
+    """Sets the password of the user's personal Stalwart account (no-op if they have none)."""
 
-	if not user or not new_password:
-		frappe.throw(_("User and new password are required to update the Stalwart password."))
+    if not user or not new_password:
+        frappe.throw(_("User and new password are required to update the Stalwart password."))
 
-	if account := get_user_personal_jmap_account(user, raise_exception=False):
-		get_account_service().set_password(account, new_password)
+    if account := get_user_personal_jmap_account(user, raise_exception=False):
+        get_account_service().set_password(account, new_password)
 
 
 def delete_account(user: str) -> None:
-	"""Deletes the user's personal Stalwart account (no-op if they have none)."""
+    """Deletes the user's personal Stalwart account (no-op if they have none)."""
 
-	if account := get_user_personal_jmap_account(user, raise_exception=False):
-		get_account_service().delete(account)
+    if account := get_user_personal_jmap_account(user, raise_exception=False):
+        get_account_service().delete(account)
 
 
 def add_account_role(user: str, role: str) -> None:
-	"""Applies a role (by description) to the user's personal account (no-op if they have none)."""
+    """Applies a role (by description) to the user's personal account (no-op if they have none)."""
 
-	if account := get_user_personal_jmap_account(user, raise_exception=False):
-		role_id = get_role_service().get_by_description(role, raise_exception=True)["id"]
-		get_account_service().add_roles(account, [role_id])
+    if account := get_user_personal_jmap_account(user, raise_exception=False):
+        role_id = get_role_service().get_by_description(role, raise_exception=True)["id"]
+        get_account_service().add_roles(account, [role_id])
 
 
 def remove_account_role(user: str, role: str) -> None:
-	"""Removes a role (by description) from the user's personal account (no-op if they have none)."""
+    """Removes a role (by description) from the user's personal account (no-op if they have none)."""
 
-	if account := get_user_personal_jmap_account(user, raise_exception=False):
-		role_id = get_role_service().get_by_description(role, raise_exception=True)["id"]
-		get_account_service().remove_roles(account, [role_id])
+    if account := get_user_personal_jmap_account(user, raise_exception=False):
+        role_id = get_role_service().get_by_description(role, raise_exception=True)["id"]
+        get_account_service().remove_roles(account, [role_id])

--- a/suite/mail/stalwart/account.py
+++ b/suite/mail/stalwart/account.py
@@ -27,7 +27,7 @@ def _default_password_credential() -> PasswordCredential:
     return PasswordCredential(secret=random_string(20))
 
 
-def _default_credentials() -> list["Credential"]:
+def _default_credentials() -> list[Credential]:
     """Returns the default credential list (a single random password)."""
 
     return [Credential()]

--- a/suite/mail/stalwart/account.py
+++ b/suite/mail/stalwart/account.py
@@ -13,329 +13,329 @@ DEFAULT_LOCALE = "en_US"
 
 
 class CredentialType(Enum):
-	PASSWORD = "Password"
+    PASSWORD = "Password"
 
 
 @dataclass
 class PasswordCredential:
-	secret: str
+    secret: str
 
 
 def _default_password_credential() -> PasswordCredential:
-	"""Returns a password credential seeded with a random secret."""
+    """Returns a password credential seeded with a random secret."""
 
-	return PasswordCredential(secret=random_string(20))
+    return PasswordCredential(secret=random_string(20))
 
 
 def _default_credentials() -> list["Credential"]:
-	"""Returns the default credential list (a single random password)."""
+    """Returns the default credential list (a single random password)."""
 
-	return [Credential()]
+    return [Credential()]
 
 
 @dataclass
 class Credential:
-	type: CredentialType = CredentialType.PASSWORD
-	password: PasswordCredential = field(default_factory=_default_password_credential)
+    type: CredentialType = CredentialType.PASSWORD
+    password: PasswordCredential = field(default_factory=_default_password_credential)
 
-	def to_dict(self) -> dict:
-		"""Serializes the credential to the JMAP wire format."""
+    def to_dict(self) -> dict:
+        """Serializes the credential to the JMAP wire format."""
 
-		if self.type == CredentialType.PASSWORD:
-			return {"@type": self.type.value, "secret": self.password.secret}
+        if self.type == CredentialType.PASSWORD:
+            return {"@type": self.type.value, "secret": self.password.secret}
 
-		raise ValueError(f"Unsupported credential type: {self.type}")
+        raise ValueError(f"Unsupported credential type: {self.type}")
 
 
 class RoleType(Enum):
-	USER = "User"
-	ADMIN = "Admin"
-	CUSTOM = "Custom"
+    USER = "User"
+    ADMIN = "Admin"
+    CUSTOM = "Custom"
 
 
 @dataclass
 class CustomRoles:
-	role_ids: list[str] = field(default_factory=list)
+    role_ids: list[str] = field(default_factory=list)
 
 
 @dataclass
 class UserRoles:
-	type: RoleType = RoleType.USER
-	roles: CustomRoles | None = None
+    type: RoleType = RoleType.USER
+    roles: CustomRoles | None = None
 
-	def __post_init__(self) -> None:
-		"""Validates that role ids are present only for the custom role type."""
+    def __post_init__(self) -> None:
+        """Validates that role ids are present only for the custom role type."""
 
-		if self.type == RoleType.CUSTOM and not self.roles:
-			raise ValueError("Custom role type requires roles to be defined.")
+        if self.type == RoleType.CUSTOM and not self.roles:
+            raise ValueError("Custom role type requires roles to be defined.")
 
-		if self.type != RoleType.CUSTOM and self.roles:
-			raise ValueError("Only custom role type can have roles defined.")
+        if self.type != RoleType.CUSTOM and self.roles:
+            raise ValueError("Only custom role type can have roles defined.")
 
-	def to_dict(self) -> dict:
-		"""Serializes the roles tagged union to the JMAP wire format."""
+    def to_dict(self) -> dict:
+        """Serializes the roles tagged union to the JMAP wire format."""
 
-		if self.type == RoleType.CUSTOM:
-			return {"@type": self.type.value, "roleIds": {role_id: True for role_id in self.roles.role_ids}}
+        if self.type == RoleType.CUSTOM:
+            return {"@type": self.type.value, "roleIds": {role_id: True for role_id in self.roles.role_ids}}
 
-		return {"@type": self.type.value}
+        return {"@type": self.type.value}
 
 
 class PermissionType(Enum):
-	INHERIT = "Inherit"
-	MERGE = "Merge"
-	REPLACE = "Replace"
+    INHERIT = "Inherit"
+    MERGE = "Merge"
+    REPLACE = "Replace"
 
 
 @dataclass
 class PermissionsList:
-	enabled_permissions: list[str] | None = None
-	disabled_permissions: list[str] | None = None
+    enabled_permissions: list[str] | None = None
+    disabled_permissions: list[str] | None = None
 
 
 @dataclass
 class Permissions:
-	type: PermissionType = PermissionType.INHERIT
-	permissions: PermissionsList | None = None
+    type: PermissionType = PermissionType.INHERIT
+    permissions: PermissionsList | None = None
 
-	def __post_init__(self) -> None:
-		"""Validates that a permission list is present unless the type is Inherit."""
+    def __post_init__(self) -> None:
+        """Validates that a permission list is present unless the type is Inherit."""
 
-		has_permissions = self.permissions and (
-			self.permissions.enabled_permissions or self.permissions.disabled_permissions
-		)
+        has_permissions = self.permissions and (
+            self.permissions.enabled_permissions or self.permissions.disabled_permissions
+        )
 
-		if self.type == PermissionType.INHERIT and has_permissions:
-			raise ValueError("Inherit permission type cannot define enabled or disabled permissions.")
+        if self.type == PermissionType.INHERIT and has_permissions:
+            raise ValueError("Inherit permission type cannot define enabled or disabled permissions.")
 
-		if self.type != PermissionType.INHERIT and not has_permissions:
-			raise ValueError("Merge or Replace permission type requires enabled or disabled permissions.")
+        if self.type != PermissionType.INHERIT and not has_permissions:
+            raise ValueError("Merge or Replace permission type requires enabled or disabled permissions.")
 
-	def to_dict(self) -> dict:
-		"""Serializes the permissions tagged union to the JMAP wire format."""
+    def to_dict(self) -> dict:
+        """Serializes the permissions tagged union to the JMAP wire format."""
 
-		if self.type == PermissionType.INHERIT:
-			return {"@type": self.type.value}
+        if self.type == PermissionType.INHERIT:
+            return {"@type": self.type.value}
 
-		return {
-			"@type": self.type.value,
-			"enabledPermissions": {perm: True for perm in self.permissions.enabled_permissions}
-			if self.permissions and self.permissions.enabled_permissions
-			else {},
-			"disabledPermissions": {perm: True for perm in self.permissions.disabled_permissions}
-			if self.permissions and self.permissions.disabled_permissions
-			else {},
-		}
+        return {
+            "@type": self.type.value,
+            "enabledPermissions": {perm: True for perm in self.permissions.enabled_permissions}
+            if self.permissions and self.permissions.enabled_permissions
+            else {},
+            "disabledPermissions": {perm: True for perm in self.permissions.disabled_permissions}
+            if self.permissions and self.permissions.disabled_permissions
+            else {},
+        }
 
 
 @dataclass
 class StorageQuota:
-	max_emails: int | None = None
-	max_mailboxes: int | None = None
-	max_email_submissions: int | None = None
-	max_email_identities: int | None = None
-	max_participant_identities: int | None = None
-	max_sieve_scripts: int | None = None
-	max_push_subscriptions: int | None = None
-	max_calendars: int | None = None
-	max_calendar_events: int | None = None
-	max_calendar_event_notifications: int | None = None
-	max_address_books: int | None = None
-	max_contact_cards: int | None = None
-	max_files: int | None = None
-	max_folders: int | None = None
-	max_masked_addresses: int | None = None
-	max_app_passwords: int | None = None
-	max_api_keys: int | None = None
-	max_public_keys: int | None = None
-	max_disk_quota: int | None = None
+    max_emails: int | None = None
+    max_mailboxes: int | None = None
+    max_email_submissions: int | None = None
+    max_email_identities: int | None = None
+    max_participant_identities: int | None = None
+    max_sieve_scripts: int | None = None
+    max_push_subscriptions: int | None = None
+    max_calendars: int | None = None
+    max_calendar_events: int | None = None
+    max_calendar_event_notifications: int | None = None
+    max_address_books: int | None = None
+    max_contact_cards: int | None = None
+    max_files: int | None = None
+    max_folders: int | None = None
+    max_masked_addresses: int | None = None
+    max_app_passwords: int | None = None
+    max_api_keys: int | None = None
+    max_public_keys: int | None = None
+    max_disk_quota: int | None = None
 
-	def __post_init__(self) -> None:
-		"""Rejects any negative quota value."""
+    def __post_init__(self) -> None:
+        """Rejects any negative quota value."""
 
-		for field_name, value in self.__dict__.items():
-			if value is not None and value < 0:
-				raise ValueError(f"{field_name} cannot be negative")
+        for field_name, value in self.__dict__.items():
+            if value is not None and value < 0:
+                raise ValueError(f"{field_name} cannot be negative")
 
-	def to_dict(self) -> dict:
-		"""Serializes the set quotas to a camelCase JMAP map, omitting unset limits."""
+    def to_dict(self) -> dict:
+        """Serializes the set quotas to a camelCase JMAP map, omitting unset limits."""
 
-		return {snake_to_camel(name): value for name, value in self.__dict__.items() if value is not None}
+        return {snake_to_camel(name): value for name, value in self.__dict__.items() if value is not None}
 
 
 @dataclass
 class EmailAlias:
-	name: str
-	domain_id: str
-	enabled: bool = True
-	description: str | None = None
+    name: str
+    domain_id: str
+    enabled: bool = True
+    description: str | None = None
 
-	def to_dict(self) -> dict:
-		"""Serializes the alias to the JMAP wire format."""
+    def to_dict(self) -> dict:
+        """Serializes the alias to the JMAP wire format."""
 
-		return {
-			"name": self.name,
-			"domainId": self.domain_id,
-			"enabled": self.enabled,
-			"description": self.description,
-		}
+        return {
+            "name": self.name,
+            "domainId": self.domain_id,
+            "enabled": self.enabled,
+            "description": self.description,
+        }
 
 
 class EncryptionType(Enum):
-	DISABLED = "Disabled"
-	AES128 = "Aes128"
-	AES256 = "Aes256"
+    DISABLED = "Disabled"
+    AES128 = "Aes128"
+    AES256 = "Aes256"
 
 
 @dataclass
 class EncryptionSettings:
-	public_key_id: str
-	encrypt_on_append: bool = False
-	allow_spam_training: bool = False
+    public_key_id: str
+    encrypt_on_append: bool = False
+    allow_spam_training: bool = False
 
-	def to_dict(self) -> dict:
-		"""Serializes the encryption settings to the JMAP wire format."""
+    def to_dict(self) -> dict:
+        """Serializes the encryption settings to the JMAP wire format."""
 
-		return {
-			"publicKey": self.public_key_id,
-			"encryptOnAppend": self.encrypt_on_append,
-			"allowSpamTraining": self.allow_spam_training,
-		}
+        return {
+            "publicKey": self.public_key_id,
+            "encryptOnAppend": self.encrypt_on_append,
+            "allowSpamTraining": self.allow_spam_training,
+        }
 
 
 @dataclass
 class EncryptionAtRest:
-	type: EncryptionType = EncryptionType.DISABLED
-	settings: EncryptionSettings | None = None
+    type: EncryptionType = EncryptionType.DISABLED
+    settings: EncryptionSettings | None = None
 
-	def __post_init__(self) -> None:
-		"""Validates that settings are present only when encryption is enabled."""
+    def __post_init__(self) -> None:
+        """Validates that settings are present only when encryption is enabled."""
 
-		if self.type != EncryptionType.DISABLED and not self.settings:
-			raise ValueError("Encryption settings must be provided when encryption is enabled.")
+        if self.type != EncryptionType.DISABLED and not self.settings:
+            raise ValueError("Encryption settings must be provided when encryption is enabled.")
 
-		if self.type == EncryptionType.DISABLED and self.settings:
-			raise ValueError("Encryption settings should not be provided when encryption is disabled.")
+        if self.type == EncryptionType.DISABLED and self.settings:
+            raise ValueError("Encryption settings should not be provided when encryption is disabled.")
 
-	def to_dict(self) -> dict:
-		"""Serializes the encryption-at-rest tagged union to the JMAP wire format."""
+    def to_dict(self) -> dict:
+        """Serializes the encryption-at-rest tagged union to the JMAP wire format."""
 
-		if self.type == EncryptionType.DISABLED:
-			return {"@type": self.type.value}
+        if self.type == EncryptionType.DISABLED:
+            return {"@type": self.type.value}
 
-		return {"@type": self.type.value, "settings": self.settings.to_dict()}
+        return {"@type": self.type.value, "settings": self.settings.to_dict()}
 
 
 @dataclass
 class Account:
-	name: str
-	domain_id: str
-	credentials: list[Credential] = field(default_factory=_default_credentials)
-	member_group_ids: list[str] | None = None
-	roles: UserRoles = field(default_factory=UserRoles)
-	permissions: Permissions = field(default_factory=Permissions)
-	quotas: StorageQuota = field(default_factory=StorageQuota)
-	aliases: list[EmailAlias] | None = None
-	description: str | None = None
-	locale: str = DEFAULT_LOCALE
-	timezone: str | None = None
-	encryption_at_rest: EncryptionAtRest = field(default_factory=EncryptionAtRest)
+    name: str
+    domain_id: str
+    credentials: list[Credential] = field(default_factory=_default_credentials)
+    member_group_ids: list[str] | None = None
+    roles: UserRoles = field(default_factory=UserRoles)
+    permissions: Permissions = field(default_factory=Permissions)
+    quotas: StorageQuota = field(default_factory=StorageQuota)
+    aliases: list[EmailAlias] | None = None
+    description: str | None = None
+    locale: str = DEFAULT_LOCALE
+    timezone: str | None = None
+    encryption_at_rest: EncryptionAtRest = field(default_factory=EncryptionAtRest)
 
-	def to_dict(self) -> dict:
-		"""Serializes the account to the JMAP wire format."""
+    def to_dict(self) -> dict:
+        """Serializes the account to the JMAP wire format."""
 
-		return {
-			"@type": "User",
-			"name": self.name,
-			"domainId": self.domain_id,
-			# credentials, memberGroupIds and aliases are id-keyed maps on the wire, not arrays.
-			"credentials": {f"{idx}": c.to_dict() for idx, c in enumerate(self.credentials)}
-			if self.credentials
-			else {},
-			"memberGroupIds": {group_id: True for group_id in self.member_group_ids}
-			if self.member_group_ids
-			else {},
-			"roles": self.roles.to_dict() if self.roles else {},
-			"permissions": self.permissions.to_dict() if self.permissions else {},
-			"quotas": self.quotas.to_dict() if self.quotas else {},
-			"aliases": {f"{idx}": a.to_dict() for idx, a in enumerate(self.aliases)} if self.aliases else {},
-			"description": self.description,
-			"locale": self.locale,
-			"timeZone": self.timezone,
-			"encryptionAtRest": self.encryption_at_rest.to_dict(),
-		}
+        return {
+            "@type": "User",
+            "name": self.name,
+            "domainId": self.domain_id,
+            # credentials, memberGroupIds and aliases are id-keyed maps on the wire, not arrays.
+            "credentials": {f"{idx}": c.to_dict() for idx, c in enumerate(self.credentials)}
+            if self.credentials
+            else {},
+            "memberGroupIds": {group_id: True for group_id in self.member_group_ids}
+            if self.member_group_ids
+            else {},
+            "roles": self.roles.to_dict() if self.roles else {},
+            "permissions": self.permissions.to_dict() if self.permissions else {},
+            "quotas": self.quotas.to_dict() if self.quotas else {},
+            "aliases": {f"{idx}": a.to_dict() for idx, a in enumerate(self.aliases)} if self.aliases else {},
+            "description": self.description,
+            "locale": self.locale,
+            "timeZone": self.timezone,
+            "encryptionAtRest": self.encryption_at_rest.to_dict(),
+        }
 
 
 class AccountService(ManagementService):
-	type = "Account"
-	default_properties = [
-		"@type",
-		"id",
-		"name",
-		"description",
-		"emailAddress",
-		"aliases",
-		"domainId",
-		"locale",
-		"memberGroupIds",
-		"quotas",
-		"roles",
-		"timeZone",
-		"usedDiskQuota",
-	]
+    type = "Account"
+    default_properties = [
+        "@type",
+        "id",
+        "name",
+        "description",
+        "emailAddress",
+        "aliases",
+        "domainId",
+        "locale",
+        "memberGroupIds",
+        "quotas",
+        "roles",
+        "timeZone",
+        "usedDiskQuota",
+    ]
 
-	def get_by_name(
-		self, name: str, properties: list[str] | None = None, raise_exception: bool = True
-	) -> dict | None:
-		"""Returns the account with the given name, or ``None`` (throws if ``raise_exception``)."""
+    def get_by_name(
+        self, name: str, properties: list[str] | None = None, raise_exception: bool = True
+    ) -> dict | None:
+        """Returns the account with the given name, or ``None`` (throws if ``raise_exception``)."""
 
-		account = self.find({"name": name}, properties=properties or ["id"])
-		if not account and raise_exception:
-			frappe.throw(_("Account {0} not found on the Stalwart server.").format(name))
+        account = self.find({"name": name}, properties=properties or ["id"])
+        if not account and raise_exception:
+            frappe.throw(_("Account {0} not found on the Stalwart server.").format(name))
 
-		return account
+        return account
 
-	def _current_role_ids(self, account_id: str) -> list[str]:
-		"""Returns the account's currently assigned custom role ids."""
+    def _current_role_ids(self, account_id: str) -> list[str]:
+        """Returns the account's currently assigned custom role ids."""
 
-		roles = (self.get(account_id, properties=["roles"]) or {}).get("roles") or {}
-		role_ids = roles.get("roleIds") or {}
-		return list(role_ids.keys() if isinstance(role_ids, dict) else role_ids)
+        roles = (self.get(account_id, properties=["roles"]) or {}).get("roles") or {}
+        role_ids = roles.get("roleIds") or {}
+        return list(role_ids.keys() if isinstance(role_ids, dict) else role_ids)
 
-	def _set_roles(self, account_id: str, role_ids: list[str]) -> None:
-		"""Replaces the account's roles with the given ids (empty reverts to the default user role)."""
+    def _set_roles(self, account_id: str, role_ids: list[str]) -> None:
+        """Replaces the account's roles with the given ids (empty reverts to the default user role)."""
 
-		# roles is a tagged union; its @type discriminator can't be patched via a sub-path, so the
-		# whole field is replaced.
-		if role_ids:
-			roles = UserRoles(type=RoleType.CUSTOM, roles=CustomRoles(role_ids=list(dict.fromkeys(role_ids))))
-		else:
-			roles = UserRoles(type=RoleType.USER)
+        # roles is a tagged union; its @type discriminator can't be patched via a sub-path, so the
+        # whole field is replaced.
+        if role_ids:
+            roles = UserRoles(type=RoleType.CUSTOM, roles=CustomRoles(role_ids=list(dict.fromkeys(role_ids))))
+        else:
+            roles = UserRoles(type=RoleType.USER)
 
-		self.update(account_id, {"roles": roles.to_dict()})
+        self.update(account_id, {"roles": roles.to_dict()})
 
-	def add_roles(self, account_id: str, role_ids: list[str]) -> None:
-		"""Adds role ids to the account, keeping any it already has."""
+    def add_roles(self, account_id: str, role_ids: list[str]) -> None:
+        """Adds role ids to the account, keeping any it already has."""
 
-		if role_ids:
-			self._set_roles(account_id, [*self._current_role_ids(account_id), *role_ids])
+        if role_ids:
+            self._set_roles(account_id, [*self._current_role_ids(account_id), *role_ids])
 
-	def remove_roles(self, account_id: str, role_ids: list[str]) -> None:
-		"""Removes the given role ids from the account."""
+    def remove_roles(self, account_id: str, role_ids: list[str]) -> None:
+        """Removes the given role ids from the account."""
 
-		if role_ids:
-			remove = set(role_ids)
-			self._set_roles(account_id, [r for r in self._current_role_ids(account_id) if r not in remove])
+        if role_ids:
+            remove = set(role_ids)
+            self._set_roles(account_id, [r for r in self._current_role_ids(account_id) if r not in remove])
 
-	def set_password(self, account_id: str, new_password: str) -> None:
-		"""Sets the account's primary password credential, leaving other credentials intact."""
+    def set_password(self, account_id: str, new_password: str) -> None:
+        """Sets the account's primary password credential, leaving other credentials intact."""
 
-		if not new_password:
-			frappe.throw(_("New password cannot be empty."))
+        if not new_password:
+            frappe.throw(_("New password cannot be empty."))
 
-		credentials = (self.get(account_id, properties=["credentials"]) or {}).get("credentials") or {}
-		row_id = next(
-			(idx for idx, c in credentials.items() if c.get("@type") == CredentialType.PASSWORD.value), "0"
-		)
+        credentials = (self.get(account_id, properties=["credentials"]) or {}).get("credentials") or {}
+        row_id = next(
+            (idx for idx, c in credentials.items() if c.get("@type") == CredentialType.PASSWORD.value), "0"
+        )
 
-		self.update(account_id, {f"credentials/{row_id}/secret": new_password})
+        self.update(account_id, {f"credentials/{row_id}/secret": new_password})

--- a/suite/mail/stalwart/actions.py
+++ b/suite/mail/stalwart/actions.py
@@ -2,33 +2,33 @@ from suite.mail.stalwart.service import ManagementService, Serializable
 
 
 class Action(Serializable):
-	"""A server management action, dispatched by its ``@type`` (see the ``ActionType`` schema enum).
+    """A server management action, dispatched by its ``@type`` (see the ``ActionType`` schema enum).
 
-	Most actions are parameterless (reloads, cache invalidation, queue pause/resume). A few carry
-	extra input, e.g. ``TroubleshootDmarc`` and ``ClassifySpam``; those extra fields are passed
-	through verbatim in ``params``.
-	"""
+    Most actions are parameterless (reloads, cache invalidation, queue pause/resume). A few carry
+    extra input, e.g. ``TroubleshootDmarc`` and ``ClassifySpam``; those extra fields are passed
+    through verbatim in ``params``.
+    """
 
-	def __init__(self, action_type: str, params: dict | None = None) -> None:
-		self.action_type = action_type
-		self.params = params or {}
+    def __init__(self, action_type: str, params: dict | None = None) -> None:
+        self.action_type = action_type
+        self.params = params or {}
 
-	def to_dict(self) -> dict:
-		"""Serializes the action to the JMAP wire format (``@type`` plus any parameters)."""
+    def to_dict(self) -> dict:
+        """Serializes the action to the JMAP wire format (``@type`` plus any parameters)."""
 
-		return {"@type": self.action_type, **self.params}
+        return {"@type": self.action_type, **self.params}
 
 
 class ActionService(ManagementService):
-	"""Executes server management actions (``x:Action``).
+    """Executes server management actions (``x:Action``).
 
-	Actions are not queryable objects; running one is a ``set``/create whose created object carries
-	any result (e.g. the DMARC troubleshooting outcome or the spam classification score).
-	"""
+    Actions are not queryable objects; running one is a ``set``/create whose created object carries
+    any result (e.g. the DMARC troubleshooting outcome or the spam classification score).
+    """
 
-	type = "Action"
+    type = "Action"
 
-	def run(self, action_type: str, params: dict | None = None) -> dict:
-		"""Executes ``action_type`` and returns the created action object, including any result."""
+    def run(self, action_type: str, params: dict | None = None) -> dict:
+        """Executes ``action_type`` and returns the created action object, including any result."""
 
-		return self._create(Action(action_type, params))
+        return self._create(Action(action_type, params))

--- a/suite/mail/stalwart/app_password.py
+++ b/suite/mail/stalwart/app_password.py
@@ -9,37 +9,37 @@ from suite.mail.stalwart.service import ManagementService
 
 @dataclass
 class AppPassword:
-	description: str
-	permissions: Permissions = field(default_factory=Permissions)
-	allowed_ips: list[str] | None = None
-	expires_at: str | None = None
+    description: str
+    permissions: Permissions = field(default_factory=Permissions)
+    allowed_ips: list[str] | None = None
+    expires_at: str | None = None
 
-	def to_dict(self) -> dict:
-		"""Serializes the app password to the JMAP wire format."""
+    def to_dict(self) -> dict:
+        """Serializes the app password to the JMAP wire format."""
 
-		payload = {"description": self.description, "permissions": self.permissions.to_dict()}
-		if self.allowed_ips:
-			payload["allowedIps"] = list(self.allowed_ips)
-		if self.expires_at:
-			payload["expiresAt"] = self.expires_at
+        payload = {"description": self.description, "permissions": self.permissions.to_dict()}
+        if self.allowed_ips:
+            payload["allowedIps"] = list(self.allowed_ips)
+        if self.expires_at:
+            payload["expiresAt"] = self.expires_at
 
-		return payload
+        return payload
 
 
 class AppPasswordService(ManagementService):
-	"""App Passwords are account-scoped, so this service needs a connection authenticated as the
-	target account (see ``get_app_password_service``)."""
+    """App Passwords are account-scoped, so this service needs a connection authenticated as the
+    target account (see ``get_app_password_service``)."""
 
-	type = "AppPassword"
+    type = "AppPassword"
 
-	def create(self, app_password: AppPassword) -> str:
-		"""Creates an app password and returns the generated secret.
+    def create(self, app_password: AppPassword) -> str:
+        """Creates an app password and returns the generated secret.
 
-		Returns the secret rather than the id because the server only exposes it at creation time.
-		"""
+        Returns the secret rather than the id because the server only exposes it at creation time.
+        """
 
-		secret = self._create(app_password).get("secret")
-		if not secret:
-			frappe.throw(_("The Stalwart server did not return a generated app password secret."))
+        secret = self._create(app_password).get("secret")
+        if not secret:
+            frappe.throw(_("The Stalwart server did not return a generated app password secret."))
 
-		return secret
+        return secret

--- a/suite/mail/stalwart/connection.py
+++ b/suite/mail/stalwart/connection.py
@@ -11,75 +11,73 @@ MANAGEMENT_SESSION_CACHE_KEY = "stalwart:management:sessions"
 
 
 def _session_manager(cache_key: str) -> JMAPSessionManager:
-	"""Returns a session manager that persists the discovered session in Frappe's cache.
+    """Returns a session manager that persists the discovered session in Frappe's cache.
 
-	Sessions are keyed by a hash of the server URL and username so that switching servers or
-	admin credentials never reuses a stale session.
-	"""
+    Sessions are keyed by a hash of the server URL and username so that switching servers or
+    admin credentials never reuses a stale session.
+    """
 
-	return JMAPSessionManager(
-		get_session=lambda: frappe.cache.hget(MANAGEMENT_SESSION_CACHE_KEY, cache_key),
-		set_session=lambda session: frappe.cache.hset(MANAGEMENT_SESSION_CACHE_KEY, cache_key, session),
-		clear_session=lambda: frappe.cache.hdel(MANAGEMENT_SESSION_CACHE_KEY, cache_key),
-	)
+    return JMAPSessionManager(
+        get_session=lambda: frappe.cache.hget(MANAGEMENT_SESSION_CACHE_KEY, cache_key),
+        set_session=lambda session: frappe.cache.hset(MANAGEMENT_SESSION_CACHE_KEY, cache_key, session),
+        clear_session=lambda: frappe.cache.hdel(MANAGEMENT_SESSION_CACHE_KEY, cache_key),
+    )
 
 
-def _build_connection(
-	username: str, cache_key: str | None, timeout: tuple[float, float]
-) -> JMAPConnection:
-	"""Builds a JMAPConnection for ``username`` using the configured admin password.
+def _build_connection(username: str, cache_key: str | None, timeout: tuple[float, float]) -> JMAPConnection:
+    """Builds a JMAPConnection for ``username`` using the configured admin password.
 
-	``cache_key`` persists the discovered session; pass ``None`` to always re-discover it.
-	"""
+    ``cache_key`` persists the discovered session; pass ``None`` to always re-discover it.
+    """
 
-	is_stalwart_configured(raise_exception=True)
+    is_stalwart_configured(raise_exception=True)
 
-	server_url, password, verify_ssl = get_config(("server_url", "password", "verify_ssl"))
+    server_url, password, verify_ssl = get_config(("server_url", "password", "verify_ssl"))
 
-	return JMAPConnection(
-		JMAPConnectionInfo(
-			server_url,
-			username,
-			password,
-			timeout,
-			verify_ssl=bool(verify_ssl),
-		),
-		session_manager=_session_manager(cache_key) if cache_key else None,
-	)
+    return JMAPConnection(
+        JMAPConnectionInfo(
+            server_url,
+            username,
+            password,
+            timeout,
+            verify_ssl=bool(verify_ssl),
+        ),
+        session_manager=_session_manager(cache_key) if cache_key else None,
+    )
 
 
 @request_cache
 def get_management_connection(timeout: tuple[float, float] = (30.0, 60.0)) -> JMAPConnection:
-	"""Returns a JMAPConnection authenticated as the Stalwart administrator.
+    """Returns a JMAPConnection authenticated as the Stalwart administrator.
 
-	Used for all server-scoped directory management (Accounts, Groups, Mailing Lists, Roles,
-	Domains, OAuth). Cached per request so the many service factories reuse one instance.
-	"""
+    Used for all server-scoped directory management (Accounts, Groups, Mailing Lists, Roles,
+    Domains, OAuth). Cached per request so the many service factories reuse one instance.
+    """
 
-	server_url, username = get_config(("server_url", "username"))
-	cache_key = hashlib.sha1(f"{server_url}|{username}".encode()).hexdigest()
+    server_url, username = get_config(("server_url", "username"))
+    cache_key = hashlib.sha1(f"{server_url}|{username}".encode()).hexdigest()
 
-	return _build_connection(username, cache_key, timeout)
+    return _build_connection(username, cache_key, timeout)
 
 
 @request_cache
 def get_account_management_connection(
-	account: str, timeout: tuple[float, float] = (30.0, 60.0)
+    account: str, timeout: tuple[float, float] = (30.0, 60.0)
 ) -> JMAPConnection:
-	"""Returns a JMAPConnection authenticated as ``account`` via Stalwart master-user auth.
+    """Returns a JMAPConnection authenticated as ``account`` via Stalwart master-user auth.
 
-	Stalwart lets an administrator authenticate as any account by logging in with the username
-	``<account>%<admin_username>`` and the admin password. This is required for account-scoped
-	management objects such as App Passwords, which are created within the target account.
+    Stalwart lets an administrator authenticate as any account by logging in with the username
+    ``<account>%<admin_username>`` and the admin password. This is required for account-scoped
+    management objects such as App Passwords, which are created within the target account.
 
-	The session is deliberately not persisted. It carries the account's id, and that id changes
-	whenever an account is deleted and recreated on the same address — a cached session then scopes
-	every call to the id of the account that is gone, which the server rejects with "You are not an
-	owner of account <id>". These connections are short-lived (one app password when an account is
-	set up) and ``request_cache`` already shares them within a request, so rediscovering costs a
-	single request and keeps the account id honest.
-	"""
+    The session is deliberately not persisted. It carries the account's id, and that id changes
+    whenever an account is deleted and recreated on the same address — a cached session then scopes
+    every call to the id of the account that is gone, which the server rejects with "You are not an
+    owner of account <id>". These connections are short-lived (one app password when an account is
+    set up) and ``request_cache`` already shares them within a request, so rediscovering costs a
+    single request and keeps the account id honest.
+    """
 
-	admin_username = get_config("username")
+    admin_username = get_config("username")
 
-	return _build_connection(f"{account}%{admin_username}", None, timeout)
+    return _build_connection(f"{account}%{admin_username}", None, timeout)

--- a/suite/mail/stalwart/domain.py
+++ b/suite/mail/stalwart/domain.py
@@ -8,263 +8,263 @@ from suite.mail.stalwart.service import ManagementService
 
 
 class CertificateManagementType(Enum):
-	MANUAL = "Manual"
-	AUTOMATIC = "Automatic"
+    MANUAL = "Manual"
+    AUTOMATIC = "Automatic"
 
 
 @dataclass
 class CertificateManagementProperties:
-	acme_provider_id: str
-	subject_alternative_names: list[str] | None = None
+    acme_provider_id: str
+    subject_alternative_names: list[str] | None = None
 
 
 @dataclass
 class CertificateManagement:
-	type: CertificateManagementType = CertificateManagementType.MANUAL
-	properties: CertificateManagementProperties | None = None
+    type: CertificateManagementType = CertificateManagementType.MANUAL
+    properties: CertificateManagementProperties | None = None
 
-	def __post_init__(self) -> None:
-		"""Validates that properties are present only for automatic management."""
+    def __post_init__(self) -> None:
+        """Validates that properties are present only for automatic management."""
 
-		if self.type == CertificateManagementType.AUTOMATIC and not self.properties:
-			raise ValueError("Properties must be provided for automatic certificate management.")
-		if self.type == CertificateManagementType.MANUAL and self.properties:
-			raise ValueError("Properties should not be provided for manual certificate management.")
+        if self.type == CertificateManagementType.AUTOMATIC and not self.properties:
+            raise ValueError("Properties must be provided for automatic certificate management.")
+        if self.type == CertificateManagementType.MANUAL and self.properties:
+            raise ValueError("Properties should not be provided for manual certificate management.")
 
-	def to_dict(self) -> dict:
-		"""Serializes the certificate management tagged union to the JMAP wire format."""
+    def to_dict(self) -> dict:
+        """Serializes the certificate management tagged union to the JMAP wire format."""
 
-		if self.type == CertificateManagementType.MANUAL:
-			return {"@type": self.type.value}
+        if self.type == CertificateManagementType.MANUAL:
+            return {"@type": self.type.value}
 
-		return {
-			"@type": self.type.value,
-			"acmeProviderId": self.properties.acme_provider_id,
-			"subjectAlternativeNames": self.properties.subject_alternative_names,
-		}
+        return {
+            "@type": self.type.value,
+            "acmeProviderId": self.properties.acme_provider_id,
+            "subjectAlternativeNames": self.properties.subject_alternative_names,
+        }
 
 
 class DkimManagementType(Enum):
-	MANUAL = "Manual"
-	AUTOMATIC = "Automatic"
+    MANUAL = "Manual"
+    AUTOMATIC = "Automatic"
 
 
 class DkimSignatureType(Enum):
-	DKIM1_ED25519_SHA256 = "Dkim1Ed25519Sha256"
-	DKIM_RSA_SHA256 = "Dkim1RsaSha256"
+    DKIM1_ED25519_SHA256 = "Dkim1Ed25519Sha256"
+    DKIM_RSA_SHA256 = "Dkim1RsaSha256"
 
 
 @dataclass
 class DkimManagementProperties:
-	algorithms: list[DkimSignatureType] = field(
-		default_factory=lambda: [
-			DkimSignatureType.DKIM1_ED25519_SHA256,
-			DkimSignatureType.DKIM_RSA_SHA256,
-		]
-	)
-	selector_template: str = "v{version}-{algorithm}-{date-%Y%m%d}"
-	rotate_after: int = 90 * 24 * 60 * 60 * 1000
-	retire_after: int = 7 * 24 * 60 * 60 * 1000
-	delete_after: int = 30 * 24 * 60 * 60 * 1000
+    algorithms: list[DkimSignatureType] = field(
+        default_factory=lambda: [
+            DkimSignatureType.DKIM1_ED25519_SHA256,
+            DkimSignatureType.DKIM_RSA_SHA256,
+        ]
+    )
+    selector_template: str = "v{version}-{algorithm}-{date-%Y%m%d}"
+    rotate_after: int = 90 * 24 * 60 * 60 * 1000
+    retire_after: int = 7 * 24 * 60 * 60 * 1000
+    delete_after: int = 30 * 24 * 60 * 60 * 1000
 
 
 @dataclass
 class DkimManagement:
-	type: DkimManagementType = DkimManagementType.AUTOMATIC
-	properties: DkimManagementProperties = field(default_factory=DkimManagementProperties)
+    type: DkimManagementType = DkimManagementType.AUTOMATIC
+    properties: DkimManagementProperties = field(default_factory=DkimManagementProperties)
 
-	def __post_init__(self) -> None:
-		"""Validates that properties are present only for automatic management."""
+    def __post_init__(self) -> None:
+        """Validates that properties are present only for automatic management."""
 
-		if self.type == DkimManagementType.AUTOMATIC and not self.properties:
-			raise ValueError("Properties must be provided for automatic DKIM management.")
-		if self.type == DkimManagementType.MANUAL and self.properties:
-			raise ValueError("Properties should not be provided for manual DKIM management.")
+        if self.type == DkimManagementType.AUTOMATIC and not self.properties:
+            raise ValueError("Properties must be provided for automatic DKIM management.")
+        if self.type == DkimManagementType.MANUAL and self.properties:
+            raise ValueError("Properties should not be provided for manual DKIM management.")
 
-	def to_dict(self) -> dict:
-		"""Serializes the DKIM management tagged union to the JMAP wire format."""
+    def to_dict(self) -> dict:
+        """Serializes the DKIM management tagged union to the JMAP wire format."""
 
-		if self.type == DkimManagementType.MANUAL:
-			return {"@type": self.type.value}
+        if self.type == DkimManagementType.MANUAL:
+            return {"@type": self.type.value}
 
-		return {
-			"@type": self.type.value,
-			"algorithms": {algorithm.value: True for algorithm in self.properties.algorithms}
-			if self.properties.algorithms
-			else {},
-			"selectorTemplate": self.properties.selector_template,
-			"rotateAfter": self.properties.rotate_after,
-			"retireAfter": self.properties.retire_after,
-			"deleteAfter": self.properties.delete_after,
-		}
+        return {
+            "@type": self.type.value,
+            "algorithms": {algorithm.value: True for algorithm in self.properties.algorithms}
+            if self.properties.algorithms
+            else {},
+            "selectorTemplate": self.properties.selector_template,
+            "rotateAfter": self.properties.rotate_after,
+            "retireAfter": self.properties.retire_after,
+            "deleteAfter": self.properties.delete_after,
+        }
 
 
 class DnsManagementType(Enum):
-	MANUAL = "Manual"
-	AUTOMATIC = "Automatic"
+    MANUAL = "Manual"
+    AUTOMATIC = "Automatic"
 
 
 class DnsRecordType(Enum):
-	DKIM = "dkim"
-	TLSA = "tlsa"
-	SPF = "spf"
-	MX = "mx"
-	DMARC = "dmarc"
-	SRV = "srv"
-	MTA_STS = "mtaSts"
-	TLS_RPT = "tlsRpt"
-	CAA = "caa"
-	AUTO_CONFIG = "autoConfig"
-	AUTO_CONFIG_LEGACY = "autoConfigLegacy"
-	AUTO_DISCOVER = "autoDiscover"
+    DKIM = "dkim"
+    TLSA = "tlsa"
+    SPF = "spf"
+    MX = "mx"
+    DMARC = "dmarc"
+    SRV = "srv"
+    MTA_STS = "mtaSts"
+    TLS_RPT = "tlsRpt"
+    CAA = "caa"
+    AUTO_CONFIG = "autoConfig"
+    AUTO_CONFIG_LEGACY = "autoConfigLegacy"
+    AUTO_DISCOVER = "autoDiscover"
 
 
 @dataclass
 class DnsManagementProperties:
-	dns_server_id: str
-	origin: str | None = None
-	publish_records: list[DnsRecordType] = field(
-		default_factory=lambda: [
-			DnsRecordType.DKIM,
-			DnsRecordType.SPF,
-			DnsRecordType.MX,
-			DnsRecordType.DMARC,
-			DnsRecordType.SRV,
-			DnsRecordType.MTA_STS,
-			DnsRecordType.TLS_RPT,
-			DnsRecordType.CAA,
-			DnsRecordType.AUTO_CONFIG,
-			DnsRecordType.AUTO_CONFIG_LEGACY,
-			DnsRecordType.AUTO_DISCOVER,
-		]
-	)
+    dns_server_id: str
+    origin: str | None = None
+    publish_records: list[DnsRecordType] = field(
+        default_factory=lambda: [
+            DnsRecordType.DKIM,
+            DnsRecordType.SPF,
+            DnsRecordType.MX,
+            DnsRecordType.DMARC,
+            DnsRecordType.SRV,
+            DnsRecordType.MTA_STS,
+            DnsRecordType.TLS_RPT,
+            DnsRecordType.CAA,
+            DnsRecordType.AUTO_CONFIG,
+            DnsRecordType.AUTO_CONFIG_LEGACY,
+            DnsRecordType.AUTO_DISCOVER,
+        ]
+    )
 
 
 @dataclass
 class DnsManagement:
-	type: DnsManagementType = DnsManagementType.MANUAL
-	properties: DnsManagementProperties | None = None
+    type: DnsManagementType = DnsManagementType.MANUAL
+    properties: DnsManagementProperties | None = None
 
-	def __post_init__(self) -> None:
-		"""Validates that properties are present only for automatic management."""
+    def __post_init__(self) -> None:
+        """Validates that properties are present only for automatic management."""
 
-		if self.type == DnsManagementType.AUTOMATIC and not self.properties:
-			raise ValueError("Properties must be provided for automatic DNS management.")
-		if self.type == DnsManagementType.MANUAL and self.properties:
-			raise ValueError("Properties should not be provided for manual DNS management.")
+        if self.type == DnsManagementType.AUTOMATIC and not self.properties:
+            raise ValueError("Properties must be provided for automatic DNS management.")
+        if self.type == DnsManagementType.MANUAL and self.properties:
+            raise ValueError("Properties should not be provided for manual DNS management.")
 
-	def to_dict(self) -> dict:
-		"""Serializes the DNS management tagged union to the JMAP wire format."""
+    def to_dict(self) -> dict:
+        """Serializes the DNS management tagged union to the JMAP wire format."""
 
-		if self.type == DnsManagementType.MANUAL:
-			return {"@type": self.type.value}
+        if self.type == DnsManagementType.MANUAL:
+            return {"@type": self.type.value}
 
-		return {
-			"@type": self.type.value,
-			"dnsServerId": self.properties.dns_server_id,
-			"origin": self.properties.origin,
-			"publishRecords": [record.value for record in self.properties.publish_records],
-		}
+        return {
+            "@type": self.type.value,
+            "dnsServerId": self.properties.dns_server_id,
+            "origin": self.properties.origin,
+            "publishRecords": [record.value for record in self.properties.publish_records],
+        }
 
 
 class SubAddressingType(Enum):
-	DISABLED = "Disabled"
-	ENABLED = "Enabled"
-	CUSTOM = "Custom"
+    DISABLED = "Disabled"
+    ENABLED = "Enabled"
+    CUSTOM = "Custom"
 
 
 @dataclass
 class SubAddressingCustom:
-	custom_rule: str
+    custom_rule: str
 
 
 @dataclass
 class SubAddressing:
-	type: SubAddressingType = SubAddressingType.ENABLED
-	properties: SubAddressingCustom | None = None
+    type: SubAddressingType = SubAddressingType.ENABLED
+    properties: SubAddressingCustom | None = None
 
-	def __post_init__(self) -> None:
-		"""Validates that a custom rule is present only for custom sub-addressing."""
+    def __post_init__(self) -> None:
+        """Validates that a custom rule is present only for custom sub-addressing."""
 
-		if self.type == SubAddressingType.CUSTOM and not self.properties:
-			raise ValueError("Properties must be provided for custom sub-addressing.")
-		if self.type != SubAddressingType.CUSTOM and self.properties:
-			raise ValueError("Properties should not be provided for non-custom sub-addressing.")
+        if self.type == SubAddressingType.CUSTOM and not self.properties:
+            raise ValueError("Properties must be provided for custom sub-addressing.")
+        if self.type != SubAddressingType.CUSTOM and self.properties:
+            raise ValueError("Properties should not be provided for non-custom sub-addressing.")
 
-	def to_dict(self) -> dict:
-		"""Serializes the sub-addressing tagged union to the JMAP wire format."""
+    def to_dict(self) -> dict:
+        """Serializes the sub-addressing tagged union to the JMAP wire format."""
 
-		if self.type != SubAddressingType.CUSTOM:
-			return {"@type": self.type.value}
+        if self.type != SubAddressingType.CUSTOM:
+            return {"@type": self.type.value}
 
-		return {"@type": self.type.value, "customRule": self.properties.custom_rule}
+        return {"@type": self.type.value, "customRule": self.properties.custom_rule}
 
 
 @dataclass
 class Domain:
-	name: str
-	aliases: list[str] | None = None
-	is_enabled: bool = True
-	description: str | None = None
-	certificate_management: CertificateManagement = field(default_factory=CertificateManagement)
-	dkim_management: DkimManagement = field(default_factory=DkimManagement)
-	dns_management: DnsManagement = field(default_factory=DnsManagement)
-	catch_all_address: str | None = None
-	sub_addressing: SubAddressing = field(default_factory=SubAddressing)
-	allow_relaying: bool = False
-	report_address_uri: str | None = "mailto:postmaster"
+    name: str
+    aliases: list[str] | None = None
+    is_enabled: bool = True
+    description: str | None = None
+    certificate_management: CertificateManagement = field(default_factory=CertificateManagement)
+    dkim_management: DkimManagement = field(default_factory=DkimManagement)
+    dns_management: DnsManagement = field(default_factory=DnsManagement)
+    catch_all_address: str | None = None
+    sub_addressing: SubAddressing = field(default_factory=SubAddressing)
+    allow_relaying: bool = False
+    report_address_uri: str | None = "mailto:postmaster"
 
-	def to_dict(self) -> dict:
-		"""Serializes the domain to the JMAP wire format."""
+    def to_dict(self) -> dict:
+        """Serializes the domain to the JMAP wire format."""
 
-		return {
-			"name": self.name,
-			"aliases": {alias: True for alias in self.aliases} if self.aliases else {},
-			"isEnabled": self.is_enabled,
-			"description": self.description,
-			"certificateManagement": self.certificate_management.to_dict(),
-			"dkimManagement": self.dkim_management.to_dict(),
-			"dnsManagement": self.dns_management.to_dict(),
-			"catchAllAddress": self.catch_all_address,
-			"subAddressing": self.sub_addressing.to_dict(),
-			"allowRelaying": self.allow_relaying,
-			"reportAddressUri": self.report_address_uri,
-		}
+        return {
+            "name": self.name,
+            "aliases": {alias: True for alias in self.aliases} if self.aliases else {},
+            "isEnabled": self.is_enabled,
+            "description": self.description,
+            "certificateManagement": self.certificate_management.to_dict(),
+            "dkimManagement": self.dkim_management.to_dict(),
+            "dnsManagement": self.dns_management.to_dict(),
+            "catchAllAddress": self.catch_all_address,
+            "subAddressing": self.sub_addressing.to_dict(),
+            "allowRelaying": self.allow_relaying,
+            "reportAddressUri": self.report_address_uri,
+        }
 
 
 class DomainService(ManagementService):
-	type = "Domain"
-	default_properties = ["id", "name", "description", "isEnabled", "createdAt"]
+    type = "Domain"
+    default_properties = ["id", "name", "description", "isEnabled", "createdAt"]
 
-	def get_by_name(
-		self, name: str, properties: list[str] | None = None, raise_exception: bool = True
-	) -> dict | None:
-		"""Returns the domain with the given name, or ``None`` (throws if ``raise_exception``)."""
+    def get_by_name(
+        self, name: str, properties: list[str] | None = None, raise_exception: bool = True
+    ) -> dict | None:
+        """Returns the domain with the given name, or ``None`` (throws if ``raise_exception``)."""
 
-		domain = self.find({"name": name}, properties=properties or ["id"])
-		if not domain and raise_exception:
-			frappe.throw(_("Domain {0} not found on the Stalwart server.").format(name))
+        domain = self.find({"name": name}, properties=properties or ["id"])
+        if not domain and raise_exception:
+            frappe.throw(_("Domain {0} not found on the Stalwart server.").format(name))
 
-		return domain
+        return domain
 
-	def delete(self, ids: str | list[str]) -> None:
-		"""Deletes domains, first removing DKIM signatures that would block the delete."""
+    def delete(self, ids: str | list[str]) -> None:
+        """Deletes domains, first removing DKIM signatures that would block the delete."""
 
-		# Stalwart refuses to delete a domain while DKIM signatures still reference it.
-		ids = [ids] if isinstance(ids, str) else list(ids)
-		dkim_service = DkimSignatureService(self.connection)
-		for domain_id in ids:
-			if signature_ids := [s["id"] for s in dkim_service.get_all_by_domain(domain_id)]:
-				dkim_service.delete(signature_ids)
+        # Stalwart refuses to delete a domain while DKIM signatures still reference it.
+        ids = [ids] if isinstance(ids, str) else list(ids)
+        dkim_service = DkimSignatureService(self.connection)
+        for domain_id in ids:
+            if signature_ids := [s["id"] for s in dkim_service.get_all_by_domain(domain_id)]:
+                dkim_service.delete(signature_ids)
 
-		super().delete(ids)
+        super().delete(ids)
 
 
 class DkimSignatureService(ManagementService):
-	type = "DkimSignature"
-	default_properties = ["id", "selector", "domainId", "stage"]
+    type = "DkimSignature"
+    default_properties = ["id", "selector", "domainId", "stage"]
 
-	def get_all_by_domain(self, domain_id: str, properties: list[str] | None = None) -> list[dict]:
-		"""Returns every DKIM signature linked to the given domain."""
+    def get_all_by_domain(self, domain_id: str, properties: list[str] | None = None) -> list[dict]:
+        """Returns every DKIM signature linked to the given domain."""
 
-		return self.get_all(filter={"domainId": domain_id}, properties=properties)
+        return self.get_all(filter={"domainId": domain_id}, properties=properties)

--- a/suite/mail/stalwart/group.py
+++ b/suite/mail/stalwart/group.py
@@ -1,98 +1,98 @@
 from dataclasses import dataclass, field
 
 from suite.mail.stalwart.account import (
-	AccountService,
-	CustomRoles,
-	EmailAlias,
-	Permissions,
-	RoleType,
-	StorageQuota,
-	UserRoles,
+    AccountService,
+    CustomRoles,
+    EmailAlias,
+    Permissions,
+    RoleType,
+    StorageQuota,
+    UserRoles,
 )
 
 
 @dataclass
 class Group:
-	"""A group principal. Groups share the ``x:Account`` object with users but carry no
-	credentials and are distinguished by the ``@type: "Group"`` discriminator."""
+    """A group principal. Groups share the ``x:Account`` object with users but carry no
+    credentials and are distinguished by the ``@type: "Group"`` discriminator."""
 
-	name: str
-	domain_id: str
-	role_ids: list[str] | None = None
-	permissions: Permissions = field(default_factory=Permissions)
-	quotas: StorageQuota = field(default_factory=StorageQuota)
-	aliases: list[EmailAlias] | None = None
-	description: str | None = None
+    name: str
+    domain_id: str
+    role_ids: list[str] | None = None
+    permissions: Permissions = field(default_factory=Permissions)
+    quotas: StorageQuota = field(default_factory=StorageQuota)
+    aliases: list[EmailAlias] | None = None
+    description: str | None = None
 
-	def to_dict(self) -> dict:
-		"""Serializes the group to the JMAP wire format (an ``x:Account`` with ``@type: Group``).
+    def to_dict(self) -> dict:
+        """Serializes the group to the JMAP wire format (an ``x:Account`` with ``@type: Group``).
 
-		Groups carry no ``memberGroupIds`` — membership lives on each member account instead.
-		"""
+        Groups carry no ``memberGroupIds`` — membership lives on each member account instead.
+        """
 
-		payload = {
-			"@type": "Group",
-			"name": self.name,
-			"domainId": self.domain_id,
-			"permissions": self.permissions.to_dict() if self.permissions else {},
-			"quotas": self.quotas.to_dict() if self.quotas else {},
-			"aliases": {f"{idx}": a.to_dict() for idx, a in enumerate(self.aliases)} if self.aliases else {},
-			"description": self.description,
-		}
+        payload = {
+            "@type": "Group",
+            "name": self.name,
+            "domainId": self.domain_id,
+            "permissions": self.permissions.to_dict() if self.permissions else {},
+            "quotas": self.quotas.to_dict() if self.quotas else {},
+            "aliases": {f"{idx}": a.to_dict() for idx, a in enumerate(self.aliases)} if self.aliases else {},
+            "description": self.description,
+        }
 
-		if self.role_ids:
-			payload["roles"] = UserRoles(
-				type=RoleType.CUSTOM, roles=CustomRoles(role_ids=self.role_ids)
-			).to_dict()
+        if self.role_ids:
+            payload["roles"] = UserRoles(
+                type=RoleType.CUSTOM, roles=CustomRoles(role_ids=self.role_ids)
+            ).to_dict()
 
-		return payload
+        return payload
 
 
 class GroupService(AccountService):
-	"""Groups live in the same ``x:Account`` collection as users."""
+    """Groups live in the same ``x:Account`` collection as users."""
 
-	def get_all_groups(self, properties: list[str] | None = None) -> list[dict]:
-		"""Returns every group principal."""
+    def get_all_groups(self, properties: list[str] | None = None) -> list[dict]:
+        """Returns every group principal."""
 
-		return self.get_all(filter={"@type": "Group"}, properties=properties)
+        return self.get_all(filter={"@type": "Group"}, properties=properties)
 
-	def get_members(self, group_id: str, properties: list[str] | None = None) -> list[dict]:
-		"""Returns the accounts that belong to the group.
+    def get_members(self, group_id: str, properties: list[str] | None = None) -> list[dict]:
+        """Returns the accounts that belong to the group.
 
-		Membership lives on each member account's ``memberGroupIds``, not on the group itself.
-		"""
+        Membership lives on each member account's ``memberGroupIds``, not on the group itself.
+        """
 
-		return self.get_all(filter={"memberGroupIds": group_id}, properties=properties)
+        return self.get_all(filter={"memberGroupIds": group_id}, properties=properties)
 
-	def add_members(self, group_id: str, account_ids: list[str]) -> None:
-		"""Adds the given accounts to the group by patching each account's membership."""
+    def add_members(self, group_id: str, account_ids: list[str]) -> None:
+        """Adds the given accounts to the group by patching each account's membership."""
 
-		for account_id in account_ids:
-			self.update(account_id, {f"memberGroupIds/{group_id}": True})
+        for account_id in account_ids:
+            self.update(account_id, {f"memberGroupIds/{group_id}": True})
 
-	def remove_members(self, group_id: str, account_ids: list[str]) -> None:
-		"""Removes the given accounts from the group by patching each account's membership."""
+    def remove_members(self, group_id: str, account_ids: list[str]) -> None:
+        """Removes the given accounts from the group by patching each account's membership."""
 
-		for account_id in account_ids:
-			self.update(account_id, {f"memberGroupIds/{group_id}": None})
+        for account_id in account_ids:
+            self.update(account_id, {f"memberGroupIds/{group_id}": None})
 
-	def set_members(self, group_id: str, account_ids: list[str]) -> None:
-		"""Reconciles the group's membership to exactly ``account_ids``."""
+    def set_members(self, group_id: str, account_ids: list[str]) -> None:
+        """Reconciles the group's membership to exactly ``account_ids``."""
 
-		current = {m["id"] for m in self.get_members(group_id, properties=["id"])}
-		desired = set(account_ids)
-		self.add_members(group_id, list(desired - current))
-		self.remove_members(group_id, list(current - desired))
+        current = {m["id"] for m in self.get_members(group_id, properties=["id"])}
+        desired = set(account_ids)
+        self.add_members(group_id, list(desired - current))
+        self.remove_members(group_id, list(current - desired))
 
-	def delete(self, ids: str | list[str]) -> None:
-		"""Deletes groups, first clearing membership so the server's link check passes.
+    def delete(self, ids: str | list[str]) -> None:
+        """Deletes groups, first clearing membership so the server's link check passes.
 
-		Stalwart refuses to destroy a group while accounts still reference it as a member.
-		"""
+        Stalwart refuses to destroy a group while accounts still reference it as a member.
+        """
 
-		ids = [ids] if isinstance(ids, str) else list(ids)
-		for group_id in ids:
-			if member_ids := [m["id"] for m in self.get_members(group_id, properties=["id"])]:
-				self.remove_members(group_id, member_ids)
+        ids = [ids] if isinstance(ids, str) else list(ids)
+        for group_id in ids:
+            if member_ids := [m["id"] for m in self.get_members(group_id, properties=["id"])]:
+                self.remove_members(group_id, member_ids)
 
-		super().delete(ids)
+        super().delete(ids)

--- a/suite/mail/stalwart/logs.py
+++ b/suite/mail/stalwart/logs.py
@@ -2,9 +2,9 @@ from suite.mail.stalwart.service import ManagementService
 
 
 class LogService(ManagementService):
-	"""Read access to server log entries (``x:Log``)."""
+    """Read access to server log entries (``x:Log``)."""
 
-	type = "Log"
-	default_properties = ["id", "timestamp", "level", "event", "details"]
-	# The log store rejects offset paging ("Pagination is only possible using anchors for logs").
-	cursor_paginated = True
+    type = "Log"
+    default_properties = ["id", "timestamp", "level", "event", "details"]
+    # The log store rejects offset paging ("Pagination is only possible using anchors for logs").
+    cursor_paginated = True

--- a/suite/mail/stalwart/mailing_list.py
+++ b/suite/mail/stalwart/mailing_list.py
@@ -8,36 +8,36 @@ from suite.mail.stalwart.service import ManagementService
 
 @dataclass
 class MailingList:
-	name: str
-	domain_id: str
-	recipients: list[str] | None = None
-	description: str | None = None
+    name: str
+    domain_id: str
+    recipients: list[str] | None = None
+    description: str | None = None
 
-	def to_dict(self) -> dict:
-		"""Serializes the mailing list to the JMAP wire format.
+    def to_dict(self) -> dict:
+        """Serializes the mailing list to the JMAP wire format.
 
-		``recipients`` is a set-valued map keyed by recipient email address — internal or
-		external (omitted when empty).
-		"""
+        ``recipients`` is a set-valued map keyed by recipient email address — internal or
+        external (omitted when empty).
+        """
 
-		payload = {"name": self.name, "domainId": self.domain_id, "description": self.description}
-		if self.recipients:
-			payload["recipients"] = {email: True for email in self.recipients}
+        payload = {"name": self.name, "domainId": self.domain_id, "description": self.description}
+        if self.recipients:
+            payload["recipients"] = {email: True for email in self.recipients}
 
-		return payload
+        return payload
 
 
 class MailingListService(ManagementService):
-	type = "MailingList"
-	default_properties = ["id", "name", "emailAddress", "domainId", "recipients", "description"]
+    type = "MailingList"
+    default_properties = ["id", "name", "emailAddress", "domainId", "recipients", "description"]
 
-	def get_by_name(
-		self, name: str, properties: list[str] | None = None, raise_exception: bool = True
-	) -> dict | None:
-		"""Returns the mailing list with the given name, or ``None`` (throws if ``raise_exception``)."""
+    def get_by_name(
+        self, name: str, properties: list[str] | None = None, raise_exception: bool = True
+    ) -> dict | None:
+        """Returns the mailing list with the given name, or ``None`` (throws if ``raise_exception``)."""
 
-		mailing_list = self.find({"name": name}, properties=properties or ["id"])
-		if not mailing_list and raise_exception:
-			frappe.throw(_("Mailing list {0} not found on the Stalwart server.").format(name))
+        mailing_list = self.find({"name": name}, properties=properties or ["id"])
+        if not mailing_list and raise_exception:
+            frappe.throw(_("Mailing list {0} not found on the Stalwart server.").format(name))
 
-		return mailing_list
+        return mailing_list

--- a/suite/mail/stalwart/oauth.py
+++ b/suite/mail/stalwart/oauth.py
@@ -8,40 +8,40 @@ from suite.mail.stalwart.service import ManagementService
 
 @dataclass
 class OAuthClient:
-	client_id: str
-	description: str | None = None
-	contacts: list[str] | None = None
-	redirect_uris: list[str] | None = None
-	secret: str | None = None
-	logo: str | None = None
-	expires_at: str | None = None
+    client_id: str
+    description: str | None = None
+    contacts: list[str] | None = None
+    redirect_uris: list[str] | None = None
+    secret: str | None = None
+    logo: str | None = None
+    expires_at: str | None = None
 
-	def to_dict(self) -> dict:
-		"""Serializes the OAuth client to the JMAP wire format."""
+    def to_dict(self) -> dict:
+        """Serializes the OAuth client to the JMAP wire format."""
 
-		return {
-			"clientId": self.client_id,
-			"description": self.description,
-			"contacts": {contact: True for contact in self.contacts} if self.contacts else {},
-			"redirectUris": {uri: True for uri in self.redirect_uris} if self.redirect_uris else {},
-			"secret": self.secret,
-			"logo": self.logo,
-			"expiresAt": self.expires_at,
-		}
+        return {
+            "clientId": self.client_id,
+            "description": self.description,
+            "contacts": {contact: True for contact in self.contacts} if self.contacts else {},
+            "redirectUris": {uri: True for uri in self.redirect_uris} if self.redirect_uris else {},
+            "secret": self.secret,
+            "logo": self.logo,
+            "expiresAt": self.expires_at,
+        }
 
 
 class OAuthClientService(ManagementService):
-	type = "OAuthClient"
-	default_properties = ["id", "clientId", "description", "contacts", "redirectUris", "expiresAt"]
+    type = "OAuthClient"
+    default_properties = ["id", "clientId", "description", "contacts", "redirectUris", "expiresAt"]
 
-	def get_by_client_id(
-		self, client_id: str, properties: list[str] | None = None, raise_exception: bool = True
-	) -> dict | None:
-		"""Returns the OAuth client with the given clientId, or ``None`` (throws if ``raise_exception``)."""
+    def get_by_client_id(
+        self, client_id: str, properties: list[str] | None = None, raise_exception: bool = True
+    ) -> dict | None:
+        """Returns the OAuth client with the given clientId, or ``None`` (throws if ``raise_exception``)."""
 
-		client = self.find({"text": client_id}, properties=properties)
-		if client and client.get("clientId") == client_id:
-			return client
+        client = self.find({"text": client_id}, properties=properties)
+        if client and client.get("clientId") == client_id:
+            return client
 
-		if raise_exception:
-			frappe.throw(_("OAuth client {0} not found on the Stalwart server.").format(client_id))
+        if raise_exception:
+            frappe.throw(_("OAuth client {0} not found on the Stalwart server.").format(client_id))

--- a/suite/mail/stalwart/queue.py
+++ b/suite/mail/stalwart/queue.py
@@ -5,26 +5,26 @@ RETRY_NOW = "2000-01-01T00:00:00Z"
 
 
 class QueuedMessageService(ManagementService):
-	"""Read + retry/cancel access to messages pending outbound delivery (``x:QueuedMessage``)."""
+    """Read + retry/cancel access to messages pending outbound delivery (``x:QueuedMessage``)."""
 
-	type = "QueuedMessage"
-	default_properties = [
-		"id",
-		"returnPath",
-		"recipients",
-		"size",
-		"priority",
-		"envId",
-		"flags",
-		"nextRetry",
-		"nextNotify",
-		"receivedFromIp",
-		"receivedViaPort",
-		"createdAt",
-		"blobId",
-	]
+    type = "QueuedMessage"
+    default_properties = [
+        "id",
+        "returnPath",
+        "recipients",
+        "size",
+        "priority",
+        "envId",
+        "flags",
+        "nextRetry",
+        "nextNotify",
+        "receivedFromIp",
+        "receivedViaPort",
+        "createdAt",
+        "blobId",
+    ]
 
-	def retry(self, ids: list[str]) -> None:
-		"""Schedules the given messages for immediate delivery."""
+    def retry(self, ids: list[str]) -> None:
+        """Schedules the given messages for immediate delivery."""
 
-		self.update_many({id: {"nextRetry": RETRY_NOW} for id in ids})
+        self.update_many({id: {"nextRetry": RETRY_NOW} for id in ids})

--- a/suite/mail/stalwart/reports.py
+++ b/suite/mail/stalwart/reports.py
@@ -7,35 +7,35 @@ _INTERNAL_PROPERTIES = ["id", "domain", "createdAt", "deliverAt", "report"]
 
 
 class DmarcExternalReportService(ManagementService):
-	"""Received DMARC aggregate reports (``x:DmarcExternalReport``)."""
+    """Received DMARC aggregate reports (``x:DmarcExternalReport``)."""
 
-	type = "DmarcExternalReport"
-	default_properties = _EXTERNAL_PROPERTIES
+    type = "DmarcExternalReport"
+    default_properties = _EXTERNAL_PROPERTIES
 
 
 class DmarcInternalReportService(ManagementService):
-	"""Outbound DMARC aggregate reports Stalwart generates (``x:DmarcInternalReport``)."""
+    """Outbound DMARC aggregate reports Stalwart generates (``x:DmarcInternalReport``)."""
 
-	type = "DmarcInternalReport"
-	default_properties = [*_INTERNAL_PROPERTIES, "rua", "policyIdentifier"]
+    type = "DmarcInternalReport"
+    default_properties = [*_INTERNAL_PROPERTIES, "rua", "policyIdentifier"]
 
 
 class TlsExternalReportService(ManagementService):
-	"""Received TLS reports (``x:TlsExternalReport``)."""
+    """Received TLS reports (``x:TlsExternalReport``)."""
 
-	type = "TlsExternalReport"
-	default_properties = _EXTERNAL_PROPERTIES
+    type = "TlsExternalReport"
+    default_properties = _EXTERNAL_PROPERTIES
 
 
 class TlsInternalReportService(ManagementService):
-	"""Outbound TLS reports Stalwart generates (``x:TlsInternalReport``)."""
+    """Outbound TLS reports Stalwart generates (``x:TlsInternalReport``)."""
 
-	type = "TlsInternalReport"
-	default_properties = [*_INTERNAL_PROPERTIES, "mailRua", "httpRua", "policyIdentifiers"]
+    type = "TlsInternalReport"
+    default_properties = [*_INTERNAL_PROPERTIES, "mailRua", "httpRua", "policyIdentifiers"]
 
 
 class ArfExternalReportService(ManagementService):
-	"""Received ARF feedback reports (``x:ArfExternalReport``)."""
+    """Received ARF feedback reports (``x:ArfExternalReport``)."""
 
-	type = "ArfExternalReport"
-	default_properties = _EXTERNAL_PROPERTIES
+    type = "ArfExternalReport"
+    default_properties = _EXTERNAL_PROPERTIES

--- a/suite/mail/stalwart/role.py
+++ b/suite/mail/stalwart/role.py
@@ -8,36 +8,36 @@ from suite.mail.stalwart.service import ManagementService
 
 @dataclass
 class Role:
-	description: str
-	role_ids: list[str] = field(default_factory=list)
-	enabled_permissions: list[str] = field(default_factory=list)
-	disabled_permissions: list[str] = field(default_factory=list)
+    description: str
+    role_ids: list[str] = field(default_factory=list)
+    enabled_permissions: list[str] = field(default_factory=list)
+    disabled_permissions: list[str] = field(default_factory=list)
 
-	def to_dict(self) -> dict:
-		"""Serializes the role to the JMAP wire format.
+    def to_dict(self) -> dict:
+        """Serializes the role to the JMAP wire format.
 
-		``roleIds`` and the permission sets are id-keyed maps on the wire, not arrays.
-		"""
+        ``roleIds`` and the permission sets are id-keyed maps on the wire, not arrays.
+        """
 
-		return {
-			"description": self.description,
-			"roleIds": {role_id: True for role_id in self.role_ids},
-			"enabledPermissions": {perm: True for perm in self.enabled_permissions},
-			"disabledPermissions": {perm: True for perm in self.disabled_permissions},
-		}
+        return {
+            "description": self.description,
+            "roleIds": {role_id: True for role_id in self.role_ids},
+            "enabledPermissions": {perm: True for perm in self.enabled_permissions},
+            "disabledPermissions": {perm: True for perm in self.disabled_permissions},
+        }
 
 
 class RoleService(ManagementService):
-	type = "Role"
-	default_properties = ["id", "description", "roleIds", "enabledPermissions", "disabledPermissions"]
+    type = "Role"
+    default_properties = ["id", "description", "roleIds", "enabledPermissions", "disabledPermissions"]
 
-	def get_by_description(
-		self, description: str, properties: list[str] | None = None, raise_exception: bool = True
-	) -> dict | None:
-		"""Returns the role with the given description, or ``None`` (throws if ``raise_exception``)."""
+    def get_by_description(
+        self, description: str, properties: list[str] | None = None, raise_exception: bool = True
+    ) -> dict | None:
+        """Returns the role with the given description, or ``None`` (throws if ``raise_exception``)."""
 
-		role = self.find({"description": description}, properties=properties or ["id", "description"])
-		if not role and raise_exception:
-			frappe.throw(_("Role {0} not found on the Stalwart server.").format(description))
+        role = self.find({"description": description}, properties=properties or ["id", "description"])
+        if not role and raise_exception:
+            frappe.throw(_("Role {0} not found on the Stalwart server.").format(description))
 
-		return role
+        return role

--- a/suite/mail/stalwart/service.py
+++ b/suite/mail/stalwart/service.py
@@ -15,320 +15,326 @@ GENERIC_ERROR = "The mail server could not process this request. Please try agai
 
 
 class Serializable:
-	"""Interface for objects that can be turned into a JMAP object body."""
+    """Interface for objects that can be turned into a JMAP object body."""
 
-	def to_dict(self) -> dict:
-		"""Returns the JMAP wire representation of the object."""
+    def to_dict(self) -> dict:
+        """Returns the JMAP wire representation of the object."""
 
-		raise NotImplementedError
+        raise NotImplementedError
 
 
 class ManagementService:
-	"""Base for every Stalwart directory resource.
+    """Base for every Stalwart directory resource.
 
-	The Stalwart management API is a JMAP dialect: it is reached with the ``urn:stalwart:jmap``
-	capability, every method name is prefixed with ``x:`` (e.g. ``x:Account/get``) and, unlike the
-	per-mailbox JMAP API, calls are server-scoped and carry no ``accountId``. All CRUD lives here so
-	each resource subclass only declares its ``type`` and any resource-specific helpers.
-	"""
+    The Stalwart management API is a JMAP dialect: it is reached with the ``urn:stalwart:jmap``
+    capability, every method name is prefixed with ``x:`` (e.g. ``x:Account/get``) and, unlike the
+    per-mailbox JMAP API, calls are server-scoped and carry no ``accountId``. All CRUD lives here so
+    each resource subclass only declares its ``type`` and any resource-specific helpers.
+    """
 
-	type: ClassVar[str] = ""
-	default_properties: ClassVar[list[str] | None] = None
-	# Set by resources the server will only page with a cursor, never an offset.
-	cursor_paginated: ClassVar[bool] = False
+    type: ClassVar[str] = ""
+    default_properties: ClassVar[list[str] | None] = None
+    # Set by resources the server will only page with a cursor, never an offset.
+    cursor_paginated: ClassVar[bool] = False
 
-	def __init__(self, connection: JMAPConnection) -> None:
-		"""Binds the service to an admin-authenticated management connection."""
+    def __init__(self, connection: JMAPConnection) -> None:
+        """Binds the service to an admin-authenticated management connection."""
 
-		if not self.type:
-			raise NotImplementedError("A ManagementService subclass must set 'type'.")
+        if not self.type:
+            raise NotImplementedError("A ManagementService subclass must set 'type'.")
 
-		self.connection = connection
+        self.connection = connection
 
-	# --- capability limits -------------------------------------------------
+    # --- capability limits -------------------------------------------------
 
-	@property
-	def _core(self) -> dict:
-		"""Returns the server's advertised core JMAP capability object."""
+    @property
+    def _core(self) -> dict:
+        """Returns the server's advertised core JMAP capability object."""
 
-		return self.connection.capabilities.get(CORE_CAPABILITY) or {}
+        return self.connection.capabilities.get(CORE_CAPABILITY) or {}
 
-	@property
-	def account_id(self) -> str:
-		"""Returns the account id management calls are scoped to (the admin's own account).
+    @property
+    def account_id(self) -> str:
+        """Returns the account id management calls are scoped to (the admin's own account).
 
-		Stalwart advertises the management capability per-account, so the id comes from the
-		session's primary account for ``urn:stalwart:jmap``.
-		"""
+        Stalwart advertises the management capability per-account, so the id comes from the
+        session's primary account for ``urn:stalwart:jmap``.
+        """
 
-		return self.connection.primary_accounts[MANAGEMENT_CAPABILITY]
+        return self.connection.primary_accounts[MANAGEMENT_CAPABILITY]
 
-	@property
-	def max_objects_in_get(self) -> int:
-		"""Returns the most objects the server allows in one ``get`` call."""
+    @property
+    def max_objects_in_get(self) -> int:
+        """Returns the most objects the server allows in one ``get`` call."""
 
-		return self._core.get("maxObjectsInGet") or 500
+        return self._core.get("maxObjectsInGet") or 500
 
-	@property
-	def max_objects_in_set(self) -> int:
-		"""Returns the most objects the server allows in one ``set`` call."""
+    @property
+    def max_objects_in_set(self) -> int:
+        """Returns the most objects the server allows in one ``set`` call."""
 
-		return self._core.get("maxObjectsInSet") or 500
+        return self._core.get("maxObjectsInSet") or 500
 
-	@staticmethod
-	def _chunks(items: list[Any], size: int) -> Iterator[list[Any]]:
-		"""Yields ``items`` in lists of at most ``size``."""
+    @staticmethod
+    def _chunks(items: list[Any], size: int) -> Iterator[list[Any]]:
+        """Yields ``items`` in lists of at most ``size``."""
 
-		for i in range(0, len(items), size):
-			yield items[i : i + size]
+        for i in range(0, len(items), size):
+            yield items[i : i + size]
 
-	@staticmethod
-	def _chunk_dict(d: dict[str, Any], size: int) -> Iterator[dict[str, Any]]:
-		"""Yields ``d`` in sub-dicts of at most ``size`` entries."""
+    @staticmethod
+    def _chunk_dict(d: dict[str, Any], size: int) -> Iterator[dict[str, Any]]:
+        """Yields ``d`` in sub-dicts of at most ``size`` entries."""
 
-		keys = list(d)
-		for i in range(0, len(keys), size):
-			yield {k: d[k] for k in keys[i : i + size]}
+        keys = list(d)
+        for i in range(0, len(keys), size):
+            yield {k: d[k] for k in keys[i : i + size]}
 
-	# --- transport ---------------------------------------------------------
+    # --- transport ---------------------------------------------------------
 
-	def _fail(self, detail: str) -> None:
-		"""Logs the real Stalwart error and raises a generic message so it is never shown to the user."""
+    def _fail(self, detail: str) -> None:
+        """Logs the real Stalwart error and raises a generic message so it is never shown to the user."""
 
-		log_mail_error(title=_("Stalwart {0} request failed").format(self.type), message=detail)
-		frappe.throw(_(GENERIC_ERROR))
+        log_mail_error(title=_("Stalwart {0} request failed").format(self.type), message=detail)
+        frappe.throw(_(GENERIC_ERROR))
 
-	def _validate_capabilities(self) -> None:
-		"""Ensures the connected account can use the management capability.
+    def _validate_capabilities(self) -> None:
+        """Ensures the connected account can use the management capability.
 
-		The management capability is advertised per-account (in ``primaryAccounts``), not in the
-		server-wide ``capabilities`` block.
-		"""
+        The management capability is advertised per-account (in ``primaryAccounts``), not in the
+        server-wide ``capabilities`` block.
+        """
 
-		if MANAGEMENT_CAPABILITY not in self.connection.primary_accounts:
-			self._fail(f"Server does not advertise {MANAGEMENT_CAPABILITY} in primaryAccounts.")
+        if MANAGEMENT_CAPABILITY not in self.connection.primary_accounts:
+            self._fail(f"Server does not advertise {MANAGEMENT_CAPABILITY} in primaryAccounts.")
 
-	def _method(self, action: str) -> str:
-		"""Returns the ``x:``-prefixed JMAP method name for ``action`` (e.g. ``x:Account/get``)."""
+    def _method(self, action: str) -> str:
+        """Returns the ``x:``-prefixed JMAP method name for ``action`` (e.g. ``x:Account/get``)."""
 
-		return f"x:{self.type}/{action}"
+        return f"x:{self.type}/{action}"
 
-	def _call(self, method_calls: list[list]) -> list[dict]:
-		"""Sends one JMAP request and returns the unwrapped args of each method response in order."""
+    def _call(self, method_calls: list[list]) -> list[dict]:
+        """Sends one JMAP request and returns the unwrapped args of each method response in order."""
 
-		self._validate_capabilities()
+        self._validate_capabilities()
 
-		try:
-			response = self.connection.request(
-				method="POST",
-				url=self.connection.api_url,
-				headers={"Content-Type": "application/json"},
-				json={"using": [CORE_CAPABILITY, MANAGEMENT_CAPABILITY], "methodCalls": method_calls},
-				return_json=True,
-			)
-		except Exception as e:
-			self._fail(str(e))
-
-		session_state = response.get("sessionState")
-		if session_state and self.connection.state != session_state:
-			self.connection._session_discovery()
-
-		results = []
-		for method_response in response.get("methodResponses", []):
-			name, args = method_response[0], method_response[1]
-			if name == "error":
-				self._fail(frappe.as_json(args))
-			results.append(args)
-
-		return results
-
-	def _invoke(self, action: str, **args) -> dict:
-		"""Runs a single method call for this resource, dropping ``None`` arguments."""
-
-		args = {k: v for k, v in args.items() if v is not None}
-		args["accountId"] = self.account_id
-		return self._call([[self._method(action), args, "0"]])[0]
-
-	def _set(self, **args) -> dict:
-		"""Runs a ``set`` call and raises if the server reports any object it could not mutate."""
-
-		result = self._invoke("set", **args)
-		for key in ("notCreated", "notUpdated", "notDestroyed"):
-			if failures := result.get(key):
-				self._fail(frappe.as_json({key: failures}))
-		return result
-
-	def _resolve_properties(self, properties: list[str] | None) -> list[str] | None:
-		"""Falls back to the resource's ``default_properties`` when ``properties`` is not given."""
-
-		return properties if properties is not None else self.default_properties
-
-	# --- read --------------------------------------------------------------
-
-	def get(self, id: str, properties: list[str] | None = None) -> dict | None:
-		"""Returns a single object by id, or ``None`` if it does not exist."""
-
-		result = self._invoke("get", ids=[id], properties=self._resolve_properties(properties))
-		objects = result.get("list") or []
-		return objects[0] if objects else None
-
-	def get_all(
-		self,
-		filter: dict | None = None,
-		sort: list[dict] | None = None,
-		limit: int | None = None,
-		properties: list[str] | None = None,
-	) -> list[dict]:
-		"""Returns every matching object in a single request.
-
-		With no filter, one ``get`` (ids omitted) returns all objects. With a filter, ``query`` and
-		``get`` are chained through a JMAP result reference so the query's ids feed the get without a
-		second round-trip.
-		"""
-
-		properties = self._resolve_properties(properties)
-
-		if filter is None and sort is None and limit is None:
-			return self._invoke("get", properties=properties).get("list") or []
-
-		query_args = {"accountId": self.account_id}
-		query_args.update({k: v for k, v in {"filter": filter, "sort": sort, "limit": limit}.items() if v is not None})
-		get_args = {
-			"accountId": self.account_id,
-			"#ids": {"resultOf": "q", "name": self._method("query"), "path": "/ids"},
-		}
-		if properties is not None:
-			get_args["properties"] = properties
-
-		responses = self._call(
-			[[self._method("query"), query_args, "q"], [self._method("get"), get_args, "g"]]
-		)
-		return responses[1].get("list") or []
-
-	def query(
-		self,
-		filter: dict | None = None,
-		sort: list[dict] | None = None,
-		position: int = 0,
-		limit: int | None = None,
-		anchor: str | None = None,
-	) -> dict:
-		"""Returns ``{"ids", "total"}`` without fetching the objects, paging until ``limit``/exhausted.
-
-		Pages by offset (``position``) unless the resource is ``cursor_paginated`` or an ``anchor`` is
-		given, in which case each page starts *after* that id — the anchor is exclusive, and the server
-		ignores any offset alongside it.
-		"""
-
-		ids: list[str] = []
-		total: int | None = None
-		page = self.max_objects_in_get
-		by_cursor = self.cursor_paginated or anchor is not None
-		cursor = anchor
-
-		while True:
-			take = page if limit is None else min(page, limit - len(ids))
-			paging = {"anchor": cursor} if by_cursor else {"position": position}
-			result = self._invoke(
-				"query", filter=filter, sort=sort, limit=take, calculateTotal=total is None, **paging
-			)
-
-			batch = result.get("ids") or []
-			ids.extend(batch)
-			if total is None:
-				total = result.get("total")
-
-			if by_cursor:
-				cursor = batch[-1] if batch else cursor
-			else:
-				position += len(batch)
-			done = not batch or (total is not None and len(ids) >= total) or (limit is not None and len(ids) >= limit)
-			if done:
-				break
-
-		return {"ids": ids if limit is None else ids[:limit], "total": total}
-
-	def find(self, filter: dict, properties: list[str] | None = None) -> dict | None:
-		"""Returns the first object matching ``filter``, or ``None``."""
-
-		matches = self.get_all(filter=filter, limit=1, properties=properties)
-		return matches[0] if matches else None
-
-	def list_page(
-		self,
-		filter: dict | None = None,
-		sort: list[dict] | None = None,
-		position: int = 0,
-		limit: int | None = None,
-		properties: list[str] | None = None,
-		anchor: str | None = None,
-	) -> dict:
-		"""Returns ``{"items", "total"}`` — one page of full objects in query order.
-
-		Unlike ``get_all`` (which fetches everything), this pages via ``position``/``limit`` for
-		large collections such as the queue, or via ``anchor`` for cursor-only ones such as the log,
-		and preserves the query's ordering.
-		"""
-
-		page = self.query(filter=filter, sort=sort, position=position, limit=limit, anchor=anchor)
-		ids = page["ids"]
-		items: list[dict] = []
-		if ids:
-			result = self._invoke("get", ids=ids, properties=self._resolve_properties(properties))
-			by_id = {obj["id"]: obj for obj in (result.get("list") or [])}
-			items = [by_id[id] for id in ids if id in by_id]
-
-		return {"items": items, "total": page["total"]}
-
-	# --- write -------------------------------------------------------------
-
-	def _create(self, obj: Serializable) -> dict:
-		"""Creates one object and returns the created object including server-set fields."""
-
-		return self._set(create={"0": obj.to_dict()})["created"]["0"]
-
-	def create(self, obj: Serializable) -> str:
-		"""Creates one object and returns its server-assigned id."""
-
-		return self._create(obj)["id"]
-
-	def create_many(self, objs: list[Serializable]) -> list[str]:
-		"""Creates objects in batches and returns their ids in the same order."""
-
-		created: dict[str, dict] = {}
-		payload = {str(i): obj.to_dict() for i, obj in enumerate(objs)}
-		for batch in self._chunk_dict(payload, self.max_objects_in_set):
-			created.update(self._set(create=batch)["created"])
-
-		return [created[str(i)]["id"] for i in range(len(objs))]
-
-	def update(self, id: str, patch: dict) -> None:
-		"""Applies a partial update. ``patch`` keys may be property names or JSON-pointer paths."""
-
-		self._set(update={id: patch})
-
-	def update_many(self, patches: dict[str, dict]) -> None:
-		"""Applies partial updates to many objects (``{id: patch}``) in batches."""
-
-		for batch in self._chunk_dict(patches, self.max_objects_in_set):
-			self._set(update=batch)
-
-	def set_aliases(self, id: str, aliases: list[Serializable]) -> None:
-		"""Replaces the object's aliases with the given set (index-keyed map on the wire).
-
-		Shared by resources that carry an ``aliases`` map (accounts, groups, mailing lists).
-		"""
-
-		self.update(id, {"aliases": {f"{idx}": alias.to_dict() for idx, alias in enumerate(aliases)}})
-
-	def delete(self, ids: str | list[str]) -> None:
-		"""Deletes one id or a list of ids in batches."""
-
-		ids = [ids] if isinstance(ids, str) else list(ids)
-		for batch in self._chunks(ids, self.max_objects_in_set):
-			self._set(destroy=batch)
-
-	def changes(self, since_state: str) -> dict:
-		"""Returns the objects changed since ``since_state`` for delta sync."""
-
-		return self._invoke("changes", sinceState=since_state)
+        try:
+            response = self.connection.request(
+                method="POST",
+                url=self.connection.api_url,
+                headers={"Content-Type": "application/json"},
+                json={"using": [CORE_CAPABILITY, MANAGEMENT_CAPABILITY], "methodCalls": method_calls},
+                return_json=True,
+            )
+        except Exception as e:
+            self._fail(str(e))
+
+        session_state = response.get("sessionState")
+        if session_state and self.connection.state != session_state:
+            self.connection._session_discovery()
+
+        results = []
+        for method_response in response.get("methodResponses", []):
+            name, args = method_response[0], method_response[1]
+            if name == "error":
+                self._fail(frappe.as_json(args))
+            results.append(args)
+
+        return results
+
+    def _invoke(self, action: str, **args) -> dict:
+        """Runs a single method call for this resource, dropping ``None`` arguments."""
+
+        args = {k: v for k, v in args.items() if v is not None}
+        args["accountId"] = self.account_id
+        return self._call([[self._method(action), args, "0"]])[0]
+
+    def _set(self, **args) -> dict:
+        """Runs a ``set`` call and raises if the server reports any object it could not mutate."""
+
+        result = self._invoke("set", **args)
+        for key in ("notCreated", "notUpdated", "notDestroyed"):
+            if failures := result.get(key):
+                self._fail(frappe.as_json({key: failures}))
+        return result
+
+    def _resolve_properties(self, properties: list[str] | None) -> list[str] | None:
+        """Falls back to the resource's ``default_properties`` when ``properties`` is not given."""
+
+        return properties if properties is not None else self.default_properties
+
+    # --- read --------------------------------------------------------------
+
+    def get(self, id: str, properties: list[str] | None = None) -> dict | None:
+        """Returns a single object by id, or ``None`` if it does not exist."""
+
+        result = self._invoke("get", ids=[id], properties=self._resolve_properties(properties))
+        objects = result.get("list") or []
+        return objects[0] if objects else None
+
+    def get_all(
+        self,
+        filter: dict | None = None,
+        sort: list[dict] | None = None,
+        limit: int | None = None,
+        properties: list[str] | None = None,
+    ) -> list[dict]:
+        """Returns every matching object in a single request.
+
+        With no filter, one ``get`` (ids omitted) returns all objects. With a filter, ``query`` and
+        ``get`` are chained through a JMAP result reference so the query's ids feed the get without a
+        second round-trip.
+        """
+
+        properties = self._resolve_properties(properties)
+
+        if filter is None and sort is None and limit is None:
+            return self._invoke("get", properties=properties).get("list") or []
+
+        query_args = {"accountId": self.account_id}
+        query_args.update(
+            {k: v for k, v in {"filter": filter, "sort": sort, "limit": limit}.items() if v is not None}
+        )
+        get_args = {
+            "accountId": self.account_id,
+            "#ids": {"resultOf": "q", "name": self._method("query"), "path": "/ids"},
+        }
+        if properties is not None:
+            get_args["properties"] = properties
+
+        responses = self._call(
+            [[self._method("query"), query_args, "q"], [self._method("get"), get_args, "g"]]
+        )
+        return responses[1].get("list") or []
+
+    def query(
+        self,
+        filter: dict | None = None,
+        sort: list[dict] | None = None,
+        position: int = 0,
+        limit: int | None = None,
+        anchor: str | None = None,
+    ) -> dict:
+        """Returns ``{"ids", "total"}`` without fetching the objects, paging until ``limit``/exhausted.
+
+        Pages by offset (``position``) unless the resource is ``cursor_paginated`` or an ``anchor`` is
+        given, in which case each page starts *after* that id — the anchor is exclusive, and the server
+        ignores any offset alongside it.
+        """
+
+        ids: list[str] = []
+        total: int | None = None
+        page = self.max_objects_in_get
+        by_cursor = self.cursor_paginated or anchor is not None
+        cursor = anchor
+
+        while True:
+            take = page if limit is None else min(page, limit - len(ids))
+            paging = {"anchor": cursor} if by_cursor else {"position": position}
+            result = self._invoke(
+                "query", filter=filter, sort=sort, limit=take, calculateTotal=total is None, **paging
+            )
+
+            batch = result.get("ids") or []
+            ids.extend(batch)
+            if total is None:
+                total = result.get("total")
+
+            if by_cursor:
+                cursor = batch[-1] if batch else cursor
+            else:
+                position += len(batch)
+            done = (
+                not batch
+                or (total is not None and len(ids) >= total)
+                or (limit is not None and len(ids) >= limit)
+            )
+            if done:
+                break
+
+        return {"ids": ids if limit is None else ids[:limit], "total": total}
+
+    def find(self, filter: dict, properties: list[str] | None = None) -> dict | None:
+        """Returns the first object matching ``filter``, or ``None``."""
+
+        matches = self.get_all(filter=filter, limit=1, properties=properties)
+        return matches[0] if matches else None
+
+    def list_page(
+        self,
+        filter: dict | None = None,
+        sort: list[dict] | None = None,
+        position: int = 0,
+        limit: int | None = None,
+        properties: list[str] | None = None,
+        anchor: str | None = None,
+    ) -> dict:
+        """Returns ``{"items", "total"}`` — one page of full objects in query order.
+
+        Unlike ``get_all`` (which fetches everything), this pages via ``position``/``limit`` for
+        large collections such as the queue, or via ``anchor`` for cursor-only ones such as the log,
+        and preserves the query's ordering.
+        """
+
+        page = self.query(filter=filter, sort=sort, position=position, limit=limit, anchor=anchor)
+        ids = page["ids"]
+        items: list[dict] = []
+        if ids:
+            result = self._invoke("get", ids=ids, properties=self._resolve_properties(properties))
+            by_id = {obj["id"]: obj for obj in (result.get("list") or [])}
+            items = [by_id[id] for id in ids if id in by_id]
+
+        return {"items": items, "total": page["total"]}
+
+    # --- write -------------------------------------------------------------
+
+    def _create(self, obj: Serializable) -> dict:
+        """Creates one object and returns the created object including server-set fields."""
+
+        return self._set(create={"0": obj.to_dict()})["created"]["0"]
+
+    def create(self, obj: Serializable) -> str:
+        """Creates one object and returns its server-assigned id."""
+
+        return self._create(obj)["id"]
+
+    def create_many(self, objs: list[Serializable]) -> list[str]:
+        """Creates objects in batches and returns their ids in the same order."""
+
+        created: dict[str, dict] = {}
+        payload = {str(i): obj.to_dict() for i, obj in enumerate(objs)}
+        for batch in self._chunk_dict(payload, self.max_objects_in_set):
+            created.update(self._set(create=batch)["created"])
+
+        return [created[str(i)]["id"] for i in range(len(objs))]
+
+    def update(self, id: str, patch: dict) -> None:
+        """Applies a partial update. ``patch`` keys may be property names or JSON-pointer paths."""
+
+        self._set(update={id: patch})
+
+    def update_many(self, patches: dict[str, dict]) -> None:
+        """Applies partial updates to many objects (``{id: patch}``) in batches."""
+
+        for batch in self._chunk_dict(patches, self.max_objects_in_set):
+            self._set(update=batch)
+
+    def set_aliases(self, id: str, aliases: list[Serializable]) -> None:
+        """Replaces the object's aliases with the given set (index-keyed map on the wire).
+
+        Shared by resources that carry an ``aliases`` map (accounts, groups, mailing lists).
+        """
+
+        self.update(id, {"aliases": {f"{idx}": alias.to_dict() for idx, alias in enumerate(aliases)}})
+
+    def delete(self, ids: str | list[str]) -> None:
+        """Deletes one id or a list of ids in batches."""
+
+        ids = [ids] if isinstance(ids, str) else list(ids)
+        for batch in self._chunks(ids, self.max_objects_in_set):
+            self._set(destroy=batch)
+
+    def changes(self, since_state: str) -> dict:
+        """Returns the objects changed since ``since_state`` for delta sync."""
+
+        return self._invoke("changes", sinceState=since_state)

--- a/suite/mail/store/__init__.py
+++ b/suite/mail/store/__init__.py
@@ -6,10 +6,10 @@ from frappe.utils import create_batch
 
 from suite.mail.store.indexes import EmailAddressIndex
 from suite.store import (
-	destroy_namespace,
-	get_blob_base_path,
-	get_data_base_path,
-	get_search_base_path,
+    destroy_namespace,
+    get_blob_base_path,
+    get_data_base_path,
+    get_search_base_path,
 )
 from suite.store.blob_store import BlobStore
 from suite.store.data_store import DataStore
@@ -27,180 +27,180 @@ _ACCOUNTS_PER_REBUILD_BATCH = 25
 
 
 class Entity(Enum):
-	"""Defines the different types of entities that can be stored in the DataStore."""
+    """Defines the different types of entities that can be stored in the DataStore."""
 
-	STATE = "state"
+    STATE = "state"
 
-	IDENTITY = "identity"
-	MAILBOX = "mailbox"
-	EMAIL = "email"
+    IDENTITY = "identity"
+    MAILBOX = "mailbox"
+    EMAIL = "email"
 
-	PARTICIPANT_IDENTITY = "participant_identity"
-	CALENDAR = "calendar"
-	EVENT = "event"
+    PARTICIPANT_IDENTITY = "participant_identity"
+    CALENDAR = "calendar"
+    EVENT = "event"
 
-	ADDRESS_BOOK = "address_book"
-	CONTACT_CARD = "contact_card"
+    ADDRESS_BOOK = "address_book"
+    CONTACT_CARD = "contact_card"
 
 
 def get_account_namespace(account: str) -> tuple[str, str]:
-	"""Return the namespace for a JMAP account: ``("mail", <account>)``.
+    """Return the namespace for a JMAP account: ``("mail", <account>)``.
 
-	Each account's data store, blob store and search indexes live at ``mail/<account>`` under
-	their respective base paths, so accounts are isolated from one another and from other apps.
-	"""
+    Each account's data store, blob store and search indexes live at ``mail/<account>`` under
+    their respective base paths, so accounts are isolated from one another and from other apps.
+    """
 
-	return (MAIL_NAMESPACE, account)
+    return (MAIL_NAMESPACE, account)
 
 
 def get_data_store(account: str) -> DataStore:
-	"""Factory function to create a DataStore instance for the given JMAP account ID.
+    """Factory function to create a DataStore instance for the given JMAP account ID.
 
-	The store is keyed solely by the account, so every user with access to a shared account
-	reads and writes the same cache. LMDB serves concurrent access natively — many lock-free
-	readers via MVCC snapshots and a single serialized writer — so multiple users (and worker
-	processes) can hit the same account's store safely.
-	"""
+    The store is keyed solely by the account, so every user with access to a shared account
+    reads and writes the same cache. LMDB serves concurrent access natively — many lock-free
+    readers via MVCC snapshots and a single serialized writer — so multiple users (and worker
+    processes) can hit the same account's store safely.
+    """
 
-	return DataStore(base_path=get_data_base_path(), namespace=get_account_namespace(account))
+    return DataStore(base_path=get_data_base_path(), namespace=get_account_namespace(account))
 
 
 def get_blob_store(account: str) -> BlobStore:
-	"""Factory function to create a BlobStore instance for the given JMAP account ID.
+    """Factory function to create a BlobStore instance for the given JMAP account ID.
 
-	Each account's blobs live in their own directory, so the blob cache is shared across every
-	user of an account. Writes are atomic (temp file + ``os.replace``) and reads open the file
-	independently, so concurrent access from multiple users/processes is safe.
-	"""
+    Each account's blobs live in their own directory, so the blob cache is shared across every
+    user of an account. Writes are atomic (temp file + ``os.replace``) and reads open the file
+    independently, so concurrent access from multiple users/processes is safe.
+    """
 
-	return BlobStore(base_path=get_blob_base_path(), namespace=get_account_namespace(account))
+    return BlobStore(base_path=get_blob_base_path(), namespace=get_account_namespace(account))
 
 
 def get_email_address_index(account: str) -> EmailAddressIndex:
-	"""Get the EmailAddressIndex for the given JMAP account ID."""
+    """Get the EmailAddressIndex for the given JMAP account ID."""
 
-	return EmailAddressIndex(get_account_namespace(account))
+    return EmailAddressIndex(get_account_namespace(account))
 
 
 @frappe.whitelist()
 def destroy_data_store() -> None:
-	"""Delete every mail data store for the current site. System Manager only.
+    """Delete every mail data store for the current site. System Manager only.
 
-	Removes only the ``mail`` namespace, leaving any other apps' data stores intact.
-	"""
+    Removes only the ``mail`` namespace, leaving any other apps' data stores intact.
+    """
 
-	from suite.utils.user import is_system_manager
+    from suite.utils.user import is_system_manager
 
-	if not is_system_manager(frappe.session.user):
-		frappe.throw(_("Only System Manager can destroy the data store."))
+    if not is_system_manager(frappe.session.user):
+        frappe.throw(_("Only System Manager can destroy the data store."))
 
-	destroy_namespace(get_data_base_path(), MAIL_NAMESPACE)
+    destroy_namespace(get_data_base_path(), MAIL_NAMESPACE)
 
 
 @frappe.whitelist()
 def destroy_blob_store() -> None:
-	"""Delete every mail blob store for the current site. System Manager only.
+    """Delete every mail blob store for the current site. System Manager only.
 
-	Removes only the ``mail`` namespace, leaving any other apps' blob stores intact.
-	"""
+    Removes only the ``mail`` namespace, leaving any other apps' blob stores intact.
+    """
 
-	from suite.utils.user import is_system_manager
+    from suite.utils.user import is_system_manager
 
-	if not is_system_manager(frappe.session.user):
-		frappe.throw(_("Only System Manager can destroy the blob store."))
+    if not is_system_manager(frappe.session.user):
+        frappe.throw(_("Only System Manager can destroy the blob store."))
 
-	destroy_namespace(get_blob_base_path(), MAIL_NAMESPACE)
+    destroy_namespace(get_blob_base_path(), MAIL_NAMESPACE)
 
 
 @frappe.whitelist()
 def destroy_search_index() -> None:
-	"""Delete every mail search index for the current site. System Manager only.
+    """Delete every mail search index for the current site. System Manager only.
 
-	Removes only the ``mail`` namespace, leaving any other apps' search indexes intact.
-	"""
+    Removes only the ``mail`` namespace, leaving any other apps' search indexes intact.
+    """
 
-	from suite.utils.user import is_system_manager
+    from suite.utils.user import is_system_manager
 
-	if not is_system_manager(frappe.session.user):
-		frappe.throw(_("Only System Manager can destroy the search index."))
+    if not is_system_manager(frappe.session.user):
+        frappe.throw(_("Only System Manager can destroy the search index."))
 
-	destroy_namespace(get_search_base_path(), MAIL_NAMESPACE)
+    destroy_namespace(get_search_base_path(), MAIL_NAMESPACE)
 
 
 def rebuild_email_address_index(account: str, in_background: bool = True) -> None:
-	"""Rebuild an account's email-address index from scratch.
+    """Rebuild an account's email-address index from scratch.
 
-	Drops the existing index, then re-indexes every cached mail message and contact card in
-	batches (bounding memory and the size of each index commit). Runs in a background job by
-	default; pass `in_background=False` to run inline (e.g. from within the job itself).
-	"""
+    Drops the existing index, then re-indexes every cached mail message and contact card in
+    batches (bounding memory and the size of each index commit). Runs in a background job by
+    default; pass `in_background=False` to run inline (e.g. from within the job itself).
+    """
 
-	if in_background:
-		enqueue_job(
-			rebuild_email_address_index,
-			job_id=f"rebuild-email-address-index::{account}",
-			deduplicate=True,
-			queue="long",
-			timeout=3600,
-			account=account,
-			in_background=False,
-		)
-		return
+    if in_background:
+        enqueue_job(
+            rebuild_email_address_index,
+            job_id=f"rebuild-email-address-index::{account}",
+            deduplicate=True,
+            queue="long",
+            timeout=3600,
+            account=account,
+            in_background=False,
+        )
+        return
 
-	# Imported lazily: these modules import this package, so a top-level import would be circular.
-	from suite.mail.doctype.contact_card.contact_card import _contact_addresses
-	from suite.mail.doctype.mail_message.mail_message import _message_addresses
+    # Imported lazily: these modules import this package, so a top-level import would be circular.
+    from suite.mail.doctype.contact_card.contact_card import _contact_addresses
+    from suite.mail.doctype.mail_message.mail_message import _message_addresses
 
-	# Drop the stale index, then take a fresh handle so its directory is recreated before writing.
-	get_email_address_index(account).drop()
-	index = get_email_address_index(account)
+    # Drop the stale index, then take a fresh handle so its directory is recreated before writing.
+    get_email_address_index(account).drop()
+    index = get_email_address_index(account)
 
-	store = get_data_store(account)
+    store = get_data_store(account)
 
-	messages = list(store.scan(Entity.EMAIL).values())
-	for batch in create_batch(messages, _REBUILD_BATCH_SIZE):
-		index.index_addresses(_message_addresses(batch))
+    messages = list(store.scan(Entity.EMAIL).values())
+    for batch in create_batch(messages, _REBUILD_BATCH_SIZE):
+        index.index_addresses(_message_addresses(batch))
 
-	contact_cards = list(store.scan(Entity.CONTACT_CARD).values())
-	for batch in create_batch(contact_cards, _REBUILD_BATCH_SIZE):
-		index.index_addresses(_contact_addresses(batch))
+    contact_cards = list(store.scan(Entity.CONTACT_CARD).values())
+    for batch in create_batch(contact_cards, _REBUILD_BATCH_SIZE):
+        index.index_addresses(_contact_addresses(batch))
 
 
 @frappe.whitelist()
 def rebuild_all_email_address_indexes() -> None:
-	"""Rebuild the email-address index for every JMAP account. System Manager only.
+    """Rebuild the email-address index for every JMAP account. System Manager only.
 
-	Fans the accounts out into long-queue background jobs of `_ACCOUNTS_PER_REBUILD_BATCH` each;
-	every job rebuilds its accounts inline. Safe to run from a scheduler or the console.
-	"""
+    Fans the accounts out into long-queue background jobs of `_ACCOUNTS_PER_REBUILD_BATCH` each;
+    every job rebuilds its accounts inline. Safe to run from a scheduler or the console.
+    """
 
-	from suite.utils.user import is_system_manager
+    from suite.utils.user import is_system_manager
 
-	if not is_system_manager(frappe.session.user):
-		frappe.throw(_("Only System Manager can rebuild the email address indexes."))
+    if not is_system_manager(frappe.session.user):
+        frappe.throw(_("Only System Manager can rebuild the email address indexes."))
 
-	accounts = frappe.db.get_all("JMAP Account", {}, pluck="name")
-	for i, batch in enumerate(create_batch(accounts, _ACCOUNTS_PER_REBUILD_BATCH)):
-		enqueue_job(
-			_rebuild_email_address_indexes,
-			job_id=f"rebuild-email-address-indexes::{i}",
-			deduplicate=True,
-			queue="long",
-			timeout=3600,
-			accounts=batch,
-		)
+    accounts = frappe.db.get_all("JMAP Account", {}, pluck="name")
+    for i, batch in enumerate(create_batch(accounts, _ACCOUNTS_PER_REBUILD_BATCH)):
+        enqueue_job(
+            _rebuild_email_address_indexes,
+            job_id=f"rebuild-email-address-indexes::{i}",
+            deduplicate=True,
+            queue="long",
+            timeout=3600,
+            accounts=batch,
+        )
 
 
 def _rebuild_email_address_indexes(accounts: list[str]) -> None:
-	"""Rebuild each account's email-address index inline, isolating per-account failures."""
+    """Rebuild each account's email-address index inline, isolating per-account failures."""
 
-	from suite.mail.utils import log_mail_error
+    from suite.mail.utils import log_mail_error
 
-	for account in accounts:
-		try:
-			rebuild_email_address_index(account, in_background=False)
-		except Exception:
-			log_mail_error(
-				_("Failed to rebuild email address index for account {0}").format(account),
-				frappe.get_traceback(with_context=True),
-			)
+    for account in accounts:
+        try:
+            rebuild_email_address_index(account, in_background=False)
+        except Exception:
+            log_mail_error(
+                _("Failed to rebuild email address index for account {0}").format(account),
+                frappe.get_traceback(with_context=True),
+            )

--- a/suite/mail/store/indexes/email_address.py
+++ b/suite/mail/store/indexes/email_address.py
@@ -6,60 +6,60 @@ _TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
 
 
 class EmailAddressIndex(SearchStore):
-	"""Shared, per-account index of email addresses for recipient suggestions.
+    """Shared, per-account index of email addresses for recipient suggestions.
 
-	Sources (cached messages, contact cards, ...) feed in plain {name, email} dicts, so the index
-	knows nothing about where an address came from. Each document is keyed by the lowercased
-	address, so re-indexing the same address from any source is an upsert and addresses stay unique
-	by construction. The index is cumulative: entries are only added or updated, never removed when
-	a source is evicted, so it doubles as an address book of everyone the user has corresponded with.
-	"""
+    Sources (cached messages, contact cards, ...) feed in plain {name, email} dicts, so the index
+    knows nothing about where an address came from. Each document is keyed by the lowercased
+    address, so re-indexing the same address from any source is an upsert and addresses stay unique
+    by construction. The index is cumulative: entries are only added or updated, never removed when
+    a source is evicted, so it doubles as an address book of everyone the user has corresponded with.
+    """
 
-	ENTITY = "email_address"
-	FIELDS = (
-		# Lowercased address; the unique document key, so the same address upserts across sources.
-		FieldSpec("id", stored=True, tokenizer="raw"),
-		# Original-cased address and display name, returned verbatim in suggestions.
-		FieldSpec("email", stored=True, tokenizer="raw"),
-		FieldSpec("name", stored=True, tokenizer="raw"),
-		# "name email" blob, tokenized so a query can match either part.
-		FieldSpec("text"),
-	)
-	DEFAULT_SEARCH_FIELDS = ("text",)
+    ENTITY = "email_address"
+    FIELDS = (
+        # Lowercased address; the unique document key, so the same address upserts across sources.
+        FieldSpec("id", stored=True, tokenizer="raw"),
+        # Original-cased address and display name, returned verbatim in suggestions.
+        FieldSpec("email", stored=True, tokenizer="raw"),
+        FieldSpec("name", stored=True, tokenizer="raw"),
+        # "name email" blob, tokenized so a query can match either part.
+        FieldSpec("text"),
+    )
+    DEFAULT_SEARCH_FIELDS = ("text",)
 
-	def to_document(self, address: dict) -> dict:
-		email = (address.get("email") or "").strip()
-		name = (address.get("name") or "").strip() or None
+    def to_document(self, address: dict) -> dict:
+        email = (address.get("email") or "").strip()
+        name = (address.get("name") or "").strip() or None
 
-		return {
-			"id": email.lower(),
-			"email": email,
-			"name": name,
-			"text": " ".join(filter(None, (name, email))),
-		}
+        return {
+            "id": email.lower(),
+            "email": email,
+            "name": name,
+            "text": " ".join(filter(None, (name, email))),
+        }
 
-	def index_addresses(self, addresses: list[dict]) -> int:
-		"""Upsert the given {name, email} dicts; skips entries without an email and dedupes the batch."""
+    def index_addresses(self, addresses: list[dict]) -> int:
+        """Upsert the given {name, email} dicts; skips entries without an email and dedupes the batch."""
 
-		unique = {}
-		for address in addresses:
-			if email := (address.get("email") or "").strip():
-				unique[email.lower()] = address
+        unique = {}
+        for address in addresses:
+            if email := (address.get("email") or "").strip():
+                unique[email.lower()] = address
 
-		return self.index_documents(list(unique.values()))
+        return self.index_documents(list(unique.values()))
 
-	def search_email_addresses(self, query: str, limit: int = 10) -> list[dict]:
-		"""Return up to `limit` {name, email} addresses matching `query`, most relevant first.
+    def search_email_addresses(self, query: str, limit: int = 10) -> list[dict]:
+        """Return up to `limit` {name, email} addresses matching `query`, most relevant first.
 
-		The query's tokens must appear as a consecutive, in-order phrase in the address's name or
-		email, with the last token matched as a prefix. So "saga" matches "sagar", and "sagar.s"
-		matches "sagar.s@…" / "Sagar Sharma" but not "sagar@…" or "sagar.v@…". Documents are unique
-		per address, so the hits need no further deduping.
-		"""
+        The query's tokens must appear as a consecutive, in-order phrase in the address's name or
+        email, with the last token matched as a prefix. So "saga" matches "sagar", and "sagar.s"
+        matches "sagar.s@…" / "Sagar Sharma" but not "sagar@…" or "sagar.v@…". Documents are unique
+        per address, so the hits need no further deduping.
+        """
 
-		tokens = _TOKEN_PATTERN.findall(query.lower()) if query else []
-		if not tokens:
-			return []
+        tokens = _TOKEN_PATTERN.findall(query.lower()) if query else []
+        if not tokens:
+            return []
 
-		hits, _total_count = self.search_phrase_prefix(tokens, limit=limit)
-		return [{"name": hit.get("name"), "email": hit.get("email")} for hit in hits]
+        hits, _total_count = self.search_phrase_prefix(tokens, limit=limit)
+        return [{"name": hit.get("name"), "email": hit.get("email")} for hit in hits]

--- a/suite/mail/utils/__init__.py
+++ b/suite/mail/utils/__init__.py
@@ -10,233 +10,233 @@ from frappe.utils.caching import request_cache
 from suite.utils import log_error
 
 CONFIG_KEYS = [
-	# JMAP
-	"server_url",
-	"username",
-	"password",
-	"verify_ssl",
-	# SpamAssassin
-	"spamd_host",
-	"spamd_port",
-	"spamd_scanning_mode",
-	"spamd_hybrid_scanning_threshold",
-	# Defaults
-	"default_dns_ttl",
-	"default_disk_quota_gb",
-	"disabled_account_role",
-	"enable_gravatar",
-	"default_gravatar",
-	"stalwart_version",
-	"stalwart_cli_version",
-	# Logs
-	"admin_log_file_count",
-	"admin_log_level",
-	"admin_log_max_file_size",
-	"push_log_file_count",
-	"push_log_level",
-	"push_log_max_file_size",
-	"inbound_log_file_count",
-	"inbound_log_level",
-	"inbound_log_max_file_size",
-	"outbound_log_file_count",
-	"outbound_log_level",
-	"outbound_log_max_file_size",
-	"exchange_log_file_count",
-	"exchange_log_level",
-	"exchange_log_max_file_size",
-	# Limits
-	"exchange_max_export",
-	"exchange_max_import",
-	"exchange_export_batch_size",
-	"max_email_sync",
-	"max_message_payload_size_mb",
-	"max_push_notifications",
-	"process_pending_emails_batch_size",
-	"process_pending_emails_max_batch_size",
-	# Timeouts
-	"ansible_play_timeout",
-	"server_job_timeout",
-	"server_deployment_timeout",
-	"scan_message_timeout",
-	"process_pending_emails_timeout",
-	"stalwart_cli_command_timeout",
-	"exchange_export_timeout",
-	"exchange_import_timeout",
+    # JMAP
+    "server_url",
+    "username",
+    "password",
+    "verify_ssl",
+    # SpamAssassin
+    "spamd_host",
+    "spamd_port",
+    "spamd_scanning_mode",
+    "spamd_hybrid_scanning_threshold",
+    # Defaults
+    "default_dns_ttl",
+    "default_disk_quota_gb",
+    "disabled_account_role",
+    "enable_gravatar",
+    "default_gravatar",
+    "stalwart_version",
+    "stalwart_cli_version",
+    # Logs
+    "admin_log_file_count",
+    "admin_log_level",
+    "admin_log_max_file_size",
+    "push_log_file_count",
+    "push_log_level",
+    "push_log_max_file_size",
+    "inbound_log_file_count",
+    "inbound_log_level",
+    "inbound_log_max_file_size",
+    "outbound_log_file_count",
+    "outbound_log_level",
+    "outbound_log_max_file_size",
+    "exchange_log_file_count",
+    "exchange_log_level",
+    "exchange_log_max_file_size",
+    # Limits
+    "exchange_max_export",
+    "exchange_max_import",
+    "exchange_export_batch_size",
+    "max_email_sync",
+    "max_message_payload_size_mb",
+    "max_push_notifications",
+    "process_pending_emails_batch_size",
+    "process_pending_emails_max_batch_size",
+    # Timeouts
+    "ansible_play_timeout",
+    "server_job_timeout",
+    "server_deployment_timeout",
+    "scan_message_timeout",
+    "process_pending_emails_timeout",
+    "stalwart_cli_command_timeout",
+    "exchange_export_timeout",
+    "exchange_import_timeout",
 ]
 
 
 @request_cache
 def get_config(key: str | tuple[str, ...] | None = None) -> dict[str, Any] | tuple | Any:
-	"""Fetches configuration values, prioritizing Mail Settings over global config.
+    """Fetches configuration values, prioritizing Mail Settings over global config.
 
-	Cached per request: the returned dict is shared, so callers must treat it as read-only.
-	"""
+    Cached per request: the returned dict is shared, so callers must treat it as read-only.
+    """
 
-	mail_conf = frappe.conf.mail or {}
-	settings = frappe.get_cached_doc("Mail Settings")
+    mail_conf = frappe.conf.mail or {}
+    settings = frappe.get_cached_doc("Mail Settings")
 
-	config = {}
-	for field in CONFIG_KEYS:
-		if field == "password":
-			config[field] = password_or_none(settings, field) or mail_conf.get(field)
-		else:
-			config[field] = settings.get(field) or mail_conf.get(field)
+    config = {}
+    for field in CONFIG_KEYS:
+        if field == "password":
+            config[field] = password_or_none(settings, field) or mail_conf.get(field)
+        else:
+            config[field] = settings.get(field) or mail_conf.get(field)
 
-	if key:
-		if isinstance(key, str):
-			key = [key]
+    if key:
+        if isinstance(key, str):
+            key = [key]
 
-		for k in key:
-			if k not in config:
-				frappe.throw(_("Mail config key '{0}' not found").format(k))
+        for k in key:
+            if k not in config:
+                frappe.throw(_("Mail config key '{0}' not found").format(k))
 
-		return tuple(config[k] for k in key) if len(key) > 1 else config[key[0]]
+        return tuple(config[k] for k in key) if len(key) > 1 else config[key[0]]
 
-	return config
+    return config
 
 
 def is_stalwart_configured(raise_exception: bool = False) -> bool:
-	"""Checks if the Stalwart server is properly configured."""
+    """Checks if the Stalwart server is properly configured."""
 
-	config = get_config()
+    config = get_config()
 
-	server_url = config.get("server_url")
-	username = config.get("username")
-	password = config.get("password")
+    server_url = config.get("server_url")
+    username = config.get("username")
+    password = config.get("password")
 
-	if server_url and (username and password):
-		return True
+    if server_url and (username and password):
+        return True
 
-	if raise_exception:
-		frappe.throw(_("Stalwart server is not properly configured. Please check your Mail Settings."))
+    if raise_exception:
+        frappe.throw(_("Stalwart server is not properly configured. Please check your Mail Settings."))
 
-	return False
+    return False
 
 
 def log_mail_error(title: str | None = None, message: str | None = None, **kwargs) -> None:
-	"""Logs an error, prefixing the title with "[Mail]" so mail errors can be filtered out."""
+    """Logs an error, prefixing the title with "[Mail]" so mail errors can be filtered out."""
 
-	log_error("Mail", title=title, message=message, **kwargs)
+    log_error("Mail", title=title, message=message, **kwargs)
 
 
 def get_mbox_files(base_dir: str) -> list[str]:
-	"""Recursively find and return all .mbox files under the given directory."""
+    """Recursively find and return all .mbox files under the given directory."""
 
-	mbox_files = [
-		os.path.join(root, filename)
-		for root, _, files in os.walk(base_dir)
-		for filename in files
-		if filename.endswith(".mbox")
-	]
-	return mbox_files
+    mbox_files = [
+        os.path.join(root, filename)
+        for root, _, files in os.walk(base_dir)
+        for filename in files
+        if filename.endswith(".mbox")
+    ]
+    return mbox_files
 
 
 def flatten_dict(d, parent_key="", sep=".") -> dict:
-	"""Recursively flattens a nested dictionary into dot notation."""
+    """Recursively flattens a nested dictionary into dot notation."""
 
-	items = {}
-	for k, v in d.items():
-		new_key = f"{parent_key}{sep}{k}" if parent_key else k
-		if isinstance(v, dict):
-			items.update(flatten_dict(v, new_key, sep))
-		else:
-			items[new_key] = v
-	return items
+    items = {}
+    for k, v in d.items():
+        new_key = f"{parent_key}{sep}{k}" if parent_key else k
+        if isinstance(v, dict):
+            items.update(flatten_dict(v, new_key, sep))
+        else:
+            items[new_key] = v
+    return items
 
 
 def password_or_none(doc, field: str) -> str | None:
-	"""Returns the password if the field is set, otherwise returns None."""
+    """Returns the password if the field is set, otherwise returns None."""
 
-	return doc.get_password(field) if doc.get(field) else None
+    return doc.get_password(field) if doc.get(field) else None
 
 
 def generate_uuid_style_hash(input_str: str) -> str:
-	"""Generates a UUID-style hash from the input string."""
+    """Generates a UUID-style hash from the input string."""
 
-	hash = hashlib.md5(input_str.encode()).hexdigest()
-	return f"{hash[:8]}-{hash[8:12]}-{hash[12:16]}-{hash[16:20]}-{hash[20:]}"
+    hash = hashlib.md5(input_str.encode()).hexdigest()
+    return f"{hash[:8]}-{hash[8:12]}-{hash[12:16]}-{hash[16:20]}-{hash[20:]}"
 
 
 def get_mail_app_path() -> str:
-	"""Returns the path to the Suite app directory."""
+    """Returns the path to the Suite app directory."""
 
-	return os.path.join(get_bench_path(), "apps/suite")
+    return os.path.join(get_bench_path(), "apps/suite")
 
 
 def get_messages_directory() -> str:
-	"""Returns the path to the messages directory for the current site."""
+    """Returns the path to the messages directory for the current site."""
 
-	directory = os.path.join(get_bench_path(), "sites", frappe.local.site, "raw_messages")
-	os.makedirs(directory, exist_ok=True)
-	return directory
+    directory = os.path.join(get_bench_path(), "sites", frappe.local.site, "raw_messages")
+    os.makedirs(directory, exist_ok=True)
+    return directory
 
 
 def get_mail_import_directory() -> str:
-	"""Returns the path to the mail import directory for the current site."""
+    """Returns the path to the mail import directory for the current site."""
 
-	directory = os.path.join(get_bench_path(), "sites", frappe.local.site, "mail-exchange", "import")
-	os.makedirs(directory, exist_ok=True)
-	return directory
+    directory = os.path.join(get_bench_path(), "sites", frappe.local.site, "mail-exchange", "import")
+    os.makedirs(directory, exist_ok=True)
+    return directory
 
 
 def get_mail_export_directory() -> str:
-	"""Returns the path to the mail export directory for the current site."""
+    """Returns the path to the mail export directory for the current site."""
 
-	directory = os.path.join(get_bench_path(), "sites", frappe.local.site, "mail-exchange", "export")
-	os.makedirs(directory, exist_ok=True)
-	return directory
+    directory = os.path.join(get_bench_path(), "sites", frappe.local.site, "mail-exchange", "export")
+    os.makedirs(directory, exist_ok=True)
+    return directory
 
 
 def get_calendar_import_directory() -> str:
-	"""Returns the path to the calendar import directory for the current site."""
+    """Returns the path to the calendar import directory for the current site."""
 
-	directory = os.path.join(get_bench_path(), "sites", frappe.local.site, "calendar-exchange", "import")
-	os.makedirs(directory, exist_ok=True)
-	return directory
+    directory = os.path.join(get_bench_path(), "sites", frappe.local.site, "calendar-exchange", "import")
+    os.makedirs(directory, exist_ok=True)
+    return directory
 
 
 def get_calendar_export_directory() -> str:
-	"""Returns the path to the calendar export directory for the current site."""
+    """Returns the path to the calendar export directory for the current site."""
 
-	directory = os.path.join(get_bench_path(), "sites", frappe.local.site, "calendar-exchange", "export")
-	os.makedirs(directory, exist_ok=True)
-	return directory
+    directory = os.path.join(get_bench_path(), "sites", frappe.local.site, "calendar-exchange", "export")
+    os.makedirs(directory, exist_ok=True)
+    return directory
 
 
 def get_contacts_import_directory() -> str:
-	"""Returns the path to the contacts import directory for the current site."""
+    """Returns the path to the contacts import directory for the current site."""
 
-	directory = os.path.join(get_bench_path(), "sites", frappe.local.site, "contacts-exchange", "import")
-	os.makedirs(directory, exist_ok=True)
-	return directory
+    directory = os.path.join(get_bench_path(), "sites", frappe.local.site, "contacts-exchange", "import")
+    os.makedirs(directory, exist_ok=True)
+    return directory
 
 
 def get_contacts_export_directory() -> str:
-	"""Returns the path to the contacts export directory for the current site."""
+    """Returns the path to the contacts export directory for the current site."""
 
-	directory = os.path.join(get_bench_path(), "sites", frappe.local.site, "contacts-exchange", "export")
-	os.makedirs(directory, exist_ok=True)
-	return directory
+    directory = os.path.join(get_bench_path(), "sites", frappe.local.site, "contacts-exchange", "export")
+    os.makedirs(directory, exist_ok=True)
+    return directory
 
 
 def get_stalwart_cli_path(raise_exception: bool = False) -> str:
-	"""Returns the path to the Stalwart CLI tool, raising an error if not found."""
+    """Returns the path to the Stalwart CLI tool, raising an error if not found."""
 
-	cli_path = os.path.join(get_mail_app_path(), "stalwart-cli")
-	if not os.path.exists(cli_path) and raise_exception:
-		relpath = os.path.relpath(cli_path, get_bench_path())
-		frappe.throw(_("Stalwart CLI not found at {0}.").format(relpath))
+    cli_path = os.path.join(get_mail_app_path(), "stalwart-cli")
+    if not os.path.exists(cli_path) and raise_exception:
+        relpath = os.path.relpath(cli_path, get_bench_path())
+        frappe.throw(_("Stalwart CLI not found at {0}.").format(relpath))
 
-	return cli_path
+    return cli_path
 
 
 def get_stalwart_version() -> str:
-	"""Returns the Stalwart version from configuration or default."""
+    """Returns the Stalwart version from configuration or default."""
 
-	return get_config("stalwart_version")
+    return get_config("stalwart_version")
 
 
 def get_stalwart_cli_version() -> str:
-	"""Returns the Stalwart CLI version from configuration or default."""
+    """Returns the Stalwart CLI version from configuration or default."""
 
-	return get_config("stalwart_cli_version")
+    return get_config("stalwart_cli_version")

--- a/suite/mail/utils/dns.py
+++ b/suite/mail/utils/dns.py
@@ -7,153 +7,153 @@ from frappe import _
 
 
 def get_dns_record(fqdn: str, type: str = "A", raise_exception: bool = False) -> dns.resolver.Answer | None:
-	"""Returns DNS record for the given FQDN and type."""
+    """Returns DNS record for the given FQDN and type."""
 
-	err_msg = None
+    err_msg = None
 
-	try:
-		resolver = dns.resolver.Resolver(configure=False)
-		resolver.nameservers = [
-			"1.1.1.1",
-			"8.8.4.4",
-			"8.8.8.8",
-			"9.9.9.9",
-		]
+    try:
+        resolver = dns.resolver.Resolver(configure=False)
+        resolver.nameservers = [
+            "1.1.1.1",
+            "8.8.4.4",
+            "8.8.8.8",
+            "9.9.9.9",
+        ]
 
-		r = resolver.resolve(fqdn, type)
-		return r
-	except dns.resolver.NXDOMAIN:
-		err_msg = _("{0} does not exist.").format(frappe.bold(fqdn))
-	except dns.resolver.NoAnswer:
-		err_msg = _("No answer for {0}.").format(frappe.bold(fqdn))
-	except dns.exception.DNSException as e:
-		err_msg = _(str(e))
+        r = resolver.resolve(fqdn, type)
+        return r
+    except dns.resolver.NXDOMAIN:
+        err_msg = _("{0} does not exist.").format(frappe.bold(fqdn))
+    except dns.resolver.NoAnswer:
+        err_msg = _("No answer for {0}.").format(frappe.bold(fqdn))
+    except dns.exception.DNSException as e:
+        err_msg = _(str(e))
 
-	if raise_exception and err_msg:
-		frappe.throw(err_msg)
+    if raise_exception and err_msg:
+        frappe.throw(err_msg)
 
 
 def get_host_by_ip(ip_address: str, raise_exception: bool = False) -> str | None:
-	"""Returns host for the given IP address."""
+    """Returns host for the given IP address."""
 
-	err_msg = None
+    err_msg = None
 
-	try:
-		return socket.gethostbyaddr(ip_address)[0]
-	except Exception as e:
-		err_msg = _(str(e))
+    try:
+        return socket.gethostbyaddr(ip_address)[0]
+    except Exception as e:
+        err_msg = _(str(e))
 
-	if raise_exception and err_msg:
-		frappe.throw(err_msg)
+    if raise_exception and err_msg:
+        frappe.throw(err_msg)
 
 
 def verify_dns_record(fqdn: str, type: str, expected_value: str, debug: bool = False) -> bool:
-	"""Verifies the DNS Record."""
+    """Verifies the DNS Record."""
 
-	if result := get_dns_record(fqdn, type):
-		for data in result:
-			if data:
-				if type == "MX":
-					data = data.exchange
-				data = data.to_text().replace('"', "")
-				if type == "TXT" and "._domainkey." in fqdn:
-					data = data.replace(" ", "")
-					expected_value = expected_value.replace(" ", "")
-				if data == expected_value:
-					return True
-			if debug:
-				frappe.msgprint(f"Expected: {expected_value} Got: {data}")
-	return False
+    if result := get_dns_record(fqdn, type):
+        for data in result:
+            if data:
+                if type == "MX":
+                    data = data.exchange
+                data = data.to_text().replace('"', "")
+                if type == "TXT" and "._domainkey." in fqdn:
+                    data = data.replace(" ", "")
+                    expected_value = expected_value.replace(" ", "")
+                if data == expected_value:
+                    return True
+            if debug:
+                frappe.msgprint(f"Expected: {expected_value} Got: {data}")
+    return False
 
 
 def parse_dns_zone_file(zone_file: str) -> list[dict]:
-	"""Parses a DNS zone file content and returns a list of DNS records with their components."""
+    """Parses a DNS zone file content and returns a list of DNS records with their components."""
 
-	# ------------------------------------------------------------
-	# Step 1: Merge multiline DNS records
-	# ------------------------------------------------------------
-	merged_records = []
-	buffer = []
-	inside_multiline = False
+    # ------------------------------------------------------------
+    # Step 1: Merge multiline DNS records
+    # ------------------------------------------------------------
+    merged_records = []
+    buffer = []
+    inside_multiline = False
 
-	for line in zone_file.splitlines():
-		line = line.strip()
+    for line in zone_file.splitlines():
+        line = line.strip()
 
-		if not line:
-			continue
+        if not line:
+            continue
 
-		if "(" in line:
-			inside_multiline = True
+        if "(" in line:
+            inside_multiline = True
 
-		buffer.append(line)
+        buffer.append(line)
 
-		if inside_multiline:
-			if ")" in line:
-				merged_records.append(" ".join(buffer))
-				buffer = []
-				inside_multiline = False
-		else:
-			merged_records.append(line)
-			buffer = []
+        if inside_multiline:
+            if ")" in line:
+                merged_records.append(" ".join(buffer))
+                buffer = []
+                inside_multiline = False
+        else:
+            merged_records.append(line)
+            buffer = []
 
-	# Safety: flush remaining buffer
-	if buffer:
-		merged_records.append(" ".join(buffer))
+    # Safety: flush remaining buffer
+    if buffer:
+        merged_records.append(" ".join(buffer))
 
-	# ------------------------------------------------------------
-	# Step 2: Parse records
-	# ------------------------------------------------------------
-	dns_records = []
+    # ------------------------------------------------------------
+    # Step 2: Parse records
+    # ------------------------------------------------------------
+    dns_records = []
 
-	for record in merged_records:
-		# Remove multiline parentheses
-		record = record.replace("(", "").replace(")", "").strip()
+    for record in merged_records:
+        # Remove multiline parentheses
+        record = record.replace("(", "").replace(")", "").strip()
 
-		# Normalize multiple spaces
-		record = re.sub(r"\s+", " ", record)
+        # Normalize multiple spaces
+        record = re.sub(r"\s+", " ", record)
 
-		parts = record.split()
+        parts = record.split()
 
-		# Minimum valid structure:
-		# name IN TYPE value
-		if len(parts) < 4:
-			continue
+        # Minimum valid structure:
+        # name IN TYPE value
+        if len(parts) < 4:
+            continue
 
-		name = parts[0]
+        name = parts[0]
 
-		# Handle optional TTL
-		#
-		# Formats:
-		# example.com. 3600 IN TXT "value"
-		# example.com. IN TXT "value"
-		#
-		if re.fullmatch(r"\d+", parts[1]):
-			ttl = parts[1]
-			record_class = parts[2]
-			record_type = parts[3]
-			value = " ".join(parts[4:])
-		else:
-			ttl = None
-			record_class = parts[1]
-			record_type = parts[2]
-			value = " ".join(parts[3:])
+        # Handle optional TTL
+        #
+        # Formats:
+        # example.com. 3600 IN TXT "value"
+        # example.com. IN TXT "value"
+        #
+        if re.fullmatch(r"\d+", parts[1]):
+            ttl = parts[1]
+            record_class = parts[2]
+            record_type = parts[3]
+            value = " ".join(parts[4:])
+        else:
+            ttl = None
+            record_class = parts[1]
+            record_type = parts[2]
+            value = " ".join(parts[3:])
 
-		# Merge adjacent quoted TXT chunks:
-		# "abc" "def" -> "abcdef"
-		if record_type == "TXT":
-			quoted_parts = re.findall(r'"([^"]*)"', value)
+        # Merge adjacent quoted TXT chunks:
+        # "abc" "def" -> "abcdef"
+        if record_type == "TXT":
+            quoted_parts = re.findall(r'"([^"]*)"', value)
 
-			if quoted_parts:
-				value = "".join(quoted_parts)
+            if quoted_parts:
+                value = "".join(quoted_parts)
 
-		dns_records.append(
-			{
-				"name": name,
-				"ttl": ttl,
-				"class": record_class,
-				"type": record_type,
-				"value": value,
-			}
-		)
+        dns_records.append(
+            {
+                "name": name,
+                "ttl": ttl,
+                "class": record_class,
+                "type": record_type,
+                "value": value,
+            }
+        )
 
-	return dns_records
+    return dns_records

--- a/suite/mail/utils/dt.py
+++ b/suite/mail/utils/dt.py
@@ -12,45 +12,45 @@ UTC_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
 def to_utc_z(value: "datetime | str | None") -> str | None:
-	"""Formats a value as the ``2026-07-28T09:02:30Z`` UTC timestamp the mail APIs return.
+    """Formats a value as the ``2026-07-28T09:02:30Z`` UTC timestamp the mail APIs return.
 
-	Aware values (Stalwart's timestamps, or the ``...Z`` an API was called with) are converted;
-	naive ones are read as system time, which is how Frappe stores datetimes in the database.
+    Aware values (Stalwart's timestamps, or the ``...Z`` an API was called with) are converted;
+    naive ones are read as system time, which is how Frappe stores datetimes in the database.
 
-	Distinct from ``suite.utils.dt.to_iso8601_z``, which reads a naive value as UTC — wrong for a
-	value that came out of a Frappe field.
-	"""
+    Distinct from ``suite.utils.dt.to_iso8601_z``, which reads a naive value as UTC — wrong for a
+    value that came out of a Frappe field.
+    """
 
-	if not value:
-		return None
+    if not value:
+        return None
 
-	return convert_to_utc(value).strftime(UTC_DATETIME_FORMAT)
+    return convert_to_utc(value).strftime(UTC_DATETIME_FORMAT)
 
 
 def from_utc_z(value: str | None) -> str | None:
-	"""Converts a ``...Z`` timestamp an API was called with to the system-time string Frappe stores.
+    """Converts a ``...Z`` timestamp an API was called with to the system-time string Frappe stores.
 
-	Only for values written to Frappe datetime fields; Stalwart's own fields stay in UTC.
-	"""
+    Only for values written to Frappe datetime fields; Stalwart's own fields stay in UTC.
+    """
 
-	if not value:
-		return None
+    if not value:
+        return None
 
-	return get_datetime_str(parse_iso_datetime(value, as_str=False))
+    return get_datetime_str(parse_iso_datetime(value, as_str=False))
 
 
 def parsedate_to_datetime(date_header: str) -> "datetime":
-	"""Returns datetime object from parsed date header."""
+    """Returns datetime object from parsed date header."""
 
-	# email.utils.parsedate_to_datetime raises ValueError on an unparsable header rather than
-	# returning None, so the guard below only works if we catch it - otherwise a malformed Date
-	# on an inbound or imported message escapes as a traceback instead of this validation error.
-	try:
-		utc_dt = parsedate(date_header)
-	except ValueError:
-		utc_dt = None
+    # email.utils.parsedate_to_datetime raises ValueError on an unparsable header rather than
+    # returning None, so the guard below only works if we catch it - otherwise a malformed Date
+    # on an inbound or imported message escapes as a traceback instead of this validation error.
+    try:
+        utc_dt = parsedate(date_header)
+    except ValueError:
+        utc_dt = None
 
-	if not utc_dt:
-		frappe.throw(_("Invalid date format: {0}").format(date_header))
+    if not utc_dt:
+        frappe.throw(_("Invalid date format: {0}").format(date_header))
 
-	return convert_utc_to_system_timezone(utc_dt)
+    return convert_utc_to_system_timezone(utc_dt)

--- a/suite/mail/utils/dt.py
+++ b/suite/mail/utils/dt.py
@@ -11,7 +11,7 @@ from suite.utils.dt import convert_to_utc, parse_iso_datetime
 UTC_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
-def to_utc_z(value: "datetime | str | None") -> str | None:
+def to_utc_z(value: datetime | str | None) -> str | None:
     """Formats a value as the ``2026-07-28T09:02:30Z`` UTC timestamp the mail APIs return.
 
     Aware values (Stalwart's timestamps, or the ``...Z`` an API was called with) are converted;
@@ -39,7 +39,7 @@ def from_utc_z(value: str | None) -> str | None:
     return get_datetime_str(parse_iso_datetime(value, as_str=False))
 
 
-def parsedate_to_datetime(date_header: str) -> "datetime":
+def parsedate_to_datetime(date_header: str) -> datetime:
     """Returns datetime object from parsed date header."""
 
     # email.utils.parsedate_to_datetime raises ValueError on an unparsable header rather than

--- a/suite/mail/utils/email_parser.py
+++ b/suite/mail/utils/email_parser.py
@@ -11,249 +11,249 @@ from frappe.utils.file_manager import save_file
 from suite.mail.utils.dt import parsedate_to_datetime
 
 if TYPE_CHECKING:
-	from email.message import Message
+    from email.message import Message
 
 
 class EmailParser:
-	def __init__(self, message: str) -> None:
-		self.message = self.get_parsed_message(message)
-		self.cid_and_file_url_map = {}
+    def __init__(self, message: str) -> None:
+        self.message = self.get_parsed_message(message)
+        self.cid_and_file_url_map = {}
 
-	@staticmethod
-	def get_parsed_message(message: str) -> "Message":
-		"""Returns parsed email message object from string."""
+    @staticmethod
+    def get_parsed_message(message: str) -> "Message":
+        """Returns parsed email message object from string."""
 
-		return message_from_string(message)
+        return message_from_string(message)
 
-	def get_message_id(self) -> str | None:
-		"""Returns the message ID of the email."""
+    def get_message_id(self) -> str | None:
+        """Returns the message ID of the email."""
 
-		if message_id := self.message.get("Message-ID"):
-			return remove_whitespace_characters(message_id)
+        if message_id := self.message.get("Message-ID"):
+            return remove_whitespace_characters(message_id)
 
-	def get_in_reply_to(self) -> str | None:
-		"""Returns the in-reply-to message ID of the email."""
+    def get_in_reply_to(self) -> str | None:
+        """Returns the in-reply-to message ID of the email."""
 
-		if in_reply_to := self.message.get("In-Reply-To"):
-			return remove_whitespace_characters(in_reply_to)
+        if in_reply_to := self.message.get("In-Reply-To"):
+            return remove_whitespace_characters(in_reply_to)
 
-	def get_subject(self) -> str | None:
-		"""Returns the decoded subject of the email."""
+    def get_subject(self) -> str | None:
+        """Returns the decoded subject of the email."""
 
-		if subject := self.message["Subject"]:
-			decoded_subject = str(make_header(decode_header(subject)))
-			return remove_whitespace_characters(decoded_subject)
+        if subject := self.message["Subject"]:
+            decoded_subject = str(make_header(decode_header(subject)))
+            return remove_whitespace_characters(decoded_subject)
 
-		return None
+        return None
 
-	def get_sender(self) -> tuple[str, str]:
-		"""Returns the display name and email of the sender."""
+    def get_sender(self) -> tuple[str, str]:
+        """Returns the display name and email of the sender."""
 
-		return parseaddr(str(make_header(decode_header(self.message["From"]))))
+        return parseaddr(str(make_header(decode_header(self.message["From"]))))
 
-	def get_delivered_to(self) -> str | None:
-		"""Returns the Delivered-To email address of the email."""
+    def get_delivered_to(self) -> str | None:
+        """Returns the Delivered-To email address of the email."""
 
-		if delivered_to := self.message.get("Delivered-To"):
-			return remove_whitespace_characters(delivered_to)
+        if delivered_to := self.message.get("Delivered-To"):
+            return remove_whitespace_characters(delivered_to)
 
-	def get_reply_to(self) -> str:
-		"""Returns the reply-to email(s) of the email."""
+    def get_reply_to(self) -> str:
+        """Returns the reply-to email(s) of the email."""
 
-		if reply_to := self.message.get("Reply-To"):
-			return remove_whitespace_characters(str(make_header(decode_header(reply_to))))
+        if reply_to := self.message.get("Reply-To"):
+            return remove_whitespace_characters(str(make_header(decode_header(reply_to))))
 
-	def get_priority(self) -> int:
-		"""Returns the priority of the email."""
+    def get_priority(self) -> int:
+        """Returns the priority of the email."""
 
-		return cint(self.get_header("X-Priority"))
+        return cint(self.get_header("X-Priority"))
 
-	def get_header(self, header: str) -> str | None:
-		"""Returns the value of the header."""
+    def get_header(self, header: str) -> str | None:
+        """Returns the value of the header."""
 
-		return self.message[header]
+        return self.message[header]
 
-	def update_header(self, header: str, value: str) -> None:
-		"""Updates the value of the header."""
+    def update_header(self, header: str, value: str) -> None:
+        """Updates the value of the header."""
 
-		if header in self.message:
-			del self.message[header]
+        if header in self.message:
+            del self.message[header]
 
-		self.message[header] = value
+        self.message[header] = value
 
-	def get_date(self) -> str | None:
-		"""Returns the date of the email."""
+    def get_date(self) -> str | None:
+        """Returns the date of the email."""
 
-		if date_header := self.message.get("Date"):
-			return get_datetime_str(parsedate_to_datetime(date_header))
+        if date_header := self.message.get("Date"):
+            return get_datetime_str(parsedate_to_datetime(date_header))
 
-	def get_size(self) -> int:
-		"""Returns the size of the email."""
+    def get_size(self) -> int:
+        """Returns the size of the email."""
 
-		return len(self.message.as_string(policy=policy.default).encode("utf-8"))
+        return len(self.message.as_string(policy=policy.default).encode("utf-8"))
 
-	def get_recipients(self, types: str | list | None = None) -> list[dict]:
-		"""Returns the list of recipients of the email."""
+    def get_recipients(self, types: str | list | None = None) -> list[dict]:
+        """Returns the list of recipients of the email."""
 
-		if not types:
-			types = ["To", "Cc", "Bcc"]
-		elif isinstance(types, str):
-			types = [types]
+        if not types:
+            types = ["To", "Cc", "Bcc"]
+        elif isinstance(types, str):
+            types = [types]
 
-		recipients = []
-		for type in types:
-			if addresses := self.message.get(type):
-				for address in addresses.split(","):
-					display_name, email = parseaddr(remove_whitespace_characters(address))
-					if email:
-						recipients.append({"type": type, "email": email, "display_name": display_name})
+        recipients = []
+        for type in types:
+            if addresses := self.message.get(type):
+                for address in addresses.split(","):
+                    display_name, email = parseaddr(remove_whitespace_characters(address))
+                    if email:
+                        recipients.append({"type": type, "email": email, "display_name": display_name})
 
-		return recipients
+        return recipients
 
-	def save_attachments(self, doctype: str, docname: str, is_private: bool = True) -> None:
-		"""Saves the attachments of the email."""
+    def save_attachments(self, doctype: str, docname: str, is_private: bool = True) -> None:
+        """Saves the attachments of the email."""
 
-		def save_attachment(
-			filename: str, content: bytes, doctype: str, docname: str, is_private: bool
-		) -> dict:
-			"""Saves the attachment as a file."""
+        def save_attachment(
+            filename: str, content: bytes, doctype: str, docname: str, is_private: bool
+        ) -> dict:
+            """Saves the attachment as a file."""
 
-			kwargs = {
-				"fname": filename,
-				"content": content,
-				"df": "file",
-				"dt": doctype,
-				"dn": docname,
-				"is_private": cint(is_private),
-			}
-			file = save_file(**kwargs)
-			return {
-				"name": file.name,
-				"file_name": file.file_name,
-				"file_url": file.file_url,
-				"is_private": file.is_private,
-			}
+            kwargs = {
+                "fname": filename,
+                "content": content,
+                "df": "file",
+                "dt": doctype,
+                "dn": docname,
+                "is_private": cint(is_private),
+            }
+            file = save_file(**kwargs)
+            return {
+                "name": file.name,
+                "file_name": file.file_name,
+                "file_url": file.file_url,
+                "is_private": file.is_private,
+            }
 
-		for part in self.message.walk():
-			filename = part.get_filename()
-			disposition = part.get("Content-Disposition")
+        for part in self.message.walk():
+            filename = part.get_filename()
+            disposition = part.get("Content-Disposition")
 
-			if disposition and filename:
-				filename = unquote(filename)
-				disposition = disposition.lower()
+            if disposition and filename:
+                filename = unquote(filename)
+                disposition = disposition.lower()
 
-				if disposition.startswith("inline"):
-					if cid := re.sub(r"[<>]", "", part.get("Content-ID", "")):
-						if payload := part.get_payload(decode=True):
-							file = save_attachment(filename, payload, doctype, docname, is_private)
-							self.cid_and_file_url_map[cid] = file["file_url"]
+                if disposition.startswith("inline"):
+                    if cid := re.sub(r"[<>]", "", part.get("Content-ID", "")):
+                        if payload := part.get_payload(decode=True):
+                            file = save_attachment(filename, payload, doctype, docname, is_private)
+                            self.cid_and_file_url_map[cid] = file["file_url"]
 
-				elif disposition.startswith("attachment"):
-					if payload := part.get_payload(decode=True):
-						save_attachment(filename, payload, doctype, docname, is_private)
+                elif disposition.startswith("attachment"):
+                    if payload := part.get_payload(decode=True):
+                        save_attachment(filename, payload, doctype, docname, is_private)
 
-	def get_body(self) -> tuple[str | None, str | None]:
-		"""Returns the HTML and plain text body of the email."""
+    def get_body(self) -> tuple[str | None, str | None]:
+        """Returns the HTML and plain text body of the email."""
 
-		body_html, body_plain = "", ""
+        body_html, body_plain = "", ""
 
-		for part in self.message.walk():
-			content_type = part.get_content_type()
+        for part in self.message.walk():
+            content_type = part.get_content_type()
 
-			if content_type == "text/html":
-				if payload := part.get_payload(decode=True):
-					charset = part.get_content_charset() or "utf-8"
-					body_html += payload.decode(charset, "ignore")
+            if content_type == "text/html":
+                if payload := part.get_payload(decode=True):
+                    charset = part.get_content_charset() or "utf-8"
+                    body_html += payload.decode(charset, "ignore")
 
-			elif content_type == "text/plain":
-				if payload := part.get_payload(decode=True):
-					charset = part.get_content_charset() or "utf-8"
-					body_plain += payload.decode(charset, "ignore")
+            elif content_type == "text/plain":
+                if payload := part.get_payload(decode=True):
+                    charset = part.get_content_charset() or "utf-8"
+                    body_plain += payload.decode(charset, "ignore")
 
-		if self.cid_and_file_url_map:
-			for cid, file_url in self.cid_and_file_url_map.items():
-				body_html = body_html.replace(f"cid:{cid}", file_url)
-				body_plain = body_plain.replace(f"cid:{cid}", file_url)
+        if self.cid_and_file_url_map:
+            for cid, file_url in self.cid_and_file_url_map.items():
+                body_html = body_html.replace(f"cid:{cid}", file_url)
+                body_plain = body_plain.replace(f"cid:{cid}", file_url)
 
-		return body_html or None, body_plain or None
+        return body_html or None, body_plain or None
 
-	def get_authentication_results(self) -> dict[str, int | str]:
-		"""Returns the authentication results of the email."""
+    def get_authentication_results(self) -> dict[str, int | str]:
+        """Returns the authentication results of the email."""
 
-		result = {}
-		checks = ["spf", "dkim", "dmarc"]
+        result = {}
+        checks = ["spf", "dkim", "dmarc"]
 
-		for check in checks:
-			result[f"{check}_pass"] = 0
-			result[f"{check}_description"] = None
+        for check in checks:
+            result[f"{check}_pass"] = 0
+            result[f"{check}_description"] = None
 
-		# Only the topmost header is trusted. Each hop prepends its own, so headers[0] is the one
-		# our receiving server wrote; anything below it came in with the message and is therefore
-		# attacker-controlled. Reading all of them let a sender forge a "dkim=pass" of their own.
-		if headers := self.message.get_all("Authentication-Results"):
-			for segment in headers[0].split(";"):
-				segment = remove_whitespace_characters(segment)
-				segment_lower = segment.lower()
+        # Only the topmost header is trusted. Each hop prepends its own, so headers[0] is the one
+        # our receiving server wrote; anything below it came in with the message and is therefore
+        # attacker-controlled. Reading all of them let a sender forge a "dkim=pass" of their own.
+        if headers := self.message.get_all("Authentication-Results"):
+            for segment in headers[0].split(";"):
+                segment = remove_whitespace_characters(segment)
+                segment_lower = segment.lower()
 
-				for check in checks:
-					if f"{check}=" in segment_lower:
-						result[f"{check}_pass"] = 1 if f"{check}=pass" in segment_lower else 0
-						result[f"{check}_description"] = segment
-						break
+                for check in checks:
+                    if f"{check}=" in segment_lower:
+                        result[f"{check}_pass"] = 1 if f"{check}=pass" in segment_lower else 0
+                        result[f"{check}_description"] = segment
+                        break
 
-		return result
+        return result
 
-	def get_message(self) -> str:
-		"""Returns the email message as a string."""
+    def get_message(self) -> str:
+        """Returns the email message as a string."""
 
-		return self.message.as_string()
+        return self.message.as_string()
 
 
 def remove_whitespace_characters(text: str) -> str:
-	"""Removes whitespace characters from the text."""
+    """Removes whitespace characters from the text."""
 
-	return text.replace("\t", "").replace("\r", "").replace("\n", "").strip()
+    return text.replace("\t", "").replace("\r", "").replace("\n", "").strip()
 
 
 def extract_ip_and_host(header: str | None = None) -> tuple[str | None, str | None]:
-	"""Extracts the IP and Host from the given `Received` header."""
+    """Extracts the IP and Host from the given `Received` header."""
 
-	if not header:
-		return None, None
+    if not header:
+        return None, None
 
-	ip_pattern = re.compile(r"\[(?P<ip>[\d\.]+|[a-fA-F0-9:]+)")
-	host_pattern = re.compile(r"from\s+(?P<host>[^\s]+)")
+    ip_pattern = re.compile(r"\[(?P<ip>[\d\.]+|[a-fA-F0-9:]+)")
+    host_pattern = re.compile(r"from\s+(?P<host>[^\s]+)")
 
-	ip_match = ip_pattern.search(header)
-	ip = ip_match.group("ip") if ip_match else None
+    ip_match = ip_pattern.search(header)
+    ip = ip_match.group("ip") if ip_match else None
 
-	host_match = host_pattern.search(header)
-	host = host_match.group("host") if host_match else None
+    host_match = host_pattern.search(header)
+    host = host_match.group("host") if host_match else None
 
-	return ip, host
+    return ip, host
 
 
 def extract_spam_status(header: str | None = None) -> tuple[bool, float]:
-	"""
-	Extracts the spam status and score from the given `X-Spam-Status` header.
+    """
+    Extracts the spam status and score from the given `X-Spam-Status` header.
 
-	Args:
-	    header (str | None): The `X-Spam-Status` header.
+    Args:
+        header (str | None): The `X-Spam-Status` header.
 
-	Returns:
-	    Tuple[bool, float]: A tuple containing the spam status (True for "Yes", False otherwise) and the spam score.
-	"""
+    Returns:
+        Tuple[bool, float]: A tuple containing the spam status (True for "Yes", False otherwise) and the spam score.
+    """
 
-	if not header:
-		return False, 0.0
+    if not header:
+        return False, 0.0
 
-	status_pattern = re.compile(r"^\s*(Yes|No)", re.IGNORECASE)
-	score_pattern = re.compile(r"score=(-?\d+\.?\d*)")
+    status_pattern = re.compile(r"^\s*(Yes|No)", re.IGNORECASE)
+    score_pattern = re.compile(r"score=(-?\d+\.?\d*)")
 
-	status_match = status_pattern.search(header)
-	score_match = score_pattern.search(header)
+    status_match = status_pattern.search(header)
+    score_match = score_pattern.search(header)
 
-	status = status_match.group(1).lower() == "yes" if status_match else False
-	score = float(score_match.group(1)) if score_match else 0.0
+    status = status_match.group(1).lower() == "yes" if status_match else False
+    score = float(score_match.group(1)) if score_match else 0.0
 
-	return status, score
+    return status, score

--- a/suite/mail/utils/email_parser.py
+++ b/suite/mail/utils/email_parser.py
@@ -20,7 +20,7 @@ class EmailParser:
         self.cid_and_file_url_map = {}
 
     @staticmethod
-    def get_parsed_message(message: str) -> "Message":
+    def get_parsed_message(message: str) -> Message:
         """Returns parsed email message object from string."""
 
         return message_from_string(message)

--- a/suite/mail/utils/logger.py
+++ b/suite/mail/utils/logger.py
@@ -13,147 +13,147 @@ DEFAULT_LOG_MAX_FILE_SIZE = 5_000_000
 
 
 class EventLogger:
-	"""Structured event logger for a mail subsystem.
+    """Structured event logger for a mail subsystem.
 
-	Binds a context dict (shared by reference, so callers can keep mutating it)
-	and emits one structured record per event. Each log method takes the event
-	name as its first argument and any event-specific fields as keyword
-	arguments, keeping call sites free of repetitive `{**ctx, "event": ...}`
-	boilerplate. Pick the method that matches the event:
+    Binds a context dict (shared by reference, so callers can keep mutating it)
+    and emits one structured record per event. Each log method takes the event
+    name as its first argument and any event-specific fields as keyword
+    arguments, keeping call sites free of repetitive `{**ctx, "event": ...}`
+    boilerplate. Pick the method that matches the event:
 
-	- `debug`   — flow tracing and routine/no-op outcomes (entry points, cache
-	              invalidations, lock contention, unchanged state).
-	- `info`    — meaningful work that happened (mail sent, messages synced,
-	              notifications delivered).
-	- `warning` — handled-but-unexpected situations (bad client input, frozen
-	              user, unknown payload type).
-	- `error`   — failures during our own processing.
-	- `exception` — same as `error` but also records the active traceback; use
-	              it inside an `except` block.
+    - `debug`   — flow tracing and routine/no-op outcomes (entry points, cache
+                  invalidations, lock contention, unchanged state).
+    - `info`    — meaningful work that happened (mail sent, messages synced,
+                  notifications delivered).
+    - `warning` — handled-but-unexpected situations (bad client input, frozen
+                  user, unknown payload type).
+    - `error`   — failures during our own processing.
+    - `exception` — same as `error` but also records the active traceback; use
+                  it inside an `except` block.
 
-	Subclasses set `logger_name` (the frappe logger channel, e.g. "suite.mail.push")
-	and `config_prefix` (the Mail Settings key prefix, e.g. "push"), which
-	selects the `<prefix>_log_max_file_size`, `<prefix>_log_file_count` and
-	`<prefix>_log_level` config values.
-	"""
+    Subclasses set `logger_name` (the frappe logger channel, e.g. "suite.mail.push")
+    and `config_prefix` (the Mail Settings key prefix, e.g. "push"), which
+    selects the `<prefix>_log_max_file_size`, `<prefix>_log_file_count` and
+    `<prefix>_log_level` config values.
+    """
 
-	logger_name: str
-	config_prefix: str
+    logger_name: str
+    config_prefix: str
 
-	def __init__(self, ctx: dict | None = None) -> None:
-		config = get_config()
+    def __init__(self, ctx: dict | None = None) -> None:
+        config = get_config()
 
-		max_size = cint(config.get(f"{self.config_prefix}_log_max_file_size")) or DEFAULT_LOG_MAX_FILE_SIZE
-		file_count = cint(config.get(f"{self.config_prefix}_log_file_count")) or DEFAULT_LOG_FILE_COUNT
-		self.logger = frappe.logger(
-			self.logger_name, allow_site=True, max_size=max_size, file_count=file_count
-		)
-		self.logger.setLevel((config.get(f"{self.config_prefix}_log_level") or DEFAULT_LOG_LEVEL).upper())
+        max_size = cint(config.get(f"{self.config_prefix}_log_max_file_size")) or DEFAULT_LOG_MAX_FILE_SIZE
+        file_count = cint(config.get(f"{self.config_prefix}_log_file_count")) or DEFAULT_LOG_FILE_COUNT
+        self.logger = frappe.logger(
+            self.logger_name, allow_site=True, max_size=max_size, file_count=file_count
+        )
+        self.logger.setLevel((config.get(f"{self.config_prefix}_log_level") or DEFAULT_LOG_LEVEL).upper())
 
-		self.ctx = ctx if ctx is not None else {}
+        self.ctx = ctx if ctx is not None else {}
 
-	def _record(self, event: str, fields: dict) -> dict:
-		return {**self.ctx, **fields, "event": event}
+    def _record(self, event: str, fields: dict) -> dict:
+        return {**self.ctx, **fields, "event": event}
 
-	def debug(self, event: str, **fields: Any) -> None:
-		self.logger.debug(self._record(event, fields))
+    def debug(self, event: str, **fields: Any) -> None:
+        self.logger.debug(self._record(event, fields))
 
-	def info(self, event: str, **fields: Any) -> None:
-		self.logger.info(self._record(event, fields))
+    def info(self, event: str, **fields: Any) -> None:
+        self.logger.info(self._record(event, fields))
 
-	def warning(self, event: str, **fields: Any) -> None:
-		self.logger.warning(self._record(event, fields))
+    def warning(self, event: str, **fields: Any) -> None:
+        self.logger.warning(self._record(event, fields))
 
-	def error(self, event: str, **fields: Any) -> None:
-		self.logger.error(self._record(event, fields))
+    def error(self, event: str, **fields: Any) -> None:
+        self.logger.error(self._record(event, fields))
 
-	def exception(self, event: str, **fields: Any) -> None:
-		self.logger.exception(self._record(event, fields))
+    def exception(self, event: str, **fields: Any) -> None:
+        self.logger.exception(self._record(event, fields))
 
 
 class PushLogger(EventLogger):
-	"""Structured event logger for mail push notifications ("suite.mail.push")."""
+    """Structured event logger for mail push notifications ("suite.mail.push")."""
 
-	logger_name = "suite.mail.push"
-	config_prefix = "push"
+    logger_name = "suite.mail.push"
+    config_prefix = "push"
 
 
 class OutboundLogger(EventLogger):
-	"""Structured event logger for outbound mail operations ("suite.mail.outbound")."""
+    """Structured event logger for outbound mail operations ("suite.mail.outbound")."""
 
-	logger_name = "suite.mail.outbound"
-	config_prefix = "outbound"
+    logger_name = "suite.mail.outbound"
+    config_prefix = "outbound"
 
 
 class InboundLogger(EventLogger):
-	"""Structured event logger for inbound mail operations ("suite.mail.inbound")."""
+    """Structured event logger for inbound mail operations ("suite.mail.inbound")."""
 
-	logger_name = "suite.mail.inbound"
-	config_prefix = "inbound"
+    logger_name = "suite.mail.inbound"
+    config_prefix = "inbound"
 
 
 class ExchangeLogger(EventLogger):
-	"""Structured event logger for mail import/export operations ("suite.mail.exchange")."""
+    """Structured event logger for mail import/export operations ("suite.mail.exchange")."""
 
-	logger_name = "suite.mail.exchange"
-	config_prefix = "exchange"
+    logger_name = "suite.mail.exchange"
+    config_prefix = "exchange"
 
 
 class AdminLogger(EventLogger):
-	"""Structured event logger for mail administration ("suite.mail.admin")."""
+    """Structured event logger for mail administration ("suite.mail.admin")."""
 
-	logger_name = "suite.mail.admin"
-	config_prefix = "admin"
+    logger_name = "suite.mail.admin"
+    config_prefix = "admin"
 
 
 def get_push_logger(ctx: dict | None = None) -> PushLogger:
-	"""Returns a structured event logger for mail push notifications.
+    """Returns a structured event logger for mail push notifications.
 
-	The returned logger is bound to `ctx` (by reference); mutating that same
-	dict between log calls is reflected in subsequent records.
-	"""
+    The returned logger is bound to `ctx` (by reference); mutating that same
+    dict between log calls is reflected in subsequent records.
+    """
 
-	return PushLogger(ctx)
+    return PushLogger(ctx)
 
 
 def get_outbound_logger(ctx: dict | None = None) -> OutboundLogger:
-	"""Returns a structured event logger for outbound mail operations.
+    """Returns a structured event logger for outbound mail operations.
 
-	The returned logger is bound to `ctx` (by reference); mutating that same
-	dict between log calls is reflected in subsequent records.
-	"""
+    The returned logger is bound to `ctx` (by reference); mutating that same
+    dict between log calls is reflected in subsequent records.
+    """
 
-	return OutboundLogger(ctx)
+    return OutboundLogger(ctx)
 
 
 def get_inbound_logger(ctx: dict | None = None) -> InboundLogger:
-	"""Returns a structured event logger for inbound mail operations.
+    """Returns a structured event logger for inbound mail operations.
 
-	The returned logger is bound to `ctx` (by reference); mutating that same
-	dict between log calls is reflected in subsequent records.
-	"""
+    The returned logger is bound to `ctx` (by reference); mutating that same
+    dict between log calls is reflected in subsequent records.
+    """
 
-	return InboundLogger(ctx)
+    return InboundLogger(ctx)
 
 
 def get_exchange_logger(ctx: dict | None = None) -> ExchangeLogger:
-	"""Returns a structured event logger for mail import/export operations.
+    """Returns a structured event logger for mail import/export operations.
 
-	The returned logger is bound to `ctx` (by reference); mutating that same
-	dict between log calls is reflected in subsequent records.
-	"""
+    The returned logger is bound to `ctx` (by reference); mutating that same
+    dict between log calls is reflected in subsequent records.
+    """
 
-	return ExchangeLogger(ctx)
+    return ExchangeLogger(ctx)
 
 
 def get_admin_logger(ctx: dict | None = None) -> AdminLogger:
-	"""Returns a structured event logger for mail administration.
+    """Returns a structured event logger for mail administration.
 
-	The returned logger is bound to `ctx` (by reference); mutating that same
-	dict between log calls is reflected in subsequent records.
-	"""
+    The returned logger is bound to `ctx` (by reference); mutating that same
+    dict between log calls is reflected in subsequent records.
+    """
 
-	return AdminLogger(ctx)
+    return AdminLogger(ctx)
 
 
 # Keeps one audit line readable when an action targets a long list of objects.
@@ -161,44 +161,44 @@ MAX_LOGGED_TARGETS = 10
 
 
 def log_admin_action(action: str, target: Any = None) -> None:
-	"""Records who performed an administrative action, and on what.
+    """Records who performed an administrative action, and on what.
 
-	Written for accountability, so it names the acting user and the object acted on — never the
-	payload, which can hold passwords and message contents. The line is emitted when the action is
-	authorized, so it records what was attempted; failures are in the Error Log alongside.
-	"""
+    Written for accountability, so it names the acting user and the object acted on — never the
+    payload, which can hold passwords and message contents. The line is emitted when the action is
+    authorized, so it records what was attempted; failures are in the Error Log alongside.
+    """
 
-	fields = {"user": frappe.session.user, "action": action}
+    fields = {"user": frappe.session.user, "action": action}
 
-	# Absent outside a request (scheduled jobs, bench console).
-	if request_ip := getattr(frappe.local, "request_ip", None):
-		fields["ip"] = request_ip
+    # Absent outside a request (scheduled jobs, bench console).
+    if request_ip := getattr(frappe.local, "request_ip", None):
+        fields["ip"] = request_ip
 
-	if target := _format_target(target):
-		fields["target"] = target
+    if target := _format_target(target):
+        fields["target"] = target
 
-	try:
-		get_admin_logger().info("admin-action", **fields)
-	except Exception:
-		# This runs in the permission gate of every administrative action, so a logging problem is
-		# recorded and swallowed rather than allowed to fail the action itself.
-		log_mail_error(title="Failed to write the admin log", message=frappe.get_traceback())
+    try:
+        get_admin_logger().info("admin-action", **fields)
+    except Exception:
+        # This runs in the permission gate of every administrative action, so a logging problem is
+        # recorded and swallowed rather than allowed to fail the action itself.
+        log_mail_error(title="Failed to write the admin log", message=frappe.get_traceback())
 
 
 def _format_target(target: Any) -> str:
-	"""Renders an action's target as one short string, capping long collections."""
+    """Renders an action's target as one short string, capping long collections."""
 
-	if target is None:
-		return ""
+    if target is None:
+        return ""
 
-	if isinstance(target, str):
-		return target
+    if isinstance(target, str):
+        return target
 
-	if isinstance(target, list | tuple | set):
-		targets = [str(t) for t in target]
-		shown = ", ".join(targets[:MAX_LOGGED_TARGETS])
-		if len(targets) > MAX_LOGGED_TARGETS:
-			shown += f" and {len(targets) - MAX_LOGGED_TARGETS} more"
-		return shown
+    if isinstance(target, list | tuple | set):
+        targets = [str(t) for t in target]
+        shown = ", ".join(targets[:MAX_LOGGED_TARGETS])
+        if len(targets) > MAX_LOGGED_TARGETS:
+            shown += f" and {len(targets) - MAX_LOGGED_TARGETS} more"
+        return shown
 
-	return str(target)
+    return str(target)

--- a/suite/mail/utils/query.py
+++ b/suite/mail/utils/query.py
@@ -10,116 +10,116 @@ from suite.utils.user import is_system_manager
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def get_user_accounts(
-	doctype: str | None = None,
-	txt: str | None = None,
-	searchfield: str | None = None,
-	start: int = 0,
-	page_len: int = 20,
-	filters: dict | None = None,
+    doctype: str | None = None,
+    txt: str | None = None,
+    searchfield: str | None = None,
+    start: int = 0,
+    page_len: int = 20,
+    filters: dict | None = None,
 ) -> list:
-	"""Returns a list of accounts for the user."""
+    """Returns a list of accounts for the user."""
 
-	filters = filters or {}
-	user = filters.get("user") or frappe.session.user
+    filters = filters or {}
+    user = filters.get("user") or frappe.session.user
 
-	if not user or user in ("Guest", "Administrator"):
-		return []
+    if not user or user in ("Guest", "Administrator"):
+        return []
 
-	if user != frappe.session.user and not is_system_manager(frappe.session.user):
-		return []
+    if user != frappe.session.user and not is_system_manager(frappe.session.user):
+        return []
 
-	result = []
-	for account in get_user_jmap_accounts(user):
-		if txt and txt.lower() not in account.lower():
-			continue
+    result = []
+    for account in get_user_jmap_accounts(user):
+        if txt and txt.lower() not in account.lower():
+            continue
 
-		result.append([account])
+        result.append([account])
 
-	return result[start : start + page_len]
+    return result[start : start + page_len]
 
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def get_account_mailboxes(
-	doctype: str | None = None,
-	txt: str | None = None,
-	searchfield: str | None = None,
-	start: int = 0,
-	page_len: int = 20,
-	filters: dict | None = None,
+    doctype: str | None = None,
+    txt: str | None = None,
+    searchfield: str | None = None,
+    start: int = 0,
+    page_len: int = 20,
+    filters: dict | None = None,
 ) -> list:
-	"""Returns a list of mailboxes for the account."""
+    """Returns a list of mailboxes for the account."""
 
-	filters = filters or {}
-	account = filters.get("account")
+    filters = filters or {}
+    account = filters.get("account")
 
-	if not account:
-		return []
+    if not account:
+        return []
 
-	result = []
-	if mailboxes := fetch_mailboxes(account):
-		for mailbox in mailboxes:
-			if txt and txt.lower() not in mailbox["name"].lower():
-				continue
+    result = []
+    if mailboxes := fetch_mailboxes(account):
+        for mailbox in mailboxes:
+            if txt and txt.lower() not in mailbox["name"].lower():
+                continue
 
-			result.append([mailbox["name"]])
+            result.append([mailbox["name"]])
 
-	return result[start : start + page_len]
+    return result[start : start + page_len]
 
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def get_account_address_books(
-	doctype: str | None = None,
-	txt: str | None = None,
-	searchfield: str | None = None,
-	start: int = 0,
-	page_len: int = 20,
-	filters: dict | None = None,
+    doctype: str | None = None,
+    txt: str | None = None,
+    searchfield: str | None = None,
+    start: int = 0,
+    page_len: int = 20,
+    filters: dict | None = None,
 ) -> list:
-	"""Returns a list of address books for the account."""
+    """Returns a list of address books for the account."""
 
-	filters = filters or {}
-	account = filters.get("account")
+    filters = filters or {}
+    account = filters.get("account")
 
-	if not account:
-		return []
+    if not account:
+        return []
 
-	result = []
-	if address_books := fetch_address_books(account):
-		for address_book in address_books:
-			if txt and txt.lower() not in address_book["name"].lower():
-				continue
+    result = []
+    if address_books := fetch_address_books(account):
+        for address_book in address_books:
+            if txt and txt.lower() not in address_book["name"].lower():
+                continue
 
-			result.append([address_book["name"]])
+            result.append([address_book["name"]])
 
-	return result[start : start + page_len]
+    return result[start : start + page_len]
 
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def get_account_calendars(
-	doctype: str | None = None,
-	txt: str | None = None,
-	searchfield: str | None = None,
-	start: int = 0,
-	page_len: int = 20,
-	filters: dict | None = None,
+    doctype: str | None = None,
+    txt: str | None = None,
+    searchfield: str | None = None,
+    start: int = 0,
+    page_len: int = 20,
+    filters: dict | None = None,
 ) -> list:
-	"""Returns a list of calendars for the account."""
+    """Returns a list of calendars for the account."""
 
-	filters = filters or {}
-	account = filters.get("account")
+    filters = filters or {}
+    account = filters.get("account")
 
-	if not account:
-		return []
+    if not account:
+        return []
 
-	result = []
-	if calendars := fetch_calendars(account):
-		for calendar in calendars:
-			if txt and txt.lower() not in calendar["name"].lower():
-				continue
+    result = []
+    if calendars := fetch_calendars(account):
+        for calendar in calendars:
+            if txt and txt.lower() not in calendar["name"].lower():
+                continue
 
-			result.append([calendar["name"]])
+            result.append([calendar["name"]])
 
-	return result[start : start + page_len]
+    return result[start : start + page_len]

--- a/suite/mail/utils/user.py
+++ b/suite/mail/utils/user.py
@@ -10,113 +10,113 @@ from suite.utils.user import is_system_manager
 
 
 def has_user_settings(user: str, raise_exception: bool = False) -> bool:
-	"""Returns True if the user has User Settings else False."""
+    """Returns True if the user has User Settings else False."""
 
-	if frappe.db.exists("User Settings", {"user": user}):
-		return True
+    if frappe.db.exists("User Settings", {"user": user}):
+        return True
 
-	if raise_exception:
-		frappe.throw(_("User {0} does not have User Settings configured.").format(frappe.bold(user)))
+    if raise_exception:
+        frappe.throw(_("User {0} does not have User Settings configured.").format(frappe.bold(user)))
 
-	return False
+    return False
 
 
 def is_jmap_configured(user: str, raise_exception: bool = False) -> bool:
-	"""Returns True if the user has JMAP settings configured else False."""
+    """Returns True if the user has JMAP settings configured else False."""
 
-	if frappe.db.exists("User Settings", {"user": user, "username": ["!=", None]}):
-		return True
+    if frappe.db.exists("User Settings", {"user": user, "username": ["!=", None]}):
+        return True
 
-	if raise_exception:
-		frappe.throw(_("User {0} does not have JMAP settings configured.").format(frappe.bold(user)))
+    if raise_exception:
+        frappe.throw(_("User {0} does not have JMAP settings configured.").format(frappe.bold(user)))
 
-	return False
+    return False
 
 
 @request_cache
 def get_user_account_ids(user: str) -> list[str]:
-	"""Returns the JMAP account IDs the user has access to.
+    """Returns the JMAP account IDs the user has access to.
 
-	The IDs are read from the user's cached JMAP session (populated whenever a JMAP
-	connection is established). This is the source of truth for which JMAP Account
-	a user may read/write, since those documents are shared per JMAP account ID.
-	"""
+    The IDs are read from the user's cached JMAP session (populated whenever a JMAP
+    connection is established). This is the source of truth for which JMAP Account
+    a user may read/write, since those documents are shared per JMAP account ID.
+    """
 
-	from suite.mail.doctype.user_account.user_account import get_user_jmap_accounts
+    from suite.mail.doctype.user_account.user_account import get_user_jmap_accounts
 
-	return get_user_jmap_accounts(user)
+    return get_user_jmap_accounts(user)
 
 
 def get_account_user(account: str, user: str | None = None) -> str:
-	"""Resolve the user whose JMAP connection authenticates requests for ``account``.
+    """Resolve the user whose JMAP connection authenticates requests for ``account``.
 
-	Defaults to the explicitly provided ``user`` or the session user. An Administrator or
-	System Manager may not personally have JMAP access to the account, so for them we fall
-	back to any user linked to the account via User Account.
-	"""
+    Defaults to the explicitly provided ``user`` or the session user. An Administrator or
+    System Manager may not personally have JMAP access to the account, so for them we fall
+    back to any user linked to the account via User Account.
+    """
 
-	if user:
-		return user
+    if user:
+        return user
 
-	user = frappe.session.user
-	if is_system_manager(user):
-		if linked := frappe.db.get_value("User Account", {"account": account}, "user"):
-			return linked
+    user = frappe.session.user
+    if is_system_manager(user):
+        if linked := frappe.db.get_value("User Account", {"account": account}, "user"):
+            return linked
 
-	return user
+    return user
 
 
 def get_account_emails(account: str) -> list[str]:
-	"""Returns the list of email addresses associated with the account."""
+    """Returns the list of email addresses associated with the account."""
 
-	from suite.mail.jmap import get_identities
+    from suite.mail.jmap import get_identities
 
-	emails = []
-	for identity in get_identities(account):
-		emails.append(identity["email"])
+    emails = []
+    for identity in get_identities(account):
+        emails.append(identity["email"])
 
-	return emails
+    return emails
 
 
 def get_user_email_address(user: str) -> str | None:
-	"""Returns the primary email address of the user."""
+    """Returns the primary email address of the user."""
 
-	return frappe.db.get_value("User", user, "email")
+    return frappe.db.get_value("User", user, "email")
 
 
 def get_sync_state(account: str, type: Literal["email"]) -> str | None:
-	"""Returns the Sync State for the given account and type."""
+    """Returns the Sync State for the given account and type."""
 
-	store = get_data_store(account)
-	value = store.get(Entity.STATE, f"{type}_current_state")
+    store = get_data_store(account)
+    value = store.get(Entity.STATE, f"{type}_current_state")
 
-	return value
+    return value
 
 
 def update_sync_state(account: str, type: Literal["email"], state: str) -> None:
-	"""Updates the Sync State for the given account and type.
+    """Updates the Sync State for the given account and type.
 
-	The state (and its last-update timestamp, used to throttle scheduled syncs) lives in
-	the per-account data store, shared across every user of the account.
-	"""
+    The state (and its last-update timestamp, used to throttle scheduled syncs) lives in
+    the per-account data store, shared across every user of the account.
+    """
 
-	store = get_data_store(account)
-	current_state = store.get(Entity.STATE, f"{type}_current_state")
-	store.set_many(
-		Entity.STATE,
-		{
-			f"{type}_previous_state": current_state,
-			f"{type}_current_state": state,
-			f"{type}_state_last_update": frappe.utils.now(),
-		},
-	)
+    store = get_data_store(account)
+    current_state = store.get(Entity.STATE, f"{type}_current_state")
+    store.set_many(
+        Entity.STATE,
+        {
+            f"{type}_previous_state": current_state,
+            f"{type}_current_state": state,
+            f"{type}_state_last_update": frappe.utils.now(),
+        },
+    )
 
 
 @reconnect_on_failure()
 def clear_sync_state(account: str, type: Literal["email"]) -> None:
-	"""Clear the Sync State for the given account and type."""
+    """Clear the Sync State for the given account and type."""
 
-	store = get_data_store(account)
-	store.delete(Entity.STATE, f"{type}_current_state")
-	store.delete(Entity.STATE, f"{type}_previous_state")
-	store.delete(Entity.STATE, f"{type}_state_last_update")
+    store = get_data_store(account)
+    store.delete(Entity.STATE, f"{type}_current_state")
+    store.delete(Entity.STATE, f"{type}_previous_state")
+    store.delete(Entity.STATE, f"{type}_state_last_update")

--- a/suite/mail/utils/validation.py
+++ b/suite/mail/utils/validation.py
@@ -12,229 +12,229 @@ from suite.mail.utils import get_config
 # A domain label is 1-63 chars of letters/digits/hyphens (no leading/trailing hyphen); a domain name is
 # two or more such labels joined by dots, at most 253 chars overall (e.g. "frappe.io").
 DOMAIN_NAME_PATTERN = re.compile(
-	r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))+$"
+    r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))+$"
 )
 
 
 def is_domain_entry(value: str) -> bool:
-	"""Whether a screened value denotes a whole domain, i.e. is prefixed with '@' (e.g. '@frappe.io')."""
+    """Whether a screened value denotes a whole domain, i.e. is prefixed with '@' (e.g. '@frappe.io')."""
 
-	return (value or "").startswith("@")
+    return (value or "").startswith("@")
 
 
 def normalize_screened_value(value: str) -> str:
-	"""Normalise a screened value: trim it, and lowercase the domain of a '@domain' entry so that
-	'@Frappe.io' and '@frappe.io' collapse to a single rule."""
+    """Normalise a screened value: trim it, and lowercase the domain of a '@domain' entry so that
+    '@Frappe.io' and '@frappe.io' collapse to a single rule."""
 
-	value = (value or "").strip()
-	if is_domain_entry(value):
-		return "@" + value[1:].strip().lower()
+    value = (value or "").strip()
+    if is_domain_entry(value):
+        return "@" + value[1:].strip().lower()
 
-	return value
+    return value
 
 
 def validate_screened_value(value: str, raise_exception: bool = False) -> bool:
-	"""Validate a Screened Email Address value.
+    """Validate a Screened Email Address value.
 
-	A value is valid when it is either a full email address (e.g. "john@example.com") or a domain
-	prefixed with '@' (e.g. "@example.com"), which screens every sender from that domain.
-	"""
+    A value is valid when it is either a full email address (e.g. "john@example.com") or a domain
+    prefixed with '@' (e.g. "@example.com"), which screens every sender from that domain.
+    """
 
-	value = (value or "").strip()
+    value = (value or "").strip()
 
-	if is_domain_entry(value):
-		is_valid = bool(DOMAIN_NAME_PATTERN.match(value[1:]))
-	else:
-		is_valid = bool(value) and bool(validate_email_address(value))
+    if is_domain_entry(value):
+        is_valid = bool(DOMAIN_NAME_PATTERN.match(value[1:]))
+    else:
+        is_valid = bool(value) and bool(validate_email_address(value))
 
-	if not is_valid and raise_exception:
-		frappe.throw(
-			_(
-				"{0} is not a valid email address or domain. Enter an email address (e.g. john@example.com) "
-				"or a domain prefixed with @ (e.g. @example.com)."
-			).format(frappe.bold(value or "''"))
-		)
+    if not is_valid and raise_exception:
+        frappe.throw(
+            _(
+                "{0} is not a valid email address or domain. Enter an email address (e.g. john@example.com) "
+                "or a domain prefixed with @ (e.g. @example.com)."
+            ).format(frappe.bold(value or "''"))
+        )
 
-	return is_valid
+    return is_valid
 
 
 def is_subaddressed_email(email: str, raise_exception: bool = False) -> bool:
-	"""Returns True if the email address contains subaddressing else False."""
+    """Returns True if the email address contains subaddressing else False."""
 
-	if re.search(r"[^@]+\+[^@]+@", email):
-		if raise_exception:
-			frappe.throw(_("Subaddressing is not allowed in the email address."))
+    if re.search(r"[^@]+\+[^@]+@", email):
+        if raise_exception:
+            frappe.throw(_("Subaddressing is not allowed in the email address."))
 
-		return True
-	return False
+        return True
+    return False
 
 
 def is_valid_email_for_domain(email: str, domain_name: str, raise_exception: bool = False) -> bool:
-	"""Returns True if the email domain matches with the given domain else False."""
+    """Returns True if the email domain matches with the given domain else False."""
 
-	email_domain = email.split("@")[1]
+    email_domain = email.split("@")[1]
 
-	if email_domain != domain_name:
-		if raise_exception:
-			frappe.throw(
-				_("Email domain {0} does not match with domain {1}.").format(
-					frappe.bold(email_domain), frappe.bold(domain_name)
-				)
-			)
+    if email_domain != domain_name:
+        if raise_exception:
+            frappe.throw(
+                _("Email domain {0} does not match with domain {1}.").format(
+                    frappe.bold(email_domain), frappe.bold(domain_name)
+                )
+            )
 
-		return False
-	return True
+        return False
+    return True
 
 
 def validate_jmap_structure(
-	base_dir: str, required_files: list[str] | None = None, raise_exception: bool = False
+    base_dir: str, required_files: list[str] | None = None, raise_exception: bool = False
 ) -> list[str]:
-	"""Validates a JMAP import directory. Returns a list of missing files or folders."""
+    """Validates a JMAP import directory. Returns a list of missing files or folders."""
 
-	required_files = required_files or {
-		"emails.json",
-		"identities.json",
-		"mailboxes.json",
-		"sieve.json",
-		"vacation.json",
-	}
-	required_dirs = {"blobs"}
+    required_files = required_files or {
+        "emails.json",
+        "identities.json",
+        "mailboxes.json",
+        "sieve.json",
+        "vacation.json",
+    }
+    required_dirs = {"blobs"}
 
-	missing = []
-	base_folder = os.path.basename(base_dir)
+    missing = []
+    base_folder = os.path.basename(base_dir)
 
-	for file in required_files:
-		if not os.path.isfile(os.path.join(base_dir, file)):
-			missing.append(f"/{base_folder}/{file}")
+    for file in required_files:
+        if not os.path.isfile(os.path.join(base_dir, file)):
+            missing.append(f"/{base_folder}/{file}")
 
-	for dir in required_dirs:
-		if not os.path.isdir(os.path.join(base_dir, dir)):
-			missing.append(f"/{base_folder}/{dir}/")
+    for dir in required_dirs:
+        if not os.path.isdir(os.path.join(base_dir, dir)):
+            missing.append(f"/{base_folder}/{dir}/")
 
-	if missing and raise_exception:
-		frappe.throw(
-			_("Missing required files/directories for JMAP format: {0}").format(
-				", ".join(f"{m}" for m in missing)
-			),
-			title=_("Invalid JMAP Structure"),
-		)
+    if missing and raise_exception:
+        frappe.throw(
+            _("Missing required files/directories for JMAP format: {0}").format(
+                ", ".join(f"{m}" for m in missing)
+            ),
+            title=_("Invalid JMAP Structure"),
+        )
 
-	return missing
+    return missing
 
 
 def is_valid_maildir(base_dir: str, raise_exception: bool = False) -> bool:
-	"""
-	Checks if the given base directory is a valid Maildir.
+    """
+    Checks if the given base directory is a valid Maildir.
 
-	Valid if at least one of `cur`, `new`, or `tmp` exists
-	and contains at least one file (recursively).
-	"""
+    Valid if at least one of `cur`, `new`, or `tmp` exists
+    and contains at least one file (recursively).
+    """
 
-	def has_file(dir_path: str) -> bool:
-		for _root, _dirs, files in os.walk(dir_path):
-			if files:
-				return True
-		return False
+    def has_file(dir_path: str) -> bool:
+        for _root, _dirs, files in os.walk(dir_path):
+            if files:
+                return True
+        return False
 
-	maildir_dirs = ("cur", "new", "tmp")
-	for d in maildir_dirs:
-		dir_path = os.path.join(base_dir, d)
-		if os.path.isdir(dir_path) and has_file(dir_path):
-			return True
+    maildir_dirs = ("cur", "new", "tmp")
+    for d in maildir_dirs:
+        dir_path = os.path.join(base_dir, d)
+        if os.path.isdir(dir_path) and has_file(dir_path):
+            return True
 
-	if raise_exception:
-		frappe.throw(
-			_("Invalid Maildir format: at least one of {0} must exist and contain files.").format(
-				", ".join(f"<code>{d}</code>" for d in maildir_dirs)
-			),
-			title=_("Invalid Maildir"),
-		)
+    if raise_exception:
+        frappe.throw(
+            _("Invalid Maildir format: at least one of {0} must exist and contain files.").format(
+                ", ".join(f"<code>{d}</code>" for d in maildir_dirs)
+            ),
+            title=_("Invalid Maildir"),
+        )
 
-	return False
+    return False
 
 
 def validate_maildir_or_maildirpp(base_dir: str, raise_exception: bool = False) -> list[str]:
-	"""Validates a base Maildir or Maildir++ structure. Returns a list of invalid subdirs (relative paths)."""
+    """Validates a base Maildir or Maildir++ structure. Returns a list of invalid subdirs (relative paths)."""
 
-	invalid_dirs = []
+    invalid_dirs = []
 
-	def to_rel(path) -> str:
-		rel = os.path.relpath(path, base_dir)
-		return "/" if rel == "." else f"/{rel}"
+    def to_rel(path) -> str:
+        rel = os.path.relpath(path, base_dir)
+        return "/" if rel == "." else f"/{rel}"
 
-	if not is_valid_maildir(base_dir, raise_exception=False):
-		invalid_dirs.append("/")
+    if not is_valid_maildir(base_dir, raise_exception=False):
+        invalid_dirs.append("/")
 
-	for entry in os.listdir(base_dir):
-		full_path = os.path.join(base_dir, entry)
-		if entry.startswith(".") and os.path.isdir(full_path):
-			if not is_valid_maildir(full_path, raise_exception=False):
-				invalid_dirs.append(to_rel(full_path))
+    for entry in os.listdir(base_dir):
+        full_path = os.path.join(base_dir, entry)
+        if entry.startswith(".") and os.path.isdir(full_path):
+            if not is_valid_maildir(full_path, raise_exception=False):
+                invalid_dirs.append(to_rel(full_path))
 
-	if invalid_dirs and raise_exception:
-		frappe.throw(
-			_("Invalid Maildir format in the following directories: {0}").format(
-				", ".join(f"<code>{d}</code>" for d in invalid_dirs)
-			),
-			title=_("Invalid Maildir"),
-		)
+    if invalid_dirs and raise_exception:
+        frappe.throw(
+            _("Invalid Maildir format in the following directories: {0}").format(
+                ", ".join(f"<code>{d}</code>" for d in invalid_dirs)
+            ),
+            title=_("Invalid Maildir"),
+        )
 
-	return invalid_dirs
+    return invalid_dirs
 
 
 def validate_nested_maildir_tree(base_dir: str, raise_exception: bool = False) -> list[str]:
-	"""
-	Recursively validates a nested Maildir++ tree.
+    """
+    Recursively validates a nested Maildir++ tree.
 
-	A mailbox is valid if it:
-	- contains cur/ or new/
-	- OR contains child mailboxes (.Child)
-	"""
+    A mailbox is valid if it:
+    - contains cur/ or new/
+    - OR contains child mailboxes (.Child)
+    """
 
-	invalid_dirs: list[str] = []
-	base_dir = os.path.abspath(base_dir)
+    invalid_dirs: list[str] = []
+    base_dir = os.path.abspath(base_dir)
 
-	def to_rel(path: str) -> str:
-		rel = os.path.relpath(path, base_dir)
-		return "/" if rel == "." else f"/{rel}"
+    def to_rel(path: str) -> str:
+        rel = os.path.relpath(path, base_dir)
+        return "/" if rel == "." else f"/{rel}"
 
-	def is_valid_nested_mailbox(path: str) -> bool:
-		try:
-			entries = os.listdir(path)
-		except OSError:
-			return False
+    def is_valid_nested_mailbox(path: str) -> bool:
+        try:
+            entries = os.listdir(path)
+        except OSError:
+            return False
 
-		has_maildir = any(
-			name in ("cur", "new") and os.path.isdir(os.path.join(path, name)) for name in entries
-		)
-		has_children = any(
-			name.startswith(".") and os.path.isdir(os.path.join(path, name)) for name in entries
-		)
+        has_maildir = any(
+            name in ("cur", "new") and os.path.isdir(os.path.join(path, name)) for name in entries
+        )
+        has_children = any(
+            name.startswith(".") and os.path.isdir(os.path.join(path, name)) for name in entries
+        )
 
-		return has_maildir or has_children
+        return has_maildir or has_children
 
-	def walk(path: str) -> None:
-		for entry in os.listdir(path):
-			if not entry.startswith("."):
-				continue
+    def walk(path: str) -> None:
+        for entry in os.listdir(path):
+            if not entry.startswith("."):
+                continue
 
-			full_path = os.path.join(path, entry)
-			if not os.path.isdir(full_path):
-				continue
+            full_path = os.path.join(path, entry)
+            if not os.path.isdir(full_path):
+                continue
 
-			if not is_valid_nested_mailbox(full_path):
-				invalid_dirs.append(to_rel(full_path))
+            if not is_valid_nested_mailbox(full_path):
+                invalid_dirs.append(to_rel(full_path))
 
-			walk(full_path)
+            walk(full_path)
 
-	walk(base_dir)
+    walk(base_dir)
 
-	if invalid_dirs and raise_exception:
-		frappe.throw(
-			_("Invalid Maildir format in the following directories: {0}").format(
-				", ".join(f"<code>{d}</code>" for d in invalid_dirs)
-			),
-			title=_("Invalid Maildir"),
-		)
+    if invalid_dirs and raise_exception:
+        frappe.throw(
+            _("Invalid Maildir format in the following directories: {0}").format(
+                ", ".join(f"<code>{d}</code>" for d in invalid_dirs)
+            ),
+            title=_("Invalid Maildir"),
+        )
 
-	return invalid_dirs
+    return invalid_dirs

--- a/suite/mail/www/mail.py
+++ b/suite/mail/www/mail.py
@@ -5,24 +5,24 @@ no_cache = 1
 
 
 def get_context():
-	frappe.db.commit()
-	context = frappe._dict()
-	context.boot = get_boot()
-	return context
+    frappe.db.commit()
+    context = frappe._dict()
+    context.boot = get_boot()
+    return context
 
 
 @frappe.whitelist(methods=["POST"], allow_guest=True)
 def get_context_for_dev():
-	if not frappe.conf.developer_mode:
-		frappe.throw(_("This method is only meant for developer mode"))
-	return get_boot()
+    if not frappe.conf.developer_mode:
+        frappe.throw(_("This method is only meant for developer mode"))
+    return get_boot()
 
 
 def get_boot():
-	return frappe._dict(
-		{
-			"site_name": frappe.local.site,
-			"csrf_token": frappe.sessions.get_csrf_token(),
-			"push_relay_server_url": frappe.conf.get("push_relay_server_url") or "",
-		}
-	)
+    return frappe._dict(
+        {
+            "site_name": frappe.local.site,
+            "csrf_token": frappe.sessions.get_csrf_token(),
+            "push_relay_server_url": frappe.conf.get("push_relay_server_url") or "",
+        }
+    )

--- a/suite/meet/api/account.py
+++ b/suite/meet/api/account.py
@@ -8,37 +8,37 @@ from frappe.utils.caching import redis_cache
 @frappe.whitelist(allow_guest=True)
 @redis_cache(ttl=10 * 60)
 def oauth_providers(redirect_url: str = "") -> list[dict]:
-	from frappe.utils.html_utils import get_icon_html
-	from frappe.utils.oauth import get_oauth2_authorize_url, get_oauth_keys
-	from frappe.utils.password import get_decrypted_password
+    from frappe.utils.html_utils import get_icon_html
+    from frappe.utils.oauth import get_oauth2_authorize_url, get_oauth_keys
+    from frappe.utils.password import get_decrypted_password
 
-	out = []
-	providers = frappe.get_all(
-		"Social Login Key",
-		filters={"enable_social_login": 1},
-		fields=["name", "client_id", "base_url", "provider_name", "icon"],
-		order_by="name",
-	)
+    out = []
+    providers = frappe.get_all(
+        "Social Login Key",
+        filters={"enable_social_login": 1},
+        fields=["name", "client_id", "base_url", "provider_name", "icon"],
+        order_by="name",
+    )
 
-	for provider in providers:
-		client_secret = get_decrypted_password("Social Login Key", provider.name, "client_secret")
-		if not client_secret:
-			continue
+    for provider in providers:
+        client_secret = get_decrypted_password("Social Login Key", provider.name, "client_secret")
+        if not client_secret:
+            continue
 
-		icon = None
-		if provider.icon:
-			if provider.provider_name == "Custom":
-				icon = get_icon_html(provider.icon, small=True)
-			else:
-				icon = f"<img src='{provider.icon}' alt={provider.provider_name}>"
+        icon = None
+        if provider.icon:
+            if provider.provider_name == "Custom":
+                icon = get_icon_html(provider.icon, small=True)
+            else:
+                icon = f"<img src='{provider.icon}' alt={provider.provider_name}>"
 
-		if provider.client_id and provider.base_url and get_oauth_keys(provider.name):
-			out.append(
-				{
-					"name": provider.name,
-					"provider_name": provider.provider_name,
-					"auth_url": get_oauth2_authorize_url(provider.name, f"/meet{redirect_url}"),
-					"icon": icon,
-				}
-			)
-	return out
+        if provider.client_id and provider.base_url and get_oauth_keys(provider.name):
+            out.append(
+                {
+                    "name": provider.name,
+                    "provider_name": provider.provider_name,
+                    "auth_url": get_oauth2_authorize_url(provider.name, f"/meet{redirect_url}"),
+                    "icon": icon,
+                }
+            )
+    return out

--- a/suite/meet/api/meeting.py
+++ b/suite/meet/api/meeting.py
@@ -14,672 +14,672 @@ from frappe.rate_limiter import rate_limit
 
 from suite.meet.utils.sfu_config import get_sfu_config
 from suite.meet.utils.user import (
-	get_guest_session,
-	get_user_info,
-	set_guest_session,
-	validate_guest_name,
+    get_guest_session,
+    get_user_info,
+    set_guest_session,
+    validate_guest_name,
 )
 
 if TYPE_CHECKING:
-	from suite.meet.doctype.meet_room.meet_room import MeetRoom
+    from suite.meet.doctype.meet_room.meet_room import MeetRoom
 
 
 def _generate_sfu_token(
-	user_id: str,
-	meeting_id: str,
-	scope: str = "full",
-	expires_in: int = 3600,
-	**extra,
+    user_id: str,
+    meeting_id: str,
+    scope: str = "full",
+    expires_in: int = 3600,
+    **extra,
 ) -> str:
-	"""Generate a JWT token for SFU authentication."""
-	sfu_config = get_sfu_config()
-	secret = sfu_config.get("sfu_secret")
-	if not secret:
-		frappe.throw(_("SFU secret not configured"))
+    """Generate a JWT token for SFU authentication."""
+    sfu_config = get_sfu_config()
+    secret = sfu_config.get("sfu_secret")
+    if not secret:
+        frappe.throw(_("SFU secret not configured"))
 
-	now = int(time.time())
-	payload = {
-		"user_id": user_id,
-		"meeting_id": meeting_id,
-		"site": getattr(frappe.local, "site", None),
-		"scope": scope,
-		"exp": now + expires_in,
-		"iat": now,
-		**extra,
-	}
-	return jwt.encode(payload, secret, algorithm="HS256")
+    now = int(time.time())
+    payload = {
+        "user_id": user_id,
+        "meeting_id": meeting_id,
+        "site": getattr(frappe.local, "site", None),
+        "scope": scope,
+        "exp": now + expires_in,
+        "iat": now,
+        **extra,
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
 
 
 def _get_codec_strategy() -> str:
-	return frappe.get_cached_doc("Meet Settings").codec_strategy or "svc"
+    return frappe.get_cached_doc("Meet Settings").codec_strategy or "svc"
 
 
 def _is_e2ee_enabled(meeting_id: str) -> bool:
-	return bool(frappe.db.get_value("Meet Room", meeting_id, "e2ee_enabled"))
+    return bool(frappe.db.get_value("Meet Room", meeting_id, "e2ee_enabled"))
 
 
 def _is_valid_e2ee_device_id(device_id: str | None) -> bool:
-	"""A device id is a short opaque client-chosen string (max 64 chars)."""
-	if not device_id or not isinstance(device_id, str):
-		return False
-	return 1 <= len(device_id) <= 64 and all(c.isalnum() or c in "-_." for c in device_id)
+    """A device id is a short opaque client-chosen string (max 64 chars)."""
+    if not device_id or not isinstance(device_id, str):
+        return False
+    return 1 <= len(device_id) <= 64 and all(c.isalnum() or c in "-_." for c in device_id)
 
 
 def _user_payload(meeting, user) -> tuple[str, str | None, bool, bool]:
-	"""Return (fullname, avatar, is_host, is_cohost) for a signed-in user."""
-	fullname, avatar = frappe.db.get_value("User", user, ["full_name", "user_image"]) or (
-		user,
-		None,
-	)
-	is_host = meeting.owner == user
-	is_cohost = meeting.is_host_or_cohost(user) and not is_host
-	return fullname, avatar, is_host, is_cohost
+    """Return (fullname, avatar, is_host, is_cohost) for a signed-in user."""
+    fullname, avatar = frappe.db.get_value("User", user, ["full_name", "user_image"]) or (
+        user,
+        None,
+    )
+    is_host = meeting.owner == user
+    is_cohost = meeting.is_host_or_cohost(user) and not is_host
+    return fullname, avatar, is_host, is_cohost
 
 
 def _build_sfu_connection_details(meeting: MeetRoom, user: str) -> dict:
-	"""SFU JWT + endpoint payload for a signed-in user.
+    """SFU JWT + endpoint payload for a signed-in user.
 
-	Callers must enforce membership / join ACL first. Mints a full-scope media
-	token from server-side identity only (never client-supplied claims).
-	"""
-	if not user or user == "Guest":
-		frappe.throw(_("Authentication required"), frappe.AuthenticationError)
+    Callers must enforce membership / join ACL first. Mints a full-scope media
+    token from server-side identity only (never client-supplied claims).
+    """
+    if not user or user == "Guest":
+        frappe.throw(_("Authentication required"), frappe.AuthenticationError)
 
-	sfu_config = get_sfu_config()
-	user_fullname, user_avatar, is_host, is_cohost = _user_payload(meeting, user)
-	e2ee_required = bool(getattr(meeting, "e2ee_enabled", False))
+    sfu_config = get_sfu_config()
+    user_fullname, user_avatar, is_host, is_cohost = _user_payload(meeting, user)
+    e2ee_required = bool(getattr(meeting, "e2ee_enabled", False))
 
-	auth_token = _generate_sfu_token(
-		user_id=user,
-		meeting_id=meeting.name,
-		scope="full",
-		user_name=user_fullname,
-		user_avatar=user_avatar,
-		is_host=is_host,
-		is_cohost=is_cohost,
-		e2ee_required=e2ee_required,
-	)
+    auth_token = _generate_sfu_token(
+        user_id=user,
+        meeting_id=meeting.name,
+        scope="full",
+        user_name=user_fullname,
+        user_avatar=user_avatar,
+        is_host=is_host,
+        is_cohost=is_cohost,
+        e2ee_required=e2ee_required,
+    )
 
-	return {
-		"sfu_url": sfu_config["sfu_server_url"],
-		"sfu_port": sfu_config["sfu_server_port"],
-		"auth_token": auth_token,
-		"user_id": user,
-		"meeting_id": meeting.name,
-		"is_host": is_host,
-		"is_cohost": is_cohost,
-		"codec_strategy": _get_codec_strategy(),
-		"e2ee_required": e2ee_required,
-		"user_data": {
-			"name": user_fullname,
-			"email": user,
-			"avatar": user_avatar,
-		},
-		"expires_in": 3600,
-		"host_only_chat": bool(meeting.host_only_chat),
-	}
+    return {
+        "sfu_url": sfu_config["sfu_server_url"],
+        "sfu_port": sfu_config["sfu_server_port"],
+        "auth_token": auth_token,
+        "user_id": user,
+        "meeting_id": meeting.name,
+        "is_host": is_host,
+        "is_cohost": is_cohost,
+        "codec_strategy": _get_codec_strategy(),
+        "e2ee_required": e2ee_required,
+        "user_data": {
+            "name": user_fullname,
+            "email": user,
+            "avatar": user_avatar,
+        },
+        "expires_in": 3600,
+        "host_only_chat": bool(meeting.host_only_chat),
+    }
 
 
 @frappe.whitelist()
 @rate_limit(limit=10, seconds=60 * 60)
 def create(meeting_type: str = "open", allow_guest: bool = True, title: str | None = None) -> str:
-	"""Create a new meeting with specified type"""
-	global_settings = frappe.get_cached_doc("Meet Settings")
-	if not global_settings.allow_guest:
-		allow_guest = False
+    """Create a new meeting with specified type"""
+    global_settings = frappe.get_cached_doc("Meet Settings")
+    if not global_settings.allow_guest:
+        allow_guest = False
 
-	meeting: MeetRoom = frappe.get_doc(
-		{
-			"doctype": "Meet Room",
-			"title": title,
-			"meeting_type": meeting_type,
-			"allow_guest": allow_guest,
-		}
-	).insert()
+    meeting: MeetRoom = frappe.get_doc(
+        {
+            "doctype": "Meet Room",
+            "title": title,
+            "meeting_type": meeting_type,
+            "allow_guest": allow_guest,
+        }
+    ).insert()
 
-	return meeting.name
+    return meeting.name
 
 
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=10, seconds=60)
 def get_public_meeting_preview(meeting_id: str) -> dict:
-	"""Return title-only data for the meeting preview."""
-	title = frappe.db.get_value("Meet Room", meeting_id, "title")
-	return {"title": title or meeting_id}
+    """Return title-only data for the meeting preview."""
+    title = frappe.db.get_value("Meet Room", meeting_id, "title")
+    return {"title": title or meeting_id}
 
 
 @frappe.whitelist()
 def get_sfu_connection_details(meeting_id: str) -> dict:
-	"""
-	Get SFU connection details for direct client-to-SFU communication
-	"""
-	meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id)
-	user = frappe.session.user
+    """
+    Get SFU connection details for direct client-to-SFU communication
+    """
+    meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id)
+    user = frappe.session.user
 
-	if meeting.is_user_banned(user):
-		frappe.throw(_("You are banned from this meeting"), frappe.PermissionError)
+    if meeting.is_user_banned(user):
+        frappe.throw(_("You are banned from this meeting"), frappe.PermissionError)
 
-	if user not in meeting.get_members():
-		frappe.throw(_("Not a meeting member"), frappe.PermissionError)
+    if user not in meeting.get_members():
+        frappe.throw(_("Not a meeting member"), frappe.PermissionError)
 
-	if not meeting.can_join(user):
-		frappe.throw(_("Access denied"), frappe.PermissionError)
+    if not meeting.can_join(user):
+        frappe.throw(_("Access denied"), frappe.PermissionError)
 
-	return _build_sfu_connection_details(meeting, user)
+    return _build_sfu_connection_details(meeting, user)
 
 
 @frappe.whitelist()
 def join_meeting(meeting_id: str) -> dict:
-	meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id, for_update=True)
+    meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id, for_update=True)
 
-	if meeting.is_user_banned(frappe.session.user):
-		frappe.throw(_("You are banned from this meeting"), frappe.PermissionError)
+    if meeting.is_user_banned(frappe.session.user):
+        frappe.throw(_("You are banned from this meeting"), frappe.PermissionError)
 
-	if meeting.can_join(frappe.session.user):
-		result = meeting.join(frappe.session.user)
+    if meeting.can_join(frappe.session.user):
+        result = meeting.join(frappe.session.user)
 
-		if isinstance(result, dict):
-			if result.get("status") == "waiting_for_approval":
-				sfu_config = get_sfu_config()
+        if isinstance(result, dict):
+            if result.get("status") == "waiting_for_approval":
+                sfu_config = get_sfu_config()
 
-				user_fullname, user_avatar = frappe.db.get_value(
-					"User", frappe.session.user, ["full_name", "user_image"]
-				) or (frappe.session.user, None)
+                user_fullname, user_avatar = frappe.db.get_value(
+                    "User", frappe.session.user, ["full_name", "user_image"]
+                ) or (frappe.session.user, None)
 
-				lobby_token = _generate_sfu_token(
-					user_id=frappe.session.user,
-					meeting_id=meeting_id,
-					scope="presence-preview",
-					user_name=user_fullname,
-					user_avatar=user_avatar,
-					is_host=False,
-					is_guest=False,
-				)
+                lobby_token = _generate_sfu_token(
+                    user_id=frappe.session.user,
+                    meeting_id=meeting_id,
+                    scope="presence-preview",
+                    user_name=user_fullname,
+                    user_avatar=user_avatar,
+                    is_host=False,
+                    is_guest=False,
+                )
 
-				return {
-					"status": "waiting_for_approval",
-					"meeting_id": meeting_id,
-					"message": result.get("message", "Waiting for host approval"),
-					"lobby_token": lobby_token,
-					"sfu_url": sfu_config["sfu_server_url"],
-					"sfu_port": sfu_config["sfu_server_port"],
-					"user_data": {
-						"name": user_fullname,
-						"avatar": user_avatar,
-					},
-				}
-			elif result.get("status") == "joined":
-				user = frappe.session.user
-				# Full media token only after membership is real (not lobby).
-				if user not in meeting.get_members():
-					frappe.throw(_("Not a meeting member"), frappe.PermissionError)
-				# Bundle SFU JWT so the client can skip a second
-				# get_sfu_connection_details round-trip on the critical path.
-				details = _build_sfu_connection_details(meeting, user)
-				return {
-					"status": "joined",
-					"message": result.get("message", "Successfully joined meeting"),
-					**details,
-				}
-	else:
-		frappe.throw(_("Access denied"))
+                return {
+                    "status": "waiting_for_approval",
+                    "meeting_id": meeting_id,
+                    "message": result.get("message", "Waiting for host approval"),
+                    "lobby_token": lobby_token,
+                    "sfu_url": sfu_config["sfu_server_url"],
+                    "sfu_port": sfu_config["sfu_server_port"],
+                    "user_data": {
+                        "name": user_fullname,
+                        "avatar": user_avatar,
+                    },
+                }
+            elif result.get("status") == "joined":
+                user = frappe.session.user
+                # Full media token only after membership is real (not lobby).
+                if user not in meeting.get_members():
+                    frappe.throw(_("Not a meeting member"), frappe.PermissionError)
+                # Bundle SFU JWT so the client can skip a second
+                # get_sfu_connection_details round-trip on the critical path.
+                details = _build_sfu_connection_details(meeting, user)
+                return {
+                    "status": "joined",
+                    "message": result.get("message", "Successfully joined meeting"),
+                    **details,
+                }
+    else:
+        frappe.throw(_("Access denied"))
 
 
 @frappe.whitelist()
 def approve_join_request(meeting_id: str, user_id: str) -> dict:
-	"""Approve a user's join request from waiting room"""
-	meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id, for_update=True)
-	meeting.approve_user(user_id)
+    """Approve a user's join request from waiting room"""
+    meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id, for_update=True)
+    meeting.approve_user(user_id)
 
-	return {"meeting_id": meeting_id, "user_id": user_id, "message": "User approved successfully"}
+    return {"meeting_id": meeting_id, "user_id": user_id, "message": "User approved successfully"}
 
 
 @frappe.whitelist()
 def approve_all_join_requests(meeting_id: str) -> dict:
-	"""Approve all users' join requests from waiting room"""
-	meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id, for_update=True)
-	meeting.approve_all_users()
+    """Approve all users' join requests from waiting room"""
+    meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id, for_update=True)
+    meeting.approve_all_users()
 
-	return {"meeting_id": meeting_id, "message": "All users approved successfully"}
+    return {"meeting_id": meeting_id, "message": "All users approved successfully"}
 
 
 @frappe.whitelist()
 def reject_join_request(meeting_id: str, user_id: str) -> dict:
-	"""Reject a user's join request from waiting room"""
-	meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id, for_update=True)
-	meeting.reject_user(user_id)
+    """Reject a user's join request from waiting room"""
+    meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id, for_update=True)
+    meeting.reject_user(user_id)
 
-	# For guests, publish realtime event in a guest-specific room
-	if user_id.startswith("guest_"):
-		frappe.publish_realtime(
-			"meet:guest_join_rejected",
-			{"meeting_id": meeting_id, "guest_id": user_id},
-			room=f"guest:{user_id}",
-			after_commit=True,
-		)
+    # For guests, publish realtime event in a guest-specific room
+    if user_id.startswith("guest_"):
+        frappe.publish_realtime(
+            "meet:guest_join_rejected",
+            {"meeting_id": meeting_id, "guest_id": user_id},
+            room=f"guest:{user_id}",
+            after_commit=True,
+        )
 
-	return {"meeting_id": meeting_id, "user_id": user_id, "message": "User rejected successfully"}
+    return {"meeting_id": meeting_id, "user_id": user_id, "message": "User rejected successfully"}
 
 
 @frappe.whitelist()
 def get_waiting_room(meeting_id: str) -> dict:
-	"""Get list of users waiting for approval"""
-	meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id)
+    """Get list of users waiting for approval"""
+    meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id)
 
-	if not meeting.is_host_or_cohost(frappe.session.user):
-		frappe.throw(_("Access denied"))
+    if not meeting.is_host_or_cohost(frappe.session.user):
+        frappe.throw(_("Access denied"))
 
-	waiting_rows = meeting.waiting_room or []
+    waiting_rows = meeting.waiting_room or []
 
-	user_details = []
-	for row in waiting_rows:
-		user = row.user
-		user_info = get_user_info(user)
-		user_name = row.user_name or (user_info.get("full_name") if user_info else None)
-		user_details.append(
-			{
-				"user_id": user,
-				"full_name": user_name or user,
-				"user_name": user_name or user,
-				"user_image": user_info.get("user_image") if user_info else None,
-				"is_guest": user_info.get("is_guest", False) if user_info else user.startswith("guest_"),
-			}
-		)
+    user_details = []
+    for row in waiting_rows:
+        user = row.user
+        user_info = get_user_info(user)
+        user_name = row.user_name or (user_info.get("full_name") if user_info else None)
+        user_details.append(
+            {
+                "user_id": user,
+                "full_name": user_name or user,
+                "user_name": user_name or user,
+                "user_image": user_info.get("user_image") if user_info else None,
+                "is_guest": user_info.get("is_guest", False) if user_info else user.startswith("guest_"),
+            }
+        )
 
-	return {"meeting_id": meeting_id, "waiting_users": user_details}
+    return {"meeting_id": meeting_id, "waiting_users": user_details}
 
 
 @frappe.whitelist()
 def refresh_sfu_token(meeting_id: str) -> dict:
-	"""
-	Refresh SFU authentication token for ongoing meetings
-	"""
-	meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id)
+    """
+    Refresh SFU authentication token for ongoing meetings
+    """
+    meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id)
 
-	if frappe.session.user not in meeting.get_members():
-		frappe.throw(_("Not a meeting member"))
+    if frappe.session.user not in meeting.get_members():
+        frappe.throw(_("Not a meeting member"))
 
-	user_fullname, user_avatar, is_host, is_cohost = _user_payload(meeting, frappe.session.user)
-	e2ee_required = bool(getattr(meeting, "e2ee_enabled", False))
+    user_fullname, user_avatar, is_host, is_cohost = _user_payload(meeting, frappe.session.user)
+    e2ee_required = bool(getattr(meeting, "e2ee_enabled", False))
 
-	auth_token = _generate_sfu_token(
-		user_id=frappe.session.user,
-		meeting_id=meeting_id,
-		user_name=user_fullname,
-		user_avatar=user_avatar,
-		is_host=is_host,
-		is_cohost=is_cohost,
-		e2ee_required=e2ee_required,
-	)
+    auth_token = _generate_sfu_token(
+        user_id=frappe.session.user,
+        meeting_id=meeting_id,
+        user_name=user_fullname,
+        user_avatar=user_avatar,
+        is_host=is_host,
+        is_cohost=is_cohost,
+        e2ee_required=e2ee_required,
+    )
 
-	return {
-		"auth_token": auth_token,
-		"expires_in": 3600,
-		"codec_strategy": _get_codec_strategy(),
-		"e2ee_required": e2ee_required,
-	}
+    return {
+        "auth_token": auth_token,
+        "expires_in": 3600,
+        "codec_strategy": _get_codec_strategy(),
+        "e2ee_required": e2ee_required,
+    }
 
 
 @frappe.whitelist()
 def get_sfu_presence_preview_token(meeting_id: str) -> dict:
-	"""Get a short-lived SFU token scoped for presence preview only.
+    """Get a short-lived SFU token scoped for presence preview only.
 
-	This is used by the meeting preview page to fetch live participants
-	from the SFU without granting any media capabilities.
-	"""
+    This is used by the meeting preview page to fetch live participants
+    from the SFU without granting any media capabilities.
+    """
 
-	try:
-		meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id)
-	except frappe.DoesNotExistError:
-		frappe.throw(_("Meeting not found"))
+    try:
+        meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id)
+    except frappe.DoesNotExistError:
+        frappe.throw(_("Meeting not found"))
 
-	if meeting.is_user_banned(frappe.session.user):
-		frappe.throw(_("You are banned from this meeting"), frappe.PermissionError)
+    if meeting.is_user_banned(frappe.session.user):
+        frappe.throw(_("You are banned from this meeting"), frappe.PermissionError)
 
-	if not meeting.can_join(frappe.session.user):
-		frappe.throw(_("Access denied"), frappe.PermissionError)
+    if not meeting.can_join(frappe.session.user):
+        frappe.throw(_("Access denied"), frappe.PermissionError)
 
-	sfu_config = get_sfu_config()
+    sfu_config = get_sfu_config()
 
-	expiry_seconds = 300
-	session_id = str(secrets.token_urlsafe(16))
+    expiry_seconds = 300
+    session_id = str(secrets.token_urlsafe(16))
 
-	auth_token = _generate_sfu_token(
-		user_id=frappe.session.user,
-		meeting_id=meeting_id,
-		scope="presence-preview",
-		expires_in=expiry_seconds,
-		session_id=session_id,
-	)
+    auth_token = _generate_sfu_token(
+        user_id=frappe.session.user,
+        meeting_id=meeting_id,
+        scope="presence-preview",
+        expires_in=expiry_seconds,
+        session_id=session_id,
+    )
 
-	return {
-		"sfu_url": sfu_config["sfu_server_url"],
-		"sfu_port": sfu_config.get("sfu_server_port"),
-		"auth_token": auth_token,
-		"expires_in": expiry_seconds,
-	}
+    return {
+        "sfu_url": sfu_config["sfu_server_url"],
+        "sfu_port": sfu_config.get("sfu_server_port"),
+        "auth_token": auth_token,
+        "expires_in": expiry_seconds,
+    }
 
 
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=10, seconds=60 * 60)
 def join_meeting_as_guest(meeting_id: str, guest_name: str, guest_id: str | None = None) -> dict:
-	"""
-	Allow guest users to join a meeting without authentication.
-	Generates a guest session and JWT token for SFU access.
-	"""
-	is_valid, error_message = validate_guest_name(guest_name)
-	if not is_valid:
-		frappe.throw(_(error_message))
+    """
+    Allow guest users to join a meeting without authentication.
+    Generates a guest session and JWT token for SFU access.
+    """
+    is_valid, error_message = validate_guest_name(guest_name)
+    if not is_valid:
+        frappe.throw(_(error_message))
 
-	if not frappe.db.exists("Meet Room", meeting_id):
-		frappe.throw(_("Meeting not found"))
+    if not frappe.db.exists("Meet Room", meeting_id):
+        frappe.throw(_("Meeting not found"))
 
-	meeting = frappe.get_doc("Meet Room", meeting_id, for_update=True)
+    meeting = frappe.get_doc("Meet Room", meeting_id, for_update=True)
 
-	global_settings = frappe.get_cached_doc("Meet Settings")
-	if not global_settings.allow_guest or not meeting.allow_guest:
-		frappe.throw(_("Guests are not allowed in this meeting"))
-	# Check if reusing existing guest_id
-	if guest_id:
-		session_data = get_guest_session(guest_id)
-		if session_data and session_data.get("meeting_id") == meeting_id:
-			# Reuse existing guest_id
-			guest_name_clean = session_data.get("guest_name", guest_name.strip())
-		else:
-			# Invalid or expired, generate new
-			guest_id = None
+    global_settings = frappe.get_cached_doc("Meet Settings")
+    if not global_settings.allow_guest or not meeting.allow_guest:
+        frappe.throw(_("Guests are not allowed in this meeting"))
+    # Check if reusing existing guest_id
+    if guest_id:
+        session_data = get_guest_session(guest_id)
+        if session_data and session_data.get("meeting_id") == meeting_id:
+            # Reuse existing guest_id
+            guest_name_clean = session_data.get("guest_name", guest_name.strip())
+        else:
+            # Invalid or expired, generate new
+            guest_id = None
 
-	if not guest_id:
-		guest_id = f"guest_{secrets.token_urlsafe(16)}"
-		guest_name_clean = guest_name.strip()
+    if not guest_id:
+        guest_id = f"guest_{secrets.token_urlsafe(16)}"
+        guest_name_clean = guest_name.strip()
 
-		session_data = {
-			"guest_id": guest_id,
-			"guest_name": guest_name_clean,
-			"meeting_id": meeting_id,
-			"ip_address": frappe.local.request_ip,
-			"joined_at": int(time.time()),
-		}
-		set_guest_session(guest_id, session_data, ttl=24 * 3600)
+        session_data = {
+            "guest_id": guest_id,
+            "guest_name": guest_name_clean,
+            "meeting_id": meeting_id,
+            "ip_address": frappe.local.request_ip,
+            "joined_at": int(time.time()),
+        }
+        set_guest_session(guest_id, session_data, ttl=24 * 3600)
 
-	if meeting.is_user_banned(guest_id):
-		frappe.throw(_("You are banned from this meeting"))
+    if meeting.is_user_banned(guest_id):
+        frappe.throw(_("You are banned from this meeting"))
 
-	sfu_config = get_sfu_config()
-	e2ee_required = bool(getattr(meeting, "e2ee_enabled", False))
+    sfu_config = get_sfu_config()
+    e2ee_required = bool(getattr(meeting, "e2ee_enabled", False))
 
-	if meeting.meeting_type == "restricted":
-		if meeting.is_user_approved(guest_id):
-			auth_token = _generate_sfu_token(
-				user_id=guest_id,
-				meeting_id=meeting_id,
-				expires_in=24 * 3600,
-				user_name=guest_name_clean,
-				is_host=False,
-				is_guest=True,
-				e2ee_required=e2ee_required,
-			)
-			return {
-				"status": "joined",
-				"meeting_id": meeting_id,
-				"guest_id": guest_id,
-				"guest_name": guest_name_clean,
-				"auth_token": auth_token,
-				"sfu_url": sfu_config["sfu_server_url"],
-				"sfu_port": sfu_config["sfu_server_port"],
-				"codec_strategy": _get_codec_strategy(),
-				"host_only_chat": bool(meeting.host_only_chat),
-				"e2ee_required": e2ee_required,
-				"message": "Successfully joined meeting",
-			}
-		elif guest_id not in meeting.get_waiting_room():
-			meeting.add_guest_to_waiting_room(guest_id)
+    if meeting.meeting_type == "restricted":
+        if meeting.is_user_approved(guest_id):
+            auth_token = _generate_sfu_token(
+                user_id=guest_id,
+                meeting_id=meeting_id,
+                expires_in=24 * 3600,
+                user_name=guest_name_clean,
+                is_host=False,
+                is_guest=True,
+                e2ee_required=e2ee_required,
+            )
+            return {
+                "status": "joined",
+                "meeting_id": meeting_id,
+                "guest_id": guest_id,
+                "guest_name": guest_name_clean,
+                "auth_token": auth_token,
+                "sfu_url": sfu_config["sfu_server_url"],
+                "sfu_port": sfu_config["sfu_server_port"],
+                "codec_strategy": _get_codec_strategy(),
+                "host_only_chat": bool(meeting.host_only_chat),
+                "e2ee_required": e2ee_required,
+                "message": "Successfully joined meeting",
+            }
+        elif guest_id not in meeting.get_waiting_room():
+            meeting.add_guest_to_waiting_room(guest_id)
 
-		return {
-			"status": "waiting_for_approval",
-			"meeting_id": meeting_id,
-			"guest_id": guest_id,
-			"guest_name": guest_name_clean,
-			"message": "Waiting for host approval",
-			"host_only_chat": bool(meeting.host_only_chat),
-		}
+        return {
+            "status": "waiting_for_approval",
+            "meeting_id": meeting_id,
+            "guest_id": guest_id,
+            "guest_name": guest_name_clean,
+            "message": "Waiting for host approval",
+            "host_only_chat": bool(meeting.host_only_chat),
+        }
 
-	# open meeting
-	auth_token = _generate_sfu_token(
-		user_id=guest_id,
-		meeting_id=meeting_id,
-		expires_in=24 * 3600,
-		user_name=guest_name_clean,
-		is_host=False,
-		is_guest=True,
-		e2ee_required=e2ee_required,
-	)
+    # open meeting
+    auth_token = _generate_sfu_token(
+        user_id=guest_id,
+        meeting_id=meeting_id,
+        expires_in=24 * 3600,
+        user_name=guest_name_clean,
+        is_host=False,
+        is_guest=True,
+        e2ee_required=e2ee_required,
+    )
 
-	meeting.add_guest_to_members(guest_id)
+    meeting.add_guest_to_members(guest_id)
 
-	return {
-		"status": "joined",
-		"meeting_id": meeting_id,
-		"guest_id": guest_id,
-		"guest_name": guest_name_clean,
-		"auth_token": auth_token,
-		"sfu_url": sfu_config["sfu_server_url"],
-		"sfu_port": sfu_config["sfu_server_port"],
-		"codec_strategy": _get_codec_strategy(),
-		"host_only_chat": bool(meeting.host_only_chat),
-		"e2ee_required": e2ee_required,
-		"message": "Successfully joined meeting",
-	}
+    return {
+        "status": "joined",
+        "meeting_id": meeting_id,
+        "guest_id": guest_id,
+        "guest_name": guest_name_clean,
+        "auth_token": auth_token,
+        "sfu_url": sfu_config["sfu_server_url"],
+        "sfu_port": sfu_config["sfu_server_port"],
+        "codec_strategy": _get_codec_strategy(),
+        "host_only_chat": bool(meeting.host_only_chat),
+        "e2ee_required": e2ee_required,
+        "message": "Successfully joined meeting",
+    }
 
 
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=10, seconds=60 * 60)
 def get_approved_guest_connection_details(meeting_id: str, guest_id: str) -> dict:
-	"""
-	Get SFU connection details for an approved guest.
-	This is called after a guest receives approval notification.
-	"""
-	session_data = get_guest_session(guest_id)
-	if not session_data:
-		frappe.throw(_("Guest session not found or expired"))
+    """
+    Get SFU connection details for an approved guest.
+    This is called after a guest receives approval notification.
+    """
+    session_data = get_guest_session(guest_id)
+    if not session_data:
+        frappe.throw(_("Guest session not found or expired"))
 
-	if not frappe.db.exists("Meet Room", meeting_id):
-		frappe.throw(_("Meeting not found"))
+    if not frappe.db.exists("Meet Room", meeting_id):
+        frappe.throw(_("Meeting not found"))
 
-	meeting = frappe.get_doc("Meet Room", meeting_id)
+    meeting = frappe.get_doc("Meet Room", meeting_id)
 
-	if not meeting.is_user_approved(guest_id):
-		frappe.throw(_("Guest not approved"))
+    if not meeting.is_user_approved(guest_id):
+        frappe.throw(_("Guest not approved"))
 
-	if meeting.is_user_banned(guest_id):
-		frappe.throw(_("You are banned from this meeting"))
+    if meeting.is_user_banned(guest_id):
+        frappe.throw(_("You are banned from this meeting"))
 
-	sfu_config = get_sfu_config()
+    sfu_config = get_sfu_config()
 
-	guest_name = session_data.get("guest_name", f"Guest-{guest_id[:8]}")
-	e2ee_required = bool(getattr(meeting, "e2ee_enabled", False))
+    guest_name = session_data.get("guest_name", f"Guest-{guest_id[:8]}")
+    e2ee_required = bool(getattr(meeting, "e2ee_enabled", False))
 
-	auth_token = _generate_sfu_token(
-		user_id=guest_id,
-		meeting_id=meeting_id,
-		expires_in=24 * 3600,
-		user_name=guest_name,
-		is_host=False,
-		is_guest=True,
-		e2ee_required=e2ee_required,
-	)
+    auth_token = _generate_sfu_token(
+        user_id=guest_id,
+        meeting_id=meeting_id,
+        expires_in=24 * 3600,
+        user_name=guest_name,
+        is_host=False,
+        is_guest=True,
+        e2ee_required=e2ee_required,
+    )
 
-	return {
-		"status": "joined",
-		"meeting_id": meeting_id,
-		"guest_id": guest_id,
-		"guest_name": guest_name,
-		"auth_token": auth_token,
-		"sfu_url": sfu_config["sfu_server_url"],
-		"sfu_port": sfu_config["sfu_server_port"],
-		"codec_strategy": _get_codec_strategy(),
-		"host_only_chat": bool(meeting.host_only_chat),
-		"e2ee_required": e2ee_required,
-		"message": "Successfully joined meeting",
-	}
+    return {
+        "status": "joined",
+        "meeting_id": meeting_id,
+        "guest_id": guest_id,
+        "guest_name": guest_name,
+        "auth_token": auth_token,
+        "sfu_url": sfu_config["sfu_server_url"],
+        "sfu_port": sfu_config["sfu_server_port"],
+        "codec_strategy": _get_codec_strategy(),
+        "host_only_chat": bool(meeting.host_only_chat),
+        "e2ee_required": e2ee_required,
+        "message": "Successfully joined meeting",
+    }
 
 
 @frappe.whitelist(allow_guest=True)
 def get_guest_sfu_connection_details(meeting_id: str, guest_token: str) -> dict:
-	"""
-	Get SFU connection details for guest users.
-	Validates the guest token and returns SFU URL/port.
-	"""
-	sfu_config = get_sfu_config()
-	secret = sfu_config.get("sfu_secret")
-	if not secret:
-		frappe.throw(_("SFU secret not configured"))
+    """
+    Get SFU connection details for guest users.
+    Validates the guest token and returns SFU URL/port.
+    """
+    sfu_config = get_sfu_config()
+    secret = sfu_config.get("sfu_secret")
+    if not secret:
+        frappe.throw(_("SFU secret not configured"))
 
-	try:
-		decoded = jwt.decode(guest_token, secret, algorithms=["HS256"])
-	except jwt.ExpiredSignatureError:
-		frappe.throw(_("Guest token has expired"))
-	except jwt.InvalidTokenError:
-		frappe.throw(_("Invalid guest token"))
+    try:
+        decoded = jwt.decode(guest_token, secret, algorithms=["HS256"])
+    except jwt.ExpiredSignatureError:
+        frappe.throw(_("Guest token has expired"))
+    except jwt.InvalidTokenError:
+        frappe.throw(_("Invalid guest token"))
 
-	if not decoded.get("is_guest"):
-		frappe.throw(_("Not a guest token"))
+    if not decoded.get("is_guest"):
+        frappe.throw(_("Not a guest token"))
 
-	if decoded.get("meeting_id") != meeting_id:
-		frappe.throw(_("Token meeting ID does not match"))
+    if decoded.get("meeting_id") != meeting_id:
+        frappe.throw(_("Token meeting ID does not match"))
 
-	if not frappe.db.exists("Meet Room", meeting_id):
-		frappe.throw(_("Meeting not found"))
+    if not frappe.db.exists("Meet Room", meeting_id):
+        frappe.throw(_("Meeting not found"))
 
-	return {
-		"sfu_url": sfu_config["sfu_server_url"],
-		"sfu_port": sfu_config["sfu_server_port"],
-		"codec_strategy": _get_codec_strategy(),
-		"e2ee_required": _is_e2ee_enabled(meeting_id),
-	}
+    return {
+        "sfu_url": sfu_config["sfu_server_url"],
+        "sfu_port": sfu_config["sfu_server_port"],
+        "codec_strategy": _get_codec_strategy(),
+        "e2ee_required": _is_e2ee_enabled(meeting_id),
+    }
 
 
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=10, seconds=60 * 60)
 def validate_guest_session(guest_id: str) -> dict:
-	"""
-	Validate that a guest session exists and is active.
+    """
+    Validate that a guest session exists and is active.
 
-	Args:
-		guest_id: The guest ID to validate
+    Args:
+            guest_id: The guest ID to validate
 
-	Returns:
-		dict: {"valid": bool}
-	"""
-	if not guest_id or not guest_id.startswith("guest_"):
-		return {"valid": False, "error": "Invalid guest ID format"}
+    Returns:
+            dict: {"valid": bool}
+    """
+    if not guest_id or not guest_id.startswith("guest_"):
+        return {"valid": False, "error": "Invalid guest ID format"}
 
-	session_data = get_guest_session(guest_id)
-	if not session_data:
-		return {"valid": False, "error": "Guest session not found"}
+    session_data = get_guest_session(guest_id)
+    if not session_data:
+        return {"valid": False, "error": "Guest session not found"}
 
-	return {
-		"valid": True,
-	}
+    return {
+        "valid": True,
+    }
 
 
 @frappe.whitelist()
 def promote_to_cohost(meeting_id: str, user_id: str) -> dict:
-	"""
-	Promote a user to co-host during an active meeting (host only)
-	"""
-	meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id, for_update=True)
-	return meeting.promote_to_cohost(frappe.session.user, user_id)
+    """
+    Promote a user to co-host during an active meeting (host only)
+    """
+    meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id, for_update=True)
+    return meeting.promote_to_cohost(frappe.session.user, user_id)
 
 
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=10, seconds=5 * 60)
 def check_meeting_access(meeting_id: str) -> dict:
-	"""
-	Check if a meeting allows guest access without authentication
+    """
+    Check if a meeting allows guest access without authentication
 
-	Args:
-		meeting_id: The meeting ID to check
+    Args:
+            meeting_id: The meeting ID to check
 
-	Returns:
-		dict: Access information for the meeting
-	"""
-	try:
-		meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id)
-		settings = frappe.get_cached_doc("Meet Settings")
-		allow_guest = settings.allow_guest and meeting.allow_guest
+    Returns:
+            dict: Access information for the meeting
+    """
+    try:
+        meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id)
+        settings = frappe.get_cached_doc("Meet Settings")
+        allow_guest = settings.allow_guest and meeting.allow_guest
 
-		return {"allow_guest": allow_guest, "host_only_chat": bool(meeting.host_only_chat)}
-	except frappe.DoesNotExistError:
-		frappe.throw(_("Meeting not found"))
+        return {"allow_guest": allow_guest, "host_only_chat": bool(meeting.host_only_chat)}
+    except frappe.DoesNotExistError:
+        frappe.throw(_("Meeting not found"))
 
 
 @frappe.whitelist()
 def get_meeting_e2ee_details(meeting_id: str) -> dict:
-	"""Return E2EE status for hosts/co-hosts.
+    """Return E2EE status for hosts/co-hosts.
 
-	Hosts see the full key proof + host X25519 pubkey so they can recover
-	their own identity on a different device only if they still have the
-	signing device (per-device ed25519 keys; see ADR 0003).
-	"""
-	meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id)
+    Hosts see the full key proof + host X25519 pubkey so they can recover
+    their own identity on a different device only if they still have the
+    signing device (per-device ed25519 keys; see ADR 0003).
+    """
+    meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id)
 
-	if not meeting.is_host_or_cohost(frappe.session.user):
-		frappe.throw(_("Only hosts and co-hosts can view E2EE details"), frappe.PermissionError)
+    if not meeting.is_host_or_cohost(frappe.session.user):
+        frappe.throw(_("Only hosts and co-hosts can view E2EE details"), frappe.PermissionError)
 
-	return {
-		"e2ee_enabled": bool(getattr(meeting, "e2ee_enabled", False)),
-	}
+    return {
+        "e2ee_enabled": bool(getattr(meeting, "e2ee_enabled", False)),
+    }
 
 
 @frappe.whitelist()
 def register_e2ee_device(
-	device_id: str,
-	ed25519_public_key: str,
+    device_id: str,
+    ed25519_public_key: str,
 ) -> dict:
-	"""Register a per-device ed25519 public key for the current user.
+    """Register a per-device ed25519 public key for the current user.
 
-	Used to bind an epoch member key package to a device identity. The client
-	generates the keypair locally and uploads only the public key.
-	"""
-	if not _is_valid_e2ee_device_id(device_id):
-		frappe.throw(_("device_id must be 1-64 chars of [a-zA-Z0-9._-]"), frappe.ValidationError)
+    Used to bind an epoch member key package to a device identity. The client
+    generates the keypair locally and uploads only the public key.
+    """
+    if not _is_valid_e2ee_device_id(device_id):
+        frappe.throw(_("device_id must be 1-64 chars of [a-zA-Z0-9._-]"), frappe.ValidationError)
 
-	try:
-		raw = base64.b64decode(ed25519_public_key, validate=True)
-	except (binascii.Error, TypeError):
-		frappe.throw(_("ed25519_public_key must be base64"), frappe.ValidationError)
-	if len(raw) != 32:
-		frappe.throw(_("ed25519_public_key must decode to 32 bytes"), frappe.ValidationError)
+    try:
+        raw = base64.b64decode(ed25519_public_key, validate=True)
+    except (binascii.Error, TypeError):
+        frappe.throw(_("ed25519_public_key must be base64"), frappe.ValidationError)
+    if len(raw) != 32:
+        frappe.throw(_("ed25519_public_key must decode to 32 bytes"), frappe.ValidationError)
 
-	user = frappe.session.user
-	# Upsert the (user, device_id) pair into the E2EE Device Key DocType.
-	if not _update_e2ee_device_key(user, device_id, ed25519_public_key):
-		doc = frappe.new_doc("E2EE Device Key")
-		doc.user = user
-		doc.device_id = device_id
-		doc.ed25519_public_key = ed25519_public_key
-		# Users may register only their own public E2EE device key through this validated API.
-		try:
-			doc.insert(ignore_permissions=True)
-		except frappe.DuplicateEntryError:
-			# Lost a concurrent insert race after the initial lookup. The DB unique
-			# constraint guarantees there is now exactly one row to update.
-			if not _update_e2ee_device_key(user, device_id, ed25519_public_key):
-				raise
+    user = frappe.session.user
+    # Upsert the (user, device_id) pair into the E2EE Device Key DocType.
+    if not _update_e2ee_device_key(user, device_id, ed25519_public_key):
+        doc = frappe.new_doc("E2EE Device Key")
+        doc.user = user
+        doc.device_id = device_id
+        doc.ed25519_public_key = ed25519_public_key
+        # Users may register only their own public E2EE device key through this validated API.
+        try:
+            doc.insert(ignore_permissions=True)
+        except frappe.DuplicateEntryError:
+            # Lost a concurrent insert race after the initial lookup. The DB unique
+            # constraint guarantees there is now exactly one row to update.
+            if not _update_e2ee_device_key(user, device_id, ed25519_public_key):
+                raise
 
-	return {"device_id": device_id, "ed25519_public_key": ed25519_public_key}
+    return {"device_id": device_id, "ed25519_public_key": ed25519_public_key}
 
 
 def _update_e2ee_device_key(user: str, device_id: str, ed25519_public_key: str) -> bool:
-	existing_name = frappe.db.get_value("E2EE Device Key", {"user": user, "device_id": device_id}, "name")
-	if not existing_name:
-		return False
-	frappe.db.set_value(
-		"E2EE Device Key",
-		existing_name,
-		"ed25519_public_key",
-		ed25519_public_key,
-		update_modified=False,
-	)
-	return True
+    existing_name = frappe.db.get_value("E2EE Device Key", {"user": user, "device_id": device_id}, "name")
+    if not existing_name:
+        return False
+    frappe.db.set_value(
+        "E2EE Device Key",
+        existing_name,
+        "ed25519_public_key",
+        ed25519_public_key,
+        update_modified=False,
+    )
+    return True

--- a/suite/meet/api/permission.py
+++ b/suite/meet/api/permission.py
@@ -4,5 +4,5 @@ from suite.utils.user import is_administrator, is_suite_user
 
 
 def has_app_permission() -> bool:
-	user = frappe.session.user
-	return is_administrator(user) or is_suite_user(user)
+    user = frappe.session.user
+    return is_administrator(user) or is_suite_user(user)

--- a/suite/meet/api/schedule.py
+++ b/suite/meet/api/schedule.py
@@ -12,71 +12,71 @@ from suite.meet.api.meeting import create as create_meeting
 
 @frappe.whitelist()
 def create_scheduled_meeting(
-	account: str,
-	user: str | None = None,
-	organizer: str | None = None,
-	calendar_ids: list[str] | None = None,
-	status: Literal["Tentative", "Confirmed", "Cancelled"] = "Confirmed",
-	draft: bool = False,
-	title: str | None = None,
-	start: str | None = None,
-	duration: str | None = None,
-	time_zone: str | None = None,
-	recurrence_rule: dict | None = None,
-	show_without_time: bool = False,
-	participants: list[dict] | None = None,
-	description: str | None = None,
-	locations: list[dict] | None = None,
-	alerts: list[dict] | None = None,
-	free_busy_status: str | None = "Busy",
-	privacy: str | None = None,
-	use_default_alerts: bool = False,
-	send_scheduling_messages: bool = False,
-	meeting_type: str = "open",
+    account: str,
+    user: str | None = None,
+    organizer: str | None = None,
+    calendar_ids: list[str] | None = None,
+    status: Literal["Tentative", "Confirmed", "Cancelled"] = "Confirmed",
+    draft: bool = False,
+    title: str | None = None,
+    start: str | None = None,
+    duration: str | None = None,
+    time_zone: str | None = None,
+    recurrence_rule: dict | None = None,
+    show_without_time: bool = False,
+    participants: list[dict] | None = None,
+    description: str | None = None,
+    locations: list[dict] | None = None,
+    alerts: list[dict] | None = None,
+    free_busy_status: str | None = "Busy",
+    privacy: str | None = None,
+    use_default_alerts: bool = False,
+    send_scheduling_messages: bool = False,
+    meeting_type: str = "open",
 ) -> dict[str, str]:
-	"""Create a Meet room and attach it to a calendar event."""
-	del user
+    """Create a Meet room and attach it to a calendar event."""
+    del user
 
-	is_jmap_account_belongs_to_user(account, raise_exception=True)
-	organizer = frappe.db.get_value("JMAP Account", account, "default_outgoing_email") or frappe.session.user
+    is_jmap_account_belongs_to_user(account, raise_exception=True)
+    organizer = frappe.db.get_value("JMAP Account", account, "default_outgoing_email") or frappe.session.user
 
-	meeting_id = create_meeting(meeting_type=meeting_type, title=title)
-	meet_url = get_url(f"/meet/{meeting_id}")
+    meeting_id = create_meeting(meeting_type=meeting_type, title=title)
+    meet_url = get_url(f"/meet/{meeting_id}")
 
-	# The meet link is attached as a structured event link (see `links=` below), which is what
-	# the UI's "Join Frappe Meet" button, the invite email's Meet card, and the exported .ics URL
-	# all read from. So it is deliberately NOT injected into the description.
-	event_id = add_calendar_event(
-		account=account,
-		organizer=organizer,
-		calendar_ids=calendar_ids,
-		status=status,
-		draft=draft,
-		title=title,
-		start=start,
-		duration=duration,
-		time_zone=time_zone,
-		recurrence_rule=recurrence_rule,
-		show_without_time=show_without_time,
-		free_busy_status=free_busy_status,
-		privacy=privacy,
-		description=description,
-		locations=locations,
-		links=[{"href": meet_url, "content_type": "text/html"}],
-		participants=participants,
-		alerts=alerts,
-		use_default_alerts=use_default_alerts,
-		send_scheduling_messages=send_scheduling_messages,
-	)
+    # The meet link is attached as a structured event link (see `links=` below), which is what
+    # the UI's "Join Frappe Meet" button, the invite email's Meet card, and the exported .ics URL
+    # all read from. So it is deliberately NOT injected into the description.
+    event_id = add_calendar_event(
+        account=account,
+        organizer=organizer,
+        calendar_ids=calendar_ids,
+        status=status,
+        draft=draft,
+        title=title,
+        start=start,
+        duration=duration,
+        time_zone=time_zone,
+        recurrence_rule=recurrence_rule,
+        show_without_time=show_without_time,
+        free_busy_status=free_busy_status,
+        privacy=privacy,
+        description=description,
+        locations=locations,
+        links=[{"href": meet_url, "content_type": "text/html"}],
+        participants=participants,
+        alerts=alerts,
+        use_default_alerts=use_default_alerts,
+        send_scheduling_messages=send_scheduling_messages,
+    )
 
-	return {"meeting_id": meeting_id, "meeting_url": meet_url, "event_id": event_id}
+    return {"meeting_id": meeting_id, "meeting_url": meet_url, "event_id": event_id}
 
 
 @frappe.whitelist()
 def create_meet_link(account: str, title: str | None = None, meeting_type: str = "open") -> dict[str, str]:
-	"""Create a Meet room and return its link, for attaching to an existing calendar event."""
+    """Create a Meet room and return its link, for attaching to an existing calendar event."""
 
-	is_jmap_account_belongs_to_user(account, raise_exception=True)
+    is_jmap_account_belongs_to_user(account, raise_exception=True)
 
-	meeting_id = create_meeting(meeting_type=meeting_type, title=title)
-	return {"meeting_id": meeting_id, "meeting_url": get_url(f"/meet/{meeting_id}")}
+    meeting_id = create_meeting(meeting_type=meeting_type, title=title)
+    return {"meeting_id": meeting_id, "meeting_url": get_url(f"/meet/{meeting_id}")}

--- a/suite/meet/api/test/test_e2ee_proof.py
+++ b/suite/meet/api/test/test_e2ee_proof.py
@@ -8,119 +8,119 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from suite.meet.api.meeting import (
-	_is_valid_e2ee_device_id,
-	get_sfu_connection_details,
-	register_e2ee_device,
+    _is_valid_e2ee_device_id,
+    get_sfu_connection_details,
+    register_e2ee_device,
 )
 
 
 def _b64(raw: bytes) -> str:
-	return base64.b64encode(raw).decode("ascii")
+    return base64.b64encode(raw).decode("ascii")
 
 
 class IntegrationTestE2EEEpoch(IntegrationTestCase):
-	@classmethod
-	def setUpClass(cls):
-		super().setUpClass()
-		cls.host_email = "host-e2ee@example.com"
-		cls._ensure_user(cls.host_email, "HostE2EE")
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.host_email = "host-e2ee@example.com"
+        cls._ensure_user(cls.host_email, "HostE2EE")
 
-	def setUp(self):
-		frappe.conf.sfu_secret = "test-sfu-secret"
+    def setUp(self):
+        frappe.conf.sfu_secret = "test-sfu-secret"
 
-	@classmethod
-	def _ensure_user(cls, email: str, first_name: str):
-		if frappe.db.exists("User", email):
-			user = frappe.get_doc("User", email)
-		else:
-			user = frappe.get_doc(
-				{
-					"doctype": "User",
-					"email": email,
-					"first_name": first_name,
-					"enabled": 1,
-					"new_password": "password",
-				}
-			)
-			user.insert(ignore_permissions=True)
-		if not any(r.role == "Suite User" for r in user.roles):
-			user.append("roles", {"role": "Suite User"})
-			user.save(ignore_permissions=True)
+    @classmethod
+    def _ensure_user(cls, email: str, first_name: str):
+        if frappe.db.exists("User", email):
+            user = frappe.get_doc("User", email)
+        else:
+            user = frappe.get_doc(
+                {
+                    "doctype": "User",
+                    "email": email,
+                    "first_name": first_name,
+                    "enabled": 1,
+                    "new_password": "password",
+                }
+            )
+            user.insert(ignore_permissions=True)
+        if not any(r.role == "Suite User" for r in user.roles):
+            user.append("roles", {"role": "Suite User"})
+            user.save(ignore_permissions=True)
 
-	def _create_meeting_as_host(self):
-		frappe.set_user(self.host_email)
-		meeting = frappe.get_doc(
-			{
-				"doctype": "Meet Room",
-				"meeting_type": "open",
-				"allow_guest": 1,
-			}
-		).insert(ignore_permissions=True)
-		return meeting
+    def _create_meeting_as_host(self):
+        frappe.set_user(self.host_email)
+        meeting = frappe.get_doc(
+            {
+                "doctype": "Meet Room",
+                "meeting_type": "open",
+                "allow_guest": 1,
+            }
+        ).insert(ignore_permissions=True)
+        return meeting
 
-	def test_device_id_validator(self):
-		self.assertTrue(_is_valid_e2ee_device_id("default"))
-		self.assertTrue(_is_valid_e2ee_device_id("laptop-2026-01"))
-		self.assertFalse(_is_valid_e2ee_device_id(""))
-		self.assertFalse(_is_valid_e2ee_device_id("a" * 65))
-		self.assertFalse(_is_valid_e2ee_device_id("has space"))
+    def test_device_id_validator(self):
+        self.assertTrue(_is_valid_e2ee_device_id("default"))
+        self.assertTrue(_is_valid_e2ee_device_id("laptop-2026-01"))
+        self.assertFalse(_is_valid_e2ee_device_id(""))
+        self.assertFalse(_is_valid_e2ee_device_id("a" * 65))
+        self.assertFalse(_is_valid_e2ee_device_id("has space"))
 
-	def test_register_e2ee_device_upserts_public_key(self):
-		frappe.set_user(self.host_email)
-		first_key = _b64(b"\x11" * 32)
-		second_key = _b64(b"\x22" * 32)
+    def test_register_e2ee_device_upserts_public_key(self):
+        frappe.set_user(self.host_email)
+        first_key = _b64(b"\x11" * 32)
+        second_key = _b64(b"\x22" * 32)
 
-		register_e2ee_device("device-1", first_key)
-		register_e2ee_device("device-1", second_key)
+        register_e2ee_device("device-1", first_key)
+        register_e2ee_device("device-1", second_key)
 
-		stored = frappe.db.get_value(
-			"E2EE Device Key",
-			{"user": self.host_email, "device_id": "device-1"},
-			"ed25519_public_key",
-		)
-		self.assertEqual(stored, second_key)
+        stored = frappe.db.get_value(
+            "E2EE Device Key",
+            {"user": self.host_email, "device_id": "device-1"},
+            "ed25519_public_key",
+        )
+        self.assertEqual(stored, second_key)
 
-	def test_register_e2ee_device_recovers_from_concurrent_insert_race(self):
-		frappe.set_user(self.host_email)
-		public_key = _b64(b"\x33" * 32)
-		fake_doc = MagicMock()
-		fake_doc.insert.side_effect = frappe.DuplicateEntryError
+    def test_register_e2ee_device_recovers_from_concurrent_insert_race(self):
+        frappe.set_user(self.host_email)
+        public_key = _b64(b"\x33" * 32)
+        fake_doc = MagicMock()
+        fake_doc.insert.side_effect = frappe.DuplicateEntryError
 
-		with (
-			patch(
-				"suite.meet.api.meeting.frappe.db.get_value",
-				side_effect=[None, "existing-row"],
-			),
-			patch("suite.meet.api.meeting.frappe.new_doc", return_value=fake_doc),
-			patch("suite.meet.api.meeting.frappe.db.set_value") as set_value,
-		):
-			result = register_e2ee_device("race-device", public_key)
+        with (
+            patch(
+                "suite.meet.api.meeting.frappe.db.get_value",
+                side_effect=[None, "existing-row"],
+            ),
+            patch("suite.meet.api.meeting.frappe.new_doc", return_value=fake_doc),
+            patch("suite.meet.api.meeting.frappe.db.set_value") as set_value,
+        ):
+            result = register_e2ee_device("race-device", public_key)
 
-		self.assertEqual(result, {"device_id": "race-device", "ed25519_public_key": public_key})
-		set_value.assert_called_once_with(
-			"E2EE Device Key",
-			"existing-row",
-			"ed25519_public_key",
-			public_key,
-			update_modified=False,
-		)
+        self.assertEqual(result, {"device_id": "race-device", "ed25519_public_key": public_key})
+        set_value.assert_called_once_with(
+            "E2EE Device Key",
+            "existing-row",
+            "ed25519_public_key",
+            public_key,
+            update_modified=False,
+        )
 
-	def test_enable_e2ee_enables_epoch_room(self):
-		meeting = self._create_meeting_as_host()
+    def test_enable_e2ee_enables_epoch_room(self):
+        meeting = self._create_meeting_as_host()
 
-		result = meeting.enable_e2ee()
+        result = meeting.enable_e2ee()
 
-		self.assertTrue(result)
-		meeting.reload()
-		self.assertTrue(meeting.e2ee_enabled)
+        self.assertTrue(result)
+        meeting.reload()
+        self.assertTrue(meeting.e2ee_enabled)
 
-	def test_sfu_connection_details_only_expose_e2ee_required(self):
-		meeting = self._create_meeting_as_host()
-		meeting.enable_e2ee()
+    def test_sfu_connection_details_only_expose_e2ee_required(self):
+        meeting = self._create_meeting_as_host()
+        meeting.enable_e2ee()
 
-		details = get_sfu_connection_details(meeting.name)
+        details = get_sfu_connection_details(meeting.name)
 
-		self.assertTrue(details["e2ee_required"])
-		self.assertNotIn("e2ee_host_public_key", details)
-		self.assertNotIn("e2ee_host_signing_public_key", details)
-		self.assertNotIn("e2ee_key_version", details)
+        self.assertTrue(details["e2ee_required"])
+        self.assertNotIn("e2ee_host_public_key", details)
+        self.assertNotIn("e2ee_host_signing_public_key", details)
+        self.assertNotIn("e2ee_key_version", details)

--- a/suite/meet/api/test/test_meeting.py
+++ b/suite/meet/api/test/test_meeting.py
@@ -7,207 +7,207 @@ from frappe.client import delete as delete_document
 from frappe.tests import IntegrationTestCase
 
 from suite.meet.api.meeting import (
-	get_public_meeting_preview,
-	get_sfu_connection_details,
-	get_sfu_presence_preview_token,
-	join_meeting,
+    get_public_meeting_preview,
+    get_sfu_connection_details,
+    get_sfu_presence_preview_token,
+    join_meeting,
 )
 
 
 class IntegrationTestMeetingApi(IntegrationTestCase):
-	def setUp(self):
-		frappe.conf.sfu_secret = "test-sfu-secret"
+    def setUp(self):
+        frappe.conf.sfu_secret = "test-sfu-secret"
 
-		self.host_email = "host-meet@example.com"
-		self.member_email = "member-meet@example.com"
-		self.outsider_email = "outsider-meet@example.com"
+        self.host_email = "host-meet@example.com"
+        self.member_email = "member-meet@example.com"
+        self.outsider_email = "outsider-meet@example.com"
 
-		for email, first_name in (
-			(self.host_email, "Host"),
-			(self.member_email, "Member"),
-			(self.outsider_email, "Outsider"),
-		):
-			self._ensure_user(email, first_name)
+        for email, first_name in (
+            (self.host_email, "Host"),
+            (self.member_email, "Member"),
+            (self.outsider_email, "Outsider"),
+        ):
+            self._ensure_user(email, first_name)
 
-		self.meeting = self._create_meeting(self.host_email, meeting_type="restricted")
+        self.meeting = self._create_meeting(self.host_email, meeting_type="restricted")
 
-	def test_member_can_get_sfu_connection_details(self):
-		self.meeting.add_user_to_table("members", self.member_email, save=True, ignore_permissions=True)
+    def test_member_can_get_sfu_connection_details(self):
+        self.meeting.add_user_to_table("members", self.member_email, save=True, ignore_permissions=True)
 
-		frappe.set_user(self.member_email)
+        frappe.set_user(self.member_email)
 
-		result = get_sfu_connection_details(self.meeting.name)
+        result = get_sfu_connection_details(self.meeting.name)
 
-		self.assertEqual(result["user_id"], self.member_email)
-		self.assertEqual(result["meeting_id"], self.meeting.name)
-		self.assertTrue(result["auth_token"])
-		self.assertFalse(result["e2ee_required"])
-		self.assertNotIn("e2ee_host_public_key", result)
-		self.assertIn("is_host", result)
-		self.assertFalse(result["is_host"])
-		self.assertIn("is_cohost", result)
-		self.assertFalse(result["is_cohost"])
+        self.assertEqual(result["user_id"], self.member_email)
+        self.assertEqual(result["meeting_id"], self.meeting.name)
+        self.assertTrue(result["auth_token"])
+        self.assertFalse(result["e2ee_required"])
+        self.assertNotIn("e2ee_host_public_key", result)
+        self.assertIn("is_host", result)
+        self.assertFalse(result["is_host"])
+        self.assertIn("is_cohost", result)
+        self.assertFalse(result["is_cohost"])
 
-	def test_host_gets_is_host_from_sfu_connection_details(self):
-		self.meeting.add_user_to_table("members", self.host_email, save=True, ignore_permissions=True)
+    def test_host_gets_is_host_from_sfu_connection_details(self):
+        self.meeting.add_user_to_table("members", self.host_email, save=True, ignore_permissions=True)
 
-		frappe.set_user(self.host_email)
+        frappe.set_user(self.host_email)
 
-		result = get_sfu_connection_details(self.meeting.name)
+        result = get_sfu_connection_details(self.meeting.name)
 
-		self.assertTrue(result["is_host"])
-		self.assertFalse(result["is_cohost"])
+        self.assertTrue(result["is_host"])
+        self.assertFalse(result["is_cohost"])
 
-		decoded = jwt.decode(
-			result["auth_token"],
-			frappe.conf.sfu_secret,
-			algorithms=["HS256"],
-		)
+        decoded = jwt.decode(
+            result["auth_token"],
+            frappe.conf.sfu_secret,
+            algorithms=["HS256"],
+        )
 
-		self.assertEqual(decoded["site"], frappe.local.site)
-		self.assertEqual(decoded["meeting_id"], self.meeting.name)
+        self.assertEqual(decoded["site"], frappe.local.site)
+        self.assertEqual(decoded["meeting_id"], self.meeting.name)
 
-	def test_sfu_token_site_claim_keeps_cross_site_meetings_isolated(self):
-		"""Two sites with meetings of the same name must mint tokens that
-		carry different `site` claims so the SFU can route them to distinct
-		rooms."""
-		from suite.meet.api.meeting import _generate_sfu_token
+    def test_sfu_token_site_claim_keeps_cross_site_meetings_isolated(self):
+        """Two sites with meetings of the same name must mint tokens that
+        carry different `site` claims so the SFU can route them to distinct
+        rooms."""
+        from suite.meet.api.meeting import _generate_sfu_token
 
-		token_a = _generate_sfu_token(
-			user_id="user-a",
-			meeting_id="all-hands",
-			site="site-a.example.com",
-		)
-		token_b = _generate_sfu_token(
-			user_id="user-b",
-			meeting_id="all-hands",
-			site="site-b.example.com",
-		)
+        token_a = _generate_sfu_token(
+            user_id="user-a",
+            meeting_id="all-hands",
+            site="site-a.example.com",
+        )
+        token_b = _generate_sfu_token(
+            user_id="user-b",
+            meeting_id="all-hands",
+            site="site-b.example.com",
+        )
 
-		decoded_a = jwt.decode(token_a, frappe.conf.sfu_secret, algorithms=["HS256"])
-		decoded_b = jwt.decode(token_b, frappe.conf.sfu_secret, algorithms=["HS256"])
+        decoded_a = jwt.decode(token_a, frappe.conf.sfu_secret, algorithms=["HS256"])
+        decoded_b = jwt.decode(token_b, frappe.conf.sfu_secret, algorithms=["HS256"])
 
-		self.assertEqual(decoded_a["meeting_id"], decoded_b["meeting_id"])
-		self.assertNotEqual(decoded_a["site"], decoded_b["site"])
+        self.assertEqual(decoded_a["meeting_id"], decoded_b["meeting_id"])
+        self.assertNotEqual(decoded_a["site"], decoded_b["site"])
 
-	def test_restricted_meeting_non_member_cannot_get_sfu_connection_details(self):
-		frappe.set_user(self.outsider_email)
+    def test_restricted_meeting_non_member_cannot_get_sfu_connection_details(self):
+        frappe.set_user(self.outsider_email)
 
-		with self.assertRaises(frappe.PermissionError):
-			get_sfu_connection_details(self.meeting.name)
+        with self.assertRaises(frappe.PermissionError):
+            get_sfu_connection_details(self.meeting.name)
 
-	def test_only_host_and_cohost_can_read_meeting_document(self):
-		self.meeting.add_user_to_table("members", self.member_email, save=True, ignore_permissions=True)
-		self.meeting.add_user_to_table("co_hosts", self.outsider_email, save=True, ignore_permissions=True)
+    def test_only_host_and_cohost_can_read_meeting_document(self):
+        self.meeting.add_user_to_table("members", self.member_email, save=True, ignore_permissions=True)
+        self.meeting.add_user_to_table("co_hosts", self.outsider_email, save=True, ignore_permissions=True)
 
-		frappe.set_user(self.member_email)
-		with self.assertRaises(frappe.PermissionError):
-			frappe.get_doc("Meet Room", self.meeting.name).check_permission("read")
+        frappe.set_user(self.member_email)
+        with self.assertRaises(frappe.PermissionError):
+            frappe.get_doc("Meet Room", self.meeting.name).check_permission("read")
 
-		for user in (self.host_email, self.outsider_email):
-			frappe.set_user(user)
-			frappe.get_doc("Meet Room", self.meeting.name).check_permission("read")
+        for user in (self.host_email, self.outsider_email):
+            frappe.set_user(user)
+            frappe.get_doc("Meet Room", self.meeting.name).check_permission("read")
 
-	def test_non_member_gets_public_preview_title_without_read_access(self):
-		self.meeting.title = "Quarterly planning"
-		self.meeting.save(ignore_permissions=True)
+    def test_non_member_gets_public_preview_title_without_read_access(self):
+        self.meeting.title = "Quarterly planning"
+        self.meeting.save(ignore_permissions=True)
 
-		frappe.set_user(self.outsider_email)
-		with self.assertRaises(frappe.PermissionError):
-			frappe.get_doc("Meet Room", self.meeting.name).check_permission("read")
+        frappe.set_user(self.outsider_email)
+        with self.assertRaises(frappe.PermissionError):
+            frappe.get_doc("Meet Room", self.meeting.name).check_permission("read")
 
-		self.assertEqual(get_public_meeting_preview(self.meeting.name)["title"], "Quarterly planning")
+        self.assertEqual(get_public_meeting_preview(self.meeting.name)["title"], "Quarterly planning")
 
-	def test_meeting_list_only_contains_hosted_or_cohosted_meetings(self):
-		self.meeting.add_user_to_table("co_hosts", self.member_email, save=True, ignore_permissions=True)
+    def test_meeting_list_only_contains_hosted_or_cohosted_meetings(self):
+        self.meeting.add_user_to_table("co_hosts", self.member_email, save=True, ignore_permissions=True)
 
-		frappe.set_user(self.member_email)
-		self.assertIn(
-			self.meeting.name,
-			frappe.get_list("Meet Room", pluck="name"),
-		)
+        frappe.set_user(self.member_email)
+        self.assertIn(
+            self.meeting.name,
+            frappe.get_list("Meet Room", pluck="name"),
+        )
 
-		frappe.set_user(self.outsider_email)
-		self.assertNotIn(
-			self.meeting.name,
-			frappe.get_list("Meet Room", pluck="name"),
-		)
+        frappe.set_user(self.outsider_email)
+        self.assertNotIn(
+            self.meeting.name,
+            frappe.get_list("Meet Room", pluck="name"),
+        )
 
-	def test_only_host_can_delete_meeting_through_frappe_api(self):
-		frappe.set_user(self.outsider_email)
-		with self.assertRaises(frappe.PermissionError):
-			delete_document("Meet Room", self.meeting.name)
+    def test_only_host_can_delete_meeting_through_frappe_api(self):
+        frappe.set_user(self.outsider_email)
+        with self.assertRaises(frappe.PermissionError):
+            delete_document("Meet Room", self.meeting.name)
 
-		self.assertTrue(frappe.db.exists("Meet Room", self.meeting.name))
+        self.assertTrue(frappe.db.exists("Meet Room", self.meeting.name))
 
-		frappe.set_user(self.host_email)
-		delete_document("Meet Room", self.meeting.name)
+        frappe.set_user(self.host_email)
+        delete_document("Meet Room", self.meeting.name)
 
-		self.assertFalse(frappe.db.exists("Meet Room", self.meeting.name))
+        self.assertFalse(frappe.db.exists("Meet Room", self.meeting.name))
 
-	def test_join_meeting_returns_sfu_connection_details(self):
-		"""join_meeting bundles SFU JWT so clients skip a second RTT."""
-		self.meeting.add_user_to_table("members", self.member_email, save=True, ignore_permissions=True)
-		self.meeting.db_set("meeting_type", "open")
+    def test_join_meeting_returns_sfu_connection_details(self):
+        """join_meeting bundles SFU JWT so clients skip a second RTT."""
+        self.meeting.add_user_to_table("members", self.member_email, save=True, ignore_permissions=True)
+        self.meeting.db_set("meeting_type", "open")
 
-		frappe.set_user(self.member_email)
-		result = join_meeting(self.meeting.name)
+        frappe.set_user(self.member_email)
+        result = join_meeting(self.meeting.name)
 
-		self.assertEqual(result["status"], "joined")
-		self.assertTrue(result.get("auth_token"))
-		self.assertEqual(result["user_id"], self.member_email)
-		self.assertEqual(result["meeting_id"], self.meeting.name)
-		self.assertIn("sfu_url", result)
-		self.assertIn("codec_strategy", result)
+        self.assertEqual(result["status"], "joined")
+        self.assertTrue(result.get("auth_token"))
+        self.assertEqual(result["user_id"], self.member_email)
+        self.assertEqual(result["meeting_id"], self.meeting.name)
+        self.assertIn("sfu_url", result)
+        self.assertIn("codec_strategy", result)
 
-		decoded = jwt.decode(
-			result["auth_token"],
-			frappe.conf.sfu_secret,
-			algorithms=["HS256"],
-		)
-		self.assertEqual(decoded["user_id"], self.member_email)
-		self.assertEqual(decoded["meeting_id"], self.meeting.name)
-		self.assertEqual(decoded.get("scope", "full"), "full")
+        decoded = jwt.decode(
+            result["auth_token"],
+            frappe.conf.sfu_secret,
+            algorithms=["HS256"],
+        )
+        self.assertEqual(decoded["user_id"], self.member_email)
+        self.assertEqual(decoded["meeting_id"], self.meeting.name)
+        self.assertEqual(decoded.get("scope", "full"), "full")
 
-	def test_restricted_waiting_join_does_not_return_full_media_token(self):
-		frappe.set_user(self.outsider_email)
-		result = join_meeting(self.meeting.name)
+    def test_restricted_waiting_join_does_not_return_full_media_token(self):
+        frappe.set_user(self.outsider_email)
+        result = join_meeting(self.meeting.name)
 
-		self.assertEqual(result["status"], "waiting_for_approval")
-		self.assertNotIn("auth_token", result)
-		self.assertIn("lobby_token", result)
+        self.assertEqual(result["status"], "waiting_for_approval")
+        self.assertNotIn("auth_token", result)
+        self.assertIn("lobby_token", result)
 
-		decoded = jwt.decode(
-			result["lobby_token"],
-			frappe.conf.sfu_secret,
-			algorithms=["HS256"],
-		)
-		self.assertEqual(decoded["scope"], "presence-preview")
+        decoded = jwt.decode(
+            result["lobby_token"],
+            frappe.conf.sfu_secret,
+            algorithms=["HS256"],
+        )
+        self.assertEqual(decoded["scope"], "presence-preview")
 
-	def _ensure_user(self, email: str, first_name: str):
-		if frappe.db.exists("User", email):
-			return frappe.get_doc("User", email)
+    def _ensure_user(self, email: str, first_name: str):
+        if frappe.db.exists("User", email):
+            return frappe.get_doc("User", email)
 
-		user = frappe.get_doc(
-			{
-				"doctype": "User",
-				"email": email,
-				"first_name": first_name,
-				"enabled": 1,
-				"new_password": "password",
-			}
-		)
-		user.insert(ignore_permissions=True)
-		return user
+        user = frappe.get_doc(
+            {
+                "doctype": "User",
+                "email": email,
+                "first_name": first_name,
+                "enabled": 1,
+                "new_password": "password",
+            }
+        )
+        user.insert(ignore_permissions=True)
+        return user
 
-	def _create_meeting(self, owner: str, meeting_type: str = "open"):
-		frappe.set_user(owner)
-		meeting = frappe.get_doc(
-			{
-				"doctype": "Meet Room",
-				"meeting_type": meeting_type,
-				"allow_guest": 1,
-			}
-		)
-		meeting.insert(ignore_permissions=True)
-		return meeting
+    def _create_meeting(self, owner: str, meeting_type: str = "open"):
+        frappe.set_user(owner)
+        meeting = frappe.get_doc(
+            {
+                "doctype": "Meet Room",
+                "meeting_type": meeting_type,
+                "allow_guest": 1,
+            }
+        )
+        meeting.insert(ignore_permissions=True)
+        return meeting

--- a/suite/meet/api/test_helpers.py
+++ b/suite/meet/api/test_helpers.py
@@ -7,8 +7,8 @@ from frappe.tests.utils import whitelist_for_tests
 
 @whitelist_for_tests()
 def clear_create_rate_limit() -> None:
-	"""Clear meeting creation, join meeting as guest rate limit cache."""
-	keys = frappe.cache.get_keys("rl:suite.meet.api.meeting.join_meeting_as_guest:*")
-	keys += frappe.cache.get_keys("rl:suite.meet.api.meeting.create:*")
-	for key in keys:
-		frappe.cache.set(key, 0)  # nosemgrep
+    """Clear meeting creation, join meeting as guest rate limit cache."""
+    keys = frappe.cache.get_keys("rl:suite.meet.api.meeting.join_meeting_as_guest:*")
+    keys += frappe.cache.get_keys("rl:suite.meet.api.meeting.create:*")
+    for key in keys:
+        frappe.cache.set(key, 0)  # nosemgrep

--- a/suite/meet/doctype/e2ee_device_key/e2ee_device_key.py
+++ b/suite/meet/doctype/e2ee_device_key/e2ee_device_key.py
@@ -17,7 +17,7 @@ def on_doctype_update() -> None:
     )
 
 
-def on_update(doc: "E2EEDeviceKey", method: str | None = None) -> None:
+def on_update(doc: E2EEDeviceKey, method: str | None = None) -> None:
     """Stamp created_at on first save (not on subsequent updates)."""
     if not doc.created_at:
         doc.db_set("created_at", frappe.utils.now_datetime(), update_modified=False)

--- a/suite/meet/doctype/e2ee_device_key/e2ee_device_key.py
+++ b/suite/meet/doctype/e2ee_device_key/e2ee_device_key.py
@@ -6,18 +6,18 @@ from frappe.model.document import Document
 
 
 class E2EEDeviceKey(Document):
-	pass
+    pass
 
 
 def on_doctype_update() -> None:
-	frappe.db.add_unique(
-		"E2EE Device Key",
-		["user", "device_id"],
-		constraint_name="unique_e2ee_device_user_device",
-	)
+    frappe.db.add_unique(
+        "E2EE Device Key",
+        ["user", "device_id"],
+        constraint_name="unique_e2ee_device_user_device",
+    )
 
 
 def on_update(doc: "E2EEDeviceKey", method: str | None = None) -> None:
-	"""Stamp created_at on first save (not on subsequent updates)."""
-	if not doc.created_at:
-		doc.db_set("created_at", frappe.utils.now_datetime(), update_modified=False)
+    """Stamp created_at on first save (not on subsequent updates)."""
+    if not doc.created_at:
+        doc.db_set("created_at", frappe.utils.now_datetime(), update_modified=False)

--- a/suite/meet/doctype/meet_room/meet_room.py
+++ b/suite/meet/doctype/meet_room/meet_room.py
@@ -9,464 +9,464 @@ from frappe import _
 from frappe.model.document import Document
 
 from suite.meet.utils.user import (
-	get_guest_session,
-	get_user_info,
-	unique_users,
+    get_guest_session,
+    get_user_info,
+    unique_users,
 )
 
 
 class MeetRoom(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
-
-	from typing import TYPE_CHECKING
-
-	if TYPE_CHECKING:
-		from frappe.types import DF
-
-		from suite.meet.doctype.meet_room_user.meet_room_user import MeetRoomUser
-
-		allow_guest: DF.Check
-		banned_users: DF.Table[MeetRoomUser]
-		co_hosts: DF.Table[MeetRoomUser]
-		e2ee_enabled: DF.Check
-		meeting_type: DF.Literal["open", "restricted"]
-		members: DF.Table[MeetRoomUser]
-		waiting_room: DF.Table[MeetRoomUser]
-	# end: auto-generated types
-
-	def autoname(self):
-		"""Set the name of the meeting"""
-		if not self.name:
-			self.name = generate()
-
-	def validate(self):
-		self.backfill_display_names()
-
-	def backfill_display_names(self):
-		"""Backfill display names for existing child rows."""
-		for fieldname in ("members", "co_hosts", "waiting_room", "banned_users"):
-			for row in self.get(fieldname) or []:
-				if row.user and not row.user_name:
-					row.user_name = self.get_user_display_name(row.user)
-
-	def get_user_display_name(self, user: str) -> str:
-		"""Resolve a display name for a member, guest, or fallback user ID."""
-		user_info = get_user_info(user)
-		if user_info and user_info.get("full_name"):
-			return user_info.get("full_name")
-
-		if user.startswith("guest_"):
-			guest_session = get_guest_session(user)
-			if guest_session and guest_session.get("guest_name"):
-				return guest_session.get("guest_name")
-
-		return user
-
-	def build_user_row(self, user: str) -> dict:
-		"""Build a child table row with both the id and display name."""
-		return {"user": user, "user_name": self.get_user_display_name(user)}
-
-	def get_table_users(self, fieldname: str) -> list[str]:
-		"""Return all user IDs from a child table."""
-		return [row.user for row in self.get(fieldname) or []]
-
-	def add_user_to_table(
-		self, fieldname: str, user: str, save: bool = False, ignore_permissions: bool = False
-	):
-		"""Append a user to a child table if they are not already present."""
-		for row in self.get(fieldname) or []:
-			if row.user != user:
-				continue
-			if not row.user_name:
-				row.user_name = self.get_user_display_name(user)
-				if save:
-					self.save(ignore_permissions=ignore_permissions)
-			return False
-
-		self.append(fieldname, self.build_user_row(user))
-		if save:
-			self.save(ignore_permissions=ignore_permissions)
-		return True
-
-	def add_waiting_room_user(self, user: str, save: bool = False, ignore_permissions: bool = False):
-		"""Add a user to the waiting room and notify authorized users."""
-		if self.is_user_approved(user):
-			return
-
-		waiting_users = self.get_waiting_room()
-		if self.add_user_to_table("waiting_room", user, save=save, ignore_permissions=ignore_permissions):
-			self.publish_waiting_room_request(user, len(waiting_users) + 1)
-
-	def get_waiting_room_payload(self, user: str) -> tuple[str, str | None]:
-		"""Return display payload for waiting-room notifications."""
-		user_info = get_user_info(user) or {}
-		return user_info.get("full_name", user), user_info.get("user_image")
-
-	def publish_waiting_room_request(self, user: str, waiting_count: int):
-		"""Notify host and co-hosts about a waiting-room request."""
-		user_name, user_image = self.get_waiting_room_payload(user)
-
-		for authorized_user in [self.owner, *self.get_co_hosts()]:
-			frappe.publish_realtime(
-				"meeting_join_request",
-				user=authorized_user,
-				message={
-					"meeting": self.name,
-					"user": user,
-					"user_name": user_name,
-					"user_image": user_image,
-					"waiting_count": waiting_count,
-				},
-			)
-
-	def after_insert(self):
-		self.join(frappe.session.user)
-
-	def join(self, user=None):
-		"""
-		Join the meeting room
-
-		Args:
-			user: User to join (defaults to current session user)
-		"""
-		if not user:
-			user = frappe.session.user
-
-		if self.meeting_type == "restricted" and user != self.owner:
-			if not self.is_user_approved(user):
-				self.add_to_waiting_room(user)
-				self.save(ignore_permissions=True)
-				return {"status": "waiting_for_approval", "message": "Waiting for host approval"}
-
-		joined = self.add_user_to_table("members", user)
-
-		# Add user if not already in room
-		if joined:
-			self.remove_from_waiting_room(user)
-
-			self.save(ignore_permissions=True)
-
-		return {"status": "joined", "message": "Successfully joined the meeting"}
-
-	def get_members(self):
-		"""Get list of current members"""
-		return self.get_table_users("members")
-
-	def get_co_hosts(self):
-		"""Get list of current co-hosts"""
-		return self.get_table_users("co_hosts")
-
-	def can_join(self, user=None):
-		"""
-		Check if a user can join this meeting
-
-		Args:
-			user: User to check (defaults to current session user)
-
-		Returns:
-			bool: True if user can join, False otherwise
-		"""
-		if not user:
-			user = frappe.session.user
-
-		return not self.is_user_banned(user)
-
-	def update_members(self, members_list):
-		"""Update members list and save"""
-		self.set("members", [])
-		for row in unique_users(members_list):
-			user = row.get("user") if isinstance(row, dict) else row
-			if user:
-				self.append("members", self.build_user_row(user))
-
-	def add_guest_to_members(self, guest_id: str):
-		self.validate_guest_id(guest_id)
-		self.add_user_to_table("members", guest_id, save=True, ignore_permissions=True)
-
-	def get_waiting_room(self):
-		"""Get list of users waiting for approval"""
-		return self.get_table_users("waiting_room")
-
-	def add_to_waiting_room(self, user):
-		"""Add user to waiting room"""
-		self.add_waiting_room_user(user)
-
-	def add_guest_to_waiting_room(self, guest_id: str):
-		self.validate_guest_id(guest_id)
-		self.add_waiting_room_user(guest_id, save=True, ignore_permissions=True)
-
-	def remove_from_waiting_room(self, user):
-		"""Remove user from waiting room"""
-		for row in self.get("waiting_room") or []:
-			if row.user == user:
-				self.remove(row)
-				return
-
-	def approve_user(self, user, save=True):
-		"""Approve a user from waiting room to join the meeting"""
-		if not self.is_host_or_cohost(frappe.session.user):
-			frappe.throw(_("Only hosts and co-hosts can approve join requests"))
-
-		waiting_users = self.get_waiting_room()
-		if user not in waiting_users:
-			frappe.throw("User is not in waiting room")
-
-		self.add_user_to_table("members", user)
-
-		self.remove_from_waiting_room(user)
-		if save:
-			self.save()
-
-		# for signed-in users
-		frappe.publish_realtime(
-			"meeting_join_approved",
-			user=user,
-			message={"meeting": self.name, "user": user, "approved_by": frappe.session.user},
-			after_commit=True,
-		)
-
-		# for guests
-		if user.startswith("guest_"):
-			session_data = get_guest_session(user)
-			if session_data:
-				guest_name = session_data.get("guest_name")
-				frappe.publish_realtime(
-					"meet:guest_join_approved",
-					{
-						"meeting_id": self.name,
-						"guest_id": user,
-						"guest_name": guest_name,
-						"message": "Your join request has been approved",
-					},
-					room=f"guest:{user}",
-					after_commit=True,
-				)
-
-		updated_waiting_users = self.get_waiting_room()
-
-		authorized_users = [self.owner, *self.get_co_hosts()]
-		for authorized_user in authorized_users:
-			frappe.publish_realtime(
-				"meeting_user_approved",
-				user=authorized_user,
-				message={"meeting": self.name, "user": user, "approved_by": frappe.session.user},
-				after_commit=True,
-			)
-
-		frappe.publish_realtime(
-			"meeting_waiting_room_updated",
-			doctype=self.doctype,
-			docname=self.name,
-			message={"meeting": self.name, "waiting_count": len(updated_waiting_users)},
-			after_commit=True,
-		)
-
-		return {"status": "joined", "message": "Successfully joined the meeting"}
-
-	def approve_all_users(self):
-		if not self.is_host_or_cohost(frappe.session.user):
-			frappe.throw(_("Only hosts and co-hosts can approve join requests"))
-
-		users = self.get_waiting_room()
-		for user in users:
-			self.approve_user(user, save=False)
-
-		self.save()
-
-	def reject_user(self, user, rejected_by=None):
-		"""Reject a user from waiting room"""
-		if not rejected_by:
-			rejected_by = frappe.session.user
-
-		if not self.is_host_or_cohost(rejected_by):
-			frappe.throw(_("Only hosts and co-hosts can reject join requests"))
-
-		waiting_users = self.get_waiting_room()
-		if user not in waiting_users:
-			frappe.throw("User is not in waiting room")
-
-		self.remove_from_waiting_room(user)
-
-		if not self.get("banned_users"):
-			self.banned_users = []
-
-		already_banned = any(row.user == user for row in self.banned_users)
-		if not already_banned:
-			self.append("banned_users", self.build_user_row(user))
-
-		self.save()
-
-		frappe.publish_realtime(
-			"meeting_join_rejected",
-			user=user,
-			message={"meeting": self.name, "user": user, "rejected_by": rejected_by},
-		)
-
-		authorized_users = [self.owner, *self.get_co_hosts()]
-		for authorized_user in authorized_users:
-			frappe.publish_realtime(
-				"meeting_user_rejected",
-				user=authorized_user,
-				message={"meeting": self.name, "user": user, "rejected_by": rejected_by},
-			)
-
-		updated_waiting_users = self.get_waiting_room()
-		frappe.publish_realtime(
-			"meeting_waiting_room_updated",
-			doctype=self.doctype,
-			docname=self.name,
-			message={"meeting": self.name, "waiting_count": len(updated_waiting_users)},
-		)
-
-	def is_user_approved(self, user):
-		"""Check if user is already approved"""
-
-		if user == self.owner:
-			return True
-
-		members = self.get_members()
-		return user in members
-
-	def is_host_or_cohost(self, user: str) -> bool:
-		"""Check if user is the host or a co-host"""
-		if user == self.owner:
-			return True
-
-		co_hosts = self.get_co_hosts()
-		return user in co_hosts
-
-	def validate_can_promote_to_cohost(self, user: str, target_user: str) -> None:
-		"""Validate that a user can promote another user to co-host"""
-		if user != self.owner:
-			frappe.throw(_("Only the meeting host can promote users to co-host"))
-
-		if target_user.startswith("guest_"):
-			frappe.throw(_("Guests cannot be promoted to co-host"))
-
-		if self.is_host_or_cohost(target_user):
-			frappe.throw(_("User is already a host or co-host"))
-
-		if target_user not in self.get_members():
-			frappe.throw(_("User is not currently in the meeting"))
-
-	def promote_to_cohost(self, user: str, target_user: str) -> dict:
-		"""Promote a user to co-host during an active meeting (host only)"""
-		self.validate_can_promote_to_cohost(user, target_user)
-
-		self.add_user_to_table("co_hosts", target_user)
-		self.save()
-
-		return {
-			"meeting_id": self.name,
-			"user_id": target_user,
-			"message": _("User promoted to co-host successfully"),
-		}
-
-	def is_user_banned(self, user):
-		"""Check if user is banned from this meeting"""
-		if not self.get("banned_users"):
-			return False
-
-		banned_user_emails = [row.user for row in self.banned_users]
-		return user in banned_user_emails
-
-	def validate_guest_id(self, guest_id: str):
-		if not guest_id or not isinstance(guest_id, str):
-			frappe.throw(_("Invalid guest ID"))
-
-		if not guest_id.startswith("guest_"):
-			frappe.throw(_("Invalid guest ID format"))
-
-		if len(guest_id) < 7:
-			frappe.throw(_("Invalid guest ID format"))
-
-		if self.is_user_banned(guest_id):
-			frappe.throw(_("Guest is banned from this meeting"))
-
-	@frappe.whitelist()
-	def enable_e2ee(self) -> bool:
-		"""Enable epoch-based E2EE for this meeting."""
-		if not self.is_host_or_cohost(frappe.session.user):
-			frappe.throw(_("Only hosts and co-hosts can convert meetings to E2EE"), frappe.PermissionError)
-
-		self.e2ee_enabled = True
-		self.save()
-
-		users_notified = set()
-		payload = {"meeting_id": self.name, "e2ee_enabled": True}
-		for member in self.members:
-			user = member.user
-			if not user or user in users_notified:
-				continue
-			users_notified.add(user)
-			if user.startswith("guest_"):
-				frappe.publish_realtime(
-					"meeting:e2ee_enabled",
-					payload,
-					room=f"guest:{user}",
-					after_commit=True,
-				)
-			else:
-				frappe.publish_realtime(
-					"meeting:e2ee_enabled",
-					payload,
-					user=user,
-					after_commit=True,
-				)
-
-		return True
-
-	@frappe.whitelist()
-	def update_settings(
-		self,
-		allow_guest: int | None = None,
-		meeting_type: str | None = None,
-		host_only_chat: int | None = None,
-	) -> None:
-		"""
-		Update meeting settings (host or co-host only)
-		"""
-
-		if not self.is_host_or_cohost(frappe.session.user):
-			frappe.throw(_("Only the meeting host or co-host can update settings"))
-
-		updated_fields = {}
-		if allow_guest is not None:
-			global_settings = frappe.get_cached_doc("Meet Settings")
-			if not global_settings.allow_guest and allow_guest:
-				frappe.throw(_("Guest access is disabled globally"))
-			self.allow_guest = bool(allow_guest)
-			updated_fields["allow_guest"] = self.allow_guest
-
-		if meeting_type is not None:
-			if meeting_type not in ["open", "restricted"]:
-				frappe.throw(_("Invalid meeting type"))
-			self.meeting_type = meeting_type
-			updated_fields["meeting_type"] = self.meeting_type
-
-		if host_only_chat is not None:
-			self.host_only_chat = bool(host_only_chat)
-			updated_fields["host_only_chat"] = self.host_only_chat
-
-		if updated_fields:
-			self.save()
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        from suite.meet.doctype.meet_room_user.meet_room_user import MeetRoomUser
+
+        allow_guest: DF.Check
+        banned_users: DF.Table[MeetRoomUser]
+        co_hosts: DF.Table[MeetRoomUser]
+        e2ee_enabled: DF.Check
+        meeting_type: DF.Literal["open", "restricted"]
+        members: DF.Table[MeetRoomUser]
+        waiting_room: DF.Table[MeetRoomUser]
+    # end: auto-generated types
+
+    def autoname(self):
+        """Set the name of the meeting"""
+        if not self.name:
+            self.name = generate()
+
+    def validate(self):
+        self.backfill_display_names()
+
+    def backfill_display_names(self):
+        """Backfill display names for existing child rows."""
+        for fieldname in ("members", "co_hosts", "waiting_room", "banned_users"):
+            for row in self.get(fieldname) or []:
+                if row.user and not row.user_name:
+                    row.user_name = self.get_user_display_name(row.user)
+
+    def get_user_display_name(self, user: str) -> str:
+        """Resolve a display name for a member, guest, or fallback user ID."""
+        user_info = get_user_info(user)
+        if user_info and user_info.get("full_name"):
+            return user_info.get("full_name")
+
+        if user.startswith("guest_"):
+            guest_session = get_guest_session(user)
+            if guest_session and guest_session.get("guest_name"):
+                return guest_session.get("guest_name")
+
+        return user
+
+    def build_user_row(self, user: str) -> dict:
+        """Build a child table row with both the id and display name."""
+        return {"user": user, "user_name": self.get_user_display_name(user)}
+
+    def get_table_users(self, fieldname: str) -> list[str]:
+        """Return all user IDs from a child table."""
+        return [row.user for row in self.get(fieldname) or []]
+
+    def add_user_to_table(
+        self, fieldname: str, user: str, save: bool = False, ignore_permissions: bool = False
+    ):
+        """Append a user to a child table if they are not already present."""
+        for row in self.get(fieldname) or []:
+            if row.user != user:
+                continue
+            if not row.user_name:
+                row.user_name = self.get_user_display_name(user)
+                if save:
+                    self.save(ignore_permissions=ignore_permissions)
+            return False
+
+        self.append(fieldname, self.build_user_row(user))
+        if save:
+            self.save(ignore_permissions=ignore_permissions)
+        return True
+
+    def add_waiting_room_user(self, user: str, save: bool = False, ignore_permissions: bool = False):
+        """Add a user to the waiting room and notify authorized users."""
+        if self.is_user_approved(user):
+            return
+
+        waiting_users = self.get_waiting_room()
+        if self.add_user_to_table("waiting_room", user, save=save, ignore_permissions=ignore_permissions):
+            self.publish_waiting_room_request(user, len(waiting_users) + 1)
+
+    def get_waiting_room_payload(self, user: str) -> tuple[str, str | None]:
+        """Return display payload for waiting-room notifications."""
+        user_info = get_user_info(user) or {}
+        return user_info.get("full_name", user), user_info.get("user_image")
+
+    def publish_waiting_room_request(self, user: str, waiting_count: int):
+        """Notify host and co-hosts about a waiting-room request."""
+        user_name, user_image = self.get_waiting_room_payload(user)
+
+        for authorized_user in [self.owner, *self.get_co_hosts()]:
+            frappe.publish_realtime(
+                "meeting_join_request",
+                user=authorized_user,
+                message={
+                    "meeting": self.name,
+                    "user": user,
+                    "user_name": user_name,
+                    "user_image": user_image,
+                    "waiting_count": waiting_count,
+                },
+            )
+
+    def after_insert(self):
+        self.join(frappe.session.user)
+
+    def join(self, user=None):
+        """
+        Join the meeting room
+
+        Args:
+                user: User to join (defaults to current session user)
+        """
+        if not user:
+            user = frappe.session.user
+
+        if self.meeting_type == "restricted" and user != self.owner:
+            if not self.is_user_approved(user):
+                self.add_to_waiting_room(user)
+                self.save(ignore_permissions=True)
+                return {"status": "waiting_for_approval", "message": "Waiting for host approval"}
+
+        joined = self.add_user_to_table("members", user)
+
+        # Add user if not already in room
+        if joined:
+            self.remove_from_waiting_room(user)
+
+            self.save(ignore_permissions=True)
+
+        return {"status": "joined", "message": "Successfully joined the meeting"}
+
+    def get_members(self):
+        """Get list of current members"""
+        return self.get_table_users("members")
+
+    def get_co_hosts(self):
+        """Get list of current co-hosts"""
+        return self.get_table_users("co_hosts")
+
+    def can_join(self, user=None):
+        """
+        Check if a user can join this meeting
+
+        Args:
+                user: User to check (defaults to current session user)
+
+        Returns:
+                bool: True if user can join, False otherwise
+        """
+        if not user:
+            user = frappe.session.user
+
+        return not self.is_user_banned(user)
+
+    def update_members(self, members_list):
+        """Update members list and save"""
+        self.set("members", [])
+        for row in unique_users(members_list):
+            user = row.get("user") if isinstance(row, dict) else row
+            if user:
+                self.append("members", self.build_user_row(user))
+
+    def add_guest_to_members(self, guest_id: str):
+        self.validate_guest_id(guest_id)
+        self.add_user_to_table("members", guest_id, save=True, ignore_permissions=True)
+
+    def get_waiting_room(self):
+        """Get list of users waiting for approval"""
+        return self.get_table_users("waiting_room")
+
+    def add_to_waiting_room(self, user):
+        """Add user to waiting room"""
+        self.add_waiting_room_user(user)
+
+    def add_guest_to_waiting_room(self, guest_id: str):
+        self.validate_guest_id(guest_id)
+        self.add_waiting_room_user(guest_id, save=True, ignore_permissions=True)
+
+    def remove_from_waiting_room(self, user):
+        """Remove user from waiting room"""
+        for row in self.get("waiting_room") or []:
+            if row.user == user:
+                self.remove(row)
+                return
+
+    def approve_user(self, user, save=True):
+        """Approve a user from waiting room to join the meeting"""
+        if not self.is_host_or_cohost(frappe.session.user):
+            frappe.throw(_("Only hosts and co-hosts can approve join requests"))
+
+        waiting_users = self.get_waiting_room()
+        if user not in waiting_users:
+            frappe.throw("User is not in waiting room")
+
+        self.add_user_to_table("members", user)
+
+        self.remove_from_waiting_room(user)
+        if save:
+            self.save()
+
+        # for signed-in users
+        frappe.publish_realtime(
+            "meeting_join_approved",
+            user=user,
+            message={"meeting": self.name, "user": user, "approved_by": frappe.session.user},
+            after_commit=True,
+        )
+
+        # for guests
+        if user.startswith("guest_"):
+            session_data = get_guest_session(user)
+            if session_data:
+                guest_name = session_data.get("guest_name")
+                frappe.publish_realtime(
+                    "meet:guest_join_approved",
+                    {
+                        "meeting_id": self.name,
+                        "guest_id": user,
+                        "guest_name": guest_name,
+                        "message": "Your join request has been approved",
+                    },
+                    room=f"guest:{user}",
+                    after_commit=True,
+                )
+
+        updated_waiting_users = self.get_waiting_room()
+
+        authorized_users = [self.owner, *self.get_co_hosts()]
+        for authorized_user in authorized_users:
+            frappe.publish_realtime(
+                "meeting_user_approved",
+                user=authorized_user,
+                message={"meeting": self.name, "user": user, "approved_by": frappe.session.user},
+                after_commit=True,
+            )
+
+        frappe.publish_realtime(
+            "meeting_waiting_room_updated",
+            doctype=self.doctype,
+            docname=self.name,
+            message={"meeting": self.name, "waiting_count": len(updated_waiting_users)},
+            after_commit=True,
+        )
+
+        return {"status": "joined", "message": "Successfully joined the meeting"}
+
+    def approve_all_users(self):
+        if not self.is_host_or_cohost(frappe.session.user):
+            frappe.throw(_("Only hosts and co-hosts can approve join requests"))
+
+        users = self.get_waiting_room()
+        for user in users:
+            self.approve_user(user, save=False)
+
+        self.save()
+
+    def reject_user(self, user, rejected_by=None):
+        """Reject a user from waiting room"""
+        if not rejected_by:
+            rejected_by = frappe.session.user
+
+        if not self.is_host_or_cohost(rejected_by):
+            frappe.throw(_("Only hosts and co-hosts can reject join requests"))
+
+        waiting_users = self.get_waiting_room()
+        if user not in waiting_users:
+            frappe.throw("User is not in waiting room")
+
+        self.remove_from_waiting_room(user)
+
+        if not self.get("banned_users"):
+            self.banned_users = []
+
+        already_banned = any(row.user == user for row in self.banned_users)
+        if not already_banned:
+            self.append("banned_users", self.build_user_row(user))
+
+        self.save()
+
+        frappe.publish_realtime(
+            "meeting_join_rejected",
+            user=user,
+            message={"meeting": self.name, "user": user, "rejected_by": rejected_by},
+        )
+
+        authorized_users = [self.owner, *self.get_co_hosts()]
+        for authorized_user in authorized_users:
+            frappe.publish_realtime(
+                "meeting_user_rejected",
+                user=authorized_user,
+                message={"meeting": self.name, "user": user, "rejected_by": rejected_by},
+            )
+
+        updated_waiting_users = self.get_waiting_room()
+        frappe.publish_realtime(
+            "meeting_waiting_room_updated",
+            doctype=self.doctype,
+            docname=self.name,
+            message={"meeting": self.name, "waiting_count": len(updated_waiting_users)},
+        )
+
+    def is_user_approved(self, user):
+        """Check if user is already approved"""
+
+        if user == self.owner:
+            return True
+
+        members = self.get_members()
+        return user in members
+
+    def is_host_or_cohost(self, user: str) -> bool:
+        """Check if user is the host or a co-host"""
+        if user == self.owner:
+            return True
+
+        co_hosts = self.get_co_hosts()
+        return user in co_hosts
+
+    def validate_can_promote_to_cohost(self, user: str, target_user: str) -> None:
+        """Validate that a user can promote another user to co-host"""
+        if user != self.owner:
+            frappe.throw(_("Only the meeting host can promote users to co-host"))
+
+        if target_user.startswith("guest_"):
+            frappe.throw(_("Guests cannot be promoted to co-host"))
+
+        if self.is_host_or_cohost(target_user):
+            frappe.throw(_("User is already a host or co-host"))
+
+        if target_user not in self.get_members():
+            frappe.throw(_("User is not currently in the meeting"))
+
+    def promote_to_cohost(self, user: str, target_user: str) -> dict:
+        """Promote a user to co-host during an active meeting (host only)"""
+        self.validate_can_promote_to_cohost(user, target_user)
+
+        self.add_user_to_table("co_hosts", target_user)
+        self.save()
+
+        return {
+            "meeting_id": self.name,
+            "user_id": target_user,
+            "message": _("User promoted to co-host successfully"),
+        }
+
+    def is_user_banned(self, user):
+        """Check if user is banned from this meeting"""
+        if not self.get("banned_users"):
+            return False
+
+        banned_user_emails = [row.user for row in self.banned_users]
+        return user in banned_user_emails
+
+    def validate_guest_id(self, guest_id: str):
+        if not guest_id or not isinstance(guest_id, str):
+            frappe.throw(_("Invalid guest ID"))
+
+        if not guest_id.startswith("guest_"):
+            frappe.throw(_("Invalid guest ID format"))
+
+        if len(guest_id) < 7:
+            frappe.throw(_("Invalid guest ID format"))
+
+        if self.is_user_banned(guest_id):
+            frappe.throw(_("Guest is banned from this meeting"))
+
+    @frappe.whitelist()
+    def enable_e2ee(self) -> bool:
+        """Enable epoch-based E2EE for this meeting."""
+        if not self.is_host_or_cohost(frappe.session.user):
+            frappe.throw(_("Only hosts and co-hosts can convert meetings to E2EE"), frappe.PermissionError)
+
+        self.e2ee_enabled = True
+        self.save()
+
+        users_notified = set()
+        payload = {"meeting_id": self.name, "e2ee_enabled": True}
+        for member in self.members:
+            user = member.user
+            if not user or user in users_notified:
+                continue
+            users_notified.add(user)
+            if user.startswith("guest_"):
+                frappe.publish_realtime(
+                    "meeting:e2ee_enabled",
+                    payload,
+                    room=f"guest:{user}",
+                    after_commit=True,
+                )
+            else:
+                frappe.publish_realtime(
+                    "meeting:e2ee_enabled",
+                    payload,
+                    user=user,
+                    after_commit=True,
+                )
+
+        return True
+
+    @frappe.whitelist()
+    def update_settings(
+        self,
+        allow_guest: int | None = None,
+        meeting_type: str | None = None,
+        host_only_chat: int | None = None,
+    ) -> None:
+        """
+        Update meeting settings (host or co-host only)
+        """
+
+        if not self.is_host_or_cohost(frappe.session.user):
+            frappe.throw(_("Only the meeting host or co-host can update settings"))
+
+        updated_fields = {}
+        if allow_guest is not None:
+            global_settings = frappe.get_cached_doc("Meet Settings")
+            if not global_settings.allow_guest and allow_guest:
+                frappe.throw(_("Guest access is disabled globally"))
+            self.allow_guest = bool(allow_guest)
+            updated_fields["allow_guest"] = self.allow_guest
+
+        if meeting_type is not None:
+            if meeting_type not in ["open", "restricted"]:
+                frappe.throw(_("Invalid meeting type"))
+            self.meeting_type = meeting_type
+            updated_fields["meeting_type"] = self.meeting_type
+
+        if host_only_chat is not None:
+            self.host_only_chat = bool(host_only_chat)
+            updated_fields["host_only_chat"] = self.host_only_chat
+
+        if updated_fields:
+            self.save()
 
 
 def generate(segment_length=4, num_segments=3, separator="-"):
-	return separator.join(
-		"".join(secrets.choice(string.ascii_lowercase) for _ in range(segment_length))
-		for _ in range(num_segments)
-	)
+    return separator.join(
+        "".join(secrets.choice(string.ascii_lowercase) for _ in range(segment_length))
+        for _ in range(num_segments)
+    )
 
 
 def get_permission_query_conditions(user: str | None = None) -> str:
-	user = user or frappe.session.user
-	if user == "Administrator" or "System Manager" in frappe.get_roles(user):
-		return ""
+    user = user or frappe.session.user
+    if user == "Administrator" or "System Manager" in frappe.get_roles(user):
+        return ""
 
-	escaped_user = frappe.db.escape(user)
-	return f"""
+    escaped_user = frappe.db.escape(user)
+    return f"""
 		`tabMeet Room`.`owner` = {escaped_user}
 		OR EXISTS (
 			SELECT 1
@@ -480,14 +480,14 @@ def get_permission_query_conditions(user: str | None = None) -> str:
 
 
 def has_permission(doc: MeetRoom, ptype: str = "read", user: str | None = None) -> bool:
-	user = user or frappe.session.user
-	if user == "Administrator" or "System Manager" in frappe.get_roles(user):
-		return True
+    user = user or frappe.session.user
+    if user == "Administrator" or "System Manager" in frappe.get_roles(user):
+        return True
 
-	if ptype == "create":
-		return True
+    if ptype == "create":
+        return True
 
-	if ptype == "delete":
-		return doc.owner == user
+    if ptype == "delete":
+        return doc.owner == user
 
-	return doc.owner == user or user in doc.get_co_hosts()
+    return doc.owner == user or user in doc.get_co_hosts()

--- a/suite/meet/doctype/meet_room/test_meet_room.py
+++ b/suite/meet/doctype/meet_room/test_meet_room.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestMeetRoom(IntegrationTestCase):
-	"""
-	Integration tests for MeetRoom.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for MeetRoom.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/meet/doctype/meet_room_user/meet_room_user.py
+++ b/suite/meet/doctype/meet_room_user/meet_room_user.py
@@ -6,19 +6,19 @@ from frappe.model.document import Document
 
 
 class MeetRoomUser(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		parent: DF.Data
-		parentfield: DF.Data
-		parenttype: DF.Data
-		user: DF.Data | None
-		user_name: DF.Data | None
-	# end: auto-generated types
+        parent: DF.Data
+        parentfield: DF.Data
+        parenttype: DF.Data
+        user: DF.Data | None
+        user_name: DF.Data | None
+    # end: auto-generated types
 
-	pass
+    pass

--- a/suite/meet/doctype/meet_settings/meet_settings.py
+++ b/suite/meet/doctype/meet_settings/meet_settings.py
@@ -6,16 +6,16 @@ from frappe.model.document import Document
 
 
 class MeetSettings(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		allow_guest: DF.Check
-		codec_strategy: DF.Literal["svc", "simulcast"]
-	# end: auto-generated types
+        allow_guest: DF.Check
+        codec_strategy: DF.Literal["svc", "simulcast"]
+    # end: auto-generated types
 
-	pass
+    pass

--- a/suite/meet/doctype/meet_settings/test_meet_settings.py
+++ b/suite/meet/doctype/meet_settings/test_meet_settings.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestMeetSettings(IntegrationTestCase):
-	"""
-	Integration tests for MeetSettings.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for MeetSettings.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/meet/patches/migrate_meeting_fields_to_table_multiselect.py
+++ b/suite/meet/patches/migrate_meeting_fields_to_table_multiselect.py
@@ -8,49 +8,49 @@ from frappe.model.document import Document
 
 
 def execute():
-	meetings = frappe.get_all("Meet Room", fields=["name", "members", "waiting_room"])
+    meetings = frappe.get_all("Meet Room", fields=["name", "members", "waiting_room"])
 
-	for meeting in meetings:
-		try:
-			if meeting.members:
-				try:
-					members_data = json.loads(meeting.members)
-					if members_data:
-						for user in members_data:
-							if user:
-								child_doc = frappe.get_doc(
-									{
-										"doctype": "Meet Room User",
-										"parent": meeting.name,
-										"parenttype": "Meet Room",
-										"parentfield": "members",
-										"user": user,
-									}
-								)
-								child_doc.insert(ignore_permissions=True)
-				except (json.JSONDecodeError, TypeError):
-					pass
+    for meeting in meetings:
+        try:
+            if meeting.members:
+                try:
+                    members_data = json.loads(meeting.members)
+                    if members_data:
+                        for user in members_data:
+                            if user:
+                                child_doc = frappe.get_doc(
+                                    {
+                                        "doctype": "Meet Room User",
+                                        "parent": meeting.name,
+                                        "parenttype": "Meet Room",
+                                        "parentfield": "members",
+                                        "user": user,
+                                    }
+                                )
+                                child_doc.insert(ignore_permissions=True)
+                except (json.JSONDecodeError, TypeError):
+                    pass
 
-			if meeting.waiting_room:
-				try:
-					waiting_data = json.loads(meeting.waiting_room)
-					if waiting_data:
-						for user in waiting_data:
-							if user:
-								child_doc = frappe.get_doc(
-									{
-										"doctype": "Meet Room User",
-										"parent": meeting.name,
-										"parenttype": "Meet Room",
-										"parentfield": "waiting_room",
-										"user": user,
-									}
-								)
-								child_doc.insert(ignore_permissions=True)
-				except (json.JSONDecodeError, TypeError):
-					pass
-		except Exception as e:
-			frappe.log_error(f"Error migrating meeting {meeting.name}: {e}")
-			continue
+            if meeting.waiting_room:
+                try:
+                    waiting_data = json.loads(meeting.waiting_room)
+                    if waiting_data:
+                        for user in waiting_data:
+                            if user:
+                                child_doc = frappe.get_doc(
+                                    {
+                                        "doctype": "Meet Room User",
+                                        "parent": meeting.name,
+                                        "parenttype": "Meet Room",
+                                        "parentfield": "waiting_room",
+                                        "user": user,
+                                    }
+                                )
+                                child_doc.insert(ignore_permissions=True)
+                except (json.JSONDecodeError, TypeError):
+                    pass
+        except Exception as e:
+            frappe.log_error(f"Error migrating meeting {meeting.name}: {e}")
+            continue
 
-	frappe.db.commit()
+    frappe.db.commit()

--- a/suite/meet/patches/rename_sae_meeting_to_meet_room.py
+++ b/suite/meet/patches/rename_sae_meeting_to_meet_room.py
@@ -2,11 +2,11 @@ import frappe
 
 
 def execute() -> None:
-	"""Rename the Meet DocTypes before their new schemas are synced."""
-	if frappe.db.exists("DocType", "Sae Meeting User"):
-		frappe.rename_doc("DocType", "Sae Meeting User", "Meet Room User", force=True)
+    """Rename the Meet DocTypes before their new schemas are synced."""
+    if frappe.db.exists("DocType", "Sae Meeting User"):
+        frappe.rename_doc("DocType", "Sae Meeting User", "Meet Room User", force=True)
 
-	if frappe.db.exists("DocType", "Sae Meeting"):
-		frappe.rename_doc("DocType", "Sae Meeting", "Meet Room", force=True)
+    if frappe.db.exists("DocType", "Sae Meeting"):
+        frappe.rename_doc("DocType", "Sae Meeting", "Meet Room", force=True)
 
-	frappe.clear_cache(doctype="Meet Room")
+    frappe.clear_cache(doctype="Meet Room")

--- a/suite/meet/patches/rename_sae_settings_to_meet_settings.py
+++ b/suite/meet/patches/rename_sae_settings_to_meet_settings.py
@@ -2,8 +2,8 @@ import frappe
 
 
 def execute() -> None:
-	"""Rename the settings DocType before its new schema is synced."""
-	if frappe.db.exists("DocType", "Sae Settings"):
-		frappe.rename_doc("DocType", "Sae Settings", "Meet Settings", force=True)
+    """Rename the settings DocType before its new schema is synced."""
+    if frappe.db.exists("DocType", "Sae Settings"):
+        frappe.rename_doc("DocType", "Sae Settings", "Meet Settings", force=True)
 
-	frappe.clear_cache(doctype="Meet Settings")
+    frappe.clear_cache(doctype="Meet Settings")

--- a/suite/meet/patches/switch_meet_user_to_suite_user.py
+++ b/suite/meet/patches/switch_meet_user_to_suite_user.py
@@ -6,93 +6,93 @@ NEW_ROLE = "Suite User"
 
 
 def execute() -> None:
-	"""Move existing "Meet User" assignments onto the suite-wide "Suite User" role.
+    """Move existing "Meet User" assignments onto the suite-wide "Suite User" role.
 
-	Meet access moved from the app-specific "Meet User" role to the shared
-	"Suite User" role. Users currently holding "Meet User" must gain "Suite User"
-	(if they don't have it already) so they keep access on upgrade, then the stale
-	"Meet User" assignments are dropped. The "Meet User" Role doc itself is left in
-	place — deleting a role cascades through core and is not worth the risk here.
-	"""
+    Meet access moved from the app-specific "Meet User" role to the shared
+    "Suite User" role. Users currently holding "Meet User" must gain "Suite User"
+    (if they don't have it already) so they keep access on upgrade, then the stale
+    "Meet User" assignments are dropped. The "Meet User" Role doc itself is left in
+    place — deleting a role cascades through core and is not worth the risk here.
+    """
 
-	if not frappe.db.exists("Role", NEW_ROLE):
-		frappe.get_doc({"doctype": "Role", "role_name": NEW_ROLE, "desk_access": 1}).insert(
-			ignore_permissions=True
-		)
+    if not frappe.db.exists("Role", NEW_ROLE):
+        frappe.get_doc({"doctype": "Role", "role_name": NEW_ROLE, "desk_access": 1}).insert(
+            ignore_permissions=True
+        )
 
-	meet_users = set(
-		frappe.get_all(
-			"Has Role",
-			filters={"parenttype": "User", "role": OLD_ROLE},
-			pluck="parent",
-		)
-	)
-	meet_users.discard("Administrator")
+    meet_users = set(
+        frappe.get_all(
+            "Has Role",
+            filters={"parenttype": "User", "role": OLD_ROLE},
+            pluck="parent",
+        )
+    )
+    meet_users.discard("Administrator")
 
-	_grant_suite_role(meet_users)
+    _grant_suite_role(meet_users)
 
-	frappe.db.delete("Has Role", {"parenttype": "User", "role": OLD_ROLE})
+    frappe.db.delete("Has Role", {"parenttype": "User", "role": OLD_ROLE})
 
 
 def _grant_suite_role(users: set[str]) -> None:
-	"""Grant NEW_ROLE to ``users`` with one bulk insert into ``Has Role``.
+    """Grant NEW_ROLE to ``users`` with one bulk insert into ``Has Role``.
 
-	NEW_ROLE carries desk access, and the bulk insert does not recompute
-	``user_type``; that is fine because every enabled user already holds a
-	desk-access role (Drive/Suite) and is therefore already a System User.
-	Inserting the child rows directly avoids the N+1 of ``User.add_roles`` on
-	migrate. Users who already hold the role are skipped, and the next ``idx``
-	per user is derived from their existing rows.
-	"""
+    NEW_ROLE carries desk access, and the bulk insert does not recompute
+    ``user_type``; that is fine because every enabled user already holds a
+    desk-access role (Drive/Suite) and is therefore already a System User.
+    Inserting the child rows directly avoids the N+1 of ``User.add_roles`` on
+    migrate. Users who already hold the role are skipped, and the next ``idx``
+    per user is derived from their existing rows.
+    """
 
-	if not users:
-		return
+    if not users:
+        return
 
-	existing = frappe.get_all(
-		"Has Role",
-		filters={"parenttype": "User", "parent": ("in", list(users))},
-		fields=["parent", "role", "idx"],
-	)
-	already_has = {row.parent for row in existing if row.role == NEW_ROLE}
-	next_idx = {}
-	for row in existing:
-		next_idx[row.parent] = max(next_idx.get(row.parent, 0), row.idx)
+    existing = frappe.get_all(
+        "Has Role",
+        filters={"parenttype": "User", "parent": ("in", list(users))},
+        fields=["parent", "role", "idx"],
+    )
+    already_has = {row.parent for row in existing if row.role == NEW_ROLE}
+    next_idx = {}
+    for row in existing:
+        next_idx[row.parent] = max(next_idx.get(row.parent, 0), row.idx)
 
-	timestamp = now()
-	rows = [
-		(
-			frappe.generate_hash(length=10),
-			user,
-			"User",
-			"roles",
-			NEW_ROLE,
-			"Administrator",
-			timestamp,
-			timestamp,
-			"Administrator",
-			next_idx.get(user, 0) + 1,
-			0,
-		)
-		for user in users
-		if user not in already_has
-	]
-	if not rows:
-		return
+    timestamp = now()
+    rows = [
+        (
+            frappe.generate_hash(length=10),
+            user,
+            "User",
+            "roles",
+            NEW_ROLE,
+            "Administrator",
+            timestamp,
+            timestamp,
+            "Administrator",
+            next_idx.get(user, 0) + 1,
+            0,
+        )
+        for user in users
+        if user not in already_has
+    ]
+    if not rows:
+        return
 
-	frappe.db.bulk_insert(
-		"Has Role",
-		fields=[
-			"name",
-			"parent",
-			"parenttype",
-			"parentfield",
-			"role",
-			"owner",
-			"creation",
-			"modified",
-			"modified_by",
-			"idx",
-			"docstatus",
-		],
-		values=rows,
-	)
+    frappe.db.bulk_insert(
+        "Has Role",
+        fields=[
+            "name",
+            "parent",
+            "parenttype",
+            "parentfield",
+            "role",
+            "owner",
+            "creation",
+            "modified",
+            "modified_by",
+            "idx",
+            "docstatus",
+        ],
+        values=rows,
+    )

--- a/suite/meet/utils/__init__.py
+++ b/suite/meet/utils/__init__.py
@@ -7,21 +7,21 @@ SUITE_USER_ROLE = "Suite User"
 
 
 def after_app_install(app_name: str | None = None):
-	assign_suite_role_to_all_users()
+    assign_suite_role_to_all_users()
 
 
 def assign_suite_role_to_all_users():
-	if not frappe.db.exists("Role", SUITE_USER_ROLE):
-		return
+    if not frappe.db.exists("Role", SUITE_USER_ROLE):
+        return
 
-	users = frappe.get_all(
-		"User",
-		filters={"enabled": 1, "name": ["not in", ["Guest", "Administrator"]]},
-		pluck="name",
-	)
+    users = frappe.get_all(
+        "User",
+        filters={"enabled": 1, "name": ["not in", ["Guest", "Administrator"]]},
+        pluck="name",
+    )
 
-	for user_name in users:
-		user = frappe.get_doc("User", user_name)
-		if not any(r.role == SUITE_USER_ROLE for r in user.roles):
-			user.append("roles", {"role": SUITE_USER_ROLE})
-			user.save(ignore_permissions=True)
+    for user_name in users:
+        user = frappe.get_doc("User", user_name)
+        if not any(r.role == SUITE_USER_ROLE for r in user.roles):
+            user.append("roles", {"role": SUITE_USER_ROLE})
+            user.save(ignore_permissions=True)

--- a/suite/meet/utils/sfu_config.py
+++ b/suite/meet/utils/sfu_config.py
@@ -7,9 +7,9 @@ from frappe.utils.caching import redis_cache
 
 @redis_cache(ttl=5 * 60)
 def get_sfu_config():
-	"""Get SFU configuration from site config or defaults"""
-	return {
-		"sfu_server_url": frappe.conf.get("sfu_server_url", "http://localhost"),
-		"sfu_server_port": frappe.conf.get("sfu_server_port", 3000),
-		"sfu_secret": frappe.conf.get("sfu_secret", ""),
-	}
+    """Get SFU configuration from site config or defaults"""
+    return {
+        "sfu_server_url": frappe.conf.get("sfu_server_url", "http://localhost"),
+        "sfu_server_port": frappe.conf.get("sfu_server_port", 3000),
+        "sfu_secret": frappe.conf.get("sfu_secret", ""),
+    }

--- a/suite/meet/utils/user.py
+++ b/suite/meet/utils/user.py
@@ -9,105 +9,105 @@ from frappe.utils.caching import redis_cache
 
 
 def unique_users(user_list: list) -> list[dict]:
-	"""Return unique child table rows, preserving order and metadata."""
-	seen = set()
-	unique_list = []
+    """Return unique child table rows, preserving order and metadata."""
+    seen = set()
+    unique_list = []
 
-	for user in user_list or []:
-		if isinstance(user, str):
-			user_id = user
-			user_row = {"user": user_id}
-		else:
-			user_id = user.get("user") if hasattr(user, "get") else getattr(user, "user", None)
-			if not user_id:
-				continue
-			user_row = dict(user) if isinstance(user, dict) else user.as_dict()
+    for user in user_list or []:
+        if isinstance(user, str):
+            user_id = user
+            user_row = {"user": user_id}
+        else:
+            user_id = user.get("user") if hasattr(user, "get") else getattr(user, "user", None)
+            if not user_id:
+                continue
+            user_row = dict(user) if isinstance(user, dict) else user.as_dict()
 
-		if user_id in seen:
-			continue
+        if user_id in seen:
+            continue
 
-		seen.add(user_id)
-		unique_list.append(user_row)
+        seen.add(user_id)
+        unique_list.append(user_row)
 
-	return unique_list
+    return unique_list
 
 
 def is_guest_user(user_id: str) -> bool:
-	"""Check if a user ID is a guest identifier."""
-	return user_id.startswith("guest_")
+    """Check if a user ID is a guest identifier."""
+    return user_id.startswith("guest_")
 
 
 @redis_cache(ttl=5 * 60)
 def get_user_info(user_id: str) -> dict | None:
-	"""
-	Get user information for both authenticated users and guests.
+    """
+    Get user information for both authenticated users and guests.
 
-	Returns dict with full_name, user_image, and is_guest flag.
-	Returns None if user not found or guest session expired.
-	"""
-	if not user_id:
-		return None
+    Returns dict with full_name, user_image, and is_guest flag.
+    Returns None if user not found or guest session expired.
+    """
+    if not user_id:
+        return None
 
-	if is_guest_user(user_id):
-		guest_session = get_guest_session(user_id)
-		if not guest_session:
-			return None
+    if is_guest_user(user_id):
+        guest_session = get_guest_session(user_id)
+        if not guest_session:
+            return None
 
-		return {
-			"full_name": guest_session.get("guest_name"),
-			"is_guest": True,
-		}
+        return {
+            "full_name": guest_session.get("guest_name"),
+            "is_guest": True,
+        }
 
-	user_info = frappe.db.get_value("User", user_id, ["full_name", "user_image"], as_dict=True)
+    user_info = frappe.db.get_value("User", user_id, ["full_name", "user_image"], as_dict=True)
 
-	if not user_info:
-		return None
+    if not user_info:
+        return None
 
-	return {
-		"full_name": user_info.get("full_name") or user_id,
-		"user_image": user_info.get("user_image"),
-		"is_guest": False,
-	}
+    return {
+        "full_name": user_info.get("full_name") or user_id,
+        "user_image": user_info.get("user_image"),
+        "is_guest": False,
+    }
 
 
 def get_guest_session(guest_id: str) -> dict | None:
-	"""Retrieve guest session data from cache."""
-	cache_key = f"guest_session:{guest_id}"
-	session_data = frappe.cache.get_value(cache_key)
+    """Retrieve guest session data from cache."""
+    cache_key = f"guest_session:{guest_id}"
+    session_data = frappe.cache.get_value(cache_key)
 
-	if not session_data:
-		return None
+    if not session_data:
+        return None
 
-	if isinstance(session_data, dict):
-		return session_data
+    if isinstance(session_data, dict):
+        return session_data
 
-	return None
+    return None
 
 
 def set_guest_session(guest_id: str, session_data: dict, ttl: int = 86400) -> None:
-	"""Store guest session data (default 24 hours)."""
-	cache_key = f"guest_session:{guest_id}"
-	frappe.cache.set_value(cache_key, session_data, expires_in_sec=ttl)
+    """Store guest session data (default 24 hours)."""
+    cache_key = f"guest_session:{guest_id}"
+    frappe.cache.set_value(cache_key, session_data, expires_in_sec=ttl)
 
 
 def validate_guest_name(guest_name: str) -> tuple[bool, str | None]:
-	"""
-	Validate guest name.
+    """
+    Validate guest name.
 
-	Returns (is_valid, error_message).
-	"""
-	if not guest_name or not guest_name.strip():
-		return False, "Guest name is required"
+    Returns (is_valid, error_message).
+    """
+    if not guest_name or not guest_name.strip():
+        return False, "Guest name is required"
 
-	guest_name = guest_name.strip()
+    guest_name = guest_name.strip()
 
-	if len(guest_name) < 2:
-		return False, "Guest name must be at least 2 characters"
+    if len(guest_name) < 2:
+        return False, "Guest name must be at least 2 characters"
 
-	if len(guest_name) > 50:
-		return False, "Guest name must be at most 50 characters"
+    if len(guest_name) > 50:
+        return False, "Guest name must be at most 50 characters"
 
-	if not re.match(r"^[a-zA-Z0-9\s'\-]+$", guest_name):
-		return False, "Guest name contains invalid characters"
+    if not re.match(r"^[a-zA-Z0-9\s'\-]+$", guest_name):
+        return False, "Guest name contains invalid characters"
 
-	return True, None
+    return True, None

--- a/suite/meet/www/meet.py
+++ b/suite/meet/www/meet.py
@@ -4,24 +4,24 @@ no_cache = 1
 
 
 def get_context():
-	csrf_token = frappe.sessions.get_csrf_token()
-	frappe.db.commit()
-	context = frappe._dict()
-	context.boot = get_boot()
-	context.boot.csrf_token = csrf_token
-	return context
+    csrf_token = frappe.sessions.get_csrf_token()
+    frappe.db.commit()
+    context = frappe._dict()
+    context.boot = get_boot()
+    context.boot.csrf_token = csrf_token
+    return context
 
 
 @frappe.whitelist(methods=["POST"], allow_guest=True)
 def get_context_for_dev():
-	if not frappe.conf.developer_mode:
-		frappe.throw("This method is only meant for developer mode")
-	return get_boot()
+    if not frappe.conf.developer_mode:
+        frappe.throw("This method is only meant for developer mode")
+    return get_boot()
 
 
 def get_boot():
-	return frappe._dict(
-		frappe_version=frappe.__version__,
-		site_name=frappe.local.site,
-		is_system_user=frappe.session.data.user_type == "System User",
-	)
+    return frappe._dict(
+        frappe_version=frappe.__version__,
+        site_name=frappe.local.site,
+        is_system_user=frappe.session.data.user_type == "System User",
+    )

--- a/suite/sheets/ai/client.py
+++ b/suite/sheets/ai/client.py
@@ -16,104 +16,100 @@ DEFAULT_MODEL = "claude-opus-4-8"
 MAX_TOKENS = 2048
 
 _SYSTEM = (
-	"You are a spreadsheet assistant embedded in a web spreadsheet app. "
-	"The user selects cells and asks, in plain language, for something to be done. "
-	"You translate that into concrete actions via the emit_actions tool.\n\n"
-	"Rules:\n"
-	"- To put something in a cell, emit a setCell action whose `formula` is a "
-	"spreadsheet formula starting with '=' (e.g. '=SUM(B2:B10)'), or a literal "
-	"value for plain text/numbers. Mirror the formula style already used in the "
-	"sample rows.\n"
-	"- NEVER compute results yourself — always return a formula and let the app "
-	"evaluate it. Reference real cells/ranges from the provided context.\n"
-	"- Target cells using A1 notation (column letters + row number), consistent "
-	"with the selection and headers given.\n"
-	"- If the request is a question about the data rather than an edit, return a "
-	"single `answer` action with a short text reply and do not modify any cells.\n"
-	"- Only emit actions you are confident about. If nothing sensible can be done, "
-	"return an empty actions list."
+    "You are a spreadsheet assistant embedded in a web spreadsheet app. "
+    "The user selects cells and asks, in plain language, for something to be done. "
+    "You translate that into concrete actions via the emit_actions tool.\n\n"
+    "Rules:\n"
+    "- To put something in a cell, emit a setCell action whose `formula` is a "
+    "spreadsheet formula starting with '=' (e.g. '=SUM(B2:B10)'), or a literal "
+    "value for plain text/numbers. Mirror the formula style already used in the "
+    "sample rows.\n"
+    "- NEVER compute results yourself — always return a formula and let the app "
+    "evaluate it. Reference real cells/ranges from the provided context.\n"
+    "- Target cells using A1 notation (column letters + row number), consistent "
+    "with the selection and headers given.\n"
+    "- If the request is a question about the data rather than an edit, return a "
+    "single `answer` action with a short text reply and do not modify any cells.\n"
+    "- Only emit actions you are confident about. If nothing sensible can be done, "
+    "return an empty actions list."
 )
 
 _EMIT_ACTIONS_TOOL = {
-	"name": "emit_actions",
-	"description": "Return the ordered list of spreadsheet actions that fulfil the user's request.",
-	"input_schema": {
-		"type": "object",
-		"properties": {
-			"actions": {
-				"type": "array",
-				"description": "Actions to apply, in order.",
-				"items": {
-					"type": "object",
-					"properties": {
-						"type": {
-							"type": "string",
-							"enum": ["setCell", "answer"],
-							"description": "setCell writes one cell; answer is a read-only text reply.",
-						},
-						"cell": {
-							"type": "string",
-							"description": "For setCell: target cell in A1 notation, e.g. 'B2'.",
-						},
-						"formula": {
-							"type": "string",
-							"description": "For setCell: a formula starting with '=', or a literal value.",
-						},
-						"text": {
-							"type": "string",
-							"description": "For answer: the text reply to show the user.",
-						},
-					},
-					"required": ["type"],
-					"additionalProperties": False,
-				},
-			}
-		},
-		"required": ["actions"],
-		"additionalProperties": False,
-	},
+    "name": "emit_actions",
+    "description": "Return the ordered list of spreadsheet actions that fulfil the user's request.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "actions": {
+                "type": "array",
+                "description": "Actions to apply, in order.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": ["setCell", "answer"],
+                            "description": "setCell writes one cell; answer is a read-only text reply.",
+                        },
+                        "cell": {
+                            "type": "string",
+                            "description": "For setCell: target cell in A1 notation, e.g. 'B2'.",
+                        },
+                        "formula": {
+                            "type": "string",
+                            "description": "For setCell: a formula starting with '=', or a literal value.",
+                        },
+                        "text": {
+                            "type": "string",
+                            "description": "For answer: the text reply to show the user.",
+                        },
+                    },
+                    "required": ["type"],
+                    "additionalProperties": False,
+                },
+            }
+        },
+        "required": ["actions"],
+        "additionalProperties": False,
+    },
 }
 
 
 def generate_actions(prompt: str, context: dict, api_key: str, model: str) -> list:
-	"""Ask Claude for an action plan. Returns the raw `actions` list (unvalidated)."""
-	try:
-		import anthropic
-	except ImportError:
-		frappe.throw(
-			"AI Assist needs the 'anthropic' Python package, which isn't installed "
-			"on the server. Run `bench pip install anthropic`."
-		)
+    """Ask Claude for an action plan. Returns the raw `actions` list (unvalidated)."""
+    try:
+        import anthropic
+    except ImportError:
+        frappe.throw(
+            "AI Assist needs the 'anthropic' Python package, which isn't installed "
+            "on the server. Run `bench pip install anthropic`."
+        )
 
-	client = anthropic.Anthropic(api_key=api_key)
-	user_content = (
-		"Worksheet context (JSON):\n"
-		f"{json.dumps(context, default=str)}\n\n"
-		f"User request: {prompt}"
-	)
+    client = anthropic.Anthropic(api_key=api_key)
+    user_content = f"Worksheet context (JSON):\n{json.dumps(context, default=str)}\n\nUser request: {prompt}"
 
-	try:
-		resp = client.messages.create(
-			model=model or DEFAULT_MODEL,
-			max_tokens=MAX_TOKENS,
-			system=_SYSTEM,
-			tools=[_EMIT_ACTIONS_TOOL],
-			tool_choice={"type": "tool", "name": "emit_actions"},
-			output_config={"effort": "low"},
-			messages=[{"role": "user", "content": user_content}],
-		)
-	except anthropic.AuthenticationError:
-		frappe.throw("The Anthropic API key is invalid or has been revoked.")
-	except anthropic.RateLimitError:
-		frappe.throw("The AI service is rate-limited right now. Try again in a moment.")
-	except anthropic.APIStatusError as e:
-		# Never echo the exception body — it can include request details.
-		frappe.throw(f"The AI request failed (HTTP {e.status_code}).")
-	except anthropic.APIConnectionError:
-		frappe.throw("Could not reach the AI service. Check the server's network access.")
+    try:
+        resp = client.messages.create(
+            model=model or DEFAULT_MODEL,
+            max_tokens=MAX_TOKENS,
+            system=_SYSTEM,
+            tools=[_EMIT_ACTIONS_TOOL],
+            tool_choice={"type": "tool", "name": "emit_actions"},
+            output_config={"effort": "low"},
+            messages=[{"role": "user", "content": user_content}],
+        )
+    except anthropic.AuthenticationError:
+        frappe.throw("The Anthropic API key is invalid or has been revoked.")
+    except anthropic.RateLimitError:
+        frappe.throw("The AI service is rate-limited right now. Try again in a moment.")
+    except anthropic.APIStatusError as e:
+        # Never echo the exception body — it can include request details.
+        frappe.throw(f"The AI request failed (HTTP {e.status_code}).")
+    except anthropic.APIConnectionError:
+        frappe.throw("Could not reach the AI service. Check the server's network access.")
 
-	for block in resp.content:
-		if getattr(block, "type", None) == "tool_use" and block.name == "emit_actions":
-			actions = (block.input or {}).get("actions")
-			return actions if isinstance(actions, list) else []
-	return []
+    for block in resp.content:
+        if getattr(block, "type", None) == "tool_use" and block.name == "emit_actions":
+            actions = (block.input or {}).get("actions")
+            return actions if isinstance(actions, list) else []
+    return []

--- a/suite/sheets/ai/context.py
+++ b/suite/sheets/ai/context.py
@@ -22,124 +22,124 @@ MAX_CONTEXT_BYTES = 12_000
 
 
 def col_to_letters(c: int) -> str:
-	"""0-indexed column number → spreadsheet letters (0 → 'A', 26 → 'AA')."""
-	s = ""
-	c += 1
-	while c:
-		c, rem = divmod(c - 1, 26)
-		s = chr(65 + rem) + s
-	return s
+    """0-indexed column number → spreadsheet letters (0 → 'A', 26 → 'AA')."""
+    s = ""
+    c += 1
+    while c:
+        c, rem = divmod(c - 1, 26)
+        s = chr(65 + rem) + s
+    return s
 
 
 def parse_cell(cid: str):
-	"""'B2' → (row, col) 0-indexed, or None if it isn't a plain cell id."""
-	m = _CELL_RE.match(cid or "")
-	if not m:
-		return None
-	letters, digits = m.group(1).upper(), m.group(2)
-	col = 0
-	for ch in letters:
-		col = col * 26 + (ord(ch) - 64)
-	return int(digits) - 1, col - 1
+    """'B2' → (row, col) 0-indexed, or None if it isn't a plain cell id."""
+    m = _CELL_RE.match(cid or "")
+    if not m:
+        return None
+    letters, digits = m.group(1).upper(), m.group(2)
+    col = 0
+    for ch in letters:
+        col = col * 26 + (ord(ch) - 64)
+    return int(digits) - 1, col - 1
 
 
 def _selection_a1(sel: dict) -> dict:
-	"""Render the selection rectangle + active cell in A1 notation."""
-	try:
-		r0, c0 = int(sel.get("r0", 0)), int(sel.get("c0", 0))
-		r1, c1 = int(sel.get("r1", r0)), int(sel.get("c1", c0))
-	except (TypeError, ValueError):
-		r0 = c0 = r1 = c1 = 0
-	lo_r, hi_r = sorted((r0, r1))
-	lo_c, hi_c = sorted((c0, c1))
-	start = f"{col_to_letters(lo_c)}{lo_r + 1}"
-	end = f"{col_to_letters(hi_c)}{hi_r + 1}"
-	rng = start if start == end else f"{start}:{end}"
-	return {"range": rng, "active": sel.get("active") or start}
+    """Render the selection rectangle + active cell in A1 notation."""
+    try:
+        r0, c0 = int(sel.get("r0", 0)), int(sel.get("c0", 0))
+        r1, c1 = int(sel.get("r1", r0)), int(sel.get("c1", c0))
+    except (TypeError, ValueError):
+        r0 = c0 = r1 = c1 = 0
+    lo_r, hi_r = sorted((r0, r1))
+    lo_c, hi_c = sorted((c0, c1))
+    start = f"{col_to_letters(lo_c)}{lo_r + 1}"
+    end = f"{col_to_letters(hi_c)}{hi_r + 1}"
+    rng = start if start == end else f"{start}:{end}"
+    return {"range": rng, "active": sel.get("active") or start}
 
 
 def _infer_type(values: list) -> str:
-	"""Cheap per-column type from its sampled values."""
-	seen = False
-	for v in values:
-		if v is None or v == "":
-			continue
-		seen = True
-		if isinstance(v, str) and v.startswith("="):
-			return "formula"
-		if isinstance(v, (int, float)):
-			continue
-		if isinstance(v, str):
-			if re.match(r"^-?\d+(\.\d+)?$", v.strip()):
-				continue
-			if re.match(r"^\d{1,4}[-/]\d{1,2}[-/]\d{1,4}", v.strip()):
-				return "date"
-			return "text"
-		return "text"
-	return "number" if seen else "empty"
+    """Cheap per-column type from its sampled values."""
+    seen = False
+    for v in values:
+        if v is None or v == "":
+            continue
+        seen = True
+        if isinstance(v, str) and v.startswith("="):
+            return "formula"
+        if isinstance(v, (int, float)):
+            continue
+        if isinstance(v, str):
+            if re.match(r"^-?\d+(\.\d+)?$", v.strip()):
+                continue
+            if re.match(r"^\d{1,4}[-/]\d{1,2}[-/]\d{1,4}", v.strip()):
+                return "date"
+            return "text"
+        return "text"
+    return "number" if seen else "empty"
 
 
 def build_context(cell_map: dict, sheet_name: str, sel: dict) -> dict:
-	"""Build the compact context dict sent to the model."""
-	cells = {}
-	max_r = max_c = -1
-	for cid, val in (cell_map or {}).items():
-		pc = parse_cell(cid)
-		if pc is None:
-			continue
-		r, c = pc
-		cells[(r, c)] = val
-		if r > max_r:
-			max_r = r
-		if c > max_c:
-			max_c = c
+    """Build the compact context dict sent to the model."""
+    cells = {}
+    max_r = max_c = -1
+    for cid, val in (cell_map or {}).items():
+        pc = parse_cell(cid)
+        if pc is None:
+            continue
+        r, c = pc
+        cells[(r, c)] = val
+        if r > max_r:
+            max_r = r
+        if c > max_c:
+            max_c = c
 
-	selection = _selection_a1(sel or {})
-	if max_r < 0:
-		return {"sheet_name": sheet_name, "empty": True, "selection": selection}
+    selection = _selection_a1(sel or {})
+    if max_r < 0:
+        return {"sheet_name": sheet_name, "empty": True, "selection": selection}
 
-	ncols = min(max_c + 1, MAX_COLS)
-	nrows = min(max_r + 1, MAX_SAMPLE_ROWS)
+    ncols = min(max_c + 1, MAX_COLS)
+    nrows = min(max_r + 1, MAX_SAMPLE_ROWS)
 
-	headers = {}
-	for c in range(ncols):
-		v = cells.get((0, c))
-		if v not in (None, ""):
-			headers[col_to_letters(c)] = v
+    headers = {}
+    for c in range(ncols):
+        v = cells.get((0, c))
+        if v not in (None, ""):
+            headers[col_to_letters(c)] = v
 
-	column_types = {}
-	for c in range(ncols):
-		col_vals = [cells.get((r, c)) for r in range(1, nrows)]
-		column_types[col_to_letters(c)] = _infer_type(col_vals)
+    column_types = {}
+    for c in range(ncols):
+        col_vals = [cells.get((r, c)) for r in range(1, nrows)]
+        column_types[col_to_letters(c)] = _infer_type(col_vals)
 
-	sample_rows = []
-	for r in range(nrows):
-		row = {"_row": r + 1}
-		has = False
-		for c in range(ncols):
-			v = cells.get((r, c))
-			if v not in (None, ""):
-				row[col_to_letters(c)] = v
-				has = True
-		if has:
-			sample_rows.append(row)
+    sample_rows = []
+    for r in range(nrows):
+        row = {"_row": r + 1}
+        has = False
+        for c in range(ncols):
+            v = cells.get((r, c))
+            if v not in (None, ""):
+                row[col_to_letters(c)] = v
+                has = True
+        if has:
+            sample_rows.append(row)
 
-	ctx = {
-		"sheet_name": sheet_name,
-		"selection": selection,
-		"headers": headers,
-		"column_types": column_types,
-		"sample_rows": sample_rows,
-		"truncated": (max_r + 1 > nrows) or (max_c + 1 > ncols),
-	}
-	_enforce_byte_cap(ctx)
-	return ctx
+    ctx = {
+        "sheet_name": sheet_name,
+        "selection": selection,
+        "headers": headers,
+        "column_types": column_types,
+        "sample_rows": sample_rows,
+        "truncated": (max_r + 1 > nrows) or (max_c + 1 > ncols),
+    }
+    _enforce_byte_cap(ctx)
+    return ctx
 
 
 def _enforce_byte_cap(ctx: dict) -> None:
-	"""Drop sample rows from the end until the serialized context fits."""
-	import json
+    """Drop sample rows from the end until the serialized context fits."""
+    import json
 
-	while len(json.dumps(ctx, default=str)) > MAX_CONTEXT_BYTES and ctx["sample_rows"]:
-		ctx["sample_rows"].pop()
-		ctx["truncated"] = True
+    while len(json.dumps(ctx, default=str)) > MAX_CONTEXT_BYTES and ctx["sample_rows"]:
+        ctx["sample_rows"].pop()
+        ctx["truncated"] = True

--- a/suite/sheets/ai/heuristics.py
+++ b/suite/sheets/ai/heuristics.py
@@ -24,136 +24,138 @@ from suite.sheets.ai.context import col_to_letters
 # Deliberately excludes positional words like "below"/"above" (which appear in
 # plain asks such as "total the column below").
 _QUALIFIER_RE = re.compile(
-	r"\b(where|only|unless|except|exclud\w*|filter|"
-	r"greater than|less than|more than|at least|at most|between|"
-	r"group by|grouped by|pivot|distinct|"
-	r"top \d|bottom \d|highest \d|lowest \d|"
-	r"if)\b",
-	re.I,
+    r"\b(where|only|unless|except|exclud\w*|filter|"
+    r"greater than|less than|more than|at least|at most|between|"
+    r"group by|grouped by|pivot|distinct|"
+    r"top \d|bottom \d|highest \d|lowest \d|"
+    r"if)\b",
+    re.I,
 )
 
 # Aggregations: keyword → engine function. Order matters (specific first).
 _AGG = [
-	(("average", "avg", "mean"), "AVERAGE"),
-	(("median",), "MEDIAN"),
-	(("count", "how many", "number of"), "COUNTA"),
-	(("maximum", "max", "largest", "highest", "biggest"), "MAX"),
-	(("minimum", "min", "smallest", "lowest"), "MIN"),
-	(("standard deviation", "std dev", "stdev"), "STDEV"),
-	(("product", "multiply"), "PRODUCT"),
-	(("sum", "total", "add up", "add them", "add these"), "SUM"),
+    (("average", "avg", "mean"), "AVERAGE"),
+    (("median",), "MEDIAN"),
+    (("count", "how many", "number of"), "COUNTA"),
+    (("maximum", "max", "largest", "highest", "biggest"), "MAX"),
+    (("minimum", "min", "smallest", "lowest"), "MIN"),
+    (("standard deviation", "std dev", "stdev"), "STDEV"),
+    (("product", "multiply"), "PRODUCT"),
+    (("sum", "total", "add up", "add them", "add these"), "SUM"),
 ]
 
 # Row-wise transforms: keyword → builder(srcCellRef) → formula string.
 _TRANSFORM = [
-	(("uppercase", "upper case", "all caps"), lambda c: f"=UPPER({c})"),
-	(("lowercase", "lower case"), lambda c: f"=LOWER({c})"),
-	(("proper case", "title case", "propercase", "titlecase", "capitalize"), lambda c: f"=PROPER({c})"),
-	(("trim", "remove whitespace", "remove extra spaces", "strip spaces"), lambda c: f"=TRIM({c})"),
-	(("length", "char count", "number of characters"), lambda c: f"=LEN({c})"),
-	(("domain",), lambda c: f'=MID({c},FIND("@",{c})+1,LEN({c}))'),
-	(("before the @", "email user", "username", "local part"), lambda c: f'=LEFT({c},FIND("@",{c})-1)'),
-	(("first name",), lambda c: f'=LEFT({c},FIND(" ",{c})-1)'),
-	(("last name", "surname"), lambda c: f'=MID({c},FIND(" ",{c})+1,LEN({c}))'),
+    (("uppercase", "upper case", "all caps"), lambda c: f"=UPPER({c})"),
+    (("lowercase", "lower case"), lambda c: f"=LOWER({c})"),
+    (("proper case", "title case", "propercase", "titlecase", "capitalize"), lambda c: f"=PROPER({c})"),
+    (("trim", "remove whitespace", "remove extra spaces", "strip spaces"), lambda c: f"=TRIM({c})"),
+    (("length", "char count", "number of characters"), lambda c: f"=LEN({c})"),
+    (("domain",), lambda c: f'=MID({c},FIND("@",{c})+1,LEN({c}))'),
+    (("before the @", "email user", "username", "local part"), lambda c: f'=LEFT({c},FIND("@",{c})-1)'),
+    (("first name",), lambda c: f'=LEFT({c},FIND(" ",{c})-1)'),
+    (("last name", "surname"), lambda c: f'=MID({c},FIND(" ",{c})+1,LEN({c}))'),
 ]
 
 
 def resolve(prompt: str, context: dict, sel: dict):
-	"""Return a list of actions for a recognised ask, else None."""
-	p = (prompt or "").lower().strip()
-	if not p:
-		return None
-	rect = _rect(sel)
-	if rect is None:
-		return None
-	lo_r, hi_r, lo_c, hi_c = rect
-	qualified = bool(_QUALIFIER_RE.search(p))
+    """Return a list of actions for a recognised ask, else None."""
+    p = (prompt or "").lower().strip()
+    if not p:
+        return None
+    rect = _rect(sel)
+    if rect is None:
+        return None
+    lo_r, hi_r, lo_c, hi_c = rect
+    qualified = bool(_QUALIFIER_RE.search(p))
 
-	# 1) Running total / percent-of-total — single column, multi-row.
-	if not qualified and hi_r > lo_r and lo_c == hi_c:
-		if "running total" in p or "cumulative" in p:
-			return _running_total(rect)
-		if any(x in p for x in ("percent of total", "% of total", "percentage of total", "share of total")):
-			return _pct_of_total(rect)
+    # 1) Running total / percent-of-total — single column, multi-row.
+    if not qualified and hi_r > lo_r and lo_c == hi_c:
+        if "running total" in p or "cumulative" in p:
+            return _running_total(rect)
+        if any(x in p for x in ("percent of total", "% of total", "percentage of total", "share of total")):
+            return _pct_of_total(rect)
 
-	# 2) Aggregation — one or more columns.
-	if not qualified:
-		fn = _detect(p, _AGG)
-		if fn:
-			return _aggregate(fn, rect, context)
+    # 2) Aggregation — one or more columns.
+    if not qualified:
+        fn = _detect(p, _AGG)
+        if fn:
+            return _aggregate(fn, rect, context)
 
-	# 3) Row-wise transform — single column.
-	if lo_c == hi_c:
-		builder = _detect(p, _TRANSFORM)
-		if builder:
-			return _transform(builder, rect)
+    # 3) Row-wise transform — single column.
+    if lo_c == hi_c:
+        builder = _detect(p, _TRANSFORM)
+        if builder:
+            return _transform(builder, rect)
 
-	return None
+    return None
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 
 def _rect(sel):
-	try:
-		r0, c0 = int(sel.get("r0", 0)), int(sel.get("c0", 0))
-		r1, c1 = int(sel.get("r1", r0)), int(sel.get("c1", c0))
-	except (TypeError, ValueError, AttributeError):
-		return None
-	lo_r, hi_r = sorted((r0, r1))
-	lo_c, hi_c = sorted((c0, c1))
-	return lo_r, hi_r, lo_c, hi_c
+    try:
+        r0, c0 = int(sel.get("r0", 0)), int(sel.get("c0", 0))
+        r1, c1 = int(sel.get("r1", r0)), int(sel.get("c1", c0))
+    except (TypeError, ValueError, AttributeError):
+        return None
+    lo_r, hi_r = sorted((r0, r1))
+    lo_c, hi_c = sorted((c0, c1))
+    return lo_r, hi_r, lo_c, hi_c
 
 
 def _detect(p, table):
-	for keys, val in table:
-		if any(k in p for k in keys):
-			return val
-	return None
+    for keys, val in table:
+        if any(k in p for k in keys):
+            return val
+    return None
 
 
 def _aggregate(fn, rect, context):
-	lo_r, hi_r, lo_c, hi_c = rect
-	col_types = (context or {}).get("column_types") or {}
-	actions = []
-	if hi_r > lo_r:
-		# Multi-row: result under each column (skip text columns unless counting).
-		for c in range(lo_c, hi_c + 1):
-			letter = col_to_letters(c)
-			if fn != "COUNTA" and col_types.get(letter) == "text":
-				continue
-			rng = f"{letter}{lo_r + 1}:{letter}{hi_r + 1}"
-			actions.append({"type": "setCell", "cell": f"{letter}{hi_r + 2}", "formula": f"={fn}({rng})"})
-	else:
-		# Single row: result in the next cell to the right.
-		rng = f"{col_to_letters(lo_c)}{lo_r + 1}:{col_to_letters(hi_c)}{lo_r + 1}"
-		actions.append({"type": "setCell", "cell": f"{col_to_letters(hi_c + 1)}{lo_r + 1}", "formula": f"={fn}({rng})"})
-	return actions or None
+    lo_r, hi_r, lo_c, hi_c = rect
+    col_types = (context or {}).get("column_types") or {}
+    actions = []
+    if hi_r > lo_r:
+        # Multi-row: result under each column (skip text columns unless counting).
+        for c in range(lo_c, hi_c + 1):
+            letter = col_to_letters(c)
+            if fn != "COUNTA" and col_types.get(letter) == "text":
+                continue
+            rng = f"{letter}{lo_r + 1}:{letter}{hi_r + 1}"
+            actions.append({"type": "setCell", "cell": f"{letter}{hi_r + 2}", "formula": f"={fn}({rng})"})
+    else:
+        # Single row: result in the next cell to the right.
+        rng = f"{col_to_letters(lo_c)}{lo_r + 1}:{col_to_letters(hi_c)}{lo_r + 1}"
+        actions.append(
+            {"type": "setCell", "cell": f"{col_to_letters(hi_c + 1)}{lo_r + 1}", "formula": f"={fn}({rng})"}
+        )
+    return actions or None
 
 
 def _running_total(rect):
-	lo_r, hi_r, lo_c, _ = rect
-	src, out = col_to_letters(lo_c), col_to_letters(lo_c + 1)
-	return [
-		{"type": "setCell", "cell": f"{out}{r + 1}", "formula": f"=SUM({src}${lo_r + 1}:{src}{r + 1})"}
-		for r in range(lo_r, hi_r + 1)
-	]
+    lo_r, hi_r, lo_c, _ = rect
+    src, out = col_to_letters(lo_c), col_to_letters(lo_c + 1)
+    return [
+        {"type": "setCell", "cell": f"{out}{r + 1}", "formula": f"=SUM({src}${lo_r + 1}:{src}{r + 1})"}
+        for r in range(lo_r, hi_r + 1)
+    ]
 
 
 def _pct_of_total(rect):
-	lo_r, hi_r, lo_c, _ = rect
-	src, out = col_to_letters(lo_c), col_to_letters(lo_c + 1)
-	total = f"SUM({src}${lo_r + 1}:{src}${hi_r + 1})"
-	return [
-		{"type": "setCell", "cell": f"{out}{r + 1}", "formula": f"={src}{r + 1}/{total}"}
-		for r in range(lo_r, hi_r + 1)
-	]
+    lo_r, hi_r, lo_c, _ = rect
+    src, out = col_to_letters(lo_c), col_to_letters(lo_c + 1)
+    total = f"SUM({src}${lo_r + 1}:{src}${hi_r + 1})"
+    return [
+        {"type": "setCell", "cell": f"{out}{r + 1}", "formula": f"={src}{r + 1}/{total}"}
+        for r in range(lo_r, hi_r + 1)
+    ]
 
 
 def _transform(builder, rect):
-	lo_r, hi_r, lo_c, _ = rect
-	src, out = col_to_letters(lo_c), col_to_letters(lo_c + 1)
-	return [
-		{"type": "setCell", "cell": f"{out}{r + 1}", "formula": builder(f"{src}{r + 1}")}
-		for r in range(lo_r, hi_r + 1)
-	]
+    lo_r, hi_r, lo_c, _ = rect
+    src, out = col_to_letters(lo_c), col_to_letters(lo_c + 1)
+    return [
+        {"type": "setCell", "cell": f"{out}{r + 1}", "formula": builder(f"{src}{r + 1}")}
+        for r in range(lo_r, hi_r + 1)
+    ]

--- a/suite/sheets/ai/validate.py
+++ b/suite/sheets/ai/validate.py
@@ -18,29 +18,29 @@ MAX_ANSWER_LEN = 4000
 
 
 def clean_actions(raw) -> list:
-	"""Return the subset of `raw` that is well-formed; drop the rest."""
-	if not isinstance(raw, list):
-		return []
-	out = []
-	for a in raw[:MAX_ACTIONS]:
-		if not isinstance(a, dict):
-			continue
-		t = a.get("type")
-		if t == "setCell":
-			cell = str(a.get("cell") or "").strip().upper()
-			if not _CELL_RE.match(cell):
-				continue
-			formula = a.get("formula")
-			if not isinstance(formula, str):
-				if formula is None:
-					continue
-				formula = str(formula)
-			if len(formula) > MAX_FORMULA_LEN:
-				continue
-			out.append({"type": "setCell", "cell": cell, "formula": formula})
-		elif t == "answer":
-			text = a.get("text")
-			if not isinstance(text, str) or not text.strip():
-				continue
-			out.append({"type": "answer", "text": text[:MAX_ANSWER_LEN]})
-	return out
+    """Return the subset of `raw` that is well-formed; drop the rest."""
+    if not isinstance(raw, list):
+        return []
+    out = []
+    for a in raw[:MAX_ACTIONS]:
+        if not isinstance(a, dict):
+            continue
+        t = a.get("type")
+        if t == "setCell":
+            cell = str(a.get("cell") or "").strip().upper()
+            if not _CELL_RE.match(cell):
+                continue
+            formula = a.get("formula")
+            if not isinstance(formula, str):
+                if formula is None:
+                    continue
+                formula = str(formula)
+            if len(formula) > MAX_FORMULA_LEN:
+                continue
+            out.append({"type": "setCell", "cell": cell, "formula": formula})
+        elif t == "answer":
+            text = a.get("text")
+            if not isinstance(text, str) or not text.strip():
+                continue
+            out.append({"type": "answer", "text": text[:MAX_ANSWER_LEN]})
+    return out

--- a/suite/sheets/api.py
+++ b/suite/sheets/api.py
@@ -14,18 +14,18 @@ MAX_TITLE_LEN = 280
 
 @frappe.whitelist()
 def ping_presence(name: str) -> None:
-	"""Broadcast caller's identity to all clients watching this sheet."""
-	# Refuse presence for sheets the caller can't read — keeps random
-	# logged-in users from spoofing presence in private sheets they
-	# shouldn't even know exist.
-	frappe.has_permission("Sheet", doc=name, throw=True)
-	user = frappe.session.user
-	identity = _user_identity(user)
-	frappe.publish_realtime(
-		"sheet_presence",
-		{"sheet": name, "user": user, **identity},
-		after_commit=False,
-	)
+    """Broadcast caller's identity to all clients watching this sheet."""
+    # Refuse presence for sheets the caller can't read — keeps random
+    # logged-in users from spoofing presence in private sheets they
+    # shouldn't even know exist.
+    frappe.has_permission("Sheet", doc=name, throw=True)
+    user = frappe.session.user
+    identity = _user_identity(user)
+    frappe.publish_realtime(
+        "sheet_presence",
+        {"sheet": name, "user": user, **identity},
+        after_commit=False,
+    )
 
 
 # ── Real-time collaboration ───────────────────────────────────────────────────
@@ -47,26 +47,26 @@ def ping_presence(name: str) -> None:
 
 @frappe.whitelist()
 def broadcast_op(name: str, op: str) -> None:
-	"""Broadcast a cell-op JSON string to all clients watching this sheet."""
-	frappe.has_permission("Sheet", doc=name, ptype="write", throw=True)
-	frappe.publish_realtime(
-		"sheet_op",
-		{"sheet": name, "user": frappe.session.user, "op": op},
-		after_commit=False,
-	)
+    """Broadcast a cell-op JSON string to all clients watching this sheet."""
+    frappe.has_permission("Sheet", doc=name, ptype="write", throw=True)
+    frappe.publish_realtime(
+        "sheet_op",
+        {"sheet": name, "user": frappe.session.user, "op": op},
+        after_commit=False,
+    )
 
 
 @frappe.whitelist()
 def broadcast_cursor(name: str, r: int, c: int, sub_sheet: str) -> None:
-	"""Broadcast cursor position to all clients watching this sheet."""
-	frappe.has_permission("Sheet", doc=name, throw=True)
-	user = frappe.session.user
-	identity = _user_identity(user)
-	frappe.publish_realtime(
-		"sheet_cursor",
-		{"sheet": name, "user": user, **identity, "r": int(r), "c": int(c), "sub_sheet": sub_sheet},
-		after_commit=False,
-	)
+    """Broadcast cursor position to all clients watching this sheet."""
+    frappe.has_permission("Sheet", doc=name, throw=True)
+    user = frappe.session.user
+    identity = _user_identity(user)
+    frappe.publish_realtime(
+        "sheet_cursor",
+        {"sheet": name, "user": user, **identity, "r": int(r), "c": int(c), "sub_sheet": sub_sheet},
+        after_commit=False,
+    )
 
 
 # ── Yjs realtime relay ────────────────────────────────────────────────────────
@@ -88,37 +88,37 @@ def broadcast_cursor(name: str, r: int, c: int, sub_sheet: str) -> None:
 
 @frappe.whitelist()
 def yjs_relay(name: str, event: str, payload: str) -> None:
-	"""Relay a single Yjs realtime event to peers watching this sheet.
+    """Relay a single Yjs realtime event to peers watching this sheet.
 
-	`payload` is an opaque JSON string built by the client (we forward it
-	verbatim so the server stays out of the CRDT protocol). The sender's
-	`from` tag inside the payload is what other clients use to ignore
-	their own echo.
+    `payload` is an opaque JSON string built by the client (we forward it
+    verbatim so the server stays out of the CRDT protocol). The sender's
+    `from` tag inside the payload is what other clients use to ignore
+    their own echo.
 
-	Mutation-shaped events (``yjs_update``, ``yjs_state``) require write
-	permission so a read-only viewer can't push CRDT updates that other
-	clients will apply locally. Presence and state-request events are
-	read-side affordances.
-	"""
-	if event not in _YJS_EVENTS:
-		frappe.throw(f"Unknown yjs event: {event}")
-	ptype = "write" if event in _YJS_WRITE_EVENTS else "read"
-	frappe.has_permission("Sheet", doc=name, ptype=ptype, throw=True)
-	frappe.publish_realtime(
-		event,
-		{"sheet": name, "user": frappe.session.user, "payload": payload},
-		after_commit=False,
-	)
+    Mutation-shaped events (``yjs_update``, ``yjs_state``) require write
+    permission so a read-only viewer can't push CRDT updates that other
+    clients will apply locally. Presence and state-request events are
+    read-side affordances.
+    """
+    if event not in _YJS_EVENTS:
+        frappe.throw(f"Unknown yjs event: {event}")
+    ptype = "write" if event in _YJS_WRITE_EVENTS else "read"
+    frappe.has_permission("Sheet", doc=name, ptype=ptype, throw=True)
+    frappe.publish_realtime(
+        event,
+        {"sheet": name, "user": frappe.session.user, "payload": payload},
+        after_commit=False,
+    )
 
 
 _YJS_EVENTS = frozenset(
-	{
-		"yjs_update",
-		"yjs_state_request",
-		"yjs_state",
-		"yjs_awareness",
-		"yjs_awareness_bye",
-	}
+    {
+        "yjs_update",
+        "yjs_state_request",
+        "yjs_state",
+        "yjs_awareness",
+        "yjs_awareness_bye",
+    }
 )
 
 # Events that mutate co-editors' local Yjs document. A read-only sharee
@@ -132,147 +132,147 @@ _YJS_WRITE_EVENTS = frozenset({"yjs_update", "yjs_state"})
 
 @frappe.whitelist()
 def get_sheet_shares(name: str) -> list:
-	"""Return users who have explicit share access to this sheet."""
-	frappe.has_permission("Sheet", doc=name, throw=True)
-	rows = frappe.get_all(
-		"DocShare",
-		filters={"share_doctype": "Sheet", "share_name": name},
-		fields=["user", "read", "write", "share", "everyone"],
-	)
-	for row in rows:
-		if row.get("everyone"):
-			row["full_name"] = ""
-			row["initials"] = ""
-			row["user_image"] = ""
-			continue
-		identity = _user_identity(row["user"])
-		row.update(identity)
-		row["user_image"] = frappe.db.get_value("User", row["user"], "user_image") or ""
-	return rows
+    """Return users who have explicit share access to this sheet."""
+    frappe.has_permission("Sheet", doc=name, throw=True)
+    rows = frappe.get_all(
+        "DocShare",
+        filters={"share_doctype": "Sheet", "share_name": name},
+        fields=["user", "read", "write", "share", "everyone"],
+    )
+    for row in rows:
+        if row.get("everyone"):
+            row["full_name"] = ""
+            row["initials"] = ""
+            row["user_image"] = ""
+            continue
+        identity = _user_identity(row["user"])
+        row.update(identity)
+        row["user_image"] = frappe.db.get_value("User", row["user"], "user_image") or ""
+    return rows
 
 
 @frappe.whitelist()
 def share_sheet(name: str, user: str = "", write: int = 0, everyone: int = 0) -> dict:
-	# `ptype="share"` — only users who themselves hold the share right
-	# may grant access to others. Default `read` was too permissive
-	# (any viewer could re-share a sheet to anyone).
-	frappe.has_permission("Sheet", doc=name, ptype="share", throw=True)
-	if int(everyone or 0):
-		# "Accessible to all" → single DocShare with everyone=1, user=NULL.
-		# notify=False because there's no individual to email.
-		frappe.share.add(
-			"Sheet",
-			name,
-			user=None,
-			write=int(write),
-			share=0,
-			everyone=1,
-			notify=False,
-		)
-		return {"status": "ok"}
-	# Reject disabled users (and non-existent ones) up front — silently
-	# carrying a share to an account that's been turned off lets it light
-	# up again the moment the account is re-enabled, which is rarely what
-	# the granter expected.
-	enabled = frappe.db.get_value("User", user, "enabled")
-	if enabled is None:
-		frappe.throw(f"User {user} not found")
-	if not enabled:
-		frappe.throw(f"User {user} is disabled")
-	# Pass notify=False to Frappe's generic share path — the default
-	# notification renders as "Asif shared a document Sheet 'Title' with
-	# you" and the click destination is the Desk doctype form, not our
-	# SPA. We dispatch our own branded notification below.
-	frappe.share.add("Sheet", name, user, write=int(write), share=0, notify=False)
-	_notify_sheet_shared(name, user, can_edit=bool(int(write)))
-	return {"status": "ok"}
+    # `ptype="share"` — only users who themselves hold the share right
+    # may grant access to others. Default `read` was too permissive
+    # (any viewer could re-share a sheet to anyone).
+    frappe.has_permission("Sheet", doc=name, ptype="share", throw=True)
+    if int(everyone or 0):
+        # "Accessible to all" → single DocShare with everyone=1, user=NULL.
+        # notify=False because there's no individual to email.
+        frappe.share.add(
+            "Sheet",
+            name,
+            user=None,
+            write=int(write),
+            share=0,
+            everyone=1,
+            notify=False,
+        )
+        return {"status": "ok"}
+    # Reject disabled users (and non-existent ones) up front — silently
+    # carrying a share to an account that's been turned off lets it light
+    # up again the moment the account is re-enabled, which is rarely what
+    # the granter expected.
+    enabled = frappe.db.get_value("User", user, "enabled")
+    if enabled is None:
+        frappe.throw(f"User {user} not found")
+    if not enabled:
+        frappe.throw(f"User {user} is disabled")
+    # Pass notify=False to Frappe's generic share path — the default
+    # notification renders as "Asif shared a document Sheet 'Title' with
+    # you" and the click destination is the Desk doctype form, not our
+    # SPA. We dispatch our own branded notification below.
+    frappe.share.add("Sheet", name, user, write=int(write), share=0, notify=False)
+    _notify_sheet_shared(name, user, can_edit=bool(int(write)))
+    return {"status": "ok"}
 
 
 def _notify_sheet_shared(sheet_name: str, recipient: str, can_edit: bool) -> None:
-	"""Send the recipient a branded share notification.
+    """Send the recipient a branded share notification.
 
-	Two surfaces:
+    Two surfaces:
 
-	  * **In-app notification** (Notification Log) — shows in the bell
-	    icon. Subject is plain text; clicking lands on /sheets?id=…
-	    instead of /app/sheet/<hash> (the Desk form view of the doctype,
-	    which is a raw JSON blob).
-	  * **Email** — only if the site has SMTP configured. `now=False`
-	    enqueues it so the share API stays fast and a flaky mailer
-	    doesn't break the user's flow. The email body links to the SPA
-	    URL using `frappe.utils.get_url` so it works in dev (localhost)
-	    and prod (https) without us hard-coding anything.
+      * **In-app notification** (Notification Log) — shows in the bell
+        icon. Subject is plain text; clicking lands on /sheets?id=…
+        instead of /app/sheet/<hash> (the Desk form view of the doctype,
+        which is a raw JSON blob).
+      * **Email** — only if the site has SMTP configured. `now=False`
+        enqueues it so the share API stays fast and a flaky mailer
+        doesn't break the user's flow. The email body links to the SPA
+        URL using `frappe.utils.get_url` so it works in dev (localhost)
+        and prod (https) without us hard-coding anything.
 
-	Anything that throws below is swallowed: a notification failure must
-	not roll back the DocShare row — the access grant has already
-	committed and the recipient now has access, the email is sugar.
-	"""
-	try:
-		share_doc = frappe.get_doc("Sheet", sheet_name)
-		title = share_doc.title or "Untitled Spreadsheet"
-		sharer = frappe.db.get_value("User", frappe.session.user, "full_name") or frappe.session.user
-		role = "edit" if can_edit else "view"
-		# Link points at the SPA, not the Desk. `get_url` respects the
-		# site's `host_name`, so this works behind reverse proxies too.
-		link = f"{frappe.utils.get_url()}/sheets?id={sheet_name}"
-		subject = f"{sharer} shared a sheet with you"
-		# Frappe's Notification Log surfaces in the bell-icon dropdown.
-		frappe.get_doc(
-			{
-				"doctype": "Notification Log",
-				"subject": (
-					f"{frappe.utils.escape_html(sharer)} shared the sheet "
-					f"<b>{frappe.utils.escape_html(title)}</b> with you "
-					f"(can {role})"
-				),
-				"for_user": recipient,
-				"type": "Share",
-				"document_type": "Sheet",
-				"document_name": sheet_name,
-				"from_user": frappe.session.user,
-				"email_content": (
-					f"<p>{frappe.utils.escape_html(sharer)} shared the sheet "
-					f"<b>{frappe.utils.escape_html(title)}</b> with you. "
-					f"You can {role} it.</p>"
-					f"<p><a href='{link}'>Open sheet</a></p>"
-				),
-			}
-		).insert(ignore_permissions=True)
-		# Best-effort email — silently skipped if the site has no mailer.
-		frappe.sendmail(
-			recipients=[recipient],
-			subject=subject,
-			message=(
-				f"<p>{frappe.utils.escape_html(sharer)} shared the sheet "
-				f"<b>{frappe.utils.escape_html(title)}</b> with you. "
-				f"You can {role} it.</p>"
-				f"<p><a href='{link}'>Open the sheet</a></p>"
-			),
-			reference_doctype="Sheet",
-			reference_name=sheet_name,
-			now=False,
-		)
-	except Exception:
-		# Don't let notification failures roll back the share — the
-		# DocShare has already committed and the access grant stands.
-		frappe.log_error(title="Sheet share notification failed")
+    Anything that throws below is swallowed: a notification failure must
+    not roll back the DocShare row — the access grant has already
+    committed and the recipient now has access, the email is sugar.
+    """
+    try:
+        share_doc = frappe.get_doc("Sheet", sheet_name)
+        title = share_doc.title or "Untitled Spreadsheet"
+        sharer = frappe.db.get_value("User", frappe.session.user, "full_name") or frappe.session.user
+        role = "edit" if can_edit else "view"
+        # Link points at the SPA, not the Desk. `get_url` respects the
+        # site's `host_name`, so this works behind reverse proxies too.
+        link = f"{frappe.utils.get_url()}/sheets?id={sheet_name}"
+        subject = f"{sharer} shared a sheet with you"
+        # Frappe's Notification Log surfaces in the bell-icon dropdown.
+        frappe.get_doc(
+            {
+                "doctype": "Notification Log",
+                "subject": (
+                    f"{frappe.utils.escape_html(sharer)} shared the sheet "
+                    f"<b>{frappe.utils.escape_html(title)}</b> with you "
+                    f"(can {role})"
+                ),
+                "for_user": recipient,
+                "type": "Share",
+                "document_type": "Sheet",
+                "document_name": sheet_name,
+                "from_user": frappe.session.user,
+                "email_content": (
+                    f"<p>{frappe.utils.escape_html(sharer)} shared the sheet "
+                    f"<b>{frappe.utils.escape_html(title)}</b> with you. "
+                    f"You can {role} it.</p>"
+                    f"<p><a href='{link}'>Open sheet</a></p>"
+                ),
+            }
+        ).insert(ignore_permissions=True)
+        # Best-effort email — silently skipped if the site has no mailer.
+        frappe.sendmail(
+            recipients=[recipient],
+            subject=subject,
+            message=(
+                f"<p>{frappe.utils.escape_html(sharer)} shared the sheet "
+                f"<b>{frappe.utils.escape_html(title)}</b> with you. "
+                f"You can {role} it.</p>"
+                f"<p><a href='{link}'>Open the sheet</a></p>"
+            ),
+            reference_doctype="Sheet",
+            reference_name=sheet_name,
+            now=False,
+        )
+    except Exception:
+        # Don't let notification failures roll back the share — the
+        # DocShare has already committed and the access grant stands.
+        frappe.log_error(title="Sheet share notification failed")
 
 
 @frappe.whitelist()
 def unshare_sheet(name: str, user: str = "", everyone: int = 0) -> dict:
-	frappe.has_permission("Sheet", doc=name, ptype="share", throw=True)
-	if int(everyone or 0):
-		# frappe.share.remove() looks up by user; for the everyone row we
-		# locate the DocShare directly and delete it.
-		share_name = frappe.db.get_value(
-			"DocShare",
-			{"share_doctype": "Sheet", "share_name": name, "everyone": 1},
-		)
-		if share_name:
-			frappe.delete_doc("DocShare", share_name, ignore_permissions=True)
-		return {"status": "ok"}
-	frappe.share.remove("Sheet", name, user)
-	return {"status": "ok"}
+    frappe.has_permission("Sheet", doc=name, ptype="share", throw=True)
+    if int(everyone or 0):
+        # frappe.share.remove() looks up by user; for the everyone row we
+        # locate the DocShare directly and delete it.
+        share_name = frappe.db.get_value(
+            "DocShare",
+            {"share_doctype": "Sheet", "share_name": name, "everyone": 1},
+        )
+        if share_name:
+            frappe.delete_doc("DocShare", share_name, ignore_permissions=True)
+        return {"status": "ok"}
+    frappe.share.remove("Sheet", name, user)
+    return {"status": "ok"}
 
 
 # Caller's `order_by` is resolved through this dict — a key lookup, never
@@ -281,265 +281,265 @@ def unshare_sheet(name: str, user: str = "", everyone: int = 0) -> dict:
 # `_list_sheets_order_by`, so neither the column nor the direction is ever
 # free text.
 _LIST_SHEETS_SORT_FIELDS = {
-	"modified": "`tabSheet`.`modified`",
-	"title": "`tabSheet`.`title`",
-	"owner": "`tabSheet`.`owner`",
+    "modified": "`tabSheet`.`modified`",
+    "title": "`tabSheet`.`title`",
+    "owner": "`tabSheet`.`owner`",
 }
 
 
 def _list_sheets_order_by(order_by: str, sort_dir: str) -> str:
-	field = _LIST_SHEETS_SORT_FIELDS.get(order_by) or _LIST_SHEETS_SORT_FIELDS["modified"]
-	direction = "asc" if str(sort_dir).lower() == "asc" else "desc"
-	order = f"{field} {direction}"
-	# Owner is a low-cardinality column, so a secondary `modified desc` keeps
-	# rows within one owner in a stable, useful order regardless of direction.
-	if order_by == "owner":
-		order += ", `tabSheet`.`modified` desc"
-	return order
+    field = _LIST_SHEETS_SORT_FIELDS.get(order_by) or _LIST_SHEETS_SORT_FIELDS["modified"]
+    direction = "asc" if str(sort_dir).lower() == "asc" else "desc"
+    order = f"{field} {direction}"
+    # Owner is a low-cardinality column, so a secondary `modified desc` keeps
+    # rows within one owner in a stable, useful order regardless of direction.
+    if order_by == "owner":
+        order += ", `tabSheet`.`modified` desc"
+    return order
 
 
 @frappe.whitelist()
 def list_sheets(
-	start: int = 0,
-	limit: int = 50,
-	search: str = "",
-	owner_filter: str = "all",
-	order_by: str = "modified",
-	sort_dir: str = "desc",
+    start: int = 0,
+    limit: int = 50,
+    search: str = "",
+    owner_filter: str = "all",
+    order_by: str = "modified",
+    sort_dir: str = "desc",
 ) -> dict:
-	# Frappe's get_list applies the permission query, so the base result is
-	# sheets the session user owns plus those shared via DocShare (per-user
-	# or everyone=1). `owner_filter` narrows within that visible set:
-	# "mine" / "shared" split on ownership, anything else means "all".
-	# `is_owner` is computed here because the SPA template doesn't inject
-	# window.frappe.session — the client can't know who it is on its own.
-	me = frappe.session.user
-	start = max(frappe.utils.cint(start), 0)
-	limit = min(max(frappe.utils.cint(limit) or 50, 1), 100)
+    # Frappe's get_list applies the permission query, so the base result is
+    # sheets the session user owns plus those shared via DocShare (per-user
+    # or everyone=1). `owner_filter` narrows within that visible set:
+    # "mine" / "shared" split on ownership, anything else means "all".
+    # `is_owner` is computed here because the SPA template doesn't inject
+    # window.frappe.session — the client can't know who it is on its own.
+    me = frappe.session.user
+    start = max(frappe.utils.cint(start), 0)
+    limit = min(max(frappe.utils.cint(limit) or 50, 1), 100)
 
-	filters = {"trashed": 0}
-	search = (search or "").strip()
-	if search:
-		filters["title"] = ["like", f"%{search}%"]
-	if owner_filter == "mine":
-		filters["owner"] = me
-	elif owner_filter == "shared":
-		filters["owner"] = ["!=", me]
+    filters = {"trashed": 0}
+    search = (search or "").strip()
+    if search:
+        filters["title"] = ["like", f"%{search}%"]
+    if owner_filter == "mine":
+        filters["owner"] = me
+    elif owner_filter == "shared":
+        filters["owner"] = ["!=", me]
 
-	rows = frappe.get_list(
-		"Sheet",
-		filters=filters,
-		fields=["name", "title", "modified", "owner"],
-		order_by=_list_sheets_order_by(order_by, sort_dir),
-		limit_start=start,
-		limit_page_length=limit,
-	)
-	for r in rows:
-		r["is_owner"] = r["owner"] == me
+    rows = frappe.get_list(
+        "Sheet",
+        filters=filters,
+        fields=["name", "title", "modified", "owner"],
+        order_by=_list_sheets_order_by(order_by, sort_dir),
+        limit_start=start,
+        limit_page_length=limit,
+    )
+    for r in rows:
+        r["is_owner"] = r["owner"] == me
 
-	# Permission-aware total for the same filters — an aggregate get_list
-	# keeps the owner + DocShare conditions that frappe.db.count would drop.
-	# Dict field syntax: newer Frappe rejects string SQL functions in SELECT.
-	total = frappe.get_list(
-		"Sheet",
-		filters=filters,
-		fields=[{"COUNT": "*", "as": "total"}],
-	)[0]["total"]
-	# `now` shares the naive server-local frame of `modified`, so the client
-	# can bucket rows by recency without mixing server and client clocks.
-	return {"sheets": rows, "total": total, "now": str(frappe.utils.now())}
+    # Permission-aware total for the same filters — an aggregate get_list
+    # keeps the owner + DocShare conditions that frappe.db.count would drop.
+    # Dict field syntax: newer Frappe rejects string SQL functions in SELECT.
+    total = frappe.get_list(
+        "Sheet",
+        filters=filters,
+        fields=[{"COUNT": "*", "as": "total"}],
+    )[0]["total"]
+    # `now` shares the naive server-local frame of `modified`, so the client
+    # can bucket rows by recency without mixing server and client clocks.
+    return {"sheets": rows, "total": total, "now": str(frappe.utils.now())}
 
 
 @frappe.whitelist()
 def get_sheet(name: str, compressed: int = 0) -> dict:
-	# `frappe.get_doc` does NOT check read permission by itself — without
-	# this guard, any logged-in user who knows a sheet id could exfiltrate
-	# its contents.
-	frappe.has_permission("Sheet", doc=name, throw=True)
-	doc = frappe.get_doc("Sheet", name)
-	# A trashed sheet must not open from a bookmarked/shared link — it's
-	# "deleted" as far as the app is concerned until restored.
-	if doc.trashed:
-		frappe.throw("This sheet is in the trash.", frappe.DoesNotExistError)
-	# When the client can gunzip (DecompressionStream), ship the stored envelope
-	# as-is — ~1.5MB instead of the ~20MB decoded JSON for a big sheet — and let
-	# it decompress. Clients without it (older Safari) get the decoded payload.
-	raw = doc.sheets_data
-	# The read guard above only proves the caller can *view* the sheet. Ship an
-	# explicit write flag so the editor can render read-only (dim the toolbar,
-	# lock the grid, hide the save path) instead of letting a viewer type into a
-	# doc they can't persist and only discovering it when save_sheet throws.
-	return {
-		"name": doc.name,
-		"title": doc.title,
-		"can_write": bool(frappe.has_permission("Sheet", doc=name, ptype="write", throw=False)),
-		"sheets_data": raw if frappe.utils.cint(compressed) else decode_sheets_data(raw),
-		# The sheet's true creator, so the Share dialog can label the owner row
-		# with the real person (and "Owner (you)" only for them) instead of
-		# falling back to whoever happens to have the dialog open.
-		"owner": doc.owner,
-	}
+    # `frappe.get_doc` does NOT check read permission by itself — without
+    # this guard, any logged-in user who knows a sheet id could exfiltrate
+    # its contents.
+    frappe.has_permission("Sheet", doc=name, throw=True)
+    doc = frappe.get_doc("Sheet", name)
+    # A trashed sheet must not open from a bookmarked/shared link — it's
+    # "deleted" as far as the app is concerned until restored.
+    if doc.trashed:
+        frappe.throw("This sheet is in the trash.", frappe.DoesNotExistError)
+    # When the client can gunzip (DecompressionStream), ship the stored envelope
+    # as-is — ~1.5MB instead of the ~20MB decoded JSON for a big sheet — and let
+    # it decompress. Clients without it (older Safari) get the decoded payload.
+    raw = doc.sheets_data
+    # The read guard above only proves the caller can *view* the sheet. Ship an
+    # explicit write flag so the editor can render read-only (dim the toolbar,
+    # lock the grid, hide the save path) instead of letting a viewer type into a
+    # doc they can't persist and only discovering it when save_sheet throws.
+    return {
+        "name": doc.name,
+        "title": doc.title,
+        "can_write": bool(frappe.has_permission("Sheet", doc=name, ptype="write", throw=False)),
+        "sheets_data": raw if frappe.utils.cint(compressed) else decode_sheets_data(raw),
+        # The sheet's true creator, so the Share dialog can label the owner row
+        # with the real person (and "Owner (you)" only for them) instead of
+        # falling back to whoever happens to have the dialog open.
+        "owner": doc.owner,
+    }
 
 
 @frappe.whitelist()
 def save_sheet(
-	title: str,
-	sheets_data: str,
-	name: str = "",
-	ops: str = "",
+    title: str,
+    sheets_data: str,
+    name: str = "",
+    ops: str = "",
 ) -> dict:
-	# Delegates to versioning.save — appends a batch of ops + the implicit
-	# save op atomically, advances head_seq, enqueues an async snapshot.
-	# Returns {"name": <sheet_id>, "head_seq": <int>} so the caller knows
-	# where its ops landed in the canonical order.
-	return save_mod.save_sheet(title, sheets_data, name or None, ops or None)
+    # Delegates to versioning.save — appends a batch of ops + the implicit
+    # save op atomically, advances head_seq, enqueues an async snapshot.
+    # Returns {"name": <sheet_id>, "head_seq": <int>} so the caller knows
+    # where its ops landed in the canonical order.
+    return save_mod.save_sheet(title, sheets_data, name or None, ops or None)
 
 
 @frappe.whitelist()
 def create_sheet(title: str = "", parent: str = "") -> str:
-	# Create a blank sheet and return its id. Used by Drive's "New > Spreadsheet"
-	# so the sheet is born inside the folder the user is looking at — `parent`
-	# is the Drive folder its backing File should land in (validated for upload
-	# access here, then threaded to Sheet.after_insert). Mirrors Writer's
-	# create_document. "{}" is a valid empty workbook — the editor's loader
-	# falls back to a fresh Sheet1 when the packed payload is absent.
-	if parent:
-		from suite.drive.api.permissions import user_has_permission
+    # Create a blank sheet and return its id. Used by Drive's "New > Spreadsheet"
+    # so the sheet is born inside the folder the user is looking at — `parent`
+    # is the Drive folder its backing File should land in (validated for upload
+    # access here, then threaded to Sheet.after_insert). Mirrors Writer's
+    # create_document. "{}" is a valid empty workbook — the editor's loader
+    # falls back to a fresh Sheet1 when the packed payload is absent.
+    if parent:
+        from suite.drive.api.permissions import user_has_permission
 
-		if not user_has_permission(parent, "upload"):
-			frappe.throw(
-				"Cannot access folder due to insufficient permissions",
-				frappe.PermissionError,
-			)
-	result = save_mod.save_sheet(title or "Untitled Spreadsheet", "{}", name=None, parent=parent or None)
-	return result["name"]
+        if not user_has_permission(parent, "upload"):
+            frappe.throw(
+                "Cannot access folder due to insufficient permissions",
+                frappe.PermissionError,
+            )
+    result = save_mod.save_sheet(title or "Untitled Spreadsheet", "{}", name=None, parent=parent or None)
+    return result["name"]
 
 
 @frappe.whitelist()
 def record_op(
-	sheet: str,
-	op_type: str,
-	sub_sheet: str = "",
-	cell_refs: str = "",
-	before: str = "",
-	after: str = "",
-	summary: str = "",
+    sheet: str,
+    op_type: str,
+    sub_sheet: str = "",
+    cell_refs: str = "",
+    before: str = "",
+    after: str = "",
+    summary: str = "",
 ) -> dict:
-	# Append a single op outside the save path. Used by collaboration
-	# broadcasts and any other UI affordance that wants to log an action
-	# without forcing a save.
-	new_seq = save_mod.append_op(
-		sheet,
-		{
-			"op_type": op_type,
-			"sub_sheet": sub_sheet or None,
-			"cell_refs": cell_refs or None,
-			"before": before or None,
-			"after": after or None,
-			"summary": summary,
-		},
-	)
-	return {"seq": new_seq}
+    # Append a single op outside the save path. Used by collaboration
+    # broadcasts and any other UI affordance that wants to log an action
+    # without forcing a save.
+    new_seq = save_mod.append_op(
+        sheet,
+        {
+            "op_type": op_type,
+            "sub_sheet": sub_sheet or None,
+            "cell_refs": cell_refs or None,
+            "before": before or None,
+            "after": after or None,
+            "summary": summary,
+        },
+    )
+    return {"seq": new_seq}
 
 
 @frappe.whitelist()
 def delete_sheet(name: str) -> str:
-	# Soft delete: flag the sheet as trashed instead of destroying it, so the
-	# owner can restore it within the retention window. The `delete` ptype gate
-	# is owner-only (the "All" role's delete perm is `if_owner`), so a shared
-	# collaborator can't trash someone else's sheet. Versioning tables are left
-	# fully intact — a restore is a perfect restore, not a last-save recovery.
-	# The nightly purge (suite.sheets.trash.purge_trashed_sheets) does the real erase.
-	frappe.has_permission("Sheet", doc=name, ptype="delete", throw=True)
-	# Flip the flag through the ORM so on_update fires and Drive drops the backing
-	# File from the listing in lockstep (see hooks.py) — no Sheets-specific Drive
-	# call, same front door as a Writer/Slides delete.
-	doc = frappe.get_doc("Sheet", name)
-	doc.trashed = 1
-	doc.trashed_on = frappe.utils.now_datetime()
-	doc.trashed_by = frappe.session.user
-	doc.save()
-	return "ok"
+    # Soft delete: flag the sheet as trashed instead of destroying it, so the
+    # owner can restore it within the retention window. The `delete` ptype gate
+    # is owner-only (the "All" role's delete perm is `if_owner`), so a shared
+    # collaborator can't trash someone else's sheet. Versioning tables are left
+    # fully intact — a restore is a perfect restore, not a last-save recovery.
+    # The nightly purge (suite.sheets.trash.purge_trashed_sheets) does the real erase.
+    frappe.has_permission("Sheet", doc=name, ptype="delete", throw=True)
+    # Flip the flag through the ORM so on_update fires and Drive drops the backing
+    # File from the listing in lockstep (see hooks.py) — no Sheets-specific Drive
+    # call, same front door as a Writer/Slides delete.
+    doc = frappe.get_doc("Sheet", name)
+    doc.trashed = 1
+    doc.trashed_on = frappe.utils.now_datetime()
+    doc.trashed_by = frappe.session.user
+    doc.save()
+    return "ok"
 
 
 @frappe.whitelist()
 def restore_sheet(name: str) -> str:
-	# Same owner-only gate as trashing — restore is the inverse of delete.
-	frappe.has_permission("Sheet", doc=name, ptype="delete", throw=True)
-	# Inverse of trashing: clear the flag through the ORM so on_update returns the
-	# backing File to the Drive listing.
-	doc = frappe.get_doc("Sheet", name)
-	doc.trashed = 0
-	doc.trashed_on = None
-	doc.trashed_by = None
-	doc.save()
-	return "ok"
+    # Same owner-only gate as trashing — restore is the inverse of delete.
+    frappe.has_permission("Sheet", doc=name, ptype="delete", throw=True)
+    # Inverse of trashing: clear the flag through the ORM so on_update returns the
+    # backing File to the Drive listing.
+    doc = frappe.get_doc("Sheet", name)
+    doc.trashed = 0
+    doc.trashed_on = None
+    doc.trashed_by = None
+    doc.save()
+    return "ok"
 
 
 @frappe.whitelist()
 def delete_sheet_permanent(name: str) -> str:
-	# Irreversible "delete forever" from the trash. Owner-only, same as trashing.
-	# The cascade lives in suite.sheets.trash so it stays in lockstep with the purge.
-	frappe.has_permission("Sheet", doc=name, ptype="delete", throw=True)
-	# Only ever fire from the trash flow: a direct call on a live sheet must not
-	# skip the recovery window and destroy it in one shot.
-	if not frappe.db.get_value("Sheet", name, "trashed"):
-		frappe.throw("Only sheets in the trash can be permanently deleted.")
-	from suite.sheets.trash import hard_delete_sheet
+    # Irreversible "delete forever" from the trash. Owner-only, same as trashing.
+    # The cascade lives in suite.sheets.trash so it stays in lockstep with the purge.
+    frappe.has_permission("Sheet", doc=name, ptype="delete", throw=True)
+    # Only ever fire from the trash flow: a direct call on a live sheet must not
+    # skip the recovery window and destroy it in one shot.
+    if not frappe.db.get_value("Sheet", name, "trashed"):
+        frappe.throw("Only sheets in the trash can be permanently deleted.")
+    from suite.sheets.trash import hard_delete_sheet
 
-	hard_delete_sheet(name)
-	return "ok"
+    hard_delete_sheet(name)
+    return "ok"
 
 
 @frappe.whitelist()
 def list_trash() -> dict:
-	# Trash is owner-scoped: only the owner can trash/restore, so a shared
-	# collaborator has no business seeing another user's trash. Filter to the
-	# caller's own trashed sheets explicitly rather than leaning on the share
-	# grant that list_sheets uses. `retention_days` rides along so the UI can
-	# state the exact purge window instead of assuming the default.
-	from suite.sheets.trash import retention_days
+    # Trash is owner-scoped: only the owner can trash/restore, so a shared
+    # collaborator has no business seeing another user's trash. Filter to the
+    # caller's own trashed sheets explicitly rather than leaning on the share
+    # grant that list_sheets uses. `retention_days` rides along so the UI can
+    # state the exact purge window instead of assuming the default.
+    from suite.sheets.trash import retention_days
 
-	sheets = frappe.get_list(
-		"Sheet",
-		filters={"trashed": 1, "owner": frappe.session.user},
-		fields=["name", "title", "trashed_on"],
-		order_by="trashed_on desc",
-		limit=100,
-	)
-	return {"sheets": sheets, "retention_days": retention_days()}
+    sheets = frappe.get_list(
+        "Sheet",
+        filters={"trashed": 1, "owner": frappe.session.user},
+        fields=["name", "title", "trashed_on"],
+        order_by="trashed_on desc",
+        limit=100,
+    )
+    return {"sheets": sheets, "retention_days": retention_days()}
 
 
 @frappe.whitelist()
 def rename_sheet(name: str, title: str) -> str:
-	# Explicit gate up-front so the failure mode is the same as the rest of
-	# this module — `doc.save()` would ultimately enforce write perm too,
-	# but defence-in-depth keeps the surface uniform if the controller ever
-	# changes.
-	frappe.has_permission("Sheet", doc=name, ptype="write", throw=True)
-	title = _clean_title(title)
-	if not title:
-		frappe.throw("Title is required")
-	doc = frappe.get_doc("Sheet", name)
-	doc.title = title
-	doc.save()
-	return doc.name
+    # Explicit gate up-front so the failure mode is the same as the rest of
+    # this module — `doc.save()` would ultimately enforce write perm too,
+    # but defence-in-depth keeps the surface uniform if the controller ever
+    # changes.
+    frappe.has_permission("Sheet", doc=name, ptype="write", throw=True)
+    title = _clean_title(title)
+    if not title:
+        frappe.throw("Title is required")
+    doc = frappe.get_doc("Sheet", name)
+    doc.title = title
+    doc.save()
+    return doc.name
 
 
 @frappe.whitelist()
 def duplicate_sheet(name: str) -> str:
-	# Route through the versioning save flow so the copy gets its own op-log
-	# seq, head pointer, and async snapshot — keeps the architecture's single
-	# write path intact and doesn't leak shared state with the source. The
-	# new save flow returns {"name": ..., "head_seq": ...}; the caller (the
-	# Home page) only needs the new sheet name, so we unwrap here.
-	# Read permission on the SOURCE is required — without this, anyone who
-	# knows a sheet id could clone its contents into a sheet they own.
-	frappe.has_permission("Sheet", doc=name, throw=True)
-	src = frappe.get_doc("Sheet", name)
-	plain = decode_sheets_data(src.sheets_data)
-	result = save_mod.save_sheet(f"{src.title} (copy)", plain, name=None)
-	return result["name"] if isinstance(result, dict) else result
+    # Route through the versioning save flow so the copy gets its own op-log
+    # seq, head pointer, and async snapshot — keeps the architecture's single
+    # write path intact and doesn't leak shared state with the source. The
+    # new save flow returns {"name": ..., "head_seq": ...}; the caller (the
+    # Home page) only needs the new sheet name, so we unwrap here.
+    # Read permission on the SOURCE is required — without this, anyone who
+    # knows a sheet id could clone its contents into a sheet they own.
+    frappe.has_permission("Sheet", doc=name, throw=True)
+    src = frappe.get_doc("Sheet", name)
+    plain = decode_sheets_data(src.sheets_data)
+    result = save_mod.save_sheet(f"{src.title} (copy)", plain, name=None)
+    return result["name"] if isinstance(result, dict) else result
 
 
 # ── AI Assist ───────────────────────────────────────────────────────────────
@@ -555,44 +555,44 @@ DEFAULT_AI_MODEL = "claude-opus-4-8"
 
 
 def _ai_key(doc) -> str:
-	"""Return the decrypted API key, or '' if none is stored.
+    """Return the decrypted API key, or '' if none is stored.
 
-	`get_password` raises when the field is empty unless `raise_exception` is
-	off — coerce the absent case to '' so callers can treat it as a plain bool.
-	"""
-	return doc.get_password("api_key", raise_exception=False) or ""
+    `get_password` raises when the field is empty unless `raise_exception` is
+    off — coerce the absent case to '' so callers can treat it as a plain bool.
+    """
+    return doc.get_password("api_key", raise_exception=False) or ""
 
 
 @frappe.whitelist()
 def get_ai_settings() -> dict:
-	# Read is ungated: the response only reveals whether AI is available
-	# (enabled + a key is configured), never the key itself, so any logged-in
-	# user can decide whether to show the "Ask" entry point.
-	doc = frappe.get_cached_doc(AI_SETTINGS)
-	return {
-		"enabled": bool(doc.enabled),
-		"model": doc.model or DEFAULT_AI_MODEL,
-		"keyIsSet": bool(_ai_key(doc)),
-	}
+    # Read is ungated: the response only reveals whether AI is available
+    # (enabled + a key is configured), never the key itself, so any logged-in
+    # user can decide whether to show the "Ask" entry point.
+    doc = frappe.get_cached_doc(AI_SETTINGS)
+    return {
+        "enabled": bool(doc.enabled),
+        "model": doc.model or DEFAULT_AI_MODEL,
+        "keyIsSet": bool(_ai_key(doc)),
+    }
 
 
 @frappe.whitelist()
 def save_ai_settings(api_key: str = "", enabled: int = 0, model: str = "") -> dict:
-	# Write is gated to System Manager — this is org-level config, not per-sheet.
-	if "System Manager" not in frappe.get_roles():
-		frappe.throw("Not permitted to change AI settings", frappe.PermissionError)
-	doc = frappe.get_doc(AI_SETTINGS)
-	doc.enabled = 1 if int(enabled or 0) else 0
-	if model:
-		doc.model = model
-	# An empty api_key means "leave the existing key untouched" — the panel
-	# never receives the real key back, so it submits "" unless the admin
-	# deliberately types a new one.
-	if api_key:
-		doc.api_key = api_key
-	doc.save(ignore_permissions=True)
-	frappe.clear_document_cache(AI_SETTINGS, AI_SETTINGS)
-	return get_ai_settings()
+    # Write is gated to System Manager — this is org-level config, not per-sheet.
+    if "System Manager" not in frappe.get_roles():
+        frappe.throw("Not permitted to change AI settings", frappe.PermissionError)
+    doc = frappe.get_doc(AI_SETTINGS)
+    doc.enabled = 1 if int(enabled or 0) else 0
+    if model:
+        doc.model = model
+    # An empty api_key means "leave the existing key untouched" — the panel
+    # never receives the real key back, so it submits "" unless the admin
+    # deliberately types a new one.
+    if api_key:
+        doc.api_key = api_key
+    doc.save(ignore_permissions=True)
+    frappe.clear_document_cache(AI_SETTINGS, AI_SETTINGS)
+    return get_ai_settings()
 
 
 MAX_PROMPT_LEN = 2000
@@ -600,69 +600,69 @@ MAX_PROMPT_LEN = 2000
 
 @frappe.whitelist()
 def ai_assist(name: str, prompt: str, selection: str) -> dict:
-	"""Turn a plain-language request into a validated spreadsheet action plan.
+    """Turn a plain-language request into a validated spreadsheet action plan.
 
-	`selection` is a JSON string describing the active selection
-	({sheet, r0, c0, r1, c1, active}). The sheet is decoded server-side, a
-	compact context is assembled, and the model is asked for actions — which
-	are validated here before returning. We do NOT mutate the sheet: the
-	frontend applies the actions through the engine so they join the existing
-	undo / op-log / autosave pipeline.
-	"""
-	# AI mutates the grid → require write permission, matching save/record_op.
-	frappe.has_permission("Sheet", doc=name, ptype="write", throw=True)
+    `selection` is a JSON string describing the active selection
+    ({sheet, r0, c0, r1, c1, active}). The sheet is decoded server-side, a
+    compact context is assembled, and the model is asked for actions — which
+    are validated here before returning. We do NOT mutate the sheet: the
+    frontend applies the actions through the engine so they join the existing
+    undo / op-log / autosave pipeline.
+    """
+    # AI mutates the grid → require write permission, matching save/record_op.
+    frappe.has_permission("Sheet", doc=name, ptype="write", throw=True)
 
-	prompt = (prompt or "").strip()
-	if not prompt:
-		frappe.throw("Type what you'd like to do first.")
-	if len(prompt) > MAX_PROMPT_LEN:
-		frappe.throw("That request is too long.")
+    prompt = (prompt or "").strip()
+    if not prompt:
+        frappe.throw("Type what you'd like to do first.")
+    if len(prompt) > MAX_PROMPT_LEN:
+        frappe.throw("That request is too long.")
 
-	cfg = frappe.get_cached_doc(AI_SETTINGS)
-	if not cfg.enabled:
-		frappe.throw("AI Assist isn't enabled for this site.")
-	model = cfg.model or DEFAULT_AI_MODEL
+    cfg = frappe.get_cached_doc(AI_SETTINGS)
+    if not cfg.enabled:
+        frappe.throw("AI Assist isn't enabled for this site.")
+    model = cfg.model or DEFAULT_AI_MODEL
 
-	sel = frappe.parse_json(selection) if selection else {}
-	if not isinstance(sel, dict):
-		sel = {}
-	sheet_name = sel.get("sheet") or "Sheet1"
+    sel = frappe.parse_json(selection) if selection else {}
+    if not isinstance(sel, dict):
+        sel = {}
+    sheet_name = sel.get("sheet") or "Sheet1"
 
-	data = json.loads(decode_sheets_data(frappe.get_doc("Sheet", name).sheets_data) or "{}")
-	cell_map = unpack_cell_map((data or {}).get("sheet") or {}, sheet_name)
+    data = json.loads(decode_sheets_data(frappe.get_doc("Sheet", name).sheets_data) or "{}")
+    cell_map = unpack_cell_map((data or {}).get("sheet") or {}, sheet_name)
 
-	from suite.sheets.ai import context as ai_context
-	from suite.sheets.ai import heuristics as ai_heuristics
-	from suite.sheets.ai import validate as ai_validate
+    from suite.sheets.ai import context as ai_context
+    from suite.sheets.ai import heuristics as ai_heuristics
+    from suite.sheets.ai import validate as ai_validate
 
-	ctx = ai_context.build_context(cell_map, sheet_name, sel)
+    ctx = ai_context.build_context(cell_map, sheet_name, sel)
 
-	# Heuristic-first cascade: common, unambiguous asks resolve locally —
-	# instant, free, deterministic — and only fall through to the model when
-	# they can't. `mock`/`demo` is the keyless mode: heuristic only, no call.
-	raw = ai_heuristics.resolve(prompt, ctx, sel)
-	source = "heuristic"
-	if raw is None:
-		if model.strip().lower() in ("mock", "demo"):
-			raw = [{"type": "answer", "text": _DEMO_HINT}]
-			source = "demo"
-		else:
-			key = _ai_key(cfg)
-			if not key:
-				frappe.throw("No Anthropic API key is configured.")
-			from suite.sheets.ai import client as ai_client
+    # Heuristic-first cascade: common, unambiguous asks resolve locally —
+    # instant, free, deterministic — and only fall through to the model when
+    # they can't. `mock`/`demo` is the keyless mode: heuristic only, no call.
+    raw = ai_heuristics.resolve(prompt, ctx, sel)
+    source = "heuristic"
+    if raw is None:
+        if model.strip().lower() in ("mock", "demo"):
+            raw = [{"type": "answer", "text": _DEMO_HINT}]
+            source = "demo"
+        else:
+            key = _ai_key(cfg)
+            if not key:
+                frappe.throw("No Anthropic API key is configured.")
+            from suite.sheets.ai import client as ai_client
 
-			raw = ai_client.generate_actions(prompt, ctx, key, model)
-			source = "model"
+            raw = ai_client.generate_actions(prompt, ctx, key, model)
+            source = "model"
 
-	return {"actions": ai_validate.clean_actions(raw), "model": model, "source": source}
+    return {"actions": ai_validate.clean_actions(raw), "model": model, "source": source}
 
 
 _DEMO_HINT = (
-	"Local demo (no API key). I can do: sum / average / count / min / max / median over a "
-	"selection, running totals and percent-of-total down a column, and text transforms "
-	"(uppercase, lowercase, proper case, trim, length, email domain, first/last name). "
-	"For anything beyond that, add an Anthropic API key in AI settings."
+    "Local demo (no API key). I can do: sum / average / count / min / max / median over a "
+    "selection, running totals and percent-of-total down a column, and text transforms "
+    "(uppercase, lowercase, proper case, trim, length, email domain, first/last name). "
+    "For anything beyond that, add an Anthropic API key in AI settings."
 )
 
 
@@ -670,16 +670,16 @@ _DEMO_HINT = (
 
 
 def _user_identity(user: str) -> dict:
-	"""Return full_name, initials, and user_image for the given user."""
-	full_name = frappe.db.get_value("User", user, "full_name") or user
-	user_image = frappe.db.get_value("User", user, "user_image") or ""
-	parts = full_name.split()
-	initials = (parts[0][0] + (parts[-1][0] if len(parts) > 1 else "")).upper()
-	return {"full_name": full_name, "initials": initials, "user_image": user_image}
+    """Return full_name, initials, and user_image for the given user."""
+    full_name = frappe.db.get_value("User", user, "full_name") or user
+    user_image = frappe.db.get_value("User", user, "user_image") or ""
+    parts = full_name.split()
+    initials = (parts[0][0] + (parts[-1][0] if len(parts) > 1 else "")).upper()
+    return {"full_name": full_name, "initials": initials, "user_image": user_image}
 
 
 def _clean_title(title: str) -> str:
-	title = (title or "").strip() or "Untitled Spreadsheet"
-	if len(title) > MAX_TITLE_LEN:
-		title = title[:MAX_TITLE_LEN]
-	return title
+    title = (title or "").strip() or "Untitled Spreadsheet"
+    if len(title) > MAX_TITLE_LEN:
+        title = title[:MAX_TITLE_LEN]
+    return title

--- a/suite/sheets/boot.py
+++ b/suite/sheets/boot.py
@@ -15,7 +15,7 @@ import frappe
 
 
 def extend_bootinfo(bootinfo) -> None:
-	# Default to legacy behaviour — opt-in to the Hocuspocus path per-site.
-	bootinfo.collab_v2 = bool(frappe.conf.get("collab_v2") or False)
-	# `None` lets the frontend fall back to the same-origin `/collab/` URL.
-	bootinfo.collab_ws_url = frappe.conf.get("collab_ws_url") or None
+    # Default to legacy behaviour — opt-in to the Hocuspocus path per-site.
+    bootinfo.collab_v2 = bool(frappe.conf.get("collab_v2") or False)
+    # `None` lets the frontend fall back to the same-origin `/collab/` URL.
+    bootinfo.collab_ws_url = frappe.conf.get("collab_ws_url") or None

--- a/suite/sheets/collab.py
+++ b/suite/sheets/collab.py
@@ -38,37 +38,37 @@ _COLLAB_SECRET_HEADER = "X-Collab-Secret"
 
 @frappe.whitelist()
 def check_collab_access(name: str) -> dict:
-	"""Return the caller's read/write capability + identity for a given sheet.
+    """Return the caller's read/write capability + identity for a given sheet.
 
-	Cookie-authenticated. Hocuspocus' ``onAuthenticate`` calls this with the
-	user's session forwarded; the response decides whether the websocket is
-	accepted and whether it's allowed to push updates.
+    Cookie-authenticated. Hocuspocus' ``onAuthenticate`` calls this with the
+    user's session forwarded; the response decides whether the websocket is
+    accepted and whether it's allowed to push updates.
 
-	Read access without write means "viewer" — the connection still receives
-	updates and emits awareness (cursor, presence), but writes are dropped
-	at the server before fan-out.
-	"""
-	if frappe.session.user == "Guest":
-		frappe.throw("Login required", frappe.AuthenticationError)
+    Read access without write means "viewer" — the connection still receives
+    updates and emits awareness (cursor, presence), but writes are dropped
+    at the server before fan-out.
+    """
+    if frappe.session.user == "Guest":
+        frappe.throw("Login required", frappe.AuthenticationError)
 
-	can_read = bool(frappe.has_permission("Sheet", doc=name, ptype="read", throw=False))
-	if not can_read:
-		# Don't 403 here — the collab server treats {canRead: False} as a
-		# clean refusal and closes the socket. Returning structured data
-		# is easier to surface to the client than parsing exception text.
-		return {"canRead": False, "canWrite": False}
+    can_read = bool(frappe.has_permission("Sheet", doc=name, ptype="read", throw=False))
+    if not can_read:
+        # Don't 403 here — the collab server treats {canRead: False} as a
+        # clean refusal and closes the socket. Returning structured data
+        # is easier to surface to the client than parsing exception text.
+        return {"canRead": False, "canWrite": False}
 
-	can_write = bool(frappe.has_permission("Sheet", doc=name, ptype="write", throw=False))
-	user = frappe.session.user
-	identity = _user_identity(user)
-	return {
-		"canRead": True,
-		"canWrite": can_write,
-		"user": user,
-		"fullName": identity["full_name"],
-		"initials": identity["initials"],
-		"userImage": identity["user_image"],
-	}
+    can_write = bool(frappe.has_permission("Sheet", doc=name, ptype="write", throw=False))
+    user = frappe.session.user
+    identity = _user_identity(user)
+    return {
+        "canRead": True,
+        "canWrite": can_write,
+        "user": user,
+        "fullName": identity["full_name"],
+        "initials": identity["initials"],
+        "userImage": identity["user_image"],
+    }
 
 
 # ── Server-to-server: persistence endpoints ───────────────────────────────────
@@ -76,105 +76,107 @@ def check_collab_access(name: str) -> dict:
 
 @frappe.whitelist(allow_guest=True)
 def load_collab_state(name: str) -> dict:
-	"""Return the persisted Y.Doc binary for ``name``, or ``None``.
+    """Return the persisted Y.Doc binary for ``name``, or ``None``.
 
-	``allow_guest=True`` because this is invoked from the Hocuspocus process
-	without a user session — auth is via the shared ``collab_server_secret``
-	checked below. The endpoint never accepts cookie-only callers.
-	"""
-	_require_collab_secret()
+    ``allow_guest=True`` because this is invoked from the Hocuspocus process
+    without a user session — auth is via the shared ``collab_server_secret``
+    checked below. The endpoint never accepts cookie-only callers.
+    """
+    _require_collab_secret()
 
-	if not frappe.db.exists("Sheet Collab State", name):
-		return {"sheet": name, "ydoc_state": None, "byte_size": 0}
+    if not frappe.db.exists("Sheet Collab State", name):
+        return {"sheet": name, "ydoc_state": None, "byte_size": 0}
 
-	# Direct DB read — the doctype has System-Manager-only perms, but the
-	# secret check above is the gate that matters here.
-	row = frappe.db.get_value(
-		"Sheet Collab State",
-		name,
-		("ydoc_state", "byte_size"),
-		as_dict=True,
-	) or {}
-	return {
-		"sheet": name,
-		"ydoc_state": row.get("ydoc_state"),
-		"byte_size": int(row.get("byte_size") or 0),
-	}
+    # Direct DB read — the doctype has System-Manager-only perms, but the
+    # secret check above is the gate that matters here.
+    row = (
+        frappe.db.get_value(
+            "Sheet Collab State",
+            name,
+            ("ydoc_state", "byte_size"),
+            as_dict=True,
+        )
+        or {}
+    )
+    return {
+        "sheet": name,
+        "ydoc_state": row.get("ydoc_state"),
+        "byte_size": int(row.get("byte_size") or 0),
+    }
 
 
 @frappe.whitelist(allow_guest=True)
 def persist_collab_state(name: str, ydoc_state: str, byte_size: int = 0) -> dict:
-	"""Upsert the Y.Doc binary for ``name``.
+    """Upsert the Y.Doc binary for ``name``.
 
-	The collab server debounces this — expect roughly one call every few
-	seconds of active editing per sheet, plus one on last-client-disconnect.
+    The collab server debounces this — expect roughly one call every few
+    seconds of active editing per sheet, plus one on last-client-disconnect.
 
-	The ``Sheet`` must exist (it always does — sheets are created via the
-	save path before any collab session opens against them). We don't
-	create the parent here.
-	"""
-	_require_collab_secret()
+    The ``Sheet`` must exist (it always does — sheets are created via the
+    save path before any collab session opens against them). We don't
+    create the parent here.
+    """
+    _require_collab_secret()
 
-	if not frappe.db.exists("Sheet", name):
-		frappe.throw(f"Sheet {name!r} does not exist", frappe.DoesNotExistError)
+    if not frappe.db.exists("Sheet", name):
+        frappe.throw(f"Sheet {name!r} does not exist", frappe.DoesNotExistError)
 
-	byte_size = int(byte_size or 0)
-	now = frappe.utils.now()
+    byte_size = int(byte_size or 0)
+    now = frappe.utils.now()
 
-	if frappe.db.exists("Sheet Collab State", name):
-		# Direct UPDATE — avoids loading the doc + permission noise on a
-		# hot persistence path. The doctype has only data fields, no
-		# Document hooks that need to run.
-		frappe.db.set_value(
-			"Sheet Collab State",
-			name,
-			{
-				"ydoc_state": ydoc_state,
-				"byte_size": byte_size,
-				"last_persisted_at": now,
-			},
-			update_modified=True,
-		)
-	else:
-		doc = frappe.new_doc("Sheet Collab State")
-		doc.sheet = name
-		doc.ydoc_state = ydoc_state
-		doc.byte_size = byte_size
-		doc.last_persisted_at = now
-		doc.insert(ignore_permissions=True)
+    if frappe.db.exists("Sheet Collab State", name):
+        # Direct UPDATE — avoids loading the doc + permission noise on a
+        # hot persistence path. The doctype has only data fields, no
+        # Document hooks that need to run.
+        frappe.db.set_value(
+            "Sheet Collab State",
+            name,
+            {
+                "ydoc_state": ydoc_state,
+                "byte_size": byte_size,
+                "last_persisted_at": now,
+            },
+            update_modified=True,
+        )
+    else:
+        doc = frappe.new_doc("Sheet Collab State")
+        doc.sheet = name
+        doc.ydoc_state = ydoc_state
+        doc.byte_size = byte_size
+        doc.last_persisted_at = now
+        doc.insert(ignore_permissions=True)
 
-	return {"sheet": name, "byte_size": byte_size, "persisted_at": now}
+    return {"sheet": name, "byte_size": byte_size, "persisted_at": now}
 
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 
 def _require_collab_secret() -> None:
-	"""Reject the call unless the request carries the configured shared secret.
+    """Reject the call unless the request carries the configured shared secret.
 
-	Misconfiguration (no secret in ``site_config.json``) is a deploy bug, not
-	a runtime accident — raise loudly so it surfaces in the collab server
-	logs on first boot rather than silently allowing unauthenticated writes.
-	"""
-	expected = (frappe.conf.get("collab_server_secret") or "").strip()
-	if not expected:
-		frappe.throw(
-			"Collab server secret is not configured "
-			"(set `collab_server_secret` in site_config.json)",
-			frappe.AuthenticationError,
-		)
-	sent = (frappe.get_request_header(_COLLAB_SECRET_HEADER) or "").strip()
-	# Constant-time compare — secrets are short enough that timing attacks
-	# are vanishingly improbable, but hmac.compare_digest is the right
-	# habit anyway.
-	if not sent or not hmac.compare_digest(expected, sent):
-		frappe.throw("Invalid collab server credentials", frappe.AuthenticationError)
+    Misconfiguration (no secret in ``site_config.json``) is a deploy bug, not
+    a runtime accident — raise loudly so it surfaces in the collab server
+    logs on first boot rather than silently allowing unauthenticated writes.
+    """
+    expected = (frappe.conf.get("collab_server_secret") or "").strip()
+    if not expected:
+        frappe.throw(
+            "Collab server secret is not configured (set `collab_server_secret` in site_config.json)",
+            frappe.AuthenticationError,
+        )
+    sent = (frappe.get_request_header(_COLLAB_SECRET_HEADER) or "").strip()
+    # Constant-time compare — secrets are short enough that timing attacks
+    # are vanishingly improbable, but hmac.compare_digest is the right
+    # habit anyway.
+    if not sent or not hmac.compare_digest(expected, sent):
+        frappe.throw("Invalid collab server credentials", frappe.AuthenticationError)
 
 
 def _user_identity(user: str) -> dict:
-	"""Return full_name, initials, and user_image — mirrors api._user_identity."""
-	full_name = frappe.db.get_value("User", user, "full_name") or user
-	user_image = frappe.db.get_value("User", user, "user_image") or ""
-	parts = full_name.split()
-	initials = (parts[0][0] + (parts[-1][0] if len(parts) > 1 else "")).upper()
-	return {"full_name": full_name, "initials": initials, "user_image": user_image}
+    """Return full_name, initials, and user_image — mirrors api._user_identity."""
+    full_name = frappe.db.get_value("User", user, "full_name") or user
+    user_image = frappe.db.get_value("User", user, "user_image") or ""
+    parts = full_name.split()
+    initials = (parts[0][0] + (parts[-1][0] if len(parts) > 1 else "")).upper()
+    return {"full_name": full_name, "initials": initials, "user_image": user_image}

--- a/suite/sheets/doctype/sheet/cell_codec.py
+++ b/suite/sheets/doctype/sheet/cell_codec.py
@@ -11,43 +11,43 @@ PACK_VERSION = 2
 
 
 def cell_map(sheet_slice: dict | None, sheet_name: str) -> dict:
-	"""Return ``{cellId: value}`` for one sheet from a saved ``sheet`` slice.
+    """Return ``{cellId: value}`` for one sheet from a saved ``sheet`` slice.
 
-	Accepts both the compact v2 envelope and the legacy
-	``{sheets: {name: {cellId: val}}}`` shape; unknown input yields ``{}``.
-	"""
-	if not isinstance(sheet_slice, dict):
-		return {}
-	sheet = (sheet_slice.get("sheets") or {}).get(sheet_name)
-	if not isinstance(sheet, dict):
-		return {}
-	if sheet_slice.get("v") != PACK_VERSION:
-		return sheet  # legacy: already a {cellId: value} map
-	return _unpack_rows(sheet.get("rows") or {})
+    Accepts both the compact v2 envelope and the legacy
+    ``{sheets: {name: {cellId: val}}}`` shape; unknown input yields ``{}``.
+    """
+    if not isinstance(sheet_slice, dict):
+        return {}
+    sheet = (sheet_slice.get("sheets") or {}).get(sheet_name)
+    if not isinstance(sheet, dict):
+        return {}
+    if sheet_slice.get("v") != PACK_VERSION:
+        return sheet  # legacy: already a {cellId: value} map
+    return _unpack_rows(sheet.get("rows") or {})
 
 
 def _unpack_rows(rows: dict) -> dict:
-	out = {}
-	for r, arr in rows.items():
-		if not arr:
-			continue
-		try:
-			row = int(r)
-		except (TypeError, ValueError):
-			continue
-		if not isinstance(arr, list):
-			continue
-		for col, value in enumerate(arr):
-			if value is None or value == "":
-				continue
-			out[f"{_col_label(col)}{row + 1}"] = value
-	return out
+    out = {}
+    for r, arr in rows.items():
+        if not arr:
+            continue
+        try:
+            row = int(r)
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(arr, list):
+            continue
+        for col, value in enumerate(arr):
+            if value is None or value == "":
+                continue
+            out[f"{_col_label(col)}{row + 1}"] = value
+    return out
 
 
 def _col_label(idx: int) -> str:
-	s = ""
-	idx += 1
-	while idx > 0:
-		idx, rem = divmod(idx - 1, 26)
-		s = chr(65 + rem) + s
-	return s
+    s = ""
+    idx += 1
+    while idx > 0:
+        idx, rem = divmod(idx - 1, 26)
+        s = chr(65 + rem) + s
+    return s

--- a/suite/sheets/doctype/sheet/sheet.py
+++ b/suite/sheets/doctype/sheet/sheet.py
@@ -5,9 +5,9 @@ from frappe.model.document import Document
 
 from suite.drive.overrides.file import File as DriveFile
 from suite.sheets.doctype.sheet.storage import (
-	MAX_SHEETS_DATA_BYTES,
-	decode_sheets_data,
-	effective_size,
+    MAX_SHEETS_DATA_BYTES,
+    decode_sheets_data,
+    effective_size,
 )
 
 # Defence in depth — anything that bypasses the whitelisted API (Desk form,
@@ -18,51 +18,51 @@ MAX_TITLE_LEN = 280
 
 
 class Sheet(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		sheets_data: DF.JSON | None
-		title: DF.Data
-	# end: auto-generated types
+        sheets_data: DF.JSON | None
+        title: DF.Data
+    # end: auto-generated types
 
-	def validate(self):
-		title = (self.title or "").strip()
-		if not title:
-			frappe.throw("Title is required")
-		self.title = title[:MAX_TITLE_LEN]
+    def validate(self):
+        title = (self.title or "").strip()
+        if not title:
+            frappe.throw("Title is required")
+        self.title = title[:MAX_TITLE_LEN]
 
-		if self.sheets_data:
-			if not isinstance(self.sheets_data, str):
-				frappe.throw("sheets_data must be a string")
-			size = effective_size(self.sheets_data)
-			if size > MAX_SHEETS_DATA_BYTES:
-				limit_mb = MAX_SHEETS_DATA_BYTES // (1024 * 1024)
-				size_mb = size / (1024 * 1024)
-				frappe.throw(
-					f"This spreadsheet is {size_mb:.1f} MB, over the {limit_mb} MB limit. "
-					f"Remove some data or split it across multiple spreadsheets."
-				)
-			try:
-				json.loads(decode_sheets_data(self.sheets_data))
-			except (ValueError, TypeError):
-				frappe.throw("sheets_data is not valid JSON")
+        if self.sheets_data:
+            if not isinstance(self.sheets_data, str):
+                frappe.throw("sheets_data must be a string")
+            size = effective_size(self.sheets_data)
+            if size > MAX_SHEETS_DATA_BYTES:
+                limit_mb = MAX_SHEETS_DATA_BYTES // (1024 * 1024)
+                size_mb = size / (1024 * 1024)
+                frappe.throw(
+                    f"This spreadsheet is {size_mb:.1f} MB, over the {limit_mb} MB limit. "
+                    f"Remove some data or split it across multiple spreadsheets."
+                )
+            try:
+                json.loads(decode_sheets_data(self.sheets_data))
+            except (ValueError, TypeError):
+                frappe.throw("sheets_data is not valid JSON")
 
-	def after_insert(self):
-		# Back every sheet with a Drive File so it shows up in — and opens
-		# from — Drive, exactly like Writer/Slides docs. The Drive File is a
-		# thin pointer (content_doctype/content_docname); the workbook itself
-		# stays in this doctype.
-		self.create_drive_file()
+    def after_insert(self):
+        # Back every sheet with a Drive File so it shows up in — and opens
+        # from — Drive, exactly like Writer/Slides docs. The Drive File is a
+        # thin pointer (content_doctype/content_docname); the workbook itself
+        # stays in this doctype.
+        self.create_drive_file()
 
-	def create_drive_file(self, parent: str | None = None):
-		return DriveFile.create_for_doc(
-			self,
-			parent=parent or self.flags.get("drive_parent"),
-			mime_type="frappe/sheet",
-			file_type="Spreadsheet",
-		)
+    def create_drive_file(self, parent: str | None = None):
+        return DriveFile.create_for_doc(
+            self,
+            parent=parent or self.flags.get("drive_parent"),
+            mime_type="frappe/sheet",
+            file_type="Spreadsheet",
+        )

--- a/suite/sheets/doctype/sheet/storage.py
+++ b/suite/sheets/doctype/sheet/storage.py
@@ -43,97 +43,93 @@ _DATA_KEY = "data"
 
 
 def encode_sheets_data(json_str: str) -> str:
-	"""Wrap a plain sheets_data JSON string into the on-disk envelope."""
-	raw = (json_str or "{}").encode("utf-8")
-	compressed = gzip.compress(raw, compresslevel=6)
-	payload = base64.b64encode(compressed).decode("ascii")
-	return json.dumps({_GZ_MARKER: _GZ_KIND, _DATA_KEY: payload})
+    """Wrap a plain sheets_data JSON string into the on-disk envelope."""
+    raw = (json_str or "{}").encode("utf-8")
+    compressed = gzip.compress(raw, compresslevel=6)
+    payload = base64.b64encode(compressed).decode("ascii")
+    return json.dumps({_GZ_MARKER: _GZ_KIND, _DATA_KEY: payload})
 
 
 def decode_sheets_data(stored: str | None) -> str:
-	"""Unwrap a stored envelope back into a plain JSON string.
+    """Unwrap a stored envelope back into a plain JSON string.
 
-	Pre-compression values pass through unchanged. Decompression is bounded
-	by ``MAX_SHEETS_DATA_BYTES`` to defuse gzip-bomb payloads — a tiny
-	envelope that expands to gigabytes raises rather than allocating
-	the full output buffer.
-	"""
-	if not stored:
-		return "{}"
-	envelope = _try_parse_envelope(stored)
-	if envelope is None:
-		return stored
-	return _bounded_decompress(envelope[_DATA_KEY]).decode("utf-8")
+    Pre-compression values pass through unchanged. Decompression is bounded
+    by ``MAX_SHEETS_DATA_BYTES`` to defuse gzip-bomb payloads — a tiny
+    envelope that expands to gigabytes raises rather than allocating
+    the full output buffer.
+    """
+    if not stored:
+        return "{}"
+    envelope = _try_parse_envelope(stored)
+    if envelope is None:
+        return stored
+    return _bounded_decompress(envelope[_DATA_KEY]).decode("utf-8")
 
 
 def effective_size(stored: str | None) -> int:
-	"""Return the uncompressed byte size of a stored value (envelope-aware).
+    """Return the uncompressed byte size of a stored value (envelope-aware).
 
-	Bounded by the same cap as :func:`decode_sheets_data` so callers can't be
-	OOM'd by probing an oversized envelope.
-	"""
-	if not stored:
-		return 0
-	envelope = _try_parse_envelope(stored)
-	if envelope is None:
-		return len(stored.encode("utf-8"))
-	return len(_bounded_decompress(envelope[_DATA_KEY]))
+    Bounded by the same cap as :func:`decode_sheets_data` so callers can't be
+    OOM'd by probing an oversized envelope.
+    """
+    if not stored:
+        return 0
+    envelope = _try_parse_envelope(stored)
+    if envelope is None:
+        return len(stored.encode("utf-8"))
+    return len(_bounded_decompress(envelope[_DATA_KEY]))
 
 
 def _bounded_decompress(b64_payload: str) -> bytes:
-	"""Decode + decompress a base64 gzip payload with a hard size ceiling.
+    """Decode + decompress a base64 gzip payload with a hard size ceiling.
 
-	Raises a Frappe-flavoured error if the compressed input or the
-	decompressed output exceeds ``MAX_SHEETS_DATA_BYTES``. Imported lazily
-	to avoid pulling `frappe` into pure-storage callers (tests, patches).
-	"""
-	# Reject oversized base64 input up front — len(b64) ≈ 4/3 × len(decoded),
-	# so a string longer than 4/3 × _MAX_COMPRESSED_BYTES can't fit.
-	if not isinstance(b64_payload, str) or len(b64_payload) > _MAX_COMPRESSED_BYTES * 2:
-		_throw_bomb()
-	try:
-		compressed = base64.b64decode(b64_payload, validate=True)
-	except (binascii.Error, ValueError):
-		_throw_bomb(reason="invalid base64 in sheets_data envelope")
-	if len(compressed) > _MAX_COMPRESSED_BYTES:
-		_throw_bomb()
-	# Stream-decompress at most ``MAX_SHEETS_DATA_BYTES``, then peek one more
-	# byte — if there's anything past the cap we reject without ever
-	# materialising the full bomb in memory.
-	try:
-		with gzip.GzipFile(fileobj=io.BytesIO(compressed), mode="rb") as gz:
-			out = gz.read(MAX_SHEETS_DATA_BYTES)
-			if gz.read(1):
-				_throw_bomb()
-	except (OSError, EOFError):
-		_throw_bomb(reason="malformed gzip envelope in sheets_data")
-	return out
+    Raises a Frappe-flavoured error if the compressed input or the
+    decompressed output exceeds ``MAX_SHEETS_DATA_BYTES``. Imported lazily
+    to avoid pulling `frappe` into pure-storage callers (tests, patches).
+    """
+    # Reject oversized base64 input up front — len(b64) ≈ 4/3 × len(decoded),
+    # so a string longer than 4/3 × _MAX_COMPRESSED_BYTES can't fit.
+    if not isinstance(b64_payload, str) or len(b64_payload) > _MAX_COMPRESSED_BYTES * 2:
+        _throw_bomb()
+    try:
+        compressed = base64.b64decode(b64_payload, validate=True)
+    except (binascii.Error, ValueError):
+        _throw_bomb(reason="invalid base64 in sheets_data envelope")
+    if len(compressed) > _MAX_COMPRESSED_BYTES:
+        _throw_bomb()
+    # Stream-decompress at most ``MAX_SHEETS_DATA_BYTES``, then peek one more
+    # byte — if there's anything past the cap we reject without ever
+    # materialising the full bomb in memory.
+    try:
+        with gzip.GzipFile(fileobj=io.BytesIO(compressed), mode="rb") as gz:
+            out = gz.read(MAX_SHEETS_DATA_BYTES)
+            if gz.read(1):
+                _throw_bomb()
+    except (OSError, EOFError):
+        _throw_bomb(reason="malformed gzip envelope in sheets_data")
+    return out
 
 
 def _throw_bomb(reason: str | None = None) -> None:
-	import frappe
+    import frappe
 
-	limit_mb = MAX_SHEETS_DATA_BYTES // (1024 * 1024)
-	frappe.throw(
-		reason
-		or (
-			f"This spreadsheet is too large to save (over {limit_mb} MB uncompressed). "
-			f"This usually comes from formatting applied across a very large range — "
-			f"clear formatting you don't need, or split the data across sheets."
-		)
-	)
+    limit_mb = MAX_SHEETS_DATA_BYTES // (1024 * 1024)
+    frappe.throw(
+        reason
+        or (
+            f"This spreadsheet is too large to save (over {limit_mb} MB uncompressed). "
+            f"This usually comes from formatting applied across a very large range — "
+            f"clear formatting you don't need, or split the data across sheets."
+        )
+    )
 
 
 def _try_parse_envelope(stored: str) -> dict | None:
-	"""Return the envelope dict iff `stored` matches our wire format."""
-	try:
-		obj = json.loads(stored)
-	except (ValueError, TypeError):
-		return None
-	if (
-		isinstance(obj, dict)
-		and obj.get(_GZ_MARKER) == _GZ_KIND
-		and isinstance(obj.get(_DATA_KEY), str)
-	):
-		return obj
-	return None
+    """Return the envelope dict iff `stored` matches our wire format."""
+    try:
+        obj = json.loads(stored)
+    except (ValueError, TypeError):
+        return None
+    if isinstance(obj, dict) and obj.get(_GZ_MARKER) == _GZ_KIND and isinstance(obj.get(_DATA_KEY), str):
+        return obj
+    return None

--- a/suite/sheets/doctype/sheet/test_cell_codec.py
+++ b/suite/sheets/doctype/sheet/test_cell_codec.py
@@ -13,43 +13,43 @@ from suite.sheets.doctype.sheet.cell_codec import cell_map
 
 
 class CellMapCompact(unittest.TestCase):
-	def test_reads_compact_v2_slice(self):
-		# As produced by packSheet: rows keyed by 0-based row, value arrays by
-		# 0-based column.
-		slice_ = {
-			"v": 2,
-			"current": "Sheet1",
-			"sheets": {"Sheet1": {"rows": {"0": ["Date", "Day"], "1": ["2013-11-26", "26"]}}},
-		}
-		self.assertEqual(
-			cell_map(slice_, "Sheet1"),
-			{"A1": "Date", "B1": "Day", "A2": "2013-11-26", "B2": "26"},
-		)
+    def test_reads_compact_v2_slice(self):
+        # As produced by packSheet: rows keyed by 0-based row, value arrays by
+        # 0-based column.
+        slice_ = {
+            "v": 2,
+            "current": "Sheet1",
+            "sheets": {"Sheet1": {"rows": {"0": ["Date", "Day"], "1": ["2013-11-26", "26"]}}},
+        }
+        self.assertEqual(
+            cell_map(slice_, "Sheet1"),
+            {"A1": "Date", "B1": "Day", "A2": "2013-11-26", "B2": "26"},
+        )
 
-	def test_column_labels_past_z(self):
-		# Column 26 -> "AA"; holes before it must not become cells.
-		slice_ = {"v": 2, "sheets": {"S": {"rows": {"0": [None] * 26 + ["wide"]}}}}
-		self.assertEqual(cell_map(slice_, "S"), {"AA1": "wide"})
+    def test_column_labels_past_z(self):
+        # Column 26 -> "AA"; holes before it must not become cells.
+        slice_ = {"v": 2, "sheets": {"S": {"rows": {"0": [None] * 26 + ["wide"]}}}}
+        self.assertEqual(cell_map(slice_, "S"), {"AA1": "wide"})
 
-	def test_skips_empty_and_null_slots(self):
-		slice_ = {"v": 2, "sheets": {"S": {"rows": {"0": ["keep", "", None]}}}}
-		self.assertEqual(cell_map(slice_, "S"), {"A1": "keep"})
+    def test_skips_empty_and_null_slots(self):
+        slice_ = {"v": 2, "sheets": {"S": {"rows": {"0": ["keep", "", None]}}}}
+        self.assertEqual(cell_map(slice_, "S"), {"A1": "keep"})
 
-	def test_unknown_sheet_is_empty(self):
-		slice_ = {"v": 2, "sheets": {"S": {"rows": {"0": ["x"]}}}}
-		self.assertEqual(cell_map(slice_, "Other"), {})
+    def test_unknown_sheet_is_empty(self):
+        slice_ = {"v": 2, "sheets": {"S": {"rows": {"0": ["x"]}}}}
+        self.assertEqual(cell_map(slice_, "Other"), {})
 
 
 class CellMapLegacy(unittest.TestCase):
-	def test_reads_legacy_unversioned_slice(self):
-		slice_ = {"current": "Sheet1", "sheets": {"Sheet1": {"A1": "old", "B2": "v"}}}
-		self.assertEqual(cell_map(slice_, "Sheet1"), {"A1": "old", "B2": "v"})
+    def test_reads_legacy_unversioned_slice(self):
+        slice_ = {"current": "Sheet1", "sheets": {"Sheet1": {"A1": "old", "B2": "v"}}}
+        self.assertEqual(cell_map(slice_, "Sheet1"), {"A1": "old", "B2": "v"})
 
-	def test_garbage_inputs_yield_empty(self):
-		self.assertEqual(cell_map(None, "Sheet1"), {})
-		self.assertEqual(cell_map({}, "Sheet1"), {})
-		self.assertEqual(cell_map({"sheets": {"Sheet1": "nope"}}, "Sheet1"), {})
+    def test_garbage_inputs_yield_empty(self):
+        self.assertEqual(cell_map(None, "Sheet1"), {})
+        self.assertEqual(cell_map({}, "Sheet1"), {})
+        self.assertEqual(cell_map({"sheets": {"Sheet1": "nope"}}, "Sheet1"), {})
 
 
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()

--- a/suite/sheets/doctype/sheet/test_sheet.py
+++ b/suite/sheets/doctype/sheet/test_sheet.py
@@ -4,7 +4,6 @@
 # import frappe
 from frappe.tests import IntegrationTestCase
 
-
 # On IntegrationTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
 # Use these module variables to add/remove to/from that list

--- a/suite/sheets/doctype/sheet/test_sheet.py
+++ b/suite/sheets/doctype/sheet/test_sheet.py
@@ -12,11 +12,10 @@ EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
-
 class IntegrationTestSheet(IntegrationTestCase):
-	"""
-	Integration tests for Sheet.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for Sheet.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/sheets/doctype/sheet/test_storage.py
+++ b/suite/sheets/doctype/sheet/test_storage.py
@@ -6,72 +6,72 @@ import json
 import unittest
 
 from suite.sheets.doctype.sheet.storage import (
-	decode_sheets_data,
-	effective_size,
-	encode_sheets_data,
+    decode_sheets_data,
+    effective_size,
+    encode_sheets_data,
 )
 
 
 class EncodeDecodeRoundTrip(unittest.TestCase):
-	def test_simple_round_trip(self):
-		original = '{"A1": "hello", "B2": "world"}'
-		self.assertEqual(decode_sheets_data(encode_sheets_data(original)), original)
+    def test_simple_round_trip(self):
+        original = '{"A1": "hello", "B2": "world"}'
+        self.assertEqual(decode_sheets_data(encode_sheets_data(original)), original)
 
-	def test_unicode_round_trip(self):
-		original = '{"A1": "héllo 🌍 寿司"}'
-		self.assertEqual(decode_sheets_data(encode_sheets_data(original)), original)
+    def test_unicode_round_trip(self):
+        original = '{"A1": "héllo 🌍 寿司"}'
+        self.assertEqual(decode_sheets_data(encode_sheets_data(original)), original)
 
-	def test_nested_workbook_round_trip(self):
-		workbook = {
-			"sheets": [{"name": "Sheet1", "cells": {"A1": "x", "B2": "y"}}],
-			"formats": {"A1": {"bold": True, "fontFamily": "Inter"}},
-			"viewState": {"zoom": 1, "freeze": {"rows": 1, "cols": 0}},
-		}
-		original = json.dumps(workbook)
-		self.assertEqual(decode_sheets_data(encode_sheets_data(original)), original)
+    def test_nested_workbook_round_trip(self):
+        workbook = {
+            "sheets": [{"name": "Sheet1", "cells": {"A1": "x", "B2": "y"}}],
+            "formats": {"A1": {"bold": True, "fontFamily": "Inter"}},
+            "viewState": {"zoom": 1, "freeze": {"rows": 1, "cols": 0}},
+        }
+        original = json.dumps(workbook)
+        self.assertEqual(decode_sheets_data(encode_sheets_data(original)), original)
 
-	def test_large_payload_compresses_at_least_5x(self):
-		# Highly compressible: repeated cell values + format keys
-		cells = {f"A{i}": "X" * 100 for i in range(2000)}
-		original = json.dumps(cells)
-		encoded = encode_sheets_data(original)
-		self.assertLess(len(encoded), len(original) // 5)
-		self.assertEqual(decode_sheets_data(encoded), original)
+    def test_large_payload_compresses_at_least_5x(self):
+        # Highly compressible: repeated cell values + format keys
+        cells = {f"A{i}": "X" * 100 for i in range(2000)}
+        original = json.dumps(cells)
+        encoded = encode_sheets_data(original)
+        self.assertLess(len(encoded), len(original) // 5)
+        self.assertEqual(decode_sheets_data(encoded), original)
 
 
 class DecodeBackwardCompat(unittest.TestCase):
-	def test_plain_json_passes_through(self):
-		# Pre-compression sheets: bare JSON should round-trip unchanged
-		plain = '{"A1": "ok"}'
-		self.assertEqual(decode_sheets_data(plain), plain)
+    def test_plain_json_passes_through(self):
+        # Pre-compression sheets: bare JSON should round-trip unchanged
+        plain = '{"A1": "ok"}'
+        self.assertEqual(decode_sheets_data(plain), plain)
 
-	def test_none_returns_empty_object(self):
-		self.assertEqual(decode_sheets_data(None), "{}")
+    def test_none_returns_empty_object(self):
+        self.assertEqual(decode_sheets_data(None), "{}")
 
-	def test_empty_string_returns_empty_object(self):
-		self.assertEqual(decode_sheets_data(""), "{}")
+    def test_empty_string_returns_empty_object(self):
+        self.assertEqual(decode_sheets_data(""), "{}")
 
-	def test_non_envelope_dict_passes_through(self):
-		# A dict with a "data" key but no "_z" marker is not our envelope
-		plain = '{"data": "looks like envelope but no marker"}'
-		self.assertEqual(decode_sheets_data(plain), plain)
+    def test_non_envelope_dict_passes_through(self):
+        # A dict with a "data" key but no "_z" marker is not our envelope
+        plain = '{"data": "looks like envelope but no marker"}'
+        self.assertEqual(decode_sheets_data(plain), plain)
 
-	def test_envelope_with_wrong_kind_passes_through(self):
-		# Future format mismatch — don't try to decode
-		other = json.dumps({"_z": "brotli", "data": "abc"})
-		self.assertEqual(decode_sheets_data(other), other)
+    def test_envelope_with_wrong_kind_passes_through(self):
+        # Future format mismatch — don't try to decode
+        other = json.dumps({"_z": "brotli", "data": "abc"})
+        self.assertEqual(decode_sheets_data(other), other)
 
 
 class EffectiveSize(unittest.TestCase):
-	def test_plain_size(self):
-		plain = '{"A1": "value"}'
-		self.assertEqual(effective_size(plain), len(plain.encode("utf-8")))
+    def test_plain_size(self):
+        plain = '{"A1": "value"}'
+        self.assertEqual(effective_size(plain), len(plain.encode("utf-8")))
 
-	def test_envelope_reports_uncompressed_size(self):
-		original = json.dumps({"A1": "X" * 5000})
-		encoded = encode_sheets_data(original)
-		self.assertEqual(effective_size(encoded), len(original.encode("utf-8")))
+    def test_envelope_reports_uncompressed_size(self):
+        original = json.dumps({"A1": "X" * 5000})
+        encoded = encode_sheets_data(original)
+        self.assertEqual(effective_size(encoded), len(original.encode("utf-8")))
 
-	def test_empty_inputs(self):
-		self.assertEqual(effective_size(None), 0)
-		self.assertEqual(effective_size(""), 0)
+    def test_empty_inputs(self):
+        self.assertEqual(effective_size(None), 0)
+        self.assertEqual(effective_size(""), 0)

--- a/suite/sheets/doctype/sheet/test_storage_bomb.py
+++ b/suite/sheets/doctype/sheet/test_storage_bomb.py
@@ -20,82 +20,86 @@ from suite.sheets.doctype.sheet import storage
 
 
 def _envelope(payload: bytes) -> str:
-	compressed = gzip.compress(payload, compresslevel=9)
-	return json.dumps(
-		{
-			storage._GZ_MARKER: storage._GZ_KIND,
-			storage._DATA_KEY: base64.b64encode(compressed).decode("ascii"),
-		}
-	)
+    compressed = gzip.compress(payload, compresslevel=9)
+    return json.dumps(
+        {
+            storage._GZ_MARKER: storage._GZ_KIND,
+            storage._DATA_KEY: base64.b64encode(compressed).decode("ascii"),
+        }
+    )
 
 
 class GzipBombGuards(unittest.TestCase):
-	def _throw(self, *a, **kw):
-		raise ValueError("bomb")
+    def _throw(self, *a, **kw):
+        raise ValueError("bomb")
 
-	def test_decompressed_size_at_cap_passes(self):
-		# An envelope whose decompressed size is exactly at the cap is allowed.
-		# (We choose the boundary deliberately to lock in the off-by-one.)
-		payload = b"x" * storage.MAX_SHEETS_DATA_BYTES
-		env = _envelope(payload)
-		out = storage.decode_sheets_data(env)
-		self.assertEqual(len(out.encode("utf-8")), storage.MAX_SHEETS_DATA_BYTES)
+    def test_decompressed_size_at_cap_passes(self):
+        # An envelope whose decompressed size is exactly at the cap is allowed.
+        # (We choose the boundary deliberately to lock in the off-by-one.)
+        payload = b"x" * storage.MAX_SHEETS_DATA_BYTES
+        env = _envelope(payload)
+        out = storage.decode_sheets_data(env)
+        self.assertEqual(len(out.encode("utf-8")), storage.MAX_SHEETS_DATA_BYTES)
 
-	def test_decompressed_size_over_cap_rejected(self):
-		# One byte over → reject without allocating the full bomb. We use a
-		# highly-compressible payload so the *compressed* size stays tiny but
-		# the decompressed size goes over the cap.
-		payload = b"x" * (storage.MAX_SHEETS_DATA_BYTES + 1)
-		env = _envelope(payload)
-		with mock.patch.object(storage.frappe if hasattr(storage, "frappe") else __import__("frappe"), "throw", side_effect=self._throw):
-			with self.assertRaises(ValueError):
-				storage.decode_sheets_data(env)
+    def test_decompressed_size_over_cap_rejected(self):
+        # One byte over → reject without allocating the full bomb. We use a
+        # highly-compressible payload so the *compressed* size stays tiny but
+        # the decompressed size goes over the cap.
+        payload = b"x" * (storage.MAX_SHEETS_DATA_BYTES + 1)
+        env = _envelope(payload)
+        with mock.patch.object(
+            storage.frappe if hasattr(storage, "frappe") else __import__("frappe"),
+            "throw",
+            side_effect=self._throw,
+        ):
+            with self.assertRaises(ValueError):
+                storage.decode_sheets_data(env)
 
-	def test_compressed_size_over_cap_rejected(self):
-		# A huge *compressed* payload is rejected before we even attempt to
-		# decompress — the base64 length guard catches the simplest case,
-		# the raw-compressed guard catches anything that gets past it.
-		payload = b"x" * (storage._MAX_COMPRESSED_BYTES + 1)
-		env_obj = {
-			storage._GZ_MARKER: storage._GZ_KIND,
-			storage._DATA_KEY: base64.b64encode(payload).decode("ascii"),
-		}
-		env = json.dumps(env_obj)
-		with mock.patch("frappe.throw", side_effect=self._throw):
-			with self.assertRaises(ValueError):
-				storage.decode_sheets_data(env)
+    def test_compressed_size_over_cap_rejected(self):
+        # A huge *compressed* payload is rejected before we even attempt to
+        # decompress — the base64 length guard catches the simplest case,
+        # the raw-compressed guard catches anything that gets past it.
+        payload = b"x" * (storage._MAX_COMPRESSED_BYTES + 1)
+        env_obj = {
+            storage._GZ_MARKER: storage._GZ_KIND,
+            storage._DATA_KEY: base64.b64encode(payload).decode("ascii"),
+        }
+        env = json.dumps(env_obj)
+        with mock.patch("frappe.throw", side_effect=self._throw):
+            with self.assertRaises(ValueError):
+                storage.decode_sheets_data(env)
 
-	def test_invalid_base64_rejected(self):
-		env = json.dumps({storage._GZ_MARKER: storage._GZ_KIND, storage._DATA_KEY: "!!!not base64!!!"})
-		with mock.patch("frappe.throw", side_effect=self._throw):
-			with self.assertRaises(ValueError):
-				storage.decode_sheets_data(env)
+    def test_invalid_base64_rejected(self):
+        env = json.dumps({storage._GZ_MARKER: storage._GZ_KIND, storage._DATA_KEY: "!!!not base64!!!"})
+        with mock.patch("frappe.throw", side_effect=self._throw):
+            with self.assertRaises(ValueError):
+                storage.decode_sheets_data(env)
 
-	def test_malformed_gzip_rejected(self):
-		# Valid base64, but the bytes don't form a gzip stream.
-		env = json.dumps(
-			{
-				storage._GZ_MARKER: storage._GZ_KIND,
-				storage._DATA_KEY: base64.b64encode(b"not really gzip").decode("ascii"),
-			}
-		)
-		with mock.patch("frappe.throw", side_effect=self._throw):
-			with self.assertRaises(ValueError):
-				storage.decode_sheets_data(env)
+    def test_malformed_gzip_rejected(self):
+        # Valid base64, but the bytes don't form a gzip stream.
+        env = json.dumps(
+            {
+                storage._GZ_MARKER: storage._GZ_KIND,
+                storage._DATA_KEY: base64.b64encode(b"not really gzip").decode("ascii"),
+            }
+        )
+        with mock.patch("frappe.throw", side_effect=self._throw):
+            with self.assertRaises(ValueError):
+                storage.decode_sheets_data(env)
 
-	def test_plain_json_passthrough_unchanged(self):
-		# Non-envelope strings still pass through verbatim.
-		plain = json.dumps({"A1": "hi"})
-		self.assertEqual(storage.decode_sheets_data(plain), plain)
+    def test_plain_json_passthrough_unchanged(self):
+        # Non-envelope strings still pass through verbatim.
+        plain = json.dumps({"A1": "hi"})
+        self.assertEqual(storage.decode_sheets_data(plain), plain)
 
-	def test_effective_size_bounded(self):
-		# `effective_size` shares the bomb path; same guarantee.
-		payload = b"x" * (storage.MAX_SHEETS_DATA_BYTES + 1)
-		env = _envelope(payload)
-		with mock.patch("frappe.throw", side_effect=self._throw):
-			with self.assertRaises(ValueError):
-				storage.effective_size(env)
+    def test_effective_size_bounded(self):
+        # `effective_size` shares the bomb path; same guarantee.
+        payload = b"x" * (storage.MAX_SHEETS_DATA_BYTES + 1)
+        env = _envelope(payload)
+        with mock.patch("frappe.throw", side_effect=self._throw):
+            with self.assertRaises(ValueError):
+                storage.effective_size(env)
 
 
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()

--- a/suite/sheets/doctype/sheet_cell/sheet_cell.py
+++ b/suite/sheets/doctype/sheet_cell/sheet_cell.py
@@ -3,8 +3,8 @@ from frappe.model.document import Document
 
 
 class SheetCell(Document):
-	"""One row per populated cell. Lifecycle is owned by the API layer
-	(`patch_sheet_v2`), not by the Desk form — direct doc.insert / doc.save
-	through Frappe ORM works but is not the primary path."""
+    """One row per populated cell. Lifecycle is owned by the API layer
+    (`patch_sheet_v2`), not by the Desk form — direct doc.insert / doc.save
+    through Frappe ORM works but is not the primary path."""
 
-	pass
+    pass

--- a/suite/sheets/doctype/sheet_collab_state/sheet_collab_state.py
+++ b/suite/sheets/doctype/sheet_collab_state/sheet_collab_state.py
@@ -15,20 +15,20 @@ from frappe.model.document import Document
 
 
 class SheetCollabState(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		byte_size: DF.Int
-		last_persisted_at: DF.Datetime | None
-		sheet: DF.Link
-		ydoc_state: DF.LongText | None
-	# end: auto-generated types
+        byte_size: DF.Int
+        last_persisted_at: DF.Datetime | None
+        sheet: DF.Link
+        ydoc_state: DF.LongText | None
+    # end: auto-generated types
 
-	def validate(self):
-		if self.byte_size is not None and self.byte_size < 0:
-			frappe.throw("byte_size must be non-negative")
+    def validate(self):
+        if self.byte_size is not None and self.byte_size < 0:
+            frappe.throw("byte_size must be non-negative")

--- a/suite/sheets/doctype/sheet_op_log/sheet_op_log.py
+++ b/suite/sheets/doctype/sheet_op_log/sheet_op_log.py
@@ -6,54 +6,54 @@ from frappe.model.document import Document
 # meaningful summaries without a per-op switch statement.  Add to this set
 # rather than inventing new values at the call site.
 VALID_OP_TYPES = {
-	# ── Lifecycle (written by versioning.save) ─────────────────────────
-	"create",        # initial save when a new Sheet is inserted
-	"save",          # subsequent save events advancing the head pointer
-	"restore",       # non-destructive restore of a snapshot
-	# ── User actions ───────────────────────────────────────────────────
-	"edit",          # single-cell typed edit
-	"paste",         # paste from clipboard (internal or external)
-	"fill",          # drag-fill / fill series
-	"import",        # CSV/XLSX import
-	"find-replace",  # bulk find & replace
-	"delete",        # delete row(s) / col(s)
-	"insert",        # insert row(s) / col(s)
-	"format",        # formatting (excluded from cell-history per spec)
-	"sort",
-	"filter",
-	"merge",
-	"unmerge",
-	"resize",
-	"freeze",
-	"hide",
-	"unhide",
-	"sheet",         # add/rename/delete/duplicate/reorder sheets
-	"validation",
-	"comment",
-	"cond-format",
-	"chart",         # chart add / edit / move / resize / delete
-	"ai_assist",     # cells written by an accepted AI Assist action plan
+    # ── Lifecycle (written by versioning.save) ─────────────────────────
+    "create",  # initial save when a new Sheet is inserted
+    "save",  # subsequent save events advancing the head pointer
+    "restore",  # non-destructive restore of a snapshot
+    # ── User actions ───────────────────────────────────────────────────
+    "edit",  # single-cell typed edit
+    "paste",  # paste from clipboard (internal or external)
+    "fill",  # drag-fill / fill series
+    "import",  # CSV/XLSX import
+    "find-replace",  # bulk find & replace
+    "delete",  # delete row(s) / col(s)
+    "insert",  # insert row(s) / col(s)
+    "format",  # formatting (excluded from cell-history per spec)
+    "sort",
+    "filter",
+    "merge",
+    "unmerge",
+    "resize",
+    "freeze",
+    "hide",
+    "unhide",
+    "sheet",  # add/rename/delete/duplicate/reorder sheets
+    "validation",
+    "comment",
+    "cond-format",
+    "chart",  # chart add / edit / move / resize / delete
+    "ai_assist",  # cells written by an accepted AI Assist action plan
 }
 
 
 class SheetOpLog(Document):
-	# begin: auto-generated types
-	from typing import TYPE_CHECKING
+    # begin: auto-generated types
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		actor: DF.Link | None
-		after_json: DF.LongText | None
-		before_json: DF.LongText | None
-		cell_refs: DF.LongText | None
-		op_type: DF.Data
-		seq: DF.Int
-		sheet: DF.Link
-		sub_sheet: DF.Data | None
-		summary: DF.Data | None
-	# end: auto-generated types
+        actor: DF.Link | None
+        after_json: DF.LongText | None
+        before_json: DF.LongText | None
+        cell_refs: DF.LongText | None
+        op_type: DF.Data
+        seq: DF.Int
+        sheet: DF.Link
+        sub_sheet: DF.Data | None
+        summary: DF.Data | None
+    # end: auto-generated types
 
-	def validate(self):
-		if self.op_type not in VALID_OP_TYPES:
-			frappe.throw(f"Unknown op_type: {self.op_type}")
+    def validate(self):
+        if self.op_type not in VALID_OP_TYPES:
+            frappe.throw(f"Unknown op_type: {self.op_type}")

--- a/suite/sheets/doctype/sheet_op_log/sheet_op_log.py
+++ b/suite/sheets/doctype/sheet_op_log/sheet_op_log.py
@@ -1,7 +1,6 @@
 import frappe
 from frappe.model.document import Document
 
-
 # Stable taxonomy of op_types — keep the list narrow so the UI can render
 # meaningful summaries without a per-op switch statement.  Add to this set
 # rather than inventing new values at the call site.

--- a/suite/sheets/doctype/sheet_seq/sheet_seq.py
+++ b/suite/sheets/doctype/sheet_seq/sheet_seq.py
@@ -10,18 +10,18 @@ from frappe.model.document import Document
 
 
 class SheetSeq(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		next_seq: DF.Int
-		sheet: DF.Link
-	# end: auto-generated types
+        next_seq: DF.Int
+        sheet: DF.Link
+    # end: auto-generated types
 
-	def validate(self):
-		if self.next_seq is None or self.next_seq < 1:
-			frappe.throw("next_seq must be >= 1")
+    def validate(self):
+        if self.next_seq is None or self.next_seq < 1:
+            frappe.throw("next_seq must be >= 1")

--- a/suite/sheets/doctype/sheet_snapshot/sheet_snapshot.py
+++ b/suite/sheets/doctype/sheet_snapshot/sheet_snapshot.py
@@ -13,29 +13,29 @@ from frappe.model.document import Document
 
 
 class SheetSnapshot(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		actor: DF.Link | None
-		byte_size: DF.Int
-		kind: DF.Literal["auto", "milestone", "named"]
-		label: DF.Data | None
-		op_count: DF.Int
-		pinned: DF.Check
-		seq: DF.Int
-		sheet: DF.Link
-		sheets_data: DF.JSON | None
-	# end: auto-generated types
+        actor: DF.Link | None
+        byte_size: DF.Int
+        kind: DF.Literal["auto", "milestone", "named"]
+        label: DF.Data | None
+        op_count: DF.Int
+        pinned: DF.Check
+        seq: DF.Int
+        sheet: DF.Link
+        sheets_data: DF.JSON | None
+    # end: auto-generated types
 
-	def validate(self):
-		if self.kind not in {"auto", "milestone", "named"}:
-			frappe.throw(f"Unknown snapshot kind: {self.kind}")
-		if self.kind == "named" and not (self.label or "").strip():
-			frappe.throw("Named snapshots require a label")
-		if self.seq is None or self.seq < 0:
-			frappe.throw("seq must be non-negative")
+    def validate(self):
+        if self.kind not in {"auto", "milestone", "named"}:
+            frappe.throw(f"Unknown snapshot kind: {self.kind}")
+        if self.kind == "named" and not (self.label or "").strip():
+            frappe.throw("Named snapshots require a label")
+        if self.seq is None or self.seq < 0:
+            frappe.throw("seq must be non-negative")

--- a/suite/sheets/doctype/sheets_ai_settings/sheets_ai_settings.py
+++ b/suite/sheets/doctype/sheets_ai_settings/sheets_ai_settings.py
@@ -13,17 +13,17 @@ from frappe.model.document import Document
 
 
 class SheetsAISettings(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		api_key: DF.Password | None
-		enabled: DF.Check
-		model: DF.Data | None
-	# end: auto-generated types
+        api_key: DF.Password | None
+        enabled: DF.Check
+        model: DF.Data | None
+    # end: auto-generated types
 
-	pass
+    pass

--- a/suite/sheets/link_preview.py
+++ b/suite/sheets/link_preview.py
@@ -38,162 +38,162 @@ USER_AGENT = "Mozilla/5.0 (compatible; FrappeSheets-LinkPreview/1.0)"
 @frappe.whitelist(methods=["GET", "POST"])
 @rate_limit(limit=60, seconds=60)
 def get_link_preview(url: str) -> dict:
-	"""Fetch {title, description, favicon, host} for a cell hyperlink."""
-	cache_key = f"sheets_link_preview::{url}"
-	cached = frappe.cache.get_value(cache_key)
-	if cached is not None:
-		return cached
+    """Fetch {title, description, favicon, host} for a cell hyperlink."""
+    cache_key = f"sheets_link_preview::{url}"
+    cached = frappe.cache.get_value(cache_key)
+    if cached is not None:
+        return cached
 
-	try:
-		result = _fetch_preview(url)
-		ttl = CACHE_OK_SEC
-	except Exception:
-		# Unreachable host, non-HTML target, blocked address, parse error —
-		# the card just degrades to the bare URL. Cache briefly so a dead
-		# link hovered repeatedly doesn't retry every time.
-		frappe.logger("sheets").error(f"link preview failed for {url}", exc_info=True)
-		result = {"error": True}
-		ttl = CACHE_ERR_SEC
+    try:
+        result = _fetch_preview(url)
+        ttl = CACHE_OK_SEC
+    except Exception:
+        # Unreachable host, non-HTML target, blocked address, parse error —
+        # the card just degrades to the bare URL. Cache briefly so a dead
+        # link hovered repeatedly doesn't retry every time.
+        frappe.logger("sheets").error(f"link preview failed for {url}", exc_info=True)
+        result = {"error": True}
+        ttl = CACHE_ERR_SEC
 
-	frappe.cache.set_value(cache_key, result, expires_in_sec=ttl)
-	return result
+    frappe.cache.set_value(cache_key, result, expires_in_sec=ttl)
+    return result
 
 
 def _fetch_preview(url: str) -> dict:
-	final_url, html = _fetch_html(url)
-	# Hand raw bytes to BeautifulSoup so it detects the page's charset itself.
-	soup = BeautifulSoup(html, "html.parser")
+    final_url, html = _fetch_html(url)
+    # Hand raw bytes to BeautifulSoup so it detects the page's charset itself.
+    soup = BeautifulSoup(html, "html.parser")
 
-	title = _first(
-		_meta(soup, property="og:title"),
-		soup.title.string if soup.title else None,
-	)
-	description = _first(
-		_meta(soup, property="og:description"),
-		_meta(soup, name="description"),
-	)
-	favicon = _favicon(soup, final_url)
-	host = urlparse(final_url).hostname or ""
-	if host.startswith("www."):
-		host = host[4:]
+    title = _first(
+        _meta(soup, property="og:title"),
+        soup.title.string if soup.title else None,
+    )
+    description = _first(
+        _meta(soup, property="og:description"),
+        _meta(soup, name="description"),
+    )
+    favicon = _favicon(soup, final_url)
+    host = urlparse(final_url).hostname or ""
+    if host.startswith("www."):
+        host = host[4:]
 
-	return {
-		"title": _clip(title, 200),
-		"description": _clip(description, 300),
-		"favicon": favicon,
-		"host": host,
-	}
+    return {
+        "title": _clip(title, 200),
+        "description": _clip(description, 300),
+        "favicon": favicon,
+        "host": host,
+    }
 
 
 def _fetch_html(url: str) -> tuple[str, bytes]:
-	"""GET `url` with SSRF guards; returns (final_url, first MAX_BYTES of body)."""
-	current = url
-	for _ in range(MAX_REDIRECTS + 1):
-		ip, host, port, scheme, path = _validate_and_resolve(current)
-		pool = _pinned_pool(ip, host, port, scheme)
-		try:
-			resp = pool.urlopen(
-				"GET",
-				path,
-				headers={"Host": host, "User-Agent": USER_AGENT, "Accept": "text/html"},
-				redirect=False,
-				preload_content=False,
-				decode_content=True,
-			)
-			if resp.status in REDIRECT_STATUSES:
-				location = resp.headers.get("location")
-				if not location:
-					raise frappe.ValidationError("Redirect without location")
-				current = urljoin(current, location)
-				continue
-			if resp.status >= 400:
-				raise frappe.ValidationError(f"HTTP {resp.status}")
-			if "html" not in resp.headers.get("content-type", ""):
-				raise frappe.ValidationError("Not an HTML page")
-			return current, resp.read(MAX_BYTES)
-		finally:
-			pool.close()
-	raise frappe.ValidationError("Too many redirects")
+    """GET `url` with SSRF guards; returns (final_url, first MAX_BYTES of body)."""
+    current = url
+    for _ in range(MAX_REDIRECTS + 1):
+        ip, host, port, scheme, path = _validate_and_resolve(current)
+        pool = _pinned_pool(ip, host, port, scheme)
+        try:
+            resp = pool.urlopen(
+                "GET",
+                path,
+                headers={"Host": host, "User-Agent": USER_AGENT, "Accept": "text/html"},
+                redirect=False,
+                preload_content=False,
+                decode_content=True,
+            )
+            if resp.status in REDIRECT_STATUSES:
+                location = resp.headers.get("location")
+                if not location:
+                    raise frappe.ValidationError("Redirect without location")
+                current = urljoin(current, location)
+                continue
+            if resp.status >= 400:
+                raise frappe.ValidationError(f"HTTP {resp.status}")
+            if "html" not in resp.headers.get("content-type", ""):
+                raise frappe.ValidationError("Not an HTML page")
+            return current, resp.read(MAX_BYTES)
+        finally:
+            pool.close()
+    raise frappe.ValidationError("Too many redirects")
 
 
 def _pinned_pool(ip: str, host: str, port: int, scheme: str):
-	"""Connection pool bound to the pre-validated IP, but presenting the original
-	hostname for Host header, TLS SNI, and cert verification."""
-	timeout = urllib3.Timeout(connect=CONNECT_TIMEOUT, read=READ_TIMEOUT)
-	if scheme == "https":
-		return urllib3.HTTPSConnectionPool(
-			ip,
-			port=port,
-			maxsize=1,
-			retries=False,
-			timeout=timeout,
-			cert_reqs="CERT_REQUIRED",
-			ca_certs=certifi.where(),
-			server_hostname=host,
-			assert_hostname=host,
-		)
-	return urllib3.HTTPConnectionPool(ip, port=port, maxsize=1, retries=False, timeout=timeout)
+    """Connection pool bound to the pre-validated IP, but presenting the original
+    hostname for Host header, TLS SNI, and cert verification."""
+    timeout = urllib3.Timeout(connect=CONNECT_TIMEOUT, read=READ_TIMEOUT)
+    if scheme == "https":
+        return urllib3.HTTPSConnectionPool(
+            ip,
+            port=port,
+            maxsize=1,
+            retries=False,
+            timeout=timeout,
+            cert_reqs="CERT_REQUIRED",
+            ca_certs=certifi.where(),
+            server_hostname=host,
+            assert_hostname=host,
+        )
+    return urllib3.HTTPConnectionPool(ip, port=port, maxsize=1, retries=False, timeout=timeout)
 
 
 def _validate_and_resolve(url: str) -> tuple[str, str, int, str, str]:
-	"""Resolve `url`'s host, reject non-public targets, and return the exact IP to
-	connect to plus (host, port, scheme, path+query)."""
-	parsed = urlparse(url)
-	if parsed.scheme not in ("http", "https"):
-		raise frappe.ValidationError("Only http/https URLs allowed")
-	if parsed.port not in (None, 80, 443):
-		raise frappe.ValidationError("Non-standard port not allowed")
-	host = parsed.hostname
-	if not host:
-		raise frappe.ValidationError("Invalid URL")
-	port = parsed.port or (443 if parsed.scheme == "https" else 80)
-	# Resolve every A/AAAA record and reject if ANY is non-public — a rebinding
-	# nameserver can rotate which record it hands out, so one bad answer taints
-	# the name. We then connect to the first (validated) IP directly.
-	try:
-		infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
-	except socket.gaierror:
-		raise frappe.ValidationError("Host not resolvable")
-	pinned_ip = None
-	for info in infos:
-		ip = info[4][0]
-		addr = ipaddress.ip_address(ip)
-		if (
-			addr.is_private
-			or addr.is_loopback
-			or addr.is_link_local
-			or addr.is_multicast
-			or addr.is_reserved
-			or addr.is_unspecified
-		):
-			raise frappe.ValidationError("Address not allowed")
-		if pinned_ip is None:
-			pinned_ip = ip
-	path = (parsed.path or "/") + (f"?{parsed.query}" if parsed.query else "")
-	return pinned_ip, host, port, parsed.scheme, path
+    """Resolve `url`'s host, reject non-public targets, and return the exact IP to
+    connect to plus (host, port, scheme, path+query)."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise frappe.ValidationError("Only http/https URLs allowed")
+    if parsed.port not in (None, 80, 443):
+        raise frappe.ValidationError("Non-standard port not allowed")
+    host = parsed.hostname
+    if not host:
+        raise frappe.ValidationError("Invalid URL")
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    # Resolve every A/AAAA record and reject if ANY is non-public — a rebinding
+    # nameserver can rotate which record it hands out, so one bad answer taints
+    # the name. We then connect to the first (validated) IP directly.
+    try:
+        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except socket.gaierror:
+        raise frappe.ValidationError("Host not resolvable")
+    pinned_ip = None
+    for info in infos:
+        ip = info[4][0]
+        addr = ipaddress.ip_address(ip)
+        if (
+            addr.is_private
+            or addr.is_loopback
+            or addr.is_link_local
+            or addr.is_multicast
+            or addr.is_reserved
+            or addr.is_unspecified
+        ):
+            raise frappe.ValidationError("Address not allowed")
+        if pinned_ip is None:
+            pinned_ip = ip
+    path = (parsed.path or "/") + (f"?{parsed.query}" if parsed.query else "")
+    return pinned_ip, host, port, parsed.scheme, path
 
 
 def _meta(soup, **attrs):
-	tag = soup.find("meta", attrs=attrs)
-	return tag.get("content") if tag else None
+    tag = soup.find("meta", attrs=attrs)
+    return tag.get("content") if tag else None
 
 
 def _favicon(soup, base_url: str) -> str:
-	link = soup.find("link", rel=lambda r: r and "icon" in str(r).lower())
-	href = link.get("href") if link else None
-	icon = urljoin(base_url, href or "/favicon.ico")
-	# Only expose http(s) icons — data: URIs are fine to render but can be
-	# megabytes; skip anything else the page might declare.
-	return icon if icon.startswith(("http://", "https://")) else ""
+    link = soup.find("link", rel=lambda r: r and "icon" in str(r).lower())
+    href = link.get("href") if link else None
+    icon = urljoin(base_url, href or "/favicon.ico")
+    # Only expose http(s) icons — data: URIs are fine to render but can be
+    # megabytes; skip anything else the page might declare.
+    return icon if icon.startswith(("http://", "https://")) else ""
 
 
 def _first(*values):
-	for v in values:
-		if v and str(v).strip():
-			return str(v).strip()
-	return ""
+    for v in values:
+        if v and str(v).strip():
+            return str(v).strip()
+    return ""
 
 
 def _clip(text: str, limit: int) -> str:
-	text = " ".join((text or "").split())
-	return text[: limit - 1] + "…" if len(text) > limit else text
+    text = " ".join((text or "").split())
+    return text[: limit - 1] + "…" if len(text) > limit else text

--- a/suite/sheets/link_preview.py
+++ b/suite/sheets/link_preview.py
@@ -19,10 +19,9 @@ import socket
 from urllib.parse import urljoin, urlparse
 
 import certifi
+import frappe
 import urllib3
 from bs4 import BeautifulSoup
-
-import frappe
 from frappe.rate_limiter import rate_limit
 
 MAX_REDIRECTS = 3

--- a/suite/sheets/patches/integrate_with_drive.py
+++ b/suite/sheets/patches/integrate_with_drive.py
@@ -4,38 +4,38 @@ from suite.drive.utils import STATUS_TRASHED, create_drive_file, get_new_file_na
 
 
 def execute():
-	"""Back existing sheets with Drive Files so they show up in Drive, the same
-	way sheets created after this change are auto-backed in Sheet.after_insert.
+    """Back existing sheets with Drive Files so they show up in Drive, the same
+    way sheets created after this change are auto-backed in Sheet.after_insert.
 
-	Only existence/listing is mirrored — sharing stays on the sheet's own
-	DocShare model. Idempotent: sheets that already have a backing File are
-	skipped, so a re-run (or a sheet created between deploy and patch) is safe.
-	"""
-	frappe.flags.mute_drive_activity_log = True
-	try:
-		sheets = frappe.get_all("Sheet", fields=["name", "title", "owner", "trashed"])
-		for sheet in sheets:
-			if frappe.db.get_value(
-				"File", {"content_doctype": "Sheet", "content_docname": sheet.name}, "name"
-			):
-				continue
+    Only existence/listing is mirrored — sharing stays on the sheet's own
+    DocShare model. Idempotent: sheets that already have a backing File are
+    skipped, so a re-run (or a sheet created between deploy and patch) is safe.
+    """
+    frappe.flags.mute_drive_activity_log = True
+    try:
+        sheets = frappe.get_all("Sheet", fields=["name", "title", "owner", "trashed"])
+        for sheet in sheets:
+            if frappe.db.get_value(
+                "File", {"content_doctype": "Sheet", "content_docname": sheet.name}, "name"
+            ):
+                continue
 
-			home = get_user_folder(sheet.owner).name
-			file = create_drive_file(
-				# Dedupe within the user folder so backfilling many like-titled
-				# sheets (e.g. several "Untitled Spreadsheet") doesn't create
-				# ambiguous same-named Drive files.
-				get_new_file_name(sheet.title or "Untitled Spreadsheet", home, "Spreadsheet"),
-				home,
-				"Spreadsheet",
-				None,
-				mime_type="frappe/sheet",
-				content_doctype="Sheet",
-				content_docname=sheet.name,
-				owner=sheet.owner,
-			)
-			# A trashed sheet's File must land in the trash too, not the listing.
-			if sheet.trashed:
-				frappe.db.set_value("File", file.name, "status", STATUS_TRASHED, update_modified=False)
-	finally:
-		frappe.flags.mute_drive_activity_log = False
+            home = get_user_folder(sheet.owner).name
+            file = create_drive_file(
+                # Dedupe within the user folder so backfilling many like-titled
+                # sheets (e.g. several "Untitled Spreadsheet") doesn't create
+                # ambiguous same-named Drive files.
+                get_new_file_name(sheet.title or "Untitled Spreadsheet", home, "Spreadsheet"),
+                home,
+                "Spreadsheet",
+                None,
+                mime_type="frappe/sheet",
+                content_doctype="Sheet",
+                content_docname=sheet.name,
+                owner=sheet.owner,
+            )
+            # A trashed sheet's File must land in the trash too, not the listing.
+            if sheet.trashed:
+                frappe.db.set_value("File", file.name, "status", STATUS_TRASHED, update_modified=False)
+    finally:
+        frappe.flags.mute_drive_activity_log = False

--- a/suite/sheets/patches/v0_1/migrate_blob_to_cells.py
+++ b/suite/sheets/patches/v0_1/migrate_blob_to_cells.py
@@ -13,89 +13,91 @@ import frappe
 
 
 def execute():
-	sheet_names = frappe.get_all("Sheet", pluck="name")
-	if not sheet_names:
-		return
+    sheet_names = frappe.get_all("Sheet", pluck="name")
+    if not sheet_names:
+        return
 
-	migrated = 0
-	skipped = 0
-	for name in sheet_names:
-		try:
-			if _migrate_one(name):
-				migrated += 1
-			else:
-				skipped += 1
-		except Exception:
-			frappe.log_error(
-				title=f"Sheet v2 migration failed for {name}",
-				message=frappe.get_traceback(),
-			)
-	frappe.db.commit()
-	print(f"sheets: migrated {migrated} workbook(s); skipped {skipped}.")
+    migrated = 0
+    skipped = 0
+    for name in sheet_names:
+        try:
+            if _migrate_one(name):
+                migrated += 1
+            else:
+                skipped += 1
+        except Exception:
+            frappe.log_error(
+                title=f"Sheet v2 migration failed for {name}",
+                message=frappe.get_traceback(),
+            )
+    frappe.db.commit()
+    print(f"sheets: migrated {migrated} workbook(s); skipped {skipped}.")
 
 
 def _migrate_one(name: str) -> bool:
-	"""Returns True if the doc was migrated; False if already migrated / empty."""
-	# Skip if any Sheet Cell rows already exist for this parent.
-	if frappe.db.exists("Sheet Cell", {"parent_sheet": name}):
-		return False
+    """Returns True if the doc was migrated; False if already migrated / empty."""
+    # Skip if any Sheet Cell rows already exist for this parent.
+    if frappe.db.exists("Sheet Cell", {"parent_sheet": name}):
+        return False
 
-	doc = frappe.get_doc("Sheet", name)
-	blob = (doc.sheets_data or "").strip()
-	if not blob or blob == "{}":
-		# Nothing to migrate; just initialize view + revision.
-		doc.view_json = doc.view_json or "{}"
-		doc.db_set("revision_id", 0, update_modified=False)
-		return False
+    doc = frappe.get_doc("Sheet", name)
+    blob = (doc.sheets_data or "").strip()
+    if not blob or blob == "{}":
+        # Nothing to migrate; just initialize view + revision.
+        doc.view_json = doc.view_json or "{}"
+        doc.db_set("revision_id", 0, update_modified=False)
+        return False
 
-	try:
-		parsed = json.loads(blob)
-	except (ValueError, TypeError):
-		# Malformed blob — leave it alone so a developer can inspect.
-		return False
+    try:
+        parsed = json.loads(blob)
+    except (ValueError, TypeError):
+        # Malformed blob — leave it alone so a developer can inspect.
+        return False
 
-	sheets   = (parsed.get("sheet")   or {}).get("sheets", {}) or {}
-	formats  = parsed.get("formats")  or {}
-	merge    = parsed.get("merge")    or None
-	view     = parsed.get("view")     or {}
-	current  = (parsed.get("sheet")   or {}).get("current", "Sheet1")
+    sheets = (parsed.get("sheet") or {}).get("sheets", {}) or {}
+    formats = parsed.get("formats") or {}
+    merge = parsed.get("merge") or None
+    view = parsed.get("view") or {}
+    current = (parsed.get("sheet") or {}).get("current", "Sheet1")
 
-	# Each Sheet Cell row corresponds to one populated cell. Empty cells are
-	# not stored — same as the old blob.
-	rows = []
-	for sheet_name, cells in suite.sheets.items():
-		for cell_id, raw in cells.items():
-			if raw is None or raw == "":
-				continue
-			fmt = ((formats.get(sheet_name) or {}).get(cell_id)) or None
-			rows.append((
-				frappe.generate_hash(length=10),
-				name,
-				sheet_name,
-				cell_id,
-				str(raw),
-				json.dumps(fmt) if fmt else None,
-			))
+    # Each Sheet Cell row corresponds to one populated cell. Empty cells are
+    # not stored — same as the old blob.
+    rows = []
+    for sheet_name, cells in suite.sheets.items():
+        for cell_id, raw in cells.items():
+            if raw is None or raw == "":
+                continue
+            fmt = ((formats.get(sheet_name) or {}).get(cell_id)) or None
+            rows.append(
+                (
+                    frappe.generate_hash(length=10),
+                    name,
+                    sheet_name,
+                    cell_id,
+                    str(raw),
+                    json.dumps(fmt) if fmt else None,
+                )
+            )
 
-	if rows:
-		frappe.db.bulk_insert(
-			"Sheet Cell",
-			fields=["name", "parent_sheet", "sheet_name", "cell_id", "raw_value", "format_json"],
-			values=rows,
-		)
+    if rows:
+        frappe.db.bulk_insert(
+            "Sheet Cell",
+            fields=["name", "parent_sheet", "sheet_name", "cell_id", "raw_value", "format_json"],
+            values=rows,
+        )
 
-	# Stash workbook-level state on the parent. `view_json` carries everything
-	# the v2 reader needs to reconstitute the workbook beyond raw cells:
-	# - sheet order
-	# - which sheet was current
-	# - col widths / row heights / freeze / hidden / merge / zoom from grid
-	combined_view = {
-		"sheet_order":  list(suite.sheets.keys()),
-		"current":      current,
-		"merge":        merge,
-		"grid":         view,
-	}
-	doc.view_json = json.dumps(combined_view)
-	doc.db_set("revision_id", 1, update_modified=False)
-	doc.save(ignore_permissions=True)
-	return True
+    # Stash workbook-level state on the parent. `view_json` carries everything
+    # the v2 reader needs to reconstitute the workbook beyond raw cells:
+    # - sheet order
+    # - which sheet was current
+    # - col widths / row heights / freeze / hidden / merge / zoom from grid
+    combined_view = {
+        "sheet_order": list(suite.sheets.keys()),
+        "current": current,
+        "merge": merge,
+        "grid": view,
+    }
+    doc.view_json = json.dumps(combined_view)
+    doc.db_set("revision_id", 1, update_modified=False)
+    doc.save(ignore_permissions=True)
+    return True

--- a/suite/sheets/permissions.py
+++ b/suite/sheets/permissions.py
@@ -26,78 +26,76 @@ _PRIVILEGED_ROLES = frozenset({"Administrator", "System Manager"})
 
 
 def sheet_op_log_query(user: str | None = None) -> str:
-	return _scope_to_readable_sheets("`tabSheet Op Log`", user)
+    return _scope_to_readable_sheets("`tabSheet Op Log`", user)
 
 
 def sheet_snapshot_query(user: str | None = None) -> str:
-	return _scope_to_readable_sheets("`tabSheet Snapshot`", user)
+    return _scope_to_readable_sheets("`tabSheet Snapshot`", user)
 
 
 def _scope_to_readable_sheets(table_prefix: str, user: str | None) -> str:
-	"""Return a SQL fragment restricting child rows to readable parent suite.sheets.
+    """Return a SQL fragment restricting child rows to readable parent suite.sheets.
 
-	Empty string = no restriction (privileged users). The fragment is AND'd
-	into the WHERE clause by Frappe's permission machinery.
-	"""
-	user = user or frappe.session.user
-	if _is_privileged(user):
-		return ""
-	user_lit = frappe.db.escape(user)
-	# Readable sheet = owned by caller OR shared with caller via DocShare.
-	# Mirrors the Sheet doctype's `if_owner` rule plus the standard share grant.
-	return (
-		f"{table_prefix}.sheet IN ("
-		f"SELECT name FROM `tabSheet` WHERE owner = {user_lit} "
-		f"UNION "
-		f"SELECT share_name FROM `tabDocShare` "
-		f"WHERE share_doctype = 'Sheet' AND user = {user_lit} AND `read` = 1"
-		f")"
-	)
+    Empty string = no restriction (privileged users). The fragment is AND'd
+    into the WHERE clause by Frappe's permission machinery.
+    """
+    user = user or frappe.session.user
+    if _is_privileged(user):
+        return ""
+    user_lit = frappe.db.escape(user)
+    # Readable sheet = owned by caller OR shared with caller via DocShare.
+    # Mirrors the Sheet doctype's `if_owner` rule plus the standard share grant.
+    return (
+        f"{table_prefix}.sheet IN ("
+        f"SELECT name FROM `tabSheet` WHERE owner = {user_lit} "
+        f"UNION "
+        f"SELECT share_name FROM `tabDocShare` "
+        f"WHERE share_doctype = 'Sheet' AND user = {user_lit} AND `read` = 1"
+        f")"
+    )
 
 
 # ── has_permission ───────────────────────────────────────────────────────────
 
 
 def sheet_op_log_has_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
-	return _child_has_permission(doc, ptype, user)
+    return _child_has_permission(doc, ptype, user)
 
 
 def sheet_snapshot_has_permission(doc, ptype: str = "read", user: str | None = None) -> bool:
-	return _child_has_permission(doc, ptype, user)
+    return _child_has_permission(doc, ptype, user)
 
 
 def _child_has_permission(doc, ptype: str, user: str | None) -> bool:
-	"""Per-doc gate: a child row is readable iff its parent Sheet is readable.
+    """Per-doc gate: a child row is readable iff its parent Sheet is readable.
 
-	Mutations on a child are gated on *write* on the parent — these doctypes
-	are append-only logs that nobody should be hand-editing via the Desk or
-	the client API anyway (internal writers use `ignore_permissions=True`).
-	"""
-	user = user or frappe.session.user
-	if _is_privileged(user):
-		return True
-	sheet_name = _extract_sheet(doc)
-	if not sheet_name:
-		return False
-	parent_ptype = "read" if ptype in _READ_PTYPES else "write"
-	return bool(
-		frappe.has_permission("Sheet", doc=sheet_name, ptype=parent_ptype, user=user)
-	)
+    Mutations on a child are gated on *write* on the parent — these doctypes
+    are append-only logs that nobody should be hand-editing via the Desk or
+    the client API anyway (internal writers use `ignore_permissions=True`).
+    """
+    user = user or frappe.session.user
+    if _is_privileged(user):
+        return True
+    sheet_name = _extract_sheet(doc)
+    if not sheet_name:
+        return False
+    parent_ptype = "read" if ptype in _READ_PTYPES else "write"
+    return bool(frappe.has_permission("Sheet", doc=sheet_name, ptype=parent_ptype, user=user))
 
 
 _READ_PTYPES = frozenset({"read", "report", "export", "email", "print", "select"})
 
 
 def _extract_sheet(doc) -> str | None:
-	"""Pull the parent sheet name from either a Document or a plain dict."""
-	if doc is None:
-		return None
-	if isinstance(doc, dict):
-		return doc.get("sheet")
-	return getattr(doc, "sheet", None)
+    """Pull the parent sheet name from either a Document or a plain dict."""
+    if doc is None:
+        return None
+    if isinstance(doc, dict):
+        return doc.get("sheet")
+    return getattr(doc, "sheet", None)
 
 
 def _is_privileged(user: str) -> bool:
-	if user == "Administrator":
-		return True
-	return bool(_PRIVILEGED_ROLES.intersection(frappe.get_roles(user)))
+    if user == "Administrator":
+        return True
+    return bool(_PRIVILEGED_ROLES.intersection(frappe.get_roles(user)))

--- a/suite/sheets/tests/test_api_security.py
+++ b/suite/sheets/tests/test_api_security.py
@@ -16,124 +16,114 @@ from unittest import mock
 
 
 class _PermCheckBase(unittest.TestCase):
-	def setUp(self):
-		patcher = mock.patch("suite.sheets.api.frappe")
-		self.frappe = patcher.start()
-		self.addCleanup(patcher.stop)
-		self.frappe.session.user = "alice@example.com"
-		# `has_permission` returns True by default — endpoints proceed past
-		# the gate so we can also assert what they emit downstream.
-		self.frappe.has_permission.return_value = True
+    def setUp(self):
+        patcher = mock.patch("suite.sheets.api.frappe")
+        self.frappe = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.frappe.session.user = "alice@example.com"
+        # `has_permission` returns True by default — endpoints proceed past
+        # the gate so we can also assert what they emit downstream.
+        self.frappe.has_permission.return_value = True
 
 
 class BroadcastsRequireWrite(_PermCheckBase):
-	def test_broadcast_op_requires_write(self):
-		from suite.sheets import api
+    def test_broadcast_op_requires_write(self):
+        from suite.sheets import api
 
-		api.broadcast_op("SH-1", '{"op_type":"edit"}')
-		self.frappe.has_permission.assert_called_with(
-			"Sheet", doc="SH-1", ptype="write", throw=True
-		)
+        api.broadcast_op("SH-1", '{"op_type":"edit"}')
+        self.frappe.has_permission.assert_called_with("Sheet", doc="SH-1", ptype="write", throw=True)
 
-	def test_yjs_update_requires_write(self):
-		from suite.sheets import api
+    def test_yjs_update_requires_write(self):
+        from suite.sheets import api
 
-		api.yjs_relay("SH-1", "yjs_update", "<opaque>")
-		self.frappe.has_permission.assert_called_with(
-			"Sheet", doc="SH-1", ptype="write", throw=True
-		)
+        api.yjs_relay("SH-1", "yjs_update", "<opaque>")
+        self.frappe.has_permission.assert_called_with("Sheet", doc="SH-1", ptype="write", throw=True)
 
-	def test_yjs_state_requires_write(self):
-		from suite.sheets import api
+    def test_yjs_state_requires_write(self):
+        from suite.sheets import api
 
-		api.yjs_relay("SH-1", "yjs_state", "<opaque>")
-		self.frappe.has_permission.assert_called_with(
-			"Sheet", doc="SH-1", ptype="write", throw=True
-		)
+        api.yjs_relay("SH-1", "yjs_state", "<opaque>")
+        self.frappe.has_permission.assert_called_with("Sheet", doc="SH-1", ptype="write", throw=True)
 
 
 class PresenceStaysRead(_PermCheckBase):
-	def test_ping_presence_is_read(self):
-		from suite.sheets import api
+    def test_ping_presence_is_read(self):
+        from suite.sheets import api
 
-		# user_identity does a db lookup; stub the fields out.
-		self.frappe.db.get_value.return_value = ""
-		api.ping_presence("SH-1")
-		# Only the read-shape call matters here.
-		args, kwargs = self.frappe.has_permission.call_args
-		self.assertEqual(kwargs.get("doc"), "SH-1")
-		self.assertEqual(kwargs.get("throw"), True)
-		# No ptype kwarg ⇒ defaults to read.
-		self.assertNotIn("ptype", kwargs)
+        # user_identity does a db lookup; stub the fields out.
+        self.frappe.db.get_value.return_value = ""
+        api.ping_presence("SH-1")
+        # Only the read-shape call matters here.
+        args, kwargs = self.frappe.has_permission.call_args
+        self.assertEqual(kwargs.get("doc"), "SH-1")
+        self.assertEqual(kwargs.get("throw"), True)
+        # No ptype kwarg ⇒ defaults to read.
+        self.assertNotIn("ptype", kwargs)
 
-	def test_yjs_awareness_is_read(self):
-		from suite.sheets import api
+    def test_yjs_awareness_is_read(self):
+        from suite.sheets import api
 
-		api.yjs_relay("SH-1", "yjs_awareness", "<opaque>")
-		self.frappe.has_permission.assert_called_with(
-			"Sheet", doc="SH-1", ptype="read", throw=True
-		)
+        api.yjs_relay("SH-1", "yjs_awareness", "<opaque>")
+        self.frappe.has_permission.assert_called_with("Sheet", doc="SH-1", ptype="read", throw=True)
 
-	def test_yjs_state_request_is_read(self):
-		from suite.sheets import api
+    def test_yjs_state_request_is_read(self):
+        from suite.sheets import api
 
-		api.yjs_relay("SH-1", "yjs_state_request", "<opaque>")
-		self.frappe.has_permission.assert_called_with(
-			"Sheet", doc="SH-1", ptype="read", throw=True
-		)
+        api.yjs_relay("SH-1", "yjs_state_request", "<opaque>")
+        self.frappe.has_permission.assert_called_with("Sheet", doc="SH-1", ptype="read", throw=True)
 
 
 class UnknownYjsEventRejected(_PermCheckBase):
-	def test_unknown_event_throws_before_perm_check(self):
-		from suite.sheets import api
+    def test_unknown_event_throws_before_perm_check(self):
+        from suite.sheets import api
 
-		self.frappe.throw.side_effect = RuntimeError("nope")
-		with self.assertRaises(RuntimeError):
-			api.yjs_relay("SH-1", "yjs_eval_payload", "<opaque>")
-		# Throw must fire before we even consult perms — otherwise an attacker
-		# can use the perm check as an oracle for sheet existence.
-		self.frappe.has_permission.assert_not_called()
+        self.frappe.throw.side_effect = RuntimeError("nope")
+        with self.assertRaises(RuntimeError):
+            api.yjs_relay("SH-1", "yjs_eval_payload", "<opaque>")
+        # Throw must fire before we even consult perms — otherwise an attacker
+        # can use the perm check as an oracle for sheet existence.
+        self.frappe.has_permission.assert_not_called()
 
 
 class ShareSheetRejectsDisabledUsers(_PermCheckBase):
-	def test_disabled_user_rejected(self):
-		from suite.sheets import api
+    def test_disabled_user_rejected(self):
+        from suite.sheets import api
 
-		# `enabled = 0` → throw.
-		self.frappe.db.get_value.return_value = 0
-		self.frappe.throw.side_effect = RuntimeError("disabled")
-		with self.assertRaises(RuntimeError):
-			api.share_sheet("SH-1", "bob@example.com")
-		self.frappe.share.add.assert_not_called()
+        # `enabled = 0` → throw.
+        self.frappe.db.get_value.return_value = 0
+        self.frappe.throw.side_effect = RuntimeError("disabled")
+        with self.assertRaises(RuntimeError):
+            api.share_sheet("SH-1", "bob@example.com")
+        self.frappe.share.add.assert_not_called()
 
-	def test_missing_user_rejected(self):
-		from suite.sheets import api
+    def test_missing_user_rejected(self):
+        from suite.sheets import api
 
-		self.frappe.db.get_value.return_value = None
-		self.frappe.throw.side_effect = RuntimeError("not found")
-		with self.assertRaises(RuntimeError):
-			api.share_sheet("SH-1", "ghost@example.com")
-		self.frappe.share.add.assert_not_called()
+        self.frappe.db.get_value.return_value = None
+        self.frappe.throw.side_effect = RuntimeError("not found")
+        with self.assertRaises(RuntimeError):
+            api.share_sheet("SH-1", "ghost@example.com")
+        self.frappe.share.add.assert_not_called()
 
-	def test_enabled_user_shared(self):
-		from suite.sheets import api
+    def test_enabled_user_shared(self):
+        from suite.sheets import api
 
-		self.frappe.db.get_value.return_value = 1
-		api.share_sheet("SH-1", "bob@example.com", write=1)
-		self.frappe.share.add.assert_called_once()
+        self.frappe.db.get_value.return_value = 1
+        api.share_sheet("SH-1", "bob@example.com", write=1)
+        self.frappe.share.add.assert_called_once()
 
 
 class RenameSheetGated(_PermCheckBase):
-	def test_rename_checks_write_before_load(self):
-		from suite.sheets import api
+    def test_rename_checks_write_before_load(self):
+        from suite.sheets import api
 
-		self.frappe.get_doc.return_value = mock.Mock(name="SH-1")
-		api.rename_sheet("SH-1", "New title")
-		# Write perm must be the first thing checked.
-		first_call = self.frappe.has_permission.call_args_list[0]
-		self.assertEqual(first_call.kwargs.get("ptype"), "write")
-		self.assertEqual(first_call.kwargs.get("doc"), "SH-1")
+        self.frappe.get_doc.return_value = mock.Mock(name="SH-1")
+        api.rename_sheet("SH-1", "New title")
+        # Write perm must be the first thing checked.
+        first_call = self.frappe.has_permission.call_args_list[0]
+        self.assertEqual(first_call.kwargs.get("ptype"), "write")
+        self.assertEqual(first_call.kwargs.get("doc"), "SH-1")
 
 
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()

--- a/suite/sheets/tests/test_boot.py
+++ b/suite/sheets/tests/test_boot.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import unittest
 from unittest import mock
 
-from suite.sheets import boot as _boot  # noqa: F401  — see test_collab.py
+from suite.sheets import boot as _boot
 
 
 class ExtendBootinfo(unittest.TestCase):

--- a/suite/sheets/tests/test_boot.py
+++ b/suite/sheets/tests/test_boot.py
@@ -11,44 +11,44 @@ from suite.sheets import boot as _boot  # noqa: F401  — see test_collab.py
 
 
 class ExtendBootinfo(unittest.TestCase):
-	def setUp(self):
-		patcher = mock.patch("suite.sheets.boot.frappe")
-		self.frappe = patcher.start()
-		self.addCleanup(patcher.stop)
+    def setUp(self):
+        patcher = mock.patch("suite.sheets.boot.frappe")
+        self.frappe = patcher.start()
+        self.addCleanup(patcher.stop)
 
-	def _bootinfo(self):
-		class B:
-			pass
+    def _bootinfo(self):
+        class B:
+            pass
 
-		return B()
+        return B()
 
-	def test_defaults_to_legacy_path_when_unset(self):
-		from suite.sheets import boot
+    def test_defaults_to_legacy_path_when_unset(self):
+        from suite.sheets import boot
 
-		self.frappe.conf.get.return_value = None
-		b = self._bootinfo()
-		boot.extend_bootinfo(b)
-		self.assertEqual(b.collab_v2, False)
-		self.assertIsNone(b.collab_ws_url)
+        self.frappe.conf.get.return_value = None
+        b = self._bootinfo()
+        boot.extend_bootinfo(b)
+        self.assertEqual(b.collab_v2, False)
+        self.assertIsNone(b.collab_ws_url)
 
-	def test_picks_up_site_config_values(self):
-		from suite.sheets import boot
+    def test_picks_up_site_config_values(self):
+        from suite.sheets import boot
 
-		# Distinct return values per key, in lookup order.
-		self.frappe.conf.get.side_effect = lambda key: {
-			"collab_v2": True,
-			"collab_ws_url": "wss://example.invalid/collab/",
-		}.get(key)
-		b = self._bootinfo()
-		boot.extend_bootinfo(b)
-		self.assertTrue(b.collab_v2)
-		self.assertEqual(b.collab_ws_url, "wss://example.invalid/collab/")
+        # Distinct return values per key, in lookup order.
+        self.frappe.conf.get.side_effect = lambda key: {
+            "collab_v2": True,
+            "collab_ws_url": "wss://example.invalid/collab/",
+        }.get(key)
+        b = self._bootinfo()
+        boot.extend_bootinfo(b)
+        self.assertTrue(b.collab_v2)
+        self.assertEqual(b.collab_ws_url, "wss://example.invalid/collab/")
 
-	def test_collab_v2_is_truthy_coerced_to_bool(self):
-		# site_config sometimes holds 1/0 rather than literal True/False.
-		from suite.sheets import boot
+    def test_collab_v2_is_truthy_coerced_to_bool(self):
+        # site_config sometimes holds 1/0 rather than literal True/False.
+        from suite.sheets import boot
 
-		self.frappe.conf.get.side_effect = lambda key: {"collab_v2": 1}.get(key)
-		b = self._bootinfo()
-		boot.extend_bootinfo(b)
-		self.assertIs(b.collab_v2, True)
+        self.frappe.conf.get.side_effect = lambda key: {"collab_v2": 1}.get(key)
+        b = self._bootinfo()
+        boot.extend_bootinfo(b)
+        self.assertIs(b.collab_v2, True)

--- a/suite/sheets/tests/test_collab.py
+++ b/suite/sheets/tests/test_collab.py
@@ -18,7 +18,7 @@ from unittest import mock
 # Eagerly import the module under test so `mock.patch("suite.sheets.collab.frappe")`
 # can resolve the attribute — the patcher's lazy import doesn't populate
 # `suite.sheets.collab` on the parent package.
-from suite.sheets import collab as _collab  # noqa: F401
+from suite.sheets import collab as _collab
 
 
 def _patched_frappe():

--- a/suite/sheets/tests/test_collab.py
+++ b/suite/sheets/tests/test_collab.py
@@ -22,161 +22,159 @@ from suite.sheets import collab as _collab  # noqa: F401
 
 
 def _patched_frappe():
-	"""Patch ``suite.sheets.collab.frappe`` with a baseline-permissive mock."""
-	patcher = mock.patch("suite.sheets.collab.frappe")
-	frappe = patcher.start()
-	frappe.session.user = "alice@example.com"
-	frappe.has_permission.return_value = True
-	frappe.conf.get.return_value = "shh-its-a-secret"
-	frappe.get_request_header.return_value = "shh-its-a-secret"
-	frappe.db.exists.return_value = True
-	frappe.db.get_value.return_value = ""
-	frappe.utils.now.return_value = "2026-06-03 12:00:00"
-	# Real AuthenticationError so `raises` checks line up with what
-	# Frappe raises in prod.
-	frappe.AuthenticationError = type("AuthenticationError", (Exception,), {})
-	frappe.DoesNotExistError = type("DoesNotExistError", (Exception,), {})
-	frappe.throw.side_effect = lambda msg, exc=Exception: (_ for _ in ()).throw(exc(msg))
-	return frappe, patcher
+    """Patch ``suite.sheets.collab.frappe`` with a baseline-permissive mock."""
+    patcher = mock.patch("suite.sheets.collab.frappe")
+    frappe = patcher.start()
+    frappe.session.user = "alice@example.com"
+    frappe.has_permission.return_value = True
+    frappe.conf.get.return_value = "shh-its-a-secret"
+    frappe.get_request_header.return_value = "shh-its-a-secret"
+    frappe.db.exists.return_value = True
+    frappe.db.get_value.return_value = ""
+    frappe.utils.now.return_value = "2026-06-03 12:00:00"
+    # Real AuthenticationError so `raises` checks line up with what
+    # Frappe raises in prod.
+    frappe.AuthenticationError = type("AuthenticationError", (Exception,), {})
+    frappe.DoesNotExistError = type("DoesNotExistError", (Exception,), {})
+    frappe.throw.side_effect = lambda msg, exc=Exception: (_ for _ in ()).throw(exc(msg))
+    return frappe, patcher
 
 
 class CheckCollabAccess(unittest.TestCase):
-	def setUp(self):
-		self.frappe, patcher = _patched_frappe()
-		self.addCleanup(patcher.stop)
+    def setUp(self):
+        self.frappe, patcher = _patched_frappe()
+        self.addCleanup(patcher.stop)
 
-	def test_rejects_guest(self):
-		from suite.sheets import collab
+    def test_rejects_guest(self):
+        from suite.sheets import collab
 
-		self.frappe.session.user = "Guest"
-		with self.assertRaises(self.frappe.AuthenticationError):
-			collab.check_collab_access("SH-1")
+        self.frappe.session.user = "Guest"
+        with self.assertRaises(self.frappe.AuthenticationError):
+            collab.check_collab_access("SH-1")
 
-	def test_no_read_returns_false_flags(self):
-		from suite.sheets import collab
+    def test_no_read_returns_false_flags(self):
+        from suite.sheets import collab
 
-		self.frappe.has_permission.return_value = False
-		out = collab.check_collab_access("SH-1")
-		self.assertEqual(out, {"canRead": False, "canWrite": False})
-		# Only the read probe should have run — no point asking about write
-		# once read is denied.
-		self.frappe.has_permission.assert_called_once_with(
-			"Sheet", doc="SH-1", ptype="read", throw=False
-		)
+        self.frappe.has_permission.return_value = False
+        out = collab.check_collab_access("SH-1")
+        self.assertEqual(out, {"canRead": False, "canWrite": False})
+        # Only the read probe should have run — no point asking about write
+        # once read is denied.
+        self.frappe.has_permission.assert_called_once_with("Sheet", doc="SH-1", ptype="read", throw=False)
 
-	def test_read_only_user_gets_view_grant(self):
-		from suite.sheets import collab
+    def test_read_only_user_gets_view_grant(self):
+        from suite.sheets import collab
 
-		# True for read, False for write.
-		self.frappe.has_permission.side_effect = [True, False]
-		out = collab.check_collab_access("SH-1")
-		self.assertTrue(out["canRead"])
-		self.assertFalse(out["canWrite"])
-		self.assertEqual(out["user"], "alice@example.com")
+        # True for read, False for write.
+        self.frappe.has_permission.side_effect = [True, False]
+        out = collab.check_collab_access("SH-1")
+        self.assertTrue(out["canRead"])
+        self.assertFalse(out["canWrite"])
+        self.assertEqual(out["user"], "alice@example.com")
 
-	def test_writer_gets_write_grant(self):
-		from suite.sheets import collab
+    def test_writer_gets_write_grant(self):
+        from suite.sheets import collab
 
-		self.frappe.has_permission.side_effect = [True, True]
-		out = collab.check_collab_access("SH-1")
-		self.assertTrue(out["canWrite"])
+        self.frappe.has_permission.side_effect = [True, True]
+        out = collab.check_collab_access("SH-1")
+        self.assertTrue(out["canWrite"])
 
 
 class CollabSecretGate(unittest.TestCase):
-	def setUp(self):
-		self.frappe, patcher = _patched_frappe()
-		self.addCleanup(patcher.stop)
+    def setUp(self):
+        self.frappe, patcher = _patched_frappe()
+        self.addCleanup(patcher.stop)
 
-	def test_load_rejects_missing_header(self):
-		from suite.sheets import collab
+    def test_load_rejects_missing_header(self):
+        from suite.sheets import collab
 
-		self.frappe.get_request_header.return_value = None
-		with self.assertRaises(self.frappe.AuthenticationError):
-			collab.load_collab_state("SH-1")
+        self.frappe.get_request_header.return_value = None
+        with self.assertRaises(self.frappe.AuthenticationError):
+            collab.load_collab_state("SH-1")
 
-	def test_load_rejects_wrong_secret(self):
-		from suite.sheets import collab
+    def test_load_rejects_wrong_secret(self):
+        from suite.sheets import collab
 
-		self.frappe.get_request_header.return_value = "wrong"
-		with self.assertRaises(self.frappe.AuthenticationError):
-			collab.load_collab_state("SH-1")
+        self.frappe.get_request_header.return_value = "wrong"
+        with self.assertRaises(self.frappe.AuthenticationError):
+            collab.load_collab_state("SH-1")
 
-	def test_load_rejects_unconfigured_server(self):
-		# Misconfigured site (no secret in site_config) must not silently
-		# accept anonymous callers — that would make every collab write
-		# unauthenticated.
-		from suite.sheets import collab
+    def test_load_rejects_unconfigured_server(self):
+        # Misconfigured site (no secret in site_config) must not silently
+        # accept anonymous callers — that would make every collab write
+        # unauthenticated.
+        from suite.sheets import collab
 
-		self.frappe.conf.get.return_value = None
-		with self.assertRaises(self.frappe.AuthenticationError):
-			collab.load_collab_state("SH-1")
+        self.frappe.conf.get.return_value = None
+        with self.assertRaises(self.frappe.AuthenticationError):
+            collab.load_collab_state("SH-1")
 
-	def test_persist_rejects_missing_header(self):
-		from suite.sheets import collab
+    def test_persist_rejects_missing_header(self):
+        from suite.sheets import collab
 
-		self.frappe.get_request_header.return_value = None
-		with self.assertRaises(self.frappe.AuthenticationError):
-			collab.persist_collab_state("SH-1", "<b64>", 10)
+        self.frappe.get_request_header.return_value = None
+        with self.assertRaises(self.frappe.AuthenticationError):
+            collab.persist_collab_state("SH-1", "<b64>", 10)
 
 
 class LoadCollabState(unittest.TestCase):
-	def setUp(self):
-		self.frappe, patcher = _patched_frappe()
-		self.addCleanup(patcher.stop)
+    def setUp(self):
+        self.frappe, patcher = _patched_frappe()
+        self.addCleanup(patcher.stop)
 
-	def test_returns_null_blob_when_missing(self):
-		from suite.sheets import collab
+    def test_returns_null_blob_when_missing(self):
+        from suite.sheets import collab
 
-		self.frappe.db.exists.return_value = False
-		out = collab.load_collab_state("SH-1")
-		self.assertEqual(out, {"sheet": "SH-1", "ydoc_state": None, "byte_size": 0})
+        self.frappe.db.exists.return_value = False
+        out = collab.load_collab_state("SH-1")
+        self.assertEqual(out, {"sheet": "SH-1", "ydoc_state": None, "byte_size": 0})
 
-	def test_returns_row_when_present(self):
-		from suite.sheets import collab
+    def test_returns_row_when_present(self):
+        from suite.sheets import collab
 
-		self.frappe.db.exists.return_value = True
-		self.frappe.db.get_value.return_value = {"ydoc_state": "<b64>", "byte_size": 42}
-		out = collab.load_collab_state("SH-1")
-		self.assertEqual(out["ydoc_state"], "<b64>")
-		self.assertEqual(out["byte_size"], 42)
+        self.frappe.db.exists.return_value = True
+        self.frappe.db.get_value.return_value = {"ydoc_state": "<b64>", "byte_size": 42}
+        out = collab.load_collab_state("SH-1")
+        self.assertEqual(out["ydoc_state"], "<b64>")
+        self.assertEqual(out["byte_size"], 42)
 
 
 class PersistCollabState(unittest.TestCase):
-	def setUp(self):
-		self.frappe, patcher = _patched_frappe()
-		self.addCleanup(patcher.stop)
+    def setUp(self):
+        self.frappe, patcher = _patched_frappe()
+        self.addCleanup(patcher.stop)
 
-	def test_rejects_when_sheet_missing(self):
-		from suite.sheets import collab
+    def test_rejects_when_sheet_missing(self):
+        from suite.sheets import collab
 
-		# `db.exists` returns False only for the Sheet existence check.
-		self.frappe.db.exists.side_effect = lambda dt, _: dt != "Sheet"
-		with self.assertRaises(self.frappe.DoesNotExistError):
-			collab.persist_collab_state("SH-1", "<b64>", 10)
+        # `db.exists` returns False only for the Sheet existence check.
+        self.frappe.db.exists.side_effect = lambda dt, _: dt != "Sheet"
+        with self.assertRaises(self.frappe.DoesNotExistError):
+            collab.persist_collab_state("SH-1", "<b64>", 10)
 
-	def test_updates_when_state_row_exists(self):
-		from suite.sheets import collab
+    def test_updates_when_state_row_exists(self):
+        from suite.sheets import collab
 
-		# Sheet exists AND state row exists → take UPDATE path.
-		self.frappe.db.exists.return_value = True
-		collab.persist_collab_state("SH-1", "<b64>", 99)
-		self.frappe.db.set_value.assert_called_once()
-		args, _ = self.frappe.db.set_value.call_args
-		self.assertEqual(args[0], "Sheet Collab State")
-		self.assertEqual(args[1], "SH-1")
-		self.assertEqual(args[2]["ydoc_state"], "<b64>")
-		self.assertEqual(args[2]["byte_size"], 99)
+        # Sheet exists AND state row exists → take UPDATE path.
+        self.frappe.db.exists.return_value = True
+        collab.persist_collab_state("SH-1", "<b64>", 99)
+        self.frappe.db.set_value.assert_called_once()
+        args, _ = self.frappe.db.set_value.call_args
+        self.assertEqual(args[0], "Sheet Collab State")
+        self.assertEqual(args[1], "SH-1")
+        self.assertEqual(args[2]["ydoc_state"], "<b64>")
+        self.assertEqual(args[2]["byte_size"], 99)
 
-	def test_inserts_when_state_row_missing(self):
-		from suite.sheets import collab
+    def test_inserts_when_state_row_missing(self):
+        from suite.sheets import collab
 
-		# Sheet exists but state row does not → take INSERT path.
-		self.frappe.db.exists.side_effect = lambda dt, _: dt == "Sheet"
-		doc = mock.MagicMock()
-		self.frappe.new_doc.return_value = doc
-		collab.persist_collab_state("SH-1", "<b64>", 7)
-		self.frappe.new_doc.assert_called_once_with("Sheet Collab State")
-		self.assertEqual(doc.sheet, "SH-1")
-		self.assertEqual(doc.ydoc_state, "<b64>")
-		self.assertEqual(doc.byte_size, 7)
-		doc.insert.assert_called_once_with(ignore_permissions=True)
+        # Sheet exists but state row does not → take INSERT path.
+        self.frappe.db.exists.side_effect = lambda dt, _: dt == "Sheet"
+        doc = mock.MagicMock()
+        self.frappe.new_doc.return_value = doc
+        collab.persist_collab_state("SH-1", "<b64>", 7)
+        self.frappe.new_doc.assert_called_once_with("Sheet Collab State")
+        self.assertEqual(doc.sheet, "SH-1")
+        self.assertEqual(doc.ydoc_state, "<b64>")
+        self.assertEqual(doc.byte_size, 7)
+        doc.insert.assert_called_once_with(ignore_permissions=True)

--- a/suite/sheets/tests/test_link_preview.py
+++ b/suite/sheets/tests/test_link_preview.py
@@ -12,54 +12,54 @@ from suite.sheets.link_preview import _validate_and_resolve
 
 
 def _addrinfo(*ips):
-	return [(None, None, None, None, (ip, 0)) for ip in ips]
+    return [(None, None, None, None, (ip, 0)) for ip in ips]
 
 
 class AssertPublicHttpUrl(unittest.TestCase):
-	def _allow(self, url, resolves_to="93.184.216.34"):
-		with mock.patch("suite.sheets.link_preview.socket.getaddrinfo", return_value=_addrinfo(resolves_to)):
-			_validate_and_resolve(url)  # must not raise
+    def _allow(self, url, resolves_to="93.184.216.34"):
+        with mock.patch("suite.sheets.link_preview.socket.getaddrinfo", return_value=_addrinfo(resolves_to)):
+            _validate_and_resolve(url)  # must not raise
 
-	def _block(self, url, resolves_to="93.184.216.34"):
-		with mock.patch("suite.sheets.link_preview.socket.getaddrinfo", return_value=_addrinfo(resolves_to)):
-			with self.assertRaises(frappe.ValidationError):
-				_validate_and_resolve(url)
+    def _block(self, url, resolves_to="93.184.216.34"):
+        with mock.patch("suite.sheets.link_preview.socket.getaddrinfo", return_value=_addrinfo(resolves_to)):
+            with self.assertRaises(frappe.ValidationError):
+                _validate_and_resolve(url)
 
-	def test_public_https_url_passes(self):
-		self._allow("https://frappe.io/")
-		self._allow("http://example.com/page?x=1")
+    def test_public_https_url_passes(self):
+        self._allow("https://frappe.io/")
+        self._allow("http://example.com/page?x=1")
 
-	def test_non_http_schemes_blocked(self):
-		self._block("ftp://example.com/")
-		self._block("file:///etc/passwd")
-		self._block("gopher://example.com/")
+    def test_non_http_schemes_blocked(self):
+        self._block("ftp://example.com/")
+        self._block("file:///etc/passwd")
+        self._block("gopher://example.com/")
 
-	def test_non_standard_ports_blocked(self):
-		self._block("http://example.com:8080/")
-		self._block("https://example.com:6379/")
+    def test_non_standard_ports_blocked(self):
+        self._block("http://example.com:8080/")
+        self._block("https://example.com:6379/")
 
-	def test_literal_private_and_loopback_ips_blocked(self):
-		self._block("http://127.0.0.1/", resolves_to="127.0.0.1")
-		self._block("http://10.1.2.3/", resolves_to="10.1.2.3")
-		self._block("http://192.168.0.10/", resolves_to="192.168.0.10")
-		self._block("http://169.254.169.254/", resolves_to="169.254.169.254")  # cloud metadata
-		self._block("http://[::1]/", resolves_to="::1")
+    def test_literal_private_and_loopback_ips_blocked(self):
+        self._block("http://127.0.0.1/", resolves_to="127.0.0.1")
+        self._block("http://10.1.2.3/", resolves_to="10.1.2.3")
+        self._block("http://192.168.0.10/", resolves_to="192.168.0.10")
+        self._block("http://169.254.169.254/", resolves_to="169.254.169.254")  # cloud metadata
+        self._block("http://[::1]/", resolves_to="::1")
 
-	def test_dns_pointing_at_private_space_blocked(self):
-		# A public-looking name whose A record is internal (DNS-based SSRF).
-		self._block("https://innocent.example.com/", resolves_to="10.0.0.5")
+    def test_dns_pointing_at_private_space_blocked(self):
+        # A public-looking name whose A record is internal (DNS-based SSRF).
+        self._block("https://innocent.example.com/", resolves_to="10.0.0.5")
 
-	def test_mixed_resolution_blocked_if_any_ip_private(self):
-		with mock.patch(
-			"suite.sheets.link_preview.socket.getaddrinfo",
-			return_value=_addrinfo("93.184.216.34", "127.0.0.1"),
-		):
-			with self.assertRaises(frappe.ValidationError):
-				_validate_and_resolve("https://tricky.example.com/")
+    def test_mixed_resolution_blocked_if_any_ip_private(self):
+        with mock.patch(
+            "suite.sheets.link_preview.socket.getaddrinfo",
+            return_value=_addrinfo("93.184.216.34", "127.0.0.1"),
+        ):
+            with self.assertRaises(frappe.ValidationError):
+                _validate_and_resolve("https://tricky.example.com/")
 
-	def test_unresolvable_host_blocked(self):
-		import socket as _socket
+    def test_unresolvable_host_blocked(self):
+        import socket as _socket
 
-		with mock.patch("suite.sheets.link_preview.socket.getaddrinfo", side_effect=_socket.gaierror):
-			with self.assertRaises(frappe.ValidationError):
-				_validate_and_resolve("https://no-such-host.invalid/")
+        with mock.patch("suite.sheets.link_preview.socket.getaddrinfo", side_effect=_socket.gaierror):
+            with self.assertRaises(frappe.ValidationError):
+                _validate_and_resolve("https://no-such-host.invalid/")

--- a/suite/sheets/tests/test_link_preview.py
+++ b/suite/sheets/tests/test_link_preview.py
@@ -8,6 +8,7 @@ import unittest
 from unittest import mock
 
 import frappe
+
 from suite.sheets.link_preview import _validate_and_resolve
 
 

--- a/suite/sheets/tests/test_list_sheets.py
+++ b/suite/sheets/tests/test_list_sheets.py
@@ -20,154 +20,159 @@ _DEFAULT_ORDER = "`tabSheet`.`modified` desc"
 
 
 class _ListSheetsBase(unittest.TestCase):
-	def setUp(self):
-		patcher = mock.patch("suite.sheets.api.frappe")
-		self.frappe = patcher.start()
-		self.addCleanup(patcher.stop)
-		self.frappe.session.user = ME
-		# The module calls frappe.utils.cint for clamping — give the mock a
-		# real implementation so the arithmetic works.
-		self.frappe.utils.cint.side_effect = _cint
-		self.frappe.utils.now.return_value = "2026-07-23 12:00:00.000001"
-		self.rows = [
-			{"name": "SH-1", "title": "Mine", "modified": "2026-07-22 10:00:00", "owner": ME},
-			{"name": "SH-2", "title": "Theirs", "modified": "2026-07-21 10:00:00", "owner": "bob@example.com"},
-		]
-		self.frappe.get_list.side_effect = [self.rows, [{"total": 42}]]
+    def setUp(self):
+        patcher = mock.patch("suite.sheets.api.frappe")
+        self.frappe = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.frappe.session.user = ME
+        # The module calls frappe.utils.cint for clamping — give the mock a
+        # real implementation so the arithmetic works.
+        self.frappe.utils.cint.side_effect = _cint
+        self.frappe.utils.now.return_value = "2026-07-23 12:00:00.000001"
+        self.rows = [
+            {"name": "SH-1", "title": "Mine", "modified": "2026-07-22 10:00:00", "owner": ME},
+            {
+                "name": "SH-2",
+                "title": "Theirs",
+                "modified": "2026-07-21 10:00:00",
+                "owner": "bob@example.com",
+            },
+        ]
+        self.frappe.get_list.side_effect = [self.rows, [{"total": 42}]]
 
-	def call(self, **kwargs):
-		from suite.sheets import api
+    def call(self, **kwargs):
+        from suite.sheets import api
 
-		return api.list_sheets(**kwargs)
+        return api.list_sheets(**kwargs)
 
-	def rows_kwargs(self):
-		return self.frappe.get_list.call_args_list[0].kwargs
+    def rows_kwargs(self):
+        return self.frappe.get_list.call_args_list[0].kwargs
 
-	def count_kwargs(self):
-		return self.frappe.get_list.call_args_list[1].kwargs
+    def count_kwargs(self):
+        return self.frappe.get_list.call_args_list[1].kwargs
 
 
 class Defaults(_ListSheetsBase):
-	def test_default_window_and_order(self):
-		self.call()
-		kw = self.rows_kwargs()
-		self.assertEqual(kw["limit_start"], 0)
-		self.assertEqual(kw["limit_page_length"], 50)
-		self.assertEqual(kw["order_by"], _DEFAULT_ORDER)
-		self.assertEqual(kw["filters"], {"trashed": 0})
+    def test_default_window_and_order(self):
+        self.call()
+        kw = self.rows_kwargs()
+        self.assertEqual(kw["limit_start"], 0)
+        self.assertEqual(kw["limit_page_length"], 50)
+        self.assertEqual(kw["order_by"], _DEFAULT_ORDER)
+        self.assertEqual(kw["filters"], {"trashed": 0})
 
-	def test_response_shape_and_is_owner(self):
-		res = self.call()
-		self.assertEqual(res["total"], 42)
-		# Server-clock `now` rides along so the client buckets recency in the
-		# same timezone frame as `modified`.
-		self.assertEqual(res["now"], "2026-07-23 12:00:00.000001")
-		self.assertTrue(res["sheets"][0]["is_owner"])
-		self.assertFalse(res["sheets"][1]["is_owner"])
+    def test_response_shape_and_is_owner(self):
+        res = self.call()
+        self.assertEqual(res["total"], 42)
+        # Server-clock `now` rides along so the client buckets recency in the
+        # same timezone frame as `modified`.
+        self.assertEqual(res["now"], "2026-07-23 12:00:00.000001")
+        self.assertTrue(res["sheets"][0]["is_owner"])
+        self.assertFalse(res["sheets"][1]["is_owner"])
 
-	def test_count_uses_aggregate_with_same_filters(self):
-		self.call(search="foo", owner_filter="mine")
-		kw = self.count_kwargs()
-		# Frappe 17 dict field syntax — string "count(...)" fields are rejected.
-		self.assertEqual(kw["fields"], [{"COUNT": "*", "as": "total"}])
-		self.assertEqual(kw["filters"], self.rows_kwargs()["filters"])
+    def test_count_uses_aggregate_with_same_filters(self):
+        self.call(search="foo", owner_filter="mine")
+        kw = self.count_kwargs()
+        # Frappe 17 dict field syntax — string "count(...)" fields are rejected.
+        self.assertEqual(kw["fields"], [{"COUNT": "*", "as": "total"}])
+        self.assertEqual(kw["filters"], self.rows_kwargs()["filters"])
 
 
 class OrderBy(_ListSheetsBase):
-	def test_known_key_and_direction_map_to_literals(self):
-		self.call(order_by="title", sort_dir="asc")
-		self.assertEqual(self.rows_kwargs()["order_by"], "`tabSheet`.`title` asc")
+    def test_known_key_and_direction_map_to_literals(self):
+        self.call(order_by="title", sort_dir="asc")
+        self.assertEqual(self.rows_kwargs()["order_by"], "`tabSheet`.`title` asc")
 
-	def test_direction_toggles_to_descending(self):
-		self.call(order_by="title", sort_dir="desc")
-		self.assertEqual(self.rows_kwargs()["order_by"], "`tabSheet`.`title` desc")
+    def test_direction_toggles_to_descending(self):
+        self.call(order_by="title", sort_dir="desc")
+        self.assertEqual(self.rows_kwargs()["order_by"], "`tabSheet`.`title` desc")
 
-	def test_owner_sort_keeps_modified_tiebreak_in_both_directions(self):
-		self.call(order_by="owner", sort_dir="asc")
-		self.assertEqual(
-			self.rows_kwargs()["order_by"],
-			"`tabSheet`.`owner` asc, `tabSheet`.`modified` desc",
-		)
-		# desc flips only the owner term; the modified-desc tiebreak stays.
-		self.frappe.get_list.reset_mock()
-		self.frappe.get_list.side_effect = [self.rows, [{"total": 42}]]
-		self.call(order_by="owner", sort_dir="desc")
-		self.assertEqual(
-			self.rows_kwargs()["order_by"],
-			"`tabSheet`.`owner` desc, `tabSheet`.`modified` desc",
-		)
+    def test_owner_sort_keeps_modified_tiebreak_in_both_directions(self):
+        self.call(order_by="owner", sort_dir="asc")
+        self.assertEqual(
+            self.rows_kwargs()["order_by"],
+            "`tabSheet`.`owner` asc, `tabSheet`.`modified` desc",
+        )
+        # desc flips only the owner term; the modified-desc tiebreak stays.
+        self.frappe.get_list.reset_mock()
+        self.frappe.get_list.side_effect = [self.rows, [{"total": 42}]]
+        self.call(order_by="owner", sort_dir="desc")
+        self.assertEqual(
+            self.rows_kwargs()["order_by"],
+            "`tabSheet`.`owner` desc, `tabSheet`.`modified` desc",
+        )
 
-	def test_unknown_order_by_falls_back_to_default(self):
-		malicious = "modified desc; DROP TABLE `tabSheet`--"
-		self.call(order_by=malicious)
-		kw = self.rows_kwargs()
-		self.assertEqual(kw["order_by"], _DEFAULT_ORDER)
-		# The caller's string must not appear anywhere in the query kwargs.
-		for call in self.frappe.get_list.call_args_list:
-			self.assertNotIn(malicious, repr(call))
+    def test_unknown_order_by_falls_back_to_default(self):
+        malicious = "modified desc; DROP TABLE `tabSheet`--"
+        self.call(order_by=malicious)
+        kw = self.rows_kwargs()
+        self.assertEqual(kw["order_by"], _DEFAULT_ORDER)
+        # The caller's string must not appear anywhere in the query kwargs.
+        for call in self.frappe.get_list.call_args_list:
+            self.assertNotIn(malicious, repr(call))
 
-	def test_unknown_direction_falls_back_to_desc(self):
-		# Direction is clamped to the "asc"/"desc" literals just like the
-		# column — anything else can't reach the ORDER BY clause as free text.
-		malicious = "asc; DROP TABLE `tabSheet`--"
-		self.call(order_by="modified", sort_dir=malicious)
-		kw = self.rows_kwargs()
-		self.assertEqual(kw["order_by"], _DEFAULT_ORDER)
-		for call in self.frappe.get_list.call_args_list:
-			self.assertNotIn(malicious, repr(call))
+    def test_unknown_direction_falls_back_to_desc(self):
+        # Direction is clamped to the "asc"/"desc" literals just like the
+        # column — anything else can't reach the ORDER BY clause as free text.
+        malicious = "asc; DROP TABLE `tabSheet`--"
+        self.call(order_by="modified", sort_dir=malicious)
+        kw = self.rows_kwargs()
+        self.assertEqual(kw["order_by"], _DEFAULT_ORDER)
+        for call in self.frappe.get_list.call_args_list:
+            self.assertNotIn(malicious, repr(call))
 
 
 class OwnerFilter(_ListSheetsBase):
-	def test_mine(self):
-		self.call(owner_filter="mine")
-		self.assertEqual(self.rows_kwargs()["filters"]["owner"], ME)
+    def test_mine(self):
+        self.call(owner_filter="mine")
+        self.assertEqual(self.rows_kwargs()["filters"]["owner"], ME)
 
-	def test_shared(self):
-		self.call(owner_filter="shared")
-		self.assertEqual(self.rows_kwargs()["filters"]["owner"], ["!=", ME])
+    def test_shared(self):
+        self.call(owner_filter="shared")
+        self.assertEqual(self.rows_kwargs()["filters"]["owner"], ["!=", ME])
 
-	def test_unknown_means_all(self):
-		self.call(owner_filter="everything-please")
-		self.assertNotIn("owner", self.rows_kwargs()["filters"])
+    def test_unknown_means_all(self):
+        self.call(owner_filter="everything-please")
+        self.assertNotIn("owner", self.rows_kwargs()["filters"])
 
 
 class Search(_ListSheetsBase):
-	def test_search_is_trimmed_like_filter(self):
-		self.call(search="  foo  ")
-		self.assertEqual(self.rows_kwargs()["filters"]["title"], ["like", "%foo%"])
+    def test_search_is_trimmed_like_filter(self):
+        self.call(search="  foo  ")
+        self.assertEqual(self.rows_kwargs()["filters"]["title"], ["like", "%foo%"])
 
-	def test_blank_search_adds_no_filter(self):
-		self.call(search="   ")
-		self.assertNotIn("title", self.rows_kwargs()["filters"])
+    def test_blank_search_adds_no_filter(self):
+        self.call(search="   ")
+        self.assertNotIn("title", self.rows_kwargs()["filters"])
 
 
 class WindowClamping(_ListSheetsBase):
-	def test_limit_capped_at_100(self):
-		self.call(limit=1000)
-		self.assertEqual(self.rows_kwargs()["limit_page_length"], 100)
+    def test_limit_capped_at_100(self):
+        self.call(limit=1000)
+        self.assertEqual(self.rows_kwargs()["limit_page_length"], 100)
 
-	def test_zero_limit_uses_default(self):
-		self.call(limit=0)
-		self.assertEqual(self.rows_kwargs()["limit_page_length"], 50)
+    def test_zero_limit_uses_default(self):
+        self.call(limit=0)
+        self.assertEqual(self.rows_kwargs()["limit_page_length"], 50)
 
-	def test_negative_start_clamped_to_zero(self):
-		self.call(start=-5)
-		self.assertEqual(self.rows_kwargs()["limit_start"], 0)
+    def test_negative_start_clamped_to_zero(self):
+        self.call(start=-5)
+        self.assertEqual(self.rows_kwargs()["limit_start"], 0)
 
-	def test_string_params_from_http_are_coerced(self):
-		# Whitelisted endpoints receive query params as strings.
-		self.call(start="50", limit="25")
-		kw = self.rows_kwargs()
-		self.assertEqual(kw["limit_start"], 50)
-		self.assertEqual(kw["limit_page_length"], 25)
+    def test_string_params_from_http_are_coerced(self):
+        # Whitelisted endpoints receive query params as strings.
+        self.call(start="50", limit="25")
+        kw = self.rows_kwargs()
+        self.assertEqual(kw["limit_start"], 50)
+        self.assertEqual(kw["limit_page_length"], 25)
 
 
 def _cint(value):
-	try:
-		return int(float(value))
-	except (TypeError, ValueError):
-		return 0
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return 0
 
 
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()

--- a/suite/sheets/tests/test_permissions.py
+++ b/suite/sheets/tests/test_permissions.py
@@ -21,102 +21,90 @@ from suite.sheets import permissions
 
 
 def _esc(value):
-	return f"'{value}'"
+    return f"'{value}'"
 
 
 class QueryConditions(unittest.TestCase):
-	def test_administrator_gets_no_filter(self):
-		with mock.patch("suite.sheets.permissions.frappe") as f:
-			f.session.user = "Administrator"
-			self.assertEqual(permissions.sheet_op_log_query(), "")
-			self.assertEqual(permissions.sheet_snapshot_query(), "")
+    def test_administrator_gets_no_filter(self):
+        with mock.patch("suite.sheets.permissions.frappe") as f:
+            f.session.user = "Administrator"
+            self.assertEqual(permissions.sheet_op_log_query(), "")
+            self.assertEqual(permissions.sheet_snapshot_query(), "")
 
-	def test_system_manager_gets_no_filter(self):
-		with mock.patch("suite.sheets.permissions.frappe") as f:
-			f.session.user = "sm@example.com"
-			f.get_roles.return_value = ["System Manager", "All"]
-			self.assertEqual(permissions.sheet_op_log_query(), "")
+    def test_system_manager_gets_no_filter(self):
+        with mock.patch("suite.sheets.permissions.frappe") as f:
+            f.session.user = "sm@example.com"
+            f.get_roles.return_value = ["System Manager", "All"]
+            self.assertEqual(permissions.sheet_op_log_query(), "")
 
-	def test_regular_user_scoped_to_owned_and_shared(self):
-		with mock.patch("suite.sheets.permissions.frappe") as f:
-			f.session.user = "alice@example.com"
-			f.get_roles.return_value = ["All"]
-			f.db.escape.side_effect = _esc
-			sql = permissions.sheet_op_log_query()
-		# Restriction must reference both ownership and DocShare paths, AND
-		# must scope by the *caller's* identity (no other email leaked in).
-		self.assertIn("`tabSheet Op Log`.sheet IN", sql)
-		self.assertIn("FROM `tabSheet` WHERE owner = 'alice@example.com'", sql)
-		self.assertIn("FROM `tabDocShare`", sql)
-		self.assertIn("share_doctype = 'Sheet'", sql)
-		self.assertIn("user = 'alice@example.com'", sql)
+    def test_regular_user_scoped_to_owned_and_shared(self):
+        with mock.patch("suite.sheets.permissions.frappe") as f:
+            f.session.user = "alice@example.com"
+            f.get_roles.return_value = ["All"]
+            f.db.escape.side_effect = _esc
+            sql = permissions.sheet_op_log_query()
+        # Restriction must reference both ownership and DocShare paths, AND
+        # must scope by the *caller's* identity (no other email leaked in).
+        self.assertIn("`tabSheet Op Log`.sheet IN", sql)
+        self.assertIn("FROM `tabSheet` WHERE owner = 'alice@example.com'", sql)
+        self.assertIn("FROM `tabDocShare`", sql)
+        self.assertIn("share_doctype = 'Sheet'", sql)
+        self.assertIn("user = 'alice@example.com'", sql)
 
-	def test_snapshot_query_targets_snapshot_table(self):
-		with mock.patch("suite.sheets.permissions.frappe") as f:
-			f.session.user = "alice@example.com"
-			f.get_roles.return_value = ["All"]
-			f.db.escape.side_effect = _esc
-			sql = permissions.sheet_snapshot_query()
-		self.assertIn("`tabSheet Snapshot`.sheet IN", sql)
+    def test_snapshot_query_targets_snapshot_table(self):
+        with mock.patch("suite.sheets.permissions.frappe") as f:
+            f.session.user = "alice@example.com"
+            f.get_roles.return_value = ["All"]
+            f.db.escape.side_effect = _esc
+            sql = permissions.sheet_snapshot_query()
+        self.assertIn("`tabSheet Snapshot`.sheet IN", sql)
 
 
 class HasPermission(unittest.TestCase):
-	def test_admin_short_circuits(self):
-		with mock.patch("suite.sheets.permissions.frappe") as f:
-			f.session.user = "Administrator"
-			doc = mock.Mock(sheet="SH-1")
-			self.assertTrue(
-				permissions.sheet_op_log_has_permission(doc, ptype="read")
-			)
-			# `has_permission` on parent must not be consulted for the admin.
-			f.has_permission.assert_not_called()
+    def test_admin_short_circuits(self):
+        with mock.patch("suite.sheets.permissions.frappe") as f:
+            f.session.user = "Administrator"
+            doc = mock.Mock(sheet="SH-1")
+            self.assertTrue(permissions.sheet_op_log_has_permission(doc, ptype="read"))
+            # `has_permission` on parent must not be consulted for the admin.
+            f.has_permission.assert_not_called()
 
-	def test_read_on_child_delegates_to_read_on_parent(self):
-		with mock.patch("suite.sheets.permissions.frappe") as f:
-			f.session.user = "alice@example.com"
-			f.get_roles.return_value = ["All"]
-			f.has_permission.return_value = True
-			doc = mock.Mock(sheet="SH-1")
-			self.assertTrue(
-				permissions.sheet_op_log_has_permission(doc, ptype="read")
-			)
-			f.has_permission.assert_called_once_with(
-				"Sheet", doc="SH-1", ptype="read", user="alice@example.com"
-			)
+    def test_read_on_child_delegates_to_read_on_parent(self):
+        with mock.patch("suite.sheets.permissions.frappe") as f:
+            f.session.user = "alice@example.com"
+            f.get_roles.return_value = ["All"]
+            f.has_permission.return_value = True
+            doc = mock.Mock(sheet="SH-1")
+            self.assertTrue(permissions.sheet_op_log_has_permission(doc, ptype="read"))
+            f.has_permission.assert_called_once_with(
+                "Sheet", doc="SH-1", ptype="read", user="alice@example.com"
+            )
 
-	def test_write_on_child_requires_write_on_parent(self):
-		with mock.patch("suite.sheets.permissions.frappe") as f:
-			f.session.user = "alice@example.com"
-			f.get_roles.return_value = ["All"]
-			f.has_permission.return_value = False
-			doc = mock.Mock(sheet="SH-1")
-			self.assertFalse(
-				permissions.sheet_snapshot_has_permission(doc, ptype="write")
-			)
-			f.has_permission.assert_called_once_with(
-				"Sheet", doc="SH-1", ptype="write", user="alice@example.com"
-			)
+    def test_write_on_child_requires_write_on_parent(self):
+        with mock.patch("suite.sheets.permissions.frappe") as f:
+            f.session.user = "alice@example.com"
+            f.get_roles.return_value = ["All"]
+            f.has_permission.return_value = False
+            doc = mock.Mock(sheet="SH-1")
+            self.assertFalse(permissions.sheet_snapshot_has_permission(doc, ptype="write"))
+            f.has_permission.assert_called_once_with(
+                "Sheet", doc="SH-1", ptype="write", user="alice@example.com"
+            )
 
-	def test_doc_with_no_sheet_denied(self):
-		with mock.patch("suite.sheets.permissions.frappe") as f:
-			f.session.user = "alice@example.com"
-			f.get_roles.return_value = ["All"]
-			# Plain dict shape (Frappe sometimes hands raw dicts to the hook).
-			self.assertFalse(
-				permissions.sheet_op_log_has_permission({}, ptype="read")
-			)
+    def test_doc_with_no_sheet_denied(self):
+        with mock.patch("suite.sheets.permissions.frappe") as f:
+            f.session.user = "alice@example.com"
+            f.get_roles.return_value = ["All"]
+            # Plain dict shape (Frappe sometimes hands raw dicts to the hook).
+            self.assertFalse(permissions.sheet_op_log_has_permission({}, ptype="read"))
 
-	def test_dict_doc_extracts_sheet(self):
-		with mock.patch("suite.sheets.permissions.frappe") as f:
-			f.session.user = "alice@example.com"
-			f.get_roles.return_value = ["All"]
-			f.has_permission.return_value = True
-			self.assertTrue(
-				permissions.sheet_snapshot_has_permission(
-					{"sheet": "SH-7"}, ptype="read"
-				)
-			)
+    def test_dict_doc_extracts_sheet(self):
+        with mock.patch("suite.sheets.permissions.frappe") as f:
+            f.session.user = "alice@example.com"
+            f.get_roles.return_value = ["All"]
+            f.has_permission.return_value = True
+            self.assertTrue(permissions.sheet_snapshot_has_permission({"sheet": "SH-7"}, ptype="read"))
 
 
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()

--- a/suite/sheets/tests/test_share_notify.py
+++ b/suite/sheets/tests/test_share_notify.py
@@ -26,7 +26,7 @@ class CustomShareNotification(unittest.TestCase):
         self.frappe.has_permission.return_value = True
         # Recipient lookup (`enabled` check) — return 1 so share proceeds.
         self.frappe.db.get_value.side_effect = lambda dt, name, field=None: {
-            ("User", "bob@example.com", "enabled"):  1,
+            ("User", "bob@example.com", "enabled"): 1,
             ("User", "alice@example.com", "full_name"): "Alice",
         }.get((dt, name, field))
         # frappe.get_doc("Sheet", name) → mock title

--- a/suite/sheets/tests/test_www.py
+++ b/suite/sheets/tests/test_www.py
@@ -33,9 +33,7 @@ class AssetManifestResolution(unittest.TestCase):
         # structure under tmpdir.
         self.tmp = tempfile.TemporaryDirectory()
         self.addCleanup(self.tmp.cleanup)
-        self.manifest_dir = os.path.join(
-            self.tmp.name, "public", "sheets", ".vite"
-        )
+        self.manifest_dir = os.path.join(self.tmp.name, "public", "sheets", ".vite")
         os.makedirs(self.manifest_dir, exist_ok=True)
         self.manifest_path = os.path.join(self.manifest_dir, "manifest.json")
 
@@ -57,12 +55,14 @@ class AssetManifestResolution(unittest.TestCase):
             json.dump(payload, fh)
 
     def test_resolves_hashed_paths_from_manifest(self):
-        self._write_manifest({
-            "index.html": {
-                "file": "index.ABCDEF.js",
-                "css":  ["index.GHIJKL.css"],
-            },
-        })
+        self._write_manifest(
+            {
+                "index.html": {
+                    "file": "index.ABCDEF.js",
+                    "css": ["index.GHIJKL.css"],
+                },
+            }
+        )
         from suite.sheets.www import sheets as www
 
         paths = www._asset_paths()
@@ -90,21 +90,25 @@ class AssetManifestResolution(unittest.TestCase):
     def test_caches_within_a_single_mtime(self):
         # First call populates the cache; second call should return the
         # cached object without re-reading. We assert via the cache flag.
-        self._write_manifest({
-            "index.html": {"file": "index.A.js", "css": ["index.A.css"]},
-        })
+        self._write_manifest(
+            {
+                "index.html": {"file": "index.A.js", "css": ["index.A.css"]},
+            }
+        )
         from suite.sheets.www import sheets as www
 
-        first  = www._read_asset_manifest()
+        first = www._read_asset_manifest()
         second = www._read_asset_manifest()
         self.assertIs(first, second)  # exact object identity → cache hit
 
     def test_invalidates_cache_when_manifest_mtime_changes(self):
         # Simulates `vite build` overwriting the manifest. The cache
         # should pick up the new content without a worker restart.
-        self._write_manifest({
-            "index.html": {"file": "index.OLD.js", "css": []},
-        })
+        self._write_manifest(
+            {
+                "index.html": {"file": "index.OLD.js", "css": []},
+            }
+        )
         from suite.sheets.www import sheets as www
 
         first = www._read_asset_manifest()
@@ -113,9 +117,11 @@ class AssetManifestResolution(unittest.TestCase):
         # Bump mtime explicitly — writing a file on a fast disk can land
         # on the same second as the previous write and silently fool the
         # cache check.
-        self._write_manifest({
-            "index.html": {"file": "index.NEW.js", "css": []},
-        })
+        self._write_manifest(
+            {
+                "index.html": {"file": "index.NEW.js", "css": []},
+            }
+        )
         new_mtime = os.path.getmtime(self.manifest_path) + 5
         os.utime(self.manifest_path, (new_mtime, new_mtime))
 
@@ -133,17 +139,15 @@ class BootContext(unittest.TestCase):
         self.frappe = patcher.start()
         self.addCleanup(patcher.stop)
         self.frappe.session.user = "alice@example.com"
-        self.frappe.session.sid  = "sid-xyz"
-        self.frappe.db.get_value.side_effect = (
-            lambda doctype, name, field: {
-                "full_name":  "Alice",
-                "user_image": "",
-                "enabled":    1,
-            }.get(field)
-        )
+        self.frappe.session.sid = "sid-xyz"
+        self.frappe.db.get_value.side_effect = lambda doctype, name, field: {
+            "full_name": "Alice",
+            "user_image": "",
+            "enabled": 1,
+        }.get(field)
         self.frappe.local.site = "test.localhost"
         self.frappe.conf.get.side_effect = lambda key, default=None: {
-            "collab_v2":     0,
+            "collab_v2": 0,
             "collab_ws_url": None,
             "socketio_port": 9001,
         }.get(key, default)
@@ -152,6 +156,7 @@ class BootContext(unittest.TestCase):
         # Class-style context object — what Frappe's www renderer hands in.
         class _Context:
             pass
+
         self.ctx = _Context()
 
     def test_guest_is_redirected_to_login(self):
@@ -185,7 +190,7 @@ class BootContext(unittest.TestCase):
     def test_sentry_dsn_picked_up_from_site_config(self):
         self.frappe.conf.get.side_effect = lambda key, default=None: {
             "sheets_sentry_dsn": "https://k@o.ingest.sentry.io/p",
-            "developer_mode":         0,
+            "developer_mode": 0,
         }.get(key, default)
         from suite.sheets.www import sheets as www
 

--- a/suite/sheets/trash.py
+++ b/suite/sheets/trash.py
@@ -30,50 +30,50 @@ MIN_RETENTION_DAYS = 1
 
 
 def retention_days() -> int:
-	configured = frappe.conf.get("sheets_trash_retention_days")
-	if configured is None:
-		return DEFAULT_RETENTION_DAYS
-	return max(MIN_RETENTION_DAYS, int(configured))
+    configured = frappe.conf.get("sheets_trash_retention_days")
+    if configured is None:
+        return DEFAULT_RETENTION_DAYS
+    return max(MIN_RETENTION_DAYS, int(configured))
 
 
 def hard_delete_sheet(name: str) -> None:
-	"""Permanently erase a Sheet and its versioning tables, in dependency order.
+    """Permanently erase a Sheet and its versioning tables, in dependency order.
 
-	Frappe's default link enforcement blocks deletion while child rows exist, so
-	the head pointer is cleared first and the child tables are dropped directly
-	before the parent doc. This is the original `delete_sheet` cascade, moved
-	here so the "delete forever" endpoint and the purge job stay in lockstep.
-	"""
-	frappe.db.set_value("Sheet", name, "head_snapshot", None, update_modified=False)
-	frappe.db.delete("Sheet Snapshot", {"sheet": name})
-	frappe.db.delete("Sheet Op Log",   {"sheet": name})
-	frappe.db.delete("Sheet Seq",      {"sheet": name})
-	frappe.delete_doc("Sheet", name, ignore_permissions=True)
+    Frappe's default link enforcement blocks deletion while child rows exist, so
+    the head pointer is cleared first and the child tables are dropped directly
+    before the parent doc. This is the original `delete_sheet` cascade, moved
+    here so the "delete forever" endpoint and the purge job stay in lockstep.
+    """
+    frappe.db.set_value("Sheet", name, "head_snapshot", None, update_modified=False)
+    frappe.db.delete("Sheet Snapshot", {"sheet": name})
+    frappe.db.delete("Sheet Op Log", {"sheet": name})
+    frappe.db.delete("Sheet Seq", {"sheet": name})
+    frappe.delete_doc("Sheet", name, ignore_permissions=True)
 
 
 def purge_trashed_sheets() -> dict:
-	"""Permanently delete sheets trashed longer than the retention window.
+    """Permanently delete sheets trashed longer than the retention window.
 
-	Idempotent and safe to re-run. Commits per sheet so a mid-run failure
-	doesn't strand progress. Returns a counter for telemetry.
-	"""
-	cutoff = now_datetime() - timedelta(days=retention_days())
-	expired = frappe.get_all(
-		"Sheet",
-		filters={"trashed": 1, "trashed_on": ["<", cutoff]},
-		pluck="name",
-	)
-	purged = 0
-	for name in expired:
-		# Re-check current state before erasing. The snapshot above is a moment
-		# in time; a restore — or a restore-then-retrash with a fresh timestamp —
-		# may have landed since. Never purge a sheet the user just recovered.
-		row = frappe.db.get_value("Sheet", name, ["trashed", "trashed_on"], as_dict=True)
-		if not row or not row.trashed or not row.trashed_on:
-			continue
-		if get_datetime(row.trashed_on) >= cutoff:
-			continue
-		hard_delete_sheet(name)
-		frappe.db.commit()
-		purged += 1
-	return {"purged": purged}
+    Idempotent and safe to re-run. Commits per sheet so a mid-run failure
+    doesn't strand progress. Returns a counter for telemetry.
+    """
+    cutoff = now_datetime() - timedelta(days=retention_days())
+    expired = frappe.get_all(
+        "Sheet",
+        filters={"trashed": 1, "trashed_on": ["<", cutoff]},
+        pluck="name",
+    )
+    purged = 0
+    for name in expired:
+        # Re-check current state before erasing. The snapshot above is a moment
+        # in time; a restore — or a restore-then-retrash with a fresh timestamp —
+        # may have landed since. Never purge a sheet the user just recovered.
+        row = frappe.db.get_value("Sheet", name, ["trashed", "trashed_on"], as_dict=True)
+        if not row or not row.trashed or not row.trashed_on:
+            continue
+        if get_datetime(row.trashed_on) >= cutoff:
+            continue
+        hard_delete_sheet(name)
+        frappe.db.commit()
+        purged += 1
+    return {"purged": purged}

--- a/suite/sheets/versioning/api.py
+++ b/suite/sheets/versioning/api.py
@@ -33,105 +33,97 @@ from . import timeline as timeline_mod
 # stay where they are; these caps only kick in when the caller passes
 # an absurd value.
 _MAX_BUCKET_LIMIT = 200
-_MAX_PAGE_LIMIT   = 500
-_MAX_OPS_LIMIT    = 1000
+_MAX_PAGE_LIMIT = 500
+_MAX_OPS_LIMIT = 1000
 
 
 def _clamp(value: int, hi: int) -> int:
-	v = int(value)
-	if v < 1:
-		return 1
-	return v if v <= hi else hi
+    v = int(value)
+    if v < 1:
+        return 1
+    return v if v <= hi else hi
 
 
 @frappe.whitelist()
 def timeline(sheet: str, tz_offset_minutes: int = 0, bucket_limit: int = 20) -> dict:
-	return timeline_mod.list_buckets(
-		sheet,
-		tz_offset_minutes=int(tz_offset_minutes),
-		bucket_limit=_clamp(bucket_limit, _MAX_BUCKET_LIMIT),
-	)
+    return timeline_mod.list_buckets(
+        sheet,
+        tz_offset_minutes=int(tz_offset_minutes),
+        bucket_limit=_clamp(bucket_limit, _MAX_BUCKET_LIMIT),
+    )
 
 
 @frappe.whitelist()
 def timeline_page(
-	sheet: str,
-	bucket: str,
-	cursor: str = "",
-	limit: int = 20,
-	tz_offset_minutes: int = 0,
+    sheet: str,
+    bucket: str,
+    cursor: str = "",
+    limit: int = 20,
+    tz_offset_minutes: int = 0,
 ) -> dict:
-	return timeline_mod.list_bucket_page(
-		sheet,
-		bucket,
-		cursor=cursor or None,
-		limit=_clamp(limit, _MAX_PAGE_LIMIT),
-		tz_offset_minutes=int(tz_offset_minutes),
-	)
+    return timeline_mod.list_bucket_page(
+        sheet,
+        bucket,
+        cursor=cursor or None,
+        limit=_clamp(limit, _MAX_PAGE_LIMIT),
+        tz_offset_minutes=int(tz_offset_minutes),
+    )
 
 
 @frappe.whitelist()
 def save_snapshot(sheet: str, label: str = "") -> dict:
-	frappe.has_permission("Sheet", doc=sheet, ptype="write", throw=True)
-	clean = (label or "").strip()
-	if not clean:
-		frappe.throw("Label is required for a named snapshot")
-	name = snap_mod.create(sheet, kind=snap_mod.KIND_NAMED, label=clean)
-	return {"id": name}
+    frappe.has_permission("Sheet", doc=sheet, ptype="write", throw=True)
+    clean = (label or "").strip()
+    if not clean:
+        frappe.throw("Label is required for a named snapshot")
+    name = snap_mod.create(sheet, kind=snap_mod.KIND_NAMED, label=clean)
+    return {"id": name}
 
 
 @frappe.whitelist()
 def state_at(snapshot: str) -> dict:
-	return state_mod.at(snapshot)
+    return state_mod.at(snapshot)
 
 
 @frappe.whitelist()
 def restore(snapshot: str) -> dict:
-	snap = frappe.db.get_value("Sheet Snapshot", snapshot, "sheet")
-	if not snap:
-		frappe.throw(f"Snapshot {snapshot} not found")
-	frappe.has_permission("Sheet", doc=snap, ptype="write", throw=True)
-	return state_mod.restore(snapshot)
+    snap = frappe.db.get_value("Sheet Snapshot", snapshot, "sheet")
+    if not snap:
+        frappe.throw(f"Snapshot {snapshot} not found")
+    frappe.has_permission("Sheet", doc=snap, ptype="write", throw=True)
+    return state_mod.restore(snapshot)
 
 
 @frappe.whitelist()
 def label_snapshot(snapshot: str, label: str = "", pinned: int | None = None) -> dict:
-	return labels_mod.set_label(
-		snapshot,
-		label=label if label != "" else None,
-		pinned=None if pinned is None else bool(int(pinned)),
-	)
+    return labels_mod.set_label(
+        snapshot,
+        label=label if label != "" else None,
+        pinned=None if pinned is None else bool(int(pinned)),
+    )
 
 
 @frappe.whitelist()
 def delete_snapshot(snapshot: str) -> dict:
-	return labels_mod.delete(snapshot)
+    return labels_mod.delete(snapshot)
 
 
 @frappe.whitelist()
 def ops_between(sheet: str, from_seq: int, to_seq: int, limit: int = 200) -> list[dict]:
-	return ops_mod.between(
-		sheet, int(from_seq), int(to_seq), limit=_clamp(limit, _MAX_OPS_LIMIT)
-	)
+    return ops_mod.between(sheet, int(from_seq), int(to_seq), limit=_clamp(limit, _MAX_OPS_LIMIT))
 
 
 @frappe.whitelist()
-def ops_for_cell(
-	sheet: str, cell_id: str, sub_sheet: str = "", limit: int = 50
-) -> list[dict]:
-	return ops_mod.for_cell(
-		sheet, cell_id, sub_sheet=sub_sheet or None, limit=_clamp(limit, _MAX_OPS_LIMIT)
-	)
+def ops_for_cell(sheet: str, cell_id: str, sub_sheet: str = "", limit: int = 50) -> list[dict]:
+    return ops_mod.for_cell(sheet, cell_id, sub_sheet=sub_sheet or None, limit=_clamp(limit, _MAX_OPS_LIMIT))
 
 
 @frappe.whitelist()
 def head(sheet: str) -> dict:
-	frappe.has_permission("Sheet", doc=sheet, throw=True)
-	row = frappe.db.get_value(
-		"Sheet", sheet, ["head_seq", "head_snapshot"], as_dict=True
-	) or {}
-	return {
-		"sheet": sheet,
-		"head_seq": int(row.get("head_seq") or 0),
-		"head_snapshot": row.get("head_snapshot"),
-	}
+    frappe.has_permission("Sheet", doc=sheet, throw=True)
+    row = frappe.db.get_value("Sheet", sheet, ["head_seq", "head_snapshot"], as_dict=True) or {}
+    return {
+        "sheet": sheet,
+        "head_seq": int(row.get("head_seq") or 0),
+        "head_snapshot": row.get("head_snapshot"),
+    }

--- a/suite/sheets/versioning/api.py
+++ b/suite/sheets/versioning/api.py
@@ -24,7 +24,6 @@ from . import snapshots as snap_mod
 from . import state as state_mod
 from . import timeline as timeline_mod
 
-
 # Hard upper bounds on user-supplied `limit` parameters. The underlying
 # modules already gate on read permission, but an authenticated caller
 # could otherwise pass `limit=99_999_999` and force the DB to walk huge

--- a/suite/sheets/versioning/labels.py
+++ b/suite/sheets/versioning/labels.py
@@ -8,61 +8,59 @@ import frappe
 
 
 def set_label(snapshot_id: str, label: str | None, pinned: bool | None = None) -> dict:
-	"""Update a snapshot's label and/or pinned flag.
+    """Update a snapshot's label and/or pinned flag.
 
-	Setting a non-empty label implicitly promotes the snapshot to `kind=named`
-	and pins it; clearing the label demotes it back to `kind=auto` (unless
-	pinned was explicitly set).
-	"""
-	snap = frappe.get_doc("Sheet Snapshot", snapshot_id)
-	frappe.has_permission("Sheet", doc=snap.sheet, ptype="write", throw=True)
+    Setting a non-empty label implicitly promotes the snapshot to `kind=named`
+    and pins it; clearing the label demotes it back to `kind=auto` (unless
+    pinned was explicitly set).
+    """
+    snap = frappe.get_doc("Sheet Snapshot", snapshot_id)
+    frappe.has_permission("Sheet", doc=snap.sheet, ptype="write", throw=True)
 
-	if label is not None:
-		clean = label.strip()
-		snap.label = clean or None
-		if clean:
-			snap.kind = "named"
-			snap.pinned = 1
-		else:
-			# Cleared the label — demote unless caller insists on pinned.
-			snap.kind = "auto" if snap.kind == "named" else snap.kind
-			if pinned is None:
-				snap.pinned = 0
+    if label is not None:
+        clean = label.strip()
+        snap.label = clean or None
+        if clean:
+            snap.kind = "named"
+            snap.pinned = 1
+        else:
+            # Cleared the label — demote unless caller insists on pinned.
+            snap.kind = "auto" if snap.kind == "named" else snap.kind
+            if pinned is None:
+                snap.pinned = 0
 
-	if pinned is not None:
-		snap.pinned = 1 if pinned else 0
+    if pinned is not None:
+        snap.pinned = 1 if pinned else 0
 
-	snap.save(ignore_permissions=True)
-	return {"id": snap.name, "label": snap.label, "kind": snap.kind, "pinned": bool(snap.pinned)}
+    snap.save(ignore_permissions=True)
+    return {"id": snap.name, "label": snap.label, "kind": snap.kind, "pinned": bool(snap.pinned)}
 
 
 def delete(snapshot_id: str) -> dict:
-	"""Delete an unpinned snapshot. Pinned ones must be unpinned first."""
-	snap = frappe.db.get_value(
-		"Sheet Snapshot", snapshot_id, ["sheet", "pinned"], as_dict=True
-	)
-	if not snap:
-		frappe.throw(f"Snapshot {snapshot_id} not found")
-	frappe.has_permission("Sheet", doc=snap.sheet, ptype="write", throw=True)
-	if snap.pinned:
-		frappe.throw("Cannot delete a pinned snapshot — unpin it first")
+    """Delete an unpinned snapshot. Pinned ones must be unpinned first."""
+    snap = frappe.db.get_value("Sheet Snapshot", snapshot_id, ["sheet", "pinned"], as_dict=True)
+    if not snap:
+        frappe.throw(f"Snapshot {snapshot_id} not found")
+    frappe.has_permission("Sheet", doc=snap.sheet, ptype="write", throw=True)
+    if snap.pinned:
+        frappe.throw("Cannot delete a pinned snapshot — unpin it first")
 
-	frappe.delete_doc("Sheet Snapshot", snapshot_id, ignore_permissions=True)
-	# If we just deleted the head_snapshot, fall back to the next-most-recent.
-	current_head = frappe.db.get_value("Sheet", snap.sheet, "head_snapshot")
-	if current_head == snapshot_id:
-		next_snap = frappe.get_all(
-			"Sheet Snapshot",
-			filters={"sheet": snap.sheet},
-			fields=["name"],
-			order_by="seq desc",
-			limit=1,
-		)
-		frappe.db.set_value(
-			"Sheet",
-			snap.sheet,
-			"head_snapshot",
-			next_snap[0]["name"] if next_snap else None,
-			update_modified=False,
-		)
-	return {"deleted": snapshot_id}
+    frappe.delete_doc("Sheet Snapshot", snapshot_id, ignore_permissions=True)
+    # If we just deleted the head_snapshot, fall back to the next-most-recent.
+    current_head = frappe.db.get_value("Sheet", snap.sheet, "head_snapshot")
+    if current_head == snapshot_id:
+        next_snap = frappe.get_all(
+            "Sheet Snapshot",
+            filters={"sheet": snap.sheet},
+            fields=["name"],
+            order_by="seq desc",
+            limit=1,
+        )
+        frappe.db.set_value(
+            "Sheet",
+            snap.sheet,
+            "head_snapshot",
+            next_snap[0]["name"] if next_snap else None,
+            update_modified=False,
+        )
+    return {"deleted": snapshot_id}

--- a/suite/sheets/versioning/ops.py
+++ b/suite/sheets/versioning/ops.py
@@ -30,89 +30,89 @@ _CELL_ID_RE = re.compile(r"^[A-Z]{1,3}\d{1,7}$")
 
 
 def between(sheet: str, from_seq: int, to_seq: int, limit: int = 200) -> list[dict]:
-	"""Return ops in the half-open interval (from_seq, to_seq] ordered ascending."""
-	frappe.has_permission("Sheet", doc=sheet, throw=True)
-	if from_seq >= to_seq:
-		return []
-	rows = frappe.db.sql(
-		"SELECT name, seq, sub_sheet, op_type, summary, actor, creation "
-		"FROM `tabSheet Op Log` "
-		"WHERE sheet = %(sheet)s AND seq > %(from_seq)s AND seq <= %(to_seq)s "
-		"ORDER BY seq ASC LIMIT %(limit)s",
-		{"sheet": sheet, "from_seq": from_seq, "to_seq": to_seq, "limit": limit},
-		as_dict=True,
-	)
-	return [_serialise(r) for r in rows]
+    """Return ops in the half-open interval (from_seq, to_seq] ordered ascending."""
+    frappe.has_permission("Sheet", doc=sheet, throw=True)
+    if from_seq >= to_seq:
+        return []
+    rows = frappe.db.sql(
+        "SELECT name, seq, sub_sheet, op_type, summary, actor, creation "
+        "FROM `tabSheet Op Log` "
+        "WHERE sheet = %(sheet)s AND seq > %(from_seq)s AND seq <= %(to_seq)s "
+        "ORDER BY seq ASC LIMIT %(limit)s",
+        {"sheet": sheet, "from_seq": from_seq, "to_seq": to_seq, "limit": limit},
+        as_dict=True,
+    )
+    return [_serialise(r) for r in rows]
 
 
 def for_cell(sheet: str, cell_id: str, sub_sheet: str | None = None, limit: int = 50) -> list[dict]:
-	"""Return ops touching `cell_id`, newest first.
+    """Return ops touching `cell_id`, newest first.
 
-	Filters by JSON-contains on `cell_refs` so we don't paginate through
-	every op for the sheet — fast even on busy suite.sheets.
-	"""
-	frappe.has_permission("Sheet", doc=sheet, throw=True)
-	if not _CELL_ID_RE.match(cell_id or ""):
-		frappe.throw("Invalid cell id")
-	conditions = ["sheet = %(sheet)s"]
-	params: dict = {"sheet": sheet, "limit": limit}
-	if sub_sheet:
-		conditions.append("sub_sheet = %(sub_sheet)s")
-		params["sub_sheet"] = sub_sheet
-	# Naive LIKE catches the cell id inside the JSON array. False positives
-	# (e.g. A1 vs A10) are filtered in Python below.
-	conditions.append("cell_refs LIKE %(cell_pat)s")
-	params["cell_pat"] = f'%"{cell_id}"%'
+    Filters by JSON-contains on `cell_refs` so we don't paginate through
+    every op for the sheet — fast even on busy suite.sheets.
+    """
+    frappe.has_permission("Sheet", doc=sheet, throw=True)
+    if not _CELL_ID_RE.match(cell_id or ""):
+        frappe.throw("Invalid cell id")
+    conditions = ["sheet = %(sheet)s"]
+    params: dict = {"sheet": sheet, "limit": limit}
+    if sub_sheet:
+        conditions.append("sub_sheet = %(sub_sheet)s")
+        params["sub_sheet"] = sub_sheet
+    # Naive LIKE catches the cell id inside the JSON array. False positives
+    # (e.g. A1 vs A10) are filtered in Python below.
+    conditions.append("cell_refs LIKE %(cell_pat)s")
+    params["cell_pat"] = f'%"{cell_id}"%'
 
-	sql = (
-		"SELECT name, seq, sub_sheet, op_type, cell_refs, before_json, after_json, "
-		"       summary, actor, creation "
-		f"FROM `tabSheet Op Log` WHERE {' AND '.join(conditions)} "
-		"ORDER BY seq DESC LIMIT %(limit)s"
-	)
-	rows = frappe.db.sql(sql, params, as_dict=True)
+    sql = (
+        "SELECT name, seq, sub_sheet, op_type, cell_refs, before_json, after_json, "
+        "       summary, actor, creation "
+        f"FROM `tabSheet Op Log` WHERE {' AND '.join(conditions)} "
+        "ORDER BY seq DESC LIMIT %(limit)s"
+    )
+    rows = frappe.db.sql(sql, params, as_dict=True)
 
-	out: list[dict] = []
-	for r in rows:
-		refs = _safe_json(r.get("cell_refs"))
-		if isinstance(refs, list) and cell_id not in refs:
-			continue
-		out.append(_serialise_cell_op(r, cell_id))
-	return out
+    out: list[dict] = []
+    for r in rows:
+        refs = _safe_json(r.get("cell_refs"))
+        if isinstance(refs, list) and cell_id not in refs:
+            continue
+        out.append(_serialise_cell_op(r, cell_id))
+    return out
 
 
 def _serialise(row: dict) -> dict:
-	return {
-		"id": row["name"],
-		"seq": int(row.get("seq") or 0),
-		"sub_sheet": row.get("sub_sheet"),
-		"op_type": row.get("op_type"),
-		"summary": row.get("summary"),
-		"actor": row.get("actor"),
-		"creation": row.get("creation").isoformat() if row.get("creation") else None,
-	}
+    return {
+        "id": row["name"],
+        "seq": int(row.get("seq") or 0),
+        "sub_sheet": row.get("sub_sheet"),
+        "op_type": row.get("op_type"),
+        "summary": row.get("summary"),
+        "actor": row.get("actor"),
+        "creation": row.get("creation").isoformat() if row.get("creation") else None,
+    }
 
 
 def _serialise_cell_op(row: dict, cell_id: str) -> dict:
-	before = _safe_json(row.get("before_json")) or {}
-	after = _safe_json(row.get("after_json")) or {}
-	return {
-		"id": row["name"],
-		"seq": int(row.get("seq") or 0),
-		"sub_sheet": row.get("sub_sheet"),
-		"op_type": row.get("op_type"),
-		"summary": row.get("summary"),
-		"actor": row.get("actor"),
-		"creation": row.get("creation").isoformat() if row.get("creation") else None,
-		"before": before.get(cell_id) if isinstance(before, dict) else None,
-		"after": after.get(cell_id) if isinstance(after, dict) else None,
-	}
+    before = _safe_json(row.get("before_json")) or {}
+    after = _safe_json(row.get("after_json")) or {}
+    return {
+        "id": row["name"],
+        "seq": int(row.get("seq") or 0),
+        "sub_sheet": row.get("sub_sheet"),
+        "op_type": row.get("op_type"),
+        "summary": row.get("summary"),
+        "actor": row.get("actor"),
+        "creation": row.get("creation").isoformat() if row.get("creation") else None,
+        "before": before.get(cell_id) if isinstance(before, dict) else None,
+        "after": after.get(cell_id) if isinstance(after, dict) else None,
+    }
 
 
 def _safe_json(value):
-	if not value:
-		return None
-	try:
-		return json.loads(value)
-	except (TypeError, ValueError):
-		return None
+    if not value:
+        return None
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return None

--- a/suite/sheets/versioning/save.py
+++ b/suite/sheets/versioning/save.py
@@ -30,9 +30,9 @@ import json
 import frappe
 
 from suite.sheets.doctype.sheet.storage import (
-	MAX_SHEETS_DATA_BYTES,
-	decode_sheets_data,
-	encode_sheets_data,
+    MAX_SHEETS_DATA_BYTES,
+    decode_sheets_data,
+    encode_sheets_data,
 )
 
 from . import seq as seq_mod
@@ -43,194 +43,194 @@ MAX_OPS_PER_SAVE = 500
 
 
 def save_sheet(
-	title: str,
-	sheets_data: str,
-	name: str | None = None,
-	ops: list | str | None = None,
-	parent: str | None = None,
+    title: str,
+    sheets_data: str,
+    name: str | None = None,
+    ops: list | str | None = None,
+    parent: str | None = None,
 ) -> dict:
-	"""Create or update a sheet.
+    """Create or update a sheet.
 
-	Returns ``{"name": <sheet_id>, "head_seq": <int>}`` so the client
-	knows where its ops landed in the canonical order.
+    Returns ``{"name": <sheet_id>, "head_seq": <int>}`` so the client
+    knows where its ops landed in the canonical order.
 
-	``parent`` is only honoured on creation (``name`` is falsy): it is the
-	Drive folder the new sheet's backing File should land in, passed through
-	to ``Sheet.after_insert``.
-	"""
-	plain = _validate_payload(sheets_data)
-	clean_title = _clean_title(title)
-	encoded = encode_sheets_data(plain)
-	byte_size = len(plain.encode("utf-8"))
-	ops_list = _coerce_ops(ops)
+    ``parent`` is only honoured on creation (``name`` is falsy): it is the
+    Drive folder the new sheet's backing File should land in, passed through
+    to ``Sheet.after_insert``.
+    """
+    plain = _validate_payload(sheets_data)
+    clean_title = _clean_title(title)
+    encoded = encode_sheets_data(plain)
+    byte_size = len(plain.encode("utf-8"))
+    ops_list = _coerce_ops(ops)
 
-	if name:
-		sheet_id, head_seq = _update_existing(name, clean_title, encoded, byte_size, ops_list)
-	else:
-		sheet_id, head_seq = _insert_new(clean_title, encoded, byte_size, ops_list, parent=parent)
+    if name:
+        sheet_id, head_seq = _update_existing(name, clean_title, encoded, byte_size, ops_list)
+    else:
+        sheet_id, head_seq = _insert_new(clean_title, encoded, byte_size, ops_list, parent=parent)
 
-	# Snapshot inline — no worker dependency. A failure here must NOT fail
-	# the save; the ops are already persisted (no data loss) and the next
-	# save will get a chance to snapshot. We log the error for ops triage.
-	try:
-		snapshots_mod.maybe_snapshot(sheet_id, expected_head_seq=head_seq)
-	except Exception:
-		frappe.log_error(
-			title="sheets: inline maybe_snapshot failed",
-			message=frappe.get_traceback(),
-		)
-	return {"name": sheet_id, "head_seq": head_seq}
+    # Snapshot inline — no worker dependency. A failure here must NOT fail
+    # the save; the ops are already persisted (no data loss) and the next
+    # save will get a chance to snapshot. We log the error for ops triage.
+    try:
+        snapshots_mod.maybe_snapshot(sheet_id, expected_head_seq=head_seq)
+    except Exception:
+        frappe.log_error(
+            title="sheets: inline maybe_snapshot failed",
+            message=frappe.get_traceback(),
+        )
+    return {"name": sheet_id, "head_seq": head_seq}
 
 
 def _insert_new(
-	title: str, encoded: str, byte_size: int, ops_list: list[dict], parent: str | None = None
+    title: str, encoded: str, byte_size: int, ops_list: list[dict], parent: str | None = None
 ) -> tuple[str, int]:
-	doc = frappe.new_doc("Sheet")
-	doc.title = title
-	doc.sheets_data = encoded
-	doc.head_seq = 0
-	# Drive folder for the backing File, read in Sheet.after_insert. Set as a
-	# flag (not a field) so it never persists on the Sheet row itself.
-	if parent:
-		doc.flags.drive_parent = parent
-	doc.insert()
-	head_seq = _append_ops_and_save(doc.name, ops_list, byte_size, save_op_type="create")
-	frappe.db.set_value("Sheet", doc.name, "head_seq", head_seq, update_modified=False)
-	return doc.name, head_seq
+    doc = frappe.new_doc("Sheet")
+    doc.title = title
+    doc.sheets_data = encoded
+    doc.head_seq = 0
+    # Drive folder for the backing File, read in Sheet.after_insert. Set as a
+    # flag (not a field) so it never persists on the Sheet row itself.
+    if parent:
+        doc.flags.drive_parent = parent
+    doc.insert()
+    head_seq = _append_ops_and_save(doc.name, ops_list, byte_size, save_op_type="create")
+    frappe.db.set_value("Sheet", doc.name, "head_seq", head_seq, update_modified=False)
+    return doc.name, head_seq
 
 
 def _update_existing(
-	name: str, title: str, encoded: str, byte_size: int, ops_list: list[dict]
+    name: str, title: str, encoded: str, byte_size: int, ops_list: list[dict]
 ) -> tuple[str, int]:
-	frappe.has_permission("Sheet", doc=name, ptype="write", throw=True)
-	# Cheap PK read so the rare rename path (below) only runs on an actual title
-	# change, not on every autosave.
-	old_title = frappe.db.get_value("Sheet", name, "title")
-	head_seq = _append_ops_and_save(name, ops_list, byte_size, save_op_type="save")
-	if title != old_title:
-		# The editor's inline rename rides the autosave. A title change is rare,
-		# so route the whole write through the ORM: on_update then fires and Drive
-		# renames the backing File via the standard doc-event — the same front
-		# door Writer/Slides use, no Sheets-specific Drive call.
-		doc = frappe.get_doc("Sheet", name)
-		doc.title = title
-		doc.sheets_data = encoded
-		doc.head_seq = head_seq
-		doc.save()
-	else:
-		# The common path: cell-data only. db.set_value keeps this off the full
-		# document lifecycle (validation, on_update, snapshotting) — the op log
-		# is the single chokepoint for advancing the head.
-		frappe.db.set_value(
-			"Sheet",
-			name,
-			{"sheets_data": encoded, "head_seq": head_seq},
-			update_modified=True,
-		)
-	return name, head_seq
+    frappe.has_permission("Sheet", doc=name, ptype="write", throw=True)
+    # Cheap PK read so the rare rename path (below) only runs on an actual title
+    # change, not on every autosave.
+    old_title = frappe.db.get_value("Sheet", name, "title")
+    head_seq = _append_ops_and_save(name, ops_list, byte_size, save_op_type="save")
+    if title != old_title:
+        # The editor's inline rename rides the autosave. A title change is rare,
+        # so route the whole write through the ORM: on_update then fires and Drive
+        # renames the backing File via the standard doc-event — the same front
+        # door Writer/Slides use, no Sheets-specific Drive call.
+        doc = frappe.get_doc("Sheet", name)
+        doc.title = title
+        doc.sheets_data = encoded
+        doc.head_seq = head_seq
+        doc.save()
+    else:
+        # The common path: cell-data only. db.set_value keeps this off the full
+        # document lifecycle (validation, on_update, snapshotting) — the op log
+        # is the single chokepoint for advancing the head.
+        frappe.db.set_value(
+            "Sheet",
+            name,
+            {"sheets_data": encoded, "head_seq": head_seq},
+            update_modified=True,
+        )
+    return name, head_seq
 
 
 def _append_ops_and_save(sheet: str, ops_list: list[dict], byte_size: int, save_op_type: str) -> int:
-	"""Append the user ops + the implicit save op as one contiguous range.
+    """Append the user ops + the implicit save op as one contiguous range.
 
-	Returns the final seq (the save op's seq).
-	"""
-	total = len(ops_list) + 1
-	first_seq = seq_mod.allocate(sheet, count=total)
-	actor = frappe.session.user
-	rows: list[dict] = []
-	for i, op in enumerate(ops_list):
-		rows.append(_op_doc(sheet, first_seq + i, op, actor))
-	save_seq = first_seq + total - 1
-	rows.append(
-		{
-			"doctype": "Sheet Op Log",
-			"sheet": sheet,
-			"seq": save_seq,
-			"op_type": save_op_type,
-			"summary": f"Saved ({_format_bytes(byte_size)})",
-			"actor": actor,
-		}
-	)
-	for row in rows:
-		frappe.get_doc(row).insert(ignore_permissions=True)
-	return save_seq
+    Returns the final seq (the save op's seq).
+    """
+    total = len(ops_list) + 1
+    first_seq = seq_mod.allocate(sheet, count=total)
+    actor = frappe.session.user
+    rows: list[dict] = []
+    for i, op in enumerate(ops_list):
+        rows.append(_op_doc(sheet, first_seq + i, op, actor))
+    save_seq = first_seq + total - 1
+    rows.append(
+        {
+            "doctype": "Sheet Op Log",
+            "sheet": sheet,
+            "seq": save_seq,
+            "op_type": save_op_type,
+            "summary": f"Saved ({_format_bytes(byte_size)})",
+            "actor": actor,
+        }
+    )
+    for row in rows:
+        frappe.get_doc(row).insert(ignore_permissions=True)
+    return save_seq
 
 
 def append_op(sheet: str, op: dict) -> int:
-	"""Append a single ad-hoc op. Used outside the save path (e.g. realtime)."""
-	frappe.has_permission("Sheet", doc=sheet, ptype="write", throw=True)
-	new_seq = seq_mod.allocate(sheet)
-	frappe.get_doc(_op_doc(sheet, new_seq, op, frappe.session.user)).insert(ignore_permissions=True)
-	# Advance head_seq only forward — never regress.
-	frappe.db.sql(
-		"UPDATE `tabSheet` SET head_seq = GREATEST(IFNULL(head_seq, 0), %s) WHERE name = %s",
-		(new_seq, sheet),
-	)
-	return new_seq
+    """Append a single ad-hoc op. Used outside the save path (e.g. realtime)."""
+    frappe.has_permission("Sheet", doc=sheet, ptype="write", throw=True)
+    new_seq = seq_mod.allocate(sheet)
+    frappe.get_doc(_op_doc(sheet, new_seq, op, frappe.session.user)).insert(ignore_permissions=True)
+    # Advance head_seq only forward — never regress.
+    frappe.db.sql(
+        "UPDATE `tabSheet` SET head_seq = GREATEST(IFNULL(head_seq, 0), %s) WHERE name = %s",
+        (new_seq, sheet),
+    )
+    return new_seq
 
 
 def _op_doc(sheet: str, seq: int, op: dict, actor: str) -> dict:
-	# Accept both snake_case and camelCase keys so the client can pass either.
-	op_type = op.get("op_type") or op.get("opType")
-	if not op_type:
-		frappe.throw("op_type is required")
-	return {
-		"doctype": "Sheet Op Log",
-		"sheet": sheet,
-		"seq": seq,
-		"op_type": op_type,
-		"sub_sheet": op.get("sub_sheet") or op.get("subSheet"),
-		"cell_refs": op.get("cell_refs") or op.get("cellRefs"),
-		"before_json": op.get("before") or op.get("before_json"),
-		"after_json": op.get("after") or op.get("after_json"),
-		"summary": op.get("summary") or "",
-		"actor": actor,
-	}
+    # Accept both snake_case and camelCase keys so the client can pass either.
+    op_type = op.get("op_type") or op.get("opType")
+    if not op_type:
+        frappe.throw("op_type is required")
+    return {
+        "doctype": "Sheet Op Log",
+        "sheet": sheet,
+        "seq": seq,
+        "op_type": op_type,
+        "sub_sheet": op.get("sub_sheet") or op.get("subSheet"),
+        "cell_refs": op.get("cell_refs") or op.get("cellRefs"),
+        "before_json": op.get("before") or op.get("before_json"),
+        "after_json": op.get("after") or op.get("after_json"),
+        "summary": op.get("summary") or "",
+        "actor": actor,
+    }
 
 
 def _coerce_ops(ops) -> list[dict]:
-	if ops is None or ops == "":
-		return []
-	if isinstance(ops, str):
-		try:
-			ops = json.loads(ops)
-		except (TypeError, ValueError):
-			frappe.throw("ops must be a JSON array")
-	if not isinstance(ops, list):
-		frappe.throw("ops must be a JSON array")
-	if len(ops) > MAX_OPS_PER_SAVE:
-		frappe.throw(f"Too many ops in one save (max {MAX_OPS_PER_SAVE})")
-	return ops
+    if ops is None or ops == "":
+        return []
+    if isinstance(ops, str):
+        try:
+            ops = json.loads(ops)
+        except (TypeError, ValueError):
+            frappe.throw("ops must be a JSON array")
+    if not isinstance(ops, list):
+        frappe.throw("ops must be a JSON array")
+    if len(ops) > MAX_OPS_PER_SAVE:
+        frappe.throw(f"Too many ops in one save (max {MAX_OPS_PER_SAVE})")
+    return ops
 
 
 def _validate_payload(sheets_data: str) -> str:
-	if not isinstance(sheets_data, str):
-		frappe.throw("sheets_data must be a JSON string")
-	plain = decode_sheets_data(sheets_data)
-	size = len(plain.encode("utf-8"))
-	if size > MAX_SHEETS_DATA_BYTES:
-		limit_mb = MAX_SHEETS_DATA_BYTES // (1024 * 1024)
-		frappe.throw(
-			f"This spreadsheet is {_format_bytes(size)}, over the {limit_mb} MB limit. "
-			f"Formatting applied across a very large range is the usual cause — clear "
-			f"formatting you don't need, or split the data across sheets."
-		)
-	try:
-		json.loads(plain)
-	except (ValueError, TypeError):
-		frappe.throw("sheets_data is not valid JSON")
-	return plain
+    if not isinstance(sheets_data, str):
+        frappe.throw("sheets_data must be a JSON string")
+    plain = decode_sheets_data(sheets_data)
+    size = len(plain.encode("utf-8"))
+    if size > MAX_SHEETS_DATA_BYTES:
+        limit_mb = MAX_SHEETS_DATA_BYTES // (1024 * 1024)
+        frappe.throw(
+            f"This spreadsheet is {_format_bytes(size)}, over the {limit_mb} MB limit. "
+            f"Formatting applied across a very large range is the usual cause — clear "
+            f"formatting you don't need, or split the data across sheets."
+        )
+    try:
+        json.loads(plain)
+    except (ValueError, TypeError):
+        frappe.throw("sheets_data is not valid JSON")
+    return plain
 
 
 def _clean_title(title: str) -> str:
-	t = (title or "").strip() or "Untitled Spreadsheet"
-	return t[:MAX_TITLE_LEN]
+    t = (title or "").strip() or "Untitled Spreadsheet"
+    return t[:MAX_TITLE_LEN]
 
 
 def _format_bytes(n: int) -> str:
-	if n < 1024:
-		return f"{n} B"
-	if n < 1024 * 1024:
-		return f"{n / 1024:.1f} KB"
-	return f"{n / (1024 * 1024):.1f} MB"
+    if n < 1024:
+        return f"{n} B"
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f} KB"
+    return f"{n / (1024 * 1024):.1f} MB"

--- a/suite/sheets/versioning/seq.py
+++ b/suite/sheets/versioning/seq.py
@@ -14,42 +14,42 @@ import frappe
 
 
 def allocate(sheet: str, count: int = 1) -> int:
-	"""Allocate `count` consecutive op-log seq numbers for the sheet.
+    """Allocate `count` consecutive op-log seq numbers for the sheet.
 
-	Returns the *first* allocated seq; callers using a batch take
-	[seq, seq+1, …, seq+count-1].
-	"""
-	if count < 1:
-		frappe.throw("allocate(count) requires count >= 1")
+    Returns the *first* allocated seq; callers using a batch take
+    [seq, seq+1, …, seq+count-1].
+    """
+    if count < 1:
+        frappe.throw("allocate(count) requires count >= 1")
 
-	_ensure_row(sheet)
-	row = frappe.db.sql(
-		"SELECT next_seq FROM `tabSheet Seq` WHERE name = %s FOR UPDATE",
-		(sheet,),
-		as_dict=True,
-	)
-	first = int(row[0]["next_seq"])
-	frappe.db.sql(
-		"UPDATE `tabSheet Seq` SET next_seq = next_seq + %s WHERE name = %s",
-		(count, sheet),
-	)
-	return first
+    _ensure_row(sheet)
+    row = frappe.db.sql(
+        "SELECT next_seq FROM `tabSheet Seq` WHERE name = %s FOR UPDATE",
+        (sheet,),
+        as_dict=True,
+    )
+    first = int(row[0]["next_seq"])
+    frappe.db.sql(
+        "UPDATE `tabSheet Seq` SET next_seq = next_seq + %s WHERE name = %s",
+        (count, sheet),
+    )
+    return first
 
 
 def peek(sheet: str) -> int:
-	"""Return the next seq that would be allocated, without consuming it."""
-	row = frappe.db.get_value("Sheet Seq", sheet, "next_seq")
-	return int(row) if row else 1
+    """Return the next seq that would be allocated, without consuming it."""
+    row = frappe.db.get_value("Sheet Seq", sheet, "next_seq")
+    return int(row) if row else 1
 
 
 def _ensure_row(sheet: str) -> None:
-	"""Create the Sheet Seq row on first use. Safe under concurrent inserts."""
-	if frappe.db.exists("Sheet Seq", sheet):
-		return
-	try:
-		frappe.get_doc({"doctype": "Sheet Seq", "sheet": sheet, "next_seq": 1}).insert(
-			ignore_permissions=True
-		)
-	except frappe.DuplicateEntryError:
-		# Lost the race — that's fine, row exists now.
-		pass
+    """Create the Sheet Seq row on first use. Safe under concurrent inserts."""
+    if frappe.db.exists("Sheet Seq", sheet):
+        return
+    try:
+        frappe.get_doc({"doctype": "Sheet Seq", "sheet": sheet, "next_seq": 1}).insert(
+            ignore_permissions=True
+        )
+    except frappe.DuplicateEntryError:
+        # Lost the race — that's fine, row exists now.
+        pass

--- a/suite/sheets/versioning/snapshots.py
+++ b/suite/sheets/versioning/snapshots.py
@@ -24,8 +24,8 @@ import frappe
 from frappe.utils import now_datetime
 
 from suite.sheets.doctype.sheet.storage import (
-	decode_sheets_data,
-	effective_size,
+    decode_sheets_data,
+    effective_size,
 )
 
 # Policy knobs — overridable via site_config:
@@ -45,116 +45,110 @@ _VALID_KINDS = {KIND_AUTO, KIND_MILESTONE, KIND_NAMED}
 
 
 def maybe_snapshot(sheet: str, expected_head_seq: int | None = None) -> str | None:
-	"""Worker entry point. Creates an auto snapshot iff policy says so.
+    """Worker entry point. Creates an auto snapshot iff policy says so.
 
-	Called from `frappe.enqueue` after `save_sheet`. `expected_head_seq` is
-	the seq the request thought was the head — used only for telemetry, not
-	correctness (we always snapshot the *current* head).
-	"""
-	doc = frappe.db.get_value(
-		"Sheet", sheet, ["head_seq", "head_snapshot"], as_dict=True
-	)
-	if not doc:
-		return None
-	last = _last_snapshot(sheet)
-	if not _should_snapshot(int(doc.head_seq or 0), last):
-		return None
-	return create(sheet, kind=KIND_AUTO)
+    Called from `frappe.enqueue` after `save_sheet`. `expected_head_seq` is
+    the seq the request thought was the head — used only for telemetry, not
+    correctness (we always snapshot the *current* head).
+    """
+    doc = frappe.db.get_value("Sheet", sheet, ["head_seq", "head_snapshot"], as_dict=True)
+    if not doc:
+        return None
+    last = _last_snapshot(sheet)
+    if not _should_snapshot(int(doc.head_seq or 0), last):
+        return None
+    return create(sheet, kind=KIND_AUTO)
 
 
 def create(
-	sheet: str,
-	*,
-	kind: str = KIND_AUTO,
-	label: str | None = None,
-	actor: str | None = None,
+    sheet: str,
+    *,
+    kind: str = KIND_AUTO,
+    label: str | None = None,
+    actor: str | None = None,
 ) -> str:
-	"""Create a snapshot at the sheet's current head. Returns the snapshot name."""
-	if kind not in _VALID_KINDS:
-		frappe.throw(f"Unknown snapshot kind: {kind}")
+    """Create a snapshot at the sheet's current head. Returns the snapshot name."""
+    if kind not in _VALID_KINDS:
+        frappe.throw(f"Unknown snapshot kind: {kind}")
 
-	head = frappe.db.get_value(
-		"Sheet", sheet, ["sheets_data", "head_seq"], as_dict=True
-	)
-	if not head:
-		frappe.throw(f"Sheet {sheet} not found")
+    head = frappe.db.get_value("Sheet", sheet, ["sheets_data", "head_seq"], as_dict=True)
+    if not head:
+        frappe.throw(f"Sheet {sheet} not found")
 
-	last = _last_snapshot(sheet)
-	head_seq = int(head.head_seq or 0)
-	op_count = max(0, head_seq - int(last["seq"] if last else 0))
+    last = _last_snapshot(sheet)
+    head_seq = int(head.head_seq or 0)
+    op_count = max(0, head_seq - int(last["seq"] if last else 0))
 
-	snap = frappe.get_doc(
-		{
-			"doctype": "Sheet Snapshot",
-			"sheet": sheet,
-			"seq": head_seq,
-			"kind": kind,
-			"label": (label or "").strip() or None,
-			"pinned": 1 if kind == KIND_NAMED else 0,
-			"op_count": op_count,
-			"byte_size": len((head.sheets_data or "").encode("utf-8")),
-			"actor": actor or frappe.session.user,
-			"sheets_data": head.sheets_data,
-		}
-	)
-	snap.insert(ignore_permissions=True)
+    snap = frappe.get_doc(
+        {
+            "doctype": "Sheet Snapshot",
+            "sheet": sheet,
+            "seq": head_seq,
+            "kind": kind,
+            "label": (label or "").strip() or None,
+            "pinned": 1 if kind == KIND_NAMED else 0,
+            "op_count": op_count,
+            "byte_size": len((head.sheets_data or "").encode("utf-8")),
+            "actor": actor or frappe.session.user,
+            "sheets_data": head.sheets_data,
+        }
+    )
+    snap.insert(ignore_permissions=True)
 
-	# Update head pointer without bumping `modified` — head_snapshot is a
-	# derived cache, not user-visible mutation.
-	frappe.db.set_value(
-		"Sheet", sheet, "head_snapshot", snap.name, update_modified=False
-	)
-	frappe.publish_realtime(
-		"sheet_snapshot_created",
-		{"sheet": sheet, "snapshot": snap.name, "kind": kind, "seq": head_seq},
-		after_commit=True,
-	)
-	return snap.name
+    # Update head pointer without bumping `modified` — head_snapshot is a
+    # derived cache, not user-visible mutation.
+    frappe.db.set_value("Sheet", sheet, "head_snapshot", snap.name, update_modified=False)
+    frappe.publish_realtime(
+        "sheet_snapshot_created",
+        {"sheet": sheet, "snapshot": snap.name, "kind": kind, "seq": head_seq},
+        after_commit=True,
+    )
+    return snap.name
 
 
 def _should_snapshot(head_seq: int, last: dict | None) -> bool:
-	if head_seq <= 0:
-		return False
-	ops_thresh = _conf_int("versioning_auto_snapshot_ops", AUTO_SNAPSHOT_OPS)
-	secs_thresh = _conf_int("versioning_auto_snapshot_secs", AUTO_SNAPSHOT_SECS)
-	if last is None:
-		return True
-	ops_since = head_seq - int(last["seq"] or 0)
-	if ops_since <= 0:
-		return False
-	if ops_since >= ops_thresh:
-		return True
-	last_at = frappe.utils.get_datetime(last["creation"])
-	elapsed = (now_datetime() - last_at).total_seconds()
-	return elapsed >= secs_thresh
+    if head_seq <= 0:
+        return False
+    ops_thresh = _conf_int("versioning_auto_snapshot_ops", AUTO_SNAPSHOT_OPS)
+    secs_thresh = _conf_int("versioning_auto_snapshot_secs", AUTO_SNAPSHOT_SECS)
+    if last is None:
+        return True
+    ops_since = head_seq - int(last["seq"] or 0)
+    if ops_since <= 0:
+        return False
+    if ops_since >= ops_thresh:
+        return True
+    last_at = frappe.utils.get_datetime(last["creation"])
+    elapsed = (now_datetime() - last_at).total_seconds()
+    return elapsed >= secs_thresh
 
 
 def _last_snapshot(sheet: str) -> dict | None:
-	rows = frappe.get_all(
-		"Sheet Snapshot",
-		filters={"sheet": sheet},
-		fields=["name", "seq", "creation"],
-		order_by="seq desc",
-		limit=1,
-	)
-	return rows[0] if rows else None
+    rows = frappe.get_all(
+        "Sheet Snapshot",
+        filters={"sheet": sheet},
+        fields=["name", "seq", "creation"],
+        order_by="seq desc",
+        limit=1,
+    )
+    return rows[0] if rows else None
 
 
 def _conf_int(key: str, default: int) -> int:
-	val = frappe.conf.get(key)
-	try:
-		return int(val) if val is not None else default
-	except (TypeError, ValueError):
-		return default
+    val = frappe.conf.get(key)
+    try:
+        return int(val) if val is not None else default
+    except (TypeError, ValueError):
+        return default
 
 
 def stored_size(snap_name: str) -> int:
-	"""Effective uncompressed byte size of a snapshot's payload."""
-	stored = frappe.db.get_value("Sheet Snapshot", snap_name, "sheets_data")
-	return effective_size(stored)
+    """Effective uncompressed byte size of a snapshot's payload."""
+    stored = frappe.db.get_value("Sheet Snapshot", snap_name, "sheets_data")
+    return effective_size(stored)
 
 
 def decode_payload(snap_name: str) -> str:
-	"""Return the snapshot's payload as plain JSON (decompressed)."""
-	stored = frappe.db.get_value("Sheet Snapshot", snap_name, "sheets_data")
-	return decode_sheets_data(stored)
+    """Return the snapshot's payload as plain JSON (decompressed)."""
+    stored = frappe.db.get_value("Sheet Snapshot", snap_name, "sheets_data")
+    return decode_sheets_data(stored)

--- a/suite/sheets/versioning/state.py
+++ b/suite/sheets/versioning/state.py
@@ -17,8 +17,8 @@ import json
 import frappe
 
 from suite.sheets.doctype.sheet.storage import (
-	decode_sheets_data,
-	encode_sheets_data,
+    decode_sheets_data,
+    encode_sheets_data,
 )
 
 from . import seq as seq_mod
@@ -26,85 +26,85 @@ from . import snapshots as snap_mod
 
 
 def at(snapshot_id: str) -> dict:
-	"""Return the workbook state captured by a snapshot.
+    """Return the workbook state captured by a snapshot.
 
-	Shape: { "name": str, "sheet": str, "seq": int, "creation": ts,
-	         "label": str|None, "kind": str, "sheets_data": <plain JSON> }
-	"""
-	snap = frappe.db.get_value(
-		"Sheet Snapshot",
-		snapshot_id,
-		["name", "sheet", "seq", "creation", "label", "kind", "sheets_data"],
-		as_dict=True,
-	)
-	if not snap:
-		frappe.throw(f"Snapshot {snapshot_id} not found")
-	frappe.has_permission("Sheet", doc=snap.sheet, throw=True)
-	return {
-		"name": snap.name,
-		"sheet": snap.sheet,
-		"seq": int(snap.seq or 0),
-		"creation": snap.creation,
-		"label": snap.label,
-		"kind": snap.kind,
-		"sheets_data": decode_sheets_data(snap.sheets_data),
-	}
+    Shape: { "name": str, "sheet": str, "seq": int, "creation": ts,
+             "label": str|None, "kind": str, "sheets_data": <plain JSON> }
+    """
+    snap = frappe.db.get_value(
+        "Sheet Snapshot",
+        snapshot_id,
+        ["name", "sheet", "seq", "creation", "label", "kind", "sheets_data"],
+        as_dict=True,
+    )
+    if not snap:
+        frappe.throw(f"Snapshot {snapshot_id} not found")
+    frappe.has_permission("Sheet", doc=snap.sheet, throw=True)
+    return {
+        "name": snap.name,
+        "sheet": snap.sheet,
+        "seq": int(snap.seq or 0),
+        "creation": snap.creation,
+        "label": snap.label,
+        "kind": snap.kind,
+        "sheets_data": decode_sheets_data(snap.sheets_data),
+    }
 
 
 def restore(snapshot_id: str) -> dict:
-	"""Restore the head to the given snapshot. Non-destructive.
+    """Restore the head to the given snapshot. Non-destructive.
 
-	Returns: { "snapshot": <new milestone snapshot name>, "seq": int }
-	"""
-	target = at(snapshot_id)  # validates read permission
-	sheet_id = target["sheet"]
-	# Authoritative write-perm gate lives here, not at the call-site — so any
-	# future caller (a fixture, a script, another whitelisted endpoint) that
-	# forgets to gate cannot accidentally mutate the head.
-	frappe.has_permission("Sheet", doc=sheet_id, ptype="write", throw=True)
+    Returns: { "snapshot": <new milestone snapshot name>, "seq": int }
+    """
+    target = at(snapshot_id)  # validates read permission
+    sheet_id = target["sheet"]
+    # Authoritative write-perm gate lives here, not at the call-site — so any
+    # future caller (a fixture, a script, another whitelisted endpoint) that
+    # forgets to gate cannot accidentally mutate the head.
+    frappe.has_permission("Sheet", doc=sheet_id, ptype="write", throw=True)
 
-	# Append a restore op so the timeline tells the story.
-	restore_seq = seq_mod.allocate(sheet_id)
-	frappe.get_doc(
-		{
-			"doctype": "Sheet Op Log",
-			"sheet": sheet_id,
-			"seq": restore_seq,
-			"op_type": "restore",
-			"summary": _restore_summary(target),
-			"actor": frappe.session.user,
-		}
-	).insert(ignore_permissions=True)
+    # Append a restore op so the timeline tells the story.
+    restore_seq = seq_mod.allocate(sheet_id)
+    frappe.get_doc(
+        {
+            "doctype": "Sheet Op Log",
+            "sheet": sheet_id,
+            "seq": restore_seq,
+            "op_type": "restore",
+            "summary": _restore_summary(target),
+            "actor": frappe.session.user,
+        }
+    ).insert(ignore_permissions=True)
 
-	# Materialise the restored state onto the head.
-	frappe.db.set_value(
-		"Sheet",
-		sheet_id,
-		{
-			"sheets_data": encode_sheets_data(target["sheets_data"]),
-			"head_seq": restore_seq,
-		},
-		update_modified=True,
-	)
+    # Materialise the restored state onto the head.
+    frappe.db.set_value(
+        "Sheet",
+        sheet_id,
+        {
+            "sheets_data": encode_sheets_data(target["sheets_data"]),
+            "head_seq": restore_seq,
+        },
+        update_modified=True,
+    )
 
-	# Take a milestone snapshot at the restore seq — anchors the new history.
-	snap_name = snap_mod.create(
-		sheet_id,
-		kind=snap_mod.KIND_MILESTONE,
-		label=_restore_label(target),
-	)
-	return {"snapshot": snap_name, "seq": restore_seq}
+    # Take a milestone snapshot at the restore seq — anchors the new history.
+    snap_name = snap_mod.create(
+        sheet_id,
+        kind=snap_mod.KIND_MILESTONE,
+        label=_restore_label(target),
+    )
+    return {"snapshot": snap_name, "seq": restore_seq}
 
 
 def _restore_summary(target: dict) -> str:
-	parts = ["Restored to"]
-	if target.get("label"):
-		parts.append(f'"{target["label"]}"')
-	else:
-		parts.append(f"seq {target['seq']}")
-	return " ".join(parts)
+    parts = ["Restored to"]
+    if target.get("label"):
+        parts.append(f'"{target["label"]}"')
+    else:
+        parts.append(f"seq {target['seq']}")
+    return " ".join(parts)
 
 
 def _restore_label(target: dict) -> str:
-	base = target.get("label") or f"seq {target['seq']}"
-	return f"Restore of {base}"
+    base = target.get("label") or f"seq {target['seq']}"
+    return f"Restore of {base}"

--- a/suite/sheets/versioning/tasks.py
+++ b/suite/sheets/versioning/tasks.py
@@ -23,11 +23,11 @@ from frappe.utils import now_datetime
 # Density tiers (configurable via site_config).
 # Tier (max age in hours, keep one snapshot per N hours).
 DEFAULT_TIERS = (
-	(24, 0),       # 0-24h: keep all
-	(24 * 7, 1),   # 1-7d: hourly
-	(24 * 30, 24), # 7-30d: daily
-	(24 * 90, 168),  # 30-90d: weekly
-	# Beyond 90d: only pinned/milestone/named survive (no auto kept).
+    (24, 0),  # 0-24h: keep all
+    (24 * 7, 1),  # 1-7d: hourly
+    (24 * 30, 24),  # 7-30d: daily
+    (24 * 90, 168),  # 30-90d: weekly
+    # Beyond 90d: only pinned/milestone/named survive (no auto kept).
 )
 HARD_CUTOFF_HOURS = 24 * 90  # auto snapshots beyond this are deleted entirely
 
@@ -35,119 +35,117 @@ OP_LOG_RETENTION_HOURS = 24 * 30
 
 
 def rollup_snapshots() -> dict:
-	"""Apply tiered retention. Returns counters for telemetry."""
-	tiers = _tiers()
-	hard_cutoff_h = int(frappe.conf.get("versioning_hard_cutoff_hours") or HARD_CUTOFF_HOURS)
-	now = now_datetime()
-	deleted = 0
-	scanned = 0
+    """Apply tiered retention. Returns counters for telemetry."""
+    tiers = _tiers()
+    hard_cutoff_h = int(frappe.conf.get("versioning_hard_cutoff_hours") or HARD_CUTOFF_HOURS)
+    now = now_datetime()
+    deleted = 0
+    scanned = 0
 
-	for sheet_name in _iter_sheets():
-		snaps = frappe.get_all(
-			"Sheet Snapshot",
-			filters={"sheet": sheet_name, "kind": "auto", "pinned": 0},
-			fields=["name", "seq", "creation"],
-			order_by="seq desc",
-		)
-		scanned += len(snaps)
-		to_delete = _pick_deletions(snaps, now, tiers, hard_cutoff_h)
-		for snap_name in to_delete:
-			frappe.delete_doc("Sheet Snapshot", snap_name, ignore_permissions=True, force=True)
-			deleted += 1
-		frappe.db.commit()
+    for sheet_name in _iter_sheets():
+        snaps = frappe.get_all(
+            "Sheet Snapshot",
+            filters={"sheet": sheet_name, "kind": "auto", "pinned": 0},
+            fields=["name", "seq", "creation"],
+            order_by="seq desc",
+        )
+        scanned += len(snaps)
+        to_delete = _pick_deletions(snaps, now, tiers, hard_cutoff_h)
+        for snap_name in to_delete:
+            frappe.delete_doc("Sheet Snapshot", snap_name, ignore_permissions=True, force=True)
+            deleted += 1
+        frappe.db.commit()
 
-	return {"scanned": scanned, "deleted": deleted}
+    return {"scanned": scanned, "deleted": deleted}
 
 
 def truncate_op_log() -> dict:
-	"""Drop op-log rows older than the oldest retained snapshot for each sheet.
+    """Drop op-log rows older than the oldest retained snapshot for each sheet.
 
-	Caps absolute retention via OP_LOG_RETENTION_HOURS as a backstop.
-	"""
-	max_age = int(
-		frappe.conf.get("versioning_op_log_retention_hours") or OP_LOG_RETENTION_HOURS
-	)
-	hard_cutoff = now_datetime() - timedelta(hours=max_age)
-	deleted = 0
+    Caps absolute retention via OP_LOG_RETENTION_HOURS as a backstop.
+    """
+    max_age = int(frappe.conf.get("versioning_op_log_retention_hours") or OP_LOG_RETENTION_HOURS)
+    hard_cutoff = now_datetime() - timedelta(hours=max_age)
+    deleted = 0
 
-	for sheet_name in _iter_sheets():
-		oldest_snap = frappe.get_all(
-			"Sheet Snapshot",
-			filters={"sheet": sheet_name},
-			fields=["seq"],
-			order_by="seq asc",
-			limit=1,
-		)
-		min_keep_seq = int(oldest_snap[0]["seq"]) if oldest_snap else 0
-		# Delete ops strictly older than the oldest retained snapshot AND
-		# older than the absolute time backstop.
-		result = frappe.db.sql(
-			"DELETE FROM `tabSheet Op Log` "
-			"WHERE sheet = %(sheet)s "
-			"  AND seq < %(min_seq)s "
-			"  AND creation < %(cutoff)s",
-			{"sheet": sheet_name, "min_seq": min_keep_seq, "cutoff": hard_cutoff},
-		)
-		deleted += frappe.db.sql("SELECT ROW_COUNT()")[0][0]
-		frappe.db.commit()
+    for sheet_name in _iter_sheets():
+        oldest_snap = frappe.get_all(
+            "Sheet Snapshot",
+            filters={"sheet": sheet_name},
+            fields=["seq"],
+            order_by="seq asc",
+            limit=1,
+        )
+        min_keep_seq = int(oldest_snap[0]["seq"]) if oldest_snap else 0
+        # Delete ops strictly older than the oldest retained snapshot AND
+        # older than the absolute time backstop.
+        result = frappe.db.sql(
+            "DELETE FROM `tabSheet Op Log` "
+            "WHERE sheet = %(sheet)s "
+            "  AND seq < %(min_seq)s "
+            "  AND creation < %(cutoff)s",
+            {"sheet": sheet_name, "min_seq": min_keep_seq, "cutoff": hard_cutoff},
+        )
+        deleted += frappe.db.sql("SELECT ROW_COUNT()")[0][0]
+        frappe.db.commit()
 
-	return {"deleted": deleted}
+    return {"deleted": deleted}
 
 
 def _tiers() -> tuple:
-	override = frappe.conf.get("versioning_tiers")
-	if override and isinstance(override, list):
-		return tuple(tuple(t) for t in override)
-	return DEFAULT_TIERS
+    override = frappe.conf.get("versioning_tiers")
+    if override and isinstance(override, list):
+        return tuple(tuple(t) for t in override)
+    return DEFAULT_TIERS
 
 
 def _iter_sheets():
-	"""Iterate sheet names in modest pages — never load the full list at once."""
-	last_name = ""
-	page = 200
-	while True:
-		rows = frappe.db.sql(
-			"SELECT name FROM `tabSheet` WHERE name > %s ORDER BY name LIMIT %s",
-			(last_name, page),
-		)
-		if not rows:
-			return
-		for (name,) in rows:
-			yield name
-			last_name = name
-		if len(rows) < page:
-			return
+    """Iterate sheet names in modest pages — never load the full list at once."""
+    last_name = ""
+    page = 200
+    while True:
+        rows = frappe.db.sql(
+            "SELECT name FROM `tabSheet` WHERE name > %s ORDER BY name LIMIT %s",
+            (last_name, page),
+        )
+        if not rows:
+            return
+        for (name,) in rows:
+            yield name
+            last_name = name
+        if len(rows) < page:
+            return
 
 
 def _pick_deletions(snaps: list[dict], now: datetime, tiers: tuple, hard_cutoff_h: int) -> list[str]:
-	"""Walk snapshots newest→oldest, deciding which to keep per tier.
+    """Walk snapshots newest→oldest, deciding which to keep per tier.
 
-	Within each tier interval we keep at most one snapshot per density bucket
-	(`tier_hours`). The kept snapshot is the *oldest* one we've seen falling
-	into a given bucket — that way the kept rows are evenly spaced.
-	"""
-	to_delete: list[str] = []
-	kept_bucket_keys: dict[tuple[int, int], bool] = {}
-	for s in snaps:
-		creation = frappe.utils.get_datetime(s["creation"])
-		age_h = (now - creation).total_seconds() / 3600.0
-		if age_h > hard_cutoff_h:
-			to_delete.append(s["name"])
-			continue
-		tier_idx, tier_hours = _tier_for(age_h, tiers)
-		if tier_hours == 0:
-			continue  # keep all in this tier
-		# Bucket key = (tier index, floor(age / tier_hours))
-		bucket = (tier_idx, int(age_h // tier_hours))
-		if bucket in kept_bucket_keys:
-			to_delete.append(s["name"])
-		else:
-			kept_bucket_keys[bucket] = True
-	return to_delete
+    Within each tier interval we keep at most one snapshot per density bucket
+    (`tier_hours`). The kept snapshot is the *oldest* one we've seen falling
+    into a given bucket — that way the kept rows are evenly spaced.
+    """
+    to_delete: list[str] = []
+    kept_bucket_keys: dict[tuple[int, int], bool] = {}
+    for s in snaps:
+        creation = frappe.utils.get_datetime(s["creation"])
+        age_h = (now - creation).total_seconds() / 3600.0
+        if age_h > hard_cutoff_h:
+            to_delete.append(s["name"])
+            continue
+        tier_idx, tier_hours = _tier_for(age_h, tiers)
+        if tier_hours == 0:
+            continue  # keep all in this tier
+        # Bucket key = (tier index, floor(age / tier_hours))
+        bucket = (tier_idx, int(age_h // tier_hours))
+        if bucket in kept_bucket_keys:
+            to_delete.append(s["name"])
+        else:
+            kept_bucket_keys[bucket] = True
+    return to_delete
 
 
 def _tier_for(age_hours: float, tiers: tuple) -> tuple[int, int]:
-	for idx, (max_age, density) in enumerate(tiers):
-		if age_hours <= max_age:
-			return idx, density
-	return len(tiers), tiers[-1][1] if tiers else 0
+    for idx, (max_age, density) in enumerate(tiers):
+        if age_hours <= max_age:
+            return idx, density
+    return len(tiers), tiers[-1][1] if tiers else 0

--- a/suite/sheets/versioning/tests/test_cursor.py
+++ b/suite/sheets/versioning/tests/test_cursor.py
@@ -15,38 +15,38 @@ from suite.sheets.versioning import timeline as tl
 
 
 class CursorRoundTrip(unittest.TestCase):
-	def test_round_trip_small(self):
-		c = tl._encode_cursor(42)
-		self.assertEqual(tl._decode_cursor(c), 42)
+    def test_round_trip_small(self):
+        c = tl._encode_cursor(42)
+        self.assertEqual(tl._decode_cursor(c), 42)
 
-	def test_round_trip_large(self):
-		c = tl._encode_cursor(2**40)
-		self.assertEqual(tl._decode_cursor(c), 2**40)
+    def test_round_trip_large(self):
+        c = tl._encode_cursor(2**40)
+        self.assertEqual(tl._decode_cursor(c), 2**40)
 
-	def test_none_and_empty_return_none(self):
-		self.assertIsNone(tl._decode_cursor(None))
-		self.assertIsNone(tl._decode_cursor(""))
+    def test_none_and_empty_return_none(self):
+        self.assertIsNone(tl._decode_cursor(None))
+        self.assertIsNone(tl._decode_cursor(""))
 
 
 class BadCursorRejected(unittest.TestCase):
-	def test_garbage_string_throws(self):
-		# `frappe.throw` raises a generic exception we can match by message.
-		with mock.patch(
-			"suite.sheets.versioning.timeline.frappe.throw",
-			side_effect=ValueError("Invalid cursor"),
-		) as m:
-			with self.assertRaises(ValueError):
-				tl._decode_cursor("not-a-real-cursor")
-			m.assert_called_once()
+    def test_garbage_string_throws(self):
+        # `frappe.throw` raises a generic exception we can match by message.
+        with mock.patch(
+            "suite.sheets.versioning.timeline.frappe.throw",
+            side_effect=ValueError("Invalid cursor"),
+        ) as m:
+            with self.assertRaises(ValueError):
+                tl._decode_cursor("not-a-real-cursor")
+            m.assert_called_once()
 
 
 class CursorShape(unittest.TestCase):
-	def test_encoded_cursor_is_url_safe(self):
-		# Base64-urlsafe characters only — no "+" or "/" that break query strings.
-		c = tl._encode_cursor(123456789)
-		self.assertNotIn("+", c)
-		self.assertNotIn("/", c)
+    def test_encoded_cursor_is_url_safe(self):
+        # Base64-urlsafe characters only — no "+" or "/" that break query strings.
+        c = tl._encode_cursor(123456789)
+        self.assertNotIn("+", c)
+        self.assertNotIn("/", c)
 
 
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()

--- a/suite/sheets/versioning/tests/test_ops_security.py
+++ b/suite/sheets/versioning/tests/test_ops_security.py
@@ -17,38 +17,38 @@ from suite.sheets.versioning import ops as ops_mod
 
 
 class CellIdGuard(unittest.TestCase):
-	def setUp(self):
-		patcher = mock.patch("suite.sheets.versioning.ops.frappe")
-		self.frappe = patcher.start()
-		self.addCleanup(patcher.stop)
-		self.frappe.has_permission.return_value = True
-		self.frappe.throw.side_effect = ValueError("bad cell id")
+    def setUp(self):
+        patcher = mock.patch("suite.sheets.versioning.ops.frappe")
+        self.frappe = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.frappe.has_permission.return_value = True
+        self.frappe.throw.side_effect = ValueError("bad cell id")
 
-	def test_valid_cell_ids_pass(self):
-		self.frappe.db.sql.return_value = []
-		for cell in ("A1", "Z99", "AA1", "ZZ9999999"):
-			ops_mod.for_cell("SH-1", cell)
+    def test_valid_cell_ids_pass(self):
+        self.frappe.db.sql.return_value = []
+        for cell in ("A1", "Z99", "AA1", "ZZ9999999"):
+            ops_mod.for_cell("SH-1", cell)
 
-	def test_wildcard_rejected(self):
-		with self.assertRaises(ValueError):
-			ops_mod.for_cell("SH-1", "%")
+    def test_wildcard_rejected(self):
+        with self.assertRaises(ValueError):
+            ops_mod.for_cell("SH-1", "%")
 
-	def test_underscore_rejected(self):
-		with self.assertRaises(ValueError):
-			ops_mod.for_cell("SH-1", "A_")
+    def test_underscore_rejected(self):
+        with self.assertRaises(ValueError):
+            ops_mod.for_cell("SH-1", "A_")
 
-	def test_quote_rejected(self):
-		with self.assertRaises(ValueError):
-			ops_mod.for_cell("SH-1", 'A1"')
+    def test_quote_rejected(self):
+        with self.assertRaises(ValueError):
+            ops_mod.for_cell("SH-1", 'A1"')
 
-	def test_lowercase_rejected(self):
-		with self.assertRaises(ValueError):
-			ops_mod.for_cell("SH-1", "a1")
+    def test_lowercase_rejected(self):
+        with self.assertRaises(ValueError):
+            ops_mod.for_cell("SH-1", "a1")
 
-	def test_empty_rejected(self):
-		with self.assertRaises(ValueError):
-			ops_mod.for_cell("SH-1", "")
+    def test_empty_rejected(self):
+        with self.assertRaises(ValueError):
+            ops_mod.for_cell("SH-1", "")
 
 
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()

--- a/suite/sheets/versioning/tests/test_retention.py
+++ b/suite/sheets/versioning/tests/test_retention.py
@@ -16,83 +16,75 @@ from suite.sheets.versioning import tasks as tasks_mod
 
 
 def _snap(name: str, hours_ago: float) -> dict:
-	return {
-		"name": name,
-		"seq": 0,
-		"creation": datetime(2026, 5, 23, 12, 0, 0) - timedelta(hours=hours_ago),
-	}
+    return {
+        "name": name,
+        "seq": 0,
+        "creation": datetime(2026, 5, 23, 12, 0, 0) - timedelta(hours=hours_ago),
+    }
 
 
 class TierLookup(unittest.TestCase):
-	def test_first_tier_chosen_for_fresh_snapshot(self):
-		idx, density = tasks_mod._tier_for(1.0, tasks_mod.DEFAULT_TIERS)
-		self.assertEqual((idx, density), (0, 0))
+    def test_first_tier_chosen_for_fresh_snapshot(self):
+        idx, density = tasks_mod._tier_for(1.0, tasks_mod.DEFAULT_TIERS)
+        self.assertEqual((idx, density), (0, 0))
 
-	def test_hourly_tier_for_a_day_old(self):
-		idx, density = tasks_mod._tier_for(48.0, tasks_mod.DEFAULT_TIERS)
-		self.assertEqual((idx, density), (1, 1))
+    def test_hourly_tier_for_a_day_old(self):
+        idx, density = tasks_mod._tier_for(48.0, tasks_mod.DEFAULT_TIERS)
+        self.assertEqual((idx, density), (1, 1))
 
-	def test_daily_tier_for_two_weeks_old(self):
-		idx, density = tasks_mod._tier_for(24 * 14, tasks_mod.DEFAULT_TIERS)
-		self.assertEqual((idx, density), (2, 24))
+    def test_daily_tier_for_two_weeks_old(self):
+        idx, density = tasks_mod._tier_for(24 * 14, tasks_mod.DEFAULT_TIERS)
+        self.assertEqual((idx, density), (2, 24))
 
 
 class PickDeletions(unittest.TestCase):
-	def setUp(self):
-		self.now = datetime(2026, 5, 23, 12, 0, 0)
+    def setUp(self):
+        self.now = datetime(2026, 5, 23, 12, 0, 0)
 
-	def test_keeps_all_in_freshest_tier(self):
-		# Six snapshots, all within 24h — none deleted.
-		snaps = [_snap(f"s{i}", hours_ago=i) for i in range(6)]
-		picked = tasks_mod._pick_deletions(
-			snaps, self.now, tasks_mod.DEFAULT_TIERS, hard_cutoff_h=24 * 90
-		)
-		self.assertEqual(picked, [])
+    def test_keeps_all_in_freshest_tier(self):
+        # Six snapshots, all within 24h — none deleted.
+        snaps = [_snap(f"s{i}", hours_ago=i) for i in range(6)]
+        picked = tasks_mod._pick_deletions(snaps, self.now, tasks_mod.DEFAULT_TIERS, hard_cutoff_h=24 * 90)
+        self.assertEqual(picked, [])
 
-	def test_thins_hourly_tier_to_one_per_hour(self):
-		# Five snapshots inside hour-bucket "37h ago": only one survives.
-		snaps = [
-			_snap("a", hours_ago=37.0),
-			_snap("b", hours_ago=37.2),
-			_snap("c", hours_ago=37.5),
-			_snap("d", hours_ago=37.8),
-			_snap("e", hours_ago=37.95),
-		]
-		picked = tasks_mod._pick_deletions(
-			snaps, self.now, tasks_mod.DEFAULT_TIERS, hard_cutoff_h=24 * 90
-		)
-		# 4 of 5 dropped, 1 kept (the first one encountered iterating
-		# newest→oldest, which is the input order here).
-		self.assertEqual(len(picked), 4)
+    def test_thins_hourly_tier_to_one_per_hour(self):
+        # Five snapshots inside hour-bucket "37h ago": only one survives.
+        snaps = [
+            _snap("a", hours_ago=37.0),
+            _snap("b", hours_ago=37.2),
+            _snap("c", hours_ago=37.5),
+            _snap("d", hours_ago=37.8),
+            _snap("e", hours_ago=37.95),
+        ]
+        picked = tasks_mod._pick_deletions(snaps, self.now, tasks_mod.DEFAULT_TIERS, hard_cutoff_h=24 * 90)
+        # 4 of 5 dropped, 1 kept (the first one encountered iterating
+        # newest→oldest, which is the input order here).
+        self.assertEqual(len(picked), 4)
 
-	def test_keeps_one_snapshot_in_each_distinct_hour_bucket(self):
-		# Two distinct hourly buckets within the hourly tier — keep one per.
-		snaps = [
-			_snap("a", hours_ago=36.0),  # bucket 36
-			_snap("b", hours_ago=36.4),  # bucket 36 — duplicate
-			_snap("c", hours_ago=40.0),  # bucket 40
-			_snap("d", hours_ago=40.6),  # bucket 40 — duplicate
-		]
-		picked = tasks_mod._pick_deletions(
-			snaps, self.now, tasks_mod.DEFAULT_TIERS, hard_cutoff_h=24 * 90
-		)
-		self.assertEqual(len(picked), 2)
-		self.assertIn("b", picked)
-		self.assertIn("d", picked)
+    def test_keeps_one_snapshot_in_each_distinct_hour_bucket(self):
+        # Two distinct hourly buckets within the hourly tier — keep one per.
+        snaps = [
+            _snap("a", hours_ago=36.0),  # bucket 36
+            _snap("b", hours_ago=36.4),  # bucket 36 — duplicate
+            _snap("c", hours_ago=40.0),  # bucket 40
+            _snap("d", hours_ago=40.6),  # bucket 40 — duplicate
+        ]
+        picked = tasks_mod._pick_deletions(snaps, self.now, tasks_mod.DEFAULT_TIERS, hard_cutoff_h=24 * 90)
+        self.assertEqual(len(picked), 2)
+        self.assertIn("b", picked)
+        self.assertIn("d", picked)
 
-	def test_hard_cutoff_deletes_everything_past_it(self):
-		snaps = [
-			_snap("recent", hours_ago=10),
-			_snap("old", hours_ago=24 * 200),
-			_snap("ancient", hours_ago=24 * 365),
-		]
-		picked = tasks_mod._pick_deletions(
-			snaps, self.now, tasks_mod.DEFAULT_TIERS, hard_cutoff_h=24 * 90
-		)
-		self.assertIn("old", picked)
-		self.assertIn("ancient", picked)
-		self.assertNotIn("recent", picked)
+    def test_hard_cutoff_deletes_everything_past_it(self):
+        snaps = [
+            _snap("recent", hours_ago=10),
+            _snap("old", hours_ago=24 * 200),
+            _snap("ancient", hours_ago=24 * 365),
+        ]
+        picked = tasks_mod._pick_deletions(snaps, self.now, tasks_mod.DEFAULT_TIERS, hard_cutoff_h=24 * 90)
+        self.assertIn("old", picked)
+        self.assertIn("ancient", picked)
+        self.assertNotIn("recent", picked)
 
 
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()

--- a/suite/sheets/versioning/tests/test_save_snapshot.py
+++ b/suite/sheets/versioning/tests/test_save_snapshot.py
@@ -24,58 +24,60 @@ from suite.sheets.versioning import save as save_mod
 
 
 def _patched_save_sheet(maybe_snapshot_side_effect=None, enqueue_should_fail=False):
-	"""Drive `save_sheet` with every DB / Frappe interaction stubbed out.
+    """Drive `save_sheet` with every DB / Frappe interaction stubbed out.
 
-	Returns the dict result + the maybe_snapshot mock for assertion.
-	"""
-	maybe_mock = mock.Mock(side_effect=maybe_snapshot_side_effect)
-	with mock.patch.object(save_mod, "snapshots_mod") as snap_mod, \
-		mock.patch.object(save_mod, "_update_existing", return_value=("sheet_x", 7)), \
-		mock.patch.object(save_mod, "encode_sheets_data", return_value="ENCODED"), \
-		mock.patch.object(save_mod, "_validate_payload", return_value='{"A1":1}'), \
-		mock.patch.object(save_mod.frappe, "log_error") as log_error, \
-		mock.patch.object(save_mod.frappe, "get_traceback", return_value="trace"), \
-		mock.patch.object(save_mod.frappe, "enqueue") as enqueue_mock:
-		snap_mod.maybe_snapshot = maybe_mock
-		if enqueue_should_fail:
-			enqueue_mock.side_effect = AssertionError("save_sheet must not enqueue")
-		out = save_mod.save_sheet(
-			title="My Sheet",
-			sheets_data='{"A1":1}',
-			name="sheet_x",
-			ops=None,
-		)
-	return out, maybe_mock, log_error
+    Returns the dict result + the maybe_snapshot mock for assertion.
+    """
+    maybe_mock = mock.Mock(side_effect=maybe_snapshot_side_effect)
+    with (
+        mock.patch.object(save_mod, "snapshots_mod") as snap_mod,
+        mock.patch.object(save_mod, "_update_existing", return_value=("sheet_x", 7)),
+        mock.patch.object(save_mod, "encode_sheets_data", return_value="ENCODED"),
+        mock.patch.object(save_mod, "_validate_payload", return_value='{"A1":1}'),
+        mock.patch.object(save_mod.frappe, "log_error") as log_error,
+        mock.patch.object(save_mod.frappe, "get_traceback", return_value="trace"),
+        mock.patch.object(save_mod.frappe, "enqueue") as enqueue_mock,
+    ):
+        snap_mod.maybe_snapshot = maybe_mock
+        if enqueue_should_fail:
+            enqueue_mock.side_effect = AssertionError("save_sheet must not enqueue")
+        out = save_mod.save_sheet(
+            title="My Sheet",
+            sheets_data='{"A1":1}',
+            name="sheet_x",
+            ops=None,
+        )
+    return out, maybe_mock, log_error
 
 
 class InlineSnapshotFromSave(unittest.TestCase):
-	def test_save_sheet_calls_maybe_snapshot_inline(self):
-		out, maybe_mock, _ = _patched_save_sheet()
-		# Inline, not enqueued — the worker is no longer in the critical path.
-		self.assertEqual(out, {"name": "sheet_x", "head_seq": 7})
-		maybe_mock.assert_called_once_with("sheet_x", expected_head_seq=7)
+    def test_save_sheet_calls_maybe_snapshot_inline(self):
+        out, maybe_mock, _ = _patched_save_sheet()
+        # Inline, not enqueued — the worker is no longer in the critical path.
+        self.assertEqual(out, {"name": "sheet_x", "head_seq": 7})
+        maybe_mock.assert_called_once_with("sheet_x", expected_head_seq=7)
 
-	def test_save_sheet_never_enqueues(self):
-		# Hard assertion that we never silently fall back to the old async
-		# path — `enqueue_should_fail=True` blows up if `frappe.enqueue` is
-		# touched during the save.
-		out, _, _ = _patched_save_sheet(enqueue_should_fail=True)
-		self.assertEqual(out["head_seq"], 7)
+    def test_save_sheet_never_enqueues(self):
+        # Hard assertion that we never silently fall back to the old async
+        # path — `enqueue_should_fail=True` blows up if `frappe.enqueue` is
+        # touched during the save.
+        out, _, _ = _patched_save_sheet(enqueue_should_fail=True)
+        self.assertEqual(out["head_seq"], 7)
 
-	def test_snapshot_failure_does_not_fail_the_save(self):
-		# Ops are already persisted before maybe_snapshot runs; a failure
-		# here must NOT propagate (otherwise the request 500s and the
-		# client thinks the save was lost — data is fine, just no
-		# snapshot for this round).
-		out, _, log_error = _patched_save_sheet(
-			maybe_snapshot_side_effect=RuntimeError("disk full"),
-		)
-		self.assertEqual(out["head_seq"], 7)
-		log_error.assert_called_once()
-		# The error message should make it obvious this is a snapshot
-		# failure (not a save failure) when ops triage finds it.
-		self.assertIn("maybe_snapshot", log_error.call_args.kwargs["title"])
+    def test_snapshot_failure_does_not_fail_the_save(self):
+        # Ops are already persisted before maybe_snapshot runs; a failure
+        # here must NOT propagate (otherwise the request 500s and the
+        # client thinks the save was lost — data is fine, just no
+        # snapshot for this round).
+        out, _, log_error = _patched_save_sheet(
+            maybe_snapshot_side_effect=RuntimeError("disk full"),
+        )
+        self.assertEqual(out["head_seq"], 7)
+        log_error.assert_called_once()
+        # The error message should make it obvious this is a snapshot
+        # failure (not a save failure) when ops triage finds it.
+        self.assertIn("maybe_snapshot", log_error.call_args.kwargs["title"])
 
 
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()

--- a/suite/sheets/versioning/tests/test_save_validation.py
+++ b/suite/sheets/versioning/tests/test_save_validation.py
@@ -18,90 +18,90 @@ from suite.sheets.versioning import save as save_mod
 
 
 class TitleCleaning(unittest.TestCase):
-	def test_strips_whitespace(self):
-		self.assertEqual(save_mod._clean_title("  My Sheet  "), "My Sheet")
+    def test_strips_whitespace(self):
+        self.assertEqual(save_mod._clean_title("  My Sheet  "), "My Sheet")
 
-	def test_blank_becomes_default(self):
-		self.assertEqual(save_mod._clean_title(""), "Untitled Spreadsheet")
-		self.assertEqual(save_mod._clean_title("   "), "Untitled Spreadsheet")
+    def test_blank_becomes_default(self):
+        self.assertEqual(save_mod._clean_title(""), "Untitled Spreadsheet")
+        self.assertEqual(save_mod._clean_title("   "), "Untitled Spreadsheet")
 
-	def test_truncates_to_max_length(self):
-		long = "x" * 1000
-		self.assertEqual(len(save_mod._clean_title(long)), save_mod.MAX_TITLE_LEN)
+    def test_truncates_to_max_length(self):
+        long = "x" * 1000
+        self.assertEqual(len(save_mod._clean_title(long)), save_mod.MAX_TITLE_LEN)
 
 
 class PayloadValidation(unittest.TestCase):
-	def test_plain_json_passes(self):
-		payload = json.dumps({"A1": "hi"})
-		self.assertEqual(save_mod._validate_payload(payload), payload)
+    def test_plain_json_passes(self):
+        payload = json.dumps({"A1": "hi"})
+        self.assertEqual(save_mod._validate_payload(payload), payload)
 
-	def test_envelope_decoded_for_size_check(self):
-		# A compressed envelope around a tiny JSON payload should validate
-		# against the *uncompressed* size.
-		plain = json.dumps({"A1": "hi"})
-		envelope = encode_sheets_data(plain)
-		self.assertEqual(save_mod._validate_payload(envelope), plain)
+    def test_envelope_decoded_for_size_check(self):
+        # A compressed envelope around a tiny JSON payload should validate
+        # against the *uncompressed* size.
+        plain = json.dumps({"A1": "hi"})
+        envelope = encode_sheets_data(plain)
+        self.assertEqual(save_mod._validate_payload(envelope), plain)
 
-	def test_non_string_throws(self):
-		with mock.patch(
-			"suite.sheets.versioning.save.frappe.throw",
-			side_effect=ValueError("must be string"),
-		):
-			with self.assertRaises(ValueError):
-				save_mod._validate_payload({"not": "a string"})
+    def test_non_string_throws(self):
+        with mock.patch(
+            "suite.sheets.versioning.save.frappe.throw",
+            side_effect=ValueError("must be string"),
+        ):
+            with self.assertRaises(ValueError):
+                save_mod._validate_payload({"not": "a string"})
 
-	def test_invalid_json_throws(self):
-		with mock.patch(
-			"suite.sheets.versioning.save.frappe.throw",
-			side_effect=ValueError("not valid JSON"),
-		):
-			with self.assertRaises(ValueError):
-				save_mod._validate_payload("{not json}")
+    def test_invalid_json_throws(self):
+        with mock.patch(
+            "suite.sheets.versioning.save.frappe.throw",
+            side_effect=ValueError("not valid JSON"),
+        ):
+            with self.assertRaises(ValueError):
+                save_mod._validate_payload("{not json}")
 
 
 class OpsCoercion(unittest.TestCase):
-	def test_none_returns_empty(self):
-		self.assertEqual(save_mod._coerce_ops(None), [])
+    def test_none_returns_empty(self):
+        self.assertEqual(save_mod._coerce_ops(None), [])
 
-	def test_empty_string_returns_empty(self):
-		self.assertEqual(save_mod._coerce_ops(""), [])
+    def test_empty_string_returns_empty(self):
+        self.assertEqual(save_mod._coerce_ops(""), [])
 
-	def test_string_json_array_parsed(self):
-		ops = save_mod._coerce_ops('[{"op_type":"edit"}]')
-		self.assertEqual(ops, [{"op_type": "edit"}])
+    def test_string_json_array_parsed(self):
+        ops = save_mod._coerce_ops('[{"op_type":"edit"}]')
+        self.assertEqual(ops, [{"op_type": "edit"}])
 
-	def test_list_passes_through(self):
-		ops = [{"op_type": "paste"}]
-		self.assertEqual(save_mod._coerce_ops(ops), ops)
+    def test_list_passes_through(self):
+        ops = [{"op_type": "paste"}]
+        self.assertEqual(save_mod._coerce_ops(ops), ops)
 
-	def test_non_array_throws(self):
-		with mock.patch(
-			"suite.sheets.versioning.save.frappe.throw",
-			side_effect=ValueError("must be array"),
-		):
-			with self.assertRaises(ValueError):
-				save_mod._coerce_ops('{"not": "an array"}')
+    def test_non_array_throws(self):
+        with mock.patch(
+            "suite.sheets.versioning.save.frappe.throw",
+            side_effect=ValueError("must be array"),
+        ):
+            with self.assertRaises(ValueError):
+                save_mod._coerce_ops('{"not": "an array"}')
 
-	def test_too_many_ops_throws(self):
-		too_many = [{"op_type": "edit"}] * (save_mod.MAX_OPS_PER_SAVE + 1)
-		with mock.patch(
-			"suite.sheets.versioning.save.frappe.throw",
-			side_effect=ValueError("too many"),
-		):
-			with self.assertRaises(ValueError):
-				save_mod._coerce_ops(too_many)
+    def test_too_many_ops_throws(self):
+        too_many = [{"op_type": "edit"}] * (save_mod.MAX_OPS_PER_SAVE + 1)
+        with mock.patch(
+            "suite.sheets.versioning.save.frappe.throw",
+            side_effect=ValueError("too many"),
+        ):
+            with self.assertRaises(ValueError):
+                save_mod._coerce_ops(too_many)
 
 
 class ByteFormatter(unittest.TestCase):
-	def test_bytes(self):
-		self.assertEqual(save_mod._format_bytes(900), "900 B")
+    def test_bytes(self):
+        self.assertEqual(save_mod._format_bytes(900), "900 B")
 
-	def test_kilobytes(self):
-		self.assertIn("KB", save_mod._format_bytes(5000))
+    def test_kilobytes(self):
+        self.assertIn("KB", save_mod._format_bytes(5000))
 
-	def test_megabytes(self):
-		self.assertIn("MB", save_mod._format_bytes(5 * 1024 * 1024))
+    def test_megabytes(self):
+        self.assertIn("MB", save_mod._format_bytes(5 * 1024 * 1024))
 
 
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()

--- a/suite/sheets/versioning/tests/test_snapshot_policy.py
+++ b/suite/sheets/versioning/tests/test_snapshot_policy.py
@@ -17,59 +17,59 @@ from suite.sheets.versioning import snapshots as snap_mod
 
 
 def _last(seq: int, mins_ago: float) -> dict:
-	"""Build a fake `_last_snapshot` row."""
-	return {
-		"name": "snap-x",
-		"seq": seq,
-		"creation": datetime(2026, 5, 23, 12, 0, 0) - timedelta(minutes=mins_ago),
-	}
+    """Build a fake `_last_snapshot` row."""
+    return {
+        "name": "snap-x",
+        "seq": seq,
+        "creation": datetime(2026, 5, 23, 12, 0, 0) - timedelta(minutes=mins_ago),
+    }
 
 
 class ShouldSnapshotPolicy(unittest.TestCase):
-	def setUp(self):
-		# Pin "now" so age computations are deterministic.
-		self._now = datetime(2026, 5, 23, 12, 0, 0)
-		patcher = mock.patch.object(snap_mod, "now_datetime", return_value=self._now)
-		self.addCleanup(patcher.stop)
-		patcher.start()
-		# Ignore site-config overrides during tests.
-		conf_patch = mock.patch("suite.sheets.versioning.snapshots.frappe.conf", {})
-		self.addCleanup(conf_patch.stop)
-		conf_patch.start()
+    def setUp(self):
+        # Pin "now" so age computations are deterministic.
+        self._now = datetime(2026, 5, 23, 12, 0, 0)
+        patcher = mock.patch.object(snap_mod, "now_datetime", return_value=self._now)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+        # Ignore site-config overrides during tests.
+        conf_patch = mock.patch("suite.sheets.versioning.snapshots.frappe.conf", {})
+        self.addCleanup(conf_patch.stop)
+        conf_patch.start()
 
-	def test_no_ops_yet_no_snapshot(self):
-		self.assertFalse(snap_mod._should_snapshot(head_seq=0, last=None))
+    def test_no_ops_yet_no_snapshot(self):
+        self.assertFalse(snap_mod._should_snapshot(head_seq=0, last=None))
 
-	def test_first_snapshot_taken_when_ops_exist(self):
-		self.assertTrue(snap_mod._should_snapshot(head_seq=1, last=None))
+    def test_first_snapshot_taken_when_ops_exist(self):
+        self.assertTrue(snap_mod._should_snapshot(head_seq=1, last=None))
 
-	def test_skipped_when_head_did_not_advance(self):
-		last = _last(seq=50, mins_ago=10)
-		self.assertFalse(snap_mod._should_snapshot(head_seq=50, last=last))
+    def test_skipped_when_head_did_not_advance(self):
+        last = _last(seq=50, mins_ago=10)
+        self.assertFalse(snap_mod._should_snapshot(head_seq=50, last=last))
 
-	def test_skipped_when_under_both_thresholds(self):
-		# 5 ops, 10 seconds ago — under both the 25-op and 30-s thresholds,
-		# so rapid autosaves cluster into the previous snapshot rather than
-		# spamming a row per save.
-		last = _last(seq=50, mins_ago=10 / 60)
-		self.assertFalse(snap_mod._should_snapshot(head_seq=55, last=last))
+    def test_skipped_when_under_both_thresholds(self):
+        # 5 ops, 10 seconds ago — under both the 25-op and 30-s thresholds,
+        # so rapid autosaves cluster into the previous snapshot rather than
+        # spamming a row per save.
+        last = _last(seq=50, mins_ago=10 / 60)
+        self.assertFalse(snap_mod._should_snapshot(head_seq=55, last=last))
 
-	def test_triggered_by_ops_threshold(self):
-		last = _last(seq=0, mins_ago=1 / 60)
-		# 25-op threshold — even a burst of edits within a few seconds
-		# produces a new snapshot so the timeline stays accurate.
-		self.assertTrue(snap_mod._should_snapshot(head_seq=25, last=last))
+    def test_triggered_by_ops_threshold(self):
+        last = _last(seq=0, mins_ago=1 / 60)
+        # 25-op threshold — even a burst of edits within a few seconds
+        # produces a new snapshot so the timeline stays accurate.
+        self.assertTrue(snap_mod._should_snapshot(head_seq=25, last=last))
 
-	def test_triggered_by_time_threshold_with_any_ops(self):
-		last = _last(seq=50, mins_ago=1)
-		# 1 op in 1 minute — under op threshold but over the 30-s time
-		# threshold; the next save snapshots so the panel reflects activity.
-		self.assertTrue(snap_mod._should_snapshot(head_seq=51, last=last))
+    def test_triggered_by_time_threshold_with_any_ops(self):
+        last = _last(seq=50, mins_ago=1)
+        # 1 op in 1 minute — under op threshold but over the 30-s time
+        # threshold; the next save snapshots so the panel reflects activity.
+        self.assertTrue(snap_mod._should_snapshot(head_seq=51, last=last))
 
-	def test_time_threshold_alone_does_not_fire_without_ops(self):
-		last = _last(seq=50, mins_ago=60)
-		self.assertFalse(snap_mod._should_snapshot(head_seq=50, last=last))
+    def test_time_threshold_alone_does_not_fire_without_ops(self):
+        last = _last(seq=50, mins_ago=60)
+        self.assertFalse(snap_mod._should_snapshot(head_seq=50, last=last))
 
 
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()

--- a/suite/sheets/versioning/timeline.py
+++ b/suite/sheets/versioning/timeline.py
@@ -28,191 +28,187 @@ ALL_BUCKETS = (BUCKET_PINNED, BUCKET_TODAY, BUCKET_YESTERDAY, BUCKET_WEEK, BUCKE
 
 
 def list_buckets(sheet: str, tz_offset_minutes: int = 0, bucket_limit: int = 20) -> dict:
-	"""Return a first-page payload for the history panel.
+    """Return a first-page payload for the history panel.
 
-	Shape:
-	  { "buckets": {
-	      "pinned":    { "items": [...], "count": N, "next_cursor": str|None },
-	      "today":     { ... },
-	      "yesterday": { ... },
-	      "week":      { ... },
-	      "earlier":   { ... },
-	    },
-	    "head_snapshot": str|None,
-	  }
-	"""
-	frappe.has_permission("Sheet", doc=sheet, throw=True)
-	now_local = now_datetime() + timedelta(minutes=tz_offset_minutes)
-	start_today = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
-	start_yesterday = start_today - timedelta(days=1)
-	start_week = start_today - timedelta(days=7)
+    Shape:
+      { "buckets": {
+          "pinned":    { "items": [...], "count": N, "next_cursor": str|None },
+          "today":     { ... },
+          "yesterday": { ... },
+          "week":      { ... },
+          "earlier":   { ... },
+        },
+        "head_snapshot": str|None,
+      }
+    """
+    frappe.has_permission("Sheet", doc=sheet, throw=True)
+    now_local = now_datetime() + timedelta(minutes=tz_offset_minutes)
+    start_today = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+    start_yesterday = start_today - timedelta(days=1)
+    start_week = start_today - timedelta(days=7)
 
-	# Convert the local bucket boundaries back to server UTC for SQL.
-	utc_today = start_today - timedelta(minutes=tz_offset_minutes)
-	utc_yesterday = start_yesterday - timedelta(minutes=tz_offset_minutes)
-	utc_week = start_week - timedelta(minutes=tz_offset_minutes)
+    # Convert the local bucket boundaries back to server UTC for SQL.
+    utc_today = start_today - timedelta(minutes=tz_offset_minutes)
+    utc_yesterday = start_yesterday - timedelta(minutes=tz_offset_minutes)
+    utc_week = start_week - timedelta(minutes=tz_offset_minutes)
 
-	pinned = _query_bucket(sheet, pinned_only=True, limit=bucket_limit)
-	today = _query_bucket(sheet, after=utc_today, limit=bucket_limit)
-	yesterday = _query_bucket(
-		sheet, after=utc_yesterday, before=utc_today, limit=bucket_limit
-	)
-	week = _query_bucket(
-		sheet, after=utc_week, before=utc_yesterday, limit=bucket_limit
-	)
-	earlier = _query_bucket(sheet, before=utc_week, limit=bucket_limit)
+    pinned = _query_bucket(sheet, pinned_only=True, limit=bucket_limit)
+    today = _query_bucket(sheet, after=utc_today, limit=bucket_limit)
+    yesterday = _query_bucket(sheet, after=utc_yesterday, before=utc_today, limit=bucket_limit)
+    week = _query_bucket(sheet, after=utc_week, before=utc_yesterday, limit=bucket_limit)
+    earlier = _query_bucket(sheet, before=utc_week, limit=bucket_limit)
 
-	head_snapshot = frappe.db.get_value("Sheet", sheet, "head_snapshot")
+    head_snapshot = frappe.db.get_value("Sheet", sheet, "head_snapshot")
 
-	return {
-		"buckets": {
-			BUCKET_PINNED: pinned,
-			BUCKET_TODAY: today,
-			BUCKET_YESTERDAY: yesterday,
-			BUCKET_WEEK: week,
-			BUCKET_EARLIER: earlier,
-		},
-		"head_snapshot": head_snapshot,
-	}
+    return {
+        "buckets": {
+            BUCKET_PINNED: pinned,
+            BUCKET_TODAY: today,
+            BUCKET_YESTERDAY: yesterday,
+            BUCKET_WEEK: week,
+            BUCKET_EARLIER: earlier,
+        },
+        "head_snapshot": head_snapshot,
+    }
 
 
 def list_bucket_page(
-	sheet: str,
-	bucket: str,
-	cursor: str | None = None,
-	limit: int = 20,
-	tz_offset_minutes: int = 0,
+    sheet: str,
+    bucket: str,
+    cursor: str | None = None,
+    limit: int = 20,
+    tz_offset_minutes: int = 0,
 ) -> dict:
-	"""Fetch a subsequent page within a single bucket."""
-	if bucket not in ALL_BUCKETS:
-		frappe.throw(f"Unknown bucket: {bucket}")
-	frappe.has_permission("Sheet", doc=sheet, throw=True)
+    """Fetch a subsequent page within a single bucket."""
+    if bucket not in ALL_BUCKETS:
+        frappe.throw(f"Unknown bucket: {bucket}")
+    frappe.has_permission("Sheet", doc=sheet, throw=True)
 
-	now_local = now_datetime() + timedelta(minutes=tz_offset_minutes)
-	start_today = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
-	start_yesterday = start_today - timedelta(days=1)
-	start_week = start_today - timedelta(days=7)
-	utc_today = start_today - timedelta(minutes=tz_offset_minutes)
-	utc_yesterday = start_yesterday - timedelta(minutes=tz_offset_minutes)
-	utc_week = start_week - timedelta(minutes=tz_offset_minutes)
+    now_local = now_datetime() + timedelta(minutes=tz_offset_minutes)
+    start_today = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+    start_yesterday = start_today - timedelta(days=1)
+    start_week = start_today - timedelta(days=7)
+    utc_today = start_today - timedelta(minutes=tz_offset_minutes)
+    utc_yesterday = start_yesterday - timedelta(minutes=tz_offset_minutes)
+    utc_week = start_week - timedelta(minutes=tz_offset_minutes)
 
-	kwargs = {"sheet": sheet, "limit": limit, "cursor": _decode_cursor(cursor)}
-	if bucket == BUCKET_PINNED:
-		kwargs["pinned_only"] = True
-	elif bucket == BUCKET_TODAY:
-		kwargs["after"] = utc_today
-	elif bucket == BUCKET_YESTERDAY:
-		kwargs["after"] = utc_yesterday
-		kwargs["before"] = utc_today
-	elif bucket == BUCKET_WEEK:
-		kwargs["after"] = utc_week
-		kwargs["before"] = utc_yesterday
-	elif bucket == BUCKET_EARLIER:
-		kwargs["before"] = utc_week
+    kwargs = {"sheet": sheet, "limit": limit, "cursor": _decode_cursor(cursor)}
+    if bucket == BUCKET_PINNED:
+        kwargs["pinned_only"] = True
+    elif bucket == BUCKET_TODAY:
+        kwargs["after"] = utc_today
+    elif bucket == BUCKET_YESTERDAY:
+        kwargs["after"] = utc_yesterday
+        kwargs["before"] = utc_today
+    elif bucket == BUCKET_WEEK:
+        kwargs["after"] = utc_week
+        kwargs["before"] = utc_yesterday
+    elif bucket == BUCKET_EARLIER:
+        kwargs["before"] = utc_week
 
-	return _query_bucket(**kwargs)
+    return _query_bucket(**kwargs)
 
 
 def _query_bucket(
-	sheet: str,
-	*,
-	pinned_only: bool = False,
-	after: datetime | None = None,
-	before: datetime | None = None,
-	limit: int = 20,
-	cursor: int | None = None,
+    sheet: str,
+    *,
+    pinned_only: bool = False,
+    after: datetime | None = None,
+    before: datetime | None = None,
+    limit: int = 20,
+    cursor: int | None = None,
 ) -> dict:
-	filters = {"sheet": sheet}
-	if pinned_only:
-		filters["pinned"] = 1
-	if after is not None:
-		filters["creation"] = (">=", after)
-	if before is not None:
-		# Combine with `after` if present — Frappe accepts a tuple of conditions
-		# via the `between` operator, but two separate conditions is clearer.
-		filters_extra = filters.copy()
-		if after is not None:
-			# We need both bounds; use raw SQL for the dual-condition case.
-			return _query_dual_bound(
-				sheet=sheet,
-				after=after,
-				before=before,
-				pinned_only=pinned_only,
-				limit=limit,
-				cursor=cursor,
-			)
-		filters["creation"] = ("<", before)
-	if cursor is not None:
-		filters["seq"] = ("<", cursor)
+    filters = {"sheet": sheet}
+    if pinned_only:
+        filters["pinned"] = 1
+    if after is not None:
+        filters["creation"] = (">=", after)
+    if before is not None:
+        # Combine with `after` if present — Frappe accepts a tuple of conditions
+        # via the `between` operator, but two separate conditions is clearer.
+        filters_extra = filters.copy()
+        if after is not None:
+            # We need both bounds; use raw SQL for the dual-condition case.
+            return _query_dual_bound(
+                sheet=sheet,
+                after=after,
+                before=before,
+                pinned_only=pinned_only,
+                limit=limit,
+                cursor=cursor,
+            )
+        filters["creation"] = ("<", before)
+    if cursor is not None:
+        filters["seq"] = ("<", cursor)
 
-	rows = frappe.get_all(
-		"Sheet Snapshot",
-		filters=filters,
-		fields=["name", "seq", "kind", "label", "pinned", "op_count", "actor", "creation"],
-		order_by="seq desc",
-		limit=limit + 1,
-	)
-	return _shape(rows, limit)
+    rows = frappe.get_all(
+        "Sheet Snapshot",
+        filters=filters,
+        fields=["name", "seq", "kind", "label", "pinned", "op_count", "actor", "creation"],
+        order_by="seq desc",
+        limit=limit + 1,
+    )
+    return _shape(rows, limit)
 
 
 def _query_dual_bound(
-	sheet: str,
-	after: datetime,
-	before: datetime,
-	pinned_only: bool,
-	limit: int,
-	cursor: int | None,
+    sheet: str,
+    after: datetime,
+    before: datetime,
+    pinned_only: bool,
+    limit: int,
+    cursor: int | None,
 ) -> dict:
-	conditions = ["sheet = %(sheet)s", "creation >= %(after)s", "creation < %(before)s"]
-	params: dict = {"sheet": sheet, "after": after, "before": before, "limit": limit + 1}
-	if pinned_only:
-		conditions.append("pinned = 1")
-	if cursor is not None:
-		conditions.append("seq < %(cursor)s")
-		params["cursor"] = cursor
-	sql = (
-		"SELECT name, seq, kind, label, pinned, op_count, actor, creation "
-		"FROM `tabSheet Snapshot` "
-		f"WHERE {' AND '.join(conditions)} "
-		"ORDER BY seq DESC LIMIT %(limit)s"
-	)
-	rows = frappe.db.sql(sql, params, as_dict=True)
-	return _shape(rows, limit)
+    conditions = ["sheet = %(sheet)s", "creation >= %(after)s", "creation < %(before)s"]
+    params: dict = {"sheet": sheet, "after": after, "before": before, "limit": limit + 1}
+    if pinned_only:
+        conditions.append("pinned = 1")
+    if cursor is not None:
+        conditions.append("seq < %(cursor)s")
+        params["cursor"] = cursor
+    sql = (
+        "SELECT name, seq, kind, label, pinned, op_count, actor, creation "
+        "FROM `tabSheet Snapshot` "
+        f"WHERE {' AND '.join(conditions)} "
+        "ORDER BY seq DESC LIMIT %(limit)s"
+    )
+    rows = frappe.db.sql(sql, params, as_dict=True)
+    return _shape(rows, limit)
 
 
 def _shape(rows: list[dict], limit: int) -> dict:
-	has_more = len(rows) > limit
-	items = rows[:limit]
-	next_cursor = _encode_cursor(items[-1]["seq"]) if has_more and items else None
-	return {
-		"items": [_serialise(r) for r in items],
-		"count": len(items),
-		"next_cursor": next_cursor,
-	}
+    has_more = len(rows) > limit
+    items = rows[:limit]
+    next_cursor = _encode_cursor(items[-1]["seq"]) if has_more and items else None
+    return {
+        "items": [_serialise(r) for r in items],
+        "count": len(items),
+        "next_cursor": next_cursor,
+    }
 
 
 def _serialise(row: dict) -> dict:
-	return {
-		"id": row["name"],
-		"seq": int(row.get("seq") or 0),
-		"kind": row.get("kind"),
-		"label": row.get("label"),
-		"pinned": bool(row.get("pinned")),
-		"op_count": int(row.get("op_count") or 0),
-		"actor": row.get("actor"),
-		"creation": row.get("creation").isoformat() if row.get("creation") else None,
-	}
+    return {
+        "id": row["name"],
+        "seq": int(row.get("seq") or 0),
+        "kind": row.get("kind"),
+        "label": row.get("label"),
+        "pinned": bool(row.get("pinned")),
+        "op_count": int(row.get("op_count") or 0),
+        "actor": row.get("actor"),
+        "creation": row.get("creation").isoformat() if row.get("creation") else None,
+    }
 
 
 def _encode_cursor(seq: int) -> str:
-	return base64.urlsafe_b64encode(json.dumps({"seq": int(seq)}).encode()).decode()
+    return base64.urlsafe_b64encode(json.dumps({"seq": int(seq)}).encode()).decode()
 
 
 def _decode_cursor(cursor: str | None) -> int | None:
-	if not cursor:
-		return None
-	try:
-		raw = base64.urlsafe_b64decode(cursor.encode()).decode()
-		return int(json.loads(raw)["seq"])
-	except Exception:
-		frappe.throw("Invalid cursor")
+    if not cursor:
+        return None
+    try:
+        raw = base64.urlsafe_b64decode(cursor.encode()).decode()
+        return int(json.loads(raw)["seq"])
+    except Exception:
+        frappe.throw("Invalid cursor")

--- a/suite/sheets/www/sheets.py
+++ b/suite/sheets/www/sheets.py
@@ -3,7 +3,6 @@ import os
 
 import frappe
 
-
 # Bundle URL resolution ─────────────────────────────────────────────────────
 #
 # Vite emits content-hashed filenames (e.g. `index.abc123.js`) plus a manifest

--- a/suite/sheets/www/sheets.py
+++ b/suite/sheets/www/sheets.py
@@ -23,7 +23,10 @@ def _read_asset_manifest() -> dict:
     global _ASSET_CACHE, _ASSET_CACHE_MTIME
     path = os.path.join(
         frappe.get_app_path("suite", "sheets"),
-        "public", "sheets", ".vite", "manifest.json",
+        "public",
+        "sheets",
+        ".vite",
+        "manifest.json",
     )
     try:
         mtime = os.path.getmtime(path)
@@ -44,10 +47,10 @@ def _read_asset_manifest() -> dict:
 def _asset_paths() -> dict:
     manifest = _read_asset_manifest()
     entry = manifest.get("index.html") or {}
-    js  = entry.get("file") or "index.js"
-    css = entry.get("css")  or ["index.css"]
+    js = entry.get("file") or "index.js"
+    css = entry.get("css") or ["index.css"]
     return {
-        "js":  _ASSET_BASE + js,
+        "js": _ASSET_BASE + js,
         "css": [_ASSET_BASE + c for c in css],
     }
 
@@ -77,16 +80,16 @@ def get_context(context):
     # `sid` is treated the same way Frappe Desk does — injected into the
     # rendered HTML so JS can read it; an XSS already implies full session
     # compromise via cookie auth, so this doesn't widen the blast radius.
-    context.collab_v2     = bool(frappe.conf.get("collab_v2") or False)
+    context.collab_v2 = bool(frappe.conf.get("collab_v2") or False)
     context.collab_ws_url = frappe.conf.get("collab_ws_url") or None
-    context.session_sid   = getattr(frappe.session, "sid", "") or ""
+    context.session_sid = getattr(frappe.session, "sid", "") or ""
 
     # Sitename + socketio_port let the SPA stand up its own `frappe.realtime`
     # against the site's socket.io namespace. Without these, the legacy
     # presence path silently has no transport on the public www page and
     # the avatar pile stays empty even with concurrent users on the sheet.
-    context.sitename       = frappe.local.site
-    context.socketio_port  = frappe.conf.get("socketio_port") or 9000
+    context.sitename = frappe.local.site
+    context.socketio_port = frappe.conf.get("socketio_port") or 9000
 
     # AI Assist gating for the SPA topbar. `extend_bootinfo` is desk-only, so —
     # like the collab flags above — these are seeded here into the SPA's boot:
@@ -102,9 +105,7 @@ def get_context(context):
         # The keyless "mock"/"demo" model counts as configured so the button
         # shows for a local, no-spend trial.
         model = (ai.model or "").strip().lower()
-        has_creds = model in ("mock", "demo") or bool(
-            ai.get_password("api_key", raise_exception=False)
-        )
+        has_creds = model in ("mock", "demo") or bool(ai.get_password("api_key", raise_exception=False))
         context.ai_assist_enabled = bool(ai.enabled and has_creds)
     except Exception:
         pass
@@ -116,9 +117,8 @@ def get_context(context):
     # `sheets_sentry_dsn` in site_config.json. The SPA's
     # frontend/src/utils/sentry.js reads these off window.frappe.boot
     # and short-circuits when the DSN is empty.
-    context.sentry_dsn         = frappe.conf.get("sheets_sentry_dsn") or ""
-    context.sentry_environment = (
-        frappe.conf.get("sheets_sentry_environment")
-        or ("development" if frappe.conf.get("developer_mode") else "production")
+    context.sentry_dsn = frappe.conf.get("sheets_sentry_dsn") or ""
+    context.sentry_environment = frappe.conf.get("sheets_sentry_environment") or (
+        "development" if frappe.conf.get("developer_mode") else "production"
     )
     context.sentry_release = frappe.conf.get("sheets_sentry_release") or ""

--- a/suite/slides/api/file.py
+++ b/suite/slides/api/file.py
@@ -8,119 +8,119 @@ from werkzeug.wrappers import Response
 
 
 def get_file_size(file_path: str) -> int:
-	"""
-	Returns the size of the file at the given path.
-	"""
-	return os.path.getsize(file_path)
+    """
+    Returns the size of the file at the given path.
+    """
+    return os.path.getsize(file_path)
 
 
 def get_range(range_header: str, file_size: int) -> tuple[int, int]:
-	"""
-	Extracts the byte range from Range header.
-	"""
-	import re
+    """
+    Extracts the byte range from Range header.
+    """
+    import re
 
-	range_start, range_end = 0, None
-	match = re.search(r"bytes=(\d+)-(\d*)", range_header)
+    range_start, range_end = 0, None
+    match = re.search(r"bytes=(\d+)-(\d*)", range_header)
 
-	if match:
-		range_start = int(match.group(1))
-		if match.group(2):
-			range_end = int(match.group(2))
+    if match:
+        range_start = int(match.group(1))
+        if match.group(2):
+            range_end = int(match.group(2))
 
-	range_end = range_end or file_size - 1
+    range_end = range_end or file_size - 1
 
-	return range_start, range_end
+    return range_start, range_end
 
 
 def get_file_data(file_path: str, range_start: int = 0, range_end: int = 0) -> bytes:
-	"""
-	Returns specified range of bytes from the file.
-	If range_end is None, returns the full file content.
-	"""
-	with open(file_path, "rb") as f:
-		f.seek(range_start)
+    """
+    Returns specified range of bytes from the file.
+    If range_end is None, returns the full file content.
+    """
+    with open(file_path, "rb") as f:
+        f.seek(range_start)
 
-		if range_end == 0:
-			# return the full file content in the response
-			data = f.read()
-		else:
-			# read the specified range from the file
-			data = f.read(range_end - range_start + 1)
+        if range_end == 0:
+            # return the full file content in the response
+            data = f.read()
+        else:
+            # read the specified range from the file
+            data = f.read(range_end - range_start + 1)
 
-	return data
+    return data
 
 
 def get_file_metadata(src: str) -> tuple[str, int, str]:
-	"""
-	Returns file metadata including path, size, and MIME type.
-	"""
-	if src.startswith("/files"):
-		src = "/public" + src
-	file_path = frappe.get_site_path() + src
-	file_size = get_file_size(file_path)
-	mimetype = mimetypes.guess_type(file_path)[0] or "video/mp4"
+    """
+    Returns file metadata including path, size, and MIME type.
+    """
+    if src.startswith("/files"):
+        src = "/public" + src
+    file_path = frappe.get_site_path() + src
+    file_size = get_file_size(file_path)
+    mimetype = mimetypes.guess_type(file_path)[0] or "video/mp4"
 
-	return file_path, file_size, mimetype
+    return file_path, file_size, mimetype
 
 
 def get_media_response(src: str) -> Response:
-	"""
-	Processes the range header from browser to return valid response.
-	"""
-	file_path, file_size, mimetype = get_file_metadata(src)
+    """
+    Processes the range header from browser to return valid response.
+    """
+    file_path, file_size, mimetype = get_file_metadata(src)
 
-	range_header = frappe.request.headers.get("Range", None)
-	range_start, range_end = None, None
+    range_header = frappe.request.headers.get("Range", None)
+    range_start, range_end = None, None
 
-	# if the request includes a Range header, return a partial content response
-	if range_header:
-		range_start, range_end = get_range(range_header, file_size)
+    # if the request includes a Range header, return a partial content response
+    if range_header:
+        range_start, range_end = get_range(range_header, file_size)
 
-		file_data = get_file_data(file_path, range_start, range_end)
-		status_code = 206  # Partial Content
-		content_length = range_end - range_start + 1
+        file_data = get_file_data(file_path, range_start, range_end)
+        status_code = 206  # Partial Content
+        content_length = range_end - range_start + 1
 
-	# otherwise, return the full content response
-	else:
-		file_data = get_file_data(file_path)
-		status_code = 200  # Full Content
-		content_length = file_size
+    # otherwise, return the full content response
+    else:
+        file_data = get_file_data(file_path)
+        status_code = 200  # Full Content
+        content_length = file_size
 
-	response = Response(file_data, status_code, mimetype=mimetype, direct_passthrough=True)
-	response.headers["Content-Length"] = str(content_length)
-	response.headers["Accept-Ranges"] = "bytes"
+    response = Response(file_data, status_code, mimetype=mimetype, direct_passthrough=True)
+    response.headers["Content-Length"] = str(content_length)
+    response.headers["Accept-Ranges"] = "bytes"
 
-	if range_start is not None and range_end is not None:
-		response.headers["Content-Range"] = f"bytes {range_start}-{range_end}/{file_size}"
-	return response
+    if range_start is not None and range_end is not None:
+        response.headers["Content-Range"] = f"bytes {range_start}-{range_end}/{file_size}"
+    return response
 
 
 def validate_media_file(src) -> None:
-	file_name = frappe.db.exists("File", {"file_url": src})
-	if not file_name:
-		raise NotFound
+    file_name = frappe.db.exists("File", {"file_url": src})
+    if not file_name:
+        raise NotFound
 
-	file_doc = frappe.get_doc("File", file_name)
-	if frappe.has_permission("File", "read", file_doc):
-		return
+    file_doc = frappe.get_doc("File", file_name)
+    if frappe.has_permission("File", "read", file_doc):
+        return
 
-	# File role perms exclude Guest, so check the attached presentation directly
-	if file_doc.attached_to_doctype == "Presentation" and frappe.has_permission(
-		"Presentation", "read", file_doc.attached_to_name
-	):
-		return
+    # File role perms exclude Guest, so check the attached presentation directly
+    if file_doc.attached_to_doctype == "Presentation" and frappe.has_permission(
+        "Presentation", "read", file_doc.attached_to_name
+    ):
+        return
 
-	raise Forbidden(_("You don't have permission to access this file"))
+    raise Forbidden(_("You don't have permission to access this file"))
 
 
 @frappe.whitelist(allow_guest=True)
 def get_media_file(src: str, public: str | None = None) -> Response:
-	"""
-	Fetches permitted video file and returns a response.
+    """
+    Fetches permitted video file and returns a response.
 
-	`public` is deprecated and ignored; access is determined server-side.
-	"""
-	validate_media_file(src)
+    `public` is deprecated and ignored; access is determined server-side.
+    """
+    validate_media_file(src)
 
-	return get_media_response(src)
+    return get_media_response(src)

--- a/suite/slides/api/test_file.py
+++ b/suite/slides/api/test_file.py
@@ -13,36 +13,36 @@ OTHER_USER = "media-other@example.com"
 
 
 class TestMediaFileAccess(IntegrationTestCase):
-	@classmethod
-	def setUpClass(cls):
-		super().setUpClass()
-		ensure_user(OWNER)
-		ensure_user(OTHER_USER)
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        ensure_user(OWNER)
+        ensure_user(OTHER_USER)
 
-		with cls.set_user(OWNER):
-			cls.presentation = make_presentation("Media Access Test")
-			cls.file = make_private_image(cls.presentation.name)
+        with cls.set_user(OWNER):
+            cls.presentation = make_presentation("Media Access Test")
+            cls.file = make_private_image(cls.presentation.name)
 
-	def test_owner_can_access(self):
-		with self.set_user(OWNER):
-			self.assertIsNone(validate_media_file(self.file.file_url))
+    def test_owner_can_access(self):
+        with self.set_user(OWNER):
+            self.assertIsNone(validate_media_file(self.file.file_url))
 
-	def test_other_user_forbidden(self):
-		with self.set_user(OTHER_USER):
-			with self.assertRaises(Forbidden):
-				validate_media_file(self.file.file_url)
+    def test_other_user_forbidden(self):
+        with self.set_user(OTHER_USER):
+            with self.assertRaises(Forbidden):
+                validate_media_file(self.file.file_url)
 
-	def test_guest_forbidden(self):
-		with self.set_user("Guest"):
-			with self.assertRaises(Forbidden):
-				validate_media_file(self.file.file_url)
+    def test_guest_forbidden(self):
+        with self.set_user("Guest"):
+            with self.assertRaises(Forbidden):
+                validate_media_file(self.file.file_url)
 
-	def test_guest_can_access_file_of_public_presentation(self):
-		# own fixtures: making the shared presentation public would break the deny tests
-		with self.set_user(OWNER):
-			presentation = make_presentation("Public Media Test")
-			file = make_private_image(presentation.name)
-			make_public(presentation.name)
+    def test_guest_can_access_file_of_public_presentation(self):
+        # own fixtures: making the shared presentation public would break the deny tests
+        with self.set_user(OWNER):
+            presentation = make_presentation("Public Media Test")
+            file = make_private_image(presentation.name)
+            make_public(presentation.name)
 
-		with self.set_user("Guest"):
-			self.assertIsNone(validate_media_file(file.file_url))
+        with self.set_user("Guest"):
+            self.assertIsNone(validate_media_file(file.file_url))

--- a/suite/slides/doctype/presentation/patches/cleanup_unused_thumbnail_files.py
+++ b/suite/slides/doctype/presentation/patches/cleanup_unused_thumbnail_files.py
@@ -8,111 +8,111 @@ FILE_URL_PREFIXES = ("/private/files/", "/files/")
 
 
 def get_url_variants(file_url):
-	if not file_url:
-		return set()
+    if not file_url:
+        return set()
 
-	path = urlparse(file_url).path or file_url
-	variants = {file_url, path}
+    path = urlparse(file_url).path or file_url
+    variants = {file_url, path}
 
-	if path.startswith("/private/files/"):
-		variants.add(path.replace("/private/files/", "/files/", 1))
-	elif path.startswith("/files/"):
-		variants.add(path.replace("/files/", "/private/files/", 1))
+    if path.startswith("/private/files/"):
+        variants.add(path.replace("/private/files/", "/files/", 1))
+    elif path.startswith("/files/"):
+        variants.add(path.replace("/files/", "/private/files/", 1))
 
-	return variants
+    return variants
 
 
 def get_file_url_path(file_url):
-	return urlparse(file_url or "").path
+    return urlparse(file_url or "").path
 
 
 def add_referenced_url(referenced_urls, file_url):
-	if isinstance(file_url, str) and file_url and not file_url.startswith("/assets"):
-		referenced_urls.update(get_url_variants(file_url))
+    if isinstance(file_url, str) and file_url and not file_url.startswith("/assets"):
+        referenced_urls.update(get_url_variants(file_url))
 
 
 def is_generated_thumbnail_file(file):
-	if not file.file_name.startswith(GENERATED_THUMBNAIL_PREFIX):
-		return False
+    if not file.file_name.startswith(GENERATED_THUMBNAIL_PREFIX):
+        return False
 
-	path = urlparse(file.file_url or "").path
-	if not path.startswith(FILE_URL_PREFIXES):
-		return False
+    path = urlparse(file.file_url or "").path
+    if not path.startswith(FILE_URL_PREFIXES):
+        return False
 
-	file_url_name = path.rsplit("/", 1)[-1]
-	return file_url_name.startswith(GENERATED_THUMBNAIL_PREFIX)
+    file_url_name = path.rsplit("/", 1)[-1]
+    return file_url_name.startswith(GENERATED_THUMBNAIL_PREFIX)
 
 
 def get_referenced_file_urls():
-	referenced_urls = set()
-	slides = frappe.get_all(
-		"Slide",
-		filters={"parenttype": "Presentation"},
-		fields=["thumbnail", "elements"],
-	)
+    referenced_urls = set()
+    slides = frappe.get_all(
+        "Slide",
+        filters={"parenttype": "Presentation"},
+        fields=["thumbnail", "elements"],
+    )
 
-	for slide in slides:
-		add_referenced_url(referenced_urls, slide.thumbnail)
+    for slide in slides:
+        add_referenced_url(referenced_urls, slide.thumbnail)
 
-		try:
-			elements = json.loads(slide.elements or "[]")
-		except json.JSONDecodeError:
-			continue
+        try:
+            elements = json.loads(slide.elements or "[]")
+        except json.JSONDecodeError:
+            continue
 
-		for element in elements:
-			if not isinstance(element, dict):
-				continue
+        for element in elements:
+            if not isinstance(element, dict):
+                continue
 
-			add_referenced_url(referenced_urls, element.get("src"))
-			add_referenced_url(referenced_urls, element.get("poster"))
+            add_referenced_url(referenced_urls, element.get("src"))
+            add_referenced_url(referenced_urls, element.get("poster"))
 
-	return referenced_urls
+    return referenced_urls
 
 
 def get_thumbnail_files():
-	thumbnail_files = frappe.get_all(
-		"File",
-		filters={
-			"attached_to_doctype": "Presentation",
-			"file_name": ["like", f"{GENERATED_THUMBNAIL_PREFIX}%"],
-		},
-		fields=["name", "file_name", "file_url", "attached_to_name"],
-	)
+    thumbnail_files = frappe.get_all(
+        "File",
+        filters={
+            "attached_to_doctype": "Presentation",
+            "file_name": ["like", f"{GENERATED_THUMBNAIL_PREFIX}%"],
+        },
+        fields=["name", "file_name", "file_url", "attached_to_name"],
+    )
 
-	return [file for file in thumbnail_files if is_generated_thumbnail_file(file)]
+    return [file for file in thumbnail_files if is_generated_thumbnail_file(file)]
 
 
 def get_unused_thumbnail_files():
-	referenced_urls = get_referenced_file_urls()
-	thumbnail_files = get_thumbnail_files()
+    referenced_urls = get_referenced_file_urls()
+    thumbnail_files = get_thumbnail_files()
 
-	unused_files = []
-	for file in thumbnail_files:
-		file_url_variants = get_url_variants(file.file_url)
-		if not file_url_variants.intersection(referenced_urls):
-			unused_files.append(file)
+    unused_files = []
+    for file in thumbnail_files:
+        file_url_variants = get_url_variants(file.file_url)
+        if not file_url_variants.intersection(referenced_urls):
+            unused_files.append(file)
 
-	print(f"Found {len(unused_files)} unused thumbnail files.")
-	return unused_files
+    print(f"Found {len(unused_files)} unused thumbnail files.")
+    return unused_files
 
 
 def cleanup_unused_thumbnail_files(dry_run=False):
-	unused_thumbnail_files = get_unused_thumbnail_files()
+    unused_thumbnail_files = get_unused_thumbnail_files()
 
-	for file in unused_thumbnail_files:
-		if dry_run:
-			continue
+    for file in unused_thumbnail_files:
+        if dry_run:
+            continue
 
-		try:
-			frappe.delete_doc("File", file.name)
-		except Exception as e:
-			frappe.log_error(
-				title="Failed to delete unused Presentation thumbnail",
-				message=f"File: {file.name}\nURL: {file.file_url}\nError: {e}",
-			)
+        try:
+            frappe.delete_doc("File", file.name)
+        except Exception as e:
+            frappe.log_error(
+                title="Failed to delete unused Presentation thumbnail",
+                message=f"File: {file.name}\nURL: {file.file_url}\nError: {e}",
+            )
 
-	return unused_thumbnail_files
+    return unused_thumbnail_files
 
 
 def execute():
-	cleanup_unused_thumbnail_files()
+    cleanup_unused_thumbnail_files()

--- a/suite/slides/doctype/presentation/patches/integrate_with_drive.py
+++ b/suite/slides/doctype/presentation/patches/integrate_with_drive.py
@@ -4,41 +4,41 @@ from suite.drive.utils import create_drive_file, get_user_folder
 
 
 def execute():
-	"""Back presentations with Drive Files; move the legacy `is_public` flag to Drive permissions."""
-	public = set()
-	if frappe.db.has_column("Presentation", "is_public"):
-		public = set(frappe.db.sql_list("SELECT name FROM `tabPresentation` WHERE is_public = 1"))
+    """Back presentations with Drive Files; move the legacy `is_public` flag to Drive permissions."""
+    public = set()
+    if frappe.db.has_column("Presentation", "is_public"):
+        public = set(frappe.db.sql_list("SELECT name FROM `tabPresentation` WHERE is_public = 1"))
 
-	frappe.flags.mute_drive_activity_log = True
-	try:
-		presentations = frappe.get_all(
-			"Presentation",
-			filters={"is_template": 0},
-			fields=["name", "title", "owner"],
-		)
-		for presentation in presentations:
-			file = frappe.db.get_value(
-				"File",
-				{"content_doctype": "Presentation", "content_docname": presentation.name},
-				"name",
-			)
-			if not file:
-				file = create_drive_file(
-					presentation.title or "Untitled",
-					get_user_folder(presentation.owner).name,
-					"Presentation",
-					None,
-					mime_type="frappe/slides",
-					content_doctype="Presentation",
-					content_docname=presentation.name,
-					owner=presentation.owner,
-				).name
+    frappe.flags.mute_drive_activity_log = True
+    try:
+        presentations = frappe.get_all(
+            "Presentation",
+            filters={"is_template": 0},
+            fields=["name", "title", "owner"],
+        )
+        for presentation in presentations:
+            file = frappe.db.get_value(
+                "File",
+                {"content_doctype": "Presentation", "content_docname": presentation.name},
+                "name",
+            )
+            if not file:
+                file = create_drive_file(
+                    presentation.title or "Untitled",
+                    get_user_folder(presentation.owner).name,
+                    "Presentation",
+                    None,
+                    mime_type="frappe/slides",
+                    content_doctype="Presentation",
+                    content_docname=presentation.name,
+                    owner=presentation.owner,
+                ).name
 
-			if presentation.name in public and not frappe.db.exists(
-				"Drive Permission", {"entity": file, "user": ""}
-			):
-				frappe.get_doc({"doctype": "Drive Permission", "entity": file, "user": "", "read": 1}).insert(
-					ignore_permissions=True
-				)
-	finally:
-		frappe.flags.mute_drive_activity_log = False
+            if presentation.name in public and not frappe.db.exists(
+                "Drive Permission", {"entity": file, "user": ""}
+            ):
+                frappe.get_doc({"doctype": "Drive Permission", "entity": file, "user": "", "read": 1}).insert(
+                    ignore_permissions=True
+                )
+    finally:
+        frappe.flags.mute_drive_activity_log = False

--- a/suite/slides/doctype/presentation/patches/move_attachments_to_private_folder.py
+++ b/suite/slides/doctype/presentation/patches/move_attachments_to_private_folder.py
@@ -71,7 +71,7 @@ def delete_public_attachments(presentation_name):
         try:
             file_doc.delete()
         except Exception as e:
-            frappe.log_error(f"Error deleting file {file_doc.file_url}: {str(e)}")
+            frappe.log_error(f"Error deleting file {file_doc.file_url}: {e!s}")
 
 
 def get_updated_elements(elements, presentation_name):

--- a/suite/slides/doctype/presentation/patches/move_attachments_to_private_folder.py
+++ b/suite/slides/doctype/presentation/patches/move_attachments_to_private_folder.py
@@ -6,111 +6,111 @@ import frappe
 
 
 def create_attachment_with_unique_name(doc):
-	file_name = doc.file_name
-	file_extension = os.path.splitext(file_name)[1]
-	base_name = os.path.splitext(file_name)[0]
-	unique_name = f"{base_name}_{uuid.uuid4().hex[:6]}{file_extension}"
+    file_name = doc.file_name
+    file_extension = os.path.splitext(file_name)[1]
+    base_name = os.path.splitext(file_name)[0]
+    unique_name = f"{base_name}_{uuid.uuid4().hex[:6]}{file_extension}"
 
-	file_content = doc.get_content()
-	new_file_doc = frappe.get_doc(
-		{
-			"doctype": "File",
-			"file_name": unique_name,
-			"file_url": f"/private/files/{unique_name}",
-			"attached_to_doctype": doc.attached_to_doctype,
-			"attached_to_name": doc.attached_to_name,
-			"is_private": 1,
-			"content": file_content,
-		}
-	)
+    file_content = doc.get_content()
+    new_file_doc = frappe.get_doc(
+        {
+            "doctype": "File",
+            "file_name": unique_name,
+            "file_url": f"/private/files/{unique_name}",
+            "attached_to_doctype": doc.attached_to_doctype,
+            "attached_to_name": doc.attached_to_name,
+            "is_private": 1,
+            "content": file_content,
+        }
+    )
 
-	new_file_doc.insert()
+    new_file_doc.insert()
 
-	return new_file_doc.file_url
+    return new_file_doc.file_url
 
 
 def move_file_to_private(presentation, file_url):
-	attachment = frappe.get_cached_value(
-		"File",
-		{
-			"file_url": file_url,
-			"attached_to_doctype": "Presentation",
-			"attached_to_name": presentation,
-		},
-		"name",
-	)
-	if not attachment:
-		return file_url
+    attachment = frappe.get_cached_value(
+        "File",
+        {
+            "file_url": file_url,
+            "attached_to_doctype": "Presentation",
+            "attached_to_name": presentation,
+        },
+        "name",
+    )
+    if not attachment:
+        return file_url
 
-	file_doc = frappe.get_doc("File", attachment)
-	if file_doc.is_private:
-		return file_doc.file_url
+    file_doc = frappe.get_doc("File", attachment)
+    if file_doc.is_private:
+        return file_doc.file_url
 
-	try:
-		file_doc.is_private = 1
-		file_doc.save()
-		return file_doc.file_url
-	except Exception:
-		new_file_url = create_attachment_with_unique_name(file_doc)
-		file_doc.delete()
-		return new_file_url
+    try:
+        file_doc.is_private = 1
+        file_doc.save()
+        return file_doc.file_url
+    except Exception:
+        new_file_url = create_attachment_with_unique_name(file_doc)
+        file_doc.delete()
+        return new_file_url
 
 
 def delete_public_attachments(presentation_name):
-	public_attachments = frappe.get_all(
-		"File",
-		filters={
-			"attached_to_doctype": "Presentation",
-			"attached_to_name": presentation_name,
-			"is_private": 0,
-		},
-		pluck="name",
-	)
-	for file_name in public_attachments:
-		file_doc = frappe.get_doc("File", file_name)
-		try:
-			file_doc.delete()
-		except Exception as e:
-			frappe.log_error(f"Error deleting file {file_doc.file_url}: {str(e)}")
+    public_attachments = frappe.get_all(
+        "File",
+        filters={
+            "attached_to_doctype": "Presentation",
+            "attached_to_name": presentation_name,
+            "is_private": 0,
+        },
+        pluck="name",
+    )
+    for file_name in public_attachments:
+        file_doc = frappe.get_doc("File", file_name)
+        try:
+            file_doc.delete()
+        except Exception as e:
+            frappe.log_error(f"Error deleting file {file_doc.file_url}: {str(e)}")
 
 
 def get_updated_elements(elements, presentation_name):
-	elements = json.loads(elements or "[]")
+    elements = json.loads(elements or "[]")
 
-	updated = False
-	for element in elements:
-		if element.get("type") in ("image", "video"):
-			src = element.get("src", "")
-			if not src.startswith("/assets"):
-				element["src"] = move_file_to_private(presentation_name, src)
-				updated = True
+    updated = False
+    for element in elements:
+        if element.get("type") in ("image", "video"):
+            src = element.get("src", "")
+            if not src.startswith("/assets"):
+                element["src"] = move_file_to_private(presentation_name, src)
+                updated = True
 
-			poster = element.get("poster", "")
-			if not poster.startswith("/assets"):
-				element["poster"] = move_file_to_private(presentation_name, poster)
-				updated = True
+            poster = element.get("poster", "")
+            if not poster.startswith("/assets"):
+                element["poster"] = move_file_to_private(presentation_name, poster)
+                updated = True
 
-	if updated:
-		return json.dumps(elements, indent=2)
+    if updated:
+        return json.dumps(elements, indent=2)
 
 
 def execute():
-	presentations = frappe.get_all("Presentation", filters={"is_public": 1, "is_composite": 0}, pluck="name")
+    presentations = frappe.get_all("Presentation", filters={"is_public": 1, "is_composite": 0}, pluck="name")
 
-	for presentation_name in presentations:
-		presentation = frappe.get_doc("Presentation", presentation_name)
+    for presentation_name in presentations:
+        presentation = frappe.get_doc("Presentation", presentation_name)
 
-		for slide in presentation.slides or []:
-			if slide.thumbnail and slide.thumbnail.startswith("/files"):
-				slide.thumbnail = move_file_to_private(presentation.name, slide.thumbnail)
+        for slide in presentation.slides or []:
+            if slide.thumbnail and slide.thumbnail.startswith("/files"):
+                slide.thumbnail = move_file_to_private(presentation.name, slide.thumbnail)
 
-			elements = slide.get("elements", [])
-			if isinstance(elements, str):
-				updated_elements = get_updated_elements(elements, presentation.name)
-				if updated_elements:
-					slide.elements = updated_elements
+            elements = slide.get("elements", [])
+            if isinstance(elements, str):
+                updated_elements = get_updated_elements(elements, presentation.name)
+                if updated_elements:
+                    slide.elements = updated_elements
 
-		presentation.save()
+        presentation.save()
 
-		# can now delete all public attachments not being used in slides
-		delete_public_attachments(presentation.name)
+        # can now delete all public attachments not being used in slides
+        delete_public_attachments(presentation.name)

--- a/suite/slides/doctype/presentation/patches/move_slide_thumbnail_to_presentation.py
+++ b/suite/slides/doctype/presentation/patches/move_slide_thumbnail_to_presentation.py
@@ -2,29 +2,29 @@ import frappe
 
 
 def is_thumbnail_path(thumbnail):
-	return thumbnail and isinstance(thumbnail, str) and not thumbnail.startswith("data:")
+    return thumbnail and isinstance(thumbnail, str) and not thumbnail.startswith("data:")
 
 
 def execute():
-	if not frappe.db.has_column("Slide", "thumbnail"):
-		return
+    if not frappe.db.has_column("Slide", "thumbnail"):
+        return
 
-	presentations = frappe.get_all("Presentation", fields=["name", "thumbnail"])
+    presentations = frappe.get_all("Presentation", fields=["name", "thumbnail"])
 
-	for presentation in presentations:
-		if presentation.thumbnail:
-			continue
+    for presentation in presentations:
+        if presentation.thumbnail:
+            continue
 
-		first_slide_thumbnail = frappe.db.get_value(
-			"Slide",
-			{"parent": presentation.name, "idx": 1},
-			"thumbnail",
-		)
-		if is_thumbnail_path(first_slide_thumbnail):
-			frappe.db.set_value(
-				"Presentation",
-				presentation.name,
-				"thumbnail",
-				first_slide_thumbnail,
-				update_modified=False,
-			)
+        first_slide_thumbnail = frappe.db.get_value(
+            "Slide",
+            {"parent": presentation.name, "idx": 1},
+            "thumbnail",
+        )
+        if is_thumbnail_path(first_slide_thumbnail):
+            frappe.db.set_value(
+                "Presentation",
+                presentation.name,
+                "thumbnail",
+                first_slide_thumbnail,
+                update_modified=False,
+            )

--- a/suite/slides/doctype/presentation/patches/sanitize_attachment_urls.py
+++ b/suite/slides/doctype/presentation/patches/sanitize_attachment_urls.py
@@ -4,26 +4,26 @@ import frappe
 
 
 def execute():
-	presentations = frappe.get_all("Presentation", pluck="name")
+    presentations = frappe.get_all("Presentation", pluck="name")
 
-	for presentation in presentations:
-		doc = frappe.get_doc("Presentation", presentation)
+    for presentation in presentations:
+        doc = frappe.get_doc("Presentation", presentation)
 
-		for slide in doc.slides:
-			if slide.thumbnail and slide.thumbnail.startswith("/private"):
-				slide.thumbnail = slide.thumbnail.replace("/private", "")
+        for slide in doc.slides:
+            if slide.thumbnail and slide.thumbnail.startswith("/private"):
+                slide.thumbnail = slide.thumbnail.replace("/private", "")
 
-			elements = json.loads(slide.elements or "[]")
+            elements = json.loads(slide.elements or "[]")
 
-			for element in elements:
-				if element.get("type") in ("image", "video"):
-					url = element.get("src", "")
-					if url.startswith("/private"):
-						element["src"] = url.replace("/private", "")
+            for element in elements:
+                if element.get("type") in ("image", "video"):
+                    url = element.get("src", "")
+                    if url.startswith("/private"):
+                        element["src"] = url.replace("/private", "")
 
-					if element.get("poster", "").startswith("/private"):
-						element["poster"] = element["poster"].replace("/private", "")
+                    if element.get("poster", "").startswith("/private"):
+                        element["poster"] = element["poster"].replace("/private", "")
 
-			slide.elements = json.dumps(elements, indent=2)
+            slide.elements = json.dumps(elements, indent=2)
 
-		doc.save()
+        doc.save()

--- a/suite/slides/doctype/presentation/presentation.py
+++ b/suite/slides/doctype/presentation/presentation.py
@@ -23,51 +23,51 @@ MAX_THUMBNAIL_BYTES = 6 * 1024 * 1024
 
 
 class Presentation(Document):
-	def before_save(self):
-		self.slug = slug(self.title)
+    def before_save(self):
+        self.slug = slug(self.title)
 
-	def validate(self):
-		if self.is_composite:
-			if not self.reference_presentations:
-				frappe.throw(
-					"Please add at least one reference presentation to create a composite presentation."
-				)
+    def validate(self):
+        if self.is_composite:
+            if not self.reference_presentations:
+                frappe.throw(
+                    "Please add at least one reference presentation to create a composite presentation."
+                )
 
-			for ref in self.reference_presentations:
-				ref_doc = frappe.get_cached_doc("Presentation", ref.presentation)
-				if not is_public_presentation(ref_doc.name):
-					frappe.throw(
-						f"Reference presentation '{ref_doc.title}' must be public to create a composite presentation."
-					)
+            for ref in self.reference_presentations:
+                ref_doc = frappe.get_cached_doc("Presentation", ref.presentation)
+                if not is_public_presentation(ref_doc.name):
+                    frappe.throw(
+                        f"Reference presentation '{ref_doc.title}' must be public to create a composite presentation."
+                    )
 
-	def after_insert(self):
-		if self.is_template:
-			return
-		self.create_drive_file()
+    def after_insert(self):
+        if self.is_template:
+            return
+        self.create_drive_file()
 
-	def on_update(self):
-		# composite decks are always public — a system invariant, enforced directly
-		# since File.share() would require the saver to hold a share grant
-		if self.is_composite and not is_public_presentation(self.name):
-			file = DriveFile.get_for_doc("Presentation", self.name)
-			if not file:
-				return
-			existing = frappe.db.get_value("Drive Permission", {"entity": file, "user": "", "deny": 0})
-			perm = (
-				frappe.get_doc("Drive Permission", existing)
-				if existing
-				else frappe.new_doc("Drive Permission").update({"entity": file, "user": ""})
-			)
-			perm.read = 1
-			perm.save(ignore_permissions=True)
+    def on_update(self):
+        # composite decks are always public — a system invariant, enforced directly
+        # since File.share() would require the saver to hold a share grant
+        if self.is_composite and not is_public_presentation(self.name):
+            file = DriveFile.get_for_doc("Presentation", self.name)
+            if not file:
+                return
+            existing = frappe.db.get_value("Drive Permission", {"entity": file, "user": "", "deny": 0})
+            perm = (
+                frappe.get_doc("Drive Permission", existing)
+                if existing
+                else frappe.new_doc("Drive Permission").update({"entity": file, "user": ""})
+            )
+            perm.read = 1
+            perm.save(ignore_permissions=True)
 
-	def create_drive_file(self, parent: str | None = None):
-		return DriveFile.create_for_doc(
-			self,
-			parent=parent or self.flags.get("drive_parent"),
-			mime_type="frappe/slides",
-			file_type="Presentation",
-		)
+    def create_drive_file(self, parent: str | None = None):
+        return DriveFile.create_for_doc(
+            self,
+            parent=parent or self.flags.get("drive_parent"),
+            mime_type="frappe/slides",
+            file_type="Presentation",
+        )
 
 
 ALLOWED_IMAGE_EXTENSIONS = {"png", "jpg", "jpeg", "gif", "webp"}
@@ -75,507 +75,507 @@ ALLOWED_IMAGE_EXTENSIONS = {"png", "jpg", "jpeg", "gif", "webp"}
 
 @frappe.whitelist()
 def save_base64_image(base64_data: str, presentation_name: str, prefix: str) -> str:
-	presentation = frappe.get_doc("Presentation", presentation_name)
-	presentation.check_permission("write")
+    presentation = frappe.get_doc("Presentation", presentation_name)
+    presentation.check_permission("write")
 
-	match = re.match(r"^data:image/([a-zA-Z0-9.+-]+);base64,(.+)$", base64_data or "", re.DOTALL)
-	if not match:
-		frappe.throw("Invalid image data")
+    match = re.match(r"^data:image/([a-zA-Z0-9.+-]+);base64,(.+)$", base64_data or "", re.DOTALL)
+    if not match:
+        frappe.throw("Invalid image data")
 
-	ext = match.group(1).lower()
-	if ext not in ALLOWED_IMAGE_EXTENSIONS:
-		frappe.throw("Unsupported image type")
+    ext = match.group(1).lower()
+    if ext not in ALLOWED_IMAGE_EXTENSIONS:
+        frappe.throw("Unsupported image type")
 
-	try:
-		content = base64.b64decode(match.group(2), validate=True)
-	except Exception:
-		frappe.throw("Malformed base64 image content")
+    try:
+        content = base64.b64decode(match.group(2), validate=True)
+    except Exception:
+        frappe.throw("Malformed base64 image content")
 
-	filename = f"{prefix}-{uuid.uuid4().hex[:6]}.{ext}"
+    filename = f"{prefix}-{uuid.uuid4().hex[:6]}.{ext}"
 
-	file_doc = frappe.get_doc(
-		{
-			"doctype": "File",
-			"file_name": filename,
-			"content": content,
-			"is_private": 1,
-			"attached_to_doctype": "Presentation",
-			"attached_to_name": presentation_name,
-		}
-	).insert()
+    file_doc = frappe.get_doc(
+        {
+            "doctype": "File",
+            "file_name": filename,
+            "content": content,
+            "is_private": 1,
+            "attached_to_doctype": "Presentation",
+            "attached_to_name": presentation_name,
+        }
+    ).insert()
 
-	return file_doc.file_url
+    return file_doc.file_url
 
 
 def get_thumbnail_content(base64_data: str) -> tuple[bytes, str]:
-	match = re.match(r"^data:(image/[^;]+);base64,(.+)$", base64_data or "", re.DOTALL)
-	if not match:
-		frappe.throw("Invalid thumbnail data")
+    match = re.match(r"^data:(image/[^;]+);base64,(.+)$", base64_data or "", re.DOTALL)
+    if not match:
+        frappe.throw("Invalid thumbnail data")
 
-	mime_type, encoded_content = match.groups()
-	if mime_type != "image/webp":
-		frappe.throw("Unsupported thumbnail image type")
+    mime_type, encoded_content = match.groups()
+    if mime_type != "image/webp":
+        frappe.throw("Unsupported thumbnail image type")
 
-	try:
-		content = base64.b64decode(encoded_content, validate=True)
-	except Exception:
-		frappe.throw("Invalid thumbnail image data")
+    try:
+        content = base64.b64decode(encoded_content, validate=True)
+    except Exception:
+        frappe.throw("Invalid thumbnail image data")
 
-	if len(content) > MAX_THUMBNAIL_BYTES:
-		frappe.throw("Thumbnail image is too large")
+    if len(content) > MAX_THUMBNAIL_BYTES:
+        frappe.throw("Thumbnail image is too large")
 
-	return content, "webp"
+    return content, "webp"
 
 
 def replace_thumbnail_file(presentation: Document, base64_data: str) -> str:
-	content, ext = get_thumbnail_content(base64_data)
-	presentation_name = presentation.name
-	file_name = f"presentation-thumbnail-{presentation_name}.{ext}"
+    content, ext = get_thumbnail_content(base64_data)
+    presentation_name = presentation.name
+    file_name = f"presentation-thumbnail-{presentation_name}.{ext}"
 
-	delete_existing_thumbnail_files(presentation, file_name)
+    delete_existing_thumbnail_files(presentation, file_name)
 
-	return create_thumbnail_file(presentation_name, file_name, content)
+    return create_thumbnail_file(presentation_name, file_name, content)
 
 
 def delete_existing_thumbnail_files(presentation: Document, file_name: str) -> None:
-	file_doc_names = set()
+    file_doc_names = set()
 
-	file_doc_names.update(
-		frappe.get_all(
-			"File",
-			filters={
-				"attached_to_doctype": "Presentation",
-				"attached_to_name": presentation.name,
-				"file_name": file_name,
-				"is_private": 1,
-			},
-			pluck="name",
-		)
-	)
+    file_doc_names.update(
+        frappe.get_all(
+            "File",
+            filters={
+                "attached_to_doctype": "Presentation",
+                "attached_to_name": presentation.name,
+                "file_name": file_name,
+                "is_private": 1,
+            },
+            pluck="name",
+        )
+    )
 
-	for file_doc_name in file_doc_names:
-		frappe.delete_doc("File", file_doc_name)
+    for file_doc_name in file_doc_names:
+        frappe.delete_doc("File", file_doc_name)
 
 
 def create_thumbnail_file(presentation_name: str, file_name: str, content: bytes) -> str:
-	file = frappe.get_doc(
-		{
-			"doctype": "File",
-			"attached_to_doctype": "Presentation",
-			"attached_to_name": presentation_name,
-			"file_name": file_name,
-			"is_private": 1,
-			"content": content,
-		}
-	).insert()
+    file = frappe.get_doc(
+        {
+            "doctype": "File",
+            "attached_to_doctype": "Presentation",
+            "attached_to_name": presentation_name,
+            "file_name": file_name,
+            "is_private": 1,
+            "content": content,
+        }
+    ).insert()
 
-	return file.file_url
+    return file.file_url
 
 
 @frappe.whitelist()
 def save_presentation_thumbnail(presentation_name: str, base64_data: str) -> str:
-	presentation = frappe.get_doc("Presentation", presentation_name)
-	presentation.check_permission("write")
+    presentation = frappe.get_doc("Presentation", presentation_name)
+    presentation.check_permission("write")
 
-	file_url = replace_thumbnail_file(presentation, base64_data)
+    file_url = replace_thumbnail_file(presentation, base64_data)
 
-	if presentation.thumbnail != file_url:
-		presentation.db_set("thumbnail", file_url)
-	return file_url
+    if presentation.thumbnail != file_url:
+        presentation.db_set("thumbnail", file_url)
+    return file_url
 
 
 def slug(text: str) -> str:
-	return text.lower().replace(" ", "-")
+    return text.lower().replace(" ", "-")
 
 
 # whitelist needed for drive integration
 @frappe.whitelist()
 def get_presentation_thumbnail(presentation_name: str, index: int | None = 1) -> str:
-	"""Returns the thumbnail of a presentation."""
-	return frappe.get_value("Presentation", presentation_name, "thumbnail") or ""
+    """Returns the thumbnail of a presentation."""
+    return frappe.get_value("Presentation", presentation_name, "thumbnail") or ""
 
 
 @frappe.whitelist()
 def get_presentations() -> list[dict]:
-	"""
-	Returns a list of presentation details
-	- info and presentation thumbnail
-	"""
-	presentations = frappe.get_list(
-		"Presentation",
-		fields=["name", "title", "owner", "creation", "modified_by", "modified", "thumbnail"],
-		order_by="modified desc",
-		filters=[["owner", "=", frappe.session.user], ["is_template", "=", 0]],
-	)
+    """
+    Returns a list of presentation details
+    - info and presentation thumbnail
+    """
+    presentations = frappe.get_list(
+        "Presentation",
+        fields=["name", "title", "owner", "creation", "modified_by", "modified", "thumbnail"],
+        order_by="modified desc",
+        filters=[["owner", "=", frappe.session.user], ["is_template", "=", 0]],
+    )
 
-	counts = get_slide_counts([p["name"] for p in presentations])
-	for presentation in presentations:
-		presentation["slide_count"] = counts.get(presentation["name"], 0)
+    counts = get_slide_counts([p["name"] for p in presentations])
+    for presentation in presentations:
+        presentation["slide_count"] = counts.get(presentation["name"], 0)
 
-	return presentations
+    return presentations
 
 
 def get_slide_counts(presentation_names: list[str]) -> dict[str, int]:
-	"""Returns a dict mapping presentation names to their slide count."""
-	if not presentation_names:
-		return {}
+    """Returns a dict mapping presentation names to their slide count."""
+    if not presentation_names:
+        return {}
 
-	Slide = frappe.qb.DocType("Slide")
-	return dict(
-		(
-			frappe.qb.from_(Slide)
-			.select(Slide.parent, Count("*"))
-			.where(Slide.parenttype == "Presentation")
-			.where(Slide.parent.isin(presentation_names))
-			.groupby(Slide.parent)
-		).run()
-	)
+    Slide = frappe.qb.DocType("Slide")
+    return dict(
+        (
+            frappe.qb.from_(Slide)
+            .select(Slide.parent, Count("*"))
+            .where(Slide.parenttype == "Presentation")
+            .where(Slide.parent.isin(presentation_names))
+            .groupby(Slide.parent)
+        ).run()
+    )
 
 
 @frappe.whitelist()
 def update_slide_attachments(parent: str, slide: dict | str):
-	frappe.get_doc("Presentation", parent).check_permission("write")
+    frappe.get_doc("Presentation", parent).check_permission("write")
 
-	slide = json.loads(slide) if isinstance(slide, str) else slide
+    slide = json.loads(slide) if isinstance(slide, str) else slide
 
-	elements_data = slide.get("elements") or "[]"
-	elements = elements_data if isinstance(elements_data, list) else json.loads(elements_data)
-	for element in elements:
-		element["id"] = "".join(random.choices(string.ascii_lowercase + string.digits, k=9))
-		if element.get("src") and element["src"].startswith("/private"):
-			element["attachmentName"] = get_attachment(parent, element["src"])
+    elements_data = slide.get("elements") or "[]"
+    elements = elements_data if isinstance(elements_data, list) else json.loads(elements_data)
+    for element in elements:
+        element["id"] = "".join(random.choices(string.ascii_lowercase + string.digits, k=9))
+        if element.get("src") and element["src"].startswith("/private"):
+            element["attachmentName"] = get_attachment(parent, element["src"])
 
-	slide["elements"] = json.dumps(elements)
+    slide["elements"] = json.dumps(elements)
 
-	return slide
+    return slide
 
 
 def apply_slide_layout(slide, ref_id, parent):
-	layout_slide = frappe.get_doc("Slide", ref_id)
+    layout_slide = frappe.get_doc("Slide", ref_id)
 
-	slide_dict = layout_slide.as_dict()
-	slide_dict = update_slide_attachments(parent, slide_dict)
+    slide_dict = layout_slide.as_dict()
+    slide_dict = update_slide_attachments(parent, slide_dict)
 
-	for key, value in slide_dict.items():
-		setattr(slide, key, value)
+    for key, value in slide_dict.items():
+        setattr(slide, key, value)
 
 
 def create_new_slide(parent, ref_id):
-	"""
-	Creates a new slide with the given reference slide id.
-	"""
-	slide = frappe.new_doc("Slide")
+    """
+    Creates a new slide with the given reference slide id.
+    """
+    slide = frappe.new_doc("Slide")
 
-	apply_slide_layout(slide, ref_id, parent)
+    apply_slide_layout(slide, ref_id, parent)
 
-	slide.parent = parent
-	slide.parentfield = "slides"
-	slide.parenttype = "Presentation"
-	slide.save()
+    slide.parent = parent
+    slide.parentfield = "slides"
+    slide.parenttype = "Presentation"
+    slide.save()
 
-	return slide
+    return slide
 
 
 def get_slides_from_ref(parent, theme, duplicate_from):
-	ref_name = duplicate_from or theme or "Light"
-	ref_presentation = frappe.get_doc("Presentation", ref_name)
+    ref_name = duplicate_from or theme or "Light"
+    ref_presentation = frappe.get_doc("Presentation", ref_name)
 
-	slides = []
+    slides = []
 
-	if duplicate_from:
-		for slide in ref_presentation.slides:
-			new_slide = create_new_slide(parent, slide.name)
-			new_slide.idx = slide.idx
-			slides.append(new_slide)
-	else:
-		first_index = 2 if ref_presentation.title in ("Light", "Dark") else 0
-		first_slide = create_new_slide(parent, ref_presentation.slides[first_index].name)
-		first_slide.idx = 1
-		slides.append(first_slide)
+    if duplicate_from:
+        for slide in ref_presentation.slides:
+            new_slide = create_new_slide(parent, slide.name)
+            new_slide.idx = slide.idx
+            slides.append(new_slide)
+    else:
+        first_index = 2 if ref_presentation.title in ("Light", "Dark") else 0
+        first_slide = create_new_slide(parent, ref_presentation.slides[first_index].name)
+        first_slide.idx = 1
+        slides.append(first_slide)
 
-	return slides
+    return slides
 
 
 def is_system_template(template_title: str) -> bool:
-	return template_title in SYSTEM_TEMPLATE_TITLES
+    return template_title in SYSTEM_TEMPLATE_TITLES
 
 
 def get_template_thumbnail(template_title: str, index: int) -> str:
-	template_title = (template_title or "light").lower()
-	return f"/assets/suite/slides/frontend/images/layouts/{template_title}/thumbnail-{index}.webp"
+    template_title = (template_title or "light").lower()
+    return f"/assets/suite/slides/frontend/images/layouts/{template_title}/thumbnail-{index}.webp"
 
 
 def get_template_cover_thumbnail(template):
-	template_title, template_thumbnail = frappe.get_value(
-		"Presentation",
-		template,
-		["title", "thumbnail"],
-	)
-	return (
-		get_template_thumbnail(template_title, 3)
-		if is_system_template(template_title)
-		else template_thumbnail
-	)
+    template_title, template_thumbnail = frappe.get_value(
+        "Presentation",
+        template,
+        ["title", "thumbnail"],
+    )
+    return (
+        get_template_thumbnail(template_title, 3)
+        if is_system_template(template_title)
+        else template_thumbnail
+    )
 
 
 def set_duplicate_metadata(presentation, duplicate_from):
-	src_title, src_theme, src_thumbnail = frappe.get_value(
-		"Presentation",
-		duplicate_from,
-		["title", "theme", "thumbnail"],
-	)
-	presentation.title = f"Copy of {src_title}"
-	presentation.theme = src_theme
-	presentation.thumbnail = src_thumbnail
+    src_title, src_theme, src_thumbnail = frappe.get_value(
+        "Presentation",
+        duplicate_from,
+        ["title", "theme", "thumbnail"],
+    )
+    presentation.title = f"Copy of {src_title}"
+    presentation.theme = src_theme
+    presentation.thumbnail = src_thumbnail
 
 
 def set_template_metadata(presentation, template):
-	presentation.title = "Untitled"
-	presentation.theme = template
-	presentation.thumbnail = get_template_cover_thumbnail(template)
+    presentation.title = "Untitled"
+    presentation.theme = template
+    presentation.thumbnail = get_template_cover_thumbnail(template)
 
 
 @frappe.whitelist()
 def create_presentation(
-	template: str | None = None, duplicate_from: str | None = None, parent: str | None = None
+    template: str | None = None, duplicate_from: str | None = None, parent: str | None = None
 ):
-	if parent and not user_has_permission(parent, "upload"):
-		frappe.throw(
-			"Cannot access folder due to insufficient permissions",
-			frappe.PermissionError,
-		)
+    if parent and not user_has_permission(parent, "upload"):
+        frappe.throw(
+            "Cannot access folder due to insufficient permissions",
+            frappe.PermissionError,
+        )
 
-	presentation = frappe.new_doc("Presentation")
-	if duplicate_from:
-		if not frappe.has_permission("Presentation", "read", duplicate_from):
-			frappe.throw("You cannot duplicate this presentation", frappe.PermissionError)
-		set_duplicate_metadata(presentation, duplicate_from)
-	else:
-		set_template_metadata(presentation, template)
-	presentation.flags.drive_parent = parent
-	presentation.insert()
+    presentation = frappe.new_doc("Presentation")
+    if duplicate_from:
+        if not frappe.has_permission("Presentation", "read", duplicate_from):
+            frappe.throw("You cannot duplicate this presentation", frappe.PermissionError)
+        set_duplicate_metadata(presentation, duplicate_from)
+    else:
+        set_template_metadata(presentation, template)
+    presentation.flags.drive_parent = parent
+    presentation.insert()
 
-	presentation.slides = get_slides_from_ref(presentation.name, template, duplicate_from)
+    presentation.slides = get_slides_from_ref(presentation.name, template, duplicate_from)
 
-	presentation.save()
-	return presentation
+    presentation.save()
+    return presentation
 
 
 @frappe.whitelist()
 def delete_presentation(name: str):
-	return frappe.delete_doc("Presentation", name)
+    return frappe.delete_doc("Presentation", name)
 
 
 @frappe.whitelist()
 def update_title(name: str, title: str):
-	presentation = frappe.get_doc("Presentation", name)
-	presentation.check_permission("write")
-	presentation.title = title
-	presentation.save()
-	return slug(title)
+    presentation = frappe.get_doc("Presentation", name)
+    presentation.check_permission("write")
+    presentation.title = title
+    presentation.save()
+    return slug(title)
 
 
 def get_attachment(presentation, file_url):
-	"""
-	Returns the attachment name for a file URL in a presentation.
-	"""
-	# if file is already attached to the presentation, return its name
-	attachment = frappe.get_value("File", {"file_url": file_url, "attached_to_name": presentation}, "name")
+    """
+    Returns the attachment name for a file URL in a presentation.
+    """
+    # if file is already attached to the presentation, return its name
+    attachment = frappe.get_value("File", {"file_url": file_url, "attached_to_name": presentation}, "name")
 
-	# if not, create a File doc from the source presentation's attachment from where this element was copied
-	if not attachment:
-		source_doc = frappe.get_all("File", filters={"file_url": file_url}, limit=1)
-		if source_doc:
-			source_file = frappe.get_doc("File", source_doc[0].name)
-			source_file.check_permission("read")
-			new_attachment_doc = frappe.copy_doc(source_file)
-			new_attachment_doc.attached_to_name = presentation
-			new_attachment_doc.insert()
-			attachment = new_attachment_doc.name
+    # if not, create a File doc from the source presentation's attachment from where this element was copied
+    if not attachment:
+        source_doc = frappe.get_all("File", filters={"file_url": file_url}, limit=1)
+        if source_doc:
+            source_file = frappe.get_doc("File", source_doc[0].name)
+            source_file.check_permission("read")
+            new_attachment_doc = frappe.copy_doc(source_file)
+            new_attachment_doc.attached_to_name = presentation
+            new_attachment_doc.insert()
+            attachment = new_attachment_doc.name
 
-	return attachment
+    return attachment
 
 
 @frappe.whitelist()
 def get_updated_json(presentation: str, elements: list[dict]):
-	frappe.get_doc("Presentation", presentation).check_permission("write")
+    frappe.get_doc("Presentation", presentation).check_permission("write")
 
-	for element in elements:
-		if element.get("type") in ["image", "video"] and element.get("src"):
-			file_url = element["src"].replace(frappe.local.site_name, "")
-			name = get_attachment(presentation, file_url)
-			element["attachmentName"] = name
+    for element in elements:
+        if element.get("type") in ["image", "video"] and element.get("src"):
+            file_url = element["src"].replace(frappe.local.site_name, "")
+            name = get_attachment(presentation, file_url)
+            element["attachmentName"] = name
 
-	return elements
+    return elements
 
 
 def get_permission_query_conditions(user):
-	return content_query_conditions("Presentation", user, extra="`tabPresentation`.is_template = 1")
+    return content_query_conditions("Presentation", user, extra="`tabPresentation`.is_template = 1")
 
 
 def has_permission(doc, ptype="read", user=None):
-	user = user or frappe.session.user
-	if doc.is_template and user != "Administrator":
-		return ptype == "read" or doc.owner == user
-	return content_has_permission(doc, ptype, user)
+    user = user or frappe.session.user
+    if doc.is_template and user != "Administrator":
+        return ptype == "read" or doc.owner == user
+    return content_has_permission(doc, ptype, user)
 
 
 @frappe.whitelist(allow_guest=True)
 def is_public_presentation(name: str):
-	file = DriveFile.get_for_doc("Presentation", name)
-	if not file:
-		return False
-	return frappe.get_doc("File", file).is_public()
+    file = DriveFile.get_for_doc("Presentation", name)
+    if not file:
+        return False
+    return frappe.get_doc("File", file).is_public()
 
 
 @frappe.whitelist(allow_guest=True)
 def is_composite_presentation(name: str):
-	return frappe.db.get_value("Presentation", name, "is_composite") == 1
+    return frappe.db.get_value("Presentation", name, "is_composite") == 1
 
 
 @frappe.whitelist(allow_guest=True)
 def get_public_presentation(name: str):
-	if not frappe.has_permission("Presentation", "read", name):
-		frappe.throw("You cannot access this presentation", frappe.PermissionError)
+    if not frappe.has_permission("Presentation", "read", name):
+        frappe.throw("You cannot access this presentation", frappe.PermissionError)
 
-	return frappe.get_doc("Presentation", name).as_dict()
+    return frappe.get_doc("Presentation", name).as_dict()
 
 
 def set_layouts_in_template(template):
-	if template.get("is_template") is not None and not template.get("is_template"):
-		return
+    if template.get("is_template") is not None and not template.get("is_template"):
+        return
 
-	doc = frappe.get_doc("Presentation", template["name"])
-	template["layouts"] = [slide.as_dict() for slide in doc.slides]
-	title = doc.title
+    doc = frappe.get_doc("Presentation", template["name"])
+    template["layouts"] = [slide.as_dict() for slide in doc.slides]
+    title = doc.title
 
-	for layout in template["layouts"]:
-		if is_system_template(title):
-			layout["thumbnail"] = get_template_thumbnail(title, layout["idx"])
-		else:
-			layout["thumbnail"] = ""
+    for layout in template["layouts"]:
+        if is_system_template(title):
+            layout["thumbnail"] = get_template_thumbnail(title, layout["idx"])
+        else:
+            layout["thumbnail"] = ""
 
 
 @frappe.whitelist()
 @redis_cache()
 def get_templates():
-	templates = frappe.get_all(
-		"Presentation",
-		filters={"is_template": 1},
-		fields=["name", "title", "slug", "creation", "is_template"],
-		order_by="creation",
-	)
+    templates = frappe.get_all(
+        "Presentation",
+        filters={"is_template": 1},
+        fields=["name", "title", "slug", "creation", "is_template"],
+        order_by="creation",
+    )
 
-	for template in templates:
-		set_layouts_in_template(template)
+    for template in templates:
+        set_layouts_in_template(template)
 
-	return templates
+    return templates
 
 
 @frappe.whitelist(allow_guest=True)
 def get_composite_presentation(name: str):
-	if not (is_public_presentation(name) and is_composite_presentation(name)):
-		frappe.throw("Presentation is not public", frappe.PermissionError)
+    if not (is_public_presentation(name) and is_composite_presentation(name)):
+        frappe.throw("Presentation is not public", frappe.PermissionError)
 
-	doc = frappe.get_doc("Presentation", name)
+    doc = frappe.get_doc("Presentation", name)
 
-	composite_slides = []
+    composite_slides = []
 
-	for reference in doc.reference_presentations:
-		# references are public when the composite is saved, but can be made private later
-		if not is_public_presentation(reference.presentation):
-			continue
-		ref_doc = frappe.get_cached_doc("Presentation", reference.presentation)
-		for slide in ref_doc.slides:
-			composite_slides.append(slide)
+    for reference in doc.reference_presentations:
+        # references are public when the composite is saved, but can be made private later
+        if not is_public_presentation(reference.presentation):
+            continue
+        ref_doc = frappe.get_cached_doc("Presentation", reference.presentation)
+        for slide in ref_doc.slides:
+            composite_slides.append(slide)
 
-	doc.slides = composite_slides
+    doc.slides = composite_slides
 
-	return doc.as_dict()
+    return doc.as_dict()
 
 
 def can_convert_image(extn):
-	return extn.lower() in ["png", "jpeg", "jpg"]
+    return extn.lower() in ["png", "jpeg", "jpg"]
 
 
 def convert_and_save_image(image, path):
-	image.save(path, "WEBP")
-	return path
+    image.save(path, "WEBP")
+    return path
 
 
 def create_new_webp_file_doc(presentation_name, file_url, image, extn):
-	files = frappe.get_all(
-		"File",
-		filters={
-			"attached_to_name": presentation_name,
-			"file_url": file_url,
-		},
-		fields=["name"],
-		limit=1,
-	)
-	if files:
-		_file = frappe.get_doc("File", files[0].name)
-		webp_path = _file.get_full_path().replace(extn, "webp")
-		convert_and_save_image(image, webp_path)
-		new_file = frappe.copy_doc(_file)
-		new_file.file_name = f"{_file.file_name.replace(extn, 'webp')}"
-		new_file.file_url = f"{_file.file_url.replace(extn, 'webp')}"
-		new_file.save()
-		_file.delete()
-		return new_file
-	return file_url
+    files = frappe.get_all(
+        "File",
+        filters={
+            "attached_to_name": presentation_name,
+            "file_url": file_url,
+        },
+        fields=["name"],
+        limit=1,
+    )
+    if files:
+        _file = frappe.get_doc("File", files[0].name)
+        webp_path = _file.get_full_path().replace(extn, "webp")
+        convert_and_save_image(image, webp_path)
+        new_file = frappe.copy_doc(_file)
+        new_file.file_name = f"{_file.file_name.replace(extn, 'webp')}"
+        new_file.file_url = f"{_file.file_url.replace(extn, 'webp')}"
+        new_file.save()
+        _file.delete()
+        return new_file
+    return file_url
 
 
 @frappe.whitelist()
 def get_webp_doc(presentation_name: str, file_doc: dict):
-	file_url = file_doc.get("file_url", "")
-	if file_url.endswith((".webp", ".svg")):
-		return file_doc
+    file_url = file_doc.get("file_url", "")
+    if file_url.endswith((".webp", ".svg")):
+        return file_doc
 
-	image, filename, extn = get_local_image(file_url)
+    image, filename, extn = get_local_image(file_url)
 
-	if can_convert_image(extn):
-		return create_new_webp_file_doc(presentation_name, file_url, image, extn)
+    if can_convert_image(extn):
+        return create_new_webp_file_doc(presentation_name, file_url, image, extn)
 
-	return file_doc
+    return file_doc
 
 
 def update_element_urls(presentation, element):
-	attribute = "poster" if element.get("type") == "video" else "src"
-	image_url = element.get(attribute, "")
+    attribute = "poster" if element.get("type") == "video" else "src"
+    image_url = element.get(attribute, "")
 
-	webp_doc = get_webp_doc(presentation, image_url)
+    webp_doc = get_webp_doc(presentation, image_url)
 
-	if webp_doc.file_url:
-		element["attachmentName"] = webp_doc.name
-		element[attribute] = webp_doc.file_url
+    if webp_doc.file_url:
+        element["attachmentName"] = webp_doc.name
+        element[attribute] = webp_doc.file_url
 
 
 @frappe.whitelist()
 def optimize_images(name: str):
-	doc = frappe.get_doc("Presentation", name)
+    doc = frappe.get_doc("Presentation", name)
 
-	for slide in doc.slides:
-		elements = json.loads(slide.elements or "[]")
+    for slide in doc.slides:
+        elements = json.loads(slide.elements or "[]")
 
-		for element in elements:
-			if element.get("type") in ["image", "video"]:
-				update_element_urls(doc.name, element)
+        for element in elements:
+            if element.get("type") in ["image", "video"]:
+                update_element_urls(doc.name, element)
 
-		slide.elements = json.dumps(elements, indent=2)
+        slide.elements = json.dumps(elements, indent=2)
 
-	return doc.save()
+    return doc.save()
 
 
 @frappe.whitelist(allow_guest=True)
 def get_editor_access(presentation_id: str) -> str:
-	is_composite = frappe.db.get_value("Presentation", presentation_id, "is_composite")
-	if is_composite:
-		return "view"
+    is_composite = frappe.db.get_value("Presentation", presentation_id, "is_composite")
+    if is_composite:
+        return "view"
 
-	if frappe.has_permission("Presentation", "write", presentation_id):
-		return "edit"
-	if frappe.has_permission("Presentation", "read", presentation_id):
-		return "view"
+    if frappe.has_permission("Presentation", "write", presentation_id):
+        return "edit"
+    if frappe.has_permission("Presentation", "read", presentation_id):
+        return "view"
 
-	return "none"
+    return "none"

--- a/suite/slides/doctype/presentation/test_presentation.py
+++ b/suite/slides/doctype/presentation/test_presentation.py
@@ -5,22 +5,22 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from suite.slides.doctype.presentation.presentation import (
-	create_presentation,
-	delete_presentation,
-	get_composite_presentation,
-	get_public_presentation,
-	get_updated_json,
-	save_base64_image,
-	save_presentation_thumbnail,
-	update_slide_attachments,
-	update_title,
+    create_presentation,
+    delete_presentation,
+    get_composite_presentation,
+    get_public_presentation,
+    get_updated_json,
+    save_base64_image,
+    save_presentation_thumbnail,
+    update_slide_attachments,
+    update_title,
 )
 from suite.slides.tests.utils import (
-	PNG_1PX,
-	make_presentation,
-	make_private,
-	make_private_image,
-	make_public,
+    PNG_1PX,
+    make_presentation,
+    make_private,
+    make_private_image,
+    make_public,
 )
 from suite.tests.utils import ensure_user
 
@@ -31,103 +31,103 @@ OTHER_USER = "slides-other@example.com"
 
 
 class TestPresentationSecurity(IntegrationTestCase):
-	@classmethod
-	def setUpClass(cls):
-		super().setUpClass()
-		ensure_user(OWNER)
-		ensure_user(OTHER_USER)
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        ensure_user(OWNER)
+        ensure_user(OTHER_USER)
 
-		with cls.set_user(OWNER):
-			cls.owner_presentation = make_presentation("Owner Presentation").name
-			cls.private_file = make_private_image(cls.owner_presentation)
+        with cls.set_user(OWNER):
+            cls.owner_presentation = make_presentation("Owner Presentation").name
+            cls.private_file = make_private_image(cls.owner_presentation)
 
-		with cls.set_user(OTHER_USER):
-			cls.other_presentation = make_presentation("Other User Presentation").name
+        with cls.set_user(OTHER_USER):
+            cls.other_presentation = make_presentation("Other User Presentation").name
 
-	def test_endpoints_require_permission(self):
-		cases = [
-			(save_base64_image, PNG_1PX, self.owner_presentation, "x"),
-			(update_slide_attachments, self.owner_presentation, {"elements": "[]"}),
-			(get_updated_json, self.owner_presentation, []),
-			(save_presentation_thumbnail, self.owner_presentation, PNG_1PX),
-			(update_title, self.owner_presentation, "Hijacked"),
-			(get_public_presentation, self.owner_presentation),
-			(delete_presentation, self.owner_presentation),
-		]
-		for func, *args in cases:
-			with self.subTest(func.__name__), self.set_user(OTHER_USER):
-				with self.assertRaises(frappe.PermissionError):
-					func(*args)
+    def test_endpoints_require_permission(self):
+        cases = [
+            (save_base64_image, PNG_1PX, self.owner_presentation, "x"),
+            (update_slide_attachments, self.owner_presentation, {"elements": "[]"}),
+            (get_updated_json, self.owner_presentation, []),
+            (save_presentation_thumbnail, self.owner_presentation, PNG_1PX),
+            (update_title, self.owner_presentation, "Hijacked"),
+            (get_public_presentation, self.owner_presentation),
+            (delete_presentation, self.owner_presentation),
+        ]
+        for func, *args in cases:
+            with self.subTest(func.__name__), self.set_user(OTHER_USER):
+                with self.assertRaises(frappe.PermissionError):
+                    func(*args)
 
-	def test_duplicate_requires_read(self):
-		with self.set_user(OTHER_USER):
-			with self.assertRaises(frappe.PermissionError):
-				create_presentation(duplicate_from=self.owner_presentation)
+    def test_duplicate_requires_read(self):
+        with self.set_user(OTHER_USER):
+            with self.assertRaises(frappe.PermissionError):
+                create_presentation(duplicate_from=self.owner_presentation)
 
-	def test_updated_json_blocks_file_exfil(self):
-		exfil = [{"type": "image", "src": self.private_file.file_url}]
-		with self.set_user(OTHER_USER):
-			with self.assertRaises(frappe.PermissionError):
-				get_updated_json(self.other_presentation, exfil)
+    def test_updated_json_blocks_file_exfil(self):
+        exfil = [{"type": "image", "src": self.private_file.file_url}]
+        with self.set_user(OTHER_USER):
+            with self.assertRaises(frappe.PermissionError):
+                get_updated_json(self.other_presentation, exfil)
 
-	def test_save_image_rejects_bad_data(self):
-		with self.set_user(OTHER_USER):
-			with self.assertRaises(frappe.ValidationError):
-				save_base64_image("not-a-data-uri", self.other_presentation, "x")
+    def test_save_image_rejects_bad_data(self):
+        with self.set_user(OTHER_USER):
+            with self.assertRaises(frappe.ValidationError):
+                save_base64_image("not-a-data-uri", self.other_presentation, "x")
 
-	def test_save_image_rejects_bad_extension(self):
-		with self.set_user(OTHER_USER):
-			with self.assertRaises(frappe.ValidationError):
-				save_base64_image(SVG, self.other_presentation, "x")
+    def test_save_image_rejects_bad_extension(self):
+        with self.set_user(OTHER_USER):
+            with self.assertRaises(frappe.ValidationError):
+                save_base64_image(SVG, self.other_presentation, "x")
 
-	def test_save_image_accepts_valid_png(self):
-		with self.set_user(OTHER_USER):
-			url = save_base64_image(PNG_1PX, self.other_presentation, "x")
+    def test_save_image_accepts_valid_png(self):
+        with self.set_user(OTHER_USER):
+            url = save_base64_image(PNG_1PX, self.other_presentation, "x")
 
-		self.assertTrue(url.endswith(".png"))
-		file = frappe.get_doc("File", {"file_url": url})
-		self.assertEqual(file.is_private, 1)
-		self.assertEqual(file.attached_to_doctype, "Presentation")
-		self.assertEqual(file.attached_to_name, self.other_presentation)
+        self.assertTrue(url.endswith(".png"))
+        file = frappe.get_doc("File", {"file_url": url})
+        self.assertEqual(file.is_private, 1)
+        self.assertEqual(file.attached_to_doctype, "Presentation")
+        self.assertEqual(file.attached_to_name, self.other_presentation)
 
-	def test_composite_blocks_private_presentation(self):
-		with self.set_user("Guest"):
-			with self.assertRaises(frappe.PermissionError):
-				get_composite_presentation(self.owner_presentation)
+    def test_composite_blocks_private_presentation(self):
+        with self.set_user("Guest"):
+            with self.assertRaises(frappe.PermissionError):
+                get_composite_presentation(self.owner_presentation)
 
-	def test_composite_serves_public_presentation_to_guest(self):
-		with self.set_user(OWNER):
-			ref = make_presentation("Public Reference")
-			make_public(ref.name)
-			composite = frappe.get_doc(
-				{
-					"doctype": "Presentation",
-					"title": "Composite Presentation",
-					"is_composite": 1,
-					"reference_presentations": [{"presentation": ref.name}],
-				}
-			).insert()
+    def test_composite_serves_public_presentation_to_guest(self):
+        with self.set_user(OWNER):
+            ref = make_presentation("Public Reference")
+            make_public(ref.name)
+            composite = frappe.get_doc(
+                {
+                    "doctype": "Presentation",
+                    "title": "Composite Presentation",
+                    "is_composite": 1,
+                    "reference_presentations": [{"presentation": ref.name}],
+                }
+            ).insert()
 
-		with self.set_user("Guest"):
-			result = get_composite_presentation(composite.name)
+        with self.set_user("Guest"):
+            result = get_composite_presentation(composite.name)
 
-		self.assertEqual(len(result["slides"]), len(ref.slides))
+        self.assertEqual(len(result["slides"]), len(ref.slides))
 
-	def test_composite_excludes_reference_made_private_later(self):
-		with self.set_user(OWNER):
-			ref = make_presentation("Later Private Reference")
-			make_public(ref.name)
-			composite = frappe.get_doc(
-				{
-					"doctype": "Presentation",
-					"title": "Stale Composite",
-					"is_composite": 1,
-					"reference_presentations": [{"presentation": ref.name}],
-				}
-			).insert()
-			make_private(ref.name)
+    def test_composite_excludes_reference_made_private_later(self):
+        with self.set_user(OWNER):
+            ref = make_presentation("Later Private Reference")
+            make_public(ref.name)
+            composite = frappe.get_doc(
+                {
+                    "doctype": "Presentation",
+                    "title": "Stale Composite",
+                    "is_composite": 1,
+                    "reference_presentations": [{"presentation": ref.name}],
+                }
+            ).insert()
+            make_private(ref.name)
 
-		with self.set_user("Guest"):
-			result = get_composite_presentation(composite.name)
+        with self.set_user("Guest"):
+            result = get_composite_presentation(composite.name)
 
-		self.assertEqual(result["slides"], [])
+        self.assertEqual(result["slides"], [])

--- a/suite/slides/doctype/reference_presentation/reference_presentation.py
+++ b/suite/slides/doctype/reference_presentation/reference_presentation.py
@@ -6,4 +6,4 @@ from frappe.model.document import Document
 
 
 class ReferencePresentation(Document):
-	pass
+    pass

--- a/suite/slides/doctype/reference_presentation/test_reference_presentation.py
+++ b/suite/slides/doctype/reference_presentation/test_reference_presentation.py
@@ -12,9 +12,9 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class IntegrationTestReferencePresentation(IntegrationTestCase):
-	"""
-	Integration tests for ReferencePresentation.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for ReferencePresentation.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/slides/doctype/slide/slide.py
+++ b/suite/slides/doctype/slide/slide.py
@@ -6,4 +6,4 @@ from frappe.model.document import Document
 
 
 class Slide(Document):
-	pass
+    pass

--- a/suite/slides/tests/utils.py
+++ b/suite/slides/tests/utils.py
@@ -7,48 +7,48 @@ import uuid
 import frappe
 
 PNG_1PX = (
-	"data:image/png;base64,"
-	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
 )
 
 
 def make_presentation(title):
-	return frappe.get_doc(
-		{
-			"doctype": "Presentation",
-			"title": title,
-			"slides": [{"elements": "[]"}],
-		}
-	).insert()
+    return frappe.get_doc(
+        {
+            "doctype": "Presentation",
+            "title": title,
+            "slides": [{"elements": "[]"}],
+        }
+    ).insert()
 
 
 def make_private_image(presentation_name):
-	# unique content per call: frappe dedupes Files by content hash, which
-	# would otherwise share one file_url across unrelated test fixtures
-	content = base64.b64decode(PNG_1PX.split(",", 1)[1]) + uuid.uuid4().bytes
-	return frappe.get_doc(
-		{
-			"doctype": "File",
-			"file_name": "private-image.png",
-			"content": content,
-			"is_private": 1,
-			"attached_to_doctype": "Presentation",
-			"attached_to_name": presentation_name,
-		}
-	).insert()
+    # unique content per call: frappe dedupes Files by content hash, which
+    # would otherwise share one file_url across unrelated test fixtures
+    content = base64.b64decode(PNG_1PX.split(",", 1)[1]) + uuid.uuid4().bytes
+    return frappe.get_doc(
+        {
+            "doctype": "File",
+            "file_name": "private-image.png",
+            "content": content,
+            "is_private": 1,
+            "attached_to_doctype": "Presentation",
+            "attached_to_name": presentation_name,
+        }
+    ).insert()
 
 
 def make_public(presentation_name):
-	from suite.drive.overrides.file import File as DriveFile
+    from suite.drive.overrides.file import File as DriveFile
 
-	file = DriveFile.get_for_doc("Presentation", presentation_name)
-	frappe.get_doc({"doctype": "Drive Permission", "entity": file, "user": "", "read": 1}).insert(
-		ignore_permissions=True
-	)
+    file = DriveFile.get_for_doc("Presentation", presentation_name)
+    frappe.get_doc({"doctype": "Drive Permission", "entity": file, "user": "", "read": 1}).insert(
+        ignore_permissions=True
+    )
 
 
 def make_private(presentation_name):
-	from suite.drive.overrides.file import File as DriveFile
+    from suite.drive.overrides.file import File as DriveFile
 
-	file = DriveFile.get_for_doc("Presentation", presentation_name)
-	frappe.db.delete("Drive Permission", {"entity": file, "user": ""})
+    file = DriveFile.get_for_doc("Presentation", presentation_name)
+    frappe.db.delete("Drive Permission", {"entity": file, "user": ""})

--- a/suite/slides/www/slides.py
+++ b/suite/slides/www/slides.py
@@ -4,8 +4,8 @@ no_cache = 1
 
 
 def get_context(context):
-	csrf_token = frappe.sessions.get_csrf_token()
-	frappe.db.commit()
-	context.csrf_token = csrf_token
-	context.apps = frappe.get_installed_apps()
-	context.site_name = frappe.local.site
+    csrf_token = frappe.sessions.get_csrf_token()
+    frappe.db.commit()
+    context.csrf_token = csrf_token
+    context.apps = frappe.get_installed_apps()
+    context.site_name = frappe.local.site

--- a/suite/store/__init__.py
+++ b/suite/store/__init__.py
@@ -9,60 +9,60 @@ from suite.store.base_store import Namespace, resolve_namespace_path
 
 
 def get_data_base_path() -> str:
-	"""Base directory holding every LMDB data-store environment for the current site.
+    """Base directory holding every LMDB data-store environment for the current site.
 
-	Sits alongside the site's private files, so it is per-site (multi-tenant safe) and never web-served.
-	"""
+    Sits alongside the site's private files, so it is per-site (multi-tenant safe) and never web-served.
+    """
 
-	return os.path.join(get_bench_path(), "sites", frappe.local.site, "private", "files", "data-store")
+    return os.path.join(get_bench_path(), "sites", frappe.local.site, "private", "files", "data-store")
 
 
 def get_blob_base_path() -> str:
-	"""Base directory holding every blob store for the current site.
+    """Base directory holding every blob store for the current site.
 
-	Sits alongside the site's private files, so it is per-site (multi-tenant safe) and never web-served.
-	"""
+    Sits alongside the site's private files, so it is per-site (multi-tenant safe) and never web-served.
+    """
 
-	return os.path.join(get_bench_path(), "sites", frappe.local.site, "private", "files", "blob-store")
+    return os.path.join(get_bench_path(), "sites", frappe.local.site, "private", "files", "blob-store")
 
 
 def get_search_base_path() -> str:
-	"""Base directory holding every Tantivy search index for the current site.
+    """Base directory holding every Tantivy search index for the current site.
 
-	Sits alongside the site's private files, so it is per-site (multi-tenant safe) and never web-served.
-	"""
+    Sits alongside the site's private files, so it is per-site (multi-tenant safe) and never web-served.
+    """
 
-	return os.path.join(get_bench_path(), "sites", frappe.local.site, "private", "files", "search-index")
+    return os.path.join(get_bench_path(), "sites", frappe.local.site, "private", "files", "search-index")
 
 
 def list_namespaces(base_path: str) -> list[tuple[str, ...]]:
-	"""Return every namespace (a tuple of decoded segments) that has a store under `base_path`.
+    """Return every namespace (a tuple of decoded segments) that has a store under `base_path`.
 
-	A namespace is a leaf directory — one with no sub-directories. The base path itself and any
-	stray files sitting in it (e.g. blob-store temp files) are ignored.
-	"""
+    A namespace is a leaf directory — one with no sub-directories. The base path itself and any
+    stray files sitting in it (e.g. blob-store temp files) are ignored.
+    """
 
-	if not os.path.isdir(base_path):
-		return []
+    if not os.path.isdir(base_path):
+        return []
 
-	namespaces = []
-	for dirpath, dirnames, _filenames in os.walk(base_path):
-		if dirpath == base_path or dirnames:
-			continue
+    namespaces = []
+    for dirpath, dirnames, _filenames in os.walk(base_path):
+        if dirpath == base_path or dirnames:
+            continue
 
-		relative = os.path.relpath(dirpath, base_path)
-		namespaces.append(tuple(unquote(segment) for segment in relative.split(os.sep)))
+        relative = os.path.relpath(dirpath, base_path)
+        namespaces.append(tuple(unquote(segment) for segment in relative.split(os.sep)))
 
-	return namespaces
+    return namespaces
 
 
 def destroy_namespace(base_path: str, namespace: Namespace) -> None:
-	"""Delete the on-disk directory for `namespace` under `base_path`, if it exists.
+    """Delete the on-disk directory for `namespace` under `base_path`, if it exists.
 
-	The namespace may be a prefix of the namespaces stores use (e.g. ``"mail"`` removes
-	``<base>/mail`` and every ``mail/<account>`` store beneath it).
-	"""
+    The namespace may be a prefix of the namespaces stores use (e.g. ``"mail"`` removes
+    ``<base>/mail`` and every ``mail/<account>`` store beneath it).
+    """
 
-	path = resolve_namespace_path(base_path, namespace)
-	if os.path.isdir(path):
-		shutil.rmtree(path, ignore_errors=True)
+    path = resolve_namespace_path(base_path, namespace)
+    if os.path.isdir(path):
+        shutil.rmtree(path, ignore_errors=True)

--- a/suite/store/base_store.py
+++ b/suite/store/base_store.py
@@ -13,112 +13,112 @@ Namespace = str | Sequence[str]
 
 
 def normalize_namespace(namespace: Namespace) -> tuple[str, ...]:
-	"""Validate a namespace and return it as a tuple of segments.
+    """Validate a namespace and return it as a tuple of segments.
 
-	Accepts either a ``"a/b"`` string (split on ``/``) or a sequence of segments. Rejects an
-	empty namespace and any empty, ``.`` or ``..`` segment, so a namespace can never escape the
-	base path once its segments are joined.
-	"""
+    Accepts either a ``"a/b"`` string (split on ``/``) or a sequence of segments. Rejects an
+    empty namespace and any empty, ``.`` or ``..`` segment, so a namespace can never escape the
+    base path once its segments are joined.
+    """
 
-	segments = namespace.split("/") if isinstance(namespace, str) else list(namespace)
+    segments = namespace.split("/") if isinstance(namespace, str) else list(namespace)
 
-	if not segments:
-		raise ValueError("namespace must have at least one segment")
+    if not segments:
+        raise ValueError("namespace must have at least one segment")
 
-	for segment in segments:
-		if not segment or segment in (".", ".."):
-			raise ValueError(f"invalid namespace segment: {segment!r}")
+    for segment in segments:
+        if not segment or segment in (".", ".."):
+            raise ValueError(f"invalid namespace segment: {segment!r}")
 
-	return tuple(segments)
+    return tuple(segments)
 
 
 def resolve_namespace_path(base_path: str, namespace: Namespace) -> str:
-	"""Return the on-disk directory for a namespace under `base_path`.
+    """Return the on-disk directory for a namespace under `base_path`.
 
-	Each segment is percent-encoded so it is a single, filesystem-safe path component (a
-	segment containing ``/`` cannot spill into extra directories).
-	"""
+    Each segment is percent-encoded so it is a single, filesystem-safe path component (a
+    segment containing ``/`` cannot spill into extra directories).
+    """
 
-	segments = normalize_namespace(namespace)
-	return os.path.join(base_path, *(quote(segment, safe="") for segment in segments))
+    segments = normalize_namespace(namespace)
+    return os.path.join(base_path, *(quote(segment, safe="") for segment in segments))
 
 
 class _StorageLogger:
-	"""Structured logger for the stores.
+    """Structured logger for the stores.
 
-	Each level takes an event name plus optional fields (and tolerates a pre-built dict as the
-	event) and emits one record per event to the ``suite.store`` frappe logger.
-	"""
+    Each level takes an event name plus optional fields (and tolerates a pre-built dict as the
+    event) and emits one record per event to the ``suite.store`` frappe logger.
+    """
 
-	def __init__(self, ctx: dict) -> None:
-		self.ctx = ctx
-		self.logger = frappe.logger("suite.store", allow_site=True)
+    def __init__(self, ctx: dict) -> None:
+        self.ctx = ctx
+        self.logger = frappe.logger("suite.store", allow_site=True)
 
-	def _record(self, event: Any, fields: dict) -> dict:
-		if isinstance(event, dict):
-			return {**self.ctx, **event}
-		return {**self.ctx, **fields, "event": event}
+    def _record(self, event: Any, fields: dict) -> dict:
+        if isinstance(event, dict):
+            return {**self.ctx, **event}
+        return {**self.ctx, **fields, "event": event}
 
-	def debug(self, event: Any, **fields: Any) -> None:
-		self.logger.debug(self._record(event, fields))
+    def debug(self, event: Any, **fields: Any) -> None:
+        self.logger.debug(self._record(event, fields))
 
-	def info(self, event: Any, **fields: Any) -> None:
-		self.logger.info(self._record(event, fields))
+    def info(self, event: Any, **fields: Any) -> None:
+        self.logger.info(self._record(event, fields))
 
-	def warning(self, event: Any, **fields: Any) -> None:
-		self.logger.warning(self._record(event, fields))
+    def warning(self, event: Any, **fields: Any) -> None:
+        self.logger.warning(self._record(event, fields))
 
-	def error(self, event: Any, **fields: Any) -> None:
-		self.logger.error(self._record(event, fields))
+    def error(self, event: Any, **fields: Any) -> None:
+        self.logger.error(self._record(event, fields))
 
-	def exception(self, event: Any, **fields: Any) -> None:
-		self.logger.exception(self._record(event, fields))
+    def exception(self, event: Any, **fields: Any) -> None:
+        self.logger.exception(self._record(event, fields))
 
 
 class BaseStore:
-	"""Base for stores scoped to a `namespace` (a relative directory under `base_path`).
+    """Base for stores scoped to a `namespace` (a relative directory under `base_path`).
 
-	The namespace gives each store its own directory, so a store's keys need no further
-	prefixing to stay isolated from other namespaces. Subclasses decide how keys map to
-	values within that directory (LMDB entries for `DataStore`, files for `BlobStore`).
-	"""
+    The namespace gives each store its own directory, so a store's keys need no further
+    prefixing to stay isolated from other namespaces. Subclasses decide how keys map to
+    values within that directory (LMDB entries for `DataStore`, files for `BlobStore`).
+    """
 
-	SEPARATOR: ClassVar[str] = ":"
-	_PROCESS_LOCKS: ClassVar[dict[str, RLock]] = {}
-	_PROCESS_LOCKS_GUARD: ClassVar[RLock] = RLock()
+    SEPARATOR: ClassVar[str] = ":"
+    _PROCESS_LOCKS: ClassVar[dict[str, RLock]] = {}
+    _PROCESS_LOCKS_GUARD: ClassVar[RLock] = RLock()
 
-	def __init__(
-		self,
-		base_path: str,
-		namespace: Namespace,
-	) -> None:
-		"""Initialize a store rooted at ``<base_path>/<namespace>``.
+    def __init__(
+        self,
+        base_path: str,
+        namespace: Namespace,
+    ) -> None:
+        """Initialize a store rooted at ``<base_path>/<namespace>``.
 
-		`namespace` is a relative path (``"a/b"`` string or sequence of segments) scoping this
-		store to its own directory.
-		"""
+        `namespace` is a relative path (``"a/b"`` string or sequence of segments) scoping this
+        store to its own directory.
+        """
 
-		self.base_path = base_path
-		self.namespace = normalize_namespace(namespace)
+        self.base_path = base_path
+        self.namespace = normalize_namespace(namespace)
 
-		self.logger_context = {"req_id": random_string(10), "namespace": "/".join(self.namespace)}
-		self.logger = _StorageLogger(self.logger_context)
+        self.logger_context = {"req_id": random_string(10), "namespace": "/".join(self.namespace)}
+        self.logger = _StorageLogger(self.logger_context)
 
-		self.path = resolve_namespace_path(self.base_path, self.namespace)
-		os.makedirs(self.path, exist_ok=True)
+        self.path = resolve_namespace_path(self.base_path, self.namespace)
+        os.makedirs(self.path, exist_ok=True)
 
-	def _get_process_lock(self, path: str | None = None) -> RLock:
-		"""Return a process-local lock shared by all storage instances for the same path."""
+    def _get_process_lock(self, path: str | None = None) -> RLock:
+        """Return a process-local lock shared by all storage instances for the same path."""
 
-		path = path or self.path
+        path = path or self.path
 
-		self.logger.debug("acquiring-rlock", path=path)
+        self.logger.debug("acquiring-rlock", path=path)
 
-		with self._PROCESS_LOCKS_GUARD:
-			lock = self._PROCESS_LOCKS.get(path)
-			if lock is None:
-				lock = RLock()
-				self._PROCESS_LOCKS[path] = lock
+        with self._PROCESS_LOCKS_GUARD:
+            lock = self._PROCESS_LOCKS.get(path)
+            if lock is None:
+                lock = RLock()
+                self._PROCESS_LOCKS[path] = lock
 
-			self.logger.debug("rlock-acquired", path=path)
-			return lock
+            self.logger.debug("rlock-acquired", path=path)
+            return lock

--- a/suite/store/blob_store.py
+++ b/suite/store/blob_store.py
@@ -11,212 +11,212 @@ from suite.store.base_store import BaseStore, Namespace
 
 
 class BlobStore(BaseStore):
-	"""A blob storage backed by the local file system.
+    """A blob storage backed by the local file system.
 
-	Each namespace's blobs live in their own directory (``<base_path>/<namespace>/``); files
-	inside are named by their encoded blob key.
-	"""
+    Each namespace's blobs live in their own directory (``<base_path>/<namespace>/``); files
+    inside are named by their encoded blob key.
+    """
 
-	def __init__(
-		self,
-		base_path: str,
-		namespace: Namespace,
-	) -> None:
-		"""Initialize per-namespace blob storage rooted at ``<base_path>/<namespace>``."""
+    def __init__(
+        self,
+        base_path: str,
+        namespace: Namespace,
+    ) -> None:
+        """Initialize per-namespace blob storage rooted at ``<base_path>/<namespace>``."""
 
-		super().__init__(base_path=base_path, namespace=namespace)
+        super().__init__(base_path=base_path, namespace=namespace)
 
-		self.logger_context["store"] = "blob"
+        self.logger_context["store"] = "blob"
 
-	def _is_within_storage_path(self, path: str) -> bool:
-		"""Return True when a path resolves within the configured storage directory."""
+    def _is_within_storage_path(self, path: str) -> bool:
+        """Return True when a path resolves within the configured storage directory."""
 
-		storage_root = os.path.realpath(self.path)
-		candidate = os.path.realpath(path)
-		return os.path.commonpath([storage_root, candidate]) == storage_root
+        storage_root = os.path.realpath(self.path)
+        candidate = os.path.realpath(path)
+        return os.path.commonpath([storage_root, candidate]) == storage_root
 
-	def _get_process_lock(self, path: str) -> RLock:
-		"""Return a process-local lock shared by all blob operations for the same path."""
+    def _get_process_lock(self, path: str) -> RLock:
+        """Return a process-local lock shared by all blob operations for the same path."""
 
-		return super()._get_process_lock(path)
+        return super()._get_process_lock(path)
 
-	def _encode_key(self, key: str) -> str:
-		"""Encode the key into a filesystem-safe file name."""
+    def _encode_key(self, key: str) -> str:
+        """Encode the key into a filesystem-safe file name."""
 
-		return quote(key, safe="")
+        return quote(key, safe="")
 
-	def _decode_key(self, key: str) -> str:
-		"""Decode a filesystem-safe file name back to the original key."""
+    def _decode_key(self, key: str) -> str:
+        """Decode a filesystem-safe file name back to the original key."""
 
-		return unquote(key)
+        return unquote(key)
 
-	def _get_blob_path(self, key: str) -> str:
-		"""Return the file path for the given blob key."""
+    def _get_blob_path(self, key: str) -> str:
+        """Return the file path for the given blob key."""
 
-		return os.path.join(self.path, self._encode_key(key))
+        return os.path.join(self.path, self._encode_key(key))
 
-	def _read_blob(self, path: str) -> bytes | None:
-		"""Read a blob from disk if it exists."""
+    def _read_blob(self, path: str) -> bytes | None:
+        """Read a blob from disk if it exists."""
 
-		try:
-			if not self._is_within_storage_path(path):
-				return None
+        try:
+            if not self._is_within_storage_path(path):
+                return None
 
-			stat_result = os.lstat(path)
-			if not stat.S_ISREG(stat_result.st_mode):
-				return None
+            stat_result = os.lstat(path)
+            if not stat.S_ISREG(stat_result.st_mode):
+                return None
 
-			flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
-			fd = os.open(path, flags)
-			with os.fdopen(fd, "rb") as file:
-				return file.read()
-		except FileNotFoundError:
-			return None
-		except OSError:
-			return None
+            flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+            fd = os.open(path, flags)
+            with os.fdopen(fd, "rb") as file:
+                return file.read()
+        except FileNotFoundError:
+            return None
+        except OSError:
+            return None
 
-	def get(self, key: str, default: bytes | None = None) -> bytes | None:
-		"""Retrieve a blob by key, returning a default if the key does not exist."""
+    def get(self, key: str, default: bytes | None = None) -> bytes | None:
+        """Retrieve a blob by key, returning a default if the key does not exist."""
 
-		value = self._read_blob(self._get_blob_path(key))
-		return value if value is not None else default
+        value = self._read_blob(self._get_blob_path(key))
+        return value if value is not None else default
 
-	def set(self, key: str, value: bytes | bytearray | memoryview) -> None:
-		"""Store a blob by key using an atomic file replacement."""
+    def set(self, key: str, value: bytes | bytearray | memoryview) -> None:
+        """Store a blob by key using an atomic file replacement."""
 
-		blob_path = self._get_blob_path(key)
-		if not self._is_within_storage_path(blob_path):
-			raise ValueError("Invalid blob path")
+        blob_path = self._get_blob_path(key)
+        if not self._is_within_storage_path(blob_path):
+            raise ValueError("Invalid blob path")
 
-		blob = bytes(value)
-		process_lock = self._get_process_lock(blob_path)
+        blob = bytes(value)
+        process_lock = self._get_process_lock(blob_path)
 
-		with process_lock:
-			# Write the temp file in the base path (not the blob's directory) so it stays
-			# outside what scan/count/delete_all walk, while remaining on the same filesystem
-			# for an atomic os.replace into place.
-			fd, temp_path = tempfile.mkstemp(dir=self.base_path)
-			try:
-				with os.fdopen(fd, "wb") as file:
-					file.write(blob)
+        with process_lock:
+            # Write the temp file in the base path (not the blob's directory) so it stays
+            # outside what scan/count/delete_all walk, while remaining on the same filesystem
+            # for an atomic os.replace into place.
+            fd, temp_path = tempfile.mkstemp(dir=self.base_path)
+            try:
+                with os.fdopen(fd, "wb") as file:
+                    file.write(blob)
 
-				os.replace(temp_path, blob_path)
-			except Exception:
-				with suppress(FileNotFoundError):
-					os.unlink(temp_path)
-				raise
+                os.replace(temp_path, blob_path)
+            except Exception:
+                with suppress(FileNotFoundError):
+                    os.unlink(temp_path)
+                raise
 
-	def delete(self, key: str) -> None:
-		"""Delete a blob by key."""
+    def delete(self, key: str) -> None:
+        """Delete a blob by key."""
 
-		blob_path = self._get_blob_path(key)
-		if not self._is_within_storage_path(blob_path):
-			return
+        blob_path = self._get_blob_path(key)
+        if not self._is_within_storage_path(blob_path):
+            return
 
-		process_lock = self._get_process_lock(blob_path)
+        process_lock = self._get_process_lock(blob_path)
 
-		with process_lock:
-			with suppress(FileNotFoundError):
-				os.remove(blob_path)
+        with process_lock:
+            with suppress(FileNotFoundError):
+                os.remove(blob_path)
 
-	def exists(self, key: str) -> bool:
-		"""Check if a blob exists in the storage."""
+    def exists(self, key: str) -> bool:
+        """Check if a blob exists in the storage."""
 
-		blob_path = self._get_blob_path(key)
-		if not self._is_within_storage_path(blob_path):
-			return False
+        blob_path = self._get_blob_path(key)
+        if not self._is_within_storage_path(blob_path):
+            return False
 
-		try:
-			return stat.S_ISREG(os.lstat(blob_path).st_mode)
-		except FileNotFoundError:
-			return False
+        try:
+            return stat.S_ISREG(os.lstat(blob_path).st_mode)
+        except FileNotFoundError:
+            return False
 
-	def get_many(self, keys: list[str]) -> dict[str, bytes | None]:
-		"""Retrieve multiple blobs by key."""
+    def get_many(self, keys: list[str]) -> dict[str, bytes | None]:
+        """Retrieve multiple blobs by key."""
 
-		if not keys:
-			return {}
+        if not keys:
+            return {}
 
-		result = {}
-		for key in keys:
-			result[key] = self._read_blob(self._get_blob_path(key))
+        result = {}
+        for key in keys:
+            result[key] = self._read_blob(self._get_blob_path(key))
 
-		return result
+        return result
 
-	def set_many(self, items: dict[str, bytes | bytearray | memoryview]) -> None:
-		"""Store multiple blobs."""
+    def set_many(self, items: dict[str, bytes | bytearray | memoryview]) -> None:
+        """Store multiple blobs."""
 
-		if not items:
-			return
+        if not items:
+            return
 
-		for key, value in items.items():
-			self.set(key, value)
+        for key, value in items.items():
+            self.set(key, value)
 
-	def delete_many(self, keys: list[str]) -> None:
-		"""Delete multiple blobs."""
+    def delete_many(self, keys: list[str]) -> None:
+        """Delete multiple blobs."""
 
-		if not keys:
-			return
+        if not keys:
+            return
 
-		for key in keys:
-			self.delete(key)
+        for key in keys:
+            self.delete(key)
 
-	def scan(self, prefix: str = "") -> dict[str, bytes]:
-		"""Scan for all blobs whose keys start with the given prefix."""
+    def scan(self, prefix: str = "") -> dict[str, bytes]:
+        """Scan for all blobs whose keys start with the given prefix."""
 
-		encoded_prefix = self._encode_key(prefix)
-		result = {}
+        encoded_prefix = self._encode_key(prefix)
+        result = {}
 
-		with os.scandir(self.path) as entries:
-			for entry in entries:
-				if not entry.is_file(follow_symlinks=False) or not entry.name.startswith(encoded_prefix):
-					continue
+        with os.scandir(self.path) as entries:
+            for entry in entries:
+                if not entry.is_file(follow_symlinks=False) or not entry.name.startswith(encoded_prefix):
+                    continue
 
-				value = self._read_blob(entry.path)
-				if value is None:
-					continue
+                value = self._read_blob(entry.path)
+                if value is None:
+                    continue
 
-				key = self._decode_key(entry.name)
-				result[key] = value
+                key = self._decode_key(entry.name)
+                result[key] = value
 
-		return result
+        return result
 
-	def count(self, prefix: str = "") -> int:
-		"""Count the number of blobs whose keys start with the given prefix."""
+    def count(self, prefix: str = "") -> int:
+        """Count the number of blobs whose keys start with the given prefix."""
 
-		encoded_prefix = self._encode_key(prefix)
-		count = 0
+        encoded_prefix = self._encode_key(prefix)
+        count = 0
 
-		with os.scandir(self.path) as entries:
-			for entry in entries:
-				if entry.is_file(follow_symlinks=False) and entry.name.startswith(encoded_prefix):
-					count += 1
+        with os.scandir(self.path) as entries:
+            for entry in entries:
+                if entry.is_file(follow_symlinks=False) and entry.name.startswith(encoded_prefix):
+                    count += 1
 
-		return count
+        return count
 
-	def browse(self, limit: int | None = None) -> list[dict]:
-		"""List blobs as ``{key, size}`` without reading their contents (for tooling)."""
+    def browse(self, limit: int | None = None) -> list[dict]:
+        """List blobs as ``{key, size}`` without reading their contents (for tooling)."""
 
-		entries = []
-		with os.scandir(self.path) as scan:
-			for entry in scan:
-				if not entry.is_file(follow_symlinks=False):
-					continue
+        entries = []
+        with os.scandir(self.path) as scan:
+            for entry in scan:
+                if not entry.is_file(follow_symlinks=False):
+                    continue
 
-				entries.append({"key": self._decode_key(entry.name), "size": entry.stat().st_size})
+                entries.append({"key": self._decode_key(entry.name), "size": entry.stat().st_size})
 
-				if limit is not None and len(entries) >= limit:
-					break
+                if limit is not None and len(entries) >= limit:
+                    break
 
-		return entries
+        return entries
 
-	def delete_all(self) -> None:
-		"""Delete every blob in this namespace's directory."""
+    def delete_all(self) -> None:
+        """Delete every blob in this namespace's directory."""
 
-		self.logger.info({**self.logger_context, "user": frappe.session.user, "event": "deleting-all-blobs"})
+        self.logger.info({**self.logger_context, "user": frappe.session.user, "event": "deleting-all-blobs"})
 
-		with os.scandir(self.path) as entries:
-			for entry in entries:
-				if entry.is_file(follow_symlinks=False):
-					with suppress(FileNotFoundError):
-						os.remove(entry.path)
+        with os.scandir(self.path) as entries:
+            for entry in entries:
+                if entry.is_file(follow_symlinks=False):
+                    with suppress(FileNotFoundError):
+                        os.remove(entry.path)

--- a/suite/store/data_store.py
+++ b/suite/store/data_store.py
@@ -12,433 +12,433 @@ from suite.store.base_store import BaseStore, Namespace
 
 
 class _EnvEntry:
-	"""Tracks a cached LMDB environment and the number of in-flight transactions using it."""
+    """Tracks a cached LMDB environment and the number of in-flight transactions using it."""
 
-	__slots__ = ("env", "refcount")
+    __slots__ = ("env", "refcount")
 
-	def __init__(self, env: "lmdb.Environment") -> None:
-		self.env = env
-		self.refcount = 0
+    def __init__(self, env: "lmdb.Environment") -> None:
+        self.env = env
+        self.refcount = 0
 
 
 class DataStore(BaseStore):
-	"""A key-value store backed by LMDB, with one environment per ``namespace``.
-
-	The store is shared by every user with access to the namespace. LMDB natively supports
-	concurrent multi-process access: many readers run lock-free via MVCC snapshots while a
-	single writer briefly serializes on a robust mutex (and waits
-	rather than failing). Environments are kept open and shared per process, so there is no
-	per-operation open cost and no external locking layer.
-	"""
-
-	MAX_MSGPACK_BYTES = 25 * 1024 * 1024
-	MAX_MSGPACK_COLLECTION_LEN = 2_00_000
-
-	# Virtual address-space ceiling per environment. It is sparse (not preallocated) on 64-bit
-	# systems, and grows automatically on MapFullError. Migration uses this same value.
-	DEFAULT_MAP_SIZE = 2 * 1024 * 1024 * 1024
-
-	# Best-effort per-process soft cap on simultaneously open environments. Before opening a
-	# new environment, idle ones (no in-flight transactions) are closed least-recently-used
-	# first. The cap may be temporarily exceeded under load when every cached environment is
-	# busy, since an in-use environment is never force-closed.
-	MAX_CACHED_ENVS = 128
-
-	# Size of each environment's reader lock table. A reader slot is held per live process/thread
-	# that has the environment open, and is shared across every process via lock.mdb, so the
-	# default (126) is easily exhausted by many web + background workers on a hot key
-	# (MDB_READERS_FULL). The table is a sparse file (~one page on disk until slots are used), so
-	# a generous value is effectively free. Stale slots left by crashed/recycled workers are
-	# reclaimed via reader_check().
-	MAX_READERS = 2048
-
-	_ENVS: ClassVar[OrderedDict[str, _EnvEntry]] = OrderedDict()
-	_ENVS_GUARD: ClassVar[RLock] = RLock()
-
-	def __init__(
-		self,
-		base_path: str,
-		namespace: Namespace,
-		map_size: int | None = None,
-		**_legacy: Any,
-	) -> None:
-		"""Initialize the store for the given base path and ``namespace``."""
-
-		super().__init__(base_path=base_path, namespace=namespace)
-
-		self.logger_context["store"] = "data"
-		self.map_size = map_size or self.DEFAULT_MAP_SIZE
-
-	def _open_env(self) -> "lmdb.Environment":
-		"""Open the LMDB environment for this store's path."""
-
-		self.logger.debug({**self.logger_context, "event": "opening-env", "path": self.path})
-
-		env = lmdb.open(
-			self.path,
-			map_size=self.map_size,
-			subdir=True,
-			max_dbs=0,
-			max_readers=self.MAX_READERS,
-			readahead=False,
-			meminit=False,
-			writemap=False,
-		)
-
-		# Reclaim reader slots left behind by crashed or recycled workers. This runs whenever a
-		# worker opens the environment, keeping the shared reader table from filling up over time.
-		self._reader_check(env)
-		return env
-
-	def _reader_check(self, env: "lmdb.Environment") -> None:
-		"""Reclaim stale reader-lock-table slots (from dead processes/threads). Best-effort."""
-
-		try:
-			reclaimed = env.reader_check()
-			if reclaimed:
-				self.logger.info(
-					{
-						**self.logger_context,
-						"event": "reader-check",
-						"path": self.path,
-						"reclaimed": reclaimed,
-					}
-				)
-		except Exception:
-			self.logger.warning({**self.logger_context, "event": "reader-check-failed", "path": self.path})
-
-	def _acquire_env(self) -> _EnvEntry:
-		"""Return the cached environment for this path, opening it if needed, and mark it in use."""
-
-		with self._ENVS_GUARD:
-			entry = self._ENVS.get(self.path)
-			if entry is None:
-				self._evict_idle_envs()
-				entry = _EnvEntry(self._open_env())
-				self._ENVS[self.path] = entry
-
-			entry.refcount += 1
-			self._ENVS.move_to_end(self.path)
-			return entry
-
-	def _release_env(self) -> None:
-		"""Mark this path's environment as no longer in use by the current operation."""
-
-		with self._ENVS_GUARD:
-			entry = self._ENVS.get(self.path)
-			if entry is not None and entry.refcount > 0:
-				entry.refcount -= 1
-
-	@classmethod
-	def close_all_envs(cls) -> None:
-		"""Close every cached LMDB environment in this process.
-
-		Intended for worker shutdown and tests. Must not be called while transactions are
-		in flight; LMDB forbids opening the same environment twice in a process, so a fresh
-		open afterwards is safe only once all handles are released.
-		"""
-
-		with cls._ENVS_GUARD:
-			for entry in cls._ENVS.values():
-				with suppress(Exception):
-					entry.env.close()
-
-			cls._ENVS.clear()
-
-	def _evict_idle_envs(self) -> None:
-		"""Close least-recently-used idle environments while over the cache cap."""
-
-		while len(self._ENVS) >= self.MAX_CACHED_ENVS:
-			victim_path = None
-			for path, entry in self._ENVS.items():
-				if entry.refcount == 0:
-					victim_path = path
-					break
-
-			if victim_path is None:
-				# Every cached environment is currently in use; nothing safe to evict.
-				return
-
-			entry = self._ENVS.pop(victim_path)
-			self.logger.debug({**self.logger_context, "event": "evicting-env", "path": victim_path})
-			with suppress(Exception):
-				entry.env.close()
-
-	def _grow_map(self) -> None:
-		"""Double the map size of this path's environment after a MapFullError."""
-
-		with self._ENVS_GUARD:
-			entry = self._ENVS.get(self.path)
-			if entry is None:
-				return
-
-			self.map_size = max(self.map_size * 2, self.DEFAULT_MAP_SIZE * 2)
-			self.logger.warning(
-				{**self.logger_context, "event": "growing-map", "path": self.path, "map_size": self.map_size}
-			)
-			entry.env.set_mapsize(self.map_size)
-
-	@contextmanager
-	def _txn(self, write: bool) -> Any:
-		"""Yield an LMDB transaction on this store's environment."""
-
-		entry = self._acquire_env()
-		try:
-			with self._begin(entry.env, write) as txn:
-				yield txn
-		finally:
-			self._release_env()
-
-	def _begin(self, env: "lmdb.Environment", write: bool) -> Any:
-		"""Begin a transaction, reclaiming stale reader slots and retrying once on MDB_READERS_FULL."""
-
-		try:
-			return env.begin(write=write, buffers=False)
-		except lmdb.ReadersFullError:
-			self._reader_check(env)
-			return env.begin(write=write, buffers=False)
+    """A key-value store backed by LMDB, with one environment per ``namespace``.
+
+    The store is shared by every user with access to the namespace. LMDB natively supports
+    concurrent multi-process access: many readers run lock-free via MVCC snapshots while a
+    single writer briefly serializes on a robust mutex (and waits
+    rather than failing). Environments are kept open and shared per process, so there is no
+    per-operation open cost and no external locking layer.
+    """
+
+    MAX_MSGPACK_BYTES = 25 * 1024 * 1024
+    MAX_MSGPACK_COLLECTION_LEN = 2_00_000
+
+    # Virtual address-space ceiling per environment. It is sparse (not preallocated) on 64-bit
+    # systems, and grows automatically on MapFullError. Migration uses this same value.
+    DEFAULT_MAP_SIZE = 2 * 1024 * 1024 * 1024
+
+    # Best-effort per-process soft cap on simultaneously open environments. Before opening a
+    # new environment, idle ones (no in-flight transactions) are closed least-recently-used
+    # first. The cap may be temporarily exceeded under load when every cached environment is
+    # busy, since an in-use environment is never force-closed.
+    MAX_CACHED_ENVS = 128
+
+    # Size of each environment's reader lock table. A reader slot is held per live process/thread
+    # that has the environment open, and is shared across every process via lock.mdb, so the
+    # default (126) is easily exhausted by many web + background workers on a hot key
+    # (MDB_READERS_FULL). The table is a sparse file (~one page on disk until slots are used), so
+    # a generous value is effectively free. Stale slots left by crashed/recycled workers are
+    # reclaimed via reader_check().
+    MAX_READERS = 2048
+
+    _ENVS: ClassVar[OrderedDict[str, _EnvEntry]] = OrderedDict()
+    _ENVS_GUARD: ClassVar[RLock] = RLock()
+
+    def __init__(
+        self,
+        base_path: str,
+        namespace: Namespace,
+        map_size: int | None = None,
+        **_legacy: Any,
+    ) -> None:
+        """Initialize the store for the given base path and ``namespace``."""
+
+        super().__init__(base_path=base_path, namespace=namespace)
+
+        self.logger_context["store"] = "data"
+        self.map_size = map_size or self.DEFAULT_MAP_SIZE
+
+    def _open_env(self) -> "lmdb.Environment":
+        """Open the LMDB environment for this store's path."""
+
+        self.logger.debug({**self.logger_context, "event": "opening-env", "path": self.path})
+
+        env = lmdb.open(
+            self.path,
+            map_size=self.map_size,
+            subdir=True,
+            max_dbs=0,
+            max_readers=self.MAX_READERS,
+            readahead=False,
+            meminit=False,
+            writemap=False,
+        )
+
+        # Reclaim reader slots left behind by crashed or recycled workers. This runs whenever a
+        # worker opens the environment, keeping the shared reader table from filling up over time.
+        self._reader_check(env)
+        return env
+
+    def _reader_check(self, env: "lmdb.Environment") -> None:
+        """Reclaim stale reader-lock-table slots (from dead processes/threads). Best-effort."""
+
+        try:
+            reclaimed = env.reader_check()
+            if reclaimed:
+                self.logger.info(
+                    {
+                        **self.logger_context,
+                        "event": "reader-check",
+                        "path": self.path,
+                        "reclaimed": reclaimed,
+                    }
+                )
+        except Exception:
+            self.logger.warning({**self.logger_context, "event": "reader-check-failed", "path": self.path})
+
+    def _acquire_env(self) -> _EnvEntry:
+        """Return the cached environment for this path, opening it if needed, and mark it in use."""
+
+        with self._ENVS_GUARD:
+            entry = self._ENVS.get(self.path)
+            if entry is None:
+                self._evict_idle_envs()
+                entry = _EnvEntry(self._open_env())
+                self._ENVS[self.path] = entry
+
+            entry.refcount += 1
+            self._ENVS.move_to_end(self.path)
+            return entry
+
+    def _release_env(self) -> None:
+        """Mark this path's environment as no longer in use by the current operation."""
+
+        with self._ENVS_GUARD:
+            entry = self._ENVS.get(self.path)
+            if entry is not None and entry.refcount > 0:
+                entry.refcount -= 1
+
+    @classmethod
+    def close_all_envs(cls) -> None:
+        """Close every cached LMDB environment in this process.
+
+        Intended for worker shutdown and tests. Must not be called while transactions are
+        in flight; LMDB forbids opening the same environment twice in a process, so a fresh
+        open afterwards is safe only once all handles are released.
+        """
+
+        with cls._ENVS_GUARD:
+            for entry in cls._ENVS.values():
+                with suppress(Exception):
+                    entry.env.close()
+
+            cls._ENVS.clear()
+
+    def _evict_idle_envs(self) -> None:
+        """Close least-recently-used idle environments while over the cache cap."""
+
+        while len(self._ENVS) >= self.MAX_CACHED_ENVS:
+            victim_path = None
+            for path, entry in self._ENVS.items():
+                if entry.refcount == 0:
+                    victim_path = path
+                    break
+
+            if victim_path is None:
+                # Every cached environment is currently in use; nothing safe to evict.
+                return
+
+            entry = self._ENVS.pop(victim_path)
+            self.logger.debug({**self.logger_context, "event": "evicting-env", "path": victim_path})
+            with suppress(Exception):
+                entry.env.close()
+
+    def _grow_map(self) -> None:
+        """Double the map size of this path's environment after a MapFullError."""
+
+        with self._ENVS_GUARD:
+            entry = self._ENVS.get(self.path)
+            if entry is None:
+                return
+
+            self.map_size = max(self.map_size * 2, self.DEFAULT_MAP_SIZE * 2)
+            self.logger.warning(
+                {**self.logger_context, "event": "growing-map", "path": self.path, "map_size": self.map_size}
+            )
+            entry.env.set_mapsize(self.map_size)
+
+    @contextmanager
+    def _txn(self, write: bool) -> Any:
+        """Yield an LMDB transaction on this store's environment."""
+
+        entry = self._acquire_env()
+        try:
+            with self._begin(entry.env, write) as txn:
+                yield txn
+        finally:
+            self._release_env()
+
+    def _begin(self, env: "lmdb.Environment", write: bool) -> Any:
+        """Begin a transaction, reclaiming stale reader slots and retrying once on MDB_READERS_FULL."""
+
+        try:
+            return env.begin(write=write, buffers=False)
+        except lmdb.ReadersFullError:
+            self._reader_check(env)
+            return env.begin(write=write, buffers=False)
 
-	def _write(self, fn: Any) -> None:
-		"""Run a write callback in a transaction, growing the map and retrying on MapFullError."""
+    def _write(self, fn: Any) -> None:
+        """Run a write callback in a transaction, growing the map and retrying on MapFullError."""
 
-		for _ in range(2):
-			try:
-				with self._txn(write=True) as txn:
-					fn(txn)
-				return
-			except lmdb.MapFullError:
-				self._grow_map()
+        for _ in range(2):
+            try:
+                with self._txn(write=True) as txn:
+                    fn(txn)
+                return
+            except lmdb.MapFullError:
+                self._grow_map()
 
-		with self._txn(write=True) as txn:
-			fn(txn)
+        with self._txn(write=True) as txn:
+            fn(txn)
 
-	def _serialize(self, value: Any) -> bytes:
-		"""Serialize a value to bytes using msgpack.
+    def _serialize(self, value: Any) -> bytes:
+        """Serialize a value to bytes using msgpack.
 
-		The size cap is enforced here and not only on the way back out: an oversized value used to
-		commit successfully and then fail every subsequent read, which also took down any ``scan``
-		covering it. Refusing the write keeps the store readable.
-		"""
+        The size cap is enforced here and not only on the way back out: an oversized value used to
+        commit successfully and then fail every subsequent read, which also took down any ``scan``
+        covering it. Refusing the write keeps the store readable.
+        """
 
-		packed = msgpack.packb(value, use_bin_type=True)
+        packed = msgpack.packb(value, use_bin_type=True)
 
-		if len(packed) > self.MAX_MSGPACK_BYTES:
-			raise ValueError("Serialized value exceeds allowed size limit")
+        if len(packed) > self.MAX_MSGPACK_BYTES:
+            raise ValueError("Serialized value exceeds allowed size limit")
 
-		return packed
+        return packed
 
-	def _deserialize(self, value: bytes) -> Any:
-		"""Deserialize bytes back to a Python object using msgpack."""
+    def _deserialize(self, value: bytes) -> Any:
+        """Deserialize bytes back to a Python object using msgpack."""
 
-		if len(value) > self.MAX_MSGPACK_BYTES:
-			raise ValueError("Serialized value exceeds allowed size limit")
+        if len(value) > self.MAX_MSGPACK_BYTES:
+            raise ValueError("Serialized value exceeds allowed size limit")
 
-		return msgpack.unpackb(
-			value,
-			raw=False,
-			# packb happily writes non-string map keys, so refusing them here would make a value
-			# that was accepted on write unreadable for good.
-			strict_map_key=False,
-			max_bin_len=self.MAX_MSGPACK_BYTES,
-			max_str_len=self.MAX_MSGPACK_BYTES,
-			max_ext_len=self.MAX_MSGPACK_BYTES,
-			max_array_len=self.MAX_MSGPACK_COLLECTION_LEN,
-			max_map_len=self.MAX_MSGPACK_COLLECTION_LEN,
-		)
+        return msgpack.unpackb(
+            value,
+            raw=False,
+            # packb happily writes non-string map keys, so refusing them here would make a value
+            # that was accepted on write unreadable for good.
+            strict_map_key=False,
+            max_bin_len=self.MAX_MSGPACK_BYTES,
+            max_str_len=self.MAX_MSGPACK_BYTES,
+            max_ext_len=self.MAX_MSGPACK_BYTES,
+            max_array_len=self.MAX_MSGPACK_COLLECTION_LEN,
+            max_map_len=self.MAX_MSGPACK_COLLECTION_LEN,
+        )
 
-	def _entity_prefix(self, entity: Enum) -> str:
-		"""Return the ``<entity>:`` prefix that scopes keys to an entity within the namespace."""
+    def _entity_prefix(self, entity: Enum) -> str:
+        """Return the ``<entity>:`` prefix that scopes keys to an entity within the namespace."""
 
-		return f"{entity.value}{self.SEPARATOR}"
+        return f"{entity.value}{self.SEPARATOR}"
 
-	def _db_key(self, entity: Enum, key: str) -> bytes:
-		"""Encode a caller's `key` into the entity-scoped LMDB key stored on disk.
+    def _db_key(self, entity: Enum, key: str) -> bytes:
+        """Encode a caller's `key` into the entity-scoped LMDB key stored on disk.
 
-		The namespace already isolates this store's directory, so the on-disk key is just
-		``<entity>:<key>`` (as UTF-8 bytes); it does not repeat the namespace.
-		"""
+        The namespace already isolates this store's directory, so the on-disk key is just
+        ``<entity>:<key>`` (as UTF-8 bytes); it does not repeat the namespace.
+        """
 
-		return f"{self._entity_prefix(entity)}{key}".encode()
+        return f"{self._entity_prefix(entity)}{key}".encode()
 
-	def get(self, entity: Enum, key: str, default: Any | None = None) -> Any | None:
-		"""Retrieve a value by key, returning a default if the key does not exist."""
+    def get(self, entity: Enum, key: str, default: Any | None = None) -> Any | None:
+        """Retrieve a value by key, returning a default if the key does not exist."""
 
-		db_key = self._db_key(entity, key)
-		with self._txn(write=False) as txn:
-			value = txn.get(db_key)
+        db_key = self._db_key(entity, key)
+        with self._txn(write=False) as txn:
+            value = txn.get(db_key)
 
-		return self._deserialize(value) if value is not None else default
+        return self._deserialize(value) if value is not None else default
 
-	def set(self, entity: Enum, key: str, value: Any) -> None:
-		"""Store a value by key, serializing it before saving."""
+    def set(self, entity: Enum, key: str, value: Any) -> None:
+        """Store a value by key, serializing it before saving."""
 
-		db_key = self._db_key(entity, key)
-		data = self._serialize(value)
-		self._write(lambda txn: txn.put(db_key, data))
+        db_key = self._db_key(entity, key)
+        data = self._serialize(value)
+        self._write(lambda txn: txn.put(db_key, data))
 
-	def delete(self, entity: Enum, key: str) -> None:
-		"""Delete a value by key."""
+    def delete(self, entity: Enum, key: str) -> None:
+        """Delete a value by key."""
 
-		db_key = self._db_key(entity, key)
-		self._write(lambda txn: txn.delete(db_key))
+        db_key = self._db_key(entity, key)
+        self._write(lambda txn: txn.delete(db_key))
 
-	def exists(self, entity: Enum, key: str) -> bool:
-		"""Check if a key exists in the storage."""
+    def exists(self, entity: Enum, key: str) -> bool:
+        """Check if a key exists in the storage."""
 
-		db_key = self._db_key(entity, key)
-		with self._txn(write=False) as txn:
-			return txn.get(db_key) is not None
+        db_key = self._db_key(entity, key)
+        with self._txn(write=False) as txn:
+            return txn.get(db_key) is not None
 
-	def get_many(self, entity: Enum, keys: list[str]) -> dict[str, Any | None]:
-		"""Retrieve multiple values by a list of keys, returning a dictionary of key-value pairs."""
+    def get_many(self, entity: Enum, keys: list[str]) -> dict[str, Any | None]:
+        """Retrieve multiple values by a list of keys, returning a dictionary of key-value pairs."""
 
-		if not keys:
-			return {}
+        if not keys:
+            return {}
 
-		db_keys = [(key, self._db_key(entity, key)) for key in keys]
+        db_keys = [(key, self._db_key(entity, key)) for key in keys]
 
-		with self._txn(write=False) as txn:
-			raw = [(key, txn.get(db_key)) for key, db_key in db_keys]
+        with self._txn(write=False) as txn:
+            raw = [(key, txn.get(db_key)) for key, db_key in db_keys]
 
-		return {key: self._deserialize(value) if value is not None else None for key, value in raw}
+        return {key: self._deserialize(value) if value is not None else None for key, value in raw}
 
-	def set_many(self, entity: Enum, items: dict[str, Any]) -> None:
-		"""Store multiple key-value pairs at once, serializing values before saving."""
+    def set_many(self, entity: Enum, items: dict[str, Any]) -> None:
+        """Store multiple key-value pairs at once, serializing values before saving."""
 
-		if not items:
-			return
+        if not items:
+            return
 
-		encoded = [(self._db_key(entity, key), self._serialize(value)) for key, value in items.items()]
+        encoded = [(self._db_key(entity, key), self._serialize(value)) for key, value in items.items()]
 
-		def _put_all(txn: Any) -> None:
-			for db_key, data in encoded:
-				txn.put(db_key, data)
+        def _put_all(txn: Any) -> None:
+            for db_key, data in encoded:
+                txn.put(db_key, data)
 
-		self._write(_put_all)
+        self._write(_put_all)
 
-	def delete_many(self, entity: Enum, keys: list[str]) -> None:
-		"""Delete multiple keys from the storage at once."""
+    def delete_many(self, entity: Enum, keys: list[str]) -> None:
+        """Delete multiple keys from the storage at once."""
 
-		if not keys:
-			return
+        if not keys:
+            return
 
-		db_keys = [self._db_key(entity, key) for key in keys]
+        db_keys = [self._db_key(entity, key) for key in keys]
 
-		def _delete_all(txn: Any) -> None:
-			for db_key in db_keys:
-				txn.delete(db_key)
+        def _delete_all(txn: Any) -> None:
+            for db_key in db_keys:
+                txn.delete(db_key)
 
-		self._write(_delete_all)
+        self._write(_delete_all)
 
-	def scan(self, entity: Enum, prefix: str = "", limit: int | None = None) -> dict[str, Any]:
-		"""Scan for all key-value pairs whose key starts with `prefix`, returning them as a dict."""
+    def scan(self, entity: Enum, prefix: str = "", limit: int | None = None) -> dict[str, Any]:
+        """Scan for all key-value pairs whose key starts with `prefix`, returning them as a dict."""
 
-		entity_prefix = self._entity_prefix(entity)
-		db_prefix = self._db_key(entity, prefix)
-		result = {}
+        entity_prefix = self._entity_prefix(entity)
+        db_prefix = self._db_key(entity, prefix)
+        result = {}
 
-		with self._txn(write=False) as txn:
-			cursor = txn.cursor()
-			if cursor.set_range(db_prefix):
-				for db_key, value in cursor:
-					if not db_key.startswith(db_prefix):
-						break
+        with self._txn(write=False) as txn:
+            cursor = txn.cursor()
+            if cursor.set_range(db_prefix):
+                for db_key, value in cursor:
+                    if not db_key.startswith(db_prefix):
+                        break
 
-					key = db_key.decode().removeprefix(entity_prefix)
-					result[key] = self._deserialize(value)
+                    key = db_key.decode().removeprefix(entity_prefix)
+                    result[key] = self._deserialize(value)
 
-					if limit is not None and len(result) >= limit:
-						break
+                    if limit is not None and len(result) >= limit:
+                        break
 
-		return result
+        return result
 
-	def count(self, entity: Enum, prefix: str = "") -> int:
-		"""Count the number of keys that start with `prefix`."""
+    def count(self, entity: Enum, prefix: str = "") -> int:
+        """Count the number of keys that start with `prefix`."""
 
-		db_prefix = self._db_key(entity, prefix)
-		count = 0
+        db_prefix = self._db_key(entity, prefix)
+        count = 0
 
-		with self._txn(write=False) as txn:
-			cursor = txn.cursor()
-			if cursor.set_range(db_prefix):
-				for db_key in cursor.iternext(keys=True, values=False):
-					if not db_key.startswith(db_prefix):
-						break
+        with self._txn(write=False) as txn:
+            cursor = txn.cursor()
+            if cursor.set_range(db_prefix):
+                for db_key in cursor.iternext(keys=True, values=False):
+                    if not db_key.startswith(db_prefix):
+                        break
 
-					count += 1
+                    count += 1
 
-		return count
+        return count
 
-	def delete_all(self, entity: Enum) -> None:
-		"""Delete all keys for a given entity type."""
+    def delete_all(self, entity: Enum) -> None:
+        """Delete all keys for a given entity type."""
 
-		self.logger.info(
-			{
-				**self.logger_context,
-				"user": frappe.session.user,
-				"event": "deleting-all-keys",
-				"entity": entity.value,
-			}
-		)
+        self.logger.info(
+            {
+                **self.logger_context,
+                "user": frappe.session.user,
+                "event": "deleting-all-keys",
+                "entity": entity.value,
+            }
+        )
 
-		db_prefix = self._db_key(entity, "")
+        db_prefix = self._db_key(entity, "")
 
-		def _delete_prefix(txn: Any) -> None:
-			# Delete in place via the cursor (O(1) memory) instead of materializing every key.
-			# cursor.delete() removes the current entry and advances to the next one.
-			cursor = txn.cursor()
-			if cursor.set_range(db_prefix):
-				while cursor.key().startswith(db_prefix):
-					if not cursor.delete():
-						break
+        def _delete_prefix(txn: Any) -> None:
+            # Delete in place via the cursor (O(1) memory) instead of materializing every key.
+            # cursor.delete() removes the current entry and advances to the next one.
+            cursor = txn.cursor()
+            if cursor.set_range(db_prefix):
+                while cursor.key().startswith(db_prefix):
+                    if not cursor.delete():
+                        break
 
-		self._write(_delete_prefix)
+        self._write(_delete_prefix)
 
-	def browse(self, limit: int | None = None) -> list[dict]:
-		"""List every entry as ``{entity, key, size}`` without deserializing values (for tooling)."""
+    def browse(self, limit: int | None = None) -> list[dict]:
+        """List every entry as ``{entity, key, size}`` without deserializing values (for tooling)."""
 
-		entries = []
-		with self._txn(write=False) as txn:
-			for db_key, value in txn.cursor():
-				entity, _, key = db_key.decode().partition(self.SEPARATOR)
-				entries.append({"entity": entity, "key": key, "size": len(value)})
+        entries = []
+        with self._txn(write=False) as txn:
+            for db_key, value in txn.cursor():
+                entity, _, key = db_key.decode().partition(self.SEPARATOR)
+                entries.append({"entity": entity, "key": key, "size": len(value)})
 
-				if limit is not None and len(entries) >= limit:
-					break
+                if limit is not None and len(entries) >= limit:
+                    break
 
-		return entries
+        return entries
 
-	def read(self, entity: str, key: str) -> dict | None:
-		"""Return ``{value, size}`` for a single entry, or None if it is absent (for tooling).
+    def read(self, entity: str, key: str) -> dict | None:
+        """Return ``{value, size}`` for a single entry, or None if it is absent (for tooling).
 
-		Unlike `get`, `entity` is a plain string, so callers (e.g. the Store Entry browser) do
-		not need the entity enum.
-		"""
+        Unlike `get`, `entity` is a plain string, so callers (e.g. the Store Entry browser) do
+        not need the entity enum.
+        """
 
-		db_key = f"{entity}{self.SEPARATOR}{key}".encode()
-		with self._txn(write=False) as txn:
-			raw = txn.get(db_key)
+        db_key = f"{entity}{self.SEPARATOR}{key}".encode()
+        with self._txn(write=False) as txn:
+            raw = txn.get(db_key)
 
-		if raw is None:
-			return None
+        if raw is None:
+            return None
 
-		return {"value": self._deserialize(raw), "size": len(raw)}
+        return {"value": self._deserialize(raw), "size": len(raw)}
 
-	def count_entries(self, entity: str | None = None) -> int:
-		"""Count entries, optionally within one entity, without materializing keys/values.
+    def count_entries(self, entity: str | None = None) -> int:
+        """Count entries, optionally within one entity, without materializing keys/values.
 
-		`entity` is a plain string (or None for every entity), so callers (e.g. the Store Entry
-		browser) don't need the entity enum. Counts over a cursor in O(1) memory.
-		"""
+        `entity` is a plain string (or None for every entity), so callers (e.g. the Store Entry
+        browser) don't need the entity enum. Counts over a cursor in O(1) memory.
+        """
 
-		prefix = f"{entity}{self.SEPARATOR}".encode() if entity is not None else b""
-		total = 0
-		with self._txn(write=False) as txn:
-			cursor = txn.cursor()
-			if cursor.set_range(prefix):
-				for db_key in cursor.iternext(keys=True, values=False):
-					if not db_key.startswith(prefix):
-						break
-					total += 1
+        prefix = f"{entity}{self.SEPARATOR}".encode() if entity is not None else b""
+        total = 0
+        with self._txn(write=False) as txn:
+            cursor = txn.cursor()
+            if cursor.set_range(prefix):
+                for db_key in cursor.iternext(keys=True, values=False):
+                    if not db_key.startswith(prefix):
+                        break
+                    total += 1
 
-		return total
+        return total

--- a/suite/store/data_store.py
+++ b/suite/store/data_store.py
@@ -16,7 +16,7 @@ class _EnvEntry:
 
     __slots__ = ("env", "refcount")
 
-    def __init__(self, env: "lmdb.Environment") -> None:
+    def __init__(self, env: lmdb.Environment) -> None:
         self.env = env
         self.refcount = 0
 
@@ -69,7 +69,7 @@ class DataStore(BaseStore):
         self.logger_context["store"] = "data"
         self.map_size = map_size or self.DEFAULT_MAP_SIZE
 
-    def _open_env(self) -> "lmdb.Environment":
+    def _open_env(self) -> lmdb.Environment:
         """Open the LMDB environment for this store's path."""
 
         self.logger.debug({**self.logger_context, "event": "opening-env", "path": self.path})
@@ -90,7 +90,7 @@ class DataStore(BaseStore):
         self._reader_check(env)
         return env
 
-    def _reader_check(self, env: "lmdb.Environment") -> None:
+    def _reader_check(self, env: lmdb.Environment) -> None:
         """Reclaim stale reader-lock-table slots (from dead processes/threads). Best-effort."""
 
         try:
@@ -189,7 +189,7 @@ class DataStore(BaseStore):
         finally:
             self._release_env()
 
-    def _begin(self, env: "lmdb.Environment", write: bool) -> Any:
+    def _begin(self, env: lmdb.Environment, write: bool) -> Any:
         """Begin a transaction, reclaiming stale reader slots and retrying once on MDB_READERS_FULL."""
 
         try:

--- a/suite/store/search_store.py
+++ b/suite/store/search_store.py
@@ -19,447 +19,447 @@ SCHEMA_VERSION_FILE = "schema.version"
 
 @dataclass(frozen=True)
 class FieldSpec:
-	"""Describes one field of a search index's schema."""
+    """Describes one field of a search index's schema."""
 
-	name: str
-	kind: Literal["text", "integer", "date", "boolean"] = "text"
-	stored: bool = False
-	fast: bool = False
-	tokenizer: str = "default"
+    name: str
+    kind: Literal["text", "integer", "date", "boolean"] = "text"
+    stored: bool = False
+    fast: bool = False
+    tokenizer: str = "default"
 
 
 class SearchStore:
-	"""A Tantivy full-text index for one entity type, scoped to a `namespace`.
-
-	Subclasses declare their schema via ENTITY and FIELDS, and may override `to_document`
-	to shape a raw source dict into the flat field/value dict this index stores. Each
-	`namespace` (a relative path, e.g. ``("mail", account)``) gets its own on-disk directory
-	under `get_search_base_path()`, so its indexes stay isolated from other namespaces.
-	"""
-
-	# Entity name; forms part of the on-disk path and lock name. Required in subclasses.
-	ENTITY: ClassVar[str] = ""
-	# Field used as the unique document identifier for upserts and deletes.
-	ID_FIELD: ClassVar[str] = "id"
-	# Schema definition; changing it bumps the schema version and triggers a rebuild.
-	FIELDS: ClassVar[tuple[FieldSpec, ...]] = ()
-	# Fields queried when a search call doesn't specify its own field list.
-	DEFAULT_SEARCH_FIELDS: ClassVar[tuple[str, ...]] = ()
-
-	# Per-writer memory budget for indexing, in bytes.
-	HEAP_SIZE: ClassVar[int] = 50 * 1024 * 1024
-
-	def __init__(self, namespace: Namespace) -> None:
-		"""Resolve this index's on-disk path from namespace/ENTITY and reconcile its schema version."""
-
-		if not self.ENTITY:
-			frappe.throw("SearchStore subclasses must define ENTITY")
-
-		self.namespace = normalize_namespace(namespace)
-		# Layout is <base>/<namespace>/<entity>, so every index for a namespace (e.g. an account)
-		# lives under one directory — easy to browse and to clear all of a namespace's indexes at once.
-		namespace_path = resolve_namespace_path(get_search_base_path(), self.namespace)
-		self.path = os.path.join(namespace_path, self.ENTITY)
-		os.makedirs(self.path, exist_ok=True)
-
-		self._schema = self._build_schema()
-		self._reconcile_schema_version()
-
-	def index_documents(self, sources: list[dict]) -> int:
-		"""Upsert the given source dicts into the index; returns the number processed.
-
-		Each source is deleted-then-added by its ID_FIELD, so re-indexing an existing
-		document replaces it. Sources without an ID are skipped.
-		"""
-
-		if not sources:
-			return 0
-
-		with write_lock(self._lockname, acquire_timeout=30, lock_timeout=300):
-			index = self._open()
-			writer = index.writer(heap_size=self.HEAP_SIZE, num_threads=1)
-
-			try:
-				for source in sources:
-					document = self._to_tantivy_document(self.to_document(source))
-					doc_id = document.get_first(self.ID_FIELD)
-					if doc_id is None:
-						continue
-
-					# Delete any existing doc with this ID first so re-indexing is an upsert.
-					writer.delete_documents(self.ID_FIELD, str(doc_id))
-					writer.add_document(document)
-
-				writer.commit()
-				writer.wait_merging_threads()
-			finally:
-				# Release the writer's lock even if commit raised.
-				del writer
-
-		return len(sources)
-
-	def delete_documents(self, ids: list[str]) -> int:
-		"""Delete documents matching the given ID_FIELD values; returns the count requested."""
-
-		if not ids:
-			return 0
-
-		with write_lock(self._lockname, acquire_timeout=30, lock_timeout=300):
-			index = self._open()
-			writer = index.writer(heap_size=self.HEAP_SIZE, num_threads=1)
-
-			try:
-				for doc_id in ids:
-					writer.delete_documents(self.ID_FIELD, str(doc_id))
-
-				writer.commit()
-				writer.wait_merging_threads()
-			finally:
-				# Release the writer's lock even if commit raised.
-				del writer
-
-		return len(ids)
-
-	def search(
-		self,
-		query: str,
-		limit: int = 20,
-		offset: int = 0,
-		fields: list[str] | None = None,
-		order_by: str | None = None,
-	) -> tuple[list[dict], int]:
-		"""Run a free-text query (parsed by Tantivy) and return `(hits, total_count)`.
-
-		`hits` is a page (`limit`/`offset`) of stored-field dicts, each annotated with
-		`_score` and `_id`; `total_count` is the full number of matches. `fields` overrides
-		DEFAULT_SEARCH_FIELDS. Returns an empty result on a blank query, a missing index, or
-		any query error (logged, never raised, so search failures don't break the caller).
-		"""
-
-		if not query or not query.strip():
-			return ([], 0)
-
-		fields = fields or list(self.DEFAULT_SEARCH_FIELDS) or None
-		return self._run_search(lambda index: index.parse_query(query, fields), limit, offset, order_by)
-
-	def search_phrase_prefix(
-		self,
-		terms: list[str],
-		limit: int = 20,
-		offset: int = 0,
-		fields: list[str] | None = None,
-		order_by: str | None = None,
-	) -> tuple[list[dict], int]:
-		"""Search for the given terms as a consecutive, in-order phrase whose last term is a prefix.
-
-		Built for as-you-type autocomplete: the terms must appear adjacent and in order in one of
-		`fields`, with the final term matched as a prefix — so "sagar s" matches "sagar.s@…" and
-		"Sagar Sharma", but not "sagar@…" (nothing follows "sagar") nor an address that merely
-		contains both words apart. A single term is a plain prefix match. Returns `(hits, count)`.
-		"""
-
-		terms = [term for term in terms if term]
-		if not terms:
-			return ([], 0)
-
-		fields = fields or list(self.DEFAULT_SEARCH_FIELDS)
-		return self._run_search(
-			lambda _index: self._build_phrase_prefix_query(terms, fields), limit, offset, order_by
-		)
-
-	def _run_search(
-		self, build_query, limit: int, offset: int, order_by: str | None
-	) -> tuple[list[dict], int]:
-		"""Open the index, build a query via `build_query(index)`, run it, and return `(hits, count)`.
-
-		Shared plumbing for `search`/`search_phrase_prefix`; swallows query errors (logged) into an
-		empty result so a malformed query never breaks the caller.
-		"""
-
-		# Nothing has been indexed yet for this key.
-		if not tantivy.Index.exists(self.path):
-			return ([], 0)
-
-		try:
-			index = self._open()
-
-			# Pick up commits made by other workers since this index was opened.
-			index.reload()
-
-			searcher = index.searcher()
-			result = searcher.search(
-				build_query(index), limit=limit, offset=offset, count=True, order_by_field=order_by
-			)
-			hits = [self._to_hit(searcher.doc(address), score) for score, address in result.hits]
-			return (hits, result.count)
-		except Exception:
-			frappe.logger("suite.store").warning(
-				{"event": "search-failed", "entity": self.ENTITY, "namespace": "/".join(self.namespace)}
-			)
-			return ([], 0)
+    """A Tantivy full-text index for one entity type, scoped to a `namespace`.
+
+    Subclasses declare their schema via ENTITY and FIELDS, and may override `to_document`
+    to shape a raw source dict into the flat field/value dict this index stores. Each
+    `namespace` (a relative path, e.g. ``("mail", account)``) gets its own on-disk directory
+    under `get_search_base_path()`, so its indexes stay isolated from other namespaces.
+    """
+
+    # Entity name; forms part of the on-disk path and lock name. Required in subclasses.
+    ENTITY: ClassVar[str] = ""
+    # Field used as the unique document identifier for upserts and deletes.
+    ID_FIELD: ClassVar[str] = "id"
+    # Schema definition; changing it bumps the schema version and triggers a rebuild.
+    FIELDS: ClassVar[tuple[FieldSpec, ...]] = ()
+    # Fields queried when a search call doesn't specify its own field list.
+    DEFAULT_SEARCH_FIELDS: ClassVar[tuple[str, ...]] = ()
+
+    # Per-writer memory budget for indexing, in bytes.
+    HEAP_SIZE: ClassVar[int] = 50 * 1024 * 1024
+
+    def __init__(self, namespace: Namespace) -> None:
+        """Resolve this index's on-disk path from namespace/ENTITY and reconcile its schema version."""
+
+        if not self.ENTITY:
+            frappe.throw("SearchStore subclasses must define ENTITY")
+
+        self.namespace = normalize_namespace(namespace)
+        # Layout is <base>/<namespace>/<entity>, so every index for a namespace (e.g. an account)
+        # lives under one directory — easy to browse and to clear all of a namespace's indexes at once.
+        namespace_path = resolve_namespace_path(get_search_base_path(), self.namespace)
+        self.path = os.path.join(namespace_path, self.ENTITY)
+        os.makedirs(self.path, exist_ok=True)
+
+        self._schema = self._build_schema()
+        self._reconcile_schema_version()
+
+    def index_documents(self, sources: list[dict]) -> int:
+        """Upsert the given source dicts into the index; returns the number processed.
+
+        Each source is deleted-then-added by its ID_FIELD, so re-indexing an existing
+        document replaces it. Sources without an ID are skipped.
+        """
+
+        if not sources:
+            return 0
+
+        with write_lock(self._lockname, acquire_timeout=30, lock_timeout=300):
+            index = self._open()
+            writer = index.writer(heap_size=self.HEAP_SIZE, num_threads=1)
+
+            try:
+                for source in sources:
+                    document = self._to_tantivy_document(self.to_document(source))
+                    doc_id = document.get_first(self.ID_FIELD)
+                    if doc_id is None:
+                        continue
+
+                    # Delete any existing doc with this ID first so re-indexing is an upsert.
+                    writer.delete_documents(self.ID_FIELD, str(doc_id))
+                    writer.add_document(document)
+
+                writer.commit()
+                writer.wait_merging_threads()
+            finally:
+                # Release the writer's lock even if commit raised.
+                del writer
+
+        return len(sources)
+
+    def delete_documents(self, ids: list[str]) -> int:
+        """Delete documents matching the given ID_FIELD values; returns the count requested."""
+
+        if not ids:
+            return 0
+
+        with write_lock(self._lockname, acquire_timeout=30, lock_timeout=300):
+            index = self._open()
+            writer = index.writer(heap_size=self.HEAP_SIZE, num_threads=1)
+
+            try:
+                for doc_id in ids:
+                    writer.delete_documents(self.ID_FIELD, str(doc_id))
+
+                writer.commit()
+                writer.wait_merging_threads()
+            finally:
+                # Release the writer's lock even if commit raised.
+                del writer
+
+        return len(ids)
+
+    def search(
+        self,
+        query: str,
+        limit: int = 20,
+        offset: int = 0,
+        fields: list[str] | None = None,
+        order_by: str | None = None,
+    ) -> tuple[list[dict], int]:
+        """Run a free-text query (parsed by Tantivy) and return `(hits, total_count)`.
+
+        `hits` is a page (`limit`/`offset`) of stored-field dicts, each annotated with
+        `_score` and `_id`; `total_count` is the full number of matches. `fields` overrides
+        DEFAULT_SEARCH_FIELDS. Returns an empty result on a blank query, a missing index, or
+        any query error (logged, never raised, so search failures don't break the caller).
+        """
+
+        if not query or not query.strip():
+            return ([], 0)
+
+        fields = fields or list(self.DEFAULT_SEARCH_FIELDS) or None
+        return self._run_search(lambda index: index.parse_query(query, fields), limit, offset, order_by)
+
+    def search_phrase_prefix(
+        self,
+        terms: list[str],
+        limit: int = 20,
+        offset: int = 0,
+        fields: list[str] | None = None,
+        order_by: str | None = None,
+    ) -> tuple[list[dict], int]:
+        """Search for the given terms as a consecutive, in-order phrase whose last term is a prefix.
+
+        Built for as-you-type autocomplete: the terms must appear adjacent and in order in one of
+        `fields`, with the final term matched as a prefix — so "sagar s" matches "sagar.s@…" and
+        "Sagar Sharma", but not "sagar@…" (nothing follows "sagar") nor an address that merely
+        contains both words apart. A single term is a plain prefix match. Returns `(hits, count)`.
+        """
+
+        terms = [term for term in terms if term]
+        if not terms:
+            return ([], 0)
+
+        fields = fields or list(self.DEFAULT_SEARCH_FIELDS)
+        return self._run_search(
+            lambda _index: self._build_phrase_prefix_query(terms, fields), limit, offset, order_by
+        )
+
+    def _run_search(
+        self, build_query, limit: int, offset: int, order_by: str | None
+    ) -> tuple[list[dict], int]:
+        """Open the index, build a query via `build_query(index)`, run it, and return `(hits, count)`.
+
+        Shared plumbing for `search`/`search_phrase_prefix`; swallows query errors (logged) into an
+        empty result so a malformed query never breaks the caller.
+        """
+
+        # Nothing has been indexed yet for this key.
+        if not tantivy.Index.exists(self.path):
+            return ([], 0)
+
+        try:
+            index = self._open()
+
+            # Pick up commits made by other workers since this index was opened.
+            index.reload()
+
+            searcher = index.searcher()
+            result = searcher.search(
+                build_query(index), limit=limit, offset=offset, count=True, order_by_field=order_by
+            )
+            hits = [self._to_hit(searcher.doc(address), score) for score, address in result.hits]
+            return (hits, result.count)
+        except Exception:
+            frappe.logger("suite.store").warning(
+                {"event": "search-failed", "entity": self.ENTITY, "namespace": "/".join(self.namespace)}
+            )
+            return ([], 0)
 
-	def _build_phrase_prefix_query(self, terms: list[str], fields: list[str]) -> "tantivy.Query":
-		"""Build a phrase-prefix query over `terms`, matching in any one of `fields`."""
-
-		if len(fields) == 1:
-			return tantivy.Query.phrase_prefix_query(self._schema, fields[0], terms)
-
-		# Match the phrase in any of the fields.
-		clauses = [
-			(tantivy.Occur.Should, tantivy.Query.phrase_prefix_query(self._schema, field, terms))
-			for field in fields
-		]
-		return tantivy.Query.boolean_query(clauses)
-
-	def drop(self) -> None:
-		"""Delete this index's entire on-disk directory."""
+    def _build_phrase_prefix_query(self, terms: list[str], fields: list[str]) -> "tantivy.Query":
+        """Build a phrase-prefix query over `terms`, matching in any one of `fields`."""
+
+        if len(fields) == 1:
+            return tantivy.Query.phrase_prefix_query(self._schema, fields[0], terms)
+
+        # Match the phrase in any of the fields.
+        clauses = [
+            (tantivy.Occur.Should, tantivy.Query.phrase_prefix_query(self._schema, field, terms))
+            for field in fields
+        ]
+        return tantivy.Query.boolean_query(clauses)
+
+    def drop(self) -> None:
+        """Delete this index's entire on-disk directory."""
 
-		with write_lock(self._lockname, acquire_timeout=30, lock_timeout=300):
-			if os.path.exists(self.path):
-				shutil.rmtree(self.path)
+        with write_lock(self._lockname, acquire_timeout=30, lock_timeout=300):
+            if os.path.exists(self.path):
+                shutil.rmtree(self.path)
 
-	def to_document(self, source: dict) -> dict:
-		"""Map a raw source dict to a flat field/value dict. Override to reshape sources."""
+    def to_document(self, source: dict) -> dict:
+        """Map a raw source dict to a flat field/value dict. Override to reshape sources."""
 
-		return source
-
-	@property
-	def _lockname(self) -> str:
-		"""Lock name scoping writes to this entity/namespace, so concurrent workers serialize."""
-
-		namespace = "/".join(quote(segment, safe="") for segment in self.namespace)
-		return f"search-index:{self.ENTITY}:{namespace}"
-
-	@property
-	def _stored_fields(self) -> list[str]:
-		"""Names of fields marked `stored`, i.e. the ones returned in search hits."""
-
-		return [field.name for field in self.FIELDS if field.stored]
-
-	@staticmethod
-	def _read_version(version_file: str) -> str | None:
-		"""Read the schema version written on disk, or None if it hasn't been written yet."""
-
-		try:
-			with open(version_file) as f:
-				return f.read().strip()
-		except FileNotFoundError:
-			return None
-
-	@staticmethod
-	def _write_version(version_file: str, version: str) -> None:
-		"""Persist the current schema version alongside the index."""
-
-		with open(version_file, "w") as f:
-			f.write(version)
-
-	def _build_schema(self) -> "tantivy.Schema":
-		"""Build the Tantivy schema from FIELDS, mapping each FieldSpec kind to a field type."""
-
-		builder = tantivy.SchemaBuilder()
-
-		for field in self.FIELDS:
-			if field.kind == "text":
-				builder.add_text_field(
-					field.name, stored=field.stored, fast=field.fast, tokenizer_name=field.tokenizer
-				)
-
-			elif field.kind == "integer":
-				builder.add_integer_field(field.name, stored=field.stored, indexed=True, fast=field.fast)
-
-			elif field.kind == "date":
-				builder.add_date_field(field.name, stored=field.stored, indexed=True, fast=field.fast)
-
-			elif field.kind == "boolean":
-				builder.add_boolean_field(field.name, stored=field.stored, indexed=True, fast=field.fast)
-
-			else:
-				frappe.throw(_("Unknown field kind: {0}").format(field.kind))
-
-		return builder.build()
-
-	def _reconcile_schema_version(self) -> None:
-		"""Rebuild the index from scratch if its stored schema version no longer matches.
-
-		A first-time index just records the current version. A version mismatch means FIELDS
-		changed, so the stale index directory is wiped and recreated (re-indexing happens
-		lazily on the next write).
-		"""
-
-		version_file = os.path.join(self.path, SCHEMA_VERSION_FILE)
-		current = self._schema_version()
-		existing = self._read_version(version_file)
-
-		if existing == current:
-			return
-
-		if existing is None:
-			self._write_version(version_file, current)
-			return
-
-		with write_lock(self._lockname, acquire_timeout=30, lock_timeout=300):
-			# Re-check inside the lock: another worker may have rebuilt it already.
-			if self._read_version(version_file) == current:
-				return
-
-			shutil.rmtree(self.path, ignore_errors=True)
-			os.makedirs(self.path, exist_ok=True)
-			self._write_version(version_file, current)
-
-	def _open(self) -> "tantivy.Index":
-		"""Open (or reuse) the on-disk index for this key."""
-
-		return tantivy.Index(self._schema, path=self.path, reuse=True)
-
-	def _to_tantivy_document(self, flat: dict) -> "tantivy.Document":
-		"""Convert a flat field/value dict into a Tantivy document, skipping None values."""
-
-		document = tantivy.Document()
-		for field in self.FIELDS:
-			value = flat.get(field.name)
-			if value is None:
-				continue
-
-			if field.kind == "text":
-				document.add_text(field.name, str(value))
-			elif field.kind == "integer":
-				document.add_integer(field.name, int(value))
-			elif field.kind == "date":
-				document.add_date(field.name, value)
-			elif field.kind == "boolean":
-				document.add_boolean(field.name, bool(value))
-
-		return document
-
-	def _to_hit(self, document: "tantivy.Document", score: float) -> dict:
-		"""Build a search hit dict from a stored document, adding `_score` and `_id`."""
-
-		hit = {name: document.get_first(name) for name in self._stored_fields}
-		hit["_score"] = score
-		hit["_id"] = hit.get(self.ID_FIELD)
-		return hit
-
-	def _schema_version(self) -> str:
-		"""Short hash of the schema; changes whenever ID_FIELD or any FieldSpec changes."""
-
-		spec = repr([(f.name, f.kind, f.stored, f.fast, f.tokenizer) for f in self.FIELDS])
-		return hashlib.sha1(f"{self.ID_FIELD}|{spec}".encode()).hexdigest()[:16]
+        return source
+
+    @property
+    def _lockname(self) -> str:
+        """Lock name scoping writes to this entity/namespace, so concurrent workers serialize."""
+
+        namespace = "/".join(quote(segment, safe="") for segment in self.namespace)
+        return f"search-index:{self.ENTITY}:{namespace}"
+
+    @property
+    def _stored_fields(self) -> list[str]:
+        """Names of fields marked `stored`, i.e. the ones returned in search hits."""
+
+        return [field.name for field in self.FIELDS if field.stored]
+
+    @staticmethod
+    def _read_version(version_file: str) -> str | None:
+        """Read the schema version written on disk, or None if it hasn't been written yet."""
+
+        try:
+            with open(version_file) as f:
+                return f.read().strip()
+        except FileNotFoundError:
+            return None
+
+    @staticmethod
+    def _write_version(version_file: str, version: str) -> None:
+        """Persist the current schema version alongside the index."""
+
+        with open(version_file, "w") as f:
+            f.write(version)
+
+    def _build_schema(self) -> "tantivy.Schema":
+        """Build the Tantivy schema from FIELDS, mapping each FieldSpec kind to a field type."""
+
+        builder = tantivy.SchemaBuilder()
+
+        for field in self.FIELDS:
+            if field.kind == "text":
+                builder.add_text_field(
+                    field.name, stored=field.stored, fast=field.fast, tokenizer_name=field.tokenizer
+                )
+
+            elif field.kind == "integer":
+                builder.add_integer_field(field.name, stored=field.stored, indexed=True, fast=field.fast)
+
+            elif field.kind == "date":
+                builder.add_date_field(field.name, stored=field.stored, indexed=True, fast=field.fast)
+
+            elif field.kind == "boolean":
+                builder.add_boolean_field(field.name, stored=field.stored, indexed=True, fast=field.fast)
+
+            else:
+                frappe.throw(_("Unknown field kind: {0}").format(field.kind))
+
+        return builder.build()
+
+    def _reconcile_schema_version(self) -> None:
+        """Rebuild the index from scratch if its stored schema version no longer matches.
+
+        A first-time index just records the current version. A version mismatch means FIELDS
+        changed, so the stale index directory is wiped and recreated (re-indexing happens
+        lazily on the next write).
+        """
+
+        version_file = os.path.join(self.path, SCHEMA_VERSION_FILE)
+        current = self._schema_version()
+        existing = self._read_version(version_file)
+
+        if existing == current:
+            return
+
+        if existing is None:
+            self._write_version(version_file, current)
+            return
+
+        with write_lock(self._lockname, acquire_timeout=30, lock_timeout=300):
+            # Re-check inside the lock: another worker may have rebuilt it already.
+            if self._read_version(version_file) == current:
+                return
+
+            shutil.rmtree(self.path, ignore_errors=True)
+            os.makedirs(self.path, exist_ok=True)
+            self._write_version(version_file, current)
+
+    def _open(self) -> "tantivy.Index":
+        """Open (or reuse) the on-disk index for this key."""
+
+        return tantivy.Index(self._schema, path=self.path, reuse=True)
+
+    def _to_tantivy_document(self, flat: dict) -> "tantivy.Document":
+        """Convert a flat field/value dict into a Tantivy document, skipping None values."""
+
+        document = tantivy.Document()
+        for field in self.FIELDS:
+            value = flat.get(field.name)
+            if value is None:
+                continue
+
+            if field.kind == "text":
+                document.add_text(field.name, str(value))
+            elif field.kind == "integer":
+                document.add_integer(field.name, int(value))
+            elif field.kind == "date":
+                document.add_date(field.name, value)
+            elif field.kind == "boolean":
+                document.add_boolean(field.name, bool(value))
+
+        return document
+
+    def _to_hit(self, document: "tantivy.Document", score: float) -> dict:
+        """Build a search hit dict from a stored document, adding `_score` and `_id`."""
+
+        hit = {name: document.get_first(name) for name in self._stored_fields}
+        hit["_score"] = score
+        hit["_id"] = hit.get(self.ID_FIELD)
+        return hit
+
+    def _schema_version(self) -> str:
+        """Short hash of the schema; changes whenever ID_FIELD or any FieldSpec changes."""
+
+        spec = repr([(f.name, f.kind, f.stored, f.fast, f.tokenizer) for f in self.FIELDS])
+        return hashlib.sha1(f"{self.ID_FIELD}|{spec}".encode()).hexdigest()[:16]
 
 
 def list_index_entities(namespace: Namespace) -> list[str]:
-	"""Return the entity names of the Tantivy indexes directly under `namespace`'s directory.
+    """Return the entity names of the Tantivy indexes directly under `namespace`'s directory.
 
-	Each `SearchStore` writes its index to ``<base>/<namespace>/<entity>``, so a namespace's
-	directory holds one sub-directory per indexed entity. Used by tooling (the Store Entry
-	browser) to discover a namespace's indexes without knowing their subclasses.
-	"""
+    Each `SearchStore` writes its index to ``<base>/<namespace>/<entity>``, so a namespace's
+    directory holds one sub-directory per indexed entity. Used by tooling (the Store Entry
+    browser) to discover a namespace's indexes without knowing their subclasses.
+    """
 
-	namespace_path = resolve_namespace_path(get_search_base_path(), namespace)
-	if not os.path.isdir(namespace_path):
-		return []
+    namespace_path = resolve_namespace_path(get_search_base_path(), namespace)
+    if not os.path.isdir(namespace_path):
+        return []
 
-	entities = [
-		entry.name
-		for entry in os.scandir(namespace_path)
-		if entry.is_dir(follow_symlinks=False) and tantivy.Index.exists(entry.path)
-	]
-	return sorted(entities)
+    entities = [
+        entry.name
+        for entry in os.scandir(namespace_path)
+        if entry.is_dir(follow_symlinks=False) and tantivy.Index.exists(entry.path)
+    ]
+    return sorted(entities)
 
 
 class SearchIndexBrowser:
-	"""Read-only, schema-agnostic view of one on-disk Tantivy index, for tooling.
+    """Read-only, schema-agnostic view of one on-disk Tantivy index, for tooling.
 
-	Unlike `SearchStore`, this does not know the index's subclass schema (ENTITY/FIELDS); it
-	opens the index with the schema persisted on disk, so any index can be browsed or read
-	generically by the Store Entry browser. Stored fields are the only ones a document exposes.
-	"""
+    Unlike `SearchStore`, this does not know the index's subclass schema (ENTITY/FIELDS); it
+    opens the index with the schema persisted on disk, so any index can be browsed or read
+    generically by the Store Entry browser. Stored fields are the only ones a document exposes.
+    """
 
-	# Field preferred as the human-facing document key when a document stores it.
-	KEY_FIELD: ClassVar[str] = "id"
+    # Field preferred as the human-facing document key when a document stores it.
+    KEY_FIELD: ClassVar[str] = "id"
 
-	def __init__(self, namespace: Namespace, entity: str) -> None:
-		# Unlike SearchStore, which joins its own ENTITY constant, the entity here comes from a
-		# Store Entry record name and can be anything. resolve_namespace_path already keeps the
-		# namespace inside the base path; the entity has to be held to one component too, or a
-		# value like "../../.." would walk out of the site's own index directory.
-		if not entity or entity in (".", "..") or "/" in entity or os.sep in entity:
-			raise ValueError(f"invalid index entity: {entity!r}")
+    def __init__(self, namespace: Namespace, entity: str) -> None:
+        # Unlike SearchStore, which joins its own ENTITY constant, the entity here comes from a
+        # Store Entry record name and can be anything. resolve_namespace_path already keeps the
+        # namespace inside the base path; the entity has to be held to one component too, or a
+        # value like "../../.." would walk out of the site's own index directory.
+        if not entity or entity in (".", "..") or "/" in entity or os.sep in entity:
+            raise ValueError(f"invalid index entity: {entity!r}")
 
-		namespace_path = resolve_namespace_path(get_search_base_path(), namespace)
-		self.path = os.path.join(namespace_path, entity)
+        namespace_path = resolve_namespace_path(get_search_base_path(), namespace)
+        self.path = os.path.join(namespace_path, entity)
 
-	def count(self) -> int:
-		"""Return the number of documents in the index (0 when it has not been created yet)."""
+    def count(self) -> int:
+        """Return the number of documents in the index (0 when it has not been created yet)."""
 
-		searcher = self._searcher()
-		return searcher.num_docs if searcher else 0
+        searcher = self._searcher()
+        return searcher.num_docs if searcher else 0
 
-	def browse(self, limit: int | None = None) -> list[dict]:
-		"""List documents as ``{key, size}`` (stored fields only), for the Store Entry browser."""
+    def browse(self, limit: int | None = None) -> list[dict]:
+        """List documents as ``{key, size}`` (stored fields only), for the Store Entry browser."""
 
-		return [
-			{"key": self._key(fields), "size": _document_size(fields)}
-			for fields in self._documents(limit=limit)
-		]
+        return [
+            {"key": self._key(fields), "size": _document_size(fields)}
+            for fields in self._documents(limit=limit)
+        ]
 
-	def read(self, key: str) -> dict | None:
-		"""Return ``{value, size}`` for the document whose key is `key`, or None if it is absent.
+    def read(self, key: str) -> dict | None:
+        """Return ``{value, size}`` for the document whose key is `key`, or None if it is absent.
 
-		`value` is the document's stored fields, flattened to scalars where a field holds a single
-		value. Scans the index because the key is a stored value, not necessarily an indexed term.
-		"""
+        `value` is the document's stored fields, flattened to scalars where a field holds a single
+        value. Scans the index because the key is a stored value, not necessarily an indexed term.
+        """
 
-		for fields in self._documents():
-			if self._key(fields) == key:
-				return {"value": _flatten(fields), "size": _document_size(fields)}
+        for fields in self._documents():
+            if self._key(fields) == key:
+                return {"value": _flatten(fields), "size": _document_size(fields)}
 
-		return None
+        return None
 
-	def _searcher(self) -> "tantivy.Searcher | None":
-		"""Open the on-disk index with its persisted schema and return a fresh searcher, or None."""
+    def _searcher(self) -> "tantivy.Searcher | None":
+        """Open the on-disk index with its persisted schema and return a fresh searcher, or None."""
 
-		if not tantivy.Index.exists(self.path):
-			return None
+        if not tantivy.Index.exists(self.path):
+            return None
 
-		index = tantivy.Index.open(self.path)
-		# Pick up commits made since the index files were opened.
-		index.reload()
-		return index.searcher()
+        index = tantivy.Index.open(self.path)
+        # Pick up commits made since the index files were opened.
+        index.reload()
+        return index.searcher()
 
-	def _documents(self, limit: int | None = None):
-		"""Yield each document's stored fields (a ``{name: [values]}`` dict) via a match-all query."""
+    def _documents(self, limit: int | None = None):
+        """Yield each document's stored fields (a ``{name: [values]}`` dict) via a match-all query."""
 
-		searcher = self._searcher()
-		if not searcher:
-			return
+        searcher = self._searcher()
+        if not searcher:
+            return
 
-		total = searcher.num_docs
-		if not total:
-			return
+        total = searcher.num_docs
+        if not total:
+            return
 
-		# Tantivy needs a positive limit; cap it at the document count so a single page covers all.
-		page = total if limit is None else min(limit, total)
-		result = searcher.search(tantivy.Query.all_query(), limit=page)
-		for _score, address in result.hits:
-			yield searcher.doc(address).to_dict()
+        # Tantivy needs a positive limit; cap it at the document count so a single page covers all.
+        page = total if limit is None else min(limit, total)
+        result = searcher.search(tantivy.Query.all_query(), limit=page)
+        for _score, address in result.hits:
+            yield searcher.doc(address).to_dict()
 
-	def _key(self, fields: dict) -> str:
-		"""Pick a document's key: the `KEY_FIELD` value when present, else the first stored field."""
+    def _key(self, fields: dict) -> str:
+        """Pick a document's key: the `KEY_FIELD` value when present, else the first stored field."""
 
-		values = fields.get(self.KEY_FIELD)
-		if values is None and fields:
-			values = next(iter(fields.values()))
+        values = fields.get(self.KEY_FIELD)
+        if values is None and fields:
+            values = next(iter(fields.values()))
 
-		return str(values[0]) if values else ""
+        return str(values[0]) if values else ""
 
 
 def _flatten(fields: dict) -> dict:
-	"""Collapse Tantivy's ``{name: [values]}`` into scalars where a field holds a single value."""
+    """Collapse Tantivy's ``{name: [values]}`` into scalars where a field holds a single value."""
 
-	return {name: (values[0] if len(values) == 1 else values) for name, values in fields.items()}
+    return {name: (values[0] if len(values) == 1 else values) for name, values in fields.items()}
 
 
 def _document_size(fields: dict) -> int:
-	"""Approximate a stored document's size as the byte length of its normalized JSON."""
+    """Approximate a stored document's size as the byte length of its normalized JSON."""
 
-	return len(json.dumps(_flatten(fields), ensure_ascii=False, default=str).encode())
+    return len(json.dumps(_flatten(fields), ensure_ascii=False, default=str).encode())

--- a/suite/store/search_store.py
+++ b/suite/store/search_store.py
@@ -198,7 +198,7 @@ class SearchStore:
             )
             return ([], 0)
 
-    def _build_phrase_prefix_query(self, terms: list[str], fields: list[str]) -> "tantivy.Query":
+    def _build_phrase_prefix_query(self, terms: list[str], fields: list[str]) -> tantivy.Query:
         """Build a phrase-prefix query over `terms`, matching in any one of `fields`."""
 
         if len(fields) == 1:
@@ -253,7 +253,7 @@ class SearchStore:
         with open(version_file, "w") as f:
             f.write(version)
 
-    def _build_schema(self) -> "tantivy.Schema":
+    def _build_schema(self) -> tantivy.Schema:
         """Build the Tantivy schema from FIELDS, mapping each FieldSpec kind to a field type."""
 
         builder = tantivy.SchemaBuilder()
@@ -306,12 +306,12 @@ class SearchStore:
             os.makedirs(self.path, exist_ok=True)
             self._write_version(version_file, current)
 
-    def _open(self) -> "tantivy.Index":
+    def _open(self) -> tantivy.Index:
         """Open (or reuse) the on-disk index for this key."""
 
         return tantivy.Index(self._schema, path=self.path, reuse=True)
 
-    def _to_tantivy_document(self, flat: dict) -> "tantivy.Document":
+    def _to_tantivy_document(self, flat: dict) -> tantivy.Document:
         """Convert a flat field/value dict into a Tantivy document, skipping None values."""
 
         document = tantivy.Document()
@@ -331,7 +331,7 @@ class SearchStore:
 
         return document
 
-    def _to_hit(self, document: "tantivy.Document", score: float) -> dict:
+    def _to_hit(self, document: tantivy.Document, score: float) -> dict:
         """Build a search hit dict from a stored document, adding `_score` and `_id`."""
 
         hit = {name: document.get_first(name) for name in self._stored_fields}
@@ -415,7 +415,7 @@ class SearchIndexBrowser:
 
         return None
 
-    def _searcher(self) -> "tantivy.Searcher | None":
+    def _searcher(self) -> tantivy.Searcher | None:
         """Open the on-disk index with its persisted schema and return a fresh searcher, or None."""
 
         if not tantivy.Index.exists(self.path):

--- a/suite/suite_core/boot.py
+++ b/suite/suite_core/boot.py
@@ -16,47 +16,47 @@ import frappe
 
 
 def _run(label, func, *args, **kwargs):
-	"""Invoke a single handler, isolating failures so siblings still run."""
-	try:
-		return func(*args, **kwargs)
-	except Exception:
-		frappe.log_error(title=f"suite.suite_core.boot: {label} failed")
-		raise
+    """Invoke a single handler, isolating failures so siblings still run."""
+    try:
+        return func(*args, **kwargs)
+    except Exception:
+        frappe.log_error(title=f"suite.suite_core.boot: {label} failed")
+        raise
 
 
 def after_install():
-	"""Run every former app's after_install handler, in order.
+    """Run every former app's after_install handler, in order.
 
-	Drive overrides the core File class app-wide and adds custom fields (team,
-	status, content_doctype, ...) to File. Those ship as fixtures that sync only
-	AFTER after_install, yet Mail's after_install creates File folders that run
-	through Drive's overridden hooks. So create Drive's File columns FIRST, before
-	any app's after_install runs.
-	"""
-	from suite.drive.install import ensure_custom_fields, after_install as drive_after_install
-	from suite.mail.install import after_install as mail_after_install
+    Drive overrides the core File class app-wide and adds custom fields (team,
+    status, content_doctype, ...) to File. Those ship as fixtures that sync only
+    AFTER after_install, yet Mail's after_install creates File folders that run
+    through Drive's overridden hooks. So create Drive's File columns FIRST, before
+    any app's after_install runs.
+    """
+    from suite.drive.install import ensure_custom_fields, after_install as drive_after_install
+    from suite.mail.install import after_install as mail_after_install
 
-	_run("drive.ensure_custom_fields", ensure_custom_fields)
-	_run("drive.after_install", drive_after_install)
-	_run("mail.after_install", mail_after_install)
+    _run("drive.ensure_custom_fields", ensure_custom_fields)
+    _run("drive.after_install", drive_after_install)
+    _run("mail.after_install", mail_after_install)
 
 
 def after_migrate():
-	"""Run every former app's after_migrate handler, in order."""
-	from suite.mail.install import after_migrate as mail_after_migrate
+    """Run every former app's after_migrate handler, in order."""
+    from suite.mail.install import after_migrate as mail_after_migrate
 
-	_run("mail.after_migrate", mail_after_migrate)
+    _run("mail.after_migrate", mail_after_migrate)
 
 
 def after_app_install(app_name=None):
-	"""Run every former app's after_app_install handler, in order."""
-	from suite.meet.utils import after_app_install as meet_after_app_install
+    """Run every former app's after_app_install handler, in order."""
+    from suite.meet.utils import after_app_install as meet_after_app_install
 
-	_run("meet.after_app_install", meet_after_app_install, app_name)
+    _run("meet.after_app_install", meet_after_app_install, app_name)
 
 
 def extend_bootinfo(bootinfo):
-	"""Run every former app's extend_bootinfo handler, in order."""
-	from suite.sheets.boot import extend_bootinfo as sheets_extend_bootinfo
+    """Run every former app's extend_bootinfo handler, in order."""
+    from suite.sheets.boot import extend_bootinfo as sheets_extend_bootinfo
 
-	_run("sheets.extend_bootinfo", sheets_extend_bootinfo, bootinfo)
+    _run("sheets.extend_bootinfo", sheets_extend_bootinfo, bootinfo)

--- a/suite/suite_core/boot.py
+++ b/suite/suite_core/boot.py
@@ -33,7 +33,8 @@ def after_install():
     through Drive's overridden hooks. So create Drive's File columns FIRST, before
     any app's after_install runs.
     """
-    from suite.drive.install import ensure_custom_fields, after_install as drive_after_install
+    from suite.drive.install import after_install as drive_after_install
+    from suite.drive.install import ensure_custom_fields
     from suite.mail.install import after_install as mail_after_install
 
     _run("drive.ensure_custom_fields", ensure_custom_fields)

--- a/suite/suite_core/doctype/rate_limit/rate_limit.py
+++ b/suite/suite_core/doctype/rate_limit/rate_limit.py
@@ -89,7 +89,7 @@ def create_rate_limit(
     ip_based: bool = True,
     methods: str = "ALL",
     ignore_in_developer_mode: bool = True,
-) -> "RateLimit":
+) -> RateLimit:
     """Create a Rate Limit document"""
 
     doc = frappe.new_doc("Rate Limit")

--- a/suite/suite_core/doctype/rate_limit/rate_limit.py
+++ b/suite/suite_core/doctype/rate_limit/rate_limit.py
@@ -8,146 +8,146 @@ from frappe.utils import cint
 
 
 class RateLimit(Document):
-	def validate(self) -> None:
-		self.validate_method_path()
-		self.validate_key_or_ip_based()
-		self.validate_value()
-		self.validate_methods()
-		self.validate_allowed_and_blocked_ips()
+    def validate(self) -> None:
+        self.validate_method_path()
+        self.validate_key_or_ip_based()
+        self.validate_value()
+        self.validate_methods()
+        self.validate_allowed_and_blocked_ips()
 
-	def on_update(self) -> None:
-		self.clear_cache()
+    def on_update(self) -> None:
+        self.clear_cache()
 
-	def on_trash(self) -> None:
-		self.clear_cache()
+    def on_trash(self) -> None:
+        self.clear_cache()
 
-	def validate_method_path(self) -> None:
-		"""Validate the method has the dynamic rate limit decorator"""
+    def validate_method_path(self) -> None:
+        """Validate the method has the dynamic rate limit decorator"""
 
-		fn = frappe.get_attr(self.method_path)
-		if not getattr(fn, "_is_dynamic_rate_limited", False):
-			frappe.throw(
-				_(
-					"The method {method} is missing the required {decorator} decorator. "
-					"Please add it to enforce dynamic rate limiting."
-				).format(
-					decorator="<code>@dynamic_rate_limit</code>", method=f"<code>{self.method_path}</code>"
-				)
-			)
+        fn = frappe.get_attr(self.method_path)
+        if not getattr(fn, "_is_dynamic_rate_limited", False):
+            frappe.throw(
+                _(
+                    "The method {method} is missing the required {decorator} decorator. "
+                    "Please add it to enforce dynamic rate limiting."
+                ).format(
+                    decorator="<code>@dynamic_rate_limit</code>", method=f"<code>{self.method_path}</code>"
+                )
+            )
 
-	def validate_key_or_ip_based(self) -> None:
-		"""Validate key_ or IP based"""
+    def validate_key_or_ip_based(self) -> None:
+        """Validate key_ or IP based"""
 
-		if not self.key_ and not self.ip_based:
-			frappe.throw(_("Either key or IP flag is required."))
+        if not self.key_ and not self.ip_based:
+            frappe.throw(_("Either key or IP flag is required."))
 
-	def validate_value(self) -> None:
-		"""Validate that a value-scoped limit also defines a key to read it from"""
+    def validate_value(self) -> None:
+        """Validate that a value-scoped limit also defines a key to read it from"""
 
-		if self.value and not self.key_:
-			frappe.throw(
-				_("{0} is required when {1} is set.").format(frappe.bold(_("Key")), frappe.bold(_("Value")))
-			)
+        if self.value and not self.key_:
+            frappe.throw(
+                _("{0} is required when {1} is set.").format(frappe.bold(_("Key")), frappe.bold(_("Value")))
+            )
 
-	def validate_methods(self) -> None:
-		"""Validate methods"""
+    def validate_methods(self) -> None:
+        """Validate methods"""
 
-		methods = []
-		if self.methods:
-			for method in self.methods.split("\n"):
-				if method and method not in methods:
-					methods.append(method)
-		self.methods = "\n".join(methods)
+        methods = []
+        if self.methods:
+            for method in self.methods.split("\n"):
+                if method and method not in methods:
+                    methods.append(method)
+        self.methods = "\n".join(methods)
 
-	def validate_allowed_and_blocked_ips(self) -> None:
-		"""Validate allowed and blocked IPs"""
+    def validate_allowed_and_blocked_ips(self) -> None:
+        """Validate allowed and blocked IPs"""
 
-		allowed_and_blocked_ips = []
-		for ip_type in ["allowed_ips", "blocked_ips"]:
-			ips = []
-			if getattr(self, ip_type):
-				for ip in getattr(self, ip_type).split("\n"):
-					if ip and ip not in ips:
-						if ip in allowed_and_blocked_ips:
-							frappe.throw(_("{0} cannot be both allowed and blocked.").format(frappe.bold(ip)))
-						ips.append(ip)
-						allowed_and_blocked_ips.append(ip)
-			setattr(self, ip_type, "\n".join(ips))
+        allowed_and_blocked_ips = []
+        for ip_type in ["allowed_ips", "blocked_ips"]:
+            ips = []
+            if getattr(self, ip_type):
+                for ip in getattr(self, ip_type).split("\n"):
+                    if ip and ip not in ips:
+                        if ip in allowed_and_blocked_ips:
+                            frappe.throw(_("{0} cannot be both allowed and blocked.").format(frappe.bold(ip)))
+                        ips.append(ip)
+                        allowed_and_blocked_ips.append(ip)
+            setattr(self, ip_type, "\n".join(ips))
 
-	def clear_cache(self) -> None:
-		"""Clear cache for the rate limit"""
+    def clear_cache(self) -> None:
+        """Clear cache for the rate limit"""
 
-		frappe.cache.hdel("rate_limits", self.method_path)
+        frappe.cache.hdel("rate_limits", self.method_path)
 
 
 def create_rate_limit(
-	method_path: str,
-	limit: int = 5,
-	seconds: int = 86_400,
-	key: str | None = None,
-	value: str | None = None,
-	ip_based: bool = True,
-	methods: str = "ALL",
-	ignore_in_developer_mode: bool = True,
+    method_path: str,
+    limit: int = 5,
+    seconds: int = 86_400,
+    key: str | None = None,
+    value: str | None = None,
+    ip_based: bool = True,
+    methods: str = "ALL",
+    ignore_in_developer_mode: bool = True,
 ) -> "RateLimit":
-	"""Create a Rate Limit document"""
+    """Create a Rate Limit document"""
 
-	doc = frappe.new_doc("Rate Limit")
-	doc.enabled = 1
-	doc.ignore_in_developer_mode = cint(ignore_in_developer_mode)
-	doc.method_path = method_path
-	doc.methods = methods
-	doc.key_ = key
-	doc.value = value
-	doc.limit = limit
-	doc.seconds = seconds
-	doc.ip_based = cint(ip_based)
-	doc.insert(ignore_permissions=True)
+    doc = frappe.new_doc("Rate Limit")
+    doc.enabled = 1
+    doc.ignore_in_developer_mode = cint(ignore_in_developer_mode)
+    doc.method_path = method_path
+    doc.methods = methods
+    doc.key_ = key
+    doc.value = value
+    doc.limit = limit
+    doc.seconds = seconds
+    doc.ip_based = cint(ip_based)
+    doc.insert(ignore_permissions=True)
 
 
 def get_rate_limits(method_path: str) -> list:
-	"""Returns the rate limits for the method path."""
+    """Returns the rate limits for the method path."""
 
-	def generator() -> list:
-		RATE_LIMIT = frappe.qb.DocType("Rate Limit")
-		rate_limits = (
-			frappe.qb.from_(RATE_LIMIT)
-			.select(
-				RATE_LIMIT.ignore_in_developer_mode,
-				RATE_LIMIT.key_.as_("key"),
-				RATE_LIMIT.value,
-				RATE_LIMIT.limit,
-				RATE_LIMIT.seconds,
-				RATE_LIMIT.methods,
-				RATE_LIMIT.ip_based,
-				RATE_LIMIT.allowed_ips,
-				RATE_LIMIT.blocked_ips,
-			)
-			.where((RATE_LIMIT.enabled == 1) & (RATE_LIMIT.method_path == method_path))
-		).run(as_dict=True)
+    def generator() -> list:
+        RATE_LIMIT = frappe.qb.DocType("Rate Limit")
+        rate_limits = (
+            frappe.qb.from_(RATE_LIMIT)
+            .select(
+                RATE_LIMIT.ignore_in_developer_mode,
+                RATE_LIMIT.key_.as_("key"),
+                RATE_LIMIT.value,
+                RATE_LIMIT.limit,
+                RATE_LIMIT.seconds,
+                RATE_LIMIT.methods,
+                RATE_LIMIT.ip_based,
+                RATE_LIMIT.allowed_ips,
+                RATE_LIMIT.blocked_ips,
+            )
+            .where((RATE_LIMIT.enabled == 1) & (RATE_LIMIT.method_path == method_path))
+        ).run(as_dict=True)
 
-		if not rate_limits:
-			return []
+        if not rate_limits:
+            return []
 
-		for rl in rate_limits:
-			rl["ignore_in_developer_mode"] = bool(rl["ignore_in_developer_mode"])
-			rl["methods"] = rl["methods"].split("\n")
-			rl["ip_based"] = bool(rl["ip_based"])
+        for rl in rate_limits:
+            rl["ignore_in_developer_mode"] = bool(rl["ignore_in_developer_mode"])
+            rl["methods"] = rl["methods"].split("\n")
+            rl["ip_based"] = bool(rl["ip_based"])
 
-			if len(rl["methods"]) == 1 and rl["methods"][0] == "ALL":
-				rl["methods"] = "ALL"
+            if len(rl["methods"]) == 1 and rl["methods"][0] == "ALL":
+                rl["methods"] = "ALL"
 
-			rl["allowed_ips"] = rl["allowed_ips"].split("\n") if rl["allowed_ips"] else []
-			rl["blocked_ips"] = rl["blocked_ips"].split("\n") if rl["blocked_ips"] else []
+            rl["allowed_ips"] = rl["allowed_ips"].split("\n") if rl["allowed_ips"] else []
+            rl["blocked_ips"] = rl["blocked_ips"].split("\n") if rl["blocked_ips"] else []
 
-		return rate_limits
+        return rate_limits
 
-	return frappe.cache.hget("rate_limits", method_path, generator)
+    return frappe.cache.hget("rate_limits", method_path, generator)
 
 
 def on_doctype_update() -> None:
-	frappe.db.add_unique(
-		"Rate Limit",
-		["method_path", "key_", "value", "ip_based", "seconds"],
-		constraint_name="unique_rate_limit",
-	)
+    frappe.db.add_unique(
+        "Rate Limit",
+        ["method_path", "key_", "value", "ip_based", "seconds"],
+        constraint_name="unique_rate_limit",
+    )

--- a/suite/suite_core/doctype/rate_limit/test_rate_limit.py
+++ b/suite/suite_core/doctype/rate_limit/test_rate_limit.py
@@ -12,18 +12,18 @@ IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
 class UnitTestRateLimit(UnitTestCase):
-	"""
-	Unit tests for RateLimit.
-	Use this class for testing individual functions and methods.
-	"""
+    """
+    Unit tests for RateLimit.
+    Use this class for testing individual functions and methods.
+    """
 
-	pass
+    pass
 
 
 class IntegrationTestRateLimit(IntegrationTestCase):
-	"""
-	Integration tests for RateLimit.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for RateLimit.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/suite_core/doctype/store_entry/store_entry.py
+++ b/suite/suite_core/doctype/store_entry/store_entry.py
@@ -11,10 +11,10 @@ from frappe.types.filter import FilterTuple
 from frappe.utils import cint, now
 
 from suite.store import (
-	get_blob_base_path,
-	get_data_base_path,
-	get_search_base_path,
-	list_namespaces,
+    get_blob_base_path,
+    get_data_base_path,
+    get_search_base_path,
+    list_namespaces,
 )
 from suite.store.base_store import resolve_namespace_path
 from suite.store.blob_store import BlobStore
@@ -37,314 +37,314 @@ _VALUE_PREVIEW_LIMIT = 20_000
 
 
 class StoreEntry(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		entity: DF.Data | None
-		key: DF.Data | None
-		namespace: DF.Data
-		size: DF.Data | None
-		store: DF.Literal["Data Store", "Blob Store", "Search Store"]
-		value: DF.Code | None
-	# end: auto-generated types
+        entity: DF.Data | None
+        key: DF.Data | None
+        namespace: DF.Data
+        size: DF.Data | None
+        store: DF.Literal["Data Store", "Blob Store", "Search Store"]
+        value: DF.Code | None
+    # end: auto-generated types
 
-	def load_from_db(self) -> None:
-		store, namespace, key_part = _parse_name(self.name)
+    def load_from_db(self) -> None:
+        store, namespace, key_part = _parse_name(self.name)
 
-		# Guard before opening a store: instantiating one creates its namespace directory, so an
-		# unknown namespace must be rejected here rather than lazily conjured into existence.
-		if not _namespace_exists(store, namespace):
-			_not_found(self.name)
+        # Guard before opening a store: instantiating one creates its namespace directory, so an
+        # unknown namespace must be rejected here rather than lazily conjured into existence.
+        if not _namespace_exists(store, namespace):
+            _not_found(self.name)
 
-		if store == DATA_STORE:
-			entity, _sep, key = key_part.partition(":")
-			entry = _data_store(namespace).read(entity, key)
-			if entry is None:
-				_not_found(self.name)
+        if store == DATA_STORE:
+            entity, _sep, key = key_part.partition(":")
+            entry = _data_store(namespace).read(entity, key)
+            if entry is None:
+                _not_found(self.name)
 
-			record = _row(store, namespace, entity, key, entry["size"], value=_pretty(entry["value"]))
-		elif store == SEARCH_STORE:
-			entity, key = _split_search_key(namespace, key_part)
-			# A hand-crafted name can carry an entity the browser refuses; that is a missing
-			# record, not a server error.
-			try:
-				index = _search_index(namespace, entity)
-			except ValueError:
-				_not_found(self.name)
+            record = _row(store, namespace, entity, key, entry["size"], value=_pretty(entry["value"]))
+        elif store == SEARCH_STORE:
+            entity, key = _split_search_key(namespace, key_part)
+            # A hand-crafted name can carry an entity the browser refuses; that is a missing
+            # record, not a server error.
+            try:
+                index = _search_index(namespace, entity)
+            except ValueError:
+                _not_found(self.name)
 
-			entry = index.read(key)
-			if entry is None:
-				_not_found(self.name)
+            entry = index.read(key)
+            if entry is None:
+                _not_found(self.name)
 
-			record = _row(store, namespace, entity, key, entry["size"], value=_pretty(entry["value"]))
-		else:
-			blob = _blob_store(namespace).get(key_part)
-			if blob is None:
-				_not_found(self.name)
+            record = _row(store, namespace, entity, key, entry["size"], value=_pretty(entry["value"]))
+        else:
+            blob = _blob_store(namespace).get(key_part)
+            if blob is None:
+                _not_found(self.name)
 
-			record = _row(store, namespace, None, key_part, len(blob), value=_blob_preview(blob))
+            record = _row(store, namespace, None, key_part, len(blob), value=_blob_preview(blob))
 
-		super(Document, self).__init__(record)
+        super(Document, self).__init__(record)
 
-	# Store Entry is a read-only browser; block all writes.
-	def db_insert(self, *args, **kwargs) -> None:
-		frappe.throw(_("Store Entry is read-only."))
+    # Store Entry is a read-only browser; block all writes.
+    def db_insert(self, *args, **kwargs) -> None:
+        frappe.throw(_("Store Entry is read-only."))
 
-	def db_update(self, *args, **kwargs) -> None:
-		frappe.throw(_("Store Entry is read-only."))
+    def db_update(self, *args, **kwargs) -> None:
+        frappe.throw(_("Store Entry is read-only."))
 
-	def delete(self, *args, **kwargs) -> None:
-		frappe.throw(_("Store Entry is read-only."))
+    def delete(self, *args, **kwargs) -> None:
+        frappe.throw(_("Store Entry is read-only."))
 
-	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs) -> list[dict]:
-		store = _filter_value(filters, "store") or DATA_STORE
-		namespace = _filter_value(filters, "namespace")
+    @staticmethod
+    def get_list(filters=None, page_length=20, **kwargs) -> list[dict]:
+        store = _filter_value(filters, "store") or DATA_STORE
+        namespace = _filter_value(filters, "namespace")
 
-		if not namespace:
-			available = _available_namespaces(store)
-			hint = ", ".join(available) if available else _("none")
-			frappe.msgprint(_("Select a namespace to browse. Available: {0}").format(hint), alert=True)
-			return []
+        if not namespace:
+            available = _available_namespaces(store)
+            hint = ", ".join(available) if available else _("none")
+            frappe.msgprint(_("Select a namespace to browse. Available: {0}").format(hint), alert=True)
+            return []
 
-		if not _namespace_exists(store, namespace):
-			frappe.msgprint(_("No {0} found for namespace {1}.").format(store.lower(), namespace), alert=True)
-			return []
+        if not _namespace_exists(store, namespace):
+            frappe.msgprint(_("No {0} found for namespace {1}.").format(store.lower(), namespace), alert=True)
+            return []
 
-		rows = _entries(store, namespace, entity=_filter_value(filters, "entity"))
+        rows = _entries(store, namespace, entity=_filter_value(filters, "entity"))
 
-		start = cint(kwargs.get("limit_start"))
-		length = cint(kwargs.get("limit_page_length") or page_length) or len(rows)
-		return rows[start : start + length]
+        start = cint(kwargs.get("limit_start"))
+        length = cint(kwargs.get("limit_page_length") or page_length) or len(rows)
+        return rows[start : start + length]
 
-	@staticmethod
-	def get_count(filters=None, **kwargs) -> int:
-		store = _filter_value(filters, "store") or DATA_STORE
-		namespace = _filter_value(filters, "namespace")
+    @staticmethod
+    def get_count(filters=None, **kwargs) -> int:
+        store = _filter_value(filters, "store") or DATA_STORE
+        namespace = _filter_value(filters, "namespace")
 
-		if not namespace or not _namespace_exists(store, namespace):
-			return 0
+        if not namespace or not _namespace_exists(store, namespace):
+            return 0
 
-		entity = _filter_value(filters, "entity")
+        entity = _filter_value(filters, "entity")
 
-		if store == DATA_STORE:
-			return _data_store(namespace).count_entries(entity)
+        if store == DATA_STORE:
+            return _data_store(namespace).count_entries(entity)
 
-		if store == SEARCH_STORE:
-			return sum(
-				_search_index(namespace, index_entity).count()
-				for index_entity in _search_index_entities(namespace, entity)
-			)
+        if store == SEARCH_STORE:
+            return sum(
+                _search_index(namespace, index_entity).count()
+                for index_entity in _search_index_entities(namespace, entity)
+            )
 
-		return _blob_store(namespace).count()
+        return _blob_store(namespace).count()
 
-	@staticmethod
-	def get_stats(**kwargs) -> dict:
-		return {}
+    @staticmethod
+    def get_stats(**kwargs) -> dict:
+        return {}
 
 
 def _filter_value(filters, fieldname: str):
-	"""Return the value a list-view filter sets for `fieldname`.
+    """Return the value a list-view filter sets for `fieldname`.
 
-	Handles both a plain ``{field: value}`` dict and a list of filter conditions, and unwraps a
-	``like`` value's surrounding ``%`` so a Data standard filter (which defaults to ``like``)
-	still yields the exact value callers expect.
-	"""
+    Handles both a plain ``{field: value}`` dict and a list of filter conditions, and unwraps a
+    ``like`` value's surrounding ``%`` so a Data standard filter (which defaults to ``like``)
+    still yields the exact value callers expect.
+    """
 
-	if isinstance(filters, dict):
-		return filters.get(fieldname)
+    if isinstance(filters, dict):
+        return filters.get(fieldname)
 
-	for condition in filters or []:
-		tup = condition if isinstance(condition, FilterTuple) else FilterTuple(condition)
-		if tup.fieldname != fieldname:
-			continue
+    for condition in filters or []:
+        tup = condition if isinstance(condition, FilterTuple) else FilterTuple(condition)
+        if tup.fieldname != fieldname:
+            continue
 
-		value = tup.value
-		if isinstance(value, str) and tup.operator in ("like", "not like"):
-			value = value.strip("%")
-		return value
+        value = tup.value
+        if isinstance(value, str) and tup.operator in ("like", "not like"):
+            value = value.strip("%")
+        return value
 
-	return None
+    return None
 
 
 def _not_found(name: str) -> None:
-	"""Raise the not-found error `load_from_db` is expected to raise for a missing record."""
+    """Raise the not-found error `load_from_db` is expected to raise for a missing record."""
 
-	frappe.throw(_("Store entry {0} not found.").format(frappe.bold(name)), frappe.DoesNotExistError)
+    frappe.throw(_("Store entry {0} not found.").format(frappe.bold(name)), frappe.DoesNotExistError)
 
 
 def _base_path(store: str) -> str:
-	"""Return the base directory for the given store."""
+    """Return the base directory for the given store."""
 
-	if store == DATA_STORE:
-		return get_data_base_path()
-	if store == SEARCH_STORE:
-		return get_search_base_path()
-	return get_blob_base_path()
+    if store == DATA_STORE:
+        return get_data_base_path()
+    if store == SEARCH_STORE:
+        return get_search_base_path()
+    return get_blob_base_path()
 
 
 def _data_store(namespace: str) -> DataStore:
-	return DataStore(base_path=get_data_base_path(), namespace=namespace)
+    return DataStore(base_path=get_data_base_path(), namespace=namespace)
 
 
 def _blob_store(namespace: str) -> BlobStore:
-	return BlobStore(base_path=get_blob_base_path(), namespace=namespace)
+    return BlobStore(base_path=get_blob_base_path(), namespace=namespace)
 
 
 def _search_index(namespace: str, entity: str) -> SearchIndexBrowser:
-	return SearchIndexBrowser(namespace, entity)
+    return SearchIndexBrowser(namespace, entity)
 
 
 def _search_index_entities(namespace: str, entity: str | None = None) -> list[str]:
-	"""Return a namespace's index entities, narrowed to `entity` when the caller filters on one."""
+    """Return a namespace's index entities, narrowed to `entity` when the caller filters on one."""
 
-	entities = list_index_entities(namespace)
-	return [e for e in entities if e == entity] if entity else entities
+    entities = list_index_entities(namespace)
+    return [e for e in entities if e == entity] if entity else entities
 
 
 def _split_search_key(namespace: str, key_part: str) -> tuple[str, str]:
-	"""Split an ``<entity>:<key>`` search key_part back into (entity, key).
+    """Split an ``<entity>:<key>`` search key_part back into (entity, key).
 
-	The entity is resolved against the namespace's real on-disk index names rather than by
-	splitting at the first colon, so an entity that itself contains ``:`` is not mis-parsed (which
-	would otherwise open the wrong index and report an existing document as missing). The longest
-	matching entity wins, disambiguating the case where one entity name is a prefix of another.
-	Falls back to a first-colon split when no index matches (e.g. one dropped since the row was
-	built).
-	"""
+    The entity is resolved against the namespace's real on-disk index names rather than by
+    splitting at the first colon, so an entity that itself contains ``:`` is not mis-parsed (which
+    would otherwise open the wrong index and report an existing document as missing). The longest
+    matching entity wins, disambiguating the case where one entity name is a prefix of another.
+    Falls back to a first-colon split when no index matches (e.g. one dropped since the row was
+    built).
+    """
 
-	matches = [e for e in list_index_entities(namespace) if key_part == e or key_part.startswith(f"{e}:")]
-	if matches:
-		entity = max(matches, key=len)
-		return entity, key_part[len(entity) + 1 :]
+    matches = [e for e in list_index_entities(namespace) if key_part == e or key_part.startswith(f"{e}:")]
+    if matches:
+        entity = max(matches, key=len)
+        return entity, key_part[len(entity) + 1 :]
 
-	entity, _sep, key = key_part.partition(":")
-	return entity, key
+    entity, _sep, key = key_part.partition(":")
+    return entity, key
 
 
 def _available_namespaces(store: str) -> list[str]:
-	"""Return the namespaces a user can browse for `store`, for the "select a namespace" hint.
+    """Return the namespaces a user can browse for `store`, for the "select a namespace" hint.
 
-	A search store nests one index directory per entity under each namespace
-	(``<base>/<namespace>/<entity>``), so its browsable namespaces are the parents of those leaf
-	directories rather than the leaves themselves.
-	"""
+    A search store nests one index directory per entity under each namespace
+    (``<base>/<namespace>/<entity>``), so its browsable namespaces are the parents of those leaf
+    directories rather than the leaves themselves.
+    """
 
-	if store == SEARCH_STORE:
-		namespaces = {"/".join(ns[:-1]) for ns in list_namespaces(get_search_base_path()) if len(ns) > 1}
-		return sorted(namespaces)
+    if store == SEARCH_STORE:
+        namespaces = {"/".join(ns[:-1]) for ns in list_namespaces(get_search_base_path()) if len(ns) > 1}
+        return sorted(namespaces)
 
-	return ["/".join(ns) for ns in list_namespaces(_base_path(store))]
+    return ["/".join(ns) for ns in list_namespaces(_base_path(store))]
 
 
 def _namespace_exists(store: str, namespace: str) -> bool:
-	"""Return True when the namespace directory exists (so browsing never creates empty stores)."""
+    """Return True when the namespace directory exists (so browsing never creates empty stores)."""
 
-	return os.path.isdir(resolve_namespace_path(_base_path(store), namespace))
+    return os.path.isdir(resolve_namespace_path(_base_path(store), namespace))
 
 
 def _entries(store: str, namespace: str, entity: str | None = None) -> list[dict]:
-	"""Return the browsable rows for a namespace, sorted by entity then key."""
+    """Return the browsable rows for a namespace, sorted by entity then key."""
 
-	if store == DATA_STORE:
-		rows = [
-			_row(store, namespace, item["entity"], item["key"], item["size"])
-			for item in _data_store(namespace).browse()
-			if not entity or item["entity"] == entity
-		]
-	elif store == SEARCH_STORE:
-		rows = [
-			_row(store, namespace, index_entity, item["key"], item["size"])
-			for index_entity in _search_index_entities(namespace, entity)
-			for item in _search_index(namespace, index_entity).browse()
-		]
-	else:
-		rows = [
-			_row(store, namespace, None, item["key"], item["size"])
-			for item in _blob_store(namespace).browse()
-		]
+    if store == DATA_STORE:
+        rows = [
+            _row(store, namespace, item["entity"], item["key"], item["size"])
+            for item in _data_store(namespace).browse()
+            if not entity or item["entity"] == entity
+        ]
+    elif store == SEARCH_STORE:
+        rows = [
+            _row(store, namespace, index_entity, item["key"], item["size"])
+            for index_entity in _search_index_entities(namespace, entity)
+            for item in _search_index(namespace, index_entity).browse()
+        ]
+    else:
+        rows = [
+            _row(store, namespace, None, item["key"], item["size"])
+            for item in _blob_store(namespace).browse()
+        ]
 
-	rows.sort(key=lambda row: (row.get("entity") or "", row["key"]))
-	return rows
+    rows.sort(key=lambda row: (row.get("entity") or "", row["key"]))
+    return rows
 
 
 def _row(
-	store: str,
-	namespace: str,
-	entity: str | None,
-	key: str,
-	size: int,
-	value: str | None = None,
+    store: str,
+    namespace: str,
+    entity: str | None,
+    key: str,
+    size: int,
+    value: str | None = None,
 ) -> dict:
-	"""Build a Store Entry record dict for either store."""
+    """Build a Store Entry record dict for either store."""
 
-	key_part = f"{entity}:{key}" if store in _ENTITY_STORES else key
-	stamp = now()
+    key_part = f"{entity}:{key}" if store in _ENTITY_STORES else key
+    stamp = now()
 
-	return {
-		"name": _make_name(store, namespace, key_part),
-		"store": store,
-		"namespace": namespace,
-		"entity": entity,
-		"key": key,
-		"size": size,
-		"value": value,
-		"creation": stamp,
-		"modified": stamp,
-	}
+    return {
+        "name": _make_name(store, namespace, key_part),
+        "store": store,
+        "namespace": namespace,
+        "entity": entity,
+        "key": key,
+        "size": size,
+        "value": value,
+        "creation": stamp,
+        "modified": stamp,
+    }
 
 
 def _make_name(store: str, namespace: str, key_part: str) -> str:
-	"""Encode a stable, parseable record name: ``<data|blob|search>|<namespace>|<key_part>``."""
+    """Encode a stable, parseable record name: ``<data|blob|search>|<namespace>|<key_part>``."""
 
-	return f"{_STORE_CODES[store]}|{namespace}|{key_part}"
+    return f"{_STORE_CODES[store]}|{namespace}|{key_part}"
 
 
 def _parse_name(name: str) -> tuple[str, str, str]:
-	"""Split a record name back into (store, namespace, key_part).
+    """Split a record name back into (store, namespace, key_part).
 
-	A well-formed name is ``<data|blob|search>|<namespace>|<key_part>``. A malformed one (e.g. a
-	hand-crafted URL, or an unknown store code) is treated as a missing record rather than
-	allowed to raise ValueError.
-	"""
+    A well-formed name is ``<data|blob|search>|<namespace>|<key_part>``. A malformed one (e.g. a
+    hand-crafted URL, or an unknown store code) is treated as a missing record rather than
+    allowed to raise ValueError.
+    """
 
-	parts = name.split("|", 2)
-	if len(parts) != 3:
-		_not_found(name)
+    parts = name.split("|", 2)
+    if len(parts) != 3:
+        _not_found(name)
 
-	code, namespace, key_part = parts
-	store = _CODE_STORES.get(code)
-	if store is None:
-		_not_found(name)
+    code, namespace, key_part = parts
+    store = _CODE_STORES.get(code)
+    if store is None:
+        _not_found(name)
 
-	return store, namespace, key_part
+    return store, namespace, key_part
 
 
 def _pretty(value) -> str:
-	"""Render a deserialized data-store value as pretty JSON, truncated for display."""
+    """Render a deserialized data-store value as pretty JSON, truncated for display."""
 
-	text = json.dumps(value, indent=2, ensure_ascii=False, default=str)
-	return _truncate(text)
+    text = json.dumps(value, indent=2, ensure_ascii=False, default=str)
+    return _truncate(text)
 
 
 def _blob_preview(blob: bytes) -> str:
-	"""Render a blob as text when it decodes as UTF-8, otherwise note its binary size."""
+    """Render a blob as text when it decodes as UTF-8, otherwise note its binary size."""
 
-	try:
-		return _truncate(blob.decode("utf-8"))
-	except UnicodeDecodeError:
-		return _("<binary blob: {0} bytes>").format(len(blob))
+    try:
+        return _truncate(blob.decode("utf-8"))
+    except UnicodeDecodeError:
+        return _("<binary blob: {0} bytes>").format(len(blob))
 
 
 def _truncate(text: str) -> str:
-	"""Clip an overly long value preview so the browser stays responsive."""
+    """Clip an overly long value preview so the browser stays responsive."""
 
-	if len(text) > _VALUE_PREVIEW_LIMIT:
-		return text[:_VALUE_PREVIEW_LIMIT] + "\n… (truncated)"
+    if len(text) > _VALUE_PREVIEW_LIMIT:
+        return text[:_VALUE_PREVIEW_LIMIT] + "\n… (truncated)"
 
-	return text
+    return text

--- a/suite/suite_core/doctype/store_entry/test_store_entry.py
+++ b/suite/suite_core/doctype/store_entry/test_store_entry.py
@@ -4,7 +4,6 @@
 # import frappe
 from frappe.tests import IntegrationTestCase
 
-
 # On IntegrationTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
 # Use these module variables to add/remove to/from that list

--- a/suite/suite_core/doctype/store_entry/test_store_entry.py
+++ b/suite/suite_core/doctype/store_entry/test_store_entry.py
@@ -12,11 +12,10 @@ EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
-
 class IntegrationTestStoreEntry(IntegrationTestCase):
-	"""
-	Integration tests for StoreEntry.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for StoreEntry.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/suite_core/patches/move_rate_limit_to_suite_core.py
+++ b/suite/suite_core/patches/move_rate_limit_to_suite_core.py
@@ -2,11 +2,11 @@ import frappe
 
 
 def execute() -> None:
-	"""Retag the Rate Limit DocType from the Mail module to Suite Core.
+    """Retag the Rate Limit DocType from the Mail module to Suite Core.
 
-	The DocType was moved to ``suite.suite_core.doctype.rate_limit`` so it can be
-	shared across modules. On upgraded sites the DocType record may still be
-	stored with ``module = "Mail"``, so retag it before anything tries to resolve
-	it. This is a plain DB update and never loads the relocated controller.
-	"""
-	frappe.db.set_value("DocType", "Rate Limit", "module", "Suite Core", update_modified=False)
+    The DocType was moved to ``suite.suite_core.doctype.rate_limit`` so it can be
+    shared across modules. On upgraded sites the DocType record may still be
+    stored with ``module = "Mail"``, so retag it before anything tries to resolve
+    it. This is a plain DB update and never loads the relocated controller.
+    """
+    frappe.db.set_value("DocType", "Rate Limit", "module", "Suite Core", update_modified=False)

--- a/suite/tests/utils.py
+++ b/suite/tests/utils.py
@@ -5,12 +5,12 @@ import frappe
 
 
 def ensure_user(email):
-	if not frappe.db.exists("User", email):
-		frappe.get_doc(
-			{
-				"doctype": "User",
-				"email": email,
-				"first_name": email.split("@")[0],
-				"send_welcome_email": 0,
-			}
-		).insert(ignore_permissions=True)
+    if not frappe.db.exists("User", email):
+        frappe.get_doc(
+            {
+                "doctype": "User",
+                "email": email,
+                "first_name": email.split("@")[0],
+                "send_welcome_email": 0,
+            }
+        ).insert(ignore_permissions=True)

--- a/suite/utils/__init__.py
+++ b/suite/utils/__init__.py
@@ -13,176 +13,176 @@ from frappe.types.filter import FilterTuple
 from MySQLdb import OperationalError
 
 INVISIBLE_CHARS = (
-	r"[\u0000-\u001F\u007F-\u009F"  # ASCII control chars
-	r"\u200B-\u200F\u202A-\u202E"  # zero-width & directional
-	r"\u2060-\u206F"  # word joiners etc
-	r"\uFEFF"  # byte order mark
-	r"\u00AD"  # soft hyphen
-	r"\u034F]"  # combining grapheme joiner
+    r"[\u0000-\u001F\u007F-\u009F"  # ASCII control chars
+    r"\u200B-\u200F\u202A-\u202E"  # zero-width & directional
+    r"\u2060-\u206F"  # word joiners etc
+    r"\uFEFF"  # byte order mark
+    r"\u00AD"  # soft hyphen
+    r"\u034F]"  # combining grapheme joiner
 )
 
 
 def reconnect_on_failure(max_retries: int = 3) -> callable:
-	"""Decorator to reconnect to the database if a connection error occurs."""
+    """Decorator to reconnect to the database if a connection error occurs."""
 
-	@wrapt.decorator
-	def wrapper(wrapped, instance, args, kwargs):
-		retries = 0
+    @wrapt.decorator
+    def wrapper(wrapped, instance, args, kwargs):
+        retries = 0
 
-		while True:
-			try:
-				return wrapped(*args, **kwargs)
+        while True:
+            try:
+                return wrapped(*args, **kwargs)
 
-			except Exception as e:
-				is_db_error = frappe.db.is_interface_error(e) or isinstance(e, OperationalError)
+            except Exception as e:
+                is_db_error = frappe.db.is_interface_error(e) or isinstance(e, OperationalError)
 
-				if not is_db_error or retries >= max_retries:
-					raise type(e)(f"{e!s} | Retries attempted: {retries}/{max_retries}") from e
+                if not is_db_error or retries >= max_retries:
+                    raise type(e)(f"{e!s} | Retries attempted: {retries}/{max_retries}") from e
 
-				retries += 1
-				frappe.db.connect()
+                retries += 1
+                frappe.db.connect()
 
-	return wrapper
+    return wrapper
 
 
 def log_error(module: str, title: str | None = None, message: str | None = None, **kwargs) -> None:
-	"""Logs an error, prefixing the title with "[module]" so module errors can be filtered out.
+    """Logs an error, prefixing the title with "[module]" so module errors can be filtered out.
 
-	Wraps `frappe.log_error` and should be used in place of it throughout the app.
-	"""
+    Wraps `frappe.log_error` and should be used in place of it throughout the app.
+    """
 
-	prefix = f"[{module}] "
-	if title and not title.startswith(prefix):
-		title = f"{prefix}{title}"
+    prefix = f"[{module}] "
+    if title and not title.startswith(prefix):
+        title = f"{prefix}{title}"
 
-	frappe.log_error(title=title, message=message, **kwargs)
+    frappe.log_error(title=title, message=message, **kwargs)
 
 
 def execute_with_logging(
-	func: callable,
-	title: str,
-	user_message: str | None = None,
-	with_context: bool = False,
-	module: str | None = None,
+    func: callable,
+    title: str,
+    user_message: str | None = None,
+    with_context: bool = False,
+    module: str | None = None,
 ) -> Any | None:
-	"""Executes a function and logs any exceptions that occur, optionally throwing a user-friendly message."""
+    """Executes a function and logs any exceptions that occur, optionally throwing a user-friendly message."""
 
-	try:
-		return func()
-	except Exception:
-		module = module or (
-			func.__module__.split(".")[0].title() if hasattr(func, "__module__") else "Unknown"
-		)
+    try:
+        return func()
+    except Exception:
+        module = module or (
+            func.__module__.split(".")[0].title() if hasattr(func, "__module__") else "Unknown"
+        )
 
-		log_error(
-			module=module,
-			title=title,
-			message=frappe.get_traceback(with_context=with_context),
-		)
+        log_error(
+            module=module,
+            title=title,
+            message=frappe.get_traceback(with_context=with_context),
+        )
 
-		if user_message:
-			frappe.throw(title=title, msg=user_message)
+        if user_message:
+            frappe.throw(title=title, msg=user_message)
 
 
 @contextmanager
 def user_context(user: str) -> Generator[None, None, None]:
-	"""Context manager to temporarily switch the user context."""
+    """Context manager to temporarily switch the user context."""
 
-	session_user = frappe.session.user
-	session_sid = frappe.session.sid
-	session_data = frappe.session.data.copy()
-	form_dict = frappe.local.form_dict
+    session_user = frappe.session.user
+    session_sid = frappe.session.sid
+    session_data = frappe.session.data.copy()
+    form_dict = frappe.local.form_dict
 
-	if session_user == user:
-		yield
-		return
+    if session_user == user:
+        yield
+        return
 
-	try:
-		frappe.set_user(user)
-		yield
-	finally:
-		# frappe.set_user() overwrites session.sid with the username and wipes session.data and
-		# form_dict, so restore all three alongside the user to avoid corrupting the original
-		# session. form_dict matters beyond tidiness: rate limiting keys its counter off
-		# form_dict.cmd, so leaving it emptied silently unlimits the rest of the request.
-		frappe.set_user(session_user)
-		frappe.session.sid = session_sid
-		frappe.session.data = session_data
-		frappe.local.form_dict = form_dict
+    try:
+        frappe.set_user(user)
+        yield
+    finally:
+        # frappe.set_user() overwrites session.sid with the username and wipes session.data and
+        # form_dict, so restore all three alongside the user to avoid corrupting the original
+        # session. form_dict matters beyond tidiness: rate limiting keys its counter off
+        # form_dict.cmd, so leaving it emptied silently unlimits the rest of the request.
+        frappe.set_user(session_user)
+        frappe.session.sid = session_sid
+        frappe.session.data = session_data
+        frappe.local.form_dict = form_dict
 
 
 def snake_to_camel(input) -> str:
-	"""Convert snake_case string to camelCase."""
+    """Convert snake_case string to camelCase."""
 
-	parts = input.split("_")
-	return parts[0] + "".join(word.capitalize() for word in parts[1:])
+    parts = input.split("_")
+    return parts[0] + "".join(word.capitalize() for word in parts[1:])
 
 
 def generate_otp(length: int = 5) -> int:
-	"""Generates a random OTP."""
+    """Generates a random OTP."""
 
-	lower_bound = 10 ** (length - 1)
-	upper_bound = 10**length
-	return int.from_bytes(os.urandom(length), byteorder="big") % (upper_bound - lower_bound) + lower_bound
+    lower_bound = 10 ** (length - 1)
+    upper_bound = 10**length
+    return int.from_bytes(os.urandom(length), byteorder="big") % (upper_bound - lower_bound) + lower_bound
 
 
 def enqueue_job(
-	method: str | Callable, job_id: str | None = None, deduplicate: bool = False, **kwargs
+    method: str | Callable, job_id: str | None = None, deduplicate: bool = False, **kwargs
 ) -> None:
-	"""Enqueues a background job."""
+    """Enqueues a background job."""
 
-	if deduplicate and not job_id:
-		job_id = method.split(".")[-1] if isinstance(method, str) else method.__name__
+    if deduplicate and not job_id:
+        job_id = method.split(".")[-1] if isinstance(method, str) else method.__name__
 
-	frappe.enqueue(method, job_id=job_id, deduplicate=deduplicate, **kwargs)
+    frappe.enqueue(method, job_id=job_id, deduplicate=deduplicate, **kwargs)
 
 
 def clean_text(text: str) -> str:
-	"""Collapse multiple spaces into a single space and trim leading/trailing spaces."""
+    """Collapse multiple spaces into a single space and trim leading/trailing spaces."""
 
-	if not text:
-		return ""
+    if not text:
+        return ""
 
-	text = unicodedata.normalize("NFKC", text)
-	text = re.sub(INVISIBLE_CHARS, "", text)
-	text = re.sub(r"([,.!?])(?=\w)", r"\1 ", text)
+    text = unicodedata.normalize("NFKC", text)
+    text = re.sub(INVISIBLE_CHARS, "", text)
+    text = re.sub(r"([,.!?])(?=\w)", r"\1 ", text)
 
-	return re.sub(r"\s+", " ", text).strip()
+    return re.sub(r"\s+", " ", text).strip()
 
 
 def convert_html_to_text(html: str) -> str:
-	"""Returns plain text from HTML <body> content, excluding interactive elements but keeping anchor text."""
+    """Returns plain text from HTML <body> content, excluding interactive elements but keeping anchor text."""
 
-	if not html:
-		return ""
+    if not html:
+        return ""
 
-	soup = BeautifulSoup(html, "html.parser")
-	body = soup.body or soup
+    soup = BeautifulSoup(html, "html.parser")
+    body = soup.body or soup
 
-	for tag in body.find_all(["a", "button", "input"]):
-		if tag.name == "a":
-			tag.unwrap()
-		elif tag.name == "input" and tag.get("type") not in ("button", "submit", "reset"):
-			continue
-		else:
-			tag.decompose()
+    for tag in body.find_all(["a", "button", "input"]):
+        if tag.name == "a":
+            tag.unwrap()
+        elif tag.name == "input" and tag.get("type") not in ("button", "submit", "reset"):
+            continue
+        else:
+            tag.decompose()
 
-	text = body.get_text(separator=" ")
-	return clean_text(text)
+    text = body.get_text(separator=" ")
+    return clean_text(text)
 
 
 def parse_filters(filters: list | None) -> dict:
-	"""Parses a list of filters into a dictionary of fieldname-value pairs for equality conditions."""
+    """Parses a list of filters into a dictionary of fieldname-value pairs for equality conditions."""
 
-	if not filters:
-		return {}
+    if not filters:
+        return {}
 
-	result = {}
-	for f in filters:
-		if isinstance(f, list):
-			f = FilterTuple(f)
+    result = {}
+    for f in filters:
+        if isinstance(f, list):
+            f = FilterTuple(f)
 
-		if f.operator == "=":
-			result[f.fieldname] = f.value
+        if f.operator == "=":
+            result[f.fieldname] = f.value
 
-	return result
+    return result

--- a/suite/utils/__init__.py
+++ b/suite/utils/__init__.py
@@ -85,7 +85,7 @@ def execute_with_logging(
 
 
 @contextmanager
-def user_context(user: str) -> Generator[None, None, None]:
+def user_context(user: str) -> Generator[None]:
     """Context manager to temporarily switch the user context."""
 
     session_user = frappe.session.user

--- a/suite/utils/dt.py
+++ b/suite/utils/dt.py
@@ -14,7 +14,7 @@ def get_utc_now(naive: bool = False) -> datetime:
     return now.replace(tzinfo=None) if naive else now
 
 
-def utcnow() -> "str":
+def utcnow() -> str:
     """Returns current UTC time in ISO format."""
 
     return get_utc_now().isoformat().replace("+00:00", "Z")
@@ -22,7 +22,7 @@ def utcnow() -> "str":
 
 def convert_to_utc(
     date_time: datetime | str, from_timezone: str | None = None, naive: bool = False
-) -> "datetime":
+) -> datetime:
     """Converts the given datetime to UTC timezone."""
 
     dt = get_datetime(date_time)

--- a/suite/utils/dt.py
+++ b/suite/utils/dt.py
@@ -8,105 +8,105 @@ from frappe.utils import get_datetime, get_datetime_str, get_system_timezone
 
 
 def get_utc_now(naive: bool = False) -> datetime:
-	"""Returns the current UTC datetime."""
+    """Returns the current UTC datetime."""
 
-	now = datetime.now(UTC)
-	return now.replace(tzinfo=None) if naive else now
+    now = datetime.now(UTC)
+    return now.replace(tzinfo=None) if naive else now
 
 
 def utcnow() -> "str":
-	"""Returns current UTC time in ISO format."""
+    """Returns current UTC time in ISO format."""
 
-	return get_utc_now().isoformat().replace("+00:00", "Z")
+    return get_utc_now().isoformat().replace("+00:00", "Z")
 
 
 def convert_to_utc(
-	date_time: datetime | str, from_timezone: str | None = None, naive: bool = False
+    date_time: datetime | str, from_timezone: str | None = None, naive: bool = False
 ) -> "datetime":
-	"""Converts the given datetime to UTC timezone."""
+    """Converts the given datetime to UTC timezone."""
 
-	dt = get_datetime(date_time)
-	if dt.tzinfo is None:
-		tz = ZoneInfo(from_timezone or get_system_timezone())
-		dt = dt.replace(tzinfo=tz)
+    dt = get_datetime(date_time)
+    if dt.tzinfo is None:
+        tz = ZoneInfo(from_timezone or get_system_timezone())
+        dt = dt.replace(tzinfo=tz)
 
-	utc_dt = dt.astimezone(UTC)
-	return utc_dt.replace(tzinfo=None) if naive else utc_dt
+    utc_dt = dt.astimezone(UTC)
+    return utc_dt.replace(tzinfo=None) if naive else utc_dt
 
 
 def parse_iso_datetime(
-	datetime_str: str, to_timezone: str | None = None, as_str: bool = True
+    datetime_str: str, to_timezone: str | None = None, as_str: bool = True
 ) -> str | datetime:
-	"""Converts ISO datetime string to datetime object in given timezone."""
+    """Converts ISO datetime string to datetime object in given timezone."""
 
-	if not to_timezone:
-		to_timezone = get_system_timezone()
+    if not to_timezone:
+        to_timezone = get_system_timezone()
 
-	dt = datetime.fromisoformat(datetime_str.replace("Z", "+00:00")).astimezone(ZoneInfo(to_timezone))
+    dt = datetime.fromisoformat(datetime_str.replace("Z", "+00:00")).astimezone(ZoneInfo(to_timezone))
 
-	return get_datetime_str(dt) if as_str else dt
+    return get_datetime_str(dt) if as_str else dt
 
 
 def add_or_update_tzinfo(date_time: datetime | str, time_zone: str | None = None) -> str:
-	"""Adds or updates timezone to the datetime."""
+    """Adds or updates timezone to the datetime."""
 
-	date_time = get_datetime(date_time)
-	target_tz = ZoneInfo(time_zone or get_system_timezone())
+    date_time = get_datetime(date_time)
+    target_tz = ZoneInfo(time_zone or get_system_timezone())
 
-	if date_time.tzinfo is None:
-		date_time = date_time.replace(tzinfo=target_tz)
-	else:
-		date_time = date_time.astimezone(target_tz)
+    if date_time.tzinfo is None:
+        date_time = date_time.replace(tzinfo=target_tz)
+    else:
+        date_time = date_time.astimezone(target_tz)
 
-	return str(date_time)
+    return str(date_time)
 
 
 def to_iso8601_z(dt: datetime) -> str:
-	"""
-	Convert a datetime (naive or aware) to an ISO 8601 string ending with 'Z' (UTC).
+    """
+    Convert a datetime (naive or aware) to an ISO 8601 string ending with 'Z' (UTC).
 
-	Rules:
-	- If naive, assume UTC.
-	- Always return a string like "YYYY-MM-DDTHH:MM:SS.sssZ".
-	"""
+    Rules:
+    - If naive, assume UTC.
+    - Always return a string like "YYYY-MM-DDTHH:MM:SS.sssZ".
+    """
 
-	if isinstance(dt, date):
-		dt = get_datetime(dt)
+    if isinstance(dt, date):
+        dt = get_datetime(dt)
 
-	if dt.tzinfo is None:
-		dt = dt.replace(tzinfo=UTC)
-	else:
-		dt = dt.astimezone(UTC)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    else:
+        dt = dt.astimezone(UTC)
 
-	return dt.isoformat().replace("+00:00", "Z")
+    return dt.isoformat().replace("+00:00", "Z")
 
 
 def add_iso_duration(
-	start_dt: str,
-	duration: str,
-	time_zone: str,
+    start_dt: str,
+    duration: str,
+    time_zone: str,
 ) -> datetime:
-	"""
-	Add ISO-8601 duration to an ISO datetime string using timezone-aware math,
-	but return a naive datetime (no offset) in the same local timezone.
-	"""
+    """
+    Add ISO-8601 duration to an ISO datetime string using timezone-aware math,
+    but return a naive datetime (no offset) in the same local timezone.
+    """
 
-	tz = ZoneInfo(time_zone)
-	start = datetime.fromisoformat(start_dt).replace(tzinfo=tz)
-	delta = isodate.parse_duration(duration)
-	end = start + delta
+    tz = ZoneInfo(time_zone)
+    start = datetime.fromisoformat(start_dt).replace(tzinfo=tz)
+    delta = isodate.parse_duration(duration)
+    end = start + delta
 
-	return end.replace(tzinfo=None)
+    return end.replace(tzinfo=None)
 
 
 def timestamp_to_datetime(
-	timestamp: float, to_timezone: str | None = None, as_str: bool = True
+    timestamp: float, to_timezone: str | None = None, as_str: bool = True
 ) -> str | datetime:
-	"""Converts a timestamp to a datetime object in the given timezone."""
+    """Converts a timestamp to a datetime object in the given timezone."""
 
-	if not to_timezone:
-		to_timezone = get_system_timezone()
+    if not to_timezone:
+        to_timezone = get_system_timezone()
 
-	dt = datetime.fromtimestamp(timestamp, tz=UTC).astimezone(ZoneInfo(to_timezone))
+    dt = datetime.fromtimestamp(timestamp, tz=UTC).astimezone(ZoneInfo(to_timezone))
 
-	return get_datetime_str(dt) if as_str else dt
+    return get_datetime_str(dt) if as_str else dt

--- a/suite/utils/file.py
+++ b/suite/utils/file.py
@@ -7,65 +7,65 @@ from frappe import _
 
 
 def extract_compressed_file(file_path: str, destination: str) -> None:
-	"""Extract a .zip, .tar.gz, or .tgz archive safely."""
+    """Extract a .zip, .tar.gz, or .tgz archive safely."""
 
-	def is_within_directory(base_path, target_path) -> bool:
-		"""Ensure target_path is inside base_path"""
+    def is_within_directory(base_path, target_path) -> bool:
+        """Ensure target_path is inside base_path"""
 
-		base_path = os.path.abspath(base_path)
-		target_path = os.path.abspath(target_path)
-		return os.path.commonpath([base_path]) == os.path.commonpath([base_path, target_path])
+        base_path = os.path.abspath(base_path)
+        target_path = os.path.abspath(target_path)
+        return os.path.commonpath([base_path]) == os.path.commonpath([base_path, target_path])
 
-	def safe_extract_zip(archive, destination) -> None:
-		"""Safely extract ZIP files, preventing path traversal."""
+    def safe_extract_zip(archive, destination) -> None:
+        """Safely extract ZIP files, preventing path traversal."""
 
-		for member in archive.namelist():
-			member_path = os.path.join(destination, member)
-			if not is_within_directory(destination, member_path):
-				frappe.throw(_("Unsafe file path detected: {0}").format(member))
-		archive.extractall(destination)
+        for member in archive.namelist():
+            member_path = os.path.join(destination, member)
+            if not is_within_directory(destination, member_path):
+                frappe.throw(_("Unsafe file path detected: {0}").format(member))
+        archive.extractall(destination)
 
-	def safe_extract_tar(archive, destination) -> None:
-		"""Safely extract TAR files, preventing path traversal."""
+    def safe_extract_tar(archive, destination) -> None:
+        """Safely extract TAR files, preventing path traversal."""
 
-		for member in archive.getmembers():
-			member_path = os.path.join(destination, member.name)
-			if not is_within_directory(destination, member_path):
-				frappe.throw(_("Unsafe file path detected: {0}").format(member.name))
-		archive.extractall(destination)
+        for member in archive.getmembers():
+            member_path = os.path.join(destination, member.name)
+            if not is_within_directory(destination, member_path):
+                frappe.throw(_("Unsafe file path detected: {0}").format(member.name))
+        archive.extractall(destination)
 
-	if not os.path.exists(file_path):
-		frappe.throw(_("File not found: {0}").format(file_path))
+    if not os.path.exists(file_path):
+        frappe.throw(_("File not found: {0}").format(file_path))
 
-	if not os.path.exists(destination):
-		os.makedirs(destination, exist_ok=True)
+    if not os.path.exists(destination):
+        os.makedirs(destination, exist_ok=True)
 
-	if file_path.endswith(".zip"):
-		with zipfile.ZipFile(file_path, "r") as archive:
-			safe_extract_zip(archive, destination)
+    if file_path.endswith(".zip"):
+        with zipfile.ZipFile(file_path, "r") as archive:
+            safe_extract_zip(archive, destination)
 
-	elif file_path.endswith((".tar.gz", ".tgz")):
-		with tarfile.open(file_path, "r:gz") as archive:
-			safe_extract_tar(archive, destination)
+    elif file_path.endswith((".tar.gz", ".tgz")):
+        with tarfile.open(file_path, "r:gz") as archive:
+            safe_extract_tar(archive, destination)
 
-	else:
-		frappe.throw(_("Unsupported file format: {0}").format(file_path))
+    else:
+        frappe.throw(_("Unsupported file format: {0}").format(file_path))
 
 
 def compress_directory(source_dir: str, output_path: str) -> None:
-	"""Compress a directory into .zip, .tgz, or .tar.gz format based on output file extension."""
+    """Compress a directory into .zip, .tgz, or .tar.gz format based on output file extension."""
 
-	if output_path.endswith(".zip"):
-		with zipfile.ZipFile(output_path, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
-			for root, _dirs, files in os.walk(source_dir):
-				for file in files:
-					file_path = os.path.join(root, file)
-					relative_path = os.path.relpath(file_path, source_dir)
-					zip_file.write(file_path, relative_path)
+    if output_path.endswith(".zip"):
+        with zipfile.ZipFile(output_path, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+            for root, _dirs, files in os.walk(source_dir):
+                for file in files:
+                    file_path = os.path.join(root, file)
+                    relative_path = os.path.relpath(file_path, source_dir)
+                    zip_file.write(file_path, relative_path)
 
-	elif output_path.endswith(".tgz") or output_path.endswith(".tar.gz"):
-		with tarfile.open(output_path, "w:gz") as tar_file:
-			tar_file.add(source_dir, arcname=".")
+    elif output_path.endswith(".tgz") or output_path.endswith(".tar.gz"):
+        with tarfile.open(output_path, "w:gz") as tar_file:
+            tar_file.add(source_dir, arcname=".")
 
-	else:
-		frappe.throw(_("Unsupported output file format. Supported formats are .zip, .tgz, and .tar.gz."))
+    else:
+        frappe.throw(_("Unsupported output file format. Supported formats are .zip, .tgz, and .tar.gz."))

--- a/suite/utils/lock.py
+++ b/suite/utils/lock.py
@@ -12,75 +12,75 @@ DEFAULT_LOCK_TIMEOUT = 120
 
 
 def acquire_lock(
-	lockname: str, acquire_timeout: int = DEFAULT_ACQUIRE_TIMEOUT, lock_timeout: int = DEFAULT_LOCK_TIMEOUT
+    lockname: str, acquire_timeout: int = DEFAULT_ACQUIRE_TIMEOUT, lock_timeout: int = DEFAULT_LOCK_TIMEOUT
 ) -> str | None:
-	"""
-	Acquire a distributed lock using Redis.
-	Returns a unique identifier for the lock if acquired, else None.
+    """
+    Acquire a distributed lock using Redis.
+    Returns a unique identifier for the lock if acquired, else None.
 
-	:param lockname: Unique lock name
-	:param acquire_timeout: How long to wait for lock (0 = no wait), default: 0
-	:param lock_timeout: TTL for lock in seconds, default: 120
-	"""
+    :param lockname: Unique lock name
+    :param acquire_timeout: How long to wait for lock (0 = no wait), default: 0
+    :param lock_timeout: TTL for lock in seconds, default: 120
+    """
 
-	if lock_timeout <= 0:
-		frappe.throw(_("Lock timeout must be greater than 0 seconds."))
+    if lock_timeout <= 0:
+        frappe.throw(_("Lock timeout must be greater than 0 seconds."))
 
-	identifier = str(uuid7())
-	lock_key = frappe.cache.make_key(f"lock:{lockname}")
+    identifier = str(uuid7())
+    lock_key = frappe.cache.make_key(f"lock:{lockname}")
 
-	if acquire_timeout == 0:
-		# nosemgrep: frappe-semgrep-rules.rules.frappe-cache-breaks-multitenancy
-		if frappe.cache.set(lock_key, identifier, ex=lock_timeout, nx=True):
-			return identifier
-		else:
-			return None
+    if acquire_timeout == 0:
+        # nosemgrep: frappe-semgrep-rules.rules.frappe-cache-breaks-multitenancy
+        if frappe.cache.set(lock_key, identifier, ex=lock_timeout, nx=True):
+            return identifier
+        else:
+            return None
 
-	end = time.time() + acquire_timeout
-	while time.time() < end:
-		# nosemgrep: frappe-semgrep-rules.rules.frappe-cache-breaks-multitenancy
-		if frappe.cache.set(lock_key, identifier, ex=lock_timeout, nx=True):
-			return identifier
-		time.sleep(0.001)
+    end = time.time() + acquire_timeout
+    while time.time() < end:
+        # nosemgrep: frappe-semgrep-rules.rules.frappe-cache-breaks-multitenancy
+        if frappe.cache.set(lock_key, identifier, ex=lock_timeout, nx=True):
+            return identifier
+        time.sleep(0.001)
 
-	return None
+    return None
 
 
 def release_lock(lockname: str, identifier: str) -> bool:
-	"""Release the lock only if it is held by the caller."""
+    """Release the lock only if it is held by the caller."""
 
-	lock_key = frappe.cache.make_key(f"lock:{lockname}")
-	pipe = frappe.cache.pipeline(True)
+    lock_key = frappe.cache.make_key(f"lock:{lockname}")
+    pipe = frappe.cache.pipeline(True)
 
-	while True:
-		try:
-			pipe.watch(lock_key)
-			value = pipe.get(lock_key)
-			if value and value.decode() == identifier:
-				pipe.multi()
-				pipe.delete(lock_key)
-				pipe.execute()
-				return True
+    while True:
+        try:
+            pipe.watch(lock_key)
+            value = pipe.get(lock_key)
+            if value and value.decode() == identifier:
+                pipe.multi()
+                pipe.delete(lock_key)
+                pipe.execute()
+                return True
 
-			pipe.unwatch()
-			break
-		except WatchError:
-			continue
+            pipe.unwatch()
+            break
+        except WatchError:
+            continue
 
-	return False
+    return False
 
 
 @contextmanager
 def write_lock(
-	lockname: str, acquire_timeout: int = DEFAULT_ACQUIRE_TIMEOUT, lock_timeout: int = DEFAULT_LOCK_TIMEOUT
+    lockname: str, acquire_timeout: int = DEFAULT_ACQUIRE_TIMEOUT, lock_timeout: int = DEFAULT_LOCK_TIMEOUT
 ) -> Generator[None, None, None]:
-	"""Context manager to acquire a distributed lock for writing."""
+    """Context manager to acquire a distributed lock for writing."""
 
-	identifier = acquire_lock(lockname, acquire_timeout=acquire_timeout, lock_timeout=lock_timeout)
-	if not identifier:
-		frappe.throw(_("Could not acquire lock: {0}").format(lockname))
+    identifier = acquire_lock(lockname, acquire_timeout=acquire_timeout, lock_timeout=lock_timeout)
+    if not identifier:
+        frappe.throw(_("Could not acquire lock: {0}").format(lockname))
 
-	try:
-		yield
-	finally:
-		release_lock(lockname, identifier)
+    try:
+        yield
+    finally:
+        release_lock(lockname, identifier)

--- a/suite/utils/lock.py
+++ b/suite/utils/lock.py
@@ -73,7 +73,7 @@ def release_lock(lockname: str, identifier: str) -> bool:
 @contextmanager
 def write_lock(
     lockname: str, acquire_timeout: int = DEFAULT_ACQUIRE_TIMEOUT, lock_timeout: int = DEFAULT_LOCK_TIMEOUT
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """Context manager to acquire a distributed lock for writing."""
 
     identifier = acquire_lock(lockname, acquire_timeout=acquire_timeout, lock_timeout=lock_timeout)

--- a/suite/utils/permissions.py
+++ b/suite/utils/permissions.py
@@ -3,27 +3,27 @@
 
 
 class OwnerFromUser:
-	"""Pin ``owner`` to the record's ``user`` field on insert.
+    """Pin ``owner`` to the record's ``user`` field on insert.
 
-	The Suite User role grants access through Frappe's ``if_owner``, which keys off the
-	standard ``owner`` (created-by) field rather than the doctype's own ``user`` field.
-	Records provisioned by an admin or a background job would otherwise be owned by
-	whoever ran the code and stay hidden from the user they belong to. Setting
-	``owner = user`` keeps ``if_owner`` aligned with the intended user regardless of who
-	actually created the record.
+    The Suite User role grants access through Frappe's ``if_owner``, which keys off the
+    standard ``owner`` (created-by) field rather than the doctype's own ``user`` field.
+    Records provisioned by an admin or a background job would otherwise be owned by
+    whoever ran the code and stay hidden from the user they belong to. Setting
+    ``owner = user`` keeps ``if_owner`` aligned with the intended user regardless of who
+    actually created the record.
 
-	Mix in *before* ``Document`` so this ``before_insert`` is picked up:
-	``class Foo(OwnerFromUser, Document): ...``
-	"""
+    Mix in *before* ``Document`` so this ``before_insert`` is picked up:
+    ``class Foo(OwnerFromUser, Document): ...``
+    """
 
-	def before_insert(self) -> None:
-		if getattr(self, "user", None):
-			self.owner = self.user
+    def before_insert(self) -> None:
+        if getattr(self, "user", None):
+            self.owner = self.user
 
-		# Cooperative multiple inheritance: forward to any before_insert further down the
-		# MRO (e.g. another mixin ordered after this one). Frappe resolves before_insert via
-		# a single getattr, so a mixin that swallows the call would silently skip the rest of
-		# the chain. Document defines none, so the call is guarded.
-		super_before_insert = getattr(super(), "before_insert", None)
-		if callable(super_before_insert):
-			super_before_insert()
+        # Cooperative multiple inheritance: forward to any before_insert further down the
+        # MRO (e.g. another mixin ordered after this one). Frappe resolves before_insert via
+        # a single getattr, so a mixin that swallows the call would silently skip the rest of
+        # the chain. Document defines none, so the call is guarded.
+        super_before_insert = getattr(super(), "before_insert", None)
+        if callable(super_before_insert):
+            super_before_insert()

--- a/suite/utils/rate_limiter.py
+++ b/suite/utils/rate_limiter.py
@@ -8,68 +8,68 @@ from suite.suite_core.doctype.rate_limit.rate_limit import get_rate_limits
 
 
 def dynamic_rate_limit() -> callable:
-	"""A decorator to apply rate limits dynamically based on the method path."""
+    """A decorator to apply rate limits dynamically based on the method path."""
 
-	def decorator(fn):
-		# Resolved once, at decoration time. Only frappe's v1 dispatcher populates form_dict.cmd;
-		# the v2 one calls the method directly, so keying off cmd alone meant every limit could be
-		# skipped by posting to /api/v2/method/... instead of /api/method/....
-		declared_method_path = f"{fn.__module__}.{fn.__qualname__}"
+    def decorator(fn):
+        # Resolved once, at decoration time. Only frappe's v1 dispatcher populates form_dict.cmd;
+        # the v2 one calls the method directly, so keying off cmd alone meant every limit could be
+        # skipped by posting to /api/v2/method/... instead of /api/method/....
+        declared_method_path = f"{fn.__module__}.{fn.__qualname__}"
 
-		@wraps(fn)
-		def wrapper(*args, **kwargs):
-			# Limits describe request traffic; an internal call is not an endpoint hit.
-			if not getattr(frappe.local, "request", None):
-				return fn(*args, **kwargs)
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            # Limits describe request traffic; an internal call is not an endpoint hit.
+            if not getattr(frappe.local, "request", None):
+                return fn(*args, **kwargs)
 
-			method_path = frappe.form_dict.cmd or declared_method_path
-			rate_limits = get_rate_limits(method_path)
-			if not rate_limits:
-				return fn(*args, **kwargs)
+            method_path = frappe.form_dict.cmd or declared_method_path
+            rate_limits = get_rate_limits(method_path)
+            if not rate_limits:
+                return fn(*args, **kwargs)
 
-			request_ip = frappe.local.request_ip
-			wrapped_fn = fn
+            request_ip = frappe.local.request_ip
+            wrapped_fn = fn
 
-			for rl in rate_limits:
-				if rl["ignore_in_developer_mode"] and frappe.conf.developer_mode:
-					continue
+            for rl in rate_limits:
+                if rl["ignore_in_developer_mode"] and frappe.conf.developer_mode:
+                    continue
 
-				# Value-scoped limits (e.g. per email priority) apply only when the
-				# request's key field matches the configured value. The counter is
-				# isolated per value via the `key` passed to `rate_limit` below.
-				if rl["value"] and frappe.form_dict.get(rl["key"]) != rl["value"]:
-					continue
+                # Value-scoped limits (e.g. per email priority) apply only when the
+                # request's key field matches the configured value. The counter is
+                # isolated per value via the `key` passed to `rate_limit` below.
+                if rl["value"] and frappe.form_dict.get(rl["key"]) != rl["value"]:
+                    continue
 
-				if request_ip:
-					if any(request_ip.startswith(prefix) for prefix in rl["allowed_ips"]):
-						continue
-					elif any(request_ip.startswith(prefix) for prefix in rl["blocked_ips"]):
-						frappe.throw(
-							_(
-								"Access denied: Your IP address ({0}) is blocked due to explicit IP restrictions."
-							).format(request_ip),
-							frappe.RateLimitExceededError,
-						)
+                if request_ip:
+                    if any(request_ip.startswith(prefix) for prefix in rl["allowed_ips"]):
+                        continue
+                    elif any(request_ip.startswith(prefix) for prefix in rl["blocked_ips"]):
+                        frappe.throw(
+                            _(
+                                "Access denied: Your IP address ({0}) is blocked due to explicit IP restrictions."
+                            ).format(request_ip),
+                            frappe.RateLimitExceededError,
+                        )
 
-				wrapped_fn = rate_limit(
-					key=rl["key"],
-					limit=rl["limit"],
-					seconds=rl["seconds"],
-					methods=rl["methods"],
-					ip_based=rl["ip_based"],
-				)(wrapped_fn)
+                wrapped_fn = rate_limit(
+                    key=rl["key"],
+                    limit=rl["limit"],
+                    seconds=rl["seconds"],
+                    methods=rl["methods"],
+                    ip_based=rl["ip_based"],
+                )(wrapped_fn)
 
-			# frappe's rate_limit builds its counter key from form_dict.cmd too, so publish the
-			# resolved path for the duration of the call - otherwise every v2 request would share
-			# a single bucket keyed on None.
-			previous_cmd = frappe.form_dict.cmd
-			frappe.form_dict.cmd = method_path
-			try:
-				return wrapped_fn(*args, **kwargs)
-			finally:
-				frappe.form_dict.cmd = previous_cmd
+            # frappe's rate_limit builds its counter key from form_dict.cmd too, so publish the
+            # resolved path for the duration of the call - otherwise every v2 request would share
+            # a single bucket keyed on None.
+            previous_cmd = frappe.form_dict.cmd
+            frappe.form_dict.cmd = method_path
+            try:
+                return wrapped_fn(*args, **kwargs)
+            finally:
+                frappe.form_dict.cmd = previous_cmd
 
-		wrapper._is_dynamic_rate_limited = True
-		return wrapper
+        wrapper._is_dynamic_rate_limited = True
+        return wrapper
 
-	return decorator
+    return decorator

--- a/suite/utils/user.py
+++ b/suite/utils/user.py
@@ -9,103 +9,103 @@ RESERVED_USERS = ("Guest", "Administrator")
 
 
 def is_administrator(user: str) -> bool:
-	"""Returns True if the user is Administrator else False."""
+    """Returns True if the user is Administrator else False."""
 
-	return user == "Administrator"
+    return user == "Administrator"
 
 
 @request_cache
 def has_role(user: str, roles: str | list) -> bool:
-	"""Returns True if the user has any of the given roles else False."""
+    """Returns True if the user has any of the given roles else False."""
 
-	if isinstance(roles, str):
-		roles = [roles]
+    if isinstance(roles, str):
+        roles = [roles]
 
-	user_roles = frappe.get_roles(user)
-	for role in roles:
-		if role in user_roles:
-			return True
+    user_roles = frappe.get_roles(user)
+    for role in roles:
+        if role in user_roles:
+            return True
 
-	return False
+    return False
 
 
 @request_cache
 def is_system_manager(user: str) -> bool:
-	"""Returns True if the user is Administrator or System Manager else False."""
+    """Returns True if the user is Administrator or System Manager else False."""
 
-	return is_administrator(user) or has_role(user, "System Manager")
+    return is_administrator(user) or has_role(user, "System Manager")
 
 
 @request_cache
 def is_suite_admin(user: str) -> bool:
-	"""Returns True if the user is a Suite Admin else False."""
+    """Returns True if the user is a Suite Admin else False."""
 
-	return has_role(user, "Suite Admin")
+    return has_role(user, "Suite Admin")
 
 
 @request_cache
 def is_suite_user(user: str) -> bool:
-	"""Returns True if the user is a Suite User else False."""
+    """Returns True if the user is a Suite User else False."""
 
-	return has_role(user, "Suite User")
+    return has_role(user, "Suite User")
 
 
 def is_user_enabled(user: str) -> bool:
-	"""Returns True if the user account is enabled else False."""
+    """Returns True if the user account is enabled else False."""
 
-	return bool(frappe.db.get_value("User", user, "enabled"))
+    return bool(frappe.db.get_value("User", user, "enabled"))
 
 
 def assign_role(user: User, role_name: str, desk_access: bool = True) -> None:
-	"""Append `role_name` to an in-memory User doc, creating the Role if missing.
+    """Append `role_name` to an in-memory User doc, creating the Role if missing.
 
-	Meant to be called from a `before_insert` hook so the role is part of the
-	document Frappe validates. Assigning roles after insert is too late for
-	`User.check_roles_added` (which warns "Newly created user X has no roles
-	enabled") and for `User.set_system_user` (which demotes a role-less user to
-	a Website User), and it costs an extra `User.save` per role.
+    Meant to be called from a `before_insert` hook so the role is part of the
+    document Frappe validates. Assigning roles after insert is too late for
+    `User.check_roles_added` (which warns "Newly created user X has no roles
+    enabled") and for `User.set_system_user` (which demotes a role-less user to
+    a Website User), and it costs an extra `User.save` per role.
 
-	When the Role does not yet exist (e.g. programmatic site setup before the
-	fixture syncs) it is created with `desk_access` so it matches its fixture.
-	Getting this wrong matters: `set_system_user` keys the new user's `user_type`
-	off whether any assigned role has desk access, so creating a desk-access role
-	without it here would silently demote the user to a Website User.
-	"""
-	# `before_insert` runs ahead of `set_new_name`, so `user.name` is still unset
-	# on a fresh User — fall back to the email it will be named after.
-	identifier = user.name or user.email
-	if not identifier or identifier in RESERVED_USERS:
-		return
+    When the Role does not yet exist (e.g. programmatic site setup before the
+    fixture syncs) it is created with `desk_access` so it matches its fixture.
+    Getting this wrong matters: `set_system_user` keys the new user's `user_type`
+    off whether any assigned role has desk access, so creating a desk-access role
+    without it here would silently demote the user to a Website User.
+    """
+    # `before_insert` runs ahead of `set_new_name`, so `user.name` is still unset
+    # on a fresh User — fall back to the email it will be named after.
+    identifier = user.name or user.email
+    if not identifier or identifier in RESERVED_USERS:
+        return
 
-	if not frappe.db.exists("Role", role_name):
-		frappe.get_doc(
-			{"doctype": "Role", "role_name": role_name, "desk_access": int(desk_access)}
-		).insert(ignore_permissions=True)
+    if not frappe.db.exists("Role", role_name):
+        frappe.get_doc({"doctype": "Role", "role_name": role_name, "desk_access": int(desk_access)}).insert(
+            ignore_permissions=True
+        )
 
-	if any(row.role == role_name for row in user.get("roles") or []):
-		return
+    if any(row.role == role_name for row in user.get("roles") or []):
+        return
 
-	user.append("roles", {"role": role_name})
+    user.append("roles", {"role": role_name})
 
 
 def assign_suite_role(user: User, method: str | None = None) -> None:
-	"""Grant the suite-wide "Suite User" role to a new User.
+    """Grant the suite-wide "Suite User" role to a new User.
 
-	Wired to the User `before_insert` hook so every new user gets suite access
-	(mail, calendar, meet, ...) before Frappe validates the document — see
-	`assign_role` for why assignment happens before insert.
-	"""
+    Wired to the User `before_insert` hook so every new user gets suite access
+    (mail, calendar, meet, ...) before Frappe validates the document — see
+    `assign_role` for why assignment happens before insert.
+    """
 
-	assign_role(user, "Suite User")
+    assign_role(user, "Suite User")
 
 
 @frappe.whitelist(methods=["POST"])
 def generate_user_keys(user: str) -> dict:
-	"""Generates API and Secret keys for the user."""
+    """Generates API and Secret keys for the user."""
 
-	session_user = frappe.session.user
-	if is_system_manager(session_user) or session_user == user:
-		with user_context("Administrator"):
-			return generate_keys(user)
+    session_user = frappe.session.user
+    if is_system_manager(session_user) or session_user == user:
+        with user_context("Administrator"):
+            return generate_keys(user)
 
-	frappe.throw(_("Not permitted"), frappe.PermissionError)
+    frappe.throw(_("Not permitted"), frappe.PermissionError)

--- a/suite/writer/api/docs.py
+++ b/suite/writer/api/docs.py
@@ -8,176 +8,176 @@ from markdown.extensions.wikilinks import WikiLinkExtension
 
 from suite.drive.api.files import get_new_title
 from suite.drive.api.permissions import (
-	get_entity_with_permissions,
-	user_has_permission,
+    get_entity_with_permissions,
+    user_has_permission,
 )
 from suite.drive.utils import (
-	create_drive_file,
-	get_user_folder,
+    create_drive_file,
+    get_user_folder,
 )
 from suite.drive.utils.files import FileManager, storage_key
 
 # To be moved to mimemapper
 QUICK_MAP = {
-	"video/quicktime": "mov",
-	"image/gif": "gif",
+    "video/quicktime": "mov",
+    "image/gif": "gif",
 }
 
 
 @frappe.whitelist()
 def create_document(title: str | None = None, parent: str | None = None, template: str | None = None):
-	parent = parent or get_user_folder().name
-	parent_doc = frappe.get_doc("File", parent)
-	if not title:
-		title = get_new_title("Untitled Document", parent)
+    parent = parent or get_user_folder().name
+    parent_doc = frappe.get_doc("File", parent)
+    if not title:
+        title = get_new_title("Untitled Document", parent)
 
-	if not user_has_permission(parent, "upload"):
-		frappe.throw(
-			"Cannot access folder due to insufficient permissions",
-			frappe.PermissionError,
-		)
+    if not user_has_permission(parent, "upload"):
+        frappe.throw(
+            "Cannot access folder due to insufficient permissions",
+            frappe.PermissionError,
+        )
 
-	writer_doc = frappe.new_doc("Writer Document")
-	writer_doc.settings = (
-		'{"collab": true}' if not template else '{"collab": true, "template": "' + template + '"}'
-	)
-	writer_doc.save()
+    writer_doc = frappe.new_doc("Writer Document")
+    writer_doc.settings = (
+        '{"collab": true}' if not template else '{"collab": true, "template": "' + template + '"}'
+    )
+    writer_doc.save()
 
-	manager = FileManager()
-	path = manager.create_folder(
-		frappe._dict(
-			{
-				"file_name": title,
-				"parent_path": Path(storage_key(parent_doc.file_url)),
-			}
-		)
-	)
-	manager.create_folder(
-		frappe._dict(
-			{
-				"file_name": ".embeds",
-				"parent_path": Path(path) if path else None,
-			}
-		)
-	)
+    manager = FileManager()
+    path = manager.create_folder(
+        frappe._dict(
+            {
+                "file_name": title,
+                "parent_path": Path(storage_key(parent_doc.file_url)),
+            }
+        )
+    )
+    manager.create_folder(
+        frappe._dict(
+            {
+                "file_name": ".embeds",
+                "parent_path": Path(path) if path else None,
+            }
+        )
+    )
 
-	entity = create_drive_file(
-		title,
-		parent,
-		"Document",
-		path,
-		mime_type="frappe_doc",
-		content_doctype="Writer Document",
-		content_docname=writer_doc.name,
-	)
-	return entity
+    entity = create_drive_file(
+        title,
+        parent,
+        "Document",
+        path,
+        mime_type="frappe_doc",
+        content_doctype="Writer Document",
+        content_docname=writer_doc.name,
+    )
+    return entity
 
 
 @frappe.whitelist(allow_guest=True)
 def get_document(file_id: str):
-	return_obj = get_entity_with_permissions(file_id)
-	entity = frappe._dict(return_obj)
+    return_obj = get_entity_with_permissions(file_id)
+    entity = frappe._dict(return_obj)
 
-	# Non-Writer-backed files (e.g. markdown) are read straight off disk.
-	if entity.content_doctype != "Writer Document":
-		return get_markdown_file(entity, return_obj)
+    # Non-Writer-backed files (e.g. markdown) are read straight off disk.
+    if entity.content_doctype != "Writer Document":
+        return get_markdown_file(entity, return_obj)
 
-	writer_doc = frappe.get_doc("Writer Document", entity.content_docname).as_dict()
-	writer_doc.pop("name")
-	writer_doc.pop("owner")
-	writer_doc.pop("versions", None)
+    writer_doc = frappe.get_doc("Writer Document", entity.content_docname).as_dict()
+    writer_doc.pop("name")
+    writer_doc.pop("owner")
+    writer_doc.pop("versions", None)
 
-	return_obj |= writer_doc | {"modified": entity.modified}
-	frappe.response["data"] = return_obj
+    return_obj |= writer_doc | {"modified": entity.modified}
+    frappe.response["data"] = return_obj
 
 
 def get_markdown_file(entity, return_obj):
-	manager = FileManager()
-	wrapper = io.TextIOWrapper(manager.get_file(entity))
-	url_builder = lambda label, base, end: f"/api/method/suite.writer.api.docs.get_wiki_link?title={label}"
-	with wrapper as r:
-		content = r.read()
-		md = markdown.Markdown(
-			extensions=["extra", "meta", WikiLinkExtension(build_url=url_builder)],
-		)
-		content = clean_content_for_obsidian(content)
-		md.set_output_format("html")
-		return_obj["file_content"] = md.convert(content)
-		return_obj["properties"] = md.Meta
+    manager = FileManager()
+    wrapper = io.TextIOWrapper(manager.get_file(entity))
+    url_builder = lambda label, base, end: f"/api/method/suite.writer.api.docs.get_wiki_link?title={label}"
+    with wrapper as r:
+        content = r.read()
+        md = markdown.Markdown(
+            extensions=["extra", "meta", WikiLinkExtension(build_url=url_builder)],
+        )
+        content = clean_content_for_obsidian(content)
+        md.set_output_format("html")
+        return_obj["file_content"] = md.convert(content)
+        return_obj["properties"] = md.Meta
 
-	frappe.response["data"] = return_obj
+    frappe.response["data"] = return_obj
 
 
 def clean_content_for_obsidian(content):
-	property_end = content[3:].find("---")
-	if content.startswith("---") and property_end != -1:
-		content = content[:property_end].replace("\n  ", " " * 4) + content[property_end:]
-	content = content[:property_end] + content[property_end:].replace("\n", "\n\n")
-	content = content[:property_end] + content[property_end:].replace("\n\n\n", "\n<p></p>")
-	return content
+    property_end = content[3:].find("---")
+    if content.startswith("---") and property_end != -1:
+        content = content[:property_end].replace("\n  ", " " * 4) + content[property_end:]
+    content = content[:property_end] + content[property_end:].replace("\n", "\n\n")
+    content = content[:property_end] + content[property_end:].replace("\n\n\n", "\n<p></p>")
+    return content
 
 
 @frappe.whitelist(allow_guest=True)
 def save_comments(doc: str, data: str):
-	file = frappe.get_doc("File", {"content_docname": doc, "content_doctype": "Writer Document"})
-	if not user_has_permission(file, "comment"):
-		frappe.throw("You cannot comment on this file.")
+    file = frappe.get_doc("File", {"content_docname": doc, "content_doctype": "Writer Document"})
+    if not user_has_permission(file, "comment"):
+        frappe.throw("You cannot comment on this file.")
 
-	frappe.get_doc("Writer Document", doc).save_comments(data, file)
+    frappe.get_doc("Writer Document", doc).save_comments(data, file)
 
 
 @frappe.whitelist()
 def get_extension(entity_name: str):
-	mime_type = frappe.get_value("File", entity_name, "mime_type")
-	try:
-		return mimemapper.get_extension(mime_type)
-	except:
-		return QUICK_MAP.get(mime_type, "")
+    mime_type = frappe.get_value("File", entity_name, "mime_type")
+    try:
+        return mimemapper.get_extension(mime_type)
+    except:
+        return QUICK_MAP.get(mime_type, "")
 
 
 @frappe.whitelist()
 def create_blog(entity_name: str, html: str, attachments: str | None = None):
-	"""
-	If the blog app is installed, creates a blog
-	"""
-	file = frappe.get_doc("File", entity_name)
-	if not user_has_permission(file, "read"):
-		frappe.throw("You don't have access to this file.", frappe.PermissionError)
-	blogger = frappe.db.exists("Blogger", {"user": frappe.session.user})
-	if not blogger:
-		frappe.throw("Please create a Blogger for your user first.")
+    """
+    If the blog app is installed, creates a blog
+    """
+    file = frappe.get_doc("File", entity_name)
+    if not user_has_permission(file, "read"):
+        frappe.throw("You don't have access to this file.", frappe.PermissionError)
+    blogger = frappe.db.exists("Blogger", {"user": frappe.session.user})
+    if not blogger:
+        frappe.throw("Please create a Blogger for your user first.")
 
-	if not frappe.db.exists("Blog Category", {"name": "writer-export"}):
-		category = frappe.get_doc({"doctype": "Blog Category", "title": "Writer Export"})
-		category.insert()
-		print("insrted", category, category.name)
-	else:
-		category = frappe.get_doc("Blog Category", "writer-export")
+    if not frappe.db.exists("Blog Category", {"name": "writer-export"}):
+        category = frappe.get_doc({"doctype": "Blog Category", "title": "Writer Export"})
+        category.insert()
+        print("insrted", category, category.name)
+    else:
+        category = frappe.get_doc("Blog Category", "writer-export")
 
-	blog = frappe.get_doc(
-		{
-			"doctype": "Blog Post",
-			"title": file.file_name,
-			"content_type": "HTML",
-			"blog_category": category.name,
-			"blogger": blogger,
-			"content_html": html,
-		}
-	)
-	blog.insert()
-	return blog.name
+    blog = frappe.get_doc(
+        {
+            "doctype": "Blog Post",
+            "title": file.file_name,
+            "content_type": "HTML",
+            "blog_category": category.name,
+            "blogger": blogger,
+            "content_html": html,
+        }
+    )
+    blog.insert()
+    return blog.name
 
 
 @frappe.whitelist(allow_guest=True)
 def get_wiki_link(title: str):
-	title = title.strip("/")
-	possible_titles = [title, title + ".md", title + ".txt"]
-	names = (frappe.get_value("File", {"file_name": k, "is_folder": 0}, "name") for k in possible_titles)
-	try:
-		name = next(k for k in names if k and user_has_permission(k, "read"))
-	except StopIteration:
-		frappe.throw("Cannot get this wikilink.", frappe.NotFound)
+    title = title.strip("/")
+    possible_titles = [title, title + ".md", title + ".txt"]
+    names = (frappe.get_value("File", {"file_name": k, "is_folder": 0}, "name") for k in possible_titles)
+    try:
+        name = next(k for k in names if k and user_has_permission(k, "read"))
+    except StopIteration:
+        frappe.throw("Cannot get this wikilink.", frappe.NotFound)
 
-	frappe.local.response["type"] = "redirect"
-	frappe.local.response["location"] = "/drive/f/" + name
-	return title
+    frappe.local.response["type"] = "redirect"
+    frappe.local.response["location"] = "/drive/f/" + name
+    return title

--- a/suite/writer/api/embed.py
+++ b/suite/writer/api/embed.py
@@ -6,19 +6,19 @@ from suite.drive.api.permissions import user_has_permission
 
 @frappe.whitelist()
 def add(file_id: str):
-	file_doc = frappe.get_doc("File", file_id)
-	file = frappe.request.files["file"]
-	file.filename = f"{file_doc.name} embed -{file.filename}"
-	embed = upload_file(parent=file_doc.name, embed=1)
-	return {"file_url": f"/api/method/suite.writer.api.embed.get?id={embed.name}"}
+    file_doc = frappe.get_doc("File", file_id)
+    file = frappe.request.files["file"]
+    file.filename = f"{file_doc.name} embed -{file.filename}"
+    embed = upload_file(parent=file_doc.name, embed=1)
+    return {"file_url": f"/api/method/suite.writer.api.embed.get?id={embed.name}"}
 
 
 @frappe.whitelist(allow_guest=True)
 def get(id: str):
-	embed = frappe.get_cached_doc("File", id)
-	parent = frappe.db.get_value("File", embed.folder, ["name", "content_docname"], as_dict=True)
-	if not parent.content_docname:
-		frappe.throw("This is not an embed", ValueError)
-	if not user_has_permission(parent.name, "read"):
-		frappe.throw("You do not have permission to view this file", frappe.PermissionError)
-	return get_file_internal(embed)
+    embed = frappe.get_cached_doc("File", id)
+    parent = frappe.db.get_value("File", embed.folder, ["name", "content_docname"], as_dict=True)
+    if not parent.content_docname:
+        frappe.throw("This is not an embed", ValueError)
+    if not user_has_permission(parent.name, "read"):
+        frappe.throw("You do not have permission to view this file", frappe.PermissionError)
+    return get_file_internal(embed)

--- a/suite/writer/api/general.py
+++ b/suite/writer/api/general.py
@@ -18,176 +18,176 @@ Binary = CustomFunction("BINARY", ["expression"])
 
 @frappe.whitelist()
 def get_document_list(
-	start: int = 0,
-	limit: int = 20,
+    start: int = 0,
+    limit: int = 20,
 ):
-	user = frappe.session.user
+    user = frappe.session.user
 
-	recently_opened = frappe.qb.from_(Recents).select(Recents.entity_name).where(Recents.user == user)
+    recently_opened = frappe.qb.from_(Recents).select(Recents.entity_name).where(Recents.user == user)
 
-	recent_field = fn.Coalesce(Recents.last_interaction, DriveFile.file_modified)
-	query = (
-		frappe.qb.from_(DriveFile)
-		.select(
-			*FILE_FIELDS,
-			DriveFile.mime_type,
-			recent_field.as_("recent"),
-		)
-		.where((DriveFile.status == STATUS_ACTIVE) & (DriveFile.mime_type == "frappe_doc"))
-		.where((DriveFile.owner == user) | (DriveFile.name.isin(recently_opened)))
-	)
+    recent_field = fn.Coalesce(Recents.last_interaction, DriveFile.file_modified)
+    query = (
+        frappe.qb.from_(DriveFile)
+        .select(
+            *FILE_FIELDS,
+            DriveFile.mime_type,
+            recent_field.as_("recent"),
+        )
+        .where((DriveFile.status == STATUS_ACTIVE) & (DriveFile.mime_type == "frappe_doc"))
+        .where((DriveFile.owner == user) | (DriveFile.name.isin(recently_opened)))
+    )
 
-	query = (
-		query.left_join(DriveFavourite)
-		.on((DriveFavourite.entity == DriveFile.name) & (DriveFavourite.user == user))
-		.select(DriveFavourite.name.as_("is_favourite"))
-	)
+    query = (
+        query.left_join(DriveFavourite)
+        .on((DriveFavourite.entity == DriveFile.name) & (DriveFavourite.user == user))
+        .select(DriveFavourite.name.as_("is_favourite"))
+    )
 
-	query = query.left_join(Recents).on(
-		(Recents.entity_name == DriveFile.name) & (Recents.user == frappe.session.user)
-	)
+    query = query.left_join(Recents).on(
+        (Recents.entity_name == DriveFile.name) & (Recents.user == frappe.session.user)
+    )
 
-	query = query.select(Recents.last_interaction.as_("accessed"))
+    query = query.select(Recents.last_interaction.as_("accessed"))
 
-	# Add ordering
-	query = query.orderby(recent_field, order=Order.desc)
-	# Fetch one extra record to check if there's a next page
-	query = query.limit(limit + 1).offset(start)
-	res = query.run(as_dict=True)
+    # Add ordering
+    query = query.orderby(recent_field, order=Order.desc)
+    # Fetch one extra record to check if there's a next page
+    query = query.limit(limit + 1).offset(start)
+    res = query.run(as_dict=True)
 
-	# Check if there's a next page
-	has_next_page = len(res) > limit
+    # Check if there's a next page
+    has_next_page = len(res) > limit
 
-	# Remove the extra record if it exists
-	if has_next_page:
-		res = res[:limit]
+    # Remove the extra record if it exists
+    if has_next_page:
+        res = res[:limit]
 
-	# Rest of your processing code
-	child_count_query = (
-		frappe.qb.from_(DriveFile)
-		.where(DriveFile.status == STATUS_ACTIVE)
-		.select(DriveFile.folder, fn.Count("*").as_("child_count"))
-		.groupby(DriveFile.folder)
-	)
-	share_query = (
-		frappe.qb.from_(DriveFile)
-		.right_join(DrivePermission)
-		.on(DrivePermission.entity == DriveFile.name)
-		.where((DrivePermission.user.notin(["", GENERAL_USER])) & (DrivePermission.deny == 0))
-		.select(DriveFile.name, fn.Count("*").as_("share_count"))
-		.groupby(DriveFile.name)
-	)
-	public_files_query = (
-		frappe.qb.from_(DrivePermission)
-		.where((DrivePermission.user == "") & (DrivePermission.deny == 0))
-		.select(DrivePermission.entity)
-	)
-	general_files_query = (
-		frappe.qb.from_(DrivePermission)
-		.where((DrivePermission.user == GENERAL_USER) & (DrivePermission.deny == 0))
-		.select(DrivePermission.entity)
-	)
-	public_files = set(k[0] for k in public_files_query.run())
-	general_files = set(k[0] for k in general_files_query.run())
+    # Rest of your processing code
+    child_count_query = (
+        frappe.qb.from_(DriveFile)
+        .where(DriveFile.status == STATUS_ACTIVE)
+        .select(DriveFile.folder, fn.Count("*").as_("child_count"))
+        .groupby(DriveFile.folder)
+    )
+    share_query = (
+        frappe.qb.from_(DriveFile)
+        .right_join(DrivePermission)
+        .on(DrivePermission.entity == DriveFile.name)
+        .where((DrivePermission.user.notin(["", GENERAL_USER])) & (DrivePermission.deny == 0))
+        .select(DriveFile.name, fn.Count("*").as_("share_count"))
+        .groupby(DriveFile.name)
+    )
+    public_files_query = (
+        frappe.qb.from_(DrivePermission)
+        .where((DrivePermission.user == "") & (DrivePermission.deny == 0))
+        .select(DrivePermission.entity)
+    )
+    general_files_query = (
+        frappe.qb.from_(DrivePermission)
+        .where((DrivePermission.user == GENERAL_USER) & (DrivePermission.deny == 0))
+        .select(DrivePermission.entity)
+    )
+    public_files = set(k[0] for k in public_files_query.run())
+    general_files = set(k[0] for k in general_files_query.run())
 
-	children_count = dict(child_count_query.run())
-	share_count = dict(share_query.run())
+    children_count = dict(child_count_query.run())
+    share_count = dict(share_query.run())
 
-	default = 0
+    default = 0
 
-	accessible = []
-	for r in res:
-		access = get_user_access(r["name"])
-		# A stale "recently opened" entry can outlive the caller's access.
-		if not access.get("read"):
-			continue
-		accessible.append(r)
-		r["children"] = children_count.get(r["name"], 0)
-		r["html"] = frappe.get_cached_value("Writer Document", r["content_docname"], "html")
-		if r["name"] in public_files:
-			r["share_count"] = -2
-		elif default > -1 and (r["name"] in general_files):
-			r["share_count"] = -1
-		elif default == 0:
-			r["share_count"] = share_count.get(r["name"], default)
-		else:
-			r["share_count"] = default
-		r |= access
+    accessible = []
+    for r in res:
+        access = get_user_access(r["name"])
+        # A stale "recently opened" entry can outlive the caller's access.
+        if not access.get("read"):
+            continue
+        accessible.append(r)
+        r["children"] = children_count.get(r["name"], 0)
+        r["html"] = frappe.get_cached_value("Writer Document", r["content_docname"], "html")
+        if r["name"] in public_files:
+            r["share_count"] = -2
+        elif default > -1 and (r["name"] in general_files):
+            r["share_count"] = -1
+        elif default == 0:
+            r["share_count"] = share_count.get(r["name"], default)
+        else:
+            r["share_count"] = default
+        r |= access
 
-	# Return in the format useList expects
-	frappe.response["data"] = accessible
-	frappe.response["has_next_page"] = has_next_page
+    # Return in the format useList expects
+    frappe.response["data"] = accessible
+    frappe.response["has_next_page"] = has_next_page
 
 
 @frappe.whitelist()
 def get_versions(id: str):
-	if not get_user_access(id).get("write"):
-		frappe.throw("You don't have write access.", frappe.PermissionError)
+    if not get_user_access(id).get("write"):
+        frappe.throw("You don't have write access.", frappe.PermissionError)
 
-	doc_name = frappe.db.get_value("File", id, "content_docname")
+    doc_name = frappe.db.get_value("File", id, "content_docname")
 
-	versions = frappe.get_all(
-		"Writer Version",
-		filters={"doc": doc_name},
-		fields=["name", "snapshot", "title", "manual", "creation"],
-		order_by="creation asc",
-	)
+    versions = frappe.get_all(
+        "Writer Version",
+        filters={"doc": doc_name},
+        fields=["name", "snapshot", "title", "manual", "creation"],
+        order_by="creation asc",
+    )
 
-	return versions
+    return versions
 
 
 @frappe.whitelist()
 def search(query: str, filters: str | None = None):
-	client = WriterSearch()
-	search = client.search(query, filters=filters)
-	metadata = get_drive_file_meta([k["name"] for k in search["results"]])
-	cleaned_results = []
-	for k in search["results"]:
-		meta = metadata.get(k["name"])
-		# The index is unscoped; only surface documents the caller can read.
-		if not meta or not get_user_access(meta["name"]).get("read"):
-			continue
-		k.update(meta)
-		cleaned_results.append(k)
-	search["results"] = cleaned_results
-	return search
+    client = WriterSearch()
+    search = client.search(query, filters=filters)
+    metadata = get_drive_file_meta([k["name"] for k in search["results"]])
+    cleaned_results = []
+    for k in search["results"]:
+        meta = metadata.get(k["name"])
+        # The index is unscoped; only surface documents the caller can read.
+        if not meta or not get_user_access(meta["name"]).get("read"):
+            continue
+        k.update(meta)
+        cleaned_results.append(k)
+    search["results"] = cleaned_results
+    return search
 
 
 def get_drive_file_meta(names, ttl=3600):
-	"""
-	Fetch {name: {title, file_id}} using Redis first, DB as fallback.
-	"""
-	if not names:
-		return {}
+    """
+    Fetch {name: {title, file_id}} using Redis first, DB as fallback.
+    """
+    if not names:
+        return {}
 
-	cache = frappe.cache()
+    cache = frappe.cache()
 
-	keys = {name: f"search:drive_file:{name}" for name in names}
-	cached = {"name": cache.get_value(k) for k in keys.values()}
+    keys = {name: f"search:drive_file:{name}" for name in names}
+    cached = {"name": cache.get_value(k) for k in keys.values()}
 
-	result = {}
-	missing = []
-	for name, key in keys.items():
-		value = cached.get(key)
-		if value:
-			result[name] = value
-		else:
-			missing.append(name)
+    result = {}
+    missing = []
+    for name, key in keys.items():
+        value = cached.get(key)
+        if value:
+            result[name] = value
+        else:
+            missing.append(name)
 
-	if missing:
-		rows = frappe.get_all(
-			"File",
-			filters={"content_docname": ["in", missing], "content_doctype": "Writer Document"},
-			fields=["name", "file_name", "content_docname"],
-		)
+    if missing:
+        rows = frappe.get_all(
+            "File",
+            filters={"content_docname": ["in", missing], "content_doctype": "Writer Document"},
+            fields=["name", "file_name", "content_docname"],
+        )
 
-		for r in rows:
-			meta = {
-				"title": r["file_name"],
-				"name": r["name"],
-			}
-			key = f"search:drive_file:{r['name']}"
-			cache.set_value(key, meta, expires_in_sec=ttl)
-			result[r["content_docname"]] = meta
+        for r in rows:
+            meta = {
+                "title": r["file_name"],
+                "name": r["name"],
+            }
+            key = f"search:drive_file:{r['name']}"
+            cache.set_value(key, meta, expires_in_sec=ttl)
+            result[r["content_docname"]] = meta
 
-	return result
+    return result

--- a/suite/writer/doctype/writer_doc_version/writer_doc_version.py
+++ b/suite/writer/doctype/writer_doc_version/writer_doc_version.py
@@ -6,4 +6,4 @@ from frappe.model.document import Document
 
 
 class WriterDocVersion(Document):
-	pass
+    pass

--- a/suite/writer/doctype/writer_document/test_writer_document.py
+++ b/suite/writer/doctype/writer_document/test_writer_document.py
@@ -4,7 +4,6 @@
 # import frappe
 from frappe.tests import IntegrationTestCase
 
-
 # On IntegrationTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
 # Use these module variables to add/remove to/from that list

--- a/suite/writer/doctype/writer_document/test_writer_document.py
+++ b/suite/writer/doctype/writer_document/test_writer_document.py
@@ -12,11 +12,10 @@ EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
-
 class IntegrationTestWriterDocument(IntegrationTestCase):
-	"""
-	Integration tests for WriterDocument.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for WriterDocument.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/writer/doctype/writer_document/writer_document.py
+++ b/suite/writer/doctype/writer_document/writer_document.py
@@ -11,151 +11,151 @@ from frappe.model.document import Document
 from suite.drive.api.notifications import create_notification, get_link
 
 COLLISION_ERRORS = (
-	frappe.exceptions.QueryDeadlockError,
-	frappe.exceptions.TimestampMismatchError,
+    frappe.exceptions.QueryDeadlockError,
+    frappe.exceptions.TimestampMismatchError,
 )
 
 AUTOVERSION_DURATION = 10
 
 
 class WriterDocument(Document):
-	@frappe.whitelist(methods=["POST"])
-	def save_doc(self, data: str, html: str | None = None):
-		self.check_permission("write")
-		try:
-			frappe.db.set_value("Writer Document", self.name, "content", data)
-			if html is not None:
-				frappe.db.set_value("Writer Document", self.name, "html", html)
-			self.update_file(file_size=len(self.content))
-		except COLLISION_ERRORS:
-			pass
+    @frappe.whitelist(methods=["POST"])
+    def save_doc(self, data: str, html: str | None = None):
+        self.check_permission("write")
+        try:
+            frappe.db.set_value("Writer Document", self.name, "content", data)
+            if html is not None:
+                frappe.db.set_value("Writer Document", self.name, "html", html)
+            self.update_file(file_size=len(self.content))
+        except COLLISION_ERRORS:
+            pass
 
-	@frappe.whitelist(methods=["POST"])
-	def new_version(self, data: str, title: str | None = None):
-		"""Create a new version of the document"""
-		self.check_permission("write")
-		if not data or not data.strip() or data.strip() == "<p></p>":
-			frappe.response["data"] = False
-			return
+    @frappe.whitelist(methods=["POST"])
+    def new_version(self, data: str, title: str | None = None):
+        """Create a new version of the document"""
+        self.check_permission("write")
+        if not data or not data.strip() or data.strip() == "<p></p>":
+            frappe.response["data"] = False
+            return
 
-		manual = bool(title)
-		if not manual:
-			now_time = frappe.utils.now_datetime()
-			last_auto_version = frappe.db.get_value(
-				"Writer Version",
-				filters={
-					"doc": self.name,
-					"manual": 0,
-				},
-				fieldname=["title", "name", "creation"],
-				order_by="creation desc",
-				as_dict=True,
-			)
+        manual = bool(title)
+        if not manual:
+            now_time = frappe.utils.now_datetime()
+            last_auto_version = frappe.db.get_value(
+                "Writer Version",
+                filters={
+                    "doc": self.name,
+                    "manual": 0,
+                },
+                fieldname=["title", "name", "creation"],
+                order_by="creation desc",
+                as_dict=True,
+            )
 
-			if last_auto_version:
-				prev_time = datetime.strptime(
-					last_auto_version.title,
-					"%Y-%m-%d %H:%M",
-				)
-				diff = now_time - prev_time
-				if diff < timedelta(minutes=AUTOVERSION_DURATION):
-					frappe.response["data"] = False
-					return
+            if last_auto_version:
+                prev_time = datetime.strptime(
+                    last_auto_version.title,
+                    "%Y-%m-%d %H:%M",
+                )
+                diff = now_time - prev_time
+                if diff < timedelta(minutes=AUTOVERSION_DURATION):
+                    frappe.response["data"] = False
+                    return
 
-			title = datetime.strftime(now_time, "%Y-%m-%d %H:%M")
+            title = datetime.strftime(now_time, "%Y-%m-%d %H:%M")
 
-		# Create a new Writer Version document
-		version = frappe.get_doc(
-			{
-				"doctype": "Writer Version",
-				"doc": self.name,
-				"snapshot": data,
-				"manual": manual,
-				"title": title,
-			}
-		)
-		version.insert()
+        # Create a new Writer Version document
+        version = frappe.get_doc(
+            {
+                "doctype": "Writer Version",
+                "doc": self.name,
+                "snapshot": data,
+                "manual": manual,
+                "title": title,
+            }
+        )
+        version.insert()
 
-		frappe.response["data"] = version.as_dict()
+        frappe.response["data"] = version.as_dict()
 
-	@frappe.whitelist(methods=["POST"])
-	def update_settings(self, data: str):
-		self.check_permission("write")
-		self.settings = data
-		self.save()
+    @frappe.whitelist(methods=["POST"])
+    def update_settings(self, data: str):
+        self.check_permission("write")
+        self.settings = data
+        self.save()
 
-	@frappe.whitelist(methods=["POST"])
-	def save_html(self, html: str):
-		self.check_permission("write")
-		self.html = html
-		self.update_file()
-		self.save()
+    @frappe.whitelist(methods=["POST"])
+    def save_html(self, html: str):
+        self.check_permission("write")
+        self.html = html
+        self.update_file()
+        self.save()
 
-	def update_file(self, **kwargs):
-		file = frappe.db.get_value(
-			"File", {"content_docname": self.name, "content_doctype": "Writer Document"}, "name"
-		)
-		doc = frappe.get_doc("File", file)
-		for k in kwargs:
-			setattr(doc, k, kwargs[k])
-		doc.file_modified = frappe.utils.now()
-		doc.save(ignore_permissions=True)
+    def update_file(self, **kwargs):
+        file = frappe.db.get_value(
+            "File", {"content_docname": self.name, "content_doctype": "Writer Document"}, "name"
+        )
+        doc = frappe.get_doc("File", file)
+        for k in kwargs:
+            setattr(doc, k, kwargs[k])
+        doc.file_modified = frappe.utils.now()
+        doc.save(ignore_permissions=True)
 
-	def save_comments(self, data, file):
-		try:
-			frappe.db.set_value("Writer Document", self.name, "ycomments", data)
+    def save_comments(self, data, file):
+        try:
+            frappe.db.set_value("Writer Document", self.name, "ycomments", data)
 
-			# Go over every comment in the YJS data and check replies for mentions
-			comments_doc = pycrdt.Doc()
-			comments_doc.apply_update(base64.b64decode(data))
-			comments_map = comments_doc.get("comments", type=pycrdt.Map)
-			for comment_id, comment_data in comments_map.items():
-				mentions = [{**k, "owner": comment_data["owner"]} for k in comment_data.get("mentions", [])]
-				for reply in comment_data["replies"]:
-					mentions.extend([{**k, "owner": reply["owner"]} for k in reply.get("mentions", [])])
-				if mentions:
-					frappe.enqueue(
-						notify_comments,
-						job_id=f"doc_comments_{self.name}_{comment_id}",
-						now=True,
-						deduplicate=True,
-						mentions=mentions,
-						file=file,
-					)
-		except COLLISION_ERRORS:
-			pass
+            # Go over every comment in the YJS data and check replies for mentions
+            comments_doc = pycrdt.Doc()
+            comments_doc.apply_update(base64.b64decode(data))
+            comments_map = comments_doc.get("comments", type=pycrdt.Map)
+            for comment_id, comment_data in comments_map.items():
+                mentions = [{**k, "owner": comment_data["owner"]} for k in comment_data.get("mentions", [])]
+                for reply in comment_data["replies"]:
+                    mentions.extend([{**k, "owner": reply["owner"]} for k in reply.get("mentions", [])])
+                if mentions:
+                    frappe.enqueue(
+                        notify_comments,
+                        job_id=f"doc_comments_{self.name}_{comment_id}",
+                        now=True,
+                        deduplicate=True,
+                        mentions=mentions,
+                        file=file,
+                    )
+        except COLLISION_ERRORS:
+            pass
 
-	def rename(self):
-		frappe.get_value({"doc": self.name}).rename()
+    def rename(self):
+        frappe.get_value({"doc": self.name}).rename()
 
-	def as_dict(self, *args, **kwargs):
-		result = super().as_dict(*args, **kwargs)
-		result.pop("versions")
-		return result
+    def as_dict(self, *args, **kwargs):
+        result = super().as_dict(*args, **kwargs)
+        result.pop("versions")
+        return result
 
 
 def notify_comments(file, mentions):
-	for mention in mentions:
-		from_owner = frappe.get_cached_value("User", mention["owner"], "full_name")
-		new_notification = create_notification(
-			mention["owner"],
-			mention["id"],
-			"Mention",
-			file,
-			f'{from_owner} mentioned you in a comment in "{file.file_name}".',
-		)
-		if new_notification:
-			try:
-				frappe.sendmail(
-					recipients=[mention["id"]],
-					subject=f"Frappe Drive - Mention in {file.file_name}",
-					template="drive_comment",
-					args={
-						"message": f"{from_owner} mentioned you in a comment.",
-						"doc": file.file_name,
-						"link": get_link(file),
-					},
-					now=True,
-				)
-			except Exception:
-				frappe.log_error(frappe.get_traceback())
+    for mention in mentions:
+        from_owner = frappe.get_cached_value("User", mention["owner"], "full_name")
+        new_notification = create_notification(
+            mention["owner"],
+            mention["id"],
+            "Mention",
+            file,
+            f'{from_owner} mentioned you in a comment in "{file.file_name}".',
+        )
+        if new_notification:
+            try:
+                frappe.sendmail(
+                    recipients=[mention["id"]],
+                    subject=f"Frappe Drive - Mention in {file.file_name}",
+                    template="drive_comment",
+                    args={
+                        "message": f"{from_owner} mentioned you in a comment.",
+                        "doc": file.file_name,
+                        "link": get_link(file),
+                    },
+                    now=True,
+                )
+            except Exception:
+                frappe.log_error(frappe.get_traceback())

--- a/suite/writer/doctype/writer_document_update/writer_document_update.py
+++ b/suite/writer/doctype/writer_document_update/writer_document_update.py
@@ -6,4 +6,4 @@ from frappe.model.document import Document
 
 
 class WriterDocumentUpdate(Document):
-	pass
+    pass

--- a/suite/writer/doctype/writer_template/test_writer_template.py
+++ b/suite/writer/doctype/writer_template/test_writer_template.py
@@ -4,7 +4,6 @@
 # import frappe
 from frappe.tests import IntegrationTestCase
 
-
 # On IntegrationTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
 # Use these module variables to add/remove to/from that list

--- a/suite/writer/doctype/writer_template/test_writer_template.py
+++ b/suite/writer/doctype/writer_template/test_writer_template.py
@@ -12,11 +12,10 @@ EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
-
 class IntegrationTestWriterTemplate(IntegrationTestCase):
-	"""
-	Integration tests for WriterTemplate.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for WriterTemplate.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/writer/doctype/writer_template/writer_template.py
+++ b/suite/writer/doctype/writer_template/writer_template.py
@@ -6,4 +6,4 @@ from frappe.model.document import Document
 
 
 class WriterTemplate(Document):
-	pass
+    pass

--- a/suite/writer/doctype/writer_version/test_writer_version.py
+++ b/suite/writer/doctype/writer_version/test_writer_version.py
@@ -4,7 +4,6 @@
 # import frappe
 from frappe.tests import IntegrationTestCase
 
-
 # On IntegrationTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
 # Use these module variables to add/remove to/from that list

--- a/suite/writer/doctype/writer_version/test_writer_version.py
+++ b/suite/writer/doctype/writer_version/test_writer_version.py
@@ -12,11 +12,10 @@ EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
-
 class IntegrationTestWriterVersion(IntegrationTestCase):
-	"""
-	Integration tests for WriterVersion.
-	Use this class for testing interactions between multiple components.
-	"""
+    """
+    Integration tests for WriterVersion.
+    Use this class for testing interactions between multiple components.
+    """
 
-	pass
+    pass

--- a/suite/writer/doctype/writer_version/writer_version.py
+++ b/suite/writer/doctype/writer_version/writer_version.py
@@ -6,4 +6,4 @@ from frappe.model.document import Document
 
 
 class WriterVersion(Document):
-	pass
+    pass

--- a/suite/writer/overrides/__init__.py
+++ b/suite/writer/overrides/__init__.py
@@ -7,52 +7,52 @@ READ_PTYPES = frozenset({"read", "report", "export", "email", "print", "select"}
 
 
 def filter_templates(user):
-	# Templates are site-wide readable; guests get nothing.
-	if (user or frappe.session.user) == "Guest":
-		return "1=0"
-	return ""
+    # Templates are site-wide readable; guests get nothing.
+    if (user or frappe.session.user) == "Guest":
+        return "1=0"
+    return ""
 
 
 def template_has_permission(doc, ptype="read", user=None):
-	user = user or frappe.session.user
-	if ptype == "create" or user == "Administrator":
-		return True
-	if ptype in READ_PTYPES:
-		return user != "Guest"
-	return doc.get("owner") == user
+    user = user or frappe.session.user
+    if ptype == "create" or user == "Administrator":
+        return True
+    if ptype in READ_PTYPES:
+        return user != "Guest"
+    return doc.get("owner") == user
 
 
 def document_query_conditions(user):
-	"""`permission_query_conditions` for Writer Document — delegate to the
-	content SDK so list views can't enumerate documents the caller can't read."""
-	return content_query_conditions("Writer Document", user)
+    """`permission_query_conditions` for Writer Document — delegate to the
+    content SDK so list views can't enumerate documents the caller can't read."""
+    return content_query_conditions("Writer Document", user)
 
 
 def version_has_permission(doc, ptype="read", user=None):
-	"""A Writer Version is readable/writable iff the backing Drive File of its
-	parent document is."""
-	user = user or frappe.session.user
-	if user == "Administrator":
-		return True
-	parent = doc.get("doc")
-	if not parent:
-		return False
-	file = File.get_for_doc("Writer Document", parent)
-	if not file:
-		return False
-	return bool(user_has_permission(file, "read" if ptype in READ_PTYPES else "write", user))
+    """A Writer Version is readable/writable iff the backing Drive File of its
+    parent document is."""
+    user = user or frappe.session.user
+    if user == "Administrator":
+        return True
+    parent = doc.get("doc")
+    if not parent:
+        return False
+    file = File.get_for_doc("Writer Document", parent)
+    if not file:
+        return False
+    return bool(user_has_permission(file, "read" if ptype in READ_PTYPES else "write", user))
 
 
 def version_query_conditions(user):
-	"""`permission_query_conditions` for Writer Version — scope rows to versions
-	whose parent document the caller can read (owned or directly shared)."""
-	if user == "Administrator":
-		return ""
-	doc_predicate = content_query_conditions("Writer Document", user)
-	if not doc_predicate:
-		return ""
-	return (
-		"`tabWriter Version`.doc IN ("
-		"SELECT `tabWriter Document`.name FROM `tabWriter Document` "
-		f"WHERE {doc_predicate})"
-	)
+    """`permission_query_conditions` for Writer Version — scope rows to versions
+    whose parent document the caller can read (owned or directly shared)."""
+    if user == "Administrator":
+        return ""
+    doc_predicate = content_query_conditions("Writer Document", user)
+    if not doc_predicate:
+        return ""
+    return (
+        "`tabWriter Version`.doc IN ("
+        "SELECT `tabWriter Document`.name FROM `tabWriter Document` "
+        f"WHERE {doc_predicate})"
+    )

--- a/suite/writer/overrides/migrate_from_drive.py
+++ b/suite/writer/overrides/migrate_from_drive.py
@@ -1,7 +1,8 @@
-import frappe
-import json
-from pycrdt import Doc, Map
 import base64
+import json
+
+import frappe
+from pycrdt import Doc, Map
 
 ACCEPTED_SETTINGS = [
     "minimal",

--- a/suite/writer/patches/remove_frappe_writer_module.py
+++ b/suite/writer/patches/remove_frappe_writer_module.py
@@ -2,4 +2,4 @@ import frappe
 
 
 def execute() -> None:
-	frappe.db.delete("Module Def", {"name": "Frappe Writer", "app_name": "suite"})
+    frappe.db.delete("Module Def", {"name": "Frappe Writer", "app_name": "suite"})

--- a/suite/writer/search.py
+++ b/suite/writer/search.py
@@ -1,6 +1,6 @@
+import frappe
 from frappe.search.sqlite_search import SQLiteSearch
 from frappe.utils import cstr
-import frappe
 
 
 class WriterSearch(SQLiteSearch):

--- a/suite/writer/www/writer.py
+++ b/suite/writer/www/writer.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import frappe
 
 from suite.drive.api.permissions import user_has_permission

--- a/suite/writer/www/writer.py
+++ b/suite/writer/www/writer.py
@@ -28,9 +28,7 @@ def get_context():
             file = frappe.get_cached_doc("File", parts[1])
             if user_has_permission(file, "read"):
                 context.title = file.file_name
-                context.description = "By " + frappe.get_cached_value(
-                    "User", file.owner, "full_name"
-                )
+                context.description = "By " + frappe.get_cached_value("User", file.owner, "full_name")
         except:
             pass
 

--- a/suite/www/event_rsvp.py
+++ b/suite/www/event_rsvp.py
@@ -20,17 +20,17 @@ AUTO_CLOSE_SECONDS = 10
 
 
 def get_context(context):
-	token = frappe.form_dict.get("token")
-	if token:
-		result = resolve_rsvp(token)
-	else:
-		result = {
-			"success": False,
-			"title": _("Invalid Link"),
-			"message": _("This response link is invalid or has expired."),
-		}
+    token = frappe.form_dict.get("token")
+    if token:
+        result = resolve_rsvp(token)
+    else:
+        result = {
+            "success": False,
+            "title": _("Invalid Link"),
+            "message": _("This response link is invalid or has expired."),
+        }
 
-	context.no_cache = 1
-	context.update(result)
-	context.auto_close_seconds = AUTO_CLOSE_SECONDS
-	return context
+    context.no_cache = 1
+    context.update(result)
+    context.auto_close_seconds = AUTO_CLOSE_SECONDS
+    return context

--- a/suite/www/suite.py
+++ b/suite/www/suite.py
@@ -8,45 +8,45 @@ no_cache = 1
 
 
 def get_context(context):
-	"""Boot context for the unified Suite SPA.
+    """Boot context for the unified Suite SPA.
 
-	Serves every former-app prefix (/suite, /drive, /slides, /sheets, /writer,
-	/mail, /meet, /calendar) via website_route_rules -> this page. The Vite-built
-	bundle is loaded by www/suite.html (regenerated on `bench build`); Vue Router
-	dispatches to the right module client-side.
-	"""
-	csrf_token = frappe.sessions.get_csrf_token()
-	frappe.db.commit()
+    Serves every former-app prefix (/suite, /drive, /slides, /sheets, /writer,
+    /mail, /meet, /calendar) via website_route_rules -> this page. The Vite-built
+    bundle is loaded by www/suite.html (regenerated on `bench build`); Vue Router
+    dispatches to the right module client-side.
+    """
+    csrf_token = frappe.sessions.get_csrf_token()
+    frappe.db.commit()
 
-	context.boot = get_boot()
-	context.boot.csrf_token = csrf_token
-	context.csrf_token = csrf_token
-	context.desk_theme = get_desk_theme()
-	context.title = "Frappe Suite"
-	return context
+    context.boot = get_boot()
+    context.boot.csrf_token = csrf_token
+    context.csrf_token = csrf_token
+    context.desk_theme = get_desk_theme()
+    context.title = "Frappe Suite"
+    return context
 
 
 def get_desk_theme():
-	if frappe.session.user == "Guest":
-		return "Light"
-	return frappe.get_cached_value("User", frappe.session.user, "desk_theme") or "Light"
+    if frappe.session.user == "Guest":
+        return "Light"
+    return frappe.get_cached_value("User", frappe.session.user, "desk_theme") or "Light"
 
 
 def get_boot():
-	sentry_dsn = None
-	if frappe.get_system_settings("enable_telemetry"):
-		sentry_dsn = os.getenv("SUITE_FRONTEND_SENTRY_DSN")
+    sentry_dsn = None
+    if frappe.get_system_settings("enable_telemetry"):
+        sentry_dsn = os.getenv("SUITE_FRONTEND_SENTRY_DSN")
 
-	return frappe._dict(
-		{
-			"site_name": frappe.local.site,
-			"socketio_port": frappe.conf.get("socketio_port") or 9000,
-			"sentry_dsn": sentry_dsn,
-			"sentry_environment": "development" if frappe.conf.developer_mode else "production",
-			"sentry_release": f"suite@{__version__}",
-			# Surfaced on window.push_relay_server_url for mail's FCM push setup
-			# (frappe-push-notification.ts / PWASettings.vue). Mirrors the old
-			# standalone www/mail.py boot, which the suite shell replaced.
-			"push_relay_server_url": frappe.conf.get("push_relay_server_url") or "",
-		}
-	)
+    return frappe._dict(
+        {
+            "site_name": frappe.local.site,
+            "socketio_port": frappe.conf.get("socketio_port") or 9000,
+            "sentry_dsn": sentry_dsn,
+            "sentry_environment": "development" if frappe.conf.developer_mode else "production",
+            "sentry_release": f"suite@{__version__}",
+            # Surfaced on window.push_relay_server_url for mail's FCM push setup
+            # (frappe-push-notification.ts / PWASettings.vue). Mirrors the old
+            # standalone www/mail.py boot, which the suite shell replaced.
+            "push_relay_server_url": frappe.conf.get("push_relay_server_url") or "",
+        }
+    )


### PR DESCRIPTION
`.pre-commit-config.yaml` landed in [#16](https://github.com/frappe/suite/pull/16) but the existing tree was never brought into line with it, and nothing enforces it, so 83 of 513 Python files stayed unformatted and touching any of them dragged an unrelated reformat into the diff.

This switches ruff to space indentation, formats the whole tree with the pinned `ruff 0.12.3`, applies the 94 lint fixes ruff can make safely, and adds a `ruff format --check` job to CI so it cannot drift again.