### PR TITLE
refactor(meet): use participant connection lifecycle

### DIFF
--- a/frontend/src/apps/meet/components/StatsForNerdsOverlay.vue
+++ b/frontend/src/apps/meet/components/StatsForNerdsOverlay.vue
@@ -44,7 +44,7 @@
 				<StatValue label="Download" :value="formatBitrate(snapshot.downloadBitrate)" />
 				<StatValue label="Upload" :value="formatBitrate(snapshot.uploadBitrate)" />
 				<StatValue label="Available upload" :value="formatBitrate(snapshot.availableOutgoingBitrate)" />
-				<StatValue label="Recovery" :value="humanize(connectionState.recoveryState)" />
+				<StatValue label="Lifecycle" :value="humanize(participantConnectionState.lifecycleState)" />
 			</div>
 
 			<template v-if="expanded">
@@ -69,7 +69,7 @@
 					<p v-if="!receiveStreams.length" class="py-2 text-ink-gray-5">No active incoming streams</p>
 				</StatsSection>
 
-				<StatsSection v-if="connectionState.recoveryTimeline.length" title="Recovery history">
+				<StatsSection v-if="participantConnectionState.recoveryTimeline.length" title="Recovery history">
 					<div v-for="entry in recentRecoveryTimeline" :key="`${entry.at}-${entry.state}`" class="border-b border-outline-gray-2 py-2 last:border-0">
 						<div class="flex justify-between gap-3">
 							<span class="capitalize text-ink-gray-7">{{ humanize(entry.state) }}</span>
@@ -93,6 +93,7 @@ import LucideChevronUp from "~icons/lucide/chevron-up";
 import LucideCopy from "~icons/lucide/copy";
 import LucideX from "~icons/lucide/x";
 import { useConnectionState } from "../composables/useConnectionState";
+import { useParticipantConnectionState } from "../composables/useParticipantConnectionState";
 import { useE2EEState } from "../composables/useE2EEState";
 import { type RTCStreamStats, useRTCStats } from "../composables/useRTCStats";
 import { setShowStatsForNerds } from "../data/statsPreferences";
@@ -100,6 +101,7 @@ import { setShowStatsForNerds } from "../data/statsPreferences";
 const active = ref(true);
 const expanded = ref(false);
 const connectionState = useConnectionState();
+const participantConnectionState = useParticipantConnectionState();
 const e2eeState = useE2EEState();
 const { snapshot, sendStreams, receiveStreams, error } = useRTCStats(active);
 
@@ -120,8 +122,8 @@ const iceRoute = computed(() => {
 	const remote = snapshot.value.remoteCandidateType;
 	return local || remote ? `${local || "unknown"} → ${remote || "unknown"}` : "n/a";
 });
