### PR TITLE
fix(mail,calendar): restore email suggestions after frappe-ui Combobox API freeze

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,7 +63,7 @@
     "feather-icons": "^4.29.2",
     "file-saver": "^2.0.5",
     "firebase": "^12.2.1",
-    "frappe-ui": "frappe/frappe-ui#1c5f72c36dcde9444fe6fc349796c6780a9cbe19",
+    "frappe-ui": "frappe/frappe-ui#548b9b950628f1cccec26687eb4a9c11f74f3877",
     "fuzzysort": "^3.1.0",
     "gemoji": "^8.1.0",
     "hast-util-to-html": "^9.0.5",

--- a/frontend/src/apps/calendar/components/ParticipantSelector.vue
+++ b/frontend/src/apps/calendar/components/ParticipantSelector.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, ref } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { useDebounceFn } from '@vueuse/core'
 import { Combobox, createResource, toast } from 'frappe-ui'
 
@@ -31,16 +31,26 @@ const mailContacts = createResource({
 	url: 'suite.mail.api.mail.get_email_suggestions',
 	makeParams: (text: string) => ({
 		account: props.account,
-		// frappe-ui's fetch nulls Event params and reuses the previous params object when called
-		// with a falsy value, feeding it back here as `text` — guard against a non-string.
-		text: typeof text === 'string' ? text : '',
+		text,
 	}),
 	transform: (data: any[]) => data.map((contact) => contact.email),
 })
 
 const debouncedSearch = useDebounceFn((text: string) => text && mailContacts.reload(text), 300)
 
-const combobox = ref<{ reset: () => void } | null>(null)
+const combobox = ref<{ clear: () => void } | null>(null)
+
+const searchText = ref('')
+const showSuggestions = ref(false)
+
+// Suggestions only exist for a typed query — with an empty input the popover
+// would show stale results from the previous query (or a bare "No results"
+// panel), so block reka's focus/arrow-key opens too, not just hide options.
+watch(showSuggestions, (open) => {
+	if (open && !searchText.value) showSuggestions.value = false
+})
+
+const options = computed(() => (searchText.value ? mailContacts?.data || [] : []))
 
 // Picking a dropdown option commits it on keydown, so the matching keyup.enter lands here too and
 // would re-add the option and clear the input from under the reset below. Typing is the only way
@@ -49,6 +59,8 @@ const justSelectedOption = ref(false)
 
 const handleInput = (text: string) => {
 	justSelectedOption.value = false
+	searchText.value = text
+	if (!text) showSuggestions.value = false
 	debouncedSearch(text)
 }
 
@@ -71,16 +83,16 @@ const addParticipant = (email: string) => {
 	]
 }
 
-// Picking a contact commits it as the Combobox's selected value — add it and reset the control so the
+// Picking a contact commits it as the Combobox's selected value — add it and clear the control so the
 // input clears for the next participant, rather than sitting there showing the one just added.
