### PR TITLE
feat(meet): add chat message pinning

### DIFF
--- a/frontend/src/apps/meet/components/ChatPanel.vue
+++ b/frontend/src/apps/meet/components/ChatPanel.vue
@@ -28,6 +28,37 @@
 					</div>
 				</div>
 
+				<div
+					v-if="pinnedMessage"
+					class="group mx-3 mb-2 flex shrink-0 items-center gap-2 rounded-[18px] bg-surface-gray-2 px-3 py-2.5"
+					role="button"
+					tabindex="0"
+					data-testid="pinned-message-banner"
+					@click="scrollToMessage(pinnedMessage.messageId)"
+					@keydown.enter.prevent="scrollToMessage(pinnedMessage.messageId)"
+					@keydown.space.prevent="scrollToMessage(pinnedMessage.messageId)"
+				>
+					<span class="lucide-pin size-3.5 shrink-0 text-ink-gray-5" aria-hidden="true" />
+					<div class="min-w-0 flex-1">
+						<div class="truncate text-[11px] tracking-[0.11px] text-ink-gray-5">
+							{{ pinnedMessage.user_name }}
+						</div>
+						<div class="mt-0.5 truncate text-sm tracking-[0.21px] text-ink-gray-8">
+							{{ pinnedMessage.message }}
+						</div>
+					</div>
+					<Button
+						v-if="canPin"
+						variant="ghost"
+						size="xs"
+						icon="lucide-pin-off"
+						class="!bg-surface-gray-1 !text-ink-gray-5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:!bg-surface-gray-3 hover:!text-ink-gray-8"
+						label="Unpin"
+						tooltip="Unpin message"
+						@click.stop="emit('unpin')"
+					/>
+				</div>
+
 				<div ref="listEl" class="flex-1 overflow-y-auto px-3 py-7">
 					<div class="flex flex-col gap-5">
 						<template v-for="item in chatItems" :key="item.key">
@@ -83,9 +114,24 @@
 									<div
 										v-for="message in item.group.messages"
 										:key="message.id"
-										class="max-w-full whitespace-pre-wrap rounded-[18px] px-3 py-2.5 text-left text-p-sm tracking-[0.28px] text-ink-gray-8 [overflow-wrap:anywhere]"
+										class="group relative max-w-full whitespace-pre-wrap rounded-[18px] px-3 py-2.5 text-left text-p-sm tracking-[0.28px] text-ink-gray-8 [overflow-wrap:anywhere]"
+										:data-message-id="message.messageId"
 										:class="item.group.isOwn ? 'bg-surface-gray-3' : 'bg-surface-gray-2'"
 									>
+										<Button
+											v-if="canPin"
+											type="button"
+											variant="ghost"
+											size="xs"
+											:icon="isPinned(message) ? 'lucide-pin-off' : 'lucide-pin'"
+											:class="[
+												'absolute -top-2.5 -right-2.5 !rounded-full border border-outline-gray-2 !bg-surface-gray-1 !p-0 !text-ink-gray-5 shadow-sm hover:!bg-surface-gray-2 hover:!text-ink-gray-8',
+												isPinned(message) ? '!opacity-100' : 'opacity-0 group-hover:opacity-100',
+											]"
+											:label="isPinned(message) ? 'Unpin message' : 'Pin message'"
+											:tooltip="isPinned(message) ? 'Unpin message' : 'Pin message'"
+											@click="togglePin(message)"
+										/>
 										<template
 											v-for="(token, i) in tokenizeChatMessage(message.message)"
 											:key="i"
