### PR TITLE
fix(mail): lift the dialog panel alongside its backdrop

### DIFF
--- a/frontend/src/apps/mail/components/InstallPrompt.vue
+++ b/frontend/src/apps/mail/components/InstallPrompt.vue
@@ -15,40 +15,45 @@
 	</Dialog>
 
 	<!-- iOS installation info message — a plain fixed banner, not a Popover: no overlay to
-	     block the app behind it, and the viewport (not the content) bounds its width. -->
-	<div
-		v-if="iosInstallMessage"
-		class="bg-surface-blue-2 fixed inset-x-2 bottom-4 z-20 flex flex-col gap-3 rounded py-5 drop-shadow-xl"
-	>
-		<div class="mb-1 flex flex-row items-center justify-between px-3 text-center">
-			<span class="text-base-bold">
-				{{ __('Install Frappe Mail') }}
-			</span>
-			<span class="inline-flex items-baseline">
-				<FeatherIcon
-					name="x"
-					class="text-ink-gray-6 ml-auto h-4 w-4"
-					@click="iosInstallMessage = false"
-				/>
-			</span>
-		</div>
-		<div class="text-ink-gray-7 px-3 text-xs">
-			<span class="flex flex-col gap-2">
-				<span>
-					{{
-						__(
-							'Get the app on your iPhone for easy access & a better experience',
-						)
-					}}
+	     block the app behind it, and the viewport (not the content) bounds its width.
+	     Teleported to body and lifted past z-50: it lives in the app tree, so the
+	     body-portaled surfaces (bottom sheets, dialogs — z-50) would otherwise paint
+	     their backdrops over it. -->
+	<Teleport to="body">
+		<div
+			v-if="iosInstallMessage"
+			class="bg-surface-blue-2 fixed inset-x-2 bottom-4 z-[60] flex flex-col gap-3 rounded py-5 drop-shadow-xl"
+		>
+			<div class="mb-1 flex flex-row items-center justify-between px-3 text-center">
+				<span class="text-base-bold">
+					{{ __('Install Frappe Mail') }}
 				</span>
-				<span>
-					{{ __('Tap') }}
-					<FeatherIcon name="share" class="inline h-4 w-4 align-[-3px] text-blue-600" />
-					{{ __('and then "Add to Home Screen"') }}
+				<span class="inline-flex items-baseline">
+					<FeatherIcon
+						name="x"
+						class="text-ink-gray-6 ml-auto h-4 w-4"
+						@click="iosInstallMessage = false"
+					/>
 				</span>
-			</span>
+			</div>
+			<div class="text-ink-gray-7 px-3 text-xs">
+				<span class="flex flex-col gap-2">
+					<span>
+						{{
+							__(
+								'Get the app on your iPhone for easy access & a better experience',
+							)
+						}}
+					</span>
+					<span>
+						{{ __('Tap') }}
+						<FeatherIcon name="share" class="inline h-4 w-4 align-[-3px] text-blue-600" />
+						{{ __('and then "Add to Home Screen"') }}
+					</span>
+				</span>
+			</div>
 		</div>
-	</div>
+	</Teleport>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/apps/mail/pages/MailLayout.vue
+++ b/frontend/src/apps/mail/pages/MailLayout.vue
@@ -330,8 +330,11 @@ body.mail-app .bottom-sheet-content > .h-\[70vh\] {
 /* Portaled dialogs and menus ship without a z-index (they rely on body DOM
    order), so the mobile panes with explicit z (thread pane, settings — z-20)
    would paint over them. Lift them above the panes but below bottom sheets
-   (z-50), preserving sheet-over-dialog ordering. */
-body.mail-app .dialog-overlay {
+   (z-50), preserving sheet-over-dialog ordering. The panel is a sibling of
+   the overlay (not nested inside it), so both layers need the lift — same z,
+   so DOM order keeps the panel above its own backdrop. */
+body.mail-app .dialog-overlay,
+body.mail-app .dialog-scroll-container {
 	z-index: 30;
 }
 body.mail-app .menu-content {


### PR DESCRIPTION
Two stacking fixes for portaled surfaces in the mail app:

**Dialog backdrop over the panel** — frappe-ui#857 restructured Dialog: the panel is now a sibling of the overlay instead of a child, relying on body DOM order for stacking. The mail app's `z-index: 30` lift on `.dialog-overlay` (which keeps dialogs above the mobile panes' z-20) therefore hoisted only the backdrop — it painted over the z-auto panel, dimming every open dialog and swallowing all clicks. Lift `.dialog-scroll-container` to the same z-30: with equal z-indexes, DOM order stacks the panel above its own backdrop again, and both stay above the panes and below bottom sheets (z-50).

**Bottom sheets over the iOS install banner** — the banner is a fixed z-20 div inside the app tree, so body-portaled sheets (z-50) painted their backdrop over it. Teleport it to body and lift it to z-60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)