### PR TITLE
fix(slides): scale slide previews to their actual card width

### DIFF
--- a/frontend/src/apps/slides/components/LayoutDialog.vue
+++ b/frontend/src/apps/slides/components/LayoutDialog.vue
@@ -33,7 +33,8 @@ import SlidePreview from '@/apps/slides/components/SlidePreview.vue'
 import { presentationTheme, templateList } from '@/apps/slides/stores/presentation'
 import { getThumbnailCardStyles } from '@/apps/slides/utils/helpers'
 
-const LAYOUT_PREVIEW_SCALE = 270 / 960
+// card width: 4xl dialog (896) - px-6 (48) - two gap-6 (48), divided by 3
+const LAYOUT_PREVIEW_SCALE = 800 / 3 / 960
 
 const emit = defineEmits(['insert'])
 

--- a/frontend/src/apps/slides/components/ThemeDialog.vue
+++ b/frontend/src/apps/slides/components/ThemeDialog.vue
@@ -50,7 +50,8 @@ import SlidePreview from '@/apps/slides/components/SlidePreview.vue'
 import { getThumbnailCardStyles } from '@/apps/slides/utils/helpers'
 import { presentationTheme, templateList } from '@/apps/slides/stores/presentation'
 
-const THEME_PREVIEW_SCALE = 310 / 960
+// card width: 2xl dialog (672) - px-6 (48) - gap-6 (24), halved, - m-1 (8)
+const THEME_PREVIEW_SCALE = 292 / 960
 
 const props = defineProps({
 	update: {


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/frappe/codesmith/suite/pr/604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789113614&installation_model_id=431961&pr_number=604&repository=frappe%2Fsuite&return_to=https%3A%2F%2Fgithub.com%2Ffrappe%2Fsuite%2Fpull%2F604&signature=a9e0c805f835fd7a8ce883bf179ee1a114895317f2c9f7a649a6149caf4d063f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->