### PR TITLE
feat(mail): rebuild the mobile composer as a page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,10 +9,15 @@
     <title>Frappe Suite</title>
     <link rel="icon" type="image/svg+xml" href="/src/assets/app-logos/suite.svg" />
     <!-- viewport-fit=cover: draw edge-to-edge in iOS standalone — required for the
-         env(safe-area-inset-*) paddings to be non-zero at all. -->
+         env(safe-area-inset-*) paddings to be non-zero at all.
+
+         interactive-widget=resizes-content: the on-screen keyboard shrinks the layout viewport
+         instead of leaving it full-height and sliding the visible part around underneath. Without
+         it a full-screen pane runs on under the keyboard, and iOS pans the whole page to reveal a
+         focused field — the compose sheet jumping on every focus change. -->
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover"
+      content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <!-- Status-bar/browser-chrome color; kept in sync with the active scheme at
          runtime (see mail's MailLayout) so the bar never sits white over a dark app. -->

--- a/frontend/src/apps/mail/components/ComposeMailEditor.vue
+++ b/frontend/src/apps/mail/components/ComposeMailEditor.vue
@@ -7,18 +7,12 @@
 	<TextEditor
 		ref="textEditor"
 		editor-class="prose-sm max-w-none [&_ol]:ps-7 [&_ul]:ps-7"
-		:extensions="[CustomImageExtension, CustomParagraphExtension, ...MentionExtensions]"
-		:content="mail.html_body.replaceAll('<div><br></div>', '<div></div>')"
-		:upload-function
-		class="flex flex-col max-sm:min-h-0 max-sm:flex-1 max-sm:overflow-y-auto max-sm:overscroll-contain"
+		:extensions="[CustomImageExtension, CustomParagraphExtension, ...mentionExtensions]"
+		:content="editorContent"
+		:upload-function="uploadFunction"
+		class="flex flex-col"
 		:class="{ 'pointer-events-none opacity-50': !show, 'sm:h-[75vh]': !isInThread }"
-		@focusin="onFocusIn"
-		@change="
-			(val: string) => {
-				mail.html_body = val.replaceAll('<div></div>', '<div><br></div>')
-				dropUnmentionedRecipients()
-			}
-		"
+		@change="onEditorChange"
 		@dragenter.prevent="handleDragEnter"
 		@dragover.prevent="handleDragOver"
 		@dragleave.prevent="handleDragLeave"
@@ -225,20 +219,8 @@
 </template>
 
 <script setup lang="ts">
-import {
-	computed,
-	inject,
-	nextTick,
-	onMounted,
-	onUnmounted,
-	reactive,
-	ref,
-	useTemplateRef,
-	watch,
-} from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { computed, nextTick, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
 import { EditorContent } from '@tiptap/vue-3'
-import { watchDebounced } from '@vueuse/core'
 import {
 	ChevronDown,
 	ChevronUp,
@@ -253,31 +235,23 @@ import {
 	Combobox,
 	Dropdown,
 	FeatherIcon,
-	ImageExtension,
 	Progress,
 	TextEditor,
 	Tooltip,
-	createResource,
 	useFileUpload,
 } from 'frappe-ui'
-import { Mention } from 'frappe-ui/editor'
 
-import { getAttachmentUrl } from '@/apps/mail/resources'
-import {
-	formatBytes,
-	isOverlayPresent,
-	processInlineImages,
-	raiseToast,
-	randomString,
-} from '@/apps/mail/utils'
+import { formatBytes, isOverlayPresent, raiseToast } from '@/apps/mail/utils'
 import { useScreenSize } from '@/apps/mail/utils/composables'
-import { createMentionSuggestion } from '@/apps/mail/utils/mentionSuggestion'
-import { CustomParagraphExtension } from '@/apps/mail/utils/text-editor'
-import { injectAccountScope } from '@/apps/mail/utils/accountScope'
+import { useComposeMail } from '@/apps/mail/composables/useComposeMail'
+import {
+	CustomImageExtension,
+	CustomParagraphExtension,
+	uploadFunction,
+} from '@/apps/mail/utils/text-editor'
 import ComposeMailToolbar from '@/apps/mail/components/ComposeMailToolbar.vue'
 
-import type { Attachment, ComposeMailData, File as FileDoc, Identity, UserResource } from '@/apps/mail/types'
-import type { MentionCandidate } from '@/apps/mail/utils/mentionSuggestion'
+import type { Attachment, ComposeMailData, File as FileDoc, Identity } from '@/apps/mail/types'
 
 import RecipientInput from './Controls/RecipientInput.vue'
 import ContactsModal from './Modals/ContactsModal.vue'
@@ -297,31 +271,53 @@ const {
 
 const emit = defineEmits(['discardMail', 'reply', 'replyAll', 'forward', 'popOut'])
 
-const router = useRouter()
-const route = useRoute()
-// The editor sends as the enclosing pane's account (the thread's owning account in
-// All Inboxes, the active one everywhere else): identities, the account's default
-// outgoing email and every create/draft call resolve through this scope.
-const scope = injectAccountScope()
-const { accountId: scopeAccountId, identities, mailboxIds } = scope
-
-const viewSentMessage = (threadID: string) =>
-	router.push({
-		name: 'mail-mail',
-		params: { accountId: scopeAccountId.value, mailbox: mailboxIds.value.sent, threadID },
-	})
-
-const getIdentity = (email: string) =>
-	identities.value.data?.find((identity: Identity) => identity.email === email)
-
-// Editor
-
 const { isMobile } = useScreenSize()
 
 const textEditor = useTemplateRef('textEditor')
 const toInput = useTemplateRef('toInput')
 const ccInput = useTemplateRef('ccInput')
 const subjectInput = useTemplateRef<HTMLInputElement>('subjectInput')
+
+// What the composition *is* — draft state, autosave, send, schedule, discard, attachments, mentions
+// — lives in the composable, shared with the phone composer (ComposeView). Only what is particular
+// to this dialog stays here: the contact picker, drag-and-drop, and the in-thread draft actions.
+const {
+	mail,
+	identities,
+	isLoading,
+	isDraftUpdated,
+	isRecipientsEmpty,
+	updateOriginalMail,
+	saveDraft,
+	sendMail,
+	discardMail,
+	onClosed,
+	showScheduleModal,
+	openScheduleModal,
+	scheduleSend,
+	openQuotedContent,
+	openAttachment,
+	mentionExtensions,
+	appendEmoji,
+	editorContent,
+	onEditorChange,
+} = useComposeMail({
+	mailDetails,
+	isInThread,
+	reloadMails,
+	close: () => (show.value = false),
+	isOpen: () => !!show.value,
+	onDiscardUnsaved: () => emit('discardMail'),
+	host: () => textEditor.value,
+	// The dialog holds the rest of the page inert, so the mention dropdown has to render inside it
+	// rather than at <body>, where it would be unreachable.
+	mentionContainer: () =>
+		(textEditor.value?.$el as HTMLElement | undefined)?.closest<HTMLElement>('[role="dialog"]') ??
+		null,
+})
+
+// The composer stays mounted when it closes, so the in-flight flags have to be cleared on the way out.
+watch(show, (open) => !open && onClosed())
 
 const showContactsModal = ref(false)
 const insertContactsInto = ref('')
@@ -337,353 +333,25 @@ const toggleCcBcc = () => {
 	if (showCcBcc.value) nextTick(() => ccInput.value?.setFocus())
 }
 
-// Pre-empt iOS's focus reveal. When focus moves to a field it thinks the keyboard covers, iOS scrolls
-// the page itself to bring it up — and a fixed pane can only chase that pan a frame behind, which is
-// the sheet lurching up and settling back on every hop between the body and the fields above.
-//
-// Putting the caret somewhere comfortable ourselves, synchronously as focus lands, leaves iOS with
-// nothing to reveal and so nothing to pan. Scrolling the pane we already own is invisible by
-// comparison — it's the scroll the reader asked for.
-const revealFocused = (target?: Element | null) => {
-	const scroller = textEditor.value?.$el as HTMLElement | undefined
-	const editor = textEditor.value?.editor
-	if (!isMobile.value || !scroller) return
-
-	const node = target ?? document.activeElement
-	if (!node || !scroller.contains(node)) return
-
-	// The body's element spans the whole composition, so its box says nothing about where the caret
-	// is; ask ProseMirror. Every other field is small enough to use its own.
-	const rect =
-		editor && node === editor.view.dom
-			? editor.view.coordsAtPos(editor.state.selection.head)
-			: node.getBoundingClientRect()
-
-	const view = scroller.getBoundingClientRect()
-	const margin = 24
-
-	if (rect.bottom > view.bottom - margin) scroller.scrollTop += rect.bottom - view.bottom + margin
-	else if (rect.top < view.top + margin) scroller.scrollTop -= view.top + margin - rect.top
-}
-
-const onFocusIn = (event: FocusEvent) => revealFocused(event.target as Element | null)
-
-// The keyboard opening shrinks the pane under whatever is already focused, which puts it back within
-// reach of iOS's reveal — so do it again once the new size has landed.
-const onViewportResize = () => requestAnimationFrame(() => revealFocused())
-
-onMounted(() => window.visualViewport?.addEventListener('resize', onViewportResize))
-onUnmounted(() => window.visualViewport?.removeEventListener('resize', onViewportResize))
-
-const appendEmoji = (emoji: string) => {
-	textEditor.value.editor.commands.insertContent(emoji)
-	textEditor.value.editor.commands.focus()
-}
-
-// Mentions
-
-// Picking a mention adds that person to To — reaching back up to the recipient fields
-// is the trip the shortcut exists to save. Only the pick adds, so a mention arriving
-// with pasted or forwarded content doesn't quietly address the mail to anyone.
-//
-// Recipients this composer added that way, and only those: deleting the mention takes
-// them back out again, while someone typed into To by hand and then mentioned stays
-// put — the mention didn't put them there and doesn't get to remove them.
-const mentionedRecipients = new Set<string>()
-
-const addMentionedRecipient = ({ email, display_name, image }: MentionCandidate) => {
-	if ([...mail.to, ...mail.cc, ...mail.bcc].some((r) => r.email === email)) return
-
-	mail.to.push({ email, display_name, image })
-	mentionedRecipients.add(email)
-}
-
-const dropUnmentionedRecipients = () => {
-	const editor = textEditor.value?.editor
-	if (!editor || !mentionedRecipients.size) return
-
-	const mentioned = new Set<string>()
-	editor.state.doc.descendants((node) => {
-		if (node.type.name === 'mention' && node.attrs.id) mentioned.add(node.attrs.id)
-	})
-
-	for (const email of mentionedRecipients) {
-		// Still named somewhere in the body — mentioning someone twice and deleting one
-		// of the two keeps them addressed.
-		if (mentioned.has(email)) continue
-
-		mail.to = mail.to.filter((recipient) => recipient.email !== email)
-		mentionedRecipients.delete(email)
-	}
-}
-
-const MentionExtensions = [
-	// The inline node. Its own `@` suggester stays inert with no item source of its
-	// own — the search below is the one wired up.
-	Mention,
-	createMentionSuggestion({
-		account: () => scopeAccountId.value,
-		onSelect: addMentionedRecipient,
-		// Null in a thread or the mobile sheet, where nothing is holding the rest of
-		// the page inert and the default <body> is fine.
-		container: () =>
-			(textEditor.value?.$el as HTMLElement | undefined)?.closest<HTMLElement>(
-				'[role="dialog"]',
-			) ?? null,
-	}),
-]
-
-// Setup & hooks
-
-const user = inject('$user') as UserResource
-
-const getDefaultFromEmail = () => {
-	const identityEmails = identities.value.data?.map((i: Identity) => i.email) ?? []
-	// The default outgoing email is per-account; pick the scope account's.
-	const defaultOutgoingEmail = scope.account.value?.default_outgoing_email
-
-	return (
-		identityEmails.find((e) => e === mailDetails?.from_email) ??
-		identityEmails.find((e) => e === defaultOutgoingEmail) ??
-		identityEmails[0] ??
-		user.data.name
-	)
-}
-
-const mail = reactive<ComposeMailData>({
-	name: mailDetails?.name || '',
-	id: mailDetails?.id || '',
-	from_email: getDefaultFromEmail(),
-	to: mailDetails?.to || [],
-	cc: mailDetails?.cc || [],
-	bcc: mailDetails?.bcc || [],
-	attachments: mailDetails?.attachments || [],
-	subject: mailDetails?.subject || '',
-	html_body: mailDetails?.html_body || '',
-	quoted_content: mailDetails?.quoted_content || '',
-	in_reply_to: mailDetails?.in_reply_to || '',
-	in_reply_to_id: mailDetails?.in_reply_to_id || '',
-	forwarded_from_id: mailDetails?.forwarded_from_id || '',
-})
-
-const originalMail = ref<ComposeMailData>()
-const updateOriginalMail = () => (originalMail.value = JSON.parse(JSON.stringify(mail)))
-const isDraftUpdated = computed(() => JSON.stringify(mail) !== JSON.stringify(originalMail.value))
-
-// Start where there is still something to write: the body on a reply (recipients and
-// subject come with the thread), the subject when the draft arrived addressed but
-// unnamed — a `mailto:` link, or a calendar invite's participants — and the To field
-// otherwise. The delay is the dialog's: focusing during its transition doesn't take.
+// Start where there is still something to write: the body on a reply (recipients and subject come
+// with the thread), the subject when the draft arrived addressed but unnamed — a `mailto:` link, or
+// a calendar invite's participants — and the To field otherwise. The delay is the dialog's: focusing
+// during its transition doesn't take.
 onMounted(() => {
 	updateOriginalMail()
 	if (mailDetails?.in_reply_to) return textEditor.value.editor.commands.focus()
 
-	// Deferred, and the choice made from inside: TextEditor renders nothing until it has
-	// built its editor on its own mounted hook, so neither field exists yet at this point.
+	// Deferred, and the choice made from inside: TextEditor renders nothing until it has built its
+	// editor on its own mounted hook, so neither field exists yet at this point.
 	setTimeout(() => {
-		if (!isRecipientsEmpty.value && !mail.subject && subjectInput.value)
-			subjectInput.value.focus()
+		if (!isRecipientsEmpty.value && !mail.subject && subjectInput.value) subjectInput.value.focus()
 		else toInput.value?.setFocus()
 	}, 50)
 })
 
 onUnmounted(() => saveDraft())
 
-watchDebounced(mail, () => saveDraft(), { debounce: 2000 })
-
-// Actions
-
-const isSavingDraft = ref(false)
-
-const saveDraft = async () => {
-	if (!isDraftUpdated.value || isLoading.value || isDiscarding.value) return
-
-	isSavingDraft.value = true
-	if (mail.id) await updateDraft.submit({ submit: false })
-	else if (!isMailEmpty.value) await createMail.submit({ save_as_draft: true })
-	isSavingDraft.value = false
-}
-
-// Mirrors UNDO_SEND_WINDOW_SECONDS in api/mail.py; the server holds delivery a few
-// seconds longer than this so a last-moment Undo still lands in time.
-const UNDO_SEND_WINDOW_MS = 10000
-
-// A plain Send holds delivery for the undo window ('undo'); the Schedule send flow
-// passes an explicit time ('scheduled'). Both come back with status 'Scheduled', so
-// the toast has to know which one it is confirming.
-const sendMode = ref<'undo' | 'scheduled'>('undo')
-
-const sendMail = async (sendAt?: string) => {
-	if (deleteMail.loading) return
-
-	if (isRecipientsEmpty.value)
-		return raiseToast(__('Please add at least one recipient.'), 'error')
-
-	sendMode.value = sendAt ? 'scheduled' : 'undo'
-	isSavingDraft.value = false
-	show.value = false
-	if (createMail.loading) await createMail.promise
-	if (updateDraft.loading) await updateDraft.promise
-
-	if (mail.id) updateDraft.submit({ submit: true, send_at: sendAt, undo_send: !sendAt })
-	else createMail.submit({ save_as_draft: false, send_at: sendAt, undo_send: !sendAt })
-}
-
-// Undo send: Send actually scheduled delivery a few seconds out (server-side hold), so
-// undoing is just cancelling that schedule — the message lands back in Drafts.
-
-const undoSend = createResource({
-	url: 'suite.mail.api.mail.cancel_scheduled_mail',
-	makeParams: ({ name }: { name: string }) => ({ account: scopeAccountId.value, name }),
-	onSuccess: () => {
-		reloadMails()
-		raiseToast(__('Sending undone. The message is back in your drafts.'))
-	},
-	onError: (error) => raiseToast(error.message, 'error'),
-})
-
-// Schedule send (FUTURERELEASE)
-
-const showScheduleModal = ref(false)
-
-const openScheduleModal = () => {
-	if (isRecipientsEmpty.value)
-		return raiseToast(__('Please add at least one recipient.'), 'error')
-
-	showScheduleModal.value = true
-}
-
-const scheduleSend = (sendAt: string) => sendMail(sendAt)
-
-const isDiscarding = ref(false)
-
-const discardMail = async () => {
-	if (deleteMail.loading) return
-
-	isDiscarding.value = true
-	show.value = false
-	if (createMail.loading) await createMail.promise
-	if (updateDraft.loading) await updateDraft.promise
-	if (mail.id) deleteMail.submit()
-	else emit('discardMail')
-}
-
-watch(show, (val) => {
-	if (val) return
-	isDiscarding.value = false
-	isSavingDraft.value = false
-})
-
 defineExpose({ sendMail, discardMail, openScheduleModal })
-
-const onMailUpdateSuccess = ({
-	name,
-	id,
-	status,
-	error,
-	thread_id,
-}: {
-	name: string
-	id: string
-	status: string
-	error: string
-	thread_id?: string
-}) => {
-	if (id) mail.id = id
-	updateOriginalMail()
-	if (error) return raiseToast(error, 'error')
-	if (isDiscarding.value) return
-
-	if (!isInThread || status === 'Submitted' || status === 'Scheduled') reloadMails()
-	if (show.value) return
-
-	if (status === 'Drafted' && isSavingDraft.value) raiseToast(__('Draft saved.'))
-	else if (status === 'Submitted')
-		raiseToast(
-			__('Message sent.'),
-			'success',
-			// No View action when the sent mail's thread is already open in front of the user.
-			thread_id && route.params.threadID !== thread_id
-				? { label: __('View'), onClick: () => viewSentMessage(thread_id) }
-				: undefined,
-		)
-	else if (status === 'Scheduled' && sendMode.value === 'undo')
-		raiseToast(
-			__('Message sent.'),
-			'success',
-			{ label: __('Undo'), onClick: () => undoSend.submit({ name }) },
-			UNDO_SEND_WINDOW_MS,
-		)
-	else if (status === 'Scheduled')
-		raiseToast(__('Send scheduled.'), 'success', {
-			label: __('View'),
-			onClick: () =>
-				router.push({
-					name: 'mail-scheduled',
-					params: { accountId: scopeAccountId.value },
-				}),
-		})
-}
-
-// Resources
-
-const createMail = createResource({
-	url: 'suite.mail.api.mail.create_mail',
-	makeParams: ({
-		save_as_draft,
-		send_at,
-		undo_send,
-	}: {
-		save_as_draft: boolean
-		send_at?: string
-		undo_send?: boolean
-	}) => ({
-		account: scopeAccountId.value,
-		...mail,
-		...processInlineImages(mail, { sending: !save_as_draft }),
-		from_name: getIdentity(mail.from_email!)._name,
-		save_as_draft,
-		send_at,
-		undo_send,
-	}),
-	onSuccess: onMailUpdateSuccess,
-	onError: (error) => raiseToast(error.message, 'error'),
-})
-
-const updateDraft = createResource({
-	url: 'suite.mail.api.mail.update_draft_mail',
-	makeParams: ({
-		submit,
-		send_at,
-		undo_send,
-	}: {
-		submit: boolean
-		send_at?: string
-		undo_send?: boolean
-	}) => ({
-		account: scopeAccountId.value,
-		...mail,
-		...processInlineImages(mail, { sending: submit }),
-		from_name: getIdentity(mail.from_email!)._name,
-		submit,
-		send_at,
-		undo_send,
-	}),
-	onSuccess: onMailUpdateSuccess,
-	onError: (error) => raiseToast(error.message, 'error'),
-})
-
-const deleteMail = createResource({
-	url: 'suite.mail.api.mail.delete_mail',
-	makeParams: () => ({ account: scopeAccountId.value, id: mail.id }),
-	onSuccess: () => {
-		reloadMails()
-		raiseToast(__('Draft discarded.'))
-	},
-	onError: (error) => raiseToast(error.message, 'error'),
-})
-
-const isLoading = computed(() => createMail.loading || updateDraft.loading || deleteMail.loading)
 
 // Local draft actions
 
@@ -692,16 +360,8 @@ const localDraftActions = computed(() => [
 		group: '',
 		items: [
 			{ label: __('Reply'), icon: Reply, onClick: () => emit('reply') },
-			{
-				label: __('Reply All'),
-				icon: ReplyAll,
-				onClick: () => emit('replyAll'),
-			},
-			{
-				label: __('Forward'),
-				icon: Forward,
-				onClick: () => emit('forward'),
-			},
+			{ label: __('Reply All'), icon: ReplyAll, onClick: () => emit('replyAll') },
+			{ label: __('Forward'), icon: Forward, onClick: () => emit('forward') },
 		],
 	},
 	{
@@ -716,121 +376,6 @@ const localDraftActions = computed(() => [
 		],
 	},
 ])
-
-// Mail content
-
-const isRecipientsEmpty = computed(() => [mail.to, mail.cc, mail.bcc].every((d) => !d.length))
-
-const isBodyEmpty = computed(() => {
-	if (!mail.html_body) return true
-
-	const element = document.createElement('div')
-	element.innerHTML = mail.html_body
-
-	const hasText = element.textContent?.trim()
-	const hasMedia = element.querySelector('img, video, svg') !== null
-
-	return !hasText && !hasMedia
-})
-
-const isMailEmpty = computed(() => {
-	const isSubjectEmpty = !mail.subject
-	const isQuotedContentEmpty = !mail.quoted_content
-	const isAttachmentsEmpty = !mail.attachments?.length
-
-	return (
-		isSubjectEmpty &&
-		isQuotedContentEmpty &&
-		isRecipientsEmpty.value &&
-		isAttachmentsEmpty &&
-		isBodyEmpty.value
-	)
-})
-
-const openQuotedContent = () => {
-	mail.html_body += `<br>${mail.quoted_content}`
-	mail.quoted_content = ''
-}
-
-const buildSignature = (email?: string) => {
-	const identity = getIdentity(email!)
-	return identity?.text_signature
-		? `<div><br></div><div><br></div>${identity.html_signature}`
-		: ''
-}
-
-const bodyText = (html: string) => {
-	const element = document.createElement('div')
-	element.innerHTML = html || ''
-	return element.textContent?.trim() ?? ''
-}
-
-// Swap the signature when the From identity changes — but only while the body is still the
-// auto-inserted signature (or empty), so a message the user has written isn't overwritten.
-// Compared by text so the editor's HTML normalization doesn't defeat the match.
-watch(
-	() => mail.from_email,
-	(val, oldVal) => {
-		if (isBodyEmpty.value || bodyText(mail.html_body) === bodyText(buildSignature(oldVal))) {
-			mail.html_body = buildSignature(val)
-		}
-	},
-	{ immediate: true },
-)
-
-// Attachments
-
-const openAttachment = async (blob_id?: string, type?: string) => {
-	if (!blob_id) return
-
-	// Opened up front, while the click's user activation is still live: Safari blocks
-	// window.open() once the gesture has expired, which it has by the time the
-	// attachment has been fetched. A null tab means the popup blocker got it —
-	// retrying after the fetch would hit the same block, so just say so.
-	const tab = window.open('', '_blank')
-	if (!tab) return raiseToast(__('Allow popups to open attachments.'), 'error')
-
-	try {
-		tab.location.href = await getAttachmentUrl(blob_id, type, scopeAccountId.value)
-	} catch {
-		tab.close()
-	}
-}
-
-// Custom Extensions
-
-const uploadFunction = async (file: File) => {
-	const fileUpload = useFileUpload()
-	return fileUpload.upload(file, {
-		private: true,
-		folder: 'Home/Frappe Mail',
-		upload_endpoint: '/api/method/suite.mail.api.mail.upload_file',
-	})
-}
-
-const CustomImageExtension = ImageExtension.extend({
-	addAttributes() {
-		return {
-			...this.parent?.(),
-			'data-cid': {
-				default: null,
-				parseHTML: (element) => element.getAttribute('data-cid'),
-				renderHTML: (attributes) => {
-					const src = attributes.src || ''
-					if (
-						!attributes['data-cid'] &&
-						(src.startsWith('/files') || src.startsWith('/private/files'))
-					)
-						attributes['data-cid'] = randomString(10)
-					return { 'data-cid': attributes['data-cid'] }
-				},
-			},
-		}
-	},
-}).configure({
-	HTMLAttributes: { width: '600', style: 'max-width:100%; height:auto' },
-	uploadFunction,
-})
 
 const TYPE_ICON_MAP = {
 	reply: Reply,

--- a/frontend/src/apps/mail/components/ComposeMailEditor.vue
+++ b/frontend/src/apps/mail/components/ComposeMailEditor.vue
@@ -10,9 +10,9 @@
 		:extensions="[CustomImageExtension, CustomParagraphExtension, ...MentionExtensions]"
 		:content="mail.html_body.replaceAll('<div><br></div>', '<div></div>')"
 		:upload-function
-		class="flex flex-col max-sm:overflow-y-auto"
+		class="flex flex-col max-sm:min-h-0 max-sm:flex-1 max-sm:overflow-y-auto max-sm:overscroll-contain"
 		:class="{ 'pointer-events-none opacity-50': !show, 'sm:h-[75vh]': !isInThread }"
-		:style="isMobile && { height: editorHeight }"
+		@focusin="onFocusIn"
 		@change="
 			(val: string) => {
 				mail.html_body = val.replaceAll('<div></div>', '<div><br></div>')
@@ -200,6 +200,9 @@
 				</div>
 			</div>
 		</template>
+		<!-- Last child of the scroller, so `sticky bottom-0` (mobile, in the toolbar itself) pins it to
+		     the bottom of the scrollport while the fields and body scroll under it. The sheet ends where
+		     the keyboard begins, so that bottom edge is the top of the keyboard. -->
 		<template #bottom>
 			<ComposeMailToolbar
 				:is-recipients-empty
@@ -267,7 +270,7 @@ import {
 	raiseToast,
 	randomString,
 } from '@/apps/mail/utils'
-import { useScreenSize, useVisualViewport } from '@/apps/mail/utils/composables'
+import { useScreenSize } from '@/apps/mail/utils/composables'
 import { createMentionSuggestion } from '@/apps/mail/utils/mentionSuggestion'
 import { CustomParagraphExtension } from '@/apps/mail/utils/text-editor'
 import { injectAccountScope } from '@/apps/mail/utils/accountScope'
@@ -334,14 +337,48 @@ const toggleCcBcc = () => {
 	if (showCcBcc.value) nextTick(() => ccInput.value?.setFocus())
 }
 
+// Pre-empt iOS's focus reveal. When focus moves to a field it thinks the keyboard covers, iOS scrolls
+// the page itself to bring it up — and a fixed pane can only chase that pan a frame behind, which is
+// the sheet lurching up and settling back on every hop between the body and the fields above.
+//
+// Putting the caret somewhere comfortable ourselves, synchronously as focus lands, leaves iOS with
+// nothing to reveal and so nothing to pan. Scrolling the pane we already own is invisible by
+// comparison — it's the scroll the reader asked for.
+const revealFocused = (target?: Element | null) => {
+	const scroller = textEditor.value?.$el as HTMLElement | undefined
+	const editor = textEditor.value?.editor
+	if (!isMobile.value || !scroller) return
+
+	const node = target ?? document.activeElement
+	if (!node || !scroller.contains(node)) return
+
+	// The body's element spans the whole composition, so its box says nothing about where the caret
+	// is; ask ProseMirror. Every other field is small enough to use its own.
+	const rect =
+		editor && node === editor.view.dom
+			? editor.view.coordsAtPos(editor.state.selection.head)
+			: node.getBoundingClientRect()
+
+	const view = scroller.getBoundingClientRect()
+	const margin = 24
+
+	if (rect.bottom > view.bottom - margin) scroller.scrollTop += rect.bottom - view.bottom + margin
+	else if (rect.top < view.top + margin) scroller.scrollTop -= view.top + margin - rect.top
+}
+
+const onFocusIn = (event: FocusEvent) => revealFocused(event.target as Element | null)
+
+// The keyboard opening shrinks the pane under whatever is already focused, which puts it back within
+// reach of iOS's reveal — so do it again once the new size has landed.
+const onViewportResize = () => requestAnimationFrame(() => revealFocused())
+
+onMounted(() => window.visualViewport?.addEventListener('resize', onViewportResize))
+onUnmounted(() => window.visualViewport?.removeEventListener('resize', onViewportResize))
+
 const appendEmoji = (emoji: string) => {
 	textEditor.value.editor.commands.insertContent(emoji)
 	textEditor.value.editor.commands.focus()
 }
-
-const editorHeight = useVisualViewport(
-	(viewport) => `${viewport.height - viewport.offsetTop - 113}px`,
-)
 
 // Mentions
 

--- a/frontend/src/apps/mail/components/ComposeMailToolbar.vue
+++ b/frontend/src/apps/mail/components/ComposeMailToolbar.vue
@@ -1,5 +1,9 @@
 <template>
-	<div :class="{ 'fixed left-0 right-0 z-20': isMobile }" :style="{ bottom: toolbarBottom }">
+	<!-- Sticky rather than fixed: fixed positions against the layout viewport, which on iOS still spans
+	     the screen with the keyboard up, so the toolbar had to be chased into place with a JS-computed
+	     `bottom` — a frame behind every pan, which is what made it judder. Sticking to the bottom of the
+	     scroller needs no measuring: the scroller already ends at the keyboard. -->
+	<div :class="{ 'bg-surface-base sticky bottom-0 z-20': isMobile }">
 		<div
 			class="flex flex-wrap justify-between gap-2 overflow-hidden pt-2.5"
 			:class="{ 'pb-2.5': isMobile }"
@@ -74,7 +78,7 @@ import { CalendarClock, ChevronDown, Laugh, Paperclip, SendHorizontal, Trash2 } 
 import { Button, Dropdown, TextEditorFixedMenu } from 'frappe-ui'
 
 import { isMac } from '@/apps/mail/utils'
-import { useScreenSize, useTextEditorButtons, useVisualViewport } from '@/apps/mail/utils/composables'
+import { useScreenSize, useTextEditorButtons } from '@/apps/mail/utils/composables'
 import EmojiPicker from '@/apps/mail/components/EmojiPicker.vue'
 
 const { isRecipientsEmpty } = defineProps<{
@@ -93,14 +97,8 @@ const sendOptions = [
 	},
 ]
 
-// Make toolbar hover over keyboard on mobile
-
 const { isMobile } = useScreenSize()
 const { buttons } = useTextEditorButtons()
-
-const toolbarBottom = useVisualViewport(
-	(viewport) => `${window.innerHeight - viewport.height - viewport.offsetTop}px`,
-)
 
 const fileInput = useTemplateRef('fileInput')
 

--- a/frontend/src/apps/mail/components/Controls/RecipientInput.vue
+++ b/frontend/src/apps/mail/components/Controls/RecipientInput.vue
@@ -2,7 +2,7 @@
 	<div
 		ref="container"
 		data-recipient-input
-		class="flex w-full flex-1 cursor-text flex-wrap items-center gap-2 rounded transition-colors"
+		class="relative flex min-h-7 w-full flex-1 cursor-text flex-wrap items-center gap-2 rounded transition-colors"
 		:class="{ 'ring-outline-gray-3 ring-2': isDragOver && !isDragging }"
 		@keydown.capture="handleContainerKeydown"
 		@dragover.prevent="isDragOver = true"
@@ -10,6 +10,10 @@
 		@drop.prevent="handleDrop"
 		@click="handleClick"
 	>
+		<!-- Not selectable on mobile: keyboard selection and drag-to-another-field are both
+		     desktop gestures, and leaving them on meant a tap that was aimed at the field
+		     picked out a chip instead. Tapping one there falls through to the container and
+		     opens the field, like a tap anywhere else on the row. -->
 		<button
 			v-for="(v, i) in displayedRecipients"
 			ref="tags"
@@ -18,39 +22,49 @@
 			:class="{
 				'ring-outline-gray-3 ring-2': focusedTagIndex === i,
 			}"
-			:draggable="true"
-			@click.stop="focusedTagIndex = i"
-			@focus="focusedTagIndex = i"
+			:tabindex="isMobile ? -1 : undefined"
+			:draggable="!isMobile"
+			@click="handleTagClick($event, i)"
+			@focus="!isMobile && (focusedTagIndex = i)"
 			@blur="focusedTagIndex = -1"
 			@keydown.delete.stop="removeValueAt(i)"
 			@dragstart="handleDragStart($event, v)"
 			@dragend="handleDragEnd($event, v)"
 		>
 			<Avatar :image="v.image" :label="v.display_name || v.email" size="xs" />
-			<span :class="{ 'max-w-32 truncate': isMobile && !isFocused }">
+			<!-- Capped on mobile whether or not the field is focused: a name too long for the
+			     row wraps the chip onto two lines otherwise, which reads as a broken box. -->
+			<span :class="{ 'max-w-40 truncate': isMobile }">
 				{{ v.display_name || v.email }}
 			</span>
 			<X v-if="!isMobile || isFocused" class="icon" @click.stop="removeValue(v.email)" />
 		</button>
-		<span
-			v-if="isMobile && !isFocused && selectedRecipients.length > 2"
-			class="text-ink-gray-6"
-		>
-			{{ `+${selectedRecipients.length - 2}` }}
-		</span>
+		<span v-if="hiddenCount" class="text-ink-gray-6 text-sm">+{{ hiddenCount }}</span>
+		<!-- Taken out of flow while the collapsed row is showing on mobile: the chips fill the
+		     line, so an input that is only ever 2px wide still wraps to a second one — a row
+		     twice as tall for a caret nobody is typing into. Parked rather than hidden, because
+		     a tap on the row focuses this input and display:none can't take focus; the class is
+		     gone by the time that matters, focus being what drops it. -->
 		<Combobox
 			v-model="input"
 			v-model:open="showSuggestions"
+			v-model:query="searchText"
 			placeholder=""
 			variant="ghost"
 			:options
 			:open-on-click="false"
 			class="recipient-combobox border-none !bg-inherit !ring-0"
-			@update:query="handleInput"
+			:class="{ 'is-parked': isMobile && !isFocused }"
+			inputmode="email"
+			enterkeyhint="done"
+			autocapitalize="none"
+			autocorrect="off"
+			spellcheck="false"
+			@keydown.enter.capture="handleInlineEnter"
 			@keydown.delete.capture.stop="handleDelete($event.target.value)"
 			@paste="handlePaste"
 			@focusin="isSearchFocused = true"
-			@focusout="isSearchFocused = false"
+			@focusout="handleFieldBlur"
 			@update:selected-option="nextTick(setFocus)"
 		>
 			<template #suffix> <span /> </template>
@@ -66,6 +80,34 @@
 			</template>
 			<template #item-create="{ query }"> {{ query }} </template>
 		</Combobox>
+
+		<!--
+		  Suggestions in flow, full width, rather than in the Combobox's floating panel — the phone
+		  form Gmail's compose uses. A panel on a phone is a small card over a field the keyboard is
+		  already crowding; a list that owns the width below the field is easier to hit and can't be
+		  clipped by anything.
+
+		  Teleported to a target the parent provides, because the list has to escape this input's
+		  column (it sits to the right of the field's label) to reach both edges of the page. The
+		  Combobox stays for the chips and the typing; only its popover is suppressed.
+		-->
+		<Teleport v-if="suggestionsTo" :to="suggestionsTo">
+			<ul v-if="inlineSuggestions.length" ref="suggestionList">
+				<li v-for="option in inlineSuggestions" :key="option.email">
+					<!-- The press must not move focus: the list is only rendered while the field has it,
+					     so letting the input blur unmounts the row from under the finger and the click
+					     lands on nothing. Selection happens on the click that follows. -->
+					<button
+						class="hover:bg-surface-gray-2 flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm"
+						@mousedown.prevent
+						@click="pickSuggestion(option)"
+					>
+						<Avatar :image="option.image" :label="option.display_name || option.email" size="lg" />
+						<ContactOption :contact="option" />
+					</button>
+				</li>
+			</ul>
+		</Teleport>
 	</div>
 </template>
 
@@ -75,7 +117,7 @@ let droppedOnTarget = false
 
 <script setup lang="ts">
 import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
-import { onClickOutside, useDebounceFn } from '@vueuse/core'
+import { onClickOutside, useDebounceFn, useResizeObserver } from '@vueuse/core'
 import { X } from 'lucide-vue-next'
 import { Avatar, Combobox, createResource } from 'frappe-ui'
 
@@ -87,21 +129,21 @@ import { userStore } from '@/apps/mail/stores/user'
 
 const emit = defineEmits(['showCcBcc'])
 
+/**
+ * Where to render the suggestion list, when it should be in flow rather than in the Combobox's
+ * floating panel. Set by the mobile composer, which wants the full-width Gmail-style list; left
+ * unset on desktop, where the panel is the right shape and the popover behaviour is kept.
+ */
+const { suggestionsTo = null } = defineProps<{ suggestionsTo?: HTMLElement | null }>()
+
 const selectedRecipients = defineModel<DraftRecipient[]>({ default: () => [] })
-
-const displayedRecipients = computed(() => {
-	if (!selectedRecipients.value?.length) return []
-	if (selectedRecipients.value.length <= 2 || !isMobile.value || isFocused.value)
-		return selectedRecipients.value
-
-	return selectedRecipients.value.slice(0, 2)
-})
 
 const { isMobile } = useScreenSize()
 const store = userStore()
 
 const containerRef = useTemplateRef('container')
 const tagsRef = useTemplateRef('tags')
+const suggestionListRef = useTemplateRef('suggestionList')
 
 const input = ref('')
 const focusedTagIndex = ref(-1)
@@ -110,7 +152,83 @@ const isSearchFocused = ref(false)
 
 const isFocused = computed(() => isClicked.value || isSearchFocused.value)
 
-onClickOutside(containerRef, () => (isClicked.value = false))
+/**
+ * Collapsed, the row is one line: a chip for every recipient that fits, and a count for the
+ * rest. How many fit is a measurement rather than a number we can know up front — a chip is
+ * as wide as its name, from "Amy" up to the 160px truncation — so the full set is rendered
+ * for a frame, measured, and then cut to the ones that stayed on the first line. Both renders
+ * flush before the browser paints, so the long version is never seen.
+ */
+const isCollapsed = computed(() => isMobile.value && !isFocused.value)
+const visibleCount = ref(Number.POSITIVE_INFINITY)
+const isMeasuring = ref(false)
+
+const displayedRecipients = computed(() => {
+	const all = selectedRecipients.value ?? []
+	if (!isCollapsed.value || isMeasuring.value) return all
+	return all.slice(0, Math.max(1, visibleCount.value))
+})
+
+const hiddenCount = computed(
+	() => (selectedRecipients.value?.length ?? 0) - displayedRecipients.value.length,
+)
+
+/** `gap-2` between chips, and what "+12" needs beside them. */
+const CHIP_GAP = 8
+const COUNTER_WIDTH = 28
+
+const measureFit = async () => {
+	if (!isCollapsed.value || isMeasuring.value) return
+
+	const all = selectedRecipients.value ?? []
+	if (all.length < 2) {
+		visibleCount.value = all.length
+		return
+	}
+
+	isMeasuring.value = true
+	await nextTick()
+
+	const available = containerRef.value?.clientWidth ?? 0
+	const chips = tagsRef.value ?? []
+
+	let used = 0
+	let fit = 0
+	for (const chip of chips) {
+		const next = used + (fit ? CHIP_GAP : 0) + chip.offsetWidth
+		// The first chip stays whatever it costs — a row with no chip at all says less than
+		// one that is too wide.
+		if (fit && next > available) break
+		used = next
+		fit++
+	}
+	// Give the counter its place back off the last chip that fits.
+	while (fit > 1 && fit < chips.length && used + CHIP_GAP + COUNTER_WIDTH > available) {
+		used -= CHIP_GAP + chips[--fit].offsetWidth
+	}
+
+	visibleCount.value = fit
+	isMeasuring.value = false
+}
+
+watch([() => selectedRecipients.value?.map((r) => r.email).join(), isCollapsed], measureFit, {
+	flush: 'post',
+})
+
+// Width only: the measuring pass itself makes the container taller for a frame, and
+// re-measuring on that would never settle.
+let measuredWidth = 0
+useResizeObserver(containerRef, ([entry]) => {
+	const { width } = entry.contentRect
+	if (width === measuredWidth) return
+	measuredWidth = width
+	measureFit()
+})
+
+// The teleported suggestion list is part of this field, however far from it in the DOM —
+// without the exemption, tapping a suggestion counts as a click outside and closes the
+// list that the tap was aimed at.
+onClickOutside(containerRef, () => (isClicked.value = false), { ignore: [suggestionListRef] })
 
 const selectedEmails = computed(() => selectedRecipients.value.map((v) => v.email))
 
@@ -121,18 +239,90 @@ const fetchSuggestions = useDebounceFn((text: string) => {
 	if (text) mailContacts.reload(text)
 }, 200)
 
-const handleInput = (text: string) => {
-	searchText.value = text
+// The query is bound rather than merely observed, so picking a suggestion from the inline
+// list can clear the typed text — that path never touches the Combobox's own model, which
+// is what normally syncs the input back down after a selection.
+watch(searchText, (text) => {
 	if (!text) showSuggestions.value = false
 	fetchSuggestions(text)
-}
+})
 
 // Suggestions only exist for a typed query — with an empty input the popover
 // would show stale results from the previous query (or a bare "No results"
 // panel), so block reka's focus/arrow-key opens too, not just hide options.
+//
+// With an inline list the popover is suppressed outright: the same suggestions would otherwise
+// appear twice, once floating over the list showing them in flow.
 watch(showSuggestions, (open) => {
-	if (open && !searchText.value) showSuggestions.value = false
+	if (open && (!searchText.value || suggestionsTo)) showSuggestions.value = false
 })
+
+/**
+ * A typed address that is nobody's contact is still a recipient — the Combobox has a
+ * synthetic row for exactly this, but that row lives in the popover the inline list
+ * replaces, so the list carries its own. Suppressed once a suggestion says the same thing,
+ * which would otherwise be the same address twice.
+ */
+const typedRecipient = computed<DraftRecipient | null>(() => {
+	const email = searchText.value.trim()
+	if (!isEmail(email)) return null
+	if (selectedEmails.value.some((v) => v.toLowerCase() === email.toLowerCase())) return null
+	return { email }
+})
+
+/**
+ * Real contacts only — the Combobox's own custom rows aren't ones. Capped at five: the list
+ * sits in flow above the keyboard, and more than that just pushes the message body off the
+ * screen.
+ */
+const inlineSuggestions = computed(() => {
+	if (!suggestionsTo || !isFocused.value) return []
+
+	const contacts = options.value.filter((o) => 'email' in o) as DraftRecipient[]
+	const typed = typedRecipient.value
+	const isSuggested = contacts.some(
+		(c) => c.email.toLowerCase() === typed?.email.toLowerCase(),
+	)
+
+	return (typed && !isSuggested ? [typed, ...contacts] : contacts).slice(0, 5)
+})
+
+const commitTyped = () => {
+	const typed = typedRecipient.value
+	if (!typed) return false
+
+	selectedRecipients.value.push(typed)
+	searchText.value = ''
+	input.value = ''
+	return true
+}
+
+// Return — and the phone keyboard's Go / Done / Search, which is the same keydown — commits
+// what has been typed. The Combobox's own Enter handling belongs to the popover, which the
+// inline list replaces, so nothing else would.
+const handleInlineEnter = (e: KeyboardEvent) => {
+	if (!suggestionsTo || !typedRecipient.value) return
+	e.preventDefault()
+	e.stopPropagation()
+	commitTyped()
+	nextTick(setFocus)
+}
+
+// Leaving the field commits it too: dismissing the keyboard and tapping elsewhere never
+// send a key at all, and a typed address left behind as loose text reads as lost. Inline
+// mode only — on desktop the blur is usually a click into the popover, which is about to
+// add its own recipient.
+const handleFieldBlur = () => {
+	isSearchFocused.value = false
+	if (suggestionsTo) commitTyped()
+}
+
+const pickSuggestion = (option: DraftRecipient) => {
+	selectedRecipients.value.push(option)
+	searchText.value = ''
+	input.value = ''
+	nextTick(setFocus)
+}
 
 const handleDelete = (currentValue: string) => {
 	if (!currentValue && selectedRecipients.value.length) tagsRef.value?.at(-1)?.focus()
@@ -148,6 +338,9 @@ const handlePaste = (e: ClipboardEvent) => {
 const setFocus = () => containerRef.value?.querySelector('input')?.focus()
 const handleClick = () => {
 	isClicked.value = true
+	// Synchronously, inside the gesture: iOS only raises the keyboard for a focus() that the
+	// tap itself caused. The nextTick pass is for the input that isn't rendered yet.
+	setFocus()
 	nextTick(setFocus)
 }
 defineExpose({ setFocus })
@@ -173,6 +366,13 @@ const handleContainerKeydown = (e: KeyboardEvent) => {
 		const target = tagsRef.value?.[nextIndex] ?? inputEl
 		target?.focus()
 	}
+}
+
+const handleTagClick = (e: MouseEvent, i: number) => {
+	// Left to bubble on mobile, where the container turns it into "open this field".
+	if (isMobile.value) return
+	e.stopPropagation()
+	focusedTagIndex.value = i
 }
 
 const removeValueAt = (i: number) => {
@@ -266,10 +466,28 @@ const options = computed(() => {
 </script>
 
 <style>
-[data-recipient-input] input[data-slot='input'] {
-	flex: 0 0 auto !important;
-	field-sizing: content;
-	min-width: 2px;
+/* The trigger takes what is left of the chips' line, down to a floor of 6rem — below that
+   it wraps to a line of its own and grows to the full width, which is the room a long
+   address needs. The input inside keeps frappe-ui's own `flex-1` and fills it, which puts
+   the caret directly after the last chip either way. Sizing the input to its text instead
+   (`field-sizing: content`) is what clipped the last glyph: the box ends exactly where the
+   text does, and an input scrolls whatever is past its edge out of view. */
+[data-recipient-input] .recipient-combobox:not(.is-parked) {
+	flex: 1 1 6rem;
+	min-width: 0;
+}
+
+/* Out of flow, so the collapsed row is exactly the height of its chips, but still in the
+   DOM and focusable. Written out rather than `sr-only`, whose `absolute` loses to the
+   `relative` in frappe-ui's own trigger classes — leaving the input in flow at 1px wide,
+   clipping the query to a sliver beside the chips. */
+[data-recipient-input] .recipient-combobox.is-parked {
+	position: absolute !important;
+	inset: 0 auto auto 0;
+	height: 1px;
+	width: 1px;
+	overflow: hidden;
+	opacity: 0;
 }
 
 /* The recipient field is an inline, box-less editor. frappe-ui v2's Combobox trigger

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -232,7 +232,7 @@
 									class="mb-4"
 								/>
 
-								<div v-show="isCollapsed(mail)" class="truncate">
+								<div v-show="isCollapsed(mail)" class="truncate text-base">
 									{{ mail.preview }}
 								</div>
 
@@ -454,6 +454,7 @@ import DeliveryStatusBanner from '@/apps/mail/components/DeliveryStatusBanner.vu
 import EmailContent from '@/apps/mail/components/EmailContent.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
 import LinkifiedText from '@/components/LinkifiedText.vue'
+import { setPendingCompose } from '@/apps/mail/composables/composeHandoff'
 import MailActions from '@/apps/mail/components/MailActions.vue'
 import MailDate from '@/apps/mail/components/MailDate.vue'
 import MailDetails from '@/apps/mail/components/MailDetails.vue'
@@ -1084,6 +1085,17 @@ const showSendModal = ref(false)
 
 const popOutDraft = (mail: ComposeMailData) => {
 	draftMails[mail.name as string] = mail
+
+	// Mobile composes on a page of its own rather than in an overlay — see ComposeView. Nothing has
+	// to be handed back on the way out: leaving the compose route remounts this thread, so the reply
+	// that was just sent is there in the refetch, and a local draft that was discarded is gone with
+	// the component that was holding it.
+	if (isMobile.value) {
+		setPendingCompose(mail)
+		router.push({ name: 'mail-compose', params: { accountId: scopeAccountId.value } })
+		return
+	}
+
 	focusedDraft.value = mail.name
 	showSendModal.value = true
 }

--- a/frontend/src/apps/mail/components/SendMailMobileLayout.vue
+++ b/frontend/src/apps/mail/components/SendMailMobileLayout.vue
@@ -10,33 +10,45 @@
 	     from inside a thread (a `mailto:` link in the message) lost to the pane —
 	     which teleports out for the same reason — however high its own z went. -->
 	<Teleport to="body">
+		<!-- Two layers, because the screen and the visible area stop being the same thing once the
+		     keyboard is up. This one is the screen: it carries the slide and the background, and exists
+		     so nothing of the page shows through the strip beside the keyboard. -->
 		<div
-			class="bg-surface-base fixed inset-0 z-30 flex flex-col pt-[env(safe-area-inset-top)] transition-[transform,visibility] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
+			class="bg-surface-base fixed inset-0 z-30 transition-[transform,visibility] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
 			:class="{ 'invisible translate-y-full': !show || !painted }"
 		>
-			<div class="sticky top-0 flex items-center border-b px-3 py-2.5">
-				<Button variant="ghost" class="mr-2" @click="close">
-					<template #icon>
-						<X class="text-ink-gray-5 h-4 w-4" />
-					</template>
-				</Button>
-				<h2 class="flex-1">{{ __('Compose Mail') }}</h2>
-				<!-- AdaptiveDropdown (bottom sheet, z-50): a plain Dropdown's popup portals
-				     to body with no z-index, so this sheet would paint over it. -->
-				<AdaptiveDropdown :options="ACTIONS">
-					<Button variant="ghost" class="mr-2">
+			<!-- And this one is the visible area. Both insets are 0 wherever the browser shrinks the
+			     layout viewport for the keyboard itself, which makes this exactly `inset-0` and leaves
+			     the sizing entirely to CSS — no JS in the loop to lag a frame behind and jump. They only
+			     carry real numbers on the older iOS that needs holding off the keyboard by hand. -->
+			<div
+				class="absolute inset-x-0 flex flex-col pt-[env(safe-area-inset-top)]"
+				:style="{ top: `${keyboardTop}px`, bottom: `${keyboardBottom}px` }"
+			>
+				<div class="flex flex-none items-center border-b px-3 py-2.5">
+					<Button variant="ghost" class="mr-2" @click="close">
 						<template #icon>
-							<EllipsisVertical class="text-ink-gray-5 h-4 w-4" />
+							<X class="text-ink-gray-5 h-4 w-4" />
 						</template>
 					</Button>
-				</AdaptiveDropdown>
-				<Button variant="ghost" @click="emit('sendMail')">
-					<template #icon>
-						<SendHorizontal class="text-ink-gray-5 h-4 w-4" />
-					</template>
-				</Button>
+					<h2 class="flex-1">{{ __('Compose Mail') }}</h2>
+					<!-- AdaptiveDropdown (bottom sheet, z-50): a plain Dropdown's popup portals
+					     to body with no z-index, so this sheet would paint over it. -->
+					<AdaptiveDropdown :options="ACTIONS">
+						<Button variant="ghost" class="mr-2">
+							<template #icon>
+								<EllipsisVertical class="text-ink-gray-5 h-4 w-4" />
+							</template>
+						</Button>
+					</AdaptiveDropdown>
+					<Button variant="ghost" @click="emit('sendMail')">
+						<template #icon>
+							<SendHorizontal class="text-ink-gray-5 h-4 w-4" />
+						</template>
+					</Button>
+				</div>
+				<slot name="body-content" />
 			</div>
-			<slot name="body-content" />
 		</div>
 	</Teleport>
 </template>
@@ -46,9 +58,12 @@ import { onMounted, onUnmounted, ref, watch } from 'vue'
 import { CalendarClock, EllipsisVertical, SendHorizontal, Trash2, X } from 'lucide-vue-next'
 import { Button } from 'frappe-ui'
 
+import { useKeyboardInsets } from '@/apps/mail/utils/composables'
 import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 
 const show = defineModel<boolean>()
+
+const { top: keyboardTop, bottom: keyboardBottom } = useKeyboardInsets()
 
 const emit = defineEmits(['reloadMails', 'sendMail', 'discardMail', 'scheduleSend'])
 
@@ -75,11 +90,44 @@ watch(
 	{ immediate: true },
 )
 
+// Hold the page still underneath, so the only thing in the sheet that scrolls is the pane below the
+// header. A drag its scroller can't absorb otherwise chains to the document, and with the keyboard up
+// that drags the whole sheet across the screen. Nothing to scroll, nothing to chain to.
+//
+// `immediate`, because reply and forward mount this already open — a watcher that only fires on change
+// would never lock it for them.
+watch(
+	show,
+	(open) => {
+		const { style } = document.body
+		style.overflow = open ? 'hidden' : ''
+		style.overscrollBehavior = open ? 'none' : ''
+		// `overflow: hidden` alone still leaves iOS a document to scroll when it wants to reveal a
+		// focused field, and with nowhere to scroll it pans the visual viewport instead — the sheet
+		// sliding up and settling back. Taking the body out of flow entirely removes the last thing
+		// that could move.
+		style.position = open ? 'fixed' : ''
+		style.width = open ? '100%' : ''
+		document.documentElement.style.overflow = open ? 'hidden' : ''
+	},
+	{ immediate: true },
+)
+
 onMounted(() => {
 	requestAnimationFrame(() => requestAnimationFrame(() => (painted.value = true)))
 	window.addEventListener('popstate', close)
 })
-onUnmounted(() => window.removeEventListener('popstate', close))
+
+onUnmounted(() => {
+	window.removeEventListener('popstate', close)
+	document.documentElement.style.overflow = ''
+	Object.assign(document.body.style, {
+		overflow: '',
+		overscrollBehavior: '',
+		position: '',
+		width: '',
+	})
+})
 
 const ACTIONS = [
 	{

--- a/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
@@ -16,7 +16,7 @@
 		variant="solid"
 		class="fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] right-4 z-10 !h-14 !w-14 !rounded-full shadow-lg"
 		:aria-label="__('Compose')"
-		@click="showSendModal = true"
+		@click="openCompose"
 	>
 		<template #icon>
 			<FeatherIcon name="edit" class="h-6 w-6" />
@@ -77,7 +77,6 @@
 		</div>
 	</nav>
 
-	<SendMail v-model="showSendModal" />
 	<SearchModal v-model="showSearchModal" />
 	<MobileFolderSheet />
 </template>
@@ -91,8 +90,8 @@ import { Icon } from 'frappe-ui/icons'
 import { getIcon, getMailboxName } from '@/apps/mail/utils'
 import { useFolderSheet, useMobileSelection } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
+import { setPendingCompose } from '@/apps/mail/composables/composeHandoff'
 import SearchModal from '@/apps/mail/components/Modals/SearchModal.vue'
-import SendMail from '@/apps/mail/components/SendMail.vue'
 import MobileFolderSheet from '@/apps/mail/components/mobile/MobileFolderSheet.vue'
 
 import type { MailboxData } from '@/apps/mail/types'
@@ -118,8 +117,14 @@ const currentFolder = computed(() => {
 	return mailbox ? { label: getMailboxName(mailbox), icon: getIcon(mailbox) } : null
 })
 
-const showSendModal = ref(false)
 const showSearchModal = ref(false)
+
+// Compose is a route now, not an overlay, so the back gesture closes it and the composer owns a
+// whole screen to lay itself out in rather than floating over this one.
+const openCompose = () => {
+	setPendingCompose(undefined)
+	router.push({ name: 'mail-compose', params: { accountId: store.accountId } })
+}
 
 const MAIL_ROUTES = ['mail-mailbox', 'mail-all-inboxes']
 const isThreadOpen = computed(() => !!route.params.threadID)

--- a/frontend/src/apps/mail/composables/composeHandoff.ts
+++ b/frontend/src/apps/mail/composables/composeHandoff.ts
@@ -1,0 +1,24 @@
+import type { ComposeMailData } from '@/apps/mail/types'
+
+/**
+ * The draft a `/compose` navigation is carrying — a reply, a forward, a `mailto:` link, or a draft
+ * being resumed.
+ *
+ * A route param can't hold it: the payload is a whole message (recipients, quoted body, attachment
+ * records), and putting that in the URL would make every compose link a wall of encoded HTML that
+ * breaks the moment someone shares or reloads it. So the opener leaves it here and the page picks it
+ * up on mount.
+ *
+ * Taking it clears it, which is the point: a reload lands on an empty composer rather than silently
+ * re-opening a reply the user has already dealt with, and the next plain "new mail" doesn't inherit
+ * the last reply's recipients.
+ */
+let pending: ComposeMailData | undefined
+
+export const setPendingCompose = (draft?: ComposeMailData) => (pending = draft)
+
+export const takePendingCompose = () => {
+	const draft = pending
+	pending = undefined
+	return draft
+}

--- a/frontend/src/apps/mail/composables/useComposeMail.ts
+++ b/frontend/src/apps/mail/composables/useComposeMail.ts
@@ -1,0 +1,458 @@
+import { computed, reactive, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { watchDebounced } from '@vueuse/core'
+import { createResource } from 'frappe-ui'
+import { Mention } from 'frappe-ui/editor'
+
+import { getAttachmentUrl } from '@/apps/mail/resources'
+import { processInlineImages, raiseToast } from '@/apps/mail/utils'
+import { createMentionSuggestion } from '@/apps/mail/utils/mentionSuggestion'
+import { injectAccountScope } from '@/apps/mail/utils/accountScope'
+
+import type { ComposeMailData, Identity } from '@/apps/mail/types'
+import type { MentionCandidate } from '@/apps/mail/utils/mentionSuggestion'
+
+/** The mounted TextEditor instance, as far as this composable cares about it. */
+interface EditorHost {
+	$el?: HTMLElement
+	editor?: {
+		commands: { insertContent: (content: string) => void; focus: () => void }
+		state: { doc: { descendants: (fn: (node: any) => void) => void } }
+	}
+}
+
+export interface ComposeMailOptions {
+	/** A draft being resumed, or the reply/forward this composition starts from. */
+	mailDetails?: ComposeMailData
+	/** Inline in a thread (desktop), rather than a composer of its own. */
+	isInThread?: boolean
+	reloadMails: () => void
+	/** Take the composer off screen — the dialog's v-model on desktop, a route pop on mobile. */
+	close: () => void
+	/** Whether the composer is still on screen. Drives whether a result is worth a toast. */
+	isOpen: () => boolean
+	/** Called instead of a server delete when discarding something never saved. */
+	onDiscardUnsaved?: () => void
+	/** The mounted TextEditor, for mention bookkeeping and emoji insertion. */
+	host: () => EditorHost | null | undefined
+	/**
+	 * Where the mention dropdown should render. The dialog on desktop, which holds the rest of the
+	 * page inert; null anywhere `<body>` will do.
+	 */
+	mentionContainer?: () => HTMLElement | null
+}
+
+/**
+ * Everything a composition *is*, with no opinion on how it's laid out: the draft itself, saving,
+ * sending, scheduling, discarding, attachments and mentions.
+ *
+ * Split out because compose has two very different shapes — a dialog on desktop, a full page on
+ * mobile — and the only way to keep those from drifting into two subtly different mail clients is
+ * for the behaviour to live in one place and only the markup to differ.
+ */
+export const useComposeMail = (options: ComposeMailOptions) => {
+	const { mailDetails, isInThread = false, reloadMails, close, isOpen, host } = options
+
+	const router = useRouter()
+	const route = useRoute()
+
+	// Sends as the enclosing pane's account (the thread's owning account in All Inboxes, the active
+	// one everywhere else): identities, the default outgoing address and every draft call resolve
+	// through this scope.
+	const scope = injectAccountScope()
+	const { accountId: scopeAccountId, identities, mailboxIds } = scope
+
+	const getIdentity = (email: string) =>
+		identities.value.data?.find((identity: Identity) => identity.email === email)
+
+	const viewSentMessage = (threadID: string) =>
+		router.push({
+			name: 'mail-mail',
+			params: { accountId: scopeAccountId.value, mailbox: mailboxIds.value.sent, threadID },
+		})
+
+	const getDefaultFromEmail = () => {
+		const identityEmails = identities.value.data?.map((i: Identity) => i.email) ?? []
+		const defaultOutgoingEmail = scope.account.value?.default_outgoing_email
+
+		return (
+			identityEmails.find((e) => e === mailDetails?.from_email) ??
+			identityEmails.find((e) => e === defaultOutgoingEmail) ??
+			identityEmails[0]
+		)
+	}
+
+	const mail = reactive<ComposeMailData>({
+		name: mailDetails?.name || '',
+		id: mailDetails?.id || '',
+		from_email: getDefaultFromEmail(),
+		to: mailDetails?.to || [],
+		cc: mailDetails?.cc || [],
+		bcc: mailDetails?.bcc || [],
+		attachments: mailDetails?.attachments || [],
+		subject: mailDetails?.subject || '',
+		html_body: mailDetails?.html_body || '',
+		quoted_content: mailDetails?.quoted_content || '',
+		in_reply_to: mailDetails?.in_reply_to || '',
+		in_reply_to_id: mailDetails?.in_reply_to_id || '',
+		forwarded_from_id: mailDetails?.forwarded_from_id || '',
+	})
+
+	const originalMail = ref<ComposeMailData>()
+	const updateOriginalMail = () => (originalMail.value = JSON.parse(JSON.stringify(mail)))
+	const isDraftUpdated = computed(() => JSON.stringify(mail) !== JSON.stringify(originalMail.value))
+
+	// ── What's in the mail ──────────────────────────────────────────────────────────────────────
+
+	const isRecipientsEmpty = computed(() => [mail.to, mail.cc, mail.bcc].every((d) => !d.length))
+
+	const isBodyEmpty = computed(() => {
+		if (!mail.html_body) return true
+
+		const element = document.createElement('div')
+		element.innerHTML = mail.html_body
+
+		return !element.textContent?.trim() && element.querySelector('img, video, svg') === null
+	})
+
+	const isMailEmpty = computed(
+		() =>
+			!mail.subject &&
+			!mail.quoted_content &&
+			!mail.attachments?.length &&
+			isRecipientsEmpty.value &&
+			isBodyEmpty.value,
+	)
+
+	const openQuotedContent = () => {
+		mail.html_body += `<br>${mail.quoted_content}`
+		mail.quoted_content = ''
+	}
+
+	// ── Signature ───────────────────────────────────────────────────────────────────────────────
+
+	const buildSignature = (email?: string) => {
+		const identity = getIdentity(email!)
+		return identity?.text_signature
+			? `<div><br></div><div><br></div>${identity.html_signature}`
+			: ''
+	}
+
+	const bodyText = (html: string) => {
+		const element = document.createElement('div')
+		element.innerHTML = html || ''
+		return element.textContent?.trim() ?? ''
+	}
+
+	// Swap the signature when the From identity changes — but only while the body is still the
+	// auto-inserted signature (or empty), so a message the user has written isn't overwritten.
+	// Compared by text so the editor's HTML normalization doesn't defeat the match.
+	watch(
+		() => mail.from_email,
+		(val, oldVal) => {
+			if (isBodyEmpty.value || bodyText(mail.html_body) === bodyText(buildSignature(oldVal)))
+				mail.html_body = buildSignature(val)
+		},
+		{ immediate: true },
+	)
+
+	// ── Sending, saving, discarding ─────────────────────────────────────────────────────────────
+
+	const isSavingDraft = ref(false)
+	const isDiscarding = ref(false)
+
+	const saveDraft = async () => {
+		if (!isDraftUpdated.value || isLoading.value || isDiscarding.value) return
+
+		isSavingDraft.value = true
+		if (mail.id) await updateDraft.submit({ submit: false })
+		else if (!isMailEmpty.value) await createMail.submit({ save_as_draft: true })
+		isSavingDraft.value = false
+	}
+
+	watchDebounced(mail, () => saveDraft(), { debounce: 2000 })
+
+	// Mirrors UNDO_SEND_WINDOW_SECONDS in api/mail.py; the server holds delivery a few seconds
+	// longer than this so a last-moment Undo still lands in time.
+	const UNDO_SEND_WINDOW_MS = 10000
+
+	// A plain Send holds delivery for the undo window ('undo'); Schedule send passes an explicit time
+	// ('scheduled'). Both come back as 'Scheduled', so the toast has to know which one it confirms.
+	const sendMode = ref<'undo' | 'scheduled'>('undo')
+
+	const sendMail = async (sendAt?: string) => {
+		if (deleteMail.loading) return
+
+		if (isRecipientsEmpty.value)
+			return raiseToast(__('Please add at least one recipient.'), 'error')
+
+		sendMode.value = sendAt ? 'scheduled' : 'undo'
+		isSavingDraft.value = false
+		close()
+		if (createMail.loading) await createMail.promise
+		if (updateDraft.loading) await updateDraft.promise
+
+		if (mail.id) updateDraft.submit({ submit: true, send_at: sendAt, undo_send: !sendAt })
+		else createMail.submit({ save_as_draft: false, send_at: sendAt, undo_send: !sendAt })
+	}
+
+	const discardMail = async () => {
+		if (deleteMail.loading) return
+
+		isDiscarding.value = true
+		close()
+		if (createMail.loading) await createMail.promise
+		if (updateDraft.loading) await updateDraft.promise
+		if (mail.id) deleteMail.submit()
+		else options.onDiscardUnsaved?.()
+	}
+
+	/** Reset the in-flight flags once the composer is off screen. */
+	const onClosed = () => {
+		isDiscarding.value = false
+		isSavingDraft.value = false
+	}
+
+	// Schedule send (FUTURERELEASE)
+
+	const showScheduleModal = ref(false)
+
+	const openScheduleModal = () => {
+		if (isRecipientsEmpty.value)
+			return raiseToast(__('Please add at least one recipient.'), 'error')
+
+		showScheduleModal.value = true
+	}
+
+	const scheduleSend = (sendAt: string) => sendMail(sendAt)
+
+	// Undo send: Send actually scheduled delivery a few seconds out (a server-side hold), so undoing
+	// is just cancelling that schedule — the message lands back in Drafts.
+	const undoSend = createResource({
+		url: 'suite.mail.api.mail.cancel_scheduled_mail',
+		makeParams: ({ name }: { name: string }) => ({ account: scopeAccountId.value, name }),
+		onSuccess: () => {
+			reloadMails()
+			raiseToast(__('Sending undone. The message is back in your drafts.'))
+		},
+		onError: (error: { message: string }) => raiseToast(error.message, 'error'),
+	})
+
+	const onMailUpdateSuccess = ({
+		name,
+		id,
+		status,
+		error,
+		thread_id,
+	}: {
+		name: string
+		id: string
+		status: string
+		error: string
+		thread_id?: string
+	}) => {
+		if (id) mail.id = id
+		updateOriginalMail()
+		if (error) return raiseToast(error, 'error')
+		if (isDiscarding.value) return
+
+		if (!isInThread || status === 'Submitted' || status === 'Scheduled') reloadMails()
+		if (isOpen()) return
+
+		if (status === 'Drafted' && isSavingDraft.value) raiseToast(__('Draft saved.'))
+		else if (status === 'Submitted')
+			raiseToast(
+				__('Message sent.'),
+				'success',
+				// No View action when the sent mail's thread is already open in front of the user.
+				thread_id && route.params.threadID !== thread_id
+					? { label: __('View'), onClick: () => viewSentMessage(thread_id) }
+					: undefined,
+			)
+		else if (status === 'Scheduled' && sendMode.value === 'undo')
+			raiseToast(
+				__('Message sent.'),
+				'success',
+				{ label: __('Undo'), onClick: () => undoSend.submit({ name }) },
+				UNDO_SEND_WINDOW_MS,
+			)
+		else if (status === 'Scheduled')
+			raiseToast(__('Send scheduled.'), 'success', {
+				label: __('View'),
+				onClick: () =>
+					router.push({
+						name: 'mail-scheduled',
+						params: { accountId: scopeAccountId.value },
+					}),
+			})
+	}
+
+	// ── Resources ───────────────────────────────────────────────────────────────────────────────
+
+	const createMail = createResource({
+		url: 'suite.mail.api.mail.create_mail',
+		makeParams: ({
+			save_as_draft,
+			send_at,
+			undo_send,
+		}: {
+			save_as_draft: boolean
+			send_at?: string
+			undo_send?: boolean
+		}) => ({
+			account: scopeAccountId.value,
+			...mail,
+			...processInlineImages(mail, { sending: !save_as_draft }),
+			from_name: getIdentity(mail.from_email!)._name,
+			save_as_draft,
+			send_at,
+			undo_send,
+		}),
+		onSuccess: onMailUpdateSuccess,
+		onError: (error: { message: string }) => raiseToast(error.message, 'error'),
+	})
+
+	const updateDraft = createResource({
+		url: 'suite.mail.api.mail.update_draft_mail',
+		makeParams: ({
+			submit,
+			send_at,
+			undo_send,
+		}: {
+			submit: boolean
+			send_at?: string
+			undo_send?: boolean
+		}) => ({
+			account: scopeAccountId.value,
+			...mail,
+			...processInlineImages(mail, { sending: submit }),
+			from_name: getIdentity(mail.from_email!)._name,
+			submit,
+			send_at,
+			undo_send,
+		}),
+		onSuccess: onMailUpdateSuccess,
+		onError: (error: { message: string }) => raiseToast(error.message, 'error'),
+	})
+
+	const deleteMail = createResource({
+		url: 'suite.mail.api.mail.delete_mail',
+		makeParams: () => ({ account: scopeAccountId.value, id: mail.id }),
+		onSuccess: () => {
+			reloadMails()
+			raiseToast(__('Draft discarded.'))
+		},
+		onError: (error: { message: string }) => raiseToast(error.message, 'error'),
+	})
+
+	const isLoading = computed(() => createMail.loading || updateDraft.loading || deleteMail.loading)
+
+	// ── Attachments ─────────────────────────────────────────────────────────────────────────────
+
+	const openAttachment = async (blob_id?: string, type?: string) => {
+		if (!blob_id) return
+
+		// Opened up front, while the click's user activation is still live: Safari blocks
+		// window.open() once the gesture has expired, which it has by the time the attachment has
+		// been fetched. A null tab means the popup blocker got it — retrying after the fetch would
+		// hit the same block, so just say so.
+		const tab = window.open('', '_blank')
+		if (!tab) return raiseToast(__('Allow popups to open attachments.'), 'error')
+
+		try {
+			tab.location.href = await getAttachmentUrl(blob_id, type, scopeAccountId.value)
+		} catch {
+			tab.close()
+		}
+	}
+
+	// ── Mentions ────────────────────────────────────────────────────────────────────────────────
+
+	// Picking a mention adds that person to To — reaching back up to the recipient fields is the trip
+	// the shortcut exists to save. Only the pick adds, so a mention arriving with pasted or forwarded
+	// content doesn't quietly address the mail to anyone.
+	//
+	// Recipients this composer added that way, and only those: deleting the mention takes them back
+	// out again, while someone typed into To by hand and then mentioned stays put — the mention
+	// didn't put them there and doesn't get to remove them.
+	const mentionedRecipients = new Set<string>()
+
+	const addMentionedRecipient = ({ email, display_name, image }: MentionCandidate) => {
+		if ([...mail.to, ...mail.cc, ...mail.bcc].some((r) => r.email === email)) return
+
+		mail.to.push({ email, display_name, image })
+		mentionedRecipients.add(email)
+	}
+
+	const dropUnmentionedRecipients = () => {
+		const editor = host()?.editor
+		if (!editor || !mentionedRecipients.size) return
+
+		const mentioned = new Set<string>()
+		editor.state.doc.descendants((node) => {
+			if (node.type.name === 'mention' && node.attrs.id) mentioned.add(node.attrs.id)
+		})
+
+		for (const email of mentionedRecipients) {
+			// Still named somewhere in the body — mentioning someone twice and deleting one of the
+			// two keeps them addressed.
+			if (mentioned.has(email)) continue
+
+			mail.to = mail.to.filter((recipient) => recipient.email !== email)
+			mentionedRecipients.delete(email)
+		}
+	}
+
+	const mentionExtensions = [
+		// The inline node. Its own `@` suggester stays inert with no item source of its own — the
+		// search below is the one wired up.
+		Mention,
+		createMentionSuggestion({
+			account: () => scopeAccountId.value,
+			onSelect: addMentionedRecipient,
+			container: () => options.mentionContainer?.() ?? null,
+		}),
+	]
+
+	const appendEmoji = (emoji: string) => {
+		const editor = host()?.editor
+		editor?.commands.insertContent(emoji)
+		editor?.commands.focus()
+	}
+
+	/** The body as the editor should receive it, and the inverse on the way back out. */
+	const editorContent = computed(() => mail.html_body.replaceAll('<div><br></div>', '<div></div>'))
+	const onEditorChange = (value: string) => {
+		mail.html_body = value.replaceAll('<div></div>', '<div><br></div>')
+		dropUnmentionedRecipients()
+	}
+
+	return {
+		mail,
+		scope,
+		scopeAccountId,
+		identities,
+		getIdentity,
+		updateOriginalMail,
+		isDraftUpdated,
+		isRecipientsEmpty,
+		isBodyEmpty,
+		isMailEmpty,
+		isLoading,
+		isSavingDraft,
+		isDiscarding,
+		saveDraft,
+		sendMail,
+		discardMail,
+		onClosed,
+		showScheduleModal,
+		openScheduleModal,
+		scheduleSend,
+		openQuotedContent,
+		openAttachment,
+		mentionExtensions,
+		appendEmoji,
+		editorContent,
+		onEditorChange,
+	}
+}

--- a/frontend/src/apps/mail/composables/useComposeMail.ts
+++ b/frontend/src/apps/mail/composables/useComposeMail.ts
@@ -1,4 +1,4 @@
-import { computed, reactive, ref, watch } from 'vue'
+import { computed, inject, reactive, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { watchDebounced } from '@vueuse/core'
 import { createResource } from 'frappe-ui'
@@ -9,7 +9,7 @@ import { processInlineImages, raiseToast } from '@/apps/mail/utils'
 import { createMentionSuggestion } from '@/apps/mail/utils/mentionSuggestion'
 import { injectAccountScope } from '@/apps/mail/utils/accountScope'
 
-import type { ComposeMailData, Identity } from '@/apps/mail/types'
+import type { ComposeMailData, Identity, UserResource } from '@/apps/mail/types'
 import type { MentionCandidate } from '@/apps/mail/utils/mentionSuggestion'
 
 /** The mounted TextEditor instance, as far as this composable cares about it. */
@@ -59,6 +59,7 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 	// Sends as the enclosing pane's account (the thread's owning account in All Inboxes, the active
 	// one everywhere else): identities, the default outgoing address and every draft call resolve
 	// through this scope.
+	const user = inject('$user') as UserResource
 	const scope = injectAccountScope()
 	const { accountId: scopeAccountId, identities, mailboxIds } = scope
 
@@ -78,7 +79,9 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 		return (
 			identityEmails.find((e) => e === mailDetails?.from_email) ??
 			identityEmails.find((e) => e === defaultOutgoingEmail) ??
-			identityEmails[0]
+			identityEmails[0] ??
+			// An account with no identities at all still has to send as somebody.
+			user.data.name
 		)
 	}
 

--- a/frontend/src/apps/mail/pages/ComposeView.vue
+++ b/frontend/src/apps/mail/pages/ComposeView.vue
@@ -22,24 +22,30 @@
 		:style="{ top: `${keyboardTop}px`, height: `${viewportHeight}px` }"
 	>
 		<header
-			class="bg-surface-base z-20 flex shrink-0 items-center gap-1 border-b px-2 pb-2.5 pt-[calc(env(safe-area-inset-top)+0.625rem)]"
+			class="bg-surface-base z-20 flex shrink-0 items-center gap-1 border-b pb-2.5 pl-2 pr-4 pt-[calc(env(safe-area-inset-top)+0.875rem)]"
 		>
 			<Button variant="ghost" :label="__('Close')" @click="closeCompose">
 				<template #icon>
-					<X class="text-ink-gray-5 h-4 w-4" />
+					<X class="text-ink-gray-5 size-5" />
 				</template>
 			</Button>
 			<h2 class="text-ink-gray-8 flex-1 text-base font-medium">{{ __('Compose Mail') }}</h2>
 			<AdaptiveDropdown :options="ACTIONS">
 				<Button variant="ghost" :label="__('More actions')">
 					<template #icon>
-						<EllipsisVertical class="text-ink-gray-5 h-4 w-4" />
+						<EllipsisVertical class="text-ink-gray-5 size-5" />
 					</template>
 				</Button>
 			</AdaptiveDropdown>
-			<Button variant="ghost" :label="__('Send')" :disabled="isRecipientsEmpty" @click="sendMail()">
+			<Button
+				variant="ghost"
+				class="ml-2"
+				:label="__('Send')"
+				:disabled="isRecipientsEmpty"
+				@click="sendMail()"
+			>
 				<template #icon>
-					<SendHorizontal class="text-ink-gray-5 h-4 w-4" />
+					<SendHorizontal class="text-ink-gray-5 size-5" />
 				</template>
 			</Button>
 		</header>
@@ -75,11 +81,16 @@
 					<div class="flex flex-col divide-y border-b" @click.stop>
 						<div class="flex min-h-13 items-center gap-2 px-4 py-2">
 							<span class="text-ink-gray-4 shrink-0 text-sm">{{ __('From') }}</span>
+							<!-- Button trigger, not the default input one: you pick an identity here, you don't
+							     type one. It also makes the control content-sized — a text input carries a
+							     fixed intrinsic width of its own, so sizing to content around one cut the
+							     address off rather than fitting it. min-w-0 keeps a long address shrinking
+							     inside the row instead of pushing it wide. -->
 							<Combobox
 								v-model="mail.from_email"
 								:options="identityOptions"
-								:open-on-click="true"
-								class="min-w-0 flex-1"
+								trigger="button"
+								class="min-w-0"
 							/>
 						</div>
 
@@ -210,7 +221,18 @@
 					v-if="isBodyFocused"
 					class="bg-surface-base z-20 shrink-0 border-t pb-[env(safe-area-inset-bottom)]"
 				>
-					<div class="flex items-center gap-1 overflow-x-auto px-2 py-2">
+					<!-- The formatting buttons come from frappe-ui's TextEditorMenu at desktop scale: a
+					     16px icon in 4px of padding, a 24px target for a thumb. Sized up from here with
+					     arbitrary variants, the markup being the menu's rather than ours — and on this
+					     row only, so the same menu keeps its desktop size in the composer dialog.
+
+					     `items-center` is not optional once the buttons are taller than their contents:
+					     the menu's buttons are `flex` with no cross-axis alignment, so the default
+					     stretch left everything sitting at the top of the new height. It showed worst on
+					     H₂, which is text rather than an icon and so a different height again. -->
+					<div
+						class="flex items-center gap-1 overflow-x-auto px-2 py-1 [&_button]:min-h-9 [&_button]:min-w-9 [&_button]:items-center [&_button]:justify-center [&_svg]:size-4"
+					>
 						<TextEditorFixedMenu :buttons class="!bg-inherit" />
 						<Button variant="ghost" :label="__('Attach files')" @click="fileInput?.click()">
 							<template #icon>

--- a/frontend/src/apps/mail/pages/ComposeView.vue
+++ b/frontend/src/apps/mail/pages/ComposeView.vue
@@ -1,0 +1,492 @@
+<template>
+	<!--
+	  Mobile compose: a header pinned to the top, and one scrolling region filling everything from
+	  under it down to the keyboard. Nothing else.
+
+	  The page is `fixed` and sized to the *visible* area rather than left in flow, because in flow it
+	  could be moved by things it doesn't control — the suite shell's `<main>` is itself a scroller,
+	  and iOS pans the visible area to reveal a focused field. Either one carried the header off the
+	  top of the screen. `sticky` on the header couldn't help: it resolves against `<main>` and rides
+	  up out of it too. `100dvh` can't size this either — dvh answers to browser chrome, not to the
+	  keyboard — so the height is measured.
+
+	  `top` follows how far iOS has panned, so the page lands back on the visible area once a pan
+	  settles; without it the header ends up under the status bar and stays there.
+
+	  Being fixed is what made the old compose sheet pan in the first place, but only because there
+	  was nothing inside it for iOS to scroll instead. There is now — and `focusWithoutReveal` below
+	  takes focus into its own hands so iOS never starts the pan to begin with.
+	-->
+	<div
+		class="bg-surface-base fixed inset-x-0 z-30 flex flex-col overflow-hidden"
+		:style="{ top: `${keyboardTop}px`, height: `${viewportHeight}px` }"
+	>
+		<header
+			class="bg-surface-base z-20 flex shrink-0 items-center gap-1 border-b px-2 pb-2.5 pt-[calc(env(safe-area-inset-top)+0.625rem)]"
+		>
+			<Button variant="ghost" :label="__('Close')" @click="closeCompose">
+				<template #icon>
+					<X class="text-ink-gray-5 h-4 w-4" />
+				</template>
+			</Button>
+			<h2 class="text-ink-gray-8 flex-1 text-base font-medium">{{ __('Compose Mail') }}</h2>
+			<AdaptiveDropdown :options="ACTIONS">
+				<Button variant="ghost" :label="__('More actions')">
+					<template #icon>
+						<EllipsisVertical class="text-ink-gray-5 h-4 w-4" />
+					</template>
+				</Button>
+			</AdaptiveDropdown>
+			<Button variant="ghost" :label="__('Send')" :disabled="isRecipientsEmpty" @click="sendMail()">
+				<template #icon>
+					<SendHorizontal class="text-ink-gray-5 h-4 w-4" />
+				</template>
+			</Button>
+		</header>
+
+		<!-- flex-1 so the body claims the rest of the page: a tap anywhere in the empty space below
+		     the last line lands in the message, which is where someone tapping there meant to type. -->
+		<TextEditor
+			ref="textEditor"
+			editor-class="prose-sm max-w-none [&_ol]:ps-7 [&_ul]:ps-7"
+			:extensions="[CustomImageExtension, CustomParagraphExtension, ...mentionExtensions]"
+			:content="editorContent"
+			:upload-function="uploadFunction"
+			class="flex min-h-0 flex-1 flex-col"
+			@change="onEditorChange"
+		>
+			<!--
+			  The one scrolling region: fields and body as a single column, so they move together and
+			  the recipients scroll away to make room once you're writing. It runs to the bottom of the
+			  page, which is the top of the keyboard.
+			-->
+			<template #editor="{ editor }">
+				<div
+					ref="scroller"
+					class="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain"
+					@pointerdown="focusWithoutReveal"
+					@focusin="onFocusIn"
+				>
+					<!-- Each row is a label + control on one line, tap target spanning the full width —
+					     on a phone the label is a hit area, not decoration. Stopped, so tapping a field
+					     doesn't also run the body's focus-at-end below. -->
+					<!-- `border-b` as well as `divide-y`: divide-y only draws between the rows, leaving
+					     the subject running straight into the message with no line between them. -->
+					<div class="flex flex-col divide-y border-b" @click.stop>
+						<div class="flex min-h-13 items-center gap-2 px-4 py-2">
+							<span class="text-ink-gray-4 shrink-0 text-sm">{{ __('From') }}</span>
+							<Combobox
+								v-model="mail.from_email"
+								:options="identityOptions"
+								:open-on-click="true"
+								class="min-w-0 flex-1"
+							/>
+						</div>
+
+						<!-- Each recipient row is a column: the field on top, and under it the target the
+						     input teleports its suggestions into. That target spans the row rather than
+						     the field, which is what lets the list reach both edges of the page. -->
+						<div class="flex flex-col">
+							<!-- items-start, so a wrapped recipient list grows downwards past a label that
+							     stays on the first line. py-3 rather than the other rows' py-2 keeps the
+							     single-line height at min-h-13 without centring doing it. The label centres
+							     itself against a chip's height, not its own line box. -->
+							<div class="flex min-h-13 items-start gap-2 px-4 py-3">
+								<span class="text-ink-gray-4 flex min-h-7 shrink-0 items-center text-sm">{{
+									__('To')
+								}}</span>
+								<RecipientInput
+									ref="toInput"
+									v-model="mail.to"
+									:suggestions-to="toSuggestions"
+									class="min-w-0 flex-1"
+								/>
+								<Button variant="ghost" :label="__('Cc and Bcc')" @click="showCcBcc = !showCcBcc">
+									<template #icon>
+										<component
+											:is="showCcBcc ? ChevronUp : ChevronDown"
+											class="text-ink-gray-5 h-4 w-4"
+										/>
+									</template>
+								</Button>
+							</div>
+							<div ref="toSuggestions" />
+						</div>
+
+						<template v-if="showCcBcc">
+							<div class="flex flex-col">
+								<div class="flex min-h-13 items-start gap-2 px-4 py-3">
+									<span class="text-ink-gray-4 flex min-h-7 shrink-0 items-center text-sm">{{
+										__('Cc')
+									}}</span>
+									<RecipientInput
+										ref="ccInput"
+										v-model="mail.cc"
+										:suggestions-to="ccSuggestions"
+										class="min-w-0 flex-1"
+									/>
+								</div>
+								<div ref="ccSuggestions" />
+							</div>
+							<div class="flex flex-col">
+								<div class="flex min-h-13 items-start gap-2 px-4 py-3">
+									<span class="text-ink-gray-4 flex min-h-7 shrink-0 items-center text-sm">{{
+										__('Bcc')
+									}}</span>
+									<RecipientInput
+										v-model="mail.bcc"
+										:suggestions-to="bccSuggestions"
+										class="min-w-0 flex-1"
+									/>
+								</div>
+								<div ref="bccSuggestions" />
+							</div>
+						</template>
+
+						<label class="flex min-h-13 cursor-text items-center gap-2 px-4 py-2">
+							<span class="text-ink-gray-4 shrink-0 text-sm">{{ __('Subject') }}</span>
+							<input
+								ref="subjectInput"
+								v-model="mail.subject"
+								class="text-ink-gray-8 min-w-0 flex-1 border-none bg-inherit p-0 text-base focus-visible:!ring-0"
+							/>
+						</label>
+					</div>
+
+					<!-- flex-1 so the body claims the rest of the scroller: a tap anywhere in the empty
+					     space below the last line lands in the message. -->
+					<div
+						class="flex flex-1 cursor-text flex-col px-4 py-3 text-sm"
+						@click="editor.commands.focus('end')"
+					>
+						<!-- Stopped here, or the wrapper's focus('end') would fire for taps on the text
+						     as well and yank the caret to the last line every time. Only taps on the
+						     empty space around the message mean "start typing at the end". -->
+						<EditorContent :editor @click.stop />
+
+						<div class="mt-auto cursor-default space-y-2.5 pt-2.5" @click.stop>
+							<Button
+								v-if="mail.quoted_content"
+								label="&middot;&middot;&middot;"
+								class="max-h-4 w-fit"
+								@click="openQuotedContent"
+							/>
+
+							<a
+								v-for="(file, index) in attachments"
+								:key="index"
+								class="bg-surface-gray-2 text-ink-gray-6 flex cursor-pointer items-center rounded p-2.5"
+								:href="file.file_url"
+								target="_blank"
+								@click="openAttachment(file.blob_id, file.type)"
+							>
+								<span class="mr-1 truncate font-medium">
+									{{ file.file_name || file.filename || file.name }}
+								</span>
+								<span class="mr-1 shrink-0 font-extralight">
+									({{ formatBytes(file.file_size || file.size) }})
+								</span>
+								<FeatherIcon
+									class="ml-auto h-3.5 w-3.5 shrink-0"
+									name="x"
+									@click.stop.prevent="removeAttachment(index)"
+								/>
+							</a>
+						</div>
+					</div>
+				</div>
+			</template>
+			<!--
+			  The formatting toolbar, last in the column and `shrink-0`, so it sits on the page's bottom
+			  edge — and that edge is the top of the keyboard, since the page is sized to the visible
+			  area. No sticky, no fixed, no measuring: it is simply the last thing in the box.
+
+			  It lives in #bottom because TextEditorFixedMenu reaches for the editor its parent
+			  TextEditor provides, and outside the scroller above so the scrollbar stops at it rather
+			  than running on underneath.
+			-->
+			<template #bottom>
+				<div
+					v-if="isBodyFocused"
+					class="bg-surface-base z-20 shrink-0 border-t pb-[env(safe-area-inset-bottom)]"
+				>
+					<div class="flex items-center gap-1 overflow-x-auto px-2 py-2">
+						<TextEditorFixedMenu :buttons class="!bg-inherit" />
+						<Button variant="ghost" :label="__('Attach files')" @click="fileInput?.click()">
+							<template #icon>
+								<Paperclip class="icon" />
+							</template>
+						</Button>
+						<input
+							ref="fileInput"
+							type="file"
+							class="hidden"
+							multiple
+							@change="onFilesSelected"
+						/>
+					</div>
+				</div>
+			</template>
+		</TextEditor>
+
+		<ScheduleSendModal v-model="showScheduleModal" @confirm="scheduleSend" />
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
+import { onBeforeRouteLeave, useRouter } from 'vue-router'
+import { EditorContent } from '@tiptap/vue-3'
+import {
+	CalendarClock,
+	ChevronDown,
+	ChevronUp,
+	EllipsisVertical,
+	Paperclip,
+	SendHorizontal,
+	Trash2,
+	X,
+} from 'lucide-vue-next'
+import { Button, Combobox, FeatherIcon, TextEditor, TextEditorFixedMenu } from 'frappe-ui'
+
+import { formatBytes, raiseToast } from '@/apps/mail/utils'
+import { useKeyboardInsets, useTextEditorButtons } from '@/apps/mail/utils/composables'
+import { CustomImageExtension, CustomParagraphExtension, uploadFunction } from '@/apps/mail/utils/text-editor'
+import { takePendingCompose } from '@/apps/mail/composables/composeHandoff'
+import { useComposeMail } from '@/apps/mail/composables/useComposeMail'
+import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
+import RecipientInput from '@/apps/mail/components/Controls/RecipientInput.vue'
+import ScheduleSendModal from '@/apps/mail/components/Modals/ScheduleSendModal.vue'
+
+import type { Attachment, Identity } from '@/apps/mail/types'
+
+const router = useRouter()
+
+const textEditor = useTemplateRef<{ $el?: HTMLElement; editor?: any }>('textEditor')
+const toInput = useTemplateRef<{ setFocus: () => void }>('toInput')
+const ccInput = useTemplateRef<{ setFocus: () => void }>('ccInput')
+const subjectInput = useTemplateRef<HTMLInputElement>('subjectInput')
+const fileInput = useTemplateRef<HTMLInputElement>('fileInput')
+const scroller = useTemplateRef<HTMLElement>('scroller')
+
+// Where each recipient input teleports its suggestion list, so the list spans the page rather than
+// the field's own column.
+const toSuggestions = useTemplateRef<HTMLElement>('toSuggestions')
+const ccSuggestions = useTemplateRef<HTMLElement>('ccSuggestions')
+const bccSuggestions = useTemplateRef<HTMLElement>('bccSuggestions')
+
+const mailDetails = takePendingCompose()
+
+// Leaving the page IS closing the composer, so both the header's close button and the system back
+// gesture land in the same place. `leaving` stops the guard from bouncing the programmatic pop.
+let leaving = false
+const closeCompose = () => {
+	if (leaving) return
+	leaving = true
+	router.back()
+}
+
+const {
+	mail,
+	identities,
+	isRecipientsEmpty,
+	saveDraft,
+	sendMail,
+	discardMail,
+	showScheduleModal,
+	openScheduleModal,
+	scheduleSend,
+	openQuotedContent,
+	openAttachment,
+	mentionExtensions,
+	editorContent,
+	onEditorChange,
+	updateOriginalMail,
+} = useComposeMail({
+	mailDetails,
+	reloadMails: () => {},
+	close: closeCompose,
+	// The page is the composer, so it is open right up until the route leaves.
+	isOpen: () => !leaving,
+	host: () => textEditor.value,
+})
+
+const { height: viewportHeight, top: keyboardTop } = useKeyboardInsets()
+
+// Hold the document still for as long as this page is open.
+//
+// This is what the bouncing was. iOS implements its keyboard "pan" as an ordinary document scroll —
+// `window.scrollY` goes non-zero — and `visualViewport.offsetTop` reports the same number. So two
+// things moved at once on every focus change: the document scrolled up, and this page, chasing
+// `offsetTop`, was pushed down by exactly as much. A document that cannot scroll has neither.
+//
+// `position: fixed` as well as `overflow: hidden`, because overflow alone still leaves iOS a document
+// to scroll for a focused field.
+onMounted(() => {
+	const { style } = document.body
+	style.overflow = 'hidden'
+	style.position = 'fixed'
+	style.width = '100%'
+	document.documentElement.style.overflow = 'hidden'
+})
+
+onUnmounted(() => {
+	const { style } = document.body
+	style.overflow = ''
+	style.position = ''
+	style.width = ''
+	document.documentElement.style.overflow = ''
+})
+
+/**
+ * Do the focusing ourselves, so it can be done without a reveal.
+ *
+ * Moving between the body and the fields bounced the whole screen. iOS reveals a newly focused field
+ * by scrolling it into view, and it cannot scroll a `position: fixed` container — so it pans the
+ * visible area instead, and the page lurches and settles back. Chasing that pan is hopeless: JS only
+ * hears about it once it has started.
+ *
+ * `preventScroll` is the opt-out built for this, but the browser only honours it on a focus *we*
+ * call. So take the tap: stop the default focus, place the caret where the tap landed, and focus with
+ * the reveal turned off. `revealFocused` still runs afterwards and does the scrolling itself, in the
+ * scroller, where it costs nothing.
+ */
+const focusWithoutReveal = (event: PointerEvent) => {
+	const target = event.target as HTMLElement | null
+	const editor = textEditor.value?.editor
+	const body = editor?.view?.dom as HTMLElement | undefined
+
+	// The body: place the caret from the tap's own coordinates, since preventing the default is what
+	// would otherwise have done it.
+	if (body && target && body.contains(target)) {
+		const pos = editor!.view.posAtCoords({ left: event.clientX, top: event.clientY })
+		if (!pos) return
+
+		event.preventDefault()
+		editor!.commands.setTextSelection(pos.pos)
+		body.focus({ preventScroll: true })
+		return
+	}
+
+	// A field. Anything with its own caret placement (a tap partway along existing text) is left to
+	// the browser — only an unfocused field is taken over, which is the case that pans.
+	const field = target?.closest?.('input, textarea')
+	if (!(field instanceof HTMLElement) || field === document.activeElement) return
+
+	event.preventDefault()
+	field.focus({ preventScroll: true })
+}
+
+/**
+ * The formatting toolbar belongs to the message, so it only appears while the message has focus —
+ * it is noise (and lost height) while someone is filling in recipients.
+ *
+ * Deliberately not "focus left the body": tapping a toolbar button takes focus out of the editor for
+ * an instant, and hiding the bar out from under the finger would make it unusable. Only moving to one
+ * of the *fields* puts it away.
+ */
+const isBodyFocused = ref(false)
+
+const onFocusIn = (event: FocusEvent) => {
+	const node = event.target as HTMLElement | null
+	const body = textEditor.value?.editor?.view?.dom as HTMLElement | undefined
+
+	if (body && node && body.contains(node)) isBodyFocused.value = true
+	else if (node?.closest?.('input, textarea')) isBodyFocused.value = false
+
+	revealFocused(event)
+}
+
+// Pre-empt iOS's focus reveal.
+//
+// When focus lands on a field it thinks the keyboard covers, iOS brings it into view — and if it
+// can't find a scroller to do that with, it pans the visible area up the page instead. The page is
+// exactly as tall as that visible area, so a pan carries its bottom edge up with it and the toolbar
+// ends up floating above the keyboard with a white gap under it.
+//
+// Bringing the focused field comfortably into view ourselves, in our own scroller and synchronously
+// as focus arrives, leaves iOS with nothing to reveal and so no reason to pan.
+const revealFocused = (event: FocusEvent) => {
+	const box = scroller.value
+	const node = event.target as HTMLElement | null
+	if (!box || !node) return
+
+	// The body's element spans the whole composition, so its box says nothing about where the caret
+	// is; ask ProseMirror. Every other field is small enough to use its own.
+	const editor = textEditor.value?.editor
+	const rect =
+		editor && node === editor.view?.dom
+			? editor.view.coordsAtPos(editor.state.selection.head)
+			: node.getBoundingClientRect()
+
+	const view = box.getBoundingClientRect()
+	const margin = 24
+
+	if (rect.bottom > view.bottom - margin) box.scrollTop += rect.bottom - view.bottom + margin
+	else if (rect.top < view.top + margin) box.scrollTop -= view.top + margin - rect.top
+}
+const { buttons } = useTextEditorButtons()
+
+const identityOptions = computed(
+	() =>
+		identities.value.data?.map((i: Identity) => ({
+			label: `${i._name} <${i.email}>`,
+			value: i.email,
+		})) ?? [],
+)
+
+const showCcBcc = ref(!!mailDetails?.cc?.length || !!mailDetails?.bcc?.length)
+watch(showCcBcc, (open) => open && nextTick(() => ccInput.value?.setFocus()))
+
+const attachments = computed(() =>
+	mail.attachments.filter((file: Attachment) => file.disposition === 'attachment'),
+)
+
+const removeAttachment = (index: number) => {
+	const file = attachments.value[index]
+	mail.attachments.splice(mail.attachments.indexOf(file), 1)
+}
+
+const onFilesSelected = async (e: Event) => {
+	const input = e.target as HTMLInputElement
+	const files = Array.from(input.files ?? [])
+	input.value = ''
+
+	for (const file of files) {
+		try {
+			const doc = await uploadFunction(file)
+			mail.attachments.push({ ...doc, disposition: 'attachment' } as Attachment)
+		} catch (error) {
+			raiseToast((error as Error)?.message ?? __('Could not attach {0}.', [file.name]), 'error')
+		}
+	}
+}
+
+const ACTIONS = [
+	{ label: __('Schedule send'), onClick: () => openScheduleModal(), icon: CalendarClock },
+	{ label: __('Discard'), onClick: () => discardMail(), icon: Trash2, theme: 'red' },
+]
+
+// Start where there is still something to write: the body on a reply (recipients and subject came
+// with the thread), the subject when the draft arrived addressed but unnamed (a `mailto:` link, or a
+// calendar invite's participants), and To otherwise.
+onMounted(() => {
+	updateOriginalMail()
+
+	// Deferred: TextEditor renders nothing until it has built its editor on its own mounted hook, so
+	// none of these exist yet at this point.
+	nextTick(() => {
+		if (mailDetails?.in_reply_to) textEditor.value?.editor?.commands.focus()
+		else if (!isRecipientsEmpty.value && !mail.subject) subjectInput.value?.focus()
+		else toInput.value?.setFocus()
+	})
+})
+
+// Navigating away is the only way off this page, so this is where an unsent message gets kept.
+onBeforeRouteLeave(() => {
+	leaving = true
+	saveDraft()
+})
+
+onUnmounted(() => saveDraft())
+</script>

--- a/frontend/src/apps/mail/pages/MailLayout.vue
+++ b/frontend/src/apps/mail/pages/MailLayout.vue
@@ -341,6 +341,20 @@ body.mail-app .menu-content {
 	z-index: 30;
 }
 
+/* Same problem one layer up, for popovers that ship WITH a z-index rather than
+   without one: frappe-ui's IconPicker gives its popover z-10, and reka copies that
+   onto the portaled wrapper as an inline style. Ten loses to the dialog above, so
+   the icon grid — the folder dialog is the only place we open it — renders behind
+   the panel, and a picker whose dropdown never appears reads as a picker that does
+   not work. Lift it between dialog (30) and bottom sheets (50).
+
+   `!important` beats the inline value, which nothing else can. The `.z-10` hook
+   keeps this to popovers that shipped with the low z: frappe-ui's own Combobox
+   content is z-[100] and is left alone. */
+body.mail-app [data-reka-popper-content-wrapper]:has(> [role='listbox'].z-10) {
+	z-index: 40 !important;
+}
+
 /* Swipe paging (mobile) — shared by the thread pane (MailThread) and the screener
    preview: the incoming page slides in from the swipe side while the outgoing one —
    lifted out of flow so they overlap — slides away in tandem. */

--- a/frontend/src/apps/mail/routes.ts
+++ b/frontend/src/apps/mail/routes.ts
@@ -115,6 +115,16 @@ export const routes: RouteRecordRaw[] = [
 				component: () => import('@/apps/mail/pages/MailboxView.vue'),
 				props: true,
 			},
+			// Compose as a page of its own rather than an overlay over the list. `noLayout` keeps
+			// the app chrome — and the full-height scroll frame it brings — out of the way, so the
+			// composer can own the visible area and decide for itself what scrolls inside it.
+			{
+				path: 'account/:accountId/compose',
+				name: 'mail-compose',
+				component: () => import('@/apps/mail/pages/ComposeView.vue'),
+				props: true,
+				meta: { noLayout: true },
+			},
 			// Profile as a page rather than a bottom sheet, so the tab behaves like the other
 			// three — a route the bar keeps a selected state for. It holds the mobile settings
 			// list itself; PWASettings stays for the sidebar and in-thread entry points.

--- a/frontend/src/apps/mail/utils/composables.ts
+++ b/frontend/src/apps/mail/utils/composables.ts
@@ -153,28 +153,56 @@ export const useTextEditorButtons = () => {
 	return { buttons }
 }
 
-export const useVisualViewport = (calc: (viewport: VisualViewport) => string) => {
-	const value = ref('0px')
+/**
+ * How much of the on-screen keyboard is covering the layout viewport, as insets for holding a
+ * full-screen pane clear of it.
+ *
+ * iOS leaves the layout viewport full-height when the keyboard opens and slides the visible part
+ * around underneath it, so `position: fixed; inset: 0` runs on behind the keyboard and has to be
+ * held off it by hand:
+ *
+ * - `bottom` is the strip the keyboard covers, so a pane ends where the keyboard starts.
+ * - `top` is how far iOS has panned to reveal a focused field, so the pane rides that pan instead of
+ *   being dragged off the top of the screen.
+ *
+ * `interactive-widget=resizes-content` (index.html) is supposed to make both of these unnecessary by
+ * shrinking the layout viewport itself. It did not, on the iOS this was built against: dropping the
+ * `bottom` inset put the toolbar straight back behind the keyboard. Treat these as load-bearing.
+ */
+export const useKeyboardInsets = () => {
+	const top = ref(0)
+	const bottom = ref(0)
+	/** The visible height — what's left of the screen once the keyboard has taken its share. */
+	const height = ref(window.innerHeight)
 
 	const update = () => {
-		if (window.visualViewport) value.value = calc(window.visualViewport)
+		const viewport = window.visualViewport
+		if (!viewport) return
+
+		height.value = viewport.height
+		top.value = viewport.offsetTop
+		// Against the layout viewport, not innerHeight: innerHeight tracks the visual viewport on iOS,
+		// which would make this always 0 and the fallback a no-op on the browsers that need it.
+		const covered = document.documentElement.clientHeight - viewport.height - viewport.offsetTop
+		bottom.value = Math.max(0, Math.round(covered))
 	}
 
 	onMounted(() => {
-		if (!window.visualViewport) return
-		window.visualViewport.addEventListener('resize', update)
-		window.visualViewport.addEventListener('scroll', update)
-
 		update()
-
-		onUnmounted(() => {
-			if (!window.visualViewport) return
-			window.visualViewport.removeEventListener('resize', update)
-			window.visualViewport.removeEventListener('scroll', update)
-		})
+		// `resize` is the keyboard opening and closing; `scroll` is iOS panning what's left of the
+		// viewport. Missing the second is what lets a pane drift off the top of the screen.
+		window.visualViewport?.addEventListener('resize', update)
+		window.visualViewport?.addEventListener('scroll', update)
+		window.addEventListener('resize', update)
 	})
 
-	return value
+	onUnmounted(() => {
+		window.visualViewport?.removeEventListener('resize', update)
+		window.visualViewport?.removeEventListener('scroll', update)
+		window.removeEventListener('resize', update)
+	})
+
+	return { top, bottom, height }
 }
 
 const undoAction = ref<() => void>()

--- a/frontend/src/apps/mail/utils/text-editor.ts
+++ b/frontend/src/apps/mail/utils/text-editor.ts
@@ -1,4 +1,7 @@
 import { Node } from '@tiptap/core'
+import { ImageExtension, useFileUpload } from 'frappe-ui'
+
+import { randomString } from '@/apps/mail/utils'
 
 export const CustomParagraphExtension = Node.create({
 	name: 'paragraph',
@@ -7,4 +10,39 @@ export const CustomParagraphExtension = Node.create({
 	content: 'inline*',
 	parseHTML: () => [{ tag: 'div' }, { tag: 'p' }],
 	renderHTML: ({ HTMLAttributes }) => ['div', HTMLAttributes, 0],
+})
+
+export const uploadFunction = async (file: File) =>
+	useFileUpload().upload(file, {
+		private: true,
+		folder: 'Home/Frappe Mail',
+		upload_endpoint: '/api/method/suite.mail.api.mail.upload_file',
+	})
+
+/**
+ * Images carry a `data-cid` so the send path can turn them into inline attachments — stamped here,
+ * on the way into the document, for any image that came from our own uploads.
+ */
+export const CustomImageExtension = ImageExtension.extend({
+	addAttributes() {
+		return {
+			...this.parent?.(),
+			'data-cid': {
+				default: null,
+				parseHTML: (element: HTMLElement) => element.getAttribute('data-cid'),
+				renderHTML: (attributes: Record<string, string>) => {
+					const src = attributes.src || ''
+					if (
+						!attributes['data-cid'] &&
+						(src.startsWith('/files') || src.startsWith('/private/files'))
+					)
+						attributes['data-cid'] = randomString(10)
+					return { 'data-cid': attributes['data-cid'] }
+				},
+			},
+		}
+	},
+}).configure({
+	HTMLAttributes: { width: '600', style: 'max-width:100%; height:auto' },
+	uploadFunction,
 })


### PR DESCRIPTION
The phone composer was a desktop dialog dropped into a slide-up sheet, and everything about it fought that shape: the header scrolled off the top, the toolbar floated somewhere above the keyboard, and moving between the fields and the message bounced the whole screen.

It's a route now — a page sized to the visible area, with the document locked while it's open. The bounce was iOS scrolling the *document* to reveal a focused field, which nothing in the layout could chase. Inside: a pinned header, one scrolling region, and a toolbar that sits on the keyboard and only appears while the message has focus.

The recipient row is rebuilt alongside it, since it was the worst of the same problem. Chips are measured to the line rather than a fixed two, suggestions render in flow at full width instead of a floating panel, and an address nobody has as a contact now commits on Return or on leaving the field — before, it had no way in at all.

The composition itself — draft state, autosave, send, schedule, discard, attachments, mentions — moves into `useComposeMail`, and both composers call it, so the phone page and the desktop dialog can't drift apart. That already caught one: the extraction had quietly dropped the fallback that picks the user's own address when an account has no identities.

Desktop behaviour is unchanged — without a `suggestionsTo` target the recipient field keeps its popover, and the dialog takes the same paths it did — but it is going through new code, so send, schedule send, discard and switching the From identity are worth a click before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/frappe/codesmith/suite/pr/600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789048670&installation_model_id=431961&pr_number=600&repository=frappe%2Fsuite&return_to=https%3A%2F%2Fgithub.com%2Ffrappe%2Fsuite%2Fpull%2F600&signature=272f9bd2e0baf4df1926b04c3301f474ddb0908bbfbf50a2bde0bc807bbfce8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

