### PR TITLE
fix(mail): block sending during attachment upload

### DIFF
--- a/frontend/src/apps/mail/components/ComposeMailEditor.vue
+++ b/frontend/src/apps/mail/components/ComposeMailEditor.vue
@@ -11,9 +11,9 @@
 	<TextEditor
 		ref="textEditor"
 		editor-class="prose-sm max-w-none [&_ol]:ps-7 [&_ul]:ps-7"
-		:extensions="[CustomImageExtension, CustomParagraphExtension, ...mentionExtensions]"
+		:extensions="[imageExtension, CustomParagraphExtension, ...mentionExtensions]"
 		:content="editorContent"
-		:upload-function="uploadFunction"
+		:upload-function="uploadInlineImage"
 		class="flex flex-col"
 		:class="[
 			{ 'pointer-events-none opacity-50': !show },
@@ -316,7 +316,20 @@ const ccInput = useTemplateRef('ccInput')
 const subjectInput = useTemplateRef<HTMLInputElement>('subjectInput')
 
 const fileUploads = ref<ReturnType<typeof useFileUpload>[]>([])
-const isUploading = computed(() => fileUploads.value.some((upload) => upload.isUploading))
+const pendingInlineUploads = ref(0)
+const isUploading = computed(
+	() => pendingInlineUploads.value > 0 || fileUploads.value.some((upload) => upload.isUploading),
+)
+
+const uploadInlineImage = async (file: File) => {
+	pendingInlineUploads.value++
+	try {
+		return await uploadFunction(file)
+	} finally {
+		pendingInlineUploads.value--
+	}
+}
+const imageExtension = CustomImageExtension.configure({ uploadFunction: uploadInlineImage })
 
 // What the composition *is* — draft state, autosave, send, schedule, discard, attachments, mentions
 // — lives in the composable, shared with the phone composer (ComposeView). Only what is particular

--- a/frontend/src/apps/mail/components/ComposeMailEditor.vue
+++ b/frontend/src/apps/mail/components/ComposeMailEditor.vue
@@ -229,6 +229,7 @@
 		<template #bottom>
 			<ComposeMailToolbar
 				:is-recipients-empty
+				:is-uploading
 				class="border-t"
 				:class="[
 					isDragging ? 'border-transparent' : '',
@@ -314,6 +315,9 @@ const toInput = useTemplateRef('toInput')
 const ccInput = useTemplateRef('ccInput')
 const subjectInput = useTemplateRef<HTMLInputElement>('subjectInput')
 
+const fileUploads = ref<ReturnType<typeof useFileUpload>[]>([])
+const isUploading = computed(() => fileUploads.value.some((upload) => upload.isUploading))
+
 // What the composition *is* — draft state, autosave, send, schedule, discard, attachments, mentions
 // — lives in the composable, shared with the phone composer (ComposeView). Only what is particular
 // to this dialog stays here: the contact picker, drag-and-drop, and the in-thread draft actions.
