### PR TITLE
fix(slides): video upload inconsistencies

### DIFF
--- a/frontend/src/apps/slides/components/ThumbnailContainer.vue
+++ b/frontend/src/apps/slides/components/ThumbnailContainer.vue
@@ -5,7 +5,7 @@
 			class="absolute inset-0 flex w-full justify-between p-2"
 			:style="getGradientOverlayStyles(slide)"
 		>
-			<div class="text-[10px] font-medium">{{ slide.idx }}</div>
+			<div class="text-[10px] font-medium">{{ slideNumber }}</div>
 			<TransitionIcon v-if="slide.transition != 'None'" class="h-3 opacity-80" />
 		</div>
 	</div>
@@ -15,6 +15,7 @@
 import { computed } from 'vue'
 
 import { focusedSlide, slides } from '@/apps/slides/stores/slide'
+import { presentationDoc } from '@/apps/slides/stores/presentation'
 import { recentlyRestored } from '@/apps/slides/stores/historyMeta'
 
 import SlidePreview from '@/apps/slides/components/SlidePreview.vue'
@@ -42,6 +43,12 @@ const getGradientOverlayStyles = (slide) => {
 		color: textColor,
 	}
 }
+
+// a composite's slides keep the idx of the reference they came from, so the count
+// restarts at every reference; number them by position instead
+const slideNumber = computed(() =>
+	presentationDoc.value?.is_composite ? slides.value.indexOf(props.slide) + 1 : props.slide.idx,
+)
 
 const isFocused = computed(() => focusedSlide.value == slides.value.indexOf(props.slide))
 const usesSelectionRing = computed(() => (props.isActive && recentlyRestored.value) || isFocused.value)

--- a/frontend/src/apps/slides/components/Toolbar.vue
+++ b/frontend/src/apps/slides/components/Toolbar.vue
@@ -10,21 +10,9 @@
 		</Tooltip>
 
 		<Tooltip text="Media" :hover-delay="0.7">
-			<FileUploader
-				:fileTypes="allowedImageFileTypes.concat(['video/*'])"
-				:uploadArgs="{
-					doctype: 'Presentation',
-					docname: presentationId,
-					private: true,
-				}"
-				@success="(file) => handleUploadSuccess(file)"
-			>
-				<template #default="{ openFileSelector }">
-					<div class="cursor-pointer rounded p-2 hover:bg-surface-gray-3" @click="openFileSelector">
-						<ImagePlus class="size-4 stroke-[1.5] text-ink-gray-7" />
-					</div>
-				</template>
-			</FileUploader>
+			<div class="cursor-pointer rounded p-2 hover:bg-surface-gray-3" @click="openFilePicker">
+				<ImagePlus class="size-4 stroke-[1.5] text-ink-gray-7" />
+			</div>
 		</Tooltip>
 
 		<ToolDropdown tooltip="Shapes" :icon="Shapes" :options="shapeTools" />
@@ -32,16 +20,23 @@
 		<ToolDropdown tooltip="Lines" :icon="Polyline" :options="lineTools" />
 
 		<TableDropdown />
+
+		<input
+			ref="filePicker"
+			type="file"
+			class="hidden"
+			:accept="allowedImageFileTypes.concat('video/*').join(',')"
+			@change="addMedia"
+		/>
 	</div>
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { useTemplateRef } from 'vue'
 
 import { Type, ImagePlus, Shapes } from 'lucide-vue-next'
 
-import { Tooltip, FileUploader, toast } from 'frappe-ui'
-import { presentationId } from '@/apps/slides/stores/presentation'
+import { Tooltip } from 'frappe-ui'
 import { addTextElement } from '@/apps/slides/stores/element'
 import { allowedImageFileTypes } from '@/apps/slides/utils/constants'
 
@@ -51,18 +46,15 @@ import TableDropdown from '@/apps/slides/components/TableDropdown.vue'
 
 import { handleScrollBarWheelEvent } from '@/apps/slides/utils/helpers'
 import { shapeTools, lineTools } from '@/apps/slides/utils/toolbarTools'
