### PR TITLE
feat(mail): upcoming events in the sidebar, with the event detail panel in place

### DIFF
--- a/frontend/src/apps/calendar/components/EventDetailSidebar.vue
+++ b/frontend/src/apps/calendar/components/EventDetailSidebar.vue
@@ -412,24 +412,29 @@ const openUrl = (location: string) => {
 			</div>
 		</div>
 
-		<div class="flex min-h-0 flex-1 flex-col overflow-y-auto">
-			<!-- Title and time. No top padding — the header's centering slack is the
-			     gap above the title; pb balances it below the date and keeps
-			     breathing room when a long title wraps (the block just grows).
-			     Single-line, the block sums to ~49px, so header (48) + block +
-			     divider match the mail header bar + screener banner (49px each)
-			     and the divider lands on the banner's border when mail hosts the
-			     panel. -->
+		<!-- -mt-2 eats the header's centering slack so the visual gap above the
+		     title (which also includes the header text's own centering slack and
+		     the title's half-leading) matches the pb below the date; it sits on
+		     the scroll wrapper because a negative margin on the first child of an
+		     overflow-y-auto box would only clip. -->
+		<div class="-mt-2 flex min-h-0 flex-1 flex-col overflow-y-auto">
+			<!-- Title and time. No top padding — what's left of the header's
+			     centering slack is the gap above the title; pb balances it below
+			     the date and keeps breathing room when a long title wraps (the
+			     block just grows). Single-line, -mt + block sum to 49px, so
+			     header (48) + block + divider match the mail header bar +
+			     screener banner (49px each) and the divider lands on the
+			     banner's border when mail hosts the panel. -->
 			<div class="flex flex-col px-4.5 pb-3">
-				<!-- Whole-pixel leadings: text-lg/text-sm's 1.15 line-height yields
-				     18.4px + 14.95px, drifting the block to 49.35px and the divider
-				     a rounded pixel below the mail banner's line. 18 + 4 + 15 + 12
-				     sums to exactly 49. -->
-				<div class="min-w-0 space-y-1">
-					<h3 class="text-ink-gray-8 break-words text-lg font-semibold leading-[18px]">
+				<!-- leading-6 keeps wrapped titles readable while leaving the
+				     title–date gap clearly wider than the title's own line gap; the
+				     date keeps text-sm's default 1.15 line-height (14.95px), so
+				     -8 + 24 + 6 + 14.95 + 12 sums to 49 within a subpixel. -->
+				<div class="min-w-0 space-y-1.5">
+					<h3 class="text-ink-gray-8 break-words text-lg font-semibold leading-6">
 						{{ calendarEvent.title || __('Untitled event') }}
 					</h3>
-					<div class="text-ink-gray-6 break-words text-sm leading-[15px]">
+					<div class="text-ink-gray-6 break-words text-sm">
 						{{ dateLabel }}
 					</div>
 				</div>
@@ -524,9 +529,11 @@ const openUrl = (location: string) => {
 
 			<div class="border-t" />
 
-			<!-- Participants: pb-4 mirrors the header row's own py-2 stacked on the
-			     section's pt-2, so the section is visually padded evenly. -->
-			<div class="flex flex-col gap-1.5 pb-4 pt-2">
+			<!-- Participants: the section's own y padding matches the header row's
+			     py-2, so it reads as evenly spaced. Counting the row's padding
+			     towards the top instead left the section 8px/16px — the row's
+			     padding belongs to the row, not to the section. -->
+			<div class="flex flex-col py-2">
 				<div class="flex items-center gap-2.5 px-4.5 py-2">
 					<Users class="icon text-ink-gray-5 size-4 shrink-0" />
 					<div class="text-ink-gray-7 min-w-0 flex-1 truncate text-sm">
@@ -549,7 +556,7 @@ const openUrl = (location: string) => {
 				<!-- Indented to the header row's text axis (gutter + icon + gap): the
 				     list is the "2 people" line's expansion, so they read as one
 				     block with the icon hanging in the gutter. -->
-				<div class="space-y-3 pl-11 pr-4.5">
+				<div class="space-y-3 py-2 pl-11 pr-4.5">
 					<EventParticipantList
 						:participants="visibleParticipants"
 						:dont-show-remove="true"

--- a/frontend/src/apps/calendar/components/EventDetailSidebar.vue
+++ b/frontend/src/apps/calendar/components/EventDetailSidebar.vue
@@ -29,7 +29,7 @@ import LinkifiedText from '@/components/LinkifiedText.vue'
 
 const { calendarEvent } = defineProps<{ calendarEvent: any }>()
 
-const emit = defineEmits(['close', 'edit', 'reloadEvents'])
+const emit = defineEmits(['close', 'edit', 'reloadEvents', 'emailParticipants'])
 
 const dayjs = inject('$dayjs')
 
@@ -39,7 +39,7 @@ const { identities } = store
 // --- User / RSVP ---
 
 const userParticipant = computed(() =>
-	calendarEvent.participants.find((p) => identities.data.some((id) => id.email === p.email)),
+	calendarEvent.participants.find((p) => identities.data?.some((id) => id.email === p.email)),
 )
 const userResponse = computed(() => userParticipant.value?.participation_status)
 
@@ -60,6 +60,25 @@ const handleSetResponse = (response: string) => {
 		error: __('Action failed. Please try again in some time.'),
 	})
 }
+
+// --- Calendar (colour + account) ---
+
+const DEFAULT_EVENT_COLOR = '#30a66d'
+
+const eventCalendar = computed(
+	() => calendarEvent.calendars?.find((c: any) => c.color) ?? calendarEvent.calendars?.[0],
+)
+
+// The organizer beats the viewer's own address (redundant in their own panel);
+// for self-organized events they coincide. Fall back to the account's address
+// (from identities — the calendar id only carries an opaque JMAP account id),
+// then the calendar's display name.
+const calendarOwnerLabel = computed(
+	() =>
+		calendarEvent.organizer?.replace('mailto:', '') ||
+		identities.data?.[0]?.email ||
+		eventCalendar.value?.calendar_name,
+)
 
 // --- Date / time label ---
 
@@ -96,11 +115,11 @@ const responseSummary = computed(() => {
 	const count = (status: string) =>
 		calendarEvent.participants.filter((p) => p.participation_status === status).length
 
+	// No "awaiting": with the total right next to it, pending = total − responses.
 	const parts = [
 		count('ACCEPTED') && __('{0} yes', [count('ACCEPTED')]),
 		count('DECLINED') && __('{0} no', [count('DECLINED')]),
 		count('TENTATIVE') && __('{0} maybe', [count('TENTATIVE')]),
-		count('NEEDS-ACTION') && __('{0} awaiting', [count('NEEDS-ACTION')]),
 	].filter(Boolean)
 
 	return parts.join(', ')
@@ -130,12 +149,13 @@ const visibleParticipants = computed(() =>
 		: orderedParticipants.value.slice(0, VISIBLE_PARTICIPANT_COUNT),
 )
 
-const mailParticipantsUrl = computed(() => {
-	const emails = calendarEvent.participants
+// Everyone except the viewer; the host decides what "email them" means (mail
+// opens its compose window, the calendar app falls back to mailto).
+const participantEmails = computed(() =>
+	calendarEvent.participants
 		.map((p) => p.email)
-		.filter((email) => identities.data.every((id) => id.email !== email))
-	return emails.length ? `mailto:${emails.join(',')}` : ''
-})
+		.filter((email) => email && identities.data?.every((id) => id.email !== email)),
+)
 
 // --- Alerts ---
 
@@ -227,8 +247,11 @@ const joinMeet = () => {
 // --- Actions dropdown (delete) ---
 
 const dropdownOptions = computed(() => {
+	const editOption = { label: __('Edit'), icon: SquarePen, onClick: () => emit('edit') }
+
 	if (calendarEvent.recurrence_id)
 		return [
+			editOption,
 			{
 				label: __('Delete'),
 				icon: Trash2,
@@ -242,7 +265,10 @@ const dropdownOptions = computed(() => {
 				],
 			},
 		]
-	return [{ label: __('Delete'), icon: Trash2, onClick: () => handleDeleteEvent() }]
+	return [
+		editOption,
+		{ label: __('Delete'), icon: Trash2, onClick: () => handleDeleteEvent() },
+	]
 })
 
 // --- Server calls ---
@@ -269,7 +295,7 @@ const isOrganizer = computed(
 )
 const hasParticipantsOtherThanUser = computed(
 	() =>
-		calendarEvent.participants?.some((p) => identities.data.every((i) => i.email !== p.email)) ??
+		calendarEvent.participants?.some((p) => identities.data?.every((i) => i.email !== p.email)) ??
 		false,
 )
 
@@ -358,48 +384,53 @@ const openUrl = (location: string) => {
 		class="bg-surface-white flex h-full w-[352px] shrink-0 flex-col overflow-hidden border-l text-left"
 	>
 		<!-- Header -->
-		<div class="flex items-center gap-3 px-[18px] py-[13px]">
-			<h2 class="text-ink-gray-7 flex-1 truncate text-base font-medium">
-				{{ __('Event detail') }}
-			</h2>
+		<!-- h-12 matches the mail header bar's 48px, so when mail hosts this panel
+		     the two headers read as one row. Instead of a static title, it names
+		     the calendar the event belongs to: its colour dot + the organizer. -->
+		<div class="flex h-12 items-center gap-3 px-4.5">
+			<div class="flex min-w-0 flex-1 items-center gap-2">
+				<span
+					class="size-2.5 shrink-0 rounded-full"
+					:style="{ backgroundColor: eventCalendar?.color || DEFAULT_EVENT_COLOR }"
+				/>
+				<span class="text-ink-gray-6 truncate text-sm">
+					{{ calendarOwnerLabel }}
+				</span>
+			</div>
 			<div class="flex items-center gap-1">
-				<Button variant="ghost" :tooltip="__('Edit')" @click="emit('edit')">
-					<SquarePen class="icon text-ink-gray-7 size-4" />
-				</Button>
 				<Dropdown :options="dropdownOptions">
 					<Button
 						variant="ghost"
 						:disabled="deleteEventInstance.loading || deleteEvent.loading"
 					>
-						<MoreHorizontal class="icon text-ink-gray-7 size-4" />
+						<MoreHorizontal class="icon text-ink-gray-7" />
 					</Button>
 				</Dropdown>
 				<Button variant="ghost" :tooltip="__('Close')" @click="emit('close')">
-					<X class="icon text-ink-gray-7 size-4" />
+					<X class="icon text-ink-gray-7" />
 				</Button>
 			</div>
 		</div>
 
 		<div class="flex min-h-0 flex-1 flex-col overflow-y-auto">
-			<!-- Title and time -->
-			<div class="flex gap-2 px-[18px] pb-3 pt-1">
-				<span class="flex h-[21px] shrink-0 items-center">
-					<span class="size-2.5 rounded-full bg-blue-500" />
-				</span>
-				<div class="min-w-0 space-y-0.5">
-					<h3
-						class="text-ink-gray-8 break-words text-lg font-semibold"
-						:class="{ italic: !calendarEvent.title }"
-					>
-						{{ calendarEvent.title || __('[No title]') }}
+			<!-- Title and time. No top padding — the header's centering slack is the
+			     gap above the title; pb balances it below the date and keeps
+			     breathing room when a long title wraps (the block just grows).
+			     Single-line, the block sums to ~49px, so header (48) + block +
+			     divider match the mail header bar + screener banner (49px each)
+			     and the divider lands on the banner's border when mail hosts the
+			     panel. -->
+			<div class="flex flex-col px-4.5 pb-3">
+				<!-- Whole-pixel leadings: text-lg/text-sm's 1.15 line-height yields
+				     18.4px + 14.95px, drifting the block to 49.35px and the divider
+				     a rounded pixel below the mail banner's line. 18 + 4 + 15 + 12
+				     sums to exactly 49. -->
+				<div class="min-w-0 space-y-1">
+					<h3 class="text-ink-gray-8 break-words text-lg font-semibold leading-[18px]">
+						{{ calendarEvent.title || __('Untitled event') }}
 					</h3>
-					<div class="text-ink-gray-6 break-words text-sm">{{ dateLabel }}</div>
-					<div
-						v-if="calendarEvent.recurrence_id"
-						class="text-ink-gray-5 flex items-center gap-1.5 text-sm"
-					>
-						<Repeat class="icon size-3.5 shrink-0" />
-						{{ getRepeatMessage(calendarEvent.recurrence_rule) }}
+					<div class="text-ink-gray-6 break-words text-sm leading-[15px]">
+						{{ dateLabel }}
 					</div>
 				</div>
 			</div>
@@ -408,9 +439,20 @@ const openUrl = (location: string) => {
 
 			<!-- Details -->
 			<div class="flex flex-col py-2">
+				<!-- Recurrence -->
+				<div
+					v-if="calendarEvent.recurrence_id"
+					class="flex items-center gap-2.5 px-4.5 py-2"
+				>
+					<Repeat class="icon text-ink-gray-5 size-4 shrink-0" />
+					<span class="text-ink-gray-7 min-w-0 break-words text-sm">
+						{{ getRepeatMessage(calendarEvent.recurrence_rule) }}
+					</span>
+				</div>
+
 				<!-- Meet link -->
 				<template v-if="meetUrl">
-					<div class="flex items-center gap-2.5 px-[18px] py-[7px]">
+					<div class="flex items-center gap-2.5 px-4.5 py-2">
 						<img :src="meetLogo" :alt="__('Frappe Meet')" class="size-7 shrink-0" />
 						<div class="min-w-0 flex-1">
 							<div class="text-ink-gray-8 text-sm font-medium">
@@ -426,7 +468,7 @@ const openUrl = (location: string) => {
 							<Copy class="icon size-4" />
 						</button>
 					</div>
-					<div class="px-[18px] py-[7px]">
+					<div class="px-4.5 py-2">
 						<button
 							class="bg-surface-gray-2 hover:bg-surface-gray-3 text-ink-gray-7 flex w-full items-center justify-center gap-2 rounded py-1.5 text-sm"
 							@click="joinMeet"
@@ -440,7 +482,7 @@ const openUrl = (location: string) => {
 				<div
 					v-for="location in calendarEvent.locations"
 					:key="location.uid"
-					class="flex items-center gap-2.5 px-[18px] py-[7px]"
+					class="flex items-center gap-2.5 px-4.5 py-2"
 				>
 					<component
 						:is="isUrl(location._name) ? Globe : MapPin"
@@ -459,7 +501,7 @@ const openUrl = (location: string) => {
 				<div
 					v-for="(alert, i) in calendarEvent.alerts"
 					:key="i"
-					class="flex items-center gap-2.5 px-[18px] py-[7px]"
+					class="flex items-center gap-2.5 px-4.5 py-2"
 				>
 					<Bell class="icon text-ink-gray-5 size-4 shrink-0" />
 					<span class="text-ink-gray-7 min-w-0 break-words text-sm">
@@ -468,13 +510,13 @@ const openUrl = (location: string) => {
 				</div>
 
 				<!-- Availability -->
-				<div v-if="calendarEvent.free_busy_status" class="flex items-center gap-2.5 px-[18px] py-[7px]">
+				<div v-if="calendarEvent.free_busy_status" class="flex items-center gap-2.5 px-4.5 py-2">
 					<Briefcase class="icon text-ink-gray-5 size-4 shrink-0" />
 					<span class="text-ink-gray-7 text-sm">{{ __(calendarEvent.free_busy_status) }}</span>
 				</div>
 
 				<!-- Visibility -->
-				<div v-if="calendarEvent.privacy" class="flex items-center gap-2.5 px-[18px] py-[7px]">
+				<div v-if="calendarEvent.privacy" class="flex items-center gap-2.5 px-4.5 py-2">
 					<Lock class="icon text-ink-gray-5 size-4 shrink-0" />
 					<span class="text-ink-gray-7 text-sm">{{ __(calendarEvent.privacy) }}</span>
 				</div>
@@ -482,26 +524,32 @@ const openUrl = (location: string) => {
 
 			<div class="border-t" />
 
-			<!-- Participants -->
-			<div class="flex flex-col gap-3 py-2">
-				<div class="flex items-start gap-2.5 px-[18px] py-[7px]">
-					<Users class="icon text-ink-gray-5 mt-0.5 size-4 shrink-0" />
-					<div class="min-w-0 flex-1 space-y-0.5">
-						<div class="text-ink-gray-7 text-sm">{{ participantSummary }}</div>
-						<div v-if="responseSummary" class="text-ink-gray-6 text-sm">
-							{{ responseSummary }}
-						</div>
+			<!-- Participants: pb-4 mirrors the header row's own py-2 stacked on the
+			     section's pt-2, so the section is visually padded evenly. -->
+			<div class="flex flex-col gap-1.5 pb-4 pt-2">
+				<div class="flex items-center gap-2.5 px-4.5 py-2">
+					<Users class="icon text-ink-gray-5 size-4 shrink-0" />
+					<div class="text-ink-gray-7 min-w-0 flex-1 truncate text-sm">
+						{{ participantSummary
+						}}<span v-if="responseSummary" class="text-ink-gray-6">
+							({{ responseSummary }})</span
+						>
 					</div>
-					<a
-						v-if="mailParticipantsUrl"
-						:href="mailParticipantsUrl"
-						class="text-ink-gray-5 hover:text-ink-gray-7 shrink-0 pt-0.5"
-						:title="__('Email participants')"
+					<!-- -my keeps the 28px ghost button from inflating the row. -->
+					<Button
+						v-if="participantEmails.length"
+						variant="ghost"
+						class="-my-1.5 shrink-0"
+						:tooltip="__('Email participants')"
+						@click="emit('emailParticipants', participantEmails)"
 					>
-						<Mail class="icon size-4" />
-					</a>
+						<Mail class="icon text-ink-gray-7 size-4" />
+					</Button>
 				</div>
-				<div class="space-y-3 px-[18px]">
+				<!-- Indented to the header row's text axis (gutter + icon + gap): the
+				     list is the "2 people" line's expansion, so they read as one
+				     block with the icon hanging in the gutter. -->
+				<div class="space-y-3 pl-11 pr-4.5">
 					<EventParticipantList
 						:participants="visibleParticipants"
 						:dont-show-remove="true"
@@ -520,13 +568,11 @@ const openUrl = (location: string) => {
 			<template v-if="calendarEvent.description">
 				<div class="border-t" />
 
-				<!-- Description -->
-				<div class="flex flex-col py-2">
-					<div class="flex items-center gap-2.5 px-[18px] py-[7px]">
-						<Text class="icon text-ink-gray-5 size-4 shrink-0" />
-						<span class="text-ink-gray-7 text-sm">{{ __('Description') }}</span>
-					</div>
-					<div class="text-ink-gray-7 min-w-0 px-[18px] py-[7px] text-sm leading-normal">
+				<!-- Description: no label — the icon in the gutter with the body on
+				     the text axis says it, like the panel's other icon rows. -->
+				<div class="flex items-start gap-2.5 px-4.5 py-4">
+					<Text class="icon text-ink-gray-5 mt-0.5 size-4 shrink-0" />
+					<div class="text-ink-gray-7 min-w-0 flex-1 text-sm leading-normal">
 						<div
 							v-if="isHtmlDescription"
 							class="break-words [&_a]:text-ink-blue-6 [&_a]:hover:underline [&_p]:m-0"
@@ -539,7 +585,7 @@ const openUrl = (location: string) => {
 		</div>
 
 		<!-- RSVP -->
-		<div v-if="userParticipant?.expect_reply" class="flex flex-col gap-2 px-[18px] pb-3 pt-2">
+		<div v-if="userParticipant?.expect_reply" class="flex flex-col gap-2 px-4.5 pb-3 pt-2">
 			<span class="text-ink-gray-6 text-sm">{{ __('Going?') }}</span>
 			<TabButtons
 				class="w-full [&>div>[data-slot=tab-button]]:flex-1 [&>div]:w-full [&_[data-slot=tab-button]>span]:w-full"

--- a/frontend/src/apps/calendar/components/EventParticipantList.vue
+++ b/frontend/src/apps/calendar/components/EventParticipantList.vue
@@ -17,8 +17,8 @@ const { identities } = userStore()
 
 const organizer = computed(() => participants.find((p) => p.isOrganizer)?.email)
 
-const isUserOrganizer = computed(() =>
-	identities.data.some((id) => id.email === organizer.value?.replace('mailto:', '')),
+const isUserOrganizer = computed(
+	() => identities.data?.some((id) => id.email === organizer.value?.replace('mailto:', '')) ?? false,
 )
 
 const showRemoveParticipant = (participant: any) =>

--- a/frontend/src/apps/calendar/components/EventParticipantList.vue
+++ b/frontend/src/apps/calendar/components/EventParticipantList.vue
@@ -40,6 +40,8 @@ const getParticipantStatusValues = (status: string) => {
 						<span class="text-ink-gray-8 text-sm-medium">
 							{{ extractNameFromEmail(p._name || p.email) }}
 						</span>
+						<!-- Same ink as the email below it: both are secondary to the name, and
+						     size + position already tell them apart. -->
 						<span v-if="p.email === organizer" class="text-ink-gray-5 text-xs">
 							({{ __('Organizer') }})
 						</span>
@@ -57,7 +59,7 @@ const getParticipantStatusValues = (status: string) => {
 							/>
 						</div>
 					</div>
-					<span class="text-ink-gray-6 text-sm">{{ p.email }}</span>
+					<span class="text-ink-gray-5 text-sm">{{ p.email }}</span>
 				</div>
 			</div>
 

--- a/frontend/src/apps/calendar/pages/CalendarLayout.vue
+++ b/frontend/src/apps/calendar/pages/CalendarLayout.vue
@@ -96,4 +96,13 @@ const updateColorScheme = createResource({
 body.calendar-app .icon {
 	stroke-width: 1.5;
 }
+
+/* Icons imported straight from lucide-vue-next ship stroke-width 2, and menu
+   item icons (frappe-ui Dropdown/Menu) render without the `.icon` class — so
+   default every lucide svg to 1.5, mirroring the mail layout. :where() keeps
+   the rule at zero specificity so an explicit stroke-* utility still wins.
+   Covers teleported menus/dialogs too. */
+:where(body.calendar-app svg.lucide) {
+	stroke-width: 1.5;
+}
 </style>

--- a/frontend/src/apps/calendar/pages/CalendarView.vue
+++ b/frontend/src/apps/calendar/pages/CalendarView.vue
@@ -65,8 +65,10 @@ const setRoute = () => {
 	const name = routeNameForView(view)
 	const accountId = route.params.accountId
 
-	if (dayjs().isSame(target, view)) router.replace({ name, params: { accountId } })
-	else router.push({ name, params: { accountId, year, month: month + 1, day } })
+	// Query carries the open event's deep link; date/view navigation keeps it.
+	if (dayjs().isSame(target, view))
+		router.replace({ name, params: { accountId }, query: route.query })
+	else router.push({ name, params: { accountId, year, month: month + 1, day }, query: route.query })
 }
 
 onMounted(() => {
@@ -95,6 +97,12 @@ const transformEvent = (event) => {
 
 	return {
 		...event,
+		// The calendar pills render `title` verbatim (frappe-ui hardcodes an italic
+		// '[No title]' fallback), so untitled events get their placeholder here.
+		// actualTitle keeps the raw value; every path that writes back to the
+		// server must restore it (withActualTitle) or the placeholder gets saved.
+		title: event.title || __('Untitled event'),
+		actualTitle: event.title,
 		fromDate: start.format('YYYY-MM-DD'),
 		toDate: end.format('YYYY-MM-DD'),
 		fromTime: start.format('HH:mm'),
@@ -156,38 +164,104 @@ const showEditEvent = ref(false)
 
 const event = reactive({})
 
+const withActualTitle = (event) => ({ ...event, title: event.actualTitle })
+
 const handleOpenEvent = (e) => {
-	Object.assign(event, e)
+	Object.assign(event, e, e.calendarEvent && { calendarEvent: withActualTitle(e.calendarEvent) })
 	showEditEvent.value = true
+
+	// Editing an existing event is addressable: ?event=<id>&edit=1 (never for
+	// new-event drafts, which have no id and no restorable form state).
+	const opened = e.calendarEvent
+	if (opened?.id && (route.query.edit !== '1' || route.query.event !== opened.id))
+		router.replace({
+			query: {
+				...route.query,
+				event: opened.id,
+				recurrence: opened.recurrence_id || undefined,
+				edit: '1',
+			},
+		})
 }
 
 // --- Event detail sidebar ---
 
 const selectedCalendarEvent = ref(null)
 
-const handleEventClick = ({ calendarEvent }) => (selectedCalendarEvent.value = calendarEvent)
+// The open event lives in the URL (?event=<id>, plus &recurrence=<id> for a
+// recurring instance): clicking a pill writes it, closing clears it, and the
+// selection is DERIVED from it below — so event links are shareable, survive
+// reload, and back/forward toggles the panel. Deriving from events.data also
+// keeps the sidebar in sync after edits/RSVPs (fresh copy swapped in, closed
+// while the event is deleted or outside the fetched range).
+const handleEventClick = ({ calendarEvent }) =>
+	router.replace({
+		query: {
+			...route.query,
+			event: calendarEvent.id,
+			recurrence: calendarEvent.recurrence_id || undefined,
+		},
+	})
 
-// Keep the sidebar in sync after edits/RSVPs: once events reload, swap in the
-// fresh copy of the selected event, or close the sidebar if it no longer exists
-// (deleted, or outside the fetched range after navigation).
+const closeEventDetail = () => {
+	const { event: _event, recurrence: _recurrence, ...query } = route.query
+	router.replace({ query })
+}
+
+// The calendar app has no compose surface of its own — hand over to mail's
+// compose window via its deep link (mailto: would depend on the OS having a
+// mail handler; the suite IS the mail client). Path, not route name: mail's
+// routes register lazily on first navigation into /mail.
+const emailParticipants = (emails: string[]) => {
+	router.push({ path: '/mail', query: { compose: '1', to: emails.join(',') } })
+}
+
 watch(
-	() => events.data,
-	(data) => {
-		if (!selectedCalendarEvent.value || !data) return
+	[() => events.data, () => route.query.event, () => route.query.recurrence],
+	([data, id, recurrence]) => {
+		if (!id) {
+			selectedCalendarEvent.value = null
+			return
+		}
 		selectedCalendarEvent.value =
-			data.find(
-				(e) =>
-					e.id === selectedCalendarEvent.value.id &&
-					e.recurrence_id === selectedCalendarEvent.value.recurrence_id,
+			data?.find(
+				(e) => e.id === id && (e.recurrence_id ?? '') === ((recurrence as string) ?? ''),
 			) ?? null
 	},
+	{ immediate: true },
 )
 
 watch(
 	() => showEditEvent.value,
 	(val) => {
-		if (!val) Object.keys(event).forEach((key) => delete event[key])
+		if (val) return
+		Object.keys(event).forEach((key) => delete event[key])
+		// Closing the modal drops only `edit` — the detail sidebar (?event=) stays.
+		if (route.query.edit) {
+			const { edit: _edit, ...query } = route.query
+			router.replace({ query })
+		}
 	},
+)
+
+// Restore the edit modal from ?edit=1 (reload, shared link), and close it when
+// back/forward removes the param. Guards: never touch an already-open modal
+// (events reloading in the background must not stomp form state), and never
+// close a NEW-event draft (those carry no calendarEvent and own no query).
+watch(
+	[() => events.data, () => route.query.event, () => route.query.recurrence, () => route.query.edit],
+	([data, id, recurrence, edit]) => {
+		if (!edit || !id) {
+			if (showEditEvent.value && event.calendarEvent) showEditEvent.value = false
+			return
+		}
+		if (showEditEvent.value) return
+		const match = data?.find(
+			(e) => e.id === id && (e.recurrence_id ?? '') === ((recurrence as string) ?? ''),
+		)
+		if (match) handleOpenEvent({ calendarEvent: match })
+	},
+	{ immediate: true },
 )
 
 const eventToBeUpdated = reactive({})
@@ -196,7 +270,7 @@ const isUpdateInstance = ref(false)
 const showNotifyModal = ref(false)
 
 const handleUpdate = (e) => {
-	Object.assign(eventToBeUpdated, e)
+	Object.assign(eventToBeUpdated, withActualTitle(e))
 	if (e.recurrence_id) showRecurringEventModal.value = true
 	else handleUpdateEvent()
 }
@@ -291,9 +365,10 @@ const NOTIFY_MODAL_OPTIONS = {
 				v-if="selectedCalendarEvent"
 				:key="selectedCalendarEvent.id + (selectedCalendarEvent.recurrence_id ?? '')"
 				:calendar-event="selectedCalendarEvent"
-				@close="selectedCalendarEvent = null"
+				@close="closeEventDetail"
 				@edit="handleOpenEvent({ calendarEvent: selectedCalendarEvent })"
 				@reload-events="events.reload()"
+				@email-participants="emailParticipants"
 			/>
 		</div>
 	</div>

--- a/frontend/src/apps/calendar/router.ts
+++ b/frontend/src/apps/calendar/router.ts
@@ -48,8 +48,9 @@ function installCalendarGuard(r: Router) {
 		store.resolveAccount(user?.accounts, to.params.accountId as string | undefined)
 		const accountId = store.accountId
 
-		// Expand shortcut routes to their full account-scoped equivalents.
-		if (to.meta.shortcut) return resolveShortcut(to.name, to.params, accountId)
+		// Expand shortcut routes to their full account-scoped equivalents. The
+		// query rides along — it carries the open event's deep link (?event=).
+		if (to.meta.shortcut) return { ...resolveShortcut(to.name, to.params, accountId), query: to.query }
 	})
 }
 

--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -529,7 +529,7 @@ const sidebarItems = computed(() => {
 	const groups = [
 		{ label: __('Default'), items: defaultItems },
 		{ label: __('Custom'), items: customItems },
-		{ label: __('People'), items: contactsItems },
+		{ label: __('People'), items: contactsItems, collapsible: true },
 	]
 
 	// All Inboxes and Screener share one nameless group pinned above the folders, so they sit at

--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -21,7 +21,11 @@
 			:disable-collapse="isMobile"
 		>
 			<template #footer-items>
-				<!-- Personal mailbox quota is meaningless while administering the server. -->
+				<!-- Personal widgets (events, quota) are meaningless while administering the server. -->
+				<UpcomingEvents
+					v-if="user.data.is_jmap_configured && !route.meta.isDashboard"
+					:is-collapsed="isSidebarCollapsed"
+				/>
 				<QuotaBar
 					v-if="user.data.is_jmap_configured && !route.meta.isDashboard"
 					:is-collapsed="isSidebarCollapsed"
@@ -107,6 +111,7 @@ import SettingsModal from '@/apps/mail/components/Modals/SettingsModal.vue'
 import ShortcutsModal from '@/apps/mail/components/Modals/ShortcutsModal.vue'
 import PWASettings from '@/apps/mail/components/PWASettings.vue'
 import QuotaBar from '@/apps/mail/components/QuotaBar.vue'
+import UpcomingEvents from '@/apps/mail/components/UpcomingEvents.vue'
 
 import type { MailboxData } from '@/apps/mail/types'
 

--- a/frontend/src/apps/mail/components/DefaultLayout.vue
+++ b/frontend/src/apps/mail/components/DefaultLayout.vue
@@ -15,18 +15,91 @@
 				<div id="scrollContainer" class="w-full overflow-auto max-sm:flex max-sm:flex-col max-sm:overflow-hidden">
 					<slot />
 				</div>
+				<!-- Detail view for an event picked in the sidebar's Upcoming events
+				     widget — the calendar app's own component, hosted here so the
+				     event opens without leaving mail. Desktop only; mobile navigates
+				     to the calendar instead. -->
+				<EventDetailSidebar
+					v-if="selectedEvent && !isMobile"
+					:key="selectedEvent.id + (selectedEvent.recurrence_id ?? '')"
+					:calendar-event="selectedEvent"
+					@close="selectedEvent = null"
+					@edit="openEventInCalendar"
+					@reload-events="events.reload()"
+					@email-participants="emailParticipants"
+				/>
+				<!-- Compose prefilled with the event's participants; keyed so each
+				     open starts a fresh draft rather than resuming the last one. -->
+				<SendMail v-model="showCompose" :key="composeKey" :mail-details="composeDetails" />
 			</div>
 		</div>
 		<MobileTabBar v-if="isMobile" />
 	</div>
 </template>
 <script setup lang="ts">
+import { provide, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import dayjs from '@/apps/calendar/utils/dayjs'
+import EventDetailSidebar from '@/apps/calendar/components/EventDetailSidebar.vue'
+import { eventDayRoute, useUpcomingEvents } from '@/apps/mail/composables/useUpcomingEvents'
 import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import AppSidebar from '@/apps/mail/components/AppSidebar.vue'
 import MobileTabBar from '@/apps/mail/components/mobile/MobileTabBar.vue'
+import SendMail from '@/apps/mail/components/SendMail.vue'
 
-const { userResource } = userStore()
+import type { ComposeMailData } from '@/apps/mail/types'
+
+const store = userStore()
+const { userResource } = store
 
 const { isMobile } = useScreenSize()
+
+const router = useRouter()
+const { events, selectedEvent } = useUpcomingEvents()
+
+// EventDetailSidebar is a calendar component and expects the calendar layout's
+// $dayjs injection (the instance with duration/tz/utc plugins installed).
+provide('$dayjs', dayjs)
+
+// Full editing (participants, recurrence) lives in the calendar app's modal;
+// hand over via the deep link (?event=<id>&edit=1) so the modal is already
+// open on arrival. Clear the selection so the sidebar isn't still open when
+// the user comes back to mail.
+const openEventInCalendar = () => {
+	const target = eventDayRoute(selectedEvent.value, store.accountId)
+	selectedEvent.value = null
+	router.push({ ...target, query: { ...target.query, edit: '1' } })
+}
+
+// The panel's "email participants" opens mail's own compose window (the
+// calendar app host falls back to mailto).
+const showCompose = ref(false)
+const composeKey = ref(0)
+const composeDetails = ref<ComposeMailData>()
+
+const emailParticipants = (emails: string[]) => {
+	composeDetails.value = { to: emails.map((email) => ({ email })) }
+	composeKey.value++
+	showCompose.value = true
+}
+
+// Compose deep link (?compose=1&to=a,b): how other apps (calendar's "email
+// participants") open mail's compose window. Consumed on arrival — the query
+// is cleared so reload/back don't reopen the draft.
+const route = useRoute()
+watch(
+	() => route.query.compose,
+	(compose) => {
+		if (!compose) return
+		const to = String(route.query.to || '')
+			.split(',')
+			.filter(Boolean)
+		emailParticipants(to)
+		const { compose: _compose, to: _to, ...query } = route.query
+		router.replace({ query })
+	},
+	{ immediate: true },
+)
 </script>

--- a/frontend/src/apps/mail/components/ThreadPane.vue
+++ b/frontend/src/apps/mail/components/ThreadPane.vue
@@ -1,9 +1,21 @@
 <template>
-	<!-- The list column. With Split View on it takes a third of the row and the pane the rest;
-	     otherwise it fills the width and the pane overlays it (or, on mobile, slides in over it). -->
+	<!-- The list column. With Split View on it's a share of the VIEWPORT (vw, not
+	     a fraction of the row: the viewport doesn't change when something else
+	     joins the row, so opening e.g. the event detail sidebar squeezes only
+	     the thread pane) and the pane takes the rest; otherwise it fills the
+	     width and the pane overlays it (or, on mobile, slides in over it). The
+	     min-w floor keeps the list usable on cramped windows; past it the
+	     thread pane shrinks to its own floor, then the row scrolls. -->
+	<!-- border-r only in Split View: full-width mode has nothing of its own to
+	     the right, and anything that does sit there (the event detail sidebar)
+	     brings its own border-l — keeping both would double the hairline. -->
 	<div
-		class="sticky top-16 flex flex-col border-r"
-		:class="!isMobile && showReadingPane ? 'w-1/3' : 'w-full'"
+		class="sticky top-16 flex flex-col"
+		:class="
+			!isMobile && showReadingPane
+				? 'w-[28vw] min-w-64 shrink-0 border-r lg:min-w-80'
+				: 'w-full'
+		"
 	>
 		<slot name="list" />
 	</div>
@@ -21,7 +33,7 @@
 			class="bg-surface-base"
 			:class="{
 				'overflow-hidden': isMobile,
-				'w-2/3': !isMobile && showReadingPane,
+				'min-w-56 flex-1 lg:min-w-64': !isMobile && showReadingPane,
 				'absolute bottom-0 left-0 right-0 top-0': !isMobile && !showReadingPane,
 				'fixed inset-0 z-20 pt-[env(safe-area-inset-top)] transition-[transform,visibility] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]':
 					isMobile,

--- a/frontend/src/apps/mail/components/UpcomingEvents.vue
+++ b/frontend/src/apps/mail/components/UpcomingEvents.vue
@@ -1,0 +1,124 @@
+<template>
+	<!-- Variant B of the Sidebar Events design doc: flat two-line rows at nav
+	     rhythm — no card chrome, surface-gray-2 hover like every other row, and
+	     the row whose detail panel is open gets the active-nav-item treatment.
+	     No horizontal padding: the sidebar body already provides it (p-2), so the
+	     label's own px-2 lands on the same 16px inset as the nav group labels.
+	     Stays mounted while the sidebar collapses, fading like frappe-ui's own
+	     sidebar labels do (they animate w-0/opacity-0; height is our axis). -->
+	<div
+		v-if="upcoming.length"
+		class="flex flex-col transition-all duration-300 ease-in-out"
+		:class="isCollapsed ? 'max-h-0 overflow-hidden py-0 opacity-0' : 'max-h-96 py-2 opacity-100'"
+	>
+		<!-- Mirrors the section labels and unread suffixes of the sidebar's nav groups. -->
+		<div class="flex items-center justify-between px-2 py-1.5">
+			<span class="truncate text-sm text-ink-gray-5">{{ __('Upcoming events') }}</span>
+			<span class="shrink-0 text-sm text-ink-gray-4">{{ upcoming.length }}</span>
+		</div>
+		<!-- Four rows tall, then scrolls. -mx/px (and -mb/pb at scroll end) keep
+		     the clip edge off the active row's shadow, same trick as the sidebar
+		     body. -->
+		<div class="-mx-1 -mb-1 flex max-h-49 flex-col gap-1.5 overflow-y-auto px-1 pb-1">
+			<button
+				v-for="event in upcoming"
+				:key="event.id + (event.recurrence_id ?? '')"
+				type="button"
+				class="bg-surface-elevation-3 flex w-full items-center gap-2.5 rounded px-2 py-1.5 text-left transition-shadow"
+				:class="isOpen(event) && 'shadow-sm ring-1 ring-outline-gray-2'"
+				@click="handleClick(event)"
+			>
+				<div
+					class="w-0.5 shrink-0 self-stretch rounded-full"
+					:style="{ backgroundColor: eventColor(event) }"
+				/>
+				<div class="min-w-0 flex-1">
+					<div class="truncate text-xs text-ink-gray-5">{{ formatEventTime(event) }}</div>
+					<div
+						class="mt-0.5 truncate text-sm"
+						:class="event.title ? 'text-ink-gray-8' : 'text-ink-gray-4'"
+					>
+						{{ event.title || __('Untitled event') }}
+					</div>
+				</div>
+			</button>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useNow } from '@vueuse/core'
+
+import dayjs from '@/apps/calendar/utils/dayjs'
+import { eventDayRoute, useUpcomingEvents } from '@/apps/mail/composables/useUpcomingEvents'
+import { userStore } from '@/apps/mail/stores/user'
+import { useScreenSize } from '@/apps/mail/utils/composables'
+
+const { isCollapsed } = defineProps<{ isCollapsed: boolean }>()
+
+// frappe-ui's calendar renders events without a color as green; falling back to
+// the same hex keeps the strip consistent with the calendar app.
+const DEFAULT_EVENT_COLOR = '#30a66d'
+
+const router = useRouter()
+const store = userStore()
+const { isMobile } = useScreenSize()
+const { events, selectedEvent, openEvent } = useUpcomingEvents()
+const now = useNow({ interval: 30_000 })
+
+const upcoming = computed(() => {
+	const currentTime = dayjs(now.value)
+	return [...(events.data || [])]
+		.filter((event: any) => {
+			if (event.status === 'Cancelled') return false
+			const start = dayjs(event.start)
+			const end = start.add(dayjs.duration(event.duration || 'PT0S'))
+			return end.isAfter(currentTime)
+		})
+		.sort((left: any, right: any) => dayjs(left.start).valueOf() - dayjs(right.start).valueOf())
+})
+
+// The row whose detail panel is open renders like the active nav tab.
+const isOpen = (event: any) =>
+	!!selectedEvent.value &&
+	selectedEvent.value.id === event.id &&
+	selectedEvent.value.recurrence_id === event.recurrence_id
+
+// Events carry the color of the calendars they belong to; the first one paints
+// the strip, matching what other clients do for multi-calendar events.
+const eventColor = (event: any) =>
+	event.calendars?.find((c: any) => c.color)?.color || DEFAULT_EVENT_COLOR
+
+const isAllDayEvent = (event: any) => {
+	const start = dayjs(event.start)
+	const duration = dayjs.duration(event.duration || 'PT0S')
+	return (
+		event.show_without_time ||
+		(start.hour() === 0 &&
+			start.minute() === 0 &&
+			start.second() === 0 &&
+			duration.asDays() >= 1 &&
+			duration.asDays() % 1 === 0)
+	)
+}
+
+const formatEventTime = (event: any) => {
+	if (isAllDayEvent(event)) return __('All day')
+
+	const start = dayjs(event.start)
+	const end = start.add(dayjs.duration(event.duration || 'PT0S'))
+	const sameMeridiem = start.format('A') === end.format('A')
+	return `${start.format(sameMeridiem ? 'h:mm' : 'h:mm A')} – ${end.format('h:mm A')}`
+}
+
+// Desktop toggles the event detail sidebar in place (hosted by DefaultLayout);
+// mobile has no room for it, so it falls back to the calendar app's day view.
+const handleClick = (event: any) => {
+	if (isMobile.value) router.push(eventDayRoute(event, store.accountId))
+	else if (isOpen(event)) selectedEvent.value = null
+	else openEvent(event)
+}
+
+</script>

--- a/frontend/src/apps/mail/components/UpcomingEvents.vue
+++ b/frontend/src/apps/mail/components/UpcomingEvents.vue
@@ -19,13 +19,17 @@
 		<!-- Four rows tall, then scrolls. -mx/px (and -mb/pb at scroll end) keep
 		     the clip edge off the active row's shadow, same trick as the sidebar
 		     body. -->
-		<div class="-mx-1 -mb-1 flex max-h-49 flex-col gap-1.5 overflow-y-auto px-1 pb-1">
+		<div class="-mx-1 -mb-1 flex max-h-49 flex-col gap-1 overflow-y-auto px-1 pb-1">
 			<button
 				v-for="event in upcoming"
 				:key="event.id + (event.recurrence_id ?? '')"
 				type="button"
-				class="bg-surface-elevation-3 flex w-full items-center gap-2.5 rounded px-2 py-1.5 text-left transition-shadow"
-				:class="isOpen(event) && 'shadow-sm ring-1 ring-outline-gray-2'"
+				class="flex w-full items-center gap-2.5 rounded px-2 py-1.5 text-left transition-shadow"
+				:class="
+					isOpen(event)
+						? 'bg-surface-elevation-3 shadow-sm ring-1 ring-outline-gray-2'
+						: 'hover:bg-surface-gray-2'
+				"
 				@click="handleClick(event)"
 			>
 				<div

--- a/frontend/src/apps/mail/composables/useUpcomingEvents.ts
+++ b/frontend/src/apps/mail/composables/useUpcomingEvents.ts
@@ -1,0 +1,91 @@
+import { effectScope, ref, watch } from 'vue'
+import { createResource } from 'frappe-ui'
+
+import dayjs from '@/apps/calendar/utils/dayjs'
+import { userStore as calendarUserStore } from '@/apps/calendar/stores/user'
+import { userStore } from '@/apps/mail/stores/user'
+
+// Module singletons: the sidebar widget renders the list while DefaultLayout
+// hosts the detail sidebar, so both need the same resource and selection.
+const selectedEvent = ref<any>(null)
+let events: any = null
+
+const timezone = () => dayjs.tz?.guess?.() || Intl.DateTimeFormat().resolvedOptions().timeZone
+
+// The detail sidebar's "delete following instances" path reads `date` (the
+// clicked instance's day, attached by the calendar grid in the calendar app);
+// derive it from the instance start here.
+const withInstanceDate = (event: any) => ({
+	...event,
+	date: dayjs(event.start).format('YYYY-MM-DD'),
+})
+
+const openEvent = (event: any) => (selectedEvent.value = withInstanceDate(event))
+
+export function useUpcomingEvents() {
+	if (!events) {
+		// Detached scope: the resource and watchers must outlive whichever
+		// component happened to touch the composable first.
+		effectScope(true).run(() => {
+			const store = userStore()
+
+			events = createResource({
+				url: 'suite.calendar.api.get_calendar_events',
+				makeParams: () => ({
+					account: store.accountId,
+					from_date: dayjs().startOf('day').format('YYYY-MM-DD[T]HH:mm:ss'),
+					to_date: dayjs().endOf('day').format('YYYY-MM-DD[T]HH:mm:ss'),
+					time_zone: timezone(),
+				}),
+			})
+
+			// The layout's setup can run before the user resource has resolved an
+			// account, so fetch on accountId becoming available, not on creation.
+			watch(
+				() => store.accountId,
+				(id) => {
+					selectedEvent.value = null
+					if (id) events.reload()
+				},
+				{ immediate: true },
+			)
+
+			// The detail sidebar reads RSVP identity from the calendar app's user
+			// store; initialize it on first open rather than on every mail load.
+			watch(selectedEvent, (event) => event && calendarUserStore())
+
+			// Keep the detail sidebar in sync after edits/RSVPs (mirrors
+			// CalendarView): swap in the fresh copy of the selected event, or close
+			// it if the event no longer exists.
+			watch(
+				() => events.data,
+				(data) => {
+					if (!selectedEvent.value || !data) return
+					const fresh = data.find(
+						(e: any) =>
+							e.id === selectedEvent.value.id &&
+							e.recurrence_id === selectedEvent.value.recurrence_id,
+					)
+					selectedEvent.value = fresh ? withInstanceDate(fresh) : null
+				},
+			)
+		})
+	}
+
+	return { events, selectedEvent, openEvent }
+}
+
+// Day view of the calendar app on the event's start date (1-indexed month),
+// deep-linked to the event itself (?event=) so its detail sidebar opens on
+// arrival. Callers can layer `edit: '1'` onto the query for the edit modal.
+// By PATH, not route name: the suite router registers each app's routes
+// lazily on the first navigation into its prefix, so a named push from mail
+// finds no match until the calendar has been visited — and silently no-ops.
+export const eventDayRoute = (event: any, accountId: string) => {
+	const start = dayjs(event.start)
+	const day = `${start.year()}/${start.month() + 1}/${start.date()}`
+	return {
+		path: `/calendar/account/${encodeURIComponent(accountId)}/day/${day}`,
+		query: { event: event.id, recurrence: event.recurrence_id || undefined },
+	}
+}

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -51,8 +51,8 @@
 		class="relative flex max-sm:min-h-0 max-sm:flex-1 max-sm:!h-auto"
 		:class="
 			showDeleteBanner || showScreenerBanner
-				? 'h-[calc(100dvh-6.1rem)]'
-				: 'h-[calc(100dvh-3.05rem)]'
+				? 'h-[calc(100dvh-6.125rem)]'
+				: 'h-[calc(100dvh-3.0625rem)]'
 		"
 	>
 		<!-- Loading -->

--- a/frontend/src/apps/mail/router.ts
+++ b/frontend/src/apps/mail/router.ts
@@ -113,8 +113,10 @@ function installMailGuard(r: Router) {
 			if (!mailboxExists) return defaultRoute
 		}
 
-		// Expand shortcut routes to their full account-scoped equivalents.
-		if (to.meta.shortcut) return resolveShortcut(to.name, to.params, accountId, defaultRoute)
+		// Expand shortcut routes to their full account-scoped equivalents. The
+		// query rides along — it can carry a compose deep link (?compose=1&to=).
+		if (to.meta.shortcut)
+			return { ...resolveShortcut(to.name, to.params, accountId, defaultRoute), query: to.query }
 
 		// Login pages redirect already-authenticated users to their mailbox.
 		if (to.meta.isLogin) return defaultRoute

--- a/suite/calendar/doctype/calendar_event/calendar_event.py
+++ b/suite/calendar/doctype/calendar_event/calendar_event.py
@@ -439,7 +439,7 @@ def get_calendar_events(account: str, ids: list[str]) -> list[dict]:
 	"""Returns a list of calendar events for the specified account and IDs."""
 
 	service = get_calendar_event_service(account)
-	calendar_map = {c["id"]: c["name"] for c in service.calendars}
+	calendar_map = {c["id"]: c for c in service.calendars}
 
 	events = {}
 	for event in service.get(ids):
@@ -629,11 +629,13 @@ def format_calendar_event(account: str, calendar_map: dict, event: dict) -> dict
 
 	calendars = []
 	for calendar_id in event["calendarIds"].keys():
+		calendar = calendar_map.get(calendar_id) or {}
 		calendars.append(
 			{
 				"calendar": f"{account}|{calendar_id}",
 				"calendar_id": calendar_id,
-				"calendar_name": calendar_map.get(calendar_id),
+				"calendar_name": calendar.get("name"),
+				"color": calendar.get("color"),
 			}
 		)
 


### PR DESCRIPTION
Today's remaining events in the mail sidebar, with the calendar's event detail panel opening in place.

- **Upcoming events widget** in the sidebar footer: flat rows with each calendar's colour strip (plumbed through `format_calendar_event` — it never reached the frontend before), live count, drops events as they end, scrolls past four.
- **Event detail panel in mail**: click a row to open the calendar's `EventDetailSidebar` beside the thread pane (click again to close). RSVP/join/delete work in place; Edit lands directly in the calendar's modal; the mail button opens compose prefilled with participants.
- **Events are addressable in the calendar**: `?event=<id>` (+`&edit=1` for the modal) on the date routes — shareable links, reload-safe, back/forward peels modal → panel. `/mail?compose=1&to=…` is the matching compose deep link.
- **Panel revamp**: header names the calendar (colour dot + organizer), Edit in the overflow menu, one-line participant summary, hanging-icon description, "Untitled event" instead of italic *[No title]* (also in grid pills, with a guard so drag-updates never persist the placeholder).
- **Split view geometry**: the list is now a steady share of the viewport, so opening the panel squeezes only the thread pane; smaller floors below `lg` fit portrait tablets. Plus a fractional-height scroll fix and a lucide stroke-width consistency fix.

| Widget (light) | Widget (dark) |
| --- | --- |
| ![widget light](https://raw.githubusercontent.com/krantheman/suite/screenshots/upcoming-events/widget-light.png) | ![widget dark](https://raw.githubusercontent.com/krantheman/suite/screenshots/upcoming-events/widget-dark.png) |

| Event panel | Participants |
| --- | --- |
| ![event panel](https://raw.githubusercontent.com/krantheman/suite/screenshots/upcoming-events/event-panel.png) | ![participants](https://raw.githubusercontent.com/krantheman/suite/screenshots/upcoming-events/participants.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
