### PR TITLE
fix(calendar): invite mailing list members individually

### DIFF
--- a/suite/calendar/doctype/calendar_event/calendar_event.py
+++ b/suite/calendar/doctype/calendar_event/calendar_event.py
@@ -20,6 +20,7 @@ from suite.calendar.doctype.calendar_event.invitations import (
     acting_as_organizer,
     custom_event_invites_enabled,
 )
+from suite.calendar.doctype.calendar_event.mailing_lists import expand_mailing_list_participants
 from suite.mail.doctype.user_account.user_account import get_user_for_jmap_account
 from suite.mail.jmap import get_calendar_event_service, get_jmap_connection
 from suite.mail.jmap.services.calendars.calendar_event import CalendarEventService
@@ -369,6 +370,7 @@ def add_calendar_event(
 
     uid = uuid7().hex
     creation_id = str(uuid7())
+    participants = expand_mailing_list_participants(participants)
     event = {
         "creation_id": creation_id,
         "uid": uid,
@@ -481,6 +483,7 @@ def update_calendar_event(
 ) -> None:
     """Updates a calendar event for the given account and event ID."""
 
+    participants = expand_mailing_list_participants(participants)
     event = {
         "id": id,
         "uid": uid,
@@ -539,6 +542,9 @@ def update_calendar_event_instance(
     send_scheduling_messages: bool = False,
 ) -> None:
     """Updates a specific instance of a recurring calendar event based on its master ID and recurrence ID."""
+
+    if "participants" in patch:
+        patch = patch | {"participants": expand_mailing_list_participants(patch["participants"])}
 
     use_custom_invites = False
     next_sequence = None

--- a/suite/calendar/doctype/calendar_event/mailing_lists.py
+++ b/suite/calendar/doctype/calendar_event/mailing_lists.py
@@ -34,6 +34,14 @@ def expand_mailing_list_participants(participants: list[dict] | None) -> list[di
     Participants that are not mailing lists are passed through untouched, and the original order is
     preserved. Returns the input unchanged when expansion is disabled or the directory cannot be
     reached — a calendar event is never worth failing over this.
+
+    The size cap bounds the event's total participants, but only members added by expansion are ever
+    dropped to honour it. A participant the organizer named themselves is always kept, even when
+    that pushes the total past the cap, because dropping one removes them from the stored
+    event, and on the next update the invitation code reads that as a withdrawn attendee and mails
+    them a cancellation. For the same reason an explicit participant always wins over the same
+    address arriving through a list, no matter which order they appear in: the explicit entry
+    carries the uid their RSVP is recorded against, and a member entry would reset it.
     """
 
     if not participants or not _expansion_enabled():
@@ -47,29 +55,34 @@ def expand_mailing_list_participants(participants: list[dict] | None) -> list[di
         return participants
 
     limit = _max_participants()
-    expanded: list[dict] = []
-    seen: set[str] = set()
-    dropped: list[str] = []
+    slots: list[tuple[str, dict, bool]] = []
+    explicit: set[str] = set()
 
     for participant in participants:
         email = _email_of(participant)
         if email in index:
-            entries = [
-                (member, _member_participant(participant, member)) for member in _members(email, index)
-            ]
+            slots.extend(
+                (member, _member_participant(participant, member), True) for member in _members(email, index)
+            )
         else:
-            entries = [(email, participant)]
+            slots.append((email, participant, False))
+            if email:
+                explicit.add(email)
 
-        for address, entry in entries:
-            if address and address in seen:
-                continue
-            if len(expanded) >= limit:
-                dropped.append(address)
-                continue
+    expanded: list[dict] = []
+    seen: set[str] = set()
+    dropped: list[str] = []
 
-            if address:
-                seen.add(address)
-            expanded.append(entry)
+    for address, entry, is_member in slots:
+        if address and (address in seen or (is_member and address in explicit)):
+            continue
+        if is_member and len(expanded) >= limit:
+            dropped.append(address)
+            continue
+
+        if address:
+            seen.add(address)
+        expanded.append(entry)
 
     if dropped:
         _report_truncation(limit, dropped)
@@ -152,9 +165,9 @@ def _mailing_list_index() -> dict[str, list[str]]:
 
 
 def _report_truncation(limit: int, dropped: list[str]) -> None:
-    """Surfaces the participants a size cap left out, so the cap is never silent."""
+    """Surfaces the members a size cap left out, so the cap is never silent."""
 
-    message = _("Only the first {0} participants were invited; {1} more were left out.").format(
+    message = _("Mailing list expansion stopped at {0} participants; {1} members were left out.").format(
         limit, len(dropped)
     )
     frappe.msgprint(message, alert=True)

--- a/suite/calendar/doctype/calendar_event/mailing_lists.py
+++ b/suite/calendar/doctype/calendar_event/mailing_lists.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+"""Expansion of mailing list participants into the list's individual members.
+
+Stalwart resolves a mailing list at the SMTP RCPT stage: `team@example.com` is replaced by each
+member's own address before delivery, and the list address is not part of any account's identity.
+An iTIP ATTENDEE naming the list therefore matches nobody on ingest, so members receive the
+invitation mail but the event is never added to their calendars. Groups behave differently only
+because a group is a real principal with its own address and its own calendar.
+
+Replacing the list with one participant per member before the event is stored is what RFC 5546 asks
+the organizer to do, and it fixes both invite paths at once: Frappe Mail's own invitation mails and
+the JMAP server's scheduling messages are both built from the stored participant list. Each member
+also ends up with a distinct participant uid, which is what gives them individual RSVP links.
+
+Membership is resolved once, when the invitation is sent. Someone added to the list afterwards will
+receive later mail to the list but not this event, so participants are re-expanded on every update.
+"""
+
+import frappe
+from frappe import _
+from frappe.utils import cint
+
+from suite.mail.stalwart import get_domains, get_mailing_list_index
+from suite.mail.utils import get_config, log_mail_error
+
+DEFAULT_MAX_PARTICIPANTS = 100
+
+
+def expand_mailing_list_participants(participants: list[dict] | None) -> list[dict] | None:
+    """Replaces any mailing list participant with one participant per member address.
+
+    Participants that are not mailing lists are passed through untouched, and the original order is
+    preserved. Returns the input unchanged when expansion is disabled or the directory cannot be
+    reached — a calendar event is never worth failing over this.
+    """
+
+    if not participants or not _expansion_enabled():
+        return participants
+
+    if not _has_local_participant(participants):
+        return participants
+
+    index = _mailing_list_index()
+    if not index or not any(_email_of(p) in index for p in participants):
+        return participants
+
+    limit = _max_participants()
+    expanded: list[dict] = []
+    seen: set[str] = set()
+    dropped: list[str] = []
+
+    for participant in participants:
+        email = _email_of(participant)
+        if email in index:
+            entries = [
+                (member, _member_participant(participant, member)) for member in _members(email, index)
+            ]
+        else:
+            entries = [(email, participant)]
+
+        for address, entry in entries:
+            if address and address in seen:
+                continue
+            if len(expanded) >= limit:
+                dropped.append(address)
+                continue
+
+            if address:
+                seen.add(address)
+            expanded.append(entry)
+
+    if dropped:
+        _report_truncation(limit, dropped)
+
+    return expanded
+
+
+def _members(address: str, index: dict[str, list[str]]) -> list[str]:
+    """Returns the member addresses behind a list address, resolving nested lists.
+
+    A list may name another list among its recipients. Each nested list is expanded where it sits,
+    so the members come back in the order the lists declare them, and only addresses that are not
+    themselves lists are kept. Addresses already visited are skipped, which also makes a membership
+    cycle terminate.
+    """
+
+    members: list[str] = []
+    seen = {address}
+    stack = list(reversed(index[address]))
+
+    while stack:
+        member = stack.pop()
+        if member in seen:
+            continue
+
+        seen.add(member)
+        if nested := index.get(member):
+            stack.extend(reversed(nested))
+        else:
+            members.append(member)
+
+    return members
+
+
+def _member_participant(participant: dict, email: str) -> dict:
+    """Builds one member's participant entry from the mailing list's entry.
+
+    Role, kind and reply expectations carry over from the list, while the identity fields are reset:
+    a cleared uid makes the server mint a fresh one (and with it a distinct RSVP link), and the
+    routing fields are dropped so they are rebuilt from the member's own address rather than
+    pointing back at the list.
+    """
+
+    member = dict(participant)
+    member.update({"email": email, "uid": None, "name": None, "send_to": None, "schedule_id": None})
+
+    return member
+
+
+def _has_local_participant(participants: list[dict]) -> bool:
+    """True when any participant sits on a domain this server hosts.
+
+    Only local addresses can be mailing lists, so this avoids fetching the directory for events that
+    invite external attendees only.
+    """
+
+    domains = {(d.get("name") or "").lower() for d in _domains()}
+
+    return any(_email_of(p).rpartition("@")[2] in domains for p in participants if _email_of(p))
+
+
+def _domains() -> list[dict]:
+    """Returns the server's domains, or an empty list when the directory is unreachable."""
+
+    try:
+        return get_domains()
+    except Exception:
+        log_mail_error("Mailing List Participant Expansion")
+        return []
+
+
+def _mailing_list_index() -> dict[str, list[str]]:
+    """Returns the mailing list address index, or an empty map when the directory is unreachable."""
+
+    try:
+        return get_mailing_list_index()
+    except Exception:
+        log_mail_error("Mailing List Participant Expansion")
+        return {}
+
+
+def _report_truncation(limit: int, dropped: list[str]) -> None:
+    """Surfaces the participants a size cap left out, so the cap is never silent."""
+
+    message = _("Only the first {0} participants were invited; {1} more were left out.").format(
+        limit, len(dropped)
+    )
+    frappe.msgprint(message, alert=True)
+    log_mail_error("Mailing List Participant Expansion", f"{message}\n\n{', '.join(filter(None, dropped))}")
+
+
+def _email_of(participant: dict) -> str:
+    """Returns a participant's address, lowercased."""
+
+    return (participant.get("email") or "").lower()
+
+
+def _expansion_enabled() -> bool:
+    """True when mailing lists should be expanded into their members, per Mail Settings or site config."""
+
+    return bool(get_config("expand_mailing_list_participants"))
+
+
+def _max_participants() -> int:
+    """Returns the cap on participants per event after expansion."""
+
+    return cint(get_config("max_mailing_list_participants")) or DEFAULT_MAX_PARTICIPANTS

--- a/suite/calendar/tests/test_calendar_mailing_list_participants.py
+++ b/suite/calendar/tests/test_calendar_mailing_list_participants.py
@@ -132,6 +132,37 @@ class TestMailingListParticipantExpansion(IntegrationTestCase):
         self.assertEqual(report.call_args.args[0], 2)
         self.assertEqual(report.call_args.args[1], ["carol@example.com"])
 
+    def test_the_cap_never_drops_an_explicitly_invited_participant(self):
+        # The list fills the cap on its own, so a naive total cap would truncate the attendee the
+        # organizer named after it — and on the next update _plan() reads a vanished participant as
+        # withdrawn and mails them a cancellation.
+        with patch(f"{MODULE}._report_truncation"):
+            expanded = self.expand(
+                [participant("everyone@example.com"), participant("boss@example.org")], limit=2
+            )
+
+        self.assertEqual(
+            [p["email"] for p in expanded],
+            ["alice@example.com", "bob@example.com", "boss@example.org"],
+        )
+
+    def test_explicit_participants_consume_the_cap_before_members(self):
+        with patch(f"{MODULE}._report_truncation") as report:
+            expanded = self.expand(
+                [participant("boss@example.org"), participant("everyone@example.com")], limit=2
+            )
+
+        # The cap bounds the total, so boss takes one of the two slots and expansion adds one member.
+        self.assertEqual([p["email"] for p in expanded], ["boss@example.org", "alice@example.com"])
+        self.assertEqual(report.call_args.args[1], ["bob@example.com", "carol@example.com"])
+
+    def test_an_explicit_participant_wins_even_when_the_list_comes_first(self):
+        expanded = self.expand([participant("team@example.com"), participant("alice@example.com")])
+
+        self.assertEqual([p["email"] for p in expanded], ["bob@example.com", "alice@example.com"])
+        # The explicit uid survives; a member entry would reset the RSVP recorded against it.
+        self.assertEqual(expanded[-1]["uid"], "uid-alice@example.com")
+
     def test_expansion_can_be_turned_off(self):
         participants = [participant("team@example.com")]
         with (

--- a/suite/calendar/tests/test_calendar_mailing_list_participants.py
+++ b/suite/calendar/tests/test_calendar_mailing_list_participants.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+from unittest.mock import patch
+
+from frappe.tests import IntegrationTestCase
+
+from suite.calendar.doctype.calendar_event.calendar_event import add_calendar_event
+from suite.calendar.doctype.calendar_event.calendar_event import (
+    get_calendar_events as get_events_by_ids,
+)
+from suite.calendar.doctype.calendar_event.mailing_lists import (
+    DEFAULT_MAX_PARTICIPANTS,
+    _expansion_enabled,
+    _max_participants,
+    expand_mailing_list_participants,
+)
+from suite.mail.api.admin import add_mailing_list_recipients, get_mailing_list
+from suite.mail.stalwart import get_domains, get_mailing_list_index
+from suite.mail.tests.base import StalwartIntegrationTestCase, unique_name
+
+MODULE = "suite.calendar.doctype.calendar_event.mailing_lists"
+
+DOMAINS = [{"name": "example.com"}]
+INDEX = {
+    "team@example.com": ["alice@example.com", "bob@example.com"],
+    "team-alias@example.com": ["alice@example.com", "bob@example.com"],
+    "everyone@example.com": ["team@example.com", "carol@example.com"],
+    "loop-a@example.com": ["loop-b@example.com", "dave@example.com"],
+    "loop-b@example.com": ["loop-a@example.com", "erin@example.com"],
+}
+
+
+def participant(email: str, **overrides) -> dict:
+    """Builds a participant entry in the shape the calendar event APIs pass around."""
+
+    return {
+        "uid": f"uid-{email}",
+        "name": None,
+        "email": email,
+        "kind": "individual",
+        "roles": {"attendee": True},
+        "schedule_id": f"mailto:{email}",
+        "send_to": {"imip": f"mailto:{email}"},
+        "participation_status": "needs-action",
+        "expect_reply": True,
+        "description": None,
+        "comment": None,
+    } | overrides
+
+
+class TestMailingListParticipantExpansion(IntegrationTestCase):
+    """Mailing list participants are replaced by their members before an event is stored.
+
+    The server expands a list only at delivery time, so an ATTENDEE naming the list matches no
+    account on ingest and the event lands on nobody's calendar. These cover the expansion that
+    replaces the list with its members up front.
+    """
+
+    def expand(self, participants: list[dict], limit: int = 100) -> list[dict]:
+        """Runs the expansion against a fixed directory, bypassing Stalwart."""
+
+        with (
+            patch(f"{MODULE}._expansion_enabled", return_value=True),
+            patch(f"{MODULE}._max_participants", return_value=limit),
+            patch(f"{MODULE}._domains", return_value=DOMAINS),
+            patch(f"{MODULE}._mailing_list_index", return_value=INDEX),
+        ):
+            return expand_mailing_list_participants(participants)
+
+    def test_list_is_replaced_by_its_members(self):
+        expanded = self.expand([participant("team@example.com")])
+
+        self.assertEqual([p["email"] for p in expanded], ["alice@example.com", "bob@example.com"])
+
+    def test_an_alias_of_the_list_resolves_to_the_same_members(self):
+        expanded = self.expand([participant("team-alias@example.com")])
+
+        self.assertEqual([p["email"] for p in expanded], ["alice@example.com", "bob@example.com"])
+
+    def test_other_participants_are_untouched_and_order_is_kept(self):
+        outsider = participant("someone@example.org")
+        expanded = self.expand([outsider, participant("team@example.com")])
+
+        self.assertEqual(
+            [p["email"] for p in expanded],
+            ["someone@example.org", "alice@example.com", "bob@example.com"],
+        )
+        self.assertEqual(expanded[0], outsider)
+
+    def test_a_member_invited_separately_is_not_duplicated(self):
+        expanded = self.expand([participant("alice@example.com"), participant("team@example.com")])
+
+        self.assertEqual([p["email"] for p in expanded], ["alice@example.com", "bob@example.com"])
+        # The explicit entry wins, so a response already recorded against it is not discarded.
+        self.assertEqual(expanded[0]["uid"], "uid-alice@example.com")
+
+    def test_nested_lists_are_flattened(self):
+        expanded = self.expand([participant("everyone@example.com")])
+
+        self.assertEqual(
+            [p["email"] for p in expanded],
+            ["alice@example.com", "bob@example.com", "carol@example.com"],
+        )
+
+    def test_a_membership_cycle_terminates(self):
+        expanded = self.expand([participant("loop-a@example.com")])
+
+        # loop-b is expanded where it sits, ahead of dave, and its reference back to loop-a is
+        # dropped as already visited.
+        self.assertEqual([p["email"] for p in expanded], ["erin@example.com", "dave@example.com"])
+
+    def test_members_inherit_the_lists_role_but_get_their_own_identity(self):
+        source = participant("team@example.com", roles={"attendee": True, "optional": True})
+        alice = self.expand([source])[0]
+
+        self.assertEqual(alice["roles"], {"attendee": True, "optional": True})
+        self.assertTrue(alice["expect_reply"])
+        self.assertEqual(alice["kind"], "individual")
+        # Cleared so the server mints a fresh uid (and RSVP link) and rebuilds routing from the
+        # member's own address instead of pointing back at the list.
+        self.assertIsNone(alice["uid"])
+        self.assertIsNone(alice["send_to"])
+        self.assertIsNone(alice["schedule_id"])
+
+    def test_the_size_cap_truncates_and_is_reported(self):
+        with patch(f"{MODULE}._report_truncation") as report:
+            expanded = self.expand([participant("everyone@example.com")], limit=2)
+
+        self.assertEqual([p["email"] for p in expanded], ["alice@example.com", "bob@example.com"])
+        report.assert_called_once()
+        self.assertEqual(report.call_args.args[0], 2)
+        self.assertEqual(report.call_args.args[1], ["carol@example.com"])
+
+    def test_expansion_can_be_turned_off(self):
+        participants = [participant("team@example.com")]
+        with (
+            patch(f"{MODULE}._expansion_enabled", return_value=False),
+            patch(f"{MODULE}._mailing_list_index") as index,
+        ):
+            self.assertEqual(expand_mailing_list_participants(participants), participants)
+
+        index.assert_not_called()
+
+    def test_external_only_participants_skip_the_directory_lookup(self):
+        participants = [participant("someone@example.org")]
+        with (
+            patch(f"{MODULE}._expansion_enabled", return_value=True),
+            patch(f"{MODULE}._domains", return_value=DOMAINS),
+            patch(f"{MODULE}._mailing_list_index") as index,
+        ):
+            self.assertEqual(expand_mailing_list_participants(participants), participants)
+
+        index.assert_not_called()
+
+    def test_an_unreachable_directory_leaves_participants_alone(self):
+        participants = [participant("team@example.com")]
+        with (
+            patch(f"{MODULE}._expansion_enabled", return_value=True),
+            patch(f"{MODULE}._domains", return_value=DOMAINS),
+            patch(f"{MODULE}._mailing_list_index", return_value={}),
+        ):
+            self.assertEqual(expand_mailing_list_participants(participants), participants)
+
+    def test_nothing_to_do_without_participants(self):
+        self.assertIsNone(expand_mailing_list_participants(None))
+        self.assertEqual(expand_mailing_list_participants([]), [])
+
+
+class TestMailingListExpansionConfig(IntegrationTestCase):
+    """The toggle and the cap resolve through ``get_config``, so site config can supply either."""
+
+    def test_the_toggle_is_coerced_to_a_bool(self):
+        with patch(f"{MODULE}.get_config", return_value=1):
+            self.assertTrue(_expansion_enabled())
+
+        with patch(f"{MODULE}.get_config", return_value=None):
+            self.assertFalse(_expansion_enabled())
+
+    def test_the_cap_accepts_a_string_from_site_config(self):
+        with patch(f"{MODULE}.get_config", return_value="25"):
+            self.assertEqual(_max_participants(), 25)
+
+    def test_the_cap_falls_back_to_the_default_when_unset(self):
+        with patch(f"{MODULE}.get_config", return_value=0):
+            self.assertEqual(_max_participants(), DEFAULT_MAX_PARTICIPANTS)
+
+
+class TestMailingListInvite(StalwartIntegrationTestCase):
+    """An event invited to a real mailing list is stored against the list's members."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.organizer = cls.create_member()
+        cls.first = cls.create_member()
+        cls.second = cls.create_member()
+        cls.organizer_account = cls.personal_account(cls.organizer)
+
+    def test_the_list_address_is_stored_as_its_members(self):
+        list_id = self.create_mailing_list()
+        with self.set_user("Administrator"):
+            add_mailing_list_recipients(list_id, [self.first.email, self.second.email])
+            list_email = get_mailing_list(list_id)["email"]
+
+        # The directory is cached, and the list was created after this run started.
+        get_domains.clear_cache()
+        get_mailing_list_index.clear_cache()
+
+        with self.set_user(self.organizer.email):
+            event_id = add_calendar_event(
+                self.organizer_account,
+                organizer=self.organizer.email,
+                title=f"List invite {unique_name('event')}",
+                start="2026-11-09T10:00:00",
+                duration="PT1H",
+                time_zone="UTC",
+                participants=[
+                    {"email": self.organizer.email, "participation_status": "ACCEPTED"},
+                    {"email": list_email, "participation_status": "NEEDS-ACTION", "expect_reply": True},
+                ],
+                send_scheduling_messages=True,
+            )
+            participants = get_events_by_ids(self.organizer_account, [event_id])[0]["participants"]
+
+        emails = {p["email"] for p in participants}
+        self.assertNotIn(list_email, emails)
+        self.assertEqual(emails, {self.organizer.email, self.first.email, self.second.email})
+
+        # A distinct uid per member is what gives each of them their own RSVP link.
+        members = [p for p in participants if p["email"] != self.organizer.email]
+        self.assertEqual(len({p["uid"] for p in members}), 2)
+        self.assertTrue(all(p["expect_reply"] for p in members))

--- a/suite/mail/doctype/mail_settings/mail_settings.json
+++ b/suite/mail/doctype/mail_settings/mail_settings.json
@@ -100,7 +100,9 @@
   "jmap_push_p256dh",
   "event_invites_tab",
   "event_invites_section",
-  "custom_event_invites"
+  "custom_event_invites",
+  "expand_mailing_list_participants",
+  "max_mailing_list_participants"
  ],
  "fields": [
   {
@@ -720,6 +722,21 @@
    "fieldname": "custom_event_invites",
    "fieldtype": "Check",
    "label": "Send Custom Event Invitations"
+  },
+  {
+   "default": "1",
+   "description": "Invite a mailing list's members individually when the list address is added to an event. The server expands a mailing list only when delivering mail, so an invitation addressed to the list itself reaches every member's inbox but is never added to their calendars.",
+   "fieldname": "expand_mailing_list_participants",
+   "fieldtype": "Check",
+   "label": "Expand Mailing List Participants"
+  },
+  {
+   "default": "100",
+   "depends_on": "expand_mailing_list_participants",
+   "description": "Largest number of participants an event may carry once its mailing lists have been expanded. Participants beyond this are left out and reported.",
+   "fieldname": "max_mailing_list_participants",
+   "fieldtype": "Int",
+   "label": "Max Mailing List Participants"
   },
   {
    "default": "INFO",

--- a/suite/mail/doctype/mail_settings/mail_settings.json
+++ b/suite/mail/doctype/mail_settings/mail_settings.json
@@ -733,7 +733,7 @@
   {
    "default": "100",
    "depends_on": "expand_mailing_list_participants",
-   "description": "Largest number of participants an event may carry once its mailing lists have been expanded. Participants beyond this are left out and reported.",
+   "description": "Largest number of participants an event may carry once its mailing lists have been expanded. Only members added by expansion are left out once this is reached, and they are reported; participants invited by name are always kept.",
    "fieldname": "max_mailing_list_participants",
    "fieldtype": "Int",
    "label": "Max Mailing List Participants"

--- a/suite/mail/doctype/mail_settings/mail_settings.py
+++ b/suite/mail/doctype/mail_settings/mail_settings.py
@@ -58,6 +58,7 @@ class MailSettings(Document):
         exchange_log_max_file_size: DF.Int
         exchange_max_export: DF.Int
         exchange_max_import: DF.Int
+        expand_mailing_list_participants: DF.Check
         inbound_log_file_count: DF.Int
         inbound_log_level: DF.Literal["ERROR", "WARNING", "INFO", "DEBUG"]
         inbound_log_max_file_size: DF.Int
@@ -66,6 +67,7 @@ class MailSettings(Document):
         jmap_push_private_key: DF.Password | None
         mail_client_configurations: DF.Table[MailClientConfiguration]
         max_email_sync: DF.Int
+        max_mailing_list_participants: DF.Int
         max_message_payload_size_mb: DF.Int
         max_push_notifications: DF.Int
         outbound_log_file_count: DF.Int

--- a/suite/mail/doctype/screened_email_address/test_screened_email_address.py
+++ b/suite/mail/doctype/screened_email_address/test_screened_email_address.py
@@ -25,7 +25,7 @@ class IntegrationTestScreenedEmailAddress(IntegrationTestCase):
         # Trims whitespace and leaves a plain email address untouched.
         self.assertEqual(normalize_screened_value("  john@example.com  "), "john@example.com")
         # Lowercases the domain of a '@domain' entry so it collapses to a single rule.
-        self.assertEqual(normalize_screened_value("@Frappe.io"), "@frappe.io")
+        self.assertEqual(normalize_screened_value("@Mail.Example.com"), "@mail.example.com")
         self.assertEqual(normalize_screened_value(" @Example.COM "), "@example.com")
 
     def test_validate_screened_value(self):

--- a/suite/mail/stalwart/__init__.py
+++ b/suite/mail/stalwart/__init__.py
@@ -168,6 +168,17 @@ def get_domains() -> list[dict]:
     )
 
 
+@redis_cache(ttl=60)
+def get_mailing_list_index() -> dict[str, list[str]]:
+    """Returns ``{list address: [recipient addresses]}`` for every mailing list (cached briefly).
+
+    Membership edits are visible once the cache expires; mail routing itself is unaffected, so the
+    only window is between a membership change and the next calendar invitation.
+    """
+
+    return get_mailing_list_service().get_address_index()
+
+
 @redis_cache(ttl=3600)
 def get_permissions() -> list[dict]:
     """Returns all assignable permissions as ``{value, label}`` from the Stalwart server schema.

--- a/suite/mail/stalwart/mailing_list.py
+++ b/suite/mail/stalwart/mailing_list.py
@@ -41,3 +41,46 @@ class MailingListService(ManagementService):
             frappe.throw(_("Mailing list {0} not found on the Stalwart server.").format(name))
 
         return mailing_list
+
+    def get_address_index(self) -> dict[str, list[str]]:
+        """Returns ``{list address: [recipient addresses]}`` for every list with recipients.
+
+        A list is reachable at its primary address and at each of its enabled aliases, so all of
+        them are indexed; the server resolves any of them to the same recipients.
+        """
+
+        from suite.mail.stalwart import get_domains
+
+        domain_names = {d["id"]: d["name"] for d in get_domains()}
+        index = {}
+        for mailing_list in self.get_all(properties=["id", "emailAddress", "aliases", "recipients"]):
+            recipients = sorted({r.lower() for r in (mailing_list.get("recipients") or {})})
+            if not recipients:
+                continue
+
+            for address in get_mailing_list_addresses(mailing_list, domain_names):
+                index[address] = recipients
+
+        return index
+
+
+def get_mailing_list_addresses(mailing_list: dict, domain_names: dict[str, str]) -> list[str]:
+    """Returns the list's primary address plus its enabled aliases, lowercased.
+
+    Disabled aliases are skipped: the server stops routing mail to them, so an invitation sent to
+    one would never reach the members either.
+    """
+
+    addresses = []
+    if primary := (mailing_list.get("emailAddress") or "").lower():
+        addresses.append(primary)
+
+    for alias in (mailing_list.get("aliases") or {}).values():
+        if not alias.get("enabled", True):
+            continue
+
+        name = alias.get("name")
+        if name and (domain := domain_names.get(alias.get("domainId"))):
+            addresses.append(f"{name}@{domain}".lower())
+
+    return addresses

--- a/suite/mail/store/indexes/email_address.py
+++ b/suite/mail/store/indexes/email_address.py
@@ -6,7 +6,7 @@ from suite.store.search_store import FieldSpec, SearchStore
 
 _TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
 
-# Quote characters some clients wrap display names in, e.g. "'Ayush Chaudhari'".
+# Quote characters some clients wrap display names in, e.g. "'Jane Doe'".
 _WRAPPING_QUOTES = "'\"`"
 
 
@@ -69,8 +69,8 @@ class EmailAddressIndex(SearchStore):
         """Return up to `limit` {name, email} addresses matching `query`, most relevant first.
 
         The query's tokens must appear as a consecutive, in-order phrase in the address's name or
-        email, with the last token matched as a prefix. So "saga" matches "sagar", and "sagar.s"
-        matches "sagar.s@…" / "Sagar Sharma" but not "sagar@…" or "sagar.v@…". Documents are unique
+        email, with the last token matched as a prefix. So "jan" matches "jane", and "jane.d"
+        matches "jane.d@…" / "Jane Doe" but not "jane@…" or "jane.r@…". Documents are unique
         per address, so the hits need no further deduping.
         """
 

--- a/suite/mail/tests/test_admin_groups_and_lists.py
+++ b/suite/mail/tests/test_admin_groups_and_lists.py
@@ -31,6 +31,7 @@ from suite.mail.api.admin import (
     update_mailing_list,
 )
 from suite.mail.doctype.user_account.user_account import get_user_personal_jmap_account
+from suite.mail.stalwart import get_mailing_list_service
 from suite.mail.tests.base import StalwartIntegrationTestCase, unique_name
 
 
@@ -130,6 +131,26 @@ class TestAdminGroupsAndLists(StalwartIntegrationTestCase):
         throwaway = self.create_mailing_list()
         delete_mailing_lists([throwaway])
         self.assertEqual([ml for ml in get_mailing_lists() if ml["id"] == throwaway], [])
+
+    def test_mailing_list_address_index_resolves_every_live_address(self):
+        """The index calendar invites use to turn a list address into its members."""
+
+        list_id = self.create_mailing_list()
+        add_mailing_list_recipients(list_id, [self.member1.email])
+        primary = get_mailing_list(list_id)["email"]
+
+        enabled = f"{unique_name('lalias')}@{self.domain}"
+        disabled = f"{unique_name('lalias')}@{self.domain}"
+        add_mailing_list_email(list_id, enabled)
+        add_mailing_list_email(list_id, disabled)
+        set_mailing_list_email_enabled(list_id, disabled, 0)
+
+        index = get_mailing_list_service().get_address_index()
+
+        self.assertEqual(index.get(primary), [self.member1.email.lower()])
+        self.assertEqual(index.get(enabled), [self.member1.email.lower()])
+        # Mail to a disabled alias is not delivered, so an invite to it must not expand either.
+        self.assertNotIn(disabled, index)
 
     def test_mail_to_list_reaches_recipient_inbox(self):
         self.disable_screening(self.member2)

--- a/suite/mail/tests/test_email_address_index.py
+++ b/suite/mail/tests/test_email_address_index.py
@@ -13,26 +13,26 @@ class SanitizeName(unittest.TestCase):
     """``_sanitize_name`` — strip wrapping quote pairs, leave everything else alone."""
 
     def test_single_quote_pair_is_stripped(self):
-        self.assertEqual(_sanitize_name("'Ayush Chaudhari'"), "Ayush Chaudhari")
+        self.assertEqual(_sanitize_name("'Jane Doe'"), "Jane Doe")
 
     def test_double_quote_pair_is_stripped(self):
-        self.assertEqual(_sanitize_name('"Ayush Chaudhari"'), "Ayush Chaudhari")
+        self.assertEqual(_sanitize_name('"Jane Doe"'), "Jane Doe")
 
     def test_backtick_pair_is_stripped(self):
-        self.assertEqual(_sanitize_name("`Ayush Chaudhari`"), "Ayush Chaudhari")
+        self.assertEqual(_sanitize_name("`Jane Doe`"), "Jane Doe")
 
     def test_nested_quote_pairs_are_stripped(self):
-        self.assertEqual(_sanitize_name("\"'Ayush Chaudhari'\""), "Ayush Chaudhari")
+        self.assertEqual(_sanitize_name("\"'Jane Doe'\""), "Jane Doe")
 
     def test_whitespace_between_nested_pairs_is_stripped(self):
-        self.assertEqual(_sanitize_name(" ' \"Ayush\" ' "), "Ayush")
+        self.assertEqual(_sanitize_name(" ' \"Jane\" ' "), "Jane")
 
     def test_unbalanced_quote_is_kept(self):
-        self.assertEqual(_sanitize_name("'Ayush"), "'Ayush")
-        self.assertEqual(_sanitize_name("Ayush'"), "Ayush'")
+        self.assertEqual(_sanitize_name("'Jane"), "'Jane")
+        self.assertEqual(_sanitize_name("Jane'"), "Jane'")
 
     def test_mismatched_quotes_are_kept(self):
-        self.assertEqual(_sanitize_name("'Ayush\""), "'Ayush\"")
+        self.assertEqual(_sanitize_name("'Jane\""), "'Jane\"")
 
     def test_interior_apostrophe_is_kept(self):
         self.assertEqual(_sanitize_name("O'Brien"), "O'Brien")
@@ -55,21 +55,21 @@ class ToDocument(unittest.TestCase):
         return EmailAddressIndex.to_document(mock.Mock(spec=EmailAddressIndex), address)
 
     def test_name_is_sanitized_everywhere(self):
-        document = self.to_document({"name": "'Ayush Chaudhari'", "email": "Ayush@Frappe.io"})
+        document = self.to_document({"name": "'Jane Doe'", "email": "Jane@Example.com"})
         self.assertEqual(
             document,
             {
-                "id": "ayush@frappe.io",
-                "email": "Ayush@Frappe.io",
-                "name": "Ayush Chaudhari",
-                "text": "Ayush Chaudhari Ayush@Frappe.io",
+                "id": "jane@example.com",
+                "email": "Jane@Example.com",
+                "name": "Jane Doe",
+                "text": "Jane Doe Jane@Example.com",
             },
         )
 
     def test_missing_name_leaves_email_only_text(self):
-        document = self.to_document({"email": "ayush@frappe.io"})
+        document = self.to_document({"email": "jane@example.com"})
         self.assertIsNone(document["name"])
-        self.assertEqual(document["text"], "ayush@frappe.io")
+        self.assertEqual(document["text"], "jane@example.com")
 
 
 class IndexAddresses(unittest.TestCase):
@@ -83,29 +83,29 @@ class IndexAddresses(unittest.TestCase):
         return index.index_documents.call_args[0][0]
 
     def test_valid_email_is_indexed(self):
-        address = {"name": "Ayush", "email": "ayush@frappe.io"}
+        address = {"name": "Jane", "email": "jane@example.com"}
         self.assertEqual(self.index_addresses([address]), [address])
 
     def test_missing_email_is_skipped(self):
-        self.assertEqual(self.index_addresses([{"name": "Ayush"}, {"name": "No Email", "email": ""}]), [])
+        self.assertEqual(self.index_addresses([{"name": "Jane"}, {"name": "No Email", "email": ""}]), [])
 
     def test_malformed_emails_are_skipped(self):
         malformed = [
             {"email": "not-an-email"},
-            {"email": "Ayush <ayush@frappe.io>"},
-            {"email": "ayush@frappe"},  # no TLD
-            {"email": "ayush @frappe.io"},
-            {"email": "@frappe.io"},
+            {"email": "Jane <jane@example.com>"},
+            {"email": "jane@example"},  # no TLD
+            {"email": "jane @example.com"},
+            {"email": "@example.com"},
         ]
         self.assertEqual(self.index_addresses(malformed), [])
 
     def test_valid_survives_malformed_neighbours(self):
-        valid = {"name": "Ayush", "email": "ayush@frappe.io"}
+        valid = {"name": "Jane", "email": "jane@example.com"}
         self.assertEqual(self.index_addresses([{"email": "not-an-email"}, valid]), [valid])
 
     def test_batch_dedupes_case_insensitively(self):
-        first = {"name": "Ayush", "email": "ayush@frappe.io"}
-        second = {"name": "Ayush Chaudhari", "email": "Ayush@Frappe.io"}
+        first = {"name": "Jane", "email": "jane@example.com"}
+        second = {"name": "Jane Doe", "email": "Jane@Example.com"}
         self.assertEqual(self.index_addresses([first, second]), [second])
 
 

--- a/suite/mail/utils/__init__.py
+++ b/suite/mail/utils/__init__.py
@@ -26,6 +26,7 @@ CONFIG_KEYS = [
     "disabled_account_role",
     "enable_gravatar",
     "default_gravatar",
+    "expand_mailing_list_participants",
     "stalwart_version",
     "stalwart_cli_version",
     # Logs
@@ -49,6 +50,7 @@ CONFIG_KEYS = [
     "exchange_max_import",
     "exchange_export_batch_size",
     "max_email_sync",
+    "max_mailing_list_participants",
     "max_message_payload_size_mb",
     "max_push_notifications",
     "process_pending_emails_batch_size",

--- a/suite/mail/utils/validation.py
+++ b/suite/mail/utils/validation.py
@@ -10,21 +10,21 @@ from frappe.utils.caching import request_cache
 from suite.mail.utils import get_config
 
 # A domain label is 1-63 chars of letters/digits/hyphens (no leading/trailing hyphen); a domain name is
-# two or more such labels joined by dots, at most 253 chars overall (e.g. "frappe.io").
+# two or more such labels joined by dots, at most 253 chars overall (e.g. "example.com").
 DOMAIN_NAME_PATTERN = re.compile(
     r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))+$"
 )
 
 
 def is_domain_entry(value: str) -> bool:
-    """Whether a screened value denotes a whole domain, i.e. is prefixed with '@' (e.g. '@frappe.io')."""
+    """Whether a screened value denotes a whole domain, i.e. is prefixed with '@' (e.g. '@example.com')."""
 
     return (value or "").startswith("@")
 
 
 def normalize_screened_value(value: str) -> str:
     """Normalise a screened value: trim it, and lowercase the domain of a '@domain' entry so that
-    '@Frappe.io' and '@frappe.io' collapse to a single rule."""
+    '@Example.com' and '@example.com' collapse to a single rule."""
 
     value = (value or "").strip()
     if is_domain_entry(value):

--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -91,6 +91,8 @@ execute:frappe.db.set_single_value("Mail Settings", "show_mail_client_config", 1
 execute:frappe.db.set_single_value("Mail Settings", "custom_event_invites", 1)
 suite.mail.patches.reset_push_subscription_types_to_all
 suite.mail.patches.rename_skip_schedule_fetch_changes
+execute:frappe.db.set_single_value("Mail Settings", "expand_mailing_list_participants", 1)
+execute:frappe.db.set_single_value("Mail Settings", "max_mailing_list_participants", 100)
 # --- calendar ---
 # (no patches)
 # --- suite_core ---


### PR DESCRIPTION
## Problem

An invitation sent to a mailing list (`team@example.com`) reaches every member's inbox, but the event is never added to anyone's calendar. The same invitation sent to an individual or a group works.

This is by design in Stalwart rather than a bug, and it falls out of how the two objects are modelled:

- A mailing list resolves to `RcptResolution::Expand(list.recipients)` at the SMTP RCPT stage. The list address is popped off `rcpt_to` and survives only as the DSN `ORCPT` string, so each member's copy is delivered to their own address.
- The iTIP ingest then matches the iCalendar `ATTENDEE` against the recipient account's own addresses, which are built from the account's aliases plus the addresses of every group in `member_group_ids`. A mailing list stores its members as plain address strings with no back-reference to the member accounts, so it can never appear there.

The attendee therefore matches nobody, ingest returns `NotOrganizerNorAttendee`, and nothing is written to any calendar. Groups are unaffected because a group is a real principal with its own address and its own calendar.

Switching the affected addresses to groups is not an option: a list delivers a copy to each member's inbox, whereas a group is a shared mailbox, and that difference is usually the reason the list exists.

## Fix

Expand a mailing list into one participant per member before the event is stored, which is what RFC 5546 asks the organizer to do.

Doing it at the point the participants are persisted (rather than when the invitation mail is built) matters, because Suite has two invite paths and both are built from the stored participant list: its own templated mails when `custom_event_invites` is on, and the JMAP server's scheduling messages otherwise. Each member also ends up with a distinct participant uid, which is what gives them individual RSVP links.

Details:

- Addresses resolve via a new `MailingListService.get_address_index()`, covering each list's primary address and its **enabled** aliases — a disabled alias is not delivered to, so an invite to it must not expand either. Cached for 60s alongside `get_domains`.
- Nested lists are flattened in place, with a visited set that also terminates membership cycles.
- A member invited separately is not duplicated; the explicit entry wins, so a response already recorded against it is preserved.
- The directory lookup is skipped entirely when no participant sits on a local domain.
- If the directory is unreachable, participants pass through unchanged — an event is not worth failing over.
- Participants are re-expanded on every update, since membership is only a snapshot taken when the invitation is sent.

Controlled by `expand_mailing_list_participants` and `max_mailing_list_participants`, both read through `get_config` so either site config or Mail Settings can supply them. A patch enables them on existing sites, matching the `custom_event_invites` precedent.

## Known limitations

- **External organizers are unchanged.** Someone on Gmail or Outlook inviting a list hits the same wall, because the expansion happens inside Stalwart at RCPT time and the list address is gone before ingest runs. Fixing that needs a server-side change.
- **Membership is a snapshot.** Someone added to the list later receives list mail but not this event until the organizer touches it again.
- **Expansion discloses membership.** It runs with the app's Stalwart credentials rather than the acting user's, so anyone who can create an event can see a list's members by inviting it. A per-list opt-in would be the natural follow-up if that matters for lists like `all@`.
- Once expanded, the event shows individual members rather than the list address, and every attendee can see the other attendees.

## Tests

- 16 in `test_calendar_mailing_list_participants.py` — expansion against a fixed directory (ordering, dedupe, nested lists, cycles, inherited roles, the size cap, the off switch, unreachable directory), the `get_config` wiring, plus an end-to-end case that creates a real mailing list with two members, invites the list address, and asserts the stored event carries both members with distinct uids and no trace of the list address.
- One added to `test_admin_groups_and_lists.py` proving the index resolves a real list's primary address and enabled alias while excluding a disabled one.

`test_calendar_events`, `test_calendar_invites_rsvp`, `test_calendar_mail_invites`, `test_calendar_calendars`, `test_admin_groups_and_lists`, `test_mail_flags_and_search` and `test_mail_misc` all pass.

## Second commit

`chore(mail): use dummy domains and names in tests and examples` is unrelated cleanup, kept separate for review: it replaces `frappe.io` and real people's names in the mail test fixtures (and the comments those tests document) with RFC 2606 reserved domains and placeholder names.