-import { performPostUploadActions } from '@/apps/slides/utils/mediaUploads'
+import { handleUploadedMedia } from '@/apps/slides/utils/mediaUploads'
 
-const handleUploadSuccess = (file) => {
-	// file_type is a Drive category ('Image'), not a format; mime_type is what the allowlist speaks
-	const fileType = allowedImageFileTypes.includes(file.mime_type) ? 'image' : 'video'
+const filePicker = useTemplateRef('filePicker')
 
-	const toastProps = {
-		loading: file.file_name ? `Uploading: ${file.file_name}` : 'Uploading...',
-		success: (data) => (file.file_name ? `Uploaded: ${file.file_name}` : 'Uploaded'),
-		error: (data) => 'Upload failed. Please try again.',
-	}
+const openFilePicker = () => filePicker.value.click()
 
-	toast.promise(performPostUploadActions(file, fileType), toastProps)
+const addMedia = (e) => {
+	const file = e.target.files[0]
+	if (file) handleUploadedMedia([file])
+	e.target.value = ''
 }
 </script>

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -461,28 +461,38 @@ const addTableElement = async (rows = 3, cols = 3) => {
 	)
 }
 
-// createResource swallows a failed request and hands back the last poster it
-// saved, so a slow network silently pins the wrong poster or none at all
-const savePoster = (posterDataUrl) =>
-	call('suite.slides.doctype.presentation.presentation.save_base64_image', {
-		presentation_name: presentationId.value,
-		base64_data: posterDataUrl,
-		prefix: 'poster',
-	})
+// createResource hands back the last poster it saved when a request fails, which
+// silently pins the wrong one on a slow network
+const savePoster = async (posterDataUrl) => {
+	try {
+		return await call('suite.slides.doctype.presentation.presentation.save_base64_image', {
+			presentation_name: presentationId.value,
+			base64_data: posterDataUrl,
+			prefix: 'poster',
+		})
+	} catch (error) {
+		// the media is worth keeping without a poster
+		console.error('Could not save poster', error)
+		return null
+	}
+}
 
