### PR TITLE
fix(slides): tab title, slideshow video controls and cursor

### DIFF
--- a/frontend/src/apps/drive/ui/drive/components/ShareDialog.vue
+++ b/frontend/src/apps/drive/ui/drive/components/ShareDialog.vue
@@ -1,7 +1,6 @@
 <template>
   <Dialog v-model:open="open" size="lg">
     <template #title>
-      <!-- the grid track pins the header's min-content to zero so the name can truncate -->
       <div class="grid grid-cols-[minmax(0,1fr)] pr-3">
         <div class="text-2xl-semibold text-ink-gray-8 flex text-nowrap overflow-hidden">
           Sharing "

--- a/frontend/src/apps/drive/ui/drive/components/ShareDialog.vue
+++ b/frontend/src/apps/drive/ui/drive/components/ShareDialog.vue
@@ -1,12 +1,15 @@
 <template>
   <Dialog v-model:open="open" size="lg">
     <template #title>
-      <div class="text-2xl-semibold text-ink-gray-8 flex text-nowrap overflow-hidden">
-        Sharing "
-        <div class="truncate max-w-[80%]">
-          {{ file?.file_name }}
+      <!-- the grid track pins the header's min-content to zero so the name can truncate -->
+      <div class="grid grid-cols-[minmax(0,1fr)] pr-3">
+        <div class="text-2xl-semibold text-ink-gray-8 flex text-nowrap overflow-hidden">
+          Sharing "
+          <div class="truncate min-w-0">
+            {{ file?.file_name }}
+          </div>
+          "
         </div>
-        "
       </div>
     </template>
     <template #default>

--- a/frontend/src/apps/slides/components/VideoElement.vue
+++ b/frontend/src/apps/slides/components/VideoElement.vue
@@ -57,6 +57,9 @@
 			class="pointer-events-none absolute left-0 top-0 size-full overflow-hidden"
 			:style="{ borderRadius: `${element.borderRadius || 0}px` }"
 		>
+			<div v-if="persistControls && !isPlaying" :class="toggleButtonClasses">
+				<Play size="16" class="stroke-[1.5] ps-[0.5px] text-white" />
+			</div>
 			<div
 				ref="progressBar"
 				:class="`${progressBarClasses} bg-black-overlay-300 transition-opacity duration-200 ease-in-out`"

--- a/frontend/src/apps/slides/components/VideoElement.vue
+++ b/frontend/src/apps/slides/components/VideoElement.vue
@@ -10,9 +10,11 @@
 	<div
 		v-else
 		class="h-full"
+		:class="{ 'cursor-pointer': inViewerMode }"
 		@click="handleVideoClick"
-		@mouseenter="handleHoverChange"
-		@mouseleave="handleHoverChange"
+		@mouseenter="handleMouseEnter"
+		@mousemove="revealControls"
+		@mouseleave="handleMouseLeave"
 	>
 		<video
 			ref="videoElement"
@@ -22,29 +24,44 @@
 			:playbackRate="element.playbackRate"
 			@timeupdate="updateProgress"
 			@loadedmetadata="updateDuration"
-			@ended="resetProgress"
+			@play="handlePlay"
+			@pause="handlePause"
+			@ended="handleEnded"
 			preload="auto"
 			:poster="getAttachmentUrl(element.poster)"
 		>
 			<source :src="getAttachmentUrl(element.src)" />
 		</video>
 		<div
+			v-if="!inViewerMode"
 			ref="overlay"
-			v-show="showOverlay"
 			class="overlay absolute left-0 top-0 size-full cursor-default overflow-hidden transition-opacity duration-500 ease-in-out"
-			:style="gradientOverlayStyles"
+			:style="editorOverlayStyles"
 		>
