### PR TITLE
feat(mail): rank recipient suggestions by correspondence

### DIFF
--- a/suite/mail/doctype/contact_card/contact_card.py
+++ b/suite/mail/doctype/contact_card/contact_card.py
@@ -505,8 +505,13 @@ def _cache_contact_cards(account: str, contact_cards: dict[str, dict]) -> None:
     store.set_many(Entity.CONTACT_CARD, items=contact_cards)
 
     # Feed contact addresses into the shared address index; never let indexing break caching.
+    # Uncounted: the whole address book is re-cached on every contact sync, and a contact card says
+    # who someone is, not how much mail they are on — counting it would rank contacts the user never
+    # writes to above the addresses they actually correspond with.
     try:
-        get_email_address_index(account).index_addresses(_contact_addresses(contact_cards.values()))
+        get_email_address_index(account).index_addresses(
+            _contact_addresses(contact_cards.values()), count=False
+        )
     except Exception:
         log_mail_error(
             _("Failed to index contact addresses for search"), frappe.get_traceback(with_context=True)

--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -1294,11 +1294,12 @@ def _cache_messages(account: str, messages: dict[str, dict]) -> None:
     """
 
     store = get_data_store(account)
-    # Checked before the write, while the store can still tell which of these it has already seen.
-    known = store.exists_many(Entity.EMAIL, keys=list(messages))
-    store.set_many(Entity.EMAIL, items=messages)
+    # Which of these the cache had never held, answered by the write itself: two fetches racing to
+    # cache the same new message would otherwise both be told it was new and count its addresses
+    # twice. Only one of them gets the message back from here.
+    new_ids = store.set_many(Entity.EMAIL, items=messages)
 
-    new_messages = [message for message_id, message in messages.items() if message_id not in known]
+    new_messages = [message for message_id, message in messages.items() if message_id in new_ids]
     if not new_messages:
         return
 

--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -1315,8 +1315,16 @@ def _cache_messages(account: str, messages: dict[str, dict]) -> None:
     except Exception:
         # Uncache what was not indexed, so the next fetch of it is new again and tries once more.
         # The message is still on the server; the cost of dropping it is one re-fetch, against
-        # addresses that would otherwise never be indexed at all. Suppressed in turn because
-        # indexing must not break caching, and a rollback that throws would do exactly that.
+        # addresses that would otherwise never be indexed at all.
+        #
+        # Unconditional on purpose, even though another request may have re-cached one of these in
+        # the meantime: that request found the id already there, so it skipped indexing too, and
+        # sparing its copy would leave the message cached with nobody left to index it — permanently,
+        # since only a cache miss brings it back through here. Its copy is a mirror of the server
+        # (flag changes write there first), so dropping it costs that request a re-fetch, not data.
+        #
+        # Suppressed in turn because indexing must not break caching, and a rollback that throws
+        # would do exactly that.
         with suppress(Exception):
             store.delete_many(Entity.EMAIL, keys=list(new_ids))
 

--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -1285,14 +1285,26 @@ def _get_cached_messages(account: str, ids: list[str]) -> dict[str, dict | None]
 
 
 def _cache_messages(account: str, messages: dict[str, dict]) -> None:
-    """Store messages in cache with the message ID as the key, and index their addresses for search."""
+    """Store messages in cache with the message ID as the key, and index their addresses for search.
+
+    Only messages the cache hasn't held before are indexed. Caching runs again whenever a message is
+    re-fetched — a flag changed, a mailbox was re-synced — and the index counts every sighting of an
+    address to rank suggestions, so re-indexing the same message would score sync churn as
+    correspondence. The addresses on a message already cached were indexed when it first arrived.
+    """
 
     store = get_data_store(account)
+    # Checked before the write, while the store can still tell which of these it has already seen.
+    known = store.exists_many(Entity.EMAIL, keys=list(messages))
     store.set_many(Entity.EMAIL, items=messages)
+
+    new_messages = [message for message_id, message in messages.items() if message_id not in known]
+    if not new_messages:
+        return
 
     # Feed sender/recipient addresses into the shared address index; never let indexing break caching.
     try:
-        get_email_address_index(account).index_addresses(_message_addresses(messages.values()))
+        get_email_address_index(account).index_addresses(_message_addresses(new_messages))
     except Exception:
         log_mail_error(
             _("Failed to index message addresses for search"), frappe.get_traceback(with_context=True)
@@ -1303,7 +1315,10 @@ def _remove_cached_messages(account: str, ids: list[str]) -> None:
     """Remove messages from cache for the provided IDs.
 
     Addresses are left in the search index on purpose: it is cumulative, and an address seen in an
-    evicted message is almost always still valid elsewhere.
+    evicted message is almost always still valid elsewhere. Their correspondence counts are left
+    standing too, and a message re-fetched after this counts again — the cache is what remembers
+    which messages have been seen. Counts rank addresses against each other, so that drift costs
+    an ordering nothing; `rebuild_email_address_index` recomputes them from the cache as it stands.
     """
 
     store = get_data_store(account)

--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -3,6 +3,7 @@
 
 import json
 import re
+from contextlib import suppress
 from email.utils import formataddr
 from functools import cached_property
 from typing import Literal
@@ -1291,6 +1292,11 @@ def _cache_messages(account: str, messages: dict[str, dict]) -> None:
     re-fetched — a flag changed, a mailbox was re-synced — and the index counts every sighting of an
     address to rank suggestions, so re-indexing the same message would score sync churn as
     correspondence. The addresses on a message already cached were indexed when it first arrived.
+
+    Being cached is therefore what marks a message indexed, and a message whose addresses did not
+    reach the index does not stay cached. Otherwise the failure would be permanent: the message
+    would never be offered as new again, and the people on it could be missing from suggestions
+    until someone rebuilt the index by hand.
     """
 
     store = get_data_store(account)
@@ -1307,6 +1313,13 @@ def _cache_messages(account: str, messages: dict[str, dict]) -> None:
     try:
         get_email_address_index(account).index_addresses(_message_addresses(new_messages))
     except Exception:
+        # Uncache what was not indexed, so the next fetch of it is new again and tries once more.
+        # The message is still on the server; the cost of dropping it is one re-fetch, against
+        # addresses that would otherwise never be indexed at all. Suppressed in turn because
+        # indexing must not break caching, and a rollback that throws would do exactly that.
+        with suppress(Exception):
+            store.delete_many(Entity.EMAIL, keys=list(new_ids))
+
         log_mail_error(
             _("Failed to index message addresses for search"), frappe.get_traceback(with_context=True)
         )

--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -28,7 +28,13 @@ from suite.mail.doctype.user_account.user_account import get_user_for_jmap_accou
 from suite.mail.jmap import get_email_service, get_jmap_connection, get_thread_service
 from suite.mail.jmap.services.mail.email import EmailService
 from suite.mail.jmap.services.mail.mailbox import MailboxService
-from suite.mail.store import Entity, get_blob_store, get_data_store, get_email_address_index
+from suite.mail.store import (
+    Entity,
+    get_blob_store,
+    get_data_store,
+    get_email_address_index,
+    rebuild_email_address_index,
+)
 from suite.mail.utils import (
     get_config,
     log_mail_error,
@@ -1296,7 +1302,8 @@ def _cache_messages(account: str, messages: dict[str, dict]) -> None:
     Being cached is therefore what marks a message indexed, and a message whose addresses did not
     reach the index does not stay cached. Otherwise the failure would be permanent: the message
     would never be offered as new again, and the people on it could be missing from suggestions
-    until someone rebuilt the index by hand.
+    until someone rebuilt the index by hand. If the store will not give the message up either, that
+    rebuild is queued rather than waited for.
     """
 
     store = get_data_store(account)
@@ -1313,6 +1320,10 @@ def _cache_messages(account: str, messages: dict[str, dict]) -> None:
     try:
         get_email_address_index(account).index_addresses(_message_addresses(new_messages))
     except Exception:
+        log_mail_error(
+            _("Failed to index message addresses for search"), frappe.get_traceback(with_context=True)
+        )
+
         # Uncache what was not indexed, so the next fetch of it is new again and tries once more.
         # The message is still on the server; the cost of dropping it is one re-fetch, against
         # addresses that would otherwise never be indexed at all.
@@ -1322,15 +1333,23 @@ def _cache_messages(account: str, messages: dict[str, dict]) -> None:
         # sparing its copy would leave the message cached with nobody left to index it — permanently,
         # since only a cache miss brings it back through here. Its copy is a mirror of the server
         # (flag changes write there first), so dropping it costs that request a re-fetch, not data.
-        #
-        # Suppressed in turn because indexing must not break caching, and a rollback that throws
-        # would do exactly that.
-        with suppress(Exception):
+        try:
             store.delete_many(Entity.EMAIL, keys=list(new_ids))
+        except Exception:
+            # The store just took these messages and now will not give them up, so nothing here can
+            # put it right: they stay cached, and being cached is what stops them being offered as
+            # new again. Hand it to a rebuild instead, which reconciles the whole index against the
+            # cache. It is deduplicated per account and runs on the long queue, so a spell of
+            # failures queues one repair rather than one apiece, and it is suppressed in turn
+            # because indexing must not break caching — a repair that cannot even be queued is
+            # still on the record above.
+            log_mail_error(
+                _("Failed to uncache messages that could not be indexed"),
+                frappe.get_traceback(with_context=True),
+            )
 
-        log_mail_error(
-            _("Failed to index message addresses for search"), frappe.get_traceback(with_context=True)
-        )
+            with suppress(Exception):
+                rebuild_email_address_index(account)
 
 
 def _remove_cached_messages(account: str, ids: list[str]) -> None:

--- a/suite/mail/patches/rebuild_email_address_indexes.py
+++ b/suite/mail/patches/rebuild_email_address_indexes.py
@@ -4,8 +4,10 @@ from suite.mail.store import rebuild_all_email_address_indexes
 def execute() -> None:
     """Build the email-address search index from data already cached for each JMAP account.
 
-    The index is new, so existing caches predate it. This fans the accounts out into long-queue
-    background jobs (rather than indexing inline during migrate), each rebuilding from the cache.
+    Re-run whenever the index's schema changes: a changed schema wipes each account's index the next
+    time it is opened, leaving suggestions empty until something re-indexes. This fans the accounts
+    out into long-queue background jobs (rather than indexing inline during migrate), each
+    rebuilding from the cache.
     """
 
     rebuild_all_email_address_indexes()

--- a/suite/mail/store/__init__.py
+++ b/suite/mail/store/__init__.py
@@ -133,6 +133,10 @@ def rebuild_email_address_index(account: str, in_background: bool = True) -> Non
     Drops the existing index, then re-indexes every cached mail message and contact card in
     batches (bounding memory and the size of each index commit). Runs in a background job by
     default; pass `in_background=False` to run inline (e.g. from within the job itself).
+
+    Correspondence counts are recomputed from the messages the cache holds now, so a rebuild both
+    clears the drift a re-fetched message leaves behind and forgets the addresses an evicted one
+    contributed. They rank suggestions against each other; they are not a record of every message.
     """
 
     if in_background:
@@ -163,7 +167,7 @@ def rebuild_email_address_index(account: str, in_background: bool = True) -> Non
 
     contact_cards = list(store.scan(Entity.CONTACT_CARD).values())
     for batch in create_batch(contact_cards, _REBUILD_BATCH_SIZE):
-        index.index_addresses(_contact_addresses(batch))
+        index.index_addresses(_contact_addresses(batch), count=False)
 
 
 @frappe.whitelist()

--- a/suite/mail/store/indexes/email_address.py
+++ b/suite/mail/store/indexes/email_address.py
@@ -69,8 +69,14 @@ def _relevance_key(query: list[str], hit: dict) -> tuple:
         default=_NO_MATCH,
     )
 
+    # Among matches the query can't tell apart, the address corresponded with most wins: typing
+    # "user" leads with whichever of user@example.com / user@example.org has been seen more. It
+    # ranks below the match itself on purpose — a much-mailed "Jane Doeringer" shouldn't displace
+    # "John Doe" for the query "doe".
+    correspondence = -(hit.get("count") or 0)
+
     # Named, shorter addresses first among equals; the address itself keeps the order deterministic.
-    return (*best, 0 if name else 1, len(email), email.lower())
+    return (*best, correspondence, 0 if name else 1, len(email), email.lower())
 
 
 def _sanitize_name(name: str | None) -> str | None:
@@ -91,6 +97,10 @@ class EmailAddressIndex(SearchStore):
     address, so re-indexing the same address from any source is an upsert and addresses stay unique
     by construction. The index is cumulative: entries are only added or updated, never removed when
     a source is evicted, so it doubles as an address book of everyone the user has corresponded with.
+
+    Each entry also carries how often it has been seen, which orders suggestions the query itself
+    can't tell apart. Only sources that represent correspondence pass `count=True`, so the tally
+    tracks who the user writes to and hears from rather than how often a source happens to re-index.
     """
 
     ENTITY = "email_address"
@@ -102,8 +112,13 @@ class EmailAddressIndex(SearchStore):
         FieldSpec("name", stored=True, tokenizer="raw"),
         # "name email" blob, tokenized so a query can match either part.
         FieldSpec("text"),
+        # Sightings after the first, so a newly indexed address starts at 0. Ranked in Python, so
+        # it only has to be stored — nothing sorts or filters on it inside the index.
+        FieldSpec("count", kind="integer", stored=True),
     )
     DEFAULT_SEARCH_FIELDS = ("text",)
+    # Sightings accumulate, so an upsert has to see the count it is replacing.
+    MERGE_ON_UPSERT = True
 
     def to_document(self, address: dict) -> dict:
         email = (address.get("email") or "").strip()
@@ -114,19 +129,66 @@ class EmailAddressIndex(SearchStore):
             "email": email,
             "name": name,
             "text": " ".join(filter(None, (name, email))),
+            # Sightings in this batch; `merge_document` resolves them against what is indexed.
+            "count": address.get("sightings") or 0,
         }
 
-    def index_addresses(self, addresses: list[dict]) -> int:
+    def merge_document(self, document: dict, existing: dict | None) -> dict:
+        """Fold this batch's sightings into the count already indexed for the address.
+
+        The sighting that first indexes an address doesn't count — it establishes the entry — so a
+        new address starts at 0 and every later sighting adds one. An upsert carrying no sightings
+        (`index_addresses(count=False)`) refreshes the entry and leaves its count where it stood.
+        """
+
+        if existing is None:
+            document["count"] = max(document["count"] - 1, 0)
+        else:
+            document["count"] += existing.get("count") or 0
+            # Sources differ in what they know: keep a name learned elsewhere rather than let a
+            # nameless sighting of the same address erase it.
+            document["name"] = document["name"] or existing.get("name")
+            document["text"] = " ".join(filter(None, (document["name"], document["email"])))
+
+        return document
+
+    def index_addresses(self, addresses: list[dict], count: bool = True) -> int:
         """Upsert the given {name, email} dicts; dedupes the batch and silently skips entries whose
-        email is missing or syntactically invalid."""
+        email is missing or syntactically invalid.
+
+        Every occurrence of an address in `addresses` counts as a sighting, not every call: one
+        batch can carry a whole page of messages, and a rebuild feeds in hundreds at a time, so
+        collapsing them would tally how the caller batched its work instead of how much mail the
+        address is on. Pass `count=False` for a source that says nothing about correspondence — a
+        contact sync re-indexes the whole address book, and counting it would lift contacts the user
+        never writes to above the addresses they do.
+        """
 
         unique = {}
+        sightings = {}
         for address in addresses:
             email = (address.get("email") or "").strip()
-            if EMAIL_MATCH_PATTERN.fullmatch(email):
-                unique[email.lower()] = address
+            if not EMAIL_MATCH_PATTERN.fullmatch(email):
+                continue
 
-        return self.index_documents(list(unique.values()))
+            key = email.lower()
+            current = unique.get(key)
+            # Last one wins, so the freshest name and casing survive — but not a *nameless* later
+            # sighting: one batch can carry the same address named from one message and bare from
+            # the next, and dropping the name there would index it as an address with no one behind
+            # it. `merge_document` keeps a name across batches; this keeps one within a batch.
+            # Sanitized on both sides, so a name that is only quote characters counts as no name —
+            # which is what it will be by the time `to_document` is through with it.
+            named = _sanitize_name(address.get("name"))
+            if current is None or named or not _sanitize_name(current.get("name")):
+                unique[key] = address
+
+            sightings[key] = sightings.get(key, 0) + 1
+
+        sources = [
+            {**address, "sightings": sightings[key] if count else 0} for key, address in unique.items()
+        ]
+        return self.index_documents(sources)
 
     def search_email_addresses(self, query: str, limit: int = 10) -> list[dict]:
         """Return up to `limit` {name, email} addresses matching `query`, most relevant first.
@@ -136,8 +198,10 @@ class EmailAddressIndex(SearchStore):
         but not "jane@…" or "jane.r@…". The index scores those matches all alike, so they are ranked
         here instead: an address wins by matching more of a name or local part, earlier, and in
         order. Searching "doe" therefore leads with "John Doe <john@example.com>" rather than
-        "Jane Doeringer <jane@example.com>". Documents are unique per address, so the hits need no
-        further deduping.
+        "Jane Doeringer <jane@example.com>". Matches the query can't separate are ordered by how
+        often the address has been corresponded with, so "user" leads with whichever of
+        user@example.com / user@example.org carries more mail. Documents are unique per address, so
+        the hits need no further deduping.
 
         Every match is ranked, not a slice of them — hence the unbounded fetch. Unscored hits come
         back in index order, so the best address can sit anywhere in the match set, and cutting the

--- a/suite/mail/tests/test_email_address_index.py
+++ b/suite/mail/tests/test_email_address_index.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
-"""The email-address index's normalization and ranking contracts: display names lose the quotes
-clients wrap them in, only syntactically valid addresses ever reach the index, and suggestions come
-back ordered by how well the query matches a name or address rather than in index order."""
+"""The email-address index's normalization, counting and ranking contracts: display names lose the
+quotes clients wrap them in, only syntactically valid addresses ever reach the index, every sighting
+of an address adds to the count that separates otherwise equal matches, and suggestions come back
+ordered by how well the query matches a name or address rather than in index order."""
 
 import unittest
 from unittest import mock
@@ -69,6 +70,7 @@ class ToDocument(unittest.TestCase):
                 "email": "Jane@Example.com",
                 "name": "Jane Doe",
                 "text": "Jane Doe Jane@Example.com",
+                "count": 0,
             },
         )
 
@@ -77,20 +79,24 @@ class ToDocument(unittest.TestCase):
         self.assertIsNone(document["name"])
         self.assertEqual(document["text"], "jane@example.com")
 
+    def test_batch_sightings_are_carried_into_the_count(self):
+        document = self.to_document({"email": "jane@example.com", "sightings": 3})
+        self.assertEqual(document["count"], 3)
+
 
 class IndexAddresses(unittest.TestCase):
-    """``index_addresses`` — silently drop entries without a syntactically valid email."""
+    """``index_addresses`` — drop invalid entries, dedupe the batch, tally every sighting."""
 
-    def index_addresses(self, addresses):
-        """Return the addresses that survive filtering and reach ``index_documents``."""
+    def index_addresses(self, addresses, count=True):
+        """Return the sources that survive filtering and reach ``index_documents``."""
 
         index = mock.Mock(spec=EmailAddressIndex)
-        EmailAddressIndex.index_addresses(index, addresses)
+        EmailAddressIndex.index_addresses(index, addresses, count=count)
         return index.index_documents.call_args[0][0]
 
     def test_valid_email_is_indexed(self):
         address = {"name": "Jane", "email": "jane@example.com"}
-        self.assertEqual(self.index_addresses([address]), [address])
+        self.assertEqual(self.index_addresses([address]), [{**address, "sightings": 1}])
 
     def test_missing_email_is_skipped(self):
         self.assertEqual(self.index_addresses([{"name": "Jane"}, {"name": "No Email", "email": ""}]), [])
@@ -107,12 +113,93 @@ class IndexAddresses(unittest.TestCase):
 
     def test_valid_survives_malformed_neighbours(self):
         valid = {"name": "Jane", "email": "jane@example.com"}
-        self.assertEqual(self.index_addresses([{"email": "not-an-email"}, valid]), [valid])
+        self.assertEqual(
+            self.index_addresses([{"email": "not-an-email"}, valid]), [{**valid, "sightings": 1}]
+        )
 
-    def test_batch_dedupes_case_insensitively(self):
+    def test_batch_dedupes_case_insensitively_and_counts_both(self):
+        # One upsert, but the address was on two messages: the batch is deduped, the sightings aren't.
         first = {"name": "Jane", "email": "jane@example.com"}
         second = {"name": "Jane Doe", "email": "Jane@Example.com"}
-        self.assertEqual(self.index_addresses([first, second]), [second])
+        self.assertEqual(self.index_addresses([first, second]), [{**second, "sightings": 2}])
+
+    def test_a_name_outlives_a_later_nameless_sighting(self):
+        # The same address arrives named from one message and bare from the next; last-wins alone
+        # would index it with no one behind it.
+        named = {"name": "Jane Doe", "email": "jane@example.com"}
+        bare = {"email": "jane@example.com"}
+        self.assertEqual(self.index_addresses([named, bare]), [{**named, "sightings": 2}])
+
+    def test_a_later_name_still_replaces_an_earlier_one(self):
+        old = {"name": "Jane Doe", "email": "jane@example.com"}
+        new = {"name": "Jane Roe", "email": "jane@example.com"}
+        self.assertEqual(self.index_addresses([old, new]), [{**new, "sightings": 2}])
+
+    def test_a_name_that_is_only_quotes_does_not_displace_a_real_one(self):
+        # It sanitizes to nothing, so treating it as a name would lose "Jane Doe" for no one.
+        named = {"name": "Jane Doe", "email": "jane@example.com"}
+        quotes = {"name": "''", "email": "jane@example.com"}
+        self.assertEqual(self.index_addresses([named, quotes]), [{**named, "sightings": 2}])
+
+    def test_a_name_is_picked_up_from_a_later_sighting(self):
+        bare = {"email": "jane@example.com"}
+        named = {"name": "Jane Doe", "email": "jane@example.com"}
+        self.assertEqual(self.index_addresses([bare, named]), [{**named, "sightings": 2}])
+
+    def test_each_address_is_tallied_on_its_own(self):
+        jane = {"email": "jane@example.com"}
+        john = {"email": "john@example.com"}
+        sources = self.index_addresses([jane, john, jane, jane])
+        self.assertEqual({s["email"]: s["sightings"] for s in sources}, {jane["email"]: 3, john["email"]: 1})
+
+    def test_uncounted_source_reports_no_sightings(self):
+        # A contact sync re-indexes the whole address book; it says nothing about correspondence.
+        address = {"name": "Jane", "email": "jane@example.com"}
+        self.assertEqual(self.index_addresses([address, address], count=False), [{**address, "sightings": 0}])
+
+
+class MergeDocument(unittest.TestCase):
+    """``merge_document`` — the first sighting establishes an address, every later one counts."""
+
+    def merge(self, document, existing=None):
+        # merge_document touches no instance state, so skip SearchStore's on-disk constructor.
+        return EmailAddressIndex.merge_document(mock.Mock(spec=EmailAddressIndex), document, existing)
+
+    def document(self, sightings, name="Jane Doe"):
+        return {
+            "id": "jane@example.com",
+            "email": "jane@example.com",
+            "name": name,
+            "text": " ".join(filter(None, (name, "jane@example.com"))),
+            "count": sightings,
+        }
+
+    def test_first_sighting_starts_the_count_at_zero(self):
+        self.assertEqual(self.merge(self.document(1))["count"], 0)
+
+    def test_first_batch_only_counts_sightings_past_the_first(self):
+        self.assertEqual(self.merge(self.document(4))["count"], 3)
+
+    def test_later_sightings_add_to_the_indexed_count(self):
+        merged = self.merge(self.document(2), {"count": 5, "name": "Jane Doe"})
+        self.assertEqual(merged["count"], 7)
+
+    def test_uncounted_upsert_leaves_the_count_alone(self):
+        merged = self.merge(self.document(0), {"count": 5, "name": "Jane Doe"})
+        self.assertEqual(merged["count"], 5)
+
+    def test_uncounted_first_sighting_starts_at_zero(self):
+        self.assertEqual(self.merge(self.document(0))["count"], 0)
+
+    def test_indexed_name_survives_a_nameless_sighting(self):
+        merged = self.merge(self.document(1, name=None), {"count": 0, "name": "Jane Doe"})
+        self.assertEqual(merged["name"], "Jane Doe")
+        self.assertEqual(merged["text"], "Jane Doe jane@example.com")
+
+    def test_a_named_sighting_replaces_the_indexed_name(self):
+        merged = self.merge(self.document(1, name="Jane Roe"), {"count": 0, "name": "Jane Doe"})
+        self.assertEqual(merged["name"], "Jane Roe")
+        self.assertEqual(merged["text"], "Jane Roe jane@example.com")
 
 
 class Tokenize(unittest.TestCase):
@@ -186,6 +273,30 @@ class Relevance(unittest.TestCase):
         self.assertEqual(
             self.rank("jane doe", [spanning, explained]), [explained["email"], spanning["email"]]
         )
+
+    def test_equally_good_matches_prefer_the_one_corresponded_with_most(self):
+        # The reported case: two addresses for the same person, matched identically by "user".
+        org = {"name": "Jane Doe", "email": "user@example.org", "count": 3}
+        com = {"name": "Jane Doe", "email": "user@example.com", "count": 42}
+        self.assertEqual(self.rank("user", [org, com]), [com["email"], org["email"]])
+
+    def test_correspondence_outranks_the_shortest_address_tie_break(self):
+        # Both match "zoe" the same way, and the shorter, alphabetically earlier address is the one
+        # with no correspondence behind it — so only the count can order these.
+        frequent = {"name": None, "email": "zoe.becker@example.com", "count": 9}
+        rare = {"name": None, "email": "zoe.ash@example.com", "count": 0}
+        self.assertEqual(self.rank("zoe", [rare, frequent]), [frequent["email"], rare["email"]])
+
+    def test_correspondence_never_beats_a_better_match(self):
+        # A much-mailed "Doeringer" still ranks below the "Doe" that was actually typed.
+        doe = {"name": "John Doe", "email": "john@example.com", "count": 0}
+        doeringer = {"name": "Jane Doeringer", "email": "jane@example.com", "count": 99}
+        self.assertEqual(self.rank("doe", [doeringer, doe]), [doe["email"], doeringer["email"]])
+
+    def test_an_uncounted_hit_ranks_as_never_corresponded_with(self):
+        counted = {"name": "Jane Doe", "email": "jane.doe@example.com", "count": 1}
+        uncounted = {"name": "Jane Doe", "email": "jane.doe@example.org"}
+        self.assertEqual(self.rank("jane", [uncounted, counted]), [counted["email"], uncounted["email"]])
 
     def test_equally_good_matches_prefer_named_then_shortest(self):
         named = {"name": "Jane Doe", "email": "jane.doe@example.com"}

--- a/suite/mail/tests/test_message_caching.py
+++ b/suite/mail/tests/test_message_caching.py
@@ -18,7 +18,7 @@ class CacheMessages(unittest.TestCase):
     """``_cache_messages`` — index what the cache had never held, and keep only what indexed."""
 
     def cache(self, messages, new_ids=None, index_error=None, rollback_error=None):
-        """Cache `messages`; returns the store, the index and the error log, all mocked."""
+        """Cache `messages`; returns the store, index, error log and rebuild, all mocked."""
 
         store = mock.Mock()
         # Whatever the store reports as new is what the batch is judged by.
@@ -32,24 +32,27 @@ class CacheMessages(unittest.TestCase):
             mock.patch.object(mail_message, "get_data_store", return_value=store),
             mock.patch.object(mail_message, "get_email_address_index", return_value=index),
             mock.patch.object(mail_message, "log_mail_error") as log_error,
+            mock.patch.object(mail_message, "rebuild_email_address_index") as rebuild,
         ):
             mail_message._cache_messages("account", messages)
 
-        return store, index, log_error
+        return store, index, log_error, rebuild
 
     def message(self, id, email):
         return {"id": id, "from_name": "Jane Doe", "from_email": email, "recipients": []}
 
     def test_a_new_message_has_its_addresses_indexed(self):
         message = self.message("m1", "jane@example.com")
-        _store, index, _log = self.cache({"m1": message})
+        _store, index, _log, _rebuild = self.cache({"m1": message})
 
         addresses = index.index_addresses.call_args.args[0]
         self.assertEqual(addresses, [{"name": "Jane Doe", "email": "jane@example.com"}])
 
     def test_a_message_the_cache_already_held_is_not_indexed_again(self):
         # The re-cache a flag change causes: counting it would score sync churn as correspondence.
-        _store, index, _log = self.cache({"m1": self.message("m1", "jane@example.com")}, new_ids=set())
+        _store, index, _log, _rebuild = self.cache(
+            {"m1": self.message("m1", "jane@example.com")}, new_ids=set()
+        )
 
         index.index_addresses.assert_not_called()
 
@@ -58,20 +61,20 @@ class CacheMessages(unittest.TestCase):
             "m1": self.message("m1", "jane@example.com"),
             "m2": self.message("m2", "john@example.com"),
         }
-        _store, index, _log = self.cache(messages, new_ids={"m2"})
+        _store, index, _log, _rebuild = self.cache(messages, new_ids={"m2"})
 
         addresses = index.index_addresses.call_args.args[0]
         self.assertEqual([address["email"] for address in addresses], ["john@example.com"])
 
     def test_a_message_that_indexed_stays_cached(self):
-        _store, _index, _log = self.cache({"m1": self.message("m1", "jane@example.com")})
+        _store, _index, _log, _rebuild = self.cache({"m1": self.message("m1", "jane@example.com")})
 
         _store.delete_many.assert_not_called()
 
     def test_a_message_that_failed_to_index_is_uncached(self):
         # Being cached is what marks a message indexed. Left cached, it would never be offered as
         # new again and jane@example.com would be missing from suggestions until a manual rebuild.
-        store, _index, log_error = self.cache(
+        store, _index, log_error, _rebuild = self.cache(
             {"m1": self.message("m1", "jane@example.com")}, index_error=RuntimeError("index is down")
         )
 
@@ -83,13 +86,13 @@ class CacheMessages(unittest.TestCase):
             "m1": self.message("m1", "jane@example.com"),
             "m2": self.message("m2", "john@example.com"),
         }
-        store, _index, _log = self.cache(messages, new_ids={"m2"}, index_error=RuntimeError("boom"))
+        store, _index, _log, _rebuild = self.cache(messages, new_ids={"m2"}, index_error=RuntimeError("boom"))
 
         store.delete_many.assert_called_once_with(Entity.EMAIL, keys=["m2"])
 
     def test_indexing_failure_never_reaches_the_caller(self):
         # Caching is the caller's business; a search index that is down is not their problem.
-        _store, _index, log_error = self.cache(
+        _store, _index, log_error, _rebuild = self.cache(
             {"m1": self.message("m1", "jane@example.com")}, index_error=RuntimeError("boom")
         )
 
@@ -97,13 +100,54 @@ class CacheMessages(unittest.TestCase):
 
     def test_a_rollback_that_fails_is_swallowed_too(self):
         # Same reason: whatever the store does here, caching must not raise at the caller.
-        _store, _index, log_error = self.cache(
+        _store, _index, log_error, _rebuild = self.cache(
             {"m1": self.message("m1", "jane@example.com")},
             index_error=RuntimeError("boom"),
             rollback_error=RuntimeError("store is down"),
         )
 
-        log_error.assert_called_once()
+        # Both failures are on the record: the index write, and the uncaching meant to undo it.
+        self.assertEqual(log_error.call_count, 2)
+
+    def test_a_rollback_that_fails_hands_the_account_to_a_rebuild(self):
+        # Nothing local can fix this one: the message stays cached, so it will never be offered as
+        # new again, and its addresses would go unindexed until someone noticed. A rebuild
+        # reconciles the whole index against the cache, and dedupes per account.
+        _store, _index, _log, rebuild = self.cache(
+            {"m1": self.message("m1", "jane@example.com")},
+            index_error=RuntimeError("boom"),
+            rollback_error=RuntimeError("store is down"),
+        )
+
+        rebuild.assert_called_once_with("account")
+
+    def test_a_rollback_that_works_needs_no_rebuild(self):
+        # The next fetch retries this one on its own; a rebuild would be a lot of work for nothing.
+        _store, _index, _log, rebuild = self.cache(
+            {"m1": self.message("m1", "jane@example.com")}, index_error=RuntimeError("boom")
+        )
+
+        rebuild.assert_not_called()
+
+    def test_a_rebuild_that_cannot_be_queued_still_does_not_reach_the_caller(self):
+        # Redis down on top of the rest. The failures are logged; caching does not raise.
+        store = mock.Mock()
+        store.set_many.return_value = {"m1"}
+        store.delete_many.side_effect = RuntimeError("store is down")
+
+        index = mock.Mock()
+        index.index_addresses.side_effect = RuntimeError("boom")
+
+        with (
+            mock.patch.object(mail_message, "get_data_store", return_value=store),
+            mock.patch.object(mail_message, "get_email_address_index", return_value=index),
+            mock.patch.object(mail_message, "log_mail_error") as log_error,
+            mock.patch.object(mail_message, "rebuild_email_address_index") as rebuild,
+        ):
+            rebuild.side_effect = RuntimeError("queue is down")
+            mail_message._cache_messages("account", {"m1": self.message("m1", "jane@example.com")})
+
+        self.assertEqual(log_error.call_count, 2)
 
 
 class RollbackAgainstAConcurrentUpdate(unittest.TestCase):

--- a/suite/mail/tests/test_message_caching.py
+++ b/suite/mail/tests/test_message_caching.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+"""``_cache_messages``'s contract with the address index: a message is indexed the once, when the
+cache first takes it, and only stays cached if that indexing got through — so a failure costs a
+re-fetch rather than leaving the people on that message out of suggestions for good."""
+
+import unittest
+from unittest import mock
+
+from suite.mail.doctype.mail_message import mail_message
+from suite.mail.store import Entity
+
+
+class CacheMessages(unittest.TestCase):
+    """``_cache_messages`` — index what the cache had never held, and keep only what indexed."""
+
+    def cache(self, messages, new_ids=None, index_error=None, rollback_error=None):
+        """Cache `messages`; returns the store, the index and the error log, all mocked."""
+
+        store = mock.Mock()
+        # Whatever the store reports as new is what the batch is judged by.
+        store.set_many.return_value = set(messages) if new_ids is None else new_ids
+        store.delete_many.side_effect = rollback_error
+
+        index = mock.Mock()
+        index.index_addresses.side_effect = index_error
+
+        with (
+            mock.patch.object(mail_message, "get_data_store", return_value=store),
+            mock.patch.object(mail_message, "get_email_address_index", return_value=index),
+            mock.patch.object(mail_message, "log_mail_error") as log_error,
+        ):
+            mail_message._cache_messages("account", messages)
+
+        return store, index, log_error
+
+    def message(self, id, email):
+        return {"id": id, "from_name": "Jane Doe", "from_email": email, "recipients": []}
+
+    def test_a_new_message_has_its_addresses_indexed(self):
+        message = self.message("m1", "jane@example.com")
+        _store, index, _log = self.cache({"m1": message})
+
+        addresses = index.index_addresses.call_args.args[0]
+        self.assertEqual(addresses, [{"name": "Jane Doe", "email": "jane@example.com"}])
+
+    def test_a_message_the_cache_already_held_is_not_indexed_again(self):
+        # The re-cache a flag change causes: counting it would score sync churn as correspondence.
+        _store, index, _log = self.cache({"m1": self.message("m1", "jane@example.com")}, new_ids=set())
+
+        index.index_addresses.assert_not_called()
+
+    def test_only_the_new_messages_of_a_mixed_batch_are_indexed(self):
+        messages = {
+            "m1": self.message("m1", "jane@example.com"),
+            "m2": self.message("m2", "john@example.com"),
+        }
+        _store, index, _log = self.cache(messages, new_ids={"m2"})
+
+        addresses = index.index_addresses.call_args.args[0]
+        self.assertEqual([address["email"] for address in addresses], ["john@example.com"])
+
+    def test_a_message_that_indexed_stays_cached(self):
+        _store, _index, _log = self.cache({"m1": self.message("m1", "jane@example.com")})
+
+        _store.delete_many.assert_not_called()
+
+    def test_a_message_that_failed_to_index_is_uncached(self):
+        # Being cached is what marks a message indexed. Left cached, it would never be offered as
+        # new again and jane@example.com would be missing from suggestions until a manual rebuild.
+        store, _index, log_error = self.cache(
+            {"m1": self.message("m1", "jane@example.com")}, index_error=RuntimeError("index is down")
+        )
+
+        store.delete_many.assert_called_once_with(Entity.EMAIL, keys=["m1"])
+        log_error.assert_called_once()
+
+    def test_only_the_messages_that_went_unindexed_are_uncached(self):
+        messages = {
+            "m1": self.message("m1", "jane@example.com"),
+            "m2": self.message("m2", "john@example.com"),
+        }
+        store, _index, _log = self.cache(messages, new_ids={"m2"}, index_error=RuntimeError("boom"))
+
+        store.delete_many.assert_called_once_with(Entity.EMAIL, keys=["m2"])
+
+    def test_indexing_failure_never_reaches_the_caller(self):
+        # Caching is the caller's business; a search index that is down is not their problem.
+        _store, _index, log_error = self.cache(
+            {"m1": self.message("m1", "jane@example.com")}, index_error=RuntimeError("boom")
+        )
+
+        log_error.assert_called_once()
+
+    def test_a_rollback_that_fails_is_swallowed_too(self):
+        # Same reason: whatever the store does here, caching must not raise at the caller.
+        _store, _index, log_error = self.cache(
+            {"m1": self.message("m1", "jane@example.com")},
+            index_error=RuntimeError("boom"),
+            rollback_error=RuntimeError("store is down"),
+        )
+
+        log_error.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/suite/mail/tests/test_message_caching.py
+++ b/suite/mail/tests/test_message_caching.py
@@ -4,11 +4,14 @@
 cache first takes it, and only stays cached if that indexing got through — so a failure costs a
 re-fetch rather than leaving the people on that message out of suggestions for good."""
 
+import shutil
+import tempfile
 import unittest
 from unittest import mock
 
 from suite.mail.doctype.mail_message import mail_message
 from suite.mail.store import Entity
+from suite.store.data_store import DataStore
 
 
 class CacheMessages(unittest.TestCase):
@@ -101,6 +104,54 @@ class CacheMessages(unittest.TestCase):
         )
 
         log_error.assert_called_once()
