### PR TITLE
fix: move blob store to site directory root

### DIFF
--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -95,3 +95,4 @@ suite.mail.patches.reset_push_subscription_types_to_all
 # --- suite_core ---
 # Existing, already-set-up sites shouldn't be sent through Suite's onboarding.
 execute:frappe.db.set_single_value("Suite Settings", "is_onboarded", 1) if frappe.is_setup_complete() else None
+suite.suite_core.patches.move_blob_store_out_of_private

--- a/suite/store/__init__.py
+++ b/suite/store/__init__.py
@@ -20,9 +20,10 @@ def get_data_base_path() -> str:
 def get_blob_base_path() -> str:
     """Base directory holding every blob store for the current site.
 
-    Sits directly under the site directory, so it is per-site (multi-tenant safe), never web-served, and excluded from site
-    backups — blobs are a cache refetched on demand, and backing them up would bloat every
-    backup.
+    Sits directly under the site directory rather than ``private``, because Frappe Cloud backs up
+    the entire ``private`` directory and blobs are a cache refetched on demand — including them
+    would bloat every backup. The location is still per-site (multi-tenant safe) and never
+    web-served.
     """
 
     return os.path.join(get_bench_path(), "sites", frappe.local.site, "blob-store")

--- a/suite/store/__init__.py
+++ b/suite/store/__init__.py
@@ -20,12 +20,12 @@ def get_data_base_path() -> str:
 def get_blob_base_path() -> str:
     """Base directory holding every blob store for the current site.
 
-    Sits under the site's ``private`` directory (not ``private/files``), so it is per-site
-    (multi-tenant safe), never web-served, and excluded from site backups — blobs are a cache
-    refetched on demand, and backing them up would bloat every files backup.
+    Sits directly under the site directory, so it is per-site (multi-tenant safe), never web-served, and excluded from site
+    backups — blobs are a cache refetched on demand, and backing them up would bloat every
+    backup.
     """
 
-    return os.path.join(get_bench_path(), "sites", frappe.local.site, "private", "blob-store")
+    return os.path.join(get_bench_path(), "sites", frappe.local.site, "blob-store")
 
 
 def get_search_base_path() -> str:

--- a/suite/suite_core/patches/move_blob_store_out_of_private.py
+++ b/suite/suite_core/patches/move_blob_store_out_of_private.py
@@ -8,18 +8,19 @@ from suite.store import get_blob_base_path
 
 
 def execute() -> None:
-    """Relocate the blob store from ``private/files/blob-store`` to the current blob base path.
+    """Relocate the blob store from ``private/blob-store`` to the site directory root.
 
