### PR TITLE
fix(mail): decode display names the server left encoded

### DIFF
--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -40,7 +40,7 @@ from suite.mail.utils import (
     log_mail_error,
 )
 from suite.mail.utils.dt import normalize_utc_z, to_user_timezone
-from suite.mail.utils.email_parser import EmailParser
+from suite.mail.utils.email_parser import EmailParser, decode_encoded_words
 from suite.mail.utils.logger import get_push_logger
 from suite.mail.utils.user import get_account_emails, get_sync_state, update_sync_state
 from suite.utils import clean_text, convert_html_to_text, enqueue_job, parse_filters, user_context
@@ -1188,14 +1188,22 @@ def format_message(account: str, mailbox_map: dict, message: dict) -> dict:
         "received_after": time_diff_in_seconds(received_at, sent_at),
     }
 
+    # Display names pass through `decode_encoded_words`: a client that MIME-encoded a name inside
+    # a quoted string leaves the server nothing it is allowed to decode, and the raw
+    # `=?UTF-8?B?...?=` would otherwise be what the reader sees — and what the address index
+    # learns the person as.
     for key in ["sender", "from"]:
-        formatted_message[f"{key}_name"] = message[key][0]["name"] if message[key] else None
+        formatted_message[f"{key}_name"] = (
+            decode_encoded_words(message[key][0]["name"]) if message[key] else None
+        )
         formatted_message[f"{key}_email"] = message[key][0]["email"] if message[key] else None
 
     formatted_message["reply_to"] = []
     if reply_to := message["replyTo"]:
         for rt in reply_to:
-            formatted_message["reply_to"].append({"display_name": rt["name"], "email": rt["email"]})
+            formatted_message["reply_to"].append(
+                {"display_name": decode_encoded_words(rt["name"]), "email": rt["email"]}
+            )
 
     formatted_message["recipients"] = []
     for key in ["to", "cc", "bcc"]:
@@ -1203,7 +1211,11 @@ def format_message(account: str, mailbox_map: dict, message: dict) -> dict:
             titled_key = key.title()
             for rcpt in rcpts:
                 formatted_message["recipients"].append(
-                    {"type": titled_key, "display_name": rcpt["name"], "email": rcpt["email"]}
+                    {
+                        "type": titled_key,
+                        "display_name": decode_encoded_words(rcpt["name"]),
+                        "email": rcpt["email"],
+                    }
                 )
 
     for key, field in {"htmlBody": "html_body", "textBody": "text_body"}.items():

--- a/suite/mail/store/indexes/email_address.py
+++ b/suite/mail/store/indexes/email_address.py
@@ -2,6 +2,7 @@ import re
 
 from frappe.utils import EMAIL_MATCH_PATTERN
 
+from suite.mail.utils.email_parser import decode_encoded_words
 from suite.store.search_store import FieldSpec, SearchStore
 
 # Runs of alphanumerics, Unicode-aware, mirroring the tokenizer the indexed text went through —
@@ -80,9 +81,15 @@ def _relevance_key(query: list[str], hit: dict) -> tuple:
 
 
 def _sanitize_name(name: str | None) -> str | None:
-    """Strip whitespace and any matching quote pairs wrapping a display name."""
+    """Strip whitespace and any matching quote pairs wrapping a display name.
 
-    name = (name or "").strip()
+    Encoded-words are decoded here as well as where messages are cached: contact cards and any
+    other feed reach the index without passing through that, and a name indexed as
+    `=?UTF-8?B?...?=` is both unreadable and unsearchable — nobody types the base64 of a name.
+    """
+
+    name = decode_encoded_words(name) or ""
+    name = name.strip()
     while len(name) >= 2 and name[0] == name[-1] and name[0] in _WRAPPING_QUOTES:
         name = name[1:-1].strip()
 

