### PR TITLE
fix(slides): don't cache template list for an hour

### DIFF
--- a/frontend/src/apps/slides/components/ThemeDialog.vue
+++ b/frontend/src/apps/slides/components/ThemeDialog.vue
@@ -12,7 +12,7 @@
 			<div class="grid max-h-[32rem] grid-cols-2 gap-6 overflow-y-auto">
 				<div
 					v-for="(theme, idx) in templateList"
-					:key="theme.idx"
+					:key="theme.name"
 					class="flex flex-col gap-3"
 				>
 					<div

--- a/frontend/src/apps/slides/stores/presentation.js
+++ b/frontend/src/apps/slides/stores/presentation.js
@@ -334,7 +334,6 @@ const templateList = ref([])
 const templateListResource = createResource({
 	url: 'suite.slides.doctype.presentation.presentation.get_templates',
 	method: 'GET',
-	cache: 'templates',
 	onSuccess: (data) => {
 		templateList.value = data
 	},

--- a/suite/slides/doctype/presentation/presentation.py
+++ b/suite/slides/doctype/presentation/presentation.py
@@ -392,6 +392,10 @@ def create_presentation(
             frappe.throw("You cannot duplicate this presentation", frappe.PermissionError)
         source_thumbnail = set_duplicate_metadata(presentation, duplicate_from)
     else:
+        if not template or not frappe.db.exists("Presentation", template):
+            frappe.throw(f"Template {template!r} does not exist", frappe.DoesNotExistError)
+        if not frappe.has_permission("Presentation", "read", template):
+            frappe.throw("You cannot create a presentation from this template", frappe.PermissionError)
         source_thumbnail = set_template_metadata(presentation, template)
     presentation.flags.drive_parent = parent
     presentation.insert()

--- a/suite/slides/doctype/presentation/presentation.py
+++ b/suite/slides/doctype/presentation/presentation.py
@@ -12,7 +12,6 @@ import frappe
 from frappe.core.doctype.file.file import get_local_image
 from frappe.model.document import Document
 from frappe.query_builder.functions import Count
-from frappe.utils.caching import redis_cache
 
 from suite.drive.api.permissions import user_has_permission
 from suite.drive.overrides.file import File as DriveFile
@@ -486,23 +485,7 @@ def get_public_presentation(name: str):
     return frappe.get_doc("Presentation", name).as_dict()
 
 
-def set_layouts_in_template(template):
-    if template.get("is_template") is not None and not template.get("is_template"):
-        return
-
-    doc = frappe.get_doc("Presentation", template["name"])
-    template["layouts"] = [slide.as_dict() for slide in doc.slides]
-    title = doc.title
-
-    for layout in template["layouts"]:
-        if is_system_template(title):
-            layout["thumbnail"] = get_template_thumbnail(title, layout["idx"])
-        else:
-            layout["thumbnail"] = ""
-
-
 @frappe.whitelist()
-@redis_cache()
 def get_templates():
     templates = frappe.get_all(
         "Presentation",
@@ -511,8 +494,30 @@ def get_templates():
         order_by="creation",
     )
 
+    slides = frappe.get_all(
+        "Slide",
+        filters={
+            "parent": ["in", [t["name"] for t in templates]],
+            "parenttype": "Presentation",
+            "parentfield": "slides",
+        },
+        fields=["*"],
+        order_by="parent asc, idx asc",
+    )
+
+    layouts_by_template: dict[str, list[dict]] = {}
+    for slide in slides:
+        slide["doctype"] = "Slide"
+        layouts_by_template.setdefault(slide["parent"], []).append(slide)
+
     for template in templates:
-        set_layouts_in_template(template)
+        template["layouts"] = layouts_by_template.get(template["name"], [])
+        for layout in template["layouts"]:
+            layout["thumbnail"] = (
+                get_template_thumbnail(template["title"], layout["idx"])
+                if is_system_template(template["title"])
+                else ""
+            )
 
     return templates
 

--- a/suite/slides/doctype/presentation/presentation.py
+++ b/suite/slides/doctype/presentation/presentation.py
@@ -392,7 +392,7 @@ def create_presentation(
             frappe.throw("You cannot duplicate this presentation", frappe.PermissionError)
         source_thumbnail = set_duplicate_metadata(presentation, duplicate_from)
     else:
-        if not template or not frappe.db.exists("Presentation", template):
+        if not template or not frappe.db.get_value("Presentation", template, "is_template"):
             frappe.throw(f"Template {template!r} does not exist", frappe.DoesNotExistError)
         if not frappe.has_permission("Presentation", "read", template):
             frappe.throw("You cannot create a presentation from this template", frappe.PermissionError)

--- a/suite/slides/doctype/presentation/test_presentation.py
+++ b/suite/slides/doctype/presentation/test_presentation.py
@@ -69,6 +69,19 @@ class TestPresentationSecurity(IntegrationTestCase):
             with self.assertRaises(frappe.PermissionError):
                 create_presentation(duplicate_from=self.owner_presentation)
 
+    def test_create_rejects_a_template_that_no_longer_exists(self):
+        for template in ("this-template-was-deleted", None, ""):
+            with self.subTest(template=template):
+                with self.assertRaises(frappe.DoesNotExistError):
+                    create_presentation(template=template)
+
+    def test_create_from_template_requires_read(self):
+        # a presentation that is not a template is not a template to copy from either,
+        # whoever names it
+        with self.set_user(OTHER_USER):
+            with self.assertRaises(frappe.PermissionError):
+                create_presentation(template=self.owner_presentation)
+
     def test_updated_json_blocks_file_exfil(self):
         exfil = [{"type": "image", "src": self.private_file.file_url}]
         with self.set_user(OTHER_USER):

--- a/suite/slides/doctype/presentation/test_presentation.py
+++ b/suite/slides/doctype/presentation/test_presentation.py
@@ -12,6 +12,7 @@ from suite.slides.doctype.presentation.presentation import (
     delete_presentation,
     get_composite_presentation,
     get_public_presentation,
+    get_templates,
     get_updated_json,
     save_base64_image,
     save_presentation_thumbnail,
@@ -190,6 +191,40 @@ class TestPresentationSecurity(IntegrationTestCase):
             result = get_composite_presentation(composite.name)
 
         self.assertEqual(result["slides"], [])
+
+
+class TestTemplates(IntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        ensure_user(OWNER)
+
+        with cls.set_user(OWNER):
+            cls.one_layout = make_presentation("One Layout Template")
+
+            cls.three_layouts = make_presentation("Three Layout Template")
+            cls.three_layouts.append("slides", {"elements": "[]"})
+            cls.three_layouts.append("slides", {"elements": "[]"})
+            cls.three_layouts.save()
+
+        for template in (cls.one_layout, cls.three_layouts):
+            frappe.db.set_value("Presentation", template.name, "is_template", 1)
+
+    def test_layouts_are_grouped_per_template_in_idx_order(self):
+        # one bulk query feeds every template, so a grouping slip shows up only when the
+        # templates differ in size
+        by_name = {template["name"]: template for template in get_templates()}
+
+        self.assertEqual(len(by_name[self.one_layout.name]["layouts"]), 1)
+
+        layouts = by_name[self.three_layouts.name]["layouts"]
+        self.assertEqual([layout["idx"] for layout in layouts], [1, 2, 3])
+        self.assertEqual(
+            [layout["name"] for layout in layouts],
+            [slide.name for slide in self.three_layouts.slides],
+        )
+        # the editor spreads a layout into a new child row, which needs its doctype
+        self.assertEqual({layout["doctype"] for layout in layouts}, {"Slide"})
 
 
 class TestSlideRows(IntegrationTestCase):

--- a/suite/slides/doctype/presentation/test_presentation.py
+++ b/suite/slides/doctype/presentation/test_presentation.py
@@ -75,12 +75,18 @@ class TestPresentationSecurity(IntegrationTestCase):
                 with self.assertRaises(frappe.DoesNotExistError):
                     create_presentation(template=template)
 
-    def test_create_from_template_requires_read(self):
-        # a presentation that is not a template is not a template to copy from either,
-        # whoever names it
-        with self.set_user(OTHER_USER):
-            with self.assertRaises(frappe.PermissionError):
-                create_presentation(template=self.owner_presentation)
+    def test_create_rejects_a_presentation_that_is_not_a_template(self):
+        # readable is not enough. `theme` has to name a template or the editor cannot
+        # resolve layouts for the slides added later, and the same throw covers a deck
+        # the caller cannot read so neither answer leaks whether it exists
+        with self.set_user(OWNER):
+            own = make_presentation("Not A Template").name
+
+        for presentation in (own, self.other_presentation):
+            with self.subTest(presentation=presentation):
+                with self.set_user(OWNER):
+                    with self.assertRaises(frappe.DoesNotExistError):
+                        create_presentation(template=presentation)
 
     def test_updated_json_blocks_file_exfil(self):
         exfil = [{"type": "image", "src": self.private_file.file_url}]


### PR DESCRIPTION
`get_templates` was decorated with `@redis_cache()`. That stores one entry per site under the function's own key with a one hour TTL. Removed the cache rather than invalidating it. The cache was only paying for the `get_doc` per template, so this replaces that with a single bulk query for the child rows.

An `on_update` hook would have worked, but it buys 0.7ms once per page load and has to stay correct across template edits, their child slide rows, and fixture import on migrate. Getting it wrong reproduces this exact bug, silently, for an hour.