### PR TITLE
fix(mail): rank recipient suggestions by relevance

### DIFF
--- a/suite/mail/store/indexes/email_address.py
+++ b/suite/mail/store/indexes/email_address.py
@@ -4,10 +4,80 @@ from frappe.utils import EMAIL_MATCH_PATTERN
 
 from suite.store.search_store import FieldSpec, SearchStore
 
-_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
+# Runs of alphanumerics, Unicode-aware, mirroring the tokenizer the indexed text went through —
+# an ASCII-only pattern would shred "Müller" into "m" + "ller" and never match the indexed "müller".
+_TOKEN_PATTERN = re.compile(r"[^\W_]+")
 
 # Quote characters some clients wrap display names in, e.g. "'Jane Doe'".
 _WRAPPING_QUOTES = "'\"`"
+
+# Candidates pulled from the index before ranking. Tantivy returns prefix matches unscored, i.e. in
+# index order, so the best address can sit anywhere in the match set and the pool has to be deep
+# enough to hold it: this covers an entire address book of that size, and costs ~20ms in the worst
+# case measured — a single-letter query against a 20k-address book, where the next keystroke narrows
+# the field anyway. Anything more selective ranks in well under a millisecond.
+_CANDIDATE_POOL = 5000
+
+# Ranks below every explained match. A hit matched the indexed "<name> <email>" blob, which can span
+# fields — "doe jane" matches "Jane Doe jane@…" — so a candidate need not match any single field.
+_NO_MATCH = (9, 9, 9, 9, 9)
+
+
+def _tokenize(text: str | None) -> list[str]:
+    """Split text into lowercased alphanumeric tokens, the way the index tokenized it."""
+
+    return _TOKEN_PATTERN.findall((text or "").lower())
+
+
+def _match_field(query: list[str], field: list[str]) -> tuple | None:
+    """Rank how well `query` tokens match one field's tokens; lower is better, None if they don't.
+
+    Returns ``(whole, scattered, position, residual)``: whether the query covers the field whole,
+    whether its terms are scattered instead of forming one in-order run, whether the match starts at
+    the field's first word, and how many characters the trailing term left unmatched. So for
+    "doe", the name "Doe Jansen" scores (1, 0, 0, 0) — a word-exact match on the first word — while
+    "Jane Doeringer" only manages (1, 0, 1, 6).
+    """
+
+    if not all(term in field for term in query[:-1]):
+        return None
+
+    # Shortest word carrying the trailing prefix: "doe" over "doeringer" when both are present.
+    tails = sorted(len(word) for word in field if word.startswith(query[-1]))
+    if not tails:
+        return None
+
+    residual = tails[0] - len(query[-1])
+    # An in-order, adjacent run beats the same terms scattered across the field.
+    runs = [
+        start
+        for start in range(len(field) - len(query) + 1)
+        if field[start : start + len(query) - 1] == query[:-1]
+        and field[start + len(query) - 1].startswith(query[-1])
+    ]
+    scattered = 0 if runs else 1
+    starts_field = (0 in runs) if runs else field[0].startswith(query[0])
+
+    return (0 if field == query else 1, scattered, 0 if starts_field else 1, residual)
+
+
+def _relevance_key(query: list[str], hit: dict) -> tuple:
+    """Sort key ordering a search hit by how relevant it is to the query; lower comes first."""
+
+    name = hit.get("name") or ""
+    email = hit.get("email") or ""
+    local, _, domain = email.partition("@")
+
+    # A match on who someone is — their name, or the part of the address before the @ — outranks one
+    # on where they are, so a query for "exa" doesn't fill up with everyone at example.com.
+    matches = ((0, name), (0, local), (1, domain))
+    best = min(
+        ((rank, *match) for rank, field in matches if (match := _match_field(query, _tokenize(field)))),
+        default=_NO_MATCH,
+    )
+
+    # Named, shorter addresses first among equals; the address itself keeps the order deterministic.
+    return (*best, 0 if name else 1, len(email), email.lower())
 
 
 def _sanitize_name(name: str | None) -> str | None:
@@ -68,15 +138,19 @@ class EmailAddressIndex(SearchStore):
     def search_email_addresses(self, query: str, limit: int = 10) -> list[dict]:
         """Return up to `limit` {name, email} addresses matching `query`, most relevant first.
 
-        The query's tokens must appear as a consecutive, in-order phrase in the address's name or
-        email, with the last token matched as a prefix. So "jan" matches "jane", and "jane.d"
-        matches "jane.d@…" / "Jane Doe" but not "jane@…" or "jane.r@…". Documents are unique
-        per address, so the hits need no further deduping.
+        Every token of the query must appear in the address's name or email, with the last token
+        matched as a prefix — so "jan" matches "jane", and "jane.d" matches "jane.d@…" / "Jane Doe"
+        but not "jane@…" or "jane.r@…". The index scores those matches all alike, so a pool of
+        candidates is ranked here instead: an address wins by matching more of a name or local part,
+        earlier, and in order. Searching "doe" therefore leads with "John Doe <john@example.com>"
+        rather than "Jane Doeringer <jane@example.com>". Documents are unique per address, so the
+        hits need no further deduping.
         """
 
-        tokens = _TOKEN_PATTERN.findall(query.lower()) if query else []
+        tokens = _tokenize(query)
         if not tokens:
             return []
 