--- a/suite/mail/tests/test_email_parser.py
+++ b/suite/mail/tests/test_email_parser.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+"""``decode_encoded_words`` — the RFC 2047 decoding display names need when the mail server could
+not do it: an encoded-word inside a quoted string, which the standard does not allow and a strict
+parser therefore passes through untouched."""
+
+import unittest
+
+from suite.mail.utils.email_parser import decode_encoded_words
+
+
+class DecodeEncodedWords(unittest.TestCase):
+    def test_encoded_word_is_decoded(self):
+        self.assertEqual(decode_encoded_words("=?UTF-8?B?7KCV7J2A7Jyk?="), "정은윤")
+
+    def test_word_joined_to_plain_text_keeps_the_join(self):
+        """No separator is invented — `make_header` would put a space after the slash."""
+
+        self.assertEqual(
+            decode_encoded_words("Jungeun Yun/=?UTF-8?B?7KCV7J2A7Jyk?="), "Jungeun Yun/정은윤"
+        )
+
+    def test_surrounding_text_and_spacing_survive(self):
+        self.assertEqual(decode_encoded_words("Ann =?utf-8?q?caf=C3=A9?= Lee"), "Ann café Lee")
+
+    def test_whitespace_between_two_words_is_dropped(self):
+        """It belongs to the encoding, not to the name (RFC 2047, §6.2)."""
+
+        self.assertEqual(decode_encoded_words("=?utf-8?q?Jane?= =?utf-8?q?_Doe?="), "Jane Doe")
+
+    def test_quoted_printable_is_decoded(self):
+        self.assertEqual(decode_encoded_words("=?utf-8?q?caf=C3=A9?="), "café")
+
+    def test_unknown_charset_falls_back_to_utf8(self):
+        self.assertEqual(decode_encoded_words("=?bogus-charset?q?hi?="), "hi")
+
+    def test_malformed_word_is_left_alone(self):
+        self.assertEqual(decode_encoded_words("=?utf-8?q?broken"), "=?utf-8?q?broken")
+
+    def test_plain_name_is_untouched(self):
+        self.assertEqual(decode_encoded_words("Jane Doe"), "Jane Doe")
+        self.assertEqual(decode_encoded_words("a=?b"), "a=?b")
+
+    def test_blank_values_pass_through(self):
+        self.assertIsNone(decode_encoded_words(None))
+        self.assertEqual(decode_encoded_words(""), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/suite/mail/utils/email_parser.py
+++ b/suite/mail/utils/email_parser.py
@@ -212,6 +212,48 @@ def remove_whitespace_characters(text: str) -> str:
     return text.replace("\t", "").replace("\r", "").replace("\n", "").strip()
 
 
+ENCODED_WORD = re.compile(r"=\?[^?\s]+\?[bBqQ]\?[^?\s]*\?=")
+# Whitespace between two encoded-words belongs to the encoding, not to the text (RFC 2047, §6.2).
+ENCODED_WORD_SEPARATOR = re.compile(r"(\?=)\s+(=\?)")
+
+
+def decode_encoded_words(text: str | None) -> str | None:
+    """Decodes any RFC 2047 encoded-words in the text, leaving the rest of it untouched.
+
+    Display names arrive decoded from the mail server, except where the sending client put an
+    encoded-word inside a quoted string — which RFC 2047 does not allow, so a strict parser
+    leaves it alone and `"Jungeun Yun/=?UTF-8?B?...?="` reaches us verbatim.
+
+    Decoding a word at a time rather than through `make_header`, which separates the pieces it
+    decodes with a space and would break that same name into two.
+    """
+
+    if not text or "=?" not in text:
+        return text
+
+    return ENCODED_WORD.sub(_decode_word, ENCODED_WORD_SEPARATOR.sub(r"\1\2", text))
+
+
+def _decode_word(match: re.Match) -> str:
+    """Decodes a single encoded-word, keeping it as it is if that isn't possible."""
+
+    word = match.group(0)
+
+    try:
+        text, charset = decode_header(word)[0]
+    except Exception:
+        return word
+
+    if not isinstance(text, bytes):
+        return text
+
+    try:
+        return text.decode(charset or "utf-8", errors="replace")
+    except LookupError:
+        # A charset the sender named and Python doesn't know.
+        return text.decode("utf-8", errors="replace")
+
+
 def extract_ip_and_host(header: str | None = None) -> tuple[str | None, str | None]:
     """Extracts the IP and Host from the given `Received` header."""
 


### PR DESCRIPTION
A sender whose client MIME-encoded its display name inside a quoted string — `"Jungeun Yun/=?UTF-8?B?7KCV7J2A7Jyk?="` — reached the reader exactly like that. RFC 2047 doesn't allow an encoded-word inside a quoted string, so a strict parser is right to leave it alone, and nothing on the JMAP → cache → UI path decoded it afterwards.

The address index learned the person under that string too, so the base64 was what recipient suggestions offered, and the only way to search for them was to type it.

## What changed

- `decode_encoded_words()` in `suite/mail/utils/email_parser.py`.
- Applied to display names in `format_message()` (from/sender, reply-to, recipients), i.e. on the way into the cache.
- Applied again in the address index's `_sanitize_name()`, which contact cards and every other feed reach without passing through the first.

Decoding is done a word at a time rather than through `make_header`, which separates the pieces it decodes with a space — that name would come back as `Jungeun Yun/ 정은윤`. Whitespace between two adjacent encoded-words is dropped instead, per RFC 2047 §6.2, so a long name split across words doesn't gain one. Malformed words, unknown charsets and plain names pass through unchanged.

## Notes

Messages already cached keep the raw name until they are re-fetched, and index entries already written stay as they are. No backfill here.

## Tests

9 unit tests in `suite/mail/tests/test_email_parser.py`; the 32 existing address-index tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/frappe/codesmith/suite/pr/599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789048653&installation_model_id=431961&pr_number=599&repository=frappe%2Fsuite&return_to=https%3A%2F%2Fgithub.com%2Ffrappe%2Fsuite%2Fpull%2F599&signature=1e6f9462811f27e97152b8b1814940c7e915e6132a936f76f7415e77762e0d42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->