### PR TITLE
fix(calendar): don't keep sender copies of custom invite emails

### DIFF
--- a/suite/calendar/doctype/calendar_event/invitations.py
+++ b/suite/calendar/doctype/calendar_event/invitations.py
@@ -239,6 +239,9 @@ def notify_organizer_of_reply(account: str, event_id: str, responder_email: str,
             raw_message=message,
             via_api=True,
             delivery_mode="Enqueue",
+            # The reply is a mechanical iTIP message, not correspondence — don't leave a copy
+            # in the attendee's Sent folder.
+            destroy_after_submit=True,
         )
     except Exception:
         log_error("Calendar", title=_("Failed to send RSVP reply for event {0}").format(event_id))
@@ -305,6 +308,9 @@ def _send(
         raw_message=message,
         via_api=True,
         delivery_mode="Enqueue",
+        # Recipients get the email; the organizer's copy is destroyed after submission so
+        # invite blasts don't pile up in their Sent folder (the event itself is the record).
+        destroy_after_submit=True,
     )
 
 

--- a/suite/calendar/tests/test_calendar_invites_rsvp.py
+++ b/suite/calendar/tests/test_calendar_invites_rsvp.py
@@ -141,6 +141,19 @@ class TestCalendarInvitesRsvp(StalwartIntegrationTestCase):
         for name in frappe.get_all("Mail Queue", {"account": account, "status": "Queued"}, pluck="name"):
             frappe.get_doc("Mail Queue", name)._process()
 
+    def _assert_sender_copy_destroyed(self, account: str) -> None:
+        """Every pending queue row for the account must drop the sender's copy after submission.
+
+        Invite and RSVP-reply mails are mechanical iTIP messages, not correspondence; without
+        this flag the server would file a copy in the sender's Sent mailbox.
+        """
+
+        rows = frappe.get_all(
+            "Mail Queue", filters={"account": account, "status": "Queued"}, fields=["destroy_after_submit"]
+        )
+        self.assertTrue(rows, "No queued mail was created.")
+        self.assertTrue(all(r.destroy_after_submit for r in rows), "Sender copy would be kept in Sent.")
+
     def test_custom_invite_email_flow(self):
         """The app-sent invite path: templated email with ICS + signed links, and the reply mail."""
 
@@ -161,6 +174,7 @@ class TestCalendarInvitesRsvp(StalwartIntegrationTestCase):
             # then push the generated mail through the queue.
             with self.set_user(self.organizer.email):
                 notify_participants(self.organizer_account, "invite", event_id=event_id)
+                self._assert_sender_copy_destroyed(self.organizer_account)
                 self._process_pending_queue(self.organizer_account)
 
             invite_thread = self.wait_until(
@@ -187,6 +201,7 @@ class TestCalendarInvitesRsvp(StalwartIntegrationTestCase):
             with self.set_user(self.attendee.email):
                 copy = add_invite_to_calendar(self.attendee_account, ics_attachments[0]["blob_id"])
                 notify_organizer_of_reply(self.attendee_account, copy["id"], self.attendee.email, "accepted")
+                self._assert_sender_copy_destroyed(self.attendee_account)
                 self._process_pending_queue(self.attendee_account)
 
             self.wait_until(


### PR DESCRIPTION
## Summary
- Custom invite/update/cancel emails and the attendee's iTIP REPLY were moved to the sender's Sent mailbox after submission, so every invite blast piled up in the organizer's account.
- Pass `destroy_after_submit=True` on both `MailQueue._create` calls in `invitations.py`, so the JMAP `EmailSubmission/set` uses `onSuccessDestroyEmail`: recipients get the email, the sender's copy is destroyed. The calendar event itself remains the record.
- `notify_organizer_of_response` (HTTP-RSVP heads-up) is unchanged — it sends via `frappe.sendmail` from the site account and never landed in a user's Sent folder.

## Test plan
- `bench --site s2 run-tests --module suite.calendar.tests.test_calendar_mail_invites` passes (2/2).
- Manual: with "custom event invites" enabled in Mail Settings, create an event with guests → guests receive the invite with `.ics`; organizer's Sent folder has no copy. Same for an attendee RSVP reply.