-			<div v-if="showProgressBar" :class="toggleButtonClasses">
-				<component
-					size="16"
-					:is="isPlaying ? Pause : Play"
-					class="stroke-[1.5] ps-[0.5px] text-white"
-				/>
-			</div>
+			<template v-if="isActive">
+				<div :class="toggleButtonClasses">
+					<component
+						size="16"
+						:is="isPlaying ? Pause : Play"
+						class="stroke-[1.5] ps-[0.5px] text-white"
+					/>
+				</div>
+				<div ref="progressBar" :class="progressBarClasses" @click.stop="seekTimestamp">
+					<div :class="getBarClasses('duration')"></div>
+					<div :class="getBarClasses('current')" :style="{ width: `${progress}%` }"></div>
+				</div>
+			</template>
+		</div>
+		<div
+			v-else
+			class="pointer-events-none absolute left-0 top-0 size-full overflow-hidden"
+			:style="{ borderRadius: `${element.borderRadius || 0}px` }"
+		>
 			<div
-				v-if="showProgressBar"
 				ref="progressBar"
-				:class="progressBarClasses"
+				:class="`${progressBarClasses} bg-black-overlay-300 transition-opacity duration-200 ease-in-out`"
+				:style="progressBarStyles"
+				@mouseenter="cancelHide"
 				@click.stop="seekTimestamp"
 			>
 				<div :class="getBarClasses('duration')"></div>
@@ -55,7 +72,7 @@
 </template>
 
 <script setup>
-import { ref, computed, useTemplateRef, inject } from 'vue'
+import { ref, computed, useTemplateRef, inject, onBeforeUnmount } from 'vue'
 
 import { Play, Pause } from 'lucide-vue-next'
 
@@ -98,11 +115,25 @@ const getBarClasses = (type) => {
 }
 
 const progressBarClasses = computed(() => {
-	const baseClasses = 'absolute w-full bottom-0 left-0 cursor-pointer h-2'
-	return `${baseClasses} ${inSlideShowMode.value ? 'bottom-0' : 'bottom-[10px]'}`
+	const baseClasses = 'absolute w-full left-0 cursor-pointer h-2'
+	return `${baseClasses} ${inViewerMode.value ? 'bottom-0' : 'bottom-[10px]'}`
 })
 
+const progressBarStyles = computed(() => ({
+	opacity: controlsVisible.value ? 1 : 0,
+	pointerEvents: controlsVisible.value ? 'auto' : 'none',
+}))
+
+const editorOverlayStyles = computed(() => ({
+	background: `radial-gradient(circle at center, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.1) 5%, rgba(0, 0, 0, 0) 100%),
+        linear-gradient(to top, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.1) 15%, rgba(0, 0, 0, 0) 100%)`,
+	opacity: isActive.value ? 1 : 0,
+	borderRadius: `${element.value.borderRadius}px`,
+}))
+
 const isPlaying = ref(false)
+const hoverOver = ref(false)
+const hoverRevealed = ref(false)
 
 const boxShadow = useBoxShadow(element)
 
@@ -128,27 +159,58 @@ const thumbnailSrc = computed(() => {
 	return element.value.poster || ''
 })
 
