### PR TITLE
feat(mail): move Junk, Archive & Trash into a collapsible More section

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,7 +63,7 @@
     "feather-icons": "^4.29.2",
     "file-saver": "^2.0.5",
     "firebase": "^12.2.1",
-    "frappe-ui": "frappe/frappe-ui#568c2a854028544c976df2cc5dfa1490cbd1310a",
+    "frappe-ui": "frappe/frappe-ui#1c5f72c36dcde9444fe6fc349796c6780a9cbe19",
     "fuzzysort": "^3.1.0",
     "gemoji": "^8.1.0",
     "hast-util-to-html": "^9.0.5",

--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -6,67 +6,89 @@
 	/>
 
 	<Transition>
+		<!-- Composition mode (default slot): the app owns the body, so each
+		     SidebarSection's collapse state can be bound (v-model:collapsed) — the
+		     legacy `sections` config keeps that state internal. Owning it lets
+		     More/People default to collapsed and persist their state. -->
 		<Sidebar
 			v-if="!isMobile || isSidebarOpen"
 			id="sidebar"
 			v-model:collapsed="isSidebarCollapsed"
-			:header="{
-				title,
-				subtitle,
-				menuItems,
-				logo: branding.data?.brand_html || MailLogo,
-			}"
-			:sections="sidebarItems"
 			:class="{ 'fixed left-0 top-0 z-10 w-60 !bg-surface-base': isMobile }"
 			:disable-collapse="isMobile"
 		>
-			<template #footer-items>
-				<!-- Personal widgets (events, quota) are meaningless while administering the server. -->
-				<UpcomingEvents
-					v-if="user.data.is_jmap_configured && !route.meta.isDashboard"
-					:is-collapsed="isSidebarCollapsed"
+			<div class="flex h-full flex-col p-2">
+				<SidebarHeader
+					:title="title"
+					:subtitle="subtitle"
+					:menu-items="menuItems"
+					:logo="branding.data?.brand_html || MailLogo"
 				/>
-				<QuotaBar
-					v-if="user.data.is_jmap_configured && !route.meta.isDashboard"
-					:is-collapsed="isSidebarCollapsed"
-				/>
-			</template>
-			<template #sidebar-item="{ item }">
-				<SidebarItem
-					:label="item.label"
-					:icon="item.icon"
-					:to="item.to"
-					:is-active="
-						item.activeFor?.includes(
-							['mail-mailbox', 'mail-mail'].includes(route.name as string)
-								? route.params.mailbox
-								: route.name,
-						)
-					"
-					:on-click="item.onClick"
-					class="group"
-				>
-					<template #suffix>
-						<div class="flex items-center">
-							<Dropdown v-if="item.menuOptions" :options="item.menuOptions">
-								<Button variant="ghost" class="!bg-transparent" @click.stop>
-									<template #icon>
-										<Ellipsis
-											class="text-ink-gray-6 invisible h-4 w-4 group-hover:visible"
-										/>
-									</template>
-								</Button>
-							</Dropdown>
-							<span
-								class="text-ink-gray-4 mr-2 text-sm"
-								:class="{ 'group-hover:hidden': item.menuOptions }"
+
+				<!-- -mx/px: rows sit flush with the clip edge, so without this the
+				     active item's shadow ring is cut off at both sides. -->
+				<div class="-mx-1 flex-1 overflow-y-auto overflow-x-hidden px-1">
+					<SidebarSection
+						v-for="section in sidebarItems"
+						:key="section.key ?? section.label"
+						:label="section.label"
+						:items="section.items"
+						:collapsible="section.collapsible"
+						:collapsed="isSectionCollapsed(section)"
+						@update:collapsed="(collapsed) => setSectionCollapsed(section.key, collapsed)"
+					>
+						<template #sidebar-item="{ item }">
+							<SidebarItem
+								:label="item.label"
+								:icon="item.icon"
+								:to="item.to"
+								:active="
+									item.activeFor?.includes(
+										['mail-mailbox', 'mail-mail'].includes(route.name as string)
+											? route.params.mailbox
+											: route.name,
+									)
+								"
+								:on-click="item.onClick"
+								class="group"
 							>
