### PR TITLE
refactor(meet): use `AvatarGroup` in grouped tile

### DIFF
--- a/frontend/src/apps/meet/components/AvatarGroup.vue
+++ b/frontend/src/apps/meet/components/AvatarGroup.vue
@@ -96,6 +96,7 @@ interface Props {
 	size?: AvatarGroupSize;
 	stackDirection?: StackDirection;
 	alignment?: "left" | "center";
+	showText?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -106,6 +107,7 @@ const props = withDefaults(defineProps<Props>(), {
 	size: "2xl",
 	stackDirection: "right",
 	alignment: "center",
+	showText: false,
 });
 
 const sizeClasses: Record<AvatarGroupSize, string> = {
@@ -132,7 +134,6 @@ const spacingClasses: Record<AvatarGroupSize, string> = {
 	"2xl": "-space-x-2",
 };
 
-const showText = computed(() => props.size === "2xl");
 const avatarWrapperClasses = computed(() => sizeClasses[props.size]);
 const extraAvatarWrapperClasses = computed(() => extraSizeClasses[props.size]);
 const spacingClass = computed(() => spacingClasses[props.size]);

--- a/frontend/src/apps/meet/components/GroupTile.vue
+++ b/frontend/src/apps/meet/components/GroupTile.vue
@@ -8,37 +8,18 @@
 		@keydown.enter.prevent="$emit('click')"
 		@keydown.space.prevent="$emit('click')"
 	>
-		<div v-if="participants && participants.length > 0" class="flex items-center justify-center">
-			<div class="relative flex">
-				<template v-for="(participant, index) in participants.slice(0, 2)" :key="participant.user_id">
-					<div
-						:class="[
-							'relative ring-1 ring-gray-800/70 rounded-full overflow-hidden bg-gradient-to-br from-gray-500 to-gray-600 flex items-center justify-center',
-							index > 0 ? '-ml-2' : '',
-							sizeClasses
-						]"
-					>
-						<img
-							v-if="participant.avatar"
-							:src="participant.avatar"
-							:alt="participant.user_name || participant.user_id"
-							class="w-full h-full object-cover"
-						/>
-						<span v-else class="font-semibold text-white" :class="textSizeClass">
-							{{ participant.initials || (participant.user_name || participant.user_id).slice(0, 2).toUpperCase() }}
-						</span>
-					</div>
-				</template>
-			</div>
-		</div>
-		<div class="text-sm text-white text-center leading-snug">
-			and {{ count }} others
-		</div>
+		<AvatarGroup
+			:participants="avatarParticipants"
+			:error="null"
+			:maxDisplayed="2"
+			size="2xl"
+		/>
 	</div>
 </template>
 
 <script setup lang="ts">
 import { computed } from "vue";
+import AvatarGroup from "./AvatarGroup.vue";
 
 const emit = defineEmits<{
 	click: [];
@@ -56,14 +37,11 @@ const props = defineProps<{
 	size?: "small" | "medium";
 }>();
 
-const sizeClasses = computed(() => {
-	// Responsive sizing: smaller on mobile, larger on desktop
-	return props.size === "medium"
-		? "w-12 h-12 sm:w-14 sm:h-14 md:w-16 md:h-16"
-		: "w-6 h-6 sm:w-7 sm:h-7 md:w-8 md:h-8";
-});
-
-const textSizeClass = computed(() => {
-	return props.size === "medium" ? "text-xl sm:text-3xl" : "text-xs";
-});
+const avatarParticipants = computed(() =>
+	(props.participants || []).map((participant) => ({
+		user_id: participant.user_id,
+		full_name: participant.user_name || participant.initials || participant.user_id,
+		avatar_url: participant.avatar,
+	})),
+);
 </script>

--- a/frontend/src/apps/meet/components/GroupTile.vue
+++ b/frontend/src/apps/meet/components/GroupTile.vue
@@ -12,7 +12,7 @@
 			:participants="avatarParticipants"
 			:error="null"
 			:maxDisplayed="2"
-			size="2xl"
+			:size="size"
 		/>
 	</div>
 </template>
@@ -34,7 +34,7 @@ const props = defineProps<{
 		avatar?: string;
 		initials?: string;
 	}>;
-	size?: "small" | "medium";
+	size?: "sm" | "md" | "lg" | "xl" | "2xl";
 }>();
 
 const avatarParticipants = computed(() =>

--- a/frontend/src/apps/meet/components/GroupTile.vue
+++ b/frontend/src/apps/meet/components/GroupTile.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="relative bg-gray-800/70 rounded-lg overflow-hidden min-h-0 flex flex-col gap-2 items-center justify-center cursor-pointer p-2"
+		class="relative bg-surface-gray-3 rounded-lg overflow-hidden min-h-0 flex flex-col gap-2 items-center justify-center cursor-pointer p-2"
 		:title="tooltip"
 		role="button"
 		tabindex="0"

--- a/frontend/src/apps/meet/components/MeetingLayout.vue
+++ b/frontend/src/apps/meet/components/MeetingLayout.vue
@@ -82,7 +82,7 @@
 				:count="displayParticipants.extra"
 				:tooltip="hiddenParticipantsTooltip"
 				:participants="displayParticipants.hidden"
-				:size="mode === 'sidebar' ? 'small' : 'medium'"
+				:size="mode === 'sidebar' ? 'xl' : '2xl'"
 				:style="tileStyle"
 				@click="emit('open-people-panel')"
 			/>

--- a/frontend/src/apps/meet/components/MeetingPreview.vue
+++ b/frontend/src/apps/meet/components/MeetingPreview.vue
@@ -59,6 +59,7 @@
 						:error="presenceError"
 						:loading="!hasFetchedParticipants"
 						:maxDisplayed="2"
+						:showText="true"
 						alignment="left"
 					/>
 


### PR DESCRIPTION

<img width="1470" height="835" alt="Screenshot 2026-08-05 at 4 47 56 PM" src="https://github.com/user-attachments/assets/3a3ffd87-003b-4558-b5de-f4b4572c0c21" />

