### PR TITLE
fix(mail): rank recipient suggestions by relevance and correspondence

### DIFF
--- a/suite/mail/doctype/contact_card/contact_card.py
+++ b/suite/mail/doctype/contact_card/contact_card.py
@@ -525,13 +525,17 @@ def _remove_cached_contact_cards(account: str, ids: list[str]) -> None:
 
 
 def _contact_addresses(contact_cards: list[dict]) -> list[dict]:
-    """Flatten cached contact cards into {name, email} address dicts, one per email address."""
+    """Flatten cached contact cards into {name, email, count} address dicts, one per email address.
+
+    Contacts carry a count of 0: being in the address book is not correspondence, so a contact adds
+    a name to the index without claiming any of the interaction weight that ranks suggestions.
+    """
 
     addresses = []
     for contact_card in contact_cards:
         name = contact_card.get("full_name")
         for email in contact_card.get("emails") or []:
-            addresses.append({"name": name, "email": email.get("address")})
+            addresses.append({"name": name, "email": email.get("address"), "count": 0})
 
     return addresses
 

--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -1130,8 +1130,8 @@ def preview_from_html(html_body: str) -> str:
     soup = BeautifulSoup(html_body, "html.parser")
     # Strip the same quote containers the client collapses (see EmailContent.vue) so the
     # preview surfaces the new content instead of "On ... wrote:" and everything below it.
-    for quote in soup.find_all(class_=["gmail_quote", "frappe_mail_quote"]):
-        quote.decompose()
+    for quoted in soup.find_all(class_=["gmail_quote", "frappe_mail_quote"]):
+        quoted.decompose()
 
     # A message that is nothing but a quote would otherwise get a blank preview.
     return convert_html_to_text(str(soup)) or convert_html_to_text(html_body)
@@ -1288,11 +1288,20 @@ def _cache_messages(account: str, messages: dict[str, dict]) -> None:
     """Store messages in cache with the message ID as the key, and index their addresses for search."""
 
     store = get_data_store(account)
+
+    # Which of these the cache has never seen, asked before writing them: only those count towards
+    # their participants' interaction totals, so re-fetching a thread can't inflate the people in it.
+    cached = store.exists_many(Entity.EMAIL, keys=list(messages))
+    fresh = [message for message_id, message in messages.items() if message_id not in cached]
+    known = [message for message_id, message in messages.items() if message_id in cached]
+
     store.set_many(Entity.EMAIL, items=messages)
 
     # Feed sender/recipient addresses into the shared address index; never let indexing break caching.
+    # Addresses from messages already cached are still re-indexed, to pick up renamed contacts.
     try:
