### PR TITLE
fix(slides): toolbar image uploads failing

### DIFF
--- a/frontend/src/apps/slides/components/Toolbar.vue
+++ b/frontend/src/apps/slides/components/Toolbar.vue
@@ -40,13 +40,14 @@ import { Type, ImagePlus } from 'lucide-vue-next'
 
 import { Tooltip, FileUploader, toast } from 'frappe-ui'
 import { presentationId } from '@/apps/slides/stores/presentation'
-import { addTextElement, addMediaElement } from '@/apps/slides/stores/element'
+import { addTextElement } from '@/apps/slides/stores/element'
 import { allowedImageFileTypes } from '@/apps/slides/utils/constants'
 
 import ShapesDropdown from '@/apps/slides/components/ShapesDropdown.vue'
 import TableDropdown from '@/apps/slides/components/TableDropdown.vue'
 
 import { handleScrollBarWheelEvent } from '@/apps/slides/utils/helpers'
+import { performPostUploadActions } from '@/apps/slides/utils/mediaUploads'
 
 const handleUploadSuccess = (file) => {
 	// file_type is a Drive category ('Image'), not a format; mime_type is what the allowlist speaks
@@ -58,6 +59,6 @@ const handleUploadSuccess = (file) => {
 		error: (data) => 'Upload failed. Please try again.',
 	}
 
-	toast.promise(addMediaElement(file, fileType), toastProps)
+	toast.promise(performPostUploadActions(file, fileType), toastProps)
 }
 </script>

--- a/frontend/src/apps/slides/components/Toolbar.vue
+++ b/frontend/src/apps/slides/components/Toolbar.vue
@@ -49,8 +49,8 @@ import TableDropdown from '@/apps/slides/components/TableDropdown.vue'
 import { handleScrollBarWheelEvent } from '@/apps/slides/utils/helpers'
 
 const handleUploadSuccess = (file) => {
-	const imageTypes = allowedImageFileTypes.map((type) => type.split('/')[1].toUpperCase())
-	const fileType = imageTypes.includes(file.file_type) ? 'image' : 'video'
+	// file_type is a Drive category ('Image'), not a format; mime_type is what the allowlist speaks
+	const fileType = allowedImageFileTypes.includes(file.mime_type) ? 'image' : 'video'
 
 	const toastProps = {
 		loading: file.file_name ? `Uploading: ${file.file_name}` : 'Uploading...',

--- a/frontend/src/apps/slides/utils/mediaUploads.js
+++ b/frontend/src/apps/slides/utils/mediaUploads.js
@@ -9,7 +9,7 @@ const fileUploadHandler = new FileUploadHandler()
 
 export const SLIDES_MEDIA_PARAM = 'slides_media=1'
 
-const performPostUploadActions = async (fileDoc, fileType, targetElement) => {
+export const performPostUploadActions = async (fileDoc, fileType, targetElement) => {
 	if (fileType === 'image') {
 		fileDoc = await getWebPDoc(fileDoc)
 	}

--- a/frontend/src/apps/slides/utils/mediaUploads.js
+++ b/frontend/src/apps/slides/utils/mediaUploads.js
@@ -9,6 +9,8 @@ const fileUploadHandler = new FileUploadHandler()
 
 export const SLIDES_MEDIA_PARAM = 'slides_media=1'
 
+// Images are converted to WebP, so the returned doc replaces the uploaded one.
+// Pass targetElement to swap that element's media instead of adding a new element.
 export const performPostUploadActions = async (fileDoc, fileType, targetElement) => {
 	if (fileType === 'image') {
 		fileDoc = await getWebPDoc(fileDoc)


### PR DESCRIPTION
Drive layer overwrites `File.file_type` with a Drive category (Image, Video, PDF) instead of the file extension frappe puts there, so the toolbar's `imageTypes.includes(file.file_type)` check never matched and every image was classified as a video. `addMediaElement` then pointed a real `<video>` at the JPEG to grab a poster frame, the decode failed, and the user got "Upload failed. Please try again." even though the upload itself returned 200.