-const saveMediaFrameAsPoster = async (media, width, height) => {
+// a full bleed poster needs twice the 960px slide to stay sharp, and no more, so
+// encoding the frame at the media's own resolution only makes the upload slower
+const POSTER_MAX_EDGE = 1920
+const POSTER_QUALITY = 0.8
+
+const captureMediaFrame = (media, width, height) => {
+	const scale = Math.min(1, POSTER_MAX_EDGE / Math.max(width, height))
+
 	const canvas = document.createElement('canvas')
-	canvas.width = width
-	canvas.height = height
+	canvas.width = Math.round(width * scale)
+	canvas.height = Math.round(height * scale)
 
 	const context = canvas.getContext('2d')
 	context.drawImage(media, 0, 0, canvas.width, canvas.height)
 
-	return await savePoster(canvas.toDataURL('image/webp'))
-}
-
-const generatePoster = async (video) => {
-	return await saveMediaFrameAsPoster(video, video.videoWidth, video.videoHeight)
+	return canvas.toDataURL('image/webp', POSTER_QUALITY)
 }
 
 const isGifFile = (file) => {
@@ -498,7 +508,7 @@ const generateImagePoster = async (imageUrl) => {
 	img.src = imageUrl
 	await img.decode()
 
-	return await saveMediaFrameAsPoster(img, img.naturalWidth, img.naturalHeight)
+	return await savePoster(captureMediaFrame(img, img.naturalWidth, img.naturalHeight))
 }
 
 const getVideoElementClone = (videoUrl) => {
@@ -516,16 +526,17 @@ const getVideoElementClone = (videoUrl) => {
 	return videoElement
 }
 
-const handleVideoCloneDataLoad = async (videoClone, resolve, reject) => {
+// the frame is read locally, so how the element is sized never waits on the network
+const handleVideoCloneDataLoad = (videoClone, resolve, reject) => {
 	try {
-		const poster = await generatePoster(videoClone)
-		const aspectRatio = videoClone.videoWidth / videoClone.videoHeight
-		resolve({ posterURL: poster, aspectRatio: aspectRatio })
+		resolve({
+			frame: captureMediaFrame(videoClone, videoClone.videoWidth, videoClone.videoHeight),
+			aspectRatio: videoClone.videoWidth / videoClone.videoHeight,
+		})
 	} catch (err) {
 		reject(err)
 	} finally {
-		// remove the video element from the DOM after poster is generated
-		document.body.removeChild(videoClone)
+		videoClone.remove()
 	}
 }
 
@@ -538,16 +549,21 @@ const revokeProbeUrl = (url) => {
 	if (url.startsWith('blob:')) URL.revokeObjectURL(url)
 }
 
-const getVideoPoster = async (videoUrl) => {
+const captureVideoFrame = async (videoUrl) => {
 	return new Promise((resolve, reject) => {
 		// create a clone of the video element to generate a poster
 		// without making the original video visible so there's no flicker
 		const videoClone = getVideoElementClone(videoUrl)
 		document.body.appendChild(videoClone)
 
-		// we cannot directly capture the poster without data load event
+		// loadeddata fires before the first frame is decoded on a slow link, which
+		// captures an empty canvas; a completed seek guarantees the frame is there
+		videoClone.addEventListener('loadeddata', () => (videoClone.currentTime = 0.05), {
+			once: true,
+		})
+
 		videoClone.addEventListener(
-			'loadeddata',
+			'seeked',
 			() => handleVideoCloneDataLoad(videoClone, resolve, reject),
 			{ once: true },
 		)
@@ -555,9 +571,8 @@ const getVideoPoster = async (videoUrl) => {
 		videoClone.addEventListener(
 			'error',
 			() => {
-				// if video fails to load, don't leave cloned element in the DOM
-				document.body.removeChild(videoClone)
-				reject(new Error('Failed to load video for poster generation'))
+				videoClone.remove()
+				reject(new Error('Failed to load video for frame capture'))
 			},
 			{ once: true },
 		)
@@ -622,9 +637,9 @@ const addMediaElement = async (file, type, targetSlide, localFile) => {
 		elementWidth = 400
 		const videoUrl = getProbeUrl(src, localFile)
 		try {
-			const { posterURL, aspectRatio } = await getVideoPoster(videoUrl)
+			const { frame, aspectRatio } = await captureVideoFrame(videoUrl)
 			elementHeight = elementWidth / aspectRatio
-			videoPoster = posterURL
+			videoPoster = await savePoster(frame)
 		} catch {
 			// the video is worth keeping without a poster; it plays either way
 			elementHeight = elementWidth * (9 / 16)
@@ -699,8 +714,8 @@ const probeReplacementMedia = async (element, fileDoc, localFile) => {
 	if (element.type === 'video') {
 		const videoUrl = getProbeUrl(fileDoc.file_url, localFile)
 		try {
-			const { posterURL, aspectRatio } = await getVideoPoster(videoUrl)
-			return { poster: posterURL, aspect: aspectRatio }
+			const { frame, aspectRatio } = await captureVideoFrame(videoUrl)
+			return { poster: await savePoster(frame), aspect: aspectRatio }
 		} catch {
 			// the old poster belongs to the video being replaced, so it goes either way
 			return { poster: null }

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -587,7 +587,7 @@ const getLeftTopForCenteredElement = (elementWidth, elementHeight) => {
 	return { left: elementLeft, top: elementTop }
 }
 
-const addMediaElement = async (file, type) => {
+const addMediaElement = async (file, type, targetSlide) => {
 	const src = file.file_url
 
 	let elementWidth = 0
@@ -617,9 +617,14 @@ const addMediaElement = async (file, type) => {
 		videoPoster = posterURL
 	}
 
+	// a slow upload can outlive a slide switch, so the element goes back to the
+	// slide it was started from, not to whatever is on screen now
+	const slideIdx = slides.value.indexOf(targetSlide)
+	if (slideIdx === -1) return
+
 	let element = {
 		id: generateUniqueId(),
-		zIndex: currentSlide.value.elements.length + 1,
+		zIndex: targetSlide.elements.length + 1,
 		width: elementWidth,
 		height: elementHeight,
 		left: position.left,
@@ -651,11 +656,11 @@ const addMediaElement = async (file, type) => {
 		}
 	}
 
-	const refCommands = getCommandsToUpdateElementRefId(element) || []
+	const refCommands = getCommandsToUpdateElementRefId(element, slideIdx) || []
 
 	const commands = [
 		addElementCommand({
-			slideId: currentSlide.value.clientId,
+			slideId: targetSlide.clientId,
 			element: element,
 		}),
 		...refCommands,
@@ -663,9 +668,10 @@ const addMediaElement = async (file, type) => {
 
 	commandHistory.execute(
 		batchCommand({
-			slideId: currentSlide.value.clientId,
+			slideId: targetSlide.clientId,
 			elementIds: [element.id],
 			commands,
+			skipJumpOnExecute: targetSlide !== currentSlide.value,
 		}),
 	)
 }
@@ -722,9 +728,9 @@ const replaceMediaElement = async (element, fileDoc) => {
 	// a slow upload can outlive a slide switch or the element itself, and older
 	// presentations repeat one layout's element ids across slides, so only the
 	// element object itself names the slide to edit
-	const slide = slides.value.find((s) => s.elements.includes(element))
-	if (!slide) return
-	const slideId = slide.clientId
+	const slideIdx = slides.value.findIndex((s) => s.elements.includes(element))
+	if (slideIdx === -1) return
+	const slideId = slides.value[slideIdx].clientId
 
 	let commands = []
 	const pushEdit = (property, oldValue, newValue) => {
@@ -744,7 +750,7 @@ const replaceMediaElement = async (element, fileDoc) => {
 	}
 
 	// include any ref-id update commands produced by transition logic
-	commands = commands.concat(getCommandsToUpdateElementRefId(element) || [])
+	commands = commands.concat(getCommandsToUpdateElementRefId(element, slideIdx) || [])
 
 	if (commands.length) {
 		commandHistory.execute(

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -1,5 +1,5 @@
 import { ref, computed, nextTick, watch } from 'vue'
-import { createResource } from 'frappe-ui'
+import { call } from 'frappe-ui'
 
 import {
 	selectionBounds,
@@ -461,14 +461,14 @@ const addTableElement = async (rows = 3, cols = 3) => {
 	)
 }
 
-const savePoster = createResource({
-	url: 'suite.slides.doctype.presentation.presentation.save_base64_image',
-	makeParams: (posterDataUrl) => ({
+// createResource swallows a failed request and hands back the last poster it
+// saved, so a slow network silently pins the wrong poster or none at all
+const savePoster = (posterDataUrl) =>
+	call('suite.slides.doctype.presentation.presentation.save_base64_image', {
 		presentation_name: presentationId.value,
 		base64_data: posterDataUrl,
 		prefix: 'poster',
-	}),
-})
+	})
 
 const saveMediaFrameAsPoster = async (media, width, height) => {
 	const canvas = document.createElement('canvas')
@@ -478,7 +478,7 @@ const saveMediaFrameAsPoster = async (media, width, height) => {
 	const context = canvas.getContext('2d')
 	context.drawImage(media, 0, 0, canvas.width, canvas.height)
 
-	return await savePoster.submit(canvas.toDataURL('image/webp'))
+	return await savePoster(canvas.toDataURL('image/webp'))
 }
 
 const generatePoster = async (video) => {
@@ -527,6 +527,15 @@ const handleVideoCloneDataLoad = async (videoClone, resolve, reject) => {
 		// remove the video element from the DOM after poster is generated
 		document.body.removeChild(videoClone)
 	}
+}
+
+// reading the frame back off the server re-downloads the whole upload, so the
+// file still in hand is what gets probed
+const getProbeUrl = (src, localFile) =>
+	localFile ? URL.createObjectURL(localFile) : getAttachmentUrl(src)
+
+const revokeProbeUrl = (url) => {
+	if (url.startsWith('blob:')) URL.revokeObjectURL(url)
 }
 
 const getVideoPoster = async (videoUrl) => {
@@ -587,7 +596,7 @@ const getLeftTopForCenteredElement = (elementWidth, elementHeight) => {
 	return { left: elementLeft, top: elementTop }
 }
 
-const addMediaElement = async (file, type, targetSlide) => {
+const addMediaElement = async (file, type, targetSlide, localFile) => {
 	const src = file.file_url
 
 	let elementWidth = 0
@@ -611,10 +620,18 @@ const addMediaElement = async (file, type, targetSlide) => {
 		}
 	} else {
 		elementWidth = 400
-		const { posterURL, aspectRatio } = await getVideoPoster(getAttachmentUrl(src))
-		elementHeight = elementWidth / aspectRatio
+		const videoUrl = getProbeUrl(src, localFile)
+		try {
+			const { posterURL, aspectRatio } = await getVideoPoster(videoUrl)
+			elementHeight = elementWidth / aspectRatio
+			videoPoster = posterURL
+		} catch {
+			// the video is worth keeping without a poster; it plays either way
+			elementHeight = elementWidth * (9 / 16)
+		} finally {
+			revokeProbeUrl(videoUrl)
+		}
 		position = getLeftTopForCenteredElement(elementWidth, elementHeight)
-		videoPoster = posterURL
 	}
 
 	// a slow upload can outlive a slide switch, so the element goes back to the
@@ -676,12 +693,20 @@ const addMediaElement = async (file, type, targetSlide) => {
 	)
 }
 
-const probeReplacementMedia = async (element, fileDoc) => {
+const probeReplacementMedia = async (element, fileDoc, localFile) => {
 	const newUrl = getAttachmentUrl(fileDoc.file_url)
 
 	if (element.type === 'video') {
-		const { posterURL, aspectRatio } = await getVideoPoster(newUrl)
-		return { poster: posterURL, aspect: aspectRatio }
+		const videoUrl = getProbeUrl(fileDoc.file_url, localFile)
+		try {
+			const { posterURL, aspectRatio } = await getVideoPoster(videoUrl)
+			return { poster: posterURL, aspect: aspectRatio }
+		} catch {
+			// the old poster belongs to the video being replaced, so it goes either way
+			return { poster: null }
+		} finally {
+			revokeProbeUrl(videoUrl)
+		}
 	}
 
 	return {
@@ -718,12 +743,12 @@ const pushImageReplaceEdits = (element, { frameHeight, newAspect, poster }, push
 	if ((element.poster ?? undefined) !== newPoster) pushEdit('poster', element.poster, newPoster)
 }
 
-const replaceMediaElement = async (element, fileDoc) => {
+const replaceMediaElement = async (element, fileDoc, localFile) => {
 	// measure while the old media is still rendered, before any await
 	const frameHeight = element.height || getElementDiv(element.id)?.offsetHeight
 
 	const srcChanged = element.src !== fileDoc.file_url
-	const probes = srcChanged ? await probeReplacementMedia(element, fileDoc) : null
+	const probes = srcChanged ? await probeReplacementMedia(element, fileDoc, localFile) : null
 
 	// a slow upload can outlive a slide switch or the element itself, and older
 	// presentations repeat one layout's element ids across slides, so only the

--- a/frontend/src/apps/slides/stores/transition.js
+++ b/frontend/src/apps/slides/stores/transition.js
@@ -51,14 +51,14 @@ const getReferenceElementOnSlide = (slide, currElement) => {
 	}
 }
 
-const getReferenceElement = (element) => {
-	const prevSlide = slides.value[slideIndex.value - 1]
-	const nextSlide = slides.value[slideIndex.value + 1]
+const getReferenceElement = (element, index) => {
+	const prevSlide = slides.value[index - 1]
+	const nextSlide = slides.value[index + 1]
 
 	let el = getReferenceElementOnSlide(prevSlide, element)
 	let onPrev = true
 
-	if (!el && currentSlide.value?.transition === 'Magic Move') {
+	if (!el && slides.value[index]?.transition === 'Magic Move') {
 		el = getReferenceElementOnSlide(nextSlide, element)
 		onPrev = false
 	}
@@ -154,16 +154,15 @@ const isAffectedByMagicMove = (slideIndex) => {
 	return prevSlide?.transition === 'Magic Move' || currentSlide?.transition === 'Magic Move'
 }
 
-const getCommandsToUpdateElementRefId = (element) => {
+const getCommandsToUpdateElementRefId = (element, index = slideIndex.value) => {
 	// TODO: add refId handling for shape elements
 	if (element.type == 'shape') return []
 	if (element.type == 'table') return []
-	const index = slideIndex.value
 	const commands = []
 	const needsUpdate = isAffectedByMagicMove(index)
 	if (!needsUpdate) return commands
 
-	const { el, onPrev } = getReferenceElement(element)
+	const { el, onPrev } = getReferenceElement(element, index)
 	if (el) {
 		const refId = generateUniqueId()
 

--- a/frontend/src/apps/slides/utils/mediaUploads.js
+++ b/frontend/src/apps/slides/utils/mediaUploads.js
@@ -13,7 +13,7 @@ export const isMediaOwner = (owner, user) => !!user && (owner === user || user =
 
 // Images are converted to WebP, so the returned doc replaces the uploaded one.
 // Pass targetElement to swap that element's media instead of adding a new element.
-export const performPostUploadActions = async (fileDoc, fileType, targetElement) => {
+const performPostUploadActions = async (fileDoc, fileType, targetElement) => {
 	if (fileType === 'image') {
 		fileDoc = await getWebPDoc(fileDoc)
 	}

--- a/frontend/src/apps/slides/utils/mediaUploads.js
+++ b/frontend/src/apps/slides/utils/mediaUploads.js
@@ -2,6 +2,7 @@ import { FileUploadHandler, toast, call } from 'frappe-ui'
 
 import { presentationId, presentationDoc } from '../stores/presentation'
 import { addMediaElement, replaceMediaElement } from '../stores/element'
+import { currentSlide } from '../stores/slide'
 
 import { session } from '@/boot/session'
 import { SLIDES_MEDIA_PARAM, MEDIA_PROXY_PATH } from './slidesRequests'
@@ -13,7 +14,7 @@ export const isMediaOwner = (owner, user) => !!user && (owner === user || user =
 
 // Images are converted to WebP, so the returned doc replaces the uploaded one.
 // Pass targetElement to swap that element's media instead of adding a new element.
-const performPostUploadActions = async (fileDoc, fileType, targetElement) => {
+const performPostUploadActions = async (fileDoc, fileType, { targetElement, targetSlide }) => {
 	if (fileType === 'image') {
 		fileDoc = await getWebPDoc(fileDoc)
 	}
@@ -23,11 +24,11 @@ const performPostUploadActions = async (fileDoc, fileType, targetElement) => {
 		return fileDoc
 	}
 
-	await addMediaElement(fileDoc, fileType)
+	await addMediaElement(fileDoc, fileType, targetSlide)
 	return fileDoc
 }
 
-const uploadMedia = (file, fileType, targetElement) => {
+const uploadMedia = (file, fileType, target) => {
 	return new Promise((resolve, reject) => {
 		fileUploadHandler
 			.upload(file, {
@@ -35,7 +36,7 @@ const uploadMedia = (file, fileType, targetElement) => {
 				docname: presentationId.value,
 				private: true,
 			})
-			.then((fileDoc) => performPostUploadActions(fileDoc, fileType, targetElement))
+			.then((fileDoc) => performPostUploadActions(fileDoc, fileType, target))
 			.then(resolve)
 			.catch((error) => {
 				reject(error)
@@ -75,7 +76,9 @@ const handleFile = (file, toastProps, targetElement) => {
 
 	if (targetElement && targetElement.type != fileType) targetElement = null
 
-	toast.promise(uploadMedia(file, fileType, targetElement), toastProps)
+	const target = { targetElement, targetSlide: currentSlide.value }
+
+	toast.promise(uploadMedia(file, fileType, target), toastProps)
 }
 
 const getToastProps = (file, index, length) => {

--- a/frontend/src/apps/slides/utils/mediaUploads.js
+++ b/frontend/src/apps/slides/utils/mediaUploads.js
@@ -14,17 +14,21 @@ export const isMediaOwner = (owner, user) => !!user && (owner === user || user =
 
 // Images are converted to WebP, so the returned doc replaces the uploaded one.
 // Pass targetElement to swap that element's media instead of adding a new element.
-const performPostUploadActions = async (fileDoc, fileType, { targetElement, targetSlide }) => {
+const performPostUploadActions = async (
+	fileDoc,
+	fileType,
+	{ targetElement, targetSlide, localFile },
+) => {
 	if (fileType === 'image') {
 		fileDoc = await getWebPDoc(fileDoc)
 	}
 
 	if (targetElement) {
-		await replaceMediaElement(targetElement, fileDoc, fileType)
+		await replaceMediaElement(targetElement, fileDoc, localFile)
 		return fileDoc
 	}
 
-	await addMediaElement(fileDoc, fileType, targetSlide)
+	await addMediaElement(fileDoc, fileType, targetSlide, localFile)
 	return fileDoc
 }
 
@@ -76,7 +80,7 @@ const handleFile = (file, toastProps, targetElement) => {
 
 	if (targetElement && targetElement.type != fileType) targetElement = null
 
-	const target = { targetElement, targetSlide: currentSlide.value }
+	const target = { targetElement, targetSlide: currentSlide.value, localFile: file }
 
 	toast.promise(uploadMedia(file, fileType, target), toastProps)
 }

--- a/frontend/src/apps/slides/utils/uploadTargetSlide.test.ts
+++ b/frontend/src/apps/slides/utils/uploadTargetSlide.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref, shallowRef } from 'vue'
+
+const currentSlide = shallowRef<any>(null)
+const addMediaElement = vi.fn()
+const replaceMediaElement = vi.fn()
+
+let resolveUpload: (fileDoc: unknown) => void
+
+vi.mock('@/apps/slides/stores/presentation', () => ({
+	presentationId: ref('p1'),
+	presentationDoc: ref({ owner: 'u1' }),
+}))
+vi.mock('@/apps/slides/stores/slide', () => ({ currentSlide }))
+vi.mock('@/apps/slides/stores/element', () => ({ addMediaElement, replaceMediaElement }))
+vi.mock('@/boot/session', () => ({ session: { user: { sessionUser: 'u1' } } }))
+vi.mock('frappe-ui', () => ({
+	call: vi.fn(),
+	toast: { promise: (promise: Promise<unknown>) => promise },
+	FileUploadHandler: class {
+		upload() {
+			return new Promise((resolve) => {
+				resolveUpload = resolve
+			})
+		}
+	},
+}))
+
+const { handleUploadedMedia } = await import('./mediaUploads')
+
+const videoFile = () => new File(['x'], 'clip.mp4', { type: 'video/mp4' })
+
+describe('slow uploads', () => {
+	it('add the media to the slide the upload was started on', async () => {
+		const startedOn = { clientId: 'A', elements: [] }
+		currentSlide.value = startedOn
+
+		handleUploadedMedia([videoFile()])
+
+		currentSlide.value = { clientId: 'B', elements: [] }
+		resolveUpload({ file_url: '/private/files/clip.mp4', name: 'f1' })
+
+		await vi.waitFor(() => expect(addMediaElement).toHaveBeenCalled())
+		expect(addMediaElement.mock.calls[0][2]).toBe(startedOn)
+	})
+})


### PR DESCRIPTION
- Toolbar uploads showed no toast while uploading, so a slow video looked stuck. Toolbar now uses the same path as drag and drop.
- Media landed on whichever slide was on screen when the upload finished. The target slide is captured when the file is picked.
- Video posters came out blank on slow connections. The frame is captured after a seek, not on `loadeddata`, which fires before a frame is decoded.
- A failed poster save attached the previous video's poster, because `createResource` keeps the last response. It uses `call` now and returns null.