### PR TITLE
fix(slides): table resize preview snapping back mid-drag

### DIFF
--- a/frontend/src/apps/slides/components/TableElement.vue
+++ b/frontend/src/apps/slides/components/TableElement.vue
@@ -28,7 +28,12 @@ import {
 	getDefaultGridColor,
 	isBackgroundColorDark,
 } from '@/apps/slides/utils/color'
-import { getColumnWidths, getTableWidth } from '@/apps/slides/utils/tableWidths'
+import {
+	frameResizeAttribute,
+	getTableWidth,
+	restoreColumnWidths,
+	stretchColumnsToFrame,
+} from '@/apps/slides/utils/tableWidths'
 import { isResizingColumn } from '@/apps/slides/utils/columnResizing'
 import { selectionColor } from '@/apps/slides/utils/constants'
 
@@ -138,28 +143,22 @@ const handleMouseDown = (e) => {
 	)
 }
 
-// the editor redraws the colgroup from the document on any update, so the preview
-// widths have to be rewritten at every step of the drag
+// the mark and the preview go on together, so a redraw between them can put it back
 watch(
 	() => interactionOffset.width,
 	(offset) => {
 		if (!showEditor.value) return
 
 		const table = getTable()
-		const row = table?.querySelector('tr')
-		if (!row) return
+		if (!table) return
 
-		const cols = Array.from(table.querySelectorAll('col'))
-		const widths = Array.from(row.children).flatMap(getColumnWidths)
-		if (cols.length !== widths.length || widths.some((width) => !width)) return
-
-		const resizing = Boolean(offset)
-		const total = widths.reduce((sum, width) => sum + width, 0)
-
-		table.style.width = resizing ? '100%' : `${total}px`
-		cols.forEach((col, index) => {
-			col.style.width = resizing ? `${(widths[index] / total) * 100}%` : `${widths[index]}px`
-		})
+		if (offset) {
+			table.setAttribute(frameResizeAttribute, '')
+			stretchColumnsToFrame(table)
+		} else {
+			table.removeAttribute(frameResizeAttribute)
+			restoreColumnWidths(table)
+		}
 	},
 )
 

--- a/frontend/src/apps/slides/utils/columnResizing.test.ts
+++ b/frontend/src/apps/slides/utils/columnResizing.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/apps/slides/utils/mediaUploads', () => ({ getAttachmentUrl: () => '' }))
 
 import { Schema } from 'prosemirror-model'
+import type { Node as ProseMirrorNode } from 'prosemirror-model'
 import { EditorState } from 'prosemirror-state'
 import { columnResizing, tableNodes } from 'prosemirror-tables'
 
@@ -56,5 +59,60 @@ describe('scaleAwareColumnResizing', () => {
 		EditorState.create({ schema, plugins: [plugin] })
 
 		expect(typeof plugin.spec.props!.nodeViews!.table).toBe('function')
+	})
+})
+
+type TableNodeView = {
+	dom: HTMLTableElement
+	contentDOM: HTMLElement
+	update: (node: ProseMirrorNode) => boolean
+}
+
+describe('the table node view', () => {
+	const cell = (width: number) =>
+		schema.nodes.table_cell.create({ colwidth: [width] }, schema.nodes.paragraph.create())
+
+	const tableNode = (widths: number[]) =>
+		schema.nodes.table.create(null, schema.nodes.table_row.create(null, widths.map(cell)))
+
+	const buildNodeView = (widths: number[]) => {
+		const plugin = scaleAwareColumnResizing({ cellMinWidth: 25, defaultCellMinWidth: 25 })
+		EditorState.create({ schema, plugins: [plugin] })
+
+		const buildView = plugin.spec.props!.nodeViews!.table as never as (
+			node: ProseMirrorNode,
+		) => TableNodeView
+
+		const node = tableNode(widths)
+		const nodeView = buildView(node)
+
+		// the cells the editor would fill the tbody with
+		nodeView.contentDOM.innerHTML = `<tr>${widths
+			.map((width) => `<td colwidth="${width}"><p>a</p></td>`)
+			.join('')}</tr>`
+
+		return { node, nodeView }
+	}
+
+	const colWidths = (dom: HTMLTableElement) =>
+		Array.from(dom.querySelectorAll('col')).map((col) => col.style.width)
+
+	it('draws the widths the document states', () => {
+		const { node, nodeView } = buildNodeView([100, 300])
+
+		nodeView.update(node)
+
+		expect(nodeView.dom.style.width).toBe('400px')
+		expect(colWidths(nodeView.dom)).toEqual(['100px', '300px'])
+	})
+
+	it('keeps the frame resize preview through a redraw', () => {
+		const { node, nodeView } = buildNodeView([100, 300])
+		nodeView.dom.setAttribute('data-frame-resizing', '')
+
+		nodeView.update(node)
+
+		expect(nodeView.dom.style.width).toBe('100%')
+		expect(colWidths(nodeView.dom)).toEqual(['25%', '75%'])
 	})
 })

--- a/frontend/src/apps/slides/utils/columnResizing.ts
+++ b/frontend/src/apps/slides/utils/columnResizing.ts
@@ -19,6 +19,8 @@ import {
 } from 'prosemirror-tables'
 import type { Node as ProseMirrorNode } from 'prosemirror-model'
 
