### PR TITLE
fix(drive): keep app-owned folders open for create

### DIFF
--- a/suite/drive/api/permissions.py
+++ b/suite/drive/api/permissions.py
@@ -2,6 +2,7 @@ import frappe
 from frappe.model.document import Document
 
 from suite.drive.utils import (
+    APP_FOLDERS,
     FILE_FIELDS,
     FRAMEWORK_FOLDERS,
     GENERAL_USER,
@@ -280,9 +281,14 @@ def can_create_in_folder(folder: str | None, user: str | None = None):
     open. `folder` is likewise still empty here for attachments that let core's
     `set_folder_name` resolve it - to one of the same two folders - during
     `validate`, which runs after this check, so treat empty the same way.
+
+    `APP_FOLDERS` are open for the same reason: they sit outside Drive's tree and
+    belong to an app rather than to a user, so adding to one takes nothing from
+    anybody. Access to what lands there is still per row - the uploader owns it,
+    and nobody else gets it without a share.
     """
     user = user or frappe.session.user
-    if not folder or folder in FRAMEWORK_FOLDERS:
+    if not folder or folder in FRAMEWORK_FOLDERS or folder in APP_FOLDERS:
         return True
     try:
         return bool(get_user_access_for_user(folder, user).get("upload"))

--- a/suite/drive/api/tests/test_files.py
+++ b/suite/drive/api/tests/test_files.py
@@ -28,6 +28,7 @@ from suite.drive.api.permissions import (
 )
 from suite.drive.overrides.file import File as DriveFile
 from suite.drive.utils import (
+    APP_FOLDERS,
     FRAMEWORK_FOLDERS,
     GENERAL_USER,
     STATUS_ACTIVE,
@@ -258,6 +259,32 @@ class TestDriveFilesAPI(IntegrationTestCase):
 
             # Drive's own flow inserts into the user's own folder.
             self.assertTrue(can_create_in_folder(get_user_folder(OTHER_USER).name))
+
+    def test_app_folder_upload_still_permitted(self):
+        """Mail's compose uploads name `Home/Frappe Mail` explicitly. It is an
+        app-owned bucket outside Drive's tree, created by Administrator at
+        install, so no user holds `upload` on it - denying it broke every
+        attachment sent from the Mail UI."""
+        for folder in APP_FOLDERS:
+            self.assertTrue(frappe.db.exists("File", folder), f"{folder} should exist")
+
+            with self.set_user(OTHER_USER):
+                self.assertFalse(get_user_access_for_user(folder, OTHER_USER).get("upload"))
+                self.assertTrue(can_create_in_folder(folder))
+
+                attachment = frappe.get_doc(
+                    {
+                        "doctype": "File",
+                        "folder": folder,
+                        "file_name": f"{frappe.generate_hash(8)}.txt",
+                        "is_private": 1,
+                        "content": "attachment contents",
+                    }
+                ).insert()
+
+            # What lands there stays owner-scoped: the bucket is shared, the rows aren't.
+            with self.set_user(MEMBER):
+                self.assertFalse(user_has_permission(attachment, "read"))
 
     def test_site_share_and_guest_public_access(self):
         # Inside a user folder, other site users are denied by default.

--- a/suite/drive/utils/__init__.py
+++ b/suite/drive/utils/__init__.py
@@ -46,6 +46,14 @@ HOME_LABEL = "Home"
 # uploads still sitting in them haven't been adopted into a user folder yet.
 FRAMEWORK_FOLDERS = ("Home", "Home/Attachments")
 
+# App-created buckets under the framework root, outside Drive's own tree
+# (`ROOT_FOLDER` / `USERS_FOLDER`). Like the framework folders they are shared
+# scaffolding rather than anyone's private space, so any user may add to them -
+# but unlike those, what lands here stays put instead of being adopted into a
+# user folder. Mail's compose attachments go to `Home/Frappe Mail`
+# (`suite/mail/install.py`).
+APP_FOLDERS = ("Home/Frappe Mail",)
+
 PERMISSION_TYPES = ["read", "comment", "share", "upload", "write"]
 
 


### PR DESCRIPTION
Uploading any attachment or inline image from the Mail UI fails with:

```
frappe.exceptions.PermissionError
You need the 'create' permission on File to perform this action.
  File "apps/suite/suite/mail/api/mail.py", line 1701, in upload_file
    ).save(ignore_permissions=ignore_permissions)
```

### Cause

#578 made `can_create_in_folder` answer File `create` against the destination folder's `upload` right, leaving only `Home` / `Home/Attachments` open. The compose editor uploads with `folder: 'Home/Frappe Mail'` (`ComposeMailEditor.vue`), a folder created by Administrator in `suite/mail/install.py` — no ordinary user holds `upload` on it, so the insert is denied.

On a real site, before the fix:

```
can_create_in_folder("Home/Frappe Mail", <mail user>) -> False
get_user_access_for_user(...)                          -> {'read': 0, ..., 'upload': 0, 'type': 'guest'}
```

The machine-facing `suite.mail.api.outbound.upload_attachment` was unaffected — it goes through `save_file`, which inserts with `ignore_permissions`.

### Fix

`Home/Frappe Mail` is app scaffolding outside Drive's own tree (`Drive` / `Users`), not anyone's private space: adding to it takes nothing from anybody, and what lands there stays owner-scoped because access is answered per row. So it joins the open set instead of the check being weakened.

It gets its own `APP_FOLDERS` tuple rather than widening `FRAMEWORK_FOLDERS`, because those two also mean "not adopted into a user folder yet" to `after_file_upload`, which would otherwise move mail attachments into the uploader's Drive folder.

#578's protection is unchanged — planting a file inside another user's folder is still denied.

### Testing

- New `test_app_folder_upload_still_permitted`: a user with no `upload` on the folder can insert there, and the row is still unreadable by another user.
- `test_cannot_create_inside_another_users_folder` and the rest of `suite.drive.api.tests.test_files` (25) pass, as do `suite.mail.tests.test_mail_inbound_outbound_api` (6).
- Verified on a live site: inserting a File into `Home/Frappe Mail` as a regular mail user with `ignore_permissions=False` now succeeds.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/frappe/codesmith/suite/pr/588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789021527&installation_model_id=431961&pr_number=588&repository=frappe%2Fsuite&return_to=https%3A%2F%2Fgithub.com%2Ffrappe%2Fsuite%2Fpull%2F588&signature=1d78234201cfa29a028d02217eded875a2947dbf280ce42e0915b78e2271602a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->