### PR TITLE
ci: balance Meet end-to-end groups

### DIFF
--- a/.github/workflows/meet-e2e.yml
+++ b/.github/workflows/meet-e2e.yml
@@ -91,13 +91,12 @@ jobs:
   e2e:
     if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: suite-e2e-meet
-    # Playwright --shard=N/M splits the suite; each job is self-contained.
+    # Historical durations keep each self-contained group near the same runtime.
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3]
-        shardTotal: [3]
-    name: E2E Tests (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+        group: [1, 2, 3]
+    name: E2E Tests (group ${{ matrix.group }})
     timeout-minutes: 60
     permissions:
       contents: read
@@ -231,11 +230,12 @@ jobs:
 
       - name: Run E2E Tests
         working-directory: ${{ github.workspace }}/e2e
-        run: yarn test:meet --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        run: yarn test:meet
         env:
           BASE_URL: http://meet.test:8000
           SFU_URL: http://localhost:3000
           CI: true
+          MEET_E2E_GROUP: ${{ matrix.group }}
           SFU_E2E_DISCONNECT_TEST: true
           SFU_E2E_DISCONNECT_WAIT_MS: 7000
 
@@ -248,7 +248,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always() && !cancelled()
         with:
-          name: meet-playwright-report-shard-${{ matrix.shardIndex }}
+          name: meet-playwright-report-group-${{ matrix.group }}
           path: |
             e2e/meet/playwright-report/
             e2e/meet/test-results/
@@ -261,7 +261,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
-          name: meet-junit-shard-${{ matrix.shardIndex }}
+          name: meet-junit-group-${{ matrix.group }}
           path: e2e/meet/results.xml
           if-no-files-found: warn
           retention-days: 14

--- a/e2e/meet/playwright.config.ts
+++ b/e2e/meet/playwright.config.ts
@@ -3,12 +3,23 @@ import { resolve } from "node:path";
 
 const baseURL = process.env.BASE_URL ?? "http://localhost:8098";
 const isCI = !!process.env.CI;
+const meetGroup = process.env.MEET_E2E_GROUP;
+
+if (meetGroup && !["1", "2", "3"].includes(meetGroup)) {
+	throw new Error(`Invalid MEET_E2E_GROUP: ${meetGroup}`);
+}
 
 export default defineConfig({
 	testDir: "./specs",
-	// Distribute individual tests across CI shards; workers keep each shard serial.
 	fullyParallel: true,
 	forbidOnly: isCI,
+	grep:
+		meetGroup === "1"
+			? /@meet-group-1/
+			: meetGroup === "2"
+				? /@meet-group-2/
+				: undefined,
+	grepInvert: meetGroup === "3" ? /@meet-group-[12]/ : undefined,
 	outputDir: resolve(__dirname, "test-results"),
 	retries: isCI ? 2 : 0,
 	workers: 1,

--- a/e2e/meet/specs/chat.spec.ts
+++ b/e2e/meet/specs/chat.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, joinHostAndGuest } from "../fixtures/test";
 
-test.describe("Chat", { tag: "@meet-group-1" }, () => {
-	test("messages are delivered between host and guest", async ({
+test.describe("Chat", () => {
+	test("messages are delivered between host and guest", { tag: "@meet-group-2" }, async ({
 		hostPage,
 		createMeeting,
 		createParticipant,
@@ -30,7 +30,7 @@ test.describe("Chat", { tag: "@meet-group-1" }, () => {
 		).toBeVisible();
 	});
 
-	test("unread badge appears when chat is closed and clears when opened", async ({
+	test("unread badge appears when chat is closed and clears when opened", { tag: "@meet-group-1" }, async ({
 		hostPage,
 		createMeeting,
 		createParticipant,

--- a/e2e/meet/specs/chat.spec.ts
+++ b/e2e/meet/specs/chat.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, joinHostAndGuest } from "../fixtures/test";
 
-test.describe("Chat", () => {
+test.describe("Chat", { tag: "@meet-group-1" }, () => {
 	test("messages are delivered between host and guest", async ({
 		hostPage,
 		createMeeting,

--- a/e2e/meet/specs/e2ee.spec.ts
+++ b/e2e/meet/specs/e2ee.spec.ts
@@ -113,7 +113,7 @@ function capturePageErrors(page: Page, filterPatterns: string[] = []) {
 
 test.describe("E2EE", () => {
 	// Join first so media is healthy, then enable E2EE (avoids host-only avatar on CI).
-	test("participants keep video after E2EE is enabled", async ({
+	test("participants keep video after E2EE is enabled", { tag: "@meet-group-2" }, async ({
 		hostPage,
 		createMeeting,
 		createParticipant,
@@ -133,7 +133,7 @@ test.describe("E2EE", () => {
 	test.describe("heavy coverage", () => {
 		test.describe.configure({ timeout: 90_000 });
 
-	test("active participants keep receiving streams after E2EE is enabled mid-call", async ({
+	test("active participants keep receiving streams after E2EE is enabled mid-call", { tag: "@meet-group-2" }, async ({
 		hostPage,
 		createMeeting,
 		createParticipant,
@@ -155,7 +155,7 @@ test.describe("E2EE", () => {
 		await expectRemoteVideoReceiving(hostPage, guestName);
 	});
 
-	test("a participant can rejoin an E2EE meeting after leaving", async ({
+	test("a participant can rejoin an E2EE meeting after leaving", { tag: "@meet-group-2" }, async ({
 		hostPage,
 		createMeeting,
 		createParticipant,
@@ -196,7 +196,7 @@ test.describe("E2EE", () => {
 		guestErrors.assertNoErrors();
 	});
 
-	test("the host can leave and rejoin an E2EE meeting while a guest stays", async ({
+	test("the host can leave and rejoin an E2EE meeting while a guest stays", { tag: "@meet-group-2" }, async ({
 		hostPage,
 		createMeeting,
 		createParticipant,
@@ -248,7 +248,7 @@ test.describe("E2EE", () => {
 		guestErrors.assertNoErrors();
 	});
 
-	test("screen share streams stay healthy in an E2EE meeting", async ({
+	test("screen share streams stay healthy in an E2EE meeting", { tag: "@meet-group-1" }, async ({
 		hostPage,
 		createMeeting,
 		createParticipant,
@@ -275,7 +275,7 @@ test.describe("E2EE", () => {
 		guestErrors.assertNoErrors();
 	});
 
-	test("multiple participants can join an active E2EE meeting and see the same fingerprint", async ({
+	test("multiple participants can join an active E2EE meeting and see the same fingerprint", { tag: "@meet-group-1" }, async ({
 		hostPage,
 		createMeeting,
 		createParticipant,

--- a/e2e/meet/specs/e2ee.spec.ts
+++ b/e2e/meet/specs/e2ee.spec.ts
@@ -113,7 +113,7 @@ function capturePageErrors(page: Page, filterPatterns: string[] = []) {
 
 test.describe("E2EE", () => {
 	// Join first so media is healthy, then enable E2EE (avoids host-only avatar on CI).
-	test("participants keep video after E2EE is enabled", { tag: "@meet-group-2" }, async ({
+	test("participants keep video after E2EE is enabled", async ({
 		hostPage,
 		createMeeting,
 		createParticipant,

--- a/e2e/meet/specs/engagement.spec.ts
+++ b/e2e/meet/specs/engagement.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, joinHostAndGuest } from "../fixtures/test";
 
-test.describe("Reactions and raise hand", () => {
+test.describe("Reactions and raise hand", { tag: "@meet-group-2" }, () => {
 	test("guest reaction and raised hand are visible to the host", async ({
 		hostPage,
 		createMeeting,

--- a/e2e/meet/specs/host-controls.spec.ts
+++ b/e2e/meet/specs/host-controls.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, joinHostAndGuest } from "../fixtures/test";
 
 test.describe("Host controls", () => {
-	test("host can mute a guest participant", async ({
+	test("host can mute a guest participant", { tag: "@meet-group-2" }, async ({
 		hostPage,
 		createMeeting,
 		createParticipant,

--- a/e2e/meet/specs/join-and-leave.spec.ts
+++ b/e2e/meet/specs/join-and-leave.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, joinFromPreview } from "../fixtures/test";
 
-test.describe("Joining and leaving", () => {
+test.describe("Joining and leaving", { tag: "@meet-group-2" }, () => {
 	test("host can join a new meeting and leave it", async ({
 		hostPage,
 		createMeetingViaUi,

--- a/e2e/meet/specs/join-and-leave.spec.ts
+++ b/e2e/meet/specs/join-and-leave.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, joinFromPreview } from "../fixtures/test";
 
-test.describe("Joining and leaving", { tag: "@meet-group-2" }, () => {
+test.describe("Joining and leaving", { tag: "@meet-group-1" }, () => {
 	test("host can join a new meeting and leave it", async ({
 		hostPage,
 		createMeetingViaUi,

--- a/e2e/meet/specs/restricted-meeting.spec.ts
+++ b/e2e/meet/specs/restricted-meeting.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, joinFromPreview, appUrl } from "../fixtures/test";
 
 const lobbyTransitionTimeout = process.env.CI ? 60_000 : 30_000;
 
-test.describe("Restricted meeting", () => {
+test.describe("Restricted meeting", { tag: "@meet-group-1" }, () => {
 	test("guest waits for approval and host can admit from people panel", async ({
 		hostPage,
 		createMeeting,


### PR DESCRIPTION
## Summary

- replace Playwright file shards with three duration-aware Meet test groups
- keep each group serial with one worker while balancing historical test durations
- leave group 3 as an inverse catch-all so new untagged tests remain covered
- use group-specific Playwright and JUnit artifact names

## Benchmark

Compared the latest merged baseline run with the decisive grouped run on the same `suite-e2e-meet` runners:

| Run | Job durations | Longest job | Test-step spread |
| --- | --- | --- | --- |
| [Merged baseline](https://github.com/frappe/suite/actions/runs/31713806356) | 7m24s / 6m30s / 4m23s | 7m24s | 3m02s |
| [Duration-aware groups](https://github.com/frappe/suite/actions/runs/31717272431) | 6m26s / 6m18s / 5m56s | 6m26s | 29s |

The workflow critical path improved by 58 seconds (13%). The decisive run covered all 20 tests exactly once across 7/6/7 tests, with zero failures, skips, errors, or retries.

## Validation

- `yarn --cwd e2e typecheck`
- `yarn check:meet-types`
- `yarn knip:e2e`
- `git diff --check upstream/develop...HEAD`
- `actionlint -ignore 'label .* is unknown' .github/workflows/meet-e2e.yml`
- Meet E2E workflow run: https://github.com/frappe/suite/actions/runs/31717272431