### PR TITLE
fix(meet): recover decoded video stalls

### DIFF
--- a/frontend/src/apps/meet/composables/__tests__/useNetworkQuality.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useNetworkQuality.test.ts
@@ -273,6 +273,94 @@ describe("useNetworkQuality", () => {
 		app.unmount();
 	});
 
+	it("requests a keyframe before recreating only a decode-stalled consumer", async () => {
+		vi.useFakeTimers();
+		const recoverConsumer = vi.fn().mockResolvedValue(undefined);
+		const resetReceiveMedia = vi.fn().mockResolvedValue(undefined);
+		const requestConsumerKeyFrame = vi.fn().mockResolvedValue(undefined);
+		let bytesReceived = 1000;
+		const stats = () =>
+			new Map<
+				string,
+				{
+					type: string;
+					kind: string;
+					bytesReceived: number;
+					framesDecoded: number;
+				}
+			>([
+				[
+					"in",
+					{
+						type: "inbound-rtp",
+						kind: "video",
+						bytesReceived: (bytesReceived += 1000),
+						framesDecoded: 10,
+					},
+				],
+			]);
+		const entry = {
+			id: "decode-stalled",
+			participantId: "remote-participant",
+			producerId: "producer-1",
+			kind: "video",
+			isScreen: false,
+			adaptivelyPaused: false,
+			track: { muted: false } as MediaStreamTrack,
+			createdAt: Date.now() - 60_000,
+			consumer: {
+				paused: false,
+				producerPaused: false,
+				getStats: vi.fn().mockImplementation(async () => stats()),
+			},
+		};
+		const sfuManager = ref({
+			sfuClient: { requestConsumerKeyFrame },
+			participantManager: {
+				getParticipant: () => ({ video_enabled: true }),
+			},
+			transportManager: {
+				getTransportStats: () => ({
+					sendTransport: { state: "connected" },
+					recvTransport: { state: "connected" },
+				}),
+				getNetworkStats: vi.fn().mockResolvedValue({
+					rtt: 50,
+					packetLoss: 0,
+					availableOutgoingBitrate: 800_000,
+					timestamp: Date.now(),
+					isValid: true,
+				}),
+			},
+			mediaManager: {
+				consumerManager: {
+					getAllConsumers: () => [entry],
+					getConsumer: (id: string) => (id === entry.id ? entry : undefined),
+				},
+				recoverConsumer,
+			},
+			resetReceiveMedia,
+		});
+		const app = createApp({
+			setup: () => {
+				useNetworkQuality();
+				return () => null;
+			},
+		});
+		app.provide("sfuManager", sfuManager);
+		app.mount(document.createElement("div"));
+
+		await vi.advanceTimersByTimeAsync(18_000);
+		expect(requestConsumerKeyFrame).toHaveBeenCalledOnce();
+		expect(recoverConsumer).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(15_000);
+		expect(recoverConsumer).toHaveBeenCalledOnce();
+		expect(recoverConsumer).toHaveBeenCalledWith(entry);
+		expect(resetReceiveMedia).not.toHaveBeenCalled();
+		app.unmount();
+	});
+
 	it("restarts only a stalled remote video consumer", async () => {
 		vi.useFakeTimers();
 

--- a/frontend/src/apps/meet/composables/useNetworkQuality.ts
+++ b/frontend/src/apps/meet/composables/useNetworkQuality.ts
@@ -1,7 +1,8 @@
 import { inject, onMounted, onUnmounted, type Ref, ref } from "vue";
 import {
 	type ConsumerSample,
-	extractInboundBytesReceived,
+	DecodeStallDetector,
+	extractInboundRtpCounters,
 	StallDetector,
 } from "../utils/media/stallDetector";
 import type { SFUMeetingManager } from "../utils/SFUMeetingManager";
@@ -33,6 +34,8 @@ export function useNetworkQuality(
 	const isPolling = ref(false);
 	let pollInterval: ReturnType<typeof setInterval> | null = null;
 	const stallDetector = new StallDetector();
+	const decodeStallDetector = new DecodeStallDetector();
+	let active = true;
 
 	const pollIntervalMs = 3000;
 	const updateQuality = (stats: NetworkStats) => {
@@ -83,37 +86,47 @@ export function useNetworkQuality(
 			downlinkQuality.value = "good";
 			return;
 		}
+		if (!active || document.hidden) {
+			stallDetector.suspend();
+			decodeStallDetector.suspend();
+			return;
+		}
 
 		const statsResults = await Promise.all(
 			consumers.map(async (entry) => {
-				let bytes: number | null = null;
+				let bytesReceived: number | null = null;
+				let framesDecoded: number | null = null;
 				try {
 					const stats = await entry.consumer.getStats();
-					bytes = extractInboundBytesReceived(stats);
+					const counters = extractInboundRtpCounters(stats, entry.kind);
+					bytesReceived = counters.bytesReceived;
+					framesDecoded = counters.framesDecoded;
 				} catch {
-					bytes = null;
+					bytesReceived = null;
 				}
-				return { entry, bytes };
+				return { entry, bytes: bytesReceived, framesDecoded };
 			}),
 		);
+		if (!active || document.hidden || sfuManagerRef?.value !== sfuManager) return;
+		const isPaused = (entry: (typeof statsResults)[number]["entry"]) => {
+			const participant = sfuManager.participantManager.getParticipant(
+				entry.participantId,
+			);
+			return (
+				entry.consumer.paused ||
+				entry.consumer.producerPaused ||
+				entry.adaptivelyPaused ||
+				(entry.kind === "audio" && participant?.audio_enabled === false) ||
+				(entry.kind === "video" &&
+					!entry.isScreen &&
+					participant?.video_enabled === false)
+			);
+		};
 
 		const samples: ConsumerSample[] = statsResults.map(({ entry, bytes }) => ({
 			id: entry.id,
 			kind: entry.kind,
-			isPaused: () => {
-				const participant = sfuManager.participantManager.getParticipant(
-					entry.participantId,
-				);
-				return (
-					entry.consumer.paused ||
-					entry.consumer.producerPaused ||
-					entry.adaptivelyPaused ||
-					(entry.kind === "audio" && participant?.audio_enabled === false) ||
-					(entry.kind === "video" &&
-						!entry.isScreen &&
-						participant?.video_enabled === false)
-				);
-			},
+			isPaused: () => isPaused(entry),
 			isMuted: () => entry.track?.muted ?? false,
 			getBytesReceived: () => bytes,
 			getCreatedAt: () => entry.createdAt,
@@ -128,9 +141,68 @@ export function useNetworkQuality(
 		}
 
 		const stalledIds = stallDetector.check(samples, allowRecovery);
-		downlinkQuality.value = stallDetector.hasActiveStall()
+		const decodeActions = decodeStallDetector.check(
+			statsResults
+				.filter(({ entry }) => entry.kind === "video")
+				.map(({ entry, bytes, framesDecoded }) => ({
+					id: entry.id,
+					isPaused: () => isPaused(entry),
+					bytesReceived: bytes,
+					framesDecoded,
+				})),
+			allowRecovery,
+		);
+		downlinkQuality.value =
+			stallDetector.hasActiveStall() || decodeStallDetector.hasActiveStall()
 			? "critical"
 			: "good";
+		for (const recovery of decodeActions) {
+			if (!active || document.hidden || sfuManagerRef?.value !== sfuManager) {
+				return;
+			}
+			const result = statsResults.find(
+				({ entry }) => entry.id === recovery.consumerId,
+			);
+			if (!result) continue;
+			const current =
+				consumerManager.getConsumer?.(result.entry.id) ??
+				consumerManager
+					.getAllConsumers()
+					.find((entry) => entry.id === result.entry.id);
+			if (
+				!current ||
+				current.consumer !== result.entry.consumer ||
+				isPaused(current)
+			) {
+				decodeStallDetector.dispose(result.entry.id);
+				continue;
+			}
+			if (recovery.action === "request-keyframe") {
+				try {
+					await sfuManager.sfuClient?.requestConsumerKeyFrame(result.entry.id);
+				} catch (error) {
+					console.warn(
+						"Failed to request a keyframe for decode-stalled consumer",
+						result.entry.id,
+						error,
+					);
+				}
+			} else {
+				decodeStallDetector.dispose(result.entry.id);
+				try {
+					await sfuManager.mediaManager.recoverConsumer(current);
+				} catch (error) {
+					console.warn(
+						"Failed to recreate decode-stalled consumer",
+						result.entry.id,
+						error,
+					);
+				}
+			}
+			if (!active || document.hidden || sfuManagerRef?.value !== sfuManager) {
+				return;
+			}
+		}
 		if (stalledIds.length === 0) return;
 		const stalledSet = new Set(stalledIds);
 		clientTelemetry?.reportMediaStalls(
@@ -205,6 +277,7 @@ export function useNetworkQuality(
 			if (isFailed) {
 				networkQuality.value = "critical";
 				stallDetector.suspend();
+				decodeStallDetector.suspend();
 				return;
 			}
 
@@ -222,16 +295,26 @@ export function useNetworkQuality(
 		}
 	};
 
+	const handleVisibilityChange = () => {
+		stallDetector.suspend();
+		decodeStallDetector.suspend();
+	};
+
 	onMounted(() => {
+		active = true;
+		document.addEventListener("visibilitychange", handleVisibilityChange);
 		pollInterval = setInterval(pollStats, pollIntervalMs);
 	});
 
 	onUnmounted(() => {
+		active = false;
+		document.removeEventListener("visibilitychange", handleVisibilityChange);
 		if (pollInterval) {
 			clearInterval(pollInterval);
 			pollInterval = null;
 		}
 		stallDetector.reset();
+		decodeStallDetector.reset();
 	});
 
 	return {

--- a/frontend/src/apps/meet/utils/media/__tests__/stallDetector.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/stallDetector.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { extractInboundBytesReceived, StallDetector } from "../stallDetector";
+import {
+	DecodeStallDetector,
+	extractInboundBytesReceived,
+	extractInboundRtpCounters,
+	StallDetector,
+} from "../stallDetector";
 
 interface MutableSample {
 	id: string;
@@ -7,6 +12,15 @@ interface MutableSample {
 	muted: boolean;
 	bytes: number | null;
 	createdAt: number;
+}
+
+interface TestRtpStat {
+	type: string;
+	kind?: string;
+	codecId?: string;
+	mimeType?: string;
+	bytesReceived?: number;
+	framesDecoded?: number;
 }
 
 function makeSample(overrides: Partial<MutableSample> = {}): MutableSample {
@@ -317,5 +331,123 @@ describe("extractInboundBytesReceived", () => {
 			["a", { type: "outbound-rtp", bytesReceived: 999 }],
 		]);
 		expect(extractInboundBytesReceived(stats)).toBeNull();
+	});
+});
+
+describe("DecodeStallDetector", () => {
+	it("requests a keyframe before recreating video with RTP but no decode progress", () => {
+		let now = 100_000;
+		const detector = new DecodeStallDetector({ now: () => now });
+		let bytes = 1000;
+		const sample = () => ({
+			id: "video-1",
+			isPaused: () => false,
+			bytesReceived: bytes,
+			framesDecoded: 10,
+		});
+
+		expect(detector.check([sample()])).toEqual([]);
+		for (let i = 0; i < 5; i++) {
+			now += 3000;
+			bytes += 1000;
+		}
+		expect(detector.check([sample()])).toEqual([
+			{ consumerId: "video-1", action: "request-keyframe" },
+		]);
+
+		for (let i = 0; i < 5; i++) {
+			now += 3000;
+			bytes += 1000;
+		}
+		expect(detector.check([sample()])).toEqual([
+			{ consumerId: "video-1", action: "recreate" },
+		]);
+	});
+
+	it("clears decode recovery when frames progress or video is paused", () => {
+		let now = 100_000;
+		const detector = new DecodeStallDetector({ now: () => now });
+		let bytes = 1000;
+		let framesDecoded = 10;
+		let paused = false;
+		const sample = () => ({
+			id: "video-1",
+			isPaused: () => paused,
+			bytesReceived: bytes,
+			framesDecoded,
+		});
+
+		detector.check([sample()]);
+		now += 15_000;
+		bytes += 1000;
+		expect(detector.check([sample()])).toHaveLength(1);
+		framesDecoded += 1;
+		bytes += 1000;
+		expect(detector.check([sample()])).toEqual([]);
+
+		paused = true;
+		now += 30_000;
+		bytes += 1000;
+		expect(detector.check([sample()])).toEqual([]);
+	});
+});
+
+describe("extractInboundRtpCounters", () => {
+	it("extracts primary inbound video counters and ignores RTX", () => {
+		const stats = new Map<string, TestRtpStat>([
+			["rtx-codec", { type: "codec", mimeType: "video/rtx" }],
+			[
+				"rtx",
+				{
+					type: "inbound-rtp",
+					kind: "video",
+					codecId: "rtx-codec",
+					bytesReceived: 999,
+					framesDecoded: 0,
+				},
+			],
+			[
+				"primary",
+				{
+					type: "inbound-rtp",
+					kind: "video",
+					bytesReceived: 12_000,
+					framesDecoded: 42,
+				},
+			],
+		]);
+
+		expect(extractInboundRtpCounters(stats, "video")).toEqual({
+			bytesReceived: 12_000,
+			framesDecoded: 42,
+		});
+	});
+
+	it("aggregates multiple primary inbound video reports", () => {
+		const stats = new Map<string, TestRtpStat>([
+			[
+				"first",
+				{
+					type: "inbound-rtp",
+					kind: "video",
+					bytesReceived: 4000,
+					framesDecoded: 20,
+				},
+			],
+			[
+				"second",
+				{
+					type: "inbound-rtp",
+					kind: "video",
+					bytesReceived: 6000,
+					framesDecoded: 30,
+				},
+			],
+		]);
+
+		expect(extractInboundRtpCounters(stats, "video")).toEqual({
+			bytesReceived: 10_000,
+			framesDecoded: 50,
+		});
 	});
 });

--- a/frontend/src/apps/meet/utils/media/stallDetector.ts
+++ b/frontend/src/apps/meet/utils/media/stallDetector.ts
@@ -234,18 +234,169 @@ export class StallDetector {
 	}
 }
 
+export interface DecodeSample {
+	id: string;
+	isPaused: () => boolean;
+	bytesReceived: number | null;
+	framesDecoded: number | null;
+}
+
+export interface DecodeRecoveryAction {
+	consumerId: string;
+	action: "request-keyframe" | "recreate";
+}
+
+interface DecodeState {
+	lastBytesReceived: number;
+	lastFramesDecoded: number;
+	stallStartedAt: number | null;
+	phase: "monitoring" | "keyframe-requested";
+}
+
+export class DecodeStallDetector {
+	private readonly stallTimeoutMs: number;
+	private readonly now: () => number;
+	private readonly state = new Map<string, DecodeState>();
+	private activeStall = false;
+
+	constructor(
+		options: { stallTimeoutMs?: number; now?: () => number } = {},
+	) {
+		this.stallTimeoutMs = options.stallTimeoutMs ?? DEFAULT_STALL_TIMEOUT_MS;
+		this.now = options.now ?? (() => Date.now());
+	}
+
+	check(
+		samples: DecodeSample[],
+		recoveryEnabled = true,
+	): DecodeRecoveryAction[] {
+		const now = this.now();
+		const activeIds = new Set<string>();
+		const actions: DecodeRecoveryAction[] = [];
+		this.activeStall = false;
+
+		for (const sample of samples) {
+			activeIds.add(sample.id);
+			if (
+				sample.isPaused() ||
+				sample.bytesReceived === null ||
+				sample.framesDecoded === null
+			) {
+				this.state.delete(sample.id);
+				continue;
+			}
+
+			const existing = this.state.get(sample.id);
+			if (!existing) {
+				this.state.set(sample.id, {
+					lastBytesReceived: sample.bytesReceived,
+					lastFramesDecoded: sample.framesDecoded,
+					stallStartedAt: now,
+					phase: "monitoring",
+				});
+				continue;
+			}
+
+			const rtpProgressed = sample.bytesReceived > existing.lastBytesReceived;
+			const decodeProgressed =
+				sample.framesDecoded > existing.lastFramesDecoded;
+			const countersReset =
+				sample.bytesReceived < existing.lastBytesReceived ||
+				sample.framesDecoded < existing.lastFramesDecoded;
+			existing.lastBytesReceived = sample.bytesReceived;
+			existing.lastFramesDecoded = sample.framesDecoded;
+
+			if (countersReset || decodeProgressed || !rtpProgressed) {
+				existing.stallStartedAt = null;
+				existing.phase = "monitoring";
+				continue;
+			}
+
+			if (existing.stallStartedAt === null) {
+				existing.stallStartedAt = now;
+				continue;
+			}
+			if (now - existing.stallStartedAt < this.stallTimeoutMs) continue;
+
+			this.activeStall = true;
+			if (!recoveryEnabled) continue;
+			if (existing.phase === "monitoring") {
+				actions.push({
+					consumerId: sample.id,
+					action: "request-keyframe",
+				});
+				existing.phase = "keyframe-requested";
+				existing.stallStartedAt = now;
+			} else {
+				actions.push({ consumerId: sample.id, action: "recreate" });
+				this.state.delete(sample.id);
+			}
+		}
+
+		for (const id of this.state.keys()) {
+			if (!activeIds.has(id)) this.state.delete(id);
+		}
+		return actions;
+	}
+
+	hasActiveStall(): boolean {
+		return this.activeStall;
+	}
+
+	reset(): void {
+		this.state.clear();
+		this.activeStall = false;
+	}
+
+	suspend(): void {
+		this.reset();
+	}
+
+	dispose(consumerId: string): void {
+		this.state.delete(consumerId);
+	}
+}
+
+interface InboundRtpReport {
+	type?: string;
+	isRemote?: boolean;
+	kind?: string;
+	mediaType?: string;
+	codecId?: string;
+	bytesReceived?: number;
+	framesDecoded?: number;
+	mimeType?: string;
+}
+
+export function extractInboundRtpCounters(
+	stats: {
+		values(): IterableIterator<InboundRtpReport>;
+		get?(id: string): InboundRtpReport | undefined;
+	},
+	kind?: "audio" | "video",
+): { bytesReceived: number | null; framesDecoded: number | null } {
+	let bytesReceived: number | null = null;
+	let framesDecoded: number | null = null;
+	for (const report of stats.values()) {
+		if (report.type !== "inbound-rtp" || report.isRemote) continue;
+		const reportKind = report.kind ?? report.mediaType;
+		if (kind && reportKind && reportKind !== kind) continue;
+		const codec = report.codecId ? stats.get?.(report.codecId) : undefined;
+		if (codec?.mimeType?.toLowerCase().includes("rtx")) continue;
+		if (typeof report.bytesReceived === "number") {
+			bytesReceived = (bytesReceived ?? 0) + report.bytesReceived;
+		}
+		if (typeof report.framesDecoded === "number") {
+			framesDecoded = (framesDecoded ?? 0) + report.framesDecoded;
+		}
+	}
+	return { bytesReceived, framesDecoded };
+}
+
 export function extractInboundBytesReceived(
 	stats: {
 		values(): IterableIterator<{ type: string; bytesReceived?: number }>;
 	},
 ): number | null {
-	for (const report of stats.values()) {
-		if (
-			report.type === "inbound-rtp" &&
-			typeof report.bytesReceived === "number"
-		) {
-			return report.bytesReceived;
-		}
-	}
-	return null;
+	return extractInboundRtpCounters(stats).bytesReceived;
 }


### PR DESCRIPTION
## Summary

- distinguish missing RTP from video decode stalls using inbound frame counters
- request a keyframe before recreating only the affected consumer
- suspend decode recovery for hidden, paused, stale, or failed media lifecycles