### PR TITLE
test(meet): add media fault injection coverage

### DIFF
--- a/e2e/meet/fixtures/media.ts
+++ b/e2e/meet/fixtures/media.ts
@@ -40,3 +40,63 @@ export const STUB_MEDIA_SCRIPT = `(() => {
 		return stream;
 	};
 })();`;
+
+export const MEDIA_FAULT_SCRIPT = `(() => {
+	const localTracks = { audio: [], video: [] };
+	const peerConnections = [];
+	const originalGetUserMedia = navigator.mediaDevices?.getUserMedia?.bind(
+		navigator.mediaDevices,
+	);
+	if (originalGetUserMedia) {
+		navigator.mediaDevices.getUserMedia = async (...args) => {
+			const stream = await originalGetUserMedia(...args);
+			for (const track of stream.getTracks()) localTracks[track.kind]?.push(track);
+			return stream;
+		};
+	}
+
+	const NativePeerConnection = window.RTCPeerConnection;
+	window.RTCPeerConnection = class extends NativePeerConnection {
+		constructor(...args) {
+			super(...args);
+			peerConnections.push(this);
+		}
+	};
+
+	window.__meetMediaFaults = {
+		latestLocalTrackId(kind) {
+			return [...localTracks[kind]].reverse().find((track) => track.readyState === "live")?.id ?? null;
+		},
+		stopLatestLocalTrack(kind) {
+			const track = [...localTracks[kind]].reverse().find((item) => item.readyState === "live");
+			if (!track) return null;
+			track.stop();
+			track.dispatchEvent(new Event("ended"));
+			return track.id;
+		},
+		async injectReceiverStats(trackId, fault) {
+			const receiver = peerConnections
+				.flatMap((connection) => connection.getReceivers())
+				.find((item) => item.track?.id === trackId);
+			if (!receiver) return false;
+			const originalGetStats = receiver.getStats.bind(receiver);
+			receiver.getStats = async () => {
+				const report = await originalGetStats();
+				const injected = new Map();
+				report.forEach((value, key) => {
+					if (value.type !== "inbound-rtp" || value.kind !== "video") {
+						injected.set(key, value);
+						return;
+					}
+					injected.set(key, {
+						...value,
+						...(fault === "zero-bytes" ? { bytesReceived: 0 } : {}),
+						...(fault === "decode-stall" ? { framesDecoded: 0 } : {}),
+					});
+				});
+				return injected;
+			};
+			return true;
+		},
+	};
+})();`;

