### PR TITLE
fix(mail): sanitize name and validate email before indexing addresses

### DIFF
--- a/suite/mail/store/indexes/email_address.py
+++ b/suite/mail/store/indexes/email_address.py
@@ -1,8 +1,23 @@
 import re
 
+from frappe.utils import EMAIL_MATCH_PATTERN
+
 from suite.store.search_store import FieldSpec, SearchStore
 
 _TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
+
+# Quote characters some clients wrap display names in, e.g. "'Ayush Chaudhari'".
+_WRAPPING_QUOTES = "'\"`"
+
+
+def _sanitize_name(name: str | None) -> str | None:
+    """Strip whitespace and any matching quote pairs wrapping a display name."""
+
+    name = (name or "").strip()
+    while len(name) >= 2 and name[0] == name[-1] and name[0] in _WRAPPING_QUOTES:
+        name = name[1:-1].strip()
+
+    return name or None
 
 
 class EmailAddressIndex(SearchStore):
@@ -29,7 +44,7 @@ class EmailAddressIndex(SearchStore):
 
     def to_document(self, address: dict) -> dict:
         email = (address.get("email") or "").strip()
-        name = (address.get("name") or "").strip() or None
+        name = _sanitize_name(address.get("name"))
 
         return {
             "id": email.lower(),
@@ -39,11 +54,13 @@ class EmailAddressIndex(SearchStore):
         }
 
     def index_addresses(self, addresses: list[dict]) -> int:
-        """Upsert the given {name, email} dicts; skips entries without an email and dedupes the batch."""
+        """Upsert the given {name, email} dicts; dedupes the batch and silently skips entries whose
+        email is missing or syntactically invalid."""
 
         unique = {}
         for address in addresses:
-            if email := (address.get("email") or "").strip():
+            email = (address.get("email") or "").strip()
+            if EMAIL_MATCH_PATTERN.fullmatch(email):
                 unique[email.lower()] = address
 
         return self.index_documents(list(unique.values()))

