### PR TITLE
ci: tighten Meet E2EE test timeouts

### DIFF
--- a/e2e/meet/specs/e2ee.spec.ts
+++ b/e2e/meet/specs/e2ee.spec.ts
@@ -17,12 +17,14 @@ async function expectParticipantsAndVideo(
 	guestPage: Page,
 	guestName: string,
 ): Promise<void> {
-	await expect(hostPage.locator("[data-participant-id]")).toHaveCount(2, {
-		timeout: 30_000,
-	});
-	await expect(guestPage.locator("[data-participant-id]")).toHaveCount(2, {
-		timeout: 30_000,
-	});
+	await Promise.all([
+		expect(hostPage.locator("[data-participant-id]")).toHaveCount(2, {
+			timeout: 30_000,
+		}),
+		expect(guestPage.locator("[data-participant-id]")).toHaveCount(2, {
+			timeout: 30_000,
+		}),
+	]);
 	await expectRemoteVideoReceiving(guestPage, meetHostName);
 	await expectRemoteVideoReceiving(hostPage, guestName);
 }
@@ -129,7 +131,7 @@ test.describe("E2EE", () => {
 	});
 
 	test.describe("heavy coverage", () => {
-		test.describe.configure({ timeout: 180_000 });
+		test.describe.configure({ timeout: 90_000 });
 
 	test("active participants keep receiving streams after E2EE is enabled mid-call", async ({
 		hostPage,
@@ -299,18 +301,20 @@ test.describe("E2EE", () => {
 		await guestB.joinAsGuest(meetingId, guestBName);
 		await guestC.joinAsGuest(meetingId, guestCName);
 
-		await expect(hostPage.locator("[data-participant-id]")).toHaveCount(4, {
-			timeout: 45_000,
-		});
-		await expect(guestA.page.locator("[data-participant-id]")).toHaveCount(4, {
-			timeout: 45_000,
-		});
-		await expect(guestB.page.locator("[data-participant-id]")).toHaveCount(4, {
-			timeout: 45_000,
-		});
-		await expect(guestC.page.locator("[data-participant-id]")).toHaveCount(4, {
-			timeout: 45_000,
-		});
+		await Promise.all([
+			expect(hostPage.locator("[data-participant-id]")).toHaveCount(4, {
+				timeout: 45_000,
+			}),
+			expect(guestA.page.locator("[data-participant-id]")).toHaveCount(4, {
+				timeout: 45_000,
+			}),
+			expect(guestB.page.locator("[data-participant-id]")).toHaveCount(4, {
+				timeout: 45_000,
+			}),
+			expect(guestC.page.locator("[data-participant-id]")).toHaveCount(4, {
+				timeout: 45_000,
+			}),
+		]);
 
 		await expectRemoteVideoReceiving(hostPage, guestAName);
 		await expectRemoteVideoReceiving(hostPage, guestBName);
@@ -319,9 +323,14 @@ test.describe("E2EE", () => {
 		await expectRemoteVideoReceiving(guestB.page, meetHostName);
 		await expectRemoteVideoReceiving(guestC.page, meetHostName);
 
-		const guestAFingerprint = await readFingerprint(guestA.page);
-		expect(await readFingerprint(guestB.page)).toBe(guestAFingerprint);
-		expect(await readFingerprint(guestC.page)).toBe(guestAFingerprint);
+		const [guestAFingerprint, guestBFingerprint, guestCFingerprint] =
+			await Promise.all([
+				readFingerprint(guestA.page),
+				readFingerprint(guestB.page),
+				readFingerprint(guestC.page),
+			]);
+		expect(guestBFingerprint).toBe(guestAFingerprint);
+		expect(guestCFingerprint).toBe(guestAFingerprint);
 	});
 	});
 
@@ -330,7 +339,7 @@ test.describe("E2EE", () => {
 		createMeeting,
 		createParticipant,
 	}) => {
-		test.setTimeout(180_000);
+		test.setTimeout(90_000);
 		const meetingId = await createMeeting();
 		const guestName = "Guest Reconnect E2EE";
 		const guest = await createParticipant();


### PR DESCRIPTION
## Summary

- cap heavy Meet E2EE tests at 90 seconds instead of 180 seconds
- wait for independent participant counts and fingerprint reads concurrently
- keep stateful participant joins and media playback checks serial

## Benchmark evidence

Native Meet runs used CI timeouts with retries disabled.

- focused previously failing scenarios: 6/6 passed; four-participant test took 41.9-46.6s
- complete E2EE spec, one worker, repeated three times: 21/21 passed in 4m 44s; four-participant test took 23.7-41.8s
- complete Meet suite, one worker: 19 passed, 1 intentionally skipped in 2m 21s
- two-worker trial: rejected; 2/21 failed and wall time increased to 10m

## Checks

- `yarn --cwd e2e typecheck`
- `yarn check:meet-types`
- `yarn knip:e2e`
- `git diff --check`