### PR TITLE
refactor(mail): remove scheduled fetch_changes, rely on JMAP push

### DIFF
--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -301,7 +301,6 @@ scheduler_events = {
     "hourly_long": [
         # mail
         "suite.mail.doctype.mail_queue.mail_queue.reconcile_scheduled_emails",
-        "suite.mail.doctype.mail_message.mail_message.schedule_fetch_changes",
     ],
     "cron": {
         "*/5 * * * *": [

--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -15,7 +15,6 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.push_notification import PushNotification
 from frappe.utils import (
-    add_to_date,
     cint,
     escape_html,
     random_string,
@@ -24,7 +23,7 @@ from frappe.utils import (
 
 from suite.mail.doctype.mail_queue.mail_queue import MailQueue
 from suite.mail.doctype.sieve_script.sieve_script import SCREENER_MAILBOX_NAME
-from suite.mail.doctype.user_account.user_account import get_user_for_jmap_account, get_user_jmap_accounts
+from suite.mail.doctype.user_account.user_account import get_user_for_jmap_account
 from suite.mail.jmap import get_email_service, get_jmap_connection, get_thread_service
 from suite.mail.jmap.services.mail.email import EmailService
 from suite.mail.jmap.services.mail.mailbox import MailboxService
@@ -38,7 +37,7 @@ from suite.mail.utils.email_parser import EmailParser
 from suite.mail.utils.logger import get_push_logger
 from suite.mail.utils.user import get_account_emails, get_sync_state, update_sync_state
 from suite.utils import clean_text, convert_html_to_text, enqueue_job, parse_filters, user_context
-from suite.utils.dt import convert_to_utc, get_utc_now
+from suite.utils.dt import get_utc_now
 from suite.utils.lock import acquire_lock, release_lock
 
 PREVIEW_MAX_LENGTH = 256
@@ -1518,60 +1517,3 @@ def enqueue_fetch_changes(
             queue="short",
             enqueue_after_commit=True,
         )
-
-
-def schedule_fetch_changes() -> None:
-    """Schedule fetch_changes for every (user, account) whose email state hasn't been
-    updated in the last 3 hours.
-
-    JMAP Account is now shared per account ID, so the set of accounts to sync is
-    derived from each JMAP-configured user's accounts, and the last-update timestamp is
-    read from that user's per-account data store."""
-
-    USER = frappe.qb.DocType("User")
-    USER_SETTINGS = frappe.qb.DocType("User Settings")
-
-    threshold = add_to_date(get_utc_now(), hours=-3)
-
-    users = (
-        frappe.qb.from_(USER_SETTINGS)
-        .join(USER)
-        .on(USER.name == USER_SETTINGS.user)
-        .select(USER_SETTINGS.user)
-        .where(
-            (USER.enabled == 1)
-            & (USER_SETTINGS.username != "")
-            & (USER_SETTINGS.username.isnotnull())
-            & (USER_SETTINGS.skip_schedule_fetch_changes == 0)
-        )
-    ).run(pluck="user")
-
-    if not users:
-        return
-
-    selected_user_accounts = []
-    for user in users:
-        try:
-            accounts = get_user_jmap_accounts(user, raise_exception=True)
-        except Exception:
-            continue
-
-        for account in accounts:
-            store = get_data_store(account)
-            last_update = store.get(Entity.STATE, "email_state_last_update")
-            # convert_to_utc reads new aware ``...Z`` stamps directly and legacy naive
-            # system-time stamps as system time, so both compare correctly.
-            if not last_update or convert_to_utc(last_update) < threshold:
-                selected_user_accounts.append((user, account))
-
-    if not selected_user_accounts:
-        return
-
-    req_id = random_string(10)
-    logger = get_push_logger({"req_id": req_id})
-
-    logger.info("scheduling-fetch-changes", account_count=len(selected_user_accounts))
-
-    for idx, (user, account) in enumerate(selected_user_accounts, start=1):
-        ctx = {"req_id": f"{req_id}-{idx}", "account": account}
-        enqueue_fetch_changes(user, account, ctx=ctx)

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -114,6 +114,22 @@ def _get_total_cache_key(user: str) -> str:
     return f"{user}:push_subscriptions:total"
 
 
+def is_push_subscription_disabled(user: str, raise_exception: bool = False) -> bool:
+    """Returns True if push subscriptions are disabled for the given user in their User Settings."""
+
+    disabled = bool(frappe.db.get_value("User Settings", {"user": user}, "disable_push_subscriptions"))
+
+    if disabled and raise_exception:
+        frappe.throw(
+            _("Push subscriptions are disabled for user {0} in their User Settings.").format(
+                frappe.bold(user)
+            ),
+            title=_("Push Subscriptions Disabled"),
+        )
+
+    return disabled
+
+
 @frappe.whitelist()
 def bulk_delete(names: str | list[str]) -> None:
     """Deletes multiple push subscriptions given their names."""
@@ -161,6 +177,8 @@ def _add_push_subscription(
 
     if not ignore_permissions:
         has_permission_for_user(user, raise_exception=True)
+
+    is_push_subscription_disabled(user, raise_exception=True)
 
     device_client_id = device_client_id or generate_uuid_style_hash(
         f"frappe-{frappe.local.site.replace('.', '-')}-{user}"
@@ -247,6 +265,8 @@ def renew_push_subscription(user: str, id: str) -> None:
 
     has_permission_for_user(user, raise_exception=True)
 
+    is_push_subscription_disabled(user, raise_exception=True)
+
     service = get_push_subscription_service(user)
     response = service.update([{"id": id}])
 
@@ -263,7 +283,8 @@ def renew_expiring_push_subscriptions() -> None:
 
     Scheduled to run daily. A subscription is renewed when its expiry is within
     ``RENEW_THRESHOLD_DAYS`` of the run; subscriptions without an expiry or expiring
-    later are left untouched.
+    later are left untouched. Users who disabled push subscriptions in their User
+    Settings are skipped.
     """
 
     if not frappe.utils.get_url().startswith("https://"):
@@ -272,6 +293,9 @@ def renew_expiring_push_subscriptions() -> None:
     cutoff = get_utc_now() + timedelta(days=RENEW_THRESHOLD_DAYS)
 
     for user in get_jmap_configured_users():
+        if is_push_subscription_disabled(user):
+            continue
+
         try:
             service = get_push_subscription_service(user, ignore_permissions=True)
 

--- a/suite/mail/doctype/user_settings/user_settings.json
+++ b/suite/mail/doctype/user_settings/user_settings.json
@@ -5,32 +5,51 @@
  "engine": "InnoDB",
  "field_order": [
   "user",
-  "column_break_klzk",
-  "session_state",
-  "session_last_update",
   "jmap_credentials_section",
   "server_url",
   "column_break_uxkb",
   "username",
   "app_password",
-  "inbound_section",
-  "disable_push_subscriptions",
-  "column_break_nqwp",
   "recovery_section",
   "backup_email",
   "column_break_gotn",
+  "push_section",
+  "disable_push_subscriptions",
+  "column_break_nqwp",
   "session_section",
+  "session_state",
+  "column_break_klzk",
+  "session_last_update",
   "jmap_session",
   "ui_tab",
   "appearance_section",
   "color_scheme",
-  "column_break_cxak",
+  "mail_list_section",
   "group_messages_by",
+  "column_break_cxak",
   "show_reading_pane"
  ],
  "fields": [
   {
-   "description": "URL of the JMAP server.",
+   "description": "The user these settings belong to.",
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "User",
+   "no_copy": 1,
+   "options": "User",
+   "reqd": 1,
+   "set_only_once": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "jmap_credentials_section",
+   "fieldtype": "Section Break",
+   "label": "JMAP Credentials"
+  },
+  {
+   "description": "URL of the JMAP server, read from the site configuration and shared by all users.",
    "fieldname": "server_url",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -46,7 +65,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "Email address or username used to sign in to your JMAP account.",
+   "description": "Email address or username used to sign in to the JMAP account.",
    "fieldname": "username",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -56,7 +75,7 @@
    "search_index": 1
   },
   {
-   "description": "App-specific password or account password used for authentication with the JMAP server.",
+   "description": "App-specific password or account password used to authenticate with the JMAP server. Saving with a username validates the credentials by connecting to the server.",
    "fieldname": "app_password",
    "fieldtype": "Password",
    "label": "App Password",
@@ -64,9 +83,9 @@
    "no_copy": 1
   },
   {
-   "fieldname": "jmap_credentials_section",
+   "fieldname": "recovery_section",
    "fieldtype": "Section Break",
-   "label": "JMAP Credentials"
+   "label": "Recovery"
   },
   {
    "description": "Secondary email address used for account recovery and important notifications.",
@@ -78,21 +97,65 @@
    "search_index": 1
   },
   {
-   "description": "The user this settings belongs to.",
-   "fieldname": "user",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "User",
+   "fieldname": "column_break_gotn",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval: doc.username",
+   "fieldname": "push_section",
+   "fieldtype": "Section Break",
+   "label": "Push Notifications"
+  },
+  {
+   "default": "0",
+   "description": "Prevent JMAP push subscriptions from being created or renewed for this user. Mailbox changes are fetched only when the server sends a push notification, so without an active subscription this user's mail stops syncing automatically. Existing subscriptions are not deleted; they lapse when they expire.",
+   "fieldname": "disable_push_subscriptions",
+   "fieldtype": "Check",
+   "label": "Disable Push Subscriptions",
+   "search_index": 1
+  },
+  {
+   "fieldname": "column_break_nqwp",
+   "fieldtype": "Column Break"
+  },
+  {
+   "collapsible": 1,
+   "depends_on": "eval: doc.username",
+   "fieldname": "session_section",
+   "fieldtype": "Section Break",
+   "label": "Session"
+  },
+  {
+   "description": "State of the cached JMAP session, as reported by the server.",
+   "fieldname": "session_state",
+   "fieldtype": "Data",
+   "is_virtual": 1,
+   "label": "Session State",
    "no_copy": 1,
-   "options": "User",
-   "reqd": 1,
-   "set_only_once": 1,
-   "unique": 1
+   "read_only": 1
   },
   {
    "fieldname": "column_break_klzk",
    "fieldtype": "Column Break"
+  },
+  {
+   "description": "When the cached JMAP session was last refreshed.",
+   "fieldname": "session_last_update",
+   "fieldtype": "Datetime",
+   "is_virtual": 1,
+   "label": "Session Last Update",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.jmap_session && doc.jmap_session != \"{}\"",
+   "description": "Raw JMAP session data cached from the server.",
+   "fieldname": "jmap_session",
+   "fieldtype": "JSON",
+   "is_virtual": 1,
+   "label": "JMAP Session",
+   "no_copy": 1,
+   "read_only": 1
   },
   {
    "fieldname": "ui_tab",
@@ -106,7 +169,7 @@
   },
   {
    "default": "System Default",
-   "description": "Choose your preferred interface theme.",
+   "description": "Preferred interface theme.",
    "fieldname": "color_scheme",
    "fieldtype": "Select",
    "label": "Color Scheme",
@@ -114,12 +177,13 @@
    "reqd": 1
   },
   {
-   "fieldname": "column_break_cxak",
-   "fieldtype": "Column Break"
+   "depends_on": "eval: doc.username",
+   "fieldname": "mail_list_section",
+   "fieldtype": "Section Break",
+   "label": "Mail List"
   },
   {
    "default": "Day",
-   "depends_on": "eval: doc.username",
    "description": "Group email messages in the list by time period (e.g., day or month).",
    "fieldname": "group_messages_by",
    "fieldtype": "Select",
@@ -127,69 +191,15 @@
    "options": "None\nDay\nMonth"
   },
   {
+   "fieldname": "column_break_cxak",
+   "fieldtype": "Column Break"
+  },
+  {
    "default": "1",
-   "depends_on": "eval: doc.username",
    "description": "Show a split view with an email preview beside the email list.",
    "fieldname": "show_reading_pane",
    "fieldtype": "Check",
    "label": "Split View"
-  },
-  {
-   "fieldname": "recovery_section",
-   "fieldtype": "Section Break",
-   "label": "Recovery"
-  },
-  {
-   "fieldname": "column_break_gotn",
-   "fieldtype": "Column Break"
-  },
-  {
-   "depends_on": "eval: doc.username",
-   "fieldname": "inbound_section",
-   "fieldtype": "Section Break",
-   "label": "Inbound"
-  },
-  {
-   "fieldname": "column_break_nqwp",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "0",
-   "description": "Prevent JMAP push subscriptions from being created or renewed for this user.",
-   "fieldname": "disable_push_subscriptions",
-   "fieldtype": "Check",
-   "label": "Disable Push Subscriptions",
-   "search_index": 1
-  },
-  {
-   "fieldname": "session_state",
-   "fieldtype": "Data",
-   "is_virtual": 1,
-   "label": "Session State",
-   "no_copy": 1,
-   "read_only": 1
-  },
-  {
-   "fieldname": "session_last_update",
-   "fieldtype": "Datetime",
-   "is_virtual": 1,
-   "label": "Session Last Update",
-   "no_copy": 1,
-   "read_only": 1
-  },
-  {
-   "collapsible": 1,
-   "fieldname": "session_section",
-   "fieldtype": "Section Break",
-   "label": "Session"
-  },
-  {
-   "depends_on": "eval: doc.jmap_session && doc.jmap_session != \"{}\"",
-   "fieldname": "jmap_session",
-   "fieldtype": "JSON",
-   "is_virtual": 1,
-   "no_copy": 1,
-   "read_only": 1
   }
  ],
  "grid_page_length": 50,
@@ -201,7 +211,7 @@
    "link_fieldname": "user_settings"
   }
  ],
- "modified": "2026-08-07 00:00:00.000000",
+ "modified": "2026-08-07 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "User Settings",

--- a/suite/mail/doctype/user_settings/user_settings.json
+++ b/suite/mail/doctype/user_settings/user_settings.json
@@ -14,7 +14,7 @@
   "username",
   "app_password",
   "inbound_section",
-  "skip_schedule_fetch_changes",
+  "disable_push_subscriptions",
   "column_break_nqwp",
   "recovery_section",
   "backup_email",
@@ -155,10 +155,10 @@
   },
   {
    "default": "0",
-   "description": "Skip periodic fetching of email changes (new, updated, or deleted).",
-   "fieldname": "skip_schedule_fetch_changes",
+   "description": "Prevent JMAP push subscriptions from being created or renewed for this user.",
+   "fieldname": "disable_push_subscriptions",
    "fieldtype": "Check",
-   "label": "Skip Schedule Fetch Changes",
+   "label": "Disable Push Subscriptions",
    "search_index": 1
   },
   {
@@ -201,7 +201,7 @@
    "link_fieldname": "user_settings"
   }
  ],
- "modified": "2026-07-21 00:00:00.000000",
+ "modified": "2026-08-07 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "User Settings",

--- a/suite/mail/doctype/user_settings/user_settings.py
+++ b/suite/mail/doctype/user_settings/user_settings.py
@@ -30,9 +30,9 @@ class UserSettings(OwnerFromUser, Document):
         app_password: DF.Password | None
         backup_email: DF.Data | None
         color_scheme: DF.Literal["System Default", "Light Mode", "Dark Mode"]
+        disable_push_subscriptions: DF.Check
         group_messages_by: DF.Literal["None", "Day", "Month"]
         show_reading_pane: DF.Check
-        skip_schedule_fetch_changes: DF.Check
         user: DF.Link
         username: DF.Data | None
     # end: auto-generated types

--- a/suite/mail/patches/enable_screening_for_personal_accounts.py
+++ b/suite/mail/patches/enable_screening_for_personal_accounts.py
@@ -50,14 +50,14 @@ def enable_screening_for_personal_accounts() -> None:
 
 
 def get_eligible_personal_accounts() -> list[str]:
-    """Deduplicated personal accounts to backfill, scoped to users who still schedule-fetch.
+    """Deduplicated personal accounts to backfill, scoped to users with push subscriptions enabled.
 
     A JMAP Account is shared across every user with access to it, so User Account links it to one
     or more users. We only want personal accounts (is_personal) that don't already have screening
     on (enable_screening = 0), and only for enabled users who have JMAP configured (username set)
-    and whose User Settings leaves scheduled change fetching on (skip_schedule_fetch_changes = 0)
-    — enabling screening relies on that periodic fetch to keep the Screening folder current, so
-    disabled users, unconfigured users, and users who opted out are left alone.
+    and whose User Settings leaves push subscriptions enabled (disable_push_subscriptions = 0)
+    — enabling screening relies on push-driven change fetching to keep the Screening folder
+    current, so disabled users, unconfigured users, and users who opted out are left alone.
 
     `.distinct()` collapses the per-user User Account rows down to one entry per account.
     """
@@ -77,7 +77,7 @@ def get_eligible_personal_accounts() -> list[str]:
         .on(USER_ACCOUNT.account == JMAP_ACCOUNT.name)
         .where(USER.enabled == 1)
         .where(USER_SETTINGS.username.isnotnull() & (USER_SETTINGS.username != ""))
-        .where(USER_SETTINGS.skip_schedule_fetch_changes == 0)
+        .where(USER_SETTINGS.disable_push_subscriptions == 0)
         .where(JMAP_ACCOUNT.is_personal == 1)
         .where(JMAP_ACCOUNT.enable_screening == 0)
         .select(USER_ACCOUNT.account)

--- a/suite/mail/patches/rename_skip_schedule_fetch_changes.py
+++ b/suite/mail/patches/rename_skip_schedule_fetch_changes.py
@@ -1,0 +1,12 @@
+from frappe.model.utils.rename_field import rename_field
+
+
+def execute() -> None:
+    """Rename User Settings.skip_schedule_fetch_changes to disable_push_subscriptions.
+
+    Scheduled change fetching (schedule_fetch_changes) is gone — changes are now fetched
+    only on received JMAP push notifications — so the flag's meaning shifts from opting
+    out of the scheduler to blocking push subscription creation and renewal entirely.
+    """
+
+    rename_field("User Settings", "skip_schedule_fetch_changes", "disable_push_subscriptions")

--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -90,6 +90,7 @@ execute:frappe.db.set_single_value("Mail Settings", "verify_ssl", 1)
 execute:frappe.db.set_single_value("Mail Settings", "show_mail_client_config", 1)
 execute:frappe.db.set_single_value("Mail Settings", "custom_event_invites", 1)
 suite.mail.patches.reset_push_subscription_types_to_all
+suite.mail.patches.rename_skip_schedule_fetch_changes
 # --- calendar ---
 # (no patches)
 # --- suite_core ---


### PR DESCRIPTION
## Summary

- Remove the hourly `schedule_fetch_changes` scheduler job and its hook entry; email changes are now fetched only when a JMAP push notification is received (`enqueue_fetch_changes` on push).
- Rename **User Settings** field `skip_schedule_fetch_changes` → `disable_push_subscriptions` (with a `rename_field` patch). When checked, push subscriptions can no longer be created or renewed for that user:
  - `_add_push_subscription` and `renew_push_subscription` now throw for such users (covers the whitelisted APIs, frontend, and doc inserts like the Mail Account Request signup flow).
  - The daily `renew_expiring_push_subscriptions` job skips them.
- Update the `enable_screening_for_personal_accounts` patch query to the renamed column (its background job runs post-migrate, after the rename).

Existing subscriptions of a user who checks the box are not deleted — they lapse at expiry since renewal is blocked.

## Notes

- `bench migrate` required (doctype change + rename patch).