### PR TITLE
fix(mail): keep editor colours through send and read

### DIFF
--- a/frontend/src/apps/mail/components/EmailContent.vue
+++ b/frontend/src/apps/mail/components/EmailContent.vue
@@ -369,6 +369,10 @@ const DOMPURIFY_CONFIG = {
 		'em',
 		'i',
 		'u',
+		// Highlighted text. Without it KEEP_CONTENT hands the words back unstyled, so a
+		// highlight applied in our own composer came back to the reader as plain text —
+		// while the text colour beside it, which rides a <span>, survived.
+		'mark',
 		'h1',
 		'h2',
 		'h3',

--- a/frontend/src/apps/mail/utils/editorColors.test.ts
+++ b/frontend/src/apps/mail/utils/editorColors.test.ts
@@ -77,14 +77,17 @@ describe('text colour inside a highlight', () => {
 	})
 })
 
-// A reply carries the quoted message along with it. That part is the other sender's document,
-// written against the browser default we would be overriding, so it is left as they wrote it.
-describe('quoted mail', () => {
-	it.each(['frappe_mail_quote', 'gmail_quote'])('keeps a highlight in a %s as written', (quote) => {
-		const html = `<div class="${quote}"><mark style="background-color: #fef08a">theirs</mark></div>`
+// A reply or a forward carries the other sender's message along with it. That part is their
+// document, written against the browser default we would be overriding, so it is left as written.
+describe('mail carried into a reply or forward', () => {
+	it.each(['frappe_mail_quote', 'frappe_mail_fwd', 'gmail_quote'])(
+		'keeps a highlight in a %s as written',
+		(wrapper) => {
+			const html = `<div class="${wrapper}"><mark style="background-color: #fef08a">theirs</mark></div>`
 
-		expect(outbound(html)).toBe(html)
-	})
+			expect(outbound(html)).toBe(html)
+		},
+	)
 
 	it('still fixes the highlight above the quote', () => {
 		const composed = '<mark style="background-color: #fef08a">mine</mark>'

--- a/frontend/src/apps/mail/utils/editorColors.test.ts
+++ b/frontend/src/apps/mail/utils/editorColors.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import * as cheerio from 'cheerio'
+
+import { preserveEditorColors } from '@/apps/mail/utils/editorColors'
+
+// Runs a body through the outbound pass the way processInlineImages does.
+const outbound = (html: string) => {
+	const $ = cheerio.load(html)
+	preserveEditorColors($)
+	return $('body').html() ?? ''
+}
+
+describe('resolving the editor’s colour variables', () => {
+	it('replaces a text colour with its literal value', () => {
+		const html = '<span style="color: var(--prose-color-blue)">tomorrow</span>'
+
+		expect(outbound(html)).toBe('<span style="color: #1579D0">tomorrow</span>')
+	})
+
+	it('replaces a highlight colour with its literal value', () => {
+		const html = '<mark style="background-color: var(--prose-highlight-yellow)">note</mark>'
+
+		expect(outbound(html)).toContain('background-color: #fef08a')
+	})
+
+	// The variable is defined only inside .ProseMirror, so anything left holding one renders
+	// uncoloured wherever the mail is actually read.
+	it('leaves no prose variables behind', () => {
+		const html =
+			'<span style="color: var(--prose-color-red)">a</span>' +
+			'<span style="color: var(--prose-color-green)">b</span>'
+
+		expect(outbound(html)).not.toContain('var(--prose-')
+	})
+
+	// Better an unstyled word than a confidently wrong colour.
+	it('leaves a colour it does not know as the variable', () => {
+		const html = '<span style="color: var(--prose-color-chartreuse)">x</span>'
+
+		expect(outbound(html)).toBe(html)
+	})
+
+	it.each([
+		['<div>plain text</div>', 'a body with no colour'],
+		['<span style="color: #1579D0">already resolved</span>', 'a body that went out before'],
+		['<span style="color: var(--surface-blue-1)">app token</span>', 'a non-prose variable'],
+	])('leaves %s untouched (%s)', (html) => {
+		expect(outbound(html)).toBe(html)
+	})
+})
+
+// Every browser's default stylesheet gives <mark> its own color, which beats a colour inherited
+// from the span the editor wraps around it — so a coloured highlight arrives with black text.
+describe('text colour inside a highlight', () => {
+	it('survives the mark’s default colour', () => {
+		const html =
+			'<span style="color: var(--prose-color-orange)">' +
+			'<mark style="background-color: var(--prose-highlight-orange)">Best,</mark></span>'
+
+		const result = outbound(html)
+
+		expect(result).toContain('color: #ea580c')
+		expect(result).toContain('background-color: #fed7aa')
+		expect(result).toContain('color: inherit')
+	})
+
+	it('does not override a colour the mark already carries', () => {
+		const html = '<mark style="background-color: #fef08a; color: #dc2626">x</mark>'
+
+		expect(outbound(html)).toBe(html)
+	})
+
+	it('is a no-op for an uncoloured highlight beyond the default it restores', () => {
+		const html = '<mark style="background-color: #fef08a">x</mark>'
+
+		expect(outbound(html)).toBe('<mark style="background-color: #fef08a; color: inherit">x</mark>')
+	})
+})

--- a/frontend/src/apps/mail/utils/editorColors.test.ts
+++ b/frontend/src/apps/mail/utils/editorColors.test.ts
@@ -76,3 +76,33 @@ describe('text colour inside a highlight', () => {
 		expect(outbound(html)).toBe('<mark style="background-color: #fef08a; color: inherit">x</mark>')
 	})
 })
+
+// A reply carries the quoted message along with it. That part is the other sender's document,
+// written against the browser default we would be overriding, so it is left as they wrote it.
+describe('quoted mail', () => {
+	it.each(['frappe_mail_quote', 'gmail_quote'])('keeps a highlight in a %s as written', (quote) => {
+		const html = `<div class="${quote}"><mark style="background-color: #fef08a">theirs</mark></div>`
+
+		expect(outbound(html)).toBe(html)
+	})
+
+	it('still fixes the highlight above the quote', () => {
+		const composed = '<mark style="background-color: #fef08a">mine</mark>'
+		const quoted =
+			'<div class="frappe_mail_quote"><mark style="background-color: #fef08a">theirs</mark></div>'
+
+		const result = outbound(composed + quoted)
+
+		expect(result).toContain('<mark style="background-color: #fef08a; color: inherit">mine</mark>')
+		expect(result).toContain('<mark style="background-color: #fef08a">theirs</mark>')
+	})
+
+	// Our own earlier mail coming back in a quote still carries our variables, and they are as
+	// unrenderable there as anywhere else.
+	it('still resolves our colour variables inside a quote', () => {
+		const html =
+			'<div class="frappe_mail_quote"><span style="color: var(--prose-color-blue)">a</span></div>'
+
+		expect(outbound(html)).toContain('color: #1579D0')
+	})
+})

--- a/frontend/src/apps/mail/utils/editorColors.ts
+++ b/frontend/src/apps/mail/utils/editorColors.ts
@@ -67,17 +67,20 @@ export const resolveColorVariables = (style: string) =>
 // `inherit` is the fix rather than the resolved hex, because it is correct whichever way round
 // the two marks happen to nest, and it is a no-op when the run isn't coloured at all. Marks that
 // already carry a colour of their own are left alone.
-// Quoted mail is somebody else's document, and a <mark> in it was written expecting the browser
-// default we would be overriding — so `inherit` there could recolour their words from whatever
-// element happens to enclose the quote. Left alone. (Both spellings, because the quote may be one
-// of ours or one carried in from Gmail, and openQuotedContent folds it straight into the body, so
-// the two can't be told apart by which string they arrived in.)
-const QUOTE = '.frappe_mail_quote, .gmail_quote'
+// Mail carried into a reply or a forward is somebody else's document, and a <mark> in it was
+// written expecting the browser default we would be overriding — so `inherit` there could recolour
+// their words from whatever element happens to enclose the block. Left alone.
+//
+// All three spellings: our own quote and forward wrappers (MailThread's getQuotedContent and
+// getForwardedContent) and Gmail's. Matching on the wrapper rather than on which field the HTML
+// arrived in is what makes this hold — openQuotedContent folds the quote straight into html_body,
+// so by the time this runs the composed and carried-over parts are one string.
+const CARRIED_OVER = '.frappe_mail_quote, .frappe_mail_fwd, .gmail_quote'
 
 const keepTextColorThroughHighlights = ($: CheerioAPI) => {
 	$('mark').each((_, element) => {
 		const mark = $(element)
-		if (mark.closest(QUOTE).length) return
+		if (mark.closest(CARRIED_OVER).length) return
 
 		const style = mark.attr('style') ?? ''
 		if (/(^|;)\s*color\s*:/.test(style)) return

--- a/frontend/src/apps/mail/utils/editorColors.ts
+++ b/frontend/src/apps/mail/utils/editorColors.ts
@@ -1,0 +1,88 @@
+import type { CheerioAPI } from 'cheerio'
+
+// The editor writes a named colour as `color: var(--prose-color-blue)`, and that variable is only
+// ever defined inside `.ProseMirror`. Everywhere else the declaration is invalid and the text falls
+// back to the inherited colour: the recipient's client shows black, and so does our own reader,
+// which renders the body in an iframe that never sees the app's stylesheet. That is why a
+// coloured line reads as uncoloured in Sent — the sender's copy is stripped just like the
+// recipient's is.
+//
+// So the variable has to be resolved to a literal colour before the body leaves the editor.
+//
+// Deliberately the light-scheme value, not the current theme's: a sent mail is a fixed document,
+// and the reader remaps light-scheme mail onto the dark canvas at display time (see darkMail.ts).
+// Baking dark colours into the wire format would defeat that and reach the recipient wrong.
+//
+// The values are frappe-ui's own — `textColorHexMap` and `highlightColorHexMap` in
+// TextEditor/extensions/shared/color-utils.ts. They are copied rather than imported because that
+// module isn't in frappe-ui's package exports. They double as the extension's own legacy parse
+// map, so a body written this way still reads back as a named colour when a draft is reopened.
+const TEXT_COLORS: Record<string, string> = {
+	black: '#000000',
+	red: '#dc2626',
+	blue: '#1579D0',
+	green: '#16a34a',
+	yellow: '#ca8a04',
+	orange: '#ea580c',
+	purple: '#9333ea',
+	pink: '#db2777',
+	gray: '#6b7280',
+	indigo: '#4f46e5',
+	teal: '#0d9488',
+	cyan: '#06b6d4',
+}
+
+const HIGHLIGHT_COLORS: Record<string, string> = {
+	red: '#fecaca',
+	blue: '#bfdbfe',
+	green: '#bbf7d0',
+	yellow: '#fef08a',
+	orange: '#fed7aa',
+	purple: '#e9d5ff',
+	pink: '#fbcfe8',
+	gray: '#e5e7eb',
+	indigo: '#c7d2fe',
+	teal: '#99f6e4',
+	cyan: '#a5f3fc',
+}
+
+const PROSE_COLOR_VAR = /var\(--prose-(color|highlight)-([a-z]+)\)/g
+
+// A name we don't know is left as the variable rather than guessed at: an unstyled word is a
+// smaller loss than a confidently wrong colour, and it keeps a colour added upstream from being
+// silently flattened to something else.
+export const resolveColorVariables = (style: string) =>
+	style.replace(PROSE_COLOR_VAR, (variable, kind: string, name: string) => {
+		const palette = kind === 'color' ? TEXT_COLORS : HIGHLIGHT_COLORS
+		return palette[name] ?? variable
+	})
+
+// Text colour and highlight are separate marks, so colouring a highlighted run nests them:
+// `<span style="color: …"><mark style="background-color: …">`. That looks right in the editor and
+// is wrong the moment it leaves, because every browser's default stylesheet gives <mark> its own
+// `color`, and a colour set *on* the element beats one inherited from an ancestor. The highlight
+// survives, the text colour is overruled, and the words come out black on the background — which
+// is exactly what Gmail shows.
+//
+// `inherit` is the fix rather than the resolved hex, because it is correct whichever way round
+// the two marks happen to nest, and it is a no-op when the run isn't coloured at all. Marks that
+// already carry a colour of their own are left alone.
+const keepTextColorThroughHighlights = ($: CheerioAPI) => {
+	$('mark').each((_, element) => {
+		const mark = $(element)
+		const style = mark.attr('style') ?? ''
+		if (/(^|;)\s*color\s*:/.test(style)) return
+
+		mark.attr('style', style ? `${style.replace(/;\s*$/, '')}; color: inherit` : 'color: inherit')
+	})
+}
+
+// Everything that has to happen to the editor's colours before a body goes on the wire.
+export const preserveEditorColors = ($: CheerioAPI) => {
+	$('[style]').each((_, element) => {
+		const styled = $(element)
+		styled.attr('style', resolveColorVariables(styled.attr('style')!))
+	})
+
+	keepTextColorThroughHighlights($)
+}

--- a/frontend/src/apps/mail/utils/editorColors.ts
+++ b/frontend/src/apps/mail/utils/editorColors.ts
@@ -58,18 +58,27 @@ export const resolveColorVariables = (style: string) =>
 	})
 
 // Text colour and highlight are separate marks, so colouring a highlighted run nests them:
-// `<span style="color: …"><mark style="background-color: …">`. That looks right in the editor and
-// is wrong the moment it leaves, because every browser's default stylesheet gives <mark> its own
-// `color`, and a colour set *on* the element beats one inherited from an ancestor. The highlight
-// survives, the text colour is overruled, and the words come out black on the background — which
-// is exactly what Gmail shows.
+// `<span style="color: …"><mark style="background-color: …">`. That looks right in the editor
+// and is wrong the moment it leaves, because every browser's default stylesheet gives <mark> its
+// own `color`, and a colour set *on* the element beats one inherited from an ancestor. The
+// highlight survives, the text colour is overruled, and the words come out black on the
+// background — which is exactly what Gmail shows.
 //
 // `inherit` is the fix rather than the resolved hex, because it is correct whichever way round
 // the two marks happen to nest, and it is a no-op when the run isn't coloured at all. Marks that
 // already carry a colour of their own are left alone.
+// Quoted mail is somebody else's document, and a <mark> in it was written expecting the browser
+// default we would be overriding — so `inherit` there could recolour their words from whatever
+// element happens to enclose the quote. Left alone. (Both spellings, because the quote may be one
+// of ours or one carried in from Gmail, and openQuotedContent folds it straight into the body, so
+// the two can't be told apart by which string they arrived in.)
+const QUOTE = '.frappe_mail_quote, .gmail_quote'
+
 const keepTextColorThroughHighlights = ($: CheerioAPI) => {
 	$('mark').each((_, element) => {
 		const mark = $(element)
+		if (mark.closest(QUOTE).length) return
+
 		const style = mark.attr('style') ?? ''
 		if (/(^|;)\s*color\s*:/.test(style)) return
 
@@ -79,6 +88,9 @@ const keepTextColorThroughHighlights = ($: CheerioAPI) => {
 
 // Everything that has to happen to the editor's colours before a body goes on the wire.
 export const preserveEditorColors = ($: CheerioAPI) => {
+	// Variables are resolved everywhere, quotes included: only our own editor writes them, so one
+	// inside a quote is our earlier mail coming back and would render just as broken as the first
+	// time. It is the mark rewrite below that has to keep its hands off other people's markup.
 	$('[style]').each((_, element) => {
 		const styled = $(element)
 		styled.attr('style', resolveColorVariables(styled.attr('style')!))

--- a/frontend/src/apps/mail/utils/index.ts
+++ b/frontend/src/apps/mail/utils/index.ts
@@ -5,6 +5,7 @@ import { toast } from 'frappe-ui'
 import { FOLDER_ICON_MAP, SCREENER_MAILBOX_NAME } from '@/apps/mail/constants'
 import dayjs from '@/apps/mail/utils/dayjs'
 import { flattenMentions } from '@/apps/mail/utils/mentions'
+import { preserveEditorColors } from '@/apps/mail/utils/editorColors'
 import AudioIcon from '@/apps/mail/components/Icons/AudioIcon.vue'
 import ImageIcon from '@/apps/mail/components/Icons/ImageIcon.vue'
 import PDFIcon from '@/apps/mail/components/Icons/PDFIcon.vue'
@@ -359,6 +360,11 @@ export const randomString = (length: number) => {
 export const processInlineImages = (mail: ComposeMailData, { sending = false } = {}) => {
 	const htmlBody = mail.html_body! + mail.quoted_content
 	const $ = cheerio.load(htmlBody)
+
+	// Unconditional, unlike the mention flattening below: a draft is rendered by the reader too,
+	// in the same iframe that can't see the editor's stylesheet, so a draft left holding the
+	// variables would already be showing the wrong colours back to its own author.
+	preserveEditorColors($)
 
 	if (sending) flattenMentions($)
 


### PR DESCRIPTION
Text colour and highlight both came out wrong in sent mail, for two separate reasons. Reported by asif and neha.

**Text colour.** The editor writes `color: var(--prose-color-blue)`, and that variable only exists inside `.ProseMirror`. Anywhere the mail is actually read — the recipient's client, our own reader's iframe — it's invalid and the text falls back to black. Sent Items is stripped the same way, so nothing tells the sender. Now resolved to a literal colour before the body leaves the composer.

**Highlight.** Our reader didn't let `mark` through the sanitizer, so the background vanished. Other clients kept the background but showed black text, because a browser's default `mark` colour beats the one inherited from the span around it. Both fixed: `mark` is allowed now, and marks carry an explicit `color: inherit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)