### PR TITLE
fix(drive): improve ui consistency

### DIFF
--- a/frontend/src/apps/drive/components/DriveListRow.vue
+++ b/frontend/src/apps/drive/components/DriveListRow.vue
@@ -1,7 +1,6 @@
 <template>
   <template v-for="item in items" :key="item.key">
     <ListRow v-if="item.placeholder === 'loading'" class="pointer-events-none">
-      <ListCell />
       <ListCell>
         <div class="flex items-center" :style="indent(item.depth)">
           <Skeleton class="h-[16px] w-[16px] shrink-0 mr-2 rounded-sm" />
@@ -14,7 +13,6 @@
       </ListCell>
       <ListCell><Skeleton class="h-3 w-20 rounded" /></ListCell>
       <ListCell><Skeleton class="h-3 w-12 rounded" /></ListCell>
-      <ListCell />
     </ListRow>
     <ListRow v-else-if="item.placeholder" class="pointer-events-none">
       <ListCell />
@@ -45,7 +43,7 @@
         :data-testid="`drive-entity-${row.name}`"
         :data-selected="selections.has(row.name) || undefined"
         @contextmenu="(e) => !selections.size && contextMenu(e, row)"
-        @click="!isModKey($event) && !selections.size && open(row)"
+        @click="isModKey($event) ? props.toggleSelection(row, $event) : !selections.size && open(row)"
         @dragstart="onDragStart($event, row)"
         @dragend="draggedItem = null"
         @dragover="
@@ -65,14 +63,6 @@
           )
         "
       >
-        <ListCell>
-          <Checkbox
-            class="shrink-0"
-            :class="selections.size > 0 || selections.has(row.name) ? '' : 'invisible group-hover:visible'"
-            :model-value="selections.has(row.name)"
-            @click.stop="props.toggleSelection(row, $event)"
-          />
-        </ListCell>
         <ListCell>
           <div
             class="relative h-[16px] w-[16px] shrink-0 mr-2"
@@ -132,7 +122,7 @@
             </Tooltip>
           </div>
         </ListCell>
-        <ListCell>
+        <ListCell class="hidden sm:flex">
           <Avatar
             v-if="row.owner"
             shape="circle"
@@ -148,13 +138,14 @@
             <span class="truncate text-base">{{ row.relativeModified }}</span>
           </Tooltip>
         </ListCell>
-        <ListCell>
+        <ListCell class="hidden sm:flex">
           <span class="truncate text-base">{{ sizeLabel(row) }}</span>
         </ListCell>
         <ListCell class="justify-end">
           <Button
             v-if="!selections.size"
-            class="!bg-inherit"
+            :label="__('Actions for {0}', [row.file_name])"
+            class="!bg-inherit sm:invisible sm:group-hover:visible"
             @click="(e) => contextMenu(e, row)"
           >
             <LucideMoreHorizontal class="size-4" />
@@ -166,13 +157,13 @@
 </template>
 <script setup>
 import { ListRow, ListCell } from 'frappe-ui/list'
-import { Avatar, Button, Checkbox, Skeleton, Tooltip } from 'frappe-ui'
+import { Avatar, Button, Skeleton, Tooltip } from 'frappe-ui'
 import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { useSessionStore } from '@/boot/session'
 import { activeEntity, renamingEntity } from '@/apps/drive/data/selection'
 import InlineRenameInput from './InlineRenameInput.vue'
-import { openEntity, isModKey, isVirtual, folderRoute, getThumbnailUrl, WRITER_CONTENT_DOCTYPE, PRESENTATION_CONTENT_DOCTYPE } from '@/apps/drive/utils/files'
+import { openEntity, isModKey, isVirtual, folderRoute, getThumbnailUrl, displayFileName } from '@/apps/drive/utils/files'
 import { formatDate } from '@/apps/drive/utils/format'
 import { expandedFolders } from '@/apps/drive/data/folderTree'
 import LucideStar from '~icons/lucide/star'
