### PR TITLE
fix(mail): guard contact search makeParams against non-string input

### DIFF
--- a/frontend/src/apps/calendar/components/ParticipantSelector.vue
+++ b/frontend/src/apps/calendar/components/ParticipantSelector.vue
@@ -29,10 +29,16 @@ const normalizedExcludedEmails = computed(() =>
 
 const mailContacts = createResource({
 	url: 'suite.mail.api.contacts.get_contacts',
-	makeParams: (text: string) => ({
-		account: props.account,
-		filter: { operator: 'OR', conditions: [{ text }, { email: text }] },
-	}),
+	makeParams: (text: string) => {
+		// frappe-ui's fetch nulls Event params and reuses the previous params object when called
+		// with a falsy value, feeding it back here as `text` — guard against a non-string so the
+		// previous {account, filter} object can't get nested into a new filter.
+		const query = typeof text === 'string' ? text : ''
+		return {
+			account: props.account,
+			...(query ? { filter: { operator: 'OR', conditions: [{ text: query }, { email: query }] } } : {}),
+		}
+	},
 	transform: (data: any[]) => data.map((contact) => contact.email),
 })
 

--- a/frontend/src/apps/mail/components/ContactCombobox.vue
+++ b/frontend/src/apps/mail/components/ContactCombobox.vue
@@ -35,10 +35,16 @@ const store = userStore()
 const contactSearch = createResource({
 	url: 'suite.mail.api.contacts.get_contacts',
 	auto: false,
-	makeParams: (text: string) => ({
-		account: store.accountId,
-		filter: { operator: 'OR', conditions: [{ text }, { email: text }] },
-	}),
+	makeParams: (text: string) => {
+		// frappe-ui's fetch nulls Event params and reuses the previous params object when called
+		// with a falsy value, feeding it back here as `text` — guard against a non-string so the
+		// previous {account, filter} object can't get nested into a new filter.
+		const query = typeof text === 'string' ? text : ''
+		return {
+			account: store.accountId,
+			...(query ? { filter: { operator: 'OR', conditions: [{ text: query }, { email: query }] } } : {}),
+		}
+	},
 	transform: (data: { email: string; full_name?: string; user_image?: string }[]) =>
 		data.map((o) => {
 			const name = o.full_name || ''

--- a/frontend/src/apps/mail/components/Controls/RecipientInput.vue
+++ b/frontend/src/apps/mail/components/Controls/RecipientInput.vue
@@ -216,10 +216,16 @@ const handleDrop = (e: DragEvent) => {
 const mailContacts = createResource({
 	url: 'suite.mail.api.contacts.get_contacts',
 	auto: false,
-	makeParams: (text: string) => ({
-		account: store.accountId,
-		filter: { operator: 'OR', conditions: [{ text }, { email: text }] },
-	}),
+	makeParams: (text: string) => {
+		// frappe-ui's fetch nulls Event params and reuses the previous params object when called
+		// with a falsy value, feeding it back here as `text` — guard against a non-string so the
+		// previous {account, filter} object can't get nested into a new filter.
+		const query = typeof text === 'string' ? text : ''
+		return {
+			account: store.accountId,
+			...(query ? { filter: { operator: 'OR', conditions: [{ text: query }, { email: query }] } } : {}),
+		}
+	},
 	transform: (data) =>
 		data.map((option) => ({
 			label: option.full_name || option.email,


### PR DESCRIPTION
## Problem

`get_contacts` requests from the contact search comboboxes intermittently failed with a Stalwart 400:

> urn:ietf:params:jmap:error:notRequest

The logged request shows a recursively nested filter — each `text`/`email` condition contains the entire previous `{account, filter}` params object instead of a search string.

## Cause

frappe-ui's `createResource.fetch` nulls params that are DOM `Event` objects and, when called with a falsy value, reuses the previous computed params object and feeds it back through `makeParams`. The `if (text)` guards at the call sites don't help because an `InputEvent` is truthy. So `makeParams` first receives `null` (the innermost `{"text": null}` conditions), then on each subsequent such call receives its own previous return value and wraps it into a new OR filter — one nesting level per call until the server rejects the request.

`SearchModal` was already hardened against exactly this (with a comment documenting the frappe-ui behaviour); the other three callers weren't.

## Fix

Apply the same guard to `RecipientInput`, `ParticipantSelector` and `ContactCombobox`: coerce a non-string `text` to an empty query and omit the `filter` param entirely when the query is empty, so a previous params object can never be nested into a new filter.