### PR TITLE
chore(meet): enforce type safety policy

### DIFF
--- a/.github/workflows/meet-type-policy.yml
+++ b/.github/workflows/meet-type-policy.yml
@@ -1,0 +1,59 @@
+name: Meet Type Policy
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - "frontend/src/apps/meet/**"
+      - "frontend/recorder/**"
+      - "suite/meet/types/**"
+      - "suite/meet/sfu-server/src/**"
+      - "suite/meet/recorder-server/src/**"
+      - "suite/meet/type-policy/**"
+      - "e2e/meet/**"
+      - "package.json"
+      - "yarn.lock"
+      - ".github/workflows/meet-type-policy.yml"
+  pull_request:
+    paths:
+      - "frontend/src/apps/meet/**"
+      - "frontend/recorder/**"
+      - "suite/meet/types/**"
+      - "suite/meet/sfu-server/src/**"
+      - "suite/meet/recorder-server/src/**"
+      - "suite/meet/type-policy/**"
+      - "e2e/meet/**"
+      - "package.json"
+      - "yarn.lock"
+      - ".github/workflows/meet-type-policy.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: meet-type-policy-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --ignore-scripts
+
+      - name: Test policy
+        run: yarn test:meet-type-policy
+
+      - name: Check Meet types
+        run: yarn check:meet-types

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ yarn-error.log
 # Migrated Node sidecar build output (sfu-server / collab-server also carry own .gitignore)
 /suite/meet/sfu-server/dist/
 
+# Stray Playwright output created relative to the Python package root
+/suite/e2e/
+
 # Mail: auto-downloaded Stalwart control binary (lives at apps/suite/stalwart-cli)
 stalwart-cli
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,6 +83,22 @@ repos:
               suite/meet/sfu-server/tsconfig\.json
           )$
 
+      - id: meet-type-policy
+        name: Meet Type Policy
+        entry: yarn check:meet-types
+        language: system
+        pass_filenames: false
+        files: |
+          (?x)^(
+              frontend/src/apps/meet/.*\.(ts|tsx|vue)|
+              frontend/recorder/.*\.(ts|tsx|vue)|
+              suite/meet/(types|sfu-server/src|recorder-server/src)/.*\.(ts|tsx)|
+              suite/meet/type-policy/.*|
+              e2e/meet/.*\.(ts|tsx)|
+              package\.json|
+              yarn\.lock
+          )$
+
 ci:
   autoupdate_schedule: weekly
   skip: []

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "knip:frontend": "knip --workspace frontend",
     "knip:sfu-server": "knip --workspace suite/meet/sfu-server",
     "knip:sheets-collab": "knip --workspace suite/sheets/collab-server",