+const isActive = computed(() => activeElementIds.value.includes(element.value.id))
+
+const inViewerMode = computed(() => inReadonlyMode.value || inSlideShowMode.value)
+
+const isPlayable = computed(() => inViewerMode.value || isActive.value)
+
+// the shared view has no other affordance, so a paused video keeps its bar
+const persistControls = computed(() => inReadonlyMode.value && !inSlideShowMode.value)
+
+const controlsVisible = computed(() => {
+	if (!inViewerMode.value) return false
+	if (!persistControls.value) return !isPlaying.value && hoverRevealed.value
+	return !isPlaying.value || hoverRevealed.value
+})
+
+const controlsHideDelay = 1000
+let hideTimeout = null
+
+const revealControls = () => {
+	clearTimeout(hideTimeout)
+	if (!inViewerMode.value) return
+	// in the slideshow a playing video shows nothing at all
+	if (isPlaying.value && !persistControls.value) return
+	hoverRevealed.value = true
+	hideTimeout = setTimeout(() => (hoverRevealed.value = false), controlsHideDelay)
+}
+
+// the bar must not fade while the pointer is aiming at it
+const cancelHide = () => clearTimeout(hideTimeout)
+
+const hideControls = () => {
+	clearTimeout(hideTimeout)
+	hoverRevealed.value = false
+}
+
+onBeforeUnmount(() => clearTimeout(hideTimeout))
+
 const togglePlaying = () => {
 	const video = el.value
 	if (video.paused) {
-		isPlaying.value = true
 		video.play()
 	} else {
-		isPlaying.value = false
 		video.pause()
 	}
 }
 
 const handleVideoClick = (e) => {
-	const isActive = activeElementIds.value.includes(element.value.id)
-
-	// in slideshow, always toggle playing on click anywhere
-	// in editor, toggle playing only when center play button is clicked
-
-	if (inReadonlyMode.value || inSlideShowMode.value || (isActive && e.target !== overlay.value)) {
-		e.stopPropagation()
-		togglePlaying()
-	}
+	if (!isPlayable.value) return
+	// in the editor a click on the backdrop selects, only the button toggles
+	if (!inViewerMode.value && e.target === overlay.value) return
+	e.stopPropagation()
+	togglePlaying()
 }
 
 const duration = ref(0)
@@ -166,18 +228,6 @@ const updateDuration = () => {
 	duration.value = video.duration
 }
 
