### PR TITLE
fix(calendar): skip disabled or deleted users during RSVP sync

### DIFF
--- a/suite/calendar/api/rsvp.py
+++ b/suite/calendar/api/rsvp.py
@@ -239,8 +239,11 @@ def sync_response_to_participant_calendars(
             if not participant_account or participant_account == account:
                 continue
 
+            # The account may still be linked to a user who has since been disabled or
+            # deleted; their calendar is unreachable (get_jmap_connection would refuse the
+            # user), so skip them instead of logging a failure for this best-effort sync.
             user = get_user_for_jmap_account(participant_account, ignore_permissions=True)
-            if not user:
+            if not user or not frappe.get_cached_value("User", user, "enabled"):
                 continue
 
             service = CalendarEventService(


### PR DESCRIPTION
## Problem

When an RSVP is accepted, `sync_response_to_participant_calendars` propagates the response to every local participant's copy of the event. It resolves each participant's address to a local JMAP account and its linked user — but that user may have been disabled or deleted since the link was created. Building a JMAP connection for such a user raises:

> User **user@example.com** does not exist or is disabled.

and the loop's catch-all logged this as an error on every RSVP for any event that user is invited to.

## Fix

After resolving the account's user, also check `frappe.get_cached_value("User", user, "enabled")` — the same check `get_jmap_connection` performs — and skip the participant when the user is missing or disabled. Their calendar is unreachable and needs no update, so this is a skip, not a failure worth logging. Genuine unexpected failures for other participants are still logged as before.