### PR TITLE
fix(mail): All Inboxes reading pane fixes

### DIFF
--- a/frontend/src/apps/mail/components/ComposeMailEditor.vue
+++ b/frontend/src/apps/mail/components/ComposeMailEditor.vue
@@ -222,7 +222,7 @@ import {
 	useTemplateRef,
 	watch,
 } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { EditorContent } from '@tiptap/vue-3'
 import { watchDebounced } from '@vueuse/core'
 import {
@@ -280,6 +280,7 @@ const {
 const emit = defineEmits(['discardMail', 'reply', 'replyAll', 'forward', 'popOut'])
 
 const router = useRouter()
+const route = useRoute()
 // The editor sends as the enclosing pane's account (the thread's owning account in
 // All Inboxes, the active one everywhere else): identities, the account's default
 // outgoing email and every create/draft call resolve through this scope.
@@ -446,7 +447,8 @@ const onMailUpdateSuccess = ({
 		raiseToast(
 			__('Message sent.'),
 			'success',
-			thread_id
+			// No View action when the sent mail's thread is already open in front of the user.
+			thread_id && route.params.threadID !== thread_id
 				? { label: __('View'), onClick: () => viewSentMessage(thread_id) }
 				: undefined,
 		)

--- a/frontend/src/apps/mail/components/UpcomingEvents.vue
+++ b/frontend/src/apps/mail/components/UpcomingEvents.vue
@@ -38,10 +38,7 @@
 				/>
 				<div class="min-w-0 flex-1">
 					<div class="truncate text-xs text-ink-gray-5">{{ formatEventTime(event) }}</div>
-					<div
-						class="mt-0.5 truncate text-sm"
-						:class="event.title ? 'text-ink-gray-8' : 'text-ink-gray-4'"
-					>
+					<div class="mt-0.5 truncate text-sm text-ink-gray-8">
 						{{ event.title || __('Untitled event') }}
 					</div>
 				</div>

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -143,7 +143,9 @@
 				     fills the pane, as in MailboxView. A deep link whose row isn't in the
 				     loaded window stays gated: the pane's action handlers act on the row.
 				     The owning account scopes the pane (folder menus, reply identities) —
-				     opening a cross-account thread does NOT switch the active account. -->
+				     opening a cross-account thread does NOT switch the active account.
+				     set-seen passes `seen` as `silent` too: the pane only marks read silently
+				     (on open), while its explicit action is Mark as Unread — as in MailboxView. -->
 				<MailThread
 					ref="mailThread"
 					v-if="openRow || !threadID"
@@ -156,7 +158,7 @@
 					:can-go-next="canGoNext"
 					:messages="openRow?.messages"
 					@reload-mails="refreshThreads()"
-					@set-seen="(seen: boolean) => handleSetSeen(openRow!, seen)"
+					@set-seen="(seen: boolean) => handleSetSeen(openRow!, seen, seen)"
 					@set-flagged="
 						(ids: string[], flagged: boolean) =>
 							handleSetFlagged(openRow!, flagged, ids)
@@ -811,7 +813,7 @@ const handleMailDelete = (mail: Mail) =>
 
 const closeThread = () => router.push({ name: 'mail-all-inboxes', query: route.query })
 
-const handleSetSeen = (thread: Thread, seen: boolean) => {
+const handleSetSeen = (thread: Thread, seen: boolean, silent = false) => {
 	if (thread.seen === (seen ? 1 : 0)) return
 
 	// Marking the open thread unread means "come back to this later", so leave the pane — staying
@@ -822,21 +824,19 @@ const handleSetSeen = (thread: Thread, seen: boolean) => {
 		thread.messages?.forEach((m) => (m.seen = value))
 	}
 	applySeen(seen ? 1 : 0)
-	// Every caller here is an explicit user action (row action, pane menu, `u`); the silent
-	// mark-as-read on opening a thread is the pane's own and never reaches this.
-	raiseOptimisticToast(
-		call('suite.mail.api.mail.set_mails_seen', {
-			account: thread.account,
-			ids: messageIds(thread),
-			seen,
+	const request = call('suite.mail.api.mail.set_mails_seen', {
+		account: thread.account,
+		ids: messageIds(thread),
+		seen,
+	})
+		.then(refreshCounts)
+		.catch((error) => {
+			applySeen(seen ? 0 : 1) // revert the optimistic update
+			throw error
 		})
-			.then(refreshCounts)
-			.catch((error) => {
-				applySeen(seen ? 0 : 1) // revert the optimistic update
-				throw error
-			}),
-		__('Thread marked as {0}.', [seen ? __('read') : __('unread')]),
-	)
+	// The auto mark-as-read on opening a thread is silent (no toast); still roll back on failure.
+	if (silent) return void request.catch(() => {})
+	raiseOptimisticToast(request, __('Thread marked as {0}.', [seen ? __('read') : __('unread')]))
 }
 
 // Star/unstar, from a list row (which names no mails, so its own representative one) or from the

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -157,7 +157,7 @@
 					:threads="threadIDs"
 					:can-go-next="canGoNext"
 					:messages="openRow?.messages"
-					@reload-mails="refreshThreads()"
+					@reload-mails="reloadPaneThread()"
 					@set-seen="(seen: boolean) => handleSetSeen(openRow!, seen, seen)"
 					@set-flagged="
 						(ids: string[], flagged: boolean) =>
@@ -360,6 +360,23 @@ const refreshThreads = (reloadCounts = true) => {
 	if (!beginRefresh()) return
 	threads.reload()
 	if (reloadCounts) refreshCounts()
+}
+
+// The pane asked for a reload (a reply was sent, a message deleted, …). The list refresh keeps
+// already-loaded rows to hold the reader's place (see usePaginatedThreads), so it never updates the
+// open row — refetch the thread directly, scoped to its owning account, and write it onto the row so
+// the pane re-derives from fresh messages. MailboxView resets its whole list instead; doing that here
+// would blank the pane for any row outside the first window (the pane only renders loaded rows).
+const reloadPaneThread = () => {
+	const row = openRow.value
+	if (row)
+		call('suite.mail.api.mail.get_thread', {
+			account: row.account,
+			thread_id: row.thread_id,
+		}).then((mails: Mail[]) => {
+			if (mails?.length) row.messages = mails
+		})
+	refreshThreads()
 }
 
 // The rendered rows and the keyboard cursor: date groups, stacks, and the marker that walks them —


### PR DESCRIPTION
Four small fixes, mostly around the All Inboxes reading pane:

- **Opening an unread thread toasted "Thread marked as read."** The pane's automatic mark-as-read on open went through the same handler as the explicit actions. It now passes `silent`, mirroring MailboxView; the row action, `U`/`Shift+U`, and Mark as Unread still toast.
- **A sent reply never appeared in the pane** (composer just sat there). The pane's reload went to `refreshThreads`, whose merge keeps already-loaded rows to hold scroll position — so the open row's messages stayed stale. The pane reload now refetches the open thread via `get_thread` (scoped to the row's owning account) and writes it onto the row. A full reset, as MailboxView does, would blank the pane for rows outside the first window.
- **The "Message sent." toast offered View for the thread already on screen** — skipped when the sent mail's `thread_id` matches the open route.
- **"Untitled event" in the sidebar widget rendered in ink-gray-4**, reading as disabled; it now uses the default ink-gray-8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)