### PR TITLE
fix: correct pagination and margins in Writer PDF/print export

### DIFF
--- a/e2e/drive-backed-apps/specs/writer/docx-import.spec.ts
+++ b/e2e/drive-backed-apps/specs/writer/docx-import.spec.ts
@@ -59,11 +59,15 @@ test("imports a .docx into a new tab, leaving existing content untouched", async
 
 	// Importing wraps the existing content into its own ("Untitled") tab and
 	// switches to a new tab named after the file for the imported content.
+	// Inactive tabs stay mounted (display: none) rather than being removed
+	// from the DOM — see TabView.vue — so assertions must scope to the
+	// visible tab; toContainText matches hidden text too, unlike innerText.
 	const tocTabs = owner.page.locator('[draggable="true"]');
 	await expect(tocTabs).toHaveCount(2);
-	await expect(editor).toContainText("E2E DOCX Import Fixture");
+	const activeTab = editor.locator("[data-tab-id]:visible");
+	await expect(activeTab).toContainText("E2E DOCX Import Fixture");
 
 	await tocTabs.filter({ hasText: "Untitled" }).click();
-	await expect(editor).toContainText("Existing content before import");
-	await expect(editor).not.toContainText("E2E DOCX Import Fixture");
+	await expect(activeTab).toContainText("Existing content before import");
+	await expect(activeTab).not.toContainText("E2E DOCX Import Fixture");
 });

--- a/frontend/src/apps/writer/styles/print.css
+++ b/frontend/src/apps/writer/styles/print.css
@@ -123,11 +123,6 @@
     text-decoration: none;
   }
 
-  .prose-sm {
-    caret-color: currentColor;
-    padding: 1rem 2.5rem;
-  }
-
   .ProseMirror pre {
     background: #0d0d0d;
     color: #fff;

--- a/frontend/src/apps/writer/utils/index.js
+++ b/frontend/src/apps/writer/utils/index.js
@@ -265,8 +265,8 @@ export function printDoc(html, settings = {}) {
               <style>${editorStyle}</style>
               <style>
               @page {
-                margin: 1.25cm 0.5cm;
-                
+                margin: 1.25cm;
+
                 @top-left {
                   content: "${settings?.print_header_left || ''}";  
                   font-family: ${fontFamily};
@@ -307,12 +307,12 @@ export function printDoc(html, settings = {}) {
                 }
                 div[data-page-break='true'] {
                   border: none;
-                  margin: none;
+                  margin: 0;
                 }
               </style>
               </head>
               <body>
-                <div class="ProseMirror prose prose-sm prose-v3" style='padding-left: 40px; padding-right: 40px; padding-top: 20px; padding-bottom: 20px; margin: 0; ${editorVars}'>
+                <div class="ProseMirror prose prose-sm prose-v3" style='max-width: ${settings?.wide ? '100ch' : '48rem'}; margin: 0 auto; padding-left: 40px; padding-right: 40px; padding-top: 20px; padding-bottom: 20px; ${editorVars}'>
                   ${highlightedHtml}
                 </div>
               </body>

--- a/frontend/src/apps/writer/utils/index.js
+++ b/frontend/src/apps/writer/utils/index.js
@@ -265,7 +265,7 @@ export function printDoc(html, settings = {}) {
               <style>${editorStyle}</style>
               <style>
               @page {
-                margin: 1.25cm;
+                margin: 1.25cm 2.5cm;
 
                 @top-left {
                   content: "${settings?.print_header_left || ''}";  

--- a/frontend/src/apps/writer/utils/index.js
+++ b/frontend/src/apps/writer/utils/index.js
@@ -312,7 +312,7 @@ export function printDoc(html, settings = {}) {
               </style>
               </head>
               <body>
-                <div class="ProseMirror prose prose-sm prose-v3" style='max-width: ${settings?.wide ? '100ch' : '48rem'}; margin: 0 auto; padding-left: 40px; padding-right: 40px; padding-top: 20px; padding-bottom: 20px; ${editorVars}'>
+                <div class="ProseMirror prose prose-sm prose-v3" style='max-width: ${settings?.wide ? '100ch' : '48rem'}; margin: 0 auto; padding-top: 20px; padding-bottom: 20px; ${editorVars}'>
                   ${highlightedHtml}
                 </div>
               </body>


### PR DESCRIPTION
Fixes pagination, spacing, and margin issues in Writer's PDF/print export.

**Changes:**

- Corrected @page margins to use consistent spacing.
- Fixed print content width and centering to prevent unnecessary blank space and extra pages.
- Removed conflicting .prose-sm print padding.
- Fixed invalid margin: none CSS on page-break elements.