### PR TITLE
fix(calendar): move the end time when the start time changes

### DIFF
--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -269,8 +269,10 @@ let previousStart = null
 
 watch(show, (val) => {
 	if (!val) return
-	previousStart = null
 	Object.assign(event, getEventData())
+	// Reopening the same event leaves the start untouched, so the watcher below
+	// won't fire — seed the baseline here or the first edit has nothing to move from.
+	previousStart = { date: event.startDate, time: event.startTime }
 	originalParams = JSON.parse(JSON.stringify(eventParams.value))
 })
 

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -56,6 +56,9 @@ const getEventData = () => {
 	}
 }
 
+// How long an event runs when the end hasn't been set by hand.
+const DEFAULT_DURATION_MINUTES = 60
+
 const getDefaultEventData = () => {
 	const startTime = selectedEvent?.time
 		? dayjs(selectedEvent.time, 'h a').format('HH:mm')
@@ -71,7 +74,7 @@ const getDefaultEventData = () => {
 		startDate: dayjs(selectedEvent.date).format('YYYY-MM-DD'),
 		startTime,
 		endDate: dayjs(selectedEvent.date).format('YYYY-MM-DD'),
-		endTime: dayjs(startTime, 'HH:mm').add(1, 'hour').format('HH:mm'),
+		endTime: dayjs(startTime, 'HH:mm').add(DEFAULT_DURATION_MINUTES, 'minute').format('HH:mm'),
 		locations: [],
 		links: [],
 		alerts: [],
@@ -260,11 +263,44 @@ const meetLinkDisplay = computed(() =>
 
 // --- Watchers ---
 
+// Moving the start drags the end along, keeping the gap the user set. A gap that
+// hasn't been set — or one the start has overtaken — falls back to the default.
+let previousStart = null
+
 watch(show, (val) => {
 	if (!val) return
+	previousStart = null
 	Object.assign(event, getEventData())
 	originalParams = JSON.parse(JSON.stringify(eventParams.value))
 })
+
+watch(
+	() => [event.startDate, event.startTime],
+	([startDate, startTime]) => {
+		const previous = previousStart
+		previousStart = { date: startDate, time: startTime }
+
+		if (!previous?.date || !startDate) return
+		if (previous.date === startDate && previous.time === startTime) return
+
+		if (event.isAllDay) {
+			const days = dayjs(event.endDate).diff(dayjs(previous.date), 'day')
+			event.endDate = dayjs(startDate).add(Math.max(days, 0), 'day').format('YYYY-MM-DD')
+			return
+		}
+
+		const start = dayjs(`${startDate}T${startTime}`)
+		if (!start.isValid()) return
+
+		const gap = dayjs(`${event.endDate}T${event.endTime}`).diff(
+			dayjs(`${previous.date}T${previous.time}`),
+			'minute',
+		)
+		const end = start.add(gap > 0 ? gap : DEFAULT_DURATION_MINUTES, 'minute')
+		event.endDate = end.format('YYYY-MM-DD')
+		event.endTime = end.format('HH:mm')
+	},
+)
 
 const showRepeatSettings = ref(false)
 watch(showRepeatSettings, (val) => {


### PR DESCRIPTION
Editing **Starts** left **Ends** alone, so setting a 2 pm start next to an 11 am end was possible — and the only feedback was a greyed-out Save.

Changing the start now drags the end along, keeping whatever gap was already set. If there isn't a sensible one (untouched, cleared, or the start has overtaken the end) it falls back to an hour. All-day events keep their day span instead.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/frappe/codesmith/suite/pr/593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789032950&installation_model_id=431961&pr_number=593&repository=frappe%2Fsuite&return_to=https%3A%2F%2Fgithub.com%2Ffrappe%2Fsuite%2Fpull%2F593&signature=36b074c2569e80921777a0e09b851b050a110a6a72746730a3c2579d722fc210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->