### PR TITLE
fix(mail): tune rate limits and cover missing endpoints

### DIFF
--- a/suite/mail/api/account.py
+++ b/suite/mail/api/account.py
@@ -426,6 +426,7 @@ def send_reset_password_link(user: str) -> str:
 
 
 @frappe.whitelist(allow_guest=True)
+@dynamic_rate_limit()
 def get_user_for_reset_password_key(key: str) -> str:
     """Return the user for a reset password key"""
 
@@ -434,6 +435,7 @@ def get_user_for_reset_password_key(key: str) -> str:
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def create_mail_import(
     account: str,
     format: Literal["eml", "jmap", "mbox", "maildir", "maildir-nested"],
@@ -456,6 +458,7 @@ def create_mail_import(
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def create_mail_export(
     account: str,
     format: Literal["jmap", "mbox", "maildir", "maildir-nested"],
@@ -483,6 +486,7 @@ def create_mail_export(
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def create_calendar_import(
     account: str,
     format: Literal["ics", "jmap"],
@@ -504,6 +508,7 @@ def create_calendar_import(
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def create_calendar_export(
     account: str,
     format: Literal["ics", "jmap"],
@@ -549,6 +554,7 @@ def normalize_calendar_filter(filter: dict) -> dict:
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def create_contacts_import(
     account: str,
     format: Literal["vcf", "jmap"],
@@ -570,6 +576,7 @@ def create_contacts_import(
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def create_contacts_export(
     account: str,
     format: Literal["jmap", "vcf"],

--- a/suite/mail/api/admin.py
+++ b/suite/mail/api/admin.py
@@ -2211,6 +2211,7 @@ def cancel_all_queued_messages(
 
 
 @frappe.whitelist(methods=["GET"])
+@dynamic_rate_limit()
 def stream_delivery_test(target: str):
     """Proxies Stalwart's live SMTP delivery trace for ``target`` as a Server-Sent Events stream.
 

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -68,6 +68,7 @@ from suite.mail.utils.dt import from_utc_z, normalize_utc_z, to_user_timezone, t
 from suite.mail.utils.user import get_account_emails, is_jmap_configured
 from suite.mail.utils.validation import normalize_screened_value, validate_screened_value
 from suite.utils import convert_html_to_text
+from suite.utils.rate_limiter import dynamic_rate_limit
 from suite.utils.user import is_system_manager
 
 AVATAR_CACHE_TTL = 60 * 60 * 24
@@ -1578,6 +1579,7 @@ def screen_out_senders(account: str, from_emails: list[str]) -> None:
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
+@dynamic_rate_limit()
 def upload_file():
     from mimetypes import guess_type
     from pathlib import Path

--- a/suite/mail/install.py
+++ b/suite/mail/install.py
@@ -15,34 +15,77 @@ def after_migrate() -> None:
 
 
 def add_rate_limits() -> None:
-    """Add rate limits."""
+    """Add rate limits.
+
+    Every limit here is per client IP and is an abuse backstop, not a quota: the numbers are
+    sized so normal use never reaches them. Guest-facing and credential-adjacent endpoints get
+    tight hourly windows (they are the ones worth brute-forcing), interactive lookups get a
+    per-minute burst window on top so a form that fires per keystroke still works, and the
+    machine-facing APIs (inbound/outbound/spamd) are limited per minute.
+    """
 
     rate_limits = [
-        # suite.mail.api.account
+        # suite.mail.api.account — public signup / password reset
+        # Availability check runs while the user types, so it needs a burst window; the hourly
+        # one is what keeps it from being used to enumerate existing addresses.
+        {"method_path": "suite.mail.api.account.validate_email_assigned", "limit": 20, "seconds": 60},
+        {
+            "method_path": "suite.mail.api.account.validate_email_assigned",
+            "limit": 100,
+            "seconds": 60 * 60,
+        },
         {"method_path": "suite.mail.api.account.signup", "limit": 5, "seconds": 60 * 60},
         {"method_path": "suite.mail.api.account.resend_otp", "limit": 5, "seconds": 60 * 60},
-        {"method_path": "suite.mail.api.account.verify_otp", "limit": 5, "seconds": 60 * 60},
-        {"method_path": "suite.mail.api.account.get_account_request", "limit": 5, "seconds": 60 * 60},
-        {"method_path": "suite.mail.api.account.get_account_setup_options", "limit": 5, "seconds": 60 * 60},
+        # The only guard on a 6-digit signup OTP - kept low enough that guessing is hopeless,
+        # high enough to survive a few typos.
+        {"method_path": "suite.mail.api.account.verify_otp", "limit": 10, "seconds": 60 * 60},
+        # Read-only, gated on an unguessable request key: sized for page reloads during setup.
+        {"method_path": "suite.mail.api.account.get_account_request", "limit": 60, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.account.get_account_setup_options", "limit": 20, "seconds": 60 * 60},
         {"method_path": "suite.mail.api.account.create_account", "limit": 10, "seconds": 60 * 60},
         {"method_path": "suite.mail.api.account.send_reset_password_link", "limit": 5, "seconds": 60 * 60},
-        {"method_path": "suite.mail.api.account.validate_email_assigned", "limit": 10, "seconds": 60 * 60},
-        # suite.mail.api.admin
-        {"method_path": "suite.mail.api.admin.add_domain", "limit": 10, "seconds": 24 * 60 * 60},
-        {"method_path": "suite.mail.api.admin.add_member", "limit": 10, "seconds": 60 * 60},
-        {"method_path": "suite.mail.api.admin.add_group", "limit": 20, "seconds": 60 * 60},
-        {"method_path": "suite.mail.api.admin.add_mailing_list", "limit": 20, "seconds": 60 * 60},
-        {"method_path": "suite.mail.api.admin.add_role", "limit": 20, "seconds": 60 * 60},
+        {
+            "method_path": "suite.mail.api.account.get_user_for_reset_password_key",
+            "limit": 20,
+            "seconds": 60 * 60,
+        },
+        # suite.mail.api.account — import/export (each one submits a long-running background job)
+        {"method_path": "suite.mail.api.account.create_mail_import", "limit": 10, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.account.create_mail_export", "limit": 10, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.account.create_calendar_import", "limit": 10, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.account.create_calendar_export", "limit": 10, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.account.create_contacts_import", "limit": 10, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.account.create_contacts_export", "limit": 10, "seconds": 60 * 60},
+        # suite.mail.api.auth
+        # Mail clients call this before a send, so it tracks the outbound per-minute tier.
+        {"method_path": "suite.mail.api.auth.validate", "limit": 60, "seconds": 60},
+        # suite.mail.api.admin — hourly windows, sized for real onboarding (a batch of members,
+        # a handful of domains) rather than for a single admin action.
+        {"method_path": "suite.mail.api.admin.add_domain", "limit": 20, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.admin.add_member", "limit": 60, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.admin.add_group", "limit": 60, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.admin.add_mailing_list", "limit": 60, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.admin.add_role", "limit": 60, "seconds": 60 * 60},
         {"method_path": "suite.mail.api.admin.add_oauth_client", "limit": 20, "seconds": 60 * 60},
+        {"method_path": "suite.mail.api.admin.change_member_password", "limit": 10, "seconds": 60 * 60},
+        # Each call holds a worker on an upstream SSE stream for up to five minutes.
+        {"method_path": "suite.mail.api.admin.stream_delivery_test", "limit": 20, "seconds": 60 * 60},
         # suite.mail.api.inbound
-        {"method_path": "suite.mail.api.inbound.fetch_blob", "limit": 60, "seconds": 60},
+        {"method_path": "suite.mail.api.inbound.fetch_blob", "limit": 120, "seconds": 60},
         {"method_path": "suite.mail.api.inbound.pull", "limit": 10, "seconds": 60},
         {"method_path": "suite.mail.api.inbound.pull_raw", "limit": 10, "seconds": 60},
+        # suite.mail.api.mail
+        # Large attachments and import archives arrive as 24 MB chunks, one request each.
+        {"method_path": "suite.mail.api.mail.upload_file", "limit": 120, "seconds": 60},
         # suite.mail.api.outbound
         {"method_path": "suite.mail.api.outbound.upload_attachment", "limit": 60, "seconds": 60},
-        {"method_path": "suite.mail.api.outbound.send", "limit": 300, "seconds": 60},
-        {"method_path": "suite.mail.api.outbound.send_raw", "limit": 300, "seconds": 120},
-        # suite.mail.api.outbound — priority-based limits (per minute)
+        # The per-priority limits below stack on top of these, so the ceiling has to leave room
+        # for a caller mixing all three tiers (100 + 50 + 10); it is also the only limit that
+        # applies when the caller sends no explicit priority.
+        {"method_path": "suite.mail.api.outbound.send", "limit": 200, "seconds": 60},
+        {"method_path": "suite.mail.api.outbound.send_raw", "limit": 200, "seconds": 60},
+        # suite.mail.api.outbound — priority-based limits (per minute). Higher priority jumps the
+        # delivery queue, so the more privileged the tier the tighter the allowance.
         {
             "method_path": "suite.mail.api.outbound.send",
             "key": "priority",


### PR DESCRIPTION
Every limit in `mail/install.py` is per client IP and is meant as an abuse backstop, not a quota — a few were sized so tight that normal use hit them, and a number of endpoints worth limiting had no row at all.

### Adjusted

| Endpoint | Before | After | Why |
|---|---|---|---|
| `account.validate_email_assigned` | 10/h | 20/min + 100/h | Fires while the user types a username; 10/h broke the signup form. The hourly window stays as the anti-enumeration guard. |
| `account.verify_otp` | 5/h | 10/h | Still the only guard on a 6-digit OTP, but five typos shouldn't lock someone out for an hour. |
| `account.get_account_request` | 5/h | 60/h | Read-only and gated on an unguessable request key; 5/h died on page reloads. |
| `account.get_account_setup_options` | 5/h | 20/h | Same, called once per setup page. |
| `admin.add_member` / `add_group` / `add_mailing_list` / `add_role` | 10–20/h | 60/h | Sized for onboarding a batch rather than a single action. |
| `admin.add_domain` | 10/day | 20/h | Windows normalized to hourly across admin writes. |
| `inbound.fetch_blob` | 60/min | 120/min | One request per attachment while a client syncs. |
| `outbound.send` / `send_raw` | 300/min, 300/2min | 200/min each | The three per-priority limits stack on the base, so the base has to exceed 100 + 50 + 10; it is also the only limit that applies when no `priority` is sent, which made "no priority" 6× looser than an explicit `Normal`. Also drops the odd 120s window. |

The priority tiers (Low 100 > Normal 50 > High 10) are unchanged — higher priority jumps the delivery queue, so the privileged tier is rightly the scarcest. Added a comment, since it reads backwards otherwise.

### Added

| Endpoint | Limit | Why |
|---|---|---|
| `auth.validate` | 60/min | Already decorated, had no limit row. |
| `admin.change_member_password` | 10/h | Same. |
| `account.get_user_for_reset_password_key` | 20/h | Guest endpoint resolving a reset key to a user. |
| `mail.upload_file` | 120/min | Guest-capable POST upload; 24 MB chunks mean one request per chunk. |
| `admin.stream_delivery_test` | 20/h | Each call pins a worker to an upstream SSE stream for up to five minutes. |
| `account.create_{mail,calendar,contacts}_{import,export}` | 10/h each | Each submit enqueues a long-running job with no concurrency guard. |

Endpoints that need the `@dynamic_rate_limit` decorator to accept a limit got it.

Deliberately skipped: `jmap.push_notification` (every push originates from one Stalwart IP, so an IP-based limit would throttle the whole site) and `mail.get_avatar` / `search_mails` (authenticated, and a shared office IP would trip them long before an abuser would).

### Verified

- All 33 method paths in the list resolve and carry `@dynamic_rate_limit` (a missing decorator makes `create_rate_limit` throw at install time).
- Confirmed on a site that the two-window `validate_email_assigned` rows both insert and are both returned by `get_rate_limits`.
- `test_mail_exchange_and_spam`, `test_admin_ops`, `test_admin_roles_and_disable`, `test_mail_inbound_outbound_api` all pass.

### Follow-ups (not in this PR)

1. **These values only reach fresh installs.** `after_migrate()` is a no-op, so existing sites keep their old rows. `add_rate_limits()` can't simply be called from there either: the `unique_rate_limit` constraint covers `key_`/`value`, which are NULL for most rows, and MariaDB treats NULLs as distinct — a re-run duplicates every row instead of erroring. Wants a patch that upserts on `(method_path, key_, value, seconds)`.
2. **The legacy aliases bypass every limit.** `hooks.py` maps `mail.api.outbound.send` → `suite.mail.api.outbound.send` via `override_whitelisted_methods`; `execute_cmd` rebinds its local `cmd` but leaves `form_dict.cmd` as the alias, and `dynamic_rate_limit` looks limits up by `form_dict.cmd`, finds none, and skips all of them. Rate Limit rows can't cover the alias either, since `validate_method_path` calls `frappe.get_attr`, which fails on `mail.api.*`. Fix is a fallback to the declared path in `suite/utils/rate_limiter.py` — **done in #553**, which resolves the bucket from the declared path for the same reason a nested endpoint needed it.