--- a/e2e/meet/fixtures/media.ts
+++ b/e2e/meet/fixtures/media.ts
@@ -44,6 +44,26 @@ export const STUB_MEDIA_SCRIPT = `(() => {
 export const MEDIA_FAULT_SCRIPT = `(() => {
 	const localTracks = { audio: [], video: [] };
 	const peerConnections = [];
+	const pendingReceiverFaults = [];
+	const injectReceiverStats = (receiver, fault) => {
+		const originalGetStats = receiver.getStats.bind(receiver);
+		receiver.getStats = async () => {
+			const report = await originalGetStats();
+			const injected = new Map();
+			report.forEach((value, key) => {
+				if (value.type !== "inbound-rtp" || value.kind !== "video") {
+					injected.set(key, value);
+					return;
+				}
+				injected.set(key, {
+					...value,
+					...(fault === "zero-bytes" ? { bytesReceived: 0 } : {}),
+					...(fault === "decode-stall" ? { framesDecoded: 0 } : {}),
+				});
+			});
+			return injected;
+		};
+	};
 	const originalGetUserMedia = navigator.mediaDevices?.getUserMedia?.bind(
 		navigator.mediaDevices,
 	);
@@ -60,6 +80,10 @@ export const MEDIA_FAULT_SCRIPT = `(() => {
 		constructor(...args) {
 			super(...args);
 			peerConnections.push(this);
+			this.addEventListener("track", (event) => {
+				if (event.track.kind !== "video" || pendingReceiverFaults.length === 0) return;
+				injectReceiverStats(event.receiver, pendingReceiverFaults.shift());
+			});
 		}
 	};
 
@@ -79,24 +103,11 @@ export const MEDIA_FAULT_SCRIPT = `(() => {
 				.flatMap((connection) => connection.getReceivers())
 				.find((item) => item.track?.id === trackId);
 			if (!receiver) return false;
-			const originalGetStats = receiver.getStats.bind(receiver);
-			receiver.getStats = async () => {
-				const report = await originalGetStats();
-				const injected = new Map();
-				report.forEach((value, key) => {
-					if (value.type !== "inbound-rtp" || value.kind !== "video") {
-						injected.set(key, value);
-						return;
-					}
-					injected.set(key, {
-						...value,
-						...(fault === "zero-bytes" ? { bytesReceived: 0 } : {}),
-						...(fault === "decode-stall" ? { framesDecoded: 0 } : {}),
-					});
-				});
-				return injected;
-			};
+			injectReceiverStats(receiver, fault);
 			return true;
+		},
+		armNextVideoReceiverFault(fault) {
+			pendingReceiverFaults.push(fault);
 		},
 	};
 })();`;

--- a/e2e/meet/fixtures/test.ts
+++ b/e2e/meet/fixtures/test.ts
@@ -5,7 +5,7 @@ import {
 	type BrowserContext,
 	type Page,
 } from "@playwright/test";
-import { STUB_MEDIA_SCRIPT } from "./media";
+import { MEDIA_FAULT_SCRIPT, STUB_MEDIA_SCRIPT } from "./media";
 import { loginViaApi } from "../../shared/auth";
 import {
 	clearMeetingCreateRateLimit,
@@ -53,7 +53,9 @@ interface TestFixtures {
 }
 
 async function prepareContext(context: BrowserContext): Promise<void> {
-	await context.addInitScript({ content: STUB_MEDIA_SCRIPT });
+	await context.addInitScript({
+		content: `${STUB_MEDIA_SCRIPT}\n${MEDIA_FAULT_SCRIPT}`,
+	});
 	await context.grantPermissions(["camera", "microphone"]);
 }
 

--- a/e2e/meet/helpers/faults.ts
+++ b/e2e/meet/helpers/faults.ts
@@ -1,0 +1,146 @@
+import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+type MediaKind = "audio" | "video";
+type ReceiverFault = "zero-bytes" | "decode-stall";
+
+export interface VideoProgress {
+	currentTime: number;
+	decodedFrames: number;
+	trackId: string;
+}
+
+function remoteVideo(page: Page, participantName: string) {
+	return page
+		.locator("[data-testid^='participant-tile-']", { hasText: participantName })
+		.locator("video")
+		.first();
+}
+
+export async function readRemoteVideoProgress(
+	page: Page,
+	participantName: string,
+): Promise<VideoProgress> {
+	return remoteVideo(page, participantName).evaluate((element, name) => {
+		const video = element as HTMLVideoElement;
+		const stream = video.srcObject as MediaStream | null;
+		const track = stream?.getVideoTracks()[0];
+		if (!track) throw new Error(`No remote video track for ${name}`);
+		return {
+			currentTime: video.currentTime,
+			decodedFrames: video.getVideoPlaybackQuality?.().totalVideoFrames ?? 0,
+			trackId: track.id,
+		};
+	}, participantName);
+}
+
+export function monitorRemoteVideoContinuity(
+	page: Page,
+	participantName: string,
+): { stop: () => Promise<void> } {
+	let stopped = false;
+	let failure: unknown;
+	const monitoring = (async () => {
+		let previous = await readRemoteVideoProgress(page, participantName);
+		const trackId = previous.trackId;
+		let lastProgressAt = Date.now();
+		while (!stopped) {
+			await page.waitForTimeout(500);
+			const current = await readRemoteVideoProgress(page, participantName);
+			if (current.trackId !== trackId) {
+				throw new Error(`Healthy ${participantName} video track was replaced`);
+			}
+			if (
+				current.currentTime > previous.currentTime ||
+				current.decodedFrames > previous.decodedFrames
+			) {
+				lastProgressAt = Date.now();
+			}
+			if (Date.now() - lastProgressAt > 3000) {
+				throw new Error(`Healthy ${participantName} video stopped advancing`);
+			}
+			previous = current;
+		}
+	})().catch((error) => {
+		failure = error;
+	});
+
+	return {
+		async stop() {
+			stopped = true;
+			await monitoring;
+			if (failure) throw failure;
+		},
+	};
+}
+
+export async function stopLatestLocalTrack(
+	page: Page,
+	kind: MediaKind,
+): Promise<string> {
+	const trackId = await page.evaluate((mediaKind) => {
+		return window.__meetMediaFaults?.stopLatestLocalTrack(mediaKind) ?? null;
+	}, kind);
+	if (!trackId) throw new Error(`No live local ${kind} track to stop`);
+	return trackId;
+}
+
+export async function expectLocalTrackReplaced(
+	page: Page,
+	kind: MediaKind,
+	previousTrackId: string,
+): Promise<void> {
+	await expect
+		.poll(
+			async () => {
+				const trackId = await page.evaluate(
+					(mediaKind) =>
+						window.__meetMediaFaults?.latestLocalTrackId(mediaKind) ?? null,
+					kind,
+				);
+				return Boolean(trackId && trackId !== previousTrackId);
+			},
+			{ timeout: 45_000 },
+		)
+		.toBe(true);
+}
+
+export async function injectRemoteVideoFault(
+	page: Page,
+	participantName: string,
+	fault: ReceiverFault,
+): Promise<VideoProgress> {
+	const baseline = await readRemoteVideoProgress(page, participantName);
+	const injected = await page.evaluate(
+		({ trackId, faultName }) =>
+			window.__meetMediaFaults?.injectReceiverStats(trackId, faultName) ?? false,
+		{ trackId: baseline.trackId, faultName: fault },
+	);
+	if (!injected) throw new Error(`Could not inject ${fault} for ${participantName}`);
+	return baseline;
+}
+
+export async function expectRemoteTrackReplaced(
+	page: Page,
+	participantName: string,
+	previousTrackId: string,
+	timeoutMs = 90_000,
+): Promise<void> {
+	await expect
+		.poll(
+			async () =>
+				(await readRemoteVideoProgress(page, participantName)).trackId,
+			{ timeout: timeoutMs },
+		)
+		.not.toBe(previousTrackId);
+}
+
+declare global {
+	interface Window {
+		__meetMediaFaults?: {
+			latestLocalTrackId(kind: MediaKind): string | null;
+			stopLatestLocalTrack(kind: MediaKind): string | null;
+			injectReceiverStats(trackId: string, fault: ReceiverFault): Promise<boolean>;
+		};
+	}
+}

--- a/e2e/meet/helpers/faults.ts
+++ b/e2e/meet/helpers/faults.ts
@@ -120,6 +120,16 @@ export async function injectRemoteVideoFault(
 	return baseline;
 }
 
+export async function armNextRemoteVideoFault(
+	page: Page,
+	fault: ReceiverFault,
+): Promise<void> {
+	await page.evaluate((faultName) => {
+		if (!window.__meetMediaFaults) throw new Error("Media fault bridge unavailable");
+		window.__meetMediaFaults.armNextVideoReceiverFault(faultName);
+	}, fault);
+}
+
 export async function expectRemoteTrackReplaced(
 	page: Page,
 	participantName: string,
@@ -141,6 +151,7 @@ declare global {
 			latestLocalTrackId(kind: MediaKind): string | null;
 			stopLatestLocalTrack(kind: MediaKind): string | null;
 			injectReceiverStats(trackId: string, fault: ReceiverFault): Promise<boolean>;
+			armNextVideoReceiverFault(fault: ReceiverFault): void;
 		};
 	}
 }

--- a/e2e/meet/specs/media-fault-recovery.spec.ts
+++ b/e2e/meet/specs/media-fault-recovery.spec.ts
@@ -1,0 +1,131 @@
+import { appUrl, expect, joinFromPreview, test } from "../fixtures/test";
+import {
+	expectLocalTrackReplaced,
+	expectRemoteTrackReplaced,
+	injectRemoteVideoFault,
+	monitorRemoteVideoContinuity,
+	stopLatestLocalTrack,
+} from "../helpers/faults";
+import { expectRemoteVideoReceiving } from "../helpers/media";
+
+test.describe("Media fault recovery", () => {
+	test("recovers an ended camera while healthy media keeps advancing", async ({
+		hostPage,
+		createMeeting,
+		createParticipant,
+	}) => {
+		const meetingId = await createMeeting();
+		const target = await createParticipant();
+		const control = await createParticipant();
+		await Promise.all([
+			(async () => {
+				await hostPage.goto(appUrl(`/meet/${meetingId}`));
+				await joinFromPreview(hostPage);
+			})(),
+			target.joinAsGuest(meetingId, "Fault Target"),
+			control.joinAsGuest(meetingId, "Healthy Control"),
+		]);
+		await Promise.all([
+			expectRemoteVideoReceiving(hostPage, "Fault Target"),
+			expectRemoteVideoReceiving(hostPage, "Healthy Control"),
+		]);
+		const controlMonitor = monitorRemoteVideoContinuity(
+			hostPage,
+			"Healthy Control",
+		);
+		const stoppedTrackId = await stopLatestLocalTrack(target.page, "video");
+		try {
+			await expectLocalTrackReplaced(target.page, "video", stoppedTrackId);
+			await expectRemoteVideoReceiving(hostPage, "Fault Target");
+		} finally {
+			await controlMonitor.stop();
+		}
+	});
+
+	test("recreates only a consumer with zero-byte stats while healthy media keeps advancing", async ({
+		hostPage,
+		createMeeting,
+		createParticipant,
+	}) => {
+		test.setTimeout(120_000);
+		const meetingId = await createMeeting();
+		const target = await createParticipant();
+		const control = await createParticipant();
+		await Promise.all([
+			(async () => {
+				await hostPage.goto(appUrl(`/meet/${meetingId}`));
+				await joinFromPreview(hostPage);
+			})(),
+			target.joinAsGuest(meetingId, "Fault Target"),
+			control.joinAsGuest(meetingId, "Healthy Control"),
+		]);
+		await Promise.all([
+			expectRemoteVideoReceiving(hostPage, "Fault Target"),
+			expectRemoteVideoReceiving(hostPage, "Healthy Control"),
+		]);
+		// Ensure the 3-second production stats poll has established stream health.
+		await hostPage.waitForTimeout(3500);
+		const controlMonitor = monitorRemoteVideoContinuity(
+			hostPage,
+			"Healthy Control",
+		);
+		try {
+			const targetBaseline = await injectRemoteVideoFault(
+				hostPage,
+				"Fault Target",
+				"zero-bytes",
+			);
+			await expectRemoteTrackReplaced(
+				hostPage,
+				"Fault Target",
+				targetBaseline.trackId,
+			);
+			await expectRemoteVideoReceiving(hostPage, "Fault Target");
+		} finally {
+			await controlMonitor.stop();
+		}
+	});
+
+	test("recreates only a decode-stalled consumer", async ({
+		hostPage,
+		createMeeting,
+		createParticipant,
+	}) => {
+		test.setTimeout(120_000);
+		const meetingId = await createMeeting();
+		const target = await createParticipant();
+		const control = await createParticipant();
+		await Promise.all([
+			(async () => {
+				await hostPage.goto(appUrl(`/meet/${meetingId}`));
+				await joinFromPreview(hostPage);
+			})(),
+			target.joinAsGuest(meetingId, "Fault Target"),
+			control.joinAsGuest(meetingId, "Healthy Control"),
+		]);
+		await Promise.all([
+			expectRemoteVideoReceiving(hostPage, "Fault Target"),
+			expectRemoteVideoReceiving(hostPage, "Healthy Control"),
+		]);
+		await hostPage.waitForTimeout(3500);
+		const controlMonitor = monitorRemoteVideoContinuity(
+			hostPage,
+			"Healthy Control",
+		);
+		try {
+			const targetBaseline = await injectRemoteVideoFault(
+				hostPage,
+				"Fault Target",
+				"decode-stall",
+			);
+			await expectRemoteTrackReplaced(
+				hostPage,
+				"Fault Target",
+				targetBaseline.trackId,
+			);
+			await expectRemoteVideoReceiving(hostPage, "Fault Target");
+		} finally {
+			await controlMonitor.stop();
+		}
+	});
+});

--- a/e2e/meet/specs/media-fault-recovery.spec.ts
+++ b/e2e/meet/specs/media-fault-recovery.spec.ts
@@ -1,9 +1,11 @@
 import { appUrl, expect, joinFromPreview, test } from "../fixtures/test";
 import {
+	armNextRemoteVideoFault,
 	expectLocalTrackReplaced,
 	expectRemoteTrackReplaced,
 	injectRemoteVideoFault,
 	monitorRemoteVideoContinuity,
+	readRemoteVideoProgress,
 	stopLatestLocalTrack,
 } from "../helpers/faults";
 import { expectRemoteVideoReceiving } from "../helpers/media";
@@ -42,7 +44,7 @@ test.describe("Media fault recovery", () => {
 		}
 	});
 
-	test("recreates only a consumer with zero-byte stats while healthy media keeps advancing", async ({
+	test("recreates only a zero-byte consumer while healthy media keeps advancing", async ({
 		hostPage,
 		createMeeting,
 		createParticipant,
@@ -56,24 +58,20 @@ test.describe("Media fault recovery", () => {
 				await hostPage.goto(appUrl(`/meet/${meetingId}`));
 				await joinFromPreview(hostPage);
 			})(),
-			target.joinAsGuest(meetingId, "Fault Target"),
 			control.joinAsGuest(meetingId, "Healthy Control"),
 		]);
-		await Promise.all([
-			expectRemoteVideoReceiving(hostPage, "Fault Target"),
-			expectRemoteVideoReceiving(hostPage, "Healthy Control"),
-		]);
-		// Ensure the 3-second production stats poll has established stream health.
-		await hostPage.waitForTimeout(3500);
+		await expectRemoteVideoReceiving(hostPage, "Healthy Control");
 		const controlMonitor = monitorRemoteVideoContinuity(
 			hostPage,
 			"Healthy Control",
 		);
 		try {
-			const targetBaseline = await injectRemoteVideoFault(
+			await armNextRemoteVideoFault(hostPage, "zero-bytes");
+			await target.joinAsGuest(meetingId, "Fault Target");
+			await expectRemoteVideoReceiving(hostPage, "Fault Target");
+			const targetBaseline = await readRemoteVideoProgress(
 				hostPage,
 				"Fault Target",
-				"zero-bytes",
 			);
 			await expectRemoteTrackReplaced(
 				hostPage,

--- a/e2e/meet/specs/media-fault-recovery.spec.ts
+++ b/e2e/meet/specs/media-fault-recovery.spec.ts
@@ -11,119 +11,119 @@ import {
 import { expectRemoteVideoReceiving } from "../helpers/media";
 
 test.describe("Media fault recovery", () => {
-	test("recovers an ended camera while healthy media keeps advancing", async ({
-		hostPage,
-		createMeeting,
-		createParticipant,
-	}) => {
-		const meetingId = await createMeeting();
-		const target = await createParticipant();
-		const control = await createParticipant();
-		await Promise.all([
-			(async () => {
-				await hostPage.goto(appUrl(`/meet/${meetingId}`));
-				await joinFromPreview(hostPage);
-			})(),
-			target.joinAsGuest(meetingId, "Fault Target"),
-			control.joinAsGuest(meetingId, "Healthy Control"),
-		]);
-		await Promise.all([
-			expectRemoteVideoReceiving(hostPage, "Fault Target"),
-			expectRemoteVideoReceiving(hostPage, "Healthy Control"),
-		]);
-		const controlMonitor = monitorRemoteVideoContinuity(
-			hostPage,
-			"Healthy Control",
-		);
-		const stoppedTrackId = await stopLatestLocalTrack(target.page, "video");
-		try {
-			await expectLocalTrackReplaced(target.page, "video", stoppedTrackId);
-			await expectRemoteVideoReceiving(hostPage, "Fault Target");
-		} finally {
-			await controlMonitor.stop();
-		}
-	});
+	test(
+		"recovers an ended camera while healthy media keeps advancing",
+		{ tag: "@meet-group-3" },
+		async ({ hostPage, createMeeting, createParticipant }) => {
+			const meetingId = await createMeeting();
+			const target = await createParticipant();
+			const control = await createParticipant();
+			await Promise.all([
+				(async () => {
+					await hostPage.goto(appUrl(`/meet/${meetingId}`));
+					await joinFromPreview(hostPage);
+				})(),
+				target.joinAsGuest(meetingId, "Fault Target"),
+				control.joinAsGuest(meetingId, "Healthy Control"),
+			]);
+			await Promise.all([
+				expectRemoteVideoReceiving(hostPage, "Fault Target"),
+				expectRemoteVideoReceiving(hostPage, "Healthy Control"),
+			]);
+			const controlMonitor = monitorRemoteVideoContinuity(
+				hostPage,
+				"Healthy Control",
+			);
+			const stoppedTrackId = await stopLatestLocalTrack(target.page, "video");
+			try {
+				await expectLocalTrackReplaced(target.page, "video", stoppedTrackId);
+				await expectRemoteVideoReceiving(hostPage, "Fault Target");
+			} finally {
+				await controlMonitor.stop();
+			}
+		},
+	);
 
-	test("recreates only a zero-byte consumer while healthy media keeps advancing", async ({
-		hostPage,
-		createMeeting,
-		createParticipant,
-	}) => {
-		test.setTimeout(120_000);
-		const meetingId = await createMeeting();
-		const target = await createParticipant();
-		const control = await createParticipant();
-		await Promise.all([
-			(async () => {
-				await hostPage.goto(appUrl(`/meet/${meetingId}`));
-				await joinFromPreview(hostPage);
-			})(),
-			control.joinAsGuest(meetingId, "Healthy Control"),
-		]);
-		await expectRemoteVideoReceiving(hostPage, "Healthy Control");
-		const controlMonitor = monitorRemoteVideoContinuity(
-			hostPage,
-			"Healthy Control",
-		);
-		try {
-			await armNextRemoteVideoFault(hostPage, "zero-bytes");
-			await target.joinAsGuest(meetingId, "Fault Target");
-			await expectRemoteVideoReceiving(hostPage, "Fault Target");
-			const targetBaseline = await readRemoteVideoProgress(
+	test(
+		"recreates only a zero-byte consumer while healthy media keeps advancing",
+		{ tag: "@meet-group-2" },
+		async ({ hostPage, createMeeting, createParticipant }) => {
+			test.setTimeout(120_000);
+			const meetingId = await createMeeting();
+			const target = await createParticipant();
+			const control = await createParticipant();
+			await Promise.all([
+				(async () => {
+					await hostPage.goto(appUrl(`/meet/${meetingId}`));
+					await joinFromPreview(hostPage);
+				})(),
+				control.joinAsGuest(meetingId, "Healthy Control"),
+			]);
+			await expectRemoteVideoReceiving(hostPage, "Healthy Control");
+			const controlMonitor = monitorRemoteVideoContinuity(
 				hostPage,
-				"Fault Target",
+				"Healthy Control",
 			);
-			await expectRemoteTrackReplaced(
-				hostPage,
-				"Fault Target",
-				targetBaseline.trackId,
-			);
-			await expectRemoteVideoReceiving(hostPage, "Fault Target");
-		} finally {
-			await controlMonitor.stop();
-		}
-	});
+			try {
+				await armNextRemoteVideoFault(hostPage, "zero-bytes");
+				await target.joinAsGuest(meetingId, "Fault Target");
+				await expectRemoteVideoReceiving(hostPage, "Fault Target");
+				const targetBaseline = await readRemoteVideoProgress(
+					hostPage,
+					"Fault Target",
+				);
+				await expectRemoteTrackReplaced(
+					hostPage,
+					"Fault Target",
+					targetBaseline.trackId,
+				);
+				await expectRemoteVideoReceiving(hostPage, "Fault Target");
+			} finally {
+				await controlMonitor.stop();
+			}
+		},
+	);
 
-	test("recreates only a decode-stalled consumer", async ({
-		hostPage,
-		createMeeting,
-		createParticipant,
-	}) => {
-		test.setTimeout(120_000);
-		const meetingId = await createMeeting();
-		const target = await createParticipant();
-		const control = await createParticipant();
-		await Promise.all([
-			(async () => {
-				await hostPage.goto(appUrl(`/meet/${meetingId}`));
-				await joinFromPreview(hostPage);
-			})(),
-			target.joinAsGuest(meetingId, "Fault Target"),
-			control.joinAsGuest(meetingId, "Healthy Control"),
-		]);
-		await Promise.all([
-			expectRemoteVideoReceiving(hostPage, "Fault Target"),
-			expectRemoteVideoReceiving(hostPage, "Healthy Control"),
-		]);
-		await hostPage.waitForTimeout(3500);
-		const controlMonitor = monitorRemoteVideoContinuity(
-			hostPage,
-			"Healthy Control",
-		);
-		try {
-			const targetBaseline = await injectRemoteVideoFault(
+	test(
+		"recreates only a decode-stalled consumer",
+		{ tag: "@meet-group-1" },
+		async ({ hostPage, createMeeting, createParticipant }) => {
+			test.setTimeout(120_000);
+			const meetingId = await createMeeting();
+			const target = await createParticipant();
+			const control = await createParticipant();
+			await Promise.all([
+				(async () => {
+					await hostPage.goto(appUrl(`/meet/${meetingId}`));
+					await joinFromPreview(hostPage);
+				})(),
+				target.joinAsGuest(meetingId, "Fault Target"),
+				control.joinAsGuest(meetingId, "Healthy Control"),
+			]);
+			await Promise.all([
+				expectRemoteVideoReceiving(hostPage, "Fault Target"),
+				expectRemoteVideoReceiving(hostPage, "Healthy Control"),
+			]);
+			await hostPage.waitForTimeout(3500);
+			const controlMonitor = monitorRemoteVideoContinuity(
 				hostPage,
-				"Fault Target",
-				"decode-stall",
+				"Healthy Control",
 			);
-			await expectRemoteTrackReplaced(
-				hostPage,
-				"Fault Target",
-				targetBaseline.trackId,
-			);
-			await expectRemoteVideoReceiving(hostPage, "Fault Target");
-		} finally {
-			await controlMonitor.stop();
-		}
-	});
+			try {
+				const targetBaseline = await injectRemoteVideoFault(
+					hostPage,
+					"Fault Target",
+					"decode-stall",
+				);
+				await expectRemoteTrackReplaced(
+					hostPage,
+					"Fault Target",
+					targetBaseline.trackId,
+				);
+				await expectRemoteVideoReceiving(hostPage, "Fault Target");
+			} finally {
+				await controlMonitor.stop();
+			}
+		},
+	);
 });

--- a/e2e/meet/specs/participant-connections.spec.ts
+++ b/e2e/meet/specs/participant-connections.spec.ts
@@ -7,57 +7,60 @@ import {
 import { expectRemoteVideoReceiving } from "../helpers/media";
 
 test.describe("Independent Participant Connections", () => {
-	test("closing one endpoint preserves the participant's other endpoint", async ({
-		hostPage,
-		createMeeting,
-		createParticipant,
-	}) => {
-		const meetingId = await createMeeting();
-		const secondHostEndpoint = await createParticipant();
-		const guest = await createParticipant();
-		await Promise.all([
-			(async () => {
-				await hostPage.goto(appUrl(`/meet/${meetingId}`));
-				await joinFromPreview(hostPage);
-			})(),
-			guest.joinAsGuest(meetingId, "Endpoint Observer"),
-		]);
+	test(
+		"closing one endpoint preserves the participant's other endpoint",
+		{ tag: "@meet-group-3" },
+		async ({ hostPage, createMeeting, createParticipant }) => {
+			const meetingId = await createMeeting();
+			const secondHostEndpoint = await createParticipant();
+			const guest = await createParticipant();
+			await Promise.all([
+				(async () => {
+					await hostPage.goto(appUrl(`/meet/${meetingId}`));
+					await joinFromPreview(hostPage);
+				})(),
+				guest.joinAsGuest(meetingId, "Endpoint Observer"),
+			]);
 
-		await Promise.all([
-			expect(hostPage.locator("[data-participant-id]")).toHaveCount(2),
-			expect(guest.page.locator("[data-participant-id]")).toHaveCount(2),
-			expectRemoteVideoReceiving(hostPage, "Endpoint Observer"),
-			expectRemoteVideoReceiving(guest.page, meetHostName),
-		]);
-		const firstHostTrack = await readRemoteVideoProgress(
-			guest.page,
-			meetHostName,
-		);
+			await Promise.all([
+				expect(hostPage.locator("[data-participant-id]")).toHaveCount(2),
+				expect(guest.page.locator("[data-participant-id]")).toHaveCount(2),
+				expectRemoteVideoReceiving(hostPage, "Endpoint Observer"),
+				expectRemoteVideoReceiving(guest.page, meetHostName),
+			]);
+			const firstHostTrack = await readRemoteVideoProgress(
+				guest.page,
+				meetHostName,
+			);
 
-		await secondHostEndpoint.joinAsHost(meetingId);
-		await expectRemoteTrackReplaced(
-			guest.page,
-			meetHostName,
-			firstHostTrack.trackId,
-		);
-		await expectRemoteVideoReceiving(secondHostEndpoint.page, "Endpoint Observer");
-		const secondHostTrack = await readRemoteVideoProgress(
-			guest.page,
-			meetHostName,
-		);
+			await secondHostEndpoint.joinAsHost(meetingId);
+			await expectRemoteTrackReplaced(
+				guest.page,
+				meetHostName,
+				firstHostTrack.trackId,
+			);
+			await expectRemoteVideoReceiving(
+				secondHostEndpoint.page,
+				"Endpoint Observer",
+			);
+			const secondHostTrack = await readRemoteVideoProgress(
+				guest.page,
+				meetHostName,
+			);
 
-		await secondHostEndpoint.context.close();
-		await expectRemoteTrackReplaced(
-			guest.page,
-			meetHostName,
-			secondHostTrack.trackId,
-		);
+			await secondHostEndpoint.context.close();
+			await expectRemoteTrackReplaced(
+				guest.page,
+				meetHostName,
+				secondHostTrack.trackId,
+			);
 
-		await Promise.all([
-			expect(hostPage.locator("[data-participant-id]")).toHaveCount(2),
-			expect(guest.page.locator("[data-participant-id]")).toHaveCount(2),
-			expectRemoteVideoReceiving(hostPage, "Endpoint Observer"),
-			expectRemoteVideoReceiving(guest.page, meetHostName),
-		]);
-	});
+			await Promise.all([
+				expect(hostPage.locator("[data-participant-id]")).toHaveCount(2),
+				expect(guest.page.locator("[data-participant-id]")).toHaveCount(2),
+				expectRemoteVideoReceiving(hostPage, "Endpoint Observer"),
+				expectRemoteVideoReceiving(guest.page, meetHostName),
+			]);
+		},
+	);
 });

--- a/e2e/meet/specs/participant-connections.spec.ts
+++ b/e2e/meet/specs/participant-connections.spec.ts
@@ -1,0 +1,63 @@
+import { appUrl, expect, joinFromPreview, test } from "../fixtures/test";
+import { meetHostName } from "../helpers/auth";
+import {
+	expectRemoteTrackReplaced,
+	readRemoteVideoProgress,
+} from "../helpers/faults";
+import { expectRemoteVideoReceiving } from "../helpers/media";
+
+test.describe("Independent Participant Connections", () => {
+	test("closing one endpoint preserves the participant's other endpoint", async ({
+		hostPage,
+		createMeeting,
+		createParticipant,
+	}) => {
+		const meetingId = await createMeeting();
+		const secondHostEndpoint = await createParticipant();
+		const guest = await createParticipant();
+		await Promise.all([
+			(async () => {
+				await hostPage.goto(appUrl(`/meet/${meetingId}`));
+				await joinFromPreview(hostPage);
+			})(),
+			guest.joinAsGuest(meetingId, "Endpoint Observer"),
+		]);
+
+		await Promise.all([
+			expect(hostPage.locator("[data-participant-id]")).toHaveCount(2),
+			expect(guest.page.locator("[data-participant-id]")).toHaveCount(2),
+			expectRemoteVideoReceiving(hostPage, "Endpoint Observer"),
+			expectRemoteVideoReceiving(guest.page, meetHostName),
+		]);
+		const firstHostTrack = await readRemoteVideoProgress(
+			guest.page,
+			meetHostName,
+		);
+
+		await secondHostEndpoint.joinAsHost(meetingId);
+		await expectRemoteTrackReplaced(
+			guest.page,
+			meetHostName,
+			firstHostTrack.trackId,
+		);
+		await expectRemoteVideoReceiving(secondHostEndpoint.page, "Endpoint Observer");
+		const secondHostTrack = await readRemoteVideoProgress(
+			guest.page,
+			meetHostName,
+		);
+
+		await secondHostEndpoint.context.close();
+		await expectRemoteTrackReplaced(
+			guest.page,
+			meetHostName,
+			secondHostTrack.trackId,
+		);
+
+		await Promise.all([
+			expect(hostPage.locator("[data-participant-id]")).toHaveCount(2),
+			expect(guest.page.locator("[data-participant-id]")).toHaveCount(2),
+			expectRemoteVideoReceiving(hostPage, "Endpoint Observer"),
+			expectRemoteVideoReceiving(guest.page, meetHostName),
+		]);
+	});
+});

--- a/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
+++ b/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
@@ -1129,6 +1129,11 @@ export class ParticipantConnection {
 				this.mediaManager.processedConsumers.delete(consumer.id);
 			}
 		}
+		void this.mediaManager
+			.reattachAfterProducerClosed(event.participantId, event.producerId)
+			.catch((error) =>
+				console.warn("Failed to attach surviving endpoint media:", error),
+			);
 	}
 
 	private applyReconciliationEvent(event: ReconciliationEvent): void {

--- a/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
@@ -97,7 +97,8 @@ export class SFUMediaManager {
 
 	private eventHandlers: MediaEventHandlers = {};
 	private getCurrentUserId: () => string | null;
-	private attachedProducerIds = new Map<string, string>();
+	private selectedProducerIds = new Map<string, string>();
+	private attachmentTails = new Map<string, Promise<void>>();
 	private pendingSubscriptions: Map<string, Promise<unknown | null>> = new Map();
 	private resubscribeTimers = new Map<
 		ReturnType<typeof setTimeout>,
@@ -675,31 +676,34 @@ export class SFUMediaManager {
 		consumer: ConsumerEntry,
 	): Promise<void> {
 		const key = `video:${participantId}`;
-		const previousProducerId = this.attachedProducerIds.get(key);
-		try {
+		const previousProducerId = this.selectedProducerIds.get(key);
+		this.selectedProducerIds.set(key, consumer.producerId);
+		return this.serializeAttachment(key, async () => {
+			if (this.selectedProducerIds.get(key) !== consumer.producerId) return;
 			const track = consumer.track as MediaStreamTrack;
 			const stream = new MediaStream([track]);
 
-			this.attachedProducerIds.set(key, consumer.producerId);
-			await this.videoManager.attachStream(participantId, stream, false);
+			try {
+				await this.videoManager.attachStream(participantId, stream, false);
 
-			const participant = this.participantManager.getParticipant(participantId);
-			if (participant && !participant.video_enabled) {
-				this.participantManager.updateParticipant(participantId, {
-					video_enabled: true,
-				});
+				const participant = this.participantManager.getParticipant(participantId);
+				if (participant && !participant.video_enabled) {
+					this.participantManager.updateParticipant(participantId, {
+						video_enabled: true,
+					});
+				}
+			} catch (error) {
+				if (this.selectedProducerIds.get(key) === consumer.producerId) {
+					if (previousProducerId) this.selectedProducerIds.set(key, previousProducerId);
+					else this.selectedProducerIds.delete(key);
+				}
+				console.error(
+					`Failed to attach video consumer for ${participantId}:`,
+					error,
+				);
+				throw error;
 			}
-		} catch (error) {
-			if (this.attachedProducerIds.get(key) === consumer.producerId) {
-				if (previousProducerId) this.attachedProducerIds.set(key, previousProducerId);
-				else this.attachedProducerIds.delete(key);
-			}
-			console.error(
-				`Failed to attach video consumer for ${participantId}:`,
-				error,
-			);
-			throw error;
-		}
+		});
 	}
 
 	async attachAudioConsumer(
@@ -707,24 +711,43 @@ export class SFUMediaManager {
 		consumer: ConsumerEntry,
 	): Promise<void> {
 		const key = `audio:${participantId}`;
-		const previousProducerId = this.attachedProducerIds.get(key);
-		try {
+		const previousProducerId = this.selectedProducerIds.get(key);
+		this.selectedProducerIds.set(key, consumer.producerId);
+		return this.serializeAttachment(key, async () => {
+			if (this.selectedProducerIds.get(key) !== consumer.producerId) return;
 			const track = consumer.track as MediaStreamTrack;
 			const stream = new MediaStream([track]);
 
-			this.attachedProducerIds.set(key, consumer.producerId);
-			await this.videoManager.attachStream(participantId, stream, false);
-		} catch (error) {
-			if (this.attachedProducerIds.get(key) === consumer.producerId) {
-				if (previousProducerId) this.attachedProducerIds.set(key, previousProducerId);
-				else this.attachedProducerIds.delete(key);
+			try {
+				await this.videoManager.attachStream(participantId, stream, false);
+			} catch (error) {
+				if (this.selectedProducerIds.get(key) === consumer.producerId) {
+					if (previousProducerId) this.selectedProducerIds.set(key, previousProducerId);
+					else this.selectedProducerIds.delete(key);
+				}
+				console.error(
+					`Failed to attach audio consumer for ${participantId}:`,
+					error,
+				);
+				throw error;
 			}
-			console.error(
-				`Failed to attach audio consumer for ${participantId}:`,
-				error,
-			);
-			throw error;
-		}
+		});
+	}
+
+	private serializeAttachment(
+		key: string,
+		operation: () => Promise<void>,
+	): Promise<void> {
+		const attachment = (this.attachmentTails.get(key) ?? Promise.resolve())
+			.catch(() => undefined)
+			.then(operation)
+			.finally(() => {
+				if (this.attachmentTails.get(key) === attachment) {
+					this.attachmentTails.delete(key);
+				}
+			});
+		this.attachmentTails.set(key, attachment);
+		return attachment;
 	}
 
 	async reattachAfterProducerClosed(
@@ -734,7 +757,7 @@ export class SFUMediaManager {
 		const consumers = this.consumerManager.getConsumersByParticipant(participantId);
 		for (const kind of ["audio", "video"] as const) {
 			const key = `${kind}:${participantId}`;
-			if (this.attachedProducerIds.get(key) !== producerId) continue;
+			if (this.selectedProducerIds.get(key) !== producerId) continue;
 			const replacement = consumers.find(
 				(consumer) =>
 					consumer.producerId !== producerId &&
@@ -743,7 +766,7 @@ export class SFUMediaManager {
 					!consumer.consumer.closed,
 			);
 			if (!replacement) {
-				this.attachedProducerIds.delete(key);
+				this.selectedProducerIds.delete(key);
 				continue;
 			}
 			if (kind === "video") {
@@ -807,7 +830,8 @@ export class SFUMediaManager {
 		const terminalCleanup = this.sendMediaMutationQueue.then(() => {
 			this.mediaHandler.cleanup();
 			this.processedConsumers.clear();
-			this.attachedProducerIds.clear();
+			this.selectedProducerIds.clear();
+			this.attachmentTails.clear();
 			this.isScreenShareActive = false;
 		});
 		this.cleanupPromise = terminalCleanup;

--- a/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
@@ -97,6 +97,7 @@ export class SFUMediaManager {
 
 	private eventHandlers: MediaEventHandlers = {};
 	private getCurrentUserId: () => string | null;
+	private attachedProducerIds = new Map<string, string>();
 	private pendingSubscriptions: Map<string, Promise<unknown | null>> = new Map();
 	private resubscribeTimers = new Map<
 		ReturnType<typeof setTimeout>,
@@ -673,10 +674,13 @@ export class SFUMediaManager {
 		participantId: string,
 		consumer: ConsumerEntry,
 	): Promise<void> {
+		const key = `video:${participantId}`;
+		const previousProducerId = this.attachedProducerIds.get(key);
 		try {
 			const track = consumer.track as MediaStreamTrack;
 			const stream = new MediaStream([track]);
 
+			this.attachedProducerIds.set(key, consumer.producerId);
 			await this.videoManager.attachStream(participantId, stream, false);
 
 			const participant = this.participantManager.getParticipant(participantId);
@@ -686,6 +690,10 @@ export class SFUMediaManager {
 				});
 			}
 		} catch (error) {
+			if (this.attachedProducerIds.get(key) === consumer.producerId) {
+				if (previousProducerId) this.attachedProducerIds.set(key, previousProducerId);
+				else this.attachedProducerIds.delete(key);
+			}
 			console.error(
 				`Failed to attach video consumer for ${participantId}:`,
 				error,
@@ -698,17 +706,51 @@ export class SFUMediaManager {
 		participantId: string,
 		consumer: ConsumerEntry,
 	): Promise<void> {
+		const key = `audio:${participantId}`;
+		const previousProducerId = this.attachedProducerIds.get(key);
 		try {
 			const track = consumer.track as MediaStreamTrack;
 			const stream = new MediaStream([track]);
 
+			this.attachedProducerIds.set(key, consumer.producerId);
 			await this.videoManager.attachStream(participantId, stream, false);
 		} catch (error) {
+			if (this.attachedProducerIds.get(key) === consumer.producerId) {
+				if (previousProducerId) this.attachedProducerIds.set(key, previousProducerId);
+				else this.attachedProducerIds.delete(key);
+			}
 			console.error(
 				`Failed to attach audio consumer for ${participantId}:`,
 				error,
 			);
 			throw error;
+		}
+	}
+
+	async reattachAfterProducerClosed(
+		participantId: string,
+		producerId: string,
+	): Promise<void> {
+		const consumers = this.consumerManager.getConsumersByParticipant(participantId);
+		for (const kind of ["audio", "video"] as const) {
+			const key = `${kind}:${participantId}`;
+			if (this.attachedProducerIds.get(key) !== producerId) continue;
+			const replacement = consumers.find(
+				(consumer) =>
+					consumer.producerId !== producerId &&
+					consumer.kind === kind &&
+					!consumer.isScreen &&
+					!consumer.consumer.closed,
+			);
+			if (!replacement) {
+				this.attachedProducerIds.delete(key);
+				continue;
+			}
+			if (kind === "video") {
+				await this.attachVideoConsumer(participantId, replacement);
+			} else {
+				await this.attachAudioConsumer(participantId, replacement);
+			}
 		}
 	}
 
@@ -765,6 +807,7 @@ export class SFUMediaManager {
 		const terminalCleanup = this.sendMediaMutationQueue.then(() => {
 			this.mediaHandler.cleanup();
 			this.processedConsumers.clear();
+			this.attachedProducerIds.clear();
 			this.isScreenShareActive = false;
 		});
 		this.cleanupPromise = terminalCleanup;

--- a/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
@@ -99,6 +99,7 @@ export class SFUMediaManager {
 	private getCurrentUserId: () => string | null;
 	private selectedProducerIds = new Map<string, string>();
 	private attachmentTails = new Map<string, Promise<void>>();
+	private closedProducerIds = new Set<string>();
 	private pendingSubscriptions: Map<string, Promise<unknown | null>> = new Map();
 	private resubscribeTimers = new Map<
 		ReturnType<typeof setTimeout>,
@@ -693,10 +694,12 @@ export class SFUMediaManager {
 					});
 				}
 			} catch (error) {
-				if (this.selectedProducerIds.get(key) === consumer.producerId) {
-					if (previousProducerId) this.selectedProducerIds.set(key, previousProducerId);
-					else this.selectedProducerIds.delete(key);
-				}
+				this.restoreSelectionAfterAttachmentFailure(
+					key,
+					participantId,
+					consumer.producerId,
+					previousProducerId,
+				);
 				console.error(
 					`Failed to attach video consumer for ${participantId}:`,
 					error,
@@ -721,10 +724,12 @@ export class SFUMediaManager {
 			try {
 				await this.videoManager.attachStream(participantId, stream, false);
 			} catch (error) {
-				if (this.selectedProducerIds.get(key) === consumer.producerId) {
-					if (previousProducerId) this.selectedProducerIds.set(key, previousProducerId);
-					else this.selectedProducerIds.delete(key);
-				}
+				this.restoreSelectionAfterAttachmentFailure(
+					key,
+					participantId,
+					consumer.producerId,
+					previousProducerId,
+				);
 				console.error(
 					`Failed to attach audio consumer for ${participantId}:`,
 					error,
@@ -750,10 +755,33 @@ export class SFUMediaManager {
 		return attachment;
 	}
 
+	private restoreSelectionAfterAttachmentFailure(
+		key: string,
+		participantId: string,
+		failedProducerId: string,
+		previousProducerId: string | undefined,
+	): void {
+		if (this.selectedProducerIds.get(key) !== failedProducerId) return;
+		if (previousProducerId && !this.closedProducerIds.has(previousProducerId)) {
+			this.selectedProducerIds.set(key, previousProducerId);
+			return;
+		}
+		this.selectedProducerIds.delete(key);
+		if (!previousProducerId) return;
+		this.selectedProducerIds.set(key, previousProducerId);
+		queueMicrotask(() => {
+			void this.reattachAfterProducerClosed(participantId, previousProducerId).catch(
+				(error) =>
+					console.warn("Failed to recover endpoint media after attachment error:", error),
+			);
+		});
+	}
+
 	async reattachAfterProducerClosed(
 		participantId: string,
 		producerId: string,
 	): Promise<void> {
+		this.closedProducerIds.add(producerId);
 		const consumers = this.consumerManager.getConsumersByParticipant(participantId);
 		for (const kind of ["audio", "video"] as const) {
 			const key = `${kind}:${participantId}`;
@@ -832,6 +860,7 @@ export class SFUMediaManager {
 			this.processedConsumers.clear();
 			this.selectedProducerIds.clear();
 			this.attachmentTails.clear();
+			this.closedProducerIds.clear();
 			this.isScreenShareActive = false;
 		});
 		this.cleanupPromise = terminalCleanup;

--- a/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnectionEvents.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnectionEvents.test.ts
@@ -30,7 +30,9 @@ function createManager({ e2eeRequired = false } = {}) {
 			clear: vi.fn(),
 			setEventHandlers: vi.fn(),
 			getConsumersByParticipant: vi.fn(() => []),
+			removeConsumer: vi.fn(),
 		},
+		reattachAfterProducerClosed: vi.fn().mockResolvedValue(undefined),
 		setEventHandlers: vi.fn(),
 	};
 	const transportManager = {
@@ -325,6 +327,56 @@ describe("ParticipantConnection", () => {
 
 		expect(participantManager.hasParticipant("remote-1")).toBe(false);
 		expect(mediaManager.subscribeToRemoteProducer).not.toHaveBeenCalled();
+	});
+
+	it("reattaches a surviving endpoint consumer when one producer closes", async () => {
+		const { handlers, manager, mediaManager } = createManager();
+		await manager.connect("token");
+		await handlers.get("producer_created")?.({
+			participantId: "remote-1",
+			producerId: "producer-1",
+			kind: "video",
+		});
+		await handlers.get("producer_created")?.({
+			participantId: "remote-1",
+			producerId: "producer-2",
+			kind: "video",
+		});
+		const closed = {
+			id: "consumer-1",
+			participantId: "remote-1",
+			producerId: "producer-1",
+			kind: "video",
+			isScreen: false,
+			consumer: { closed: false, producerId: "producer-1" },
+		};
+		const survivor = {
+			id: "consumer-2",
+			participantId: "remote-1",
+			producerId: "producer-2",
+			kind: "video",
+			isScreen: false,
+			consumer: { closed: false, producerId: "producer-2" },
+		};
+		let consumers = [closed, survivor];
+		mediaManager.consumerManager.getConsumersByParticipant.mockImplementation(
+			() => consumers,
+		);
+		mediaManager.consumerManager.removeConsumer.mockImplementation((id: string) => {
+			consumers = consumers.filter((entry) => entry.id !== id);
+		});
+
+		handlers.get("producer_closed")?.({
+			participantId: "remote-1",
+			producerId: "producer-1",
+		});
+
+		await vi.waitFor(() =>
+			expect(mediaManager.reattachAfterProducerClosed).toHaveBeenCalledWith(
+				"remote-1",
+				"producer-1",
+			),
+		);
 	});
 
 	it("preserves participant state during producer-only reconciliation", async () => {

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
@@ -355,6 +355,51 @@ describe("SFUMediaManager endpoint media handoff", () => {
 		expect(attach).not.toHaveBeenCalled();
 		vi.unstubAllGlobals();
 	});
+
+	it("lets a newer endpoint attachment win over an in-flight handoff", async () => {
+		const { mediaManager, consumerManager, videoManager } = createManager();
+		vi.stubGlobal("MediaStream", FakeMediaStream);
+		const firstAttachment = deferred<void>();
+		const closed = {
+			producerId: "producer-1",
+			kind: "video",
+			track: mediaTrack("track-1", "video"),
+		} as never;
+		const survivor = {
+			producerId: "producer-2",
+			kind: "video",
+			isScreen: false,
+			track: mediaTrack("track-2", "video"),
+			consumer: { closed: false },
+		} as never;
+		const newest = {
+			producerId: "producer-3",
+			kind: "video",
+			track: mediaTrack("track-3", "video"),
+		} as never;
+		await mediaManager.attachVideoConsumer("remote-1", closed);
+		videoManager.attachStream.mockClear();
+		consumerManager.getConsumersByParticipant.mockReturnValue([survivor]);
+		videoManager.attachStream
+			.mockImplementationOnce(() => firstAttachment.promise)
+			.mockResolvedValueOnce(undefined);
+
+		const handoff = mediaManager.reattachAfterProducerClosed(
+			"remote-1",
+			"producer-1",
+		);
+		await vi.waitFor(() => expect(videoManager.attachStream).toHaveBeenCalledOnce());
+		const newerAttachment = mediaManager.attachVideoConsumer("remote-1", newest);
+		firstAttachment.resolve();
+		await Promise.all([handoff, newerAttachment]);
+
+		expect(videoManager.attachStream).toHaveBeenCalledTimes(2);
+		expect(
+			(videoManager.attachStream.mock.calls[1][1] as FakeMediaStream)
+				.getVideoTracks()[0]?.id,
+		).toBe("track-3");
+		vi.unstubAllGlobals();
+	});
 });
 
 describe("SFUMediaManager.rebuildSendSide", () => {

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
@@ -400,6 +400,45 @@ describe("SFUMediaManager endpoint media handoff", () => {
 		).toBe("track-3");
 		vi.unstubAllGlobals();
 	});
+
+	it("retries handoff when a newer endpoint attachment fails", async () => {
+		const { mediaManager, consumerManager, videoManager } = createManager();
+		vi.stubGlobal("MediaStream", FakeMediaStream);
+		const closed = {
+			producerId: "producer-1",
+			kind: "video",
+			track: mediaTrack("track-1", "video"),
+		} as never;
+		const survivor = {
+			producerId: "producer-2",
+			kind: "video",
+			isScreen: false,
+			track: mediaTrack("track-2", "video"),
+			consumer: { closed: false },
+		} as never;
+		const failed = {
+			producerId: "producer-3",
+			kind: "video",
+			track: mediaTrack("track-3", "video"),
+		} as never;
+		await mediaManager.attachVideoConsumer("remote-1", closed);
+		videoManager.attachStream.mockClear();
+		consumerManager.getConsumersByParticipant.mockReturnValue([survivor]);
+		videoManager.attachStream
+			.mockRejectedValueOnce(new Error("attachment failed"))
+			.mockResolvedValueOnce(undefined);
+
+		const failedAttachment = mediaManager.attachVideoConsumer("remote-1", failed);
+		await mediaManager.reattachAfterProducerClosed("remote-1", "producer-1");
+		await expect(failedAttachment).rejects.toThrow("attachment failed");
+		await vi.waitFor(() => expect(videoManager.attachStream).toHaveBeenCalledTimes(2));
+
+		expect(
+			(videoManager.attachStream.mock.calls[1][1] as FakeMediaStream)
+				.getVideoTracks()[0]?.id,
+		).toBe("track-2");
+		vi.unstubAllGlobals();
+	});
 });
 
 describe("SFUMediaManager.rebuildSendSide", () => {

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
@@ -9,6 +9,8 @@ type MockTransportManager = {
 };
 type MockParticipantManager = {
 	hasParticipant: ReturnType<typeof vi.fn>;
+	getParticipant: ReturnType<typeof vi.fn>;
+	updateParticipant: ReturnType<typeof vi.fn>;
 };
 
 class FakeMediaStream {
@@ -96,6 +98,8 @@ function createManager(
 
 	const participantManager: MockParticipantManager = {
 		hasParticipant: vi.fn().mockReturnValue(opts.hasParticipant ?? true),
+		getParticipant: vi.fn().mockReturnValue({ video_enabled: true }),
+		updateParticipant: vi.fn(),
 	};
 
 	const getCurrentUserId = vi.fn().mockReturnValue(opts.currentUserId ?? "me");
@@ -305,6 +309,50 @@ describe("SFUMediaManager.attachAudioConsumer", () => {
 		await expect(mediaManager.attachAudioConsumer("remote-1", {
 			track: { kind: "audio" },
 		} as never)).rejects.toThrow("audio blocked");
+		vi.unstubAllGlobals();
+	});
+});
+
+describe("SFUMediaManager endpoint media handoff", () => {
+	it("reattaches the surviving consumer even when the closed consumer is already gone", async () => {
+		const { mediaManager, consumerManager } = createManager();
+		vi.stubGlobal("MediaStream", FakeMediaStream);
+		const closed = {
+			producerId: "producer-1",
+			kind: "video",
+			track: mediaTrack("track-1", "video"),
+		} as never;
+		const survivor = {
+			producerId: "producer-2",
+			kind: "video",
+			isScreen: false,
+			track: mediaTrack("track-2", "video"),
+			consumer: { closed: false },
+		} as never;
+		await mediaManager.attachVideoConsumer("remote-1", closed);
+		const attach = vi.spyOn(mediaManager, "attachVideoConsumer");
+		consumerManager.getConsumersByParticipant.mockReturnValue([survivor]);
+
+		await mediaManager.reattachAfterProducerClosed("remote-1", "producer-1");
+
+		expect(attach).toHaveBeenCalledWith("remote-1", survivor);
+		vi.unstubAllGlobals();
+	});
+
+	it("does not replace media when a non-attached endpoint closes", async () => {
+		const { mediaManager, consumerManager } = createManager();
+		vi.stubGlobal("MediaStream", FakeMediaStream);
+		await mediaManager.attachVideoConsumer("remote-1", {
+			producerId: "producer-1",
+			kind: "video",
+			track: mediaTrack("track-1", "video"),
+		} as never);
+		const attach = vi.spyOn(mediaManager, "attachVideoConsumer");
+		consumerManager.getConsumersByParticipant.mockReturnValue([]);
+
+		await mediaManager.reattachAfterProducerClosed("remote-1", "producer-2");
+
+		expect(attach).not.toHaveBeenCalled();
 		vi.unstubAllGlobals();
 	});
 });

--- a/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
@@ -1160,6 +1160,91 @@ describe('SocketHandlerManager characterization', () => {
 		});
 	});
 
+	it('reports a producer creation fault without broadcasting and allows retry', async () => {
+		const harness = createManager();
+		const publisher = connectFullSocket(harness, {
+			id: 'publisher-peer',
+			userId: 'publisher-1',
+		});
+		const viewer = connectFullSocket(harness, {
+			id: 'viewer-peer',
+			userId: 'viewer-1',
+		});
+		emitJoin(publisher, { userId: 'publisher-1', name: 'Publisher' });
+		emitJoin(viewer, { userId: 'viewer-1', name: 'Viewer' });
+		await new Promise((resolve) => setImmediate(resolve));
+		viewer.emitCalls.length = 0;
+		vi.mocked(harness.mediasoup.createProducer).mockRejectedValueOnce(
+			new Error('injected producer fault'),
+		);
+		const data = {
+			transportId: 'send-1',
+			rtpParameters: {},
+			kind: 'video',
+			appData: { type: 'camera' },
+		};
+		const failed = vi.fn();
+
+		publisher.fire('create_producer', data, failed);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(failed).toHaveBeenCalledWith({
+			success: false,
+			error: 'injected producer fault',
+		});
+		expect(viewer.emitCalls).not.toContainEqual(
+			expect.objectContaining({ event: 'producer_created' }),
+		);
+
+		const recovered = vi.fn();
+		publisher.fire('create_producer', data, recovered);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(recovered).toHaveBeenCalledWith(
+			expect.objectContaining({ success: true, id: 'producer-1' }),
+		);
+		expect(viewer.emitCalls).toContainEqual({
+			event: 'producer_created',
+			data: expect.objectContaining({ producerId: 'producer-1' }),
+		});
+	});
+
+	it('reports a consumer creation fault and allows the same request to retry', async () => {
+		const harness = createManager();
+		const viewer = connectFullSocket(harness, {
+			id: 'viewer-peer',
+			userId: 'viewer-1',
+		});
+		emitJoin(viewer, { userId: 'viewer-1', name: 'Viewer' });
+		await new Promise((resolve) => setImmediate(resolve));
+		vi.mocked(harness.mediasoup.createConsumer).mockRejectedValueOnce(
+			new Error('injected consumer fault'),
+		);
+		const data = {
+			transportId: 'recv-1',
+			producerId: 'producer-1',
+			rtpCapabilities: {},
+		};
+		const failed = vi.fn();
+
+		viewer.fire('create_consumer', data, failed);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(failed).toHaveBeenCalledWith({
+			success: false,
+			error: 'injected consumer fault',
+		});
+
+		const recovered = vi.fn();
+		viewer.fire('create_consumer', data, recovered);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(recovered).toHaveBeenCalledWith(
+			expect.objectContaining({ success: true, id: 'consumer-1' }),
+		);
+		expect(harness.mediasoup.createConsumer).toHaveBeenCalledTimes(2);
+	});
+
 	it('propagates producer lifecycle closure and targets dependent consumers', async () => {
 		const harness = createManager();
 		const publisher = connectFullSocket(harness, {

--- a/suite/meet/sfu-server/src/server/__tests__/test-helpers.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/test-helpers.ts
@@ -220,6 +220,18 @@ function createMockMediasoupManager(): MediasoupManager {
 			kind: 'video',
 			appData: { type: 'screen' },
 		}),
+		getProducer: vi.fn().mockReturnValue({
+			id: 'producer-1',
+			kind: 'video',
+			appData: { type: 'camera' },
+		}),
+		createConsumer: vi.fn().mockResolvedValue({
+			id: 'consumer-1',
+			producerId: 'producer-1',
+			kind: 'video',
+			rtpParameters: {},
+			paused: false,
+		}),
 		applyMediaControl: vi.fn(),
 	} as unknown as MediasoupManager;
 }


### PR DESCRIPTION
## Summary
- add deterministic browser faults for ended capture, zero-byte RTP observations, and decode stalls while monitoring unaffected media
- cover SFU producer and consumer creation failures through signaling retries
- hand off attached media to a surviving Participant Connection when another endpoint closes