### PR TITLE
feat(mail): Outbox backed by JMAP EmailSubmission

### DIFF
--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -551,7 +551,7 @@ const sidebarItems = computed(() => {
 		label: __('Scheduled'),
 		icon: CalendarClock,
 		to: { name: 'mail-scheduled', params: { accountId: store.accountId } },
-		activeFor: ['mail-scheduled'],
+		activeFor: ['mail-scheduled', 'mail-submission'],
 	}
 	const defaultItems = [...defaultMailboxes, starredItem, scheduledItem]
 

--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -547,13 +547,13 @@ const sidebarItems = computed(() => {
 	}
 	// Synthetic like Starred, but backed by the server's held (FUTURERELEASE)
 	// EmailSubmissions rather than a mailbox, so it opens a dedicated page.
-	const scheduledItem = {
-		label: __('Scheduled'),
+	const outboxItem = {
+		label: __('Outbox'),
 		icon: CalendarClock,
-		to: { name: 'mail-scheduled', params: { accountId: store.accountId } },
-		activeFor: ['mail-scheduled', 'mail-submission'],
+		to: { name: 'mail-outbox', params: { accountId: store.accountId } },
+		activeFor: ['mail-outbox', 'mail-submission'],
 	}
-	const defaultItems = [...defaultMailboxes, starredItem, scheduledItem]
+	const defaultItems = [...defaultMailboxes, starredItem, outboxItem]
 
 	const secondaryItems = mailboxItems.value
 		.filter((item) => {

--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -545,8 +545,8 @@ const sidebarItems = computed(() => {
 		to: { name: 'mail-mailbox', params: { accountId: store.accountId, mailbox: 'starred' } },
 		activeFor: ['starred'],
 	}
-	// Synthetic like Starred, but backed by the Mail Queue's held (FUTURERELEASE)
-	// submissions rather than a mailbox, so it opens a dedicated page.
+	// Synthetic like Starred, but backed by the server's held (FUTURERELEASE)
+	// EmailSubmissions rather than a mailbox, so it opens a dedicated page.
 	const scheduledItem = {
 		label: __('Scheduled'),
 		icon: CalendarClock,

--- a/frontend/src/apps/mail/components/InformationField.vue
+++ b/frontend/src/apps/mail/components/InformationField.vue
@@ -2,7 +2,9 @@
 	<div class="even:bg-surface-gray-1 flex items-center px-5 py-3.5 text-base last:rounded-b">
 		<div class="text-ink-gray-5 w-1/3">{{ label }}</div>
 		<div class="flex w-2/3 items-center font-medium">
-			<span class="truncate">{{ value || '—' }}</span>
+			<slot>
+				<span class="truncate">{{ value || '—' }}</span>
+			</slot>
 		</div>
 	</div>
 </template>

--- a/frontend/src/apps/mail/components/OutboxFilters.vue
+++ b/frontend/src/apps/mail/components/OutboxFilters.vue
@@ -1,0 +1,80 @@
+<template>
+	<div class="flex items-center justify-between gap-2 border-b px-3 py-2 sm:px-5">
+		<!-- undoStatus is the filter everyone reaches for, so it lives in the bar; the
+		precise ones (identity, ids, date window) wait behind the Filter button. -->
+		<TabButtons v-model="filters.undoStatus" :options="STATUS_TABS" />
+
+		<Popover side="bottom" align="end">
+			<template #target="{ togglePopover }">
+				<Button :label="__('Filter')" @click="togglePopover()">
+					<template #prefix><ListFilter class="h-4 w-4" /></template>
+					<template v-if="activeCount" #suffix>
+						<Badge :label="String(activeCount)" theme="gray" />
+					</template>
+				</Button>
+			</template>
+			<template #body-main>
+				<div class="flex w-72 flex-col gap-3 p-4">
+					<FormControl
+						v-model="filters.identityId"
+						type="select"
+						:label="__('Identity')"
+						:options="identityOptions"
+					/>
+					<FormControl v-model="filters.emailId" :label="__('Email ID')" />
+					<FormControl v-model="filters.threadId" :label="__('Thread ID')" />
+					<div class="grid grid-cols-2 gap-2">
+						<FormControl v-model="filters.after" type="date" :label="__('After')" />
+						<FormControl v-model="filters.before" type="date" :label="__('Before')" />
+					</div>
+					<Button
+						v-if="activeCount"
+						class="self-end"
+						variant="ghost"
+						:label="__('Clear filters')"
+						@click="clear"
+					/>
+				</div>
+			</template>
+		</Popover>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { ListFilter } from 'lucide-vue-next'
+import { Badge, Button, FormControl, Popover, TabButtons } from 'frappe-ui'
+
+import { userStore } from '@/apps/mail/stores/user'
+import {
+	activeSubmissionFilterCount,
+	emptySubmissionFilters,
+	type SubmissionFilters,
+} from '@/apps/mail/utils/submission'
+
+// The parent owns the reactive filters object (its list resource reads it and reloads on
+// change); this component only writes into it.
+const { filters } = defineProps<{ filters: SubmissionFilters }>()
+
+const store = userStore()
+
+const STATUS_TABS = [
+	{ label: __('Pending'), value: 'pending' },
+	{ label: __('Final'), value: 'final' },
+	{ label: __('Cancelled'), value: 'canceled' },
+]
+
+const identityOptions = computed(() => [
+	{ label: __('All identities'), value: '' },
+	...((store.identities.data || []) as { id: string; email: string }[]).map((identity) => ({
+		label: identity.email,
+		value: identity.id,
+	})),
+])
+
+// Only the popover's filters count toward the badge — the status tabs show their own state.
+const activeCount = computed(() => activeSubmissionFilterCount(filters))
+
+const clear = () =>
+	Object.assign(filters, { ...emptySubmissionFilters(), undoStatus: filters.undoStatus })
+</script>

--- a/frontend/src/apps/mail/components/mobile/MobileFolderSheet.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileFolderSheet.vue
@@ -111,7 +111,7 @@ const groups = computed(() => {
 		icon: 'calendar-clock',
 		iconColor: '',
 		count: 0,
-		active: route.name === 'mail-scheduled',
+		active: route.name === 'mail-scheduled' || route.name === 'mail-submission',
 		to: {
 			name: 'mail-scheduled',
 			params: { accountId: store.accountId },

--- a/frontend/src/apps/mail/components/mobile/MobileFolderSheet.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileFolderSheet.vue
@@ -105,15 +105,15 @@ const groups = computed(() => {
 		} as RouteLocationRaw,
 	}
 
-	const scheduledRow = {
-		id: 'scheduled',
-		label: __('Scheduled'),
+	const outboxRow = {
+		id: 'outbox',
+		label: __('Outbox'),
 		icon: 'calendar-clock',
 		iconColor: '',
 		count: 0,
-		active: route.name === 'mail-scheduled' || route.name === 'mail-submission',
+		active: route.name === 'mail-outbox' || route.name === 'mail-submission',
 		to: {
-			name: 'mail-scheduled',
+			name: 'mail-outbox',
 			params: { accountId: store.accountId },
 		} as RouteLocationRaw,
 	}
@@ -127,7 +127,7 @@ const groups = computed(() => {
 			rows: [
 				...items.filter((m: MailboxData) => m.role && !isSecondary(m)).map(toRow),
 				starredRow,
-				scheduledRow,
+				outboxRow,
 			],
 		},
 		{

--- a/frontend/src/apps/mail/composables/useComposeMail.ts
+++ b/frontend/src/apps/mail/composables/useComposeMail.ts
@@ -244,7 +244,8 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 	const UNDO_SEND_WINDOW_MS = 10000
 
 	// A plain Send holds delivery for the undo window ('undo'); Schedule send passes an explicit time
-	// ('scheduled'). Both come back as 'Scheduled', so the toast has to know which one it confirms.
+	// ('scheduled'). Both come back as 'Submitted' with a send_at, so the toast has to know which one
+	// it confirms.
 	const sendMode = ref<'undo' | 'scheduled'>('undo')
 
 	const sendMail = async (sendAt?: string) => {
@@ -299,10 +300,10 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 	const scheduleSend = (sendAt: string) => sendMail(sendAt)
 
 	// Undo send: Send actually scheduled delivery a few seconds out (a server-side hold), so undoing
-	// is just cancelling that schedule — the message lands back in Drafts.
+	// is just cancelling that submission — the message lands back in Drafts.
 	const undoSend = createResource({
-		url: 'suite.mail.api.mail.cancel_scheduled_mail',
-		makeParams: ({ name }: { name: string }) => ({ account: scopeAccountId.value, name }),
+		url: 'suite.mail.api.scheduled.cancel_scheduled_mail',
+		makeParams: ({ id }: { id: string }) => ({ account: scopeAccountId.value, id }),
 		onSuccess: () => {
 			reloadMails()
 			raiseToast(__('Sending undone. The message is back in your drafts.'))
@@ -311,24 +312,29 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 	})
 
 	const onMailUpdateSuccess = ({
-		name,
 		id,
 		status,
 		error,
 		thread_id,
+		submission_id,
+		send_at,
 	}: {
 		name: string
 		id: string
 		status: string
 		error: string
 		thread_id?: string
+		/** The held delivery's EmailSubmission id — what Undo cancels. */
+		submission_id?: string
+		/** Set when the server is holding delivery (undo window or scheduled send). */
+		send_at?: string
 	}) => {
 		if (id) mail.id = id
 		updateOriginalMail()
 		if (error) return raiseToast(error, 'error')
 		if (isDiscarding.value) return
 
-		if (!isInThread || status === 'Submitted' || status === 'Scheduled') reloadMails()
+		if (!isInThread || status === 'Submitted') reloadMails()
 		// In a thread the list is where the messages come from — the pane is built from the rows the
 		// list is holding, not from a fetch of its own. So a draft saved in here goes to the server
 		// and the list goes on holding the version from before this sitting: leave the thread, open
@@ -342,6 +348,28 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 		if (isOpen()) return
 
 		if (status === 'Drafted' && isSavingDraft.value) raiseToast(__('Draft saved.'))
+		else if (status === 'Submitted' && send_at && submission_id && sendMode.value === 'undo')
+			// Two buttons, and they are not equals: Undo expires with the toast, so it takes the
+			// urgent slot; View is an aside you could reach any time from Sent, offered only when the
+			// thread isn't already the one in front of you.
+			raiseToast(
+				__('Message sent.'),
+				'success',
+				{ label: __('Undo'), onClick: () => undoSend.submit({ id: submission_id }) },
+				UNDO_SEND_WINDOW_MS,
+				thread_id && route.params.threadID !== thread_id
+					? { label: __('View'), onClick: () => viewSentMessage(thread_id) }
+					: undefined,
+			)
+		else if (status === 'Submitted' && send_at && sendMode.value === 'scheduled')
+			raiseToast(__('Send scheduled.'), 'success', {
+				label: __('View'),
+				onClick: () =>
+					router.push({
+						name: 'mail-scheduled',
+						params: { accountId: scopeAccountId.value },
+					}),
+			})
 		else if (status === 'Submitted')
 			raiseToast(
 				__('Message sent.'),
@@ -351,28 +379,6 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 					? { label: __('View'), onClick: () => viewSentMessage(thread_id) }
 					: undefined,
 			)
-		else if (status === 'Scheduled' && sendMode.value === 'undo')
-			// Two buttons, and they are not equals: Undo expires with the toast, so it takes the
-			// urgent slot; View is an aside you could reach any time from Sent, offered only when the
-			// thread isn't already the one in front of you.
-			raiseToast(
-				__('Message sent.'),
-				'success',
-				{ label: __('Undo'), onClick: () => undoSend.submit({ name }) },
-				UNDO_SEND_WINDOW_MS,
-				thread_id && route.params.threadID !== thread_id
-					? { label: __('View'), onClick: () => viewSentMessage(thread_id) }
-					: undefined,
-			)
-		else if (status === 'Scheduled')
-			raiseToast(__('Send scheduled.'), 'success', {
-				label: __('View'),
-				onClick: () =>
-					router.push({
-						name: 'mail-scheduled',
-						params: { accountId: scopeAccountId.value },
-					}),
-			})
 	}
 
 	// ── Resources ───────────────────────────────────────────────────────────────────────────────

--- a/frontend/src/apps/mail/composables/useComposeMail.ts
+++ b/frontend/src/apps/mail/composables/useComposeMail.ts
@@ -366,7 +366,7 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 				label: __('View'),
 				onClick: () =>
 					router.push({
-						name: 'mail-scheduled',
+						name: 'mail-outbox',
 						params: { accountId: scopeAccountId.value },
 					}),
 			})

--- a/frontend/src/apps/mail/pages/OutboxView.vue
+++ b/frontend/src/apps/mail/pages/OutboxView.vue
@@ -3,9 +3,9 @@
 		<header
 			class="flex items-center justify-between border-b px-3 py-2.5 max-sm:p-0 sm:px-5"
 		>
-			<MobileTitleHeader v-if="isMobile" class="min-w-0 flex-1" :title="__('Scheduled')" />
+			<MobileTitleHeader v-if="isMobile" class="min-w-0 flex-1" :title="__('Outbox')" />
 			<!-- -ml-0.5 cancels the crumb's own padding so the title sits on the px-5 axis -->
-			<Breadcrumbs v-else :items="[{ label: __('Scheduled') }]" class="-ml-0.5" />
+			<Breadcrumbs v-else :items="[{ label: __('Outbox') }]" class="-ml-0.5" />
 			<HeaderActions @reload-mails="scheduledMails.reload()" />
 		</header>
 
@@ -138,7 +138,7 @@ import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
 import ScheduleSendModal from '@/apps/mail/components/Modals/ScheduleSendModal.vue'
 
-usePageMeta(() => ({ title: __('Scheduled') }))
+usePageMeta(() => ({ title: __('Outbox') }))
 
 const store = userStore()
 const router = useRouter()

--- a/frontend/src/apps/mail/pages/OutboxView.vue
+++ b/frontend/src/apps/mail/pages/OutboxView.vue
@@ -85,6 +85,15 @@
 			<DashboardListSkeleton v-else :columns="4" />
 		</div>
 
+		<DashboardPager
+			v-if="submissions.data && !refetching"
+			class="border-t px-3 sm:px-5"
+			:page="page"
+			:page-length="PAGE_LENGTH"
+			:total="total"
+			@update:page="(p: number) => (page = p)"
+		/>
+
 		<ScheduleSendModal
 			v-model="showReschedule"
 			:title="__('Reschedule delivery')"
@@ -140,6 +149,7 @@ import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
+import DashboardPager from '@/apps/mail/components/DashboardPager.vue'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
 import OutboxFilters from '@/apps/mail/components/OutboxFilters.vue'
@@ -172,6 +182,9 @@ const hasActiveFilters = computed(() => activeSubmissionFilterCount(filters) > 0
 // empty flashes the (wrong) empty state before the response arrives.
 const refetching = ref(false)
 
+const PAGE_LENGTH = 50
+const page = ref(1)
+
 const submissions = createResource({
 	url: 'suite.mail.api.scheduled.get_submissions',
 	auto: true,
@@ -185,6 +198,8 @@ const submissions = createResource({
 		// instants that day spans.
 		after: filters.after ? utcDayStart(filters.after) : undefined,
 		before: filters.before ? utcDayEnd(filters.before) : undefined,
+		page: page.value,
+		page_length: PAGE_LENGTH,
 	}),
 	onSuccess: () => (refetching.value = false),
 	onError: (error: { message?: string }) => {
@@ -198,14 +213,25 @@ const applyFilters = () => {
 	submissions.reload()
 }
 
+// A filter change restarts from the first page; when the page actually moves, its own
+// watcher does the refetch (avoiding a double request).
+const applyFiltersFromStart = () => {
+	if (page.value !== 1) page.value = 1
+	else applyFilters()
+}
+
+watch(page, applyFilters)
 watch(
 	() => store.accountId,
-	() => store.accountId && applyFilters(),
+	() => store.accountId && applyFiltersFromStart(),
 )
 
 // The id filters are typed; the rest change atomically.
-watchDebounced(() => [filters.emailId, filters.threadId], applyFilters, { debounce: 300 })
-watch(() => [filters.undoStatus, filters.identityId, filters.after, filters.before], applyFilters)
+watchDebounced(() => [filters.emailId, filters.threadId], applyFiltersFromStart, { debounce: 300 })
+watch(
+	() => [filters.undoStatus, filters.identityId, filters.after, filters.before],
+	applyFiltersFromStart,
+)
 
 // Kept current the way mailboxes are — a periodic poll (holds release, retries advance, and
 // other clients schedule/cancel without any local signal) plus the new-mail socket (an undo
@@ -224,7 +250,8 @@ onUnmounted(() => {
 	socket.off('new_mail_created', onNewMail)
 })
 
-const rows = computed<Submission[]>(() => submissions.data || [])
+const rows = computed<Submission[]>(() => submissions.data?.rows || [])
+const total = computed<number>(() => submissions.data?.total || 0)
 
 const recipientLabel = (row: Submission) => {
 	const emails = [

--- a/frontend/src/apps/mail/pages/OutboxView.vue
+++ b/frontend/src/apps/mail/pages/OutboxView.vue
@@ -301,7 +301,7 @@ const rowOptions = (row: Submission) => {
 
 	if (row.status === 'failed') {
 		const retry = { label: __('Send again'), icon: RefreshCw, onClick: open(showRetry) }
-		const dismiss = { label: __('Dismiss'), icon: X, onClick: open(undefined, dismissMail) }
+		const dismiss = { label: __('Remove'), icon: X, onClick: open(undefined, dismissMail) }
 		// A deleted message can't be resubmitted — dropping the failed record is all that's left.
 		return row.email_deleted ? [dismiss] : [retry, dismiss]
 	}

--- a/frontend/src/apps/mail/pages/OutboxView.vue
+++ b/frontend/src/apps/mail/pages/OutboxView.vue
@@ -6,12 +6,14 @@
 			<MobileTitleHeader v-if="isMobile" class="min-w-0 flex-1" :title="__('Outbox')" />
 			<!-- -ml-0.5 cancels the crumb's own padding so the title sits on the px-5 axis -->
 			<Breadcrumbs v-else :items="[{ label: __('Outbox') }]" class="-ml-0.5" />
-			<HeaderActions @reload-mails="scheduledMails.reload()" />
+			<HeaderActions @reload-mails="submissions.reload()" />
 		</header>
+
+		<OutboxFilters :filters="filters" />
 
 		<div class="flex-1 overflow-y-auto px-3 py-2.5 sm:px-5">
 			<ListView
-				v-if="scheduledMails.data"
+				v-if="submissions.data && !refetching"
 				class="flex-1"
 				:columns="LIST_COLUMNS"
 				:rows="rows"
@@ -43,16 +45,16 @@
 									{{ formatDateTime(row.send_at) }}
 									<span class="text-ink-gray-5">({{ fromNow(row.send_at) }})</span>
 								</span>
-								<span v-else-if="column.key === 'retries'" class="text-ink-gray-7">
-									{{ row.retries ?? '—' }}
-								</span>
 								<div
 									v-else-if="column.key === 'status'"
 									class="flex w-full items-center justify-between gap-2"
 								>
 									<!-- The failure detail rides on the badge's hover title. -->
 									<span :title="deliveryErrorTitle(row) || undefined">
-										<Badge :label="statusLabel(row.status)" :theme="statusTheme(row.status)" />
+										<Badge
+											:label="undoStatusLabel(row.undo_status)"
+											:theme="undoStatusTheme(row.undo_status)"
+										/>
 									</span>
 									<div class="flex items-center">
 										<Button
@@ -80,7 +82,7 @@
 					<ListEmptyState v-else />
 				</ListRows>
 			</ListView>
-			<DashboardListSkeleton v-else :columns="5" />
+			<DashboardListSkeleton v-else :columns="4" />
 		</div>
 
 		<ScheduleSendModal
@@ -96,8 +98,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, inject, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
+import { watchDebounced } from '@vueuse/core'
 import {
 	CalendarClock,
 	EllipsisVertical,
@@ -122,13 +125,16 @@ import {
 } from 'frappe-ui'
 
 import { raiseToast } from '@/apps/mail/utils'
-import { formatDateTime, fromNow } from '@/apps/mail/utils/datetime'
+import { formatDateTime, fromNow, utcDayEnd, utcDayStart } from '@/apps/mail/utils/datetime'
 import {
+	activeSubmissionFilterCount,
 	deliveryErrorTitle,
-	statusLabel,
-	statusTheme,
+	emptySubmissionFilters,
 	subjectLabel,
-	type ScheduledMail,
+	undoStatusLabel,
+	undoStatusTheme,
+	type Submission,
+	type SubmissionFilters,
 } from '@/apps/mail/utils/submission'
 import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
@@ -136,6 +142,7 @@ import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
+import OutboxFilters from '@/apps/mail/components/OutboxFilters.vue'
 import ScheduleSendModal from '@/apps/mail/components/Modals/ScheduleSendModal.vue'
 
 usePageMeta(() => ({ title: __('Outbox') }))
@@ -148,31 +155,64 @@ const socket = inject('$socket') as {
 }
 const { isMobile } = useScreenSize()
 
-const selected = ref<ScheduledMail | null>(null)
+const selected = ref<Submission | null>(null)
 const showReschedule = ref(false)
 const showSendNow = ref(false)
 const showRetry = ref(false)
 const showCancel = ref(false)
 
-const scheduledMails = createResource({
-	url: 'suite.mail.api.scheduled.get_scheduled_mails',
+const filters = reactive(emptySubmissionFilters())
+// The status tabs always narrow the list; only the optional filters make an empty result
+// mean "no matches" rather than "nothing with this status".
+const hasActiveFilters = computed(() => activeSubmissionFilterCount(filters) > 0)
+
+// A filter or account change makes the current rows a different query's answer, so the list
+// waits on the skeleton until the server responds — unlike the background refreshes below,
+// which keep the rows in place. Without this, switching tabs while the previous result was
+// empty flashes the (wrong) empty state before the response arrives.
+const refetching = ref(false)
+
+const submissions = createResource({
+	url: 'suite.mail.api.scheduled.get_submissions',
 	auto: true,
-	makeParams: () => ({ account: store.accountId }),
-	onError: (error: { message?: string }) =>
-		raiseToast(error.message || __('Request failed.'), 'error'),
+	makeParams: () => ({
+		account: store.accountId,
+		undo_status: filters.undoStatus,
+		identity_id: filters.identityId || undefined,
+		email_id: filters.emailId.trim() || undefined,
+		thread_id: filters.threadId.trim() || undefined,
+		// The date pickers select local calendar days; sendAt is bounded by the UTC
+		// instants that day spans.
+		after: filters.after ? utcDayStart(filters.after) : undefined,
+		before: filters.before ? utcDayEnd(filters.before) : undefined,
+	}),
+	onSuccess: () => (refetching.value = false),
+	onError: (error: { message?: string }) => {
+		refetching.value = false
+		raiseToast(error.message || __('Request failed.'), 'error')
+	},
 })
+
+const applyFilters = () => {
+	refetching.value = true
+	submissions.reload()
+}
 
 watch(
 	() => store.accountId,
-	() => store.accountId && scheduledMails.reload(),
+	() => store.accountId && applyFilters(),
 )
+
+// The id filters are typed; the rest change atomically.
+watchDebounced(() => [filters.emailId, filters.threadId], applyFilters, { debounce: 300 })
+watch(() => [filters.undoStatus, filters.identityId, filters.after, filters.before], applyFilters)
 
 // Kept current the way mailboxes are — a periodic poll (holds release, retries advance, and
 // other clients schedule/cancel without any local signal) plus the new-mail socket (an undo
 // or schedule cancel publishes it). reload() keeps the previous rows while fetching, so the
 // list never flickers back to the skeleton.
 const reloadInterval = ref<ReturnType<typeof setInterval>>()
-const onNewMail = () => scheduledMails.reload()
+const onNewMail = () => submissions.reload()
 
 onMounted(() => {
 	reloadInterval.value = setInterval(onNewMail, 30000)
@@ -184,9 +224,9 @@ onUnmounted(() => {
 	socket.off('new_mail_created', onNewMail)
 })
 
-const rows = computed<ScheduledMail[]>(() => scheduledMails.data || [])
+const rows = computed<Submission[]>(() => submissions.data || [])
 
-const recipientLabel = (row: ScheduledMail) => {
+const recipientLabel = (row: Submission) => {
 	const emails = [
 		...row.recipients.filter((r) => r.type === 'To'),
 		...row.recipients.filter((r) => r.type !== 'To'),
@@ -200,10 +240,26 @@ const recipientLabel = (row: ScheduledMail) => {
 const LIST_COLUMNS = [
 	{ label: __('To'), key: 'recipients' },
 	{ label: __('Subject'), key: 'subject' },
-	{ label: __('Scheduled for'), key: 'send_at' },
-	{ label: __('Retries'), key: 'retries', width: '80px' },
+	{ label: __('Send at'), key: 'send_at' },
 	{ label: __('Status'), key: 'status' },
 ]
+
+// What an empty result means depends on the status tab being viewed.
+const EMPTY_STATES: Record<SubmissionFilters['undoStatus'], { title: string; description: string }> =
+	{
+		pending: {
+			title: __('No pending submissions'),
+			description: __('Scheduled emails and deliveries still in flight will wait here.'),
+		},
+		final: {
+			title: __('No final submissions'),
+			description: __('Concluded deliveries — delivered, sent, or failed — will appear here.'),
+		},
+		canceled: {
+			title: __('No cancelled submissions'),
+			description: __('Deliveries you cancel will appear here.'),
+		},
+	}
 
 const listOptions = computed(() => ({
 	showTooltip: false,
@@ -211,18 +267,20 @@ const listOptions = computed(() => ({
 	rowHeight: 50,
 	// The row opens the submission's details page; the message itself is behind the
 	// explicit Open-email button instead.
-	getRowRoute: (row: ScheduledMail) => ({
+	getRowRoute: (row: Submission) => ({
 		name: 'mail-submission',
 		params: { accountId: store.accountId, submissionId: row.id },
 	}),
-	emptyState: {
-		title: __('No scheduled emails'),
-		description: __('Emails you schedule from the composer will wait here until they are sent.'),
-	},
+	emptyState: hasActiveFilters.value
+		? {
+				title: __('No matching submissions'),
+				description: __('Try adjusting the filters.'),
+			}
+		: EMPTY_STATES[filters.undoStatus],
 }))
 
 // A held message sits in Sent until delivery, so its thread opens there.
-const openEmail = (row: ScheduledMail) => {
+const openEmail = (row: Submission) => {
 	if (!row.thread_id || !store.mailboxIds.sent) return
 	router.push({
 		name: 'mail-mail',
@@ -234,7 +292,7 @@ const openEmail = (row: ScheduledMail) => {
 	})
 }
 
-const rowOptions = (row: ScheduledMail) => {
+const rowOptions = (row: Submission) => {
 	const open = (dialog?: { value: boolean }, submit?: { submit: () => void }) => () => {
 		selected.value = row
 		if (dialog) dialog.value = true
@@ -255,15 +313,24 @@ const rowOptions = (row: ScheduledMail) => {
 		// A released delivery stays cancellable for as long as its submission is pending.
 		return row.undo_status === 'pending' ? [retry, cancel] : [retry]
 	}
-	// A deleted message can't be resubmitted (send now / reschedule recreate the
-	// submission from it) — cancelling the pending delivery is all that's left.
-	if (row.email_deleted) return [cancel]
 
-	return [
-		{ label: __('Send now'), icon: SendHorizontal, onClick: open(showSendNow) },
-		{ label: __('Reschedule'), icon: CalendarClock, onClick: open(showReschedule) },
-		cancel,
-	]
+	if (row.status === 'scheduled') {
+		// A deleted message can't be resubmitted (send now / reschedule recreate the
+		// submission from it) — cancelling the pending delivery is all that's left.
+		if (row.email_deleted) return [cancel]
+
+		return [
+			{ label: __('Send now'), icon: SendHorizontal, onClick: open(showSendNow) },
+			{ label: __('Reschedule'), icon: CalendarClock, onClick: open(showReschedule) },
+			cancel,
+		]
+	}
+
+	// Concluded (sent/delivered/read) or cancelled rows: resubmit and/or drop the record.
+	const remove = { label: __('Remove'), icon: X, onClick: open(undefined, dismissMail) }
+	if (row.status === 'cancelled' || row.email_deleted) return [remove]
+
+	return [{ label: __('Send again'), icon: RefreshCw, onClick: open(showRetry) }, remove]
 }
 
 const openDrafts = () => {
@@ -281,7 +348,7 @@ const onActionError = (error: { messages?: string[]; message?: string }) => {
 	raiseToast(error.messages?.[0] || error.message || __('Request failed.'), 'error')
 	// The action may have failed because the email already went out; reflect the
 	// reconciled state either way.
-	scheduledMails.reload()
+	submissions.reload()
 }
 
 const rescheduleMail = createResource({
@@ -292,7 +359,7 @@ const rescheduleMail = createResource({
 		send_at,
 	}),
 	onSuccess: (data: { send_at: string }) => {
-		scheduledMails.reload()
+		submissions.reload()
 		raiseToast(__('Delivery rescheduled to {0}.', [formatDateTime(data.send_at)]))
 	},
 	onError: onActionError,
@@ -303,7 +370,7 @@ const sendNow = createResource({
 	makeParams: () => ({ account: store.accountId, id: selected.value?.id }),
 	onSuccess: () => {
 		showSendNow.value = false
-		scheduledMails.reload()
+		submissions.reload()
 		raiseToast(__('Message sent.'))
 	},
 	onError: onActionError,
@@ -314,7 +381,7 @@ const retryMail = createResource({
 	makeParams: () => ({ account: store.accountId, id: selected.value?.id }),
 	onSuccess: () => {
 		showRetry.value = false
-		scheduledMails.reload()
+		submissions.reload()
 		raiseToast(__('Message sent.'))
 	},
 	onError: onActionError,
@@ -324,7 +391,7 @@ const retryNow = createResource({
 	url: 'suite.mail.api.scheduled.retry_delivery_now',
 	makeParams: () => ({ account: store.accountId, id: selected.value?.id }),
 	onSuccess: () => {
-		scheduledMails.reload()
+		submissions.reload()
 		raiseToast(__('Delivery attempt scheduled.'))
 	},
 	onError: onActionError,
@@ -333,7 +400,7 @@ const retryNow = createResource({
 const dismissMail = createResource({
 	url: 'suite.mail.api.scheduled.dismiss_failed_mail',
 	makeParams: () => ({ account: store.accountId, id: selected.value?.id }),
-	onSuccess: () => scheduledMails.reload(),
+	onSuccess: () => submissions.reload(),
 	onError: onActionError,
 })
 
@@ -342,7 +409,7 @@ const cancelSchedule = createResource({
 	makeParams: () => ({ account: store.accountId, id: selected.value?.id }),
 	onSuccess: (data: { id?: string }) => {
 		showCancel.value = false
-		scheduledMails.reload()
+		submissions.reload()
 		// No message was moved when the email had been deleted — don't point at Drafts.
 		if (!data.id) return raiseToast(__('Delivery cancelled.'), 'success')
 		raiseToast(
@@ -371,7 +438,10 @@ const sendNowOptions = computed(() => ({
 
 const retryOptions = computed(() => ({
 	title: __('Send Again'),
-	message: __('The delivery failed. Try to send this email again now?'),
+	message:
+		selected.value?.status === 'failed'
+			? __('The delivery failed. Try to send this email again now?')
+			: __('Send this email again now?'),
 	actions: [
 		{
 			label: __('Send'),

--- a/frontend/src/apps/mail/pages/ScheduledMailsView.vue
+++ b/frontend/src/apps/mail/pages/ScheduledMailsView.vue
@@ -96,7 +96,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, inject, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import {
 	CalendarClock,
@@ -142,6 +142,10 @@ usePageMeta(() => ({ title: __('Scheduled') }))
 
 const store = userStore()
 const router = useRouter()
+const socket = inject('$socket') as {
+	on: (event: string, handler: () => void) => void
+	off: (event: string, handler: () => void) => void
+}
 const { isMobile } = useScreenSize()
 
 const selected = ref<ScheduledMail | null>(null)
@@ -162,6 +166,23 @@ watch(
 	() => store.accountId,
 	() => store.accountId && scheduledMails.reload(),
 )
+
+// Kept current the way mailboxes are — a periodic poll (holds release, retries advance, and
+// other clients schedule/cancel without any local signal) plus the new-mail socket (an undo
+// or schedule cancel publishes it). reload() keeps the previous rows while fetching, so the
+// list never flickers back to the skeleton.
+const reloadInterval = ref<ReturnType<typeof setInterval>>()
+const onNewMail = () => scheduledMails.reload()
+
+onMounted(() => {
+	reloadInterval.value = setInterval(onNewMail, 30000)
+	socket.on('new_mail_created', onNewMail)
+})
+
+onUnmounted(() => {
+	if (reloadInterval.value) clearInterval(reloadInterval.value)
+	socket.off('new_mail_created', onNewMail)
+})
 
 const rows = computed<ScheduledMail[]>(() => scheduledMails.data || [])
 

--- a/frontend/src/apps/mail/pages/ScheduledMailsView.vue
+++ b/frontend/src/apps/mail/pages/ScheduledMailsView.vue
@@ -39,21 +39,40 @@
 								>
 									{{ subjectLabel(row) }}
 								</span>
+								<span v-else-if="column.key === 'send_at'" class="truncate">
+									{{ formatDateTime(row.send_at) }}
+									<span class="text-ink-gray-5">({{ fromNow(row.send_at) }})</span>
+								</span>
+								<span v-else-if="column.key === 'retries'" class="text-ink-gray-7">
+									{{ row.retries ?? '—' }}
+								</span>
 								<div
-									v-else-if="column.key === 'send_at'"
+									v-else-if="column.key === 'status'"
 									class="flex w-full items-center justify-between gap-2"
 								>
-									<span class="truncate">
-										{{ formatDateTime(row.send_at) }}
-										<span class="text-ink-gray-5">({{ fromNow(row.send_at) }})</span>
+									<!-- The failure detail rides on the badge's hover title. -->
+									<span :title="deliveryErrorTitle(row) || undefined">
+										<Badge :label="statusLabel(row.status)" :theme="statusTheme(row.status)" />
 									</span>
-									<AdaptiveDropdown :options="rowOptions(row)" placement="bottom-end">
-										<Button variant="ghost" @click.stop.prevent>
+									<div class="flex items-center">
+										<Button
+											v-if="!row.email_deleted && row.thread_id"
+											variant="ghost"
+											:title="__('Open email')"
+											@click.stop.prevent="openEmail(row)"
+										>
 											<template #icon>
-												<EllipsisVertical class="text-ink-gray-5 h-4 w-4" />
+												<Mail class="text-ink-gray-5 h-4 w-4" />
 											</template>
 										</Button>
-									</AdaptiveDropdown>
+										<AdaptiveDropdown :options="rowOptions(row)" placement="bottom-end">
+											<Button variant="ghost" @click.stop.prevent>
+												<template #icon>
+													<EllipsisVertical class="text-ink-gray-5 h-4 w-4" />
+												</template>
+											</Button>
+										</AdaptiveDropdown>
+									</div>
 								</div>
 							</ListRowItem>
 						</ListRow>
@@ -61,7 +80,7 @@
 					<ListEmptyState v-else />
 				</ListRows>
 			</ListView>
-			<DashboardListSkeleton v-else :columns="3" />
+			<DashboardListSkeleton v-else :columns="5" />
 		</div>
 
 		<ScheduleSendModal
@@ -71,6 +90,7 @@
 			@confirm="(sendAt: string) => rescheduleMail.submit({ send_at: sendAt })"
 		/>
 		<Dialog v-model="showSendNow" :options="sendNowOptions" />
+		<Dialog v-model="showRetry" :options="retryOptions" />
 		<Dialog v-model="showCancel" :options="cancelOptions" />
 	</div>
 </template>
@@ -78,8 +98,16 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { CalendarClock, EllipsisVertical, SendHorizontal, X } from 'lucide-vue-next'
 import {
+	CalendarClock,
+	EllipsisVertical,
+	Mail,
+	RefreshCw,
+	SendHorizontal,
+	X,
+} from 'lucide-vue-next'
+import {
+	Badge,
 	Breadcrumbs,
 	Button,
 	Dialog,
@@ -95,6 +123,13 @@ import {
 
 import { raiseToast } from '@/apps/mail/utils'
 import { formatDateTime, fromNow } from '@/apps/mail/utils/datetime'
+import {
+	deliveryErrorTitle,
+	statusLabel,
+	statusTheme,
+	subjectLabel,
+	type ScheduledMail,
+} from '@/apps/mail/utils/submission'
 import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
@@ -102,22 +137,6 @@ import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
 import ScheduleSendModal from '@/apps/mail/components/Modals/ScheduleSendModal.vue'
-
-// One row per held EmailSubmission — the server is the source of truth, so emails
-// scheduled by other clients appear too. `id` is the submission id every action is keyed
-// on. `email_deleted` marks a submission whose Email was deleted after scheduling: it can
-// only be cancelled, and its recipients come from the SMTP envelope.
-type ScheduledMail = {
-	id: string
-	email_id?: string
-	thread_id?: string
-	subject?: string
-	from_name?: string
-	from_email?: string
-	recipients: { type: string; email: string; display_name?: string }[]
-	send_at: string
-	email_deleted: boolean
-}
 
 usePageMeta(() => ({ title: __('Scheduled') }))
 
@@ -128,6 +147,7 @@ const { isMobile } = useScreenSize()
 const selected = ref<ScheduledMail | null>(null)
 const showReschedule = ref(false)
 const showSendNow = ref(false)
+const showRetry = ref(false)
 const showCancel = ref(false)
 
 const scheduledMails = createResource({
@@ -145,9 +165,6 @@ watch(
 
 const rows = computed<ScheduledMail[]>(() => scheduledMails.data || [])
 
-const subjectLabel = (row: ScheduledMail) =>
-	row.email_deleted ? __('(Message deleted)') : row.subject || __('(No subject)')
-
 const recipientLabel = (row: ScheduledMail) => {
 	const emails = [
 		...row.recipients.filter((r) => r.type === 'To'),
@@ -163,62 +180,67 @@ const LIST_COLUMNS = [
 	{ label: __('To'), key: 'recipients' },
 	{ label: __('Subject'), key: 'subject' },
 	{ label: __('Scheduled for'), key: 'send_at' },
+	{ label: __('Retries'), key: 'retries', width: '80px' },
+	{ label: __('Status'), key: 'status' },
 ]
 
 const listOptions = computed(() => ({
 	showTooltip: false,
 	selectable: false,
 	rowHeight: 50,
-	// A held message sits in Sent until delivery, so the row opens its thread there. A
-	// falsy route renders the row as a plain div — deleted-email rows stay non-clickable.
-	getRowRoute: (row: ScheduledMail) =>
-		!row.email_deleted && row.thread_id && store.mailboxIds.sent
-			? {
-					name: 'mail-mail',
-					params: {
-						accountId: store.accountId,
-						mailbox: store.mailboxIds.sent,
-						threadID: row.thread_id,
-					},
-				}
-			: undefined,
+	// The row opens the submission's details page; the message itself is behind the
+	// explicit Open-email button instead.
+	getRowRoute: (row: ScheduledMail) => ({
+		name: 'mail-submission',
+		params: { accountId: store.accountId, submissionId: row.id },
+	}),
 	emptyState: {
 		title: __('No scheduled emails'),
 		description: __('Emails you schedule from the composer will wait here until they are sent.'),
 	},
 }))
 
-const rowOptions = (row: ScheduledMail) => {
-	const cancel = {
-		label: __('Cancel delivery'),
-		icon: X,
-		theme: 'red',
-		onClick: () => {
-			selected.value = row
-			showCancel.value = true
+// A held message sits in Sent until delivery, so its thread opens there.
+const openEmail = (row: ScheduledMail) => {
+	if (!row.thread_id || !store.mailboxIds.sent) return
+	router.push({
+		name: 'mail-mail',
+		params: {
+			accountId: store.accountId,
+			mailbox: store.mailboxIds.sent,
+			threadID: row.thread_id,
 		},
+	})
+}
+
+const rowOptions = (row: ScheduledMail) => {
+	const open = (dialog?: { value: boolean }, submit?: { submit: () => void }) => () => {
+		selected.value = row
+		if (dialog) dialog.value = true
+		submit?.submit()
+	}
+
+	if (row.status === 'failed') {
+		const retry = { label: __('Send again'), icon: RefreshCw, onClick: open(showRetry) }
+		const dismiss = { label: __('Dismiss'), icon: X, onClick: open(undefined, dismissMail) }
+		// A deleted message can't be resubmitted — dropping the failed record is all that's left.
+		return row.email_deleted ? [dismiss] : [retry, dismiss]
+	}
+
+	const cancel = { label: __('Cancel delivery'), icon: X, theme: 'red', onClick: open(showCancel) }
+
+	if (row.status === 'retrying' || row.status === 'queued') {
+		const retry = { label: __('Try again now'), icon: RefreshCw, onClick: open(undefined, retryNow) }
+		// A released delivery stays cancellable for as long as its submission is pending.
+		return row.undo_status === 'pending' ? [retry, cancel] : [retry]
 	}
 	// A deleted message can't be resubmitted (send now / reschedule recreate the
 	// submission from it) — cancelling the pending delivery is all that's left.
 	if (row.email_deleted) return [cancel]
 
 	return [
-		{
-			label: __('Send now'),
-			icon: SendHorizontal,
-			onClick: () => {
-				selected.value = row
-				showSendNow.value = true
-			},
-		},
-		{
-			label: __('Reschedule'),
-			icon: CalendarClock,
-			onClick: () => {
-				selected.value = row
-				showReschedule.value = true
-			},
-		},
+		{ label: __('Send now'), icon: SendHorizontal, onClick: open(showSendNow) },
+		{ label: __('Reschedule'), icon: CalendarClock, onClick: open(showReschedule) },
 		cancel,
 	]
 }
@@ -233,6 +255,7 @@ const openDrafts = () => {
 
 const onActionError = (error: { messages?: string[]; message?: string }) => {
 	showSendNow.value = false
+	showRetry.value = false
 	showCancel.value = false
 	raiseToast(error.messages?.[0] || error.message || __('Request failed.'), 'error')
 	// The action may have failed because the email already went out; reflect the
@@ -265,6 +288,34 @@ const sendNow = createResource({
 	onError: onActionError,
 })
 
+const retryMail = createResource({
+	url: 'suite.mail.api.scheduled.retry_failed_mail',
+	makeParams: () => ({ account: store.accountId, id: selected.value?.id }),
+	onSuccess: () => {
+		showRetry.value = false
+		scheduledMails.reload()
+		raiseToast(__('Message sent.'))
+	},
+	onError: onActionError,
+})
+
+const retryNow = createResource({
+	url: 'suite.mail.api.scheduled.retry_delivery_now',
+	makeParams: () => ({ account: store.accountId, id: selected.value?.id }),
+	onSuccess: () => {
+		scheduledMails.reload()
+		raiseToast(__('Delivery attempt scheduled.'))
+	},
+	onError: onActionError,
+})
+
+const dismissMail = createResource({
+	url: 'suite.mail.api.scheduled.dismiss_failed_mail',
+	makeParams: () => ({ account: store.accountId, id: selected.value?.id }),
+	onSuccess: () => scheduledMails.reload(),
+	onError: onActionError,
+})
+
 const cancelSchedule = createResource({
 	url: 'suite.mail.api.scheduled.cancel_scheduled_mail',
 	makeParams: () => ({ account: store.accountId, id: selected.value?.id }),
@@ -293,6 +344,19 @@ const sendNowOptions = computed(() => ({
 			variant: 'solid',
 			loading: sendNow.loading,
 			onClick: sendNow.submit,
+		},
+	],
+}))
+
+const retryOptions = computed(() => ({
+	title: __('Send Again'),
+	message: __('The delivery failed. Try to send this email again now?'),
+	actions: [
+		{
+			label: __('Send'),
+			variant: 'solid',
+			loading: retryMail.loading,
+			onClick: retryMail.submit,
 		},
 	],
 }))

--- a/frontend/src/apps/mail/pages/ScheduledMailsView.vue
+++ b/frontend/src/apps/mail/pages/ScheduledMailsView.vue
@@ -16,14 +16,14 @@
 				:columns="LIST_COLUMNS"
 				:rows="rows"
 				:options="listOptions"
-				row-key="name"
+				row-key="id"
 			>
 				<ListHeader />
 				<ListRows>
 					<template v-if="rows.length">
 						<ListRow
 							v-for="row in rows"
-							:key="row.name"
+							:key="row.id"
 							v-slot="{ column, item }"
 							:row="row"
 							class="hover:!bg-surface-gray-1"
@@ -32,8 +32,12 @@
 								<span v-if="column.key === 'recipients'" class="truncate">
 									{{ recipientLabel(row) }}
 								</span>
-								<span v-else-if="column.key === 'subject'" class="truncate">
-									{{ row.subject || __('(No subject)') }}
+								<span
+									v-else-if="column.key === 'subject'"
+									class="truncate"
+									:class="{ 'text-ink-gray-5 italic': row.email_deleted }"
+								>
+									{{ subjectLabel(row) }}
 								</span>
 								<div
 									v-else-if="column.key === 'send_at'"
@@ -99,16 +103,20 @@ import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
 import ScheduleSendModal from '@/apps/mail/components/Modals/ScheduleSendModal.vue'
 
+// One row per held EmailSubmission — the server is the source of truth, so emails
+// scheduled by other clients appear too. `id` is the submission id every action is keyed
+// on. `email_deleted` marks a submission whose Email was deleted after scheduling: it can
+// only be cancelled, and its recipients come from the SMTP envelope.
 type ScheduledMail = {
-	name: string
 	id: string
+	email_id?: string
 	thread_id?: string
 	subject?: string
+	from_name?: string
 	from_email?: string
 	recipients: { type: string; email: string; display_name?: string }[]
 	send_at: string
-	submission_id?: string
-	creation?: string
+	email_deleted: boolean
 }
 
 usePageMeta(() => ({ title: __('Scheduled') }))
@@ -123,7 +131,7 @@ const showSendNow = ref(false)
 const showCancel = ref(false)
 
 const scheduledMails = createResource({
-	url: 'suite.mail.api.mail.get_scheduled_mails',
+	url: 'suite.mail.api.scheduled.get_scheduled_mails',
 	auto: true,
 	makeParams: () => ({ account: store.accountId }),
 	onError: (error: { message?: string }) =>
@@ -136,6 +144,9 @@ watch(
 )
 
 const rows = computed<ScheduledMail[]>(() => scheduledMails.data || [])
+
+const subjectLabel = (row: ScheduledMail) =>
+	row.email_deleted ? __('(Message deleted)') : row.subject || __('(No subject)')
 
 const recipientLabel = (row: ScheduledMail) => {
 	const emails = [
@@ -158,30 +169,27 @@ const listOptions = computed(() => ({
 	showTooltip: false,
 	selectable: false,
 	rowHeight: 50,
+	// A held message sits in Sent until delivery, so the row opens its thread there. A
+	// falsy route renders the row as a plain div — deleted-email rows stay non-clickable.
+	getRowRoute: (row: ScheduledMail) =>
+		!row.email_deleted && row.thread_id && store.mailboxIds.sent
+			? {
+					name: 'mail-mail',
+					params: {
+						accountId: store.accountId,
+						mailbox: store.mailboxIds.sent,
+						threadID: row.thread_id,
+					},
+				}
+			: undefined,
 	emptyState: {
 		title: __('No scheduled emails'),
 		description: __('Emails you schedule from the composer will wait here until they are sent.'),
 	},
 }))
 
-const rowOptions = (row: ScheduledMail) => [
-	{
-		label: __('Send now'),
-		icon: SendHorizontal,
-		onClick: () => {
-			selected.value = row
-			showSendNow.value = true
-		},
-	},
-	{
-		label: __('Reschedule'),
-		icon: CalendarClock,
-		onClick: () => {
-			selected.value = row
-			showReschedule.value = true
-		},
-	},
-	{
+const rowOptions = (row: ScheduledMail) => {
+	const cancel = {
 		label: __('Cancel delivery'),
 		icon: X,
 		theme: 'red',
@@ -189,8 +197,31 @@ const rowOptions = (row: ScheduledMail) => [
 			selected.value = row
 			showCancel.value = true
 		},
-	},
-]
+	}
+	// A deleted message can't be resubmitted (send now / reschedule recreate the
+	// submission from it) — cancelling the pending delivery is all that's left.
+	if (row.email_deleted) return [cancel]
+
+	return [
+		{
+			label: __('Send now'),
+			icon: SendHorizontal,
+			onClick: () => {
+				selected.value = row
+				showSendNow.value = true
+			},
+		},
+		{
+			label: __('Reschedule'),
+			icon: CalendarClock,
+			onClick: () => {
+				selected.value = row
+				showReschedule.value = true
+			},
+		},
+		cancel,
+	]
+}
 
 const openDrafts = () => {
 	if (!store.mailboxIds.drafts) return
@@ -210,10 +241,10 @@ const onActionError = (error: { messages?: string[]; message?: string }) => {
 }
 
 const rescheduleMail = createResource({
-	url: 'suite.mail.api.mail.reschedule_mail',
+	url: 'suite.mail.api.scheduled.reschedule_mail',
 	makeParams: ({ send_at }: { send_at: string }) => ({
 		account: store.accountId,
-		name: selected.value?.name,
+		id: selected.value?.id,
 		send_at,
 	}),
 	onSuccess: (data: { send_at: string }) => {
@@ -224,8 +255,8 @@ const rescheduleMail = createResource({
 })
 
 const sendNow = createResource({
-	url: 'suite.mail.api.mail.send_scheduled_mail_now',
-	makeParams: () => ({ account: store.accountId, name: selected.value?.name }),
+	url: 'suite.mail.api.scheduled.send_scheduled_mail_now',
+	makeParams: () => ({ account: store.accountId, id: selected.value?.id }),
 	onSuccess: () => {
 		showSendNow.value = false
 		scheduledMails.reload()
@@ -235,11 +266,13 @@ const sendNow = createResource({
 })
 
 const cancelSchedule = createResource({
-	url: 'suite.mail.api.mail.cancel_scheduled_mail',
-	makeParams: () => ({ account: store.accountId, name: selected.value?.name }),
-	onSuccess: () => {
+	url: 'suite.mail.api.scheduled.cancel_scheduled_mail',
+	makeParams: () => ({ account: store.accountId, id: selected.value?.id }),
+	onSuccess: (data: { id?: string }) => {
 		showCancel.value = false
 		scheduledMails.reload()
+		// No message was moved when the email had been deleted — don't point at Drafts.
+		if (!data.id) return raiseToast(__('Delivery cancelled.'), 'success')
 		raiseToast(
 			__('Delivery cancelled. The message is back in your drafts.'),
 			'success',
@@ -266,7 +299,9 @@ const sendNowOptions = computed(() => ({
 
 const cancelOptions = computed(() => ({
 	title: __('Cancel Delivery'),
-	message: __('Cancel the scheduled delivery and move the message back to Drafts?'),
+	message: selected.value?.email_deleted
+		? __('Cancel the scheduled delivery?')
+		: __('Cancel the scheduled delivery and move the message back to Drafts?'),
 	icon: { name: 'alert-triangle', appearance: 'warning' },
 	actions: [
 		{

--- a/frontend/src/apps/mail/pages/SubmissionDetailsView.vue
+++ b/frontend/src/apps/mail/pages/SubmissionDetailsView.vue
@@ -1,0 +1,392 @@
+<template>
+	<div class="flex h-full flex-col">
+		<header
+			class="flex items-center justify-between gap-2 border-b px-3 py-2.5 max-sm:p-0 sm:px-5"
+		>
+			<MobileTitleHeader v-if="isMobile" class="min-w-0 flex-1" :title="title" />
+			<!-- -ml-0.5 cancels the crumb's own padding so the title sits on the px-5 axis -->
+			<Breadcrumbs
+				v-else
+				:items="[
+					{ label: __('Scheduled'), route: { name: 'mail-scheduled', params: { accountId } } },
+					{ label: title },
+				]"
+				class="-ml-0.5 min-w-0"
+			/>
+			<div v-if="data" class="flex shrink-0 items-center gap-2 max-sm:px-3 max-sm:py-2">
+				<Button v-if="canOpenEmail" :label="__('Open email')" @click="openEmail">
+					<template #prefix><Mail class="h-4 w-4" /></template>
+				</Button>
+				<template v-if="data.status === 'scheduled'">
+					<Button
+						v-if="!data.email_deleted"
+						:label="__('Send now')"
+						@click="showSendNow = true"
+					/>
+					<Button
+						v-if="!data.email_deleted"
+						:label="__('Reschedule')"
+						@click="showReschedule = true"
+					/>
+					<Button theme="red" :label="__('Cancel delivery')" @click="showCancel = true" />
+				</template>
+				<template v-else-if="data.status === 'retrying' || data.status === 'queued'">
+					<Button
+						:label="__('Try again now')"
+						:loading="retryNow.loading"
+						@click="retryNow.submit()"
+					/>
+					<!-- A released delivery stays cancellable while its submission is pending. -->
+					<Button
+						v-if="data.undo_status === 'pending'"
+						theme="red"
+						:label="__('Cancel delivery')"
+						@click="showCancel = true"
+					/>
+				</template>
+				<template v-else-if="data.status === 'failed'">
+					<Button
+						v-if="!data.email_deleted"
+						:label="__('Send again')"
+						@click="showRetry = true"
+					/>
+					<Button
+						:label="__('Dismiss')"
+						:loading="dismissMail.loading"
+						@click="dismissMail.submit()"
+					/>
+				</template>
+			</div>
+		</header>
+
+		<div v-if="data" class="flex-1 overflow-y-auto px-3 py-4 sm:px-5">
+			<div class="mx-auto grid max-w-5xl grid-cols-1 gap-5 lg:grid-cols-2">
+				<DashboardCard :title="__('Delivery')">
+					<div class="even:bg-surface-gray-1 flex items-center px-5 py-3.5 text-base">
+						<div class="text-ink-gray-5 w-1/3">{{ __('Status') }}</div>
+						<div class="w-2/3">
+							<Badge :label="statusLabel(data.status)" :theme="statusTheme(data.status)" />
+						</div>
+					</div>
+					<InformationField
+						:label="data.status === 'scheduled' ? __('Scheduled for') : __('Released at')"
+						:value="sendAtLabel"
+					/>
+					<InformationField :label="__('Retries')" :value="String(data.retries ?? '—')" />
+					<InformationField :label="__('Next retry')" :value="formatDateTime(data.next_retry)" />
+					<InformationField :label="__('Priority')" :value="priorityLabel" />
+					<InformationField :label="__('Delivery reports')" :value="String(data.dsn_count)" />
+					<InformationField :label="__('Read receipts')" :value="String(data.mdn_count)" />
+				</DashboardCard>
+
+				<DashboardCard :title="__('Message')">
+					<InformationField :label="__('Subject')" :value="subjectLabel(data)" />
+					<InformationField :label="__('From')" :value="fromLabel" />
+					<InformationField
+						v-for="type in ['To', 'Cc', 'Bcc']"
+						:key="type"
+						:label="__(type)"
+						:value="recipientsOfType(type)"
+					/>
+					<div v-if="data.email_deleted" class="text-ink-gray-5 px-5 py-3.5 text-sm">
+						{{
+							__(
+								'The original message was deleted after scheduling, so only the envelope details remain.',
+							)
+						}}
+					</div>
+				</DashboardCard>
+
+				<DashboardCard :title="__('Recipients')">
+					<template v-if="data.recipients_status.length">
+						<div
+							v-for="r in data.recipients_status"
+							:key="r.email"
+							class="flex items-start gap-3 border-b px-5 py-3 last:border-b-0"
+						>
+							<div class="min-w-0 flex-1">
+								<p class="truncate text-base">{{ r.email }}</p>
+								<!-- The server's raw SMTP reply, whatever the outcome. -->
+								<p v-if="r.smtp_reply || r.reason" class="text-ink-gray-6 mt-0.5 text-xs break-words">
+									{{ r.smtp_reply || r.reason }}
+								</p>
+								<p v-if="deliverySummary(r)" class="text-ink-gray-5 mt-0.5 text-xs">
+									{{ deliverySummary(r) }}
+								</p>
+							</div>
+							<Badge :label="statusLabel(r.status)" :theme="statusTheme(r.status)" />
+						</div>
+					</template>
+					<div v-else class="text-ink-gray-5 px-5 py-6 text-center text-sm">
+						{{ __('No recipients.') }}
+					</div>
+				</DashboardCard>
+
+				<DashboardCard :title="__('References')">
+					<InformationField :label="__('Submission ID')" :value="data.id" />
+					<InformationField :label="__('Email ID')" :value="data.email_id" />
+					<InformationField :label="__('Thread ID')" :value="data.thread_id" />
+					<InformationField :label="__('Identity')" :value="data.identity_email" />
+					<InformationField :label="__('Envelope sender')" :value="data.envelope_from" />
+					<InformationField
+						:label="__('Envelope recipients')"
+						:value="data.envelope_recipients.join(', ')"
+					/>
+				</DashboardCard>
+			</div>
+		</div>
+		<div v-else class="flex flex-1 items-center justify-center">
+			<LoadingIndicator class="text-ink-gray-5 h-5 w-5" />
+		</div>
+
+		<ScheduleSendModal
+			v-model="showReschedule"
+			:title="__('Reschedule delivery')"
+			:initial-value="data?.send_at"
+			@confirm="(sendAt: string) => rescheduleMail.submit({ send_at: sendAt })"
+		/>
+		<Dialog v-model="showSendNow" :options="sendNowOptions" />
+		<Dialog v-model="showRetry" :options="retryOptions" />
+		<Dialog v-model="showCancel" :options="cancelOptions" />
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { Mail } from 'lucide-vue-next'
+import {
+	Badge,
+	Breadcrumbs,
+	Button,
+	Dialog,
+	LoadingIndicator,
+	createResource,
+	usePageMeta,
+} from 'frappe-ui'
+
+import { raiseToast } from '@/apps/mail/utils'
+import { formatDateTime, fromNow } from '@/apps/mail/utils/datetime'
+import {
+	statusLabel,
+	statusTheme,
+	subjectLabel,
+	type RecipientState,
+	type SubmissionDetails,
+} from '@/apps/mail/utils/submission'
+import { useScreenSize } from '@/apps/mail/utils/composables'
+import { userStore } from '@/apps/mail/stores/user'
+import DashboardCard from '@/apps/mail/components/DashboardCard.vue'
+import InformationField from '@/apps/mail/components/InformationField.vue'
+import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
+import ScheduleSendModal from '@/apps/mail/components/Modals/ScheduleSendModal.vue'
+
+const { accountId, submissionId } = defineProps<{ accountId: string; submissionId: string }>()
+
+usePageMeta(() => ({ title: __('Scheduled email') }))
+
+const store = userStore()
+const router = useRouter()
+const { isMobile } = useScreenSize()
+
+const showReschedule = ref(false)
+const showSendNow = ref(false)
+const showRetry = ref(false)
+const showCancel = ref(false)
+
+const submission = createResource({
+	url: 'suite.mail.api.scheduled.get_scheduled_mail',
+	auto: true,
+	makeParams: () => ({ account: accountId, id: submissionId }),
+	onError: (error: { messages?: string[]; message?: string }) => {
+		raiseToast(error.messages?.[0] || error.message || __('Submission not found.'), 'error')
+		backToList()
+	},
+})
+
+// Actions that replace the submission land on the successor's id (see below).
+watch(
+	() => submissionId,
+	() => submission.reload(),
+)
+
+const data = computed<SubmissionDetails | null>(() => submission.data || null)
+
+const title = computed(() => (data.value ? subjectLabel(data.value) : __('Scheduled email')))
+
+const canOpenEmail = computed(
+	() => !!data.value && !data.value.email_deleted && !!data.value.thread_id,
+)
+
+const sendAtLabel = computed(() =>
+	data.value?.send_at
+		? `${formatDateTime(data.value.send_at)} (${fromNow(data.value.send_at)})`
+		: undefined,
+)
+
+const fromLabel = computed(() => {
+	if (!data.value) return undefined
+	const { from_name, from_email, identity_email, envelope_from } = data.value
+	const email = from_email || identity_email || envelope_from
+	return from_name && email ? `${from_name} <${email}>` : email
+})
+
+// The MT-Priority values MailQueue submits with (RFC 6710).
+const priorityLabel = computed(() => {
+	const labels: Record<number, string> = { 4: __('High'), 0: __('Normal'), [-4]: __('Low') }
+	return labels[data.value?.priority ?? 0] || String(data.value?.priority)
+})
+
+const recipientsOfType = (type: string) =>
+	data.value?.recipients
+		.filter((r) => r.type === type)
+		.map((r) => (r.display_name ? `${r.display_name} <${r.email}>` : r.email))
+		.join(', ') || undefined
+
+// The DeliveryStatus enums, spelled out for the reader.
+const DELIVERED_LABELS: Record<string, string> = {
+	queued: __('Queued'),
+	yes: __('Yes'),
+	no: __('No'),
+	unknown: __('Unknown'),
+}
+
+const deliverySummary = (r: RecipientState) => {
+	const parts = []
+	if (r.delivered) parts.push(__('Delivered: {0}', [DELIVERED_LABELS[r.delivered] || r.delivered]))
+	if (r.displayed)
+		parts.push(__('Displayed: {0}', [DELIVERED_LABELS[r.displayed] || r.displayed]))
+	if (r.retries) parts.push(__('Retries: {0}', [String(r.retries)]))
+	if (r.next_retry) parts.push(__('Next retry {0}', [fromNow(r.next_retry)]))
+	return parts.join(' · ')
+}
+
+// A held message sits in Sent until delivery, so its thread opens there.
+const openEmail = () => {
+	if (!data.value?.thread_id || !store.mailboxIds.sent) return
+	router.push({
+		name: 'mail-mail',
+		params: {
+			accountId,
+			mailbox: store.mailboxIds.sent,
+			threadID: data.value.thread_id,
+		},
+	})
+}
+
+const backToList = () => router.replace({ name: 'mail-scheduled', params: { accountId } })
+
+/** Follow an action that replaced this submission to its successor's page. */
+const followReplacement = (id: string) =>
+	router.replace({ name: 'mail-submission', params: { accountId, submissionId: id } })
+
+const onActionError = (error: { messages?: string[]; message?: string }) => {
+	showSendNow.value = false
+	showRetry.value = false
+	showCancel.value = false
+	raiseToast(error.messages?.[0] || error.message || __('Request failed.'), 'error')
+	submission.reload()
+}
+
+const rescheduleMail = createResource({
+	url: 'suite.mail.api.scheduled.reschedule_mail',
+	makeParams: ({ send_at }: { send_at: string }) => ({
+		account: accountId,
+		id: submissionId,
+		send_at,
+	}),
+	onSuccess: (result: { id: string; send_at: string }) => {
+		raiseToast(__('Delivery rescheduled to {0}.', [formatDateTime(result.send_at)]))
+		followReplacement(result.id)
+	},
+	onError: onActionError,
+})
+
+const sendNow = createResource({
+	url: 'suite.mail.api.scheduled.send_scheduled_mail_now',
+	makeParams: () => ({ account: accountId, id: submissionId }),
+	onSuccess: (result: { id: string }) => {
+		showSendNow.value = false
+		raiseToast(__('Message sent.'))
+		followReplacement(result.id)
+	},
+	onError: onActionError,
+})
+
+const retryMail = createResource({
+	url: 'suite.mail.api.scheduled.retry_failed_mail',
+	makeParams: () => ({ account: accountId, id: submissionId }),
+	onSuccess: (result: { id: string }) => {
+		showRetry.value = false
+		raiseToast(__('Message sent.'))
+		followReplacement(result.id)
+	},
+	onError: onActionError,
+})
+
+const retryNow = createResource({
+	url: 'suite.mail.api.scheduled.retry_delivery_now',
+	makeParams: () => ({ account: accountId, id: submissionId }),
+	onSuccess: () => {
+		raiseToast(__('Delivery attempt scheduled.'))
+		submission.reload()
+	},
+	onError: onActionError,
+})
+
+const dismissMail = createResource({
+	url: 'suite.mail.api.scheduled.dismiss_failed_mail',
+	makeParams: () => ({ account: accountId, id: submissionId }),
+	onSuccess: backToList,
+	onError: onActionError,
+})
+
+const cancelSchedule = createResource({
+	url: 'suite.mail.api.scheduled.cancel_scheduled_mail',
+	makeParams: () => ({ account: accountId, id: submissionId }),
+	onSuccess: (result: { id?: string }) => {
+		showCancel.value = false
+		raiseToast(
+			result.id
+				? __('Delivery cancelled. The message is back in your drafts.')
+				: __('Delivery cancelled.'),
+			'success',
+		)
+		backToList()
+	},
+	onError: onActionError,
+})
+
+const sendNowOptions = computed(() => ({
+	title: __('Send Now'),
+	message: __('Deliver this email immediately instead of at the scheduled time?'),
+	actions: [
+		{ label: __('Send'), variant: 'solid', loading: sendNow.loading, onClick: sendNow.submit },
+	],
+}))
+
+const retryOptions = computed(() => ({
+	title: __('Send Again'),
+	message: __('The delivery failed. Try to send this email again now?'),
+	actions: [
+		{ label: __('Send'), variant: 'solid', loading: retryMail.loading, onClick: retryMail.submit },
+	],
+}))
+
+const cancelOptions = computed(() => ({
+	title: __('Cancel Delivery'),
+	message: data.value?.email_deleted
+		? __('Cancel the scheduled delivery?')
+		: __('Cancel the scheduled delivery and move the message back to Drafts?'),
+	icon: { name: 'alert-triangle', appearance: 'warning' },
+	actions: [
+		{
+			label: __('Confirm'),
+			variant: 'solid',
+			theme: 'red',
+			loading: cancelSchedule.loading,
+			onClick: cancelSchedule.submit,
+		},
+	],
+}))
+</script>

--- a/frontend/src/apps/mail/pages/SubmissionDetailsView.vue
+++ b/frontend/src/apps/mail/pages/SubmissionDetailsView.vue
@@ -62,80 +62,90 @@
 		</header>
 
 		<div v-if="data" class="flex-1 overflow-y-auto px-3 py-4 sm:px-5">
-			<div class="mx-auto grid max-w-5xl grid-cols-1 gap-5 lg:grid-cols-2">
-				<DashboardCard :title="__('Delivery')">
-					<!-- Status is the raw JMAP undoStatus, as on the list page; the merged
-					delivery state is not shown but still drives the header actions. -->
-					<InformationField :label="__('Status')">
-						<Badge
-							:label="undoStatusLabel(data.undo_status)"
-							:theme="undoStatusTheme(data.undo_status)"
+			<!-- Two independent stacks, not a grid: rows in a grid stretch to the tallest
+			card, leaving dead space under the shorter one. md, not lg — the page should
+			pair up as soon as two cards fit. -->
+			<div class="mx-auto flex max-w-5xl flex-col gap-5 md:flex-row md:items-start">
+				<div class="flex min-w-0 flex-1 flex-col gap-5">
+					<DashboardCard :title="__('Delivery')">
+						<!-- Status is the raw JMAP undoStatus, as on the list page; the merged
+						delivery state is not shown but still drives the header actions. -->
+						<InformationField :label="__('Status')">
+							<Badge
+								:label="undoStatusLabel(data.undo_status)"
+								:theme="undoStatusTheme(data.undo_status)"
+							/>
+						</InformationField>
+						<InformationField
+							:label="data.status === 'scheduled' ? __('Scheduled for') : __('Released at')"
+							:value="sendAtLabel"
 						/>
-					</InformationField>
-					<InformationField
-						:label="data.status === 'scheduled' ? __('Scheduled for') : __('Released at')"
-						:value="sendAtLabel"
-					/>
-					<InformationField :label="__('Retries')" :value="String(data.retries ?? '—')" />
-					<InformationField :label="__('Next retry')" :value="formatDateTime(data.next_retry)" />
-					<InformationField :label="__('Priority')" :value="priorityLabel" />
-					<InformationField :label="__('Delivery reports')" :value="String(data.dsn_count)" />
-					<InformationField :label="__('Read receipts')" :value="String(data.mdn_count)" />
-				</DashboardCard>
+						<InformationField :label="__('Retries')" :value="String(data.retries ?? '—')" />
+						<InformationField :label="__('Next retry')" :value="formatDateTime(data.next_retry)" />
+						<InformationField :label="__('Priority')" :value="priorityLabel" />
+						<InformationField :label="__('Delivery reports')" :value="String(data.dsn_count)" />
+						<InformationField :label="__('Read receipts')" :value="String(data.mdn_count)" />
+					</DashboardCard>
 
-				<DashboardCard :title="__('Message')">
-					<InformationField :label="__('Subject')" :value="subjectLabel(data)" />
-					<InformationField :label="__('From')" :value="fromLabel" />
-					<InformationField
-						v-for="type in ['To', 'Cc', 'Bcc']"
-						:key="type"
-						:label="__(type)"
-						:value="recipientsOfType(type)"
-					/>
-					<div v-if="data.email_deleted" class="text-ink-gray-5 px-5 py-3.5 text-sm">
-						{{
-							__(
-								'The original message was deleted after scheduling, so only the envelope details remain.',
-							)
-						}}
-					</div>
-				</DashboardCard>
-
-				<DashboardCard :title="__('Recipients')">
-					<template v-if="data.recipients_status.length">
-						<div
-							v-for="r in data.recipients_status"
-							:key="r.email"
-							class="flex items-start gap-3 border-b px-5 py-3 last:border-b-0"
-						>
-							<div class="min-w-0 flex-1">
-								<p class="truncate text-base">{{ r.email }}</p>
-								<!-- The server's raw SMTP reply, whatever the outcome. -->
-								<p v-if="r.smtp_reply || r.reason" class="text-ink-gray-6 mt-0.5 text-xs break-words">
-									{{ r.smtp_reply || r.reason }}
-								</p>
-								<p v-if="deliverySummary(r)" class="text-ink-gray-5 mt-0.5 text-xs">
-									{{ deliverySummary(r) }}
-								</p>
+					<DashboardCard :title="__('Recipients')">
+						<template v-if="data.recipients_status.length">
+							<div
+								v-for="r in data.recipients_status"
+								:key="r.email"
+								class="flex items-start gap-3 border-b px-5 py-3 last:border-b-0"
+							>
+								<div class="min-w-0 flex-1">
+									<p class="truncate text-base">{{ r.email }}</p>
+									<!-- The server's raw SMTP reply, whatever the outcome. -->
+									<p
+										v-if="r.smtp_reply || r.reason"
+										class="text-ink-gray-6 mt-0.5 text-xs break-words"
+									>
+										{{ r.smtp_reply || r.reason }}
+									</p>
+									<p v-if="deliverySummary(r)" class="text-ink-gray-5 mt-0.5 text-xs">
+										{{ deliverySummary(r) }}
+									</p>
+								</div>
 							</div>
+						</template>
+						<div v-else class="text-ink-gray-5 px-5 py-6 text-center text-sm">
+							{{ __('No recipients.') }}
 						</div>
-					</template>
-					<div v-else class="text-ink-gray-5 px-5 py-6 text-center text-sm">
-						{{ __('No recipients.') }}
-					</div>
-				</DashboardCard>
+					</DashboardCard>
+				</div>
 
-				<DashboardCard :title="__('References')">
-					<InformationField :label="__('Submission ID')" :value="data.id" />
-					<InformationField :label="__('Email ID')" :value="data.email_id" />
-					<InformationField :label="__('Thread ID')" :value="data.thread_id" />
-					<InformationField :label="__('Identity')" :value="data.identity_email" />
-					<InformationField :label="__('Envelope sender')" :value="data.envelope_from" />
-					<InformationField
-						:label="__('Envelope recipients')"
-						:value="data.envelope_recipients.join(', ')"
-					/>
-				</DashboardCard>
+				<div class="flex min-w-0 flex-1 flex-col gap-5">
+					<DashboardCard :title="__('Message')">
+						<InformationField :label="__('Subject')" :value="subjectLabel(data)" />
+						<InformationField :label="__('From')" :value="fromLabel" />
+						<InformationField
+							v-for="type in ['To', 'Cc', 'Bcc']"
+							:key="type"
+							:label="__(type)"
+							:value="recipientsOfType(type)"
+						/>
+						<div v-if="data.email_deleted" class="text-ink-gray-5 px-5 py-3.5 text-sm">
+							{{
+								__(
+									'The original message was deleted after scheduling, so only the envelope details remain.',
+								)
+							}}
+						</div>
+					</DashboardCard>
+
+					<DashboardCard :title="__('References')">
+						<InformationField :label="__('Submission ID')" :value="data.id" />
+						<InformationField :label="__('Email ID')" :value="data.email_id" />
+						<InformationField :label="__('Thread ID')" :value="data.thread_id" />
+						<InformationField :label="__('Identity')" :value="data.identity_email" />
+						<InformationField :label="__('Envelope sender')" :value="data.envelope_from" />
+						<InformationField
+							:label="__('Envelope recipients')"
+							:value="data.envelope_recipients.join(', ')"
+						/>
+					</DashboardCard>
+				</div>
 			</div>
 		</div>
 		<div v-else class="flex flex-1 items-center justify-center">

--- a/frontend/src/apps/mail/pages/SubmissionDetailsView.vue
+++ b/frontend/src/apps/mail/pages/SubmissionDetailsView.vue
@@ -8,7 +8,7 @@
 			<Breadcrumbs
 				v-else
 				:items="[
-					{ label: __('Scheduled'), route: { name: 'mail-scheduled', params: { accountId } } },
+					{ label: __('Outbox'), route: { name: 'mail-outbox', params: { accountId } } },
 					{ label: title },
 				]"
 				class="-ml-0.5 min-w-0"
@@ -183,7 +183,7 @@ import ScheduleSendModal from '@/apps/mail/components/Modals/ScheduleSendModal.v
 
 const { accountId, submissionId } = defineProps<{ accountId: string; submissionId: string }>()
 
-usePageMeta(() => ({ title: __('Scheduled email') }))
+usePageMeta(() => ({ title: __('Outbox email') }))
 
 const store = userStore()
 const router = useRouter()
@@ -212,7 +212,7 @@ watch(
 
 const data = computed<SubmissionDetails | null>(() => submission.data || null)
 
-const title = computed(() => (data.value ? subjectLabel(data.value) : __('Scheduled email')))
+const title = computed(() => (data.value ? subjectLabel(data.value) : __('Outbox email')))
 
 const canOpenEmail = computed(
 	() => !!data.value && !data.value.email_deleted && !!data.value.thread_id,
@@ -274,7 +274,7 @@ const openEmail = () => {
 	})
 }
 
-const backToList = () => router.replace({ name: 'mail-scheduled', params: { accountId } })
+const backToList = () => router.replace({ name: 'mail-outbox', params: { accountId } })
 
 /** Follow an action that replaced this submission to its successor's page. */
 const followReplacement = (id: string) =>

--- a/frontend/src/apps/mail/pages/SubmissionDetailsView.vue
+++ b/frontend/src/apps/mail/pages/SubmissionDetailsView.vue
@@ -53,7 +53,7 @@
 						@click="showRetry = true"
 					/>
 					<Button
-						:label="__('Dismiss')"
+						:label="__('Remove')"
 						:loading="dismissMail.loading"
 						@click="dismissMail.submit()"
 					/>
@@ -64,12 +64,14 @@
 		<div v-if="data" class="flex-1 overflow-y-auto px-3 py-4 sm:px-5">
 			<div class="mx-auto grid max-w-5xl grid-cols-1 gap-5 lg:grid-cols-2">
 				<DashboardCard :title="__('Delivery')">
-					<div class="even:bg-surface-gray-1 flex items-center px-5 py-3.5 text-base">
-						<div class="text-ink-gray-5 w-1/3">{{ __('Status') }}</div>
-						<div class="w-2/3">
-							<Badge :label="statusLabel(data.status)" :theme="statusTheme(data.status)" />
-						</div>
-					</div>
+					<!-- Status is the raw JMAP undoStatus, as on the list page; the merged
+					delivery state is not shown but still drives the header actions. -->
+					<InformationField :label="__('Status')">
+						<Badge
+							:label="undoStatusLabel(data.undo_status)"
+							:theme="undoStatusTheme(data.undo_status)"
+						/>
+					</InformationField>
 					<InformationField
 						:label="data.status === 'scheduled' ? __('Scheduled for') : __('Released at')"
 						:value="sendAtLabel"
@@ -116,7 +118,6 @@
 									{{ deliverySummary(r) }}
 								</p>
 							</div>
-							<Badge :label="statusLabel(r.status)" :theme="statusTheme(r.status)" />
 						</div>
 					</template>
 					<div v-else class="text-ink-gray-5 px-5 py-6 text-center text-sm">
@@ -170,9 +171,9 @@ import {
 import { raiseToast } from '@/apps/mail/utils'
 import { formatDateTime, fromNow } from '@/apps/mail/utils/datetime'
 import {
-	statusLabel,
-	statusTheme,
 	subjectLabel,
+	undoStatusLabel,
+	undoStatusTheme,
 	type RecipientState,
 	type SubmissionDetails,
 } from '@/apps/mail/utils/submission'

--- a/frontend/src/apps/mail/pages/SubmissionDetailsView.vue
+++ b/frontend/src/apps/mail/pages/SubmissionDetailsView.vue
@@ -44,9 +44,11 @@
 						@click="showCancel = true"
 					/>
 				</template>
-				<template v-else-if="data.status === 'failed'">
+				<!-- Failed, concluded (sent/delivered/read), or cancelled: the submission is done —
+				it can be resubmitted (when its message still exists) and its record dropped. -->
+				<template v-else>
 					<Button
-						v-if="!data.email_deleted"
+						v-if="!data.email_deleted && data.status !== 'cancelled'"
 						:label="__('Send again')"
 						@click="showRetry = true"
 					/>
@@ -367,7 +369,10 @@ const sendNowOptions = computed(() => ({
 
 const retryOptions = computed(() => ({
 	title: __('Send Again'),
-	message: __('The delivery failed. Try to send this email again now?'),
+	message:
+		data.value?.status === 'failed'
+			? __('The delivery failed. Try to send this email again now?')
+			: __('Send this email again now?'),
 	actions: [
 		{ label: __('Send'), variant: 'solid', loading: retryMail.loading, onClick: retryMail.submit },
 	],

--- a/frontend/src/apps/mail/pages/SubmissionDetailsView.vue
+++ b/frontend/src/apps/mail/pages/SubmissionDetailsView.vue
@@ -9,7 +9,7 @@
 				v-else
 				:items="[
 					{ label: __('Outbox'), route: { name: 'mail-outbox', params: { accountId } } },
-					{ label: title },
+					...(title ? [{ label: title }] : []),
 				]"
 				class="-ml-0.5 min-w-0"
 			/>
@@ -148,8 +148,30 @@
 				</div>
 			</div>
 		</div>
-		<div v-else class="flex flex-1 items-center justify-center">
-			<LoadingIndicator class="text-ink-gray-5 h-5 w-5" />
+		<!-- Mirrors the settled layout so list → details (and details → replacement) transitions
+		without a blank frame. -->
+		<div
+			v-else
+			class="flex-1 overflow-y-auto px-3 py-4 sm:px-5"
+			:aria-label="__('Loading')"
+			role="status"
+		>
+			<div class="mx-auto flex max-w-5xl flex-col gap-5 md:flex-row md:items-start">
+				<div v-for="stack in 2" :key="stack" class="flex min-w-0 flex-1 flex-col gap-5">
+					<div v-for="card in 2" :key="card" class="rounded-md border">
+						<div class="flex h-13 items-center border-b px-4">
+							<Skeleton class="h-3.5 w-24 rounded" />
+						</div>
+						<div v-for="row in 5" :key="row" class="flex items-center px-5 py-4">
+							<Skeleton class="h-3 w-1/4 rounded" />
+							<Skeleton
+								class="ml-12 h-3 rounded"
+								:style="{ width: `${20 + ((stack * 5 + card * 7 + row * 13) % 25)}%` }"
+							/>
+						</div>
+					</div>
+				</div>
+			</div>
 		</div>
 
 		<ScheduleSendModal
@@ -173,7 +195,7 @@ import {
 	Breadcrumbs,
 	Button,
 	Dialog,
-	LoadingIndicator,
+	Skeleton,
 	createResource,
 	usePageMeta,
 } from 'frappe-ui'
@@ -196,8 +218,6 @@ import ScheduleSendModal from '@/apps/mail/components/Modals/ScheduleSendModal.v
 
 const { accountId, submissionId } = defineProps<{ accountId: string; submissionId: string }>()
 
-usePageMeta(() => ({ title: __('Outbox email') }))
-
 const store = userStore()
 const router = useRouter()
 const { isMobile } = useScreenSize()
@@ -207,11 +227,19 @@ const showSendNow = ref(false)
 const showRetry = ref(false)
 const showCancel = ref(false)
 
+// An id change makes the loaded details another submission's answer, so the page drops to
+// the skeleton until the server responds — reload() alone would keep showing the previous
+// submission's content under the new URL. In-place refreshes (the actions below) keep the
+// content in place instead.
+const refetching = ref(false)
+
 const submission = createResource({
 	url: 'suite.mail.api.scheduled.get_scheduled_mail',
 	auto: true,
 	makeParams: () => ({ account: accountId, id: submissionId }),
+	onSuccess: () => (refetching.value = false),
 	onError: (error: { messages?: string[]; message?: string }) => {
+		refetching.value = false
 		raiseToast(error.messages?.[0] || error.message || __('Submission not found.'), 'error')
 		backToList()
 	},
@@ -220,12 +248,22 @@ const submission = createResource({
 // Actions that replace the submission land on the successor's id (see below).
 watch(
 	() => submissionId,
-	() => submission.reload(),
+	() => {
+		refetching.value = true
+		submission.reload()
+	},
 )
 
-const data = computed<SubmissionDetails | null>(() => submission.data || null)
+const data = computed<SubmissionDetails | null>(() =>
+	refetching.value ? null : submission.data || null,
+)
 
-const title = computed(() => (data.value ? subjectLabel(data.value) : __('Outbox email')))
+// The subject once known; until then the tab keeps saying "Outbox" (where the user came
+// from) and the breadcrumb/mobile header render no second crumb — a placeholder title
+// would just flash and be replaced.
+const title = computed(() => (data.value ? subjectLabel(data.value) : ''))
+
+usePageMeta(() => ({ title: title.value || __('Outbox') }))
 
 const canOpenEmail = computed(
 	() => !!data.value && !data.value.email_deleted && !!data.value.thread_id,

--- a/frontend/src/apps/mail/routes.ts
+++ b/frontend/src/apps/mail/routes.ts
@@ -149,13 +149,13 @@ export const routes: RouteRecordRaw[] = [
 				props: true,
 			},
 			{
-				path: 'account/:accountId/scheduled',
-				name: 'mail-scheduled',
-				component: () => import('@/apps/mail/pages/ScheduledMailsView.vue'),
+				path: 'account/:accountId/outbox',
+				name: 'mail-outbox',
+				component: () => import('@/apps/mail/pages/OutboxView.vue'),
 				props: true,
 			},
 			{
-				path: 'account/:accountId/scheduled/:submissionId',
+				path: 'account/:accountId/outbox/:submissionId',
 				name: 'mail-submission',
 				component: () => import('@/apps/mail/pages/SubmissionDetailsView.vue'),
 				props: true,

--- a/frontend/src/apps/mail/routes.ts
+++ b/frontend/src/apps/mail/routes.ts
@@ -155,6 +155,12 @@ export const routes: RouteRecordRaw[] = [
 				props: true,
 			},
 			{
+				path: 'account/:accountId/scheduled/:submissionId',
+				name: 'mail-submission',
+				component: () => import('@/apps/mail/pages/SubmissionDetailsView.vue'),
+				props: true,
+			},
+			{
 				path: 'account/:accountId/address-books/',
 				name: 'mail-address-books',
 				component: () => import('@/apps/mail/pages/AddressBooksView.vue'),

--- a/frontend/src/apps/mail/utils/submission.ts
+++ b/frontend/src/apps/mail/utils/submission.ts
@@ -1,0 +1,88 @@
+// Shared shapes and display helpers for EmailSubmission rows — the Scheduled list and the
+// submission details page render the same server-derived state.
+
+// The submission's merged delivery state, worst recipient wins: 'queued' is a released
+// delivery the MTA hasn't concluded yet, 'retrying' one that failed temporarily and waits
+// for its next attempt, 'sent' relayed with no delivery confirmation, 'displayed' one whose
+// read receipt (MDN) arrived.
+export type SubmissionStatus =
+	| 'scheduled'
+	| 'queued'
+	| 'retrying'
+	| 'failed'
+	| 'delivered'
+	| 'displayed'
+	| 'sent'
+	| 'cancelled'
+
+export type RecipientState = {
+	email: string
+	status: SubmissionStatus
+	reason?: string
+	// The raw JMAP DeliveryStatus for this recipient.
+	smtp_reply?: string
+	delivered?: 'queued' | 'yes' | 'no' | 'unknown'
+	displayed?: 'unknown' | 'yes'
+	retries?: number | null
+	next_retry?: string
+}
+
+// One row per EmailSubmission — the server is the source of truth, so emails scheduled by
+// other clients appear too. `id` is the submission id every action is keyed on.
+// `email_deleted` marks a submission whose Email was deleted after scheduling: it cannot be
+// resubmitted, and its recipients come from the SMTP envelope.
+export type ScheduledMail = {
+	id: string
+	email_id?: string
+	thread_id?: string
+	subject?: string
+	from_name?: string
+	from_email?: string
+	recipients: { type: string; email: string; display_name?: string }[]
+	recipients_status: RecipientState[]
+	send_at: string
+	// 'pending' means the delivery can still be cancelled — true for an unreleased hold AND
+	// for a released message the MTA is still working on.
+	undo_status: string
+	status: SubmissionStatus
+	retries: number | null
+	delivery_errors: { email: string; reason: string }[]
+	email_deleted: boolean
+}
+
+export type SubmissionDetails = ScheduledMail & {
+	identity_email?: string
+	envelope_from?: string
+	envelope_recipients: string[]
+	priority: number
+	next_retry?: string
+	dsn_count: number
+	mdn_count: number
+}
+
+export const statusLabel = (status: SubmissionStatus | string) =>
+	({
+		scheduled: __('Scheduled'),
+		queued: __('Sending'),
+		retrying: __('Retrying'),
+		failed: __('Failed'),
+		delivered: __('Delivered'),
+		displayed: __('Read'),
+		sent: __('Sent'),
+		cancelled: __('Cancelled'),
+	})[status] || status
+
+export const statusTheme = (status: SubmissionStatus | string) => {
+	if (status === 'failed') return 'red'
+	if (status === 'retrying') return 'amber'
+	if (status === 'scheduled' || status === 'queued') return 'blue'
+	if (status === 'delivered' || status === 'displayed') return 'green'
+	return 'gray'
+}
+
+/** The per-recipient failure detail, for the status hover. */
+export const deliveryErrorTitle = (row: ScheduledMail) =>
+	row.delivery_errors.map((e) => `${e.email}: ${e.reason}`).join('\n')
+
+export const subjectLabel = (row: ScheduledMail) =>
+	row.email_deleted ? __('(Message deleted)') : row.subject || __('(No subject)')

--- a/frontend/src/apps/mail/utils/submission.ts
+++ b/frontend/src/apps/mail/utils/submission.ts
@@ -27,11 +27,11 @@ export type RecipientState = {
 	next_retry?: string
 }
 
-// One row per EmailSubmission — the server is the source of truth, so emails scheduled by
+// One row per EmailSubmission — the server is the source of truth, so emails submitted by
 // other clients appear too. `id` is the submission id every action is keyed on.
 // `email_deleted` marks a submission whose Email was deleted after scheduling: it cannot be
 // resubmitted, and its recipients come from the SMTP envelope.
-export type ScheduledMail = {
+export type Submission = {
 	id: string
 	email_id?: string
 	thread_id?: string
@@ -50,7 +50,7 @@ export type ScheduledMail = {
 	email_deleted: boolean
 }
 
-export type SubmissionDetails = ScheduledMail & {
+export type SubmissionDetails = Submission & {
 	identity_email?: string
 	envelope_from?: string
 	envelope_recipients: string[]
@@ -59,6 +59,33 @@ export type SubmissionDetails = ScheduledMail & {
 	dsn_count: number
 	mdn_count: number
 }
+
+// The RFC 8621 §7.3 EmailSubmission/query filters the Outbox browses with. undoStatus is
+// always applied (the status tabs have no "all" state); for the rest an empty string means
+// "not filtering on this". after/before hold local calendar days from date inputs.
+export type SubmissionFilters = {
+	undoStatus: 'pending' | 'final' | 'canceled'
+	identityId: string
+	emailId: string
+	threadId: string
+	after: string
+	before: string
+}
+
+export const emptySubmissionFilters = (): SubmissionFilters => ({
+	undoStatus: 'pending',
+	identityId: '',
+	emailId: '',
+	threadId: '',
+	after: '',
+	before: '',
+})
+
+/** How many optional filters are set — undoStatus doesn't count, it always has a value. */
+export const activeSubmissionFilterCount = (filters: SubmissionFilters) =>
+	[filters.identityId, filters.emailId, filters.threadId, filters.after, filters.before].filter(
+		Boolean,
+	).length
 
 export const statusLabel = (status: SubmissionStatus | string) =>
 	({
@@ -80,9 +107,24 @@ export const statusTheme = (status: SubmissionStatus | string) => {
 	return 'gray'
 }
 
+// The list page badges the raw JMAP undoStatus; the merged delivery state stays on the
+// details page (and still drives which actions a row offers).
+export const undoStatusLabel = (undoStatus: string) =>
+	({
+		pending: __('Pending'),
+		final: __('Final'),
+		canceled: __('Cancelled'),
+	})[undoStatus] || undoStatus
+
+export const undoStatusTheme = (undoStatus: string) => {
+	if (undoStatus === 'pending') return 'blue'
+	if (undoStatus === 'final') return 'green'
+	return 'gray'
+}
+
 /** The per-recipient failure detail, for the status hover. */
-export const deliveryErrorTitle = (row: ScheduledMail) =>
+export const deliveryErrorTitle = (row: Submission) =>
 	row.delivery_errors.map((e) => `${e.email}: ${e.reason}`).join('\n')
 
-export const subjectLabel = (row: ScheduledMail) =>
+export const subjectLabel = (row: Submission) =>
 	row.email_deleted ? __('(Message deleted)') : row.subject || __('(No subject)')

--- a/frontend/src/apps/mail/utils/submission.ts
+++ b/frontend/src/apps/mail/utils/submission.ts
@@ -1,4 +1,4 @@
-// Shared shapes and display helpers for EmailSubmission rows — the Scheduled list and the
+// Shared shapes and display helpers for EmailSubmission rows — the Outbox list and the
 // submission details page render the same server-derived state.
 
 // The submission's merged delivery state, worst recipient wins: 'queued' is a released

--- a/frontend/src/apps/mail/utils/submission.ts
+++ b/frontend/src/apps/mail/utils/submission.ts
@@ -107,8 +107,8 @@ export const statusTheme = (status: SubmissionStatus | string) => {
 	return 'gray'
 }
 
-// The list page badges the raw JMAP undoStatus; the merged delivery state stays on the
-// details page (and still drives which actions a row offers).
+// Both pages badge the raw JMAP undoStatus as the submission's status; the merged delivery
+// state is a separate detail (and still drives which actions a row offers).
 export const undoStatusLabel = (undoStatus: string) =>
 	({
 		pending: __('Pending'),

--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -305,10 +305,6 @@ scheduler_events = {
         "suite.calendar.doctype.calendar_exchange.calendar_exchange.retry_stuck_calendar_exchanges",
         "suite.mail.doctype.contacts_exchange.contacts_exchange.retry_stuck_contacts_exchanges",
     ],
-    "hourly_long": [
-        # mail
-        "suite.mail.doctype.mail_queue.mail_queue.reconcile_scheduled_emails",
-    ],
     "cron": {
         "* * * * *": ["suite.meet.api.recording.reconcile_pending_recordings"],
         "*/5 * * * *": [

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -1,6 +1,5 @@
 import hashlib
 import io
-import json
 import os
 import zipfile
 
@@ -34,7 +33,7 @@ from suite.mail.doctype.mail_message.mail_message import (
     set_seen_status,
     set_spam_status,
 )
-from suite.mail.doctype.mail_queue.mail_queue import MailQueue, apply_reconciled_submissions
+from suite.mail.doctype.mail_queue.mail_queue import MailQueue
 from suite.mail.doctype.mailbox.mailbox import add_mailbox, delete_mailboxes
 from suite.mail.doctype.mailbox_settings.mailbox_settings import (
     automation_rules_to_settings,
@@ -57,7 +56,6 @@ from suite.mail.doctype.user_account.user_account import (
 )
 from suite.mail.jmap import (
     get_email_service,
-    get_email_submission_service,
     get_mailbox_id_by_name,
     get_mailbox_id_by_role,
     get_mailbox_service,
@@ -70,7 +68,6 @@ from suite.mail.utils.user import get_account_emails, is_jmap_configured
 from suite.mail.utils.validation import normalize_screened_value, validate_screened_value
 from suite.utils import convert_html_to_text
 from suite.utils.rate_limiter import dynamic_rate_limit
-from suite.utils.user import is_system_manager
 
 AVATAR_CACHE_TTL = 60 * 60 * 24
 SCREENING_FETCH_LIMIT = 500
@@ -659,7 +656,7 @@ def create_mail(
         send_at=send_at,
     )
 
-    if not save_as_draft and doc.status in ("Submitted", "Scheduled"):
+    if not save_as_draft and doc.status == "Submitted":
         create_contacts_if_not_exists(account, doc.recipients)
         auto_accept_recipients(account, doc.recipients)
 
@@ -669,6 +666,8 @@ def create_mail(
         "status": doc.status,
         "error": doc.error_message,
         "thread_id": doc.thread_id,
+        "submission_id": doc.submission_id,
+        "send_at": to_utc_z(doc.send_at),
     }
 
 
@@ -747,7 +746,7 @@ def update_draft_mail(
 
     queue = message.submit(send_at=send_at) if submit else message.save_draft()
 
-    if submit and queue.status in ("Submitted", "Scheduled"):
+    if submit and queue.status == "Submitted":
         create_contacts_if_not_exists(account, message.recipients)
         auto_accept_recipients(account, message.recipients)
 
@@ -757,105 +756,9 @@ def update_draft_mail(
         "status": queue.status,
         "error": queue.error_message,
         "thread_id": queue.thread_id,
+        "submission_id": queue.submission_id,
+        "send_at": to_utc_z(queue.send_at),
     }
-
-
-@frappe.whitelist()
-def get_scheduled_mails(account: str) -> list[dict]:
-    """Returns the account's scheduled (held) emails, reconciling any whose submission went final."""
-
-    user = get_user_for_jmap_account(account, raise_exception=True)
-    if user != frappe.session.user and not is_system_manager(frappe.session.user):
-        frappe.throw(_("You are not permitted to access this account."), frappe.PermissionError)
-
-    rows = frappe.db.get_all(
-        "Mail Queue",
-        filters={"account": account, "user": user, "status": "Scheduled"},
-        fields=[
-            "name",
-            "id",
-            "thread_id",
-            "subject",
-            "from_email",
-            "recipients",
-            "send_at",
-            "submission_id",
-            "creation",
-        ],
-        order_by="send_at asc",
-    )
-    if not rows:
-        return []
-
-    # Lazy reconcile via EmailSubmission/get — EmailSubmission/query returns empty on Stalwart
-    # even for pending submissions, so the queue rows are the source of truth for listing.
-    service = get_email_submission_service(account)
-    submission_ids = [row.submission_id for row in rows if row.submission_id]
-    undo_by_id = {
-        s["id"]: s.get("undoStatus") for s in (service.get(submission_ids) if submission_ids else [])
-    }
-
-    result, submitted, cancelled = [], [], []
-    for row in rows:
-        undo_status = undo_by_id.get(row.submission_id)
-        if row.submission_id and undo_status == "final":
-            submitted.append(row.name)
-            continue
-        if row.submission_id and undo_status == "canceled":
-            # Canceled out-of-band (e.g. from the desk or the admin MTA queue).
-            cancelled.append(row.name)
-            continue
-
-        row.recipients = json.loads(row.recipients or "[]")
-        row.send_at = to_utc_z(row.send_at)
-        row.creation = to_utc_z(row.creation)
-        result.append(row)
-
-    # Two writes at most, however many rows finalized since the last visit.
-    apply_reconciled_submissions(submitted, cancelled)
-
-    return result
-
-
-def _get_scheduled_queue_doc(account: str, name: str) -> MailQueue:
-    """Fetches a Mail Queue row for a scheduled-send action, enforcing account and owner checks."""
-
-    doc: MailQueue = frappe.get_doc("Mail Queue", name)
-    if doc.account != account:
-        frappe.throw(_("Mail Queue {0} does not belong to account {1}.").format(name, account))
-
-    doc.check_permission("write")
-    return doc
-
-
-@frappe.whitelist()
-def reschedule_mail(account: str, name: str, send_at: str) -> dict:
-    """Updates the delivery time of a scheduled email. `send_at` is UTC `...Z`."""
-
-    doc = _get_scheduled_queue_doc(account, name)
-    doc.reschedule(from_utc_z(send_at))
-
-    return {"status": doc.status, "send_at": to_utc_z(doc.send_at)}
-
-
-@frappe.whitelist()
-def send_scheduled_mail_now(account: str, name: str) -> dict:
-    """Delivers a scheduled email immediately."""
-
-    doc = _get_scheduled_queue_doc(account, name)
-    doc.send_now()
-
-    return {"status": doc.status, "thread_id": doc.thread_id}
-
-
-@frappe.whitelist()
-def cancel_scheduled_mail(account: str, name: str) -> dict:
-    """Cancels a scheduled email's delivery and moves the message back to Drafts."""
-
-    doc = _get_scheduled_queue_doc(account, name)
-    doc.cancel_schedule()
-
-    return {"status": doc.status, "id": doc.id}
 
 
 @frappe.whitelist()

--- a/suite/mail/api/scheduled.py
+++ b/suite/mail/api/scheduled.py
@@ -1,0 +1,290 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+"""Scheduled send, read and acted on through JMAP EmailSubmission objects.
+
+The server's held (FUTURERELEASE) submissions are the source of truth: listing queries them
+directly, so emails scheduled by other clients appear too, and nothing is reconciled into the
+Mail Queue — its rows are only a log of what this app submitted. Every action is keyed on the
+EmailSubmission id. Since undoStatus is a submission's only mutable property (RFC 8621 §7.5),
+reschedule and send-now cancel the held submission and create a replacement.
+
+The referenced Email may have been deleted after scheduling (EmailSubmission/get then returns a
+dangling emailId): such a delivery can still be cancelled — there is just no message to move
+back to Drafts — but not resubmitted, so reschedule and send-now refuse it.
+"""
+
+from uuid import uuid7
+
+import frappe
+from frappe import _
+from frappe.utils import cint, get_datetime, get_datetime_str, now, now_datetime, time_diff_in_seconds
+
+from suite.mail.jmap import (
+    get_email_service,
+    get_email_submission_service,
+    get_jmap_set_error_message,
+    get_mailbox_id_by_role,
+)
+from suite.mail.jmap.services.mail.submission.email_submission import EmailSubmissionService
+from suite.mail.utils import log_mail_error
+from suite.mail.utils.dt import from_utc_z, to_utc_z
+
+SUBMISSION_PROPERTIES = ["id", "emailId", "threadId", "undoStatus", "sendAt", "envelope"]
+EMAIL_SUMMARY_PROPERTIES = ["id", "threadId", "subject", "from", "to", "cc", "bcc"]
+
+
+@frappe.whitelist()
+def get_scheduled_mails(account: str) -> list[dict]:
+    """Returns the account's held (FUTURERELEASE) submissions, soonest first."""
+
+    service = get_email_submission_service(account)
+
+    ids = service.query({"undoStatus": "pending"})
+    if not ids:
+        return []
+
+    # Re-read undoStatus from the get: a submission can go final between query and get.
+    submissions = [
+        s for s in service.get(ids, properties=SUBMISSION_PROPERTIES) if s.get("undoStatus") == "pending"
+    ]
+
+    email_ids = [s["emailId"] for s in submissions if s.get("emailId")]
+    emails = (
+        get_email_service(account).get(email_ids, properties=EMAIL_SUMMARY_PROPERTIES) if email_ids else []
+    )
+    emails_by_id = {e["id"]: e for e in emails}
+
+    rows = [_serialize_submission(s, emails_by_id.get(s.get("emailId"))) for s in submissions]
+    rows.sort(key=lambda row: row["send_at"] or "")
+    return rows
+
+
+@frappe.whitelist()
+def reschedule_mail(account: str, id: str, send_at: str) -> dict:
+    """Moves a held submission's delivery time. `send_at` is UTC `...Z`."""
+
+    service = get_email_submission_service(account)
+    submission = _get_pending_submission(service, id)
+    send_at = _validate_send_at(service, from_utc_z(send_at))
+
+    created = _replace_submission(account, service, submission, hold_until=_hold_until(send_at))
+    _sync_queue_log(id, submission_id=created["id"], send_at=send_at)
+
+    return {"id": created["id"], "send_at": to_utc_z(send_at)}
+
+
+@frappe.whitelist()
+def send_scheduled_mail_now(account: str, id: str) -> dict:
+    """Delivers a held submission immediately."""
+
+    service = get_email_submission_service(account)
+    submission = _get_pending_submission(service, id)
+
+    created = _replace_submission(account, service, submission, hold_until=None)
+    _sync_queue_log(id, submission_id=created["id"], status="Submitted", submitted_at=now(), send_at=None)
+
+    return {"id": created["id"], "thread_id": submission.get("threadId")}
+
+
+@frappe.whitelist()
+def cancel_scheduled_mail(account: str, id: str) -> dict:
+    """Cancels a held submission's delivery and moves the message back to Drafts."""
+
+    service = get_email_submission_service(account)
+    submission = _get_submission(service, id)
+
+    undo_status = submission.get("undoStatus")
+    if undo_status == "pending":
+        service.cancel(id)
+    elif undo_status != "canceled":
+        frappe.throw(_("This email has already been delivered and can no longer be changed."))
+    # Already canceled (e.g. a retried undo whose move below failed): skip straight to the move.
+
+    email_id = _move_email_to_drafts(account, submission.get("emailId"))
+    # The row stays Submitted — it did get submitted; cancelled_at records the undone hold.
+    _sync_queue_log(id, cancelled_at=now())
+
+    return {"id": email_id}
+
+
+def _serialize_submission(submission: dict, email: dict | None) -> dict:
+    """One Scheduled-page row. Display fields come from the referenced Email; when it was deleted
+    after scheduling, the envelope's SMTP recipients are all that is left to show."""
+
+    if email:
+        recipients = [
+            {"type": rcpt_type, "email": a.get("email"), "display_name": a.get("name")}
+            for rcpt_type in ("To", "Cc", "Bcc")
+            for a in email.get(rcpt_type.lower()) or []
+        ]
+    else:
+        envelope = submission.get("envelope") or {}
+        recipients = [
+            {"type": "To", "email": r.get("email"), "display_name": None}
+            for r in envelope.get("rcptTo") or []
+        ]
+
+    sender = (email.get("from") or [{}])[0] if email else {}
+    return {
+        "id": submission["id"],
+        "email_id": submission.get("emailId"),
+        "thread_id": (email or {}).get("threadId") or submission.get("threadId"),
+        "subject": (email or {}).get("subject"),
+        "from_name": sender.get("name"),
+        "from_email": sender.get("email"),
+        "recipients": recipients,
+        "send_at": submission.get("sendAt"),
+        "email_deleted": email is None,
+    }
+
+
+def _get_submission(service: EmailSubmissionService, id: str) -> dict:
+    submissions = service.get([id], properties=SUBMISSION_PROPERTIES)
+    if not submissions:
+        frappe.throw(_("This scheduled email no longer exists."))
+
+    return submissions[0]
+
+
+def _get_pending_submission(service: EmailSubmissionService, id: str) -> dict:
+    submission = _get_submission(service, id)
+
+    undo_status = submission.get("undoStatus")
+    if undo_status == "canceled":
+        frappe.throw(_("This scheduled delivery has been cancelled."))
+    if undo_status != "pending":
+        frappe.throw(_("This email has already been delivered and can no longer be changed."))
+
+    return submission
+
+
+def _validate_send_at(service: EmailSubmissionService, send_at: str) -> str:
+    """Validates a new delivery time (system-time string) against the FUTURERELEASE window."""
+
+    send_at = get_datetime_str(get_datetime(send_at))
+    if get_datetime(send_at) <= now_datetime():
+        frappe.throw(_("Send At must be in the future."))
+
+    max_delay = service.max_delayed_send
+    if time_diff_in_seconds(send_at, now()) > max_delay:
+        frappe.throw(_("Send At cannot be more than {0} days in the future.").format(max_delay // 86400))
+
+    return send_at
+
+
+def _hold_until(send_at: str) -> int:
+    """The RFC 4865 HOLDUNTIL value (epoch seconds) for a system-time `send_at` string."""
+
+    from suite.utils.dt import convert_to_utc
+
+    return int(convert_to_utc(get_datetime(send_at)).timestamp())
+
+
+def _replace_submission(
+    account: str, service: EmailSubmissionService, submission: dict, hold_until: int | None
+) -> dict:
+    """Cancels the held submission and creates its replacement (reschedule / send-now)."""
+
+    email_id = submission.get("emailId")
+    emails = (
+        get_email_service(account).get([email_id], properties=["from", "to", "cc", "bcc"])
+        if email_id
+        else []
+    )
+    if not emails:
+        frappe.throw(_("The scheduled message no longer exists, so its delivery can only be cancelled."))
+
+    from_email, rcpt_emails, priority = _envelope_args(submission, emails[0])
+
+    service.cancel(submission["id"])
+    try:
+        return service.resubmit(
+            email_id=email_id,
+            from_email=from_email,
+            rcpt_emails=rcpt_emails,
+            envelope_id=str(uuid7()),
+            priority=priority,
+            hold_until=hold_until,
+        )
+    except Exception:
+        # The old submission is already canceled: fail closed as a cancellation, so the
+        # message lands back in Drafts instead of sitting in Sent never sending.
+        log_mail_error(_("Failed to resubmit scheduled email"), frappe.get_traceback(with_context=True))
+        _move_email_to_drafts(account, email_id)
+        _sync_queue_log(submission["id"], cancelled_at=now())
+        frappe.throw(
+            _(
+                "The email could not be resubmitted; its delivery was cancelled and the message "
+                "moved back to Drafts."
+            )
+        )
+
+
+def _envelope_args(submission: dict, email: dict) -> tuple[str, list[str], int]:
+    """SMTP sender, recipients, and MT-Priority for a replacement submission.
+
+    The stored envelope is preferred — it repeats exactly what the server accepted before.
+    Submissions created without one (the server derived it from the message) fall back to the
+    Email's headers.
+    """
+
+    if envelope := submission.get("envelope"):
+        mail_from = envelope.get("mailFrom") or {}
+        parameters = mail_from.get("parameters") or {}
+        rcpt_emails = [r["email"] for r in envelope.get("rcptTo") or []]
+        return mail_from["email"], rcpt_emails, cint(parameters.get("MT-PRIORITY"))
+
+    rcpt_emails = [a["email"] for key in ("to", "cc", "bcc") for a in email.get(key) or []]
+    return email["from"][0]["email"], rcpt_emails, 0
+
+
+def _move_email_to_drafts(account: str, email_id: str | None) -> str | None:
+    """Returns a cancelled delivery's message to Drafts; a message deleted after scheduling
+    (or a submission with no emailId) has nothing to move."""
+
+    from suite.mail.doctype.mail_message.mail_message import _remove_cached_messages
+
+    if not email_id:
+        return None
+
+    email_service = get_email_service(account)
+    emails = email_service.get([email_id], properties=["mailboxIds"])
+    if not emails:
+        return None
+
+    drafts_mailbox_id = get_mailbox_id_by_role(
+        account, "drafts", create_if_not_exists=True, raise_exception=True
+    )
+
+    # Replace (not patch) mailboxIds so the message leaves Sent; restore $draft.
+    result = email_service.update(
+        [{"id": email_id, "mailbox_ids": {drafts_mailbox_id: True}, "keywords": {"$draft": True}}],
+        replace_mailboxes=True,
+    )
+    if email_id not in result["updated"]:
+        # The submission is already canceled; retrying this action skips the cancel
+        # step (undoStatus is "canceled") and reattempts the move.
+        frappe.throw(get_jmap_set_error_message(result, "notUpdated", email_id))
+
+    # Evict the cached copy — it still carries the Sent mailbox and would show a
+    # stale folder label in Drafts until the next sync.
+    _remove_cached_messages(account, [email_id])
+
+    # Refresh the open mailbox views (both the folder it left and the one it landed in). The
+    # composer that raised the undo toast is unmounted by the time Undo runs, so the refresh
+    # rides the same realtime event the message actions use.
+    previous_mailbox_ids = list(emails[0].get("mailboxIds") or {})
+    frappe.publish_realtime(
+        "new_mail_created", list({drafts_mailbox_id, *previous_mailbox_ids}), user=frappe.session.user
+    )
+
+    return email_id
+
+
+def _sync_queue_log(current_submission_id: str, **values) -> None:
+    """Best-effort mirror into the Mail Queue log for sends that originated here — submissions
+    created by other clients have no row. `values` may carry a replacement submission_id."""
+
+    if name := frappe.db.get_value("Mail Queue", {"submission_id": current_submission_id}):
+        frappe.db.set_value("Mail Queue", name, values)

--- a/suite/mail/api/scheduled.py
+++ b/suite/mail/api/scheduled.py
@@ -51,7 +51,7 @@ from suite.mail.jmap import (
 )
 from suite.mail.jmap.services.mail.submission.email_submission import EmailSubmissionService
 from suite.mail.utils import log_mail_error
-from suite.mail.utils.dt import from_utc_z, normalize_utc_z, to_utc_z
+from suite.mail.utils.dt import UTC_DATETIME_FORMAT, from_utc_z, normalize_utc_z, to_utc_z
 
 SUBMISSION_PROPERTIES = ["id", "emailId", "threadId", "undoStatus", "sendAt", "envelope"]
 DETAIL_PROPERTIES = [*SUBMISSION_PROPERTIES, "deliveryStatus", "identityId", "dsnBlobIds", "mdnBlobIds"]
@@ -82,6 +82,9 @@ def get_submissions(
 
     if undo_status and undo_status not in UNDO_STATUSES:
         frappe.throw(_("undoStatus must be one of {0}.").format(", ".join(UNDO_STATUSES)))
+
+    before = _validate_utc_z(before, "before")
+    after = _validate_utc_z(after, "after")
 
     page = max(cint(page), 1)
     page_length = min(max(cint(page_length), 1), 100)
@@ -507,6 +510,25 @@ def _get_final_submission(service: EmailSubmissionService, id: str) -> dict:
         frappe.throw(_("This delivery is still pending — cancel or reschedule it instead."))
 
     return submission
+
+
+def _validate_utc_z(value: str | None, label: str) -> str | None:
+    """A client-supplied sendAt bound: anything but an ISO timestamp is refused, and a valid
+    one is re-serialized to the canonical UTC ``...Z`` form — the only shape that ever reaches
+    the JMAP filter."""
+
+    if not value:
+        return None
+
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        frappe.throw(_("{0} must be a UTC timestamp like 2026-01-31T09:30:00Z.").format(label))
+
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+
+    return dt.astimezone(UTC).strftime(UTC_DATETIME_FORMAT)
 
 
 def _validate_send_at(service: EmailSubmissionService, send_at: str) -> str:

--- a/suite/mail/api/scheduled.py
+++ b/suite/mail/api/scheduled.py
@@ -29,7 +29,7 @@ landed — until they are retried or dismissed, or the server expunges the submi
 every other concluded row.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from uuid import uuid7
 
 import frappe
@@ -407,7 +407,7 @@ def _hold_active(submission: dict) -> bool:
     if not send_at:
         return False
 
-    return datetime.fromisoformat(send_at.replace("Z", "+00:00")) > datetime.now(timezone.utc)
+    return datetime.fromisoformat(send_at.replace("Z", "+00:00")) > datetime.now(UTC)
 
 
 def _envid(submission: dict) -> str | None:
@@ -525,9 +525,7 @@ def _resubmit_args(account: str, submission: dict) -> dict:
 
     email_id = submission.get("emailId")
     emails = (
-        get_email_service(account).get([email_id], properties=["from", "to", "cc", "bcc"])
-        if email_id
-        else []
+        get_email_service(account).get([email_id], properties=["from", "to", "cc", "bcc"]) if email_id else []
     )
     if not emails:
         frappe.throw(_("The original message no longer exists, so it cannot be resubmitted."))

--- a/suite/mail/api/scheduled.py
+++ b/suite/mail/api/scheduled.py
@@ -9,16 +9,36 @@ Mail Queue — its rows are only a log of what this app submitted. Every action 
 EmailSubmission id. Since undoStatus is a submission's only mutable property (RFC 8621 §7.5),
 reschedule and send-now cancel the held submission and create a replacement.
 
+Where the delivery actually stands is computed per recipient from the submission's
+deliveryStatus — delivered (queued/yes/no/unknown), displayed (unknown/yes, a read receipt),
+and the raw smtpReply — refined, while the message is still in the MTA queue, by Stalwart's
+management queue API, correlated through the ENVID this app writes into every envelope. The
+queue side contributes what JMAP cannot: retry counts, the next retry time, the last error of
+a temporarily failing delivery, and whether "queued" means a first attempt or a retry wait. It is read
+best-effort with the admin connection, exposing only messages matching the account's own
+submissions; without it rows just lack the retry detail.
+
 The referenced Email may have been deleted after scheduling (EmailSubmission/get then returns a
 dangling emailId): such a delivery can still be cancelled — there is just no message to move
-back to Drafts — but not resubmitted, so reschedule and send-now refuse it.
+back to Drafts — but not resubmitted, so the resubmitting actions refuse it. Held releases that
+failed (permanently or between retries) stay on the listing so the user learns the send never
+landed — until they are retried or dismissed, or the server expunges the submission record
+(how long finalized submissions are kept is the server's policy alone).
 """
 
+from datetime import datetime, timezone
 from uuid import uuid7
 
 import frappe
 from frappe import _
-from frappe.utils import cint, get_datetime, get_datetime_str, now, now_datetime, time_diff_in_seconds
+from frappe.utils import (
+    cint,
+    get_datetime,
+    get_datetime_str,
+    now,
+    now_datetime,
+    time_diff_in_seconds,
+)
 
 from suite.mail.jmap import (
     get_email_service,
@@ -28,36 +48,91 @@ from suite.mail.jmap import (
 )
 from suite.mail.jmap.services.mail.submission.email_submission import EmailSubmissionService
 from suite.mail.utils import log_mail_error
-from suite.mail.utils.dt import from_utc_z, to_utc_z
+from suite.mail.utils.dt import from_utc_z, normalize_utc_z, to_utc_z
 
 SUBMISSION_PROPERTIES = ["id", "emailId", "threadId", "undoStatus", "sendAt", "envelope"]
+DETAIL_PROPERTIES = [*SUBMISSION_PROPERTIES, "deliveryStatus", "identityId", "dsnBlobIds", "mdnBlobIds"]
 EMAIL_SUMMARY_PROPERTIES = ["id", "threadId", "subject", "from", "to", "cc", "bcc"]
 
 
 @frappe.whitelist()
 def get_scheduled_mails(account: str) -> list[dict]:
-    """Returns the account's held (FUTURERELEASE) submissions, soonest first."""
+    """Returns the account's held (FUTURERELEASE) submissions plus released ones whose delivery
+    has not succeeded, soonest first — problem rows have a past sendAt, so they lead."""
 
     service = get_email_submission_service(account)
 
-    ids = service.query({"undoStatus": "pending"})
-    if not ids:
+    pending_ids = service.query({"undoStatus": "pending"})
+    final_ids = service.query({"undoStatus": "final"})
+    if not pending_ids and not final_ids:
         return []
 
-    # Re-read undoStatus from the get: a submission can go final between query and get.
-    submissions = [
-        s for s in service.get(ids, properties=SUBMISSION_PROPERTIES) if s.get("undoStatus") == "pending"
-    ]
-
-    email_ids = [s["emailId"] for s in submissions if s.get("emailId")]
-    emails = (
-        get_email_service(account).get(email_ids, properties=EMAIL_SUMMARY_PROPERTIES) if email_ids else []
+    # Re-read undoStatus from the get: a submission can go final between query and get. A final
+    # one is kept only when it was actually held (HOLDUNTIL) and its delivery is still troubled —
+    # otherwise this page would grow into a delivery log of every send.
+    fetched = service.get(
+        list(dict.fromkeys(pending_ids + final_ids)), properties=[*SUBMISSION_PROPERTIES, "deliveryStatus"]
     )
-    emails_by_id = {e["id"]: e for e in emails}
+    queue_by_envid = _queue_messages_by_envid(fetched)
 
-    rows = [_serialize_submission(s, emails_by_id.get(s.get("emailId"))) for s in submissions]
+    rows = []
+    for submission in fetched:
+        if submission.get("undoStatus") not in ("pending", "final"):
+            continue
+        row = _serialize_submission(submission, None, queue_by_envid.get(_envid(submission)))
+        if row["status"] == "scheduled" or (_was_held(submission) and row["status"] in PROBLEM_STATUSES):
+            rows.append(row)
+
+    email_ids = [row["email_id"] for row in rows if row["email_id"]]
+    emails_by_id = {
+        e["id"]: e
+        for e in (
+            get_email_service(account).get(email_ids, properties=EMAIL_SUMMARY_PROPERTIES)
+            if email_ids
+            else []
+        )
+    }
+    for row in rows:
+        _add_email_fields(row, emails_by_id.get(row["email_id"]))
+
     rows.sort(key=lambda row: row["send_at"] or "")
     return rows
+
+
+@frappe.whitelist()
+def get_scheduled_mail(account: str, id: str) -> dict:
+    """Returns one submission with everything EmailSubmission/get knows about it, enriched with
+    the referenced Email's summary and the MTA queue's live delivery state."""
+
+    service = get_email_submission_service(account)
+    submissions = service.get([id], properties=DETAIL_PROPERTIES)
+    if not submissions:
+        frappe.throw(_("This submission no longer exists."))
+
+    submission = submissions[0]
+    queue_message = _queue_messages_by_envid([submission]).get(_envid(submission))
+
+    row = _serialize_submission(submission, None, queue_message)
+    email_id = submission.get("emailId")
+    emails = (
+        get_email_service(account).get([email_id], properties=EMAIL_SUMMARY_PROPERTIES) if email_id else []
+    )
+    _add_email_fields(row, emails[0] if emails else None)
+
+    envelope = submission.get("envelope") or {}
+    mail_from = envelope.get("mailFrom") or {}
+    row.update(
+        {
+            "identity_email": _identity_email(service, submission.get("identityId")),
+            "envelope_from": mail_from.get("email"),
+            "envelope_recipients": [r.get("email") for r in envelope.get("rcptTo") or []],
+            "priority": cint((mail_from.get("parameters") or {}).get("MT-PRIORITY")),
+            "next_retry": normalize_utc_z((queue_message or {}).get("nextRetry")),
+            "dsn_count": len(submission.get("dsnBlobIds") or []),
+            "mdn_count": len(submission.get("mdnBlobIds") or []),
+        }
+    )
+    return row
 
 
 @frappe.whitelist()
@@ -82,7 +157,7 @@ def send_scheduled_mail_now(account: str, id: str) -> dict:
     submission = _get_pending_submission(service, id)
 
     created = _replace_submission(account, service, submission, hold_until=None)
-    _sync_queue_log(id, submission_id=created["id"], status="Submitted", submitted_at=now(), send_at=None)
+    _sync_queue_log(id, submission_id=created["id"], submitted_at=now(), send_at=None)
 
     return {"id": created["id"], "thread_id": submission.get("threadId")}
 
@@ -108,9 +183,96 @@ def cancel_scheduled_mail(account: str, id: str) -> dict:
     return {"id": email_id}
 
 
-def _serialize_submission(submission: dict, email: dict | None) -> dict:
-    """One Scheduled-page row. Display fields come from the referenced Email; when it was deleted
-    after scheduling, the envelope's SMTP recipients are all that is left to show."""
+@frappe.whitelist()
+def retry_delivery_now(account: str, id: str) -> None:
+    """Tells the MTA to attempt a released, still-queued (retrying) delivery again right away.
+
+    A release mid-retry is still undoStatus "pending" (it can be cancelled until it concludes),
+    so this gates on the hold — not on the submission being final; an unreleased hold must go
+    through send-now instead, which replaces the submission."""
+
+    service = get_email_submission_service(account)
+    submission = _get_submission(service, id)
+
+    if submission.get("undoStatus") == "canceled":
+        frappe.throw(_("This scheduled delivery has been cancelled."))
+    if _hold_active(submission):
+        frappe.throw(_("This delivery is still scheduled — use send now instead."))
+
+    queue_message = _queue_messages_by_envid([submission]).get(_envid(submission))
+    if not queue_message:
+        frappe.throw(_("This delivery is no longer waiting in the outbound queue."))
+
+    from suite.mail.stalwart import get_queued_message_service
+
+    get_queued_message_service().retry([queue_message["id"]])
+
+
+@frappe.whitelist()
+def retry_failed_mail(account: str, id: str) -> dict:
+    """Resubmits a finalized submission's email for immediate delivery, replacing the failed
+    record so the listing shows only the live attempt."""
+
+    service = get_email_submission_service(account)
+    submission = _get_final_submission(service, id)
+
+    created = service.resubmit(
+        **_resubmit_args(account, submission), envelope_id=str(uuid7()), hold_until=None
+    )
+    service.destroy(id)
+    _sync_queue_log(id, submission_id=created["id"], submitted_at=now(), send_at=None)
+
+    return {"id": created["id"]}
+
+
+@frappe.whitelist()
+def dismiss_failed_mail(account: str, id: str) -> None:
+    """Drops a finalized submission's record from the Scheduled listing."""
+
+    service = get_email_submission_service(account)
+    _get_final_submission(service, id)
+    service.destroy(id)
+
+
+# --- delivery state ------------------------------------------------------------------------------
+
+# Recipient/overall statuses, worst first. "queued" is a released delivery the MTA has not
+# concluded yet (first attempt or between retries); "sent" is relayed with no confirmation;
+# "displayed" means a read receipt (MDN) arrived — the furthest a delivery can get.
+STATUS_SEVERITY = ("failed", "retrying", "queued", "scheduled", "cancelled", "sent", "delivered", "displayed")
+PROBLEM_STATUSES = ("failed", "retrying", "queued")
+
+
+def _serialize_submission(submission: dict, email: dict | None, queue_message: dict | None) -> dict:
+    """One Scheduled-page row: the submission itself plus its merged delivery state."""
+
+    recipients_status = _recipient_states(submission, queue_message)
+    retries = [r["retries"] for r in recipients_status if r["retries"] is not None]
+
+    row = {
+        "id": submission["id"],
+        "email_id": submission.get("emailId"),
+        "thread_id": submission.get("threadId"),
+        "send_at": submission.get("sendAt"),
+        # A released delivery can be cancelled for as long as it is pending; the actions
+        # offered for a retrying row depend on this, not on the display status.
+        "undo_status": submission.get("undoStatus"),
+        "status": _overall_status(submission, recipients_status),
+        "retries": max(retries) if retries else None,
+        "recipients_status": recipients_status,
+        "delivery_errors": [
+            {"email": r["email"], "reason": r["reason"]}
+            for r in recipients_status
+            if r["status"] in PROBLEM_STATUSES and r["reason"]
+        ],
+    }
+    _add_email_fields(row, email)
+    return row
+
+
+def _add_email_fields(row: dict, email: dict | None) -> None:
+    """Fills a row's display fields from the referenced Email; when it was deleted after
+    scheduling, the envelope recipients already collected in recipients_status remain."""
 
     if email:
         recipients = [
@@ -119,24 +281,177 @@ def _serialize_submission(submission: dict, email: dict | None) -> dict:
             for a in email.get(rcpt_type.lower()) or []
         ]
     else:
-        envelope = submission.get("envelope") or {}
         recipients = [
-            {"type": "To", "email": r.get("email"), "display_name": None}
-            for r in envelope.get("rcptTo") or []
+            {"type": "To", "email": r["email"], "display_name": None} for r in row["recipients_status"]
         ]
 
     sender = (email.get("from") or [{}])[0] if email else {}
-    return {
-        "id": submission["id"],
-        "email_id": submission.get("emailId"),
-        "thread_id": (email or {}).get("threadId") or submission.get("threadId"),
-        "subject": (email or {}).get("subject"),
-        "from_name": sender.get("name"),
-        "from_email": sender.get("email"),
-        "recipients": recipients,
-        "send_at": submission.get("sendAt"),
-        "email_deleted": email is None,
+    row.update(
+        {
+            "thread_id": (email or {}).get("threadId") or row.get("thread_id"),
+            "subject": (email or {}).get("subject"),
+            "from_name": sender.get("name"),
+            "from_email": sender.get("email"),
+            "recipients": recipients,
+            "email_deleted": email is None,
+        }
+    )
+
+
+def _recipient_states(submission: dict, queue_message: dict | None) -> list[dict]:
+    """Merges deliveryStatus and MTA-queue state into one row per recipient."""
+
+    delivery = submission.get("deliveryStatus") or {}
+    queue_recipients = (queue_message or {}).get("recipients") or {}
+    envelope_emails = [r.get("email") for r in (submission.get("envelope") or {}).get("rcptTo") or []]
+
+    emails = list(dict.fromkeys([*envelope_emails, *delivery, *queue_recipients]))
+    held = _hold_active(submission)
+
+    states = []
+    for email in emails:
+        status = delivery.get(email) or {}
+        queued = queue_recipients.get(email) or {}
+        queue_status = queued.get("status") or {}
+
+        states.append(
+            {
+                "email": email,
+                "status": _recipient_status(
+                    held, status, queue_status.get("@type"), queued.get("retryCount")
+                ),
+                "reason": queue_status.get("errorMessage")
+                or queue_status.get("responseMessage")
+                or status.get("smtpReply"),
+                # The raw DeliveryStatus, so the details page can show the exact server state.
+                "smtp_reply": status.get("smtpReply"),
+                "delivered": status.get("delivered"),
+                "displayed": status.get("displayed"),
+                "retries": queued.get("retryCount"),
+                "next_retry": normalize_utc_z(queued.get("retryDue")),
+            }
+        )
+
+    return states
+
+
+def _recipient_status(
+    held: bool, delivery: dict, queue_status: str | None, retry_count: int | None = 0
+) -> str:
+    """One recipient's latest place in the lifecycle, computed from the submission's
+    DeliveryStatus (delivered: queued/yes/no/unknown, displayed: unknown/yes). The MTA
+    queue's live state only refines what "queued" currently means — a first attempt in
+    flight or a failed one waiting to retry."""
+
+    if held:
+        return "scheduled"
+
+    if delivery.get("displayed") == "yes":
+        return "displayed"  # a read receipt (MDN) arrived — implies delivery
+
+    delivered = delivery.get("delivered")
+    if delivered == "no":
+        return "failed"
+    if delivered == "yes":
+        return "delivered"
+    if delivered == "queued" or (delivered is None and queue_status):
+        return "retrying" if queue_status == "TemporaryFailure" or cint(retry_count) else "queued"
+    return "sent"  # "unknown": relayed with no delivery confirmation
+
+
+def _overall_status(submission: dict, recipients_status: list[dict]) -> str:
+    """The submission's single-word state: the worst of its recipients' states."""
+
+    if submission.get("undoStatus") == "canceled":
+        return "cancelled"
+    if _hold_active(submission):
+        return "scheduled"
+
+    statuses = {r["status"] for r in recipients_status}
+    return next((s for s in STATUS_SEVERITY if s in statuses), "sent")
+
+
+def _hold_active(submission: dict) -> bool:
+    """Whether the FUTURERELEASE hold is still in effect — pending with sendAt in the future.
+
+    Stalwart keeps undoStatus "pending" for as long as a released message can still be pulled
+    back from the queue, so pending alone does not mean scheduled: a release mid-retry is
+    pending too, and must show its real delivery state.
+    """
+
+    if submission.get("undoStatus") != "pending":
+        return False
+
+    send_at = submission.get("sendAt")
+    if not send_at:
+        return False
+
+    return datetime.fromisoformat(send_at.replace("Z", "+00:00")) > datetime.now(timezone.utc)
+
+
+def _was_held(submission: dict) -> bool:
+    """Whether the submission's delivery was held (scheduled or undo-send) — marked by the
+    RFC 4865 HOLDUNTIL parameter in its stored envelope."""
+
+    parameters = ((submission.get("envelope") or {}).get("mailFrom") or {}).get("parameters") or {}
+    return any(key.upper() == "HOLDUNTIL" for key in parameters)
+
+
+def _envid(submission: dict) -> str | None:
+    """The submission envelope's ENVID — the key that ties it to its MTA queue message."""
+
+    parameters = ((submission.get("envelope") or {}).get("mailFrom") or {}).get("parameters") or {}
+    return parameters.get("ENVID")
+
+
+def _queue_messages_by_envid(submissions: list[dict]) -> dict[str, dict]:
+    """The MTA queue messages behind the given submissions, keyed by ENVID.
+
+    Read with the admin management connection but exposing only messages whose ENVID matches
+    one of the account's own submissions. Best-effort: without the management API the rows
+    just lack retry counts and live queue state.
+    """
+
+    envids = {envid for s in submissions if (envid := _envid(s))}
+    senders = {
+        email
+        for s in submissions
+        if _envid(s) and (email := ((s.get("envelope") or {}).get("mailFrom") or {}).get("email"))
     }
+    if not envids:
+        return {}
+
+    try:
+        from suite.mail.stalwart import get_queued_message_service
+
+        service = get_queued_message_service()
+        messages = []
+        for sender in senders:
+            messages.extend(
+                service.get_all(
+                    filter={"returnPath": sender},
+                    properties=["id", "envId", "recipients", "nextRetry"],
+                )
+            )
+    except Exception:
+        log_mail_error(
+            _("Failed to read the MTA queue for scheduled mails"), frappe.get_traceback(with_context=True)
+        )
+        return {}
+
+    return {m["envId"]: m for m in messages if m.get("envId") in envids}
+
+
+def _identity_email(service: EmailSubmissionService, identity_id: str | None) -> str | None:
+    """The sending identity's email address, when the id still resolves."""
+
+    if not identity_id:
+        return None
+
+    return next((i.get("email") for i in service.identities if i.get("id") == identity_id), None)
+
+
+# --- submission plumbing -------------------------------------------------------------------------
 
 
 def _get_submission(service: EmailSubmissionService, id: str) -> dict:
@@ -155,6 +470,16 @@ def _get_pending_submission(service: EmailSubmissionService, id: str) -> dict:
         frappe.throw(_("This scheduled delivery has been cancelled."))
     if undo_status != "pending":
         frappe.throw(_("This email has already been delivered and can no longer be changed."))
+
+    return submission
+
+
+def _get_final_submission(service: EmailSubmissionService, id: str) -> dict:
+    """A submission the server is done with — what the retry and dismiss actions operate on."""
+
+    submission = _get_submission(service, id)
+    if submission.get("undoStatus") == "pending":
+        frappe.throw(_("This delivery is still pending — cancel or reschedule it instead."))
 
     return submission
 
@@ -181,10 +506,9 @@ def _hold_until(send_at: str) -> int:
     return int(convert_to_utc(get_datetime(send_at)).timestamp())
 
 
-def _replace_submission(
-    account: str, service: EmailSubmissionService, submission: dict, hold_until: int | None
-) -> dict:
-    """Cancels the held submission and creates its replacement (reschedule / send-now)."""
+def _resubmit_args(account: str, submission: dict) -> dict:
+    """The resubmit() arguments recoverable from a submission; throws when its Email is gone
+    (a message that no longer exists cannot be resubmitted)."""
 
     email_id = submission.get("emailId")
     emails = (
@@ -193,25 +517,32 @@ def _replace_submission(
         else []
     )
     if not emails:
-        frappe.throw(_("The scheduled message no longer exists, so its delivery can only be cancelled."))
+        frappe.throw(_("The original message no longer exists, so it cannot be resubmitted."))
 
     from_email, rcpt_emails, priority = _envelope_args(submission, emails[0])
+    return {
+        "email_id": email_id,
+        "from_email": from_email,
+        "rcpt_emails": rcpt_emails,
+        "priority": priority,
+    }
+
+
+def _replace_submission(
+    account: str, service: EmailSubmissionService, submission: dict, hold_until: int | None
+) -> dict:
+    """Cancels the held submission and creates its replacement (reschedule / send-now)."""
+
+    args = _resubmit_args(account, submission)
 
     service.cancel(submission["id"])
     try:
-        return service.resubmit(
-            email_id=email_id,
-            from_email=from_email,
-            rcpt_emails=rcpt_emails,
-            envelope_id=str(uuid7()),
-            priority=priority,
-            hold_until=hold_until,
-        )
+        return service.resubmit(**args, envelope_id=str(uuid7()), hold_until=hold_until)
     except Exception:
         # The old submission is already canceled: fail closed as a cancellation, so the
         # message lands back in Drafts instead of sitting in Sent never sending.
         log_mail_error(_("Failed to resubmit scheduled email"), frappe.get_traceback(with_context=True))
-        _move_email_to_drafts(account, email_id)
+        _move_email_to_drafts(account, args["email_id"])
         _sync_queue_log(submission["id"], cancelled_at=now())
         frappe.throw(
             _(

--- a/suite/mail/api/scheduled.py
+++ b/suite/mail/api/scheduled.py
@@ -29,6 +29,7 @@ landed — until they are retried or dismissed, or the server expunges the submi
 every other concluded row.
 """
 
+import re
 from datetime import UTC, datetime
 from uuid import uuid7
 
@@ -60,6 +61,9 @@ EMAIL_SUMMARY_PROPERTIES = ["id", "threadId", "subject", "from", "to", "cc", "bc
 
 UNDO_STATUSES = ("pending", "final", "canceled")
 
+# RFC 8620 §1.2: a JMAP Id is 1 to 255 characters of [A-Za-z0-9_-].
+JMAP_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]{1,255}\Z")
+
 
 @frappe.whitelist()
 def get_submissions(
@@ -79,6 +83,11 @@ def get_submissions(
 
     The filters are the RFC 8621 §7.3 FilterCondition properties: `undo_status` is one of
     pending/final/canceled, `before`/`after` bound sendAt (UTC `...Z` timestamps)."""
+
+    _validate_jmap_id(account, "account")
+    _validate_jmap_id(identity_id, "identity_id")
+    _validate_jmap_id(email_id, "email_id")
+    _validate_jmap_id(thread_id, "thread_id")
 
     if undo_status and undo_status not in UNDO_STATUSES:
         frappe.throw(_("undoStatus must be one of {0}.").format(", ".join(UNDO_STATUSES)))
@@ -140,6 +149,9 @@ def get_scheduled_mail(account: str, id: str) -> dict:
     """Returns one submission with everything EmailSubmission/get knows about it, enriched with
     the referenced Email's summary and the MTA queue's live delivery state."""
 
+    _validate_jmap_id(account, "account")
+    _validate_jmap_id(id, "id")
+
     service = get_email_submission_service(account)
     submissions = service.get([id], properties=DETAIL_PROPERTIES)
     if not submissions:
@@ -175,6 +187,9 @@ def get_scheduled_mail(account: str, id: str) -> dict:
 def reschedule_mail(account: str, id: str, send_at: str) -> dict:
     """Moves a held submission's delivery time. `send_at` is UTC `...Z`."""
 
+    _validate_jmap_id(account, "account")
+    _validate_jmap_id(id, "id")
+
     service = get_email_submission_service(account)
     submission = _get_pending_submission(service, id)
     send_at = _validate_send_at(service, from_utc_z(send_at))
@@ -189,6 +204,9 @@ def reschedule_mail(account: str, id: str, send_at: str) -> dict:
 def send_scheduled_mail_now(account: str, id: str) -> dict:
     """Delivers a held submission immediately."""
 
+    _validate_jmap_id(account, "account")
+    _validate_jmap_id(id, "id")
+
     service = get_email_submission_service(account)
     submission = _get_pending_submission(service, id)
 
@@ -201,6 +219,9 @@ def send_scheduled_mail_now(account: str, id: str) -> dict:
 @frappe.whitelist()
 def cancel_scheduled_mail(account: str, id: str) -> dict:
     """Cancels a held submission's delivery and moves the message back to Drafts."""
+
+    _validate_jmap_id(account, "account")
+    _validate_jmap_id(id, "id")
 
     service = get_email_submission_service(account)
     submission = _get_submission(service, id)
@@ -227,6 +248,9 @@ def retry_delivery_now(account: str, id: str) -> None:
     so this gates on the hold — not on the submission being final; an unreleased hold must go
     through send-now instead, which replaces the submission."""
 
+    _validate_jmap_id(account, "account")
+    _validate_jmap_id(id, "id")
+
     service = get_email_submission_service(account)
     submission = _get_submission(service, id)
 
@@ -249,6 +273,9 @@ def retry_failed_mail(account: str, id: str) -> dict:
     """Resubmits a finalized submission's email for immediate delivery, replacing the failed
     record so the listing shows only the live attempt."""
 
+    _validate_jmap_id(account, "account")
+    _validate_jmap_id(id, "id")
+
     service = get_email_submission_service(account)
     submission = _get_final_submission(service, id)
 
@@ -264,6 +291,9 @@ def retry_failed_mail(account: str, id: str) -> dict:
 @frappe.whitelist()
 def dismiss_failed_mail(account: str, id: str) -> None:
     """Drops a finalized submission's record from the Outbox listing."""
+
+    _validate_jmap_id(account, "account")
+    _validate_jmap_id(id, "id")
 
     service = get_email_submission_service(account)
     _get_final_submission(service, id)
@@ -510,6 +540,20 @@ def _get_final_submission(service: EmailSubmissionService, id: str) -> dict:
         frappe.throw(_("This delivery is still pending — cancel or reschedule it instead."))
 
     return submission
+
+
+def _validate_jmap_id(value: str | None, label: str) -> str | None:
+    """A client-supplied JMAP identifier: RFC 8620 §1.2 confines an Id to 1 to 255 characters of
+    [A-Za-z0-9_-], so anything else is refused before it reaches a JMAP operation. Empty
+    optional filters pass through (they are dropped, not forwarded)."""
+
+    if not value:
+        return None
+
+    if not JMAP_ID_PATTERN.fullmatch(value):
+        frappe.throw(_("{0} is not a valid JMAP identifier.").format(label))
+
+    return value
 
 
 def _validate_utc_z(value: str | None, label: str) -> str | None:

--- a/suite/mail/api/scheduled.py
+++ b/suite/mail/api/scheduled.py
@@ -70,14 +70,21 @@ def get_submissions(
     thread_id: str | None = None,
     before: str | None = None,
     after: str | None = None,
-) -> list[dict]:
-    """Browses the account's EmailSubmission objects, newest sendAt first.
+    page: int = 1,
+    page_length: int = 50,
+) -> dict:
+    """Browses one page of the account's EmailSubmission objects, newest sendAt first —
+    returned as {"rows", "total"} so the listing can paginate past the server's single-query
+    cap (maxObjectsInGet).
 
     The filters are the RFC 8621 §7.3 FilterCondition properties: `undo_status` is one of
     pending/final/canceled, `before`/`after` bound sendAt (UTC `...Z` timestamps)."""
 
     if undo_status and undo_status not in UNDO_STATUSES:
         frappe.throw(_("undoStatus must be one of {0}.").format(", ".join(UNDO_STATUSES)))
+
+    page = max(cint(page), 1)
+    page_length = min(max(cint(page_length), 1), 100)
 
     filter = {
         "undoStatus": undo_status,
@@ -90,9 +97,14 @@ def get_submissions(
     filter = {key: value for key, value in filter.items() if value}
 
     service = get_email_submission_service(account)
-    ids = service.query(filter or None, sort=[{"property": "sentAt", "isAscending": False}])
+    ids, total = service.query(
+        filter or None,
+        position=(page - 1) * page_length,
+        limit=page_length,
+        sort=[{"property": "sentAt", "isAscending": False}],
+    )
     if not ids:
-        return []
+        return {"rows": [], "total": total}
 
     fetched = service.get(ids, properties=[*SUBMISSION_PROPERTIES, "deliveryStatus"])
     queue_by_envid = _queue_messages_by_envid(fetched)
@@ -117,7 +129,7 @@ def get_submissions(
     for row in rows:
         _add_email_fields(row, emails_by_id.get(row["email_id"]))
 
-    return rows
+    return {"rows": rows, "total": total}
 
 
 @frappe.whitelist()

--- a/suite/mail/api/scheduled.py
+++ b/suite/mail/api/scheduled.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-"""Scheduled send, read and acted on through JMAP EmailSubmission objects.
+"""The Outbox: JMAP EmailSubmission objects, browsed and acted on directly.
 
-The server's held (FUTURERELEASE) submissions are the source of truth: listing queries them
-directly, so emails scheduled by other clients appear too, and nothing is reconciled into the
-Mail Queue — its rows are only a log of what this app submitted. Every action is keyed on the
+The server's submissions are the source of truth: the listing browses all of them — held
+(FUTURERELEASE), in flight, and concluded — through EmailSubmission/query with the RFC 8621
+§7.3 filters (undoStatus, identity, email, thread, and a sendAt window), newest sends first.
+Emails submitted by other clients appear too, and nothing is reconciled into the Mail Queue —
+its rows are only a log of what this app submitted. Every action is keyed on the
 EmailSubmission id. Since undoStatus is a submission's only mutable property (RFC 8621 §7.5),
 reschedule and send-now cancel the held submission and create a replacement.
 
@@ -23,7 +25,8 @@ dangling emailId): such a delivery can still be cancelled — there is just no m
 back to Drafts — but not resubmitted, so the resubmitting actions refuse it. Held releases that
 failed (permanently or between retries) stay on the listing so the user learns the send never
 landed — until they are retried or dismissed, or the server expunges the submission record
-(how long finalized submissions are kept is the server's policy alone).
+(how long finalized submissions are kept is the server's policy alone); the same goes for
+every other concluded row.
 """
 
 from datetime import datetime, timezone
@@ -55,35 +58,54 @@ DETAIL_PROPERTIES = [*SUBMISSION_PROPERTIES, "deliveryStatus", "identityId", "ds
 EMAIL_SUMMARY_PROPERTIES = ["id", "threadId", "subject", "from", "to", "cc", "bcc"]
 
 
+UNDO_STATUSES = ("pending", "final", "canceled")
+
+
 @frappe.whitelist()
-def get_scheduled_mails(account: str) -> list[dict]:
-    """Returns the account's held (FUTURERELEASE) submissions plus released ones whose delivery
-    has not succeeded, soonest first — problem rows have a past sendAt, so they lead."""
+def get_submissions(
+    account: str,
+    undo_status: str | None = None,
+    identity_id: str | None = None,
+    email_id: str | None = None,
+    thread_id: str | None = None,
+    before: str | None = None,
+    after: str | None = None,
+) -> list[dict]:
+    """Browses the account's EmailSubmission objects, newest sendAt first.
+
+    The filters are the RFC 8621 §7.3 FilterCondition properties: `undo_status` is one of
+    pending/final/canceled, `before`/`after` bound sendAt (UTC `...Z` timestamps)."""
+
+    if undo_status and undo_status not in UNDO_STATUSES:
+        frappe.throw(_("undoStatus must be one of {0}.").format(", ".join(UNDO_STATUSES)))
+
+    filter = {
+        "undoStatus": undo_status,
+        "identityIds": [identity_id] if identity_id else None,
+        "emailIds": [email_id] if email_id else None,
+        "threadIds": [thread_id] if thread_id else None,
+        "before": before,
+        "after": after,
+    }
+    filter = {key: value for key, value in filter.items() if value}
 
     service = get_email_submission_service(account)
-
-    pending_ids = service.query({"undoStatus": "pending"})
-    final_ids = service.query({"undoStatus": "final"})
-    if not pending_ids and not final_ids:
+    ids = service.query(filter or None, sort=[{"property": "sentAt", "isAscending": False}])
+    if not ids:
         return []
 
-    # Re-read undoStatus from the get: a submission can go final between query and get. A final
-    # one is kept only when it was actually held (HOLDUNTIL) and its delivery is still troubled —
-    # otherwise this page would grow into a delivery log of every send.
-    fetched = service.get(
-        list(dict.fromkeys(pending_ids + final_ids)), properties=[*SUBMISSION_PROPERTIES, "deliveryStatus"]
-    )
+    fetched = service.get(ids, properties=[*SUBMISSION_PROPERTIES, "deliveryStatus"])
     queue_by_envid = _queue_messages_by_envid(fetched)
 
-    rows = []
-    for submission in fetched:
-        if submission.get("undoStatus") not in ("pending", "final"):
-            continue
-        row = _serialize_submission(submission, None, queue_by_envid.get(_envid(submission)))
-        if row["status"] == "scheduled" or (_was_held(submission) and row["status"] in PROBLEM_STATUSES):
-            rows.append(row)
+    # The query's order (sentAt desc) is the listing's order; get() does not guarantee it.
+    submissions_by_id = {s["id"]: s for s in fetched}
+    rows = [
+        _serialize_submission(submission, None, queue_by_envid.get(_envid(submission)))
+        for id in ids
+        if (submission := submissions_by_id.get(id))
+    ]
 
-    email_ids = [row["email_id"] for row in rows if row["email_id"]]
+    email_ids = list(dict.fromkeys(row["email_id"] for row in rows if row["email_id"]))
     emails_by_id = {
         e["id"]: e
         for e in (
@@ -95,7 +117,6 @@ def get_scheduled_mails(account: str) -> list[dict]:
     for row in rows:
         _add_email_fields(row, emails_by_id.get(row["email_id"]))
 
-    rows.sort(key=lambda row: row["send_at"] or "")
     return rows
 
 
@@ -227,7 +248,7 @@ def retry_failed_mail(account: str, id: str) -> dict:
 
 @frappe.whitelist()
 def dismiss_failed_mail(account: str, id: str) -> None:
-    """Drops a finalized submission's record from the Scheduled listing."""
+    """Drops a finalized submission's record from the Outbox listing."""
 
     service = get_email_submission_service(account)
     _get_final_submission(service, id)
@@ -244,7 +265,7 @@ PROBLEM_STATUSES = ("failed", "retrying", "queued")
 
 
 def _serialize_submission(submission: dict, email: dict | None, queue_message: dict | None) -> dict:
-    """One Scheduled-page row: the submission itself plus its merged delivery state."""
+    """One Outbox row: the submission itself plus its merged delivery state."""
 
     recipients_status = _recipient_states(submission, queue_message)
     retries = [r["retries"] for r in recipients_status if r["retries"] is not None]
@@ -387,14 +408,6 @@ def _hold_active(submission: dict) -> bool:
         return False
 
     return datetime.fromisoformat(send_at.replace("Z", "+00:00")) > datetime.now(timezone.utc)
-
-
-def _was_held(submission: dict) -> bool:
-    """Whether the submission's delivery was held (scheduled or undo-send) — marked by the
-    RFC 4865 HOLDUNTIL parameter in its stored envelope."""
-
-    parameters = ((submission.get("envelope") or {}).get("mailFrom") or {}).get("parameters") or {}
-    return any(key.upper() == "HOLDUNTIL" for key in parameters)
 
 
 def _envid(submission: dict) -> str | None:

--- a/suite/mail/doctype/mail_queue/mail_queue.js
+++ b/suite/mail/doctype/mail_queue/mail_queue.js
@@ -31,16 +31,6 @@ frappe.ui.form.on('Mail Queue', {
 			frm.add_custom_button(__('Retry'), () => frm.trigger('retry'), __('Actions'))
 		}
 
-		if (frm.doc.status === 'Scheduled') {
-			frm.add_custom_button(__('Send Now'), () => frm.trigger('send_now'), __('Actions'))
-			frm.add_custom_button(__('Reschedule'), () => frm.trigger('reschedule'), __('Actions'))
-			frm.add_custom_button(
-				__('Cancel Schedule'),
-				() => frm.trigger('cancel_schedule'),
-				__('Actions'),
-			)
-		}
-
 		if (
 			frm.doc.blob_id &&
 			!frm.doc.message &&
@@ -52,68 +42,6 @@ frappe.ui.form.on('Mail Queue', {
 				__('Actions'),
 			)
 		}
-	},
-
-	send_now(frm) {
-		frappe.confirm(__('Deliver this scheduled email immediately?'), () => {
-			frappe.call({
-				doc: frm.doc,
-				method: 'send_now',
-				freeze: true,
-				freeze_message: __('Sending...'),
-				callback: (r) => {
-					if (!r.exc) {
-						frm.reload_doc()
-					}
-				},
-			})
-		})
-	},
-
-	reschedule(frm) {
-		frappe.prompt(
-			{
-				label: __('Send At'),
-				fieldname: 'send_at',
-				fieldtype: 'Datetime',
-				reqd: 1,
-				default: frm.doc.send_at,
-			},
-			(values) => {
-				frappe.call({
-					doc: frm.doc,
-					method: 'reschedule',
-					args: { send_at: values.send_at },
-					freeze: true,
-					freeze_message: __('Rescheduling...'),
-					callback: (r) => {
-						if (!r.exc) {
-							frm.reload_doc()
-						}
-					},
-				})
-			},
-			__('Reschedule Delivery'),
-		)
-	},
-
-	cancel_schedule(frm) {
-		frappe.confirm(
-			__('Cancel delivery and move the message back to Drafts? This cannot be undone.'),
-			() => {
-				frappe.call({
-					doc: frm.doc,
-					method: 'cancel_schedule',
-					freeze: true,
-					freeze_message: __('Cancelling...'),
-					callback: (r) => {
-						if (!r.exc) {
-							frm.reload_doc()
-						}
-					},
-				})
-			},
-		)
 	},
 
 	retry(frm) {

--- a/suite/mail/doctype/mail_queue/mail_queue.json
+++ b/suite/mail/doctype/mail_queue/mail_queue.json
@@ -79,14 +79,14 @@
    "fieldtype": "Section Break"
   },
   {
-   "description": "Delivery lifecycle status, set by the system: Pending/Queued are awaiting processing, Drafted is stored on the server, Submitted is handed over for delivery, Scheduled is held for later delivery, Cancelled had its scheduled delivery cancelled, and the Failed states are eligible for retry.",
+   "description": "Delivery lifecycle status, set by the system: Pending/Queued are awaiting processing, Drafted is stored on the server, Submitted is handed over for delivery (the server may still hold it until Send At; Cancelled At records a cancelled hold), and the Failed states are eligible for retry.",
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
    "no_copy": 1,
-   "options": "\nPending\nQueued\nFailed\nDrafted\nFailed to Draft\nSubmitted\nFailed to Submit\nScheduled\nCancelled",
+   "options": "\nPending\nQueued\nFailed\nDrafted\nFailed to Draft\nSubmitted\nFailed to Submit",
    "read_only": 1,
    "search_index": 1
   },
@@ -372,8 +372,8 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval: doc.status == 'Cancelled'",
-   "description": "When the scheduled delivery was cancelled.",
+   "depends_on": "eval: doc.cancelled_at",
+   "description": "When the held (scheduled or undo-send) delivery was cancelled \u2014 the submission itself is the source of truth.",
    "fieldname": "cancelled_at",
    "fieldtype": "Datetime",
    "label": "Cancelled At",
@@ -590,7 +590,7 @@
    "search_index": 1
   },
   {
-   "description": "JMAP EmailSubmission id of the latest submission. While Scheduled, it is used to reconcile, reschedule, or cancel the held delivery.",
+   "description": "JMAP EmailSubmission id of the latest submission \u2014 the source of truth for a held (scheduled) delivery's state.",
    "fieldname": "submission_id",
    "fieldtype": "Data",
    "in_standard_filter": 1,

--- a/suite/mail/doctype/mail_queue/mail_queue.py
+++ b/suite/mail/doctype/mail_queue/mail_queue.py
@@ -103,8 +103,6 @@ class MailQueue(OwnerFromUser, Document):
             "Failed to Draft",
             "Submitted",
             "Failed to Submit",
-            "Scheduled",
-            "Cancelled",
         ]
         subject: DF.SmallText | None
         submission_id: DF.Data | None
@@ -121,13 +119,7 @@ class MailQueue(OwnerFromUser, Document):
         cutoff = get_datetime(add_to_date(now(), days=-days))
         (
             frappe.qb.from_(MQ)
-            .where(
-                ((MQ.status.isin(["Drafted", "Submitted", "Cancelled"])) & (MQ.creation < cutoff))
-                # A Scheduled row whose hold elapsed this long ago has delivered (or surfaced
-                # in the MTA queue) — without this, rows never reconciled by the Scheduled
-                # page (e.g. every undo-send hold) would accumulate forever.
-                | ((MQ.status == "Scheduled") & (MQ.send_at < cutoff))
-            )
+            .where((MQ.status.isin(["Drafted", "Submitted"])) & (MQ.creation < cutoff))
             .delete()
         ).run()
 
@@ -720,153 +712,6 @@ class MailQueue(OwnerFromUser, Document):
         self._process()
 
     @frappe.whitelist()
-    def reschedule(self, send_at: str) -> None:
-        """Moves the scheduled delivery time by canceling the held submission and creating a
-        new one — undoStatus is the only mutable property of a submission (RFC 8621 §7.5)."""
-
-        self.check_permission("write")
-        self._lock_and_validate_scheduled()
-
-        self.send_at = send_at
-        self.validate_send_at_window()
-
-        self._cancel_submission()
-        self._resubmit(hold_until=self._hold_until)
-
-    @frappe.whitelist()
-    def send_now(self) -> None:
-        """Delivers a scheduled email immediately by canceling the held submission and creating an unheld one."""
-
-        self.check_permission("write")
-        self._lock_and_validate_scheduled()
-
-        self._cancel_submission()
-        self._resubmit(hold_until=None)
-
-    @frappe.whitelist()
-    def cancel_schedule(self) -> None:
-        """Cancels scheduled delivery and moves the message back to Drafts for editing."""
-
-        self.check_permission("write")
-        self._lock_and_validate_scheduled()
-        self._cancel_submission()
-
-        from suite.mail.jmap import get_jmap_set_error_message
-
-        connection = get_jmap_connection(self.user)
-        email_service = EmailService(self.account, connection)
-        drafts_mailbox_id = MailboxService(self.account, connection).get_mailbox_id_by_role(
-            "drafts", create_if_not_exists=True, raise_exception=True
-        )
-
-        # Replace (not patch) mailboxIds so the message leaves Sent; restore $draft.
-        result = email_service.update(
-            [{"id": self.id, "mailbox_ids": {drafts_mailbox_id: True}, "keywords": {"$draft": True}}],
-            replace_mailboxes=True,
-        )
-        if self.id not in result["updated"]:
-            # The submission is already canceled; retrying this action skips the cancel
-            # step (undoStatus is "canceled") and reattempts the move.
-            frappe.throw(get_jmap_set_error_message(result, "notUpdated", self.id))
-
-        # Evict the cached copy — it still carries the Sent mailbox and would show a
-        # stale folder label in Drafts until the next sync.
-        from suite.mail.doctype.mail_message.mail_message import _remove_cached_messages
-
-        _remove_cached_messages(self.account, [self.id])
-
-        previous_mailbox_id = self.mailbox_id
-        self._db_set(notify=True, status="Cancelled", cancelled_at=now(), mailbox_id=drafts_mailbox_id)
-
-        # Refresh the open mailbox view the way the message actions do. It can't be driven
-        # from the composer that raised the undo toast: the dialog drops its content when it
-        # closes, so that component is already gone by the time the undo runs.
-        if mailbox_ids := [m for m in {drafts_mailbox_id, previous_mailbox_id} if m]:
-            frappe.publish_realtime("new_mail_created", mailbox_ids, user=self.user)
-
-    def _lock_and_validate_scheduled(self) -> None:
-        """Serializes the scheduled-send actions on this row and validates it is still held.
-
-        Each action cancels the current submission and may create a replacement, so two of
-        them reading the same state both pass validation and race: the loser either fails
-        on an already-canceled submission or — the damaging case — resubmits a message the
-        winner just cancelled and moved back to Drafts, delivering mail the user undid.
-
-        The lock is held until the request's transaction ends, so a second action blocks
-        and then re-reads what the first committed. The state is re-read from the locked
-        row rather than trusted from the in-memory doc, which may predate that write.
-        """
-
-        current = frappe.db.get_value(
-            "Mail Queue",
-            self.name,
-            ["status", "submission_id", "send_at"],
-            for_update=True,
-            as_dict=True,
-        )
-        if not current:
-            frappe.throw(_("Mail Queue {0} no longer exists.").format(self.name))
-
-        self.status = current.status
-        self.submission_id = current.submission_id
-        self.send_at = current.send_at
-
-        if self.status != "Scheduled":
-            frappe.throw(_("Only scheduled emails can be modified. Current status: {0}").format(self.status))
-
-    def _cancel_submission(self) -> None:
-        """Cancels the held submission; reconciles the row and throws if it already went final."""
-
-        if not self.submission_id:
-            return  # an earlier resubmit failed after canceling; nothing left to cancel
-
-        service = get_email_submission_service(self.account)
-        submissions = service.get([self.submission_id])
-        undo_status = submissions[0].get("undoStatus") if submissions else "final"
-
-        if undo_status == "pending":
-            service.cancel(self.submission_id)
-        elif undo_status != "canceled":
-            self._db_set(notify=True, status="Submitted", submitted_at=now())
-            frappe.throw(_("This email has already been delivered and can no longer be changed."))
-
-    def _resubmit(self, hold_until: int | None) -> None:
-        """Creates a replacement submission for the (already canceled) previous one."""
-
-        service = get_email_submission_service(self.account)
-
-        try:
-            created = service.resubmit(
-                email_id=self.id,
-                from_email=self.from_email,
-                rcpt_emails=[r["email"].lower() for r in json_loads(self.recipients, default=[])],
-                envelope_id=self.name,
-                priority=self._priority,
-                hold_until=hold_until,
-            )
-        except Exception:
-            # The old submission is already canceled: fail closed. The row stays Scheduled
-            # without a submission id, so a retried action skips the cancel step.
-            self._db_set(notify=True, submission_id=None, error_log=frappe.get_traceback(with_context=True))
-            raise
-
-        if hold_until:
-            self._db_set(
-                notify=True,
-                status="Scheduled",
-                submission_id=created["id"],
-                send_at=get_datetime_str(get_datetime(self.send_at)),
-            )
-        else:
-            self._db_set(
-                notify=True,
-                status="Submitted",
-                submission_id=created["id"],
-                submitted_at=now(),
-                send_at=None,
-            )
-
-    @frappe.whitelist()
     def get_mime_message(self) -> str:
         """Returns the MIME message content."""
 
@@ -988,18 +833,17 @@ class MailQueue(OwnerFromUser, Document):
             if not self.save_as_draft:
                 idx = 2 if self.raw_message and self.id else 1
                 if data := response["methodResponses"][idx][1].get("created", {}).get(f"submit-{self.name}"):
+                    # For a scheduled send the server holds delivery (FUTURERELEASE); the row
+                    # is still Submitted — the EmailSubmission object is the source of truth
+                    # for the hold's state, and send_at merely logs it.
                     kwargs.update(
                         {
                             "submission_id": data["id"],
                             "mailbox_id": sent_mailbox_id,
+                            "status": "Submitted",
+                            "submitted_at": now(),
                         }
                     )
-                    if self.send_at:
-                        # The server holds delivery (FUTURERELEASE); submitted_at is set once
-                        # the submission goes final (reconciliation or send-now).
-                        kwargs["status"] = "Scheduled"
-                    else:
-                        kwargs.update({"status": "Submitted", "submitted_at": now()})
                 elif response["methodResponses"][idx][1].get("notCreated", {}).get(f"submit-{self.name}"):
                     retries = cint(self.retries) + 1
                     kwargs.update(
@@ -1110,81 +954,6 @@ def process_pending_emails(mails: list[str]) -> None:
                         "({failure_rate:.2%} failure rate). Please investigate the issue before retrying."
                     ).format(retries=retries, total_count=total_count, failure_rate=failure_ratio)
                 )
-
-
-def apply_reconciled_submissions(submitted: list[str], cancelled: list[str]) -> None:
-    """Moves Scheduled rows to the terminal state their submission reports.
-
-    Batched on purpose: the Scheduled page reconciles on its read path, so a per-row write
-    would make page latency grow with the number of finalized rows — and with undo send,
-    every UI send leaves one behind between hourly sweeps.
-
-    Still-Scheduled guard: an action may have moved a row to a terminal state since the
-    submission states were read, and must not be clobbered back.
-    """
-
-    MQ = frappe.qb.DocType("Mail Queue")
-    timestamp = now()
-
-    for names, status, field in (
-        (submitted, "Submitted", MQ.submitted_at),
-        (cancelled, "Cancelled", MQ.cancelled_at),
-    ):
-        # Chunked so a backlog (e.g. the first sweep after downtime) can't build an
-        # oversized IN list.
-        for batch in create_batch(names, 500):
-            (
-                frappe.qb.update(MQ)
-                .set(MQ.status, status)
-                .set(field, timestamp)
-                .where(MQ.name.isin(batch) & (MQ.status == "Scheduled"))
-            ).run()
-
-
-def reconcile_scheduled_emails() -> None:
-    """Flips Scheduled rows whose hold has elapsed to their real submission state.
-
-    The Scheduled page reconciles lazily and clear_old_logs purges eventually, but with
-    undo send every UI send passes through Scheduled — without this sweep the queue log
-    would show delivered mail as Scheduled (and never record submitted_at) until purged.
-
-    Hourly is deliberate: nothing user-facing waits on it (the page reconciles on load),
-    and a row survives days before purge, so it gets many attempts.
-    """
-
-    rows = frappe.db.get_all(
-        "Mail Queue",
-        filters={
-            "status": "Scheduled",
-            "submission_id": ("is", "set"),
-            # Small buffer past the hold so in-flight releases aren't queried mid-flip.
-            "send_at": ("<", add_to_date(now(), minutes=-1)),
-        },
-        fields=["name", "account", "submission_id"],
-    )
-    if not rows:
-        return
-
-    by_account: dict[str, list] = {}
-    for row in rows:
-        by_account.setdefault(row.account, []).append(row)
-
-    for account, account_rows in by_account.items():
-        try:
-            service = get_email_submission_service(account, ignore_permissions=True)
-            undo_by_id = {
-                s["id"]: s.get("undoStatus") for s in service.get([r.submission_id for r in account_rows])
-            }
-        except Exception:
-            log_mail_error(_("Failed - Reconcile Scheduled Emails"), frappe.get_traceback(with_context=True))
-            continue
-
-        # Unknown ids (submission object gone) are left alone — same conservative call as
-        # the Scheduled page; clear_old_logs picks them up eventually.
-        submitted = [r.name for r in account_rows if undo_by_id.get(r.submission_id) == "final"]
-        cancelled = [r.name for r in account_rows if undo_by_id.get(r.submission_id) == "canceled"]
-
-        apply_reconciled_submissions(submitted, cancelled)
 
 
 def enqueue_process_pending_emails(batch_size: int | None = None, max_batch_size: int | None = None) -> None:

--- a/suite/mail/doctype/mail_queue/mail_queue_list.js
+++ b/suite/mail/doctype/mail_queue/mail_queue_list.js
@@ -18,8 +18,6 @@ frappe.listview_settings['Mail Queue'] = {
 			'Failed to Draft': 'red',
 			Submitted: 'green',
 			'Failed to Submit': 'red',
-			Scheduled: 'blue',
-			Cancelled: 'grey',
 		}
 		return [__(doc.status), status_colors[doc.status] || 'darkgrey', 'status,=,' + doc.status]
 	},

--- a/suite/mail/jmap/services/mail/submission/email_submission.py
+++ b/suite/mail/jmap/services/mail/submission/email_submission.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import ClassVar
 
 from suite import __version__
@@ -65,7 +65,7 @@ class EmailSubmissionService(CoreService):
 
         if hold_until:
             # RFC 4865 requires an RFC 3339 date-time; Stalwart >= 0.16.17 rejects epoch seconds.
-            parameters["HOLDUNTIL"] = datetime.fromtimestamp(hold_until, tz=timezone.utc).strftime(
+            parameters["HOLDUNTIL"] = datetime.fromtimestamp(hold_until, tz=UTC).strftime(
                 "%Y-%m-%dT%H:%M:%SZ"
             )
 
@@ -87,17 +87,28 @@ class EmailSubmissionService(CoreService):
         }
 
     def query(
-        self, filter: dict | None = None, limit: int | None = None, sort: list[dict] | None = None
-    ) -> list[str]:
-        """Returns ids of submissions matching `filter` (e.g. {"undoStatus": "pending"}), in
-        `sort` order (e.g. [{"property": "sentAt", "isAscending": False}])."""
+        self,
+        filter: dict | None = None,
+        position: int = 0,
+        limit: int | None = None,
+        sort: list[dict] | None = None,
+    ) -> tuple[list[str], int]:
+        """Returns one page of ids of submissions matching `filter` (e.g. {"undoStatus":
+        "pending"}), in `sort` order (e.g. [{"property": "sentAt", "isAscending": False}]),
+        plus the server's total match count."""
 
-        response = self._query(filter=filter, limit=limit or self.max_objects_in_get, sort=sort)
+        response = self._query(
+            filter=filter, position=position, limit=limit or self.max_objects_in_get, sort=sort
+        )
 
         if method_responses := response.get("methodResponses"):
-            return method_responses[0][1].get("ids", [])
+            body = method_responses[0][1]
+            ids = body.get("ids", [])
+            # calculateTotal is requested, but RFC 8620 §5.5 lets a server omit total; the
+            # page's own bound is then the best available floor.
+            return ids, int(body.get("total") or position + len(ids))
 
-        return []
+        return [], 0
 
     def get(self, ids: list[str], properties: list[str] | None = None) -> list[dict]:
         """Public method to get email submissions by ids, handling batching if the number of ids exceeds the server's maximum allowed in a single 'get' call."""

--- a/suite/mail/jmap/services/mail/submission/email_submission.py
+++ b/suite/mail/jmap/services/mail/submission/email_submission.py
@@ -97,16 +97,24 @@ class EmailSubmissionService(CoreService):
         "pending"}), in `sort` order (e.g. [{"property": "sentAt", "isAscending": False}]),
         plus the server's total match count."""
 
-        response = self._query(
-            filter=filter, position=position, limit=limit or self.max_objects_in_get, sort=sort
-        )
+        limit = limit or self.max_objects_in_get
+        # One id past the page is a look-ahead: whether more matches exist is then known even
+        # when the server's total is missing or zero-valued.
+        response = self._query(filter=filter, position=position, limit=limit + 1, sort=sort)
 
         if method_responses := response.get("methodResponses"):
             body = method_responses[0][1]
             ids = body.get("ids", [])
-            # calculateTotal is requested, but RFC 8620 §5.5 lets a server omit total; the
-            # page's own bound is then the best available floor.
-            return ids, int(body.get("total") or position + len(ids))
+            has_more = len(ids) > limit
+            ids = ids[:limit]
+
+            total = body.get("total")
+            if total is None:
+                # calculateTotal is requested, but RFC 8620 §5.5 lets a server omit total; the
+                # floor then sits one past a full page, so the pager can still advance.
+                total = position + len(ids) + (1 if has_more else 0)
+
+            return ids, int(total)
 
         return [], 0
 

--- a/suite/mail/jmap/services/mail/submission/email_submission.py
+++ b/suite/mail/jmap/services/mail/submission/email_submission.py
@@ -122,6 +122,21 @@ class EmailSubmissionService(CoreService):
         if submission_id not in (result.get("updated") or {}):
             raise ValueError(get_jmap_set_error_message(result, "notUpdated", submission_id))
 
+    def destroy(self, submission_id: str) -> None:
+        """Destroys a submission object (its record, not the message) — used to drop a finalized
+        failed delivery from the Scheduled listing."""
+
+        from suite.mail.jmap import get_jmap_set_error_message
+
+        response = self._delete([submission_id])
+
+        result = {}
+        if method_responses := response.get("methodResponses"):
+            result = method_responses[0][1]
+
+        if submission_id not in (result.get("destroyed") or []):
+            raise ValueError(get_jmap_set_error_message(result, "notDestroyed", submission_id))
+
     def resubmit(
         self,
         email_id: str,

--- a/suite/mail/jmap/services/mail/submission/email_submission.py
+++ b/suite/mail/jmap/services/mail/submission/email_submission.py
@@ -105,13 +105,19 @@ class EmailSubmissionService(CoreService):
         if method_responses := response.get("methodResponses"):
             body = method_responses[0][1]
             ids = body.get("ids", [])
+            # A server that enforces a lower limit than requested echoes the one it used
+            # (RFC 8620 §5.5) — a clamp at or below the page length swallows the look-ahead.
+            served_limit = min(int(body.get("limit") or limit + 1), limit + 1)
             has_more = len(ids) > limit
             ids = ids[:limit]
 
             total = body.get("total")
             if total is None:
-                # calculateTotal is requested, but RFC 8620 §5.5 lets a server omit total; the
-                # floor then sits one past a full page, so the pager can still advance.
+                # calculateTotal is requested, but RFC 8620 §5.5 also lets a server omit total.
+                # A page filled to a clamped limit is then indistinguishable from "more exist":
+                # keep the floor one past it, so the pager advances rather than strand rows.
+                if not has_more and 0 < served_limit <= limit and len(ids) == served_limit:
+                    has_more = True
                 total = position + len(ids) + (1 if has_more else 0)
 
             return ids, int(total)

--- a/suite/mail/jmap/services/mail/submission/email_submission.py
+++ b/suite/mail/jmap/services/mail/submission/email_submission.py
@@ -86,10 +86,13 @@ class EmailSubmissionService(CoreService):
             ],
         }
 
-    def query(self, filter: dict | None = None, limit: int | None = None) -> list[str]:
-        """Returns ids of submissions matching `filter` (e.g. {"undoStatus": "pending"})."""
+    def query(
+        self, filter: dict | None = None, limit: int | None = None, sort: list[dict] | None = None
+    ) -> list[str]:
+        """Returns ids of submissions matching `filter` (e.g. {"undoStatus": "pending"}), in
+        `sort` order (e.g. [{"property": "sentAt", "isAscending": False}])."""
 
-        response = self._query(filter=filter, limit=limit or self.max_objects_in_get)
+        response = self._query(filter=filter, limit=limit or self.max_objects_in_get, sort=sort)
 
         if method_responses := response.get("methodResponses"):
             return method_responses[0][1].get("ids", [])
@@ -124,7 +127,7 @@ class EmailSubmissionService(CoreService):
 
     def destroy(self, submission_id: str) -> None:
         """Destroys a submission object (its record, not the message) — used to drop a finalized
-        failed delivery from the Scheduled listing."""
+        delivery from the Outbox listing."""
 
         from suite.mail.jmap import get_jmap_set_error_message
 

--- a/suite/mail/jmap/services/mail/submission/email_submission.py
+++ b/suite/mail/jmap/services/mail/submission/email_submission.py
@@ -86,6 +86,16 @@ class EmailSubmissionService(CoreService):
             ],
         }
 
+    def query(self, filter: dict | None = None, limit: int | None = None) -> list[str]:
+        """Returns ids of submissions matching `filter` (e.g. {"undoStatus": "pending"})."""
+
+        response = self._query(filter=filter, limit=limit or self.max_objects_in_get)
+
+        if method_responses := response.get("methodResponses"):
+            return method_responses[0][1].get("ids", [])
+
+        return []
+
     def get(self, ids: list[str], properties: list[str] | None = None) -> list[dict]:
         """Public method to get email submissions by ids, handling batching if the number of ids exceeds the server's maximum allowed in a single 'get' call."""
 

--- a/suite/mail/jmap/services/mail/submission/email_submission.py
+++ b/suite/mail/jmap/services/mail/submission/email_submission.py
@@ -95,34 +95,51 @@ class EmailSubmissionService(CoreService):
     ) -> tuple[list[str], int]:
         """Returns one page of ids of submissions matching `filter` (e.g. {"undoStatus":
         "pending"}), in `sort` order (e.g. [{"property": "sentAt", "isAscending": False}]),
-        plus the server's total match count."""
+        plus the server's total match count.
+
+        The page is filled across follow-up queries when the server enforces a lower limit
+        than requested (it then echoes the limit it used, RFC 8620 §5.5) — otherwise a clamp
+        below the page length would silently shrink the page and strand the rows behind it,
+        since the pager advances in strides of the full page."""
 
         limit = limit or self.max_objects_in_get
         # One id past the page is a look-ahead: whether more matches exist is then known even
         # when the server's total is missing or zero-valued.
-        response = self._query(filter=filter, position=position, limit=limit + 1, sort=sort)
+        target = limit + 1
 
-        if method_responses := response.get("methodResponses"):
+        ids: list[str] = []
+        total = None
+        while len(ids) < target:
+            remaining = target - len(ids)
+            response = self._query(filter=filter, position=position + len(ids), limit=remaining, sort=sort)
+            if not (method_responses := response.get("methodResponses")):
+                if not ids:
+                    return [], 0
+                break
+
             body = method_responses[0][1]
-            ids = body.get("ids", [])
-            # A server that enforces a lower limit than requested echoes the one it used
-            # (RFC 8620 §5.5) — a clamp at or below the page length swallows the look-ahead.
-            served_limit = min(int(body.get("limit") or limit + 1), limit + 1)
-            has_more = len(ids) > limit
-            ids = ids[:limit]
+            batch = body.get("ids", [])[:remaining]
+            served_limit = min(int(body.get("limit") or remaining), remaining)
+            if total is None and body.get("total") is not None:
+                total = int(body["total"])
 
-            total = body.get("total")
-            if total is None:
-                # calculateTotal is requested, but RFC 8620 §5.5 also lets a server omit total.
-                # A page filled to a clamped limit is then indistinguishable from "more exist":
-                # keep the floor one past it, so the pager advances rather than strand rows.
-                if not has_more and 0 < served_limit <= limit and len(ids) == served_limit:
-                    has_more = True
-                total = position + len(ids) + (1 if has_more else 0)
+            ids.extend(batch)
+            # A batch below the enforced limit is the end of the results; one that merely
+            # filled a clamp is not — loop on for the rest of the page.
+            if not batch or len(batch) < served_limit:
+                break
+            if total is not None and position + len(ids) >= total:
+                break
 
-            return ids, int(total)
+        has_more = len(ids) > limit
+        ids = ids[:limit]
 
-        return [], 0
+        if total is None:
+            # calculateTotal is requested, but RFC 8620 §5.5 lets a server omit total; the
+            # floor then sits one past a full page, so the pager can still advance.
+            total = position + len(ids) + (1 if has_more else 0)
+
+        return ids, int(total)
 
     def get(self, ids: list[str], properties: list[str] | None = None) -> list[dict]:
         """Public method to get email submissions by ids, handling batching if the number of ids exceeds the server's maximum allowed in a single 'get' call."""

--- a/suite/mail/patches/remove_held_queue_statuses.py
+++ b/suite/mail/patches/remove_held_queue_statuses.py
@@ -1,0 +1,20 @@
+import frappe
+from frappe.query_builder.functions import Coalesce
+
+
+def execute() -> None:
+    """Flip Mail Queue rows from the removed Scheduled/Cancelled statuses to Submitted.
+
+    Scheduled sends are now read straight from the server's EmailSubmission objects; the
+    queue row only logs that the email was handed over (Submitted), with send_at recording
+    the hold and cancelled_at a cancelled one. submitted_at backfills from creation — the
+    submission was created then.
+    """
+
+    MQ = frappe.qb.DocType("Mail Queue")
+    (
+        frappe.qb.update(MQ)
+        .set(MQ.status, "Submitted")
+        .set(MQ.submitted_at, Coalesce(MQ.submitted_at, MQ.creation))
+        .where(MQ.status.isin(["Scheduled", "Cancelled"]))
+    ).run()

--- a/suite/mail/tests/test_mail_scheduled_send.py
+++ b/suite/mail/tests/test_mail_scheduled_send.py
@@ -624,11 +624,33 @@ class TestOutboxRequestBoundary(IntegrationTestCase):
 
 
 class TestSubmissionQueryTotal(IntegrationTestCase):
-    """The submission query's look-ahead, exercised against a fake server response: the pager
-    must keep advancing even when the server omits total (RFC 8620 §5.5 allows it), and a
-    genuine total of 0 must not be mistaken for an omitted one."""
+    """The submission query, exercised against a fake (possibly clamping) server: the pager
+    must keep advancing even when the server omits total (RFC 8620 §5.5 allows it), a genuine
+    total of 0 must not be mistaken for an omitted one, and a server-enforced limit below the
+    page length must not shrink the page — the pager advances in strides of the full page, so
+    the rows behind the clamp would be stranded."""
 
-    def _query_page(self, body: dict, position: int = 0, limit: int = 2) -> tuple[list[str], int]:
+    def _query_page(
+        self,
+        all_ids: list[str],
+        position: int = 0,
+        limit: int = 2,
+        server_limit: int | None = None,
+        server_total: int | None = None,
+    ) -> tuple[list[str], int, int]:
+        """Runs query() against a fake server holding `all_ids`, which clamps every request to
+        `server_limit` ids (echoing the limit it used, per RFC 8620 §5.5) and reports
+        `server_total` as total when given. Returns (ids, total, request_count)."""
+
+        def respond(filter=None, position=0, limit=50, sort=None):
+            served = limit if server_limit is None else min(server_limit, limit)
+            body = {"ids": all_ids[position : position + served]}
+            if server_total is not None:
+                body["total"] = server_total
+            if served < limit:
+                body["limit"] = served
+            return {"methodResponses": [["EmailSubmission/query", body, "0"]]}
+
         service = EmailSubmissionService(
             "acc",
             SimpleNamespace(
@@ -639,52 +661,55 @@ class TestSubmissionQueryTotal(IntegrationTestCase):
                 ]
             ),
         )
-        response = {"methodResponses": [["EmailSubmission/query", body, "0"]]}
-        with mock.patch.object(service, "_query", return_value=response) as query:
+        with mock.patch.object(service, "_query", side_effect=respond) as query:
             ids, total = service.query(position=position, limit=limit)
 
         # The look-ahead: one id past the page is requested, never returned.
-        self.assertEqual(query.call_args.kwargs["limit"], limit + 1)
-        return ids, total
+        self.assertEqual(query.call_args_list[0].kwargs["limit"], limit + 1)
+        return ids, total, query.call_count
 
     def test_omitted_total_keeps_the_pager_advancing(self):
         # A full page plus the look-ahead id: the floor sits one past the page, so the
         # pager's page count stays ahead of the current page.
-        ids, total = self._query_page({"ids": ["a", "b", "c"]}, position=2)
-        self.assertEqual(ids, ["a", "b"])
+        ids, total, _ = self._query_page(["a", "b", "c", "d", "e"], position=2)
+        self.assertEqual(ids, ["c", "d"])
         self.assertEqual(total, 5)
 
         # A full page with nothing behind it: the floor is exact and Next disables.
-        ids, total = self._query_page({"ids": ["a", "b"]}, position=2)
-        self.assertEqual(ids, ["a", "b"])
+        ids, total, _ = self._query_page(["a", "b", "c", "d"], position=2)
+        self.assertEqual(ids, ["c", "d"])
         self.assertEqual(total, 4)
 
     def test_server_total_is_trusted_even_when_zero(self):
         # total 0 is falsy but real — an out-of-range page must not report phantom pages.
-        ids, total = self._query_page({"ids": [], "total": 0}, position=2)
+        ids, total, _ = self._query_page([], position=2, server_total=0)
         self.assertEqual((ids, total), ([], 0))
 
-        ids, total = self._query_page({"ids": ["a", "b", "c"], "total": 7})
+        ids, total, _ = self._query_page(["a", "b", "c", "d", "e"], server_total=7)
         self.assertEqual((ids, total), (["a", "b"], 7))
 
-    def test_clamped_lookahead_keeps_the_pager_advancing(self):
-        # The server clamps the requested limit+1 to the page length, swallowing the
-        # look-ahead (it echoes the limit it used, RFC 8620 §5.5): a page filled to the
-        # clamp is indistinguishable from "more exist", so the floor sits one past it.
-        ids, total = self._query_page({"ids": ["a", "b"], "limit": 2}, position=2)
-        self.assertEqual(ids, ["a", "b"])
+    def test_clamped_server_still_fills_the_page(self):
+        # The server clamps every query below the page length: the page is filled across
+        # follow-up queries, so no rows are stranded between the pager's strides — and the
+        # look-ahead still lands, keeping the floor one past the page.
+        ids, total, requests = self._query_page(["a", "b", "c", "d", "e", "f"], limit=4, server_limit=1)
+        self.assertEqual(ids, ["a", "b", "c", "d"])
+        self.assertEqual(total, 5)
+        self.assertEqual(requests, 5)
+
+        # A clamp exactly at the page length behaves the same — the look-ahead alone spills
+        # into a follow-up query.
+        ids, total, _ = self._query_page(["a", "b", "c", "d", "e", "f"], position=2, server_limit=2)
+        self.assertEqual(ids, ["c", "d"])
         self.assertEqual(total, 5)
 
-        # A clamp below the page length: the short page filled the clamp, so it is not
-        # the last page either.
-        ids, total = self._query_page({"ids": ["a"], "limit": 1}, position=2)
-        self.assertEqual(ids, ["a"])
-        self.assertEqual(total, 4)
+        # A clamped server that runs dry mid-fill: the results end, exactly.
+        ids, total, _ = self._query_page(["a", "b", "c"], limit=4, server_limit=1)
+        self.assertEqual(ids, ["a", "b", "c"])
+        self.assertEqual(total, 3)
 
-        # A short page under an unclamped (or above-page) limit really is the end.
-        ids, total = self._query_page({"ids": ["a"]}, position=2)
-        self.assertEqual((ids, total), (["a"], 3))
-
-        # The clamp never overrides a total the server did provide.
-        ids, total = self._query_page({"ids": ["a", "b"], "limit": 2, "total": 4}, position=2)
-        self.assertEqual((ids, total), (["a", "b"], 4))
+        # The fill respects a total the server did provide — it stops there and never
+        # overrides it.
+        ids, total, requests = self._query_page(["a", "b", "c", "d"], limit=4, server_limit=2, server_total=4)
+        self.assertEqual((ids, total), (["a", "b", "c", "d"], 4))
+        self.assertEqual(requests, 2)

--- a/suite/mail/tests/test_mail_scheduled_send.py
+++ b/suite/mail/tests/test_mail_scheduled_send.py
@@ -22,6 +22,8 @@ and retry/dismiss against delivered (final) submissions.
 """
 
 from datetime import datetime
+from types import SimpleNamespace
+from unittest import mock
 
 import frappe
 from frappe.exceptions import FrappeTypeError
@@ -39,6 +41,7 @@ from suite.mail.api.scheduled import (
     send_scheduled_mail_now,
 )
 from suite.mail.jmap import get_email_service, get_email_submission_service
+from suite.mail.jmap.services.mail.submission.email_submission import EmailSubmissionService
 from suite.mail.tests.base import StalwartIntegrationTestCase, unique_name
 from suite.mail.utils.dt import to_utc_z
 from suite.utils.dt import convert_to_utc
@@ -618,3 +621,48 @@ class TestOutboxRequestBoundary(IntegrationTestCase):
 
         with self.assertRaisesRegex(frappe.ValidationError, "undoStatus must be one of"):
             get_submissions("acc", undo_status="bogus")
+
+
+class TestSubmissionQueryTotal(IntegrationTestCase):
+    """The submission query's look-ahead, exercised against a fake server response: the pager
+    must keep advancing even when the server omits total (RFC 8620 §5.5 allows it), and a
+    genuine total of 0 must not be mistaken for an omitted one."""
+
+    def _query_page(self, body: dict, position: int = 0, limit: int = 2) -> tuple[list[str], int]:
+        service = EmailSubmissionService(
+            "acc",
+            SimpleNamespace(
+                capabilities=[
+                    "urn:ietf:params:jmap:core",
+                    "urn:ietf:params:jmap:mail",
+                    "urn:ietf:params:jmap:submission",
+                ]
+            ),
+        )
+        response = {"methodResponses": [["EmailSubmission/query", body, "0"]]}
+        with mock.patch.object(service, "_query", return_value=response) as query:
+            ids, total = service.query(position=position, limit=limit)
+
+        # The look-ahead: one id past the page is requested, never returned.
+        self.assertEqual(query.call_args.kwargs["limit"], limit + 1)
+        return ids, total
+
+    def test_omitted_total_keeps_the_pager_advancing(self):
+        # A full page plus the look-ahead id: the floor sits one past the page, so the
+        # pager's page count stays ahead of the current page.
+        ids, total = self._query_page({"ids": ["a", "b", "c"]}, position=2)
+        self.assertEqual(ids, ["a", "b"])
+        self.assertEqual(total, 5)
+
+        # A full page with nothing behind it: the floor is exact and Next disables.
+        ids, total = self._query_page({"ids": ["a", "b"]}, position=2)
+        self.assertEqual(ids, ["a", "b"])
+        self.assertEqual(total, 4)
+
+    def test_server_total_is_trusted_even_when_zero(self):
+        # total 0 is falsy but real — an out-of-range page must not report phantom pages.
+        ids, total = self._query_page({"ids": [], "total": 0}, position=2)
+        self.assertEqual((ids, total), ([], 0))
+
+        ids, total = self._query_page({"ids": ["a", "b", "c"], "total": 7})
+        self.assertEqual((ids, total), (["a", "b"], 7))

--- a/suite/mail/tests/test_mail_scheduled_send.py
+++ b/suite/mail/tests/test_mail_scheduled_send.py
@@ -24,6 +24,8 @@ and retry/dismiss against delivered (final) submissions.
 from datetime import datetime
 
 import frappe
+from frappe.exceptions import FrappeTypeError
+from frappe.tests import IntegrationTestCase
 from frappe.utils import add_to_date, get_datetime, get_datetime_str, now, time_diff_in_seconds
 
 from suite.mail.api.scheduled import (
@@ -575,3 +577,44 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
                     action(scheduled.submission_id)
 
             self.assertEqual(self._get_submission(account, scheduled.submission_id)["undoStatus"], "canceled")
+
+
+class TestOutboxRequestBoundary(IntegrationTestCase):
+    """The Outbox endpoints' request boundary, exercised without Stalwart.
+
+    ``frappe.whitelist`` wraps every endpoint in ``validate_argument_types`` (active in requests
+    and tests alike), so a client-supplied complex value — a dict or list where a scalar is
+    annotated — is rejected before the endpoint body runs, i.e. before anything can reach JMAP
+    or the database; the endpoints' own explicit checks then refuse malformed scalars.
+    """
+
+    def test_complex_values_are_rejected_before_the_body_runs(self):
+        for call in (
+            lambda: get_submissions(account={"account": "x"}),
+            lambda: get_submissions("acc", undo_status={"operator": "OR", "conditions": []}),
+            lambda: get_submissions("acc", identity_id=["id-1", "id-2"]),
+            lambda: get_submissions("acc", email_id={"$ne": ""}),
+            lambda: get_submissions("acc", before={"utcDate": "2026-01-01T00:00:00Z"}),
+            lambda: get_submissions("acc", page={"gt": 1}),
+            lambda: get_submissions("acc", page_length=[100]),
+            lambda: get_scheduled_mail("acc", id=["sub-1"]),
+            lambda: reschedule_mail("acc", "sub", send_at=["2026-01-01T00:00:00Z"]),
+            lambda: send_scheduled_mail_now("acc", id=None),
+            lambda: cancel_scheduled_mail("acc", id={"id": "sub"}),
+            lambda: retry_delivery_now("acc", id={}),
+            lambda: retry_failed_mail(["acc"], "sub"),
+            lambda: dismiss_failed_mail("acc", id=42),
+        ):
+            self.assertRaises(FrappeTypeError, call)
+
+    def test_malformed_filter_scalars_are_rejected(self):
+        # Well-typed strings that aren't valid filter values; the endpoint's own explicit
+        # checks refuse them before any account lookup or server contact (asserted on the
+        # message so a later failure — e.g. the unknown account — can't pass for it).
+        for bad in ("yesterday", "31-01-2026", "2026-13-45T99:00:00Z"):
+            for bound in ("before", "after"):
+                with self.assertRaisesRegex(frappe.ValidationError, "must be a UTC timestamp"):
+                    get_submissions("acc", **{bound: bad})
+
+        with self.assertRaisesRegex(frappe.ValidationError, "undoStatus must be one of"):
+            get_submissions("acc", undo_status="bogus")

--- a/suite/mail/tests/test_mail_scheduled_send.py
+++ b/suite/mail/tests/test_mail_scheduled_send.py
@@ -4,13 +4,13 @@
 """Scheduled send via JMAP FUTURERELEASE (RFC 4865).
 
 Scheduling submits immediately with a HOLDUNTIL envelope parameter, so the server holds
-delivery; the Mail Queue row carries the schedule (``send_at``/``submission_id``, status
-``Scheduled``). Reschedule/send-now cancel the held submission and create a new one
-(undoStatus is the only mutable submission property); cancel reverts the message to Drafts.
-Listing reconciles lazily through ``EmailSubmission/get`` — ``EmailSubmission/query`` returns
-empty on Stalwart even for pending submissions and must not be used.
-
-There is no undo-send window feature — only explicit scheduling is covered here.
+delivery; the Mail Queue row is only a log (status ``Submitted``, ``send_at`` recording the
+hold). The server's EmailSubmission objects are the source of truth: the Scheduled page lists
+them via ``EmailSubmission/query`` (``undoStatus: "pending"``), so submissions created by
+other clients appear too, and every action is keyed on the submission id. Reschedule and
+send-now cancel the held submission and create a new one (undoStatus is the only mutable
+submission property); cancel reverts the message to Drafts. An Email deleted after scheduling
+leaves a dangling emailId — such a delivery can only be cancelled.
 """
 
 from datetime import datetime
@@ -18,6 +18,12 @@ from datetime import datetime
 import frappe
 from frappe.utils import add_to_date, get_datetime, get_datetime_str, now, time_diff_in_seconds
 
+from suite.mail.api.scheduled import (
+    cancel_scheduled_mail,
+    get_scheduled_mails,
+    reschedule_mail,
+    send_scheduled_mail_now,
+)
 from suite.mail.jmap import get_email_service, get_email_submission_service
 from suite.mail.tests.base import StalwartIntegrationTestCase, unique_name
 from suite.mail.utils.dt import to_utc_z
@@ -41,7 +47,7 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
     # --- helpers ------------------------------------------------------------
 
     def _schedule(self, minutes: int = 120, subject: str | None = None) -> frappe._dict:
-        """Schedules a mail from the class sender and returns the Mail Queue row's details."""
+        """Schedules a mail from the class sender and returns the send result's details."""
 
         subject = subject or f"Scheduled {unique_name('subject')}"
         result = self.send_mail(
@@ -50,33 +56,43 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
             subject=subject,
             send_at=to_utc_z(add_to_date(now(), minutes=minutes)),
         )
-        self.assertEqual(result["status"], "Scheduled", result.get("error"))
+        self.assertEqual(result["status"], "Submitted", result.get("error"))
+        self.assertTrue(result["submission_id"])
 
-        with self.set_user("Administrator"):
-            doc = frappe.get_last_doc("Mail Queue", {"id": result["id"]})
-
-        return frappe._dict(name=doc.name, doc=doc, subject=subject, result=result)
+        return frappe._dict(
+            name=result["name"],
+            id=result["id"],
+            submission_id=result["submission_id"],
+            subject=subject,
+            result=result,
+        )
 
     def _get_submission(self, account: str, submission_id: str) -> dict | None:
         with self.set_user(self.sender.email):
             submissions = get_email_submission_service(account).get([submission_id])
         return submissions[0] if submissions else None
 
+    def _scheduled_rows(self, account: str) -> list[dict]:
+        with self.set_user(self.sender.email):
+            return get_scheduled_mails(account)
+
     # --- tests --------------------------------------------------------------
 
     def test_schedule_holds_delivery(self):
         scheduled = self._schedule(minutes=120)
-        doc = scheduled.doc
 
-        self.assertEqual(doc.status, "Scheduled")
+        # The queue row is just a log now: submitted, with send_at recording the hold.
+        with self.set_user("Administrator"):
+            doc = frappe.get_doc("Mail Queue", scheduled.name)
+        self.assertEqual(doc.status, "Submitted")
         self.assertTrue(doc.submission_id)
         self.assertTrue(doc.send_at)
-        self.assertFalse(doc.submitted_at)
+        self.assertTrue(doc.submitted_at)
 
         account = self.personal_account(self.sender)
 
         # Trust EmailSubmission/get, not the create echo (which reports "final").
-        submission = self._get_submission(account, doc.submission_id)
+        submission = self._get_submission(account, scheduled.submission_id)
         self.assertIsNotNone(submission)
         self.assertEqual(submission["undoStatus"], "pending")
 
@@ -86,56 +102,94 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
 
         # The message sits in Sent while held (moved there at submission time).
         with self.set_user(self.sender.email):
-            sent_id = frappe.get_doc("Mail Queue", doc.name).mailbox_id
-            emails = get_email_service(account).get([doc.id], properties=["mailboxIds"])
+            sent_id = frappe.get_doc("Mail Queue", scheduled.name).mailbox_id
+            emails = get_email_service(account).get([scheduled.id], properties=["mailboxIds"])
         self.assertTrue(emails and emails[0]["mailboxIds"].get(sent_id))
 
         # Held, so nothing has reached the recipient.
         threads = self.get_inbox_threads(self.recipient)
         self.assertNotIn(scheduled.subject, [t["subject"] for t in threads])
 
+    def test_listing_reads_submissions(self):
+        scheduled = self._schedule(minutes=120)
+        account = self.personal_account(self.sender)
+
+        rows = self._scheduled_rows(account)
+        row = next((r for r in rows if r["id"] == scheduled.submission_id), None)
+
+        self.assertIsNotNone(row, "The held submission is missing from the Scheduled listing.")
+        self.assertEqual(row["email_id"], scheduled.id)
+        self.assertEqual(row["subject"], scheduled.subject)
+        self.assertFalse(row["email_deleted"])
+        self.assertIn(self.recipient.email, [r["email"] for r in row["recipients"]])
+        self.assertTrue(row["send_at"])
+
+        # Soonest first.
+        send_ats = [r["send_at"] for r in rows]
+        self.assertEqual(send_ats, sorted(send_ats))
+
+    def test_delivered_submission_drops_out_of_listing(self):
+        # Held only briefly: once the hold elapses the submission goes final and the
+        # listing — driven by EmailSubmission/query on undoStatus — must drop it.
+        subject = f"Delivered {unique_name('subject')}"
+        result = self.send_mail(
+            self.sender,
+            self.recipient.email,
+            subject=subject,
+            send_at=to_utc_z(add_to_date(now(), seconds=15)),
+        )
+        self.assertEqual(result["status"], "Submitted", result.get("error"))
+
+        account = self.personal_account(self.sender)
+        self.wait_until(
+            lambda: (self._get_submission(account, result["submission_id"]) or {}).get("undoStatus")
+            == "final",
+            timeout=90,
+            message="The held submission never went final.",
+        )
+
+        rows = self._scheduled_rows(account)
+        self.assertNotIn(result["submission_id"], [row["id"] for row in rows])
+
     def test_cancel_reverts_to_draft(self):
         scheduled = self._schedule(minutes=120)
         account = self.personal_account(self.sender)
-        old_submission_id = scheduled.doc.submission_id
 
-        from suite.mail.api.mail import cancel_scheduled_mail
         from suite.mail.doctype.mail_message.mail_message import _cache_messages, _get_cached_messages
 
         # Seed the data store with the (soon stale, Sent-labelled) cached copy; cancel
         # must evict it or Drafts keeps showing the old folder label until the next sync.
-        _cache_messages(account, {scheduled.doc.id: {"id": scheduled.doc.id}})
+        _cache_messages(account, {scheduled.id: {"id": scheduled.id}})
 
         with self.set_user(self.sender.email):
-            result = cancel_scheduled_mail(account, scheduled.name)
-        self.assertEqual(result["status"], "Cancelled")
-        self.assertIsNone(_get_cached_messages(account, [scheduled.doc.id])[scheduled.doc.id])
+            result = cancel_scheduled_mail(account, scheduled.submission_id)
+        self.assertEqual(result["id"], scheduled.id)
+        self.assertIsNone(_get_cached_messages(account, [scheduled.id])[scheduled.id])
 
+        submission = self._get_submission(account, scheduled.submission_id)
+        self.assertEqual(submission["undoStatus"], "canceled")
+
+        # The queue log mirrors the cancellation via cancelled_at; the row stays Submitted.
         with self.set_user("Administrator"):
             doc = frappe.get_doc("Mail Queue", scheduled.name)
-        self.assertEqual(doc.status, "Cancelled")
+        self.assertEqual(doc.status, "Submitted")
         self.assertTrue(doc.cancelled_at)
-
-        submission = self._get_submission(account, old_submission_id)
-        self.assertEqual(submission["undoStatus"], "canceled")
 
         # Back in Drafts only (mailboxIds replaced, not patched) with $draft restored.
         with self.set_user(self.sender.email):
             from suite.mail.jmap import get_mailbox_id_by_role
 
             drafts_id = get_mailbox_id_by_role(account, "drafts", raise_exception=True)
-            emails = get_email_service(account).get([doc.id], properties=["mailboxIds", "keywords"])
+            emails = get_email_service(account).get([scheduled.id], properties=["mailboxIds", "keywords"])
 
         self.assertEqual(list(emails[0]["mailboxIds"].keys()), [drafts_id])
         self.assertTrue(emails[0]["keywords"].get("$draft"))
-        self.assertEqual(doc.mailbox_id, drafts_id)
 
     def test_cancel_refreshes_open_mailbox_views(self):
         # The composer that raises the undo toast is unmounted by the time Undo runs, so
         # the refresh rides the same realtime event the message actions use.
         from unittest.mock import patch
 
-        from suite.mail.api.mail import cancel_scheduled_mail
         from suite.mail.jmap import get_mailbox_id_by_role
 
         scheduled = self._schedule(minutes=120)
@@ -146,7 +200,7 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
             sent_id = get_mailbox_id_by_role(account, "sent", raise_exception=True)
 
             with patch("frappe.publish_realtime") as publish:
-                cancel_scheduled_mail(account, scheduled.name)
+                cancel_scheduled_mail(account, scheduled.submission_id)
 
         events = [c for c in publish.call_args_list if c.args and c.args[0] == "new_mail_created"]
         self.assertTrue(events, "cancel did not publish a mailbox refresh")
@@ -158,41 +212,37 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
     def test_reschedule_creates_new_submission(self):
         scheduled = self._schedule(minutes=120)
         account = self.personal_account(self.sender)
-        old_submission_id = scheduled.doc.submission_id
         new_send_at = to_utc_z(add_to_date(now(), minutes=240))
 
-        from suite.mail.api.mail import reschedule_mail
-
         with self.set_user(self.sender.email):
-            result = reschedule_mail(account, scheduled.name, new_send_at)
-        self.assertEqual(result["status"], "Scheduled")
+            result = reschedule_mail(account, scheduled.submission_id, new_send_at)
+        self.assertTrue(result["id"])
+        self.assertNotEqual(result["id"], scheduled.submission_id)
 
-        with self.set_user("Administrator"):
-            doc = frappe.get_doc("Mail Queue", scheduled.name)
-        self.assertEqual(doc.status, "Scheduled")
-        self.assertNotEqual(doc.submission_id, old_submission_id)
-
-        old_submission = self._get_submission(account, old_submission_id)
+        old_submission = self._get_submission(account, scheduled.submission_id)
         self.assertEqual(old_submission["undoStatus"], "canceled")
 
-        new_submission = self._get_submission(account, doc.submission_id)
+        new_submission = self._get_submission(account, result["id"])
         self.assertEqual(new_submission["undoStatus"], "pending")
         self.assertLessEqual(abs(_epoch(new_submission["sendAt"]) - _epoch(new_send_at)), 5)
+
+        # The queue log follows the replacement submission.
+        with self.set_user("Administrator"):
+            doc = frappe.get_doc("Mail Queue", scheduled.name)
+        self.assertEqual(doc.submission_id, result["id"])
+        self.assertLessEqual(abs(_epoch(to_utc_z(doc.send_at)) - _epoch(new_send_at)), 5)
 
     def test_send_now_delivers(self):
         scheduled = self._schedule(minutes=60 * 24)
         account = self.personal_account(self.sender)
 
-        from suite.mail.api.mail import send_scheduled_mail_now
-
         with self.set_user(self.sender.email):
-            result = send_scheduled_mail_now(account, scheduled.name)
-        self.assertEqual(result["status"], "Submitted")
+            result = send_scheduled_mail_now(account, scheduled.submission_id)
+        self.assertTrue(result["id"])
 
         with self.set_user("Administrator"):
             doc = frappe.get_doc("Mail Queue", scheduled.name)
-        self.assertEqual(doc.status, "Submitted")
-        self.assertTrue(doc.submitted_at)
+        self.assertEqual(doc.submission_id, result["id"])
         self.assertFalse(doc.send_at)
 
         def find_thread():
@@ -205,6 +255,43 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
             message=f"Send-now mail '{scheduled.subject}' did not reach {self.recipient.email}.",
         )
 
+    def test_dangling_email_is_cancel_only(self):
+        # The Email may be deleted after scheduling; the submission then carries a dangling
+        # emailId. The listing must still show the row (recipients off the envelope), the
+        # resubmitting actions must refuse it, and cancel must work without a move.
+        scheduled = self._schedule(minutes=120)
+        account = self.personal_account(self.sender)
+
+        with self.set_user(self.sender.email):
+            get_email_service(account).delete([scheduled.id])
+
+        rows = self._scheduled_rows(account)
+        row = next((r for r in rows if r["id"] == scheduled.submission_id), None)
+        self.assertIsNotNone(row, "A dangling submission is missing from the Scheduled listing.")
+        self.assertTrue(row["email_deleted"])
+        self.assertIn(self.recipient.email, [r["email"] for r in row["recipients"]])
+
+        with self.set_user(self.sender.email):
+            for action in (
+                lambda: send_scheduled_mail_now(account, scheduled.submission_id),
+                lambda: reschedule_mail(
+                    account, scheduled.submission_id, to_utc_z(add_to_date(now(), minutes=240))
+                ),
+            ):
+                with self.assertRaises(frappe.ValidationError):
+                    action()
+
+            # Refusing to resubmit must leave the hold untouched.
+            self.assertEqual(
+                self._get_submission(account, scheduled.submission_id)["undoStatus"], "pending"
+            )
+
+            result = cancel_scheduled_mail(account, scheduled.submission_id)
+
+        self.assertIsNone(result["id"])  # nothing left to move to Drafts
+        submission = self._get_submission(account, scheduled.submission_id)
+        self.assertEqual(submission["undoStatus"], "canceled")
+
     def test_validation_errors(self):
         for kwargs in [
             {"send_at": to_utc_z(add_to_date(now(), minutes=-5))},  # in the past
@@ -213,6 +300,17 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
         ]:
             with self.assertRaises(frappe.ValidationError):
                 self.send_mail(self.sender, self.recipient.email, **kwargs)
+
+        # The same window applies to a reschedule.
+        scheduled = self._schedule(minutes=120)
+        account = self.personal_account(self.sender)
+        with self.set_user(self.sender.email):
+            for send_at in (
+                to_utc_z(add_to_date(now(), minutes=-5)),
+                to_utc_z(add_to_date(now(), days=31)),
+            ):
+                with self.assertRaises(frappe.ValidationError):
+                    reschedule_mail(account, scheduled.submission_id, send_at)
 
         # destroy_after_submit is not exposed by create_mail; exercise the queue factory.
         from suite.mail.doctype.mail_queue.mail_queue import MailQueue
@@ -229,180 +327,47 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
                 send_at=get_datetime_str(add_to_date(now(), minutes=60)),
             )
 
-    def test_lazy_reconciliation(self):
-        # Held only briefly: once the hold elapses the submission goes final and the
-        # listing must flip the row to Submitted and drop it.
-        subject = f"Reconcile {unique_name('subject')}"
-        result = self.send_mail(
-            self.sender,
-            self.recipient.email,
-            subject=subject,
-            send_at=to_utc_z(add_to_date(now(), seconds=15)),
-        )
-        self.assertEqual(result["status"], "Scheduled", result.get("error"))
-
-        account = self.personal_account(self.sender)
-        with self.set_user("Administrator"):
-            doc = frappe.get_last_doc("Mail Queue", {"id": result["id"]})
-
-        self.wait_until(
-            lambda: (self._get_submission(account, doc.submission_id) or {}).get("undoStatus") == "final",
-            timeout=90,
-            message="The held submission never went final.",
-        )
-
-        from suite.mail.api.mail import get_scheduled_mails
-
-        with self.set_user(self.sender.email):
-            rows = get_scheduled_mails(account)
-        self.assertNotIn(doc.name, [row.name for row in rows])
-
-        with self.set_user("Administrator"):
-            doc = frappe.get_doc("Mail Queue", doc.name)
-        self.assertEqual(doc.status, "Submitted")
-        self.assertTrue(doc.submitted_at)
-
-    def test_cron_ignores_scheduled_rows(self):
-        scheduled = self._schedule(minutes=120)
-
-        from suite.mail.doctype.mail_queue.mail_queue import enqueue_process_pending_emails
-
-        with self.set_user("Administrator"):
-            enqueue_process_pending_emails(batch_size=10, max_batch_size=10)
-            doc = frappe.get_doc("Mail Queue", scheduled.name)
-
-        self.assertEqual(doc.status, "Scheduled")
-        self.assertEqual(doc.submission_id, scheduled.doc.submission_id)
-
     def test_undo_send_holds_and_cancels(self):
         # The composer's default Send: the server computes a short hold so the sender
         # can cancel from the undo toast; Undo is just cancel_scheduled_mail.
-        from suite.mail.api.mail import UNDO_SEND_HOLD_SECONDS, cancel_scheduled_mail
+        from suite.mail.api.mail import UNDO_SEND_HOLD_SECONDS
 
         result = self.send_mail(self.sender, self.recipient.email, undo_send=True)
-        self.assertEqual(result["status"], "Scheduled", result.get("error"))
-        self.assertTrue(result["name"])
+        self.assertEqual(result["status"], "Submitted", result.get("error"))
+        self.assertTrue(result["submission_id"])
+        self.assertTrue(result["send_at"])
 
-        with self.set_user("Administrator"):
-            doc = frappe.get_doc("Mail Queue", result["name"])
-        self.assertTrue(doc.submission_id)
-
-        hold = time_diff_in_seconds(doc.send_at, now())
+        hold = time_diff_in_seconds(frappe.db.get_value("Mail Queue", result["name"], "send_at"), now())
         self.assertGreater(hold, 0)
         self.assertLessEqual(hold, UNDO_SEND_HOLD_SECONDS + 5)
 
         account = self.personal_account(self.sender)
         with self.set_user(self.sender.email):
-            cancelled = cancel_scheduled_mail(account, result["name"])
-        self.assertEqual(cancelled["status"], "Cancelled")
+            cancelled = cancel_scheduled_mail(account, result["submission_id"])
+        self.assertEqual(cancelled["id"], result["id"])
 
-        submission = self._get_submission(account, doc.submission_id)
+        submission = self._get_submission(account, result["submission_id"])
         self.assertEqual(submission["undoStatus"], "canceled")
 
     def test_stale_action_cannot_resurrect_a_cancelled_schedule(self):
-        # Overlapping actions used to both pass validation on the same state: the loser
-        # saw the winner's cancellation as "already canceled", fell through, and created
-        # a live submission for a message that had just been moved back to Drafts.
-        from suite.mail.api.mail import cancel_scheduled_mail
-
+        # Reschedule/send-now on a submission that was cancelled in the meantime must not
+        # create a live replacement for a message already moved back to Drafts.
         account = self.personal_account(self.sender)
 
         for action in (
-            lambda doc: doc.send_now(),
-            lambda doc: doc.reschedule(get_datetime_str(add_to_date(now(), minutes=240))),
+            lambda submission_id: send_scheduled_mail_now(account, submission_id),
+            lambda submission_id: reschedule_mail(
+                account, submission_id, to_utc_z(add_to_date(now(), minutes=240))
+            ),
         ):
             scheduled = self._schedule(minutes=120)
 
             with self.set_user(self.sender.email):
-                # Loaded while still Scheduled, i.e. before the cancellation below.
-                stale = frappe.get_doc("Mail Queue", scheduled.name)
-                cancel_scheduled_mail(account, scheduled.name)
+                cancel_scheduled_mail(account, scheduled.submission_id)
 
                 with self.assertRaises(frappe.ValidationError):
-                    action(stale)
+                    action(scheduled.submission_id)
 
-            with self.set_user("Administrator"):
-                doc = frappe.get_doc("Mail Queue", scheduled.name)
-
-            self.assertEqual(doc.status, "Cancelled")
-            self.assertEqual(doc.submission_id, scheduled.doc.submission_id)
-            self.assertEqual(self._get_submission(account, doc.submission_id)["undoStatus"], "canceled")
-
-    def test_reconciliation_sweep(self):
-        # The 5-minute cron flips rows whose hold elapsed: delivered submissions to
-        # Submitted, out-of-band cancellations to Cancelled.
-        from suite.mail.doctype.mail_queue.mail_queue import reconcile_scheduled_emails
-
-        account = self.personal_account(self.sender)
-
-        delivered = self.send_mail(
-            self.sender,
-            self.recipient.email,
-            subject=f"Sweep {unique_name('subject')}",
-            send_at=to_utc_z(add_to_date(now(), seconds=15)),
-        )
-        self.assertEqual(delivered["status"], "Scheduled", delivered.get("error"))
-
-        out_of_band = self._schedule(minutes=120)
-        with self.set_user(self.sender.email):
-            get_email_submission_service(account).cancel(out_of_band.doc.submission_id)
-
-        with self.set_user("Administrator"):
-            delivered_doc = frappe.get_doc("Mail Queue", delivered["name"])
-
-        self.wait_until(
-            lambda: (self._get_submission(account, delivered_doc.submission_id) or {}).get("undoStatus")
-            == "final",
-            timeout=90,
-            message="The held submission never went final.",
-        )
-
-        with self.set_user("Administrator"):
-            # Age both rows past the sweep's buffer.
-            for name in (delivered["name"], out_of_band.name):
-                frappe.db.set_value(
-                    "Mail Queue", name, "send_at", add_to_date(now(), minutes=-2), update_modified=False
-                )
-            reconcile_scheduled_emails()
-
-            self.assertEqual(frappe.db.get_value("Mail Queue", delivered["name"], "status"), "Submitted")
-            self.assertTrue(frappe.db.get_value("Mail Queue", delivered["name"], "submitted_at"))
-            self.assertEqual(frappe.db.get_value("Mail Queue", out_of_band.name, "status"), "Cancelled")
-            self.assertTrue(frappe.db.get_value("Mail Queue", out_of_band.name, "cancelled_at"))
-
-    def test_reconciliation_writes_are_batched(self):
-        # Reconciliation runs on the Scheduled page's read path, so its write count must
-        # stay flat as rows finalize rather than growing one UPDATE per row.
-        from suite.mail.doctype.mail_queue.mail_queue import apply_reconciled_submissions
-
-        rows = [self._schedule(minutes=120) for _ in range(3)]
-        submitted = [rows[0].name, rows[1].name]
-        cancelled = [rows[2].name]
-
-        with self.set_user("Administrator"):
-            with self.assertQueryCount(2):  # one per terminal state, not per row
-                apply_reconciled_submissions(submitted, cancelled)
-
-            for name in submitted:
-                self.assertEqual(frappe.db.get_value("Mail Queue", name, "status"), "Submitted")
-            self.assertEqual(frappe.db.get_value("Mail Queue", cancelled[0], "status"), "Cancelled")
-
-    def test_clear_old_logs_purges_stale_scheduled(self):
-        from suite.mail.doctype.mail_queue.mail_queue import MailQueue
-
-        stale = self._schedule(minutes=120)
-        fresh = self._schedule(minutes=120)
-
-        with self.set_user("Administrator"):
-            # A hold that elapsed days ago has long since delivered; the row is a log now.
-            frappe.db.set_value(
-                "Mail Queue",
-                stale.name,
-                "send_at",
-                add_to_date(now(), days=-4),
-                update_modified=False,
+            self.assertEqual(
+                self._get_submission(account, scheduled.submission_id)["undoStatus"], "canceled"
             )
-            MailQueue.clear_old_logs()
-
-        self.assertFalse(frappe.db.exists("Mail Queue", stale.name))
-        self.assertTrue(frappe.db.exists("Mail Queue", fresh.name))

--- a/suite/mail/tests/test_mail_scheduled_send.py
+++ b/suite/mail/tests/test_mail_scheduled_send.py
@@ -11,6 +11,13 @@ other clients appear too, and every action is keyed on the submission id. Resche
 send-now cancel the held submission and create a new one (undoStatus is the only mutable
 submission property); cancel reverts the message to Drafts. An Email deleted after scheduling
 leaves a dangling emailId — such a delivery can only be cancelled.
+
+Delivery state is computed from the submission's deliveryStatus (delivered, displayed,
+smtpReply), refined by the MTA queue (correlated via the envelope's ENVID): the listing and
+the details endpoint report a status (scheduled, queued, retrying, failed, delivered,
+displayed, sent) plus retry counts. A real delivery failure can't be
+provoked reliably against the test server, so the failure sieve is covered at the helper level
+and retry/dismiss against delivered (final) submissions.
 """
 
 from datetime import datetime
@@ -20,8 +27,12 @@ from frappe.utils import add_to_date, get_datetime, get_datetime_str, now, time_
 
 from suite.mail.api.scheduled import (
     cancel_scheduled_mail,
+    dismiss_failed_mail,
+    get_scheduled_mail,
     get_scheduled_mails,
     reschedule_mail,
+    retry_delivery_now,
+    retry_failed_mail,
     send_scheduled_mail_now,
 )
 from suite.mail.jmap import get_email_service, get_email_submission_service
@@ -76,6 +87,10 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
         with self.set_user(self.sender.email):
             return get_scheduled_mails(account)
 
+    def _get_details(self, account: str, submission_id: str) -> dict:
+        with self.set_user(self.sender.email):
+            return get_scheduled_mail(account, submission_id)
+
     # --- tests --------------------------------------------------------------
 
     def test_schedule_holds_delivery(self):
@@ -124,13 +139,22 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
         self.assertIn(self.recipient.email, [r["email"] for r in row["recipients"]])
         self.assertTrue(row["send_at"])
 
+        # The merged delivery state: a held submission is "scheduled", with no attempts yet
+        # (retries comes off the MTA queue message, correlated via ENVID) and no errors.
+        self.assertEqual(row["status"], "scheduled")
+        self.assertFalse(row["retries"])
+        self.assertEqual(row["delivery_errors"], [])
+        recipient_states = {r["email"]: r["status"] for r in row["recipients_status"]}
+        self.assertEqual(recipient_states.get(self.recipient.email), "scheduled")
+
         # Soonest first.
         send_ats = [r["send_at"] for r in rows]
         self.assertEqual(send_ats, sorted(send_ats))
 
     def test_delivered_submission_drops_out_of_listing(self):
-        # Held only briefly: once the hold elapses the submission goes final and the
-        # listing — driven by EmailSubmission/query on undoStatus — must drop it.
+        # Held only briefly: once the hold elapses and the delivery concludes, the listing
+        # must drop the row. Between release and conclusion the row may legitimately linger
+        # as "queued", so the check waits on the listing itself.
         subject = f"Delivered {unique_name('subject')}"
         result = self.send_mail(
             self.sender,
@@ -142,14 +166,14 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
 
         account = self.personal_account(self.sender)
         self.wait_until(
-            lambda: (self._get_submission(account, result["submission_id"]) or {}).get("undoStatus")
-            == "final",
+            lambda: result["submission_id"] not in [row["id"] for row in self._scheduled_rows(account)],
             timeout=90,
-            message="The held submission never went final.",
+            message="The delivered submission never left the Scheduled listing.",
         )
 
-        rows = self._scheduled_rows(account)
-        self.assertNotIn(result["submission_id"], [row["id"] for row in rows])
+        details = self._get_details(account, result["submission_id"])
+        self.assertIn(details["status"], ("delivered", "sent"))
+        self.assertEqual(details["undo_status"], "final")
 
     def test_cancel_reverts_to_draft(self):
         scheduled = self._schedule(minutes=120)
@@ -348,6 +372,123 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
 
         submission = self._get_submission(account, result["submission_id"])
         self.assertEqual(submission["undoStatus"], "canceled")
+
+    def test_submission_details(self):
+        scheduled = self._schedule(minutes=120)
+        account = self.personal_account(self.sender)
+
+        details = self._get_details(account, scheduled.submission_id)
+
+        self.assertEqual(details["id"], scheduled.submission_id)
+        self.assertEqual(details["subject"], scheduled.subject)
+        self.assertEqual(details["status"], "scheduled")
+        self.assertEqual(details["undo_status"], "pending")
+        self.assertFalse(details["email_deleted"])
+
+        # The envelope this app submitted with, echoed back by the server.
+        self.assertEqual(details["envelope_from"], self.sender.email)
+        self.assertIn(self.recipient.email, details["envelope_recipients"])
+        self.assertIsInstance(details["priority"], int)
+        self.assertEqual(details["identity_email"], self.sender.email)
+
+        recipient_states = {r["email"]: r for r in details["recipients_status"]}
+        state = recipient_states[self.recipient.email]
+        self.assertEqual(state["status"], "scheduled")
+        # The raw DeliveryStatus rides along for the details page.
+        for key in ("smtp_reply", "delivered", "displayed"):
+            self.assertIn(key, state)
+
+        self.assertEqual(details["dsn_count"], 0)
+        self.assertEqual(details["mdn_count"], 0)
+
+    def test_status_sifting_helpers(self):
+        # The listing keeps a finalized submission only when it was held and troubled;
+        # these helpers are that sieve.
+        from suite.mail.api.scheduled import _hold_active, _recipient_status, _was_held
+
+        held = {"envelope": {"mailFrom": {"email": "a@x.test", "parameters": {"HOLDUNTIL": "..."}}}}
+        self.assertTrue(_was_held(held))
+        self.assertFalse(_was_held({"envelope": None}))
+        self.assertFalse(
+            _was_held({"envelope": {"mailFrom": {"email": "a@x.test", "parameters": {"ENVID": "e"}}}})
+        )
+
+        # A hold is active only while pending AND before sendAt: Stalwart keeps a released
+        # message pending for as long as it can still be cancelled from the queue.
+        future = to_utc_z(add_to_date(now(), minutes=60))
+        past = to_utc_z(add_to_date(now(), minutes=-60))
+        self.assertTrue(_hold_active({"undoStatus": "pending", "sendAt": future}))
+        self.assertFalse(_hold_active({"undoStatus": "pending", "sendAt": past}))
+        self.assertFalse(_hold_active({"undoStatus": "final", "sendAt": future}))
+        self.assertFalse(_hold_active({"undoStatus": "pending"}))
+
+        # (hold active, DeliveryStatus, queue status, retries) → status. DeliveryStatus drives
+        # the state; the queue tells a first attempt apart from one awaiting a retry.
+        for expected, args in [
+            ("scheduled", (True, {}, None, 0)),
+            ("displayed", (False, {"delivered": "yes", "displayed": "yes"}, None, 0)),
+            ("failed", (False, {"delivered": "no", "smtpReply": "550 5.1.1"}, None, 0)),
+            ("delivered", (False, {"delivered": "yes", "displayed": "unknown"}, None, 0)),
+            ("retrying", (False, {"delivered": "queued"}, "TemporaryFailure", 0)),
+            ("retrying", (False, {"delivered": "queued"}, "Scheduled", 1)),
+            ("queued", (False, {"delivered": "queued"}, None, 0)),
+            ("queued", (False, {"delivered": "queued"}, "Scheduled", 0)),
+            ("queued", (False, {}, "Scheduled", 0)),
+            ("sent", (False, {"delivered": "unknown"}, None, 0)),
+            ("sent", (False, {}, None, 0)),
+        ]:
+            self.assertEqual(_recipient_status(*args), expected, args)
+
+    def test_retry_and_dismiss_finalized_submissions(self):
+        account = self.personal_account(self.sender)
+
+        # All three refuse a submission whose delivery is still pending.
+        pending = self._schedule(minutes=120)
+        with self.set_user(self.sender.email):
+            for action in (retry_failed_mail, retry_delivery_now, dismiss_failed_mail):
+                with self.assertRaises(frappe.ValidationError):
+                    action(account, pending.submission_id)
+
+        subject = f"Retry {unique_name('subject')}"
+        result = self.send_mail(
+            self.sender,
+            self.recipient.email,
+            subject=subject,
+            send_at=to_utc_z(add_to_date(now(), seconds=15)),
+        )
+        self.assertEqual(result["status"], "Submitted", result.get("error"))
+        self.wait_until(
+            lambda: (self._get_submission(account, result["submission_id"]) or {}).get("undoStatus")
+            == "final",
+            timeout=90,
+            message="The held submission never went final.",
+        )
+
+        # A concluded delivery has left the MTA queue — nothing there to poke.
+        self.wait_until(
+            lambda: self._get_details(account, result["submission_id"])["status"] in ("delivered", "sent"),
+            timeout=90,
+            message="The released delivery never concluded.",
+        )
+        with self.set_user(self.sender.email):
+            with self.assertRaises(frappe.ValidationError):
+                retry_delivery_now(account, result["submission_id"])
+
+        # Retry replaces the finalized record with a fresh immediate submission.
+        with self.set_user(self.sender.email):
+            retried = retry_failed_mail(account, result["submission_id"])
+        self.assertTrue(retried["id"])
+        self.assertIsNone(self._get_submission(account, result["submission_id"]))
+
+        # Dismiss destroys the record outright.
+        self.wait_until(
+            lambda: (self._get_submission(account, retried["id"]) or {}).get("undoStatus") == "final",
+            timeout=90,
+            message="The retried submission never went final.",
+        )
+        with self.set_user(self.sender.email):
+            dismiss_failed_mail(account, retried["id"])
+        self.assertIsNone(self._get_submission(account, retried["id"]))
 
     def test_stale_action_cannot_resurrect_a_cancelled_schedule(self):
         # Reschedule/send-now on a submission that was cancelled in the meantime must not

--- a/suite/mail/tests/test_mail_scheduled_send.py
+++ b/suite/mail/tests/test_mail_scheduled_send.py
@@ -666,3 +666,25 @@ class TestSubmissionQueryTotal(IntegrationTestCase):
 
         ids, total = self._query_page({"ids": ["a", "b", "c"], "total": 7})
         self.assertEqual((ids, total), (["a", "b"], 7))
+
+    def test_clamped_lookahead_keeps_the_pager_advancing(self):
+        # The server clamps the requested limit+1 to the page length, swallowing the
+        # look-ahead (it echoes the limit it used, RFC 8620 §5.5): a page filled to the
+        # clamp is indistinguishable from "more exist", so the floor sits one past it.
+        ids, total = self._query_page({"ids": ["a", "b"], "limit": 2}, position=2)
+        self.assertEqual(ids, ["a", "b"])
+        self.assertEqual(total, 5)
+
+        # A clamp below the page length: the short page filled the clamp, so it is not
+        # the last page either.
+        ids, total = self._query_page({"ids": ["a"], "limit": 1}, position=2)
+        self.assertEqual(ids, ["a"])
+        self.assertEqual(total, 4)
+
+        # A short page under an unclamped (or above-page) limit really is the end.
+        ids, total = self._query_page({"ids": ["a"]}, position=2)
+        self.assertEqual((ids, total), (["a"], 3))
+
+        # The clamp never overrides a total the server did provide.
+        ids, total = self._query_page({"ids": ["a", "b"], "limit": 2, "total": 4}, position=2)
+        self.assertEqual((ids, total), (["a", "b"], 4))

--- a/suite/mail/tests/test_mail_scheduled_send.py
+++ b/suite/mail/tests/test_mail_scheduled_send.py
@@ -5,9 +5,10 @@
 
 Scheduling submits immediately with a HOLDUNTIL envelope parameter, so the server holds
 delivery; the Mail Queue row is only a log (status ``Submitted``, ``send_at`` recording the
-hold). The server's EmailSubmission objects are the source of truth: the Scheduled page lists
-them via ``EmailSubmission/query`` (``undoStatus: "pending"``), so submissions created by
-other clients appear too, and every action is keyed on the submission id. Reschedule and
+hold). The server's EmailSubmission objects are the source of truth: the Outbox browses all
+of them via ``EmailSubmission/query`` with the RFC 8621 §7.3 filters (undoStatus, identity,
+email, thread, sendAt window), newest sends first, so submissions created by other clients
+appear too, and every action is keyed on the submission id. Reschedule and
 send-now cancel the held submission and create a new one (undoStatus is the only mutable
 submission property); cancel reverts the message to Drafts. An Email deleted after scheduling
 leaves a dangling emailId — such a delivery can only be cancelled.
@@ -29,7 +30,7 @@ from suite.mail.api.scheduled import (
     cancel_scheduled_mail,
     dismiss_failed_mail,
     get_scheduled_mail,
-    get_scheduled_mails,
+    get_submissions,
     reschedule_mail,
     retry_delivery_now,
     retry_failed_mail,
@@ -83,9 +84,9 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
             submissions = get_email_submission_service(account).get([submission_id])
         return submissions[0] if submissions else None
 
-    def _scheduled_rows(self, account: str) -> list[dict]:
+    def _outbox_rows(self, account: str, **filters) -> list[dict]:
         with self.set_user(self.sender.email):
-            return get_scheduled_mails(account)
+            return get_submissions(account, **filters)
 
     def _get_details(self, account: str, submission_id: str) -> dict:
         with self.set_user(self.sender.email):
@@ -129,10 +130,10 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
         scheduled = self._schedule(minutes=120)
         account = self.personal_account(self.sender)
 
-        rows = self._scheduled_rows(account)
+        rows = self._outbox_rows(account)
         row = next((r for r in rows if r["id"] == scheduled.submission_id), None)
 
-        self.assertIsNotNone(row, "The held submission is missing from the Scheduled listing.")
+        self.assertIsNotNone(row, "The held submission is missing from the Outbox listing.")
         self.assertEqual(row["email_id"], scheduled.id)
         self.assertEqual(row["subject"], scheduled.subject)
         self.assertFalse(row["email_deleted"])
@@ -147,14 +148,15 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
         recipient_states = {r["email"]: r["status"] for r in row["recipients_status"]}
         self.assertEqual(recipient_states.get(self.recipient.email), "scheduled")
 
-        # Soonest first.
+        # Newest sends first (sentAt desc).
         send_ats = [r["send_at"] for r in rows]
-        self.assertEqual(send_ats, sorted(send_ats))
+        self.assertEqual(send_ats, sorted(send_ats, reverse=True))
 
-    def test_delivered_submission_drops_out_of_listing(self):
-        # Held only briefly: once the hold elapses and the delivery concludes, the listing
-        # must drop the row. Between release and conclusion the row may legitimately linger
-        # as "queued", so the check waits on the listing itself.
+    def test_delivered_submission_goes_final_in_listing(self):
+        # Held only briefly: once the hold elapses and the delivery concludes, the row leaves
+        # the pending filter but stays browsable — the Outbox is a log of every submission,
+        # narrowed only by the filters. Between release and conclusion the submission may
+        # legitimately linger as pending, so the check waits on the filtered listing itself.
         subject = f"Delivered {unique_name('subject')}"
         result = self.send_mail(
             self.sender,
@@ -166,14 +168,65 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
 
         account = self.personal_account(self.sender)
         self.wait_until(
-            lambda: result["submission_id"] not in [row["id"] for row in self._scheduled_rows(account)],
+            lambda: result["submission_id"]
+            not in [row["id"] for row in self._outbox_rows(account, undo_status="pending")],
             timeout=90,
-            message="The delivered submission never left the Scheduled listing.",
+            message="The delivered submission never left the pending filter.",
         )
+
+        row = next((r for r in self._outbox_rows(account) if r["id"] == result["submission_id"]), None)
+        self.assertIsNotNone(row, "The delivered submission is missing from the Outbox listing.")
+        self.assertEqual(row["undo_status"], "final")
 
         details = self._get_details(account, result["submission_id"])
         self.assertIn(details["status"], ("delivered", "sent"))
         self.assertEqual(details["undo_status"], "final")
+
+    def test_listing_filters(self):
+        scheduled = self._schedule(minutes=120)
+        account = self.personal_account(self.sender)
+
+        row = next(r for r in self._outbox_rows(account) if r["id"] == scheduled.submission_id)
+
+        # Each RFC 8621 §7.3 filter matches the held submission...
+        for filters in [
+            {"undo_status": "pending"},
+            {"email_id": row["email_id"]},
+            {"thread_id": row["thread_id"]},
+            {
+                "after": to_utc_z(add_to_date(now(), minutes=60)),
+                "before": to_utc_z(add_to_date(now(), minutes=180)),
+            },
+        ]:
+            ids = [r["id"] for r in self._outbox_rows(account, **filters)]
+            self.assertIn(scheduled.submission_id, ids, filters)
+
+        # ...and excludes it when it doesn't.
+        for filters in [
+            {"undo_status": "canceled"},
+            {"before": to_utc_z(add_to_date(now(), minutes=30))},
+            {"after": to_utc_z(add_to_date(now(), minutes=180))},
+        ]:
+            ids = [r["id"] for r in self._outbox_rows(account, **filters)]
+            self.assertNotIn(scheduled.submission_id, ids, filters)
+
+        # The identity filter keys on the JMAP Identity id.
+        with self.set_user(self.sender.email):
+            identities = get_email_submission_service(account).identities
+        identity_id = next(i["id"] for i in identities if i["email"] == self.sender.email)
+        ids = [r["id"] for r in self._outbox_rows(account, identity_id=identity_id)]
+        self.assertIn(scheduled.submission_id, ids)
+
+        # A cancelled submission stays browsable, under its own undoStatus.
+        with self.set_user(self.sender.email):
+            cancel_scheduled_mail(account, scheduled.submission_id)
+        canceled_ids = [r["id"] for r in self._outbox_rows(account, undo_status="canceled")]
+        self.assertIn(scheduled.submission_id, canceled_ids)
+        pending_ids = [r["id"] for r in self._outbox_rows(account, undo_status="pending")]
+        self.assertNotIn(scheduled.submission_id, pending_ids)
+
+        with self.set_user(self.sender.email), self.assertRaises(frappe.ValidationError):
+            get_submissions(account, undo_status="bogus")
 
     def test_cancel_reverts_to_draft(self):
         scheduled = self._schedule(minutes=120)
@@ -289,9 +342,9 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
         with self.set_user(self.sender.email):
             get_email_service(account).delete([scheduled.id])
 
-        rows = self._scheduled_rows(account)
+        rows = self._outbox_rows(account)
         row = next((r for r in rows if r["id"] == scheduled.submission_id), None)
-        self.assertIsNotNone(row, "A dangling submission is missing from the Scheduled listing.")
+        self.assertIsNotNone(row, "A dangling submission is missing from the Outbox listing.")
         self.assertTrue(row["email_deleted"])
         self.assertIn(self.recipient.email, [r["email"] for r in row["recipients"]])
 
@@ -401,17 +454,9 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
         self.assertEqual(details["dsn_count"], 0)
         self.assertEqual(details["mdn_count"], 0)
 
-    def test_status_sifting_helpers(self):
-        # The listing keeps a finalized submission only when it was held and troubled;
-        # these helpers are that sieve.
-        from suite.mail.api.scheduled import _hold_active, _recipient_status, _was_held
-
-        held = {"envelope": {"mailFrom": {"email": "a@x.test", "parameters": {"HOLDUNTIL": "..."}}}}
-        self.assertTrue(_was_held(held))
-        self.assertFalse(_was_held({"envelope": None}))
-        self.assertFalse(
-            _was_held({"envelope": {"mailFrom": {"email": "a@x.test", "parameters": {"ENVID": "e"}}}})
-        )
+    def test_status_helpers(self):
+        # The merged delivery state every row reports is computed by these helpers.
+        from suite.mail.api.scheduled import _hold_active, _recipient_status
 
         # A hold is active only while pending AND before sendAt: Stalwart keeps a released
         # message pending for as long as it can still be cancelled from the queue.

--- a/suite/mail/tests/test_mail_scheduled_send.py
+++ b/suite/mail/tests/test_mail_scheduled_send.py
@@ -86,7 +86,7 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
 
     def _outbox_rows(self, account: str, **filters) -> list[dict]:
         with self.set_user(self.sender.email):
-            return get_submissions(account, **filters)
+            return get_submissions(account, **filters)["rows"]
 
     def _get_details(self, account: str, submission_id: str) -> dict:
         with self.set_user(self.sender.email):
@@ -227,6 +227,28 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
 
         with self.set_user(self.sender.email), self.assertRaises(frappe.ValidationError):
             get_submissions(account, undo_status="bogus")
+
+    def test_listing_pagination(self):
+        # The server caps a single query at maxObjectsInGet, so the listing pages: every
+        # submission must stay reachable through page/page_length, without overlap.
+        account = self.personal_account(self.sender)
+        first = self._schedule(minutes=120)
+        second = self._schedule(minutes=180)
+
+        with self.set_user(self.sender.email):
+            result = get_submissions(account, undo_status="pending", page=1, page_length=1)
+        self.assertEqual(len(result["rows"]), 1)
+        self.assertGreaterEqual(result["total"], 2)
+
+        seen = []
+        for page in range(1, result["total"] + 1):
+            with self.set_user(self.sender.email):
+                rows = get_submissions(account, undo_status="pending", page=page, page_length=1)["rows"]
+            seen.extend(row["id"] for row in rows)
+
+        self.assertEqual(len(seen), len(set(seen)), "Pages overlap.")
+        for submission_id in (first.submission_id, second.submission_id):
+            self.assertIn(submission_id, seen)
 
     def test_cancel_reverts_to_draft(self):
         scheduled = self._schedule(minutes=120)

--- a/suite/mail/tests/test_mail_scheduled_send.py
+++ b/suite/mail/tests/test_mail_scheduled_send.py
@@ -359,9 +359,7 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
                     action()
 
             # Refusing to resubmit must leave the hold untouched.
-            self.assertEqual(
-                self._get_submission(account, scheduled.submission_id)["undoStatus"], "pending"
-            )
+            self.assertEqual(self._get_submission(account, scheduled.submission_id)["undoStatus"], "pending")
 
             result = cancel_scheduled_mail(account, scheduled.submission_id)
 
@@ -554,6 +552,4 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
                 with self.assertRaises(frappe.ValidationError):
                     action(scheduled.submission_id)
 
-            self.assertEqual(
-                self._get_submission(account, scheduled.submission_id)["undoStatus"], "canceled"
-            )
+            self.assertEqual(self._get_submission(account, scheduled.submission_id)["undoStatus"], "canceled")

--- a/suite/mail/tests/test_mail_scheduled_send.py
+++ b/suite/mail/tests/test_mail_scheduled_send.py
@@ -622,6 +622,21 @@ class TestOutboxRequestBoundary(IntegrationTestCase):
         with self.assertRaisesRegex(frappe.ValidationError, "undoStatus must be one of"):
             get_submissions("acc", undo_status="bogus")
 
+    def test_malformed_identifiers_are_rejected(self):
+        # RFC 8620 §1.2 confines a JMAP Id to 1 to 255 characters of [A-Za-z0-9_-]: any other
+        # string is refused before it can reach a JMAP operation.
+        for call in (
+            lambda: get_submissions("not an account id"),
+            lambda: get_submissions("acc", identity_id="id with spaces"),
+            lambda: get_submissions("acc", email_id="a/../b"),
+            lambda: get_submissions("acc", thread_id='T{"x":1}'),
+            lambda: get_scheduled_mail("acc", id="sub;drop"),
+            lambda: cancel_scheduled_mail("acc", id="x" * 256),
+            lambda: retry_failed_mail("acc", id="sub\nid"),
+        ):
+            with self.assertRaisesRegex(frappe.ValidationError, "not a valid JMAP identifier"):
+                call()
+
 
 class TestSubmissionQueryTotal(IntegrationTestCase):
     """The submission query, exercised against a fake (possibly clamping) server: the pager

--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -95,6 +95,7 @@ suite.mail.patches.reset_push_subscription_types_to_all
 suite.mail.patches.rename_skip_schedule_fetch_changes
 execute:frappe.db.set_single_value("Mail Settings", "expand_mailing_list_participants", 1)
 execute:frappe.db.set_single_value("Mail Settings", "max_mailing_list_participants", 100)
+suite.mail.patches.remove_held_queue_statuses
 # --- calendar ---
 # (no patches)
 # --- suite_core ---


### PR DESCRIPTION
Makes the server's JMAP EmailSubmission objects the source of truth for scheduled sends, replacing the Mail Queue as the listing's backing store, and rebuilds the page around them as the **Outbox**.

## What this does

- **EmailSubmission as source of truth**: the listing queries the server directly (`EmailSubmission/query`), so emails scheduled by other clients appear too; the Mail Queue rows remain only a log of what this app submitted. Every action (reschedule, send now, cancel, retry, remove) is keyed on the submission id; since `undoStatus` is a submission's only mutable property (RFC 8621 §7.5), reschedule and send-now cancel the held submission and create a replacement.
- **Generic Outbox browser**: the page (renamed from Scheduled) browses all submissions with the RFC 8621 §7.3 filters — `undoStatus` tabs (Pending / Final / Cancelled, defaulting to Pending), plus identity, email, thread, and a sendAt window behind a filter popover — sorted by `sentAt` desc. Rows badge the raw `undoStatus`.
- **Submission details page**: delivery card (undoStatus, send time, retries, priority, DSN/MDN counts), per-recipient state merged from `deliveryStatus` and the Stalwart management queue (correlated via ENVID: retry counts, next retry, live SMTP replies), and references (submission/email/thread ids, identity, envelope).
- **Delivery state per recipient**: computed from `deliveryStatus` (delivered/displayed/smtpReply), refined by the MTA queue while the message is still in flight; failed held releases stay listed until retried or removed.
- **Loading polish**: filter/tab changes and submission navigation wait on layout-matching skeletons instead of flashing empty states or placeholder titles.

## Tests

Integration tests cover the JMAP listing and filters, schedule/reschedule/send-now/cancel flows (including dangling emails deleted after scheduling and stale-action races), undo-send, and retry/remove of finalized submissions.

Closes #530