### PR TITLE
Writer: fix back navigation, rebuild the list, regroup the toolbar

### DIFF
--- a/e2e/drive-backed-apps/specs/writer/back-nav.spec.ts
+++ b/e2e/drive-backed-apps/specs/writer/back-nav.spec.ts
@@ -1,0 +1,61 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../fixtures/test";
+import { createWriterDocument, uniqueWriterTitle, writerEditor } from "../../helpers/writer";
+
+/**
+ * Leaving a document used to abort Vue's unmount: ToC/ToCMobile read
+ * `editor.view.dom` in beforeUnmount, and tiptap's post-destroy `view` proxy
+ * throws on keys it does not stub. The URL changed but the old component stayed
+ * mounted, so the document list never rendered.
+ */
+const UNMOUNT_ABORT = /editor view is not available|beforeUnmount|Unhandled error during execution/i;
+
+function collectErrors(page: Page): string[] {
+	const errors: string[] = [];
+	page.on("pageerror", (e) => errors.push(`pageerror: ${e.message}`));
+	page.on("console", (m) => {
+		if (m.type() === "error" || m.type() === "warning") errors.push(`${m.type()}: ${m.text()}`);
+	});
+	return errors;
+}
+
+async function openFirstDocument(page: Page, testId: string) {
+	await page.goto("/writer");
+	const row = page.getByTestId(testId);
+	await expect(row).toBeVisible();
+	await row.click();
+	await expect(writerEditor(page)).toBeVisible();
+	return row;
+}
+
+test("browser back from a document renders the document list", async ({ owner, run }) => {
+	const errors = collectErrors(owner.page);
+	const title = uniqueWriterTitle(run.run_id, "backnav");
+	const file = await createWriterDocument(owner.page.request, title);
+
+	const row = await openFirstDocument(owner.page, `writer-document-${file.name}`);
+	await expect(owner.page).toHaveURL(new RegExp(`/writer/w/${file.name}`));
+
+	await owner.page.goBack();
+
+	await expect(owner.page).toHaveURL(/\/writer\/?$/);
+	await expect(row).toBeVisible({ timeout: 10_000 });
+	await expect(writerEditor(owner.page)).toBeHidden();
+	expect(errors.filter((e) => UNMOUNT_ABORT.test(e))).toEqual([]);
+});
+
+test("Back to Home from a document renders the document list", async ({ owner, run }) => {
+	const errors = collectErrors(owner.page);
+	const title = uniqueWriterTitle(run.run_id, "backhome");
+	const file = await createWriterDocument(owner.page.request, title);
+
+	const row = await openFirstDocument(owner.page, `writer-document-${file.name}`);
+
+	await owner.page.locator('#navbar [aria-haspopup="menu"]').first().click();
+	await owner.page.getByText("Back to Home").click();
+
+	await expect(owner.page).toHaveURL(/\/writer\/?$/);
+	await expect(row).toBeVisible({ timeout: 10_000 });
+	await expect(writerEditor(owner.page)).toBeHidden();
+	expect(errors.filter((e) => UNMOUNT_ABORT.test(e))).toEqual([]);
+});

--- a/frontend/src/apps/writer/components/FontSelect.vue
+++ b/frontend/src/apps/writer/components/FontSelect.vue
@@ -12,9 +12,12 @@
     :placeholder="options.find((k) => k.key === font_family)?.label"
     :open-on-click="true"
     class="min-w-[10rem]"
-    variant="outline"
     @update:model-value="onSelect"
   >
+    <!-- Forwarded so the toolbar can swap the boxed trigger for a compact one. -->
+    <template v-if="$slots.trigger" #trigger="slotProps">
+      <slot name="trigger" v-bind="slotProps" />
+    </template>
     <template #font="{ option }"
       ><span :style="{ fontFamily: `var(--font-${option.key})` }">
         {{ option.label }}</span

--- a/frontend/src/apps/writer/components/ManageFont.vue
+++ b/frontend/src/apps/writer/components/ManageFont.vue
@@ -1,21 +1,66 @@
 <template>