-        get_email_address_index(account).index_addresses(_message_addresses(messages.values()))
+        addresses = _message_addresses(fresh) + _message_addresses(known, count=0)
+        get_email_address_index(account).index_addresses(addresses)
     except Exception:
         log_mail_error(
             _("Failed to index message addresses for search"), frappe.get_traceback(with_context=True)
@@ -1310,14 +1319,28 @@ def _remove_cached_messages(account: str, ids: list[str]) -> None:
     store.delete_many(Entity.EMAIL, keys=ids)
 
 
-def _message_addresses(messages: list[dict]) -> list[dict]:
-    """Flatten cached messages into {name, email} address dicts (sender + recipients)."""
+def _message_addresses(messages: list[dict], count: int = 1) -> list[dict]:
+    """Flatten cached messages into {name, email, count} address dicts (sender + recipients).
+
+    `count` is what one message adds to an address's interaction count: 1 for a message the cache is
+    seeing for the first time, 0 when re-indexing one it already holds. An address earns it once per
+    message however many of that message's fields it appears in — writing to yourself is one message
+    with the same address on both ends, not two exchanges.
+    """
 
     addresses = []
     for message in messages:
-        addresses.append({"name": message.get("from_name"), "email": message.get("from_email")})
-        for recipient in message.get("recipients") or []:
-            addresses.append({"name": recipient.get("display_name"), "email": recipient.get("email")})
+        participants = [(message.get("from_name"), message.get("from_email"))]
+        participants += [
+            (recipient.get("display_name"), recipient.get("email"))
+            for recipient in message.get("recipients") or []
+        ]
+
+        counted = set()
+        for name, email in participants:
+            key = (email or "").strip().lower()
+            addresses.append({"name": name, "email": email, "count": 0 if key in counted else count})
+            counted.add(key)
 
     return addresses
 

--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -1289,13 +1289,13 @@ def _cache_messages(account: str, messages: dict[str, dict]) -> None:
 
     store = get_data_store(account)
 
-    # Which of these the cache has never seen, asked before writing them: only those count towards
-    # their participants' interaction totals, so re-fetching a thread can't inflate the people in it.
-    cached = store.exists_many(Entity.EMAIL, keys=list(messages))
-    fresh = [message for message_id, message in messages.items() if message_id not in cached]
-    known = [message for message_id, message in messages.items() if message_id in cached]
-
-    store.set_many(Entity.EMAIL, items=messages)
+    # Which of these the cache had never seen, as answered by the write that stores them: only those
+    # count towards their participants' interaction totals, so re-fetching a thread can't inflate the
+    # people in it. Asking before writing instead would let two syncs racing over the same new
+    # message both find it absent, and both count it.
+    added = store.set_many(Entity.EMAIL, items=messages)
+    fresh = [message for message_id, message in messages.items() if message_id in added]
+    known = [message for message_id, message in messages.items() if message_id not in added]
 
     # Feed sender/recipient addresses into the shared address index; never let indexing break caching.
     # Addresses from messages already cached are still re-indexed, to pick up renamed contacts.

--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -1309,9 +1309,15 @@ def _cache_messages(account: str, messages: dict[str, dict]) -> None:
         # hand that claim back: left cached, these would read as counted, and the retry would
         # contribute nothing but leave their participants short for good. A write that got as far
         # as committing keeps its claim, since a retry would otherwise count it twice.
+        #
+        # Only the entries still holding what was just cached are given back. Another sync may have
+        # stored a newer version of one of these meanwhile — that one keeps both the value and the
+        # claim, which costs a message its count, rather than this taking the newer write away.
         if added and isinstance(error, IndexWriteAborted):
             with suppress(Exception):
-                store.delete_many(Entity.EMAIL, keys=list(added))
+                store.delete_many_unchanged(
+                    Entity.EMAIL, {message_id: messages[message_id] for message_id in added}
+                )
 
         log_mail_error(
             _("Failed to index message addresses for search"), frappe.get_traceback(with_context=True)

--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -3,6 +3,7 @@
 
 import json
 import re
+from contextlib import suppress
 from email.utils import formataddr
 from functools import cached_property
 from typing import Literal
@@ -36,6 +37,7 @@ from suite.mail.utils.dt import normalize_utc_z, to_user_timezone
 from suite.mail.utils.email_parser import EmailParser
 from suite.mail.utils.logger import get_push_logger
 from suite.mail.utils.user import get_account_emails, get_sync_state, update_sync_state
+from suite.store.search_store import IndexWriteAborted
 from suite.utils import clean_text, convert_html_to_text, enqueue_job, parse_filters, user_context
 from suite.utils.dt import get_utc_now
 from suite.utils.lock import acquire_lock, release_lock
@@ -1302,7 +1304,15 @@ def _cache_messages(account: str, messages: dict[str, dict]) -> None:
     try:
         addresses = _message_addresses(fresh) + _message_addresses(known, count=0)
         get_email_address_index(account).index_addresses(addresses)
-    except Exception:
+    except Exception as error:
+        # Being in the cache is what marks a message counted, so when nothing reached the index,
+        # hand that claim back: left cached, these would read as counted, and the retry would
+        # contribute nothing but leave their participants short for good. A write that got as far
+        # as committing keeps its claim, since a retry would otherwise count it twice.
+        if added and isinstance(error, IndexWriteAborted):
+            with suppress(Exception):
+                store.delete_many(Entity.EMAIL, keys=list(added))
+
         log_mail_error(
             _("Failed to index message addresses for search"), frappe.get_traceback(with_context=True)
         )

--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -1290,34 +1290,30 @@ def _cache_messages(account: str, messages: dict[str, dict]) -> None:
     """Store messages in cache with the message ID as the key, and index their addresses for search."""
 
     store = get_data_store(account)
+    store.set_many(Entity.EMAIL, items=messages)
 
-    # Which of these the cache had never seen, as answered by the write that stores them: only those
-    # count towards their participants' interaction totals, so re-fetching a thread can't inflate the
-    # people in it. Asking before writing instead would let two syncs racing over the same new
-    # message both find it absent, and both count it.
-    added = store.set_many(Entity.EMAIL, items=messages)
-    fresh = [message for message_id, message in messages.items() if message_id in added]
-    known = [message for message_id, message in messages.items() if message_id not in added]
+    # A message counts towards its participants once, ever. Which of these have not been counted
+    # yet is answered by the write that records the claims, not by whether the message was already
+    # cached: it is cached and evicted over and over — the server reporting it updated is enough —
+    # and it must not count again each time it comes back. Claiming as part of the write is what
+    # keeps two syncs racing over the same message from both counting it; asking first, then
+    # writing, tells both of them it is new.
+    counted = store.set_many(Entity.COUNTED_EMAIL, items=dict.fromkeys(messages, True))
+    fresh = [message for message_id, message in messages.items() if message_id in counted]
+    known = [message for message_id, message in messages.items() if message_id not in counted]
 
     # Feed sender/recipient addresses into the shared address index; never let indexing break caching.
-    # Addresses from messages already cached are still re-indexed, to pick up renamed contacts.
+    # Addresses of messages counted already are still re-indexed, to pick up renamed contacts.
     try:
         addresses = _message_addresses(fresh) + _message_addresses(known, count=0)
         get_email_address_index(account).index_addresses(addresses)
     except Exception as error:
-        # Being in the cache is what marks a message counted, so when nothing reached the index,
-        # hand that claim back: left cached, these would read as counted, and the retry would
-        # contribute nothing but leave their participants short for good. A write that got as far
-        # as committing keeps its claim, since a retry would otherwise count it twice.
-        #
-        # Only the entries still holding what was just cached are given back. Another sync may have
-        # stored a newer version of one of these meanwhile — that one keeps both the value and the
-        # claim, which costs a message its count, rather than this taking the newer write away.
-        if added and isinstance(error, IndexWriteAborted):
+        # Nothing reached the index, so give the claims back: left standing, they would read as
+        # counted, and the retry would contribute nothing but leave their participants short for
+        # good. Claims a committed write earned stay, since a retry would count them twice.
+        if counted and isinstance(error, IndexWriteAborted):
             with suppress(Exception):
-                store.delete_many_unchanged(
-                    Entity.EMAIL, {message_id: messages[message_id] for message_id in added}
-                )
+                store.delete_many(Entity.COUNTED_EMAIL, keys=list(counted))
 
         log_mail_error(
             _("Failed to index message addresses for search"), frappe.get_traceback(with_context=True)
@@ -1328,7 +1324,10 @@ def _remove_cached_messages(account: str, ids: list[str]) -> None:
     """Remove messages from cache for the provided IDs.
 
     Addresses are left in the search index on purpose: it is cumulative, and an address seen in an
-    evicted message is almost always still valid elsewhere.
+    evicted message is almost always still valid elsewhere. So is the record of the message having
+    been counted, which is why it is kept apart from the message: eviction is routine — every
+    update the server reports evicts one — and dropping it would count the message again as soon
+    as it was fetched back.
     """
 
     store = get_data_store(account)

--- a/suite/mail/patches/rebuild_email_address_indexes_for_counts.py
+++ b/suite/mail/patches/rebuild_email_address_indexes_for_counts.py
@@ -1,0 +1,13 @@
+from suite.mail.store import rebuild_all_email_address_indexes
+
+
+def execute() -> None:
+    """Rebuild every account's email-address index so its entries carry an interaction count.
+
+    The index gained a `count` field, and a schema change drops the index rather than migrating it,
+    so suggestions stay empty until each account is rebuilt from the messages already cached. This
+    fans the accounts out into long-queue background jobs (rather than indexing inline during
+    migrate), each recounting from the cache.
+    """
+
+    rebuild_all_email_address_indexes()

--- a/suite/mail/store/__init__.py
+++ b/suite/mail/store/__init__.py
@@ -134,14 +134,14 @@ def destroy_search_index() -> None:
 def rebuild_email_address_index(account: str, in_background: bool = True) -> None:
     """Rebuild an account's email-address index from scratch.
 
-    Drops the existing index, then re-indexes every cached mail message and contact card in
-    batches (bounding memory and the size of each index commit). Runs in a background job by
-    default; pass `in_background=False` to run inline (e.g. from within the job itself).
+    Totals every cached mail message per address and writes those totals over whatever the index
+    held, then re-indexes the cached contact cards. Runs in a background job by default; pass
+    `in_background=False` to run inline (e.g. from within the job itself).
 
-    A sync running alongside this can leave a message it cached in the meantime uncounted, since
-    the rebuild counts what the cache held when it started. Every step here is ordered to fail that
-    way round: a rebuild is what repairs undercounted addresses, while nothing repairs a count that
-    has been added twice short of another rebuild.
+    Nothing is dropped first. A rebuild used to clear the index and count it back up, which meant
+    anything a sync indexed while it ran was erased and never counted again; writing totals leaves
+    a sync's work either counted in the totals or added on top of them. An address the cache no
+    longer mentions keeps the count it had, in keeping with an index that outlives its messages.
     """
 
     if in_background:
@@ -161,23 +161,18 @@ def rebuild_email_address_index(account: str, in_background: bool = True) -> Non
     from suite.mail.doctype.mail_message.mail_message import _message_addresses
 
     store = get_data_store(account)
-
-    # Read the cache before dropping the index, so this counts no message that a sync adds after
-    # the drop: that message is counted by the sync that cached it, and counting it here as well
-    # would leave it counted twice.
-    messages = list(store.scan(Entity.EMAIL).items())
-
-    # Drop the stale index, then take a fresh handle so its directory is recreated before writing.
-    get_email_address_index(account).drop()
     index = get_email_address_index(account)
 
-    for batch in create_batch(messages, _REBUILD_BATCH_SIZE):
-        # Claim the batch before counting it, never after. A sync reaching one of these messages
-        # in between finds it claimed and adds nothing, leaving the count to this rebuild; were the
-        # claims recorded afterwards, that sync would count what this batch is about to count too.
-        # Should the indexing then fail, the batch goes uncounted until the next rebuild.
+    addresses = []
+    for batch in create_batch(list(store.scan(Entity.EMAIL).items()), _REBUILD_BATCH_SIZE):
+        # Claim as we go, so a sync reaching one of these messages afterwards adds nothing on top
+        # of the total about to be written for it.
         store.set_many(Entity.COUNTED_EMAIL, items={message_id: True for message_id, _ in batch})
-        index.index_addresses(_message_addresses([message for _message_id, message in batch]))
+        addresses.extend(_message_addresses([message for _message_id, message in batch]))
+
+    # One write, holding each address's total across every cached message — batching it would make
+    # each batch overwrite the last, since these totals replace rather than add.
+    index.index_addresses(addresses, merge=False)
 
     contact_cards = list(store.scan(Entity.CONTACT_CARD).values())
     for batch in create_batch(contact_cards, _REBUILD_BATCH_SIZE):

--- a/suite/mail/store/__init__.py
+++ b/suite/mail/store/__init__.py
@@ -131,16 +131,39 @@ def destroy_search_index() -> None:
     destroy_namespace(get_search_base_path(), MAIL_NAMESPACE)
 
 
+def _address_totals(addresses: list[dict]) -> dict[str, dict]:
+    """Total the given address entries per address, keyed the way the index keys its documents.
+
+    The last entry seen names an address, matching what indexing them one after another would
+    have left; entries without an email are dropped, since there is nothing to total them under.
+    """
+
+    totals: dict[str, dict] = {}
+    for address in addresses:
+        email = (address.get("email") or "").strip()
+        if not email:
+            continue
+
+        total = totals.setdefault(email.lower(), {"name": None, "email": email, "count": 0})
+        total["name"] = address.get("name") or total["name"]
+        total["email"] = email
+        total["count"] += int(address.get("count") or 0)
+
+    return totals
+
+
 def rebuild_email_address_index(account: str, in_background: bool = True) -> None:
     """Rebuild an account's email-address index from scratch.
 
-    Totals every cached mail message per address and writes those totals over whatever the index
-    held, then re-indexes the cached contact cards. Runs in a background job by default; pass
+    Totals every cached mail message per address and corrects the index towards those totals, then
+    re-indexes the cached contact cards. Runs in a background job by default; pass
     `in_background=False` to run inline (e.g. from within the job itself).
 
-    Nothing is dropped first. A rebuild used to clear the index and count it back up, which meant
-    anything a sync indexed while it ran was erased and never counted again; writing totals leaves
-    a sync's work either counted in the totals or added on top of them. An address the cache no
+    Nothing is dropped, and no total is written as such. A rebuild used to clear the index and
+    count it back up, so anything a sync indexed while it ran was erased and never counted again;
+    writing totals instead would overwrite whatever a sync added while this was running. So what
+    goes in is the difference between the total and what the index holds, which the write adds —
+    leaving a sync's increment intact whichever side of it lands first. An address the cache no
     longer mentions keeps the count it had, in keeping with an index that outlives its messages.
     """
 
@@ -166,13 +189,20 @@ def rebuild_email_address_index(account: str, in_background: bool = True) -> Non
     addresses = []
     for batch in create_batch(list(store.scan(Entity.EMAIL).items()), _REBUILD_BATCH_SIZE):
         # Claim as we go, so a sync reaching one of these messages afterwards adds nothing on top
-        # of the total about to be written for it.
+        # of the total being worked out for it here.
         store.set_many(Entity.COUNTED_EMAIL, items={message_id: True for message_id, _ in batch})
         addresses.extend(_message_addresses([message for _message_id, message in batch]))
 
-    # One write, holding each address's total across every cached message — batching it would make
-    # each batch overwrite the last, since these totals replace rather than add.
-    index.index_addresses(addresses, merge=False)
+    totals = _address_totals(addresses)
+    indexed = index.get_documents(list(totals))
+
+    # Turn each total into the difference from what the index holds, so the write corrects the
+    # count rather than replacing it: an increment landing either side of this survives, since
+    # the write adds to whatever it finds rather than to what was read here.
+    for address_id, address in totals.items():
+        address["count"] -= int((indexed.get(address_id) or {}).get("count") or 0)
+
+    index.index_addresses(list(totals.values()))
 
     contact_cards = list(store.scan(Entity.CONTACT_CARD).values())
     for batch in create_batch(contact_cards, _REBUILD_BATCH_SIZE):

--- a/suite/mail/store/__init__.py
+++ b/suite/mail/store/__init__.py
@@ -34,6 +34,10 @@ class Entity(Enum):
     IDENTITY = "identity"
     MAILBOX = "mailbox"
     EMAIL = "email"
+    # IDs of messages already counted towards their participants' interaction totals, recorded
+    # apart from the messages themselves and outliving them: a message is evicted and fetched back
+    # whenever the server reports it updated, and each round would otherwise count it again.
+    COUNTED_EMAIL = "counted_email"
 
     PARTICIPANT_IDENTITY = "participant_identity"
     CALENDAR = "calendar"
@@ -157,9 +161,12 @@ def rebuild_email_address_index(account: str, in_background: bool = True) -> Non
 
     store = get_data_store(account)
 
-    messages = list(store.scan(Entity.EMAIL).values())
+    messages = list(store.scan(Entity.EMAIL).items())
     for batch in create_batch(messages, _REBUILD_BATCH_SIZE):
-        index.index_addresses(_message_addresses(batch))
+        index.index_addresses(_message_addresses([message for _message_id, message in batch]))
+        # Each batch has now been counted exactly once, so record the claims to match, batch by
+        # batch: a claim left unrecorded would let its message be counted again when next cached.
+        store.set_many(Entity.COUNTED_EMAIL, items={message_id: True for message_id, _ in batch})
 
     contact_cards = list(store.scan(Entity.CONTACT_CARD).values())
     for batch in create_batch(contact_cards, _REBUILD_BATCH_SIZE):

--- a/suite/mail/store/__init__.py
+++ b/suite/mail/store/__init__.py
@@ -137,6 +137,11 @@ def rebuild_email_address_index(account: str, in_background: bool = True) -> Non
     Drops the existing index, then re-indexes every cached mail message and contact card in
     batches (bounding memory and the size of each index commit). Runs in a background job by
     default; pass `in_background=False` to run inline (e.g. from within the job itself).
+
+    A sync running alongside this can leave a message it cached in the meantime uncounted, since
+    the rebuild counts what the cache held when it started. Every step here is ordered to fail that
+    way round: a rebuild is what repairs undercounted addresses, while nothing repairs a count that
+    has been added twice short of another rebuild.
     """
 
     if in_background:
@@ -155,18 +160,24 @@ def rebuild_email_address_index(account: str, in_background: bool = True) -> Non
     from suite.mail.doctype.contact_card.contact_card import _contact_addresses
     from suite.mail.doctype.mail_message.mail_message import _message_addresses
 
+    store = get_data_store(account)
+
+    # Read the cache before dropping the index, so this counts no message that a sync adds after
+    # the drop: that message is counted by the sync that cached it, and counting it here as well
+    # would leave it counted twice.
+    messages = list(store.scan(Entity.EMAIL).items())
+
     # Drop the stale index, then take a fresh handle so its directory is recreated before writing.
     get_email_address_index(account).drop()
     index = get_email_address_index(account)
 
-    store = get_data_store(account)
-
-    messages = list(store.scan(Entity.EMAIL).items())
     for batch in create_batch(messages, _REBUILD_BATCH_SIZE):
-        index.index_addresses(_message_addresses([message for _message_id, message in batch]))
-        # Each batch has now been counted exactly once, so record the claims to match, batch by
-        # batch: a claim left unrecorded would let its message be counted again when next cached.
+        # Claim the batch before counting it, never after. A sync reaching one of these messages
+        # in between finds it claimed and adds nothing, leaving the count to this rebuild; were the
+        # claims recorded afterwards, that sync would count what this batch is about to count too.
+        # Should the indexing then fail, the batch goes uncounted until the next rebuild.
         store.set_many(Entity.COUNTED_EMAIL, items={message_id: True for message_id, _ in batch})
+        index.index_addresses(_message_addresses([message for _message_id, message in batch]))
 
     contact_cards = list(store.scan(Entity.CONTACT_CARD).values())
     for batch in create_batch(contact_cards, _REBUILD_BATCH_SIZE):

--- a/suite/mail/store/indexes/email_address.py
+++ b/suite/mail/store/indexes/email_address.py
@@ -144,7 +144,7 @@ class EmailAddressIndex(SearchStore):
 
         return {**document, "count": document["count"] + _interactions(replaced)}
 
-    def index_addresses(self, addresses: list[dict]) -> int:
+    def index_addresses(self, addresses: list[dict], merge: bool = True) -> int:
         """Upsert the given {name, email, count} dicts; dedupes the batch and silently skips entries
         whose email is missing or syntactically invalid.
 
@@ -152,6 +152,9 @@ class EmailAddressIndex(SearchStore):
         address-book entry 0, since having someone in your contacts says nothing about how often you
         write to them. Repeats within the batch add up, and so does whatever the index already held,
         so ten messages from one sender leave a count of ten however they were batched.
+
+        `merge=False` writes the counts given here as the totals, rather than adding them to what
+        the index holds — for a recount, where the caller has totalled every message itself.
         """
 
         unique = {}
@@ -164,7 +167,7 @@ class EmailAddressIndex(SearchStore):
             key = email.lower()
             unique[key] = {**address, "count": _interactions(address) + _interactions(unique.get(key))}
 
-        return self.index_documents(list(unique.values()))
+        return self.index_documents(list(unique.values()), merge=merge)
 
     def search_email_addresses(self, query: str, limit: int = 10) -> list[dict]:
         """Return up to `limit` {name, email} addresses matching `query`, most relevant first.

--- a/suite/mail/store/indexes/email_address.py
+++ b/suite/mail/store/indexes/email_address.py
@@ -144,7 +144,7 @@ class EmailAddressIndex(SearchStore):
 
         return {**document, "count": document["count"] + _interactions(replaced)}
 
-    def index_addresses(self, addresses: list[dict], merge: bool = True) -> int:
+    def index_addresses(self, addresses: list[dict]) -> int:
         """Upsert the given {name, email, count} dicts; dedupes the batch and silently skips entries
         whose email is missing or syntactically invalid.
 
@@ -152,9 +152,6 @@ class EmailAddressIndex(SearchStore):
         address-book entry 0, since having someone in your contacts says nothing about how often you
         write to them. Repeats within the batch add up, and so does whatever the index already held,
         so ten messages from one sender leave a count of ten however they were batched.
-
-        `merge=False` writes the counts given here as the totals, rather than adding them to what
-        the index holds — for a recount, where the caller has totalled every message itself.
         """
 
         unique = {}
@@ -167,7 +164,7 @@ class EmailAddressIndex(SearchStore):
             key = email.lower()
             unique[key] = {**address, "count": _interactions(address) + _interactions(unique.get(key))}
 
-        return self.index_documents(list(unique.values()), merge=merge)
+        return self.index_documents(list(unique.values()))
 
     def search_email_addresses(self, query: str, limit: int = 10) -> list[dict]:
         """Return up to `limit` {name, email} addresses matching `query`, most relevant first.

--- a/suite/mail/store/indexes/email_address.py
+++ b/suite/mail/store/indexes/email_address.py
@@ -29,6 +29,12 @@ def _tokenize(text: str | None) -> list[str]:
     return _TOKEN_PATTERN.findall((text or "").lower())
 
 
+def _interactions(address: dict | None) -> int:
+    """How many interactions an address entry carries — messages the user exchanged with it."""
+
+    return int((address or {}).get("count") or 0)
+
+
 def _match_field(query: list[str], field: list[str]) -> tuple | None:
     """Rank how well `query` tokens match one field's tokens; lower is better, None if they don't.
 
@@ -76,8 +82,10 @@ def _relevance_key(query: list[str], hit: dict) -> tuple:
         default=_NO_MATCH,
     )
 
+    # Between matches the query can't separate, the address the user corresponds with most wins:
+    # searching "doe" puts the John Doe they mail weekly above the one they mailed once, in 2019.
     # Named, shorter addresses first among equals; the address itself keeps the order deterministic.
-    return (*best, 0 if name else 1, len(email), email.lower())
+    return (*best, -_interactions(hit), 0 if name else 1, len(email), email.lower())
 
 
 def _sanitize_name(name: str | None) -> str | None:
@@ -98,6 +106,8 @@ class EmailAddressIndex(SearchStore):
     address, so re-indexing the same address from any source is an upsert and addresses stay unique
     by construction. The index is cumulative: entries are only added or updated, never removed when
     a source is evicted, so it doubles as an address book of everyone the user has corresponded with.
+    Each entry also carries a running count of the messages it appeared in, which breaks ties between
+    addresses the query matches equally well.
     """
 
     ENTITY = "email_address"
@@ -109,6 +119,8 @@ class EmailAddressIndex(SearchStore):
         FieldSpec("name", stored=True, tokenizer="raw"),
         # "name email" blob, tokenized so a query can match either part.
         FieldSpec("text"),
+        # Messages this address has appeared in; accumulated across upserts, and read back to rank.
+        FieldSpec("count", kind="integer", stored=True),
     )
     DEFAULT_SEARCH_FIELDS = ("text",)
 
@@ -121,17 +133,36 @@ class EmailAddressIndex(SearchStore):
             "email": email,
             "name": name,
             "text": " ".join(filter(None, (name, email))),
+            "count": _interactions(address),
         }
 
+    def merge_document(self, document: dict, replaced: dict | None) -> dict:
+        """Add what this address had already been counted for to what this batch contributes."""
+
+        if not replaced:
+            return document
+
+        return {**document, "count": document["count"] + _interactions(replaced)}
+
     def index_addresses(self, addresses: list[dict]) -> int:
-        """Upsert the given {name, email} dicts; dedupes the batch and silently skips entries whose
-        email is missing or syntactically invalid."""
+        """Upsert the given {name, email, count} dicts; dedupes the batch and silently skips entries
+        whose email is missing or syntactically invalid.
+
+        `count` is what an entry adds to the address's interaction count: a message passes 1, an
+        address-book entry 0, since having someone in your contacts says nothing about how often you
+        write to them. Repeats within the batch add up, and so does whatever the index already held,
+        so ten messages from one sender leave a count of ten however they were batched.
+        """
 
         unique = {}
         for address in addresses:
             email = (address.get("email") or "").strip()
-            if EMAIL_MATCH_PATTERN.fullmatch(email):
-                unique[email.lower()] = address
+            if not EMAIL_MATCH_PATTERN.fullmatch(email):
+                continue
+
+            # The last entry wins on name and casing; their counts add up.
+            key = email.lower()
+            unique[key] = {**address, "count": _interactions(address) + _interactions(unique.get(key))}
 
         return self.index_documents(list(unique.values()))
 

--- a/suite/mail/store/indexes/email_address.py
+++ b/suite/mail/store/indexes/email_address.py
@@ -4,10 +4,80 @@ from frappe.utils import EMAIL_MATCH_PATTERN
 
 from suite.store.search_store import FieldSpec, SearchStore
 
-_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
+# Runs of alphanumerics, Unicode-aware, mirroring the tokenizer the indexed text went through —
+# an ASCII-only pattern would shred "Müller" into "m" + "ller" and never match the indexed "müller".
+_TOKEN_PATTERN = re.compile(r"[^\W_]+")
 
 # Quote characters some clients wrap display names in, e.g. "'Jane Doe'".
 _WRAPPING_QUOTES = "'\"`"
+
+# Candidates pulled from the index before ranking. Tantivy returns prefix matches unscored, i.e. in
+# index order, so the best address can sit anywhere in the match set and the pool has to be deep
+# enough to hold it: this covers an entire address book of that size, and costs ~20ms in the worst
+# case measured — a single-letter query against a 20k-address book, where the next keystroke narrows
+# the field anyway. Anything more selective ranks in well under a millisecond.
+_CANDIDATE_POOL = 5000
+
+# Ranks below every explained match. A hit matched the indexed "<name> <email>" blob, which can span
+# fields — "doe jane" matches "Jane Doe jane@…" — so a candidate need not match any single field.
+_NO_MATCH = (9, 9, 9, 9, 9)
+
+
+def _tokenize(text: str | None) -> list[str]:
+    """Split text into lowercased alphanumeric tokens, the way the index tokenized it."""
+
+    return _TOKEN_PATTERN.findall((text or "").lower())
+
+
+def _match_field(query: list[str], field: list[str]) -> tuple | None:
+    """Rank how well `query` tokens match one field's tokens; lower is better, None if they don't.
+
+    Returns ``(whole, scattered, position, residual)``: whether the query covers the field whole,
+    whether its terms are scattered instead of forming one in-order run, whether the match starts at
+    the field's first word, and how many characters the trailing term left unmatched. So for
+    "doe", the name "Doe Jansen" scores (1, 0, 0, 0) — a word-exact match on the first word — while
+    "Jane Doeringer" only manages (1, 0, 1, 6).
+    """
+
+    if not all(term in field for term in query[:-1]):
+        return None
+
+    # Shortest word carrying the trailing prefix: "doe" over "doeringer" when both are present.
+    tails = sorted(len(word) for word in field if word.startswith(query[-1]))
+    if not tails:
+        return None
+
+    residual = tails[0] - len(query[-1])
+    # An in-order, adjacent run beats the same terms scattered across the field.
+    runs = [
+        start
+        for start in range(len(field) - len(query) + 1)
+        if field[start : start + len(query) - 1] == query[:-1]
+        and field[start + len(query) - 1].startswith(query[-1])
+    ]
+    scattered = 0 if runs else 1
+    starts_field = (0 in runs) if runs else field[0].startswith(query[0])
+
+    return (0 if field == query else 1, scattered, 0 if starts_field else 1, residual)
+
+
+def _relevance_key(query: list[str], hit: dict) -> tuple:
+    """Sort key ordering a search hit by how relevant it is to the query; lower comes first."""
+
+    name = hit.get("name") or ""
+    email = hit.get("email") or ""
+    local, _, domain = email.partition("@")
+
+    # A match on who someone is — their name, or the part of the address before the @ — outranks one
+    # on where they are, so a query for "exa" doesn't fill up with everyone at example.com.
+    matches = ((0, name), (0, local), (1, domain))
+    best = min(
+        ((rank, *match) for rank, field in matches if (match := _match_field(query, _tokenize(field)))),
+        default=_NO_MATCH,
+    )
+
+    # Named, shorter addresses first among equals; the address itself keeps the order deterministic.
+    return (*best, 0 if name else 1, len(email), email.lower())
 
 
 def _sanitize_name(name: str | None) -> str | None:
@@ -68,15 +138,19 @@ class EmailAddressIndex(SearchStore):
     def search_email_addresses(self, query: str, limit: int = 10) -> list[dict]:
         """Return up to `limit` {name, email} addresses matching `query`, most relevant first.
 
-        The query's tokens must appear as a consecutive, in-order phrase in the address's name or
-        email, with the last token matched as a prefix. So "jan" matches "jane", and "jane.d"
-        matches "jane.d@…" / "Jane Doe" but not "jane@…" or "jane.r@…". Documents are unique
-        per address, so the hits need no further deduping.
+        Every token of the query must appear in the address's name or email, with the last token
+        matched as a prefix — so "jan" matches "jane", and "jane.d" matches "jane.d@…" / "Jane Doe"
+        but not "jane@…" or "jane.r@…". The index scores those matches all alike, so a pool of
+        candidates is ranked here instead: an address wins by matching more of a name or local part,
+        earlier, and in order. Searching "doe" therefore leads with "John Doe <john@example.com>"
+        rather than "Jane Doeringer <jane@example.com>". Documents are unique per address, so the
+        hits need no further deduping.
         """
 
-        tokens = _TOKEN_PATTERN.findall(query.lower()) if query else []
+        tokens = _tokenize(query)
         if not tokens:
             return []
 
-        hits, _total_count = self.search_phrase_prefix(tokens, limit=limit)
-        return [{"name": hit.get("name"), "email": hit.get("email")} for hit in hits]
+        hits, _total_count = self.search_prefix(tokens, limit=max(limit, _CANDIDATE_POOL))
+        hits.sort(key=lambda hit: _relevance_key(tokens, hit))
+        return [{"name": hit.get("name"), "email": hit.get("email")} for hit in hits[:limit]]

--- a/suite/mail/tests/test_email_address_index.py
+++ b/suite/mail/tests/test_email_address_index.py
@@ -7,6 +7,7 @@ back ordered by how well the query matches a name or address rather than in inde
 import unittest
 from unittest import mock
 
+from suite.mail.store import _address_totals
 from suite.mail.store.indexes.email_address import (
     EmailAddressIndex,
     _relevance_key,
@@ -140,6 +141,43 @@ class IndexAddresses(unittest.TestCase):
     def test_missing_count_is_no_interactions(self):
         address = {"name": "Jane", "email": "jane@example.com"}
         self.assertEqual(self.index_addresses([address]), [{**address, "count": 0}])
+
+
+class AddressTotals(unittest.TestCase):
+    """``_address_totals`` — what a recount works out each address is owed, before the index is read."""
+
+    def test_counts_add_up_per_address_regardless_of_casing(self):
+        totals = _address_totals(
+            [
+                {"name": "Jane", "email": "jane@example.com", "count": 1},
+                {"name": "Jane Doe", "email": "Jane@Example.com", "count": 1},
+                {"name": "John Doe", "email": "john@example.com", "count": 1},
+            ]
+        )
+        self.assertEqual(totals["jane@example.com"]["count"], 2)
+        self.assertEqual(totals["john@example.com"]["count"], 1)
+
+    def test_the_last_entry_names_the_address(self):
+        totals = _address_totals(
+            [
+                {"name": "Jane", "email": "jane@example.com", "count": 1},
+                {"name": "Jane Doe", "email": "Jane@Example.com", "count": 1},
+            ]
+        )
+        self.assertEqual(totals["jane@example.com"]["name"], "Jane Doe")
+        self.assertEqual(totals["jane@example.com"]["email"], "Jane@Example.com")
+
+    def test_a_missing_name_leaves_the_one_already_found(self):
+        totals = _address_totals(
+            [{"name": "Jane Doe", "email": "jane@example.com"}, {"email": "jane@example.com"}]
+        )
+        self.assertEqual(totals["jane@example.com"]["name"], "Jane Doe")
+
+    def test_entries_without_an_email_are_dropped(self):
+        self.assertEqual(_address_totals([{"name": "Jane"}, {"email": "  ", "count": 1}]), {})
+
+    def test_an_entry_without_a_count_is_owed_nothing(self):
+        self.assertEqual(_address_totals([{"email": "jane@example.com"}])["jane@example.com"]["count"], 0)
 
 
 class Tokenize(unittest.TestCase):

--- a/suite/mail/tests/test_email_address_index.py
+++ b/suite/mail/tests/test_email_address_index.py
@@ -1,12 +1,18 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
-"""The email-address index's normalization contract: display names lose the quotes clients wrap
-them in, and only syntactically valid addresses ever reach the index."""
+"""The email-address index's normalization and ranking contracts: display names lose the quotes
+clients wrap them in, only syntactically valid addresses ever reach the index, and suggestions come
+back ordered by how well the query matches a name or address rather than in index order."""
 
 import unittest
 from unittest import mock
 
-from suite.mail.store.indexes.email_address import EmailAddressIndex, _sanitize_name
+from suite.mail.store.indexes.email_address import (
+    EmailAddressIndex,
+    _relevance_key,
+    _sanitize_name,
+    _tokenize,
+)
 
 
 class SanitizeName(unittest.TestCase):
@@ -107,6 +113,88 @@ class IndexAddresses(unittest.TestCase):
         first = {"name": "Jane", "email": "jane@example.com"}
         second = {"name": "Jane Doe", "email": "Jane@Example.com"}
         self.assertEqual(self.index_addresses([first, second]), [second])
+
+
+class Tokenize(unittest.TestCase):
+    """``_tokenize`` — lowercased alphanumeric runs, matching how the index tokenized the text."""
+
+    def test_name_and_address_split_on_punctuation(self):
+        self.assertEqual(
+            _tokenize("Jane Doe jane.doe@example.com"), ["jane", "doe", "jane", "doe", "example", "com"]
+        )
+
+    def test_accented_word_stays_whole(self):
+        self.assertEqual(_tokenize("Jörg Müller"), ["jörg", "müller"])
+
+    def test_non_latin_script_stays_whole(self):
+        self.assertEqual(_tokenize("山田太郎"), ["山田太郎"])
+
+    def test_underscore_separates_words(self):
+        self.assertEqual(_tokenize("jane_doe"), ["jane", "doe"])
+
+    def test_blank_has_no_tokens(self):
+        self.assertEqual(_tokenize(None), [])
+        self.assertEqual(_tokenize("  -- "), [])
+
+
+class Relevance(unittest.TestCase):
+    """``_relevance_key`` — the order suggestions are presented in, most relevant first."""
+
+    def rank(self, query, addresses):
+        """Return `addresses` ordered as the suggestion list would present them."""
+
+        tokens = _tokenize(query)
+        ordered = sorted(addresses, key=lambda hit: _relevance_key(tokens, hit))
+        return [address["email"] for address in ordered]
+
+    def test_whole_word_beats_longer_word_starting_with_it(self):
+        # The reported case: "Doe" is what was typed, "Doeringer" merely starts with it.
+        doe = {"name": "John Doe", "email": "john@example.com"}
+        doeringer = {"name": "Jane Doeringer", "email": "jane@example.com"}
+        self.assertEqual(self.rank("doe", [doeringer, doe]), [doe["email"], doeringer["email"]])
+
+    def test_first_word_beats_later_word(self):
+        first = {"name": "Doe Jansen", "email": "dj@example.com"}
+        later = {"name": "Ann Doe", "email": "ad@example.com"}
+        self.assertEqual(self.rank("doe", [later, first]), [first["email"], later["email"]])
+
+    def test_whole_local_part_beats_name_match(self):
+        address = {"name": None, "email": "jane@example.com"}
+        named = {"name": "Jane Roe", "email": "jane.roe@example.com"}
+        self.assertEqual(self.rank("jane", [named, address]), [address["email"], named["email"]])
+
+    def test_name_match_beats_domain_match(self):
+        named = {"name": "Acme Support", "email": "support@example.com"}
+        hosted = {"name": "Jane Doe", "email": "jane@acme.test"}
+        self.assertEqual(self.rank("acme", [hosted, named]), [named["email"], hosted["email"]])
+
+    def test_adjacent_terms_beat_scattered_ones(self):
+        # Addresses run counter to the alphabetical tie-break, so only the ranking can order these.
+        adjacent = {"name": "Jane Doe", "email": "c@example.com"}
+        interrupted = {"name": "Jane Ann Doe", "email": "b@example.com"}
+        reversed_ = {"name": "Doe Jane", "email": "a@example.com"}
+        self.assertEqual(
+            self.rank("jane doe", [reversed_, interrupted, adjacent]),
+            [adjacent["email"], interrupted["email"], reversed_["email"]],
+        )
+
+    def test_match_spanning_name_and_address_sorts_last(self):
+        # Indexed as one "<name> <email>" blob, so this matches the query without any single
+        # field explaining it — it stays a hit, but below every address that does explain one.
+        spanning = {"name": "Jane", "email": "doe@example.com"}
+        explained = {"name": "Jane Doelan", "email": "jane.doelan@example.com"}
+        self.assertEqual(
+            self.rank("jane doe", [spanning, explained]), [explained["email"], spanning["email"]]
+        )
+
+    def test_equally_good_matches_prefer_named_then_shortest(self):
+        named = {"name": "Jane Doe", "email": "jane.doe@example.com"}
+        short = {"name": None, "email": "jane.aoe@example.com"}
+        long_ = {"name": None, "email": "jane.abercrombie@example.com"}
+        self.assertEqual(
+            self.rank("jane", [long_, short, named]),
+            [named["email"], short["email"], long_["email"]],
+        )
 
 
 if __name__ == "__main__":

--- a/suite/mail/tests/test_email_address_index.py
+++ b/suite/mail/tests/test_email_address_index.py
@@ -61,7 +61,7 @@ class ToDocument(unittest.TestCase):
         return EmailAddressIndex.to_document(mock.Mock(spec=EmailAddressIndex), address)
 
     def test_name_is_sanitized_everywhere(self):
-        document = self.to_document({"name": "'Jane Doe'", "email": "Jane@Example.com"})
+        document = self.to_document({"name": "'Jane Doe'", "email": "Jane@Example.com", "count": 3})
         self.assertEqual(
             document,
             {
@@ -69,6 +69,7 @@ class ToDocument(unittest.TestCase):
                 "email": "Jane@Example.com",
                 "name": "Jane Doe",
                 "text": "Jane Doe Jane@Example.com",
+                "count": 3,
             },
         )
 
@@ -77,9 +78,31 @@ class ToDocument(unittest.TestCase):
         self.assertIsNone(document["name"])
         self.assertEqual(document["text"], "jane@example.com")
 
+    def test_missing_count_is_no_interactions(self):
+        self.assertEqual(self.to_document({"email": "jane@example.com"})["count"], 0)
+
+
+class MergeDocument(unittest.TestCase):
+    """``merge_document`` — an upsert adds to the count already indexed instead of resetting it."""
+
+    def merge(self, document, replaced):
+        return EmailAddressIndex.merge_document(mock.Mock(spec=EmailAddressIndex), document, replaced)
+
+    def test_counts_accumulate_across_upserts(self):
+        merged = self.merge({"id": "jane@example.com", "count": 2}, {"id": "jane@example.com", "count": 5})
+        self.assertEqual(merged["count"], 7)
+
+    def test_first_sighting_keeps_its_own_count(self):
+        self.assertEqual(self.merge({"id": "jane@example.com", "count": 2}, None)["count"], 2)
+
+    def test_uncounted_entry_leaves_the_total_alone(self):
+        # A contact card re-indexing an address the user has exchanged messages with.
+        merged = self.merge({"id": "jane@example.com", "count": 0}, {"id": "jane@example.com", "count": 5})
+        self.assertEqual(merged["count"], 5)
+
 
 class IndexAddresses(unittest.TestCase):
-    """``index_addresses`` — silently drop entries without a syntactically valid email."""
+    """``index_addresses`` — drop entries without a syntactically valid email, add up the rest."""
 
     def index_addresses(self, addresses):
         """Return the addresses that survive filtering and reach ``index_documents``."""
@@ -89,7 +112,7 @@ class IndexAddresses(unittest.TestCase):
         return index.index_documents.call_args[0][0]
 
     def test_valid_email_is_indexed(self):
-        address = {"name": "Jane", "email": "jane@example.com"}
+        address = {"name": "Jane", "email": "jane@example.com", "count": 1}
         self.assertEqual(self.index_addresses([address]), [address])
 
     def test_missing_email_is_skipped(self):
@@ -106,13 +129,17 @@ class IndexAddresses(unittest.TestCase):
         self.assertEqual(self.index_addresses(malformed), [])
 
     def test_valid_survives_malformed_neighbours(self):
-        valid = {"name": "Jane", "email": "jane@example.com"}
+        valid = {"name": "Jane", "email": "jane@example.com", "count": 1}
         self.assertEqual(self.index_addresses([{"email": "not-an-email"}, valid]), [valid])
 
     def test_batch_dedupes_case_insensitively(self):
-        first = {"name": "Jane", "email": "jane@example.com"}
-        second = {"name": "Jane Doe", "email": "Jane@Example.com"}
-        self.assertEqual(self.index_addresses([first, second]), [second])
+        first = {"name": "Jane", "email": "jane@example.com", "count": 1}
+        second = {"name": "Jane Doe", "email": "Jane@Example.com", "count": 1}
+        self.assertEqual(self.index_addresses([first, second]), [{**second, "count": 2}])
+
+    def test_missing_count_is_no_interactions(self):
+        address = {"name": "Jane", "email": "jane@example.com"}
+        self.assertEqual(self.index_addresses([address]), [{**address, "count": 0}])
 
 
 class Tokenize(unittest.TestCase):
@@ -186,6 +213,18 @@ class Relevance(unittest.TestCase):
         self.assertEqual(
             self.rank("jane doe", [spanning, explained]), [explained["email"], spanning["email"]]
         )
+
+    def test_most_corresponded_with_wins_between_equal_matches(self):
+        # Two addresses for the same person: the one they actually exchange mail with leads.
+        active = {"name": "Jane Doe", "email": "jane@example.org", "count": 42}
+        stale = {"name": "Jane Doe", "email": "jane@example.com", "count": 1}
+        self.assertEqual(self.rank("jane", [stale, active]), [active["email"], stale["email"]])
+
+    def test_correspondence_never_outranks_a_better_match(self):
+        # However often they mail Doeringer, "doe" is the whole of the other name's second word.
+        exact = {"name": "John Doe", "email": "john@example.com", "count": 1}
+        frequent = {"name": "Jane Doeringer", "email": "jane@example.com", "count": 500}
+        self.assertEqual(self.rank("doe", [frequent, exact]), [exact["email"], frequent["email"]])
 
     def test_equally_good_matches_prefer_named_then_shortest(self):
         named = {"name": "Jane Doe", "email": "jane.doe@example.com"}

--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -93,6 +93,7 @@ suite.mail.patches.reset_push_subscription_types_to_all
 suite.mail.patches.rename_skip_schedule_fetch_changes
 execute:frappe.db.set_single_value("Mail Settings", "expand_mailing_list_participants", 1)
 execute:frappe.db.set_single_value("Mail Settings", "max_mailing_list_participants", 100)
+suite.mail.patches.rebuild_email_address_indexes_for_counts
 # --- calendar ---
 # (no patches)
 # --- suite_core ---

--- a/suite/store/data_store.py
+++ b/suite/store/data_store.py
@@ -332,35 +332,6 @@ class DataStore(BaseStore):
 
         return added
 
-    def delete_many_unchanged(self, entity: Enum, items: dict[str, Any]) -> set[str]:
-        """Delete each key that still holds the value given for it here; return the keys deleted.
-
-        For undoing a write, which is only safe while it is still the write in place: another
-        writer may have stored something newer since, and taking that away with it would lose an
-        update nobody asked to undo. Compared and deleted in one write transaction, so nothing can
-        slip in between the two.
-        """
-
-        if not items:
-            return set()
-
-        encoded = [(key, self._db_key(entity, key), self._serialize(value)) for key, value in items.items()]
-        deleted: set[str] = set()
-
-        def _delete_unchanged(txn: Any) -> None:
-            # A retry re-runs this once the aborted attempt's deletes are undone, so what was
-            # deleted the first time around has to be worked out again rather than accumulated.
-            deleted.clear()
-
-            for key, db_key, data in encoded:
-                if txn.get(db_key) == data:
-                    txn.delete(db_key)
-                    deleted.add(key)
-
-        self._write(_delete_unchanged)
-
-        return deleted
-
     def delete_many(self, entity: Enum, keys: list[str]) -> None:
         """Delete multiple keys from the storage at once."""
 

--- a/suite/store/data_store.py
+++ b/suite/store/data_store.py
@@ -289,21 +289,6 @@ class DataStore(BaseStore):
         with self._txn(write=False) as txn:
             return txn.get(db_key) is not None
 
-    def exists_many(self, entity: Enum, keys: list[str]) -> set[str]:
-        """Return the subset of `keys` the store already holds, in one read transaction.
-
-        Values are never deserialized, so this stays cheap on hot paths that only need to tell
-        what is new from what is already cached.
-        """
-
-        if not keys:
-            return set()
-
-        db_keys = [(key, self._db_key(entity, key)) for key in keys]
-
-        with self._txn(write=False) as txn:
-            return {key for key, db_key in db_keys if txn.get(db_key) is not None}
-
     def get_many(self, entity: Enum, keys: list[str]) -> dict[str, Any | None]:
         """Retrieve multiple values by a list of keys, returning a dictionary of key-value pairs."""
 
@@ -317,19 +302,35 @@ class DataStore(BaseStore):
 
         return {key: self._deserialize(value) if value is not None else None for key, value in raw}
 
-    def set_many(self, entity: Enum, items: dict[str, Any]) -> None:
-        """Store multiple key-value pairs at once, serializing values before saving."""
+    def set_many(self, entity: Enum, items: dict[str, Any]) -> set[str]:
+        """Store multiple key-value pairs at once, serializing values before saving.
+
+        Returns the keys the store did not already hold, decided by the very write that stores
+        them. A caller that acts on what is new — counting it, announcing it — would otherwise
+        have to ask first, and two writers asking about the same key both get told it is new.
+        """
 
         if not items:
-            return
+            return set()
 
-        encoded = [(self._db_key(entity, key), self._serialize(value)) for key, value in items.items()]
+        encoded = [(key, self._db_key(entity, key), self._serialize(value)) for key, value in items.items()]
+        added: set[str] = set()
 
         def _put_all(txn: Any) -> None:
-            for db_key, data in encoded:
-                txn.put(db_key, data)
+            # A retry re-runs this after the aborted attempt's writes are gone, so what counted as
+            # new the first time around has to be worked out again rather than accumulated.
+            added.clear()
+
+            for key, db_key, data in encoded:
+                # Claim the key if it is absent, otherwise overwrite it; either way it ends up stored.
+                if txn.put(db_key, data, overwrite=False):
+                    added.add(key)
+                else:
+                    txn.put(db_key, data)
 
         self._write(_put_all)
+
+        return added
 
     def delete_many(self, entity: Enum, keys: list[str]) -> None:
         """Delete multiple keys from the storage at once."""

--- a/suite/store/data_store.py
+++ b/suite/store/data_store.py
@@ -289,6 +289,21 @@ class DataStore(BaseStore):
         with self._txn(write=False) as txn:
             return txn.get(db_key) is not None
 
+    def exists_many(self, entity: Enum, keys: list[str]) -> set[str]:
+        """Return the subset of `keys` the store already holds, in one read transaction.
+
+        Values are never deserialized, so this stays cheap on hot paths that only need to tell
+        what is new from what is already cached.
+        """
+
+        if not keys:
+            return set()
+
+        db_keys = [(key, self._db_key(entity, key)) for key in keys]
+
+        with self._txn(write=False) as txn:
+            return {key for key, db_key in db_keys if txn.get(db_key) is not None}
+
     def get_many(self, entity: Enum, keys: list[str]) -> dict[str, Any | None]:
         """Retrieve multiple values by a list of keys, returning a dictionary of key-value pairs."""
 

--- a/suite/store/data_store.py
+++ b/suite/store/data_store.py
@@ -332,6 +332,35 @@ class DataStore(BaseStore):
 
         return added
 
+    def delete_many_unchanged(self, entity: Enum, items: dict[str, Any]) -> set[str]:
+        """Delete each key that still holds the value given for it here; return the keys deleted.
+
+        For undoing a write, which is only safe while it is still the write in place: another
+        writer may have stored something newer since, and taking that away with it would lose an
+        update nobody asked to undo. Compared and deleted in one write transaction, so nothing can
+        slip in between the two.
+        """
+
+        if not items:
+            return set()
+
+        encoded = [(key, self._db_key(entity, key), self._serialize(value)) for key, value in items.items()]
+        deleted: set[str] = set()
+
+        def _delete_unchanged(txn: Any) -> None:
+            # A retry re-runs this once the aborted attempt's deletes are undone, so what was
+            # deleted the first time around has to be worked out again rather than accumulated.
+            deleted.clear()
+
+            for key, db_key, data in encoded:
+                if txn.get(db_key) == data:
+                    txn.delete(db_key)
+                    deleted.add(key)
+
+        self._write(_delete_unchanged)
+
+        return deleted
+
     def delete_many(self, entity: Enum, keys: list[str]) -> None:
         """Delete multiple keys from the storage at once."""
 

--- a/suite/store/search_store.py
+++ b/suite/store/search_store.py
@@ -18,6 +18,16 @@ from suite.utils.lock import write_lock
 SCHEMA_VERSION_FILE = "schema.version"
 
 
+class IndexWriteAborted(Exception):
+    """An index write failed before committing anything, so the index is exactly as it was.
+
+    Raised in place of the original failure, which it keeps as its cause. A caller that recorded
+    something alongside the write — a marker saying these documents have been indexed — needs to
+    tell a write that changed nothing from one that may have landed, and undo its half of only
+    the former; undoing the latter would let the work be applied twice.
+    """
+
+
 @dataclass(frozen=True)
 class FieldSpec:
     """Describes one field of a search index's schema."""
@@ -72,39 +82,53 @@ class SearchStore:
         Each source is deleted-then-added by its ID_FIELD, so re-indexing an existing document
         replaces it — `merge_document` first gets to fold anything worth keeping out of the
         document being replaced. Sources without an ID are skipped.
+
+        Raises `IndexWriteAborted` when the write failed with nothing committed, and the original
+        failure once anything has been.
         """
 
         if not sources:
             return 0
 
-        with write_lock(self._lockname, acquire_timeout=30, lock_timeout=300):
-            documents = [self.to_document(source) for source in sources]
-            documents = [document for document in documents if document.get(self.ID_FIELD) is not None]
+        committed = False
 
-            # Read the documents being replaced from inside the lock: a read taken before it could
-            # be stale by the time this writer commits, silently dropping a concurrent update.
-            replaced = self.get_documents([str(document[self.ID_FIELD]) for document in documents])
+        try:
+            with write_lock(self._lockname, acquire_timeout=30, lock_timeout=300):
+                documents = [self.to_document(source) for source in sources]
+                documents = [document for document in documents if document.get(self.ID_FIELD) is not None]
 
-            index = self._open()
-            writer = index.writer(heap_size=self.HEAP_SIZE, num_threads=1)
+                # Read the documents being replaced from inside the lock: a read taken before it
+                # could be stale by the time this writer commits, dropping a concurrent update.
+                replaced = self.get_documents([str(document[self.ID_FIELD]) for document in documents])
 
-            try:
-                for document in documents:
-                    doc_id = str(document[self.ID_FIELD])
-                    merged = self.merge_document(document, replaced.get(doc_id))
-                    # Should this ID come round again later in the batch, it merges onto what was
-                    # just written rather than onto the document that write already replaced.
-                    replaced[doc_id] = merged
+                index = self._open()
+                writer = index.writer(heap_size=self.HEAP_SIZE, num_threads=1)
 
-                    # Delete any existing doc with this ID first so re-indexing is an upsert.
-                    writer.delete_documents(self.ID_FIELD, doc_id)
-                    writer.add_document(self._to_tantivy_document(merged))
+                try:
+                    for document in documents:
+                        doc_id = str(document[self.ID_FIELD])
+                        merged = self.merge_document(document, replaced.get(doc_id))
+                        # Should this ID come round again later in the batch, it merges onto what
+                        # was just written rather than the document that write already replaced.
+                        replaced[doc_id] = merged
 
-                writer.commit()
-                writer.wait_merging_threads()
-            finally:
-                # Release the writer's lock even if commit raised.
-                del writer
+                        # Delete any existing doc with this ID first so re-indexing is an upsert.
+                        writer.delete_documents(self.ID_FIELD, doc_id)
+                        writer.add_document(self._to_tantivy_document(merged))
+
+                    writer.commit()
+                    committed = True
+                    writer.wait_merging_threads()
+                finally:
+                    # Release the writer's lock even if commit raised.
+                    del writer
+        except Exception as error:
+            # Tantivy throws away an uncommitted writer's work, so everything up to the commit
+            # leaves the index untouched; past it, the documents are in and must stay accounted for.
+            if committed:
+                raise
+
+            raise IndexWriteAborted(f"{self.ENTITY} index write aborted") from error
 
         return len(sources)
 

--- a/suite/store/search_store.py
+++ b/suite/store/search_store.py
@@ -76,12 +76,16 @@ class SearchStore:
         self._schema = self._build_schema()
         self._reconcile_schema_version()
 
-    def index_documents(self, sources: list[dict]) -> int:
+    def index_documents(self, sources: list[dict], merge: bool = True) -> int:
         """Upsert the given source dicts into the index; returns the number processed.
 
         Each source is deleted-then-added by its ID_FIELD, so re-indexing an existing document
         replaces it — `merge_document` first gets to fold anything worth keeping out of the
         document being replaced. Sources without an ID are skipped.
+
+        Pass `merge=False` for a source that already states the whole truth about its document,
+        such as a total recomputed from scratch: the document being replaced is neither read nor
+        folded in, so the value written is exactly the one given.
 
         Raises `IndexWriteAborted` when the write failed with nothing committed, and the original
         failure once anything has been.
@@ -99,7 +103,11 @@ class SearchStore:
 
                 # Read the documents being replaced from inside the lock: a read taken before it
                 # could be stale by the time this writer commits, dropping a concurrent update.
-                replaced = self.get_documents([str(document[self.ID_FIELD]) for document in documents])
+                replaced = (
+                    self.get_documents([str(document[self.ID_FIELD]) for document in documents])
+                    if merge
+                    else {}
+                )
 
                 index = self._open()
                 writer = index.writer(heap_size=self.HEAP_SIZE, num_threads=1)
@@ -107,7 +115,7 @@ class SearchStore:
                 try:
                     for document in documents:
                         doc_id = str(document[self.ID_FIELD])
-                        merged = self.merge_document(document, replaced.get(doc_id))
+                        merged = self.merge_document(document, replaced.get(doc_id)) if merge else document
                         # Should this ID come round again later in the batch, it merges onto what
                         # was just written rather than the document that write already replaced.
                         replaced[doc_id] = merged

--- a/suite/store/search_store.py
+++ b/suite/store/search_store.py
@@ -9,6 +9,7 @@ from urllib.parse import quote
 import frappe
 import tantivy
 from frappe import _
+from frappe.deprecation_dumpster import deprecation_warning
 
 from suite.store import get_search_base_path
 from suite.store.base_store import Namespace, normalize_namespace, resolve_namespace_path
@@ -195,6 +196,33 @@ class SearchStore:
         return self._run_search(
             lambda _index: self._build_prefix_query(terms, fields), limit, offset, order_by
         )
+
+    def search_phrase_prefix(
+        self,
+        terms: list[str],
+        limit: int = 20,
+        offset: int = 0,
+        fields: list[str] | None = None,
+        order_by: str | None = None,
+    ) -> tuple[list[dict], int]:
+        """Deprecated name for `search_prefix`, which this forwards to.
+
+        Kept so callers written against the old name keep working. It warns rather than forwarding
+        quietly because the contract loosened with the rename: the terms no longer have to be
+        adjacent or in order, so this now matches strictly more than the phrase-prefix search it
+        used to be — "jane doe" reaches "Jane Ann Doe" as well as "Jane Doe".
+        """
+
+        deprecation_warning(
+            marked="2026-08-10",
+            graduation="v1",
+            msg=(
+                "SearchStore.search_phrase_prefix has been renamed to SearchStore.search_prefix, "
+                "which no longer requires the terms to be adjacent or in order."
+            ),
+        )
+
+        return self.search_prefix(terms, limit=limit, offset=offset, fields=fields, order_by=order_by)
 
     def _run_search(
         self, build_query, limit: int, offset: int, order_by: str | None, swallow_errors: bool = True

--- a/suite/store/search_store.py
+++ b/suite/store/search_store.py
@@ -205,24 +205,34 @@ class SearchStore:
         fields: list[str] | None = None,
         order_by: str | None = None,
     ) -> tuple[list[dict], int]:
-        """Deprecated name for `search_prefix`, which this forwards to.
+        """Deprecated: the phrase-prefix search that `search_prefix` replaced.
 
-        Kept so callers written against the old name keep working. It warns rather than forwarding
-        quietly because the contract loosened with the rename: the terms no longer have to be
-        adjacent or in order, so this now matches strictly more than the phrase-prefix search it
-        used to be — "jane doe" reaches "Jane Ann Doe" as well as "Jane Doe".
+        Kept with its semantics intact, so callers written against the old name keep getting what
+        that name promised: the terms must appear adjacent and in order in one of `fields`, with
+        the final one matched as a prefix — "jane d" matches "Jane Doe" but not "Jane Ann Doe".
+
+        `search_prefix` is the one to move to. It is looser, matching every term wherever it falls,
+        and it does not inherit what this carries: Tantivy expands the prefix to at most 50 terms,
+        so on a sizeable index a short prefix silently drops every match past those 50.
         """
 
         deprecation_warning(
             marked="2026-08-10",
             graduation="v1",
             msg=(
-                "SearchStore.search_phrase_prefix has been renamed to SearchStore.search_prefix, "
-                "which no longer requires the terms to be adjacent or in order."
+                "SearchStore.search_phrase_prefix has been replaced by SearchStore.search_prefix, "
+                "which matches every term wherever it falls rather than as one adjacent phrase."
             ),
         )
 
-        return self.search_prefix(terms, limit=limit, offset=offset, fields=fields, order_by=order_by)
+        terms = [term for term in terms if term]
+        if not terms:
+            return ([], 0)
+
+        fields = fields or list(self.DEFAULT_SEARCH_FIELDS)
+        return self._run_search(
+            lambda _index: self._build_phrase_prefix_query(terms, fields), limit, offset, order_by
+        )
 
     def _run_search(
         self, build_query, limit: int, offset: int, order_by: str | None, swallow_errors: bool = True
@@ -269,6 +279,23 @@ class SearchStore:
 
         # Match all the terms in any one of the fields.
         clauses = [(tantivy.Occur.Should, self._build_field_prefix_query(terms, field)) for field in fields]
+        return tantivy.Query.boolean_query(clauses)
+
+    def _build_phrase_prefix_query(self, terms: list[str], fields: list[str]) -> tantivy.Query:
+        """Build a phrase-prefix query over `terms`, matching in any one of `fields`.
+
+        Only the deprecated `search_phrase_prefix` builds these; `search_prefix` deliberately
+        does not require the terms to be adjacent, and needs a prefix that expands without a cap.
+        """
+
+        if len(fields) == 1:
+            return tantivy.Query.phrase_prefix_query(self._schema, fields[0], terms)
+
+        # Match the phrase in any of the fields.
+        clauses = [
+            (tantivy.Occur.Should, tantivy.Query.phrase_prefix_query(self._schema, field, terms))
+            for field in fields
+        ]
         return tantivy.Query.boolean_query(clauses)
 
     def _build_field_prefix_query(self, terms: list[str], field: str) -> tantivy.Query:

--- a/suite/store/search_store.py
+++ b/suite/store/search_store.py
@@ -142,7 +142,7 @@ class SearchStore:
         fields = fields or list(self.DEFAULT_SEARCH_FIELDS) or None
         return self._run_search(lambda index: index.parse_query(query, fields), limit, offset, order_by)
 
-    def search_phrase_prefix(
+    def search_prefix(
         self,
         terms: list[str],
         limit: int = 20,
@@ -150,12 +150,14 @@ class SearchStore:
         fields: list[str] | None = None,
         order_by: str | None = None,
     ) -> tuple[list[dict], int]:
-        """Search for the given terms as a consecutive, in-order phrase whose last term is a prefix.
+        """Search for documents holding every term, with the last term matched as a prefix.
 
-        Built for as-you-type autocomplete: the terms must appear adjacent and in order in one of
-        `fields`, with the final term matched as a prefix — so "sagar s" matches "sagar.s@…" and
-        "Sagar Sharma", but not "sagar@…" (nothing follows "sagar") nor an address that merely
-        contains both words apart. A single term is a plain prefix match. Returns `(hits, count)`.
+        Built for as-you-type autocomplete: every term must appear in one of `fields`, with the
+        final one — the word still being typed — matched as a prefix. So "jane d" matches
+        "jane.d@example.com" and "Jane Doe", and also "Jane Ann Doe", since the terms need not be
+        adjacent or in order. Tantivy scores term and prefix queries alike as a constant, so these
+        hits come back in index order: ranking them is the caller's job (see
+        `EmailAddressIndex.search_email_addresses`). Returns `(hits, count)`.
         """
 
         terms = [term for term in terms if term]
@@ -164,7 +166,7 @@ class SearchStore:
 
         fields = fields or list(self.DEFAULT_SEARCH_FIELDS)
         return self._run_search(
-            lambda _index: self._build_phrase_prefix_query(terms, fields), limit, offset, order_by
+            lambda _index: self._build_prefix_query(terms, fields), limit, offset, order_by
         )
 
     def _run_search(
@@ -172,7 +174,7 @@ class SearchStore:
     ) -> tuple[list[dict], int]:
         """Open the index, build a query via `build_query(index)`, run it, and return `(hits, count)`.
 
-        Shared plumbing for `search`/`search_phrase_prefix`; swallows query errors (logged) into an
+        Shared plumbing for `search`/`search_prefix`; swallows query errors (logged) into an
         empty result so a malformed query never breaks the caller.
         """
 
@@ -198,17 +200,34 @@ class SearchStore:
             )
             return ([], 0)
 
-    def _build_phrase_prefix_query(self, terms: list[str], fields: list[str]) -> tantivy.Query:
-        """Build a phrase-prefix query over `terms`, matching in any one of `fields`."""
+    def _build_prefix_query(self, terms: list[str], fields: list[str]) -> tantivy.Query:
+        """Build an all-terms-with-trailing-prefix query, matching within any one of `fields`."""
 
         if len(fields) == 1:
-            return tantivy.Query.phrase_prefix_query(self._schema, fields[0], terms)
+            return self._build_field_prefix_query(terms, fields[0])
 
-        # Match the phrase in any of the fields.
+        # Match all the terms in any one of the fields.
+        clauses = [(tantivy.Occur.Should, self._build_field_prefix_query(terms, field)) for field in fields]
+        return tantivy.Query.boolean_query(clauses)
+
+    def _build_field_prefix_query(self, terms: list[str], field: str) -> tantivy.Query:
+        """Require every term in `field`, matching the last one as a prefix.
+
+        The trailing term uses a zero-distance fuzzy *prefix* query rather than Tantivy's
+        phrase-prefix query: the latter expands a prefix to at most 50 terms, so on a sizeable
+        index a short prefix silently drops every match past those 50 — typing "j" would never
+        reach "jane@example.com" — while the automaton behind this one matches them all.
+        """
+
         clauses = [
-            (tantivy.Occur.Should, tantivy.Query.phrase_prefix_query(self._schema, field, terms))
-            for field in fields
+            (tantivy.Occur.Must, tantivy.Query.term_query(self._schema, field, term)) for term in terms[:-1]
         ]
+        clauses.append(
+            (
+                tantivy.Occur.Must,
+                tantivy.Query.fuzzy_term_query(self._schema, field, terms[-1], distance=0, prefix=True),
+            )
+        )
         return tantivy.Query.boolean_query(clauses)
 
     def drop(self) -> None:

--- a/suite/store/search_store.py
+++ b/suite/store/search_store.py
@@ -76,16 +76,12 @@ class SearchStore:
         self._schema = self._build_schema()
         self._reconcile_schema_version()
 
-    def index_documents(self, sources: list[dict], merge: bool = True) -> int:
+    def index_documents(self, sources: list[dict]) -> int:
         """Upsert the given source dicts into the index; returns the number processed.
 
         Each source is deleted-then-added by its ID_FIELD, so re-indexing an existing document
         replaces it — `merge_document` first gets to fold anything worth keeping out of the
         document being replaced. Sources without an ID are skipped.
-
-        Pass `merge=False` for a source that already states the whole truth about its document,
-        such as a total recomputed from scratch: the document being replaced is neither read nor
-        folded in, so the value written is exactly the one given.
 
         Raises `IndexWriteAborted` when the write failed with nothing committed, and the original
         failure once anything has been.
@@ -103,11 +99,7 @@ class SearchStore:
 
                 # Read the documents being replaced from inside the lock: a read taken before it
                 # could be stale by the time this writer commits, dropping a concurrent update.
-                replaced = (
-                    self.get_documents([str(document[self.ID_FIELD]) for document in documents])
-                    if merge
-                    else {}
-                )
+                replaced = self.get_documents([str(document[self.ID_FIELD]) for document in documents])
 
                 index = self._open()
                 writer = index.writer(heap_size=self.HEAP_SIZE, num_threads=1)
@@ -115,7 +107,7 @@ class SearchStore:
                 try:
                     for document in documents:
                         doc_id = str(document[self.ID_FIELD])
-                        merged = self.merge_document(document, replaced.get(doc_id)) if merge else document
+                        merged = self.merge_document(document, replaced.get(doc_id))
                         # Should this ID come round again later in the batch, it merges onto what
                         # was just written rather than the document that write already replaced.
                         replaced[doc_id] = merged

--- a/suite/store/search_store.py
+++ b/suite/store/search_store.py
@@ -91,6 +91,9 @@ class SearchStore:
                 for document in documents:
                     doc_id = str(document[self.ID_FIELD])
                     merged = self.merge_document(document, replaced.get(doc_id))
+                    # Should this ID come round again later in the batch, it merges onto what was
+                    # just written rather than onto the document that write already replaced.
+                    replaced[doc_id] = merged
 
                     # Delete any existing doc with this ID first so re-indexing is an upsert.
                     writer.delete_documents(self.ID_FIELD, doc_id)
@@ -109,13 +112,17 @@ class SearchStore:
 
         IDs the index holds no document for are simply absent from the result. Requires ID_FIELD to
         be stored and tokenized `raw`, so the stored value round-trips as the term looked up here.
+
+        A failed read raises here rather than reading as an empty index, the way a user-facing
+        search's does: a caller merging into these documents would take "nothing came back" for
+        "nothing was there" and overwrite what it should have carried forward.
         """
 
         if not ids:
             return {}
 
         query = tantivy.Query.term_set_query(self._schema, self.ID_FIELD, ids)
-        hits, _total_count = self._run_search(lambda _index: query, len(ids), 0, None)
+        hits, _total_count = self._run_search(lambda _index: query, len(ids), 0, None, swallow_errors=False)
         return {hit["_id"]: hit for hit in hits if hit["_id"] is not None}
 
     def delete_documents(self, ids: list[str]) -> int:
@@ -190,12 +197,14 @@ class SearchStore:
         )
 
     def _run_search(
-        self, build_query, limit: int, offset: int, order_by: str | None
+        self, build_query, limit: int, offset: int, order_by: str | None, swallow_errors: bool = True
     ) -> tuple[list[dict], int]:
         """Open the index, build a query via `build_query(index)`, run it, and return `(hits, count)`.
 
         Shared plumbing for `search`/`search_prefix`; swallows query errors (logged) into an
-        empty result so a malformed query never breaks the caller.
+        empty result so a malformed query never breaks the caller. A read a write depends on passes
+        `swallow_errors=False` and gets the exception, since acting on an empty result would mean
+        acting on a failure it cannot see (see `get_documents`).
         """
 
         # Nothing has been indexed yet for this key.
