### PR TITLE
fix(meet): recover missing remote streams

### DIFF
--- a/frontend/src/apps/meet/composables/__tests__/useNetworkQuality.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useNetworkQuality.test.ts
@@ -204,6 +204,75 @@ describe("useNetworkQuality", () => {
 		app.unmount();
 	});
 
+	it("recreates only a consumer that misses its first RTP deadline", async () => {
+		vi.useFakeTimers();
+		const recoverConsumer = vi.fn().mockResolvedValue(undefined);
+		const resetReceiveMedia = vi.fn().mockResolvedValue(undefined);
+		const requestConsumerKeyFrame = vi.fn().mockResolvedValue(undefined);
+		const zeroStats = new Map<string, { type: string; bytesReceived: number }>([
+			["in", { type: "inbound-rtp", bytesReceived: 0 }],
+		]);
+		const consumer = (id: string, adaptivelyPaused = false) => ({
+			id,
+			participantId: `participant-${id}`,
+			producerId: `producer-${id}`,
+			kind: "video",
+			isScreen: false,
+			adaptivelyPaused,
+			track: { muted: false } as MediaStreamTrack,
+			createdAt: Date.now() - 20_000,
+			consumer: {
+				paused: false,
+				producerPaused: false,
+				getStats: vi.fn().mockResolvedValue(zeroStats),
+			},
+		});
+		const expected = consumer("expected");
+		const hidden = consumer("hidden", true);
+		const sfuManager = ref({
+			sfuClient: { requestConsumerKeyFrame },
+			participantManager: {
+				getParticipant: () => ({ audio_enabled: true, video_enabled: true }),
+			},
+			transportManager: {
+				getTransportStats: () => ({
+					sendTransport: { state: "connected" },
+					recvTransport: { state: "connected" },
+				}),
+				getNetworkStats: vi.fn().mockResolvedValue({
+					rtt: 50,
+					packetLoss: 0,
+					availableOutgoingBitrate: 800_000,
+					timestamp: Date.now(),
+					isValid: true,
+				}),
+			},
+			mediaManager: {
+				consumerManager: {
+					getAllConsumers: () => [expected, hidden],
+				},
+				recoverConsumer,
+			},
+			resetReceiveMedia,
+		});
+		const app = createApp({
+			setup: () => {
+				useNetworkQuality();
+				return () => null;
+			},
+		});
+		app.provide("sfuManager", sfuManager);
+		app.mount(document.createElement("div"));
+
+		await vi.advanceTimersByTimeAsync(3000);
+
+		expect(recoverConsumer).toHaveBeenCalledOnce();
+		expect(recoverConsumer).toHaveBeenCalledWith(expected);
+		expect(requestConsumerKeyFrame).not.toHaveBeenCalled();
+		expect(resetReceiveMedia).not.toHaveBeenCalled();
+		app.unmount();
+	});
+
 	it("restarts only a stalled remote video consumer", async () => {
 		vi.useFakeTimers();
 

--- a/frontend/src/apps/meet/composables/useNetworkQuality.ts
+++ b/frontend/src/apps/meet/composables/useNetworkQuality.ts
@@ -106,6 +106,8 @@ export function useNetworkQuality(
 				);
 				return (
 					entry.consumer.paused ||
+					entry.consumer.producerPaused ||
+					entry.adaptivelyPaused ||
 					(entry.kind === "audio" && participant?.audio_enabled === false) ||
 					(entry.kind === "video" &&
 						!entry.isScreen &&
@@ -143,8 +145,21 @@ export function useNetworkQuality(
 		const stalledEntries = statsResults
 			.map(({ entry }) => entry)
 			.filter((entry) => stalledSet.has(entry.id));
-		const hasAudioStall = stalledEntries.some((entry) => entry.kind === "audio");
-		const hasExhaustedVideoRecovery = stalledEntries.some(
+		const neverStartedEntries = stalledEntries.filter(
+			(entry) => !stallDetector.hasReceivedMedia(entry.id),
+		);
+		for (const entry of neverStartedEntries) {
+			stallDetector.dispose(entry.id);
+			void sfuManager.mediaManager.recoverConsumer(entry);
+		}
+		const establishedStalls = stalledEntries.filter(
+			(entry) => stallDetector.hasReceivedMedia(entry.id),
+		);
+		if (establishedStalls.length === 0) return;
+		const hasAudioStall = establishedStalls.some(
+			(entry) => entry.kind === "audio",
+		);
+		const hasExhaustedVideoRecovery = establishedStalls.some(
 			(entry) =>
 				entry.kind === "video" && stallDetector.getRecoveryAttempts(entry.id) > 2,
 		);
@@ -154,7 +169,7 @@ export function useNetworkQuality(
 			return;
 		}
 
-		for (const entry of stalledEntries) {
+		for (const entry of establishedStalls) {
 			if (entry.kind === "video") {
 				void sfuManager.sfuClient
 					?.requestConsumerKeyFrame(entry.id)

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -59,6 +59,7 @@ export class SFUMeetingManager {
 	private connectionManager: ParticipantConnection;
 	mediaManager: SFUMediaManager;
 	private recoveryManager: SFURecoveryManager;
+	private consumerPreferenceGenerations = new Map<string, number>();
 
 	constructor(sfuClient: SFUClient) {
 		this.sfuClient = sfuClient;
@@ -377,17 +378,34 @@ export class SFUMeetingManager {
 			height: number;
 		},
 	): Promise<unknown | null> {
+		const generation =
+			(this.consumerPreferenceGenerations.get(consumerId) ?? 0) + 1;
+		this.consumerPreferenceGenerations.set(consumerId, generation);
+		if (!preferences.visible) {
+			this.consumerManager.updateConsumer(consumerId, {
+				adaptivelyPaused: true,
+			});
+		}
 		if (!this.sfuClient?.isConnected()) {
 			return null;
 		}
 
 		try {
-			return await this.sfuClient.updateConsumerPreferences({
+			const result = await this.sfuClient.updateConsumerPreferences({
 				consumerId,
 				visible: preferences.visible,
 				width: preferences.width,
 				height: preferences.height,
 			});
+			if (
+				preferences.visible &&
+				this.consumerPreferenceGenerations.get(consumerId) === generation
+			) {
+				this.consumerManager.updateConsumer(consumerId, {
+					adaptivelyPaused: false,
+				});
+			}
+			return result;
 		} catch (error) {
 			console.warn(
 				"Failed to update consumer preferences",
@@ -395,6 +413,10 @@ export class SFUMeetingManager {
 				(error as Error)?.message || error,
 			);
 			return null;
+		} finally {
+			if (this.consumerPreferenceGenerations.get(consumerId) === generation) {
+				this.consumerPreferenceGenerations.delete(consumerId);
+			}
 		}
 	}
 

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -387,7 +387,7 @@ export class SFUMeetingManager {
 			});
 		}
 		if (!this.sfuClient?.isConnected()) {
-			return null;
+			throw new Error("Cannot update consumer preferences while disconnected");
 		}
 
 		try {
@@ -412,7 +412,7 @@ export class SFUMeetingManager {
 				consumerId,
 				(error as Error)?.message || error,
 			);
-			return null;
+			throw error;
 		} finally {
 			if (this.consumerPreferenceGenerations.get(consumerId) === generation) {
 				this.consumerPreferenceGenerations.delete(consumerId);

--- a/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
@@ -77,6 +77,37 @@ function prepareE2EEManager() {
 }
 
 describe("SFUMeetingManager adaptive streaming", () => {
+	it("rejects visible preferences while disconnected", async () => {
+		const manager = new SFUMeetingManager({
+			isConnected: vi.fn(() => false),
+		} as never);
+
+		await expect(
+			manager.updateConsumerStreamPreferences("consumer-1", {
+				visible: true,
+				width: 640,
+				height: 360,
+			}),
+		).rejects.toThrow("disconnected");
+	});
+
+	it("rejects a failed visible preference without clearing adaptive pause", async () => {
+		const manager = new SFUMeetingManager({
+			isConnected: vi.fn(() => true),
+			updateConsumerPreferences: vi.fn().mockRejectedValue(new Error("offline")),
+		} as never);
+		const updateConsumer = vi.spyOn(manager.consumerManager, "updateConsumer");
+
+		await expect(
+			manager.updateConsumerStreamPreferences("consumer-1", {
+				visible: true,
+				width: 640,
+				height: 360,
+			}),
+		).rejects.toThrow("offline");
+		expect(updateConsumer).not.toHaveBeenCalled();
+	});
+
 	it("keeps the latest hidden preference when an older resume resolves late", async () => {
 		const visibleRequest = deferred<unknown>();
 		const hiddenRequest = deferred<unknown>();

--- a/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
@@ -76,6 +76,42 @@ function prepareE2EEManager() {
 	return manager;
 }
 
+describe("SFUMeetingManager adaptive streaming", () => {
+	it("keeps the latest hidden preference when an older resume resolves late", async () => {
+		const visibleRequest = deferred<unknown>();
+		const hiddenRequest = deferred<unknown>();
+		const updateConsumerPreferences = vi
+			.fn()
+			.mockReturnValueOnce(visibleRequest.promise)
+			.mockReturnValueOnce(hiddenRequest.promise);
+		const manager = new SFUMeetingManager({
+			isConnected: vi.fn(() => true),
+			updateConsumerPreferences,
+		} as never);
+		const updateConsumer = vi.spyOn(manager.consumerManager, "updateConsumer");
+
+		const visible = manager.updateConsumerStreamPreferences("consumer-1", {
+			visible: true,
+			width: 640,
+			height: 360,
+		});
+		const hidden = manager.updateConsumerStreamPreferences("consumer-1", {
+			visible: false,
+			width: 0,
+			height: 0,
+		});
+		hiddenRequest.resolve(null);
+		await hidden;
+		visibleRequest.resolve(null);
+		await visible;
+
+		expect(updateConsumer).toHaveBeenCalledOnce();
+		expect(updateConsumer).toHaveBeenCalledWith("consumer-1", {
+			adaptivelyPaused: true,
+		});
+	});
+});
+
 describe("SFUMeetingManager recovery fallback", () => {
 	it("keeps existing consumers after a successful ICE restart", async () => {
 		const manager = new SFUMeetingManager({

--- a/frontend/src/apps/meet/utils/media/ConsumerManager.ts
+++ b/frontend/src/apps/meet/utils/media/ConsumerManager.ts
@@ -11,6 +11,7 @@ export interface ConsumerEntry {
 	producerId: string;
 	kind: MediaKind;
 	isScreen: boolean;
+	adaptivelyPaused: boolean;
 	track?: MediaStreamTrack;
 	appData?: AppData;
 	createdAt: number;
@@ -81,6 +82,7 @@ export class ConsumerManager {
 			producerId: consumer.producerId,
 			kind: consumer.kind,
 			isScreen: consumer.appData?.type === "screen" || false,
+			adaptivelyPaused: false,
 			track: consumer.track,
 			appData: consumer.appData,
 			createdAt: Date.now(),

--- a/frontend/src/apps/meet/utils/media/__tests__/stallDetector.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/stallDetector.test.ts
@@ -179,11 +179,37 @@ describe("StallDetector", () => {
 		expect(det.check([toSample(sample)])).toEqual([]);
 	});
 
+	it("gives a resumed consumer a fresh first-media deadline", () => {
+		const det = detector();
+		const sample = makeSample({ createdAt: now, paused: true, bytes: 0 });
+		det.check([toSample(sample)]);
+
+		now += 30_000;
+		sample.paused = false;
+		expect(det.check([toSample(sample)])).toEqual([]);
+
+		now += 14_000;
+		expect(det.check([toSample(sample)])).toEqual([]);
+		now += 1_000;
+		expect(det.check([toSample(sample)])).toEqual(["c1"]);
+	});
+
 	it("ignores consumers with no bytesReceived (stats unavailable)", () => {
 		const det = detector();
 		const sample = makeSample({ createdAt: now - 10_000, bytes: null });
 		now += 10_000;
 		expect(det.check([toSample(sample)])).toEqual([]);
+	});
+
+	it("reports an expected consumer that receives no RTP before its deadline", () => {
+		const det = detector();
+		const sample = makeSample({ createdAt: now, bytes: 0 });
+
+		now += 14_000;
+		expect(det.check([toSample(sample)])).toEqual([]);
+
+		now += 1_000;
+		expect(det.check([toSample(sample)])).toEqual(["c1"]);
 	});
 
 	it("disposes state for a removed consumer", () => {
@@ -211,7 +237,7 @@ describe("StallDetector", () => {
 			expect(det.check([audioSample])).toEqual(["c1"]);
 		});
 
-		it("uses the longer startup window for audio before RTP arrives", () => {
+		it("uses the longer startup window for audio before reporting no RTP", () => {
 			const det = detector();
 			const sample = makeSample({ createdAt: now - 10_000, bytes: 0 });
 			const audioSample = { ...toSample(sample), kind: "audio" };
@@ -227,10 +253,10 @@ describe("StallDetector", () => {
 
 			now += 5_000;
 			sample.bytes = 0;
-			expect(det.check([audioSample])).toEqual([]);
+			expect(det.check([audioSample])).toEqual(["c1"]);
 		});
 
-		it("does not report a startup video stall before RTP arrives", () => {
+		it("reports startup video that misses the first RTP deadline", () => {
 			const det = detector();
 			const sample = makeSample({ createdAt: now - 10_000, bytes: 0 });
 			const videoSample = { ...toSample(sample), kind: "video" };
@@ -242,7 +268,7 @@ describe("StallDetector", () => {
 
 			now += 6_000;
 			sample.bytes = 0;
-			expect(det.check([videoSample])).toEqual([]);
+			expect(det.check([videoSample])).toEqual(["c1"]);
 		});
 
 		it("uses the longer default window for video", () => {

--- a/frontend/src/apps/meet/utils/media/stallDetector.ts
+++ b/frontend/src/apps/meet/utils/media/stallDetector.ts
@@ -36,6 +36,8 @@ interface StallDetectorOptions {
 interface ConsumerState {
 	lastBytesReceived: number;
 	hasReceivedBytes: boolean;
+	startupStartedAt: number;
+	wasPaused: boolean;
 	stallStartedAt: number | null;
 	lastRecoveredAt: number | null;
 	recoveryAttempts: number;
@@ -70,10 +72,17 @@ export class StallDetector {
 
 		for (const sample of samples) {
 			activeIds.add(sample.id);
+			const st = this.ensureState(sample.id, sample.getCreatedAt());
 
 			if (sample.isPaused()) {
-				this.state.delete(sample.id);
+				st.wasPaused = true;
+				st.hasReceivedBytes = false;
+				st.stallStartedAt = null;
 				continue;
+			}
+			if (st.wasPaused) {
+				st.wasPaused = false;
+				st.startupStartedAt = now;
 			}
 
 			if (now - sample.getCreatedAt() < this.minConsumerAgeMs) {
@@ -81,14 +90,24 @@ export class StallDetector {
 			}
 
 			const bytes = sample.getBytesReceived();
-			const st = this.ensureState(sample.id);
 			if (bytes !== null && bytes > 0) {
 				st.hasReceivedBytes = true;
 			}
 
 			if (!st.hasReceivedBytes) {
-				st.stallStartedAt = null;
 				st.lastBytesReceived = bytes ?? 0;
+				if (bytes === null) {
+					st.stallStartedAt = null;
+					continue;
+				}
+				if (now - st.startupStartedAt >= this.stallTimeoutMs) {
+					this.activeStall = true;
+					if (recoveryEnabled && this.shouldRecover(st, now)) {
+						stalled.push(sample.id);
+						st.lastRecoveredAt = now;
+						st.recoveryAttempts += 1;
+					}
+				}
 				continue;
 			}
 
@@ -160,12 +179,14 @@ export class StallDetector {
 			: this.stallTimeoutMs;
 	}
 
-	private ensureState(id: string): ConsumerState {
+	private ensureState(id: string, createdAt: number): ConsumerState {
 		let st = this.state.get(id);
 		if (!st) {
 			st = {
 				lastBytesReceived: 0,
 				hasReceivedBytes: false,
+				startupStartedAt: createdAt,
+				wasPaused: false,
 				stallStartedAt: null,
 				lastRecoveredAt: null,
 				recoveryAttempts: 0,
@@ -187,6 +208,10 @@ export class StallDetector {
 
 	getRecoveryAttempts(consumerId: string): number {
 		return this.state.get(consumerId)?.recoveryAttempts ?? 0;
+	}
+
+	hasReceivedMedia(consumerId: string): boolean {
+		return this.state.get(consumerId)?.hasReceivedBytes ?? false;
 	}
 
 	hasActiveStall(): boolean {

--- a/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
+++ b/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
@@ -821,6 +821,10 @@ export class ParticipantConnection {
 	}
 
 	private removeProducerConsumers(event: SFUProducerEvent): void {
+		this.mediaManager.cancelProducerSubscription?.(
+			event.participantId,
+			event.producerId,
+		);
 		const consumers =
 			this.mediaManager.consumerManager.getConsumersByParticipant(
 				event.participantId,

--- a/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
@@ -97,10 +97,13 @@ export class SFUMediaManager {
 
 	private eventHandlers: MediaEventHandlers = {};
 	private getCurrentUserId: () => string | null;
-	private resubscribeAttempts: Map<string, number> = new Map();
 	private pendingSubscriptions: Map<string, Promise<unknown | null>> = new Map();
-	private resubscribeTimers = new Set<ReturnType<typeof setTimeout>>();
+	private resubscribeTimers = new Map<
+		ReturnType<typeof setTimeout>,
+		() => void
+	>();
 	private subscriptionGeneration = 0;
+	private producerSubscriptionGenerations = new Map<string, number>();
 	private receiveSubscriptionsClosed = false;
 	private sendMediaMutationQueue: Promise<unknown> = Promise.resolve();
 	private sendMediaMutationGeneration = 0;
@@ -410,14 +413,11 @@ export class SFUMediaManager {
 		if (pending) return pending;
 
 		let subscription: Promise<unknown | null>;
-		subscription = this.subscribeToProducer(producerId, participantId, {
-			isScreen: !!isScreen,
-		})
-			.then((result) => {
-				this.resubscribeAttempts.delete(key);
-				return result;
-			})
-			.finally(() => {
+		subscription = this.subscribeWithRetry(
+			{ producerId, participantId, isScreen },
+			this.subscriptionGeneration,
+			this.producerSubscriptionGenerations.get(key) ?? 0,
+		).finally(() => {
 				if (this.pendingSubscriptions.get(key) === subscription) {
 					this.pendingSubscriptions.delete(key);
 				}
@@ -445,36 +445,153 @@ export class SFUMediaManager {
 			return;
 		}
 
-		const key = this.resubscribeKey(info.participantId, info.producerId);
-		const attempts = this.resubscribeAttempts.get(key) ?? 0;
-		if (attempts >= SFUMediaManager.MAX_RESUBSCRIBE_ATTEMPTS) {
-			console.warn("Giving up on re-subscribing to lost consumer", {
-				participantId: info.participantId,
-				producerId: info.producerId,
-				kind: info.kind,
-				attempts,
-			});
-			this.resubscribeAttempts.delete(key);
-			this.eventHandlers.onRecoveryExhausted?.();
-			return;
-		}
-		this.resubscribeAttempts.set(key, attempts + 1);
-
-		const timer = setTimeout(() => {
-			this.resubscribeTimers.delete(timer);
-			void this.subscribeToRemoteProducer({
+		void this.startSubscription(
+			{
 				producerId: info.producerId,
 				participantId: info.participantId,
 				isScreen: info.isScreen,
-			}).catch((error: unknown) => {
+			},
+			true,
+		).catch((error: unknown) => {
 				console.warn("Failed to re-subscribe to lost consumer", {
 					participantId: info.participantId,
 					producerId: info.producerId,
 					error: (error as Error).message,
 				});
 			});
-		}, SFUMediaManager.RESUBSCRIBE_DELAY_MS);
-		this.resubscribeTimers.add(timer);
+	}
+
+	async recoverConsumer(entry: ConsumerEntry): Promise<void> {
+		this.consumerManager.removeConsumer(entry.id);
+		await this.handleConsumerLost({
+			consumerId: entry.id,
+			participantId: entry.participantId,
+			producerId: entry.producerId,
+			kind: entry.kind,
+			isScreen: entry.isScreen,
+		});
+	}
+
+	private startSubscription(
+		request: { producerId: string; participantId: string; isScreen: boolean },
+		delayFirstAttempt = false,
+	): Promise<unknown | null> {
+		const key = this.resubscribeKey(request.participantId, request.producerId);
+		const pending = this.pendingSubscriptions.get(key);
+		if (pending) return pending;
+
+		let subscription: Promise<unknown | null>;
+		subscription = this.subscribeWithRetry(
+			request,
+			this.subscriptionGeneration,
+			this.producerSubscriptionGenerations.get(key) ?? 0,
+			delayFirstAttempt,
+		).finally(() => {
+			if (this.pendingSubscriptions.get(key) === subscription) {
+				this.pendingSubscriptions.delete(key);
+			}
+		});
+		this.pendingSubscriptions.set(key, subscription);
+		return subscription;
+	}
+
+	private async subscribeWithRetry(
+		request: { producerId: string; participantId: string; isScreen: boolean },
+		generation: number,
+		producerGeneration: number,
+		delayFirstAttempt = false,
+	): Promise<unknown | null> {
+		const key = this.resubscribeKey(request.participantId, request.producerId);
+		let lastError: unknown;
+		for (
+			let attempt = 1;
+			attempt <= SFUMediaManager.MAX_RESUBSCRIBE_ATTEMPTS;
+			attempt++
+		) {
+			if (delayFirstAttempt || attempt > 1) {
+				await this.waitForResubscribeDelay(
+					generation,
+					key,
+					producerGeneration,
+				);
+			}
+			delayFirstAttempt = false;
+			if (
+				this.receiveSubscriptionsClosed ||
+				generation !== this.subscriptionGeneration ||
+				producerGeneration !==
+					(this.producerSubscriptionGenerations.get(key) ?? 0)
+			) {
+				throw new DOMException("Receive media lifecycle has ended", "AbortError");
+			}
+
+			try {
+				const consumer = await this.subscribeToProducer(
+					request.producerId,
+					request.participantId,
+					{ isScreen: request.isScreen },
+				);
+				if (
+					producerGeneration !==
+					(this.producerSubscriptionGenerations.get(key) ?? 0)
+				) {
+					if (consumer) this.consumerManager.removeConsumer(consumer.id);
+					throw new DOMException("Producer subscription was cancelled", "AbortError");
+				}
+				return consumer;
+			} catch (error) {
+				lastError = error;
+				if (
+					generation !== this.subscriptionGeneration ||
+					producerGeneration !==
+						(this.producerSubscriptionGenerations.get(key) ?? 0)
+				)
+					throw error;
+			}
+		}
+
+		console.warn("Giving up on remote consumer subscription", {
+			participantId: request.participantId,
+			producerId: request.producerId,
+			attempts: SFUMediaManager.MAX_RESUBSCRIBE_ATTEMPTS,
+		});
+		this.eventHandlers.onRecoveryExhausted?.();
+		throw lastError;
+	}
+
+	private waitForResubscribeDelay(
+		generation: number,
+		key: string,
+		producerGeneration: number,
+	): Promise<void> {
+		return new Promise((resolve, reject) => {
+			const finish = () => {
+				this.resubscribeTimers.delete(timer);
+				if (
+					this.receiveSubscriptionsClosed ||
+					generation !== this.subscriptionGeneration ||
+					producerGeneration !==
+						(this.producerSubscriptionGenerations.get(key) ?? 0)
+				) {
+					reject(
+						new DOMException("Receive media lifecycle has ended", "AbortError"),
+					);
+					return;
+				}
+				resolve();
+			};
+			const timer = setTimeout(finish, SFUMediaManager.RESUBSCRIBE_DELAY_MS);
+			this.resubscribeTimers.set(timer, finish);
+		});
+	}
+
+	cancelProducerSubscription(participantId: string, producerId: string): void {
+		const key = this.resubscribeKey(participantId, producerId);
+		this.producerSubscriptionGenerations.set(
+			key,
+			(this.producerSubscriptionGenerations.get(key) ?? 0) + 1,
+		);
+		this.pendingSubscriptions.delete(key);
 	}
 
 	private resubscribeKey(participantId: string, producerId: string): string {
@@ -483,9 +600,12 @@ export class SFUMediaManager {
 
 	cancelPendingSubscriptions(): Promise<void> {
 		this.subscriptionGeneration++;
-		for (const timer of this.resubscribeTimers) clearTimeout(timer);
+		for (const [timer, finish] of this.resubscribeTimers) {
+			clearTimeout(timer);
+			finish();
+		}
 		this.resubscribeTimers.clear();
-		this.resubscribeAttempts.clear();
+		this.producerSubscriptionGenerations.clear();
 		const pending = Array.from(this.pendingSubscriptions.values());
 		this.pendingSubscriptions.clear();
 		void Promise.allSettled(pending);

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
@@ -61,6 +61,7 @@ function createManager(
 	consumerManager: {
 		addConsumer: ReturnType<typeof vi.fn>;
 		getConsumersByParticipant: ReturnType<typeof vi.fn>;
+		removeConsumer: ReturnType<typeof vi.fn>;
 	};
 	participantManager: MockParticipantManager;
 } {
@@ -84,6 +85,7 @@ function createManager(
 
 	const consumerManager = {
 		getConsumersByParticipant: vi.fn(() => []),
+		removeConsumer: vi.fn(),
 		addConsumer: vi.fn((c) => ({
 			id: c.id,
 			producerId: c.producerId,
@@ -118,6 +120,14 @@ function createManager(
 }
 
 describe("SFUMediaManager.subscribeToRemoteProducer", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it("shares one subscription across concurrent callers", async () => {
 		const { mediaManager, transportManager } = createManager();
 		const request = {
@@ -132,6 +142,83 @@ describe("SFUMediaManager.subscribeToRemoteProducer", () => {
 		]);
 
 		expect(transportManager.createConsumer).toHaveBeenCalledTimes(1);
+	});
+
+	it("retries an initial subscription until it succeeds", async () => {
+		const { mediaManager, transportManager } = createManager();
+		transportManager.createConsumer
+			.mockRejectedValueOnce(new Error("not ready"))
+			.mockResolvedValueOnce({
+				id: "new-c1",
+				producerId: "producer-1",
+				kind: "video",
+				track: { kind: "video" },
+				appData: { type: "camera" },
+				close: vi.fn(),
+			});
+
+		const subscription = mediaManager.subscribeToRemoteProducer({
+			producerId: "producer-1",
+			participantId: "remote-1",
+			isScreen: false,
+		});
+		await vi.advanceTimersByTimeAsync(250);
+
+		await expect(subscription).resolves.toMatchObject({ id: "new-c1" });
+		expect(transportManager.createConsumer).toHaveBeenCalledTimes(2);
+	});
+
+	it("exhausts one automatic retry chain", async () => {
+		const { mediaManager, transportManager } = createManager();
+		const onRecoveryExhausted = vi.fn();
+		mediaManager.setEventHandlers({ onRecoveryExhausted });
+		transportManager.createConsumer.mockRejectedValue(new Error("server down"));
+
+		const subscription = mediaManager.subscribeToRemoteProducer({
+			producerId: "producer-1",
+			participantId: "remote-1",
+			isScreen: false,
+		});
+		void subscription.catch(() => {});
+		await vi.advanceTimersByTimeAsync(1000);
+
+		await expect(subscription).rejects.toThrow("server down");
+		expect(transportManager.createConsumer).toHaveBeenCalledTimes(3);
+		expect(onRecoveryExhausted).toHaveBeenCalledOnce();
+	});
+
+	it("discards an in-flight subscription when its producer closes", async () => {
+		const { mediaManager, transportManager, consumerManager } = createManager();
+		const request = deferred<{
+			id: string;
+			producerId: string;
+			kind: string;
+			track: { kind: string };
+			appData: { type: string };
+			close: ReturnType<typeof vi.fn>;
+		}>();
+		transportManager.createConsumer.mockReturnValue(request.promise);
+		const subscription = mediaManager.subscribeToRemoteProducer({
+			producerId: "producer-1",
+			participantId: "remote-1",
+			isScreen: false,
+		});
+		const rejected = expect(subscription).rejects.toMatchObject({
+			name: "AbortError",
+		});
+
+		mediaManager.cancelProducerSubscription("remote-1", "producer-1");
+		request.resolve({
+			id: "stale-c1",
+			producerId: "producer-1",
+			kind: "video",
+			track: { kind: "video" },
+			appData: { type: "camera" },
+			close: vi.fn(),
+		});
+
+		await rejected;
+		expect(consumerManager.removeConsumer).toHaveBeenCalledWith("stale-c1");
 	});
 
 	it("discards a subscription that finishes after receive teardown", async () => {
@@ -782,6 +869,21 @@ describe("SFUMediaManager.handleConsumerLost", () => {
 		);
 	});
 
+	it("removes and recreates only the consumer that never started", async () => {
+		const { mediaManager, transportManager, consumerManager } = createManager();
+		await mediaManager.recoverConsumer({
+			id: "stalled-c1",
+			participantId: "remote-1",
+			producerId: "producer-1",
+			kind: "video",
+			isScreen: false,
+		} as never);
+
+		expect(consumerManager.removeConsumer).toHaveBeenCalledWith("stalled-c1");
+		await vi.advanceTimersByTimeAsync(250);
+		expect(transportManager.createConsumer).toHaveBeenCalledOnce();
+	});
+
 	it("does not re-subscribe if the participant has left", async () => {
 		const { mediaManager, transportManager } = createManager({
 			hasParticipant: false,
@@ -823,29 +925,16 @@ describe("SFUMediaManager.handleConsumerLost", () => {
 		expect(transportManager.createConsumer).not.toHaveBeenCalled();
 	});
 
-	it("caps retries at 3, then resets and tries again on the next lost event", async () => {
+	it("automatically caps lost-consumer recovery at 3 attempts", async () => {
 		const { mediaManager, transportManager } = createManager();
+		const onRecoveryExhausted = vi.fn();
+		mediaManager.setEventHandlers({ onRecoveryExhausted });
 		transportManager.createConsumer.mockRejectedValue(new Error("server down"));
 
-		for (let i = 0; i < 3; i++) {
-			await mediaManager.handleConsumerLost(baseInfo);
-			await vi.advanceTimersByTimeAsync(250);
-		}
-		expect(transportManager.createConsumer).toHaveBeenCalledTimes(3);
-
 		await mediaManager.handleConsumerLost(baseInfo);
-		await vi.advanceTimersByTimeAsync(250);
+		await vi.advanceTimersByTimeAsync(1000);
 		expect(transportManager.createConsumer).toHaveBeenCalledTimes(3);
-
-		await mediaManager.handleConsumerLost(baseInfo);
-		await vi.advanceTimersByTimeAsync(250);
-		expect(transportManager.createConsumer).toHaveBeenCalledTimes(4);
-
-		for (let i = 0; i < 2; i++) {
-			await mediaManager.handleConsumerLost(baseInfo);
-			await vi.advanceTimersByTimeAsync(250);
-		}
-		expect(transportManager.createConsumer).toHaveBeenCalledTimes(6);
+		expect(onRecoveryExhausted).toHaveBeenCalledOnce();
 	});
 
 	it("treats a successful re-subscribe as a fresh retry budget", async () => {


### PR DESCRIPTION
## Summary

- detect expected remote consumers that miss their first RTP deadline and recreate only the affected subscription
- retry initial, live, and lost-consumer subscriptions with a bounded lifecycle-safe chain
- exclude muted, paused, and adaptively hidden media from recovery