@@ -262,21 +253,11 @@ function thumbnail(row) {
 }
 
 function displayName(row) {
-  if (!row.file_name) return row.title || ''
-  return row.file_name.lastIndexOf('.') === -1 ||
-    row.is_folder ||
-    row.content_doctype === WRITER_CONTENT_DOCTYPE ||
-    row.content_doctype === PRESENTATION_CONTENT_DOCTYPE
-    ? row.file_name
-    : row.file_name.slice(0, row.file_name.lastIndexOf('.'))
+  return displayFileName(row)
 }
 function nameTooltip(row) {
-  return !row.file_name ||
-    row.is_folder ||
-    row.content_doctype === WRITER_CONTENT_DOCTYPE ||
-    row.content_doctype === PRESENTATION_CONTENT_DOCTYPE
-    ? ''
-    : row.file_name
+  const display = displayFileName(row)
+  return display === row.file_name ? '' : row.file_name
 }
 
 function shareIcon(row) {

--- a/frontend/src/apps/drive/components/DriveListRow.vue
+++ b/frontend/src/apps/drive/components/DriveListRow.vue
@@ -1,6 +1,7 @@
 <template>
   <template v-for="item in items" :key="item.key">
     <ListRow v-if="item.placeholder === 'loading'" class="pointer-events-none">
+      <ListCell />
       <ListCell>
         <div class="flex items-center" :style="indent(item.depth)">
           <Skeleton class="h-[16px] w-[16px] shrink-0 mr-2 rounded-sm" />
@@ -13,6 +14,7 @@
       </ListCell>
       <ListCell><Skeleton class="h-3 w-20 rounded" /></ListCell>
       <ListCell><Skeleton class="h-3 w-12 rounded" /></ListCell>
+      <ListCell />
     </ListRow>
     <ListRow v-else-if="item.placeholder" class="pointer-events-none">
       <ListCell />
@@ -64,6 +66,15 @@
         "
       >
         <ListCell>
+          <Checkbox
+            class="shrink-0"
+            :class="selections.size > 0 || selections.has(row.name) ? '' : 'invisible group-hover:visible'"
+            :model-value="selections.has(row.name)"
+            :aria-label="__('Select {0}', [row.file_name])"
+            @click.stop="props.toggleSelection(row, $event)"
+          />
+        </ListCell>
+        <ListCell>
           <div
             class="relative h-[16px] w-[16px] shrink-0 mr-2"
             :class="canExpand(row) ? 'cursor-pointer' : ''"
@@ -73,13 +84,7 @@
           >
             <div
               class="absolute inset-0"
-              :class="
-                canExpand(row)
-                  ? isExpanded(row)
-                    ? 'opacity-0'
-                    : 'group-hover:opacity-0'
-                  : ''
-              "
+              :class="canExpand(row) ? (isExpanded(row) ? 'opacity-0' : 'group-hover:opacity-0') : ''"
             >
               <img
                 v-if="!loadedThumbnails.has(row.name)"
@@ -157,7 +162,7 @@
 </template>
 <script setup>
 import { ListRow, ListCell } from 'frappe-ui/list'
-import { Avatar, Button, Skeleton, Tooltip } from 'frappe-ui'
+import { Avatar, Button, Checkbox, Skeleton, Tooltip } from 'frappe-ui'
 import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { useSessionStore } from '@/boot/session'

--- a/frontend/src/apps/drive/components/DriveListRow.vue
+++ b/frontend/src/apps/drive/components/DriveListRow.vue
@@ -111,19 +111,20 @@
             />
           </div>
           <InlineRenameInput :entity="row">
-            <Tooltip :text="nameTooltip(row)" :disabled="!nameTooltip(row)">
+            <Tooltip :text="nameTooltip(row)" :disabled="!nameTooltip(row)" class="min-w-0 flex-1">
               <div class="truncate text-base">{{ displayName(row) }}</div>
             </Tooltip>
           </InlineRenameInput>
-          <div class="flex flex-row grow justify-end gap-2 w-[20px] pr-3">
+          <div v-if="(row.is_favourite && $route.name !== 'Favourites') || shareIcon(row)"
+            class="ml-auto flex min-w-8 shrink-0 flex-row justify-end gap-2 pr-3">
             <LucideStar
               v-if="row.is_favourite && $route.name !== 'Favourites'"
               width="16"
               height="16"
-              class="my-auto text-ink-amber-6 stroke-current fill-current"
+              class="my-auto shrink-0 text-ink-amber-6 stroke-current fill-current"
             />
-            <Tooltip v-if="shareIcon(row)" :text="shareIcon(row).tooltip">
-              <component :is="shareIcon(row).icon" class="size-4" />
+            <Tooltip v-if="shareIcon(row)" :text="shareIcon(row).tooltip" class="shrink-0">
+              <component :is="shareIcon(row).icon" class="size-4 shrink-0" />
             </Tooltip>
           </div>
         </ListCell>

--- a/frontend/src/apps/drive/components/DriveListSkeleton.vue
+++ b/frontend/src/apps/drive/components/DriveListSkeleton.vue
@@ -1,23 +1,22 @@
 <template>
   <List
-    class="pt-3 flex flex-col flex-1 min-h-0 list-row-px-3"
+    class="pt-3 flex flex-col flex-1 min-h-0 list-row-px-5 sm:list-row-px-3"
     :columns="columnTracks"
     :row-height="40"
-    divider="inset"
+    divider="full"
   >
-    <div class="flex-1 min-h-0 overflow-hidden px-2">
+    <div class="flex-1 min-h-0 overflow-hidden px-0 sm:px-2">
       <ListRow v-for="i in 10" :key="i" class="pointer-events-none">
-        <ListCell />
         <ListCell>
           <Skeleton class="h-[16px] w-[16px] shrink-0 mr-2 rounded-sm" />
           <Skeleton class="h-3.5 rounded" :style="{ width: nameWidths[i % nameWidths.length] }" />
         </ListCell>
-        <ListCell>
+        <ListCell class="hidden sm:flex">
           <Skeleton class="size-5 shrink-0 mr-2 rounded-full" />
           <Skeleton class="h-3 w-16 rounded" />
         </ListCell>
         <ListCell><Skeleton class="h-3 w-20 rounded" /></ListCell>
-        <ListCell><Skeleton class="h-3 w-12 rounded" /></ListCell>
+        <ListCell class="hidden sm:flex"><Skeleton class="h-3 w-12 rounded" /></ListCell>
         <ListCell />
       </ListRow>
     </div>

--- a/frontend/src/apps/drive/components/DriveListSkeleton.vue
+++ b/frontend/src/apps/drive/components/DriveListSkeleton.vue
@@ -7,6 +7,7 @@
   >
     <div class="flex-1 min-h-0 overflow-hidden px-0 sm:px-2">
       <ListRow v-for="i in 10" :key="i" class="pointer-events-none">
+        <ListCell />
         <ListCell>
           <Skeleton class="h-[16px] w-[16px] shrink-0 mr-2 rounded-sm" />
           <Skeleton class="h-3.5 rounded" :style="{ width: nameWidths[i % nameWidths.length] }" />

--- a/frontend/src/apps/drive/components/DriveToolBar.vue
+++ b/frontend/src/apps/drive/components/DriveToolBar.vue
@@ -1,11 +1,14 @@
 <template>
   <div class="flex flex-wrap items-center gap-2 px-5 pt-3 min-h-12">
-    <div v-if="selections?.length" class="my-auto text-base text-ink-gray-8 sm:w-[40%]">
-      {{ selections.length }}
-      {{ selections.length === 1 ? __('item') : __('items') }}
-      {{ __('selected') }}
+    <div v-if="selectionMode" class="flex min-w-0 items-center gap-2">
+      <span class="whitespace-nowrap text-base text-ink-gray-8">
+        {{ selections.length }} {{ __('selected') }}
+      </span>
+      <Button v-if="view !== 'list'" variant="outline"
+        :label="allSelected ? __('Unselect all') : __('Select all {0}', [selectableCount])"
+        @click="emit('select-all')" />
     </div>
-    <div v-if="$route.name === 'drive-Home'"
+    <div v-if="!selectionMode && $route.name === 'drive-Home'"
       class="bg-surface-gray-2 rounded-md space-x-0.5 h-7 flex items-center sm:mr-2 py-1">
       <TabButtons v-model="shareView" :options="[
         {
@@ -18,14 +21,14 @@
         },
       ]" />
     </div>
-    <TextInput ref="search-input" v-model="search" :disabled :class="selections.length ? 'hidden' : 'block'"
+    <TextInput ref="search-input" v-model="search" :disabled :class="selectionMode ? 'hidden' : 'block'"
       :placeholder="__('Find')" class="min-w-0 flex-1 sm:w-[30%] sm:flex-none">
       <template #prefix>
         <LucideSearch class="size-4" />
       </template>
     </TextInput>
     <div class="flex gap-2 ml-auto my-auto">
-      <template v-if="!selections?.length">
+      <template v-if="!selectionMode">
         <div v-if="activeFilters.length" class="flex flex-wrap items-start justify-end gap-1 ml-3">
           <div v-for="({ icon, name }, index) in activeFilters" :key="index">
             <div class="flex items-center border rounded pl-2 py-1 h-7 text-base select-none">
@@ -57,7 +60,7 @@
           },
         ]" />
       </template>
