### PR TITLE
fix(drive): return search results the caller can actually read

### DIFF
--- a/frontend/src/apps/drive/components/SearchPopup.vue
+++ b/frontend/src/apps/drive/components/SearchPopup.vue
@@ -97,7 +97,7 @@
 <script setup>
 import { Dialog, Avatar, createResource } from 'frappe-ui'
 import { getIconUrl, openEntity } from '@/apps/drive/utils/files'
-import { ref, watch } from 'vue'
+import { onScopeDispose, ref, watch } from 'vue'
 
 import LucideFilePlus2 from '~icons/lucide/file-plus-2'
 import LucideFolderPlus from '~icons/lucide/folder-plus'
@@ -111,6 +111,10 @@ const searchResults = createResource({
   auto: false,
   method: 'POST',
   url: 'suite.drive.api.files.search',
+  // Typing fires this on every keystroke, and the endpoint resolves access one
+  // row at a time - a wide query is the most expensive call in Drive. Wait for
+  // a pause first, as the list resources do.
+  debounce: 300,
 })
 
 watch(search, (val) => {
@@ -119,9 +123,15 @@ watch(search, (val) => {
       query: val,
     })
   } else {
+    // Drop anything still pending, or it lands after the reset and repopulates
+    // the list for a query the user has already backspaced away.
+    searchResults.submit.cancel()
     searchResults.reset()
   }
 })
+
+// A trailing call left in flight fires against a closed dialog.
+onScopeDispose(() => searchResults.submit.cancel())
 </script>
 
 <style scoped>

--- a/frontend/src/apps/drive/components/SearchPopup.vue
+++ b/frontend/src/apps/drive/components/SearchPopup.vue
@@ -127,12 +127,16 @@ watch(search, (val) => {
     // Drop anything still pending, or it lands after the reset and repopulates
     // the list for a query the user has already backspaced away.
     searchResults.submit.cancel()
+    searchResults.abort()
     searchResults.reset()
   }
 })
 
-// A trailing call left in flight fires against a closed dialog.
-onScopeDispose(() => searchResults.submit.cancel())
+// Do not leave queued or in-flight work behind when the dialog closes.
+onScopeDispose(() => {
+  searchResults.submit.cancel()
+  searchResults.abort()
+})
 </script>
 
 <style scoped>

