### PR TITLE
fix(calendar): show emails in participant search

### DIFF
--- a/frontend/src/apps/calendar/components/ParticipantSelector.vue
+++ b/frontend/src/apps/calendar/components/ParticipantSelector.vue
@@ -156,7 +156,7 @@ const removeParticipant = (email: string) => {
 				@keyup.enter="handleParticipantEnter($event)"
 			>
 				<template #item-prefix="{ item }">
-					<Avatar :image="item.user_image" :label="item.description || item.label" size="sm" />
+					<Avatar :image="item.user_image" :label="item.description || item.label" size="md" />
 				</template>
 			</Combobox>
 		</div>

--- a/frontend/src/apps/calendar/components/ParticipantSelector.vue
+++ b/frontend/src/apps/calendar/components/ParticipantSelector.vue
@@ -155,19 +155,8 @@ const removeParticipant = (email: string) => {
 				@update:model-value="handleParticipantSelect($event)"
 				@keyup.enter="handleParticipantEnter($event)"
 			>
-				<template #item-label="{ item }">
-					<div class="min-w-0">
-						<div class="truncate">{{ item.label }}</div>
-						<div v-if="item.description" class="mt-1 flex items-center gap-1.5 text-p-sm text-ink-gray-5">
-							<Avatar
-								:image="item.user_image"
-								:label="item.description"
-								size="sm"
-								class="shrink-0"
-							/>
-							<span class="truncate">{{ item.description }}</span>
-						</div>
-					</div>
+				<template #item-prefix="{ item }">
+					<Avatar :image="item.user_image" :label="item.description || item.label" size="sm" />
 				</template>
 			</Combobox>
 		</div>

--- a/frontend/src/apps/calendar/components/ParticipantSelector.vue
+++ b/frontend/src/apps/calendar/components/ParticipantSelector.vue
@@ -14,6 +14,7 @@ interface ContactSuggestion {
 interface ContactOption extends ContactSuggestion {
 	label: string
 	value: string
+	description?: string
 }
 
 const props = withDefaults(
@@ -47,8 +48,9 @@ const mailContacts = createResource({
 	transform: (data: ContactSuggestion[]): ContactOption[] =>
 		data.map((contact) => ({
 			...contact,
-			label: contact.name || contact.email,
+			label: contact.email,
 			value: contact.email,
+			description: contact.name || undefined,
 		})),
 })
 
@@ -147,6 +149,7 @@ const removeParticipant = (email: string) => {
 				v-model:open="showSuggestions"
 				class="w-full"
 				:options="options"
+				:filterable="false"
 				:placeholder="placeholder"
 				@update:query="handleInput($event)"
 				@update:model-value="handleParticipantSelect($event)"

--- a/frontend/src/apps/calendar/components/ParticipantSelector.vue
+++ b/frontend/src/apps/calendar/components/ParticipantSelector.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from 'vue'
 import { useDebounceFn } from '@vueuse/core'
-import { Combobox, createResource, toast } from 'frappe-ui'
+import { Avatar, Combobox, createResource, toast } from 'frappe-ui'
 
 import EventParticipantList from '@/apps/calendar/components/EventParticipantList.vue'
 
@@ -154,7 +154,22 @@ const removeParticipant = (email: string) => {
 				@update:query="handleInput($event)"
 				@update:model-value="handleParticipantSelect($event)"
 				@keyup.enter="handleParticipantEnter($event)"
-			/>
+			>
+				<template #item-label="{ item }">
+					<div class="min-w-0">
+						<div class="truncate">{{ item.label }}</div>
+						<div v-if="item.description" class="mt-1 flex items-center gap-1.5 text-p-sm text-ink-gray-5">
+							<Avatar
+								:image="item.user_image"
+								:label="item.description"
+								size="sm"
+								class="shrink-0"
+							/>
+							<span class="truncate">{{ item.description }}</span>
+						</div>
+					</div>
+				</template>
+			</Combobox>
 		</div>
 		<div class="max-h-[32rem] space-y-4 overflow-y-auto">
 			<EventParticipantList


### PR DESCRIPTION
## Summary

Show participant email addresses as the primary autocomplete label, with contact names as secondary descriptions and avatars alongside both lines. Keep server-ranked name and email search results from being filtered again in the browser.