### PR TITLE
fix(slides): border controls, hex input, escape behaviour and more

### DIFF
--- a/frontend/src/apps/slides/components/BorderSection.vue
+++ b/frontend/src/apps/slides/components/BorderSection.vue
@@ -3,9 +3,9 @@
 		<PropertyRow label="Color">
 			<ColorPicker
 				:modelValue="activeElement.borderColor || defaultBorderColor"
-				@update:modelValue="borderColor.set"
-				@colordown="borderColor.begin"
-				@colorup="borderColor.commit"
+				@update:modelValue="setBorderColor"
+				@colordown="beginBorderEdit"
+				@colorup="commitBorderEdit"
 			/>
 		</PropertyRow>
 		<NumberControl
@@ -16,9 +16,9 @@
 			:max="50"
 			:max-digits="3"
 			:step="0.5"
-			@update:modelValue="borderWidth.set"
-			@change-start="borderWidth.begin"
-			@change-end="borderWidth.commit"
+			@update:modelValue="setBorderWidth"
+			@change-start="beginBorderEdit"
+			@change-end="commitBorderEdit"
 		/>
 		<NumberControl
 			:modelValue="activeElement.borderRadius ?? 0"
@@ -85,7 +85,45 @@ const setBorderStyle = (style) => {
 	])
 }
 
-const borderColor = useElementProperty('borderColor')
-const borderWidth = useElementProperty('borderWidth')
+const hasVisibleStyle = () =>
+	activeElement.value.borderStyle && activeElement.value.borderStyle !== 'none'
+
+let borderSnapshot = null
+
+const beginBorderEdit = () => {
+	const el = activeElement.value
+	borderSnapshot = {
+		borderColor: el.borderColor,
+		borderWidth: el.borderWidth,
+		borderStyle: el.borderStyle,
+	}
+}
+
+const setBorderColor = (value) => {
+	const el = activeElement.value
+	el.borderColor = value
+	if (!hasVisibleStyle()) el.borderStyle = 'solid'
+	if (!Number(el.borderWidth)) el.borderWidth = defaultBorderWidth
+}
+
+const setBorderWidth = (value) => {
+	const el = activeElement.value
+	el.borderWidth = value
+	if (Number(value) && !hasVisibleStyle()) el.borderStyle = 'solid'
+}
+
+const commitBorderEdit = () => {
+	if (!borderSnapshot) return
+	const el = activeElement.value
+	setElementProperties(
+		['borderColor', 'borderWidth', 'borderStyle'].map((property) => ({
+			property,
+			oldValue: borderSnapshot[property],
+			newValue: el[property],
+		})),
+	)
+	borderSnapshot = null
+}
+
 const borderRadius = useElementProperty('borderRadius')
 </script>

--- a/frontend/src/apps/slides/components/BorderSection.vue
+++ b/frontend/src/apps/slides/components/BorderSection.vue
@@ -1,5 +1,12 @@
 <template>
 	<Section label="Border" :initialState="hasBorder">
+		<PropertyRow label="Style">
+			<LineStyleSelect
+				:modelValue="displayStyle"
+				:options="borderStyleOptions"
+				@update:modelValue="setBorderStyle"
+			/>
+		</PropertyRow>
 		<PropertyRow label="Color">
 			<ColorPicker
 				:modelValue="activeElement.borderColor || defaultBorderColor"
@@ -32,13 +39,6 @@
 			@change-start="borderRadius.begin"
 			@change-end="borderRadius.commit"
 		/>
-		<PropertyRow label="Style">
-			<LineStyleSelect
-				:modelValue="displayStyle"
-				:options="borderStyleOptions"
-				@update:modelValue="setBorderStyle"
-			/>
-		</PropertyRow>
 	</Section>
 </template>
 

--- a/frontend/src/apps/slides/components/PresentationHeader.vue
+++ b/frontend/src/apps/slides/components/PresentationHeader.vue
@@ -7,6 +7,7 @@
 		@focus="setCursorPositionAtEnd"
 		@blur="saveTitle"
 		@keydown.enter.prevent.stop="(e) => e.target.blur()"
+		@keydown.esc.prevent.stop="cancelTitle"
 	>
 		{{ title }}
 	</div>