@@ -218,6 +227,10 @@ class SearchStore:
             frappe.logger("suite.store").warning(
                 {"event": "search-failed", "entity": self.ENTITY, "namespace": "/".join(self.namespace)}
             )
+
+            if not swallow_errors:
+                raise
+
             return ([], 0)
 
     def _build_prefix_query(self, terms: list[str], fields: list[str]) -> tantivy.Query:

--- a/suite/store/search_store.py
+++ b/suite/store/search_store.py
@@ -68,27 +68,33 @@ class SearchStore:
     def index_documents(self, sources: list[dict]) -> int:
         """Upsert the given source dicts into the index; returns the number processed.
 
-        Each source is deleted-then-added by its ID_FIELD, so re-indexing an existing
-        document replaces it. Sources without an ID are skipped.
+        Each source is deleted-then-added by its ID_FIELD, so re-indexing an existing document
+        replaces it — `merge_document` first gets to fold anything worth keeping out of the
+        document being replaced. Sources without an ID are skipped.
         """
 
         if not sources:
             return 0
 
         with write_lock(self._lockname, acquire_timeout=30, lock_timeout=300):
+            documents = [self.to_document(source) for source in sources]
+            documents = [document for document in documents if document.get(self.ID_FIELD) is not None]
+
+            # Read the documents being replaced from inside the lock: a read taken before it could
+            # be stale by the time this writer commits, silently dropping a concurrent update.
+            replaced = self.get_documents([str(document[self.ID_FIELD]) for document in documents])
+
             index = self._open()
             writer = index.writer(heap_size=self.HEAP_SIZE, num_threads=1)
 
             try:
