### PR TITLE
fix(mail): raise on JMAP method-level errors in changes calls

### DIFF
--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -1365,6 +1365,10 @@ def fetch_changes(user: str, account: str, email_state: str | None = None, ctx: 
 
         result = email_service.changes(current_state)
 
+        if not result:
+            logger.warning("empty-changes-response")
+            return
+
         if created_ids := result["created"]:
             logger.info("new-messages-created", count=len(created_ids))
 

--- a/suite/mail/jmap/services/core.py
+++ b/suite/mail/jmap/services/core.py
@@ -376,9 +376,20 @@ class CoreService(CoreServiceHelper):
         )
 
     def _changes(self, since_state: str) -> dict:
-        """Internal method to get changes of the specified type since a given state using the JMAP 'changes' method."""
+        """Internal method to get changes of the specified type since a given state using the JMAP 'changes' method.
 
-        return self._exec("changes", sinceState=since_state)
+        A method-level failure (e.g. `forbidden`, `cannotCalculateChanges`) comes back as an
+        `["error", {...}]` method response; raise instead of returning it, since every caller
+        unwraps the first method response as if it were a changes result.
+        """
+
+        response = self._exec("changes", sinceState=since_state)
+
+        for name, body, _call_id in response.get("methodResponses") or []:
+            if name == "error":
+                raise RuntimeError(f"{self._type}/changes failed: {body}")
+
+        return response
 
     def upload_blob(self, blob: bytes | str, content_type: str = "message/rfc822") -> dict:
         """Uploads a blob to the JMAP server using the upload URL, and returns the response containing the blob ID and other metadata."""

--- a/suite/mail/tests/test_mail_push_sync.py
+++ b/suite/mail/tests/test_mail_push_sync.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+"""How the push-sync path reacts when the JMAP server cannot answer an ``Email/changes`` call:
+method-level errors surface as exceptions instead of flowing downstream as fake changes results,
+and the stored sync state is never advanced on failure."""
+
+import unittest
+from unittest import mock
+
+from suite.mail.doctype.mail_message import mail_message
+from suite.mail.jmap.services.mail.email import EmailService
+
+FORBIDDEN = {"type": "forbidden", "description": "You are not authorized to perform this action"}
+
+
+class EmailServiceChanges(unittest.TestCase):
+    """``EmailService.changes`` — unwrap real results, raise on method-level errors."""
+
+    def _service(self, response: dict) -> EmailService:
+        service = EmailService("f7", mock.MagicMock())
+        service._exec = mock.MagicMock(return_value=response)
+        return service
+
+    def test_returns_first_method_response_body(self):
+        body = {"created": [], "updated": ["e1"], "destroyed": [], "newState": "s2", "hasMoreChanges": False}
+        service = self._service({"methodResponses": [["Email/changes", body, "0"]]})
+
+        self.assertEqual(service.changes("s1"), body)
+
+    def test_raises_on_method_level_error(self):
+        service = self._service({"methodResponses": [["error", FORBIDDEN, "0"]]})
+
+        with self.assertRaises(RuntimeError) as ctx:
+            service.changes("s1")
+
+        self.assertIn("Email/changes failed", str(ctx.exception))
+        self.assertIn("forbidden", str(ctx.exception))
+
+    def test_returns_empty_dict_without_method_responses(self):
+        self.assertEqual(self._service({}).changes("s1"), {})
+
+
+class FetchChanges(unittest.TestCase):
+    """``fetch_changes`` — server failures are logged and leave the sync state untouched."""
+
+    def _run(self, changes: mock.Mock) -> tuple[mock.Mock, mock.Mock]:
+        with (
+            mock.patch.object(mail_message, "get_sync_state", return_value="s1"),
+            mock.patch.object(mail_message, "update_sync_state") as update_sync_state,
+            mock.patch.object(mail_message, "get_jmap_connection"),
+            mock.patch.object(mail_message, "MailboxService"),
+            mock.patch.object(mail_message, "EmailService") as email_service,
+            mock.patch.object(mail_message, "log_mail_error") as log_mail_error,
+        ):
+            email_service.return_value.changes = changes
+            mail_message.fetch_changes("user@example.test", "f7", email_state="s2")
+
+        return update_sync_state, log_mail_error
+
+    def test_method_level_error_is_logged_and_preserves_state(self):
+        changes = mock.MagicMock(side_effect=RuntimeError(f"Email/changes failed: {FORBIDDEN}"))
+
+        update_sync_state, log_mail_error = self._run(changes)
+
+        log_mail_error.assert_called_once()
+        update_sync_state.assert_not_called()
+
+    def test_empty_response_is_not_an_error_and_preserves_state(self):
+        update_sync_state, log_mail_error = self._run(mock.MagicMock(return_value={}))
+
+        log_mail_error.assert_not_called()
+        update_sync_state.assert_not_called()


### PR DESCRIPTION
## Problem

`fetch_changes` crashed with a misleading `KeyError: 'created'` when the JMAP server answered `Email/changes` with a method-level error response:

```
result = {'type': 'forbidden', 'description': 'You are not authorized to perform this action'}
builtins.KeyError: 'created'
```

`EmailService.changes()` (and the equivalent `changes()` wrapper in the other seven services) unwraps the first method response as if it were always a changes result, so an `["error", {...}]` response flowed downstream as-is.

## Fix

- `CoreService._changes()` now raises a `RuntimeError` naming the JMAP error (e.g. `Email/changes failed: {'type': 'forbidden', ...}`) when the server returns an `error` method response. The check lives in the shared base method so all services with a `changes()` wrapper are covered.
- `fetch_changes` bails out with a warning if `changes()` returns an empty dict (the no-`methodResponses` path), which would previously hit the same `KeyError`.

The failure is still logged via the existing handler in `fetch_changes`, but as a readable error naming the actual server response, and the sync state is left untouched.