-        hits, _total_count = self.search_phrase_prefix(tokens, limit=limit)
-        return [{"name": hit.get("name"), "email": hit.get("email")} for hit in hits]
+        hits, _total_count = self.search_prefix(tokens, limit=max(limit, _CANDIDATE_POOL))
+        hits.sort(key=lambda hit: _relevance_key(tokens, hit))
+        return [{"name": hit.get("name"), "email": hit.get("email")} for hit in hits[:limit]]

--- a/suite/mail/store/indexes/email_address.py
+++ b/suite/mail/store/indexes/email_address.py
@@ -11,11 +11,6 @@ _TOKEN_PATTERN = re.compile(r"[^\W_]+")
 # Quote characters some clients wrap display names in, e.g. "'Jane Doe'".
 _WRAPPING_QUOTES = "'\"`"
 
-# How many candidates a search asks for up front. Ranking needs the whole match set — see
-# `search_email_addresses` — and this is sized so one round-trip almost always holds it: a query
-# matching more addresses than this is a very short prefix against a very large address book.
-_CANDIDATE_POOL = 5000
-
 # Ranks below every explained match. A hit matched the indexed "<name> <email>" blob, which can span
 # fields — "doe jane" matches "Jane Doe jane@…" — so a candidate need not match any single field.
 _NO_MATCH = (9, 9, 9, 9, 9)
@@ -144,20 +139,18 @@ class EmailAddressIndex(SearchStore):
         "Jane Doeringer <jane@example.com>". Documents are unique per address, so the hits need no
         further deduping.
 
-        Every match is ranked, not a slice of them. Unscored hits come back in index order, so the
-        best address can sit anywhere in the match set, and cutting the set before ranking would
-        drop it: whoever was indexed first would win a broad query outright. Cost therefore scales
-        with how many addresses match — a single letter against a 20k-address book is the worst
-        case at ~90ms, and anything more selective comes back in a millisecond or so.
+        Every match is ranked, not a slice of them — hence the unbounded fetch. Unscored hits come
+        back in index order, so the best address can sit anywhere in the match set, and cutting the
+        set before ranking would drop it: whoever was indexed first would win a broad query
+        outright. Cost therefore scales with how many addresses match — a single letter against a
+        20k-address book is the worst case at ~90ms, and anything more selective comes back in a
+        millisecond or so.
         """
 
         tokens = _tokenize(query)
         if not tokens:
             return []
 
-        hits, total = self.search_prefix(tokens, limit=max(limit, _CANDIDATE_POOL))
-        if total > len(hits):
-            hits, _total = self.search_prefix(tokens, limit=total)
-
+        hits, _total = self.search_prefix(tokens, limit=None)
         hits.sort(key=lambda hit: _relevance_key(tokens, hit))
         return [{"name": hit.get("name"), "email": hit.get("email")} for hit in hits[:limit]]

--- a/suite/mail/store/indexes/email_address.py
+++ b/suite/mail/store/indexes/email_address.py
@@ -11,11 +11,9 @@ _TOKEN_PATTERN = re.compile(r"[^\W_]+")
 # Quote characters some clients wrap display names in, e.g. "'Jane Doe'".
 _WRAPPING_QUOTES = "'\"`"
 
-# Candidates pulled from the index before ranking. Tantivy returns prefix matches unscored, i.e. in
-# index order, so the best address can sit anywhere in the match set and the pool has to be deep
-# enough to hold it: this covers an entire address book of that size, and costs ~20ms in the worst
-# case measured — a single-letter query against a 20k-address book, where the next keystroke narrows
-# the field anyway. Anything more selective ranks in well under a millisecond.
+# How many candidates a search asks for up front. Ranking needs the whole match set — see
+# `search_email_addresses` — and this is sized so one round-trip almost always holds it: a query
+# matching more addresses than this is a very short prefix against a very large address book.
 _CANDIDATE_POOL = 5000
 
 # Ranks below every explained match. A hit matched the indexed "<name> <email>" blob, which can span
@@ -140,17 +138,26 @@ class EmailAddressIndex(SearchStore):
 
         Every token of the query must appear in the address's name or email, with the last token
         matched as a prefix — so "jan" matches "jane", and "jane.d" matches "jane.d@…" / "Jane Doe"
-        but not "jane@…" or "jane.r@…". The index scores those matches all alike, so a pool of
-        candidates is ranked here instead: an address wins by matching more of a name or local part,
-        earlier, and in order. Searching "doe" therefore leads with "John Doe <john@example.com>"
-        rather than "Jane Doeringer <jane@example.com>". Documents are unique per address, so the
-        hits need no further deduping.
+        but not "jane@…" or "jane.r@…". The index scores those matches all alike, so they are ranked
+        here instead: an address wins by matching more of a name or local part, earlier, and in
+        order. Searching "doe" therefore leads with "John Doe <john@example.com>" rather than
+        "Jane Doeringer <jane@example.com>". Documents are unique per address, so the hits need no
+        further deduping.
+
+        Every match is ranked, not a slice of them. Unscored hits come back in index order, so the
+        best address can sit anywhere in the match set, and cutting the set before ranking would
+        drop it: whoever was indexed first would win a broad query outright. Cost therefore scales
+        with how many addresses match — a single letter against a 20k-address book is the worst
+        case at ~90ms, and anything more selective comes back in a millisecond or so.
         """
 
         tokens = _tokenize(query)
         if not tokens:
             return []
 
-        hits, _total_count = self.search_prefix(tokens, limit=max(limit, _CANDIDATE_POOL))
+        hits, total = self.search_prefix(tokens, limit=max(limit, _CANDIDATE_POOL))
+        if total > len(hits):
+            hits, _total = self.search_prefix(tokens, limit=total)
+
         hits.sort(key=lambda hit: _relevance_key(tokens, hit))
         return [{"name": hit.get("name"), "email": hit.get("email")} for hit in hits[:limit]]

