### PR TITLE
fix(writer): purge versions when a document is deleted

### DIFF
--- a/suite/writer/doctype/writer_document/test_writer_document.py
+++ b/suite/writer/doctype/writer_document/test_writer_document.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests import IntegrationTestCase
 
 # On IntegrationTestCase, the doctype test records and all
@@ -17,4 +17,21 @@ class IntegrationTestWriterDocument(IntegrationTestCase):
     Use this class for testing interactions between multiple components.
     """
 
-    pass
+    def test_delete_purges_versions(self):
+        doc = frappe.new_doc("Writer Document")
+        doc.save()
+        version = frappe.get_doc(
+            {
+                "doctype": "Writer Version",
+                "doc": doc.name,
+                "snapshot": "<p>hello</p>",
+                "title": "2026-01-01 00:00",
+            }
+        ).insert()
+
+        # a version links back to the document — without the cascade the
+        # framework's link check refuses the delete
+        doc.delete()
+
+        self.assertFalse(frappe.db.exists("Writer Document", doc.name))
+        self.assertFalse(frappe.db.exists("Writer Version", version.name))

--- a/suite/writer/doctype/writer_document/writer_document.py
+++ b/suite/writer/doctype/writer_document/writer_document.py
@@ -19,6 +19,12 @@ AUTOVERSION_DURATION = 10
 
 
 class WriterDocument(Document):
+    def on_trash(self):
+        # Versions are a standalone doctype linking back here, so the framework's
+        # link check would refuse the delete before anything cleaned them up —
+        # and nothing outside this document references a version.
+        frappe.db.delete("Writer Version", {"doc": self.name})
+
     @frappe.whitelist(methods=["POST"])
     def save_doc(self, data: str, html: str | None = None):
         self.check_permission("write")


### PR DESCRIPTION
### Problem

Drive's nightly `clear_deleted_files` sweep fails on every Writer-backed file with:

```
frappe.exceptions.LinkExistsError: Cannot delete or cancel because Writer Document
<...> is linked with Writer Version <...>
```

`File.after_delete` hard-deletes the backing content doc, but `Writer Version` is a
standalone doctype with a Link field (`doc`) pointing at `Writer Document`. Frappe's
`check_if_doc_is_linked` runs before the delete goes through, so any document that ever
got a version — auto-versions are created every 10 minutes of editing — can never be
purged, and the sweep logs the same error nightly.

### Fix

Cascade the versions in `WriterDocument.on_trash`, which frappe runs *before* the link
check (`frappe/model/delete_doc.py:163` vs `:172`).

Chose a cascade over adding `Writer Version` to `ignore_links_on_delete`: that would
leave the version rows — which carry full document snapshots — orphaned in the database
after the document and its file are gone.

### Testing

Added `test_delete_purges_versions`. With the fix reverted it fails with exactly the
reported `LinkExistsError`; with the fix it passes.

```
bench --site s2 run-tests --module suite.writer.doctype.writer_document.test_writer_document
Ran 1 test in 0.290s
OK
```

Removed files already stuck in the database will be purged on the next nightly run —
the sweep already isolates per-file failures, so no data migration is needed.
