### PR TITLE
fix(mail,calendar): omit empty limit in export params

### DIFF
--- a/frontend/src/apps/calendar/components/Settings/ExportSettings.vue
+++ b/frontend/src/apps/calendar/components/Settings/ExportSettings.vue
@@ -145,7 +145,12 @@ const createCalendarExport = createResource({
 		// in the user's zone or the first/last hours of the range get cut off.
 		if (cleanedFilter.after) cleanedFilter.after = utcDayStart(cleanedFilter.after as string)
 		if (cleanedFilter.before) cleanedFilter.before = utcDayEnd(cleanedFilter.before as string)
-		return { account: accountId, ...calendarExport, filter: cleanedFilter }
+		return {
+			account: accountId,
+			...calendarExport,
+			limit: calendarExport.limit || undefined,
+			filter: cleanedFilter,
+		}
 	},
 	onSuccess: () => ongoingExport.reload(),
 })

--- a/frontend/src/apps/mail/components/Settings/ContactsExportSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/ContactsExportSettings.vue
@@ -107,7 +107,12 @@ const createContactsExport = createResource({
 				.map(([k, v]) => [k, typeof v === 'string' ? v.trim() : v])
 				.filter(([, v]) => Boolean(v)),
 		)
-		return { account: accountId, ...contactsExport, filter: cleanedFilter }
+		return {
+			account: accountId,
+			...contactsExport,
+			limit: contactsExport.limit || undefined,
+			filter: cleanedFilter,
+		}
 	},
 	onSuccess: () => ongoingExport.reload(),
 })

--- a/frontend/src/apps/mail/components/Settings/MailExportSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/MailExportSettings.vue
@@ -143,7 +143,12 @@ const createMailExport = createResource({
 		// in the user's zone or the first/last hours of the range get cut off.
 		if (cleanedFilter.after) cleanedFilter.after = utcDayStart(cleanedFilter.after as string)
 		if (cleanedFilter.before) cleanedFilter.before = utcDayEnd(cleanedFilter.before as string)
-		return { account: accountId, ...mailExport, filter: cleanedFilter }
+		return {
+			account: accountId,
+			...mailExport,
+			limit: mailExport.limit || undefined,
+			filter: cleanedFilter,
+		}
 	},
 	onSuccess: () => ongoingExport.reload(),
 })


### PR DESCRIPTION
## Problem

Creating a mail, contacts, or calendar export with the **Max Number of …** field left blank fails with:

```
FrappeTypeError: Argument 'limit' in 'suite.mail.api.account.create_contacts_export' should be of type 'int | None' but got 'str' instead.
```

The number input's `v-model` yields an empty string `''` when the field is blank (or cleared after typing), which is sent as `limit: ''` and rejected by backend type validation. The same pattern exists in all three export settings components (`create_mail_export`, `create_contacts_export`, `create_calendar_export`).

## Fix

Coerce a falsy `limit` to `undefined` in `makeParams` so the parameter is omitted from the request when the field is blank. Applied to:

- `frontend/src/apps/mail/components/Settings/ContactsExportSettings.vue`
- `frontend/src/apps/mail/components/Settings/MailExportSettings.vue`
- `frontend/src/apps/calendar/components/Settings/ExportSettings.vue`

Import components are unaffected (they use a hardcoded limit).