### PR TITLE
fix(writer): marking a document as favourite in Writer sync to Drive's Favourites tab

### DIFF
--- a/frontend/src/apps/drive/resources/files.js
+++ b/frontend/src/apps/drive/resources/files.js
@@ -197,6 +197,22 @@ export const toggleFav = createResource({
       toast(`${toggleFav.params.entities.length} items unfavourited`)
     else toast(`${toggleFav.params.entities.length} items favourited`)
   },
+  onError() {
+    if (toggleFav.params?.entities) {
+      const reverted = toggleFav.params.entities.map((e) => ({
+        ...e,
+        is_favourite: !e.is_favourite,
+      }))
+      getFavourites.setData((d) => {
+        const names = reverted.map((r) => r.name)
+        return reverted[0].is_favourite
+          ? [...(d ?? []), ...reverted]
+          : (d ?? []).filter(({ name }) => !names.includes(name))
+      })
+      mutate(reverted, (el, { is_favourite }) => (el.is_favourite = is_favourite))
+    }
+    toast.error('Failed to update favourite status')
+  },
 })
 
 export const clearRecent = createResource({

--- a/frontend/src/apps/writer/components/Navbar.vue
+++ b/frontend/src/apps/writer/components/Navbar.vue
@@ -239,11 +239,18 @@ const fileActions = computed(() =>
               icon: LucideStar,
               onClick: () => {
                 props.file.doc.is_favourite = true
-                toggleFav.submit({
-                  entities: [{ name: props.file.doc.name, is_favourite: true }],
-                })
+                toggleFav.submit(
+                  {
+                    entities: [{ name: props.file.doc.name, is_favourite: true }],
+                  },
+                  {
+                    onError: () => {
+                      props.file.doc.is_favourite = false
+                    },
+                  }
+                )
               },
-              isEnabled: () => !props.file.doc.is_favourite,
+              isEnabled: () => isLoggedIn.value && !props.file.doc.is_favourite,
             },
             {
               label: __('Unfavourite'),
@@ -251,11 +258,18 @@ const fileActions = computed(() =>
               color: 'stroke-amber-500 fill-amber-500',
               onClick: () => {
                 props.file.doc.is_favourite = false
-                toggleFav.submit({
-                  entities: [{ name: props.file.doc.name, is_favourite: false }],
-                })
+                toggleFav.submit(
+                  {
+                    entities: [{ name: props.file.doc.name, is_favourite: false }],
+                  },
+                  {
+                    onError: () => {
+                      props.file.doc.is_favourite = true
+                    },
+                  }
+                )
               },
-              isEnabled: () => props.file.doc.is_favourite,
+              isEnabled: () => isLoggedIn.value && props.file.doc.is_favourite,
             },
           ],
         },

--- a/frontend/src/apps/writer/components/Navbar.vue
+++ b/frontend/src/apps/writer/components/Navbar.vue
@@ -98,6 +98,7 @@
 import { Button, Dropdown } from 'frappe-ui'
 import EditableBreadcrumbs from '@/apps/drive/components/EditableBreadcrumbs.vue'
 import { getFileLink } from '@/apps/drive/sdk'
+import { toggleFav } from '@/apps/drive/resources/files'
 
 import { useSessionStore } from '@/boot/session'
 import emitter from '@/apps/writer/emitter'
@@ -238,7 +239,9 @@ const fileActions = computed(() =>
               icon: LucideStar,
               onClick: () => {
                 props.file.doc.is_favourite = true
-                toggleFav.submit({ entities: [props.file.doc] })
+                toggleFav.submit({
+                  entities: [{ name: props.file.doc.name, is_favourite: true }],
+                })
               },
               isEnabled: () => !props.file.doc.is_favourite,
             },
@@ -248,7 +251,9 @@ const fileActions = computed(() =>
               color: 'stroke-amber-500 fill-amber-500',
               onClick: () => {
                 props.file.doc.is_favourite = false
-                toggleFav.submit({ entities: [props.file.doc] })
+                toggleFav.submit({
+                  entities: [{ name: props.file.doc.name, is_favourite: false }],
+                })
               },
               isEnabled: () => props.file.doc.is_favourite,
             },

--- a/frontend/src/apps/writer/composables/useDocument.ts
+++ b/frontend/src/apps/writer/composables/useDocument.ts
@@ -21,9 +21,6 @@ export default function useDocument(docId: MaybeRefOrGetter<string>) {
     transform: (doc) => {
       return prettyData(doc)
     },
-    methods: {
-      toggleFav: { name: 'toggle_favourite' },
-    },
   })
   // Construct a fake useDoc until we fetch data
   const document = ref({ doc: null })

--- a/suite/drive/overrides/file.py
+++ b/suite/drive/overrides/file.py
@@ -307,6 +307,7 @@ class File(FrappeFile):
 
         return frappe.get_value("File", new_parent, ["file_name", "name", "folder"], as_dict=True)
 
+    @frappe.whitelist()
     def toggle_favourite(self):
         existing_doc = frappe.db.exists(
             {

--- a/suite/drive/overrides/file.py
+++ b/suite/drive/overrides/file.py
@@ -308,28 +308,6 @@ class File(FrappeFile):
         return frappe.get_value("File", new_parent, ["file_name", "name", "folder"], as_dict=True)
 
     @frappe.whitelist()
-    def toggle_favourite(self):
-        existing_doc = frappe.db.exists(
-            {
-                "doctype": "Drive Favourite",
-                "entity": self.name,
-                "user": frappe.session.user,
-            }
-        )
-        if existing_doc:
-            frappe.delete_doc("Drive Favourite", existing_doc)
-            return False
-        else:
-            frappe.get_doc(
-                {
-                    "doctype": "Drive Favourite",
-                    "entity": self.name,
-                    "user": frappe.session.user,
-                }
-            ).insert()
-            return True
-
-    @frappe.whitelist()
     @_update_modified
     def rename(self, new_file_name: str):
         """


### PR DESCRIPTION
### Summary

Favouriting a document from Writer's navbar (⋯ → Favourite) never synced to Drive:

- The document didn't appear in Drive's Favourites tab.
- The favourite state didn't survive a page reload.
- After a partial fix, favouriting would also break the editor (page became read-only until reload).

### Root cause
Writer called `toggle_favourite`, a `File `doc-method, through Frappe's generic doc-method dispatcher. That dispatcher auto-attaches the raw document (`doc.as_dict()`) to every response. Frappe-ui's global fetch layer uses that to fully overwrite the client's cached document — wiping out fields like `write/share` that are only populated by the enriched fetch, which is what broke editing.

The underlying `toggle_favourite` method also lacked `@frappe.whitelist()` (dropped accidentally in an earlier refactor), and separately was being called with an argument shape (`entities: [...]`) it didn't accept.

### Fix
Instead of patching that path further, Writer now calls the same shared, whitelisted API Drive's own UI already uses — `suite.drive.api.files.set_favourite`, via the existing `toggleFav` resource in `@/apps/drive/resources/files`. This is a plain `/api/method` call, so it never touches the doc-method dispatcher and never clobbers the cached document.

- `suite/drive/overrides/file.py`: removed the now-unused t`oggle_favourite` doc-method.
- `frontend/src/apps/writer/composables/useDocument.ts`: removed the doc-method wiring that pointed at it.
- `frontend/src/apps/writer/components/Navbar.vue`: Favourite/Unfavourite now call the shared `toggleFav` resource, same as Drive.

Closes #518 


https://github.com/user-attachments/assets/22f004fd-2d48-424a-92b6-827e777274c3

