### PR TITLE
Fix Firefox microphone device fallback

### DIFF
--- a/frontend/src/apps/meet/composables/useMediaControls.test.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.test.ts
@@ -174,6 +174,47 @@ describe("useMediaControls", () => {
 		expect(setSelectedCameraId).not.toHaveBeenCalled();
 	});
 
+	it("does not clear device selections for other overconstrained settings", async () => {
+		const resolutionError = Object.assign(
+			new DOMException("Resolution unavailable", "OverconstrainedError"),
+			{ constraint: "width" },
+		);
+		const getUserMedia = vi.fn().mockRejectedValue(resolutionError);
+		Object.defineProperty(navigator, "mediaDevices", {
+			configurable: true,
+			value: { getUserMedia },
+		});
+
+		const controls = useMediaControls({
+			mediaState: {},
+			connectionState: {},
+			raiseHandStore: {},
+			currentUser: {},
+			sfuClient: {},
+			sfuManager: ref(null),
+			deviceManager: {
+				enumerateDevices: vi.fn().mockResolvedValue(undefined),
+				isDeviceAvailable: vi.fn(() => true),
+				findDeviceById: vi.fn(() => ({ label: "Built-in Microphone" })),
+			},
+			backgroundEffects: {},
+			noiseCancellation: { error: ref(null) },
+			toast: {},
+			mediaPreferences: {},
+		} as never);
+
+		await expect(
+			controls.acquireUserMedia(true, true, {
+				cameraDeviceId: "selected-camera",
+				micDeviceId: "selected-mic",
+			}),
+		).rejects.toBe(resolutionError);
+
+		expect(getUserMedia).toHaveBeenCalledTimes(1);
+		expect(setSelectedMicId).not.toHaveBeenCalled();
+		expect(setSelectedCameraId).not.toHaveBeenCalled();
+	});
+
 	it("replaces a stale live processed track before resuming the microphone", async () => {
 		const sourceTrack = audioTrack("source");
 		const staleProcessedTrack = audioTrack("stale-processed");

--- a/frontend/src/apps/meet/composables/useMediaControls.test.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.test.ts
@@ -71,6 +71,57 @@ describe("useMediaControls", () => {
 		vi.stubGlobal("MediaStream", FakeMediaStream);
 	});
 
+	it("falls back to the default microphone when Firefox cannot find the selected device", async () => {
+		const fallbackStream = new FakeMediaStream([audioTrack("fallback")]);
+		const requestedConstraints: MediaStreamConstraints[] = [];
+		const getUserMedia = vi.fn((constraints: MediaStreamConstraints) => {
+			requestedConstraints.push(structuredClone(constraints));
+			if (requestedConstraints.length === 1) {
+				return Promise.reject(
+					new DOMException("The object can not be found here.", "NotFoundError"),
+				);
+			}
+			return Promise.resolve(fallbackStream);
+		});
+		Object.defineProperty(navigator, "mediaDevices", {
+			configurable: true,
+			value: { getUserMedia },
+		});
+
+		const controls = useMediaControls({
+			mediaState: {},
+			connectionState: {},
+			raiseHandStore: {},
+			currentUser: {},
+			sfuClient: {},
+			sfuManager: ref(null),
+			deviceManager: {
+				enumerateDevices: vi.fn().mockResolvedValue(undefined),
+				isDeviceAvailable: vi.fn(() => true),
+				findDeviceById: vi.fn(() => ({ label: "Built-in Microphone" })),
+			},
+			backgroundEffects: {},
+			noiseCancellation: { error: ref(null) },
+			toast: {},
+			mediaPreferences: {},
+		} as never);
+
+		const result = await controls.acquireUserMedia(false, true, {
+			micDeviceId: "remembered-mic",
+		});
+
+		expect(result.stream).toBe(fallbackStream);
+		expect(getUserMedia).toHaveBeenCalledTimes(2);
+		expect(
+			(requestedConstraints[0].audio as MediaTrackConstraints).deviceId,
+		).toEqual({
+			exact: "remembered-mic",
+		});
+		expect(
+			(requestedConstraints[1].audio as MediaTrackConstraints).deviceId,
+		).toBeUndefined();
+	});
+
 	it("replaces a stale live processed track before resuming the microphone", async () => {
 		const sourceTrack = audioTrack("source");
 		const staleProcessedTrack = audioTrack("stale-processed");

--- a/frontend/src/apps/meet/composables/useMediaControls.test.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.test.ts
@@ -26,6 +26,10 @@ vi.mock("../data/mediaPreferences", () => ({
 }));
 
 import { useMediaControls } from "./useMediaControls";
+import {
+	setSelectedCameraId,
+	setSelectedMicId,
+} from "../data/mediaPreferences";
 
 class FakeMediaStream {
 	id = "fake-media-stream";
@@ -120,6 +124,54 @@ describe("useMediaControls", () => {
 		expect(
 			(requestedConstraints[1].audio as MediaTrackConstraints).deviceId,
 		).toBeUndefined();
+	});
+
+	it("preserves the selected camera when only the microphone is unavailable", async () => {
+		const fallbackStream = new FakeMediaStream([audioTrack("fallback")]);
+		const requestedConstraints: MediaStreamConstraints[] = [];
+		const getUserMedia = vi.fn((constraints: MediaStreamConstraints) => {
+			requestedConstraints.push(structuredClone(constraints));
+			if (requestedConstraints.length === 1) {
+				return Promise.reject(new DOMException("Missing device", "NotFoundError"));
+			}
+			return Promise.resolve(fallbackStream);
+		});
+		Object.defineProperty(navigator, "mediaDevices", {
+			configurable: true,
+			value: { getUserMedia },
+		});
+
+		const controls = useMediaControls({
+			mediaState: {},
+			connectionState: {},
+			raiseHandStore: {},
+			currentUser: {},
+			sfuClient: {},
+			sfuManager: ref(null),
+			deviceManager: {
+				enumerateDevices: vi.fn().mockResolvedValue(undefined),
+				isDeviceAvailable: vi.fn(() => true),
+				findDeviceById: vi.fn(() => ({ label: "Built-in Microphone" })),
+			},
+			backgroundEffects: {},
+			noiseCancellation: { error: ref(null) },
+			toast: {},
+			mediaPreferences: {},
+		} as never);
+
+		await controls.acquireUserMedia(true, true, {
+			cameraDeviceId: "selected-camera",
+			micDeviceId: "missing-mic",
+		});
+
+		expect(
+			(requestedConstraints[1].audio as MediaTrackConstraints).deviceId,
+		).toBeUndefined();
+		expect(
+			(requestedConstraints[1].video as MediaTrackConstraints).deviceId,
+		).toEqual({ exact: "selected-camera" });
+		expect(setSelectedMicId).toHaveBeenCalledWith("");
+		expect(setSelectedCameraId).not.toHaveBeenCalled();
 	});
 
 	it("replaces a stale live processed track before resuming the microphone", async () => {

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -668,29 +668,54 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		try {
 			stream = await navigator.mediaDevices.getUserMedia(constraints);
 		} catch (error) {
-			const missingDevice =
-				(error as Error).name === "NotFoundError" ||
-				(error as Error).name === "OverconstrainedError";
-			const hasExactDevice =
-				(typeof constraints.audio === "object" &&
-					constraints.audio.deviceId !== undefined) ||
-				(typeof constraints.video === "object" &&
-					constraints.video.deviceId !== undefined);
+			const isMissingDeviceError = (candidate: unknown) =>
+				(candidate as Error).name === "NotFoundError" ||
+				(candidate as Error).name === "OverconstrainedError";
+			const audioConstraints =
+				typeof constraints.audio === "object" ? constraints.audio : null;
+			const videoConstraints =
+				typeof constraints.video === "object" ? constraints.video : null;
+			const audioDeviceId = audioConstraints?.deviceId;
+			const videoDeviceId = videoConstraints?.deviceId;
 
-			if (!missingDevice || !hasExactDevice) throw error;
-
-			if (typeof constraints.audio === "object") {
-				if (constraints.audio.deviceId !== undefined) {
-					setSelectedMicId("");
-				}
-				delete constraints.audio.deviceId;
+			if (!isMissingDeviceError(error) || (!audioDeviceId && !videoDeviceId)) {
+				throw error;
 			}
-			if (typeof constraints.video === "object") {
-				if (constraints.video.deviceId !== undefined) {
+
+			if (audioDeviceId && videoDeviceId) {
+				delete audioConstraints.deviceId;
+				try {
+					stream = await navigator.mediaDevices.getUserMedia(constraints);
+					setSelectedMicId("");
+					return { stream, constraints };
+				} catch (audioFallbackError) {
+					if (!isMissingDeviceError(audioFallbackError)) {
+						throw audioFallbackError;
+					}
+					audioConstraints.deviceId = audioDeviceId;
+					delete videoConstraints.deviceId;
+				}
+
+				try {
+					stream = await navigator.mediaDevices.getUserMedia(constraints);
+					setSelectedCameraId("");
+					return { stream, constraints };
+				} catch (videoFallbackError) {
+					if (!isMissingDeviceError(videoFallbackError)) {
+						throw videoFallbackError;
+					}
+					delete audioConstraints.deviceId;
+					setSelectedMicId("");
 					setSelectedCameraId("");
 				}
-				delete constraints.video.deviceId;
+			} else if (audioDeviceId) {
+				delete audioConstraints?.deviceId;
+				setSelectedMicId("");
+			} else {
+				delete videoConstraints?.deviceId;
+				setSelectedCameraId("");
 			}
+
 			stream = await navigator.mediaDevices.getUserMedia(constraints);
 		}
 		return { stream, constraints };

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -668,9 +668,14 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		try {
 			stream = await navigator.mediaDevices.getUserMedia(constraints);
 		} catch (error) {
-			const isMissingDeviceError = (candidate: unknown) =>
-				(candidate as Error).name === "NotFoundError" ||
-				(candidate as Error).name === "OverconstrainedError";
+			const isMissingDeviceError = (candidate: unknown) => {
+				const mediaError = candidate as Error & { constraint?: string };
+				return (
+					mediaError.name === "NotFoundError" ||
+					(mediaError.name === "OverconstrainedError" &&
+						mediaError.constraint === "deviceId")
+				);
+			};
 			const audioConstraints =
 				typeof constraints.audio === "object" ? constraints.audio : null;
 			const videoConstraints =

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -664,7 +664,35 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			}
 		}
 
-		const stream = await navigator.mediaDevices.getUserMedia(constraints);
+		let stream: MediaStream;
+		try {
+			stream = await navigator.mediaDevices.getUserMedia(constraints);
+		} catch (error) {
+			const missingDevice =
+				(error as Error).name === "NotFoundError" ||
+				(error as Error).name === "OverconstrainedError";
+			const hasExactDevice =
+				(typeof constraints.audio === "object" &&
+					constraints.audio.deviceId !== undefined) ||
+				(typeof constraints.video === "object" &&
+					constraints.video.deviceId !== undefined);
+
+			if (!missingDevice || !hasExactDevice) throw error;
+
+			if (typeof constraints.audio === "object") {
+				if (constraints.audio.deviceId !== undefined) {
+					setSelectedMicId("");
+				}
+				delete constraints.audio.deviceId;
+			}
+			if (typeof constraints.video === "object") {
+				if (constraints.video.deviceId !== undefined) {
+					setSelectedCameraId("");
+				}
+				delete constraints.video.deviceId;
+			}
+			stream = await navigator.mediaDevices.getUserMedia(constraints);
+		}
 		return { stream, constraints };
 	};
 


### PR DESCRIPTION

- retry media capture without exact device constraints when a saved device is unavailable
- clear stale saved microphone or camera IDs before using the browser default
- cover Firefox's `NotFoundError` microphone failure
