### PR TITLE
feat(calendar): send push notifications for JMAP event alerts

### DIFF
--- a/frontend/src/apps/mail/components/Modals/AddPushSubscriptionModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddPushSubscriptionModal.vue
@@ -35,9 +35,10 @@
 				<div class="space-y-2">
 					<label class="text-ink-gray-5 block text-xs">{{ __('Types') }}</label>
 					<p class="text-ink-gray-5 text-xs">
-						{{ __('A StateChange notification is sent only when one of these types changes.') }}
+						{{ __('A notification is sent only for the selected types.') }}
 					</p>
-					<div class="grid grid-cols-2 gap-2">
+					<Checkbox v-model="allTypes" :label="__('All')" />
+					<div v-if="!allTypes" class="grid grid-cols-2 gap-2">
 						<Checkbox
 							v-for="type in AVAILABLE_TYPES"
 							:key="type"
@@ -63,13 +64,14 @@ const emit = defineEmits<{ created: [] }>()
 
 const user = inject('$user')
 
-// The JMAP data types a client can subscribe to. These mirror the Push Subscription doctype's default
-// set; all are enabled by default so a new subscription behaves like a fresh client registration.
-const AVAILABLE_TYPES = ['Email', 'Mailbox', 'Identity', 'VacationResponse'] as const
+// The JMAP data types a client can narrow a subscription down to. 'All' is the default and sends
+// no types at all — the server then subscribes to every type, including ones not listed here.
+const AVAILABLE_TYPES = ['Email', 'Mailbox', 'Identity', 'VacationResponse', 'CalendarAlert'] as const
 type SubscriptionType = (typeof AVAILABLE_TYPES)[number]
 
 const url = ref('')
 const deviceClientId = ref('')
+const allTypes = ref(true)
 const selectedTypes = reactive<Record<SubscriptionType, boolean>>(
 	Object.fromEntries(AVAILABLE_TYPES.map((t) => [t, true])) as Record<SubscriptionType, boolean>,
 )
