### PR TITLE
fix(drive): skip empty trash cleanup in auto_delete_from_trash

### DIFF
--- a/suite/drive/api/scripts.py
+++ b/suite/drive/api/scripts.py
@@ -97,7 +97,8 @@ def auto_delete_from_trash():
         filters={"status": STATUS_TRASHED, "file_modified": ["<", days_before]},
         fields=["name"],
     )
-    delete_entities(result)
+    if result:
+        delete_entities(result)
 
 
 def clear_deleted_files():


### PR DESCRIPTION
The daily `auto_delete_from_trash` job fails whenever the 30-day trash sweep comes back empty.

`suite/drive/api/scripts.py`:

```python
result = frappe.db.get_all(
    "File",
    filters={"status": STATUS_TRASHED, "file_modified": ["<", days_before]},
    fields=["name"],
)
delete_entities(result)
```

`delete_entities()` rejects an empty list explicitly (`suite/drive/api/files.py`):

```python
elif not isinstance(entity_names, list) or not entity_names:
    frappe.throw(f"Expected non-empty list but got {type(entity_names)}", ValueError)
```

So on any day where nothing in the trash is older than 30 days, `result` is `[]` and the scheduled job raises `ValueError: Expected non-empty list but got <class 'list'>` instead of doing nothing. On a site with a quiet trash that is most days, which fills the scheduler error log and makes a genuinely failing run harder to spot.

That guard is correct for the whitelisted callers — an explicit user-triggered delete with nothing selected really is a bad request. It just isn't right for the scheduled sweep, where "nothing to do" is the normal case, so fixing it at the call site keeps the API contract intact.

`clear_deleted_files()` directly below already handles the empty case naturally, since it iterates rather than passing the list along.

**Change:** guard the call so an empty sweep is a no-op.

```python
if result:
    delete_entities(result)
```

No behaviour change when there is something to delete.