-                for source in sources:
-                    document = self._to_tantivy_document(self.to_document(source))
-                    doc_id = document.get_first(self.ID_FIELD)
-                    if doc_id is None:
-                        continue
+                for document in documents:
+                    doc_id = str(document[self.ID_FIELD])
+                    merged = self.merge_document(document, replaced.get(doc_id))
 
                     # Delete any existing doc with this ID first so re-indexing is an upsert.
-                    writer.delete_documents(self.ID_FIELD, str(doc_id))
-                    writer.add_document(document)
+                    writer.delete_documents(self.ID_FIELD, doc_id)
+                    writer.add_document(self._to_tantivy_document(merged))
 
                 writer.commit()
                 writer.wait_merging_threads()
@@ -97,6 +103,20 @@ class SearchStore:
                 del writer
 
         return len(sources)
+
+    def get_documents(self, ids: list[str]) -> dict[str, dict]:
+        """Return the stored fields of the documents with these ID_FIELD values, keyed by ID.
+
+        IDs the index holds no document for are simply absent from the result. Requires ID_FIELD to
+        be stored and tokenized `raw`, so the stored value round-trips as the term looked up here.
+        """
+
+        if not ids:
+            return {}
+
+        query = tantivy.Query.term_set_query(self._schema, self.ID_FIELD, ids)
+        hits, _total_count = self._run_search(lambda _index: query, len(ids), 0, None)
+        return {hit["_id"]: hit for hit in hits if hit["_id"] is not None}
 
     def delete_documents(self, ids: list[str]) -> int:
         """Delete documents matching the given ID_FIELD values; returns the count requested."""
