### PR TITLE
fix: Screener undo, shortcuts and page titles, plus four unrelated fixes

### DIFF
--- a/frontend/src/apps/calendar/pages/CalendarView.vue
+++ b/frontend/src/apps/calendar/pages/CalendarView.vue
@@ -3,6 +3,7 @@ import { computed, inject, onMounted, reactive, ref, useTemplateRef, watch } fro
 import { useRoute, useRouter } from 'vue-router'
 import { Button, Calendar, Dialog, createResource, usePageMeta } from 'frappe-ui'
 
+import { useScreenSize } from '@/composables/useScreenSize'
 import { raiseToast } from '@/apps/calendar/utils'
 import { fromEventZone } from '@/apps/calendar/utils/datetime'
 import { userStore } from '@/apps/calendar/stores/user'
@@ -14,6 +15,7 @@ const dayjs = inject('$dayjs')
 
 const store = userStore()
 const { participantIdentities } = store
+const { isMobile } = useScreenSize()
 
 const route = useRoute()
 const router = useRouter()
@@ -385,8 +387,12 @@ const NOTIFY_MODAL_OPTIONS = {
 					@update="handleUpdate"
 				/>
 			</div>
+			<!-- Desktop only: it is a side panel with a fixed width, so on a phone it
+			     covered the grid it is meant to sit beside. The selection still happens
+			     (?event= stays in the URL, so a shared link still names its event),
+			     there is just nowhere to show it until this gets a sheet of its own. -->
 			<EventDetailSidebar
-				v-if="selectedCalendarEvent"
+				v-if="selectedCalendarEvent && !isMobile"
 				:key="selectedCalendarEvent.id + (selectedCalendarEvent.recurrence_id ?? '')"
 				:calendar-event="selectedCalendarEvent"
 				@close="closeEventDetail"

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -297,10 +297,16 @@
 											@trust="trustSender.submit(mail.from_email)"
 										/>
 
+										<!-- font-sans is the system stack, not Inter: the preset leaves
+										     fontFamily.sans alone and puts InterVar on <html> instead. So this is
+										     deliberately off the variable font — and text-base's 420 then has no
+										     face to land on, which CSS resolves upward to the system Medium,
+										     rendering the body bolder than everything around it. font-normal pins
+										     it to Regular. -->
 										<LinkifiedText
 											v-else
 											:text="getPlainTextBody(mail)"
-											class="pt-4 font-sans text-base !leading-5 sm:text-sm"
+											class="pt-4 font-sans !font-normal text-base !leading-5 sm:text-sm"
 										/>
 									</template>
 

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -159,9 +159,13 @@
 												>
 													{{ mail.from_name || mail.from_email }}
 												</span>
+												<!-- leading-4: truncate is overflow-hidden, and the preset's 1.15 puts 13px
+												     text in a 14.95px box while Inter's glyph box wants ~15.7 — so the
+												     descenders of a g or a p were shaved off. 16px still sits under the
+												     sender name beside it, so the row does not grow. -->
 												<span
 													v-if="!isMobile"
-													class="text-ink-gray-5 truncate"
+													class="text-ink-gray-5 truncate leading-4"
 												>
 													<span>&lt;</span>
 													<Tooltip :text="__('Filter messages from this sender')">
@@ -192,7 +196,8 @@
 													<MailDetailsPopover v-else :mail />
 												</template>
 											</div>
-											<div class="truncate">
+											<!-- Same 13px truncate, same shaved descenders. -->
+											<div class="truncate leading-4">
 												{{ getFormattedRecipients(mail.recipients) }}
 											</div>
 										</div>

--- a/frontend/src/apps/mail/components/Modals/ShortcutsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/ShortcutsModal.vue
@@ -81,10 +81,13 @@ const shortcutGroups = computed(() => [
 	],
 	[
 		{
-			// Same keys as the Actions above, because they are the same intent — allowing the sender is
-			// implied, and the key says where their waiting mail goes.
+			// The two plain verdicts first, then the qualified ones. Those two keep the keys the
+			// Actions above use, because they are the same intent — allowing the sender is implied,
+			// and the key says where their waiting mail goes.
 			title: __('Screener'),
 			shortcuts: [
+				[['A'], __('Allow Sender')],
+				[['D'], __('Deny Sender')],
 				[['E'], __('Allow Sender, Archive Their Mail')],
 				[['Delete'], __('Allow Sender, Trash Their Mail')],
 			],

--- a/frontend/src/apps/mail/components/Modals/ShortcutsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/ShortcutsModal.vue
@@ -78,8 +78,7 @@ const shortcutGroups = computed(() => [
 				[[modifier.value, 'Z'], __('Undo Last Action')],
 			],
 		},
-	],
-	[
+
 		{
 			// The two plain verdicts first, then the qualified ones. Those two keep the keys the
 			// Actions above use, because they are the same intent — allowing the sender is implied,
@@ -92,12 +91,13 @@ const shortcutGroups = computed(() => [
 				[['Delete'], __('Allow Sender, Trash Their Mail')],
 			],
 		},
-
+	],
+	[
 		{
 			title: __('Navigation'),
 			shortcuts: [
-				[['↓', __('or'), 'J'], __('Go to Next Mail')],
-				[['↑', __('or'), 'K'], __('Go to Previous Mail')],
+				[['↓', __('or'), 'J'], __('Go to Next Item')],
+				[['↑', __('or'), 'K'], __('Go to Previous Item')],
 				[['G', __('then'), 'G'], __('Go to Top of List')],
 				[['Shift', 'G'], __('Go to Bottom of List')],
 				[['Enter'], __('Open Mail, or Fold Stack')],

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -307,9 +307,13 @@
 							     place the same kind of decision is made everywhere else in the app. -->
 							<div v-if="!isMobile" class="flex shrink-0 gap-2">
 								<div class="flex items-center">
+									<!-- The key is named on the tooltip rather than in the label: this is the
+									     desktop split-button pair, so there is a keyboard to press it on, and
+									     the qualified verdicts in the menu behind it name theirs the same way. -->
 									<Button
 										variant="outline"
 										:label="__('Deny')"
+										:tooltip="__('Deny ({0})', ['D'])"
 										class="!rounded-r-none"
 										@click="screenOut([openSender.from_email])"
 									/>
@@ -326,6 +330,7 @@
 									<Button
 										variant="solid"
 										:label="__('Allow')"
+										:tooltip="__('Allow ({0})', ['A'])"
 										class="!rounded-r-none"
 										@click="allow([openSender.from_email])"
 									/>
@@ -654,8 +659,8 @@ watch(openSender, (sender) => {
 	if (sender) senderPaneKey.value = sender.from_email
 })
 
-// Once a mail is open: ↑/↓ (or k/j) step senders, E and Delete allow the sender straight to Archive
-// or Trash, and Esc closes. Else inert.
+// Once a mail is open: ↑/↓ (or k/j) step senders, A and D give the two plain verdicts, E and Delete
+// allow the sender straight to Archive or Trash, and Esc closes. Else inert.
 const handleKeydown = (e: KeyboardEvent) => {
 	const key = e.key.toLowerCase()
 
@@ -671,6 +676,20 @@ const handleKeydown = (e: KeyboardEvent) => {
 	if (key === 'escape') {
 		e.preventDefault()
 		closeSender()
+		return
+	}
+
+	// The two plain verdicts — the ones every other key here is a qualified version of. Only these
+	// were missing from the keyboard, so a pass down the queue could file the rarer decisions and had
+	// to reach for the pointer for the common ones. Both keys are free: the mailbox map spends A only
+	// with a modifier and never binds D.
+	//
+	// Modifier-free only, unlike the keys below — Cmd/Ctrl+A is Select All in the lists and select-all
+	// in the browser, and neither should turn into a verdict on a stranger.
+	if ((key === 'a' || key === 'd') && !e.metaKey && !e.ctrlKey && !e.altKey) {
+		e.preventDefault()
+		if (key === 'a') allow([openSender.value.from_email])
+		else screenOut([openSender.value.from_email])
 		return
 	}
 

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -755,6 +755,11 @@ onUnmounted(() => {
 })
 
 usePageMeta(() => {
+	// Name the open sender, the way the mailbox view names the open thread. The queue's own title is
+	// the right one for the list, but it made every sender's page — each its own URL, each shareable
+	// and restorable — read as the same tab, and the count kept moving under it as you triaged.
+	if (openSender.value) return { title: openSender.value.from_name || openSender.value.from_email }
+
 	const n = senders.data?.length ?? 0
 	return { title: n ? `(${n}) ${__('Screener')}` : __('Screener') }
 })

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -901,7 +901,15 @@ const runAction = (
 	// Optimistically drop the acted senders so the rows leave immediately and every other row stays
 	// interactive. Their names are remembered until the advance below lands, so the route naming one
 	// of them for that tick isn't mistaken for a stale URL (see `justActed`).
-	list.filter(matchSender).forEach((s: ScreeningSender) => justActed.add(s.from_email))
+	//
+	// The rows themselves are kept, with where they sat, so undo can put them back without waiting
+	// for the server to confirm what this never waited for either.
+	const removed: RemovedSender[] = []
+	list.forEach((s: ScreeningSender, index: number) => {
+		if (!matchSender(s)) return
+		justActed.add(s.from_email)
+		removed.push({ index, sender: s })
+	})
 	senders.data = list.filter((s: ScreeningSender) => !matchSender(s))
 
 	// Advance to the next sender (or close the preview if there's nothing below).
@@ -923,7 +931,7 @@ const runAction = (
 			: undefined
 
 	queueScreening(action, fromEmails, destination)
-	announce(action, fromEmails, destination, movedIds, acted?.from_name)
+	announce(action, fromEmails, destination, movedIds, removed, acted?.from_name)
 }
 
 /**
@@ -943,14 +951,54 @@ const settledVerdictIds = async (movedIds: Promise<string[]>) => {
 }
 
 /**
+ * A row the verdict took off the list, and where it sat, so undo can put it back.
+ */
+interface RemovedSender {
+	index: number
+	sender: ScreeningSender
+}
+
+/**
+ * Put the acted rows back where they were, skipping any the list has since regained (a reload
+ * overlapping the undo). Ascending index, so each splice lands before the next one is measured.
+ */
+const restoreSenders = (removed: RemovedSender[]) => {
+	const list = [...((senders.data ?? []) as ScreeningSender[])]
+	const present = new Set(list.map((s) => s.from_email))
+
+	for (const { index, sender } of [...removed].sort((a, b) => a.index - b.index)) {
+		if (present.has(sender.from_email)) continue
+		list.splice(Math.min(index, list.length), 0, sender)
+	}
+
+	senders.data = list
+}
+
+/**
  * Take a verdict back: drop the rules it wrote and return the mail to the Screener, so the senders are
  * waiting to be decided about again exactly as they were.
+ *
+ * The rows come back first, before any of it. Applying a verdict never waited — it drops the rows and
+ * batches the write behind a timer — so an undo that waited for that deferred write, then its own
+ * round trip, then a full reload left the row missing for all three while the press that caused it
+ * cost nothing. The ids the server needs only exist once the flush returns, but the list doesn't
+ * depend on them.
  */
-const undoVerdict = async (fromEmails: string[], undone: string, movedIds: Promise<string[]>) => {
+const undoVerdict = async (
+	fromEmails: string[],
+	undone: string,
+	movedIds: Promise<string[]>,
+	removed: RemovedSender[],
+) => {
 	// The verdict's own toast has served its purpose. Sonner clears it when its button is what was
 	// pressed, but not when the keyboard was, so say so either way rather than leave it beside the
 	// line about to replace it.
 	toast.dismiss()
+
+	// Back on the list, and answerable again: the route watcher can find these senders now, so the
+	// names held for the advance are no longer standing in for them.
+	restoreSenders(removed)
+	for (const email of fromEmails) justActed.delete(email)
 
 	try {
 		const ids = await settledVerdictIds(movedIds)
@@ -961,10 +1009,13 @@ const undoVerdict = async (fromEmails: string[], undone: string, movedIds: Promi
 			from_emails: fromEmails,
 			ids,
 		})
+		// Reconciliation, not the mechanism: the rows are already back. This settles what the optimistic
+		// splice can only approximate — the server's ordering, and counts that moved while it was away.
 		senders.reload()
 		store.mailboxes.reload()
 		raiseToast(undone)
 	} catch (error) {
+		// The undo did not land, so the verdict still stands and the rows this put back are wrong.
 		senders.reload()
 		raiseToast((error as Error).message || __('Could not undo that.'), 'error')
 	}
@@ -988,6 +1039,7 @@ const announce = (
 	fromEmails: string[],
 	destination: AllowDestination,
 	movedIds: Promise<string[]>,
+	removed: RemovedSender[],
 	senderName?: string,
 ) => {
 	const target = fromEmails[0] ?? ''
@@ -1021,7 +1073,7 @@ const announce = (
 
 	// Cmd/Ctrl+Z reaches the same verdict as the toast's button, and only the latest one: a triage
 	// pass is a run of decisions, and each replaces the last as the one still in reach.
-	setUndoAction(() => undoVerdict(fromEmails, undone, movedIds))
+	setUndoAction(() => undoVerdict(fromEmails, undone, movedIds, removed))
 
 	// One toast at a time. A run of verdicts would otherwise stack them over the list they are about,
 	// and only the newest is still undoable — the rest would offer a button that took back someone

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -1000,6 +1000,13 @@ const undoVerdict = async (
 	restoreSenders(removed)
 	for (const email of fromEmails) justActed.delete(email)
 
+	// Said now, not when the server agrees. The rows are already back, so a confirmation arriving a
+	// round trip later describes something the reader watched happen — and the line itself ("… is back
+	// in the Screener") is about the list, which is already true. This is what raiseOptimisticToast
+	// does for every other undoable action in mail; not reused here because its failure branch is one
+	// generic line, and an undo that did not land is worth naming precisely.
+	const pendingToast = raiseToast(undone)
+
 	try {
 		const ids = await settledVerdictIds(movedIds)
 		// One call so the rules are dropped and the mail comes home together: a half-undone verdict —
@@ -1013,9 +1020,10 @@ const undoVerdict = async (
 		// splice can only approximate — the server's ordering, and counts that moved while it was away.
 		senders.reload()
 		store.mailboxes.reload()
-		raiseToast(undone)
 	} catch (error) {
-		// The undo did not land, so the verdict still stands and the rows this put back are wrong.
+		// The undo did not land, so the verdict still stands: retract the line that said otherwise and
+		// let the refetch take the rows away again.
+		toast.dismiss(pendingToast)
 		senders.reload()
 		raiseToast((error as Error).message || __('Could not undo that.'), 'error')
 	}

--- a/frontend/src/apps/mail/utils/composables.ts
+++ b/frontend/src/apps/mail/utils/composables.ts
@@ -2,20 +2,18 @@ import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { createResource, toast } from 'frappe-ui'
 
+import { useScreenSize } from '@/composables/useScreenSize'
 import { matchesScreenedValue, raiseOptimisticToast, raiseToast } from '@/apps/mail/utils'
 import router from '@/apps/mail/router'
 import { userStore } from '@/apps/mail/stores/user'
 
 import type { COLOR_SCHEME, ComposeMailData, Identity, ScreenedAddress } from '@/apps/mail/types'
 
-// Decided once, at load, and deliberately not reactive to resize. Mobile and desktop are
-// separate component trees here, not one tree restyled: crossing 640px mid-session swaps
-// them and unmounts whatever they were holding — a half-written mail vanished this way
-// (#38), and every other open surface has the same exposure. A resized window therefore
-// keeps the layout it started with until the page is reloaded.
-const isMobile = ref(window.innerWidth < 640)
-
-export const useScreenSize = () => ({ isMobile })
+// Re-exported from the suite-wide composable so mail's many callers keep one import, and so the
+// calendar reads the same ref rather than a second copy of the same window width. Imported at the
+// top rather than `export ... from`, which would re-export the name without binding it here — this
+// file calls it too.
+export { useScreenSize }
 
 /**
  * Split View: the reading pane sits beside the list rather than over it. One user setting, read the
@@ -280,6 +278,8 @@ const isEditable = (el: Element | null) => {
  * listeners aren't worth attaching.
  */
 export const useKeyboardOpen = () => {
+	const { isMobile } = useScreenSize()
+
 	if (!watchingFocus && isMobile.value) {
 		watchingFocus = true
 		// Re-read the focus on the next frame rather than trusting the event: moving between two

--- a/frontend/src/apps/mail/utils/threadStacks.test.ts
+++ b/frontend/src/apps/mail/utils/threadStacks.test.ts
@@ -74,16 +74,27 @@ describe('stackKeyOf', () => {
 		expect(stackKeyOf(thread({ messages: two }))).toBeNull()
 	})
 
-	it('counts addresses rather than people, so a relay thread still stacks', () => {
-		// Three posters, one envelope address: a notification, not correspondence.
-		const posted = thread({
-			messages: [post('Sarfaraz Shaikh'), post('M Umair Sayed'), post('Jay1987')],
-		})
-		expect(stackKeyOf(posted)).toBe(stackKeyOf(thread({ messages: [post('Neha Sankhe')] })))
+	it('separates relay posters, who share an address but are different people', () => {
+		// A mailing list rewrites the display name per original sender. Keying on the address alone
+		// piled a whole digest under whichever member was newest.
+		expect(stackKeyOf(thread({ messages: [post('Sarfaraz Shaikh')] }))).not.toBe(
+			stackKeyOf(thread({ messages: [post('Neha Sankhe')] })),
+		)
+		// Several posters in ONE thread is no single writer either, so it never stacks.
+		expect(
+			stackKeyOf(thread({ messages: [post('Sarfaraz Shaikh'), post('M Umair Sayed')] })),
+		).toBeNull()
 		// Your own reply is a second address, and takes the thread out of the pile as it always did.
 		expect(
 			stackKeyOf(thread({ messages: [post('Jay1987'), message('vibhav@frappe.io', 'Vibhav')] })),
 		).toBeNull()
+	})
+
+	it('treats a blank display name as absent, not as a second writer', () => {
+		// Bots fill from_name on some messages and not others.
+		expect(
+			stackKeyOf(thread({ messages: [message('alerts@uptimerobot.com'), message('alerts@uptimerobot.com', 'UptimeRobot')] })),
+		).toBe(stackKeyOf(thread()))
 	})
 
 	it('is case- and whitespace-insensitive about the sender', () => {
@@ -158,13 +169,24 @@ describe('buildListRows', () => {
 		])
 	})
 
-	it('collapses a run of relay threads however many posted in each', () => {
-		const notifications = run(3, {
-			messages: [post('Sarfaraz Shaikh'), post('M Umair Sayed')],
-		})
+	it('collapses a run of relay threads from one poster', () => {
+		const notifications = run(3, { messages: [post('Sarfaraz Shaikh')] })
 		const rows = buildListRows(notifications, rowOptions)
 		expect(rows).toHaveLength(1)
 		expect(rows[0].type === 'stack' && rows[0].threads).toHaveLength(3)
+	})
+
+	it('leaves a mailing list alone when its posters differ', () => {
+		// The Developers-list case: one address, a different writer each time. Three rows in, three
+		// rows out — burying distinct people under one of their names is worse than a longer list.
+		const digest = [
+			thread({ name: 'm0', thread_id: 't0', messages: [post('Scaleway')] }),
+			thread({ name: 'm1', thread_id: 't1', messages: [post('Twilio Notifications')] }),
+			thread({ name: 'm2', thread_id: 't2', messages: [post('Oracle Support')] }),
+		]
+		const rows = buildListRows(digest, rowOptions)
+		expect(rows).toHaveLength(3)
+		expect(rows.every((r) => r.type === 'thread')).toBe(true)
 	})
 
 	it('breaks a run where the user has replied to one of its threads', () => {

--- a/frontend/src/apps/mail/utils/threadStacks.ts
+++ b/frontend/src/apps/mail/utils/threadStacks.ts
@@ -7,30 +7,42 @@ import type { Thread } from '@/apps/mail/types'
 // single stack row. Two in a row is normal correspondence, not a flood — hence three.
 const MIN_STACK_SIZE = 3
 
-// The thread's lone sending address, or null when more than one has written in it. Search results are
-// single messages with no conversation behind them, so their sender is all there is to go on.
+// The thread's lone sender — display name AND address — or null when more than one of either has
+// written in it. Search results are single messages with no conversation behind them, so their
+// sender is all there is to go on.
 //
-// Distinct ADDRESSES, not the names the row goes by: a relay (Discourse, GitHub, Jira) gives every
-// writer the same address and its own display name, so one notification thread names as many people
-// as it had posters. Those are exactly the floods stacking exists to bury, and counting people here
-// would unstack them the moment a second one posted. What names the row and what identifies a flood
-// are different questions — the row wants people, the stack wants the machine sending them.
+// The name is part of the identity, not decoration. A relay (a mailing list, Discourse, GitHub)
+// gives every writer the same address and rewrites the display name per original sender, so keying
+// on the address alone piled a whole list digest into one row headed by whichever member happened
+// to be newest — ten distinct people and ten distinct subjects presented as ten from Scaleway.
+// Burying distinct writers is worse than a longer list, so they stay apart. The cost is that
+// relays now rarely stack at all, since a run has to be three ADJACENT threads and a busy list
+// interleaves its senders; that is the intended trade.
+//
+// A blank name is not a name: bots that fill it on some messages and not others would otherwise
+// look like two writers.
 const loneSenderOf = (thread: Thread): string | null => {
-	const emails = new Set(
-		(thread.messages ?? []).map((m) => (m.from_email ?? '').trim().toLowerCase()).filter(Boolean),
-	)
+	const messages = thread.messages ?? []
 
+	const emails = new Set(messages.map((m) => (m.from_email ?? '').trim().toLowerCase()).filter(Boolean))
 	if (emails.size > 1) return null
 
-	const [only] = emails
-	return only || (thread.from_email ?? '').trim().toLowerCase() || null
+	const names = new Set(messages.map((m) => (m.from_name ?? '').trim().toLowerCase()).filter(Boolean))
+	if (names.size > 1) return null
+
+	const email = [...emails][0] || (thread.from_email ?? '').trim().toLowerCase()
+	if (!email) return null
+
+	const name = [...names][0] ?? (thread.from_name ?? '').trim().toLowerCase()
+	return `${name}|${email}`
 }
 
 /**
  * The stack identity of a thread, or null when it must never stack.
  *
- * Only threads that ONE person has written in can stack, and they stack by that person — never by the
- * subject. Matching subjects too was tried and measured against a real 300-thread inbox, and the two
+ * Only threads that ONE person has written in can stack, and they stack by that person — name and
+ * address both, see loneSenderOf — never by the subject. Matching subjects too was tried and
+ * measured against a real 300-thread inbox, and the two
  * classes turned out not to be separable: "Outbound IP Change — KSA Region" vs "… Johannesburg Region"
  * (one template, must stack) scored 0.71 similarity, while "Your CRM trial just expired" vs "Your
  * Learning trial just expired" (distinct notices, must not stack) scored 0.74 — higher. Any threshold

--- a/frontend/src/composables/useScreenSize.ts
+++ b/frontend/src/composables/useScreenSize.ts
@@ -1,0 +1,18 @@
+import { ref } from 'vue'
+
+// Decided once, at load, and deliberately not reactive to resize. Mobile and desktop are
+// separate component trees, not one tree restyled: crossing 640px mid-session swaps them and
+// unmounts whatever they were holding — a half-written mail vanished this way (#38), and every
+// other open surface has the same exposure. A resized window therefore keeps the layout it
+// started with until the page is reloaded.
+//
+// Which is why this is for STRUCTURE — which tree to mount, which route to take — and not for
+// sizing. Tailwind's `max-sm:` keys on the same 640px but follows the viewport live, so a
+// component that sizes itself from this ref ends up disagreeing with the one next to it after a
+// resize. The mobile steps live in src/index.css.
+//
+// Shared rather than per-app: mail owned the only copy, so the calendar had no way to ask and
+// rendered its desktop event panel at every width. (meet still has its own in utils/device.ts.)
+const isMobile = ref(window.innerWidth < 640)
+
+export const useScreenSize = () => ({ isMobile })


### PR DESCRIPTION
Small fixes found while testing, one commit each.

### Screener

**Undo waited for everything.** Applying a verdict never waits — the rows leave and the write is batched behind a timer. Undo force-flushed that write, awaited its own round trip, then refetched the list. The rows and the toast come back first now; the reload becomes reconciliation, and the rollback on failure.

**Allow and Deny had no keys.** `E` and `Delete` were bound, so only the *rarer* decisions were reachable from the keyboard. `A` allows, `D` denies — modifier-free, so Cmd/Ctrl+A stays Select All.

**Every sender's page was titled "Screener".** Each is its own URL; the tab names the open sender now, as the mailbox names the open thread.

### Elsewhere

**List stacks named after one member.** A relay gives every writer the same address and its own display name, so a `Developers` digest collapsed under whichever was newest. The display name is part of the sender's identity now. Cost, taken deliberately: relays rarely stack at all, a run being three *adjacent* threads.

**Plain-text bodies rendered bolder than the app.** `font-sans` is the system stack, not Inter, so `text-base`'s `font-weight: 420` had no face to land on and CSS resolved it upward to Medium. `font-normal` pins it to Regular.

**The sender line shaved its descenders.** `truncate` is overflow-hidden and 13px text sits in a 14.95px line box. `leading-4` — row height unchanged.

**The calendar's event panel on mobile.** A fixed-width side panel covering the grid it should sit beside. The mobile check moved to `src/composables` so the calendar can read it; mail re-exports it.

---

Conflicts with #630 on `MailThread.vue` and `composables.ts` — both small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
