### PR TITLE
feat(slides): reduce interruptions for long projector presentations

### DIFF
--- a/frontend/src/apps/slides/SlidesShell.vue
+++ b/frontend/src/apps/slides/SlidesShell.vue
@@ -9,10 +9,11 @@
 </template>
 
 <script setup>
-import { h, onMounted, onUnmounted, provide, ref } from 'vue'
+import { h, onMounted, onUnmounted, provide, ref, watch } from 'vue'
 import { toast, FrappeUIProvider } from 'frappe-ui'
 import { Wifi, WifiOff } from 'lucide-vue-next'
 import { saveCurrentState } from '@/apps/slides/stores/saving'
+import { inSlideShowMode } from '@/apps/slides/stores/slideshow'
 import { setupTheme } from '@/utils/setupTheme'
 import '@/apps/slides/styles/fonts.css'
 
@@ -37,6 +38,7 @@ const preloadBundledFonts = () => {
 
 const handleOffline = () => {
   isOnline.value = false
+  if (inSlideShowMode.value) return
   toast('Lost internet connection.', {
     icon: () => h(WifiOff, { class: 'size-4' }),
   })
@@ -45,6 +47,7 @@ const handleOffline = () => {
 const handleOnline = () => {
   isOnline.value = true
   saveCurrentState()
+  if (inSlideShowMode.value) return
   toast('You are back online.', {
     icon: () => h(Wifi, { class: 'size-4' }),
   })
@@ -56,6 +59,10 @@ const registerServiceWorker = () => {
     console.warn('Slides Service Worker registration failed:', err)
   })
 }
+
+watch(inSlideShowMode, (presenting) => {
+  document.body.classList.toggle('slides-presenting', presenting)
+})
 
 onMounted(() => {
   isOnline.value = navigator?.onLine
@@ -70,6 +77,7 @@ onMounted(() => {
 onUnmounted(() => {
   window.removeEventListener('online', handleOnline)
   window.removeEventListener('offline', handleOffline)
+  document.body.classList.remove('slides-presenting')
   document.documentElement.style.overscrollBehavior = ''
 })
 
@@ -77,6 +85,10 @@ provide('isOnline', isOnline)
 </script>
 
 <style>
+body.slides-presenting [data-sonner-toaster] {
+  display: none;
+}
+
 .no-scrollbar {
   scrollbar-width: none;
   -ms-overflow-style: none;

--- a/frontend/src/apps/slides/pages/Slideshow.vue
+++ b/frontend/src/apps/slides/pages/Slideshow.vue
@@ -76,6 +76,8 @@ import {
 	showSlideshowEndScreen,
 	requestFullscreen,
 	exitFullscreen,
+	requestWakeLock,
+	releaseWakeLock,
 	endSlideShow,
 	prefetchNextSlide,
 	changeSlideInSlideshow,
@@ -281,10 +283,16 @@ const stopCursorTracking = () => {
 const handleFullScreenChange = () => {
 	if (document.fullscreenElement) {
 		inSlideShowMode.value = true
+		requestWakeLock()
 	} else {
 		stopCursorTracking()
 		if (inSlideShowMode.value) endSlideShow()
 	}
+}
+
+// the lock is dropped when the tab is hidden
+const handleVisibilityChange = () => {
+	if (document.visibilityState === 'visible' && inSlideShowMode.value) requestWakeLock()
 }
 
 const slideContainerStyles = computed(() => {
@@ -324,6 +332,7 @@ onActivated(() => {
 	loadPresentation()
 	initFullscreenMode()
 	document.addEventListener('fullscreenchange', handleFullScreenChange)
+	document.addEventListener('visibilitychange', handleVisibilityChange)
 	document.addEventListener('mousemove', resetCursorVisibility)
 	window.addEventListener('resize', updateWindowSize)
 
@@ -335,8 +344,10 @@ onActivated(() => {
 
 onDeactivated(() => {
 	document.removeEventListener('fullscreenchange', handleFullScreenChange)
+	document.removeEventListener('visibilitychange', handleVisibilityChange)
 	window.removeEventListener('resize', updateWindowSize)
 	stopCursorTracking()
+	releaseWakeLock()
 
 	// leaving by any route other than endSlideShow would strand the editor in fullscreen
 	if (inSlideShowMode.value) {

--- a/frontend/src/apps/slides/stores/slideshow.js
+++ b/frontend/src/apps/slides/stores/slideshow.js
@@ -36,17 +36,23 @@ const exitFullscreen = () => {
 }
 
 let wakeLock = null
+let pendingWakeLock = null
 
-const requestWakeLock = async () => {
-	if (!navigator.wakeLock) return
-	if (wakeLock && !wakeLock.released) return
+const requestWakeLock = () => {
+	if (pendingWakeLock) return pendingWakeLock
+	if (wakeLock && !wakeLock.released) return Promise.resolve()
+	if (!navigator.wakeLock) return Promise.resolve()
 
-	try {
-		wakeLock = await navigator.wakeLock.request('screen')
-		if (!inSlideShowMode.value) releaseWakeLock()
-	} catch (error) {
-		console.warn('Could not keep the screen awake:', error)
-	}
+	pendingWakeLock = navigator.wakeLock
+		.request('screen')
+		.then((lock) => {
+			wakeLock = lock
+			if (!inSlideShowMode.value) releaseWakeLock()
+		})
+		.catch((error) => console.warn('Could not keep the screen awake:', error))
+		.finally(() => (pendingWakeLock = null))
+
+	return pendingWakeLock
 }
 
 const releaseWakeLock = () => {

--- a/frontend/src/apps/slides/stores/slideshow.js
+++ b/frontend/src/apps/slides/stores/slideshow.js
@@ -35,6 +35,25 @@ const exitFullscreen = () => {
 	if (document.fullscreenElement) document.exitFullscreen()
 }
 
+let wakeLock = null
+
+const requestWakeLock = async () => {
+	if (!navigator.wakeLock) return
+	if (wakeLock && !wakeLock.released) return
+
+	try {
+		wakeLock = await navigator.wakeLock.request('screen')
+		if (!inSlideShowMode.value) releaseWakeLock()
+	} catch (error) {
+		console.warn('Could not keep the screen awake:', error)
+	}
+}
+
+const releaseWakeLock = () => {
+	wakeLock?.release().catch(() => {})
+	wakeLock = null
+}
+
 const startSlideShow = () => {
 	requestFullscreen()
 	router.replace({
@@ -46,6 +65,7 @@ const startSlideShow = () => {
 
 const endSlideShow = () => {
 	exitFullscreen()
+	releaseWakeLock()
 	inSlideShowMode.value = false
 	focusedSlide.value = null
 	const slide =
@@ -164,6 +184,8 @@ export {
 	showSlideshowEndScreen,
 	requestFullscreen,
 	exitFullscreen,
+	requestWakeLock,
+	releaseWakeLock,
 	startSlideShow,
 	endSlideShow,
 	prefetchNextSlide,


### PR DESCRIPTION
Two small things for presenting a long session on a projector.

### No toasts over the slideshow

- Fullscreen is requested on `document.documentElement`, so every toast renders on top of the slide.
- The shell toasts on every `online` and `offline` event, and venue Wi-Fi flaps constantly.
- The shell's two handlers now skip the toast while presenting. `saveCurrentState()` and the `isOnline` state still run as before.

### Keep the screen awake

- Nothing held a wake lock, so the display could sleep while a presenter talks over one slide for long.
- The lock is taken when the slideshow enters fullscreen and released on exit, whether that is Escape, another route, or the end of the show.
- Browsers drop the lock whenever the tab is hidden, so it is taken again on `visibilitychange` when the tab comes back and a show is still running.