### PR TITLE
test(meet): run e2e tests as suite user

### DIFF
--- a/e2e/meet/fixtures/test.ts
+++ b/e2e/meet/fixtures/test.ts
@@ -12,6 +12,7 @@ import {
 	createMeetingViaApi,
 	type MeetingType,
 } from "../helpers/meeting";
+import { meetHost } from "../helpers/auth";
 
 const isCI = !!process.env.CI;
 const previewTimeout = isCI ? 45_000 : 20_000;
@@ -149,7 +150,7 @@ async function buildParticipant(browser: Browser): Promise<Participant> {
 			await joinFromPreview(page);
 		},
 		async joinAsHost(meetingId: string) {
-			await loginViaApi(context.request);
+			await loginViaApi(context.request, meetHost);
 			await page.goto(appUrl("/meet/"));
 			await page.goto(appUrl(`/meet/${meetingId}`));
 			await joinFromPreview(page);
@@ -165,7 +166,7 @@ export const test = base.extend<TestFixtures>({
 	hostPage: async ({ browser }, use) => {
 		const context = await browser.newContext();
 		await prepareContext(context);
-		await loginViaApi(context.request);
+		await loginViaApi(context.request, meetHost);
 		const page = await context.newPage();
 		await page.goto(appUrl("/meet/"));
 		await use(page);
@@ -175,7 +176,7 @@ export const test = base.extend<TestFixtures>({
 	// API-only meeting create so tests do not share rooms across workers.
 	createMeeting: async ({ playwright }, use) => {
 		const api = await playwright.request.newContext({ baseURL });
-		await loginViaApi(api);
+		await loginViaApi(api, meetHost);
 
 		await use(async (meetingType = "open") => {
 			await clearMeetingCreateRateLimit(api);

--- a/e2e/meet/global-setup.ts
+++ b/e2e/meet/global-setup.ts
@@ -1,4 +1,6 @@
-import type { FullConfig } from "@playwright/test";
+import { request, type FullConfig } from "@playwright/test";
+import { loginViaApi } from "../shared/auth";
+import { provisionMeetHost } from "./helpers/auth";
 
 async function waitForService(url: string, name: string): Promise<void> {
 	for (let attempt = 0; attempt < 40; attempt += 1) {
@@ -28,4 +30,9 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
 	// Meetings are created per-test for worker isolation; only health-check here.
 	await waitForService(baseURL, "Frappe Meet");
 	await waitForService(sfuHealthURL, "SFU server");
+
+	const api = await request.newContext({ baseURL });
+	await loginViaApi(api);
+	await provisionMeetHost(api);
+	await api.dispose();
 }

--- a/e2e/meet/helpers/auth.ts
+++ b/e2e/meet/helpers/auth.ts
@@ -6,6 +6,7 @@ export const meetHost: Credentials = {
 	email: "meet-e2e-host@example.com",
 	password: "MeetE2EHost!2026",
 };
+export const meetHostName = "Meet E2E Host";
 
 export async function provisionMeetHost(
 	request: APIRequestContext,

--- a/e2e/meet/helpers/auth.ts
+++ b/e2e/meet/helpers/auth.ts
@@ -1,0 +1,23 @@
+import type { APIRequestContext } from "@playwright/test";
+import type { Credentials } from "../../shared/auth";
+import { frappeData } from "../../shared/frappe";
+
+export const meetHost: Credentials = {
+	email: "meet-e2e-host@example.com",
+	password: "MeetE2EHost!2026",
+};
+
+export async function provisionMeetHost(
+	request: APIRequestContext,
+): Promise<void> {
+	const response = await request.post(
+		"/api/method/suite.meet.api.test_helpers.provision_host",
+	);
+	const credentials = await frappeData<Credentials>(response);
+	if (
+		credentials.email !== meetHost.email ||
+		credentials.password !== meetHost.password
+	) {
+		throw new Error("Meet host provisioning returned unexpected credentials");
+	}
+}

--- a/e2e/meet/specs/chat.spec.ts
+++ b/e2e/meet/specs/chat.spec.ts
@@ -25,7 +25,9 @@ test.describe("Chat", () => {
 		await hostPage.getByRole("button", { name: "Send message" }).click();
 
 		await guest.page.getByRole("button", { name: "Show Chat" }).click();
-		await expect(guest.page.getByText(message, { exact: true })).toBeVisible();
+		await expect(
+			guest.page.getByTestId("chat-panel").getByText(message, { exact: true }),
+		).toBeVisible();
 	});
 
 	test("unread badge appears when chat is closed and clears when opened", async ({
@@ -56,7 +58,9 @@ test.describe("Chat", () => {
 		await expect(unreadBadge).toHaveCount(1);
 
 		await chatButton.click();
-		await expect(hostPage.getByText(message, { exact: true })).toBeVisible();
+		await expect(
+			hostPage.getByTestId("chat-panel").getByText(message, { exact: true }),
+		).toBeVisible();
 		await expect(unreadBadge).toHaveCount(0);
 	});
 });

--- a/e2e/meet/specs/e2ee.spec.ts
+++ b/e2e/meet/specs/e2ee.spec.ts
@@ -44,8 +44,10 @@ async function enableE2EEInSettings(page: Page): Promise<void> {
 		timeout: 30_000,
 	});
 	await page.keyboard.press("Escape");
-	await page.waitForTimeout(150);
-	await page.keyboard.press("Escape");
+	if (await toggle.isVisible()) {
+		await page.mouse.click(20, 20);
+	}
+	await expect(toggle).not.toBeVisible();
 }
 
 async function openMeetingInformation(page: Page): Promise<void> {
@@ -71,7 +73,7 @@ async function expectScreenShareReceiving(page: Page): Promise<void> {
 
 async function clickScreenShare(page: Page): Promise<void> {
 	await page
-		.getByRole("button", { name: "Toggle Screen Share" })
+		.locator('button[aria-label="Toggle Screen Share"]')
 		.evaluate((button) => (button as HTMLButtonElement).click());
 }
 
@@ -124,6 +126,7 @@ test.describe("E2EE", () => {
 
 	test.describe("heavy coverage", () => {
 		test.skip(!!process.env.CI, "Skipped in CI to keep media e2e lightweight");
+		test.describe.configure({ timeout: 180_000 });
 
 	test("active participants keep receiving streams after E2EE is enabled mid-call", async ({
 		hostPage,
@@ -216,8 +219,13 @@ test.describe("E2EE", () => {
 			guest.page.getByRole("toolbar", { name: "Meeting controls" }),
 		).toBeVisible();
 
-		const hostErrors = capturePageErrors(hostPage, ["request_consumer_keyframe"]);
-		const guestErrors = capturePageErrors(guest.page, ["request_consumer_keyframe"]);
+		const teardownErrors = [
+			"request_consumer_keyframe",
+			"refresh_sfu_token",
+			"403 (FORBIDDEN)",
+		];
+		const hostErrors = capturePageErrors(hostPage, teardownErrors);
+		const guestErrors = capturePageErrors(guest.page, teardownErrors);
 
 		await hostPage.goto(appUrl(`/meet/${meetingId}`));
 		await joinFromPreview(hostPage);

--- a/e2e/meet/specs/e2ee.spec.ts
+++ b/e2e/meet/specs/e2ee.spec.ts
@@ -6,6 +6,7 @@ import {
 	joinHostAndGuest,
 	appUrl,
 } from "../fixtures/test";
+import { meetHostName } from "../helpers/auth";
 import {
 	expectRemoteVideoReceiving,
 	expectVideoReceiving,
@@ -22,7 +23,7 @@ async function expectParticipantsAndVideo(
 	await expect(guestPage.locator("[data-participant-id]")).toHaveCount(2, {
 		timeout: 30_000,
 	});
-	await expectRemoteVideoReceiving(guestPage, "Administrator");
+	await expectRemoteVideoReceiving(guestPage, meetHostName);
 	await expectRemoteVideoReceiving(hostPage, guestName);
 }
 
@@ -64,7 +65,7 @@ async function readFingerprint(page: Page): Promise<string> {
 async function expectScreenShareReceiving(page: Page): Promise<void> {
 	const tile = page.locator("[data-tile-id^='screenshare-']");
 	await expect(tile).toHaveCount(1, { timeout: 45_000 });
-	await expect(page.getByText("Administrator's screen")).toBeVisible();
+	await expect(page.getByText(`${meetHostName}'s screen`)).toBeVisible();
 	await expectVideoReceiving(tile.locator("video").first());
 }
 
@@ -135,14 +136,14 @@ test.describe("E2EE", () => {
 
 		await joinHostAndGuest(hostPage, guest, meetingId, guestName);
 
-		await expectRemoteVideoReceiving(guest.page, "Administrator");
+		await expectRemoteVideoReceiving(guest.page, meetHostName);
 		await expectRemoteVideoReceiving(hostPage, guestName);
 
 		const hostErrors = capturePageErrors(hostPage);
 		await enableE2EEInSettings(hostPage);
 		hostErrors.assertNoErrors();
 
-		await expectRemoteVideoReceiving(guest.page, "Administrator");
+		await expectRemoteVideoReceiving(guest.page, meetHostName);
 		await expectRemoteVideoReceiving(hostPage, guestName);
 	});
 
@@ -157,12 +158,12 @@ test.describe("E2EE", () => {
 
 		await joinHostAndGuest(hostPage, guest, meetingId, guestName);
 
-		await expectRemoteVideoReceiving(guest.page, "Administrator");
+		await expectRemoteVideoReceiving(guest.page, meetHostName);
 		await expectRemoteVideoReceiving(hostPage, guestName);
 
 		await enableE2EEInSettings(hostPage);
 
-		await expectRemoteVideoReceiving(guest.page, "Administrator");
+		await expectRemoteVideoReceiving(guest.page, meetHostName);
 		await expectRemoteVideoReceiving(hostPage, guestName);
 
 		await guest.page.goto(appUrl("/meet/"));
@@ -181,7 +182,7 @@ test.describe("E2EE", () => {
 		await expect(guest.page.locator("[data-participant-id]")).toHaveCount(2, {
 			timeout: 30_000,
 		});
-		await expectRemoteVideoReceiving(guest.page, "Administrator");
+		await expectRemoteVideoReceiving(guest.page, meetHostName);
 		await expectRemoteVideoReceiving(hostPage, guestName);
 		hostErrors.assertNoErrors();
 		guestErrors.assertNoErrors();
@@ -198,12 +199,12 @@ test.describe("E2EE", () => {
 
 		await joinHostAndGuest(hostPage, guest, meetingId, guestName);
 
-		await expectRemoteVideoReceiving(guest.page, "Administrator");
+		await expectRemoteVideoReceiving(guest.page, meetHostName);
 		await expectRemoteVideoReceiving(hostPage, guestName);
 
 		await enableE2EEInSettings(hostPage);
 
-		await expectRemoteVideoReceiving(guest.page, "Administrator");
+		await expectRemoteVideoReceiving(guest.page, meetHostName);
 		await expectRemoteVideoReceiving(hostPage, guestName);
 
 		await hostPage.goto(appUrl("/meet/"));
@@ -228,7 +229,7 @@ test.describe("E2EE", () => {
 			timeout: 45_000,
 		});
 
-		await expectRemoteVideoReceiving(guest.page, "Administrator");
+		await expectRemoteVideoReceiving(guest.page, meetHostName);
 		await expectRemoteVideoReceiving(hostPage, guestName);
 		hostErrors.assertNoErrors();
 		guestErrors.assertNoErrors();
@@ -245,7 +246,7 @@ test.describe("E2EE", () => {
 
 		await joinHostAndGuest(hostPage, guest, meetingId, guestName);
 
-		await expectRemoteVideoReceiving(guest.page, "Administrator");
+		await expectRemoteVideoReceiving(guest.page, meetHostName);
 		await expectRemoteVideoReceiving(hostPage, guestName);
 
 		await enableE2EEInSettings(hostPage);
@@ -276,12 +277,12 @@ test.describe("E2EE", () => {
 
 		await joinHostAndGuest(hostPage, guestA, meetingId, guestAName);
 
-		await expectRemoteVideoReceiving(guestA.page, "Administrator");
+		await expectRemoteVideoReceiving(guestA.page, meetHostName);
 		await expectRemoteVideoReceiving(hostPage, guestAName);
 
 		await enableE2EEInSettings(hostPage);
 
-		await expectRemoteVideoReceiving(guestA.page, "Administrator");
+		await expectRemoteVideoReceiving(guestA.page, meetHostName);
 		await expectRemoteVideoReceiving(hostPage, guestAName);
 
 		await guestB.joinAsGuest(meetingId, guestBName);
@@ -303,9 +304,9 @@ test.describe("E2EE", () => {
 		await expectRemoteVideoReceiving(hostPage, guestAName);
 		await expectRemoteVideoReceiving(hostPage, guestBName);
 		await expectRemoteVideoReceiving(hostPage, guestCName);
-		await expectRemoteVideoReceiving(guestA.page, "Administrator");
-		await expectRemoteVideoReceiving(guestB.page, "Administrator");
-		await expectRemoteVideoReceiving(guestC.page, "Administrator");
+		await expectRemoteVideoReceiving(guestA.page, meetHostName);
+		await expectRemoteVideoReceiving(guestB.page, meetHostName);
+		await expectRemoteVideoReceiving(guestC.page, meetHostName);
 
 		const guestAFingerprint = await readFingerprint(guestA.page);
 		expect(await readFingerprint(guestB.page)).toBe(guestAFingerprint);

--- a/e2e/meet/specs/media-controls.spec.ts
+++ b/e2e/meet/specs/media-controls.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, joinHostAndGuest } from "../fixtures/test";
+import { meetHostName } from "../helpers/auth";
 import {
 	expectRemoteVideoReceiving,
 	expectVideoReceiving,
@@ -19,12 +20,12 @@ test.describe("Media controls", () => {
 			meetingId,
 			`Guest Media ${test.info().parallelIndex}`,
 		);
-		await expectRemoteVideoReceiving(guest.page, "Administrator");
+		await expectRemoteVideoReceiving(guest.page, meetHostName);
 
 		await hostPage.getByRole("button", { name: /Toggle Video/ }).click();
 		await hostPage.getByRole("button", { name: /Toggle Audio/ }).click();
 
-		const hostTile = guest.page.getByTestId("participant-tile-Administrator");
+		const hostTile = guest.page.getByTestId(`participant-tile-${meetHostName}`);
 		await expect(hostTile).toBeVisible();
 		await expect(hostTile).toHaveAttribute("data-audio-enabled", "false");
 		await expect(hostTile).toHaveAttribute("data-video-enabled", "false");
@@ -48,7 +49,7 @@ test.describe("Media controls", () => {
 		await hostPage.getByRole("button", { name: "Toggle Screen Share" }).click();
 
 		await expect(guest.page.locator("[data-tile-id^='screenshare-']")).toHaveCount(1);
-		await expect(guest.page.getByText("Administrator's screen")).toBeVisible();
+		await expect(guest.page.getByText(`${meetHostName}'s screen`)).toBeVisible();
 		await expectVideoReceiving(
 			guest.page.locator("[data-tile-id^='screenshare-'] video").first(),
 		);
@@ -56,6 +57,6 @@ test.describe("Media controls", () => {
 		await hostPage.getByRole("button", { name: "Toggle Screen Share" }).click();
 
 		await expect(guest.page.locator("[data-tile-id^='screenshare-']")).toHaveCount(0);
-		await expect(guest.page.getByText("Administrator's screen")).toHaveCount(0);
+		await expect(guest.page.getByText(`${meetHostName}'s screen`)).toHaveCount(0);
 	});
 });

--- a/e2e/meet/specs/media-controls.spec.ts
+++ b/e2e/meet/specs/media-controls.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, joinHostAndGuest } from "../fixtures/test";
-import { meetHostName } from "../helpers/auth";
+import { meetHost, meetHostName } from "../helpers/auth";
 import {
 	expectRemoteVideoReceiving,
 	expectVideoReceiving,
@@ -25,7 +25,7 @@ test.describe("Media controls", () => {
 		await hostPage.getByRole("button", { name: /Toggle Video/ }).click();
 		await hostPage.getByRole("button", { name: /Toggle Audio/ }).click();
 
-		const hostTile = guest.page.getByTestId(`participant-tile-${meetHostName}`);
+		const hostTile = guest.page.getByTestId(`participant-tile-${meetHost.email}`);
 		await expect(hostTile).toBeVisible();
 		await expect(hostTile).toHaveAttribute("data-audio-enabled", "false");
 		await expect(hostTile).toHaveAttribute("data-video-enabled", "false");

--- a/e2e/meet/specs/multi-participant.spec.ts
+++ b/e2e/meet/specs/multi-participant.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, joinFromPreview, appUrl } from "../fixtures/test";
+import { meetHostName } from "../helpers/auth";
 import { expectRemoteVideoReceiving } from "../helpers/media";
 
 test.describe("Multi participant", () => {
@@ -26,14 +27,14 @@ test.describe("Multi participant", () => {
 		await Promise.all([
 			expectRemoteVideoReceiving(hostPage, "Guest One"),
 			expectRemoteVideoReceiving(hostPage, "Guest Two"),
-			expectRemoteVideoReceiving(guestOne.page, "Administrator"),
-			expectRemoteVideoReceiving(guestTwo.page, "Administrator"),
+			expectRemoteVideoReceiving(guestOne.page, meetHostName),
+			expectRemoteVideoReceiving(guestTwo.page, meetHostName),
 		]);
 		await hostPage.getByRole("button", { name: "Show Participants" }).click();
 
 		const peoplePanel = hostPage.getByTestId("people-panel");
 		await expect(peoplePanel).toContainText("People");
-		await expect(peoplePanel).toContainText("Administrator");
+		await expect(peoplePanel).toContainText(meetHostName);
 		await expect(peoplePanel).toContainText("Guest One");
 		await expect(peoplePanel).toContainText("Guest Two");
 	});

--- a/e2e/meet/specs/sfu-reconnect.spec.ts
+++ b/e2e/meet/specs/sfu-reconnect.spec.ts
@@ -1,4 +1,5 @@
 import { expect, joinHostAndGuest, test } from "../fixtures/test";
+import { meetHostName } from "../helpers/auth";
 import { expectRemoteVideoReceiving } from "../helpers/media";
 
 const disconnectTestEnabled =
@@ -25,7 +26,7 @@ test.describe("SFU reconnect", () => {
 
 		await joinHostAndGuest(hostPage, guest, meetingId, guestName);
 		await expectRemoteVideoReceiving(hostPage, guestName);
-		await expectRemoteVideoReceiving(guest.page, "Administrator");
+		await expectRemoteVideoReceiving(guest.page, meetHostName);
 
 		await guest.context.setOffline(true);
 		await expect(hostPage.locator("[data-participant-id]")).toHaveCount(1, {
@@ -40,6 +41,6 @@ test.describe("SFU reconnect", () => {
 			timeout: 45_000,
 		});
 		await expectRemoteVideoReceiving(hostPage, guestName);
-		await expectRemoteVideoReceiving(guest.page, "Administrator");
+		await expectRemoteVideoReceiving(guest.page, meetHostName);
 	});
 });

--- a/suite/meet/api/test_helpers.py
+++ b/suite/meet/api/test_helpers.py
@@ -4,6 +4,35 @@
 import frappe
 from frappe.tests.utils import whitelist_for_tests
 
+E2E_HOST_EMAIL = "meet-e2e-host@example.com"
+E2E_HOST_PASSWORD = "MeetE2EHost!2026"
+
+
+@whitelist_for_tests(methods=["POST"])
+def provision_host() -> dict[str, str]:
+    frappe.only_for("System Manager")
+
+    if frappe.db.exists("User", E2E_HOST_EMAIL):
+        user = frappe.get_doc("User", E2E_HOST_EMAIL)
+        user.enabled = 1
+        user.new_password = E2E_HOST_PASSWORD
+        user.save(ignore_permissions=True)
+    else:
+        user = frappe.get_doc(
+            {
+                "doctype": "User",
+                "email": E2E_HOST_EMAIL,
+                "first_name": "Meet E2E Host",
+                "enabled": 1,
+                "send_welcome_email": 0,
+                "new_password": E2E_HOST_PASSWORD,
+            }
+        )
+        user.insert(ignore_permissions=True)
+
+    user.add_roles("Suite User")
+    return {"email": E2E_HOST_EMAIL, "password": E2E_HOST_PASSWORD}
+
 
 @whitelist_for_tests()
 def clear_create_rate_limit() -> None:


### PR DESCRIPTION
E2E tests ended up being broken due to #96 since it required onboarding to be completed for System Manager users. And we were using admin user for tests (which I shouldn't have done in the first place 🙈)