### PR TITLE
fix(mail): improve Outbox usability on mobile

### DIFF
--- a/frontend/src/apps/mail/components/mobile/MobileTitleHeader.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileTitleHeader.vue
@@ -1,9 +1,9 @@
 <template>
 	<!-- Shared mobile title row (mailbox / all inboxes / screener / profile): 2xl
-	     semibold title, optional xs count, optional folder-sheet hamburger, actions
-	     slot on the right. Without the hamburger the title gets pl-4 (4px row + 16px =
-	     20px) to sit on the px-5 axis of the list content below it; with it,
-	     the button's own inset provides the offset. -->
+	     semibold title, optional xs count, optional folder-sheet hamburger or back
+	     button, actions slot on the right. Without a leading button the title gets
+	     pl-4 (4px row + 16px = 20px) to sit on the px-5 axis of the list content
+	     below it; with one, the button's own inset provides the offset. -->
 	<!-- A flat h-14 (56px), not a min-height and no vertical padding: the row is the same
 	     height in every view and `items-center` centres against the whole of it. Anything
 	     taller than 56px in the actions slot would overflow rather than grow the row —
@@ -17,7 +17,18 @@
 		>
 			<Menu :size="18" />
 		</button>
-		<div class="flex min-w-0 flex-1 items-baseline gap-2" :class="{ 'pl-4': !withMenu }">
+		<button
+			v-else-if="withBack"
+			:aria-label="__('Back')"
+			class="text-ink-gray-6 flex h-10 w-10 shrink-0 items-center justify-center rounded-full"
+			@click="emit('back')"
+		>
+			<ChevronLeft :size="18" />
+		</button>
+		<div
+			class="flex min-w-0 flex-1 items-baseline gap-2"
+			:class="{ 'pl-4': !withMenu && !withBack }"
+		>
 			<span class="truncate text-2xl !font-semibold tracking-[-0.01em]">{{ title }}</span>
 			<span v-if="count" class="text-ink-gray-5 shrink-0 text-xs !font-medium">{{ count }}</span>
 		</div>
@@ -26,7 +37,7 @@
 </template>
 
 <script setup lang="ts">
-import { Menu } from 'lucide-vue-next'
+import { ChevronLeft, Menu } from 'lucide-vue-next'
 
 import { useFolderSheet } from '@/apps/mail/utils/composables'
 
@@ -34,7 +45,10 @@ defineProps<{
 	title: string
 	count?: string
 	withMenu?: boolean
+	withBack?: boolean
 }>()
+
+const emit = defineEmits<{ back: [] }>()
 
 const { openFolderSheet } = useFolderSheet()
 </script>

