### PR TITLE
feat(mail): pick the reply identity from the original message's recipients

### DIFF
--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -1285,6 +1285,7 @@ const getSourceMail = (mail: string) =>
 	thread.value.find((m: Mail) => m.name === mail.split(':')[1])
 
 const getReplyDetails = (mail: Mail) => ({
+	from_email: getReplyIdentityEmail(mail),
 	subject: mail.subject?.startsWith('Re: ') ? mail.subject : `Re: ${mail.subject}`,
 	quoted_content: getQuotedContent(mail),
 	attachments: mail.attachments?.filter((a: Attachment) => a.disposition === 'inline') || [],
@@ -1314,6 +1315,14 @@ const getReplyAllRecipients = (mail: Mail) => {
 
 const isUserEmail = (email: string) =>
 	identities.value.data?.map((i: Identity) => i.email).includes(email)
+
+// The identity a reply should go out as: the one the message was addressed to (the sender,
+// when the message is our own). Undefined when no identity took part, and the composer falls
+// back to the account's default outgoing address, then its first identity.
+const getReplyIdentityEmail = (mail: Mail) => {
+	const { to = [], cc = [], bcc = [] } = mail.groupedRecipients ?? {}
+	return [mail.from_email, ...[...to, ...cc, ...bcc].map((r) => r.email)].find(isUserEmail)
+}
 
 // The plain-text reading of a body, normalised. Servers hand some bodies over already
 // entity-escaped, and those carry no real tags — so they take this path, where showing

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -1313,15 +1313,22 @@ const getReplyAllRecipients = (mail: Mail) => {
 		}
 }
 
-const isUserEmail = (email: string) =>
-	identities.value.data?.map((i: Identity) => i.email).includes(email)
+// Addresses arrive in whatever casing the other side used: match case-insensitively, and hand
+// back the identity's own spelling, since the composer looks the address up by that.
+const getIdentityEmail = (email?: string) =>
+	identities.value.data?.find((i: Identity) => i.email.toLowerCase() === email?.toLowerCase())
+		?.email
+
+const isUserEmail = (email: string) => !!getIdentityEmail(email)
 
 // The identity a reply should go out as: the one the message was addressed to (the sender,
 // when the message is our own). Undefined when no identity took part, and the composer falls
 // back to the account's default outgoing address, then its first identity.
 const getReplyIdentityEmail = (mail: Mail) => {
 	const { to = [], cc = [], bcc = [] } = mail.groupedRecipients ?? {}
-	return [mail.from_email, ...[...to, ...cc, ...bcc].map((r) => r.email)].find(isUserEmail)
+	return getIdentityEmail(
+		[mail.from_email, ...[...to, ...cc, ...bcc].map((r) => r.email)].find(isUserEmail),
+	)
 }
 
 // The plain-text reading of a body, normalised. Servers hand some bodies over already

--- a/frontend/src/apps/mail/composables/useComposeMail.ts
+++ b/frontend/src/apps/mail/composables/useComposeMail.ts
@@ -101,10 +101,13 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 	const getDefaultFromEmail = () => {
 		const identityEmails = identities.value.data?.map((i: Identity) => i.email) ?? []
 		const defaultOutgoingEmail = scope.account.value?.default_outgoing_email
+		// Matched case-insensitively; the identity's own spelling is what goes out.
+		const identityMatching = (email?: string) =>
+			identityEmails.find((e) => e.toLowerCase() === email?.toLowerCase())
 
 		return (
-			identityEmails.find((e) => e === mailDetails?.from_email) ??
-			identityEmails.find((e) => e === defaultOutgoingEmail) ??
+			identityMatching(mailDetails?.from_email) ??
+			identityMatching(defaultOutgoingEmail) ??
 			identityEmails[0] ??
 			// An account with no identities at all still has to send as somebody.
 			user.data.name


### PR DESCRIPTION
Closes #687

When replying from an account with several identities, the From address was always the default identity. Now a reply (and reply-all) is sent as the identity the original message was addressed to — or sent from, when replying to our own message. If none of the identities took part, the composer keeps its existing fallback: the account's default outgoing email, then the first identity. Compose already followed that default → first rule.