### PR TITLE
fix(meet): recover browser media lifecycle

### DIFF
--- a/frontend/src/apps/meet/composables/__tests__/useNetworkQuality.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useNetworkQuality.test.ts
@@ -6,6 +6,7 @@ import { useNetworkQuality } from "../useNetworkQuality";
 describe("useNetworkQuality", () => {
 	afterEach(() => {
 		vi.useRealTimers();
+		vi.restoreAllMocks();
 	});
 
 	const mountWithStats = (stats: unknown, transportState = "connected") => {
@@ -530,6 +531,144 @@ describe("useNetworkQuality", () => {
 		expect(requestConsumerKeyFrame).toHaveBeenCalledTimes(1);
 		expect(resetReceiveSide).not.toHaveBeenCalled();
 
+		app.unmount();
+	});
+
+	it("suspends reconciliation while hidden or offline and recovers on resume", async () => {
+		vi.useFakeTimers();
+		let hidden = false;
+		let online = true;
+		vi.spyOn(document, "hidden", "get").mockImplementation(() => hidden);
+		vi.spyOn(navigator, "onLine", "get").mockImplementation(() => online);
+		const getNetworkStats = vi.fn().mockResolvedValue({
+			rtt: 50,
+			packetLoss: 0,
+			availableOutgoingBitrate: 800_000,
+			isValid: true,
+		});
+		const reconcileExpectedMedia = vi.fn().mockResolvedValue(undefined);
+		const recoverBrowserLifecycle = vi.fn().mockResolvedValue(undefined);
+		const sfuManager = ref({
+			transportManager: {
+				getTransportStats: () => ({
+					sendTransport: { state: "connected" },
+					recvTransport: { state: "connected" },
+				}),
+				getNetworkStats,
+			},
+			mediaManager: {
+				consumerManager: { getAllConsumers: () => [] },
+			},
+			reconcileExpectedMedia,
+			recoverBrowserLifecycle,
+		});
+		const app = createApp({
+			setup: () => (useNetworkQuality(), () => null),
+		});
+		app.provide("sfuManager", sfuManager);
+		app.mount(document.createElement("div"));
+
+		hidden = true;
+		document.dispatchEvent(new Event("visibilitychange"));
+		await vi.advanceTimersByTimeAsync(6000);
+		expect(getNetworkStats).not.toHaveBeenCalled();
+		expect(reconcileExpectedMedia).not.toHaveBeenCalled();
+
+		hidden = false;
+		document.dispatchEvent(new Event("visibilitychange"));
+		await vi.waitFor(() => expect(recoverBrowserLifecycle).toHaveBeenCalledOnce());
+		online = false;
+		window.dispatchEvent(new Event("offline"));
+		await vi.advanceTimersByTimeAsync(6000);
+		expect(getNetworkStats).not.toHaveBeenCalled();
+
+		online = true;
+		window.dispatchEvent(new Event("online"));
+		await vi.waitFor(() =>
+			expect(recoverBrowserLifecycle).toHaveBeenCalledTimes(2),
+		);
+		app.unmount();
+	});
+
+	it("uses fresh media progress baselines after visibility resumes", async () => {
+		vi.useFakeTimers();
+		let hidden = false;
+		vi.spyOn(document, "hidden", "get").mockImplementation(() => hidden);
+		vi.spyOn(navigator, "onLine", "get").mockReturnValue(true);
+		const observeRemoteMediaProgress = vi.fn();
+		const stats = new Map([
+			[
+				"inbound",
+				{
+					type: "inbound-rtp",
+					kind: "video",
+					bytesReceived: 1000,
+					framesDecoded: 10,
+				},
+			],
+		]);
+		const entry = {
+			id: "consumer-1",
+			producerId: "producer-1",
+			participantId: "remote-1",
+			kind: "video",
+			isScreen: false,
+			adaptivelyPaused: false,
+			track: { muted: false },
+			createdAt: Date.now(),
+			consumer: {
+				paused: false,
+				producerPaused: false,
+				getStats: vi.fn().mockResolvedValue(stats),
+			},
+		};
+		const sfuManager = ref({
+			participantManager: { getParticipant: () => ({ video_enabled: true }) },
+			transportManager: {
+				getTransportStats: () => ({
+					sendTransport: { state: "connected" },
+					recvTransport: { state: "connected" },
+				}),
+			},
+			mediaManager: {
+				consumerManager: { getAllConsumers: () => [entry] },
+			},
+			observeRemoteMediaProgress,
+			reconcileExpectedMedia: vi.fn().mockResolvedValue(undefined),
+			recoverBrowserLifecycle: vi.fn().mockResolvedValue(undefined),
+		});
+		const app = createApp({
+			setup: () => (useNetworkQuality(), () => null),
+		});
+		app.provide("sfuManager", sfuManager);
+		app.mount(document.createElement("div"));
+
+		await vi.advanceTimersByTimeAsync(3000);
+		expect(observeRemoteMediaProgress).toHaveBeenLastCalledWith(
+			"producer-1",
+			"video",
+			true,
+			true,
+		);
+		await vi.advanceTimersByTimeAsync(3000);
+		expect(observeRemoteMediaProgress).toHaveBeenLastCalledWith(
+			"producer-1",
+			"video",
+			false,
+			false,
+		);
+
+		hidden = true;
+		document.dispatchEvent(new Event("visibilitychange"));
+		hidden = false;
+		document.dispatchEvent(new Event("visibilitychange"));
+		await vi.advanceTimersByTimeAsync(3000);
+		expect(observeRemoteMediaProgress).toHaveBeenLastCalledWith(
+			"producer-1",
+			"video",
+			true,
+			true,
+		);
 		app.unmount();
 	});
 });

--- a/frontend/src/apps/meet/composables/useNetworkQuality.ts
+++ b/frontend/src/apps/meet/composables/useNetworkQuality.ts
@@ -40,8 +40,16 @@ export function useNetworkQuality(
 		{ bytesReceived: number | null; framesDecoded: number | null }
 	>();
 	let active = true;
+	let lifecycleGeneration = 0;
 
 	const pollIntervalMs = 3000;
+	const isLifecycleSuspended = () =>
+		!active || document.hidden || navigator.onLine === false;
+	const resetHealthBaselines = () => {
+		stallDetector.suspend();
+		decodeStallDetector.suspend();
+		expectedMediaCounters.clear();
+	};
 	const updateQuality = (stats: NetworkStats) => {
 		if (!stats.isValid) {
 			// If we can't get valid stats, assume network is good
@@ -90,9 +98,8 @@ export function useNetworkQuality(
 			downlinkQuality.value = "good";
 			return;
 		}
-		if (!active || document.hidden) {
-			stallDetector.suspend();
-			decodeStallDetector.suspend();
+		if (isLifecycleSuspended()) {
+			resetHealthBaselines();
 			return;
 		}
 
@@ -111,7 +118,7 @@ export function useNetworkQuality(
 				return { entry, bytes: bytesReceived, framesDecoded };
 			}),
 		);
-		if (!active || document.hidden || sfuManagerRef?.value !== sfuManager) return;
+		if (isLifecycleSuspended() || sfuManagerRef?.value !== sfuManager) return;
 		const isPaused = (entry: (typeof statsResults)[number]["entry"]) => {
 			const participant = sfuManager.participantManager.getParticipant(
 				entry.participantId,
@@ -174,7 +181,7 @@ export function useNetworkQuality(
 			? "critical"
 			: "good";
 		for (const recovery of decodeActions) {
-			if (!active || document.hidden || sfuManagerRef?.value !== sfuManager) {
+			if (isLifecycleSuspended() || sfuManagerRef?.value !== sfuManager) {
 				return;
 			}
 			const result = statsResults.find(
@@ -216,7 +223,7 @@ export function useNetworkQuality(
 					);
 				}
 			}
-			if (!active || document.hidden || sfuManagerRef?.value !== sfuManager) {
+			if (isLifecycleSuspended() || sfuManagerRef?.value !== sfuManager) {
 				return;
 			}
 		}
@@ -271,8 +278,13 @@ export function useNetworkQuality(
 
 	const pollStats = async () => {
 		if (isPolling.value) return;
+		if (isLifecycleSuspended()) {
+			resetHealthBaselines();
+			return;
+		}
 
 		isPolling.value = true;
+		const generation = lifecycleGeneration;
 		try {
 			const transportManager = sfuManagerRef?.value?.transportManager;
 
@@ -300,6 +312,12 @@ export function useNetworkQuality(
 
 			if (transportManager.getNetworkStats) {
 				const stats = await transportManager.getNetworkStats();
+				if (
+					generation !== lifecycleGeneration ||
+					isLifecycleSuspended()
+				) {
+					return;
+				}
 				updateQuality(stats);
 				const sfuClient = sfuManagerRef?.value?.sfuClient;
 				if (sfuClient && stats.isValid) {
@@ -313,20 +331,49 @@ export function useNetworkQuality(
 		}
 	};
 
+	const suspendBrowserLifecycle = () => {
+		lifecycleGeneration += 1;
+		resetHealthBaselines();
+	};
+
+	const recoverBrowserLifecycle = async () => {
+		const generation = ++lifecycleGeneration;
+		resetHealthBaselines();
+		if (isLifecycleSuspended()) return;
+		const sfuManager = sfuManagerRef?.value;
+		await sfuManager?.recoverBrowserLifecycle?.();
+		if (
+			generation !== lifecycleGeneration ||
+			isLifecycleSuspended() ||
+			sfuManagerRef?.value !== sfuManager
+		) {
+			return;
+		}
+	};
+
 	const handleVisibilityChange = () => {
-		stallDetector.suspend();
-		decodeStallDetector.suspend();
+		if (document.hidden) {
+			suspendBrowserLifecycle();
+		} else {
+			void recoverBrowserLifecycle();
+		}
 	};
 
 	onMounted(() => {
 		active = true;
 		document.addEventListener("visibilitychange", handleVisibilityChange);
+		window.addEventListener("offline", suspendBrowserLifecycle);
+		window.addEventListener("online", recoverBrowserLifecycle);
+		window.addEventListener("pageshow", recoverBrowserLifecycle);
 		pollInterval = setInterval(pollStats, pollIntervalMs);
 	});
 
 	onUnmounted(() => {
 		active = false;
 		document.removeEventListener("visibilitychange", handleVisibilityChange);
+		window.removeEventListener("offline", suspendBrowserLifecycle);
+		window.removeEventListener("online", recoverBrowserLifecycle);
+		window.removeEventListener("pageshow", recoverBrowserLifecycle);
 		if (pollInterval) {
 			clearInterval(pollInterval);
 			pollInterval = null;

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -137,6 +137,7 @@ export class SFUMeetingManager {
 		return this.connectionManager.reconcileExpectedMedia();
 	}
 
+	/** Restarts playback, then reconciles expected media after browser resume. */
 	async recoverBrowserLifecycle(): Promise<void> {
 		await this.videoManager.retryPlayback();
 		await this.reconcileExpectedMedia();

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -137,6 +137,11 @@ export class SFUMeetingManager {
 		return this.connectionManager.reconcileExpectedMedia();
 	}
 
+	async recoverBrowserLifecycle(): Promise<void> {
+		await this.videoManager.retryPlayback();
+		await this.reconcileExpectedMedia();
+	}
+
 	observeRemoteMediaProgress(
 		producerId: string,
 		media: "audio" | "video",

--- a/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
@@ -77,6 +77,24 @@ function prepareE2EEManager() {
 }
 
 describe("SFUMeetingManager adaptive streaming", () => {
+	it("retries playback before reconciling media after browser resume", async () => {
+		const manager = new SFUMeetingManager({} as never);
+		const retryPlayback = vi
+			.spyOn(manager.videoManager, "retryPlayback")
+			.mockResolvedValue();
+		const reconcile = vi
+			.spyOn(manager, "reconcileExpectedMedia")
+			.mockResolvedValue();
+
+		await manager.recoverBrowserLifecycle();
+
+		expect(retryPlayback).toHaveBeenCalledOnce();
+		expect(reconcile).toHaveBeenCalledOnce();
+		expect(retryPlayback.mock.invocationCallOrder[0]).toBeLessThan(
+			reconcile.mock.invocationCallOrder[0],
+		);
+	});
+
 	it("rejects visible preferences while disconnected", async () => {
 		const manager = new SFUMeetingManager({
 			isConnected: vi.fn(() => false),

--- a/frontend/src/apps/meet/utils/media/VideoElementManager.ts
+++ b/frontend/src/apps/meet/utils/media/VideoElementManager.ts
@@ -238,6 +238,28 @@ export class VideoElementManager {
 		}
 	}
 
+	async retryPlayback(): Promise<void> {
+		await Promise.all([
+			...Array.from(this.videoElements, ([participantId, element]) =>
+				element.srcObject
+					? this.playVideo(element, participantId)
+					: Promise.resolve(false),
+			),
+			...Array.from(this.audioElements, async ([participantId, element]) => {
+				if (!element.srcObject) return false;
+				try {
+					await element.play();
+					return true;
+				} catch (error) {
+					if ((error as DOMException).name === "NotAllowedError") {
+						this.addUserInteractionHandler(element, participantId);
+					}
+					return false;
+				}
+			}),
+		]);
+	}
+
 	addUserInteractionHandler(
 		element: HTMLMediaElement,
 		participantId: string,

--- a/frontend/src/apps/meet/utils/media/VideoElementManager.ts
+++ b/frontend/src/apps/meet/utils/media/VideoElementManager.ts
@@ -21,6 +21,7 @@ export class VideoElementManager {
 	deferredAttachments: Map<string, DeferredAttachment>;
 	private lastVideoAttachAt: Map<string, number>;
 	private lastAudioAttachAt: Map<string, number>;
+	private playbackHandlers: Map<HTMLMediaElement, () => void>;
 
 	constructor(private strictAttachmentTimeoutMs?: number) {
 		this.videoElements = new Map();
@@ -28,6 +29,7 @@ export class VideoElementManager {
 		this.deferredAttachments = new Map();
 		this.lastVideoAttachAt = new Map();
 		this.lastAudioAttachAt = new Map();
+		this.playbackHandlers = new Map();
 	}
 
 	registerVideoElement(participantId: string, element: HTMLElement): void {
@@ -221,6 +223,7 @@ export class VideoElementManager {
 	): Promise<boolean> {
 		try {
 			await element.play();
+			this.clearPlaybackHandler(element);
 			return true;
 		} catch (error) {
 			if ((error as DOMException).name === "NotAllowedError") {
@@ -238,6 +241,7 @@ export class VideoElementManager {
 		}
 	}
 
+	/** Retries playback for every attached remote media element after resume. */
 	async retryPlayback(): Promise<void> {
 		await Promise.all([
 			...Array.from(this.videoElements, ([participantId, element]) =>
@@ -249,6 +253,7 @@ export class VideoElementManager {
 				if (!element.srcObject) return false;
 				try {
 					await element.play();
+					this.clearPlaybackHandler(element);
 					return true;
 				} catch (error) {
 					if ((error as DOMException).name === "NotAllowedError") {
@@ -264,12 +269,11 @@ export class VideoElementManager {
 		element: HTMLMediaElement,
 		participantId: string,
 	): void {
+		if (this.playbackHandlers.has(element)) return;
 		const playOnInteraction = async () => {
 			try {
 				await element.play();
-
-				document.removeEventListener("click", playOnInteraction);
-				document.removeEventListener("touchstart", playOnInteraction);
+				this.clearPlaybackHandler(element);
 			} catch (error) {
 				console.warn(
 					`Unable to play video for ${participantId}:`,
@@ -278,8 +282,17 @@ export class VideoElementManager {
 			}
 		};
 
-		document.addEventListener("click", playOnInteraction, { once: true });
-		document.addEventListener("touchstart", playOnInteraction, { once: true });
+		this.playbackHandlers.set(element, playOnInteraction);
+		document.addEventListener("click", playOnInteraction);
+		document.addEventListener("touchstart", playOnInteraction);
+	}
+
+	private clearPlaybackHandler(element: HTMLMediaElement): void {
+		const handler = this.playbackHandlers.get(element);
+		if (!handler) return;
+		document.removeEventListener("click", handler);
+		document.removeEventListener("touchstart", handler);
+		this.playbackHandlers.delete(element);
 	}
 
 	removeVideoElement(participantId: string): void {
@@ -306,6 +319,8 @@ export class VideoElementManager {
 			audioElement.remove();
 			this.audioElements.delete(participantId);
 		}
+		if (element) this.clearPlaybackHandler(element);
+		if (audioElement) this.clearPlaybackHandler(audioElement);
 
 		this.videoElements.delete(participantId);
 		const deferred = this.deferredAttachments.get(participantId);
@@ -322,6 +337,9 @@ export class VideoElementManager {
 	}
 
 	cleanup(): void {
+		for (const element of this.playbackHandlers.keys()) {
+			this.clearPlaybackHandler(element);
+		}
 		for (const deferred of this.deferredAttachments.values()) {
 			if (deferred.timer) clearTimeout(deferred.timer);
 			deferred.reject?.(new Error("Video element manager cleaned up"));

--- a/frontend/src/apps/meet/utils/media/__tests__/VideoElementManager.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/VideoElementManager.test.ts
@@ -173,6 +173,23 @@ describe("VideoElementManager.attachStream stale re-attach", () => {
 		await manager.attachStream("p1", makeStream([makeTrack("t1")]), false);
 		expect((el2.srcObject as MediaStream).getVideoTracks()[0].id).toBe("t1");
 	});
+
+	it("retries playback for attached video and audio after resume", async () => {
+		const video = makeVideoElement();
+		video.srcObject = makeStream([makeTrack("video-1")]);
+		manager.registerVideoElement("p1", video);
+		const audio = document.createElement("audio");
+		audio.srcObject = makeStream([
+			{ ...makeTrack("audio-1"), kind: "audio" } as MediaStreamTrack,
+		]);
+		audio.play = vi.fn().mockResolvedValue(undefined);
+		manager.audioElements.set("p1", audio);
+
+		await manager.retryPlayback();
+
+		expect(video.play).toHaveBeenCalledOnce();
+		expect(audio.play).toHaveBeenCalledOnce();
+	});
 });
 
 describe("VideoElementManager.attachAudioStream stale re-attach", () => {

--- a/frontend/src/apps/meet/utils/media/__tests__/VideoElementManager.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/VideoElementManager.test.ts
@@ -128,6 +128,22 @@ describe("VideoElementManager.attachStream stale re-attach", () => {
 		play.mockRestore();
 	});
 
+	it("deduplicates and removes pending playback interaction handlers", async () => {
+		const element = makeVideoElement();
+		element.play = vi.fn().mockRejectedValue(new Error("still blocked"));
+		manager.addUserInteractionHandler(element, "p1");
+		manager.addUserInteractionHandler(element, "p1");
+
+		document.dispatchEvent(new Event("click"));
+		await vi.waitFor(() => expect(element.play).toHaveBeenCalledOnce());
+
+		manager.registerVideoElement("p1", element);
+		manager.removeVideoElement("p1");
+		document.dispatchEvent(new Event("click"));
+		await Promise.resolve();
+		expect(element.play).toHaveBeenCalledOnce();
+	});
+
 	it("skips re-attach when track id is unchanged", async () => {
 		const el = makeVideoElement();
 		manager.registerVideoElement("p1", el);


### PR DESCRIPTION
## Summary

- suspend media health repairs while the browser is hidden or offline
- reset media progress baselines and reconcile expected media after resume
- retry attached audio and video playback after browser lifecycle transitions