### PR TITLE
refactor(meet): validate frontend protocols

### DIFF
--- a/frontend/src/apps/meet/components/ChatPanel.vue
+++ b/frontend/src/apps/meet/components/ChatPanel.vue
@@ -205,6 +205,7 @@ import {
 	type EmojiSuggestion,
 } from "../utils/emojiSuggest";
 import { usePollStore } from "../composables/usePollStore";
+import { pollKey } from "../composables/usePoll";
 import type { PollPayloadFE } from "../types";
 import CreatePollModal from "./CreatePollModal.vue";
 import MeetAvatar from "./MeetAvatar.vue";
@@ -231,7 +232,7 @@ const props = defineProps<{
 }>();
 
 const pollStore = usePollStore();
-const pollService = inject("poll") as any;
+const pollService = inject(pollKey);
 const showPollModal = ref(false);
 
 const activePolls = computed(() => pollStore.activePolls);
@@ -284,7 +285,7 @@ const chatItems = computed(() =>
 	buildChatTimeline(props.messages || [], activePolls.value, props.userId),
 );
 
-function time(ts) {
+function time(ts: string) {
 	try {
 		return new Date(ts).toLocaleTimeString([], {
 			hour: "2-digit",

--- a/frontend/src/apps/meet/components/GroupTile.vue
+++ b/frontend/src/apps/meet/components/GroupTile.vue
@@ -31,7 +31,7 @@ const props = defineProps<{
 	participants?: Array<{
 		user_id: string;
 		user_name?: string;
-		avatar?: string;
+		avatar?: string | null;
 		initials?: string;
 	}>;
 	size?: "sm" | "md" | "lg" | "xl" | "2xl";
@@ -41,7 +41,7 @@ const avatarParticipants = computed(() =>
 	(props.participants || []).map((participant) => ({
 		user_id: participant.user_id,
 		full_name: participant.user_name || participant.initials || participant.user_id,
-		avatar_url: participant.avatar,
+		avatar_url: participant.avatar ?? undefined,
 	})),
 );
 </script>

--- a/frontend/src/apps/meet/components/MeetSidebar.vue
+++ b/frontend/src/apps/meet/components/MeetSidebar.vue
@@ -66,6 +66,24 @@ function selectTheme(theme: string) {
 
 const apps = { get data() { return getAppSwitcherItems("meet"); } };
 
+function renderAppLink(app: ReturnType<typeof getAppSwitcherItems>[number]) {
+	const className =
+		"flex items-center gap-2 p-1.5 rounded hover:bg-surface-gray-2";
+	const children = [
+		h("img", { src: app.logo, class: "size-6" }),
+		h(
+			"span",
+			{
+				class: "max-w-18 text-sm w-full truncate text-ink-gray-9",
+			},
+			app.title,
+		),
+	];
+	return app.spa
+		? h(RouterLink, { class: className, to: app.route }, () => children)
+		: h("a", { class: className, href: app.route }, children);
+}
+
 const userName = computed(
 	() => userResource.data?.full_name || userResource.data?.name || "User",
 );
@@ -79,34 +97,18 @@ const settingsItems = computed(() => [
 				icon: LucideLayoutGrid,
 				label: "Apps",
 				submenu:
-					apps.data?.map((app: any) => ({
+					apps.data?.map((app) => ({
 						label: app.title,
 						icon: app.logo,
-						component: h(
-							app.spa ? RouterLink : "a",
-							{
-								class:
-									"flex items-center gap-2 p-1.5 rounded hover:bg-surface-gray-2",
-								...(app.spa ? { to: app.route } : { href: app.route }),
-							},
-							[
-								h("img", { src: app.logo, class: "size-6" }),
-								h(
-									"span",
-									{
-										class:
-											"max-w-18 text-sm w-full truncate text-ink-gray-9",
-									},
-									app.title,
-								),
-							],
-						),
+						component: renderAppLink(app),
 					})) || [],
 			},
 			{
 				icon: LucideKeyboard,
 				label: "Shortcuts",
-				onClick: () => (showShortcutsDialog.value = true),
+				onClick: () => {
+					showShortcutsDialog.value = true;
+				},
 			},
 			{
 				icon: LucideSunMoon,
@@ -162,7 +164,10 @@ const sidebarSections = computed(() => [
 	},
 ]);
 
-const showShortcutsDialog = inject("showShortcutsDialog") as unknown as ReturnType<typeof ref<boolean>>;
+const showShortcutsDialog = inject(
+	"showShortcutsDialog",
+	ref(false),
+);
 </script>
 
 <template>

--- a/frontend/src/apps/meet/components/MeetingLayout.vue
+++ b/frontend/src/apps/meet/components/MeetingLayout.vue
@@ -94,7 +94,7 @@
 		<FloatingReactions
 			class="!z-[60]"
 			:reactions="floatingReactions"
-			:container-ref="container"
+			:container-ref="container || undefined"
 		/>
 	</div>
 </template>
@@ -105,7 +105,10 @@ import { useLayout } from "../composables/useLayout";
 import { useMeetingContext } from "../composables/useMeetingContext";
 import { usePinnedTileAnimation } from "../composables/usePinnedTileAnimation";
 import { useResponsiveGrid } from "../composables/useResponsiveGrid";
-import { useScreenShareTiles } from "../composables/useScreenShareTiles";
+import {
+	type ScreenShareTile,
+	useScreenShareTiles,
+} from "../composables/useScreenShareTiles";
 import { useTileAdaptiveStreaming } from "../composables/useTileAdaptiveStreaming";
 import type { Participant } from "../utils/media/ParticipantManager";
 import { getInitials } from "../utils/text";
@@ -127,12 +130,13 @@ const props = withDefaults(defineProps<{
 const showLocalTile = computed(() => props.showLocalTile);
 const interactive = computed(() => props.interactive);
 
-const meetingCtx = useMeetingContext();
-const setLocalVideoRef = inject<(el: unknown) => void>("setLocalVideoRef");
+const meetingCtx = useMeetingContext()!;
+const setLocalVideoRef =
+	inject<(el: unknown) => void>("setLocalVideoRef") || (() => {});
 const setRemoteVideoRef =
 	inject<(participantId: string, el: HTMLVideoElement | null) => void>(
 		"setRemoteVideoRef",
-	);
+	) || (() => {});
 const setScreenShareVideoRef = inject<
 	(consumerId: string, el: HTMLVideoElement | null) => void
 >("setScreenShareVideoRef");
@@ -147,8 +151,8 @@ const pinnedPanelsMap = ref<Record<string, HTMLElement>>({});
 
 const setPinnedPanelRef = (el: unknown, tile: { type: string; id: string }) => {
 	const key = `${tile.type}-${tile.id}`;
-	if (el) {
-		pinnedPanelsMap.value[key] = el as HTMLElement;
+	if (el instanceof HTMLElement) {
+		pinnedPanelsMap.value[key] = el;
 	} else {
 		delete pinnedPanelsMap.value[key];
 	}
@@ -159,18 +163,19 @@ const videoRefHandlers = new Map<string, (el: unknown) => void>();
 const getRemoteVideoRef = (participantId: string): ((el: unknown) => void) => {
 	if (!videoRefHandlers.has(participantId)) {
 		videoRefHandlers.set(participantId, (el: unknown) => {
-			setRemoteVideoRef(participantId, el as HTMLVideoElement | null);
-			registerTile(participantId, el as HTMLVideoElement | null);
+			const video = el instanceof HTMLVideoElement ? el : null;
+			setRemoteVideoRef(participantId, video);
+			registerTile(participantId, video);
 		});
 	}
-	return videoRefHandlers.get(participantId);
+	return videoRefHandlers.get(participantId)!;
 };
 
 // ── Reactive state from meeting context ───────────────────────────────────────
 
-const participants = computed(
+const participants: ComputedRef<Record<string, Participant>> = computed(
 	() => meetingCtx.participantStore.participants,
-) as ComputedRef<Record<string, Participant>>;
+);
 const currentUser = computed(() => meetingCtx.currentUser.currentUser.value);
 const isCameraOn = computed(() => meetingCtx.mediaState.isCameraOn);
 const isMicOn = computed(() => meetingCtx.mediaState.isMicOn);
@@ -197,10 +202,10 @@ watch(
 
 // ── Pin helpers ───────────────────────────────────────────────────────────────
 
-const isPinnedParticipant = (userId) =>
+const isPinnedParticipant = (userId: string) =>
 	pinnedTiles.value.some((t) => t.type === "participant" && t.id === userId);
 
-const isPinnedScreenShare = (pinId) =>
+const isPinnedScreenShare = (pinId: string) =>
 	pinnedTiles.value.some((t) => t.type === "screenshare" && t.id === pinId);
 
 const { screenShareTiles: allScreenShareTiles } = useScreenShareTiles({
@@ -211,24 +216,17 @@ const { screenShareTiles: allScreenShareTiles } = useScreenShareTiles({
 	getParticipantName,
 });
 
-const getScreenShareTileBindings = (shareTile: {
-	pinId: string;
-	consumerId: string;
-	participant:
-		| Record<string, unknown>
-		| { user_id: string; user_name: string; avatar: string };
-}) => {
+const getScreenShareTileBindings = (shareTile: ScreenShareTile) => {
 	const isPinned = isPinnedScreenShare(shareTile.pinId);
-	const wrappedVideoRef = setScreenShareVideoRef
-		? (el: unknown) =>
-			setScreenShareVideoRef(
-				shareTile.consumerId,
-				el as HTMLVideoElement | null,
-			)
-		: undefined;
+	const wrappedVideoRef = (el: unknown) => {
+		if (setScreenShareVideoRef) {
+				const video = el instanceof HTMLVideoElement ? el : null;
+				setScreenShareVideoRef(shareTile.consumerId, video);
+			}
+	};
 
 	return {
-		participant: shareTile.participant as unknown as Participant,
+		participant: shareTile.participant,
 		isLocal: false,
 		isVideoEnabled: true,
 		isAudioEnabled: false,
@@ -381,8 +379,7 @@ const { pinnedTileStyles } = usePinnedTileAnimation({
 
 const floatingReactions = computed(() => {
 	const reactions = meetingCtx.reactionStore.reactions;
-	const currentUserId = (currentUser.value as Record<string, unknown> | null)
-		?.user_id as string | undefined;
+	const currentUserId = currentUser.value?.user_id;
 
 	let sourceIds: Set<string>;
 	if (mode.value === "grid") {
@@ -406,12 +403,15 @@ const floatingReactions = computed(() => {
 		if (!sourceIds.has(userId) || !reaction) continue;
 		const participant =
 			userId === currentUserId ? currentUser.value : participants.value[userId];
-		const p = participant as Record<string, unknown> | null;
 		const userName =
-			(p?.user_name as string) ||
-			(p?.full_name as string) ||
-			(p?.name as string) ||
-			(p?.user_id as string) ||
+			(participant && "user_name" in participant
+				? participant.user_name
+				: undefined) ||
+			(participant && "full_name" in participant
+				? participant.full_name
+				: undefined) ||
+			(participant && "name" in participant ? participant.name : undefined) ||
+			participant?.user_id ||
 			"Unknown";
 		result.push({
 			userId,

--- a/frontend/src/apps/meet/components/PeoplePanel.vue
+++ b/frontend/src/apps/meet/components/PeoplePanel.vue
@@ -102,7 +102,7 @@ interface CurrentUser {
 	user_id?: string;
 	full_name?: string;
 	name?: string;
-	avatar?: string;
+	avatar?: string | null;
 	initials?: string;
 	is_guest?: boolean;
 }

--- a/frontend/src/apps/meet/components/PollMessageCard.vue
+++ b/frontend/src/apps/meet/components/PollMessageCard.vue
@@ -54,13 +54,14 @@
 import { computed, inject, ref } from "vue";
 import { PollPayloadFE } from "../types";
 import { usePollStore } from "../composables/usePollStore";
+import { pollKey } from "../composables/usePoll";
 
 const props = defineProps<{
 	poll: PollPayloadFE;
 	isGuest?: boolean;
 }>();
 
-const pollService = inject("poll") as any;
+const pollService = inject(pollKey);
 const pollStore = usePollStore()
 
 const localVotedOption = ref<string | null>(null);

--- a/frontend/src/apps/meet/components/UpcomingMeetings.vue
+++ b/frontend/src/apps/meet/components/UpcomingMeetings.vue
@@ -8,6 +8,65 @@ import { userStore as useCalendarUserStore } from '@/apps/calendar/stores/user'
 import dayjs from '@/apps/calendar/utils/dayjs'
 import AvatarGroup from '@/apps/meet/components/AvatarGroup.vue'
 
+interface CalendarEventParticipant {
+	email: string
+	_name?: string | null
+	user_image?: string | null
+}
+
+interface CalendarEventLink {
+	href?: string | null
+}
+
+interface CalendarEvent {
+	id: string
+	title?: string
+	start: string
+	duration?: string
+	show_without_time?: boolean | 0 | 1
+	participants?: CalendarEventParticipant[]
+	links?: CalendarEventLink[]
+	description?: string | null
+}
+
+const isOptionalString = (value: unknown) =>
+	value === undefined || value === null || typeof value === 'string'
+
+const isCalendarEventParticipant = (value: unknown): value is CalendarEventParticipant =>
+	typeof value === 'object' &&
+	value !== null &&
+	'email' in value &&
+	typeof value.email === 'string' &&
+	(!('_name' in value) || isOptionalString(value._name)) &&
+	(!('user_image' in value) || isOptionalString(value.user_image))
+
+const isCalendarEventLink = (value: unknown): value is CalendarEventLink =>
+	typeof value === 'object' &&
+	value !== null &&
+	(!('href' in value) || isOptionalString(value.href))
+
+const isCalendarEvent = (value: unknown): value is CalendarEvent =>
+	typeof value === 'object' &&
+	value !== null &&
+	'id' in value &&
+	typeof value.id === 'string' &&
+	'start' in value &&
+	typeof value.start === 'string' &&
+	(!('title' in value) || isOptionalString(value.title)) &&
+	(!('duration' in value) || isOptionalString(value.duration)) &&
+	(!('show_without_time' in value) ||
+		value.show_without_time === undefined ||
+		typeof value.show_without_time === 'boolean' ||
+		value.show_without_time === 0 ||
+		value.show_without_time === 1) &&
+	(!('description' in value) || isOptionalString(value.description)) &&
+	(!('participants' in value) ||
+		value.participants === undefined ||
+		(Array.isArray(value.participants) && value.participants.every(isCalendarEventParticipant))) &&
+	(!('links' in value) ||
+		value.links === undefined ||
+		(Array.isArray(value.links) && value.links.every(isCalendarEventLink)))
+
 const router = useRouter()
 const calendarStore = useCalendarUserStore()
 const now = useNow({ interval: 30_000 })
@@ -27,20 +86,22 @@ const upcomingEvents = createResource({
 
 const meetings = computed(() => {
 	const currentTime = dayjs(now.value)
-	return [...(upcomingEvents.data || [])]
-		.filter((event: any) => {
+	const data: unknown = upcomingEvents.data
+	const events = Array.isArray(data) ? data.filter(isCalendarEvent) : []
+	return events
+		.filter((event) => {
 			const start = dayjs(event.start)
 			const end = start.add(dayjs.duration(event.duration || 'PT0S'))
 			return getMeetingUrl(event) && start.isSame(currentTime, 'day') && end.isAfter(currentTime)
 		})
-		.sort((left: any, right: any) => dayjs(left.start).valueOf() - dayjs(right.start).valueOf())
+		.sort((left, right) => dayjs(left.start).valueOf() - dayjs(right.start).valueOf())
 		.slice(0, 4)
 })
 
-const formatMeetingMonth = (event: any) => dayjs(event.start).format('MMM')
-const formatMeetingDay = (event: any) => dayjs(event.start).format('D')
+const formatMeetingMonth = (event: CalendarEvent) => dayjs(event.start).format('MMM')
+const formatMeetingDay = (event: CalendarEvent) => dayjs(event.start).format('D')
 
-const isAllDayEvent = (event: any) => {
+const isAllDayEvent = (event: CalendarEvent) => {
 	const start = dayjs(event.start)
 	const duration = dayjs.duration(event.duration || 'PT0S')
 	return (
@@ -53,7 +114,7 @@ const isAllDayEvent = (event: any) => {
 	)
 }
 
-const formatMeetingTime = (event: any) => {
+const formatMeetingTime = (event: CalendarEvent) => {
 	if (isAllDayEvent(event)) return 'All day'
 
 	const start = dayjs(event.start)
@@ -61,7 +122,7 @@ const formatMeetingTime = (event: any) => {
 	return `${start.format('h:mma')} - ${end.format('h:mma')}`
 }
 
-const eventParticipants = (event: any) => {
+const eventParticipants = (event: CalendarEvent) => {
 	const participantsByEmail = new Map<string, { user_id: string; full_name: string; avatar_url?: string }>()
 	for (const participant of event.participants || []) {
 		if (!participant.email || participantsByEmail.has(participant.email)) continue
@@ -74,14 +135,14 @@ const eventParticipants = (event: any) => {
 	return [...participantsByEmail.values()]
 }
 
-const getMeetingUrl = (event: any) => {
-	const link = event.links?.find((item: any) => getTrustedMeetUrl(item?.href))
+const getMeetingUrl = (event: CalendarEvent) => {
+	const link = event.links?.find((item) => getTrustedMeetUrl(item.href))
 	if (link?.href) return getTrustedMeetUrl(link.href)
 	const match = event.description?.match(/https?:\/\/\S+\/meet\/[a-zA-Z0-9-]+|\/meet\/[a-zA-Z0-9-]+/)
 	return getTrustedMeetUrl(match?.[0])
 }
 
-const getTrustedMeetUrl = (url?: string) => {
+const getTrustedMeetUrl = (url?: string | null) => {
 	if (!url) return ''
 	const value = url.replace(/\W+$/, '')
 
@@ -96,10 +157,10 @@ const getTrustedMeetUrl = (url?: string) => {
 	return ''
 }
 
-const getMeetingId = (event: any) =>
+const getMeetingId = (event: CalendarEvent) =>
 	getMeetingUrl(event).split('/meet/').pop()?.replace(/\W+$/, '') || ''
 
-const joinMeeting = (event: any) => {
+const joinMeeting = (event: CalendarEvent) => {
 	const meetingId = getMeetingId(event)
 	if (!meetingId) return
 	router.push({ name: 'meet-meeting', params: { meetingId } })
@@ -110,9 +171,14 @@ const reload = () => {
 }
 
 onMounted(() => {
-	calendarStore.userResource.promise
+	const userPromise = calendarStore.userResource.promise
+	if (!userPromise) {
+		reload()
+		return
+	}
+	userPromise
 		.then(reload)
-		.catch((error: any) => console.warn('Could not load upcoming calendar meetings:', error))
+		.catch((error: unknown) => console.warn('Could not load upcoming calendar meetings:', error))
 })
 
 defineExpose({ reload })

--- a/frontend/src/apps/meet/components/settings/BackgroundSettingsTab.vue
+++ b/frontend/src/apps/meet/components/settings/BackgroundSettingsTab.vue
@@ -108,7 +108,10 @@ import AppSettingsHeader from '@/components/settings/AppSettingsHeader.vue'
 import AppSettingsBody from '@/components/settings/AppSettingsBody.vue'
 import { toast } from 'frappe-ui';
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
-import { useBackgroundEffects } from "../../composables/useBackgroundEffects";
+import {
+	type BackgroundEffectOptions,
+	useBackgroundEffects,
+} from "../../composables/useBackgroundEffects";
 import { useMeetingContext } from "../../composables/useMeetingContext";
 import {
 	addCustomBackgroundImage,
@@ -163,8 +166,8 @@ const pendingPreviewRefresh = ref(false);
 const fileInputRef = ref<HTMLInputElement | null>(null);
 let previewSession: {
 	cleanup: () => void;
-	updateOptions?: (opts: unknown) => Promise<void>;
-	stream?: MediaStream;
+	updateOptions: (opts: BackgroundEffectOptions) => Promise<void>;
+	stream: MediaStream;
 } | null = null;
 let previewInputStream: MediaStream | null = null; // Raw stream feeding the preview pipeline
 let isPreviewStreamDedicated = false; // Track if preview stream is dedicated (not meeting's processed stream; needed when cam is off in meeting)
@@ -177,8 +180,15 @@ const selectedBackgroundImageLocal = ref<BackgroundImageOption | string | null>(
 );
 const blurIntensityLocal = ref(blurIntensity.value);
 
-const allBackgroundOptionsTyped = computed(
-	() => allBackgroundOptions.value as unknown as BackgroundOption[],
+const allBackgroundOptionsTyped = computed<BackgroundOption[]>(() =>
+	allBackgroundOptions.value.map((option) => ({
+		name: option.name,
+		label: option.label,
+		type: "type" in option ? option.type : undefined,
+		url: option.url,
+		isAddButton: "isAddButton" in option ? option.isAddButton : undefined,
+		isCustom: "isCustom" in option ? option.isCustom : undefined,
+	})),
 );
 
 // Background effects composable
@@ -272,7 +282,11 @@ async function handleFileSelect(event: Event) {
 		toast.success(`Added custom background: ${file.name}`);
 	} catch (error) {
 		console.error("Failed to add custom image:", error);
-		toast.error(error.message || "Failed to add custom background image");
+		toast.error(
+			error instanceof Error
+				? error.message
+				: "Failed to add custom background image",
+		);
 	}
 
 	target.value = "";

--- a/frontend/src/apps/meet/composables/__tests__/useChat.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useChat.test.ts
@@ -25,16 +25,24 @@ function makeChatStore(): ChatStore {
 	};
 }
 
-function makeSFUClient(overrides: Record<string, unknown> = {}) {
-	const handlers = new Map<string, (data: Record<string, unknown>) => void>();
+function makeSFUClient(
+	overrides: Partial<{
+		isE2EERequired: () => boolean;
+		sendChatMessage: (message: string) => Promise<{
+			success: boolean;
+			timestamp: string;
+		}>;
+	}> = {},
+) {
+	const handlers = new Map<string, (data: unknown) => void>();
 	return {
-		on: vi.fn((event: string, handler: (data: Record<string, unknown>) => void) => {
+		on: vi.fn((event: string, handler: (data: unknown) => void) => {
 			handlers.set(event, handler);
 		}),
 		isConnected: vi.fn(() => true),
 		isE2EERequired: vi.fn(() => true),
 		sendChatMessage: vi.fn(),
-		emitChatMessage: (data: Record<string, unknown>) =>
+		emitChatMessage: (data: unknown) =>
 			handlers.get("chat:message")?.(data),
 		...overrides,
 	};

--- a/frontend/src/apps/meet/composables/__tests__/useRecording.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useRecording.test.ts
@@ -1,21 +1,22 @@
 import { toast } from "frappe-ui";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createApp } from "vue";
+import type { RecordingState } from "../useRecording";
 
 const mocks = vi.hoisted(() => ({
 	startParams: [] as Array<{ meeting_id: string; request_id: string }>,
 	startCount: 0,
-	startResults: [] as Array<Record<string, unknown>>,
+	startResults: [] as Array<RecordingState | { status: "Rejected" }>,
 	getStateCount: 0,
 	getStateCompleted: 0,
 	getStateResults: [] as Array<
-		| Record<string, unknown>
+		| RecordingState
 		| null
-		| Promise<Record<string, unknown> | null>
+		| Promise<RecordingState | null>
 	>,
 	socketHandler: null as ((event: {
 		meeting_id: string;
-		recording: Record<string, unknown> | null;
+		recording: RecordingState | null;
 	}) => void) | null,
 	stopped: false,
 }));
@@ -110,8 +111,8 @@ describe("useRecording", () => {
 	});
 
 	it("does not let a stale state load overwrite a newer command revision", async () => {
-		let resolveStale!: (value: Record<string, unknown>) => void;
-		const stale = new Promise<Record<string, unknown>>((resolve) => {
+		let resolveStale!: (value: RecordingState) => void;
+		const stale = new Promise<RecordingState>((resolve) => {
 			resolveStale = resolve;
 		});
 		mocks.getStateResults.push(stale, {
@@ -137,8 +138,8 @@ describe("useRecording", () => {
 	});
 
 	it("does not resurrect state after a realtime null transition", async () => {
-		let resolveStale!: (value: Record<string, unknown>) => void;
-		mocks.getStateResults.push(new Promise<Record<string, unknown>>((resolve) => {
+		let resolveStale!: (value: RecordingState) => void;
+		mocks.getStateResults.push(new Promise<RecordingState>((resolve) => {
 			resolveStale = resolve;
 		}));
 		let recording!: ReturnType<typeof useRecording>;

--- a/frontend/src/apps/meet/composables/useBackgroundEffects.ts
+++ b/frontend/src/apps/meet/composables/useBackgroundEffects.ts
@@ -11,7 +11,7 @@ import {
 import { WebGLManager } from "../utils/webglShaders";
 
 // Types and interfaces
-interface BackgroundEffectOptions {
+export interface BackgroundEffectOptions {
 	backgroundBlurEnabled?: boolean;
 	backgroundImageEnabled?: boolean;
 	selectedBackgroundImage?: string | null;
@@ -280,7 +280,7 @@ export function useBackgroundEffects(): UseBackgroundEffectsReturn {
 
 			if ("MediaStreamTrackProcessor" in window) {
 				const MediaStreamTrackProcessor = (
-					window as unknown as {
+					window as typeof window & {
 						MediaStreamTrackProcessor: new (init: {
 							track: MediaStreamTrack;
 						}) => {
@@ -664,12 +664,14 @@ export function useBackgroundEffects(): UseBackgroundEffectsReturn {
 			processFrame();
 
 			let outputStream: MediaStream;
-			let trackGenerator: MediaStreamTrack | null = null;
+			let trackGenerator:
+				| (MediaStreamTrack & { writable: WritableStream })
+				| null = null;
 			let trackWriter: WritableStreamDefaultWriter | null = null;
 
 			if (useOffscreenCanvas) {
 				const MediaStreamTrackGenerator = (
-					window as unknown as {
+					window as typeof window & {
 						MediaStreamTrackGenerator: new (init: {
 							kind: string;
 						}) => MediaStreamTrack & {
@@ -678,9 +680,7 @@ export function useBackgroundEffects(): UseBackgroundEffectsReturn {
 					}
 				).MediaStreamTrackGenerator;
 				trackGenerator = new MediaStreamTrackGenerator({ kind: "video" });
-				trackWriter = (
-					trackGenerator as unknown as { writable: WritableStream }
-				).writable.getWriter();
+				trackWriter = trackGenerator.writable.getWriter();
 				outputStream = new MediaStream([trackGenerator]);
 			} else {
 				outputStream = (outputCanvas as HTMLCanvasElement).captureStream(30); // 30 FPS
@@ -821,11 +821,9 @@ export function useBackgroundEffects(): UseBackgroundEffectsReturn {
 		}
 
 		latestResults = null;
-		const resetFn = (
-			selfieSegmentation as unknown as {
-				reset?: () => void;
-			}
-		).reset;
+		const resetFn = Reflect.get(selfieSegmentation, "reset") as
+			| (() => void)
+			| undefined;
 		if (typeof resetFn === "function") {
 			try {
 				resetFn.call(selfieSegmentation);

--- a/frontend/src/apps/meet/composables/useChat.ts
+++ b/frontend/src/apps/meet/composables/useChat.ts
@@ -4,6 +4,7 @@ import { E2EEMeeting } from "../utils/media/E2EEMeeting";
 import type { SFUClient } from "../utils/SFUClient";
 import type { ChatMessage, ChatStore } from "./useChatStore";
 import type { CurrentUser } from "./useCurrentUser";
+import { isUnknownRecord } from "../types";
 
 interface ChatAPI {
 	setupChatEvents: (notify: (notification: ChatNotification) => void) => void;
@@ -16,6 +17,31 @@ interface ChatNotification {
 	fromUser: string;
 	fromName: string;
 	type: "chat";
+}
+
+interface IncomingChatMessage {
+	fromUser: string;
+	fromName: string;
+	message: string;
+	timestamp: string;
+}
+
+function normalizeChatMessage(value: unknown): IncomingChatMessage | null {
+	if (
+		!isUnknownRecord(value) ||
+		typeof value.fromUser !== "string" ||
+		typeof value.message !== "string"
+	) return null;
+	return {
+		fromUser: value.fromUser,
+		fromName:
+			typeof value.fromName === "string" ? value.fromName : value.fromUser,
+		message: value.message,
+		timestamp:
+			typeof value.timestamp === "string"
+				? value.timestamp
+				: new Date().toISOString(),
+	};
 }
 
 const E2EE_CHAT_PREFIX = "e2ee:";
@@ -88,12 +114,14 @@ export function useChat(deps: {
 	}
 
 	const setupChatEvents = (notify: (notification: ChatNotification) => void) => {
-		sfuClient.on("chat:message", async (data: Record<string, unknown>) => {
+		sfuClient.on("chat:message", async (value: unknown) => {
+			const data = normalizeChatMessage(value);
+			if (!data) return;
 			if (data.fromUser === currentUser.currentUser.value?.user_id) {
 				return;
 			}
 
-			let plaintext = data.message as string;
+			let plaintext = data.message;
 
 			if (isEncryptedChatMessage(plaintext)) {
 				const key = await getChatKey();
@@ -117,12 +145,10 @@ export function useChat(deps: {
 
 			const message: ChatMessage = {
 				id: Date.now() + Math.random(),
-				user_id: data.fromUser as string,
-				user_name: (data.fromName || data.fromUser) as string,
+				user_id: data.fromUser,
+				user_name: data.fromName,
 				message: plaintext,
-				timestamp:
-					(typeof data.timestamp === "string" && data.timestamp) ||
-					new Date().toISOString(),
+				timestamp: data.timestamp,
 			};
 
 			chatStore.addMessage(message);
@@ -135,19 +161,21 @@ export function useChat(deps: {
 
 				notify({
 					message: plaintext,
-					fromUser: data.fromUser as string,
-					fromName: (data.fromName || data.fromUser) as string,
+					fromUser: data.fromUser,
+					fromName: data.fromName,
 					type: "chat",
 				});
 				audioNotificationManager.playChatNotification();
 			}
 		});
-		sfuClient.on("chat:restriction_updated", (data: any) => {
-			chatStore.hostOnlyChat = data.enabled;
+		sfuClient.on("chat:restriction_updated", (value: unknown) => {
+			if (isUnknownRecord(value) && typeof value.enabled === "boolean") {
+				chatStore.hostOnlyChat = value.enabled;
+			}
 		});
 
-		sfuClient.on("sfu_error", (data: any) => {
-			if (data?.code === "HOST_ONLY_CHAT") {
+		sfuClient.on("sfu_error", (value: unknown) => {
+			if (isUnknownRecord(value) && value.code === "HOST_ONLY_CHAT") {
 				toast.error("The host has restricted chat to hosts and co-hosts only.");
 				chatStore.hostOnlyChat = true;
 			}

--- a/frontend/src/apps/meet/composables/useMediaControls.test.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.test.ts
@@ -57,13 +57,13 @@ class FakeMediaStream {
 }
 
 const audioTrack = (id: string) =>
-	({
+	Object.assign(Object.create(null), {
 		id,
 		kind: "audio",
 		enabled: true,
 		readyState: "live",
 		stop: vi.fn(),
-	} as unknown as MediaStreamTrack);
+	}) as MediaStreamTrack;
 
 describe("useMediaControls", () => {
 	beforeEach(() => {

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -21,6 +21,7 @@ import type { ConnectionState } from "./useConnectionState";
 import type { CurrentUser } from "./useCurrentUser";
 import type { MediaState } from "./useMediaState";
 import type { RaiseHandStore } from "./useRaiseHandStore";
+import type { BackgroundEffectOptions } from "./useBackgroundEffects";
 
 const BLUETOOTH_DEVICE_LABEL_REGEX =
 	/airpods|bluetooth|\bbt\b|wireless|jbl|bose|sony|beats|sennheiser|akg|jabra|anker|skullcandy|shure|bang\s*&\s*olufsen|b\s*&\s*o|marley|skullcandy|logitech\s*bt|plantronics|poly|razer\s*(?:bt|opus)|corsair|steelseries|hyperx|audeze|sennheiser|soundcore|tozo|earfun|earbuds|earbud/i;
@@ -53,11 +54,11 @@ function getBackgroundEffectsFromStorage() {
 interface BackgroundEffectsAPI {
 	applyBackgroundEffects: (
 		stream: MediaStream,
-		options: Record<string, unknown>,
+		options: BackgroundEffectOptions,
 	) => Promise<{
 		stream: MediaStream;
 		cleanup: () => void;
-		updateOptions: (opts: Record<string, unknown>) => Promise<void>;
+		updateOptions: (opts: BackgroundEffectOptions) => Promise<void>;
 	}>;
 	stopProcessing: () => void;
 	processedStream: Ref<MediaStream | null>;
@@ -107,17 +108,17 @@ interface MediaControlsAPI {
 	acquireUserMedia: (
 		videoEnabled: boolean,
 		audioEnabled: boolean,
-		deviceOverrides?: Record<string, string>,
-	) => Promise<{ stream: MediaStream; constraints: Record<string, unknown> }>;
+		deviceOverrides?: MediaDeviceOverrides,
+	) => Promise<{ stream: MediaStream; constraints: MediaStreamConstraints }>;
 	toggleMicrophone: () => Promise<void>;
 	toggleCamera: () => Promise<void>;
 	toggleScreenShare: () => Promise<void>;
 	switchInputDevice: (type: DeviceType, deviceId: string) => Promise<void>;
 	applySpeakerDevice: () => Promise<void>;
 	applyBackgroundEffectsToLocalStream: () => Promise<void>;
-	setLocalVideoRef: (el: HTMLElement | null) => void;
-	setRemoteVideoRef: (participantId: string, el: HTMLElement) => void;
-	setScreenShareVideoRef: (el: HTMLElement) => void;
+	setLocalVideoRef: (el: HTMLVideoElement | null) => void;
+	setRemoteVideoRef: (participantId: string, el: HTMLVideoElement) => void;
+	setScreenShareVideoRef: (el: HTMLVideoElement) => void;
 	processedStream: MediaStream | null;
 }
 
@@ -151,6 +152,15 @@ type ScreenShareStopReason =
 	| "publish-failed"
 	| "cleanup";
 
+interface MediaDeviceOverrides {
+	cameraDeviceId?: string;
+	micDeviceId?: string;
+}
+
+interface ScreenShareStopExtra {
+	message?: string;
+}
+
 function getMediaHandler(
 	manager: SFUMeetingManager | null,
 ): MediaHandlerLike | null {
@@ -170,14 +180,14 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		noiseCancellation,
 	} = deps;
 
-	const localVideo = ref<HTMLElement | null>(null);
-	const screenShareVideoElements = new Map<string, HTMLElement>();
+	const localVideo = ref<HTMLVideoElement | null>(null);
+	const screenShareVideoElements = new Map<string, HTMLVideoElement>();
 	const _unmutedByPushToTalk = ref(false);
 
 	let backgroundSession: {
 		stream: MediaStream;
 		cleanup: () => void;
-		updateOptions: (opts: Record<string, unknown>) => Promise<void>;
+		updateOptions: (opts: BackgroundEffectOptions) => Promise<void>;
 	} | null = null;
 	let noiseCancellationSession: {
 		stream: MediaStream;
@@ -190,22 +200,19 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				title: "Start Screen Share Anyway?",
 				message:
 					"Someone is already sharing their screen. Starting yours may result in multiple active screen shares.",
-				onConfirm: ({ hideDialog }: { hideDialog: () => void }) => {
-					hideDialog();
-					resolve(true);
-				},
+				onConfirm: () => resolve(true),
 				onCancel: () => resolve(false),
 			});
 		});
 
 	const getScreenShareStopMetadata = (
 		reason: ScreenShareStopReason,
-		extra: Record<string, unknown> = {},
+		extra: ScreenShareStopExtra = {},
 	) => {
 		const screenTrack = mediaState.screenShareStream?.getVideoTracks?.()[0];
 		return {
 			reason,
-			source: "screen-share",
+			source: "screen-share" as const,
 			details: {
 				trackId: screenTrack?.id,
 				trackReadyState: screenTrack?.readyState,
@@ -568,7 +575,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		videoEnabled: boolean,
 		audioEnabled: boolean,
 	) => {
-		const constraints: Record<string, unknown> = {};
+		const constraints: MediaStreamConstraints = {};
 
 		const audioConstraints = {
 			channelCount: { ideal: 2 },
@@ -578,7 +585,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		};
 
 		if (videoEnabled) {
-			constraints.video = {
+			const videoConstraints: MediaTrackConstraints = {
 				width: { ideal: 1280, min: 960 },
 				height: { ideal: 720, min: 540 },
 				frameRate: { ideal: 30, max: 30 },
@@ -589,10 +596,11 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				"camera",
 			);
 			if (validCameraId) {
-				(constraints.video as Record<string, unknown>).deviceId = {
+				videoConstraints.deviceId = {
 					exact: validCameraId,
 				};
 			}
+			constraints.video = videoConstraints;
 		}
 
 		if (audioEnabled) {
@@ -606,13 +614,16 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			if (isBluetoothMicLabel(selectedMic?.label)) {
 				audioConstraints.autoGainControl = false;
 			}
-			constraints.audio = { ...audioConstraints };
+			const mediaAudioConstraints: MediaTrackConstraints = {
+				...audioConstraints,
+			};
 
 			if (validMicId) {
-				(constraints.audio as Record<string, unknown>).deviceId = {
+				mediaAudioConstraints.deviceId = {
 					exact: validMicId,
 				};
 			}
+			constraints.audio = mediaAudioConstraints;
 		}
 
 		return constraints;
@@ -621,35 +632,35 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 	const acquireUserMedia = async (
 		videoEnabled: boolean,
 		audioEnabled: boolean,
-		deviceOverrides: Record<string, string> = {},
+		deviceOverrides: MediaDeviceOverrides = {},
 	) => {
 		const constraints = await buildMediaConstraints(videoEnabled, audioEnabled);
 
 		if (videoEnabled && Object.hasOwn(deviceOverrides, "cameraDeviceId")) {
 			const validCameraId = await getValidDeviceId(
-				deviceOverrides.cameraDeviceId,
+				deviceOverrides.cameraDeviceId ?? null,
 				"camera",
 			);
-			if (validCameraId && constraints.video) {
-				(constraints.video as Record<string, unknown>).deviceId = {
+			if (validCameraId && typeof constraints.video === "object") {
+				constraints.video.deviceId = {
 					exact: validCameraId,
 				};
-			} else if ((constraints.video as Record<string, unknown>)?.deviceId) {
-				delete (constraints.video as Record<string, unknown>).deviceId;
+			} else if (typeof constraints.video === "object") {
+				delete constraints.video.deviceId;
 			}
 		}
 
 		if (audioEnabled && Object.hasOwn(deviceOverrides, "micDeviceId")) {
 			const validMicId = await getValidDeviceId(
-				deviceOverrides.micDeviceId,
+				deviceOverrides.micDeviceId ?? null,
 				"microphone",
 			);
-			if (validMicId && constraints.audio) {
-				(constraints.audio as Record<string, unknown>).deviceId = {
+			if (validMicId && typeof constraints.audio === "object") {
+				constraints.audio.deviceId = {
 					exact: validMicId,
 				};
-			} else if ((constraints.audio as Record<string, unknown>)?.deviceId) {
-				delete (constraints.audio as Record<string, unknown>).deviceId;
+			} else if (typeof constraints.audio === "object") {
+				delete constraints.audio.deviceId;
 			}
 		}
 
@@ -1084,7 +1095,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 
 	const stopScreenShare = async (
 		reason: ScreenShareStopReason,
-		extra: Record<string, unknown> = {},
+		extra: ScreenShareStopExtra = {},
 	) => {
 		const metadata = getScreenShareStopMetadata(reason, extra);
 		const mediaHandler = getMediaHandler(sfuManager.value);
@@ -1241,10 +1252,10 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		}
 	};
 
-	function setLocalVideoRef(el: HTMLElement | null) {
+	function setLocalVideoRef(el: HTMLVideoElement | null) {
 		localVideo.value = el;
 		if (el && mediaState.localStream) {
-			const videoEl = el as HTMLVideoElement;
+			const videoEl = el;
 			const streamToUse = mediaState.processedStream || mediaState.localStream;
 
 			const currentStreamId = streamToUse.id;
@@ -1265,18 +1276,16 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		mediaState.localVideo = el;
 	}
 
-	const setRemoteVideoRef = (participantId: string, el: HTMLElement) => {
+	const setRemoteVideoRef = (participantId: string, el: HTMLVideoElement) => {
 		if (sfuManager.value?.videoManager) {
 			sfuManager.value.videoManager.registerVideoElement(participantId, el);
 		}
 	};
 
-	const setScreenShareVideoRef = (el: HTMLElement) => {
+	const setScreenShareVideoRef = (el: HTMLVideoElement) => {
 		if (!el) return;
 
-		const participantId = (
-			el as HTMLElement & { dataset: Record<string, string> }
-		).dataset?.participantId;
+		const participantId = el.dataset.participantId;
 		if (participantId) {
 			screenShareVideoElements.set(participantId, el);
 
@@ -1288,16 +1297,16 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 
 			if (stream instanceof MediaStream) {
 				const currentStreamId = stream.id;
-				const srcObject = (el as HTMLVideoElement).srcObject;
+				const srcObject = el.srcObject;
 				const existingStreamId =
 					srcObject instanceof MediaStream ? srcObject.id : undefined;
 
 				if (
-					!(el as HTMLVideoElement).srcObject ||
+					!el.srcObject ||
 					existingStreamId !== currentStreamId
 				) {
-					(el as HTMLVideoElement).srcObject = stream;
-					(el as HTMLVideoElement).play?.().catch(() => {});
+					el.srcObject = stream;
+					el.play?.().catch(() => {});
 				}
 			}
 		}

--- a/frontend/src/apps/meet/composables/useMeetingDoc.ts
+++ b/frontend/src/apps/meet/composables/useMeetingDoc.ts
@@ -14,18 +14,22 @@ interface MeetingDocument {
 	banned_users?: { user: string }[];
 }
 
-interface DocumentResource {
+export interface DocumentResource {
 	doc?: MeetingDocument;
 	setValue: {
-		submit(params: Record<string, unknown>): Promise<unknown>;
+		submit(params: { banned_users: { user: string }[] }): Promise<unknown>;
 	};
 	reload(): Promise<void>;
 	updateSettings: {
-		submit(params: Record<string, unknown>): Promise<unknown>;
+		submit(params: {
+			allow_guest: boolean;
+			meeting_type: string;
+			host_only_chat: boolean;
+		}): Promise<unknown>;
 		loading: boolean;
 	};
 	enableE2ee: {
-		submit(params?: Record<string, unknown>): Promise<unknown>;
+		submit(): Promise<unknown>;
 		loading: boolean;
 	};
 	get: {
@@ -62,7 +66,7 @@ export function useMeetingDoc(): UseMeetingDocReturn {
 			clearMeetingDoc();
 		}
 
-		const docResource = createDocumentResource({
+		const resource = createDocumentResource({
 			doctype: "Meet Room",
 			name: meetingId,
 			auto: session.isLoggedIn,
@@ -70,6 +74,10 @@ export function useMeetingDoc(): UseMeetingDocReturn {
 				updateSettings: "update_settings",
 				enableE2ee: "enable_e2ee",
 			},
+		});
+		const docResource: DocumentResource = Object.assign(resource, {
+			updateSettings: Reflect.get(resource, "updateSettings"),
+			enableE2ee: Reflect.get(resource, "enableE2ee"),
 		});
 
 		meetingDoc.value = docResource;

--- a/frontend/src/apps/meet/composables/useMeetingHandlers.ts
+++ b/frontend/src/apps/meet/composables/useMeetingHandlers.ts
@@ -3,15 +3,22 @@ import type { Ref } from "vue";
 import type { Router } from "vue-router";
 import type { TransportManager } from "../utils/media/TransportManager";
 import type { SFUClient } from "../utils/SFUClient";
+import type { SFUMeetingManager } from "../utils/SFUMeetingManager";
 import type { ChatStore } from "./useChatStore";
 import type { ConnectionState } from "./useConnectionState";
 import type { CurrentUser } from "./useCurrentUser";
 import type { GridLayout } from "./useGridLayout";
 import type { LobbyStore } from "./useLobbyStore";
 import type { MediaState } from "./useMediaState";
+import type { DocumentResource } from "./useMeetingDoc";
 import type { ParticipantStore } from "./useParticipantStore";
 import type { RaiseHandStore } from "./useRaiseHandStore";
 import type { ReactionStore } from "./useReactionStore";
+import {
+	isUnknownRecord,
+	type JoinPayload,
+	normalizeJoinPayload,
+} from "../types";
 
 interface LobbyActions {
 	approveUser: (userId: string) => Promise<void>;
@@ -41,7 +48,9 @@ interface MediaHandlerLike {
 	audioProducer: ProducerLike | null;
 	videoProducer: ProducerLike | null;
 	screenProducer: ProducerLike | null;
-	setProducers: (producers: Record<string, unknown>) => void;
+	setProducers: (producers: Partial<Pick<MediaHandlerLike,
+		"audioProducer" | "videoProducer" | "screenProducer"
+	>>) => void;
 	stopScreenShare: () => void;
 }
 
@@ -56,19 +65,14 @@ interface SFUMeetingManagerLike {
 	videoManager: VideoManagerLike | null;
 }
 
-export type MeetingDocLike = {
-	doc: { banned_users?: Array<{ user: string }> } | null | undefined;
-	setValue: { submit: (data: Record<string, unknown>) => Promise<unknown> };
-	reload: () => Promise<void>;
-	[key: string]: unknown;
-};
+export type MeetingDocLike = DocumentResource;
 
 interface SFUConnectionActions {
-	sfuManager: Ref<SFUMeetingManagerLike | null>;
+	sfuManager: Ref<SFUMeetingManager | null>;
 	sfuClient: SFUClient;
 	joinMeetingRoom: () => Promise<void>;
 	handleGuestJoinResult: (
-		joinResult: Record<string, unknown>,
+		joinResult: JoinPayload,
 		guestName: string,
 	) => Promise<void>;
 }
@@ -110,10 +114,15 @@ export function useMeetingHandlers(deps: MeetingHandlersDeps) {
 		joinResult,
 	}: {
 		guestName: string;
-		joinResult: Record<string, unknown>;
+		joinResult: unknown;
 	}) => {
+		const normalizedJoinResult = normalizeJoinPayload(joinResult);
+		if (!normalizedJoinResult) {
+			deps.connectionState.connectionError = "Invalid guest join response";
+			return;
+		}
 		const guestId =
-			(joinResult?.guest_id as string) ||
+			normalizedJoinResult.guest_id ||
 			(deps.connectionState.guestId as string);
 		const resolvedGuestName = guestName || localStorage.getItem("guest_name");
 
@@ -128,7 +137,7 @@ export function useMeetingHandlers(deps: MeetingHandlersDeps) {
 		}
 
 		await deps.sfuConnection.handleGuestJoinResult(
-			joinResult,
+			normalizedJoinResult,
 			resolvedGuestName || "",
 		);
 	};
@@ -241,7 +250,10 @@ export function useMeetingHandlers(deps: MeetingHandlersDeps) {
 				},
 			});
 
-			if ((response as { meeting_id?: string })?.meeting_id) {
+			if (
+				isUnknownRecord(response) &&
+				typeof response.meeting_id === "string"
+			) {
 				toast.success("User promoted to co-host");
 				await deps.meetingDoc.reload();
 			}
@@ -307,14 +319,20 @@ export function useMeetingHandlers(deps: MeetingHandlersDeps) {
 		});
 	};
 
-	const handleDeviceChanged = async (event: Record<string, unknown>) => {
-		if (typeof event.type !== "string" || typeof event.deviceId !== "string") {
+	const handleDeviceChanged = async (event: unknown) => {
+		if (
+			!isUnknownRecord(event) ||
+			(event.type !== "camera" &&
+				event.type !== "microphone" &&
+				event.type !== "speaker") ||
+			typeof event.deviceId !== "string"
+		) {
 			return;
 		}
 
 		try {
 			await deps.mediaControls.switchInputDevice(
-				event.type as "camera" | "microphone" | "speaker",
+				event.type,
 				event.deviceId,
 			);
 		} catch (error) {

--- a/frontend/src/apps/meet/composables/useParticipantStore.ts
+++ b/frontend/src/apps/meet/composables/useParticipantStore.ts
@@ -1,31 +1,35 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
+import type {
+	Participant,
+	ParticipantUpdate,
+} from "../utils/media/ParticipantManager";
 
 export interface ParticipantStore {
-	participants: Record<string, unknown>;
+	participants: Record<string, Participant>;
 	remoteVideos: Record<string, HTMLVideoElement>;
 	activeSpeakerIds: string[];
 	stableSpeakerIds: string[];
 	speakerStartTimes: Record<string, number>;
-	addParticipant: (participant: Record<string, unknown>) => void;
+	addParticipant: (participant: Participant) => void;
 	removeParticipant: (participantId: string) => void;
 	updateParticipant: (
 		participantId: string,
-		updates: Record<string, unknown>,
+		updates: ParticipantUpdate,
 	) => void;
 	getParticipantName: (participantId: string) => string;
 	$reset: () => void;
 }
 
 export const useParticipantStore = defineStore("meet-participant", () => {
-	const participants = ref<Record<string, unknown>>({});
+	const participants = ref<Record<string, Participant>>({});
 	const remoteVideos = ref<Record<string, HTMLVideoElement>>({});
 	const activeSpeakerIds = ref<string[]>([]);
 	const stableSpeakerIds = ref<string[]>([]);
 	const speakerStartTimes = ref<Record<string, number>>({});
 
-	function addParticipant(participant: Record<string, unknown>) {
-		const userId = participant.user_id as string;
+	function addParticipant(participant: Participant) {
+		const userId = participant.user_id;
 		if (!userId) return;
 		participants.value[userId] = participant;
 	}
@@ -45,21 +49,17 @@ export const useParticipantStore = defineStore("meet-participant", () => {
 
 	function updateParticipant(
 		participantId: string,
-		updates: Record<string, unknown>,
+		updates: ParticipantUpdate,
 	) {
-		const participant = participants.value[participantId] as
-			| Record<string, unknown>
-			| undefined;
+		const participant = participants.value[participantId];
 		if (participant) {
 			participants.value[participantId] = { ...participant, ...updates };
 		}
 	}
 
 	function getParticipantName(participantId: string): string {
-		const participant = participants.value[participantId] as
-			| Record<string, unknown>
-			| undefined;
-		return (participant?.user_name as string) || participantId;
+		const participant = participants.value[participantId];
+		return participant?.user_name || participantId;
 	}
 
 	function $reset() {

--- a/frontend/src/apps/meet/composables/usePoll.ts
+++ b/frontend/src/apps/meet/composables/usePoll.ts
@@ -7,12 +7,15 @@ import { useChatStore } from "./useChatStore";
 import { PollPayloadFE } from "../types";
 import { getErrorMessage } from "../utils/error";
 import audioNotificationManager from "../utils/audioNotifications";
+import type { InjectionKey } from "vue";
 
-interface PollAPI {
+export interface PollAPI {
 	setupPollEvents: (notify: (notification: PollNotification) => void) => void;
 	createPoll: (question: string, options: { text: string }[]) => Promise<void>;
-	submitVote: (pollId: string, optionId: string) => void;
+	submitVote: (pollId: string, optionId: string) => Promise<void>;
 }
+
+export const pollKey: InjectionKey<PollAPI> = Symbol("poll");
 
 interface PollNotification {
 	message: string;
@@ -22,6 +25,83 @@ interface PollNotification {
 }
 
 const E2EE_POLL_PREFIX = "e2ee:";
+
+interface PollResponse {
+	success: boolean;
+	error?: string;
+	poll?: PollPayloadFE;
+	polls?: PollPayloadFE[];
+}
+
+function isPollOption(value: unknown): value is PollPayloadFE["options"][number] {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"id" in value &&
+		typeof value.id === "string" &&
+		"text" in value &&
+		typeof value.text === "string" &&
+		"votes" in value &&
+		typeof value.votes === "number"
+	);
+}
+
+function isPollPayload(value: unknown): value is PollPayloadFE {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"pollId" in value &&
+		typeof value.pollId === "string" &&
+		"createdBy" in value &&
+		typeof value.createdBy === "string" &&
+		(!("createdByName" in value) ||
+			value.createdByName === undefined ||
+			typeof value.createdByName === "string") &&
+		"question" in value &&
+		typeof value.question === "string" &&
+		"options" in value &&
+		Array.isArray(value.options) &&
+		value.options.every(isPollOption) &&
+		"isActive" in value &&
+		typeof value.isActive === "boolean" &&
+		(!("hasVoted" in value) ||
+			value.hasVoted === undefined ||
+			typeof value.hasVoted === "boolean") &&
+		"createdAt" in value &&
+		typeof value.createdAt === "string"
+	);
+}
+
+function isPollResponse(value: unknown): value is PollResponse {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"success" in value &&
+		typeof value.success === "boolean" &&
+		(!("error" in value) ||
+			value.error === undefined ||
+			typeof value.error === "string") &&
+		(!("poll" in value) || value.poll === undefined || isPollPayload(value.poll)) &&
+		(!("polls" in value) ||
+			value.polls === undefined ||
+			(Array.isArray(value.polls) && value.polls.every(isPollPayload)))
+	);
+}
+
+function isExistingPollsEvent(value: unknown): value is { polls: PollPayloadFE[] } {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"polls" in value &&
+		Array.isArray(value.polls) &&
+		value.polls.every(isPollPayload)
+	);
+}
+
+function requirePollResponse(value: unknown, operation: string): PollResponse {
+	if (!isPollResponse(value)) throw new Error(`Invalid ${operation} response`);
+	return value;
+}
 
 function isEncryptedPollText(text: string): boolean {
 	return typeof text === "string" && text.startsWith(E2EE_POLL_PREFIX);
@@ -95,7 +175,11 @@ async function decryptPollPayload(
 			return { ...opt, text };
 		}),
 	);
-	if (options.some((option) => option === null)) return null;
+	if (
+		!options.every(
+			(option): option is PollPayloadFE["options"][number] => option !== null,
+		)
+	) return null;
 	return { ...poll, question, options };
 }
 
@@ -144,9 +228,10 @@ export function usePoll(deps: {
 		await Promise.all(
 			plaintextPolls.map(async (poll) => {
 				const payload = await encryptExistingPollPayload(key, poll);
-				const response = await sfuClient.sendRequest("poll:sync_encrypted", payload) as {
-					success?: boolean;
-				};
+				const response = requirePollResponse(
+					await sfuClient.sendRequest("poll:sync_encrypted", payload),
+					"poll sync",
+				);
 				if (!response?.success) return;
 			}),
 		);
@@ -157,10 +242,10 @@ export function usePoll(deps: {
 		const key = await E2EEMeeting.instance.getE2EEPollKey();
 		if (!key && sfuClient.isE2EERequired?.()) return;
 		try {
-			const response = (await sfuClient.sendRequest("get_existing_polls", {})) as {
-				success: boolean;
-				polls?: PollPayloadFE[];
-			};
+			const response = requirePollResponse(
+				await sfuClient.sendRequest("get_existing_polls", {}),
+				"existing polls",
+			);
 			if (response.success && response.polls) {
 				if (!key && response.polls.some(hasEncryptedPollText)) return;
 				const decrypted = (
@@ -186,10 +271,10 @@ export function usePoll(deps: {
 
 	const setupPollEvents = (notify: (notification: PollNotification) => void) => {
 		sfuClient.on("poll:new", async (data: unknown) => {
+			if (!isPollPayload(data)) return;
 			const key = await E2EEMeeting.instance.getE2EEPollKey();
-			const payload = data as PollPayloadFE;
-			if (!key && hasEncryptedPollText(payload)) return;
-			const poll = await decryptPollPayload(key, payload);
+			if (!key && hasEncryptedPollText(data)) return;
+			const poll = await decryptPollPayload(key, data);
 			if (!poll) return;
 			pollStore.addPoll(poll);
 			if (poll.createdBy !== currentUserId() && !chatStore.isChatOpen) {
@@ -205,24 +290,24 @@ export function usePoll(deps: {
 		});
 
 		sfuClient.on("poll:update", async (data: unknown) => {
+			if (!isPollPayload(data)) return;
 			const key = await E2EEMeeting.instance.getE2EEPollKey();
-			const payload = data as PollPayloadFE;
-			if (!key && hasEncryptedPollText(payload)) return;
-			const poll = await decryptPollPayload(key, payload);
+			if (!key && hasEncryptedPollText(data)) return;
+			const poll = await decryptPollPayload(key, data);
 			if (!poll) return;
 			pollStore.updatePoll(poll);
 		});
 
 		sfuClient.on("existing_polls", async (data: unknown) => {
+			if (!isExistingPollsEvent(data)) return;
 			const key = await E2EEMeeting.instance.getE2EEPollKey();
-			const payload = data as { polls: PollPayloadFE[] };
-			if (!key && payload.polls.some(hasEncryptedPollText)) return;
+			if (!key && data.polls.some(hasEncryptedPollText)) return;
 			const decrypted = (
 				await Promise.all(
-					payload.polls.map((p) => decryptPollPayload(key, p)),
+					data.polls.map((p) => decryptPollPayload(key, p)),
 				)
 			).filter((poll): poll is PollPayloadFE => poll !== null);
-			if (decrypted.length === 0 && payload.polls.length > 0) return;
+			if (decrypted.length === 0 && data.polls.length > 0) return;
 			pollStore.setExistingPolls(decrypted);
 		});
 
@@ -250,7 +335,10 @@ export function usePoll(deps: {
 				createdByName: currentUserName(),
 			};
 
-			const response = (await sfuClient.sendRequest("poll:create", payload)) as any;
+			const response = requirePollResponse(
+				await sfuClient.sendRequest("poll:create", payload),
+				"poll creation",
+			);
 
 			if (response && response.success) {
 				if (response.poll) {
@@ -275,10 +363,10 @@ export function usePoll(deps: {
 		}
 
 		try {
-			const response = await sfuClient.sendRequest("poll:vote", {
-				pollId,
-				optionId,
-			}) as { success: boolean; error?: string };
+			const response = requirePollResponse(
+				await sfuClient.sendRequest("poll:vote", { pollId, optionId }),
+				"poll vote",
+			);
 
 			if (!response.success) {
 				throw new Error(response.error ?? "Failed to submit vote");
@@ -287,7 +375,7 @@ export function usePoll(deps: {
 			pollStore.markPollAsVoted(pollId);
 		} catch (error) {
 			console.error("Failed to submit vote:", error);
-			toast.error((error as Error).message);
+			toast.error(getErrorMessage(error));
 			throw error;
 		}
 	};

--- a/frontend/src/apps/meet/composables/useRTCStats.ts
+++ b/frontend/src/apps/meet/composables/useRTCStats.ts
@@ -1,6 +1,7 @@
-import type { Consumer, Producer } from "mediasoup-client/types";
+import type { AppData, Consumer, Producer } from "mediasoup-client/types";
 import { computed, inject, onUnmounted, type Ref, ref, watch } from "vue";
 import type { SFUMeetingManager } from "../utils/SFUMeetingManager";
+import { isUnknownRecord } from "../types";
 
 type StatsReport = Record<string, unknown> & {
 	id?: string;
@@ -86,7 +87,11 @@ function stringValue(value: unknown): string | undefined {
 function reports(stats: unknown): StatsReport[] {
 	if (!stats || typeof stats !== "object") return [];
 	const values = (stats as { values?: () => IterableIterator<unknown> }).values?.();
-	return values ? Array.from(values) as StatsReport[] : [];
+	return values
+		? Array.from(values).filter(
+				(report): report is StatsReport => isUnknownRecord(report),
+			)
+		: [];
 }
 
 export function selectPrimaryRtpReport(
@@ -154,7 +159,7 @@ function sourceForProducer(producer: Producer): RTCStreamStats["source"] {
 function sourceForConsumer(entry: {
 	kind: string;
 	isScreen?: boolean;
-	appData?: Record<string, unknown>;
+	appData?: AppData;
 }): RTCStreamStats["source"] {
 	if (entry.kind === "audio") return "remote audio";
 	return entry.isScreen || entry.appData?.type === "screen"

--- a/frontend/src/apps/meet/composables/useRaiseHand.ts
+++ b/frontend/src/apps/meet/composables/useRaiseHand.ts
@@ -2,6 +2,7 @@ import audioNotificationManager from "../utils/audioNotifications";
 import type { SFUClient } from "../utils/SFUClient";
 import type { CurrentUser } from "./useCurrentUser";
 import type { RaiseHandStore } from "./useRaiseHandStore";
+import { isUnknownRecord } from "../types";
 
 interface RaiseHandAPI {
 	setupRaiseHandEvents: () => void;
@@ -16,14 +17,21 @@ export function useRaiseHand(deps: {
 	const { raiseHandStore, currentUser, sfuClient } = deps;
 
 	const setupRaiseHandEvents = () => {
-		sfuClient.on("hand_raised", (data: Record<string, unknown>) => {
-			const participantId = data.participantId as string;
-			const raised = data.raised as boolean;
+		sfuClient.on("hand_raised", (value: unknown) => {
+			if (
+				!isUnknownRecord(value) ||
+				typeof value.participantId !== "string" ||
+				typeof value.raised !== "boolean"
+			) return;
+			const participantId = value.participantId;
+			const raised = value.raised;
 
 			if (raised) {
 				raiseHandStore.raiseHand(
 					participantId,
-					(data.timestamp as string) || new Date().toISOString(),
+					typeof value.timestamp === "string"
+						? value.timestamp
+						: new Date().toISOString(),
 				);
 				audioNotificationManager.playRaiseHandNotification();
 			} else {
@@ -31,8 +39,13 @@ export function useRaiseHand(deps: {
 			}
 		});
 
-		sfuClient.on("existing_raised_hands", (data: Record<string, unknown>) => {
-			raiseHandStore.setHands((data.hands as Record<string, string>) || {});
+		sfuClient.on("existing_raised_hands", (value: unknown) => {
+			if (!isUnknownRecord(value) || !isUnknownRecord(value.hands)) return;
+			const hands: Record<string, string> = {};
+			for (const [participantId, timestamp] of Object.entries(value.hands)) {
+				if (typeof timestamp === "string") hands[participantId] = timestamp;
+			}
+			raiseHandStore.setHands(hands);
 		});
 	};
 

--- a/frontend/src/apps/meet/composables/useReactions.ts
+++ b/frontend/src/apps/meet/composables/useReactions.ts
@@ -1,6 +1,7 @@
 import type { SFUClient } from "../utils/SFUClient";
 import type { CurrentUser } from "./useCurrentUser";
 import type { ReactionStore } from "./useReactionStore";
+import { isUnknownRecord } from "../types";
 
 interface ReactionsAPI {
 	setupReactionEvents: () => void;
@@ -20,10 +21,19 @@ export function useReactions(deps: {
 	const { reactionStore, currentUser, sfuClient } = deps;
 
 	const setupReactionEvents = () => {
-		sfuClient.on("reaction:message", (data: Record<string, unknown>) => {
-			const userId = data.fromUser as string;
-			const emoji = (data.message || data.reaction) as string;
-			const duration = (data.duration || 5000) as number;
+		sfuClient.on("reaction:message", (value: unknown) => {
+			if (!isUnknownRecord(value) || typeof value.fromUser !== "string") return;
+			const userId = value.fromUser;
+			const emoji =
+				typeof value.message === "string"
+					? value.message
+					: typeof value.reaction === "string"
+						? value.reaction
+						: "";
+			const duration =
+				typeof value.duration === "number" && value.duration > 0
+					? value.duration
+					: 5000;
 
 			if (userId && emoji) {
 				reactionStore.showReactionForUser(userId, emoji, duration);

--- a/frontend/src/apps/meet/composables/useSFUConnection.ts
+++ b/frontend/src/apps/meet/composables/useSFUConnection.ts
@@ -31,6 +31,16 @@ import type { LobbyStore } from "./useLobbyStore";
 import type { MediaState } from "./useMediaState";
 import type { ParticipantStore } from "./useParticipantStore";
 import type { RecordingState } from "./useRecording";
+import {
+	isUnknownRecord,
+	type JoinPayload,
+	type JoinUserData,
+	normalizeJoinPayload,
+} from "../types";
+import type {
+	Participant,
+	ParticipantUpdate,
+} from "../utils/media/ParticipantManager";
 
 const LARGE_MEETING_PARTICIPANT_THRESHOLD = 5;
 
@@ -41,6 +51,58 @@ interface WaitingRoomResponse {
 		user_image?: string;
 		is_guest?: boolean;
 	}>;
+}
+
+interface MeetingRealtimeEvent {
+	meeting: string;
+	user: string;
+	userName?: string;
+	userImage?: string;
+}
+
+function normalizeMeetingRealtimeEvent(value: unknown): MeetingRealtimeEvent | null {
+	if (
+		!isUnknownRecord(value) ||
+		typeof value.meeting !== "string" ||
+		typeof value.user !== "string"
+	) return null;
+	return {
+		meeting: value.meeting,
+		user: value.user,
+		userName: typeof value.user_name === "string" ? value.user_name : undefined,
+		userImage: typeof value.user_image === "string" ? value.user_image : undefined,
+	};
+}
+
+function normalizeGuestRealtimeEvent(
+	value: unknown,
+): { guestId: string; meetingId: string } | null {
+	if (
+		!isUnknownRecord(value) ||
+		typeof value.guest_id !== "string" ||
+		typeof value.meeting_id !== "string"
+	) return null;
+	return { guestId: value.guest_id, meetingId: value.meeting_id };
+}
+
+function normalizeWaitingRoomResponse(value: unknown): WaitingRoomResponse | null {
+	if (!isUnknownRecord(value) || !Array.isArray(value.waiting_users)) return null;
+	const waitingUsers: WaitingRoomResponse["waiting_users"] = [];
+	for (const candidate of value.waiting_users) {
+		if (!isUnknownRecord(candidate) || typeof candidate.user_id !== "string") {
+			continue;
+		}
+		waitingUsers.push({
+			user_id: candidate.user_id,
+			full_name:
+				typeof candidate.full_name === "string" ? candidate.full_name : undefined,
+			user_image:
+				typeof candidate.user_image === "string" ? candidate.user_image : undefined,
+			is_guest:
+				typeof candidate.is_guest === "boolean" ? candidate.is_guest : undefined,
+		});
+	}
+	return { waiting_users: waitingUsers };
 }
 
 export interface SFUScreenShareData {
@@ -55,12 +117,13 @@ interface SFUConnectionAPI {
 	sfuManager: Ref<SFUMeetingManager | null>;
 	joinMeetingRoom: () => Promise<void>;
 	handleGuestJoinResult: (
-		joinResult: Record<string, unknown>,
+		joinResult: JoinPayload,
 		guestName: string,
 	) => Promise<void>;
 	setupFrappeRealtimeEventListeners: () => void;
 	endCall: () => Promise<void>;
 	fetchExistingWaitingRoomUsers: () => Promise<void>;
+	localNetworkQuality: Ref<string>;
 }
 
 export function useSFUConnection(deps: {
@@ -134,7 +197,7 @@ export function useSFUConnection(deps: {
 	const localNetworkQuality = shallowRef("good");
 	let stabilityCheckTimeout: ReturnType<typeof setTimeout> | null = null;
 
-	const handleParticipantJoined = (participant: Record<string, unknown>) => {
+	const handleParticipantJoined = (participant: Participant) => {
 		const participantName = participant?.user_name || participant?.user_id;
 		const participantId = participant.participantId || participant?.user_id;
 		const currentUserId = currentUser.currentUser.value?.user_id;
@@ -156,7 +219,7 @@ export function useSFUConnection(deps: {
 		}
 
 		audioNotificationManager.playJoinNotification(
-			participant.participantId as string,
+			participant.user_id,
 		);
 
 		const LucideUserIcon = defineAsyncComponent(
@@ -179,9 +242,7 @@ export function useSFUConnection(deps: {
 	}: {
 		participantId: string;
 	}) => {
-		const participant = participantStore.participants[participantId] as
-			| Record<string, unknown>
-			| undefined;
+		const participant = participantStore.participants[participantId];
 		const participantName = participant?.user_name || participantId;
 
 		participantStore.removeParticipant(participantId);
@@ -207,8 +268,8 @@ export function useSFUConnection(deps: {
 
 	const handleParticipantUpdated = (
 		participantId: string,
-		_participant: Record<string, unknown>,
-		updates: Record<string, unknown>,
+		_participant: Participant,
+		updates: ParticipantUpdate,
 	) => {
 		if (participantId) {
 			participantStore.updateParticipant(participantId, updates || {});
@@ -355,7 +416,7 @@ export function useSFUConnection(deps: {
 			sfuManager.value = manager;
 			const stopIfCancelled = async () => {
 				if (!setupCancelled) return false;
-				await manager.cleanup();
+					await manager!.cleanup();
 				if (sfuManager.value === manager) {
 					sfuManager.value = null;
 				}
@@ -389,7 +450,7 @@ export function useSFUConnection(deps: {
 				}
 			}
 
-			let userData: Record<string, unknown>;
+			let userData: JoinUserData;
 			if (guestName) {
 				userData = {
 					name: guestName,
@@ -469,7 +530,7 @@ export function useSFUConnection(deps: {
 						...audioTracks,
 					]);
 
-					await manager.publishMedia(streamToPublish, {
+					await manager!.publishMedia(streamToPublish, {
 						publishVideo: mediaState.isCameraOn,
 						publishAudio: mediaState.isMicOn,
 					});
@@ -483,7 +544,7 @@ export function useSFUConnection(deps: {
 
 			await Promise.all([
 				publishLocal(),
-				manager.setupExistingParticipants(),
+				manager!.setupExistingParticipants(),
 			]);
 			if (await stopIfCancelled()) return;
 
@@ -513,10 +574,10 @@ export function useSFUConnection(deps: {
 
 	const fetchExistingWaitingRoomUsers = async () => {
 		try {
-			const result = (await frappeRequest({
+			const result = normalizeWaitingRoomResponse(await frappeRequest({
 				url: "suite.meet.api.meeting.get_waiting_room",
 				params: { meeting_id: meetingId },
-			})) as WaitingRoomResponse;
+			}));
 
 			if (result?.waiting_users) {
 				const transformedUsers = result.waiting_users.map((user) => ({
@@ -552,17 +613,16 @@ export function useSFUConnection(deps: {
 			return;
 		}
 
-		socket.emit("guest_subscribe", guestId);
-
 		socket.on("meet:guest_join_approved", handleGuestApproved);
 		socket.on("meet:guest_join_rejected", handleGuestRejected);
 
-		async function handleGuestApproved(data: Record<string, unknown>) {
-			if (data.guest_id !== guestId || data.meeting_id !== meetingId) {
+		async function handleGuestApproved(value: unknown) {
+			const event = normalizeGuestRealtimeEvent(value);
+			if (event?.guestId !== guestId || event.meetingId !== meetingId) {
 				return;
 			}
 
-			stopGuestApprovalListener();
+			removeGuestApprovalListeners();
 
 			lobbyStore.isWaitingForApproval = false;
 			connectionState.isConnecting = true;
@@ -570,34 +630,30 @@ export function useSFUConnection(deps: {
 			try {
 				const resolvedGuestName =
 					guestName || sessionStorage.getItem("guest_name") || "Guest";
-				const response = await frappeRequest({
+				const response = normalizeJoinPayload(await frappeRequest({
 					url: "suite.meet.api.meeting.get_approved_guest_connection_details",
 					params: {
 						meeting_id: meetingId,
 						guest_id: guestId,
 					},
-				});
+				}));
 				if (
-					(response as Record<string, unknown>)?.status === "joined" &&
-					(response as Record<string, unknown>).auth_token
+					response?.status === "joined" &&
+					response.auth_token
 				) {
-					if (
-						(response as Record<string, unknown>).host_only_chat !== undefined
-					) {
-						chatStore.hostOnlyChat = !!(response as Record<string, unknown>)
-							.host_only_chat;
+					if (response.host_only_chat !== undefined) {
+						chatStore.hostOnlyChat = response.host_only_chat;
 					}
 
-					const approved = response as Record<string, unknown>;
-					if ("recording" in approved)
-						onRecordingState?.(approved.recording as RecordingState | null);
-					connectionState.guestAuthToken = approved.auth_token as string;
-					connectionState.guestSfuUrl = (approved.sfu_url as string) || null;
+					if (response.recording !== undefined)
+						onRecordingState?.(response.recording);
+					connectionState.guestAuthToken = response.auth_token;
+					connectionState.guestSfuUrl = response.sfu_url || null;
 					connectionState.guestSfuPort =
-						(approved.sfu_port as string) || null;
+						response.sfu_port == null ? null : String(response.sfu_port);
 
-					const prefetched = connectionDetailsFromJoinPayload(approved, {
-						guestAuthToken: approved.auth_token as string,
+					const prefetched = connectionDetailsFromJoinPayload(response, {
+						guestAuthToken: response.auth_token,
 						guestId,
 						guestName: resolvedGuestName,
 						expectedMeetingId: meetingId,
@@ -629,15 +685,14 @@ export function useSFUConnection(deps: {
 			}
 		}
 
-		function handleGuestRejected(data: Record<string, unknown>) {
-			if (
-				(data as Record<string, unknown>).guest_id !== guestId ||
-				(data as Record<string, unknown>).meeting_id !== meetingId
-			) {
+		function handleGuestRejected(value: unknown) {
+			const event = normalizeGuestRealtimeEvent(value);
+			if (event?.guestId !== guestId || event.meetingId !== meetingId) {
 				return;
 			}
 
-			stopGuestApprovalListener();
+			removeGuestApprovalListeners();
+			unsubscribeGuestRealtime();
 
 			lobbyStore.isJoinRequestRejected = true;
 			lobbyStore.isWaitingForApproval = false;
@@ -646,29 +701,26 @@ export function useSFUConnection(deps: {
 		}
 	};
 
-	const stopGuestApprovalListener = () => {
+	const removeGuestApprovalListeners = () => {
 		if (!socket) return;
-
-		const guestId = sessionStorage.getItem("guest_id");
-
-		if (guestId) {
-			socket.emit("guest_unsubscribe", guestId);
-		}
 
 		socket.off("meet:guest_join_approved");
 		socket.off("meet:guest_join_rejected");
 	};
 
-	const handleMeetingJoinRequest = (data: Record<string, unknown>) => {
-		if (data.meeting === meetingId) {
-			if (!data.user) {
-				return;
-			}
+	const unsubscribeGuestRealtime = () => {
+		const guestId = sessionStorage.getItem("guest_id");
+		if (socket && guestId) socket.emit("guest_unsubscribe", guestId);
+	};
+
+	const handleMeetingJoinRequest = (value: unknown) => {
+		const data = normalizeMeetingRealtimeEvent(value);
+		if (data?.meeting === meetingId) {
 
 			const userData = {
-				userId: data.user as string,
-				name: (data.user_name || data.user) as string,
-				avatar: data.user_image as string,
+				userId: data.user,
+				name: data.userName || data.user,
+				avatar: data.userImage,
 				requested_at: new Date().toISOString(),
 			};
 
@@ -678,30 +730,30 @@ export function useSFUConnection(deps: {
 		}
 	};
 
-	const handleMeetingJoinApproved = async (data: Record<string, unknown>) => {
+	const handleMeetingJoinApproved = async (value: unknown) => {
+		const data = normalizeMeetingRealtimeEvent(value);
 		const currentUserId = currentUser.currentUser.value?.user_id;
 
-		if (data.meeting === meetingId && data.user === currentUserId) {
+		if (data?.meeting === meetingId && data.user === currentUserId) {
 			lobbyStore.isWaitingForApproval = false;
 
 			try {
-				const sfuResult = await frappeRequest({
+				const sfuResult = normalizeJoinPayload(await frappeRequest({
 					url: "suite.meet.api.meeting.get_sfu_connection_details",
 					params: {
 						meeting_id: meetingId,
 					},
-				});
+				}));
 
 				if (sfuResult) {
-					const details = sfuResult as Record<string, unknown>;
-					onRecordingEnabled?.(!!details.recording_enabled);
-					const prefetched = connectionDetailsFromJoinPayload(details, {
+					onRecordingEnabled?.(!!sfuResult.recording_enabled);
+					const prefetched = connectionDetailsFromJoinPayload(sfuResult, {
 						expectedMeetingId: meetingId,
 					});
 					await setupSFUConnection(
 						null,
-						details.is_host as boolean,
-						details.is_cohost as boolean,
+						!!sfuResult.is_host,
+						!!sfuResult.is_cohost,
 						prefetched,
 					);
 					connectionState.isInPreview = false;
@@ -718,10 +770,11 @@ export function useSFUConnection(deps: {
 		}
 	};
 
-	const handleMeetingJoinRejected = (data: Record<string, unknown>) => {
+	const handleMeetingJoinRejected = (value: unknown) => {
+		const data = normalizeMeetingRealtimeEvent(value);
 		const currentUserId = currentUser.currentUser.value?.user_id;
 
-		if (data.meeting === meetingId && data.user === currentUserId) {
+		if (data?.meeting === meetingId && data.user === currentUserId) {
 			lobbyStore.isJoinRequestRejected = true;
 			lobbyStore.isWaitingForApproval = false;
 
@@ -729,15 +782,17 @@ export function useSFUConnection(deps: {
 		}
 	};
 
-	const handleMeetingUserApproved = (data: Record<string, unknown>) => {
-		if (data.meeting === meetingId) {
-			lobbyStore.removeLobbyUser(data.user as string);
+	const handleMeetingUserApproved = (value: unknown) => {
+		const data = normalizeMeetingRealtimeEvent(value);
+		if (data?.meeting === meetingId) {
+			lobbyStore.removeLobbyUser(data.user);
 		}
 	};
 
-	const handleMeetingUserRejected = (data: Record<string, unknown>) => {
-		if (data.meeting === meetingId) {
-			lobbyStore.removeLobbyUser(data.user as string);
+	const handleMeetingUserRejected = (value: unknown) => {
+		const data = normalizeMeetingRealtimeEvent(value);
+		if (data?.meeting === meetingId) {
+			lobbyStore.removeLobbyUser(data.user);
 		}
 	};
 
@@ -780,7 +835,7 @@ export function useSFUConnection(deps: {
 	};
 
 	const handleGuestJoinResult = async (
-		joinResult: Record<string, unknown>,
+		joinResult: JoinPayload,
 		guestName: string,
 	) => {
 		if (!guestName || !joinResult?.guest_id) {
@@ -792,16 +847,18 @@ export function useSFUConnection(deps: {
 		try {
 			connectionState.connectionError = null;
 
-			sessionStorage.setItem("guest_id", joinResult.guest_id as string);
+			sessionStorage.setItem("guest_id", joinResult.guest_id);
 			sessionStorage.setItem("guest_name", guestName);
 			sessionStorage.setItem("guest_meeting_id", meetingId);
-			sessionStorage.setItem("guest_status", joinResult.status as string);
+			sessionStorage.setItem("guest_status", joinResult.status || "joined");
+			socket?.emit("guest_subscribe", joinResult.guest_id);
 
-			connectionState.guestId = joinResult.guest_id as string;
+			connectionState.guestId = joinResult.guest_id;
 			connectionState.guestAuthToken =
-				(joinResult.auth_token as string) || null;
-			connectionState.guestSfuUrl = (joinResult.sfu_url as string) || null;
-			connectionState.guestSfuPort = (joinResult.sfu_port as string) || null;
+				joinResult.auth_token || null;
+			connectionState.guestSfuUrl = joinResult.sfu_url || null;
+			connectionState.guestSfuPort =
+				joinResult.sfu_port == null ? null : String(joinResult.sfu_port);
 
 			if (joinResult.host_only_chat !== undefined) {
 				chatStore.hostOnlyChat = !!joinResult.host_only_chat;
@@ -815,8 +872,8 @@ export function useSFUConnection(deps: {
 				setupGuestApprovalListener(guestName);
 				return;
 			}
-			if ("recording" in joinResult)
-				onRecordingState?.(joinResult.recording as RecordingState | null);
+			if (joinResult.recording !== undefined)
+				onRecordingState?.(joinResult.recording);
 
 			// Show meeting shell immediately; SFU setup continues in the background.
 			connectionState.isInPreview = false;
@@ -853,7 +910,8 @@ export function useSFUConnection(deps: {
 			connectionState.guestSfuUrl = null;
 			connectionState.guestSfuPort = null;
 
-			const joinResult = await joinMeetingAPI.fetch();
+			const joinResult = normalizeJoinPayload(await joinMeetingAPI.fetch());
+			if (!joinResult) throw new Error("Invalid meeting join response");
 
 			if (joinResult.status === "waiting_for_approval") {
 				lobbyStore.isWaitingForApproval = true;
@@ -872,8 +930,8 @@ export function useSFUConnection(deps: {
 			});
 			await setupSFUConnection(
 				null,
-				(joinResult?.is_host || false) as boolean,
-				(joinResult?.is_cohost || false) as boolean,
+				!!joinResult.is_host,
+				!!joinResult.is_cohost,
 				prefetched,
 			);
 
@@ -891,7 +949,8 @@ export function useSFUConnection(deps: {
 	const endCall = async () => {
 		try {
 			setupCancelled = true;
-			stopGuestApprovalListener();
+			removeGuestApprovalListeners();
+			unsubscribeGuestRealtime();
 
 			if (activeSpeakerTimeout.value) {
 				clearTimeout(activeSpeakerTimeout.value);
@@ -926,7 +985,8 @@ export function useSFUConnection(deps: {
 			stabilityCheckTimeout = null;
 		}
 
-		stopGuestApprovalListener();
+		removeGuestApprovalListeners();
+		unsubscribeGuestRealtime();
 		removeFrappeRealtimeEventListeners();
 
 		if (sfuManager.value) {

--- a/frontend/src/apps/meet/composables/useScreenShareTiles.ts
+++ b/frontend/src/apps/meet/composables/useScreenShareTiles.ts
@@ -13,7 +13,7 @@ interface CurrentUser {
 	name?: string;
 }
 
-interface ScreenShareTileParticipant {
+export interface ScreenShareTileParticipant {
 	user_id: string;
 	user_name: string;
 	avatar: string;
@@ -21,7 +21,7 @@ interface ScreenShareTileParticipant {
 	isLocalScreenShare: boolean;
 }
 
-interface ScreenShareTile {
+export interface ScreenShareTile {
 	pinId: string;
 	consumerId: string;
 	participant: ScreenShareTileParticipant;

--- a/frontend/src/apps/meet/icons.d.ts
+++ b/frontend/src/apps/meet/icons.d.ts
@@ -3,10 +3,6 @@
 
 declare module "~icons/*" {
 	import type { DefineComponent } from "vue";
-	const component: DefineComponent<
-		Record<string, unknown>,
-		Record<string, unknown>,
-		unknown
-	>;
+	const component: DefineComponent;
 	export default component;
 }

--- a/frontend/src/apps/meet/pages/Home.vue
+++ b/frontend/src/apps/meet/pages/Home.vue
@@ -151,6 +151,15 @@ import LucideZap from "~icons/lucide/zap";
 import LucideLink from "~icons/lucide/link";
 import LucideLock from "~icons/lucide/lock";
 
+interface CalendarParticipant {
+	email: string;
+	_name?: string;
+	user_image?: string;
+	participation_status?: string;
+	expect_reply?: boolean;
+	isNew?: boolean;
+}
+
 const router = useRouter();
 const connectionState = useConnectionState();
 const calendarStore = useCalendarUserStore();
@@ -162,7 +171,7 @@ const scheduleTitle = ref("");
 const scheduleDate = ref(dayjs().format("YYYY-MM-DD"));
 const scheduleStartTime = ref(dayjs().add(1, "hour").startOf("hour").format("HH:mm"));
 const scheduleEndTime = ref(dayjs().add(2, "hour").startOf("hour").format("HH:mm"));
-const scheduleParticipants = ref<any[]>([]);
+const scheduleParticipants = ref<CalendarParticipant[]>([]);
 const upcomingMeetingsRef = ref<{ reload: () => void } | null>(null);
 
 const userResource = createResource({
@@ -186,7 +195,7 @@ const createMeeting = createResource({
 		});
 		connectionState.justCreated = true;
 	},
-	onError: (error: any) => {
+	onError: (error: unknown) => {
 		console.error("Error creating meeting:", error);
 		toast.error("Failed to create meeting. Please try again.");
 	},
@@ -216,7 +225,7 @@ const currentUserEmail = computed(() => calendarStore.userResource.data?.name ||
 const scheduledParticipants = computed(() => {
 	const currentName = calendarStore.userResource.data?.full_name || userResource.data?.full_name;
 	const currentImage = calendarStore.userResource.data?.user_image || userResource.data?.user_image;
-	const participants = currentUserEmail.value
+	const participants: CalendarParticipant[] = currentUserEmail.value
 		? [
 				{
 					email: currentUserEmail.value,
@@ -248,7 +257,7 @@ const scheduleMeeting = createResource({
 		toast.success("Meeting scheduled.");
 		upcomingMeetingsRef.value?.reload();
 	},
-	onError: (error: any) => {
+	onError: (error: unknown) => {
 		console.error("Error scheduling meeting:", error);
 	},
 });

--- a/frontend/src/apps/meet/pages/Meeting.vue
+++ b/frontend/src/apps/meet/pages/Meeting.vue
@@ -285,7 +285,6 @@ import { useMediaState } from "../composables/useMediaState";
 import { provideMeetingContext } from "../composables/useMeetingContext";
 import { useMeetingDoc } from "../composables/useMeetingDoc";
 import {
-	type MeetingDocLike,
 	useMeetingHandlers,
 } from "../composables/useMeetingHandlers";
 import { useNoiseCancellation } from "../composables/useNoiseCancellation";
@@ -318,7 +317,7 @@ import { session, userResource } from "@/boot/session";
 import { useSocket } from "../socket";
 import { deviceManager } from "../utils/media/DeviceManager";
 import type { Participant } from "../utils/media/ParticipantManager";
-import { usePoll } from "../composables/usePoll.js";
+import { pollKey, usePoll } from "../composables/usePoll.js";
 import { usePollStore } from "../composables/usePollStore.js";
 
 // Router
@@ -696,7 +695,7 @@ provide("hostControls", {
 });
 provide("meetingTitle", computed(() => meetingTitle.value));
 
-provide("poll", poll);
+provide(pollKey, poll);
 
 // --- Computed properties ---
 const isConnecting = computed(() => connectionState.isConnecting);
@@ -833,7 +832,7 @@ const handlers = useMeetingHandlers({
 	sfuConnection,
 	mediaControls,
 	lobby,
-	meetingDoc: meetingDoc as unknown as MeetingDocLike,
+	meetingDoc,
 	meetingId: meetingId.value,
 	isCurrentUserHost,
 	isPeopleOpen,
@@ -993,7 +992,7 @@ const handleE2EENeedsMediaRepublish = async () => {
 		if (mediaState.isMicOn) {
 			mediaState.microphonePermissionGranted = true;
 		}
-		if (mediaState.localVideo) {
+		if (mediaState.localVideo instanceof HTMLVideoElement) {
 			mediaControls.setLocalVideoRef(mediaState.localVideo);
 		}
 		if (mediaState.localStream && sfuConnection.sfuManager.value) {

--- a/frontend/src/apps/meet/router.ts
+++ b/frontend/src/apps/meet/router.ts
@@ -2,6 +2,7 @@ import type { RouteLocationNormalized, Router } from "vue-router";
 
 import suiteRouter from "@/router";
 import { userResource } from "@/boot/session";
+import { isUnknownRecord } from "./types";
 
 /**
  * Meet-local guard on the shared suite router: the `requiresAdmin` role check
@@ -28,8 +29,14 @@ function installMeetGuard(r: Router) {
 				// userResource onError already redirects to /login on auth errors.
 				return false;
 			}
-			const user = userResource.data as Record<string, unknown> | null;
-			const isAdmin = (user?.roles as string[])?.some((r) =>
+			const user = userResource.data;
+			const roles =
+				isUnknownRecord(user) &&
+				Array.isArray(user.roles) &&
+				user.roles.every((role) => typeof role === "string")
+					? user.roles
+					: [];
+			const isAdmin = roles.some((r) =>
 				["System Manager", "Administrator"].includes(r),
 			);
 			if (!isAdmin) {

--- a/frontend/src/apps/meet/types.ts
+++ b/frontend/src/apps/meet/types.ts
@@ -49,10 +49,156 @@ export interface PresenceJoinResponse {
 export interface UserData {
 	name: string;
 	userId: string;
-	avatar?: string;
+	avatar?: string | null;
 	audio_enabled: boolean;
 	video_enabled: boolean;
 	is_guest?: boolean;
+	isHost?: boolean;
+}
+
+export interface JoinUserData {
+	name?: string;
+	userId?: string;
+	avatar?: string | null;
+	audio_enabled?: boolean;
+	video_enabled?: boolean;
+	is_guest?: boolean;
+	isHost?: boolean;
+}
+
+export interface JoinPayload {
+	status?: string;
+	lobby_token?: string;
+	auth_token?: string;
+	guest_id?: string;
+	guest_name?: string;
+	meeting_id?: string;
+	user_id?: string;
+	sfu_url?: string;
+	sfu_port?: string | number;
+	expires_in?: number;
+	codec_strategy?: string;
+	e2ee_required?: boolean;
+	is_host?: boolean;
+	is_cohost?: boolean;
+	host_only_chat?: boolean;
+	recording_enabled?: boolean;
+	user_data?: JoinUserData;
+	recording?: {
+		name: string;
+		status:
+			| "Pending"
+			| "Recording"
+			| "Interrupted"
+			| "Stopping"
+			| "Processing"
+			| "Ready"
+			| "Partial"
+			| "Failed";
+		started_at?: string;
+		capture_started_at?: string;
+		state_revision: number;
+	} | null;
+}
+
+export interface JoinRoomMediaState {
+	audio_enabled?: boolean;
+	video_enabled?: boolean;
+}
+
+export interface DeviceChangedEvent {
+	type: "camera" | "microphone" | "speaker";
+	deviceId: string;
+}
+
+export function isUnknownRecord(
+	value: unknown,
+): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function optionalBoolean(value: unknown): boolean | undefined {
+	return typeof value === "boolean" ? value : undefined;
+}
+
+function normalizeJoinUserData(value: unknown): JoinUserData | undefined {
+	if (!isUnknownRecord(value)) return undefined;
+	return {
+		name: optionalString(value.name),
+		userId: optionalString(value.userId),
+		avatar:
+			value.avatar === null ? null : optionalString(value.avatar),
+		audio_enabled: optionalBoolean(value.audio_enabled),
+		video_enabled: optionalBoolean(value.video_enabled),
+		is_guest: optionalBoolean(value.is_guest),
+		isHost: optionalBoolean(value.isHost),
+	};
+}
+
+const RECORDING_STATUSES = new Set<NonNullable<JoinPayload["recording"]>["status"]>([
+	"Pending",
+	"Recording",
+	"Interrupted",
+	"Stopping",
+	"Processing",
+	"Ready",
+	"Partial",
+	"Failed",
+]);
+
+function normalizeRecording(value: unknown): JoinPayload["recording"] | undefined {
+	if (value === null) return null;
+	if (
+		!isUnknownRecord(value) ||
+		typeof value.name !== "string" ||
+		typeof value.status !== "string" ||
+		!RECORDING_STATUSES.has(
+			value.status as NonNullable<JoinPayload["recording"]>["status"],
+		) ||
+		typeof value.state_revision !== "number"
+	) {
+		return undefined;
+	}
+	return {
+		name: value.name,
+		status: value.status as NonNullable<JoinPayload["recording"]>["status"],
+		started_at: optionalString(value.started_at),
+		capture_started_at: optionalString(value.capture_started_at),
+		state_revision: value.state_revision,
+	};
+}
+
+export function normalizeJoinPayload(value: unknown): JoinPayload | null {
+	if (!isUnknownRecord(value)) return null;
+	const sfuPort =
+		typeof value.sfu_port === "string" || typeof value.sfu_port === "number"
+			? value.sfu_port
+			: undefined;
+	return {
+		status: optionalString(value.status),
+		lobby_token: optionalString(value.lobby_token),
+		auth_token: optionalString(value.auth_token),
+		guest_id: optionalString(value.guest_id),
+		guest_name: optionalString(value.guest_name),
+		meeting_id: optionalString(value.meeting_id),
+		user_id: optionalString(value.user_id),
+		sfu_url: optionalString(value.sfu_url),
+		sfu_port: sfuPort,
+		expires_in:
+			typeof value.expires_in === "number" ? value.expires_in : undefined,
+		codec_strategy: optionalString(value.codec_strategy),
+		e2ee_required: optionalBoolean(value.e2ee_required),
+		is_host: optionalBoolean(value.is_host),
+		is_cohost: optionalBoolean(value.is_cohost),
+		host_only_chat: optionalBoolean(value.host_only_chat),
+		recording_enabled: optionalBoolean(value.recording_enabled),
+		user_data: normalizeJoinUserData(value.user_data),
+		recording: normalizeRecording(value.recording),
+	};
 }
 
 export interface ParticipantJoinedEvent {

--- a/frontend/src/apps/meet/utils/SFUClient.ts
+++ b/frontend/src/apps/meet/utils/SFUClient.ts
@@ -2,6 +2,26 @@
 // For license information, please see license.txt
 
 import { frappeRequest } from "frappe-ui";
+import type {
+	AppData,
+	DtlsParameters,
+	IceCandidate,
+	IceParameters,
+	MediaKind,
+	RtpCapabilities,
+	RtpParameters,
+} from "mediasoup-client/types";
+import {
+	isUnknownRecord,
+	type JoinPayload,
+	type JoinRoomMediaState,
+	type JoinUserData,
+	normalizeJoinPayload,
+} from "../types";
+import {
+	normalizeParticipantData,
+	type ParticipantData,
+} from "./media/ParticipantManager";
 import { normalizeCodecStrategy } from "./media/codecStrategy";
 import type { E2eeEpochEnvelope } from "./media/E2EEEpochSignaling";
 import { getE2EETransformCapability } from "./media/e2ee";
@@ -19,7 +39,7 @@ export interface ConnectionDetails {
 	e2eeRequired: boolean;
 	isHost: boolean;
 	isCohost: boolean;
-	userData?: Record<string, unknown>;
+	userData?: JoinUserData;
 }
 
 /**
@@ -28,7 +48,7 @@ export interface ConnectionDetails {
  * auth_token + sfu_url. Lobby-only payloads (lobby_token / waiting) return null.
  */
 export function connectionDetailsFromJoinPayload(
-	payload: Record<string, unknown>,
+	payload: JoinPayload,
 	options: {
 		guestAuthToken?: string | null;
 		guestId?: string | null;
@@ -74,7 +94,7 @@ export function connectionDetailsFromJoinPayload(
 		options.guestId ||
 			options.guestAuthToken ||
 			payload.guest_id ||
-			(payload.user_data as Record<string, unknown> | undefined)?.is_guest,
+			payload.user_data?.is_guest,
 	);
 
 	if (options.guestId) {
@@ -99,7 +119,7 @@ export function connectionDetailsFromJoinPayload(
 				? String(payload.sfu_port)
 				: null,
 		userData:
-			(payload.user_data as Record<string, unknown> | undefined) ||
+			payload.user_data ||
 			(isGuest
 				? {
 						name: options.guestName || payload.guest_name || "Guest",
@@ -107,9 +127,7 @@ export function connectionDetailsFromJoinPayload(
 					}
 				: undefined),
 		tokenExpiresAt: Date.now() + expiresInSeconds * 1000,
-		codecStrategy: normalizeCodecStrategy(
-			(payload.codec_strategy as string) || "svc",
-		),
+		codecStrategy: normalizeCodecStrategy(payload.codec_strategy || "svc"),
 		e2eeRequired: Boolean(payload.e2ee_required),
 		isHost: Boolean(payload.is_host),
 		isCohost: Boolean(payload.is_cohost),
@@ -126,73 +144,51 @@ interface ConnectionStatus {
 interface SFUResponse {
 	success: boolean;
 	error?: string;
-	[key: string]: unknown;
 }
 
-interface SFUConnectionDetailsResponse {
-	sfu_url: string;
-	sfu_port: string;
-	auth_token: string;
-	user_id: string;
-	meeting_id: string;
-	user_data: Record<string, unknown>;
-	expires_in: number;
-	codec_strategy: string;
-	e2ee_required?: boolean;
-	is_host?: boolean;
-	is_cohost?: boolean;
-}
-
-interface SFUGuestConnectionDetailsResponse {
-	sfu_url: string;
-	sfu_port: string;
-	codec_strategy: string;
-	e2ee_required?: boolean;
-	is_host?: boolean;
-	is_cohost?: boolean;
-}
-
-interface SFUTokenRefreshResponse {
-	auth_token: string;
-	expires_in: number;
-	codec_strategy: string;
-	e2ee_required?: boolean;
-}
-
-interface SFURouterCapabilitiesResponse {
-	rtpCapabilities: unknown;
-	[key: string]: unknown;
-}
-
-interface SFUWebRtcTransportResponse {
+export interface SFUWebRtcTransportResponse {
 	id: string;
-	iceParameters: unknown;
-	iceCandidates: unknown;
-	dtlsParameters: unknown;
-	[key: string]: unknown;
+	iceParameters: IceParameters;
+	iceCandidates: IceCandidate[];
+	dtlsParameters: DtlsParameters;
 }
 
-interface SFUProducerResponse {
+export interface SFUProducerResponse {
 	id: string;
-	[key: string]: unknown;
 }
 
-interface SFUConsumerResponse {
+export interface SFUConsumerResponse {
 	id: string;
 	producerId: string;
-	kind: string;
-	rtpParameters: unknown;
+	kind: MediaKind;
+	rtpParameters: RtpParameters;
 	isScreen?: boolean;
-	appData?: {
-		type?: string;
-	};
+	appData?: AppData;
 	senderId?: number;
-	[key: string]: unknown;
 }
 
-interface SFUParticipantsResponse {
-	participants: unknown[];
-	[key: string]: unknown;
+export interface SFUExistingProducer {
+	id: string;
+	participantId: string;
+	kind?: MediaKind;
+	isScreen: boolean;
+}
+
+export interface ProducerCloseMetadata {
+	reason?: "user-click" | "track-ended" | "publish-failed" | "cleanup";
+	source?: "screen-share";
+	producerId?: string;
+	details?: {
+		trackId?: string;
+		trackReadyState?: MediaStreamTrackState;
+		trackSettings?: MediaTrackSettings;
+		message?: string;
+	};
+}
+
+export interface ScreenShareSignalData extends ProducerCloseMetadata {
+	startedAt?: number;
+	stoppedAt?: number;
 }
 
 type SFUEventHandler = (...args: unknown[]) => void;
@@ -210,6 +206,95 @@ export class SFURequestError extends Error {
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
+
+function requireJoinPayload(value: unknown, context: string): JoinPayload {
+	const payload = normalizeJoinPayload(value);
+	if (!payload) throw new Error(`Invalid ${context} response`);
+	return payload;
+}
+
+function requireString(value: unknown, field: string, context: string): string {
+	if (typeof value !== "string" || !value) {
+		throw new Error(`Invalid ${context} response: missing ${field}`);
+	}
+	return value;
+}
+
+function requireObject(value: unknown, context: string): Record<string, unknown> {
+	if (!isUnknownRecord(value)) throw new Error(`Invalid ${context} response`);
+	return value;
+}
+
+function normalizeExistingProducer(value: unknown): SFUExistingProducer | null {
+	if (!isUnknownRecord(value) || typeof value.id !== "string") return null;
+	const participantId = [value.participantId, value.user_id, value.userId].find(
+		(candidate): candidate is string => typeof candidate === "string" && !!candidate,
+	);
+	if (!participantId) return null;
+	return {
+		id: value.id,
+		participantId,
+		kind: value.kind === "audio" || value.kind === "video" ? value.kind : undefined,
+		isScreen: value.isScreen === true,
+	};
+}
+
+function normalizeRtpCapabilities(value: unknown): RtpCapabilities {
+	const payload = requireObject(value, "router RTP capabilities");
+	const codecs = payload.codecs;
+	if (!Array.isArray(codecs)) {
+		throw new Error("Invalid router RTP capabilities response: missing codecs");
+	}
+	for (const codec of codecs) {
+		if (
+			!isUnknownRecord(codec) ||
+			typeof codec.mimeType !== "string" ||
+			typeof codec.clockRate !== "number"
+		) {
+			throw new Error("Invalid router RTP capabilities response: malformed codec");
+		}
+	}
+	return payload as RtpCapabilities;
+}
+
+function normalizeTransportResponse(value: unknown): SFUWebRtcTransportResponse {
+	const payload = requireObject(value, "WebRTC transport");
+	if (
+		typeof payload.id !== "string" ||
+		!isUnknownRecord(payload.iceParameters) ||
+		!Array.isArray(payload.iceCandidates) ||
+		!isUnknownRecord(payload.dtlsParameters)
+	) {
+		throw new Error("Invalid WebRTC transport response");
+	}
+	return {
+		id: payload.id,
+		iceParameters: payload.iceParameters as IceParameters,
+		iceCandidates: payload.iceCandidates as IceCandidate[],
+		dtlsParameters: payload.dtlsParameters as DtlsParameters,
+	};
+}
+
+function normalizeConsumerResponse(value: unknown): SFUConsumerResponse {
+	const payload = requireObject(value, "consumer");
+	if (
+		typeof payload.id !== "string" ||
+		typeof payload.producerId !== "string" ||
+		(payload.kind !== "audio" && payload.kind !== "video") ||
+		!isUnknownRecord(payload.rtpParameters)
+	) {
+		throw new Error("Invalid consumer response");
+	}
+	return {
+		id: payload.id,
+		producerId: payload.producerId,
+		kind: payload.kind,
+		rtpParameters: payload.rtpParameters as RtpParameters,
+		isScreen: payload.isScreen === true,
+		appData: isUnknownRecord(payload.appData) ? payload.appData : undefined,
+		senderId: typeof payload.senderId === "number" ? payload.senderId : undefined,
+	};
+}
 
 export class SFUClient {
 	signalChannel: SignalChannel;
@@ -326,22 +411,27 @@ export class SFUClient {
 			}
 
 			try {
-				const response = (await frappeRequest({
+				const response = requireJoinPayload(await frappeRequest({
 					url: "suite.meet.api.meeting.get_guest_sfu_connection_details",
 					params: {
 						meeting_id: meetingId,
 						guest_token: guestAuthToken,
 					},
-				})) as SFUGuestConnectionDetailsResponse;
+				}), "guest SFU connection details");
+				const sfuUrl = requireString(
+					response.sfu_url,
+					"sfu_url",
+					"guest SFU connection details",
+				);
 
 				return {
 					authToken: guestAuthToken,
 					meetingId: meetingId,
 					userId: guestId,
-					sfuUrl: response.sfu_url,
-					sfuPort: response.sfu_port,
+					sfuUrl,
+					sfuPort: response.sfu_port == null ? null : String(response.sfu_port),
 					userData: {
-						name: guestName,
+						name: guestName ?? undefined,
 						is_guest: true,
 					},
 					tokenExpiresAt: Date.now() + 24 * 60 * 60 * 1000,
@@ -356,24 +446,44 @@ export class SFUClient {
 			}
 		}
 
-		const response = (await frappeRequest({
+		const response = requireJoinPayload(await frappeRequest({
 			url: "suite.meet.api.meeting.get_sfu_connection_details",
 			params: { meeting_id: meetingId },
-		})) as SFUConnectionDetailsResponse;
+		}), "SFU connection details");
+		const authToken = requireString(
+			response.auth_token,
+			"auth_token",
+			"SFU connection details",
+		);
+		const responseMeetingId = requireString(
+			response.meeting_id,
+			"meeting_id",
+			"SFU connection details",
+		);
+		const userId = requireString(
+			response.user_id,
+			"user_id",
+			"SFU connection details",
+		);
+		const sfuUrl = requireString(
+			response.sfu_url,
+			"sfu_url",
+			"SFU connection details",
+		);
 
 		const expiresInSeconds =
 			typeof response.expires_in === "number" ? response.expires_in : 3600;
 		const tokenExpiresAt = Date.now() + expiresInSeconds * 1000;
 
 		return {
-			authToken: response.auth_token,
-			meetingId: response.meeting_id,
-			userId: response.user_id,
-			sfuUrl: response.sfu_url,
-			sfuPort: response.sfu_port,
+			authToken,
+			meetingId: responseMeetingId,
+			userId,
+			sfuUrl,
+			sfuPort: response.sfu_port == null ? null : String(response.sfu_port),
 			userData: response.user_data,
 			tokenExpiresAt,
-			codecStrategy: normalizeCodecStrategy(response.codec_strategy),
+			codecStrategy: normalizeCodecStrategy(response.codec_strategy || "svc"),
 			e2eeRequired: Boolean(response.e2ee_required),
 			isHost: Boolean(response.is_host),
 			isCohost: Boolean(response.is_cohost),
@@ -472,15 +582,20 @@ export class SFUClient {
 		try {
 			this.isRefreshingToken = true;
 
-			const response = (await frappeRequest({
+		const response = requireJoinPayload(await frappeRequest({
 				url: "suite.meet.api.meeting.refresh_sfu_token",
 				params: { meeting_id: this.connectionDetails.meetingId },
-			})) as SFUTokenRefreshResponse;
+			}), "SFU token refresh");
+			const authToken = requireString(
+				response.auth_token,
+				"auth_token",
+				"SFU token refresh",
+			);
 
 			const expiresInSeconds =
 				typeof response.expires_in === "number" ? response.expires_in : 3600;
 
-			this.connectionDetails.authToken = response.auth_token;
+			this.connectionDetails.authToken = authToken;
 			this.connectionDetails.tokenExpiresAt =
 				Date.now() + expiresInSeconds * 1000;
 			this.connectionDetails.codecStrategy = normalizeCodecStrategy(
@@ -489,11 +604,11 @@ export class SFUClient {
 			this.connectionDetails.e2eeRequired =
 				this.connectionDetails.e2eeRequired || Boolean(response.e2ee_required);
 
-			this.signalChannel.updateAuth(response.auth_token);
+			this.signalChannel.updateAuth(authToken);
 
 			if (!skipServerUpdate && this.connected) {
 				await this.sendRequest("auth:update_token", {
-					token: response.auth_token,
+					token: authToken,
 				});
 			} else if (!this.connected) {
 				console.log(
@@ -503,7 +618,7 @@ export class SFUClient {
 
 			this.scheduleTokenRefresh();
 
-			return response.auth_token;
+			return authToken;
 		} catch (error) {
 			console.warn("Token refresh failed:", error);
 			throw error;
@@ -647,47 +762,26 @@ export class SFUClient {
 
 	// ==================== WEBRTC OPERATIONS ====================
 
-	async getRouterRtpCapabilities(): Promise<unknown> {
-		const resp = (await this.sendRequest(
+	async getRouterRtpCapabilities(): Promise<RtpCapabilities> {
+		const response = requireObject(await this.sendRequest(
 			"get_router_rtp_capabilities",
 			{},
-		)) as SFURouterCapabilitiesResponse;
-		try {
-			const payload = resp?.rtpCapabilities || resp;
-			return JSON.parse(JSON.stringify(payload));
-		} catch (err: unknown) {
-			console.warn("Failed to deep-clone router RTP capabilities:", err);
-			return resp?.rtpCapabilities || resp;
-		}
+		), "router RTP capabilities");
+		return normalizeRtpCapabilities(response.rtpCapabilities ?? response);
 	}
 
-	async createWebRtcTransport(direction: string): Promise<{
-		id: string;
-		iceParameters: unknown;
-		iceCandidates: unknown;
-		dtlsParameters: unknown;
-	}> {
-		const response = (await this.sendRequest("create_webrtc_transport", {
+	async createWebRtcTransport(
+		direction: "send" | "recv",
+	): Promise<SFUWebRtcTransportResponse> {
+		return normalizeTransportResponse(await this.sendRequest("create_webrtc_transport", {
 			direction,
 			encryptionEnabled: this.connectionDetails.e2eeRequired,
-		})) as SFUWebRtcTransportResponse;
-		try {
-			const clean = JSON.parse(JSON.stringify(response));
-			const { id, iceParameters, iceCandidates, dtlsParameters } = clean;
-			return { id, iceParameters, iceCandidates, dtlsParameters };
-		} catch (err: unknown) {
-			console.warn(
-				"Failed to deep-clone transport response, returning raw response",
-				err,
-			);
-			const { id, iceParameters, iceCandidates, dtlsParameters } = response;
-			return { id, iceParameters, iceCandidates, dtlsParameters };
-		}
+		}));
 	}
 
 	async connectWebRtcTransport(
 		transportId: string,
-		dtlsParameters: unknown,
+		dtlsParameters: DtlsParameters,
 	): Promise<void> {
 		console.log(`Connecting transport ${transportId} to SFU...`);
 		console.log("DTLS Parameters:", dtlsParameters);
@@ -700,43 +794,47 @@ export class SFUClient {
 		console.log(`Transport ${transportId} connected successfully`);
 	}
 
-	async restartWebRtcTransportIce(transportId: string): Promise<unknown> {
-		const response = (await this.sendRequest("restart_webrtc_transport_ice", {
+	async restartWebRtcTransportIce(transportId: string): Promise<IceParameters> {
+		const response = requireObject(await this.sendRequest("restart_webrtc_transport_ice", {
 			transportId,
-		})) as Record<string, unknown>;
-		return response.iceParameters;
+		}), "ICE restart");
+		if (!isUnknownRecord(response.iceParameters)) {
+			throw new Error("Invalid ICE restart response");
+		}
+		return response.iceParameters as IceParameters;
 	}
 
 	async createProducer(
 		transportId: string,
-		rtpParameters: unknown,
-		kind: string,
-		appData: unknown = {},
+		rtpParameters: RtpParameters,
+		kind: MediaKind,
+		appData: AppData = {},
 	): Promise<SFUProducerResponse> {
-		return (await this.sendRequest("create_producer", {
+		const response = requireObject(await this.sendRequest("create_producer", {
 			transportId,
 			rtpParameters,
 			kind,
 			appData,
-		})) as SFUProducerResponse;
+		}), "producer");
+		return { id: requireString(response.id, "id", "producer") };
 	}
 
 	async createConsumer(
 		transportId: string,
 		producerId: string,
-		rtpCapabilities: unknown,
+		rtpCapabilities: RtpCapabilities,
 	): Promise<SFUConsumerResponse> {
 		console.log(`Creating consumer for producer ${producerId} @ ${Date.now()}`);
-		return (await this.sendRequest("create_consumer", {
+		return normalizeConsumerResponse(await this.sendRequest("create_consumer", {
 			transportId,
 			producerId,
 			rtpCapabilities,
-		})) as SFUConsumerResponse;
+		}));
 	}
 
 	async closeProducer(
 		producerId: string,
-		metadata: Record<string, unknown> = {},
+		metadata: ProducerCloseMetadata = {},
 	): Promise<unknown> {
 		return this.sendRequest("close_producer", { producerId, ...metadata });
 	}
@@ -778,30 +876,38 @@ export class SFUClient {
 
 	// ==================== ROOM OPERATIONS ====================
 
-	async getExistingProducers(roomId: string | null = null): Promise<unknown[]> {
+	async getExistingProducers(
+		roomId: string | null = null,
+	): Promise<SFUExistingProducer[]> {
 		const requestData = roomId ? { roomId } : {};
-		const response = (await this.sendRequest(
+		const response = requireObject(await this.sendRequest(
 			"get_existing_producers",
 			requestData,
-		)) as Record<string, unknown>;
-		return (response.producers as unknown[]) || [];
+		), "existing producers");
+		if (!Array.isArray(response.producers)) return [];
+		return response.producers
+			.map(normalizeExistingProducer)
+			.filter((producer): producer is SFUExistingProducer => producer !== null);
 	}
 
-	async getRoomParticipants(): Promise<unknown[]> {
-		const response = (await this.sendRequest(
+	async getRoomParticipants(): Promise<ParticipantData[]> {
+		const response = requireObject(await this.sendRequest(
 			"get_room_participants",
 			{},
-		)) as SFUParticipantsResponse;
-		return response.participants || [];
+		), "room participants");
+		if (!Array.isArray(response.participants)) return [];
+		return response.participants
+			.map(normalizeParticipantData)
+			.filter((participant): participant is ParticipantData => participant !== null);
 	}
 
 	// ==================== ROOM MANAGEMENT ====================
 
 	async joinRoom(
 		roomId: string,
-		userData: unknown,
-		mediaState: unknown,
-	): Promise<unknown> {
+		userData: JoinUserData,
+		mediaState: JoinRoomMediaState,
+	): Promise<{ success: boolean; senderId?: number }> {
 		const e2eeMode = this.getE2EEMode();
 		const e2eeShouldBeActive = this.isE2EERequired();
 		const result = (await this.sendRequest("join_room", {
@@ -815,11 +921,17 @@ export class SFUClient {
 					mode: e2eeMode,
 				},
 			},
-		})) as { success?: boolean; senderId?: number };
-		if (result && typeof result.senderId === "number") {
-			this.setOwnSenderId(result.senderId);
+		}));
+		const response = requireObject(result, "join room");
+		if (response.success !== true) throw new Error("Invalid join room response");
+		const normalized = {
+			success: true,
+			senderId: typeof response.senderId === "number" ? response.senderId : undefined,
+		};
+		if (normalized.senderId !== undefined) {
+			this.setOwnSenderId(normalized.senderId);
 		}
-		return result;
+		return normalized;
 	}
 
 	setE2EERequired(required: boolean): void {
@@ -867,7 +979,10 @@ export class SFUClient {
 		this.sendEvent("media_control", { action });
 	}
 
-	sendScreenShare(action: unknown, shareData: unknown = {}): void {
+	sendScreenShare(
+		action: "start_share" | "stop_share",
+		shareData: ScreenShareSignalData = {},
+	): void {
 		this.sendEvent("screen_share", { action, shareData });
 	}
 
@@ -944,8 +1059,23 @@ export class SFUClient {
 			this.pendingRequestRejectors.add(rejectPending);
 
 			try {
-				this.signalChannel.emit(event, data, (response: SFUResponse) => {
+				this.signalChannel.emit(event, data, (rawResponse: unknown) => {
 					finish(() => {
+						if (
+							!isUnknownRecord(rawResponse) ||
+							typeof rawResponse.success !== "boolean"
+						) {
+							reject(new Error(`Malformed SFU response: ${event}`));
+							return;
+						}
+						const response: SFUResponse = {
+							...rawResponse,
+							success: rawResponse.success,
+							error:
+								typeof rawResponse.error === "string"
+									? rawResponse.error
+									: undefined,
+						};
 						if (response.success) {
 							resolve(response);
 						} else {

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -13,16 +13,21 @@ import { ParticipantManager } from "./media/ParticipantManager";
 import { TransportManager } from "./media/TransportManager";
 import { VideoElementManager } from "./media/VideoElementManager";
 import type { ConnectionDetails, SFUClient } from "./SFUClient";
+import type { JoinRoomMediaState, JoinUserData } from "../types";
+import type { User } from "../composables/useCurrentUser";
 import {
 	SFUConnectionManager,
 	type SFUEventHandlers,
 } from "./sfu/SFUConnectionManager";
-import { SFUMediaManager } from "./sfu/SFUMediaManager";
+import {
+	SFUMediaManager,
+	type PublishedMedia,
+} from "./sfu/SFUMediaManager";
 import { SFURecoveryManager } from "./sfu/SFURecoveryManager";
 
 interface SFUMeetingManagerOptions {
 	meetingId: string;
-	currentUser: unknown;
+	currentUser: User | null;
 	eventHandlers?: SFUEventHandlers;
 }
 
@@ -118,7 +123,10 @@ export class SFUMeetingManager {
 		return this.connectionManager.connect(authToken, prefetchedDetails);
 	}
 
-	async joinRoom(userData: unknown, mediaState: unknown): Promise<boolean> {
+	async joinRoom(
+		userData: JoinUserData,
+		mediaState: JoinRoomMediaState,
+	): Promise<boolean> {
 		return this.connectionManager.joinRoom(userData, mediaState);
 	}
 
@@ -133,7 +141,7 @@ export class SFUMeetingManager {
 	async publishMedia(
 		localStream: MediaStream,
 		options: { publishVideo?: boolean; publishAudio?: boolean } = {},
-	): Promise<Record<string, unknown>> {
+	): Promise<PublishedMedia> {
 		return this.mediaManager.publishMedia(localStream, options);
 	}
 

--- a/frontend/src/apps/meet/utils/__tests__/SFUClient.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUClient.test.ts
@@ -301,9 +301,7 @@ describe("sendChatMessage", () => {
 			success: true,
 			timestamp: "2026-07-28T12:00:00.000Z",
 		});
-		await client.sendChatMessage(42 as unknown as string, {
-			clientId: 99 as unknown as string,
-		});
+		await Reflect.apply(client.sendChatMessage, client, [42, { clientId: 99 }]);
 		expect(sendRequest).toHaveBeenCalledWith("chat:send", {
 			message: "42",
 			clientId: "99",
@@ -689,28 +687,16 @@ describe("E2EE signaling payloads", () => {
 		).RTCRtpReceiver;
 
 		try {
-			(
-				globalThis as typeof globalThis & {
-					RTCRtpSender?: {
-						prototype?: { createEncodedStreams?: () => void };
-					};
-				}
-			).RTCRtpSender = {
+			Reflect.set(globalThis, "RTCRtpSender", {
 				prototype: {
 					createEncodedStreams: () => {},
 				},
-			} as unknown as typeof globalThis.RTCRtpSender;
-			(
-				globalThis as typeof globalThis & {
-					RTCRtpReceiver?: {
-						prototype?: { createEncodedStreams?: () => void };
-					};
-				}
-			).RTCRtpReceiver = {
+			});
+			Reflect.set(globalThis, "RTCRtpReceiver", {
 				prototype: {
 					createEncodedStreams: () => {},
 				},
-			} as unknown as typeof globalThis.RTCRtpReceiver;
+			});
 
 			const sendRequestSpy = vi
 				.spyOn(client, "sendRequest")

--- a/frontend/src/apps/meet/utils/identity/DeviceIdentityProvider.ts
+++ b/frontend/src/apps/meet/utils/identity/DeviceIdentityProvider.ts
@@ -139,12 +139,10 @@ async function loadOrCreateKeyPair(
 	publicKeyId: string,
 ): Promise<CryptoKeyPair> {
 	const privJwk = await idbGet(privateKeyId);
-	if (privJwk) {
+	const pubJwk = await idbGet(publicKeyId);
+	if (privJwk && pubJwk) {
 		const privateKey = await loadPrivateSigningKey(privateKeyId, privJwk);
-		const pubJwk = await idbGet(publicKeyId);
-		const publicKey = pubJwk
-			? await loadPublicVerifyKey(publicKeyId, pubJwk)
-			: (null as unknown as CryptoKey);
+		const publicKey = await loadPublicVerifyKey(publicKeyId, pubJwk);
 		return { privateKey, publicKey };
 	}
 	const kp = await ed25519KeyPair();

--- a/frontend/src/apps/meet/utils/media/ConsumerManager.ts
+++ b/frontend/src/apps/meet/utils/media/ConsumerManager.ts
@@ -3,16 +3,16 @@
  * Handles MediaSoup consumer lifecycle and stream management
  */
 
-import type { Consumer } from "mediasoup-client/types";
+import type { AppData, Consumer, MediaKind } from "mediasoup-client/types";
 
 export interface ConsumerEntry {
 	id: string;
 	participantId: string;
 	producerId: string;
-	kind: string;
+	kind: MediaKind;
 	isScreen: boolean;
 	track?: MediaStreamTrack;
-	appData?: Record<string, unknown>;
+	appData?: AppData;
 	createdAt: number;
 	consumer: Consumer;
 	close?: () => void;
@@ -24,7 +24,7 @@ interface ConsumerLostInfo {
 	consumerId: string;
 	participantId: string;
 	producerId: string;
-	kind: string;
+	kind: MediaKind;
 	isScreen: boolean;
 }
 
@@ -34,7 +34,7 @@ interface ConsumerEventHandlers {
 	onConsumerUpdated?: (
 		consumerId: string,
 		updatedConsumer: ConsumerEntry,
-		updates: Record<string, unknown>,
+		updates: Partial<ConsumerEntry>,
 	) => void;
 	onAllConsumersCleared?: (consumerIds: string[]) => void;
 	onConsumerLost?: (info: ConsumerLostInfo) => void;
@@ -249,7 +249,7 @@ export class ConsumerManager {
 
 	updateConsumer(
 		consumerId: string,
-		updates: Record<string, unknown>,
+		updates: Partial<ConsumerEntry>,
 	): ConsumerEntry | null {
 		const consumer = this.consumers.get(consumerId);
 		if (consumer) {

--- a/frontend/src/apps/meet/utils/media/E2EEHandshakeController.ts
+++ b/frontend/src/apps/meet/utils/media/E2EEHandshakeController.ts
@@ -245,16 +245,7 @@ export class E2EEHandshakeController {
 
 	private async listCurrentNonHostSenderIds(): Promise<number[]> {
 		try {
-			const participants = (await this.deps.sfuClient.getRoomParticipants()) as
-				| Array<{
-						user_id?: string;
-						sender_id?: number;
-						senderId?: number;
-						is_host?: boolean;
-						isHost?: boolean;
-					}>
-				| undefined;
-			if (!Array.isArray(participants)) return [];
+			const participants = await this.deps.sfuClient.getRoomParticipants();
 			const hostParticipantId = this.ownParticipantId();
 			return participants
 				.filter((p) => {
@@ -266,7 +257,10 @@ export class E2EEHandshakeController {
 						p.user_id !== hostParticipantId
 					);
 				})
-				.map((p) => (p.sender_id ?? p.senderId) as number);
+				.flatMap((p) => {
+					const senderId = p.sender_id ?? p.senderId;
+					return typeof senderId === "number" ? [senderId] : [];
+				});
 		} catch (error) {
 			console.warn(
 				"[DEBUG-e2ee] listCurrentNonHostSenderIds: getRoomParticipants failed",

--- a/frontend/src/apps/meet/utils/media/E2EEMeeting.ts
+++ b/frontend/src/apps/meet/utils/media/E2EEMeeting.ts
@@ -582,7 +582,7 @@ export class E2EEMeeting {
 
 	private installScriptTransform(
 		target: TransformableSender | TransformableReceiver,
-		options: Record<string, unknown>,
+		options: E2EETransformOptions,
 	): Worker | null {
 		const RTCRtpScriptTransform = this.getRTCRtpScriptTransform();
 		if (!RTCRtpScriptTransform) return null;
@@ -604,5 +604,15 @@ export class E2EEMeeting {
 
 type RTCRtpScriptTransformConstructor = new (
 	worker: Worker,
-	options: Record<string, unknown>,
-) => unknown;
+	options: E2EETransformOptions,
+) => RTCRtpScriptTransform;
+
+type E2EETransformOptions = {
+	direction: "send" | "recv";
+	meetingSecret: Uint8Array;
+	keyVersion: number;
+	senderId: number;
+	mediaType: string;
+	senderSigningPrivateKey?: CryptoKey;
+	senderSigningPubs?: Array<[number, CryptoKey]>;
+};

--- a/frontend/src/apps/meet/utils/media/ParticipantManager.ts
+++ b/frontend/src/apps/meet/utils/media/ParticipantManager.ts
@@ -8,26 +8,42 @@ export interface Participant {
 	user_name: string;
 	avatar: string | null;
 	initials: string;
+	participantId?: string;
 	audio_enabled?: boolean;
 	video_enabled?: boolean;
 	is_guest?: boolean;
-	[key: string]: unknown;
+	isHost?: boolean;
+	networkQuality?: string;
+	userData?: ParticipantUserData;
+	isLocalScreenShare?: boolean;
+}
+
+export interface ParticipantUserData {
+	name?: string;
+	avatar?: string | null;
+	audio_enabled?: boolean;
+	video_enabled?: boolean;
+	is_guest?: boolean;
+	isHost?: boolean;
 }
 
 export interface ParticipantData {
 	participantId?: string;
 	user_id?: string;
 	user_name?: string;
-	userData?: {
-		name?: string;
-		avatar?: string | null;
-		audio_enabled?: boolean;
-		video_enabled?: boolean;
-		is_guest?: boolean;
-	};
+	userData?: ParticipantUserData;
 	avatar?: string | null;
-	[key: string]: unknown;
+	audio_enabled?: boolean;
+	video_enabled?: boolean;
+	is_guest?: boolean;
+	isHost?: boolean;
+	networkQuality?: string;
+	senderId?: number;
+	sender_id?: number;
+	is_host?: boolean;
 }
+
+export type ParticipantUpdate = Partial<Participant>;
 
 interface MediaStateUpdate {
 	audioEnabled?: boolean;
@@ -43,7 +59,7 @@ interface ParticipantEventHandlers {
 	onParticipantUpdated?: (
 		participantId: string,
 		updatedParticipant: Participant,
-		updates: Record<string, unknown>,
+		updates: ParticipantUpdate,
 	) => void;
 	onAllParticipantsCleared?: (participantIds: string[]) => void;
 }
@@ -76,7 +92,10 @@ export class ParticipantManager {
 			audio_enabled: participantData.userData?.audio_enabled,
 			video_enabled: participantData.userData?.video_enabled,
 			is_guest: participantData.userData?.is_guest,
-			...participantData,
+			isHost: participantData.userData?.isHost ?? participantData.isHost,
+			networkQuality: participantData.networkQuality,
+			participantId: participantData.participantId,
+			userData: participantData.userData,
 		};
 
 		this.participants.set(participant.user_id, participant);
@@ -102,7 +121,7 @@ export class ParticipantManager {
 
 	updateParticipant(
 		participantId: string,
-		updates: Record<string, unknown>,
+		updates: ParticipantUpdate,
 	): Participant | null {
 		const participant = this.participants.get(participantId);
 		if (participant) {
@@ -208,4 +227,72 @@ export class ParticipantManager {
 			}
 		}
 	}
+}
+
+function isObject(value: unknown): value is object {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(value: object, key: string): string | undefined {
+	if (!(key in value)) return undefined;
+	const field = Reflect.get(value, key);
+	return typeof field === "string" ? field : undefined;
+}
+
+function booleanField(value: object, key: string): boolean | undefined {
+	if (!(key in value)) return undefined;
+	const field = Reflect.get(value, key);
+	return typeof field === "boolean" ? field : undefined;
+}
+
+function numberField(value: object, key: string): number | undefined {
+	if (!(key in value)) return undefined;
+	const field = Reflect.get(value, key);
+	return typeof field === "number" && Number.isFinite(field) ? field : undefined;
+}
+
+function normalizeUserData(value: unknown): ParticipantUserData | undefined {
+	if (!isObject(value)) return undefined;
+	const avatar = "avatar" in value && value.avatar === null
+		? null
+		: stringField(value, "avatar");
+	return {
+		name: stringField(value, "name"),
+		avatar,
+		audio_enabled: booleanField(value, "audio_enabled"),
+		video_enabled: booleanField(value, "video_enabled"),
+		is_guest: booleanField(value, "is_guest"),
+		isHost: booleanField(value, "isHost"),
+	};
+}
+
+export function normalizeParticipantData(value: unknown): ParticipantData | null {
+	if (!isObject(value)) return null;
+	const participantId = stringField(value, "participantId");
+	const userId = stringField(value, "user_id") ?? stringField(value, "id");
+	if (!participantId && !userId) return null;
+	const nestedUserData =
+		"userData" in value
+			? normalizeUserData(value.userData)
+			: "info" in value
+				? normalizeUserData(value.info)
+				: undefined;
+	const avatar = "avatar" in value && value.avatar === null
+		? null
+		: stringField(value, "avatar");
+	return {
+		participantId: participantId ?? userId,
+		user_id: userId ?? participantId,
+		user_name: stringField(value, "user_name") ?? nestedUserData?.name,
+		userData: nestedUserData,
+		avatar,
+		audio_enabled: booleanField(value, "audio_enabled"),
+		video_enabled: booleanField(value, "video_enabled"),
+		is_guest: booleanField(value, "is_guest"),
+		isHost: booleanField(value, "isHost"),
+		networkQuality: stringField(value, "networkQuality"),
+		senderId: numberField(value, "senderId"),
+		sender_id: numberField(value, "sender_id"),
+		is_host: booleanField(value, "is_host"),
+	};
 }

--- a/frontend/src/apps/meet/utils/media/SignalChannel.ts
+++ b/frontend/src/apps/meet/utils/media/SignalChannel.ts
@@ -165,13 +165,10 @@ export class SocketIOSignalChannel implements SignalChannel {
 
 	updateAuth(token: string): void {
 		if (!this.socket) return;
-		(this.socket.auth as Record<string, unknown>).token = token;
-		const ioOpts = this.socket.io?.opts as Record<string, unknown> | undefined;
-		if (ioOpts && "auth" in ioOpts) {
-			ioOpts.auth = {
-				...((ioOpts.auth as Record<string, unknown> | undefined) || {}),
-				token,
-			};
-		}
+		this.socket.auth = { token };
+		const managerOptions = this.socket.io.opts as typeof this.socket.io.opts & {
+			auth?: { token?: string };
+		};
+		managerOptions.auth = { token };
 	}
 }

--- a/frontend/src/apps/meet/utils/media/TransportManager.ts
+++ b/frontend/src/apps/meet/utils/media/TransportManager.ts
@@ -1,4 +1,15 @@
-import type { Consumer, Producer } from "mediasoup-client/types";
+import type {
+	AppData,
+	Consumer,
+	ConsumerOptions,
+	Device,
+	DtlsParameters,
+	Producer,
+	ProducerOptions,
+	RtpCapabilities,
+	Transport,
+	TransportOptions,
+} from "mediasoup-client/types";
 import type { SFUClient } from "../SFUClient";
 import { resolveCodecStrategy } from "./codecStrategy";
 import {
@@ -50,49 +61,8 @@ type EventHandlers = {
 	onTransportConnectionStateChange?: TransportStateHandler;
 };
 
-type ConsumerParams = {
-	id: string;
-	producerId: string;
-	kind: string;
-	rtpParameters: unknown;
-	isScreen?: boolean;
-	appData?: {
-		type?: string;
-	};
-	senderId?: number;
-};
-
-type RouterCapabilities = {
-	codecs?: Array<{
-		mimeType?: string;
-		mime_type?: string;
-		scalabilityModes?: string[];
-	}>;
-} | null;
-
-type TransportLike = {
-	id: string;
-	connectionState: TransportConnectionState;
-	on: <TArgs extends unknown[]>(
-		event: string,
-		handler: (...args: TArgs) => void,
-	) => void;
-	close: () => void;
-	restartIce: (args: { iceParameters: unknown }) => Promise<void>;
-	produce?: (options: Record<string, unknown>) => Promise<Producer>;
-	consume?: (args: Record<string, unknown>) => Promise<Consumer>;
-	getStats: () => Promise<Map<string, TransportStatReport>>;
-};
-
-type DeviceLike = {
-	loaded: boolean;
-	rtpCapabilities?: {
-		codecs?: Array<{ mimeType: string }>;
-	};
-	load: (args: { routerRtpCapabilities: unknown }) => Promise<void>;
-	canProduce: (kind: string) => boolean;
-	createSendTransport: (args: Record<string, unknown>) => TransportLike;
-	createRecvTransport: (args: Record<string, unknown>) => TransportLike;
+type InsertableStreamRTCConfiguration = Partial<RTCConfiguration> & {
+	encodedInsertableStreams?: boolean;
 };
 
 async function applyScreenShareSenderPreferences(producer: {
@@ -117,16 +87,16 @@ function sleep(ms: number): Promise<void> {
 }
 
 export class TransportManager {
-	sendTransport: TransportLike | null;
-	recvTransport: TransportLike | null;
-	device: DeviceLike | null;
+	sendTransport: Transport | null;
+	recvTransport: Transport | null;
+	device: Device | null;
 	sfuClient: SFUClient | null;
-	routerRtpCapabilities: RouterCapabilities;
+	routerRtpCapabilities: RtpCapabilities | null;
 	activeVideoStrategy: string;
 	eventHandlers: EventHandlers;
 	e2eePolicy: E2EETransformPolicy;
-	private sendTransportCreation: Promise<TransportLike> | null = null;
-	private recvTransportCreation: Promise<TransportLike> | null = null;
+	private sendTransportCreation: Promise<Transport> | null = null;
+	private recvTransportCreation: Promise<Transport> | null = null;
 	private sendTransportGeneration = 0;
 	private recvTransportGeneration = 0;
 	private previousInboundPackets = new Map<
@@ -205,26 +175,12 @@ export class TransportManager {
 		return this.sfuClient;
 	}
 
-	private extractRouterRtpCapabilities(response: unknown): RouterCapabilities {
-		if (
-			typeof response === "object" &&
-			response !== null &&
-			"rtpCapabilities" in response
-		) {
-			return (response as { rtpCapabilities: RouterCapabilities })
-				.rtpCapabilities;
-		}
-		return response as RouterCapabilities;
-	}
-
 	async initializeDevice() {
 		if (this.device) return this.device;
 		const { Device } = await import("mediasoup-client");
 		const client = this.getClient();
-		this.device = new Device() as unknown as DeviceLike;
-		const routerCapsResp = await client.getRouterRtpCapabilities();
-		const routerRtpCapabilities =
-			this.extractRouterRtpCapabilities(routerCapsResp);
+		this.device = new Device();
+		const routerRtpCapabilities = await client.getRouterRtpCapabilities();
 		this.routerRtpCapabilities = routerRtpCapabilities;
 
 		await this.device.load({ routerRtpCapabilities });
@@ -244,7 +200,7 @@ export class TransportManager {
 			if (!device) throw new Error("Device failed to initialize");
 			const client = this.getClient();
 			const rawTransportParams = await client.createWebRtcTransport("send");
-			const additionalSettings: Record<string, unknown> = {};
+			const additionalSettings: InsertableStreamRTCConfiguration = {};
 			if (this.e2eePolicy.legacyInsertableStreamsEnabled) {
 				additionalSettings.encodedInsertableStreams = true;
 			}
@@ -278,46 +234,39 @@ export class TransportManager {
 	setupSendTransportHandlers() {
 		if (!this.sendTransport) return;
 		const client = this.getClient();
-		const sendTransport: TransportLike = this.sendTransport;
+		const sendTransport = this.sendTransport;
 		const sendTransportId = sendTransport.id;
 		sendTransport.on(
 			"connect",
 			async (
-				{ dtlsParameters }: { dtlsParameters: unknown },
+				{ dtlsParameters }: { dtlsParameters: DtlsParameters },
 				callback: () => void,
-				errback: (error: unknown) => void,
+				errback: (error: Error) => void,
 			) => {
 				try {
 					await client.connectWebRtcTransport(sendTransportId, dtlsParameters);
 					callback();
 				} catch (error) {
-					errback(error);
+					errback(error instanceof Error ? error : new Error(String(error)));
 				}
 			},
 		);
 
-		sendTransport.on("produce", async (...args: unknown[]) => {
-			const [parameters, callback, errback] = args as [
-				{ rtpParameters: unknown; kind: string; appData: unknown },
-				(result: { id: string }) => void,
-				(error: unknown) => void,
-			];
-			if (!parameters || typeof callback !== "function") return;
-
+		sendTransport.on("produce", async (parameters, callback, errback) => {
 			try {
-				const response = (await client.createProducer(
+				const response = await client.createProducer(
 					sendTransportId,
 					parameters.rtpParameters,
 					parameters.kind,
 					parameters.appData,
-				)) as { id: string };
+				);
 				callback({ id: response.id });
 			} catch (error) {
-				errback(error);
+				errback(error instanceof Error ? error : new Error(String(error)));
 			}
 		});
 
-		sendTransport.on("connectionstatechange", (state: unknown) => {
+		sendTransport.on("connectionstatechange", (state) => {
 			if (state === "failed") {
 				console.error("Send transport failed");
 			}
@@ -337,7 +286,7 @@ export class TransportManager {
 			if (!device) throw new Error("Device failed to initialize");
 			const client = this.getClient();
 			const rawTransportParams = await client.createWebRtcTransport("recv");
-			const additionalSettings: Record<string, unknown> = {};
+			const additionalSettings: InsertableStreamRTCConfiguration = {};
 			if (this.e2eePolicy.legacyInsertableStreamsEnabled) {
 				additionalSettings.encodedInsertableStreams = true;
 			}
@@ -397,24 +346,24 @@ export class TransportManager {
 	setupReceiveTransportHandlers() {
 		if (!this.recvTransport) return;
 		const client = this.getClient();
-		const recvTransport: TransportLike = this.recvTransport;
+		const recvTransport = this.recvTransport;
 		recvTransport.on(
 			"connect",
 			async (
-				{ dtlsParameters }: { dtlsParameters: unknown },
+				{ dtlsParameters }: { dtlsParameters: DtlsParameters },
 				callback: () => void,
-				errback: (error: unknown) => void,
+				errback: (error: Error) => void,
 			) => {
 				try {
 					await client.connectWebRtcTransport(recvTransport.id, dtlsParameters);
 					callback();
 				} catch (error) {
-					errback(error);
+					errback(error instanceof Error ? error : new Error(String(error)));
 				}
 			},
 		);
 
-		recvTransport.on("connectionstatechange", (state: unknown) => {
+		recvTransport.on("connectionstatechange", (state) => {
 			if (state === "failed") {
 				console.error("Receive transport failed");
 			}
@@ -462,10 +411,11 @@ export class TransportManager {
 
 	async createProducer(
 		track: MediaStreamTrack,
-		appData: Record<string, unknown> = {},
+		appData: AppData = {},
 	) {
 		if (!this.sendTransport) await this.createSendTransport();
-		if (!this.device?.canProduce?.(track?.kind || "video"))
+		const kind = track.kind === "audio" ? "audio" : "video";
+		if (!this.device?.canProduce(kind))
 			throw new Error("Unsupported");
 		if (!this.sendTransport?.produce)
 			throw new Error("Send transport is not ready to produce");
@@ -479,7 +429,7 @@ export class TransportManager {
 		});
 
 		const e2eeWantedBeforeProduce = this.e2eePolicy.transformsEnabled;
-		const produceOptions: Record<string, unknown> = {
+		const produceOptions: ProducerOptions = {
 			track,
 			appData: {
 				...safeAppData,
@@ -575,7 +525,7 @@ export class TransportManager {
 
 	async createConsumer(
 		producerId: string,
-		metadata: Record<string, unknown> = {},
+		metadata: { isScreen?: boolean } = {},
 	) {
 		if (!this.device) await this.initializeDevice();
 		if (!this.recvTransport) await this.createReceiveTransport();
@@ -591,7 +541,7 @@ export class TransportManager {
 			recvTransport.id,
 			producerId,
 			device.rtpCapabilities,
-		)) as ConsumerParams;
+		));
 
 		const isScreen = !!(
 			metadata.isScreen ||
@@ -603,7 +553,7 @@ export class TransportManager {
 		let consumer: Consumer | null = null;
 		let firstError: unknown = null;
 		try {
-			const consumeArgs: Record<string, unknown> = {
+			const consumeArgs: ConsumerOptions = {
 				id: rawConsumerParams.id,
 				producerId: rawConsumerParams.producerId,
 				kind: rawConsumerParams.kind,
@@ -737,7 +687,7 @@ export class TransportManager {
 			const transportRtt: number[] = [];
 
 			const processStats = (
-				stats: Map<string, TransportStatReport>,
+				stats: RTCStatsReport | Map<string, TransportStatReport>,
 				preferRemoteInbound: boolean,
 				transportDirection: Direction,
 			) => {
@@ -820,8 +770,7 @@ export class TransportManager {
 
 			if (
 				this.sendTransport &&
-				(this.sendTransport.connectionState === "connected" ||
-					this.sendTransport.connectionState === "completed")
+				this.sendTransport.connectionState === "connected"
 			) {
 				const sendStats = await this.sendTransport.getStats();
 				processStats(sendStats, true, "send");
@@ -829,8 +778,7 @@ export class TransportManager {
 
 			if (
 				this.recvTransport &&
-				(this.recvTransport.connectionState === "connected" ||
-					this.recvTransport.connectionState === "completed")
+				this.recvTransport.connectionState === "connected"
 			) {
 				const recvStats = await this.recvTransport.getStats();
 				processStats(recvStats, false, "recv");

--- a/frontend/src/apps/meet/utils/media/__tests__/ConsumerManager.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/ConsumerManager.test.ts
@@ -1,5 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ConsumerManager } from "../ConsumerManager";
+import {
+	type ConsumerEntry,
+	ConsumerManager,
+} from "../ConsumerManager";
+
+interface MockConsumerOverrides {
+	id?: string;
+	producerId?: string;
+	kind?: "audio" | "video";
+	track?: MediaStreamTrack;
+	appData?: { userId: string; type?: string };
+	close?: ReturnType<typeof vi.fn>;
+	pause?: ReturnType<typeof vi.fn>;
+	resume?: ReturnType<typeof vi.fn>;
+	once?: ReturnType<typeof vi.fn>;
+}
 
 beforeEach(() => {
 	vi.clearAllMocks();
@@ -9,7 +24,7 @@ function createManager() {
 	return new ConsumerManager();
 }
 
-function mockConsumer(overrides: Record<string, unknown> = {}) {
+function mockConsumer(overrides: MockConsumerOverrides = {}) {
 	const consumer = {
 		id: "c1",
 		producerId: "producer-1",
@@ -27,7 +42,7 @@ function mockConsumer(overrides: Record<string, unknown> = {}) {
 
 function assertEntry(
 	entry: ReturnType<ConsumerManager["addConsumer"]>,
-): asserts entry is NonNullable<ReturnType<ConsumerManager["addConsumer"]>> {
+): asserts entry is ConsumerEntry {
 	expect(entry).not.toBe(false);
 }
 
@@ -36,11 +51,9 @@ describe("addConsumer", () => {
 		const cm = createManager();
 		const entry = cm.addConsumer(mockConsumer());
 		assertEntry(entry);
-		expect((entry as unknown as { id: string }).id).toBe("c1");
-		expect((entry as unknown as { participantId: string }).participantId).toBe(
-			"p1",
-		);
-		expect((entry as unknown as { kind: string }).kind).toBe("video");
+		expect(entry.id).toBe("c1");
+		expect(entry.participantId).toBe("p1");
+		expect(entry.kind).toBe("video");
 	});
 
 	it("returns false for invalid consumer", () => {
@@ -52,9 +65,7 @@ describe("addConsumer", () => {
 		const cm = createManager();
 		const entry = cm.addConsumer(mockConsumer(), "override-id");
 		assertEntry(entry);
-		expect((entry as unknown as { participantId: string }).participantId).toBe(
-			"override-id",
-		);
+		expect(entry.participantId).toBe("override-id");
 	});
 
 	it("fires onConsumerAdded event", () => {
@@ -296,7 +307,7 @@ describe("clear", () => {
 
 describe("consumer @close handling", () => {
 	function setupMockConsumerWithClose(
-		overrides: Record<string, unknown> = {},
+		overrides: MockConsumerOverrides = {},
 	): {
 		consumer: ReturnType<typeof mockConsumer> & {
 			once: ReturnType<typeof vi.fn>;
@@ -379,8 +390,6 @@ describe("consumer @close handling", () => {
 			mockConsumer({ id: "c2", producerId: "producer-2" }),
 		);
 		assertEntry(entry);
-		expect((entry as unknown as { producerId: string }).producerId).toBe(
-			"producer-2",
-		);
+		expect(entry.producerId).toBe("producer-2");
 	});
 });

--- a/frontend/src/apps/meet/utils/media/__tests__/E2EEHandshakeController.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/E2EEHandshakeController.test.ts
@@ -69,8 +69,7 @@ describe("E2EEHandshakeController", () => {
 		expect(controller.keyVersion).toBe(1);
 		expect(installedSecret?.byteLength).toBe(32);
 		expect(
-			(controller as unknown as { sfuClient: { sendE2EEEpochEnvelope: ReturnType<typeof vi.fn> } }).sfuClient
-				.sendE2EEEpochEnvelope,
+			Reflect.get(Reflect.get(controller, "sfuClient"), "sendE2EEEpochEnvelope"),
 		).toHaveBeenCalledWith({
 			type: "ack",
 			fromParticipantId: "user-1",

--- a/frontend/src/apps/meet/utils/media/__tests__/ParticipantManager.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/ParticipantManager.test.ts
@@ -1,15 +1,38 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ParticipantManager } from "../ParticipantManager";
+import {
+	type ParticipantData,
+	ParticipantManager,
+	normalizeParticipantData,
+} from "../ParticipantManager";
 
 beforeEach(() => {
 	vi.clearAllMocks();
+});
+
+it("preserves E2EE roster metadata while normalizing SFU participants", () => {
+	expect(normalizeParticipantData({
+		id: "participant-1",
+		user_id: "user-1",
+		senderId: 42,
+		sender_id: 42,
+		is_host: false,
+		info: { name: "Alice" },
+	})).toMatchObject({
+		participantId: "user-1",
+		user_id: "user-1",
+		senderId: 42,
+		sender_id: 42,
+		is_host: false,
+	});
 });
 
 function createManager() {
 	return new ParticipantManager();
 }
 
-function makeParticipantData(overrides: Record<string, unknown> = {}) {
+function makeParticipantData(
+	overrides: Partial<ParticipantData> = {},
+): ParticipantData {
 	return {
 		participantId: "p1",
 		user_id: "p1",

--- a/frontend/src/apps/meet/utils/media/__tests__/TransportManager.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/TransportManager.test.ts
@@ -18,6 +18,11 @@ function createManager() {
 	return new TransportManager();
 }
 
+function mockedIceRestart(manager: TransportManager) {
+	if (!manager.sfuClient) throw new Error("Missing mock SFU client");
+	return vi.mocked(manager.sfuClient.restartWebRtcTransportIce);
+}
+
 function mockSfuClient(getCodecStrategy?: () => string) {
 	return {
 		getCodecStrategy: getCodecStrategy ?? (() => "svc"),
@@ -58,8 +63,7 @@ describe("getVideoEncodingDecision", () => {
 	it("falls back to svc when sfuClient has no getCodecStrategy", () => {
 		const manager = createManager();
 		manager.sfuClient = mockSfuClient() as never;
-		(manager.sfuClient as unknown as Record<string, unknown>).getCodecStrategy =
-			undefined;
+		Reflect.set(manager.sfuClient, "getCodecStrategy", undefined);
 		manager.device = { rtpCapabilities: { codecs: [] } } as never;
 		manager.routerRtpCapabilities = { codecs: [] };
 
@@ -97,8 +101,9 @@ describe("getVideoEncodingConfig", () => {
 		expect(config.decision.scalabilityMode).toBe("L3T1");
 		expect(config.encodings).toHaveLength(1);
 		expect(
-			(config.encodings[0] as unknown as { scalabilityMode: string })
-				.scalabilityMode,
+			config.encodings[0] && "scalabilityMode" in config.encodings[0]
+				? config.encodings[0].scalabilityMode
+				: undefined,
 		).toBe("L3T1");
 	});
 
@@ -200,24 +205,6 @@ describe("E2EE transport options", () => {
 				onRtpSender: expect.any(Function),
 			}),
 		);
-	});
-});
-
-describe("extractRouterRtpCapabilities", () => {
-	it("extracts rtpCapabilities key from response", () => {
-		const manager = createManager();
-		const result = (manager as unknown as Record<string, unknown>)
-			.extractRouterRtpCapabilities as (resp: unknown) => unknown;
-		const response = { rtpCapabilities: { codecs: [] } };
-		expect(result(response)).toEqual({ codecs: [] });
-	});
-
-	it("returns response as-is when no rtpCapabilities key", () => {
-		const manager = createManager();
-		const result = (manager as unknown as Record<string, unknown>)
-			.extractRouterRtpCapabilities as (resp: unknown) => unknown;
-		const response = { codecs: [] };
-		expect(result(response)).toEqual(response);
 	});
 });
 
@@ -341,10 +328,7 @@ describe("restartAllTransportIce", () => {
 			close: vi.fn(),
 			getStats: vi.fn(),
 		} as never;
-		vi.mocked(
-			(manager.sfuClient as unknown as Record<string, unknown>)
-				.restartWebRtcTransportIce as ReturnType<typeof vi.fn>,
-		).mockResolvedValue({ iceParams: true });
+		mockedIceRestart(manager).mockResolvedValue({ iceParams: true } as never);
 		const result = await manager.restartAllTransportIce();
 		expect(result).toEqual({ send: "restarted", recv: "not-needed" });
 	});
@@ -359,10 +343,7 @@ describe("restartAllTransportIce", () => {
 			close: vi.fn(),
 			getStats: vi.fn(),
 		} as never;
-		vi.mocked(
-			(manager.sfuClient as unknown as Record<string, unknown>)
-				.restartWebRtcTransportIce as ReturnType<typeof vi.fn>,
-		).mockRejectedValue(new Error("fail"));
+		mockedIceRestart(manager).mockRejectedValue(new Error("fail"));
 		const result = await manager.restartAllTransportIce();
 		expect(result).toEqual({ send: "failed", recv: "not-needed" });
 	});
@@ -384,12 +365,9 @@ describe("restartAllTransportIce", () => {
 			close: vi.fn(),
 			getStats: vi.fn(),
 		} as never;
-		vi.mocked(
-			(manager.sfuClient as unknown as Record<string, unknown>)
-				.restartWebRtcTransportIce as ReturnType<typeof vi.fn>,
-		).mockImplementation((transportId: string) => {
+		mockedIceRestart(manager).mockImplementation((transportId: string) => {
 			return transportId === "send-tp"
-				? Promise.resolve({ iceParams: true })
+				? Promise.resolve({ usernameFragment: "u", password: "p" })
 				: Promise.reject(new Error("recv failed"));
 		});
 
@@ -416,10 +394,7 @@ describe("restartAllTransportIce", () => {
 			close: vi.fn(),
 			getStats: vi.fn(),
 		} as never;
-		vi.mocked(
-			(manager.sfuClient as unknown as Record<string, unknown>)
-				.restartWebRtcTransportIce as ReturnType<typeof vi.fn>,
-		).mockResolvedValue({ iceParams: true });
+		mockedIceRestart(manager).mockResolvedValue({ iceParams: true } as never);
 
 		await expect(manager.restartAllTransportIce()).resolves.toEqual({
 			send: "restarted",
@@ -444,13 +419,10 @@ describe("restartAllTransportIce", () => {
 			close: vi.fn(),
 			getStats: vi.fn(),
 		} as never;
-		vi.mocked(
-			(manager.sfuClient as unknown as Record<string, unknown>)
-				.restartWebRtcTransportIce as ReturnType<typeof vi.fn>,
-		).mockImplementation((transportId: string) => {
+		mockedIceRestart(manager).mockImplementation((transportId: string) => {
 			return transportId === "send-tp"
 				? Promise.reject(new Error("send failed"))
-				: Promise.resolve({ iceParams: true });
+				: Promise.resolve({ usernameFragment: "u", password: "p" });
 		});
 
 		await expect(manager.restartAllTransportIce()).resolves.toEqual({
@@ -476,10 +448,7 @@ describe("restartAllTransportIce", () => {
 			close: vi.fn(),
 			getStats: vi.fn(),
 		} as never;
-		vi.mocked(
-			(manager.sfuClient as unknown as Record<string, unknown>)
-				.restartWebRtcTransportIce as ReturnType<typeof vi.fn>,
-		).mockRejectedValue(new Error("restart failed"));
+		mockedIceRestart(manager).mockRejectedValue(new Error("restart failed"));
 
 		await expect(manager.restartAllTransportIce()).resolves.toEqual({
 			send: "failed",

--- a/frontend/src/apps/meet/utils/media/__tests__/VideoElementManager.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/VideoElementManager.test.ts
@@ -3,7 +3,7 @@ import { VideoElementManager } from "../VideoElementManager";
 
 type StreamCtor = new (tracks: MediaStreamTrack[]) => MediaStream;
 
-const globalAny = globalThis as unknown as { MediaStream?: StreamCtor };
+const globalAny = globalThis as typeof globalThis & { MediaStream?: StreamCtor };
 
 beforeEach(() => {
 	if (globalAny.MediaStream === undefined) {
@@ -24,16 +24,16 @@ beforeEach(() => {
 				return this.tracks;
 			}
 		}
-		globalAny.MediaStream = MockMediaStream as unknown as StreamCtor;
+		Reflect.set(globalAny, "MediaStream", MockMediaStream);
 	}
 });
 
 function makeTrack(id: string): MediaStreamTrack {
-	return {
+	return Object.assign(Object.create(null), {
 		id,
 		kind: "video",
 		stop: vi.fn(),
-	} as unknown as MediaStreamTrack;
+	}) as MediaStreamTrack;
 }
 
 function makeStream(tracks: MediaStreamTrack[]): MediaStream {

--- a/frontend/src/apps/meet/utils/media/__tests__/e2ee.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/e2ee.test.ts
@@ -9,16 +9,8 @@ beforeAll(() => {
 });
 
 afterEach(() => {
-	delete (
-		RTCRtpSender.prototype as unknown as {
-			createEncodedStreams?: () => unknown;
-		}
-	).createEncodedStreams;
-	delete (
-		RTCRtpReceiver.prototype as unknown as {
-			createEncodedStreams?: () => unknown;
-		}
-	).createEncodedStreams;
+	Reflect.deleteProperty(RTCRtpSender.prototype, "createEncodedStreams");
+	Reflect.deleteProperty(RTCRtpReceiver.prototype, "createEncodedStreams");
 });
 
 import { decodeFrameHeader, encodeFrameHeader } from "../frameCodec";
@@ -782,9 +774,10 @@ describe("ReceiverChainState anti-replay behavior", () => {
 			expect("key" in result).toBe(true);
 		}
 
-		const seenFrames = (
-			state as unknown as { seenFrames: Map<string, Set<number>> }
-		).seenFrames;
+		const seenFrames = Reflect.get(state, "seenFrames") as Map<
+			string,
+			Set<number>
+		>;
 		const seen = seenFrames.get("1:video");
 		expect(seen ? Array.from(seen).sort((a, b) => a - b) : []).toEqual([
 			97, 98, 99,
@@ -1201,18 +1194,15 @@ function makeMockSender(): RTCRtpSender {
 	const writable = new WritableStream<{ data: ArrayBuffer }>({
 		write() {},
 	});
-	const sender = {
-		createEncodedStreams: () => ({ readable, writable }),
-	} as unknown as RTCRtpSender;
-	(
-		RTCRtpSender.prototype as unknown as {
-			createEncodedStreams?: () => unknown;
-		}
-	).createEncodedStreams = () => ({ readable, writable });
-	(
-		RTCRtpReceiver.prototype as unknown as {
-			createEncodedStreams?: () => unknown;
-		}
-	).createEncodedStreams = () => ({ readable, writable });
+	const sender: RTCRtpSender = Object.create(RTCRtpSender.prototype);
+	Reflect.set(sender, "createEncodedStreams", () => ({ readable, writable }));
+	Reflect.set(RTCRtpSender.prototype, "createEncodedStreams", () => ({
+		readable,
+		writable,
+	}));
+	Reflect.set(RTCRtpReceiver.prototype, "createEncodedStreams", () => ({
+		readable,
+		writable,
+	}));
 	return sender;
 }

--- a/frontend/src/apps/meet/utils/media/__tests__/stallDetector.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/stallDetector.test.ts
@@ -283,17 +283,13 @@ describe("extractInboundBytesReceived", () => {
 			["a", { type: "outbound-rtp", bytesReceived: 999 }],
 			["b", { type: "inbound-rtp", bytesReceived: 12345 }],
 		]);
-		expect(
-			extractInboundBytesReceived(stats as unknown as RTCStatsReport),
-		).toBe(12345);
+		expect(extractInboundBytesReceived(stats)).toBe(12345);
 	});
 
 	it("returns null when no inbound-rtp report is present", () => {
 		const stats = new Map<string, { type: string; bytesReceived?: number }>([
 			["a", { type: "outbound-rtp", bytesReceived: 999 }],
 		]);
-		expect(
-			extractInboundBytesReceived(stats as unknown as RTCStatsReport),
-		).toBeNull();
+		expect(extractInboundBytesReceived(stats)).toBeNull();
 	});
 });

--- a/frontend/src/apps/meet/utils/media/e2ee.ts
+++ b/frontend/src/apps/meet/utils/media/e2ee.ts
@@ -49,7 +49,7 @@ export type TransformableReceiver = RTCRtpReceiver & {
 
 type RTCRtpScriptTransformConstructor = new (
 	worker: Worker,
-	options: Record<string, unknown>,
+	options: object,
 ) => unknown;
 
 type E2EETransformCapability =
@@ -520,10 +520,10 @@ function hasLegacyInsertableStreamSupport(): boolean {
 	if (typeof globalThis.RTCRtpSender === "undefined") return false;
 	if (typeof globalThis.RTCRtpReceiver === "undefined") return false;
 	try {
-		const senderProto = globalThis.RTCRtpSender.prototype as unknown as {
+		const senderProto = globalThis.RTCRtpSender.prototype as RTCRtpSender & {
 			createEncodedStreams?: () => unknown;
 		};
-		const receiverProto = globalThis.RTCRtpReceiver.prototype as unknown as {
+		const receiverProto = globalThis.RTCRtpReceiver.prototype as RTCRtpReceiver & {
 			createEncodedStreams?: () => unknown;
 		};
 		return (

--- a/frontend/src/apps/meet/utils/media/encodings.ts
+++ b/frontend/src/apps/meet/utils/media/encodings.ts
@@ -1,3 +1,5 @@
+import type { ProducerCodecOptions } from "mediasoup-client/types";
+
 // layers for simulcast video streaming (adaptive streaming)
 // layer 0: low quality (300 kbps)
 // layer 1: medium quality (700 kbps)
@@ -11,15 +13,6 @@ interface VideoEncodingLayer {
 interface SVCEncodingLayer {
 	scalabilityMode: string;
 	maxBitrate: number;
-}
-
-interface CodecOptions {
-	videoGoogleStartBitrate?: number;
-	opusStereo?: number;
-	opusDtx?: number;
-	opusFec?: number;
-	opusMaxAverageBitrate?: number;
-	opusMaxPlaybackRate?: number;
 }
 
 export const videoEncodings: VideoEncodingLayer[] = [
@@ -46,15 +39,15 @@ export const svcEncodingTemplate = (
 // and fps is handled by the hint in the browser in case of congestion control
 export const screenEncodings: VideoEncodingLayer[] = [{ maxBitrate: 4000000 }];
 
-export const videoCodecOptions: CodecOptions = {
+export const videoCodecOptions: ProducerCodecOptions = {
 	videoGoogleStartBitrate: 2500,
 };
 
-export const audioCodecOptions: CodecOptions = {
+export const audioCodecOptions: ProducerCodecOptions = {
 	// ref: https://mediasoup.org/documentation/v3/mediasoup-client/api/#ProducerCodecOptions
-	opusStereo: 1,
-	opusDtx: 1, // enable DTX to save bandwidth during silence periods
-	opusFec: 1, // enable FEC to improve audio quality in case of packet loss
+	opusStereo: true,
+	opusDtx: true, // enable DTX to save bandwidth during silence periods
+	opusFec: true, // enable FEC to improve audio quality in case of packet loss
 	opusMaxAverageBitrate: 128000, // more headroom for stereo voice while staying efficient
 	opusMaxPlaybackRate: 48000, // allow fullband Opus instead of forcing 24 kHz wideband
 };

--- a/frontend/src/apps/meet/utils/media/stallDetector.ts
+++ b/frontend/src/apps/meet/utils/media/stallDetector.ts
@@ -210,7 +210,9 @@ export class StallDetector {
 }
 
 export function extractInboundBytesReceived(
-	stats: RTCStatsReport,
+	stats: {
+		values(): IterableIterator<{ type: string; bytesReceived?: number }>;
+	},
 ): number | null {
 	for (const report of stats.values()) {
 		if (

--- a/frontend/src/apps/meet/utils/sfu/SFUConnectionManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUConnectionManager.ts
@@ -5,14 +5,28 @@
 
 import type { ConsumerEntry } from "../media/ConsumerManager";
 import type {
+	Participant,
 	ParticipantData,
 	ParticipantManager,
+	ParticipantUpdate,
 } from "../media/ParticipantManager";
+import { normalizeParticipantData } from "../media/ParticipantManager";
 import type { TransportManager } from "../media/TransportManager";
 import type { VideoElementManager } from "../media/VideoElementManager";
 import { waitForE2EEContextReady } from "../media/E2EEContextReady";
-import type { ConnectionDetails, SFUClient } from "../SFUClient";
+import type {
+	ConnectionDetails,
+	SFUClient,
+	SFUExistingProducer,
+} from "../SFUClient";
+import type {
+	JoinRoomMediaState,
+	JoinUserData,
+} from "../../types";
+import { isUnknownRecord } from "../../types";
+import type { User } from "../../composables/useCurrentUser";
 import type { SFUMediaManager } from "./SFUMediaManager";
+import type { MediaScreenShareEvent } from "./SFUMediaManager";
 import type { SFURecoveryManager } from "./SFURecoveryManager";
 
 interface SFUProducerEvent {
@@ -38,23 +52,65 @@ interface SFUHostControlEvent {
 	hostId?: string;
 }
 
+function normalizeProducerEvent(value: unknown): SFUProducerEvent | null {
+	if (
+		!isUnknownRecord(value) ||
+		typeof value.producerId !== "string" ||
+		typeof value.participantId !== "string"
+	) {
+		return null;
+	}
+	return {
+		producerId: value.producerId,
+		participantId: value.participantId,
+		isScreen: value.isScreen === true,
+	};
+}
+
+function normalizeProducerClosedEvent(
+	value: unknown,
+): SFUProducerClosedEvent | null {
+	if (!isUnknownRecord(value)) return null;
+	return {
+		participantId:
+			typeof value.participantId === "string" ? value.participantId : undefined,
+		producerId:
+			typeof value.producerId === "string" ? value.producerId : undefined,
+		isScreen: value.isScreen === true,
+	};
+}
+
+function normalizeScreenShareEvent(value: unknown): ScreenShareEvent | null {
+	if (!isUnknownRecord(value)) return null;
+	return {
+		participantId:
+			typeof value.participantId === "string" ? value.participantId : undefined,
+		consumerId:
+			typeof value.consumerId === "string" ? value.consumerId : undefined,
+		stream:
+			typeof MediaStream !== "undefined" && value.stream instanceof MediaStream
+				? value.stream
+				: undefined,
+	};
+}
+
 export interface SFUEventHandlers {
-	onParticipantJoined?: (participant: unknown) => void;
+	onParticipantJoined?: (participant: Participant) => void;
 	onParticipantLeft?: (data: {
 		participantId: string;
-		participant?: unknown;
+		participant?: Participant;
 	}) => void;
 	onParticipantUpdated?: (
 		participantId: string,
-		participant: unknown,
-		updates: unknown,
+		participant: Participant,
+		updates: ParticipantUpdate,
 	) => void;
-	onScreenShareStarted?: (data: unknown) => void;
-	onScreenShareStopped?: (data: unknown) => void;
+	onScreenShareStarted?: (data: ScreenShareEvent) => void;
+	onScreenShareStopped?: (data: ScreenShareEvent) => void;
 	onActiveSpeakerChanged?: (participantIds: string[]) => void;
 	onNetworkQualityUpdated?: (participantId: string, quality: string) => void;
 	onHostMutedYou?: () => void;
-	onHostKickedYou?: (data: unknown) => void;
+	onHostKickedYou?: (data: { hostId?: string }) => void;
 	onRecoveryStateChange?: (
 		state:
 			| "reconnecting"
@@ -66,6 +122,13 @@ export interface SFUEventHandlers {
 		detail?: string,
 	) => void;
 	onRecoveryExhausted?: () => void;
+}
+
+interface ScreenShareEvent {
+	participantId?: string;
+	consumerId?: string;
+	stream?: MediaStream;
+	consumer?: { id: string };
 }
 
 interface ConnectionManagerOptions {
@@ -86,13 +149,16 @@ export class SFUConnectionManager {
 	recoveryManager: SFURecoveryManager;
 
 	meetingId: string | null = null;
-	currentUser: { value: unknown } = { value: null };
+	currentUser: { value: User | null } = { value: null };
 	isConnected = false;
 	initialSyncInProgress = false;
 	bufferedProducerEvents: SFUProducerEvent[] = [];
 	eventHandlers: SFUEventHandlers = {};
-	private lastJoinUserData: unknown = null;
-	private lastJoinMediaState: Record<string, unknown> = {};
+	private lastJoinUserData: JoinUserData | null = null;
+	private lastJoinMediaState: JoinRoomMediaState = {
+		audio_enabled: false,
+		video_enabled: false,
+	};
 	private activeRejoin: Promise<void> | null = null;
 	private activeReceiveReset: Promise<void> | null = null;
 	private lifecycleGeneration = 0;
@@ -108,7 +174,7 @@ export class SFUConnectionManager {
 
 	initialize(
 		meetingId: string,
-		currentUser: unknown,
+		currentUser: User | { value: User | null } | null,
 		eventHandlers?: SFUEventHandlers,
 	): void {
 		this.meetingId = meetingId;
@@ -144,14 +210,14 @@ export class SFUConnectionManager {
 		}
 	}
 
-	async joinRoom(userData: unknown, mediaState: unknown): Promise<boolean> {
+	async joinRoom(
+		userData: JoinUserData,
+		mediaState: JoinRoomMediaState,
+	): Promise<boolean> {
 		try {
 			await this.sfuClient.joinRoom(this.meetingId ?? "", userData, mediaState);
 			this.lastJoinUserData = userData;
-			this.lastJoinMediaState =
-				mediaState && typeof mediaState === "object"
-					? { ...(mediaState as Record<string, unknown>) }
-					: {};
+			this.lastJoinMediaState = { ...mediaState };
 			console.log("Successfully joined room:", this.meetingId);
 			return true;
 		} catch (error) {
@@ -190,28 +256,13 @@ export class SFUConnectionManager {
 			const participants = await this.sfuClient.getRoomParticipants();
 			const currentUserId = this.getCurrentUserId();
 
-			const normalized = (participants || [])
-				.map((p: Record<string, unknown>) => {
-					const info = (p.info || {}) as Record<string, unknown>;
-					return {
-						participantId: (p.user_id ?? p.id) as string,
-						user_id: (p.user_id ?? p.id) as string,
-						user_name: (info.name ??
-							info.user_name ??
-							p.user_id ??
-							"") as string,
-						avatar: (info.avatar ?? null) as string | null,
-						audio_enabled:
-							typeof info.audio_enabled === "boolean"
-								? info.audio_enabled
-								: false,
-						video_enabled:
-							typeof info.video_enabled === "boolean"
-								? info.video_enabled
-								: false,
-						is_guest: (info.is_guest as boolean) || false,
-					};
-				})
+			const normalized = participants
+				.map((participant) => ({
+					...participant,
+					audio_enabled: participant.userData?.audio_enabled ?? false,
+					video_enabled: participant.userData?.video_enabled ?? false,
+					is_guest: participant.userData?.is_guest ?? false,
+				}))
 				.filter((p) => p.user_id !== currentUserId);
 
 			this.participantManager.syncParticipants(normalized);
@@ -227,47 +278,30 @@ export class SFUConnectionManager {
 		}
 	}
 
-	async requestExistingProducers(): Promise<unknown[] | null> {
+	async requestExistingProducers(): Promise<SFUExistingProducer[] | null> {
 		try {
 			const existingProducers = await this.sfuClient.getExistingProducers();
 
 			if (existingProducers?.length) {
 				console.log(
 					`Found ${existingProducers.length} existing producers:`,
-					existingProducers.map((p: unknown) => {
-						const producer = p as Record<string, unknown>;
-						return {
-							id: producer.id,
-							participantId:
-								producer.participantId || producer.user_id || producer.userId,
-							kind: producer.kind,
-							isScreen: !!producer.isScreen,
-						};
-					}),
+					existingProducers,
 				);
 
 				if (!(await this.waitForE2EEContextIfRequired())) {
 					this.bufferedProducerEvents.push(
-						...existingProducers.map((producerInfo: unknown) => {
-							const info = producerInfo as Record<string, unknown>;
-							return {
-								producerId: info.id as string,
-								participantId: (info.participantId ??
-									info.user_id ??
-									info.userId) as string,
-								isScreen: !!info.isScreen,
-							};
-						}),
+						...existingProducers.map((producer) => ({
+							producerId: producer.id,
+							participantId: producer.participantId,
+							isScreen: producer.isScreen,
+						})),
 					);
 					return existingProducers;
 				}
 
 				for (const producerInfo of existingProducers) {
-					const info = producerInfo as Record<string, unknown>;
-					const participantId = (info.participantId ??
-						info.user_id ??
-						info.userId) as string;
-					const producerId = info.id as string;
+					const participantId = producerInfo.participantId;
+					const producerId = producerInfo.id;
 
 					if (this.hasConsumerForProducer(participantId, producerId)) {
 						continue;
@@ -276,13 +310,13 @@ export class SFUConnectionManager {
 					console.log("Subscribing to existing producer:", {
 						producerId,
 						participantId,
-						kind: info.kind,
-						isScreen: !!info.isScreen,
+						kind: producerInfo.kind,
+						isScreen: producerInfo.isScreen,
 					});
 					await this.mediaManager.subscribeToRemoteProducer({
 						producerId,
 						participantId,
-						isScreen: !!info.isScreen,
+						isScreen: producerInfo.isScreen,
 					});
 				}
 			} else {
@@ -387,6 +421,8 @@ export class SFUConnectionManager {
 		}
 		this.recoveryManager.reset();
 		const generation = this.lifecycleGeneration;
+		const lastJoinUserData = this.lastJoinUserData;
+		const meetingId = this.meetingId;
 
 		const rejoin = (async () => {
 			this.reportRecoveryState("rejoining", "signaling reconnected");
@@ -400,8 +436,8 @@ export class SFUConnectionManager {
 			if (generation !== this.lifecycleGeneration) return;
 
 			await this.sfuClient.joinRoom(
-				this.meetingId as string,
-				this.lastJoinUserData,
+				meetingId,
+				lastJoinUserData,
 				this.getCurrentRejoinMediaState(),
 			);
 			if (generation !== this.lifecycleGeneration) return;
@@ -445,7 +481,7 @@ export class SFUConnectionManager {
 		);
 	}
 
-	private getCurrentRejoinMediaState(): Record<string, unknown> {
+	private getCurrentRejoinMediaState(): JoinRoomMediaState {
 		const localStream = this.mediaManager.mediaHandler.localStream;
 		if (!localStream) return this.lastJoinMediaState;
 
@@ -475,14 +511,14 @@ export class SFUConnectionManager {
 
 	private setupManagerEventHandlers(): void {
 		this.participantManager.setEventHandlers({
-			onParticipantAdded: (participant: Record<string, unknown>) => {
+			onParticipantAdded: (participant: Participant) => {
 				if (this.eventHandlers.onParticipantJoined) {
 					this.eventHandlers.onParticipantJoined(participant);
 				}
 			},
 			onParticipantRemoved: (
 				participantId: string,
-				participant: Record<string, unknown>,
+				participant: Participant,
 			) => {
 				this.videoManager.removeVideoElement(participantId);
 				this.mediaManager.consumerManager.cleanupParticipantConsumers(
@@ -494,8 +530,8 @@ export class SFUConnectionManager {
 			},
 			onParticipantUpdated: (
 				participantId: string,
-				participant: Record<string, unknown>,
-				updates: Record<string, unknown>,
+				participant: Participant,
+				updates: ParticipantUpdate,
 			) => {
 				if (this.eventHandlers.onParticipantUpdated) {
 					this.eventHandlers.onParticipantUpdated(
@@ -531,12 +567,12 @@ export class SFUConnectionManager {
 			onRecoveryExhausted: () => {
 				this.eventHandlers.onRecoveryExhausted?.();
 			},
-			onScreenShareStarted: (data: unknown) => {
+			onScreenShareStarted: (data: MediaScreenShareEvent) => {
 				if (this.eventHandlers.onScreenShareStarted) {
 					this.eventHandlers.onScreenShareStarted(data);
 				}
 			},
-			onScreenShareStopped: (data: unknown) => {
+			onScreenShareStopped: (data: MediaScreenShareEvent) => {
 				if (this.eventHandlers.onScreenShareStopped) {
 					this.eventHandlers.onScreenShareStopped(data);
 				}
@@ -561,7 +597,9 @@ export class SFUConnectionManager {
 			});
 		});
 
-		this.sfuClient.on("participant_joined", (data: ParticipantData) => {
+		this.sfuClient.on("participant_joined", (value: unknown) => {
+			const data = normalizeParticipantData(value);
+			if (!data) return;
 			const currentUserId = this.getCurrentUserId();
 			const joinedUserId = data.participantId || data.user_id || "";
 
@@ -570,13 +608,16 @@ export class SFUConnectionManager {
 			}
 		});
 
-		this.sfuClient.on("participant_left", (data: ParticipantData) => {
-			const d = data as ParticipantData;
-			this.participantManager.removeParticipant(d.participantId || "");
+		this.sfuClient.on("participant_left", (value: unknown) => {
+			const participant = normalizeParticipantData(value);
+			if (participant?.participantId) {
+				this.participantManager.removeParticipant(participant.participantId);
+			}
 		});
 
-		this.sfuClient.on("producer_created", async (data: unknown) => {
-			const d = data as SFUProducerEvent;
+		this.sfuClient.on("producer_created", async (value: unknown) => {
+			const d = normalizeProducerEvent(value);
+			if (!d) return;
 			if (d.participantId === this.getCurrentUserId()) return;
 
 			if (
@@ -602,8 +643,9 @@ export class SFUConnectionManager {
 			}
 		});
 
-		this.sfuClient.on("producer_closed", (data: unknown) => {
-			const d = data as SFUProducerClosedEvent;
+		this.sfuClient.on("producer_closed", (value: unknown) => {
+			const d = normalizeProducerClosedEvent(value);
+			if (!d) return;
 			const pid = d.participantId;
 			const closedProducerId = d.producerId;
 			const closedIsScreen = d.isScreen;
@@ -634,15 +676,19 @@ export class SFUConnectionManager {
 			}
 		});
 
-		this.sfuClient.on("consumer_closed", (data: unknown) => {
+		this.sfuClient.on("consumer_closed", (value: unknown) => {
 			try {
-				const d = data as { consumerId?: string; participantId?: string };
-				const consumerId = d.consumerId;
+				if (!isUnknownRecord(value)) return;
+				const consumerId =
+					typeof value.consumerId === "string" ? value.consumerId : undefined;
 				if (!consumerId) return;
 				const removed =
 					this.mediaManager.consumerManager.removeConsumer(consumerId);
 				if (!removed) {
-					const pid = d.participantId;
+					const pid =
+						typeof value.participantId === "string"
+							? value.participantId
+							: undefined;
 					if (pid) {
 						const allForPid =
 							this.mediaManager.consumerManager.getConsumersByParticipant(pid);
@@ -663,8 +709,22 @@ export class SFUConnectionManager {
 			}
 		});
 
-		this.sfuClient.on("media_control_update", (data: unknown) => {
-			const d = data as SFUMediaControlEvent;
+		this.sfuClient.on("media_control_update", (value: unknown) => {
+			if (!isUnknownRecord(value) || typeof value.participantId !== "string") {
+				return;
+			}
+			const action = value.action;
+			const d: SFUMediaControlEvent = {
+				participantId: value.participantId,
+				action:
+					typeof action === "string"
+						? action
+						: isUnknownRecord(action) &&
+								typeof action.type === "string" &&
+								typeof action.enabled === "boolean"
+							? { type: action.type, enabled: action.enabled }
+							: undefined,
+			};
 			const updates: Record<string, boolean> = {};
 			if (d.action && typeof d.action === "object") {
 				const a = d.action;
@@ -698,18 +758,33 @@ export class SFUConnectionManager {
 			}
 		});
 
-		this.sfuClient.on("network_quality_update", (data: unknown) => {
-			const d = data as { participantId?: string; quality?: string };
-			if (d.participantId && d.quality) {
-				this.eventHandlers.onNetworkQualityUpdated?.(d.participantId, d.quality);
-				this.participantManager.updateParticipant(d.participantId, {
-					networkQuality: d.quality,
+		this.sfuClient.on("network_quality_update", (value: unknown) => {
+			if (
+				isUnknownRecord(value) &&
+				typeof value.participantId === "string" &&
+				typeof value.quality === "string"
+			) {
+				this.eventHandlers.onNetworkQualityUpdated?.(
+					value.participantId,
+					value.quality,
+				);
+				this.participantManager.updateParticipant(value.participantId, {
+					networkQuality: value.quality,
 				});
 			}
 		});
 
-		this.sfuClient.on("host_control_update", (data: unknown) => {
-			const d = data as SFUHostControlEvent;
+		this.sfuClient.on("host_control_update", (value: unknown) => {
+			if (
+				!isUnknownRecord(value) ||
+				typeof value.action !== "string" ||
+				typeof value.targetParticipantId !== "string"
+			) return;
+			const d: SFUHostControlEvent = {
+				action: value.action,
+				targetParticipantId: value.targetParticipantId,
+				hostId: typeof value.hostId === "string" ? value.hostId : undefined,
+			};
 			const myParticipantId = this.getCurrentUserId();
 			const isForMe = d.targetParticipantId === myParticipantId;
 
@@ -733,21 +808,23 @@ export class SFUConnectionManager {
 			}
 		});
 
-		this.sfuClient.on("screen_share_started", (data: unknown) => {
-			const d = data as { participantId?: string; stream?: MediaStream };
+		this.sfuClient.on("screen_share_started", (value: unknown) => {
+			const d = normalizeScreenShareEvent(value);
+			if (!d) return;
 			console.log("SFU event: screen_share_started (from signaling)", {
 				participantId: d.participantId,
 				hasDirectStream: !!d.stream,
 			});
 		});
 
-		this.sfuClient.on("screen_share_stopped", (data: unknown) => {
-			const d = data as { participantId?: string };
+		this.sfuClient.on("screen_share_stopped", (value: unknown) => {
+			const d = normalizeScreenShareEvent(value);
+			if (!d) return;
 			console.log("Screen share stopped - resetting sidebar mode flag");
 			this.mediaManager.isScreenShareActive = false;
 
 			if (this.eventHandlers.onScreenShareStopped) {
-				this.eventHandlers.onScreenShareStopped(data);
+				this.eventHandlers.onScreenShareStopped(d);
 			}
 
 			const pid = d.participantId;
@@ -783,28 +860,31 @@ export class SFUConnectionManager {
 			}
 		});
 
-		this.sfuClient.on("active_speaker", (data: unknown) => {
-			const d = data as { participantIds: string[] };
+		this.sfuClient.on("active_speaker", (value: unknown) => {
+			if (
+				!isUnknownRecord(value) ||
+				!Array.isArray(value.participantIds) ||
+				!value.participantIds.every((id) => typeof id === "string")
+			) return;
+			const d = { participantIds: value.participantIds };
 			if (this.eventHandlers.onActiveSpeakerChanged) {
 				this.eventHandlers.onActiveSpeakerChanged(d.participantIds);
 			}
 		});
 	}
 
-	private ensureRef(obj: unknown): { value: unknown } {
-		if (obj && typeof obj === "object" && "value" in (obj as object)) {
-			return obj as { value: unknown };
+	private ensureRef(
+		obj: User | { value: User | null } | null,
+	): { value: User | null } {
+		if (obj && "value" in obj) {
+			return obj;
 		}
 		return { value: obj };
 	}
 
 	getCurrentUserId(): string | null {
-		const cu = this.currentUser?.value || this.currentUser;
-		return (
-			((cu as Record<string, unknown>)?.user_id as string) ||
-			((cu as Record<string, unknown>)?.userId as string) ||
-			null
-		);
+		const user = this.currentUser.value;
+		return user?.user_id || user?.userId || null;
 	}
 
 	async disconnect(): Promise<void> {
@@ -830,7 +910,10 @@ export class SFUConnectionManager {
 		this.isConnected = false;
 		this.initialSyncInProgress = false;
 		this.lastJoinUserData = null;
-		this.lastJoinMediaState = {};
+		this.lastJoinMediaState = {
+			audio_enabled: false,
+			video_enabled: false,
+		};
 		this.activeRejoin = null;
 	}
 }

--- a/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
@@ -59,10 +59,26 @@ interface MediaManagerOptions {
 	participantManager: ParticipantManager;
 }
 
+export interface PublishedMedia {
+	videoProducer?: Producer;
+	audioProducer?: Producer;
+	screenProducer?: Producer;
+}
+
+export interface ConsumerMetadata {
+	isScreen?: boolean;
+}
+
 interface MediaEventHandlers {
-	onScreenShareStarted?: (data: unknown) => void;
-	onScreenShareStopped?: (data: unknown) => void;
+	onScreenShareStarted?: (data: MediaScreenShareEvent) => void;
+	onScreenShareStopped?: (data: MediaScreenShareEvent) => void;
 	onRecoveryExhausted?: () => void;
+}
+
+export interface MediaScreenShareEvent {
+	participantId: string;
+	stream?: MediaStream;
+	consumer?: ConsumerEntry;
 }
 
 export class SFUMediaManager {
@@ -107,9 +123,9 @@ export class SFUMediaManager {
 	async publishMedia(
 		localStream: MediaStream,
 		options: { publishVideo?: boolean; publishAudio?: boolean } = {},
-	): Promise<Record<string, unknown>> {
+	): Promise<PublishedMedia> {
 		const { publishVideo = true, publishAudio = true } = options;
-		const results: Record<string, unknown> = {};
+		const results: PublishedMedia = {};
 
 		try {
 			this.mediaHandler.localStream = localStream;
@@ -163,7 +179,7 @@ export class SFUMediaManager {
 		}
 	}
 
-	async rebuildSendSide(): Promise<Record<string, unknown>> {
+	async rebuildSendSide(): Promise<PublishedMedia> {
 		const localStream = this.mediaHandler.localStream;
 		const screenTrack = this.mediaHandler.screenProducer?.track;
 		const hasLiveScreen = screenTrack?.readyState === "live";
@@ -205,8 +221,8 @@ export class SFUMediaManager {
 	async subscribeToProducer(
 		producerId: string,
 		participantId: string,
-		metadata: Record<string, unknown> = {},
-	): Promise<unknown> {
+		metadata: ConsumerMetadata = {},
+	): Promise<ConsumerEntry | false> {
 		const generation = this.subscriptionGeneration;
 		try {
 			const consumer = await this.transportManager.createConsumer(

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
@@ -95,7 +95,12 @@ describe("SFUMediaManager.subscribeToRemoteProducer", () => {
 
 	it("discards a subscription that finishes after receive teardown", async () => {
 		const { mediaManager, transportManager, consumerManager } = createManager();
-		let resolveConsumer: (consumer: Record<string, unknown>) => void = () => {};
+		let resolveConsumer: (consumer: {
+			id: string;
+			producerId: string;
+			kind: string;
+			close: ReturnType<typeof vi.fn>;
+		}) => void = () => {};
 		transportManager.createConsumer.mockReturnValue(
 			new Promise((resolve) => {
 				resolveConsumer = resolve;


### PR DESCRIPTION
- Check API and Socket.IO messages when they enter the Meet frontend.
- Use named types for participants, media, transports, polls, and E2EE data.
- Remove explicit `any` and unsafe `as unknown as` casts from production code.