+
+
+class RollbackAgainstAConcurrentUpdate(unittest.TestCase):
+    """What the rollback does when another request re-cached the message while indexing ran.
+
+    Against a real store, with the competing write landing inside the failing index call — the
+    window it would really land in.
+    """
+
+    def setUp(self):
+        self.path = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.path, ignore_errors=True)
+        self.store = DataStore(base_path=self.path, namespace=("test", "message-caching"))
+
+    def cache_with_a_competing_write_during_indexing(self, message, competing):
+        """Cache `message`; while indexing runs (and fails), another request caches `competing`."""
+
+        def index_addresses(_addresses):
+            self.store.set_many(Entity.EMAIL, items={"m1": competing})
+            raise RuntimeError("index is down")
+
+        index = mock.Mock()
+        index.index_addresses.side_effect = index_addresses
+
+        with (
+            mock.patch.object(mail_message, "get_data_store", return_value=self.store),
+            mock.patch.object(mail_message, "get_email_address_index", return_value=index),
+            mock.patch.object(mail_message, "log_mail_error"),
+        ):
+            mail_message._cache_messages("account", {"m1": message})
+
+    def test_the_newer_copy_is_dropped_along_with_the_rest(self):
+        # Deliberate, and the reason is the other request: it found the id already cached, so it
+        # skipped indexing on the same grounds this one did. Keeping its copy would leave the
+        # message cached with no one left to index it, and nothing brings it back through here
+        # except a cache miss — so the addresses on it would never be indexed at all. The copy is a
+        # mirror of the server, so dropping it costs a re-fetch; keeping it would cost the index.
+        message = {"id": "m1", "from_name": "Jane Doe", "from_email": "jane@example.com"}
+        self.cache_with_a_competing_write_during_indexing(message, {**message, "seen": 1})
+
+        self.assertFalse(self.store.exists(Entity.EMAIL, "m1"))
+
+    def test_the_next_fetch_of_it_is_new_again(self):
+        # Which is what makes the drop recoverable: the retry indexes the addresses that were lost.
+        message = {"id": "m1", "from_name": "Jane Doe", "from_email": "jane@example.com"}
+        self.cache_with_a_competing_write_during_indexing(message, {**message, "seen": 1})
+
+        self.assertEqual(self.store.set_many(Entity.EMAIL, items={"m1": message}), {"m1"})
 
 
 if __name__ == "__main__":

