### PR TITLE
fix: guard migration patches against sites missing legacy schemas

### DIFF
--- a/suite/drive/patches/add_modified_field.py
+++ b/suite/drive/patches/add_modified_field.py
@@ -2,6 +2,10 @@ import frappe
 
 
 def execute():
+    if not frappe.db.table_exists("Drive File"):
+        # Site never had the legacy Drive schema — nothing to migrate.
+        return
+
     for k in frappe.get_all("Drive File", fields=["name", "modified"]):
         frappe.db.set_value(
             "Drive File",

--- a/suite/drive/patches/folder_size.py
+++ b/suite/drive/patches/folder_size.py
@@ -11,6 +11,10 @@ def scan(folder):
 
 
 def execute():
+    if not frappe.db.table_exists("Drive File"):
+        # Site never had the legacy Drive schema — nothing to migrate.
+        return
+
     roots = frappe.get_list("Drive File", {"folder": ""}, pluck="name")
     for root in roots:
         scan(root)

--- a/suite/drive/patches/new_writer.py
+++ b/suite/drive/patches/new_writer.py
@@ -7,6 +7,10 @@ import pycrdt
 
 
 def execute():
+    if not frappe.db.table_exists("Drive File"):
+        # Site never had the legacy Drive schema — nothing to migrate.
+        return
+
     files = frappe.get_all("Drive File", filters={"document": ("!=", "")}, fields=["name", "document"])
     yjs_map = {k["name"]: frappe.get_doc("Drive Document", k["document"]).content for k in files}
 

--- a/suite/drive/patches/remove_personal.py
+++ b/suite/drive/patches/remove_personal.py
@@ -5,6 +5,10 @@ import frappe
 
 
 def execute():
+    if not frappe.db.table_exists("Drive Team"):
+        # Site never had the legacy Drive schema — nothing to migrate.
+        return
+
     print(
         "This migration to a beta release might CORRUPT your data. Do NOT run this before taking a complete backup. You have two minutes left to cancel this deployment. "
     )

--- a/suite/drive/patches/settings.py
+++ b/suite/drive/patches/settings.py
@@ -2,6 +2,10 @@ import frappe
 
 
 def execute():
+    if not frappe.db.table_exists("Drive Team Member"):
+        # Site never had the legacy Drive schema — nothing to migrate.
+        return
+
     for user in frappe.db.get_list("User", pluck="name"):
         teams = frappe.get_all(
             "Drive Team Member",

--- a/suite/drive/patches/team_restructure.py
+++ b/suite/drive/patches/team_restructure.py
@@ -6,6 +6,10 @@ import frappe
 
 
 def execute():
+    if not frappe.db.table_exists("Drive Entity"):
+        # Site never had the legacy Drive schema — nothing to restructure.
+        return
+
     print(
         "This migration to an alpha release might CORRUPT your data. Do NOT run this before taking a complete backup. You have two minutes left to cancel this deployment. "
     )

--- a/suite/drive/patches/update_roles.py
+++ b/suite/drive/patches/update_roles.py
@@ -2,6 +2,10 @@ import frappe
 
 
 def execute():
+    if not frappe.db.table_exists("Drive Team Member"):
+        # Site never had the legacy Drive schema — nothing to migrate.
+        return
+
     frappe.reload_doc("Drive", "doctype", "Drive Team Member")
     for id in frappe.get_all("Drive Team Member"):
         member = frappe.get_doc("Drive Team Member", id)

--- a/suite/mail/patches/capture_user_outgoing_settings.py
+++ b/suite/mail/patches/capture_user_outgoing_settings.py
@@ -13,6 +13,10 @@ def execute() -> None:
     columns still exist in the table, so the query builder references them by column name.
     """
 
+    if not frappe.db.table_exists("User Settings"):
+        # Site never had the mail schema — nothing to capture.
+        return
+
     if not frappe.db.has_column("User Settings", "default_outgoing_email"):
         return
 

--- a/suite/meet/patches/migrate_meeting_fields_to_table_multiselect.py
+++ b/suite/meet/patches/migrate_meeting_fields_to_table_multiselect.py
@@ -8,6 +8,10 @@ from frappe.model.document import Document
 
 
 def execute():
+    if not frappe.db.has_column("Meet Room", "members"):
+        # The legacy JSON columns never existed on this site — nothing to migrate.
+        return
+
     meetings = frappe.get_all("Meet Room", fields=["name", "members", "waiting_room"])
 
     for meeting in meetings:

--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -13,7 +13,7 @@ suite.drive.patches.update_roles
 suite.drive.patches.remove_personal #3
 suite.drive.patches.integrate_with_framework
 # --- mail ---
-execute:frappe.db.delete("Mail Cluster Store")
+execute:frappe.db.delete("Mail Cluster Store") if frappe.db.table_exists("Mail Cluster Store") else None
 # --- writer ---
 suite.writer.patches.remove_frappe_writer_module
 

--- a/suite/slides/doctype/presentation/patches/move_attachments_to_private_folder.py
+++ b/suite/slides/doctype/presentation/patches/move_attachments_to_private_folder.py
@@ -95,6 +95,10 @@ def get_updated_elements(elements, presentation_name):
 
 
 def execute():
+    if not frappe.db.has_column("Presentation", "is_public"):
+        # The legacy flag never existed on this site — nothing to move.
+        return
+
     presentations = frappe.get_all("Presentation", filters={"is_public": 1, "is_composite": 0}, pluck="name")
 
     for presentation_name in presentations:


### PR DESCRIPTION
## Problem

`bench migrate` crashes on sites that were never standalone installs of every merged app — e.g. a site restored from a **mail-only** (or drive-only, meet-only, …) backup. Patches written for upgrading the old standalone apps unconditionally query legacy tables/columns that only exist on sites coming from that app:

```
suite.drive.patches.team_restructure
MySQLdb.ProgrammingError: ('DocType', 'Drive Team')
```

and after that, the same failure repeats down the patch chain (`update_roles`, `move_attachments_to_private_folder` with `Unknown column 'is_public'`, `migrate_meeting_fields_to_table_multiselect` with `Unknown column 'members'`, …).

## Fix

Audited every patch in `patches.txt` for this scenario and added an early exit to each patch that migrates *from* a legacy schema, skipping when the source table/column doesn't exist — the same pattern already used by `integrate_with_framework`, `remove_teams` and `move_slide_thumbnail_to_presentation`:

- **Drive**: `team_restructure`, `update_roles`, `remove_personal`, `folder_size`, `settings`, `new_writer`, `add_modified_field` — skip when the legacy `Drive Entity` / `Drive Team` / `Drive Team Member` / `Drive File` tables don't exist. Also skips the two 120s "might corrupt your data" sleeps on sites with nothing to migrate.
- **Slides**: `move_attachments_to_private_folder` — skip when the dropped `Presentation.is_public` column is absent.
- **Meet**: `migrate_meeting_fields_to_table_multiselect` — skip when the legacy `Meet Room.members` JSON column is absent.
- **Mail**: `capture_user_outgoing_settings` — check `table_exists("User Settings")` before `has_column` (which raises `TableMissingError` on a missing table; this patch runs pre-model-sync, before non-mail sites have the table).
- **patches.txt**: the `execute:frappe.db.delete("Mail Cluster Store")` line (pre-model-sync) now no-ops when the table doesn't exist. The edited line registers as a new patch entry and re-runs once on existing sites, but the delete is idempotent.

The guards are no-ops on real legacy sites, so upgrade behavior there is unchanged. The remaining patches were audited and are safe as-is: they run post-model-sync against current doctypes (tables guaranteed by sync, empty on foreign sites), the filesystem, or core tables.

## Verification

`bench --site <site> migrate && bench build` now completes cleanly on a site restored from a mail-only backup, and re-runs cleanly after the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)