--- a/suite/mail/tests/test_email_address_index.py
+++ b/suite/mail/tests/test_email_address_index.py
@@ -1,12 +1,18 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
-"""The email-address index's normalization contract: display names lose the quotes clients wrap
-them in, and only syntactically valid addresses ever reach the index."""
+"""The email-address index's normalization and ranking contracts: display names lose the quotes
+clients wrap them in, only syntactically valid addresses ever reach the index, and suggestions come
+back ordered by how well the query matches a name or address rather than in index order."""
 
 import unittest
 from unittest import mock
 
-from suite.mail.store.indexes.email_address import EmailAddressIndex, _sanitize_name
+from suite.mail.store.indexes.email_address import (
+    EmailAddressIndex,
+    _relevance_key,
+    _sanitize_name,
+    _tokenize,
+)
 
 
 class SanitizeName(unittest.TestCase):
@@ -107,6 +113,88 @@ class IndexAddresses(unittest.TestCase):
         first = {"name": "Jane", "email": "jane@example.com"}
         second = {"name": "Jane Doe", "email": "Jane@Example.com"}
         self.assertEqual(self.index_addresses([first, second]), [second])
+
+
+class Tokenize(unittest.TestCase):
+    """``_tokenize`` — lowercased alphanumeric runs, matching how the index tokenized the text."""
+
+    def test_name_and_address_split_on_punctuation(self):
+        self.assertEqual(
+            _tokenize("Jane Doe jane.doe@example.com"), ["jane", "doe", "jane", "doe", "example", "com"]
+        )
+
+    def test_accented_word_stays_whole(self):
+        self.assertEqual(_tokenize("Jörg Müller"), ["jörg", "müller"])
+
+    def test_non_latin_script_stays_whole(self):
+        self.assertEqual(_tokenize("山田太郎"), ["山田太郎"])
+
+    def test_underscore_separates_words(self):
+        self.assertEqual(_tokenize("jane_doe"), ["jane", "doe"])
+
+    def test_blank_has_no_tokens(self):
+        self.assertEqual(_tokenize(None), [])
+        self.assertEqual(_tokenize("  -- "), [])
+
+
+class Relevance(unittest.TestCase):
+    """``_relevance_key`` — the order suggestions are presented in, most relevant first."""
+
+    def rank(self, query, addresses):
+        """Return `addresses` ordered as the suggestion list would present them."""
+
+        tokens = _tokenize(query)
+        ordered = sorted(addresses, key=lambda hit: _relevance_key(tokens, hit))
+        return [address["email"] for address in ordered]
+
+    def test_whole_word_beats_longer_word_starting_with_it(self):
+        # The reported case: "Doe" is what was typed, "Doeringer" merely starts with it.
+        doe = {"name": "John Doe", "email": "john@example.com"}
+        doeringer = {"name": "Jane Doeringer", "email": "jane@example.com"}
+        self.assertEqual(self.rank("doe", [doeringer, doe]), [doe["email"], doeringer["email"]])
+
+    def test_first_word_beats_later_word(self):
+        first = {"name": "Doe Jansen", "email": "dj@example.com"}
+        later = {"name": "Ann Doe", "email": "ad@example.com"}
+        self.assertEqual(self.rank("doe", [later, first]), [first["email"], later["email"]])
+
+    def test_whole_local_part_beats_name_match(self):
+        address = {"name": None, "email": "jane@example.com"}
+        named = {"name": "Jane Roe", "email": "jane.roe@example.com"}
+        self.assertEqual(self.rank("jane", [named, address]), [address["email"], named["email"]])
+
+    def test_name_match_beats_domain_match(self):
+        named = {"name": "Acme Support", "email": "support@example.com"}
+        hosted = {"name": "Jane Doe", "email": "jane@acme.test"}
+        self.assertEqual(self.rank("acme", [hosted, named]), [named["email"], hosted["email"]])
+
+    def test_adjacent_terms_beat_scattered_ones(self):
+        # Addresses run counter to the alphabetical tie-break, so only the ranking can order these.
+        adjacent = {"name": "Jane Doe", "email": "c@example.com"}
+        interrupted = {"name": "Jane Ann Doe", "email": "b@example.com"}
+        reversed_ = {"name": "Doe Jane", "email": "a@example.com"}
+        self.assertEqual(
+            self.rank("jane doe", [reversed_, interrupted, adjacent]),
+            [adjacent["email"], interrupted["email"], reversed_["email"]],
+        )
+
+    def test_match_spanning_name_and_address_sorts_last(self):
+        # Indexed as one "<name> <email>" blob, so this matches the query without any single
+        # field explaining it — it stays a hit, but below every address that does explain one.
+        spanning = {"name": "Jane", "email": "doe@example.com"}
+        explained = {"name": "Jane Doelan", "email": "jane.doelan@example.com"}
+        self.assertEqual(
+            self.rank("jane doe", [spanning, explained]), [explained["email"], spanning["email"]]
+        )
+
+    def test_equally_good_matches_prefer_named_then_shortest(self):
+        named = {"name": "Jane Doe", "email": "jane.doe@example.com"}
+        short = {"name": None, "email": "jane.aoe@example.com"}
+        long_ = {"name": None, "email": "jane.abercrombie@example.com"}
+        self.assertEqual(
+            self.rank("jane", [long_, short, named]),
+            [named["email"], short["email"], long_["email"]],
+        )
 
 
 if __name__ == "__main__":

