### PR TITLE
test(meet): move lifecycle recovery to group 2

### DIFF
--- a/e2e/meet/specs/media-fault-recovery.spec.ts
+++ b/e2e/meet/specs/media-fault-recovery.spec.ts
@@ -130,7 +130,7 @@ test.describe("Media fault recovery", () => {
 
 	test(
 		"defers media repair while hidden and offline, then recovers on resume",
-		{ tag: "@meet-group-3" },
+		{ tag: "@meet-group-2" },
 		async ({ hostPage, createMeeting, createParticipant }) => {
 			test.setTimeout(120_000);
 			const meetingId = await createMeeting();


### PR DESCRIPTION
## What changed
- move the browser lifecycle recovery scenario from Meet E2E group 3 to group 2

## Why
The post-merge run measured group 3 at 4m00s and group 2 at 3m13s. The lifecycle scenario takes approximately 53 seconds, so group 2 is the better assignment.

## Verification
- group 2 selection lists the lifecycle scenario
- group 3 selection excludes it
- `yarn typecheck` in `e2e`
- commit hooks, including E2E Knip and Meet type policy