### PR TITLE
fix(drive): unsubscribe emitter handlers when components unmount

### DIFF
--- a/frontend/src/apps/drive/components/FileTypePreview/ImagePreview.vue
+++ b/frontend/src/apps/drive/components/FileTypePreview/ImagePreview.vue
@@ -11,8 +11,9 @@
 
 <script setup>
 import FilePreviewSkeleton from '@/apps/drive/components/FileTypePreview/FilePreviewSkeleton.vue'
-import { onBeforeUnmount, onMounted, ref, watch, inject } from 'vue'
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useObjectUrl } from '@vueuse/core'
+import { useEmitter } from '@/apps/drive/utils/useEmitter'
 
 const props = defineProps({
   previewEntity: Object,
@@ -21,7 +22,6 @@ const props = defineProps({
 const loading = ref(true)
 const imgBlob = ref(null)
 const previewURL = useObjectUrl(imgBlob)
-const emitter = inject('emitter')
 
 watch(props.previewEntity, () => {
   loading.value = true
@@ -49,7 +49,7 @@ async function fetchContent() {
   }
 }
 
-emitter.on('printFile', () => {
+useEmitter('printFile', () => {
   const printFrame = document.createElement('iframe')
   printFrame.style.position = 'absolute'
   printFrame.style.width = '0'
@@ -94,7 +94,6 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
-  emitter.off('printFile')
   loading.value = true
   imgBlob.value = null
 })

--- a/frontend/src/apps/drive/components/FileUploader.vue
+++ b/frontend/src/apps/drive/components/FileUploader.vue
@@ -8,6 +8,7 @@ import { addUpload, updateUpload } from '@/apps/drive/data/uploads'
 import { currentFolder } from '@/apps/drive/data/currentFolder'
 import Dropzone from 'dropzone'
 import { storageBar } from '@/apps/drive/resources/files'
+import { useEmitter } from '@/apps/drive/utils/useEmitter'
 
 const route = useRoute()
 defineEmits(['success'])
@@ -229,13 +230,13 @@ onMounted(() => {
     })
   })
 })
-emitter.on('uploadFile', () => {
+useEmitter('uploadFile', () => {
   if (dropzone.value.hiddenFileInput) {
     dropzone.value.hiddenFileInput.removeAttribute('webkitdirectory')
     dropzone.value.hiddenFileInput.click()
   }
 })
-emitter.on('cancelUpload', (uuid) => {
+useEmitter('cancelUpload', (uuid) => {
   const files = dropzone.value.files
   for (let i = 0; i < files.length; i++) {
     if (files[i].upload.uuid === uuid) {
@@ -243,7 +244,7 @@ emitter.on('cancelUpload', (uuid) => {
     }
   }
 })
-emitter.on('retryUpload', (uuid) => {
+useEmitter('retryUpload', (uuid) => {
   const file = dropzone.value.files.find((f) => f.upload.uuid === uuid)
   if (file) {
     file.status = Dropzone.ADDED
@@ -257,10 +258,10 @@ emitter.on('retryUpload', (uuid) => {
     })
   }
 })
-emitter.on('cancelAllUploads', () => {
+useEmitter('cancelAllUploads', () => {
   dropzone.value.removeAllFiles(true)
 })
-emitter.on('uploadFolder', () => {
+useEmitter('uploadFolder', () => {
   if (dropzone.value.hiddenFileInput) {
     dropzone.value.hiddenFileInput.setAttribute('webkitdirectory', true)
     dropzone.value.hiddenFileInput.click()

--- a/frontend/src/apps/drive/components/GenericPage.vue
+++ b/frontend/src/apps/drive/components/GenericPage.vue
@@ -78,6 +78,7 @@ import { move } from '@/apps/drive/resources/files'
 import DriveListSkeleton from '@/apps/drive/components/DriveListSkeleton.vue'
 import { settings } from '@/apps/drive/resources/permissions'
 import emitter from '@/apps/drive/emitter'
+import { useEmitter } from '@/apps/drive/utils/useEmitter'
 import { getFileLink } from '@/apps/drive/ui/drive/js/utils'
 
 import LucideClock from '~icons/lucide/clock'
@@ -329,7 +330,7 @@ watch(
   },
   { immediate: true, deep: false }
 )
-emitter.on('refresh', refreshData)
+useEmitter('refresh', refreshData)
 
 // Removes entities from the currently rendered list once a confirm-dialog
 // write (remove/restore/delete forever) succeeds server-side. Provided so
@@ -343,7 +344,7 @@ function removeFromList(entities) {
 }
 provide('removeFromList', removeFromList)
 
-emitter.on('remove-file', (item) => {
+useEmitter('remove-file', (item) => {
   const names = Array.isArray(item) ? item : [item]
   const entities = allRows.value.filter((e) => names.includes(e.name))
   if (!entities.length) return
@@ -385,7 +386,7 @@ const onDrop = (targetFile, draggedItem) => {
     refreshFolder(targetFile.name, sortOrder.value)
   selections.value = new Set()
 }
-emitter.on('remove-file-ui', removeFile)
+useEmitter('remove-file-ui', removeFile)
 
 // Auto-scroll the file area while dragging near its top/bottom edge, so files
 // can be dropped into folders that aren't currently in view.

--- a/frontend/src/apps/drive/components/Navbar.vue
+++ b/frontend/src/apps/drive/components/Navbar.vue
@@ -64,6 +64,7 @@ import { shareView } from '@/apps/drive/data/prefs'
 import { startRename } from '@/apps/drive/data/selection'
 const { systemUser } = useCurrentUser()
 import emitter from '@/apps/drive/emitter'
+import { useEmitter } from '@/apps/drive/utils/useEmitter'
 import { ref, computed, inject, h } from 'vue'
 import { entitiesDownload } from '@/apps/drive/utils/download'
 import { getRecents, getTrash, getFavourites, toggleFav, rootInfo } from '@/apps/drive/resources/files'
@@ -179,17 +180,17 @@ function removeCurrentEntities() {
   })
 }
 
-emitter.on('share', () => routeDialog('s'))
+useEmitter('share', () => routeDialog('s'))
 // Rename is inline everywhere: a list row in list/grid views, the last
 // breadcrumb on an entity page.
-emitter.on('rename', () => {
+useEmitter('rename', () => {
   const target = dialogEntities.value[0]
   if (target) startRename(target.name)
 })
-emitter.on('remove', removeCurrentEntities)
-emitter.on('move', () => routeDialog('m'))
-emitter.on('newFolder', () => openListDialog('f'))
-emitter.on('newLink', () => openListDialog('l'))
+useEmitter('remove', removeCurrentEntities)
+useEmitter('move', () => routeDialog('m'))
+useEmitter('newFolder', () => openListDialog('f'))
+useEmitter('newLink', () => openListDialog('l'))
 
 const defaultActions = computed(() => {
   if (!rootEntity.value?.file_name) return

--- a/frontend/src/apps/drive/components/Sidebar.vue
+++ b/frontend/src/apps/drive/components/Sidebar.vue
@@ -47,6 +47,7 @@ import LucideGalleryVerticalEnd from '~icons/lucide/gallery-vertical-end'
 import SettingsDialog from '@/apps/drive/components/Settings/SettingsDialog.vue'
 import ShortcutsDialog from '@/apps/drive/components/ShortcutsDialog.vue'
 import emitter from '@/apps/drive/emitter'
+import { useEmitter } from '@/apps/drive/utils/useEmitter'
 import { ref, computed, watch } from 'vue'
 import { useAppSwitcher } from '@/composables/useAppSwitcher'
 import { useRouter, useRoute } from 'vue-router'
@@ -70,14 +71,14 @@ rootInfo.fetch()
 const showSettings = ref(false)
 const showShortcuts = ref(false)
 const suggestedTab = ref('profile')
-emitter.on('showSettings', (val = 'profile') => {
+useEmitter('showSettings', (val = 'profile') => {
   if (val === -1) showSettings.value = false
   else {
     showSettings.value = true
     suggestedTab.value = val
   }
 })
-emitter.on('toggleShortcuts', () => {
+useEmitter('toggleShortcuts', () => {
   showShortcuts.value = !showShortcuts.value
 })
 

--- a/frontend/src/apps/drive/pages/DriveLayout.vue
+++ b/frontend/src/apps/drive/pages/DriveLayout.vue
@@ -49,6 +49,7 @@ import { ref, computed, onMounted, provide } from 'vue'
 import { sidebarCollapsed, shareView } from '@/apps/drive/data/prefs'
 import { onKeyDown, useMediaQuery } from '@vueuse/core'
 import emitter from '@/apps/drive/emitter'
+import { useEmitter } from '@/apps/drive/utils/useEmitter'
 import { initSocket } from '@/apps/drive/socket'
 import { DesktopShell, FrappeUIProvider, MobileShell } from 'frappe-ui'
 import { useRoute } from 'vue-router'
@@ -67,7 +68,7 @@ provide('inIframe', inIframe)
 const showSearchPopup = ref(false)
 const isLoggedIn = computed(() => useSessionStore().isLoggedIn)
 const normalView = computed(() => !inIframe && isLoggedIn.value)
-emitter.on('showSearchPopup', (data) => {
+useEmitter('showSearchPopup', (data) => {
   showSearchPopup.value = data
 })
 

--- a/frontend/src/apps/drive/utils/useEmitter.js
+++ b/frontend/src/apps/drive/utils/useEmitter.js
@@ -1,0 +1,25 @@
+import { onScopeDispose } from 'vue'
+
+import emitter from '@/apps/drive/emitter'
+
+/**
+ * Subscribe to the app-wide emitter for as long as the calling component lives.
+ *
+ * `emitter` is a single mitt instance shared by all of Drive, so a plain
+ * `emitter.on(...)` outlives the component that registered it: unmounting does
+ * not unsubscribe. GenericPage backs eight routes and Navbar is mounted inside
+ * it, so navigating between lists stacks a fresh set of handlers on top of the
+ * dead ones — one `refresh` becomes N refetches, and handlers keep unmounted
+ * pages (and the data they closed over) reachable.
+ *
+ * `onScopeDispose` fires when the component's effect scope is torn down, which
+ * covers unmount without each caller having to remember an `onBeforeUnmount`.
+ *
+ * The handler is passed to `off` explicitly: mitt's `off(type)` with no handler
+ * clears *every* listener for that event, which would unsubscribe whichever
+ * other component happens to share it.
+ */
+export function useEmitter(event, handler) {
+  emitter.on(event, handler)
+  onScopeDispose(() => emitter.off(event, handler))
+}


### PR DESCRIPTION
`emitter` is one mitt instance shared by all of Drive, so `emitter.on(...)` outlives the component that registered it — unmounting does not unsubscribe. Of 18 subscriptions, exactly one had a matching `off`.

GenericPage is the single component behind eight routes and Navbar mounts inside it, so moving between lists stacks a fresh set of handlers on top of the dead ones. The list resources they close over (`getPersonal`, `getFavourites`, ...) are module-level singletons, so those handlers stay live: one `refresh` emit becomes N refetches, a `remove-file` can be handled by pages the user already left, and every visited page stays reachable from the emitter instead of being collected.

Add a `useEmitter(event, handler)` composable that registers the handler and removes it via `onScopeDispose`, and route all 18 subscriptions through it. The handler is passed to `off` explicitly — mitt's `off(type)` with no handler clears every listener for that event, which is what ImagePreview (the one component that did clean up) was doing.

No behaviour change intended: the live component's own subscription is registered exactly as before, so nothing that worked stops working.