--- a/suite/mail/tests/test_email_address_index.py
+++ b/suite/mail/tests/test_email_address_index.py
@@ -198,50 +198,27 @@ class Relevance(unittest.TestCase):
 
 
 class SearchEmailAddresses(unittest.TestCase):
-    """``search_email_addresses`` — every match is ranked, however many the index returns."""
+    """``search_email_addresses`` — ranks the whole match set, so it asks for the whole match set."""
 
-    def search(self, query, corpus, limit=10):
-        """Search `corpus` — held in index order — through a stand-in for the Tantivy retrieval.
+    def test_every_match_is_asked_for_not_a_page_of_them(self):
+        # Retrieval is unscored, so a page is an arbitrary slice: the best address sits wherever it
+        # was indexed. Ranking a page would let whoever was indexed first win a broad query.
+        index = mock.Mock(spec=EmailAddressIndex)
+        index.search_prefix.return_value = ([], 0)
 
-        The stand-in matches the way the real prefix query does (every token present, the last one
-        as a prefix), returns hits unscored in index order, and honours `limit` by truncating,
-        reporting the full match count alongside as Tantivy does.
-        """
+        EmailAddressIndex.search_email_addresses(index, "jan", limit=5)
 
-        def search_prefix(tokens, limit):
-            matched = [
-                hit
-                for hit in corpus
-                if all(
-                    any(word.startswith(token) for word in _tokenize(f"{hit['name']} {hit['email']}"))
-                    for token in tokens
-                )
-            ]
-            return (matched[:limit], len(matched))
+        index.search_prefix.assert_called_once_with(["jan"], limit=None)
+
+    def test_hits_come_back_ranked_and_capped_at_the_limit(self):
+        exact = {"name": "Jan Novak", "email": "jan@example.org"}
+        longer = {"name": "Janssen One", "email": "janssen1@example.com"}
 
         index = mock.Mock(spec=EmailAddressIndex)
-        index.search_prefix.side_effect = search_prefix
+        index.search_prefix.return_value = ([longer, exact], 2)
 
-        results = EmailAddressIndex.search_email_addresses(index, query, limit=limit)
-        return [result["email"] for result in results], index.search_prefix.call_count
-
-    def test_a_better_match_past_the_first_page_still_wins(self):
-        # The whole set has to be ranked: retrieval is unscored, so this exact-word match sits
-        # wherever it was indexed — here past a pool of longer words that merely start with "jan".
-        noise = [{"name": f"Janssen {n}", "email": f"janssen{n}@example.com"} for n in range(6000)]
-        exact = {"name": "Jan Novak", "email": "jan@example.org"}
-
-        emails, searches = self.search("jan", [*noise, exact])
-        self.assertEqual(emails[0], exact["email"])
-        # One search to fill the pool, a second once its count showed the pool had been truncated.
-        self.assertEqual(searches, 2)
-
-    def test_a_set_that_fits_the_pool_is_fetched_once(self):
-        corpus = [{"name": "Jane Doe", "email": "jane@example.com"}]
-
-        emails, searches = self.search("jane", corpus)
-        self.assertEqual(emails, [corpus[0]["email"]])
-        self.assertEqual(searches, 1)
+        results = EmailAddressIndex.search_email_addresses(index, "jan", limit=1)
+        self.assertEqual(results, [{"name": exact["name"], "email": exact["email"]}])
 
     def test_blank_query_searches_for_nothing(self):
         index = mock.Mock(spec=EmailAddressIndex)

--- a/suite/mail/tests/test_email_address_index.py
+++ b/suite/mail/tests/test_email_address_index.py
@@ -197,5 +197,58 @@ class Relevance(unittest.TestCase):
         )
 
 
+class SearchEmailAddresses(unittest.TestCase):
+    """``search_email_addresses`` — every match is ranked, however many the index returns."""
+
+    def search(self, query, corpus, limit=10):
+        """Search `corpus` — held in index order — through a stand-in for the Tantivy retrieval.
+
+        The stand-in matches the way the real prefix query does (every token present, the last one
+        as a prefix), returns hits unscored in index order, and honours `limit` by truncating,
+        reporting the full match count alongside as Tantivy does.
+        """
+
+        def search_prefix(tokens, limit):
+            matched = [
+                hit
+                for hit in corpus
+                if all(
+                    any(word.startswith(token) for word in _tokenize(f"{hit['name']} {hit['email']}"))
+                    for token in tokens
+                )
+            ]
+            return (matched[:limit], len(matched))
+
+        index = mock.Mock(spec=EmailAddressIndex)
+        index.search_prefix.side_effect = search_prefix
+
+        results = EmailAddressIndex.search_email_addresses(index, query, limit=limit)
+        return [result["email"] for result in results], index.search_prefix.call_count
+
+    def test_a_better_match_past_the_first_page_still_wins(self):
+        # The whole set has to be ranked: retrieval is unscored, so this exact-word match sits
+        # wherever it was indexed — here past a pool of longer words that merely start with "jan".
+        noise = [{"name": f"Janssen {n}", "email": f"janssen{n}@example.com"} for n in range(6000)]
+        exact = {"name": "Jan Novak", "email": "jan@example.org"}
+
+        emails, searches = self.search("jan", [*noise, exact])
+        self.assertEqual(emails[0], exact["email"])
+        # One search to fill the pool, a second once its count showed the pool had been truncated.
+        self.assertEqual(searches, 2)
+
+    def test_a_set_that_fits_the_pool_is_fetched_once(self):
+        corpus = [{"name": "Jane Doe", "email": "jane@example.com"}]
+
+        emails, searches = self.search("jane", corpus)
+        self.assertEqual(emails, [corpus[0]["email"]])
+        self.assertEqual(searches, 1)
+
+    def test_blank_query_searches_for_nothing(self):
+        index = mock.Mock(spec=EmailAddressIndex)
+
+        self.assertEqual(EmailAddressIndex.search_email_addresses(index, "  -- "), [])
+        index.search_prefix.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/suite/store/search_store.py
+++ b/suite/store/search_store.py
@@ -142,7 +142,7 @@ class SearchStore:
         fields = fields or list(self.DEFAULT_SEARCH_FIELDS) or None
         return self._run_search(lambda index: index.parse_query(query, fields), limit, offset, order_by)
 
