### PR TITLE
Calendar invite strip, responsive event emails

### DIFF
--- a/frontend/src/apps/calendar/components/DateChip.vue
+++ b/frontend/src/apps/calendar/components/DateChip.vue
@@ -1,0 +1,29 @@
+<template>
+	<!-- Month over day in a bordered box: the date as a glyph, readable at a glance down a list.
+	     The month band takes the sender avatar's fallback pair (surface-gray-2 / ink-gray-5), so
+	     the two filled shapes flanking a message read as one family. Caveat: that lands at 3.6:1
+	     in dark mode, and this text is 11px. -->
+	<div
+		class="border-outline-gray-2 bg-surface-base w-10 shrink-0 overflow-hidden rounded border text-center"
+	>
+		<!-- Both rows are sized by leading rather than by padding around the text's own line box:
+		     16 + 20, a hairline of breathing room each, and the borders lands the chip at ~43px
+		     against 40px of width — near enough square, and close to the two-line title/subtitle
+		     block it stands beside rather than overhanging it at both ends. -->
+		<div
+			class="border-outline-gray-1 bg-surface-gray-2 text-ink-gray-5 border-b py-px text-tiny uppercase leading-4"
+		>
+			{{ month }}
+		</div>
+		<div class="text-ink-gray-9 text-lg-semibold py-px leading-5 tabular-nums">{{ day }}</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+/**
+ * A calendar date as a chip. Callers pass the already-formatted parts rather than an event, so
+ * the chip never has to know how a start is read into a zone — that stays with the caller, which
+ * is the only place that knows whether the event is all-day (see `@/apps/calendar/utils/eventTime`).
+ */
+defineProps<{ month: string; day: string }>()
+</script>

--- a/frontend/src/apps/calendar/pages/CalendarView.vue
+++ b/frontend/src/apps/calendar/pages/CalendarView.vue
@@ -221,17 +221,35 @@ const emailParticipants = (emails: string[]) => {
 	router.push({ path: '/mail', query: { compose: '1', to: emails.join(',') } })
 }
 
+// A deep link can only be built from the ids its author has. The grid's own
+// events come out of a recurrence-expanded query, so each carries a synthetic
+// per-instance id and wears the real event's id as `master_id` — but mail's
+// invite strip resolves an invite's UID to that master id, which matches
+// nothing here. So a link that misses on id falls back to the master, narrowed
+// to the instance covering the routed day (the day the link itself picked).
+const findLinkedEvent = (data, id, recurrence) => {
+	if (!data || !id) return null
+
+	const rec = (recurrence as string) ?? ''
+	const exact = data.find((e) => e.id === id && (e.recurrence_id ?? '') === rec)
+	if (exact) return exact
+
+	const instances = data.filter((e) => e.master_id === id)
+	if (!instances.length) return null
+	if (rec) return instances.find((e) => (e.recurrence_id ?? '') === rec) ?? null
+
+	const { year, month, day } = route.params
+	const routed = year && month && day ? dayjs(`${year}-${month}-${day}`, 'YYYY-M-D') : null
+	if (!routed?.isValid()) return instances[0]
+
+	const routedDay = routed.format('YYYY-MM-DD')
+	return instances.find((e) => e.fromDate <= routedDay && routedDay <= e.toDate) ?? instances[0]
+}
+
 watch(
 	[() => events.data, () => route.query.event, () => route.query.recurrence],
 	([data, id, recurrence]) => {
-		if (!id) {
-			selectedCalendarEvent.value = null
-			return
-		}
-		selectedCalendarEvent.value =
-			data?.find(
-				(e) => e.id === id && (e.recurrence_id ?? '') === ((recurrence as string) ?? ''),
-			) ?? null
+		selectedCalendarEvent.value = findLinkedEvent(data, id, recurrence)
 	},
 	{ immediate: true },
 )
@@ -261,9 +279,7 @@ watch(
 			return
 		}
 		if (showEditEvent.value) return
-		const match = data?.find(
-			(e) => e.id === id && (e.recurrence_id ?? '') === ((recurrence as string) ?? ''),
-		)
+		const match = findLinkedEvent(data, id, recurrence)
 		if (match) handleOpenEvent({ calendarEvent: match })
 	},
 	{ immediate: true },

--- a/frontend/src/apps/calendar/utils/eventTime.test.ts
+++ b/frontend/src/apps/calendar/utils/eventTime.test.ts
@@ -1,0 +1,150 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { translate } from '@/boot/translation'
+import dayjs from '@/apps/calendar/utils/dayjs'
+import { eventLastDay, formatEventWhen, isAllDayEvent } from '@/apps/calendar/utils/eventTime'
+
+// The formatter calls the global `__()` the translation boot installs at app start.
+beforeAll(() => {
+	window.__ = translate
+})
+
+// Fixed "today" so the Today / this-year branches assert something stable. In 2026 the 17th of
+// August is a Monday and the 9th of January 2027 a Saturday.
+const now = dayjs('2026-08-13T09:00:00')
+const when = (start: string, duration?: string, options = {}) =>
+	formatEventWhen(dayjs(start), duration, { now, ...options })
+const allDay = (start: string, duration?: string, options = {}) =>
+	when(start, duration, { allDay: true, ...options })
+
+describe('isAllDayEvent', () => {
+	it('trusts the flag', () => {
+		expect(
+			isAllDayEvent({ start: '2026-08-17T00:00:00', duration: 'P1D', show_without_time: 1 }),
+		).toBe(true)
+		// Some senders flag an all-day event without normalising the wall clock to midnight.
+		expect(
+			isAllDayEvent({ start: '2026-08-17T09:00:00', duration: 'PT1H', show_without_time: true }),
+		).toBe(true)
+	})
+
+	it('reads an unflagged midnight-to-midnight span as all day', () => {
+		expect(isAllDayEvent({ start: '2026-08-17T00:00:00', duration: 'P1D' })).toBe(true)
+		expect(isAllDayEvent({ start: '2026-08-17T00:00:00', duration: 'P3D' })).toBe(true)
+	})
+
+	it('leaves timed events alone', () => {
+		expect(isAllDayEvent({ start: '2026-08-17T15:00:00', duration: 'PT1H' })).toBe(false)
+		// Starts at midnight but stops short of the next one.
+		expect(isAllDayEvent({ start: '2026-08-17T00:00:00', duration: 'PT12H' })).toBe(false)
+		expect(isAllDayEvent({ start: '2026-08-17T00:00:00' })).toBe(false)
+	})
+})
+
+describe('eventLastDay', () => {
+	// The strip draws a chip per end, so a wrong answer here shows up as a visible extra day.
+	const lastDay = (start: string, duration?: string, allDay = false) => {
+		const day = eventLastDay(dayjs(start), duration, allDay)
+		return day && day.format('YYYY-MM-DD')
+	}
+
+	it('walks back the exclusive midnight end of an all-day span', () => {
+		expect(lastDay('2026-08-17T00:00:00', 'P3D', true)).toBe('2026-08-19')
+	})
+
+	it('gives nothing to pair with when the event covers one day', () => {
+		expect(lastDay('2026-08-17T00:00:00', 'P1D', true)).toBe(null)
+		expect(lastDay('2026-08-17T15:00:00', 'PT1H')).toBe(null)
+		expect(lastDay('2026-08-17T15:00:00')).toBe(null)
+	})
+
+	it('refuses a second chip for an evening that merely runs past midnight', () => {
+		expect(lastDay('2026-08-17T23:00:00', 'PT3H')).toBe(null)
+		// Still one sitting at the limit; a minute over and it is a span.
+		expect(lastDay('2026-08-17T09:00:00', 'PT23H59M')).toBe(null)
+		expect(lastDay('2026-08-17T09:00:00', 'PT24H1M')).toBe('2026-08-18')
+	})
+
+	it('uses the real end of a timed span', () => {
+		expect(lastDay('2026-08-31T09:00:00', 'PT56H')).toBe('2026-09-02')
+	})
+})
+
+describe('formatEventWhen', () => {
+	it('says all day instead of midnight to midnight', () => {
+		expect(allDay('2026-08-17T00:00:00', 'P1D')).toBe('Mon, 17 Aug · All day')
+	})
+
+	it('counts a multi-day span from its inclusive last day', () => {
+		// Stored as 17 Aug → 20 Aug, an exclusive end: the event does not run into Thursday.
+		expect(allDay('2026-08-17T00:00:00', 'P3D')).toBe('Mon, 17 – Wed, 19 Aug · 3 days')
+	})
+
+	it('spells the month on both ends of a span that crosses one', () => {
+		expect(allDay('2026-08-30T00:00:00', 'P3D')).toBe('Sun, 30 Aug – Tue, 1 Sep · 3 days')
+	})
+
+	it('prints one meridiem when the range stays inside it', () => {
+		expect(when('2026-08-17T15:00:00', 'PT1H')).toBe('Mon, 17 Aug · 3:00 – 4:00 pm · 1 hr')
+	})
+
+	it('prints both when the range crosses noon', () => {
+		expect(when('2026-08-17T11:00:00', 'PT2H')).toBe('Mon, 17 Aug · 11:00 am – 1:00 pm · 2 hr')
+	})
+
+	it('drops the date the reader is already living in', () => {
+		expect(when('2026-08-13T15:00:00', 'PT1H')).toBe('Today · 3:00 – 4:00 pm · 1 hr')
+	})
+
+	it('keeps the year only when it is not this one', () => {
+		expect(when('2027-01-09T15:00:00', 'PT1H')).toBe('Sat, 9 Jan 2027 · 3:00 – 4:00 pm · 1 hr')
+	})
+
+	it('keeps an overnight on one day, naming the second inline', () => {
+		expect(when('2026-08-17T23:00:00', 'PT3H')).toBe('Mon, 17 Aug · 11:00 pm – 2:00 am Tue · 3 hr')
+	})
+
+	it('breaks a length into hours and minutes', () => {
+		expect(when('2026-08-17T23:30:00', 'PT1H30M')).toBe(
+			'Mon, 17 Aug · 11:30 pm – 1:00 am Tue · 1 hr 30 min',
+		)
+		expect(when('2026-08-17T23:45:00', 'PT30M')).toBe(
+			'Mon, 17 Aug · 11:45 pm – 12:15 am Tue · 30 min',
+		)
+	})
+
+	it('never compacts an overnight, so both weekdays share a register', () => {
+		expect(when('2026-08-17T23:00:00', 'PT3H', { compact: true })).toBe(
+			'Mon, 17 Aug · 11:00 pm – 2:00 am Tue · 3 hr',
+		)
+	})
+
+	it('dates both ends of a timed span in full', () => {
+		expect(when('2026-08-31T09:00:00', 'PT56H')).toBe(
+			'Mon, 31 Aug, 9:00 am – Wed, 2 Sep, 5:00 pm',
+		)
+	})
+
+	it('handles an event with no duration', () => {
+		expect(when('2026-08-17T15:00:00')).toBe('Mon, 17 Aug · 3:00 pm')
+	})
+
+	describe('compact', () => {
+		const compact = (start: string, duration?: string, options = {}) =>
+			when(start, duration, { compact: true, ...options })
+
+		it('leaves only the weekday when a date chip carries the rest', () => {
+			expect(compact('2026-08-17T00:00:00', 'P1D', { allDay: true })).toBe('Monday · All day')
+			expect(compact('2026-08-17T15:00:00', 'PT1H')).toBe('Monday · 3:00 – 4:00 pm · 1 hr')
+			expect(compact('2026-08-13T15:00:00', 'PT1H')).toBe('Today · 3:00 – 4:00 pm · 1 hr')
+		})
+
+		it('still spells out what a chip cannot carry', () => {
+			// A chip shows one date and no year, so a span and another year keep their full label.
+			expect(compact('2026-08-17T00:00:00', 'P3D', { allDay: true })).toBe(
+				'Mon, 17 – Wed, 19 Aug · 3 days',
+			)
+			expect(compact('2027-01-09T15:00:00', 'PT1H')).toBe('Sat, 9 Jan 2027 · 3:00 – 4:00 pm · 1 hr')
+		})
+	})
+})

