### PR TITLE
feat(meet): persist locked framing across sessions

### DIFF
--- a/frontend/src/apps/meet/composables/useBackgroundEffects.ts
+++ b/frontend/src/apps/meet/composables/useBackgroundEffects.ts
@@ -1,7 +1,11 @@
 import type { SelfieSegmentation } from "@mediapipe/selfie_segmentation";
 import { toast } from "frappe-ui";
 import { onUnmounted, type Ref, ref } from "vue";
-import { availableBackgroundImages } from "../data/backgroundEffects";
+import {
+	availableBackgroundImages,
+	framingCrop,
+	setFramingCrop,
+} from "../data/backgroundEffects";
 import { CameraFramingProcessor } from "../utils/cameraFraming";
 import {
 	applyBlurEffect,
@@ -504,6 +508,9 @@ export function useBackgroundEffects({
 					try {
 						if (!cameraFraming && !cameraFramingDisposal) {
 							cameraFraming = new CameraFramingProcessor();
+							if (settings.autoFramingPaused && framingCrop.value) {
+								cameraFraming.restoreCrop(framingCrop.value);
+							}
 						}
 						if (!cameraFraming) {
 							ctx.clearRect(0, 0, width, height);
@@ -1022,7 +1029,23 @@ export function useBackgroundEffects({
 				}
 				if ("autoFramingEnabled" in normalizedOptions) {
 					framingUnavailable = false;
-					if (!settings.autoFramingEnabled) stopCameraFraming();
+					if (!settings.autoFramingEnabled) {
+						stopCameraFraming();
+						setFramingCrop(null);
+					}
+				}
+				if ("autoFramingPaused" in normalizedOptions) {
+					if (settings.autoFramingPaused) {
+						setFramingCrop(
+							cameraFraming?.getNormalizedCrop() ?? {
+								x: 0,
+								y: 0,
+								size: 1,
+							},
+						);
+					} else {
+						setFramingCrop(null);
+					}
 				}
 
 				if (

--- a/frontend/src/apps/meet/composables/useBackgroundEffects.ts
+++ b/frontend/src/apps/meet/composables/useBackgroundEffects.ts
@@ -1036,13 +1036,8 @@ export function useBackgroundEffects({
 				}
 				if ("autoFramingPaused" in normalizedOptions) {
 					if (settings.autoFramingPaused) {
-						setFramingCrop(
-							cameraFraming?.getNormalizedCrop() ?? {
-								x: 0,
-								y: 0,
-								size: 1,
-							},
-						);
+						const crop = cameraFraming?.getNormalizedCrop();
+						if (crop) setFramingCrop(crop);
 					} else {
 						setFramingCrop(null);
 					}

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -1,9 +1,6 @@
 import { confirmDialog, toast } from "frappe-ui";
 import { onUnmounted, type Ref, ref, watch } from "vue";
-import {
-	autoFramingPaused,
-	setAutoFramingPaused,
-} from "../data/backgroundEffects";
+import { autoFramingPaused } from "../data/backgroundEffects";
 import {
 	cameraEnabled as prefCameraEnabled,
 	micEnabled as prefMicEnabled,
@@ -636,10 +633,6 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				});
 				assertCurrentCameraOperation(operation);
 			} else {
-				if (bgEffects.autoFramingPaused) {
-					setAutoFramingPaused(false);
-					bgEffects.autoFramingPaused = false;
-				}
 				if (backgroundSession) {
 					await reconcileRawEffectsTrack(
 						rawTrack,

--- a/frontend/src/apps/meet/data/backgroundEffects.ts
+++ b/frontend/src/apps/meet/data/backgroundEffects.ts
@@ -50,7 +50,39 @@ export const blurIntensity: Ref<number> = ref(
 export const autoFramingEnabled: Ref<boolean> = ref(
 	readBool("backgroundEffects.autoFraming", false),
 );
-export const autoFramingPaused: Ref<boolean> = ref(false);
+
+export interface FramingCropSnapshot {
+	x: number;
+	y: number;
+	size: number;
+}
+
+function readFramingCrop(): FramingCropSnapshot | null {
+	try {
+		const raw = localStorage.getItem("backgroundEffects.framingCrop");
+		if (!raw) return null;
+		const parsed = JSON.parse(raw) as Partial<FramingCropSnapshot> | null;
+		if (
+			typeof parsed?.x !== "number" ||
+			typeof parsed?.y !== "number" ||
+			typeof parsed?.size !== "number" ||
+			!Number.isFinite(parsed.x) ||
+			!Number.isFinite(parsed.y) ||
+			!Number.isFinite(parsed.size)
+		) {
+			return null;
+		}
+		return { x: parsed.x, y: parsed.y, size: parsed.size };
+	} catch {
+		return null;
+	}
+}
+
+export const autoFramingPaused: Ref<boolean> = ref(
+	readBool("backgroundEffects.autoFramingPaused", false),
+);
+export const framingCrop: Ref<FramingCropSnapshot | null> =
+	ref(readFramingCrop());
 
 // Custom background images
 export const customBackgroundImages: Ref<BackgroundImage[]> = ref([]);
@@ -150,10 +182,25 @@ export function setAutoFramingEnabled(val: boolean): void {
 		"backgroundEffects.autoFraming",
 		autoFramingEnabled.value ? "1" : "0",
 	);
+	if (!autoFramingEnabled.value) setAutoFramingPaused(false);
 }
 
 export function setAutoFramingPaused(val: boolean): void {
 	autoFramingPaused.value = !!val;
+	localStorage.setItem(
+		"backgroundEffects.autoFramingPaused",
+		autoFramingPaused.value ? "1" : "0",
+	);
+	if (!autoFramingPaused.value) setFramingCrop(null);
+}
+
+export function setFramingCrop(crop: FramingCropSnapshot | null): void {
+	framingCrop.value = crop;
+	if (crop) {
+		localStorage.setItem("backgroundEffects.framingCrop", JSON.stringify(crop));
+	} else {
+		localStorage.removeItem("backgroundEffects.framingCrop");
+	}
 }
 
 // Add a custom background image

--- a/frontend/src/apps/meet/utils/cameraFraming.ts
+++ b/frontend/src/apps/meet/utils/cameraFraming.ts
@@ -89,7 +89,9 @@ export class CameraFramingTracker {
 				: largest;
 		}, null);
 		if (!face) {
-			if (wasAwaitingResumeDetection) this.lastFaceAt = now;
+			if (wasAwaitingResumeDetection && this.hasAcquiredCrop) {
+				this.lastFaceAt = now;
+			}
 			return;
 		}
 

--- a/frontend/src/apps/meet/utils/cameraFraming.ts
+++ b/frontend/src/apps/meet/utils/cameraFraming.ts
@@ -50,6 +50,7 @@ const SMOOTHING_TIME_MS = 420;
 const CENTER_DEAD_ZONE = 0.035;
 const SIZE_DEAD_ZONE = 0.05;
 const SIZE_CONFIRMATION_SAMPLES = 5;
+const CROP_CONVERGENCE_EPSILON = 0.02;
 
 const clamp = (value: number, min: number, max: number) =>
 	Math.min(max, Math.max(min, value));
@@ -142,7 +143,6 @@ export class CameraFramingTracker {
 			size,
 		};
 		this.lastFaceAt = now;
-		this.hasAcquiredCrop = true;
 	}
 
 	getCrop(sourceWidth: number, sourceHeight: number, now: number): CropRect {
@@ -162,6 +162,14 @@ export class CameraFramingTracker {
 		this.current.y += (this.target.y - this.current.y) * blend;
 		this.current.size += (this.target.size - this.current.size) * blend;
 		this.lastFrameAt = now;
+		const maxDrift = Math.max(
+			Math.abs(this.target.x - this.current.x),
+			Math.abs(this.target.y - this.current.y),
+			Math.abs(this.target.size - this.current.size),
+		);
+		if (maxDrift <= CROP_CONVERGENCE_EPSILON) {
+			this.hasAcquiredCrop = true;
+		}
 
 		return this.toCropRect(sourceWidth, sourceHeight);
 	}

--- a/frontend/src/apps/meet/utils/cameraFraming.ts
+++ b/frontend/src/apps/meet/utils/cameraFraming.ts
@@ -19,7 +19,7 @@ export interface CropRect {
 	height: number;
 }
 
-interface NormalizedCrop {
+export interface NormalizedCrop {
 	x: number;
 	y: number;
 	size: number;
@@ -168,6 +168,23 @@ export class CameraFramingTracker {
 		if (this.paused === paused) return;
 		this.paused = paused;
 		this.awaitingResumeDetection = !paused;
+		this.resetPendingSize();
+	}
+
+	getNormalizedCrop(): NormalizedCrop {
+		return { ...this.current };
+	}
+
+	restoreCrop(crop: NormalizedCrop): void {
+		const size = clamp(crop.size, 0, 1);
+		this.current = {
+			x: clamp(crop.x, 0, 1 - size),
+			y: clamp(crop.y, 0, 1 - size),
+			size,
+		};
+		this.target = { ...this.current };
+		this.lastFaceAt = null;
+		this.lastFrameAt = null;
 		this.resetPendingSize();
 	}
 
@@ -323,6 +340,14 @@ export class CameraFramingProcessor {
 		this.detectionGeneration++;
 		this.tracker.setPaused(paused);
 		if (!paused) this.nextDetectionAt = 0;
+	}
+
+	getNormalizedCrop(): NormalizedCrop {
+		return this.tracker.getNormalizedCrop();
+	}
+
+	restoreCrop(crop: NormalizedCrop): void {
+		this.tracker.restoreCrop(crop);
 	}
 
 	async dispose(): Promise<void> {

--- a/frontend/src/apps/meet/utils/cameraFraming.ts
+++ b/frontend/src/apps/meet/utils/cameraFraming.ts
@@ -69,6 +69,7 @@ export class CameraFramingTracker {
 	private pendingSizeSamples = 0;
 	private paused = false;
 	private awaitingResumeDetection = false;
+	private hasTrackedFace = false;
 	private hasAcquiredCrop = false;
 
 	private resetPendingSize(): void {
@@ -143,6 +144,7 @@ export class CameraFramingTracker {
 			size,
 		};
 		this.lastFaceAt = now;
+		this.hasTrackedFace = true;
 	}
 
 	getCrop(sourceWidth: number, sourceHeight: number, now: number): CropRect {
@@ -167,10 +169,7 @@ export class CameraFramingTracker {
 			Math.abs(this.target.y - this.current.y),
 			Math.abs(this.target.size - this.current.size),
 		);
-		if (
-			this.lastFaceAt !== null &&
-			maxDrift <= CROP_CONVERGENCE_EPSILON
-		) {
+		if (this.hasTrackedFace && maxDrift <= CROP_CONVERGENCE_EPSILON) {
 			this.hasAcquiredCrop = true;
 		}
 
@@ -198,6 +197,7 @@ export class CameraFramingTracker {
 		this.target = { ...this.current };
 		this.lastFaceAt = null;
 		this.lastFrameAt = null;
+		this.hasTrackedFace = true;
 		this.hasAcquiredCrop = true;
 		this.resetPendingSize();
 	}
@@ -220,6 +220,7 @@ export class CameraFramingTracker {
 		this.lastFrameAt = null;
 		this.paused = false;
 		this.awaitingResumeDetection = false;
+		this.hasTrackedFace = false;
 		this.hasAcquiredCrop = false;
 		this.resetPendingSize();
 	}

--- a/frontend/src/apps/meet/utils/cameraFraming.ts
+++ b/frontend/src/apps/meet/utils/cameraFraming.ts
@@ -167,7 +167,10 @@ export class CameraFramingTracker {
 			Math.abs(this.target.y - this.current.y),
 			Math.abs(this.target.size - this.current.size),
 		);
-		if (maxDrift <= CROP_CONVERGENCE_EPSILON) {
+		if (
+			this.lastFaceAt !== null &&
+			maxDrift <= CROP_CONVERGENCE_EPSILON
+		) {
 			this.hasAcquiredCrop = true;
 		}
 

--- a/frontend/src/apps/meet/utils/cameraFraming.ts
+++ b/frontend/src/apps/meet/utils/cameraFraming.ts
@@ -155,6 +155,7 @@ export class CameraFramingTracker {
 		if (this.lastFaceAt === null || now - this.lastFaceAt > FACE_HOLD_MS) {
 			this.target = { ...FULL_FRAME };
 			this.lastFaceAt = null;
+			this.hasAcquiredCrop = false;
 			this.resetPendingSize();
 		}
 
@@ -169,7 +170,11 @@ export class CameraFramingTracker {
 			Math.abs(this.target.y - this.current.y),
 			Math.abs(this.target.size - this.current.size),
 		);
-		if (this.hasTrackedFace && maxDrift <= CROP_CONVERGENCE_EPSILON) {
+		if (
+			this.hasTrackedFace &&
+			this.lastFaceAt !== null &&
+			maxDrift <= CROP_CONVERGENCE_EPSILON
+		) {
 			this.hasAcquiredCrop = true;
 		}
 

--- a/frontend/src/apps/meet/utils/cameraFraming.ts
+++ b/frontend/src/apps/meet/utils/cameraFraming.ts
@@ -68,6 +68,7 @@ export class CameraFramingTracker {
 	private pendingSizeSamples = 0;
 	private paused = false;
 	private awaitingResumeDetection = false;
+	private hasAcquiredCrop = false;
 
 	private resetPendingSize(): void {
 		this.pendingSize = 0;
@@ -141,6 +142,7 @@ export class CameraFramingTracker {
 			size,
 		};
 		this.lastFaceAt = now;
+		this.hasAcquiredCrop = true;
 	}
 
 	getCrop(sourceWidth: number, sourceHeight: number, now: number): CropRect {
@@ -171,8 +173,8 @@ export class CameraFramingTracker {
 		this.resetPendingSize();
 	}
 
-	getNormalizedCrop(): NormalizedCrop {
-		return { ...this.current };
+	getNormalizedCrop(): NormalizedCrop | null {
+		return this.hasAcquiredCrop ? { ...this.current } : null;
 	}
 
 	restoreCrop(crop: NormalizedCrop): void {
@@ -185,6 +187,7 @@ export class CameraFramingTracker {
 		this.target = { ...this.current };
 		this.lastFaceAt = null;
 		this.lastFrameAt = null;
+		this.hasAcquiredCrop = true;
 		this.resetPendingSize();
 	}
 
@@ -206,6 +209,7 @@ export class CameraFramingTracker {
 		this.lastFrameAt = null;
 		this.paused = false;
 		this.awaitingResumeDetection = false;
+		this.hasAcquiredCrop = false;
 		this.resetPendingSize();
 	}
 }
@@ -342,7 +346,7 @@ export class CameraFramingProcessor {
 		if (!paused) this.nextDetectionAt = 0;
 	}
 
-	getNormalizedCrop(): NormalizedCrop {
+	getNormalizedCrop(): NormalizedCrop | null {
 		return this.tracker.getNormalizedCrop();
 	}
 

--- a/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
@@ -186,6 +186,19 @@ describe("CameraFramingTracker", () => {
 		expect(restored.getCrop(1280, 720, 6500).x).toBeGreaterThan(locked.x);
 	});
 
+	it("does not report a crop before the first detection or restore", () => {
+		const tracker = new CameraFramingTracker();
+
+		expect(tracker.getNormalizedCrop()).toBeNull();
+
+		tracker.restoreCrop({ x: 0.1, y: 0.1, size: 0.5 });
+		expect(tracker.getNormalizedCrop()).toEqual({
+			x: 0.1,
+			y: 0.1,
+			size: 0.5,
+		});
+	});
+
 	it("clamps an out-of-bounds restored crop into the frame", () => {
 		const tracker = new CameraFramingTracker();
 		tracker.restoreCrop({ x: -0.5, y: 2, size: 1.5 });

--- a/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
@@ -190,6 +190,9 @@ describe("CameraFramingTracker", () => {
 		const tracker = new CameraFramingTracker();
 
 		expect(tracker.getNormalizedCrop()).toBeNull();
+		tracker.getCrop(1280, 720, 0);
+		tracker.getCrop(1280, 720, 500);
+		expect(tracker.getNormalizedCrop()).toBeNull();
 
 		tracker.updateFaces(
 			[{ xCenter: 0.5, yCenter: 0.3, width: 0.2, height: 0.24 }],

--- a/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
@@ -157,6 +157,46 @@ describe("CameraFramingTracker", () => {
 
 		expect(tracker.getCrop(1280, 720, 5500).x).toBeGreaterThan(fixed.x);
 	});
+
+	it("restores a persisted crop snapshot and resumes tracking from it", () => {
+		const tracker = new CameraFramingTracker();
+		const face = (xCenter: number) => [
+			{ xCenter, yCenter: 0.3, width: 0.2, height: 0.24 },
+		];
+		tracker.updateFaces(face(0.35), 0);
+		for (let now = 0; now <= 1000; now += 20) {
+			tracker.getCrop(1280, 720, now);
+		}
+		const snapshot = tracker.getNormalizedCrop();
+		tracker.setPaused(true);
+		const locked = tracker.getCrop(1280, 720, 1000);
+
+		const restored = new CameraFramingTracker();
+		restored.restoreCrop(snapshot);
+		restored.setPaused(true);
+		expect(restored.getCrop(1280, 720, 5000)).toEqual(locked);
+
+		restored.setPaused(false);
+		expect(restored.getCrop(1280, 720, 5020)).toEqual(locked);
+		restored.updateFaces(face(0.75), 5200);
+		for (let now = 5200; now <= 6500; now += 20) {
+			restored.getCrop(1280, 720, now);
+		}
+
+		expect(restored.getCrop(1280, 720, 6500).x).toBeGreaterThan(locked.x);
+	});
+
+	it("clamps an out-of-bounds restored crop into the frame", () => {
+		const tracker = new CameraFramingTracker();
+		tracker.restoreCrop({ x: -0.5, y: 2, size: 1.5 });
+
+		const crop = tracker.getCrop(1280, 720, 0);
+
+		expect(crop.x).toBe(0);
+		expect(crop.y).toBe(0);
+		expect(crop.width).toBe(1280);
+		expect(crop.height).toBe(720);
+	});
 });
 
 describe("CameraFramingProcessor", () => {

--- a/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
@@ -194,6 +194,13 @@ describe("CameraFramingTracker", () => {
 		tracker.getCrop(1280, 720, 500);
 		expect(tracker.getNormalizedCrop()).toBeNull();
 
+		tracker.setPaused(true);
+		tracker.setPaused(false);
+		tracker.updateFaces([], 600);
+		tracker.getCrop(1280, 720, 620);
+		tracker.getCrop(1280, 720, 640);
+		expect(tracker.getNormalizedCrop()).toBeNull();
+
 		tracker.updateFaces(
 			[{ xCenter: 0.5, yCenter: 0.3, width: 0.2, height: 0.24 }],
 			0,

--- a/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
@@ -191,6 +191,12 @@ describe("CameraFramingTracker", () => {
 
 		expect(tracker.getNormalizedCrop()).toBeNull();
 
+		tracker.updateFaces(
+			[{ xCenter: 0.5, yCenter: 0.3, width: 0.2, height: 0.24 }],
+			0,
+		);
+		expect(tracker.getNormalizedCrop()).toBeNull();
+
 		tracker.restoreCrop({ x: 0.1, y: 0.1, size: 0.5 });
 		expect(tracker.getNormalizedCrop()).toEqual({
 			x: 0.1,

--- a/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
@@ -226,6 +226,23 @@ describe("CameraFramingTracker", () => {
 		expect(crop.width).toBe(1280);
 		expect(crop.height).toBe(720);
 	});
+
+	it("stops reporting a crop after face loss falls back to the full frame", () => {
+		const tracker = new CameraFramingTracker();
+		const face = [{ xCenter: 0.5, yCenter: 0.3, width: 0.2, height: 0.24 }];
+		tracker.updateFaces(face, 0);
+		for (let now = 0; now <= 2000; now += 20) {
+			if (now % 200 === 0) tracker.updateFaces(face, now);
+			tracker.getCrop(1280, 720, now);
+		}
+		expect(tracker.getNormalizedCrop()).not.toBeNull();
+
+		for (let now = 2000; now <= 8000; now += 20) {
+			tracker.getCrop(1280, 720, now);
+		}
+
+		expect(tracker.getNormalizedCrop()).toBeNull();
+	});
 });
 
 describe("CameraFramingProcessor", () => {

--- a/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
@@ -242,6 +242,14 @@ describe("CameraFramingTracker", () => {
 		}
 
 		expect(tracker.getNormalizedCrop()).toBeNull();
+
+		tracker.setPaused(true);
+		tracker.setPaused(false);
+		tracker.updateFaces([], 8100);
+		tracker.getCrop(1280, 720, 8120);
+		tracker.getCrop(1280, 720, 8140);
+
+		expect(tracker.getNormalizedCrop()).toBeNull();
 	});
 });
 


### PR DESCRIPTION
## Summary

- persist the framing lock and its normalized crop so reloads and future calls start at the locked position
- restore persisted crops with validation and bounds clamping
- clear the stored crop when framing is unlocked or disabled