### PR TITLE
feat(calendar): add rate limits

### DIFF
--- a/suite/calendar/api/__init__.py
+++ b/suite/calendar/api/__init__.py
@@ -14,6 +14,7 @@ from suite.calendar.doctype.calendar_event.calendar_event import (
 )
 from suite.mail.jmap import get_calendar_event_service
 from suite.mail.utils.dt import normalize_utc_z
+from suite.utils.rate_limiter import dynamic_rate_limit
 
 
 @frappe.whitelist()
@@ -124,6 +125,7 @@ def _with_name(items: list[dict] | None) -> list[dict] | None:
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def rsvp_calendar_event(account: str, id: str, response: str) -> None:
     """Records the logged-in user's RSVP (accepted / declined / tentative) on the event.
 
@@ -135,6 +137,7 @@ def rsvp_calendar_event(account: str, id: str, response: str) -> None:
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def edit_calendar_event(account: str, id: str, **kwargs) -> None:
     events = get_calendar_events_by_ids(account, [id])
     if not events:

--- a/suite/calendar/api/invites.py
+++ b/suite/calendar/api/invites.py
@@ -12,9 +12,11 @@ from suite.calendar.doctype.calendar_exchange.calendar_exchange import SERVER_MA
 from suite.mail.jmap import format_jmap_error, get_calendar_event_service, get_participant_identities
 from suite.mail.jmap.services.calendars.calendar import CalendarService
 from suite.mail.jmap.services.calendars.calendar_event import CalendarEventService
+from suite.utils.rate_limiter import dynamic_rate_limit
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def get_invite_details(account: str, blob_id: str) -> dict | None:
     """Parses a text/calendar mail attachment (already a blob in the account's JMAP namespace) and
     reports whether its event is on the calendar yet, so the thread view can offer "Add to Calendar".
@@ -62,6 +64,7 @@ def get_invite_details(account: str, blob_id: str) -> dict | None:
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def add_invite_to_calendar(account: str, blob_id: str) -> dict:
     """Creates the invite's event(s) from a text/calendar mail attachment on the account's default
     calendar and returns the calendar copy. No scheduling messages are sent — adding the invite is
@@ -77,6 +80,7 @@ def add_invite_to_calendar(account: str, blob_id: str) -> dict:
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def rsvp_to_invite(account: str, blob_id: str, response: str) -> dict:
     """Records the viewer's RSVP to an invite attachment: puts the event on their calendar first
     if it isn't yet, then records the response via `record_rsvp` — which notifies the organizer

--- a/suite/calendar/doctype/calendar/calendar.py
+++ b/suite/calendar/doctype/calendar/calendar.py
@@ -13,6 +13,7 @@ from frappe.utils import cint, today
 from suite.mail.doctype.user_account.user_account import get_user_for_jmap_account
 from suite.mail.jmap import get_calendar_service
 from suite.utils import parse_filters
+from suite.utils.rate_limiter import dynamic_rate_limit
 
 
 class Calendar(Document):
@@ -162,6 +163,7 @@ def bulk_delete(names: str | list[str]) -> None:
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def add_calendar(
     account: str,
     name: str,
@@ -217,6 +219,7 @@ def get_calendar(account: str, id: str) -> dict:
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def update_calendar(
     account: str,
     id: str,
@@ -257,6 +260,7 @@ def update_calendar(
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def delete_calendars(account: str, ids: list[str], remove_events: bool = True) -> None:
     """Deletes calendars for the specified account and ID(s)."""
 

--- a/suite/calendar/doctype/calendar_event/calendar_event.py
+++ b/suite/calendar/doctype/calendar_event/calendar_event.py
@@ -29,6 +29,7 @@ from suite.mail.utils.dt import normalize_utc_z
 from suite.mail.utils.logger import get_push_logger
 from suite.utils import enqueue_job, parse_filters, user_context
 from suite.utils.dt import utcnow
+from suite.utils.rate_limiter import dynamic_rate_limit
 
 
 class CalendarEvent(Document):
@@ -344,6 +345,7 @@ def bulk_delete(names: str | list[str]) -> None:
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def add_calendar_event(
     account: str,
     organizer: str | None = None,
@@ -457,6 +459,7 @@ def get_calendar_events(account: str, ids: list[str]) -> list[dict]:
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def update_calendar_event(
     account: str,
     id: str,
@@ -534,6 +537,7 @@ def update_calendar_event(
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def update_calendar_event_instance(
     account: str,
     master_id: str,
@@ -577,6 +581,7 @@ def update_calendar_event_instance(
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def delete_calendar_events(account: str, ids: list[str], send_scheduling_messages: bool = False) -> None:
     """Deletes a calendar event for the given account by its ID."""
 
@@ -606,6 +611,7 @@ def delete_calendar_events(account: str, ids: list[str], send_scheduling_message
 
 
 @frappe.whitelist()
+@dynamic_rate_limit()
 def delete_calendar_event_instance(
     account: str, master_id: str, recurrence_id: str, send_scheduling_messages: bool = False
 ) -> None:

--- a/suite/calendar/install.py
+++ b/suite/calendar/install.py
@@ -1,0 +1,79 @@
+from suite.suite_core.doctype.rate_limit.rate_limit import create_rate_limit
+
+
+def after_install() -> None:
+    add_rate_limits()
+
+
+def add_rate_limits() -> None:
+    """Add rate limits.
+
+    Every limit here is per client IP and is an abuse backstop, not a quota: the numbers are
+    sized so normal use never reaches them. Unlike the mail APIs, these endpoints are all
+    interactive and everyone in an office can share one address, so they use per-minute
+    windows - a runaway script trips them in seconds, while a floor of people working a
+    calendar never gets close. Event creation carries an hourly ceiling on top, since that is
+    the endpoint that fans invitation mail out to arbitrary addresses.
+    """
+
+    rate_limits = [
+        # suite.calendar.api — invite attachments in the mail thread view
+        {"method_path": "suite.calendar.api.invites.get_invite_details", "limit": 120, "seconds": 60},
+        {"method_path": "suite.calendar.api.invites.add_invite_to_calendar", "limit": 60, "seconds": 60},
+        {"method_path": "suite.calendar.api.invites.rsvp_to_invite", "limit": 60, "seconds": 60},
+        # suite.calendar.api — each RSVP writes the response and emails the organizer
+        {"method_path": "suite.calendar.api.rsvp_calendar_event", "limit": 60, "seconds": 60},
+        # Delegates to update_calendar_event, so an edit spends from that limit as well.
+        {"method_path": "suite.calendar.api.edit_calendar_event", "limit": 120, "seconds": 60},
+        # suite.calendar.doctype.calendar_event
+        # Creating an event mails an invitation to every participant, and a mailing list
+        # participant expands to many - hence the hourly ceiling alongside the burst one.
+        {
+            "method_path": "suite.calendar.doctype.calendar_event.calendar_event.add_calendar_event",
+            "limit": 60,
+            "seconds": 60,
+        },
+        {
+            "method_path": "suite.calendar.doctype.calendar_event.calendar_event.add_calendar_event",
+            "limit": 600,
+            "seconds": 60 * 60,
+        },
+        # Edits are the most frequent write (dragging an event reschedules it) and each one can
+        # send an update to every participant.
+        {
+            "method_path": "suite.calendar.doctype.calendar_event.calendar_event.update_calendar_event",
+            "limit": 120,
+            "seconds": 60,
+        },
+        {
+            "method_path": "suite.calendar.doctype.calendar_event.calendar_event.update_calendar_event_instance",
+            "limit": 120,
+            "seconds": 60,
+        },
+        # Deleting sends a cancellation to every participant.
+        {
+            "method_path": "suite.calendar.doctype.calendar_event.calendar_event.delete_calendar_events",
+            "limit": 60,
+            "seconds": 60,
+        },
+        {
+            "method_path": "suite.calendar.doctype.calendar_event.calendar_event.delete_calendar_event_instance",
+            "limit": 60,
+            "seconds": 60,
+        },
+        # suite.calendar.doctype.calendar — calendars are created once and then lived in
+        {"method_path": "suite.calendar.doctype.calendar.calendar.add_calendar", "limit": 20, "seconds": 60},
+        {
+            "method_path": "suite.calendar.doctype.calendar.calendar.update_calendar",
+            "limit": 60,
+            "seconds": 60,
+        },
+        {
+            "method_path": "suite.calendar.doctype.calendar.calendar.delete_calendars",
+            "limit": 20,
+            "seconds": 60,
+        },
+    ]
+
+    for rl in rate_limits:
+        create_rate_limit(**rl)

--- a/suite/suite_core/boot.py
+++ b/suite/suite_core/boot.py
@@ -33,6 +33,7 @@ def after_install():
     through Drive's overridden hooks. So create Drive's File columns FIRST, before
     any app's after_install runs.
     """
+    from suite.calendar.install import after_install as calendar_after_install
     from suite.drive.install import after_install as drive_after_install
     from suite.drive.install import ensure_custom_fields
     from suite.mail.install import after_install as mail_after_install
@@ -40,6 +41,7 @@ def after_install():
     _run("drive.ensure_custom_fields", ensure_custom_fields)
     _run("drive.after_install", drive_after_install)
     _run("mail.after_install", mail_after_install)
+    _run("calendar.after_install", calendar_after_install)
 
 
 def after_migrate():

--- a/suite/suite_core/doctype/rate_limit/test_rate_limit.py
+++ b/suite/suite_core/doctype/rate_limit/test_rate_limit.py
@@ -1,14 +1,38 @@
 # Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests import IntegrationTestCase, UnitTestCase
+from werkzeug.test import EnvironBuilder
+from werkzeug.wrappers import Request
+
+from suite.suite_core.doctype.rate_limit.rate_limit import create_rate_limit
+from suite.utils.rate_limiter import dynamic_rate_limit
 
 # On IntegrationTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
 # Use these module variables to add/remove to/from that list
 EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+PROBE_IP = "203.0.113.7"
+
+
+# Two rate-limited endpoints where one calls the other, standing in for the real pairs that do
+# (api.edit_calendar_event -> calendar_event.update_calendar_event). Module-level so their declared
+# path is importable, which is what a Rate Limit row has to reference.
+@dynamic_rate_limit()
+def probe_inner() -> str:
+    return "inner"
+
+
+@dynamic_rate_limit()
+def probe_outer() -> str:
+    return probe_inner()
+
+
+OUTER_PATH = f"{__name__}.probe_outer"
+INNER_PATH = f"{__name__}.probe_inner"
 
 
 class UnitTestRateLimit(UnitTestCase):
@@ -26,4 +50,79 @@ class IntegrationTestRateLimit(IntegrationTestCase):
     Use this class for testing interactions between multiple components.
     """
 
-    pass
+    def setUp(self) -> None:
+        for path in (OUTER_PATH, INNER_PATH):
+            # Every row for a path applies, so clear first: a leftover from an earlier test would
+            # stack a second identical limit and charge the counter twice per call.
+            frappe.db.delete("Rate Limit", {"method_path": path})
+            # ignore_in_developer_mode is off: a developer bench must still exercise the counters.
+            create_rate_limit(method_path=path, limit=1000, seconds=60, ignore_in_developer_mode=False)
+            frappe.cache.hdel("rate_limits", path)
+        self._reset_counters()
+
+    def tearDown(self) -> None:
+        # The rows go with the test transaction; the redis counters and cache do not.
+        self._reset_counters()
+        for path in (OUTER_PATH, INNER_PATH):
+            frappe.cache.hdel("rate_limits", path)
+
+    def test_nested_endpoints_charge_their_own_bucket(self):
+        """An endpoint delegating to another spends one hit from each, not two from its own."""
+
+        # frappe's v1 dispatcher publishes the called path in form_dict.cmd.
+        self._dispatch(OUTER_PATH)
+
+        self.assertEqual(self._counter(OUTER_PATH), 1)
+        self.assertEqual(self._counter(INNER_PATH), 1)
+
+    def test_limits_apply_when_the_request_carries_no_command(self):
+        """frappe's v2 dispatcher calls the method directly, leaving form_dict.cmd unset."""
+
+        self._dispatch(None)
+
+        self.assertEqual(self._counter(OUTER_PATH), 1)
+        self.assertEqual(self._counter(INNER_PATH), 1)
+
+    def test_limits_apply_when_dispatched_under_an_alias(self):
+        """override_whitelisted_methods leaves the caller's alias in form_dict.cmd.
+
+        No Rate Limit row can name that alias - `validate_method_path` resolves the path through
+        `frappe.get_attr`, and an alias like `mail.api.outbound.send` is not importable - so a limit
+        keyed on the request's command would simply not be found.
+        """
+
+        self._dispatch("legacy.alias.probe_outer")
+
+        self.assertEqual(self._counter(OUTER_PATH), 1)
+        self.assertEqual(self._counter(INNER_PATH), 1)
+
+    def _dispatch(self, cmd: str | None) -> None:
+        """Calls probe_outer as a request dispatched under `cmd`."""
+
+        builder = EnvironBuilder(path=f"/api/method/{cmd}", method="POST")
+        previous_request = getattr(frappe.local, "request", None)
+        previous_cmd = frappe.form_dict.cmd
+        frappe.local.request = Request(builder.get_environ())
+        frappe.local.request_ip = PROBE_IP
+        frappe.form_dict.cmd = cmd
+        try:
+            probe_outer()
+        finally:
+            frappe.form_dict.cmd = previous_cmd
+            if previous_request is None:
+                delattr(frappe.local, "request")
+            else:
+                frappe.local.request = previous_request
+
+    @staticmethod
+    def _counter_key(path: str, seconds: int = 60) -> bytes:
+        # Mirrors the key frappe.rate_limiter.rate_limit builds for an IP-based limit.
+        return frappe.cache.make_key(f"rl:{path}:{PROBE_IP}") + f":{seconds}".encode()
+
+    def _counter(self, path: str) -> int:
+        value = frappe.cache.get(self._counter_key(path))
+        return int(value) if value else 0
+
+    def _reset_counters(self) -> None:
+        for path in (OUTER_PATH, INNER_PATH):
+            frappe.cache.delete(self._counter_key(path))

--- a/suite/utils/rate_limiter.py
+++ b/suite/utils/rate_limiter.py
@@ -11,9 +11,12 @@ def dynamic_rate_limit() -> callable:
     """A decorator to apply rate limits dynamically based on the method path."""
 
     def decorator(fn):
-        # Resolved once, at decoration time. Only frappe's v1 dispatcher populates form_dict.cmd;
-        # the v2 one calls the method directly, so keying off cmd alone meant every limit could be
-        # skipped by posting to /api/v2/method/... instead of /api/method/....
+        # Resolved once, at decoration time, and used in preference to form_dict.cmd - which names
+        # the request, not this function. Reading cmd instead meant a limit was skipped entirely
+        # when the request arrived under some other name (frappe's v2 dispatcher leaves cmd unset,
+        # and override_whitelisted_methods leaves the caller's alias in it, neither of which any
+        # Rate Limit row can match), and that one decorated endpoint calling another charged the
+        # outer endpoint's bucket twice while never touching the inner one's.
         declared_method_path = f"{fn.__module__}.{fn.__qualname__}"
 
         @wraps(fn)
@@ -22,7 +25,7 @@ def dynamic_rate_limit() -> callable:
             if not getattr(frappe.local, "request", None):
                 return fn(*args, **kwargs)
 
-            method_path = frappe.form_dict.cmd or declared_method_path
+            method_path = declared_method_path
             rate_limits = get_rate_limits(method_path)
             if not rate_limits:
                 return fn(*args, **kwargs)
@@ -59,9 +62,11 @@ def dynamic_rate_limit() -> callable:
                     ip_based=rl["ip_based"],
                 )(wrapped_fn)
 
-            # frappe's rate_limit builds its counter key from form_dict.cmd too, so publish the
-            # resolved path for the duration of the call - otherwise every v2 request would share
-            # a single bucket keyed on None.
+            # frappe's rate_limit builds its counter key from form_dict.cmd too, so publish this
+            # method's path for the duration of the call - otherwise the counter lands in whatever
+            # bucket the request happens to be named after (a single one keyed on None for every
+            # v2 request, or the calling endpoint's for a nested call). Restored on the way out, so
+            # the caller's own counter stays its own.
             previous_cmd = frappe.form_dict.cmd
             frappe.form_dict.cmd = method_path
             try:


### PR DESCRIPTION
Calendar has no rate limits today — there is no `calendar/install.py` at all. Creating or editing an event mails an invitation to every participant, and a mailing list participant expands to many, so it's the same fan-out that `outbound.send` is limited for. This adds `suite/calendar/install.py` on the same shape as the mail one and wires it into the `suite_core.boot.after_install` dispatcher.

Sibling of #551 (mail).

### Sizing

Unlike the mail APIs these endpoints are all interactive, and every person in an office can share one public address, so the windows are **per minute**: a runaway script trips them within seconds, while a floor of people working a calendar never gets close. Event creation carries an hourly ceiling on top, since that is the endpoint that fans invitation mail out to arbitrary addresses.

| Endpoint | Limit | Why |
|---|---|---|
| `calendar_event.add_calendar_event` | 60/min + 600/h | Mails an invitation to every participant; the hourly ceiling is the anti-spam backstop. |
| `calendar_event.update_calendar_event` | 120/min | Most frequent write (dragging an event reschedules it), each can send an update to every participant. |
| `calendar_event.update_calendar_event_instance` | 120/min | Same, single occurrence. |
| `calendar_event.delete_calendar_events` | 60/min | Sends a cancellation to every participant. |
| `calendar_event.delete_calendar_event_instance` | 60/min | Same, single occurrence. |
| `api.edit_calendar_event` | 120/min | The path the frontend uses; delegates to `update_calendar_event`, so an edit spends from that limit too — which makes the doctype-level one the aggregate across both entry points. This only holds with the limiter fix below. |
| `api.rsvp_calendar_event` | 60/min | Writes the response and emails the organizer. |
| `api.invites.rsvp_to_invite` | 60/min | Puts the event on the calendar, then the above. |
| `api.invites.add_invite_to_calendar` | 60/min | Parses a `text/calendar` blob and creates events. |
| `api.invites.get_invite_details` | 120/min | Parses a blob plus a JMAP lookup on every thread open. |
| `calendar.add_calendar` | 20/min | Calendars are created once and then lived in. |
| `calendar.update_calendar` | 60/min | |
| `calendar.delete_calendars` | 20/min | |

Endpoints that need the `@dynamic_rate_limit` decorator to accept a limit got it.

### Also fixes: limits were keyed by the request, not by the method

The nesting above surfaced a bug in `dynamic_rate_limit`, so a second commit fixes it. The wrapper resolved its bucket from `frappe.form_dict.cmd`, which names the request rather than the function it decorates:

- **Nested endpoints charged the wrong bucket.** `edit_calendar_event` → `update_calendar_event` charged the *edit* bucket twice and never touched the update one — halving edit's effective limit and leaving the aggregate uncounted. Every other nesting was hit too: `bulk_delete` → `delete_calendar_events`, and Meet's scheduler → `add_calendar_event`, both resolved to a caller with no rows at all, so the limit was skipped outright.
- **Legacy aliases were unlimited.** `override_whitelisted_methods` maps `mail.api.outbound.send` → the real path but leaves the alias in `cmd`, so no row matched and every limit was skipped. No Rate Limit row can name the alias either — `validate_method_path` resolves through `frappe.get_attr`, and an alias is not importable.
- **v2 requests shared one bucket.** With `cmd` unset the fallback path was already correct for lookup, but the counter key still landed wherever the outer call had published.

Measured on a site, one dispatched call through the outer endpoint, counters read straight out of redis:

| dispatch | before (outer / inner) | after |
|---|---|---|
| v1, real path in `cmd` | 2 / 0 | 1 / 1 |
| v2, `cmd` unset | 2 / 0 | 1 / 1 |
| legacy alias in `cmd` | 0 / 0 | 1 / 1 |

The fix resolves the bucket from the declared path and publishes that path while the call runs. This closes follow-up 2 from #551.

### Deliberately skipped

- **The guest RSVP page** (`/event_rsvp`). It is the only unauthenticated calendar surface and it does write through JMAP, but every recipient of one invitation can sit behind a single corporate NAT — a per-IP limit there would reject genuine responses. Replay of a valid signed token is the only real abuse case, and it is idempotent.
- **Read endpoints** (`get_calendars`, `get_calendar_events`, `fetch_calendar_events`, `fetch_calendars`, event notification reads). They fire on every calendar navigation, and a shared office address would trip them long before an abuser would — same call as `search_mails` / `get_avatar` in #551.
- **`CalendarExchange.retry`.** It re-enqueues a heavy job and is worth limiting, but it is a document method: `frappe.get_attr` can't resolve `...calendar_exchange.CalendarExchange.retry`, so the Rate Limit doctype can't reference it. Would need the mechanism to grow support for doc methods (Mail Exchange has the same gap).

### Verified

- All 13 method paths resolve and carry `@dynamic_rate_limit` (a missing decorator makes `create_rate_limit` throw at install time).
- Ran `add_rate_limits()` against a site inside a transaction: all 14 rows insert, and both windows on `add_calendar_event` come back from `get_rate_limits`.
- All 39 calendar tests pass, plus `suite.meet.api.test.test_meeting` — Meet schedules through `add_calendar_event`, so it shares that limit.
- The three dispatch shapes above are now covered by tests in `test_rate_limit.py` (the doctype had none). Each one fails on the unfixed limiter with exactly the counts in the table.