--- a/frontend/src/apps/calendar/utils/eventTime.ts
+++ b/frontend/src/apps/calendar/utils/eventTime.ts
@@ -1,0 +1,171 @@
+import dayjs from '@/apps/calendar/utils/dayjs'
+
+/**
+ * Turning an event's timing into the sentence a reader wants. The one rule behind every
+ * branch below: drop what the reader can infer. No year unless it isn't this one, no times on
+ * an all-day event, no repeated month or meridiem inside a range, weekday always — it's the
+ * cheapest orientation there is.
+ *
+ * Kept apart from `@/apps/calendar/utils/datetime` (which resolves zones through the calendar
+ * user store) so any app can format an event without pulling that store in. Callers hand in a
+ * start already read into the zone they want; this module only turns it into words.
+ */
+
+type Dayjs = ReturnType<typeof dayjs>
+
+/**
+ * The timing fields every formatted calendar event carries (the backend's
+ * `format_calendar_event`): a JSCalendar wall clock, an ISO-8601 duration, and the all-day flag.
+ */
+export interface EventTiming {
+	start: string
+	duration?: string | null
+	show_without_time?: boolean | 0 | 1
+}
+
+/**
+ * All-day-ness is a property of the event, not of the reader, so this reads the event's own wall
+ * clock — never a zone-converted copy, which would slide the midnight test into the previous or
+ * next day. The flag is authoritative when set; the midnight-to-midnight fallback catches the
+ * invites that arrive as a whole-day span without one (an ICS `DTSTART;VALUE=DATE` is exactly
+ * that: midnight to midnight, with the end an *exclusive* boundary on the following day).
+ */
+export const isAllDayEvent = (event: EventTiming): boolean => {
+	const start = dayjs(event.start)
+	const duration = dayjs.duration(event.duration || 'PT0S')
+	return Boolean(
+		event.show_without_time ||
+			(start.hour() === 0 &&
+				start.minute() === 0 &&
+				start.second() === 0 &&
+				duration.asDays() >= 1 &&
+				duration.asDays() % 1 === 0),
+	)
+}
+
+/** The moment an event stops, from its start and ISO-8601 duration. */
+const eventEnd = (start: Dayjs, duration?: string | null): Dayjs =>
+	start.add(dayjs.duration(duration || 'PT0S'))
+
+/** Whole days an all-day event covers; its stored end is the midnight *after* the last one. */
+const allDayCount = (duration?: string | null): number =>
+	Math.max(1, Math.round(dayjs.duration(duration || 'PT0S').asDays()))
+
+/**
+ * Under this, an event that passes midnight is one sitting rather than a span — an evening that
+ * runs late, not a second day. A day is the natural line: anything shorter fits in one go.
+ */
+const OVERNIGHT_LIMIT_HOURS = 24
+
+/** Whether a timed event runs past midnight without being long enough to count as a span. */
+const isOvernight = (start: Dayjs, end: Dayjs) =>
+	!end.isSame(start, 'day') && end.diff(start, 'hour', true) < OVERNIGHT_LIMIT_HOURS
+
+/**
+ * The inclusive last day an event covers, or `null` when it reads as living on a single one —
+ * which is also the question of whether the strip draws one date chip or two.
+ *
+ * All-day spans store an *exclusive* end — the midnight after the last day — so this walks that
+ * back; printing it raw is what told readers a 17–19 August event ran into the 20th. An
+ * overnight gets `null`: two calendar days, but a chip for the second would sell one evening as
+ * a two-day event, so the label names that day inline instead.
+ */
+export const eventLastDay = (
+	start: Dayjs,
+	duration?: string | null,
+	allDay = false,
+): Dayjs | null => {
+	if (allDay) {
+		const days = allDayCount(duration)
+		return days > 1 ? start.add(days - 1, 'day') : null
+	}
+	const end = eventEnd(start, duration)
+	if (end.isSame(start, 'day') || isOvernight(start, end)) return null
+	return end
+}
+
+/** Years are worth printing only when they aren't the one the reader is living in. */
+const yearFormat = (day: Dayjs, now: Dayjs) => (day.year() === now.year() ? '' : ' YYYY')
+
+/**
+ * A single day: `Today`, `Sun, 17 Aug`, or `Sat, 9 Jan 2027`. `compact` is for callers that
+ * already print the month and day beside the label (the invite strip's date chip does), leaving
+ * only the weekday to say — but a year no chip carries still spells itself out. Spans never
+ * compact: `dayRangeLabel` pairs each weekday with its date, which is the whole point of it.
+ */
+const dayLabel = (day: Dayjs, now: Dayjs, compact = false) => {
+	if (day.isSame(now, 'day')) return __('Today')
+	if (day.year() !== now.year()) return day.format(`ddd, D MMM${yearFormat(day, now)}`)
+	return day.format(compact ? 'dddd' : 'ddd, D MMM')
+}
+
+/** A span of days: `Mon, 17 – Wed, 19 Aug`, dropping the month from the first end when shared. */
+const dayRangeLabel = (first: Dayjs, last: Dayjs, now: Dayjs) => {
+	const sharesMonth = first.isSame(last, 'month')
+	const from = first.format(sharesMonth ? 'ddd, D' : `ddd, D MMM${yearFormat(first, now)}`)
+	return `${from} – ${last.format(`ddd, D MMM${yearFormat(last, now)}`)}`
+}
+
+/** `3:00 – 4:00 pm`, keeping the first meridiem only when the span crosses one. */
+const timeRangeLabel = (start: Dayjs, end: Dayjs) => {
+	if (end.isSame(start)) return start.format('h:mm a')
+	const sharesMeridiem = start.format('a') === end.format('a')
+	return `${start.format(sharesMeridiem ? 'h:mm' : 'h:mm a')} – ${end.format('h:mm a')}`
+}
+
+/** How long an all-day event runs: `All day`, or `3 days` once it spans more than one. */
+const allDayLabel = (days: number) =>
+	days === 1 ? __('All day') : __('{0} days', [String(days)])
+
+/** How long a timed event runs: `3 hr`, `1 hr 30 min`, `45 min`. */
+const lengthLabel = (start: Dayjs, end: Dayjs) => {
+	const minutes = end.diff(start, 'minute')
+	const hours = Math.floor(minutes / 60)
+	const rest = minutes % 60
+	if (!hours) return __('{0} min', [String(rest)])
+	if (!rest) return __('{0} hr', [String(hours)])
+	return __('{0} hr {1} min', [String(hours), String(rest)])
+}
+
+/**
+ * The whole sentence — when the event is, then how long it runs: `Sun, 17 Aug · All day`,
+ * `Mon, 17 – Wed, 19 Aug · 3 days`, `Today · 3:00 – 4:00 pm`.
+ *
+ * `now` is injectable for tests; `compact` is passed through to {@link dayLabel}.
+ */
+export const formatEventWhen = (
+	start: Dayjs,
+	duration?: string | null,
+	options: { allDay?: boolean; compact?: boolean; now?: Dayjs } = {},
+): string => {
+	const { allDay = false, compact = false, now = dayjs() } = options
+
+	if (allDay) {
+		const last = eventLastDay(start, duration, true)
+		const when = last ? dayRangeLabel(start, last, now) : dayLabel(start, now, compact)
+		return `${when} · ${allDayLabel(allDayCount(duration))}`
+	}
+
+	const end = eventEnd(start, duration)
+
+	// A genuine span carries a time at each end, so both dates spell themselves out in full and
+	// the `·` separator — which reads as "on this day, at this time" — goes.
+	if (eventLastDay(start, duration)) {
+		const from = `${dayLabel(start, now)}, ${start.format('h:mm a')}`
+		return `${from} – ${dayLabel(end, now)}, ${end.format('h:mm a')}`
+	}
+
+	// An overnight stays one day's entry, with the second day named after the closing time.
+	// Never compacted: the inline `Tue` sets the register, and `Monday · … Tue` mixes two.
+	if (isOvernight(start, end)) {
+		const times = `${start.format('h:mm a')} – ${end.format('h:mm a ddd')}`
+		return `${dayLabel(start, now)} · ${times} · ${lengthLabel(start, end)}`
+	}
+
+	// Every `·` sentence closes on a length — `All day`, `3 days`, `1 hr`. Whether the reader
+	// *could* subtract two clock times isn't a rule they can see, so a length that came and went
+	// between events would read as missing data rather than as inference.
+	const times = timeRangeLabel(start, end)
+	if (end.isSame(start)) return `${dayLabel(start, now, compact)} · ${times}`
+	return `${dayLabel(start, now, compact)} · ${times} · ${lengthLabel(start, end)}`
+}