-    "knip": "knip"
+    "knip": "knip",
+    "check:meet-types": "node suite/meet/type-policy/check.mjs",
+    "test:meet-type-policy": "node --test suite/meet/type-policy/check.test.mjs"
   },
   "resolutions": {
     "@tiptap/core": "3.26.0",

--- a/suite/meet/type-policy/allowlist.json
+++ b/suite/meet/type-policy/allowlist.json
@@ -1,0 +1,53 @@
+{
+  "version": 1,
+  "exceptions": [
+    {
+      "path": "frontend/src/apps/meet/composables/useRTCStats.ts",
+      "line": 6,
+      "column": 20,
+      "rule": "MTP001",
+      "lineText": "type StatsReport = Record<string, unknown> & {",
+      "reason": "Browser RTC statistics are an extensible cross-browser metadata dictionary with guarded reads."
+    },
+    {
+      "path": "frontend/src/apps/meet/types.ts",
+      "line": 116,
+      "column": 13,
+      "rule": "MTP001",
+      "lineText": "): value is Record<string, unknown> {",
+      "reason": "This central guard narrows untrusted values only for immediate field-by-field validation."
+    },
+    {
+      "path": "frontend/src/apps/meet/utils/media/E2EEEpochSignalingController.ts",
+      "line": 640,
+      "column": 29,
+      "rule": "MTP001",
+      "lineText": "\t\tconst envelope = value as Record<string, unknown>;",
+      "reason": "The assertion is contained inside an exhaustive discriminated runtime envelope validator."
+    },
+    {
+      "path": "frontend/src/apps/meet/utils/SFUClient.ts",
+      "line": 223,
+      "column": 58,
+      "rule": "MTP001",
+      "lineText": "function requireObject(value: unknown, context: string): Record<string, unknown> {",
+      "reason": "The helper rejects non-objects before event-specific parsers validate and construct response DTOs."
+    },
+    {
+      "path": "suite/meet/sfu-server/src/server/handlers/ClientTelemetryHandlers.ts",
+      "line": 158,
+      "column": 45,
+      "rule": "MTP001",
+      "lineText": "function isRecord(value: unknown): value is Record<string, unknown> {",
+      "reason": "The socket telemetry parser validates exact keys and every value before constructing an event."
+    },
+    {
+      "path": "suite/meet/sfu-server/src/server/handlers/ClientTelemetryHandlers.ts",
+      "line": 162,
+      "column": 29,
+      "rule": "MTP001",
+      "lineText": "function hasOnlyKeys(value: Record<string, unknown>, keys: string[]): boolean {",
+      "reason": "The helper is confined to exact-key validation of untrusted socket telemetry payloads."
+    }
+  ]
+}

--- a/suite/meet/type-policy/check.mjs
+++ b/suite/meet/type-policy/check.mjs
@@ -1,0 +1,238 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import ts from "typescript";
+
+const POLICY_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(POLICY_DIR, "../../..");
+const ALLOWLIST_PATH = path.join(POLICY_DIR, "allowlist.json");
+const SOURCE_ROOTS = [
+	"frontend/src/apps/meet",
+	"frontend/recorder",
+	"suite/meet/types",
+	"suite/meet/sfu-server/src",
+	"suite/meet/recorder-server/src",
+	"e2e/meet",
+];
+const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".vue"]);
+
+function isTestPath(relativePath) {
+	return /(?:^|\/)(?:__tests__|test)(?:\/|$)|\.(?:test|spec)\.[cm]?[jt]sx?$/.test(
+		relativePath,
+	);
+}
+
+function filesUnder(directory) {
+	if (!fs.existsSync(directory)) return [];
+	const files = [];
+	for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+		const entryPath = path.join(directory, entry.name);
+		if (entry.isDirectory()) files.push(...filesUnder(entryPath));
+		else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) files.push(entryPath);
+	}
+	return files.sort();
+}
+
+function vueScripts(source) {
+	const scripts = [];
+	const pattern = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+	for (const match of source.matchAll(pattern)) {
+		if (!/\blang\s*=\s*["']ts["']/.test(match[1])) continue;
+		const openingTagLength = match[0].indexOf(">");
+		scripts.push({
+			text: match[2],
+			offset: match.index + openingTagLength + 1,
+		});
+	}
+	return scripts;
+}
+
+function locationAt(source, offset) {
+	const before = source.slice(0, offset);
+	const line = before.split("\n").length;
+	const lineStart = before.lastIndexOf("\n") + 1;
+	const lineEnd = source.indexOf("\n", offset);
+	return {
+		line,
+		column: offset - lineStart + 1,
+		lineText: source.slice(lineStart, lineEnd === -1 ? source.length : lineEnd),
+	};
+}
+
+function isRawOpenRecord(node) {
+	if (!ts.isTypeReferenceNode(node) || node.typeArguments?.length !== 2) return false;
+	if (!ts.isIdentifier(node.typeName) || node.typeName.text !== "Record") return false;
+	const [key, value] = node.typeArguments;
+	return (
+		key.kind === ts.SyntaxKind.StringKeyword &&
+		(value.kind === ts.SyntaxKind.UnknownKeyword || value.kind === ts.SyntaxKind.AnyKeyword)
+	);
+}
+
+function isUnknownStringIndex(node) {
+	if (!ts.isIndexSignatureDeclaration(node) || node.parameters.length !== 1) return false;
+	const parameterType = node.parameters[0].type;
+	return (
+		parameterType?.kind === ts.SyntaxKind.StringKeyword &&
+		node.type?.kind === ts.SyntaxKind.UnknownKeyword
+	);
+}
+
+function isUnsafeUnknownAssertion(node) {
+	return (
+		ts.isAsExpression(node) &&
+		ts.isAsExpression(node.expression) &&
+		node.expression.type.kind === ts.SyntaxKind.UnknownKeyword
+	);
+}
+
+export function analyzeSource(relativePath, source) {
+	const findings = [];
+	const sections = relativePath.endsWith(".vue")
+		? vueScripts(source)
+		: [{ text: source, offset: 0 }];
+
+	for (const section of sections) {
+		const scriptKind = relativePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+		const sourceFile = ts.createSourceFile(
+			relativePath,
+			section.text,
+			ts.ScriptTarget.Latest,
+			true,
+			scriptKind,
+		);
+
+		for (const diagnostic of sourceFile.parseDiagnostics) {
+			const offset = section.offset + (diagnostic.start ?? 0);
+			findings.push({
+				path: relativePath,
+				rule: "MTP000",
+				message: ts.flattenDiagnosticMessageText(diagnostic.messageText, " "),
+				...locationAt(source, offset),
+			});
+		}
+
+		function visit(node) {
+			let rule;
+			let message;
+			if (isRawOpenRecord(node) || isUnknownStringIndex(node)) {
+				rule = "MTP001";
+				message = "Use a concrete domain type, or validate an unknown value at the boundary.";
+			} else if (node.kind === ts.SyntaxKind.AnyKeyword) {
+				rule = "MTP002";
+				message = "Explicit any disables the Meet type contract.";
+			} else if (!isTestPath(relativePath) && isUnsafeUnknownAssertion(node)) {
+				rule = "MTP003";
+				message = "Do not launder a value through 'as unknown as'; model or validate it.";
+			}
+
+			if (rule) {
+				findings.push({
+					path: relativePath,
+					rule,
+					message,
+					...locationAt(source, section.offset + node.getStart(sourceFile)),
+				});
+				if (rule === "MTP001") return;
+			}
+			ts.forEachChild(node, visit);
+		}
+		visit(sourceFile);
+	}
+
+	return findings;
+}
+
+function loadAllowlist() {
+	const parsed = JSON.parse(fs.readFileSync(ALLOWLIST_PATH, "utf8"));
+	if (parsed.version !== 1 || !Array.isArray(parsed.exceptions)) {
+		throw new Error("allowlist.json must contain version 1 and an exceptions array");
+	}
+	const keys = new Set();
+	for (const exception of parsed.exceptions) {
+		const fields = ["path", "line", "column", "rule", "lineText", "reason"];
+		if (
+			Object.keys(exception).sort().join(",") !== fields.sort().join(",") ||
+			!fields.every((field) => exception[field] !== undefined)
+		) {
+			throw new Error("Every allowlist exception must have only the required fields");
+		}
+		if (exception.rule !== "MTP001" || exception.reason.trim().length < 20) {
+			throw new Error("Only reviewed MTP001 boundaries with a meaningful reason may be allowlisted");
+		}
+		const key = `${exception.path}:${exception.line}:${exception.column}:${exception.rule}`;
+		if (keys.has(key)) throw new Error(`Duplicate allowlist entry: ${key}`);
+		keys.add(key);
+	}
+	const sorted = [...parsed.exceptions].sort((left, right) =>
+		`${left.path}:${String(left.line).padStart(8, "0")}:${String(left.column).padStart(8, "0")}`.localeCompare(
+			`${right.path}:${String(right.line).padStart(8, "0")}:${String(right.column).padStart(8, "0")}`,
+		),
+	);
+	if (JSON.stringify(sorted) !== JSON.stringify(parsed.exceptions)) {
+		throw new Error("Allowlist exceptions must be sorted by path, line, and column");
+	}
+	return parsed.exceptions;
+}
+
+export function runPolicy() {
+	const findings = SOURCE_ROOTS.flatMap((root) =>
+		filesUnder(path.join(ROOT, root)).flatMap((file) => {
+			const relativePath = path.relative(ROOT, file).split(path.sep).join("/");
+			return analyzeSource(relativePath, fs.readFileSync(file, "utf8"));
+		}),
+	).sort((left, right) =>
+		`${left.path}:${String(left.line).padStart(8, "0")}:${String(left.column).padStart(8, "0")}:${left.rule}`.localeCompare(
+			`${right.path}:${String(right.line).padStart(8, "0")}:${String(right.column).padStart(8, "0")}:${right.rule}`,
+		),
+	);
+
+	const allowlist = loadAllowlist();
+	const used = new Set();
+	const active = findings.filter((finding) => {
+		const index = allowlist.findIndex(
+			(exception) =>
+				exception.path === finding.path &&
+				exception.line === finding.line &&
+				exception.column === finding.column &&
+				exception.rule === finding.rule &&
+				exception.lineText === finding.lineText,
+		);
+		if (index === -1) return true;
+		used.add(index);
+		return false;
+	});
+
+	for (let index = 0; index < allowlist.length; index += 1) {
+		if (!used.has(index)) {
+			const exception = allowlist[index];
+			active.push({
+				...exception,
+				rule: "MTP004",
+				message: `Stale allowlist entry for ${exception.rule}`,
+			});
+		}
+	}
+
+	return active.sort((left, right) =>
+		`${left.path}:${String(left.line).padStart(8, "0")}:${String(left.column).padStart(8, "0")}:${left.rule}`.localeCompare(
+			`${right.path}:${String(right.line).padStart(8, "0")}:${String(right.column).padStart(8, "0")}:${right.rule}`,
+		),
+	);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+	try {
+		const findings = runPolicy();
+		for (const finding of findings) {
+			console.error(
+				`${finding.path}:${finding.line}:${finding.column} ${finding.rule} ${finding.message}`,
+			);
+		}
+		if (findings.length) process.exitCode = 1;
+		else console.log("Meet type policy passed");
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : error);
+		process.exitCode = 1;
+	}
+}

--- a/suite/meet/type-policy/check.mjs
+++ b/suite/meet/type-policy/check.mjs
@@ -82,11 +82,17 @@ function isAssertionExpression(node) {
 	return ts.isAsExpression(node) || ts.isTypeAssertionExpression(node);
 }
 
+function unwrapParentheses(node) {
+	while (ts.isParenthesizedExpression(node)) node = node.expression;
+	return node;
+}
+
 function isUnsafeUnknownAssertion(node) {
+	if (!isAssertionExpression(node)) return false;
+	const inner = unwrapParentheses(node.expression);
 	return (
-		isAssertionExpression(node) &&
-		isAssertionExpression(node.expression) &&
-		node.expression.type.kind === ts.SyntaxKind.UnknownKeyword
+		isAssertionExpression(inner) &&
+		inner.type.kind === ts.SyntaxKind.UnknownKeyword
 	);
 }
 

--- a/suite/meet/type-policy/check.mjs
+++ b/suite/meet/type-policy/check.mjs
@@ -78,10 +78,14 @@ function isUnknownStringIndex(node) {
 	);
 }
 
