### PR TITLE
fix(slides): images replaced on the wrong slide

### DIFF
--- a/frontend/src/apps/slides/stores/duplicateElementIds.test.ts
+++ b/frontend/src/apps/slides/stores/duplicateElementIds.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/apps/slides/utils/mediaUploads', () => ({ getAttachmentUrl: (url: string) => url }))
+vi.mock('@/apps/slides/router', () => ({ router: { replace: () => Promise.resolve() } }))
+vi.mock('@/apps/slides/stores/elementRegistry', () => ({
+	registerElementDiv: () => {},
+	getElementDiv: () => null,
+}))
+
+// jsdom never loads an image, so every probe reports a square
+class StubImage {
+	naturalWidth = 100
+	naturalHeight = 100
+	onload: (() => void) | null = null
+	onerror: (() => void) | null = null
+	set src(_value: string) {
+		queueMicrotask(() => this.onload?.())
+	}
+}
+vi.stubGlobal('Image', StubImage)
+
+const { slides, slideIndex, getNewSlide } = await import('./slide')
+const { replaceMediaElement } = await import('./element')
+const { resetImageCrop } = await import('./imageCrop')
+const { setCommandHistory } = await import('./historyMeta')
+const { useCommandHistory } = await import('@/apps/slides/composables/useCommandHistory')
+
+const actionOrder = {
+	execute: { editElement: ['execute'], batch: ['execute'] },
+	undo: { editElement: ['undo'], batch: ['undo'] },
+}
+
+const image = (id: string, src: string, overrides = {}) => ({
+	id,
+	type: 'image',
+	src,
+	left: 0,
+	top: 0,
+	width: 100,
+	height: 100,
+	...overrides,
+})
+
+const seedSharedId = (overrides = {}) => {
+	slides.value = [
+		{ clientId: 'c1', elements: [image('shared', '/files/first.webp', overrides)] },
+		{ clientId: 'c2', elements: [image('shared', '/files/second.webp', overrides)] },
+	] as any
+	slideIndex.value = 1
+	setCommandHistory(useCommandHistory(slides, { actionOrder, actions: {} }))
+}
+
+describe('a slide inserted from a layout', () => {
+	it('takes fresh element ids so repeat inserts never collide', () => {
+		const layout = { elements: JSON.stringify([image('fw89mlzl4', '/files/placeholder.webp')]) }
+
+		const first = getNewSlide(false, { ...layout })
+		const second = getNewSlide(false, { ...layout })
+
+		expect(first.elements[0].id).not.toBe('fw89mlzl4')
+		expect(second.elements[0].id).not.toBe(first.elements[0].id)
+	})
+})
+
+describe('replacing an image whose id repeats on an earlier slide', () => {
+	beforeEach(() => seedSharedId())
+
+	it('swaps the src of the element it was handed', async () => {
+		await replaceMediaElement(slides.value[1].elements[0], {
+			name: 'File-3',
+			file_url: '/files/third.webp',
+		})
+
+		expect(slides.value[0].elements[0].src).toBe('/files/first.webp')
+		expect(slides.value[1].elements[0].src).toBe('/files/third.webp')
+	})
+})
+
+describe('resetting the crop of an image whose id repeats on an earlier slide', () => {
+	const crop = { x: 0, y: 0, width: 0.5, height: 1 }
+
+	beforeEach(() => seedSharedId({ crop }))
+
+	it('clears the crop of the element it was handed', async () => {
+		await resetImageCrop(slides.value[1].elements[0])
+
+		expect(slides.value[0].elements[0].crop).toEqual(crop)
+		expect(slides.value[1].elements[0].crop).toBeUndefined()
+	})
+})

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -719,8 +719,10 @@ const replaceMediaElement = async (element, fileDoc) => {
 	const srcChanged = element.src !== fileDoc.file_url
 	const probes = srcChanged ? await probeReplacementMedia(element, fileDoc) : null
 
-	// a slow upload can outlive a slide switch or the element itself
-	const slide = slides.value.find((s) => s.elements.some((el) => el.id === element.id))
+	// a slow upload can outlive a slide switch or the element itself, and older
+	// presentations repeat one layout's element ids across slides, so only the
+	// element object itself names the slide to edit
+	const slide = slides.value.find((s) => s.elements.includes(element))
 	if (!slide) return
 	const slideId = slide.clientId
 

--- a/frontend/src/apps/slides/stores/imageCrop.js
+++ b/frontend/src/apps/slides/stores/imageCrop.js
@@ -105,8 +105,9 @@ const resetImageCrop = async (element) => {
 	const naturalAspect = await probeNaturalAspect(element)
 	if (naturalAspect == null) return
 
-	// the load may outlive a slide switch or the element itself
-	const slide = slides.value.find((s) => s.elements.some((el) => el.id == element.id))
+	// the load may outlive a slide switch or the element itself, and older
+	// presentations repeat one layout's element ids across slides
+	const slide = slides.value.find((s) => s.elements.includes(element))
 	if (!slide) return
 
 	const inset = getBorderInset(element)

--- a/frontend/src/apps/slides/stores/slide.js
+++ b/frontend/src/apps/slides/stores/slide.js
@@ -66,7 +66,6 @@ const getNewSlide = (toDuplicate = false, layoutObject, source = currentSlide.va
 
 	if (toDuplicate) {
 		layout = { ...source }
-		layout.elements = remapElementIds(source.elements.map(cloneObj))
 	} else {
 		layout = layoutObject || null
 		layout.elements =
@@ -76,7 +75,8 @@ const getNewSlide = (toDuplicate = false, layoutObject, source = currentSlide.va
 	let slide = {}
 	if (layout) {
 		slide = { ...layout }
-		slide.elements = layout.elements.map((e) => ({ ...e }))
+		// the same layout is inserted more than once, so its stored ids can't carry over
+		slide.elements = remapElementIds(layout.elements.map(cloneObj))
 	}
 
 	// override metadata and generate unique IDs for elements


### PR DESCRIPTION
### Bug
- `getNewSlide` only regenerated element ids when duplicating a slide, so every slide inserted from the same layout carried the template's ids.
- `replaceMediaElement` found its slide by scanning all slides for the element id, which returns the first match, so the edit landed on an earlier slide.
- `resetImageCrop` used the same lookup and had the same failure.

### Fix
- Slides inserted from a layout get fresh element ids.
- Both lookups resolve the slide by element identity instead of by id, so they stay correct on presentations that already have duplicate ids.