### PR TITLE
fix(mail): stop assigning the Tenant Administrator role on Stalwart

### DIFF
--- a/suite/mail/api/admin.py
+++ b/suite/mail/api/admin.py
@@ -11,13 +11,8 @@ from frappe.utils import cint, flt, validate_email_address
 from pypika import Case, Order
 
 from suite.mail.api.utils import get_avatar_url
-from suite.mail.doctype.mail_account_request.mail_account_request import (
-    STALWART_DEFAULT_ADMIN_ROLES,
-    STALWART_DEFAULT_USER_ROLES,
-)
 from suite.mail.doctype.user_account.user_account import get_user_personal_jmap_account
 from suite.mail.stalwart import (
-    add_account_role,
     get_account_metadata,
     get_account_service,
     get_action_service,
@@ -34,7 +29,6 @@ from suite.mail.stalwart import (
     get_queued_message_service,
     get_report_service,
     get_role_service,
-    remove_account_role,
 )
 from suite.mail.stalwart import get_domains as get_stalwart_domains
 from suite.mail.stalwart import get_permissions as get_stalwart_permissions
@@ -798,7 +792,11 @@ def update_member(
     locale: str | None = None,
     time_zone: str | None = None,
 ) -> None:
-    """Updates a member's role, display name, quota, locale and time zone on Frappe and Stalwart."""
+    """Updates a member's role, display name, quota, locale and time zone.
+
+    The role only toggles the Suite Admin role on Frappe; Stalwart roles stay untouched, since
+    Suite Admin calls are proxied through the configured Stalwart admin credentials.
+    """
 
     check_admin_permission("update members", member_id)
     check_member_target(member_id)
@@ -821,18 +819,6 @@ def update_member(
 
     account_id = _member_account(member_id)
     account_service = get_account_service()
-
-    # Role: the base "User" Stalwart role always stays; only the admin-only roles are toggled.
-    if role is not None:
-        extra_roles = list(set(STALWART_DEFAULT_ADMIN_ROLES) - set(STALWART_DEFAULT_USER_ROLES))
-        toggle = add_account_role if role == "admin" else remove_account_role
-        execute_with_logging(
-            func=lambda: [toggle(member_id, r) for r in extra_roles],
-            title=_("Failed to update roles for {0}").format(member_id),
-            user_message=_("An error occurred while updating the role, check error logs for more details."),
-            with_context=False,
-            module="Mail",
-        )
 
     if not account_id:
         return

--- a/suite/mail/doctype/mail_account_request/mail_account_request.json
+++ b/suite/mail/doctype/mail_account_request/mail_account_request.json
@@ -198,7 +198,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "Stalwart roles (one per line) assigned to the account on creation. Left blank, defaults follow the Is Admin flag: User, plus Tenant Administrator for admins.",
+   "description": "Stalwart roles (one per line) assigned to the account on creation. Left blank, defaults to User.",
    "fieldname": "roles",
    "fieldtype": "Small Text",
    "label": "Stalwart Roles",
@@ -207,7 +207,7 @@
   },
   {
    "default": "0",
-   "description": "If enabled, the created user gets the Suite Admin role in Frappe and the Tenant Administrator role on Stalwart.",
+   "description": "If enabled, the created user gets the Suite Admin role in Frappe.",
    "fieldname": "is_admin",
    "fieldtype": "Check",
    "label": "Is Admin",

--- a/suite/mail/doctype/mail_account_request/mail_account_request.py
+++ b/suite/mail/doctype/mail_account_request/mail_account_request.py
@@ -28,7 +28,6 @@ from suite.utils import execute_with_logging, generate_otp
 from suite.utils.user import is_suite_admin, is_system_manager
 
 STALWART_DEFAULT_USER_ROLES = ["User"]
-STALWART_DEFAULT_ADMIN_ROLES = ["User", "Tenant Administrator"]
 
 # How long a signup OTP stays valid. Only its hash is kept (in cache); the code itself
 # travels by email and is never stored.
@@ -90,7 +89,7 @@ class MailAccountRequest(Document):
         if roles := _lines(self.roles):
             return roles
 
-        return list(STALWART_DEFAULT_ADMIN_ROLES if self.is_admin else STALWART_DEFAULT_USER_ROLES)
+        return list(STALWART_DEFAULT_USER_ROLES)
 
     @property
     def domain(self) -> str:

--- a/suite/mail/doctype/screened_email_address/screened_email_address.py
+++ b/suite/mail/doctype/screened_email_address/screened_email_address.py
@@ -47,7 +47,7 @@ class ScreenedEmailAddress(Document):
         if not (is_system_manager(user) or is_suite_admin(user)):
             frappe.throw(
                 _(
-                    "Only a System Manager or Mail Admin can manage global screened email addresses (without an account)."
+                    "Only a System Manager or Suite Admin can manage global screened email addresses (without an account)."
                 ),
                 frappe.PermissionError,
             )


### PR DESCRIPTION
Mail Admin calls are proxied through the configured Stalwart admin credentials, so admin accounts don't need the Tenant Administrator role on Stalwart — the `User` role is sufficient.

- `is_admin` on Mail Account Request now only grants the Suite Admin role in Frappe; the default Stalwart roles are just `User` for everyone (an explicit `roles` value still wins).
- `update_member` no longer toggles Stalwart roles when promoting/demoting a member — the change is Frappe-only.
- Updated the `roles` / `is_admin` field descriptions accordingly.
- Corrected the global screened email address permission error message to say Suite Admin instead of Mail Admin.

Note: existing admin accounts that already carry Tenant Administrator on Stalwart keep it — this only stops assigning it going forward.

Tests: `test_admin_roles_and_disable` (9) and `test_admin_members` (5) pass against a live Stalwart.