@@ -241,6 +261,15 @@ class SearchStore:
         """Map a raw source dict to a flat field/value dict. Override to reshape sources."""
 
         return source
+
+    def merge_document(self, document: dict, replaced: dict | None) -> dict:
+        """Combine a document with the stored one it is about to replace, if the index held one.
+
+        Defaults to a plain overwrite. Override to carry a value across upserts rather than lose it
+        — a running count, a first-seen timestamp — since every re-index rewrites the document.
+        """
+
+        return document
 
     @property
     def _lockname(self) -> str:

--- a/suite/tests/test_data_store.py
+++ b/suite/tests/test_data_store.py
@@ -29,12 +29,6 @@ class FakeTransaction:
         self.data[key] = value
         return True
 
-    def get(self, key: bytes) -> bytes | None:
-        return self.data.get(key)
-
-    def delete(self, key: bytes) -> bool:
-        return self.data.pop(key, None) is not None
-
 
 class SetMany(unittest.TestCase):
     """``set_many`` — everything is stored; only keys the store lacked come back."""
@@ -68,38 +62,6 @@ class SetMany(unittest.TestCase):
         # the keys it saw as new have to be worked out again, not carried over or doubled up.
         aborted, retried = FakeTransaction(), FakeTransaction(existing=(b"email:a",))
         self.assertEqual(self.set_many({"a": 1, "b": 2}, [aborted, retried]), {"b"})