-      <div v-else-if="actionItems" class="flex gap-3 ml-4 overflow-auto">
+      <div v-else-if="selections.length && actionItems" class="flex gap-2 overflow-auto">
         <template v-for="item in actionItems
           .filter((i) => i.important && (selections.length === 1 || i.multi))
           .filter(
@@ -100,7 +103,11 @@ const props = defineProps({
   selections: Array,
   actionItems: Array,
   getEntities: Object,
+  selectableCount: Number,
+  allSelected: Boolean,
+  selectionMode: Boolean,
 })
+const emit = defineEmits(['select-all'])
 
 const activeFilters = defineModel('filters')
 const disabled = computed(() => !props.getEntities.data?.length)

--- a/frontend/src/apps/drive/components/DriveToolBar.vue
+++ b/frontend/src/apps/drive/components/DriveToolBar.vue
@@ -37,13 +37,7 @@
           </div>
         </div>
         <Button v-if="delayedLoading" :loading="true" label="Loading..." />
-        <Dropdown :options="availableFilterTypes.map(({ name, icon }) => ({
-          label: __(name),
-          icon: h('img', { src: icon }),
-          onClick: () => activeFilters.push({ name, icon }),
-          disabled: activeFilters.includes({ name, icon }),
-        }))
-          " :button="{
+        <Dropdown :options="filterOptions" :button="{
             icon: LucideFilter,
             tooltip: 'Filter',
           }" :disabled placement="right" />
@@ -83,14 +77,13 @@
   </div>
 </template>
 <script setup>
-import { Button, Dropdown, TextInput, TabButtons, Switch } from 'frappe-ui'
+import { Button, Dropdown, TextInput, TabButtons } from 'frappe-ui'
 import {
   ref,
   computed,
   watch,
   useTemplateRef,
   h,
-  defineComponent,
   onWatcherCleanup,
 } from 'vue'
 import { getIconUrl } from '@/apps/drive/utils/files'
@@ -139,6 +132,24 @@ const availableFilterTypes = computed(() => {
     .sort((a, b) => (a > b ? 1 : -1))
     .map((t) => ({ name: t, icon: getIconUrl(t) }))
 })
+
+const filterOptions = computed(() =>
+  availableFilterTypes.value.map(({ name, icon }) => {
+    const selected = activeFilters.value.some((filter) => filter.name === name)
+    return {
+      label: __(name),
+      icon: selected ? 'lucide-check' : h('img', { src: icon }),
+      selected,
+      onClick: () => toggleTypeFilter({ name, icon }),
+    }
+  })
+)
+
+function toggleTypeFilter(filter) {
+  const index = activeFilters.value.findIndex(({ name }) => name === filter.name)
+  if (index === -1) activeFilters.value.push(filter)
+  else activeFilters.value.splice(index, 1)
+}
 
 onKeyDown('Escape', () => {
   searchInput.value.el.blur()

--- a/frontend/src/apps/drive/components/DriveToolBar.vue
+++ b/frontend/src/apps/drive/components/DriveToolBar.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="flex items-center px-5 pt-3 h-12">
-    <div v-if="selections?.length" class="my-auto w-[40%] text-base text-ink-gray-8">
+  <div class="flex flex-wrap items-center gap-2 px-5 pt-3 min-h-12">
+    <div v-if="selections?.length" class="my-auto text-base text-ink-gray-8 sm:w-[40%]">
       {{ selections.length }}
       {{ selections.length === 1 ? __('item') : __('items') }}
       {{ __('selected') }}
     </div>
     <div v-if="$route.name === 'drive-Home'"
-      class="bg-surface-gray-2 rounded-[10px] space-x-0.5 h-7 flex items-center mr-4 py-1">
+      class="bg-surface-gray-2 rounded-md space-x-0.5 h-7 flex items-center sm:mr-2 py-1">
       <TabButtons v-model="shareView" :options="[
         {
           label: __('Yours'),
@@ -19,22 +19,11 @@
       ]" />
     </div>
     <TextInput ref="search-input" v-model="search" :disabled :class="selections.length ? 'hidden' : 'block'"
-      :placeholder="__('Find')" class="w-[30%]">
+      :placeholder="__('Find')" class="min-w-0 flex-1 sm:w-[30%] sm:flex-none">
       <template #prefix>
         <LucideSearch class="size-4" />
       </template>
     </TextInput>
-    <Dropdown v-if="!selections?.length" class="ml-2 my-auto" :options="availableFilterTypes.map(({ name, icon }) => ({
-      label: __(name),
-      icon: h('img', { src: icon }),
-      onClick: () => activeFilters.push({ name, icon }),
-      disabled: activeFilters.includes({ name, icon }),
-    }))
-      " :button="{
-        icon: LucideFilter,
-        tooltip: 'Filter',
-      }" :disabled placement="right" />
-
     <div class="flex gap-2 ml-auto my-auto">
       <template v-if="!selections?.length">
         <div v-if="activeFilters.length" class="flex flex-wrap items-start justify-end gap-1 ml-3">
@@ -48,6 +37,16 @@
           </div>
         </div>
         <Button v-if="delayedLoading" :loading="true" label="Loading..." />
+        <Dropdown :options="availableFilterTypes.map(({ name, icon }) => ({
+          label: __(name),
+          icon: h('img', { src: icon }),
+          onClick: () => activeFilters.push({ name, icon }),
+          disabled: activeFilters.includes({ name, icon }),
+        }))
+          " :button="{
+            icon: LucideFilter,
+            tooltip: 'Filter',
+          }" :disabled placement="right" />
         <SortControl v-if="$route.name !== 'Recents' && view !== 'list'" v-model="sortOrder" :options="columnHeaders"
           :menu-items="sortMenuItems" :disabled />
 

--- a/frontend/src/apps/drive/components/DriveToolBar.vue
+++ b/frontend/src/apps/drive/components/DriveToolBar.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="flex flex-wrap items-center gap-2 px-5 pt-3 min-h-12">
+  <div
+    class="items-center gap-2 px-3 pt-3 min-h-12 sm:flex sm:flex-wrap sm:px-5"
+    :class="selectionMode ? 'flex flex-wrap' : 'grid grid-cols-[auto_minmax(0,1fr)]'"
+  >
     <div v-if="selectionMode" class="flex min-w-0 items-center gap-2">
       <span class="whitespace-nowrap text-base text-ink-gray-8">
         {{ selections.length }} {{ __('selected') }}
@@ -21,21 +24,27 @@
         },
       ]" />
     </div>
-    <TextInput ref="search-input" v-model="search" :disabled :class="selectionMode ? 'hidden' : 'block'"
+    <TextInput ref="search-input" v-model="search" :disabled :class="[
+      selectionMode ? 'hidden' : 'block',
+      $route.name === 'drive-Home' ? '' : 'col-span-2 sm:col-span-1',
+    ]"
       :placeholder="__('Find')" class="min-w-0 flex-1 sm:w-[30%] sm:flex-none">
       <template #prefix>
         <LucideSearch class="size-4" />
       </template>
     </TextInput>
-    <div class="flex gap-2 ml-auto my-auto">
+    <div class="col-span-2 flex min-w-0 w-full justify-end gap-2 my-auto sm:ml-auto sm:w-auto">
       <template v-if="!selectionMode">
