### PR TITLE
feat(slides): indent lines with tab and keep whitespace in text

### DIFF
--- a/frontend/src/apps/slides/components/TextElement.vue
+++ b/frontend/src/apps/slides/components/TextElement.vue
@@ -213,6 +213,11 @@ onBeforeMount(() => normalizeContent())
 	overflow-wrap: break-word;
 }
 
+/* the browser's own stop is 8 characters, which on a slide reads as a gap */
+.textElement {
+	tab-size: 4;
+}
+
 /* use CSS variable set on container to apply legacy element line-height without
    mutating inner HTML. Inline styles on <p> will still take precedence. */
 .textElement p,

--- a/frontend/src/apps/slides/composables/textIndentation.test.ts
+++ b/frontend/src/apps/slides/composables/textIndentation.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+vi.mock('@/apps/slides/utils/mediaUploads', () => ({ getAttachmentUrl: () => '' }))
+vi.mock('@/apps/slides/router', () => ({ router: { replace: () => Promise.resolve() } }))
+
+const { slides, slideIndex } = await import('@/apps/slides/stores/slide')
+const { focusElementId } = await import('@/apps/slides/stores/element')
+const { useTextEditor } = await import('./useTextEditor')
+
+const { activeEditor } = useTextEditor()
+
+const indented = '<p>def foo():</p><p>    return 1</p>'
+const indentedLine = '<p><span style="font-size: 20px">    b</span></p>'
+
+const editText = async (content: string) => {
+	slides.value = [{ clientId: 'c1', elements: [{ id: 't1', type: 'text', content }] }]
+	slideIndex.value = 0
+	focusElementId.value = 't1'
+	await nextTick()
+	await nextTick()
+}
+
+const lines = () => {
+	const texts: string[] = []
+	activeEditor.value.state.doc.descendants((node) => {
+		if (node.type.name === 'paragraph') texts.push(node.textContent)
+	})
+	return texts
+}
+
+afterEach(() => {
+	activeEditor.value?.destroy()
+	activeEditor.value = null
+	focusElementId.value = null
+	slides.value = []
+})
+
+// prosemirror's default parse drops a line's leading spaces, so indentation only
+// lasted until the element was read back into an editor
+describe('indentation through a parse', () => {
+	it('keeps the leading spaces of a line the editor opens on', async () => {
+		await editText(indented)
+
+		expect(lines()).toEqual(['def foo():', '    return 1'])
+	})
+
+	it('keeps them when history rewrites the content underneath the editor', async () => {
+		await editText(indented)
+
+		slides.value[0].elements[0].content = '<p>def foo():</p><p>    return 2</p>'
+		await nextTick()
+
+		expect(lines()).toEqual(['def foo():', '    return 2'])
+	})
+
+	it('writes them back out to the stored content', async () => {
+		await editText(indented)
+
+		expect(activeEditor.value.getHTML()).toContain('    return 1')
+	})
+
+	// a line left holding only its indent reads as empty to patchEmptyParagraphs, and
+	// the placeholder it writes must not read back as a change and reset the editor
+	it('holds the caret where it was when a line is erased down to its indent', async () => {
+		await editText('<p><span style="font-size: 20px">a</span></p>' + indentedLine)
+
+		activeEditor.value.commands.setTextSelection({ from: 8, to: 9 })
+		activeEditor.value.commands.deleteSelection()
+		await nextTick()
+
+		expect(activeEditor.value.state.selection.from).toBe(8)
+		expect(slides.value[0].elements[0].content).toContain('<span style="font-size: 20px;">')
+	})
+
+	// a cell's static render collapses whitespace the way the browser lays out any
+	// table, so keeping it in the editor would draw the two differently
+	it('leaves the whitespace in a table cell collapsed', async () => {
+		slides.value = [
+			{
+				clientId: 'c1',
+				elements: [
+					{
+						id: 't1',
+						type: 'table',
+						content: '<table><tbody><tr><td><p>    a  b</p></td></tr></tbody></table>',
+					},
+				],
+			},
+		] as any
+		slideIndex.value = 0
+		focusElementId.value = 't1'
+		await nextTick()
+		await nextTick()
+
+		expect(lines()).toEqual(['a b'])
+	})
+
+	it('reads no line out of the gaps in indented html', async () => {
+		await editText('<p>one</p>\n\t<p>two</p>\n')
+
+		expect(lines()).toEqual(['one', 'two'])
+	})
+})