--- a/frontend/src/apps/drive/components/SearchPopup.vue
+++ b/frontend/src/apps/drive/components/SearchPopup.vue
@@ -113,8 +113,9 @@ const searchResults = createResource({
   url: 'suite.drive.api.files.search',
   // Typing fires this on every keystroke, and the endpoint resolves access one
   // row at a time - a wide query is the most expensive call in Drive. Wait for
-  // a pause first, as the list resources do.
-  debounce: 300,
+  // a pause first, as the list resources do. Short enough to still feel
+  // immediate; long enough to coalesce a normal typing burst.
+  debounce: 180,
 })
 
 watch(search, (val) => {

--- a/frontend/src/apps/drive/components/ShortcutsDialog.vue
+++ b/frontend/src/apps/drive/components/ShortcutsDialog.vue
@@ -25,6 +25,7 @@
 <script setup>
 import { Dialog } from 'frappe-ui'
 import { computed } from 'vue'
+import { isApple } from '@/apps/drive/utils/files'
 const props = defineProps({
   modelValue: Boolean,
 })
@@ -41,11 +42,15 @@ const metaKey = computed(() => {
   }
   return 'Meta'
 })
+// Find Files binds Ctrl+K (Windows/Linux) or Cmd+K (Mac) - see
+// `isModKey`/DriveLayout.vue's onKeyDown - which is Ctrl, not the Windows key
+// `metaKey` above documents for the other Meta-only shortcuts below.
+const findFilesKey = computed(() => (isApple() ? '⌘' : 'Ctrl'))
 const shortcutGroups = [
   {
     title: 'General',
     shortcuts: [
-      [[metaKey.value, 'K'], 'Find Files'],
+      [[findFilesKey.value, 'K'], 'Find Files'],
       [[metaKey.value, 'Shift', ','], 'Open Settings'],
     ],
   },

--- a/frontend/src/apps/drive/components/Sidebar.vue
+++ b/frontend/src/apps/drive/components/Sidebar.vue
@@ -27,7 +27,7 @@ import StorageBar from './StorageBar.vue'
 import { Sidebar, SidebarItem } from 'frappe-ui'
 import { notifCount, apps } from '@/apps/drive/resources/permissions'
 import { rootInfo } from '@/apps/drive/resources/files'
-import { dynamicList } from '@/apps/drive/utils/files'
+import { dynamicList, isApple } from '@/apps/drive/utils/files'
 
 import { useCurrentUser, useSessionStore } from '@/boot/session'
 const { fullName: currentUserFullName } = useCurrentUser()
@@ -156,6 +156,7 @@ const sidebarItems = computed(() => {
           label: __('Search'),
           icon: LucideSearch,
           onClick: () => emitter.emit('showSearchPopup', true),
+          suffix: isApple() ? '⌘ + K' : 'Ctrl + K',
         },
         {
           label: __('Notifications'),

--- a/frontend/src/apps/drive/pages/DriveLayout.vue
+++ b/frontend/src/apps/drive/pages/DriveLayout.vue
@@ -50,6 +50,7 @@ import { sidebarCollapsed, shareView } from '@/apps/drive/data/prefs'
 import { onKeyDown, useMediaQuery } from '@vueuse/core'
 import emitter from '@/apps/drive/emitter'
 import { useEmitter } from '@/apps/drive/utils/useEmitter'
+import { isModKey } from '@/apps/drive/utils/files'
 import { initSocket } from '@/apps/drive/socket'
 import { DesktopShell, FrappeUIProvider, MobileShell } from 'frappe-ui'
 import { useRoute } from 'vue-router'
@@ -109,10 +110,15 @@ onKeyDown((e) => {
         e.preventDefault()
       }
     }
-    if (e.key == 'k') {
-      showSearchPopup.value = true
-      e.preventDefault()
-    }
+  }
+
+  // Ctrl+K on Windows/Linux, Cmd+K on Mac - same convention as Mail's search
+  // shortcut (`HeaderActions.vue`). Not nested under the `e.metaKey` branch
+  // above: on Windows/Linux `metaKey` is the literal Windows key, which this
+  // never bound, so Ctrl+K did nothing there until now.
+  if (isModKey(e) && e.key.toLowerCase() == 'k') {
+    showSearchPopup.value = true
+    e.preventDefault()
   }
 })
 </script>

--- a/frontend/src/apps/drive/utils/files.js
+++ b/frontend/src/apps/drive/utils/files.js
@@ -727,7 +727,7 @@ export const newExternal = async (type) => {
   window.location.href = '/writer/w/' + data.name
 }
 
-function isApple() {
+export function isApple() {
   // Pattern borrowed from TinyKeys library.
   // --
   // https://github.com/jamiebuilds/tinykeys/blob/e0d23b4f248af59ffbbe52411505c3d681c73045/src/tinykeys.ts#L50-L54

--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -834,18 +834,21 @@ def move(entity_names: list[str], new_parent: str | None = None):
     return res
 
 
-@frappe.whitelist()
-def search(query: str):
-    """
-    Basic search implementation
-    """
-    text = " ".join(k + "*" for k in query.split())
-    try:
-        result = frappe.db.sql(
-            """
+# `search` resolves access one row at a time, so the rows it scans are not the
+# rows it can return. Walk the match set in windows and keep only what the
+# caller may read, until the page is full or the scan budget is spent.
+SEARCH_PAGE_LENGTH = 50
+SEARCH_SCAN_WINDOW = 100
+MAX_SEARCH_SCAN_WINDOWS = 10
+
+SEARCH_QUERY = """
         SELECT  `tabFile`.name,
                 `tabFile`.file_name,
                 `tabFile`.file_type,
+                `tabFile`.is_folder,
+                `tabFile`.owner,
+                `tabFile`.attached_to_doctype,
+                `tabFile`.attached_to_name,
                 `tabFile`.content_doctype,
                 `tabFile`.content_docname,
                 `tabUser`.name AS user_name,
@@ -857,12 +860,57 @@ def search(query: str):
             AND COALESCE(`tabFile`.`folder`, '') <> ''
             AND MATCH(`tabFile`.file_name) AGAINST (%(text)s IN BOOLEAN MODE)
         GROUP BY `tabFile`.`name`
-        LIMIT 500
-        """,
-            values={"text": text, "status": STATUS_ACTIVE},
-            as_dict=1,
-        )
-        return [r for r in result if user_has_permission(r.name, "read")][:50]
+        ORDER BY MATCH(`tabFile`.file_name) AGAINST (%(text)s IN BOOLEAN MODE) DESC,
+                 `tabFile`.`name` ASC
+        LIMIT %(limit)s OFFSET %(offset)s
+        """
+
+
+@frappe.whitelist()
+def search(query: str):
+    """Search active files by name, returning only rows the caller may read.
+
+    Access cannot be resolved in the query - `file_permission_criterion` does
+    not model inheritance - so it is filtered per row in Python. Filtering a
+    single fixed window that way makes the reply depend on how many *unreadable*
+    rows happen to sort first: a caller shared on few files gets a short page,
+    or an empty one, while matches they can read sit just past the window. Walk
+    successive windows instead, stopping once the page is full.
+    """
+    text = " ".join(k + "*" for k in query.split())
+    if not text:
+        return []
+    try:
+        rows = []
+        seen = set()
+        for window in range(MAX_SEARCH_SCAN_WINDOWS):
+            batch = frappe.db.sql(
+                SEARCH_QUERY,
+                values={
+                    "text": text,
+                    "status": STATUS_ACTIVE,
+                    "limit": SEARCH_SCAN_WINDOW,
+                    "offset": window * SEARCH_SCAN_WINDOW,
+                },
+                as_dict=1,
+            )
+            for row in batch:
+                # A window can overlap the one before it if rows are written
+                # mid-scan; never pay for the same row - or return it - twice.
+                if row.name in seen:
+                    continue
+                seen.add(row.name)
+                # Pass the row, not its name: `user_has_permission` reloads the
+                # whole document when given a string, and the access check only
+                # reads fields this query already selects.
+                if not user_has_permission(row, "read"):
+                    continue
+                rows.append(row)
+                if len(rows) == SEARCH_PAGE_LENGTH:
+                    return rows
+            if len(batch) < SEARCH_SCAN_WINDOW:
+                break
+        return rows
     except Exception as e:
         frappe.log_error(frappe.get_traceback(), "Frappe Drive Search Error")
         return {"error": str(e)}

--- a/suite/drive/api/tests/test_files.py
+++ b/suite/drive/api/tests/test_files.py
@@ -10,6 +10,7 @@ from werkzeug.test import EnvironBuilder
 from werkzeug.wrappers import Request
 
 from suite.drive.api.files import (
+    SEARCH_PAGE_LENGTH,
     create_auth_token,
     does_entity_exist,
     get_file_content,
@@ -17,6 +18,7 @@ from suite.drive.api.files import (
     move,
     remove_or_restore,
     rename,
+    search,
     stream_file_content,
     track_visit,
     update_access,
@@ -767,3 +769,144 @@ class TestDriveFilesAPI(IntegrationTestCase):
             self.assertFalse(does_entity_exist(name=f"{frappe.generate_hash(8)}.txt"))
             self.assertNotEqual(get_new_title(self.file.file_name, self.folder.name), self.file.file_name)
             self.assertEqual(get_new_title("unclaimed.txt", self.folder.name), "unclaimed.txt")
+
+
+class TestDriveSearch(IntegrationTestCase):
+    """`search` resolves access per row, so what it scans and what it returns
+    are different counts. These cover the gap between them."""
+
+    # Enough files to sit past a shrunken scan window several times over.
+    FILE_COUNT = 7
+    # Small enough that the tests can force a multi-window scan without seeding
+    # the hundreds of rows the real window would need.
+    WINDOW = 2
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        ensure_user(OWNER)
+        ensure_user(OTHER_USER)
+        with cls.set_user(OWNER):
+            cls.home = get_user_folder(OWNER).name
+
+    def setUp(self):
+        frappe.flags.mute_drive_activity_log = True
+        # A token no other file on the site can match, so the result set is
+        # exactly what this test seeded.
+        self.token = f"zqx{frappe.generate_hash(10)}"
+        with self.set_user(OWNER):
+            manager = FileManager()
+            self.folder = create_drive_file(
+                frappe.generate_hash(8), self.home, "Folder", lambda file: manager.create_folder(file)
+            )
+            self.files = [
+                create_drive_file(
+                    f"{self.token}{i}.txt",
+                    self.folder.name,
+                    "Text",
+                    f"{self.folder.file_url}{frappe.generate_hash(8)}.txt",
+                    "text/plain",
+                    12,
+                )
+                for i in range(self.FILE_COUNT)
+            ]
+        # InnoDB publishes fulltext rows to the index at commit, so an
+        # uncommitted seed is invisible to MATCH ... AGAINST.
+        frappe.db.commit()
+
+    def tearDown(self):
+        frappe.flags.mute_drive_activity_log = False
+        for file in self.files:
+            frappe.delete_doc("File", file.name, force=True, ignore_permissions=True)
+        frappe.delete_doc("File", self.folder.name, force=True, ignore_permissions=True)
+        frappe.db.commit()
+        super().tearDown()
+
+    def share(self, entity, user):
+        frappe.get_doc({"doctype": "Drive Permission", "entity": entity, "user": user, "read": 1}).insert(
+            ignore_permissions=True
+        )
+        frappe.db.commit()
+
+    def search_names(self, query):
+        return [row["name"] for row in search(query)]
+
+    def test_reaches_readable_rows_past_the_first_window(self):
+        """The regression: filtering one fixed window makes the reply depend on
+        how many *unreadable* rows sort first."""
+        with self.set_user(OWNER):
+            ordered = self.search_names(self.token)
+        self.assertEqual(len(ordered), self.FILE_COUNT)
+
+        # Share only the last row in scan order - several windows deep.
+        last = ordered[-1]
+        self.share(last, OTHER_USER)
+
+        with (
+            self.set_user(OTHER_USER),
+            patch("suite.drive.api.files.SEARCH_SCAN_WINDOW", self.WINDOW),
+        ):
+            self.assertEqual(self.search_names(self.token), [last])
+
+    def test_returns_only_readable_rows(self):
+        self.share(self.files[0].name, OTHER_USER)
+
+        with self.set_user(OTHER_USER):
+            self.assertEqual(self.search_names(self.token), [self.files[0].name])
+
+    def test_unshared_user_gets_nothing(self):
+        with self.set_user(OTHER_USER):
+            self.assertEqual(search(self.token), [])
+
+    def test_scan_stops_at_the_budget(self):
+        """A caller who can read nothing must not walk the whole match set."""
+        with (
+            self.set_user(OTHER_USER),
+            patch("suite.drive.api.files.SEARCH_SCAN_WINDOW", self.WINDOW),
+            patch("suite.drive.api.files.MAX_SEARCH_SCAN_WINDOWS", 2),
+            patch("suite.drive.api.files.user_has_permission", return_value=False) as has_permission,
+        ):
+            self.assertEqual(search(self.token), [])
+
+        self.assertEqual(has_permission.call_count, self.WINDOW * 2)
+
+    def test_stops_once_the_page_is_full(self):
+        with (
+            self.set_user(OWNER),
+            patch("suite.drive.api.files.SEARCH_PAGE_LENGTH", 3),
+            patch("suite.drive.api.files.SEARCH_SCAN_WINDOW", self.WINDOW),
+        ):
+            self.assertEqual(len(self.search_names(self.token)), 3)
+
+    def test_page_is_capped(self):
+        with self.set_user(OWNER):
+            self.assertLessEqual(len(search(self.token)), SEARCH_PAGE_LENGTH)
+
+    def test_access_is_resolved_without_reloading_each_row(self):
+        """`user_has_permission` reloads the whole document when handed a name;
+        the row the query already selected carries every field it reads."""
+        with (
+            self.set_user(OWNER),
+            patch("suite.drive.api.files.user_has_permission", return_value=True) as has_permission,
+        ):
+            search(self.token)
+
+        self.assertTrue(has_permission.call_args_list)
+        for call in has_permission.call_args_list:
+            row = call.args[0]
+            self.assertNotIsInstance(row, str)
+            self.assertIn("owner", row)
+            self.assertIn("attached_to_doctype", row)
+
+    def test_blank_query_short_circuits(self):
+        with self.set_user(OWNER), patch("suite.drive.api.files.frappe.db.sql") as sql:
+            for query in ("", "   ", "\t\n"):
+                self.assertEqual(search(query), [])
+        sql.assert_not_called()
+
+    def test_trashed_rows_are_excluded(self):
+        self.files[0].db_set("status", STATUS_TRASHED)
+        frappe.db.commit()
+
+        with self.set_user(OWNER):
+            self.assertNotIn(self.files[0].name, self.search_names(self.token))


### PR DESCRIPTION
`search` pulled a fixed 500-row window, filtered it by permission in Python, then truncated to 50. Because the filter ran *after* the window, the reply depended on how many **unreadable** rows happened to sort first — a caller shared on few files got a short page, or an empty one, while matches they could read sat just past row 500. Same shape as the pagination bug in `api/list.py`.

Access can't be pushed into the query (`file_permission_criterion` doesn't model inheritance), so this walks the match set in windows instead, keeping readable rows until the page is full or a 1000-row budget is spent.

Three things that came with it:

- The query had no `ORDER BY`, so windowing it would skip or repeat rows. It now orders by relevance, then name.
- `user_has_permission(name, ...)` reloads the whole document — a `get_doc` per row, 500 per call. It now takes the row the query already selected, which pays for scanning deeper.
- `is_folder` was never sent, though `SearchPopup.vue:32` reads it to pick the row icon, so folders always showed a file icon.

### Frontend, folded in

- Popup debounces now (was firing per keystroke), tuned to 180ms.
- **Ctrl+K now works on Windows/Linux.** The shortcut only checked `e.metaKey` — Cmd on Mac, but the literal Windows key elsewhere, never Ctrl. Switched to `isModKey`, already used elsewhere in Drive for the same Ctrl-vs-Cmd distinction. Mac is unaffected (still Cmd+K).
- Added a "Ctrl K" / "⌘K" hint next to the sidebar Search item, via `SidebarItem`'s existing `suffix` prop — no new component.
- Fixed `ShortcutsDialog` documenting Find Files as bound to the Windows key, which the Ctrl+K fix would've made worse.

### Measured

2200 matching files, min of 3 runs:

| case | before | after |
|---|---|---|
| caller can read ~none of the matches | **0 rows**, 0.227s | **all 9 rows**, 0.454s |
| common case, page fills from first window | 50 rows, 0.084s | 50 rows, **0.015s** |

The worst case is ~2x slower by choice — it's the case the old code got wrong, and the budget came down from 2000 rows (0.862s) after measuring.

### Testing

9 backend regression tests, each verified failing without its fix. Full Drive suite passes (1926 frontend, full backend suite), lint clean on the CI-pinned `ruff==0.12.3`. Verified over HTTP as a second real user: 0 rows before, 9 after.

No test for the debounce or the keybinding — `vitest.config.ts` aliases `frappe-ui` to a stub with no `submit`/debounce, and the keybinding helper's module pulls in that same stub transitively. Verified both by hand instead.

Follow-up: cancelling search now also aborts an already-started request, so backspacing or closing the popup cannot leave stale work running.