--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -76,7 +76,7 @@ suite.mail.patches.sync_jmap_accounts_for_configured_users
 suite.mail.patches.copy_sync_history_account_id_to_account
 suite.mail.patches.destroy_data_store
 suite.mail.patches.backfill_screened_email_address_account
-suite.mail.patches.rebuild_email_address_indexes #2
+suite.mail.patches.rebuild_email_address_indexes #3
 suite.mail.patches.enable_screening_for_personal_accounts
 suite.mail.patches.create_suite_user_role
 suite.mail.patches.rename_mail_admin_to_suite_admin

--- a/suite/store/data_store.py
+++ b/suite/store/data_store.py
@@ -289,6 +289,23 @@ class DataStore(BaseStore):
         with self._txn(write=False) as txn:
             return txn.get(db_key) is not None
 
+    def exists_many(self, entity: Enum, keys: list[str]) -> set[str]:
+        """Return the subset of `keys` the store holds, checked in one transaction.
+
+        Cheaper than `get_many` when only presence matters — the cursor positions on the key
+        without reading its value, so nothing is fetched or deserialized — and cheaper than a
+        call to `exists` per key, which opens a transaction each time.
+        """
+
+        if not keys:
+            return set()
+
+        db_keys = [(key, self._db_key(entity, key)) for key in keys]
+
+        with self._txn(write=False) as txn:
+            cursor = txn.cursor()
+            return {key for key, db_key in db_keys if cursor.set_key(db_key)}
+
     def get_many(self, entity: Enum, keys: list[str]) -> dict[str, Any | None]:
         """Retrieve multiple values by a list of keys, returning a dictionary of key-value pairs."""
 

