### PR TITLE
feat(mail,calendar): add-to-calendar banner for .ics email invites

### DIFF
--- a/frontend/src/apps/calendar/components/EventDetailSidebar.vue
+++ b/frontend/src/apps/calendar/components/EventDetailSidebar.vue
@@ -50,12 +50,23 @@ const RSVP_OPTIONS = [
 	{ label: __('Maybe'), value: 'TENTATIVE' },
 ]
 
+// RSVPs go through the dedicated endpoint rather than a whole-event edit: it patches only the
+// caller's own participationStatus, and routes the organizer's notification through the custom
+// event_response template when custom event invites are enabled.
+const rsvpEvent = createResource({
+	url: 'suite.calendar.api.rsvp_calendar_event',
+	makeParams: (response: string) => ({
+		account: store.accountId,
+		// master_id is only set on recurring events; fall back to the event's own id
+		id: calendarEvent.master_id || calendarEvent.id,
+		response: response.toLowerCase(),
+	}),
+	onSuccess: () => emit('reloadEvents'),
+})
+
 const handleSetResponse = (response: string) => {
 	if (!response || response === userResponse.value) return
-	const participants = calendarEvent.participants.map((p) =>
-		p.email === userParticipant.value?.email ? { ...p, participation_status: response } : p,
-	)
-	toast.promise(editEvent.submit({ patch: { participants } }), {
+	toast.promise(rsvpEvent.submit(response), {
 		loading: __('Sending response...'),
 		success: __('Response sent.'),
 		error: __('Action failed. Please try again in some time.'),

--- a/frontend/src/apps/mail/components/CalendarInviteBanner.vue
+++ b/frontend/src/apps/mail/components/CalendarInviteBanner.vue
@@ -1,0 +1,119 @@
+<template>
+	<div
+		v-if="invite"
+		class="text-ink-gray-6 mb-3 flex flex-col gap-3 rounded border p-2.5 px-4 sm:flex-row sm:items-center"
+	>
+		<div class="flex min-w-0 flex-1 items-center gap-3">
+			<CalendarPlus class="h-4.5 w-4.5 shrink-0 stroke-1.5" />
+			<div class="min-w-0 flex-1">
+				<span class="text-ink-gray-8 block truncate">
+					{{ invite.event.title || __('Untitled event') }}
+				</span>
+				<span v-if="whenLabel" class="block truncate">{{ whenLabel }}</span>
+			</div>
+		</div>
+		<div class="flex shrink-0 items-center justify-end gap-3">
+			<Button
+				v-if="!invite.exists"
+				:label="__('Add to Calendar')"
+				:loading="addInvite.loading"
+				@click="addInvite.submit()"
+			/>
+			<Button
+				v-else
+				variant="outline"
+				:label="__('View in Calendar')"
+				@click="viewInCalendar"
+			/>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { CalendarPlus } from 'lucide-vue-next'
+import { Button, createResource } from 'frappe-ui'
+
+import dayjs from '@/apps/calendar/utils/dayjs'
+import { eventDayRoute, useUpcomingEvents } from '@/apps/mail/composables/useUpcomingEvents'
+import { raiseToast } from '@/apps/mail/utils'
+
+import type { Attachment } from '@/apps/mail/types'
+
+// The slice of the formatted calendar event the banner reads; the full shape comes from the
+// backend's format_calendar_event, identical for a parsed preview and an existing event.
+interface InviteEvent {
+	id: string
+	title: string
+	start: string
+	duration: string
+	time_zone: string
+	show_without_time: 0 | 1
+	recurrence_id?: string | null
+}
+
+interface InviteDetails {
+	uid: string
+	method: string
+	exists: boolean
+	event: InviteEvent
+}
+
+const { attachment, account } = defineProps<{ attachment: Attachment; account: string }>()
+
+const router = useRouter()
+
+const details = createResource({
+	url: 'suite.calendar.api.invites.get_invite_details',
+	params: { account, blob_id: attachment.blob_id },
+	auto: true,
+})
+
+// Only an invitation (or a plain published event) is addable — a cancellation or an attendee's
+// reply also travels as text/calendar, and a banner offering to add those would be nonsense.
+const invite = computed<InviteDetails | null>(() => {
+	const data = details.data
+	if (!data?.event) return null
+	if (data.method && !['request', 'publish'].includes(data.method)) return null
+	return data
+})
+
+// JSCalendar start/duration are a wall clock in the event's own zone; render them in the
+// reader's, mirroring the calendar app (see @/apps/calendar/utils/datetime).
+const localZone = () => dayjs.tz?.guess?.() || Intl.DateTimeFormat().resolvedOptions().timeZone
+
+const whenLabel = computed(() => {
+	const event = invite.value?.event
+	if (!event?.start) return ''
+
+	const start = event.time_zone
+		? dayjs.tz(event.start, event.time_zone).tz(localZone())
+		: dayjs(event.start)
+	if (event.show_without_time) return start.format('dddd, MMM D, YYYY')
+
+	const end = start.add(dayjs.duration(event.duration || 'PT0S'))
+	if (end.isSame(start, 'day'))
+		return `${start.format('dddd, MMM D, YYYY ⋅ h:mm A')} – ${end.format('h:mm A')}`
+	return `${start.format('MMM D, YYYY, h:mm A')} – ${end.format('MMM D, YYYY, h:mm A')}`
+})
+
+const addInvite = createResource({
+	url: 'suite.calendar.api.invites.add_invite_to_calendar',
+	makeParams: () => ({ account, blob_id: attachment.blob_id }),
+	onSuccess: (event: InviteEvent) => {
+		// Flip to the "added" state with the created copy (which has the id the deep link needs)
+		// instead of refetching — the server's uid index updates asynchronously, so an immediate
+		// refetch could still report the event as missing.
+		details.data = { ...details.data, exists: true, event }
+		raiseToast(__('Event added to your calendar.'))
+		useUpcomingEvents().events.reload()
+	},
+	onError: (error: { message?: string }) => raiseToast(error.message || '', 'error'),
+})
+
+const viewInCalendar = () => {
+	const event = invite.value?.event
+	if (event?.id) router.push(eventDayRoute(event, account))
+}
+</script>

--- a/frontend/src/apps/mail/components/CalendarInviteBanner.vue
+++ b/frontend/src/apps/mail/components/CalendarInviteBanner.vue
@@ -10,11 +10,25 @@
 					{{ invite.event.title || __('Untitled event') }}
 				</span>
 				<span v-if="whenLabel" class="block truncate">{{ whenLabel }}</span>
+				<span v-if="locationLabel" class="block truncate">{{ locationLabel }}</span>
 			</div>
 		</div>
 		<div class="flex shrink-0 items-center justify-end gap-3">
+			<template v-if="invite.participant">
+				<span>{{ __('Going?') }}</span>
+				<div class="flex items-center gap-1.5">
+					<Button
+						v-for="option in RSVP_OPTIONS"
+						:key="option.value"
+						:label="option.label"
+						:variant="currentResponse === option.value ? 'solid' : 'outline'"
+						:loading="rsvp.loading && pendingResponse === option.value"
+						@click="handleRsvp(option.value)"
+					/>
+				</div>
+			</template>
 			<Button
-				v-if="!invite.exists"
+				v-else-if="!invite.exists"
 				:label="__('Add to Calendar')"
 				:loading="addInvite.loading"
 				@click="addInvite.submit()"
@@ -30,7 +44,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { CalendarPlus } from 'lucide-vue-next'
 import { Button, createResource } from 'frappe-ui'
@@ -51,6 +65,7 @@ interface InviteEvent {
 	time_zone: string
 	show_without_time: 0 | 1
 	recurrence_id?: string | null
+	locations: { _name?: string }[]
 }
 
 interface InviteDetails {
@@ -58,6 +73,9 @@ interface InviteDetails {
 	method: string
 	exists: boolean
 	event: InviteEvent
+	// The viewer's own entry on the event — present when they're invited, carrying their
+	// current response (e.g. 'ACCEPTED', or '' when they haven't answered yet).
+	participant: { uid: string; email: string; status: string } | null
 }
 
 const { attachment, account } = defineProps<{ attachment: Attachment; account: string }>()
@@ -98,6 +116,13 @@ const whenLabel = computed(() => {
 	return `${start.format('MMM D, YYYY, h:mm A')} – ${end.format('MMM D, YYYY, h:mm A')}`
 })
 
+const locationLabel = computed(() =>
+	(invite.value?.event.locations || [])
+		.map((location) => location._name)
+		.filter(Boolean)
+		.join(', '),
+)
+
 const addInvite = createResource({
 	url: 'suite.calendar.api.invites.add_invite_to_calendar',
 	makeParams: () => ({ account, blob_id: attachment.blob_id }),
@@ -111,6 +136,39 @@ const addInvite = createResource({
 	},
 	onError: (error: { message?: string }) => raiseToast(error.message || '', 'error'),
 })
+
+// --- RSVP (mirrors the calendar app's "Going?" control) ---
+
+const RSVP_OPTIONS = [
+	{ label: __('Yes'), value: 'ACCEPTED' },
+	{ label: __('No'), value: 'DECLINED' },
+	{ label: __('Maybe'), value: 'TENTATIVE' },
+]
+
+const currentResponse = computed(() => invite.value?.participant?.status || '')
+const pendingResponse = ref('')
+
+const rsvp = createResource({
+	url: 'suite.calendar.api.invites.rsvp_to_invite',
+	makeParams: (response: string) => ({ account, blob_id: attachment.blob_id, response }),
+	onSuccess: (event: InviteEvent) => {
+		details.data = {
+			...details.data,
+			exists: true,
+			event,
+			participant: { ...details.data.participant, status: pendingResponse.value },
+		}
+		raiseToast(__('Response sent.'))
+		useUpcomingEvents().events.reload()
+	},
+	onError: (error: { message?: string }) => raiseToast(error.message || '', 'error'),
+})
+
+const handleRsvp = (response: string) => {
+	if (rsvp.loading || response === currentResponse.value) return
+	pendingResponse.value = response
+	rsvp.submit(response.toLowerCase())
+}
 
 const viewInCalendar = () => {
 	const event = invite.value?.event

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -272,6 +272,12 @@
 											</div>
 										</template>
 									</Alert>
+									<CalendarInviteBanner
+										v-if="!readonly && !isCollapsed(mail) && icsAttachment(mail)"
+										:key="`invite-${mail.name}`"
+										:attachment="icsAttachment(mail)"
+										:account="scopeAccountId"
+									/>
 									<EmailContent
 										v-if="hasHtmlContent(mail.html_body)"
 										:content="mail.html_body"
@@ -428,6 +434,7 @@ import { provideAccountScope } from '@/apps/mail/utils/accountScope'
 import { userStore } from '@/apps/mail/stores/user'
 import AttachmentCapsule from '@/apps/mail/components/AttachmentCapsule.vue'
 import AttachmentViewer from '@/apps/mail/components/AttachmentViewer.vue'
+import CalendarInviteBanner from '@/apps/mail/components/CalendarInviteBanner.vue'
 import ComposeMailEditor from '@/apps/mail/components/ComposeMailEditor.vue'
 import EmailContent from '@/apps/mail/components/EmailContent.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
@@ -857,6 +864,17 @@ const showMailDetails = ref<string>()
 const filteredAttachments = (mail: Mail) =>
 	mail.attachments.filter(
 		(a: Attachment) => a.disposition === 'attachment' || !a.type.startsWith('image/'),
+	)
+
+// The message's calendar invite, if it carries one — as a text/calendar (or application/ics)
+// part or a file merely named *.ics.
+const icsAttachment = (mail: Mail) =>
+	mail.attachments?.find(
+		(a: Attachment) =>
+			a.blob_id &&
+			(a.type?.toLowerCase().startsWith('text/calendar') ||
+				a.type?.toLowerCase() === 'application/ics' ||
+				a.filename?.toLowerCase().endsWith('.ics')),
 	)
 
 const showAttachmentViewer = ref(false)

--- a/suite/calendar/api/__init__.py
+++ b/suite/calendar/api/__init__.py
@@ -3,6 +3,7 @@ import json
 import frappe
 from frappe import _
 
+from suite.calendar.api.rsvp import record_rsvp
 from suite.calendar.doctype.calendar.calendar import fetch_calendars
 from suite.calendar.doctype.calendar_event.calendar_event import (
     fetch_calendar_events,
@@ -120,6 +121,17 @@ def _with_name(items: list[dict] | None) -> list[dict] | None:
     return [
         {**item, "name": item["_name"]} if "name" not in item and "_name" in item else item for item in items
     ]
+
+
+@frappe.whitelist()
+def rsvp_calendar_event(account: str, id: str, response: str) -> None:
+    """Records the logged-in user's RSVP (accepted / declined / tentative) on the event.
+
+    Patches only the caller's own participationStatus — unlike edit_calendar_event, which
+    rewrites the whole event — and routes the organizer's notification through the custom
+    event_response template when custom event invites are enabled (see record_rsvp)."""
+
+    record_rsvp(account, id, response)
 
 
 @frappe.whitelist()

--- a/suite/calendar/api/invites.py
+++ b/suite/calendar/api/invites.py
@@ -3,6 +3,7 @@ from uuid import uuid7
 import frappe
 from frappe import _
 
+from suite.calendar.api.rsvp import record_rsvp
 from suite.calendar.doctype.calendar_event.calendar_event import (
     format_calendar_event,
     get_calendar_events,
@@ -11,9 +12,6 @@ from suite.calendar.doctype.calendar_exchange.calendar_exchange import SERVER_MA
 from suite.mail.jmap import format_jmap_error, get_calendar_event_service, get_participant_identities
 from suite.mail.jmap.services.calendars.calendar import CalendarService
 from suite.mail.jmap.services.calendars.calendar_event import CalendarEventService
-
-# JSCalendar participationStatus values a reader can respond with.
-RSVP_RESPONSES = ("accepted", "tentative", "declined")
 
 
 @frappe.whitelist()
@@ -80,34 +78,14 @@ def add_invite_to_calendar(account: str, blob_id: str) -> dict:
 
 @frappe.whitelist()
 def rsvp_to_invite(account: str, blob_id: str, response: str) -> dict:
-    """Records the viewer's RSVP to an invite attachment: puts the event on their calendar first if
-    it isn't yet, then patches their own participationStatus with scheduling messages on, so the
-    JMAP server sends the iTIP reply to the organizer. Returns the updated calendar copy."""
-
-    response = (response or "").lower()
-    if response not in RSVP_RESPONSES:
-        frappe.throw(_("Invalid RSVP response."))
+    """Records the viewer's RSVP to an invite attachment: puts the event on their calendar first
+    if it isn't yet, then records the response via `record_rsvp` — which notifies the organizer
+    through the custom event_response template when custom event invites are enabled, or the JMAP
+    server's own scheduling mail otherwise. Returns the updated calendar copy."""
 
     service = get_calendar_event_service(account)
     event_id = _ensure_on_calendar(service, _parse_events(service, blob_id))
-
-    copies = service.get([event_id])
-    if not copies:
-        frappe.throw(_("Could not record your response. The event may no longer exist."))
-
-    # Participant keys are per-copy (each server generates its own), so locate the viewer in this
-    # copy by address — any of the account's participant identities counts as "me".
-    emails = {identity["email"] for identity in get_participant_identities(account)}
-    participant_uid = _find_participant_uid(copies[0], emails)
-    if not participant_uid:
-        frappe.throw(_("You are not a participant of this event."))
-
-    result = service.set_participation_status(
-        event_id, participant_uid, response, send_scheduling_messages=True
-    )
-    if result.get("notUpdated"):
-        error = next(iter(result["notUpdated"].values()), None)
-        frappe.throw(_("Could not record your response: {0}").format(format_jmap_error(error)))
+    record_rsvp(account, event_id, response)
 
     if formatted := get_calendar_events(account, [event_id]):
         return formatted[0]
@@ -185,17 +163,6 @@ def _viewer_participant(account: str, event: dict) -> dict | None:
                 "email": participant["email"],
                 "status": participant.get("participation_status") or "",
             }
-
-    return None
-
-
-def _find_participant_uid(event: dict, emails: set[str]) -> str | None:
-    """Returns the participant key in a *raw* JMAP event copy matching any of the given addresses."""
-
-    for uid, participant in (event.get("participants") or {}).items():
-        address = (participant.get("calendarAddress") or participant.get("email") or "").lower()
-        if address.replace("mailto:", "") in emails:
-            return uid
 
     return None
 

--- a/suite/calendar/api/invites.py
+++ b/suite/calendar/api/invites.py
@@ -1,0 +1,124 @@
+from uuid import uuid7
+
+import frappe
+from frappe import _
+
+from suite.calendar.doctype.calendar_event.calendar_event import (
+    format_calendar_event,
+    get_calendar_events,
+)
+from suite.calendar.doctype.calendar_exchange.calendar_exchange import SERVER_MANAGED_KEYS
+from suite.mail.jmap import format_jmap_error, get_calendar_event_service
+from suite.mail.jmap.services.calendars.calendar import CalendarService
+from suite.mail.jmap.services.calendars.calendar_event import CalendarEventService
+
+
+@frappe.whitelist()
+def get_invite_details(account: str, blob_id: str) -> dict | None:
+    """Parses a text/calendar mail attachment (already a blob in the account's JMAP namespace) and
+    reports whether its event is on the calendar yet, so the thread view can offer "Add to Calendar".
+
+    Returns None when the blob has no parsable event or the event carries no UID (nothing to
+    deduplicate against). ``event`` is the existing calendar copy when one is found, else a preview
+    formatted from the parsed invite (its id is empty — it does not exist on the server yet).
+
+    Caveat: the UID lookup runs on the server's search index, which is updated asynchronously, so
+    an event added moments ago may still report ``exists: False``."""
+
+    service = get_calendar_event_service(account)
+    events = _parse_events(service, blob_id)
+    if not events:
+        return None
+
+    invite = events[0]
+    uid = invite.get("uid")
+    if not uid:
+        return None
+
+    # The iTIP METHOD (request/cancel/reply/...) travels through the parse; only a request or
+    # publish is something the reader can add.
+    method = (invite.get("method") or "").lower()
+
+    if master_ids := service.get_master_ids([uid]):
+        if existing := get_calendar_events(account, master_ids[:1]):
+            return {"uid": uid, "method": method, "exists": True, "event": existing[0]}
+
+    return {"uid": uid, "method": method, "exists": False, "event": _format_preview(account, invite)}
+
+
+@frappe.whitelist()
+def add_invite_to_calendar(account: str, blob_id: str) -> dict:
+    """Creates the invite's event(s) from a text/calendar mail attachment on the account's default
+    calendar and returns the calendar copy. No scheduling messages are sent — adding the invite is
+    not an RSVP. Idempotent: an event whose UID is already on the calendar is not recreated."""
+
+    service = get_calendar_event_service(account)
+    events = _parse_events(service, blob_id)
+
+    uids = [e["uid"] for e in events if e.get("uid")]
+    if not uids:
+        frappe.throw(_("The attachment does not contain a valid calendar event."))
+
+    existing_ids = service.get_master_ids(uids)
+    existing_uids = {e["uid"] for e in service.get(existing_ids) if e.get("uid")} if existing_ids else set()
+
+    default_calendar_id = None
+
+    payload = {}
+    for event in events:
+        if not event.get("uid") or event["uid"] in existing_uids:
+            continue
+        if default_calendar_id is None:
+            default_calendar_id = CalendarService(service.account, service.connection).get_default(
+                raise_exception=True
+            )
+        event = {k: v for k, v in event.items() if k not in SERVER_MANAGED_KEYS}
+        event["@type"] = "Event"
+        event["calendarIds"] = {default_calendar_id: True}
+        payload[str(uuid7())] = event
+
+    created_ids = []
+    if payload:
+        response = service._create(payload, sendSchedulingMessages=False)
+        method_responses = response.get("methodResponses") or []
+        result = method_responses[0][1] if method_responses else {}
+        created_ids = [info["id"] for info in (result.get("created") or {}).values()]
+
+        if not_created := result.get("notCreated"):
+            error = next(iter(not_created.values()), None)
+            frappe.throw(_("Could not add the event to the calendar: {0}").format(format_jmap_error(error)))
+
+    if formatted := get_calendar_events(account, (created_ids or existing_ids)[:1]):
+        return formatted[0]
+
+    frappe.throw(_("Could not add the event to the calendar."))
+
+
+def _parse_events(service: CalendarEventService, blob_id: str) -> list[dict]:
+    """Parses the blob into JSCalendar events. A mail attachment's blob id lives in the same JMAP
+    account namespace as calendar blobs, so it can be parsed directly without re-uploading."""
+
+    if not blob_id:
+        frappe.throw(_("Blob ID is required."))
+
+    response = service.parse([blob_id])
+
+    events = []
+    for parsed in (response.get("parsed") or {}).values():
+        events.extend(parsed or [])
+
+    return events
+
+
+def _format_preview(account: str, event: dict) -> dict:
+    """Formats a parsed (not yet created) invite through the same formatter served events go
+    through, so the frontend renders one shape either way."""
+
+    preview = dict(event)
+    # A parsed invite has no server id or calendar membership yet, and the formatter indexes into
+    # these (and iterates the sub-object maps) unconditionally.
+    preview["id"] = preview.get("id") or ""
+    for key in ("calendarIds", "locations", "links", "alerts", "participants"):
+        preview[key] = preview.get(key) or {}
+
+    return format_calendar_event(account, {}, preview)

--- a/suite/calendar/api/invites.py
+++ b/suite/calendar/api/invites.py
@@ -8,9 +8,12 @@ from suite.calendar.doctype.calendar_event.calendar_event import (
     get_calendar_events,
 )
 from suite.calendar.doctype.calendar_exchange.calendar_exchange import SERVER_MANAGED_KEYS
-from suite.mail.jmap import format_jmap_error, get_calendar_event_service
+from suite.mail.jmap import format_jmap_error, get_calendar_event_service, get_participant_identities
 from suite.mail.jmap.services.calendars.calendar import CalendarService
 from suite.mail.jmap.services.calendars.calendar_event import CalendarEventService
+
+# JSCalendar participationStatus values a reader can respond with.
+RSVP_RESPONSES = ("accepted", "tentative", "declined")
 
 
 @frappe.whitelist()
@@ -21,6 +24,8 @@ def get_invite_details(account: str, blob_id: str) -> dict | None:
     Returns None when the blob has no parsable event or the event carries no UID (nothing to
     deduplicate against). ``event`` is the existing calendar copy when one is found, else a preview
     formatted from the parsed invite (its id is empty — it does not exist on the server yet).
+    ``participant`` is the viewer's own entry on that event (None when they aren't invited), so the
+    thread view can offer RSVP actions with their current response.
 
     Caveat: the UID lookup runs on the server's search index, which is updated asynchronously, so
     an event added moments ago may still report ``exists: False``."""
@@ -39,11 +44,23 @@ def get_invite_details(account: str, blob_id: str) -> dict | None:
     # publish is something the reader can add.
     method = (invite.get("method") or "").lower()
 
+    exists = False
+    event = None
     if master_ids := service.get_master_ids([uid]):
         if existing := get_calendar_events(account, master_ids[:1]):
-            return {"uid": uid, "method": method, "exists": True, "event": existing[0]}
+            exists = True
+            event = existing[0]
 
-    return {"uid": uid, "method": method, "exists": False, "event": _format_preview(account, invite)}
+    if event is None:
+        event = _format_preview(account, invite)
+
+    return {
+        "uid": uid,
+        "method": method,
+        "exists": exists,
+        "event": event,
+        "participant": _viewer_participant(account, event),
+    }
 
 
 @frappe.whitelist()
@@ -53,7 +70,54 @@ def add_invite_to_calendar(account: str, blob_id: str) -> dict:
     not an RSVP. Idempotent: an event whose UID is already on the calendar is not recreated."""
 
     service = get_calendar_event_service(account)
-    events = _parse_events(service, blob_id)
+    event_id = _ensure_on_calendar(service, _parse_events(service, blob_id))
+
+    if formatted := get_calendar_events(account, [event_id]):
+        return formatted[0]
+
+    frappe.throw(_("Could not add the event to the calendar."))
+
+
+@frappe.whitelist()
+def rsvp_to_invite(account: str, blob_id: str, response: str) -> dict:
+    """Records the viewer's RSVP to an invite attachment: puts the event on their calendar first if
+    it isn't yet, then patches their own participationStatus with scheduling messages on, so the
+    JMAP server sends the iTIP reply to the organizer. Returns the updated calendar copy."""
+
+    response = (response or "").lower()
+    if response not in RSVP_RESPONSES:
+        frappe.throw(_("Invalid RSVP response."))
+
+    service = get_calendar_event_service(account)
+    event_id = _ensure_on_calendar(service, _parse_events(service, blob_id))
+
+    copies = service.get([event_id])
+    if not copies:
+        frappe.throw(_("Could not record your response. The event may no longer exist."))
+
+    # Participant keys are per-copy (each server generates its own), so locate the viewer in this
+    # copy by address — any of the account's participant identities counts as "me".
+    emails = {identity["email"] for identity in get_participant_identities(account)}
+    participant_uid = _find_participant_uid(copies[0], emails)
+    if not participant_uid:
+        frappe.throw(_("You are not a participant of this event."))
+
+    result = service.set_participation_status(
+        event_id, participant_uid, response, send_scheduling_messages=True
+    )
+    if result.get("notUpdated"):
+        error = next(iter(result["notUpdated"].values()), None)
+        frappe.throw(_("Could not record your response: {0}").format(format_jmap_error(error)))
+
+    if formatted := get_calendar_events(account, [event_id]):
+        return formatted[0]
+
+    frappe.throw(_("Could not record your response."))
+
+
+def _ensure_on_calendar(service: CalendarEventService, events: list[dict]) -> str:
+    """Creates the parsed events that aren't on the calendar yet (idempotent by UID, on the default
+    calendar, no scheduling messages) and returns the master id of the invite's event."""
 
     uids = [e["uid"] for e in events if e.get("uid")]
     if not uids:
@@ -88,10 +152,7 @@ def add_invite_to_calendar(account: str, blob_id: str) -> dict:
             error = next(iter(not_created.values()), None)
             frappe.throw(_("Could not add the event to the calendar: {0}").format(format_jmap_error(error)))
 
-    if formatted := get_calendar_events(account, (created_ids or existing_ids)[:1]):
-        return formatted[0]
-
-    frappe.throw(_("Could not add the event to the calendar."))
+    return (created_ids or existing_ids)[0]
 
 
 def _parse_events(service: CalendarEventService, blob_id: str) -> list[dict]:
@@ -108,6 +169,35 @@ def _parse_events(service: CalendarEventService, blob_id: str) -> list[dict]:
         events.extend(parsed or [])
 
     return events
+
+
+def _viewer_participant(account: str, event: dict) -> dict | None:
+    """Returns the viewer's entry from a *formatted* event's participants, or None if they aren't
+    one. Matched by address against the account's participant identities, mirroring how the
+    calendar app decides whose RSVP the "Going?" control edits."""
+
+    emails = {identity["email"] for identity in get_participant_identities(account)}
+
+    for participant in event.get("participants") or []:
+        if (participant.get("email") or "").lower() in emails:
+            return {
+                "uid": participant["uid"],
+                "email": participant["email"],
+                "status": participant.get("participation_status") or "",
+            }
+
+    return None
+
+
+def _find_participant_uid(event: dict, emails: set[str]) -> str | None:
+    """Returns the participant key in a *raw* JMAP event copy matching any of the given addresses."""
+
+    for uid, participant in (event.get("participants") or {}).items():
+        address = (participant.get("calendarAddress") or participant.get("email") or "").lower()
+        if address.replace("mailto:", "") in emails:
+            return uid
+
+    return None
 
 
 def _format_preview(account: str, event: dict) -> dict:

--- a/suite/calendar/api/rsvp.py
+++ b/suite/calendar/api/rsvp.py
@@ -24,7 +24,12 @@ from frappe import _
 from frappe.utils import escape_html
 
 from suite.mail.doctype.user_account.user_account import get_user_for_jmap_account
-from suite.mail.jmap import get_jmap_connection
+from suite.mail.jmap import (
+    format_jmap_error,
+    get_calendar_event_service,
+    get_jmap_connection,
+    get_participant_identities,
+)
 from suite.mail.jmap.services.calendars.calendar_event import CalendarEventService
 from suite.utils import log_error
 from suite.utils.dt import get_utc_now
@@ -35,6 +40,9 @@ RESPONSES: dict[str, tuple[str, str]] = {
     "tentative": ("tentative", "Maybe"),
     "decline": ("declined", "No"),
 }
+
+# JSCalendar participationStatus values a logged-in attendee can respond with (see record_rsvp).
+PARTICIPATION_RESPONSES = ("accepted", "tentative", "declined")
 
 
 def build_rsvp_links(
@@ -103,6 +111,63 @@ def resolve_rsvp(token: str) -> dict:
         "event_title": escape_html((event or {}).get("title") or ""),
         "event_when": _format_event_when(event) if event else "",
     }
+
+
+def record_rsvp(account: str, event_id: str, response: str) -> str:
+    """Records the logged-in caller's RSVP on their own copy of the event and tells the organizer.
+
+    Their entry is matched by address against the account's participant identities and patched
+    surgically. With custom event invites enabled (Mail Settings) the server's iMIP scheduling
+    mail is suppressed and the custom event_response email — carrying the iTIP REPLY — is sent
+    instead (see `notify_organizer_of_reply`); otherwise the JMAP server emits its own reply.
+    Returns the responder's address.
+    """
+
+    from suite.calendar.doctype.calendar_event.invitations import custom_event_invites_enabled
+
+    response = (response or "").lower()
+    if response not in PARTICIPATION_RESPONSES:
+        frappe.throw(_("Invalid RSVP response."))
+
+    service = get_calendar_event_service(account)
+    copies = service.get([event_id])
+    if not copies:
+        frappe.throw(_("Could not record your response. The event may no longer exist."))
+
+    # Participant keys are per-copy (each server generates its own), so locate the caller in this
+    # copy by address — any of the account's participant identities counts as "me".
+    identity_emails = {identity["email"] for identity in get_participant_identities(account)}
+
+    participant_uid = responder_email = None
+    for uid, participant in (copies[0].get("participants") or {}).items():
+        address = (participant.get("calendarAddress") or participant.get("email") or "").lower()
+        if (address := address.replace("mailto:", "")) in identity_emails:
+            participant_uid, responder_email = uid, address
+            break
+
+    if not participant_uid:
+        frappe.throw(_("You are not a participant of this event."))
+
+    use_custom_reply = custom_event_invites_enabled()
+    result = service.set_participation_status(
+        event_id, participant_uid, response, send_scheduling_messages=not use_custom_reply
+    )
+    if result.get("notUpdated"):
+        error = next(iter(result["notUpdated"].values()), None)
+        frappe.throw(_("Could not record your response: {0}").format(format_jmap_error(error)))
+
+    if use_custom_reply:
+        frappe.enqueue(
+            "suite.calendar.doctype.calendar_event.invitations.notify_organizer_of_reply",
+            queue="short",
+            enqueue_after_commit=True,
+            account=account,
+            event_id=event_id,
+            responder_email=responder_email,
+            status=response,
+        )
+
+    return responder_email
 
 
 def _notify_organizer(payload: dict, status: str) -> None:

--- a/suite/calendar/doctype/calendar_event/ics.py
+++ b/suite/calendar/doctype/calendar_event/ics.py
@@ -22,11 +22,19 @@ from suite.calendar.doctype.calendar_exchange.calendar_exchange import (
 PRODID = "-//Frappe Mail//Calendar Invite//EN"
 
 
-def build_event_ics(event: dict, method: str = "REQUEST", recurrence_id: str | None = None) -> str:
+def build_event_ics(
+    event: dict,
+    method: str = "REQUEST",
+    recurrence_id: str | None = None,
+    attendee_email: str | None = None,
+) -> str:
     """Returns the iCalendar text for a JSCalendar event using the given iTIP method.
 
     When `recurrence_id` is set, a single occurrence (tagged with RECURRENCE-ID) is emitted
     instead of the whole series — used to cancel one instance of a recurring event.
+
+    Pass `attendee_email` for a REPLY: RFC 5546 requires the reply to carry exactly the
+    responding ATTENDEE, so every other one is dropped from the components.
     """
 
     cal = Calendar()
@@ -36,12 +44,16 @@ def build_event_ics(event: dict, method: str = "REQUEST", recurrence_id: str | N
 
     if recurrence_id:
         component = _instance_component(event, recurrence_id, method)
+        if attendee_email:
+            _only_attendee(component, attendee_email)
         _stamp_outgoing(component, method)
         cal.add_component(component)
     else:
         for component in _build_components(event):
             if method == "CANCEL":
                 _mark_cancelled(component)
+            if attendee_email:
+                _only_attendee(component, attendee_email)
             _stamp_outgoing(component, method)
             cal.add_component(component)
 
@@ -89,6 +101,23 @@ def _instance_component(event: dict, recurrence_id: str, method: str):
         _mark_cancelled(component)
 
     return component
+
+
+def _only_attendee(component, email: str) -> None:
+    """Keeps only the given address's ATTENDEE property (with its params — PARTSTAT et al)."""
+
+    attendees = component.get("attendee")
+    if attendees is None:
+        return
+    if not isinstance(attendees, list):
+        attendees = [attendees]
+
+    email = email.lower()
+    kept = [a for a in attendees if str(a).lower().replace("mailto:", "") == email]
+
+    del component["attendee"]
+    for attendee in kept:
+        component.add("attendee", attendee)
 
 
 def _mark_cancelled(component) -> None:

--- a/suite/calendar/doctype/calendar_event/invitations.py
+++ b/suite/calendar/doctype/calendar_event/invitations.py
@@ -183,6 +183,63 @@ def notify_organizer_of_response(account: str, event_id: str, participant_email:
         frappe.set_user(original_user)
 
 
+def notify_organizer_of_reply(account: str, event_id: str, responder_email: str, status: str) -> None:
+    """Sends the organizer an attendee's RSVP as a custom-template email carrying an iTIP REPLY.
+
+    The custom-invite counterpart of the server's iMIP scheduling mail: when Mail Settings sends
+    invites from the client, an attendee's response goes out the same way — the visible body is
+    the event_response template, sent from the attendee's own account, and the embedded
+    text/calendar part (METHOD:REPLY, only the responder's ATTENDEE per RFC 5546) lets the
+    organizer's calendar server record the response mechanically, wherever they're hosted.
+    """
+
+    display = RESPONSE_DISPLAY.get((status or "").lower())
+    if not display:
+        return
+
+    try:
+        events = get_calendar_event_service(account).get([event_id])
+        if not events:
+            return
+        event = events[0]
+
+        organizer = (event.get("organizerCalendarAddress") or "").lower().replace("mailto:", "")
+        responder_email = responder_email.lower()
+        # No organizer to tell, or the organizer responding on their own event.
+        if not organizer or organizer == responder_email:
+            return
+
+        user = get_user_for_jmap_account(account, raise_exception=True)
+        responder_name = _organizer_name(account, event, responder_email)
+        subject, html = _render_response(
+            event,
+            organizer,
+            _organizer_name(account, event, organizer),
+            responder_email,
+            responder_name or responder_email,
+            display,
+            # Hand-built MIME embeds the logo as a CID part (attached by _build_mime), not
+            # frappe.sendmail's `embed=` mechanism.
+            logo_src_attr='src="cid:eventlogo"',
+        )
+
+        ics = build_event_ics(event, method="REPLY", attendee_email=responder_email)
+        message = _build_mime(responder_name, responder_email, organizer, subject, html, ics, "REPLY")
+
+        MailQueue._create(
+            user=user,
+            account=account,
+            from_name=responder_name,
+            from_email=responder_email,
+            recipients=[{"name": None, "email": organizer, "type": "To"}],
+            raw_message=message,
+            via_api=True,
+            delivery_mode="Enqueue",
+        )
+    except Exception:
+        log_error("Calendar", title=_("Failed to send RSVP reply for event {0}").format(event_id))
+
+
 def _response_inline_images() -> list[dict]:
     """Returns the Calendar logo for the response email in frappe.sendmail's `embed=` format."""
 
@@ -258,9 +315,13 @@ def _render(kind, event, organizer, organizer_name, participant, links) -> tuple
 
 
 def _render_response(
-    event, organizer, organizer_name, responder_email, responder_name, display
+    event, organizer, organizer_name, responder_email, responder_name, display, logo_src_attr=None
 ) -> tuple[str, str]:
-    """Returns (subject, html) for the organizer's RSVP notification email."""
+    """Returns (subject, html) for the organizer's RSVP notification email.
+
+    The default logo reference suits frappe.sendmail (the HTTP RSVP heads-up), which inlines
+    images from an `embed=` attribute; the iTIP REPLY path passes its own CID reference.
+    """
 
     label, state = display
     context = _context(event, organizer, organizer_name, None, None)
@@ -270,8 +331,7 @@ def _render_response(
             "responder_email": responder_email,
             "response_label": label,
             "response_state": state,
-            # Sent via frappe.sendmail, which inlines the logo from an `embed=` attribute.
-            "logo_src_attr": f'embed="{RESPONSE_LOGO_EMBED}"',
+            "logo_src_attr": logo_src_attr or f'embed="{RESPONSE_LOGO_EMBED}"',
         }
     )
 


### PR DESCRIPTION
Closes #53

Opening an email with a `text/calendar` / `.ics` attachment now shows a banner above the message body with the event's title, time and location. When the reader is a participant it offers **Going? Yes / No / Maybe** RSVP actions (current response highlighted); otherwise it offers **Add to Calendar** when the invite isn't on the calendar yet, or **View in Calendar** when it already is.

https://github.com/frappe/suite/issues/53

## How it works

**Backend** — new `suite/calendar/api/invites.py`:
- `get_invite_details(account, blob_id)`: a mail attachment's blob lives in the same JMAP account namespace as calendar blobs, so it is parsed directly via the server's `CalendarEvent/parse` (no re-upload, no Python-side ICS parsing). The event's UID is then checked against the calendar via `get_master_ids`. Returns `{uid, method, exists, event, participant}`, where `event` is the existing calendar copy or a preview of the parsed invite — both shaped by `format_calendar_event`, so the frontend renders one shape either way — and `participant` is the viewer's own entry on the event (matched by address against the account's participant identities, mirroring the calendar app's "Going?" control) with their current response.
- `add_invite_to_calendar(account, blob_id)`: creates the parsed event(s) on the account's default calendar, mirroring the Calendar Exchange import (strips server-managed keys, skips UIDs that already exist — idempotent) with `sendSchedulingMessages: false`, since adding an invite to your calendar is not an RSVP.
- `rsvp_to_invite(account, blob_id, response)`: records the viewer's RSVP — puts the event on their calendar first if it isn't yet, then records the response via the shared `record_rsvp` (below). The participant key is located per-copy by address, since each server generates its own participant keys.

**RSVP with the custom email templates** — `record_rsvp` in `suite/calendar/api/rsvp.py`, shared by the banner and the calendar sidebar's "Going?" control (new `rsvp_calendar_event` endpoint, which patches only the caller's own `participationStatus` instead of rewriting the whole event through `edit_calendar_event`):
- With custom event invites **off**, the JMAP server sends its own iMIP reply, as before.
- With custom event invites **on** (Mail Settings), the server's scheduling mail is suppressed and `notify_organizer_of_reply` sends the `event_response` template instead — from the attendee's own account, mirroring how organizer-side custom invites already replace server scheduling. The email embeds a `text/calendar; method=REPLY` part carrying only the responder's `ATTENDEE` (RFC 5546, via `build_event_ics(..., method="REPLY", attendee_email=...)`), so the organizer's calendar server still records the response mechanically wherever they're hosted, while the human sees the same template the HTTP RSVP links use.

Account access is enforced by the existing JMAP connection layer.

## Frontend

- New `CalendarInviteBanner.vue`, styled after the remote-images bar in `EmailContent.vue`. Fetches invite details on mount, renders the event time in the reader's timezone (converted from the event's own IANA zone; all-day events handled) plus the location, and only shows for iTIP `REQUEST`/`PUBLISH` — cancellations and attendee replies also travel as `text/calendar` and should not get add/RSVP actions. After adding or responding, the banner updates locally (the server's UID search index updates asynchronously, so an immediate refetch could still miss the event) and refreshes the upcoming-events sidebar.
- `MailThread.vue` detects the invite attachment (`text/calendar` / `application/ics` MIME or a `*.ics` filename with a blob id) and renders the banner for expanded, non-readonly messages, scoped to the thread's owning account so it also works from All Inboxes.

## Tests

- ruff lint + format pass on the changed modules; all import cleanly in the bench env
- `build_event_ics(method="REPLY")` verified end-to-end: exactly one `ATTENDEE` (the responder, with the updated `PARTSTAT`), `ORGANIZER`/`UID`/`SEQUENCE` preserved
- vite build compiles; all 1213 frontend unit tests pass
