### PR TITLE
fix: preserve referenced Mail Cluster Store records during migration

### DIFF
--- a/suite/mail/patches/delete_stale_cluster_stores.py
+++ b/suite/mail/patches/delete_stale_cluster_stores.py
@@ -16,17 +16,29 @@ def execute() -> None:
     if not frappe.db.table_exists("Mail Cluster Store"):
         return
 
-    referenced = set()
-    if frappe.db.table_exists("Mail Cluster"):
-        for field in STORE_FIELDS:
-            if frappe.db.has_column("Mail Cluster", field):
-                referenced.update(
-                    frappe.db.sql_list(
-                        f"select distinct `{field}` from `tabMail Cluster` where ifnull(`{field}`, '') != ''"
-                    )
-                )
+    referenced = get_referenced_store_names()
 
     if referenced:
-        frappe.db.delete("Mail Cluster Store", {"name": ("not in", list(referenced))})
+        frappe.db.delete("Mail Cluster Store", {"name": ("not in", sorted(referenced))})
     else:
+        # Nothing links to any store, so every row predates the new schema.
+        # Old suite sites, where the DocType was removed before any cluster
+        # could reference it, land here and get the original full cleanup.
         frappe.db.delete("Mail Cluster Store")
+
+
+def get_referenced_store_names() -> set[str]:
+    if not frappe.db.table_exists("Mail Cluster"):
+        return set()
+
+    cluster = frappe.qb.DocType("Mail Cluster")
+    referenced = set()
+
+    for field in STORE_FIELDS:
+        if not frappe.db.has_column("Mail Cluster", field):
+            continue
+
+        stores = frappe.qb.from_(cluster).select(cluster[field]).distinct().run(pluck=True)
+        referenced.update(store for store in stores if store)
+
+    return referenced

--- a/suite/mail/patches/delete_stale_cluster_stores.py
+++ b/suite/mail/patches/delete_stale_cluster_stores.py
@@ -1,0 +1,32 @@
+import frappe
+
+STORE_FIELDS = ["data_store", "blob_store", "search_store", "in_memory_store"]
+
+
+def execute() -> None:
+    """Delete Mail Cluster Store records left over from the legacy schema.
+
+    The DocType was removed and re-introduced with a new schema, so rows created
+    under the old schema must not survive model sync. Sites migrating from the
+    standalone mail app, however, arrive with live store records that Mail
+    Cluster links to (wiping those fails configure_mail_cluster with a
+    LinkValidationError), so only rows no cluster references are deleted.
+    """
+
+    if not frappe.db.table_exists("Mail Cluster Store"):
+        return
+
+    referenced = set()
+    if frappe.db.table_exists("Mail Cluster"):
+        for field in STORE_FIELDS:
+            if frappe.db.has_column("Mail Cluster", field):
+                referenced.update(
+                    frappe.db.sql_list(
+                        f"select distinct `{field}` from `tabMail Cluster` where ifnull(`{field}`, '') != ''"
+                    )
+                )
+
+    if referenced:
+        frappe.db.delete("Mail Cluster Store", {"name": ("not in", list(referenced))})
+    else:
+        frappe.db.delete("Mail Cluster Store")

--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -13,7 +13,7 @@ suite.drive.patches.update_roles
 suite.drive.patches.remove_personal #3
 suite.drive.patches.integrate_with_framework
 # --- mail ---
-execute:frappe.db.delete("Mail Cluster Store") if frappe.db.table_exists("Mail Cluster Store") else None
+suite.mail.patches.delete_stale_cluster_stores
 # --- writer ---
 suite.writer.patches.remove_frappe_writer_module
 


### PR DESCRIPTION
## Problem

On sites restored from a standalone mail app backup, `bench migrate` failed in `configure_mail_cluster` with:

```
frappe.exceptions.LinkValidationError: Could not find Data Store: ..., Blob Store: ..., Search Store: ..., In-Memory Store: ...
```

The backup itself is fine — it contains all the `Mail Cluster Store` records the clusters link to. The pre-model-sync line in `patches.txt` then wiped the whole table:

```
execute:frappe.db.delete("Mail Cluster Store") if frappe.db.table_exists("Mail Cluster Store") else None
```

Since the restored Patch Log comes from the mail site, this runs on first migrate and deletes the live store configs, so every `Mail Cluster.save()` afterwards fails link validation. `_initialize_data_store()` doesn't recover because `data_store` is still set to the now-missing name.

## Fix

Replace the one-liner with `suite.mail.patches.delete_stale_cluster_stores`, which:

- exits early when `tabMail Cluster Store` doesn't exist (keeps the single-app-backup guard from #618)
- collects store names referenced by `Mail Cluster`'s `data_store` / `blob_store` / `search_store` / `in_memory_store` columns (checking each column exists first)
- deletes only unreferenced rows; when nothing is referenced (the old-suite upgrade case the wipe was written for) it still clears the table

## Verification

On a site restored from a production mail backup (7 store rows, 5 clusters):

- the patch kept exactly the 6 referenced stores and deleted the 1 stale unreferenced row
- `configure_mail_cluster` then completed for all 5 clusters with no Error Log entries

Note: since the patch line text changed, sites that already ran the old `execute:` line will run the new patch once more — harmless, it only deletes unreferenced rows.