-// The reset waits a tick: this handler fires mid-commit, and the Combobox writes the option's label
-// into its input right after we return, which would undo a synchronous reset.
+// The clear waits a tick: this handler fires mid-commit, and the Combobox writes the option's label
+// into its input right after we return, which would undo a synchronous clear.
 const handleParticipantSelect = async (email: string | null) => {
 	if (!email) return
 	justSelectedOption.value = true
 	addParticipant(email)
 	await nextTick()
-	combobox.value?.reset()
+	combobox.value?.clear()
 }
 
 const handleParticipantEnter = (e: Event) => {
@@ -106,10 +118,11 @@ const removeParticipant = (email: string) => {
 			<h3 v-if="label" class="text-base-medium mb-2 text-ink-gray-8">{{ label }}</h3>
 			<Combobox
 				ref="combobox"
+				v-model:open="showSuggestions"
 				class="w-full"
-				:options="mailContacts?.data || []"
+				:options="options"
 				:placeholder="placeholder"
-				@input="handleInput($event)"
+				@update:query="handleInput($event)"
 				@update:model-value="handleParticipantSelect($event)"
 				@keyup.enter="handleParticipantEnter($event)"
 			/>

--- a/frontend/src/apps/mail/components/ContactCombobox.vue
+++ b/frontend/src/apps/mail/components/ContactCombobox.vue
@@ -1,11 +1,12 @@
 <template>
 	<Combobox
 		v-model="model"
+		v-model:open="showSuggestions"
 		:label="label"
 		:options="options"
 		placeholder=""
 		:open-on-click="false"
-		@input="search"
+		@update:query="search"
 	>
 		<template #item-prefix="{ item, query }">
 			<Avatar :image="item.image" :label="item.label || query" size="sm" />
@@ -19,7 +20,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useDebounceFn } from '@vueuse/core'
 import { Avatar, Combobox, createResource } from 'frappe-ui'
 
@@ -37,9 +38,7 @@ const contactSearch = createResource({
 	auto: false,
 	makeParams: (text: string) => ({
 		account: store.accountId,
-		// frappe-ui's fetch nulls Event params and reuses the previous params object when called
-		// with a falsy value, feeding it back here as `text` — guard against a non-string.
-		text: typeof text === 'string' ? text : '',
+		text,
 	}),
 	transform: (data: { email: string; name?: string; user_image?: string }[]) =>
 		data.map((o) => {
@@ -47,21 +46,40 @@ const contactSearch = createResource({
 			return { value: o.email, label: name || o.email, email: o.email, display_name: name, image: o.user_image }
 		}),
 })
-const search = useDebounceFn((text: string) => {
+const searchText = ref('')
+const showSuggestions = ref(false)
+
+const fetchSuggestions = useDebounceFn((text: string) => {
 	if (text) contactSearch.fetch(text)
 }, 300)
 
+const search = (text: string) => {
+	searchText.value = text
+	if (!text) showSuggestions.value = false
+	fetchSuggestions(text)
+}
+
+// Suggestions only exist for a typed query — with an empty input the popover
+// would show stale results from the previous query (or a bare "No results"
+// panel), so block reka's focus/arrow-key opens too, not just hide options.
+watch(showSuggestions, (open) => {
+	if (open && !searchText.value) showSuggestions.value = false
+})
+
 // Contact matches plus a "create" entry (like compose's RecipientInput) so a typed value that isn't a
 // contact can still be applied.
-const options = computed(() => [
-	...(contactSearch.data ?? []),
-	{
-		type: 'custom',
-		slot: 'create',
-		condition: () => !contactSearch.data?.length,
-		onClick: ({ query }: { query: string }) => {
-			model.value = query
+const options = computed(() => {
+	if (!searchText.value) return []
+	return [
+		...(contactSearch.data ?? []),
+		{
+			type: 'custom',
+			slot: 'create',
+			condition: () => !contactSearch.data?.length,
+			onClick: ({ query }: { query: string }) => {
+				model.value = query
+			},
 		},
-	},
-])
+	]
+})
 </script>

--- a/frontend/src/apps/mail/components/Controls/RecipientInput.vue
+++ b/frontend/src/apps/mail/components/Controls/RecipientInput.vue
@@ -40,12 +40,13 @@
 		</span>
 		<Combobox
 			v-model="input"
+			v-model:open="showSuggestions"
 			placeholder=""
 			variant="ghost"
 			:options
 			:open-on-click="false"
 			class="recipient-combobox border-none !bg-inherit !ring-0"
-			@input="handleInput"
+			@update:query="handleInput"
 			@keydown.delete.capture.stop="handleDelete($event.target.value)"
 			@paste="handlePaste"
 			@focusin="isSearchFocused = true"
@@ -109,9 +110,25 @@ onClickOutside(containerRef, () => (isClicked.value = false))
 
 const selectedEmails = computed(() => selectedRecipients.value.map((v) => v.email))
 
-const handleInput = useDebounceFn((text: string) => {
+const searchText = ref('')
+const showSuggestions = ref(false)
+
+const fetchSuggestions = useDebounceFn((text: string) => {
 	if (text) mailContacts.reload(text)
 }, 200)
+
+const handleInput = (text: string) => {
+	searchText.value = text
+	if (!text) showSuggestions.value = false
+	fetchSuggestions(text)
+}
+
+// Suggestions only exist for a typed query — with an empty input the popover
+// would show stale results from the previous query (or a bare "No results"
+// panel), so block reka's focus/arrow-key opens too, not just hide options.
+watch(showSuggestions, (open) => {
+	if (open && !searchText.value) showSuggestions.value = false
+})
 
 const handleDelete = (currentValue: string) => {
 	if (!currentValue && selectedRecipients.value.length) tagsRef.value?.at(-1)?.focus()
@@ -218,9 +235,7 @@ const mailContacts = createResource({
 	auto: false,
 	makeParams: (text: string) => ({
 		account: store.accountId,
-		// frappe-ui's fetch nulls Event params and reuses the previous params object when called
-		// with a falsy value, feeding it back here as `text` — guard against a non-string.
-		text: typeof text === 'string' ? text : '',
+		text,
 	}),
 	transform: (data) =>
 		data.map((option) => ({
@@ -232,15 +247,18 @@ const mailContacts = createResource({
 		})),
 })
 
-const options = computed(() => [
-	...(mailContacts.data?.filter((option) => !selectedEmails.value.includes(option.email)) || []),
-	{
-		type: 'custom',
-		slot: 'create',
-		condition: () => !mailContacts?.data?.length,
-		onClick: ({ query }: { query: string }) => addValues(query),
-	},
-])
+const options = computed(() => {
+	if (!searchText.value) return []
+	return [
+		...(mailContacts.data?.filter((option) => !selectedEmails.value.includes(option.email)) || []),
+		{
+			type: 'custom',
+			slot: 'create',
+			condition: () => !mailContacts?.data?.length,
+			onClick: ({ query }: { query: string }) => addValues(query),
+		},
+	]
+})
 </script>
 
 <style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4685,9 +4685,9 @@ fraction.js@^5.3.4:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-5.3.4.tgz#8c0fcc6a9908262df4ed197427bdeef563e0699a"
   integrity sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==
 
-frappe-ui@frappe/frappe-ui#1c5f72c36dcde9444fe6fc349796c6780a9cbe19:
+frappe-ui@frappe/frappe-ui#548b9b950628f1cccec26687eb4a9c11f74f3877:
   version "1.0.0-beta.29"
-  resolved "https://codeload.github.com/frappe/frappe-ui/tar.gz/1c5f72c36dcde9444fe6fc349796c6780a9cbe19"
+  resolved "https://codeload.github.com/frappe/frappe-ui/tar.gz/548b9b950628f1cccec26687eb4a9c11f74f3877"
   dependencies:
     "@codemirror/lang-css" "^6.3.0"
     "@codemirror/lang-html" "^6.4.9"


### PR DESCRIPTION
The frappe-ui Combobox v1 API freeze removed the `input` emit (replaced by `update:query`) and renamed the exposed `reset()` to `clear()` — so since the bump to `1c5f72c36`, the recipient/contact/participant fields stopped fetching suggestions entirely, and selecting a calendar participant threw.

- Switch the three consumers to `@update:query` / `clear()`, dropping the now-dead Event-payload guards.
- Bump frappe-ui to pull frappe/frappe-ui#891, which keeps the first suggestion highlighted when debounced results replace the list (Enter commits the top match again).
- Show the dropdown only once at least one character has been typed — stale results from the previous query no longer surface on an empty input, and reka's focus/arrow-key opens are blocked while empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)