### PR TITLE
feat(mail): mention organization users inline

### DIFF
--- a/frontend/src/apps/mail/components/ComposeMailEditor.vue
+++ b/frontend/src/apps/mail/components/ComposeMailEditor.vue
@@ -116,6 +116,7 @@
 				>
 					<span class="text-ink-gray-4 text-sm">{{ __('Subject') }}</span>
 					<input
+						ref="subjectInput"
 						v-model="mail.subject"
 						class="flex-1 cursor-text border-none bg-inherit text-base focus-visible:!ring-0"
 					/>
@@ -309,6 +310,7 @@ const { isMobile } = useScreenSize()
 const textEditor = useTemplateRef('textEditor')
 const toInput = useTemplateRef('toInput')
 const ccInput = useTemplateRef('ccInput')
+const subjectInput = useTemplateRef<HTMLInputElement>('subjectInput')
 
 const showContactsModal = ref(false)
 const insertContactsInto = ref('')
@@ -423,10 +425,21 @@ const originalMail = ref<ComposeMailData>()
 const updateOriginalMail = () => (originalMail.value = JSON.parse(JSON.stringify(mail)))
 const isDraftUpdated = computed(() => JSON.stringify(mail) !== JSON.stringify(originalMail.value))
 
+// Start where there is still something to write: the body on a reply (recipients and
+// subject come with the thread), the subject when the draft arrived addressed but
+// unnamed — a `mailto:` link, or a calendar invite's participants — and the To field
+// otherwise. The delay is the dialog's: focusing during its transition doesn't take.
 onMounted(() => {
 	updateOriginalMail()
-	if (!mailDetails?.in_reply_to) setTimeout(() => toInput.value?.setFocus(), 50)
-	else textEditor.value.editor.commands.focus()
+	if (mailDetails?.in_reply_to) return textEditor.value.editor.commands.focus()
+
+	// Deferred, and the choice made from inside: TextEditor renders nothing until it has
+	// built its editor on its own mounted hook, so neither field exists yet at this point.
+	setTimeout(() => {
+		if (!isRecipientsEmpty.value && !mail.subject && subjectInput.value)
+			subjectInput.value.focus()
+		else toInput.value?.setFocus()
+	}, 50)
 })
 
 onUnmounted(() => saveDraft())

--- a/frontend/src/apps/mail/components/ComposeMailEditor.vue
+++ b/frontend/src/apps/mail/components/ComposeMailEditor.vue
@@ -2,14 +2,17 @@
 	<TextEditor
 		ref="textEditor"
 		editor-class="prose-sm max-w-none"
-		:extensions="[CustomImageExtension, CustomParagraphExtension]"
+		:extensions="[CustomImageExtension, CustomParagraphExtension, ...MentionExtensions]"
 		:content="mail.html_body.replaceAll('<div><br></div>', '<div></div>')"
 		:upload-function
 		class="flex flex-col max-sm:overflow-y-auto"
 		:class="{ 'pointer-events-none opacity-50': !show, 'sm:h-[75vh]': !isInThread }"
 		:style="isMobile && { height: editorHeight }"
 		@change="
-			(val: string) => (mail.html_body = val.replaceAll('<div></div>', '<div><br></div>'))
+			(val: string) => {
+				mail.html_body = val.replaceAll('<div></div>', '<div><br></div>')
+				dropUnmentionedRecipients()
+			}
 		"
 		@dragenter.prevent="handleDragEnter"
 		@dragover.prevent="handleDragOver"
@@ -246,6 +249,7 @@ import {
 	createResource,
 	useFileUpload,
 } from 'frappe-ui'
