### PR TITLE
fix(drive): enforce the share ceiling on move(), not just share()

### DIFF
--- a/suite/drive/api/tests/test_files.py
+++ b/suite/drive/api/tests/test_files.py
@@ -820,6 +820,35 @@ class TestDriveFilesAPI(IntegrationTestCase):
         with self.set_user("Guest"):
             self.assertFalse(user_has_permission(movable, "read"))
 
+    def test_move_cannot_widen_site_wide_file_to_anonymous_visitors(self):
+        """ "Readable by every site user" and "readable by anyone with the link"
+        are different populations - the second reaches people who never logged
+        in. Comparing them as one bit would read this move as "no wider", since
+        both sides already say "broadly readable", and quietly publish a
+        site-internal file to anonymous visitors."""
+        with self.set_user(OWNER):
+            movable = self.upload(b"move me", "movable.txt")
+            movable.share(user=GENERAL_USER, read=True)
+            movable.share(user=OTHER_USER, write=True)
+
+        with self.set_user("Guest"):
+            self.assertFalse(user_has_permission(movable, "read"))
+
+        with self.set_user(OTHER_USER):
+            link_public_folder = create_drive_file(
+                frappe.generate_hash(8),
+                get_user_folder(OTHER_USER).name,
+                "Folder",
+                lambda file: FileManager().create_folder(file),
+            )
+            link_public_folder.share(read=True)
+
+            with self.assertRaises(frappe.PermissionError):
+                move([movable.name], new_parent=link_public_folder.name)
+
+        with self.set_user("Guest"):
+            self.assertFalse(user_has_permission(movable, "read"))
+
     def test_move_allowed_without_share_rights_when_not_widening_audience(self):
         """The check only fires when the destination would expose the file to
         someone new - ordinary reorganizing by a write-only collaborator, into

--- a/suite/drive/api/tests/test_files.py
+++ b/suite/drive/api/tests/test_files.py
@@ -794,6 +794,91 @@ class TestDriveFilesAPI(IntegrationTestCase):
             self.assertNotEqual(get_new_title(self.file.file_name, self.folder.name), self.file.file_name)
             self.assertEqual(get_new_title("unclaimed.txt", self.folder.name), "unclaimed.txt")
 
+    def test_move_cannot_widen_audience_without_share_rights(self):
+        """share() refuses to hand out access the granter doesn't hold - move()
+        must refuse the same thing. Write-only access lets you edit a file, not
+        decide who else gets to see it; moving it into a folder you've made
+        public would do exactly that."""
+        with self.set_user(OWNER):
+            movable = self.upload(b"move me", "movable.txt")
+            movable.share(user=OTHER_USER, write=True)
+
+        with self.set_user(OTHER_USER):
+            public_folder = create_drive_file(
+                frappe.generate_hash(8),
+                get_user_folder(OTHER_USER).name,
+                "Folder",
+                lambda file: FileManager().create_folder(file),
+            )
+            public_folder.share(read=True)
+
+            self.assertTrue(user_has_permission(movable, "write"))
+            self.assertFalse(user_has_permission(movable, "share"))
+            with self.assertRaises(frappe.PermissionError):
+                move([movable.name], new_parent=public_folder.name)
+
+        with self.set_user("Guest"):
+            self.assertFalse(user_has_permission(movable, "read"))
+
+    def test_move_allowed_without_share_rights_when_not_widening_audience(self):
+        """The check only fires when the destination would expose the file to
+        someone new - ordinary reorganizing by a write-only collaborator, into
+        a folder with no broader audience than the file already has, must keep
+        working."""
+        with self.set_user(OWNER):
+            movable = self.upload(b"move me", "movable.txt")
+            movable.share(user=OTHER_USER, write=True)
+
+        with self.set_user(OTHER_USER):
+            private_folder = create_drive_file(
+                frappe.generate_hash(8),
+                get_user_folder(OTHER_USER).name,
+                "Folder",
+                lambda file: FileManager().create_folder(file),
+            )
+            move([movable.name], new_parent=private_folder.name)
+
+        movable.reload()
+        self.assertEqual(movable.folder, private_folder.name)
+
+    def test_move_allowed_with_share_rights(self):
+        """A collaborator who does hold `share` on the file can already
+        publish it directly via share() - move() into a public folder must
+        stay just as permitted, not a second, stricter gate."""
+        with self.set_user(OWNER):
+            movable = self.upload(b"move me", "movable.txt")
+            movable.share(user=OTHER_USER, write=True, share=True)
+
+        with self.set_user(OTHER_USER):
+            public_folder = create_drive_file(
+                frappe.generate_hash(8),
+                get_user_folder(OTHER_USER).name,
+                "Folder",
+                lambda file: FileManager().create_folder(file),
+            )
+            public_folder.share(read=True)
+            move([movable.name], new_parent=public_folder.name)
+
+        movable.reload()
+        self.assertEqual(movable.folder, public_folder.name)
+
+    def test_owner_can_move_own_file_into_public_folder(self):
+        """Ownership already grants every level, including `share` - moving
+        your own file somewhere more exposed is your call to make."""
+        with self.set_user(OWNER):
+            movable = self.upload(b"move me", "movable.txt")
+            public_folder = create_drive_file(
+                frappe.generate_hash(8),
+                self.home,
+                "Folder",
+                lambda file: FileManager().create_folder(file),
+            )
+            public_folder.share(read=True)
+            move([movable.name], new_parent=public_folder.name)
+
+        movable.reload()
+        self.assertEqual(movable.folder, public_folder.name)
+
 
 class TestDriveSearch(IntegrationTestCase):
     """`search` resolves access per row, so what it scans and what it returns

