### PR TITLE
fix(mail): handle missing description in JMAP SetError during patch

### DIFF
--- a/suite/mail/patches/reset_push_subscription_types_to_all.py
+++ b/suite/mail/patches/reset_push_subscription_types_to_all.py
@@ -30,7 +30,11 @@ def execute() -> None:
 
             response = service.update(updates)
             if not_updated := response.get("notUpdated"):
-                errors = "<br>".join(f"{id}: {error['description']}" for id, error in not_updated.items())
+                errors = "<br>".join(
+                    # SetError's description is optional; fall back to its required type
+                    f"{id}: {error.get('description') or error.get('type')}"
+                    for id, error in not_updated.items()
+                )
                 log_mail_error(
                     _("Push Subscription Update Failed"),
                     _("Failed to reset push subscription types for user {0}:<br>{1}").format(user, errors),


### PR DESCRIPTION
## Problem

The `reset_push_subscription_types_to_all` patch logged:

> Failed to reset push subscription types for user sadiq@frappe.io: 'description'

This is a `KeyError`, not the real failure. Per RFC 8620, a JMAP `SetError` always has a `type` field but `description` is optional. When the server returned a `notUpdated` entry without a description, `error['description']` raised, and the outer `except` logged the key name instead of the actual update error.

## Fix

Fall back to the error's required `type` field when `description` is absent, so the log shows why the subscription update failed.