### PR TITLE
refactor(meet): type SFU protocol boundaries

### DIFF
--- a/suite/meet/api/meeting.py
+++ b/suite/meet/api/meeting.py
@@ -343,6 +343,7 @@ def get_sfu_presence_preview_token(meeting_id: str) -> dict:
 
     expiry_seconds = 300
     session_id = str(secrets.token_urlsafe(16))
+    user_name, user_avatar, is_host, is_cohost = _user_payload(meeting, frappe.session.user)
 
     auth_token = _generate_sfu_token(
         user_id=frappe.session.user,
@@ -350,6 +351,11 @@ def get_sfu_presence_preview_token(meeting_id: str) -> dict:
         scope="presence-preview",
         expires_in=expiry_seconds,
         session_id=session_id,
+        user_name=user_name,
+        user_avatar=user_avatar,
+        is_host=is_host,
+        is_cohost=is_cohost,
+        is_guest=False,
     )
 
     return {

--- a/suite/meet/api/test/test_meeting.py
+++ b/suite/meet/api/test/test_meeting.py
@@ -70,6 +70,17 @@ class IntegrationTestMeetingApi(IntegrationTestCase):
         self.assertEqual(decoded["site"], frappe.local.site)
         self.assertEqual(decoded["meeting_id"], self.meeting.name)
 
+    def test_presence_preview_token_includes_required_participant_claims(self):
+        frappe.set_user(self.host_email)
+
+        result = get_sfu_presence_preview_token(self.meeting.name)
+        decoded = jwt.decode(result["auth_token"], frappe.conf.sfu_secret, algorithms=["HS256"])
+
+        self.assertEqual(decoded["user_name"], "Host")
+        self.assertTrue(decoded["is_host"])
+        self.assertFalse(decoded["is_cohost"])
+        self.assertFalse(decoded["is_guest"])
+
     def test_sfu_connection_details_include_disabled_global_recording_setting(self):
         self.meeting.add_user_to_table("members", self.host_email, save=True, ignore_permissions=True)
         frappe.db.set_single_value("Meet Settings", "enable_recording", 0)

--- a/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
@@ -1,5 +1,4 @@
 import type {
-	AppData,
 	CloseProducerResult,
 	Consumer,
 	ConsumerData,
@@ -11,11 +10,14 @@ import type {
 	ParticipantInfo,
 	Peer,
 	PeerInfo,
+	ProducerAppData,
 	ProducerData,
 	Room,
 	RtpCapabilities,
 	RtpCodecCapability,
 	RtpParameters,
+	TransportData,
+	WebRtcTransportData,
 } from '../types';
 import { loggers } from '../utils/logger';
 import { ConsumerManager } from './ConsumerManager';
@@ -350,11 +352,15 @@ export class MediasoupManager {
 		peerId: string,
 		rtpParameters: RtpParameters,
 		kind: 'audio' | 'video',
-		appData: AppData = {},
+		appData: ProducerAppData = {},
 		senderId?: number,
 		paused = false,
-	): Promise<{ id: string; kind: 'audio' | 'video'; appData: AppData }> {
-		const enrichedAppData: AppData =
+	): Promise<{
+		id: string;
+		kind: 'audio' | 'video';
+		appData: ProducerAppData;
+	}> {
+		const enrichedAppData: ProducerAppData =
 			senderId !== undefined ? { ...appData, senderId } : appData;
 		const transportData = this.assertTransportAccess(
 			transportId,
@@ -417,7 +423,6 @@ export class MediasoupManager {
 			peerId,
 			'recv',
 		);
-
 		const producerData = this.producerManager.getProducerData(producerId);
 		if (!producerData) {
 			throw new Error(`Producer ${producerId} not found`);
@@ -561,8 +566,26 @@ export class MediasoupManager {
 		transportId: string,
 		roomId: string,
 		peerId: string,
+		direction: 'recv',
+	): WebRtcTransportData;
+	assertTransportAccess(
+		transportId: string,
+		roomId: string,
+		peerId: string,
+		direction: 'send',
+	): TransportData;
+	assertTransportAccess(
+		transportId: string,
+		roomId: string,
+		peerId: string,
 		direction?: 'send' | 'recv',
-	) {
+	): TransportData;
+	assertTransportAccess(
+		transportId: string,
+		roomId: string,
+		peerId: string,
+		direction?: 'send' | 'recv',
+	): TransportData {
 		const data = this.transportManager.getTransportData(transportId);
 		if (!data) throw new Error(`Transport ${transportId} not found`);
 		if (data.roomId !== roomId || data.peerId !== peerId) {

--- a/suite/meet/sfu-server/src/mediasoup/ProducerManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/ProducerManager.ts
@@ -3,9 +3,10 @@ import type * as mediasoup from 'mediasoup';
 import type {
 	AppData,
 	CloseProducerResult,
+	ProducerAppData,
 	ProducerData,
 	RtpParameters,
-	WebRtcTransport,
+	TransportData,
 } from '../types';
 import { loggers } from '../utils/logger';
 
@@ -13,14 +14,18 @@ export class ProducerManager extends EventEmitter {
 	private producers = new Map<string, ProducerData>();
 
 	async createProducer(
-		transport: WebRtcTransport,
+		transport: TransportData['transport'],
 		roomId: string,
 		peerId: string,
 		rtpParameters: RtpParameters,
 		kind: 'audio' | 'video',
-		appData: AppData = {},
+		appData: ProducerAppData = {},
 		paused = false,
-	): Promise<{ id: string; kind: 'audio' | 'video'; appData: AppData }> {
+	): Promise<{
+		id: string;
+		kind: 'audio' | 'video';
+		appData: ProducerAppData;
+	}> {
 		loggers.producerManager.info(
 			'Creating %s producer for peer %s',
 			kind,
@@ -55,7 +60,7 @@ export class ProducerManager extends EventEmitter {
 		return {
 			id: producer.id,
 			kind: producer.kind,
-			appData: producer.appData || appData,
+			appData: sanitizedAppData(producer.appData),
 		};
 	}
 
@@ -180,4 +185,19 @@ export class ProducerManager extends EventEmitter {
 		}
 		this.producers.clear();
 	}
+}
+
+function sanitizedAppData(value: AppData): ProducerAppData {
+	const appData: ProducerAppData = {};
+	if (value.type === 'screen') appData.type = 'screen';
+	if (typeof value.e2eeStartPaused === 'boolean') {
+		appData.e2eeStartPaused = value.e2eeStartPaused;
+	}
+	if (
+		typeof value.senderId === 'number' &&
+		Number.isSafeInteger(value.senderId)
+	) {
+		appData.senderId = value.senderId;
+	}
+	return appData;
 }

--- a/suite/meet/sfu-server/src/mediasoup/TransportManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/TransportManager.ts
@@ -110,6 +110,7 @@ export class TransportManager {
 			peerId,
 			transport,
 			direction,
+			type: 'webrtc',
 		};
 		this.transports.set(transport.id, transportData);
 		transport.observer.on('close', () => {
@@ -164,6 +165,9 @@ export class TransportManager {
 		if (!transportData) {
 			throw new Error(`Transport ${transportId} not found`);
 		}
+		if (transportData.type !== 'webrtc') {
+			throw new Error(`Transport ${transportId} is not a WebRTC transport`);
+		}
 
 		try {
 			await transportData.transport.connect({ dtlsParameters });
@@ -187,12 +191,16 @@ export class TransportManager {
 		if (!transportData) {
 			throw new Error(`Transport ${transportId} not found`);
 		}
+		if (transportData.type !== 'webrtc') {
+			throw new Error(`Transport ${transportId} is not a WebRTC transport`);
+		}
 
 		return transportData.transport.restartIce();
 	}
 
 	getTransport(transportId: string): WebRtcTransport | undefined {
-		return this.transports.get(transportId)?.transport;
+		const data = this.transports.get(transportId);
+		return data?.type === 'webrtc' ? data.transport : undefined;
 	}
 
 	getTransportData(transportId: string): TransportData | undefined {
@@ -277,8 +285,9 @@ export class TransportManager {
 		const transportData: TransportData = {
 			roomId,
 			peerId,
-			transport: transport as unknown as WebRtcTransport, // fake as WebRtcTransport
+			transport,
 			direction: 'send',
+			type: 'plain',
 		};
 		this.transports.set(transport.id, transportData);
 

--- a/suite/meet/sfu-server/src/server/AuthManager.ts
+++ b/suite/meet/sfu-server/src/server/AuthManager.ts
@@ -16,17 +16,19 @@ export class AuthManager {
 
 	authenticateSocket(socket: Socket): boolean {
 		try {
-			const token = socket.handshake.auth.token || socket.handshake.query.token;
+			const candidate: unknown =
+				socket.handshake.auth.token || socket.handshake.query.token;
 
-			if (!token) {
+			if (typeof candidate !== 'string' || !candidate) {
 				loggers.authManager.error('No authentication token provided');
 				return false;
 			}
+			const token = candidate;
 
-			const header = jwt.decode(String(token), { complete: true })?.header;
+			const header = jwt.decode(token, { complete: true })?.header;
 			if (header?.typ === 'meet-recording-grant+jwt') {
 				if (!this.recordingGrantManager) return false;
-				const claims = this.recordingGrantManager.verifyGrant(String(token));
+				const claims = this.recordingGrantManager.verifyGrant(token);
 				socket.userId = `recorder:${claims.recording_id}`;
 				socket.userName = 'Recorder';
 				socket.meetingId = claims.meeting_id;
@@ -37,21 +39,14 @@ export class AuthManager {
 				socket.scope = 'recording';
 				socket.e2eeRequired = false;
 				socket.e2eeReady = false;
-				socket.currentToken = String(token);
+				socket.currentToken = token;
 				socket.tokenExpiresAt = claims.exp * 1000;
 				socket.recordingClaims = claims;
 				socket.recordingProofComplete = false;
 				return true;
 			}
 
-			const decoded = jwt.verify(token, this.jwtSecret) as JWTPayload;
-			if (
-				decoded.scope !== undefined &&
-				decoded.scope !== 'full' &&
-				decoded.scope !== 'presence-preview'
-			) {
-				throw new Error('Invalid participant scope');
-			}
+			const decoded = parseParticipantClaims(jwt.verify(token, this.jwtSecret));
 
 			// Attach user info to socket
 			socket.userId = decoded.user_id;
@@ -87,7 +82,7 @@ export class AuthManager {
 		if (socket.scope === 'recording') {
 			throw new Error('Recording authorization cannot be refreshed');
 		}
-		const decoded = jwt.verify(token, this.jwtSecret) as JWTPayload;
+		const decoded = parseParticipantClaims(jwt.verify(token, this.jwtSecret));
 		const wasE2EERequired = socket.e2eeRequired === true;
 		const wasE2EEReady = socket.e2eeReady === true;
 
@@ -187,7 +182,7 @@ export class AuthManager {
 		}
 
 		try {
-			const decoded = jwt.verify(token, this.jwtSecret) as JWTPayload;
+			const decoded = parseParticipantClaims(jwt.verify(token, this.jwtSecret));
 			if (decoded.meeting_id !== socket.meetingId) {
 				loggers.authManager.warn(
 					'Meeting ID mismatch for user %s: token has %s, socket has %s',
@@ -233,4 +228,95 @@ export class AuthManager {
 			throw new Error('Guests are not permitted to perform this action.');
 		}
 	}
+}
+
+function parseParticipantClaims(value: unknown): JWTPayload {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		throw new Error('Invalid participant claims');
+	}
+	const userId = claimString(value, 'user_id');
+	const userName = claimString(value, 'user_name');
+	const meetingId = claimString(value, 'meeting_id');
+	if (!('is_host' in value) || typeof value.is_host !== 'boolean') {
+		throw new Error('Invalid participant claims');
+	}
+	const scope = optionalString(value, 'scope');
+	if (scope !== undefined && scope !== 'full' && scope !== 'presence-preview') {
+		throw new Error('Invalid participant scope');
+	}
+	const site = optionalString(value, 'site');
+	const userAvatar = optionalNullableString(value, 'user_avatar');
+	const sessionId = optionalString(value, 'session_id');
+	const isCohost = optionalBoolean(value, 'is_cohost');
+	const isGuest = optionalBoolean(value, 'is_guest');
+	const e2eeRequired = optionalBoolean(value, 'e2ee_required');
+	const exp = optionalInteger(value, 'exp');
+	const iat = optionalInteger(value, 'iat');
+	return {
+		user_id: userId,
+		user_name: userName,
+		meeting_id: meetingId,
+		is_host: value.is_host,
+		...(site !== undefined ? { site } : {}),
+		...(userAvatar !== undefined ? { user_avatar: userAvatar } : {}),
+		...(isCohost !== undefined ? { is_cohost: isCohost } : {}),
+		...(isGuest !== undefined ? { is_guest: isGuest } : {}),
+		...(scope !== undefined ? { scope } : {}),
+		...(e2eeRequired !== undefined ? { e2ee_required: e2eeRequired } : {}),
+		...(sessionId !== undefined ? { session_id: sessionId } : {}),
+		...(exp !== undefined ? { exp } : {}),
+		...(iat !== undefined ? { iat } : {}),
+	};
+}
+
+function claimString(value: object, key: string): string {
+	if (!(key in value)) throw new Error('Invalid participant claims');
+	const claim = value[key as keyof typeof value];
+	if (typeof claim !== 'string' || !claim) {
+		throw new Error('Invalid participant claims');
+	}
+	return claim;
+}
+
+function optionalString(value: object, key: string): string | undefined {
+	if (!(key in value) || value[key as keyof typeof value] === undefined) {
+		return undefined;
+	}
+	const claim = value[key as keyof typeof value];
+	if (typeof claim !== 'string') throw new Error('Invalid participant claims');
+	return claim;
+}
+
+function optionalNullableString(
+	value: object,
+	key: string,
+): string | undefined {
+	if (
+		!(key in value) ||
+		value[key as keyof typeof value] === undefined ||
+		value[key as keyof typeof value] === null
+	) {
+		return undefined;
+	}
+	return optionalString(value, key);
+}
+
+function optionalBoolean(value: object, key: string): boolean | undefined {
+	if (!(key in value) || value[key as keyof typeof value] === undefined) {
+		return undefined;
+	}
+	const claim = value[key as keyof typeof value];
+	if (typeof claim !== 'boolean') throw new Error('Invalid participant claims');
+	return claim;
+}
+
+function optionalInteger(value: object, key: string): number | undefined {
+	if (!(key in value) || value[key as keyof typeof value] === undefined) {
+		return undefined;
+	}
+	const claim = value[key as keyof typeof value];
+	if (typeof claim !== 'number' || !Number.isSafeInteger(claim)) {
+		throw new Error('Invalid participant claims');
+	}
+	return claim;
 }

--- a/suite/meet/sfu-server/src/server/E2EEEpochRelay.ts
+++ b/suite/meet/sfu-server/src/server/E2EEEpochRelay.ts
@@ -1386,7 +1386,7 @@ export class E2EEEpochRelay {
 	private async getCommitterDebugState(
 		roomId: string,
 		excludeSenderIds: number[],
-	): Promise<Record<string, unknown>> {
+	) {
 		const rosterEntries = (await this.roster?.list(roomId)) ?? [];
 		const fullAccessSocketIds = Array.from(
 			this.fullAccessSockets.get(roomId) ?? [],
@@ -1484,9 +1484,7 @@ export class E2EEEpochRelay {
 		if (!socketsInRoom) return null;
 
 		for (const socketId of socketsInRoom) {
-			const socket = this.io.sockets.sockets.get(socketId) as
-				| TypedSocket
-				| undefined;
+			const socket = this.io.sockets.sockets.get(socketId);
 			if (socket && socket.participantId === participantId) {
 				return socket;
 			}
@@ -1569,8 +1567,7 @@ export class E2EEEpochRelay {
 		for (const socketId of socketIds) {
 			const socket = this.io.sockets.sockets.get(socketId);
 			if (socket) {
-				// biome-ignore lint/suspicious/noExplicitAny: typed-socket emit with narrowed payload
-				(socket as any).emit('e2ee:epoch', data);
+				socket.emit('e2ee:epoch', data);
 			}
 		}
 	}

--- a/suite/meet/sfu-server/src/server/RecordingGrantManager.ts
+++ b/suite/meet/sfu-server/src/server/RecordingGrantManager.ts
@@ -49,17 +49,27 @@ export class RecordingGrantManager {
 		if (!this.persistence.isReady()) {
 			throw new Error('Recording authorization is not ready');
 		}
-		const decoded = jwt.verify(token, this.secret, {
+		const decoded: unknown = jwt.verify(token, this.secret, {
 			algorithms: ['HS256'],
 			audience: GRANT_AUDIENCE,
 			clockTimestamp: now,
 			clockTolerance: this.clockSkewSeconds,
 			complete: true,
-		}) as jwt.Jwt;
+		});
 		if (
+			!decoded ||
+			typeof decoded !== 'object' ||
+			Array.isArray(decoded) ||
+			!('header' in decoded) ||
+			!decoded.header ||
+			typeof decoded.header !== 'object' ||
+			Array.isArray(decoded.header) ||
 			Object.keys(decoded.header).length !== 2 ||
+			!('alg' in decoded.header) ||
 			decoded.header.alg !== 'HS256' ||
-			decoded.header.typ !== GRANT_TYPE
+			!('typ' in decoded.header) ||
+			decoded.header.typ !== GRANT_TYPE ||
+			!('payload' in decoded)
 		) {
 			throw new Error('Invalid recording grant header');
 		}
@@ -157,38 +167,94 @@ export function jwkThumbprint(jwk: JsonWebKey): string {
 	return createHash('sha256').update(canonical).digest('base64url');
 }
 
-function parseClaims(payload: string | jwt.JwtPayload): RecordingGrantClaims {
-	if (typeof payload === 'string')
+function parseClaims(payload: unknown): RecordingGrantClaims {
+	if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
 		throw new Error('Invalid recording grant claims');
-	const requiredStrings = [
-		'iss',
-		'jti',
-		'site',
-		'meeting_id',
-		'recording_id',
-		'recorder_job_id',
-	] as const;
-	for (const name of requiredStrings) {
-		if (typeof payload[name] !== 'string' || payload[name].length === 0) {
-			throw new Error(`Missing recording grant claim: ${name}`);
-		}
 	}
-	if (payload.aud !== GRANT_AUDIENCE || payload.scope !== 'recording') {
+	if (
+		!('aud' in payload) ||
+		payload.aud !== GRANT_AUDIENCE ||
+		!('scope' in payload) ||
+		payload.scope !== 'recording'
+	) {
 		throw new Error('Invalid recording grant audience or scope');
 	}
-	for (const name of ['iat', 'exp', 'authorization_expires_at'] as const) {
-		if (!Number.isSafeInteger(payload[name])) {
-			throw new Error(`Missing recording grant claim: ${name}`);
-		}
+	return {
+		iss: requiredClaimString(property(payload, 'iss'), 'iss'),
+		aud: GRANT_AUDIENCE,
+		scope: 'recording',
+		jti: requiredClaimString(property(payload, 'jti'), 'jti'),
+		site: requiredClaimString(property(payload, 'site'), 'site'),
+		meeting_id: requiredClaimString(
+			property(payload, 'meeting_id'),
+			'meeting_id',
+		),
+		recording_id: requiredClaimString(
+			property(payload, 'recording_id'),
+			'recording_id',
+		),
+		recorder_job_id: requiredClaimString(
+			property(payload, 'recorder_job_id'),
+			'recorder_job_id',
+		),
+		cnf: parseConfirmation(property(payload, 'cnf')),
+		iat: requiredClaimInteger(property(payload, 'iat'), 'iat'),
+		exp: requiredClaimInteger(property(payload, 'exp'), 'exp'),
+		authorization_expires_at: requiredClaimInteger(
+			property(payload, 'authorization_expires_at'),
+			'authorization_expires_at',
+		),
+	};
+}
+
+function property(value: object, key: string): unknown {
+	return key in value ? value[key as keyof typeof value] : undefined;
+}
+
+function requiredClaimString(value: unknown, name: string): string {
+	if (typeof value !== 'string' || value.length === 0) {
+		throw new Error(`Missing recording grant claim: ${name}`);
 	}
-	if (!payload.cnf || typeof payload.cnf !== 'object') {
+	return value;
+}
+
+function requiredClaimInteger(value: unknown, name: string): number {
+	if (typeof value !== 'number' || !Number.isSafeInteger(value)) {
+		throw new Error(`Missing recording grant claim: ${name}`);
+	}
+	return value;
+}
+
+function parseConfirmation(value: unknown): { jwk: JsonWebKey; jkt: string } {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
 		throw new Error('Missing recording grant claim: cnf');
 	}
-	const cnf = payload.cnf as Record<string, unknown>;
-	if (!cnf.jwk || typeof cnf.jwk !== 'object' || typeof cnf.jkt !== 'string') {
+	if (!('jwk' in value) || !('jkt' in value) || typeof value.jkt !== 'string') {
 		throw new Error('Invalid recording grant cnf');
 	}
-	return payload as RecordingGrantClaims;
+	return { jwk: parsePublicJwk(value.jwk), jkt: value.jkt };
+}
+
+function parsePublicJwk(value: unknown): JsonWebKey {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		throw new Error('Invalid recording grant public JWK');
+	}
+	if (
+		!('kty' in value) ||
+		value.kty !== 'EC' ||
+		!('crv' in value) ||
+		value.crv !== 'P-256' ||
+		'd' in value ||
+		!('x' in value) ||
+		typeof value.x !== 'string' ||
+		!('y' in value) ||
+		typeof value.y !== 'string'
+	) {
+		throw new Error('Invalid recording grant public JWK');
+	}
+	decodeBase64Url(value.x, 32, 'JWK x');
+	decodeBase64Url(value.y, 32, 'JWK y');
+	return { kty: 'EC', crv: 'P-256', x: value.x, y: value.y };
 }
 
 function validatePublicJwk(jwk: JsonWebKey): void {

--- a/suite/meet/sfu-server/src/server/RoomRegistry.ts
+++ b/suite/meet/sfu-server/src/server/RoomRegistry.ts
@@ -3,11 +3,26 @@ import type {
 	ActivePoll,
 	ChatMessage,
 	ClientToServerEvents,
+	HandRaisedEvent,
 	MediaControlAction,
+	ProducerCloseDetails,
+	ProducerCloseReason,
+	ProducerCloseSource,
 	ReactionMessage,
+	ScreenShareStartedEvent,
+	ScreenShareStoppedEvent,
 	ServerToClientEvents,
+	SocketData,
 	UserData,
 } from '../types';
+
+type ServerSocket = Socket<
+	ClientToServerEvents,
+	ServerToClientEvents,
+	Record<string, never>,
+	SocketData
+>;
+type ServerEventName = keyof ServerToClientEvents;
 
 const fullRoom = (roomId: string) => `${roomId}:full`;
 const previewRoom = (roomId: string) => `${roomId}:preview`;
@@ -205,48 +220,50 @@ export class RoomRegistry {
 		this.participantToSender.delete(roomId);
 	}
 
-	emitToScope(
+	emitToScope<Event extends ServerEventName>(
 		roomId: string,
 		scope: 'full' | 'presence-preview',
-		event: string,
-		data: unknown,
+		event: Event,
+		...args: Parameters<ServerToClientEvents[Event]>
 	): void {
 		const key = scope === 'full' ? fullRoom(roomId) : previewRoom(roomId);
 		const ids = this.io.sockets.adapter.rooms.get(key);
 		if (!ids) return;
 		for (const id of ids) {
-			const socket = this.io.sockets.sockets.get(id);
+			const socket: ServerSocket | undefined = this.io.sockets.sockets.get(id);
 			if (socket) {
-				// biome-ignore lint/suspicious/noExplicitAny: Internal utility for type-safe emission to dynamic event names
-				(socket as any).emit(event, data);
+				socket.emit(event, ...args);
 			}
 		}
 	}
 
-	emitToFullAccessParticipants(
+	emitToFullAccessParticipants<Event extends ServerEventName>(
 		roomId: string,
-		event: string,
-		data: unknown,
+		event: Event,
+		...args: Parameters<ServerToClientEvents[Event]>
 	): void {
-		this.emitToScope(roomId, 'full', event, data);
+		this.emitToScope(roomId, 'full', event, ...args);
 	}
 
-	emitToPreviewParticipants(
+	emitToPreviewParticipants<Event extends ServerEventName>(
 		roomId: string,
-		event: string,
-		data: unknown,
+		event: Event,
+		...args: Parameters<ServerToClientEvents[Event]>
 	): void {
-		this.emitToScope(roomId, 'presence-preview', event, data);
+		this.emitToScope(roomId, 'presence-preview', event, ...args);
 	}
 
-	private emitToRecorders(roomId: string, event: string, data: unknown): void {
+	private emitToRecorders<Event extends ServerEventName>(
+		roomId: string,
+		event: Event,
+		...args: Parameters<ServerToClientEvents[Event]>
+	): void {
 		const ids = this.io.sockets.adapter.rooms.get(recorderRoom(roomId));
 		if (!ids) return;
 		for (const id of ids) {
-			const socket = this.io.sockets.sockets.get(id);
+			const socket: ServerSocket | undefined = this.io.sockets.sockets.get(id);
 			if (socket) {
-				// biome-ignore lint/suspicious/noExplicitAny: Internal utility used only by the explicit recorder allowlist below
-				(socket as any).emit(event, data);
+				socket.emit(event, ...args);
 			}
 		}
 	}
@@ -256,7 +273,7 @@ export class RoomRegistry {
 		data: {
 			participantId: string;
 			producerId: string;
-			kind: string;
+			kind: 'audio' | 'video';
 			paused: boolean;
 			isScreen: boolean;
 		},
@@ -272,9 +289,9 @@ export class RoomRegistry {
 			participantId: string;
 			producerId: string;
 			isScreen: boolean;
-			reason?: string;
-			source?: string;
-			details?: Record<string, unknown>;
+			reason?: ProducerCloseReason;
+			source?: ProducerCloseSource;
+			details?: ProducerCloseDetails;
 		},
 	): void {
 		this.emitToFullAccessParticipants(roomId, 'producer_closed', {
@@ -297,15 +314,28 @@ export class RoomRegistry {
 
 	emitScreenShare(
 		roomId: string,
+		event: 'screen_share_started',
+		data: ScreenShareStartedEvent,
+	): void;
+	emitScreenShare(
+		roomId: string,
+		event: 'screen_share_stopped',
+		data: ScreenShareStoppedEvent,
+	): void;
+	emitScreenShare(
+		roomId: string,
 		event: 'screen_share_started' | 'screen_share_stopped',
-		data: Record<string, unknown>,
+		data: ScreenShareStartedEvent | ScreenShareStoppedEvent,
 	): void {
 		this.emitToFullAccessParticipants(roomId, event, data);
-		const shareData = data.shareData as Record<string, unknown> | undefined;
+		const producerId =
+			'shareData' in data && typeof data.shareData.producerId === 'string'
+				? data.shareData.producerId
+				: undefined;
 		this.emitToRecorders(roomId, event, {
 			participantId: data.participantId,
-			...(event === 'screen_share_started' && shareData?.producerId
-				? { shareData: { producerId: shareData.producerId } }
+			...(event === 'screen_share_started' && producerId
+				? { shareData: { producerId } }
 				: {}),
 			timestamp: data.timestamp,
 		});
@@ -316,7 +346,7 @@ export class RoomRegistry {
 		this.emitToRecorders(roomId, 'reaction:message', data);
 	}
 
-	emitRaisedHand(roomId: string, data: Record<string, unknown>): void {
+	emitRaisedHand(roomId: string, data: HandRaisedEvent): void {
 		this.emitToFullAccessParticipants(roomId, 'hand_raised', data);
 		this.emitToRecorders(roomId, 'hand_raised', data);
 	}
@@ -386,7 +416,7 @@ export class RoomRegistry {
 					userData: {
 						name: userData.name,
 						avatar: userData.avatar,
-					} as UserData,
+					},
 				});
 			} else if (event === 'participant_left') {
 				this.emitToPreviewParticipants(roomId, event, {

--- a/suite/meet/sfu-server/src/server/__tests__/AuthManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/AuthManager.test.ts
@@ -1,11 +1,14 @@
 import * as jwt from 'jsonwebtoken';
 import { describe, expect, it } from 'vitest';
+import type { JWTPayload } from '../../types';
 import { AuthManager } from '../AuthManager';
 import { createMockSocket } from './test-helpers';
 
 const SECRET = 'test-secret';
 
-function token(overrides: Record<string, unknown> = {}): string {
+function token(
+	overrides: Partial<JWTPayload> & { user_avatar?: string | null } = {},
+): string {
 	return jwt.sign(
 		{
 			user_id: 'user-1',
@@ -36,6 +39,20 @@ describe('AuthManager', () => {
 		expect(manager.authenticateSocket(socket)).toBe(true);
 
 		expect(socket.site).toBe('site-a');
+	});
+
+	it('accepts a null avatar from the participant token issuer', () => {
+		const manager = new AuthManager(SECRET);
+		const socket = createMockSocket({
+			handshake: {
+				auth: { token: token({ user_avatar: null }) },
+				query: {},
+				headers: {},
+				address: '127.0.0.1',
+			} as never,
+		});
+
+		expect(manager.authenticateSocket(socket)).toBe(true);
 	});
 
 	it('rejects token refreshes that change site', () => {

--- a/suite/meet/sfu-server/src/server/__tests__/E2eeRedesignation.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/E2eeRedesignation.test.ts
@@ -121,7 +121,7 @@ async function main(): Promise<void> {
 	const makeSocket = (
 		id: string,
 		participantId: string,
-		overrides: Record<string, unknown> = {},
+		overrides: { isHost?: boolean; senderId?: number } = {},
 	) => ({
 		id,
 		participantId,

--- a/suite/meet/sfu-server/src/server/__tests__/RecordingGrantManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/RecordingGrantManager.test.ts
@@ -157,7 +157,11 @@ describe('RecordingGrantManager', () => {
 });
 
 function makeToken(
-	overrides: Record<string, unknown> = {},
+	overrides: {
+		scope?: string;
+		iss?: string;
+		cnf?: RecordingGrantClaims['cnf'];
+	} = {},
 	header: Record<string, string> = {},
 ): string {
 	const claims: RecordingGrantClaims = {

--- a/suite/meet/sfu-server/src/server/__tests__/RoomRegistry.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/RoomRegistry.test.ts
@@ -3,6 +3,17 @@ import { describe, expect, it } from 'vitest';
 import type { UserData } from '../../types';
 import { RoomRegistry } from '../RoomRegistry';
 
+interface EmissionFixture {
+	event: string;
+	data: {
+		roomId?: string;
+		participantId?: string;
+		producerId?: string;
+		isScreen?: boolean;
+		shareData?: { producerId: string };
+	};
+}
+
 function makeSocket(id: string): Socket {
 	const emitCalls: { event: string; data: unknown }[] = [];
 	const sock = {
@@ -233,7 +244,7 @@ describe('RoomRegistry', () => {
 				producerId: 'producer-1',
 				isScreen: false,
 				reason: 'private diagnostic',
-				details: { private: true },
+				details: { message: 'private diagnostic' },
 			});
 			registry.emitScreenShare('r1', 'screen_share_started', {
 				participantId: 'p1',
@@ -247,7 +258,11 @@ describe('RoomRegistry', () => {
 				fromName: 'Alice',
 				timestamp: 'ts',
 			});
-			registry.emitRaisedHand('r1', { participantId: 'p1', raised: true });
+			registry.emitRaisedHand('r1', {
+				participantId: 'p1',
+				raised: true,
+				timestamp: 'ts',
+			});
 			registry.emitPublicChat('r1', {
 				roomId: 'r1',
 				message: 'hello',
@@ -278,7 +293,7 @@ describe('RoomRegistry', () => {
 			]);
 			const calls = (
 				recorder as unknown as {
-					_emitCalls: { event: string; data: Record<string, unknown> }[];
+					_emitCalls: EmissionFixture[];
 				}
 			)._emitCalls;
 			expect(

--- a/suite/meet/sfu-server/src/server/handlers/DisconnectHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/DisconnectHandlers.ts
@@ -11,7 +11,7 @@ export function registerDisconnectHandlers(deps: HandlerDeps) {
 			deps.telemetry.socketDisconnects.inc({ reason: normalizedReason });
 			loggers.telemetry.event('socket_disconnect', {
 				reason: normalizedReason,
-				scope: socket.scope,
+				scope: socket.scope ?? 'unassigned',
 			});
 			deps.authManager.cleanupSocket(socket);
 

--- a/suite/meet/sfu-server/src/server/handlers/ProducerHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/ProducerHandlers.ts
@@ -1,4 +1,11 @@
 import type { Socket } from 'socket.io';
+import type {
+	AppData,
+	ProducerAppData,
+	ProducerCloseDetails,
+	ProducerCloseReason,
+	ProducerCloseTrackSettings,
+} from '../../types';
 import { loggers } from '../../utils/logger';
 import type { HandlerDeps } from './Handler';
 import { getRoomId } from './utils';
@@ -9,13 +16,14 @@ export function registerProducerHandlers(deps: HandlerDeps) {
 			const startedAt = performance.now();
 			const media =
 				data.kind === 'audio' || data.kind === 'video' ? data.kind : 'unknown';
-			const source = data.appData?.type === 'screen' ? 'screen' : 'camera';
+			const appData = sanitizeProducerAppData(data.appData);
+			const source = appData.type === 'screen' ? 'screen' : 'camera';
 			let outcome: 'success' | 'failure' = 'failure';
 			try {
 				deps.authManager.ensureFullAccess(socket);
 				enforceE2EEMediaPolicy(socket);
-				const { transportId, rtpParameters, kind, appData = {} } = data;
-				const startPaused = !!appData.e2eeStartPaused;
+				const { transportId, rtpParameters, kind } = data;
+				const startPaused = appData.e2eeStartPaused === true;
 				const roomId = getRoomId(socket);
 				const producer = await deps.mediasoup.createProducer(
 					transportId,
@@ -65,7 +73,10 @@ export function registerProducerHandlers(deps: HandlerDeps) {
 		socket.on('close_producer', async (data, callback) => {
 			try {
 				deps.authManager.ensureFullAccess(socket);
-				const { producerId, reason, source, details } = data;
+				const { producerId } = data;
+				const reason = producerCloseReason(data.reason);
+				const source = data.source === 'screen-share' ? data.source : undefined;
+				const details = sanitizeProducerCloseDetails(data.details);
 				deps.mediasoup.assertProducerAccess(
 					producerId,
 					getRoomId(socket),
@@ -176,4 +187,104 @@ function enforceE2EEMediaPolicy(socket: Socket): void {
 	if (!socket.e2eeReady) {
 		throw new Error('E2EE join handshake not completed');
 	}
+}
+
+function sanitizeProducerAppData(value: AppData | undefined): ProducerAppData {
+	const appData: ProducerAppData = {};
+	if (value?.type === 'screen') appData.type = 'screen';
+	if (typeof value?.e2eeStartPaused === 'boolean') {
+		appData.e2eeStartPaused = value.e2eeStartPaused;
+	}
+	return appData;
+}
+
+function producerCloseReason(value: unknown): ProducerCloseReason | undefined {
+	return value === 'user-click' ||
+		value === 'track-ended' ||
+		value === 'publish-failed' ||
+		value === 'cleanup'
+		? value
+		: undefined;
+}
+
+function sanitizeProducerCloseDetails(
+	value: unknown,
+): ProducerCloseDetails | undefined {
+	if (!value || typeof value !== 'object' || Array.isArray(value))
+		return undefined;
+	const details: ProducerCloseDetails = {};
+	if ('trackId' in value && typeof value.trackId === 'string')
+		details.trackId = value.trackId.slice(0, 256);
+	if (
+		'trackReadyState' in value &&
+		(value.trackReadyState === 'live' || value.trackReadyState === 'ended')
+	) {
+		details.trackReadyState = value.trackReadyState;
+	}
+	if ('trackSettings' in value) {
+		const trackSettings = sanitizeTrackSettings(value.trackSettings);
+		if (trackSettings) details.trackSettings = trackSettings;
+	}
+	if ('message' in value && typeof value.message === 'string')
+		details.message = value.message.slice(0, 256);
+	return Object.keys(details).length ? details : undefined;
+}
+
+function sanitizeTrackSettings(
+	value: unknown,
+): ProducerCloseTrackSettings | undefined {
+	if (!value || typeof value !== 'object' || Array.isArray(value))
+		return undefined;
+	const settings: ProducerCloseTrackSettings = {};
+	if ('aspectRatio' in value && typeof value.aspectRatio === 'number')
+		settings.aspectRatio = value.aspectRatio;
+	if ('autoGainControl' in value && typeof value.autoGainControl === 'boolean')
+		settings.autoGainControl = value.autoGainControl;
+	if ('channelCount' in value && typeof value.channelCount === 'number')
+		settings.channelCount = value.channelCount;
+	if ('deviceId' in value && typeof value.deviceId === 'string')
+		settings.deviceId = value.deviceId.slice(0, 256);
+	if ('displaySurface' in value && typeof value.displaySurface === 'string')
+		settings.displaySurface = value.displaySurface.slice(0, 64);
+	if (
+		'echoCancellation' in value &&
+		typeof value.echoCancellation === 'boolean'
+	)
+		settings.echoCancellation = value.echoCancellation;
+	if ('facingMode' in value && typeof value.facingMode === 'string')
+		settings.facingMode = value.facingMode.slice(0, 64);
+	if ('frameRate' in value && typeof value.frameRate === 'number')
+		settings.frameRate = value.frameRate;
+	if ('groupId' in value && typeof value.groupId === 'string')
+		settings.groupId = value.groupId.slice(0, 256);
+	if ('height' in value && typeof value.height === 'number')
+		settings.height = value.height;
+	if ('latency' in value && typeof value.latency === 'number')
+		settings.latency = value.latency;
+	if ('logicalSurface' in value && typeof value.logicalSurface === 'boolean')
+		settings.logicalSurface = value.logicalSurface;
+	if (
+		'noiseSuppression' in value &&
+		typeof value.noiseSuppression === 'boolean'
+	)
+		settings.noiseSuppression = value.noiseSuppression;
+	if (
+		'restrictOwnAudio' in value &&
+		typeof value.restrictOwnAudio === 'boolean'
+	)
+		settings.restrictOwnAudio = value.restrictOwnAudio;
+	if ('sampleRate' in value && typeof value.sampleRate === 'number')
+		settings.sampleRate = value.sampleRate;
+	if ('sampleSize' in value && typeof value.sampleSize === 'number')
+		settings.sampleSize = value.sampleSize;
+	if ('screenPixelRatio' in value && typeof value.screenPixelRatio === 'number')
+		settings.screenPixelRatio = value.screenPixelRatio;
+	if (
+		'suppressLocalAudioPlayback' in value &&
+		typeof value.suppressLocalAudioPlayback === 'boolean'
+	)
+		settings.suppressLocalAudioPlayback = value.suppressLocalAudioPlayback;
+	if ('width' in value && typeof value.width === 'number')
+		settings.width = value.width;
+	return Object.keys(settings).length ? settings : undefined;
 }

--- a/suite/meet/sfu-server/src/server/handlers/RoomJoinHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/RoomJoinHandlers.ts
@@ -107,10 +107,7 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 			}
 
 			socket.emit('existing_raised_hands', {
-				hands: deps.registry.getRaisedHands(scopedRoomId) as unknown as Record<
-					string,
-					boolean
-				>,
+				hands: deps.registry.getRaisedHands(scopedRoomId),
 			});
 
 			if (socket.scope === 'full' && !socket.e2eeRequired) {
@@ -180,10 +177,7 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 					video_enabled: false,
 				});
 				socket.emit('existing_raised_hands', {
-					hands: deps.registry.getRaisedHands(roomId) as unknown as Record<
-						string,
-						boolean
-					>,
+					hands: deps.registry.getRaisedHands(roomId),
 				});
 				callback({ success: true });
 			} catch (error) {

--- a/suite/meet/sfu-server/src/server/handlers/ScreenShareHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/ScreenShareHandlers.ts
@@ -9,8 +9,9 @@ export function registerScreenShareHandlers(deps: HandlerDeps) {
 				deps.authManager.ensureFullAccess(socket);
 				const { action, shareData } = data;
 				const roomId = socket.roomId;
+				const participantId = socket.participantId;
 
-				if (!roomId) return;
+				if (!roomId || !participantId) return;
 
 				if (action === 'start_share') {
 					loggers.socketHandler.info(
@@ -19,21 +20,35 @@ export function registerScreenShareHandlers(deps: HandlerDeps) {
 						shareData?.producerId || 'unspecified',
 					);
 					deps.registry.emitScreenShare(roomId, 'screen_share_started', {
-						participantId: socket.participantId,
-						shareData,
+						participantId,
+						shareData: {
+							...(typeof shareData?.producerId === 'string'
+								? { producerId: shareData.producerId }
+								: {}),
+							...(typeof shareData?.streamId === 'string'
+								? { streamId: shareData.streamId }
+								: {}),
+							...(shareData?.kind === 'video' ? { kind: shareData.kind } : {}),
+							...(typeof shareData?.isScreen === 'boolean'
+								? { isScreen: shareData.isScreen }
+								: {}),
+							...(typeof shareData?.startedAt === 'number' &&
+							Number.isFinite(shareData.startedAt)
+								? { startedAt: shareData.startedAt }
+								: {}),
+						},
 						timestamp: new Date().toISOString(),
 					});
 				} else if (action === 'stop_share') {
 					loggers.socketHandler.info(
-						'screen_share action=stop_share peer=%s producer=%s reason=%s source=%s details=%o',
+						'screen_share action=stop_share peer=%s producer=%s reason=%s source=%s',
 						socket.participantId || socket.userId,
 						shareData?.producerId || 'unspecified',
 						shareData?.reason || 'unspecified',
 						shareData?.source || 'unspecified',
-						shareData?.details || {},
 					);
 					deps.registry.emitScreenShare(roomId, 'screen_share_stopped', {
-						participantId: socket.participantId,
+						participantId,
 						reason: shareData?.reason,
 						timestamp: new Date().toISOString(),
 					});

--- a/suite/meet/sfu-server/src/types/index.ts
+++ b/suite/meet/sfu-server/src/types/index.ts
@@ -5,6 +5,7 @@ import type {
 	DtlsParameters,
 	IceCandidate,
 	IceParameters,
+	PlainTransport,
 	Producer,
 	Router,
 	RouterRtpCodecCapability,
@@ -38,7 +39,11 @@ import type {
 	ParticipantJoinedEvent,
 	ParticipantLeftEvent,
 	PreviewParticipantInfo,
+	ProducerCloseDetails,
 	ProducerClosedEvent,
+	ProducerCloseReason,
+	ProducerCloseSource,
+	ProducerCloseTrackSettings,
 	ProducerCreatedEvent,
 	RaiseHandRequest,
 	ReactionMessage,
@@ -82,9 +87,14 @@ export type {
 	ParticipantInfo,
 	ParticipantJoinedEvent,
 	ParticipantLeftEvent,
+	PlainTransport,
 	PreviewParticipantInfo,
 	Producer,
+	ProducerCloseDetails,
 	ProducerClosedEvent,
+	ProducerCloseReason,
+	ProducerCloseSource,
+	ProducerCloseTrackSettings,
 	ProducerCreatedEvent,
 	RaiseHandRequest,
 	ReactionMessage,
@@ -177,7 +187,7 @@ export interface ClientToServerEvents {
 			transportId: string;
 			rtpParameters: RtpParameters;
 			kind: 'audio' | 'video';
-			appData?: Record<string, unknown>;
+			appData?: AppData;
 		},
 		callback: (response: ProducerResponse) => void,
 	) => void;
@@ -192,9 +202,9 @@ export interface ClientToServerEvents {
 	close_producer: (
 		data: {
 			producerId: string;
-			reason?: string;
-			source?: string;
-			details?: Record<string, unknown>;
+			reason?: ProducerCloseReason;
+			source?: ProducerCloseSource;
+			details?: ProducerCloseDetails;
 		},
 		callback: (response: CloseProducerResponse) => void,
 	) => void;
@@ -351,8 +361,25 @@ export interface RoomParticipantsResponse extends SFUResponse {
 export interface ProducerInfo {
 	id: string;
 	kind: 'audio' | 'video';
-	appData: Record<string, unknown>;
+	appData: ProducerAppData;
 }
+
+export interface ProducerAppData extends AppData {
+	type?: 'screen';
+	e2eeStartPaused?: boolean;
+	senderId?: number;
+}
+
+export type JsonValue =
+	| string
+	| number
+	| boolean
+	| null
+	| JsonValue[]
+	| { [key: string]: JsonValue };
+
+export type JsonObject = { [key: string]: JsonValue };
+
 export interface ConsumerInfo {
 	id: string;
 	producerId: string;
@@ -403,12 +430,23 @@ export interface PeerInfo extends UserData {
 	isHost?: boolean;
 }
 
-export interface TransportData {
+export interface WebRtcTransportData {
 	roomId: string;
 	peerId: string;
 	transport: WebRtcTransport;
-	direction?: 'send' | 'recv';
+	direction: 'send' | 'recv';
+	type: 'webrtc';
 }
+
+export interface PlainTransportData {
+	roomId: string;
+	peerId: string;
+	transport: PlainTransport;
+	direction: 'send';
+	type: 'plain';
+}
+
+export type TransportData = WebRtcTransportData | PlainTransportData;
 
 export interface ProducerData {
 	roomId: string;

--- a/suite/meet/sfu-server/src/utils/logger.ts
+++ b/suite/meet/sfu-server/src/utils/logger.ts
@@ -1,4 +1,5 @@
 import { format } from 'node:util';
+import type { JsonValue } from '../types';
 
 enum LogLevel {
 	DEBUG = 0,
@@ -55,7 +56,7 @@ class Logger {
 		}
 	}
 
-	event(name: string, fields: Record<string, unknown> = {}): void {
+	event(name: string, fields: { [key: string]: JsonValue } = {}): void {
 		if (this.shouldLog(LogLevel.INFO)) {
 			console.log(
 				JSON.stringify({

--- a/suite/meet/types/index.ts
+++ b/suite/meet/types/index.ts
@@ -1,4 +1,4 @@
-export type SFUScope = "presence-preview" | "full" | "recording";
+export type SFUScope = 'presence-preview' | 'full' | 'recording';
 
 export interface RecordingJoinRequest {
 	roomId: string;
@@ -41,22 +41,60 @@ export interface PreviewParticipantInfo {
 	};
 }
 
-export type MediaControlAction = "mute" | "unmute" | "video_off" | "video_on";
+export type MediaControlAction = 'mute' | 'unmute' | 'video_off' | 'video_on';
 
 export type HostControlAction =
-	| "mute_participant"
-	| "kick_participant"
-	| "lower_hand";
+	| 'mute_participant'
+	| 'kick_participant'
+	| 'lower_hand';
+
+export type ProducerCloseReason =
+	| 'user-click'
+	| 'track-ended'
+	| 'publish-failed'
+	| 'cleanup';
+
+export type ProducerCloseSource = 'screen-share';
+
+export interface ProducerCloseTrackSettings {
+	aspectRatio?: number;
+	autoGainControl?: boolean;
+	channelCount?: number;
+	deviceId?: string;
+	displaySurface?: string;
+	echoCancellation?: boolean;
+	facingMode?: string;
+	frameRate?: number;
+	groupId?: string;
+	height?: number;
+	latency?: number;
+	logicalSurface?: boolean;
+	noiseSuppression?: boolean;
+	restrictOwnAudio?: boolean;
+	sampleRate?: number;
+	sampleSize?: number;
+	screenPixelRatio?: number;
+	suppressLocalAudioPlayback?: boolean;
+	width?: number;
+}
+
+export interface ProducerCloseDetails {
+	trackId?: string;
+	trackReadyState?: 'live' | 'ended';
+	trackSettings?: ProducerCloseTrackSettings;
+	message?: string;
+}
 
 export interface ScreenShareData {
 	streamId?: string;
-	kind?: "video";
+	kind?: 'video';
 	isScreen?: boolean;
-	reason?: string;
-	source?: string;
+	reason?: ProducerCloseReason;
+	source?: ProducerCloseSource;
 	producerId?: string;
-	details?: Record<string, unknown>;
-	[key: string]: unknown;
+	details?: ProducerCloseDetails;
+	startedAt?: number;
+	stoppedAt?: number;
 }
 
 export interface ChatMessage {
@@ -79,7 +117,7 @@ export interface ReactionMessage {
 export interface ParticipantJoinedEvent {
 	roomId: string;
 	participantId: string;
-	userData: UserData;
+	userData: UserData | Pick<UserData, 'name' | 'avatar'>;
 }
 
 export interface ParticipantLeftEvent {
@@ -87,7 +125,7 @@ export interface ParticipantLeftEvent {
 	participantId: string;
 }
 
-export type ProducerKind = "audio" | "video";
+export type ProducerKind = 'audio' | 'video';
 
 export interface ProducerCreatedEvent {
 	roomId: string;
@@ -103,9 +141,9 @@ export interface ProducerClosedEvent {
 	producerId: string;
 	participantId: string;
 	isScreen: boolean;
-	reason?: string;
-	source?: string;
-	details?: Record<string, unknown>;
+	reason?: ProducerCloseReason;
+	source?: ProducerCloseSource;
+	details?: ProducerCloseDetails;
 }
 
 export interface ConsumerClosedEvent {
@@ -154,7 +192,7 @@ export interface AuthExpiredEvent {
 
 export interface NetworkQualityUpdateEvent {
 	participantId: string;
-	quality: "good" | "poor" | "critical";
+	quality: 'good' | 'poor' | 'critical';
 }
 
 export interface HandRaisedEvent {
@@ -164,7 +202,7 @@ export interface HandRaisedEvent {
 }
 
 export interface ExistingRaisedHandsEvent {
-	hands: Record<string, boolean>;
+	hands: Record<string, string>;
 }
 
 export interface UpdateTokenRequest {
@@ -176,7 +214,7 @@ export interface MediaState {
 	video_enabled: boolean;
 }
 
-export type E2EEMode = "insertable-streams" | "none";
+export type E2EEMode = 'insertable-streams' | 'none';
 
 export interface E2EECapability {
 	supported: boolean;
@@ -197,7 +235,7 @@ export interface JoinRoomRequest {
 }
 
 export interface CreateWebRtcTransportRequest {
-	direction: "send" | "recv";
+	direction: 'send' | 'recv';
 	encryptionEnabled?: boolean;
 }
 
@@ -211,7 +249,7 @@ export interface HostControlRequest {
 }
 
 export interface ScreenShareRequest {
-	action: "start_share" | "stop_share";
+	action: 'start_share' | 'stop_share';
 	shareData?: ScreenShareData;
 }
 
@@ -249,7 +287,7 @@ export interface PresenceTokenResponse {
 
 export interface PresenceParticipant extends PreviewParticipantInfo {
 	user_id?: string;
-	info: PreviewParticipantInfo["info"] & {
+	info: PreviewParticipantInfo['info'] & {
 		userId?: string;
 		audio_enabled?: boolean;
 		video_enabled?: boolean;


### PR DESCRIPTION
- Define exact types for SFU requests and events shared by the client and server.
- Check auth tokens, participant data, producer details, screen-sharing data, and telemetry before using them.
- Use mediasoup types and JSON-safe metadata types instead of generic objects.