### PR TITLE
fix(drive): require site admin to preview files on disk

### DIFF
--- a/suite/drive/api/scripts.py
+++ b/suite/drive/api/scripts.py
@@ -17,6 +17,19 @@ from suite.drive.utils.files import FileManager
 
 @frappe.whitelist()
 def sync_preview(json: bool = True):
+    """
+    List files present on disk but not yet registered in Drive.
+
+    Admin-only: these files have no `File` record yet, so there is no share or
+    folder permission to filter them by - the listing exposes the raw storage
+    tree (paths, sizes, mtimes) of everything staged under the site folder.
+    """
+    if not is_drive_site_admin():
+        frappe.throw(
+            "You do not have permission to view files on disk.",
+            frappe.PermissionError,
+        )
+
     manager = FileManager()
     files = manager.fetch_new_files()
     sorted_files = sorted(files.items(), key=lambda p: len(p[0].parts))

--- a/suite/drive/tests/test_sync_permissions.py
+++ b/suite/drive/tests/test_sync_permissions.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import Mock, patch
+
+import frappe
+
+from suite.drive.api.scripts import sync_from_disk, sync_preview
+
+
+class TestSyncPermissions(unittest.TestCase):
+    """`sync_preview` lists files that have no `File` record yet, so no share or
+    folder permission can filter them. Only a site admin may read that listing."""
+
+    def _run(self, fn, is_admin):
+        with patch("suite.drive.api.scripts.is_drive_site_admin", return_value=is_admin):
+            # Patched so the test asserts on the permission gate, not on disk state.
+            with patch("suite.drive.api.scripts.FileManager") as manager:
+                manager.return_value.fetch_new_files.return_value = {}
+                return fn()
+
+    def test_sync_preview_is_refused_without_admin(self):
+        with self.assertRaises(frappe.PermissionError):
+            self._run(sync_preview, is_admin=False)
+
+    def test_sync_preview_is_allowed_for_admin(self):
+        self.assertEqual(list(self._run(sync_preview, is_admin=True)), [])
+
+    def test_sync_from_disk_is_still_refused_without_admin(self):
+        with self.assertRaises(frappe.PermissionError):
+            self._run(sync_from_disk, is_admin=False)
+
+    def test_sync_preview_does_not_touch_storage_before_refusing(self):
+        """The refusal must precede `FileManager()`, so a non-admin request never
+        reaches the filesystem or S3 at all."""
+        with patch("suite.drive.api.scripts.is_drive_site_admin", return_value=False):
+            with patch("suite.drive.api.scripts.FileManager") as manager:
+                with self.assertRaises(frappe.PermissionError):
+                    sync_preview()
+        manager.assert_not_called()


### PR DESCRIPTION
`sync_preview` was whitelisted with no permission check, so any logged-in user could retrieve the full listing of files staged under the site's Drive storage folder - relative paths, byte sizes, mtimes and MIME types - by calling the endpoint directly.

The listing cannot be permission-filtered after the fact: it returns exactly those files that have no `File` record yet, so there is no owner, share or folder to resolve access against. The only correct gate is the one `sync_from_disk` already applies ten lines below - `is_drive_site_admin()`, which was simply never added to the read half of the same operation.

The check runs before `FileManager()` is constructed, so an unauthorised request never reaches the filesystem or S3.

No caller changes: the sole frontend consumer is `SyncBreakdown.vue`, reachable only through the Storage tab of `SettingsDialog`, which is already inside an `adminOnly` group gated on the same `is_drive_site_admin()` check. `sync_from_disk` calls `sync_preview(json=False)` after its own admin check, so the guard is a no-op there and both halves remain independently safe.

Adds 4 regression tests; the two covering `sync_preview` were verified failing without this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/frappe/codesmith/suite/pr/602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789108066&installation_model_id=431961&pr_number=602&repository=frappe%2Fsuite&return_to=https%3A%2F%2Fgithub.com%2Ffrappe%2Fsuite%2Fpull%2F602&signature=a35b830e76b94cb6ad74fc0ffb6f1529e6c6e2492d8d2b664c7e87c91439a184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->