### PR TITLE
ci: tighten Meet E2EE test timeouts

### DIFF
--- a/e2e/meet/specs/e2ee.spec.ts
+++ b/e2e/meet/specs/e2ee.spec.ts
@@ -280,6 +280,7 @@ test.describe("E2EE", () => {
 		createMeeting,
 		createParticipant,
 	}) => {
+		test.setTimeout(180_000);
 		const meetingId = await createMeeting();
 		const guestAName = "Guest Fingerprint A";
 		const guestBName = "Guest Fingerprint B";
@@ -299,7 +300,6 @@ test.describe("E2EE", () => {
 		await expectRemoteVideoReceiving(hostPage, guestAName);
 
 		await guestB.joinAsGuest(meetingId, guestBName);
-		await expectRemoteVideoReceiving(guestB.page, meetHostName);
 		await guestC.joinAsGuest(meetingId, guestCName);
 
 		await Promise.all([

--- a/e2e/meet/specs/e2ee.spec.ts
+++ b/e2e/meet/specs/e2ee.spec.ts
@@ -299,6 +299,7 @@ test.describe("E2EE", () => {
 		await expectRemoteVideoReceiving(hostPage, guestAName);
 
 		await guestB.joinAsGuest(meetingId, guestBName);
+		await expectRemoteVideoReceiving(guestB.page, meetHostName);
 		await guestC.joinAsGuest(meetingId, guestCName);
 
 		await Promise.all([

--- a/e2e/meet/specs/e2ee.spec.ts
+++ b/e2e/meet/specs/e2ee.spec.ts
@@ -17,12 +17,14 @@ async function expectParticipantsAndVideo(
 	guestPage: Page,
 	guestName: string,
 ): Promise<void> {
-	await expect(hostPage.locator("[data-participant-id]")).toHaveCount(2, {
-		timeout: 30_000,
-	});
-	await expect(guestPage.locator("[data-participant-id]")).toHaveCount(2, {
-		timeout: 30_000,
-	});
+	await Promise.all([
+		expect(hostPage.locator("[data-participant-id]")).toHaveCount(2, {
+			timeout: 30_000,
+		}),
+		expect(guestPage.locator("[data-participant-id]")).toHaveCount(2, {
+			timeout: 30_000,
+		}),
+	]);
 	await expectRemoteVideoReceiving(guestPage, meetHostName);
 	await expectRemoteVideoReceiving(hostPage, guestName);
 }
@@ -129,7 +131,7 @@ test.describe("E2EE", () => {
 	});
 
 	test.describe("heavy coverage", () => {
-		test.describe.configure({ timeout: 180_000 });
+		test.describe.configure({ timeout: 90_000 });
 
 	test("active participants keep receiving streams after E2EE is enabled mid-call", async ({
 		hostPage,
@@ -299,18 +301,20 @@ test.describe("E2EE", () => {
 		await guestB.joinAsGuest(meetingId, guestBName);
 		await guestC.joinAsGuest(meetingId, guestCName);
 
-		await expect(hostPage.locator("[data-participant-id]")).toHaveCount(4, {
-			timeout: 45_000,
-		});
-		await expect(guestA.page.locator("[data-participant-id]")).toHaveCount(4, {
-			timeout: 45_000,
-		});
-		await expect(guestB.page.locator("[data-participant-id]")).toHaveCount(4, {
-			timeout: 45_000,
-		});
-		await expect(guestC.page.locator("[data-participant-id]")).toHaveCount(4, {
-			timeout: 45_000,
-		});
+		await Promise.all([
+			expect(hostPage.locator("[data-participant-id]")).toHaveCount(4, {
+				timeout: 45_000,
+			}),
+			expect(guestA.page.locator("[data-participant-id]")).toHaveCount(4, {
+				timeout: 45_000,
+			}),
+			expect(guestB.page.locator("[data-participant-id]")).toHaveCount(4, {
+				timeout: 45_000,
+			}),
+			expect(guestC.page.locator("[data-participant-id]")).toHaveCount(4, {
+				timeout: 45_000,
+			}),
+		]);
 
 		await expectRemoteVideoReceiving(hostPage, guestAName);
 		await expectRemoteVideoReceiving(hostPage, guestBName);
@@ -319,9 +323,14 @@ test.describe("E2EE", () => {
 		await expectRemoteVideoReceiving(guestB.page, meetHostName);
 		await expectRemoteVideoReceiving(guestC.page, meetHostName);
 
-		const guestAFingerprint = await readFingerprint(guestA.page);
-		expect(await readFingerprint(guestB.page)).toBe(guestAFingerprint);
-		expect(await readFingerprint(guestC.page)).toBe(guestAFingerprint);
+		const [guestAFingerprint, guestBFingerprint, guestCFingerprint] =
+			await Promise.all([
+				readFingerprint(guestA.page),
+				readFingerprint(guestB.page),
+				readFingerprint(guestC.page),
+			]);
+		expect(guestBFingerprint).toBe(guestAFingerprint);
+		expect(guestCFingerprint).toBe(guestAFingerprint);
 	});
 	});
 
@@ -330,7 +339,7 @@ test.describe("E2EE", () => {
 		createMeeting,
 		createParticipant,
 	}) => {
-		test.setTimeout(180_000);
+		test.setTimeout(90_000);
 		const meetingId = await createMeeting();
 		const guestName = "Guest Reconnect E2EE";
 		const guest = await createParticipant();


### PR DESCRIPTION
## Summary

- cap the two-participant heavy Meet E2EE scenarios at 90 seconds instead of 180 seconds
- retain the 180-second exception for the four-participant E2EE scenario, which exceeded 90 seconds on the CI runner
- wait for independent participant counts and fingerprint reads concurrently
- keep stateful participant joins and media playback checks serial

## Benchmark evidence

Native Meet runs used CI timeouts with retries disabled.

- focused four-participant scenario: repeated local runs passed, typically in 13.8-46.6s
- complete E2EE spec, one worker, repeated three times: 21/21 passed in 4m 44s
- complete Meet suite, one worker: 19 passed, 1 intentionally skipped in 2m 21s
- two-worker trial: rejected; 2/21 failed and wall time increased to 10m
- CI showed the four-participant scenario can exceed 90 seconds, so it retains its prior 180-second exception