@@ -214,6 +260,7 @@ import LucideChartColumn from "~icons/lucide/chart-column";
 
 interface ChatMessage {
 	id: string | number;
+	messageId?: string;
 	user_id: string;
 	user_name: string;
 	message: string;
@@ -229,6 +276,7 @@ const props = defineProps<{
 	isCohost?: boolean;
 	isGuest?: boolean;
 	hostOnlyChat?: boolean;
+	pinnedMessage?: ChatMessage | null;
 }>();
 
 const pollStore = usePollStore();
@@ -261,6 +309,8 @@ const handlePollSubmit = async (payload: {
 const emit = defineEmits<{
 	close: [];
 	send: [text: string];
+	pin: [messageId: string];
+	unpin: [];
 }>();
 const listEl = ref<HTMLElement | null>(null);
 const inputEl = ref<HTMLTextAreaElement | null>(null);
@@ -276,6 +326,28 @@ const canSendMessages = computed(() => {
 	if (!props.hostOnlyChat) return true;
 	return props.isHost || props.isCohost;
 });
+
+const canPin = computed(() => props.isHost || props.isCohost);
+
+function isPinned(message: ChatMessage): boolean {
+	return Boolean(
+		props.pinnedMessage && props.pinnedMessage.messageId === message.messageId,
+	);
+}
+
+function togglePin(message: ChatMessage) {
+	if (!message.messageId) return;
+	if (isPinned(message)) emit("unpin");
+	else emit("pin", message.messageId);
+}
+
+function scrollToMessage(messageId?: string) {
+	if (!messageId) return;
+	const messageEl = listEl.value?.querySelector<HTMLElement>(
+		`[data-message-id="${messageId}"]`,
+	);
+	messageEl?.scrollIntoView({ behavior: "smooth", block: "center" });
+}
 
 onMounted(async () => {
 	await scrollToBottom();

--- a/frontend/src/apps/meet/composables/__tests__/useChat.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useChat.test.ts
@@ -18,6 +18,8 @@ function makeChatStore(): ChatStore {
 		chatMessages: messages,
 		hasUnreadMessages: false,
 		hostOnlyChat: false,
+		pinnedMessage: null,
+		setPinnedMessage: vi.fn(),
 		toggleChat: vi.fn(),
 		markAsRead: vi.fn(),
 		addMessage: vi.fn((message: ChatMessage) => messages.push(message)),
@@ -31,6 +33,7 @@ function makeSFUClient(
 		sendChatMessage: (message: string) => Promise<{
 			success: boolean;
 			timestamp: string;
+			messageId?: string;
 		}>;
 	}> = {},
 ) {
@@ -42,8 +45,13 @@ function makeSFUClient(
 		isConnected: vi.fn(() => true),
 		isE2EERequired: vi.fn(() => true),
 		sendChatMessage: vi.fn(),
+		sendChatPin: vi.fn(),
 		emitChatMessage: (data: unknown) =>
 			handlers.get("chat:message")?.(data),
+		emitPinUpdated: (data: unknown) =>
+			handlers.get("chat:pin_updated")?.(data),
+		emitExistingPinned: (data: unknown) =>
+			handlers.get("existing_pinned_message")?.(data),
 		...overrides,
 	};
 }
@@ -132,7 +140,11 @@ describe("useChat E2EE gating", () => {
 		const timestamp = "2026-07-28T12:02:00.000Z";
 		const sfuClient = makeSFUClient({
 			isE2EERequired: vi.fn(() => false),
-			sendChatMessage: vi.fn(async () => ({ success: true, timestamp })),
+			sendChatMessage: vi.fn(async () => ({
+				success: true,
+				timestamp,
+				messageId: "msg-1",
+			})),
 		});
 		const chat = useChat({
 			chatStore,
@@ -143,5 +155,122 @@ describe("useChat E2EE gating", () => {
 		await chat.onSendChat("After the poll");
 
 		expect(chatStore.chatMessages.at(-1)?.timestamp).toBe(timestamp);
+		expect(chatStore.chatMessages.at(-1)?.messageId).toBe("msg-1");
+	});
+});
+
+describe("useChat pinning", () => {
+	it("sends chat:pin with the message id via pinMessage", async () => {
+		E2EEMeeting.instance = new E2EEMeeting();
+		const chatStore = makeChatStore();
+		const sfuClient = makeSFUClient();
+		const chat = useChat({
+			chatStore,
+			currentUser: currentUser as never,
+			sfuClient: sfuClient as never,
+		});
+
+		await chat.pinMessage("msg-42");
+
+		expect(sfuClient.sendChatPin).toHaveBeenCalledWith("msg-42");
+	});
+
+	it("updates the pinned message on chat:pin_updated", async () => {
+		E2EEMeeting.instance = new E2EEMeeting();
+		const chatStore = makeChatStore();
+		const sfuClient = makeSFUClient({ isE2EERequired: vi.fn(() => false) });
+		const chat = useChat({
+			chatStore,
+			currentUser: currentUser as never,
+			sfuClient: sfuClient as never,
+		});
+		chat.setupChatEvents(vi.fn());
+
+		sfuClient.emitPinUpdated({
+			pinned: {
+				messageId: "msg-1",
+				message: "Pinned text",
+				fromUser: "bob@example.com",
+				fromName: "Bob",
+				timestamp: "2026-07-28T12:00:00.000Z",
+			},
+		});
+		await Promise.resolve();
+
+		expect(chatStore.setPinnedMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				messageId: "msg-1",
+				user_id: "bob@example.com",
+				user_name: "Bob",
+				message: "Pinned text",
+			}),
+		);
+	});
+
+	it("clears the pinned message when chat:pin_updated sends null", async () => {
+		E2EEMeeting.instance = new E2EEMeeting();
+		const chatStore = makeChatStore();
+		const sfuClient = makeSFUClient();
+		const chat = useChat({
+			chatStore,
+			currentUser: currentUser as never,
+			sfuClient: sfuClient as never,
+		});
+		chat.setupChatEvents(vi.fn());
+
+		sfuClient.emitPinUpdated({ pinned: null });
+		await Promise.resolve();
+
+		expect(chatStore.setPinnedMessage).toHaveBeenCalledWith(null);
+	});
+
+	it("restores an existing pinned message for late joiners", async () => {
+		E2EEMeeting.instance = new E2EEMeeting();
+		const chatStore = makeChatStore();
+		const sfuClient = makeSFUClient({ isE2EERequired: vi.fn(() => false) });
+		const chat = useChat({
+			chatStore,
+			currentUser: currentUser as never,
+			sfuClient: sfuClient as never,
+		});
+		chat.setupChatEvents(vi.fn());
+
+		sfuClient.emitExistingPinned({
+			pinned: {
+				messageId: "msg-9",
+				message: "Welcome",
+				fromUser: "host@example.com",
+				fromName: "Host",
+				timestamp: "2026-07-28T12:05:00.000Z",
+			},
+		});
+		await Promise.resolve();
+
+		expect(chatStore.setPinnedMessage).toHaveBeenCalledWith(
+			expect.objectContaining({ messageId: "msg-9", message: "Welcome" }),
+		);
+	});
+
+	it("carries the server message id onto inbound messages", async () => {
+		E2EEMeeting.instance = new E2EEMeeting();
+		const chatStore = makeChatStore();
+		const sfuClient = makeSFUClient({ isE2EERequired: vi.fn(() => false) });
+		const chat = useChat({
+			chatStore,
+			currentUser: currentUser as never,
+			sfuClient: sfuClient as never,
+		});
+		chat.setupChatEvents(vi.fn());
+
+		sfuClient.emitChatMessage({
+			fromUser: "bob@example.com",
+			fromName: "Bob",
+			message: "With an id",
+			messageId: "msg-5",
+			timestamp: "2026-07-28T12:00:00.000Z",
+		});
+		await Promise.resolve();
+
+		expect(chatStore.chatMessages.at(-1)?.messageId).toBe("msg-5");
 	});
 });

--- a/frontend/src/apps/meet/composables/__tests__/useChat.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useChat.test.ts
@@ -172,7 +172,11 @@ describe("useChat pinning", () => {
 
 		await chat.pinMessage("msg-42");
 
-		expect(sfuClient.sendChatPin).toHaveBeenCalledWith("msg-42", "pin");
+		expect(sfuClient.sendChatPin).toHaveBeenCalledWith(
+			"msg-42",
+			"pin",
+			undefined,
+		);
 	});
 
 	it("updates the pinned message on chat:pin_updated", async () => {

--- a/frontend/src/apps/meet/composables/__tests__/useChat.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useChat.test.ts
@@ -253,6 +253,9 @@ describe("useChat pinning", () => {
 		expect(chatStore.setPinnedMessage).toHaveBeenCalledWith(
 			expect.objectContaining({ messageId: "msg-9", message: "Welcome" }),
 		);
+		expect(chatStore.addMessage).toHaveBeenCalledWith(
+			expect.objectContaining({ messageId: "msg-9", message: "Welcome" }),
+		);
 	});
 
 	it("carries the server message id onto inbound messages", async () => {

--- a/frontend/src/apps/meet/composables/__tests__/useChat.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useChat.test.ts
@@ -172,7 +172,7 @@ describe("useChat pinning", () => {
 
 		await chat.pinMessage("msg-42");
 
-		expect(sfuClient.sendChatPin).toHaveBeenCalledWith("msg-42");
+		expect(sfuClient.sendChatPin).toHaveBeenCalledWith("msg-42", "pin");
 	});
 
 	it("updates the pinned message on chat:pin_updated", async () => {

--- a/frontend/src/apps/meet/composables/useChat.ts
+++ b/frontend/src/apps/meet/composables/useChat.ts
@@ -193,8 +193,24 @@ export function useChat(deps: {
 			if (!data) return;
 			pendingPinnedMessage = data;
 			if (isEncryptedChatMessage(data.message) && !(await getChatKey())) return;
-			data.message = await resolvePlaintext(data.message);
-			chatStore.setPinnedMessage(toChatMessage(data));
+			const plaintext = await resolvePlaintext(data.message);
+			if (
+				isEncryptedChatMessage(data.message) &&
+				plaintext.startsWith("[Encrypted")
+			) {
+				return;
+			}
+			data.message = plaintext;
+			const message = toChatMessage(data);
+			if (
+				message.messageId &&
+				!chatStore.chatMessages.some(
+					(existing) => existing.messageId === message.messageId,
+				)
+			) {
+				chatStore.addMessage(message);
+			}
+			chatStore.setPinnedMessage(message);
 			pendingPinnedMessage = null;
 		};
 

--- a/frontend/src/apps/meet/composables/useChat.ts
+++ b/frontend/src/apps/meet/composables/useChat.ts
@@ -110,8 +110,9 @@ export function useChat(deps: {
 	chatStore: ChatStore;
 	currentUser: CurrentUser;
 	sfuClient: SFUClient;
+	canPin?: () => boolean;
 }): ChatAPI {
-	const { chatStore, currentUser, sfuClient } = deps;
+	const { chatStore, currentUser, sfuClient, canPin = () => false } = deps;
 
 	async function getChatKey(): Promise<CryptoKey | null> {
 		return E2EEMeeting.instance.getE2EEChatKey();
@@ -203,6 +204,9 @@ export function useChat(deps: {
 			if (pendingPinnedMessage) {
 				void applyPinnedMessage({ pinned: pendingPinnedMessage });
 			}
+			if (canPin() && chatStore.pinnedMessage?.messageId) {
+				void pinMessage(chatStore.pinnedMessage.messageId);
+			}
 		});
 		sfuClient.on("chat:restriction_updated", (value: unknown) => {
 			if (isUnknownRecord(value) && typeof value.enabled === "boolean") {
@@ -274,7 +278,17 @@ export function useChat(deps: {
 	) => {
 		try {
 			if (sfuClient.isConnected()) {
-				await sfuClient.sendChatPin(messageId, action);
+				let encryptedMessage: string | undefined;
+				if (action === "pin" && shouldEncryptChat()) {
+					const message = chatStore.chatMessages.find(
+						(item) => item.messageId === messageId,
+					);
+					const key = await getChatKey();
+					if (message && key && !isEncryptedChatMessage(message.message)) {
+						encryptedMessage = await encryptChatMessage(key, message.message);
+					}
+				}
+				await sfuClient.sendChatPin(messageId, action, encryptedMessage);
 			}
 		} catch (error) {
 			console.error("Failed to pin chat message:", error);

--- a/frontend/src/apps/meet/composables/useChat.ts
+++ b/frontend/src/apps/meet/composables/useChat.ts
@@ -10,6 +10,7 @@ interface ChatAPI {
 	setupChatEvents: (notify: (notification: ChatNotification) => void) => void;
 	onSendChat: (text: string) => void;
 	toggleRestriction: (enabled: boolean) => void;
+	pinMessage: (messageId: string) => void;
 }
 
 interface ChatNotification {
@@ -24,6 +25,7 @@ interface IncomingChatMessage {
 	fromName: string;
 	message: string;
 	timestamp: string;
+	messageId?: string;
 }
 
 function normalizeChatMessage(value: unknown): IncomingChatMessage | null {
@@ -41,6 +43,8 @@ function normalizeChatMessage(value: unknown): IncomingChatMessage | null {
 			typeof value.timestamp === "string"
 				? value.timestamp
 				: new Date().toISOString(),
+		messageId:
+			typeof value.messageId === "string" ? value.messageId : undefined,
 	};
 }
 
@@ -113,6 +117,40 @@ export function useChat(deps: {
 		return E2EEMeeting.instance.getE2EEChatKey();
 	}
 
+	async function resolvePlaintext(raw: string): Promise<string> {
+		if (isEncryptedChatMessage(raw)) {
+			const key = await getChatKey();
+			if (!key) {
+				console.warn(
+					"E2EE chat: received encrypted message but no meeting context set",
+				);
+				return "[Encrypted message]";
+			}
+			try {
+				return await decryptChatMessage(key, raw);
+			} catch (e) {
+				console.error("E2EE chat: decryption failed", e);
+				const errName = e instanceof Error ? e.name : "Error";
+				return `[Encrypted: ${errName}]`;
+			}
+		}
+		if (isE2EERequired(sfuClient)) {
+			return "[Unencrypted message blocked]";
+		}
+		return raw;
+	}
+
+	function toChatMessage(data: IncomingChatMessage): ChatMessage {
+		return {
+			id: Date.now() + Math.random(),
+			messageId: data.messageId,
+			user_id: data.fromUser,
+			user_name: data.fromName,
+			message: data.message,
+			timestamp: data.timestamp,
+		};
+	}
+
 	const setupChatEvents = (notify: (notification: ChatNotification) => void) => {
 		sfuClient.on("chat:message", async (value: unknown) => {
 			const data = normalizeChatMessage(value);
@@ -121,35 +159,8 @@ export function useChat(deps: {
 				return;
 			}
 
-			let plaintext = data.message;
-
-			if (isEncryptedChatMessage(plaintext)) {
-				const key = await getChatKey();
-				if (!key) {
-					console.warn(
-						"E2EE chat: received encrypted message but no meeting context set",
-					);
-					plaintext = "[Encrypted message]";
-				} else {
-					try {
-						plaintext = await decryptChatMessage(key, plaintext);
-					} catch (e) {
-						console.error("E2EE chat: decryption failed", e);
-						const errName = e instanceof Error ? e.name : "Error";
-						plaintext = `[Encrypted: ${errName}]`;
-					}
-				}
-			} else if (isE2EERequired(sfuClient)) {
-				plaintext = "[Unencrypted message blocked]";
-			}
-
-			const message: ChatMessage = {
-				id: Date.now() + Math.random(),
-				user_id: data.fromUser,
-				user_name: data.fromName,
-				message: plaintext,
-				timestamp: data.timestamp,
-			};
+			data.message = await resolvePlaintext(data.message);
+			const message = toChatMessage(data);
 
 			chatStore.addMessage(message);
 
@@ -160,7 +171,7 @@ export function useChat(deps: {
 				chatStore.hasUnreadMessages = true;
 
 				notify({
-					message: plaintext,
+					message: data.message,
 					fromUser: data.fromUser,
 					fromName: data.fromName,
 					type: "chat",
@@ -168,6 +179,20 @@ export function useChat(deps: {
 				audioNotificationManager.playChatNotification();
 			}
 		});
+
+		const applyPinnedMessage = async (value: unknown) => {
+			if (!isUnknownRecord(value) || value.pinned == null) {
+				chatStore.setPinnedMessage(null);
+				return;
+			}
+			const data = normalizeChatMessage(value.pinned);
+			if (!data) return;
+			data.message = await resolvePlaintext(data.message);
+			chatStore.setPinnedMessage(toChatMessage(data));
+		};
+
+		sfuClient.on("chat:pin_updated", applyPinnedMessage);
+		sfuClient.on("existing_pinned_message", applyPinnedMessage);
 		sfuClient.on("chat:restriction_updated", (value: unknown) => {
 			if (isUnknownRecord(value) && typeof value.enabled === "boolean") {
 				chatStore.hostOnlyChat = value.enabled;
@@ -205,15 +230,18 @@ export function useChat(deps: {
 			}
 
 			let timestamp = new Date().toISOString();
+			let messageId: string | undefined;
 			if (sfuClient.isConnected()) {
 				const response = await sfuClient.sendChatMessage(messageToSend, {
 					clientId: currentUser.currentUser.value?.user_id,
 				});
 				timestamp = response.timestamp;
+				messageId = response.messageId;
 			}
 
 			const message: ChatMessage = {
 				id: Date.now() + Math.random(),
+				messageId,
 				user_id: currentUser.currentUser.value?.user_id as string,
 				user_name:
 					(currentUser.currentUser.value?.full_name as string) ||
@@ -229,9 +257,21 @@ export function useChat(deps: {
 		}
 	};
 
+	const pinMessage = async (messageId: string) => {
+		try {
+			if (sfuClient.isConnected()) {
+				await sfuClient.sendChatPin(messageId);
+			}
+		} catch (error) {
+			console.error("Failed to pin chat message:", error);
+			toast.error("Failed to pin message");
+		}
+	};
+
 	return {
 		setupChatEvents,
 		toggleRestriction,
 		onSendChat,
+		pinMessage,
 	};
 }

--- a/frontend/src/apps/meet/composables/useChat.ts
+++ b/frontend/src/apps/meet/composables/useChat.ts
@@ -10,7 +10,7 @@ interface ChatAPI {
 	setupChatEvents: (notify: (notification: ChatNotification) => void) => void;
 	onSendChat: (text: string) => void;
 	toggleRestriction: (enabled: boolean) => void;
-	pinMessage: (messageId: string) => void;
+	pinMessage: (messageId: string, action?: "pin" | "unpin") => void;
 }
 
 interface ChatNotification {
@@ -152,6 +152,8 @@ export function useChat(deps: {
 	}
 
 	const setupChatEvents = (notify: (notification: ChatNotification) => void) => {
+		let pendingPinnedMessage: IncomingChatMessage | null = null;
+
 		sfuClient.on("chat:message", async (value: unknown) => {
 			const data = normalizeChatMessage(value);
 			if (!data) return;
@@ -182,17 +184,26 @@ export function useChat(deps: {
 
 		const applyPinnedMessage = async (value: unknown) => {
 			if (!isUnknownRecord(value) || value.pinned == null) {
+				pendingPinnedMessage = null;
 				chatStore.setPinnedMessage(null);
 				return;
 			}
 			const data = normalizeChatMessage(value.pinned);
 			if (!data) return;
+			pendingPinnedMessage = data;
+			if (isEncryptedChatMessage(data.message) && !(await getChatKey())) return;
 			data.message = await resolvePlaintext(data.message);
 			chatStore.setPinnedMessage(toChatMessage(data));
+			pendingPinnedMessage = null;
 		};
 
 		sfuClient.on("chat:pin_updated", applyPinnedMessage);
 		sfuClient.on("existing_pinned_message", applyPinnedMessage);
+		document.addEventListener("meet:e2ee-context-ready", () => {
+			if (pendingPinnedMessage) {
+				void applyPinnedMessage({ pinned: pendingPinnedMessage });
+			}
+		});
 		sfuClient.on("chat:restriction_updated", (value: unknown) => {
 			if (isUnknownRecord(value) && typeof value.enabled === "boolean") {
 				chatStore.hostOnlyChat = value.enabled;
@@ -257,10 +268,13 @@ export function useChat(deps: {
 		}
 	};
 
-	const pinMessage = async (messageId: string) => {
+	const pinMessage = async (
+		messageId: string,
+		action: "pin" | "unpin" = "pin",
+	) => {
 		try {
 			if (sfuClient.isConnected()) {
-				await sfuClient.sendChatPin(messageId);
+				await sfuClient.sendChatPin(messageId, action);
 			}
 		} catch (error) {
 			console.error("Failed to pin chat message:", error);

--- a/frontend/src/apps/meet/composables/useChat.ts
+++ b/frontend/src/apps/meet/composables/useChat.ts
@@ -154,6 +154,7 @@ export function useChat(deps: {
 
 	const setupChatEvents = (notify: (notification: ChatNotification) => void) => {
 		let pendingPinnedMessage: IncomingChatMessage | null = null;
+		let pinnedMessageUpdate = 0;
 
 		sfuClient.on("chat:message", async (value: unknown) => {
 			const data = normalizeChatMessage(value);
@@ -184,6 +185,7 @@ export function useChat(deps: {
 		});
 
 		const applyPinnedMessage = async (value: unknown) => {
+			const update = ++pinnedMessageUpdate;
 			if (!isUnknownRecord(value) || value.pinned == null) {
 				pendingPinnedMessage = null;
 				chatStore.setPinnedMessage(null);
@@ -200,6 +202,7 @@ export function useChat(deps: {
 			) {
 				return;
 			}
+			if (update !== pinnedMessageUpdate) return;
 			data.message = plaintext;
 			const message = toChatMessage(data);
 			if (

--- a/frontend/src/apps/meet/composables/useChatStore.ts
+++ b/frontend/src/apps/meet/composables/useChatStore.ts
@@ -3,6 +3,7 @@ import { ref } from "vue";
 
 export interface ChatMessage {
 	id: number;
+	messageId?: string;
 	user_id: string;
 	user_name: string;
 	message: string;
@@ -17,6 +18,8 @@ export interface ChatStore {
 	hostOnlyChat: boolean;
 	markAsRead: () => void;
 	addMessage: (message: ChatMessage) => void;
+	pinnedMessage: ChatMessage | null;
+	setPinnedMessage: (message: ChatMessage | null) => void;
 	$reset: () => void;
 }
 
@@ -25,6 +28,7 @@ export const useChatStore = defineStore("meet-chat", () => {
 	const chatMessages = ref<ChatMessage[]>([]);
 	const hasUnreadMessages = ref(false);
 	const hostOnlyChat = ref(false);
+	const pinnedMessage = ref<ChatMessage | null>(null);
 
 	function toggleChat() {
 		isChatOpen.value = !isChatOpen.value;
@@ -44,11 +48,16 @@ export const useChatStore = defineStore("meet-chat", () => {
 		chatMessages.value.push(message);
 	}
 
+	function setPinnedMessage(message: ChatMessage | null) {
+		pinnedMessage.value = message;
+	}
+
 	function $reset() {
 		isChatOpen.value = false;
 		chatMessages.value = [];
 		hasUnreadMessages.value = false;
 		hostOnlyChat.value = false;
+		pinnedMessage.value = null;
 	}
 
 	return {
@@ -59,6 +68,8 @@ export const useChatStore = defineStore("meet-chat", () => {
 		hostOnlyChat,
 		markAsRead,
 		addMessage,
+		pinnedMessage,
+		setPinnedMessage,
 		$reset,
 	};
 });

--- a/frontend/src/apps/meet/pages/Meeting.vue
+++ b/frontend/src/apps/meet/pages/Meeting.vue
@@ -629,7 +629,7 @@ const chat = useChat({
 
 function unpinChatMessage() {
 	const messageId = chatStore.pinnedMessage?.messageId;
-	if (messageId) chat.pinMessage(messageId);
+	if (messageId) chat.pinMessage(messageId, "unpin");
 }
 
 // --- Poll ---

--- a/frontend/src/apps/meet/pages/Meeting.vue
+++ b/frontend/src/apps/meet/pages/Meeting.vue
@@ -625,6 +625,7 @@ const chat = useChat({
 	chatStore,
 	currentUser,
 	sfuClient: sfuConnection.sfuClient,
+	canPin: () => isCurrentUserHost.value || isCurrentUserCohost.value,
 });
 
 function unpinChatMessage() {

--- a/frontend/src/apps/meet/pages/Meeting.vue
+++ b/frontend/src/apps/meet/pages/Meeting.vue
@@ -151,8 +151,11 @@
 								:isCohost="isCurrentUserCohost"
 								:isGuest="isGuestSession"
 								:hostOnlyChat="chatStore.hostOnlyChat"
+								:pinned-message="chatStore.pinnedMessage"
 								@close="toggleChat"
 								@send="chat.onSendChat"
+								@pin="chat.pinMessage"
+								@unpin="unpinChatMessage"
 							/>
 
 							<!-- People Panel -->
@@ -623,6 +626,11 @@ const chat = useChat({
 	currentUser,
 	sfuClient: sfuConnection.sfuClient,
 });
+
+function unpinChatMessage() {
+	const messageId = chatStore.pinnedMessage?.messageId;
+	if (messageId) chat.pinMessage(messageId);
+}
 
 // --- Poll ---
 

--- a/frontend/src/apps/meet/utils/SFUClient.ts
+++ b/frontend/src/apps/meet/utils/SFUClient.ts
@@ -705,6 +705,8 @@ export class SFUClient {
 			webrtc_answer: () => {},
 			ice_candidate: () => {},
 			"chat:message": () => {},
+			"chat:pin_updated": () => {},
+			"existing_pinned_message": () => {},
 			active_speaker: () => {},
 			hand_raised: () => {},
 			existing_raised_hands: () => {},
@@ -991,7 +993,7 @@ export class SFUClient {
 	async sendChatMessage(
 		message: string,
 		options: { clientId?: unknown } = {},
-	): Promise<{ success: boolean; timestamp: string }> {
+	): Promise<{ success: boolean; timestamp: string; messageId?: string }> {
 		if (!this.connected) {
 			throw new Error("Not connected to SFU");
 		}
@@ -1004,7 +1006,15 @@ export class SFUClient {
 		return (await this.sendRequest("chat:send", payload)) as {
 			success: boolean;
 			timestamp: string;
+			messageId?: string;
 		};
+	}
+
+	async sendChatPin(messageId: string): Promise<unknown> {
+		if (!this.connected) {
+			throw new SFURequestError("DISCONNECTED", "Not connected to SFU");
+		}
+		return this.sendRequest("chat:pin", { messageId: String(messageId) });
 	}
 
 	// ==================== REACTION OPERATIONS ====================

--- a/frontend/src/apps/meet/utils/SFUClient.ts
+++ b/frontend/src/apps/meet/utils/SFUClient.ts
@@ -1014,14 +1014,17 @@ export class SFUClient {
 	async sendChatPin(
 		messageId: string,
 		action: "pin" | "unpin" = "pin",
+		encryptedMessage?: string,
 	): Promise<unknown> {
 		if (!this.connected) {
 			throw new SFURequestError("DISCONNECTED", "Not connected to SFU");
 		}
-		return this.sendRequest("chat:pin", {
+		const payload: Record<string, string> = {
 			messageId: String(messageId),
 			action,
-		});
+		};
+		if (encryptedMessage) payload.encryptedMessage = encryptedMessage;
+		return this.sendRequest("chat:pin", payload);
 	}
 
 	// ==================== REACTION OPERATIONS ====================

--- a/frontend/src/apps/meet/utils/SFUClient.ts
+++ b/frontend/src/apps/meet/utils/SFUClient.ts
@@ -1010,11 +1010,18 @@ export class SFUClient {
 		};
 	}
 
-	async sendChatPin(messageId: string): Promise<unknown> {
+	/** Pin or explicitly unpin a room chat message. */
+	async sendChatPin(
+		messageId: string,
+		action: "pin" | "unpin" = "pin",
+	): Promise<unknown> {
 		if (!this.connected) {
 			throw new SFURequestError("DISCONNECTED", "Not connected to SFU");
 		}
-		return this.sendRequest("chat:pin", { messageId: String(messageId) });
+		return this.sendRequest("chat:pin", {
+			messageId: String(messageId),
+			action,
+		});
 	}
 
 	// ==================== REACTION OPERATIONS ====================

--- a/frontend/src/apps/meet/utils/__tests__/SFUClient.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUClient.test.ts
@@ -309,6 +309,26 @@ describe("sendChatMessage", () => {
 	});
 });
 
+describe("sendChatPin", () => {
+	it("throws when not connected", async () => {
+		const client = createClient();
+		client.connected = false;
+		await expect(client.sendChatPin("msg-1")).rejects.toThrow(
+			"Not connected to SFU",
+		);
+	});
+
+	it("sends chat:pin with the message id", async () => {
+		const client = createClient();
+		client.connected = true;
+		const sendRequest = vi.spyOn(client, "sendRequest").mockResolvedValue({
+			success: true,
+		});
+		await client.sendChatPin("msg-1");
+		expect(sendRequest).toHaveBeenCalledWith("chat:pin", { messageId: "msg-1" });
+	});
+});
+
 describe("sendReaction", () => {
 	it("throws when not connected", () => {
 		const client = createClient();

--- a/frontend/src/apps/meet/utils/__tests__/SFUClient.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUClient.test.ts
@@ -325,7 +325,10 @@ describe("sendChatPin", () => {
 			success: true,
 		});
 		await client.sendChatPin("msg-1");
-		expect(sendRequest).toHaveBeenCalledWith("chat:pin", { messageId: "msg-1" });
+		expect(sendRequest).toHaveBeenCalledWith("chat:pin", {
+			messageId: "msg-1",
+			action: "pin",
+		});
 	});
 });
 

--- a/suite/meet/sfu-server/src/server/RoomRegistry.ts
+++ b/suite/meet/sfu-server/src/server/RoomRegistry.ts
@@ -5,6 +5,7 @@ import type {
 	ClientToServerEvents,
 	HandRaisedEvent,
 	MediaControlAction,
+	PinnedChatMessage,
 	ProducerCloseDetails,
 	ProducerCloseReason,
 	ProducerCloseSource,
@@ -32,6 +33,8 @@ export class RoomRegistry {
 	private io: Server<ClientToServerEvents, ServerToClientEvents>;
 	private raisedHands: Record<string, Record<string, string>> = {};
 	private hostOnlyChat: Record<string, boolean> = {};
+	private recentChatMessages: Record<string, ChatMessage[]> = {};
+	private pinnedChatMessage: Record<string, PinnedChatMessage> = {};
 	private participantSockets: Record<string, Record<string, string>> = {};
 	private participantConnections = new Map<string, Map<string, Set<string>>>();
 	private activePolls: Record<string, Map<string, ActivePoll>> = {};
@@ -223,6 +226,31 @@ export class RoomRegistry {
 		return Boolean(this.hostOnlyChat[roomId]);
 	}
 
+	recordChatMessage(roomId: string, message: ChatMessage): void {
+		const buffer = this.recentChatMessages[roomId] ?? [];
+		buffer.push(message);
+		if (buffer.length > 200) buffer.shift();
+		this.recentChatMessages[roomId] = buffer;
+	}
+
+	getRecentChatMessage(
+		roomId: string,
+		messageId: string,
+	): ChatMessage | undefined {
+		return this.recentChatMessages[roomId]?.find(
+			(message) => message.messageId === messageId,
+		);
+	}
+
+	setPinnedChatMessage(roomId: string, pinned: PinnedChatMessage | null): void {
+		if (pinned === null) delete this.pinnedChatMessage[roomId];
+		else this.pinnedChatMessage[roomId] = pinned;
+	}
+
+	getPinnedChatMessage(roomId: string): PinnedChatMessage | null {
+		return this.pinnedChatMessage[roomId] ?? null;
+	}
+
 	getActivePolls(roomId: string): Map<string, ActivePoll> | undefined {
 		return this.activePolls[roomId];
 	}
@@ -252,6 +280,8 @@ export class RoomRegistry {
 		}
 		delete this.raisedHands[roomId];
 		delete this.hostOnlyChat[roomId];
+		delete this.recentChatMessages[roomId];
+		delete this.pinnedChatMessage[roomId];
 		delete this.participantSockets[roomId];
 		this.participantConnections.delete(roomId);
 		delete this.activePolls[roomId];
@@ -398,6 +428,7 @@ export class RoomRegistry {
 		this.emitToFullAccessParticipants(roomId, 'chat:message', data);
 		this.emitToRecorders(roomId, 'chat:message', {
 			roomId: data.roomId,
+			messageId: data.messageId,
 			message: data.message,
 			fromUser: data.fromUser,
 			fromName: data.fromName,

--- a/suite/meet/sfu-server/src/server/RoomRegistry.ts
+++ b/suite/meet/sfu-server/src/server/RoomRegistry.ts
@@ -226,6 +226,7 @@ export class RoomRegistry {
 		return Boolean(this.hostOnlyChat[roomId]);
 	}
 
+	/** Keep the bounded message window used to resolve pin requests. */
 	recordChatMessage(roomId: string, message: ChatMessage): void {
 		const buffer = this.recentChatMessages[roomId] ?? [];
 		buffer.push(message);
@@ -233,6 +234,7 @@ export class RoomRegistry {
 		this.recentChatMessages[roomId] = buffer;
 	}
 
+	/** Resolve a message that is still eligible for pinning. */
 	getRecentChatMessage(
 		roomId: string,
 		messageId: string,
@@ -242,11 +244,13 @@ export class RoomRegistry {
 		);
 	}
 
+	/** Set or clear the room-wide pin; room cleanup removes this ephemeral state. */
 	setPinnedChatMessage(roomId: string, pinned: PinnedChatMessage | null): void {
 		if (pinned === null) delete this.pinnedChatMessage[roomId];
 		else this.pinnedChatMessage[roomId] = pinned;
 	}
 
+	/** Return the current room-wide pin, if one exists. */
 	getPinnedChatMessage(roomId: string): PinnedChatMessage | null {
 		return this.pinnedChatMessage[roomId] ?? null;
 	}

--- a/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
@@ -1316,7 +1316,7 @@ describe('SocketHandlerManager characterization', () => {
 		);
 	});
 
-	it('chat:pin broadcasts the pinned message to full-access participants and unpins on a repeat pin', async () => {
+	it('chat:pin broadcasts pin and explicit unpin actions', async () => {
 		const harness = createManager();
 
 		const host = connectFullSocket(harness, {
@@ -1346,7 +1346,7 @@ describe('SocketHandlerManager characterization', () => {
 		participant.emitCalls.length = 0;
 
 		const pinCallback = vi.fn();
-		host.fire('chat:pin', { messageId }, pinCallback);
+		host.fire('chat:pin', { messageId, action: 'pin' }, pinCallback);
 
 		expect(pinCallback).toHaveBeenCalledWith({ success: true });
 		const pinnedUpdate = participant.emitCalls.find(
@@ -1364,9 +1364,30 @@ describe('SocketHandlerManager characterization', () => {
 		});
 
 		participant.emitCalls.length = 0;
-		host.fire('chat:pin', { messageId }, pinCallback);
+		const secondSendCallback = vi.fn();
+		host.fire('chat:send', { message: 'pin me too' }, secondSendCallback);
+		const secondMessageId = secondSendCallback.mock.calls[0]?.[0]
+			.messageId as string;
+		host.fire(
+			'chat:pin',
+			{ messageId: secondMessageId, action: 'pin' },
+			pinCallback,
+		);
+		const secondPinnedUpdate = participant.emitCalls.filter(
+			(c) => c.event === 'chat:pin_updated',
+		);
+		host.fire('chat:pin', { messageId, action: 'unpin' }, pinCallback);
 		expect(
-			participant.emitCalls.find((c) => c.event === 'chat:pin_updated')?.data,
+			participant.emitCalls.filter((c) => c.event === 'chat:pin_updated'),
+		).toEqual(secondPinnedUpdate);
+		host.fire(
+			'chat:pin',
+			{ messageId: secondMessageId, action: 'unpin' },
+			pinCallback,
+		);
+		expect(
+			participant.emitCalls.filter((c) => c.event === 'chat:pin_updated').at(-1)
+				?.data,
 		).toEqual({ pinned: null });
 	});
 
@@ -1393,7 +1414,11 @@ describe('SocketHandlerManager characterization', () => {
 
 		participant.emitCalls.length = 0;
 		const deniedCallback = vi.fn();
-		participant.fire('chat:pin', { messageId: 'any-id' }, deniedCallback);
+		participant.fire(
+			'chat:pin',
+			{ messageId: 'any-id', action: 'pin' },
+			deniedCallback,
+		);
 		expect(deniedCallback).toHaveBeenCalledWith({
 			success: false,
 			error: 'Only hosts and co-hosts can pin messages',
@@ -1404,7 +1429,11 @@ describe('SocketHandlerManager characterization', () => {
 
 		host.emitCalls.length = 0;
 		const unknownCallback = vi.fn();
-		host.fire('chat:pin', { messageId: 'missing-id' }, unknownCallback);
+		host.fire(
+			'chat:pin',
+			{ messageId: 'missing-id', action: 'pin' },
+			unknownCallback,
+		);
 		expect(unknownCallback).toHaveBeenCalledWith({
 			success: false,
 			error: 'Message is no longer available to pin',
@@ -1430,7 +1459,7 @@ describe('SocketHandlerManager characterization', () => {
 		const sendCallback = vi.fn();
 		host.fire('chat:send', { message: 'pinned greeting' }, sendCallback);
 		const messageId = sendCallback.mock.calls[0]?.[0].messageId as string;
-		host.fire('chat:pin', { messageId }, () => {});
+		host.fire('chat:pin', { messageId, action: 'pin' }, () => {});
 
 		const lateJoiner = connectFullSocket(harness, {
 			id: 'sock-pin-late',

--- a/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
@@ -1255,6 +1255,7 @@ describe('SocketHandlerManager characterization', () => {
 		expect(callback).toHaveBeenCalledWith({
 			success: true,
 			timestamp: receiverMsg?.data.timestamp,
+			messageId: expect.any(String),
 		});
 
 		const senderChatMessages = sender.emitCalls.filter(
@@ -1313,6 +1314,145 @@ describe('SocketHandlerManager characterization', () => {
 		expect(nonHost.emitCalls.some((c) => c.event === 'chat:message')).toBe(
 			false,
 		);
+	});
+
+	it('chat:pin broadcasts the pinned message to full-access participants and unpins on a repeat pin', async () => {
+		const harness = createManager();
+
+		const host = connectFullSocket(harness, {
+			id: 'sock-pin-host',
+			userId: 'pin-host-1',
+			userName: 'PinHost',
+			isHost: true,
+			isCohost: false,
+		});
+		emitJoin(host, { userId: 'pin-host-1', name: 'PinHost' });
+		await new Promise((r) => setImmediate(r));
+
+		const participant = connectFullSocket(harness, {
+			id: 'sock-pin-user',
+			userId: 'pin-user-1',
+			userName: 'PinUser',
+		});
+		emitJoin(participant, { userId: 'pin-user-1', name: 'PinUser' });
+		await new Promise((r) => setImmediate(r));
+
+		const sendCallback = vi.fn();
+		host.fire('chat:send', { message: 'pin me' }, sendCallback);
+		const messageId = sendCallback.mock.calls[0]?.[0].messageId as string;
+		expect(messageId).toBeTruthy();
+
+		host.emitCalls.length = 0;
+		participant.emitCalls.length = 0;
+
+		const pinCallback = vi.fn();
+		host.fire('chat:pin', { messageId }, pinCallback);
+
+		expect(pinCallback).toHaveBeenCalledWith({ success: true });
+		const pinnedUpdate = participant.emitCalls.find(
+			(c) => c.event === 'chat:pin_updated',
+		);
+		expect(pinnedUpdate).toBeDefined();
+		expect(pinnedUpdate?.data).toEqual({
+			pinned: {
+				messageId,
+				message: 'pin me',
+				fromUser: 'pin-host-1',
+				fromName: 'PinHost',
+				timestamp: expect.any(String),
+			},
+		});
+
+		participant.emitCalls.length = 0;
+		host.fire('chat:pin', { messageId }, pinCallback);
+		expect(
+			participant.emitCalls.find((c) => c.event === 'chat:pin_updated')?.data,
+		).toEqual({ pinned: null });
+	});
+
+	it('chat:pin rejects non-host participants and unknown message ids', async () => {
+		const harness = createManager();
+
+		const host = connectFullSocket(harness, {
+			id: 'sock-pin-host2',
+			userId: 'pin-host-2',
+			userName: 'PinHost2',
+			isHost: true,
+			isCohost: false,
+		});
+		emitJoin(host, { userId: 'pin-host-2', name: 'PinHost2' });
+		await new Promise((r) => setImmediate(r));
+
+		const participant = connectFullSocket(harness, {
+			id: 'sock-pin-user2',
+			userId: 'pin-user-2',
+			userName: 'PinUser2',
+		});
+		emitJoin(participant, { userId: 'pin-user-2', name: 'PinUser2' });
+		await new Promise((r) => setImmediate(r));
+
+		participant.emitCalls.length = 0;
+		const deniedCallback = vi.fn();
+		participant.fire('chat:pin', { messageId: 'any-id' }, deniedCallback);
+		expect(deniedCallback).toHaveBeenCalledWith({
+			success: false,
+			error: 'Only hosts and co-hosts can pin messages',
+		});
+		expect(
+			participant.emitCalls.some((c) => c.event === 'chat:pin_updated'),
+		).toBe(false);
+
+		host.emitCalls.length = 0;
+		const unknownCallback = vi.fn();
+		host.fire('chat:pin', { messageId: 'missing-id' }, unknownCallback);
+		expect(unknownCallback).toHaveBeenCalledWith({
+			success: false,
+			error: 'Message is no longer available to pin',
+		});
+		expect(host.emitCalls.some((c) => c.event === 'chat:pin_updated')).toBe(
+			false,
+		);
+	});
+
+	it('late joiners receive existing_pinned_message for a currently pinned chat message', async () => {
+		const harness = createManager();
+
+		const host = connectFullSocket(harness, {
+			id: 'sock-pin-host3',
+			userId: 'pin-host-3',
+			userName: 'PinHost3',
+			isHost: true,
+			isCohost: false,
+		});
+		emitJoin(host, { userId: 'pin-host-3', name: 'PinHost3' });
+		await new Promise((r) => setImmediate(r));
+
+		const sendCallback = vi.fn();
+		host.fire('chat:send', { message: 'pinned greeting' }, sendCallback);
+		const messageId = sendCallback.mock.calls[0]?.[0].messageId as string;
+		host.fire('chat:pin', { messageId }, () => {});
+
+		const lateJoiner = connectFullSocket(harness, {
+			id: 'sock-pin-late',
+			userId: 'pin-late-1',
+			userName: 'Late',
+		});
+		emitJoin(lateJoiner, { userId: 'pin-late-1', name: 'Late' });
+		await new Promise((r) => setImmediate(r));
+
+		const existing = lateJoiner.emitCalls.find(
+			(c) => c.event === 'existing_pinned_message',
+		);
+		expect(existing).toBeDefined();
+		expect(existing?.data).toEqual({
+			pinned: {
+				messageId,
+				message: 'pinned greeting',
+				fromUser: 'pin-host-3',
+				fromName: 'PinHost3',
+				timestamp: expect.any(String),
+			},
+		});
 	});
 
 	it('raise_hand round-trip: raised:true stores timestamp and broadcasts, raised:false clears the entry and broadcasts with raised:false', async () => {

--- a/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
@@ -1364,6 +1364,18 @@ describe('SocketHandlerManager characterization', () => {
 		});
 
 		participant.emitCalls.length = 0;
+		host.fire(
+			'chat:pin',
+			{ messageId, action: 'pin', encryptedMessage: 'e2ee:refreshed' },
+			pinCallback,
+		);
+		expect(participant.emitCalls.at(-1)?.data).toEqual({
+			pinned: expect.objectContaining({
+				messageId,
+				message: 'e2ee:refreshed',
+			}),
+		});
+		participant.emitCalls.length = 0;
 		const secondSendCallback = vi.fn();
 		host.fire('chat:send', { message: 'pin me too' }, secondSendCallback);
 		const secondMessageId = secondSendCallback.mock.calls[0]?.[0]

--- a/suite/meet/sfu-server/src/server/handlers/ChatHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/ChatHandlers.ts
@@ -114,13 +114,18 @@ export function registerChatHandlers(deps: HandlerDeps) {
 
 				const messageId =
 					typeof data?.messageId === 'string' ? data.messageId : '';
-				if (!messageId) {
+				const action = data?.action;
+				if (!messageId || (action !== 'pin' && action !== 'unpin')) {
 					callback?.({ success: false, error: 'Invalid chat message' });
 					return;
 				}
 
 				const existing = deps.registry.getPinnedChatMessage(roomId);
-				if (existing?.messageId === messageId) {
+				if (action === 'unpin') {
+					if (existing?.messageId !== messageId) {
+						callback?.({ success: true });
+						return;
+					}
 					deps.registry.setPinnedChatMessage(roomId, null);
 					deps.registry.emitToFullAccessParticipants(
 						roomId,
@@ -129,6 +134,10 @@ export function registerChatHandlers(deps: HandlerDeps) {
 							pinned: null,
 						},
 					);
+					callback?.({ success: true });
+					return;
+				}
+				if (existing?.messageId === messageId) {
 					callback?.({ success: true });
 					return;
 				}

--- a/suite/meet/sfu-server/src/server/handlers/ChatHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/ChatHandlers.ts
@@ -4,10 +4,13 @@ import type { ChatMessage, PinnedChatMessage } from '../../types';
 import { loggers } from '../../utils/logger';
 import type { HandlerDeps } from './Handler';
 
-function toPinnedChatMessage(message: ChatMessage): PinnedChatMessage {
+function toPinnedChatMessage(
+	message: ChatMessage,
+	content = message.message,
+): PinnedChatMessage {
 	return {
 		messageId: message.messageId,
-		message: message.message,
+		message: content,
 		fromUser: message.fromUser,
 		fromName: message.fromName,
 		timestamp: message.timestamp,
@@ -137,7 +140,10 @@ export function registerChatHandlers(deps: HandlerDeps) {
 					callback?.({ success: true });
 					return;
 				}
-				if (existing?.messageId === messageId) {
+				if (
+					existing?.messageId === messageId &&
+					typeof data.encryptedMessage !== 'string'
+				) {
 					callback?.({ success: true });
 					return;
 				}
@@ -151,7 +157,11 @@ export function registerChatHandlers(deps: HandlerDeps) {
 					return;
 				}
 
-				const pinned = toPinnedChatMessage(message);
+				const encryptedMessage =
+					typeof data.encryptedMessage === 'string'
+						? data.encryptedMessage
+						: message.message;
+				const pinned = toPinnedChatMessage(message, encryptedMessage);
 				deps.registry.setPinnedChatMessage(roomId, pinned);
 				deps.registry.emitToFullAccessParticipants(roomId, 'chat:pin_updated', {
 					pinned,

--- a/suite/meet/sfu-server/src/server/handlers/ChatHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/ChatHandlers.ts
@@ -1,7 +1,18 @@
+import { randomUUID } from 'node:crypto';
 import type { Socket } from 'socket.io';
-import type { ChatMessage } from '../../types';
+import type { ChatMessage, PinnedChatMessage } from '../../types';
 import { loggers } from '../../utils/logger';
 import type { HandlerDeps } from './Handler';
+
+function toPinnedChatMessage(message: ChatMessage): PinnedChatMessage {
+	return {
+		messageId: message.messageId,
+		message: message.message,
+		fromUser: message.fromUser,
+		fromName: message.fromName,
+		timestamp: message.timestamp,
+	};
+}
 
 export function registerChatHandlers(deps: HandlerDeps) {
 	return (socket: Socket) => {
@@ -61,14 +72,20 @@ export function registerChatHandlers(deps: HandlerDeps) {
 
 				const payload: ChatMessage = {
 					roomId,
+					messageId: randomUUID(),
 					message: text,
 					fromUser: socket.participantId,
 					fromName: socket.userName,
 					timestamp: new Date().toISOString(),
 				};
 				if (data.clientId) payload.clientId = String(data.clientId);
-				callback?.({ success: true, timestamp: payload.timestamp });
+				callback?.({
+					success: true,
+					timestamp: payload.timestamp,
+					messageId: payload.messageId,
+				});
 
+				deps.registry.recordChatMessage(roomId, payload);
 				deps.registry.emitPublicChat(roomId, payload);
 			} catch (e) {
 				callback?.({
@@ -77,6 +94,67 @@ export function registerChatHandlers(deps: HandlerDeps) {
 				});
 				loggers.socketHandler.warn(
 					'chat:send handling failed: %s',
+					(e as Error).message || e,
+				);
+			}
+		});
+
+		socket.on('chat:pin', (data, callback) => {
+			try {
+				deps.authManager.ensureFullAccess(socket);
+				const roomId = socket.roomId;
+
+				if (!roomId || (!socket.isHost && !socket.isCohost)) {
+					callback?.({
+						success: false,
+						error: 'Only hosts and co-hosts can pin messages',
+					});
+					return;
+				}
+
+				const messageId =
+					typeof data?.messageId === 'string' ? data.messageId : '';
+				if (!messageId) {
+					callback?.({ success: false, error: 'Invalid chat message' });
+					return;
+				}
+
+				const existing = deps.registry.getPinnedChatMessage(roomId);
+				if (existing?.messageId === messageId) {
+					deps.registry.setPinnedChatMessage(roomId, null);
+					deps.registry.emitToFullAccessParticipants(
+						roomId,
+						'chat:pin_updated',
+						{
+							pinned: null,
+						},
+					);
+					callback?.({ success: true });
+					return;
+				}
+
+				const message = deps.registry.getRecentChatMessage(roomId, messageId);
+				if (!message) {
+					callback?.({
+						success: false,
+						error: 'Message is no longer available to pin',
+					});
+					return;
+				}
+
+				const pinned = toPinnedChatMessage(message);
+				deps.registry.setPinnedChatMessage(roomId, pinned);
+				deps.registry.emitToFullAccessParticipants(roomId, 'chat:pin_updated', {
+					pinned,
+				});
+				callback?.({ success: true });
+			} catch (e) {
+				callback?.({
+					success: false,
+					error: (e as Error).message || String(e),
+				});
+				loggers.socketHandler.warn(
+					'chat:pin handling failed: %s',
 					(e as Error).message || e,
 				);
 			}

--- a/suite/meet/sfu-server/src/server/handlers/RoomJoinHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/RoomJoinHandlers.ts
@@ -115,6 +115,13 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 				hands: deps.registry.getRaisedHands(scopedRoomId),
 			});
 
+			if (socket.scope === 'full') {
+				const pinned = deps.registry.getPinnedChatMessage(scopedRoomId);
+				if (pinned) {
+					socket.emit('existing_pinned_message', { pinned });
+				}
+			}
+
 			if (socket.scope === 'full' && !socket.e2eeRequired) {
 				const roomPolls = deps.registry.getActivePolls(scopedRoomId);
 				if (roomPolls && roomPolls.size > 0) {

--- a/suite/meet/sfu-server/src/types/index.ts
+++ b/suite/meet/sfu-server/src/types/index.ts
@@ -38,6 +38,7 @@ import type {
 	ParticipantInfo,
 	ParticipantJoinedEvent,
 	ParticipantLeftEvent,
+	PinnedChatMessage,
 	PreviewParticipantInfo,
 	ProducerCloseDetails,
 	ProducerClosedEvent,
@@ -87,6 +88,7 @@ export type {
 	ParticipantInfo,
 	ParticipantJoinedEvent,
 	ParticipantLeftEvent,
+	PinnedChatMessage,
 	PlainTransport,
 	PreviewParticipantInfo,
 	Producer,
@@ -135,6 +137,8 @@ export interface ServerToClientEvents {
 	screen_share_stopped: (data: ScreenShareStoppedEvent) => void;
 	'chat:message': (data: ChatMessage) => void;
 	'chat:restriction_updated': (data: { enabled: boolean }) => void;
+	'chat:pin_updated': (data: { pinned: PinnedChatMessage | null }) => void;
+	existing_pinned_message: (data: { pinned: PinnedChatMessage | null }) => void;
 	'reaction:message': (data: ReactionMessage) => void;
 	'poll:new': (data: PollPayloadFE) => void;
 	'poll:update': (data: PollPayloadFE) => void;
@@ -233,9 +237,15 @@ export interface ClientToServerEvents {
 	screen_share: (data: ScreenShareRequest) => void;
 	'chat:send': (
 		data: ChatSendRequest,
-		callback?: (response: SFUResponse & { timestamp?: string }) => void,
+		callback?: (
+			response: SFUResponse & { timestamp?: string; messageId?: string },
+		) => void,
 	) => void;
 	'chat:toggle_restriction': (data: { enabled: boolean }) => void;
+	'chat:pin': (
+		data: { messageId: string },
+		callback?: (response: SFUResponse) => void,
+	) => void;
 	'poll:create': (
 		data: {
 			question: string;

--- a/suite/meet/sfu-server/src/types/index.ts
+++ b/suite/meet/sfu-server/src/types/index.ts
@@ -243,7 +243,11 @@ export interface ClientToServerEvents {
 	) => void;
 	'chat:toggle_restriction': (data: { enabled: boolean }) => void;
 	'chat:pin': (
-		data: { messageId: string; action: 'pin' | 'unpin' },
+		data: {
+			messageId: string;
+			action: 'pin' | 'unpin';
+			encryptedMessage?: string;
+		},
 		callback?: (response: SFUResponse) => void,
 	) => void;
 	'poll:create': (

--- a/suite/meet/sfu-server/src/types/index.ts
+++ b/suite/meet/sfu-server/src/types/index.ts
@@ -243,7 +243,7 @@ export interface ClientToServerEvents {
 	) => void;
 	'chat:toggle_restriction': (data: { enabled: boolean }) => void;
 	'chat:pin': (
-		data: { messageId: string },
+		data: { messageId: string; action: 'pin' | 'unpin' },
 		callback?: (response: SFUResponse) => void,
 	) => void;
 	'poll:create': (

--- a/suite/meet/types/index.ts
+++ b/suite/meet/types/index.ts
@@ -99,11 +99,20 @@ export interface ScreenShareData {
 
 export interface ChatMessage {
 	roomId: string;
+	messageId: string;
 	message: string;
 	fromUser: string;
 	fromName: string;
 	timestamp: string;
 	clientId?: string;
+}
+
+export interface PinnedChatMessage {
+	messageId: string;
+	message: string;
+	fromUser: string;
+	fromName: string;
+	timestamp: string;
 }
 
 export interface ReactionMessage {


### PR DESCRIPTION
Allow hosts and co-hosts to pin chat messages for everyone in a Meet room. Pinned messages are synchronized with late joiners and remain compatible with encrypted chat.

https://github.com/user-attachments/assets/b597f870-8fac-4cbb-9e2a-ea42ee8d3439


