### PR TITLE
refactor(meet): type recorder protocols

### DIFF
--- a/frontend/recorder/RecorderRenderer.vue
+++ b/frontend/recorder/RecorderRenderer.vue
@@ -74,7 +74,7 @@ provide("setScreenShareVideoRef", (consumerId: string, element: HTMLVideoElement
 });
 
 const attachmentRetryDelay = () => new Promise<void>((resolve) => setTimeout(resolve, 50));
-const attachScreenShare = async (element: HTMLVideoElement, stream: MediaStream, onFailure: (error: unknown) => void): Promise<void> => {
+const attachScreenShare = async (element: HTMLVideoElement, stream: MediaStream, onFailure: (error: Error) => void): Promise<void> => {
 	while (!element.parentNode) await attachmentRetryDelay();
 	if (element.srcObject !== stream) element.srcObject = stream;
 	while (true) {
@@ -86,8 +86,9 @@ const attachScreenShare = async (element: HTMLVideoElement, stream: MediaStream,
 				await attachmentRetryDelay();
 				continue;
 			}
-			onFailure(error);
-			throw error;
+			const failure = error instanceof Error ? error : new Error("Screen playback failed");
+			onFailure(failure);
+			throw failure;
 		}
 	}
 };

--- a/frontend/recorder/RecorderSocketController.test.ts
+++ b/frontend/recorder/RecorderSocketController.test.ts
@@ -1,30 +1,77 @@
 import { describe, expect, it, vi } from "vitest";
-import { RecorderSocketController, trustedAvatar } from "./RecorderSocketController";
+import type { Participant, ParticipantData } from "../src/apps/meet/utils/media/ParticipantManager";
+import type { RecorderParticipantData, RecorderParticipantUpdate } from "./protocol";
+import { RecorderSocketController, trustedAvatar, type RecorderState } from "./RecorderSocketController";
+import type { RecorderConfig, RecordingChallenge } from "./rendererBridge";
 
-const config = { job: "j", grant: "g", meetingId: "r", sfuOrigin: "https://sfu.test", frappeOrigin: "https://frappe.test", socketPath: "/socket.io", startedAt: 0 };
+vi.stubGlobal("MediaStream", class MediaStream {});
 
