### PR TITLE
fix(mail): recursively sanitize client-supplied contact filters

### DIFF
--- a/suite/mail/api/contacts.py
+++ b/suite/mail/api/contacts.py
@@ -22,12 +22,28 @@ def get_address_books(account: str) -> list[dict]:
     return [{f: d[f] for f in fields} for d in address_books]
 
 
+def sanitize_filter(filter: dict | None) -> dict | None:
+    """Recursively removes conditions with empty values from the given JMAP filter."""
+
+    if not filter:
+        return None
+
+    if "conditions" in filter:
+        conditions = [c for c in map(sanitize_filter, filter["conditions"] or []) if c]
+        if not conditions:
+            return None
+        if len(conditions) == 1:
+            return conditions[0]
+        return {**filter, "conditions": conditions}
+
+    return {k: v for k, v in filter.items() if v} or None
+
+
 @frappe.whitelist()
 def get_contact_cards(account: str, filter: dict | None = None, limit: int = 50) -> list[dict]:
     """Returns the contact cards for the given account."""
 
-    if filter:
-        filter = {k: v for k, v in filter.items() if v}
+    filter = sanitize_filter(filter)
 
     if not (contact_cards := fetch_contact_cards(account, filter, 0, limit)[0]):
         return []


### PR DESCRIPTION
## Problem

Production error on `suite.mail.api.contacts.get_contacts`:

```
Request failed with status 400: {"type":"urn:ietf:params:jmap:error:notRequest", ...}
```

Stale frontend bundles (pre-#459 / 13d1dab33) send contact search filters with null condition values — `{"operator": "OR", "conditions": [{"text": null}, {"email": null}]}` — when frappe-ui nulls the query param. The existing sanitization in `get_contact_cards` only stripped **top-level** falsy values, so the nulls inside `conditions` passed through untouched and reached Stalwart, which rejects them with a 400 `notRequest` error.

## Fix

Sanitize the filter recursively before querying:

- conditions with empty values are dropped
- a lone surviving condition is unwrapped from its `operator` wrapper
- a fully-empty filter collapses to `None` (an unfiltered query — same as no search text)

The exact failing payload above now collapses to `None` instead of erroring, while valid searches like `OR [{text: "ne"}, {email: "ne"}]` pass through unchanged. Nested filters (e.g. `AND(OR(text, email), inAddressBook)` from ContactsModal) sanitize correctly at every level.

This is defense-in-depth alongside the frontend guard from 13d1dab33: that stops current clients from sending null filters; this stops any client — including cached stale bundles — from turning them into logged JMAP 400s.
