### PR TITLE
fix(meet): ignore stale keyframe requests

### DIFF
--- a/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
@@ -1165,6 +1165,31 @@ describe('SocketHandlerManager characterization', () => {
 		expect(harness.mediasoup.requestConsumerKeyFrame).not.toHaveBeenCalled();
 	});
 
+	it('treats a keyframe request for an already-closed consumer as a no-op', async () => {
+		const harness = createManager();
+		const socket = connectFullSocket(harness, {
+			userId: 'viewer-1',
+			roomId: 'room-1',
+		});
+		harness.mediasoup.assertConsumerAccess.mockImplementation(() => {
+			throw new Error('Consumer stale-consumer not found');
+		});
+		const callback = vi.fn();
+
+		socket.fire(
+			'request_consumer_keyframe',
+			{ consumerId: 'stale-consumer' },
+			callback,
+		);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(callback).toHaveBeenCalledWith({
+			success: true,
+			requested: false,
+		});
+		expect(harness.mediasoup.requestConsumerKeyFrame).not.toHaveBeenCalled();
+	});
+
 	it('rejects an untracked WebRTC transport connect when E2EE is required', async () => {
 		const harness = createManager();
 		const socket = connectFullSocket(harness, {

--- a/suite/meet/sfu-server/src/server/handlers/ConsumerHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/ConsumerHandlers.ts
@@ -122,6 +122,14 @@ export function registerConsumerHandlers(deps: HandlerDeps) {
 					await deps.mediasoup.requestConsumerKeyFrame(consumerId);
 				callback({ success: true, requested });
 			} catch (error) {
+				if (
+					error instanceof Error &&
+					error.message.startsWith('Consumer ') &&
+					error.message.endsWith(' not found')
+				) {
+					callback({ success: true, requested: false });
+					return;
+				}
 				loggers.socketHandler.error(
 					'Error requesting consumer key frame: %s',
 					(error as Error).message,


### PR DESCRIPTION
## Summary

- treat keyframe requests for already-closed consumers as idempotent no-ops
- preserve normal failures for ownership mismatches and other request errors
- cover the stale-consumer response behavior