-function harness(existing: Record<string, unknown>[] = [], subscription: unknown = undefined, state: Record<string, unknown> = {}) {
+const config: RecorderConfig = { job: "j", grant: "g", meetingId: "r", sfuOrigin: "https://sfu.test", frappeOrigin: "https://frappe.test", socketPath: "/socket.io", startedAt: 0 };
+const challenge: RecordingChallenge = { version: 1, jti: "jti", socket_id: "socket", nonce: "nonce", issued_at: 1, expires_at: 2 };
+type ChallengeFixture = RecordingChallenge | { version: 2 };
+
+interface ProducerFixture {
+	id: string;
+	participantId: string;
+	isScreen?: boolean;
+}
+
+interface ConsumerFixture {
+	id: string;
+	producerId: string;
+	participantId: string;
+	kind: "audio" | "video";
+	isScreen: boolean;
+}
+
+interface ParticipantHandlers {
+	onParticipantAdded?: (participant: Participant) => void;
+	onParticipantRemoved?: (participantId: string) => void;
+	onParticipantUpdated?: (participantId: string, participant: Participant, updates: RecorderParticipantUpdate) => void;
+}
+
+interface ConsumerHandlers {
+	onConsumerAdded?: (consumer: ConsumerFixture) => void;
+}
+
+interface MediaHandlers {
+	onScreenShareStarted?: (value: { participantId: string; stream: MediaStream; consumer: ConsumerFixture }) => void;
+}
+
+const participantFixture = (data: RecorderParticipantData): Participant => ({
+	user_id: data.participantId || data.user_id || "",
+	user_name: data.userData?.name || data.user_name || "",
+	avatar: data.userData?.avatar || data.avatar || null,
+	initials: "",
+	audio_enabled: data.userData?.audio_enabled ?? data.audio_enabled,
+	video_enabled: data.userData?.video_enabled ?? data.video_enabled,
+	is_guest: data.userData?.is_guest ?? data.is_guest,
+	participantId: data.participantId,
+	userData: data.userData,
+});
+
+function harness(existing: ProducerFixture[] = [], subscription?: ConsumerFixture | null, state: RecorderState = {}, challengeFixture: ChallengeFixture = challenge) {
 	const calls: string[] = [];
 	const socketHandlers = new Map<string, (...args: unknown[]) => void>();
 	const sfuHandlers = new Map<string, (...args: unknown[]) => void>();
-	let consumerAdded: ((consumer: Record<string, unknown>) => void) | undefined;
-	let participantHandlers: Record<string, (...args: never[]) => void> = {};
-	let mediaHandlers: Record<string, (value: unknown) => void> = {};
+	let consumerAdded: ConsumerHandlers["onConsumerAdded"];
+	let participantHandlers: ParticipantHandlers = {};
+	let mediaHandlers: MediaHandlers = {};
 	const channel = {
 		on: vi.fn((event: string, handler: (...args: unknown[]) => void) => socketHandlers.set(event, handler)),
-		connect: vi.fn(async () => { calls.push("connect"); socketHandlers.get("recording:challenge")?.({ version: 1 }); }),
-		emit: vi.fn((event: string, _data: unknown, callback?: (value: unknown) => void) => { calls.push(event); callback?.({ success: true }); }),
+		connect: vi.fn(async () => { calls.push("connect"); socketHandlers.get("recording:challenge")?.(challengeFixture); }),
+		emit: vi.fn((event: string, _data: { signature: string } | { roomId: string }, callback?: (value: unknown) => void) => { calls.push(event); callback?.({ success: true }); }),
 		disconnect: vi.fn(), off: vi.fn(), isConnected: vi.fn(), id: vi.fn(), updateAuth: vi.fn(),
 	};
 	const bridge = { sign: vi.fn(async () => "signature"), reportCaptureReady: vi.fn(), reportInterruption: vi.fn(), reportProofComplete: vi.fn(), reportJoinComplete: vi.fn(), reportFailure: vi.fn() };
-	const participants = new Map<string, Record<string, unknown>>();
+	const participants = new Map<string, Participant>();
 	const dependencies = {
-		sfuClient: { connected: false, connectionDetails: {}, on: vi.fn((event, handler) => sfuHandlers.set(event, handler)), registerEventHandlers: vi.fn(), getRoomParticipants: vi.fn(async () => { calls.push("participants"); return []; }), getExistingProducers: vi.fn(async () => { calls.push("producers"); return existing; }), disconnect: vi.fn() },
+		sfuClient: { connected: false, connectionDetails: {}, on: vi.fn((event: string, handler: (...args: unknown[]) => void) => sfuHandlers.set(event, handler)), registerEventHandlers: vi.fn(), getRoomParticipants: vi.fn(async (): Promise<ParticipantData[]> => { calls.push("participants"); return []; }), getExistingProducers: vi.fn(async () => { calls.push("producers"); return existing; }), disconnect: vi.fn() },
 		transportManager: { initializeDevice: vi.fn(async () => calls.push("device")), createReceiveTransport: vi.fn(async () => calls.push("recv")), setEventHandlers: vi.fn(), cleanup: vi.fn() },
-		consumerManager: { setEventHandlers: vi.fn((handlers) => { consumerAdded = handlers.onConsumerAdded; }), getConsumersByParticipant: vi.fn(() => []), getScreenShareConsumers: vi.fn(() => []), cleanupParticipantConsumers: vi.fn(), clear: vi.fn(), removeConsumer: vi.fn() },
-		participantManager: { setEventHandlers: vi.fn((handlers) => { participantHandlers = handlers; }), syncParticipants: vi.fn((values) => values.forEach((p) => participants.set(p.participantId, p))), addParticipant: vi.fn((p) => participants.set(p.participantId || p.user_id, p)), removeParticipant: vi.fn((id) => participants.delete(id)), updateMediaState: vi.fn(), getAllParticipants: vi.fn(() => [...participants.values()]), hasParticipant: vi.fn((id) => participants.has(id)) },
+		consumerManager: { setEventHandlers: vi.fn((handlers: ConsumerHandlers) => { consumerAdded = handlers.onConsumerAdded; }), getConsumersByParticipant: vi.fn(() => []), getScreenShareConsumers: vi.fn(() => []), cleanupParticipantConsumers: vi.fn(), clear: vi.fn(), removeConsumer: vi.fn() },
+		participantManager: { setEventHandlers: vi.fn((handlers: ParticipantHandlers) => { participantHandlers = handlers; }), syncParticipants: vi.fn((values: RecorderParticipantData[]) => values.forEach((value) => { const participant = participantFixture(value); participants.set(participant.user_id, participant); })), addParticipant: vi.fn((value: RecorderParticipantData) => { const participant = participantFixture(value); participants.set(participant.user_id, participant); return participant; }), removeParticipant: vi.fn((id: string) => participants.delete(id)), updateMediaState: vi.fn(), getAllParticipants: vi.fn(() => [...participants.values()]), hasParticipant: vi.fn((id: string) => participants.has(id)) },
 		videoManager: { removeVideoElement: vi.fn(), cleanup: vi.fn() },
-		mediaManager: { setEventHandlers: vi.fn((handlers) => { mediaHandlers = handlers; }), handleNewConsumer: vi.fn(async (consumer) => { if (consumer.isScreen) mediaHandlers.onScreenShareStarted?.({ participantId: consumer.participantId, stream: {}, consumer }); }), handleConsumerLost: vi.fn(), subscribeToRemoteProducer: vi.fn(async (event) => { if (subscription === null) return null; const consumer = subscription || { id: `c-${event.producerId}`, producerId: event.producerId, participantId: event.participantId, kind: "audio", isScreen: false }; consumerAdded?.(consumer as Record<string, unknown>); return consumer; }), cancelPendingSubscriptions: vi.fn(async () => undefined), cleanup: vi.fn() },
+		mediaManager: { setEventHandlers: vi.fn((handlers: MediaHandlers) => { mediaHandlers = handlers; }), handleNewConsumer: vi.fn(async (consumer: ConsumerFixture) => { if (consumer.isScreen) mediaHandlers.onScreenShareStarted?.({ participantId: consumer.participantId, stream: new MediaStream(), consumer }); }), handleConsumerLost: vi.fn(), subscribeToRemoteProducer: vi.fn(async (event: { producerId: string; participantId: string; isScreen: boolean }) => { if (subscription === null) return null; const consumer: ConsumerFixture = subscription || { id: `c-${event.producerId}`, producerId: event.producerId, participantId: event.participantId, kind: "audio", isScreen: false }; consumerAdded?.(consumer); return consumer; }), cancelPendingSubscriptions: vi.fn(async () => undefined), cleanup: vi.fn() },
 	};
 	const controller = new RecorderSocketController(bridge as never, channel, state, dependencies as never);
 	return { calls, channel, bridge, dependencies, sfuHandlers, getParticipantHandlers: () => participantHandlers, participants, controller };
@@ -48,7 +95,7 @@ describe("RecorderSocketController", () => {
 
 	it("tombstones producer closes and participant leaves during snapshots", async () => {
 		const h = harness([{ id: "p1", participantId: "alice" }]);
-		h.dependencies.sfuClient.getRoomParticipants.mockImplementationOnce(async () => { h.sfuHandlers.get("participant_left")?.({ participantId: "alice" }); h.sfuHandlers.get("producer_closed")?.({ producerId: "p1", participantId: "alice" }); return [{ id: "alice", info: { name: "Alice" } }]; });
+		h.dependencies.sfuClient.getRoomParticipants.mockImplementationOnce(async () => { h.sfuHandlers.get("participant_left")?.({ participantId: "alice" }); h.sfuHandlers.get("producer_closed")?.({ producerId: "p1", participantId: "alice" }); return [{ participantId: "alice", user_id: "alice", userData: { name: "Alice" } }]; });
 		await h.controller.connect(config);
 		expect(h.participants.has("alice")).toBe(false);
 		expect(h.dependencies.mediaManager.subscribeToRemoteProducer).not.toHaveBeenCalled();
@@ -70,10 +117,18 @@ describe("RecorderSocketController", () => {
 		expect(h.dependencies.mediaManager.subscribeToRemoteProducer).not.toHaveBeenCalled();
 	});
 
+	it("rejects a malformed recording challenge", async () => {
+		const h = harness([], undefined, {}, { version: 2 });
+
+		await expect(h.controller.connect(config)).rejects.toThrow("Invalid recording challenge");
+		expect(h.bridge.sign).not.toHaveBeenCalled();
+		expect(h.bridge.reportFailure).toHaveBeenCalledWith("Invalid recording challenge");
+	});
+
 	it("defaults missing snapshot media state to off", async () => {
 		const h = harness([]);
 		h.dependencies.sfuClient.getRoomParticipants.mockResolvedValueOnce([
-			{ id: "alice", info: { name: "Alice" } },
+			{ participantId: "alice", user_id: "alice", userData: { name: "Alice" } },
 		]);
 
 		await h.controller.connect(config);
@@ -103,9 +158,9 @@ describe("RecorderSocketController", () => {
 		const roomEmpty = vi.fn();
 		const h = harness([], undefined, { roomEmpty });
 
-		h.getParticipantHandlers().onParticipantRemoved?.("alice" as never);
+		h.getParticipantHandlers().onParticipantRemoved?.("alice");
 		vi.advanceTimersByTime(5_000);
-		h.getParticipantHandlers().onParticipantAdded?.({ user_id: "alice" } as never);
+		h.getParticipantHandlers().onParticipantAdded?.({ user_id: "alice", user_name: "Alice", avatar: null, initials: "A" });
 		vi.advanceTimersByTime(5_000);
 
 		expect(roomEmpty).not.toHaveBeenCalled();
@@ -131,6 +186,40 @@ describe("RecorderSocketController", () => {
 		await expect(h.controller.connect(config)).rejects.toThrow("screen decoder failed");
 		expect(h.bridge.reportFailure).toHaveBeenCalledWith("screen decoder failed");
 		expect(h.bridge.reportInterruption).not.toHaveBeenCalled();
+	});
+
+	it("rejects malformed external SFU values without mutating recorder state", async () => {
+		const activeSpeakersChanged = vi.fn();
+		const h = harness([], undefined, { activeSpeakersChanged });
+		await h.controller.connect(config);
+
+		h.sfuHandlers.get("participant_joined")?.({ participantId: 42 });
+		h.sfuHandlers.get("producer_created")?.({ producerId: "p1", participantId: null });
+		h.sfuHandlers.get("media_control_update")?.({ participantId: "alice", action: { type: "audio", enabled: "yes" } });
+		h.sfuHandlers.get("active_speaker")?.({ participantIds: ["alice", 42] });
+
+		expect(h.participants).toHaveLength(0);
+		expect(h.dependencies.mediaManager.subscribeToRemoteProducer).not.toHaveBeenCalled();
+		expect(h.dependencies.participantManager.updateMediaState).not.toHaveBeenCalled();
+		expect(activeSpeakersChanged).not.toHaveBeenCalled();
+	});
+
+	it("normalizes valid media controls and preserves precise participant updates", async () => {
+		const participantUpdated = vi.fn();
+		const h = harness([], undefined, { participantUpdated });
+		await h.controller.connect(config);
+
+		h.sfuHandlers.get("media_control_update")?.({ participantId: "alice", action: "unmute" });
+		h.sfuHandlers.get("media_control_update")?.({ participantId: "alice", action: { type: "video", enabled: true } });
+		h.getParticipantHandlers().onParticipantUpdated?.(
+			"alice",
+			{ user_id: "alice", user_name: "Alice", avatar: null, initials: "A" },
+			{ audio_enabled: true },
+		);
+
+		expect(h.dependencies.participantManager.updateMediaState).toHaveBeenNthCalledWith(1, "alice", { audioEnabled: true });
+		expect(h.dependencies.participantManager.updateMediaState).toHaveBeenNthCalledWith(2, "alice", { videoEnabled: true });
+		expect(participantUpdated).toHaveBeenCalledWith("alice", { audio_enabled: true });
 	});
 
 	it("rewrites only public avatars on the trusted Frappe origin", () => {

--- a/frontend/recorder/RecorderSocketController.ts
+++ b/frontend/recorder/RecorderSocketController.ts
@@ -1,23 +1,41 @@
 import { readonly, ref, type Ref } from "vue";
-import { ConsumerManager, type ConsumerEntry } from "../src/apps/meet/utils/media/ConsumerManager";
-import { ParticipantManager, type Participant, type ParticipantData } from "../src/apps/meet/utils/media/ParticipantManager";
+import { ConsumerManager } from "../src/apps/meet/utils/media/ConsumerManager";
+import { ParticipantManager, type Participant } from "../src/apps/meet/utils/media/ParticipantManager";
 import { SocketIOSignalChannel, type SignalChannel } from "../src/apps/meet/utils/media/SignalChannel";
 import { TransportManager } from "../src/apps/meet/utils/media/TransportManager";
 import { VideoElementManager } from "../src/apps/meet/utils/media/VideoElementManager";
 import { SFUClient } from "../src/apps/meet/utils/SFUClient";
 import { SFUMediaManager } from "../src/apps/meet/utils/sfu/SFUMediaManager";
-import type { RecorderConfig, RecorderRendererBridge, RecordingChallenge } from "./rendererBridge";
+import {
+	parseActiveSpeakers,
+	parseChatMessage,
+	parseConsumerId,
+	parseHandChange,
+	parseMediaControlMessage,
+	parseParticipantId,
+	parseParticipantMessage,
+	parseParticipantUpdate,
+	parseProducerMessage,
+	parseProducerSnapshot,
+	parseRaisedHands,
+	parseReaction,
+	parseRecordingChallenge,
+	parseRequestResponse,
+	parseScreenShareStarted,
+	type MediaControlMessage,
+	type ParticipantMessage,
+	type ProducerEvent,
+	type ProducerMessage,
+	type RecorderParticipantData,
+	type RecorderParticipantUpdate,
+} from "./protocol";
+import type { RecorderConfig, RecorderRendererBridge } from "./rendererBridge";
 
-type ProducerEvent = { producerId: string; participantId: string; isScreen?: boolean };
-type SyncEvent =
-	| { type: "participant-joined"; value: ParticipantData }
-	| { type: "participant-left"; value: ParticipantData }
-	| { type: "producer-created"; value: ProducerEvent }
-	| { type: "producer-closed"; value: ProducerEvent };
-type RecorderState = {
+type SyncEvent = ParticipantMessage | ProducerMessage;
+export type RecorderState = {
 	participantAdded?: (participant: Participant) => void;
 	participantRemoved?: (participantId: string) => void;
-	participantUpdated?: (participantId: string, updates: Record<string, unknown>) => void;
+	participantUpdated?: (participantId: string, updates: RecorderParticipantUpdate) => void;
 	activeSpeakersChanged?: (participantIds: string[]) => void;
 	screenStarted?: (data: { participantId: string; consumerId: string; stream: MediaStream; startedAt: number }) => Promise<void> | void;
 	screenStopped?: (participantId: string) => void;
@@ -94,8 +112,13 @@ export class RecorderSocketController {
 		let resolveProof!: () => void;
 		let rejectProof!: (error: Error) => void;
 		const proved = new Promise<void>((resolve, reject) => { resolveProof = resolve; rejectProof = reject; });
-		this.channel.on("recording:challenge", (...args) => {
-			this.bridge.sign(args[0] as RecordingChallenge)
+		this.channel.on("recording:challenge", (value) => {
+			const challenge = parseRecordingChallenge(value);
+			if (!challenge) {
+				rejectProof(new Error("Invalid recording challenge"));
+				return;
+			}
+			this.bridge.sign(challenge)
 				.then((signature) => this.request("recording:proof", { signature }))
 				.then(resolveProof, rejectProof);
 		});
@@ -148,7 +171,10 @@ export class RecorderSocketController {
 				this.state.participantRemoved?.(id);
 				this.scheduleRoomEmpty();
 			},
-			onParticipantUpdated: (id, _p, updates) => this.state.participantUpdated?.(id, updates),
+			onParticipantUpdated: (id, _p, updates) => {
+				const parsed = parseParticipantUpdate(updates);
+				if (parsed) this.state.participantUpdated?.(id, parsed);
+			},
 		});
 		this.deps.consumerManager.setEventHandlers({
 			onConsumerAdded: (consumer) => {
@@ -156,7 +182,7 @@ export class RecorderSocketController {
 					if (consumer.isScreen) await this.screenAttachmentPromises.get(consumer.id);
 				});
 				this.attachmentPromises.set(consumer.producerId, attached);
-				void attached.catch((error: unknown) => {
+				void attached.catch((error) => {
 					if (this._ready.value) this.interrupt(`Media attachment failed: ${error instanceof Error ? error.message : "unknown error"}`);
 				});
 			},
@@ -165,9 +191,10 @@ export class RecorderSocketController {
 		});
 		this.deps.mediaManager.setEventHandlers({
 			onScreenShareStarted: (value) => {
-				const data = value as { participantId: string; stream: MediaStream; consumer: ConsumerEntry };
-				const acknowledged = Promise.resolve(this.state.screenStarted?.({ participantId: data.participantId, consumerId: data.consumer.id, stream: data.stream, startedAt: Date.now() }));
-				this.screenAttachmentPromises.set(data.consumer.id, this.withTimeout(acknowledged, `Timed out waiting for screen element for ${data.participantId}`));
+				const data = parseScreenShareStarted(value);
+				if (!data) return;
+				const acknowledged = Promise.resolve(this.state.screenStarted?.({ participantId: data.participantId, consumerId: data.consumerId, stream: data.stream, startedAt: Date.now() }));
+				this.screenAttachmentPromises.set(data.consumerId, this.withTimeout(acknowledged, `Timed out waiting for screen element for ${data.participantId}`));
 			},
 			onRecoveryExhausted: () => this.interrupt("Media subscription recovery exhausted"),
 		});
@@ -178,27 +205,56 @@ export class RecorderSocketController {
 
 	private setupSFUEvents(): void {
 		const client = this.deps.sfuClient;
-		client.on("participant_joined", (value) => this.queueOrApply({ type: "participant-joined", value: value as ParticipantData }));
-		client.on("participant_left", (value) => this.queueOrApply({ type: "participant-left", value: value as ParticipantData }));
-		client.on("producer_created", (value) => this.queueOrApply({ type: "producer-created", value: value as ProducerEvent }));
-		client.on("producer_closed", (value) => this.queueOrApply({ type: "producer-closed", value: value as ProducerEvent }));
-		client.on("consumer_closed", (value) => { const id = (value as { consumerId?: string }).consumerId; if (id) this.deps.consumerManager.removeConsumer(id); });
-		client.on("media_control_update", (value) => this.updateMedia(value as Record<string, unknown>));
-		client.on("active_speaker", (value) => this.state.activeSpeakersChanged?.((value as { participantIds?: string[] }).participantIds || []));
-		client.on("screen_share_stopped", (value) => this.stopScreen((value as { participantId?: string }).participantId || ""));
-		client.on("reaction:message", (value) => { const d = value as { fromUser?: string; reaction?: string }; if (d.fromUser && d.reaction) this.state.reactionReceived?.(d.fromUser, d.reaction); });
-		client.on("hand_raised", (value) => { const d = value as { participantId?: string; raised?: boolean; timestamp?: string }; if (d.participantId) this.state.handChanged?.(d.participantId, !!d.raised, d.timestamp || new Date().toISOString()); });
-		client.on("existing_raised_hands", (value) => this.state.handsSynced?.((value as { hands?: Record<string, string> }).hands || {}));
-		client.on("chat:message", (value) => { const d = value as { fromUser?: string; fromName?: string; message?: string; timestamp?: string }; const time = Date.parse(d.timestamp || ""); if (d.message && (!Number.isFinite(time) || time >= this.captureStartedAt)) this.state.chatReceived?.({ id: `${d.fromUser || "unknown"}-${d.timestamp || Date.now()}`, participantId: d.fromUser, author: d.fromName || d.fromUser || "Unknown", text: d.message }); });
+		client.on("participant_joined", (value) => { const event = parseParticipantMessage("participant-joined", value); if (event) this.queueOrApply(event); });
+		client.on("participant_left", (value) => { const event = parseParticipantMessage("participant-left", value); if (event) this.queueOrApply(event); });
+		client.on("producer_created", (value) => { const event = parseProducerMessage("producer-created", value); if (event) this.queueOrApply(event); });
+		client.on("producer_closed", (value) => { const event = parseProducerMessage("producer-closed", value); if (event) this.queueOrApply(event); });
+		client.on("consumer_closed", (value) => { const id = parseConsumerId(value); if (id) this.deps.consumerManager.removeConsumer(id); });
+		client.on("media_control_update", (value) => { const message = parseMediaControlMessage(value); if (message) this.updateMedia(message); });
+		client.on("active_speaker", (value) => { const ids = parseActiveSpeakers(value); if (ids) this.state.activeSpeakersChanged?.(ids); });
+		client.on("screen_share_stopped", (value) => { const id = parseParticipantId(value); if (id) this.stopScreen(id); });
+		client.on("reaction:message", (value) => { const reaction = parseReaction(value); if (reaction) this.state.reactionReceived?.(reaction.fromUser, reaction.reaction); });
+		client.on("hand_raised", (value) => { const hand = parseHandChange(value); if (hand) this.state.handChanged?.(hand.participantId, hand.raised, hand.timestamp); });
+		client.on("existing_raised_hands", (value) => { const hands = parseRaisedHands(value); if (hands) this.state.handsSynced?.(hands); });
+		client.on("chat:message", (value) => { const message = parseChatMessage(value); if (!message) return; const time = Date.parse(message.timestamp || ""); if (!Number.isFinite(time) || time >= this.captureStartedAt) this.state.chatReceived?.({ id: `${message.fromUser || "unknown"}-${message.timestamp || Date.now()}`, participantId: message.fromUser, author: message.fromName || message.fromUser || "Unknown", text: message.message }); });
 	}
 
 	private async initialSynchronize(): Promise<void> {
-		const participants = await this.deps.sfuClient.getRoomParticipants() as Record<string, unknown>[];
-		this.deps.participantManager.syncParticipants(participants.map((p) => this.snapshotParticipant(p)).filter((p) => !this.departedParticipants.has(p.participantId || "")));
+		const participants = await this.deps.sfuClient.getRoomParticipants();
+		this.deps.participantManager.syncParticipants(
+			participants
+				.filter((participant) =>
+					!this.departedParticipants.has(participant.participantId || ""),
+				)
+				.map((participant) => this.sanitizeParticipant({
+					...participant,
+					userData: {
+						...participant.userData,
+						audio_enabled:
+							participant.userData?.audio_enabled ??
+							participant.audio_enabled ??
+							false,
+						video_enabled:
+							participant.userData?.video_enabled ??
+							participant.video_enabled ??
+							false,
+					},
+					audio_enabled:
+						participant.userData?.audio_enabled ??
+						participant.audio_enabled ??
+						false,
+					video_enabled:
+						participant.userData?.video_enabled ??
+						participant.video_enabled ??
+						false,
+				})),
+		);
 		const existing = await this.deps.sfuClient.getExistingProducers();
 		const producers = new Map<string, ProducerEvent>();
-		for (const value of existing as Record<string, unknown>[]) {
-			const event = { producerId: value.id as string, participantId: (value.participantId || value.user_id || value.userId) as string, isScreen: !!value.isScreen };
+		for (const value of existing) {
+			const producer = parseProducerSnapshot(value);
+			if (!producer) continue;
+			const event = { producerId: producer.id, participantId: producer.participantId, isScreen: producer.isScreen };
 			if (!this.closedProducers.has(event.producerId) && !this.departedParticipants.has(event.participantId)) producers.set(event.producerId, event);
 		}
 		while (this.bufferedEvents.length) for (const event of this.bufferedEvents.splice(0)) this.applySyncEvent(event, producers);
@@ -212,11 +268,11 @@ export class RecorderSocketController {
 	}
 	private applySyncEvent(event: SyncEvent, producers?: Map<string, ProducerEvent>): void {
 		if (event.type === "participant-joined") {
-			const id = event.value.participantId || event.value.user_id || "";
+			const id = event.value.participantId;
 			this.departedParticipants.delete(id);
 			this.deps.participantManager.addParticipant(this.sanitizeParticipant(event.value));
 		} else if (event.type === "participant-left") {
-			const id = event.value.participantId || event.value.user_id || "";
+			const id = event.value.participantId;
 			this.departedParticipants.add(id);
 			const removed = this.deps.participantManager.removeParticipant(id);
 			if (!removed) this.scheduleRoomEmpty();
@@ -242,26 +298,11 @@ export class RecorderSocketController {
 	private async subscribeLive(event: ProducerEvent): Promise<void> {
 		try { await this.subscribeRequired(event); } catch (error) { this.interrupt(error instanceof Error ? error.message : "Media subscription failed"); }
 	}
-	private snapshotParticipant(p: Record<string, unknown>): ParticipantData {
-		const info = (p.info || {}) as Record<string, unknown>;
-		return this.sanitizeParticipant({
-			participantId: (p.user_id || p.id) as string,
-			user_id: (p.user_id || p.id) as string,
-			user_name: (info.name || info.user_name || p.user_id || "") as string,
-			avatar: info.avatar as string | null,
-			audio_enabled:
-				typeof info.audio_enabled === "boolean" ? info.audio_enabled : false,
-			video_enabled:
-				typeof info.video_enabled === "boolean" ? info.video_enabled : false,
-			is_guest: Boolean(info.is_guest),
-			userData: info,
-		});
-	}
-	private sanitizeParticipant(p: ParticipantData): ParticipantData { const avatar = trustedAvatar(p.userData?.avatar || p.avatar, this.frappeOrigin); return { ...p, avatar, userData: { ...p.userData, avatar } }; }
+	private sanitizeParticipant(p: RecorderParticipantData): RecorderParticipantData { const avatar = trustedAvatar(p.userData?.avatar || p.avatar, this.frappeOrigin); return { ...p, avatar, userData: { ...p.userData, avatar } }; }
 	private frappeOrigin = "";
 	private removeProducer(event: ProducerEvent): void { for (const c of this.deps.consumerManager.getConsumersByParticipant(event.participantId || "")) if (c.producerId === event.producerId || (event.isScreen && c.isScreen)) this.deps.consumerManager.removeConsumer(c.id); }
 	private stopScreen(participantId: string): void { if (!participantId) return; for (const c of this.deps.consumerManager.getScreenShareConsumers().filter((c) => c.participantId === participantId)) this.deps.consumerManager.removeConsumer(c.id); this.state.screenStopped?.(participantId); }
-	private updateMedia(data: Record<string, unknown>): void { const action = data.action as { type?: string; enabled?: boolean } | string; const update: { audioEnabled?: boolean; videoEnabled?: boolean } = {}; if (typeof action === "object") action.type === "audio" ? update.audioEnabled = !!action.enabled : action.type === "video" ? update.videoEnabled = !!action.enabled : undefined; else if (action === "mute" || action === "unmute") update.audioEnabled = action === "unmute"; else if (action === "video_on" || action === "video_off") update.videoEnabled = action === "video_on"; this.deps.participantManager.updateMediaState(data.participantId as string, update); }
+	private updateMedia(data: MediaControlMessage): void { const action = data.action; const update: { audioEnabled?: boolean; videoEnabled?: boolean } = {}; if (typeof action === "object") action.type === "audio" ? update.audioEnabled = action.enabled : update.videoEnabled = action.enabled; else if (action === "mute" || action === "unmute") update.audioEnabled = action === "unmute"; else update.videoEnabled = action === "video_on"; this.deps.participantManager.updateMediaState(data.participantId, update); }
 	private interrupt(reason: string): void { if (!this._ready.value && this._interruption.value) return; this._ready.value = false; this._interruption.value = reason; this.bridge.reportInterruption(reason); }
 	private withTimeout(promise: Promise<void>, message: string): Promise<void> {
 		return new Promise((resolve, reject) => {
@@ -290,7 +331,7 @@ export class RecorderSocketController {
 				this.state.roomEmpty?.();
 		}, 10_000);
 	}
-	private request(event: string, data: unknown): Promise<void> { return new Promise((resolve, reject) => this.channel.emit(event, data, (value) => { const response = value as { success?: boolean; error?: string }; response?.success ? resolve() : reject(new Error(response?.error || `${event} failed`)); })); }
+	private request(event: string, data: { signature: string } | { roomId: string }): Promise<void> { return new Promise((resolve, reject) => this.channel.emit(event, data, (value) => { const response = parseRequestResponse(value); response?.success ? resolve() : reject(new Error(response?.error || `${event} failed`)); })); }
 }
 
 export function trustedAvatar(value: unknown, frappeOrigin: string): string | null {

--- a/frontend/recorder/frappeUi.ts
+++ b/frontend/recorder/frappeUi.ts
@@ -56,7 +56,7 @@ export const Avatar = defineComponent({
 });
 export const frappeRequest = () => Promise.reject(new Error("Frappe requests are unavailable in the recorder"));
 export const createResource = () => ({ data: {}, loading: false, fetch: () => Promise.resolve() });
-export const debounce = <T extends (...args: never[]) => unknown>(fn: T, wait: number) => {
+export const debounce = <T extends (...args: never[]) => void>(fn: T, wait: number) => {
 	let timer: ReturnType<typeof setTimeout>;
 	return (...args: Parameters<T>) => { clearTimeout(timer); timer = setTimeout(() => fn(...args), wait); };
 };

--- a/frontend/recorder/main.ts
+++ b/frontend/recorder/main.ts
@@ -27,11 +27,11 @@ const app = createApp({
 		const lobbyStore = useLobbyStore();
 		const gridLayout = useGridLayout(mediaState);
 		const messages = ref<Array<{ id: string; author: string; text: string; avatar?: string | null }>>([]);
-		const pendingScreenAttachments = new Map<string, { resolve: () => void; reject: (error: unknown) => void }>();
+		const pendingScreenAttachments = new Map<string, { resolve: () => void; reject: (error?: Error) => void }>();
 		const controller = new RecorderSocketController(bridge, undefined, {
 			participantAdded: (participant) => participantStore.addParticipant(participant),
 			participantRemoved: (id) => participantStore.removeParticipant(id),
-			participantUpdated: (id, updates) => participantStore.updateParticipant(id, updates),
+			participantUpdated: (id, updates) => participantStore.updateParticipant(id, { ...updates }),
 			activeSpeakersChanged: (ids) => { participantStore.activeSpeakerIds = ids; participantStore.stableSpeakerIds = ids; },
 			screenStarted: ({ participantId, consumerId, stream, startedAt }) => {
 				mediaState.screenShareStreams[consumerId] = stream;

--- a/frontend/recorder/protocol.ts
+++ b/frontend/recorder/protocol.ts
@@ -1,0 +1,401 @@
+export interface RecorderParticipantUserData {
+	name?: string;
+	avatar?: string | null;
+	audio_enabled?: boolean;
+	video_enabled?: boolean;
+	is_guest?: boolean;
+}
+
+export interface RecorderParticipantData {
+	participantId?: string;
+	user_id?: string;
+	user_name?: string;
+	avatar?: string | null;
+	audio_enabled?: boolean;
+	video_enabled?: boolean;
+	is_guest?: boolean;
+	userData?: RecorderParticipantUserData;
+}
+
+export interface RecorderParticipantUpdate {
+	participantId?: string;
+	user_id?: string;
+	user_name?: string;
+	avatar?: string | null;
+	initials?: string;
+	audio_enabled?: boolean;
+	video_enabled?: boolean;
+	is_guest?: boolean;
+	userData?: RecorderParticipantUserData;
+}
+
+export type ParticipantMessage =
+	| { type: "participant-joined"; value: RecorderParticipantData & { participantId: string } }
+	| { type: "participant-left"; value: { participantId: string } };
+
+export interface ProducerEvent {
+	producerId: string;
+	participantId: string;
+	isScreen: boolean;
+}
+
+export type ProducerMessage =
+	| { type: "producer-created"; value: ProducerEvent }
+	| { type: "producer-closed"; value: ProducerEvent };
+
+export type LegacyMediaControlAction =
+	| "mute"
+	| "unmute"
+	| "video_off"
+	| "video_on";
+
+export type MediaControlAction =
+	| LegacyMediaControlAction
+	| { type: "audio" | "video"; enabled: boolean };
+
+export type MediaControlMessage =
+	| { participantId: string; action: LegacyMediaControlAction }
+	| { participantId: string; action: { type: "audio" | "video"; enabled: boolean } };
+
+export interface ParticipantSnapshot {
+	id: string;
+	user_id?: string;
+	info: RecorderParticipantUserData & { user_name?: string };
+}
+
+export interface ProducerSnapshot {
+	id: string;
+	participantId: string;
+	isScreen: boolean;
+}
+
+export interface ChatMessage {
+	fromUser?: string;
+	fromName?: string;
+	message: string;
+	timestamp?: string;
+}
+
+export interface RecordingChallengeMessage {
+	version: 1;
+	jti: string;
+	socket_id: string;
+	nonce: string;
+	issued_at: number;
+	expires_at: number;
+}
+
+const optionalString = (value: unknown): value is string | undefined =>
+	value === undefined || typeof value === "string";
+const optionalBoolean = (value: unknown): value is boolean | undefined =>
+	value === undefined || typeof value === "boolean";
+const optionalAvatar = (value: unknown): value is string | null | undefined =>
+	value === undefined || value === null || typeof value === "string";
+
+const parseParticipantUserData = (
+	value: unknown,
+): RecorderParticipantUserData | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const name = "name" in value ? value.name : undefined;
+	const avatar = "avatar" in value ? value.avatar : undefined;
+	const audioEnabled =
+		"audio_enabled" in value ? value.audio_enabled : undefined;
+	const videoEnabled =
+		"video_enabled" in value ? value.video_enabled : undefined;
+	const isGuest = "is_guest" in value ? value.is_guest : undefined;
+	if (
+		!optionalString(name) ||
+		!optionalAvatar(avatar) ||
+		!optionalBoolean(audioEnabled) ||
+		!optionalBoolean(videoEnabled) ||
+		!optionalBoolean(isGuest)
+	) return null;
+	return {
+		name,
+		avatar,
+		audio_enabled: audioEnabled,
+		video_enabled: videoEnabled,
+		is_guest: isGuest,
+	};
+};
+
+export const parseParticipantMessage = (
+	type: ParticipantMessage["type"],
+	value: unknown,
+): ParticipantMessage | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const participantId =
+		"participantId" in value ? value.participantId : undefined;
+	if (typeof participantId !== "string" || !participantId) return null;
+	if (type === "participant-left") {
+		return { type, value: { participantId } };
+	}
+	const userDataValue = "userData" in value ? value.userData : undefined;
+	const userData =
+		userDataValue === undefined ? undefined : parseParticipantUserData(userDataValue);
+	if (userDataValue !== undefined && !userData) return null;
+	return { type, value: { participantId, ...(userData ? { userData } : {}) } };
+};
+
+export const parseProducerMessage = (
+	type: ProducerMessage["type"],
+	value: unknown,
+): ProducerMessage | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const producerId = "producerId" in value ? value.producerId : undefined;
+	const participantId =
+		"participantId" in value ? value.participantId : undefined;
+	const isScreen = "isScreen" in value ? value.isScreen : false;
+	if (
+		typeof producerId !== "string" ||
+		!producerId ||
+		typeof participantId !== "string" ||
+		!participantId ||
+		typeof isScreen !== "boolean"
+	) return null;
+	return { type, value: { producerId, participantId, isScreen } };
+};
+
+export const parseParticipantSnapshot = (
+	value: unknown,
+): ParticipantSnapshot | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const id = "id" in value ? value.id : undefined;
+	const userId = "user_id" in value ? value.user_id : undefined;
+	const infoValue = "info" in value ? value.info : undefined;
+	if (
+		typeof id !== "string" ||
+		!id ||
+		!optionalString(userId) ||
+		typeof infoValue !== "object" ||
+		infoValue === null
+	) return null;
+	const info = parseParticipantUserData(infoValue);
+	const userName = "user_name" in infoValue ? infoValue.user_name : undefined;
+	if (!info || !optionalString(userName)) return null;
+	return { id, user_id: userId, info: { ...info, user_name: userName } };
+};
+
+export const parseProducerSnapshot = (
+	value: unknown,
+): ProducerSnapshot | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const id = "id" in value ? value.id : undefined;
+	const participantId = "participantId" in value
+		? value.participantId
+		: "user_id" in value
+			? value.user_id
+			: "userId" in value
+				? value.userId
+				: undefined;
+	const isScreen = "isScreen" in value ? value.isScreen : false;
+	if (
+		typeof id !== "string" ||
+		!id ||
+		typeof participantId !== "string" ||
+		!participantId ||
+		typeof isScreen !== "boolean"
+	) return null;
+	return { id, participantId, isScreen };
+};
+
+export const parseMediaControlMessage = (
+	value: unknown,
+): MediaControlMessage | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const participantId =
+		"participantId" in value ? value.participantId : undefined;
+	const action = "action" in value ? value.action : undefined;
+	if (typeof participantId !== "string" || !participantId) return null;
+	if (
+		action === "mute" ||
+		action === "unmute" ||
+		action === "video_off" ||
+		action === "video_on"
+	) return { participantId, action };
+	if (typeof action !== "object" || action === null) return null;
+	const actionType = "type" in action ? action.type : undefined;
+	const enabled = "enabled" in action ? action.enabled : undefined;
+	if (
+		(actionType !== "audio" && actionType !== "video") ||
+		typeof enabled !== "boolean"
+	) return null;
+	return { participantId, action: { type: actionType, enabled } };
+};
+
+export const parseConsumerId = (value: unknown): string | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const consumerId = "consumerId" in value ? value.consumerId : undefined;
+	return typeof consumerId === "string" && consumerId ? consumerId : null;
+};
+
+export const parseParticipantId = (value: unknown): string | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const participantId =
+		"participantId" in value ? value.participantId : undefined;
+	return typeof participantId === "string" && participantId
+		? participantId
+		: null;
+};
+
+export const parseActiveSpeakers = (value: unknown): string[] | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const participantIds =
+		"participantIds" in value ? value.participantIds : undefined;
+	return Array.isArray(participantIds) &&
+		participantIds.every((id) => typeof id === "string" && id)
+		? participantIds
+		: null;
+};
+
+export const parseReaction = (
+	value: unknown,
+): { fromUser: string; reaction: string } | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const fromUser = "fromUser" in value ? value.fromUser : undefined;
+	const reaction = "reaction" in value ? value.reaction : undefined;
+	return typeof fromUser === "string" && fromUser &&
+		typeof reaction === "string" && reaction
+		? { fromUser, reaction }
+		: null;
+};
+
+export const parseHandChange = (
+	value: unknown,
+): { participantId: string; raised: boolean; timestamp: string } | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const participantId =
+		"participantId" in value ? value.participantId : undefined;
+	const raised = "raised" in value ? value.raised : undefined;
+	const timestamp = "timestamp" in value ? value.timestamp : undefined;
+	if (
+		typeof participantId !== "string" ||
+		!participantId ||
+		typeof raised !== "boolean" ||
+		!optionalString(timestamp)
+	) return null;
+	return {
+		participantId,
+		raised,
+		timestamp: timestamp || new Date().toISOString(),
+	};
+};
+
+export const parseRaisedHands = (
+	value: unknown,
+): Record<string, string> | null => {
+	if (typeof value !== "object" || value === null || !("hands" in value))
+		return null;
+	const hands = value.hands;
+	if (typeof hands !== "object" || hands === null || Array.isArray(hands))
+		return null;
+	const entries = Object.entries(hands);
+	if (entries.some(([, timestamp]) => typeof timestamp !== "string")) return null;
+	return Object.fromEntries(entries);
+};
+
+export const parseChatMessage = (value: unknown): ChatMessage | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const fromUser = "fromUser" in value ? value.fromUser : undefined;
+	const fromName = "fromName" in value ? value.fromName : undefined;
+	const message = "message" in value ? value.message : undefined;
+	const timestamp = "timestamp" in value ? value.timestamp : undefined;
+	if (
+		!optionalString(fromUser) ||
+		!optionalString(fromName) ||
+		typeof message !== "string" ||
+		!message ||
+		!optionalString(timestamp)
+	) return null;
+	return { fromUser, fromName, message, timestamp };
+};
+
+export const parseParticipantUpdate = (
+	value: unknown,
+): RecorderParticipantUpdate | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const participantId =
+		"participantId" in value ? value.participantId : undefined;
+	const userId = "user_id" in value ? value.user_id : undefined;
+	const userName = "user_name" in value ? value.user_name : undefined;
+	const avatar = "avatar" in value ? value.avatar : undefined;
+	const initials = "initials" in value ? value.initials : undefined;
+	const audioEnabled =
+		"audio_enabled" in value ? value.audio_enabled : undefined;
+	const videoEnabled =
+		"video_enabled" in value ? value.video_enabled : undefined;
+	const isGuest = "is_guest" in value ? value.is_guest : undefined;
+	const userDataValue = "userData" in value ? value.userData : undefined;
+	const userData = userDataValue === undefined
+		? undefined
+		: parseParticipantUserData(userDataValue);
+	if (
+		!optionalString(participantId) ||
+		!optionalString(userId) ||
+		!optionalString(userName) ||
+		!optionalAvatar(avatar) ||
+		!optionalString(initials) ||
+		!optionalBoolean(audioEnabled) ||
+		!optionalBoolean(videoEnabled) ||
+		!optionalBoolean(isGuest) ||
+		(userDataValue !== undefined && !userData)
+	) return null;
+	return {
+		...("participantId" in value ? { participantId } : {}),
+		...("user_id" in value ? { user_id: userId } : {}),
+		...("user_name" in value ? { user_name: userName } : {}),
+		...("avatar" in value ? { avatar } : {}),
+		...("initials" in value ? { initials } : {}),
+		...("audio_enabled" in value ? { audio_enabled: audioEnabled } : {}),
+		...("video_enabled" in value ? { video_enabled: videoEnabled } : {}),
+		...("is_guest" in value ? { is_guest: isGuest } : {}),
+		...("userData" in value ? { userData: userData || undefined } : {}),
+	};
+};
+
+export const parseRecordingChallenge = (
+	value: unknown,
+): RecordingChallengeMessage | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const version = "version" in value ? value.version : undefined;
+	const jti = "jti" in value ? value.jti : undefined;
+	const socketId = "socket_id" in value ? value.socket_id : undefined;
+	const nonce = "nonce" in value ? value.nonce : undefined;
+	const issuedAt = "issued_at" in value ? value.issued_at : undefined;
+	const expiresAt = "expires_at" in value ? value.expires_at : undefined;
+	if (
+		version !== 1 ||
+		typeof jti !== "string" || !jti ||
+		typeof socketId !== "string" || !socketId ||
+		typeof nonce !== "string" || !nonce ||
+		typeof issuedAt !== "number" || !Number.isFinite(issuedAt) ||
+		typeof expiresAt !== "number" || !Number.isFinite(expiresAt)
+	) return null;
+	return { version, jti, socket_id: socketId, nonce, issued_at: issuedAt, expires_at: expiresAt };
+};
+
+export const parseRequestResponse = (
+	value: unknown,
+): { success: boolean; error?: string } | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const success = "success" in value ? value.success : undefined;
+	const error = "error" in value ? value.error : undefined;
+	if (typeof success !== "boolean" || !optionalString(error)) return null;
+	return { success, error };
+};
+
+export const parseScreenShareStarted = (
+	value: unknown,
+): { participantId: string; consumerId: string; stream: MediaStream } | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const participantId = "participantId" in value ? value.participantId : undefined;
+	const stream = "stream" in value ? value.stream : undefined;
+	const consumer = "consumer" in value ? value.consumer : undefined;
+	if (
+		typeof participantId !== "string" || !participantId ||
+		(typeof MediaStream === "undefined" || !(stream instanceof MediaStream)) ||
+		typeof consumer !== "object" || consumer === null ||
+		!("id" in consumer) || typeof consumer.id !== "string" || !consumer.id
+	) return null;
+	return { participantId, consumerId: consumer.id, stream };
+};

--- a/frontend/recorder/rendererBridge.test.ts
+++ b/frontend/recorder/rendererBridge.test.ts
@@ -34,6 +34,8 @@ describe("RecorderRendererBridge", () => {
 		const config: RecorderConfig = { job: "job", grant: "grant", meetingId: "room", sfuOrigin: "https://sfu.test", frappeOrigin: "https://frappe.test", socketPath: "/socket.io", startedAt: 1 };
 		const bridge = new RecorderRendererBridge();
 		const pending = bridge.waitForConfig(source);
+		listeners[0](new MessageEvent("message", { data: { type: "suite-recorder:configure", config: { ...config, startedAt: "now" } }, origin: window.location.origin, source: window }));
+		expect(source.removeEventListener).not.toHaveBeenCalled();
 		listeners[0](new MessageEvent("message", { data: { type: "suite-recorder:configure", config }, origin: window.location.origin, source: window }));
 
 		expect(await pending).toEqual(config);

--- a/frontend/recorder/rendererBridge.ts
+++ b/frontend/recorder/rendererBridge.ts
@@ -18,7 +18,20 @@ export interface RecordingChallenge {
 	expires_at: number;
 }
 
-export const canonicalChallenge = (challenge: RecordingChallenge): Uint8Array =>
+type RendererReport =
+	| { type: "suite-recorder:capture-ready" }
+	| { type: "suite-recorder:interruption"; reason: string }
+	| { type: "suite-recorder:proof-complete" }
+	| { type: "suite-recorder:join-complete" }
+	| { type: "suite-recorder:room-empty" }
+	| { type: "suite-recorder:failure"; reason: string };
+
+export type OutboundRendererMessage =
+	| { type: "suite-recorder:public-key-ready"; publicKey: JsonWebKey }
+	| { type: "suite-recorder:configuration-accepted"; job: string }
+	| (RendererReport & { job: string });
+
+export const canonicalChallenge = (challenge: RecordingChallenge): Uint8Array<ArrayBuffer> =>
 	new TextEncoder().encode(`meet-recording-proof-v1\n${challenge.jti}\n${challenge.socket_id}\n${challenge.nonce}\n${challenge.issued_at}\n${challenge.expires_at}`);
 
 const base64url = (bytes: ArrayBuffer): string => {
@@ -32,7 +45,7 @@ export class RecorderRendererBridge {
 	private configured = false;
 	private job?: string;
 
-	private post(message: Record<string, unknown>, target: Pick<Window, "postMessage"> = window): void {
+	private post(message: OutboundRendererMessage, target: Pick<Window, "postMessage"> = window): void {
 		target.postMessage(message, window.location.origin);
 	}
 
@@ -52,8 +65,8 @@ export class RecorderRendererBridge {
 		return new Promise((resolve) => {
 			const receive = (event: MessageEvent) => {
 				if (this.configured || event.source !== window || event.origin !== window.location.origin) return;
-				const message = event.data as { type?: string; config?: RecorderConfig };
-				if (message?.type !== "suite-recorder:configure" || !isConfig(message.config)) return;
+				const message = parseConfigureMessage(event.data);
+				if (!message) return;
 				this.configured = true;
 				this.job = message.config.job;
 				source.removeEventListener("message", receive as EventListener);
@@ -75,37 +88,78 @@ export class RecorderRendererBridge {
 	}
 
 	reportCaptureReady(target: Pick<Window, "postMessage"> = window): void {
-		this.report("capture-ready", {}, target);
+		this.report({ type: "suite-recorder:capture-ready" }, target);
 	}
 
 	reportInterruption(reason: string, target: Pick<Window, "postMessage"> = window): void {
-		this.report("interruption", { reason }, target);
+		this.report({ type: "suite-recorder:interruption", reason }, target);
 	}
 
 	reportProofComplete(target: Pick<Window, "postMessage"> = window): void {
-		this.report("proof-complete", {}, target);
+		this.report({ type: "suite-recorder:proof-complete" }, target);
 	}
 
 	reportJoinComplete(target: Pick<Window, "postMessage"> = window): void {
-		this.report("join-complete", {}, target);
+		this.report({ type: "suite-recorder:join-complete" }, target);
 	}
 
 	reportRoomEmpty(target: Pick<Window, "postMessage"> = window): void {
-		this.report("room-empty", {}, target);
+		this.report({ type: "suite-recorder:room-empty" }, target);
 	}
 
 	reportFailure(reason: string, target: Pick<Window, "postMessage"> = window): void {
-		this.report("failure", { reason }, target);
+		this.report({ type: "suite-recorder:failure", reason }, target);
 	}
 
-	private report(type: string, fields: Record<string, unknown>, target: Pick<Window, "postMessage">): void {
+	private report(message: RendererReport, target: Pick<Window, "postMessage">): void {
 		if (!this.job) return;
-		this.post({ type: `suite-recorder:${type}`, job: this.job, ...fields }, target);
+		this.post({ ...message, job: this.job }, target);
 	}
 }
 
-const isConfig = (value: unknown): value is RecorderConfig => {
-	if (!value || typeof value !== "object") return false;
-	const config = value as Record<string, unknown>;
-	return ["job", "grant", "meetingId", "sfuOrigin", "frappeOrigin", "socketPath"].every((key) => typeof config[key] === "string" && config[key] !== "") && typeof config.startedAt === "number";
+const isHttpUrl = (value: string): boolean => {
+	try {
+		return ["http:", "https:"].includes(new URL(value).protocol);
+	} catch {
+		return false;
+	}
+};
+
+const parseConfig = (value: unknown): RecorderConfig | null => {
+	if (!value || typeof value !== "object") return null;
+	if (!("job" in value) || typeof value.job !== "string" || !value.job ||
+		!("grant" in value) || typeof value.grant !== "string" || !value.grant ||
+		!("meetingId" in value) || typeof value.meetingId !== "string" || !value.meetingId ||
+		!("sfuOrigin" in value) || typeof value.sfuOrigin !== "string" || !isHttpUrl(value.sfuOrigin) ||
+		!("frappeOrigin" in value) || typeof value.frappeOrigin !== "string" || !isHttpUrl(value.frappeOrigin) ||
+		!("socketPath" in value) || typeof value.socketPath !== "string" || !value.socketPath ||
+		!("startedAt" in value) || typeof value.startedAt !== "number" || !Number.isFinite(value.startedAt) ||
+		("publicChat" in value && value.publicChat !== undefined && typeof value.publicChat !== "boolean")
+	) return null;
+	return {
+		job: value.job,
+		grant: value.grant,
+		meetingId: value.meetingId,
+		sfuOrigin: value.sfuOrigin,
+		frappeOrigin: value.frappeOrigin,
+		socketPath: value.socketPath,
+		startedAt: value.startedAt,
+		...("publicChat" in value && typeof value.publicChat === "boolean"
+			? { publicChat: value.publicChat }
+			: {}),
+	};
+};
+
+const parseConfigureMessage = (
+	value: unknown,
+): { type: "suite-recorder:configure"; config: RecorderConfig } | null => {
+	if (
+		typeof value !== "object" ||
+		value === null ||
+		!("type" in value) ||
+		value.type !== "suite-recorder:configure" ||
+		!("config" in value)
+	) return null;
+	const config = parseConfig(value.config);
+	return config ? { type: value.type, config } : null;
 };

--- a/suite/meet/recorder-server/src/AuthManager.ts
+++ b/suite/meet/recorder-server/src/AuthManager.ts
@@ -53,36 +53,53 @@ export function validUtcTimestamp(value: unknown): value is string {
 }
 
 export function validLimits(value: unknown): value is RecordingLimits {
+	return parseLimits(value) !== null;
+}
+
+function parseLimits(value: unknown): RecordingLimits | null {
 	if (
 		!value ||
 		typeof value !== 'object' ||
 		Array.isArray(value) ||
 		!exactKeys(value, LIMIT_KEYS)
 	)
-		return false;
-	const limits = value as Record<string, unknown>;
+		return null;
 	if (
-		!Number.isSafeInteger(limits.budget_bytes) ||
-		(limits.budget_bytes as number) <= 0
+		!('budget_bytes' in value) ||
+		typeof value.budget_bytes !== 'number' ||
+		!Number.isSafeInteger(value.budget_bytes) ||
+		value.budget_bytes <= 0 ||
+		!('max_ends_at' in value) ||
+		!validUtcTimestamp(value.max_ends_at) ||
+		!('output' in value)
 	)
-		return false;
-	if (!validUtcTimestamp(limits.max_ends_at)) return false;
-	const output = limits.output;
+		return null;
+	const output = value.output;
 	if (
 		!output ||
 		typeof output !== 'object' ||
 		Array.isArray(output) ||
 		!exactKeys(output, OUTPUT_KEYS)
 	)
-		return false;
-	const out = output as Record<string, unknown>;
-	return (
-		out.width === 1920 &&
-		out.height === 1080 &&
-		out.fps === 30 &&
-		out.video === 'h264' &&
-		out.audio === 'aac'
-	);
+		return null;
+	if (
+		!('width' in output) ||
+		output.width !== 1920 ||
+		!('height' in output) ||
+		output.height !== 1080 ||
+		!('fps' in output) ||
+		output.fps !== 30 ||
+		!('video' in output) ||
+		output.video !== 'h264' ||
+		!('audio' in output) ||
+		output.audio !== 'aac'
+	)
+		return null;
+	return {
+		budget_bytes: value.budget_bytes,
+		max_ends_at: value.max_ends_at,
+		output: { width: 1920, height: 1080, fps: 30, video: 'h264', audio: 'aac' },
+	};
 }
 
 export class AuthManager {
@@ -137,7 +154,7 @@ export class AuthManager {
 			!exactKeys(decoded, CLAIM_KEYS)
 		)
 			throw new AuthError('invalid claims');
-		const claims = decoded as unknown as CommandClaims;
+		const claims = parseCommandClaims(decoded);
 		if (
 			claims.aud !== COMMAND_AUDIENCE ||
 			claims.operation !== expectedOperation ||
@@ -158,7 +175,6 @@ export class AuthManager {
 			claims.iat < now - 35
 		)
 			throw new AuthError('invalid command lifetime');
-		if (!validLimits(claims.limits)) throw new AuthError('invalid limits');
 		return claims;
 	}
 
@@ -173,4 +189,56 @@ export class AuthManager {
 			actual.length === expected.length && timingSafeEqual(actual, expected)
 		);
 	}
+}
+
+function parseCommandClaims(value: unknown): CommandClaims {
+	if (
+		!value ||
+		typeof value !== 'object' ||
+		Array.isArray(value) ||
+		!exactKeys(value, CLAIM_KEYS)
+	) {
+		throw new AuthError('invalid claims');
+	}
+	if (
+		!('aud' in value) ||
+		value.aud !== COMMAND_AUDIENCE ||
+		!('operation' in value) ||
+		(value.operation !== 'reserve' &&
+			value.operation !== 'query' &&
+			value.operation !== 'grant' &&
+			value.operation !== 'stop') ||
+		!('iat' in value) ||
+		typeof value.iat !== 'number' ||
+		!Number.isSafeInteger(value.iat) ||
+		!('exp' in value) ||
+		typeof value.exp !== 'number' ||
+		!Number.isSafeInteger(value.exp) ||
+		!('limits' in value)
+	) {
+		throw new AuthError('invalid claims');
+	}
+	const limits = parseLimits(value.limits);
+	if (!limits) throw new AuthError('invalid limits');
+	return {
+		iss: claimString(value, 'iss'),
+		aud: COMMAND_AUDIENCE,
+		site: claimString(value, 'site'),
+		origin: claimString(value, 'origin'),
+		room: claimString(value, 'room'),
+		recording: claimString(value, 'recording'),
+		job: claimString(value, 'job'),
+		operation: value.operation,
+		limits,
+		jti: claimString(value, 'jti'),
+		iat: value.iat,
+		exp: value.exp,
+	};
+}
+
+function claimString(value: object, key: string): string {
+	if (!(key in value)) throw new AuthError('invalid claims');
+	const claim = value[key as keyof typeof value];
+	if (typeof claim !== 'string') throw new AuthError('invalid claims');
+	return claim;
 }

--- a/suite/meet/recorder-server/src/CallbackClient.test.ts
+++ b/suite/meet/recorder-server/src/CallbackClient.test.ts
@@ -10,6 +10,7 @@ import type { JobRecord } from './types.js';
 const roots: string[] = [];
 
 afterEach(async () => {
+	vi.useRealTimers();
 	vi.unstubAllGlobals();
 	await Promise.all(
 		roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
@@ -52,7 +53,8 @@ describe('CallbackClient', () => {
 		});
 	});
 
-	it('uploads a finalized artifact with scoped chunk tokens', async () => {
+	it('rejects string offsets while uploading with scoped chunk tokens', async () => {
+		vi.useFakeTimers();
 		const root = join(tmpdir(), `callback-client-${crypto.randomUUID()}`);
 		roots.push(root);
 		const content = Buffer.from('recording artifact');
@@ -100,10 +102,12 @@ describe('CallbackClient', () => {
 			requests.push({ url: String(url), init });
 			const message =
 				requests.length === 1
-					? { offset: 0, complete: false }
+					? { offset: '0', complete: false }
 					: requests.length === 2
-						? { offset: content.length }
-						: { artifact: 'file', status: 'Ready' };
+						? { offset: 0, complete: false }
+						: requests.length === 3
+							? { offset: content.length }
+							: { artifact: 'file', status: 'Ready' };
 			return new Response(JSON.stringify({ message }), {
 				status: 200,
 				headers: { 'Content-Type': 'application/json' },
@@ -112,15 +116,19 @@ describe('CallbackClient', () => {
 		vi.stubGlobal('fetch', fetch);
 		const secret = 's'.repeat(32);
 
-		await new CallbackClient({
+		const upload = new CallbackClient({
 			origin: 'https://site.test',
 			site: 'site.test',
 			secret,
 			dataRoot: root,
 		}).upload(job);
+		await vi.advanceTimersByTimeAsync(1_000);
+		await upload;
 
-		expect(requests).toHaveLength(3);
-		expect(JSON.parse(String(requests[0]?.init.body))).toMatchObject({
+		expect(requests).toHaveLength(4);
+		expect(requests[0]?.url).toContain('recorder_stopped');
+		expect(requests[1]?.url).toContain('recorder_stopped');
+		expect(JSON.parse(String(requests[1]?.init.body))).toMatchObject({
 			gaps: [
 				{
 					started_at: '2026-01-01T00:00:59.000Z',
@@ -129,8 +137,8 @@ describe('CallbackClient', () => {
 				},
 			],
 		});
-		expect(Buffer.from(requests[1]?.init.body as Uint8Array)).toEqual(content);
-		const authorization = new Headers(requests[1]?.init.headers).get(
+		expect(Buffer.from(requests[2]?.init.body as Uint8Array)).toEqual(content);
+		const authorization = new Headers(requests[2]?.init.headers).get(
 			'X-Meet-Recorder-Authorization',
 		);
 		const token = authorization?.slice('Bearer '.length) ?? '';

--- a/suite/meet/recorder-server/src/CallbackClient.ts
+++ b/suite/meet/recorder-server/src/CallbackClient.ts
@@ -17,6 +17,70 @@ interface CallbackClientOptions {
 	timeoutMs?: number;
 }
 
+interface InterruptedRequest {
+	recording_id: string;
+	job: string;
+	event_sequence: 2;
+	reason: string;
+}
+
+interface FailedRequest {
+	recording_id: string;
+	job: string;
+	event_sequence: 3;
+	failure_code: 'capture_failed';
+}
+
+interface StoppedRequest {
+	recording_id: string;
+	job: string;
+	event_sequence: 3;
+	size: number;
+	sha256: string;
+	duration_ms: number;
+	ended_at: string;
+	end_reason: string;
+	gaps: Array<{ started_at: string; ended_at: string; reason: string }>;
+}
+
+interface CompleteUploadRequest {
+	recording_id: string;
+	job: string;
+	event_sequence: 4;
+}
+
+type CallbackRequest =
+	| InterruptedRequest
+	| FailedRequest
+	| StoppedRequest
+	| CompleteUploadRequest;
+
+type CallbackMethod =
+	| 'recorder_interrupted'
+	| 'recorder_failed'
+	| 'recorder_stopped'
+	| 'recorder_complete_upload';
+
+type CallbackOperation =
+	| 'interrupted'
+	| 'failed'
+	| 'stopped'
+	| 'upload_chunk'
+	| 'complete_upload';
+
+interface StatusResponse {
+	status: string;
+}
+
+interface UploadStartResponse {
+	offset: number;
+	complete: boolean;
+}
+
+interface UploadChunkResponse {
+	offset: number;
+}
+
 export class CallbackClient {
 	private readonly timeoutMs: number;
 	constructor(private readonly options: CallbackClientOptions) {
@@ -24,12 +88,19 @@ export class CallbackClient {
 	}
 
 	async interrupted(job: JobRecord): Promise<void> {
-		await this.json('recorder_interrupted', job, 'interrupted', '2', {
-			recording_id: job.recording,
-			job: job.job,
-			event_sequence: 2,
-			reason: job.health_reason ?? 'capture_interrupted',
-		});
+		await this.json(
+			'recorder_interrupted',
+			job,
+			'interrupted',
+			'2',
+			{
+				recording_id: job.recording,
+				job: job.job,
+				event_sequence: 2,
+				reason: job.health_reason ?? 'capture_interrupted',
+			},
+			parseStatusResponse,
+		);
 	}
 
 	async upload(job: JobRecord): Promise<void> {
@@ -52,12 +123,19 @@ export class CallbackClient {
 
 	private async performUpload(job: JobRecord): Promise<void> {
 		if (job.state === 'failed') {
-			await this.json('recorder_failed', job, 'failed', '3', {
-				recording_id: job.recording,
-				job: job.job,
-				event_sequence: 3,
-				failure_code: 'capture_failed',
-			});
+			await this.json(
+				'recorder_failed',
+				job,
+				'failed',
+				'3',
+				{
+					recording_id: job.recording,
+					job: job.job,
+					event_sequence: 3,
+					failure_code: 'capture_failed',
+				},
+				parseStatusResponse,
+			);
 			return;
 		}
 		const artifact = job.artifact;
@@ -69,23 +147,30 @@ export class CallbackClient {
 		)
 			throw new Error('terminal recording artifact is incomplete');
 		const stoppedSequence = 3;
-		const begun = await this.json('recorder_stopped', job, 'stopped', '3', {
-			recording_id: job.recording,
-			job: job.job,
-			event_sequence: stoppedSequence,
-			size: artifact.bytes,
-			sha256: artifact.sha256,
-			duration_ms: artifact.duration_ms,
-			ended_at: job.terminal_at ?? new Date().toISOString(),
-			end_reason: this.endReason(job),
-			gaps: (artifact.gaps ?? []).map((gap) => ({
-				started_at: gap.started_at,
-				ended_at: gap.ended_at ?? job.terminal_at ?? new Date().toISOString(),
-				reason: this.gapReason(gap.reason),
-			})),
-		});
+		const begun = await this.json(
+			'recorder_stopped',
+			job,
+			'stopped',
+			'3',
+			{
+				recording_id: job.recording,
+				job: job.job,
+				event_sequence: stoppedSequence,
+				size: artifact.bytes,
+				sha256: artifact.sha256,
+				duration_ms: artifact.duration_ms,
+				ended_at: job.terminal_at ?? new Date().toISOString(),
+				end_reason: this.endReason(job),
+				gaps: (artifact.gaps ?? []).map((gap) => ({
+					started_at: gap.started_at,
+					ended_at: gap.ended_at ?? job.terminal_at ?? new Date().toISOString(),
+					reason: this.gapReason(gap.reason),
+				})),
+			},
+			parseUploadStartResponse,
+		);
 		if (begun.complete === true) return;
-		let offset = Number(begun.offset);
+		let offset = begun.offset;
 		if (!Number.isSafeInteger(offset) || offset < 0 || offset > artifact.bytes)
 			throw new Error('invalid Frappe upload offset');
 
@@ -103,7 +188,7 @@ export class CallbackClient {
 					throw new Error('recording artifact ended early');
 				const hash = createHash('sha256').update(chunk).digest('hex');
 				const result = await this.binary(job, offset, hash, chunk);
-				const next = Number(result.offset);
+				const next = result.offset;
 				if (next !== offset + length)
 					throw new Error('invalid Frappe upload acknowledgement');
 				offset = next;
@@ -111,11 +196,18 @@ export class CallbackClient {
 		} finally {
 			await file.close();
 		}
-		await this.json('recorder_complete_upload', job, 'complete_upload', '4', {
-			recording_id: job.recording,
-			job: job.job,
-			event_sequence: 4,
-		});
+		await this.json(
+			'recorder_complete_upload',
+			job,
+			'complete_upload',
+			'4',
+			{
+				recording_id: job.recording,
+				job: job.job,
+				event_sequence: 4,
+			},
+			parseStatusResponse,
+		);
 	}
 
 	private async binary(
@@ -123,7 +215,7 @@ export class CallbackClient {
 		offset: number,
 		hash: string,
 		chunk: Buffer,
-	): Promise<Record<string, unknown>> {
+	): Promise<UploadChunkResponse> {
 		const operationId = `${offset}:${hash}`;
 		const url = new URL(
 			'/api/method/suite.meet.api.recording.recorder_upload_chunk',
@@ -135,38 +227,54 @@ export class CallbackClient {
 		url.searchParams.set('chunk_sha256', hash);
 		const body = new Uint8Array(chunk.length);
 		body.set(chunk);
-		return this.request(url, job, 'upload_chunk', operationId, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/octet-stream' },
-			body,
-		});
+		return this.request(
+			url,
+			job,
+			'upload_chunk',
+			operationId,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/octet-stream' },
+				body,
+			},
+			parseUploadChunkResponse,
+		);
 	}
 
-	private json(
-		method: string,
+	private json<T>(
+		method: CallbackMethod,
 		job: JobRecord,
-		operation: string,
+		operation: Exclude<CallbackOperation, 'upload_chunk'>,
 		operationId: string,
-		body: Record<string, unknown>,
-	): Promise<Record<string, unknown>> {
+		body: CallbackRequest,
+		parseResponse: (value: unknown) => T,
+	): Promise<T> {
 		const url = new URL(
 			`/api/method/suite.meet.api.recording.${method}`,
 			this.options.origin,
 		);
-		return this.request(url, job, operation, operationId, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(body),
-		});
+		return this.request(
+			url,
+			job,
+			operation,
+			operationId,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(body),
+			},
+			parseResponse,
+		);
 	}
 
-	private async request(
+	private async request<T>(
 		url: URL,
 		job: JobRecord,
-		operation: string,
+		operation: CallbackOperation,
 		operationId: string,
 		init: RequestInit,
-	): Promise<Record<string, unknown>> {
+		parseResponse: (value: unknown) => T,
+	): Promise<T> {
 		const response = await fetch(url, {
 			...init,
 			headers: {
@@ -179,22 +287,18 @@ export class CallbackClient {
 		if (!response.ok || text.length > 64 * 1024)
 			throw new Error(`Frappe callback failed with HTTP ${response.status}`);
 		const parsed: unknown = JSON.parse(text);
-		if (
-			!parsed ||
-			typeof parsed !== 'object' ||
-			Array.isArray(parsed) ||
-			!('message' in parsed) ||
-			!(parsed as { message?: unknown }).message ||
-			typeof (parsed as { message: unknown }).message !== 'object' ||
-			Array.isArray((parsed as { message: unknown }).message)
-		)
+		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
 			throw new Error('invalid Frappe callback response');
-		return (parsed as { message: Record<string, unknown> }).message;
+		}
+		if (!('message' in parsed)) {
+			throw new Error('invalid Frappe callback response');
+		}
+		return parseResponse(parsed.message);
 	}
 
 	private token(
 		job: JobRecord,
-		operation: string,
+		operation: CallbackOperation,
 		operationId: string,
 	): string {
 		const now = Math.floor(Date.now() / 1000);
@@ -235,4 +339,47 @@ export class CallbackClient {
 		if (reason.includes('renderer')) return 'renderer_interrupted';
 		return 'capture_interrupted';
 	}
+}
+
+function parseStatusResponse(value: unknown): StatusResponse {
+	if (
+		!value ||
+		typeof value !== 'object' ||
+		Array.isArray(value) ||
+		!('status' in value) ||
+		typeof value.status !== 'string'
+	) {
+		throw new Error('invalid Frappe callback response');
+	}
+	return { status: value.status };
+}
+
+function parseUploadStartResponse(value: unknown): UploadStartResponse {
+	if (
+		!value ||
+		typeof value !== 'object' ||
+		Array.isArray(value) ||
+		!('complete' in value) ||
+		typeof value.complete !== 'boolean' ||
+		!('offset' in value) ||
+		typeof value.offset !== 'number' ||
+		!Number.isSafeInteger(value.offset)
+	) {
+		throw new Error('invalid Frappe callback response');
+	}
+	return { complete: value.complete, offset: value.offset };
+}
+
+function parseUploadChunkResponse(value: unknown): UploadChunkResponse {
+	if (
+		!value ||
+		typeof value !== 'object' ||
+		Array.isArray(value) ||
+		!('offset' in value) ||
+		typeof value.offset !== 'number' ||
+		!Number.isSafeInteger(value.offset)
+	) {
+		throw new Error('invalid Frappe callback response');
+	}
+	return { offset: value.offset };
 }

--- a/suite/meet/recorder-server/src/Finalizer.ts
+++ b/suite/meet/recorder-server/src/Finalizer.ts
@@ -32,9 +32,105 @@ async function command(program: string, args: string[]): Promise<string> {
 	});
 }
 
-function rate(value: string): number {
-	const [a = 0, b = 1] = value.split('/').map(Number);
-	return a / b;
+function rate(value: unknown): number {
+	if (
+		typeof value !== 'string' ||
+		!/^\d+(?:\.\d+)?\/\d+(?:\.\d+)?$/.test(value)
+	) {
+		return Number.NaN;
+	}
+	const [numerator, denominator] = value.split('/').map(Number);
+	return denominator ? (numerator ?? 0) / denominator : Number.NaN;
+}
+
+function decimal(value: unknown): number {
+	if (typeof value !== 'string' || !/^-?\d+(?:\.\d+)?$/.test(value)) {
+		return Number.NaN;
+	}
+	return Number(value);
+}
+
+function validateFfprobeOutput(value: unknown): MediaProbe {
+	if (
+		!value ||
+		typeof value !== 'object' ||
+		Array.isArray(value) ||
+		!('streams' in value) ||
+		!Array.isArray(value.streams) ||
+		value.streams.length !== 2 ||
+		!('format' in value) ||
+		!value.format ||
+		typeof value.format !== 'object' ||
+		Array.isArray(value.format)
+	) {
+		throw new Error('invalid ffprobe output');
+	}
+	const video = value.streams.find(
+		(stream) =>
+			stream &&
+			typeof stream === 'object' &&
+			!Array.isArray(stream) &&
+			'codec_type' in stream &&
+			stream.codec_type === 'video',
+	);
+	const audio = value.streams.find(
+		(stream) =>
+			stream &&
+			typeof stream === 'object' &&
+			!Array.isArray(stream) &&
+			'codec_type' in stream &&
+			stream.codec_type === 'audio',
+	);
+	if (!video || !audio) throw new Error('invalid stream types');
+	const videoStart =
+		'start_time' in video ? decimal(video.start_time) : Number.NaN;
+	const frameRate =
+		'avg_frame_rate' in video ? rate(video.avg_frame_rate) : Number.NaN;
+	if (
+		!('codec_name' in video) ||
+		video.codec_name !== 'h264' ||
+		!('profile' in video) ||
+		video.profile !== 'High' ||
+		!('width' in video) ||
+		video.width !== 1920 ||
+		!('height' in video) ||
+		video.height !== 1080 ||
+		!('pix_fmt' in video) ||
+		video.pix_fmt !== 'yuv420p' ||
+		!Number.isFinite(frameRate) ||
+		Math.abs(frameRate - 30) > 1 ||
+		!Number.isFinite(videoStart) ||
+		videoStart < 0
+	) {
+		throw new Error('invalid video invariant');
+	}
+	const audioStart =
+		'start_time' in audio ? decimal(audio.start_time) : Number.NaN;
+	if (
+		!('codec_name' in audio) ||
+		audio.codec_name !== 'aac' ||
+		!('profile' in audio) ||
+		audio.profile !== 'LC' ||
+		!('sample_rate' in audio) ||
+		decimal(audio.sample_rate) !== 48000 ||
+		!('channels' in audio) ||
+		audio.channels !== 2 ||
+		!Number.isFinite(audioStart) ||
+		audioStart < 0 ||
+		Math.abs(videoStart - audioStart) > 0.1
+	) {
+		throw new Error('invalid audio invariant');
+	}
+	const duration =
+		'duration' in value.format ? decimal(value.format.duration) : Number.NaN;
+	if (!Number.isFinite(duration) || duration <= 0) {
+		throw new Error('invalid media duration');
+	}
+	return {
+		duration_ms: Math.round(duration * 1000),
+		video: { codec: 'h264', width: 1920, height: 1080, fps: 30 },
+		audio: { codec: 'aac', sample_rate: 48000, channels: 2 },
+	};
 }
 
 async function fileDigest(
@@ -53,7 +149,7 @@ export class FfmpegMediaTools implements MediaTools {
 	) {}
 	async validate(path: string): Promise<MediaProbe> {
 		await command(this.ffmpeg, ['-v', 'error', '-i', path, '-f', 'null', '-']);
-		const parsed = JSON.parse(
+		const parsed: unknown = JSON.parse(
 			await command(this.ffprobe, [
 				'-v',
 				'error',
@@ -63,44 +159,8 @@ export class FfmpegMediaTools implements MediaTools {
 				'json',
 				path,
 			]),
-		) as {
-			streams: Array<Record<string, unknown>>;
-			format: Record<string, unknown>;
-		};
-		if (parsed.streams.length !== 2) throw new Error('invalid stream count');
-		const video = parsed.streams.find((s) => s.codec_type === 'video');
-		const audio = parsed.streams.find((s) => s.codec_type === 'audio');
-		const videoStart = Number(video?.start_time);
-		const audioStart = Number(audio?.start_time);
-		if (
-			video?.codec_name !== 'h264' ||
-			video.profile !== 'High' ||
-			video.width !== 1920 ||
-			video.height !== 1080 ||
-			video.pix_fmt !== 'yuv420p' ||
-			Math.abs(rate(String(video.avg_frame_rate)) - 30) > 1 ||
-			!Number.isFinite(videoStart) ||
-			videoStart < 0
-		)
-			throw new Error('invalid video invariant');
-		if (
-			audio?.codec_name !== 'aac' ||
-			audio.profile !== 'LC' ||
-			Number(audio.sample_rate) !== 48000 ||
-			audio.channels !== 2 ||
-			!Number.isFinite(audioStart) ||
-			audioStart < 0 ||
-			Math.abs(videoStart - audioStart) > 0.1
-		)
-			throw new Error('invalid audio invariant');
-		const duration = Number(parsed.format.duration);
-		if (!Number.isFinite(duration) || duration <= 0)
-			throw new Error('invalid media duration');
-		return {
-			duration_ms: Math.round(duration * 1000),
-			video: { codec: 'h264', width: 1920, height: 1080, fps: 30 },
-			audio: { codec: 'aac', sample_rate: 48000, channels: 2 },
-		};
+		);
+		return validateFfprobeOutput(parsed);
 	}
 	async concat(list: string, output: string): Promise<void> {
 		await command(this.ffmpeg, [

--- a/suite/meet/recorder-server/src/RecorderVerticalChain.test.ts
+++ b/suite/meet/recorder-server/src/RecorderVerticalChain.test.ts
@@ -120,7 +120,11 @@ describe('recorder vertical chain', () => {
 					joined = true;
 					callback({ success: true });
 				});
-				const query = (event: string, response: Record<string, unknown>) =>
+				type QueryResponse =
+					| { rtpCapabilities: { codecs: never[]; headerExtensions: never[] } }
+					| { participants: never[] }
+					| { producers: never[] };
+				const query = (event: string, response: QueryResponse) =>
 					socket.on(event, (_data, callback) => {
 						expect(joined).toBe(true);
 						callback({ success: true, ...response });

--- a/suite/meet/recorder-server/src/RendererBridge.ts
+++ b/suite/meet/recorder-server/src/RendererBridge.ts
@@ -13,6 +13,12 @@ import puppeteer, {
 import type { CaptureArtifact, CaptureGap } from './captureTypes.js';
 import type { CommandClaims, PublicJwk } from './types.js';
 
+declare global {
+	interface Window {
+		__suiteRecorderLifecycle(value: unknown): void;
+	}
+}
+
 export interface RendererBridge {
 	readonly productionReady: boolean;
 	reserve(command: CommandClaims): Promise<PublicJwk>;
@@ -78,14 +84,17 @@ const browserAdapter: BrowserAdapter = {
 
 function isPublicJwk(value: unknown): value is PublicJwk {
 	if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
-	const jwk = value as Record<string, unknown>;
 	return (
-		jwk.kty === 'EC' &&
-		jwk.crv === 'P-256' &&
-		typeof jwk.x === 'string' &&
-		typeof jwk.y === 'string' &&
-		/^[A-Za-z0-9_-]{43}$/.test(jwk.x) &&
-		/^[A-Za-z0-9_-]{43}$/.test(jwk.y)
+		'kty' in value &&
+		value.kty === 'EC' &&
+		'crv' in value &&
+		value.crv === 'P-256' &&
+		'x' in value &&
+		typeof value.x === 'string' &&
+		'y' in value &&
+		typeof value.y === 'string' &&
+		/^[A-Za-z0-9_-]{43}$/.test(value.x) &&
+		/^[A-Za-z0-9_-]{43}$/.test(value.y)
 	);
 }
 
@@ -227,11 +236,7 @@ export class ChromiumRendererBridge implements RendererBridge {
 						event.source === window &&
 						event.origin === window.location.origin
 					) {
-						(
-							window as unknown as {
-								__suiteRecorderLifecycle(value: unknown): void;
-							}
-						).__suiteRecorderLifecycle(event.data);
+						window.__suiteRecorderLifecycle(event.data);
 					}
 				});
 			});
@@ -397,32 +402,21 @@ export class ChromiumRendererBridge implements RendererBridge {
 		rejectReady: (error: Error) => void,
 	): void {
 		if (!value || typeof value !== 'object' || Array.isArray(value)) return;
-		const message = value as Record<string, unknown>;
-		if (message.type === 'suite-recorder:public-key-ready') {
-			if (isPublicJwk(message.publicKey)) {
-				const { kty, crv, x, y } = message.publicKey;
+		if ('type' in value && value.type === 'suite-recorder:public-key-ready') {
+			if ('publicKey' in value && isPublicJwk(value.publicKey)) {
+				const { kty, crv, x, y } = value.publicKey;
 				resolveReady({ kty, crv, x, y });
 			} else rejectReady(new Error('renderer returned an invalid public JWK'));
 			return;
 		}
-		if (message.job !== job) return;
+		if (!('job' in value) || value.job !== job || !('type' in value)) return;
 		const renderer = this.jobs.get(job);
-		const types: Record<string, RendererLifecycleEvent['type']> = {
-			'suite-recorder:configuration-accepted': 'configured',
-			'suite-recorder:proof-complete': 'proof_complete',
-			'suite-recorder:join-complete': 'joined',
-			'suite-recorder:capture-ready': 'capture_ready',
-			'suite-recorder:interruption': 'interrupted',
-			'suite-recorder:room-empty': 'room_empty',
-			'suite-recorder:failure': 'failed',
-		};
-		const type =
-			typeof message.type === 'string' ? types[message.type] : undefined;
+		const type = rendererLifecycleType(value.type);
 		if (!type) return;
 		if (type === 'configured') renderer?.resolveConfiguration?.();
 		const reason =
-			typeof message.reason === 'string'
-				? message.reason.slice(0, 256)
+			'reason' in value && typeof value.reason === 'string'
+				? value.reason.slice(0, 256)
 				: undefined;
 		void this.lifecycleHandler({ job, type, ...(reason ? { reason } : {}) });
 	}
@@ -432,6 +426,29 @@ export class ChromiumRendererBridge implements RendererBridge {
 		if (!renderer) return;
 		renderer.rejectConfiguration?.(new Error(reason));
 		await this.lifecycleHandler({ job, type: 'failed', reason });
+	}
+}
+
+function rendererLifecycleType(
+	value: unknown,
+): RendererLifecycleEvent['type'] | undefined {
+	switch (value) {
+		case 'suite-recorder:configuration-accepted':
+			return 'configured';
+		case 'suite-recorder:proof-complete':
+			return 'proof_complete';
+		case 'suite-recorder:join-complete':
+			return 'joined';
+		case 'suite-recorder:capture-ready':
+			return 'capture_ready';
+		case 'suite-recorder:interruption':
+			return 'interrupted';
+		case 'suite-recorder:room-empty':
+			return 'room_empty';
+		case 'suite-recorder:failure':
+			return 'failed';
+		default:
+			return undefined;
 	}
 }
 

--- a/suite/meet/recorder-server/src/app.ts
+++ b/suite/meet/recorder-server/src/app.ts
@@ -10,15 +10,51 @@ import type { JobManager } from './JobManager.js';
 import type { Logger } from './logger.js';
 import type { CommandClaims, JobRecord } from './types.js';
 
-function exactBody(
-	value: unknown,
-	keys: string[],
-): value is Record<string, unknown> {
+interface ReserveBody {
+	job: string;
+}
+
+interface GrantBody {
+	grant: string;
+}
+
+interface StopBody {
+	job: string;
+	operation_id: string;
+}
+
+function exactBody(value: unknown, keys: string[]): value is object {
 	return (
 		!!value &&
 		typeof value === 'object' &&
 		!Array.isArray(value) &&
 		JSON.stringify(Object.keys(value).sort()) === JSON.stringify(keys)
+	);
+}
+
+function reserveBody(value: unknown): value is ReserveBody {
+	return (
+		exactBody(value, ['job']) && 'job' in value && typeof value.job === 'string'
+	);
+}
+
+function grantBody(value: unknown): value is GrantBody {
+	return (
+		exactBody(value, ['grant']) &&
+		'grant' in value &&
+		typeof value.grant === 'string' &&
+		value.grant.length > 0
+	);
+}
+
+function stopBody(value: unknown): value is StopBody {
+	return (
+		exactBody(value, ['job', 'operation_id']) &&
+		'job' in value &&
+		typeof value.job === 'string' &&
+		'operation_id' in value &&
+		typeof value.operation_id === 'string' &&
+		value.operation_id.length > 0
 	);
 }
 
@@ -109,7 +145,8 @@ export function createApp(
 	app.post('/v1/recordings', command('reserve'), async (req, res, next) => {
 		try {
 			const claims = res.locals.command as CommandClaims;
-			if (!exactBody(req.body, ['job']) || req.body.job !== claims.job)
+			const body: unknown = req.body;
+			if (!reserveBody(body) || body.job !== claims.job)
 				return res
 					.status(422)
 					.json({ status: 'rejected', job: claims.job, reason: 'invalid_job' });
@@ -152,18 +189,15 @@ export function createApp(
 		async (req, res, next) => {
 			try {
 				const claims = res.locals.command as CommandClaims;
-				if (
-					!exactBody(req.body, ['grant']) ||
-					typeof req.body.grant !== 'string' ||
-					!req.body.grant
-				)
+				const body: unknown = req.body;
+				if (!grantBody(body))
 					return res.status(422).json({
 						status: 'rejected',
 						job: claims.job,
 						reason: 'invalid_job',
 					});
 				await auth.consume(claims);
-				if (!(await jobs.grant(claims, req.body.grant)))
+				if (!(await jobs.grant(claims, body.grant)))
 					return res.status(422).json({
 						status: 'rejected',
 						job: claims.job,
@@ -183,19 +217,15 @@ export function createApp(
 		async (req, res, next) => {
 			try {
 				const claims = res.locals.command as CommandClaims;
-				if (
-					!exactBody(req.body, ['job', 'operation_id']) ||
-					req.body.job !== claims.job ||
-					typeof req.body.operation_id !== 'string' ||
-					!req.body.operation_id
-				)
+				const body: unknown = req.body;
+				if (!stopBody(body) || body.job !== claims.job)
 					return res.status(422).json({
 						status: 'rejected',
 						job: claims.job,
 						reason: 'invalid_job',
 					});
 				await auth.consume(claims);
-				if (!(await jobs.stop(claims, req.body.operation_id)))
+				if (!(await jobs.stop(claims, body.operation_id)))
 					return res.status(422).json({
 						status: 'rejected',
 						job: claims.job,
@@ -205,7 +235,7 @@ export function createApp(
 				return res.status(202).json({
 					status: 'accepted',
 					job: claims.job,
-					operation_id: req.body.operation_id,
+					operation_id: body.operation_id,
 				});
 			} catch (error) {
 				next(error);

--- a/suite/meet/recorder-server/src/core.test.ts
+++ b/suite/meet/recorder-server/src/core.test.ts
@@ -10,7 +10,7 @@ import type { Config } from './config.js';
 import { loadConfig } from './config.js';
 import { JobManager } from './JobManager.js';
 import { JobStore } from './JobStore.js';
-import type { Logger } from './logger.js';
+import type { LogEntry, Logger } from './logger.js';
 import { FakeRendererBridge, TEST_PUBLIC_JWK } from './RendererBridge.js';
 import { COMMAND_AUDIENCE, COMMAND_TYPE, type CommandClaims } from './types.js';
 
@@ -36,13 +36,20 @@ const baseClaims = {
 } satisfies CommandClaims;
 
 function token(
-	overrides: Record<string, unknown> = {},
-	header: Record<string, unknown> = {},
+	overrides: Partial<Omit<CommandClaims, 'aud' | 'limits'>> & {
+		aud?: string;
+		limits?: CommandClaims['limits'];
+		extra?: boolean;
+	} = {},
+	header: { typ?: string; kid?: string } = {},
 ): string {
 	return jwt.sign(
 		{ ...baseClaims, jti: crypto.randomUUID(), ...overrides },
 		secret,
-		{ algorithm: 'HS256', header: { typ: COMMAND_TYPE, ...header } },
+		{
+			algorithm: 'HS256',
+			header: { alg: 'HS256', typ: COMMAND_TYPE, ...header },
+		},
 	);
 }
 
@@ -582,7 +589,7 @@ describe('JobStore and JobManager', () => {
 describe('HTTP contract', () => {
 	let app: ReturnType<typeof createApp>;
 	let bridge: FakeRendererBridge;
-	let logs: Array<Record<string, unknown>>;
+	let logs: LogEntry[];
 	let config: Config;
 
 	beforeEach(async () => {
@@ -647,7 +654,13 @@ describe('HTTP contract', () => {
 			authenticated('POST', { job: 'job' }),
 		);
 		expect(reserve.status).toBe(202);
-		const reserveBody = (await reserve.json()) as Record<string, unknown>;
+		const reserveBody: {
+			status: 'accepted';
+			job: string;
+			accepted_at: string;
+			public_jwk: typeof TEST_PUBLIC_JWK;
+			state: string;
+		} = await reserve.json();
 		expect(Object.keys(reserveBody).sort()).toEqual([
 			'accepted_at',
 			'job',


### PR DESCRIPTION
- Define the messages exchanged by the recorder page, recorder server, and SFU.
- Check callback responses, ffprobe output, browser messages, and recording auth data before using them.
- Use named types for participants, producers, media controls, and uploads.