### PR TITLE
fix(meet): allow recorder integration output writes

### DIFF
--- a/suite/meet/recorder-server/integration/run.sh
+++ b/suite/meet/recorder-server/integration/run.sh
@@ -6,6 +6,8 @@ compose="$root/suite/meet/recorder-server/integration/docker-compose.yml"
 output="$root/suite/meet/recorder-server/integration/output"
 
 mkdir -p "$output"
+# Linux bind mounts retain the host runner's UID, while the image runs as UID 1000.
+chmod o+rwx "$output"
 docker compose -f "$compose" build recorder-integration
 docker compose -f "$compose" run --rm recorder-integration node dist/integration/CaptureWorker.integration.js clean
 docker compose -f "$compose" run --rm recorder-integration node dist/integration/CaptureWorker.integration.js recovery


### PR DESCRIPTION
## Summary

- make the recorder integration bind mount writable by the image user on Linux
- preserve the unprivileged recorder runtime user

## Verification

- `sh -n suite/meet/recorder-server/integration/run.sh`
- reproduced the GitHub runner UID mismatch and verified UID 1000 can create `/output/clean`
- `yarn test:integration`