### PR TITLE
fix(mail): dark-mode remap follow-ups, sidebar divider, infinite-scroll stall

### DIFF
--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -14,6 +14,7 @@
 			v-if="!isMobile || isSidebarOpen"
 			id="sidebar"
 			v-model:collapsed="isSidebarCollapsed"
+			class="border-r border-outline-gray-1"
 			:class="{ 'fixed left-0 top-0 z-10 w-60 !bg-surface-base': isMobile }"
 			:disable-collapse="isMobile"
 		>

--- a/frontend/src/apps/mail/composables/useListRows.ts
+++ b/frontend/src/apps/mail/composables/useListRows.ts
@@ -114,6 +114,25 @@ export const useListRows = ({
 		),
 	)
 
+	/**
+	 * How many loaded threads the rendered rows stand for. A collapsed stack row still stands for its
+	 * members (that's its count badge), so they count; threads inside a collapsed date group have no
+	 * row at all and don't. This is infinite scroll's fill-progress metric (see usePaginatedThreads):
+	 * a fetched window that doesn't advance it landed entirely inside collapsed groups.
+	 */
+	const visibleThreadCount = computed(() => {
+		let count = 0
+		for (const [dateKey, rows] of Object.entries(groupedRows.value)) {
+			if (headersVisible.value && collapsedGroups.value.includes(dateKey)) continue
+			for (const row of rows) {
+				// An expanded stack emits its members again as inStack thread rows — skip the dupes.
+				if (row.type === 'stack') count += row.threads.length
+				else if (!row.inStack) count++
+			}
+		}
+		return count
+	})
+
 	// ── The cursor ──────────────────────────────────────────────────────────────────────────────────
 
 	/**
@@ -271,6 +290,7 @@ export const useListRows = ({
 		collapsedGroups,
 		expandedStacks,
 		groupedRows,
+		visibleThreadCount,
 		navigableRows,
 		focusedRowKey,
 		focusedRow,

--- a/frontend/src/apps/mail/composables/usePaginatedThreads.ts
+++ b/frontend/src/apps/mail/composables/usePaginatedThreads.ts
@@ -68,6 +68,13 @@ export interface PaginatedThreadsOptions {
 	 * merged view keys by account + thread id, since one thread id can recur across accounts.
 	 */
 	threadKey?: (thread: Thread) => string
