### PR TITLE
fix: put text edits on the same undo stack

### DIFF
--- a/frontend/src/apps/slides/composables/useCommandHistory.js
+++ b/frontend/src/apps/slides/composables/useCommandHistory.js
@@ -34,9 +34,9 @@ export const useCommandHistory = (state, historyMeta = {}) => {
 				break
 			default: {
 				const handler = actions[action]
-				if (handler) {
-					handler(action, command, operation)
-				}
+				// the sequence is ordered, so a navigating action has to finish
+				// before the next one reads the slide it landed on
+				if (handler) await handler(action, command, operation)
 				break
 			}
 		}

--- a/frontend/src/apps/slides/composables/useCommandHistory.js
+++ b/frontend/src/apps/slides/composables/useCommandHistory.js
@@ -52,14 +52,20 @@ export const useCommandHistory = (state, historyMeta = {}) => {
 
 		if (canCoalesce(command, top, forceCoalesce)) {
 			top.coalesceWith(command)
-			if (top.oldValue === top.newValue) prevCommands.value.pop()
+			if (top.oldValue === top.newValue) {
+				prevCommands.value.pop()
+				// the entry now on top is an older burst the next keystroke must not join
+				lastRecordedAt = 0
+			} else {
+				lastRecordedAt = Date.now()
+			}
 		} else {
 			prevCommands.value.push(command)
 			if (prevCommands.value.length > MAX_HISTORY) prevCommands.value.shift()
+			lastRecordedAt = Date.now()
 		}
 
 		nextCommands.value = []
-		lastRecordedAt = Date.now()
 
 		markDirty()
 	}

--- a/frontend/src/apps/slides/composables/useCommandHistory.js
+++ b/frontend/src/apps/slides/composables/useCommandHistory.js
@@ -78,37 +78,47 @@ export const useCommandHistory = (state, historyMeta = {}) => {
 		record(command)
 	}
 
