### PR TITLE
feat(mail,calendar): tiered email suggestions for all email input fields

### DIFF
--- a/frontend/src/apps/calendar/components/ParticipantSelector.vue
+++ b/frontend/src/apps/calendar/components/ParticipantSelector.vue
@@ -28,17 +28,13 @@ const normalizedExcludedEmails = computed(() =>
 )
 
 const mailContacts = createResource({
-	url: 'suite.mail.api.contacts.get_contacts',
-	makeParams: (text: string) => {
+	url: 'suite.mail.api.mail.get_email_suggestions',
+	makeParams: (text: string) => ({
+		account: props.account,
 		// frappe-ui's fetch nulls Event params and reuses the previous params object when called
-		// with a falsy value, feeding it back here as `text` — guard against a non-string so the
-		// previous {account, filter} object can't get nested into a new filter.
-		const query = typeof text === 'string' ? text : ''
-		return {
-			account: props.account,
-			...(query ? { filter: { operator: 'OR', conditions: [{ text: query }, { email: query }] } } : {}),
-		}
-	},
+		// with a falsy value, feeding it back here as `text` — guard against a non-string.
+		text: typeof text === 'string' ? text : '',
+	}),
 	transform: (data: any[]) => data.map((contact) => contact.email),
 })
 

--- a/frontend/src/apps/mail/components/ContactCombobox.vue
+++ b/frontend/src/apps/mail/components/ContactCombobox.vue
@@ -33,21 +33,17 @@ const model = defineModel<string>()
 const store = userStore()
 
 const contactSearch = createResource({
-	url: 'suite.mail.api.contacts.get_contacts',
+	url: 'suite.mail.api.mail.get_email_suggestions',
 	auto: false,
-	makeParams: (text: string) => {
+	makeParams: (text: string) => ({
+		account: store.accountId,
 		// frappe-ui's fetch nulls Event params and reuses the previous params object when called
-		// with a falsy value, feeding it back here as `text` — guard against a non-string so the
-		// previous {account, filter} object can't get nested into a new filter.
-		const query = typeof text === 'string' ? text : ''
-		return {
-			account: store.accountId,
-			...(query ? { filter: { operator: 'OR', conditions: [{ text: query }, { email: query }] } } : {}),
-		}
-	},
-	transform: (data: { email: string; full_name?: string; user_image?: string }[]) =>
+		// with a falsy value, feeding it back here as `text` — guard against a non-string.
+		text: typeof text === 'string' ? text : '',
+	}),
+	transform: (data: { email: string; name?: string; user_image?: string }[]) =>
 		data.map((o) => {
-			const name = o.full_name || ''
+			const name = o.name || ''
 			return { value: o.email, label: name || o.email, email: o.email, display_name: name, image: o.user_image }
 		}),
 })

--- a/frontend/src/apps/mail/components/Controls/RecipientInput.vue
+++ b/frontend/src/apps/mail/components/Controls/RecipientInput.vue
@@ -214,24 +214,20 @@ const handleDrop = (e: DragEvent) => {
 }
 
 const mailContacts = createResource({
-	url: 'suite.mail.api.contacts.get_contacts',
+	url: 'suite.mail.api.mail.get_email_suggestions',
 	auto: false,
-	makeParams: (text: string) => {
+	makeParams: (text: string) => ({
+		account: store.accountId,
 		// frappe-ui's fetch nulls Event params and reuses the previous params object when called
-		// with a falsy value, feeding it back here as `text` — guard against a non-string so the
-		// previous {account, filter} object can't get nested into a new filter.
-		const query = typeof text === 'string' ? text : ''
-		return {
-			account: store.accountId,
-			...(query ? { filter: { operator: 'OR', conditions: [{ text: query }, { email: query }] } } : {}),
-		}
-	},
+		// with a falsy value, feeding it back here as `text` — guard against a non-string.
+		text: typeof text === 'string' ? text : '',
+	}),
 	transform: (data) =>
 		data.map((option) => ({
-			label: option.full_name || option.email,
+			label: option.name || option.email,
 			value: option.email,
 			email: option.email,
-			display_name: option.full_name,
+			display_name: option.name,
 			image: option.user_image,
 		})),
 })