--- a/suite/store/data_store.py
+++ b/suite/store/data_store.py
@@ -289,23 +289,6 @@ class DataStore(BaseStore):
         with self._txn(write=False) as txn:
             return txn.get(db_key) is not None
 
-    def exists_many(self, entity: Enum, keys: list[str]) -> set[str]:
-        """Return the subset of `keys` the store holds, checked in one transaction.
-
-        Cheaper than `get_many` when only presence matters — the cursor positions on the key
-        without reading its value, so nothing is fetched or deserialized — and cheaper than a
-        call to `exists` per key, which opens a transaction each time.
-        """
-
-        if not keys:
-            return set()
-
-        db_keys = [(key, self._db_key(entity, key)) for key in keys]
-
-        with self._txn(write=False) as txn:
-            cursor = txn.cursor()
-            return {key for key, db_key in db_keys if cursor.set_key(db_key)}
-
     def get_many(self, entity: Enum, keys: list[str]) -> dict[str, Any | None]:
         """Retrieve multiple values by a list of keys, returning a dictionary of key-value pairs."""
 
@@ -319,19 +302,35 @@ class DataStore(BaseStore):
 
         return {key: self._deserialize(value) if value is not None else None for key, value in raw}
 
-    def set_many(self, entity: Enum, items: dict[str, Any]) -> None:
-        """Store multiple key-value pairs at once, serializing values before saving."""
+    def set_many(self, entity: Enum, items: dict[str, Any]) -> set[str]:
+        """Store multiple key-value pairs at once, serializing values before saving.
+
+        Returns the keys the store did not already hold. They are decided inside the very
+        transaction that writes them, and that is what makes the answer safe to act on: LMDB
+        serializes writers, so of two workers storing the same key at once exactly one is told it
+        was new. Asking beforehand cannot promise that — both would look before either committed,
+        and both would be told yes. Callers that only need the write can ignore it.
+        """
 
         if not items:
