### PR TITLE
fix(drive): require upload access to probe a folder for filenames

### DIFF
--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -779,14 +779,31 @@ def remove_recents(entity_names: list[str] | None = None, clear_all: bool = Fals
 
 @frappe.whitelist()
 def does_entity_exist(name: str | None = None, folder: str | None = None):
+    """Whether `folder` already holds a file called `name`.
+
+    Answers about a folder the caller cannot open are an enumeration oracle:
+    the reply is derived from names the caller is not entitled to see. Gate it
+    on `upload` rather than `read` - this only ever serves the uploader naming
+    a file it is about to write, so it should refuse anyone who could not write
+    there, and `upload_file` resolves the same folder against the same level.
+    """
     if not folder:
         folder = get_user_folder().name
+    if not user_has_permission(folder, "upload"):
+        frappe.throw("Ask the folder owner for upload access.", frappe.PermissionError)
     result = frappe.db.exists("File", {"folder": folder, "file_name": name})
     return result
 
 
 @frappe.whitelist()
 def get_new_title(title: str, parent_name: str, folder: bool = False):
+    """Return `title`, suffixed to avoid a collision inside `parent_name`.
+
+    Leaks strictly more than `does_entity_exist` - the suffix is a count of the
+    matching siblings - so it takes the same `upload` gate, for the same reason.
+    """
+    if not user_has_permission(parent_name, "upload"):
+        frappe.throw("Ask the folder owner for upload access.", frappe.PermissionError)
     return get_new_file_name(title, parent_name, folder)
 
 

--- a/suite/drive/api/tests/test_files.py
+++ b/suite/drive/api/tests/test_files.py
@@ -9,7 +9,9 @@ from werkzeug.wrappers import Request
 
 from suite.drive.api.files import (
     create_auth_token,
+    does_entity_exist,
     get_file_content,
+    get_new_title,
     move,
     remove_or_restore,
     rename,
@@ -506,3 +508,49 @@ class TestDriveFilesAPI(IntegrationTestCase):
                 rename(self.file.name, "forbidden.txt")
             with self.assertRaises(frappe.PermissionError):
                 move([self.file.name], new_parent=destination.name)
+
+    def test_unrelated_user_cannot_probe_folder_for_filenames(self):
+        with self.set_user(OTHER_USER):
+            with self.assertRaises(frappe.PermissionError):
+                does_entity_exist(name=self.file.file_name, folder=self.folder.name)
+            with self.assertRaises(frappe.PermissionError):
+                get_new_title(self.file.file_name, self.folder.name)
+
+    def test_revoked_user_cannot_probe_folder_for_filenames(self):
+        """The realistic caller: access was granted, the folder ID was learned,
+        then access was taken away. The ID outlives the grant."""
+        with self.set_user(OWNER):
+            update_access(self.folder.name, "share", cmd="share", user=OTHER_USER, read=True)
+
+        with self.set_user(OTHER_USER):
+            # Read alone is not enough - only the upload flow needs these.
+            with self.assertRaises(frappe.PermissionError):
+                does_entity_exist(name=self.file.file_name, folder=self.folder.name)
+
+        with self.set_user(OWNER):
+            update_access(self.folder.name, "unshare", cmd="unshare", user=OTHER_USER)
+
+        with self.set_user(OTHER_USER):
+            with self.assertRaises(frappe.PermissionError):
+                does_entity_exist(name=self.file.file_name, folder=self.folder.name)
+            with self.assertRaises(frappe.PermissionError):
+                get_new_title(self.file.file_name, self.folder.name)
+
+    def test_upload_access_still_answers_both_helpers(self):
+        with self.set_user(OWNER):
+            update_access(self.folder.name, "share", cmd="share", user=OTHER_USER, read=True, upload=True)
+
+        with self.set_user(OTHER_USER):
+            # Answered, not refused. What `get_new_title` answers for a user whose
+            # access is inherited is a separate matter - `get_new_file_name` lists
+            # siblings with `get_list`, whose criterion does not follow inheritance -
+            # so this asserts it returns rather than what it returns.
+            self.assertTrue(does_entity_exist(name=self.file.file_name, folder=self.folder.name))
+            self.assertIsInstance(get_new_title(self.file.file_name, self.folder.name), str)
+
+    def test_owner_can_still_probe_own_folder_and_default_home(self):
+        with self.set_user(OWNER):
+            self.assertTrue(does_entity_exist(name=self.file.file_name, folder=self.folder.name))
+            self.assertFalse(does_entity_exist(name=f"{frappe.generate_hash(8)}.txt"))
+            self.assertNotEqual(get_new_title(self.file.file_name, self.folder.name), self.file.file_name)
+            self.assertEqual(get_new_title("unclaimed.txt", self.folder.name), "unclaimed.txt")

--- a/suite/writer/api/docs.py
+++ b/suite/writer/api/docs.py
@@ -28,14 +28,15 @@ QUICK_MAP = {
 def create_document(title: str | None = None, parent: str | None = None, template: str | None = None):
     parent = parent or get_user_folder().name
     parent_doc = frappe.get_doc("File", parent)
-    if not title:
-        title = get_new_title("Untitled Document", parent)
 
     if not user_has_permission(parent, "upload"):
         frappe.throw(
             "Cannot access folder due to insufficient permissions",
             frappe.PermissionError,
         )
+
+    if not title:
+        title = get_new_title("Untitled Document", parent)
 
     writer_doc = frappe.new_doc("Writer Document")
     writer_doc.settings = (


### PR DESCRIPTION
`does_entity_exist` and `get_new_title` were whitelisted with no permission check. Both take a folder id straight from the caller, so any logged-in user could ask whether a given filename exists in any folder on the site:

    /api/method/suite.drive.api.files.does_entity_exist?name=<name>&folder=<id>

`get_new_title` leaks strictly more - on an exact match it returns the name suffixed with a count of the matching siblings, so the reply also reveals how many similarly named files the folder holds.

Filenames are content. The realistic caller is not someone guessing ids, it is someone whose access was revoked: folder ids are learned while shared and outlive the grant, so an unshared user can keep polling a folder they can no longer open and keep getting answers.

Both now resolve the folder against `upload`.

Why `upload` and not `read`: these serve only the uploader naming a file it is about to write, and every principal the share dialog grants `upload` also holds `read` (`ShareDialog.vue` sets `read: 1` on all three presets), so `upload` is the narrower gate of the two - it refuses everyone `read` would, plus view-only users who never call these. It also puts them in agreement with `upload_file` and `can_create_in_folder`, which resolve the same folder at the same level.

The guard cannot break an upload that would otherwise succeed: `upload_file` already applies the identical check, with the same default-folder resolution and the same message, moments later in the same flow.

`suite/writer/api/docs.py` calls `get_new_title`. It already checked the same level on the same folder two lines below; the check is moved above the call so Writer keeps its own error message and skips a lookup for a caller it is about to turn away. No behavioural change - the same callers are refused.

Adds 4 regression tests to the existing integration suite; the 2 covering the unshared and revoked callers were verified failing without this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/frappe/codesmith/suite/pr/603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789112222&installation_model_id=431961&pr_number=603&repository=frappe%2Fsuite&return_to=https%3A%2F%2Fgithub.com%2Ffrappe%2Fsuite%2Fpull%2F603&signature=1ffb60a3c506df5cc9046741770b19483b130b9360213e97bb8e63b918c7bea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->