-    def search_phrase_prefix(
+    def search_prefix(
         self,
         terms: list[str],
         limit: int = 20,
@@ -150,12 +150,14 @@ class SearchStore:
         fields: list[str] | None = None,
         order_by: str | None = None,
     ) -> tuple[list[dict], int]:
-        """Search for the given terms as a consecutive, in-order phrase whose last term is a prefix.
+        """Search for documents holding every term, with the last term matched as a prefix.
 
-        Built for as-you-type autocomplete: the terms must appear adjacent and in order in one of
-        `fields`, with the final term matched as a prefix — so "sagar s" matches "sagar.s@…" and
-        "Sagar Sharma", but not "sagar@…" (nothing follows "sagar") nor an address that merely
-        contains both words apart. A single term is a plain prefix match. Returns `(hits, count)`.
+        Built for as-you-type autocomplete: every term must appear in one of `fields`, with the
+        final one — the word still being typed — matched as a prefix. So "jane d" matches
+        "jane.d@example.com" and "Jane Doe", and also "Jane Ann Doe", since the terms need not be
+        adjacent or in order. Tantivy scores term and prefix queries alike as a constant, so these
+        hits come back in index order: ranking them is the caller's job (see
+        `EmailAddressIndex.search_email_addresses`). Returns `(hits, count)`.
         """
 
         terms = [term for term in terms if term]
@@ -164,7 +166,7 @@ class SearchStore:
 
         fields = fields or list(self.DEFAULT_SEARCH_FIELDS)
         return self._run_search(
-            lambda _index: self._build_phrase_prefix_query(terms, fields), limit, offset, order_by
+            lambda _index: self._build_prefix_query(terms, fields), limit, offset, order_by
         )
 
     def _run_search(
@@ -172,7 +174,7 @@ class SearchStore:
     ) -> tuple[list[dict], int]:
         """Open the index, build a query via `build_query(index)`, run it, and return `(hits, count)`.
 
-        Shared plumbing for `search`/`search_phrase_prefix`; swallows query errors (logged) into an
+        Shared plumbing for `search`/`search_prefix`; swallows query errors (logged) into an
         empty result so a malformed query never breaks the caller.
         """
 
@@ -198,17 +200,34 @@ class SearchStore:
             )
             return ([], 0)
 
-    def _build_phrase_prefix_query(self, terms: list[str], fields: list[str]) -> tantivy.Query:
-        """Build a phrase-prefix query over `terms`, matching in any one of `fields`."""
+    def _build_prefix_query(self, terms: list[str], fields: list[str]) -> tantivy.Query:
+        """Build an all-terms-with-trailing-prefix query, matching within any one of `fields`."""
 
         if len(fields) == 1:
-            return tantivy.Query.phrase_prefix_query(self._schema, fields[0], terms)
+            return self._build_field_prefix_query(terms, fields[0])
 
-        # Match the phrase in any of the fields.
+        # Match all the terms in any one of the fields.
+        clauses = [(tantivy.Occur.Should, self._build_field_prefix_query(terms, field)) for field in fields]
+        return tantivy.Query.boolean_query(clauses)
+
+    def _build_field_prefix_query(self, terms: list[str], field: str) -> tantivy.Query:
+        """Require every term in `field`, matching the last one as a prefix.
+
+        The trailing term uses a zero-distance fuzzy *prefix* query rather than Tantivy's
+        phrase-prefix query: the latter expands a prefix to at most 50 terms, so on a sizeable
+        index a short prefix silently drops every match past those 50 — typing "j" would never
+        reach "jane@example.com" — while the automaton behind this one matches them all.
+        """
+
         clauses = [
-            (tantivy.Occur.Should, tantivy.Query.phrase_prefix_query(self._schema, field, terms))
-            for field in fields
+            (tantivy.Occur.Must, tantivy.Query.term_query(self._schema, field, term)) for term in terms[:-1]
         ]
+        clauses.append(
+            (
+                tantivy.Occur.Must,
+                tantivy.Query.fuzzy_term_query(self._schema, field, terms[-1], distance=0, prefix=True),
+            )
+        )
         return tantivy.Query.boolean_query(clauses)
 
     def drop(self) -> None:

--- a/suite/store/search_store.py
+++ b/suite/store/search_store.py
@@ -17,6 +17,10 @@ from suite.utils.lock import write_lock
 
 SCHEMA_VERSION_FILE = "schema.version"
 
+# How many documents an unbounded fetch (`limit=None`) asks for before it knows how many match.
+# Sized so one pass almost always holds the whole match set; see `_run_search` for what a miss costs.
+UNBOUNDED_FETCH_PAGE = 5000
+
 
 @dataclass(frozen=True)
 class FieldSpec:
@@ -146,7 +150,7 @@ class SearchStore:
     def search_prefix(
         self,
         terms: list[str],
-        limit: int = 20,
+        limit: int | None = 20,
         offset: int = 0,
         fields: list[str] | None = None,
         order_by: str | None = None,
@@ -159,6 +163,9 @@ class SearchStore:
         adjacent or in order. Tantivy scores term and prefix queries alike as a constant, so these
         hits come back in index order: ranking them is the caller's job (see
         `EmailAddressIndex.search_email_addresses`). Returns `(hits, count)`.
+
+        A caller that ranks the hits itself has to see all of them — an unscored page is an
+        arbitrary slice, not the best matches — so `limit=None` returns every match.
         """
 
         terms = [term for term in terms if term]