--- a/suite/drive/overrides/file.py
+++ b/suite/drive/overrides/file.py
@@ -287,13 +287,32 @@ class File(FrappeFile):
             }
         ).insert(ignore_permissions=True)
 
+    # The broad audiences a file can be exposed to, kept apart deliberately.
+    # `link` is the `""` principal - anyone holding the URL, including
+    # unauthenticated visitors. `site` is `$GENERAL` - every logged-in user.
+    # These are different populations, so they must be compared separately: a
+    # file every site user can read is still not readable by anonymous
+    # visitors, and collapsing the two into one bit would let a move from one
+    # into the other pass as "no wider".
+    BROAD_AUDIENCES = ("link", "site")
+
     def _general_access(self, entity_name):
-        """The level a passer-by (anyone with the link) or any other site user
-        would get from `entity_name` alone - its own rows plus whatever it
-        inherits - ignoring anything more specific like an individual share."""
-        public = get_user_access_for_user(entity_name, "Guest")
-        general = generate_upward_path(entity_name, GENERAL_USER)[-1]
-        return {t: bool(public.get(t) or general.get(t)) for t in PERMISSION_TYPES}
+        """What each broad audience gets from `entity_name` alone - its own rows
+        plus whatever it inherits - ignoring anything more specific like an
+        individual share.
+
+        `site` is resolved through `$GENERAL`, whose principal ladder also
+        contains `""` (see `get_principals`), so it is really "link or site".
+        That overlap is harmless here because `link` is measured on its own:
+        widening onto the link audience is caught by the `link` comparison even
+        though `site` cannot distinguish it.
+        """
+        link = get_user_access_for_user(entity_name, "Guest")
+        site = generate_upward_path(entity_name, GENERAL_USER)[-1]
+        return {
+            "link": {t: bool(link.get(t)) for t in PERMISSION_TYPES},
+            "site": {t: bool(site.get(t)) for t in PERMISSION_TYPES},
+        }
 
     def _exposes_more_broadly(self, new_parent):
         """Whether moving into `new_parent` would open this file to a broader
@@ -309,7 +328,11 @@ class File(FrappeFile):
         """
         current = self._general_access(self.name)
         destination = self._general_access(new_parent)