@@ -52,6 +53,11 @@ const makeTitleEditable = (e) => {
 	editingTitle.value = true
 	e.target.focus()
 	e.target.tabIndex = 0
+}
+
+const cancelTitle = (e) => {
+	e.target.innerText = props.title
+	e.target.blur()
 }
 
 const saveTitle = async (e) => {

--- a/frontend/src/apps/slides/components/ShadowSection.vue
+++ b/frontend/src/apps/slides/components/ShadowSection.vue
@@ -68,16 +68,54 @@ import NumberControl from '@/apps/slides/components/controls/NumberControl.vue'
 import Section from '@/apps/slides/components/controls/Section.vue'
 
 import { activeElement } from '@/apps/slides/stores/element'
-import { useElementProperty } from '@/apps/slides/composables/editProperty'
+import { setElementProperties, useElementProperty } from '@/apps/slides/composables/editProperty'
 import { defaultShadowColor } from '@/apps/slides/utils/constants'
+
+const defaultShadowBlur = 10
 
 const hasShadow = computed(() =>
 	Boolean(activeElement.value.shadowBlur || activeElement.value.shadowOffset),
 )
 
-const shadowColor = useElementProperty('shadowColor')
-const shadowOpacity = useElementProperty('shadowOpacity')
+let shadowSnapshot = null
+
+const beginShadowEdit = () => {
+	const el = activeElement.value
+	shadowSnapshot = {
+		shadowColor: el.shadowColor,
+		shadowOpacity: el.shadowOpacity,
+		shadowAngle: el.shadowAngle,
+		shadowBlur: el.shadowBlur,
+	}
+}
+
+const commitShadowEdit = () => {
+	if (!shadowSnapshot) return
+	const el = activeElement.value
+	setElementProperties(
+		Object.keys(shadowSnapshot).map((property) => ({
+			property,
+			oldValue: shadowSnapshot[property],
+			newValue: el[property],
+		})),
+	)
+	shadowSnapshot = null
+}
+
+// color, opacity and angle are invisible until a blur or offset exists
+const useShadowProperty = (property) => ({
+	set: (value) => {
+		const el = activeElement.value
+		el[property] = value
+		if (!hasShadow.value) el.shadowBlur = defaultShadowBlur
+	},
+	begin: beginShadowEdit,
+	commit: commitShadowEdit,
+})
+
+const shadowColor = useShadowProperty('shadowColor')
+const shadowOpacity = useShadowProperty('shadowOpacity')
+const shadowAngle = useShadowProperty('shadowAngle')
 const shadowBlur = useElementProperty('shadowBlur')
 const shadowOffset = useElementProperty('shadowOffset')
-const shadowAngle = useElementProperty('shadowAngle')
 </script>

--- a/frontend/src/apps/slides/components/ThumbnailCapture.vue
+++ b/frontend/src/apps/slides/components/ThumbnailCapture.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script setup>
-import { nextTick, useTemplateRef } from 'vue'
+import { toRef, useTemplateRef } from 'vue'
 
 import SlidePreview from '@/apps/slides/components/SlidePreview.vue'
 
@@ -29,7 +29,7 @@ const props = defineProps({
 
 const captureRef = useTemplateRef('captureRef')
 
-const thumbnailCaptureControls = useThumbnailCapture(captureRef, props.disableCapture)
+const thumbnailCaptureControls = useThumbnailCapture(captureRef, toRef(props, 'disableCapture'))
 
 defineExpose(thumbnailCaptureControls)
 </script>

--- a/frontend/src/apps/slides/components/controls/ColorPicker.vue
+++ b/frontend/src/apps/slides/components/controls/ColorPicker.vue
@@ -58,12 +58,13 @@
 							placeholder="Set Color"
 							:aria-label="'Hex color input'"
 							:value="getDisplayColor()"
-							class="max-w-[94px] border-none text-sm uppercase"
+							class="max-w-[94px] border-none text-sm"
 							@update:modelValue="
 								(val) => {
 									setColor(val)
 								}
 							"
+							@keydown.enter.prevent.stop="(e) => e.target.blur()"
 							@click="handleColorInputClick"
 						/>
 
@@ -300,29 +301,38 @@ watch(sRGBHex, (newColor) => {
 })
 
 const setColor = (newColor) => {
-	if (!tinycolor(newColor).isValid()) {
+	const parsed = tinycolor(newColor)
+	if (!parsed.isValid()) {
 		revertKey.value++
 		return
 	}
+
+	// keep the slider's transparency unless the typed value carries its own alpha
+	if (parsed.getAlpha() === 1 && currentOpacity.value < 1) {
+		parsed.setAlpha(currentOpacity.value)
+	}
+
 	emit('colordown')
-	currentColor.value = newColor
-	const initialHsv = tinycolor(newColor).toHsv()
+	currentColor.value = parsed.toHex8String()
+	const initialHsv = parsed.toHsv()
 	colorHue.value = initialHsv.h
 	colorSaturation.value = initialHsv.s
 	colorValue.value = initialHsv.v
 	currentOpacity.value = initialHsv.a
 	currentHue.value = tinycolor({ h: colorHue.value, s: 1, l: 0.5 })
 	emit('colorup')
+
+	// remount the input so the display re-syncs to the normalized value
+	revertKey.value++
 }
 
 const getDisplayColor = () => {
 	if (!currentColor.value) return ''
-	return tinycolor(currentColor.value).toHex8String()
+	return tinycolor(currentColor.value).toHexString().toUpperCase()
 }
 
 const handleClipboardCopy = () => {
-	const color = getDisplayColor().toUpperCase()
-	copyToClipboard(color)
+	copyToClipboard(getDisplayColor())
 }
 
 const handleColorInputClick = (e) => {

--- a/frontend/src/apps/slides/components/controls/LineStyleSelect.vue
+++ b/frontend/src/apps/slides/components/controls/LineStyleSelect.vue
@@ -11,9 +11,9 @@
 			<span v-else :class="linePreviewClasses(selectedOption?.value)" />
 			<span :class="chevronClasses" />
 		</template>
-		<template #item-label="{ option }">
-			<span v-if="option.value === 'none'" :class="noneLabelClasses">None</span>
-			<span v-else :class="linePreviewClasses(option.value)" />
+		<template #item-label="{ item }">
+			<span v-if="item.value === 'none'" :class="noneLabelClasses">None</span>
+			<span v-else :class="linePreviewClasses(item.value)" />
 		</template>
 	</Select>
 </template>

--- a/frontend/src/apps/slides/components/controls/NumberControl.vue
+++ b/frontend/src/apps/slides/components/controls/NumberControl.vue
@@ -107,6 +107,12 @@ function onArrowStep(event) {
 		inputRef.value?.blur()
 		return
 	}
+	if (event.key === 'Escape') {
+		event.stopPropagation()
+		live.value = null
+		inputRef.value?.blur()
+		return
+	}
 	if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return
 	event.preventDefault()
 	const typed = live.value !== null ? parseFloat(live.value) : Number(model.value)

--- a/frontend/src/apps/slides/components/controls/Section.vue
+++ b/frontend/src/apps/slides/components/controls/Section.vue
@@ -2,7 +2,10 @@
 	<div class="flex flex-col gap-3 py-3">
 		<div class="flex cursor-pointer items-center justify-between" @click="toggleContent">
 			<span :class="labelClasses">{{ label }}</span>
-			<lucide-chevron-down v-if="!showContent" class="size-4 stroke-[1.5] text-ink-gray-7" />
+			<lucide-chevron-down
+				class="size-4 stroke-[1.5] text-ink-gray-7 transition-transform duration-200"
+				:class="{ '-rotate-90': !showContent }"
+			/>
 		</div>
 
 		<div v-if="showContent" class="flex flex-col gap-2">

--- a/frontend/src/apps/slides/composables/useShortcuts.js
+++ b/frontend/src/apps/slides/composables/useShortcuts.js
@@ -148,9 +148,10 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 		pendingShapeType.value = shapeType
 	}
 
-	// dialogs dismiss on Escape only if the event wasn't defaultPrevented,
+	// overlays dismiss on Escape only if the event wasn't defaultPrevented,
 	// and matching a shortcut always prevents — so don't match while one is open
-	const hasOpenDialog = () => !!document.querySelector('[role="dialog"]')
+	const hasOpenOverlay = () =>
+		!!document.querySelector('[data-dismissable-layer][data-state="open"]')
 
 	const handleEscape = (e) => {
 		if (isPlainInput(e)) return e.target.blur()
@@ -268,7 +269,7 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 			description: 'Deselect',
 			group: 'Edit',
 			allowInInput: true,
-			condition: () => inEditMode() && !hasOpenDialog(),
+			condition: () => inEditMode() && !hasOpenOverlay(),
 			handler: handleEscape,
 		},
 		{

--- a/frontend/src/apps/slides/composables/useShortcuts.js
+++ b/frontend/src/apps/slides/composables/useShortcuts.js
@@ -276,14 +276,16 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 			key: 'Escape',
 			description: 'Exit crop mode',
 			group: 'Edit',
-			condition: () => inCropMode.value,
+			allowInInput: true,
+			condition: () => inCropMode.value && !hasOpenOverlay(),
 			handler: () => cancelCrop(),
 		},
 		{
 			key: 'Enter',
 			description: 'Apply crop',
 			group: 'Edit',
-			condition: () => inCropMode.value,
+			allowInInput: true,
+			condition: () => inCropMode.value && !hasOpenOverlay(),
 			handler: () => commitCrop(),
 		},
 		{

--- a/frontend/src/apps/slides/composables/useShortcuts.js
+++ b/frontend/src/apps/slides/composables/useShortcuts.js
@@ -18,6 +18,8 @@ import {
 } from '@/apps/slides/stores/slide'
 import {
 	resetFocus,
+	exitTextEditing,
+	focusElementId,
 	addTextElement,
 	pendingShapeType,
 	selectAllElements,
@@ -146,6 +148,17 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 		pendingShapeType.value = shapeType
 	}
 
+	// dialogs dismiss on Escape only if the event wasn't defaultPrevented,
+	// and matching a shortcut always prevents — so don't match while one is open
+	const hasOpenDialog = () => !!document.querySelector('[role="dialog"]')
+
+	const handleEscape = (e) => {
+		if (isPlainInput(e)) return e.target.blur()
+		if (focusElementId.value) return exitTextEditing()
+		if (e.target?.isContentEditable) return e.target.blur()
+		resetFocus()
+	}
+
 	useShortcut([
 		{
 			key: '?',
@@ -254,8 +267,9 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 			key: 'Escape',
 			description: 'Deselect',
 			group: 'Edit',
-			condition: inEditMode,
-			handler: () => resetFocus(),
+			allowInInput: true,
+			condition: () => inEditMode() && !hasOpenDialog(),
+			handler: handleEscape,
 		},
 		{
 			key: 'Escape',

--- a/frontend/src/apps/slides/composables/useThumbnailCapture.js
+++ b/frontend/src/apps/slides/composables/useThumbnailCapture.js
@@ -1,4 +1,4 @@
-import { computed, ref, watch, nextTick } from 'vue'
+import { computed, ref, watch, nextTick, onScopeDispose } from 'vue'
 import { debounce } from 'lodash'
 import { call } from 'frappe-ui'
 
@@ -143,6 +143,8 @@ export const useThumbnailCapture = (thumbnailCapture, hasOngoingInteraction) => 
 	}
 
 	watch(slideKey, onSlideChange, { immediate: true })
+
+	onScopeDispose(reset)
 
 	return {
 		cancel,

--- a/frontend/src/apps/slides/composables/useThumbnailCapture.js
+++ b/frontend/src/apps/slides/composables/useThumbnailCapture.js
@@ -10,10 +10,12 @@ import { captureDOM } from '@/apps/slides/utils/domToWebp'
 import { getAttachmentUrl } from '@/apps/slides/utils/mediaUploads'
 
 const DEBOUNCE_MS = 5000
+const MAX_CAPTURE_ATTEMPTS = 3
 
 export const useThumbnailCapture = (thumbnailCapture, hasOngoingInteraction) => {
 	const pendingKey = ref('')
 	const busy = ref(false)
+	const failedAttempts = ref(0)
 
 	const slideKey = computed(() => getSlideKey())
 
@@ -33,6 +35,7 @@ export const useThumbnailCapture = (thumbnailCapture, hasOngoingInteraction) => 
 
 	const markPending = (key) => {
 		pendingKey.value = key
+		failedAttempts.value = 0
 		schedule()
 	}
 
@@ -66,7 +69,12 @@ export const useThumbnailCapture = (thumbnailCapture, hasOngoingInteraction) => 
 			await apply(url)
 			clear(key)
 		} catch (error) {
-			console.warn('Could not generate presentation thumbnail', error)
+			failedAttempts.value++
+			// give up until the slide changes again
+			if (failedAttempts.value >= MAX_CAPTURE_ATTEMPTS) {
+				console.warn('Could not generate presentation thumbnail', error)
+				clear(key)
+			}
 		} finally {
 			busy.value = false
 			retryIfPending()

--- a/frontend/src/apps/slides/pages/Home.vue
+++ b/frontend/src/apps/slides/pages/Home.vue
@@ -57,6 +57,7 @@ import {
 	templateList,
 	templateListResource,
 } from '@/apps/slides/stores/presentation'
+import { requestFullscreen } from '@/apps/slides/stores/slideshow'
 
 const router = useRouter()
 
@@ -87,6 +88,7 @@ const navigateToPresentation = (name, present) => {
 	name = name || previewPresentation.value?.name
 	previewPresentation.value = null
 	if (present) {
+		requestFullscreen()
 		router.replace({
 			name: 'slides-slideshow',
 			params: { presentationId: name },

--- a/frontend/src/apps/slides/pages/Slideshow.vue
+++ b/frontend/src/apps/slides/pages/Slideshow.vue
@@ -73,6 +73,7 @@ import {
 	inSlideShowMode,
 	showSlideshowEndScreen,
 	requestFullscreen,
+	exitFullscreen,
 	endSlideShow,
 	prefetchNextSlide,
 	changeSlideInSlideshow,
@@ -322,6 +323,12 @@ onActivated(() => {
 onDeactivated(() => {
 	document.removeEventListener('fullscreenchange', handleFullScreenChange)
 	window.removeEventListener('resize', updateWindowSize)
+
+	// leaving by any route other than endSlideShow would strand the editor in fullscreen
+	if (inSlideShowMode.value) {
+		inSlideShowMode.value = false
+		exitFullscreen()
+	}
 })
 
 watch(

--- a/frontend/src/apps/slides/pages/Slideshow.vue
+++ b/frontend/src/apps/slides/pages/Slideshow.vue
@@ -63,8 +63,7 @@
 
 <script setup>
 import { computed, onActivated, onDeactivated, ref, useTemplateRef, watch, provide } from 'vue'
-import { useRouter } from 'vue-router'
-import { useShortcut } from 'frappe-ui'
+import { toast, useShortcut } from 'frappe-ui'
 
 import SlideElement from '@/apps/slides/components/SlideElement.vue'
 import SlideshowEndScreen from '@/apps/slides/components/SlideshowEndScreen.vue'
@@ -73,6 +72,7 @@ import FadeElementTransition from '@/apps/slides/components/FadeElementTransitio
 import {
 	inSlideShowMode,
 	showSlideshowEndScreen,
+	requestFullscreen,
 	endSlideShow,
 	prefetchNextSlide,
 	changeSlideInSlideshow,
@@ -85,8 +85,6 @@ import { currentSlide, setSlideIndex, slideIndex, slides } from '@/apps/slides/s
 import { resetFocus } from '@/apps/slides/stores/element'
 
 const slideContainerRef = useTemplateRef('slideContainer')
-
-const router = useRouter()
 
 const props = defineProps({
 	presentationId: {
@@ -275,7 +273,7 @@ const handleFullScreenChange = () => {
 		inSlideShowMode.value = true
 	} else {
 		slideContainerRef.value?.removeEventListener('mousemove', resetCursorVisibility)
-		endSlideShow()
+		if (inSlideShowMode.value) endSlideShow()
 	}
 }
 
@@ -287,23 +285,15 @@ const slideContainerStyles = computed(() => {
 })
 
 const initFullscreenMode = async () => {
-	const container = slideContainerRef.value
-	if (!container) return
-
-	const fullscreenMethods = [
-		container.requestFullscreen,
-		container.webkitRequestFullscreen, // Safari
-		container.msRequestFullscreen, // IE
-		container.mozRequestFullScreen, // Firefox
-	]
-
-	const fullscreenMethod = fullscreenMethods.find((method) => method)
-
-	if (fullscreenMethod) {
-		fullscreenMethod.call(container).catch((e) => {
-			router.replace({ name: 'slides-editor' })
-		})
+	// fullscreen is requested on the click that starts the slideshow, so the
+	// change event fires before this component is around to hear it
+	if (!document.fullscreenElement && !(await requestFullscreen())) {
+		toast.error('Could not enter fullscreen mode')
+		endSlideShow()
+		return
 	}
+
+	handleFullScreenChange()
 }
 
 const loadPresentation = async () => {

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -673,13 +673,17 @@ const deleteElements = async (e, ids) => {
 	let commands = []
 
 	idsToDelete.forEach((id) => {
+		const element = currentSlide.value.elements.find((el) => el.id === id)
+		if (!element) return
 		commands.push(
 			removeElementCommand({
 				slideId: currentSlide.value.clientId,
-				element: currentSlide.value.elements.find((el) => el.id === id),
+				element,
 			}),
 		)
 	})
+
+	if (!commands.length) return
 
 	const elementsCopy = JSON.parse(JSON.stringify(currentSlide.value.elements))
 	const normalizedElements = normalizeZIndices(
@@ -718,6 +722,12 @@ const resetFocus = () => {
 	activeElementIds.value = []
 	focusElementId.value = null
 	pairElementId.value = null
+}
+
+// exit text editing but keep the element selected; the focusElementId
+// watch tears down the editor
+const exitTextEditing = () => {
+	focusElementId.value = null
 }
 
 const getElementPosition = (elementId) => {
@@ -889,7 +899,7 @@ watch(
 
 // focusElementId changing to a shape's id enters text-edit mode for that shape.
 // The activeElement watch won't fire then (same element object), so this handles it.
-// Also handles the inverse: focusElementId cleared while still on the same shape (Escape).
+// Also handles the inverse: focusElementId cleared while the element stays selected (Escape).
 watch(
 	() => focusElementId.value,
 	(id, oldId) => {
@@ -899,9 +909,10 @@ watch(
 		} else if (oldId && activeEditor.value) {
 			if (activeElement.value?.id !== oldId) return
 			const oldElement = findSlideElement(oldId)
-			if (oldElement?.type !== 'shape') return
+			if (!['text', 'shape'].includes(oldElement?.type)) return
 			blurAndSaveContent(oldElement)
-			replaceEditor()
+			if (oldElement.type === 'shape') replaceEditor()
+			else replaceEditor(() => initEditorForElement(findSlideElement(oldId)))
 		}
 	},
 )
@@ -1042,6 +1053,7 @@ export {
 	activeElement,
 	setActiveElements,
 	resetFocus,
+	exitTextEditing,
 	addTextElement,
 	addMediaElement,
 	addShapeElement,

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -673,6 +673,7 @@ const deleteElements = async (e, ids) => {
 	let commands = []
 
 	idsToDelete.forEach((id) => {
+		// re-entrant: the focusElementId and activeElement watches both blur an empty text element
 		const element = currentSlide.value.elements.find((el) => el.id === id)
 		if (!element) return
 		commands.push(

--- a/frontend/src/apps/slides/stores/presentation.js
+++ b/frontend/src/apps/slides/stores/presentation.js
@@ -7,6 +7,7 @@ import { router } from '@/apps/slides/router'
 import { slides } from './slide'
 import { markClean, markDirty, getPresentationFromLocalDB } from './saving'
 import { normalizeZIndices } from '@/apps/slides/stores/element'
+import { normalizeColor } from '@/apps/slides/utils/color'
 import { v4 as uuid4 } from 'uuid'
 import { commandHistory } from './historyMeta'
 
@@ -170,6 +171,9 @@ const parseElements = (value, slide) => {
 			// 'circle' was renamed to 'oval' to match the display name
 			el.shapeType = 'oval'
 		}
+		for (const key of ['fillColor', 'strokeColor', 'borderColor', 'shadowColor']) {
+			if (el[key]) el[key] = normalizeColor(el[key])
+		}
 		migrateShadow(el)
 		return el
 	})
@@ -193,6 +197,7 @@ const ensureUniqueClientIds = (slides) => {
 
 const normalizeSlideDoc = (doc) => {
 	for (const slide of doc.slides || []) {
+		slide.background = normalizeColor(slide.background)
 		slide.elements = parseElements(slide.elements, slide)
 		slide.clientId = slide.client_id || uuid4()
 		slide.transitionDuration = slide.transition_duration
@@ -229,6 +234,7 @@ const getPresentationResource = (name) => {
 				const restored = JSON.parse(JSON.stringify(local.content))
 				// local content skips the load pipeline; migrate + dedup it here too
 				for (const slide of restored) {
+					slide.background = normalizeColor(slide.background)
 					slide.elements = parseElements(slide.elements, slide)
 				}
 				ensureUniqueClientIds(restored)

--- a/frontend/src/apps/slides/stores/saving.js
+++ b/frontend/src/apps/slides/stores/saving.js
@@ -106,24 +106,28 @@ const isSaving = ref(false)
 // true when an online save to the server failed; drives the "Not saved" indicator
 const saveFailed = ref(false)
 
-const syncSnapshotToServer = async (snapshot) => {
+const syncSnapshotToServer = async (snapshot, generation) => {
 	await savePresentationDoc(snapshot.content)
 
-	// mark local copy clean; baseModified tracks the server version we're now in sync with
+	// an edit made mid-save isn't in the snapshot the server just took, so the
+	// local copy has to keep it and stay dirty; baseModified tracks the server version
+	const editedDuringSave = dirtyGeneration !== generation
+
 	await savePresentationToLocalDB({
 		...snapshot,
-		dirty: false,
+		content: editedDuringSave ? getLatestSlideContent() : snapshot.content,
+		dirty: editedDuringSave,
 		updatedAt: Date.now(),
 		baseModified: presentationDoc.value?.modified,
 	})
 }
 
-const syncPresentationToServer = async () => {
+const syncPresentationToServer = async (generation) => {
 	const snapshot = await getPresentationFromLocalDB(presentationId.value)
 	if (!snapshot || !snapshot.dirty) return
 
 	// throws on failure so the caller keeps the state dirty and retries
-	await syncSnapshotToServer(snapshot)
+	await syncSnapshotToServer(snapshot, generation)
 }
 
 const getLatestSlideContent = () => {
@@ -156,7 +160,7 @@ const saveCurrentState = async () => {
 
 		// only mark clean once the server actually has the changes,
 		// and only if no edit arrived while this save was in flight
-		await syncPresentationToServer()
+		await syncPresentationToServer(generationAtSnapshot)
 		if (dirtyGeneration === generationAtSnapshot) markClean()
 		saveFailed.value = false
 	} catch (err) {

--- a/frontend/src/apps/slides/stores/saving.js
+++ b/frontend/src/apps/slides/stores/saving.js
@@ -89,8 +89,12 @@ const getPresentationFromLocalDB = async (id) => {
 // explicit dirty flag set by every mutation path
 const dirty = ref(false)
 
+// bumped on every markDirty so a save can tell if edits arrived while it was in flight
+let dirtyGeneration = 0
+
 const markDirty = () => {
 	dirty.value = true
+	dirtyGeneration++
 }
 
 const markClean = () => {
@@ -135,6 +139,7 @@ const saveCurrentState = async () => {
 	isSaving.value = true
 
 	try {
+		const generationAtSnapshot = dirtyGeneration
 		const content = getLatestSlideContent()
 
 		// save to indexedDB as dirty (not yet synced); baseModified = server version these build on
@@ -149,9 +154,10 @@ const saveCurrentState = async () => {
 		// if offline, stay dirty so we retry once back online
 		if (!navigator.onLine) return
 
-		// only mark clean once the server actually has the changes
+		// only mark clean once the server actually has the changes,
+		// and only if no edit arrived while this save was in flight
 		await syncPresentationToServer()
-		markClean()
+		if (dirtyGeneration === generationAtSnapshot) markClean()
 		saveFailed.value = false
 	} catch (err) {
 		// keep dirty so autosave retries and beforeunload warns; log once per outage

--- a/frontend/src/apps/slides/stores/saving.js
+++ b/frontend/src/apps/slides/stores/saving.js
@@ -106,8 +106,16 @@ const isSaving = ref(false)
 // true when an online save to the server failed; drives the "Not saved" indicator
 const saveFailed = ref(false)
 
-const syncSnapshotToServer = async (snapshot, generation) => {
+const syncSnapshotToServer = async (snapshot, id, generation) => {
+	// the resource points at whatever the editor moved on to, so this content
+	// would land on the wrong document; the snapshot stays dirty and gets retried
+	if (presentationId.value !== id) return
+
 	await savePresentationDoc(snapshot.content)
+
+	// slides and presentationDoc now belong to another presentation,
+	// so there's nothing safe to write back to the local copy
+	if (presentationId.value !== id) return
 
 	// an edit made mid-save isn't in the snapshot the server just took, so the
 	// local copy has to keep it and stay dirty; baseModified tracks the server version
@@ -122,12 +130,12 @@ const syncSnapshotToServer = async (snapshot, generation) => {
 	})
 }
 
-const syncPresentationToServer = async (generation) => {
-	const snapshot = await getPresentationFromLocalDB(presentationId.value)
+const syncPresentationToServer = async (id, generation) => {
+	const snapshot = await getPresentationFromLocalDB(id)
 	if (!snapshot || !snapshot.dirty) return
 
 	// throws on failure so the caller keeps the state dirty and retries
-	await syncSnapshotToServer(snapshot, generation)
+	await syncSnapshotToServer(snapshot, id, generation)
 }
 
 const getLatestSlideContent = () => {
@@ -143,12 +151,13 @@ const saveCurrentState = async () => {
 	isSaving.value = true
 
 	try {
+		const idAtSnapshot = presentationId.value
 		const generationAtSnapshot = dirtyGeneration
 		const content = getLatestSlideContent()
 
 		// save to indexedDB as dirty (not yet synced); baseModified = server version these build on
 		await savePresentationToLocalDB({
-			id: presentationId.value,
+			id: idAtSnapshot,
 			content: content,
 			updatedAt: Date.now(),
 			dirty: true,
@@ -160,9 +169,12 @@ const saveCurrentState = async () => {
 
 		// only mark clean once the server actually has the changes,
 		// and only if no edit arrived while this save was in flight
-		await syncPresentationToServer(generationAtSnapshot)
-		if (dirtyGeneration === generationAtSnapshot) markClean()
+		await syncPresentationToServer(idAtSnapshot, generationAtSnapshot)
 		saveFailed.value = false
+
+		// dirty belongs to another presentation now, so it isn't ours to clear
+		if (presentationId.value !== idAtSnapshot) return
+		if (dirtyGeneration === generationAtSnapshot) markClean()
 	} catch (err) {
 		// keep dirty so autosave retries and beforeunload warns; log once per outage
 		if (!saveFailed.value) console.error('Save failed: ', err)

--- a/frontend/src/apps/slides/stores/saving.test.ts
+++ b/frontend/src/apps/slides/stores/saving.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+const presentationId = ref('p1')
+const presentationDoc = ref<any>({ modified: 'M1' })
+const inReadonlyMode = ref(false)
+const slides = ref<any[]>([{ clientId: 'c1', background: '#ff0000ff', elements: [] }])
+
+let serverSave: (content: any) => Promise<void>
+
+vi.mock('@/apps/slides/stores/presentation', () => ({
+	presentationId,
+	presentationDoc,
+	inReadonlyMode,
+	savePresentationDoc: (content: any) => serverSave(content),
+}))
+
+vi.mock('@/apps/slides/stores/slide', () => ({ slides }))
+
+vi.mock('@/apps/slides/utils/helpers', () => ({
+	cloneObj: (obj: any) => JSON.parse(JSON.stringify(obj)),
+}))
+
+const { saveCurrentState, markDirty, dirty, getPresentationFromLocalDB } = await import('./saving')
+
+describe('saveCurrentState', () => {
+	beforeEach(() => {
+		presentationDoc.value = { modified: 'M1' }
+		slides.value = [{ clientId: 'c1', background: '#ff0000ff', elements: [] }]
+		serverSave = async () => {
+			presentationDoc.value = { modified: 'M2' }
+		}
+	})
+
+	it('persists edits made while the server save is in flight', async () => {
+		markDirty()
+
+		serverSave = async () => {
+			// the user picks a second color while the first save is still in flight
+			slides.value[0].background = '#00ff00ff'
+			markDirty()
+			presentationDoc.value = { modified: 'M2' }
+		}
+
+		await saveCurrentState()
+
+		const local: any = await getPresentationFromLocalDB('p1')
+		expect(dirty.value).toBe(true)
+		expect(local.dirty).toBe(true)
+		expect(local.content[0].background).toBe('#00ff00ff')
+	})
+
+	it('marks the local copy clean when nothing changed during the save', async () => {
+		markDirty()
+
+		await saveCurrentState()
+
+		const local: any = await getPresentationFromLocalDB('p1')
+		expect(dirty.value).toBe(false)
+		expect(local.dirty).toBe(false)
+		expect(local.baseModified).toBe('M2')
+	})
+})

--- a/frontend/src/apps/slides/stores/saving.test.ts
+++ b/frontend/src/apps/slides/stores/saving.test.ts
@@ -25,6 +25,7 @@ const { saveCurrentState, markDirty, dirty, getPresentationFromLocalDB } = await
 
 describe('saveCurrentState', () => {
 	beforeEach(() => {
+		presentationId.value = 'p1'
 		presentationDoc.value = { modified: 'M1' }
 		slides.value = [{ clientId: 'c1', background: '#ff0000ff', elements: [] }]
 		serverSave = async () => {
@@ -48,6 +49,25 @@ describe('saveCurrentState', () => {
 		expect(dirty.value).toBe(true)
 		expect(local.dirty).toBe(true)
 		expect(local.content[0].background).toBe('#00ff00ff')
+	})
+
+	it('leaves the local copy alone when the editor moved on mid-save', async () => {
+		markDirty()
+
+		serverSave = async () => {
+			// resetEditorState() blanks slides but leaves presentationId and the resource,
+			// and savePresentationDoc then repoints presentationDoc at the old doc
+			slides.value = []
+			markDirty()
+			presentationId.value = 'p2'
+			presentationDoc.value = { modified: 'M2' }
+		}
+
+		await saveCurrentState()
+
+		const local: any = await getPresentationFromLocalDB('p1')
+		expect(local.content).toHaveLength(1)
+		expect(local.baseModified).toBe('M1')
 	})
 
 	it('marks the local copy clean when nothing changed during the save', async () => {

--- a/frontend/src/apps/slides/stores/slideshow.js
+++ b/frontend/src/apps/slides/stores/slideshow.js
@@ -9,22 +9,22 @@ const inSlideShowMode = ref(false)
 
 // the click's user activation expires before the slideshow route finishes
 // loading, so fullscreen has to be requested here and not on the other side
-const requestFullscreen = async () => {
+let pendingFullscreen = null
+
+const requestFullscreen = () => {
+	if (pendingFullscreen) return pendingFullscreen
+
 	const el = document.documentElement
-	const request =
-		el.requestFullscreen ||
-		el.webkitRequestFullscreen ||
-		el.msRequestFullscreen ||
-		el.mozRequestFullScreen
+	if (!el.requestFullscreen) return Promise.resolve(false)
 
-	if (!request) return false
+	// a second request would consume the already-spent activation and reject
+	pendingFullscreen = el
+		.requestFullscreen()
+		.then(() => true)
+		.catch(() => false)
+		.finally(() => (pendingFullscreen = null))
 
-	try {
-		await request.call(el)
-		return true
-	} catch {
-		return false
-	}
+	return pendingFullscreen
 }
 
 const exitFullscreen = () => {
@@ -156,6 +156,7 @@ export {
 	inSlideShowMode,
 	showSlideshowEndScreen,
 	requestFullscreen,
+	exitFullscreen,
 	startSlideShow,
 	endSlideShow,
 	prefetchNextSlide,

--- a/frontend/src/apps/slides/stores/slideshow.js
+++ b/frontend/src/apps/slides/stores/slideshow.js
@@ -7,7 +7,32 @@ import { session } from '@/boot/session'
 
 const inSlideShowMode = ref(false)
 
+// the click's user activation expires before the slideshow route finishes
+// loading, so fullscreen has to be requested here and not on the other side
+const requestFullscreen = async () => {
+	const el = document.documentElement
+	const request =
+		el.requestFullscreen ||
+		el.webkitRequestFullscreen ||
+		el.msRequestFullscreen ||
+		el.mozRequestFullScreen
+
+	if (!request) return false
+
+	try {
+		await request.call(el)
+		return true
+	} catch {
+		return false
+	}
+}
+
+const exitFullscreen = () => {
+	if (document.fullscreenElement) document.exitFullscreen()
+}
+
 const startSlideShow = () => {
+	requestFullscreen()
 	router.replace({
 		name: 'slides-slideshow',
 		params: router.currentRoute.value.params,
@@ -16,6 +41,7 @@ const startSlideShow = () => {
 }
 
 const endSlideShow = () => {
+	exitFullscreen()
 	inSlideShowMode.value = false
 	focusedSlide.value = null
 	const slide =
@@ -129,6 +155,7 @@ const changeSlideInSlideshow = (index) => {
 export {
 	inSlideShowMode,
 	showSlideshowEndScreen,
+	requestFullscreen,
 	startSlideShow,
 	endSlideShow,
 	prefetchNextSlide,

--- a/frontend/src/apps/slides/utils/color.js
+++ b/frontend/src/apps/slides/utils/color.js
@@ -2,7 +2,8 @@ import tinycolor from 'tinycolor2'
 
 // colors saved before hex normalization lack the leading '#' and render as invalid CSS
 export const normalizeColor = (colorString) => {
-	if (!colorString || colorString.startsWith('#')) return colorString
+	if (!colorString || typeof colorString !== 'string' || colorString.startsWith('#'))
+		return colorString
 	const parsed = tinycolor(colorString)
 	return parsed.isValid() ? parsed.toHex8String() : colorString
 }

--- a/frontend/src/apps/slides/utils/color.js
+++ b/frontend/src/apps/slides/utils/color.js
@@ -1,3 +1,12 @@
+import tinycolor from 'tinycolor2'
+
+// colors saved before hex normalization lack the leading '#' and render as invalid CSS
+export const normalizeColor = (colorString) => {
+	if (!colorString || colorString.startsWith('#')) return colorString
+	const parsed = tinycolor(colorString)
+	return parsed.isValid() ? parsed.toHex8String() : colorString
+}
+
 export const isBackgroundColorDark = (colorString = '#ffffff') => {
 	if (!colorString) colorString = '#ffffff'
 	const rgb = colorString.replace('#', '')


### PR DESCRIPTION
### Fixes

- Border Style dropdown read a renamed slot prop and threw on open, so the menu never rendered. Same control backs shape Stroke Style.
- Images default to `borderStyle: none`, so Weight and Color were invisible no-ops. Setting either now turns the border on, and Style leads the section.
- Color picker showed 8-digit hex next to an opacity slider, ignored Enter, stored typed values raw, and uppercased its placeholder. Now 6 digits with alpha on the slider, Enter commits, `ff0000` and `#f00` normalize, placeholder doesn't capitalize.
- Escape was swallowed while focus sat in text or a panel input. Now exits one level at a time, reverts number inputs, and leaves dialogs and popovers to close on their own.
- Failed thumbnail captures retried every 5s for the life of the session. Now gives up after 3 with one warning.
- Fullscreen was requested after the route transition, past the user-gesture window, and the rejection bounced silently back to the editor. Requested up front now, and leaving by any route exits fullscreen.