@@ -208,12 +215,19 @@ class SearchStore:
         )
 
     def _run_search(
-        self, build_query, limit: int, offset: int, order_by: str | None
+        self, build_query, limit: int | None, offset: int, order_by: str | None
     ) -> tuple[list[dict], int]:
         """Open the index, build a query via `build_query(index)`, run it, and return `(hits, count)`.
 
         Shared plumbing for the `search*` methods; swallows query errors (logged) into an empty
-        result so a malformed query never breaks the caller.
+        result so a malformed query never breaks the caller. `limit=None` returns every match.
+
+        Everything runs against one searcher, which holds the segments as they stood when it was
+        made. That is what makes an unbounded fetch whole rather than nearly whole: Tantivy needs a
+        limit up front, so the fetch guesses a page and repeats with the count if it guessed short,
+        and both passes have to read the same index for the count to still describe what the second
+        pass fetches. Reopening between them would let a write land in between and leave the fetch
+        short of its own count — the very truncation `limit=None` exists to avoid.
         """
 
         # Nothing has been indexed yet for this key.
@@ -227,9 +241,19 @@ class SearchStore:
             index.reload()
 
             searcher = index.searcher()
+            query = build_query(index)
+
+            page = UNBOUNDED_FETCH_PAGE if limit is None else limit
             result = searcher.search(
-                build_query(index), limit=limit, offset=offset, count=True, order_by_field=order_by
+                query, limit=page, offset=offset, count=True, order_by_field=order_by
             )
+
+            # Guessed short: ask this same searcher again, now knowing how many there are.
+            if limit is None and result.count - offset > page:
+                result = searcher.search(
+                    query, limit=result.count, offset=offset, count=True, order_by_field=order_by
+                )
+
             hits = [self._to_hit(searcher.doc(address), score) for score, address in result.hits]
             return (hits, result.count)
         except Exception:

--- a/suite/store/search_store.py
+++ b/suite/store/search_store.py
@@ -244,9 +244,7 @@ class SearchStore:
             query = build_query(index)
 
             page = UNBOUNDED_FETCH_PAGE if limit is None else limit
-            result = searcher.search(
-                query, limit=page, offset=offset, count=True, order_by_field=order_by
-            )
+            result = searcher.search(query, limit=page, offset=offset, count=True, order_by_field=order_by)
 
             # Guessed short: ask this same searcher again, now knowing how many there are.
             if limit is None and result.count - offset > page:

--- a/suite/store/search_store.py
+++ b/suite/store/search_store.py
@@ -9,6 +9,7 @@ from urllib.parse import quote
 import frappe
 import tantivy
 from frappe import _
+from frappe.deprecation_dumpster import deprecation_warning
 
 from suite.store import get_search_base_path
 from suite.store.base_store import Namespace, normalize_namespace, resolve_namespace_path
@@ -169,13 +170,50 @@ class SearchStore:
             lambda _index: self._build_prefix_query(terms, fields), limit, offset, order_by
         )
 
+    def search_phrase_prefix(
+        self,
+        terms: list[str],
+        limit: int = 20,
+        offset: int = 0,
+        fields: list[str] | None = None,
+        order_by: str | None = None,
+    ) -> tuple[list[dict], int]:
+        """Deprecated: the phrase-prefix search that `search_prefix` replaced.
+
+        Kept with its semantics intact, so callers written against the old name keep getting what
+        that name promised: the terms must appear adjacent and in order in one of `fields`, with the
+        final one matched as a prefix — "jane d" matches "Jane Doe" but not "Jane Ann Doe".
+
+        `search_prefix` is the one to move to. It is looser, matching every term wherever it falls,
+        and it does not inherit what this carries: Tantivy expands the prefix to at most 50 terms,
+        so on a sizeable index a short prefix silently drops every match past those 50.
+        """
+
+        deprecation_warning(
+            marked="2026-08-10",
+            graduation="v1",
+            msg=(
+                "SearchStore.search_phrase_prefix has been replaced by SearchStore.search_prefix, "
+                "which matches every term wherever it falls rather than as one adjacent phrase."
+            ),
+        )
+
+        terms = [term for term in terms if term]
+        if not terms:
+            return ([], 0)
+
+        fields = fields or list(self.DEFAULT_SEARCH_FIELDS)
+        return self._run_search(
+            lambda _index: self._build_phrase_prefix_query(terms, fields), limit, offset, order_by
+        )
+
     def _run_search(
         self, build_query, limit: int, offset: int, order_by: str | None
     ) -> tuple[list[dict], int]:
         """Open the index, build a query via `build_query(index)`, run it, and return `(hits, count)`.
 
-        Shared plumbing for `search`/`search_prefix`; swallows query errors (logged) into an
-        empty result so a malformed query never breaks the caller.
+        Shared plumbing for the `search*` methods; swallows query errors (logged) into an empty
+        result so a malformed query never breaks the caller.
         """
 
         # Nothing has been indexed yet for this key.