+import { Mention } from 'frappe-ui/editor'
 
 import { getAttachmentUrl } from '@/apps/mail/resources'
 import {
@@ -256,11 +260,13 @@ import {
 	randomString,
 } from '@/apps/mail/utils'
 import { useScreenSize, useVisualViewport } from '@/apps/mail/utils/composables'
+import { createMentionSuggestion } from '@/apps/mail/utils/mentionSuggestion'
 import { CustomParagraphExtension } from '@/apps/mail/utils/text-editor'
 import { injectAccountScope } from '@/apps/mail/utils/accountScope'
 import ComposeMailToolbar from '@/apps/mail/components/ComposeMailToolbar.vue'
 
 import type { Attachment, ComposeMailData, File as FileDoc, Identity, UserResource } from '@/apps/mail/types'
+import type { MentionCandidate } from '@/apps/mail/utils/mentionSuggestion'
 
 import RecipientInput from './Controls/RecipientInput.vue'
 import ContactsModal from './Modals/ContactsModal.vue'
@@ -326,6 +332,59 @@ const appendEmoji = (emoji: string) => {
 const editorHeight = useVisualViewport(
 	(viewport) => `${viewport.height - viewport.offsetTop - 113}px`,
 )
+
+// Mentions
+
+// Picking a mention adds that person to To — reaching back up to the recipient fields
+// is the trip the shortcut exists to save. Only the pick adds, so a mention arriving
+// with pasted or forwarded content doesn't quietly address the mail to anyone.
+//
+// Recipients this composer added that way, and only those: deleting the mention takes
+// them back out again, while someone typed into To by hand and then mentioned stays
+// put — the mention didn't put them there and doesn't get to remove them.
+const mentionedRecipients = new Set<string>()
+
+const addMentionedRecipient = ({ email, display_name, image }: MentionCandidate) => {
+	if ([...mail.to, ...mail.cc, ...mail.bcc].some((r) => r.email === email)) return
+
+	mail.to.push({ email, display_name, image })
+	mentionedRecipients.add(email)
+}
+
+const dropUnmentionedRecipients = () => {
+	const editor = textEditor.value?.editor
+	if (!editor || !mentionedRecipients.size) return
+
+	const mentioned = new Set<string>()
+	editor.state.doc.descendants((node) => {
+		if (node.type.name === 'mention' && node.attrs.id) mentioned.add(node.attrs.id)
+	})
+
+	for (const email of mentionedRecipients) {
+		// Still named somewhere in the body — mentioning someone twice and deleting one
+		// of the two keeps them addressed.
+		if (mentioned.has(email)) continue
+
+		mail.to = mail.to.filter((recipient) => recipient.email !== email)
+		mentionedRecipients.delete(email)
+	}
+}
+
+const MentionExtensions = [
+	// The inline node. Its own `@` suggester stays inert with no item source of its
+	// own — the search below is the one wired up.
+	Mention,
+	createMentionSuggestion({
+		account: () => scopeAccountId.value,
+		onSelect: addMentionedRecipient,
+		// Null in a thread or the mobile sheet, where nothing is holding the rest of
+		// the page inert and the default <body> is fine.
+		container: () =>
+			(textEditor.value?.$el as HTMLElement | undefined)?.closest<HTMLElement>(
+				'[role="dialog"]',
+			) ?? null,
+	}),
+]
 
 // Setup & hooks
 
@@ -461,7 +520,7 @@ const createMail = createResource({
 	makeParams: ({ save_as_draft }: { save_as_draft: boolean }) => ({
 		account: scopeAccountId.value,
 		...mail,
-		...processInlineImages(mail),
+		...processInlineImages(mail, { sending: !save_as_draft }),
 		from_name: getIdentity(mail.from_email!)._name,
 		save_as_draft,
 	}),
@@ -474,7 +533,7 @@ const updateDraft = createResource({
 	makeParams: ({ submit }: { submit: boolean }) => ({
 		account: scopeAccountId.value,
 		...mail,
-		...processInlineImages(mail),
+		...processInlineImages(mail, { sending: submit }),
 		from_name: getIdentity(mail.from_email!)._name,
 		submit,
 	}),

--- a/frontend/src/apps/mail/components/ContactCombobox.vue
+++ b/frontend/src/apps/mail/components/ContactCombobox.vue
@@ -9,11 +9,10 @@
 		@update:query="search"
 	>
 		<template #item-prefix="{ item, query }">
-			<Avatar :image="item.image" :label="item.label || query" size="sm" />
+			<Avatar :image="item.image" :label="item.label || query" size="lg" />
 		</template>
 		<template #item-label="{ item }">
-			<div class="truncate">{{ item.display_name || item.email }}</div>
-			<div v-if="item.display_name" class="text-ink-gray-5 truncate text-xs">{{ item.email }}</div>
+			<ContactOption :contact="item" />
 		</template>
 		<template #item-create="{ query }"> {{ query }} </template>
 	</Combobox>
@@ -24,6 +23,7 @@ import { computed, ref, watch } from 'vue'
 import { useDebounceFn } from '@vueuse/core'
 import { Avatar, Combobox, createResource } from 'frappe-ui'
 
+import ContactOption from '@/apps/mail/components/Controls/ContactOption.vue'
 import { userStore } from '@/apps/mail/stores/user'
 
 // Self-contained contact-autocomplete combobox: searches contacts as you type (Avatar + name over email)

--- a/frontend/src/apps/mail/components/Controls/ContactOption.vue
+++ b/frontend/src/apps/mail/components/Controls/ContactOption.vue
@@ -1,0 +1,18 @@
+<template>
+	<div class="min-w-0">
+		<div class="text-ink-gray-8 truncate">{{ contact.display_name || contact.email }}</div>
+		<!-- Only worth a second line when the first one isn't already the address. -->
+		<div v-if="contact.display_name" class="text-ink-gray-5 truncate text-xs">
+			{{ contact.email }}
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import type { DraftRecipient } from '@/apps/mail/types'
+
+// How a contact reads in any of the pickers — recipient autocomplete, the contacts
+// combobox, `@` mentions. The address is the disambiguator between two people with
+// the same name, so it stays visible under the name rather than replacing it.
+defineProps<{ contact: DraftRecipient }>()
+</script>

--- a/frontend/src/apps/mail/components/Controls/MentionList.vue
+++ b/frontend/src/apps/mail/components/Controls/MentionList.vue
@@ -1,0 +1,86 @@
+<template>
+	<!-- Bare root: the popup is positioned around whatever this renders, so an empty
+	     query (or a search that came back with nothing) must render nothing at all
+	     rather than an empty panel hanging off the caret. -->
+	<div>
+		<div
+			v-if="items.length"
+			class="bg-surface-base max-h-64 min-w-56 overflow-y-auto rounded-lg p-1 shadow-lg"
+		>
+			<!-- Picks on mousedown, default prevented: letting the press land would pull
+			     focus out of the editor, and the suggester drops the popup the moment the
+			     selection leaves the `@` it is tracking — so the row is gone before any
+			     click can arrive. -->
+			<ItemListRow
+				v-for="(item, index) in items"
+				:key="item.email"
+				:ref="(el) => setItemRef(el, index)"
+				as="button"
+				class="text-left"
+				:selected="index === selectedIndex"
+				@mousedown.prevent="selectItem(index)"
+				@mouseover="selectedIndex = index"
+			>
+				<template #prefix>
+					<Avatar :image="item.image" :label="item.display_name || item.email" size="lg" />
+				</template>
+				<template #label>
+					<ContactOption :contact="item" />
+				</template>
+			</ItemListRow>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { nextTick, onBeforeUpdate, ref, watch, type ComponentPublicInstance } from 'vue'
+import { Avatar, ItemListRow } from 'frappe-ui'
+
+import ContactOption from '@/apps/mail/components/Controls/ContactOption.vue'
+
+import type { MentionCandidate } from '@/apps/mail/utils/mentionSuggestion'
+
+// The suggestion renderer drives this list by keyboard through the exposed handler —
+// the caret stays in the editor, so the list never holds focus itself.
+const props = defineProps<{
+	items: MentionCandidate[]
+	command: (item: MentionCandidate) => void
+}>()
+
+const selectedIndex = ref(0)
+const itemRefs = ref<(HTMLElement | null)[]>([])
+
+onBeforeUpdate(() => (itemRefs.value = []))
+
+// The rows are components, so what comes back is an instance — scrolling wants its
+// element.
+const setItemRef = (el: Element | ComponentPublicInstance | null, index: number) =>
+	(itemRefs.value[index] = ((el as ComponentPublicInstance)?.$el ?? el) as HTMLElement | null)
+
+const selectItem = (index: number) => {
+	const item = props.items[index]
+	if (item) props.command(item)
+}
+
+const move = (by: number) => {
+	const count = props.items.length
+	selectedIndex.value = (selectedIndex.value + by + count) % count
+	nextTick(() => itemRefs.value[selectedIndex.value]?.scrollIntoView({ block: 'nearest' }))
+}
+
+const onKeyDown = ({ event }: { event: KeyboardEvent }) => {
+	if (!props.items.length) return false
+
+	if (event.key === 'ArrowUp') return move(-1), true
+	if (event.key === 'ArrowDown') return move(1), true
+	if (event.key === 'Enter') return selectItem(selectedIndex.value), true
+
+	return false
+}
+
+// A fresh result set is a fresh list: keeping the old index would arm Enter on
+// whichever row happened to land in that slot.
+watch(() => props.items, () => (selectedIndex.value = 0))
+
+defineExpose({ onKeyDown })
+</script>

--- a/frontend/src/apps/mail/components/Controls/RecipientInput.vue
+++ b/frontend/src/apps/mail/components/Controls/RecipientInput.vue
@@ -55,11 +55,14 @@
 		>
 			<template #suffix> <span /> </template>
 			<template #item-prefix="{ item, query }">
-				<Avatar :image="item.image" :label="item.display_name || item.email || query" />
+				<Avatar
+					:image="item.image"
+					:label="item.display_name || item.email || query"
+					size="lg"
+				/>
 			</template>
 			<template #item-label="{ item }">
-				<div class="truncate">{{ item.display_name || item.email }}</div>
-				<div class="text-p-sm text-ink-gray-5 truncate">{{ item.email }}</div>
+				<ContactOption :contact="item" />
 			</template>
 			<template #item-create="{ query }"> {{ query }} </template>
 		</Combobox>
@@ -76,6 +79,7 @@ import { onClickOutside, useDebounceFn } from '@vueuse/core'
 import { X } from 'lucide-vue-next'
 import { Avatar, Combobox, createResource } from 'frappe-ui'
 
+import ContactOption from '@/apps/mail/components/Controls/ContactOption.vue'
 import { type DraftRecipient } from '@/apps/mail/types'
 import { isEmail } from '@/apps/mail/utils'
 import { useScreenSize } from '@/apps/mail/utils/composables'

--- a/frontend/src/apps/mail/components/DefaultLayout.vue
+++ b/frontend/src/apps/mail/components/DefaultLayout.vue
@@ -43,7 +43,7 @@ import { useRoute, useRouter } from 'vue-router'
 import dayjs from '@/apps/calendar/utils/dayjs'
 import EventDetailSidebar from '@/apps/calendar/components/EventDetailSidebar.vue'
 import { eventDayRoute, useUpcomingEvents } from '@/apps/mail/composables/useUpcomingEvents'
-import { useScreenSize } from '@/apps/mail/utils/composables'
+import { useComposeMail, useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import AppSidebar from '@/apps/mail/components/AppSidebar.vue'
 import MobileTabBar from '@/apps/mail/components/mobile/MobileTabBar.vue'
@@ -79,11 +79,25 @@ const showCompose = ref(false)
 const composeKey = ref(0)
 const composeDetails = ref<ComposeMailData>()
 
-const emailParticipants = (emails: string[]) => {
-	composeDetails.value = { to: emails.map((email) => ({ email })) }
+const openCompose = (details: ComposeMailData) => {
+	composeDetails.value = details
+	// Remount, so a second request replaces the draft on screen instead of being
+	// swallowed by the composer already holding one.
 	composeKey.value++
 	showCompose.value = true
 }
+
+const emailParticipants = (emails: string[]) =>
+	openCompose({ to: emails.map((email) => ({ email })) })
+
+// A `mailto:` link clicked inside a message. It comes through shared state because the
+// message body is an iframe — several components deep, and across a document boundary.
+const { composeRequest, clearComposeRequest } = useComposeMail()
+watch(composeRequest, (details) => {
+	if (!details) return
+	openCompose(details)
+	clearComposeRequest()
+})
 
 // Compose deep link (?compose=1&to=a,b): how other apps (calendar's "email
 // participants") open mail's compose window. Consumed on arrival — the query

--- a/frontend/src/apps/mail/components/EmailContent.vue
+++ b/frontend/src/apps/mail/components/EmailContent.vue
@@ -47,7 +47,8 @@ import { ImageOff } from 'lucide-vue-next'
 import { Button } from 'frappe-ui'
 
 import { analyzeRemoteAssets, blockRemoteAssets } from '@/apps/mail/utils'
-import { useTheme } from '@/apps/mail/utils/composables'
+import { useComposeMail, useTheme } from '@/apps/mail/utils/composables'
+import { parseMailto } from '@/apps/mail/utils/mailto'
 import { isArtDirected, normalizeToLightScheme, remapEmailForDarkMode } from '@/apps/mail/utils/darkMail'
 
 const {
@@ -58,6 +59,7 @@ const {
 const emit = defineEmits<{ trust: [] }>()
 
 const { dataTheme } = useTheme()
+const { requestCompose } = useComposeMail()
 
 const isIframeReady = ref(false)
 
@@ -94,6 +96,12 @@ const handleMessage = (event: MessageEvent) => {
 	// swipe navigation (MailboxView listens; it dedupes across EmailContent instances).
 	if (event.data?.type === 'swipe') {
 		window.dispatchEvent(new CustomEvent('email-swipe', { detail: event.data.direction }))
+		return
+	}
+	// A `mailto:` the reader clicked inside the message — open our own composer on it.
+	if (event.data?.type === 'mailto') {
+		const draft = parseMailto(String(event.data.href ?? ''))
+		if (draft) requestCompose(draft)
 		return
 	}
 	if (event.data?.type !== 'keyboard') return
@@ -282,9 +290,15 @@ const srcdoc = computed(() => {
 					const anchor = e.target.closest('a');
 					if (anchor) {
 						e.preventDefault();
-						if (anchor.getAttribute('href')?.trim()) {
-							window.open(anchor.href, '_blank');
+						const href = anchor.getAttribute('href')?.trim();
+						if (!href) return;
+						// A mailto belongs to this app: opening it would hand the OS's default
+						// mail client a draft the user has to finish somewhere else.
+						if (/^mailto:/i.test(href)) {
+							window.parent.postMessage({ type: 'mailto', href: anchor.href }, '*');
+							return;
 						}
+						window.open(anchor.href, '_blank');
 					}
 				});
 

--- a/frontend/src/apps/mail/components/EmailContent.vue
+++ b/frontend/src/apps/mail/components/EmailContent.vue
@@ -26,6 +26,7 @@
 		/>
 	</div>
 	<IframeResizer
+		ref="frame"
 		v-show="isIframeReady"
 		class="w-full"
 		license="GPLv3"
@@ -36,7 +37,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref, useTemplateRef } from 'vue'
 import iframeResizerChildScript from '@iframe-resizer/child/index.umd.js?raw'
 // The package maps `./sfc` only via its (non-honored) `browser` field under
 // Vite 8/Rolldown, so import the concrete SFC file directly.
@@ -60,6 +61,7 @@ const emit = defineEmits<{ trust: [] }>()
 
 const { dataTheme } = useTheme()
 const { requestCompose } = useComposeMail()
+const frame = useTemplateRef<{ $el: HTMLIFrameElement }>('frame')
 
 const isIframeReady = ref(false)
 
@@ -99,7 +101,13 @@ const handleMessage = (event: MessageEvent) => {
 		return
 	}
 	// A `mailto:` the reader clicked inside the message — open our own composer on it.
+	// Only this message's own frame gets to do that: `window` hears every window that
+	// can reach us (an attachment rendered in a frame, an embedder), and this one puts
+	// a stranger's address and body in front of the user as a ready-to-send draft.
 	if (event.data?.type === 'mailto') {
+		if (event.source !== (frame.value?.$el as HTMLIFrameElement | undefined)?.contentWindow)
+			return
+
 		const draft = parseMailto(String(event.data.href ?? ''))
 		if (draft) requestCompose(draft)
 		return

--- a/frontend/src/apps/mail/components/SendMailMobileLayout.vue
+++ b/frontend/src/apps/mail/components/SendMailMobileLayout.vue
@@ -3,35 +3,42 @@
 	     Stays mounted and slides via transform so dismissal animates too; visibility
 	     flips after the slide-out, keeping the closed sheet out of the focus order.
 	     z-30: above the thread's reply bar (z-20), which stays mounted underneath
-	     and is revealed as the sheet slides out. -->
-	<div
-		class="bg-surface-base fixed inset-0 z-30 flex flex-col pt-[env(safe-area-inset-top)] transition-[transform,visibility] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
-		:class="{ 'invisible translate-y-full': !show || !painted }"
-	>
-		<div class="sticky top-0 flex items-center border-b px-3 py-2.5">
-			<Button variant="ghost" class="mr-2" @click="close">
-				<template #icon>
-					<X class="text-ink-gray-5 h-4 w-4" />
-				</template>
-			</Button>
-			<h2 class="flex-1">{{ __('Compose Mail') }}</h2>
-			<!-- AdaptiveDropdown (bottom sheet, z-50): a plain Dropdown's popup portals
-			     to body with no z-index, so this sheet would paint over it. -->
-			<AdaptiveDropdown :options="ACTIONS">
-				<Button variant="ghost" class="mr-2">
+	     and is revealed as the sheet slides out.
+
+	     Teleported to body, like the thread pane: the layout's isolate paints its
+	     whole subtree as one unit in the root stacking context, so a sheet opened
+	     from inside a thread (a `mailto:` link in the message) lost to the pane —
+	     which teleports out for the same reason — however high its own z went. -->
+	<Teleport to="body">
+		<div
+			class="bg-surface-base fixed inset-0 z-30 flex flex-col pt-[env(safe-area-inset-top)] transition-[transform,visibility] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
+			:class="{ 'invisible translate-y-full': !show || !painted }"
+		>
+			<div class="sticky top-0 flex items-center border-b px-3 py-2.5">
+				<Button variant="ghost" class="mr-2" @click="close">
 					<template #icon>
-						<EllipsisVertical class="text-ink-gray-5 h-4 w-4" />
+						<X class="text-ink-gray-5 h-4 w-4" />
 					</template>
 				</Button>
-			</AdaptiveDropdown>
-			<Button variant="ghost" @click="emit('sendMail')">
-				<template #icon>
-					<SendHorizontal class="text-ink-gray-5 h-4 w-4" />
-				</template>
-			</Button>
+				<h2 class="flex-1">{{ __('Compose Mail') }}</h2>
+				<!-- AdaptiveDropdown (bottom sheet, z-50): a plain Dropdown's popup portals
+				     to body with no z-index, so this sheet would paint over it. -->
+				<AdaptiveDropdown :options="ACTIONS">
+					<Button variant="ghost" class="mr-2">
+						<template #icon>
+							<EllipsisVertical class="text-ink-gray-5 h-4 w-4" />
+						</template>
+					</Button>
+				</AdaptiveDropdown>
+				<Button variant="ghost" @click="emit('sendMail')">
+					<template #icon>
+						<SendHorizontal class="text-ink-gray-5 h-4 w-4" />
+					</template>
+				</Button>
+			</div>
+			<slot name="body-content" />
 		</div>
-		<slot name="body-content" />
-	</div>
+	</Teleport>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/apps/mail/pages/dashboard/UsersView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/UsersView.vue
@@ -45,10 +45,11 @@
 						<template v-if="column.key === 'user'">
 							<div class="flex items-center space-x-2">
 								<Avatar :image="row.user_image" :label="row.full_name" size="lg" />
-								<div class="text-sm">
-									<p class="font-medium">{{ row.full_name }}</p>
-									<p class="text-ink-gray-5 mt-0.5">{{ row.name }}</p>
-								</div>
+								<!-- A member row is a contact row: the User's docname is the address. -->
+								<ContactOption
+									:contact="{ email: row.name, display_name: row.full_name }"
+									class="text-sm"
+								/>
 							</div>
 						</template>
 						<template v-else-if="column.key === 'role'">
@@ -126,6 +127,7 @@ import {
 
 import { raiseToast } from '@/apps/mail/utils'
 import { fromNow } from '@/apps/mail/utils/datetime'
+import ContactOption from '@/apps/mail/components/Controls/ContactOption.vue'
 import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 
 type MemberRow = {

--- a/frontend/src/apps/mail/utils/composables.ts
+++ b/frontend/src/apps/mail/utils/composables.ts
@@ -5,7 +5,7 @@ import { createResource, toast } from 'frappe-ui'
 import { matchesScreenedValue, raiseOptimisticToast, raiseToast } from '@/apps/mail/utils'
 import { userStore } from '@/apps/mail/stores/user'
 
-import type { COLOR_SCHEME, Identity, ScreenedAddress } from '@/apps/mail/types'
+import type { COLOR_SCHEME, ComposeMailData, Identity, ScreenedAddress } from '@/apps/mail/types'
 
 // Decided once, at load, and deliberately not reactive to resize. Mobile and desktop are
 // separate component trees here, not one tree restyled: crossing 640px mid-session swaps
@@ -218,6 +218,17 @@ export const useUndo = () => {
 
 	return { setUndoAction, undo, prependUndoAction }
 }
+
+// Shared state for the compose window. A single <SendMail> (rendered in DefaultLayout) reacts to
+// this, so anything deeper in the tree — a `mailto:` link clicked inside a message, which is served
+// from an iframe and can't reach it by props — can ask for a draft.
+const composeRequest = ref<ComposeMailData>()
+
+export const useComposeMail = () => ({
+	composeRequest,
+	requestCompose: (details: ComposeMailData) => (composeRequest.value = details),
+	clearComposeRequest: () => (composeRequest.value = undefined),
+})
 
 // Shared state for the "Block sender?" prompt shown after marking/moving mail to Junk. A single
 // <ScreenedEmailAddressModal> (rendered in MailboxView) reacts to this, so any view can open it.

--- a/frontend/src/apps/mail/utils/index.ts
+++ b/frontend/src/apps/mail/utils/index.ts
@@ -4,6 +4,7 @@ import { toast } from 'frappe-ui'
 
 import { FOLDER_ICON_MAP, SCREENER_MAILBOX_NAME } from '@/apps/mail/constants'
 import dayjs from '@/apps/mail/utils/dayjs'
+import { flattenMentions } from '@/apps/mail/utils/mentions'
 import AudioIcon from '@/apps/mail/components/Icons/AudioIcon.vue'
 import ImageIcon from '@/apps/mail/components/Icons/ImageIcon.vue'
 import PDFIcon from '@/apps/mail/components/Icons/PDFIcon.vue'
@@ -351,9 +352,13 @@ export const randomString = (length: number) => {
 	return result
 }
 
-export const processInlineImages = (mail: ComposeMailData) => {
+// `sending`: mentions are flattened to plain links only on the way out. A draft keeps
+// the editor's own mention nodes, so reopening one still shows the chips.
+export const processInlineImages = (mail: ComposeMailData, { sending = false } = {}) => {
 	const htmlBody = mail.html_body! + mail.quoted_content
 	const $ = cheerio.load(htmlBody)
+
+	if (sending) flattenMentions($)
 
 	const regularAttachments = mail.attachments?.filter((a) => a.disposition !== 'inline') || []
 	const inlineAttachments = mail.attachments?.filter((a) => a.disposition === 'inline') || []

--- a/frontend/src/apps/mail/utils/mailto.test.ts
+++ b/frontend/src/apps/mail/utils/mailto.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseMailto } from './mailto'
+
+describe('parseMailto', () => {
+	it('reads the address out of a bare link', () => {
+		expect(parseMailto('mailto:sagar@example.com')).toMatchObject({
+			to: [{ email: 'sagar@example.com' }],
+			cc: [],
+			bcc: [],
+		})
+	})
+
+	it('ignores anything that is not a mailto link', () => {
+		expect(parseMailto('https://example.com')).toBeNull()
+		expect(parseMailto('')).toBeNull()
+	})
+
+	it('takes every recipient, from the path and the headers', () => {
+		const draft = parseMailto('mailto:a@x.com,b@x.com?to=c@x.com&cc=d@x.com&bcc=e@x.com')
+
+		expect(draft?.to).toEqual([{ email: 'a@x.com' }, { email: 'b@x.com' }, { email: 'c@x.com' }])
+		expect(draft?.cc).toEqual([{ email: 'd@x.com' }])
+		expect(draft?.bcc).toEqual([{ email: 'e@x.com' }])
+	})
+
+	it('leaves a plus-addressed recipient intact', () => {
+		// The trap here is URLSearchParams, which would read the `+` as a space.
+		expect(parseMailto('mailto:user+tag@example.com')?.to).toEqual([
+			{ email: 'user+tag@example.com' },
+		])
+		expect(parseMailto('mailto:?to=user%2Btag@example.com')?.to).toEqual([
+			{ email: 'user+tag@example.com' },
+		])
+	})
+
+	it('carries subject and body', () => {
+		const draft = parseMailto('mailto:a@x.com?subject=Hello%20there&body=Line%20one%0ALine%20two')
+
+		expect(draft?.subject).toBe('Hello there')
+		expect(draft?.html_body).toBe('<div>Line one</div><div>Line two</div>')
+	})
+
+	it('keeps a blank line in the body', () => {
+		expect(parseMailto('mailto:a@x.com?body=one%0A%0Atwo')?.html_body).toBe(
+			'<div>one</div><div><br></div><div>two</div>',
+		)
+	})
+
+	it('escapes markup in the body rather than injecting it into the draft', () => {
+		expect(parseMailto('mailto:a@x.com?body=%3Cimg%20src%3Dx%20onerror%3Dalert(1)%3E')?.html_body)
+			.toBe('<div>&lt;img src=x onerror=alert(1)&gt;</div>')
+	})
+
+	it('lets the first of a repeated header win', () => {
+		expect(parseMailto('mailto:?to=a@x.com&to=b@x.com')?.to).toEqual([{ email: 'a@x.com' }])
+	})
+
+	it('survives a malformed escape', () => {
+		expect(parseMailto('mailto:a@x.com?subject=100%')?.subject).toBe('100%')
+	})
+
+	it('opens an empty draft for a link with no address', () => {
+		expect(parseMailto('mailto:')).toMatchObject({ to: [], cc: [], bcc: [] })
+	})
+})

--- a/frontend/src/apps/mail/utils/mailto.ts
+++ b/frontend/src/apps/mail/utils/mailto.ts
@@ -1,0 +1,64 @@
+import type { ComposeMailData, DraftRecipient } from '@/apps/mail/types'
+
+// RFC 6068 `mailto:` links, turned into a draft. Clicking one in a message should open
+// this app's composer, not hand the OS's default mail client a half-written mail.
+//
+// Percent-decoding is done per field rather than through URLSearchParams: that treats
+// `+` as a space, which would quietly break plus-addressed recipients (`user+tag@…`),
+// and splits are done before decoding so an encoded comma stays inside its address.
+
+const decode = (value: string) => {
+	try {
+		return decodeURIComponent(value)
+	} catch {
+		// A malformed escape is worth showing literally rather than dropping the field.
+		return value
+	}
+}
+
+const recipients = (list: string | undefined): DraftRecipient[] =>
+	(list ?? '')
+		.split(',')
+		.map((address) => decode(address).trim())
+		.filter(Boolean)
+		.map((email) => ({ email }))
+
+const escapeHtml = (text: string) =>
+	text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+// The body arrives as plain text; the editor speaks divs (see CustomParagraphExtension),
+// and an empty line needs the <br> to survive the round trip.
+const toHtml = (text: string) =>
+	text
+		.split(/\r?\n/)
+		.map((line) => `<div>${escapeHtml(line) || '<br>'}</div>`)
+		.join('')
+
+export const parseMailto = (href: string): ComposeMailData | null => {
+	if (!/^mailto:/i.test(href)) return null
+
+	const target = href.slice('mailto:'.length)
+	const separator = target.indexOf('?')
+	const addresses = separator < 0 ? target : target.slice(0, separator)
+
+	// First occurrence of a header wins, so a link can't quietly append a second
+	// recipient list behind the one the user can see.
+	const headers = new Map<string, string>()
+	for (const pair of (separator < 0 ? '' : target.slice(separator + 1)).split('&')) {
+		if (!pair) continue
+		const equals = pair.indexOf('=')
+		const key = decode(equals < 0 ? pair : pair.slice(0, equals)).toLowerCase()
+		if (!headers.has(key)) headers.set(key, equals < 0 ? '' : decode(pair.slice(equals + 1)))
+	}
+
+	const subject = headers.get('subject')
+	const body = headers.get('body')
+
+	return {
+		to: [...recipients(addresses), ...recipients(headers.get('to'))],
+		cc: recipients(headers.get('cc')),
+		bcc: recipients(headers.get('bcc')),
+		...(subject ? { subject } : {}),
+		...(body ? { html_body: toHtml(body) } : {}),
+	}
+}

--- a/frontend/src/apps/mail/utils/mentionSuggestion.ts
+++ b/frontend/src/apps/mail/utils/mentionSuggestion.ts
@@ -1,0 +1,105 @@
+import { PluginKey } from '@tiptap/pm/state'
+import { call, createSuggestionExtension } from 'frappe-ui'
+import type { BaseSuggestionItem } from 'frappe-ui'
+
+import MentionList from '@/apps/mail/components/Controls/MentionList.vue'
+
+// Same shape as a draft recipient, so a picked mention can be added to To as-is.
+export interface MentionCandidate extends BaseSuggestionItem {
+	email: string
+	display_name?: string
+	image?: string
+}
+
+type EmailSuggestion = { email: string; name?: string | null; user_image?: string }
+
+const SEARCH_DEBOUNCE = 200
+
+// `@` searches the same index the To field's autocomplete does — the account's cached
+// message addresses first, then contacts, then the server — rather than the site's user
+// list, which on most installs is a handful of people who are not who you write to.
+const createContactSearch = (account: () => string) => {
+	let pending: ReturnType<typeof setTimeout> | undefined
+	let latest = 0
+
+	// The suggester asks on every keystroke and each ask is a round trip, so the search
+	// is debounced. Only the newest query is allowed to resolve: an earlier answer
+	// arriving late would repaint the list under a query the user has already moved past.
+	return (text: string) =>
+		new Promise<MentionCandidate[]>((resolve) => {
+			if (pending) clearTimeout(pending)
+			if (!text) return resolve([])
+
+			const query = ++latest
+			pending = setTimeout(async () => {
+				let suggestions: EmailSuggestion[] = []
+				try {
+					suggestions = await call('suite.mail.api.mail.get_email_suggestions', {
+						account: account(),
+						text,
+					})
+				} catch {
+					// A failed search is an empty dropdown, not a broken composer.
+				}
+
+				if (query !== latest) return
+				resolve(
+					suggestions.map((suggestion) => ({
+						email: suggestion.email,
+						display_name: suggestion.name || undefined,
+						image: suggestion.user_image,
+					})),
+				)
+			}, SEARCH_DEBOUNCE)
+		})
+}
+
+// The `@` suggester. Pairs with frappe-ui's Mention extension, which contributes the
+// inline node this inserts (and stays inert on its own, having no item source).
+export const createMentionSuggestion = ({
+	account,
+	onSelect,
+	container,
+}: {
+	account: () => string
+	onSelect: (contact: MentionCandidate) => void
+	container?: () => HTMLElement | null
+}) => {
+	const search = createContactSearch(account)
+
+	return createSuggestionExtension<MentionCandidate>({
+		name: 'mailMentionSuggestion',
+		char: '@',
+		pluginKey: new PluginKey('mailMentionSuggestion'),
+		component: MentionList,
+		items: ({ query }) => search(query),
+		command: ({ editor, range, props }) => {
+			editor
+				.chain()
+				.focus()
+				.insertContentAt(range, [
+					{
+						type: 'mention',
+						attrs: { id: props.email, label: props.display_name || props.email },
+					},
+					{ type: 'text', text: ' ' },
+				])
+				.run()
+
+			onSelect(props)
+		},
+		allowSpaces: false,
+		decorationTag: 'span',
+		decorationClass: 'mention-suggestion-active',
+		tippyOptions: {
+			placement: 'bottom-start',
+			offset: [0, 8],
+			// The popup defaults into <body>, which is where a modal composer's dialog
+			// parks `pointer-events: none` on everything but itself: the list renders and
+			// highlights on hover, but the press lands on the layer underneath, moves the
+			// selection off the `@`, and the suggester tears the list down. Rendering it
+			// inside the dialog keeps it in the interactive layer.
+			appendTo: () => container?.() ?? document.body,
+		},
+	})
+}

--- a/frontend/src/apps/mail/utils/mentions.test.ts
+++ b/frontend/src/apps/mail/utils/mentions.test.ts
@@ -1,0 +1,52 @@
+import * as cheerio from 'cheerio'
+import { describe, expect, it } from 'vitest'
+
+import { flattenMentions } from './mentions'
+
+const flatten = (html: string) => {
+	const $ = cheerio.load(html)
+	flattenMentions($)
+	return $('body').html() ?? ''
+}
+
+describe('flattenMentions', () => {
+	it('sends a mention as a mailto link over its own text', () => {
+		const html = flatten(
+			'<p>hi <span class="mention" data-type="mention" data-id="s-aga-r@example.com" data-label="Sagar Sharma">@Sagar Sharma</span></p>',
+		)
+
+		expect(html).toContain('<a href="mailto:s-aga-r@example.com">@Sagar Sharma</a>')
+		// None of the editor's internal markup survives — the recipient's client has
+		// neither the class nor the node.
+		expect(html).not.toContain('data-type="mention"')
+		expect(html).not.toContain('class="mention"')
+	})
+
+	it('keeps the label escaped', () => {
+		const html = flatten(
+			'<p><span class="mention" data-type="mention" data-id="a@b.com" data-label="A &amp; B">@A &amp; B</span></p>',
+		)
+
+		expect(html).toContain('<a href="mailto:a@b.com">@A &amp; B</a>')
+	})
+
+	it('falls back to the label when the node carries no text', () => {
+		const html = flatten(
+			'<p><span class="mention" data-type="mention" data-id="a@b.com" data-label="A B"></span></p>',
+		)
+
+		expect(html).toContain('<a href="mailto:a@b.com">@A B</a>')
+	})
+
+	it('leaves a mention without an address alone', () => {
+		const html = flatten('<p><span class="mention" data-type="mention">@nobody</span></p>')
+
+		expect(html).toContain('<span class="mention" data-type="mention">@nobody</span>')
+	})
+
+	it('leaves the rest of the body untouched', () => {
+		const html = flatten('<p>plain <a href="https://example.com">link</a> &amp; text</p>')
+
+		expect(html).toBe('<p>plain <a href="https://example.com">link</a> &amp; text</p>')
+	})
+})

--- a/frontend/src/apps/mail/utils/mentions.ts
+++ b/frontend/src/apps/mail/utils/mentions.ts
@@ -1,0 +1,19 @@
+import * as cheerio from 'cheerio'
+
+// The editor's mention nodes are internal markup: a `<span class="mention">` styled by
+// our own stylesheet, which no recipient's client has. Send them as mailto links over
+// the same `@Name` text, so a mention still reads as the person it names — and resolves
+// to them — wherever the mail lands.
+export const flattenMentions = ($: cheerio.CheerioAPI) => {
+	$('span[data-type="mention"]').each((_, span) => {
+		const $mention = $(span)
+		const email = $mention.attr('data-id')
+		if (!email) return
+
+		$mention.replaceWith(
+			$('<a></a>')
+				.attr('href', `mailto:${email}`)
+				.text($mention.text() || `@${$mention.attr('data-label') || email}`),
+		)
+	})
+}


### PR DESCRIPTION
Closes #59.

`@` in the composer searches the same recipient index the To field autocompletes against. Picking someone adds them to To; deleting the mention takes them back out. Mentions go out as `mailto:` links — the mention span means nothing in a recipient's client — while drafts keep the chips.

Clicking a `mailto:` link in a message now opens this composer instead of the OS mail client, parsed per RFC 6068. A draft that arrives addressed but unnamed opens focused on the subject.

Also folds three drifted copies of the contact row (avatar + name over email) into one, shared by the recipient autocomplete, contacts combobox, mention list and members table.

15 unit tests.