@@ -77,9 +79,11 @@ const selectedTypes = reactive<Record<SubscriptionType, boolean>>(
 const chosenTypes = computed(() => AVAILABLE_TYPES.filter((t) => selectedTypes[t]))
 
 // A URL is optional (blank falls back to the app default), but if given it must be an https URL to
-// match the backend's validation. At least one type must be selected.
+// match the backend's validation. Either 'All' or at least one type must be selected.
 const canCreate = computed(
-	() => chosenTypes.value.length > 0 && (!url.value.trim() || url.value.trim().startsWith('https://')),
+	() =>
+		(allTypes.value || chosenTypes.value.length > 0) &&
+		(!url.value.trim() || url.value.trim().startsWith('https://')),
 )
 
 const addPushSubscription = createResource({
@@ -88,7 +92,7 @@ const addPushSubscription = createResource({
 		user: user.data.name,
 		url: url.value.trim() || undefined,
 		device_client_id: deviceClientId.value.trim() || undefined,
-		types: chosenTypes.value,
+		types: allTypes.value ? undefined : chosenTypes.value,
 	}),
 	onSuccess: () => {
 		raiseToast(__('Push subscription created.'))
@@ -103,6 +107,7 @@ watch(show, (open) => {
 	if (!open) return
 	url.value = ''
 	deviceClientId.value = ''
+	allTypes.value = true
 	AVAILABLE_TYPES.forEach((t) => (selectedTypes[t] = true))
 })
 </script>

--- a/suite/calendar/doctype/calendar_event/calendar_event.py
+++ b/suite/calendar/doctype/calendar_event/calendar_event.py
@@ -3,13 +3,17 @@
 
 
 import json
+from datetime import datetime
 from typing import Literal
+from urllib.parse import quote
 from uuid import uuid7
+from zoneinfo import ZoneInfo
 
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import cint
+from frappe.push_notification import PushNotification
+from frappe.utils import cint, get_system_timezone
 
 from suite.calendar.doctype.calendar.calendar import validate_calendar_name_format
 from suite.calendar.doctype.calendar_event.invitations import (
@@ -17,9 +21,12 @@ from suite.calendar.doctype.calendar_event.invitations import (
     custom_event_invites_enabled,
 )
 from suite.mail.doctype.user_account.user_account import get_user_for_jmap_account
-from suite.mail.jmap import get_calendar_event_service
+from suite.mail.jmap import get_calendar_event_service, get_jmap_connection
+from suite.mail.jmap.services.calendars.calendar_event import CalendarEventService
+from suite.mail.utils import log_mail_error
 from suite.mail.utils.dt import normalize_utc_z
-from suite.utils import parse_filters
+from suite.mail.utils.logger import get_push_logger
+from suite.utils import enqueue_job, parse_filters, user_context
 from suite.utils.dt import utcnow
 
 
@@ -739,6 +746,109 @@ def _enqueue_event_notification(account: str, action: str, **kwargs) -> None:
         action=action,
         **kwargs,
     )
+
+
+def send_event_alert_notification(user: str, alert: dict, ctx: dict | None = None) -> None:
+    """Sends a device push notification for a JMAP CalendarAlert triggered by the server.
+
+    The alert only carries identifiers (accountId, calendarEventId, recurrenceId), so the event
+    is fetched with the user's own JMAP credentials to build the notification content — which
+    also ensures a forged alert can't surface another account's event to this user."""
+
+    ctx = ctx or {}
+    logger = get_push_logger(ctx)
+
+    account = alert.get("accountId")
+    event_id = alert.get("calendarEventId")
+    recurrence_id = alert.get("recurrenceId")
+
+    if not account or not event_id:
+        logger.warning("calendar-alert-missing-ids")
+        return
+
+    try:
+        pn = PushNotification("mail")
+        if not pn.is_enabled():
+            logger.debug("push-notifications-disabled")
+            return
+
+        service = CalendarEventService(account, get_jmap_connection(user))
+
+        events = service.get([event_id])
+        if not events:
+            logger.warning("calendar-alert-event-not-found")
+            return
+
+        event = events[0]
+        all_day = bool(event.get("showWithoutTime"))
+
+        # For a recurring event the alert's recurrenceId is the triggering instance's local
+        # start; a non-recurring event has none, so fall back to the event's own start.
+        start_dt = None
+        if start := recurrence_id or event.get("start"):
+            start_dt = datetime.fromisoformat(start)
+
+        # LocalDate values carry no zone — they are local to the event's timeZone. Convert
+        # timed events to the user's time zone for display; all-day dates stay as-is.
+        if start_dt and not all_day:
+            try:
+                user_time_zone = frappe.db.get_value("User", user, "time_zone")
+                start_dt = start_dt.replace(tzinfo=ZoneInfo(event.get("timeZone") or get_system_timezone()))
+                start_dt = start_dt.astimezone(ZoneInfo(user_time_zone or get_system_timezone()))
+            except Exception:
+                logger.warning("calendar-alert-timezone-conversion-failed")
+
+        if not start_dt:
+            body = _("Event starting soon")
+        elif all_day:
+            body = _("{0} · All day").format(start_dt.strftime("%a, %d %b"))
+        else:
+            body = _("{0} at {1}").format(
+                start_dt.strftime("%a, %d %b"), start_dt.strftime("%I:%M %p").lstrip("0")
+            )
+
+        url = frappe.utils.get_url()
+        link = f"{url}/calendar/account/{account}"
+        if start_dt:
+            link += f"/day/{start_dt.year}/{start_dt.month}/{start_dt.day}?event={quote(event_id, safe='')}"
+            if recurrence_id:
+                link += f"&recurrence={quote(recurrence_id, safe='')}"
+
+        pn.send_notification_to_user(
+            user,
+            event.get("title") or _("[No title]"),
+            body,
+            link,
+            f"{url}/assets/suite/calendar/images/logo.png",
+        )
+
+        logger.info("calendar-alert-notification-sent")
+
+    except Exception:
+        logger.error("calendar-alert-notification-failed")
+        log_mail_error(
+            _("Failed to send calendar alert notification"),
+            frappe.get_traceback(with_context=True),
+        )
+
+
+def enqueue_send_event_alert_notification(user: str, alert: dict, ctx: dict | None = None) -> None:
+    """Enqueues the device push notification for a triggered JMAP CalendarAlert."""
+
+    ctx = ctx or {}
+    logger = get_push_logger(ctx)
+
+    logger.debug("enqueueing-event-alert-notification")
+
+    with user_context("Administrator"):
+        enqueue_job(
+            send_event_alert_notification,
+            user=user,
+            alert=alert,
+            ctx=ctx,
+            queue="short",
+            enqueue_after_commit=True,
+        )
 
 
 def _previous_invite_state(account: str, id: str) -> tuple[list[str], int]:

--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -276,8 +276,8 @@ scheduler_events = {
         "suite.mail.doctype.jmap_account.jmap_account.delete_orphaned_jmap_accounts",
         "suite.mail.doctype.mail_exchange.mail_exchange.clean_import_export_directories",
         "suite.mail.doctype.push_subscription.push_subscription.renew_expiring_push_subscriptions",
-        "suite.calendar.doctype.calendar_exchange.calendar_exchange.clean_calendar_import_export_directories",
         "suite.mail.doctype.contacts_exchange.contacts_exchange.clean_contacts_import_export_directories",
+        "suite.calendar.doctype.calendar_exchange.calendar_exchange.clean_calendar_import_export_directories",
     ],
     "hourly": [
         # drive

--- a/suite/mail/api/jmap.py
+++ b/suite/mail/api/jmap.py
@@ -4,6 +4,7 @@ import frappe
 from frappe import _
 from frappe.utils import random_string
 
+from suite.calendar.doctype.calendar_event.calendar_event import enqueue_send_event_alert_notification
 from suite.mail.doctype.mail_message.mail_message import enqueue_fetch_changes
 from suite.mail.doctype.push_subscription.push_subscription import (
     decrypt_jmap_push_payload,
@@ -99,6 +100,14 @@ def push_notification() -> dict:
 
                     else:
                         logger.warning("unhandled-state-change-entity", entity=entity)
+
+            return {"status": "processed"}
+
+        elif event_type == "CalendarAlert":
+            ctx["account"] = request_data.get("accountId")
+
+            logger.info("calendar-alert-received")
+            enqueue_send_event_alert_notification(user, request_data, ctx=ctx)
 
             return {"status": "processed"}
 

--- a/suite/mail/doctype/push_subscription/push_subscription.json
+++ b/suite/mail/doctype/push_subscription/push_subscription.json
@@ -54,8 +54,7 @@
    "set_only_once": 1
   },
   {
-   "default": "[\n    \"Email\",\n    \"Mailbox\",\n    \"Identity\",\n    \"VacationResponse\"\n]",
-   "description": "A list of types the client is interested in. A `StateChange` notification will only be sent if the data for one of these types changes.",
+   "description": "A list of types the client is interested in. Leave blank to subscribe to all types. A `StateChange` notification is sent when data for a subscribed type changes; the `CalendarAlert` pseudo-type delivers triggered event alerts instead of state changes.",
    "fieldname": "types",
    "fieldtype": "JSON",
    "label": "Types",
@@ -87,7 +86,7 @@
  "index_web_pages_for_search": 1,
  "is_virtual": 1,
  "links": [],
- "modified": "2026-07-21 00:00:00.000000",
+ "modified": "2026-08-02 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Push Subscription",

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -14,7 +14,7 @@ from frappe.utils import cint, today
 from suite.mail.jmap import get_push_subscription_service
 from suite.mail.utils import generate_uuid_style_hash, log_mail_error
 from suite.mail.utils.dt import normalize_utc_z
-from suite.mail.utils.user import is_jmap_configured
+from suite.mail.utils.user import get_jmap_configured_users, is_jmap_configured
 from suite.utils import parse_filters
 from suite.utils.dt import get_utc_now, parse_iso_datetime
 from suite.utils.user import is_system_manager
@@ -246,7 +246,7 @@ def renew_push_subscription(user: str, id: str) -> None:
             frappe.throw(_(response["description"]), title=title)
 
 
-def renew_expiring_push_subscriptions() -> None:
+def z() -> None:
     """Renews soon-to-expire push subscriptions for all JMAP configured users.
 
     Scheduled to run daily. A subscription is renewed when its expiry is within
@@ -259,7 +259,7 @@ def renew_expiring_push_subscriptions() -> None:
 
     cutoff = get_utc_now() + timedelta(days=RENEW_THRESHOLD_DAYS)
 
-    for user in frappe.db.get_all("User Settings", {"enabled": 1, "username": ["!=", ""]}, pluck="user"):
+    for user in get_jmap_configured_users():
         try:
             service = get_push_subscription_service(user, ignore_permissions=True)
 

--- a/suite/mail/jmap/services/push_subscription.py
+++ b/suite/mail/jmap/services/push_subscription.py
@@ -64,12 +64,18 @@ class PushSubscriptionService(CoreService):
         for batch in self.create_batches(subscriptions, self.max_objects_in_set):
             payload = {}
             for subscription in batch:
-                payload[subscription["id"]] = {}
+                patch = {}
 
                 if verification_code := subscription.get("verification_code"):
-                    payload[subscription["id"]]["verificationCode"] = verification_code
-                else:
-                    payload[subscription["id"]]["expires"] = subscription.get("expires")
+                    patch["verificationCode"] = verification_code
+                if "types" in subscription:
+                    patch["types"] = subscription["types"]
+                # A bare {"id": ...} is a renewal: expires=null makes the server bump the
+                # subscription to its maximum lifetime.
+                if not patch or "expires" in subscription:
+                    patch["expires"] = subscription.get("expires")
+
+                payload[subscription["id"]] = patch
 
             response = self._update(payload)
 

--- a/suite/mail/patches/reset_push_subscription_types_to_all.py
+++ b/suite/mail/patches/reset_push_subscription_types_to_all.py
@@ -1,0 +1,42 @@
+import frappe
+from frappe import _
+
+from suite.mail.jmap import get_push_subscription_service
+from suite.mail.utils import log_mail_error
+from suite.mail.utils.user import get_jmap_configured_users
+
+
+def execute() -> None:
+    """Reset every push subscription's types to null, subscribing it to all types.
+
+    The JMAP server only pushes CalendarAlert notifications (triggered event alerts) to
+    subscriptions whose types include it. Subscriptions used to be created with an explicit
+    list ("Email", "Mailbox", "Identity", "VacationResponse") that predates calendar alert
+    support and would never receive them. Null means all supported types — including
+    CalendarAlert and any types added later — which is now also the default for new
+    subscriptions.
+    """
+
+    if not frappe.utils.get_url().startswith("https://"):
+        return
+
+    for user in get_jmap_configured_users():
+        try:
+            service = get_push_subscription_service(user, ignore_permissions=True)
+
+            updates = [{"id": subscription["id"], "types": None} for subscription in service.get()]
+            if not updates:
+                continue
+
+            response = service.update(updates)
+            if not_updated := response.get("notUpdated"):
+                errors = "<br>".join(f"{id}: {error['description']}" for id, error in not_updated.items())
+                log_mail_error(
+                    _("Push Subscription Update Failed"),
+                    _("Failed to reset push subscription types for user {0}:<br>{1}").format(user, errors),
+                )
+        except Exception as e:
+            log_mail_error(
+                _("Push Subscription Update Failed"),
+                _("Failed to reset push subscription types for user {0}: {1}").format(user, str(e)),
+            )

--- a/suite/mail/utils/user.py
+++ b/suite/mail/utils/user.py
@@ -22,6 +22,25 @@ def has_user_settings(user: str, raise_exception: bool = False) -> bool:
     return False
 
 
+def get_jmap_configured_users() -> list[str]:
+    """Returns enabled users that have JMAP credentials configured.
+
+    The enabled flag lives on User — User Settings has no such field — so the two doctypes
+    must be joined to filter on it.
+    """
+
+    USER = frappe.qb.DocType("User")
+    USER_SETTINGS = frappe.qb.DocType("User Settings")
+
+    return (
+        frappe.qb.from_(USER_SETTINGS)
+        .join(USER)
+        .on(USER.name == USER_SETTINGS.user)
+        .select(USER_SETTINGS.user)
+        .where((USER.enabled == 1) & (USER_SETTINGS.username != "") & (USER_SETTINGS.username.isnotnull()))
+    ).run(pluck="user")
+
+
 def is_jmap_configured(user: str, raise_exception: bool = False) -> bool:
     """Returns True if the user has JMAP settings configured else False."""
 

--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -89,5 +89,6 @@ suite.mail.patches.rename_default_mailboxes
 execute:frappe.db.set_single_value("Mail Settings", "verify_ssl", 1)
 execute:frappe.db.set_single_value("Mail Settings", "show_mail_client_config", 1)
 execute:frappe.db.set_single_value("Mail Settings", "custom_event_invites", 1)
+suite.mail.patches.reset_push_subscription_types_to_all
 # --- calendar ---
 # (no patches)


### PR DESCRIPTION
## What

Adds device push notifications for calendar event alerts. When an event's alert triggers, the JMAP server pushes a [`CalendarAlert`](https://github.com/jmapio/jmap/blob/master/spec/calendars/alerts.mdown#push-events) object to the push endpoint; we now forward it to the user's devices as a push notification before the event starts.

## How

- **`suite.mail.api.jmap.push_notification`**: new `CalendarAlert` branch (alongside `PushVerification` / `StateChange`) that enqueues a background job, so decryption and frozen-user checks apply unchanged.
- **`send_event_alert_notification`** (calendar_event.py): fetches the event with the user's own JMAP credentials (a forged alert can't surface another account's event), then sends title, instance start time converted to the user's time zone, and a deep link to the day view (`?event=` opens the detail sidebar for non-recurring events). For recurring events the alert's `recurrenceId` is the triggering instance's local start, so the notification shows that instance's time.

## Push subscription types

The server only delivers `CalendarAlert` to subscriptions whose `types` include it, and `types: null` means all types. Subscriptions now default to `null`:

- Doctype no longer defaults to an explicit list; blank → `null` → all types (including future pseudo-types).
- The New Push Subscription modal shows an **All** checkbox (default on, sends no `types`); unchecking reveals the per-type list, which now includes `CalendarAlert`.
- `PushSubscriptionService.update` supports patching `types` (mutable per RFC 8620); renewals still send a bare `expires: null`.
- New patch `reset_push_subscription_types_to_all` resets existing subscriptions to `null`, since they were created with the old explicit list that predates calendar alerts.

## Fix

`renew_expiring_push_subscriptions` filtered User Settings on an `enabled` column that doesn't exist (crashes with `Unknown column 'enabled'`); the flag lives on User. The new `get_jmap_configured_users` helper joins the two doctypes and is used by both the daily job and the patch, so they only act on enabled users.