@@ -208,6 +246,23 @@ class SearchStore:
 
         # Match all the terms in any one of the fields.
         clauses = [(tantivy.Occur.Should, self._build_field_prefix_query(terms, field)) for field in fields]
+        return tantivy.Query.boolean_query(clauses)
+
+    def _build_phrase_prefix_query(self, terms: list[str], fields: list[str]) -> tantivy.Query:
+        """Build a phrase-prefix query over `terms`, matching in any one of `fields`.
+
+        Only the deprecated `search_phrase_prefix` builds these; `search_prefix` deliberately does
+        not require the terms to be adjacent, and needs a prefix that expands without a cap.
+        """
+
+        if len(fields) == 1:
+            return tantivy.Query.phrase_prefix_query(self._schema, fields[0], terms)
+
+        # Match the phrase in any of the fields.
+        clauses = [
+            (tantivy.Occur.Should, tantivy.Query.phrase_prefix_query(self._schema, field, terms))
+            for field in fields
+        ]
         return tantivy.Query.boolean_query(clauses)
 
     def _build_field_prefix_query(self, terms: list[str], field: str) -> tantivy.Query:

--- a/suite/tests/test_search_store.py
+++ b/suite/tests/test_search_store.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+"""``SearchStore``'s deprecated ``search_phrase_prefix``: the pre-rename name still searches for a
+phrase rather than quietly becoming the looser search that replaced it."""
+
+import unittest
+from unittest import mock
+
+import tantivy
+
+from suite.store.search_store import SearchStore
+
+
+class SearchPhrasePrefix(unittest.TestCase):
+    """``search_phrase_prefix`` — the pre-rename name, still searching for a phrase, still deprecated."""
+
+    def search(self, terms, **kwargs):
+        """Return the Tantivy query the deprecated search would run."""
+
+        schema_builder = tantivy.SchemaBuilder()
+        schema_builder.add_text_field("text")
+
+        store = mock.Mock(spec=SearchStore)
+        store._schema = schema_builder.build()
+        store.DEFAULT_SEARCH_FIELDS = ("text",)
+        store._build_phrase_prefix_query.side_effect = lambda t, f: SearchStore._build_phrase_prefix_query(
+            store, t, f
+        )
+        store._run_search.side_effect = lambda build_query, *_args: (build_query(None), 0)
+
+        with self.assertWarns(Warning):
+            query, _count = SearchStore.search_phrase_prefix(store, terms, **kwargs)
+
+        return query
+
+    def test_terms_are_searched_for_as_a_phrase_not_scattered(self):
+        # The contract the name promises, and the reason this isn't a forward to search_prefix:
+        # a phrase query matches "Jane Doe" but not "Jane Ann Doe" or "Doe Jane".
+        self.assertIn("PhrasePrefixQuery", repr(self.search(["jane", "d"])))
+
+    def test_blank_terms_search_for_nothing(self):
+        store = mock.Mock(spec=SearchStore)
+
+        with self.assertWarns(Warning):
+            self.assertEqual(SearchStore.search_phrase_prefix(store, ["", None]), ([], 0))
+
+        store._run_search.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/suite/tests/test_search_store.py
+++ b/suite/tests/test_search_store.py
@@ -1,14 +1,98 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
-"""``SearchStore``'s deprecated ``search_phrase_prefix``: the pre-rename name still searches for a
-phrase rather than quietly becoming the looser search that replaced it."""
+"""``SearchStore``'s two search contracts: an unbounded fetch returns every match, reading the index
+once so its own count still describes what it fetched, and the deprecated ``search_phrase_prefix``
+still searches for a phrase rather than quietly becoming the looser search that replaced it."""
 
 import unittest
 from unittest import mock
 
 import tantivy
 