-  <div class="flex gap-2">
-    <FormControl
-      class="w-15"
-      variant="outline"
-      type="number"
-      v-model="size"
-      @focus="$event.target.select()"
-      @update:modelValue="(val) => val && props.editor.commands.setFontSize(val + 'px')"
-    />
-    <FontSelect v-model="selected" :font_family :editor />
+  <div class="flex items-center gap-1">
+    <FontSelect v-model="selected" :font_family :editor variant="ghost">
+      <!-- Toolbar trigger: name + chevron, no box. The boxed Combobox trigger
+           is ~200px wide and dwarfs the neighbouring icon buttons. -->
+      <template #trigger="{ open, displayValue }">
+        <Button
+          size="xs"
+          variant="ghost"
+          :aria-label="__('Font family')"
+          :tooltip="__('Font family')"
+          class="aria-pressed:bg-surface-gray-3"
+          :aria-pressed="open"
+        >
+          <span class="flex items-center gap-1">
+            <span class="truncate">{{ displayValue || fontLabel }}</span>
+            <LucideChevronDown class="size-3 text-ink-gray-5" />
+          </span>
+        </Button>
+      </template>
+    </FontSelect>
+
+    <div class="flex items-center gap-1">
+      <Button
+        size="xs"
+        variant="subtle"
+        icon="lucide-minus"
+        :label="__('Decrease font size')"
+        :tooltip="__('Decrease font size')"
+        :disabled="size <= MIN_FONT_SIZE"
+        @click="step(-1)"
+      />
+      <TextInput
+        v-model.number="size"
+        type="number"
+        size="sm"
+        variant="ghost"
+        class="w-9 [&_input]:px-0 [&_input]:text-center [&_input]:[appearance:textfield] [&_input::-webkit-inner-spin-button]:appearance-none"
+        :aria-label="__('Font size')"
+        @focus="$event.target.select()"
+        @update:modelValue="apply"
+      />
+      <Button
+        size="xs"
+        variant="subtle"
+        icon="lucide-plus"
+        :label="__('Increase font size')"
+        :tooltip="__('Increase font size')"
+        :disabled="size >= MAX_FONT_SIZE"
+        @click="step(1)"
+      />
+    </div>
   </div>
 </template>
 <script setup>
-import { FormControl } from 'frappe-ui'
-import { ref, watch } from 'vue'
+import { Button, TextInput } from 'frappe-ui'
+import { computed, ref, watch } from 'vue'
 import { FONT_FAMILIES } from '@/apps/writer/utils'
 import FontSelect from './FontSelect.vue'
