### PR TITLE
fix(drive): mark notifications read when files open

### DIFF
--- a/e2e/drive-backed-apps/specs/drive/notifications.spec.ts
+++ b/e2e/drive-backed-apps/specs/drive/notifications.spec.ts
@@ -6,6 +6,7 @@ interface DriveNotification {
 	notif_doctype_name: string;
 	type: string;
 	message: string;
+	read: number;
 }
 
 test("sharing a document notifies the recipient", async ({
@@ -34,4 +35,20 @@ test("sharing a document notifies the recipient", async ({
 				.map((row) => row.message);
 		})
 		.toEqual([expect.stringContaining(title)]);
+
+	await collaborator.page.goto(`/writer/w/${file.name}`);
+
+	// Opening the shared document directly also consumes its notification.
+	await expect
+		.poll(async () => {
+			const response = await collaborator.page.request.get(
+				"/api/method/suite.drive.api.notifications.get_notifications",
+			);
+			if (!response.ok()) return undefined;
+			const rows = await frappeData<DriveNotification[]>(response).catch(() => []);
+			return rows.find(
+				(row) => row.notif_doctype_name === file.name && row.type === "Share",
+			)?.read;
+		})
+		.toBe(1);
 });

--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -888,6 +888,16 @@ def redirect_to_original(file_id: str):
 def track_visit(entity_name: str):
     entity = frappe.get_doc("File", entity_name)
     mark_as_viewed(entity)
+    frappe.db.set_value(
+        "Drive Notification",
+        {
+            "to_user": frappe.session.user,
+            "notif_doctype_name": entity_name,
+            "read": False,
+        },
+        "read",
+        True,
+    )
 
 
 @frappe.whitelist()


### PR DESCRIPTION
shared drive files when open not from notification list doesn't get marked as read