### PR TITLE
fix(meet): skip recorder-dependent reconciliation when no recorder is configured

### DIFF
--- a/suite/meet/api/recording.py
+++ b/suite/meet/api/recording.py
@@ -680,16 +680,20 @@ def recorder_failed(
 
 
 def reconcile_pending_recordings():
-    names = frappe.get_all(
-        "Meet Recording",
-        filters={"status": "Pending", "pending_deadline": ["<=", now_datetime()]},
-        pluck="name",
-    )
-    for name in names:
-        _run_reconciliation(name, _reconcile_pending)
+    # Pending/Stopping reconciliation needs the recorder server. Without one configured,
+    # skip those phases instead of erroring per recording; the stale sweep below fails
+    # such recordings with "recorder_unavailable" once they pass max_ends_at.
+    if _fixture_enabled() or _recorder_available():
+        names = frappe.get_all(
+            "Meet Recording",
+            filters={"status": "Pending", "pending_deadline": ["<=", now_datetime()]},
+            pluck="name",
+        )
+        for name in names:
+            _run_reconciliation(name, _reconcile_pending)
 
-    for name in frappe.get_all("Meet Recording", filters={"status": "Stopping"}, pluck="name"):
-        _run_reconciliation(name, _retry_stopping)
+        for name in frappe.get_all("Meet Recording", filters={"status": "Stopping"}, pluck="name"):
+            _run_reconciliation(name, _retry_stopping)
 
     stale_active_cutoff = add_to_date(now_datetime(), seconds=-RECONCILIATION_GRACE_SECONDS)
     for name in frappe.get_all(

--- a/suite/meet/api/test/test_recording.py
+++ b/suite/meet/api/test/test_recording.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock, patch
 import frappe
 import jwt
 from frappe.tests import IntegrationTestCase
-from frappe.utils import now_datetime
+from frappe.utils import add_to_date, now_datetime
 
 from suite.drive.api.storage import get_storage_usage
 from suite.meet.api.recording import (
@@ -660,6 +660,38 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
                     frappe.db.commit()
         self.assertFalse(frappe.db.exists("Meet Recording", names[1]))
         self.assertEqual(frappe.db.get_value("Meet Recording", names[2], "status"), "Pending")
+
+    def test_reconciliation_without_recorder_skips_client_phases_but_fails_stale(self):
+        frappe.conf.recording_fixture_mode = False
+        client = Mock()
+        client.reserve.return_value = RecorderOutcome("indeterminate")
+        with patch("suite.meet.api.recording._client", return_value=client):
+            name = start(self.room.name, str(uuid.uuid4()))["name"]
+        frappe.db.set_value("Meet Recording", name, "pending_deadline", "2000-01-01")
+
+        url = frappe.conf.pop("recorder_server_url")
+        try:
+            with patch("suite.meet.api.recording._client") as client_factory:
+                # Pending past its deadline is left alone instead of erroring per recording.
+                reconcile_pending_recordings()
+                self.assertEqual(frappe.db.get_value("Meet Recording", name, "status"), "Pending")
+
+                frappe.db.set_value("Meet Recording", name, "status", "Stopping")
+                reconcile_pending_recordings()
+                self.assertEqual(frappe.db.get_value("Meet Recording", name, "status"), "Stopping")
+
+                frappe.db.set_value(
+                    "Meet Recording", name, "max_ends_at", add_to_date(now_datetime(), days=-1)
+                )
+                reconcile_pending_recordings()
+                client_factory.assert_not_called()
+            failed = frappe.db.get_value(
+                "Meet Recording", name, ["status", "failure_code"], as_dict=True
+            )
+            self.assertEqual(failed.status, "Failed")
+            self.assertEqual(failed.failure_code, "recorder_unavailable")
+        finally:
+            frappe.conf.recorder_server_url = url
 
     def test_reconciliation_compensates_policy_change_without_blind_delete(self):
         frappe.conf.recording_fixture_mode = False

--- a/suite/meet/api/test/test_recording.py
+++ b/suite/meet/api/test/test_recording.py
@@ -685,9 +685,7 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
                 )
                 reconcile_pending_recordings()
                 client_factory.assert_not_called()
-            failed = frappe.db.get_value(
-                "Meet Recording", name, ["status", "failure_code"], as_dict=True
-            )
+            failed = frappe.db.get_value("Meet Recording", name, ["status", "failure_code"], as_dict=True)
             self.assertEqual(failed.status, "Failed")
             self.assertEqual(failed.failure_code, "recorder_unavailable")
         finally:


### PR DESCRIPTION
## Problem

On sites without a recorder server configured, the `reconcile_pending_recordings` scheduled job called `_client()` for every Pending/Stopping recording, raising `ValueError: URL must be configured` and creating an error log per recording on every scheduler run.

## Fix

Guard the two client-dependent phases (querying pending recordings and retrying stops) behind `_fixture_enabled() or _recorder_available()`. When the recorder is not configured these phases are skipped; affected recordings are not left stuck, because the stale sweep in the same job (which needs no client) still fails them with `recorder_unavailable` once past `max_ends_at`, and failed-recording cleanup continues to run.

## Tests

- `suite.meet.api.test.test_recording_reliability` — 12 passed
- `suite.meet.api.test.test_recording` — 25 passed