-								{{ item.suffix }}
-							</span>
-						</div>
-					</template>
-				</SidebarItem>
-			</template>
+								<template #suffix>
+									<div class="flex items-center">
+										<Dropdown v-if="item.menuOptions" :options="item.menuOptions">
+											<Button variant="ghost" class="!bg-transparent" @click.stop>
+												<template #icon>
+													<Ellipsis
+														class="text-ink-gray-6 invisible h-4 w-4 group-hover:visible"
+													/>
+												</template>
+											</Button>
+										</Dropdown>
+										<span
+											class="text-ink-gray-4 mr-2 text-sm"
+											:class="{ 'group-hover:hidden': item.menuOptions }"
+										>
+											{{ item.suffix }}
+										</span>
+									</div>
+								</template>
+							</SidebarItem>
+						</template>
+					</SidebarSection>
+				</div>
+
+				<div class="mt-auto">
+					<!-- Personal widgets (events, quota) are meaningless while administering the server. -->
+					<UpcomingEvents
+						v-if="user.data.is_jmap_configured && !route.meta.isDashboard"
+						:is-collapsed="isSidebarCollapsed"
+					/>
+					<QuotaBar
+						v-if="user.data.is_jmap_configured && !route.meta.isDashboard"
+						:is-collapsed="isSidebarCollapsed"
+					/>
+					<SidebarCollapseToggle v-if="!isMobile" />
+				</div>
+			</div>
 		</Sidebar>
 	</Transition>
 
@@ -96,14 +118,23 @@ import { useRoute, useRouter } from 'vue-router'
 import { useStorage } from '@vueuse/core'
 import { Icon } from 'frappe-ui/icons'
 import { Check, Keyboard, User } from 'lucide-vue-next'
-import { Avatar, Button, Dropdown, Sidebar, SidebarItem } from 'frappe-ui'
+import {
+	Avatar,
+	Button,
+	Dropdown,
+	Sidebar,
+	SidebarCollapseToggle,
+	SidebarHeader,
+	SidebarItem,
+	SidebarSection,
+} from 'frappe-ui'
 
 import { useAppSwitcher } from '@/composables/useAppSwitcher'
 import { FOLDER_ICON_COLOR_MAP } from '@/apps/mail/constants'
 import { getIcon, getMailboxName, toTitleCase } from '@/apps/mail/utils'
 import { useAccountSwitch, useScreenSize, useSettings, useSidebar } from '@/apps/mail/utils/composables'
 import { sessionStore } from '@/apps/mail/stores/session'
-import { userStore } from '@/apps/mail/stores/user'
+import { SECONDARY_MAILBOX_ROLES, userStore } from '@/apps/mail/stores/user'
 import MailLogo from '@/apps/mail/components/Icons/MailLogo.vue'
 import DeleteFolderModal from '@/apps/mail/components/Modals/DeleteFolderModal.vue'
 import FolderModal from '@/apps/mail/components/Modals/FolderModal.vue'
@@ -149,6 +180,19 @@ const { isMobile } = useScreenSize()
 const { switchAccount } = useAccountSwitch()
 const { isSidebarOpen, closeSidebar } = useSidebar()
 const isSidebarCollapsed = useStorage('isSidebarCollapsed', false)
+
+// Per-section open/closed state for collapsible sections, keyed by the section's
+// stable `key` (labels are translated, so they can't be storage keys). More and
+// People start collapsed for new users; every toggle is remembered.
+const collapsedSections = useStorage<Record<string, boolean>>('mail-sidebar-collapsed-sections', {
+	more: true,
+	people: true,
+})
+const setSectionCollapsed = (key: string | undefined, collapsed: boolean) => {
+	if (key) collapsedSections.value[key] = collapsed
+}
+const isSectionCollapsed = (section: { key?: string }) =>
+	!!section.key && !!collapsedSections.value[section.key]
 const { logout, branding } = sessionStore()
 const store = userStore()
 const { mailboxes, allInboxesUnread } = store