-	const undo = async () => {
-		if (!canUndo.value) return
-
-		const command = prevCommands.value.pop()
-
-		const sequence = getActionSequence(command.key, 'undo')
-		for (const action of sequence) {
-			await executeAction(action, command, 'undo')
-		}
-
-		nextCommands.value.push(command)
-		lastRecordedAt = 0
-
-		markDirty()
+	// undo and redo await navigation, so a second shortcut has to queue rather
+	// than interleave and land its command on the opposite stack out of order
+	let pending = Promise.resolve()
+	const queue = (run) => {
+		pending = pending.then(run, run)
+		return pending
 	}
 
-	const redo = async () => {
-		if (!canRedo.value) return
+	const undo = () =>
+		queue(async () => {
+			if (!canUndo.value) return
 
-		const command = nextCommands.value.pop()
+			const command = prevCommands.value.pop()
 
-		const sequence = getActionSequence(command.key, 'redo')
-		for (const action of sequence) {
-			await executeAction(action, command, 'redo')
-		}
+			const sequence = getActionSequence(command.key, 'undo')
+			for (const action of sequence) {
+				await executeAction(action, command, 'undo')
+			}
 
-		prevCommands.value.push(command)
-		lastRecordedAt = 0
+			nextCommands.value.push(command)
+			lastRecordedAt = 0
 
-		markDirty()
-	}
+			markDirty()
+		})
+
+	const redo = () =>
+		queue(async () => {
+			if (!canRedo.value) return
+
+			const command = nextCommands.value.pop()
+
+			const sequence = getActionSequence(command.key, 'redo')
+			for (const action of sequence) {
+				await executeAction(action, command, 'redo')
+			}
+
+			prevCommands.value.push(command)
+			lastRecordedAt = 0
+
+			markDirty()
+		})
 
 	const clearHistory = () => {
 		prevCommands.value = []

--- a/frontend/src/apps/slides/composables/useCommandHistory.js
+++ b/frontend/src/apps/slides/composables/useCommandHistory.js
@@ -43,6 +43,9 @@ export const useCommandHistory = (state, historyMeta = {}) => {
 	const canCoalesce = (command, top, forceCoalesce) => {
 		// key-less commands would match on undefined === undefined
 		if (!command.coalesceKey || command.coalesceKey !== top?.coalesceKey) return false
+		// a zeroed clock marks the top as no continuation target, and a forced
+		// fold must not reach past that either
+		if (!lastRecordedAt) return false
 		return forceCoalesce || Date.now() - lastRecordedAt <= COALESCE_WINDOW
 	}
 

--- a/frontend/src/apps/slides/composables/useCommandHistory.js
+++ b/frontend/src/apps/slides/composables/useCommandHistory.js
@@ -24,7 +24,9 @@ export const useCommandHistory = (state, historyMeta = {}) => {
 		return actionOrder[op]?.[commandKey]
 	}
 
-	const executeAction = async (action, command, operation) => {
+	// every action has to stay synchronous: an await here would let a second
+	// undo interleave between this one's pop and its push
+	const executeAction = (action, command, operation) => {
 		switch (action) {
 			case 'execute':
 				command.execute(state.value)
@@ -32,13 +34,9 @@ export const useCommandHistory = (state, historyMeta = {}) => {
 			case 'undo':
 				command.undo(state.value)
 				break
-			default: {
-				const handler = actions[action]
-				// the sequence is ordered, so a navigating action has to finish
-				// before the next one reads the slide it landed on
-				if (handler) await handler(action, command, operation)
+			default:
+				actions[action]?.(action, command, operation)
 				break
-			}
 		}
 	}
 
@@ -66,59 +64,49 @@ export const useCommandHistory = (state, historyMeta = {}) => {
 		markDirty()
 	}
 
-	const execute = async (command) => {
+	const execute = (command) => {
 		// undo and redo must still be able to restore a lock
 		if (isBlockedByLock(command, state.value)) return
 
 		const sequence = getActionSequence(command.key, 'execute')
 		for (const action of sequence) {
-			await executeAction(action, command, 'execute')
+			executeAction(action, command, 'execute')
 		}
 
 		record(command)
 	}
 
-	// undo and redo await navigation, so a second shortcut has to queue rather
-	// than interleave and land its command on the opposite stack out of order
-	let pending = Promise.resolve()
-	const queue = (run) => {
-		pending = pending.then(run, run)
-		return pending
+	const undo = () => {
+		if (!canUndo.value) return
+
+		const command = prevCommands.value.pop()
+
+		const sequence = getActionSequence(command.key, 'undo')
+		for (const action of sequence) {
+			executeAction(action, command, 'undo')
+		}
+
+		nextCommands.value.push(command)
+		lastRecordedAt = 0
+
+		markDirty()
 	}
 
-	const undo = () =>
-		queue(async () => {
-			if (!canUndo.value) return
+	const redo = () => {
+		if (!canRedo.value) return
 
-			const command = prevCommands.value.pop()
+		const command = nextCommands.value.pop()
 
-			const sequence = getActionSequence(command.key, 'undo')
-			for (const action of sequence) {
-				await executeAction(action, command, 'undo')
-			}
+		const sequence = getActionSequence(command.key, 'redo')
+		for (const action of sequence) {
+			executeAction(action, command, 'redo')
+		}
 
-			nextCommands.value.push(command)
-			lastRecordedAt = 0
+		prevCommands.value.push(command)
+		lastRecordedAt = 0
 
-			markDirty()
-		})
-
-	const redo = () =>
-		queue(async () => {
-			if (!canRedo.value) return
-
-			const command = nextCommands.value.pop()
-
-			const sequence = getActionSequence(command.key, 'redo')
-			for (const action of sequence) {
-				await executeAction(action, command, 'redo')
-			}
-
-			prevCommands.value.push(command)
-			lastRecordedAt = 0
-
-			markDirty()
-		})
+		markDirty()
+	}
 
 	const clearHistory = () => {
 		prevCommands.value = []

--- a/frontend/src/apps/slides/composables/useCommandHistory.js
+++ b/frontend/src/apps/slides/composables/useCommandHistory.js
@@ -2,12 +2,18 @@ import { ref, computed } from 'vue'
 import { markDirty } from '@/apps/slides/stores/saving'
 import { isBlockedByLock } from '@/apps/slides/stores/commands'
 
+// prosemirror-history's newGroupDelay
+const COALESCE_WINDOW = 500
+const MAX_HISTORY = 200
+
 export const useCommandHistory = (state, historyMeta = {}) => {
 	const actionOrder = historyMeta.actionOrder
 	const actions = historyMeta.actions
 
 	const prevCommands = ref([])
 	const nextCommands = ref([])
+
+	let lastRecordedAt = 0
 
 	const canUndo = computed(() => prevCommands.value.length > 0)
 	const canRedo = computed(() => nextCommands.value.length > 0)
@@ -36,6 +42,30 @@ export const useCommandHistory = (state, historyMeta = {}) => {
 		}
 	}
 
+	const canCoalesce = (command, top, forceCoalesce) => {
+		// key-less commands would match on undefined === undefined
+		if (!command.coalesceKey || command.coalesceKey !== top?.coalesceKey) return false
+		return forceCoalesce || Date.now() - lastRecordedAt <= COALESCE_WINDOW
+	}
+
+	// files a command whose change is already applied
+	const record = (command, { forceCoalesce } = {}) => {
+		const top = prevCommands.value.at(-1)
+
+		if (canCoalesce(command, top, forceCoalesce)) {
+			top.coalesceWith(command)
+			if (top.oldValue === top.newValue) prevCommands.value.pop()
+		} else {
+			prevCommands.value.push(command)
+			if (prevCommands.value.length > MAX_HISTORY) prevCommands.value.shift()
+		}
+
+		nextCommands.value = []
+		lastRecordedAt = Date.now()
+
+		markDirty()
+	}
+
 	const execute = async (command) => {
 		// undo and redo must still be able to restore a lock
 		if (isBlockedByLock(command, state.value)) return
@@ -45,10 +75,7 @@ export const useCommandHistory = (state, historyMeta = {}) => {
 			await executeAction(action, command, 'execute')
 		}
 
-		prevCommands.value.push(command)
-		nextCommands.value = []
-
-		markDirty()
+		record(command)
 	}
 
 	const undo = async () => {
@@ -62,6 +89,7 @@ export const useCommandHistory = (state, historyMeta = {}) => {
 		}
 
 		nextCommands.value.push(command)
+		lastRecordedAt = 0
 
 		markDirty()
 	}
@@ -77,6 +105,7 @@ export const useCommandHistory = (state, historyMeta = {}) => {
 		}
 
 		prevCommands.value.push(command)
+		lastRecordedAt = 0
 
 		markDirty()
 	}
@@ -84,12 +113,14 @@ export const useCommandHistory = (state, historyMeta = {}) => {
 	const clearHistory = () => {
 		prevCommands.value = []
 		nextCommands.value = []
+		lastRecordedAt = 0
 	}
 
 	return {
 		canUndo,
 		canRedo,
 		execute,
+		record,
 		undo,
 		redo,
 		clearHistory,

--- a/frontend/src/apps/slides/composables/useCommandHistory.test.ts
+++ b/frontend/src/apps/slides/composables/useCommandHistory.test.ts
@@ -134,6 +134,22 @@ describe('record coalescing', () => {
 		expect(history.canUndo.value).toBe(true)
 	})
 
+	it('never force-folds into the entry a dropped step exposed', async () => {
+		history.record(contentEdit('a', 'ab'))
+		await history.undo()
+		await history.redo()
+
+		history.record(contentEdit('ab', 'abc'), { forceCoalesce: true })
+		history.record(contentEdit('abc', 'ab'), { forceCoalesce: true })
+		history.record(contentEdit('ab', 'abx'), { forceCoalesce: true })
+
+		state.value[0].elements[0].content = 'abx'
+		await history.undo()
+
+		expect(state.value[0].elements[0].content).toBe('ab')
+		expect(history.canUndo.value).toBe(true)
+	})
+
 	it('does not fold the next edit into the step undo just restored', async () => {
 		history.record(contentEdit('a', 'ab'))
 		vi.advanceTimersByTime(COALESCE_WINDOW + 1)

--- a/frontend/src/apps/slides/composables/useCommandHistory.test.ts
+++ b/frontend/src/apps/slides/composables/useCommandHistory.test.ts
@@ -137,14 +137,15 @@ describe('record coalescing', () => {
 })
 
 describe('overlapping operations', () => {
-	it('applies two undos in press order even when navigation settles out of order', async () => {
-		const resolvers: Array<() => void> = []
+	// deliberately awaits nothing: an action that suspends the sequence would let a
+	// second undo interleave between this one's pop and its push
+	it('applies a run of undos in press order without waiting on a navigating action', () => {
 		const navigating = useCommandHistory(state, {
 			actionOrder: {
 				execute: { editElement: ['execute'] },
 				undo: { editElement: ['jump', 'undo'] },
 			},
-			actions: { jump: () => new Promise<void>((resolve) => resolvers.push(resolve)) },
+			actions: { jump: () => new Promise<void>(() => {}) },
 		})
 
 		navigating.record(contentEdit('a', 'ab'))
@@ -152,24 +153,14 @@ describe('overlapping operations', () => {
 		navigating.record(contentEdit('ab', 'abc'))
 		state.value[0].elements[0].content = 'abc'
 
-		const first = navigating.undo()
-		const second = navigating.undo()
-
-		// releasing the newest jump first is what reorders the edits
-		for (let i = 0; i < 20; i++) {
-			await Promise.resolve()
-			resolvers
-				.splice(0)
-				.reverse()
-				.forEach((resolve) => resolve())
-		}
-		await Promise.all([first, second])
+		navigating.undo()
+		navigating.undo()
 
 		expect(state.value[0].elements[0].content).toBe('a')
 
-		await navigating.redo()
+		navigating.redo()
 		expect(state.value[0].elements[0].content).toBe('ab')
-		await navigating.redo()
+		navigating.redo()
 		expect(state.value[0].elements[0].content).toBe('abc')
 	})
 })

--- a/frontend/src/apps/slides/composables/useCommandHistory.test.ts
+++ b/frontend/src/apps/slides/composables/useCommandHistory.test.ts
@@ -120,6 +120,20 @@ describe('record coalescing', () => {
 		expect(history.canUndo.value).toBe(false)
 	})
 
+	it('does not fold the next edit into the burst before a dropped step', async () => {
+		history.record(contentEdit('a', 'ab'))
+		vi.advanceTimersByTime(COALESCE_WINDOW + 1)
+		history.record(contentEdit('ab', 'abc'))
+		history.record(contentEdit('abc', 'ab'))
+		history.record(contentEdit('ab', 'abx'))
+
+		state.value[0].elements[0].content = 'abx'
+		await history.undo()
+
+		expect(state.value[0].elements[0].content).toBe('ab')
+		expect(history.canUndo.value).toBe(true)
+	})
+
 	it('does not fold the next edit into the step undo just restored', async () => {
 		history.record(contentEdit('a', 'ab'))
 		vi.advanceTimersByTime(COALESCE_WINDOW + 1)

--- a/frontend/src/apps/slides/composables/useCommandHistory.test.ts
+++ b/frontend/src/apps/slides/composables/useCommandHistory.test.ts
@@ -136,6 +136,44 @@ describe('record coalescing', () => {
 	})
 })
 
+describe('overlapping operations', () => {
+	it('applies two undos in press order even when navigation settles out of order', async () => {
+		const resolvers: Array<() => void> = []
+		const navigating = useCommandHistory(state, {
+			actionOrder: {
+				execute: { editElement: ['execute'] },
+				undo: { editElement: ['jump', 'undo'] },
+			},
+			actions: { jump: () => new Promise<void>((resolve) => resolvers.push(resolve)) },
+		})
+
+		navigating.record(contentEdit('a', 'ab'))
+		vi.advanceTimersByTime(COALESCE_WINDOW + 1)
+		navigating.record(contentEdit('ab', 'abc'))
+		state.value[0].elements[0].content = 'abc'
+
+		const first = navigating.undo()
+		const second = navigating.undo()
+
+		// releasing the newest jump first is what reorders the edits
+		for (let i = 0; i < 20; i++) {
+			await Promise.resolve()
+			resolvers
+				.splice(0)
+				.reverse()
+				.forEach((resolve) => resolve())
+		}
+		await Promise.all([first, second])
+
+		expect(state.value[0].elements[0].content).toBe('a')
+
+		await navigating.redo()
+		expect(state.value[0].elements[0].content).toBe('ab')
+		await navigating.redo()
+		expect(state.value[0].elements[0].content).toBe('abc')
+	})
+})
+
 describe('record bookkeeping', () => {
 	it('discards the redo stack', async () => {
 		history.record(contentEdit('a', 'ab'))

--- a/frontend/src/apps/slides/composables/useCommandHistory.test.ts
+++ b/frontend/src/apps/slides/composables/useCommandHistory.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+vi.mock('@/apps/slides/stores/saving', () => ({ markDirty: () => {} }))
+vi.mock('@/apps/slides/stores/presentation', () => ({ slidesLength: ref(0) }))
+vi.mock('@/apps/slides/utils/helpers', () => ({
+	cloneObj: (obj: any) => JSON.parse(JSON.stringify(obj)),
+}))
+
+const { useCommandHistory } = await import('./useCommandHistory')
+const { editElementCommand } = await import('@/apps/slides/stores/commands')
+
+const COALESCE_WINDOW = 500
+
+const actionOrder = {
+	execute: { editElement: ['execute'] },
+	undo: { editElement: ['undo'] },
+}
+
+const makeState = (overrides = {}) => [
+	{
+		clientId: 'c1',
+		elements: [{ id: 1, type: 'text', content: 'a', locked: false, ...overrides }],
+	},
+]
+
+const contentEdit = (oldValue: string, newValue: string, coalesceKey = 'content:c1:1') =>
+	editElementCommand({
+		slideId: 'c1',
+		elementIds: [1],
+		property: 'content',
+		oldValue,
+		newValue,
+		coalesceKey,
+	})
+
+const keylessEdit = (oldValue: string, newValue: string) =>
+	editElementCommand({
+		slideId: 'c1',
+		elementIds: [1],
+		property: 'content',
+		oldValue,
+		newValue,
+	})
+
+let state: any
+let history: ReturnType<typeof useCommandHistory>
+
+beforeEach(() => {
+	vi.useFakeTimers()
+	state = ref(makeState())
+	history = useCommandHistory(state, { actionOrder, actions: {} })
+})
+
+afterEach(() => {
+	vi.useRealTimers()
+})
+
+describe('record coalescing', () => {
+	it('folds edits sharing a key inside the window into one undo step', async () => {
+		history.record(contentEdit('a', 'ab'))
+		vi.advanceTimersByTime(COALESCE_WINDOW - 1)
+		history.record(contentEdit('ab', 'abc'))
+
+		state.value[0].elements[0].content = 'abc'
+		await history.undo()
+
+		expect(state.value[0].elements[0].content).toBe('a')
+		expect(history.canUndo.value).toBe(false)
+	})
+
+	it('starts a new step once the window has passed', async () => {
+		history.record(contentEdit('a', 'ab'))
+		vi.advanceTimersByTime(COALESCE_WINDOW + 1)
+		history.record(contentEdit('ab', 'abc'))
+
+		state.value[0].elements[0].content = 'abc'
+		await history.undo()
+
+		expect(state.value[0].elements[0].content).toBe('ab')
+		expect(history.canUndo.value).toBe(true)
+	})
+
+	it('never folds key-less commands, which would match on undefined', async () => {
+		history.record(keylessEdit('a', 'ab'))
+		history.record(keylessEdit('ab', 'abc'))
+
+		state.value[0].elements[0].content = 'abc'
+		await history.undo()
+
+		expect(state.value[0].elements[0].content).toBe('ab')
+		expect(history.canUndo.value).toBe(true)
+	})
+
+	it('never folds across two different elements', async () => {
+		history.record(contentEdit('a', 'ab', 'content:c1:1'))
+		history.record(contentEdit('x', 'xy', 'content:c1:2'))
+
+		expect(history.canUndo.value).toBe(true)
+		await history.undo()
+		expect(history.canUndo.value).toBe(true)
+	})
+
+	it('folds an IME run even when a candidate pause outlasts the window', async () => {
+		history.record(contentEdit('a', 'ab'))
+		vi.advanceTimersByTime(COALESCE_WINDOW * 4)
+		history.record(contentEdit('ab', 'abc'), { forceCoalesce: true })
+
+		state.value[0].elements[0].content = 'abc'
+		await history.undo()
+
+		expect(state.value[0].elements[0].content).toBe('a')
+		expect(history.canUndo.value).toBe(false)
+	})
+
+	it('drops the step when typing lands back on the original value', () => {
+		history.record(contentEdit('a', 'ab'))
+		history.record(contentEdit('ab', 'a'))
+
+		expect(history.canUndo.value).toBe(false)
+	})
+
+	it('does not fold the next edit into the step undo just restored', async () => {
+		history.record(contentEdit('a', 'ab'))
+		vi.advanceTimersByTime(COALESCE_WINDOW + 1)
+		history.record(contentEdit('ab', 'abc'))
+
+		state.value[0].elements[0].content = 'abc'
+		await history.undo()
+
+		history.record(contentEdit('ab', 'abx'))
+		state.value[0].elements[0].content = 'abx'
+		await history.undo()
+
+		expect(state.value[0].elements[0].content).toBe('ab')
+	})
+})
+
+describe('record bookkeeping', () => {
+	it('discards the redo stack', async () => {
+		history.record(contentEdit('a', 'ab'))
+		await history.undo()
+		expect(history.canRedo.value).toBe(true)
+
+		history.record(contentEdit('a', 'ax'))
+
+		expect(history.canRedo.value).toBe(false)
+	})
+
+	it('drops the oldest step once the stack is full', async () => {
+		for (let i = 0; i < 205; i++) {
+			history.record(contentEdit(`v${i}`, `v${i + 1}`, `content:c1:${i}`))
+		}
+
+		for (let i = 0; i < 200; i++) await history.undo()
+
+		expect(history.canUndo.value).toBe(false)
+		expect(state.value[0].elements[0].content).toBe('v5')
+	})
+})

--- a/frontend/src/apps/slides/composables/useShortcuts.js
+++ b/frontend/src/apps/slides/composables/useShortcuts.js
@@ -27,7 +27,6 @@ import {
 	activeElements,
 	deleteElements,
 	duplicateElements,
-	activeElement,
 	isSelectionLocked,
 	toggleLock,
 } from '@/apps/slides/stores/element'
@@ -77,8 +76,6 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 		markDirty()
 	}
 
-	const isEditorFocused = () => activeEditor.value?.isEditable
-
 	const isPlainInput = (e) => {
 		const target = e?.target
 		return (
@@ -88,32 +85,25 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 		)
 	}
 
-	const performHistory = (operation) => {
-		if (isEditorFocused()) {
-			if (operation == 'undo' && !activeEditor.value?.can().undo()) {
-				commandHistory.undo()
-			} else if (operation == 'redo' && !activeEditor.value?.can().redo()) {
-				commandHistory.redo()
-			}
-			return
-		}
+	// every editable field except the slide editor keeps its own text undo. this
+	// has to gate the shortcut rather than its handler: a matched shortcut is
+	// preventDefaulted before the handler runs, which would kill the native undo too
+	const ownsNativeUndo = () => {
+		const target = document.activeElement
+		if (!target || target.closest('.ProseMirror')) return false
+		return (
+			target.isContentEditable ||
+			target.tagName == 'INPUT' ||
+			target.tagName == 'TEXTAREA'
+		)
+	}
 
-		if (
-			activeEditor.value?.can()[operation]() &&
-			activeElement.value?.type == 'text' &&
-			!isSelectionLocked.value
-		) {
-			activeEditor.value.commands[operation]()
-			return
-		}
+	const performHistory = (e, operation) => {
+		// an undo mid-composition destroys the IME node
+		if (e.isComposing || activeEditor.value?.view.composing) return
 
-		if (operation == 'undo' && commandHistory.canUndo.value) {
-			if (activeElement.value?.type == 'text') activeElementIds.value = []
-			commandHistory.undo()
-		} else if (operation == 'redo' && commandHistory.canRedo.value) {
-			if (activeElement.value?.type == 'text') activeElementIds.value = []
-			commandHistory.redo()
-		}
+		if (operation == 'undo') commandHistory.undo()
+		else commandHistory.redo()
 	}
 
 	const handleBold = (e) => {
@@ -200,11 +190,8 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 			description: 'Undo',
 			group: 'General',
 			allowInInput: true,
-			condition: inEditMode,
-			handler: (e) => {
-				if (isPlainInput(e)) return
-				performHistory('undo')
-			},
+			condition: () => inEditMode() && !ownsNativeUndo(),
+			handler: (e) => performHistory(e, 'undo'),
 		},
 		{
 			key: 'y',
@@ -212,11 +199,8 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 			description: 'Redo',
 			group: 'General',
 			allowInInput: true,
-			condition: inEditMode,
-			handler: (e) => {
-				if (isPlainInput(e)) return
-				performHistory('redo')
-			},
+			condition: () => inEditMode() && !ownsNativeUndo(),
+			handler: (e) => performHistory(e, 'redo'),
 		},
 		{
 			key: 'z',
@@ -225,11 +209,8 @@ export const useShortcuts = (inReadonlyMode, inSlideShowMode) => {
 			description: 'Redo',
 			group: 'General',
 			allowInInput: true,
-			condition: inEditMode,
-			handler: (e) => {
-				if (isPlainInput(e)) return
-				performHistory('redo')
-			},
+			condition: () => inEditMode() && !ownsNativeUndo(),
+			handler: (e) => performHistory(e, 'redo'),
 		},
 
 		{

--- a/frontend/src/apps/slides/composables/useTextEditor.js
+++ b/frontend/src/apps/slides/composables/useTextEditor.js
@@ -262,6 +262,9 @@ export const useTextEditor = () => {
 				extensions: extensions,
 				editable: isEditable,
 				content: content,
+				// focus only lands once EditorContent has adopted the view, so tiptap
+				// has to do it itself after mounting
+				autofocus: isEditable ? 'all' : false,
 				// to update styles in sidebar based on cursor position
 				onSelectionUpdate: ({ editor }) => setEditorStyles(editor),
 				// to update element content on every change
@@ -271,7 +274,7 @@ export const useTextEditor = () => {
 
 			// If there is a legacy lineHeight to migrate for display, apply it in-memory
 			if (initialLineHeight != null) {
-				activeEditor.value.chain().focus().setGlobalLineHeight(initialLineHeight).run()
+				activeEditor.value.commands.setGlobalLineHeight(initialLineHeight)
 				delete editorElement?.editorMetadata
 			}
 		})

--- a/frontend/src/apps/slides/composables/useTextEditor.js
+++ b/frontend/src/apps/slides/composables/useTextEditor.js
@@ -1,19 +1,59 @@
 import { ref, reactive, watch } from 'vue'
 import { Editor } from '@tiptap/vue-3'
-import { extensions } from '@/apps/slides/stores/tiptapSetup'
+import { extensions, patchEmptyParagraphs } from '@/apps/slides/stores/tiptapSetup'
 import { TextSelection } from 'prosemirror-state'
 import { commandHistory } from '@/apps/slides/stores/historyMeta'
 import { markDirty } from '@/apps/slides/stores/saving'
-import { activeElement } from '@/apps/slides/stores/element'
+import {
+	activeElement,
+	findSlideElement,
+	getInitialShapeTextContent,
+} from '@/apps/slides/stores/element'
 import { editElementCommand } from '@/apps/slides/stores/commands'
 import { currentSlide } from '@/apps/slides/stores/slide'
 
 export const activeEditor = ref(null)
 
-const contentHistory = ref('')
+// the element this editor was built for: activeElement flips a tick earlier
+let editorElement = null
+let editorSlideId = null
+let lastCompositionId = null
 
-let lastFocusedSlideName = null
-let lastFocusedElementId = null
+let suppressRecording = false
+
+const withRecordingSuppressed = (fn) => {
+	suppressRecording = true
+	try {
+		return fn()
+	} finally {
+		suppressRecording = false
+	}
+}
+
+const patchedHTML = (html) => (html ? patchEmptyParagraphs(html).updatedHTML : html)
+
+const isEditorLive = () => activeEditor.value && editorElement?.id === activeElement.value?.id
+
+// history writes state; the mounted editor has to be told
+watch(
+	() => activeElement.value?.content,
+	(html) => {
+		if (!isEditorLive()) return
+
+		const editor = activeEditor.value
+
+		if (html == null) {
+			if (activeElement.value?.type !== 'shape') return
+			const seed = getInitialShapeTextContent(activeElement.value)
+			withRecordingSuppressed(() => editor.commands.setContent(seed, { emitUpdate: false }))
+			return
+		}
+
+		if (patchedHTML(editor.getHTML()) === html) return
+
+		withRecordingSuppressed(() => editor.commands.setContent(html, { emitUpdate: false }))
+	},
+)
 
 const editorStyles = reactive({
 	textAlign: null,
@@ -57,8 +97,31 @@ export const useTextEditor = () => {
 	}
 
 	const updateElementContent = (editor) => {
-		activeElement.value.content = editor.getHTML()
+		if (!editorElement) return
+		editorElement.content = patchedHTML(editor.getHTML())
 		markDirty()
+	}
+
+	const recordContentEdit = (oldValue, transaction) => {
+		const compositionId = transaction.getMeta('composition')
+		// an IME candidate pause routinely outlasts the coalesce window
+		const forceCoalesce = compositionId != null && compositionId === lastCompositionId
+		lastCompositionId = compositionId
+
+		const newValue = editorElement.content
+		if (!commandHistory || oldValue === newValue) return
+
+		commandHistory.record(
+			editElementCommand({
+				slideId: editorSlideId,
+				elementIds: [editorElement.id],
+				property: 'content',
+				oldValue,
+				newValue,
+				coalesceKey: `content:${editorSlideId}:${editorElement.id}`,
+			}),
+			{ forceCoalesce },
+		)
 	}
 
 	const handleOnTransaction = (editor, transaction) => {
@@ -68,33 +131,15 @@ export const useTextEditor = () => {
 		// since onUpdate also triggers when activeEditor changes from one text box to another
 		// leading to overwriting content for second one with first one's content
 
+		// history and init pushes must leave no trace at all
+		if (suppressRecording || !editorElement) return setEditorStyles(editor)
+
+		const oldValue = patchedHTML(editorElement.content)
+
 		updateElementContent(editor)
 		setEditorStyles(editor)
-	}
 
-	const handleOnFocus = (editor) => {
-		if (!editor) return
-		lastFocusedSlideName = currentSlide.value.clientId
-		lastFocusedElementId = activeElement.value.id
-		contentHistory.value = editor.getHTML()
-	}
-
-	const handleOnBlur = (editor) => {
-		if (!editor) return
-		if (contentHistory.value == editor.getHTML()) return
-		if (!commandHistory) return
-
-		commandHistory.execute(
-			editElementCommand({
-				slideId: lastFocusedSlideName,
-				elementIds: [lastFocusedElementId],
-				property: 'content',
-				oldValue: contentHistory.value,
-				newValue: editor.getHTML(),
-				// saving on blur must not pull selection back to this element
-				skipJumpOnExecute: true,
-			}),
-		)
+		recordContentEdit(oldValue, transaction)
 	}
 
 	const markCommands = {
@@ -207,24 +252,28 @@ export const useTextEditor = () => {
 	}
 
 	const initTextEditor = (id, content, isEditable = false, initialLineHeight = null) => {
-		activeEditor.value = new Editor({
-			extensions: extensions,
-			editable: isEditable,
-			content: content,
-			// to update styles in sidebar based on cursor position
-			onSelectionUpdate: ({ editor }) => setEditorStyles(editor),
-			// to update element content on every change
-			onTransaction: ({ editor, transaction }) => handleOnTransaction(editor, transaction),
-			onFocus: ({ editor }) => handleOnFocus(editor),
-			onBlur: ({ editor }) => handleOnBlur(editor),
-		})
+		editorElement = findSlideElement(id)
+		editorSlideId = currentSlide.value?.clientId
+		lastCompositionId = null
 
-		// If there is a legacy lineHeight to migrate for display, apply it in-memory
-		if (initialLineHeight != null) {
-			if (content != null) contentHistory.value = content
-			activeEditor.value.chain().focus().setGlobalLineHeight(initialLineHeight).run()
-			delete activeElement.value?.editorMetadata
-		}
+		withRecordingSuppressed(() => {
+			activeEditor.value = new Editor({
+				extensions: extensions,
+				editable: isEditable,
+				content: content,
+				// to update styles in sidebar based on cursor position
+				onSelectionUpdate: ({ editor }) => setEditorStyles(editor),
+				// to update element content on every change
+				onTransaction: ({ editor, transaction }) =>
+					handleOnTransaction(editor, transaction),
+			})
+
+			// If there is a legacy lineHeight to migrate for display, apply it in-memory
+			if (initialLineHeight != null) {
+				activeEditor.value.chain().focus().setGlobalLineHeight(initialLineHeight).run()
+				delete editorElement?.editorMetadata
+			}
+		})
 
 		setEditorStyles(activeEditor.value)
 	}

--- a/frontend/src/apps/slides/composables/useTextEditor.js
+++ b/frontend/src/apps/slides/composables/useTextEditor.js
@@ -18,6 +18,7 @@ export const activeEditor = ref(null)
 let editorElement = null
 let editorSlideId = null
 let lastCompositionId = null
+let stopContentWatch = null
 
 let suppressRecording = false
 
@@ -35,25 +36,22 @@ const patchedHTML = (html) => (html ? patchEmptyParagraphs(html).updatedHTML : h
 const isEditorLive = () => activeEditor.value && editorElement?.id === activeElement.value?.id
 
 // history writes state; the mounted editor has to be told
-watch(
-	() => activeElement.value?.content,
-	(html) => {
-		if (!isEditorLive()) return
+const reconcileEditorContent = (html) => {
+	if (!isEditorLive()) return
 
-		const editor = activeEditor.value
+	const editor = activeEditor.value
 
-		if (html == null) {
-			if (activeElement.value?.type !== 'shape') return
-			const seed = getInitialShapeTextContent(activeElement.value)
-			withRecordingSuppressed(() => editor.commands.setContent(seed, { emitUpdate: false }))
-			return
-		}
+	if (html == null) {
+		if (activeElement.value?.type !== 'shape') return
+		const seed = getInitialShapeTextContent(activeElement.value)
+		withRecordingSuppressed(() => editor.commands.setContent(seed, { emitUpdate: false }))
+		return
+	}
 
-		if (patchedHTML(editor.getHTML()) === html) return
+	if (patchedHTML(editor.getHTML()) === html) return
 
-		withRecordingSuppressed(() => editor.commands.setContent(html, { emitUpdate: false }))
-	},
-)
+	withRecordingSuppressed(() => editor.commands.setContent(html, { emitUpdate: false }))
+}
 
 const editorStyles = reactive({
 	textAlign: null,
@@ -255,6 +253,9 @@ export const useTextEditor = () => {
 		editorElement = findSlideElement(id)
 		editorSlideId = currentSlide.value?.clientId
 		lastCompositionId = null
+
+		stopContentWatch?.()
+		stopContentWatch = watch(() => activeElement.value?.content, reconcileEditorContent)
 
 		withRecordingSuppressed(() => {
 			activeEditor.value = new Editor({

--- a/frontend/src/apps/slides/stores/blurOnSlideChange.test.ts
+++ b/frontend/src/apps/slides/stores/blurOnSlideChange.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+vi.mock('@/apps/slides/utils/mediaUploads', () => ({ getAttachmentUrl: () => '' }))
+vi.mock('@/apps/slides/router', () => ({ router: { replace: () => Promise.resolve() } }))
+
+const editorState = vi.hoisted(() => ({ text: '', html: '<p></p>' }))
+
+vi.mock('@/apps/slides/composables/useTextEditor', async () => {
+	const { ref } = await import('vue')
+	const activeEditor = ref<any>(null)
+	const editor = {
+		setEditable: () => {},
+		isFocused: false,
+		commands: { blur: () => {}, focus: () => {}, setTextSelection: () => {} },
+		getText: () => editorState.text,
+		getHTML: () => editorState.html,
+		destroy: () => {},
+	}
+	return {
+		useTextEditor: () => ({
+			initTextEditor: () => {
+				activeEditor.value = editor
+			},
+			activeEditor,
+		}),
+	}
+})
+
+const { activeElementIds, focusElementId } = await import('./element')
+const { slides, slideIndex, changeEditorSlide } = await import('./slide')
+const { slidesLength } = await import('./presentation')
+const { setCommandHistory } = await import('./historyMeta')
+
+const text = (id: string) => ({ id, type: 'text', left: 10, top: 10, width: 100, height: 100 })
+
+describe('leaving a slide while a text element is focused', () => {
+	let recorded: any[]
+
+	beforeEach(async () => {
+		recorded = []
+		setCommandHistory({
+			execute: (command: any) => {
+				command.execute(slides.value)
+				recorded.push(command)
+			},
+		} as any)
+
+		slides.value = [
+			{ clientId: 'A', elements: [text('t1')] },
+			{ clientId: 'B', elements: [text('t2')] },
+		] as any
+		slidesLength.value = 2
+		slideIndex.value = 0
+		activeElementIds.value = []
+		focusElementId.value = null
+		editorState.text = ''
+		editorState.html = '<p></p>'
+
+		for (let i = 0; i < 4; i++) await nextTick()
+	})
+
+	it('deletes the emptied text box off the slide it was on', async () => {
+		activeElementIds.value = ['t1']
+		focusElementId.value = 't1'
+		for (let i = 0; i < 4; i++) await nextTick()
+
+		changeEditorSlide(1)
+		for (let i = 0; i < 6; i++) await nextTick()
+
+		expect(slideIndex.value).toBe(1)
+		expect(slides.value[0].elements).toEqual([])
+		expect(slides.value[1].elements.map((e: any) => e.id)).toEqual(['t2'])
+		expect(recorded.map((c) => c.jumpToSlideId)).toEqual(['A'])
+	})
+
+	// legacy content keeps patchEmptyParagraphs reporting an update forever, so
+	// the save must become a no-op by comparison against the stored content, or
+	// the watch's second blur-save pairs magic-move refIds against the new slide
+	it('does not pair magic-move refIds against the slide it navigated to', async () => {
+		const legacyHTML = '<p><span style="font-size: 16px">hello</span></p><p></p>'
+		slides.value[0].elements[0].content = legacyHTML
+		slides.value[1].transition = 'Magic Move'
+		editorState.text = 'hello'
+		editorState.html = legacyHTML
+
+		activeElementIds.value = ['t1']
+		focusElementId.value = 't1'
+		for (let i = 0; i < 4; i++) await nextTick()
+
+		changeEditorSlide(1)
+		for (let i = 0; i < 6; i++) await nextTick()
+
+		expect(recorded).toEqual([])
+		expect(slides.value[0].elements[0].refId).toBeUndefined()
+	})
+})

--- a/frontend/src/apps/slides/stores/burstSelection.test.ts
+++ b/frontend/src/apps/slides/stores/burstSelection.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+vi.mock('@/apps/slides/utils/mediaUploads', () => ({ getAttachmentUrl: () => '' }))
+
+const { useCommandHistory } = await import('@/apps/slides/composables/useCommandHistory')
+const { addElementCommand, editElementCommand } = await import('./commands')
+const { actionOrder, actions } = await import('./historyMeta')
+const { activeElementIds, focusElementId, cropSelectionToFitContent } = await import('./element')
+const { slides, slideIndex } = await import('./slide')
+
+const slideId = 'c1'
+const image = (id: number) => ({ id, type: 'image', left: 10, top: 10, width: 100, height: 100 })
+
+describe('a held-key run of undos', () => {
+	beforeEach(() => {
+		slides.value = [{ clientId: slideId, elements: [] }] as any
+		slideIndex.value = 0
+		activeElementIds.value = []
+		focusElementId.value = null
+	})
+
+	it('leaves nothing selected once every element it named is gone', async () => {
+		const history = useCommandHistory(slides, { actionOrder, actions })
+
+		await history.execute(addElementCommand({ slideId, element: image(1) }))
+		await nextTick()
+		await history.execute(addElementCommand({ slideId, element: image(2) }))
+		await nextTick()
+		await history.execute(
+			editElementCommand({
+				slideId,
+				elementIds: [1],
+				property: 'left',
+				oldValue: 10,
+				newValue: 50,
+			}),
+		)
+		await nextTick()
+
+		// the user clicks the other element before holding Cmd+Z
+		activeElementIds.value = [2]
+
+		const runs = [history.undo(), history.undo(), history.undo()]
+
+		await Promise.all(runs)
+		for (let i = 0; i < 5; i++) await nextTick()
+
+		expect(slides.value[0].elements).toEqual([])
+		expect(activeElementIds.value).toEqual([])
+	})
+
+	it('lets the last undo decide the selection, not the first to be deferred', async () => {
+		const history = useCommandHistory(slides, { actionOrder, actions })
+
+		history.execute(addElementCommand({ slideId, element: image(1) }))
+		await nextTick()
+		history.execute(addElementCommand({ slideId, element: image(2) }))
+		await nextTick()
+		history.execute(
+			editElementCommand({
+				slideId,
+				elementIds: [1],
+				property: 'left',
+				oldValue: 10,
+				newValue: 50,
+			}),
+		)
+		await nextTick()
+
+		activeElementIds.value = []
+
+		// the edit undo defers a selection of element 1; the undo after it removes
+		// element 2 and clears the selection, and it spoke last
+		history.undo()
+		history.undo()
+
+		for (let i = 0; i < 5; i++) await nextTick()
+
+		expect(slides.value[0].elements.map((e: any) => e.id)).toEqual([1])
+		expect(activeElementIds.value).toEqual([])
+	})
+
+	it('drops the deferred crop of an element it went on to remove', async () => {
+		const frames: Array<() => void> = []
+		vi.stubGlobal('requestAnimationFrame', (cb: () => void) => frames.push(cb))
+
+		const history = useCommandHistory(slides, { actionOrder, actions })
+
+		history.execute(addElementCommand({ slideId, element: image(1) }))
+		await nextTick()
+		history.execute(
+			editElementCommand({
+				slideId,
+				elementIds: [1],
+				property: 'left',
+				oldValue: 10,
+				newValue: 50,
+			}),
+		)
+		await nextTick()
+
+		// the crop only defers when the selection already names the element
+		activeElementIds.value = [1]
+
+		history.undo()
+		history.undo()
+		await nextTick()
+
+		expect(frames.length).toBeGreaterThan(0)
+		expect(() => frames.forEach((f) => f())).not.toThrow()
+	})
+})
+
+describe('cropSelectionToFitContent', () => {
+	it('ignores an id that is no longer on the slide', () => {
+		slides.value = [{ clientId: slideId, elements: [] }] as any
+		slideIndex.value = 0
+
+		expect(() => cropSelectionToFitContent([99])).not.toThrow()
+	})
+})

--- a/frontend/src/apps/slides/stores/burstSelection.test.ts
+++ b/frontend/src/apps/slides/stores/burstSelection.test.ts
@@ -7,7 +7,7 @@ const { useCommandHistory } = await import('@/apps/slides/composables/useCommand
 const { addElementCommand, editElementCommand } = await import('./commands')
 const { actionOrder, actions } = await import('./historyMeta')
 const { activeElementIds, focusElementId, cropSelectionToFitContent } = await import('./element')
-const { slides, slideIndex } = await import('./slide')
+const { slides, slideIndex, selectionBounds, updateSelectionBounds } = await import('./slide')
 
 const slideId = 'c1'
 const image = (id: number) => ({ id, type: 'image', left: 10, top: 10, width: 100, height: 100 })
@@ -109,6 +109,42 @@ describe('a held-key run of undos', () => {
 
 		expect(frames.length).toBeGreaterThan(0)
 		expect(() => frames.forEach((f) => f())).not.toThrow()
+	})
+
+	it('drops the stale deferred crop once a later undo has retaken the selection', async () => {
+		const frames: Array<() => void> = []
+		vi.stubGlobal('requestAnimationFrame', (cb: () => void) => frames.push(cb))
+
+		const history = useCommandHistory(slides, { actionOrder, actions })
+
+		history.execute(addElementCommand({ slideId, element: image(1) }))
+		await nextTick()
+		history.execute(addElementCommand({ slideId, element: image(2) }))
+		await nextTick()
+		history.execute(
+			editElementCommand({
+				slideId,
+				elementIds: [1],
+				property: 'left',
+				oldValue: 10,
+				newValue: 50,
+			}),
+		)
+		await nextTick()
+
+		activeElementIds.value = [1]
+		updateSelectionBounds({ left: 400, top: 400, width: 50, height: 50 })
+
+		// the edit undo defers a crop of element 1, which survives; the undo after
+		// it clears the selection, so the crop must not repaint the old box
+		history.undo()
+		history.undo()
+
+		for (let i = 0; i < 5; i++) await nextTick()
+		frames.forEach((f) => f())
+
+		expect(activeElementIds.value).toEqual([])
+		expect(selectionBounds.left).toBe(400)
 	})
 })
 

--- a/frontend/src/apps/slides/stores/commands.js
+++ b/frontend/src/apps/slides/stores/commands.js
@@ -78,24 +78,29 @@ const editElementCommand = ({
 	oldValue,
 	newValue,
 	skipJumpOnExecute,
+	coalesceKey,
 }) => {
-	oldValue = cloneValue(oldValue)
-	newValue = cloneValue(newValue)
-
 	return {
 		key: 'editElement',
 		slideId,
 		elementIds,
 		property,
+		oldValue: cloneValue(oldValue),
+		newValue: cloneValue(newValue),
+		coalesceKey,
 		jumpToSlideId: slideId,
 		jumpToElementIds: elementIds,
 		skipJumpOnExecute,
 		debug: `Edit ${property} of element ${elementIds} on slide ${slideId} to ${newValue}`,
+		coalesceWith(incoming) {
+			this.newValue = incoming.newValue
+			this.debug = incoming.debug
+		},
 		execute(state) {
-			editElements(state, slideId, elementIds, property, newValue)
+			editElements(state, slideId, elementIds, property, this.newValue)
 		},
 		undo(state) {
-			editElements(state, slideId, elementIds, property, oldValue)
+			editElements(state, slideId, elementIds, property, this.oldValue)
 		},
 	}
 }

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -1144,6 +1144,7 @@ export {
 	updatePosition,
 	flipElements,
 	findSlideElement,
+	getInitialShapeTextContent,
 	cropSelectionToFitContent,
 	getElementCenter,
 }

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -1017,7 +1017,8 @@ const cropSelectionToFitContent = (elementIds) => {
 	// crop selection to selected element edges
 	elementIds.forEach((id) => {
 		const element = currentSlide.value.elements.find((el) => el.id === id)
-		const useLayoutBounds = elementIds.length == 1 && ['shape', 'image'].includes(element?.type)
+		// same source the resize observer writes from, so the two never disagree by a sub-pixel
+		const useLayoutBounds = elementIds.length == 1
 
 		const {
 			left: elementLeft,

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -719,10 +719,10 @@ const duplicateElements = async (e, elements, srcSlide, toDisplace = true) => {
 	)
 }
 
-const deleteElements = async (e, ids) => {
+const deleteElements = (e, ids) => {
 	const idsToDelete = (ids || activeElementIds.value).filter((id) => !findSlideElement(id)?.locked)
 	if (!idsToDelete.length) return
-	await resetFocus()
+	resetFocus()
 	let commands = []
 
 	idsToDelete.forEach((id) => {
@@ -877,10 +877,13 @@ const getEditorHTML = () => {
 }
 
 const updateElementContent = (element) => {
-	const { wasUpdated, updatedHTML } = getEditorHTML()
+	const { updatedHTML } = getEditorHTML()
 	const currentText = activeEditor.value.getText()
 
-	if (editorOldText == currentText && !wasUpdated) return
+	// legacy content keeps needing the patch, so idempotence has to come from
+	// comparing against what is stored, or a second blur-save runs the refId
+	// pairing again after the slide index has already moved on
+	if (editorOldText == currentText && element.content == updatedHTML) return
 
 	const refCommands = getCommandsToUpdateElementRefId(element) || []
 	if (refCommands.length) {
@@ -918,6 +921,14 @@ const blurAndSaveContent = (element) => {
 	} else {
 		deleteElements(null, [element.id])
 	}
+}
+
+// the watches below only fire after the slide has already changed, so leaving
+// a slide has to save the open editor while its element is still reachable
+const flushPendingBlur = () => {
+	const element = activeElement.value
+	if (!activeEditor.value || !['text', 'shape'].includes(element?.type)) return
+	blurAndSaveContent(element)
 }
 
 const setEditableState = () => {
@@ -1137,6 +1148,7 @@ export {
 	unlockAll,
 	setActiveElements,
 	resetFocus,
+	flushPendingBlur,
 	exitTextEditing,
 	addTextElement,
 	addMediaElement,

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -1017,6 +1017,9 @@ const normalizeZIndices = (elements) => {
 }
 
 const cropSelectionToFitContent = (elementIds) => {
+	// every caller defers this, so the elements it names can be gone by now
+	if (!elementIds.every((id) => findSlideElement(id))) return
+
 	let l = 10000,
 		t = 10000,
 		r = 0,

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -896,7 +896,8 @@ const updateElementContent = (element) => {
 
 const blurAndSaveContent = (element) => {
 	activeEditor.value.setEditable(false)
-	activeEditor.value.commands.blur()
+	// blur() drops the window selection, including one this editor never held
+	if (activeEditor.value.isFocused) activeEditor.value.commands.blur()
 
 	const isEmpty = (activeEditor.value?.getText() || '').replace(/\u200B/g, '') === ''
 
@@ -923,31 +924,31 @@ const setEditableState = () => {
 
 const initEditorForElement = (element) => {
 	if (element?.type == 'text') {
-		const isEditable = focusElementId.value == element.id
 		initTextEditor(
 			element.id,
 			element.content,
-			isEditable,
+			focusElementId.value == element.id,
 			element.locked ? null : element.editorMetadata?.lineHeight,
 		)
-
-		if (isEditable) setEditableState()
 	}
 }
 
-const replaceEditor = (fn) =>
-	nextTick(() => {
-		activeEditor.value?.destroy()
-		activeEditor.value = null
+// dropping the old editor before the next render keeps EditorContent from
+// mounting onto an editor that is about to be destroyed
+const replaceEditor = (fn) => {
+	activeEditor.value?.destroy()
+	activeEditor.value = null
+
+	return nextTick(() => {
 		fn?.()
 		editorOldText = activeEditor.value?.getText()
 	})
+}
 
 const initShapeEditor = (element) =>
-	replaceEditor(() => {
-		initTextEditor(element.id, element.content || getInitialShapeTextContent(element), true)
-		setEditableState()
-	})
+	replaceEditor(() =>
+		initTextEditor(element.id, element.content || getInitialShapeTextContent(element), true),
+	)
 
 watch(
 	() => activeElement.value,

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -29,6 +29,7 @@ import {
 	addElementCommand,
 	removeElementCommand,
 } from '@/apps/slides/stores/commands'
+import { interactionOffset } from '@/apps/slides/stores/interaction'
 
 const findSlideElement = (id) => currentSlide.value?.elements.find((el) => el.id === id)
 
@@ -810,21 +811,27 @@ const getElementPosition = (elementId) => {
 
 const getElementLayoutPosition = (element) => {
 	const elementDiv = getElementDiv(element.id)
+
+	// a gesture in flight rides on a transform, so the rendered position is
+	// left/top plus the offset, which is what SelectionBox subtracts back out
+	const left = element.left + interactionOffset.left
+	const top = element.top + interactionOffset.top
+
 	// no rendered node yet: fall back to the element's stored bounds
 	if (!elementDiv) {
 		return {
-			left: element.left,
-			top: element.top,
-			right: element.left + (element.width || 0),
-			bottom: element.top + (element.height || 0),
+			left,
+			top,
+			right: left + (element.width || 0),
+			bottom: top + (element.height || 0),
 		}
 	}
 
 	return {
-		left: element.left,
-		top: element.top,
-		right: element.left + elementDiv.offsetWidth,
-		bottom: element.top + elementDiv.offsetHeight,
+		left,
+		top,
+		right: left + elementDiv.offsetWidth,
+		bottom: top + elementDiv.offsetHeight,
 	}
 }
 

--- a/frontend/src/apps/slides/stores/historyMeta.js
+++ b/frontend/src/apps/slides/stores/historyMeta.js
@@ -31,7 +31,7 @@ const actionOrder = {
 	undo: {
 		addSlide: ['jumpToSlide', 'undo'],
 		removeSlide: ['undo', 'jumpToSlide'],
-		addElement: ['jumpToSlide', 'undo'],
+		addElement: ['jumpToSlide', 'undo', 'jumpToElements'],
 		removeElement: ['jumpToSlide', 'undo', 'jumpToElements'],
 		editElement: ['jumpToSlide', 'jumpToElements', 'undo'],
 		batch: ['jumpToSlide', 'undo', 'jumpToElements'],
@@ -40,11 +40,11 @@ const actionOrder = {
 	},
 }
 
-const jumpToSlideByIndex = async (index, focus) => {
+const jumpToSlideByIndex = (index, focus) => {
 	const onActiveSlide = index === slideIndex.value
 
 	if (!onActiveSlide && index != null) {
-		await changeEditorSlide(index, focus)
+		changeEditorSlide(index, focus)
 
 		recentlyRestored.value = true
 		setTimeout(() => {
@@ -53,13 +53,18 @@ const jumpToSlideByIndex = async (index, focus) => {
 	}
 }
 
+let latestJump = 0
+
 const jumpToElementsByIds = (jumpToIds, focusOnId) => {
 	if (!jumpToIds?.length) return
 
+	const jump = ++latestJump
 	const targetIds = selectableIds(jumpToIds)
 
+	// the elements are gone, so the selection naming them has to go too
 	if (!targetIds.every((id) => findSlideElement(id))) {
 		activeElementIds.value = []
+		if (!findSlideElement(focusElementId.value)) focusElementId.value = null
 		return
 	}
 
@@ -70,6 +75,11 @@ const jumpToElementsByIds = (jumpToIds, focusOnId) => {
 	}
 
 	nextTick(() => {
+		// a whole run of undos lands in one tick, so by now a later one may have
+		// decided the selection, or removed the elements this call named
+		if (jump !== latestJump) return
+		if (!targetIds.every((id) => findSlideElement(id))) return
+
 		// setActiveElements early-returns when the one surviving id is already
 		// selected, which would leave the locked ones in the selection
 		if (targetIds.length < jumpToIds.length) {

--- a/frontend/src/apps/slides/stores/historyMeta.js
+++ b/frontend/src/apps/slides/stores/historyMeta.js
@@ -70,7 +70,10 @@ const jumpToElementsByIds = (jumpToIds, focusOnId) => {
 
 	if (JSON.stringify(activeElementIds.value) === JSON.stringify(targetIds)) {
 		// the box is measured off the DOM, so it can only be fitted once the change renders
-		requestAnimationFrame(() => cropSelectionToFitContent(targetIds))
+		requestAnimationFrame(() => {
+			if (jump !== latestJump) return
+			cropSelectionToFitContent(targetIds)
+		})
 		return
 	}
 

--- a/frontend/src/apps/slides/stores/historyMeta.js
+++ b/frontend/src/apps/slides/stores/historyMeta.js
@@ -64,7 +64,8 @@ const jumpToElementsByIds = (jumpToIds, focusOnId) => {
 	}
 
 	if (JSON.stringify(activeElementIds.value) === JSON.stringify(targetIds)) {
-		cropSelectionToFitContent(targetIds)
+		// the box is measured off the DOM, so it can only be fitted once the change renders
+		requestAnimationFrame(() => cropSelectionToFitContent(targetIds))
 		return
 	}
 

--- a/frontend/src/apps/slides/stores/historySelection.test.ts
+++ b/frontend/src/apps/slides/stores/historySelection.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+vi.mock('@/apps/slides/utils/mediaUploads', () => ({ getAttachmentUrl: () => '' }))
+
+const { useCommandHistory } = await import('@/apps/slides/composables/useCommandHistory')
+const { addElementCommand } = await import('./commands')
+const { actionOrder, actions } = await import('./historyMeta')
+const { activeElementIds, focusElementId } = await import('./element')
+const { slides, slideIndex } = await import('./slide')
+
+const slideId = 'c1'
+const element = { id: 1, type: 'image', left: 64, top: 378, width: 620, height: 132 }
+
+describe('selection after an element disappears', () => {
+	beforeEach(() => {
+		slides.value = [{ clientId: slideId, elements: [] }] as any
+		slideIndex.value = 0
+		activeElementIds.value = []
+		focusElementId.value = null
+	})
+
+	it('drops the selection when undo removes the element it names', async () => {
+		const history = useCommandHistory(slides, { actionOrder, actions })
+
+		await history.execute(addElementCommand({ slideId, element }))
+		await nextTick()
+
+		expect(activeElementIds.value).toEqual([1])
+
+		// adding a text element focuses it, which its own editor teardown covers
+		focusElementId.value = 1
+
+		await history.undo()
+		await nextTick()
+
+		expect(activeElementIds.value).toEqual([])
+		expect(focusElementId.value).toBe(null)
+	})
+})

--- a/frontend/src/apps/slides/stores/selectionBounds.test.ts
+++ b/frontend/src/apps/slides/stores/selectionBounds.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/apps/slides/utils/mediaUploads', () => ({ getAttachmentUrl: () => '' }))
+
+const { cropSelectionToFitContent } = await import('./element')
+const { slides, slideIndex, selectionBounds, updateSelectionBounds } = await import('./slide')
+const { interactionOffset, resetInteractionOffset } = await import('./interaction')
+
+// SelectionBox renders at selectionBounds minus the offset and re-adds it as a
+// transform, so bounds written mid-gesture have to already include the offset
+describe('cropSelectionToFitContent during a live gesture', () => {
+	beforeEach(() => {
+		slides.value = [
+			{
+				clientId: 'c1',
+				elements: [{ id: 1, type: 'text', left: 100, top: 50, width: 200, height: 40 }],
+			},
+		] as any
+		slideIndex.value = 0
+		resetInteractionOffset()
+		updateSelectionBounds({ left: 100, top: 50, width: 200, height: 40 })
+	})
+
+	it('leaves the box on the element when nothing is in flight', () => {
+		cropSelectionToFitContent([1])
+
+		expect(selectionBounds.left).toBe(100)
+		expect(selectionBounds.top).toBe(50)
+	})
+
+	it('follows the element while a drag offset is uncommitted', () => {
+		interactionOffset.left = -64
+		interactionOffset.top = 12
+
+		cropSelectionToFitContent([1])
+
+		expect(selectionBounds.left).toBe(36)
+		expect(selectionBounds.top).toBe(62)
+	})
+})

--- a/frontend/src/apps/slides/stores/slide.js
+++ b/frontend/src/apps/slides/stores/slide.js
@@ -8,7 +8,7 @@ import {
 	presentationTheme,
 	transformElements,
 } from '@/apps/slides/stores/presentation'
-import { resetFocus } from '@/apps/slides/stores/element'
+import { flushPendingBlur, resetFocus } from '@/apps/slides/stores/element'
 import { saveChanges, dirty, saveFailed } from '@/apps/slides/stores/saving'
 import { commandHistory } from '@/apps/slides/stores/historyMeta'
 import { generateUniqueId, cloneObj } from '@/apps/slides/utils/helpers'
@@ -173,6 +173,7 @@ const deleteSlide = (deleteActive, index) => {
 
 const changeEditorSlide = (index, focus = true) => {
 	if (!inReadonlyMode.value) {
+		flushPendingBlur()
 		resetFocus()
 	}
 	return changeSlide(index, focus)

--- a/frontend/src/apps/slides/stores/slide.js
+++ b/frontend/src/apps/slides/stores/slide.js
@@ -98,18 +98,21 @@ const setSlideIndex = (index) => {
 	slideIndex.value = index
 }
 
-const changeSlide = async (index, focus = true) => {
+const changeSlide = (index, focus = true) => {
 	index = Math.max(0, Math.min(index, slidesLength.value - 1))
 
-	await router.replace({
-		query: { slide: index + 1 },
-	})
+	slideIndex.value = index
 
 	if (focus) {
 		focusedSlide.value = index
 	} else {
 		focusedSlide.value = null
 	}
+
+	// the query only mirrors the slide we already landed on, so nothing waits on it
+	router.replace({
+		query: { slide: index + 1 },
+	})
 }
 
 const resetAndSave = async () => {
@@ -168,9 +171,9 @@ const deleteSlide = (deleteActive, index) => {
 	)
 }
 
-const changeEditorSlide = async (index, focus = true) => {
+const changeEditorSlide = (index, focus = true) => {
 	if (!inReadonlyMode.value) {
-		await resetFocus()
+		resetFocus()
 	}
 	return changeSlide(index, focus)
 }

--- a/frontend/src/apps/slides/stores/tiptapSetup.js
+++ b/frontend/src/apps/slides/stores/tiptapSetup.js
@@ -666,6 +666,8 @@ const LineHeight = Extension.create({
 
 export const extensions = [
 	StarterKit.configure({
+		// the app's command history owns undo now
+		undoRedo: false,
 		paragraph: false,
 		bulletList: false,
 		orderedList: false,


### PR DESCRIPTION
### Why

Slides had two undo histories. The text editor kept its own for typing. The app kept a separate one for everything else: moving a shape, adding a slide, changing a colour.

Which one Cmd+Z reached depended on what was selected at that moment, not on what you had actually just done. Undo stopped being "step back through my work" and became "step back through whatever this thing is."

So undo could hit the wrong change or miss a change completely.

### What this changes

- One history. Text edits are recorded into the same stack as everything else, as they happen, in the order they happen. The editor's built-in undo is switched off, so there is one stack and one Cmd+Z path.

- Undo now walks backwards through your work in time order, no matter what is selected.

- Typing still groups the way you would expect. A pause of about half a second starts a new undo step, which is the same rule the editor used before.