--- a/frontend/src/apps/mail/components/CalendarInviteBanner.vue
+++ b/frontend/src/apps/mail/components/CalendarInviteBanner.vue
@@ -1,40 +1,70 @@
 <template>
+	<!-- Variant B of the Invite strip design doc: the generic calendar glyph carries no
+	     information, so it becomes the date itself — scannable down a thread at a glance — and
+	     the RSVP trio becomes a segmented control, the one thing three outline buttons can't do:
+	     hold a selection. -->
 	<div
 		v-if="invite"
-		class="text-ink-gray-6 mb-3 flex flex-col gap-3 rounded border p-2.5 px-4 sm:flex-row sm:items-center"
+		class="border-outline-gray-2 bg-surface-base mb-3 flex flex-col gap-3 rounded-md border px-4 py-3 sm:flex-row sm:items-center"
 	>
-		<div class="flex min-w-0 flex-1 items-center gap-3">
-			<CalendarPlus class="h-4.5 w-4.5 shrink-0 stroke-1.5" />
+		<!-- Opening the event is the first thing anyone tries to tap, so the target is the dates and
+		     the text together rather than the title alone — but it stops at the content: no flex-1,
+		     or the empty space between the strip's two halves would answer to a click. Only offered
+		     once the event is on a calendar of the reader's: the detail panel is a view of a real
+		     event, not of a parsed preview. -->
+		<component
+			:is="canViewEvent ? 'button' : 'div'"
+			:type="canViewEvent ? 'button' : undefined"
+			class="flex min-w-0 max-w-full items-center gap-3.5 self-start text-left sm:self-center"
+			@click="openEventDetail"
+		>
+			<!-- A span gets a chip per end: one chip can only ever claim one date. The arrow between
+			     them is what keeps 17 → 19 from reading as two unrelated events. -->
+			<div class="flex shrink-0 items-center gap-1.5">
+				<template v-for="(chip, index) in chips" :key="index">
+					<ArrowRight v-if="index" class="text-ink-gray-4 size-3 shrink-0 stroke-1.5" />
+					<DateChip :month="chip.month" :day="chip.day" />
+				</template>
+			</div>
 			<div class="min-w-0 flex-1">
-				<span class="text-ink-gray-8 block truncate">
+				<!-- The strip is the only place the event is named, so at 393px — where a real title
+				     rarely fits on one line — it wraps to two rather than truncating. -->
+				<span class="text-ink-gray-8 text-base-medium line-clamp-2 sm:line-clamp-1">
 					{{ invite.event.title || __('Untitled event') }}
 				</span>
-				<span v-if="whenLabel" class="block truncate">{{ whenLabel }}</span>
-				<span v-if="locationLabel" class="block truncate">{{ locationLabel }}</span>
+				<span v-if="whenLabel" class="text-ink-gray-5 mt-0.5 block truncate text-sm">
+					{{ whenLabel }}
+				</span>
+				<span v-if="locationLabel" class="text-ink-gray-5 block truncate text-sm">
+					{{ locationLabel }}
+				</span>
 			</div>
-		</div>
-		<div class="flex shrink-0 items-center justify-end gap-3">
-			<template v-if="invite.participant">
-				<span>{{ __('Going?') }}</span>
-				<div class="flex items-center gap-1.5">
-					<Button
-						v-for="option in RSVP_OPTIONS"
-						:key="option.value"
-						:label="option.label"
-						:variant="currentResponse === option.value ? 'solid' : 'outline'"
-						:loading="rsvp.loading && pendingResponse === option.value"
-						@click="handleRsvp(option.value)"
-					/>
-				</div>
-			</template>
+		</component>
+		<div class="flex shrink-0 items-center justify-end sm:ml-auto">
+			<!-- On mobile the answers get the width the row was already spending: full-bleed, and
+			     40px tall inside a 44px control, against the ~26px the intrinsic-width version gave
+			     them. Same overrides the calendar app's event detail sidebar uses, held to max-sm so
+			     the desktop strip keeps its compact right-aligned control. -->
+			<TabButtons
+				v-if="invite.participant"
+				class="max-sm:w-full max-sm:[&>div>[data-slot=tab-button]]:flex-1 max-sm:[&>div]:w-full max-sm:[&>div]:p-0.5 max-sm:[&_[data-slot=tab-button]>span]:h-10 max-sm:[&_[data-slot=tab-button]>span]:w-full"
+				:options="RSVP_OPTIONS"
+				:model-value="selectedResponse"
+				@update:model-value="handleRsvp"
+			/>
+			<!-- The single-button states take the same mobile treatment as the RSVP control they
+			     stand in for: whichever one the strip shows, it is the row's one action and gets the
+			     full width and the 40px height. -->
 			<Button
 				v-else-if="!invite.exists"
+				class="max-sm:!h-10 max-sm:w-full"
 				:label="__('Add to Calendar')"
 				:loading="addInvite.loading"
 				@click="addInvite.submit()"
 			/>
 			<Button
 				v-else
+				class="max-sm:!h-10 max-sm:w-full"
 				variant="outline"
 				:label="__('View in Calendar')"
 				@click="viewInCalendar"
@@ -46,12 +76,15 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { CalendarPlus } from 'lucide-vue-next'
-import { Button, createResource } from 'frappe-ui'
+import { ArrowRight } from 'lucide-vue-next'
+import { Button, TabButtons, createResource } from 'frappe-ui'
 
+import DateChip from '@/apps/calendar/components/DateChip.vue'
 import dayjs from '@/apps/calendar/utils/dayjs'
+import { eventLastDay, formatEventWhen, isAllDayEvent } from '@/apps/calendar/utils/eventTime'
 import { eventDayRoute, useUpcomingEvents } from '@/apps/mail/composables/useUpcomingEvents'
 import { raiseToast } from '@/apps/mail/utils'
+import { useScreenSize } from '@/apps/mail/utils/composables'
 
 import type { Attachment } from '@/apps/mail/types'
 
