### PR TITLE
feat(mail): rename default mailboxes from their server-assigned names

### DIFF
--- a/suite/mail/doctype/jmap_account/jmap_account.py
+++ b/suite/mail/doctype/jmap_account/jmap_account.py
@@ -11,6 +11,7 @@ from frappe.utils import cint
 from suite.mail.jmap import (
     get_core_service,
     get_mailbox_id_by_role,
+    get_mailbox_service,
     invalidate_jmap_identities_cache,
     invalidate_jmap_mailboxes_cache,
 )
@@ -32,6 +33,15 @@ from suite.mail.utils.user import get_account_emails
 from suite.utils import execute_with_logging, user_context
 from suite.utils.lock import acquire_lock, release_lock
 from suite.utils.user import is_suite_admin, is_system_manager
+
+
+DEFAULT_MAILBOX_RENAMES = {
+    "inbox": ("Inbox", "Inbox"),
+    "sent": ("Sent Items", "Sent"),
+    "drafts": ("Drafts", "Drafts"),
+    "junk": ("Junk Mail", "Spam"),
+    "trash": ("Deleted Items", "Trash"),
+}
 
 
 class JMAPAccount(Document):
@@ -301,6 +311,7 @@ def sync_jmap_accounts(user: str, accounts: dict[str, dict]) -> None:
         with user_context(user):
             for account in new_accounts:
                 create_archive_mailbox(account)
+                rename_default_mailboxes(account)
                 build_automation_sieve(account, activate=True)
     finally:
         release_lock(lockname, identifier)
@@ -399,6 +410,55 @@ def create_archive_mailbox(account: str) -> None:
         with_context=False,
         module="Mail",
     )
+
+
+def rename_default_mailboxes(account: str) -> int:
+    """Rename the account's default mailboxes from their server-assigned names.
+
+    Returns the number of mailboxes renamed."""
+
+    return execute_with_logging(
+        lambda: _rename_default_mailboxes(account),
+        title=_("Default Mailbox Rename Error"),
+        user_message=_("Failed to rename default mailboxes for account {0}").format(frappe.bold(account)),
+        with_context=False,
+        module="Mail",
+    )
+
+
+def _rename_default_mailboxes(account: str) -> int:
+    service = get_mailbox_service(account)
+
+    updates = []
+    for mailbox in service.mailboxes:
+        current_name, new_name = DEFAULT_MAILBOX_RENAMES.get(
+            (mailbox.get("role") or "").lower(), (None, None)
+        )
+        if current_name is None or mailbox["name"] != current_name or current_name == new_name:
+            continue
+
+        updates.append(
+            {
+                "id": mailbox["id"],
+                "name": new_name,
+                "role": mailbox["role"],
+                "parent_id": mailbox["parentId"],
+                "sort_order": mailbox["sortOrder"],
+                "is_subscribed": mailbox["isSubscribed"],
+            }
+        )
+
+    if not updates:
+        return 0
+
+    response = service.update(updates)
+    service.invalidate_cache(service.account, key="mailboxes")
+
+    if not_updated := response.get("notUpdated"):
+        errors = ", ".join(f"{id}: {error.get('description')}" for id, error in not_updated.items())
+        raise ValueError(f"Failed to rename mailbox(es): {errors}")
+
+    return len(updates)
 
 
 def get_permission_query_condition(user: str | None = None) -> str | None:

