### PR TITLE
fix(drive): scope mark_as_read to the notification's recipient

### DIFF
--- a/suite/drive/api/notifications.py
+++ b/suite/drive/api/notifications.py
@@ -58,7 +58,9 @@ def mark_as_read(name: str | None = None, all: bool = False):
             "Drive Notification", {"to_user": frappe.session.user, "read": False}, "read", True
         )
         return
-    frappe.db.set_value("Drive Notification", name, "read", True)
+    # filter on the recipient too: a bare name would let any caller flip the flag
+    # on someone else's notification
+    frappe.db.set_value("Drive Notification", {"name": name, "to_user": frappe.session.user}, "read", True)
     return
 
 

--- a/suite/drive/api/tests/test_notifications.py
+++ b/suite/drive/api/tests/test_notifications.py
@@ -1,8 +1,13 @@
 from unittest.mock import patch
 
-from frappe.tests import UnitTestCase
+import frappe
+from frappe.tests import IntegrationTestCase, UnitTestCase
 
-from suite.drive.api.notifications import send_share_email
+from suite.drive.api.notifications import mark_as_read, send_share_email
+from suite.tests.utils import ensure_user
+
+RECIPIENT = "drive-notifications-recipient@example.com"
+OTHER_USER = "drive-notifications-other@example.com"
 
 
 class TestShareEmail(UnitTestCase):
@@ -13,3 +18,40 @@ class TestShareEmail(UnitTestCase):
 
         sendmail.assert_called_once()
         self.assertNotIn("now", sendmail.call_args.kwargs)
+
+
+class TestMarkAsRead(IntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        ensure_user(RECIPIENT)
+        ensure_user(OTHER_USER)
+
+    def setUp(self):
+        self.notification = frappe.get_doc(
+            {
+                "doctype": "Drive Notification",
+                "to_user": RECIPIENT,
+                "from_user": OTHER_USER,
+                "message": "A file was shared with you",
+                "read": 0,
+            }
+        ).insert(ignore_permissions=True)
+
+    def test_recipient_can_mark_own_notification_as_read(self):
+        with self.set_user(RECIPIENT):
+            mark_as_read(name=self.notification.name)
+
+        self.assertTrue(frappe.db.get_value("Drive Notification", self.notification.name, "read"))
+
+    def test_other_user_cannot_mark_notification_as_read(self):
+        with self.set_user(OTHER_USER):
+            mark_as_read(name=self.notification.name)
+
+        self.assertFalse(frappe.db.get_value("Drive Notification", self.notification.name, "read"))
+
+    def test_mark_all_only_touches_own_notifications(self):
+        with self.set_user(OTHER_USER):
+            mark_as_read(all=True)
+
+        self.assertFalse(frappe.db.get_value("Drive Notification", self.notification.name, "read"))


### PR DESCRIPTION
`mark_as_read(name=...)` passed the name straight to `frappe.db.set_value` with no check that the notification belongs to the caller, so any logged-in user could mark another user's notification as read — hiding a share notification before the recipient ever saw it.

Filter on `to_user` as well, matching what the `all=True` branch a few lines above already does. A non-matching filter is a silent no-op, so the endpoint does not become an existence oracle for notification names either.

The sole caller (`Notifications.vue`) only ever passes rows returned by `get_notifications`, which is already scoped to the session user, so there is no behaviour change for the UI.

3 regression tests; the one covering the cross-user case verified failing without the fix.