### PR TITLE
fix(meet): clean up closed producers

### DIFF
--- a/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
@@ -12,6 +12,9 @@ import type {
 	Peer,
 	PeerInfo,
 	ProducerAppData,
+	ProducerCloseDetails,
+	ProducerCloseReason,
+	ProducerCloseSource,
 	ProducerData,
 	Room,
 	RtpCapabilities,
@@ -27,6 +30,22 @@ import { ProducerManager } from './ProducerManager';
 import { RoomManager } from './RoomManager';
 import { TransportManager } from './TransportManager';
 import { WorkerManager } from './WorkerManager';
+
+export interface ProducerCloseMetadata {
+	reason?: ProducerCloseReason;
+	source?: ProducerCloseSource;
+	details?: ProducerCloseDetails;
+}
+
+export interface ProducerClosedLifecycle extends ProducerCloseMetadata {
+	roomId: string;
+	peerId: string;
+	participantId: string;
+	producerId: string;
+	kind: 'audio' | 'video';
+	isScreen: boolean;
+	removedConsumers: CloseProducerResult['removedConsumers'];
+}
 
 export class MediasoupManager {
 	private readonly closingRooms = new Set<string>();
@@ -46,6 +65,9 @@ export class MediasoupManager {
 	> = [];
 	private mediaScoreListeners: Array<
 		(direction: 'send' | 'recv', kind: 'audio' | 'video', score: number) => void
+	> = [];
+	private producerClosedListeners: Array<
+		(event: ProducerClosedLifecycle) => void
 	> = [];
 
 	private peerScores = new Map<
@@ -106,6 +128,12 @@ export class MediasoupManager {
 					delete peerState[kind];
 					this.evaluateAndEmitNetworkQuality(roomId, peerId);
 				}
+			},
+		);
+		this.producerManager.on(
+			'producer_transport_closed',
+			(producerId: string) => {
+				this.closeProducer(producerId);
 			},
 		);
 	}
