### PR TITLE
fix(drive): check upload on the parent instead of granting create

### DIFF
--- a/suite/drive/api/permissions.py
+++ b/suite/drive/api/permissions.py
@@ -3,6 +3,7 @@ from frappe.model.document import Document
 
 from suite.drive.utils import (
     FILE_FIELDS,
+    FRAMEWORK_FOLDERS,
     GENERAL_USER,
     GROUP_PREFIX,
     PERMISSION_TYPES,
@@ -263,13 +264,43 @@ def activity_log_has_permission(doc, ptype="read", user=None):
     return ptype in ("read", "select") and bool(user_has_permission(doc.entity, "read", user))
 
 
+def can_create_in_folder(folder: str | None, user: str | None = None):
+    """Whether `user` may add a child to `folder`, which Drive spells `upload`.
+
+    `create` on a File is only meaningful relative to its parent, so it has to be
+    answered against the destination folder rather than the row being inserted -
+    the row has no permissions of its own yet, and its owner (the inserter) would
+    otherwise hold everything on it via the ownership short-circuit above.
+
+    Framework folders are the exception. Core's uploader inserts into `Home` /
+    `Home/Attachments` (`frappe/handler.py`) and `after_file_upload` adopts the
+    row into the uploader's own folder before it is saved; guests, and uploads
+    that never reach that hook, legitimately stay behind. Those two are framework
+    scaffolding rather than anyone's private space, so creating in them stays
+    open. `folder` is likewise still empty here for attachments that let core's
+    `set_folder_name` resolve it - to one of the same two folders - during
+    `validate`, which runs after this check, so treat empty the same way.
+    """
+    user = user or frappe.session.user
+    if not folder or folder in FRAMEWORK_FOLDERS:
+        return True
+    try:
+        return bool(get_user_access_for_user(folder, user).get("upload"))
+    except frappe.DoesNotExistError:
+        # Link validation would reject it during `validate` anyway; denying here
+        # keeps a bad parent from reading as permitted.
+        return False
+
+
 def user_has_permission(doc, ptype, user=None):
     if isinstance(doc, str):
         doc = frappe.get_doc("File", doc)
     if not user:
         user = frappe.session.user
-    if user == "Administrator" or ptype == "create":
+    if user == "Administrator":
         return True
+    if ptype == "create":
+        return can_create_in_folder(doc.get("folder"), user)
     if ptype not in PERMISSION_TYPES:
         # Should ideally deflect to Framework
         ptype = "write"

--- a/suite/drive/api/tests/test_files.py
+++ b/suite/drive/api/tests/test_files.py
@@ -20,6 +20,7 @@ from suite.drive.api.files import (
 )
 from suite.drive.api.list import get_attachments
 from suite.drive.api.permissions import (
+    can_create_in_folder,
     get_general_access,
     get_user_access,
     get_user_access_for_user,
@@ -27,6 +28,7 @@ from suite.drive.api.permissions import (
 )
 from suite.drive.overrides.file import File as DriveFile
 from suite.drive.utils import (
+    FRAMEWORK_FOLDERS,
     GENERAL_USER,
     STATUS_ACTIVE,
     STATUS_TRASHED,
@@ -202,6 +204,60 @@ class TestDriveFilesAPI(IntegrationTestCase):
             frappe.db.get_value("File", backing_file.name, "content_docname"),
             victim_doc.name,
         )
+
+    def test_cannot_create_inside_another_users_folder(self):
+        """`create` used to be granted unconditionally, so the generic REST API
+        (`frappe.client.insert`, core's `/api/method/upload_file`) let any user
+        insert a File with `folder` pointing anywhere - planting content inside a
+        folder they hold no `upload` on. Drive's own endpoints checked `upload`,
+        but nothing checked it behind them."""
+        with self.set_user(OTHER_USER):
+            self.assertFalse(user_has_permission(self.folder, "upload"))
+
+            for values in (
+                {"file_name": "planted.txt", "is_private": 1},
+                {"file_name": "planted", "is_folder": 1},
+            ):
+                with self.assertRaises(frappe.PermissionError):
+                    frappe.get_doc({"doctype": "File", "folder": self.folder.name, **values}).insert()
+
+        self.assertFalse(
+            frappe.db.exists("File", {"folder": self.folder.name, "file_name": ["like", "planted%"]})
+        )
+
+    def test_upload_access_is_enough_to_create(self):
+        """The check is `upload` on the parent, not ownership: a collaborator
+        granted upload keeps `create`, so sharing a folder for contribution still
+        works. Asserted at the hook the framework actually calls on insert."""
+        with self.set_user(OWNER):
+            self.folder.share(user=MEMBER, read=True, upload=True)
+
+        incoming = frappe.get_doc(
+            {
+                "doctype": "File",
+                "folder": self.folder.name,
+                "file_name": f"{frappe.generate_hash(8)}.txt",
+                "is_private": 1,
+            }
+        )
+
+        with self.set_user(MEMBER):
+            self.assertTrue(user_has_permission(self.folder, "upload"))
+            self.assertTrue(user_has_permission(incoming, "create"))
+
+        with self.set_user(OTHER_USER):
+            self.assertFalse(user_has_permission(incoming, "create"))
+
+    def test_framework_upload_flow_still_permitted(self):
+        """Core inserts attachments into `Home`/`Home/Attachments`, and resolves
+        an unset `folder` to one of them in `validate` - after the create check.
+        Denying either would break every attachment upload in the suite."""
+        with self.set_user(OTHER_USER):
+            for folder in (*FRAMEWORK_FOLDERS, None, ""):
+                self.assertTrue(can_create_in_folder(folder))
+
+            # Drive's own flow inserts into the user's own folder.
+            self.assertTrue(can_create_in_folder(get_user_folder(OTHER_USER).name))
 
     def test_site_share_and_guest_public_access(self):
         # Inside a user folder, other site users are denied by default.

--- a/suite/drive/overrides/file.py
+++ b/suite/drive/overrides/file.py
@@ -17,6 +17,7 @@ from suite.drive.api.permissions import (
 from suite.drive.api.product import create_invites
 from suite.drive.utils import (
     ATTACHMENT_CONTENT_DOCTYPE,
+    FRAMEWORK_FOLDERS,
     GENERAL_USER,
     GROUP_PREFIX,
     ROOT_FOLDER,
@@ -32,10 +33,6 @@ from suite.drive.utils import (
     validate_filename,
 )
 from suite.drive.utils.files import S3_URL_PREFIX, FileManager, get_s3_url, storage_key
-
-# Framework-created folders (the site root and its attachments folder);
-# uploads still sitting in them haven't been adopted into a user folder yet.
-FRAMEWORK_FOLDERS = ("Home", "Home/Attachments")
 
 
 class File(FrappeFile):

--- a/suite/drive/utils/__init__.py
+++ b/suite/drive/utils/__init__.py
@@ -42,6 +42,10 @@ PREVIOUS_TEAMS_FOLDER = "Previous Teams"
 # What a user's own folder is called back to them.
 HOME_LABEL = "Home"
 
+# Framework-created folders (the site root and its attachments folder);
+# uploads still sitting in them haven't been adopted into a user folder yet.
+FRAMEWORK_FOLDERS = ("Home", "Home/Attachments")
+
 PERMISSION_TYPES = ["read", "comment", "share", "upload", "write"]
 
 


### PR DESCRIPTION
`user_has_permission` is the `has_permission` hook for File (`suite/hooks.py`), so it answers every generic-API create - `frappe.client.insert`, core's and Mail's `upload_file`. It returned True for `create` unconditionally, and `ignore_file_permissions = True` means the framework's own File guard is off, so nothing sat behind it.

Drive's own endpoints do check `upload` on the parent (`api/files.py` `upload_file`, `create_folder`), but the generic path skipped them: any authenticated user could insert a File with `folder` pointing at a folder they hold no `upload` on, planting content inside someone else's private Drive - and keeping full control of the row afterwards, since the inserter owns it and owners short-circuit to every permission.

Answer `create` against the destination folder, which is the only place it is meaningful. Framework folders (`Home`, `Home/Attachments`) and an unset `folder` stay open: core inserts attachments there and Drive adopts them into the uploader's own folder in `after_file_upload`, guests legitimately stay behind, and `set_folder_name` resolves an empty folder to one of the same two during `validate`, which runs after this check.

Drive's own creation paths go through `create_drive_file` / `create_for_doc`, which insert with `ignore_permissions=True`, so they are unaffected.