### PR TITLE
fix(slides): serve template media in shared presentations

### DIFF
--- a/suite/slides/api/file.py
+++ b/suite/slides/api/file.py
@@ -128,12 +128,40 @@ def get_attached_presentations(src: str, names: set[str]) -> set[str]:
     )
 
 
+def is_template_media(src: str) -> bool:
+    """Layouts are copied into a presentation wholesale, so it shows the file urls of
+    every template it ever drew a slide from without holding a File row for any."""
+    holders = frappe.get_all(
+        "File",
+        filters={"file_url": src, "attached_to_doctype": "Presentation"},
+        pluck="attached_to_name",
+        distinct=True,
+        order_by=None,
+    )
+    if not holders:
+        return False
+
+    return bool(
+        frappe.get_all(
+            "Presentation",
+            filters={"name": ("in", holders), "is_template": 1},
+            limit=1,
+            order_by=None,
+        )
+    )
+
+
 def validate_media_file(src: str, presentation: str | None = None) -> None:
     if presentation:
         shown = {presentation} | get_reference_presentations(presentation)
         for name in get_attached_presentations(src, shown):
             if frappe.has_permission("Presentation", "read", name):
                 return
+
+        # templates are readable by everyone, so the only question left is whether the
+        # caller may see the presentation they claim to be viewing
+        if frappe.has_permission("Presentation", "read", presentation) and is_template_media(src):
+            return
 
     if not frappe.db.exists("File", {"file_url": src}):
         raise NotFound

--- a/suite/slides/api/test_file.py
+++ b/suite/slides/api/test_file.py
@@ -5,10 +5,12 @@ import frappe
 from frappe.tests import IntegrationTestCase
 from werkzeug.exceptions import Forbidden, NotFound
 
+from suite.drive.overrides.file import File as DriveFile
 from suite.slides.api.file import get_reference_presentations, validate_media_file
 from suite.slides.tests.utils import (
     PNG_1PX,
     make_presentation,
+    make_private,
     make_private_image,
     make_public,
     unique_bytes,
@@ -85,6 +87,40 @@ class TestMediaFileAccess(IntegrationTestCase):
         with self.set_user("Guest"):
             self.assertIsNone(validate_media_file(file.file_url, presentation.name))
 
+    def test_guest_can_access_media_of_a_template(self):
+        # a presentation built from a template shows the template's own file urls: the
+        # layout is copied over, the File row stays on the template
+        _, file = self.make_template("Media Template")
+
+        with self.set_user(OTHER_USER):
+            presentation = make_presentation("Built From Template")
+            make_public(presentation.name)
+
+        with self.set_user("Guest"):
+            self.assertIsNone(validate_media_file(file.file_url, presentation.name))
+
+    def test_template_media_still_needs_a_readable_presentation(self):
+        # a file url is not a credential: naming no presentation, or one the caller
+        # cannot read, stays forbidden
+        _, file = self.make_template("Gated Template")
+
+        with self.set_user("Guest"):
+            with self.assertRaises(Forbidden):
+                validate_media_file(file.file_url)
+            with self.assertRaises(Forbidden):
+                validate_media_file(file.file_url, self.presentation.name)
+
+    def test_a_readable_presentation_does_not_unlock_private_media(self):
+        # the template branch must not turn "you may see this presentation" into
+        # "you may see any private file"
+        with self.set_user(OTHER_USER):
+            presentation = make_presentation("Public But Unrelated")
+            make_public(presentation.name)
+
+        with self.set_user("Guest"):
+            with self.assertRaises(Forbidden):
+                validate_media_file(self.file.file_url, presentation.name)
+
     def test_composite_resolves_to_the_presentations_it_shows(self):
         # a composite's media hangs off the presentations it references, not off itself
         with self.set_user(OWNER):
@@ -102,10 +138,58 @@ class TestMediaFileAccess(IntegrationTestCase):
         with self.set_user("Guest"):
             self.assertIsNone(validate_media_file(file.file_url, composite.name))
 
+    def test_composite_shows_template_media_of_its_references(self):
+        # references built from templates carry the template's file urls too, and the
+        # composite is the only presentation the viewer ever names
+        _, file = self.make_template("Referenced Template")
+
+        with self.set_user(OTHER_USER):
+            source = make_presentation("Built From Template Source")
+            make_public(source.name)
+
+            composite = make_presentation("Composite Of Templated")
+            composite.is_composite = 1
+            composite.append("reference_presentations", {"presentation": source.name})
+            composite.save()
+
+        with self.set_user("Guest"):
+            self.assertIsNone(validate_media_file(file.file_url, composite.name))
+
+    def test_a_reference_made_private_later_keeps_its_own_media_private(self):
+        # references are public when the composite is saved but can be made private
+        # afterwards; the template branch must not become a way around that
+        with self.set_user(OWNER):
+            source = make_presentation("Reference Made Private")
+            file = make_private_image(source.name)
+            make_public(source.name)
+
+            composite = make_presentation("Composite Of Private")
+            composite.is_composite = 1
+            composite.append("reference_presentations", {"presentation": source.name})
+            composite.save()
+
+            make_private(source.name)
+
+        with self.set_user("Guest"):
+            with self.assertRaises(Forbidden):
+                validate_media_file(file.file_url, composite.name)
+
     def test_unknown_url_not_found(self):
         with self.set_user(OWNER):
             with self.assertRaises(NotFound):
                 validate_media_file("/private/files/no-such-file.png")
+
+    def make_template(self, title):
+        """Inserted as a template, so `after_insert` skips `create_drive_file`: the
+        shape templates actually have in production, with no backing Drive File."""
+        with self.set_user(OWNER):
+            template = frappe.get_doc(
+                {"doctype": "Presentation", "title": title, "is_template": 1, "slides": [{"elements": "[]"}]}
+            ).insert()
+            file = make_private_image(template.name)
+
+        self.assertIsNone(DriveFile.get_for_doc("Presentation", template.name))
+        return template, file
 
     def make_shared_url(self, title):
         """Two presentations holding the same image, which frappe stores once and


### PR DESCRIPTION
Recently scoped media access to the presentation being viewed plus its references, which is the right rule but leaves nothing to authorize a url whose only File row sits on a template.

Fix: `validate_media_file` serves the file if the caller can read the presentation they named and the file is attached to a template. Both conditions are required, so a bare file url still 403s and a readable presentation does not unlock non-template media.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/frappe/codesmith/suite/pr/608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789124812&installation_model_id=431961&pr_number=608&repository=frappe%2Fsuite&return_to=https%3A%2F%2Fgithub.com%2Ffrappe%2Fsuite%2Fpull%2F608&signature=86aa9c877e508a8e8b37aaaa9b180e662982208006ad560a48fa09653ffe4f43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->