--- a/suite/mail/tests/test_email_address_index.py
+++ b/suite/mail/tests/test_email_address_index.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+"""The email-address index's normalization contract: display names lose the quotes clients wrap
+them in, and only syntactically valid addresses ever reach the index."""
+
+import unittest
+from unittest import mock
+
+from suite.mail.store.indexes.email_address import EmailAddressIndex, _sanitize_name
+
+
+class SanitizeName(unittest.TestCase):
+    """``_sanitize_name`` — strip wrapping quote pairs, leave everything else alone."""
+
+    def test_single_quote_pair_is_stripped(self):
+        self.assertEqual(_sanitize_name("'Ayush Chaudhari'"), "Ayush Chaudhari")
+
+    def test_double_quote_pair_is_stripped(self):
+        self.assertEqual(_sanitize_name('"Ayush Chaudhari"'), "Ayush Chaudhari")
+
+    def test_backtick_pair_is_stripped(self):
+        self.assertEqual(_sanitize_name("`Ayush Chaudhari`"), "Ayush Chaudhari")
+
+    def test_nested_quote_pairs_are_stripped(self):
+        self.assertEqual(_sanitize_name("\"'Ayush Chaudhari'\""), "Ayush Chaudhari")
+
+    def test_whitespace_between_nested_pairs_is_stripped(self):
+        self.assertEqual(_sanitize_name(" ' \"Ayush\" ' "), "Ayush")
+
+    def test_unbalanced_quote_is_kept(self):
+        self.assertEqual(_sanitize_name("'Ayush"), "'Ayush")
+        self.assertEqual(_sanitize_name("Ayush'"), "Ayush'")
+
+    def test_mismatched_quotes_are_kept(self):
+        self.assertEqual(_sanitize_name("'Ayush\""), "'Ayush\"")
+
+    def test_interior_apostrophe_is_kept(self):
+        self.assertEqual(_sanitize_name("O'Brien"), "O'Brien")
+
+    def test_quotes_only_becomes_none(self):
+        self.assertIsNone(_sanitize_name("''"))
+        self.assertIsNone(_sanitize_name('" "'))
+
+    def test_blank_becomes_none(self):
+        self.assertIsNone(_sanitize_name(None))
+        self.assertIsNone(_sanitize_name(""))
+        self.assertIsNone(_sanitize_name("   "))
+
+
+class ToDocument(unittest.TestCase):
+    """``to_document`` — lowercased key, original-cased address, sanitized name in the text blob."""
+
+    def to_document(self, address):
+        # to_document touches no instance state, so skip SearchStore's on-disk constructor.
+        return EmailAddressIndex.to_document(mock.Mock(spec=EmailAddressIndex), address)
+
+    def test_name_is_sanitized_everywhere(self):
+        document = self.to_document({"name": "'Ayush Chaudhari'", "email": "Ayush@Frappe.io"})
+        self.assertEqual(
+            document,
+            {
+                "id": "ayush@frappe.io",
+                "email": "Ayush@Frappe.io",
+                "name": "Ayush Chaudhari",
+                "text": "Ayush Chaudhari Ayush@Frappe.io",
+            },
+        )
+
+    def test_missing_name_leaves_email_only_text(self):
+        document = self.to_document({"email": "ayush@frappe.io"})
+        self.assertIsNone(document["name"])
+        self.assertEqual(document["text"], "ayush@frappe.io")
+
+
+class IndexAddresses(unittest.TestCase):
+    """``index_addresses`` — silently drop entries without a syntactically valid email."""
+
+    def index_addresses(self, addresses):
+        """Return the addresses that survive filtering and reach ``index_documents``."""
+
+        index = mock.Mock(spec=EmailAddressIndex)
+        EmailAddressIndex.index_addresses(index, addresses)
+        return index.index_documents.call_args[0][0]
+
+    def test_valid_email_is_indexed(self):
+        address = {"name": "Ayush", "email": "ayush@frappe.io"}
+        self.assertEqual(self.index_addresses([address]), [address])
+
+    def test_missing_email_is_skipped(self):
+        self.assertEqual(self.index_addresses([{"name": "Ayush"}, {"name": "No Email", "email": ""}]), [])
+
+    def test_malformed_emails_are_skipped(self):
+        malformed = [
+            {"email": "not-an-email"},
+            {"email": "Ayush <ayush@frappe.io>"},
+            {"email": "ayush@frappe"},  # no TLD
+            {"email": "ayush @frappe.io"},
+            {"email": "@frappe.io"},
+        ]
+        self.assertEqual(self.index_addresses(malformed), [])
+
+    def test_valid_survives_malformed_neighbours(self):
+        valid = {"name": "Ayush", "email": "ayush@frappe.io"}
+        self.assertEqual(self.index_addresses([{"email": "not-an-email"}, valid]), [valid])
+
+    def test_batch_dedupes_case_insensitively(self):
+        first = {"name": "Ayush", "email": "ayush@frappe.io"}
+        second = {"name": "Ayush Chaudhari", "email": "Ayush@Frappe.io"}
+        self.assertEqual(self.index_addresses([first, second]), [second])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -76,7 +76,7 @@ suite.mail.patches.sync_jmap_accounts_for_configured_users
 suite.mail.patches.copy_sync_history_account_id_to_account
 suite.mail.patches.destroy_data_store
 suite.mail.patches.backfill_screened_email_address_account
-suite.mail.patches.rebuild_email_address_indexes
+suite.mail.patches.rebuild_email_address_indexes #2
 suite.mail.patches.enable_screening_for_personal_accounts
 suite.mail.patches.create_suite_user_role
 suite.mail.patches.rename_mail_admin_to_suite_admin


### PR DESCRIPTION
The email-address FTS index was storing display names verbatim, including the quote characters some clients wrap around them (e.g. `'Ayush Chaudhari'`), and indexing entries without checking the email syntax.

- Strip matching quote pairs (`'`, `"`, `` ` ``) wrapping display names before building the document, leaving interior apostrophes (`O'Brien`) and unbalanced quotes untouched.
- Validate email syntax in `index_addresses` with `frappe.utils.EMAIL_MATCH_PATTERN` (the same strict check `validate_email_address` uses internally); entries with a missing or invalid email are silently skipped. This covers both index rebuilds and inserts, since all writers funnel through `index_addresses`.
- Bump `rebuild_email_address_indexes` to `#2` in `patches.txt` so existing sites rebuild their indexes through the sanitized/validated path (the index is upsert-only, so stale bad entries wouldn't fix themselves).