### PR TITLE
fix(meet): avoid false local network warnings

### DIFF
--- a/frontend/src/apps/meet/composables/__tests__/useNetworkQuality.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useNetworkQuality.test.ts
@@ -49,29 +49,16 @@ describe("useNetworkQuality", () => {
 		};
 	};
 
-	it("requires consecutive degraded downlink samples and healthy samples to recover", async () => {
-		const stats = {
+	it("does not treat packet loss alone as visible downlink degradation", async () => {
+		const { observedDownlink, unmount } = mountWithStats({
 			rtt: 50,
-			packetLoss: 0,
+			packetLoss: 20,
 			availableOutgoingBitrate: 900_000,
-			downlinkPacketLoss: 10,
-			hasDownlinkSample: true,
 			timestamp: Date.now(),
 			isValid: true,
-		};
-		const { observedDownlink, unmount } = mountWithStats(stats);
+		});
 
-		await vi.advanceTimersByTimeAsync(3000);
-		expect(observedDownlink.value).toBe("good");
-
-		await vi.advanceTimersByTimeAsync(3000);
-		expect(observedDownlink.value).toBe("poor");
-
-		stats.downlinkPacketLoss = 0;
 		await vi.advanceTimersByTimeAsync(6000);
-		expect(observedDownlink.value).toBe("poor");
-
-		await vi.advanceTimersByTimeAsync(3000);
 		expect(observedDownlink.value).toBe("good");
 
 		unmount();
@@ -256,8 +243,6 @@ describe("useNetworkQuality", () => {
 					rtt: 50,
 					packetLoss: 0,
 					availableOutgoingBitrate: 800_000,
-					downlinkPacketLoss: 0,
-					hasDownlinkSample: true,
 					timestamp: Date.now(),
 					isValid: true,
 				}),
@@ -376,9 +361,6 @@ describe("useNetworkQuality", () => {
 		qualityStats.rtt = 50;
 		qualityStats.packetLoss = 0;
 		qualityStats.availableOutgoingBitrate = 800_000;
-		await vi.advanceTimersByTimeAsync(18_000);
-		expect(resetReceiveSide).not.toHaveBeenCalled();
-
 		await vi.advanceTimersByTimeAsync(3000);
 		expect(requestConsumerKeyFrame).toHaveBeenCalledTimes(1);
 		expect(resetReceiveSide).not.toHaveBeenCalled();

--- a/frontend/src/apps/meet/composables/useNetworkQuality.ts
+++ b/frontend/src/apps/meet/composables/useNetworkQuality.ts
@@ -13,8 +13,6 @@ interface NetworkStats {
 	rtt: number;
 	packetLoss: number;
 	availableOutgoingBitrate: number;
-	downlinkPacketLoss?: number;
-	hasDownlinkSample?: boolean;
 	timestamp: number;
 	isValid: boolean;
 }
@@ -32,9 +30,6 @@ export function useNetworkQuality(
 	const networkQuality = ref<NetworkQuality>("good");
 	const downlinkQuality = ref<NetworkQuality>("good");
 	const isTransportFailed = ref(false);
-	let degradedDownlinkSamples = 0;
-	let healthyDownlinkSamples = 0;
-	let pendingDownlinkQuality: NetworkQuality = "good";
 	const isPolling = ref(false);
 	let pollInterval: ReturnType<typeof setInterval> | null = null;
 	const stallDetector = new StallDetector();
@@ -73,47 +68,21 @@ export function useNetworkQuality(
 		}
 	};
 
-	const updateDownlinkQuality = (stats: NetworkStats) => {
-		if (!stats.hasDownlinkSample) return;
-
-		const packetLoss = stats.downlinkPacketLoss ?? 0;
-		const sampleQuality: NetworkQuality =
-			packetLoss > CRITICAL_PACKET_LOSS_PERCENT
-				? "critical"
-				: packetLoss > POOR_PACKET_LOSS_PERCENT
-					? "poor"
-					: "good";
-
-		if (sampleQuality === "good") {
-			degradedDownlinkSamples = 0;
-			pendingDownlinkQuality = "good";
-			healthyDownlinkSamples++;
-			if (healthyDownlinkSamples >= 3) downlinkQuality.value = "good";
-			return;
-		}
-
-		healthyDownlinkSamples = 0;
-		degradedDownlinkSamples++;
-		if (
-			sampleQuality === "critical" ||
-			pendingDownlinkQuality === "good"
-		) {
-			pendingDownlinkQuality = sampleQuality;
-		}
-		if (degradedDownlinkSamples >= 2) {
-			downlinkQuality.value = pendingDownlinkQuality;
-		}
-	};
-
-	const checkConsumerStalls = async (): Promise<void> => {
+	const checkConsumerStalls = async (allowRecovery: boolean): Promise<void> => {
 		const sfuManager = sfuManagerRef?.value;
 		if (!sfuManager) return;
 
 		const consumerManager = sfuManager.mediaManager?.consumerManager;
-		if (!consumerManager) return;
+		if (!consumerManager) {
+			downlinkQuality.value = "good";
+			return;
+		}
 
 		const consumers = consumerManager.getAllConsumers();
-		if (consumers.length === 0) return;
+		if (consumers.length === 0) {
+			downlinkQuality.value = "good";
+			return;
+		}
 
 		const statsResults = await Promise.all(
 			consumers.map(async (entry) => {
@@ -156,11 +125,10 @@ export function useNetworkQuality(
 			}
 		}
 
-		const stalledIds = stallDetector.check(samples);
-		if (stallDetector.hasActiveStall()) {
-			downlinkQuality.value = "critical";
-			healthyDownlinkSamples = 0;
-		}
+		const stalledIds = stallDetector.check(samples, allowRecovery);
+		downlinkQuality.value = stallDetector.hasActiveStall()
+			? "critical"
+			: "good";
 		if (stalledIds.length === 0) return;
 		const stalledSet = new Set(stalledIds);
 		clientTelemetry?.reportMediaStalls(
@@ -228,18 +196,12 @@ export function useNetworkQuality(
 			if (transportManager.getNetworkStats) {
 				const stats = await transportManager.getNetworkStats();
 				updateQuality(stats);
-				updateDownlinkQuality(stats);
 				const sfuClient = sfuManagerRef?.value?.sfuClient;
 				if (sfuClient && stats.isValid) {
 					getClientTelemetry(sfuClient).reportNetworkQuality(stats);
 				}
 			}
-			if (networkQuality.value !== "good") {
-				stallDetector.suspend();
-				return;
-			}
-
-			await checkConsumerStalls();
+			await checkConsumerStalls(networkQuality.value === "good");
 		} finally {
 			isPolling.value = false;
 		}

--- a/frontend/src/apps/meet/utils/media/TransportManager.ts
+++ b/frontend/src/apps/meet/utils/media/TransportManager.ts
@@ -99,10 +99,6 @@ export class TransportManager {
 	private recvTransportCreation: Promise<Transport> | null = null;
 	private sendTransportGeneration = 0;
 	private recvTransportGeneration = 0;
-	private previousInboundPackets = new Map<
-		string,
-		{ received: number; lost: number }
-	>();
 
 	constructor(e2eePolicy?: E2EETransformPolicy) {
 		this.sendTransport = null;
@@ -664,8 +660,6 @@ export class TransportManager {
 		const result = {
 			rtt: 0,
 			packetLoss: 0,
-			downlinkPacketLoss: 0,
-			hasDownlinkSample: false,
 			availableOutgoingBitrate: 0,
 			timestamp: Date.now(),
 			isValid: false,
@@ -678,10 +672,7 @@ export class TransportManager {
 		try {
 			let packetsSent = 0;
 			let packetsLost = 0;
-			let downlinkPackets = 0;
-			let downlinkPacketsLost = 0;
 			let validStatsFound = false;
-			const seenInboundReports = new Set<string>();
 
 			// One RTT sample per transport, from a single report type.
 			const transportRtt: number[] = [];
@@ -689,14 +680,13 @@ export class TransportManager {
 			const processStats = (
 				stats: RTCStatsReport | Map<string, TransportStatReport>,
 				preferRemoteInbound: boolean,
-				transportDirection: Direction,
 			) => {
 				let remoteRttSum = 0;
 				let remoteRttCount = 0;
 				let pairRttSum = 0;
 				let pairRttCount = 0;
 
-				for (const [reportId, report] of stats) {
+				for (const report of stats.values()) {
 					if (
 						report.type === "candidate-pair" &&
 						report.state === "succeeded"
@@ -725,24 +715,6 @@ export class TransportManager {
 						) {
 							packetsSent += report.packetsReceived + report.packetsLost;
 							packetsLost += report.packetsLost;
-
-							const sampleId = `${transportDirection}:${reportId}`;
-							seenInboundReports.add(sampleId);
-							const previous = this.previousInboundPackets.get(sampleId);
-							if (
-								previous &&
-								report.packetsReceived >= previous.received &&
-								report.packetsLost >= previous.lost
-							) {
-								const receivedDelta = report.packetsReceived - previous.received;
-								const lostDelta = report.packetsLost - previous.lost;
-								downlinkPackets += receivedDelta + lostDelta;
-								downlinkPacketsLost += lostDelta;
-							}
-							this.previousInboundPackets.set(sampleId, {
-								received: report.packetsReceived,
-								lost: report.packetsLost,
-							});
 						}
 					}
 
@@ -773,7 +745,7 @@ export class TransportManager {
 				this.sendTransport.connectionState === "connected"
 			) {
 				const sendStats = await this.sendTransport.getStats();
-				processStats(sendStats, true, "send");
+				processStats(sendStats, true);
 			}
 
 			if (
@@ -781,13 +753,7 @@ export class TransportManager {
 				this.recvTransport.connectionState === "connected"
 			) {
 				const recvStats = await this.recvTransport.getStats();
-				processStats(recvStats, false, "recv");
-			}
-
-			for (const reportId of this.previousInboundPackets.keys()) {
-				if (!seenInboundReports.has(reportId)) {
-					this.previousInboundPackets.delete(reportId);
-				}
+				processStats(recvStats, false);
 			}
 
 			if (transportRtt.length > 0) {
@@ -798,11 +764,6 @@ export class TransportManager {
 
 			if (packetsSent > 0) {
 				result.packetLoss = (packetsLost / packetsSent) * 100;
-			}
-			if (downlinkPackets > 0) {
-				result.downlinkPacketLoss =
-					(downlinkPacketsLost / downlinkPackets) * 100;
-				result.hasDownlinkSample = true;
 			}
 
 			result.isValid = validStatsFound;
@@ -817,6 +778,5 @@ export class TransportManager {
 		this.closeSendTransport();
 		this.closeReceiveTransport();
 		this.device = null;
-		this.previousInboundPackets.clear();
 	}
 }

--- a/frontend/src/apps/meet/utils/media/__tests__/TransportManager.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/TransportManager.test.ts
@@ -529,40 +529,6 @@ describe("getNetworkStats", () => {
 		expect(stats.isValid).toBe(true);
 	});
 
-	it("calculates downlink loss from packet deltas between polls", async () => {
-		const manager = createManager();
-		manager.recvTransport = {
-			id: "r",
-			connectionState: "connected",
-			getStats: vi
-				.fn()
-				.mockResolvedValueOnce(
-					new Map([
-						[
-							"in1",
-							{ type: "inbound-rtp", packetsReceived: 100, packetsLost: 0 },
-						],
-					]),
-				)
-				.mockResolvedValueOnce(
-					new Map([
-						[
-							"in1",
-							{ type: "inbound-rtp", packetsReceived: 180, packetsLost: 20 },
-						],
-					]),
-				),
-		} as never;
-		manager.sendTransport = null;
-
-		const first = await manager.getNetworkStats();
-		const second = await manager.getNetworkStats();
-
-		expect(first.hasDownlinkSample).toBe(false);
-		expect(second.hasDownlinkSample).toBe(true);
-		expect(second.downlinkPacketLoss).toBe(20);
-	});
-
 	it("includes remote-inbound-rtp RTT in average", async () => {
 		const manager = createManager();
 		manager.sendTransport = {

--- a/frontend/src/apps/meet/utils/media/stallDetector.ts
+++ b/frontend/src/apps/meet/utils/media/stallDetector.ts
@@ -62,7 +62,7 @@ export class StallDetector {
 		this.now = options.now ?? (() => Date.now());
 	}
 
-	check(samples: ConsumerSample[]): string[] {
+	check(samples: ConsumerSample[], recoveryEnabled = true): string[] {
 		const now = this.now();
 		const activeIds = new Set<string>();
 		const stalled: string[] = [];
@@ -100,7 +100,7 @@ export class StallDetector {
 				}
 				if (now - st.stallStartedAt >= timeoutMs) {
 					this.activeStall = true;
-					if (this.shouldRecover(st, now)) {
+					if (recoveryEnabled && this.shouldRecover(st, now)) {
 						stalled.push(sample.id);
 						st.lastRecoveredAt = now;
 						st.recoveryAttempts += 1;
@@ -131,7 +131,7 @@ export class StallDetector {
 
 			if (now - st.stallStartedAt >= timeoutMs) {
 				this.activeStall = true;
-				if (this.shouldRecover(st, now)) {
+				if (recoveryEnabled && this.shouldRecover(st, now)) {
 					stalled.push(sample.id);
 					st.lastRecoveredAt = now;
 					st.recoveryAttempts += 1;


### PR DESCRIPTION

- stop using reported RTP packet loss alone for the local downlink warning
- drive receive-side warnings from confirmed consumer stalls and clear them when media bytes advance
- continue observing stalls while suppressing recovery actions during noisy network samples

