### PR TITLE
fix(meet): ease camera framing back to full frame

### DIFF
--- a/frontend/src/apps/meet/composables/useBackgroundEffects.ts
+++ b/frontend/src/apps/meet/composables/useBackgroundEffects.ts
@@ -527,6 +527,9 @@ export function useBackgroundEffects({
 							height,
 							performance.now(),
 						);
+						if (!settings.autoFramingEnabled && cameraFraming.isAtFullFrame()) {
+							stopCameraFraming();
+						}
 						assertOwnerActive(signal);
 					} catch (framingError) {
 						if (isDisposed || signal?.aborted) throw framingError;

--- a/frontend/src/apps/meet/composables/useBackgroundEffects.ts
+++ b/frontend/src/apps/meet/composables/useBackgroundEffects.ts
@@ -504,7 +504,7 @@ export function useBackgroundEffects({
 			};
 			const drawCameraFrame = async (source: CanvasImageSource) => {
 				let crop = { x: 0, y: 0, width, height };
-				if (settings.autoFramingEnabled && !framingUnavailable) {
+				if ((settings.autoFramingEnabled || cameraFraming) && !framingUnavailable) {
 					try {
 						if (!cameraFraming && !cameraFramingDisposal) {
 							cameraFraming = new CameraFramingProcessor();
@@ -517,7 +517,10 @@ export function useBackgroundEffects({
 							ctx.drawImage(source, 0, 0, width, height);
 							return;
 						}
-						cameraFraming.setPaused(settings.autoFramingPaused);
+						cameraFraming.setEnabled(settings.autoFramingEnabled);
+						cameraFraming.setPaused(
+							settings.autoFramingEnabled && settings.autoFramingPaused,
+						);
 						crop = await cameraFraming.process(
 							() => getDetectionImage(source),
 							width,
@@ -1030,7 +1033,6 @@ export function useBackgroundEffects({
 				if ("autoFramingEnabled" in normalizedOptions) {
 					framingUnavailable = false;
 					if (!settings.autoFramingEnabled) {
-						stopCameraFraming();
 						setFramingCrop(null);
 					}
 				}

--- a/frontend/src/apps/meet/utils/cameraFraming.ts
+++ b/frontend/src/apps/meet/utils/cameraFraming.ts
@@ -205,6 +205,17 @@ export class CameraFramingTracker {
 		return this.hasAcquiredCrop ? { ...this.current } : null;
 	}
 
+	isAtFullFrame(): boolean {
+		return (
+			!this.enabled &&
+			Math.max(
+				Math.abs(this.current.x),
+				Math.abs(this.current.y),
+				Math.abs(1 - this.current.size),
+			) <= CROP_CONVERGENCE_EPSILON
+		);
+	}
+
 	restoreCrop(crop: NormalizedCrop): void {
 		const size = clamp(crop.size, 0, 1);
 		this.current = {
@@ -391,6 +402,10 @@ export class CameraFramingProcessor {
 
 	getNormalizedCrop(): NormalizedCrop | null {
 		return this.tracker.getNormalizedCrop();
+	}
+
+	isAtFullFrame(): boolean {
+		return this.tracker.isAtFullFrame();
 	}
 
 	restoreCrop(crop: NormalizedCrop): void {

--- a/frontend/src/apps/meet/utils/cameraFraming.ts
+++ b/frontend/src/apps/meet/utils/cameraFraming.ts
@@ -68,6 +68,7 @@ export class CameraFramingTracker {
 	private pendingSizeDirection = 0;
 	private pendingSizeSamples = 0;
 	private paused = false;
+	private enabled = true;
 	private awaitingResumeDetection = false;
 	private hasTrackedFace = false;
 	private hasAcquiredCrop = false;
@@ -79,7 +80,7 @@ export class CameraFramingTracker {
 	}
 
 	updateFaces(faces: NormalizedFaceBox[], now: number): void {
-		if (this.paused) return;
+		if (this.paused || !this.enabled) return;
 		const wasAwaitingResumeDetection = this.awaitingResumeDetection;
 		this.awaitingResumeDetection = false;
 		const face = faces.reduce<NormalizedFaceBox | null>((largest, candidate) => {
@@ -190,6 +191,16 @@ export class CameraFramingTracker {
 		this.resetPendingSize();
 	}
 
+	setEnabled(enabled: boolean): void {
+		if (this.enabled === enabled) return;
+		this.enabled = enabled;
+		if (enabled) return;
+		this.target = { ...FULL_FRAME };
+		this.lastFaceAt = null;
+		this.hasAcquiredCrop = false;
+		this.resetPendingSize();
+	}
+
 	getNormalizedCrop(): NormalizedCrop | null {
 		return this.hasAcquiredCrop ? { ...this.current } : null;
 	}
@@ -226,6 +237,7 @@ export class CameraFramingTracker {
 		this.lastFaceAt = null;
 		this.lastFrameAt = null;
 		this.paused = false;
+		this.enabled = true;
 		this.awaitingResumeDetection = false;
 		this.hasTrackedFace = false;
 		this.hasAcquiredCrop = false;
@@ -278,6 +290,7 @@ export class CameraFramingProcessor {
 	private nextDetectionAt = 0;
 	private disposed = false;
 	private paused = false;
+	private enabled = true;
 
 	constructor({
 		detectorFactory = createFaceDetector,
@@ -327,7 +340,12 @@ export class CameraFramingProcessor {
 			this.detectionError = null;
 			throw error;
 		}
-		if (!this.paused && !this.detectionPromise && now >= this.nextDetectionAt) {
+		if (
+			this.enabled &&
+			!this.paused &&
+			!this.detectionPromise &&
+			now >= this.nextDetectionAt
+		) {
 			this.nextDetectionAt = now + this.detectionIntervalMs;
 			const generation = this.detectionGeneration;
 			const input = typeof image === "function" ? image() : image;
@@ -363,6 +381,12 @@ export class CameraFramingProcessor {
 		this.detectionGeneration++;
 		this.tracker.setPaused(paused);
 		if (!paused) this.nextDetectionAt = 0;
+	}
+
+	setEnabled(enabled: boolean): void {
+		if (this.enabled === enabled) return;
+		this.enabled = enabled;
+		this.tracker.setEnabled(enabled);
 	}
 
 	getNormalizedCrop(): NormalizedCrop | null {

--- a/frontend/src/apps/meet/utils/cameraFraming.ts
+++ b/frontend/src/apps/meet/utils/cameraFraming.ts
@@ -187,7 +187,7 @@ export class CameraFramingTracker {
 	setPaused(paused: boolean): void {
 		if (this.paused === paused) return;
 		this.paused = paused;
-		this.awaitingResumeDetection = !paused;
+		this.awaitingResumeDetection = !paused && this.enabled;
 		this.resetPendingSize();
 	}
 
@@ -195,6 +195,8 @@ export class CameraFramingTracker {
 		if (this.enabled === enabled) return;
 		this.enabled = enabled;
 		if (enabled) return;
+		this.paused = false;
+		this.awaitingResumeDetection = false;
 		this.target = { ...FULL_FRAME };
 		this.lastFaceAt = null;
 		this.hasAcquiredCrop = false;

--- a/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
@@ -79,7 +79,9 @@ describe("CameraFramingTracker", () => {
 		}
 		const fitted = tracker.getCrop(1280, 720, 1000);
 
+		tracker.setPaused(true);
 		tracker.setEnabled(false);
+		tracker.setPaused(false);
 		const easing = tracker.getCrop(1280, 720, 1020);
 		expect(tracker.isAtFullFrame()).toBe(false);
 		let fullFrame = easing;

--- a/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
@@ -81,6 +81,7 @@ describe("CameraFramingTracker", () => {
 
 		tracker.setEnabled(false);
 		const easing = tracker.getCrop(1280, 720, 1020);
+		expect(tracker.isAtFullFrame()).toBe(false);
 		let fullFrame = easing;
 		for (let now = 1040; now <= 4000; now += 20) {
 			fullFrame = tracker.getCrop(1280, 720, now);
@@ -89,6 +90,7 @@ describe("CameraFramingTracker", () => {
 		expect(easing.width).toBeGreaterThan(fitted.width);
 		expect(easing.width).toBeLessThan(1280);
 		expect(fullFrame.width).toBeCloseTo(1280, 0);
+		expect(tracker.isAtFullFrame()).toBe(true);
 	});
 
 	it("ignores small face-box fluctuations while the subject is stationary", () => {

--- a/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/cameraFraming.test.ts
@@ -70,6 +70,27 @@ describe("CameraFramingTracker", () => {
 		expect(reset.height).toBeCloseTo(720, 0);
 	});
 
+	it("eases back to the full frame when disabled", () => {
+		const tracker = new CameraFramingTracker();
+		const face = [{ xCenter: 0.5, yCenter: 0.3, width: 0.2, height: 0.24 }];
+		for (let now = 0; now <= 1000; now += 20) {
+			if (now % 200 === 0) tracker.updateFaces(face, now);
+			tracker.getCrop(1280, 720, now);
+		}
+		const fitted = tracker.getCrop(1280, 720, 1000);
+
+		tracker.setEnabled(false);
+		const easing = tracker.getCrop(1280, 720, 1020);
+		let fullFrame = easing;
+		for (let now = 1040; now <= 4000; now += 20) {
+			fullFrame = tracker.getCrop(1280, 720, now);
+		}
+
+		expect(easing.width).toBeGreaterThan(fitted.width);
+		expect(easing.width).toBeLessThan(1280);
+		expect(fullFrame.width).toBeCloseTo(1280, 0);
+	});
+
 	it("ignores small face-box fluctuations while the subject is stationary", () => {
 		const tracker = new CameraFramingTracker();
 		const widths: number[] = [];


### PR DESCRIPTION
Keep the framing pipeline active while auto framing winds down, so the camera view eases back to its full frame instead of jumping.