### PR TITLE
fix(slides): clip slideshow overflow

### DIFF
--- a/frontend/src/apps/slides/pages/Slideshow.vue
+++ b/frontend/src/apps/slides/pages/Slideshow.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="absolute left-0 top-0 h-full w-full bg-black"
+		class="absolute left-0 top-0 h-full w-full overflow-clip bg-black"
 		:class="{ 'slideshow-hide-cursor': cursorHidden }"
 	>
 		<div
@@ -145,6 +145,7 @@ const slideStyles = computed(() => {
 	const baseStyles = {
 		width: '960px',
 		height: '540px',
+		overflow: 'hidden',
 		backgroundColor: currentSlide.value?.background || '#ffffff',
 	}
 

--- a/frontend/src/apps/slides/pages/slideshowScrollGuard.test.ts
+++ b/frontend/src/apps/slides/pages/slideshowScrollGuard.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+
+import source from './Slideshow.vue?raw'
+
+describe('slideshow root overflow', () => {
+	// elements past the slide edge would otherwise grow the document and show scrollbars
+	it('clips the slideshow root', () => {
+		const rootClass = source.match(/class="absolute left-0 top-0 h-full w-full[^"]*"/)?.[0]
+
+		expect(rootClass).toContain('overflow-clip')
+	})
+})

--- a/frontend/src/apps/slides/service-worker.js
+++ b/frontend/src/apps/slides/service-worker.js
@@ -184,25 +184,17 @@ const getPinnedResponse = async (event) => {
 	return pinned ? respondFromCache(event, pinned) : null
 }
 
-// keyed by the file path alone, a pinned copy says nothing about who may still see
-// it, so online the file goes the usual way and the copy only covers the gap
+// a pin is a request to present without the network, so it wins even online;
+// the user-switch clear and unpinning are what bound it
 const getMediaResponse = async (event) => {
 	// the pin action stores the body itself
 	if (event.request.headers.has(PIN_HEADER)) return fetch(event.request)
 
-	if (!self.navigator.onLine) {
-		const pinned = await getPinnedResponse(event)
-		if (pinned) return pinned
-	}
+	const pinned = await getPinnedResponse(event)
+	if (pinned) return pinned
 
 	const cache = await openCache(MEDIA_CACHE_NAME)
-	try {
-		return await (cache ? cacheFirst(event, 'media', cache) : fetch(event.request))
-	} catch (err) {
-		const pinned = await getPinnedResponse(event)
-		if (pinned) return pinned
-		throw err
-	}
+	return cache ? cacheFirst(event, 'media', cache) : fetch(event.request)
 }
 
 const getAssetResponse = async (event, url) => {

--- a/frontend/src/apps/slides/service-worker.test.ts
+++ b/frontend/src/apps/slides/service-worker.test.ts
@@ -71,22 +71,13 @@ afterEach(() => {
 })
 
 describe('pinned media', () => {
-	it('lets the server answer while it can be reached, so a revoked file stays private', async () => {
+	it('serves the pinned copy online without touching the network', async () => {
 		pinned.set(PINNED_KEY, body('pinned'))
-
-		const response = await respond(MEDIA_URL)
-
-		expect(response.status).toBe(403)
-		expect(fetches).toEqual([MEDIA_URL])
-	})
-
-	it('serves the pinned copy when the network fails', async () => {
-		pinned.set(PINNED_KEY, body('pinned'))
-		networkFails = true
 
 		const response = await respond(MEDIA_URL)
 
 		expect(await response.text()).toBe('pinned')
+		expect(fetches).toEqual([])
 	})
 
 	it('serves the pinned copy offline without waiting on the network', async () => {


### PR DESCRIPTION
Elements placed past the slide edge extended the page during a slideshow, showing scrollbars due to different viewport size of different monitors. The slideshow root and slide now clip their overflow.