+function isAssertionExpression(node) {
+	return ts.isAsExpression(node) || ts.isTypeAssertionExpression(node);
+}
+
 function isUnsafeUnknownAssertion(node) {
 	return (
-		ts.isAsExpression(node) &&
-		ts.isAsExpression(node.expression) &&
+		isAssertionExpression(node) &&
+		isAssertionExpression(node.expression) &&
 		node.expression.type.kind === ts.SyntaxKind.UnknownKeyword
 	);
 }

--- a/suite/meet/type-policy/check.test.mjs
+++ b/suite/meet/type-policy/check.test.mjs
@@ -44,6 +44,14 @@ test("rejects angle-bracket double assertions", () => {
 	assert.deepEqual(findings.map(({ rule }) => rule), ["MTP003"]);
 });
 
+test("rejects parenthesized double assertions", () => {
+	const findings = analyzeSource(
+		"frontend/src/apps/meet/example.ts",
+		"const participant = (<unknown>input) as Participant;",
+	);
+	assert.deepEqual(findings.map(({ rule }) => rule), ["MTP003"]);
+});
+
 test("permits test-double assertions", () => {
 	const findings = analyzeSource(
 		"suite/meet/sfu-server/src/example.test.ts",

--- a/suite/meet/type-policy/check.test.mjs
+++ b/suite/meet/type-policy/check.test.mjs
@@ -36,6 +36,14 @@ test("rejects production double assertions", () => {
 	assert.deepEqual(findings.map(({ rule }) => rule), ["MTP003"]);
 });
 
+test("rejects angle-bracket double assertions", () => {
+	const findings = analyzeSource(
+		"frontend/src/apps/meet/example.ts",
+		"const participant = <Participant><unknown>input;",
+	);
+	assert.deepEqual(findings.map(({ rule }) => rule), ["MTP003"]);
+});
+
 test("permits test-double assertions", () => {
 	const findings = analyzeSource(
 		"suite/meet/sfu-server/src/example.test.ts",

--- a/suite/meet/type-policy/check.test.mjs
+++ b/suite/meet/type-policy/check.test.mjs
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { analyzeSource } from "./check.mjs";
+
+test("rejects open records without matching text in comments", () => {
+	const findings = analyzeSource(
+		"frontend/src/apps/meet/example.ts",
+		"// Record<string, unknown>\ntype Data = Record<string, unknown>;\n",
+	);
+	assert.deepEqual(findings.map(({ rule, line }) => ({ rule, line })), [
+		{ rule: "MTP001", line: 2 },
+	]);
+});
+
+test("rejects open unknown index signatures", () => {
+	const findings = analyzeSource(
+		"suite/meet/types/example.ts",
+		"interface Data { [key: string]: unknown }",
+	);
+	assert.deepEqual(findings.map(({ rule }) => rule), ["MTP001"]);
+});
+
+test("rejects explicit any but accepts boundary unknown", () => {
+	const findings = analyzeSource(
+		"frontend/src/apps/meet/example.ts",
+		"function parse(value: unknown): any { return value }",
+	);
+	assert.deepEqual(findings.map(({ rule }) => rule), ["MTP002"]);
+});
+
+test("rejects production double assertions", () => {
+	const findings = analyzeSource(
+		"frontend/src/apps/meet/example.ts",
+		"const participant = input as unknown as Participant;",
+	);
+	assert.deepEqual(findings.map(({ rule }) => rule), ["MTP003"]);
+});
+
+test("permits test-double assertions", () => {
+	const findings = analyzeSource(
+		"suite/meet/sfu-server/src/example.test.ts",
+		"const socket = fake as unknown as Socket;",
+	);
+	assert.deepEqual(findings, []);
+});
+
+test("maps Vue script findings to original lines", () => {
+	const findings = analyzeSource(
+		"frontend/src/apps/meet/Example.vue",
+		'<template>ok</template>\n<script setup lang="ts">\nconst value: any = 1\n</script>\n',
+	);
+	assert.deepEqual(findings.map(({ rule, line }) => ({ rule, line })), [
+		{ rule: "MTP002", line: 3 },
+	]);
+});


### PR DESCRIPTION
- Add a type-safety check for Meet TypeScript and Vue files.
- Reject `Record<string, unknown>`, explicit `any`, and production `as unknown as` casts.
- Keep a small reviewed allowlist for the cases that need open data.
- Run the check in pre-commit and GitHub Actions.