### PR TITLE
ci(meet): enable full e2e coverage

### DIFF
--- a/e2e/meet/playwright.config.ts
+++ b/e2e/meet/playwright.config.ts
@@ -6,8 +6,8 @@ const isCI = !!process.env.CI;
 
 export default defineConfig({
 	testDir: "./specs",
-	// Calls share a local SFU, so run serially; CI shards jobs independently.
-	fullyParallel: !isCI,
+	// Distribute individual tests across CI shards; workers keep each shard serial.
+	fullyParallel: true,
 	forbidOnly: isCI,
 	outputDir: resolve(__dirname, "test-results"),
 	retries: isCI ? 2 : 0,

--- a/e2e/meet/specs/e2ee.spec.ts
+++ b/e2e/meet/specs/e2ee.spec.ts
@@ -129,7 +129,6 @@ test.describe("E2EE", () => {
 	});
 
 	test.describe("heavy coverage", () => {
-		test.skip(!!process.env.CI, "Skipped in CI to keep media e2e lightweight");
 		test.describe.configure({ timeout: 180_000 });
 
 	test("active participants keep receiving streams after E2EE is enabled mid-call", async ({


### PR DESCRIPTION

- run the previously CI-skipped E2EE coverage on the self-hosted E2E runners
- shard at test granularity while keeping one serial worker per runner
- balance the 20 Meet E2E tests across the three jobs at 7/7/6