### PR TITLE
fix(drive): handle missing entity_name in get_entity_with_permissions

### DIFF
--- a/suite/drive/api/permissions.py
+++ b/suite/drive/api/permissions.py
@@ -105,16 +105,18 @@ def _ref_doc_access(entity, user):
 
 
 @frappe.whitelist(allow_guest=True)
-def get_entity_with_permissions(entity_name: str):
+def get_entity_with_permissions(entity_name: str | None = None):
     """
     Return file data with permissions
     """
-    entity = frappe.get_all(
-        "File",
-        filters={"name": entity_name, "status": STATUS_ACTIVE},
-        fields=FILE_FIELDS,
-        limit=1,
-    )
+    entity = None
+    if entity_name:
+        entity = frappe.get_all(
+            "File",
+            filters={"name": entity_name, "status": STATUS_ACTIVE},
+            fields=FILE_FIELDS,
+            limit=1,
+        )
     if not entity:
         # Mimic API v2 points
         frappe.local.response.errors = [


### PR DESCRIPTION
### Problem

`get_entity_with_permissions` is whitelisted with `allow_guest=True`, so a `GET` without `entity_name` (bot/crawler, direct hit, stale link) reaches the handler with an empty `form_dict` and raises a `TypeError` 500 before any of the function's own error handling runs:

```
builtins.TypeError: get_entity_with_permissions() missing 1 required positional argument: 'entity_name'
```

### Fix

Make `entity_name` optional and skip the lookup when it is blank, so the request falls into the existing not-found branch and returns the same `PageDoesNotExistError` ("We couldn't find what you're looking for.") as an unknown file ID.

All in-app callers already pass `entity_name`, so there is no frontend change.