### PR TITLE
fix(slides): save slides by client_id with conflict detection

### DIFF
--- a/frontend/src/apps/slides/SlidesShell.vue
+++ b/frontend/src/apps/slides/SlidesShell.vue
@@ -13,7 +13,7 @@ import { h, onMounted, onUnmounted, provide, ref, watch } from 'vue'
 import { onBeforeRouteLeave } from 'vue-router'
 import { toast, FrappeUIProvider } from 'frappe-ui'
 import { Wifi, WifiOff } from 'lucide-vue-next'
-import { saveCurrentState } from '@/apps/slides/stores/saving'
+import { saveChanges } from '@/apps/slides/stores/saving'
 import { inSlideShowMode } from '@/apps/slides/stores/slideshow'
 import { setupTheme } from '@/utils/setupTheme'
 import { postToServiceWorker } from '@/apps/slides/utils/serviceWorker'
@@ -32,7 +32,7 @@ const handleOffline = () => {
 
 const handleOnline = () => {
   isOnline.value = true
-  saveCurrentState()
+  saveChanges()
   if (inSlideShowMode.value) return
   toast('You are back online.', {
     icon: () => h(Wifi, { class: 'size-4' }),

--- a/frontend/src/apps/slides/pages/PresentationEditor.vue
+++ b/frontend/src/apps/slides/pages/PresentationEditor.vue
@@ -109,7 +109,7 @@ import {
 } from '@/apps/slides/stores/historyMeta'
 
 import { useShortcuts, showShortcutsModal } from '@/apps/slides/composables/useShortcuts'
-import { saveChanges, saveCurrentState, dirty } from '@/apps/slides/stores/saving'
+import { saveChanges, dirty } from '@/apps/slides/stores/saving'
 import {
 	refreshOfflineStatus,
 	warmOfflineCopyAssets,
@@ -248,7 +248,7 @@ const handleBeforeUnmount = () => {
 
 	if (router.currentRoute.value.name !== 'slides-slideshow') {
 		resetFocus()
-		saveCurrentState()
+		saveChanges()
 	}
 	window.removeEventListener('beforeunload', handleBeforeUnload)
 	window.removeEventListener('popstate', hideOpenDialogs)

--- a/frontend/src/apps/slides/pages/PresentationEditor.vue
+++ b/frontend/src/apps/slides/pages/PresentationEditor.vue
@@ -87,6 +87,7 @@ import {
 	duplicatePresentation,
 	confirmDeletePresentation,
 	presentationTheme,
+	adoptServerVersion,
 	resetEditorState,
 	pageTitle,
 } from '@/apps/slides/stores/presentation'
@@ -356,21 +357,16 @@ const updatePresentationTheme = async (theme) => {
 	showThemeDialog.value = false
 
 	try {
-		const doc = await call('frappe.client.set_value', {
-			doctype: 'Presentation',
+		const doc = await call('suite.slides.doctype.presentation.presentation.update_theme', {
 			name: id,
-			fieldname: 'theme',
-			value: theme,
+			theme: theme,
 		})
 
-		// the editor can move on mid-request; writing then would apply the theme
-		// and the modified stamp to a different presentation
+		// the editor can move to another presentation mid-request
 		if (presentationDoc.value?.name !== id) return
 
 		presentationDoc.value.theme = theme
-		// autosave stamps this onto the local copy, so a stale value would make the
-		// next load discard edits that had not synced yet
-		presentationDoc.value.modified = doc.modified
+		await adoptServerVersion(id, doc)
 	} catch (error) {
 		console.error('Failed to update theme: ', error)
 		toast.error('Could not update the theme. Please try again.')

--- a/frontend/src/apps/slides/stores/commands.js
+++ b/frontend/src/apps/slides/stores/commands.js
@@ -130,8 +130,6 @@ const addSlideCommand = ({ slide, index, slideIndex }) => ({
 	fromSlideIndex: slideIndex,
 	debug: `Add slide ${slide.clientId} at index ${index}`,
 	execute(state) {
-		// a name carried over from another row would make the next save update it
-		slide.name = ''
 		addSlide(state, index, slide)
 	},
 	undo(state) {
@@ -148,8 +146,6 @@ const removeSlideCommand = ({ slide, index, slideIndex }) => ({
 		removeSlide(state, index, slide)
 	},
 	undo(state) {
-		// autosave may already have deleted the row, so the next save has to insert it
-		slide.name = ''
 		addSlide(state, index, slide)
 	},
 })

--- a/frontend/src/apps/slides/stores/commands.test.ts
+++ b/frontend/src/apps/slides/stores/commands.test.ts
@@ -9,29 +9,14 @@ vi.mock('@/apps/slides/utils/helpers', () => ({
 	cloneObj: (obj: any) => JSON.parse(JSON.stringify(obj)),
 }))
 
-const { addSlideCommand, removeSlideCommand } = await import('./commands')
+const { removeSlideCommand } = await import('./commands')
 
-const makeSlide = (clientId: string, name: string) => ({ clientId, name, elements: [] })
+const makeSlide = (clientId: string) => ({ clientId, elements: [] })
 
 describe('removeSlideCommand', () => {
-	it('drops the child row name so undo re-inserts a slide autosave already deleted', () => {
-		const slide = makeSlide('c2', 'srv-row-2')
-		const state = [makeSlide('c1', 'srv-row-1'), slide]
-
-		const command = removeSlideCommand({ slide, index: 1, slideIndex: 1 })
-		command.execute(state)
-		expect(state).toHaveLength(1)
-
-		command.undo(state)
-
-		expect(state).toHaveLength(2)
-		expect(state[1].clientId).toBe('c2')
-		expect(state[1].name).toBe('')
-	})
-
 	it('keeps the restored slide at its original index', () => {
-		const slide = makeSlide('c1', 'srv-row-1')
-		const state = [slide, makeSlide('c2', 'srv-row-2'), makeSlide('c3', 'srv-row-3')]
+		const slide = makeSlide('c1')
+		const state = [slide, makeSlide('c2'), makeSlide('c3')]
 
 		const command = removeSlideCommand({ slide, index: 0, slideIndex: 0 })
 		command.execute(state)
@@ -41,16 +26,4 @@ describe('removeSlideCommand', () => {
 		expect(state.map((s) => s.idx)).toEqual([1, 2, 3])
 	})
 })
-
-describe('addSlideCommand', () => {
-	it('never inserts a slide under a child row name it was handed', () => {
-		// pasted slides come from json, so the name is not ours to trust
-		const slide = makeSlide('c2', 'srv-row-2')
-		const state = [makeSlide('c1', 'srv-row-1')]
-
-		addSlideCommand({ slide, index: 1, slideIndex: 0 }).execute(state)
-
-		expect(state).toHaveLength(2)
-		expect(state[1].name).toBe('')
-	})
 })

--- a/frontend/src/apps/slides/stores/commands.test.ts
+++ b/frontend/src/apps/slides/stores/commands.test.ts
@@ -26,4 +26,3 @@ describe('removeSlideCommand', () => {
 		expect(state.map((s) => s.idx)).toEqual([1, 2, 3])
 	})
 })
-})

--- a/frontend/src/apps/slides/stores/presentation.js
+++ b/frontend/src/apps/slides/stores/presentation.js
@@ -278,28 +278,44 @@ const getReadonlyPresentationResource = (name, url) => {
 	})
 }
 
+// rows are matched by client_id on the server, so name, parent and idx stay out
+const toSlideRow = (slide) => ({
+	client_id: slide.clientId,
+	background: slide.background,
+	elements: slide.corruptElements ?? JSON.stringify(slide.elements, null, 2),
+	transition: slide.transition,
+	transition_duration: slide.transitionDuration,
+	fade_unmatched_elements: slide.fadeUnmatchedElements,
+})
+
+const isSaveConflict = (error) => error?.exc_type === 'TimestampMismatchError'
+
 const savePresentationDoc = async (updatedSlides) => {
-	const newSlides = updatedSlides.map((slide) => {
-		const { thumbnail, corruptElements, ...slideData } = slide
-		return {
-			...slideData,
-			client_id: slide.clientId,
-			elements: corruptElements ?? JSON.stringify(slide.elements, null, 2),
-			transition_duration: slide.transitionDuration,
-			fade_unmatched_elements: slide.fadeUnmatchedElements,
-		}
+	const doc = presentationDoc.value
+	// the server refuses a snapshot built on an older version than it holds, which
+	// is what keeps a stale tab from wiping rows another editor saved since
+	const { modified } = await call('suite.slides.api.slides.save_slides', {
+		name: doc.name,
+		slides: updatedSlides.map(toSlideRow),
+		base_modified: doc.modified,
 	})
 
+	// the editor can move on mid-save; stamping then would mark another
+	// presentation with this save's version
+	if (presentationDoc.value === doc) doc.modified = modified
+
+	return modified
+}
+
+// another editor saved first: their version is the truth now, so take it in
+// place of the local snapshot rather than fight over whose rows survive
+const reloadAfterConflict = async (id) => {
+	if (presentationId.value !== id) return
+	toast.warning('This presentation was changed elsewhere. Showing the latest version.')
 	const resource = presentationResource.value
-	const doc = await resource.setValue.submit({
-		slides: newSlides,
-	})
-
-	// the editor can move on mid-save, and repointing presentationDoc at whatever
-	// the resource ref holds now would stamp this save onto another presentation
+	await resource.get.fetch()
+	// the fetch replaces resource.doc, and the next save reads its version from here
 	if (presentationResource.value === resource) presentationDoc.value = resource.doc
-
-	return doc?.modified
 }
 
 const presentationResource = ref(null)
@@ -409,6 +425,8 @@ export {
 	inReadonlyMode,
 	updatePresentationTitle,
 	savePresentationDoc,
+	isSaveConflict,
+	reloadAfterConflict,
 	initPresentationDoc,
 	deletePresentation,
 	confirmDeletePresentation,

--- a/frontend/src/apps/slides/stores/presentation.js
+++ b/frontend/src/apps/slides/stores/presentation.js
@@ -315,7 +315,10 @@ const reloadAfterConflict = async (id) => {
 	const resource = presentationResource.value
 	await resource.get.fetch()
 	// the fetch replaces resource.doc, and the next save reads its version from here
-	if (presentationResource.value === resource) presentationDoc.value = resource.doc
+	if (presentationResource.value !== resource) return
+	presentationDoc.value = resource.doc
+	// undo still holds the discarded content and would save it right back
+	commandHistory.clearHistory()
 }
 
 const presentationResource = ref(null)

--- a/frontend/src/apps/slides/stores/presentation.js
+++ b/frontend/src/apps/slides/stores/presentation.js
@@ -42,16 +42,23 @@ const createPresentationResource = createResource({
 })
 
 const updatePresentationTitle = async (id, newTitle) => {
-	return call('suite.slides.doctype.presentation.presentation.update_title', {
+	const response = await call('suite.slides.doctype.presentation.presentation.update_title', {
 		name: id,
 		title: newTitle,
-	}).then((response) => {
-		if (!response) throw new Error('Failed to rename presentation')
-		// autosave stamps this onto the local copy, so a stale value would make the
-		// next load discard edits that had not synced yet
-		if (presentationDoc.value?.name === id) presentationDoc.value.modified = response.modified
-		return response.slug
 	})
+	if (!response) throw new Error('Failed to rename presentation')
+	await adoptServerVersion(id, response)
+	return response.slug
+}
+
+// adopting a stamp over a stale base would let the next save wipe rows saved elsewhere
+const adoptServerVersion = async (id, { modified, base_modified }) => {
+	if (presentationDoc.value?.name !== id) return
+	if (presentationDoc.value.modified === base_modified) {
+		presentationDoc.value.modified = modified
+	} else {
+		await reloadAfterConflict(id)
+	}
 }
 
 const getElementDimensions = async (el) => {
@@ -427,6 +434,7 @@ export {
 	presentationTheme,
 	inReadonlyMode,
 	updatePresentationTitle,
+	adoptServerVersion,
 	savePresentationDoc,
 	isSaveConflict,
 	reloadAfterConflict,

--- a/frontend/src/apps/slides/stores/saving.js
+++ b/frontend/src/apps/slides/stores/saving.js
@@ -2,6 +2,8 @@ import { ref } from 'vue'
 import {
 	presentationId,
 	savePresentationDoc,
+	isSaveConflict,
+	reloadAfterConflict,
 	presentationDoc,
 	inReadonlyMode,
 } from '@/apps/slides/stores/presentation'
@@ -156,8 +158,19 @@ const syncPresentationToServer = async (id, generation) => {
 	const snapshot = await getPresentationFromLocalDB(id)
 	if (!snapshot || !snapshot.dirty) return
 
-	// throws on failure so the caller keeps the state dirty and retries
-	await syncSnapshotToServer(snapshot, id, generation)
+	try {
+		// throws on failure so the caller keeps the state dirty and retries
+		await syncSnapshotToServer(snapshot, id, generation)
+	} catch (error) {
+		if (!isSaveConflict(error)) throw error
+		await discardSnapshot(snapshot, id)
+	}
+}
+
+// a refused snapshot can never be retried: the server's version replaces it
+const discardSnapshot = async (snapshot, id) => {
+	await savePresentationToLocalDB({ ...snapshot, dirty: false, updatedAt: Date.now() })
+	await reloadAfterConflict(id)
 }
 
 const getLatestSlideContent = () => {

--- a/frontend/src/apps/slides/stores/saving.test.ts
+++ b/frontend/src/apps/slides/stores/saving.test.ts
@@ -7,12 +7,15 @@ const inReadonlyMode = ref(false)
 const slides = ref<any[]>([{ clientId: 'c1', background: '#ff0000ff', elements: [] }])
 
 let serverSave: (content: any) => Promise<string | undefined>
+const reloadAfterConflict = vi.fn(async () => {})
 
 vi.mock('@/apps/slides/stores/presentation', () => ({
 	presentationId,
 	presentationDoc,
 	inReadonlyMode,
 	savePresentationDoc: (content: any) => serverSave(content),
+	isSaveConflict: (error: any) => error?.exc_type === 'TimestampMismatchError',
+	reloadAfterConflict,
 }))
 
 vi.mock('@/apps/slides/stores/slide', () => ({ slides }))
@@ -21,10 +24,12 @@ vi.mock('@/apps/slides/utils/helpers', () => ({
 	cloneObj: (obj: any) => JSON.parse(JSON.stringify(obj)),
 }))
 
-const { saveCurrentState, markDirty, dirty, getPresentationFromLocalDB } = await import('./saving')
+const { saveCurrentState, markDirty, dirty, saveFailed, getPresentationFromLocalDB } =
+	await import('./saving')
 
 describe('saveCurrentState', () => {
 	beforeEach(() => {
+		reloadAfterConflict.mockClear()
 		presentationId.value = 'p1'
 		presentationDoc.value = { modified: 'M1' }
 		slides.value = [{ clientId: 'c1', background: '#ff0000ff', elements: [] }]
@@ -102,5 +107,22 @@ describe('saveCurrentState', () => {
 		expect(dirty.value).toBe(false)
 		expect(local.dirty).toBe(false)
 		expect(local.baseModified).toBe('M2')
+	})
+
+	it('drops a snapshot the server refused as stale and reloads', async () => {
+		markDirty()
+
+		serverSave = async () => {
+			throw Object.assign(new Error('stale'), { exc_type: 'TimestampMismatchError' })
+		}
+
+		await saveCurrentState()
+
+		const local: any = await getPresentationFromLocalDB('p1')
+		// retrying would only be refused again, so nothing stays pending
+		expect(local.dirty).toBe(false)
+		expect(dirty.value).toBe(false)
+		expect(saveFailed.value).toBe(false)
+		expect(reloadAfterConflict).toHaveBeenCalledWith('p1')
 	})
 })

--- a/frontend/src/apps/slides/stores/slide.js
+++ b/frontend/src/apps/slides/stores/slide.js
@@ -80,7 +80,6 @@ const getNewSlide = (toDuplicate = false, layoutObject, source = currentSlide.va
 	}
 
 	// override metadata and generate unique IDs for elements
-	slide.name = ''
 	slide.clientId = uuid4()
 	slide.parent = presentationId.value
 	slide.fadeUnmatchedElements = 1

--- a/suite/slides/api/slides.py
+++ b/suite/slides/api/slides.py
@@ -1,0 +1,59 @@
+import frappe
+from frappe import _
+from frappe.model import default_fields, no_value_fields
+from frappe.utils import cstr
+
+
+@frappe.whitelist()
+def save_slides(name: str, slides: list[dict] | str, base_modified: str) -> dict:
+    """Replace a presentation's slides with the editor's list.
+
+    Rows are matched by `client_id`, the identity the editor owns, so a slide it
+    created keeps one row across autosaves instead of being re-inserted each time.
+    `base_modified` is the version the editor built on: anything older than the
+    server's is a stale snapshot that would wipe another editor's rows, so it is
+    refused rather than merged.
+    """
+    doc = frappe.get_doc("Presentation", name)
+    doc.check_permission("write")
+    if doc.is_composite:
+        frappe.throw(_("Composite presentations have no slides of their own"))
+    if cstr(doc.modified) != cstr(base_modified):
+        frappe.throw(
+            _("This presentation was changed elsewhere. Reload to get the latest version."),
+            frappe.TimestampMismatchError,
+        )
+
+    slides = frappe.parse_json(slides) if isinstance(slides, str) else slides
+    doc.set("slides", merge_rows(doc.slides, slides))
+    doc.save()
+    return {"modified": doc.modified}
+
+
+def merge_rows(existing_rows, incoming):
+    """Existing rows keep their name when the editor still lists their client_id;
+    everything else is a new row. A client_id listed twice keeps one row and
+    inserts another, so a stray duplicate never collapses two slides into one."""
+    by_client_id = {row.client_id: row for row in existing_rows if row.client_id}
+    fields = slide_value_fields()
+    rows = []
+    for idx, slide in enumerate(incoming, start=1):
+        values = {field: slide.get(field) for field in fields if field in slide}
+        row = by_client_id.pop(values.get("client_id"), None)
+        if row:
+            row.update(values)
+        else:
+            row = frappe.new_doc("Slide").update(values)
+        row.idx = idx
+        rows.append(row)
+    return rows
+
+
+def slide_value_fields() -> set[str]:
+    """Fields the editor may set; name, parent, idx and timestamps stay framework-owned."""
+    meta = frappe.get_meta("Slide")
+    return {
+        df.fieldname
+        for df in meta.fields
+        if df.fieldtype not in no_value_fields and df.fieldname not in default_fields
+    }

--- a/suite/slides/api/slides.py
+++ b/suite/slides/api/slides.py
@@ -5,7 +5,7 @@ from frappe.utils import cstr
 
 
 @frappe.whitelist()
-def save_slides(name: str, slides: list[dict] | str, base_modified: str) -> dict:
+def save_slides(name: str, slides: list[dict], base_modified: str) -> dict:
     """Replace a presentation's slides with the editor's list.
 
     Rows are matched by `client_id`, the identity the editor owns, so a slide it
@@ -24,7 +24,6 @@ def save_slides(name: str, slides: list[dict] | str, base_modified: str) -> dict
             frappe.TimestampMismatchError,
         )
 
-    slides = frappe.parse_json(slides) if isinstance(slides, str) else slides
     doc.set("slides", merge_rows(doc.slides, slides))
     doc.save()
     return {"modified": doc.modified}

--- a/suite/slides/api/slides.py
+++ b/suite/slides/api/slides.py
@@ -4,7 +4,8 @@ from frappe.model import default_fields, no_value_fields
 from frappe.utils import cstr
 
 
-@frappe.whitelist()
+# a save over GET would report success and then be rolled back after responding
+@frappe.whitelist(methods=["POST"])
 def save_slides(name: str, slides: list[dict], base_modified: str) -> dict:
     """Replace a presentation's slides with the editor's list.
 

--- a/suite/slides/api/test_slides.py
+++ b/suite/slides/api/test_slides.py
@@ -1,0 +1,94 @@
+import frappe
+from frappe.utils import cstr
+from frappe.tests import IntegrationTestCase
+
+from suite.slides.api.slides import save_slides
+from suite.slides.tests.utils import make_presentation
+from suite.tests.utils import ensure_user
+
+OWNER = "slides-save-owner@example.com"
+OTHER_USER = "slides-save-other@example.com"
+
+
+def slide(client_id, background="#ffffffff"):
+    return {"client_id": client_id, "background": background, "elements": "[]"}
+
+
+def row_names(presentation):
+    return frappe.get_all(
+        "Slide",
+        {"parent": presentation, "parenttype": "Presentation"},
+        pluck="name",
+        order_by="idx",
+    )
+
+
+class TestSaveSlides(IntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        ensure_user(OWNER)
+        ensure_user(OTHER_USER)
+
+    def setUp(self):
+        with self.set_user(OWNER):
+            self.presentation = make_presentation("Save Slides").name
+
+    def modified(self):
+        return cstr(frappe.db.get_value("Presentation", self.presentation, "modified"))
+
+    def save(self, slides, base_modified=None):
+        with self.set_user(OWNER):
+            return save_slides(self.presentation, slides, base_modified or self.modified())
+
+    def test_rows_keep_their_name_across_saves(self):
+        self.save([slide("a"), slide("b")])
+        first = row_names(self.presentation)
+
+        self.save([slide("a", "#000000ff"), slide("b")])
+
+        self.assertEqual(row_names(self.presentation), first)
+        self.assertEqual(frappe.db.get_value("Slide", first[0], "background"), "#000000ff")
+
+    def test_rows_follow_the_editor_list(self):
+        self.save([slide("a"), slide("b")])
+        a_name, b_name = row_names(self.presentation)
+
+        self.save([slide("c"), slide("a")])
+
+        names = row_names(self.presentation)
+        self.assertEqual(names[1], a_name)
+        self.assertNotIn(b_name, names)
+        self.assertEqual(frappe.db.get_value("Slide", names[0], "client_id"), "c")
+
+    def test_duplicate_client_id_keeps_both_slides(self):
+        self.save([slide("a"), slide("a")])
+        self.assertEqual(len(row_names(self.presentation)), 2)
+
+    def test_stale_snapshot_is_refused_and_changes_nothing(self):
+        self.save([slide("a")])
+        stale = self.modified()
+        self.save([slide("a"), slide("b")])
+        before = row_names(self.presentation)
+
+        with self.assertRaises(frappe.TimestampMismatchError):
+            self.save([slide("a")], base_modified=stale)
+
+        self.assertEqual(row_names(self.presentation), before)
+
+    def test_returns_the_new_version(self):
+        result = self.save([slide("a")])
+        self.assertEqual(cstr(result["modified"]), self.modified())
+
+    def test_framework_fields_are_not_editable(self):
+        self.save([slide("a")])
+        (name,) = row_names(self.presentation)
+
+        self.save([{**slide("a"), "name": "forged", "parent": "other", "owner": OTHER_USER}])
+
+        self.assertEqual(row_names(self.presentation), [name])
+        self.assertEqual(frappe.db.get_value("Slide", name, "owner"), OWNER)
+
+    def test_requires_write_permission(self):
+        with self.set_user(OTHER_USER), self.assertRaises(frappe.PermissionError):
+            save_slides(self.presentation, [slide("a")], self.modified())

--- a/suite/slides/doctype/presentation/presentation.py
+++ b/suite/slides/doctype/presentation/presentation.py
@@ -432,13 +432,24 @@ def delete_presentation(name: str):
     return frappe.delete_doc("Presentation", name)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def update_title(name: str, title: str):
     presentation = frappe.get_doc("Presentation", name)
     presentation.check_permission("write")
+    base_modified = presentation.modified
     presentation.title = title
     presentation.save()
-    return {"slug": slug(title), "modified": presentation.modified}
+    return {"slug": slug(title), "modified": presentation.modified, "base_modified": base_modified}
+
+
+@frappe.whitelist(methods=["POST"])
+def update_theme(name: str, theme: str):
+    presentation = frappe.get_doc("Presentation", name)
+    presentation.check_permission("write")
+    base_modified = presentation.modified
+    presentation.theme = theme
+    presentation.save()
+    return {"modified": presentation.modified, "base_modified": base_modified}
 
 
 def get_attachment(presentation, file_url):

--- a/suite/slides/doctype/presentation/test_presentation.py
+++ b/suite/slides/doctype/presentation/test_presentation.py
@@ -7,6 +7,7 @@ import os
 import frappe
 from frappe.client import set_value
 from frappe.tests import IntegrationTestCase
+from frappe.utils import cstr
 from PIL import Image
 
 from suite.slides.doctype.presentation.presentation import (
@@ -20,6 +21,7 @@ from suite.slides.doctype.presentation.presentation import (
     save_base64_image,
     save_presentation_thumbnail,
     update_slide_attachments,
+    update_theme,
     update_title,
 )
 from suite.slides.tests.utils import (
@@ -59,6 +61,7 @@ class TestPresentationSecurity(IntegrationTestCase):
             (get_updated_json, self.owner_presentation, []),
             (save_presentation_thumbnail, self.owner_presentation, PNG_1PX),
             (update_title, self.owner_presentation, "Hijacked"),
+            (update_theme, self.owner_presentation, "hijacked-theme"),
             (get_public_presentation, self.owner_presentation),
             (delete_presentation, self.owner_presentation),
         ]
@@ -288,3 +291,31 @@ class TestSlideRows(IntegrationTestCase):
         self.assertEqual(len(slides), 2)
         self.assertEqual(slides[0].name, kept.name)
         self.assertNotIn(slides[1].name, ("", removed.name))
+
+
+class TestVersionHandshake(IntegrationTestCase):
+    """Endpoints report the modified they saved over, so a stale editor can tell it must reload."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        ensure_user(OWNER)
+
+    def assert_base_reported(self, endpoint, *args):
+        with self.set_user(OWNER):
+            presentation = make_presentation("Version Handshake Presentation")
+            before = cstr(presentation.modified)
+            result = endpoint(presentation.name, *args)
+
+        self.assertEqual(cstr(result["base_modified"]), before)
+        self.assertNotEqual(cstr(result["modified"]), before)
+        self.assertEqual(
+            cstr(result["modified"]),
+            cstr(frappe.db.get_value("Presentation", presentation.name, "modified")),
+        )
+
+    def test_update_title_reports_the_base_it_saved_over(self):
+        self.assert_base_reported(update_title, "Renamed")
+
+    def test_update_theme_reports_the_base_it_saved_over(self):
+        self.assert_base_reported(update_theme, "another-theme")


### PR DESCRIPTION
## Problem

A presentation's `Slide` rows could be wiped when two editors had the same deck open (e.g. a presenter's laptop plus the author's).

1. Slides added/pasted/duplicated in the editor carried `name: ''`, and the store never adopted the server-assigned name after a save. Frappe therefore treated them as new rows on **every autosave**: delete + re-insert under fresh names.
2. Frappe's `update_child_table` deletes every row not in the saved list, then runs `UPDATE … WHERE name=` for named rows — a stale name matches 0 rows, silently.
3. A second editor saving its snapshot (autosave, or the unconditional `saveCurrentState()` on unmount/reconnect) deleted the author's current rows and "updated" names that no longer existed → empty deck.

## Steps to reproduce (on `develop`)

Two browser sessions with **write** access to the same deck — two browsers/profiles on one machine, same account is fine.

1. **Browser A**: open a presentation in the editor. Add 2–3 slides (new, duplicate or paste). Wait for autosave. Keep the tab open.
2. **Browser B**: open the same presentation in the editor. It now holds the current row names. Keep it open.
3. **Browser A**: make any edit. Autosave re-inserts the slides from step 1 under new row names (they still carry `name: ''` in A's memory).
4. **Browser B**: make any tiny edit, or just navigate away from the editor — both pushed B's stale snapshot.
5. Reload the deck in either browser, or open `/desk/presentation/<name>`: the Slides table is empty.

The more slides were created in A's session without a reload, the more is lost; a freshly combined deck (every slide added that session) ends up completely empty.

Scripted equivalent (`apps/suite/suite/tmp_repro.py`, run with `bench --site <site> execute suite.tmp_repro.run`):

```python
import frappe
from frappe.client import set_value
from suite.slides.doctype.presentation.presentation import create_presentation

def rows(name):
    return frappe.get_all("Slide", {"parent": name, "parenttype": "Presentation"}, pluck="name")

def run():
    frappe.set_user("Administrator")
    tpl = frappe.get_all("Presentation", {"is_template": 1}, pluck="name")[0]
    p = create_presentation(template=tpl)
    # what the editor sends for slides it created: name ''
    unnamed = [{"name": "", "elements": "[]", "background": "#fff", "client_id": f"c{i}"} for i in range(3)]

    set_value("Presentation", p.name, {"slides": unnamed})
    print("after user's save #1: ", rows(p.name))
    # second client loads the deck now and holds these names
    presenter_copy = [s.as_dict() for s in frappe.get_doc("Presentation", p.name).slides]
    set_value("Presentation", p.name, {"slides": unnamed})
    print("after user's save #2: ", rows(p.name))   # same slides, new names
    set_value("Presentation", p.name, {"slides": presenter_copy})
    print("after presenter's save:", rows(p.name))  # []
    frappe.db.rollback()
```

```
after user's save #1:  ['7b4e1clnuu', '7b4esihrdc', '7b4offmksi']
after user's save #2:  ['7b42b1f4nv', '7b4ib7r7c5', '7b4ve5bggl']
after presenter's save: []
```

With this branch, step 4 shows "This presentation was changed elsewhere. Showing the latest version." in Browser B and the deck stays intact; the scripted case is covered by `test_stale_snapshot_is_refused_and_changes_nothing` and `test_rows_keep_their_name_across_saves`.

## Fix

- New `suite.slides.api.slides.save_slides(name, slides, base_modified)` replaces `frappe.client.set_value` for slide saves. Rows are matched on `client_id` (the identity the editor owns), so a slide keeps one row across saves. Only Slide value fields are accepted; `name`/`parent`/`idx`/`owner` from the client are ignored.
- Snapshots built on an older `modified` than the server's are refused with `TimestampMismatchError`, so a stale tab can no longer delete another editor's rows.
- Editor: sends `presentationDoc.modified` as the base, adopts the returned version, and on conflict marks the local draft clean and reloads the server version with a toast. Unmount and reconnect now save only when dirty.
- Removed the `slide.name = ''` bookkeeping; the payload no longer carries row names.

## Tests

- `suite/slides/api/test_slides.py`: rows keep names across saves, follow the editor list, duplicate `client_id` keeps both slides, stale snapshot is refused without changing rows, framework fields not editable, write permission required.
- `saving.test.ts`: a refused snapshot is dropped and triggers a reload.
- Removed two `commands.test.ts` cases that asserted the old name-blanking.

## Behaviour note

On conflict the losing editor's unsynced edits are dropped in favour of the server's version (with a toast). A `client_id`-keyed merge can be added later on the same API.
