### PR TITLE
feat(mail): show quota usage in admin dashboard members list

### DIFF
--- a/frontend/src/apps/mail/pages/dashboard/UsersView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/UsersView.vue
@@ -64,6 +64,28 @@
 								:theme="row.enabled ? 'green' : 'gray'"
 							/>
 						</template>
+						<template v-else-if="column.key === 'storage'">
+							<span v-if="!row.quota" class="text-ink-gray-5 text-sm">—</span>
+							<Tooltip v-else :text="storageTooltip(row.quota)">
+								<span v-if="row.quota.unlimited" class="text-ink-gray-5 text-sm">∞</span>
+								<div v-else class="flex items-center gap-2">
+									<div class="bg-surface-gray-4 h-1.5 w-16 shrink-0 rounded-full">
+										<div
+											class="h-full rounded-full"
+											:class="
+												row.quota.used_percentage > 80
+													? 'bg-surface-red-8'
+													: 'bg-surface-gray-10'
+											"
+											:style="{ width: storageBarWidth(row.quota) }"
+										/>
+									</div>
+									<span class="text-ink-gray-5 text-xs">
+										{{ Math.round(row.quota.used_percentage) }}%
+									</span>
+								</div>
+							</Tooltip>
+						</template>
 						<template v-else-if="column.key === 'last_active'">
 							<span class="text-ink-gray-5 text-sm">
 								{{
@@ -99,7 +121,7 @@
 			</template>
 		</ListSelectBanner>
 	</ListView>
-	<DashboardListSkeleton v-else :columns="4" />
+	<DashboardListSkeleton v-else :columns="5" />
 	<Dialog v-model="showEnableMembers" :options="ENABLE_MEMBERS_OPTIONS" />
 	<Dialog v-model="showDisableMembers" :options="DISABLE_MEMBERS_OPTIONS" />
 	<Dialog v-model="showDeleteMembers" :options="DELETE_MEMBERS_OPTIONS" />
@@ -122,13 +144,16 @@ import {
 	ListRows,
 	ListSelectBanner,
 	ListView,
+	Tooltip,
 	createResource,
 } from 'frappe-ui'
 
-import { raiseToast } from '@/apps/mail/utils'
+import { formatBytes, raiseToast } from '@/apps/mail/utils'
 import { fromNow } from '@/apps/mail/utils/datetime'
 import ContactOption from '@/apps/mail/components/Controls/ContactOption.vue'
 import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
+
+import type { QuotaUsage } from '@/apps/mail/types'
 
 type MemberRow = {
 	name: string
@@ -137,7 +162,18 @@ type MemberRow = {
 	last_active?: string | null
 	is_admin: boolean
 	enabled: boolean
+	quota?: QuotaUsage | null
 }
+
+// Members without a personal mail account (or when the mail server is unreachable) have no quota.
+const storageTooltip = (quota: QuotaUsage) =>
+	quota.unlimited
+		? __('{0} used · Unlimited', [formatBytes(quota.used)])
+		: __('{0} of {1} used', [formatBytes(quota.used), formatBytes(quota.total)])
+
+// Hide sub-1% usage entirely: a rounded fill that narrow renders as a misleading dot.
+const storageBarWidth = (quota: QuotaUsage) =>
+	quota.used_percentage < 1 ? '0' : `${quota.used_percentage}%`
 
 
 const search = ref('')
@@ -193,6 +229,7 @@ const LIST_COLUMNS = [
 	{ label: __('User'), key: 'user' },
 	{ label: __('Role'), key: 'role' },
 	{ label: __('Status'), key: 'status' },
+	{ label: __('Storage'), key: 'storage' },
 	{ label: __('Last Active'), key: 'last_active' },
 ]
 

--- a/suite/mail/api/admin.py
+++ b/suite/mail/api/admin.py
@@ -455,14 +455,16 @@ def _attach_quota_usage(users: list[dict]) -> None:
             pluck="name",
         )
     )
-    personal_by_user: dict[str, list[str]] = {}
+    personal_by_user: dict[str, set[str]] = {}
     for row in user_accounts:
         if row.account in personal_accounts:
-            personal_by_user.setdefault(row.user, []).append(row.account)
+            personal_by_user.setdefault(row.user, set()).add(row.account)
 
-    # Mirror get_user_personal_jmap_account: a user with several personal accounts is ambiguous and
-    # resolves to no account, rather than showing quota for an arbitrary mailbox.
-    account_by_user = {user: accounts[0] for user, accounts in personal_by_user.items() if len(accounts) == 1}
+    # Mirror get_user_personal_jmap_account: a user with several distinct personal accounts is
+    # ambiguous and resolves to no account, rather than showing quota for an arbitrary mailbox.
+    account_by_user = {
+        user: next(iter(accounts)) for user, accounts in personal_by_user.items() if len(accounts) == 1
+    }
     if not account_by_user:
         return
 

--- a/suite/mail/api/admin.py
+++ b/suite/mail/api/admin.py
@@ -424,7 +424,52 @@ def get_members(
         # Stored in system time; the API speaks UTC, like every other timestamp it returns.
         user["last_active"] = to_utc_z(user.get("last_active"))
 
+    _attach_quota_usage(users)
+
     return users
+
+
+def _attach_quota_usage(users: list[dict]) -> None:
+    """Adds each member's Stalwart disk-quota usage to their row as ``quota``.
+
+    All accounts are read in one bulk call rather than one per member. ``quota`` stays ``None``
+    for members without a personal account, and for everyone when Stalwart is unreachable — the
+    members list still loads, just without storage figures.
+    """
+
+    for user in users:
+        user["quota"] = None
+
+    if not users:
+        return
+
+    user_accounts = frappe.get_all(
+        "User Account",
+        filters={"user": ("in", [user["name"] for user in users])},
+        fields=["user", "account"],
+    )
+    personal_accounts = set(
+        frappe.get_all(
+            "JMAP Account",
+            filters={"is_personal": True, "name": ("in", [row.account for row in user_accounts])},
+            pluck="name",
+        )
+    )
+    account_by_user = {row.user: row.account for row in user_accounts if row.account in personal_accounts}
+    if not account_by_user:
+        return
+
+    with suppress(Exception):
+        accounts = {
+            account["id"]: account
+            for account in get_account_service().get_all(properties=["id", "quotas", "usedDiskQuota"])
+        }
+        for user in users:
+            if account := accounts.get(account_by_user.get(user["name"])):
+                user["quota"] = _build_quota_usage(
+                    (account.get("quotas") or {}).get("maxDiskQuota") or 0,
+                    account.get("usedDiskQuota") or 0,
+                )
 
 
 def _build_quota_usage(total: int, used: int) -> dict:

--- a/suite/mail/api/admin.py
+++ b/suite/mail/api/admin.py
@@ -455,7 +455,14 @@ def _attach_quota_usage(users: list[dict]) -> None:
             pluck="name",
         )
     )