-    The blob store used to live inside ``private/files``, so every files backup tarred the whole
-    blob cache. It now sits at ``get_blob_base_path()`` (the site directory root), which backups
-    do not include. Migrating is a single directory move — the internal layout is unchanged.
+    Frappe Cloud backs up the entire ``private`` directory, so even after moving out of
+    ``private/files`` the blob cache still landed in every site backup. It now sits directly
+    under the site directory (``sites/<site>/blob-store``), which backups do not include.
+    Migrating is a single directory move — the internal layout is unchanged.
 
     Best-effort: blobs are a cache refetched on demand, so if the new directory already exists
     (an interrupted earlier run, or stores already created at the new location) the old directory
     is simply dropped rather than merged.
     """
 
-    old_path = os.path.join(get_bench_path(), "sites", frappe.local.site, "private", "files", "blob-store")
+    old_path = os.path.join(get_bench_path(), "sites", frappe.local.site, "private", "blob-store")
     if not os.path.isdir(old_path) or os.path.islink(old_path):
         return
 

--- a/suite/suite_core/patches/test_move_blob_store.py
+++ b/suite/suite_core/patches/test_move_blob_store.py
@@ -48,7 +48,9 @@ class MoveBlobStorePatchTests:
         self.module.execute()
 
         self.assertFalse(os.path.exists(self.old_path))
-        self.assertEqual(self.read_blob(self.new_path, "mail", "account%40example.com", "data.mdb"), b"blob-bytes")
+        self.assertEqual(
+            self.read_blob(self.new_path, "mail", "account%40example.com", "data.mdb"), b"blob-bytes"
+        )
 
     def test_drops_old_store_when_destination_exists(self):
         self.write_blob(self.old_path, "mail", "stale.mdb", content=b"stale")

--- a/suite/suite_core/patches/test_move_blob_store.py
+++ b/suite/suite_core/patches/test_move_blob_store.py
@@ -1,0 +1,97 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from suite.suite_core.patches import move_blob_store_out_of_files, move_blob_store_out_of_private
+
+
+class MoveBlobStorePatchTests:
+    """Regression tests shared by both blob-store relocation patches.
+
+    The patches move (or drop) directories on disk, so each branch is exercised against a
+    throwaway bench laid out in a temp directory: a populated move, a pre-existing destination,
+    a rerun after success, and a symlinked source.
+    """
+
+    module = None  # patch module under test
+    old_relative: tuple[str, ...] = ()  # legacy blob-store location, relative to the site directory
+
+    SITE = "blob-store-patch-test-site"
+
+    def setUp(self):
+        self.bench_path = self.enterContext(tempfile.TemporaryDirectory())
+        self.site_path = os.path.join(self.bench_path, "sites", self.SITE)
+        self.old_path = os.path.join(self.site_path, *self.old_relative)
+        self.new_path = os.path.join(self.site_path, "blob-store")
+        os.makedirs(self.site_path)
+
+        # Point both the patch module and suite.store (get_blob_base_path) at the temp bench.
+        for name in (self.module.__name__, "suite.store"):
+            frappe_mock = self.enterContext(mock.patch(f"{name}.frappe"))
+            frappe_mock.local.site = self.SITE
+            self.enterContext(mock.patch(f"{name}.get_bench_path", return_value=self.bench_path))
+
+    def write_blob(self, base: str, *relative: str, content: bytes = b"x") -> None:
+        path = os.path.join(base, *relative)
+        os.makedirs(os.path.dirname(path))
+        with open(path, "wb") as f:
+            f.write(content)
+
+    def read_blob(self, base: str, *relative: str) -> bytes:
+        with open(os.path.join(base, *relative), "rb") as f:
+            return f.read()
+
+    def test_moves_populated_store_to_site_root(self):
+        self.write_blob(self.old_path, "mail", "account%40example.com", "data.mdb", content=b"blob-bytes")
+
+        self.module.execute()
+
+        self.assertFalse(os.path.exists(self.old_path))
+        self.assertEqual(self.read_blob(self.new_path, "mail", "account%40example.com", "data.mdb"), b"blob-bytes")
+
+    def test_drops_old_store_when_destination_exists(self):
+        self.write_blob(self.old_path, "mail", "stale.mdb", content=b"stale")
+        self.write_blob(self.new_path, "mail", "fresh.mdb", content=b"fresh")
+
+        self.module.execute()
+
+        self.assertFalse(os.path.exists(self.old_path))
+        self.assertEqual(os.listdir(os.path.join(self.new_path, "mail")), ["fresh.mdb"])
+        self.assertEqual(self.read_blob(self.new_path, "mail", "fresh.mdb"), b"fresh")
+
+    def test_rerun_after_successful_move_is_a_noop(self):
+        self.write_blob(self.old_path, "mail", "data.mdb", content=b"blob-bytes")
+        self.module.execute()
+
+        self.module.execute()
+
+        self.assertFalse(os.path.exists(self.old_path))
+        self.assertEqual(self.read_blob(self.new_path, "mail", "data.mdb"), b"blob-bytes")
+
+    def test_noop_when_nothing_to_migrate(self):
+        self.module.execute()
+
+        self.assertFalse(os.path.exists(self.new_path))
+
+    def test_leaves_symlinked_store_alone(self):
+        target = os.path.join(self.site_path, "blob-store-elsewhere")
+        self.write_blob(target, "mail", "data.mdb", content=b"blob-bytes")
+        os.makedirs(os.path.dirname(self.old_path), exist_ok=True)
+        os.symlink(target, self.old_path)
+
+        self.module.execute()
+
+        self.assertTrue(os.path.islink(self.old_path))
+        self.assertFalse(os.path.exists(self.new_path))
+        self.assertEqual(self.read_blob(target, "mail", "data.mdb"), b"blob-bytes")
+
+
+class MoveBlobStoreOutOfFiles(MoveBlobStorePatchTests, unittest.TestCase):
+    module = move_blob_store_out_of_files
+    old_relative = ("private", "files", "blob-store")
+
+
+class MoveBlobStoreOutOfPrivate(MoveBlobStorePatchTests, unittest.TestCase):
+    module = move_blob_store_out_of_private
+    old_relative = ("private", "blob-store")


### PR DESCRIPTION
## Problem

The blob store was recently moved from `sites/<site>/private/files/blob-store` to `sites/<site>/private/blob-store` to keep it out of files backups. However, Frappe Cloud backs up the **entire** `private` directory, so the blob cache still ends up in every site backup.

## Fix

- Move the blob store to the site directory root: `sites/<site>/blob-store`. It remains per-site (multi-tenant safe) and is never web-served, but is no longer included in backups.
- Add a `move_blob_store_out_of_private` patch that relocates `private/blob-store` to the site root with the same best-effort semantics as the earlier relocation patch (if the destination already exists, the old directory is dropped rather than merged — blobs are a cache refetched on demand).
- Sites still on the oldest layout (`private/files/blob-store`) are moved straight to the site root by the existing `move_blob_store_out_of_files` patch, since it resolves the destination via `get_blob_base_path()`; the new patch then finds nothing to do.

## Verification

Ran the patch on a local site: `private/blob-store` (with the `mail` namespace) was moved to `sites/<site>/blob-store` intact, and `get_blob_base_path()` resolves to the new location.