+import LucideChevronDown from '~icons/lucide/chevron-down'
+
+const MIN_FONT_SIZE = 8
+const MAX_FONT_SIZE = 96
 
 const props = defineProps({
   editor: Object,
@@ -25,6 +70,19 @@ const props = defineProps({
 
 const selected = ref(props.font_family)
 const size = ref(props.font_size)
+
+const fontLabel = computed(
+  () => FONT_FAMILIES.find((opt) => opt.key === selected.value)?.label ?? '',
+)
+
+const apply = (val) => {
+  const next = Math.min(Math.max(parseFloat(val), MIN_FONT_SIZE), MAX_FONT_SIZE)
+  if (Number.isNaN(next)) return
+  size.value = next
+  props.editor.commands.setFontSize(next + 'px')
+}
+
+const step = (delta) => apply(size.value + delta)
 
 // The editor is plain @tiptap/core (not reactive), so state reads don't
 // trigger re-runs — sync on transactions instead.

--- a/frontend/src/apps/writer/components/RoundedListView.vue
+++ b/frontend/src/apps/writer/components/RoundedListView.vue
@@ -3,125 +3,125 @@
     ref="container"
     class="mx-auto w-96 sm:w-[60%] pt-8 h-screen space pb-64"
   >
-    <template
-      v-for="([group, files], i) in Object.entries(groups).filter(
-        ([_, f]) => f.length,
-      )"
-      :key="group"
+    <List
+      v-if="thumbnail === 'list'"
+      :columns="columnTracks"
+      :row-height="40"
+      divider="inset"
+      class="list-row-px-3 max-sm:[--list-columns:auto_minmax(0,1fr)_auto]"
     >
-      <div
-        class="flex justify-between items-center sticky top-0 bg-surface-base h-8 z-10 mt-3 mb-1 -mx-3"
+      <ListGroup
+        v-for="([group, files], i) in visibleGroups"
+        :key="group"
+        :label="group"
+        sticky
+        class="mt-3 first:mt-0"
       >
-        <h2 class="text-sm font-medium text-ink-gray-5">
-          {{ group }}
-        </h2>
-        <TabButtons
-          v-if="i === 0"
-          class="w-fit"
-          v-model="thumbnail"
-          :options="[
-            {
-              label: 'Grid',
-              value: 'grid',
-              icon: LucideGrid,
-              hideLabel: true,
-            },
-            {
-              label: 'List',
-              value: 'list',
-              icon: LucideList,
-              hideLabel: true,
-            },
-          ]"
-        />
-      </div>
-      <div
-        :class="
-          thumbnail === 'grid' &&
-          'grid grid-cols-2 gap-x-5 gap-y-8 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 !mb-0 mx-0.5'
-        "
-      >
-        <div
-          v-for="(row, i) in files"
+        <template #header>
+          <span class="flex-1">{{ group }}</span>
+          <TabButtons
+            v-if="i === 0"
+            v-model="thumbnail"
+            class="w-fit"
+            :options="viewOptions"
+          />
+        </template>
+        <ListRow
+          v-for="row in files"
           :key="row.name"
+          :to="{ name: 'writer-document', params: { id: row.name } }"
           :data-testid="`writer-document-${row.name}`"
         >
-          <template v-if="thumbnail === 'grid'">
-            <section
-              class="group"
-              @click="
-                $router.push({ name: 'writer-document', params: { id: row.name } })
-              "
-            >
-              <div
-                class="aspect-[37/50] cursor-pointer overflow-hidden rounded-md dark:bg-gray-900 border border-gray-50 dark:border-outline-gray-1 px-2.5 py-1 shadow-lg transition-shadow hover:shadow-xl"
-              >
-                <div class="overflow-hidden text-ellipsis whitespace-nowrap">
-                  <div
-                    class="prose prose-sm prose-v3 pointer-events-none w-[200%] origin-top-left scale-[.55] prose-p:my-1 md:w-[250%] md:scale-[.39]"
-                    v-html="row.html"
-                  />
-                </div>
-              </div>
-              <div class="mt-3 flex justify-between items-center">
-                <div class="flex-grow w-full min-w-0">
-                  <h1 class="text-base-medium truncate text-ink-gray-7">
-                    {{ row.file_name }}
-                  </h1>
-                </div>
-              </div>
-            </section>
-          </template>
-          <template v-else>
+          <ListCell>
+            <LucideFileText class="size-4 text-ink-gray-5" />
+          </ListCell>
+          <ListCell>
+            <p class="text-base-medium text-ink-gray-8 truncate">
+              {{ row.file_name }}
+            </p>
+          </ListCell>
+          <ListCell class="justify-end gap-2 max-sm:hidden text-xs text-ink-gray-5">
+            <LucideGlobe2
+              v-if="row.share_count == -2"
+              class="size-4 text-ink-gray-6"
+            />
+            <LucideBuilding2
+              v-else-if="row.share_count == -1"
+              class="size-4 text-ink-gray-6"
+            />
+            <LucideUsers
+              v-else-if="row.share_count > 0"
+              class="size-4 text-ink-gray-6"
+            />
+            <template v-if="row.owner === currentUserId">
+              <Avatar
+                :image="$user(row.owner)?.user_image"
+                :label="$user(row.owner)?.full_name || 'Deleted'"
+                size="xs"
+              />
+              <span :title="row.owner">
+                {{ $user(row.owner)?.full_name || 'Deleted' }}
+              </span>
+            </template>
+          </ListCell>
+          <ListCell class="justify-end text-xs text-ink-gray-5">
+            <span :title="row.recentDate">{{ row.relativeModified }}</span>
+          </ListCell>
+        </ListRow>
+      </ListGroup>
+    </List>
+
+    <template v-else>
+      <div
+        v-for="([group, files], i) in visibleGroups"
+        :key="group"
+        class="mt-3 first:mt-0"
+      >
+        <!-- Mirrors ListGroup's header box exactly (h-8, text-sm-medium,
+             sticky) so toggling grid/list moves nothing. `px-3` stands in for
+             the `--list-row-padding-x` that list-group-header inherits from
+             the List's `list-row-px-3`. -->
+        <div
+          class="flex h-8 items-center text-sm-medium text-ink-gray-5 sticky top-0 z-10 bg-surface-base px-3"
+        >
+          <span class="flex-1">{{ group }}</span>
+          <TabButtons
+            v-if="i === 0"
+            v-model="thumbnail"
+            class="w-fit"
+            :options="viewOptions"
+          />
+        </div>
+        <div
+          class="grid grid-cols-2 gap-x-5 gap-y-8 md:grid-cols-3 lg:grid-cols-5 !mb-0 px-3"
+        >
+          <section
+            v-for="row in files"
+            :key="row.name"
+            class="group"
+            :data-testid="`writer-document-${row.name}`"
+            @click="
+              $router.push({ name: 'writer-document', params: { id: row.name } })
+            "
+          >
             <div
-              @click="
-                $router.push({ name: 'writer-document', params: { id: row.name } })
-              "
-              class="group flex flex-col gap-2 md:flex-row p-3 md:items-center md:justify-between hover:bg-surface-gray-1 rounded cursor-pointer my-px -mx-3"
+              class="aspect-[37/50] cursor-pointer overflow-hidden rounded-md dark:bg-gray-900 border border-gray-50 dark:border-outline-gray-1 px-2.5 py-1 shadow-lg transition-shadow hover:shadow-xl"
             >
-              <p
-                class="text-base-medium text-ink-gray-8 truncate md:w-1/2 overflow-clip"
-              >
-                {{ row.file_name }}
-              </p>
-
-              <div
-                class="flex items-center justify-between gap-2 text-sm text-gray-600 flex-shrink-0"
-              >
+              <div class="overflow-hidden text-ellipsis whitespace-nowrap">
                 <div
-                  class="text-xs text-ink-gray-5 flex gap-2 md:gap-5 items-center"
-                >
-                  <LucideGlobe2
-                    v-if="row.share_count == -2"
-                    class="size-4 text-ink-gray-6"
-                  />
-                  <LucideBuilding2
-                    v-else-if="row.share_count == -1"
-                    class="size-4 text-ink-gray-6"
-                  />
-                  <LucideUsers
-                    v-else-if="row.share_count > 0"
-                    class="size-4 text-ink-gray-6"
-                  />
-                  <template v-if="row.owner === currentUserId">
-                    <Avatar
-                      :image="$user(row.owner)?.user_image"
-                      :label="$user(row.owner)?.full_name || 'Deleted'"
-                      size="xs"
-                    />
-                    <span :title="row.owner">
-                      {{ $user(row.owner)?.full_name || 'Deleted' }}
-                    </span>
-                  </template>
-                </div>
-
-                <span :title="row.recentDate" class="w-28 text-end">{{
-                  row.relativeModified
-                }}</span>
+                  class="prose prose-sm prose-v3 pointer-events-none w-[200%] origin-top-left scale-[.55] prose-p:my-1 md:w-[250%] md:scale-[.39]"
+                  v-html="row.html"
+                />
               </div>
             </div>
-            <hr v-if="i !== files.length - 1" />
-          </template>
+            <div class="mt-3 flex justify-between items-center">
+              <div class="flex-grow w-full min-w-0">
+                <h1 class="text-base-medium truncate text-ink-gray-7">
+                  {{ row.file_name }}
+                </h1>
+              </div>
+            </div>
+          </section>
         </div>
       </div>
     </template>
@@ -154,6 +154,7 @@
 import { computed, ref, watch, useTemplateRef } from 'vue'
 
 import { Avatar, TabButtons } from 'frappe-ui'
+import { List, ListCell, ListGroup, ListRow } from 'frappe-ui/list'
 import { useInfiniteScroll } from '@vueuse/core'
 import LucideGrid from '~icons/lucide/grid'
 import LucideList from '~icons/lucide/list'
@@ -176,6 +177,20 @@ const props = defineProps({
   resource: Object,
   actionItems: Array,
 })
+
+const viewOptions = [
+  { label: 'Grid', value: 'grid', icon: LucideGrid, hideLabel: true },
+  { label: 'List', value: 'list', icon: LucideList, hideLabel: true },
+]
+
+// icon | title | owner meta (hidden on mobile) | relative date.
+// The leading track matters: `divider="inset"` spans `2 / -1`, so dividers
+// start at the title rather than under the icon.
+const columnTracks = ['auto', 'minmax(0,1fr)', 'auto', '7rem']
+
+const visibleGroups = computed(() =>
+  Object.entries(props.groups).filter(([, files]) => files.length),
+)
 
 const container = useTemplateRef<HTMLElement>('container')
 useInfiniteScroll(

--- a/frontend/src/apps/writer/components/SpacingDialog.vue
+++ b/frontend/src/apps/writer/components/SpacingDialog.vue
@@ -5,8 +5,13 @@
          our own — same as DropdownMenuGroup.vue. It has to stay the direct child
          of #trigger: PopoverTrigger wires the click onto it via as-child. -->
     <template #trigger="{ isOpen }">
-      <Button size="xs" variant="ghost" :icon="icon" label="Custom Spacing" tooltip="Custom Spacing"
-        class="aria-pressed:bg-surface-gray-3" :aria-pressed="isOpen" />
+      <Button size="xs" variant="ghost" aria-label="Custom Spacing" tooltip="Custom Spacing"
+        class="aria-pressed:bg-surface-gray-3" :aria-pressed="isOpen">
+        <span class="flex items-center gap-1">
+          <component :is="icon" class="size-4" />
+          <LucideChevronDown class="size-3 text-ink-gray-5" />
+        </span>
+      </Button>
     </template>
     <template #default>
       <div class="p-4 flex flex-col gap-4 w-64">
@@ -51,6 +56,7 @@
 import { reactive, computed, watch } from 'vue'
 import { Popover, Button } from 'frappe-ui'
 import { FormControl, FormLabel } from 'frappe-ui'
+import LucideChevronDown from '~icons/lucide/chevron-down'
 import {
   DEFAULT_LINE_HEIGHT,
   toCssLineHeight,

--- a/frontend/src/apps/writer/components/ToC.vue
+++ b/frontend/src/apps/writer/components/ToC.vue
@@ -155,10 +155,14 @@ onMounted(() => {
     finishRenaming(false, false)
   }
 
-  props.editor.view.dom.addEventListener('tab-changed', handleTabChange)
+  // Held from mount: on teardown the editor view may already be destroyed, and
+  // tiptap's post-destroy `view` proxy throws on any key it doesn't stub (`dom`
+  // is one). Throwing here aborts Vue's unmount, so the next route never mounts.
+  const editorDom = props.editor.view.dom
+  editorDom.addEventListener('tab-changed', handleTabChange)
   onBeforeUnmount(() => {
     props.editor.off('update', updateTabs)
-    props.editor.view.dom.removeEventListener('tab-changed', handleTabChange)
+    editorDom.removeEventListener('tab-changed', handleTabChange)
   })
 })
 

--- a/frontend/src/apps/writer/components/ToCMobile.vue
+++ b/frontend/src/apps/writer/components/ToCMobile.vue
@@ -59,17 +59,24 @@ const selectTab = (id) => {
   if (id && id !== activeTabId.value) props.editor.commands.changeTab(id)
 }
 
+// Held from mount: on teardown the editor view may already be destroyed, and
+// tiptap's post-destroy `view` proxy throws on any key it doesn't stub (`dom`
+// is one). Throwing here aborts Vue's unmount, so the next route never mounts.
+let editorDom = null
+
 onMounted(() => {
   updateTabs()
   activeTabId.value = props.editor.storage.tab?.activeTabId ?? activeTabId.value
   props.editor.on('update', updateTabs)
-  props.editor.view.dom.addEventListener('tab-changed', handleTabChange)
+  editorDom = props.editor.view.dom
+  editorDom.addEventListener('tab-changed', handleTabChange)
 })
 
 onBeforeUnmount(() => {
   observer?.disconnect()
   setBarHeight(0)
   props.editor.off('update', updateTabs)
-  props.editor.view.dom.removeEventListener('tab-changed', handleTabChange)
+  editorDom?.removeEventListener('tab-changed', handleTabChange)
+  editorDom = null
 })
 </script>

--- a/frontend/src/apps/writer/components/core-editor/DropdownMenuGroup.vue
+++ b/frontend/src/apps/writer/components/core-editor/DropdownMenuGroup.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, computed, watch } from 'vue'
 import { Popover, Button } from 'frappe-ui'
+import LucideChevronDown from '~icons/lucide/chevron-down'
 
 const props = defineProps({
   // Passed by MenuItems.vue for all component items
@@ -9,6 +10,8 @@ const props = defineProps({
   // Fallback icon/label when no item is active
   defaultIcon: [String, Object],
   defaultLabel: { type: String, default: '' },
+  // Show the active item's name in the trigger instead of only its icon.
+  showLabel: { type: Boolean, default: false },
 })
 
 const isOpen = ref(false)
@@ -58,14 +61,30 @@ function run(item, event) {
        ignore that slot and render our own button so the icon can be reactive. -->
   <Popover v-model:open="isOpen" placement="bottom-start">
     <template #trigger>
+      <!-- Content goes in the default slot, not the `icon` prop: an `icon`
+           Button is square, and this trigger has to fit icon + chevron. -->
       <Button
         size="xs"
         variant="ghost"
-        :icon="triggerIcon"
-        :label="triggerLabel"
+        :aria-label="triggerLabel"
+        :tooltip="triggerLabel"
         class="aria-pressed:bg-surface-gray-3"
         :aria-pressed="isOpen"
-      />
+      >
+        <span class="flex items-center gap-1">
+          <span v-if="showLabel" class="truncate">{{ triggerLabel }}</span>
+          <!-- frappe-ui items carry a `lucide-*` class string; ours carry a
+               component. Button resolves both, but only through its icon
+               props, which we can't use here. -->
+          <span
+            v-else-if="typeof triggerIcon === 'string'"
+            :class="[triggerIcon, 'size-4']"
+            aria-hidden="true"
+          />
+          <component :is="triggerIcon" v-else class="size-4" />
+          <LucideChevronDown class="size-3 text-ink-gray-5" />
+        </span>
+      </Button>
     </template>
     <div class="flex flex-col p-1 w-40">
       <Button

--- a/frontend/src/apps/writer/components/core-editor/menu-buttons.js
+++ b/frontend/src/apps/writer/components/core-editor/menu-buttons.js
@@ -78,26 +78,48 @@ const IndentList = {
 const headingItems = [Paragraph, H1, H2, H3, H4]
 const alignItems = [AlignLeft, AlignCenter, AlignRight]
 
+// Clusters follow the reference toolbar: type & font, then character format,
+// then block format, then lists & flow, then inserts, then document tools.
 export function buildMenuButtons({ editor, settings, isPainting, openSettings }) {
   return [
-    // Heading type selector — dropdown group
+    // Block type selector — named in the trigger, like the reference's "Text".
     {
       label: 'Heading',
       icon: LucideHeading,
       component: h(DropdownMenuGroup, {
         items: headingItems,
         defaultIcon: LucideHeading,
-        defaultLabel: 'Heading',
+        defaultLabel: 'Paragraph',
+        showLabel: true,
       }),
       action: () => {},
     },
-    Separator,
+    {
+      label: 'FontOptions',
+      component: h(ManageFont, {
+        editor,
+        font_size: +settings.font_size || 15,
+        font_family: settings.font_family || 'inter',
+      }),
+      action: () => {},
+    },
     Bold,
     Italic,
     Underline,
     Strike,
-    InsertLink,
     FontColor,
+    Separator,
+    InlineCode,
+    Blockquote,
+    {
+      label: 'Page Break',
+      icon: LucideForm,
+      action: (e) => e.commands.setPageBreak(),
+    },
+    Separator,
+    BulletList,
+    OrderedList,
+    TaskListItem,
     // Alignment — dropdown group
     {
       label: 'Align',
@@ -109,6 +131,27 @@ export function buildMenuButtons({ editor, settings, isPainting, openSettings })
       }),
       action: () => {},
     },
+    {
+      label: 'Custom Spacing',
+      icon: LucideAlignVerticalSpacingAround,
+      component: h(SpacingDialogAsync, {
+        settings,
+        editor,
+        icon: LucideAlignVerticalSpacingAround,
+      }),
+      action: () => {},
+    },
+    DedentList,
+    IndentList,
+    Separator,
+    InsertLink,
+    InsertTable,
+    TableOfContentsItem,
+    Separator,
+    InsertImage,
+    InsertVideo,
+    InsertIframe,
+    Separator,
     {
       label: 'Paint Styles',
       icon: LucidePaintRoller,
@@ -128,52 +171,10 @@ export function buildMenuButtons({ editor, settings, isPainting, openSettings })
         e.commands.cleanStyles()
       },
     },
-    Separator,
-    {
-      label: 'FontOptions',
-      component: h(ManageFont, {
-        editor,
-        font_size: +settings.font_size || 15,
-        font_family: settings.font_family || 'inter',
-      }),
-      action: () => {},
-    },
-    Separator,
-    BulletList,
-    OrderedList,
-    TaskListItem,
-    Blockquote,
-    InlineCode,
-    Separator,
-    InsertImage,
-    InsertVideo,
-    InsertIframe,
-    Separator,
-    InsertTable,
-    TableOfContentsItem,
-    Separator,
-    {
-      label: 'Page Break',
-      icon: LucideForm,
-      action: (e) => e.commands.setPageBreak(),
-    },
-    {
-      label: 'Custom Spacing',
-      icon: LucideAlignVerticalSpacingAround,
-      component: h(SpacingDialogAsync, {
-        settings,
-        editor,
-        icon: LucideAlignVerticalSpacingAround,
-      }),
-      action: () => {},
-    },
     {
       icon: LucideSettings,
       label: 'Settings',
       action: openSettings,
     },
-    Separator,
-    DedentList,
-    IndentList,
   ]
 }


### PR DESCRIPTION
> [!WARNING]
> Don't merge yet 

Three independent Writer fixes, one commit each.

## Back navigation left the list blank

`ToC` and `ToCMobile` read `editor.view.dom` in `beforeUnmount`. The editor is destroyed by then, and tiptap's post-destroy `view` proxy throws on any key it does not stub. The throw aborted Vue's unmount, so the route changed but the old component stayed mounted and the list never rendered.

Both components now hold the DOM node from mount.

## Writer list uses frappe-ui/list

`List` / `ListGroup` / `ListRow` / `ListCell` with inset dividers, matching Drive's `ListView`. Inset dividers span `2 / -1`, so the first track is a leading icon cell and dividers start under the title.

The grid header mirrors `ListGroup`'s header box (h-8, text-sm-medium, sticky, px-3), so switching between grid and list shifts nothing. Grid shows 5 per row.

Before

![Before](https://github.com/user-attachments/assets/4dbf4d87-c6c1-4cee-b7d7-3e2fb4c91c6c)

After

![After](https://github.com/user-attachments/assets/b7214a5e-b9a9-4bc7-a025-27ced9d45d3c)

Grid, same header box and 5 per row:

Before

![Before](https://github.com/user-attachments/assets/8e58aab3-8305-42fd-8aea-2b4f58e39cba)

After

![After](https://github.com/user-attachments/assets/d0014a5f-0d23-4f79-80e8-aa20fa810d9b)


## Toolbar regrouped

Clusters: block type and font, character format, block format, lists and flow, inserts, document tools.

- Font size is a `- 15 +` stepper, clamped 8-96.
- Font family is a compact `Inter` trigger, not a 200px boxed Combobox. `FontSelect` forwards Combobox's `#trigger` slot for it.
- Dropdown triggers carry a chevron. The block-type trigger names the active type ("Paragraph", "Heading 2") instead of showing a bare `T`.

Before

![Before](https://github.com/user-attachments/assets/6db6fcd0-196a-40b5-989a-eb2c7413c6cb)

After

![After](https://github.com/user-attachments/assets/6f0766cb-624e-42ff-96a8-937942d38fc7)


## Verified

- New e2e specs for browser back and for "Back to Home"; both fail without the fix.
- 16 Writer specs and 3 drive-writer specs pass.
- Vitest: 1596 passed.
- `yarn build` clean.
- Toolbar checked by hand at 1440px: stepper writes `font-size` to the document, font family sets `--font-geist`, block type applies and relabels, align and spacing popovers open. No console errors.

## Not covered

- No e2e spec asserts the toolbar layout.
- `FloatingComments.vue:410` still throws an uncaught TypeError on teardown when a document has comments. It does not block navigation. Left for a separate fix.

