### PR TITLE
fix(meet): recover initial media publication

### DIFF
--- a/frontend/src/apps/meet/composables/useSFUConnection.ts
+++ b/frontend/src/apps/meet/composables/useSFUConnection.ts
@@ -527,23 +527,25 @@ export function useSFUConnection(deps: {
 						{ publishVideo, publishAudio },
 						signal,
 					);
-					if (publishVideo && publication.videoProducer) {
+					const videoStillRequested = publishVideo && mediaState.isCameraOn;
+					const audioStillRequested = publishAudio && mediaState.isMicOn;
+					if (videoStillRequested && publication.videoProducer) {
 						sfuClient.sendMediaControl("video_on");
-					} else if (publishVideo) {
+					} else if (videoStillRequested) {
 						mediaState.isCameraOn = false;
 						for (const track of videoTracks) track.enabled = false;
 					}
-					if (publishAudio && publication.audioProducer) {
+					if (audioStillRequested && publication.audioProducer) {
 						sfuClient.sendMediaControl("unmute");
-					} else if (publishAudio) {
+					} else if (audioStillRequested) {
 						mediaState.isMicOn = false;
 						for (const track of mediaState.localStream.getAudioTracks()) {
 							track.enabled = false;
 						}
 					}
 					if (
-						(publishVideo && !publication.videoProducer) ||
-						(publishAudio && !publication.audioProducer)
+						(videoStillRequested && !publication.videoProducer) ||
+						(audioStillRequested && !publication.audioProducer)
 					) {
 						console.warn("Initial media publication did not fully recover", {
 							video: publication.videoError

--- a/frontend/src/apps/meet/composables/useSFUConnection.ts
+++ b/frontend/src/apps/meet/composables/useSFUConnection.ts
@@ -45,7 +45,6 @@ import type {
 	ParticipantUpdate,
 } from "../utils/media/ParticipantManager";
 import type { ParticipantConnectionState } from "../utils/sfu/ParticipantConnection";
-import { publishInitialMediaWithRetry } from "../utils/sfu/initialMediaPublication";
 
 const LARGE_MEETING_PARTICIPANT_THRESHOLD = 5;
 
@@ -523,8 +522,7 @@ export function useSFUConnection(deps: {
 						...videoTracks,
 						...mediaState.localStream.getAudioTracks(),
 					]);
-					const publication = await publishInitialMediaWithRetry(
-						manager!.publishMedia.bind(manager),
+					const publication = await manager!.publishInitialMedia(
 						streamToPublish,
 						{ publishVideo, publishAudio },
 						signal,

--- a/frontend/src/apps/meet/composables/useSFUConnection.ts
+++ b/frontend/src/apps/meet/composables/useSFUConnection.ts
@@ -45,6 +45,7 @@ import type {
 	ParticipantUpdate,
 } from "../utils/media/ParticipantManager";
 import type { ParticipantConnectionState } from "../utils/sfu/ParticipantConnection";
+import { publishInitialMediaWithRetry } from "../utils/sfu/initialMediaPublication";
 
 const LARGE_MEETING_PARTICIPANT_THRESHOLD = 5;
 
@@ -478,7 +479,7 @@ export function useSFUConnection(deps: {
 						userData,
 						mediaState: {
 							audio_enabled: false,
-							video_enabled: mediaState.isCameraOn,
+							video_enabled: false,
 						},
 					};
 				},
@@ -506,11 +507,15 @@ export function useSFUConnection(deps: {
 							for (const track of mediaState.localStream?.getAudioTracks() || []) {
 								track.enabled = false;
 							}
-						} else {
-							sfuClient.sendMediaControl("unmute");
 						}
 					}
-					if (!mediaState.localStream) return;
+					const publishVideo = mediaState.isCameraOn;
+					const publishAudio = mediaState.isMicOn;
+					if (!mediaState.localStream) {
+						mediaState.isCameraOn = false;
+						mediaState.isMicOn = false;
+						return;
+					}
 					const videoTracks = mediaState.processedStream
 						? mediaState.processedStream.getVideoTracks()
 						: mediaState.localStream.getVideoTracks();
@@ -518,16 +523,40 @@ export function useSFUConnection(deps: {
 						...videoTracks,
 						...mediaState.localStream.getAudioTracks(),
 					]);
-					try {
-						await manager!.publishMedia(streamToPublish, {
-							publishVideo: mediaState.isCameraOn,
-							publishAudio: mediaState.isMicOn,
+					const publication = await publishInitialMediaWithRetry(
+						manager!.publishMedia.bind(manager),
+						streamToPublish,
+						{ publishVideo, publishAudio },
+						signal,
+					);
+					if (publishVideo && publication.videoProducer) {
+						sfuClient.sendMediaControl("video_on");
+					} else if (publishVideo) {
+						mediaState.isCameraOn = false;
+						for (const track of videoTracks) track.enabled = false;
+					}
+					if (publishAudio && publication.audioProducer) {
+						sfuClient.sendMediaControl("unmute");
+					} else if (publishAudio) {
+						mediaState.isMicOn = false;
+						for (const track of mediaState.localStream.getAudioTracks()) {
+							track.enabled = false;
+						}
+					}
+					if (
+						(publishVideo && !publication.videoProducer) ||
+						(publishAudio && !publication.audioProducer)
+					) {
+						console.warn("Initial media publication did not fully recover", {
+							video: publication.videoError
+								? getErrorMessage(publication.videoError)
+								: undefined,
+							audio: publication.audioError
+								? getErrorMessage(publication.audioError)
+								: undefined,
 						});
-					} catch (error) {
-						if (signal.aborted) throw error;
-						console.warn(
-							"Media publishing failed, continuing without media:",
-							getErrorMessage(error),
+						toast.error(
+							"Some media could not be started. You can try enabling it again.",
 						);
 					}
 				},

--- a/frontend/src/apps/meet/composables/useSFUConnection.ts
+++ b/frontend/src/apps/meet/composables/useSFUConnection.ts
@@ -510,55 +510,58 @@ export function useSFUConnection(deps: {
 					}
 					const publishVideo = mediaState.isCameraOn;
 					const publishAudio = mediaState.isMicOn;
-					if (!mediaState.localStream) {
+					const localStream = mediaState.localStream;
+					if (!localStream) {
 						mediaState.isCameraOn = false;
 						mediaState.isMicOn = false;
 						return;
 					}
 					const videoTracks = mediaState.processedStream
 						? mediaState.processedStream.getVideoTracks()
-						: mediaState.localStream.getVideoTracks();
+						: localStream.getVideoTracks();
 					const streamToPublish = new MediaStream([
 						...videoTracks,
-						...mediaState.localStream.getAudioTracks(),
+						...localStream.getAudioTracks(),
 					]);
-					const publication = await manager!.publishInitialMedia(
+					await manager!.publishInitialMedia(
 						streamToPublish,
 						{ publishVideo, publishAudio },
 						signal,
-					);
-					const videoStillRequested = publishVideo && mediaState.isCameraOn;
-					const audioStillRequested = publishAudio && mediaState.isMicOn;
-					if (videoStillRequested && publication.videoProducer) {
-						sfuClient.sendMediaControl("video_on");
-					} else if (videoStillRequested) {
-						mediaState.isCameraOn = false;
-						for (const track of videoTracks) track.enabled = false;
-					}
-					if (audioStillRequested && publication.audioProducer) {
-						sfuClient.sendMediaControl("unmute");
-					} else if (audioStillRequested) {
-						mediaState.isMicOn = false;
-						for (const track of mediaState.localStream.getAudioTracks()) {
-							track.enabled = false;
+						(publication) => {
+							const videoStillRequested = publishVideo && mediaState.isCameraOn;
+							const audioStillRequested = publishAudio && mediaState.isMicOn;
+							if (videoStillRequested && publication.videoProducer) {
+								sfuClient.sendMediaControl("video_on");
+							} else if (videoStillRequested) {
+								mediaState.isCameraOn = false;
+								for (const track of videoTracks) track.enabled = false;
+							}
+							if (audioStillRequested && publication.audioProducer) {
+								sfuClient.sendMediaControl("unmute");
+							} else if (audioStillRequested) {
+								mediaState.isMicOn = false;
+								for (const track of localStream.getAudioTracks()) {
+									track.enabled = false;
+								}
+							}
+							if (
+								(videoStillRequested && !publication.videoProducer) ||
+								(audioStillRequested && !publication.audioProducer)
+							) {
+								console.warn("Initial media publication did not fully recover", {
+									video: publication.videoError
+										? getErrorMessage(publication.videoError)
+										: undefined,
+									audio: publication.audioError
+										? getErrorMessage(publication.audioError)
+										: undefined,
+								});
+								toast.error(
+									"Some media could not be started. You can try enabling it again.",
+								);
+							}
 						}
-					}
-					if (
-						(videoStillRequested && !publication.videoProducer) ||
-						(audioStillRequested && !publication.audioProducer)
-					) {
-						console.warn("Initial media publication did not fully recover", {
-							video: publication.videoError
-								? getErrorMessage(publication.videoError)
-								: undefined,
-							audio: publication.audioError
-								? getErrorMessage(publication.audioError)
-								: undefined,
-						});
-						toast.error(
-							"Some media could not be started. You can try enabling it again.",
-						);
-					}
+					);
 				},
 			});
 			if (wasAutomaticallyMuted) {

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -134,6 +134,14 @@ export class SFUMeetingManager {
 		return this.mediaManager.publishMedia(localStream, options);
 	}
 
+	async publishInitialMedia(
+		localStream: MediaStream,
+		options: { publishVideo: boolean; publishAudio: boolean },
+		signal?: AbortSignal,
+	): Promise<PublishedMedia> {
+		return this.mediaManager.publishInitialMedia(localStream, options, signal);
+	}
+
 	setLocalMediaTrack(
 		kind: "audio" | "video",
 		track: MediaStreamTrack | null,

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -138,8 +138,14 @@ export class SFUMeetingManager {
 		localStream: MediaStream,
 		options: { publishVideo: boolean; publishAudio: boolean },
 		signal?: AbortSignal,
+		finalize?: (publication: PublishedMedia) => void | Promise<void>,
 	): Promise<PublishedMedia> {
-		return this.mediaManager.publishInitialMedia(localStream, options, signal);
+		return this.mediaManager.publishInitialMedia(
+			localStream,
+			options,
+			signal,
+			finalize,
+		);
 	}
 
 	setLocalMediaTrack(

--- a/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
@@ -186,16 +186,19 @@ export class SFUMediaManager {
 		localStream: MediaStream,
 		options: { publishVideo: boolean; publishAudio: boolean },
 		signal?: AbortSignal,
+		finalize?: (publication: PublishedMedia) => void | Promise<void>,
 	): Promise<PublishedMedia> {
-		return this.serializeSendMediaMutation(() =>
-			publishInitialMediaWithRetry(
+		return this.serializeSendMediaMutation(async () => {
+			const publication = await publishInitialMediaWithRetry(
 				(stream, retryOptions) =>
 					this.publishMediaNow(stream, retryOptions),
 				localStream,
 				options,
 				signal,
-			),
-		);
+			);
+			await finalize?.(publication);
+			return publication;
+		});
 	}
 
 	private async publishMediaNow(

--- a/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
@@ -8,6 +8,7 @@ import type { ConsumerEntry, ConsumerManager } from "../media/ConsumerManager";
 import type { ParticipantManager } from "../media/ParticipantManager";
 import type { TransportManager } from "../media/TransportManager";
 import type { VideoElementManager } from "../media/VideoElementManager";
+import { publishInitialMediaWithRetry } from "./initialMediaPublication";
 
 interface MediaHandler {
 	localStream: MediaStream | null;
@@ -178,6 +179,22 @@ export class SFUMediaManager {
 	): Promise<PublishedMedia> {
 		return this.serializeSendMediaMutation(() =>
 			this.publishMediaNow(localStream, options),
+		);
+	}
+
+	async publishInitialMedia(
+		localStream: MediaStream,
+		options: { publishVideo: boolean; publishAudio: boolean },
+		signal?: AbortSignal,
+	): Promise<PublishedMedia> {
+		return this.serializeSendMediaMutation(() =>
+			publishInitialMediaWithRetry(
+				(stream, retryOptions) =>
+					this.publishMediaNow(stream, retryOptions),
+				localStream,
+				options,
+				signal,
+			),
 		);
 	}
 

--- a/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
@@ -63,6 +63,8 @@ export interface PublishedMedia {
 	videoProducer?: Producer;
 	audioProducer?: Producer;
 	screenProducer?: Producer;
+	videoError?: unknown;
+	audioError?: unknown;
 }
 
 export interface ConsumerMetadata {
@@ -232,6 +234,7 @@ export class SFUMediaManager {
 						console.log("Video published successfully");
 					}
 				} catch (error: unknown) {
+					results.videoError = error;
 					console.warn(
 						"Failed to publish video, continuing without video:",
 						(error as Error).message,
@@ -258,6 +261,7 @@ export class SFUMediaManager {
 						console.log("Audio published successfully");
 					}
 				} catch (error: unknown) {
+					results.audioError = error;
 					console.warn(
 						"Failed to publish audio, continuing without audio:",
 						(error as Error).message,

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
@@ -447,6 +447,36 @@ describe("SFUMediaManager local recovery tracks", () => {
 		expect(result.audioError).toEqual(new Error("audio failed"));
 	});
 
+	it("serializes controls behind all initial publication retries", async () => {
+		vi.useFakeTimers();
+		const { mediaManager, transportManager } = createManager();
+		const video = mediaTrack("video", "video");
+		const videoProducer = { id: "video-producer", track: video };
+		transportManager.createProducer
+			.mockRejectedValueOnce(new Error("temporary failure"))
+			.mockResolvedValueOnce(videoProducer);
+
+		const publication = mediaManager.publishInitialMedia(
+			new FakeMediaStream([video]) as never,
+			{ publishVideo: true, publishAudio: false },
+		);
+		await vi.waitFor(() =>
+			expect(transportManager.createProducer).toHaveBeenCalledOnce(),
+		);
+		let controlRan = false;
+		const control = mediaManager.serializeSendMediaMutation(async () => {
+			controlRan = true;
+		});
+
+		expect(controlRan).toBe(false);
+		await vi.runAllTimersAsync();
+		await Promise.all([publication, control]);
+
+		expect(transportManager.createProducer).toHaveBeenCalledTimes(2);
+		expect(controlRan).toBe(true);
+		vi.useRealTimers();
+	});
+
 	it("finishes initial publication before a later send-media mutation", async () => {
 		const { mediaManager, transportManager } = createManager();
 		const initialTrack = mediaTrack("initial-video", "video");

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
@@ -400,7 +400,7 @@ describe("SFUMediaManager local recovery tracks", () => {
 			new Error("producer failed"),
 		);
 
-		await mediaManager.publishMedia(input as never, {
+		const result = await mediaManager.publishMedia(input as never, {
 			publishVideo: true,
 			publishAudio: false,
 		});
@@ -414,6 +414,8 @@ describe("SFUMediaManager local recovery tracks", () => {
 		expect(synchronize.mock.invocationCallOrder[0]).toBeLessThan(
 			transportManager.createProducer.mock.invocationCallOrder[0],
 		);
+		expect(result.videoError).toEqual(new Error("producer failed"));
+		expect(result.audioError).toBeUndefined();
 
 		transportManager.createProducer.mockResolvedValueOnce({});
 		await mediaManager.rebuildSendSide();
@@ -423,6 +425,26 @@ describe("SFUMediaManager local recovery tracks", () => {
 			type: "camera",
 		});
 		expect(mediaManager.mediaHandler.localStream?.getAudioTracks()).toEqual([]);
+	});
+
+	it("reports audio and video producer outcomes independently", async () => {
+		const { mediaManager, transportManager } = createManager();
+		const video = mediaTrack("video", "video");
+		const audio = mediaTrack("audio", "audio");
+		const videoProducer = { id: "video-producer", track: video };
+		transportManager.createProducer
+			.mockResolvedValueOnce(videoProducer)
+			.mockRejectedValueOnce(new Error("audio failed"));
+
+		const result = await mediaManager.publishMedia(
+			new FakeMediaStream([video, audio]) as never,
+			{ publishVideo: true, publishAudio: true },
+		);
+
+		expect(result.videoProducer).toBe(videoProducer);
+		expect(result.videoError).toBeUndefined();
+		expect(result.audioProducer).toBeUndefined();
+		expect(result.audioError).toEqual(new Error("audio failed"));
 	});
 
 	it("finishes initial publication before a later send-media mutation", async () => {

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
@@ -455,10 +455,15 @@ describe("SFUMediaManager local recovery tracks", () => {
 		transportManager.createProducer
 			.mockRejectedValueOnce(new Error("temporary failure"))
 			.mockResolvedValueOnce(videoProducer);
+		const ordering: string[] = [];
 
 		const publication = mediaManager.publishInitialMedia(
 			new FakeMediaStream([video]) as never,
 			{ publishVideo: true, publishAudio: false },
+			undefined,
+			() => {
+				ordering.push("reconciled");
+			},
 		);
 		await vi.waitFor(() =>
 			expect(transportManager.createProducer).toHaveBeenCalledOnce(),
@@ -466,6 +471,7 @@ describe("SFUMediaManager local recovery tracks", () => {
 		let controlRan = false;
 		const control = mediaManager.serializeSendMediaMutation(async () => {
 			controlRan = true;
+			ordering.push("control");
 		});
 
 		expect(controlRan).toBe(false);
@@ -474,6 +480,7 @@ describe("SFUMediaManager local recovery tracks", () => {
 
 		expect(transportManager.createProducer).toHaveBeenCalledTimes(2);
 		expect(controlRan).toBe(true);
+		expect(ordering).toEqual(["reconciled", "control"]);
 		vi.useRealTimers();
 	});
 

--- a/frontend/src/apps/meet/utils/sfu/__tests__/initialMediaPublication.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/initialMediaPublication.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PublishedMedia } from "../SFUMediaManager";
+import { publishInitialMediaWithRetry } from "../initialMediaPublication";
+
+const stream = {} as MediaStream;
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("publishInitialMediaWithRetry", () => {
+	it("retries only the failed media kind after partial success", async () => {
+		vi.useFakeTimers();
+		const videoProducer = { id: "video" };
+		const audioProducer = { id: "audio" };
+		const publish = vi
+			.fn<() => Promise<PublishedMedia>>()
+			.mockResolvedValueOnce({
+				videoProducer: videoProducer as never,
+				audioError: new Error("temporary audio failure"),
+			})
+			.mockResolvedValueOnce({ audioProducer: audioProducer as never });
+
+		const publication = publishInitialMediaWithRetry(publish, stream, {
+			publishVideo: true,
+			publishAudio: true,
+		});
+		await vi.runAllTimersAsync();
+
+		await expect(publication).resolves.toMatchObject({
+			videoProducer,
+			audioProducer,
+		});
+		expect(publish).toHaveBeenCalledTimes(2);
+		expect(publish).toHaveBeenNthCalledWith(1, stream, {
+			publishVideo: true,
+			publishAudio: true,
+		});
+		expect(publish).toHaveBeenNthCalledWith(2, stream, {
+			publishVideo: false,
+			publishAudio: true,
+		});
+	});
+
+	it("returns independent terminal failures after the bounded retry budget", async () => {
+		vi.useFakeTimers();
+		const publish = vi.fn<() => Promise<PublishedMedia>>().mockResolvedValue({
+			videoError: new Error("video unavailable"),
+			audioError: new Error("audio unavailable"),
+		});
+
+		const publication = publishInitialMediaWithRetry(publish, stream, {
+			publishVideo: true,
+			publishAudio: true,
+		});
+		await vi.runAllTimersAsync();
+
+		const result = await publication;
+		expect(publish).toHaveBeenCalledTimes(3);
+		expect(result.videoProducer).toBeUndefined();
+		expect(result.audioProducer).toBeUndefined();
+		expect(result.videoError).toEqual(new Error("video unavailable"));
+		expect(result.audioError).toEqual(new Error("audio unavailable"));
+	});
+});

--- a/frontend/src/apps/meet/utils/sfu/initialMediaPublication.ts
+++ b/frontend/src/apps/meet/utils/sfu/initialMediaPublication.ts
@@ -1,0 +1,67 @@
+import type { PublishedMedia } from "./SFUMediaManager";
+
+const MAX_PUBLICATION_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 250;
+
+type PublishMedia = (
+	stream: MediaStream,
+	options: { publishVideo: boolean; publishAudio: boolean },
+) => Promise<PublishedMedia>;
+
+const waitForRetry = (delay: number, signal?: AbortSignal) =>
+	new Promise<void>((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(signal.reason);
+			return;
+		}
+		const onAbort = () => {
+			window.clearTimeout(timeout);
+			reject(signal?.reason);
+		};
+		const timeout = window.setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, delay);
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+
+export async function publishInitialMediaWithRetry(
+	publishMedia: PublishMedia,
+	stream: MediaStream,
+	options: { publishVideo: boolean; publishAudio: boolean },
+	signal?: AbortSignal,
+): Promise<PublishedMedia> {
+	const result: PublishedMedia = {};
+	let publishVideo = options.publishVideo;
+	let publishAudio = options.publishAudio;
+
+	for (let attempt = 1; attempt <= MAX_PUBLICATION_ATTEMPTS; attempt++) {
+		if (signal?.aborted) throw signal.reason;
+		try {
+			const attemptResult = await publishMedia(stream, {
+				publishVideo,
+				publishAudio,
+			});
+			Object.assign(result, attemptResult);
+			if (attemptResult.videoProducer) {
+				publishVideo = false;
+				delete result.videoError;
+			}
+			if (attemptResult.audioProducer) {
+				publishAudio = false;
+				delete result.audioError;
+			}
+		} catch (error) {
+			if (signal?.aborted) throw error;
+			if (publishVideo) result.videoError = error;
+			if (publishAudio) result.audioError = error;
+		}
+
+		if ((!publishVideo && !publishAudio) || attempt === MAX_PUBLICATION_ATTEMPTS) {
+			break;
+		}
+		await waitForRetry(RETRY_DELAY_MS * attempt, signal);
+	}
+
+	return result;
+}


### PR DESCRIPTION
## Summary

- retry failed initial camera and microphone publication independently with a bounded policy
- advertise media as enabled only after its producer is established
- surface terminal publication failures and keep local controls truthful