### PR TITLE
fix(slides): text overflow and selection in editor

### DIFF
--- a/frontend/src/apps/slides/components/SlideContainer.vue
+++ b/frontend/src/apps/slides/components/SlideContainer.vue
@@ -314,16 +314,34 @@ const duplicateAndDrag = (e, id) => {
 	})
 }
 
+// the multi-selection box covers its whole bounding rect, so an unselected
+// element inside it never receives the press
+const findElementUnderPointer = (e) => {
+	if (!e.target?.matches?.('[data-selection-box]')) return null
+
+	for (const node of document.elementsFromPoint(e.clientX, e.clientY)) {
+		if (!slideRef.value?.contains(node)) continue
+
+		const id = node.closest('[data-index]')?.getAttribute('data-index')
+		if (!id) continue
+
+		return activeElementIds.value.includes(id) ? null : id
+	}
+	return null
+}
+
 const handleMouseDown = (e, element) => {
 	if (inReadonlyMode.value || e.button == 2) return
-	const id = element?.id
 
 	e.stopPropagation()
 	e.preventDefault()
 
 	dragOccurred.value = false
 
-	if (e.altKey) return duplicateAndDrag(e, id)
+	// alt-drag duplicates the whole selection, so it ignores what is under the pointer
+	if (e.altKey) return duplicateAndDrag(e, element?.id)
+
+	const id = element?.id ?? findElementUnderPointer(e)
 
 	// start dragging once the pointer moves past a small threshold
 	watchForDragIntent(e, id)

--- a/frontend/src/apps/slides/components/TextElement.vue
+++ b/frontend/src/apps/slides/components/TextElement.vue
@@ -205,7 +205,6 @@ onBeforeMount(() => normalizeContent())
 	width: 100%;
 	white-space: pre-wrap;
 	overflow-wrap: break-word;
-	hyphens: auto;
 }
 
 /* use CSS variable set on container to apply legacy element line-height without

--- a/frontend/src/apps/slides/composables/useTextEditor.js
+++ b/frontend/src/apps/slides/composables/useTextEditor.js
@@ -6,10 +6,11 @@ import { commandHistory } from '@/apps/slides/stores/historyMeta'
 import { markDirty } from '@/apps/slides/stores/saving'
 import {
 	activeElement,
+	clampWidthToSlide,
 	findSlideElement,
 	getInitialShapeTextContent,
 } from '@/apps/slides/stores/element'
-import { editElementCommand } from '@/apps/slides/stores/commands'
+import { batchCommand, editElementCommand } from '@/apps/slides/stores/commands'
 import { currentSlide } from '@/apps/slides/stores/slide'
 
 export const activeEditor = ref(null)
@@ -100,7 +101,7 @@ export const useTextEditor = () => {
 		markDirty()
 	}
 
-	const recordContentEdit = (oldValue, transaction) => {
+	const recordContentEdit = (oldValue, transaction, clampedWidth) => {
 		const compositionId = transaction.getMeta('composition')
 		// an IME candidate pause routinely outlasts the coalesce window
 		const forceCoalesce = compositionId != null && compositionId === lastCompositionId
@@ -109,16 +110,32 @@ export const useTextEditor = () => {
 		const newValue = editorElement.content
 		if (!commandHistory || oldValue === newValue) return
 
+		const contentCommand = editElementCommand({
+			slideId: editorSlideId,
+			elementIds: [editorElement.id],
+			property: 'content',
+			oldValue,
+			newValue,
+			coalesceKey: `content:${editorSlideId}:${editorElement.id}`,
+		})
+
+		if (!clampedWidth) return commandHistory.record(contentCommand, { forceCoalesce })
+
+		// the clamp has to undo with the edit that triggered it
+		const widthCommand = editElementCommand({
+			slideId: editorSlideId,
+			elementIds: [editorElement.id],
+			property: 'width',
+			oldValue: null,
+			newValue: clampedWidth,
+		})
+
 		commandHistory.record(
-			editElementCommand({
+			batchCommand({
 				slideId: editorSlideId,
 				elementIds: [editorElement.id],
-				property: 'content',
-				oldValue,
-				newValue,
-				coalesceKey: `content:${editorSlideId}:${editorElement.id}`,
+				commands: [contentCommand, widthCommand],
 			}),
-			{ forceCoalesce },
 		)
 	}
 
@@ -135,9 +152,10 @@ export const useTextEditor = () => {
 		const oldValue = patchedHTML(editorElement.content)
 
 		updateElementContent(editor)
+		const clampedWidth = clampWidthToSlide(editorElement)
 		setEditorStyles(editor)
 
-		recordContentEdit(oldValue, transaction)
+		recordContentEdit(oldValue, transaction, clampedWidth)
 	}
 
 	const markCommands = {

--- a/frontend/src/apps/slides/pages/PresentationEditor.vue
+++ b/frontend/src/apps/slides/pages/PresentationEditor.vue
@@ -1,6 +1,7 @@
 <template>
+	<!-- clip so the caret can't scroll the editor; hidden is the fallback -->
 	<div
-		class="isolate flex h-screen w-screen select-none flex-col overflow-hidden"
+		class="isolate flex h-screen w-screen select-none flex-col overflow-hidden overflow-clip"
 		@click="focusedSlide = null"
 	>
 		<EditorNavbar

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -15,6 +15,7 @@ import { getElementDiv } from './elementRegistry'
 import { markDirty } from './saving'
 import { generateUniqueId, cloneObj, normalizeRotation } from '../utils/helpers'
 import { getBorderInset, getCoverCrop, isFullRect } from '../utils/cropGeometry'
+import { getMinSizeForElement } from '../utils/resize'
 import { getAttachmentUrl } from '../utils/mediaUploads'
 import { guessTextColorFromBackground, guessShapeColorsFromBackground } from '../utils/color'
 import { presentationId } from './presentation'
@@ -859,6 +860,28 @@ const addFixedWidthToElement = () => {
 	}
 }
 
+// cap an auto-width box at the room left to the slide edge so it wraps instead of growing off
+const clampWidthToSlide = (element) => {
+	if (element?.type != 'text' || element.width) return
+
+	const elementDiv = getElementDiv(element.id)
+	if (!elementDiv) return
+
+	// offsetParent is the containing block, so the slide border is already excluded
+	const slideWidth = elementDiv.offsetParent?.clientWidth
+	if (!slideWidth) return
+
+	const availableWidth = slideWidth - element.left
+	if (availableWidth < getMinSizeForElement('text').width) return
+
+	if (elementDiv.offsetWidth <= availableWidth) return
+
+	element.width = availableWidth
+	markDirty()
+
+	return availableWidth
+}
+
 // the stored number equals what auto-height already renders, so no markDirty
 const ensureExplicitHeight = (element) => {
 	if (!element || !['image', 'video'].includes(element.type)) return
@@ -1159,6 +1182,7 @@ export {
 	selectableIds,
 	getElementPosition,
 	addFixedWidthToElement,
+	clampWidthToSlide,
 	ensureExplicitHeight,
 	getNaturalAspectRatio,
 	setEditableState,

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -877,7 +877,6 @@ const clampWidthToSlide = (element) => {
 	if (elementDiv.offsetWidth <= availableWidth) return
 
 	element.width = availableWidth
-	markDirty()
 
 	return availableWidth
 }


### PR DESCRIPTION
- Clicking an element that sits under the multi-selection box now selects that element instead of the box.
- A text box with no set width now wraps at the slide's right edge instead of growing past it, so pasting a paragraph no longer shifts the rest of the layout.
- Long words wrap whole instead of being split across lines with a hyphen.