+	/**
+	 * How far the viewport fill has gotten, in units the reader can see — the views pass the count of
+	 * threads their rendered rows stand for (see useListRows' visibleThreadCount). Pixel height (the
+	 * fallback) cannot tell progress from a dead end: a window absorbed into existing stack rows adds
+	 * no height but is progress, while one landing in a collapsed date group adds none and is not.
+	 */
+	fillProgress?: () => number
 }
 
 export const usePaginatedThreads = ({
@@ -76,6 +83,7 @@ export const usePaginatedThreads = ({
 	openThreadID,
 	onEdgeThread,
 	threadKey = (thread: Thread) => thread.thread_id,
+	fillProgress,
 }: PaginatedThreadsOptions) => {
 	const container = useTemplateRef<HTMLElement>('mailList')
 	const sentinel = useTemplateRef<HTMLElement>('loadMoreSentinel')
@@ -241,48 +249,63 @@ export const usePaginatedThreads = ({
 	// True while the sentinel is in view.
 	const sentinelVisible = ref(false)
 
-	// The height the list had reached the last time we topped it up, so a fill that adds nothing can be
-	// detected. Reset at the start of each fill episode.
-	let lastFillHeight = 0
+	// How far the fill had gotten (see fillProgress) the last time we topped it up, so a fill that
+	// adds nothing visible can be detected. Reset at the start of each fill episode.
+	let lastFillProgress = 0
 
 	useIntersectionObserver(
 		sentinel,
 		([entry]) => {
 			const entering = !!entry?.isIntersecting && !sentinelVisible.value
 			sentinelVisible.value = !!entry?.isIntersecting
-			if (entering) lastFillHeight = 0
+			if (entering) lastFillProgress = 0
 			if (sentinelVisible.value) loadMore()
 		},
 		{ root: container },
 	)
 
 	/**
-	 * Rescues the one case the observer cannot: the rendered list is too short to scroll, so the
-	 * sentinel can never leave and re-enter the viewport to fire again — infinite scroll would die with
-	 * nothing left to scroll. A window of 25 threads can collapse to a single stack row, so filling the
-	 * viewport can take several of them.
+	 * Rescues the case the observer cannot: the sentinel is already in view and stays there, so it
+	 * never leaves and re-enters to fire again — infinite scroll would die with the viewport unfilled.
+	 * A window of 25 threads can collapse to a single stack row (or vanish into an existing one), so
+	 * filling the viewport can take several of them.
 	 *
-	 * Both guards are load-bearing. Stop once the list can scroll, because from there the user's own
-	 * scrolling drives the observer. And stop if a window added no height: its rows landed somewhere
-	 * they cannot be seen (a collapsed date group), so further windows would be just as invisible —
-	 * without this, collapsing a large group turns into a stampede that walks the entire mailbox 25
-	 * threads at a time.
+	 * The progress guard is load-bearing: stop as soon as a window advanced nothing the reader can see
+	 * — its threads landed inside a collapsed date group, so further windows would be just as
+	 * invisible. Without it, collapsing a large group turns into a stampede that walks the entire
+	 * mailbox 25 threads at a time. Progress is the caller's fillProgress metric, NOT pixel height:
+	 * a window absorbed into existing stack rows adds no height yet is real progress, and height-based
+	 * stopping stranded exactly the incident-heavy inboxes that stack hardest, with the sentinel in
+	 * view but nothing left to re-fire it.
 	 *
-	 * Call it from a watcher on the RENDERED rows, not on the loaded threads: a fill is judged by the
-	 * height the rows took, and rows also come and go as stacks and date groups fold. That watcher must
-	 * be declared below the rows it watches — `watch` evaluates its source at setup, and reading a
+	 * Call it from a watcher on the RENDERED rows, not on the loaded threads: rows come and go as
+	 * stacks and date groups fold, and each change can move the sentinel. That watcher must be
+	 * declared below the rows it watches — `watch` evaluates its source at setup, and reading a
 	 * `<script setup>` computed from above its declaration is a temporal-dead-zone crash.
 	 */
+	// Whether the sentinel is inside the container's viewport RIGHT NOW, measured — not the observer
+	// flag, which is stale at nextTick (observer callbacks land after render): a fill that pushed the
+	// sentinel below the fold would read as still-visible and chain an unwanted extra window onto
+	// every ordinary scroll-to-bottom load.
+	const sentinelInView = () => {
+		const el = container.value
+		const s = sentinel.value
+		if (!el || !s) return false
+		const c = el.getBoundingClientRect()
+		const r = s.getBoundingClientRect()
+		return r.top < c.bottom && r.bottom > c.top
+	}
+
 	const topUpIfShort = () => {
 		if (!sentinelVisible.value || !hasMore.value) return
 
 		nextTick(() => {
-			const el = container.value
-			if (!el || !sentinelVisible.value) return
+			if (!sentinelInView()) return
 
-			const grew = el.scrollHeight > lastFillHeight
-			lastFillHeight = el.scrollHeight
-			if (el.scrollHeight <= el.clientHeight && grew) loadMore()
+			const progress = fillProgress ? fillProgress() : (container.value?.scrollHeight ?? 0)
+			const grew = progress > lastFillProgress
+			lastFillProgress = progress
+			if (grew) loadMore()
 		})
 	}
 

--- a/frontend/src/apps/mail/composables/usePaginatedThreads.ts
+++ b/frontend/src/apps/mail/composables/usePaginatedThreads.ts
@@ -27,6 +27,12 @@ import type { Thread } from '@/apps/mail/types'
 /** Rows per window. Fetches ask for one more, to detect whether further rows exist without a total. */
 export const PAGE_LENGTH = 25
 
+// Windows one fill episode may pull before it gives up (see topUpIfShort). Far more than any viewport
+// needs — the cap only catches the case where the fill can never succeed: every window absorbed into
+// the trailing stack row, which adds no height, so the sentinel stays in view and the list would walk
+// the whole mailbox 25 threads at a time.
+const MAX_FILL_WINDOWS = 20
+
 // How long a row optimistically removed by an action stays suppressed. The server keeps returning it
 // until the mutation lands, so a refresh or append in that window would put it back.
 const REMOVAL_SUPPRESSION_MS = 15000
@@ -250,15 +256,20 @@ export const usePaginatedThreads = ({
 	const sentinelVisible = ref(false)
 
 	// How far the fill had gotten (see fillProgress) the last time we topped it up, so a fill that
-	// adds nothing visible can be detected. Reset at the start of each fill episode.
+	// adds nothing visible can be detected, and how many windows this episode has pulled. Both reset
+	// at the start of each fill episode.
 	let lastFillProgress = 0
+	let fillWindows = 0
 
 	useIntersectionObserver(
 		sentinel,
 		([entry]) => {
 			const entering = !!entry?.isIntersecting && !sentinelVisible.value
 			sentinelVisible.value = !!entry?.isIntersecting
-			if (entering) lastFillProgress = 0
+			if (entering) {
+				lastFillProgress = 0
+				fillWindows = 0
+			}
 			if (sentinelVisible.value) loadMore()
 		},
 		{ root: container },
@@ -270,13 +281,19 @@ export const usePaginatedThreads = ({
 	 * A window of 25 threads can collapse to a single stack row (or vanish into an existing one), so
 	 * filling the viewport can take several of them.
 	 *
-	 * The progress guard is load-bearing: stop as soon as a window advanced nothing the reader can see
-	 * — its threads landed inside a collapsed date group, so further windows would be just as
-	 * invisible. Without it, collapsing a large group turns into a stampede that walks the entire
-	 * mailbox 25 threads at a time. Progress is the caller's fillProgress metric, NOT pixel height:
-	 * a window absorbed into existing stack rows adds no height yet is real progress, and height-based
-	 * stopping stranded exactly the incident-heavy inboxes that stack hardest, with the sentinel in
-	 * view but nothing left to re-fire it.
+	 * What normally ends an episode is the sentinel leaving the viewport — the fill worked. Two guards
+	 * cover the fills that can't:
+	 *
+	 * Progress, the caller's fillProgress metric and NOT pixel height: a window absorbed into existing
+	 * stack rows adds no height yet is real progress, and height-based stopping stranded exactly the
+	 * incident-heavy inboxes that stack hardest, with the sentinel in view but nothing left to re-fire
+	 * it. A window that advances nothing landed somewhere unrenderable (a collapsed date group), so
+	 * further windows would be too. Appends normally extend the last date group, which can't be
+	 * collapsed, so this mostly guards rows arriving out of order.
+	 *
+	 * And the episode's window budget, for the fill that makes progress forever without ever filling:
+	 * every window absorbed into the trailing stack row is invisible height-wise, so absent a cap an
+	 * alerting inbox would walk itself end to end. The reader can still scroll and re-arm the observer.
 	 *
 	 * Call it from a watcher on the RENDERED rows, not on the loaded threads: rows come and go as
 	 * stacks and date groups fold, and each change can move the sentinel. That watcher must be
@@ -297,7 +314,7 @@ export const usePaginatedThreads = ({
 	}
 
 	const topUpIfShort = () => {
-		if (!sentinelVisible.value || !hasMore.value) return
+		if (!sentinelVisible.value || !hasMore.value || fillWindows >= MAX_FILL_WINDOWS) return
 
 		nextTick(() => {
 			if (!sentinelInView()) return
@@ -305,7 +322,9 @@ export const usePaginatedThreads = ({
 			const progress = fillProgress ? fillProgress() : (container.value?.scrollHeight ?? 0)
 			const grew = progress > lastFillProgress
 			lastFillProgress = progress
-			if (grew) loadMore()
+			if (!grew) return
+			fillWindows++
+			loadMore()
 		})
 	}
 

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -290,6 +290,8 @@ const {
 	// just takes the cursor to it — onto whatever row stands for it (see rowForThread).
 	onEdgeThread: (id, action) => (action === 'open' ? openThread(id) : focusOnThread(id)),
 	threadKey,
+	// Deferred read — visibleThreadCount is declared below, with the rows it counts.
+	fillProgress: () => visibleThreadCount.value,
 })
 
 const isLoaded = ref(false)
@@ -389,6 +391,7 @@ const {
 	collapsedGroups,
 	expandedStacks,
 	groupedRows,
+	visibleThreadCount,
 	navigableRows,
 	focusedRowKey,
 	focusedRow,

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -601,6 +601,8 @@ const {
 	fetchMore: () => (mailbox === 'search' ? loadMoreSearch : loadMoreThreads).reload(),
 	openThreadID: () => threadID,
 	onEdgeThread: (id, action) => (action === 'open' ? goToThread(id) : focusOnThread(id)),
+	// Deferred read — visibleThreadCount is declared below, with the rows it counts.
+	fillProgress: () => visibleThreadCount.value,
 })
 
 // Rows and the cursor
@@ -627,6 +629,7 @@ const {
 	collapsedGroups,
 	expandedStacks,
 	groupedRows,
+	visibleThreadCount,
 	navigableRows,
 	focusedRowKey,
 	focusedRow,

--- a/frontend/src/apps/mail/utils/darkMail.test.ts
+++ b/frontend/src/apps/mail/utils/darkMail.test.ts
@@ -101,6 +101,20 @@ describe('mapColorToken', () => {
 		expect(luma(banner)).toBeLessThan(0.35)
 	})
 
+	it('keeps visible borders visible — light hairlines land in the hairline band', () => {
+		// A #e5e7eb table divider reads clearly on white; pure bg inversion would
+		// land it a whisker above the canvas, invisible in the compressed dark.
+		const divider = mapColorToken('#e5e7eb', 'border')!
+		expect(luma(divider)).toBeGreaterThan(luma(mapColorToken('#e5e7eb', 'bg')!) + 0.05)
+		expect(luma(divider)).toBeLessThan(0.35)
+	})
+
+	it('keeps invisible spacer borders invisible — near-white tracks pure inversion', () => {
+		// border: 1px solid #fff on a white surface is a spacing hack, not a
+		// divider; flooring it would draw a grid the author never had.
+		expect(mapColorToken('#ffffff', 'border')).toBe('#171717')
+	})
+
 	it('preserves alpha and skips fully transparent colors', () => {
 		expect(mapColorToken('rgba(255, 255, 255, 0.5)', 'bg')).toMatch(/^rgba\(.*0\.5\)$/)
 		expect(mapColorToken('rgba(255, 255, 255, 0)', 'bg')).toBeNull()
@@ -232,6 +246,29 @@ describe('remapEmailForDarkMode', () => {
 		const card = doc.querySelector('a')!.getAttribute('style')!
 		expect(card).toContain('background-color: #171717;')
 		expect(luma(card.match(/(?:^|;)\s*color:\s*([^;]+)/)![1])).toBeGreaterThan(0.6)
+	})
+
+	it('counts sheet-defined surfaces in the walk — a classed white card inside a textured wrapper remaps', () => {
+		// The Twilio receipt: dark textured wrapper, a white card whose background
+		// is a <style> class, and a textured footer. The card is the text's real
+		// surface — walking past it (inline-only walk) pinned authored-dark text
+		// onto the card that the sheet remap had just turned dark.
+		const doc = parseDoc(`
+			<style>
+				.card { background-color: #ffffff; }
+				.foot { background: #eeeeee url(https://cdn.example.com/texture.png); }
+			</style>
+			<div style="background: #242424 url(https://cdn.example.com/dark-texture.png);">
+				<div class="card"><p style="color: #414141;">We charged your card.</p></div>
+				<div class="foot"><p style="color: #414141;">This system email was sent to you.</p></div>
+			</div>
+		`)
+		remapEmailForDarkMode(doc)
+		const [card, foot] = Array.from(doc.querySelectorAll('p'))
+		// Card text follows the remap — its sheet-defined surface remaps with it…
+		expect(luma(card!.getAttribute('style')!.match(/color:\s*([^;]+)/)![1])).toBeGreaterThan(0.6)
+		// …while footer text stays authored: its surface is an unremappable texture.
+		expect(foot!.getAttribute('style')).toContain('color: #414141;')
 	})
 
 	it('pins inherited text color onto an image surface explicitly', () => {

--- a/frontend/src/apps/mail/utils/darkMail.test.ts
+++ b/frontend/src/apps/mail/utils/darkMail.test.ts
@@ -292,6 +292,25 @@ describe('remapEmailForDarkMode', () => {
 		})
 	})
 
+	it('classifies surfaces through the cascade — specificity and !important, not just source order', () => {
+		const doc = parseDoc(`
+			<style>
+				div.hero { background-image: url(https://cdn.example.com/hero.jpg); }
+				.hero { background-image: none; }
+				.banner { background-image: url(https://cdn.example.com/banner.jpg) !important; }
+				.banner { background: #ffffff; }
+			</style>
+			<div class="hero"><p style="color: #444444;">image wins on specificity</p></div>
+			<div class="banner" style="background: #ffffff;"><p style="color: #444444;">image wins on importance</p></div>
+		`)
+		remapEmailForDarkMode(doc)
+		// Both surfaces keep their image despite later/inline repaints, so both
+		// texts stay authored.
+		doc.querySelectorAll('p').forEach((p) => {
+			expect(p.getAttribute('style')).toContain('color: #444444;')
+		})
+	})
+
 	it('pins inherited text color onto an image surface explicitly', () => {
 		// The wrapper's literal gets remapped light for the rest of the email; the
 		// image surface must keep an authored copy for the text inheriting into it.

--- a/frontend/src/apps/mail/utils/darkMail.test.ts
+++ b/frontend/src/apps/mail/utils/darkMail.test.ts
@@ -331,6 +331,20 @@ describe('remapEmailForDarkMode', () => {
 		expect(luma(sideText!.getAttribute('style')!.match(/color:\s*([^;]+)/)![1])).toBeGreaterThan(0.6)
 	})
 
+	it('a later inline shorthand reset beats an earlier inline url', () => {
+		// The style attribute is itself a cascade: the shorthand that follows the
+		// url declaration resets the image layer, so no image paints and the text
+		// must follow the remap.
+		const doc = parseDoc(`
+			<div style="background-image: url(https://cdn.example.com/tex.png); background: #ffffff;">
+				<p style="color: #444444;">reset within the attribute</p>
+			</div>
+		`)
+		remapEmailForDarkMode(doc)
+		const text = doc.querySelector('p')!.getAttribute('style')!
+		expect(luma(text.match(/color:\s*([^;]+)/)![1])).toBeGreaterThan(0.6)
+	})
+
 	it('a sheet !important image reset beats a non-important inline url', () => {
 		// The browser paints no image here: the sheet's !important none wins over
 		// the inline url, so the surface is its (remapped) color and the text

--- a/frontend/src/apps/mail/utils/darkMail.test.ts
+++ b/frontend/src/apps/mail/utils/darkMail.test.ts
@@ -271,6 +271,27 @@ describe('remapEmailForDarkMode', () => {
 		expect(foot!.getAttribute('style')).toContain('color: #414141;')
 	})
 
+	it('a later rule or inline style repainting the surface strips the image classification', () => {
+		// Cascade order matters: `background: #fff` after an image hero, or a
+		// `background-image: none` reset, means no image actually paints — text
+		// there must follow the remap, not stay pinned authored-dark.
+		const doc = parseDoc(`
+			<style>
+				.hero { background: url(https://cdn.example.com/hero.jpg); }
+				.hero { background: #ffffff; }
+				.banner { background-image: url(https://cdn.example.com/banner.jpg); }
+				.banner { background-image: none; }
+			</style>
+			<div class="hero"><p style="color: #444444;">repainted</p></div>
+			<div class="banner" style="background-color: #ffffff;"><p style="color: #444444;">reset</p></div>
+			<div class="hero" style="background: #ffffff;"><p style="color: #444444;">inline repaint</p></div>
+		`)
+		remapEmailForDarkMode(doc)
+		doc.querySelectorAll('p').forEach((p) => {
+			expect(luma(p.getAttribute('style')!.match(/color:\s*([^;]+)/)![1])).toBeGreaterThan(0.6)
+		})
+	})
+
 	it('pins inherited text color onto an image surface explicitly', () => {
 		// The wrapper's literal gets remapped light for the rest of the email; the
 		// image surface must keep an authored copy for the text inheriting into it.

--- a/frontend/src/apps/mail/utils/darkMail.test.ts
+++ b/frontend/src/apps/mail/utils/darkMail.test.ts
@@ -331,6 +331,22 @@ describe('remapEmailForDarkMode', () => {
 		expect(luma(sideText!.getAttribute('style')!.match(/color:\s*([^;]+)/)![1])).toBeGreaterThan(0.6)
 	})
 
+	it('splits selector lists on top-level commas only — functional arguments keep theirs', () => {
+		// Naive comma splitting turns `.hero:not(.a, .b), .strip` into invalid
+		// fragments and silently drops both surfaces.
+		const doc = parseDoc(`
+			<style>
+				.hero:not(.plain, .quiet), .strip { background-image: url(https://cdn.example.com/hero.jpg); }
+			</style>
+			<div class="hero"><p style="color: #444444;">on the hero image</p></div>
+			<div class="strip"><p style="color: #444444;">on the strip image</p></div>
+		`)
+		remapEmailForDarkMode(doc)
+		doc.querySelectorAll('p').forEach((p) => {
+			expect(p.getAttribute('style')).toContain('color: #444444;')
+		})
+	})
+
 	it('pins inherited text color onto an image surface explicitly', () => {
 		// The wrapper's literal gets remapped light for the rest of the email; the
 		// image surface must keep an authored copy for the text inheriting into it.

--- a/frontend/src/apps/mail/utils/darkMail.test.ts
+++ b/frontend/src/apps/mail/utils/darkMail.test.ts
@@ -331,6 +331,21 @@ describe('remapEmailForDarkMode', () => {
 		expect(luma(sideText!.getAttribute('style')!.match(/color:\s*([^;]+)/)![1])).toBeGreaterThan(0.6)
 	})
 
+	it('a sheet !important image reset beats a non-important inline url', () => {
+		// The browser paints no image here: the sheet's !important none wins over
+		// the inline url, so the surface is its (remapped) color and the text
+		// must follow the remap.
+		const doc = parseDoc(`
+			<style>.stripped { background-image: none !important; }</style>
+			<div class="stripped" style="background: #ffffff url(https://cdn.example.com/tex.png);">
+				<p style="color: #444444;">no image painted</p>
+			</div>
+		`)
+		remapEmailForDarkMode(doc)
+		const text = doc.querySelector('p')!.getAttribute('style')!
+		expect(luma(text.match(/color:\s*([^;]+)/)![1])).toBeGreaterThan(0.6)
+	})
+
 	it('an inline !important repaint beats a sheet !important image', () => {
 		// The style attribute wins at equal importance: the browser paints white,
 		// the remap turns it dark, so the text must follow the remap.

--- a/frontend/src/apps/mail/utils/darkMail.test.ts
+++ b/frontend/src/apps/mail/utils/darkMail.test.ts
@@ -311,6 +311,26 @@ describe('remapEmailForDarkMode', () => {
 		})
 	})
 
+	it('weighs functional pseudo-classes per spec — :not() carries its argument, :where() nothing', () => {
+		// div:not(#promo) is id-weight (1,0,1): the later class-pile reset must
+		// lose to it. :where(#promo) .side is class-weight only (0,0,0)+(0,1,0):
+		// the plain-class reset that follows wins there.
+		const doc = parseDoc(`
+			<style>
+				div:not(#promo) { background-image: url(https://cdn.example.com/hero.jpg); }
+				.card.wide.padded { background-image: none; }
+				:where(#promo) .side { background-image: url(https://cdn.example.com/side.jpg); }
+				.side { background-image: none; }
+			</style>
+			<div class="card wide padded"><p style="color: #444444;">not() carries the id</p></div>
+			<section id="promo"><span class="side"><p style="color: #444444;">where() weighs nothing</p></span></section>
+		`)
+		remapEmailForDarkMode(doc)
+		const [heroText, sideText] = Array.from(doc.querySelectorAll('p'))
+		expect(heroText!.getAttribute('style')).toContain('color: #444444;')
+		expect(luma(sideText!.getAttribute('style')!.match(/color:\s*([^;]+)/)![1])).toBeGreaterThan(0.6)
+	})
+
 	it('pins inherited text color onto an image surface explicitly', () => {
 		// The wrapper's literal gets remapped light for the rest of the email; the
 		// image surface must keep an authored copy for the text inheriting into it.

--- a/frontend/src/apps/mail/utils/darkMail.test.ts
+++ b/frontend/src/apps/mail/utils/darkMail.test.ts
@@ -331,6 +331,20 @@ describe('remapEmailForDarkMode', () => {
 		expect(luma(sideText!.getAttribute('style')!.match(/color:\s*([^;]+)/)![1])).toBeGreaterThan(0.6)
 	})
 
+	it('an inline !important repaint beats a sheet !important image', () => {
+		// The style attribute wins at equal importance: the browser paints white,
+		// the remap turns it dark, so the text must follow the remap.
+		const doc = parseDoc(`
+			<style>.banner { background-image: url(https://cdn.example.com/banner.jpg) !important; }</style>
+			<div class="banner" style="background: #ffffff !important;">
+				<p style="color: #444444;">painted over</p>
+			</div>
+		`)
+		remapEmailForDarkMode(doc)
+		const text = doc.querySelector('p')!.getAttribute('style')!
+		expect(luma(text.match(/color:\s*([^;]+)/)![1])).toBeGreaterThan(0.6)
+	})
+
 	it('splits selector lists on top-level commas only — functional arguments keep theirs', () => {
 		// Naive comma splitting turns `.hero:not(.a, .b), .strip` into invalid
 		// fragments and silently drops both surfaces.

--- a/frontend/src/apps/mail/utils/darkMail.ts
+++ b/frontend/src/apps/mail/utils/darkMail.ts
@@ -477,14 +477,14 @@ const elementTextColor = (el: Element): string | null => {
 }
 
 // A surface painted by url(...) — a raster the remap cannot rewrite (the token
-// pass masks url() precisely so it never touches one). Its pixels are
+// pass masks url() precisely so it never touches one) — shows pixels that are
 // byte-identical in dark mode, so the text resting on it must be too:
 // remapping dark text over a light gradient JPEG flips it near-white and it
 // vanishes into the image. CSS gradients don't count — they carry color
-// literals and are remapped like any other surface. Requires a non-empty
-// url(): blocked remote assets are blanked to url() and paint nothing.
-const hasImageBackground = (el: Element): boolean =>
-	/background[^;:]*:[^;]*url\(\s*[^)\s]/i.test(el.getAttribute('style') ?? '')
+// literals and are remapped like any other surface. Detection requires a
+// non-empty url(): blocked remote assets are blanked to url() and paint
+// nothing. Whether an image actually paints is a cascade question, resolved by
+// inlineImageClaim and collectSheetSurfaces below.
 
 // Surfaces whose background is authored in <style> sheets rather than inline
 // (Twilio's white card is a classed rule; some heroes class their bg image).
@@ -616,20 +616,37 @@ const collectSheetSurfaces = (doc: Document): SheetSurfaces => {
 	return surfaces
 }
 
+// The style attribute's own claim on the image axis, resolved by the same
+// last-writer-wins the sheets use: a later inline shorthand reset
+// (`background: #fff`) beats an earlier inline url exactly as it paints, and
+// a later non-important declaration does not beat an earlier !important one.
+// `background-color` never enters — it only touches the layer beneath.
+const inlineImageClaim = (el: Element): { on: boolean; important: boolean } | null => {
+	let claim: { on: boolean; important: boolean } | null = null
+	for (const decl of (el.getAttribute('style') ?? '').matchAll(
+		/(?:^|;)\s*background(-color|-image)?\s*:([^;]*)/gi,
+	)) {
+		if ((decl[1] ?? '').toLowerCase() === '-color') continue
+		const next = {
+			on: /url\(\s*[^)\s]/i.test(decl[2]),
+			important: /!\s*important/i.test(decl[2]),
+		}
+		if (!claim || next.important || !claim.important) claim = next
+	}
+	return claim
+}
+
 // An image layer paints over any color layer, wherever each is declared. The
-// image axis is decided between the style attribute and the winning sheet
-// claim by importance, style attribute on ties — in both directions: a sheet
-// !important url beats an inline repaint, and a sheet !important `none` reset
-// beats an inline url. `background-color` (either place) only touches the
-// color layer beneath the image and never enters this contest.
+// image axis is decided between the style attribute's claim and the winning
+// sheet claim by importance, style attribute on ties — in both directions: a
+// sheet !important url beats an inline repaint, and a sheet !important `none`
+// reset beats a non-important inline url.
 const isImageSurface = (el: Element, sheets: SheetSurfaces): boolean => {
-	const style = el.getAttribute('style') ?? ''
-	const inlineDecls = [...style.matchAll(/(?:^|;)\s*background(?:-image)?\s*:[^;]*/gi)]
-	const inlineImportant = inlineDecls.some((decl) => /!\s*important/i.test(decl[0]))
+	const inline = inlineImageClaim(el)
 	const sheet = sheets.imageClaims.get(el)
-	if (inlineDecls.length && (inlineImportant || !sheet?.important)) return hasImageBackground(el)
+	if (inline && (inline.important || !sheet?.important)) return inline.on
 	if (sheet) return sheet.on
-	return hasImageBackground(el)
+	return false
 }
 
 // The innermost element whose background the text actually rests on — the one

--- a/frontend/src/apps/mail/utils/darkMail.ts
+++ b/frontend/src/apps/mail/utils/darkMail.ts
@@ -514,7 +514,7 @@ const selectorSpecificity = (selector: string): number => {
 			if (fn.toLowerCase() !== 'where')
 				functional += Math.max(
 					0,
-					...args.split(',').map((arg: string) => selectorSpecificity(arg)),
+					...splitSelectorList(args).map((arg: string) => selectorSpecificity(arg)),
 				)
 			return ' '
 		})
@@ -523,6 +523,26 @@ const selectorSpecificity = (selector: string): number => {
 	const classes = (s.match(/\.[\w-]+|\[[^\]]*\]|:[\w-]+(?:\([^)]*\))?/g) ?? []).length
 	const elements = (s.match(/(?:^|[\s>+~(,])[a-zA-Z][\w-]*/g) ?? []).length
 	return functional + ids * 10_000 + classes * 100 + elements
+}
+
+// Split a selector list on top-level commas only — commas inside functional
+// arguments (`:not(.x, .y)`) or attribute values belong to their selector, and
+// naive splitting turns it into invalid fragments whose surfaces silently drop.
+const splitSelectorList = (list: string): string[] => {
+	const parts: string[] = []
+	let depth = 0
+	let start = 0
+	for (let i = 0; i < list.length; i++) {
+		const ch = list[i]
+		if (ch === '(' || ch === '[') depth++
+		else if (ch === ')' || ch === ']') depth = Math.max(0, depth - 1)
+		else if (ch === ',' && depth === 0) {
+			parts.push(list.slice(start, i))
+			start = i + 1
+		}
+	}
+	parts.push(list.slice(start))
+	return parts
 }
 
 // The winning claim on one background axis of one element, cascade-ordered:
@@ -555,7 +575,7 @@ const collectSheetSurfaces = (doc: Document): SheetSurfaces => {
 			const decls = [...rule[2].matchAll(/background(-color|-image)?\s*:\s*([^;]+)/gi)]
 			if (!decls.length) continue
 			// Per selector in the list: each carries its own specificity.
-			for (const selector of selectorList.split(',')) {
+			for (const selector of splitSelectorList(selectorList)) {
 				let els: NodeListOf<Element>
 				try {
 					els = doc.querySelectorAll(selector)

--- a/frontend/src/apps/mail/utils/darkMail.ts
+++ b/frontend/src/apps/mail/utils/darkMail.ts
@@ -502,15 +502,27 @@ type SheetSurfaces = {
 }
 
 // Email-grade selector specificity: (ids, classes/attributes/pseudo-classes,
-// elements), packed into one comparable number. Enough fidelity for the
-// selectors mail templates ship; the exotica (:is() argument weighing, layers)
-// doesn't appear in email CSS.
+// elements), packed into one comparable number. Per spec, :is()/:not()/:has()
+// weigh as their most specific argument and add nothing themselves, and
+// :where() adds nothing at all — frappe's own email CSS ships
+// `.email-body a:not(.btn)`, so these are not exotica here. Nested functional
+// pseudo-classes and cascade layers stay unmodeled; email CSS has neither.
 const selectorSpecificity = (selector: string): number => {
-	const s = selector.replace(/::[\w-]+/g, ' x ') // pseudo-elements weigh as elements
+	let functional = 0
+	const s = selector
+		.replace(/:(is|not|has|where)\(([^()]*)\)/gi, (_, fn: string, args: string) => {
+			if (fn.toLowerCase() !== 'where')
+				functional += Math.max(
+					0,
+					...args.split(',').map((arg: string) => selectorSpecificity(arg)),
+				)
+			return ' '
+		})
+		.replace(/::[\w-]+/g, ' x ') // pseudo-elements weigh as elements
 	const ids = (s.match(/#[\w-]+/g) ?? []).length
 	const classes = (s.match(/\.[\w-]+|\[[^\]]*\]|:[\w-]+(?:\([^)]*\))?/g) ?? []).length
 	const elements = (s.match(/(?:^|[\s>+~(,])[a-zA-Z][\w-]*/g) ?? []).length
-	return ids * 10_000 + classes * 100 + elements
+	return functional + ids * 10_000 + classes * 100 + elements
 }
 
 // The winning claim on one background axis of one element, cascade-ordered:

--- a/frontend/src/apps/mail/utils/darkMail.ts
+++ b/frontend/src/apps/mail/utils/darkMail.ts
@@ -494,54 +494,107 @@ const hasImageBackground = (el: Element): boolean =>
 // treated as unconditional, which is exact for the surviving light-scheme
 // rules (dark blocks are stripped before remapping) and a fair approximation
 // for responsive ones.
-type SheetSurfaces = { color: Set<Element>; image: Set<Element> }
+type SheetSurfaces = {
+	color: Set<Element>
+	image: Set<Element>
+	// Image claims won with !important — these beat even an inline repaint.
+	imageImportant: Set<Element>
+}
+
+// Email-grade selector specificity: (ids, classes/attributes/pseudo-classes,
+// elements), packed into one comparable number. Enough fidelity for the
+// selectors mail templates ship; the exotica (:is() argument weighing, layers)
+// doesn't appear in email CSS.
+const selectorSpecificity = (selector: string): number => {
+	const s = selector.replace(/::[\w-]+/g, ' x ') // pseudo-elements weigh as elements
+	const ids = (s.match(/#[\w-]+/g) ?? []).length
+	const classes = (s.match(/\.[\w-]+|\[[^\]]*\]|:[\w-]+(?:\([^)]*\))?/g) ?? []).length
+	const elements = (s.match(/(?:^|[\s>+~(,])[a-zA-Z][\w-]*/g) ?? []).length
+	return ids * 10_000 + classes * 100 + elements
+}
+
+// The winning claim on one background axis of one element, cascade-ordered:
+// !important first, then specificity, then source order (ties go to the later
+// declaration, as in CSS).
+type AxisClaim = { on: boolean; important: boolean; specificity: number; order: number }
+
+const beats = (a: AxisClaim, b: AxisClaim | undefined) =>
+	!b ||
+	(a.important !== b.important
+		? a.important
+		: a.specificity !== b.specificity
+			? a.specificity > b.specificity
+			: a.order >= b.order)
 
 const collectSheetSurfaces = (doc: Document): SheetSurfaces => {
-	// Last-writer-wins per background axis, in source order — the closest thing
-	// to the cascade email-grade CSS needs. A later rule that repaints an
-	// element (`background: #fff` after an image hero, `background-image: none`
-	// in a reset) must strip the earlier image classification, or its text
-	// stays pinned against a surface that was remapped dark. Specificity is not
-	// modeled; source order decides, as it does for the equal-specificity rules
-	// emails actually ship.
-	const image = new Map<Element, boolean>()
-	const color = new Map<Element, boolean>()
+	// Resolve each element's effective background per axis through the cascade,
+	// so classification matches what the browser paints. A repaint that wins
+	// (`background: #fff` over an image hero, a `background-image: none` reset)
+	// must strip the image classification, or its text stays pinned
+	// authored-dark against a surface that was remapped; a repaint that loses
+	// (lower specificity than an `!important` hero rule) must not.
+	const image = new Map<Element, AxisClaim>()
+	const color = new Map<Element, AxisClaim>()
+	let order = 0
 	doc.querySelectorAll('style').forEach((style) => {
 		for (const rule of (style.textContent ?? '').matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
-			const selector = rule[1].trim()
-			if (selector.startsWith('@')) continue
+			const selectorList = rule[1].trim()
+			if (selectorList.startsWith('@')) continue
 			const decls = [...rule[2].matchAll(/background(-color|-image)?\s*:\s*([^;]+)/gi)]
 			if (!decls.length) continue
-			let els: NodeListOf<Element>
-			try {
-				els = doc.querySelectorAll(selector)
-			} catch {
-				continue // selector syntax we can't resolve — skip
-			}
-			for (const decl of decls) {
-				const axis = (decl[1] ?? '').toLowerCase()
-				const hasUrl = /url\(\s*[^)\s]/i.test(decl[2])
-				const token = decl[2].match(COLOR_TOKEN)?.[0]
-				const hasColor = !!token && (parseCssColor(token)?.a ?? 0) > 0
-				els.forEach((el) => {
-					if (axis !== '-color') image.set(el, hasUrl)
-					if (axis !== '-image') color.set(el, hasColor)
-				})
+			// Per selector in the list: each carries its own specificity.
+			for (const selector of selectorList.split(',')) {
+				let els: NodeListOf<Element>
+				try {
+					els = doc.querySelectorAll(selector)
+				} catch {
+					continue // selector syntax we can't resolve — skip
+				}
+				const specificity = selectorSpecificity(selector)
+				for (const decl of decls) {
+					const axis = (decl[1] ?? '').toLowerCase()
+					const important = /!\s*important/i.test(decl[2])
+					const hasUrl = /url\(\s*[^)\s]/i.test(decl[2])
+					const token = decl[2].match(COLOR_TOKEN)?.[0]
+					const hasColor = !!token && (parseCssColor(token)?.a ?? 0) > 0
+					const claim = (on: boolean): AxisClaim => ({
+						on,
+						important,
+						specificity,
+						order: order++,
+					})
+					els.forEach((el) => {
+						if (axis !== '-color') {
+							const next = claim(hasUrl)
+							if (beats(next, image.get(el))) image.set(el, next)
+						}
+						if (axis !== '-image') {
+							const next = claim(hasColor)
+							if (beats(next, color.get(el))) color.set(el, next)
+						}
+					})
+				}
 			}
 		}
 	})
-	const surfaces: SheetSurfaces = { color: new Set(), image: new Set() }
-	image.forEach((isImage, el) => isImage && surfaces.image.add(el))
-	color.forEach((isColor, el) => isColor && surfaces.color.add(el))
+	const surfaces: SheetSurfaces = { color: new Set(), image: new Set(), imageImportant: new Set() }
+	image.forEach((c, el) => {
+		if (!c.on) return
+		surfaces.image.add(el)
+		if (c.important) surfaces.imageImportant.add(el)
+	})
+	color.forEach((c, el) => c.on && surfaces.color.add(el))
 	return surfaces
 }
 
-// An image layer paints over any color layer, wherever each is declared — but
-// an inline `background`/`background-image` repaint overrides a sheet-declared
-// image (the shorthand resets the image layer), while `background-color` alone
-// touches only the color layer beneath it.
+// An image layer paints over any color layer, wherever each is declared. An
+// inline `background`/`background-image` repaint overrides a sheet-declared
+// image (the shorthand resets the image layer) — unless the sheet claim won
+// with !important, which beats inline styles; `background-color` alone only
+// touches the color layer beneath the image.
 const isImageSurface = (el: Element, sheets: SheetSurfaces): boolean => {
 	if (hasImageBackground(el)) return true
+	if (sheets.imageImportant.has(el)) return true
 	if (/(?:^|;)\s*background(?:-image)?\s*:/i.test(el.getAttribute('style') ?? '')) return false
 	return sheets.image.has(el)
 }

--- a/frontend/src/apps/mail/utils/darkMail.ts
+++ b/frontend/src/apps/mail/utils/darkMail.ts
@@ -622,12 +622,16 @@ const collectSheetSurfaces = (doc: Document): SheetSurfaces => {
 // An image layer paints over any color layer, wherever each is declared. An
 // inline `background`/`background-image` repaint overrides a sheet-declared
 // image (the shorthand resets the image layer) — unless the sheet claim won
-// with !important, which beats inline styles; `background-color` alone only
-// touches the color layer beneath the image.
+// with !important, which beats a normal inline repaint but loses to an inline
+// !important one (the style attribute wins at equal importance).
+// `background-color` alone only touches the color layer beneath the image.
 const isImageSurface = (el: Element, sheets: SheetSurfaces): boolean => {
 	if (hasImageBackground(el)) return true
-	if (sheets.imageImportant.has(el)) return true
-	if (/(?:^|;)\s*background(?:-image)?\s*:/i.test(el.getAttribute('style') ?? '')) return false
+	const style = el.getAttribute('style') ?? ''
+	const repaints = [...style.matchAll(/(?:^|;)\s*background(?:-image)?\s*:[^;]*/gi)]
+	const repaintImportant = repaints.some((decl) => /!\s*important/i.test(decl[0]))
+	if (sheets.imageImportant.has(el) && !repaintImportant) return true
+	if (repaints.length) return false
 	return sheets.image.has(el)
 }
 

--- a/frontend/src/apps/mail/utils/darkMail.ts
+++ b/frontend/src/apps/mail/utils/darkMail.ts
@@ -13,7 +13,7 @@
 // a brand link) is kept byte-identical unless it lacks contrast against the
 // dark canvas, in which case it is brightened just enough, hue untouched.
 
-export type ColorRole = 'fg' | 'bg'
+export type ColorRole = 'fg' | 'bg' | 'border'
 
 // OKLab lightness of #171717 — frappe-ui's dark surface-base and the reading
 // pane's canvas. White backgrounds map exactly onto it so remapped emails seam
@@ -37,6 +37,12 @@ const MIN_FG_LUMINANCE = 0.216
 // canvas — a saturated brand banner should read as a tinted dark surface, not
 // a neon slab.
 const BG_MAX_CHROMA = 0.1
+
+// Where visible borders land in dark mode (≈ #333 on the #171717 canvas).
+// Pure background inversion maps a light hairline (#e5e7eb) a whisker above
+// the canvas, where dark lightness deltas compress into invisibility — a
+// divider authored to be seen must stay seen.
+const HAIRLINE_L = 0.32
 
 // Was this color authored as gray or as a color? Authors reach for blue-tinted
 // grays (Tailwind slate & friends) as "gray" on white, where the tint is
@@ -63,6 +69,11 @@ const BG_PROPS = new Set([
 	'background',
 	'background-color',
 	'background-image',
+	'box-shadow',
+	'text-shadow',
+])
+
+const BORDER_PROPS = new Set([
 	'border',
 	'border-color',
 	'border-top',
@@ -75,8 +86,6 @@ const BG_PROPS = new Set([
 	'border-left-color',
 	'outline',
 	'outline-color',
-	'box-shadow',
-	'text-shadow',
 ])
 
 const NAMED_COLORS: Record<string, string> = {
@@ -243,6 +252,17 @@ export const mapColorToken = (token: string, role: ColorRole): string | null => 
 		// neutral canvas reads as colored words, a tinted surface just reads as
 		// brand. Damping only keeps flipped-light surfaces from going neon.
 		targetChroma = Math.min(chroma * 0.85, BG_MAX_CHROMA)
+	} else if (role === 'border') {
+		// Borders invert like surfaces but are floored at the hairline band,
+		// weighted by how visible they were against white — a divider that read
+		// in light mode still reads in dark, while a near-white "spacer" border
+		// (authored invisible over a white surface) tracks pure inversion and
+		// stays invisible over the surface's remapped color.
+		// Full floor for anything up to #eee-grade dividers (L ≈ 0.95), fading
+		// to none by #fafafa (L ≈ 0.99), where light mode itself showed nothing.
+		const visibility = Math.min(1, Math.max(0, (0.99 - L) / 0.04))
+		mappedL = Math.max(invertBackgroundL(L), HAIRLINE_L * visibility)
+		targetChroma = Math.min(chroma * 0.85, BG_MAX_CHROMA)
 	} else {
 		// Gray text flips into the light band and sheds its tint. Colorful text
 		// keeps its hue and saturation exactly and is only brightened when it
@@ -287,7 +307,13 @@ export const remapCssValue = (value: string, role: ColorRole) => {
 export const remapCssText = (css: string) =>
 	css.replace(DECLARATION, (full, prop: string, sep: string, value: string) => {
 		const name = prop.toLowerCase()
-		const role = FG_PROPS.has(name) ? 'fg' : BG_PROPS.has(name) ? 'bg' : null
+		const role = FG_PROPS.has(name)
+			? 'fg'
+			: BG_PROPS.has(name)
+				? 'bg'
+				: BORDER_PROPS.has(name)
+					? 'border'
+					: null
 		return role ? prop + sep + remapCssValue(value, role) : full
 	})
 
@@ -460,13 +486,59 @@ const elementTextColor = (el: Element): string | null => {
 const hasImageBackground = (el: Element): boolean =>
 	/background[^;:]*:[^;]*url\(\s*[^)\s]/i.test(el.getAttribute('style') ?? '')
 
+// Surfaces whose background is authored in <style> sheets rather than inline
+// (Twilio's white card is a classed rule; some heroes class their bg image).
+// The walk below must stop at them too: missing a sheet-backed card between
+// the text and a textured wrapper pins the text to a surface it doesn't rest
+// on. Selectors are resolved with querySelectorAll — rules inside @media are
+// treated as unconditional, which is exact for the surviving light-scheme
+// rules (dark blocks are stripped before remapping) and a fair approximation
+// for responsive ones.
+type SheetSurfaces = { color: Set<Element>; image: Set<Element> }
+
+const collectSheetSurfaces = (doc: Document): SheetSurfaces => {
+	const surfaces: SheetSurfaces = { color: new Set(), image: new Set() }
+	doc.querySelectorAll('style').forEach((style) => {
+		for (const rule of (style.textContent ?? '').matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+			const values = [...rule[2].matchAll(/background(?:-color|-image)?\s*:\s*([^;]+)/gi)]
+			if (!values.length) continue
+			const isImage = values.some((v) => /url\(\s*[^)\s]/i.test(v[1]))
+			const isColor = values.some((v) => {
+				const token = v[1].match(COLOR_TOKEN)?.[0]
+				return !!token && (parseCssColor(token)?.a ?? 0) > 0
+			})
+			if (!isImage && !isColor) continue
+			const selector = rule[1].trim()
+			if (selector.startsWith('@')) continue
+			try {
+				doc.querySelectorAll(selector).forEach((el) => {
+					;(isImage ? surfaces.image : surfaces.color).add(el)
+				})
+			} catch {
+				/* selector syntax we can't resolve — skip */
+			}
+		}
+	})
+	return surfaces
+}
+
+// An image layer paints over any color layer, wherever each is declared.
+const isImageSurface = (el: Element, sheets: SheetSurfaces): boolean =>
+	hasImageBackground(el) || sheets.image.has(el)
+
 // The innermost element whose background the text actually rests on — the one
 // that decides whether its text follows the remap (color surface) or the
 // authored bytes (image surface). A color-backed card nested inside a hero
 // image is its own surface: its text keeps following the remap.
-const nearestSurface = (el: Element): Element | null => {
+const nearestSurface = (el: Element, sheets: SheetSurfaces): Element | null => {
 	let cur: Element | null = el
-	while (cur && !elementBackground(cur) && !hasImageBackground(cur)) cur = cur.parentElement
+	while (
+		cur &&
+		!elementBackground(cur) &&
+		!isImageSurface(cur, sheets) &&
+		!sheets.color.has(cur)
+	)
+		cur = cur.parentElement
 	return cur
 }
 
@@ -485,14 +557,16 @@ export const remapEmailForDarkMode = (doc: Document) => {
 	// Snapshot those pairs before remapping: afterwards the text is re-pinned to
 	// its surface's mapped color, so it follows the background mapping instead
 	// of the text mapping and dark mode doesn't reveal what light mode hides.
+	const sheets = collectSheetSurfaces(doc)
+
 	const camouflaged: Array<{ el: Element; surface: Element }> = []
 	doc.querySelectorAll('[style], [color]').forEach((el) => {
 		const fg = parseAnyColor(elementTextColor(el))
 		if (!fg || fg.a !== 1) return
-		const surface = nearestSurface(el)
+		const surface = nearestSurface(el, sheets)
 		// Text over an image surface is pinned to its authored bytes below —
 		// matching a color further up the tree there is coincidence, not intent.
-		if (surface && hasImageBackground(surface)) return
+		if (surface && isImageSurface(surface, sheets)) return
 		const bg = surface && parseAnyColor(elementBackground(surface))
 		if (!surface || !bg || bg.a !== 1) return
 		if (
@@ -513,11 +587,15 @@ export const remapEmailForDarkMode = (doc: Document) => {
 	doc.querySelectorAll('[style], [color]').forEach((el) => {
 		const authored = elementTextColor(el)
 		if (!authored) return
-		const surface = nearestSurface(el)
-		if (surface && hasImageBackground(surface)) pinned.push({ el, color: authored })
+		const surface = nearestSurface(el, sheets)
+		if (surface && isImageSurface(surface, sheets)) pinned.push({ el, color: authored })
 	})
+	const imageSurfaces = new Set<Element>(sheets.image)
 	doc.querySelectorAll('[style]').forEach((el) => {
-		if (!hasImageBackground(el) || elementTextColor(el)) return
+		if (hasImageBackground(el)) imageSurfaces.add(el)
+	})
+	imageSurfaces.forEach((el) => {
+		if (elementTextColor(el)) return
 		let cur = el.parentElement
 		while (cur && !elementTextColor(cur)) cur = cur.parentElement
 		pinned.push({ el, color: (cur && elementTextColor(cur)) || '#000000' })

--- a/frontend/src/apps/mail/utils/darkMail.ts
+++ b/frontend/src/apps/mail/utils/darkMail.ts
@@ -496,9 +496,11 @@ const hasImageBackground = (el: Element): boolean =>
 // for responsive ones.
 type SheetSurfaces = {
 	color: Set<Element>
-	image: Set<Element>
-	// Image claims won with !important — these beat even an inline repaint.
-	imageImportant: Set<Element>
+	// Each element's winning sheet claim on the image axis — kept as a claim,
+	// not a set, so inline-versus-sheet resolution can weigh its importance in
+	// both directions (an !important url beats an inline repaint; an !important
+	// `none` reset beats an inline url).
+	imageClaims: Map<Element, AxisClaim>
 }
 
 // Email-grade selector specificity: (ids, classes/attributes/pseudo-classes,
@@ -609,30 +611,25 @@ const collectSheetSurfaces = (doc: Document): SheetSurfaces => {
 			}
 		}
 	})
-	const surfaces: SheetSurfaces = { color: new Set(), image: new Set(), imageImportant: new Set() }
-	image.forEach((c, el) => {
-		if (!c.on) return
-		surfaces.image.add(el)
-		if (c.important) surfaces.imageImportant.add(el)
-	})
+	const surfaces: SheetSurfaces = { color: new Set(), imageClaims: image }
 	color.forEach((c, el) => c.on && surfaces.color.add(el))
 	return surfaces
 }
 
-// An image layer paints over any color layer, wherever each is declared. An
-// inline `background`/`background-image` repaint overrides a sheet-declared
-// image (the shorthand resets the image layer) — unless the sheet claim won
-// with !important, which beats a normal inline repaint but loses to an inline
-// !important one (the style attribute wins at equal importance).
-// `background-color` alone only touches the color layer beneath the image.
+// An image layer paints over any color layer, wherever each is declared. The
+// image axis is decided between the style attribute and the winning sheet
+// claim by importance, style attribute on ties — in both directions: a sheet
+// !important url beats an inline repaint, and a sheet !important `none` reset
+// beats an inline url. `background-color` (either place) only touches the
+// color layer beneath the image and never enters this contest.
 const isImageSurface = (el: Element, sheets: SheetSurfaces): boolean => {
-	if (hasImageBackground(el)) return true
 	const style = el.getAttribute('style') ?? ''
-	const repaints = [...style.matchAll(/(?:^|;)\s*background(?:-image)?\s*:[^;]*/gi)]
-	const repaintImportant = repaints.some((decl) => /!\s*important/i.test(decl[0]))
-	if (sheets.imageImportant.has(el) && !repaintImportant) return true
-	if (repaints.length) return false
-	return sheets.image.has(el)
+	const inlineDecls = [...style.matchAll(/(?:^|;)\s*background(?:-image)?\s*:[^;]*/gi)]
+	const inlineImportant = inlineDecls.some((decl) => /!\s*important/i.test(decl[0]))
+	const sheet = sheets.imageClaims.get(el)
+	if (inlineDecls.length && (inlineImportant || !sheet?.important)) return hasImageBackground(el)
+	if (sheet) return sheet.on
+	return hasImageBackground(el)
 }
 
 // The innermost element whose background the text actually rests on — the one
@@ -699,9 +696,12 @@ export const remapEmailForDarkMode = (doc: Document) => {
 		const surface = nearestSurface(el, sheets)
 		if (surface && isImageSurface(surface, sheets)) pinned.push({ el, color: authored })
 	})
-	const imageSurfaces = new Set<Element>(sheets.image)
+	const imageSurfaces = new Set<Element>()
+	sheets.imageClaims.forEach((_, el) => {
+		if (isImageSurface(el, sheets)) imageSurfaces.add(el)
+	})
 	doc.querySelectorAll('[style]').forEach((el) => {
-		if (hasImageBackground(el)) imageSurfaces.add(el)
+		if (isImageSurface(el, sheets)) imageSurfaces.add(el)
 	})
 	imageSurfaces.forEach((el) => {
 		if (elementTextColor(el)) return

--- a/frontend/src/apps/mail/utils/darkMail.ts
+++ b/frontend/src/apps/mail/utils/darkMail.ts
@@ -497,34 +497,54 @@ const hasImageBackground = (el: Element): boolean =>
 type SheetSurfaces = { color: Set<Element>; image: Set<Element> }
 
 const collectSheetSurfaces = (doc: Document): SheetSurfaces => {
-	const surfaces: SheetSurfaces = { color: new Set(), image: new Set() }
+	// Last-writer-wins per background axis, in source order — the closest thing
+	// to the cascade email-grade CSS needs. A later rule that repaints an
+	// element (`background: #fff` after an image hero, `background-image: none`
+	// in a reset) must strip the earlier image classification, or its text
+	// stays pinned against a surface that was remapped dark. Specificity is not
+	// modeled; source order decides, as it does for the equal-specificity rules
+	// emails actually ship.
+	const image = new Map<Element, boolean>()
+	const color = new Map<Element, boolean>()
 	doc.querySelectorAll('style').forEach((style) => {
 		for (const rule of (style.textContent ?? '').matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
-			const values = [...rule[2].matchAll(/background(?:-color|-image)?\s*:\s*([^;]+)/gi)]
-			if (!values.length) continue
-			const isImage = values.some((v) => /url\(\s*[^)\s]/i.test(v[1]))
-			const isColor = values.some((v) => {
-				const token = v[1].match(COLOR_TOKEN)?.[0]
-				return !!token && (parseCssColor(token)?.a ?? 0) > 0
-			})
-			if (!isImage && !isColor) continue
 			const selector = rule[1].trim()
 			if (selector.startsWith('@')) continue
+			const decls = [...rule[2].matchAll(/background(-color|-image)?\s*:\s*([^;]+)/gi)]
+			if (!decls.length) continue
+			let els: NodeListOf<Element>
 			try {
-				doc.querySelectorAll(selector).forEach((el) => {
-					;(isImage ? surfaces.image : surfaces.color).add(el)
-				})
+				els = doc.querySelectorAll(selector)
 			} catch {
-				/* selector syntax we can't resolve — skip */
+				continue // selector syntax we can't resolve — skip
+			}
+			for (const decl of decls) {
+				const axis = (decl[1] ?? '').toLowerCase()
+				const hasUrl = /url\(\s*[^)\s]/i.test(decl[2])
+				const token = decl[2].match(COLOR_TOKEN)?.[0]
+				const hasColor = !!token && (parseCssColor(token)?.a ?? 0) > 0
+				els.forEach((el) => {
+					if (axis !== '-color') image.set(el, hasUrl)
+					if (axis !== '-image') color.set(el, hasColor)
+				})
 			}
 		}
 	})
+	const surfaces: SheetSurfaces = { color: new Set(), image: new Set() }
+	image.forEach((isImage, el) => isImage && surfaces.image.add(el))
+	color.forEach((isColor, el) => isColor && surfaces.color.add(el))
 	return surfaces
 }
 
-// An image layer paints over any color layer, wherever each is declared.
-const isImageSurface = (el: Element, sheets: SheetSurfaces): boolean =>
-	hasImageBackground(el) || sheets.image.has(el)
+// An image layer paints over any color layer, wherever each is declared — but
+// an inline `background`/`background-image` repaint overrides a sheet-declared
+// image (the shorthand resets the image layer), while `background-color` alone
+// touches only the color layer beneath it.
+const isImageSurface = (el: Element, sheets: SheetSurfaces): boolean => {
+	if (hasImageBackground(el)) return true
+	if (/(?:^|;)\s*background(?:-image)?\s*:/i.test(el.getAttribute('style') ?? '')) return false
+	return sheets.image.has(el)
+}
 
 // The innermost element whose background the text actually rests on — the one
 // that decides whether its text follows the remap (color surface) or the

--- a/suite/templates/emails/_event_macros.html
+++ b/suite/templates/emails/_event_macros.html
@@ -44,7 +44,7 @@
 						<div style="font-size: 13px; color: #7c7c7c; margin-top: 1px;">{{ meet.label }}</div>
 					</td>
 					<td style="vertical-align: middle; text-align: right; white-space: nowrap;">
-						<a href="{{ meet.url }}" style="display: inline-block; padding: 7px 15px; background-color: #ffffff; color: #383838; border: 1px solid #e2e2e2; text-decoration: none; border-radius: 10px; font-family: {{ font }}; font-size: 14px; font-weight: 500;">Join</a>
+						<a class="btn" href="{{ meet.url }}" style="display: inline-block; padding: 7px 15px; background-color: #ffffff; color: #383838; border: 1px solid #e2e2e2; text-decoration: none; border-radius: 10px; font-family: {{ font }}; font-size: 14px; font-weight: 500;">Join</a>
 					</td>
 				</tr>
 			</table>
@@ -64,13 +64,13 @@
 <table role="presentation" cellpadding="0" cellspacing="0">
 	<tr>
 		<td style="padding-right: 10px;">
-			<a href="{{ rsvp.accept }}" style="display: inline-block; padding: 10px 20px; background-color: #171717; color: #ffffff; text-decoration: none; border-radius: 10px; font-family: {{ font }}; font-size: 14px; font-weight: 600;">Yes</a>
+			<a class="btn" href="{{ rsvp.accept }}" style="display: inline-block; padding: 10px 20px; background-color: #171717; color: #ffffff; text-decoration: none; border-radius: 10px; font-family: {{ font }}; font-size: 14px; font-weight: 600;">Yes</a>
 		</td>
 		<td style="padding-right: 10px;">
-			<a href="{{ rsvp.tentative }}" style="display: inline-block; padding: 9px 19px; background-color: #ffffff; color: #383838; border: 1px solid #e2e2e2; text-decoration: none; border-radius: 10px; font-family: {{ font }}; font-size: 14px; font-weight: 500;">Maybe</a>
+			<a class="btn" href="{{ rsvp.tentative }}" style="display: inline-block; padding: 9px 19px; background-color: #ffffff; color: #383838; border: 1px solid #e2e2e2; text-decoration: none; border-radius: 10px; font-family: {{ font }}; font-size: 14px; font-weight: 500;">Maybe</a>
 		</td>
 		<td>
-			<a href="{{ rsvp.decline }}" style="display: inline-block; padding: 9px 19px; background-color: #ffffff; color: #383838; border: 1px solid #e2e2e2; text-decoration: none; border-radius: 10px; font-family: {{ font }}; font-size: 14px; font-weight: 500;">No</a>
+			<a class="btn" href="{{ rsvp.decline }}" style="display: inline-block; padding: 9px 19px; background-color: #ffffff; color: #383838; border: 1px solid #e2e2e2; text-decoration: none; border-radius: 10px; font-family: {{ font }}; font-size: 14px; font-weight: 500;">No</a>
 		</td>
 	</tr>
 </table>

--- a/suite/templates/emails/_event_macros.html
+++ b/suite/templates/emails/_event_macros.html
@@ -44,7 +44,7 @@
 						<div style="font-size: 13px; color: #7c7c7c; margin-top: 1px;">{{ meet.label }}</div>
 					</td>
 					<td style="vertical-align: middle; text-align: right; white-space: nowrap;">
-						<a class="btn" href="{{ meet.url }}" style="display: inline-block; padding: 7px 15px; background-color: #ffffff; color: #383838; border: 1px solid #e2e2e2; text-decoration: none; border-radius: 10px; font-family: {{ font }}; font-size: 14px; font-weight: 500;">Join</a>
+						<a href="{{ meet.url }}" style="display: inline-block; padding: 7px 15px; background-color: #ffffff; color: #383838; border: 1px solid #e2e2e2; text-decoration: none; border-radius: 10px; font-family: {{ font }}; font-size: 14px; font-weight: 500;">Join</a>
 					</td>
 				</tr>
 			</table>
@@ -64,13 +64,13 @@
 <table role="presentation" cellpadding="0" cellspacing="0">
 	<tr>
 		<td style="padding-right: 10px;">
-			<a class="btn" href="{{ rsvp.accept }}" style="display: inline-block; padding: 10px 20px; background-color: #171717; color: #ffffff; text-decoration: none; border-radius: 10px; font-family: {{ font }}; font-size: 14px; font-weight: 600;">Yes</a>
+			<a href="{{ rsvp.accept }}" style="display: inline-block; padding: 10px 20px; background-color: #171717; color: #ffffff; text-decoration: none; border-radius: 10px; font-family: {{ font }}; font-size: 14px; font-weight: 600;">Yes</a>
 		</td>
 		<td style="padding-right: 10px;">
-			<a class="btn" href="{{ rsvp.tentative }}" style="display: inline-block; padding: 9px 19px; background-color: #ffffff; color: #383838; border: 1px solid #e2e2e2; text-decoration: none; border-radius: 10px; font-family: {{ font }}; font-size: 14px; font-weight: 500;">Maybe</a>
+			<a href="{{ rsvp.tentative }}" style="display: inline-block; padding: 9px 19px; background-color: #ffffff; color: #383838; border: 1px solid #e2e2e2; text-decoration: none; border-radius: 10px; font-family: {{ font }}; font-size: 14px; font-weight: 500;">Maybe</a>
 		</td>
 		<td>
-			<a class="btn" href="{{ rsvp.decline }}" style="display: inline-block; padding: 9px 19px; background-color: #ffffff; color: #383838; border: 1px solid #e2e2e2; text-decoration: none; border-radius: 10px; font-family: {{ font }}; font-size: 14px; font-weight: 500;">No</a>
+			<a href="{{ rsvp.decline }}" style="display: inline-block; padding: 9px 19px; background-color: #ffffff; color: #383838; border: 1px solid #e2e2e2; text-decoration: none; border-radius: 10px; font-family: {{ font }}; font-size: 14px; font-weight: 500;">No</a>
 		</td>
 	</tr>
 </table>

--- a/suite/templates/emails/drive_invitation.html
+++ b/suite/templates/emails/drive_invitation.html
@@ -27,7 +27,7 @@
 						<p style="font-size: 14px; line-height: 1.5; color: #444444; max-width: 400px; margin: 0 auto 24px;">
 							{{ user }} has invited you to join {% if team_name %}<strong>{{ team_name }}</strong> on {% endif %}Frappe Drive. Click below to get started.
 						</p>
-						<a href="{{ invite_link }}" style="display: inline-block; padding: 12px 24px; font-size: 14px; color: #ffffff; background-color: #171717; text-decoration: none; border-radius: 8px;">Accept Invitation</a>
+						<a class="btn" href="{{ invite_link }}" style="display: inline-block; padding: 12px 24px; font-size: 14px; color: #ffffff; background-color: #171717; text-decoration: none; border-radius: 8px;">Accept Invitation</a>
 						<p style="font-size: 12px; color: #888888; margin: 24px 0 0;">If you didn’t request this, feel free to ignore this email.</p>
 					</td>
 				</tr>

--- a/suite/templates/emails/drive_invitation.html
+++ b/suite/templates/emails/drive_invitation.html
@@ -27,7 +27,10 @@
 						<p style="font-size: 14px; line-height: 1.5; color: #444444; max-width: 400px; margin: 0 auto 24px;">
 							{{ user }} has invited you to join {% if team_name %}<strong>{{ team_name }}</strong> on {% endif %}Frappe Drive. Click below to get started.
 						</p>
-						<a class="btn" href="{{ invite_link }}" style="display: inline-block; padding: 12px 24px; font-size: 14px; color: #ffffff; background-color: #171717; text-decoration: none; border-radius: 8px;">Accept Invitation</a>
+						{#- .btn exempts the anchor from frappe's `.email-body a:not(.btn)` restyle, which
+						    premailer keeps as !important. border/margin are re-declared because the class
+						    brings the rest of frappe's .btn in with it. -#}
+						<a class="btn" href="{{ invite_link }}" style="display: inline-block; padding: 12px 24px; font-size: 14px; color: #ffffff; background-color: #171717; text-decoration: none; border-radius: 8px; border: 0; margin: 0;">Accept Invitation</a>
 						<p style="font-size: 12px; color: #888888; margin: 24px 0 0;">If you didn’t request this, feel free to ignore this email.</p>
 					</td>
 				</tr>

--- a/suite/templates/emails/drive_share.html
+++ b/suite/templates/emails/drive_share.html
@@ -27,7 +27,10 @@
 						{#- No card heading: the wordmark above already says Frappe Drive, and
 						    the message line ("X shared a document with you: …") is the story. -#}
 						<p style="font-size: 15px; line-height: 1.5; color: #171717; max-width: 400px; margin: 0 auto 24px;">{{ message }}</p>
-						<a class="btn" href="{{ link }}" style="display: inline-block; padding: 12px 24px; font-size: 14px; color: #ffffff; background-color: #171717; text-decoration: none; border-radius: 8px;">Open {{ type }}</a>
+						{#- .btn exempts the anchor from frappe's `.email-body a:not(.btn)` restyle, which
+						    premailer keeps as !important. border/margin are re-declared because the class
+						    brings the rest of frappe's .btn in with it. -#}
+						<a class="btn" href="{{ link }}" style="display: inline-block; padding: 12px 24px; font-size: 14px; color: #ffffff; background-color: #171717; text-decoration: none; border-radius: 8px; border: 0; margin: 0;">Open {{ type }}</a>
 						<p style="font-size: 12px; color: #888888; margin: 24px 0 0;">If you didn’t request this, feel free to ignore this email.</p>
 					</td>
 				</tr>

--- a/suite/templates/emails/drive_share.html
+++ b/suite/templates/emails/drive_share.html
@@ -27,7 +27,7 @@
 						{#- No card heading: the wordmark above already says Frappe Drive, and
 						    the message line ("X shared a document with you: …") is the story. -#}
 						<p style="font-size: 15px; line-height: 1.5; color: #171717; max-width: 400px; margin: 0 auto 24px;">{{ message }}</p>
-						<a href="{{ link }}" style="display: inline-block; padding: 12px 24px; font-size: 14px; color: #ffffff; background-color: #171717; text-decoration: none; border-radius: 8px;">Open {{ type }}</a>
+						<a class="btn" href="{{ link }}" style="display: inline-block; padding: 12px 24px; font-size: 14px; color: #ffffff; background-color: #171717; text-decoration: none; border-radius: 8px;">Open {{ type }}</a>
 						<p style="font-size: 12px; color: #888888; margin: 24px 0 0;">If you didn’t request this, feel free to ignore this email.</p>
 					</td>
 				</tr>

--- a/suite/templates/emails/macros.html
+++ b/suite/templates/emails/macros.html
@@ -3,7 +3,10 @@
 	<tbody>
 		<tr>
 			<td class="button {{ 'button-primary' if primary else '' }}">
-				<a href="{{ link }}" rel="nofollow">
+				{# .btn exempts the label from frappe's `.email-body a:not(.btn)` link
+				   restyle, which premailer keeps as !important (it can't inline :not())
+				   and which would bury the button's own color under the link color. #}
+				<a class="btn" href="{{ link }}" rel="nofollow">
 					{{ label }}
 				</a>
 			</td>

--- a/suite/templates/emails/macros.html
+++ b/suite/templates/emails/macros.html
@@ -5,8 +5,11 @@
 			<td class="button {{ 'button-primary' if primary else '' }}">
 				{# .btn exempts the label from frappe's `.email-body a:not(.btn)` link
 				   restyle, which premailer keeps as !important (it can't inline :not())
-				   and which would bury the button's own color under the link color. #}
-				<a class="btn" href="{{ link }}" rel="nofollow">
+				   and which would bury the button's own color under the link color.
+				   The class comes with the rest of frappe's .btn, which premailer inlines
+				   too: border and margin are re-declared here (the style attribute wins,
+				   in place) so the button keeps the geometry .button-primary gives it. #}
+				<a class="btn" href="{{ link }}" rel="nofollow" style="border: 0; margin: 0;">
 					{{ label }}
 				</a>
 			</td>


### PR DESCRIPTION
Follow-ups to #480, plus an infinite-scroll stall.

**Dark-mode remap (`darkMail.ts`)**
- Border/outline colors get their own role: inversion floored at a hairline band (~`#333`), so a `#e5e7eb` divider that read on white still reads on the dark canvas. The floor fades out for near-white spacer borders (authored invisible), which keep tracking pure inversion.
- The surface walk now resolves `<style>`-defined backgrounds (Twilio's classed white card inside a textured wrapper pinned its text authored-dark while the sheet remap turned the card dark). Also covers class-defined hero images.
- Verified against the real Twilio receipt through the full pipeline; 39 unit tests.

**Mail UI**
- Restored the sidebar divider dropped by the slot-API migration (#455) — invisible in dark mode where the sidebar and content surfaces match.
- Infinite scroll's viewport fill now measures progress as the count of threads the rendered rows stand for, not pixel height. A window absorbed into existing stack rows adds no height and read as a collapsed-group dead end, stalling incident-heavy inboxes mid-viewport with no way to re-fire the observer (any browser). Stack absorption now keeps the fill going; the collapsed-group stampede guard still holds. Also: geometric sentinel check (the observer flag is stale at nextTick and chained double fetches) and no more early stop once the list barely scrolls.

**Outbound**
- Button anchors in the email templates now carry `.btn`, the escape hatch of frappe's `.email-body a:not(.btn)` restyle — premailer keeps that rule `!important` (it can't inline `:not()`), which buried the buttons' inlined white-on-dark styles: "Verify Account" rendered near-black on near-black in every light-mode client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