-        <div v-if="activeFilters.length" class="flex flex-wrap items-start justify-end gap-1 ml-3">
-          <div v-for="({ icon, name }, index) in activeFilters" :key="index">
-            <div class="flex items-center border rounded pl-2 py-1 h-7 text-base select-none">
-              <img class="w-4" :src="icon" />
-              <span class="text-sm ml-2">{{ name }}</span>
-              <Button variant="minimal" :icon="h(LucideX, { class: 'size-3' })"
-                @click="activeFilters.splice(index, 1)" />
+        <div v-if="activeFilters.length"
+          class="min-w-0 flex-1 overflow-x-auto sm:ml-3 sm:flex sm:flex-initial sm:flex-wrap sm:items-start sm:justify-end sm:gap-1 sm:overflow-visible">
+          <div class="flex min-w-full w-max justify-end gap-1 sm:contents">
+            <div v-for="({ icon, name }, index) in activeFilters" :key="index" class="shrink-0">
+              <div class="flex items-center border rounded pl-2 py-1 h-7 text-base select-none">
+                <img class="w-4" :src="icon" />
+                <span class="text-sm ml-2">{{ name }}</span>
+                <Button variant="minimal" :icon="h(LucideX, { class: 'size-3' })"
+                  @click="activeFilters.splice(index, 1)" />
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/apps/drive/components/GenericPage.vue
+++ b/frontend/src/apps/drive/components/GenericPage.vue
@@ -13,7 +13,8 @@
     <NoFilesSection v-else-if="!props.getEntities.data?.length" v-bind="empty" />
     <ListView v-else-if="view === 'list'" ref="viewEl" v-model="selections" v-model:sort-order="sortOrder" :folder-contents="rows && grouper(rows)"
       :action-items="actionItems" :root-entity="verify?.data" :loading-more="loadingMore" @dropped="onDrop" />
-    <GridView v-else ref="viewEl" v-model="selections" :folder-contents="rows" :action-items="actionItems" @dropped="onDrop" />
+    <GridView v-else ref="viewEl" v-model="selections" :folder-contents="rows" :action-items="actionItems"
+      :loading-more="loadingMore" @dropped="onDrop" />
   </div>
   <p class="hidden absolute text-center top-1/2 left-[calc(50%-4rem)] w-32 z-10 font-bold">
     Drop to upload