--- a/frontend/src/apps/slides/composables/useTextEditor.js
+++ b/frontend/src/apps/slides/composables/useTextEditor.js
@@ -17,6 +17,10 @@ import { currentSlide } from '@/apps/slides/stores/slide'
 
 export const activeEditor = ref(null)
 
+// the default parse drops a line's leading spaces, so indentation lasts only until the
+// content is read back. 'full' would turn the gaps in pretty-printed HTML into lines
+const parseOptions = { preserveWhitespace: true }
+
 // the element this editor was built for: activeElement flips a tick earlier
 let editorElement = null
 let editorSlideId = null
@@ -65,7 +69,9 @@ const reconcileEditorContent = (html) => {
 	if (html == null) {
 		if (activeElement.value?.type !== 'shape') return
 		const seed = getInitialShapeTextContent(activeElement.value)
-		withRecordingSuppressed(() => editor.commands.setContent(seed, { emitUpdate: false }))
+		withRecordingSuppressed(() =>
+			editor.commands.setContent(seed, { emitUpdate: false, parseOptions }),
+		)
 		return
 	}
 
@@ -73,7 +79,7 @@ const reconcileEditorContent = (html) => {
 
 	// setContent replaces the whole doc, mapping the selection to its end. the two
 	// documents differ over one range, so a caret past it moves by the size change
-	const incoming = createDocument(html, editor.schema)
+	const incoming = createDocument(html, editor.schema, parseOptions)
 	const { content } = editor.state.doc
 	const start = content.findDiffStart(incoming.content)
 	const { a: endHere, b: endThere } = start == null ? {} : content.findDiffEnd(incoming.content)
@@ -88,7 +94,7 @@ const reconcileEditorContent = (html) => {
 	})
 
 	withRecordingSuppressed(() => {
-		editor.commands.setContent(html, { emitUpdate: false })
+		editor.commands.setContent(html, { emitUpdate: false, parseOptions })
 		// between, so that endpoints a cell selection left on cell boundaries come back
 		// as the nearest position that can hold a caret
 		editor.commands.command(({ tr }) => {
@@ -383,6 +389,7 @@ export const useTextEditor = () => {
 				extensions: extensions,
 				editable: isEditable,
 				content: content,
+				parseOptions,
 				// focus only lands once EditorContent has adopted the view, so tiptap
 				// has to do it itself after mounting. 'all' inside a table would
 				// select every cell, so tables start with a cursor in the first one

--- a/frontend/src/apps/slides/stores/blurOnSlideChange.test.ts
+++ b/frontend/src/apps/slides/stores/blurOnSlideChange.test.ts
@@ -74,6 +74,22 @@ describe('leaving a slide while a text element is focused', () => {
 		expect(recorded.map((c) => c.jumpToSlideId)).toEqual(['A'])
 	})
 
+	// the editor keeps the spaces a line was indented by, and a box holding only
+	// those still looks empty to the person who left it behind
+	it('deletes a text box left holding nothing but whitespace', async () => {
+		editorState.text = '    '
+		editorState.html = '<p><span style="font-size: 16px">    </span></p>'
+
+		activeElementIds.value = ['t1']
+		focusElementId.value = 't1'
+		for (let i = 0; i < 4; i++) await nextTick()
+
+		changeEditorSlide(1)
+		for (let i = 0; i < 6; i++) await nextTick()
+
+		expect(slides.value[0].elements).toEqual([])
+	})
+
 	// legacy content keeps patchEmptyParagraphs reporting an update forever, so
 	// the save must become a no-op by comparison against the stored content, or
 	// the watch's second blur-save pairs magic-move refIds against the new slide

--- a/frontend/src/apps/slides/stores/blurOnSlideChange.test.ts
+++ b/frontend/src/apps/slides/stores/blurOnSlideChange.test.ts
@@ -90,6 +90,22 @@ describe('leaving a slide while a text element is focused', () => {
 		expect(slides.value[0].elements).toEqual([])
 	})
 
+	// a box of blank lines is a spacer someone placed on purpose, and getText
+	// joins its lines, so reading whitespace loosely would delete it
+	it('keeps a text box holding blank lines', async () => {
+		editorState.text = '​\n\n​\n\n​'
+		editorState.html = '<p><span style="font-size: 16px">​</span></p>'.repeat(3)
+
+		activeElementIds.value = ['t1']
+		focusElementId.value = 't1'
+		for (let i = 0; i < 4; i++) await nextTick()
+
+		changeEditorSlide(1)
+		for (let i = 0; i < 6; i++) await nextTick()
+
+		expect(slides.value[0].elements.map((e: any) => e.id)).toEqual(['t1'])
+	})
+
 	// legacy content keeps patchEmptyParagraphs reporting an update forever, so
 	// the save must become a no-op by comparison against the stored content, or
 	// the watch's second blur-save pairs magic-move refIds against the new slide

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -1064,7 +1064,9 @@ const updateElementContent = (element) => {
 // empty cells are still a table, only a deleted one leaves nothing to edit
 const isEditorEmpty = (element) => {
 	if (element.type === 'table') return !hasTableNode(activeEditor.value.state.doc)
-	return !activeEditor.value.getText().replace(/\u200B/g, '')
+	// indentation survives the parse now, so a box holding nothing else has to keep
+	// reading as the empty one it looks like
+	return !activeEditor.value.getText().replace(/\u200B/g, '').trim()
 }
 
 const blurAndSaveContent = (element) => {

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -1065,8 +1065,9 @@ const updateElementContent = (element) => {
 const isEditorEmpty = (element) => {
 	if (element.type === 'table') return !hasTableNode(activeEditor.value.state.doc)
 	// indentation survives the parse now, so a box holding nothing else has to keep
-	// reading as the empty one it looks like
-	return !activeEditor.value.getText().replace(/\u200B/g, '').trim()
+	// reading as the empty one it looks like. the line breaks stay, or a box of
+	// blank lines starts reading as empty too
+	return !activeEditor.value.getText().replace(/[\u200B\t ]/g, '')
 }
 
 const blurAndSaveContent = (element) => {

--- a/frontend/src/apps/slides/stores/lineIndent.test.ts
+++ b/frontend/src/apps/slides/stores/lineIndent.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+import { Editor } from '@tiptap/vue-3'
+
+vi.mock('@/apps/slides/utils/mediaUploads', () => ({ getAttachmentUrl: () => '' }))
+
+const { extensions, ZWSP } = await import('./tiptapSetup')
+
+let editor: Editor | null = null
+
+const mountEditor = (content: string) => {
+	const element = document.createElement('div')
+	document.body.appendChild(element)
+	editor = new Editor({ element, extensions, content, parseOptions: { preserveWhitespace: true } })
+	return editor
+}
+
+const pressTab = (editor: Editor, shift = false) =>
+	editor.view.dom.dispatchEvent(
+		new KeyboardEvent('keydown', { key: 'Tab', shiftKey: shift, bubbles: true, cancelable: true }),
+	)
+
+const lines = (editor: Editor) => {
+	const texts: string[] = []
+	editor.state.doc.descendants((node) => {
+		if (node.isTextblock) texts.push(node.textContent)
+	})
+	return texts
+}
+
+const caretAt = (editor: Editor, text: string, offset: number) => {
+	let start = -1
+	editor.state.doc.descendants((node, pos) => {
+		if (node.isTextblock && node.textContent === text) start = pos + 1
+	})
+	editor.commands.setTextSelection(start + offset)
+}
+
+afterEach(() => {
+	editor?.destroy()
+	editor = null
+})
+
+describe('indenting a line with tab', () => {
+	it('writes the indent where the caret stands', () => {
+		const editor = mountEditor('<p>return 1</p>')
+		caretAt(editor, 'return 1', 0)
+
+		pressTab(editor)
+
+		expect(lines(editor)).toEqual(['\treturn 1'])
+	})
+
+	it('indents every line a selection reaches, from their starts', () => {
+		const editor = mountEditor('<p>def foo():</p><p>return 1</p>')
+		editor.commands.setTextSelection({ from: 3, to: 15 })
+
+		pressTab(editor)
+
+		expect(lines(editor)).toEqual(['\tdef foo():', '\treturn 1'])
+	})
+
+	it('takes the indent back off', () => {
+		const editor = mountEditor('<p>\treturn 1</p>')
+		caretAt(editor, '\treturn 1', 1)
+
+		pressTab(editor, true)
+
+		expect(lines(editor)).toEqual(['return 1'])
+	})
+
+	it('leaves a line that has no indent alone', () => {
+		const editor = mountEditor('<p>return 1</p>')
+		caretAt(editor, 'return 1', 0)
+
+		pressTab(editor, true)
+
+		expect(lines(editor)).toEqual(['return 1'])
+	})
+
+	it('indents a blank line without displacing its placeholder', () => {
+		const editor = mountEditor(`<p><span style="font-size: 20px">${ZWSP}</span></p>`)
+		caretAt(editor, ZWSP, 1)
+
+		pressTab(editor)
+
+		expect(lines(editor)).toEqual([`${ZWSP}\t`])
+		expect(editor.getHTML()).toContain('font-size: 20px')
+	})
+
+	it('carries the line styles onto the indent it writes', () => {
+		const editor = mountEditor('<p><span style="font-size: 20px">return 1</span></p>')
+		caretAt(editor, 'return 1', 0)
+
+		pressTab(editor)
+
+		expect(editor.getHTML()).toContain('<span style="font-size: 20px;">\treturn 1</span>')
+	})
+
+	it('still nests a list item rather than indenting inside it', () => {
+		const editor = mountEditor('<ul><li><p>one</p></li><li><p>two</p></li></ul>')
+		caretAt(editor, 'two', 0)
+
+		pressTab(editor)
+
+		expect(lines(editor)).toEqual(['one', 'two'])
+		expect(editor.state.selection.$from.node(-3).type.name).toBe('listItem')
+	})
+
+	it('leaves the item that cannot nest as it is', () => {
+		const editor = mountEditor('<ul><li><p>one</p></li></ul>')
+		caretAt(editor, 'one', 0)
+
+		pressTab(editor)
+
+		expect(lines(editor)).toEqual(['one'])
+	})
+
+	it('still moves between cells rather than indenting inside one', () => {
+		const editor = mountEditor(
+			'<table><tbody><tr><td><p>a</p></td><td><p>b</p></td></tr></tbody></table>',
+		)
+		caretAt(editor, 'a', 1)
+
+		pressTab(editor)
+
+		expect(lines(editor)).toEqual(['a', 'b'])
+		expect(editor.state.selection.$from.parent.textContent).toBe('b')
+	})
+})

--- a/frontend/src/apps/slides/stores/tiptapSetup.js
+++ b/frontend/src/apps/slides/stores/tiptapSetup.js
@@ -742,11 +742,19 @@ const StyledEmptyLine = Extension.create({
 
 const INDENT = '\t'
 
+// nodesBetween reaches a block the selection only touches the edge of, which is
+// one the user never selected any of
 const getSelectedTextblocks = (state) => {
+	const { from, to, empty } = state.selection
 	const blocks = []
-	state.doc.nodesBetween(state.selection.from, state.selection.to, (node, pos) => {
-		if (node.isTextblock) blocks.push({ node, pos })
+
+	state.doc.nodesBetween(from, to, (node, pos) => {
+		if (!node.isTextblock) return
+
+		const start = pos + 1
+		if (empty || (start < to && start + node.content.size > from)) blocks.push({ node, pos })
 	})
+
 	return blocks
 }
 

--- a/frontend/src/apps/slides/stores/tiptapSetup.js
+++ b/frontend/src/apps/slides/stores/tiptapSetup.js
@@ -740,6 +740,82 @@ const StyledEmptyLine = Extension.create({
 	},
 })
 
+const INDENT = '\t'
+
+const getSelectedTextblocks = (state) => {
+	const blocks = []
+	state.doc.nodesBetween(state.selection.from, state.selection.to, (node, pos) => {
+		if (node.isTextblock) blocks.push({ node, pos })
+	})
+	return blocks
+}
+
+// the indent goes after a blank line's placeholder, which holds its styles
+const readLineStart = (node, pos) => {
+	const heldByPlaceholder = node.textContent.startsWith(ZWSP)
+
+	return {
+		pos: pos + 1 + (heldByPlaceholder ? 1 : 0),
+		text: heldByPlaceholder ? node.textContent.slice(1) : node.textContent,
+	}
+}
+
+const addIndent = ({ editor }) => {
+	const { state, dispatch } = editor.view
+	// a list item nests instead, and the one that cannot nest keeps its place
+	if (isInList(state.selection.$from)) return true
+
+	const { tr, selection, schema } = state
+	const blocks = getSelectedTextblocks(state)
+
+	if (blocks.length < 2) {
+		tr.replaceWith(selection.from, selection.to, schema.text(INDENT, getMarksForPlaceholder(state)))
+	} else {
+		blocks.reverse().forEach(({ node, pos }) => {
+			tr.insert(readLineStart(node, pos).pos, schema.text(INDENT, getFirstMarks(node)))
+		})
+	}
+
+	dispatch(tr)
+	return true
+}
+
+const removeIndent = ({ editor }) => {
+	const { state, dispatch } = editor.view
+	if (isInList(state.selection.$from)) return true
+
+	const { tr } = state
+	let outdented = false
+
+	getSelectedTextblocks(state)
+		.reverse()
+		.forEach(({ node, pos }) => {
+			const line = readLineStart(node, pos)
+			if (!line.text.startsWith(INDENT)) return
+
+			tr.delete(line.pos, line.pos + 1)
+			outdented = true
+		})
+
+	if (outdented) dispatch(tr)
+
+	// swallow the key even when there was nothing to outdent, else focus leaves the element
+	return true
+}
+
+// runs last of the tab bindings, so tables and lists keep theirs
+const LineIndent = Extension.create({
+	name: 'lineIndent',
+	priority: 50,
+
+	addKeyboardShortcuts() {
+		return {
+			Tab: addIndent,
+			'Shift-Tab': removeIndent,
+		}
+	},
+})
+
 const updateParagraphHTML = (doc, p, prevSpanStyles) => {
 	p.innerHTML = ''
 
@@ -1021,6 +1097,7 @@ export const extensions = [
 		keepMarks: true,
 	}),
 	StyledEmptyLine,
+	LineIndent,
 	LineHeight,
 	Selection.configure({ className: 'persisted-selection' }),
 	// resizing is app-level: prosemirror's column resizing math ignores canvas scale

--- a/frontend/src/apps/slides/stores/tiptapSetup.js
+++ b/frontend/src/apps/slides/stores/tiptapSetup.js
@@ -856,6 +856,15 @@ const withCellAttributes = (extension) =>
 		addAttributes() {
 			return { ...this.parent?.(), ...cellAttributes }
 		},
+		// a cell is laid out by the browser's table rules, which collapse whitespace in
+		// the static render but not in the editor. Keeping the indentation a text
+		// element now reads back would only make the two disagree
+		parseHTML() {
+			return (this.parent?.() || []).map((rule) => ({ ...rule, preserveWhitespace: false }))
+		},
+		// a cell is laid out by the browser's table rules, which collapse whitespace in
+		// the static render but not in the editor. Keeping the indentation a text
+		// element now reads back would only make the two disagree
 	})
 
 const getCellAlign = (doc) => {

--- a/frontend/src/apps/slides/stores/tiptapSetup.js
+++ b/frontend/src/apps/slides/stores/tiptapSetup.js
@@ -932,15 +932,11 @@ const withCellAttributes = (extension) =>
 		addAttributes() {
 			return { ...this.parent?.(), ...cellAttributes }
 		},
-		// a cell is laid out by the browser's table rules, which collapse whitespace in
-		// the static render but not in the editor. Keeping the indentation a text
-		// element now reads back would only make the two disagree
+		// the static render lays a cell out by the browser's table rules, which
+		// collapse whitespace the editor would otherwise keep
 		parseHTML() {
 			return (this.parent?.() || []).map((rule) => ({ ...rule, preserveWhitespace: false }))
 		},
-		// a cell is laid out by the browser's table rules, which collapse whitespace in
-		// the static render but not in the editor. Keeping the indentation a text
-		// element now reads back would only make the two disagree
 	})
 
 const getCellAlign = (doc) => {


### PR DESCRIPTION
Tab did nothing inside a text element, and hand-typed indentation did not survive a reload. The editor collapsed runs of spaces and dropped leading ones while parsing saved HTML, so any indentation a user added came back flattened.

Now:
- Tab and Shift-Tab indent and outdent lines. Tables and lists keep their own Tab behaviour.
- Tab stops are 4 characters wide instead of the browser's default 8, which is too wide at slide font sizes.
- Editor content is parsed with with `preserveWhitespace: true` so leading spaces and runs of spaces survive a reload.
