### PR TITLE
fix(writer): fix last version-history row being clipped by panel edge

### DIFF
--- a/frontend/src/apps/writer/components/VersionsSidebar.vue
+++ b/frontend/src/apps/writer/components/VersionsSidebar.vue
@@ -32,8 +32,8 @@
     </div>
   </div>
   <div class="flex h-full overflow-hidden">
-    <div class="self-stretch w-72 border-e h-full relative">
-      <div class="flex flex-col items-center w-full">
+    <div class="self-stretch w-72 border-e h-full relative flex flex-col">
+      <div class="flex flex-col items-center w-full shrink-0">
         <Tabs
           v-model="tab"
           class="w-full"
@@ -47,7 +47,7 @@
           @click="showVersions = false"
         />
       </div>
-      <div class="p-3.5 gap-4 flex flex-col h-full overflow-y-auto">
+      <div class="p-3.5 gap-4 flex flex-col flex-1 min-h-0 overflow-y-auto">
         <Button
           v-if="tab === 1"
           :icon="LucidePlus"


### PR DESCRIPTION
## Summary
- The version-history sidebar wrapper wasn't a flex container, so the scrollable version list used `h-full` (100% of the whole panel) while also being pushed down by the Tabs header above it, causing it to overflow the visible panel and get clipped by an ancestor's `overflow-hidden`.
- The last row ended up visually hidden but still clickable — an invisible interactive element a user could accidentally trigger.
- Fixed by making the wrapper `flex flex-col` and sizing the scrollable list with `flex-1 min-h-0` instead of `h-full`, so it fills exactly the remaining space.

Fixes #576

## Test plan
- Verified locally with Playwright against a Writer document seeded with 200 version entries: on the pre-fix code the last row's bounding box extended past the panel's clipped visible boundary (~23px hidden) after scrolling the list to its own bottom, while a click at the row's center hit nothing; on the fixed code the row sits fully within bounds and a click correctly resolves to the row's content.
