### PR TITLE
fix(calendar): hide Advanced settings tab when client config is disabled

### DIFF
--- a/frontend/src/apps/calendar/components/Modals/SettingsModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/SettingsModal.vue
@@ -2,7 +2,7 @@
 	<SettingsDialog v-model="show" v-model:tab="activeTab" size="5xl">
 		<template #title>{{ __('Settings') }}</template>
 		<SettingsSidebar>
-			<SettingsNavGroup v-for="group in TAB_GROUPS" :key="group.label" :label="group.label">
+			<SettingsNavGroup v-for="group in tabGroups" :key="group.label" :label="group.label">
 				<SettingsNavItem v-for="tab in group.items" :key="tab.value" :value="tab.value">
 					<template #prefix>
 						<component :is="tab.icon" class="size-4 shrink-0 text-ink-gray-6" />
@@ -12,16 +12,17 @@
 			</SettingsNavGroup>
 		</SettingsSidebar>
 		<SettingsContent>
-			<SettingsPanel v-for="tab in TABS" :key="tab.value" :value="tab.value">
+			<SettingsPanel v-for="tab in tabs" :key="tab.value" :value="tab.value">
 				<component :is="tab.component" />
 			</SettingsPanel>
 		</SettingsContent>
 	</SettingsDialog>
 </template>
 <script setup lang="ts">
-import { markRaw, ref } from 'vue'
+import { computed, markRaw, ref } from 'vue'
 import { Code, Contact, HardDriveDownload, HardDriveUpload, Palette, User } from 'lucide-vue-next'
 import {
+	createResource,
 	SettingsContent,
 	SettingsDialog,
 	SettingsNavGroup,
@@ -93,7 +94,21 @@ const TAB_GROUPS = [
 	},
 ]
 
-const TABS = TAB_GROUPS.flatMap((group) => group.items)
+// The Advanced tab only holds the CalDAV client config, which the server withholds
+// unless Mail Settings enables it — hide the whole Developer group when it's empty.
+const clientConfig = createResource({
+	url: 'suite.mail.api.account.get_calendar_client_config',
+	cache: 'calendar-client-config',
+	auto: true,
+})
 
-const activeTab = ref(TABS[0].value)
+const tabGroups = computed(() =>
+	clientConfig.data?.server_url
+		? TAB_GROUPS
+		: TAB_GROUPS.filter((group) => group.label !== __('Developer')),
+)
+
+const tabs = computed(() => tabGroups.value.flatMap((group) => group.items))
+
+const activeTab = ref(tabs.value[0].value)
 </script>

--- a/frontend/src/apps/calendar/components/Settings/AdvancedSettings.vue
+++ b/frontend/src/apps/calendar/components/Settings/AdvancedSettings.vue
@@ -34,6 +34,7 @@ import CopyControl from '@/components/CopyControl.vue'
 
 const clientConfig = createResource({
 	url: 'suite.mail.api.account.get_calendar_client_config',
+	cache: 'calendar-client-config',
 	auto: true,
 })
 


### PR DESCRIPTION
## Problem

When `show_calendar_client_config` is disabled in Mail Settings, the Advanced tab in Calendar settings renders completely empty — the CalDAV client config is its only content.

## Fix

Hide the Advanced tab (and its Developer sidebar group, which contains nothing else) when there is no client config to show.

No new API was needed: `get_calendar_client_config` already returns an empty dict when the setting is disabled, Stalwart isn't configured, or the user has no Stalwart username. The settings modal now fetches it on mount and filters the tab groups reactively based on the response, so all of those cases hide the tab instead of rendering a blank panel.

`AdvancedSettings.vue` shares the same resource via `cache: 'calendar-client-config'`, so the config is only fetched once when the tab is visible.