@@ -486,9 +530,13 @@ const sidebarItems = computed(() => {
 
 	const screenerItem = mailboxItems.value.find((item) => isScreening(item))
 
-	const defaultMailboxes = mailboxItems.value.filter(
-		(item) => mailboxes.data?.find((m) => m.id === item.mailboxId)?.role,
-	)
+	const roleOf = (item: { mailboxId?: string }) =>
+		mailboxes.data?.find((m) => m.id === item.mailboxId)?.role
+
+	const defaultMailboxes = mailboxItems.value.filter((item) => {
+		const role = roleOf(item)
+		return role && !SECONDARY_MAILBOX_ROLES.includes(role)
+	})
 	const starredItem = {
 		label: __('Starred'),
 		icon: Star,
@@ -497,9 +545,18 @@ const sidebarItems = computed(() => {
 	}
 	const defaultItems = [...defaultMailboxes, starredItem]
 
+	const secondaryItems = mailboxItems.value
+		.filter((item) => {
+			const role = roleOf(item)
+			return role && SECONDARY_MAILBOX_ROLES.includes(role)
+		})
+		.sort(
+			(a, b) =>
+				SECONDARY_MAILBOX_ROLES.indexOf(roleOf(a)!) - SECONDARY_MAILBOX_ROLES.indexOf(roleOf(b)!),
+		)
+
 	const customMailboxes = mailboxItems.value.filter(
-		(item) =>
-			!mailboxes.data?.find((m) => m.id === item.mailboxId)?.role && !isScreening(item),
+		(item) => !roleOf(item) && !isScreening(item),
 	)
 	const addMailboxItem = {
 		label: __('New Folder'),
@@ -529,7 +586,10 @@ const sidebarItems = computed(() => {
 	const groups = [
 		{ label: __('Default'), items: defaultItems },
 		{ label: __('Custom'), items: customItems },
-		{ label: __('People'), items: contactsItems, collapsible: true },
+		...(secondaryItems.length
+			? [{ label: __('More'), key: 'more', items: secondaryItems, collapsible: true }]
+			: []),
+		{ label: __('People'), key: 'people', items: contactsItems, collapsible: true },
 	]
 
 	// All Inboxes and Screener share one nameless group pinned above the folders, so they sit at

--- a/frontend/src/apps/mail/components/mobile/MobileFolderSheet.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileFolderSheet.vue
@@ -54,7 +54,7 @@ import FolderModal from '@/apps/mail/components/Modals/FolderModal.vue'
 import { FOLDER_ICON_COLOR_MAP } from '@/apps/mail/constants'
 import { getIcon, getMailboxName } from '@/apps/mail/utils'
 import { useFolderSheet } from '@/apps/mail/utils/composables'
-import { userStore } from '@/apps/mail/stores/user'
+import { SECONDARY_MAILBOX_ROLES, userStore } from '@/apps/mail/stores/user'
 
 import type { MailboxData } from '@/apps/mail/types'
 
@@ -105,17 +105,34 @@ const groups = computed(() => {
 		} as RouteLocationRaw,
 	}
 
+	const isSecondary = (m: MailboxData) => !!m.role && SECONDARY_MAILBOX_ROLES.includes(m.role)
+
 	return [
 		{
 			label: __('Default'),
 			isCustom: false,
-			rows: [...items.filter((m: MailboxData) => m.role).map(toRow), starredRow],
+			rows: [
+				...items.filter((m: MailboxData) => m.role && !isSecondary(m)).map(toRow),
+				starredRow,
+			],
 		},
 		{
 			// Always rendered (even with no custom folders yet): it hosts New Folder.
 			label: __('Custom'),
 			isCustom: true,
 			rows: items.filter((m: MailboxData) => !m.role).map(toRow),
+		},
+		{
+			// Junk/Archive/Trash sit in their own section below Custom, as in the desktop sidebar.
+			label: __('More'),
+			isCustom: false,
+			rows: items
+				.filter(isSecondary)
+				.sort(
+					(a: MailboxData, b: MailboxData) =>
+						SECONDARY_MAILBOX_ROLES.indexOf(a.role!) - SECONDARY_MAILBOX_ROLES.indexOf(b.role!),
+				)
+				.map(toRow),
 		},
 	].filter((group) => group.isCustom || group.rows.length)
 })

--- a/frontend/src/apps/mail/stores/user.ts
+++ b/frontend/src/apps/mail/stores/user.ts
@@ -9,6 +9,15 @@ import type { UserAccount, UserResource } from '@/apps/mail/types'
 
 export type MailboxRole = 'inbox' | 'sent' | 'drafts' | 'trash' | 'junk' | 'archive' | 'important'
 
+/** Destinations rather than places mail is read — the folder lists (desktop sidebar,
+ * mobile folder sheet) render these in their own "More" section below the custom folders,
+ * in this order. Typed wide (string) because mailbox data carries role as a string. */
+export const SECONDARY_MAILBOX_ROLES: readonly string[] = [
+	'junk',
+	'archive',
+	'trash',
+] satisfies readonly MailboxRole[]
+
 /** Role → mailbox id map for a mailbox list (plus the named Screener). Shared with
  * utils/accountScope, which derives the same map for a non-active account's list. */
 export const deriveMailboxIds = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -4423,6 +4423,11 @@ es-errors@^1.3.0:
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
+es-module-lexer@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
+
 es-module-lexer@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-2.1.0.tgz#1dfcbb5ea3bbfb63f28e1fc3676c3676d1c9624c"
@@ -4680,9 +4685,9 @@ fraction.js@^5.3.4:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-5.3.4.tgz#8c0fcc6a9908262df4ed197427bdeef563e0699a"
   integrity sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==
 
-frappe-ui@frappe/frappe-ui#568c2a854028544c976df2cc5dfa1490cbd1310a:
-  version "1.0.0-beta.25"
-  resolved "https://codeload.github.com/frappe/frappe-ui/tar.gz/568c2a854028544c976df2cc5dfa1490cbd1310a"
+frappe-ui@frappe/frappe-ui#1c5f72c36dcde9444fe6fc349796c6780a9cbe19:
+  version "1.0.0-beta.29"
+  resolved "https://codeload.github.com/frappe/frappe-ui/tar.gz/1c5f72c36dcde9444fe6fc349796c6780a9cbe19"
   dependencies:
     "@codemirror/lang-css" "^6.3.0"
     "@codemirror/lang-html" "^6.4.9"
@@ -4741,6 +4746,7 @@ frappe-ui@frappe/frappe-ui#568c2a854028544c976df2cc5dfa1490cbd1310a:
     dayjs "^1.11.13"
     dompurify "^3.4.0"
     echarts "^5.6.0"
+    es-module-lexer "^1.7.0"
     feather-icons "^4.28.0"
     fuzzysort "^3.1.0"
     grid-layout-plus "^1.1.0"
@@ -4748,6 +4754,7 @@ frappe-ui@frappe/frappe-ui#568c2a854028544c976df2cc5dfa1490cbd1310a:
     idb-keyval "^6.2.0"
     lowlight "^3.3.0"
     lucide-static "^1.16.0"
+    magic-string "^0.30.21"
     marked "^15.0.12"
     ora "5.4.1"
     prettier "^3.3.2"


### PR DESCRIPTION
Junk, Archive and Trash are destinations, not reading folders — they now live in a **More** section below Custom, collapsed by default. More and People remember their collapsed state per user (localStorage). Mobile folder sheet mirrors the grouping.

Under the hood the sidebar now composes `SidebarHeader`/`SidebarSection` directly instead of the deprecated `sections` config, using the new `v-model:collapsed` from frappe/frappe-ui#888. frappe-ui pin bumped to pick it up (beta.25 → beta.29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)