### PR TITLE
fix(slides): images pasted from another tab were not visible to viewers

### DIFF
--- a/frontend/src/apps/slides/stores/copyPaste.js
+++ b/frontend/src/apps/slides/stores/copyPaste.js
@@ -169,6 +169,8 @@ const handleClipboardJSON = async (clipboardJSON) => {
 	const json = JSON.parse(clipboardJSON)
 	if (json?.srcPresentation) return handlePastedJSON(json)
 	if (json?.clientId) return handlePastedSlideJSON(json)
+	// a bare array is the pre-source payload: no origin known, so attach as if foreign
+	if (Array.isArray(json)) return handlePastedJSON({ srcPresentation: null, elements: json })
 }
 
 const dataURLToFile = (dataURL, filename) => {

--- a/frontend/src/apps/slides/stores/copyPaste.js
+++ b/frontend/src/apps/slides/stores/copyPaste.js
@@ -25,14 +25,18 @@ const { activeEditor } = useTextEditor()
 
 const isCopyTriggeredByButton = ref(false)
 
-const getCopiedElementsJSON = () => JSON.stringify(activeElements.value)
+// the source travels with the payload: a copy in one tab is pasted in another
+const getCopiedElementsJSON = () =>
+	JSON.stringify({
+		srcPresentation: presentationId.value,
+		srcSlide: slideIndex.value,
+		elements: activeElements.value,
+	})
 
 const getCopiedSlideJSON = () => {
 	const slide = getNewSlide(true)
 	return JSON.stringify(slide)
 }
-
-const copiedFrom = ref({})
 
 const copySlide = (e) => {
 	const clipboardJSON = getCopiedSlideJSON()
@@ -43,10 +47,6 @@ const copySlide = (e) => {
 const copyElements = (e) => {
 	const clipboardJSON = getCopiedElementsJSON()
 	e.clipboardData.setData('application/json', clipboardJSON)
-	copiedFrom.value = {
-		srcPresentation: presentationId.value,
-		srcSlide: slideIndex.value,
-	}
 }
 
 const handleCopy = (e) => {
@@ -86,8 +86,8 @@ const handlePastedText = async (clipboardText) => {
 	addTextElement(clipboardText)
 }
 
-const handlePastedJSON = async (json) => {
-	const pastedArray = Array.isArray(json) ? json : []
+const handlePastedJSON = async ({ srcPresentation, srcSlide, elements }) => {
+	const pastedArray = Array.isArray(elements) ? elements : []
 
 	if (
 		pastedArray[0]?.type == 'text' &&
@@ -98,18 +98,19 @@ const handlePastedJSON = async (json) => {
 		return
 	}
 
-	const { srcPresentation, srcSlide } = copiedFrom.value
-
+	let json = pastedArray
 	if (srcPresentation !== presentationId.value) {
 		// if pasted elements are from a different presentation
 		// add file attachments correctly to current presentation + update docnames in json
 		json = await call('suite.slides.doctype.presentation.presentation.get_updated_json', {
 			presentation: presentationId.value,
-			elements: json,
+			elements: pastedArray,
 		})
 	}
 
-	duplicateElements(null, json, srcSlide)
+	// a foreign slide index means nothing here, and there is no original to displace from
+	const sameSource = srcPresentation === presentationId.value
+	duplicateElements(null, json, sameSource ? srcSlide : null, sameSource)
 }
 
 const handleSvgText = (svgText) => {
@@ -118,10 +119,9 @@ const handleSvgText = (svgText) => {
 	handleUploadedMedia([{ kind: 'file', getAsFile: () => svgFile }])
 }
 
-const handlePastedSlideJSON = async (json) => {
+const handlePastedSlideJSON = async (slideJSON) => {
 	const index = slideIndex.value
 
-	let slideJSON = JSON.parse(json)
 	if (slideJSON.parent != presentationId.value) {
 		// if pasted slide is from a different presentation
 		// add file attachments correctly to current presentation + update docnames in json
@@ -166,12 +166,9 @@ const handleClipboardText = (clipboardText) => {
 }
 
 const handleClipboardJSON = async (clipboardJSON) => {
-	const isSlideJSON = !Array.isArray(clipboardJSON) && clipboardJSON.includes('"elements"')
-	if (isSlideJSON) {
-		await handlePastedSlideJSON(clipboardJSON)
-		return
-	}
-	return handlePastedJSON(JSON.parse(clipboardJSON))
+	const json = JSON.parse(clipboardJSON)
+	if (json?.srcPresentation) return handlePastedJSON(json)
+	if (json?.clientId) return handlePastedSlideJSON(json)
 }
 
 const dataURLToFile = (dataURL, filename) => {

--- a/suite/slides/doctype/presentation/presentation.py
+++ b/suite/slides/doctype/presentation/presentation.py
@@ -249,6 +249,7 @@ def update_slide_attachments(parent: str, slide: dict | str):
         element["id"] = "".join(random.choices(string.ascii_lowercase + string.digits, k=9))
         if element.get("src") and element["src"].startswith("/private"):
             element["attachmentName"] = get_attachment(parent, element["src"])
+        attach_poster(parent, element)
 
     slide["elements"] = json.dumps(elements)
 
@@ -444,6 +445,17 @@ def get_attachment(presentation, file_url):
     return attachment
 
 
+def attach_poster(presentation, element):
+    """Best-effort: a broken poster must not fail the paste."""
+    poster = element.get("poster")
+    if not isinstance(poster, str) or not poster.startswith("/private"):
+        return
+    try:
+        get_attachment(presentation, poster)
+    except Exception:
+        frappe.log_error(f"could not attach poster {poster} to {presentation}")
+
+
 @frappe.whitelist()
 def get_updated_json(presentation: str, elements: list[dict]):
     frappe.get_doc("Presentation", presentation).check_permission("write")
@@ -453,6 +465,7 @@ def get_updated_json(presentation: str, elements: list[dict]):
             file_url = element["src"].replace(frappe.local.site_name, "")
             name = get_attachment(presentation, file_url)
             element["attachmentName"] = name
+        attach_poster(presentation, element)
 
     return elements
 

--- a/suite/slides/tests/test_pasted_media.py
+++ b/suite/slides/tests/test_pasted_media.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import json
+import os
+
+import frappe
+from frappe.tests import IntegrationTestCase
+from werkzeug.exceptions import Forbidden
+
+from suite.drive.overrides.file import File as DriveFile
+from suite.slides.api.file import validate_media_file
+from suite.slides.doctype.presentation.presentation import get_updated_json, update_slide_attachments
+from suite.slides.tests.utils import make_presentation, make_private_image
+from suite.tests.utils import ensure_user
+
+OWNER = "pasted-media-owner@example.com"
+VIEWER = "pasted-media-viewer@example.com"
+
+
+def share_read(presentation_name, user):
+    entity = DriveFile.get_for_doc("Presentation", presentation_name)
+    frappe.get_doc({"doctype": "Drive Permission", "entity": entity, "user": user, "read": 1}).insert(
+        ignore_permissions=True
+    )
+
+
+def attached_to(file_url):
+    return set(frappe.get_all("File", {"file_url": file_url}, pluck="attached_to_name", order_by=None))
+
+
+class TestPastedMedia(IntegrationTestCase):
+    """Media pasted from another presentation must end up attached to the destination,
+    or viewers of the destination get a 403 for it."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        ensure_user(OWNER)
+        ensure_user(VIEWER)
+        with cls.set_user(OWNER):
+            cls.source = make_presentation("Paste Source").name
+            cls.image_url = make_private_image(cls.source).file_url
+            cls.poster_url = make_private_image(cls.source).file_url
+
+    def make_destination(self, title):
+        with self.set_user(OWNER):
+            name = make_presentation(title).name
+        share_read(name, VIEWER)
+        return name
+
+    def assert_viewer_sees(self, url, presentation):
+        with self.set_user(VIEWER):
+            self.assertIsNone(validate_media_file(url, presentation))
+
+    def test_element_paste_attaches_src_and_poster(self):
+        destination = self.make_destination("Element Paste Destination")
+        video = {"type": "video", "src": self.image_url, "poster": self.poster_url}
+
+        with self.set_user(VIEWER):
+            with self.assertRaises(Forbidden):
+                validate_media_file(self.image_url, destination)
+
+        with self.set_user(OWNER):
+            elements = get_updated_json(destination, [video])
+
+        self.assertEqual(elements[0]["src"], self.image_url)
+        self.assertIn(destination, attached_to(self.image_url))
+        self.assertIn(destination, attached_to(self.poster_url))
+        self.assert_viewer_sees(self.image_url, destination)
+        self.assert_viewer_sees(self.poster_url, destination)
+
+    def test_slide_paste_attaches_poster(self):
+        destination = self.make_destination("Slide Paste Destination")
+        slide = {
+            "elements": json.dumps([{"type": "video", "src": self.image_url, "poster": self.poster_url}])
+        }
+
+        with self.set_user(OWNER):
+            update_slide_attachments(destination, slide)
+
+        self.assertIn(destination, attached_to(self.poster_url))
+        self.assert_viewer_sees(self.poster_url, destination)
+
+    def test_broken_poster_does_not_fail_the_paste(self):
+        destination = self.make_destination("Broken Poster Destination")
+        with self.set_user(OWNER):
+            gone = make_private_image(self.source)
+            os.remove(gone.get_full_path())
+            legacy = {"type": "video", "src": self.image_url, "poster": {"posterURL": gone.file_url}}
+            missing = {"type": "video", "src": self.image_url, "poster": gone.file_url}
+
+            elements = get_updated_json(destination, [legacy, missing])
+
+        self.assertEqual(len(elements), 2)
+        self.assertIn(destination, attached_to(self.image_url))
+        self.assertNotIn(destination, attached_to(gone.file_url))


### PR DESCRIPTION
- Copying elements in one tab and pasting into a different presentation in another tab saved the source's file url without attaching the file to the destination, so anyone the presentation was shared with got a 403 for that media (the owner sees it directly and never noticed)
- Cross-presentation pastes no longer offset by 40px or read a slide index from the other presentation
- Video posters are attached alongside the video src on both element and slide paste, best-effort so a broken poster does not fail the paste
- Tests for element paste, slide paste and the broken-poster case