### PR TITLE
fix(drive): allow uploads with unknown MIME types

### DIFF
--- a/suite/drive/api/tests/test_files.py
+++ b/suite/drive/api/tests/test_files.py
@@ -142,6 +142,15 @@ class TestDriveFilesAPI(IntegrationTestCase):
             with self.assertRaises(frappe.PermissionError):
                 upload_file(total_file_size=6, parent=self.folder.name)
 
+    def test_upload_with_unknown_mime_type(self):
+        with self.set_user(OWNER):
+            uploaded = self.upload(b"unknown file contents", "upload.unknownextension")
+
+            self.assertEqual(uploaded.file_type, "Unknown")
+            self.assertFalse(uploaded.mime_type)
+            with FileManager().get_file(uploaded) as stored:
+                self.assertEqual(stored.read(), b"unknown file contents")
+
     def test_ordered_chunks_are_assembled_byte_for_byte(self):
         session = frappe.generate_hash(12)
         with self.set_user(OWNER):

--- a/suite/drive/utils/files.py
+++ b/suite/drive/utils/files.py
@@ -59,7 +59,7 @@ class FileManager:
 
     def can_create_thumbnail(self, file):
         # Only images, videos and PDFs get thumbnails.
-        if not hasattr(file, "mime_type"):
+        if not getattr(file, "mime_type", None):
             return False
         return file.mime_type.startswith(("image", "video")) or file.mime_type == "application/pdf"
 


### PR DESCRIPTION
fix #430 