### PR TITLE
fix(drive): filter out trashed files from archive downloads

### DIFF
--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -457,10 +457,10 @@ def _collect_download_files(entity_names):
         entity = frappe.get_value(
             "File",
             name,
-            ["name", "file_name", "is_folder", "file_type", "file_url"],
+            ["name", "file_name", "is_folder", "file_type", "file_url", "status"],
             as_dict=True,
         )
-        if not entity:
+        if not entity or entity.status != STATUS_ACTIVE:
             continue
         if entity.is_folder:
             yield from _iter_folder_files(entity.name, prefix=f"{entity.file_name}/")

--- a/suite/drive/tests/test_download_archive.py
+++ b/suite/drive/tests/test_download_archive.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import patch
+
+import frappe
+
+from suite.drive.api.files import _collect_download_files
+from suite.drive.utils import STATUS_ACTIVE, STATUS_TRASHED
+
+
+class TestDownloadArchive(unittest.TestCase):
+    @patch("suite.drive.api.files.user_has_permission", return_value=True)
+    def test_collect_files_skips_trashed_entities(self, mock_perm):
+        active_file = frappe._dict(
+            name="f1",
+            file_name="active.png",
+            is_folder=0,
+            file_type="Image",
+            file_url="/files/active.png",
+            status=STATUS_ACTIVE,
+        )
+        trashed_file = frappe._dict(
+            name="f2",
+            file_name="trashed.png",
+            is_folder=0,
+            file_type="Image",
+            file_url="/files/trashed.png",
+            status=STATUS_TRASHED,
+        )
+
+        def fake_get_value(doctype, name, fields, as_dict=True):
+            if name == "f1":
+                return active_file
+            if name == "f2":
+                return trashed_file
+            return None
+
+        with patch("frappe.get_value", side_effect=fake_get_value):
+            results = list(_collect_download_files(["f1", "f2", "nonexistent"]))
+            self.assertEqual(len(results), 1)
+            arcname, entity = results[0]
+            self.assertEqual(arcname, "active.png")
+            self.assertEqual(entity.name, "f1")
+
+    def test_collect_files_enforces_permission(self):
+        with patch("suite.drive.api.files.user_has_permission", return_value=False):
+            with self.assertRaises(frappe.PermissionError):
+                list(_collect_download_files(["denied-file"]))


### PR DESCRIPTION
### Summary
While `_iter_folder_files` already filters folder children by `status == STATUS_ACTIVE`, the top-level entity collector `_collect_download_files` omitted `status` from its field list. Consequently, passing trashed file IDs directly to `download_folder` bundled them into archive downloads, bypassing the status checks enforced on single-file downloads in `get_file_content`.

### Changes
- Include `status` in `frappe.get_value` within `_collect_download_files` and skip any non-`Active` entity.
- Add unit tests in `suite/drive/tests/test_download_archive.py` verifying that trashed files are skipped and permissions are enforced.
