### PR TITLE
fix(slides): flaky undo-delete and 403 on shared presentation media

### DIFF
--- a/frontend/src/apps/slides/components/PresentationList.vue
+++ b/frontend/src/apps/slides/components/PresentationList.vue
@@ -32,7 +32,7 @@
 							<div
 								v-if="presentation.thumbnail"
 								class="size-full"
-								:style="getThumbnailCardStyles(presentation.thumbnail)"
+								:style="getThumbnailCardStyles(presentation.thumbnail, presentation)"
 							></div>
 							<div
 								v-else

--- a/frontend/src/apps/slides/components/PresentationPreview.vue
+++ b/frontend/src/apps/slides/components/PresentationPreview.vue
@@ -98,7 +98,7 @@ const getActionIconClasses = (action) => {
 }
 
 const previewStyles = computed(() => {
-	return getThumbnailCardStyles(props.presentation.thumbnail)
+	return getThumbnailCardStyles(props.presentation.thumbnail, props.presentation)
 })
 
 const previewDetails = computed(() => {

--- a/frontend/src/apps/slides/pages/PresentationEditor.vue
+++ b/frontend/src/apps/slides/pages/PresentationEditor.vue
@@ -93,7 +93,7 @@ import {
 } from 'vue'
 import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router'
 
-import { call, usePageMeta, KeyboardShortcutsModal, Dialog, Button } from 'frappe-ui'
+import { call, toast, usePageMeta, KeyboardShortcutsModal, Dialog, Button } from 'frappe-ui'
 
 import ExportView from '@/apps/slides/pages/ExportView.vue'
 import EditorNavbar from '@/apps/slides/components/EditorNavbar.vue'
@@ -364,21 +364,31 @@ const createPresentation = async (theme) => {
 }
 
 const updatePresentationTheme = async (theme) => {
-	if (!presentationId.value) return
+	const id = presentationId.value
+	if (!id) return
 
 	showThemeDialog.value = false
 
-	call('frappe.client.set_value', {
-		doctype: 'Presentation',
-		name: presentationId.value,
-		fieldname: 'theme',
-		value: theme,
-	}).then((doc) => {
+	try {
+		const doc = await call('frappe.client.set_value', {
+			doctype: 'Presentation',
+			name: id,
+			fieldname: 'theme',
+			value: theme,
+		})
+
+		// the editor can move on mid-request; writing then would apply the theme
+		// and the modified stamp to a different presentation
+		if (presentationDoc.value?.name !== id) return
+
 		presentationDoc.value.theme = theme
 		// autosave stamps this onto the local copy, so a stale value would make the
 		// next load discard edits that had not synced yet
 		presentationDoc.value.modified = doc.modified
-	})
+	} catch (error) {
+		console.error('Failed to update theme: ', error)
+		toast.error('Could not update the theme. Please try again.')
+	}
 }
 
 const performNavbarDropdownAction = async (action) => {

--- a/frontend/src/apps/slides/pages/PresentationEditor.vue
+++ b/frontend/src/apps/slides/pages/PresentationEditor.vue
@@ -373,8 +373,11 @@ const updatePresentationTheme = async (theme) => {
 		name: presentationId.value,
 		fieldname: 'theme',
 		value: theme,
-	}).then(() => {
+	}).then((doc) => {
 		presentationDoc.value.theme = theme
+		// autosave stamps this onto the local copy, so a stale value would make the
+		// next load discard edits that had not synced yet
+		presentationDoc.value.modified = doc.modified
 	})
 }
 

--- a/frontend/src/apps/slides/stores/commands.js
+++ b/frontend/src/apps/slides/stores/commands.js
@@ -83,6 +83,8 @@ const editElementCommand = ({
 }
 
 const addSlide = (state, index, slide) => {
+	// autosave may already have deleted the row, so the next save has to insert it
+	slide.name = ''
 	state.splice(index, 0, slide)
 	state.forEach((slide, idx) => {
 		slide.idx = idx + 1

--- a/frontend/src/apps/slides/stores/commands.js
+++ b/frontend/src/apps/slides/stores/commands.js
@@ -83,8 +83,6 @@ const editElementCommand = ({
 }
 
 const addSlide = (state, index, slide) => {
-	// autosave may already have deleted the row, so the next save has to insert it
-	slide.name = ''
 	state.splice(index, 0, slide)
 	state.forEach((slide, idx) => {
 		slide.idx = idx + 1
@@ -107,6 +105,8 @@ const addSlideCommand = ({ slide, index, slideIndex }) => ({
 	fromSlideIndex: slideIndex,
 	debug: `Add slide ${slide.clientId} at index ${index}`,
 	execute(state) {
+		// autosave may already have deleted the row, so the next save has to insert it
+		slide.name = ''
 		addSlide(state, index, slide)
 	},
 	undo(state) {
@@ -123,6 +123,8 @@ const removeSlideCommand = ({ slide, index, slideIndex }) => ({
 		removeSlide(state, index, slide)
 	},
 	undo(state) {
+		// autosave may already have deleted the row, so the next save has to insert it
+		slide.name = ''
 		addSlide(state, index, slide)
 	},
 })

--- a/frontend/src/apps/slides/stores/commands.js
+++ b/frontend/src/apps/slides/stores/commands.js
@@ -105,7 +105,7 @@ const addSlideCommand = ({ slide, index, slideIndex }) => ({
 	fromSlideIndex: slideIndex,
 	debug: `Add slide ${slide.clientId} at index ${index}`,
 	execute(state) {
-		// autosave may already have deleted the row, so the next save has to insert it
+		// a name carried over from another row would make the next save update it
 		slide.name = ''
 		addSlide(state, index, slide)
 	},

--- a/frontend/src/apps/slides/stores/commands.test.ts
+++ b/frontend/src/apps/slides/stores/commands.test.ts
@@ -43,17 +43,14 @@ describe('removeSlideCommand', () => {
 })
 
 describe('addSlideCommand', () => {
-	it('drops the child row name on redo so the deleted row is re-inserted', () => {
-		const slide = makeSlide('c2', '')
+	it('never inserts a slide under a child row name it was handed', () => {
+		// pasted slides come from json, so the name is not ours to trust
+		const slide = makeSlide('c2', 'srv-row-2')
 		const state = [makeSlide('c1', 'srv-row-1')]
 
-		const command = addSlideCommand({ slide, index: 1, slideIndex: 0 })
-		command.execute(state)
-		// a save in between hands the row a server name that undo then deletes
-		state[1].name = 'srv-row-2'
-		command.undo(state)
-		command.execute(state)
+		addSlideCommand({ slide, index: 1, slideIndex: 0 }).execute(state)
 
+		expect(state).toHaveLength(2)
 		expect(state[1].name).toBe('')
 	})
 })

--- a/frontend/src/apps/slides/stores/commands.test.ts
+++ b/frontend/src/apps/slides/stores/commands.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+const slidesLength = ref(0)
+
+vi.mock('@/apps/slides/stores/presentation', () => ({ slidesLength }))
+vi.mock('@/apps/slides/stores/element', () => ({ findElement: () => null }))
+vi.mock('@/apps/slides/utils/helpers', () => ({
+	cloneObj: (obj: any) => JSON.parse(JSON.stringify(obj)),
+}))
+
+const { addSlideCommand, removeSlideCommand } = await import('./commands')
+
+const makeSlide = (clientId: string, name: string) => ({ clientId, name, elements: [] })
+
+describe('removeSlideCommand', () => {
+	it('drops the child row name so undo re-inserts a slide autosave already deleted', () => {
+		const slide = makeSlide('c2', 'srv-row-2')
+		const state = [makeSlide('c1', 'srv-row-1'), slide]
+
+		const command = removeSlideCommand({ slide, index: 1, slideIndex: 1 })
+		command.execute(state)
+		expect(state).toHaveLength(1)
+
+		command.undo(state)
+
+		expect(state).toHaveLength(2)
+		expect(state[1].clientId).toBe('c2')
+		expect(state[1].name).toBe('')
+	})
+
+	it('keeps the restored slide at its original index', () => {
+		const slide = makeSlide('c1', 'srv-row-1')
+		const state = [slide, makeSlide('c2', 'srv-row-2'), makeSlide('c3', 'srv-row-3')]
+
+		const command = removeSlideCommand({ slide, index: 0, slideIndex: 0 })
+		command.execute(state)
+		command.undo(state)
+
+		expect(state.map((s) => s.clientId)).toEqual(['c1', 'c2', 'c3'])
+		expect(state.map((s) => s.idx)).toEqual([1, 2, 3])
+	})
+})
+
+describe('addSlideCommand', () => {
+	it('drops the child row name on redo so the deleted row is re-inserted', () => {
+		const slide = makeSlide('c2', '')
+		const state = [makeSlide('c1', 'srv-row-1')]
+
+		const command = addSlideCommand({ slide, index: 1, slideIndex: 0 })
+		command.execute(state)
+		// a save in between hands the row a server name that undo then deletes
+		state[1].name = 'srv-row-2'
+		command.undo(state)
+		command.execute(state)
+
+		expect(state[1].name).toBe('')
+	})
+})

--- a/frontend/src/apps/slides/stores/presentation.js
+++ b/frontend/src/apps/slides/stores/presentation.js
@@ -286,11 +286,16 @@ const savePresentationDoc = async (updatedSlides) => {
 		}
 	})
 
-	await presentationResource.value.setValue.submit({
+	const resource = presentationResource.value
+	const doc = await resource.setValue.submit({
 		slides: newSlides,
 	})
 
-	presentationDoc.value = presentationResource.value.doc
+	// the editor can move on mid-save, and repointing presentationDoc at whatever
+	// the resource ref holds now would stamp this save onto another presentation
+	if (presentationResource.value === resource) presentationDoc.value = resource.doc
+
+	return doc?.modified
 }
 
 const presentationResource = ref(null)

--- a/frontend/src/apps/slides/stores/presentation.js
+++ b/frontend/src/apps/slides/stores/presentation.js
@@ -46,11 +46,11 @@ const updatePresentationTitle = async (id, newTitle) => {
 		name: id,
 		title: newTitle,
 	}).then((response) => {
-		if (response) {
-			return response
-		} else {
-			throw new Error('Failed to rename presentation')
-		}
+		if (!response) throw new Error('Failed to rename presentation')
+		// autosave stamps this onto the local copy, so a stale value would make the
+		// next load discard edits that had not synced yet
+		if (presentationDoc.value?.name === id) presentationDoc.value.modified = response.modified
+		return response.slug
 	})
 }
 
@@ -230,18 +230,21 @@ const getPresentationResource = (name) => {
 
 			// restore unsynced local edits, but only if the server hasn't moved past them
 			const local = await getPresentationFromLocalDB(name)
-			if (local?.dirty && local.baseModified === doc.modified) {
-				const restored = JSON.parse(JSON.stringify(local.content))
-				// local content skips the load pipeline; migrate + dedup it here too
-				for (const slide of restored) {
-					slide.background = normalizeColor(slide.background)
-					slide.elements = parseElements(slide.elements, slide)
+			if (local?.dirty) {
+				if (local.baseModified === doc.modified) {
+					const restored = JSON.parse(JSON.stringify(local.content))
+					// local content skips the load pipeline; migrate + dedup it here too
+					for (const slide of restored) {
+						slide.background = normalizeColor(slide.background)
+						slide.elements = parseElements(slide.elements, slide)
+					}
+					ensureUniqueClientIds(restored)
+					slides.value = restored
+					slidesLength.value = slides.value.length
+					markDirty()
+					return
 				}
-				ensureUniqueClientIds(restored)
-				slides.value = restored
-				slidesLength.value = slides.value.length
-				markDirty()
-				return
+				toast.warning('Changes that never reached the server were discarded.')
 			}
 
 			slides.value = JSON.parse(JSON.stringify(doc.slides || []))

--- a/frontend/src/apps/slides/stores/saving.js
+++ b/frontend/src/apps/slides/stores/saving.js
@@ -113,9 +113,14 @@ const syncSnapshotToServer = async (snapshot, id, generation) => {
 
 	await savePresentationDoc(snapshot.content)
 
-	// slides and presentationDoc now belong to another presentation,
-	// so there's nothing safe to write back to the local copy
-	if (presentationId.value !== id) return
+	// presentationDoc moved on, so baseModified can't be refreshed - but the server has this
+	// snapshot, and a clean record is never read back for baseModified anyway
+	if (presentationId.value !== id) {
+		if (dirtyGeneration === generation) {
+			await savePresentationToLocalDB({ ...snapshot, dirty: false, updatedAt: Date.now() })
+		}
+		return
+	}
 
 	// an edit made mid-save isn't in the snapshot the server just took, so the
 	// local copy has to keep it and stay dirty; baseModified tracks the server version

--- a/frontend/src/apps/slides/stores/saving.js
+++ b/frontend/src/apps/slides/stores/saving.js
@@ -89,6 +89,8 @@ const getPresentationFromLocalDB = async (id) => {
 // explicit dirty flag set by every mutation path
 const dirty = ref(false)
 
+const isSaving = ref(false)
+
 // bumped on every markDirty so a save can tell if edits arrived while it was in flight;
 // per presentation, since loading one marks it dirty and must not disturb another's save
 const dirtyGenerations = new Map()
@@ -103,9 +105,9 @@ const markDirty = () => {
 
 const markClean = () => {
 	dirty.value = false
+	// a save in flight still has a generation to compare against, so leave it alone
+	if (!isSaving.value) dirtyGenerations.delete(presentationId.value)
 }
-
-const isSaving = ref(false)
 
 // true when an online save to the server failed; drives the "Not saved" indicator
 const saveFailed = ref(false)
@@ -115,14 +117,20 @@ const syncSnapshotToServer = async (snapshot, id, generation) => {
 	// would land on the wrong document; the snapshot stays dirty and gets retried
 	if (presentationId.value !== id) return
 
-	await savePresentationDoc(snapshot.content)
+	// the version this save produced, read from its own response: presentationDoc
+	// may already point at another presentation by the time it resolves
+	const savedModified = await savePresentationDoc(snapshot.content)
 
-	// presentationDoc moved on, so baseModified can't be refreshed - but the server has this
-	// snapshot, and a clean record is never read back for baseModified anyway
 	if (presentationId.value !== id) {
-		if (generationFor(id) === generation) {
-			await savePresentationToLocalDB({ ...snapshot, dirty: false, updatedAt: Date.now() })
-		}
+		// an edit made mid-save lives in slides.value, which belongs to another
+		// presentation now and can't be read back; the server has this snapshot
+		await savePresentationToLocalDB({
+			...snapshot,
+			dirty: false,
+			updatedAt: Date.now(),
+			baseModified: savedModified,
+		})
+		dirtyGenerations.delete(id)
 		return
 	}
 
@@ -135,7 +143,7 @@ const syncSnapshotToServer = async (snapshot, id, generation) => {
 		content: editedDuringSave ? getLatestSlideContent() : snapshot.content,
 		dirty: editedDuringSave,
 		updatedAt: Date.now(),
-		baseModified: presentationDoc.value?.modified,
+		baseModified: savedModified,
 	})
 }
 

--- a/frontend/src/apps/slides/stores/saving.js
+++ b/frontend/src/apps/slides/stores/saving.js
@@ -89,12 +89,16 @@ const getPresentationFromLocalDB = async (id) => {
 // explicit dirty flag set by every mutation path
 const dirty = ref(false)
 
-// bumped on every markDirty so a save can tell if edits arrived while it was in flight
-let dirtyGeneration = 0
+// bumped on every markDirty so a save can tell if edits arrived while it was in flight;
+// per presentation, since loading one marks it dirty and must not disturb another's save
+const dirtyGenerations = new Map()
+
+const generationFor = (id) => dirtyGenerations.get(id) ?? 0
 
 const markDirty = () => {
 	dirty.value = true
-	dirtyGeneration++
+	const id = presentationId.value
+	if (id) dirtyGenerations.set(id, generationFor(id) + 1)
 }
 
 const markClean = () => {
@@ -116,7 +120,7 @@ const syncSnapshotToServer = async (snapshot, id, generation) => {
 	// presentationDoc moved on, so baseModified can't be refreshed - but the server has this
 	// snapshot, and a clean record is never read back for baseModified anyway
 	if (presentationId.value !== id) {
-		if (dirtyGeneration === generation) {
+		if (generationFor(id) === generation) {
 			await savePresentationToLocalDB({ ...snapshot, dirty: false, updatedAt: Date.now() })
 		}
 		return
@@ -124,7 +128,7 @@ const syncSnapshotToServer = async (snapshot, id, generation) => {
 
 	// an edit made mid-save isn't in the snapshot the server just took, so the
 	// local copy has to keep it and stay dirty; baseModified tracks the server version
-	const editedDuringSave = dirtyGeneration !== generation
+	const editedDuringSave = generationFor(id) !== generation
 
 	await savePresentationToLocalDB({
 		...snapshot,
@@ -157,7 +161,7 @@ const saveCurrentState = async () => {
 
 	try {
 		const idAtSnapshot = presentationId.value
-		const generationAtSnapshot = dirtyGeneration
+		const generationAtSnapshot = generationFor(idAtSnapshot)
 		const content = getLatestSlideContent()
 
 		// save to indexedDB as dirty (not yet synced); baseModified = server version these build on
@@ -179,7 +183,7 @@ const saveCurrentState = async () => {
 
 		// dirty belongs to another presentation now, so it isn't ours to clear
 		if (presentationId.value !== idAtSnapshot) return
-		if (dirtyGeneration === generationAtSnapshot) markClean()
+		if (generationFor(idAtSnapshot) === generationAtSnapshot) markClean()
 	} catch (err) {
 		// keep dirty so autosave retries and beforeunload warns; log once per outage
 		if (!saveFailed.value) console.error('Save failed: ', err)

--- a/frontend/src/apps/slides/stores/saving.test.ts
+++ b/frontend/src/apps/slides/stores/saving.test.ts
@@ -6,7 +6,7 @@ const presentationDoc = ref<any>({ modified: 'M1' })
 const inReadonlyMode = ref(false)
 const slides = ref<any[]>([{ clientId: 'c1', background: '#ff0000ff', elements: [] }])
 
-let serverSave: (content: any) => Promise<void>
+let serverSave: (content: any) => Promise<string | undefined>
 
 vi.mock('@/apps/slides/stores/presentation', () => ({
 	presentationId,
@@ -30,6 +30,7 @@ describe('saveCurrentState', () => {
 		slides.value = [{ clientId: 'c1', background: '#ff0000ff', elements: [] }]
 		serverSave = async () => {
 			presentationDoc.value = { modified: 'M2' }
+			return 'M2'
 		}
 	})
 
@@ -41,6 +42,7 @@ describe('saveCurrentState', () => {
 			slides.value[0].background = '#00ff00ff'
 			markDirty()
 			presentationDoc.value = { modified: 'M2' }
+			return 'M2'
 		}
 
 		await saveCurrentState()
@@ -51,23 +53,28 @@ describe('saveCurrentState', () => {
 		expect(local.content[0].background).toBe('#00ff00ff')
 	})
 
-	it('leaves the local copy alone when the editor moved on mid-save', async () => {
+	it('records the version the server took when the editor moved on mid-save', async () => {
 		markDirty()
 
 		serverSave = async () => {
-			// resetEditorState() blanks slides but leaves presentationId and the resource,
-			// and savePresentationDoc then repoints presentationDoc at the old doc
+			// resetEditorState() blanks slides, then the editor loads another presentation
 			slides.value = []
 			markDirty()
 			presentationId.value = 'p2'
-			presentationDoc.value = { modified: 'M2' }
+			// presentationDoc belongs to p2 by now, so baseModified has to come
+			// from what this save returned
+			presentationDoc.value = { modified: 'M9' }
+			return 'M2'
 		}
 
 		await saveCurrentState()
 
 		const local: any = await getPresentationFromLocalDB('p1')
+		// the snapshot the server took, not the blanked slides of the presentation
+		// the editor moved on to
 		expect(local.content).toHaveLength(1)
-		expect(local.baseModified).toBe('M1')
+		expect(local.dirty).toBe(false)
+		expect(local.baseModified).toBe('M2')
 	})
 
 	it('still marks the local copy clean when the editor moved on without editing', async () => {
@@ -76,12 +83,14 @@ describe('saveCurrentState', () => {
 		serverSave = async () => {
 			presentationId.value = 'p2'
 			presentationDoc.value = { modified: 'M2' }
+			return 'M2'
 		}
 
 		await saveCurrentState()
 
 		const local: any = await getPresentationFromLocalDB('p1')
 		expect(local.dirty).toBe(false)
+		expect(local.baseModified).toBe('M2')
 	})
 
 	it('marks the local copy clean when nothing changed during the save', async () => {

--- a/frontend/src/apps/slides/stores/saving.test.ts
+++ b/frontend/src/apps/slides/stores/saving.test.ts
@@ -70,6 +70,20 @@ describe('saveCurrentState', () => {
 		expect(local.baseModified).toBe('M1')
 	})
 
+	it('still marks the local copy clean when the editor moved on without editing', async () => {
+		markDirty()
+
+		serverSave = async () => {
+			presentationId.value = 'p2'
+			presentationDoc.value = { modified: 'M2' }
+		}
+
+		await saveCurrentState()
+
+		const local: any = await getPresentationFromLocalDB('p1')
+		expect(local.dirty).toBe(false)
+	})
+
 	it('marks the local copy clean when nothing changed during the save', async () => {
 		markDirty()
 

--- a/frontend/src/apps/slides/stores/slideshow.js
+++ b/frontend/src/apps/slides/stores/slideshow.js
@@ -79,7 +79,10 @@ const getAssetUrl = (url) => {
 	if (presentationDoc.value?.owner === user || user === 'Administrator') {
 		return url
 	}
-	return `/api/method/suite.slides.api.file.get_media_file?src=${encodeURIComponent(url)}`
+	const presentation = encodeURIComponent(presentationDoc.value?.name || '')
+	return `/api/method/suite.slides.api.file.get_media_file?src=${encodeURIComponent(
+		url,
+	)}&presentation=${presentation}`
 }
 
 const prefetchAsset = async (src, type) => {

--- a/frontend/src/apps/slides/stores/slideshow.js
+++ b/frontend/src/apps/slides/stores/slideshow.js
@@ -1,5 +1,9 @@
 import { ref, computed, nextTick } from 'vue'
-import { applyReverseTransition, presentationDoc } from '@/apps/slides/stores/presentation'
+import {
+	applyReverseTransition,
+	presentationDoc,
+	presentationId,
+} from '@/apps/slides/stores/presentation'
 import { focusedSlide, slideIndex, slides, setSlideIndex } from '@/apps/slides/stores/slide'
 
 import { router } from '@/apps/slides/router'
@@ -79,7 +83,7 @@ const getAssetUrl = (url) => {
 	if (presentationDoc.value?.owner === user || user === 'Administrator') {
 		return url
 	}
-	const presentation = encodeURIComponent(presentationDoc.value?.name || '')
+	const presentation = encodeURIComponent(presentationId.value || '')
 	return `/api/method/suite.slides.api.file.get_media_file?src=${encodeURIComponent(
 		url,
 	)}&presentation=${presentation}`

--- a/frontend/src/apps/slides/stores/slideshow.js
+++ b/frontend/src/apps/slides/stores/slideshow.js
@@ -83,10 +83,10 @@ const getAssetUrl = (url) => {
 	if (presentationDoc.value?.owner === user || user === 'Administrator') {
 		return url
 	}
-	const presentation = encodeURIComponent(presentationId.value || '')
+	if (!presentationId.value) return url
 	return `/api/method/suite.slides.api.file.get_media_file?src=${encodeURIComponent(
 		url,
-	)}&presentation=${presentation}`
+	)}&presentation=${encodeURIComponent(presentationId.value)}`
 }
 
 const prefetchAsset = async (src, type) => {

--- a/frontend/src/apps/slides/utils/helpers.ts
+++ b/frontend/src/apps/slides/utils/helpers.ts
@@ -66,8 +66,11 @@ const handleScrollBarWheelEvent = (e: WheelEvent) => {
 
 const cloneObj = (obj: any) => JSON.parse(JSON.stringify(obj))
 
-const getThumbnailCardStyles = (thumbnail: string) => {
-	const thumbnailUrl = getAttachmentUrl(thumbnail)
+const getThumbnailCardStyles = (
+	thumbnail: string,
+	sourcePresentation?: { name: string; owner: string },
+) => {
+	const thumbnailUrl = getAttachmentUrl(thumbnail, sourcePresentation)
 	return {
 		backgroundImage: `url(${thumbnailUrl})`,
 		backgroundSize: 'cover',

--- a/frontend/src/apps/slides/utils/mediaUploads.js
+++ b/frontend/src/apps/slides/utils/mediaUploads.js
@@ -116,6 +116,7 @@ export const getAttachmentUrl = (fileUrl) => {
 			// Non-owner media already goes through the slides-namespaced proxy below.
 			return `${fileUrl}${fileUrl.includes('?') ? '&' : '?'}${SLIDES_MEDIA_PARAM}`
 		}
-		return `/api/method/suite.slides.api.file.get_media_file?src=${fileUrl}`
+		const presentation = encodeURIComponent(presentationId.value || '')
+		return `/api/method/suite.slides.api.file.get_media_file?src=${fileUrl}&presentation=${presentation}`
 	}
 }

--- a/frontend/src/apps/slides/utils/mediaUploads.js
+++ b/frontend/src/apps/slides/utils/mediaUploads.js
@@ -117,6 +117,8 @@ export const getAttachmentUrl = (fileUrl) => {
 			return `${fileUrl}${fileUrl.includes('?') ? '&' : '?'}${SLIDES_MEDIA_PARAM}`
 		}
 		const presentation = encodeURIComponent(presentationId.value || '')
-		return `/api/method/suite.slides.api.file.get_media_file?src=${fileUrl}&presentation=${presentation}`
+		return `/api/method/suite.slides.api.file.get_media_file?src=${encodeURIComponent(
+			fileUrl,
+		)}&presentation=${presentation}`
 	}
 }

--- a/frontend/src/apps/slides/utils/mediaUploads.js
+++ b/frontend/src/apps/slides/utils/mediaUploads.js
@@ -98,7 +98,7 @@ export const handleUploadedMedia = (files, targetElement) => {
 	})
 }
 
-export const getAttachmentUrl = (fileUrl) => {
+export const getAttachmentUrl = (fileUrl, sourcePresentation) => {
 	if (!fileUrl) return ''
 
 	// if starts with data: or /assets return as it is
@@ -108,17 +108,22 @@ export const getAttachmentUrl = (fileUrl) => {
 	if (fileUrl.startsWith('/files')) fileUrl = `/private${fileUrl}`
 
 	if (fileUrl.startsWith('/private')) {
-		// if owner is trying to access just send static path
+		const name = sourcePresentation ? sourcePresentation.name : presentationId.value
+		const owner = sourcePresentation ? sourcePresentation.owner : presentationDoc.value?.owner
 		const user = session.user?.sessionUser
-		if (presentationDoc.value?.owner === user || user === 'Administrator') {
+
+		// if owner is trying to access just send static path
+		if (owner === user || user === 'Administrator') {
+			// a duplicate borrows its source's thumbnail url, so the proxy can't serve it
+			if (sourcePresentation) return fileUrl
 			// Tag the request so the slides service worker can cache it without
 			// touching other apps' /private/files/ traffic (Drive, Mail, ...).
 			// Non-owner media already goes through the slides-namespaced proxy below.
 			return `${fileUrl}${fileUrl.includes('?') ? '&' : '?'}${SLIDES_MEDIA_PARAM}`
 		}
-		if (!presentationId.value) return fileUrl
+		if (!name) return fileUrl
 		return `/api/method/suite.slides.api.file.get_media_file?src=${encodeURIComponent(
 			fileUrl,
-		)}&presentation=${encodeURIComponent(presentationId.value)}`
+		)}&presentation=${encodeURIComponent(name)}`
 	}
 }

--- a/frontend/src/apps/slides/utils/mediaUploads.js
+++ b/frontend/src/apps/slides/utils/mediaUploads.js
@@ -116,9 +116,9 @@ export const getAttachmentUrl = (fileUrl) => {
 			// Non-owner media already goes through the slides-namespaced proxy below.
 			return `${fileUrl}${fileUrl.includes('?') ? '&' : '?'}${SLIDES_MEDIA_PARAM}`
 		}
-		const presentation = encodeURIComponent(presentationId.value || '')
+		if (!presentationId.value) return fileUrl
 		return `/api/method/suite.slides.api.file.get_media_file?src=${encodeURIComponent(
 			fileUrl,
-		)}&presentation=${presentation}`
+		)}&presentation=${encodeURIComponent(presentationId.value)}`
 	}
 }

--- a/suite/slides/api/file.py
+++ b/suite/slides/api/file.py
@@ -6,6 +6,8 @@ from frappe import _
 from werkzeug.exceptions import Forbidden, NotFound
 from werkzeug.wrappers import Response
 
+from suite.drive.overrides.file import content_has_permission
+
 
 def get_file_size(file_path: str) -> int:
     """
@@ -96,7 +98,34 @@ def get_media_response(src: str) -> Response:
     return response
 
 
-def validate_media_file(src, presentation: str | None = None) -> None:
+SCAN_LIMIT = 100
+
+
+def get_unshared_templates(names: set[str]) -> set[str]:
+    """Every user, Guest included, may read a template presentation, so a File row
+    attached to one would hand out its url globally. A template that is genuinely
+    shared keeps its real Drive grant, which is what gets checked here. Viewing a
+    template itself still works, through the `presentation` argument."""
+    if not names:
+        return set()
+
+    rows = frappe.get_all(
+        "Presentation",
+        filters={"name": ("in", list(names)), "is_template": 1},
+        fields=["name", "owner"],
+        order_by=None,
+    )
+
+    return {
+        row.name
+        for row in rows
+        if not content_has_permission(
+            frappe._dict(doctype="Presentation", name=row.name, owner=row.owner), "read"
+        )
+    }
+
+
+def validate_media_file(src: str, presentation: str | None = None) -> None:
     # the presentation being viewed resolves to a single indexed row, so the scan
     # below is left to composite presentations and links made without this argument
     if presentation and frappe.db.exists(
@@ -113,23 +142,36 @@ def validate_media_file(src, presentation: str | None = None) -> None:
         filters={"file_url": src},
         fields=["name", "attached_to_doctype", "attached_to_name"],
         # a widely reused image collects a row per presentation, and guests reach
-        # this, so read a bounded slice; ordering it would scan every row first
+        # this, so read a bounded slice; the default order would sort the whole
+        # set before the limit applies
         order_by=None,
-        limit=100,
+        limit=SCAN_LIMIT,
     )
     if not files:
         raise NotFound
 
+    attached_presentations = {
+        file.attached_to_name
+        for file in files
+        if file.attached_to_doctype == "Presentation" and file.attached_to_name
+    }
+    templates = get_unshared_templates(attached_presentations)
+
     # File role perms exclude Guest, so check the attached presentation directly
-    for file in files:
-        if file.attached_to_doctype == "Presentation" and frappe.has_permission(
-            "Presentation", "read", file.attached_to_name
-        ):
+    for name in attached_presentations - templates:
+        if frappe.has_permission("Presentation", "read", name):
             return
 
+    # File permissions fall through to the document a file is attached to, so
+    # templates have to stay out of this pass too
     for file in files:
+        if file.attached_to_name in templates:
+            continue
         if frappe.has_permission("File", "read", file.name):
             return
+
+    if len(files) == SCAN_LIMIT:
+        frappe.logger("slides").warning(f"media access check for {src} stopped at {SCAN_LIMIT} rows")
 
     raise Forbidden(_("You don't have permission to access this file"))
 

--- a/suite/slides/api/file.py
+++ b/suite/slides/api/file.py
@@ -96,31 +96,54 @@ def get_media_response(src: str) -> Response:
     return response
 
 
-def validate_media_file(src) -> None:
-    file_name = frappe.db.exists("File", {"file_url": src})
-    if not file_name:
+def validate_media_file(src, presentation: str | None = None) -> None:
+    # the presentation being viewed resolves to a single indexed row, so the scan
+    # below is left to composite presentations and links made without this argument
+    if presentation and frappe.db.exists(
+        "File",
+        {"file_url": src, "attached_to_doctype": "Presentation", "attached_to_name": presentation},
+    ):
+        if frappe.has_permission("Presentation", "read", presentation):
+            return
+
+    # frappe dedupes file content, so one url can have many File rows attached to
+    # different presentations; access is allowed if any one of them is readable
+    files = frappe.get_all(
+        "File",
+        filters={"file_url": src},
+        fields=["name", "attached_to_doctype", "attached_to_name"],
+        # a widely reused image collects a row per presentation, and guests reach
+        # this, so read a bounded slice; ordering it would scan every row first
+        order_by=None,
+        limit=100,
+    )
+    if not files:
         raise NotFound
 
-    file_doc = frappe.get_doc("File", file_name)
-    if frappe.has_permission("File", "read", file_doc):
-        return
-
     # File role perms exclude Guest, so check the attached presentation directly
-    if file_doc.attached_to_doctype == "Presentation" and frappe.has_permission(
-        "Presentation", "read", file_doc.attached_to_name
-    ):
-        return
+    for file in files:
+        if file.attached_to_doctype == "Presentation" and frappe.has_permission(
+            "Presentation", "read", file.attached_to_name
+        ):
+            return
+
+    for file in files:
+        if frappe.has_permission("File", "read", file.name):
+            return
 
     raise Forbidden(_("You don't have permission to access this file"))
 
 
 @frappe.whitelist(allow_guest=True)
-def get_media_file(src: str, public: str | None = None) -> Response:
+def get_media_file(src: str, public: str | None = None, presentation: str | None = None) -> Response:
     """
     Fetches permitted video file and returns a response.
 
+    `presentation` is the presentation being viewed; it only narrows the lookup,
+    access is granted the same way with or without it.
+
     `public` is deprecated and ignored; access is determined server-side.
     """
-    validate_media_file(src)
+    validate_media_file(src, presentation)
 
     return get_media_response(src)

--- a/suite/slides/api/file.py
+++ b/suite/slides/api/file.py
@@ -96,9 +96,6 @@ def get_media_response(src: str) -> Response:
     return response
 
 
-SCAN_LIMIT = 100
-
-
 def get_reference_presentations(name: str) -> set[str]:
     """Presentations a composite shows; its media is attached to those, not to it."""
     return set(
@@ -111,79 +108,35 @@ def get_reference_presentations(name: str) -> set[str]:
     )
 
 
-def get_attached_presentations(src: str, names: set[str] | None = None) -> set[str]:
-    """Presentations holding `src`, deduped: one url collects a File row per upload."""
-    filters = {"file_url": src, "attached_to_doctype": "Presentation"}
-    limit = SCAN_LIMIT
-    if names is not None:
-        if not names:
-            return set()
-        filters["attached_to_name"] = ("in", list(names))
-        limit = None
-
-    found = set(
-        frappe.get_all(
-            "File", filters=filters, pluck="attached_to_name", distinct=True, order_by=None, limit=limit
-        )
-    )
-
-    if limit and len(found) == limit:
-        frappe.logger("slides").warning(f"media access check for {src} stopped at {limit}")
-
-    return found
-
-
-def can_read_any(names: set[str]) -> bool:
-    """Whether the caller may read any of `names`. Templates they don't own don't
-    count, since everyone can read a template."""
+def get_attached_presentations(src: str, names: set[str]) -> set[str]:
+    """Which of `names` hold `src`, deduped: one url collects a File row per upload."""
     if not names:
-        return False
+        return set()
 
-    user = frappe.session.user
-    candidates = {
-        row.name
-        for row in frappe.get_all(
-            "Presentation",
-            filters={"name": ("in", list(names))},
-            fields=["name", "owner", "is_template"],
+    return set(
+        frappe.get_all(
+            "File",
+            filters={
+                "file_url": src,
+                "attached_to_doctype": "Presentation",
+                "attached_to_name": ("in", list(names)),
+            },
+            pluck="attached_to_name",
+            distinct=True,
             order_by=None,
         )
-        if not row.is_template or row.owner == user
-    }
-    if not candidates:
-        return False
-
-    # a hint that skips the loop in the common case, never a decision
-    shortlist = frappe.get_list(
-        "Presentation", filters={"name": ("in", list(candidates))}, pluck="name", limit=1
     )
-    if shortlist and frappe.has_permission("Presentation", "read", shortlist[0]):
-        return True
-
-    return any(frappe.has_permission("Presentation", "read", name) for name in candidates)
 
 
 def validate_media_file(src: str, presentation: str | None = None) -> None:
     if presentation:
-        viewed = get_attached_presentations(src, {presentation} | get_reference_presentations(presentation))
-        # everyone can read a template, which is what makes viewing one work
-        if presentation in viewed and frappe.has_permission("Presentation", "read", presentation):
-            return
-        if can_read_any(viewed - {presentation}):
-            return
+        shown = {presentation} | get_reference_presentations(presentation)
+        for name in get_attached_presentations(src, shown):
+            if frappe.has_permission("Presentation", "read", name):
+                return
 
     if not frappe.db.exists("File", {"file_url": src}):
         raise NotFound
-
-    if frappe.db.exists("File", {"file_url": src, "is_private": 0}):
-        return
-
-    user = frappe.session.user
-    if user != "Guest" and frappe.db.exists("File", {"file_url": src, "owner": user}):
-        return
-
-    if can_read_any(get_attached_presentations(src)):
-        return
 
     raise Forbidden(_("You don't have permission to access this file"))
 
@@ -193,7 +146,8 @@ def get_media_file(src: str, public: str | None = None, presentation: str | None
     """
     Fetches permitted video file and returns a response.
 
-    `presentation` narrows the lookup, and is the only way a template's media is served.
+    `presentation` is the presentation the media is being viewed in, and is required:
+    a file url on its own does not identify who may see it.
 
     `public` is deprecated and ignored; access is determined server-side.
     """

--- a/suite/slides/api/file.py
+++ b/suite/slides/api/file.py
@@ -6,8 +6,6 @@ from frappe import _
 from werkzeug.exceptions import Forbidden, NotFound
 from werkzeug.wrappers import Response
 
-from suite.drive.overrides.file import content_has_permission
-
 
 def get_file_size(file_path: str) -> int:
     """
@@ -101,77 +99,91 @@ def get_media_response(src: str) -> Response:
 SCAN_LIMIT = 100
 
 
-def get_unshared_templates(names: set[str]) -> set[str]:
-    """Every user, Guest included, may read a template presentation, so a File row
-    attached to one would hand out its url globally. A template that is genuinely
-    shared keeps its real Drive grant, which is what gets checked here. Viewing a
-    template itself still works, through the `presentation` argument."""
-    if not names:
-        return set()
-
-    rows = frappe.get_all(
-        "Presentation",
-        filters={"name": ("in", list(names)), "is_template": 1},
-        fields=["name", "owner"],
-        order_by=None,
+def get_reference_presentations(name: str) -> set[str]:
+    """Presentations a composite shows; its media is attached to those, not to it."""
+    return set(
+        frappe.get_all(
+            "Reference Presentation",
+            filters={"parent": name, "parenttype": "Presentation"},
+            pluck="presentation",
+            order_by=None,
+        )
     )
 
-    return {
-        row.name
-        for row in rows
-        if not content_has_permission(
-            frappe._dict(doctype="Presentation", name=row.name, owner=row.owner), "read"
+
+def get_attached_presentations(src: str, names: set[str] | None = None) -> set[str]:
+    """Presentations holding `src`, deduped: one url collects a File row per upload."""
+    filters = {"file_url": src, "attached_to_doctype": "Presentation"}
+    limit = SCAN_LIMIT
+    if names is not None:
+        if not names:
+            return set()
+        filters["attached_to_name"] = ("in", list(names))
+        limit = None
+
+    found = set(
+        frappe.get_all(
+            "File", filters=filters, pluck="attached_to_name", distinct=True, order_by=None, limit=limit
         )
+    )
+
+    if limit and len(found) == limit:
+        frappe.logger("slides").warning(f"media access check for {src} stopped at {limit}")
+
+    return found
+
+
+def can_read_any(names: set[str]) -> bool:
+    """Whether the caller may read any of `names`. Templates they don't own don't
+    count, since everyone can read a template."""
+    if not names:
+        return False
+
+    user = frappe.session.user
+    candidates = {
+        row.name
+        for row in frappe.get_all(
+            "Presentation",
+            filters={"name": ("in", list(names))},
+            fields=["name", "owner", "is_template"],
+            order_by=None,
+        )
+        if not row.is_template or row.owner == user
     }
+    if not candidates:
+        return False
+
+    # a hint that skips the loop in the common case, never a decision
+    shortlist = frappe.get_list(
+        "Presentation", filters={"name": ("in", list(candidates))}, pluck="name", limit=1
+    )
+    if shortlist and frappe.has_permission("Presentation", "read", shortlist[0]):
+        return True
+
+    return any(frappe.has_permission("Presentation", "read", name) for name in candidates)
 
 
 def validate_media_file(src: str, presentation: str | None = None) -> None:
-    # the presentation being viewed resolves to a single indexed row, so the scan
-    # below is left to composite presentations and links made without this argument
-    if presentation and frappe.db.exists(
-        "File",
-        {"file_url": src, "attached_to_doctype": "Presentation", "attached_to_name": presentation},
-    ):
-        if frappe.has_permission("Presentation", "read", presentation):
+    if presentation:
+        viewed = get_attached_presentations(src, {presentation} | get_reference_presentations(presentation))
+        # everyone can read a template, which is what makes viewing one work
+        if presentation in viewed and frappe.has_permission("Presentation", "read", presentation):
+            return
+        if can_read_any(viewed - {presentation}):
             return
 
-    # frappe dedupes file content, so one url can have many File rows attached to
-    # different presentations; access is allowed if any one of them is readable
-    files = frappe.get_all(
-        "File",
-        filters={"file_url": src},
-        fields=["name", "attached_to_doctype", "attached_to_name"],
-        # a widely reused image collects a row per presentation, and guests reach
-        # this, so read a bounded slice; the default order would sort the whole
-        # set before the limit applies
-        order_by=None,
-        limit=SCAN_LIMIT,
-    )
-    if not files:
+    if not frappe.db.exists("File", {"file_url": src}):
         raise NotFound
 
-    attached_presentations = {
-        file.attached_to_name
-        for file in files
-        if file.attached_to_doctype == "Presentation" and file.attached_to_name
-    }
-    templates = get_unshared_templates(attached_presentations)
+    if frappe.db.exists("File", {"file_url": src, "is_private": 0}):
+        return
 
-    # File role perms exclude Guest, so check the attached presentation directly
-    for name in attached_presentations - templates:
-        if frappe.has_permission("Presentation", "read", name):
-            return
+    user = frappe.session.user
+    if user != "Guest" and frappe.db.exists("File", {"file_url": src, "owner": user}):
+        return
 
-    # File permissions fall through to the document a file is attached to, so
-    # templates have to stay out of this pass too
-    for file in files:
-        if file.attached_to_name in templates:
-            continue
-        if frappe.has_permission("File", "read", file.name):
-            return
-
-    if len(files) == SCAN_LIMIT:
-        frappe.logger("slides").warning(f"media access check for {src} stopped at {SCAN_LIMIT} rows")
+    if can_read_any(get_attached_presentations(src)):
+        return
 
     raise Forbidden(_("You don't have permission to access this file"))
 
@@ -181,8 +193,7 @@ def get_media_file(src: str, public: str | None = None, presentation: str | None
     """
     Fetches permitted video file and returns a response.
 
-    `presentation` is the presentation being viewed; it only narrows the lookup,
-    access is granted the same way with or without it.
+    `presentation` narrows the lookup, and is the only way a template's media is served.
 
     `public` is deprecated and ignored; access is determined server-side.
     """

--- a/suite/slides/api/test_file.py
+++ b/suite/slides/api/test_file.py
@@ -31,17 +31,17 @@ class TestMediaFileAccess(IntegrationTestCase):
 
     def test_owner_can_access(self):
         with self.set_user(OWNER):
-            self.assertIsNone(validate_media_file(self.file.file_url))
+            self.assertIsNone(validate_media_file(self.file.file_url, self.presentation.name))
 
     def test_other_user_forbidden(self):
         with self.set_user(OTHER_USER):
             with self.assertRaises(Forbidden):
-                validate_media_file(self.file.file_url)
+                validate_media_file(self.file.file_url, self.presentation.name)
 
     def test_guest_forbidden(self):
         with self.set_user("Guest"):
             with self.assertRaises(Forbidden):
-                validate_media_file(self.file.file_url)
+                validate_media_file(self.file.file_url, self.presentation.name)
 
     def test_guest_can_access_file_of_public_presentation(self):
         # own fixtures: making the shared presentation public would break the deny tests
@@ -51,44 +51,29 @@ class TestMediaFileAccess(IntegrationTestCase):
             make_public(presentation.name)
 
         with self.set_user("Guest"):
-            self.assertIsNone(validate_media_file(file.file_url))
+            self.assertIsNone(validate_media_file(file.file_url, presentation.name))
 
-    def test_guest_can_access_when_a_sibling_row_is_private(self):
+    def test_missing_presentation_is_forbidden(self):
+        with self.set_user(OWNER):
+            self.assertRaises(Forbidden, validate_media_file, self.file.file_url)
+
+    def test_a_public_presentation_sharing_the_url_grants_nothing(self):
+        # frappe stores one copy of the bytes, so a public presentation can hold the
+        # same url as a private one; only the presentation being viewed decides
         with self.set_user(OWNER):
             files = self.make_shared_url("Sibling Media")
             make_public(files[1].attached_to_name)
 
         with self.set_user("Guest"):
-            self.assertIsNone(validate_media_file(files[0].file_url))
-
-    def test_guest_forbidden_when_every_row_is_private(self):
-        with self.set_user(OWNER):
-            files = self.make_shared_url("Private Sibling Media")
-
-        with self.set_user("Guest"):
+            self.assertIsNone(validate_media_file(files[1].file_url, files[1].attached_to_name))
             with self.assertRaises(Forbidden):
-                validate_media_file(files[0].file_url)
-
-    def test_presentation_arg_narrows_the_lookup(self):
-        with self.set_user(OWNER):
-            self.assertIsNone(validate_media_file(self.file.file_url, self.presentation.name))
+                validate_media_file(files[0].file_url, files[0].attached_to_name)
 
     def test_presentation_arg_grants_nothing_on_its_own(self):
         with self.set_user(OTHER_USER):
             own = make_presentation("Unrelated Presentation")
             with self.assertRaises(Forbidden):
                 validate_media_file(self.file.file_url, own.name)
-
-    def test_template_row_grants_nothing_to_the_world(self):
-        # anyone can read a template presentation, so a row attached to one would
-        # hand out every url it shares with a private presentation
-        with self.set_user(OWNER):
-            files = self.make_shared_url("Template Media")
-            frappe.db.set_value("Presentation", files[1].attached_to_name, "is_template", 1)
-
-        with self.set_user("Guest"):
-            with self.assertRaises(Forbidden):
-                validate_media_file(files[0].file_url)
 
     def test_guest_can_access_a_template_being_viewed(self):
         with self.set_user(OWNER):
@@ -100,8 +85,7 @@ class TestMediaFileAccess(IntegrationTestCase):
             self.assertIsNone(validate_media_file(file.file_url, presentation.name))
 
     def test_composite_resolves_to_the_presentations_it_shows(self):
-        # references must be public, so the scan would allow this too; resolving
-        # them is what keeps composites off that scan
+        # a composite's media hangs off the presentations it references, not off itself
         with self.set_user(OWNER):
             source = make_presentation("Composite Source")
             file = make_private_image(source.name)
@@ -116,16 +100,6 @@ class TestMediaFileAccess(IntegrationTestCase):
 
         with self.set_user("Guest"):
             self.assertIsNone(validate_media_file(file.file_url, composite.name))
-
-    def test_orphan_attachment_row_is_forbidden_not_an_error(self):
-        with self.set_user(OWNER):
-            presentation = make_presentation("Orphan Row")
-            file = make_private_image(presentation.name)
-            frappe.db.set_value("File", file.name, "attached_to_name", "does-not-exist")
-
-        with self.set_user(OTHER_USER):
-            with self.assertRaises(Forbidden):
-                validate_media_file(file.file_url)
 
     def test_unknown_url_not_found(self):
         with self.set_user(OWNER):

--- a/suite/slides/api/test_file.py
+++ b/suite/slides/api/test_file.py
@@ -1,11 +1,17 @@
 # Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+import frappe
 from frappe.tests import IntegrationTestCase
-from werkzeug.exceptions import Forbidden
+from werkzeug.exceptions import Forbidden, NotFound
 
 from suite.slides.api.file import validate_media_file
-from suite.slides.tests.utils import make_presentation, make_private_image, make_public
+from suite.slides.tests.utils import (
+    make_presentation,
+    make_private_image,
+    make_public,
+    unique_image_content,
+)
 from suite.tests.utils import ensure_user
 
 OWNER = "media-owner@example.com"
@@ -46,3 +52,47 @@ class TestMediaFileAccess(IntegrationTestCase):
 
         with self.set_user("Guest"):
             self.assertIsNone(validate_media_file(file.file_url))
+
+    def test_guest_can_access_when_a_sibling_row_is_private(self):
+        with self.set_user(OWNER):
+            files = self.make_shared_url("Sibling Media")
+            # the lookup returns rows in name order, so share the one it won't reach first
+            first = frappe.db.exists("File", {"file_url": files[0].file_url})
+            reachable = next(f for f in files if f.name != first)
+            make_public(reachable.attached_to_name)
+
+        with self.set_user("Guest"):
+            self.assertIsNone(validate_media_file(files[0].file_url))
+
+    def test_guest_forbidden_when_every_row_is_private(self):
+        with self.set_user(OWNER):
+            files = self.make_shared_url("Private Sibling Media")
+
+        with self.set_user("Guest"):
+            with self.assertRaises(Forbidden):
+                validate_media_file(files[0].file_url)
+
+    def test_presentation_arg_narrows_the_lookup(self):
+        with self.set_user(OWNER):
+            self.assertIsNone(validate_media_file(self.file.file_url, self.presentation.name))
+
+    def test_presentation_arg_grants_nothing_on_its_own(self):
+        with self.set_user(OTHER_USER):
+            own = make_presentation("Unrelated Presentation")
+            with self.assertRaises(Forbidden):
+                validate_media_file(self.file.file_url, own.name)
+
+    def test_unknown_url_not_found(self):
+        with self.set_user(OWNER):
+            with self.assertRaises(NotFound):
+                validate_media_file("/private/files/no-such-file.png")
+
+    def make_shared_url(self, title):
+        """Two presentations holding the same image, which frappe stores once and
+        references from a File row per presentation."""
+        content = unique_image_content()
+        files = [
+            make_private_image(make_presentation(f"{title} {i}").name, content=content) for i in range(2)
+        ]
+        self.assertEqual(files[0].file_url, files[1].file_url)
+        return files

--- a/suite/slides/api/test_file.py
+++ b/suite/slides/api/test_file.py
@@ -5,7 +5,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 from werkzeug.exceptions import Forbidden, NotFound
 
-from suite.slides.api.file import validate_media_file
+from suite.slides.api.file import get_reference_presentations, validate_media_file
 from suite.slides.tests.utils import (
     make_presentation,
     make_private_image,
@@ -56,10 +56,7 @@ class TestMediaFileAccess(IntegrationTestCase):
     def test_guest_can_access_when_a_sibling_row_is_private(self):
         with self.set_user(OWNER):
             files = self.make_shared_url("Sibling Media")
-            # the lookup returns rows in name order, so share the one it won't reach first
-            first = frappe.db.exists("File", {"file_url": files[0].file_url})
-            reachable = next(f for f in files if f.name != first)
-            make_public(reachable.attached_to_name)
+            make_public(files[1].attached_to_name)
 
         with self.set_user("Guest"):
             self.assertIsNone(validate_media_file(files[0].file_url))
@@ -93,17 +90,6 @@ class TestMediaFileAccess(IntegrationTestCase):
             with self.assertRaises(Forbidden):
                 validate_media_file(files[0].file_url)
 
-    def test_shared_template_keeps_serving_its_media(self):
-        # a composite sends its own name, so a referenced template falls to the scan
-        with self.set_user(OWNER):
-            presentation = make_presentation("Shared Template Media")
-            file = make_private_image(presentation.name)
-            make_public(presentation.name)
-            frappe.db.set_value("Presentation", presentation.name, "is_template", 1)
-
-        with self.set_user("Guest"):
-            self.assertIsNone(validate_media_file(file.file_url))
-
     def test_guest_can_access_a_template_being_viewed(self):
         with self.set_user(OWNER):
             presentation = make_presentation("Viewed Template")
@@ -112,6 +98,34 @@ class TestMediaFileAccess(IntegrationTestCase):
 
         with self.set_user("Guest"):
             self.assertIsNone(validate_media_file(file.file_url, presentation.name))
+
+    def test_composite_resolves_to_the_presentations_it_shows(self):
+        # references must be public, so the scan would allow this too; resolving
+        # them is what keeps composites off that scan
+        with self.set_user(OWNER):
+            source = make_presentation("Composite Source")
+            file = make_private_image(source.name)
+            make_public(source.name)
+
+            composite = make_presentation("Composite")
+            composite.is_composite = 1
+            composite.append("reference_presentations", {"presentation": source.name})
+            composite.save()
+
+        self.assertEqual(get_reference_presentations(composite.name), {source.name})
+
+        with self.set_user("Guest"):
+            self.assertIsNone(validate_media_file(file.file_url, composite.name))
+
+    def test_orphan_attachment_row_is_forbidden_not_an_error(self):
+        with self.set_user(OWNER):
+            presentation = make_presentation("Orphan Row")
+            file = make_private_image(presentation.name)
+            frappe.db.set_value("File", file.name, "attached_to_name", "does-not-exist")
+
+        with self.set_user(OTHER_USER):
+            with self.assertRaises(Forbidden):
+                validate_media_file(file.file_url)
 
     def test_unknown_url_not_found(self):
         with self.set_user(OWNER):

--- a/suite/slides/api/test_file.py
+++ b/suite/slides/api/test_file.py
@@ -82,6 +82,37 @@ class TestMediaFileAccess(IntegrationTestCase):
             with self.assertRaises(Forbidden):
                 validate_media_file(self.file.file_url, own.name)
 
+    def test_template_row_grants_nothing_to_the_world(self):
+        # anyone can read a template presentation, so a row attached to one would
+        # hand out every url it shares with a private presentation
+        with self.set_user(OWNER):
+            files = self.make_shared_url("Template Media")
+            frappe.db.set_value("Presentation", files[1].attached_to_name, "is_template", 1)
+
+        with self.set_user("Guest"):
+            with self.assertRaises(Forbidden):
+                validate_media_file(files[0].file_url)
+
+    def test_shared_template_keeps_serving_its_media(self):
+        # a composite sends its own name, so a referenced template falls to the scan
+        with self.set_user(OWNER):
+            presentation = make_presentation("Shared Template Media")
+            file = make_private_image(presentation.name)
+            make_public(presentation.name)
+            frappe.db.set_value("Presentation", presentation.name, "is_template", 1)
+
+        with self.set_user("Guest"):
+            self.assertIsNone(validate_media_file(file.file_url))
+
+    def test_guest_can_access_a_template_being_viewed(self):
+        with self.set_user(OWNER):
+            presentation = make_presentation("Viewed Template")
+            file = make_private_image(presentation.name)
+            frappe.db.set_value("Presentation", presentation.name, "is_template", 1)
+
+        with self.set_user("Guest"):
+            self.assertIsNone(validate_media_file(file.file_url, presentation.name))
+
     def test_unknown_url_not_found(self):
         with self.set_user(OWNER):
             with self.assertRaises(NotFound):

--- a/suite/slides/doctype/presentation/presentation.py
+++ b/suite/slides/doctype/presentation/presentation.py
@@ -180,7 +180,9 @@ def save_presentation_thumbnail(presentation_name: str, base64_data: str) -> str
     file_url = replace_thumbnail_file(presentation, base64_data)
 
     if presentation.thumbnail != file_url:
-        presentation.db_set("thumbnail", file_url)
+        # the thumbnail is derived, not an edit: bumping modified would make the
+        # editor discard local changes it had not synced yet
+        presentation.db_set("thumbnail", file_url, update_modified=False)
     return file_url
 
 
@@ -372,7 +374,7 @@ def update_title(name: str, title: str):
     presentation.check_permission("write")
     presentation.title = title
     presentation.save()
-    return slug(title)
+    return {"slug": slug(title), "modified": presentation.modified}
 
 
 def get_attachment(presentation, file_url):

--- a/suite/slides/doctype/presentation/test_presentation.py
+++ b/suite/slides/doctype/presentation/test_presentation.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 import frappe
+from frappe.client import set_value
 from frappe.tests import IntegrationTestCase
 
 from suite.slides.doctype.presentation.presentation import (
@@ -131,3 +132,31 @@ class TestPresentationSecurity(IntegrationTestCase):
             result = get_composite_presentation(composite.name)
 
         self.assertEqual(result["slides"], [])
+
+
+class TestSlideRows(IntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        ensure_user(OWNER)
+
+    def test_slide_resent_without_a_name_is_reinserted(self):
+        """Undoing a delete restores a slide whose row an autosave already dropped, so
+        the editor blanks the row name and the next save has to insert it again."""
+        with self.set_user(OWNER):
+            presentation = make_presentation("Undo Delete Presentation")
+            presentation.append("slides", {"elements": "[]"})
+            presentation.save()
+            kept, removed = (slide.as_dict() for slide in presentation.slides)
+
+            set_value("Presentation", presentation.name, {"slides": [kept]})
+            self.assertFalse(frappe.db.exists("Slide", removed.name))
+
+            restored = removed.copy()
+            restored.name = ""
+            set_value("Presentation", presentation.name, {"slides": [kept, restored]})
+
+        slides = frappe.get_doc("Presentation", presentation.name).slides
+        self.assertEqual(len(slides), 2)
+        self.assertEqual(slides[0].name, kept.name)
+        self.assertNotIn(slides[1].name, ("", removed.name))

--- a/suite/slides/tests/utils.py
+++ b/suite/slides/tests/utils.py
@@ -22,10 +22,14 @@ def make_presentation(title):
     ).insert()
 
 
-def make_private_image(presentation_name):
+def unique_image_content():
+    return base64.b64decode(PNG_1PX.split(",", 1)[1]) + uuid.uuid4().bytes
+
+
+def make_private_image(presentation_name, content=None):
     # unique content per call: frappe dedupes Files by content hash, which
     # would otherwise share one file_url across unrelated test fixtures
-    content = base64.b64decode(PNG_1PX.split(",", 1)[1]) + uuid.uuid4().bytes
+    content = content or unique_image_content()
     return frappe.get_doc(
         {
             "doctype": "File",

--- a/suite/slides/tests/utils.py
+++ b/suite/slides/tests/utils.py
@@ -29,7 +29,9 @@ def unique_image_content():
 def make_private_image(presentation_name, content=None):
     # unique content per call: frappe dedupes Files by content hash, which
     # would otherwise share one file_url across unrelated test fixtures
-    content = content or unique_image_content()
+    if content is None:
+        content = unique_image_content()
+
     return frappe.get_doc(
         {
             "doctype": "File",


### PR DESCRIPTION
- **Media 403s.** Access was checked against one File row picked at random for that file url. One url can have many rows, so a viewer got their image or a 403. `get_media_file` now takes the presentation the media is being viewed in, and grants access if the file belongs to it and you can read it.

- **Undo losing a slide.** Undoing a delete brought the slide back under the row id autosave had already deleted on the server, so the next save quietly wrote nothing and the slide was gone on reload. The row id is now cleared, so it saves as a new row.