### PR TITLE
fix(meet): isolate participant connections

### DIFF
--- a/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
@@ -877,15 +877,15 @@ export class MediasoupManager {
 			return existingProducers;
 		}
 
-		for (const [peerId, peer] of room.peers) {
+		for (const peer of room.peers.values()) {
 			// Exclude requester
-			if (peerId === userId) continue;
+			if (peer.info.userId === userId) continue;
 
 			for (const producer of peer.producers.values()) {
 				existingProducers.push({
 					id: producer.id,
 					roomId,
-					user_id: peerId,
+					user_id: peer.info.userId,
 					kind: producer.kind,
 					paused: producer.paused,
 					isScreen:
@@ -901,67 +901,71 @@ export class MediasoupManager {
 		const room = this.roomManager.getRoom(roomId);
 		if (!room) return [];
 
-		return Array.from(room.peers.entries())
-			.filter(([_peerId, peer]) => !peer.info.userId.startsWith('preview-'))
-			.map(([peerId, peer]) => {
-				let audioEnabled = false;
-				let videoEnabled = false;
-				for (const producer of peer.producers.values()) {
-					const isScreen =
-						(producer.appData && producer.appData.type === 'screen') || false;
-					if (producer.kind === 'audio' && !producer.paused)
-						audioEnabled = true;
-					// Count video as enabled only if it's NOT a screen share producer
-					if (producer.kind === 'video' && !producer.paused && !isScreen)
-						videoEnabled = true;
-				}
-
-				return {
-					id: peerId,
-					user_id: peerId,
+		const participants = new Map<string, ParticipantInfo>();
+		for (const peer of room.peers.values()) {
+			const participantId = peer.info.userId;
+			if (participantId.startsWith('preview-')) continue;
+			let participant = participants.get(participantId);
+			if (!participant) {
+				participant = {
+					id: participantId,
+					user_id: participantId,
 					senderId: peer.info.senderId,
 					sender_id: peer.info.senderId,
 					is_host: peer.info.isHost || false,
 					info: {
 						name: peer.info.name,
-						userId: peer.info.userId,
+						userId: participantId,
 						avatar: peer.info.avatar,
-						audio_enabled: audioEnabled,
-						video_enabled: videoEnabled,
+						audio_enabled: false,
+						video_enabled: false,
 						is_guest: peer.info.is_guest || false,
 					},
 				};
-			});
+				participants.set(participantId, participant);
+			}
+			let audioEnabled = false;
+			let videoEnabled = false;
+			for (const producer of peer.producers.values()) {
+				const isScreen =
+					(producer.appData && producer.appData.type === 'screen') || false;
+				if (producer.kind === 'audio' && !producer.paused) audioEnabled = true;
+				// Count video as enabled only if it's NOT a screen share producer
+				if (producer.kind === 'video' && !producer.paused && !isScreen)
+					videoEnabled = true;
+			}
+
+			participant.info.audio_enabled ||= audioEnabled;
+			participant.info.video_enabled ||= videoEnabled;
+			participant.is_host ||= peer.info.isHost || false;
+		}
+		return Array.from(participants.values());
 	}
 
 	applyMediaControl(
 		roomId: string,
-		peerId: string,
+		participantId: string,
 		action: MediaControlAction,
 	): void {
 		const room = this.roomManager.getRoom(roomId);
 		if (!room) return;
 
-		const peer = room.peers.get(peerId);
-		if (!peer) return;
-
-		const setFlag = (k: 'audio_enabled' | 'video_enabled', v: boolean) => {
-			peer.info[k] = v;
-		};
-
-		switch (action) {
-			case 'mute':
-				setFlag('audio_enabled', false);
-				break;
-			case 'unmute':
-				setFlag('audio_enabled', true);
-				break;
-			case 'video_off':
-				setFlag('video_enabled', false);
-				break;
-			case 'video_on':
-				setFlag('video_enabled', true);
-				break;
+		for (const peer of room.peers.values()) {
+			if (peer.info.userId !== participantId) continue;
+			switch (action) {
+				case 'mute':
+					peer.info.audio_enabled = false;
+					break;
+				case 'unmute':
+					peer.info.audio_enabled = true;
+					break;
+				case 'video_off':
+					peer.info.video_enabled = false;
+					break;
+				case 'video_on':
+					peer.info.video_enabled = true;
+					break;
+			}
 		}
 	}
 
@@ -976,6 +980,13 @@ export class MediasoupManager {
 	peerExistsInRoom(roomId: string, peerId: string): boolean {
 		const room = this.roomManager.getRoom(roomId);
 		return room?.peers.has(peerId) || false;
+	}
+
+	participantExistsInRoom(roomId: string, participantId: string): boolean {
+		const room = this.roomManager.getRoom(roomId);
+		return Array.from(room?.peers.values() ?? []).some(
+			(peer) => peer.info.userId === participantId,
+		);
 	}
 
 	get rooms() {

--- a/suite/meet/sfu-server/src/mediasoup/__tests__/MediasoupManager.test.ts
+++ b/suite/meet/sfu-server/src/mediasoup/__tests__/MediasoupManager.test.ts
@@ -135,6 +135,89 @@ describe('MediasoupManager.createConsumer', () => {
 	});
 });
 
+describe('MediasoupManager participant connections', () => {
+	it('deduplicates participant snapshots while combining connection media', () => {
+		const mgr = createManager();
+		const internals = mgr as unknown as {
+			roomManager: { getRoom: (roomId: string) => unknown };
+		};
+		vi.spyOn(internals.roomManager, 'getRoom').mockReturnValue({
+			peers: new Map([
+				[
+					'connection-1',
+					{
+						info: { userId: 'user-1', name: 'Alice', isHost: false },
+						producers: new Map([
+							['audio', { kind: 'audio', paused: false, appData: {} }],
+						]),
+					},
+				],
+				[
+					'connection-2',
+					{
+						info: { userId: 'user-1', name: 'Alice', isHost: true },
+						producers: new Map([
+							['video', { kind: 'video', paused: false, appData: {} }],
+						]),
+					},
+				],
+			]),
+		} as never);
+
+		const participants = mgr.getRoomParticipants('room-1');
+
+		expect(participants).toHaveLength(1);
+		expect(participants[0]).toMatchObject({
+			id: 'user-1',
+			user_id: 'user-1',
+			is_host: true,
+			info: { userId: 'user-1', audio_enabled: true, video_enabled: true },
+		});
+	});
+
+	it('excludes every connection owned by the requesting participant', async () => {
+		const mgr = createManager();
+		const internals = mgr as unknown as {
+			roomManager: { getRoom: (roomId: string) => unknown };
+		};
+		const producer = (id: string) => ({
+			id,
+			kind: 'video',
+			paused: false,
+			appData: {},
+		});
+		vi.spyOn(internals.roomManager, 'getRoom').mockReturnValue({
+			peers: new Map([
+				[
+					'connection-1',
+					{
+						info: { userId: 'user-1' },
+						producers: new Map([['own-1', producer('own-1')]]),
+					},
+				],
+				[
+					'connection-2',
+					{
+						info: { userId: 'user-1' },
+						producers: new Map([['own-2', producer('own-2')]]),
+					},
+				],
+				[
+					'connection-3',
+					{
+						info: { userId: 'user-2' },
+						producers: new Map([['remote', producer('remote')]]),
+					},
+				],
+			]),
+		} as never);
+
+		await expect(mgr.getExistingProducers('room-1', 'user-1')).resolves.toEqual(
+			[expect.objectContaining({ id: 'remote', user_id: 'user-2' })],
+		);
+	});
+});
+
 describe('MediasoupManager resource access', () => {
 	it('removes every peer resource before closing a populated room', async () => {
 		const mgr = createManager();

--- a/suite/meet/sfu-server/src/server/E2EEEpochRelay.ts
+++ b/suite/meet/sfu-server/src/server/E2EEEpochRelay.ts
@@ -196,9 +196,9 @@ export class E2EEEpochRelay {
 			const socket = this.io.sockets.sockets.get(socketId) as
 				| TypedSocket
 				| undefined;
-			if (!socket?.participantId || socket.senderId === excludedSenderId)
-				continue;
-			this.emitToTarget(roomId, socket.participantId, {
+			const peerId = socket?.peerId ?? socket?.participantId;
+			if (!peerId || socket?.senderId === excludedSenderId) continue;
+			this.emitToTarget(roomId, peerId, {
 				type: 'key-package-request',
 				epochNumber,
 				reason,
@@ -328,7 +328,7 @@ export class E2EEEpochRelay {
 			await this.hydrate();
 			if (socket.scope !== 'full') return;
 			const roomId = socket.roomId;
-			const fromParticipantId = socket.participantId;
+			const fromParticipantId = socket.peerId ?? socket.participantId;
 			const fromSenderId = socket.senderId;
 			loggers.socketHandler.debug(
 				'[DEBUG-e2ee] SFU: epoch envelope received %o',
@@ -1487,7 +1487,7 @@ export class E2EEEpochRelay {
 
 		for (const socketId of socketsInRoom) {
 			const socket = this.io.sockets.sockets.get(socketId);
-			if (socket && socket.participantId === participantId) {
+			if (socket && (socket.peerId ?? socket.participantId) === participantId) {
 				return socket;
 			}
 		}

--- a/suite/meet/sfu-server/src/server/RoomRegistry.ts
+++ b/suite/meet/sfu-server/src/server/RoomRegistry.ts
@@ -35,7 +35,6 @@ export class RoomRegistry {
 	private hostOnlyChat: Record<string, boolean> = {};
 	private recentChatMessages: Record<string, ChatMessage[]> = {};
 	private pinnedChatMessage: Record<string, PinnedChatMessage> = {};
-	private participantSockets: Record<string, Record<string, string>> = {};
 	private participantConnections = new Map<string, Map<string, Set<string>>>();
 	private activePolls: Record<string, Map<string, ActivePoll>> = {};
 	private fullAccessSockets: Map<string, Set<string>> = new Map();
@@ -155,20 +154,20 @@ export class RoomRegistry {
 		socket: Socket,
 		roomId: string,
 		participantId: string,
-	): void {
-		if (!this.participantSockets[roomId]) this.participantSockets[roomId] = {};
+	): boolean {
 		let participants = this.participantConnections.get(roomId);
 		if (!participants) {
 			participants = new Map();
 			this.participantConnections.set(roomId, participants);
 		}
 		let connections = participants.get(participantId);
+		const isFirstConnection = !connections || connections.size === 0;
 		if (!connections) {
 			connections = new Set();
 			participants.set(participantId, connections);
 		}
 		connections.add(socket.id);
-		this.participantSockets[roomId][participantId] = socket.id;
+		return isFirstConnection;
 	}
 
 	releaseParticipant(
@@ -178,17 +177,13 @@ export class RoomRegistry {
 	): boolean {
 		const participants = this.participantConnections.get(roomId);
 		const connections = participants?.get(participantId);
-		connections?.delete(socket.id);
+		if (!connections?.delete(socket.id)) return false;
 		if (connections?.size === 0) {
 			participants?.delete(participantId);
 			if (participants?.size === 0) this.participantConnections.delete(roomId);
+			return true;
 		}
-		if (this.participantSockets[roomId]?.[participantId] !== socket.id) {
-			return false;
-		}
-
-		delete this.participantSockets[roomId][participantId];
-		return true;
+		return false;
 	}
 
 	hasHumanParticipants(roomId: string): boolean {
@@ -286,7 +281,6 @@ export class RoomRegistry {
 		delete this.hostOnlyChat[roomId];
 		delete this.recentChatMessages[roomId];
 		delete this.pinnedChatMessage[roomId];
-		delete this.participantSockets[roomId];
 		this.participantConnections.delete(roomId);
 		delete this.activePolls[roomId];
 		this.fullAccessSockets.delete(roomId);

--- a/suite/meet/sfu-server/src/server/__tests__/RoomRegistry.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/RoomRegistry.test.ts
@@ -108,6 +108,35 @@ describe('RoomRegistry', () => {
 		expect(registry.hasHumanParticipants('r1')).toBe(false);
 	});
 
+	it('reports departure only after the last connection regardless of leave order', () => {
+		const { io } = makeIo();
+		const registry = new RoomRegistry(io);
+		const first = makeSocket('first');
+		const second = makeSocket('second');
+
+		expect(registry.claimParticipant(first, 'r1', 'p1')).toBe(true);
+		expect(registry.claimParticipant(second, 'r1', 'p1')).toBe(false);
+		expect(registry.releaseParticipant(second, 'r1', 'p1')).toBe(false);
+		expect(registry.hasHumanParticipants('r1')).toBe(true);
+		expect(registry.releaseParticipant(first, 'r1', 'p1')).toBe(true);
+		expect(registry.hasHumanParticipants('r1')).toBe(false);
+	});
+
+	it('assigns independent E2EE sender IDs to participant connections', () => {
+		const { io } = makeIo();
+		const registry = new RoomRegistry(io);
+
+		const first = registry.assignSenderId('r1', 'peer-1');
+		const second = registry.assignSenderId('r1', 'peer-2');
+
+		expect(first).not.toBe(second);
+		expect(registry.assignSenderId('r1', 'peer-1')).toBe(first);
+		registry.removeSender('r1', 'peer-1');
+		expect(registry.getParticipantToSender().get('r1')?.get('peer-2')).toBe(
+			second,
+		);
+	});
+
 	it('does not count preview or recorder sockets as humans', () => {
 		const { io } = makeIo();
 		const registry = new RoomRegistry(io);

--- a/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
@@ -453,7 +453,7 @@ describe('SocketHandlerManager characterization', () => {
 		);
 		expect(harness.mediasoup.addPeer).toHaveBeenCalledWith(
 			'room-1',
-			'user-1',
+			'sock-A',
 			expect.objectContaining({
 				userId: 'user-1',
 				name: 'Alice',
@@ -480,6 +480,48 @@ describe('SocketHandlerManager characterization', () => {
 				userData: expect.objectContaining({ userId: 'user-1', name: 'Alice' }),
 			}),
 		);
+	});
+
+	it('keeps same-user participant connections and E2EE sender identities independent', async () => {
+		const harness = createManager();
+		const first = connectFullSocket(harness, {
+			id: 'connection-1',
+			userId: 'user-1',
+		});
+		emitJoin(first);
+		await new Promise((resolve) => setImmediate(resolve));
+		first.emitCalls.length = 0;
+
+		const second = connectFullSocket(harness, {
+			id: 'connection-2',
+			userId: 'user-1',
+		});
+		emitJoin(second);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(harness.mediasoup.addPeer).toHaveBeenCalledWith(
+			'room-1',
+			'connection-1',
+			expect.objectContaining({ userId: 'user-1' }),
+		);
+		expect(harness.mediasoup.addPeer).toHaveBeenCalledWith(
+			'room-1',
+			'connection-2',
+			expect.objectContaining({ userId: 'user-1' }),
+		);
+		expect(first.senderId).not.toBe(second.senderId);
+		expect(
+			await harness.roster.get('room-1', first.senderId ?? -1),
+		).toMatchObject({ participantId: 'connection-1' });
+		expect(
+			await harness.roster.get('room-1', second.senderId ?? -1),
+		).toMatchObject({ participantId: 'connection-2' });
+		expect(
+			first.emitCalls.some((call) => call.event === 'participant_joined'),
+		).toBe(false);
+		expect(
+			second.emitCalls.some((call) => call.event === 'participant_joined'),
+		).toBe(false);
 	});
 
 	it('join_room with scope:presence-preview tracks the socket in previewSockets, skips mediasoup.addPeer, and still emits existing_raised_hands', async () => {
@@ -804,7 +846,7 @@ describe('SocketHandlerManager characterization', () => {
 
 		expect(harness.mediasoup.removePeer).toHaveBeenCalledWith(
 			'room-1',
-			'user-1',
+			'sock-X',
 		);
 		expect(stay.emitCalls.some((c) => c.event === 'participant_left')).toBe(
 			true,
@@ -816,7 +858,7 @@ describe('SocketHandlerManager characterization', () => {
 
 		expect(harness.mediasoup.removePeer).toHaveBeenCalledWith(
 			'room-1',
-			'stay-1',
+			'sock-stay',
 		);
 		expect(harness.mediasoup.closeRoom).not.toHaveBeenCalled();
 		await vi.advanceTimersByTimeAsync(1);
@@ -825,7 +867,7 @@ describe('SocketHandlerManager characterization', () => {
 		vi.useRealTimers();
 	});
 
-	it('disconnect of an older duplicate full-access socket does not remove the current peer', async () => {
+	it('disconnecting one participant connection preserves the other connection', async () => {
 		const harness = createManager();
 
 		const older = connectFullSocket(harness, {
@@ -846,14 +888,21 @@ describe('SocketHandlerManager characterization', () => {
 		older.fire('disconnect');
 		await new Promise((r) => setImmediate(r));
 
-		expect(harness.mediasoup.removePeer).not.toHaveBeenCalled();
+		expect(harness.mediasoup.removePeer).toHaveBeenCalledWith(
+			'room-1',
+			'sock-old',
+		);
+		expect(
+			current.emitCalls.some((call) => call.event === 'participant_left'),
+		).toBe(false);
 
+		(harness.mediasoup.removePeer as ReturnType<typeof vi.fn>).mockClear();
 		current.fire('disconnect');
 		await new Promise((r) => setImmediate(r));
 
 		expect(harness.mediasoup.removePeer).toHaveBeenCalledWith(
 			'room-1',
-			'user-1',
+			'sock-current',
 		);
 	});
 
@@ -881,8 +930,14 @@ describe('SocketHandlerManager characterization', () => {
 		older.fire('leave_room');
 		await new Promise((r) => setImmediate(r));
 
-		expect(harness.mediasoup.removePeer).not.toHaveBeenCalled();
+		expect(harness.mediasoup.removePeer).toHaveBeenCalledWith(
+			'room-1',
+			'sock-old',
+		);
 		expect(harness.mediasoup.closeRoom).not.toHaveBeenCalled();
+		expect(
+			current.emitCalls.some((call) => call.event === 'participant_left'),
+		).toBe(false);
 	});
 
 	it('keeps previews connected while grace cleanup evicts recorders and closes media', async () => {
@@ -962,6 +1017,10 @@ describe('SocketHandlerManager characterization', () => {
 			action: 'mute_participant',
 			targetParticipantId: 'target-1',
 		});
+		expect(harness.mediasoup.participantExistsInRoom).toHaveBeenCalledWith(
+			'room-1',
+			'target-1',
+		);
 
 		const targetUpdate = target.emitCalls.find(
 			(c) => c.event === 'host_control_update',
@@ -1014,6 +1073,45 @@ describe('SocketHandlerManager characterization', () => {
 		expect(
 			anotherTarget.emitCalls.some((c) => c.event === 'host_control_update'),
 		).toBe(false);
+	});
+
+	it('host control targets every Participant Connection for a participant', async () => {
+		const harness = createManager();
+		const host = connectFullSocket(harness, {
+			id: 'sock-host',
+			userId: 'host-1',
+			isHost: true,
+		});
+		const first = connectFullSocket(harness, {
+			id: 'sock-target-1',
+			userId: 'target-1',
+		});
+		const second = connectFullSocket(harness, {
+			id: 'sock-target-2',
+			userId: 'target-1',
+		});
+		emitJoin(host, { userId: 'host-1', name: 'Host' });
+		emitJoin(first, { userId: 'target-1', name: 'Target' });
+		emitJoin(second, { userId: 'target-1', name: 'Target' });
+		await new Promise((resolve) => setImmediate(resolve));
+		harness.io.socketsAdapterRooms.set(
+			'room-1',
+			new Set([host.id, first.id, second.id]),
+		);
+		first.emitCalls.length = 0;
+		second.emitCalls.length = 0;
+
+		host.fire('host_control', {
+			action: 'mute_participant',
+			targetParticipantId: 'target-1',
+		});
+
+		expect(
+			first.emitCalls.some((call) => call.event === 'host_control_update'),
+		).toBe(true);
+		expect(
+			second.emitCalls.some((call) => call.event === 'host_control_update'),
+		).toBe(true);
 	});
 
 	it('create_producer broadcasts screen producers to existing full-access participants', async () => {

--- a/suite/meet/sfu-server/src/server/__tests__/test-helpers.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/test-helpers.ts
@@ -181,6 +181,7 @@ function createMockMediasoupManager(): MediasoupManager {
 		addPeer: vi.fn(),
 		removePeer: vi.fn().mockResolvedValue(undefined),
 		peerExistsInRoom: vi.fn().mockReturnValue(true),
+		participantExistsInRoom: vi.fn().mockReturnValue(true),
 		createWebRtcTransport: vi.fn().mockResolvedValue({
 			id: 'transport-1',
 			iceParameters: {},

--- a/suite/meet/sfu-server/src/server/handlers/ConsumerHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/ConsumerHandlers.ts
@@ -1,7 +1,7 @@
 import type { Socket } from 'socket.io';
 import { loggers } from '../../utils/logger';
 import type { HandlerDeps } from './Handler';
-import { getRoomId } from './utils';
+import { getPeerId, getRoomId } from './utils';
 
 export function registerConsumerHandlers(deps: HandlerDeps) {
 	return (socket: Socket) => {
@@ -23,7 +23,7 @@ export function registerConsumerHandlers(deps: HandlerDeps) {
 					transportId,
 					producerId,
 					roomId,
-					socket.userId,
+					getPeerId(socket),
 					rtpCapabilities,
 				);
 				media =
@@ -60,7 +60,7 @@ export function registerConsumerHandlers(deps: HandlerDeps) {
 				deps.mediasoup.assertConsumerAccess(
 					consumerId,
 					getRoomId(socket),
-					socket.userId,
+					getPeerId(socket),
 				);
 				await deps.mediasoup.closeConsumer(consumerId);
 
@@ -85,7 +85,7 @@ export function registerConsumerHandlers(deps: HandlerDeps) {
 				deps.mediasoup.assertConsumerAccess(
 					consumerId,
 					getRoomId(socket),
-					socket.userId,
+					getPeerId(socket),
 				);
 
 				const visible = Boolean(data.visible);
@@ -116,7 +116,7 @@ export function registerConsumerHandlers(deps: HandlerDeps) {
 				deps.mediasoup.assertConsumerAccess(
 					consumerId,
 					getRoomId(socket),
-					socket.userId,
+					getPeerId(socket),
 				);
 				const requested =
 					await deps.mediasoup.requestConsumerKeyFrame(consumerId);

--- a/suite/meet/sfu-server/src/server/handlers/DisconnectHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/DisconnectHandlers.ts
@@ -24,11 +24,12 @@ export function registerDisconnectHandlers(deps: HandlerDeps) {
 
 			const roomId = socket.roomId;
 			const participantId = socket.participantId;
+			const peerId = socket.peerId ?? participantId;
 			if (socket.scope === 'recording') {
 				deps.registry.deactivateRecorder(socket);
 			}
 
-			if (roomId && participantId) {
+			if (roomId && participantId && peerId) {
 				try {
 					if (socket.scope === 'recording') {
 						const ownsPeer = deps.registry.leaveRecorder(
@@ -44,22 +45,19 @@ export function registerDisconnectHandlers(deps: HandlerDeps) {
 					deps.registry.leaveScope(socket, roomId, 'presence-preview');
 
 					if (socket.scope === 'full') {
-						const shouldCleanupPeer = deps.registry.releaseParticipant(
+						const participantDeparted = deps.registry.releaseParticipant(
 							socket,
 							roomId,
 							participantId,
 						);
-						if (shouldCleanupPeer) {
-							if (socket.senderId !== undefined) {
-								await deps.e2eeRoster.remove(roomId, socket.senderId);
-								deps.e2eeEpochRelay.removePendingJoiner(
-									roomId,
-									socket.senderId,
-								);
-							}
-							deps.registry.removeSender(roomId, participantId);
-							await deps.mediasoup.removePeer(roomId, participantId);
+						if (socket.senderId !== undefined) {
+							await deps.e2eeRoster.remove(roomId, socket.senderId);
+							deps.e2eeEpochRelay.removePendingJoiner(roomId, socket.senderId);
+						}
+						deps.registry.removeSender(roomId, peerId);
+						await deps.mediasoup.removePeer(roomId, peerId);
 
+						if (participantDeparted) {
 							if (isRealParticipant(participantId)) {
 								deps.registry.emitParticipantEvent(
 									roomId,

--- a/suite/meet/sfu-server/src/server/handlers/HostControlHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/HostControlHandlers.ts
@@ -1,7 +1,7 @@
 import type { Socket } from 'socket.io';
 import { loggers } from '../../utils/logger';
 import type { HandlerDeps } from './Handler';
-import { findSocketByParticipantId } from './utils';
+import { findSocketsByParticipantId } from './utils';
 
 export function registerHostControlHandlers(deps: HandlerDeps) {
 	return (socket: Socket) => {
@@ -32,7 +32,9 @@ export function registerHostControlHandlers(deps: HandlerDeps) {
 					return;
 				}
 
-				if (!deps.mediasoup.peerExistsInRoom(roomId, targetParticipantId)) {
+				if (
+					!deps.mediasoup.participantExistsInRoom(roomId, targetParticipantId)
+				) {
 					socket.emit('sfu_error', {
 						error: 'Target participant not found',
 						timestamp: new Date().toISOString(),
@@ -40,13 +42,13 @@ export function registerHostControlHandlers(deps: HandlerDeps) {
 					return;
 				}
 
-				const targetSocket = findSocketByParticipantId(
+				const targetSockets = findSocketsByParticipantId(
 					deps.io,
 					roomId,
 					targetParticipantId,
 				);
 
-				if (!targetSocket) {
+				if (targetSockets.length === 0) {
 					socket.emit('sfu_error', {
 						error: 'Target participant socket not found',
 						timestamp: new Date().toISOString(),
@@ -56,12 +58,14 @@ export function registerHostControlHandlers(deps: HandlerDeps) {
 
 				switch (action) {
 					case 'mute_participant':
-						targetSocket.emit('host_control_update', {
-							action,
-							targetParticipantId,
-							hostId: socket.participantId,
-							timestamp: new Date().toISOString(),
-						});
+						for (const targetSocket of targetSockets) {
+							targetSocket.emit('host_control_update', {
+								action,
+								targetParticipantId,
+								hostId: socket.participantId,
+								timestamp: new Date().toISOString(),
+							});
+						}
 						loggers.socketHandler.info(
 							'Host %s sent mute command to participant %s in room %s',
 							socket.participantId,
@@ -70,37 +74,44 @@ export function registerHostControlHandlers(deps: HandlerDeps) {
 						);
 						break;
 					case 'kick_participant': {
-						const targetSenderId = targetSocket.senderId;
-						targetSocket.emit('host_control_update', {
-							action,
-							targetParticipantId,
-							hostId: socket.participantId,
-							timestamp: new Date().toISOString(),
-						});
+						const targetSenderIds = targetSockets
+							.map((targetSocket) => targetSocket.senderId)
+							.filter((senderId): senderId is number => senderId !== undefined);
+						for (const targetSocket of targetSockets) {
+							targetSocket.emit('host_control_update', {
+								action,
+								targetParticipantId,
+								hostId: socket.participantId,
+								timestamp: new Date().toISOString(),
+							});
+						}
 
 						loggers.socketHandler.info(
-							'Host %s kicked participant %s (senderId=%s) from room %s',
+							'Host %s kicked participant %s (senderIds=%s) from room %s',
 							socket.participantId,
 							targetParticipantId,
-							targetSenderId,
+							targetSenderIds.join(','),
 							roomId,
 						);
-						if (targetSocket.e2eeRequired && targetSenderId !== undefined) {
+						if (
+							targetSockets.some((targetSocket) => targetSocket.e2eeRequired) &&
+							targetSenderIds.length > 0
+						) {
 							await deps.e2eeEpochRelay.requestCommitForRemoval(
 								roomId,
-								[targetSenderId],
+								targetSenderIds,
 								deps.e2eeEpochRelay.getCurrentEpochNumber(roomId),
 							);
 						}
 
 						setTimeout(() => {
-							if (targetSocket.connected) {
-								targetSocket.disconnect(true);
-								loggers.socketHandler.info(
-									'Forcefully disconnected kicked participant %s',
-									targetParticipantId,
-								);
+							for (const targetSocket of targetSockets) {
+								if (targetSocket.connected) targetSocket.disconnect(true);
 							}
+							loggers.socketHandler.info(
+								'Forcefully disconnected kicked participant %s',
+								targetParticipantId,
+							);
 						}, 1000);
 						break;
 					}

--- a/suite/meet/sfu-server/src/server/handlers/ProducerHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/ProducerHandlers.ts
@@ -8,7 +8,7 @@ import type {
 } from '../../types';
 import { loggers } from '../../utils/logger';
 import type { HandlerDeps } from './Handler';
-import { getRoomId } from './utils';
+import { getPeerId, getRoomId } from './utils';
 
 export function registerProducerHandlers(deps: HandlerDeps) {
 	return (socket: Socket) => {
@@ -28,7 +28,7 @@ export function registerProducerHandlers(deps: HandlerDeps) {
 				const producer = await deps.mediasoup.createProducer(
 					transportId,
 					roomId,
-					socket.userId,
+					getPeerId(socket),
 					rtpParameters,
 					kind,
 					appData,
@@ -80,7 +80,7 @@ export function registerProducerHandlers(deps: HandlerDeps) {
 				deps.mediasoup.assertProducerAccess(
 					producerId,
 					getRoomId(socket),
-					socket.userId,
+					getPeerId(socket),
 				);
 				const result = deps.mediasoup.closeProducer(producerId);
 
@@ -110,7 +110,7 @@ export function registerProducerHandlers(deps: HandlerDeps) {
 					for (const rc of result.removedConsumers) {
 						const targetPeerSocket = Array.from(
 							deps.io.sockets.sockets.values(),
-						).find((s) => s.userId === rc.peerId && s.roomId === rc.roomId);
+						).find((s) => s.peerId === rc.peerId && s.roomId === rc.roomId);
 						if (targetPeerSocket) {
 							targetPeerSocket.emit('consumer_closed', {
 								consumerId: rc.consumerId,
@@ -145,7 +145,7 @@ export function registerProducerHandlers(deps: HandlerDeps) {
 				deps.mediasoup.assertProducerAccess(
 					producerId,
 					getRoomId(socket),
-					socket.userId,
+					getPeerId(socket),
 				);
 				const paused = await deps.mediasoup.pauseProducer(producerId);
 
@@ -166,7 +166,7 @@ export function registerProducerHandlers(deps: HandlerDeps) {
 				deps.mediasoup.assertProducerAccess(
 					producerId,
 					getRoomId(socket),
-					socket.userId,
+					getPeerId(socket),
 				);
 				const resumed = await deps.mediasoup.resumeProducer(producerId);
 

--- a/suite/meet/sfu-server/src/server/handlers/RoomJoinHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/RoomJoinHandlers.ts
@@ -18,8 +18,10 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 		const startedAt = performance.now();
 		const scope = socket.scope ?? 'unknown';
 		let participantClaimed = false;
+		if (socket.scope === 'full' && !socket.peerId) socket.peerId = socket.id;
+		const peerId = socket.peerId ?? participantId;
 		const rejoin = Boolean(
-			deps.mediasoup.getRoomPeers?.(getRoomId(socket))?.get(participantId),
+			deps.mediasoup.getRoomPeers?.(getRoomId(socket))?.get(peerId),
 		);
 
 		try {
@@ -38,8 +40,11 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 			if (socket.scope === 'full') {
 				await deps.mediasoup.createRoom(
 					scopedRoomId,
-					(roomIdInner, participantIds) => {
-						deps.registry.emitActiveSpeaker(roomIdInner, participantIds);
+					(roomIdInner, peerIds) => {
+						deps.registry.emitActiveSpeaker(
+							roomIdInner,
+							participantIdsForPeers(deps, roomIdInner, peerIds),
+						);
 					},
 				);
 			}
@@ -51,16 +56,17 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 
 			if (socket.scope === 'full') {
 				deps.registry.joinScope(socket, scopedRoomId, 'full');
-				deps.registry.claimParticipant(socket, scopedRoomId, participantId);
-				participantClaimed = true;
-				const senderId = deps.registry.assignSenderId(
+				const isFirstConnection = deps.registry.claimParticipant(
+					socket,
 					scopedRoomId,
 					participantId,
 				);
+				participantClaimed = true;
+				const senderId = deps.registry.assignSenderId(scopedRoomId, peerId);
 				socket.senderId = senderId;
 				if (!socket.e2eeRequired) {
 					await deps.e2eeRoster.add(scopedRoomId, {
-						participantId,
+						participantId: peerId,
 						senderId,
 						isHost: Boolean(socket.isHost),
 						joinedAt: Date.now(),
@@ -70,22 +76,22 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 
 				const existingPeer = deps.mediasoup
 					.getRoomPeers?.(scopedRoomId)
-					?.get(participantId);
+					?.get(peerId);
 				if (existingPeer) {
 					loggers.socketHandler.info(
 						'Peer %s already in room %s — clearing stale transports/producers before rejoin',
-						participantId,
+						peerId,
 						scopedRoomId,
 					);
-					await deps.mediasoup.removePeer(scopedRoomId, participantId);
+					await deps.mediasoup.removePeer(scopedRoomId, peerId);
 				}
-				deps.mediasoup.addPeer(scopedRoomId, participantId, {
+				deps.mediasoup.addPeer(scopedRoomId, peerId, {
 					...userData,
 					senderId: socket.senderId,
 					isHost: Boolean(socket.isHost),
 				});
 
-				if (isRealParticipant(userData.userId)) {
+				if (isFirstConnection && isRealParticipant(userData.userId)) {
 					deps.registry.emitParticipantEvent(
 						scopedRoomId,
 						'participant_joined',
@@ -182,12 +188,12 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 					throw new Error('Room ID mismatch');
 				const roomId = getRoomId(socket);
 				const peerId = socket.userId;
-				await deps.mediasoup.createRoom(
-					roomId,
-					(roomIdInner, participantIds) => {
-						deps.registry.emitActiveSpeaker(roomIdInner, participantIds);
-					},
-				);
+				await deps.mediasoup.createRoom(roomId, (roomIdInner, peerIds) => {
+					deps.registry.emitActiveSpeaker(
+						roomIdInner,
+						participantIdsForPeers(deps, roomIdInner, peerIds),
+					);
+				});
 				socket.join(roomId);
 				socket.roomId = roomId;
 				socket.participantId = peerId;
@@ -236,7 +242,7 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 					socket,
 					deps,
 					getRoomId(socket),
-					socket.userId,
+					socket.peerId ?? socket.userId,
 				).catch((error: unknown) => {
 					deps.telemetry.recordE2EEEvent('join-status', 'failure');
 					loggers.socketHandler.error(
@@ -280,19 +286,22 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 							await deps.mediasoup.removePeer(roomId, participantId);
 						}
 					}
-					const shouldCleanupPeer = deps.registry.releaseParticipant(
+					const participantDeparted = deps.registry.releaseParticipant(
 						socket,
 						roomId,
 						participantId,
 					);
-					if (shouldCleanupPeer) {
+					const peerId = socket.peerId ?? participantId;
+					if (socket.scope === 'full') {
 						if (socket.senderId !== undefined) {
 							await deps.e2eeRoster.remove(roomId, socket.senderId);
 							deps.e2eeEpochRelay.removePendingJoiner(roomId, socket.senderId);
 						}
-						deps.registry.removeSender(roomId, participantId);
-						await deps.mediasoup.removePeer(roomId, participantId);
+						deps.registry.removeSender(roomId, peerId);
+						await deps.mediasoup.removePeer(roomId, peerId);
+					}
 
+					if (participantDeparted) {
 						if (isRealParticipant(participantId)) {
 							deps.registry.emitParticipantEvent(
 								roomId,
@@ -318,6 +327,7 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 					deps.registry.leaveScope(socket, roomId, 'full');
 					deps.registry.leaveScope(socket, roomId, 'presence-preview');
 					socket.roomId = undefined;
+					socket.peerId = undefined;
 					loggers.socketHandler.info('%s left room %s', participantId, roomId);
 				} catch (e) {
 					loggers.socketHandler.warn(
@@ -328,6 +338,23 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 			}
 		});
 	};
+}
+
+function participantIdsForPeers(
+	deps: HandlerDeps,
+	roomId: string,
+	peerIds: string[],
+): string[] {
+	const peers = deps.mediasoup.getRoomPeers?.(roomId);
+	return Array.from(
+		new Set(
+			peerIds
+				.map((peerId) => peers?.get(peerId)?.info.userId)
+				.filter((participantId): participantId is string =>
+					Boolean(participantId),
+				),
+		),
+	);
 }
 
 function enforceE2EEJoinPolicy(

--- a/suite/meet/sfu-server/src/server/handlers/WebRtcTransportHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/WebRtcTransportHandlers.ts
@@ -2,7 +2,7 @@ import type { Socket } from 'socket.io';
 import { direction } from '../../telemetry/Telemetry';
 import { loggers } from '../../utils/logger';
 import type { HandlerDeps } from './Handler';
-import { getRoomId } from './utils';
+import { getPeerId, getRoomId } from './utils';
 
 export function registerWebRtcTransportHandlers(deps: HandlerDeps) {
 	return (socket: Socket) => {
@@ -19,11 +19,11 @@ export function registerWebRtcTransportHandlers(deps: HandlerDeps) {
 					throw new Error('Recorder send transports are not permitted');
 				enforceE2EETransportPolicy(socket, encryptionEnabled);
 				const roomId = getRoomId(socket);
-				const userId = socket.userId;
+				const peerId = getPeerId(socket);
 
 				const transportParams = await deps.mediasoup.createWebRtcTransport(
 					roomId,
-					userId,
+					peerId,
 					direction,
 				);
 				if (socket.e2eeRequired && encryptionEnabled) {
@@ -79,7 +79,7 @@ export function registerWebRtcTransportHandlers(deps: HandlerDeps) {
 					transportId,
 					dtlsParameters,
 					getRoomId(socket),
-					socket.userId,
+					getPeerId(socket),
 					socket.scope === 'recording' ? 'recv' : undefined,
 				);
 
@@ -122,7 +122,7 @@ export function registerWebRtcTransportHandlers(deps: HandlerDeps) {
 				const iceParameters = await deps.mediasoup.restartWebRtcTransportIce(
 					transportId,
 					getRoomId(socket),
-					socket.userId,
+					getPeerId(socket),
 					socket.scope === 'recording' ? 'recv' : undefined,
 				);
 
@@ -163,11 +163,11 @@ export function registerWebRtcTransportHandlers(deps: HandlerDeps) {
 				deps.authManager.ensureFullAccess(socket);
 
 				const roomId = getRoomId(socket);
-				const userId = socket.userId;
+				const peerId = getPeerId(socket);
 
 				const transportParams = await deps.mediasoup.createPlainTransport(
 					roomId,
-					userId,
+					peerId,
 				);
 
 				callback({ success: true, ...transportParams });

--- a/suite/meet/sfu-server/src/server/handlers/utils.ts
+++ b/suite/meet/sfu-server/src/server/handlers/utils.ts
@@ -16,6 +16,10 @@ export function getRoomId(socket: Socket): string {
 	return `${site}::${meetingId}`;
 }
 
+export function getPeerId(socket: Socket): string {
+	return socket.peerId ?? socket.userId;
+}
+
 export function checkSocketRateLimits(
 	socket: Socket,
 	rateLimiter: RateLimiter,
@@ -57,20 +61,21 @@ export function checkSocketRateLimits(
 	return userAllowed && ipAllowed;
 }
 
-export function findSocketByParticipantId(
+export function findSocketsByParticipantId(
 	io: Server,
 	roomId: string,
 	participantId: string,
-): TypedSocket | null {
+): TypedSocket[] {
 	const socketsInRoom = io.sockets.adapter.rooms.get(roomId);
-	if (!socketsInRoom) return null;
+	if (!socketsInRoom) return [];
 
+	const matches: TypedSocket[] = [];
 	for (const socketId of socketsInRoom) {
 		const socket = io.sockets.sockets.get(socketId) as TypedSocket | undefined;
 		if (socket && socket.participantId === participantId) {
-			return socket;
+			matches.push(socket);
 		}
 	}
 
-	return null;
+	return matches;
 }

--- a/suite/meet/sfu-server/src/types/index.ts
+++ b/suite/meet/sfu-server/src/types/index.ts
@@ -316,6 +316,7 @@ export type ClientTelemetryEvent =
 
 export interface SocketData {
 	userId: string;
+	peerId?: string;
 	userName: string;
 	meetingId: string;
 	isHost: boolean;
@@ -653,6 +654,7 @@ export type E2eeEpochJoinStatus = {
 declare module 'socket.io' {
 	interface Socket {
 		userId: string;
+		peerId?: string;
 		userName: string;
 		meetingId: string;
 		site?: string;


### PR DESCRIPTION
## Summary

- isolate SFU media ownership per Participant Connection while preserving participant-facing identity
- aggregate participant media state and route active-speaker and E2EE messages at the correct scope
- apply host controls across every endpoint owned by a participant