### PR TITLE
fix(sheets): auto-focus Find input when opening Find & Replace dialog

### DIFF
--- a/frontend/src/apps/sheets/components/SheetEditor/FindReplace.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/FindReplace.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fr-panel">
+  <div class="fr-panel" ref="panelRef">
     <div class="fr-header">
       <span class="fr-title">Find &amp; Replace</span>
       <Button variant="ghost" size="sm" icon="x" @click="emit('close')" />
@@ -11,6 +11,7 @@
       placeholder="Find"
       autocomplete="off"
       @keydown.enter="findNext"
+      @keydown.escape="emit('close')"
     />
     <FormControl
       type="text"
@@ -29,7 +30,7 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { ref, watch, onMounted, nextTick } from 'vue'
 import { Button, FormControl } from 'frappe-ui'
 
 const props = defineProps({
@@ -45,6 +46,30 @@ const replaceQuery = ref('')
 const matches      = ref([])
 const matchIndex   = ref(-1)
 const status       = ref('')
+const panelRef     = ref(null)
+
+function focusInput() {
+  const doFocus = () => {
+    const input = panelRef.value?.querySelector('input')
+    if (input && typeof input.focus === 'function') {
+      input.focus()
+      if (typeof input.select === 'function') {
+        input.select()
+      }
+    }
+  }
+  nextTick(doFocus)
+  setTimeout(doFocus, 0)
+  setTimeout(doFocus, 50)
+}
+
+onMounted(() => {
+  focusInput()
+})
+
+defineExpose({
+  focusInput,
+})
 
 function _buildMatches() {
   const q = findQuery.value.toLowerCase()

--- a/frontend/src/apps/sheets/components/SheetEditor/commandPalette.config.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/commandPalette.config.js
@@ -31,7 +31,7 @@ function buildFormatGroup({ toggleFmt, setAlign, setValign, adjustDecimals, togg
   }
 }
 
-function buildEditGroup({ undo, redo, repeatLast, showFindReplace, showFormulas, repopulateGrid, showShortcutsHelp }) {
+function buildEditGroup({ undo, redo, repeatLast, showFindReplace, openFindReplace, showFormulas, repopulateGrid, showShortcutsHelp }) {
   return {
     title: 'Edit',
     component: CommandPaletteItem,
@@ -39,7 +39,7 @@ function buildEditGroup({ undo, redo, repeatLast, showFindReplace, showFormulas,
       item('undo',      'Undo',               'Ctrl+Z', () => undo()),
       item('redo',      'Redo',               'Ctrl+Y', () => redo()),
       item('repeat',    'Repeat last action', 'F4',     () => repeatLast()),
-      item('find',      'Find & replace',     'Ctrl+F', () => { showFindReplace.value = true }),
+      item('find',      'Find & replace',     'Ctrl+F', () => { openFindReplace ? openFindReplace() : (showFindReplace.value = true) }),
       item('formulas',  'Show formulas',      'Ctrl+`', () => { showFormulas.value = !showFormulas.value; repopulateGrid() }),
       item('shortcuts', 'Keyboard shortcuts', '?',      () => { showShortcutsHelp.value = true }),
     ],

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -871,10 +871,11 @@
     <!-- Find & Replace panel -->
     <FindReplace
       v-if="showFindReplace"
+      ref="findReplaceRef"
       :sheet="sheet"
       :grid="grid"
       :is-protected="(id) => _cellSilentlyProtected(id)"
-      @close="showFindReplace = false"
+      @close="showFindReplace = false; canvasRef?.focus?.()"
       @navigate-to="onNavigateTo"
     />
 
@@ -1641,6 +1642,17 @@ const editingHomeCell  = ref(null)
 // `number:3` still shows "Number" as selected.
 const activeNumberFormatType = computed(() => parseNumberFmt(activeNumberFormat.value).type)
 const showFindReplace   = ref(false)
+const findReplaceRef    = ref(null)
+
+function openFindReplace() {
+  document.activeElement?.blur?.()
+  showFindReplace.value = true
+  const triggerFocus = () => findReplaceRef.value?.focusInput?.()
+  nextTick(triggerFocus)
+  setTimeout(triggerFocus, 0)
+  setTimeout(triggerFocus, 50)
+}
+
 const showShortcutsHelp = ref(false)
 
 const showInsertManyDialog = ref(false)
@@ -3944,7 +3956,7 @@ function _deleteRowsColsFromSelection() {
 const { onGlobalKey } = useShortcuts({
   formulaInputEl:           () => formulaInputRef.value,
   undo, redo, onSave, toggleFmt, repeatLast, toggleShowFormulas,
-  showFindReplace,
+  showFindReplace, openFindReplace,
   openVersionHistory, openHyperlinkDialog, openCommentPanel, openQuickFilterForActive,
   zoomBy, resetZoom,
   commentPanel, dropdownPanel, splitText,
@@ -5706,7 +5718,7 @@ const cmdQuery       = ref('')
 
 const cmdGroups = computed(() => buildCommandGroups({
   toggleFmt, setAlign, setValign, adjustDecimals, toggleWrap, clearFormatting,
-  undo, redo, repeatLast, showFindReplace, showFormulas, repopulateGrid: _repopulateGrid, showShortcutsHelp,
+  undo, redo, repeatLast, showFindReplace, openFindReplace, showFormulas, repopulateGrid: _repopulateGrid, showShortcutsHelp,
   contextMenu, getGrid: () => grid,
   doInsertRow, doDeleteRow, doInsertCol, doDeleteCol,
   doHideRows, doHideCols, doUnhideAllRows, doUnhideAllCols,

--- a/frontend/src/apps/sheets/components/SheetEditor/useShortcuts.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/useShortcuts.js
@@ -53,7 +53,7 @@ const NUMBER_FORMAT_KEYS = {
 export function useShortcuts(actions) {
   const {
     formulaInputEl, undo, redo, onSave, toggleFmt, repeatLast,
-    toggleShowFormulas, showFindReplace,
+    toggleShowFormulas, showFindReplace, openFindReplace,
     openVersionHistory, openHyperlinkDialog, openCommentPanel, openQuickFilterForActive,
     zoomBy, resetZoom,
     commentPanel, dropdownPanel, splitText, revertSplitPreview, closeSplit,
@@ -79,7 +79,18 @@ export function useShortcuts(actions) {
   useShortcut([
     // View / tools — available even in read-only.
     { key: 's',  ctrl: true, description: 'Save',            group: 'View', handler: onSave },
-    { key: 'f',  ctrl: true, description: 'Find & replace',  group: 'View', handler: () => { showFindReplace.value = true } },
+    {
+      key: 'f',
+      ctrl: true,
+      description: 'Find & replace',
+      group: 'View',
+      allowInInput: true,
+      handler: () => {
+        document.activeElement?.blur?.()
+        if (openFindReplace) openFindReplace()
+        else if (showFindReplace) showFindReplace.value = true
+      },
+    },
     { key: '`',  ctrl: true, description: 'Show formulas',   group: 'View', handler: toggleShowFormulas },
     { key: '=',  ctrl: true, description: 'Zoom in',         group: 'View', handler: () => zoomBy(+0.1) },
     { key: '+',  ctrl: true, description: 'Zoom in',         group: 'View', handler: () => zoomBy(+0.1) },


### PR DESCRIPTION
- Blur active element (cell editor or formula bar) when Ctrl+F is pressed
- Allow Ctrl+F shortcut to trigger while typing inside inputs/textareas
- Focus and select text in Find input box when panel opens or re-focuses
- Restore focus to canvas when closing Find & Replace panel

Closes #467