### PR TITLE
fix(meet): recover ended local tracks

### DIFF
--- a/frontend/src/apps/meet/composables/useMediaControls.test.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.test.ts
@@ -178,6 +178,7 @@ function createCameraHarness({
 	createProducer,
 	applyBackgroundEffects = vi.fn(),
 	backgroundEffects: backgroundEffectsOverride,
+	noiseCancellation: noiseCancellationOverride,
 	publishMedia: publishMediaOverride,
 	deviceManager = {},
 }: {
@@ -188,6 +189,7 @@ function createCameraHarness({
 	createProducer?: ReturnType<typeof vi.fn>;
 	applyBackgroundEffects?: ReturnType<typeof vi.fn>;
 	backgroundEffects?: ReturnType<typeof useBackgroundEffects>;
+	noiseCancellation?: object;
 	publishMedia?: ReturnType<typeof vi.fn>;
 	deviceManager?: object;
 } = {}) {
@@ -302,7 +304,7 @@ function createCameraHarness({
 		sfuManager: ref(manager),
 		deviceManager,
 		backgroundEffects: effectsApi,
-		noiseCancellation: { error: ref(null) },
+		noiseCancellation: noiseCancellationOverride ?? { error: ref(null) },
 		toast: {},
 		mediaPreferences: {},
 	} as never);
@@ -543,6 +545,60 @@ describe("useMediaControls", () => {
 		await vi.waitFor(() => expect(lateTrack.stop).toHaveBeenCalledOnce());
 		expect(replaceTrack).not.toHaveBeenCalled();
 		expect(harness.state.localStream.getAudioTracks()).not.toContain(lateTrack);
+	});
+
+	it("does not publish microphone recovery after processing finishes post-unmount", async () => {
+		const oldTrack = audioTrack("old-mic");
+		const candidate = audioTrack("candidate-mic");
+		const processed = audioTrack("processed-mic");
+		const processing = deferred<{
+			stream: MediaStream;
+			cleanup: () => void;
+		}>();
+		const processingEntered = deferred<void>();
+		const replaceTrack = vi.fn();
+		const applyNoiseCancellation = vi.fn(() => {
+			processingEntered.resolve();
+			return processing.promise;
+		});
+		let harness!: ReturnType<typeof createCameraHarness>;
+		const app = createApp(
+			defineComponent({
+				setup() {
+					harness = createCameraHarness({
+						mediaState: {
+							isMicOn: true,
+							localStream: new FakeMediaStream([oldTrack]),
+						},
+						getUserMedia: vi
+							.fn()
+							.mockResolvedValue(new FakeMediaStream([candidate])),
+						audioProducer: {
+							id: "audio-producer",
+							track: oldTrack,
+							replaceTrack,
+						},
+						noiseCancellation: {
+							error: ref(null),
+							applyNoiseCancellation,
+						},
+					});
+					return () => null;
+				},
+			}),
+		);
+		app.mount(document.createElement("div"));
+		Reflect.set(oldTrack, "readyState", "ended");
+		oldTrack.dispatchEvent(new Event("ended"));
+		await processingEntered.promise;
+		app.unmount();
+		processing.resolve({
+			stream: new FakeMediaStream([processed]) as never,
+			cleanup: vi.fn(),
+		});
+
+		await vi.waitFor(() => expect(candidate.stop).toHaveBeenCalledOnce());
+		expect(replaceTrack).not.toHaveBeenCalled();
 	});
 
 	it("falls back to the default microphone when Firefox cannot find the selected device", async () => {

--- a/frontend/src/apps/meet/composables/useMediaControls.test.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.test.ts
@@ -47,6 +47,7 @@ import { toast } from "frappe-ui";
 import {
 	cameraEnabled,
 	micEnabled,
+	noiseCancellationEnabled,
 	selectedCameraId,
 	selectedMicId,
 	setCameraEnabled,
@@ -328,6 +329,7 @@ describe("useMediaControls", () => {
 		localStorage.clear();
 		cameraEnabled.value = false;
 		micEnabled.value = false;
+		noiseCancellationEnabled.value = true;
 		selectedCameraId.value = "";
 		selectedMicId.value = "";
 		setAutoFramingPaused(false);
@@ -468,6 +470,79 @@ describe("useMediaControls", () => {
 		expect(toast.error).toHaveBeenCalledWith(
 			"Microphone stopped and could not be restarted. Check browser permissions and devices.",
 		);
+	});
+
+	it("observes a microphone replaced by noise cancellation toggling", async () => {
+		const oldTrack = audioTrack("old-mic");
+		const freshTrack = audioTrack("fresh-mic");
+		const recoveredTrack = audioTrack("recovered-mic");
+		const producer: TestVideoProducer = {
+			id: "audio-producer",
+			track: oldTrack,
+			replaceTrack: vi.fn(async ({ track }) => {
+				producer.track = track;
+			}),
+		};
+		const getUserMedia = vi
+			.fn()
+			.mockResolvedValue(new FakeMediaStream([recoveredTrack]))
+			.mockResolvedValueOnce(new FakeMediaStream([freshTrack]))
+			.mockResolvedValueOnce(new FakeMediaStream([recoveredTrack]));
+		createCameraHarness({
+			mediaState: {
+				isMicOn: true,
+				localStream: new FakeMediaStream([oldTrack]),
+			},
+			getUserMedia,
+			audioProducer: producer,
+		});
+
+		noiseCancellationEnabled.value = false;
+		await vi.waitFor(() => expect(producer.replaceTrack).toHaveBeenCalledOnce());
+		Reflect.set(freshTrack, "readyState", "ended");
+		freshTrack.dispatchEvent(new Event("ended"));
+
+		await vi.waitFor(() => expect(getUserMedia.mock.calls.length).toBeGreaterThan(1));
+	});
+
+	it("stops microphone recovery that resolves after unmount", async () => {
+		const oldTrack = audioTrack("old-mic");
+		const lateTrack = audioTrack("late-mic");
+		const request = deferred<MediaStream>();
+		const replaceTrack = vi.fn();
+		let harness!: ReturnType<typeof createCameraHarness>;
+		const app = createApp(
+			defineComponent({
+				setup() {
+					harness = createCameraHarness({
+						mediaState: {
+							isMicOn: true,
+							localStream: new FakeMediaStream([oldTrack]),
+						},
+						getUserMedia: vi.fn(() => request.promise),
+						audioProducer: {
+							id: "audio-producer",
+							track: oldTrack,
+							replaceTrack,
+						},
+					});
+					return () => null;
+				},
+			}),
+		);
+		app.mount(document.createElement("div"));
+		Reflect.set(oldTrack, "readyState", "ended");
+		oldTrack.dispatchEvent(new Event("ended"));
+		await vi.waitFor(() =>
+			expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledOnce(),
+		);
+
+		app.unmount();
+		request.resolve(new FakeMediaStream([lateTrack]) as never);
+
+		await vi.waitFor(() => expect(lateTrack.stop).toHaveBeenCalledOnce());
+		expect(replaceTrack).not.toHaveBeenCalled();
+		expect(harness.state.localStream.getAudioTracks()).not.toContain(lateTrack);
 	});
 
 	it("falls back to the default microphone when Firefox cannot find the selected device", async () => {

--- a/frontend/src/apps/meet/composables/useMediaControls.test.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.test.ts
@@ -46,8 +46,11 @@ import { mergeReacquiredMedia, useMediaControls } from "./useMediaControls";
 import { toast } from "frappe-ui";
 import {
 	cameraEnabled,
+	micEnabled,
 	selectedCameraId,
+	selectedMicId,
 	setCameraEnabled,
+	setMicEnabled,
 	setSelectedCameraId,
 	setSelectedMicId,
 } from "../data/mediaPreferences";
@@ -82,25 +85,44 @@ class FakeMediaStream {
 	}
 }
 
-const audioTrack = (id: string) =>
-	Object.assign(Object.create(null), {
-		id,
-		kind: "audio",
-		enabled: true,
-		readyState: "live",
-		stop: vi.fn(),
-	}) as MediaStreamTrack;
-
-const videoTrack = (id: string, readyState: MediaStreamTrackState = "live") => {
+const localTrack = (id: string, kind: "audio" | "video") => {
+	const listeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
 	const track = Object.assign(Object.create(null), {
 		id,
-		kind: "video",
+		kind,
 		enabled: true,
-		readyState,
+		readyState: "live",
 		stop: vi.fn(() => {
 			track.readyState = "ended";
 		}),
+		addEventListener: vi.fn(
+			(type: string, listener: EventListenerOrEventListenerObject) => {
+				const handlers = listeners.get(type) ?? new Set();
+				handlers.add(listener);
+				listeners.set(type, handlers);
+			},
+		),
+		removeEventListener: vi.fn(
+			(type: string, listener: EventListenerOrEventListenerObject) => {
+				listeners.get(type)?.delete(listener);
+			},
+		),
+		dispatchEvent: vi.fn((event: Event) => {
+			for (const listener of listeners.get(event.type) ?? []) {
+				if (typeof listener === "function") listener.call(track, event);
+				else listener.handleEvent(event);
+			}
+			return true;
+		}),
 	}) as MediaStreamTrack;
+	return track;
+};
+
+const audioTrack = (id: string) => localTrack(id, "audio");
+
+const videoTrack = (id: string, readyState: MediaStreamTrackState = "live") => {
+	const track = localTrack(id, "video");
+	Reflect.set(track, "readyState", readyState);
 	return track;
 };
 
@@ -151,6 +173,7 @@ function createCameraHarness({
 	mediaState = {},
 	getUserMedia = vi.fn(),
 	videoProducer = null,
+	audioProducer = null,
 	createProducer,
 	applyBackgroundEffects = vi.fn(),
 	backgroundEffects: backgroundEffectsOverride,
@@ -160,6 +183,7 @@ function createCameraHarness({
 	mediaState?: CameraMediaStateOverrides;
 	getUserMedia?: ReturnType<typeof vi.fn>;
 	videoProducer?: TestVideoProducer | null;
+	audioProducer?: TestVideoProducer | null;
 	createProducer?: ReturnType<typeof vi.fn>;
 	applyBackgroundEffects?: ReturnType<typeof vi.fn>;
 	backgroundEffects?: ReturnType<typeof useBackgroundEffects>;
@@ -189,11 +213,14 @@ function createCameraHarness({
 		}),
 	});
 	const mediaHandler = {
-		audioProducer: null,
+		audioProducer,
 		videoProducer,
 		screenProducer: null,
 		localStream: new FakeMediaStream(),
-		setProducers: vi.fn((producers: { videoProducer?: TestVideoProducer }) => {
+		setProducers: vi.fn((producers: {
+			audioProducer?: TestVideoProducer;
+			videoProducer?: TestVideoProducer;
+		}) => {
 			Object.assign(mediaHandler, producers);
 		}),
 		stopScreenShare: vi.fn(),
@@ -300,8 +327,147 @@ describe("useMediaControls", () => {
 		vi.stubGlobal("MediaStream", FakeMediaStream);
 		localStorage.clear();
 		cameraEnabled.value = false;
+		micEnabled.value = false;
 		selectedCameraId.value = "";
+		selectedMicId.value = "";
 		setAutoFramingPaused(false);
+	});
+
+	it("reacquires and republishes an enabled camera whose track ends", async () => {
+		selectedCameraId.value = "selected-camera";
+		const oldTrack = videoTrack("old-camera");
+		const nextTrack = videoTrack("next-camera");
+		const producer: TestVideoProducer = {
+			id: "camera-producer",
+			track: oldTrack,
+			replaceTrack: vi.fn(async ({ track }) => {
+				producer.track = track;
+			}),
+		};
+		const getUserMedia = vi.fn().mockResolvedValue(
+			new FakeMediaStream([nextTrack]),
+		);
+		const harness = createCameraHarness({
+			mediaState: {
+				isCameraOn: true,
+				localStream: new FakeMediaStream([oldTrack]),
+			},
+			getUserMedia,
+			videoProducer: producer,
+		});
+
+		Reflect.set(oldTrack, "readyState", "ended");
+		oldTrack.dispatchEvent(new Event("ended"));
+
+		await vi.waitFor(() => expect(producer.replaceTrack).toHaveBeenCalledOnce());
+		expect(
+			(getUserMedia.mock.calls[0][0].video as MediaTrackConstraints).deviceId,
+		).toEqual({ exact: "selected-camera" });
+		expect(producer.track).toBe(nextTrack);
+		expect(harness.state.localStream.getVideoTracks()).toEqual([nextTrack]);
+		expect(oldTrack.stop).toHaveBeenCalledOnce();
+		expect(harness.state.isCameraOn).toBe(true);
+	});
+
+	it("reacquires and republishes an enabled microphone whose track ends", async () => {
+		selectedMicId.value = "selected-mic";
+		const oldTrack = audioTrack("old-mic");
+		const nextTrack = audioTrack("next-mic");
+		const producer: TestVideoProducer = {
+			id: "audio-producer",
+			track: oldTrack,
+			replaceTrack: vi.fn(async ({ track }) => {
+				producer.track = track;
+			}),
+		};
+		const getUserMedia = vi.fn().mockResolvedValue(
+			new FakeMediaStream([nextTrack]),
+		);
+		const harness = createCameraHarness({
+			mediaState: {
+				isMicOn: true,
+				localStream: new FakeMediaStream([oldTrack]),
+			},
+			getUserMedia,
+			audioProducer: producer,
+			deviceManager: {
+				enumerateDevices: vi.fn(),
+				isDeviceAvailable: vi.fn(() => true),
+				findDeviceById: vi.fn(() => ({ label: "Built-in Microphone" })),
+			},
+		});
+
+		Reflect.set(oldTrack, "readyState", "ended");
+		oldTrack.dispatchEvent(new Event("ended"));
+
+		await vi.waitFor(() => expect(producer.replaceTrack).toHaveBeenCalledOnce());
+		expect(
+			(getUserMedia.mock.calls[0][0].audio as MediaTrackConstraints).deviceId,
+		).toEqual({ exact: "selected-mic" });
+		expect(producer.track).toBe(nextTrack);
+		expect(harness.state.localStream.getAudioTracks()).toEqual([nextTrack]);
+		expect(oldTrack.stop).toHaveBeenCalledOnce();
+		expect(harness.state.isMicOn).toBe(true);
+	});
+
+	it("turns off camera truthfully when ended-track recovery fails", async () => {
+		const oldTrack = videoTrack("old-camera");
+		const producer = {
+			id: "camera-producer",
+			track: oldTrack,
+			close: vi.fn(),
+		};
+		const harness = createCameraHarness({
+			mediaState: {
+				isCameraOn: true,
+				localStream: new FakeMediaStream([oldTrack]),
+			},
+			getUserMedia: vi
+				.fn()
+				.mockRejectedValue(new DOMException("Denied", "NotAllowedError")),
+			videoProducer: producer,
+		});
+
+		Reflect.set(oldTrack, "readyState", "ended");
+		oldTrack.dispatchEvent(new Event("ended"));
+
+		await vi.waitFor(() => expect(harness.state.isCameraOn).toBe(false));
+		expect(setCameraEnabled).toHaveBeenCalledWith(false);
+		expect(producer.close).toHaveBeenCalledOnce();
+		expect(harness.sfuClient.sendMediaControl).toHaveBeenCalledWith("video_off");
+		expect(toast.error).toHaveBeenCalledWith(
+			"Camera stopped and could not be restarted. Check browser permissions and devices.",
+		);
+	});
+
+	it("turns off microphone truthfully when ended-track recovery fails", async () => {
+		const oldTrack = audioTrack("old-mic");
+		const producer = {
+			id: "audio-producer",
+			track: oldTrack,
+			close: vi.fn(),
+		};
+		const harness = createCameraHarness({
+			mediaState: {
+				isMicOn: true,
+				localStream: new FakeMediaStream([oldTrack]),
+			},
+			getUserMedia: vi
+				.fn()
+				.mockRejectedValue(new DOMException("Denied", "NotAllowedError")),
+			audioProducer: producer,
+		});
+
+		Reflect.set(oldTrack, "readyState", "ended");
+		oldTrack.dispatchEvent(new Event("ended"));
+
+		await vi.waitFor(() => expect(harness.state.isMicOn).toBe(false));
+		expect(setMicEnabled).toHaveBeenCalledWith(false);
+		expect(producer.close).toHaveBeenCalledOnce();
+		expect(harness.sfuClient.sendMediaControl).toHaveBeenCalledWith("mute");
+		expect(toast.error).toHaveBeenCalledWith(
+			"Microphone stopped and could not be restarted. Check browser permissions and devices.",
+		);
 	});
 
 	it("falls back to the default microphone when Firefox cannot find the selected device", async () => {

--- a/frontend/src/apps/meet/composables/useMediaControls.test.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.test.ts
@@ -557,6 +557,7 @@ describe("useMediaControls", () => {
 		}>();
 		const processingEntered = deferred<void>();
 		const replaceTrack = vi.fn();
+		const cleanup = vi.fn();
 		const applyNoiseCancellation = vi.fn(() => {
 			processingEntered.resolve();
 			return processing.promise;
@@ -594,10 +595,66 @@ describe("useMediaControls", () => {
 		app.unmount();
 		processing.resolve({
 			stream: new FakeMediaStream([processed]) as never,
-			cleanup: vi.fn(),
+			cleanup,
 		});
 
 		await vi.waitFor(() => expect(candidate.stop).toHaveBeenCalledOnce());
+		expect(cleanup).toHaveBeenCalledOnce();
+		expect(processed.stop).toHaveBeenCalledOnce();
+		expect(replaceTrack).not.toHaveBeenCalled();
+	});
+
+	it("does not replace the microphone after noise cancellation resolves post-unmount", async () => {
+		const oldTrack = audioTrack("old-mic");
+		const freshTrack = audioTrack("fresh-mic");
+		const processed = audioTrack("processed-mic");
+		const processing = deferred<{
+			stream: MediaStream;
+			cleanup: () => void;
+		}>();
+		const processingEntered = deferred<void>();
+		const cleanup = vi.fn();
+		const replaceTrack = vi.fn();
+		noiseCancellationEnabled.value = false;
+		const app = createApp(
+			defineComponent({
+				setup() {
+					createCameraHarness({
+						mediaState: {
+							isMicOn: true,
+							localStream: new FakeMediaStream([oldTrack]),
+						},
+						getUserMedia: vi
+							.fn()
+							.mockResolvedValue(new FakeMediaStream([freshTrack])),
+						audioProducer: {
+							id: "audio-producer",
+							track: oldTrack,
+							replaceTrack,
+						},
+						noiseCancellation: {
+							error: ref(null),
+							applyNoiseCancellation: vi.fn(() => {
+								processingEntered.resolve();
+								return processing.promise;
+							}),
+						},
+					});
+					return () => null;
+				},
+			}),
+		);
+		app.mount(document.createElement("div"));
+		noiseCancellationEnabled.value = true;
+		await processingEntered.promise;
+		app.unmount();
+		processing.resolve({
+			stream: new FakeMediaStream([processed]) as never,
+			cleanup,
+		});
+
+		await vi.waitFor(() => expect(cleanup).toHaveBeenCalledOnce());
+		expect(processed.stop).toHaveBeenCalledOnce();
 		expect(replaceTrack).not.toHaveBeenCalled();
 	});
 

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -1539,14 +1539,21 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		) return;
 		try {
 			const currentStream = mediaState.localStream;
-			const { stream: acquiredStream } = await acquireUserMedia(false, true, {
-				micDeviceId: selectedMicId.value,
-			});
+			const operation = createCameraOperation();
+			const { stream: acquiredStream } = await acquireUserMedia(
+				false,
+				true,
+				{ micDeviceId: selectedMicId.value },
+				operation,
+			);
+			ownCameraStream(operation, acquiredStream);
+			assertCurrentCameraOperation(operation);
 			const candidate = acquiredStream
 				.getAudioTracks()
 				.find((track) => track.readyState === "live");
 			if (
 				!candidate ||
+				!isCurrentCameraOperation(operation) ||
 				!mediaState.isMicOn ||
 				mediaState.localStream !== currentStream ||
 				!currentStream.getAudioTracks().includes(endedTrack)
@@ -1603,6 +1610,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				if (track !== candidate) stopLifecycleTrack(track);
 			}
 			stopLifecycleTrack(endedTrack);
+			operation.ownedStreams.clear();
 		} catch (error) {
 			if (isCameraLifecycleAbort(error)) return;
 			console.error("Failed to recover ended microphone track:", error);
@@ -2338,17 +2346,13 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 	};
 
 	// Watch noise cancellation toggle
-	watch(prefNoiseCancellationEnabled, async (enabled) => {
-		const mh = getMediaHandler(sfuManager.value);
-		if (!mediaState.isMicOn || !mh) {
-			return;
-		}
+	watch(prefNoiseCancellationEnabled, (enabled) => {
+		void enqueueMicrophoneTransition(async () => {
+			const mh = getMediaHandler(sfuManager.value);
+			if (!mediaState.isMicOn || !mh) return;
 
-		try {
 			const freshTrack = await getFreshMicTrack();
-			if (!freshTrack) {
-				return;
-			}
+			if (!freshTrack) return;
 
 			if (noiseCancellationSession) {
 				noiseCancellationSession.cleanup();
@@ -2356,27 +2360,25 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			}
 
 			let trackToPublish = freshTrack;
-
 			if (enabled) {
 				const audioStream = new MediaStream([freshTrack]);
 				const result =
 					await noiseCancellation.applyNoiseCancellation(audioStream);
 				noiseCancellationSession = result;
-
 				const processedTrack = result.stream.getAudioTracks()[0];
 				if (processedTrack && processedTrack.readyState === "live") {
 					trackToPublish = processedTrack;
 				}
 			}
-
 			if (mh?.audioProducer && trackToPublish.readyState === "live") {
 				if (typeof mh.audioProducer.replaceTrack === "function") {
 					await mh.audioProducer.replaceTrack({ track: trackToPublish });
 				}
 			}
-		} catch (error) {
+		}).catch((error) => {
+			if (isCameraLifecycleAbort(error)) return;
 			console.error("[Noise Cancellation] Failed to toggle:", error);
-		}
+		});
 	});
 
 	// Watch chat state for notification context

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -1098,11 +1098,15 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 
 	let shouldApplyBackgroundEffectsWhenVideoAvailable = false;
 
-	const getFreshMicTrack = async () => {
+	const getFreshMicTrack = async (operation?: CameraOperation) => {
 		try {
-			const { stream: freshStream } = await acquireUserMedia(false, true, {
-				micDeviceId: selectedMicId.value,
-			});
+			const { stream: freshStream } = await acquireUserMedia(
+				false,
+				true,
+				{ micDeviceId: selectedMicId.value },
+				operation,
+			);
+			assertCurrentCameraOperation(operation);
 			const freshTrack = freshStream.getAudioTracks()[0];
 
 			if (!freshTrack) {
@@ -1126,7 +1130,10 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		}
 	};
 
-	const getProcessedAudioTrack = async (stream: MediaStream) => {
+	const getProcessedAudioTrack = async (
+		stream: MediaStream,
+		operation?: CameraOperation,
+	) => {
 		const originalTrack = stream.getAudioTracks()[0];
 		if (!originalTrack) {
 			return null;
@@ -1139,7 +1146,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			}
 
 			if (originalTrack.readyState === "ended") {
-				return await getFreshMicTrack();
+				return await getFreshMicTrack(operation);
 			}
 
 			return originalTrack;
@@ -1149,6 +1156,11 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			const audioStream = new MediaStream([originalTrack]);
 			const result =
 				await noiseCancellation.applyNoiseCancellation(audioStream);
+			if (operation && !isCurrentCameraOperation(operation)) {
+				result.cleanup();
+				stopLifecycleStream(result.stream);
+				throw cameraLifecycleAbort();
+			}
 			noiseCancellationSession = result;
 
 			const processedTrack = result.stream.getAudioTracks()[0];
@@ -1159,6 +1171,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			console.warn("[Noise Cancellation] No processed track returned");
 			return originalTrack;
 		} catch (error) {
+			if (isCameraLifecycleAbort(error, operation)) throw error;
 			console.error("[Noise Cancellation] Failed to apply:", error);
 			return originalTrack;
 		}
@@ -1568,7 +1581,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			currentStream.addTrack(candidate);
 			noiseCancellationSession?.cleanup();
 			noiseCancellationSession = null;
-			const trackToPublish = await getProcessedAudioTrack(currentStream);
+			const trackToPublish = await getProcessedAudioTrack(currentStream, operation);
 			assertCurrentCameraOperation(operation);
 			if (!trackToPublish || trackToPublish.readyState !== "live") {
 				throw new Error("No live microphone track available after recovery");
@@ -2350,10 +2363,12 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 	// Watch noise cancellation toggle
 	watch(prefNoiseCancellationEnabled, (enabled) => {
 		void enqueueMicrophoneTransition(async () => {
+			const operation = createCameraOperation();
 			const mh = getMediaHandler(sfuManager.value);
 			if (!mediaState.isMicOn || !mh) return;
 
-			const freshTrack = await getFreshMicTrack();
+			const freshTrack = await getFreshMicTrack(operation);
+			assertCurrentCameraOperation(operation);
 			if (!freshTrack) return;
 
 			if (noiseCancellationSession) {
@@ -2364,14 +2379,15 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			let trackToPublish = freshTrack;
 			if (enabled) {
 				const audioStream = new MediaStream([freshTrack]);
-				const result =
-					await noiseCancellation.applyNoiseCancellation(audioStream);
-				noiseCancellationSession = result;
-				const processedTrack = result.stream.getAudioTracks()[0];
+				const processedTrack = await getProcessedAudioTrack(
+					audioStream,
+					operation,
+				);
 				if (processedTrack && processedTrack.readyState === "live") {
 					trackToPublish = processedTrack;
 				}
 			}
+			assertCurrentCameraOperation(operation);
 			if (mh?.audioProducer && trackToPublish.readyState === "live") {
 				if (typeof mh.audioProducer.replaceTrack === "function") {
 					await mh.audioProducer.replaceTrack({ track: trackToPublish });

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -308,10 +308,15 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		cleanup: () => void;
 	} | null = null;
 	let cameraTransitionQueue: Promise<unknown> = Promise.resolve();
+	let microphoneTransitionQueue: Promise<unknown> = Promise.resolve();
 	let cameraLifecycleGeneration = 0;
 	const cameraLifecycleAbortController = new AbortController();
 	const lifecycleStoppedTracks = new WeakSet<MediaStreamTrack>();
 	const detachedCameraTracks = new Set<MediaStreamTrack>();
+	let observedCameraTrack: MediaStreamTrack | null = null;
+	let observedMicrophoneTrack: MediaStreamTrack | null = null;
+	let cameraEndedListener: (() => void) | null = null;
+	let microphoneEndedListener: (() => void) | null = null;
 
 	const cameraLifecycleAbort = () =>
 		new DOMException("Camera lifecycle has ended", "AbortError");
@@ -371,8 +376,27 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 	const enqueueCameraTransition = <T>(
 		operation: () => Promise<T>,
 	): Promise<T> => {
-		const result = cameraTransitionQueue.then(operation);
+		const result = cameraTransitionQueue.then(async () => {
+			try {
+				return await operation();
+			} finally {
+				observeLocalTracks();
+			}
+		});
 		cameraTransitionQueue = result.catch(() => undefined);
+		return result;
+	};
+	const enqueueMicrophoneTransition = <T>(
+		operation: () => Promise<T>,
+	): Promise<T> => {
+		const result = microphoneTransitionQueue.then(async () => {
+			try {
+				return await operation();
+			} finally {
+				observeLocalTracks();
+			}
+		});
+		microphoneTransitionQueue = result.catch(() => undefined);
 		return result;
 	};
 
@@ -1062,7 +1086,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			if (type === "speaker") {
 				await switchSpeaker(deviceId);
 			} else if (type === "microphone") {
-				await switchMic(deviceId);
+				await enqueueMicrophoneTransition(() => switchMic(deviceId));
 			} else if (type === "camera") {
 				await enqueueCameraTransition(() => switchCam(deviceId));
 			}
@@ -1432,6 +1456,212 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		return { stream, constraints };
 	};
 
+	const signalMediaDisabled = (kind: "audio" | "video") => {
+		if (!sfuClient.isConnected()) return;
+		try {
+			sfuClient.sendMediaControl(kind === "video" ? "video_off" : "mute");
+		} catch (_) {
+			sfuClient.sendMediaControl({ type: kind, enabled: false });
+		}
+	};
+
+	const failEndedTrackRecovery = async (kind: "audio" | "video") => {
+		if (kind === "video") {
+			try {
+				const operation = createCameraOperation();
+				await reconcileCameraTrack(null, "camera-track-ended", false, operation);
+			} catch (error) {
+				console.error("Failed to close ended camera publication:", error);
+			}
+			cleanupBackgroundSession();
+			for (const track of mediaState.localStream?.getVideoTracks() ?? []) {
+				mediaState.localStream?.removeTrack(track);
+				stopLifecycleTrack(track);
+			}
+			mediaState.isCameraOn = false;
+			setCameraEnabled(false);
+			toast.error(
+				"Camera stopped and could not be restarted. Check browser permissions and devices.",
+			);
+		} else {
+			const manager = sfuManager.value;
+			try {
+				if (manager) {
+					await manager.serializeSendMediaMutation(async () => {
+						const mediaHandler = getMediaHandler(manager);
+						const producer = mediaHandler?.audioProducer;
+						producer?.close?.();
+						if (producer?.id && sfuClient.isConnected()) {
+							void sfuClient.closeProducer(producer.id).catch(() => {});
+						}
+						if (mediaHandler) mediaHandler.audioProducer = null;
+						manager.setLocalMediaTrack("audio", null);
+					});
+				}
+			} catch (error) {
+				console.error("Failed to close ended microphone publication:", error);
+			}
+			noiseCancellationSession?.cleanup();
+			noiseCancellationSession = null;
+			for (const track of mediaState.localStream?.getAudioTracks() ?? []) {
+				mediaState.localStream?.removeTrack(track);
+				stopLifecycleTrack(track);
+			}
+			mediaState.isMicOn = false;
+			setMicEnabled(false);
+			toast.error(
+				"Microphone stopped and could not be restarted. Check browser permissions and devices.",
+			);
+		}
+		signalMediaDisabled(kind);
+	};
+
+	const recoverEndedCameraTrack = async (endedTrack: MediaStreamTrack) => {
+		if (
+			cameraLifecycleAbortController.signal.aborted ||
+			!mediaState.isCameraOn ||
+			!mediaState.localStream?.getVideoTracks().includes(endedTrack)
+		) return;
+		try {
+			await switchCam(selectedCameraId.value);
+		} catch (error) {
+			if (isCameraLifecycleAbort(error)) return;
+			console.error("Failed to recover ended camera track:", error);
+			await failEndedTrackRecovery("video");
+		}
+	};
+
+	const recoverEndedMicrophoneTrack = async (endedTrack: MediaStreamTrack) => {
+		if (
+			cameraLifecycleAbortController.signal.aborted ||
+			!mediaState.isMicOn ||
+			!mediaState.localStream?.getAudioTracks().includes(endedTrack)
+		) return;
+		try {
+			const currentStream = mediaState.localStream;
+			const { stream: acquiredStream } = await acquireUserMedia(false, true, {
+				micDeviceId: selectedMicId.value,
+			});
+			const candidate = acquiredStream
+				.getAudioTracks()
+				.find((track) => track.readyState === "live");
+			if (
+				!candidate ||
+				!mediaState.isMicOn ||
+				mediaState.localStream !== currentStream ||
+				!currentStream.getAudioTracks().includes(endedTrack)
+			) {
+				stopLifecycleStream(acquiredStream);
+				return;
+			}
+
+			for (const track of currentStream.getAudioTracks()) {
+				currentStream.removeTrack(track);
+			}
+			currentStream.addTrack(candidate);
+			noiseCancellationSession?.cleanup();
+			noiseCancellationSession = null;
+			const trackToPublish = await getProcessedAudioTrack(currentStream);
+			if (!trackToPublish || trackToPublish.readyState !== "live") {
+				throw new Error("No live microphone track available after recovery");
+			}
+
+			const manager = sfuManager.value;
+			if (manager) {
+				await manager.serializeSendMediaMutation(async () => {
+					if (!mediaState.isMicOn || candidate.readyState !== "live") {
+						throw new Error("Microphone recovery became stale");
+					}
+					const mediaHandler = getMediaHandler(manager);
+					const producer = mediaHandler?.audioProducer;
+					if (producer) {
+						if (typeof producer.replaceTrack !== "function") {
+							throw new Error("Microphone producer cannot replace its track");
+						}
+						await producer.replaceTrack({ track: trackToPublish });
+						if (trackToPublish.readyState !== "live") {
+							throw new Error("Microphone track ended during recovery");
+						}
+						producer.resume?.();
+					} else if (manager.transportManager) {
+						const nextProducer = await manager.transportManager.createProducer(
+							trackToPublish,
+							{ type: "microphone" },
+						);
+						if (trackToPublish.readyState !== "live") {
+							nextProducer.close?.();
+							throw new Error("Microphone track ended during recovery");
+						}
+						mediaHandler?.setProducers({
+							audioProducer: nextProducer as ProducerLike,
+						});
+					}
+					manager.setLocalMediaTrack("audio", trackToPublish);
+				});
+			}
+			for (const track of acquiredStream.getTracks()) {
+				if (track !== candidate) stopLifecycleTrack(track);
+			}
+			stopLifecycleTrack(endedTrack);
+		} catch (error) {
+			if (isCameraLifecycleAbort(error)) return;
+			console.error("Failed to recover ended microphone track:", error);
+			stopLifecycleTrack(endedTrack);
+			await failEndedTrackRecovery("audio");
+		}
+	};
+
+	function observeLocalTracks() {
+		const cameraTrack =
+			mediaState.localStream
+				?.getVideoTracks()
+				.find((track) => track.readyState === "live") ?? null;
+		if (cameraTrack !== observedCameraTrack) {
+			if (observedCameraTrack && cameraEndedListener) {
+				observedCameraTrack.removeEventListener("ended", cameraEndedListener);
+			}
+			observedCameraTrack = cameraTrack;
+			cameraEndedListener = cameraTrack
+				? () => {
+						void enqueueCameraTransition(() =>
+							recoverEndedCameraTrack(cameraTrack),
+						).catch((error) =>
+							console.error("Camera track recovery failed:", error),
+						);
+					}
+				: null;
+			if (cameraTrack && cameraEndedListener) {
+				cameraTrack.addEventListener("ended", cameraEndedListener);
+			}
+		}
+
+		const microphoneTrack =
+			mediaState.localStream
+				?.getAudioTracks()
+				.find((track) => track.readyState === "live") ?? null;
+		if (microphoneTrack !== observedMicrophoneTrack) {
+			if (observedMicrophoneTrack && microphoneEndedListener) {
+				observedMicrophoneTrack.removeEventListener(
+					"ended",
+					microphoneEndedListener,
+				);
+			}
+			observedMicrophoneTrack = microphoneTrack;
+			microphoneEndedListener = microphoneTrack
+				? () => {
+						void enqueueMicrophoneTransition(() =>
+							recoverEndedMicrophoneTrack(microphoneTrack),
+						).catch((error) =>
+							console.error("Microphone track recovery failed:", error),
+						);
+					}
+				: null;
+			if (microphoneTrack && microphoneEndedListener) {
+				microphoneTrack.addEventListener("ended", microphoneEndedListener);
+			}
+		}
+	}
+
 	const applySpeakerDevice = async () => {
 		try {
 			const validSpeakerId = await getValidDeviceId(
@@ -1541,7 +1771,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 	const initializeCamera = () =>
 		enqueueCameraTransition(initializeCameraImplementation);
 
-	const toggleMicrophone = async () => {
+	const toggleMicrophoneImplementation = async () => {
 		try {
 			const enable = !mediaState.isMicOn;
 			const mh = getMediaHandler(sfuManager.value);
@@ -1706,6 +1936,8 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			toast.error("Failed to toggle microphone");
 		}
 	};
+	const toggleMicrophone = () =>
+		enqueueMicrophoneTransition(toggleMicrophoneImplementation);
 
 	const toggleCameraImplementation = async () => {
 		const operation = createCameraOperation();
@@ -2165,10 +2397,21 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		}
 	});
 
+	observeLocalTracks();
+
 	onUnmounted(() => {
 		cameraLifecycleGeneration++;
 		cameraLifecycleAbortController.abort(cameraLifecycleAbort());
 		mediaState.isCameraOn = false;
+		if (observedCameraTrack && cameraEndedListener) {
+			observedCameraTrack.removeEventListener("ended", cameraEndedListener);
+		}
+		if (observedMicrophoneTrack && microphoneEndedListener) {
+			observedMicrophoneTrack.removeEventListener(
+				"ended",
+				microphoneEndedListener,
+			);
+		}
 
 		if (noiseCancellationSession) {
 			noiseCancellationSession.cleanup();

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -1569,6 +1569,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			noiseCancellationSession?.cleanup();
 			noiseCancellationSession = null;
 			const trackToPublish = await getProcessedAudioTrack(currentStream);
+			assertCurrentCameraOperation(operation);
 			if (!trackToPublish || trackToPublish.readyState !== "live") {
 				throw new Error("No live microphone track available after recovery");
 			}
@@ -1576,6 +1577,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			const manager = sfuManager.value;
 			if (manager) {
 				await manager.serializeSendMediaMutation(async () => {
+					assertCurrentCameraOperation(operation);
 					if (!mediaState.isMicOn || candidate.readyState !== "live") {
 						throw new Error("Microphone recovery became stale");
 					}


### PR DESCRIPTION
## Summary

- reacquire and republish enabled camera or microphone tracks that end unexpectedly
- serialize recovery with media controls and preserve selected-device fallback behavior
- make terminal recovery failures visible while keeping participant media state truthful