### PR TITLE
fix(mail): show replies that land in already-loaded threads

### DIFF
--- a/frontend/src/apps/mail/composables/mergeByReceivedAt.test.ts
+++ b/frontend/src/apps/mail/composables/mergeByReceivedAt.test.ts
@@ -2,13 +2,15 @@ import { describe, expect, it } from 'vitest'
 
 import type { Thread } from '@/apps/mail/types'
 
-import { mergeByReceivedAt } from './usePaginatedThreads'
+import { mergeByReceivedAt, refreshLoadedThreads } from './usePaginatedThreads'
 
 // Only received_at and thread_id matter to the merge.
 const thread = (thread_id: string, received_at: string) =>
 	({ thread_id, received_at }) as unknown as Thread
 
 const ids = (threads: Thread[]) => threads.map((t) => t.thread_id)
+
+const key = (t: Thread) => t.thread_id
 
 describe('mergeByReceivedAt', () => {
 	it('prepends genuinely new mail', () => {
@@ -42,5 +44,65 @@ describe('mergeByReceivedAt', () => {
 		expect(ids(mergeByReceivedAt([], rows))).toEqual(['a'])
 		expect(ids(mergeByReceivedAt(rows, []))).toEqual(['a'])
 		expect(mergeByReceivedAt([], [])).toEqual([])
+	})
+})
+
+describe('refreshLoadedThreads', () => {
+	// The reason this exists: a reply lands in a thread that's already on screen. It never appears as
+	// a new row, so the loaded copy has to be swapped for the server's.
+	it('takes the server copy of a thread that changed', () => {
+		const stale = thread('a', '2026-07-29 10:00:00')
+		const updated = thread('a', '2026-07-30 12:00:00')
+		const loaded = [stale, thread('b', '2026-07-28 10:00:00')]
+
+		const result = refreshLoadedThreads(loaded, [updated], key)
+
+		expect(result[0]).toBe(updated)
+		expect(result[0]).not.toBe(stale)
+	})
+
+	it('moves a replied-to thread up to its new date', () => {
+		const loaded = [
+			thread('a', '2026-07-30 10:00:00'),
+			thread('b', '2026-07-29 10:00:00'),
+			thread('c', '2026-07-28 10:00:00'),
+		]
+		// c just got a reply, so it is now the newest.
+		const freshWindow = [thread('c', '2026-07-30 18:00:00')]
+
+		expect(ids(refreshLoadedThreads(loaded, freshWindow, key))).toEqual(['c', 'a', 'b'])
+	})
+
+	it('leaves rows past the window alone', () => {
+		const older = thread('old', '2026-06-01 10:00:00')
+		const loaded = [thread('a', '2026-07-30 10:00:00'), older]
+
+		const result = refreshLoadedThreads(loaded, [thread('a', '2026-07-30 10:00:00')], key)
+
+		expect(result[1]).toBe(older)
+	})
+
+	it('holds order when nothing changed', () => {
+		const loaded = [
+			thread('a', '2026-07-30 10:00:00'),
+			thread('b', '2026-07-30 10:00:00'),
+			thread('c', '2026-07-29 10:00:00'),
+		]
+
+		expect(ids(refreshLoadedThreads(loaded, loaded, key))).toEqual(['a', 'b', 'c'])
+	})
+
+	// The merged All Inboxes list keys by account + thread id, since one thread id can recur across
+	// accounts — a refresh must not let one account's copy overwrite the other's.
+	it('respects a composite thread key', () => {
+		const composite = (t: Thread) => `${(t as unknown as { account: string }).account}|${t.thread_id}`
+		const rowA = { ...thread('t1', '2026-07-29 10:00:00'), account: 'a1' } as unknown as Thread
+		const rowB = { ...thread('t1', '2026-07-28 10:00:00'), account: 'a2' } as unknown as Thread
+		const updatedA = { ...thread('t1', '2026-07-30 10:00:00'), account: 'a1' } as unknown as Thread
+
+		const result = refreshLoadedThreads([rowA, rowB], [updatedA], composite)
+
+		expect(result[0]).toBe(updatedA)
+		expect(result[1]).toBe(rowB)
 	})
 })

--- a/frontend/src/apps/mail/composables/usePaginatedThreads.ts
+++ b/frontend/src/apps/mail/composables/usePaginatedThreads.ts
@@ -51,6 +51,26 @@ export const mergeByReceivedAt = (fresh: Thread[], loaded: Thread[]): Thread[] =
 	return [...merged, ...fresh.slice(f), ...loaded.slice(l)]
 }
 
+/**
+ * Re-derives the loaded rows from the newest window: a thread in both takes the server's copy, since
+ * a reply into an already-loaded thread changes that row (another message, a newer received_at, unread
+ * again) without ever arriving as a new one. Rows past the window keep their loaded copy — the window
+ * says nothing about them.
+ *
+ * The result is re-sorted: a thread that just got a reply carries a newer received_at than the loaded
+ * list was ordered by, and belongs further up. The sort is stable, so untouched rows keep their order.
+ */
+export const refreshLoadedThreads = (
+	loaded: Thread[],
+	freshWindow: Thread[],
+	threadKey: (thread: Thread) => string,
+): Thread[] => {
+	const updated = new Map(freshWindow.map((thread) => [threadKey(thread), thread]))
+	return loaded
+		.map((thread) => updated.get(threadKey(thread)) ?? thread)
+		.sort((a, b) => (a.received_at === b.received_at ? 0 : a.received_at > b.received_at ? -1 : 1))
+}
+
 /** The shape of a reset resource this reads and writes — createResource satisfies it. */
 export interface ThreadListResource {
 	data?: Thread[]
@@ -174,8 +194,9 @@ export const usePaginatedThreads = ({
 
 	/**
 	 * Called when a first-window fetch resolves. Two modes:
-	 * - refresh: keep the loaded rows, prepend only threads not already loaded (new mail), and hold
-	 *   the reader's scroll position (re-anchored by the height the prepended rows added).
+	 * - refresh: keep the loaded rows, merge in threads not already loaded and refresh the ones that
+	 *   are (new mail arrives both ways), and hold the reader's scroll position (re-anchored by the
+	 *   height the merge added above them).
 	 * - reset: reveal the fresh first window and scroll to top (mailbox switch, filter, undo, …).
 	 * Either way, cancel any pending edge navigation.
 	 */
@@ -206,11 +227,15 @@ export const usePaginatedThreads = ({
 				(thread: Thread) =>
 					!existing.has(threadKey(thread)) && !recentlyRemoved.has(threadKey(thread)),
 			)
+			// Threads already loaded are filtered out of `fresh` above, so a reply into one of them
+			// would be dropped on the floor — re-derive those rows from the window instead. Keeping
+			// the snapshot's copy is what left replies invisible until a hard reload.
+			const loaded = refreshLoadedThreads(refreshSnapshot, freshWindow, threadKey)
 			// Date-merge rather than blind prepend. A prepend assumes everything in the newest window
 			// that isn't loaded yet is newer than everything that is — true for one account, false for
 			// the merged list, where a second account's newest mail can be older than the first's oldest
 			// loaded row and would otherwise open a stale date group above today's.
-			resource().data = mergeByReceivedAt(fresh, refreshSnapshot)
+			resource().data = mergeByReceivedAt(fresh, loaded)
 			// Keep the reader where they were: shift scroll by the height the merge added above them. If
 			// they were already at the top, leave them there so the new mail is visible.
 			nextTick(() => {

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -1035,8 +1035,8 @@ const selectActions = computed((): SelectAction[] => [
 // An optimistic removal emptied the list but more threads exist, so a refill is coming once the server
 // mutation lands. Keeps the loading state (not the empty state) during the gap before the refill fetch.
 const refillPending = ref(false)
-// Current mailbox's record (carries total_threads/unread_threads); used by the periodic poll to
-// detect count changes and by the tab title's unread badge.
+// Current mailbox's record (carries total_emails/total_threads/unread_threads); used by the periodic
+// poll to detect count changes and by the tab title's unread badge.
 const mailboxObj = computed(() => mailboxes.data?.find((m) => m.id === mailbox))
 
 // ── Screener banner ─────────────────────────────────────────────────────────────────────────────
@@ -1337,12 +1337,15 @@ watch(
 )
 
 // Periodically refresh the mailbox list (keeps sidebar counts current), then merge in new threads only
-// when the mailbox's thread count actually changed — so a quiet mailbox isn't touched (and the reader
+// when the mailbox's message count actually changed — so a quiet mailbox isn't touched (and the reader
 // isn't disturbed) every 30s.
+//
+// Messages, not threads: a reply landing in a thread that's already here leaves total_threads flat, so
+// gating on that count made this backstop blind to exactly the arrivals the socket exists to deliver.
 const pollForChanges = async () => {
-	const prevTotal = mailboxObj.value?.total_threads
+	const prevTotal = mailboxObj.value?.total_emails
 	await mailboxes.reload()
-	if (mailboxObj.value?.total_threads !== prevTotal) refreshThreads(false)
+	if (mailboxObj.value?.total_emails !== prevTotal) refreshThreads(false)
 }
 
 onMounted(() => {

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -525,9 +525,10 @@ const handleKeydown = (e: KeyboardEvent) => {
 
 // Poll the Screening folder's count and only refetch the (heavier) sender list when it changes — the
 // same cheap-count-then-reload approach the mailbox uses, so a quiet screener isn't reloaded every tick.
+// Counting messages rather than threads: another mail from a sender already waiting here doesn't move
+// the thread count.
 const screeningCount = () =>
-	store.mailboxes.data?.find((m: MailboxData) => m.id === store.mailboxIds.screener)
-		?.total_threads
+	store.mailboxes.data?.find((m: MailboxData) => m.id === store.mailboxIds.screener)?.total_emails
 
 const pollForChanges = async () => {
 	const prev = screeningCount()

--- a/frontend/src/apps/mail/types/index.ts
+++ b/frontend/src/apps/mail/types/index.ts
@@ -201,6 +201,7 @@ export interface MailboxData {
 	name: string
 	id: string
 	role: string | null
+	total_emails: number
 	total_threads: number
 	unread_threads: number
 	_name: string

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -101,7 +101,9 @@ def get_mailboxes(account: str) -> list[dict]:
     if not mailboxes:
         return []
 
-    fields = ["name", "id", "_name", "role", "total_threads", "unread_threads", "subscribed"]
+    # total_emails rides along for the pollers: it moves on a reply into an existing thread, which
+    # total_threads doesn't.
+    fields = ["name", "id", "_name", "role", "total_emails", "total_threads", "unread_threads", "subscribed"]
 
     mailbox_settings = frappe.db.get_all(
         "Mailbox Settings",


### PR DESCRIPTION
A reply arriving in a thread already on screen never showed up. On refresh we filter out threads already loaded as duplicates and keep the copy we had — so the refetched thread was thrown away, and the row kept its old preview, date and read state.

Threads present in both now take the server's copy, and the list is re-sorted so a replied-to thread moves up.

The 30s poll had the same blind spot: it gated on `total_threads`, which doesn't move when a reply joins an existing thread. Now gates on `total_emails`.

Not verified end-to-end (needs a live Stalwart) — worth a manual pass with the socket live and disconnected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)