-        return any(destination[t] and not current[t] for t in PERMISSION_TYPES)
+        return any(
+            destination[audience][t] and not current[audience][t]
+            for audience in self.BROAD_AUDIENCES
+            for t in PERMISSION_TYPES
+        )
 
     @_update_modified
     def move(self, new_parent=None):

--- a/suite/drive/overrides/file.py
+++ b/suite/drive/overrides/file.py
@@ -20,6 +20,7 @@ from suite.drive.utils import (
     FRAMEWORK_FOLDERS,
     GENERAL_USER,
     GROUP_PREFIX,
+    PERMISSION_TYPES,
     ROOT_FOLDER,
     STATUS_ACTIVE,
     STATUS_REMOVED,
@@ -286,6 +287,30 @@ class File(FrappeFile):
             }
         ).insert(ignore_permissions=True)
 
+    def _general_access(self, entity_name):
+        """The level a passer-by (anyone with the link) or any other site user
+        would get from `entity_name` alone - its own rows plus whatever it
+        inherits - ignoring anything more specific like an individual share."""
+        public = get_user_access_for_user(entity_name, "Guest")
+        general = generate_upward_path(entity_name, GENERAL_USER)[-1]
+        return {t: bool(public.get(t) or general.get(t)) for t in PERMISSION_TYPES}
+
+    def _exposes_more_broadly(self, new_parent):
+        """Whether moving into `new_parent` would open this file to a broader
+        audience (anyone with the link, or every site user) than it already has
+        where it sits now.
+
+        `share()` requires `share` rights before handing any single grantee
+        access this file's owner doesn't already extend. Moving into a
+        publicly- or site-wide-shared folder is the same act - it hands that
+        same audience access - so it needs the same rights; without this,
+        `move()` is a side door around the check `share()` enforces on the
+        front door.
+        """
+        current = self._general_access(self.name)
+        destination = self._general_access(new_parent)
+        return any(destination[t] and not current[t] for t in PERMISSION_TYPES)
+
     @_update_modified
     def move(self, new_parent=None):
         """
@@ -306,6 +331,16 @@ class File(FrappeFile):
             )
         elif not user_has_permission(new_parent, "upload") or not user_has_permission(self, "write"):
             frappe.throw("You don't have permission to move this file.", frappe.PermissionError)
+        elif (
+            new_parent != self.folder
+            and self._exposes_more_broadly(new_parent)
+            and not user_has_permission(self, "share")
+        ):
+            frappe.throw(
+                "Moving this file here would expose it to people who can't already see it. "
+                "You need share access to do that.",
+                frappe.PermissionError,
+            )
 
         if not frappe.db.get_value("File", new_parent, "is_folder"):
             frappe.throw(


### PR DESCRIPTION
share() refuses to grant a level of access the granter doesn't hold themselves - a user with only read+write on a file can't turn around and grant someone else write. move() enforced no equivalent: it only checked `upload` on the destination and `write` on the file, so a user with write-only access could move that file into a folder they'd made public (or shared site-wide) and expose it to that whole audience - the exact escalation share() exists to block, reachable through a side door.

Add File._exposes_more_broadly(), comparing the broad-audience access (anyone with the link, or every site user) the file already has against what the destination folder would grant. move() now requires `share` on the file whenever the destination would widen that audience - mirroring share()'s own ceiling, applied to the audience a folder move creates rather than an explicit grantee. Moves that don't widen the audience (the common case - reorganizing files you can already write to) are untouched.

5 regression tests; verified test_move_cannot_widen_audience_without_share_rights fails without the check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/frappe/codesmith/suite/pr/590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789027240&installation_model_id=431961&pr_number=590&repository=frappe%2Fsuite&return_to=https%3A%2F%2Fgithub.com%2Ffrappe%2Fsuite%2Fpull%2F590&signature=fbe772e7eaa33bea6c1c41d619fa9c0c257cef261c6e4e8ec55f7d997a76963b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->