### PR TITLE
fix(meet): reconcile expected media

### DIFF
--- a/frontend/src/apps/meet/composables/__tests__/useNetworkQuality.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useNetworkQuality.test.ts
@@ -278,6 +278,7 @@ describe("useNetworkQuality", () => {
 		const recoverConsumer = vi.fn().mockResolvedValue(undefined);
 		const resetReceiveMedia = vi.fn().mockResolvedValue(undefined);
 		const requestConsumerKeyFrame = vi.fn().mockResolvedValue(undefined);
+		const observeRemoteMediaProgress = vi.fn();
 		let bytesReceived = 1000;
 		const stats = () =>
 			new Map<
@@ -316,6 +317,7 @@ describe("useNetworkQuality", () => {
 		};
 		const sfuManager = ref({
 			sfuClient: { requestConsumerKeyFrame },
+			observeRemoteMediaProgress,
 			participantManager: {
 				getParticipant: () => ({ video_enabled: true }),
 			},
@@ -353,6 +355,12 @@ describe("useNetworkQuality", () => {
 		await vi.advanceTimersByTimeAsync(18_000);
 		expect(requestConsumerKeyFrame).toHaveBeenCalledOnce();
 		expect(recoverConsumer).not.toHaveBeenCalled();
+		expect(observeRemoteMediaProgress).toHaveBeenLastCalledWith(
+			"producer-1",
+			"video",
+			true,
+			false,
+		);
 
 		await vi.advanceTimersByTimeAsync(15_000);
 		expect(recoverConsumer).toHaveBeenCalledOnce();

--- a/frontend/src/apps/meet/composables/useNetworkQuality.ts
+++ b/frontend/src/apps/meet/composables/useNetworkQuality.ts
@@ -35,6 +35,10 @@ export function useNetworkQuality(
 	let pollInterval: ReturnType<typeof setInterval> | null = null;
 	const stallDetector = new StallDetector();
 	const decodeStallDetector = new DecodeStallDetector();
+	const expectedMediaCounters = new Map<
+		string,
+		{ bytesReceived: number | null; framesDecoded: number | null }
+	>();
 	let active = true;
 
 	const pollIntervalMs = 3000;
@@ -135,13 +139,19 @@ export function useNetworkQuality(
 			? getClientTelemetry(sfuManager.sfuClient)
 			: null;
 		for (const { entry, bytes, framesDecoded } of statsResults) {
+			const previous = expectedMediaCounters.get(entry.id);
 			sfuManager.observeRemoteMediaProgress?.(
 				entry.producerId,
 				entry.kind === "audio" ? "audio" : "video",
-				bytes !== null && bytes > 0,
+				bytes !== null && bytes > (previous?.bytesReceived ?? 0),
 				entry.kind !== "video" ||
-					(framesDecoded !== null && framesDecoded > 0),
+					(framesDecoded !== null &&
+						framesDecoded > (previous?.framesDecoded ?? 0)),
 			);
+			expectedMediaCounters.set(entry.id, {
+				bytesReceived: bytes,
+				framesDecoded,
+			});
 			if (bytes !== null && bytes > 0 && (entry.kind === "audio" || entry.kind === "video")) {
 				clientTelemetry?.markFirstRemoteMedia(entry.kind);
 			}
@@ -323,6 +333,7 @@ export function useNetworkQuality(
 		}
 		stallDetector.reset();
 		decodeStallDetector.reset();
+		expectedMediaCounters.clear();
 	});
 
 	return {

--- a/frontend/src/apps/meet/composables/useNetworkQuality.ts
+++ b/frontend/src/apps/meet/composables/useNetworkQuality.ts
@@ -134,7 +134,14 @@ export function useNetworkQuality(
 		const clientTelemetry = sfuManager.sfuClient
 			? getClientTelemetry(sfuManager.sfuClient)
 			: null;
-		for (const { entry, bytes } of statsResults) {
+		for (const { entry, bytes, framesDecoded } of statsResults) {
+			sfuManager.observeRemoteMediaProgress?.(
+				entry.producerId,
+				entry.kind === "audio" ? "audio" : "video",
+				bytes !== null && bytes > 0,
+				entry.kind !== "video" ||
+					(framesDecoded !== null && framesDecoded > 0),
+			);
 			if (bytes !== null && bytes > 0 && (entry.kind === "audio" || entry.kind === "video")) {
 				clientTelemetry?.markFirstRemoteMedia(entry.kind);
 			}
@@ -289,6 +296,7 @@ export function useNetworkQuality(
 					getClientTelemetry(sfuClient).reportNetworkQuality(stats);
 				}
 			}
+			await sfuManagerRef.value?.reconcileExpectedMedia?.();
 			await checkConsumerStalls(networkQuality.value === "good");
 		} finally {
 			isPolling.value = false;

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -25,6 +25,8 @@ import {
 	SFURecoveryManager,
 	type RecoveryResult,
 } from "./sfu/SFURecoveryManager";
+import { ExpectedMediaReconciler } from "./sfu/ExpectedMediaReconciler";
+import { getClientTelemetry } from "./telemetry/ClientTelemetry";
 
 const isAbortError = (error: unknown) =>
 	(error as { name?: unknown } | null)?.name === "AbortError";
@@ -111,6 +113,9 @@ export class SFUMeetingManager {
 			transportManager: this.transportManager,
 			mediaManager: this.mediaManager,
 			recoveryManager: this.recoveryManager,
+			expectedMedia: new ExpectedMediaReconciler((event) =>
+				getClientTelemetry(sfuClient).reportMediaRepair(event),
+			),
 		});
 	}
 
@@ -126,6 +131,24 @@ export class SFUMeetingManager {
 		options: ParticipantConnectionStartOptions,
 	): Promise<ParticipantConnectionState> {
 		return this.connectionManager.start(options);
+	}
+
+	reconcileExpectedMedia(): Promise<void> {
+		return this.connectionManager.reconcileExpectedMedia();
+	}
+
+	observeRemoteMediaProgress(
+		producerId: string,
+		media: "audio" | "video",
+		flowing: boolean,
+		decoding: boolean,
+	): void {
+		this.connectionManager.observeRemoteMediaProgress(
+			producerId,
+			media,
+			flowing,
+			decoding,
+		);
 	}
 
 	async publishMedia(

--- a/frontend/src/apps/meet/utils/sfu/ExpectedMediaReconciler.ts
+++ b/frontend/src/apps/meet/utils/sfu/ExpectedMediaReconciler.ts
@@ -1,0 +1,226 @@
+export type ExpectedMediaStage =
+	| "disabled"
+	| "desired"
+	| "captured"
+	| "published"
+	| "subscribed"
+	| "flowing"
+	| "decoding"
+	| "failed";
+
+export type MediaRepairStage =
+	| "capture"
+	| "publication"
+	| "subscription"
+	| "rtp"
+	| "decode";
+
+export type MediaRepairAction =
+	| "reacquire"
+	| "recreate_producer"
+	| "subscribe"
+	| "recreate_consumer"
+	| "request_keyframe";
+
+export interface ExpectedMediaObservation {
+	key: string;
+	direction: "local" | "remote";
+	media: "audio" | "video";
+	source: "camera" | "microphone" | "screen" | "remote";
+	desired: boolean;
+	captured?: boolean;
+	published?: boolean;
+	subscribed?: boolean;
+	flowing?: boolean;
+	decoding?: boolean;
+}
+
+export interface ExpectedMediaEntry extends ExpectedMediaObservation {
+	stage: ExpectedMediaStage;
+	attempts: number;
+	healthySamples: number;
+}
+
+export interface MediaRepairTelemetry {
+	media: "audio" | "video";
+	source: "camera" | "microphone" | "screen" | "remote";
+	stage: MediaRepairStage;
+	action: MediaRepairAction;
+	attempt: number;
+	outcome: "success" | "failure" | "exhausted" | "cancelled";
+	durationMs: number;
+}
+
+interface ActiveRepair {
+	stage: MediaRepairStage;
+	action: MediaRepairAction;
+	attempt: number;
+	startedAt: number;
+}
+
+export class ExpectedMediaReconciler {
+	private readonly entries = new Map<string, ExpectedMediaEntry>();
+	private readonly tails = new Map<string, Promise<unknown>>();
+	private readonly activeRepairs = new Map<string, ActiveRepair>();
+	private readonly exhausted = new Set<string>();
+	private generation = 0;
+
+	constructor(
+		private readonly report: (event: MediaRepairTelemetry) => void = () => {},
+		private readonly now: () => number = () => performance.now(),
+		private readonly maxAttempts = 3,
+	) {}
+
+	observe(observation: ExpectedMediaObservation): ExpectedMediaEntry {
+		const previous = this.entries.get(observation.key);
+		const stage = this.stageFor(observation);
+		const healthy = this.isHealthy(observation);
+		const healthySamples = healthy ? (previous?.healthySamples ?? 0) + 1 : 0;
+		const entry: ExpectedMediaEntry = {
+			...observation,
+			stage,
+			attempts: previous?.attempts ?? 0,
+			healthySamples,
+		};
+
+		if (!observation.desired) {
+			entry.attempts = 0;
+			this.finishRepair(observation.key, previous, "cancelled");
+			this.exhausted.delete(observation.key);
+		} else if (healthySamples >= 2) {
+			entry.attempts = 0;
+			this.finishRepair(observation.key, entry, "success");
+			this.exhausted.delete(observation.key);
+		}
+		this.entries.set(observation.key, entry);
+		return { ...entry };
+	}
+
+	get(key: string): ExpectedMediaEntry | undefined {
+		const entry = this.entries.get(key);
+		return entry ? { ...entry } : undefined;
+	}
+
+	snapshot(): ExpectedMediaEntry[] {
+		return Array.from(this.entries.values(), (entry) => ({ ...entry }));
+	}
+
+	repair(
+		key: string,
+		stage: MediaRepairStage,
+		action: MediaRepairAction,
+		operation: () => Promise<void>,
+	): Promise<boolean> {
+		const entry = this.entries.get(key);
+		if (!entry?.desired) return Promise.resolve(false);
+		if (entry.attempts >= this.maxAttempts) {
+			if (!this.exhausted.has(key)) {
+				this.exhausted.add(key);
+				this.reportRepair(entry, stage, action, entry.attempts, "exhausted", 0);
+			}
+			entry.stage = "failed";
+			return Promise.resolve(false);
+		}
+
+		const pending = this.tails.get(key);
+		if (pending) return pending.then(() => false);
+		this.finishRepair(key, entry, "failure");
+		entry.attempts += 1;
+		const repair: ActiveRepair = {
+			stage,
+			action,
+			attempt: entry.attempts,
+			startedAt: this.now(),
+		};
+		this.activeRepairs.set(key, repair);
+		const generation = this.generation;
+		const promise = Promise.resolve()
+			.then(async () => {
+				if (generation !== this.generation) throw this.cancelled();
+				await operation();
+				if (generation !== this.generation) throw this.cancelled();
+				return true;
+			})
+			.catch((error) => {
+				const outcome =
+					(error as { name?: unknown } | null)?.name === "AbortError"
+						? "cancelled"
+						: "failure";
+				this.finishRepair(key, entry, outcome);
+				throw error;
+			})
+			.finally(() => {
+				if (this.tails.get(key) === promise) this.tails.delete(key);
+			});
+		this.tails.set(key, promise);
+		return promise;
+	}
+
+	reset(): void {
+		this.generation += 1;
+		for (const [key, entry] of this.entries) {
+			this.finishRepair(key, entry, "cancelled");
+		}
+		this.entries.clear();
+		this.tails.clear();
+		this.exhausted.clear();
+	}
+
+	private stageFor(observation: ExpectedMediaObservation): ExpectedMediaStage {
+		if (!observation.desired) return "disabled";
+		if (observation.decoding) return "decoding";
+		if (observation.flowing) return "flowing";
+		if (observation.subscribed) return "subscribed";
+		if (observation.published) return "published";
+		if (observation.captured) return "captured";
+		return "desired";
+	}
+
+	private isHealthy(observation: ExpectedMediaObservation): boolean {
+		if (observation.direction === "local") return observation.flowing === true;
+		return observation.media === "video"
+			? observation.decoding === true
+			: observation.flowing === true;
+	}
+
+	private finishRepair(
+		key: string,
+		entry: ExpectedMediaObservation | undefined,
+		outcome: "success" | "failure" | "cancelled",
+	): void {
+		const repair = this.activeRepairs.get(key);
+		if (!repair || !entry) return;
+		this.activeRepairs.delete(key);
+		this.reportRepair(
+			entry,
+			repair.stage,
+			repair.action,
+			repair.attempt,
+			outcome,
+			this.now() - repair.startedAt,
+		);
+	}
+
+	private reportRepair(
+		entry: ExpectedMediaObservation,
+		stage: MediaRepairStage,
+		action: MediaRepairAction,
+		attempt: number,
+		outcome: MediaRepairTelemetry["outcome"],
+		durationMs: number,
+	): void {
+		this.report({
+			media: entry.media,
+			source: entry.source,
+			stage,
+			action,
+			attempt,
+			outcome,
+			durationMs: Math.max(0, Math.min(300_000, Math.round(durationMs))),
+		});
+	}
+
+	private cancelled(): DOMException {
+		return new DOMException("Expected media lifecycle ended", "AbortError");
+	}
+}

--- a/frontend/src/apps/meet/utils/sfu/MeetingSnapshotReconciler.ts
+++ b/frontend/src/apps/meet/utils/sfu/MeetingSnapshotReconciler.ts
@@ -6,6 +6,7 @@ export interface ReconciledProducer {
   producerId: string;
   participantId: string;
   isScreen: boolean;
+  kind?: "audio" | "video";
 }
 
 export type MeetingReconciliationEvent<

--- a/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
+++ b/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
@@ -23,6 +23,7 @@ import type { User } from "../../composables/useCurrentUser";
 import type { SFUMediaManager } from "./SFUMediaManager";
 import type { MediaScreenShareEvent } from "./SFUMediaManager";
 import type { RecoveryResult, SFURecoveryManager } from "./SFURecoveryManager";
+import { ExpectedMediaReconciler } from "./ExpectedMediaReconciler";
 import {
 	applyMeetingReconciliationEvent,
 	createMeetingReconciliationState,
@@ -35,6 +36,7 @@ interface SFUProducerEvent {
 	producerId: string;
 	participantId: string;
 	isScreen?: boolean;
+	kind?: "audio" | "video";
 }
 
 type ReconciledParticipant = ParticipantData & { participantId: string };
@@ -69,6 +71,8 @@ function normalizeProducerEvent(value: unknown): SFUProducerEvent | null {
 		producerId: value.producerId,
 		participantId: value.participantId,
 		isScreen: value.isScreen === true,
+		kind:
+			value.kind === "audio" || value.kind === "video" ? value.kind : undefined,
 	};
 }
 
@@ -166,6 +170,7 @@ interface ParticipantConnectionOptions {
 	transportManager: TransportManager;
 	mediaManager: SFUMediaManager;
 	recoveryManager: SFURecoveryManager;
+	expectedMedia?: ExpectedMediaReconciler;
 }
 
 export class ParticipantConnection {
@@ -175,6 +180,7 @@ export class ParticipantConnection {
 	transportManager: TransportManager;
 	mediaManager: SFUMediaManager;
 	recoveryManager: SFURecoveryManager;
+	readonly expectedMedia: ExpectedMediaReconciler;
 
 	meetingId: string | null = null;
 	currentUser: { value: User | null } = { value: null };
@@ -208,6 +214,7 @@ export class ParticipantConnection {
 		this.transportManager = options.transportManager;
 		this.mediaManager = options.mediaManager;
 		this.recoveryManager = options.recoveryManager;
+		this.expectedMedia = options.expectedMedia ?? new ExpectedMediaReconciler();
 	}
 
 	get state(): ParticipantConnectionState {
@@ -522,6 +529,10 @@ export class ParticipantConnection {
 						producerId: producer.id,
 						participantId: producer.participantId,
 						isScreen: producer.isScreen === true,
+						kind:
+							producer.kind === "audio" || producer.kind === "video"
+								? producer.kind
+								: undefined,
 					})),
 				},
 				this.bufferedReconciliationEvents.splice(0),
@@ -789,6 +800,131 @@ export class ParticipantConnection {
 		);
 	}
 
+	async reconcileExpectedMedia(): Promise<void> {
+		await this.reconcileExpectedLocalMedia();
+		for (const producer of this.reconciliation.producers.values()) {
+			const consumer = this.mediaManager.consumerManager
+				.getConsumersByParticipant(producer.participantId)
+				.find(
+					(entry) =>
+						!entry.consumer.closed &&
+						(entry.producerId === producer.producerId ||
+							entry.consumer.producerId === producer.producerId),
+				);
+			const media = consumer?.kind ?? producer.kind ?? (producer.isScreen ? "video" : null);
+			if (media !== "audio" && media !== "video") continue;
+			const key = `remote:${producer.producerId}`;
+			this.expectedMedia.observe({
+				key,
+				direction: "remote",
+				media,
+				source: "remote",
+				desired: true,
+				subscribed: Boolean(consumer),
+			});
+			if (!consumer) {
+				void this.expectedMedia
+					.repair(key, "subscription", "subscribe", () =>
+						this.subscribeToReconciledProducer(producer),
+					)
+					.catch((error) =>
+						console.warn("Expected media subscription repair failed:", error),
+					);
+			}
+		}
+	}
+
+	private async reconcileExpectedLocalMedia(): Promise<void> {
+		const stream = this.mediaManager.mediaHandler.localStream;
+		const local = [
+			{
+				key: "local:microphone",
+				media: "audio" as const,
+				source: "microphone" as const,
+				track: stream?.getAudioTracks().find((track) => track.readyState === "live"),
+				producer: this.mediaManager.mediaHandler.audioProducer,
+			},
+			{
+				key: "local:camera",
+				media: "video" as const,
+				source: "camera" as const,
+				track: stream?.getVideoTracks().find((track) => track.readyState === "live"),
+				producer: this.mediaManager.mediaHandler.videoProducer,
+			},
+			{
+				key: "local:screen",
+				media: "video" as const,
+				source: "screen" as const,
+				track: this.mediaManager.mediaHandler.screenProducer?.track,
+				producer: this.mediaManager.mediaHandler.screenProducer,
+			},
+		];
+
+		for (const item of local) {
+			let flowing = false;
+			if (item.producer && !item.producer.closed) {
+				try {
+					const stats = await item.producer.getStats();
+					for (const report of stats.values()) {
+						if (
+							report.type === "outbound-rtp" &&
+							typeof report.bytesSent === "number" &&
+							report.bytesSent > 0
+						) {
+							flowing = true;
+							break;
+						}
+					}
+				} catch {
+					// A later safety-net pass will retry the observation.
+				}
+			}
+			const desired = item.track?.readyState === "live";
+			this.expectedMedia.observe({
+				key: item.key,
+				direction: "local",
+				media: item.media,
+				source: item.source,
+				desired,
+				captured: desired,
+				published: Boolean(item.producer && !item.producer.closed),
+				flowing,
+			});
+			if (desired && !item.producer && item.source !== "screen" && stream) {
+				void this.expectedMedia
+					.repair(item.key, "publication", "recreate_producer", async () => {
+						await this.mediaManager.publishMedia(stream, {
+							publishAudio: item.media === "audio",
+							publishVideo: item.media === "video",
+						});
+					})
+					.catch((error) =>
+						console.warn("Expected local publication repair failed:", error),
+					);
+			}
+		}
+	}
+
+	observeRemoteMediaProgress(
+		producerId: string,
+		media: "audio" | "video",
+		flowing: boolean,
+		decoding: boolean,
+	): void {
+		const producer = this.reconciliation.producers.get(producerId);
+		if (!producer) return;
+		this.expectedMedia.observe({
+			key: `remote:${producerId}`,
+			direction: "remote",
+			media,
+			source: "remote",
+			desired: true,
+			subscribed: this.hasConsumerForProducer(producer.participantId, producerId),
+			flowing,
+			decoding,
+		});
+	}
+
 	private async subscribeToReconciledProducer(
 		event: SFUProducerEvent,
 		signal: AbortSignal = this.lifecycleAbortController.signal,
@@ -808,7 +944,11 @@ export class ParticipantConnection {
 			this.throwIfAborted(signal);
 			if (this.reconciliation.producers.get(event.producerId) !== event) return;
 			await this.awaitAbortable(
-				this.mediaManager.subscribeToRemoteProducer(event),
+				this.mediaManager.subscribeToRemoteProducer({
+					producerId: event.producerId,
+					participantId: event.participantId,
+					isScreen: event.isScreen,
+				}),
 				signal,
 			);
 			this.throwIfAborted(signal);
@@ -821,6 +961,8 @@ export class ParticipantConnection {
 	}
 
 	private removeProducerConsumers(event: SFUProducerEvent): void {
+		const existing = this.expectedMedia.get(`remote:${event.producerId}`);
+		if (existing) this.expectedMedia.observe({ ...existing, desired: false });
 		this.mediaManager.cancelProducerSubscription?.(
 			event.participantId,
 			event.producerId,
@@ -1299,6 +1441,7 @@ export class ParticipantConnection {
 		this.e2eeReadyForLifecycle = false;
 		try {
 			this.lifecycleGeneration++;
+			this.expectedMedia.reset();
 			this.recoveryManager.reset();
 			let disconnectError: unknown = null;
 			try {
@@ -1329,6 +1472,7 @@ export class ParticipantConnection {
 	reset(): void {
 		this.lifecycleAbortController.abort();
 		this.lifecycleGeneration++;
+		this.expectedMedia.reset();
 		this.meetingId = null;
 		this.currentUser = { value: null };
 		this.eventHandlers = {};

--- a/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
+++ b/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
@@ -814,14 +814,17 @@ export class ParticipantConnection {
 			const media = consumer?.kind ?? producer.kind ?? (producer.isScreen ? "video" : null);
 			if (media !== "audio" && media !== "video") continue;
 			const key = `remote:${producer.producerId}`;
-			this.expectedMedia.observe({
-				key,
-				direction: "remote",
-				media,
-				source: "remote",
-				desired: true,
-				subscribed: Boolean(consumer),
-			});
+			const existing = this.expectedMedia.get(key);
+			if (!existing || existing.subscribed !== Boolean(consumer)) {
+				this.expectedMedia.observe({
+					key,
+					direction: "remote",
+					media,
+					source: "remote",
+					desired: true,
+					subscribed: Boolean(consumer),
+				});
+			}
 			if (!consumer) {
 				void this.expectedMedia
 					.repair(key, "subscription", "subscribe", () =>
@@ -890,14 +893,16 @@ export class ParticipantConnection {
 				published: Boolean(item.producer && !item.producer.closed),
 				flowing,
 			});
-			if (desired && !item.producer && item.source !== "screen" && stream) {
+			if (
+				desired &&
+				(!item.producer || item.producer.closed) &&
+				item.source !== "screen" &&
+				stream
+			) {
 				void this.expectedMedia
-					.repair(item.key, "publication", "recreate_producer", async () => {
-						await this.mediaManager.publishMedia(stream, {
-							publishAudio: item.media === "audio",
-							publishVideo: item.media === "video",
-						});
-					})
+					.repair(item.key, "publication", "recreate_producer", () =>
+						this.mediaManager.repairLocalPublication(item.media, stream),
+					)
 					.catch((error) =>
 						console.warn("Expected local publication repair failed:", error),
 					);

--- a/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
@@ -185,6 +185,26 @@ export class SFUMediaManager {
 		);
 	}
 
+	repairLocalPublication(
+		kind: "audio" | "video",
+		localStream: MediaStream,
+	): Promise<void> {
+		return this.serializeSendMediaMutation(async () => {
+			const producer =
+				kind === "audio"
+					? this.mediaHandler.audioProducer
+					: this.mediaHandler.videoProducer;
+			if (producer && !producer.closed) return;
+			this.mediaHandler.setProducers(
+				kind === "audio" ? { audioProducer: null } : { videoProducer: null },
+			);
+			await this.publishMediaNow(localStream, {
+				publishAudio: kind === "audio",
+				publishVideo: kind === "video",
+			});
+		});
+	}
+
 	async publishInitialMedia(
 		localStream: MediaStream,
 		options: { publishVideo: boolean; publishAudio: boolean },

--- a/frontend/src/apps/meet/utils/sfu/__tests__/ExpectedMediaReconciler.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/ExpectedMediaReconciler.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { ExpectedMediaReconciler } from "../ExpectedMediaReconciler";
+
+const remoteVideo = {
+	key: "remote:producer-1",
+	direction: "remote" as const,
+	media: "video" as const,
+	source: "remote" as const,
+	desired: true,
+};
+
+describe("ExpectedMediaReconciler", () => {
+	it("tracks explicit lifecycle stages and verifies health twice", async () => {
+		const report = vi.fn();
+		let now = 0;
+		const reconciler = new ExpectedMediaReconciler(report, () => now);
+		reconciler.observe(remoteVideo);
+		await reconciler.repair(
+			remoteVideo.key,
+			"subscription",
+			"subscribe",
+			vi.fn().mockResolvedValue(undefined),
+		);
+
+		expect(
+			reconciler.observe({ ...remoteVideo, subscribed: true }).stage,
+		).toBe("subscribed");
+		now = 500;
+		reconciler.observe({
+			...remoteVideo,
+			subscribed: true,
+			flowing: true,
+			decoding: true,
+		});
+		expect(report).not.toHaveBeenCalled();
+		reconciler.observe({
+			...remoteVideo,
+			subscribed: true,
+			flowing: true,
+			decoding: true,
+		});
+
+		expect(reconciler.get(remoteVideo.key)).toMatchObject({
+			stage: "decoding",
+			attempts: 0,
+		});
+		expect(report).toHaveBeenCalledWith(
+			expect.objectContaining({
+				stage: "subscription",
+				action: "subscribe",
+				outcome: "success",
+				durationMs: 500,
+			}),
+		);
+	});
+
+	it("serializes and bounds repairs per expected stream", async () => {
+		const report = vi.fn();
+		const reconciler = new ExpectedMediaReconciler(report);
+		reconciler.observe(remoteVideo);
+		const operation = vi.fn().mockResolvedValue(undefined);
+
+		for (let attempt = 0; attempt < 3; attempt++) {
+			await Promise.all([
+				reconciler.repair(
+					remoteVideo.key,
+					"subscription",
+					"subscribe",
+					operation,
+				),
+				reconciler.repair(
+					remoteVideo.key,
+					"subscription",
+					"subscribe",
+					operation,
+				),
+			]);
+		}
+		await reconciler.repair(
+			remoteVideo.key,
+			"subscription",
+			"subscribe",
+			operation,
+		);
+
+		expect(operation).toHaveBeenCalledTimes(3);
+		expect(report).toHaveBeenCalledWith(
+			expect.objectContaining({ outcome: "exhausted", attempt: 3 }),
+		);
+	});
+});

--- a/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnectionEvents.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnectionEvents.test.ts
@@ -21,6 +21,7 @@ function createManager({ e2eeRequired = false } = {}) {
 		cancelPendingSubscriptions: vi.fn(),
 		cleanup: vi.fn(),
 		rebuildSendSide: vi.fn().mockResolvedValue({}),
+		repairLocalPublication: vi.fn().mockResolvedValue(undefined),
 		subscribeToRemoteProducer: vi.fn().mockResolvedValue(undefined),
 		processedConsumers: new Set<string>(),
 		isScreenShareActive: false,
@@ -88,6 +89,58 @@ describe("ParticipantConnection", () => {
 			producerId: "producer-1",
 			isScreen: false,
 		});
+	});
+
+	it("preserves remote progress while the subscription remains present", async () => {
+		const { handlers, manager, mediaManager } = createManager();
+		await manager.connect("token");
+		await handlers.get("producer_created")?.({
+			participantId: "remote-1",
+			producerId: "producer-1",
+			kind: "video",
+		});
+		mediaManager.consumerManager.getConsumersByParticipant.mockReturnValue([
+			{
+				producerId: "producer-1",
+				kind: "video",
+				consumer: { closed: false, producerId: "producer-1" },
+			},
+		]);
+		manager.observeRemoteMediaProgress("producer-1", "video", true, true);
+
+		await manager.reconcileExpectedMedia();
+
+		expect(manager.expectedMedia.get("remote:producer-1")).toMatchObject({
+			healthySamples: 1,
+			flowing: true,
+			decoding: true,
+		});
+	});
+
+	it("repairs a closed local producer when its track remains live", async () => {
+		const { manager, mediaManager } = createManager();
+		const localStream = {
+			getAudioTracks: () => [{ readyState: "live" }],
+			getVideoTracks: () => [],
+		};
+		mediaManager.mediaHandler = {
+			localStream,
+			audioProducer: {
+				closed: true,
+				getStats: vi.fn().mockResolvedValue(new Map()),
+			},
+			videoProducer: null,
+			screenProducer: null,
+		} as never;
+
+		await manager.reconcileExpectedMedia();
+
+		await vi.waitFor(() =>
+			expect(mediaManager.repairLocalPublication).toHaveBeenCalledWith(
+				"audio",
+				localStream,
+			),
+		);
 	});
 
 	it("passes the screen-share flag for screen video producers", async () => {

--- a/frontend/src/apps/meet/utils/telemetry/ClientTelemetry.ts
+++ b/frontend/src/apps/meet/utils/telemetry/ClientTelemetry.ts
@@ -1,4 +1,5 @@
 import type { MeetingRecoveryState } from "../../composables/useParticipantConnectionState";
+import type { MediaRepairTelemetry } from "../sfu/ExpectedMediaReconciler";
 
 export type ClientTelemetryEvent =
 	| {
@@ -25,7 +26,8 @@ export type ClientTelemetryEvent =
 			rttMs: number;
 			packetLossPercent: number;
 			availableOutgoingBitrate: number;
-	  };
+	  }
+	| ({ event: "media_repair" } & MediaRepairTelemetry);
 
 type TelemetryClient = {
 	sendClientTelemetry(event: ClientTelemetryEvent): void;
@@ -78,6 +80,10 @@ export class ClientTelemetry {
 		event: "recovery_exhausted";
 	}>, "event">): void {
 		this.send({ event: "recovery_exhausted", ...event });
+	}
+
+	reportMediaRepair(event: MediaRepairTelemetry): void {
+		this.send({ event: "media_repair", ...event });
 	}
 
 	reportNetworkQuality(stats: {

--- a/frontend/src/apps/meet/utils/telemetry/__tests__/ClientTelemetry.test.ts
+++ b/frontend/src/apps/meet/utils/telemetry/__tests__/ClientTelemetry.test.ts
@@ -92,6 +92,32 @@ describe("ClientTelemetry", () => {
 		});
 	});
 
+	it("reports expected-media repair outcomes", () => {
+		const sendClientTelemetry = vi.fn();
+		const telemetry = new ClientTelemetry({ sendClientTelemetry }, true);
+
+		telemetry.reportMediaRepair({
+			media: "video",
+			source: "remote",
+			stage: "subscription",
+			action: "subscribe",
+			attempt: 1,
+			outcome: "success",
+			durationMs: 500,
+		});
+
+		expect(sendClientTelemetry).toHaveBeenCalledWith({
+			event: "media_repair",
+			media: "video",
+			source: "remote",
+			stage: "subscription",
+			action: "subscribe",
+			attempt: 1,
+			outcome: "success",
+			durationMs: 500,
+		});
+	});
+
 	it("throttles and bounds sampled network quality", () => {
 		const sendClientTelemetry = vi.fn();
 		let now = 0;

--- a/suite/meet/sfu-server/src/server/handlers/ClientTelemetryHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/ClientTelemetryHandlers.ts
@@ -69,6 +69,21 @@ export function registerClientTelemetryHandlers(deps: HandlerDeps) {
 						event.availableOutgoingBitrate,
 					);
 					break;
+				case 'media_repair': {
+					const labels = {
+						media: event.media,
+						source: event.source,
+						stage: event.stage,
+						action: event.action,
+						outcome: event.outcome,
+					};
+					deps.telemetry.clientMediaRepairs.inc(labels);
+					deps.telemetry.clientMediaRepairDuration.observe(
+						labels,
+						event.durationMs / 1000,
+					);
+					break;
+				}
 			}
 		});
 	};
@@ -150,6 +165,41 @@ export function parseClientTelemetry(
 					packetLossPercent: data.packetLossPercent,
 					availableOutgoingBitrate: data.availableOutgoingBitrate,
 				}
+			: null;
+	}
+	if (data.event === 'media_repair') {
+		return hasOnlyKeys(data, [
+			'event',
+			'media',
+			'source',
+			'stage',
+			'action',
+			'attempt',
+			'outcome',
+			'durationMs',
+		]) &&
+			isMedia(data.media) &&
+			['camera', 'microphone', 'screen', 'remote'].includes(
+				String(data.source),
+			) &&
+			['capture', 'publication', 'subscription', 'rtp', 'decode'].includes(
+				String(data.stage),
+			) &&
+			[
+				'reacquire',
+				'recreate_producer',
+				'subscribe',
+				'recreate_consumer',
+				'request_keyframe',
+			].includes(String(data.action)) &&
+			Number.isInteger(data.attempt) &&
+			(data.attempt as number) >= 1 &&
+			(data.attempt as number) <= 3 &&
+			['success', 'failure', 'exhausted', 'cancelled'].includes(
+				String(data.outcome),
+			) &&
+			isDuration(data.durationMs)
+			? (data as ClientTelemetryEvent)
 			: null;
 	}
 	return null;

--- a/suite/meet/sfu-server/src/server/handlers/__tests__/ClientTelemetryHandlers.test.ts
+++ b/suite/meet/sfu-server/src/server/handlers/__tests__/ClientTelemetryHandlers.test.ts
@@ -71,4 +71,31 @@ describe('parseClientTelemetry', () => {
 			}),
 		).toBeNull();
 	});
+
+	it('accepts bounded expected-media repair outcomes', () => {
+		expect(
+			parseClientTelemetry({
+				event: 'media_repair',
+				media: 'video',
+				source: 'remote',
+				stage: 'subscription',
+				action: 'subscribe',
+				attempt: 1,
+				outcome: 'success',
+				durationMs: 500,
+			}),
+		).not.toBeNull();
+		expect(
+			parseClientTelemetry({
+				event: 'media_repair',
+				media: 'video',
+				source: 'remote',
+				stage: 'subscription',
+				action: 'subscribe',
+				attempt: 4,
+				outcome: 'success',
+				durationMs: 500,
+			}),
+		).toBeNull();
+	});
 });

--- a/suite/meet/sfu-server/src/telemetry/Telemetry.ts
+++ b/suite/meet/sfu-server/src/telemetry/Telemetry.ts
@@ -137,6 +137,19 @@ export class Telemetry {
 		labelNames: ['subsystem', 'direction', 'reason'] as const,
 		registers: [this.registry],
 	});
+	readonly clientMediaRepairs = new Counter({
+		name: 'meet_sfu_client_media_repairs_total',
+		help: 'Sampled browser expected-media repair outcomes',
+		labelNames: ['media', 'source', 'stage', 'action', 'outcome'] as const,
+		registers: [this.registry],
+	});
+	readonly clientMediaRepairDuration = new Histogram({
+		name: 'meet_sfu_client_media_repair_duration_seconds',
+		help: 'Sampled browser expected-media repair duration',
+		labelNames: ['media', 'source', 'stage', 'action', 'outcome'] as const,
+		buckets: [0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30, 60],
+		registers: [this.registry],
+	});
 	readonly clientRtt = new Histogram({
 		name: 'meet_sfu_client_rtt_seconds',
 		help: 'Sampled browser WebRTC round-trip time',

--- a/suite/meet/sfu-server/src/types/index.ts
+++ b/suite/meet/sfu-server/src/types/index.ts
@@ -312,6 +312,21 @@ export type ClientTelemetryEvent =
 			rttMs: number;
 			packetLossPercent: number;
 			availableOutgoingBitrate: number;
+	  }
+	| {
+			event: 'media_repair';
+			media: 'audio' | 'video';
+			source: 'camera' | 'microphone' | 'screen' | 'remote';
+			stage: 'capture' | 'publication' | 'subscription' | 'rtp' | 'decode';
+			action:
+				| 'reacquire'
+				| 'recreate_producer'
+				| 'subscribe'
+				| 'recreate_consumer'
+				| 'request_keyframe';
+			attempt: number;
+			outcome: 'success' | 'failure' | 'exhausted' | 'cancelled';
+			durationMs: number;
 	  };
 
 export interface SocketData {

--- a/suite/meet/type-policy/allowlist.json
+++ b/suite/meet/type-policy/allowlist.json
@@ -35,7 +35,7 @@
     },
     {
       "path": "suite/meet/sfu-server/src/server/handlers/ClientTelemetryHandlers.ts",
-      "line": 158,
+      "line": 208,
       "column": 45,
       "rule": "MTP001",
       "lineText": "function isRecord(value: unknown): value is Record<string, unknown> {",
@@ -43,7 +43,7 @@
     },
     {
       "path": "suite/meet/sfu-server/src/server/handlers/ClientTelemetryHandlers.ts",
-      "line": 162,
+      "line": 212,
       "column": 29,
       "rule": "MTP001",
       "lineText": "function hasOnlyKeys(value: Record<string, unknown>, keys: string[]): boolean {",


### PR DESCRIPTION
## Summary

- track explicit expected-media lifecycle state for local and remote streams
- periodically reconcile missing publications and subscriptions with bounded serialized repairs
- record repair stage, action, duration, attempt, and outcome telemetry