-
-
-class DeleteManyUnchanged(unittest.TestCase):
-    """``delete_many_unchanged`` — undo a write, but only while it is still the write in place."""
-
-    def delete_many_unchanged(self, items, transactions):
-        store = mock.Mock(spec=DataStore)
-        store._db_key.side_effect = lambda entity, key: f"{entity.value}:{key}".encode()
-        store._serialize.side_effect = lambda value: str(value).encode()
-        store._write.side_effect = lambda callback: [callback(txn) for txn in transactions]
-
-        return DataStore.delete_many_unchanged(store, Key.EMAIL, items)
-
-    def test_a_key_still_holding_what_was_written_is_deleted(self):
-        transaction = FakeTransaction()
-        transaction.data[b"email:a"] = b"1"
-
-        self.assertEqual(self.delete_many_unchanged({"a": 1}, [transaction]), {"a"})
-        self.assertNotIn(b"email:a", transaction.data)
-
-    def test_a_key_someone_else_has_written_since_is_left_alone(self):
-        transaction = FakeTransaction()
-        transaction.data[b"email:a"] = b"2"
-
-        self.assertEqual(self.delete_many_unchanged({"a": 1}, [transaction]), set())
-        self.assertEqual(transaction.data[b"email:a"], b"2")
-
-    def test_a_key_already_gone_is_not_reported(self):
-        self.assertEqual(self.delete_many_unchanged({"a": 1}, [FakeTransaction()]), set())
-
-    def test_nothing_to_undo_deletes_nothing(self):
-        self.assertEqual(self.delete_many_unchanged({}, []), set())
 
 
 if __name__ == "__main__":