--- a/suite/mail/patches/rename_default_mailboxes.py
+++ b/suite/mail/patches/rename_default_mailboxes.py
@@ -1,0 +1,92 @@
+import frappe
+from frappe.utils import create_batch
+
+from suite.mail.doctype.jmap_account.jmap_account import rename_default_mailboxes
+from suite.mail.doctype.sieve_script.sieve_script import build_automation_sieve
+from suite.utils import enqueue_job, user_context
+
+_ACCOUNTS_PER_BATCH = 100
+
+
+def execute() -> None:
+    """Rename default mailboxes still carrying their server-assigned names.
+
+    New accounts get renamed during account setup; this backfills accounts created before
+    that. Only mailboxes still carrying the exact server-assigned name are touched, so
+    user-renamed mailboxes are left alone and a re-run is a no-op. Accounts that got a
+    rename also get their automation sieve script rebuilt, since it files into mailboxes
+    by path and would otherwise keep referencing the old names.
+
+    Deferred to a background job: renaming needs a live JMAP session per account, which is
+    not reliably reachable during ``bench migrate``.
+    """
+
+    frappe.enqueue(rename_default_mailboxes_for_existing_accounts, queue="long", enqueue_after_commit=True)
+
+
+def rename_default_mailboxes_for_existing_accounts() -> None:
+    """Fan the accounts out into long-queue batches."""
+
+    account_users = get_accounts_with_enabled_user()
+    for i, batch in enumerate(create_batch(list(account_users.items()), _ACCOUNTS_PER_BATCH)):
+        enqueue_job(
+            _rename_default_mailboxes,
+            job_id=f"rename-default-mailboxes::{i}",
+            deduplicate=True,
+            queue="long",
+            timeout=3600,
+            account_users=dict(batch),
+        )
+
+
+def _rename_default_mailboxes(account_users: dict[str, str]) -> None:
+    """Rename each account's default mailboxes, isolating per-account failures."""
+
+    for account, user in account_users.items():
+        # The job runs async after the fan-out committed, so an account can vanish in between.
+        if not frappe.db.exists("JMAP Account", account):
+            continue
+
+        try:
+            # Reached over JMAP as the account's own (enabled) user, not as Administrator:
+            # resolving the connection as Administrator picks an arbitrary linked user,
+            # which may be disabled.
+            with user_context(user):
+                if rename_default_mailboxes(account):
+                    # The automation sieve files into mailboxes by path, so the stored
+                    # script still references the old names. activate=False on purpose:
+                    # activating here would override an account whose active script is the
+                    # vacation auto-responder or one the user wrote themselves.
+                    build_automation_sieve(account)
+        except Exception:
+            # Already logged by rename_default_mailboxes; move on to the next account.
+            pass
+
+
+def get_accounts_with_enabled_user() -> dict[str, str]:
+    """JMAP accounts mapped to one of their enabled users.
+
+    Accounts whose linked users are all disabled are skipped: a JMAP connection can only be
+    opened as an enabled user. Joined to JMAP Account to drop stale User Account rows
+    pointing at accounts that no longer exist.
+    """
+
+    USER_ACCOUNT = frappe.qb.DocType("User Account")
+    USER = frappe.qb.DocType("User")
+    JMAP_ACCOUNT = frappe.qb.DocType("JMAP Account")
+
+    rows = (
+        frappe.qb.from_(USER_ACCOUNT)
+        .inner_join(USER)
+        .on(USER_ACCOUNT.user == USER.name)
+        .inner_join(JMAP_ACCOUNT)
+        .on(USER_ACCOUNT.account == JMAP_ACCOUNT.name)
+        .where(USER.enabled == 1)
+        .select(USER_ACCOUNT.account, USER_ACCOUNT.user)
+    ).run(as_dict=True)
+
+    account_users = {}
+    for row in rows:
+        account_users.setdefault(row.account, row.user)
+
+    return account_users

--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -84,6 +84,7 @@ suite.mail.patches.migrate_cache_to_mail_namespace
 suite.mail.patches.migrate_search_index_to_mail_namespace
 suite.mail.patches.rebuild_automation_sieve_scripts
 suite.mail.patches.migrate_data_store_timestamps_to_utc
+suite.mail.patches.rename_default_mailboxes
 execute:frappe.db.set_single_value("Mail Settings", "verify_ssl", 1)
 execute:frappe.db.set_single_value("Mail Settings", "show_mail_client_config", 1)
 execute:frappe.db.set_single_value("Mail Settings", "custom_event_invites", 1)


### PR DESCRIPTION
Stalwart provisions accounts with mailboxes named **Sent Items**, **Junk Mail** and **Deleted Items**. This renames them to **Sent**, **Spam** and **Trash**:

| Role | Server-assigned name | New name |
|---|---|---|
| `sent` | Sent Items | Sent |
| `junk` | Junk Mail | Spam |
| `trash` | Deleted Items | Trash |

- **New accounts**: renamed during account setup (`sync_jmap_accounts`), right after the archive mailbox is created and before the automation sieve is built.
- **Existing accounts**: a patch backfills accounts that have an enabled user, fanning out into batched long-queue jobs (a live JMAP session per account is not reliably reachable during `bench migrate`). Each rename runs as the account's own enabled user, and accounts that got a rename also get their automation sieve rebuilt, since the script files into mailboxes by path and would otherwise keep referencing the old names (`activate=False`, so a vacation auto-responder or user-authored active script is never overridden).

A mailbox is renamed only when both its role **and** its current name match the server-assigned default, so user-renamed mailboxes are left untouched and the patch is a no-op on re-run.