### PR TITLE
fix(deps): widen beautifulsoup4 pin to resolve with frappe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     # kept for other suite modules (drive dropped these): PyJWT→meet, Markdown→writer, beautifulsoup4→mail/client
     "PyJWT>=2.8.0",
     "Markdown==3.8.2",
-    "beautifulsoup4~=4.15.0",
+    "beautifulsoup4>=4.13.5,<5",
     # mail
     "lmdb~=1.7.1",
     "wrapt~=1.17.3",


### PR DESCRIPTION
frappe pins `beautifulsoup4~=4.13.5` while suite pinned `~=4.15.0` — the two ranges never overlap, so a strict resolver (uv, as used by pilot) can't install frappe and suite together. This widens the pin to a range that includes frappe's.

Cherry-picked from #485 — all credit to @Delte for the fix. Opened fresh since #485's source branch picked up an unrelated commit that shouldn't be merged.

Closes #485