--- a/frontend/src/apps/mail/pages/OutboxView.vue
+++ b/frontend/src/apps/mail/pages/OutboxView.vue
@@ -256,6 +256,9 @@ const refresh = async () => {
 	// Refreshes can overlap (poll + socket + post-action); a response may only apply if
 	// it's newer than the last one applied — comparing against the latest *started*
 	// instead would let a newer refresh that failed suppress an older success.
+	// seq is taken in the same synchronous block that starts the fetches (the depth
+	// retry below re-enters and takes a fresh one), so seq order is fetch-start order:
+	// an applied snapshot is only ever replaced by one whose fetches began later.
 	const seq = ++refreshSeq
 	const pages = Math.max(loadedPages.value, 1)
 	try {

--- a/frontend/src/apps/mail/pages/OutboxView.vue
+++ b/frontend/src/apps/mail/pages/OutboxView.vue
@@ -250,18 +250,21 @@ const loadMore = async () => {
 /** Background refresh: refetches every loaded page and swaps the rows in place, so the
  * periodic poll, socket events, and post-action reloads never flash the skeleton. */
 let refreshSeq = 0
+let appliedRefreshSeq = 0
 const refresh = async () => {
 	const token = fetchToken
-	// Refreshes can overlap (poll + socket + post-action); only the latest-started one
-	// may apply, or an older response finishing last would restore staler rows.
+	// Refreshes can overlap (poll + socket + post-action); a response may only apply if
+	// it's newer than the last one applied — comparing against the latest *started*
+	// instead would let a newer refresh that failed suppress an older success.
 	const seq = ++refreshSeq
 	const pages = Math.max(loadedPages.value, 1)
 	try {
 		const results = await Promise.all(Array.from({ length: pages }, (_, i) => fetchPage(i + 1)))
-		if (token !== fetchToken || seq !== refreshSeq) return
+		if (token !== fetchToken || seq <= appliedRefreshSeq) return
 		// loadMore appended a page while this refetch was in flight — applying the
 		// shallower snapshot would drop it, so refetch at the new depth instead.
 		if (Math.max(loadedPages.value, 1) !== pages) return refresh()
+		appliedRefreshSeq = seq
 		rows.value = dedupeById(results.flatMap((data) => data.rows))
 		total.value = results[results.length - 1].total
 		loadedPages.value = pages

--- a/frontend/src/apps/mail/pages/OutboxView.vue
+++ b/frontend/src/apps/mail/pages/OutboxView.vue
@@ -249,12 +249,16 @@ const loadMore = async () => {
 
 /** Background refresh: refetches every loaded page and swaps the rows in place, so the
  * periodic poll, socket events, and post-action reloads never flash the skeleton. */
+let refreshSeq = 0
 const refresh = async () => {
 	const token = fetchToken
+	// Refreshes can overlap (poll + socket + post-action); only the latest-started one
+	// may apply, or an older response finishing last would restore staler rows.
+	const seq = ++refreshSeq
 	const pages = Math.max(loadedPages.value, 1)
 	try {
 		const results = await Promise.all(Array.from({ length: pages }, (_, i) => fetchPage(i + 1)))
-		if (token !== fetchToken) return
+		if (token !== fetchToken || seq !== refreshSeq) return
 		// loadMore appended a page while this refetch was in flight — applying the
 		// shallower snapshot would drop it, so refetch at the new depth instead.
 		if (Math.max(loadedPages.value, 1) !== pages) return refresh()

--- a/frontend/src/apps/mail/pages/OutboxView.vue
+++ b/frontend/src/apps/mail/pages/OutboxView.vue
@@ -255,6 +255,9 @@ const refresh = async () => {
 	try {
 		const results = await Promise.all(Array.from({ length: pages }, (_, i) => fetchPage(i + 1)))
 		if (token !== fetchToken) return
+		// loadMore appended a page while this refetch was in flight — applying the
+		// shallower snapshot would drop it, so refetch at the new depth instead.
+		if (Math.max(loadedPages.value, 1) !== pages) return refresh()
 		rows.value = dedupeById(results.flatMap((data) => data.rows))
 		total.value = results[results.length - 1].total
 		loadedPages.value = pages

--- a/frontend/src/apps/mail/pages/OutboxView.vue
+++ b/frontend/src/apps/mail/pages/OutboxView.vue
@@ -6,23 +6,23 @@
 			<MobileTitleHeader v-if="isMobile" class="min-w-0 flex-1" :title="__('Outbox')" />
 			<!-- -ml-0.5 cancels the crumb's own padding so the title sits on the px-5 axis -->
 			<Breadcrumbs v-else :items="[{ label: __('Outbox') }]" class="-ml-0.5" />
-			<HeaderActions @reload-mails="submissions.reload()" />
+			<HeaderActions @reload-mails="refresh()" />
 		</header>
 
 		<OutboxFilters :filters="filters" />
 
-		<div class="flex-1 overflow-y-auto px-3 py-2.5 sm:px-5">
-			<ListView
-				v-if="submissions.data && !refetching"
-				class="flex-1"
-				:columns="LIST_COLUMNS"
-				:rows="rows"
-				:options="listOptions"
-				row-key="id"
-			>
-				<ListHeader />
-				<ListRows>
-					<template v-if="rows.length">
+		<div class="flex-1 overflow-y-auto px-3 py-2.5 sm:px-5" @scroll.passive="onScroll">
+			<template v-if="!refetching">
+				<ListView
+					v-if="rows.length"
+					class="flex-1"
+					:columns="LIST_COLUMNS"
+					:rows="rows"
+					:options="listOptions"
+					row-key="id"
+				>
+					<ListHeader />
+					<ListRows>
 						<ListRow
 							v-for="row in rows"
 							:key="row.id"
@@ -78,21 +78,20 @@
 								</div>
 							</ListRowItem>
 						</ListRow>
-					</template>
-					<ListEmptyState v-else />
-				</ListRows>
-			</ListView>
+					</ListRows>
+				</ListView>
+				<!-- Outside the ListView: its horizontally scrolling body would center this
+				within the full (off-screen) table width on narrow viewports. -->
+				<div v-else class="flex h-full flex-col items-center justify-center px-4 text-center">
+					<div class="text-2xl-medium text-ink-gray-8">{{ emptyState.title }}</div>
+					<div class="text-ink-gray-5 mt-1 text-base">{{ emptyState.description }}</div>
+				</div>
+				<div v-if="loadingMore" class="flex justify-center py-3">
+					<LoadingIndicator class="text-ink-gray-5 h-4 w-4" />
+				</div>
+			</template>
 			<DashboardListSkeleton v-else :columns="4" />
 		</div>
-
-		<DashboardPager
-			v-if="submissions.data && !refetching"
-			class="border-t px-3 sm:px-5"
-			:page="page"
-			:page-length="PAGE_LENGTH"
-			:total="total"
-			@update:page="(p: number) => (page = p)"
-		/>
 
 		<ScheduleSendModal
 			v-model="showReschedule"
@@ -109,26 +108,20 @@
 <script setup lang="ts">
 import { computed, inject, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { watchDebounced } from '@vueuse/core'
-import {
-	CalendarClock,
-	EllipsisVertical,
-	Mail,
-	RefreshCw,
-	SendHorizontal,
-	X,
-} from 'lucide-vue-next'
+import { useDebounceFn, watchDebounced } from '@vueuse/core'
+import { EllipsisVertical, Mail } from 'lucide-vue-next'
 import {
 	Badge,
 	Breadcrumbs,
 	Button,
 	Dialog,
-	ListEmptyState,
 	ListHeader,
 	ListRow,
 	ListRowItem,
 	ListRows,
 	ListView,
+	LoadingIndicator,
+	call,
 	createResource,
 	usePageMeta,
 } from 'frappe-ui'
@@ -140,6 +133,7 @@ import {
 	deliveryErrorTitle,
 	emptySubmissionFilters,
 	subjectLabel,
+	submissionActions,
 	undoStatusLabel,
 	undoStatusTheme,
 	type Submission,
@@ -149,7 +143,6 @@ import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
 import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
-import DashboardPager from '@/apps/mail/components/DashboardPager.vue'
 import HeaderActions from '@/apps/mail/components/HeaderActions.vue'
 import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
 import OutboxFilters from '@/apps/mail/components/OutboxFilters.vue'
@@ -180,15 +173,24 @@ const hasActiveFilters = computed(() => activeSubmissionFilterCount(filters) > 0
 // waits on the skeleton until the server responds — unlike the background refreshes below,
 // which keep the rows in place. Without this, switching tabs while the previous result was
 // empty flashes the (wrong) empty state before the response arrives.
-const refetching = ref(false)
+const refetching = ref(true)
 
+// The rest of the user-facing Mail UI scrolls instead of paging, so the Outbox does too:
+// scrolling near the bottom appends the next page; background refreshes refetch every
+// loaded page and swap the rows in place.
 const PAGE_LENGTH = 50
-const page = ref(1)
+const rows = ref<Submission[]>([])
+const total = ref(0)
+const loadedPages = ref(0)
+const loadingMore = ref(false)
+const hasMore = computed(() => rows.value.length < total.value)
 
-const submissions = createResource({
-	url: 'suite.mail.api.scheduled.get_submissions',
-	auto: true,
-	makeParams: () => ({
+// Bumped by restart(); an in-flight response from an older cycle must not land on the
+// newer query's rows.
+let fetchToken = 0
+
+const fetchPage = (page: number) =>
+	call('suite.mail.api.scheduled.get_submissions', {
 		account: store.accountId,
 		undo_status: filters.undoStatus,
 		identity_id: filters.identityId || undefined,
@@ -198,47 +200,90 @@ const submissions = createResource({
 		// instants that day spans.
 		after: filters.after ? utcDayStart(filters.after) : undefined,
 		before: filters.before ? utcDayEnd(filters.before) : undefined,
-		page: page.value,
+		page,
 		page_length: PAGE_LENGTH,
-	}),
-	onSuccess: () => (refetching.value = false),
-	onError: (error: { message?: string }) => {
-		refetching.value = false
-		raiseToast(error.message || __('Request failed.'), 'error')
-	},
-})
+	}) as Promise<{ rows: Submission[]; total: number }>
 
-const applyFilters = () => {
+const onFetchError = (error: { messages?: string[]; message?: string }) =>
+	raiseToast(error.messages?.[0] || error.message || __('Request failed.'), 'error')
+
+// Rows can shift between pages while loading (another client schedules or cancels), so
+// every merge drops ids already present.
+const dedupeById = (merged: Submission[]) => {
+	const seen = new Set<string>()
+	return merged.filter((row) => !seen.has(row.id) && (seen.add(row.id), true))
+}
+
+const restart = async () => {
+	const token = ++fetchToken
 	refetching.value = true
-	submissions.reload()
+	try {
+		const data = await fetchPage(1)
+		if (token !== fetchToken) return
+		rows.value = data.rows
+		total.value = data.total
+		loadedPages.value = 1
+	} catch (error) {
+		onFetchError(error as { message?: string })
+	} finally {
+		if (token === fetchToken) refetching.value = false
+	}
 }
 
-// A filter change restarts from the first page; when the page actually moves, its own
-// watcher does the refetch (avoiding a double request).
-const applyFiltersFromStart = () => {
-	if (page.value !== 1) page.value = 1
-	else applyFilters()
+const loadMore = async () => {
+	if (loadingMore.value || refetching.value || !hasMore.value) return
+	const token = fetchToken
+	loadingMore.value = true
+	try {
+		const data = await fetchPage(loadedPages.value + 1)
+		if (token !== fetchToken) return
+		rows.value = dedupeById([...rows.value, ...data.rows])
+		total.value = data.total
+		loadedPages.value += 1
+	} catch (error) {
+		onFetchError(error as { message?: string })
+	} finally {
+		loadingMore.value = false
+	}
 }
 
-watch(page, applyFilters)
+/** Background refresh: refetches every loaded page and swaps the rows in place, so the
+ * periodic poll, socket events, and post-action reloads never flash the skeleton. */
+const refresh = async () => {
+	const token = fetchToken
+	const pages = Math.max(loadedPages.value, 1)
+	try {
+		const results = await Promise.all(Array.from({ length: pages }, (_, i) => fetchPage(i + 1)))
+		if (token !== fetchToken) return
+		rows.value = dedupeById(results.flatMap((data) => data.rows))
+		total.value = results[results.length - 1].total
+		loadedPages.value = pages
+	} catch (error) {
+		onFetchError(error as { message?: string })
+	}
+}
+
+const onScroll = useDebounceFn((e: Event) => {
+	const { scrollTop, scrollHeight, clientHeight } = e.target as HTMLElement
+	if (scrollTop + clientHeight >= scrollHeight - 100) loadMore()
+}, 200)
+
+restart()
+
 watch(
 	() => store.accountId,
-	() => store.accountId && applyFiltersFromStart(),
+	() => store.accountId && restart(),
 )
 
 // The id filters are typed; the rest change atomically.
-watchDebounced(() => [filters.emailId, filters.threadId], applyFiltersFromStart, { debounce: 300 })
-watch(
-	() => [filters.undoStatus, filters.identityId, filters.after, filters.before],
-	applyFiltersFromStart,
-)
+watchDebounced(() => [filters.emailId, filters.threadId], restart, { debounce: 300 })
+watch(() => [filters.undoStatus, filters.identityId, filters.after, filters.before], restart)
 
 // Kept current the way mailboxes are — a periodic poll (holds release, retries advance, and
 // other clients schedule/cancel without any local signal) plus the new-mail socket (an undo
-// or schedule cancel publishes it). reload() keeps the previous rows while fetching, so the
-// list never flickers back to the skeleton.
+// or schedule cancel publishes it).
 const reloadInterval = ref<ReturnType<typeof setInterval>>()
-const onNewMail = () => submissions.reload()
+const onNewMail = () => refresh()
 
 onMounted(() => {
 	reloadInterval.value = setInterval(onNewMail, 30000)
@@ -249,9 +294,6 @@ onUnmounted(() => {
 	if (reloadInterval.value) clearInterval(reloadInterval.value)
 	socket.off('new_mail_created', onNewMail)
 })
-
-const rows = computed<Submission[]>(() => submissions.data?.rows || [])
-const total = computed<number>(() => submissions.data?.total || 0)
 
 const recipientLabel = (row: Submission) => {
 	const emails = [
@@ -288,7 +330,7 @@ const EMPTY_STATES: Record<SubmissionFilters['undoStatus'], { title: string; des
 		},
 	}
 
-const listOptions = computed(() => ({
+const listOptions = {
 	showTooltip: false,
 	selectable: false,
 	rowHeight: 50,
@@ -298,13 +340,13 @@ const listOptions = computed(() => ({
 		name: 'mail-submission',
 		params: { accountId: store.accountId, submissionId: row.id },
 	}),
-	emptyState: hasActiveFilters.value
-		? {
-				title: __('No matching submissions'),
-				description: __('Try adjusting the filters.'),
-			}
+}
+
+const emptyState = computed(() =>
+	hasActiveFilters.value
+		? { title: __('No matching submissions'), description: __('Try adjusting the filters.') }
 		: EMPTY_STATES[filters.undoStatus],
-}))
+)
 
 // A held message sits in Sent until delivery, so its thread opens there.
 const openEmail = (row: Submission) => {
@@ -320,44 +362,22 @@ const openEmail = (row: Submission) => {
 }
 
 const rowOptions = (row: Submission) => {
-	const open = (dialog?: { value: boolean }, submit?: { submit: () => void }) => () => {
+	// Every handler targets this row: `selected` must be set before dialogs read it
+	// and before the resources build their params.
+	const act = (fn: () => void) => () => {
 		selected.value = row
-		if (dialog) dialog.value = true
-		submit?.submit()
+		fn()
 	}
 
-	if (row.status === 'failed') {
-		const retry = { label: __('Send again'), icon: RefreshCw, onClick: open(showRetry) }
-		const dismiss = { label: __('Remove'), icon: X, onClick: open(undefined, dismissMail) }
-		// A deleted message can't be resubmitted — dropping the failed record is all that's left.
-		return row.email_deleted ? [dismiss] : [retry, dismiss]
-	}
-
-	const cancel = { label: __('Cancel delivery'), icon: X, theme: 'red', onClick: open(showCancel) }
-
-	if (row.status === 'retrying' || row.status === 'queued') {
-		const retry = { label: __('Try again now'), icon: RefreshCw, onClick: open(undefined, retryNow) }
-		// A released delivery stays cancellable for as long as its submission is pending.
-		return row.undo_status === 'pending' ? [retry, cancel] : [retry]
-	}
-
-	if (row.status === 'scheduled') {
-		// A deleted message can't be resubmitted (send now / reschedule recreate the
-		// submission from it) — cancelling the pending delivery is all that's left.
-		if (row.email_deleted) return [cancel]
-
-		return [
-			{ label: __('Send now'), icon: SendHorizontal, onClick: open(showSendNow) },
-			{ label: __('Reschedule'), icon: CalendarClock, onClick: open(showReschedule) },
-			cancel,
-		]
-	}
-
-	// Concluded (sent/delivered/read) or cancelled rows: resubmit and/or drop the record.
-	const remove = { label: __('Remove'), icon: X, onClick: open(undefined, dismissMail) }
-	if (row.status === 'cancelled' || row.email_deleted) return [remove]
-
-	return [{ label: __('Send again'), icon: RefreshCw, onClick: open(showRetry) }, remove]
+	// No openEmail here — the list row keeps its explicit Open-email button.
+	return submissionActions(row, {
+		sendNow: act(() => (showSendNow.value = true)),
+		reschedule: act(() => (showReschedule.value = true)),
+		cancelDelivery: act(() => (showCancel.value = true)),
+		sendAgain: act(() => (showRetry.value = true)),
+		tryAgainNow: act(() => retryNow.submit()),
+		remove: act(() => dismissMail.submit()),
+	})
 }
 
 const openDrafts = () => {
@@ -375,7 +395,7 @@ const onActionError = (error: { messages?: string[]; message?: string }) => {
 	raiseToast(error.messages?.[0] || error.message || __('Request failed.'), 'error')
 	// The action may have failed because the email already went out; reflect the
 	// reconciled state either way.
-	submissions.reload()
+	refresh()
 }
 
 const rescheduleMail = createResource({
@@ -386,7 +406,7 @@ const rescheduleMail = createResource({
 		send_at,
 	}),
 	onSuccess: (data: { send_at: string }) => {
-		submissions.reload()
+		refresh()
 		raiseToast(__('Delivery rescheduled to {0}.', [formatDateTime(data.send_at)]))
 	},
 	onError: onActionError,
@@ -397,7 +417,7 @@ const sendNow = createResource({
 	makeParams: () => ({ account: store.accountId, id: selected.value?.id }),
 	onSuccess: () => {
 		showSendNow.value = false
-		submissions.reload()
+		refresh()
 		raiseToast(__('Message sent.'))
 	},
 	onError: onActionError,
@@ -408,7 +428,7 @@ const retryMail = createResource({
 	makeParams: () => ({ account: store.accountId, id: selected.value?.id }),
 	onSuccess: () => {
 		showRetry.value = false
-		submissions.reload()
+		refresh()
 		raiseToast(__('Message sent.'))
 	},
 	onError: onActionError,
@@ -418,7 +438,7 @@ const retryNow = createResource({
 	url: 'suite.mail.api.scheduled.retry_delivery_now',
 	makeParams: () => ({ account: store.accountId, id: selected.value?.id }),
 	onSuccess: () => {
-		submissions.reload()
+		refresh()
 		raiseToast(__('Delivery attempt scheduled.'))
 	},
 	onError: onActionError,
@@ -427,7 +447,7 @@ const retryNow = createResource({
 const dismissMail = createResource({
 	url: 'suite.mail.api.scheduled.dismiss_failed_mail',
 	makeParams: () => ({ account: store.accountId, id: selected.value?.id }),
-	onSuccess: () => submissions.reload(),
+	onSuccess: () => refresh(),
 	onError: onActionError,
 })
 
@@ -436,7 +456,7 @@ const cancelSchedule = createResource({
 	makeParams: () => ({ account: store.accountId, id: selected.value?.id }),
 	onSuccess: (data: { id?: string }) => {
 		showCancel.value = false
-		submissions.reload()
+		refresh()
 		// No message was moved when the email had been deleted — don't point at Drafts.
 		if (!data.id) return raiseToast(__('Delivery cancelled.'), 'success')
 		raiseToast(

--- a/frontend/src/apps/mail/pages/SubmissionDetailsView.vue
+++ b/frontend/src/apps/mail/pages/SubmissionDetailsView.vue
@@ -3,7 +3,13 @@
 		<header
 			class="flex items-center justify-between gap-2 border-b px-3 py-2.5 max-sm:p-0 sm:px-5"
 		>
-			<MobileTitleHeader v-if="isMobile" class="min-w-0 flex-1" :title="title" />
+			<MobileTitleHeader
+				v-if="isMobile"
+				class="min-w-0 flex-1"
+				:title="title"
+				with-back
+				@back="backToList"
+			/>
 			<!-- -ml-0.5 cancels the crumb's own padding so the title sits on the px-5 axis -->
 			<Breadcrumbs
 				v-else
@@ -13,52 +19,20 @@
 				]"
 				class="-ml-0.5 min-w-0"
 			/>
-			<div v-if="data" class="flex shrink-0 items-center gap-2 max-sm:px-3 max-sm:py-2">
-				<Button v-if="canOpenEmail" :label="__('Open email')" @click="openEmail">
-					<template #prefix><Mail class="h-4 w-4" /></template>
+			<!-- All actions live in one menu (sheet on mobile) so the long subject keeps
+			the header's width instead of a row of buttons. -->
+			<AdaptiveDropdown
+				v-if="actions.length"
+				:options="actions"
+				:title="__('Actions')"
+				placement="bottom-end"
+			>
+				<Button variant="ghost" :title="__('Actions')" class="shrink-0 max-sm:mr-2">
+					<template #icon>
+						<EllipsisVertical class="text-ink-gray-5 h-4 w-4" />
+					</template>
 				</Button>
-				<template v-if="data.status === 'scheduled'">
-					<Button
-						v-if="!data.email_deleted"
-						:label="__('Send now')"
-						@click="showSendNow = true"
-					/>
-					<Button
-						v-if="!data.email_deleted"
-						:label="__('Reschedule')"
-						@click="showReschedule = true"
-					/>
-					<Button theme="red" :label="__('Cancel delivery')" @click="showCancel = true" />
-				</template>
-				<template v-else-if="data.status === 'retrying' || data.status === 'queued'">
-					<Button
-						:label="__('Try again now')"
-						:loading="retryNow.loading"
-						@click="retryNow.submit()"
-					/>
-					<!-- A released delivery stays cancellable while its submission is pending. -->
-					<Button
-						v-if="data.undo_status === 'pending'"
-						theme="red"
-						:label="__('Cancel delivery')"
-						@click="showCancel = true"
-					/>
-				</template>
-				<!-- Failed, concluded (sent/delivered/read), or cancelled: the submission is done —
-				it can be resubmitted (when its message still exists) and its record dropped. -->
-				<template v-else>
-					<Button
-						v-if="!data.email_deleted && data.status !== 'cancelled'"
-						:label="__('Send again')"
-						@click="showRetry = true"
-					/>
-					<Button
-						:label="__('Remove')"
-						:loading="dismissMail.loading"
-						@click="dismissMail.submit()"
-					/>
-				</template>
-			</div>
+			</AdaptiveDropdown>
 		</header>
 
 		<div v-if="data" class="flex-1 overflow-y-auto px-3 py-4 sm:px-5">
@@ -189,7 +163,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { Mail } from 'lucide-vue-next'
+import { EllipsisVertical } from 'lucide-vue-next'
 import {
 	Badge,
 	Breadcrumbs,
@@ -204,6 +178,7 @@ import { raiseToast } from '@/apps/mail/utils'
 import { formatDateTime, fromNow } from '@/apps/mail/utils/datetime'
 import {
 	subjectLabel,
+	submissionActions,
 	undoStatusLabel,
 	undoStatusTheme,
 	type RecipientState,
@@ -211,6 +186,7 @@ import {
 } from '@/apps/mail/utils/submission'
 import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
+import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
 import DashboardCard from '@/apps/mail/components/DashboardCard.vue'
 import InformationField from '@/apps/mail/components/InformationField.vue'
 import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
@@ -265,9 +241,18 @@ const title = computed(() => (data.value ? subjectLabel(data.value) : ''))
 
 usePageMeta(() => ({ title: title.value || __('Outbox') }))
 
-const canOpenEmail = computed(
-	() => !!data.value && !data.value.email_deleted && !!data.value.thread_id,
-)
+const actions = computed(() => {
+	if (!data.value) return []
+	return submissionActions(data.value, {
+		openEmail,
+		sendNow: () => (showSendNow.value = true),
+		reschedule: () => (showReschedule.value = true),
+		cancelDelivery: () => (showCancel.value = true),
+		sendAgain: () => (showRetry.value = true),
+		tryAgainNow: () => retryNow.submit(),
+		remove: () => dismissMail.submit(),
+	})
+})
 
 const sendAtLabel = computed(() =>
 	data.value?.send_at

--- a/frontend/src/apps/mail/utils/submission.ts
+++ b/frontend/src/apps/mail/utils/submission.ts
@@ -1,6 +1,9 @@
 // Shared shapes and display helpers for EmailSubmission rows — the Outbox list and the
 // submission details page render the same server-derived state.
 
+import type { Component } from 'vue'
+import { CalendarClock, Mail, RefreshCw, SendHorizontal, X } from 'lucide-vue-next'
+
 // The submission's merged delivery state, worst recipient wins: 'queued' is a released
 // delivery the MTA hasn't concluded yet, 'retrying' one that failed temporarily and waits
 // for its next attempt, 'sent' relayed with no delivery confirmation, 'displayed' one whose
@@ -128,3 +131,70 @@ export const deliveryErrorTitle = (row: Submission) =>
 
 export const subjectLabel = (row: Submission) =>
 	row.email_deleted ? __('(Message deleted)') : row.subject || __('(No subject)')
+
+export type SubmissionAction = {
+	label: string
+	icon: Component
+	theme?: string
+	onClick: () => void
+}
+
+export type SubmissionActionHandlers = {
+	/** When provided, "Open email" leads the menu (for submissions whose message still exists). */
+	openEmail?: () => void
+	sendNow: () => void
+	reschedule: () => void
+	cancelDelivery: () => void
+	sendAgain: () => void
+	tryAgainNow: () => void
+	remove: () => void
+}
+
+/**
+ * The actions a submission's state offers, as dropdown options — shared by the Outbox
+ * list rows and the details page header so the two menus never drift apart.
+ */
+export const submissionActions = (
+	row: Submission,
+	on: SubmissionActionHandlers,
+): SubmissionAction[] => {
+	const openEmail =
+		on.openEmail && !row.email_deleted && row.thread_id
+			? [{ label: __('Open email'), icon: Mail, onClick: on.openEmail }]
+			: []
+	const sendAgain = { label: __('Send again'), icon: RefreshCw, onClick: on.sendAgain }
+	const remove = { label: __('Remove'), icon: X, onClick: on.remove }
+	const cancel = {
+		label: __('Cancel delivery'),
+		icon: X,
+		theme: 'red',
+		onClick: on.cancelDelivery,
+	}
+
+	// A deleted message can't be resubmitted — dropping the failed record is all that's left.
+	if (row.status === 'failed')
+		return [...openEmail, ...(row.email_deleted ? [] : [sendAgain]), remove]
+
+	if (row.status === 'retrying' || row.status === 'queued') {
+		const retry = { label: __('Try again now'), icon: RefreshCw, onClick: on.tryAgainNow }
+		// A released delivery stays cancellable for as long as its submission is pending.
+		return [...openEmail, retry, ...(row.undo_status === 'pending' ? [cancel] : [])]
+	}
+
+	if (row.status === 'scheduled') {
+		// A deleted message can't be resubmitted (send now / reschedule recreate the
+		// submission from it) — cancelling the pending delivery is all that's left.
+		if (row.email_deleted) return [cancel]
+
+		return [
+			...openEmail,
+			{ label: __('Send now'), icon: SendHorizontal, onClick: on.sendNow },
+			{ label: __('Reschedule'), icon: CalendarClock, onClick: on.reschedule },
+			cancel,
+		]
+	}
+
+	// Concluded (sent/delivered/read) or cancelled rows: resubmit and/or drop the record.
+	if (row.status === 'cancelled' || row.email_deleted) return [...openEmail, remove]
+	return [...openEmail, sendAgain, remove]
+}


### PR DESCRIPTION
Fixes several usability issues on the Outbox pages, mostly affecting mobile.

### List view

- **Empty state was clipped on mobile**: the ListView body scrolls horizontally, so the "no submissions" text was centered against the full (off-screen) table width and required scrolling right to read. It now renders outside the ListView, centered in the visible viewport.
- **Pagination → infinite scroll**: the pager was inconsistent with the rest of the user-facing Mail UI. Scrolling near the bottom now appends the next page (deduped by id, since rows can shift while other clients schedule/cancel). The 30s poll, the new-mail socket event, and post-action reloads refetch every loaded page in parallel and swap the rows in place, so scroll position and loaded depth survive background refreshes. Filter/account changes still restart from page 1 behind the skeleton, with a fetch token guarding against stale responses.

### Details view

- **Header actions moved into a dropdown** (desktop and mobile): the row of buttons took nearly the full device width and squeezed the subject out. All actions now live in one `AdaptiveDropdown` (regular dropdown on desktop, bottom sheet on mobile) behind an ellipsis trigger, so long subjects keep the header width and truncate. The action state machine was duplicated between the list rows and this header, so it's extracted into a shared `submissionActions()` builder both pages use.
- **Back button on mobile**: the details page had no way back. `MobileTitleHeader` gains an optional `with-back` prop (styled like the existing folder-sheet hamburger) and the details page uses it to return to the Outbox; desktop keeps the breadcrumb link.

Trade-off: the details page's "Try again now" / "Remove" buttons previously showed a loading spinner; as dropdown items they can't, so feedback comes from the success/error toasts.

All 180 mail frontend unit tests pass.