### PR TITLE
fix(drive): preview framework attachments

### DIFF
--- a/suite/drive/api/tests/test_files.py
+++ b/suite/drive/api/tests/test_files.py
@@ -29,6 +29,7 @@ from suite.drive.api.permissions import (
     user_has_permission,
 )
 from suite.drive.overrides.file import File as DriveFile
+from suite.drive.patches.normalize_attachment_file_types import execute as normalize_attachment_file_types
 from suite.drive.utils import (
     APP_FOLDERS,
     FRAMEWORK_FOLDERS,
@@ -82,6 +83,24 @@ class TestDriveFilesAPI(IntegrationTestCase):
             attachments = get_attachments("User", OWNER)
 
         self.assertEqual([attachment["name"] for attachment in attachments], [self.file.name])
+
+    def test_attachment_patch_normalizes_framework_file_type(self):
+        try:
+            self.file.db_set(
+                {
+                    "attached_to_doctype": "User",
+                    "attached_to_name": OWNER,
+                    "file_type": "TXT",
+                }
+            )
+
+            normalize_attachment_file_types()
+
+            self.file.reload()
+            self.assertEqual(self.file.file_type, "Text")
+            self.assertEqual(self.file.mime_type, "text/plain")
+        finally:
+            self.file.db_set({"attached_to_doctype": None, "attached_to_name": None})
 
     def test_track_visit_resolves_backing_file(self):
         self.file.db_set({"content_doctype": "User", "content_docname": OWNER})

--- a/suite/drive/overrides/file.py
+++ b/suite/drive/overrides/file.py
@@ -100,7 +100,10 @@ class File(FrappeFile):
     def before_insert(self):
         # Drive's upload flow owns storage; framework uploads keep core's flow.
         if not self.flags.file_created:
-            return super().before_insert()
+            super().before_insert()
+            if not self.mime_type:
+                self.mime_type = mimemapper.get_mime_type(self.file_name, native_first=False)
+            self.file_type = get_file_type(self.mime_type)
 
     def autoname(self):
         if not self.flags.file_created:

--- a/suite/drive/patches/normalize_attachment_file_types.py
+++ b/suite/drive/patches/normalize_attachment_file_types.py
@@ -1,0 +1,24 @@
+import frappe
+import mimemapper
+
+from suite.drive.utils import get_file_type
+
+
+def execute():
+    attachments = frappe.get_all(
+        "File",
+        filters={"attached_to_doctype": ["is", "set"], "is_folder": 0},
+        fields=["name", "file_name", "file_type", "mime_type"],
+    )
+
+    for attachment in attachments:
+        mime_type = mimemapper.get_mime_type(attachment.file_name, native_first=False)
+        file_type = get_file_type(mime_type)
+        if file_type == "Unknown" or (attachment.file_type == file_type and attachment.mime_type):
+            continue
+        frappe.db.set_value(
+            "File",
+            attachment.name,
+            {"mime_type": mime_type, "file_type": file_type},
+            update_modified=False,
+        )

--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -34,6 +34,7 @@ suite.drive.patches.add_modified_field
 suite.drive.patches.add_search_index
 suite.drive.patches.migrate_s3_url_prefix
 suite.drive.patches.switch_drive_roles_to_suite_roles
+suite.drive.patches.normalize_attachment_file_types
 # --- slides ---
 suite.slides.doctype.presentation.patches.sanitize_attachment_urls
 suite.slides.doctype.presentation.patches.move_attachments_to_private_folder

--- a/suite/slides/doctype/presentation/presentation.py
+++ b/suite/slides/doctype/presentation/presentation.py
@@ -574,6 +574,7 @@ def create_new_webp_file_doc(presentation_name, file_url, image, extn):
         new_file = frappe.copy_doc(_file)
         new_file.file_name = f"{_file.file_name.replace(extn, 'webp')}"
         new_file.file_url = f"{_file.file_url.replace(extn, 'webp')}"
+        new_file.mime_type = "image/webp"
         new_file.save()
         _file.delete()
         return new_file

--- a/suite/slides/doctype/presentation/test_presentation.py
+++ b/suite/slides/doctype/presentation/test_presentation.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+import io
 import os
 
 import frappe
 from frappe.client import set_value
 from frappe.tests import IntegrationTestCase
+from PIL import Image
 
 from suite.slides.doctype.presentation.presentation import (
     create_presentation,
@@ -14,6 +16,7 @@ from suite.slides.doctype.presentation.presentation import (
     get_public_presentation,
     get_templates,
     get_updated_json,
+    get_webp_doc,
     save_base64_image,
     save_presentation_thumbnail,
     update_slide_attachments,
@@ -111,8 +114,21 @@ class TestPresentationSecurity(IntegrationTestCase):
         self.assertTrue(url.endswith(".png"))
         file = frappe.get_doc("File", {"file_url": url})
         self.assertEqual(file.is_private, 1)
+        self.assertEqual(file.file_type, "Image")
+        self.assertEqual(file.mime_type, "image/png")
         self.assertEqual(file.attached_to_doctype, "Presentation")
         self.assertEqual(file.attached_to_name, self.other_presentation)
+
+    def test_webp_conversion_keeps_drive_image_metadata(self):
+        content = io.BytesIO()
+        Image.new("RGB", (2, 1), (17, 34, 51)).save(content, "PNG")
+
+        with self.set_user(OWNER):
+            source = make_private_image(self.owner_presentation, content.getvalue())
+            converted = get_webp_doc(self.owner_presentation, source.as_dict())
+
+        self.assertEqual(converted.file_type, "Image")
+        self.assertEqual(converted.mime_type, "image/webp")
 
     def test_composite_blocks_private_presentation(self):
         with self.set_user("Guest"):


### PR DESCRIPTION
## Summary
- normalize MIME and semantic file types for framework-created attachments
- preserve WebP metadata when Slides converts presentation images
- backfill existing attachment metadata so Drive previews render