### PR TITLE
docs: add migration guide from standalone apps to Suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,57 @@ Frappe Suite brings seven collaboration products into one Frappe app. Keep files
 - [**Hocuspocus**](https://github.com/ueberdosis/hocuspocus): Runs the collaboration server used for realtime spreadsheet editing in Sheets.
 - [**mediasoup**](https://github.com/versatica/mediasoup): Powers Meet's WebRTC selective forwarding unit for group video calls.
 
+## Migrating from the Standalone Apps
+
+Frappe Suite ships the same modules and DocTypes as the standalone apps, so it cannot be installed on a site that still has any of them — installation aborts with a message listing the conflicting apps. To move an existing site to Suite:
+
+1. **Take a backup of the site**, including files.
+2. **Uninstall all the standalone apps** (Drive, Writer, Sheets, Slides, Meet, Mail, Calendar). Uninstalling deletes each app's data on the site, which is why the backup comes first.
+3. **Install Frappe Suite.**
+4. **Restore the backup.** Suite uses the same tables, so the restored data is picked up as-is.
+
+The same steps apply to sites hosted on [Frappe Cloud](https://frappecloud.com): download a backup from the site dashboard (**Backups**), remove the standalone apps from the **Apps** tab, install Frappe Suite, and then restore the backup from **Backups → Restore**.
+
+### Migrating with bench
+
+```bash
+# 1. Back up the site along with its public and private files
+bench --site yoursite backup --with-files
+
+# 2. Uninstall every standalone app present on the site
+#    (run only the lines for the apps your site actually has)
+bench --site yoursite uninstall-app drive
+bench --site yoursite uninstall-app writer
+bench --site yoursite uninstall-app sheets
+bench --site yoursite uninstall-app slides
+bench --site yoursite uninstall-app meet
+bench --site yoursite uninstall-app mail
+bench --site yoursite uninstall-app calendar_app
+
+# 3. Install Frappe Suite
+bench get-app https://github.com/frappe/suite
+bench --site yoursite install-app suite
+
+# 4. Restore the backup taken in step 1
+bench --site yoursite restore sites/yoursite/private/backups/<timestamp>-database.sql.gz \
+	--with-public-files sites/yoursite/private/backups/<timestamp>-files.tar \
+	--with-private-files sites/yoursite/private/backups/<timestamp>-private-files.tar
+```
+
+The restored database still lists the standalone apps as installed, so point the site at Suite and migrate:
+
+```bash
+bench --site yoursite remove-from-installed-apps drive
+bench --site yoursite remove-from-installed-apps writer
+bench --site yoursite remove-from-installed-apps sheets
+bench --site yoursite remove-from-installed-apps slides
+bench --site yoursite remove-from-installed-apps meet
+bench --site yoursite remove-from-installed-apps mail
+bench --site yoursite remove-from-installed-apps calendar_app
+bench --site yoursite install-app suite
+bench --site yoursite migrate
+```
+
 ## Development Setup
 
 Install [Bench](https://github.com/frappe/bench) and create a Frappe site by following the [Frappe Framework installation guide](https://docs.frappe.io/framework/user/en/installation).

--- a/suite/suite_core/boot.py
+++ b/suite/suite_core/boot.py
@@ -35,8 +35,18 @@ def before_install():
         frappe.throw(
             _(
                 "Cannot install Frappe Suite because the following standalone app(s) are installed on this site: {0}. "
-                "Frappe Suite already includes them. Please uninstall these app(s) first, then install Frappe Suite."
-            ).format(", ".join(frappe.bold(app) for app in conflicting))
+                "Frappe Suite already includes them.\n\n"
+                "To migrate this site to Frappe Suite:\n"
+                "1. Take a backup of the site, including files.\n"
+                "2. Uninstall the standalone app(s) listed above. This deletes their data on the site, which is why the backup comes first.\n"
+                "3. Install Frappe Suite.\n"
+                "4. Restore the backup, then follow the post-restore steps in the migration guide.\n\n"
+                "The same steps apply to sites hosted on Frappe Cloud. "
+                "See {1} for the full commands."
+            ).format(
+                ", ".join(frappe.bold(app) for app in conflicting),
+                "https://github.com/frappe/suite#migrating-from-the-standalone-apps",
+            )
         )
 
 


### PR DESCRIPTION
Suite cannot be installed on a site that still has any of the standalone apps (the `before_install` check aborts with an error). This PR documents how to actually get from the standalone apps to Suite:

- **README**: new "Migrating from the Standalone Apps" section with the four-step flow (backup → uninstall standalone apps → install Suite → restore), a note that the same steps apply on Frappe Cloud, and the full `bench` command walkthrough — including the post-restore `remove-from-installed-apps` / `install-app suite` / `migrate` reconciliation, since a full restore brings back the old installed-apps list.
- **Validation message**: `before_install` now includes the same numbered steps and links to the README section, so users who try to install Suite directly get the migration path without having to find the repo readme.