+import { frameResizeAttribute, stretchColumnsToFrame } from './tableWidths'
+
 interface Dragging {
 	startX: number
 	startWidth: number
@@ -44,10 +46,13 @@ class BareTableView {
 		this.contentDOM = this.dom.appendChild(document.createElement('tbody'))
 	}
 
+	// hovering a column edge is an update of its own, so a redraw lands mid frame drag
+	// and writes the document's pixels over the preview
 	update(node: ProseMirrorNode) {
 		if (node.type != this.node.type) return false
 		this.node = node
 		updateColumnsOnResize(node, this.colgroup, this.dom, this.defaultCellMinWidth)
+		if (this.dom.hasAttribute(frameResizeAttribute)) stretchColumnsToFrame(this.dom)
 		return true
 	}
 

--- a/frontend/src/apps/slides/utils/tableWidths.test.ts
+++ b/frontend/src/apps/slides/utils/tableWidths.test.ts
@@ -2,9 +2,14 @@ import { describe, it, expect, vi } from 'vitest'
 
 vi.mock('@/apps/slides/utils/mediaUploads', () => ({ getAttachmentUrl: () => '' }))
 
-const { getMinTableWidth, getTableInfo, getTableWidth, rescaleColumnWidths } = await import(
-	'./tableWidths',
-)
+const {
+	getMinTableWidth,
+	getTableInfo,
+	getTableWidth,
+	rescaleColumnWidths,
+	restoreColumnWidths,
+	stretchColumnsToFrame,
+} = await import('./tableWidths')
 
 // what tiptap serializes: the widths on the cells, everything else derived from them
 const table = (widths: number[], total = widths.reduce((sum, width) => sum + width, 0)) =>
@@ -51,6 +56,48 @@ describe('rescaleColumnWidths', () => {
 
 		expect(rescaleColumnWidths(content, 1.5)).toBe(null)
 		expect(getTableWidth(content)).toBe(null)
+	})
+})
+
+describe('the frame resize preview', () => {
+	const render = (content: string) => {
+		const host = document.createElement('div')
+		host.innerHTML = content
+		return host.querySelector('table')!
+	}
+
+	const colWidths = (rendered: HTMLTableElement) =>
+		Array.from(rendered.querySelectorAll('col')).map((col) => col.style.width)
+
+	it('hands every column its share of the frame', () => {
+		const rendered = render(table([100, 300]))
+
+		stretchColumnsToFrame(rendered)
+
+		expect(rendered.style.width).toBe('100%')
+		expect(colWidths(rendered)).toEqual(['25%', '75%'])
+	})
+
+	it('puts the pixels the document states back', () => {
+		const rendered = render(table([100, 300]))
+
+		stretchColumnsToFrame(rendered)
+		restoreColumnWidths(rendered)
+
+		expect(rendered.style.width).toBe('400px')
+		expect(colWidths(rendered)).toEqual(['100px', '300px'])
+	})
+
+	it('leaves a table whose columns carry no widths alone', () => {
+		const rendered = render(
+			'<table><colgroup><col></colgroup><tbody><tr><td>a</td></tr></tbody></table>',
+		)
+
+		stretchColumnsToFrame(rendered)
+		restoreColumnWidths(rendered)
+
+		expect(rendered.style.width).toBe('')
+		expect(colWidths(rendered)).toEqual([''])
 	})
 })
 

--- a/frontend/src/apps/slides/utils/tableWidths.ts
+++ b/frontend/src/apps/slides/utils/tableWidths.ts
@@ -4,7 +4,7 @@
 
 import { getDocFromHTML } from './helpers'
 
-export const getColumnWidths = (cell: Element) =>
+const getColumnWidths = (cell: Element) =>
 	(cell.getAttribute('colwidth') || '').split(',').map((width) => parseInt(width, 10))
 
 const getFirstRow = (content: string) => getDocFromHTML(content || '').body.querySelector('tr')
@@ -160,4 +160,40 @@ export const rescaleColumnWidths = (content: string, ratio: number, cellMinWidth
 	table.style.minWidth = ''
 
 	return { content: doc.body.innerHTML, width: parseFloat(table.style.width) }
+}
+
+// on the table for as long as its frame is being dragged
+export const frameResizeAttribute = 'data-frame-resizing'
+
+const readRenderedColumns = (table: HTMLTableElement) => {
+	const row = table.querySelector('tr')
+	if (!row) return null
+
+	const cols = Array.from(table.querySelectorAll('col'))
+	const widths = Array.from(row.children).flatMap(getColumnWidths)
+	if (!widths.length || widths.length !== cols.length) return null
+	if (widths.some((width) => !width)) return null
+
+	return { cols, widths, total: widths.reduce((sum, width) => sum + width, 0) }
+}
+
+// pixel columns would hold the table at its old size inside a moving frame, shares follow it
+export const stretchColumnsToFrame = (table: HTMLTableElement) => {
+	const columns = readRenderedColumns(table)
+	if (!columns) return
+
+	table.style.width = '100%'
+	columns.cols.forEach((col, index) => {
+		col.style.width = `${(columns.widths[index] / columns.total) * 100}%`
+	})
+}
+
+export const restoreColumnWidths = (table: HTMLTableElement) => {
+	const columns = readRenderedColumns(table)
+	if (!columns) return
+
+	table.style.width = `${columns.total}px`
+	columns.cols.forEach((col, index) => {
+		col.style.width = `${columns.widths[index]}px`
+	})
 }


### PR DESCRIPTION
- Dragging a table's frame kept flashing back to the original width. Hovering a column edge dispatches a transaction, and the table node view redraws its colgroup in the document's pixel widths, overwriting the live preview.
- The table is now marked while its frame is being dragged, and the node view re-applies the percentage preview.
- Scoped to the dragged table via that mark. Nothing touches the document, `element.width`, or any other element type, and column dragging is unchanged.