### PR TITLE
fix(calendar): sync HTTP RSVP responses to local participants' calendars

### DIFF
--- a/suite/calendar/api/rsvp.py
+++ b/suite/calendar/api/rsvp.py
@@ -23,6 +23,7 @@ import frappe
 from frappe import _
 from frappe.utils import escape_html
 
+from suite.mail.doctype.user_account.user_account import get_user_for_jmap_account
 from suite.mail.jmap import get_jmap_connection
 from suite.mail.jmap.services.calendars.calendar_event import CalendarEventService
 from suite.utils import log_error
@@ -173,7 +174,7 @@ def sync_response_to_participant_calendars(
             if not participant_account or participant_account == account:
                 continue
 
-            user = frappe.db.get_value("User Account", {"account": participant_account}, "user")
+            user = get_user_for_jmap_account(participant_account, ignore_permissions=True)
             if not user:
                 continue
 
@@ -286,11 +287,11 @@ def _format_event_when(event: dict) -> str:
 def _guest_calendar_service(account: str) -> CalendarEventService:
     """Builds a CalendarEventService for the organizer's account without a logged-in user."""
 
-    users = frappe.db.get_all("User Account", {"account": account}, pluck="user")
-    if not users:
+    user = get_user_for_jmap_account(account, ignore_permissions=True)
+    if not user:
         frappe.throw(_("Calendar account not found."))
 
-    connection = get_jmap_connection(users[0], ignore_permissions=True)
+    connection = get_jmap_connection(user, ignore_permissions=True)
     return CalendarEventService(account, connection)
 
 

--- a/suite/calendar/api/rsvp.py
+++ b/suite/calendar/api/rsvp.py
@@ -7,6 +7,11 @@ An invitation email carries three signed links (Yes / Maybe / No) that point at 
 `event_rsvp` web page. `resolve_rsvp` verifies the token and writes the participant's
 response to the organizer's copy of the event via JMAP. Recipients may be on any mail
 server, so we never require a login — the signed token is the only authorization.
+
+Participants hosted on this site each hold their own copy of the event (created when the
+invite email was delivered), so after the organizer's copy is updated a background job
+propagates the response to those copies too — otherwise everyone but the organizer keeps
+seeing the stale status.
 """
 
 import base64
@@ -67,6 +72,7 @@ def resolve_rsvp(token: str) -> dict:
         result = service.set_participation_status(payload["e"], payload["u"], status)
         if not result.get("notUpdated"):
             _notify_organizer(payload, status)
+            _sync_participant_calendars(payload, status)
         frappe.db.commit()
     except Exception:
         log_error("Calendar", title=_("Calendar RSVP failed"))
@@ -114,6 +120,110 @@ def _notify_organizer(payload: dict, status: str) -> None:
         participant_email=payload["m"],
         status=status,
     )
+
+
+def _sync_participant_calendars(payload: dict, status: str) -> None:
+    """Enqueues the job that mirrors a just-recorded RSVP onto local participants' copies.
+
+    Runs after the response commits and off the request, so a slow or failing sync never
+    delays or breaks the guest's confirmation page.
+    """
+
+    frappe.enqueue(
+        "suite.calendar.api.rsvp.sync_response_to_participant_calendars",
+        queue="short",
+        enqueue_after_commit=True,
+        account=payload["a"],
+        event_id=payload["e"],
+        participant_email=payload["m"],
+        status=status,
+    )
+
+
+def sync_response_to_participant_calendars(
+    account: str, event_id: str, participant_email: str, status: str
+) -> None:
+    """Propagates a recorded RSVP to every local participant's copy of the event (best-effort).
+
+    The RSVP link writes the response to the organizer's copy only; no scheduling messages
+    are sent in the custom-invite flow, so the copies that other participants on this site
+    received via the invite email still show the old status. For each participant whose
+    address resolves to a local JMAP account, this finds that account's copy by the event's
+    uid and patches the responder's participationStatus there too. External participants
+    have no reachable calendar and are skipped.
+    """
+
+    organizer_service = _guest_calendar_service(account)
+    events = organizer_service.get([event_id])
+    if not events:
+        return
+
+    event = events[0]
+    uid = event.get("uid")
+    if not uid:
+        return
+
+    for email in _participant_emails(event):
+        try:
+            # Resolve the address through the mail server's account registry (JMAP Account
+            # _name is the principal address) rather than the User doctype: a participant
+            # address can be an alias or a group, where a User.email lookup could match the
+            # wrong local mailbox or none at all.
+            participant_account = frappe.db.get_value("JMAP Account", {"_name": email})
+            if not participant_account or participant_account == account:
+                continue
+
+            user = frappe.db.get_value("User Account", {"account": participant_account}, "user")
+            if not user:
+                continue
+
+            service = CalendarEventService(
+                participant_account, get_jmap_connection(user, ignore_permissions=True)
+            )
+            copy_ids = service.get_master_ids([uid])
+            if not copy_ids:
+                continue
+
+            copies = service.get([copy_ids[0]])
+            if not copies:
+                continue
+
+            # Participant keys are per-copy (each server generates its own), so locate the
+            # responder in this copy by address rather than by the organizer-side uid.
+            responder_uid = _find_participant_uid(copies[0], participant_email)
+            if not responder_uid:
+                continue
+
+            service.set_participation_status(copy_ids[0], responder_uid, status)
+        except Exception:
+            log_error(
+                "Calendar",
+                title=_("Failed to sync RSVP for event {0} to {1}'s calendar").format(event_id, email),
+            )
+
+
+def _participant_emails(event: dict) -> set[str]:
+    """Returns the lowercase addresses of every participant on the event."""
+
+    emails = set()
+    for participant in (event.get("participants") or {}).values():
+        email = (participant.get("calendarAddress") or participant.get("email") or "").lower()
+        if email := email.replace("mailto:", ""):
+            emails.add(email)
+
+    return emails
+
+
+def _find_participant_uid(event: dict, email: str) -> str | None:
+    """Returns the participant key in this copy of the event matching the given address."""
+
+    email = email.lower()
+    for uid, participant in (event.get("participants") or {}).items():
+        address = (participant.get("calendarAddress") or participant.get("email") or "").lower()
+        if address.replace("mailto:", "") == email:
+            return uid
+
+    return None
 
 
 def _confirmation_copy(response_key: str) -> tuple[str, str, str]:

--- a/suite/calendar/doctype/calendar_event/invitations.py
+++ b/suite/calendar/doctype/calendar_event/invitations.py
@@ -145,9 +145,9 @@ def notify_organizer_of_response(account: str, event_id: str, participant_email:
     if not display:
         return
 
-    # The RSVP request is unauthenticated (Guest), so resolve the account owner straight from the
-    # DB — get_user_for_jmap_account would reject Guest — then act as them to read the event.
-    owner = frappe.db.get_value("User Account", {"account": account}, "user")
+    # The RSVP request is unauthenticated (Guest), so resolve the account owner while ignoring
+    # permissions — a plain lookup would reject Guest — then act as them to read the event.
+    owner = get_user_for_jmap_account(account, ignore_permissions=True)
     if not owner:
         return
 

--- a/suite/mail/doctype/user_account/user_account.py
+++ b/suite/mail/doctype/user_account/user_account.py
@@ -33,9 +33,17 @@ class UserAccount(OwnerFromUser, Document):
 
 @request_cache
 def get_user_for_jmap_account(
-    account: str, allow_system_manager: bool = True, raise_exception: bool = False
+    account: str,
+    allow_system_manager: bool = True,
+    raise_exception: bool = False,
+    ignore_permissions: bool = False,
 ) -> str | None:
-    """Returns the user for the given JMAP account ID. If no user is found, it returns None. If raise_exception is True, it raises an exception if the account does not belong to any user."""
+    """Returns the user for the given JMAP account ID. If no user is found, it returns None. If raise_exception is True, it raises an exception if the account does not belong to any user.
+
+    Pass ignore_permissions=True to resolve a linked user regardless of the session user's
+    role — for background jobs and unauthenticated flows (e.g. Guest RSVP requests) that
+    act on an account they don't own.
+    """
 
     if frappe.db.exists("JMAP Account", account):
         account_users = frappe.db.get_all("User Account", {"account": account}, pluck="user")
@@ -46,7 +54,11 @@ def get_user_for_jmap_account(
             if user in account_users:
                 return user
 
-            elif is_administrator(user) or (allow_system_manager and is_system_manager(user)):
+            elif (
+                ignore_permissions
+                or is_administrator(user)
+                or (allow_system_manager and is_system_manager(user))
+            ):
                 return account_users[0]
 
             elif raise_exception:

--- a/suite/mail/utils/user.py
+++ b/suite/mail/utils/user.py
@@ -59,9 +59,11 @@ def get_account_user(account: str, user: str | None = None) -> str:
     if user:
         return user
 
+    from suite.mail.doctype.user_account.user_account import get_user_for_jmap_account
+
     user = frappe.session.user
     if is_system_manager(user):
-        if linked := frappe.db.get_value("User Account", {"account": account}, "user"):
+        if linked := get_user_for_jmap_account(account, ignore_permissions=True):
             return linked
 
     return user


### PR DESCRIPTION
## Problem

Clicking a custom HTTP RSVP button (Yes / Maybe / No) from an event invite email only updates the participant's status on the **organizer's** copy of the event. Every other participant hosted on the same site has their own copy of the event (delivered via the invite email's iMIP), and those copies keep showing the stale participation status — nothing in the custom-invite flow sends scheduling messages that would refresh them.

## Fix

After a successful RSVP, `resolve_rsvp` now enqueues a best-effort background job (`sync_response_to_participant_calendars`, mirroring the existing `_notify_organizer` pattern: short queue, after commit) that:

- resolves each participant address to a local JMAP account via the account registry's principal address (`JMAP Account._name`) — so aliases and group addresses resolve to the right mailbox instead of a false `User.email` match, and unresolvable/external addresses are skipped
- skips the organizer's account (already updated) and accounts with no linked user
- finds that account's copy of the event by `uid`, locates the responder in the copy by address (participant keys are generated per copy, so the organizer-side key can't be reused), and patches just their `participationStatus`
- wraps each participant in its own try/except with `log_error`, so one broken account never blocks the rest

A side benefit: when the responder is a local user themselves, their own calendar now reflects the answer they clicked, matching the confirmation page's "This event is now on your calendar" copy.

## External participants

Intentionally out of scope: their calendars are only reachable over email (iMIP), and per-RSVP `REQUEST` re-sends would be noisy (mail volume, SEQUENCE bumps triggering "event updated" prompts) with limited payoff since major clients ignore other attendees' PARTSTAT from iMIP anyway. They converge on the next organizer-driven update, whose .ics already carries current PARTSTATs.