### PR TITLE
fix(mail): realign owner with user on records that predate OwnerFromUser

### DIFF
--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -100,3 +100,4 @@ execute:frappe.db.set_single_value("Mail Settings", "max_mailing_list_participan
 # Existing, already-set-up sites shouldn't be sent through Suite's onboarding.
 execute:frappe.db.set_single_value("Suite Settings", "is_onboarded", 1) if frappe.is_setup_complete() else None
 suite.suite_core.patches.move_blob_store_out_of_private
+suite.suite_core.patches.align_owner_with_user

--- a/suite/suite_core/patches/align_owner_with_user.py
+++ b/suite/suite_core/patches/align_owner_with_user.py
@@ -1,0 +1,32 @@
+import frappe
+
+# Doctypes that mix in OwnerFromUser (suite.utils.permissions) as of this patch.
+OWNER_FROM_USER_DOCTYPES = (
+    "Calendar Exchange",
+    "Contacts Exchange",
+    "Mail Exchange",
+    "Mail Queue",
+    "Mail Signature",
+    "User Account",
+    "User Settings",
+)
+
+
+def execute() -> None:
+    """Realign ``owner`` with the ``user`` field on records that predate OwnerFromUser.
+
+    The Suite User role reaches these doctypes through ``if_owner``, which keys off the
+    standard ``owner`` (created-by) field. New records get ``owner = user`` pinned by the
+    OwnerFromUser mixin, but records provisioned before the mixin — e.g. User Settings
+    created by the User after_insert hook while an admin or the signup flow's
+    Administrator session was active — are still owned by whoever ran the code, so the
+    user they belong to gets a 403 on their own record.
+    """
+
+    for doctype in OWNER_FROM_USER_DOCTYPES:
+        table = frappe.qb.DocType(doctype)
+        (
+            frappe.qb.update(table)
+            .set(table.owner, table.user)
+            .where(table.user.isnotnull() & (table.user != "") & (table.owner != table.user))
+        ).run()

--- a/suite/suite_core/patches/test_align_owner_with_user.py
+++ b/suite/suite_core/patches/test_align_owner_with_user.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+from uuid import uuid4
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from suite.suite_core.patches.align_owner_with_user import OWNER_FROM_USER_DOCTYPES, execute
+
+
+def make_suite_user() -> str:
+    email = f"align-owner-{uuid4().hex[:8]}@example.com"
+    user = frappe.new_doc("User")
+    user.email = email
+    user.first_name = "Align Owner Test"
+    user.append("roles", {"role": "Suite User"})
+    user.insert(ignore_permissions=True)
+    return email
+
+
+def insert_bare_row(doctype: str, user: str | None, owner: str) -> str:
+    """Insert a minimal legacy-style row directly, bypassing controllers.
+
+    The patch is a plain UPDATE, so document validation is irrelevant to what it sees;
+    a bare row is enough and keeps the expensive doctypes (exchanges, queue) cheap to
+    populate. Setting owner explicitly sidesteps the OwnerFromUser mixin, which is
+    exactly the state of records that predate it.
+    """
+
+    doc = frappe.new_doc(doctype)
+    doc.name = uuid4().hex
+    doc.user = user
+    doc.owner = owner
+    doc.db_insert()
+    return doc.name
+
+
+class AlignOwnerWithUser(IntegrationTestCase):
+    """Regression tests for the owner backfill over legacy per-user records.
+
+    Records created before the OwnerFromUser mixin are owned by whoever provisioned
+    them (typically Administrator), which locks the actual user out of their own record
+    through the Suite User role's if_owner permissions. The patch must restore access
+    on those records without rewriting rows that are already correct or that carry no
+    user at all.
+    """
+
+    def setUp(self) -> None:
+        self.addCleanup(frappe.set_user, "Administrator")
+        self.user = make_suite_user()
+        # Created by the User after_insert hook, owner already pinned to the user.
+        self.settings = frappe.db.get_value("User Settings", {"user": self.user}, "name")
+
+    def test_realigns_stale_owner_and_restores_access(self) -> None:
+        frappe.db.set_value("User Settings", self.settings, "owner", "Administrator", update_modified=False)
+
+        frappe.set_user(self.user)
+        self.assertFalse(frappe.has_permission("User Settings", "read", doc=self.settings))
+
+        frappe.set_user("Administrator")
+        execute()
+
+        self.assertEqual(frappe.db.get_value("User Settings", self.settings, "owner"), self.user)
+        frappe.set_user(self.user)
+        self.assertTrue(frappe.has_permission("User Settings", "read", doc=self.settings))
+
+    def test_realigns_every_owner_from_user_doctype(self) -> None:
+        rows = {
+            doctype: insert_bare_row(doctype, user=self.user, owner="Administrator")
+            for doctype in OWNER_FROM_USER_DOCTYPES
+            if doctype != "User Settings"  # covered via the hook-created record above
+        }
+
+        execute()
+
+        for doctype, name in rows.items():
+            self.assertEqual(frappe.db.get_value(doctype, name, "owner"), self.user, doctype)
+
+    def test_leaves_aligned_and_userless_rows_untouched(self) -> None:
+        aligned_modified = frappe.db.get_value("User Settings", self.settings, "modified")
+        orphan = insert_bare_row("Mail Signature", user=None, owner="Administrator")
+
+        execute()
+
+        self.assertEqual(frappe.db.get_value("User Settings", self.settings, "owner"), self.user)
+        self.assertEqual(frappe.db.get_value("User Settings", self.settings, "modified"), aligned_modified)
+        self.assertEqual(frappe.db.get_value("Mail Signature", orphan, "owner"), "Administrator")
+
+    def test_rerun_is_a_noop(self) -> None:
+        frappe.db.set_value("User Settings", self.settings, "owner", "Administrator", update_modified=False)
+        execute()
+        modified = frappe.db.get_value("User Settings", self.settings, "modified")
+
+        execute()
+
+        self.assertEqual(frappe.db.get_value("User Settings", self.settings, "owner"), self.user)
+        self.assertEqual(frappe.db.get_value("User Settings", self.settings, "modified"), modified)


### PR DESCRIPTION
## Problem

A user with only the **Suite User** role gets a 403 when the Mail UI loads the Credentials page:

```
GET /api/method/frappe.client.get?doctype=User+Settings&name=...
[HTTP/2 403]
frappe.exceptions.PermissionError
```

The Suite User role reaches User Settings (and the other `OwnerFromUser` doctypes) through `if_owner`, which keys off the standard `owner` (created-by) field. New records get `owner = user` pinned by the `OwnerFromUser` mixin, but records provisioned before the mixin existed — e.g. User Settings created by the User `after_insert` hook while an admin or the signup flow's Administrator session was active — are still owned by whoever ran the code. The user they belong to fails the `if_owner` check on their own record.

## Fix

A data patch that backfills `owner = user` (wherever they disagree) for all seven doctypes that mix in `OwnerFromUser`: User Settings, User Account, Mail Signature, Mail Queue, Mail Exchange, Contacts Exchange, and Calendar Exchange. One idempotent UPDATE per doctype; `modified` is left untouched.

## Verification

Simulated the broken state locally (Suite User's User Settings with `owner = Administrator`):

- Before the patch: `frappe.has_permission("User Settings", "read", doc=...)` as that user returns False (reproduces the 403).
- After the patch: the failing `frappe.client.get` call succeeds; the user still cannot read other users' settings, and list views return only their own row.
- `bench migrate` runs the patch cleanly.