### PR TITLE
fix(meet): bound participant snapshot retries

### DIFF
--- a/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
+++ b/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
@@ -214,6 +214,7 @@ export class ParticipantConnection {
 	private _state: ParticipantConnectionState = "stopped";
 	private static readonly INITIAL_RETRY_DELAY_MS = 1000;
 	private static readonly MAX_RETRY_DELAY_MS = 30000;
+	private static readonly MAX_SNAPSHOT_RETRY_ATTEMPTS = 3;
 
 	constructor(options: ParticipantConnectionOptions) {
 		this.sfuClient = options.sfuClient;
@@ -418,6 +419,7 @@ export class ParticipantConnection {
 		if (this.snapshotRetry) return;
 		this.snapshotRetry = (async () => {
 			let delay = ParticipantConnection.INITIAL_RETRY_DELAY_MS;
+			let attempts = 0;
 			while (!signal.aborted && this.isSignalingConnected()) {
 				try {
 					await this.waitUntilOnline(signal);
@@ -433,6 +435,19 @@ export class ParticipantConnection {
 					if (signal.aborted || !this.isSignalingConnected()) return;
 					this.initialSyncInProgress = true;
 					console.warn("Participant snapshot retry failed:", error);
+					attempts += 1;
+					if (
+						attempts >= ParticipantConnection.MAX_SNAPSHOT_RETRY_ATTEMPTS
+					) {
+						void this.escalateRecovery({
+							scope: "subscription",
+							direction: "recv",
+							reason: "snapshot_retry_limit",
+						}).catch((recoveryError) =>
+							console.warn("Snapshot recovery escalation failed:", recoveryError),
+						);
+						return;
+					}
 					delay = Math.min(delay * 2, ParticipantConnection.MAX_RETRY_DELAY_MS);
 				}
 			}

--- a/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnection.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnection.test.ts
@@ -222,6 +222,42 @@ describe("ParticipantConnection lifecycle", () => {
 		expect(participantManager.hasParticipant("alice")).toBe(false);
 	});
 
+	it("escalates after three failed snapshot retries", async () => {
+		vi.useFakeTimers();
+		const { connection, sfuClient } = createConnection();
+		const escalate = vi.spyOn(connection, "escalateRecovery").mockResolvedValue(true);
+		sfuClient.getRoomParticipants.mockRejectedValue(
+			new Error("snapshot unavailable"),
+		);
+
+		await expect(connection.start(startOptions())).resolves.toBe("degraded");
+		await vi.advanceTimersByTimeAsync(7000);
+
+		expect(sfuClient.getRoomParticipants).toHaveBeenCalledTimes(4);
+		expect(escalate).toHaveBeenCalledOnce();
+		expect(escalate).toHaveBeenCalledWith({
+			scope: "subscription",
+			direction: "recv",
+			reason: "snapshot_retry_limit",
+		});
+	});
+
+	it("does not escalate snapshot retries after disconnect", async () => {
+		vi.useFakeTimers();
+		const { connection, sfuClient } = createConnection();
+		const escalate = vi.spyOn(connection, "escalateRecovery").mockResolvedValue(true);
+		sfuClient.getRoomParticipants.mockRejectedValue(
+			new Error("snapshot unavailable"),
+		);
+
+		await expect(connection.start(startOptions())).resolves.toBe("degraded");
+		await connection.disconnect();
+		await vi.advanceTimersByTimeAsync(60000);
+
+		expect(sfuClient.getRoomParticipants).toHaveBeenCalledOnce();
+		expect(escalate).not.toHaveBeenCalled();
+	});
+
 	it("aborts E2EE readiness and prevents startup from mutating after cleanup", async () => {
 		const { connection } = createConnection({ e2eeRequired: true });
 		let readinessSignal: AbortSignal | undefined;


### PR DESCRIPTION
## Summary

- bound degraded participant snapshot recovery to three retries
- escalate exhausted retries through the Participant Connection recovery coordinator
- stop pending retry escalation when the connection lifecycle is cancelled