@@ -347,6 +351,7 @@ const {
 	onDiscardUnsaved: () => emit('discardMail'),
 	onDiscardStarted: () => emit('discardStarted'),
 	host: () => textEditor.value,
+	isUploading: () => isUploading.value,
 	// The dialog holds the rest of the page inert, so the mention dropdown has to render inside it
 	// rather than at <body>, where it would be unreachable.
 	mentionContainer: () =>
@@ -517,8 +522,6 @@ const handleDrop = (e: DragEvent) => {
 	const files = Array.from(e.dataTransfer?.files ?? [])
 	uploadFiles(files)
 }
-
-const fileUploads = ref<ReturnType<typeof useFileUpload>[]>([])
 
 const uploadFiles = async (files: File[]) => {
 	if (!files.length) return

--- a/frontend/src/apps/mail/components/ComposeMailToolbar.vue
+++ b/frontend/src/apps/mail/components/ComposeMailToolbar.vue
@@ -66,7 +66,7 @@
 						:label="__('Send')"
 						:tooltip="__('Send ({0}+Enter)', [modifier])"
 						:icon-left="SendHorizontal"
-						:disabled="isRecipientsEmpty"
+						:disabled="isRecipientsEmpty || isUploading"
 						class="!rounded-r-none"
 						@click="emit('sendMail')"
 					/>
@@ -74,7 +74,7 @@
 						<Button
 							variant="solid"
 							:tooltip="__('Schedule send')"
-							:disabled="isRecipientsEmpty"
+							:disabled="isRecipientsEmpty || isUploading"
 							class="!rounded-l-none"
 						>
 							<template #icon>
@@ -96,8 +96,9 @@ import { isMac } from '@/apps/mail/utils'
 import { useScreenSize, useTextEditorButtons } from '@/apps/mail/utils/composables'
 import EmojiPicker from '@/apps/mail/components/EmojiPicker.vue'
 
-const { isRecipientsEmpty } = defineProps<{
+const { isRecipientsEmpty, isUploading } = defineProps<{
 	isRecipientsEmpty: boolean
+	isUploading?: boolean
 }>()
 
 const emit = defineEmits(['appendEmoji', 'selectFiles', 'discardMail', 'sendMail', 'scheduleSend'])

--- a/frontend/src/apps/mail/composables/useComposeMail.ts
+++ b/frontend/src/apps/mail/composables/useComposeMail.ts
@@ -42,6 +42,8 @@ export interface ComposeMailOptions {
 	onDiscardStarted?: () => void
 	/** The mounted TextEditor, for mention bookkeeping and emoji insertion. */
 	host: () => EditorHost | null | undefined
+	/** Whether a file is still being attached. Sending must wait until it is part of the draft. */
+	isUploading?: () => boolean
 	/**
 	 * Where the mention dropdown should render. The dialog on desktop, which holds the rest of the
 	 * page inert; null anywhere `<body>` will do.
@@ -250,6 +252,9 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 
 	const sendMail = async (sendAt?: string) => {
 		if (deleteMail.loading) return
+
+		if (options.isUploading?.())
+			return raiseToast(__('Please wait for attachments to finish uploading.'), 'error')
 
 		if (isRecipientsEmpty.value)
 			return raiseToast(__('Please add at least one recipient.'), 'error')

--- a/frontend/src/apps/mail/pages/ComposeView.vue
+++ b/frontend/src/apps/mail/pages/ComposeView.vue
@@ -41,7 +41,7 @@
 				variant="ghost"
 				class="ml-2"
 				:label="__('Send')"
-				:disabled="isRecipientsEmpty"
+				:disabled="isRecipientsEmpty || isUploading"
 				@click="sendMail()"
 			>
 				<template #icon>
@@ -290,6 +290,8 @@ const ccInput = useTemplateRef<{ setFocus: () => void }>('ccInput')
 const subjectInput = useTemplateRef<HTMLInputElement>('subjectInput')
 const fileInput = useTemplateRef<HTMLInputElement>('fileInput')
 const scroller = useTemplateRef<HTMLElement>('scroller')
+const pendingUploads = ref(0)
+const isUploading = computed(() => pendingUploads.value > 0)
 
 // Where each recipient input teleports its suggestion list, so the list spans the page rather than
 // the field's own column.
@@ -331,6 +333,7 @@ const {
 	// The page is the composer, so it is open right up until the route leaves.
 	isOpen: () => !leaving,
 	host: () => textEditor.value,
+	isUploading: () => isUploading.value,
 })
 
 const { height: viewportHeight, top: keyboardTop } = useKeyboardInsets()
@@ -475,11 +478,14 @@ const onFilesSelected = async (e: Event) => {
 	input.value = ''
 
 	for (const file of files) {
+		pendingUploads.value++
 		try {
 			const doc = await uploadFunction(file)
 			mail.attachments.push({ ...doc, disposition: 'attachment' } as Attachment)
 		} catch (error) {
 			raiseToast((error as Error)?.message ?? __('Could not attach {0}.', [file.name]), 'error')
+		} finally {
+			pendingUploads.value--
 		}
 	}
 }

--- a/frontend/src/apps/mail/pages/ComposeView.vue
+++ b/frontend/src/apps/mail/pages/ComposeView.vue
@@ -55,9 +55,9 @@
 		<TextEditor
 			ref="textEditor"
 			editor-class="prose-sm max-w-none [&_ol]:ps-7 [&_ul]:ps-7"
-			:extensions="[CustomImageExtension, CustomParagraphExtension, ...mentionExtensions]"
+			:extensions="[imageExtension, CustomParagraphExtension, ...mentionExtensions]"
 			:content="editorContent"
-			:upload-function="uploadFunction"
+			:upload-function="uploadInlineImage"
 			class="flex min-h-0 flex-1 flex-col"
 			@change="onEditorChange"
 		>
@@ -292,6 +292,16 @@ const fileInput = useTemplateRef<HTMLInputElement>('fileInput')
 const scroller = useTemplateRef<HTMLElement>('scroller')
 const pendingUploads = ref(0)
 const isUploading = computed(() => pendingUploads.value > 0)
+
+const uploadInlineImage = async (file: File) => {
+	pendingUploads.value++
+	try {
+		return await uploadFunction(file)
+	} finally {
+		pendingUploads.value--
+	}
+}
+const imageExtension = CustomImageExtension.configure({ uploadFunction: uploadInlineImage })
 
 // Where each recipient input teleports its suggestion list, so the list spans the page rather than
 // the field's own column.


### PR DESCRIPTION
## Summary

- disable send and schedule controls while file attachments upload
- track pasted and inserted inline-image uploads through the same guard
- guard shared send behavior so buttons, shortcuts, and scheduling cannot bypass pending uploads
- cover desktop, thread, and mobile composers