### PR TITLE
fix(drive): serve framework attachment blobs from disk on S3 sites

### DIFF
--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -37,6 +37,7 @@ from suite.drive.utils.files import (
     get_s3_key,
     get_s3_url,
     storage_key,
+    stored_on_disk,
 )
 from suite.drive.utils.users import mark_as_viewed
 
@@ -319,7 +320,7 @@ def _serve_resumable(manager, key, download_name, mime_type=None):
 
     S3 → presigned URL; disk+nginx → X-Accel-Redirect; disk → send_file.
     """
-    if manager.s3_enabled:
+    if manager.s3_enabled and not stored_on_disk(key):
         frappe.local.response["type"] = "redirect"
         frappe.local.response["location"] = manager.presigned_url(key, download_name, mime_type)
         return
@@ -408,7 +409,7 @@ def stream_file_content(entity_name: str):
 
     manager = FileManager()
     data = None
-    if manager.s3_enabled:
+    if manager.s3_enabled and not stored_on_disk(entity.file_url):
         data = manager.get_file(entity, f"bytes={byte1}-{byte1 + length - 1}")
     else:
         with manager.open_file(storage_key(entity.file_url)) as f:

--- a/suite/drive/api/tests/test_files.py
+++ b/suite/drive/api/tests/test_files.py
@@ -41,7 +41,7 @@ from suite.drive.utils import (
     create_drive_file,
     get_user_folder,
 )
-from suite.drive.utils.files import FileManager
+from suite.drive.utils.files import FileManager, get_s3_url
 from suite.tests.utils import ensure_user
 
 OWNER = "drive-files-owner@example.com"
@@ -553,11 +553,25 @@ class TestDriveFilesAPI(IntegrationTestCase):
         manager.s3_enabled = True
         manager.conn = Mock()
         manager.conn.get_object.return_value = {"Body": BytesIO(b"storage boundary")}
-        self.assertEqual(manager.get_file(uploaded).read(), b"storage boundary")
+        remote = frappe._dict(file_url=get_s3_url(f"team/{uploaded.name}"))
+        self.assertEqual(manager.get_file(remote).read(), b"storage boundary")
         manager.conn.get_object.assert_called_once_with(
             Bucket=manager.bucket,
-            Key=uploaded.file_url.lstrip("/"),
+            Key=f"team/{uploaded.name}",
         )
+
+    def test_framework_attachment_blob_reads_from_disk_even_with_s3(self):
+        # Adopted framework uploads keep their /private/files url and their blob
+        # on the site's disk; enabling S3 must not send their reads to the bucket.
+        with self.set_user(OWNER):
+            uploaded = self.upload(b"disk blob")
+
+        manager = FileManager()
+        manager.s3_enabled = True
+        manager.conn = Mock()
+        with manager.get_file(uploaded) as stored:
+            self.assertEqual(stored.read(), b"disk blob")
+        manager.conn.get_object.assert_not_called()
 
     def test_private_video_range_stream_uses_storage_relative_path(self):
         self.file.file_type = "Video"

--- a/suite/drive/tests/test_storage_helpers.py
+++ b/suite/drive/tests/test_storage_helpers.py
@@ -154,3 +154,17 @@ class TestStorageHelpers(unittest.TestCase):
 
             with manager.open_file("/private/files/video.mp4") as file:
                 self.assertEqual(file.read(), b"video")
+
+    def test_open_file_reads_framework_blob_from_disk_even_with_s3(self):
+        with TemporaryDirectory() as site_folder:
+            manager = object.__new__(FileManager)
+            manager.s3_enabled = True
+            manager.conn = Mock()
+            manager.site_folder = Path(site_folder)
+            file_path = manager.site_folder / "private/files/video.mp4"
+            file_path.parent.mkdir(parents=True)
+            file_path.write_bytes(b"video")
+
+            with manager.open_file("private/files/video.mp4") as file:
+                self.assertEqual(file.read(), b"video")
+            manager.conn.get_object.assert_not_called()

--- a/suite/drive/utils/files.py
+++ b/suite/drive/utils/files.py
@@ -188,7 +188,7 @@ class FileManager:
         """
         file_url = storage_key(entity.file_url)
         try:
