### PR TITLE
refactor(meet): reconcile snapshots with live events

### DIFF
--- a/frontend/recorder/RecorderSocketController.test.ts
+++ b/frontend/recorder/RecorderSocketController.test.ts
@@ -93,12 +93,45 @@ describe("RecorderSocketController", () => {
 		expect(h.dependencies.mediaManager.subscribeToRemoteProducer).toHaveBeenCalledOnce();
 	});
 
+	it("claims duplicate live producers synchronously", async () => {
+		const h = harness();
+		await h.controller.connect(config);
+
+		h.sfuHandlers.get("producer_created")?.({ producerId: "p1", participantId: "alice" });
+		h.sfuHandlers.get("producer_created")?.({ producerId: "p1", participantId: "alice" });
+		await vi.waitFor(() =>
+			expect(h.dependencies.mediaManager.subscribeToRemoteProducer).toHaveBeenCalledOnce(),
+		);
+	});
+
 	it("tombstones producer closes and participant leaves during snapshots", async () => {
 		const h = harness([{ id: "p1", participantId: "alice" }]);
 		h.dependencies.sfuClient.getRoomParticipants.mockImplementationOnce(async () => { h.sfuHandlers.get("participant_left")?.({ participantId: "alice" }); h.sfuHandlers.get("producer_closed")?.({ producerId: "p1", participantId: "alice" }); return [{ participantId: "alice", user_id: "alice", userData: { name: "Alice" } }]; });
 		await h.controller.connect(config);
 		expect(h.participants.has("alice")).toBe(false);
 		expect(h.dependencies.mediaManager.subscribeToRemoteProducer).not.toHaveBeenCalled();
+	});
+
+	it("does not resurrect old producers when a participant leaves and rejoins", async () => {
+		const h = harness([{ id: "old", participantId: "alice" }]);
+		h.dependencies.sfuClient.getRoomParticipants.mockResolvedValueOnce([
+			{ participantId: "alice", user_id: "alice", userData: { name: "Alice" } },
+		]);
+		h.dependencies.sfuClient.getExistingProducers.mockImplementationOnce(async () => {
+			h.sfuHandlers.get("participant_left")?.({ participantId: "alice" });
+			h.sfuHandlers.get("participant_joined")?.({ participantId: "alice" });
+			h.sfuHandlers.get("producer_created")?.({ producerId: "new", participantId: "alice" });
+			return [{ id: "old", participantId: "alice" }];
+		});
+
+		await h.controller.connect(config);
+
+		expect(h.dependencies.mediaManager.subscribeToRemoteProducer).toHaveBeenCalledOnce();
+		expect(h.dependencies.mediaManager.subscribeToRemoteProducer).toHaveBeenCalledWith({
+			producerId: "new",
+			participantId: "alice",
+			isScreen: false,
+		});
 	});
 
 	it("fails readiness when an initial producer returns no consumer", async () => {

--- a/frontend/recorder/RecorderSocketController.ts
+++ b/frontend/recorder/RecorderSocketController.ts
@@ -7,6 +7,13 @@ import { VideoElementManager } from "../src/apps/meet/utils/media/VideoElementMa
 import { SFUClient } from "../src/apps/meet/utils/SFUClient";
 import { SFUMediaManager } from "../src/apps/meet/utils/sfu/SFUMediaManager";
 import {
+	applyMeetingReconciliationEvent,
+	createMeetingReconciliationState,
+	reconcileMeetingSnapshot,
+	type MeetingReconciliationEvent,
+	type MeetingReconciliationState,
+} from "../src/apps/meet/utils/sfu/MeetingSnapshotReconciler";
+import {
 	parseActiveSpeakers,
 	parseChatMessage,
 	parseConsumerId,
@@ -23,15 +30,14 @@ import {
 	parseRequestResponse,
 	parseScreenShareStarted,
 	type MediaControlMessage,
-	type ParticipantMessage,
 	type ProducerEvent,
-	type ProducerMessage,
 	type RecorderParticipantData,
 	type RecorderParticipantUpdate,
 } from "./protocol";
 import type { RecorderConfig, RecorderRendererBridge } from "./rendererBridge";
 
-type SyncEvent = ParticipantMessage | ProducerMessage;
+type ReconciledRecorderParticipant = RecorderParticipantData & { participantId: string };
+type SyncEvent = MeetingReconciliationEvent<ReconciledRecorderParticipant>;
 export type RecorderState = {
 	participantAdded?: (participant: Participant) => void;
 	participantRemoved?: (participantId: string) => void;
@@ -60,8 +66,9 @@ export class RecorderSocketController {
 	private channel: SignalChannel;
 	private deps: RecorderDependencies;
 	private bufferedEvents: SyncEvent[] = [];
-	private closedProducers = new Set<string>();
-	private departedParticipants = new Set<string>();
+	private reconciliation: MeetingReconciliationState<ReconciledRecorderParticipant> =
+		createMeetingReconciliationState();
+	private producerClaims = new Set<string>();
 	private attachmentPromises = new Map<string, Promise<void>>();
 	private screenAttachmentPromises = new Map<string, Promise<void>>();
 	private initialSync = true;
@@ -221,13 +228,13 @@ export class RecorderSocketController {
 
 	private async initialSynchronize(): Promise<void> {
 		const participants = await this.deps.sfuClient.getRoomParticipants();
-		this.deps.participantManager.syncParticipants(
-			participants
-				.filter((participant) =>
-					!this.departedParticipants.has(participant.participantId || ""),
-				)
-				.map((participant) => this.sanitizeParticipant({
+		const participantSnapshot = participants
+			.map((participant) => {
+				const participantId = participant.participantId || participant.user_id;
+				if (!participantId) return null;
+				return this.sanitizeParticipant({
 					...participant,
+					participantId,
 					userData: {
 						...participant.userData,
 						audio_enabled:
@@ -247,57 +254,74 @@ export class RecorderSocketController {
 						participant.userData?.video_enabled ??
 						participant.video_enabled ??
 						false,
-				})),
-		);
+				});
+			})
+			.filter((participant): participant is ReconciledRecorderParticipant => participant !== null);
 		const existing = await this.deps.sfuClient.getExistingProducers();
-		const producers = new Map<string, ProducerEvent>();
+		const producers: ProducerEvent[] = [];
 		for (const value of existing) {
 			const producer = parseProducerSnapshot(value);
 			if (!producer) continue;
-			const event = { producerId: producer.id, participantId: producer.participantId, isScreen: producer.isScreen };
-			if (!this.closedProducers.has(event.producerId) && !this.departedParticipants.has(event.participantId)) producers.set(event.producerId, event);
+			producers.push({ producerId: producer.id, participantId: producer.participantId, isScreen: producer.isScreen });
 		}
-		while (this.bufferedEvents.length) for (const event of this.bufferedEvents.splice(0)) this.applySyncEvent(event, producers);
+		this.reconciliation = reconcileMeetingSnapshot(
+			this.reconciliation,
+			{ participants: participantSnapshot, producers },
+			this.bufferedEvents.splice(0),
+		);
+		this.deps.participantManager.syncParticipants([...this.reconciliation.participants.values()]);
+		if (this.reconciliation.participants.size === 0) this.scheduleRoomEmpty();
 		this.initialSync = false;
-		for (const event of producers.values()) await this.subscribeRequired(event);
+		for (const event of this.reconciliation.producers.values()) await this.subscribeRequired(event);
 	}
 
 	private queueOrApply(event: SyncEvent): void {
 		if (this.initialSync) this.bufferedEvents.push(event);
 		else this.applySyncEvent(event);
 	}
-	private applySyncEvent(event: SyncEvent, producers?: Map<string, ProducerEvent>): void {
+	private applySyncEvent(event: SyncEvent): void {
+		const previous = this.reconciliation;
+		this.reconciliation = applyMeetingReconciliationEvent(previous, event);
 		if (event.type === "participant-joined") {
 			const id = event.value.participantId;
-			this.departedParticipants.delete(id);
-			this.deps.participantManager.addParticipant(this.sanitizeParticipant(event.value));
+			if (!previous.participants.has(id) || previous.departedParticipantIds.has(id)) {
+				this.deps.participantManager.addParticipant(this.sanitizeParticipant(event.value));
+			}
 		} else if (event.type === "participant-left") {
 			const id = event.value.participantId;
-			this.departedParticipants.add(id);
-			const removed = this.deps.participantManager.removeParticipant(id);
-			if (!removed) this.scheduleRoomEmpty();
-			if (producers) for (const [producerId, producer] of producers) if (producer.participantId === id) { producers.delete(producerId); this.closedProducers.add(producerId); }
+			if (!previous.departedParticipantIds.has(id)) {
+				const removed = this.deps.participantManager.removeParticipant(id);
+				if (!removed) this.scheduleRoomEmpty();
+			}
 		} else if (event.type === "producer-created") {
-			this.closedProducers.delete(event.value.producerId);
-			if (!this.departedParticipants.has(event.value.participantId)) producers ? producers.set(event.value.producerId, event.value) : void this.subscribeLive(event.value);
+			if (
+				!previous.producers.has(event.value.producerId) &&
+				this.reconciliation.producers.has(event.value.producerId)
+			) void this.subscribeLive(event.value);
 		} else {
-			this.closedProducers.add(event.value.producerId);
-			producers?.delete(event.value.producerId);
-			this.removeProducer(event.value);
+			if (!previous.closedProducerIds.has(event.value.producerId)) this.removeProducer(event.value);
 		}
 	}
 	private async subscribeRequired(event: ProducerEvent): Promise<void> {
-		if (this.closedProducers.has(event.producerId) || this.departedParticipants.has(event.participantId)) return;
-		const result = await this.deps.mediaManager.subscribeToRemoteProducer(event);
-		if (this.closedProducers.has(event.producerId) || this.departedParticipants.has(event.participantId)) { this.removeProducer(event); return; }
-		if (!result) throw new Error(`Initial producer ${event.producerId} did not create a consumer`);
-		const attached = this.attachmentPromises.get(event.producerId);
-		if (!attached) throw new Error(`Initial producer ${event.producerId} was not attached`);
-		await attached;
+		if (!this.isCurrentProducer(event) || this.producerClaims.has(event.producerId)) return;
+		this.producerClaims.add(event.producerId);
+		try {
+			if (!this.isCurrentProducer(event)) return;
+			const result = await this.deps.mediaManager.subscribeToRemoteProducer(event);
+			if (!this.isCurrentProducer(event)) { this.removeProducer(event); return; }
+			if (!result) throw new Error(`Initial producer ${event.producerId} did not create a consumer`);
+			const attached = this.attachmentPromises.get(event.producerId);
+			if (!attached) throw new Error(`Initial producer ${event.producerId} was not attached`);
+			await attached;
+			if (!this.isCurrentProducer(event)) this.removeProducer(event);
+		} finally {
+			this.producerClaims.delete(event.producerId);
+		}
 	}
 	private async subscribeLive(event: ProducerEvent): Promise<void> {
 		try { await this.subscribeRequired(event); } catch (error) { this.interrupt(error instanceof Error ? error.message : "Media subscription failed"); }
 	}
+	private isCurrentProducer(event: ProducerEvent): boolean { return this.reconciliation.producers.get(event.producerId) === event; }
 	private sanitizeParticipant(p: RecorderParticipantData): RecorderParticipantData { const avatar = trustedAvatar(p.userData?.avatar || p.avatar, this.frappeOrigin); return { ...p, avatar, userData: { ...p.userData, avatar } }; }
 	private frappeOrigin = "";
 	private removeProducer(event: ProducerEvent): void { for (const c of this.deps.consumerManager.getConsumersByParticipant(event.participantId || "")) if (c.producerId === event.producerId || (event.isScreen && c.isScreen)) this.deps.consumerManager.removeConsumer(c.id); }

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -161,7 +161,7 @@ export class SFUMeetingManager {
 			mediaHandler.cleanup();
 			this.consumerManager.clear();
 			this.mediaManager.processedConsumers.clear();
-			this.connectionManager.bufferedProducerEvents = [];
+			this.connectionManager.clearBufferedReconciliationEvents();
 			this.transportManager.cleanup();
 
 			await this.transportManager.initializeDevice();

--- a/frontend/src/apps/meet/utils/sfu/MeetingSnapshotReconciler.ts
+++ b/frontend/src/apps/meet/utils/sfu/MeetingSnapshotReconciler.ts
@@ -1,0 +1,133 @@
+export interface ReconciledParticipant {
+  participantId: string;
+}
+
+export interface ReconciledProducer {
+  producerId: string;
+  participantId: string;
+  isScreen: boolean;
+}
+
+export type MeetingReconciliationEvent<
+  Participant extends ReconciledParticipant,
+> =
+  | { type: "participant-joined"; value: Participant }
+  | { type: "participant-left"; value: { participantId: string } }
+  | { type: "producer-created"; value: ReconciledProducer }
+  | { type: "producer-closed"; value: ReconciledProducer };
+
+export interface MeetingReconciliationState<
+  Participant extends ReconciledParticipant,
+> {
+  participants: ReadonlyMap<string, Participant>;
+  producers: ReadonlyMap<string, ReconciledProducer>;
+  departedParticipantIds: ReadonlySet<string>;
+  closedProducerIds: ReadonlySet<string>;
+}
+
+export interface MeetingSnapshot<Participant extends ReconciledParticipant> {
+  participants?: readonly Participant[];
+  producers?: readonly ReconciledProducer[];
+}
+
+export function createMeetingReconciliationState<
+  Participant extends ReconciledParticipant,
+>(): MeetingReconciliationState<Participant> {
+  return {
+    participants: new Map(),
+    producers: new Map(),
+    departedParticipantIds: new Set(),
+    closedProducerIds: new Set(),
+  };
+}
+
+export function applyMeetingReconciliationEvent<
+  Participant extends ReconciledParticipant,
+>(
+  state: MeetingReconciliationState<Participant>,
+  event: MeetingReconciliationEvent<Participant>,
+): MeetingReconciliationState<Participant> {
+  const participants = new Map(state.participants);
+  const producers = new Map(state.producers);
+  const departedParticipantIds = new Set(state.departedParticipantIds);
+  const closedProducerIds = new Set(state.closedProducerIds);
+
+  if (event.type === "participant-joined") {
+    if (!participants.has(event.value.participantId)) {
+      participants.set(event.value.participantId, event.value);
+    }
+    departedParticipantIds.delete(event.value.participantId);
+  } else if (event.type === "participant-left") {
+    participants.delete(event.value.participantId);
+    departedParticipantIds.add(event.value.participantId);
+    for (const [producerId, producer] of producers) {
+      if (producer.participantId === event.value.participantId) {
+        producers.delete(producerId);
+        closedProducerIds.add(producerId);
+      }
+    }
+  } else if (event.type === "producer-created") {
+    closedProducerIds.delete(event.value.producerId);
+    if (
+      !departedParticipantIds.has(event.value.participantId) &&
+      !producers.has(event.value.producerId)
+    ) {
+      producers.set(event.value.producerId, event.value);
+    }
+  } else {
+    producers.delete(event.value.producerId);
+    closedProducerIds.add(event.value.producerId);
+  }
+
+  return {
+    participants,
+    producers,
+    departedParticipantIds,
+    closedProducerIds,
+  };
+}
+
+export function reconcileMeetingSnapshot<
+  Participant extends ReconciledParticipant,
+>(
+  state: MeetingReconciliationState<Participant>,
+  snapshot: MeetingSnapshot<Participant>,
+  liveEvents: readonly MeetingReconciliationEvent<Participant>[],
+): MeetingReconciliationState<Participant> {
+  let reconciled: MeetingReconciliationState<Participant> = {
+    participants: snapshot.participants
+      ? new Map(
+          snapshot.participants.map((participant) => [
+            participant.participantId,
+            participant,
+          ]),
+        )
+      : new Map(state.participants),
+    producers: snapshot.producers
+      ? new Map(
+          snapshot.producers.map((producer) => [producer.producerId, producer]),
+        )
+      : new Map(state.producers),
+    departedParticipantIds: snapshot.participants
+      ? new Set()
+      : new Set(state.departedParticipantIds),
+    closedProducerIds: snapshot.producers
+      ? new Set()
+      : new Set(state.closedProducerIds),
+  };
+
+  if (snapshot.producers) {
+    const producers = new Map(reconciled.producers);
+    for (const [producerId, producer] of producers) {
+      if (reconciled.departedParticipantIds.has(producer.participantId)) {
+        producers.delete(producerId);
+      }
+    }
+    reconciled = { ...reconciled, producers };
+  }
+
+  for (const event of liveEvents) {
+    reconciled = applyMeetingReconciliationEvent(reconciled, event);
+  }
+  return reconciled;
+}

--- a/frontend/src/apps/meet/utils/sfu/MeetingSnapshotReconciler.ts
+++ b/frontend/src/apps/meet/utils/sfu/MeetingSnapshotReconciler.ts
@@ -30,6 +30,7 @@ export interface MeetingSnapshot<Participant extends ReconciledParticipant> {
   producers?: readonly ReconciledProducer[];
 }
 
+/** Creates empty current state and empty tombstone sets. */
 export function createMeetingReconciliationState<
   Participant extends ReconciledParticipant,
 >(): MeetingReconciliationState<Participant> {
@@ -41,6 +42,10 @@ export function createMeetingReconciliationState<
   };
 }
 
+/**
+ * Applies one live event. Later events win, while leave and close events leave
+ * tombstones for stale snapshots.
+ */
 export function applyMeetingReconciliationEvent<
   Participant extends ReconciledParticipant,
 >(
@@ -87,6 +92,10 @@ export function applyMeetingReconciliationEvent<
   };
 }
 
+/**
+ * Uses supplied snapshot sections as the baseline, then replays live events in
+ * arrival order. Omitted sections keep their current state.
+ */
 export function reconcileMeetingSnapshot<
   Participant extends ReconciledParticipant,
 >(

--- a/frontend/src/apps/meet/utils/sfu/SFUConnectionManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUConnectionManager.ts
@@ -971,6 +971,10 @@ export class SFUConnectionManager {
 		}
 	}
 
+	clearBufferedReconciliationEvents(): void {
+		this.bufferedReconciliationEvents = [];
+	}
+
 	reset(): void {
 		this.lifecycleGeneration++;
 		this.meetingId = null;

--- a/frontend/src/apps/meet/utils/sfu/SFUConnectionManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUConnectionManager.ts
@@ -28,12 +28,22 @@ import type { User } from "../../composables/useCurrentUser";
 import type { SFUMediaManager } from "./SFUMediaManager";
 import type { MediaScreenShareEvent } from "./SFUMediaManager";
 import type { SFURecoveryManager } from "./SFURecoveryManager";
+import {
+	applyMeetingReconciliationEvent,
+	createMeetingReconciliationState,
+	reconcileMeetingSnapshot,
+	type MeetingReconciliationEvent,
+	type MeetingReconciliationState,
+} from "./MeetingSnapshotReconciler";
 
 interface SFUProducerEvent {
 	producerId: string;
 	participantId: string;
 	isScreen?: boolean;
 }
+
+type ReconciledParticipant = ParticipantData & { participantId: string };
+type ReconciliationEvent = MeetingReconciliationEvent<ReconciledParticipant>;
 
 interface SFUProducerClosedEvent {
 	participantId?: string;
@@ -152,7 +162,10 @@ export class SFUConnectionManager {
 	currentUser: { value: User | null } = { value: null };
 	isConnected = false;
 	initialSyncInProgress = false;
-	bufferedProducerEvents: SFUProducerEvent[] = [];
+	private bufferedReconciliationEvents: ReconciliationEvent[] = [];
+	private reconciliation: MeetingReconciliationState<ReconciledParticipant> =
+		createMeetingReconciliationState();
+	private producerClaims = new Set<string>();
 	eventHandlers: SFUEventHandlers = {};
 	private lastJoinUserData: JoinUserData | null = null;
 	private lastJoinMediaState: JoinRoomMediaState = {
@@ -256,21 +269,32 @@ export class SFUConnectionManager {
 			const participants = await this.sfuClient.getRoomParticipants();
 			const currentUserId = this.getCurrentUserId();
 
-			const normalized = participants
+			const normalized: ReconciledParticipant[] = participants
 				.map((participant) => ({
 					...participant,
+					participantId: participant.participantId || participant.user_id || "",
 					audio_enabled: participant.userData?.audio_enabled ?? false,
 					video_enabled: participant.userData?.video_enabled ?? false,
 					is_guest: participant.userData?.is_guest ?? false,
 				}))
-				.filter((p) => p.user_id !== currentUserId);
-
-			this.participantManager.syncParticipants(normalized);
-
-			await this.requestExistingProducers();
-			await this.flushBufferedProducers();
+				.filter((p) => p.participantId && p.user_id !== currentUserId);
+			const existingProducers = await this.sfuClient.getExistingProducers();
+			this.reconciliation = reconcileMeetingSnapshot(
+				this.reconciliation,
+				{
+					participants: normalized,
+					producers: existingProducers.map((producer) => ({
+						producerId: producer.id,
+						participantId: producer.participantId,
+						isScreen: producer.isScreen === true,
+					})),
+				},
+				this.bufferedReconciliationEvents.splice(0),
+			);
+			this.participantManager.syncParticipants([...this.reconciliation.participants.values()]);
 
 			this.initialSyncInProgress = false;
+			await this.flushBufferedProducers();
 		} catch (error) {
 			console.error("Error in setupExistingParticipants:", error);
 			this.initialSyncInProgress = false;
@@ -280,85 +304,59 @@ export class SFUConnectionManager {
 
 	async requestExistingProducers(): Promise<SFUExistingProducer[] | null> {
 		try {
+			this.initialSyncInProgress = true;
 			const existingProducers = await this.sfuClient.getExistingProducers();
+			const previous = this.reconciliation;
+			const bufferedEvents = this.bufferedReconciliationEvents.splice(0);
+			this.reconciliation = reconcileMeetingSnapshot(
+				this.reconciliation,
+				{
+					producers: existingProducers.map((producer) => ({
+						producerId: producer.id,
+						participantId: producer.participantId,
+						isScreen: producer.isScreen === true,
+					})),
+				},
+				[],
+			);
+			for (const event of bufferedEvents) this.applyReconciliationEvent(event);
+			for (const producer of previous.producers.values()) {
+				if (!this.reconciliation.producers.has(producer.producerId)) {
+					this.removeProducerConsumers(producer);
+				}
+			}
+			this.initialSyncInProgress = false;
 
-			if (existingProducers?.length) {
+			if (existingProducers.length) {
 				console.log(
 					`Found ${existingProducers.length} existing producers:`,
 					existingProducers,
 				);
-
-				if (!(await this.waitForE2EEContextIfRequired())) {
-					this.bufferedProducerEvents.push(
-						...existingProducers.map((producer) => ({
-							producerId: producer.id,
-							participantId: producer.participantId,
-							isScreen: producer.isScreen,
-						})),
-					);
-					return existingProducers;
-				}
-
-				for (const producerInfo of existingProducers) {
-					const participantId = producerInfo.participantId;
-					const producerId = producerInfo.id;
-
-					if (this.hasConsumerForProducer(participantId, producerId)) {
-						continue;
-					}
-
-					console.log("Subscribing to existing producer:", {
-						producerId,
-						participantId,
-						kind: producerInfo.kind,
-						isScreen: producerInfo.isScreen,
-					});
-					await this.mediaManager.subscribeToRemoteProducer({
-						producerId,
-						participantId,
-						isScreen: producerInfo.isScreen,
-					});
-				}
+				await this.flushBufferedProducers();
 			} else {
 				console.log("No existing producers found");
 			}
 
 			return existingProducers;
 		} catch (error) {
+			this.initialSyncInProgress = false;
 			console.warn("Failed to request existing producers:", error);
 			return null;
 		}
 	}
 
 	async flushBufferedProducers(): Promise<void> {
-		if (!this.bufferedProducerEvents.length) {
+		if (!this.reconciliation.producers.size) {
 			console.log("No buffered producer events to flush");
-			return;
-		}
-		if (!(await this.waitForE2EEContextIfRequired())) {
 			return;
 		}
 
 		console.log(
-			`Flushing ${this.bufferedProducerEvents.length} buffered producer events`,
+			`Flushing ${this.reconciliation.producers.size} buffered producer events`,
 		);
-		const pending = this.bufferedProducerEvents.splice(0);
-		for (const event of pending) {
+		for (const event of this.reconciliation.producers.values()) {
 			try {
-				if (!event?.producerId || !event.participantId) {
-					console.warn("Skipping malformed buffered producer event:", event);
-					continue;
-				}
-
-				if (this.hasConsumerForProducer(event.participantId, event.producerId)) {
-					continue;
-				}
-
-				await this.mediaManager.subscribeToRemoteProducer({
-					producerId: event.producerId as string,
-					participantId: event.participantId as string,
-					isScreen: !!event.isScreen,
-				});
+				await this.subscribeToReconciledProducer(event);
 			} catch (error) {
 				console.warn("Failed to process buffered producer:", error);
 			}
@@ -481,6 +479,64 @@ export class SFUConnectionManager {
 		);
 	}
 
+	private async subscribeToReconciledProducer(event: SFUProducerEvent): Promise<void> {
+		if (
+			this.reconciliation.producers.get(event.producerId) !== event ||
+			this.producerClaims.has(event.producerId) ||
+			this.hasConsumerForProducer(event.participantId, event.producerId) ||
+			!this.transportManager?.isDeviceLoaded?.()
+		) return;
+
+		this.producerClaims.add(event.producerId);
+		try {
+			if (!(await this.waitForE2EEContextIfRequired())) return;
+			if (this.reconciliation.producers.get(event.producerId) !== event) return;
+			await this.mediaManager.subscribeToRemoteProducer(event);
+			if (this.reconciliation.producers.get(event.producerId) !== event) {
+				this.removeProducerConsumers(event);
+			}
+		} finally {
+			this.producerClaims.delete(event.producerId);
+		}
+	}
+
+	private removeProducerConsumers(event: SFUProducerEvent): void {
+		const consumers =
+			this.mediaManager.consumerManager.getConsumersByParticipant(event.participantId);
+		for (const consumer of consumers) {
+			const producerMatches =
+				consumer.consumer.producerId === event.producerId ||
+				consumer.appData?.producerId === event.producerId;
+			const isScreen =
+				consumer.isScreen ||
+				consumer.appData?.type === "screen" ||
+				consumer.consumer.appData?.type === "screen";
+			if (producerMatches || (event.isScreen && isScreen)) {
+				this.mediaManager.consumerManager.removeConsumer(consumer.id);
+				this.mediaManager.processedConsumers.delete(consumer.id);
+			}
+		}
+	}
+
+	private applyReconciliationEvent(event: ReconciliationEvent): void {
+		const previous = this.reconciliation;
+		this.reconciliation = applyMeetingReconciliationEvent(previous, event);
+		if (event.type === "participant-joined") {
+			if (!previous.participants.has(event.value.participantId)) {
+				this.participantManager.addParticipant(event.value);
+			}
+		} else if (event.type === "participant-left") {
+			if (!previous.departedParticipantIds.has(event.value.participantId)) {
+				this.participantManager.removeParticipant(event.value.participantId);
+			}
+		} else if (
+			event.type === "producer-closed" &&
+			!previous.closedProducerIds.has(event.value.producerId)
+		) {
+			this.removeProducerConsumers(event.value);
+		}
+	}
+
 	private getCurrentRejoinMediaState(): JoinRoomMediaState {
 		const localStream = this.mediaManager.mediaHandler.localStream;
 		if (!localStream) return this.lastJoinMediaState;
@@ -599,19 +655,43 @@ export class SFUConnectionManager {
 
 		this.sfuClient.on("participant_joined", (value: unknown) => {
 			const data = normalizeParticipantData(value);
-			if (!data) return;
+			if (!data?.participantId) return;
 			const currentUserId = this.getCurrentUserId();
 			const joinedUserId = data.participantId || data.user_id || "";
 
 			if (joinedUserId && joinedUserId !== currentUserId) {
-				this.participantManager.addParticipant(data);
+				const event: ReconciliationEvent = {
+					type: "participant-joined",
+					value: { ...data, participantId: data.participantId },
+				};
+				if (this.initialSyncInProgress) {
+					this.bufferedReconciliationEvents.push(event);
+					return;
+				}
+				const previous = this.reconciliation;
+				this.reconciliation = applyMeetingReconciliationEvent(previous, event);
+				if (!previous.participants.has(data.participantId)) {
+					this.participantManager.addParticipant(data);
+				}
 			}
 		});
 
 		this.sfuClient.on("participant_left", (value: unknown) => {
 			const participant = normalizeParticipantData(value);
 			if (participant?.participantId) {
-				this.participantManager.removeParticipant(participant.participantId);
+				const event: ReconciliationEvent = {
+					type: "participant-left",
+					value: { participantId: participant.participantId },
+				};
+				if (this.initialSyncInProgress) {
+					this.bufferedReconciliationEvents.push(event);
+					return;
+				}
+				const previous = this.reconciliation;
+				this.reconciliation = applyMeetingReconciliationEvent(previous, event);
+				if (!previous.departedParticipantIds.has(participant.participantId)) {
+					this.participantManager.removeParticipant(participant.participantId);
+				}
 			}
 		});
 
@@ -619,57 +699,46 @@ export class SFUConnectionManager {
 			const d = normalizeProducerEvent(value);
 			if (!d) return;
 			if (d.participantId === this.getCurrentUserId()) return;
-
+			const event: ReconciliationEvent = {
+				type: "producer-created",
+				value: { ...d, isScreen: d.isScreen === true },
+			};
+			if (this.initialSyncInProgress) {
+				this.bufferedReconciliationEvents.push(event);
+				return;
+			}
+			const previous = this.reconciliation;
+			this.reconciliation = applyMeetingReconciliationEvent(previous, event);
 			if (
-				this.initialSyncInProgress ||
-				!this.transportManager?.isDeviceLoaded?.()
-			) {
-				this.bufferedProducerEvents.push(d);
-				return;
-			}
-			if (!(await this.waitForE2EEContextIfRequired())) {
-				this.bufferedProducerEvents.push(d);
-				return;
-			}
-
-			try {
-				await this.mediaManager.subscribeToRemoteProducer({
-					producerId: d.producerId,
-					participantId: d.participantId,
-					isScreen: !!d.isScreen,
-				});
-			} catch (error) {
+				previous.producers.has(d.producerId) ||
+				!this.reconciliation.producers.has(d.producerId)
+			) return;
+			await this.subscribeToReconciledProducer(event.value).catch((error) => {
 				console.warn("Failed to subscribe to producer_created event:", error);
-			}
+			});
 		});
 
 		this.sfuClient.on("producer_closed", (value: unknown) => {
 			const d = normalizeProducerClosedEvent(value);
-			if (!d) return;
-			const pid = d.participantId;
-			const closedProducerId = d.producerId;
-			const closedIsScreen = d.isScreen;
-			if (pid) {
-				const allForPid =
-					this.mediaManager.consumerManager.getConsumersByParticipant(pid);
-				for (const c of allForPid) {
-					const producedMatch =
-						(closedProducerId && c.consumer.producerId === closedProducerId) ||
-						c.appData?.producerId === closedProducerId;
-					const isScreenLike =
-						c.isScreen ||
-						c.appData?.type === "screen" ||
-						c.consumer.appData?.type === "screen";
-					const shouldRemove =
-						producedMatch || (isScreenLike && closedIsScreen);
-					if (shouldRemove) {
-						this.mediaManager.consumerManager.removeConsumer(c.id);
-						this.mediaManager.processedConsumers.delete(c.id);
-					}
-				}
+			if (!d?.participantId || !d.producerId) return;
+			const event: ReconciliationEvent = {
+				type: "producer-closed",
+				value: {
+					participantId: d.participantId,
+					producerId: d.producerId,
+					isScreen: d.isScreen === true,
+				},
+			};
+			if (this.initialSyncInProgress) {
+				this.bufferedReconciliationEvents.push(event);
+				return;
 			}
+			const previous = this.reconciliation;
+			this.reconciliation = applyMeetingReconciliationEvent(previous, event);
+			if (previous.closedProducerIds.has(d.producerId)) return;
+			this.removeProducerConsumers(event.value);
 
-			if (this.eventHandlers && d?.isScreen) {
+			if (d.isScreen) {
 				this.eventHandlers.onScreenShareStopped?.({
 					participantId: d.participantId,
 				});
@@ -909,6 +978,9 @@ export class SFUConnectionManager {
 		this.eventHandlers = {};
 		this.isConnected = false;
 		this.initialSyncInProgress = false;
+		this.bufferedReconciliationEvents = [];
+		this.reconciliation = createMeetingReconciliationState();
+		this.producerClaims.clear();
 		this.lastJoinUserData = null;
 		this.lastJoinMediaState = {
 			audio_enabled: false,

--- a/frontend/src/apps/meet/utils/sfu/__tests__/MeetingSnapshotReconciler.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/MeetingSnapshotReconciler.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyMeetingReconciliationEvent,
+  createMeetingReconciliationState,
+  reconcileMeetingSnapshot,
+  type MeetingReconciliationEvent,
+} from "../MeetingSnapshotReconciler";
+
+interface Participant {
+  participantId: string;
+  name: string;
+}
+
+const participant = (participantId: string): Participant => ({
+  participantId,
+  name: participantId,
+});
+const producer = (producerId: string, participantId = "alice") => ({
+  producerId,
+  participantId,
+  isScreen: false,
+});
+
+describe("MeetingSnapshotReconciler", () => {
+  it("uses the snapshot as a baseline and replays live events in arrival order", () => {
+    const events: MeetingReconciliationEvent<Participant>[] = [
+      { type: "participant-left", value: { participantId: "alice" } },
+      { type: "participant-joined", value: participant("alice") },
+      { type: "producer-created", value: producer("new") },
+    ];
+
+    const state = reconcileMeetingSnapshot(
+      createMeetingReconciliationState<Participant>(),
+      { participants: [participant("alice")], producers: [producer("old")] },
+      events,
+    );
+
+    expect([...state.participants.keys()]).toEqual(["alice"]);
+    expect([...state.producers.keys()]).toEqual(["new"]);
+  });
+
+  it("lets leaves and closes beat stale snapshot entries", () => {
+    const state = reconcileMeetingSnapshot(
+      createMeetingReconciliationState<Participant>(),
+      {
+        participants: [participant("alice")],
+        producers: [producer("audio"), producer("video")],
+      },
+      [
+        { type: "producer-closed", value: producer("audio") },
+        { type: "participant-left", value: { participantId: "alice" } },
+      ],
+    );
+
+    expect(state.participants.size).toBe(0);
+    expect(state.producers.size).toBe(0);
+  });
+
+  it("is idempotent and ignores producers for a departed participant", () => {
+    let state = createMeetingReconciliationState<Participant>();
+    const events: MeetingReconciliationEvent<Participant>[] = [
+      { type: "participant-left", value: { participantId: "alice" } },
+      { type: "participant-left", value: { participantId: "alice" } },
+      { type: "producer-created", value: producer("ignored") },
+      { type: "producer-closed", value: producer("ignored") },
+      { type: "producer-closed", value: producer("ignored") },
+    ];
+    for (const event of events)
+      state = applyMeetingReconciliationEvent(state, event);
+
+    expect(state.participants.size).toBe(0);
+    expect(state.producers.size).toBe(0);
+    expect([...state.departedParticipantIds]).toEqual(["alice"]);
+    expect([...state.closedProducerIds]).toEqual(["ignored"]);
+  });
+
+  it("keeps the first live producer claim when a create is duplicated", () => {
+    const first = producer("audio");
+    let state = applyMeetingReconciliationEvent(
+      createMeetingReconciliationState<Participant>(),
+      { type: "producer-created", value: first },
+    );
+    state = applyMeetingReconciliationEvent(state, {
+      type: "producer-created",
+      value: producer("audio"),
+    });
+
+    expect(state.producers.get("audio")).toBe(first);
+  });
+
+  it("preserves participant state during producer-only reconciliation", () => {
+    const initial = reconcileMeetingSnapshot(
+      createMeetingReconciliationState<Participant>(),
+      { participants: [participant("alice")] },
+      [],
+    );
+    const state = reconcileMeetingSnapshot(
+      initial,
+      { producers: [producer("audio")] },
+      [],
+    );
+
+    expect([...state.participants.values()]).toEqual([participant("alice")]);
+    expect([...state.producers.keys()]).toEqual(["audio"]);
+  });
+});

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFUConnectionManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFUConnectionManager.test.ts
@@ -152,6 +152,62 @@ describe("SFUConnectionManager", () => {
 		});
 	});
 
+	it("claims duplicate producer events before awaiting E2EE", async () => {
+		const { handlers, manager, mediaManager } = createManager({
+			e2eeRequired: true,
+		});
+		await manager.connect("token");
+		const event = {
+			participantId: "remote-1",
+			producerId: "producer-1",
+			kind: "audio",
+		};
+
+		const first = handlers.get("producer_created")?.(event);
+		const duplicate = handlers.get("producer_created")?.(event);
+		E2EEMeeting.instance.setMeetingContext(
+			new Uint8Array(32) as Uint8Array<ArrayBuffer>,
+			1,
+		);
+		await Promise.all([first, duplicate]);
+
+		expect(mediaManager.subscribeToRemoteProducer).toHaveBeenCalledOnce();
+	});
+
+	it("replays participant leaves and producer closes over stale snapshots", async () => {
+		const { handlers, manager, mediaManager, participantManager, sfuClient } =
+			createManager();
+		await manager.connect("token");
+		sfuClient.getRoomParticipants.mockImplementationOnce(async () => {
+			handlers.get("participant_left")?.({ participantId: "remote-1" });
+			return [{ participantId: "remote-1", user_id: "remote-1" }];
+		});
+		sfuClient.getExistingProducers.mockImplementationOnce(async () => {
+			handlers.get("producer_closed")?.({
+				participantId: "remote-1",
+				producerId: "producer-1",
+			});
+			return [{ id: "producer-1", participantId: "remote-1" }];
+		});
+
+		await manager.setupExistingParticipants();
+
+		expect(participantManager.hasParticipant("remote-1")).toBe(false);
+		expect(mediaManager.subscribeToRemoteProducer).not.toHaveBeenCalled();
+	});
+
+	it("preserves participant state during producer-only reconciliation", async () => {
+		const { manager, participantManager } = createManager();
+		participantManager.addParticipant({
+			participantId: "remote-1",
+			userData: { name: "Remote" },
+		});
+
+		await manager.requestExistingProducers();
+
+		expect(participantManager.hasParticipant("remote-1")).toBe(true);
+	});
+
 	it("rejoins the room and rebuilds media after signaling reconnect", async () => {
 		const { manager, mediaManager, sfuClient, transportManager, recoveryManager } =
 			createManager();


### PR DESCRIPTION
- Added one shared Module for participant and producer snapshot reconciliation.
- Merged live join, leave, producer create, and producer close events over snapshots in arrival order.
- Used the shared reconciliation logic in normal Meet and the Recorder Endpoint.
- Prevented stale snapshots and duplicate events from restoring closed media or departed participants.
- Added race and duplicate-event tests.