-    account_by_user = {row.user: row.account for row in user_accounts if row.account in personal_accounts}
+    personal_by_user: dict[str, list[str]] = {}
+    for row in user_accounts:
+        if row.account in personal_accounts:
+            personal_by_user.setdefault(row.user, []).append(row.account)
+
+    # Mirror get_user_personal_jmap_account: a user with several personal accounts is ambiguous and
+    # resolves to no account, rather than showing quota for an arbitrary mailbox.
+    account_by_user = {user: accounts[0] for user, accounts in personal_by_user.items() if len(accounts) == 1}
     if not account_by_user:
         return
 


### PR DESCRIPTION
## Summary

Shows each member's storage quota usage in the Mail Admin Dashboard → Members list, so admins can spot accounts running out of space without opening each member's page.

- **Backend**: `get_members` now attaches a `quota` object per row. Users are mapped to their personal JMAP account, then all Stalwart accounts' `quotas`/`usedDiskQuota` are read in a single bulk call (no per-member round trips), normalized via the existing `_build_quota_usage` helper. If a member has no personal account, or Stalwart is unreachable, `quota` is `null` and the list still loads.
- **Frontend**: new **Storage** column with a compact usage bar + percentage (fill turns red above 80% used, matching the sidebar `QuotaBar` convention), `∞` for unlimited accounts, and `—` when there's no quota data. Exact figures ("1.2 GB of 5 GB used") are shown in a tooltip on hover.
