### PR TITLE
fix: block installing Suite when a standalone suite app is installed

### DIFF
--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -327,6 +327,7 @@ scheduler_events = {
 # ============================================================================
 from suite.suite_core import boot as _suite_boot
 
+before_install = "suite.suite_core.boot.before_install"
 after_install = "suite.suite_core.boot.after_install"
 after_migrate = "suite.suite_core.boot.after_migrate"
 after_app_install = "suite.suite_core.boot.after_app_install"

--- a/suite/suite_core/boot.py
+++ b/suite/suite_core/boot.py
@@ -13,6 +13,31 @@ Imports are performed lazily inside each dispatcher so that importing
 """
 
 import frappe
+from frappe import _
+
+# The standalone apps that were consolidated into Suite. Suite ships the same
+# modules and DocTypes, so it cannot coexist with any of them on one site.
+CONSOLIDATED_STANDALONE_APPS = (
+    "calendar_app",
+    "drive",
+    "mail",
+    "meet",
+    "sheets",
+    "slides",
+    "writer",
+)
+
+
+def before_install():
+    """Abort installing Suite on a site that still has a standalone suite app."""
+    conflicting = [app for app in CONSOLIDATED_STANDALONE_APPS if app in frappe.get_installed_apps()]
+    if conflicting:
+        frappe.throw(
+            _(
+                "Cannot install Frappe Suite because the following standalone app(s) are installed on this site: {0}. "
+                "Frappe Suite already includes them. Please uninstall these app(s) first, then install Frappe Suite."
+            ).format(", ".join(frappe.bold(app) for app in conflicting))
+        )
 
 
 def _run(label, func, *args, **kwargs):


### PR DESCRIPTION
## Problem

Installing the Suite app on a site that already has one of the standalone apps it consolidates (Calendar, Drive, Mail, Meet, Sheets, Slides, Writer) leads to conflicting modules and DocTypes.

## Fix

Add a `before_install` hook (dispatched through `suite.suite_core.boot`) that checks the site's installed apps and aborts `install-app suite` with an error listing the conflicting standalone app(s), asking the user to uninstall them first.

Error shown:

> Cannot install Frappe Suite because the following standalone app(s) are installed on this site: **drive**, **mail**. Frappe Suite already includes them. Please uninstall these app(s) first, then install Frappe Suite.

The check runs per-site at install time (bench CLI and Desk install flow), before anything is written.