@@ -81,6 +114,8 @@ interface InviteDetails {
 const { attachment, account } = defineProps<{ attachment: Attachment; account: string }>()
 
 const router = useRouter()
+const { isMobile } = useScreenSize()
+const { events: calendarEvents, selectedEvent, openEvent } = useUpcomingEvents()
 
 const details = createResource({
 	url: 'suite.calendar.api.invites.get_invite_details',
@@ -101,20 +136,38 @@ const invite = computed<InviteDetails | null>(() => {
 // reader's, mirroring the calendar app (see @/apps/calendar/utils/datetime).
 const localZone = () => dayjs.tz?.guess?.() || Intl.DateTimeFormat().resolvedOptions().timeZone
 
-const whenLabel = computed(() => {
+const isAllDay = computed(() => !!invite.value?.event && isAllDayEvent(invite.value.event))
+
+const start = computed(() => {
 	const event = invite.value?.event
-	if (!event?.start) return ''
-
-	const start = event.time_zone
-		? dayjs.tz(event.start, event.time_zone).tz(localZone())
-		: dayjs(event.start)
-	if (event.show_without_time) return start.format('dddd, MMM D, YYYY')
-
-	const end = start.add(dayjs.duration(event.duration || 'PT0S'))
-	if (end.isSame(start, 'day'))
-		return `${start.format('dddd, MMM D, YYYY ⋅ h:mm A')} – ${end.format('h:mm A')}`
-	return `${start.format('MMM D, YYYY, h:mm A')} – ${end.format('MMM D, YYYY, h:mm A')}`
+	if (!event?.start) return null
+	// An all-day event falls on the same calendar date for everyone, so it keeps its own wall
+	// clock — moving its midnight into the reader's zone would slide it a day either way.
+	if (isAllDay.value) return dayjs(event.start)
+	if (!event.time_zone) return dayjs(event.start)
+	return dayjs.tz(event.start, event.time_zone).tz(localZone())
 })
+
+// One chip for a single day, two for a span — the last day coming from the formatter rather than
+// the raw end, so the exclusive midnight boundary is walked back in exactly one place.
+const chips = computed(() => {
+	if (!start.value) return []
+	const duration = invite.value?.event.duration
+	const last = eventLastDay(start.value, duration, isAllDay.value)
+	return [start.value, ...(last ? [last] : [])].map((day) => ({
+		month: day.format('MMM'),
+		day: day.format('D'),
+	}))
+})
+
+const whenLabel = computed(() =>
+	start.value
+		? formatEventWhen(start.value, invite.value?.event.duration, {
+				allDay: isAllDay.value,
+				compact: true,
+			})
+		: '',
+)
 
 const locationLabel = computed(() =>
 	(invite.value?.event.locations || [])
@@ -132,17 +185,17 @@ const addInvite = createResource({
 		// refetch could still report the event as missing.
 		details.data = { ...details.data, exists: true, event }
 		raiseToast(__('Event added to your calendar.'))
-		useUpcomingEvents().events.reload()
+		calendarEvents.reload()
 	},
 	onError: (error: { message?: string }) => raiseToast(error.message || '', 'error'),
 })
 
-// --- RSVP (mirrors the calendar app's "Going?" control) ---
+// --- RSVP (the same segmented control the calendar app's event detail sidebar uses) ---
 
 const RSVP_OPTIONS = [
 	{ label: __('Yes'), value: 'ACCEPTED' },
-	{ label: __('No'), value: 'DECLINED' },
 	{ label: __('Maybe'), value: 'TENTATIVE' },
+	{ label: __('No'), value: 'DECLINED' },
 ]
 
 const currentResponse = computed(() => invite.value?.participant?.status || '')
@@ -159,19 +212,49 @@ const rsvp = createResource({
 			participant: { ...details.data.participant, status: pendingResponse.value },
 		}
 		raiseToast(__('Response sent.'))
-		useUpcomingEvents().events.reload()
+		calendarEvents.reload()
+		// The panel isn't fed by that resource when it was opened from here (untracked), so hand it
+		// the fresh copy directly or it would keep showing the previous answer.
+		if (isOpen.value) openEvent(event, { tracked: false })
 	},
 	onError: (error: { message?: string }) => raiseToast(error.message || '', 'error'),
 })
 
-const handleRsvp = (response: string) => {
-	if (rsvp.loading || response === currentResponse.value) return
+// An RSVP is a state, so the control shows the answer as soon as it's tapped, and falls back to
+// the stored one if the request fails.
+const selectedResponse = computed(() =>
+	rsvp.loading ? pendingResponse.value : currentResponse.value,
+)
+
+const handleRsvp = (response?: string | number) => {
+	if (typeof response !== 'string' || rsvp.loading || response === currentResponse.value) return
 	pendingResponse.value = response
 	rsvp.submit(response.toLowerCase())
 }
 
+// Opening the event — in the panel or in the calendar — needs its own id, which only a copy on
+// one of the reader's calendars has; a parsed preview of an invite they haven't added yet has none.
+const canViewEvent = computed(() => !!invite.value?.exists && !!invite.value.event.id)
+
 const viewInCalendar = () => {
 	const event = invite.value?.event
-	if (event?.id) router.push(eventDayRoute(event, account))
+	if (canViewEvent.value && event) router.push(eventDayRoute(event, account))
+}
+
+// Whether the detail panel is currently showing this strip's event.
+const isOpen = computed(
+	() => !!selectedEvent.value && selectedEvent.value.id === invite.value?.event.id,
+)
+
+// Reading an invite and leaving the thread to read the event are different things: the strip
+// opens the same detail panel the sidebar's Upcoming events widget uses, hosted by DefaultLayout,
+// so the message stays where it is. Mobile has no room for that panel (DefaultLayout only mounts
+// it on desktop), so there it still hands over to the calendar app's day view.
+const openEventDetail = () => {
+	const event = invite.value?.event
+	if (!canViewEvent.value || !event) return
+	if (isMobile.value) router.push(eventDayRoute(event, account))
+	else if (isOpen.value) selectedEvent.value = null
+	else openEvent(event, { tracked: false })
 }
 </script>

--- a/frontend/src/apps/mail/components/EmailContent.vue
+++ b/frontend/src/apps/mail/components/EmailContent.vue
@@ -197,7 +197,9 @@ const srcdoc = computed(() => {
 
 				/* Emails routinely hardcode widths (width attrs, inline styles); clamp them to the
 				   viewport so the message reflows instead of scrolling sideways. max-width wins over
-				   both the width attribute and inline width, covering every fixed-width variant. */
+				   both the width attribute and inline width, covering every fixed-width variant.
+				   An author's own narrower cap is handed back by normalizeWidths() below, which
+				   re-asserts it inline — the one declaration that outranks this one. */
 				table, td, th, div {
 					max-width: 100% !important;
 				}
@@ -269,8 +271,21 @@ const srcdoc = computed(() => {
 						if (parseInt(el.getAttribute('width'), 10) > limit) el.setAttribute('width', '100%');
 						const style = el.style;
 						if (style.width.endsWith('px') && parseFloat(style.width) > limit) style.width = '100%';
-						if (style.maxWidth.endsWith('px') && parseFloat(style.maxWidth) > limit) style.maxWidth = '100%';
 						if (style.minWidth.endsWith('px') && parseFloat(style.minWidth) > limit) style.minWidth = '0';
+
+						// A percentage width capped by a pixel max-width is how every responsive
+						// email builds its centered column. The sheet's blanket clamp outranks that
+						// cap (stylesheet !important beats a plain inline declaration) and flattens
+						// the column across the pane, so hand it back as inline !important — the one
+						// declaration that outranks the sheet. Only while it is narrower than the
+						// viewport: any wider and the clamp is what stops sideways scrolling. The
+						// author's value is stashed on first pass, since writing to max-width
+						// destroys it and a resize back to a wide pane has to restore it.
+						if (el.dataset.authorMaxWidth === undefined && style.maxWidth.endsWith('px'))
+							el.dataset.authorMaxWidth = style.maxWidth;
+						const cap = parseFloat(el.dataset.authorMaxWidth);
+						if (cap > 0)
+							style.setProperty('max-width', cap > limit ? '100%' : el.dataset.authorMaxWidth, 'important');
 					});
 				};
 				normalizeWidths();

--- a/frontend/src/apps/mail/components/EmailContent.vue
+++ b/frontend/src/apps/mail/components/EmailContent.vue
@@ -51,7 +51,12 @@ import { analyzeRemoteAssets, blockRemoteAssets } from '@/apps/mail/utils'
 import { escapeBracketedAddresses } from '@/apps/mail/utils/html'
 import { useComposeMail, useTheme } from '@/apps/mail/utils/composables'
 import { parseMailto } from '@/apps/mail/utils/mailto'
-import { isArtDirected, normalizeToLightScheme, remapEmailForDarkMode } from '@/apps/mail/utils/darkMail'
+import {
+	declaresFixedPalette,
+	isArtDirected,
+	normalizeToLightScheme,
+	remapEmailForDarkMode,
+} from '@/apps/mail/utils/darkMail'
 
 const {
 	content,
@@ -155,18 +160,19 @@ const srcdoc = computed(() => {
 	let sanitized = DOMPurify.sanitize(escapeBracketedAddresses(content), DOMPURIFY_CONFIG)
 	if (effectiveBlock.value) sanitized = blockRemoteAssets(sanitized)
 	const doc = new DOMParser().parseFromString(sanitized, 'text/html')
-	// Art-directed emails — the author claimed the full canvas and painted with
-	// color — render exactly as authored, dark theme or not; remapping them
-	// would second-guess a deliberate design. Everything else (plain mail,
-	// floating cards, replies quoting either kind) adapts to the dark canvas.
-	// Note this is a DOM-shape check, not "does it declare dark support" — the
-	// email's own dark-scheme rules are dropped up front (sanitization guts the
-	// selectors they rely on, and half a dark design is worse than none), so
-	// every email is judged and remapped as its light-scheme self. Remap runs
-	// before collapseQuotes so the toggle buttons it inserts keep their exact
-	// theme colors.
+	// Two kinds of email render exactly as authored, dark theme or not: those
+	// declaring a fixed palette (suite's own templates), and art-directed ones
+	// — the author claimed the full canvas and painted with color — where
+	// remapping would second-guess a deliberate design. Everything else (plain
+	// mail, floating cards, replies quoting either kind) adapts to the dark
+	// canvas. Art direction is a DOM-shape check, not "does it declare dark
+	// support" — the email's own dark-scheme rules are dropped up front
+	// (sanitization guts the selectors they rely on, and half a dark design is
+	// worse than none), so every email is judged and remapped as its
+	// light-scheme self. Remap runs before collapseQuotes so the toggle buttons
+	// it inserts keep their exact theme colors.
 	normalizeToLightScheme(doc)
-	const remapped = dataTheme.value === 'dark' && !isArtDirected(doc)
+	const remapped = dataTheme.value === 'dark' && !declaresFixedPalette(doc) && !isArtDirected(doc)
 	if (remapped) remapEmailForDarkMode(doc)
 	collapseQuotes(doc)
 	const transformedContent = doc.documentElement.outerHTML
@@ -431,6 +437,9 @@ const DOMPURIFY_CONFIG = {
 		'data-label',
 		'data-list',
 		'data-email-footer',
+		// Suite's own templates opt out of the dark-mode remap with this (see
+		// declaresFixedPalette); stripping it would silently re-enable remapping.
+		'data-fixed-palette',
 		'xmlns',
 		'content',
 		'name',

--- a/frontend/src/apps/mail/components/UpcomingEvents.vue
+++ b/frontend/src/apps/mail/components/UpcomingEvents.vue
@@ -11,9 +11,12 @@
 		class="flex flex-col transition-all duration-300 ease-in-out"
 		:class="isCollapsed ? 'max-h-0 overflow-hidden py-0 opacity-0' : 'max-h-96 py-2 opacity-100'"
 	>
-		<!-- Mirrors the section labels and unread suffixes of the sidebar's nav groups. -->
+		<!-- Mirrors the section labels and unread suffixes of the sidebar's nav groups.
+		     leading-4 on every truncating line: the preset's 1.15 line-height is
+		     shorter than Inter's glyph box, so truncate's overflow-hidden shaves
+		     the descenders. 16px is what frappe-ui pins its own section label to. -->
 		<div class="flex items-center justify-between px-2 py-1.5">
-			<span class="truncate text-sm text-ink-gray-5">{{ __('Upcoming events') }}</span>
+			<span class="truncate text-sm leading-4 text-ink-gray-5">{{ __('Upcoming events') }}</span>
 			<!-- The list shows three rows before scrolling, so a count only says
 			     something new once there are events hidden below the fold. -->
 			<span v-if="upcoming.length > 3" class="shrink-0 text-sm text-ink-gray-4">
@@ -41,8 +44,8 @@
 					:style="{ backgroundColor: eventColor(event) }"
 				/>
 				<div class="min-w-0 flex-1">
-					<div class="truncate text-xs text-ink-gray-5">{{ formatEventTime(event) }}</div>
-					<div class="mt-0.5 truncate text-sm text-ink-gray-8">
+					<div class="truncate text-xs leading-4 text-ink-gray-5">{{ formatEventTime(event) }}</div>
+					<div class="mt-0.5 truncate text-sm leading-4 text-ink-gray-8">
 						{{ event.title || __('Untitled event') }}
 					</div>
 				</div>
@@ -57,6 +60,7 @@ import { useRouter } from 'vue-router'
 import { useNow } from '@vueuse/core'
 
 import dayjs from '@/apps/calendar/utils/dayjs'
+import { isAllDayEvent } from '@/apps/calendar/utils/eventTime'
 import { eventDayRoute, useUpcomingEvents } from '@/apps/mail/composables/useUpcomingEvents'
 import { userStore } from '@/apps/mail/stores/user'
 import { useScreenSize } from '@/apps/mail/utils/composables'
@@ -95,19 +99,6 @@ const isOpen = (event: any) =>
 // the strip, matching what other clients do for multi-calendar events.
 const eventColor = (event: any) =>
 	event.calendars?.find((c: any) => c.color)?.color || DEFAULT_EVENT_COLOR
-
-const isAllDayEvent = (event: any) => {
-	const start = dayjs(event.start)
-	const duration = dayjs.duration(event.duration || 'PT0S')
-	return (
-		event.show_without_time ||
-		(start.hour() === 0 &&
-			start.minute() === 0 &&
-			start.second() === 0 &&
-			duration.asDays() >= 1 &&
-			duration.asDays() % 1 === 0)
-	)
-}
 
 const formatEventTime = (event: any) => {
 	if (isAllDayEvent(event)) return __('All day')

--- a/frontend/src/apps/mail/composables/useUpcomingEvents.ts
+++ b/frontend/src/apps/mail/composables/useUpcomingEvents.ts
@@ -2,6 +2,7 @@ import { effectScope, ref, watch } from 'vue'
 import { createResource } from 'frappe-ui'
 
 import dayjs from '@/apps/calendar/utils/dayjs'
+import { isAllDayEvent } from '@/apps/calendar/utils/eventTime'
 import { userStore as calendarUserStore } from '@/apps/calendar/stores/user'
 import { userStore } from '@/apps/mail/stores/user'
 
@@ -20,7 +21,13 @@ const withInstanceDate = (event: any) => ({
 	date: dayjs(event.start).format('YYYY-MM-DD'),
 })
 
-const openEvent = (event: any) => (selectedEvent.value = withInstanceDate(event))
+// The widget's own list is a today-only slice of the calendar, so an event
+// picked from it can be kept in step with the resource below. An event opened
+// from anywhere else — mail's invite strip, whose event sits on whatever date
+// the invite names — usually isn't in that slice at all, and `tracked: false`
+// stops a reload from reading its absence as "deleted" and closing the panel.
+const openEvent = (event: any, { tracked = true } = {}) =>
+	(selectedEvent.value = { ...withInstanceDate(event), _tracked: tracked })
 
 export function useUpcomingEvents() {
 	if (!events) {
@@ -60,13 +67,13 @@ export function useUpcomingEvents() {
 			watch(
 				() => events.data,
 				(data) => {
-					if (!selectedEvent.value || !data) return
+					if (!selectedEvent.value?._tracked || !data) return
 					const fresh = data.find(
 						(e: any) =>
 							e.id === selectedEvent.value.id &&
 							e.recurrence_id === selectedEvent.value.recurrence_id,
 					)
-					selectedEvent.value = fresh ? withInstanceDate(fresh) : null
+					selectedEvent.value = fresh ? { ...withInstanceDate(fresh), _tracked: true } : null
 				},
 			)
 		})
@@ -82,7 +89,15 @@ export function useUpcomingEvents() {
 // lazily on the first navigation into its prefix, so a named push from mail
 // finds no match until the calendar has been visited — and silently no-ops.
 export const eventDayRoute = (event: any, accountId: string) => {
-	const start = dayjs(event.start)
+	// JSCalendar `start` is a wall clock in the event's own zone and the calendar draws it in the
+	// reader's, so the day has to be converted too or the link lands a day off either side of
+	// midnight. All-day events keep their own date — moving their midnight would slide them.
+	// Mirrors @/apps/calendar/utils/datetime's fromEventZone, minus its calendar-store fallback:
+	// this runs inside mail.
+	const start =
+		event.time_zone && !isAllDayEvent(event)
+			? dayjs.tz(event.start, event.time_zone).tz(timezone())
+			: dayjs(event.start)
 	const day = `${start.year()}/${start.month() + 1}/${start.date()}`
 	return {
 		path: `/calendar/account/${encodeURIComponent(accountId)}/day/${day}`,

--- a/frontend/src/apps/mail/utils/darkMail.test.ts
+++ b/frontend/src/apps/mail/utils/darkMail.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+	declaresFixedPalette,
 	isArtDirected,
 	mapColorToken,
 	normalizeToLightScheme,
@@ -485,6 +486,34 @@ describe('normalizeToLightScheme', () => {
 		)
 		normalizeToLightScheme(doc)
 		expect(doc.querySelector('style')).toBeNull()
+	})
+})
+
+describe('declaresFixedPalette', () => {
+	it('detects the opt-out suite\'s own templates carry', () => {
+		expect(declaresFixedPalette(parseDoc('<body data-fixed-palette><p>hi</p></body>'))).toBe(true)
+	})
+
+	it('is not implied by a light-only color-scheme declaration', () => {
+		// Near every email declares this; honoring it would disable the remap inbox-wide.
+		const doc = parseDoc('<meta name="color-scheme" content="light"><p>hi</p>')
+		expect(declaresFixedPalette(doc)).toBe(false)
+	})
+
+	it('leaves the achromatic card of an event invite alone', () => {
+		// The shape of suite/templates/emails/_event_base.html: every background is
+		// achromatic, so the art-direction heuristic reads it as plain mail and would
+		// remap it. The attribute is what keeps it in its authored palette.
+		const invite = `
+			<body data-fixed-palette style="background-color: #f3f3f3">
+				<table width="100%" style="background-color: #f3f3f3"><tr><td>
+					<table style="max-width: 600px"><tr>
+						<td style="background-color: #ffffff">Onsite sprint</td>
+					</tr></table>
+				</td></tr></table>
+			</body>`
+		expect(isArtDirected(parseDoc(invite))).toBe(false)
+		expect(declaresFixedPalette(parseDoc(invite))).toBe(true)
 	})
 })
 

--- a/frontend/src/apps/mail/utils/darkMail.ts
+++ b/frontend/src/apps/mail/utils/darkMail.ts
@@ -386,6 +386,21 @@ export const normalizeToLightScheme = (doc: Document) => {
 	})
 }
 
+// ——— Explicit opt-out ———————————————————————————————————————————————————————
+//
+// The heuristic below reads DOM shape rather than declarations on purpose:
+// nearly all third-party mail declares `color-scheme: light`, so honoring that
+// would switch the remap off almost everywhere. Suite's own templates are the
+// exception — they are designed as one fixed light card, and they can say so in
+// a way third-party mail never says by accident. A message carrying this
+// attribute renders exactly as authored in either theme.
+//
+// Spoofable by any sender, deliberately: the worst an impostor buys is the
+// rendering an art-directed email already gets for free.
+
+export const declaresFixedPalette = (doc: Document): boolean =>
+	doc.body.hasAttribute('data-fixed-palette')
+
 // ——— Art direction detection ————————————————————————————————————————————————
 //
 // An email is art-directed when its author both claimed the whole canvas — a

--- a/suite/calendar/doctype/calendar_event/invitations.py
+++ b/suite/calendar/doctype/calendar_event/invitations.py
@@ -60,6 +60,10 @@ RESPONSE_LOGO_EMBED = "event-logo.png"
 # Shared font stack for the event email templates (passed into the render context).
 EMAIL_FONT = "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
 
+# `strip_html_tags` only drops the tags, so the <style> block that carries the templates'
+# responsive rules would otherwise land in the text/plain part as raw CSS.
+STYLE_BLOCK_PATTERN = re.compile(r"<style\b[^>]*>.*?</style>", re.IGNORECASE | re.DOTALL)
+
 
 def custom_event_invites_enabled() -> bool:
     """Returns True when Mail Settings is configured to send invites from the client."""
@@ -397,7 +401,7 @@ def _build_mime(from_name, organizer, to_email, subject, html, ics, method) -> s
     root["Message-ID"] = make_msgid()
 
     alternative = MIMEMultipart("alternative")
-    alternative.attach(MIMEText(strip_html_tags(html), "plain", "utf-8"))
+    alternative.attach(MIMEText(_plain_text(html), "plain", "utf-8"))
     alternative.attach(MIMEText(html, "html", "utf-8"))
 
     # Inline calendar part carries the iTIP method so clients can offer native controls.
@@ -434,6 +438,12 @@ def _build_mime(from_name, organizer, to_email, subject, html, ics, method) -> s
     root.attach(attachment)
 
     return root.as_string()
+
+
+def _plain_text(html: str) -> str:
+    """Returns the text/plain alternative for a rendered email body."""
+
+    return strip_html_tags(STYLE_BLOCK_PATTERN.sub("", html))
 
 
 _IMAGE_CACHE: dict[str, bytes] = {}

--- a/suite/templates/emails/_event_base.html
+++ b/suite/templates/emails/_event_base.html
@@ -1,10 +1,61 @@
-{#- Shared shell for the calendar event emails (invite / update / cancel): the gray page, the
-    centered "Frappe Calendar" wordmark, the white card, and the footer. Each email extends this
-    and fills the `card` block. `font` comes from the render context (invitations._context). -#}
+{#- Shared shell for the calendar event emails (invite / update / cancel / response): the gray page,
+    the centered "Frappe Calendar" wordmark, the white card, and the footer. Each email extends this
+    and fills the `card` block. `font` comes from the render context (invitations._context).
+
+    Responsive strategy: fluid tables (percentage widths capped by max-width) so the layout reflows
+    everywhere, plus the `evt-` classes below for clients that honour embedded <style> + media
+    queries (Gmail, Apple Mail, Outlook.com, the mobile clients). Clients that drop the <style>
+    block — Windows Outlook above all — are desktop-width anyway, so the inline styles they do read
+    are the right fallback; the mso conditional keeps the card pinned to 600px there, since Outlook
+    ignores max-width. The <style> rules are stripped from the text/plain alternative by
+    `_plain_text()` in invitations.py. -#}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+{#- The palette is light-only (hardcoded #fff card on #f3f3f3); declaring it keeps clients from
+    auto-inverting parts of it in dark mode. -#}
+<meta name="color-scheme" content="light" />
+<meta name="supported-color-schemes" content="light" />
+<style>
+	@media only screen and (max-width: 480px) {
+		.evt-page { padding: 20px 12px !important; }
+		.evt-card { padding: 24px 20px !important; border-radius: 14px !important; }
+		.evt-title { font-size: 20px !important; }
+		.evt-detail-pad { padding: 2px 14px !important; }
+		/* Label above value instead of a fixed 88px gutter, so long dates and organizer
+		   addresses get the full width of the card. The row's rule moves to the value
+		   cell — on the label it would draw between the two halves of one row. */
+		.evt-label {
+			display: block !important;
+			width: auto !important;
+			padding: 12px 0 0 !important;
+			border-bottom: 0 !important;
+		}
+		.evt-value {
+			display: block !important;
+			width: auto !important;
+			padding: 2px 0 12px !important;
+		}
+		/* Meet card: the logo and label stay together (own nested table), the Join button
+		   drops below them as a full-width tap target. */
+		.evt-meet-info, .evt-meet-action {
+			display: block !important;
+			width: 100% !important;
+			text-align: left !important;
+		}
+		.evt-meet-action { padding: 12px 0 0 !important; }
+		.evt-meet-button { display: block !important; text-align: center !important; }
+	}
+</style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f3f3f3;">
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f3f3f3; margin: 0; padding: 0;">
 	<tr>
-		<td align="center" style="padding: 32px 16px;">
-			<table role="presentation" width="600" cellpadding="0" cellspacing="0" style="width: 600px; max-width: 600px;">
+		<td align="center" class="evt-page" style="padding: 32px 16px;">
+			<!--[if mso]><table role="presentation" width="600" cellpadding="0" cellspacing="0"><tr><td><![endif]-->
+			<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; max-width: 600px;">
 				<tr>
 					<td align="center" style="padding: 8px 0 26px;">
 						<table role="presentation" cellpadding="0" cellspacing="0">
@@ -18,7 +69,7 @@
 					</td>
 				</tr>
 				<tr>
-					<td style="background-color: #ffffff; border: 1px solid #ededed; border-radius: 16px; padding: 36px; font-family: {{ font }};">
+					<td class="evt-card" style="background-color: #ffffff; border: 1px solid #ededed; border-radius: 16px; padding: 36px; font-family: {{ font }};">
 {% block card %}{% endblock %}
 					</td>
 				</tr>
@@ -28,6 +79,9 @@
 					</td>
 				</tr>
 			</table>
+			<!--[if mso]></td></tr></table><![endif]-->
 		</td>
 	</tr>
 </table>
+</body>
+</html>

--- a/suite/templates/emails/_event_base.html
+++ b/suite/templates/emails/_event_base.html
@@ -15,7 +15,9 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 {#- The palette is light-only (hardcoded #fff card on #f3f3f3); declaring it keeps clients from
-    auto-inverting parts of it in dark mode. -#}
+    auto-inverting parts of it in dark mode. Suite's own reader ignores these two — near enough
+    every email declares light-only, so honoring them would disable its dark-mode remap across the
+    inbox — and takes `data-fixed-palette` on the body instead. -#}
 <meta name="color-scheme" content="light" />
 <meta name="supported-color-schemes" content="light" />
 <style>
@@ -50,7 +52,7 @@
 	}
 </style>
 </head>
-<body style="margin: 0; padding: 0; background-color: #f3f3f3;">
+<body data-fixed-palette style="margin: 0; padding: 0; background-color: #f3f3f3;">
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f3f3f3; margin: 0; padding: 0;">
 	<tr>
 		<td align="center" class="evt-page" style="padding: 32px 16px;">

--- a/suite/templates/emails/_event_macros.html
+++ b/suite/templates/emails/_event_macros.html
@@ -1,56 +1,91 @@
 {#- Reusable blocks shared by the calendar event emails. Import with context so the macros can
     read `font` from the render context:  {% import "templates/emails/_event_macros.html" as m with context %} -#}
 
-{#- The event details card: a labelled When/Where/Organizer table. `bold` renders the date value
-    in bold (used by invite/update; the cancel email passes bold=false and label="Was"). -#}
-{%- macro details_table(when_label, when_value, timezone, location, organizer_name, organizer_email, bold=false) -%}
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f8f8f8; border-radius: 12px; margin: 22px 0;">
+{#- The line above a card's title ("… invited you to", "This event was updated"). -#}
+{%- macro eyebrow(text) -%}
+<p style="margin: 0 0 6px; font-size: 14px; color: #7c7c7c;">{{ text }}</p>
+{%- endmacro -%}
+
+{#- The card's title. `evt-title` drops the size on narrow screens (see _event_base.html); the
+    cancel email greys it and strikes it through. -#}
+{%- macro heading(title, cancelled=false) -%}
+<h1 class="evt-title" style="margin: 0; font-size: 22px; line-height: 1.25; font-weight: 700; letter-spacing: -0.01em; color: {{ '#7c7c7c' if cancelled else '#171717' }};{% if cancelled %} text-decoration: line-through;{% endif %}">{{ title }}</h1>
+{%- endmacro -%}
+
+{#- The event's own description, below the details. Renders nothing when there isn't one. -#}
+{%- macro description(text) -%}
+{% if text %}
+<p style="margin: 4px 0 0; font-size: 15px; line-height: 1.6; color: #383838;">{{ text }}</p>
+{% endif %}
+{%- endmacro -%}
+
+{#- The rounded tinted block every card section sits in — details, meet, responder, cancel notice.
+    Call it with a body:  {% call m.panel(padding='16px 18px') %}…{% endcall %}
+    Only the tint, margin and padding vary; the table boilerplate and the 12px radius that make
+    these read as one family do not, which is the whole reason this is a macro. -#}
+{%- macro panel(bg='#f8f8f8', margin='22px 0', padding='6px 18px', pad_class='') -%}
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: {{ bg }}; border-radius: 12px; margin: {{ margin }};">
 	<tr>
-		<td style="padding: 6px 18px;">
-			<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="font-family: {{ font }};">
-				<tr>
-					<td style="padding: 12px 0; font-size: 14px; color: #7c7c7c; width: 88px; vertical-align: top; border-bottom: 1px solid #ededed;">{{ when_label }}</td>
-					<td style="padding: 12px 0; font-size: 14px; color: #383838; line-height: 1.5; border-bottom: 1px solid #ededed;">{% if bold %}<b style="font-weight: 600; color: #171717;">{{ when_value }}</b>{% else %}{{ when_value }}{% endif %}{% if timezone %}<br />{{ timezone }}{% endif %}</td>
-				</tr>
-				{% if location %}
-				<tr>
-					<td style="padding: 12px 0; font-size: 14px; color: #7c7c7c; vertical-align: top; border-bottom: 1px solid #ededed;">Where</td>
-					<td style="padding: 12px 0; font-size: 14px; color: #383838; line-height: 1.5; border-bottom: 1px solid #ededed;">{{ location }}</td>
-				</tr>
-				{% endif %}
-				<tr>
-					<td style="padding: 12px 0; font-size: 14px; color: #7c7c7c; vertical-align: top;">Organizer</td>
-					<td style="padding: 12px 0; font-size: 14px; color: #383838; line-height: 1.5;">{% if organizer_name and organizer_name != organizer_email %}{{ organizer_name }} &middot; <a href="mailto:{{ organizer_email }}" style="color: #007be0; text-decoration: none;">{{ organizer_email }}</a>{% else %}<a href="mailto:{{ organizer_email }}" style="color: #007be0; text-decoration: none;">{{ organizer_email }}</a>{% endif %}</td>
-				</tr>
-			</table>
+		<td{% if pad_class %} class="{{ pad_class }}"{% endif %} style="padding: {{ padding }}; font-family: {{ font }};">
+{{ caller() }}
 		</td>
 	</tr>
 </table>
 {%- endmacro -%}
 
-{#- The Frappe Meet card (logo + link + Join). Renders nothing when the event has no meet link. -#}
+{#- The event details card: a labelled When/Where/Organizer table. `bold` renders the date value
+    in bold (used by invite/update; the cancel email passes bold=false and label="Was").
+    The `evt-label`/`evt-value` classes let narrow screens stack each row (see _event_base.html);
+    long values (`word-break`) can't push the card wider than the viewport either way. -#}
+{%- macro details_table(when_label, when_value, timezone, location, organizer_name, organizer_email, bold=false) -%}
+{% call panel(pad_class='evt-detail-pad') %}
+			<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="font-family: {{ font }};">
+				<tr>
+					<td class="evt-label" style="padding: 12px 0; font-size: 14px; color: #7c7c7c; width: 88px; vertical-align: top; border-bottom: 1px solid #ededed;">{{ when_label }}</td>
+					<td class="evt-value" style="padding: 12px 0; font-size: 14px; color: #383838; line-height: 1.5; border-bottom: 1px solid #ededed;">{% if bold %}<b style="font-weight: 600; color: #171717;">{{ when_value }}</b>{% else %}{{ when_value }}{% endif %}{% if timezone %}<br />{{ timezone }}{% endif %}</td>
+				</tr>
+				{% if location %}
+				<tr>
+					<td class="evt-label" style="padding: 12px 0; font-size: 14px; color: #7c7c7c; width: 88px; vertical-align: top; border-bottom: 1px solid #ededed;">Where</td>
+					<td class="evt-value" style="padding: 12px 0; font-size: 14px; color: #383838; line-height: 1.5; word-break: break-word; border-bottom: 1px solid #ededed;">{{ location }}</td>
+				</tr>
+				{% endif %}
+				<tr>
+					<td class="evt-label" style="padding: 12px 0; font-size: 14px; color: #7c7c7c; width: 88px; vertical-align: top;">Organizer</td>
+					<td class="evt-value" style="padding: 12px 0; font-size: 14px; color: #383838; line-height: 1.5; word-break: break-word;">{% if organizer_name and organizer_name != organizer_email %}{{ organizer_name }} &middot; <a href="mailto:{{ organizer_email }}" style="color: #007be0; text-decoration: none;">{{ organizer_email }}</a>{% else %}<a href="mailto:{{ organizer_email }}" style="color: #007be0; text-decoration: none;">{{ organizer_email }}</a>{% endif %}</td>
+				</tr>
+			</table>
+{% endcall %}
+{%- endmacro -%}
+
+{#- The Frappe Meet card (logo + link + Join). Renders nothing when the event has no meet link.
+    Logo and label live in their own nested table so that when the outer cells stack on a phone
+    (`evt-meet-info` / `evt-meet-action`), only the Join button moves — it becomes a full-width
+    tap target under the label instead of a narrow one squeezed against it. -#}
 {%- macro meet_card(meet) -%}
 {% if meet %}
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f8f8f8; border-radius: 12px; margin-top: 20px;">
-	<tr>
-		<td style="padding: 14px 16px; font-family: {{ font }};">
+{% call panel(margin='20px 0 0', padding='14px 16px') %}
 			<table role="presentation" width="100%" cellpadding="0" cellspacing="0">
 				<tr>
-					<td width="24" style="vertical-align: middle; padding-right: 12px;">
-						<img src="cid:meetlogo" width="24" height="24" alt="Frappe Meet" style="display: block; border: 0; width: 24px; height: 24px;" />
+					<td class="evt-meet-info" style="vertical-align: middle;">
+						<table role="presentation" cellpadding="0" cellspacing="0">
+							<tr>
+								<td width="24" style="vertical-align: middle; padding-right: 12px;">
+									<img src="cid:meetlogo" width="24" height="24" alt="Frappe Meet" style="display: block; border: 0; width: 24px; height: 24px;" />
+								</td>
+								<td style="vertical-align: middle;">
+									<div style="font-size: 14px; font-weight: 600; color: #171717;">Frappe Meet</div>
+									<div style="font-size: 13px; color: #7c7c7c; margin-top: 1px; word-break: break-word;">{{ meet.label }}</div>
+								</td>
+							</tr>
+						</table>
 					</td>
-					<td style="vertical-align: middle;">
-						<div style="font-size: 14px; font-weight: 600; color: #171717;">Frappe Meet</div>
-						<div style="font-size: 13px; color: #7c7c7c; margin-top: 1px;">{{ meet.label }}</div>
-					</td>
-					<td style="vertical-align: middle; text-align: right; white-space: nowrap;">
-						<a href="{{ meet.url }}" style="display: inline-block; padding: 7px 15px; background-color: #ffffff; color: #383838; border: 1px solid #e2e2e2; text-decoration: none; border-radius: 10px; font-family: {{ font }}; font-size: 14px; font-weight: 500;">Join</a>
+					<td class="evt-meet-action" style="vertical-align: middle; text-align: right; white-space: nowrap;">
+						<a class="evt-meet-button" href="{{ meet.url }}" style="display: inline-block; padding: 7px 15px; background-color: #ffffff; color: #383838; border: 1px solid #e2e2e2; text-decoration: none; border-radius: 10px; font-family: {{ font }}; font-size: 14px; font-weight: 500;">Join</a>
 					</td>
 				</tr>
 			</table>
-		</td>
-	</tr>
-</table>
+{% endcall %}
 {% endif %}
 {%- endmacro -%}
 

--- a/suite/templates/emails/event_cancel.html
+++ b/suite/templates/emails/event_cancel.html
@@ -2,13 +2,9 @@
 {% block card %}
 {% import "templates/emails/_event_macros.html" as m with context %}
 						<div style="margin: 0 0 14px;"><span style="display: inline-block; padding: 4px 10px; background-color: #fff7f7; color: #e03636; border-radius: 6px; font-family: {{ font }}; font-size: 12px; font-weight: 600;">Cancelled</span></div>
-						<h1 style="margin: 0; font-size: 22px; line-height: 1.25; font-weight: 700; color: #7c7c7c; text-decoration: line-through;">{{ title }}</h1>
+						{{ m.heading(title, cancelled=true) }}
 						{{ m.details_table('Was', when, timezone, location, organizer_name, organizer_email, bold=false) }}
-						<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #fff7f7; border-radius: 12px; margin: 20px 0 0;">
-							<tr>
-								<td style="padding: 13px 16px; font-family: {{ font }}; font-size: 14px; line-height: 1.5; color: #383838;">
-									This event has been cancelled and removed from your calendar. No further action is needed.
-								</td>
-							</tr>
-						</table>
+						{% call m.panel(bg='#fff7f7', margin='20px 0 0', padding='13px 16px') %}
+							<div style="font-size: 14px; line-height: 1.5; color: #383838;">This event has been cancelled and removed from your calendar. No further action is needed.</div>
+						{% endcall %}
 {% endblock %}

--- a/suite/templates/emails/event_invite.html
+++ b/suite/templates/emails/event_invite.html
@@ -1,12 +1,10 @@
 {% extends "templates/emails/_event_base.html" %}
 {% block card %}
 {% import "templates/emails/_event_macros.html" as m with context %}
-						<p style="margin: 0 0 6px; font-size: 14px; color: #7c7c7c;">{{ organizer_name }} invited you to</p>
-						<h1 style="margin: 0; font-size: 22px; line-height: 1.25; font-weight: 700; color: #171717; letter-spacing: -0.01em;">{{ title }}</h1>
+						{{ m.eyebrow(organizer_name ~ ' invited you to') }}
+						{{ m.heading(title) }}
 						{{ m.details_table('When', when, timezone, location, organizer_name, organizer_email, bold=true) }}
-						{% if description %}
-						<p style="margin: 4px 0 0; font-size: 15px; line-height: 1.6; color: #383838;">{{ description }}</p>
-						{% endif %}
+						{{ m.description(description) }}
 						{{ m.meet_card(meet) }}
 						{{ m.rsvp_block(rsvp, 'Will you attend?') }}
 {% endblock %}

--- a/suite/templates/emails/event_response.html
+++ b/suite/templates/emails/event_response.html
@@ -2,18 +2,14 @@
 {% block card %}
 {% import "templates/emails/_event_macros.html" as m with context %}
 {%- set pill = {'yes': ('#eaf7ef', '#1a7f45'), 'maybe': ('#fdf6ec', '#a9690a'), 'no': ('#fff2f2', '#e03636')}.get(response_state, ('#f0f0f0', '#383838')) -%}
-						<p style="margin: 0 0 6px; font-size: 14px; color: #7c7c7c;">New response to your invitation</p>
-						<h1 style="margin: 0; font-size: 22px; line-height: 1.25; font-weight: 700; color: #171717; letter-spacing: -0.01em;">{{ title }}</h1>
-						<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f8f8f8; border-radius: 12px; margin: 22px 0;">
-							<tr>
-								<td style="padding: 16px 18px; font-family: {{ font }};">
-									<div style="font-size: 15px; color: #171717; font-weight: 600;">{{ responder_name }}</div>
-									{% if responder_name != responder_email %}
-									<div style="font-size: 13px; margin-top: 2px;"><a href="mailto:{{ responder_email }}" style="color: #007be0; text-decoration: none;">{{ responder_email }}</a></div>
-									{% endif %}
-									<div style="margin-top: 12px;"><span style="display: inline-block; padding: 5px 12px; background-color: {{ pill[0] }}; color: {{ pill[1] }}; border-radius: 8px; font-size: 13px; font-weight: 600;">Responded &ldquo;{{ response_label }}&rdquo;</span></div>
-								</td>
-							</tr>
-						</table>
+						{{ m.eyebrow('New response to your invitation') }}
+						{{ m.heading(title) }}
+						{% call m.panel(padding='16px 18px') %}
+							{#- Name and address on one line, separated the way the Organizer row below does
+							    it; weight and color already tell them apart, so a second line only adds
+							    height. `word-break` lets a long address wrap instead of widening the card. -#}
+							<div style="font-size: 15px; color: #171717; font-weight: 600; line-height: 1.5; word-break: break-word;">{{ responder_name }}{% if responder_name != responder_email %} <span style="color: #b5b5b5; font-weight: 400;">&middot;</span> <a href="mailto:{{ responder_email }}" style="color: #007be0; text-decoration: none; font-weight: 400;">{{ responder_email }}</a>{% endif %}</div>
+							<div style="margin-top: 12px;"><span style="display: inline-block; padding: 5px 12px; background-color: {{ pill[0] }}; color: {{ pill[1] }}; border-radius: 8px; font-size: 13px; font-weight: 600;">Responded &ldquo;{{ response_label }}&rdquo;</span></div>
+						{% endcall %}
 						{{ m.details_table('When', when, timezone, location, organizer_name, organizer_email, bold=true) }}
 {% endblock %}

--- a/suite/templates/emails/event_update.html
+++ b/suite/templates/emails/event_update.html
@@ -1,12 +1,10 @@
 {% extends "templates/emails/_event_base.html" %}
 {% block card %}
 {% import "templates/emails/_event_macros.html" as m with context %}
-						<p style="margin: 0 0 6px; font-size: 14px; color: #7c7c7c;">This event was updated</p>
-						<h1 style="margin: 0; font-size: 22px; line-height: 1.25; font-weight: 700; color: #171717; letter-spacing: -0.01em;">{{ title }}</h1>
+						{{ m.eyebrow('This event was updated') }}
+						{{ m.heading(title) }}
 						{{ m.details_table('When', when, timezone, location, organizer_name, organizer_email, bold=true) }}
-						{% if description %}
-						<p style="margin: 4px 0 0; font-size: 15px; line-height: 1.6; color: #383838;">{{ description }}</p>
-						{% endif %}
+						{{ m.description(description) }}
 						{{ m.meet_card(meet) }}
 						{{ m.rsvp_block(rsvp, 'Does this still work for you?') }}
 {% endblock %}


### PR DESCRIPTION
### Invite strip

The generic calendar glyph becomes the date itself — a chip per end of a span — and the RSVP trio becomes the segmented control the calendar's detail sidebar already uses, so it can hold the answer.

All-day events printed as the timestamps they're stored as: `Aug 17, 2026, 12:00 AM – Aug 18, 2026, 12:00 AM`. That's the exclusive end, so a one-day event also claimed the 18th. One formatter now covers every shape:

| | |
|---|---|
| all-day | `Mon, 17 Aug · All day` |
| all-day span | `Mon, 17 – Wed, 19 Aug · 3 days` |
| timed | `Mon, 17 Aug · 3:00 – 4:00 pm · 1 hr` |
| overnight | `Mon, 17 Aug · 11:00 pm – 2:00 am Tue · 3 hr` |
| timed span | `Mon, 31 Aug, 9:00 am – Wed, 2 Sep, 5:00 pm` |

Clicking the strip opens the detail panel beside the thread instead of navigating away. Mobile has no room for it and still routes to the day view.

### Deep links — mobile, and the panel's edit button

An invite's UID resolves to the real event id, but the grid's recurrence-expanded events carry that on `master_id`, so the link matched nothing and the panel never opened. A miss on id falls back to the master now, narrowed to the instance on the routed day. That day was built from the raw JSCalendar start — a wall clock in the event's own zone — so links could land a day off.

### Event emails

A fixed 600px grid with an 88px label gutter, so a phone overflowed the card and squeezed long dates into a third of the width. Fluid now: labels stack above values, the Meet button goes full-width below 480px, and an mso conditional holds 600px in Windows Outlook.

`event_invite` and `event_update` had drifted to twelve near-identical lines differing in two strings. Title, eyebrow, description and the section panel are macros now; the four files stay separately replaceable, which is what `invite_templates.py` promises.

### Email viewer

- The viewport clamp's stylesheet `!important` also beat the author's inline `max-width` — a percentage width under a pixel cap is how every responsive email centres its column, so those rendered edge to edge (20 of the last 20 messages in a real inbox declare a cap). The cap is handed back inline while it's narrower than the viewport; nothing clamped before stops being clamped.
- Dark mode inverted the event emails. The remap only spares art-directed mail, which needs a chromatic background, and every background here is grey. They opt out with `data-fixed-palette`; the `color-scheme: light` they declare can't be the signal, since nearly every email declares it.

### Testing

21 tests on the formatter (overnight boundary, exclusive-end walk-back), 3 on the opt-out. All four templates rendered before and after and diffed at tag level: no change beyond declaration order, plus the cancel heading picking up the `letter-spacing` the other three already had. The width fix is cascade behaviour — worth checking a non-invite email wide, then narrow, then wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
