### PR TITLE
ci: allow collaborator E2E pull requests

### DIFF
--- a/.github/workflows/drive-backed-apps-e2e.yml
+++ b/.github/workflows/drive-backed-apps-e2e.yml
@@ -54,7 +54,10 @@ concurrency:
 
 jobs:
   e2e:
-    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: suite-e2e
     timeout-minutes: 45
     permissions:

--- a/.github/workflows/meet-e2e.yml
+++ b/.github/workflows/meet-e2e.yml
@@ -50,7 +50,10 @@ concurrency:
 
 jobs:
   e2e:
-    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: suite-e2e
     # Playwright --shard=N/M splits the suite; each job is self-contained.
     strategy:


### PR DESCRIPTION
Allow trusted organization members and repository collaborators to run E2E tests from forks.