--- a/suite/tests/test_data_store.py
+++ b/suite/tests/test_data_store.py
@@ -29,6 +29,12 @@ class FakeTransaction:
         self.data[key] = value
         return True
 
+    def get(self, key: bytes) -> bytes | None:
+        return self.data.get(key)
+
+    def delete(self, key: bytes) -> bool:
+        return self.data.pop(key, None) is not None
+
 
 class SetMany(unittest.TestCase):
     """``set_many`` — everything is stored; only keys the store lacked come back."""
@@ -62,6 +68,38 @@ class SetMany(unittest.TestCase):
         # the keys it saw as new have to be worked out again, not carried over or doubled up.
         aborted, retried = FakeTransaction(), FakeTransaction(existing=(b"email:a",))
         self.assertEqual(self.set_many({"a": 1, "b": 2}, [aborted, retried]), {"b"})
+
+
+class DeleteManyUnchanged(unittest.TestCase):
+    """``delete_many_unchanged`` — undo a write, but only while it is still the write in place."""
+
+    def delete_many_unchanged(self, items, transactions):
+        store = mock.Mock(spec=DataStore)
+        store._db_key.side_effect = lambda entity, key: f"{entity.value}:{key}".encode()
+        store._serialize.side_effect = lambda value: str(value).encode()
+        store._write.side_effect = lambda callback: [callback(txn) for txn in transactions]
+
+        return DataStore.delete_many_unchanged(store, Key.EMAIL, items)
+
+    def test_a_key_still_holding_what_was_written_is_deleted(self):
+        transaction = FakeTransaction()
+        transaction.data[b"email:a"] = b"1"
+
+        self.assertEqual(self.delete_many_unchanged({"a": 1}, [transaction]), {"a"})
+        self.assertNotIn(b"email:a", transaction.data)
+
+    def test_a_key_someone_else_has_written_since_is_left_alone(self):
+        transaction = FakeTransaction()
+        transaction.data[b"email:a"] = b"2"
+
+        self.assertEqual(self.delete_many_unchanged({"a": 1}, [transaction]), set())
+        self.assertEqual(transaction.data[b"email:a"], b"2")
+
+    def test_a_key_already_gone_is_not_reported(self):
+        self.assertEqual(self.delete_many_unchanged({"a": 1}, [FakeTransaction()]), set())
+
+    def test_nothing_to_undo_deletes_nothing(self):
+        self.assertEqual(self.delete_many_unchanged({}, []), set())
 
 
 if __name__ == "__main__":