-            if self.s3_enabled:
+            if self.s3_enabled and not stored_on_disk(entity.file_url):
                 if range_header:
                     buf = self.conn.get_object(Bucket=self.bucket, Key=file_url, Range=range_header)["Body"]
                 else:
@@ -260,7 +260,7 @@ class FileManager:
 
     def iter_blocks(self, entity, block_size=4 * 1024 * 1024):
         """Yield a file's bytes lazily so a worker never holds the whole file."""
-        if self.s3_enabled:
+        if self.s3_enabled and not stored_on_disk(entity.file_url):
             source = self.get_file(entity)
             try:
                 while chunk := source.read(block_size):
@@ -519,6 +519,13 @@ def storage_key(file_url):
     if file_url.startswith(S3_URL_PREFIX):
         return unquote(file_url[len(S3_URL_PREFIX) :])
     return file_url.lstrip("/")
+
+
+def stored_on_disk(file_url):
+    # Framework-managed blobs (attachments, adopted uploads) keep their
+    # /private/files url and live on the site's disk even when Drive stores its
+    # own blobs on S3 — those always carry S3_URL_PREFIX or a bare bucket key.
+    return storage_key(file_url).startswith("private/files/")
 
 
 def content_disposition(download_name):

--- a/suite/drive/utils/files.py
+++ b/suite/drive/utils/files.py
@@ -286,7 +286,7 @@ class FileManager:
         - On disk: opens in binary mode, closes automatically.
         - On S3: yields the botocore StreamingBody, closes automatically.
         """
-        if self.s3_enabled:
+        if self.s3_enabled and not stored_on_disk(path):
             obj = self.conn.get_object(Bucket=self.bucket, Key=path)
             body = obj["Body"]
             try:
@@ -522,9 +522,12 @@ def storage_key(file_url):
 
 
 def stored_on_disk(file_url):
-    # Framework-managed blobs (attachments, adopted uploads) keep their
-    # /private/files url and live on the site's disk even when Drive stores its
-    # own blobs on S3 — those always carry S3_URL_PREFIX or a bare bucket key.
+    """Whether a file_url (or storage key) names a blob on the site's disk.
+
+    Framework-managed blobs (attachments, adopted uploads) keep their
+    /private/files url and live on the site's disk even when Drive stores its
+    own blobs on S3 — those always carry S3_URL_PREFIX or a bare bucket key.
+    """
     return storage_key(file_url).startswith("private/files/")
 
 


### PR DESCRIPTION
## Problem

On S3-enabled sites, previewing a framework-managed attachment in Drive fails:

```
Drive: could not read file
An error occurred (NoSuchKey) when calling the GetObject operation: The specified key does not exist.
```

Framework attachments — e.g. images pasted into Slides (`create_new_webp_file_doc` writes the converted webp to local disk via `get_full_path()`) and adopted framework uploads — keep their `/private/files` url and their blob on the site's disk. Every Drive read path treated `s3_enabled` as "all blobs are in S3" and issued `GetObject` with a `private/files/...` key that only exists on disk. #638 made these attachments previewable, exposing the broken read path.

## Fix

On S3 sites, Drive-managed blobs always carry an `s3.fetch?path=` url (`get_s3_url`) or a bare bucket key — a `/private/files` url means the blob lives on the site's disk. Added a `stored_on_disk()` helper and routed all read paths through it:

- `FileManager.get_file` (preview — the reported error) and `FileManager.iter_blocks` (zip downloads) read such files from disk even when S3 is enabled.
- `_serve_resumable` (downloads) falls back to X-Accel-Redirect / `send_file` instead of presigning a URL for a nonexistent key.
- `stream_file_content` (video range requests) seeks the local file instead of sending a ranged `GetObject`.

This also un-breaks pre-S3 Drive files on sites that enabled S3 later: nothing migrates their blobs, so their reads previously hit the same `NoSuchKey`.

## Tests

- Added `test_framework_attachment_blob_reads_from_disk_even_with_s3` as a regression test.
- Updated `test_local_and_s3_file_manager_reads_have_the_same_boundary`, which had encoded the old broken key mapping; its S3 expectation now uses a real `?path=`-style url.