-from suite.store.search_store import SearchStore
+from suite.store.search_store import UNBOUNDED_FETCH_PAGE, SearchStore
+
+
+class FakeResult:
+    """Stands in for Tantivy's search result: a page of hits, and how many there are in total."""
+
+    def __init__(self, hits, count):
+        self.hits = hits
+        self.count = count
+
+
+class FakeSearcher:
+    """A fixed set of matches, paged out the way Tantivy pages them, recording each limit asked for.
+
+    Like a real searcher it is a snapshot: `matches` is whatever it was made with, so a test can
+    change what the index holds without this seeing it.
+    """
+
+    def __init__(self, matches):
+        self.matches = matches
+        self.limits = []
+
+    def search(self, _query, limit, offset=0, count=True, order_by_field=None):
+        self.limits.append(limit)
+        return FakeResult(self.matches[offset : offset + limit], len(self.matches))
+
+    def doc(self, address):
+        return address
+
+
+class UnboundedFetch(unittest.TestCase):
+    """``_run_search(limit=None)`` — every match, from one reading of the index."""
+
+    def search(self, matches, limit=None, offset=0):
+        """Run a search over `matches`; returns its hits and the searcher that served them."""
+
+        searcher = FakeSearcher(matches)
+        index = mock.Mock()
+        index.searcher.return_value = searcher
+
+        store = mock.Mock(spec=SearchStore)
+        store.path = "/nonexistent/index"
+        store._open.return_value = index
+        store._to_hit.side_effect = lambda document, _score: document
+
+        with mock.patch.object(tantivy, "Index") as tantivy_index:
+            tantivy_index.exists.return_value = True
+            hits, count = SearchStore._run_search(store, lambda _index: "query", limit, offset, None)
+
+        self.assertEqual(count, len(matches))
+        return hits, searcher, index
+
+    def test_a_page_that_came_back_short_is_refetched_at_the_full_count(self):
+        hits, searcher, _index = self.search([(1.0, n) for n in range(6000)])
+
+        self.assertEqual(searcher.limits, [UNBOUNDED_FETCH_PAGE, 6000])
+        self.assertEqual(len(hits), 6000)
+
+    def test_the_refetch_reads_the_searcher_that_reported_the_count(self):
+        # The whole point of doing this here rather than by calling search twice: a second reading
+        # of the index could have grown, leaving the fetch short of its own count — the truncation
+        # an unbounded fetch exists to avoid.
+        _hits, _searcher, index = self.search([(1.0, n) for n in range(6000)])
+
+        self.assertEqual(index.searcher.call_count, 1)
+        self.assertEqual(index.reload.call_count, 1)
+
+    def test_a_match_set_the_first_page_holds_is_fetched_once(self):
+        hits, searcher, _index = self.search([(1.0, n) for n in range(10)])
+
+        self.assertEqual(searcher.limits, [UNBOUNDED_FETCH_PAGE])
+        self.assertEqual(len(hits), 10)
+
+    def test_only_what_is_left_past_an_offset_has_to_fit_the_page(self):
+        hits, searcher, _index = self.search([(1.0, n) for n in range(6000)], offset=5999)
+
+        self.assertEqual(searcher.limits, [UNBOUNDED_FETCH_PAGE])
+        self.assertEqual(len(hits), 1)
+
+    def test_a_bounded_search_is_left_at_the_limit_it_was_given(self):
+        hits, searcher, _index = self.search([(1.0, n) for n in range(6000)], limit=20)
+
+        self.assertEqual(searcher.limits, [20])
+        self.assertEqual(len(hits), 20)
 
 
 class SearchPhrasePrefix(unittest.TestCase):


### PR DESCRIPTION
## Problem

Searching the email-address index for `doe` could return the person you meant last. The cause was not weak ranking — there was **no ranking**:

1. **Prefix matches come back unscored.** Every hit from Tantivy's `phrase_prefix_query` scores exactly `1.0`, so results were ordered by internal doc id, i.e. *insertion order*. "Jane Doeringer" outranked "John Doe" only because it was indexed first.
2. **Short prefixes silently lost matches.** Phrase-prefix expands a prefix to at most 50 terms. On a 20k-address index, querying `j` returned 20000 hits and excluded `jane@example.com` entirely — one letter made a contact unreachable.
3. **Non-ASCII names could never match.** The query tokenizer was `[a-z0-9]+`, so "Müller" shredded into `m` + `ller` while the index held `müller`.

## Changes

**Retrieval** (`suite/store/search_store.py`) — `search_prefix` joins `search_phrase_prefix`: all terms required, trailing term matched by an automaton-backed prefix query with no expansion cap. Adjacency is no longer required at retrieval, so "jane doe" now also finds "Jane Ann Doe". The docstring states that hits are unranked and ranking is the caller's job.

`search_phrase_prefix` is kept as a deprecated alias with its phrase semantics **intact** — it still runs a phrase-prefix query, so a caller held up by the old name keeps getting the adjacent, in-order match that name promises. It warns and points at `search_prefix`. Deprecating a name is no licence to change what it does.

**Ranking** (`suite/mail/store/indexes/email_address.py`) — matches are scored where the name/local-part/domain structure is known:

```
match quality (name/local over domain, whole, adjacent, position, residual)
  → named, shortest, alphabetical
```

Every match is ranked, not a fixed pool of them. Retrieval is unscored, so the best address can sit anywhere in the match set — cutting the set before the sort would drop it, and whoever was indexed first would win a broad query outright. `search_prefix(limit=None)` fetches the lot: a page of 5000 first, then a refetch sized by the count if that page came up short, so the common query stays one round-trip.

Both passes run against **one searcher**. A searcher holds the segments as they stood when it was made, so the count still describes what the second pass fetches however many writes land meanwhile. Two independent searches would let a write in between leave the fetch short of its own count — and short at the end, which is exactly where a newly indexed address sits.

The schema is unchanged, so no reindex is needed.

## Verification

Built real Tantivy indexes and drove them through the actual classes:

| Check | Result |
|---|---|
| `"doe"` | word-exact match leads, not the longer word that merely starts with it |
| `"jörg"` / `"müller"` | now match (previously impossible) |
| 6001 addresses starting `"jan"`, exact one indexed **last** | leads the suggestions; before the pool fix it was absent entirely |
| a concurrent worker committing an address mid-search | 6000 of 6000 fetched; before the shared-searcher fix, 6000 of 6001, the new address dropped |
| single letter against 20k addresses | ~85ms worst case; ~1ms for anything more selective |
| `search_phrase_prefix("jane d")` over "Jane Doe" / "Jane Ann Doe" / "Doe Jane" | returns "Jane Doe" alone, and warns |
| `search_prefix("jane d")` over the same three | returns all three |

39 unit tests pass, including the reported case as a regression test.

## Known gaps

- **No accent folding** — "muller" still will not find "Müller"; that needs a custom index-time tokenizer plus a rebuild.
- **No frequency signal** — addresses the query matches equally well are separated only by name presence and address length, not by which one you actually write to. That is the follow-up in #568.
