### PR TITLE
fix(meet): fail recovery on snapshot errors

### DIFF
--- a/frontend/src/apps/meet/composables/__tests__/useNetworkQuality.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useNetworkQuality.test.ts
@@ -373,7 +373,8 @@ describe("useNetworkQuality", () => {
 	it("restarts only a stalled remote video consumer", async () => {
 		vi.useFakeTimers();
 
-		const resetReceiveSide = vi.fn().mockResolvedValue(undefined);
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const resetReceiveSide = vi.fn().mockRejectedValue(new Error("snapshot failed"));
 		const requestConsumerKeyFrame = vi.fn().mockResolvedValue(undefined);
 
 		const track = { muted: false } as MediaStreamTrack;
@@ -458,6 +459,10 @@ describe("useNetworkQuality", () => {
 
 		await vi.advanceTimersByTimeAsync(30_000);
 		expect(resetReceiveSide).toHaveBeenCalledOnce();
+		expect(warn).toHaveBeenCalledWith(
+			"Failed to reset stalled receive media",
+			expect.any(Error),
+		);
 
 		await vi.advanceTimersByTimeAsync(21_000);
 		expect(resetReceiveSide).toHaveBeenCalledOnce();

--- a/frontend/src/apps/meet/composables/useNetworkQuality.ts
+++ b/frontend/src/apps/meet/composables/useNetworkQuality.ts
@@ -260,7 +260,11 @@ export function useNetworkQuality(
 				entry.kind === "video" && stallDetector.getRecoveryAttempts(entry.id) > 2,
 		);
 		if (hasAudioStall || hasExhaustedVideoRecovery) {
-			void sfuManager.resetReceiveMedia();
+			try {
+				await sfuManager.resetReceiveMedia();
+			} catch (error) {
+				console.warn("Failed to reset stalled receive media", error);
+			}
 			stallDetector.suspend();
 			return;
 		}

--- a/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
+++ b/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
@@ -644,7 +644,7 @@ export class ParticipantConnection {
 		} catch (error) {
 			this.initialSyncInProgress = false;
 			console.warn("Failed to request existing producers:", error);
-			return null;
+			throw error;
 		}
 	}
 

--- a/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnectionEvents.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnectionEvents.test.ts
@@ -526,6 +526,13 @@ describe("ParticipantConnection", () => {
 		expect(sfuClient.getExistingProducers).toHaveBeenCalledTimes(1);
 	});
 
+	it("fails receive recovery when the producer snapshot fails", async () => {
+		const { manager, sfuClient } = createManager();
+		sfuClient.getExistingProducers.mockRejectedValue(new Error("snapshot failed"));
+
+		await expect(manager.resetReceiveSide()).rejects.toThrow("snapshot failed");
+	});
+
 	it("does not resume receive recovery after disconnect", async () => {
 		const { manager, mediaManager, transportManager } = createManager();
 		let finishCancellation: () => void = () => {};


### PR DESCRIPTION
## Summary

- propagate producer snapshot failures from receive recovery
- let the existing recovery coordinator escalate instead of accepting an empty receive state
- handle propagated snapshot errors from stall-triggered receive resets
- cover failed snapshots during receive reset and stall recovery