### PR TITLE
test(meet): cover browser lifecycle recovery

### DIFF
--- a/e2e/meet/fixtures/media.ts
+++ b/e2e/meet/fixtures/media.ts
@@ -125,9 +125,9 @@ export const MEDIA_FAULT_SCRIPT = `(() => {
 			const hiddenChanged = lifecycle.hidden !== next.hidden;
 			const onlineChanged = lifecycle.online !== next.online;
 			lifecycle.hidden = next.hidden;
+			if (hiddenChanged) document.dispatchEvent(new Event("visibilitychange"));
 			lifecycle.online = next.online;
 			if (onlineChanged) window.dispatchEvent(new Event(next.online ? "online" : "offline"));
-			if (hiddenChanged) document.dispatchEvent(new Event("visibilitychange"));
 		},
 	};
 })();`;

--- a/e2e/meet/fixtures/media.ts
+++ b/e2e/meet/fixtures/media.ts
@@ -45,6 +45,18 @@ export const MEDIA_FAULT_SCRIPT = `(() => {
 	const localTracks = { audio: [], video: [] };
 	const peerConnections = [];
 	const pendingReceiverFaults = [];
+	const lifecycle = { hidden: document.hidden, online: navigator.onLine };
+	Object.defineProperties(document, {
+		hidden: { configurable: true, get: () => lifecycle.hidden },
+		visibilityState: {
+			configurable: true,
+			get: () => (lifecycle.hidden ? "hidden" : "visible"),
+		},
+	});
+	Object.defineProperty(navigator, "onLine", {
+		configurable: true,
+		get: () => lifecycle.online,
+	});
 	const injectReceiverStats = (receiver, fault) => {
 		const originalGetStats = receiver.getStats.bind(receiver);
 		receiver.getStats = async () => {
@@ -108,6 +120,14 @@ export const MEDIA_FAULT_SCRIPT = `(() => {
 		},
 		armNextVideoReceiverFault(fault) {
 			pendingReceiverFaults.push(fault);
+		},
+		setBrowserLifecycle(next) {
+			const hiddenChanged = lifecycle.hidden !== next.hidden;
+			const onlineChanged = lifecycle.online !== next.online;
+			lifecycle.hidden = next.hidden;
+			lifecycle.online = next.online;
+			if (onlineChanged) window.dispatchEvent(new Event(next.online ? "online" : "offline"));
+			if (hiddenChanged) document.dispatchEvent(new Event("visibilitychange"));
 		},
 	};
 })();`;

--- a/e2e/meet/helpers/faults.ts
+++ b/e2e/meet/helpers/faults.ts
@@ -130,6 +130,17 @@ export async function armNextRemoteVideoFault(
 	}, fault);
 }
 
+export async function setBrowserLifecycle(
+	page: Page,
+	state: { hidden: boolean; online: boolean },
+): Promise<void> {
+	await page.evaluate((next) => {
+		if (!window.__meetMediaFaults)
+			throw new Error("Media fault bridge unavailable");
+		window.__meetMediaFaults.setBrowserLifecycle(next);
+	}, state);
+}
+
 export async function expectRemoteTrackReplaced(
 	page: Page,
 	participantName: string,
@@ -152,6 +163,7 @@ declare global {
 			stopLatestLocalTrack(kind: MediaKind): string | null;
 			injectReceiverStats(trackId: string, fault: ReceiverFault): Promise<boolean>;
 			armNextVideoReceiverFault(fault: ReceiverFault): void;
+			setBrowserLifecycle(state: { hidden: boolean; online: boolean }): void;
 		};
 	}
 }

--- a/e2e/meet/specs/media-fault-recovery.spec.ts
+++ b/e2e/meet/specs/media-fault-recovery.spec.ts
@@ -6,6 +6,7 @@ import {
 	injectRemoteVideoFault,
 	monitorRemoteVideoContinuity,
 	readRemoteVideoProgress,
+	setBrowserLifecycle,
 	stopLatestLocalTrack,
 } from "../helpers/faults";
 import { expectRemoteVideoReceiving } from "../helpers/media";
@@ -124,6 +125,59 @@ test.describe("Media fault recovery", () => {
 			} finally {
 				await controlMonitor.stop();
 			}
+		},
+	);
+
+	test(
+		"defers media repair while hidden and offline, then recovers on resume",
+		{ tag: "@meet-group-3" },
+		async ({ hostPage, createMeeting, createParticipant }) => {
+			test.setTimeout(120_000);
+			const meetingId = await createMeeting();
+			const target = await createParticipant();
+			const control = await createParticipant();
+			await Promise.all([
+				(async () => {
+					await hostPage.goto(appUrl(`/meet/${meetingId}`));
+					await joinFromPreview(hostPage);
+				})(),
+				target.joinAsGuest(meetingId, "Fault Target"),
+				control.joinAsGuest(meetingId, "Healthy Control"),
+			]);
+			await Promise.all([
+				expectRemoteVideoReceiving(hostPage, "Fault Target"),
+				expectRemoteVideoReceiving(hostPage, "Healthy Control"),
+			]);
+			await hostPage.waitForTimeout(3500);
+			const targetBaseline = await readRemoteVideoProgress(
+				hostPage,
+				"Fault Target",
+			);
+			const controlBaseline = await readRemoteVideoProgress(
+				hostPage,
+				"Healthy Control",
+			);
+
+			await setBrowserLifecycle(hostPage, { hidden: true, online: false });
+			await injectRemoteVideoFault(hostPage, "Fault Target", "decode-stall");
+			await hostPage.waitForTimeout(7000);
+			expect(
+				(await readRemoteVideoProgress(hostPage, "Fault Target")).trackId,
+			).toBe(targetBaseline.trackId);
+
+			await setBrowserLifecycle(hostPage, { hidden: false, online: true });
+			await expectRemoteTrackReplaced(
+				hostPage,
+				"Fault Target",
+				targetBaseline.trackId,
+			);
+			await Promise.all([
+				expectRemoteVideoReceiving(hostPage, "Fault Target"),
+				expectRemoteVideoReceiving(hostPage, "Healthy Control"),
+			]);
+			expect(
+				(await readRemoteVideoProgress(hostPage, "Healthy Control")).trackId,
+			).toBe(controlBaseline.trackId);
 		},
 	);
 });


### PR DESCRIPTION
## What changed
- add deterministic browser visibility and connectivity controls to the Meet media fault bridge
- verify decode-stall recovery is suspended while hidden/offline
- verify resume recreates only the affected consumer and preserves healthy media

## Verification
- focused lifecycle Playwright scenario: 1 passed
- complete media fault recovery Playwright file: 4 passed in 1.9m
- `yarn typecheck` in `e2e`
- Meet type policy
- commit hooks, including E2E Knip