### PR TITLE
fix(meet): restore emoji popup background

### DIFF
--- a/frontend/src/apps/meet/components/ChatPanel.vue
+++ b/frontend/src/apps/meet/components/ChatPanel.vue
@@ -119,7 +119,7 @@
 						>
 							<div
 								v-if="emojiMenuActive"
-								class="absolute bottom-full left-0 z-50 mb-1 max-h-[220px] min-w-[12rem] overflow-y-auto rounded-lg border border-outline-gray-2 bg-surface-modal p-1 shadow-lg"
+								class="absolute bottom-full left-0 z-50 mb-1 max-h-[220px] min-w-[12rem] overflow-y-auto rounded-lg border border-outline-gray-2 bg-surface-elevation-2 p-1 shadow-lg"
 								role="listbox"
 								aria-label="Emoji suggestions"
 								data-testid="chat-emoji-suggestions"


### PR DESCRIPTION
The Meet chat emoji suggestion popup used the retired `surface-modal` token, so no background utility was generated and chat messages showed through it. Use the current elevated floating-panel surface token instead.