-            return
+            return set()
 
-        encoded = [(self._db_key(entity, key), self._serialize(value)) for key, value in items.items()]
+        encoded = [(key, self._db_key(entity, key), self._serialize(value)) for key, value in items.items()]
+        new: set[str] = set()
 
         def _put_all(txn: Any) -> None:
-            for db_key, data in encoded:
-                txn.put(db_key, data)
+            # Rebuilt per attempt: `_write` runs this again if the map has to grow first.
+            new.clear()
+            cursor = txn.cursor()
+            for key, db_key, data in encoded:
+                # Positions on the key without reading its value: a lookup, not a copy of the value.
+                if not cursor.set_key(db_key):
+                    new.add(key)
+
+                cursor.put(db_key, data)
 
         self._write(_put_all)
+        return new
 
     def delete_many(self, entity: Enum, keys: list[str]) -> None:
         """Delete multiple keys from the storage at once."""

--- a/suite/store/search_store.py
+++ b/suite/store/search_store.py
@@ -21,6 +21,10 @@ SCHEMA_VERSION_FILE = "schema.version"
 # Sized so one pass almost always holds the whole match set; see `_run_search` for what a miss costs.
 UNBOUNDED_FETCH_PAGE = 5000
 
+# How many IDs one `merge_document` lookup asks about at a time, bounding the size of the boolean
+# query it builds when a caller upserts a large batch.
+UPSERT_LOOKUP_CHUNK = 1000
+
 
 @dataclass(frozen=True)
 class FieldSpec:
@@ -50,6 +54,8 @@ class SearchStore:
     FIELDS: ClassVar[tuple[FieldSpec, ...]] = ()
     # Fields queried when a search call doesn't specify its own field list.
     DEFAULT_SEARCH_FIELDS: ClassVar[tuple[str, ...]] = ()
+    # Whether an upsert reads the document it replaces and hands it to `merge_document`.
+    MERGE_ON_UPSERT: ClassVar[bool] = False
 
     # Per-writer memory budget for indexing, in bytes.
     HEAP_SIZE: ClassVar[int] = 50 * 1024 * 1024
@@ -75,25 +81,47 @@ class SearchStore:
 
         Each source is deleted-then-added by its ID_FIELD, so re-indexing an existing
         document replaces it. Sources without an ID are skipped.
+
+        A store with MERGE_ON_UPSERT set reads the documents being replaced first and runs each
+        replacement through `merge_document`, so state already in the index can be carried into it.
+        That read happens under the same write lock as the write: the lock is not reentrant, so a
+        subclass could not take it itself, and reading outside it would let a concurrent upsert of
+        the same document land in between and lose whatever the merge carried forward.
         """
 
         if not sources:
             return 0
 
+        documents = [self.to_document(source) for source in sources]
+        documents = [document for document in documents if document.get(self.ID_FIELD) is not None]
+
         with write_lock(self._lockname, acquire_timeout=30, lock_timeout=300):
             index = self._open()
+
+            if self.MERGE_ON_UPSERT:
+                # Pick up commits made by other workers since this index was opened, so the merge
+                # builds on their documents rather than on a stale view of them.
+                index.reload()
+                indexed = self._existing_documents(index, [str(d[self.ID_FIELD]) for d in documents])
+
+                # Collected by ID, so a batch carrying the same document twice accumulates into one
+                # write: the second merges onto what the first produced instead of replacing it
+                # unread, which would drop whatever the first had carried forward.
+                merged = {}
+                for document in documents:
+                    doc_id = str(document[self.ID_FIELD])
+                    replaced = merged.get(doc_id) or indexed.get(doc_id)
+                    merged[doc_id] = self.merge_document(document, replaced)
+
+                documents = list(merged.values())
+
             writer = index.writer(heap_size=self.HEAP_SIZE, num_threads=1)
 
             try:
-                for source in sources:
-                    document = self._to_tantivy_document(self.to_document(source))
-                    doc_id = document.get_first(self.ID_FIELD)
-                    if doc_id is None:
-                        continue
-
+                for document in documents:
                     # Delete any existing doc with this ID first so re-indexing is an upsert.
-                    writer.delete_documents(self.ID_FIELD, str(doc_id))
-                    writer.add_document(document)
+                    writer.delete_documents(self.ID_FIELD, str(document[self.ID_FIELD]))
+                    writer.add_document(self._to_tantivy_document(document))
 
                 writer.commit()
                 writer.wait_merging_threads()
@@ -102,6 +130,35 @@ class SearchStore:
                 del writer
 
         return len(sources)
+
+    def _existing_documents(self, index: tantivy.Index, ids: list[str]) -> dict[str, dict]:
+        """Return the indexed documents for `ids`, keyed by ID_FIELD; absent IDs are simply missing.
+
+        Only the documents an upsert is about to replace are looked up, in chunks of
+        `UPSERT_LOOKUP_CHUNK` so one large batch doesn't build one enormous boolean query. Errors
+        are left to propagate: a lookup that quietly came back empty would read as "nothing indexed
+        yet" and let the merge discard what every one of these documents had accumulated.
+        """
+
+        searcher = index.searcher()
+        if not ids or not searcher.num_docs:
+            return {}
+
+        found = {}
+        for start in range(0, len(ids), UPSERT_LOOKUP_CHUNK):
+            chunk = ids[start : start + UPSERT_LOOKUP_CHUNK]
+            query = tantivy.Query.boolean_query(
+                [
+                    (tantivy.Occur.Should, tantivy.Query.term_query(self._schema, self.ID_FIELD, doc_id))
+                    for doc_id in chunk
+                ]
+            )
+            result = searcher.search(query, limit=len(chunk))
+            for score, address in result.hits:
+                hit = self._to_hit(searcher.doc(address), score)
+                found[str(hit[self.ID_FIELD])] = hit
+
+        return found
 
     def delete_documents(self, ids: list[str]) -> int:
         """Delete documents matching the given ID_FIELD values; returns the count requested."""
@@ -318,6 +375,16 @@ class SearchStore:
         """Map a raw source dict to a flat field/value dict. Override to reshape sources."""
 
         return source
+
+    def merge_document(self, document: dict, existing: dict | None) -> dict:
+        """Reconcile a document with the one it replaces, or None if the index doesn't hold one.
+
+        Called for every upsert when MERGE_ON_UPSERT is set; override to carry state across
+        re-indexing. `existing` holds the stored fields of the indexed document, so only stored
+        fields survive into a merge.
+        """
+
+        return document
 
     @property
     def _lockname(self) -> str:

--- a/suite/tests/test_data_store.py
+++ b/suite/tests/test_data_store.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+"""``DataStore.set_many``'s newness contract: storing a batch reports which of it the store did not
+already hold, decided inside the transaction that writes it — so of two writers racing to store the
+same key, exactly one is told it was theirs to store."""
+
+import shutil
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from enum import Enum
+
+from suite.store.data_store import DataStore
+
+
+class Thing(Enum):
+    """An entity to scope test keys under; the store only reads `.value` off it."""
+
+    THING = "thing"
+
+
+class SetMany(unittest.TestCase):
+    """``set_many`` — stores the batch, and says which of it the store had never held."""
+
+    def setUp(self):
+        # A directory per test: LMDB environments are cached per path for the life of the process.
+        self.path = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.path, ignore_errors=True)
+        self.store = DataStore(base_path=self.path, namespace=("test", "data-store"))
+
+    def test_every_key_of_a_fresh_batch_is_new(self):
+        self.assertEqual(self.store.set_many(Thing.THING, {"a": 1, "b": 2}), {"a", "b"})
+
+    def test_a_key_already_stored_is_not_new_again(self):
+        self.store.set_many(Thing.THING, {"a": 1})
+
+        self.assertEqual(self.store.set_many(Thing.THING, {"a": 2, "b": 3}), {"b"})
+
+    def test_a_key_that_isnt_new_is_still_written(self):
+        self.store.set_many(Thing.THING, {"a": 1})
+        self.store.set_many(Thing.THING, {"a": 2})
+
+        self.assertEqual(self.store.get(Thing.THING, "a"), 2)
+
+    def test_an_empty_batch_stores_nothing_and_is_new_in_no_part(self):
+        self.assertEqual(self.store.set_many(Thing.THING, {}), set())
+
+    def test_only_one_of_two_writers_racing_on_a_key_is_told_it_was_new(self):
+        # The race this contract exists to close. Checking before writing cannot settle it: both
+        # writers look before either commits, both are told the key is new, and a caller that acts
+        # on that — indexing a message's addresses, say — does it twice. Deciding inside the write
+        # hands it to whichever transaction LMDB serializes first.
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            results = list(pool.map(lambda n: self.store.set_many(Thing.THING, {"a": n}), range(8)))
+
+        self.assertEqual(sum("a" in result for result in results), 1)
+
+    def test_a_racing_batch_is_split_between_its_writers(self):
+        # Every key is claimed, and claimed once, however the writers interleave.
+        batches = [{"a": 1, "b": 1}, {"b": 2, "c": 2}, {"c": 3, "a": 3}]
+
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            results = list(pool.map(lambda batch: self.store.set_many(Thing.THING, batch), batches))
+
+        claimed = [key for result in results for key in result]
+        self.assertEqual(sorted(claimed), ["a", "b", "c"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/suite/tests/test_search_store.py
+++ b/suite/tests/test_search_store.py
@@ -1,15 +1,16 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
-"""``SearchStore``'s two search contracts: an unbounded fetch returns every match, reading the index
-once so its own count still describes what it fetched, and the deprecated ``search_phrase_prefix``
-still searches for a phrase rather than quietly becoming the looser search that replaced it."""
+"""``SearchStore``'s search and upsert contracts: an unbounded fetch returns every match, reading
+the index once so its own count still describes what it fetched, the deprecated
+``search_phrase_prefix`` still searches for a phrase rather than quietly becoming the looser search
+that replaced it, and a store that merges on upsert sees the document it is about to replace."""
 
 import unittest
 from unittest import mock
 
 import tantivy
 
-from suite.store.search_store import UNBOUNDED_FETCH_PAGE, SearchStore
+from suite.store.search_store import UNBOUNDED_FETCH_PAGE, UPSERT_LOOKUP_CHUNK, SearchStore
 
 
 class FakeResult:
@@ -129,6 +130,132 @@ class SearchPhrasePrefix(unittest.TestCase):
             self.assertEqual(SearchStore.search_phrase_prefix(store, ["", None]), ([], 0))
 
         store._run_search.assert_not_called()
+
+
+class MergeOnUpsert(unittest.TestCase):
+    """``index_documents`` — a merging store reads what it replaces; every other store doesn't."""
+
+    def index(self, sources, merge_on_upsert=True, existing=None):
+        """Upsert `sources`; returns the store, the index, and the documents handed to the writer."""
+
+        writer = mock.Mock()
+        index = mock.Mock()
+        index.writer.return_value = writer
+
+        store = mock.Mock(spec=SearchStore)
+        store.ID_FIELD = "id"
+        store.MERGE_ON_UPSERT = merge_on_upsert
+        store._open.return_value = index
+        store.to_document.side_effect = dict
+        store._existing_documents.return_value = existing or {}
+        store._to_tantivy_document.side_effect = lambda document: document
+        store.merge_document.side_effect = lambda document, replaced: {**document, "replaced": replaced}
+
+        with mock.patch("suite.store.search_store.write_lock"):
+            SearchStore.index_documents(store, sources)
+
+        return store, index, [call.args[0] for call in writer.add_document.call_args_list]
+
+    def test_the_document_being_replaced_is_handed_to_the_merge(self):
+        replaced = {"id": "jane@example.com", "count": 7}
+        _store, _index, written = self.index(
+            [{"id": "jane@example.com"}], existing={"jane@example.com": replaced}
+        )
+
+        self.assertEqual(written, [{"id": "jane@example.com", "replaced": replaced}])
+
+    def test_a_document_the_index_doesnt_hold_merges_against_nothing(self):
+        _store, _index, written = self.index([{"id": "jane@example.com"}])
+
+        self.assertEqual(written, [{"id": "jane@example.com", "replaced": None}])
+
+    def test_only_the_ids_being_upserted_are_looked_up(self):
+        store, _index, _written = self.index([{"id": "jane@example.com"}, {"id": "john@example.com"}])
+
+        ids = store._existing_documents.call_args.args[1]
+        self.assertEqual(ids, ["jane@example.com", "john@example.com"])
+
+    def test_the_lookup_reads_an_index_reloaded_first(self):
+        # Another worker may have committed since this index was opened; merging onto a stale view
+        # of its documents would drop whatever it carried forward.
+        _store, index, _written = self.index([{"id": "jane@example.com"}])
+
+        self.assertEqual(index.reload.call_count, 1)
+
+    def test_a_store_that_doesnt_merge_reads_nothing(self):
+        store, index, written = self.index([{"id": "jane@example.com"}], merge_on_upsert=False)
+
+        store._existing_documents.assert_not_called()
+        store.merge_document.assert_not_called()
+        index.reload.assert_not_called()
+        self.assertEqual(written, [{"id": "jane@example.com"}])
+
+    def test_a_batch_holding_one_id_twice_merges_it_onto_itself(self):
+        # Both would otherwise merge against the same indexed document and the second would
+        # overwrite the first, losing whatever it carried forward.
+        _store, _index, written = self.index([{"id": "jane@example.com"}, {"id": "jane@example.com"}])
+
+        self.assertEqual(
+            written,
+            [{"id": "jane@example.com", "replaced": {"id": "jane@example.com", "replaced": None}}],
+        )
+
+    def test_a_source_without_an_id_is_skipped_before_it_is_looked_up(self):
+        store, _index, written = self.index([{"id": None}, {"id": "jane@example.com"}])
+
+        self.assertEqual(store._existing_documents.call_args.args[1], ["jane@example.com"])
+        self.assertEqual(written, [{"id": "jane@example.com", "replaced": None}])
+
+
+class ExistingDocuments(unittest.TestCase):
+    """``_existing_documents`` — the indexed documents for a batch of IDs, keyed by ID."""
+
+    def lookup(self, ids, hits=(), num_docs=5):
+        """Look `ids` up against an index holding `hits`; returns the documents and the searcher."""
+
+        searcher = mock.Mock()
+        searcher.num_docs = num_docs
+        searcher.search.return_value = FakeResult(list(hits), len(hits))
+        searcher.doc.side_effect = lambda address: address
+
+        index = mock.Mock()
+        index.searcher.return_value = searcher
+
+        schema_builder = tantivy.SchemaBuilder()
+        schema_builder.add_text_field("id", stored=True, tokenizer_name="raw")
+
+        store = mock.Mock(spec=SearchStore)
+        store.ID_FIELD = "id"
+        store._schema = schema_builder.build()
+        store._to_hit.side_effect = lambda document, _score: document
+
+        return SearchStore._existing_documents(store, index, ids), searcher
+
+    def test_documents_come_back_keyed_by_id(self):
+        jane = {"id": "jane@example.com", "count": 2}
+        found, _searcher = self.lookup(["jane@example.com"], hits=[(1.0, jane)])
+
+        self.assertEqual(found, {"jane@example.com": jane})
+
+    def test_an_id_the_index_doesnt_hold_is_simply_absent(self):
+        found, _searcher = self.lookup(["jane@example.com"])
+
+        self.assertEqual(found, {})
+
+    def test_an_empty_index_is_never_searched(self):
+        found, searcher = self.lookup(["jane@example.com"], num_docs=0)
+
+        self.assertEqual(found, {})
+        searcher.search.assert_not_called()
+
+    def test_a_large_batch_is_looked_up_in_chunks(self):
+        # One query per chunk, so upserting thousands of documents doesn't build one boolean query
+        # with thousands of clauses in it.
+        ids = [f"user{n}@example.com" for n in range(UPSERT_LOOKUP_CHUNK + 1)]
+        _found, searcher = self.lookup(ids)
+
+        limits = [call.kwargs["limit"] for call in searcher.search.call_args_list]
+        self.assertEqual(limits, [UPSERT_LOOKUP_CHUNK, 1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Recipient suggestions are ranked by how well the query matches a name or address (#571), with no notion of who you actually write to. For `user`, two equally good matches — `user@example.com` and `user@example.org` — are separated only by address length and alphabetical order, so the address you mail daily can sit below one you mailed once.

### What changed

Every indexed address now carries a `count`: sightings past the first, so a new address is inserted at `0` and each later one adds to it. It slots into `_relevance_key` **after** the match-quality tuple and before the named/shortest tie-breaks, so it only ever separates matches the query cannot tell apart — a much-mailed "Jane Doeringer" still ranks below "John Doe" for `doe`, and a busy address at `example.com` never outranks a name match for `exa`.

Accumulating requires an upsert to read the count it replaces, so `SearchStore` grows a `merge_document(document, existing)` hook behind a `MERGE_ON_UPSERT` flag. The read runs under the same write lock as the write — the Redis lock is not reentrant, so a subclass could not take it itself, and reading outside it would lose increments to a concurrent upsert of the same address. Stores that leave the flag off take exactly the old path.

Two counting rules keep the tally meaningful:

- **Every occurrence in a batch counts, not every call.** One batch can carry a page of messages and a rebuild feeds in hundreds, so collapsing them would tally how the caller batched its work rather than how much mail the address is on.
- **Messages count, contact cards do not.** A contact sync re-indexes the whole address book; counting it would lift contacts you never write to above the addresses you do. Contact cards still upsert, refreshing names, with no bump.

### Caching is what marks a message indexed

Only messages the cache has not held before are indexed — otherwise a message re-fetched after a flag change would score sync churn as correspondence. Three things follow from leaning on the cache that way, and each is handled:

**Which messages are new is decided by the write itself.** `DataStore.set_many` returns the keys the store did not already hold, found by the cursor as it writes each one. Asking first and writing second cannot settle it — two fetches racing to cache the same message both look before either commits, both are told it is new, and both count its addresses. Measured with eight concurrent writers on one key, the check-then-write shape told eight of them they had stored it first; deciding inside the write tells exactly one, since LMDB serializes writers. It also drops a transaction from the caching path rather than adding one.

**A message that failed to index does not stay cached.** Otherwise the failure would be permanent — the message would never be offered as new again, and the people on it could be missing from suggestions until someone rebuilt the index by hand. Indexing can fail for ordinary reasons (a write lock not acquired within 30s, a write error), so the batch that did not index is dropped from the cache and picked up on the next fetch, at the cost of one round trip to a server that still has the message. The drop is unconditional even if another request re-cached one of those messages meanwhile: that request skipped indexing on the same grounds, so sparing its copy would leave the message cached with nobody left to index it. Its copy mirrors the server, which flag changes write to first, so dropping it costs a re-fetch rather than state.

**If the store will not give the message up either, a rebuild is queued.** That is the one case nothing local can fix, so it goes to `rebuild_email_address_index`, which reconciles the whole index against the cache and dedupes per account. Both failures are logged, and a repair that cannot even be queued still never reaches the caller.

Adding a field changes the index's schema hash, which wipes each account's index the next time it is opened, so `rebuild_email_address_indexes` is bumped to `#3` to re-run.

### Known, deliberate drift

Counts rank addresses against each other; they are not a ledger. A message evicted and re-fetched counts again, clearing the message cache lets a re-sync count everything a second time, and your own address — on every message you send or receive — accumulates the highest count of all. `rebuild_email_address_index` recomputes counts from the cache whenever they need resetting. Each is documented where someone would trip over it.

### Testing

- 50 unit tests on the index (tally, merge, name preservation, ranking), 18 on the search store (merge hook, chunked lookup, duplicate-ID merge chaining), 13 on message caching (what gets indexed, what gets rolled back, what gets escalated) and 6 on the data store — including a threaded test asserting exactly one of eight racing writers is told a key was new.
- Full mail suite green: 23 modules, 191 tests.
- Against a live index: first insert → `0`, three more sightings → `3`, an uncounted upsert leaves the count and keeps a name a bare sighting would have erased, and `search_email_addresses("user")` returns `user@example.com` (3) ahead of `user@example.org` (1).
- Recovery, with the real store and index: an indexing failure leaves the message uncached and the index empty; the next fetch caches and indexes it at `0`; a later re-cache does not count it again. With the rollback failing too, the message stays cached and unindexed — and the queued rebuild, when run, indexes it.
- 1500 addresses in one call (a real rebuild crosses the 1000-ID chunk boundary): 1200 seen twice land at `2`, the other 300 at `1`, none lost at the boundary.
- Cost at 20k addresses: indexing 40×500 batches 2.75s fresh, 3.71s when every document already exists (~24ms per batch for the merge lookup). Search unchanged — 89ms for the pathological single-letter query, 1.1ms for a selective one.