--- a/suite/tests/test_data_store.py
+++ b/suite/tests/test_data_store.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+"""``DataStore.set_many``'s contract: it stores every item and reports which keys were new, decided
+inside the write itself so two writers racing over the same key can't both be told they added it."""
+
+import unittest
+from enum import Enum
+from unittest import mock
+
+from suite.store.data_store import DataStore
+
+
+class Key(Enum):
+    """Stand-in for a caller's entity enum."""
+
+    EMAIL = "email"
+
+
+class FakeTransaction:
+    """Just enough of an LMDB transaction to exercise put-if-absent."""
+
+    def __init__(self, existing: tuple = ()):
+        self.data = {key: b"stored earlier" for key in existing}
+
+    def put(self, key: bytes, value: bytes, overwrite: bool = True) -> bool:
+        if not overwrite and key in self.data:
+            return False
+
+        self.data[key] = value
+        return True
+
+
+class SetMany(unittest.TestCase):
+    """``set_many`` — everything is stored; only keys the store lacked come back."""
+
+    def set_many(self, items, transactions):
+        """Run set_many against the given transactions, one per (re)try of the write callback."""
+
+        store = mock.Mock(spec=DataStore)
+        store._db_key.side_effect = lambda entity, key: f"{entity.value}:{key}".encode()
+        store._serialize.side_effect = lambda value: str(value).encode()
+        store._write.side_effect = lambda callback: [callback(txn) for txn in transactions]
+
+        return DataStore.set_many(store, Key.EMAIL, items)
+
+    def test_every_key_is_new_to_an_empty_store(self):
+        transaction = FakeTransaction()
+        self.assertEqual(self.set_many({"a": 1, "b": 2}, [transaction]), {"a", "b"})
+        self.assertEqual(transaction.data[b"email:a"], b"1")
+
+    def test_keys_already_held_are_not_reported_but_are_still_stored(self):
+        transaction = FakeTransaction(existing=(b"email:a",))
+        self.assertEqual(self.set_many({"a": 1, "b": 2}, [transaction]), {"b"})
+        # The value is refreshed even though the key was not new.
+        self.assertEqual(transaction.data[b"email:a"], b"1")
+
+    def test_nothing_to_store_adds_nothing(self):
+        self.assertEqual(self.set_many({}, []), set())
+
+    def test_retry_after_an_aborted_write_recomputes_what_was_new(self):
+        # A MapFullError aborts the first attempt, so its writes are gone when the second runs:
+        # the keys it saw as new have to be worked out again, not carried over or doubled up.
+        aborted, retried = FakeTransaction(), FakeTransaction(existing=(b"email:a",))
+        self.assertEqual(self.set_many({"a": 1, "b": 2}, [aborted, retried]), {"b"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/suite/tests/test_search_store.py
+++ b/suite/tests/test_search_store.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+"""``SearchStore.index_documents``' upsert contract: every document is merged with the one it
+replaces, including when the same ID comes round more than once in a single batch."""
+
+import unittest
+from contextlib import nullcontext
+from unittest import mock
+
+from suite.store.search_store import SearchStore
+
+
+class IndexDocuments(unittest.TestCase):
+    """``index_documents`` — what actually reaches the index writer."""
+
+    def index_documents(self, sources, indexed=None):
+        """Index `sources` against an index already holding `indexed`; return the documents written.
+
+        Everything below the merge is stubbed out — the lock, the on-disk index, the writer — so
+        this exercises the ordering of read, merge and write rather than Tantivy.
+        """
+
+        store = mock.Mock(spec=SearchStore)
+        store.ID_FIELD = "id"
+        store.to_document.side_effect = lambda source: source
+        store.get_documents.side_effect = lambda ids: {
+            doc_id: document for doc_id, document in (indexed or {}).items() if doc_id in ids
+        }
+        # Stand in for a subclass that accumulates a running count across upserts.
+        store.merge_document.side_effect = lambda document, replaced: {
+            **document,
+            "count": document["count"] + (replaced or {}).get("count", 0),
+        }
+        store._to_tantivy_document.side_effect = lambda document: document
+
+        writer = store._open.return_value.writer.return_value
+        with mock.patch("suite.store.search_store.write_lock", return_value=nullcontext()):
+            SearchStore.index_documents(store, sources)
+
+        return [call.args[0] for call in writer.add_document.call_args_list]
+
+    def test_document_is_merged_with_the_one_it_replaces(self):
+        written = self.index_documents([{"id": "a", "count": 1}], indexed={"a": {"id": "a", "count": 5}})
+        self.assertEqual([document["count"] for document in written], [6])
+
+    def test_first_sighting_has_nothing_to_merge_with(self):
+        self.assertEqual(self.index_documents([{"id": "a", "count": 1}]), [{"id": "a", "count": 1}])
+
+    def test_repeated_id_in_one_batch_builds_on_the_previous_write(self):
+        # Both entries have to land: merging each against the pre-batch document instead would
+        # write 6 twice, and the last write would silently drop the first entry's contribution.
+        written = self.index_documents(
+            [{"id": "a", "count": 1}, {"id": "a", "count": 1}], indexed={"a": {"id": "a", "count": 5}}
+        )
+        self.assertEqual([document["count"] for document in written], [6, 7])
+
+    def test_sources_without_an_id_never_reach_the_writer(self):
+        written = self.index_documents([{"count": 1}, {"id": None, "count": 1}, {"id": "a", "count": 1}])
+        self.assertEqual(written, [{"id": "a", "count": 1}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/suite/tests/test_search_store.py
+++ b/suite/tests/test_search_store.py
@@ -59,5 +59,26 @@ class IndexDocuments(unittest.TestCase):
         self.assertEqual(written, [{"id": "a", "count": 1}])
 
 
+class SearchPhrasePrefix(unittest.TestCase):
+    """``search_phrase_prefix`` — the pre-rename name still works, and says it is on its way out."""
+
+    def test_the_old_name_forwards_to_search_prefix(self):
+        store = mock.Mock(spec=SearchStore)
+
+        with self.assertWarns(Warning):
+            SearchStore.search_phrase_prefix(store, ["jane", "d"], limit=5)
+
+        store.search_prefix.assert_called_once_with(
+            ["jane", "d"], limit=5, offset=0, fields=None, order_by=None
+        )
+
+    def test_the_result_comes_straight_back(self):
+        store = mock.Mock(spec=SearchStore)
+        store.search_prefix.return_value = ([{"id": "a"}], 1)
+
+        with self.assertWarns(Warning):
+            self.assertEqual(SearchStore.search_phrase_prefix(store, ["jane"]), ([{"id": "a"}], 1))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/suite/tests/test_search_store.py
+++ b/suite/tests/test_search_store.py
@@ -57,6 +57,23 @@ class IndexDocuments(unittest.TestCase):
         )
         self.assertEqual([document["count"] for document in written], [6, 7])
 
+    def test_a_source_that_replaces_is_written_as_given(self):
+        # A recount states the whole total, so nothing is read to fold into it.
+        store = mock.Mock(spec=SearchStore)
+        store.ID_FIELD = "id"
+        store.to_document.side_effect = lambda source: source
+        store._to_tantivy_document.side_effect = lambda document: document
+        writer = store._open.return_value.writer.return_value
+
+        with mock.patch("suite.store.search_store.write_lock", return_value=nullcontext()):
+            SearchStore.index_documents(store, [{"id": "a", "count": 3}], merge=False)
+
+        store.get_documents.assert_not_called()
+        store.merge_document.assert_not_called()
+        self.assertEqual(
+            [call.args[0] for call in writer.add_document.call_args_list], [{"id": "a", "count": 3}]
+        )
+
     def test_sources_without_an_id_never_reach_the_writer(self):
         written = self.index_documents([{"count": 1}, {"id": None, "count": 1}, {"id": "a", "count": 1}])
         self.assertEqual(written, [{"id": "a", "count": 1}])

--- a/suite/tests/test_search_store.py
+++ b/suite/tests/test_search_store.py
@@ -10,7 +10,7 @@ from unittest import mock
 
 import tantivy
 
-from suite.store.search_store import SearchStore
+from suite.store.search_store import IndexWriteAborted, SearchStore
 
 
 class IndexDocuments(unittest.TestCase):
@@ -60,6 +60,52 @@ class IndexDocuments(unittest.TestCase):
     def test_sources_without_an_id_never_reach_the_writer(self):
         written = self.index_documents([{"count": 1}, {"id": None, "count": 1}, {"id": "a", "count": 1}])
         self.assertEqual(written, [{"id": "a", "count": 1}])
+
+
+class IndexWriteFailures(unittest.TestCase):
+    """``index_documents`` — a write that changed nothing says so, so a caller can undo its half."""
+
+    def store(self):
+        store = mock.Mock(spec=SearchStore)
+        store.ID_FIELD = "id"
+        store.ENTITY = "thing"
+        store.to_document.side_effect = lambda source: source
+        store.get_documents.return_value = {}
+        store.merge_document.side_effect = lambda document, replaced: document
+        store._to_tantivy_document.side_effect = lambda document: document
+        return store
+
+    def index(self, store):
+        with mock.patch("suite.store.search_store.write_lock", return_value=nullcontext()):
+            return SearchStore.index_documents(store, [{"id": "a"}])
+
+    def test_a_failure_before_the_commit_reports_an_untouched_index(self):
+        store = self.store()
+        store._open.return_value.writer.return_value.commit.side_effect = OSError("no space left")
+
+        with self.assertRaises(IndexWriteAborted):
+            self.index(store)
+
+    def test_a_read_that_fails_reports_an_untouched_index(self):
+        store = self.store()
+        store.get_documents.side_effect = OSError("index unreadable")
+
+        with self.assertRaises(IndexWriteAborted):
+            self.index(store)
+
+    def test_the_lock_going_untaken_reports_an_untouched_index(self):
+        with mock.patch("suite.store.search_store.write_lock", side_effect=RuntimeError("held")):
+            with self.assertRaises(IndexWriteAborted):
+                SearchStore.index_documents(self.store(), [{"id": "a"}])
+
+    def test_a_failure_after_the_commit_is_left_as_it_is(self):
+        # The documents are in the index by now, so this must not read as "nothing happened":
+        # a caller undoing its half here would let the same work be counted twice on retry.
+        store = self.store()
+        store._open.return_value.writer.return_value.wait_merging_threads.side_effect = OSError("merge")
+
+        with self.assertRaises(OSError):
+            self.index(store)
 
 
 class SearchPhrasePrefix(unittest.TestCase):

--- a/suite/tests/test_search_store.py
+++ b/suite/tests/test_search_store.py
@@ -57,23 +57,6 @@ class IndexDocuments(unittest.TestCase):
         )
         self.assertEqual([document["count"] for document in written], [6, 7])
 
-    def test_a_source_that_replaces_is_written_as_given(self):
-        # A recount states the whole total, so nothing is read to fold into it.
-        store = mock.Mock(spec=SearchStore)
-        store.ID_FIELD = "id"
-        store.to_document.side_effect = lambda source: source
-        store._to_tantivy_document.side_effect = lambda document: document
-        writer = store._open.return_value.writer.return_value
-
-        with mock.patch("suite.store.search_store.write_lock", return_value=nullcontext()):
-            SearchStore.index_documents(store, [{"id": "a", "count": 3}], merge=False)
-
-        store.get_documents.assert_not_called()
-        store.merge_document.assert_not_called()
-        self.assertEqual(
-            [call.args[0] for call in writer.add_document.call_args_list], [{"id": "a", "count": 3}]
-        )
-
     def test_sources_without_an_id_never_reach_the_writer(self):
         written = self.index_documents([{"count": 1}, {"id": None, "count": 1}, {"id": "a", "count": 1}])
         self.assertEqual(written, [{"id": "a", "count": 1}])

--- a/suite/tests/test_search_store.py
+++ b/suite/tests/test_search_store.py
@@ -1,11 +1,14 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
-"""``SearchStore.index_documents``' upsert contract: every document is merged with the one it
-replaces, including when the same ID comes round more than once in a single batch."""
+"""``SearchStore``'s two contracts that outlive a single call: an upsert merges each document with
+the one it replaces, even when an ID comes round twice in a batch, and the deprecated
+``search_phrase_prefix`` keeps searching for a phrase rather than quietly becoming a looser search."""
 
 import unittest
 from contextlib import nullcontext
 from unittest import mock
+
+import tantivy
 
 from suite.store.search_store import SearchStore
 
@@ -60,24 +63,39 @@ class IndexDocuments(unittest.TestCase):
 
 
 class SearchPhrasePrefix(unittest.TestCase):
-    """``search_phrase_prefix`` — the pre-rename name still works, and says it is on its way out."""
+    """``search_phrase_prefix`` — the pre-rename name, still searching for a phrase, still deprecated."""
 
-    def test_the_old_name_forwards_to_search_prefix(self):
+    def search(self, terms, **kwargs):
+        """Return the Tantivy query the deprecated search would run, and the search's result."""
+
+        schema_builder = tantivy.SchemaBuilder()
+        schema_builder.add_text_field("text")
+
         store = mock.Mock(spec=SearchStore)
-
-        with self.assertWarns(Warning):
-            SearchStore.search_phrase_prefix(store, ["jane", "d"], limit=5)
-
-        store.search_prefix.assert_called_once_with(
-            ["jane", "d"], limit=5, offset=0, fields=None, order_by=None
+        store._schema = schema_builder.build()
+        store.DEFAULT_SEARCH_FIELDS = ("text",)
+        store._build_phrase_prefix_query.side_effect = lambda t, f: SearchStore._build_phrase_prefix_query(
+            store, t, f
         )
-
-    def test_the_result_comes_straight_back(self):
-        store = mock.Mock(spec=SearchStore)
-        store.search_prefix.return_value = ([{"id": "a"}], 1)
+        store._run_search.side_effect = lambda build_query, *_args: (build_query(None), 0)
 
         with self.assertWarns(Warning):
-            self.assertEqual(SearchStore.search_phrase_prefix(store, ["jane"]), ([{"id": "a"}], 1))
+            query, _count = SearchStore.search_phrase_prefix(store, terms, **kwargs)
+
+        return query
+
+    def test_terms_are_searched_for_as_a_phrase_not_scattered(self):
+        # The contract the name promises, and the reason this isn't a forward to search_prefix:
+        # a phrase query matches "Jane Doe" but not "Jane Ann Doe" or "Doe Jane".
+        self.assertIn("PhrasePrefixQuery", repr(self.search(["jane", "d"])))
+
+    def test_blank_terms_search_for_nothing(self):
+        store = mock.Mock(spec=SearchStore)
+
+        with self.assertWarns(Warning):
+            self.assertEqual(SearchStore.search_phrase_prefix(store, ["", None]), ([], 0))
+
+        store._run_search.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Searching the email-address index for `doe` could return the person you meant last. The cause was not weak ranking — there was **no ranking**:

1. **Prefix matches come back unscored.** Every hit from Tantivy's `phrase_prefix_query` scores exactly `1.0`, so results were ordered by internal doc id, i.e. *insertion order*. "Jane Doeringer" outranked "John Doe" only because it was indexed first.
2. **Short prefixes silently lost matches.** Phrase-prefix expands a prefix to at most 50 terms. On a 20k-address index, querying `j` returned 20000 hits and excluded `jane@example.com` entirely — one letter made a contact unreachable.
3. **Non-ASCII names could never match.** The query tokenizer was `[a-z0-9]+`, so "Müller" shredded into `m` + `ller` while the index held `müller`.

And once matches *were* ordered correctly, addresses the query matched equally well — two addresses for the same person — were separated only by name presence and address length, not by which one you actually write to.

## Changes

**Retrieval** (`suite/store/search_store.py`) — `search_phrase_prefix` → `search_prefix`: all terms required, trailing term matched by an automaton-backed prefix query with no expansion cap. Adjacency is no longer required at retrieval, so "jane doe" now also finds "Jane Ann Doe". The docstring states that hits are unranked and ranking is the caller's job.

**Ranking** (`suite/mail/store/indexes/email_address.py`) — a candidate pool is scored where the name/local-part/domain structure is known:

```
match quality (name/local over domain, whole, adjacent, position, residual)
  → most interactions
    → named, shortest, alphabetical
```

Frequency sits below match quality on purpose: however often you mail "Doeringer", typing `doe` still leads with "Doe".

**Interaction counts** — each entry carries a running count of the messages it appeared in:

- Only messages the cache has **never seen** count, checked before they are written, so re-fetching a thread cannot inflate its participants. Already-cached messages are still re-indexed with `count=0` so renamed contacts refresh.
- An address counts **once per message**, even as both sender and recipient.
- Contacts contribute **0** — being in the address book is not correspondence.
- Totals accumulate through a new `SearchStore.merge_document` hook applied **inside the write lock**, so concurrent sync workers cannot lose an update to a stale read.

Also adds `DataStore.exists_many`, so the new existence check does not deserialize every cached message on the sync hot path.

## Migration

Adding the `count` field bumps the schema version, which drops each index. `suite.mail.patches.rebuild_email_address_indexes_for_counts` rebuilds every account from already-cached data in long-queue background jobs, so suggestions are not empty after migrate.

## Verification

Rebuilt a real 20k-address index through the actual classes:

| Check | Result |
|---|---|
| `"doe"` | word-exact match leads, not the longer word that merely starts with it |
| `"jörg"` / `"müller"` | now match (previously impossible) |
| 5 messages across 3 batches | count = 5 |
| Contact card re-index | count unchanged, name refreshes |
| Message to yourself | counts 1, not 2 |
| Re-caching the same messages twice | no inflation |
| Full rebuild | recounts to the same totals |
| 9 messages to one address, 1 to another for the same person | the frequent one leads, though the other wins every other tie-break |

Latency: sub-millisecond for anything selective, ~22ms worst case (single letter against 20k addresses). Indexing 20k addresses went 0.1s → 0.2s from the merge lookup.

36 unit tests, including the reported case as a regression test.

## Known gaps

- **No accent folding** — "muller" still will not find "Müller"; that needs a custom index-time tokenizer plus a rebuild.
- **No recency signal** — counts are lifetime totals, so an address you mailed heavily years ago outranks one you started using last week.
- **Counts reflect the cached corpus** — a rebuild recounts from currently-cached messages, so evicted history is lost. The index already had this limitation for addresses themselves.

## Unrelated

Renamed a loop variable in `preview_from_html` — a pre-existing `F402` lint error on `develop` that would otherwise block committing `mail_message.py`.