--- a/frontend/src/apps/drive/components/GenericPage.vue
+++ b/frontend/src/apps/drive/components/GenericPage.vue
@@ -179,6 +179,14 @@ const allRows = computed(() => [
 const selectedEntitities = computed(() =>
   allRows.value.filter(({ name }) => selections.value.has(name))
 )
+watch(allRows, (entities) => {
+  const names = new Set(entities.map(({ name }) => name))
+  if ([...selections.value].some((name) => !names.has(name))) {
+    selections.value = new Set(
+      [...selections.value].filter((name) => names.has(name))
+    )
+  }
+})
 const selectableNames = computed(
   () => viewEl.value?.visibleNames ?? rows.value.map(({ name }) => name)
 )
@@ -235,14 +243,19 @@ const pageStart = ref(0)
 const hasNextPage = ref(false)
 const loadingMore = ref(false)
 
-const refreshData = () => {
-  const res = props.getEntities
+const queryParams = () => {
   const params = {}
   if (sortOrder.value) {
     params.order_by = sortOrder.value.field
     params.ascending = sortOrder.value.ascending
   }
   params.search = search.value || ''
+  return params
+}
+
+const refreshData = () => {
+  const res = props.getEntities
+  const params = queryParams()
   pageStart.value = 0
   hasNextPage.value = false
   if (res.paginated) {
@@ -272,7 +285,12 @@ async function loadMore() {
     const resp = await request({
       url: path,
       method: 'GET',
-      params: { ...res.params, start: next, limit: PAGE_SIZE },
+      params: {
+        ...res.params,
+        ...queryParams(),
+        start: next,
+        limit: PAGE_SIZE,
+      },
       credentials: 'include',
     })
     // request() is a raw fetch that skips the resource's transform, so the page

--- a/frontend/src/apps/drive/components/GenericPage.vue
+++ b/frontend/src/apps/drive/components/GenericPage.vue
@@ -7,13 +7,17 @@
   <div v-else id="drop-area" ref="container" class="flex flex-col flex-1 min-h-0 overflow-hidden bg-surface-base"
     @dragover="onDragOverScroll" @drop="stopAutoScroll" @dragend="stopAutoScroll">
     <DriveToolBar v-model:sort-order="sortOrder" v-model:search="search" v-model:filters="filters"
-      :action-items="actionItems" :selections="selectedEntitities" :get-entities="getEntities || { data: [] }" />
+      :selection-mode="selectionMode" :action-items="actionItems" :selections="selectedEntitities"
+      :selectable-count="selectableNames.length" :all-selected="allVisibleSelected"
+      :get-entities="getEntities || { data: [] }" @select-all="toggleSelectAll" />
 
     <DriveListSkeleton v-if="!props.getEntities.data" />
     <NoFilesSection v-else-if="!props.getEntities.data?.length" v-bind="empty" />
-    <ListView v-else-if="view === 'list'" ref="viewEl" v-model="selections" v-model:sort-order="sortOrder" :folder-contents="rows && grouper(rows)"
+    <ListView v-else-if="view === 'list'" ref="viewEl" v-model="selections" v-model:sort-order="sortOrder"
+      :folder-contents="rows && grouper(rows)"
       :action-items="actionItems" :root-entity="verify?.data" :loading-more="loadingMore" @dropped="onDrop" />
-    <GridView v-else ref="viewEl" v-model="selections" :folder-contents="rows" :action-items="actionItems"
+    <GridView v-else ref="viewEl" v-model="selections" :selection-mode="selectionMode"
+      :folder-contents="rows" :action-items="actionItems"
       :loading-more="loadingMore" @dropped="onDrop" />
   </div>
   <p class="hidden absolute text-center top-1/2 left-[calc(50%-4rem)] w-32 z-10 font-bold">
@@ -166,6 +170,8 @@ watch(
 )
 
 const selections = ref(new Set())
+const selectionMode = computed(() => selections.value.size > 0)
+const viewEl = ref(null)
 const allRows = computed(() => [
   ...(props.getEntities.data ?? []),
   ...loadedChildRows.value,
@@ -173,6 +179,23 @@ const allRows = computed(() => [
 const selectedEntitities = computed(() =>
   allRows.value.filter(({ name }) => selections.value.has(name))
 )
+const selectableNames = computed(
+  () => viewEl.value?.visibleNames ?? rows.value.map(({ name }) => name)
+)
+const allVisibleSelected = computed(
+  () => selectableNames.value.length > 0 && selectableNames.value.every((name) => selections.value.has(name))
+)
+
+function toggleSelectAll() {
+  const next = new Set(selections.value)
+  if (allVisibleSelected.value) selectableNames.value.forEach((name) => next.delete(name))
+  else selectableNames.value.forEach((name) => next.add(name))
+  selections.value = next
+}
+
+function clearSelection() {
+  selections.value = new Set()
+}
 
 // Shared by both views, as selections is Drive's own Set-based model.
 const isTyping = (e) =>
@@ -182,8 +205,8 @@ const isTyping = (e) =>
 
 onKeyDown('a', (e) => {
   if (isTyping(e)) return
-  if (e.metaKey) {
-    selections.value = new Set(rows.value.map((k) => k.name))
+  if (e.metaKey || e.ctrlKey) {
+    toggleSelectAll()
     e.preventDefault()
   }
 })
@@ -199,7 +222,7 @@ onKeyDown('Escape', (e) => {
   if (isTyping(e)) return
   // Let an open dialog handle its own Escape.
   if (document.querySelector('.dialog-content[data-state="open"]')) return
-  selections.value = new Set()
+  clearSelection()
   e.preventDefault()
 })
 
@@ -265,7 +288,6 @@ async function loadMore() {
   }
 }
 
-const viewEl = ref(null)
 const scrollHost = ref(null)
 const resolveScrollHost = () => {
   let el = viewEl.value?.scrollEl

--- a/frontend/src/apps/drive/components/GridItem.vue
+++ b/frontend/src/apps/drive/components/GridItem.vue
@@ -26,10 +26,12 @@
   <div
     class="p-2 h-[35%] border-t border-outline-gray-1 flex flex-col justify-evenly"
   >
-    <InlineRenameInput :entity="file" class="text-base-medium">
-      <div class="truncate w-full w-fit text-base-medium text-ink-gray-8">
-        {{ file.file_name }}
-      </div>
+    <InlineRenameInput :entity="file">
+      <Tooltip :text="file.file_name" :disabled="displayFileName(file) === file.file_name">
+        <div class="truncate w-full text-base text-ink-gray-8">
+          {{ displayFileName(file) }}
+        </div>
+      </Tooltip>
     </InlineRenameInput>
     <div class="mt-[5px] text-xs text-ink-gray-5">
       <div class="flex items-center justify-start gap-1">
@@ -41,9 +43,7 @@
           :draggable="false"
         />
         <p class="truncate">
-          {{ file.is_folder ? childrenSentence + '∙' : '' }}
-          {{ file.file_type !== 'Unknown' ? file.file_type + '∙' : '' }}
-          {{ file.relativeModified }}
+          {{ metadata }}
         </p>
       </div>
       <!-- <p class="mt-1">
@@ -53,7 +53,8 @@
   </div>
 </template>
 <script setup>
-import { getIconUrl, getThumbnailUrl } from '@/apps/drive/utils/files'
+import { getIconUrl, getThumbnailUrl, displayFileName } from '@/apps/drive/utils/files'
+import { Tooltip } from 'frappe-ui'
 import { ref, computed } from 'vue'
 import InlineRenameInput from './InlineRenameInput.vue'
 const props = defineProps({ file: Object })
@@ -76,4 +77,13 @@ const childrenSentence = computed(() => {
   if (!props.file.child_count) return 'empty'
   return props.file.child_count + ' item' + (props.file.child_count === 1 ? '' : 's')
 })
+const metadata = computed(() =>
+  [
+    props.file.is_folder ? childrenSentence.value : null,
+    props.file.file_type !== 'Unknown' ? props.file.file_type : null,
+    props.file.relativeModified,
+  ]
+    .filter(Boolean)
+    .join(' · ')
+)
 </script>

--- a/frontend/src/apps/drive/components/GridView.vue
+++ b/frontend/src/apps/drive/components/GridView.vue
@@ -3,18 +3,18 @@
   <div
     v-if="rows?.length"
     ref="scrollContainer"
-    class="grid-container content-start gap-5 p-5 pb-[60px] overflow-auto select-none flex-1 min-h-0"
+    class="grid-container content-start gap-3 p-3 pb-[60px] sm:gap-5 sm:p-5 sm:pb-[60px] overflow-auto select-none flex-1 min-h-0"
   >
     <div
       v-for="file in rows"
       :id="file.name"
       :key="file.name"
       :data-testid="`drive-entity-${file.name}`"
-      class="grid-item rounded-lg group select-none entity cursor-pointer relative h-[172px] border bg-surface-base"
+      class="grid-item rounded-md group select-none entity cursor-pointer relative h-40 sm:h-[172px] border bg-surface-base"
       :class="[
         selections.has(file.name) || selectedRow?.name === file.name
-          ? 'bg-surface-gray-2 shadow-gray'
-          : 'border-outline-elevation-2 hover:shadow-lg',
+          ? 'border-outline-gray-3 bg-surface-gray-2 shadow-sm'
+          : 'border-outline-gray-2 hover:bg-surface-gray-1 hover:shadow-sm',
         draggingNames.has(file.name) ? 'opacity-60 hover:shadow-none' : '',
         dragOverItem === file.name ? '!bg-surface-gray-3' : '',
       ]"
@@ -31,12 +31,7 @@
         }
       "
       @drop="$emit('dropped', file, draggedItem)"
-      @click.meta="
-        selections.has(file.name)
-          ? selections.delete(file.name)
-          : selections.add(file.name)
-      "
-      @click="open(file)"
+      @click="isModKey($event) ? toggleSelection(file) : open(file)"
       @contextmenu="contextMenu($event, file)"
       @mousedown.stop
     >
@@ -65,7 +60,7 @@
           selections.size > 0 ? '' : '!bg-surface-gray-3 hover:shadow-lg',
           selectedRow?.name === file.name
             ? ''
-            : 'invisible group-hover:visible',
+            : 'sm:invisible sm:group-hover:visible',
         ]"
         @click.stop="contextMenu($event, file)"
       >
@@ -73,6 +68,10 @@
       </Button>
       <GridItem :file="file" />
     </div>
+  </div>
+  <NoFilesSection v-else description="Nothing found - try something else?" />
+  <div v-if="loadingMore" class="pointer-events-none px-3 pb-5 sm:px-5">
+    <Skeleton class="h-3 w-24 rounded" />
   </div>
   <ContextMenu
     v-if="rowEvent && selectedRow"
@@ -87,9 +86,10 @@
 <script setup>
 import GridItem from '@/apps/drive/components/GridItem.vue'
 import ContextMenu from '@/apps/drive/components/ContextMenu.vue'
-import { Button, Checkbox } from 'frappe-ui'
+import NoFilesSection from '@/apps/drive/components/NoFilesSection.vue'
+import { Button, Checkbox, Skeleton } from 'frappe-ui'
 import { ref, computed } from 'vue'
-import { openEntity } from '@/apps/drive/utils/files'
+import { openEntity, isModKey } from '@/apps/drive/utils/files'
 import { useRoute } from 'vue-router'
 import { setActiveEntity, renamingEntity } from '@/apps/drive/data/selection'
 import { settings } from '@/apps/drive/resources/permissions'
@@ -98,6 +98,7 @@ import { onOutsideClickDirective as vOnOutsideClick } from 'frappe-ui'
 const props = defineProps({
   folderContents: Object,
   actionItems: Array,
+  loadingMore: Boolean,
 })
 defineEmits(['dropped'])
 const route = useRoute()
@@ -115,7 +116,7 @@ const rowEvent = ref(null)
 const contextMenu = (event, row) => {
   if (selections.value.size > 0) return
   // Ctrl + click triggers context menu on Mac
-  if (event.ctrlKey) openEntity(row, true)
+  if (isModKey(event)) openEntity(row, true)
   rowEvent.value = event
   selectedRow.value = row
   event.stopPropagation()
@@ -183,7 +184,4 @@ const onDragStart = (e, file) => {
   grid-auto-columns: minmax(170px, 1fr);
 }
 
-.shadow-gray {
-  box-shadow: 0px 0px 0px 2px rgb(161, 159, 159);
-}
 </style>

--- a/frontend/src/apps/drive/components/GridView.vue
+++ b/frontend/src/apps/drive/components/GridView.vue
@@ -10,7 +10,7 @@
       :id="file.name"
       :key="file.name"
       :data-testid="`drive-entity-${file.name}`"
-      class="grid-item rounded-md group select-none entity cursor-pointer relative h-40 sm:h-[172px] border bg-surface-base"
+      class="grid-item rounded-md group select-none entity cursor-pointer relative h-40 sm:h-[172px] border bg-surface-base [-webkit-touch-callout:none]"
       :class="[
         selections.has(file.name) || selectedRow?.name === file.name
           ? 'border-outline-gray-3 bg-surface-gray-2 shadow-sm'
@@ -31,33 +31,40 @@
         }
       "
       @drop="$emit('dropped', file, draggedItem)"
-      @click="isModKey($event) ? toggleSelection(file) : open(file)"
+      @click="selectionMode || isModKey($event) ? toggleSelection(file, $event) : open(file)"
       @contextmenu="contextMenu($event, file)"
+      @touchstart="onTouchStart($event, file)"
+      @touchend="onTouchEnd"
+      @touchcancel="clearTouchTimer"
       @mousedown.stop
     >
       <LucideStar
         v-if="$route.name !== 'Favourites' && file.is_favourite"
         class="z-10 text-ink-amber-6 stroke-current fill-current absolute top-2 left-2 h-4"
-        :class="selections.size ? 'invisible' : 'group-hover:invisible'"
+        :class="selectionMode ? 'invisible' : 'group-hover:invisible'"
         width="16"
         height="16"
       />
-      <Checkbox
+      <div
         class="z-10 absolute top-1 left-1 cursor-pointer"
         :class="
-          selections.size > 0 || selections.has(file.name)
+          selectionMode || selections.has(file.name)
             ? ''
-            : 'invisible group-hover:visible'
+            : 'invisible sm:group-hover:visible'
         "
-        :model-value="selections.has(file.name)"
-        @click.stop="toggleSelection(file)"
-      />
+      >
+        <Checkbox
+          :model-value="selections.has(file.name)"
+          :aria-label="__('Select {0}', [file.file_name])"
+          @click.stop="toggleSelection(file, $event)"
+        />
+      </div>
       <Button
         :variant="'subtle'"
         :label="`Actions for ${file.file_name}`"
         class="z-10 duration-300 absolute top-2 right-2"
         :class="[
-          selections.size > 0 ? '' : '!bg-surface-gray-3 hover:shadow-lg',
+          selectionMode ? 'hidden' : '!bg-surface-gray-3 hover:shadow-lg',
           selectedRow?.name === file.name
             ? ''
             : 'sm:invisible sm:group-hover:visible',
@@ -99,21 +106,68 @@ const props = defineProps({
   folderContents: Object,
   actionItems: Array,
   loadingMore: Boolean,
+  selectionMode: Boolean,
 })
 defineEmits(['dropped'])
 const route = useRoute()
 const selections = defineModel(new Set())
+const selectionMode = computed(() => props.selectionMode)
 
 const rows = computed(() => props.folderContents)
+const visibleNames = computed(() => rows.value?.map(({ name }) => name) ?? [])
 
 const scrollContainer = ref(null)
-defineExpose({ scrollEl: scrollContainer })
+defineExpose({ scrollEl: scrollContainer, visibleNames })
 
 const selectedRow = ref(null)
 const rowEvent = ref(null)
 
+let touchStartX = 0
+let touchStartY = 0
+let touchTimer = null
+let didLongPress = false
+const isTouching = ref(false)
+
+function onTouchStart(event, file) {
+  const touch = event.touches[0]
+  touchStartX = touch.clientX
+  touchStartY = touch.clientY
+  didLongPress = false
+  isTouching.value = true
+  document.addEventListener('touchmove', onTouchMove, { passive: true })
+  touchTimer = setTimeout(() => {
+    didLongPress = true
+    toggleSelection(file)
+  }, 450)
+}
+
+function onTouchEnd(event) {
+  if (didLongPress) event.preventDefault()
+  clearTouchTimer()
+}
+
+function onTouchMove(event) {
+  const touch = event.touches[0]
+  if (
+    Math.abs(touch.clientX - touchStartX) > 10 ||
+    Math.abs(touch.clientY - touchStartY) > 10
+  )
+    clearTouchTimer()
+}
+
+function clearTouchTimer() {
+  isTouching.value = false
+  document.removeEventListener('touchmove', onTouchMove)
+  if (touchTimer) clearTimeout(touchTimer)
+  touchTimer = null
+}
+
 // Duplication, redesign
 const contextMenu = (event, row) => {
+  if (isTouching.value || selectionMode.value) {
+    event.preventDefault()
+    return
+  }
   if (selections.value.size > 0) return
   // Ctrl + click triggers context menu on Mac
   if (isModKey(event)) openEntity(row, true)
@@ -136,9 +190,25 @@ const dropdownActionItems = (row) => {
       },
     }))
 }
-const toggleSelection = (file) => {
-  if (selections.value.has(file.name)) selections.value.delete(file.name)
-  else selections.value.add(file.name)
+const lastSelectedName = ref(null)
+const toggleSelection = (file, event) => {
+  const names = rows.value.map(({ name }) => name)
+  if (event?.shiftKey && lastSelectedName.value) {
+    const from = names.indexOf(lastSelectedName.value)
+    const to = names.indexOf(file.name)
+    if (from !== -1 && to !== -1) {
+      const [start, end] = from < to ? [from, to] : [to, from]
+      const next = new Set(selections.value)
+      names.slice(start, end + 1).forEach((name) => next.add(name))
+      selections.value = next
+      return
+    }
+  }
+  const next = new Set(selections.value)
+  if (next.has(file.name)) next.delete(file.name)
+  else next.add(file.name)
+  selections.value = next
+  lastSelectedName.value = file.name
 }
 
 const open = (row) =>

--- a/frontend/src/apps/drive/components/GridView.vue
+++ b/frontend/src/apps/drive/components/GridView.vue
@@ -3,7 +3,7 @@
   <div
     v-if="rows?.length"
     ref="scrollContainer"
-    class="grid-container content-start gap-3 p-3 pb-[60px] sm:gap-5 sm:p-5 sm:pb-[60px] overflow-auto select-none flex-1 min-h-0"
+    class="grid-container isolate content-start gap-3 p-3 pb-[60px] sm:gap-5 sm:p-5 sm:pb-[60px] overflow-auto select-none flex-1 min-h-0"
   >
     <div
       v-for="file in rows"

--- a/frontend/src/apps/drive/components/ListView.vue
+++ b/frontend/src/apps/drive/components/ListView.vue
@@ -1,32 +1,23 @@
 <template>
   <List
-    class="relative select-none pt-3 flex flex-col flex-1 min-h-0 list-row-px-3"
+    class="relative select-none pt-3 flex flex-col flex-1 min-h-0 list-row-px-5 sm:list-row-px-3"
     :columns="columnTracks"
     :row-height="40"
-    divider="inset"
+    divider="full"
   >
     <!-- Header is inside the scroll container so it shares the rows' width -->
     <div
       ref="scrollContainer"
-      class="flex-1 min-h-0 overflow-y-auto px-2 isolate [scrollbar-gutter:stable]"
+      class="flex-1 min-h-0 overflow-y-auto px-0 sm:px-2 isolate [scrollbar-gutter:stable]"
     >
       <ListHeader class="group sticky top-0 z-10 bg-surface-base">
-        <ListHeaderCell>
-          <Checkbox
-            class="shrink-0"
-            :class="selectAllState.some ? '' : 'invisible group-hover:visible'"
-            :model-value="selectAllState.all"
-            :indeterminate="selectAllState.some && !selectAllState.all"
-            @click.stop="toggleSelectAll"
-          />
-        </ListHeaderCell>
         <ListHeaderCellSort :direction="directionFor('file_name')" @click="toggleSort('file_name', __('Name'))">
           {{ __('Name') }}
           <template #suffix="{ direction }">
             <span class="block size-3.5" :class="sortIcon(direction)" />
           </template>
         </ListHeaderCellSort>
-        <ListHeaderCellSort :direction="directionFor('owner')" @click="toggleSort('owner', __('Owner'))">
+        <ListHeaderCellSort class="hidden sm:flex" :direction="directionFor('owner')" @click="toggleSort('owner', __('Owner'))">
           {{ __('Owner') }}
           <template #suffix="{ direction }">
             <span class="block size-3.5" :class="sortIcon(direction)" />
@@ -38,7 +29,7 @@
             <span class="block size-3.5" :class="sortIcon(direction)" />
           </template>
         </ListHeaderCellSort>
-        <ListHeaderCellSort :direction="directionFor('file_size')" @click="toggleSort('file_size', __('Size'))">
+        <ListHeaderCellSort class="hidden sm:flex" :direction="directionFor('file_size')" @click="toggleSort('file_size', __('Size'))">
           {{ __('Size') }}
           <template #suffix="{ direction }">
             <span class="block size-3.5" :class="sortIcon(direction)" />
@@ -73,19 +64,18 @@
           />
         </div>
         <ListRow v-if="loadingMore" class="pointer-events-none">
-          <ListCell />
           <ListCell>
             <div class="h-[16px] w-[16px] shrink-0 mr-2">
               <Skeleton class="h-[16px] w-[16px] rounded-sm" />
             </div>
             <Skeleton class="h-3.5 w-40 rounded" />
           </ListCell>
-          <ListCell>
+          <ListCell class="hidden sm:flex">
             <Skeleton class="size-5 shrink-0 mr-2 rounded-full" />
             <Skeleton class="h-3 w-16 rounded" />
           </ListCell>
           <ListCell><Skeleton class="h-3 w-20 rounded" /></ListCell>
-          <ListCell><Skeleton class="h-3 w-12 rounded" /></ListCell>
+          <ListCell class="hidden sm:flex"><Skeleton class="h-3 w-12 rounded" /></ListCell>
           <ListCell />
         </ListRow>
       </template>
@@ -96,7 +86,7 @@
 </template>
 <script setup>
 import { List, ListHeader, ListHeaderCell, ListHeaderCellSort, ListGroup, ListRow, ListCell } from 'frappe-ui/list'
-import { Checkbox, Skeleton, onOutsideClickDirective as vOnOutsideClick } from 'frappe-ui'
+import { Skeleton, onOutsideClickDirective as vOnOutsideClick } from 'frappe-ui'
 import { activeEntity, setActiveEntity } from '@/apps/drive/data/selection'
 import { computed, ref, watch } from 'vue'
 import ContextMenu from '@/apps/drive/components/ContextMenu.vue'
@@ -211,17 +201,6 @@ function toggleSelection(row, event) {
   lastSelectedName.value = row.name
 }
 
-const selectAllState = computed(() => {
-  const names = flatRows.value.map((r) => r.name)
-  const count = names.filter((n) => selections.value.has(n)).length
-  return { all: names.length > 0 && count === names.length, some: count > 0 }
-})
-function toggleSelectAll() {
-  selections.value = selectAllState.value.all
-    ? new Set()
-    : new Set(flatRows.value.map((r) => r.name))
-}
-
 const setActive = (entityName) => {
   const entity = props.folderContents.find((k) => k.name === entityName)
   selectedRow.value =
@@ -257,8 +236,8 @@ const contextMenu = (event, row) => {
 
 </script>
 <style>
-/* Match the inset row dividers — frappe-ui always spans this 1 / -1 */
+/* Keep the header divider aligned with the full-width row dividers. */
 [data-slot='list-header-border'] {
-  grid-column: 2 / -1;
+  grid-column: 1 / -1;
 }
 </style>

--- a/frontend/src/apps/drive/components/ListView.vue
+++ b/frontend/src/apps/drive/components/ListView.vue
@@ -3,7 +3,7 @@
     class="relative select-none pt-3 flex flex-col flex-1 min-h-0 list-row-px-5 sm:list-row-px-3"
     :columns="columnTracks"
     :row-height="40"
-    divider="full"
+    divider="inset"
   >
     <!-- Header is inside the scroll container so it shares the rows' width -->
     <div
@@ -11,6 +11,16 @@
       class="flex-1 min-h-0 overflow-y-auto px-0 sm:px-2 isolate [scrollbar-gutter:stable]"
     >
       <ListHeader class="group sticky top-0 z-10 bg-surface-base">
+        <ListHeaderCell>
+          <Checkbox
+            class="shrink-0"
+            :class="selectAllState.some ? '' : 'invisible group-hover:visible'"
+            :model-value="selectAllState.all"
+            :indeterminate="selectAllState.some && !selectAllState.all"
+            :aria-label="__('Select all visible items')"
+            @click.stop="toggleSelectAll"
+          />
+        </ListHeaderCell>
         <ListHeaderCellSort :direction="directionFor('file_name')" @click="toggleSort('file_name', __('Name'))">
           {{ __('Name') }}
           <template #suffix="{ direction }">
@@ -64,6 +74,7 @@
           />
         </div>
         <ListRow v-if="loadingMore" class="pointer-events-none">
+          <ListCell />
           <ListCell>
             <div class="h-[16px] w-[16px] shrink-0 mr-2">
               <Skeleton class="h-[16px] w-[16px] rounded-sm" />
@@ -86,7 +97,7 @@
 </template>
 <script setup>
 import { List, ListHeader, ListHeaderCell, ListHeaderCellSort, ListGroup, ListRow, ListCell } from 'frappe-ui/list'
-import { Skeleton, onOutsideClickDirective as vOnOutsideClick } from 'frappe-ui'
+import { Checkbox, Skeleton, onOutsideClickDirective as vOnOutsideClick } from 'frappe-ui'
 import { activeEntity, setActiveEntity } from '@/apps/drive/data/selection'
 import { computed, ref, watch } from 'vue'
 import ContextMenu from '@/apps/drive/components/ContextMenu.vue'
@@ -116,7 +127,6 @@ const selectedRow = ref(null)
 const rowEvent = ref(null)
 
 const scrollContainer = ref(null)
-defineExpose({ scrollEl: scrollContainer })
 
 // Sort state lives on `sortOrder` (shared with the toolbar's sort control on
 // grid view); clicking a header toggles direction on repeat-click of the same
@@ -181,6 +191,8 @@ const flatRows = computed(() =>
     .filter((i) => i.row)
     .map((i) => i.row)
 )
+const visibleNames = computed(() => flatRows.value.map(({ name }) => name))
+defineExpose({ scrollEl: scrollContainer, visibleNames })
 function toggleSelection(row, event) {
   if (event?.shiftKey && lastSelectedName.value) {
     const names = flatRows.value.map((r) => r.name)
@@ -199,6 +211,20 @@ function toggleSelection(row, event) {
   else next.add(row.name)
   selections.value = next
   lastSelectedName.value = row.name
+}
+
+const selectAllState = computed(() => {
+  const names = flatRows.value.map(({ name }) => name)
+  const count = names.filter((name) => selections.value.has(name)).length
+  return { all: names.length > 0 && count === names.length, some: count > 0 }
+})
+
+function toggleSelectAll() {
+  const names = flatRows.value.map(({ name }) => name)
+  const next = new Set(selections.value)
+  if (selectAllState.value.all) names.forEach((name) => next.delete(name))
+  else names.forEach((name) => next.add(name))
+  selections.value = next
 }
 
 const setActive = (entityName) => {
@@ -236,8 +262,8 @@ const contextMenu = (event, row) => {
 
 </script>
 <style>
-/* Keep the header divider aligned with the full-width row dividers. */
+/* Keep the header divider aligned with the inset row dividers. */
 [data-slot='list-header-border'] {
-  grid-column: 1 / -1;
+  grid-column: 2 / -1;
 }
 </style>

--- a/frontend/src/apps/drive/data/listColumns.ts
+++ b/frontend/src/apps/drive/data/listColumns.ts
@@ -10,12 +10,13 @@ export function useListColumns() {
   return computed(() =>
     isDesktop.value
       ? [
+          '16px',
           'minmax(0,1fr)',
           '10%',
           '15%',
           route.name === 'drive-Attachments' ? '25%' : '8%',
           '5%',
         ]
-      : ['minmax(0,1fr)', '7rem', '32px']
+      : ['16px', 'minmax(0,1fr)', '7rem', '32px']
   )
 }

--- a/frontend/src/apps/drive/data/listColumns.ts
+++ b/frontend/src/apps/drive/data/listColumns.ts
@@ -1,16 +1,21 @@
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
+import { useMediaQuery } from '@vueuse/core'
 
 // Grid tracks shared by the list view and its loading skeleton, so the
 // placeholder rows land exactly where the real ones will.
 export function useListColumns() {
   const route = useRoute()
-  return computed(() => [
-    '16px',
-    'minmax(0,1fr)',
-    '10%',
-    '15%',
-    route.name === 'drive-Attachments' ? '25%' : '8%',
-    '5%',
-  ])
+  const isDesktop = useMediaQuery('(min-width: 640px)')
+  return computed(() =>
+    isDesktop.value
+      ? [
+          'minmax(0,1fr)',
+          '10%',
+          '15%',
+          route.name === 'drive-Attachments' ? '25%' : '8%',
+          '5%',
+        ]
+      : ['minmax(0,1fr)', '7rem', '32px']
+  )
 }

--- a/frontend/src/apps/drive/utils/files.js
+++ b/frontend/src/apps/drive/utils/files.js
@@ -55,6 +55,17 @@ const FILE_ICONS = {
 
 export const WRITER_CONTENT_DOCTYPE = 'Writer Document'
 export const PRESENTATION_CONTENT_DOCTYPE = 'Presentation'
+
+export function displayFileName(file) {
+  const name = file.file_name || file.title || ''
+  const dot = name.lastIndexOf('.')
+  return dot === -1 ||
+    file.is_folder ||
+    file.content_doctype === WRITER_CONTENT_DOCTYPE ||
+    file.content_doctype === PRESENTATION_CONTENT_DOCTYPE
+    ? name
+    : name.slice(0, dot)
+}
 export const SHEET_CONTENT_DOCTYPE = 'Sheet'
 export const ATTACHMENT_CONTENT_DOCTYPE = 'File'
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -153,6 +153,7 @@ export default defineConfig(({ mode }) => ({
   },
   optimizeDeps: {
     include: [
+      'debug',
       'frappe-ui > feather-icons',
       'frappe-ui > lowlight',
       'yjs',


### PR DESCRIPTION
<img width="1440" height="900" alt="list-row-hover" src="https://github.com/user-attachments/assets/97ea256d-0f42-4930-8cb2-61054e91342b" />

<img width="1470" height="835" alt="Screenshot 2026-08-05 at 2 10 53 PM" src="https://github.com/user-attachments/assets/66badb7e-e5a8-4c3f-be77-13ae34e5a2c2" />

<img height="900" alt="drive-mobile-grid-view" src="https://github.com/user-attachments/assets/aeec6935-e621-4a76-8239-4b635a905704" />

<img height="900" alt="drive-mobile-list-view" src="https://github.com/user-attachments/assets/631ef9f7-e294-4782-a6ae-5bff698aea3b" />

- move filter to right side 
- better filter experience - selecting the same filter undo the filter and no more duplicate filters
- better mobile view with fewer columns and better filter/sort stacking
- hide file extension (existing docs, slides and sheets don't show them anyway)