@@ -171,6 +199,10 @@ export class MediasoupManager {
 		) => void,
 	): void {
 		this.mediaScoreListeners.push(listener);
+	}
+
+	onProducerClosed(listener: (event: ProducerClosedLifecycle) => void): void {
+		this.producerClosedListeners.push(listener);
 	}
 
 	async getWorkerResourceUsage(): Promise<{
@@ -519,13 +551,19 @@ export class MediasoupManager {
 		return this.producerManager.getProducer(producerId);
 	}
 
-	closeProducer(producerId: string): CloseProducerResult {
+	closeProducer(
+		producerId: string,
+		metadata: ProducerCloseMetadata = {},
+	): CloseProducerResult {
 		const producerData = this.producerManager.getProducerData(producerId);
 		if (!producerData) return { isScreen: false, removedConsumers: [] };
+		const room = this.roomManager.getRoom(producerData.roomId);
+		const participantId =
+			room?.peers.get(producerData.peerId)?.info.userId ?? producerData.peerId;
+		const kind = producerData.producer.kind;
 
 		const result = this.producerManager.closeProducer(producerId);
 
-		const room = this.roomManager.getRoom(producerData.roomId);
 		if (room) {
 			const peer = room.peers.get(producerData.peerId);
 			if (peer) {
@@ -555,7 +593,30 @@ export class MediasoupManager {
 			}
 		}
 
-		return { ...result, removedConsumers };
+		const closeResult = { ...result, removedConsumers };
+		const event: ProducerClosedLifecycle = {
+			roomId: producerData.roomId,
+			peerId: producerData.peerId,
+			participantId,
+			producerId,
+			kind,
+			isScreen: closeResult.isScreen,
+			removedConsumers,
+			...metadata,
+		};
+		for (const listener of this.producerClosedListeners) {
+			try {
+				listener(event);
+			} catch (error) {
+				loggers.mediasoupManager.warn(
+					'Producer close listener failed for %s: %s',
+					producerId,
+					(error as Error).message,
+				);
+			}
+		}
+
+		return closeResult;
 	}
 
 	closeConsumer(consumerId: string): void {

--- a/suite/meet/sfu-server/src/mediasoup/ProducerManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/ProducerManager.ts
@@ -56,6 +56,9 @@ export class ProducerManager extends EventEmitter {
 		producer.on('score', (scores) => {
 			this.emit('score', roomId, peerId, kind, scores);
 		});
+		producer.on('transportclose', () => {
+			this.emit('producer_transport_closed', producer.id);
+		});
 
 		return {
 			id: producer.id,
@@ -70,18 +73,19 @@ export class ProducerManager extends EventEmitter {
 
 		const { producer } = producerData;
 		const isScreen = producer?.appData?.type === 'screen';
-
-		try {
-			producer.close();
-		} catch (error) {
-			loggers.producerManager.warn(
-				'Error closing producer %s: %s',
-				producerId,
-				(error as Error).message,
-			);
-		}
-
 		this.producers.delete(producerId);
+
+		if (!producer.closed) {
+			try {
+				producer.close();
+			} catch (error) {
+				loggers.producerManager.warn(
+					'Error closing producer %s: %s',
+					producerId,
+					(error as Error).message,
+				);
+			}
+		}
 
 		loggers.producerManager.info(
 			'Producer closed: %s%s',

--- a/suite/meet/sfu-server/src/mediasoup/__tests__/MediasoupManager.test.ts
+++ b/suite/meet/sfu-server/src/mediasoup/__tests__/MediasoupManager.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import { describe, expect, it, vi } from 'vitest';
 import { loadConfig } from '../../config';
 import type { Consumer } from '../../types';
@@ -214,6 +215,103 @@ describe('MediasoupManager participant connections', () => {
 
 		await expect(mgr.getExistingProducers('room-1', 'user-1')).resolves.toEqual(
 			[expect.objectContaining({ id: 'remote', user_id: 'user-2' })],
+		);
+	});
+});
+
+describe('MediasoupManager producer cleanup', () => {
+	it('finalizes transport-closed producers, consumers, snapshots, and notifications once', async () => {
+		const mgr = createManager();
+		const internals = mgr as unknown as {
+			producerManager: {
+				createProducer: (...args: unknown[]) => Promise<unknown>;
+				getProducerCount: () => number;
+			};
+			roomManager: { getRoom: (roomId: string) => unknown };
+		};
+		const producer = Object.assign(new EventEmitter(), {
+			id: 'producer-1',
+			kind: 'video' as const,
+			appData: {},
+			paused: false,
+			closed: false,
+			close: vi.fn(),
+		});
+		const consumer = Object.assign(new EventEmitter(), {
+			id: 'consumer-1',
+			producerId: producer.id,
+			kind: 'video' as const,
+			paused: false,
+			rtpParameters: {},
+			close: vi.fn(),
+			resume: vi.fn(),
+			requestKeyFrame: vi.fn().mockResolvedValue(undefined),
+		});
+		const publisher = {
+			info: { userId: 'publisher-1', name: 'Publisher' },
+			producers: new Map([[producer.id, producer]]),
+			consumers: new Map(),
+		};
+		const viewer = {
+			info: { userId: 'viewer-1', name: 'Viewer' },
+			producers: new Map(),
+			consumers: new Map([[consumer.id, consumer]]),
+		};
+		const room = {
+			peers: new Map([
+				['publisher-peer', publisher],
+				['viewer-peer', viewer],
+			]),
+		};
+		vi.spyOn(internals.roomManager, 'getRoom').mockReturnValue(room);
+		await internals.producerManager.createProducer(
+			{ produce: vi.fn().mockResolvedValue(producer) },
+			'room-1',
+			'publisher-peer',
+			{},
+			'video',
+		);
+		await mgr.consumerManager.createConsumer(
+			{
+				id: 'recv-1',
+				closed: false,
+				dtlsState: 'connected',
+				consume: vi.fn().mockResolvedValue(consumer),
+			} as never,
+			producer as never,
+			producer.id,
+			'room-1',
+			'viewer-peer',
+			{} as never,
+		);
+		const onProducerClosed = vi.fn();
+		mgr.onProducerClosed(onProducerClosed);
+
+		producer.closed = true;
+		producer.emit('transportclose');
+		producer.emit('transportclose');
+
+		expect(internals.producerManager.getProducerCount()).toBe(0);
+		expect(mgr.consumerManager.getConsumerCount()).toBe(0);
+		expect(publisher.producers.has(producer.id)).toBe(false);
+		expect(viewer.consumers.has(consumer.id)).toBe(false);
+		await expect(
+			mgr.getExistingProducers('room-1', 'viewer-1'),
+		).resolves.toEqual([]);
+		expect(onProducerClosed).toHaveBeenCalledTimes(1);
+		expect(onProducerClosed).toHaveBeenCalledWith(
+			expect.objectContaining({
+				roomId: 'room-1',
+				peerId: 'publisher-peer',
+				participantId: 'publisher-1',
+				producerId: 'producer-1',
+				removedConsumers: [
+					expect.objectContaining({
+						consumerId: 'consumer-1',
+						peerId: 'viewer-peer',
+					}),
+				],
+			}),
 		);
 	});
 });

--- a/suite/meet/sfu-server/src/mediasoup/__tests__/ProducerManager.test.ts
+++ b/suite/meet/sfu-server/src/mediasoup/__tests__/ProducerManager.test.ts
@@ -1,0 +1,60 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import { ProducerManager } from '../ProducerManager';
+
+function makeProducer() {
+	return Object.assign(new EventEmitter(), {
+		id: 'producer-1',
+		kind: 'video' as const,
+		appData: {},
+		closed: false,
+		close: vi.fn(),
+	});
+}
+
+describe('ProducerManager', () => {
+	it('reports transport closure for central producer finalization', async () => {
+		const manager = new ProducerManager();
+		const producer = makeProducer();
+		const transport = { produce: vi.fn().mockResolvedValue(producer) };
+		const transportClosed = vi.fn();
+		manager.on('producer_transport_closed', transportClosed);
+
+		await manager.createProducer(
+			transport as never,
+			'room-1',
+			'peer-1',
+			{} as never,
+			'video',
+		);
+		producer.emit('transportclose');
+
+		expect(transportClosed).toHaveBeenCalledWith('producer-1');
+	});
+
+	it('finalizes repeated close requests once', async () => {
+		const manager = new ProducerManager();
+		const producer = makeProducer();
+		producer.close.mockImplementation(() => {
+			producer.closed = true;
+			producer.emit('transportclose');
+		});
+		const transport = { produce: vi.fn().mockResolvedValue(producer) };
+		const closed = vi.fn();
+		manager.on('producer_closed', closed);
+
+		await manager.createProducer(
+			transport as never,
+			'room-1',
+			'peer-1',
+			{} as never,
+			'video',
+		);
+		manager.closeProducer('producer-1');
+		manager.closeProducer('producer-1');
+
+		expect(producer.close).toHaveBeenCalledTimes(1);
+		expect(closed).toHaveBeenCalledTimes(1);
+		expect(manager.getProducerCount()).toBe(0);
+	});
+});

--- a/suite/meet/sfu-server/src/server/SocketHandlerManager.ts
+++ b/suite/meet/sfu-server/src/server/SocketHandlerManager.ts
@@ -109,6 +109,27 @@ export class SocketHandlerManager {
 			registerErrorHandlers(deps),
 		];
 
+		this.mediasoup.onProducerClosed((event) => {
+			this.registry.emitProducerClosed(event.roomId, {
+				participantId: event.participantId,
+				producerId: event.producerId,
+				isScreen: event.isScreen,
+				reason: event.reason,
+				source: event.source,
+				details: event.details,
+			});
+			for (const removed of event.removedConsumers) {
+				const targetSocket = Array.from(this.io.sockets.sockets.values()).find(
+					(socket) =>
+						socket.peerId === removed.peerId &&
+						socket.roomId === removed.roomId,
+				);
+				targetSocket?.emit('consumer_closed', {
+					consumerId: removed.consumerId,
+				});
+			}
+		});
+
 		this.mediasoup.onNetworkQualityUpdate((roomId, peerId, quality) => {
 			this.registry.emitToFullAccessParticipants(
 				roomId,

--- a/suite/meet/sfu-server/src/server/SocketHandlerManager.ts
+++ b/suite/meet/sfu-server/src/server/SocketHandlerManager.ts
@@ -124,9 +124,20 @@ export class SocketHandlerManager {
 						socket.peerId === removed.peerId &&
 						socket.roomId === removed.roomId,
 				);
-				targetSocket?.emit('consumer_closed', {
-					consumerId: removed.consumerId,
-				});
+				if (targetSocket) {
+					targetSocket.emit('consumer_closed', {
+						consumerId: removed.consumerId,
+					});
+				} else {
+					this.registry.emitToFullAccessParticipants(
+						event.roomId,
+						'consumer_closed',
+						{
+							consumerId: removed.consumerId,
+							peerId: removed.peerId,
+						},
+					);
+				}
 			}
 		});
 

--- a/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
@@ -1160,6 +1160,90 @@ describe('SocketHandlerManager characterization', () => {
 		});
 	});
 
+	it('propagates producer lifecycle closure and targets dependent consumers', async () => {
+		const harness = createManager();
+		const publisher = connectFullSocket(harness, {
+			id: 'publisher-peer',
+			userId: 'publisher-1',
+		});
+		const viewer = connectFullSocket(harness, {
+			id: 'viewer-peer',
+			userId: 'viewer-1',
+		});
+		emitJoin(publisher, { userId: 'publisher-1', name: 'Publisher' });
+		emitJoin(viewer, { userId: 'viewer-1', name: 'Viewer' });
+		await new Promise((resolve) => setImmediate(resolve));
+		publisher.emitCalls.length = 0;
+		viewer.emitCalls.length = 0;
+		const onProducerClosed = vi.mocked(harness.mediasoup.onProducerClosed).mock
+			.calls[0][0];
+
+		onProducerClosed({
+			roomId: 'room-1',
+			peerId: 'publisher-peer',
+			participantId: 'publisher-1',
+			producerId: 'producer-1',
+			kind: 'video',
+			isScreen: false,
+			removedConsumers: [
+				{
+					consumerId: 'consumer-1',
+					peerId: 'viewer-peer',
+					roomId: 'room-1',
+				},
+			],
+		});
+
+		expect(viewer.emitCalls).toContainEqual({
+			event: 'producer_closed',
+			data: expect.objectContaining({
+				participantId: 'publisher-1',
+				producerId: 'producer-1',
+			}),
+		});
+		expect(viewer.emitCalls).toContainEqual({
+			event: 'consumer_closed',
+			data: { consumerId: 'consumer-1' },
+		});
+		expect(
+			publisher.emitCalls.some((call) => call.event === 'consumer_closed'),
+		).toBe(false);
+	});
+
+	it('passes explicit producer close metadata through the lifecycle finalizer', async () => {
+		const harness = createManager();
+		const socket = connectFullSocket(harness, {
+			id: 'publisher-peer',
+			userId: 'user-1',
+		});
+		emitJoin(socket);
+		await new Promise((resolve) => setImmediate(resolve));
+		const callback = vi.fn();
+
+		socket.fire(
+			'close_producer',
+			{
+				producerId: 'producer-1',
+				reason: 'track-ended',
+				source: 'screen-share',
+				details: { message: 'display ended' },
+			},
+			callback,
+		);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(harness.mediasoup.closeProducer).toHaveBeenCalledWith('producer-1', {
+			reason: 'track-ended',
+			source: 'screen-share',
+			details: { message: 'display ended' },
+		});
+		expect(callback).toHaveBeenCalledWith({
+			success: true,
+			isScreen: false,
+			removedConsumers: [],
+		});
+	});
+
 	it('allows an encrypted WebRTC transport to connect when E2EE is required', async () => {
 		const harness = createManager();
 		const socket = connectFullSocket(harness, {

--- a/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
@@ -1210,6 +1210,40 @@ describe('SocketHandlerManager characterization', () => {
 		).toBe(false);
 	});
 
+	it('broadcasts consumer closure when its owning peer socket is absent', async () => {
+		const harness = createManager();
+		const participant = connectFullSocket(harness, {
+			id: 'connected-peer',
+			userId: 'user-1',
+		});
+		emitJoin(participant);
+		await new Promise((resolve) => setImmediate(resolve));
+		participant.emitCalls.length = 0;
+		const onProducerClosed = vi.mocked(harness.mediasoup.onProducerClosed).mock
+			.calls[0][0];
+
+		onProducerClosed({
+			roomId: 'room-1',
+			peerId: 'publisher-peer',
+			participantId: 'publisher-1',
+			producerId: 'producer-1',
+			kind: 'video',
+			isScreen: false,
+			removedConsumers: [
+				{
+					consumerId: 'consumer-1',
+					peerId: 'missing-peer',
+					roomId: 'room-1',
+				},
+			],
+		});
+
+		expect(participant.emitCalls).toContainEqual({
+			event: 'consumer_closed',
+			data: { consumerId: 'consumer-1', peerId: 'missing-peer' },
+		});
+	});
+
 	it('passes explicit producer close metadata through the lifecycle finalizer', async () => {
 		const harness = createManager();
 		const socket = connectFullSocket(harness, {

--- a/suite/meet/sfu-server/src/server/__tests__/test-helpers.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/test-helpers.ts
@@ -171,8 +171,14 @@ function createMockServer(): MockServer {
 }
 
 function createMockMediasoupManager(): MediasoupManager {
+	let producerClosedListener:
+		| Parameters<MediasoupManager['onProducerClosed']>[0]
+		| undefined;
 	return {
 		onNetworkQualityUpdate: vi.fn().mockReturnValue(() => {}),
+		onProducerClosed: vi.fn((listener) => {
+			producerClosedListener = listener;
+		}),
 		createRoom: vi.fn().mockResolvedValue({
 			peers: new Map(),
 			activeSpeakerObserver: null,
@@ -192,6 +198,19 @@ function createMockMediasoupManager(): MediasoupManager {
 		connectWebRtcTransport: vi.fn().mockResolvedValue(undefined),
 		restartWebRtcTransportIce: vi.fn().mockResolvedValue({}),
 		assertProducerAccess: vi.fn(),
+		closeProducer: vi.fn((producerId, metadata = {}) => {
+			const result = { isScreen: false, removedConsumers: [] };
+			producerClosedListener?.({
+				roomId: 'room-1',
+				peerId: 'peer-1',
+				participantId: 'user-1',
+				producerId,
+				kind: 'video',
+				...result,
+				...metadata,
+			});
+			return result;
+		}),
 		assertConsumerAccess: vi.fn(),
 		closeConsumer: vi.fn().mockResolvedValue(undefined),
 		requestConsumerKeyFrame: vi.fn().mockResolvedValue(true),

--- a/suite/meet/sfu-server/src/server/handlers/ProducerHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/ProducerHandlers.ts
@@ -82,7 +82,11 @@ export function registerProducerHandlers(deps: HandlerDeps) {
 					getRoomId(socket),
 					getPeerId(socket),
 				);
-				const result = deps.mediasoup.closeProducer(producerId);
+				const result = deps.mediasoup.closeProducer(producerId, {
+					reason,
+					source,
+					details,
+				});
 
 				loggers.socketHandler.info(
 					'close_producer peer=%s producer=%s isScreen=%s reason=%s source=%s details=%o',
@@ -95,40 +99,6 @@ export function registerProducerHandlers(deps: HandlerDeps) {
 				);
 
 				callback({ success: true, ...result });
-
-				const roomId = getRoomId(socket);
-				deps.registry.emitProducerClosed(roomId, {
-					participantId: socket.userId,
-					producerId,
-					isScreen: !!result.isScreen,
-					reason,
-					source,
-					details,
-				});
-
-				try {
-					for (const rc of result.removedConsumers) {
-						const targetPeerSocket = Array.from(
-							deps.io.sockets.sockets.values(),
-						).find((s) => s.peerId === rc.peerId && s.roomId === rc.roomId);
-						if (targetPeerSocket) {
-							targetPeerSocket.emit('consumer_closed', {
-								consumerId: rc.consumerId,
-							});
-						} else {
-							deps.registry.emitToFullAccessParticipants(
-								roomId,
-								'consumer_closed',
-								{ consumerId: rc.consumerId, peerId: rc.peerId },
-							);
-						}
-					}
-				} catch (e) {
-					loggers.socketHandler.warn(
-						'Failed to emit consumer_closed notifications: %s',
-						(e as Error).message,
-					);
-				}
 			} catch (error) {
 				loggers.socketHandler.error(
 					'Error closing producer: %s',


### PR DESCRIPTION
## Summary

- finalize producers through one idempotent lifecycle for explicit and transport-driven closure
- remove dependent consumers and stale producer snapshot state
- propagate producer and consumer closure from the authoritative SFU lifecycle