### PR TITLE
fix(mail): default stack rows to selectable

### DIFF
--- a/frontend/src/apps/mail/components/StackListItem.vue
+++ b/frontend/src/apps/mail/components/StackListItem.vue
@@ -71,7 +71,14 @@ import type { Thread } from '@/apps/mail/types'
 //
 // Its hover actions apply to every member at once, so each one names the count and every move it makes
 // is undoable.
-const { threads, expanded, isSelected, selectable, hideAvatar, accountLabel } = defineProps<{
+const {
+	threads,
+	expanded,
+	isSelected,
+	selectable = true,
+	hideAvatar,
+	accountLabel,
+} = defineProps<{
 	threads: Thread[]
 	expanded: boolean
 	isSelected: boolean


### PR DESCRIPTION
MailboxView doesn't pass the `selectable` prop to StackListItem, so it resolved to `undefined` and stack rows lost their selection affordance in mailbox views. Default it to `true` — All Inboxes still opts out explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)