### PR TITLE
fix(mail): keep bracketed addresses out of the HTML parser

### DIFF
--- a/frontend/src/apps/mail/components/EmailContent.vue
+++ b/frontend/src/apps/mail/components/EmailContent.vue
@@ -48,6 +48,7 @@ import { ImageOff } from 'lucide-vue-next'
 import { Button } from 'frappe-ui'
 
 import { analyzeRemoteAssets, blockRemoteAssets } from '@/apps/mail/utils'
+import { escapeBracketedAddresses } from '@/apps/mail/utils/html'
 import { useComposeMail, useTheme } from '@/apps/mail/utils/composables'
 import { parseMailto } from '@/apps/mail/utils/mailto'
 import { isArtDirected, normalizeToLightScheme, remapEmailForDarkMode } from '@/apps/mail/utils/darkMail'
@@ -151,7 +152,7 @@ const collapseQuotes = (doc: Document) => {
 }
 
 const srcdoc = computed(() => {
-	let sanitized = DOMPurify.sanitize(content, DOMPURIFY_CONFIG)
+	let sanitized = DOMPurify.sanitize(escapeBracketedAddresses(content), DOMPURIFY_CONFIG)
 	if (effectiveBlock.value) sanitized = blockRemoteAssets(sanitized)
 	const doc = new DOMParser().parseFromString(sanitized, 'text/html')
 	// Art-directed emails — the author claimed the full canvas and painted with
@@ -168,10 +169,7 @@ const srcdoc = computed(() => {
 	const remapped = dataTheme.value === 'dark' && !isArtDirected(doc)
 	if (remapped) remapEmailForDarkMode(doc)
 	collapseQuotes(doc)
-	const transformedContent = doc.documentElement.outerHTML.replace(
-		/<([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>/g,
-		'<b>&lt;$1&gt;</b>',
-	)
+	const transformedContent = doc.documentElement.outerHTML
 
 	/* eslint-disable no-useless-escape */
 	return `

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -422,6 +422,7 @@ import { Alert, Avatar, Badge, Button, Tooltip, createResource } from 'frappe-ui
 import { getAttachmentsZipUrl } from '@/apps/mail/resources'
 import {
 	downloadUrlAsFile,
+	escapeHtml,
 	extractQuotedContent,
 	getFormattedDate,
 	getFormattedRecipients,
@@ -1100,9 +1101,14 @@ const getReplyAllRecipients = (mail: Mail) => {
 const isUserEmail = (email: string) =>
 	identities.value.data?.map((i: Identity) => i.email).includes(email)
 
+// A body with no markup is plain text, so it has to be escaped before going into the
+// <pre> — the reader parses this as HTML. Bounce notices are the case that bites:
+// their `RCPT TO:<user@host>` reads as an unknown tag, which the sanitizer then drops,
+// silently deleting the very addresses the notice is about.
 const getBodyContent = (mail: Mail) => {
 	if (hasHtmlContent(mail.html_body)) return mail.html_body
-	return `<pre style="white-space: pre-wrap; word-break: break-word">${mail.html_body || mail.text_body || '&nbsp;'}</pre>`
+	const text = mail.html_body || mail.text_body
+	return `<pre style="white-space: pre-wrap; word-break: break-word">${text ? escapeHtml(text) : '&nbsp;'}</pre>`
 }
 
 const getQuotedContent = (mail: Mail) =>

--- a/frontend/src/apps/mail/utils/bounceBody.test.ts
+++ b/frontend/src/apps/mail/utils/bounceBody.test.ts
@@ -39,6 +39,19 @@ describe('addresses in angle brackets', () => {
 		expect(hasHtmlContent(BOUNCE)).toBe(true)
 	})
 
+	// Recipients a stricter address grammar would have kept deleting: a local MTA's
+	// dotless host, an address literal, a domain that is not ASCII.
+	it.each([
+		['user@localhost', 'a dotless host'],
+		['user@[192.168.1.1]', 'an address literal'],
+		['user@例え.jp', 'an internationalized domain'],
+		["odd'name+tag@sub.example.co.uk", 'a local part with punctuation'],
+	])('survive for %s (%s)', (address) => {
+		const sanitized = DOMPurify.sanitize(escapeBracketedAddresses(`<div>To <${address}></div>`))
+
+		expect(sanitized).toContain(address)
+	})
+
 	it('leave real markup alone', () => {
 		const html = '<a href="mailto:x@y.com" title="Mail x@y.com">Write</a>'
 

--- a/frontend/src/apps/mail/utils/bounceBody.test.ts
+++ b/frontend/src/apps/mail/utils/bounceBody.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import DOMPurify from 'dompurify'
+
+import { escapeBracketedAddresses, escapeHtml, hasHtmlContent } from '@/apps/mail/utils/html'
+
+// A real MAILER-DAEMON bounce: no markup, addresses in angle brackets.
+const BOUNCE = `Your message could not be delivered to the following recipients:
+
+<arushi@frappe.io> (host 'localhost' rejected command 'RCPT TO:<arushi@frappe.io>' with code 550 (5.5.0) 'This account is not authorized to receive email.')`
+
+describe('addresses in angle brackets', () => {
+	// The failure this all guards against: the parser reads <arushi@frappe.io> as a tag and
+	// the sanitizer drops it, deleting the address the notice is about — while the text
+	// around it survives, so nothing looks obviously broken.
+	it('are destroyed by sanitization when passed through raw', () => {
+		const sanitized = DOMPurify.sanitize(`<pre>${BOUNCE}</pre>`)
+
+		expect(sanitized).not.toContain('arushi@frappe.io')
+		expect(sanitized).toContain('with code 550')
+	})
+
+	it('survive when escaped as plain text', () => {
+		const sanitized = DOMPurify.sanitize(`<pre>${escapeHtml(BOUNCE)}</pre>`)
+
+		expect(sanitized).toContain('&lt;arushi@frappe.io&gt;')
+		expect(sanitized).toContain('RCPT TO:&lt;arushi@frappe.io&gt;')
+	})
+
+	it('survive inside a body that is treated as HTML', () => {
+		const sanitized = DOMPurify.sanitize(escapeBracketedAddresses(`<div>${BOUNCE}</div>`))
+
+		expect(sanitized).toContain('&lt;arushi@frappe.io&gt;')
+		expect(sanitized).toContain('RCPT TO:<b>&lt;arushi@frappe.io&gt;</b>')
+	})
+
+	// Which is the path a bounce actually takes: its own bracketed addresses look enough
+	// like an <a> tag to pass the markup sniff, so the body is handed over as HTML.
+	it('make a plain-text body look like markup', () => {
+		expect(hasHtmlContent(BOUNCE)).toBe(true)
+	})
+
+	it('leave real markup alone', () => {
+		const html = '<a href="mailto:x@y.com" title="Mail x@y.com">Write</a>'
+
+		expect(escapeBracketedAddresses(html)).toBe(html)
+	})
+})

--- a/frontend/src/apps/mail/utils/html.ts
+++ b/frontend/src/apps/mail/utils/html.ts
@@ -1,0 +1,26 @@
+// Pure HTML-string helpers, kept out of the utils barrel so they can be used (and
+// tested) without pulling in its Vue-component and frappe-ui imports.
+
+export const escapeHtml = (s: string) =>
+	s.replace(
+		/[&<>"']/g,
+		(c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c] ?? c,
+	)
+
+// `<user@host>` in a body is an address, not markup — but the HTML parser reads it as
+// an unknown tag and the sanitizer drops it, silently deleting the addresses a bounce
+// notice is entirely about (its own `<a...>`-shaped text also fools hasHtmlContent
+// below, so such a body can reach the reader as "HTML" either way). Escaping them has
+// to happen before sanitizing, the last point where they still exist; the <b> marks
+// the recipient the notice is reporting on.
+const BRACKETED_ADDRESS = /<([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>/g
+
+export const escapeBracketedAddresses = (html: string) =>
+	html.replace(BRACKETED_ADDRESS, '<b>&lt;$1&gt;</b>')
+
+export const hasHtmlContent = (content: string | null | undefined): boolean => {
+	if (!content) return false
+	return /<(html|head|body|div|p|span|table|td|tr|a|img|br|hr|h[1-6]|ul|ol|li|strong|em|b|i|font|style)[^>]*>/i.test(
+		content,
+	)
+}

--- a/frontend/src/apps/mail/utils/html.ts
+++ b/frontend/src/apps/mail/utils/html.ts
@@ -13,7 +13,12 @@ export const escapeHtml = (s: string) =>
 // below, so such a body can reach the reader as "HTML" either way). Escaping them has
 // to happen before sanitizing, the last point where they still exist; the <b> marks
 // the recipient the notice is reporting on.
-const BRACKETED_ADDRESS = /<([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>/g
+// Deliberately loose about what an address may look like — `user@localhost` carries no
+// dot, an address literal carries brackets (`user@[10.0.0.1]`), an internationalized
+// mailbox carries neither in ASCII — because spelling out the grammar only decides
+// which recipients still get deleted. The test applied is the parser's own: something
+// with an `@` and no whitespace, which no real tag name can be.
+const BRACKETED_ADDRESS = /<([^<>\s]+@[^<>\s]+)>/g
 
 export const escapeBracketedAddresses = (html: string) =>
 	html.replace(BRACKETED_ADDRESS, '<b>&lt;$1&gt;</b>')

--- a/frontend/src/apps/mail/utils/index.ts
+++ b/frontend/src/apps/mail/utils/index.ts
@@ -405,12 +405,7 @@ export const getScriptName = (scriptName: string) => {
 export const isSystemScript = (scriptName: string) =>
 	['vacation', 'frappe_mail_automation'].includes(scriptName)
 
-export const hasHtmlContent = (content: string | null | undefined): boolean => {
-	if (!content) return false
-	return /<(html|head|body|div|p|span|table|td|tr|a|img|br|hr|h[1-6]|ul|ol|li|strong|em|b|i|font|style)[^>]*>/i.test(
-		content,
-	)
-}
+export { escapeHtml, hasHtmlContent } from '@/apps/mail/utils/html'
 
 export const getIcon = (mailbox: MailboxData) => {
 	// The Screener is a system folder: its 'eye' icon is authoritative and can't be overridden by a

--- a/frontend/src/apps/mail/utils/mailto.ts
+++ b/frontend/src/apps/mail/utils/mailto.ts
@@ -1,3 +1,5 @@
+import { escapeHtml } from '@/apps/mail/utils/html'
+
 import type { ComposeMailData, DraftRecipient } from '@/apps/mail/types'
 
 // RFC 6068 `mailto:` links, turned into a draft. Clicking one in a message should open
@@ -22,9 +24,6 @@ const recipients = (list: string | undefined): DraftRecipient[] =>
 		.map((address) => decode(address).trim())
 		.filter(Boolean)
 		.map((email) => ({ email }))
-
-const escapeHtml = (text: string) =>
-	text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
 // The body arrives as plain text; the editor speaks divs (see CustomParagraphExtension),
 // and an empty line needs the <br> to survive the round trip.


### PR DESCRIPTION
`<user@host>` in a message body parses as an unknown tag, which the sanitizer then drops. A bounce notice renders as `rejected command 'RCPT TO:'` — the address it is reporting on is gone, while the text around it survives, so nothing looks broken.

Escape those addresses before sanitizing, the last point where they still exist. The pass that did this ran on the serialized output afterwards, by which point there was nothing left to match.

Plain-text bodies are escaped now too, rather than being interpolated into the `<pre>` raw. Their own bracketed addresses look enough like an `<a...>` tag to pass the markup sniff, so such a body reaches the reader as HTML either way.

Addresses render bold, which is what the existing (unreachable) pass intended. It only fires on unescaped brackets, so normal HTML mail is unaffected.

Tests cover both paths, plus the failure itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)