### PR TITLE
fix: repair annotations broken by the ruff autofix

### DIFF
--- a/suite/mail/ansible.py
+++ b/suite/mail/ansible.py
@@ -126,7 +126,7 @@ class Ansible:
 
         return plays[0]
 
-    def run(self, quiet: bool = True) -> ServerAnsiblePlay:
+    def run(self, quiet: bool = True) -> "ServerAnsiblePlay":  # noqa: UP037
         """Run the playbook using ansible-runner and track its progress."""
 
         server = frappe.get_doc("Mail Server", self.server)

--- a/suite/mail/api/inbound.py
+++ b/suite/mail/api/inbound.py
@@ -1,6 +1,5 @@
 import base64
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
 
 import frappe
 from frappe import _
@@ -8,16 +7,16 @@ from frappe.utils import cint, convert_utc_to_system_timezone, create_batch, now
 
 from suite.mail.api.auth import validate_user
 from suite.mail.doctype.mail_message.mail_message import fetch_blobs, fetch_messages
-from suite.mail.doctype.mail_sync_history.mail_sync_history import get_mail_sync_history
+from suite.mail.doctype.mail_sync_history.mail_sync_history import (
+    MailSyncHistory,
+    get_mail_sync_history,
+)
 from suite.mail.doctype.user_account.user_account import get_user_personal_jmap_account
 from suite.mail.jmap import get_mailbox_id_by_role
 from suite.mail.utils import get_config
 from suite.mail.utils.logger import get_inbound_logger
 from suite.utils.dt import convert_to_utc
 from suite.utils.rate_limiter import dynamic_rate_limit
-
-if TYPE_CHECKING:
-    from suite.mail.doctype.mail_sync_history.mail_sync_history import MailSyncHistory
 
 
 @frappe.whitelist(methods=["GET"])

--- a/suite/mail/doctype/jmap_account/jmap_account.py
+++ b/suite/mail/doctype/jmap_account/jmap_account.py
@@ -76,7 +76,7 @@ class JMAPAccount(Document):
         return self.flags.get("user") or frappe.session.user
 
     @property
-    def core_service(self) -> CoreService | None:
+    def core_service(self) -> "CoreService | None":  # noqa: UP037
         """Return the JMAP core service for the account, or None if there is an error."""
 
         if self.flags.in_delete or not self.name:

--- a/suite/mail/jmap/services/push_subscription.py
+++ b/suite/mail/jmap/services/push_subscription.py
@@ -1,9 +1,7 @@
-from typing import TYPE_CHECKING, ClassVar
+from typing import ClassVar
 
+from suite.mail.jmap.connection import JMAPConnection
 from suite.mail.jmap.services.core import CoreService
-
-if TYPE_CHECKING:
-    from suite.mail.jmap.connection import JMAPConnection
 
 
 class PushSubscriptionService(CoreService):

--- a/suite/mail/utils/email_parser.py
+++ b/suite/mail/utils/email_parser.py
@@ -1,17 +1,14 @@
 import re
 from email import message_from_string, policy
 from email.header import decode_header, make_header
+from email.message import Message
 from email.utils import parseaddr
-from typing import TYPE_CHECKING
 from urllib.parse import unquote
 
 from frappe.utils import cint, get_datetime_str
 from frappe.utils.file_manager import save_file
 
 from suite.mail.utils.dt import parsedate_to_datetime
-
-if TYPE_CHECKING:
-    from email.message import Message
 
 
 class EmailParser:

--- a/suite/meet/api/meeting.py
+++ b/suite/meet/api/meeting.py
@@ -5,13 +5,13 @@ import base64
 import binascii
 import secrets
 import time
-from typing import TYPE_CHECKING
 
 import frappe
 import jwt
 from frappe import _
 from frappe.rate_limiter import rate_limit
 
+from suite.meet.doctype.meet_room.meet_room import MeetRoom
 from suite.meet.utils.sfu_config import get_sfu_config
 from suite.meet.utils.user import (
     get_guest_session,
@@ -19,9 +19,6 @@ from suite.meet.utils.user import (
     set_guest_session,
     validate_guest_name,
 )
-
-if TYPE_CHECKING:
-    from suite.meet.doctype.meet_room.meet_room import MeetRoom
 
 
 def _generate_sfu_token(

--- a/suite/sheets/tests/test_boot.py
+++ b/suite/sheets/tests/test_boot.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import unittest
 from unittest import mock
 
+# Eagerly imported so `mock.patch` can resolve the attribute (see test_collab.py).
 from suite.sheets import boot as _boot
 
 


### PR DESCRIPTION
#438's UP037 autofix unquoted five type annotations whose names are imported only under `if TYPE_CHECKING:`. A sixth, in meet, predates it.

Python 3.14 evaluates annotations lazily, so the modules still import, but `__annotations__` and `inspect.signature()` now raise `NameError` on those functions. Frappe reads `func.__annotations__` to validate arguments on whitelisted callables, so whitelisting one later would fail. None is whitelisted today.

Imports the name at runtime where that creates no cycle. `ServerAnsiblePlay` and `CoreService` are circular, so those stay quoted with UP037 silenced. Also restores a comment RUF100 removed with a redundant `# noqa: F401`.