-const hoverOver = ref(false)
-
-const showProgressBar = computed(() => {
-	// In editor, show it when video is active
-	const isActive = activeElementIds.value.includes(element.value.id)
-
-	// During slideshow, show it only if user is hovering over video
-	const slideshowHovering = inSlideShowMode.value && hoverOver.value
-
-	return isActive || slideshowHovering || (inReadonlyMode.value && !inSlideShowMode.value)
-})
-
 const progressBarRef = useTemplateRef('progressBar')
 
 const seekTimestamp = (e) => {
@@ -188,28 +238,28 @@ const seekTimestamp = (e) => {
 	video.currentTime = seekTo
 }
 
-const gradientOverlayStyles = computed(() => ({
-	background: `radial-gradient(circle at center, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.1) 5%, rgba(0, 0, 0, 0) 100%),
-        linear-gradient(to top, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.1) 15%, rgba(0, 0, 0, 0) 100%)`,
-	opacity: showProgressBar.value ? 1 : 0,
-	borderRadius: `${element.value.borderRadius}px`,
-}))
+const handlePlay = () => {
+	isPlaying.value = true
+	hideControls()
+}
 
-const resetProgress = () => {
-	progress.value = 0
+const handlePause = () => {
 	isPlaying.value = false
+	if (hoverOver.value) revealControls()
 }
 
-const handleHoverChange = (e) => {
-	if (e.type === 'mouseenter') {
-		hoverOver.value = true
-	} else if (e.type === 'mouseleave') {
-		hoverOver.value = false
-	}
+const handleEnded = () => {
+	progress.value = 0
+	handlePause()
 }
 
-const showOverlay = computed(() => {
-	if (inSlideShowMode.value) return hoverOver.value || !isPlaying.value
-	return true
-})
+const handleMouseEnter = () => {
+	hoverOver.value = true
+	revealControls()
+}
+
+const handleMouseLeave = () => {
+	hoverOver.value = false
+	hideControls()
+}
 </script>

--- a/frontend/src/apps/slides/components/VideoElement.vue
+++ b/frontend/src/apps/slides/components/VideoElement.vue
@@ -165,7 +165,7 @@ const inViewerMode = computed(() => inReadonlyMode.value || inSlideShowMode.valu
 
 const isPlayable = computed(() => inViewerMode.value || isActive.value)
 
-// the shared view has no other affordance, so a paused video keeps its bar
+// the shared view has no other play affordance
 const persistControls = computed(() => inReadonlyMode.value && !inSlideShowMode.value)
 
 const controlsVisible = computed(() => {
@@ -180,13 +180,11 @@ let hideTimeout = null
 const revealControls = () => {
 	clearTimeout(hideTimeout)
 	if (!inViewerMode.value) return
-	// in the slideshow a playing video shows nothing at all
 	if (isPlaying.value && !persistControls.value) return
 	hoverRevealed.value = true
 	hideTimeout = setTimeout(() => (hoverRevealed.value = false), controlsHideDelay)
 }
 
-// the bar must not fade while the pointer is aiming at it
 const cancelHide = () => clearTimeout(hideTimeout)
 
 const hideControls = () => {
@@ -207,7 +205,7 @@ const togglePlaying = () => {
 
 const handleVideoClick = (e) => {
 	if (!isPlayable.value) return
-	// in the editor a click on the backdrop selects, only the button toggles
+	// in the editor only the play button toggles, the backdrop selects
 	if (!inViewerMode.value && e.target === overlay.value) return
 	e.stopPropagation()
 	togglePlaying()

--- a/frontend/src/apps/slides/pages/PresentationEditor.vue
+++ b/frontend/src/apps/slides/pages/PresentationEditor.vue
@@ -184,7 +184,6 @@ usePageMeta(() => {
 	}
 })
 
-// the editor is kept alive, so returning from the slideshow leaves the router's title in place
 onActivated(() => (document.title = pageTitle()))
 
 const handleAutoSave = () => {

--- a/frontend/src/apps/slides/pages/PresentationEditor.vue
+++ b/frontend/src/apps/slides/pages/PresentationEditor.vue
@@ -81,6 +81,7 @@ import {
 	ref,
 	watch,
 	onMounted,
+	onActivated,
 	onBeforeUnmount,
 	provide,
 	nextTick,
@@ -113,6 +114,7 @@ import {
 	deletePresentation,
 	presentationTheme,
 	resetEditorState,
+	pageTitle,
 } from '@/apps/slides/stores/presentation'
 import {
 	slides,
@@ -178,9 +180,12 @@ useShortcuts(inReadonlyMode, inSlideShowMode)
 
 usePageMeta(() => {
 	return {
-		title: presentationDoc.value?.title || 'Slides',
+		title: pageTitle(),
 	}
 })
+
+// the editor is kept alive, so returning from the slideshow leaves the router's title in place
+onActivated(() => (document.title = pageTitle()))
 
 const handleAutoSave = () => {
 	if (isSlideInteractionActive.value || focusElementId.value != null) return

--- a/frontend/src/apps/slides/pages/Slideshow.vue
+++ b/frontend/src/apps/slides/pages/Slideshow.vue
@@ -65,7 +65,7 @@
 
 <script setup>
 import { computed, onActivated, onDeactivated, ref, watch, provide } from 'vue'
-import { toast, useShortcut } from 'frappe-ui'
+import { toast, useShortcut, usePageMeta } from 'frappe-ui'
 
 import SlideElement from '@/apps/slides/components/SlideElement.vue'
 import SlideshowEndScreen from '@/apps/slides/components/SlideshowEndScreen.vue'
@@ -83,7 +83,12 @@ import {
 	performPreviousStep,
 } from '@/apps/slides/stores/slideshow'
 
-import { applyReverseTransition, initPresentationDoc, inReadonlyMode } from '@/apps/slides/stores/presentation'
+import {
+	applyReverseTransition,
+	initPresentationDoc,
+	inReadonlyMode,
+	pageTitle,
+} from '@/apps/slides/stores/presentation'
 import { currentSlide, setSlideIndex, slideIndex, slides } from '@/apps/slides/stores/slide'
 import { resetFocus } from '@/apps/slides/stores/element'
 
@@ -312,7 +317,11 @@ const updateWindowSize = () => {
 	windowHeight.value = window.innerHeight
 }
 
+usePageMeta(() => ({ title: pageTitle() }))
+
 onActivated(() => {
+	// kept alive, so re-entering the slideshow leaves the router's app title in place
+	document.title = pageTitle()
 	resetFocus()
 	loadPresentation()
 	initFullscreenMode()

--- a/frontend/src/apps/slides/pages/Slideshow.vue
+++ b/frontend/src/apps/slides/pages/Slideshow.vue
@@ -320,7 +320,6 @@ const updateWindowSize = () => {
 usePageMeta(() => ({ title: pageTitle() }))
 
 onActivated(() => {
-	// kept alive, so re-entering the slideshow leaves the router's app title in place
 	document.title = pageTitle()
 	resetFocus()
 	loadPresentation()
@@ -375,7 +374,7 @@ useShortcut([
 </script>
 
 <style>
-/* elements set their own cursor (videos are cursor-pointer), so the idle hide has to win over them */
+/* has to beat the cursor elements set on themselves */
 .slideshow-hide-cursor,
 .slideshow-hide-cursor * {
 	cursor: none !important;

--- a/frontend/src/apps/slides/pages/Slideshow.vue
+++ b/frontend/src/apps/slides/pages/Slideshow.vue
@@ -1,7 +1,9 @@
 <template>
-	<div class="absolute left-0 top-0 h-full w-full bg-black">
+	<div
+		class="absolute left-0 top-0 h-full w-full bg-black"
+		:class="{ 'slideshow-hide-cursor': cursorHidden }"
+	>
 		<div
-			ref="slideContainer"
 			class="flex h-screen w-full items-center justify-center"
 			:style="slideContainerStyles"
 		>
@@ -62,7 +64,7 @@
 </template>
 
 <script setup>
-import { computed, onActivated, onDeactivated, ref, useTemplateRef, watch, provide } from 'vue'
+import { computed, onActivated, onDeactivated, ref, watch, provide } from 'vue'
 import { toast, useShortcut } from 'frappe-ui'
 
 import SlideElement from '@/apps/slides/components/SlideElement.vue'
@@ -84,8 +86,6 @@ import {
 import { applyReverseTransition, initPresentationDoc, inReadonlyMode } from '@/apps/slides/stores/presentation'
 import { currentSlide, setSlideIndex, slideIndex, slides } from '@/apps/slides/stores/slide'
 import { resetFocus } from '@/apps/slides/stores/element'
-
-const slideContainerRef = useTemplateRef('slideContainer')
 
 const props = defineProps({
 	presentationId: {
@@ -115,7 +115,7 @@ const getElementKey = (element) => {
 	return element.refId || element.id
 }
 
-const slideCursor = ref('none')
+const cursorHidden = ref(true)
 
 const prevSlide = computed(() => {
 	if (slideIndex.value == 0) return null
@@ -139,7 +139,6 @@ const slideStyles = computed(() => {
 		width: '960px',
 		height: '540px',
 		backgroundColor: currentSlide.value?.background || '#ffffff',
-		cursor: slideCursor.value,
 	}
 
 	if (prevSlide.value?.transition == 'Magic Move') {
@@ -258,22 +257,28 @@ const slideLeave = (el, done) => {
 	done()
 }
 
+const CURSOR_IDLE_DELAY = 3000
 let cursorTimer = null
 
 const resetCursorVisibility = () => {
-	slideCursor.value = 'auto'
+	cursorHidden.value = false
 	clearTimeout(cursorTimer)
 	cursorTimer = setTimeout(() => {
-		slideCursor.value = 'none'
-	}, 4000)
+		cursorHidden.value = true
+	}, CURSOR_IDLE_DELAY)
+}
+
+const stopCursorTracking = () => {
+	clearTimeout(cursorTimer)
+	document.removeEventListener('mousemove', resetCursorVisibility)
+	cursorHidden.value = true
 }
 
 const handleFullScreenChange = () => {
 	if (document.fullscreenElement) {
-		slideContainerRef.value?.addEventListener('mousemove', resetCursorVisibility)
 		inSlideShowMode.value = true
 	} else {
-		slideContainerRef.value?.removeEventListener('mousemove', resetCursorVisibility)
+		stopCursorTracking()
 		if (inSlideShowMode.value) endSlideShow()
 	}
 }
@@ -312,6 +317,7 @@ onActivated(() => {
 	loadPresentation()
 	initFullscreenMode()
 	document.addEventListener('fullscreenchange', handleFullScreenChange)
+	document.addEventListener('mousemove', resetCursorVisibility)
 	window.addEventListener('resize', updateWindowSize)
 
 	// Initial prefetch of next slide
@@ -323,6 +329,7 @@ onActivated(() => {
 onDeactivated(() => {
 	document.removeEventListener('fullscreenchange', handleFullScreenChange)
 	window.removeEventListener('resize', updateWindowSize)
+	stopCursorTracking()
 
 	// leaving by any route other than endSlideShow would strand the editor in fullscreen
 	if (inSlideShowMode.value) {
@@ -359,6 +366,12 @@ useShortcut([
 </script>
 
 <style>
+/* elements set their own cursor (videos are cursor-pointer), so the idle hide has to win over them */
+.slideshow-hide-cursor,
+.slideshow-hide-cursor * {
+	cursor: none !important;
+}
+
 .forward-transition .textElement span {
 	transition-property: all;
 	transition-duration: var(--transition-duration);

--- a/frontend/src/apps/slides/stores/presentation.js
+++ b/frontend/src/apps/slides/stores/presentation.js
@@ -360,6 +360,12 @@ const duplicatePresentation = async (presentation) => {
 	return newPresentation.name
 }
 
+const pageTitle = () => {
+	const appTitle = router.currentRoute.value.meta.title || 'Frappe Slides'
+	const title = presentationDoc.value?.title
+	return title ? `${title} - ${appTitle}` : appTitle
+}
+
 const resetEditorState = () => {
 	presentationDoc.value = null
 	slides.value = []
@@ -385,4 +391,5 @@ export {
 	deletePresentation,
 	duplicatePresentation,
 	resetEditorState,
+	pageTitle,
 }

--- a/frontend/src/router/documentTitle.test.ts
+++ b/frontend/src/router/documentTitle.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { RouteLocationNormalizedLoaded } from 'vue-router'
+
+import { setDocumentTitle } from './index'
+
+const HOME = { name: 'slides-home' }
+const EDITOR = { name: 'slides-editor' }
+
+/** Only `matched` and `meta` are read; everything else on the location is irrelevant here. */
+const at = (record: object, title = 'Frappe Slides') =>
+	({ matched: [{ name: 'slides-group' }, record], meta: { title } }) as RouteLocationNormalizedLoaded
+
+describe('setDocumentTitle', () => {
+	beforeEach(() => {
+		document.title = 'Presentation - Frappe Slides'
+	})
+
+	// Regression: slides replaces its own route on every slide change (?slide=N) and once
+	// more to add the slug. Both re-run afterEach with the view still mounted, so resetting
+	// the title wiped the presentation name the view had put there.
+	it('leaves the title alone on a same-view navigation', () => {
+		setDocumentTitle(at(EDITOR), at(EDITOR))
+		expect(document.title).toBe('Presentation - Frappe Slides')
+	})
+
+	it('applies the app title when the view changes', () => {
+		setDocumentTitle(at(HOME), at(EDITOR))
+		expect(document.title).toBe('Frappe Slides')
+	})
+
+	it('leaves the title alone when the route carries none', () => {
+		setDocumentTitle(at(HOME, ''), at(EDITOR))
+		expect(document.title).toBe('Presentation - Frappe Slides')
+	})
+})

--- a/frontend/src/router/documentTitle.test.ts
+++ b/frontend/src/router/documentTitle.test.ts
@@ -6,30 +6,29 @@ import { setDocumentTitle } from './index'
 const HOME = { name: 'slides-home' }
 const EDITOR = { name: 'slides-editor' }
 
-/** Only `matched` and `meta` are read; everything else on the location is irrelevant here. */
 const at = (record: object, title = 'Frappe Slides') =>
-	({ matched: [{ name: 'slides-group' }, record], meta: { title } }) as RouteLocationNormalizedLoaded
+  ({
+    matched: [{ name: 'slides-group' }, record],
+    meta: { title },
+  }) as RouteLocationNormalizedLoaded
 
 describe('setDocumentTitle', () => {
-	beforeEach(() => {
-		document.title = 'Presentation - Frappe Slides'
-	})
+  beforeEach(() => {
+    document.title = 'Presentation - Frappe Slides'
+  })
 
-	// Regression: slides replaces its own route on every slide change (?slide=N) and once
-	// more to add the slug. Both re-run afterEach with the view still mounted, so resetting
-	// the title wiped the presentation name the view had put there.
-	it('leaves the title alone on a same-view navigation', () => {
-		setDocumentTitle(at(EDITOR), at(EDITOR))
-		expect(document.title).toBe('Presentation - Frappe Slides')
-	})
+  it('leaves the title alone on a same-view navigation', () => {
+    setDocumentTitle(at(EDITOR), at(EDITOR))
+    expect(document.title).toBe('Presentation - Frappe Slides')
+  })
 
-	it('applies the app title when the view changes', () => {
-		setDocumentTitle(at(HOME), at(EDITOR))
-		expect(document.title).toBe('Frappe Slides')
-	})
+  it('applies the app title when the view changes', () => {
+    setDocumentTitle(at(HOME), at(EDITOR))
+    expect(document.title).toBe('Frappe Slides')
+  })
 
-	it('leaves the title alone when the route carries none', () => {
-		setDocumentTitle(at(HOME, ''), at(EDITOR))
-		expect(document.title).toBe('Presentation - Frappe Slides')
-	})
+  it('leaves the title alone when the route carries none', () => {
+    setDocumentTitle(at(HOME, ''), at(EDITOR))
+    expect(document.title).toBe('Presentation - Frappe Slides')
+  })
 })

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -196,9 +196,7 @@ export function setDocumentTitle(
   to: RouteLocationNormalizedLoaded,
   from: RouteLocationNormalizedLoaded,
 ) {
-  // The app-level title only covers entering a view; from then on the view owns it via
-  // usePageMeta. A same-route replace (slides' ?slide=N, its slug rewrite) leaves that view
-  // mounted, so resetting here would clobber the document name it put in the tab.
+  // a same-view replace leaves the view mounted, so its usePageMeta title stands
   const view = to.matched.at(-1)
   if (view && view === from.matched.at(-1)) return
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -182,17 +182,26 @@ router.beforeEach(async (to) => {
   return true
 })
 
-router.afterEach((to, _from, failure) => {
+router.afterEach((to, from, failure) => {
   // A failed navigation (e.g. re-clicking the current folder, which vue-router reports
   // as duplicated but still runs afterEach for) leaves the page untouched — resetting
   // the title here would clobber the one the view set via usePageMeta.
   if (failure) return
-  setDocumentTitle(to)
+  setDocumentTitle(to, from)
   setFavicon(to)
   setPwaTags(to)
 })
 
-function setDocumentTitle(to: RouteLocationNormalizedLoaded) {
+export function setDocumentTitle(
+  to: RouteLocationNormalizedLoaded,
+  from: RouteLocationNormalizedLoaded,
+) {
+  // The app-level title only covers entering a view; from then on the view owns it via
+  // usePageMeta. A same-route replace (slides' ?slide=N, its slug rewrite) leaves that view
+  // mounted, so resetting here would clobber the document name it put in the tab.
+  const view = to.matched.at(-1)
+  if (view && view === from.matched.at(-1)) return
+
   if (to.meta.title) {
     document.title = to.meta.title
   }


### PR DESCRIPTION
- Tab title now shows the presentation name alongside the app name, in the editor and the slideshow.
- Slideshow: video controls stay hidden while playing, and appear for a second on hover while paused.
- Slideshow: cursor hides after 3s idle, including over videos. Shared read-only view keeps the play affordance on a paused video.
- Share dialog truncates long file names in its title.