### PR TITLE
feat: move blob store out of private/files to exclude it from backups

### DIFF
--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -80,6 +80,7 @@ suite.mail.patches.rebuild_email_address_indexes
 suite.mail.patches.enable_screening_for_personal_accounts
 suite.mail.patches.create_suite_user_role
 suite.mail.patches.rename_mail_admin_to_suite_admin
+suite.suite_core.patches.move_blob_store_out_of_files
 suite.mail.patches.migrate_cache_to_mail_namespace
 suite.mail.patches.migrate_search_index_to_mail_namespace
 suite.mail.patches.rebuild_automation_sieve_scripts

--- a/suite/store/__init__.py
+++ b/suite/store/__init__.py
@@ -20,10 +20,12 @@ def get_data_base_path() -> str:
 def get_blob_base_path() -> str:
     """Base directory holding every blob store for the current site.
 
-    Sits alongside the site's private files, so it is per-site (multi-tenant safe) and never web-served.
+    Sits under the site's ``private`` directory (not ``private/files``), so it is per-site
+    (multi-tenant safe), never web-served, and excluded from site backups — blobs are a cache
+    refetched on demand, and backing them up would bloat every files backup.
     """
 
-    return os.path.join(get_bench_path(), "sites", frappe.local.site, "private", "files", "blob-store")
+    return os.path.join(get_bench_path(), "sites", frappe.local.site, "private", "blob-store")
 
 
 def get_search_base_path() -> str:

--- a/suite/suite_core/patches/move_blob_store_out_of_files.py
+++ b/suite/suite_core/patches/move_blob_store_out_of_files.py
@@ -1,0 +1,31 @@
+import os
+import shutil
+
+import frappe
+from frappe.utils import get_bench_path
+
+from suite.store import get_blob_base_path
+
+
+def execute() -> None:
+    """Relocate the blob store from ``private/files/blob-store`` to ``private/blob-store``.
+
+    The blob store used to live inside ``private/files``, so every files backup tarred the whole
+    blob cache. It now sits directly under ``private``, which backups do not include. Migrating is
+    a single directory move — the internal layout is unchanged.
+
+    Best-effort: blobs are a cache refetched on demand, so if the new directory already exists
+    (an interrupted earlier run, or stores already created at the new location) the old directory
+    is simply dropped rather than merged.
+    """
+
+    old_path = os.path.join(get_bench_path(), "sites", frappe.local.site, "private", "files", "blob-store")
+    if not os.path.isdir(old_path) or os.path.islink(old_path):
+        return
+
+    new_path = get_blob_base_path()
+    if os.path.exists(new_path):
+        shutil.rmtree(old_path, ignore_errors=True)
+        return
+
+    os.rename(old_path, new_path)


### PR DESCRIPTION
## Problem

Fetched blobs are cached under `sites/<site>/private/files/blob-store`, so every files backup tars the entire blob cache — even though blobs are refetched on demand and don't need to be backed up.

## Change

- `get_blob_base_path()` now returns `sites/<site>/private/blob-store` (directly under `private`, not `private/files`). The location is still per-site and never web-served, but Frappe's files backup only includes `private/files` and `public/files`, so the blob cache is no longer part of backups.
- New patch `suite.suite_core.patches.move_blob_store_out_of_files` relocates an existing blob store with a single rename. Blobs are a refetchable cache, so if the destination already exists the old directory is dropped rather than merged. It lives in `suite_core` since the blob store is shared by mail and Store Entry.
- The patch is registered **before** `migrate_cache_to_mail_namespace`: sites upgrading across both patches need the store at its new location before the namespace patch reorganizes its internal layout (otherwise that patch would no-op and the moved blobs would be unreadable strays).

`data-store` and `search-index` are also rebuildable caches under `private/files` — left untouched here, but the same treatment could apply to them in a follow-up.