### PR TITLE
fix(drive): don't email share notifications to non-user principals

### DIFF
--- a/suite/drive/doctype/drive_permission/drive_permission.py
+++ b/suite/drive/doctype/drive_permission/drive_permission.py
@@ -5,6 +5,7 @@ import frappe
 from frappe.model.document import Document
 
 from suite.drive.api.notifications import notify_share
+from suite.drive.utils import GENERAL_USER, GROUP_PREFIX
 
 
 class DrivePermission(Document):
@@ -13,7 +14,9 @@ class DrivePermission(Document):
         # historical grants would mail everyone about folders they already had.
         if frappe.flags.in_install or frappe.flags.in_migrate or frappe.flags.in_patch:
             return
-        if self.user:
+        # Only individual users get notified — "" (anyone with the link),
+        # $GENERAL (site users) and $GROUP: rows are not email addresses.
+        if self.user and self.user != GENERAL_USER and not self.user.startswith(GROUP_PREFIX):
             frappe.enqueue(
                 notify_share,
                 queue="short",


### PR DESCRIPTION
## Problem

Sharing a file with **all site users** (`user = $GENERAL`) or with a **user group** (`user = $GROUP:<name>`) creates a Drive Permission row whose `user` is a placeholder principal, not an email address. `DrivePermission.after_insert` only skipped the empty (anyone-with-link) row, so `notify_share` ran for these rows and `frappe.sendmail(recipients="$GENERAL")` queued mail that failed with:

```
frappe.exceptions.InvalidEmailAddressError: $GENERAL is not a valid Email Address
```

Seen in production via `suite.drive.api.files.update_access` with `user: "$GENERAL"`.

## Fix

Skip the share notification for `$GENERAL` and `$GROUP:`-prefixed rows in `after_insert` — only individual users are notified.