-const recoveryCount = computed(() => connectionState.recoveryTimeline.filter((entry) => entry.state !== "healthy").length);
-const recentRecoveryTimeline = computed(() => connectionState.recoveryTimeline.slice(-8).reverse());
+const recoveryCount = computed(() => participantConnectionState.recoveryTimeline.filter((entry) => entry.state !== "healthy").length);
+const recentRecoveryTimeline = computed(() => participantConnectionState.recoveryTimeline.slice(-8).reverse());
 const encryptionStatus = computed(() => e2eeState.isContextReady.value ? "Active" : "Not active");
 
 function close() {
@@ -156,8 +158,8 @@ async function copyDiagnostics() {
 	await navigator.clipboard.writeText(JSON.stringify({
 		capturedAt: new Date().toISOString(),
 		stats: snapshot.value,
-		recoveryState: connectionState.recoveryState,
-		recoveryTimeline: connectionState.recoveryTimeline,
+		lifecycleState: participantConnectionState.lifecycleState,
+		recoveryTimeline: participantConnectionState.recoveryTimeline,
 	}, null, 2));
 }
 

--- a/frontend/src/apps/meet/composables/__tests__/useConnectionState.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useConnectionState.test.ts
@@ -2,31 +2,21 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 import { useConnectionState } from "../useConnectionState";
 
-describe("useConnectionState recovery timeline", () => {
+describe("useConnectionState", () => {
 	beforeEach(() => {
 		setActivePinia(createPinia());
 	});
 
-	it("keeps the latest 40 recovery transitions", () => {
+	it("resets preview, guest connection details, and page errors", () => {
 		const connectionState = useConnectionState();
-
-		for (let index = 0; index < 41; index++) {
-			connectionState.setRecoveryState("reconnecting", `attempt-${index}`);
-		}
-
-		expect(connectionState.recoveryState).toBe("reconnecting");
-		expect(connectionState.recoveryTimeline).toHaveLength(40);
-		expect(connectionState.recoveryTimeline[0].detail).toBe("attempt-1");
-		expect(connectionState.recoveryTimeline[39].detail).toBe("attempt-40");
-	});
-
-	it("clears recovery state with the rest of the connection state", () => {
-		const connectionState = useConnectionState();
-		connectionState.setRecoveryState("failed", "session rebuild failed");
+		connectionState.connectionError = "failed";
+		connectionState.isInPreview = false;
+		connectionState.guestAuthToken = "token";
 
 		connectionState.$reset();
 
-		expect(connectionState.recoveryState).toBe("healthy");
-		expect(connectionState.recoveryTimeline).toEqual([]);
+		expect(connectionState.connectionError).toBeNull();
+		expect(connectionState.isInPreview).toBe(true);
+		expect(connectionState.guestAuthToken).toBeNull();
 	});
 });

--- a/frontend/src/apps/meet/composables/__tests__/useNetworkQuality.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useNetworkQuality.test.ts
@@ -199,7 +199,7 @@ describe("useNetworkQuality", () => {
 					],
 				},
 			},
-			connectionManager: { resetReceiveSide },
+			resetReceiveMedia: resetReceiveSide,
 		});
 
 		const app = createApp({
@@ -267,7 +267,7 @@ describe("useNetworkQuality", () => {
 					getAllConsumers: () => [entry],
 				},
 			},
-			connectionManager: { resetReceiveSide },
+			resetReceiveMedia: resetReceiveSide,
 		});
 
 		const observedDownlink = ref("unknown");
@@ -358,7 +358,7 @@ describe("useNetworkQuality", () => {
 					],
 				},
 			},
-			connectionManager: { resetReceiveSide },
+			resetReceiveMedia: resetReceiveSide,
 		});
 
 		const app = createApp({

--- a/frontend/src/apps/meet/composables/__tests__/useParticipantConnectionState.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useParticipantConnectionState.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { useParticipantConnectionState } from "../useParticipantConnectionState";
+
+describe("useParticipantConnectionState", () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	it("reports UI setup complete only after lifecycle startup settles", () => {
+		const state = useParticipantConnectionState();
+
+		state.setLifecycleState("starting");
+		expect(state.isConnecting).toBe(true);
+		expect(state.isSetupComplete).toBe(false);
+
+		state.setLifecycleState("syncing");
+		expect(state.isConnecting).toBe(true);
+		expect(state.isSetupComplete).toBe(false);
+
+		state.setLifecycleState("ready");
+		expect(state.isConnecting).toBe(false);
+		expect(state.isSetupComplete).toBe(true);
+	});
+
+	it("treats degraded as operational", () => {
+		const state = useParticipantConnectionState();
+		state.setLifecycleState("degraded");
+
+		expect(state.isSetupComplete).toBe(true);
+	});
+
+	it("resets lifecycle state and recovery diagnostics", () => {
+		const state = useParticipantConnectionState();
+		state.setLifecycleState("ready");
+		state.recordRecovery("reconnecting", "socket closed");
+
+		state.$reset();
+
+		expect(state.lifecycleState).toBe("stopped");
+		expect(state.isSetupComplete).toBe(false);
+		expect(state.recoveryTimeline).toEqual([]);
+	});
+});

--- a/frontend/src/apps/meet/composables/useConnectionState.ts
+++ b/frontend/src/apps/meet/composables/useConnectionState.ts
@@ -1,27 +1,9 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
 
-export type MeetingRecoveryState =
-	| "healthy"
-	| "reconnecting"
-	| "rejoining"
-	| "recovering_send"
-	| "recovering_receive"
-	| "failed";
-
-export type RecoveryTimelineEntry = {
-	at: string;
-	state: MeetingRecoveryState;
-	detail?: string;
-};
-
-const RECOVERY_TIMELINE_LIMIT = 40;
-
 export interface ConnectionState {
-	isConnecting: boolean;
 	connectionError: string | null;
 	isInPreview: boolean;
-	isSetupComplete: boolean;
 	codecStrategy: string;
 	networkQuality: string;
 	connectionIssues: string[];
@@ -30,17 +12,13 @@ export interface ConnectionState {
 	guestSfuUrl: string | null;
 	guestSfuPort: string | null;
 	guestSessionToken: string | null;
-	recoveryState: MeetingRecoveryState;
-	recoveryTimeline: RecoveryTimelineEntry[];
-	setRecoveryState: (state: MeetingRecoveryState, detail?: string) => void;
+	justCreated: boolean;
 	$reset: () => void;
 }
 
 export const useConnectionState = defineStore("meet-connection", () => {
-	const isConnecting = ref(false);
 	const connectionError = ref<string | null>(null);
 	const isInPreview = ref(true);
-	const isSetupComplete = ref(false);
 	const codecStrategy = ref("svc");
 	const networkQuality = ref("good");
 	const connectionIssues = ref<string[]>([]);
@@ -50,22 +28,10 @@ export const useConnectionState = defineStore("meet-connection", () => {
 	const guestSfuPort = ref<string | null>(null);
 	const guestSessionToken = ref<string | null>(null);
 	const justCreated = ref(false);
-	const recoveryState = ref<MeetingRecoveryState>("healthy");
-	const recoveryTimeline = ref<RecoveryTimelineEntry[]>([]);
-
-	function setRecoveryState(state: MeetingRecoveryState, detail?: string) {
-		recoveryState.value = state;
-		recoveryTimeline.value = [
-			...recoveryTimeline.value,
-			{ at: new Date().toISOString(), state, ...(detail ? { detail } : {}) },
-		].slice(-RECOVERY_TIMELINE_LIMIT);
-	}
 
 	function $reset() {
 		connectionError.value = null;
-		isConnecting.value = false;
 		isInPreview.value = true;
-		isSetupComplete.value = false;
 		codecStrategy.value = "svc";
 		networkQuality.value = "good";
 		connectionIssues.value = [];
@@ -75,15 +41,11 @@ export const useConnectionState = defineStore("meet-connection", () => {
 		guestSfuPort.value = null;
 		guestSessionToken.value = null;
 		justCreated.value = false;
-		recoveryState.value = "healthy";
-		recoveryTimeline.value = [];
 	}
 
 	return {
-		isConnecting,
 		connectionError,
 		isInPreview,
-		isSetupComplete,
 		codecStrategy,
 		networkQuality,
 		connectionIssues,
@@ -93,9 +55,6 @@ export const useConnectionState = defineStore("meet-connection", () => {
 		guestSfuPort,
 		guestSessionToken,
 		justCreated,
-		recoveryState,
-		recoveryTimeline,
-		setRecoveryState,
 		$reset,
 	};
 });

--- a/frontend/src/apps/meet/composables/useMeetingHandlers.ts
+++ b/frontend/src/apps/meet/composables/useMeetingHandlers.ts
@@ -12,6 +12,7 @@ import type { LobbyStore } from "./useLobbyStore";
 import type { MediaState } from "./useMediaState";
 import type { DocumentResource } from "./useMeetingDoc";
 import type { ParticipantStore } from "./useParticipantStore";
+import type { RecoveryTimelineEntry } from "./useParticipantConnectionState";
 import type { RaiseHandStore } from "./useRaiseHandStore";
 import type { ReactionStore } from "./useReactionStore";
 import {
@@ -75,6 +76,7 @@ interface SFUConnectionActions {
 		joinResult: JoinPayload,
 		guestName: string,
 	) => Promise<void>;
+	recoveryTimeline: Ref<RecoveryTimelineEntry[]>;
 }
 
 interface MeetingHandlersDeps {
@@ -101,7 +103,6 @@ interface MeetingHandlersDeps {
 export function useMeetingHandlers(deps: MeetingHandlersDeps) {
 	const resetToPreview = () => {
 		deps.connectionState.connectionError = null;
-		deps.connectionState.isConnecting = false;
 		deps.connectionState.isInPreview = true;
 	};
 
@@ -315,7 +316,7 @@ export function useMeetingHandlers(deps: MeetingHandlersDeps) {
 			transportManager:
 				deps.sfuConnection.sfuManager.value?.transportManager || null,
 			sfuClient: deps.sfuConnection.sfuClient,
-			recoveryTimeline: deps.connectionState.recoveryTimeline,
+			recoveryTimeline: deps.sfuConnection.recoveryTimeline.value,
 		});
 	};
 

--- a/frontend/src/apps/meet/composables/useNetworkQuality.ts
+++ b/frontend/src/apps/meet/composables/useNetworkQuality.ts
@@ -181,7 +181,7 @@ export function useNetworkQuality(
 				entry.kind === "video" && stallDetector.getRecoveryAttempts(entry.id) > 2,
 		);
 		if (hasAudioStall || hasExhaustedVideoRecovery) {
-			void sfuManager.connectionManager.resetReceiveSide();
+			void sfuManager.resetReceiveMedia();
 			stallDetector.suspend();
 			return;
 		}

--- a/frontend/src/apps/meet/composables/useParticipantConnectionState.ts
+++ b/frontend/src/apps/meet/composables/useParticipantConnectionState.ts
@@ -1,0 +1,64 @@
+import { computed, ref } from "vue";
+import { defineStore } from "pinia";
+import type { ParticipantConnectionState } from "../utils/sfu/ParticipantConnection";
+
+export type MeetingRecoveryState =
+	| "healthy"
+	| "reconnecting"
+	| "rejoining"
+	| "recovering_send"
+	| "recovering_receive"
+	| "failed";
+
+export type RecoveryTimelineEntry = {
+	at: string;
+	state: MeetingRecoveryState;
+	detail?: string;
+};
+
+const RECOVERY_TIMELINE_LIMIT = 40;
+
+export const useParticipantConnectionState = defineStore(
+	"meet-participant-connection",
+	() => {
+		const lifecycleState = ref<ParticipantConnectionState>("stopped");
+		const recoveryTimeline = ref<RecoveryTimelineEntry[]>([]);
+		const isConnecting = computed(
+			() =>
+				lifecycleState.value === "starting" ||
+				lifecycleState.value === "syncing",
+		);
+		const isSetupComplete = computed(
+			() =>
+				lifecycleState.value === "ready" ||
+				lifecycleState.value === "degraded" ||
+				lifecycleState.value === "recovering",
+		);
+
+		function setLifecycleState(state: ParticipantConnectionState) {
+			lifecycleState.value = state;
+		}
+
+		function recordRecovery(state: MeetingRecoveryState, detail?: string) {
+			recoveryTimeline.value = [
+				...recoveryTimeline.value,
+				{ at: new Date().toISOString(), state, ...(detail ? { detail } : {}) },
+			].slice(-RECOVERY_TIMELINE_LIMIT);
+		}
+
+		function $reset() {
+			lifecycleState.value = "stopped";
+			recoveryTimeline.value = [];
+		}
+
+		return {
+			lifecycleState,
+			recoveryTimeline,
+			isConnecting,
+			isSetupComplete,
+			setLifecycleState,
+			recordRecovery,
+			$reset,
+		};
+	},
+);

--- a/frontend/src/apps/meet/composables/useSFUConnection.ts
+++ b/frontend/src/apps/meet/composables/useSFUConnection.ts
@@ -1,6 +1,7 @@
 import { createResource, frappeRequest, toast } from "frappe-ui";
 import {
 	defineAsyncComponent,
+	computed,
 	h,
 	onUnmounted,
 	type Ref,
@@ -30,6 +31,8 @@ import type { GridLayout } from "./useGridLayout";
 import type { LobbyStore } from "./useLobbyStore";
 import type { MediaState } from "./useMediaState";
 import type { ParticipantStore } from "./useParticipantStore";
+import { useParticipantConnectionState } from "./useParticipantConnectionState";
+import type { RecoveryTimelineEntry } from "./useParticipantConnectionState";
 import type { RecordingState } from "./useRecording";
 import {
 	isUnknownRecord,
@@ -41,6 +44,7 @@ import type {
 	Participant,
 	ParticipantUpdate,
 } from "../utils/media/ParticipantManager";
+import type { ParticipantConnectionState } from "../utils/sfu/ParticipantConnection";
 
 const LARGE_MEETING_PARTICIPANT_THRESHOLD = 5;
 
@@ -124,6 +128,10 @@ interface SFUConnectionAPI {
 	endCall: () => Promise<void>;
 	fetchExistingWaitingRoomUsers: () => Promise<void>;
 	localNetworkQuality: Ref<string>;
+	lifecycleState: Ref<ParticipantConnectionState>;
+	isConnecting: Ref<boolean>;
+	isSetupComplete: Ref<boolean>;
+	recoveryTimeline: Ref<RecoveryTimelineEntry[]>;
 }
 
 export function useSFUConnection(deps: {
@@ -164,6 +172,8 @@ export function useSFUConnection(deps: {
 	const socket = useSocket();
 
 	const chatStore = useChatStore();
+	const participantConnectionState = useParticipantConnectionState();
+	participantConnectionState.$reset();
 
 	const signalChannel = new SocketIOSignalChannel();
 	const sfuClient = new SFUClient(signalChannel);
@@ -174,7 +184,6 @@ export function useSFUConnection(deps: {
 	const joiningInProgress = shallowRef(false);
 	const hasShownE2EEKeyMismatchToast = shallowRef(false);
 	const isCurrentTabHost = shallowRef(false);
-	let setupCancelled = false;
 
 	const e2eeHandshake: E2EEConnectionHandshake = useE2EEConnectionHandshake({
 		meetingId,
@@ -195,6 +204,12 @@ export function useSFUConnection(deps: {
 		null,
 	);
 	const localNetworkQuality = shallowRef("good");
+	const isConnecting = computed(
+		() => joiningInProgress.value || participantConnectionState.isConnecting,
+	);
+	const isSetupComplete = computed(
+		() => participantConnectionState.isSetupComplete,
+	);
 	let stabilityCheckTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	const handleParticipantJoined = (participant: Participant) => {
@@ -214,7 +229,10 @@ export function useSFUConnection(deps: {
 
 		participantStore.addParticipant(participant);
 
-		if (isRejoin || sfuManager.value?.initialSyncInProgress) {
+		if (
+			isRejoin ||
+			participantConnectionState.lifecycleState === "syncing"
+		) {
 			return;
 		}
 
@@ -286,12 +304,13 @@ export function useSFUConnection(deps: {
 				});
 			},
 			onRecoveryStateChange: (
-				state: Parameters<typeof connectionState.setRecoveryState>[0],
+				state: Parameters<typeof participantConnectionState.recordRecovery>[0],
 				detail?: string,
 			) => {
-				connectionState.setRecoveryState(state, detail);
+				participantConnectionState.recordRecovery(state, detail);
 				clientTelemetry.recordRecoveryState(state, detail);
 			},
+			onLifecycleStateChange: participantConnectionState.setLifecycleState,
 			onParticipantJoined: handleParticipantJoined,
 			onParticipantLeft: handleParticipantLeft,
 			onParticipantUpdated: handleParticipantUpdated,
@@ -393,20 +412,19 @@ export function useSFUConnection(deps: {
 		initialIsCohost = false,
 		prefetchedDetails: ConnectionDetails | null = null,
 	) => {
-		setupCancelled = false;
 		clientTelemetry.startSession();
 		let isHost = initialIsHost;
 		let isCohost = initialIsCohost;
 		let manager: SFUMeetingManager | null = null;
 		isCurrentTabHost.value = isHost;
-		if (connectionState.isSetupComplete) {
+		if (participantConnectionState.isSetupComplete) {
 			connectionState.isInPreview = false;
-			connectionState.isConnecting = false;
 			return;
 		}
 
 		try {
 			let wasAutomaticallyMuted = false;
+			const wantsAudio = mediaState.isMicOn;
 			manager = new SFUMeetingManager(sfuClient);
 			manager.initialize({
 				meetingId,
@@ -414,141 +432,106 @@ export function useSFUConnection(deps: {
 				eventHandlers: createSFUEventHandlers(),
 			});
 			sfuManager.value = manager;
-			const stopIfCancelled = async () => {
-				if (!setupCancelled) return false;
-					await manager!.cleanup();
-				if (sfuManager.value === manager) {
-					sfuManager.value = null;
-				}
-				return true;
-			};
 
 			// Register SFU signaling handlers before connect/join. E2EE joiners can
 			// receive their host envelope immediately after sending their hello.
 			setupFrappeRealtimeEventListeners();
 
-			await manager.connect(
-				connectionState.guestAuthToken,
+			await manager.startParticipantConnection({
+				authToken: connectionState.guestAuthToken,
 				prefetchedDetails,
-			);
-			if (await stopIfCancelled()) return;
-			connectionState.codecStrategy = sfuClient.getCodecStrategy() || "svc";
-			if (!guestName) {
-				const effectiveIsHost = sfuClient.connectionDetails.isHost || isHost;
-				const effectiveIsCohost =
-					sfuClient.connectionDetails.isCohost || isCohost;
-				isHost = effectiveIsHost;
-				isCohost = effectiveIsCohost;
-				isCurrentTabHost.value = isHost;
-			}
-
-			if (sfuClient.isE2EERequired()) {
-				if (!sfuClient.isInsertableStreamsSupported()) {
-					throw new Error(
-						"This meeting requires E2EE, but your browser does not support encoded insertable streams.",
-					);
-				}
-			}
-
-			let userData: JoinUserData;
-			if (guestName) {
-				userData = {
-					name: guestName,
-					userId: connectionState.guestId || "",
-					avatar: null,
-					is_guest: true,
-					isHost: false,
-				};
-			} else {
-				userData = {
-					name:
-						currentUser.currentUser.value?.full_name ||
-						currentUser.currentUser.value?.name ||
-						"You",
-					userId: currentUser.currentUser.value?.user_id || "",
-					avatar: currentUser.currentUser.value?.avatar || "",
-					is_guest: false,
-					isHost,
-				};
-			}
-
-			const wantsAudio = mediaState.isMicOn;
-			await manager.joinRoom(userData, {
-				audio_enabled: false,
-				video_enabled: mediaState.isCameraOn,
-			});
-			if (await stopIfCancelled()) return;
-
-			if (wantsAudio) {
-				let shouldMute = true;
-				try {
-					const participants = await sfuClient.getRoomParticipants();
-					shouldMute =
-						participants.length > LARGE_MEETING_PARTICIPANT_THRESHOLD;
-				} catch (error) {
-					console.warn(
-						"Could not determine meeting size; joining muted:",
-						(error as Error).message,
-					);
-				}
-
-				if (shouldMute) {
-					mediaState.isMicOn = false;
-					wasAutomaticallyMuted = true;
-					for (const track of mediaState.localStream?.getAudioTracks() || []) {
-						track.enabled = false;
+				prepareJoin: async (signal) => {
+					if (signal.aborted) throw signal.reason;
+					connectionState.codecStrategy = sfuClient.getCodecStrategy() || "svc";
+					if (!guestName) {
+						isHost = sfuClient.connectionDetails.isHost || isHost;
+						isCohost = sfuClient.connectionDetails.isCohost || isCohost;
+						isCurrentTabHost.value = isHost;
 					}
-				} else {
-					sfuClient.sendMediaControl("unmute");
-				}
-			}
-			if (sfuClient.isE2EERequired()) {
-				await waitForE2EEContextReady(0);
-				if (await stopIfCancelled()) return;
-			}
-
-			await manager.initializeDevice();
-			if (await stopIfCancelled()) return;
-			await manager.createReceiveTransport();
-			if (await stopIfCancelled()) return;
-
-			// Send path (local publish) and recv path (existing remotes) are
-			// independent once the device + receive transport exist.
-			const publishLocal = async () => {
-				if (!mediaState.localStream) {
-					return;
-				}
-				try {
+					if (
+						sfuClient.isE2EERequired() &&
+						!sfuClient.isInsertableStreamsSupported()
+					) {
+						throw new Error(
+							"This meeting requires E2EE, but your browser does not support encoded insertable streams.",
+						);
+					}
+					const userData: JoinUserData = guestName
+						? {
+								name: guestName,
+								userId: connectionState.guestId || "",
+								avatar: null,
+								is_guest: true,
+								isHost: false,
+							}
+						: {
+								name:
+									currentUser.currentUser.value?.full_name ||
+									currentUser.currentUser.value?.name ||
+									"You",
+								userId: currentUser.currentUser.value?.user_id || "",
+								avatar: currentUser.currentUser.value?.avatar || "",
+								is_guest: false,
+								isHost,
+							};
+					return {
+						userData,
+						mediaState: {
+							audio_enabled: false,
+							video_enabled: mediaState.isCameraOn,
+						},
+					};
+				},
+				waitForE2EEReady: async () => {
+					await waitForE2EEContextReady(0);
+				},
+				publishLocalMedia: async (signal) => {
+					if (wantsAudio) {
+						let shouldMute = true;
+						try {
+							const participants = await sfuClient.getRoomParticipants();
+							if (signal.aborted) throw signal.reason;
+							shouldMute =
+								participants.length > LARGE_MEETING_PARTICIPANT_THRESHOLD;
+						} catch (error) {
+							if (signal.aborted) throw error;
+							console.warn(
+								"Could not determine meeting size; joining muted:",
+								(error as Error).message,
+							);
+						}
+						if (shouldMute) {
+							mediaState.isMicOn = false;
+							wasAutomaticallyMuted = true;
+							for (const track of mediaState.localStream?.getAudioTracks() || []) {
+								track.enabled = false;
+							}
+						} else {
+							sfuClient.sendMediaControl("unmute");
+						}
+					}
+					if (!mediaState.localStream) return;
 					const videoTracks = mediaState.processedStream
 						? mediaState.processedStream.getVideoTracks()
 						: mediaState.localStream.getVideoTracks();
-
-					const audioTracks = mediaState.localStream.getAudioTracks();
-
 					const streamToPublish = new MediaStream([
 						...videoTracks,
-						...audioTracks,
+						...mediaState.localStream.getAudioTracks(),
 					]);
-
-					await manager!.publishMedia(streamToPublish, {
-						publishVideo: mediaState.isCameraOn,
-						publishAudio: mediaState.isMicOn,
-					});
-				} catch (error) {
-					console.warn(
-						"Media publishing failed, continuing without media:",
-						(error as Error).message,
-					);
-				}
-			};
-
-			await Promise.all([
-				publishLocal(),
-				manager!.setupExistingParticipants(),
-			]);
-			if (await stopIfCancelled()) return;
-
-			connectionState.isSetupComplete = true;
+					try {
+						await manager!.publishMedia(streamToPublish, {
+							publishVideo: mediaState.isCameraOn,
+							publishAudio: mediaState.isMicOn,
+						});
+					} catch (error) {
+						if (signal.aborted) throw error;
+						console.warn(
+							"Media publishing failed, continuing without media:",
+							getErrorMessage(error),
+						);
+					}
+				},
+			});
 			if (wasAutomaticallyMuted) {
 				const MicOffIcon = defineAsyncComponent(
 					() => import("~icons/lucide/mic-off"),
@@ -563,6 +546,10 @@ export function useSFUConnection(deps: {
 				fetchExistingWaitingRoomUsers();
 			}
 		} catch (error) {
+			if (isUnknownRecord(error) && error.name === "AbortError") {
+				if (sfuManager.value === manager) sfuManager.value = null;
+				return;
+			}
 			console.error("SFU setup failed:", error);
 			await manager?.cleanup();
 			if (sfuManager.value === manager) {
@@ -625,7 +612,7 @@ export function useSFUConnection(deps: {
 			removeGuestApprovalListeners();
 
 			lobbyStore.isWaitingForApproval = false;
-			connectionState.isConnecting = true;
+			joiningInProgress.value = true;
 
 			try {
 				const resolvedGuestName =
@@ -681,7 +668,7 @@ export function useSFUConnection(deps: {
 				);
 				connectionState.connectionError = "Failed to connect after approval";
 			} finally {
-				connectionState.isConnecting = false;
+				joiningInProgress.value = false;
 			}
 		}
 
@@ -867,7 +854,6 @@ export function useSFUConnection(deps: {
 			if (joinResult.status === "waiting_for_approval") {
 				lobbyStore.isWaitingForApproval = true;
 				connectionState.isInPreview = false;
-				connectionState.isConnecting = false;
 				connectionState.guestAuthToken = null;
 				setupGuestApprovalListener(guestName);
 				return;
@@ -877,7 +863,7 @@ export function useSFUConnection(deps: {
 
 			// Show meeting shell immediately; SFU setup continues in the background.
 			connectionState.isInPreview = false;
-			connectionState.isConnecting = true;
+			joiningInProgress.value = true;
 			const prefetched = connectionDetailsFromJoinPayload(joinResult, {
 				guestAuthToken: connectionState.guestAuthToken,
 				guestId: connectionState.guestId,
@@ -886,11 +872,11 @@ export function useSFUConnection(deps: {
 			});
 			await setupSFUConnection(guestName, false, false, prefetched);
 			setupFrappeRealtimeEventListeners();
-			connectionState.isConnecting = false;
 		} catch (error) {
 			console.error("Failed to complete guest join:", error);
 			connectionState.connectionError = getErrorMessage(error);
-			connectionState.isConnecting = false;
+		} finally {
+			joiningInProgress.value = false;
 		}
 	};
 
@@ -901,7 +887,6 @@ export function useSFUConnection(deps: {
 
 		try {
 			joiningInProgress.value = true;
-			connectionState.isConnecting = true;
 			connectionState.connectionError = null;
 			// Optimistic UI: leave preview shell while join/SFU work runs.
 			connectionState.isInPreview = false;
@@ -915,7 +900,6 @@ export function useSFUConnection(deps: {
 
 			if (joinResult.status === "waiting_for_approval") {
 				lobbyStore.isWaitingForApproval = true;
-				connectionState.isConnecting = false;
 				setupFrappeRealtimeEventListeners();
 				return;
 			}
@@ -936,11 +920,9 @@ export function useSFUConnection(deps: {
 			);
 
 			setupFrappeRealtimeEventListeners();
-			connectionState.isConnecting = false;
 		} catch (error) {
 			console.error("Failed to join meeting:", error);
 			connectionState.connectionError = getErrorMessage(error);
-			connectionState.isConnecting = false;
 		} finally {
 			joiningInProgress.value = false;
 		}
@@ -948,7 +930,6 @@ export function useSFUConnection(deps: {
 
 	const endCall = async () => {
 		try {
-			setupCancelled = true;
 			removeGuestApprovalListeners();
 			unsubscribeGuestRealtime();
 
@@ -973,7 +954,6 @@ export function useSFUConnection(deps: {
 	};
 
 	onUnmounted(async () => {
-		setupCancelled = true;
 		hasShownE2EEKeyMismatchToast.value = false;
 
 		if (activeSpeakerTimeout.value) {
@@ -1001,6 +981,14 @@ export function useSFUConnection(deps: {
 		sfuClient,
 		sfuManager,
 		localNetworkQuality,
+		lifecycleState: computed(
+			() => participantConnectionState.lifecycleState,
+		),
+		isConnecting,
+		isSetupComplete,
+		recoveryTimeline: computed(
+			() => participantConnectionState.recoveryTimeline,
+		),
 		joinMeetingRoom,
 		handleGuestJoinResult,
 		setupFrappeRealtimeEventListeners,

--- a/frontend/src/apps/meet/pages/Meeting.vue
+++ b/frontend/src/apps/meet/pages/Meeting.vue
@@ -60,7 +60,7 @@
 				:isMicOn="mediaState.isMicOn"
 				:cameraPermissionGranted="mediaState.cameraPermissionGranted"
 				:microphonePermissionGranted="mediaState.microphonePermissionGranted"
-				:isConnecting="connectionState.isConnecting"
+				:isConnecting="sfuConnection.isConnecting.value"
 				:userInitials="currentUser.userInitials.value"
 				:userAvatar="currentUser.userAvatar.value"
 				:currentUserName="
@@ -698,7 +698,7 @@ provide("meetingTitle", computed(() => meetingTitle.value));
 provide(pollKey, poll);
 
 // --- Computed properties ---
-const isConnecting = computed(() => connectionState.isConnecting);
+const isConnecting = sfuConnection.isConnecting;
 const hasConnectionError = computed(() => !!connectionState.connectionError);
 const isInLobby = computed(() => lobbyStore.isInLobby || false);
 const isWaitingForApproval = computed(
@@ -768,7 +768,7 @@ watch(
 		connectingToastTimer = setTimeout(() => {
 			connectingToastTimer = null;
 			if (
-				!connectionState.isConnecting ||
+				!sfuConnection.isConnecting.value ||
 				connectionState.isInPreview ||
 				lobbyStore.isWaitingForApproval ||
 				lobbyStore.isInLobby ||

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -12,8 +12,7 @@ import { ConsumerManager } from "./media/ConsumerManager";
 import { ParticipantManager } from "./media/ParticipantManager";
 import { TransportManager } from "./media/TransportManager";
 import { VideoElementManager } from "./media/VideoElementManager";
-import type { ConnectionDetails, SFUClient } from "./SFUClient";
-import type { JoinRoomMediaState, JoinUserData } from "../types";
+import type { SFUClient } from "./SFUClient";
 import type { User } from "../composables/useCurrentUser";
 import {
 	ParticipantConnection,
@@ -22,7 +21,10 @@ import {
 	type SFUEventHandlers,
 } from "./sfu/ParticipantConnection";
 import { SFUMediaManager, type PublishedMedia } from "./sfu/SFUMediaManager";
-import { SFURecoveryManager } from "./sfu/SFURecoveryManager";
+import {
+	SFURecoveryManager,
+	type RecoveryResult,
+} from "./sfu/SFURecoveryManager";
 
 interface SFUMeetingManagerOptions {
 	meetingId: string;
@@ -38,9 +40,9 @@ export class SFUMeetingManager {
 	consumerManager: ConsumerManager;
 	transportManager: TransportManager;
 
-	connectionManager: ParticipantConnection;
+	private connectionManager: ParticipantConnection;
 	mediaManager: SFUMediaManager;
-	recoveryManager: SFURecoveryManager;
+	private recoveryManager: SFURecoveryManager;
 
 	constructor(sfuClient: SFUClient) {
 		this.sfuClient = sfuClient;
@@ -103,32 +105,10 @@ export class SFUMeetingManager {
 		);
 	}
 
-	async connect(
-		authToken: string | null = null,
-		prefetchedDetails: ConnectionDetails | null = null,
-	): Promise<boolean> {
-		return this.connectionManager.connect(authToken, prefetchedDetails);
-	}
-
 	startParticipantConnection(
 		options: ParticipantConnectionStartOptions,
 	): Promise<ParticipantConnectionState> {
 		return this.connectionManager.start(options);
-	}
-
-	async joinRoom(
-		userData: JoinUserData,
-		mediaState: JoinRoomMediaState,
-	): Promise<boolean> {
-		return this.connectionManager.joinRoom(userData, mediaState);
-	}
-
-	async initializeDevice(): Promise<boolean> {
-		return this.connectionManager.initializeDevice();
-	}
-
-	async createReceiveTransport(): Promise<boolean> {
-		return this.connectionManager.createReceiveTransport();
 	}
 
 	async publishMedia(
@@ -202,7 +182,7 @@ export class SFUMeetingManager {
 				}
 			}
 
-			await this.setupExistingParticipants();
+			await this.connectionManager.setupExistingParticipants();
 			console.log("E2EE reconfiguration completed");
 		} catch (error) {
 			console.error("E2EE reconfiguration failed:", error);
@@ -212,12 +192,16 @@ export class SFUMeetingManager {
 		}
 	}
 
-	async setupExistingParticipants(): Promise<void> {
-		return this.connectionManager.setupExistingParticipants();
-	}
-
 	async resyncAfterRecovery(reason: string): Promise<void> {
 		return this.connectionManager.resyncAfterRecovery(reason);
+	}
+
+	async recoverTransport(reason: string): Promise<RecoveryResult> {
+		return this.recoveryManager.recoverTransportIce(reason);
+	}
+
+	async resetReceiveMedia(): Promise<void> {
+		return this.connectionManager.resetReceiveSide();
 	}
 
 	async subscribeToRemoteProducer({
@@ -318,7 +302,4 @@ export class SFUMeetingManager {
 		return this.connectionManager.currentUser;
 	}
 
-	get initialSyncInProgress(): boolean {
-		return this.connectionManager.initialSyncInProgress;
-	}
 }

--- a/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
@@ -16,7 +16,7 @@ describe("SFUMeetingManager recovery fallback", () => {
 		);
 
 		await expect(
-			manager.recoveryManager.recoverTransportIce("transport_recv_failed"),
+			manager.recoverTransport("transport_recv_failed"),
 		).resolves.toBe("recovered");
 
 		expect(closeReceiveTransport).not.toHaveBeenCalled();
@@ -39,7 +39,7 @@ describe("SFUMeetingManager recovery fallback", () => {
 		);
 
 		await expect(
-			manager.recoveryManager.recoverTransportIce("transport_send_failed"),
+			manager.recoverTransport("transport_send_failed"),
 		).resolves.toBe("failed");
 
 		expect(closeReceiveTransport).toHaveBeenCalledOnce();

--- a/frontend/src/apps/meet/utils/diagnostics/problemReport.ts
+++ b/frontend/src/apps/meet/utils/diagnostics/problemReport.ts
@@ -1,5 +1,5 @@
 import type { SFUClient } from "../SFUClient";
-import type { RecoveryTimelineEntry } from "../../composables/useConnectionState";
+import type { RecoveryTimelineEntry } from "../../composables/useParticipantConnectionState";
 import { getConsoleLogLines, getConsoleLogSummary } from "./consoleBuffer";
 
 type TransportStats = {

--- a/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
+++ b/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
@@ -144,8 +144,10 @@ export type ParticipantConnectionState =
 export interface ParticipantConnectionStartOptions {
 	authToken?: string | null;
 	prefetchedDetails?: ConnectionDetails | null;
-	userData: JoinUserData;
-	mediaState: JoinRoomMediaState;
+	prepareJoin: (signal: AbortSignal) => Promise<{
+		userData: JoinUserData;
+		mediaState: JoinRoomMediaState;
+	}>;
 	waitForE2EEReady: (signal: AbortSignal) => Promise<void>;
 	publishLocalMedia: (signal: AbortSignal) => Promise<unknown>;
 }
@@ -233,11 +235,16 @@ export class ParticipantConnection {
 			this.lifecycleAbortController = new AbortController();
 			const signal = this.lifecycleAbortController.signal;
 			this.setState("starting");
+			this.initialSyncInProgress = true;
 
 			try {
 				await this.connect(options.authToken, options.prefetchedDetails);
 				this.throwIfAborted(signal);
-				await this.joinRoom(options.userData, options.mediaState);
+				const { userData, mediaState } = await this.awaitAbortable(
+					options.prepareJoin(signal),
+					signal,
+				);
+				await this.joinRoom(userData, mediaState);
 				this.throwIfAborted(signal);
 				if (this.sfuClient.isE2EERequired?.()) {
 					await this.awaitAbortable(options.waitForE2EEReady(signal), signal);
@@ -253,7 +260,7 @@ export class ParticipantConnection {
 
 				const [publication, snapshot] = await Promise.allSettled([
 					this.awaitAbortable(options.publishLocalMedia(signal), signal),
-					this.setupExistingParticipants(signal),
+					this.setupExistingParticipants(signal, true),
 				]);
 				this.throwIfAborted(signal);
 				if (publication.status === "rejected") {
@@ -261,6 +268,7 @@ export class ParticipantConnection {
 					this.eventHandlers.onInitialPublicationError?.(publication.reason);
 				}
 				if (snapshot.status === "rejected") {
+					this.initialSyncInProgress = true;
 					this.setState("degraded");
 					this.startSnapshotRetry(signal);
 				} else {
@@ -268,6 +276,7 @@ export class ParticipantConnection {
 				}
 				return this._state;
 			} catch (error) {
+				this.initialSyncInProgress = false;
 				if (signal.aborted) throw error;
 				this.setState("failed");
 				throw error;
@@ -358,13 +367,14 @@ export class ParticipantConnection {
 					await this.delay(delay, signal);
 					await this.serializeLifecycle(async () => {
 						this.throwIfAborted(signal);
-						await this.setupExistingParticipants(signal);
+						await this.setupExistingParticipants(signal, true);
 						this.throwIfAborted(signal);
 						this.setState("ready");
 					});
 					return;
 				} catch (error) {
 					if (signal.aborted || !this.isSignalingConnected()) return;
+					this.initialSyncInProgress = true;
 					console.warn("Participant snapshot retry failed:", error);
 					delay = Math.min(delay * 2, ParticipantConnection.MAX_RETRY_DELAY_MS);
 				}
@@ -475,7 +485,10 @@ export class ParticipantConnection {
 		}
 	}
 
-	async setupExistingParticipants(signal?: AbortSignal): Promise<void> {
+	async setupExistingParticipants(
+		signal?: AbortSignal,
+		keepBufferingOnFailure = false,
+	): Promise<void> {
 		const generation = this.lifecycleGeneration;
 		try {
 			this.initialSyncInProgress = true;
@@ -522,7 +535,7 @@ export class ParticipantConnection {
 			await this.flushBufferedProducers();
 		} catch (error) {
 			console.error("Error in setupExistingParticipants:", error);
-			this.initialSyncInProgress = false;
+			if (!keepBufferingOnFailure) this.initialSyncInProgress = false;
 			throw error;
 		}
 	}
@@ -728,7 +741,7 @@ export class ParticipantConnection {
 					if (generation !== this.lifecycleGeneration) return;
 					await this.mediaManager.rebuildSendSide();
 					if (generation !== this.lifecycleGeneration) return;
-					await this.setupExistingParticipants(signal);
+					await this.setupExistingParticipants(signal, true);
 					if (generation !== this.lifecycleGeneration) return;
 					this.recoveryManager.setupTransportEventHandlers();
 					this.reportRecoveryState("healthy", "session rebuilt");
@@ -1261,6 +1274,7 @@ export class ParticipantConnection {
 
 	async disconnect(): Promise<void> {
 		this.setState("stopping");
+		this.initialSyncInProgress = false;
 		this.lifecycleAbortController.abort(
 			new DOMException("Participant connection stopped", "AbortError"),
 		);

--- a/frontend/src/apps/meet/utils/sfu/SFUConnectionManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUConnectionManager.ts
@@ -1,6 +1,0 @@
-export {
-	ParticipantConnection as SFUConnectionManager,
-	type ParticipantConnectionStartOptions,
-	type ParticipantConnectionState,
-	type SFUEventHandlers,
-} from "./ParticipantConnection";

--- a/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnection.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnection.test.ts
@@ -17,6 +17,7 @@ function deferred<T>() {
 
 function createConnection({ e2eeRequired = false } = {}) {
 	const participantManager = new ParticipantManager();
+	const handlers = new Map<string, (data: unknown) => unknown>();
 	const sfuClient = {
 		connect: vi.fn().mockResolvedValue(undefined),
 		disconnect: vi.fn().mockResolvedValue(undefined),
@@ -24,7 +25,9 @@ function createConnection({ e2eeRequired = false } = {}) {
 		getRoomParticipants: vi.fn().mockResolvedValue([]),
 		isE2EERequired: vi.fn(() => e2eeRequired),
 		joinRoom: vi.fn().mockResolvedValue(undefined),
-		on: vi.fn(),
+		on: vi.fn((event: string, handler: (data: unknown) => unknown) => {
+			handlers.set(event, handler);
+		}),
 	};
 	const mediaManager = {
 		cancelPendingSubscriptions: vi.fn().mockResolvedValue(undefined),
@@ -64,6 +67,7 @@ function createConnection({ e2eeRequired = false } = {}) {
 	connection.initialize("meeting-1", { user_id: "me" });
 	return {
 		connection,
+		handlers,
 		mediaManager,
 		participantManager,
 		recoveryManager,
@@ -76,8 +80,10 @@ function startOptions(
 	overrides: Partial<ParticipantConnectionStartOptions> = {},
 ): ParticipantConnectionStartOptions {
 	return {
-		userData: { name: "Me", userId: "me" },
-		mediaState: { audio_enabled: true, video_enabled: true },
+		prepareJoin: vi.fn().mockResolvedValue({
+			userData: { name: "Me", userId: "me" },
+			mediaState: { audio_enabled: true, video_enabled: true },
+		}),
 		waitForE2EEReady: vi.fn().mockResolvedValue(undefined),
 		publishLocalMedia: vi.fn().mockResolvedValue(undefined),
 		...overrides,
@@ -108,6 +114,52 @@ describe("ParticipantConnection lifecycle", () => {
 		publication.resolve(undefined);
 		await expect(start).resolves.toBe("ready");
 		expect(states).toEqual(["starting", "syncing", "ready"]);
+	});
+
+	it("prepares join after connection details are available", async () => {
+		const { connection, sfuClient } = createConnection();
+		const prepareJoin = vi.fn(async () => {
+			expect(sfuClient.connect).toHaveBeenCalledOnce();
+			return {
+				userData: { name: "Host", userId: "me", isHost: true },
+				mediaState: { audio_enabled: false, video_enabled: true },
+			};
+		});
+
+		await connection.start(startOptions({ prepareJoin }));
+
+		expect(prepareJoin).toHaveBeenCalledOnce();
+		expect(sfuClient.joinRoom).toHaveBeenCalledWith(
+			"meeting-1",
+			expect.objectContaining({ isHost: true }),
+			{ audio_enabled: false, video_enabled: true },
+		);
+	});
+
+	it("buffers live events from signaling connect until the first snapshot", async () => {
+		const { connection, handlers, participantManager, sfuClient } =
+			createConnection();
+		const join = deferred<{
+			userData: { name: string; userId: string };
+			mediaState: { audio_enabled: boolean; video_enabled: boolean };
+		}>();
+		const start = connection.start(
+			startOptions({ prepareJoin: () => join.promise }),
+		);
+		await vi.waitFor(() => expect(sfuClient.connect).toHaveBeenCalledOnce());
+
+		handlers.get("participant_joined")?.({
+			participantId: "alice",
+			user_id: "alice",
+		});
+		expect(participantManager.hasParticipant("alice")).toBe(false);
+
+		join.resolve({
+			userData: { name: "Me", userId: "me" },
+			mediaState: { audio_enabled: false, video_enabled: false },
+		});
+		await start;
+		expect(participantManager.hasParticipant("alice")).toBe(true);
 	});
 
 	it("reports publication failure without failing startup", async () => {
@@ -146,6 +198,24 @@ describe("ParticipantConnection lifecycle", () => {
 		await vi.advanceTimersByTimeAsync(1);
 		expect(sfuClient.getRoomParticipants).toHaveBeenCalledTimes(2);
 		expect(connection.state).toBe("ready");
+	});
+
+	it("replays events received between failed snapshot attempts", async () => {
+		vi.useFakeTimers();
+		const { connection, handlers, participantManager, sfuClient } =
+			createConnection();
+		sfuClient.getRoomParticipants
+			.mockRejectedValueOnce(new Error("snapshot unavailable"))
+			.mockResolvedValueOnce([
+				{ participantId: "alice", user_id: "alice" },
+			]);
+
+		await expect(connection.start(startOptions())).resolves.toBe("degraded");
+		handlers.get("participant_left")?.({ participantId: "alice" });
+		await vi.advanceTimersByTimeAsync(1000);
+
+		expect(connection.state).toBe("ready");
+		expect(participantManager.hasParticipant("alice")).toBe(false);
 	});
 
 	it("aborts E2EE readiness and prevents startup from mutating after cleanup", async () => {

--- a/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnectionEvents.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnectionEvents.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { E2EEMeeting } from "../../media/E2EEMeeting";
 import { ParticipantManager } from "../../media/ParticipantManager";
-import { SFUConnectionManager } from "../SFUConnectionManager";
+import { ParticipantConnection } from "../ParticipantConnection";
 
 function createManager({ e2eeRequired = false } = {}) {
 	const participantManager = new ParticipantManager();
@@ -40,16 +40,17 @@ function createManager({ e2eeRequired = false } = {}) {
 		initialize: vi.fn(),
 		isDeviceLoaded: vi.fn(() => true),
 	};
-	const manager = new SFUConnectionManager({
+	const recoveryManager = {
+		setupTransportEventHandlers: vi.fn(),
+		reset: vi.fn(),
+	};
+	const manager = new ParticipantConnection({
 		sfuClient: sfuClient as never,
 		videoManager: {} as never,
 		participantManager,
 		transportManager: transportManager as never,
 		mediaManager: mediaManager as never,
-		recoveryManager: {
-			setupTransportEventHandlers: vi.fn(),
-			reset: vi.fn(),
-		} as never,
+		recoveryManager: recoveryManager as never,
 	});
 	manager.currentUser = { value: { user_id: "me" } };
 	return {
@@ -59,11 +60,11 @@ function createManager({ e2eeRequired = false } = {}) {
 		participantManager,
 		sfuClient,
 		transportManager,
-		recoveryManager: manager.recoveryManager,
+		recoveryManager,
 	};
 }
 
-describe("SFUConnectionManager", () => {
+describe("ParticipantConnection", () => {
 	afterEach(() => {
 		E2EEMeeting.instance.wipeMeetingContext();
 	});

--- a/frontend/src/apps/meet/utils/telemetry/ClientTelemetry.ts
+++ b/frontend/src/apps/meet/utils/telemetry/ClientTelemetry.ts
@@ -1,4 +1,4 @@
-import type { MeetingRecoveryState } from "../../composables/useConnectionState";
+import type { MeetingRecoveryState } from "../../composables/useParticipantConnectionState";
 
 export type ClientTelemetryEvent =
 	| {


### PR DESCRIPTION
- Replaced the manual Meet setup sequence with one Participant Connection start operation.
- Kept host, guest, waiting-room, auto-mute, media selection, and encryption policy outside the lifecycle Module.
- Moved live lifecycle state out of the page connection store.
- Derived UI loading and setup state from Participant Connection state.
- Hid connection and recovery internals behind meaningful Meet methods.
- Updated recovery diagnostics and tests.