--- a/frontend/src/apps/mail/components/Modals/SearchModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SearchModal.vue
@@ -387,24 +387,19 @@ const folderMatches = computed<MailboxData[]>(() =>
 )
 
 const contactSearch = createResource({
-	url: 'suite.mail.api.contacts.get_contacts',
+	url: 'suite.mail.api.mail.get_email_suggestions',
 	auto: false,
-	makeParams: (text: string) => {
+	makeParams: (text: string) => ({
+		account: store.accountId,
 		// frappe-ui's fetch reuses the previous params object when called with a falsy value (our
 		// intended empty query) and feeds it back here as `text`, so guard against a non-string.
-		const query = typeof text === 'string' ? text : ''
-		return {
-			account: store.accountId,
-			limit: 5,
-			// Omit the filter entirely for an empty query → the backend returns a default contact list, so the
-			// dropdown is populated the moment an operator (e.g. `from:`) is inserted, before anything is typed.
-			// (Sending `filter: undefined` can serialize to the string "undefined" and error server-side.)
-			...(query ? { filter: { operator: 'OR', conditions: [{ text: query }, { email: query }] } } : {}),
-		}
-	},
-	transform: (data: { email: string; full_name?: string; user_image?: string }[]) =>
+		// An empty query returns [] (no default contact list), which also clears stale matches.
+		text: typeof text === 'string' ? text : '',
+		limit: 5,
+	}),
+	transform: (data: { email: string; name?: string; user_image?: string }[]) =>
 		data.map((o) => {
-			const name = o.full_name || ''
+			const name = o.name || ''
 			// Shape serves both consumers: the inline operator dropdown (email/name/image) and the advanced
 			// comboboxes (value/label/display_name for frappe-ui's Combobox).
 			return { value: o.email, label: name || o.email, email: o.email, name, display_name: name, image: o.user_image }

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -10,7 +10,11 @@ from frappe import _
 from frappe.model.document import bulk_insert
 from frappe.utils import cint, random_string
 
-from suite.mail.api.contacts import create_contacts_if_not_exists
+from suite.mail.api.contacts import (
+    create_contacts_if_not_exists,
+    enrich_contacts_with_user_images,
+    get_contacts,
+)
 from suite.mail.api.utils import get_avatar_url
 from suite.mail.doctype.mail_message.mail_message import (
     add_messages_to_mailbox,
@@ -1023,6 +1027,45 @@ def search_email_addresses(account: str, text: str, limit: int = 10) -> list[dic
     get_user_for_jmap_account(account, raise_exception=True)
 
     return get_email_address_index(account).search_email_addresses(text, limit=cint(limit))
+
+
+@frappe.whitelist()
+def get_email_suggestions(account: str, text: str, limit: int = 10) -> list[dict]:
+    """Suggest up to `limit` {name, email, user_image} recipients matching `text`.
+
+    Sources are tried in cost order — the account's local address index (built from cached messages
+    and contacts), then a JMAP contact search, and finally the server-side email search (slowest —
+    it queries the JMAP server's messages) — falling through to the next source only when the
+    previous one returned nothing.
+    """
+
+    get_user_for_jmap_account(account, raise_exception=True)
+
+    text = (text or "").strip()
+    limit = cint(limit) or 10
+    if not text:
+        return []
+
+    suggestions = get_email_address_index(account).search_email_addresses(text, limit=limit)
+
+    if not suggestions:
+        filter = {"operator": "OR", "conditions": [{"text": text}, {"email": text}]}
+        seen = set()
+        for contact in get_contacts(account, filter, limit):
+            email = (contact.get("email") or "").strip()
+            if email and email.lower() not in seen:
+                seen.add(email.lower())
+                suggestions.append({"name": contact.get("full_name") or None, "email": email})
+
+    if not suggestions:
+        suggestions = [
+            {"name": None, "email": email}
+            for email in get_email_service(account).get_email_suggestions(text, limit=limit)
+        ]
+
+    suggestions = suggestions[:limit]
+    enrich_contacts_with_user_images(suggestions)
+    return suggestions
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Closes #54

## What

Adds `suite.mail.api.mail.get_email_suggestions(account, text, limit)` and points every email autocomplete input in the Mail and Calendar UI at it.

Sources are tried in cost order, falling through to the next one only when the previous returned nothing:

1. **Local address index** (`search_email_addresses`) — cached emails and contacts, no JMAP round trip.
2. **JMAP contact search** (`get_contacts`) with a `text`/`email` OR filter.
3. **Server-side email search** (`EmailService.get_email_suggestions`) — slowest, queries the JMAP server's messages.

Results are trimmed to `limit` and enriched with `user_image` for avatars.

## Frontend

Switched from `suite.mail.api.contacts.get_contacts` to the new endpoint:

- `RecipientInput.vue` — compose To/Cc/Bcc
- `ContactCombobox.vue` — advanced search From/To/Cc/Bcc comboboxes
- `SearchModal.vue` — inline `from:`/`to:`/`cc:`/`bcc:` operator autocomplete; also removes the no-query default contact list load (previously fetched contacts with no filter the moment an operator was typed)
- `ParticipantSelector.vue` — calendar event participants

`ContactsModal.vue` (the "Select Contacts" browser) intentionally stays on `get_contacts`: it's a contact list with address-book filtering and pagination, not an email input.