### PR TITLE
Event detail panel and blocked-images banner

### DIFF
--- a/frontend/src/apps/calendar/components/DateChip.vue
+++ b/frontend/src/apps/calendar/components/DateChip.vue
@@ -15,7 +15,7 @@
 		>
 			{{ month }}
 		</div>
-		<div class="text-ink-gray-9 text-lg-semibold py-px leading-5 tabular-nums">{{ day }}</div>
+		<div class="text-ink-gray-8 text-lg-semibold py-px leading-5 tabular-nums">{{ day }}</div>
 	</div>
 </template>
 

--- a/frontend/src/apps/calendar/components/EventDetailSidebar.vue
+++ b/frontend/src/apps/calendar/components/EventDetailSidebar.vue
@@ -259,6 +259,21 @@ const joinMeet = () => {
 	else window.open(meetUrl.value, '_blank', 'noopener')
 }
 
+// --- Details block ---
+
+// Every row of it is individually optional, so an event with nothing but a
+// title and a time has none of them — and the block would otherwise render as
+// a hollow band of padding between two dividers.
+const hasDetails = computed(
+	() =>
+		!!calendarEvent.recurrence_id ||
+		!!meetUrl.value ||
+		!!calendarEvent.locations?.length ||
+		!!calendarEvent.alerts?.length ||
+		!!calendarEvent.free_busy_status ||
+		!!calendarEvent.privacy,
+)
+
 // --- Actions dropdown (delete) ---
 
 const dropdownOptions = computed(() => {
@@ -457,8 +472,10 @@ const openUrl = (location: string) => {
 
 			<div class="border-t" />
 
-			<!-- Details -->
-			<div class="flex flex-col py-2">
+			<!-- Details. The block goes, trailing divider included, when the event
+			     carries none of these rows — the divider above it stays, so the
+			     panel reads title / date / participants. -->
+			<div v-if="hasDetails" class="flex flex-col py-2">
 				<!-- Recurrence -->
 				<div
 					v-if="calendarEvent.recurrence_id"
@@ -542,7 +559,7 @@ const openUrl = (location: string) => {
 				</div>
 			</div>
 
-			<div class="border-t" />
+			<div v-if="hasDetails" class="border-t" />
 
 			<!-- Participants: the section's own y padding matches the header row's
 			     py-2, so it reads as evenly spaced. Counting the row's padding

--- a/frontend/src/apps/mail/components/EmailContent.vue
+++ b/frontend/src/apps/mail/components/EmailContent.vue
@@ -3,18 +3,34 @@
 		v-if="showImagesBanner"
 		class="text-ink-gray-6 mb-3 flex flex-col gap-3 rounded border p-2.5 px-4 sm:flex-row sm:items-center"
 	>
-		<div class="flex min-w-0 flex-1 items-center gap-3">
-			<ImageOff class="h-4.5 w-4.5 shrink-0 stroke-1.5" />
-			<span class="text-ink-gray-8 min-w-0 flex-1"> {{ blockedLabel }} </span>
+		<div class="flex min-w-0 flex-1 items-start gap-3">
+			<!-- Centered on the FIRST line, not on the block: the label wraps to two lines
+			     at 393px and a block-centered icon would float between them.
+
+			     leading-5 states the line box instead of leaving it at the preset's 1.15,
+			     which lands on 16.1px — tighter than a wrapped label wants, and not a
+			     number an icon can be centered on. At a stated 20px the offset is
+			     arithmetic: an 18px glyph, 1px of it either side. -->
+			<ImageOff class="mt-px h-4.5 w-4.5 shrink-0 stroke-1.5" />
+			<span class="text-ink-gray-8 min-w-0 flex-1 leading-5"> {{ blockedLabel }} </span>
 		</div>
-		<div class="flex shrink-0 items-center justify-end gap-3">
+		<!-- On mobile the two answers split the width the row was already spending,
+		     40px tall — the same treatment the invite strip's RSVP control gets. -->
+		<div class="flex shrink-0 items-center justify-end gap-3 max-sm:w-full">
+			<!-- Outline, not ghost: at full width a borderless button reads as loose
+			     text rather than the other half of a pair of answers. -->
 			<Button
 				v-if="canTrust"
-				variant="ghost"
+				variant="outline"
+				class="max-sm:!h-10 max-sm:flex-1"
 				:label="__('Mark Sender as Trusted')"
 				@click="handleTrust"
 			/>
-			<Button :label="__('Load Images')" class="w-28" @click="imagesLoaded = true" />
+			<Button
+				class="max-sm:!h-10 max-sm:flex-1 sm:w-28"
+				:label="__('Load Images')"
+				@click="imagesLoaded = true"
+			/>
 		</div>
 	</div>
 	<div v-if="!isIframeReady" class="animate-pulse space-y-2 py-4">


### PR DESCRIPTION
Follow-ups to #623, found while using it on a phone.

### Event detail panel

Recurrence, Meet link, locations, alerts, availability and visibility are each optional, so an event with nothing but a title and a time rendered the details block as a hollow band of padding between two dividers. The block and its trailing divider now go together when there's nothing to put in them.

### Blocked-images banner

The two answers split the row full-width at 40px on mobile — the same treatment the invite strip's RSVP control gets — and the ghost button becomes outline, since at full width a borderless button reads as loose text rather than one of a pair. The icon aligns to the first line instead of the block, so it stops floating between the two lines the label wraps to at 393px.

### Not in this PR

Search, compose subject (14px), compose body (13px), recipient input and every settings field (14px) are all under the 16px iOS zoom threshold, and the thread header's tap targets are 32px. Those go in the mobile scaling pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
