### PR TITLE
feat(mail): better plaintext support

### DIFF
--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -476,13 +476,13 @@ import { getAttachmentsZipUrl } from '@/apps/mail/resources'
 import {
 	decodeHtmlEntities,
 	downloadUrlAsFile,
-	escapeHtml,
 	extractQuotedContent,
 	getFormattedDate,
 	getFormattedRecipients,
 	getGroupedRecipients,
 	hasHtmlContent,
 	matchesScreenedValue,
+	plainTextToHtml,
 	raiseToast,
 	shouldIgnoreKeypress,
 } from '@/apps/mail/utils'
@@ -1337,14 +1337,17 @@ const getReplyIdentityEmail = (mail: Mail) => {
 // the address it stands for. Both consumers below start from here.
 const getPlainTextBody = (mail: Mail) => decodeHtmlEntities(mail.html_body || mail.text_body || '')
 
-// A body with no markup is plain text, so it has to be escaped before going into the
-// <pre> — the reader parses this as HTML. Bounce notices are the case that bites:
-// their `RCPT TO:<user@host>` reads as an unknown tag, which the sanitizer then drops,
-// silently deleting the very addresses the notice is about.
+// A body with no markup is plain text, so it has to be escaped before going in here: the
+// reader parses this as HTML. Bounce notices are the case that bites, since their
+// `RCPT TO:<user@host>` reads as an unknown tag, which the sanitizer then drops, silently
+// deleting the very addresses the notice is about.
+// Deliberately not a <pre>: the editor parses one as a code block, so quoting or forwarding
+// a plain-text mail used to hand the recipient the sender's prose in monospace that never
+// wrapped. plainTextToHtml keeps the line breaks without asking for that.
 const getBodyContent = (mail: Mail) => {
 	if (hasHtmlContent(mail.html_body)) return mail.html_body
 	const text = getPlainTextBody(mail)
-	return `<pre style="white-space: pre-wrap; word-break: break-word">${text ? escapeHtml(text) : '&nbsp;'}</pre>`
+	return `<div style="white-space: pre-wrap">${text ? plainTextToHtml(text) : '&nbsp;'}</div>`
 }
 
 const getQuotedContent = (mail: Mail) =>

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -321,7 +321,7 @@
 										     face to land on, which CSS resolves upward to the system Medium,
 										     rendering the body bolder than everything around it. font-normal pins
 										     it to Regular. -->
-										<LinkifiedText
+										<PlainTextBody
 											v-else
 											:text="getPlainTextBody(mail)"
 											class="pt-4 font-sans !font-normal text-base !leading-5 sm:text-sm"
@@ -497,7 +497,7 @@ import ComposeMailEditor from '@/apps/mail/components/ComposeMailEditor.vue'
 import DeliveryStatusBanner from '@/apps/mail/components/DeliveryStatusBanner.vue'
 import EmailContent from '@/apps/mail/components/EmailContent.vue'
 import NoMails from '@/apps/mail/components/Icons/NoMails.vue'
-import LinkifiedText from '@/components/LinkifiedText.vue'
+import PlainTextBody from '@/apps/mail/components/PlainTextBody.vue'
 import { openComposePage } from '@/apps/mail/composables/composeHandoff'
 import MailActions from '@/apps/mail/components/MailActions.vue'
 import MailDate from '@/apps/mail/components/MailDate.vue'

--- a/frontend/src/apps/mail/components/PlainTextBody.vue
+++ b/frontend/src/apps/mail/components/PlainTextBody.vue
@@ -31,23 +31,23 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
-import { groupPlainText } from "@/apps/mail/utils/plainTextBlocks";
-import LinkifiedText from "@/components/LinkifiedText.vue";
+import { computed, ref, watch } from 'vue'
+import { groupPlainText } from '@/apps/mail/utils/plainTextBlocks'
+import LinkifiedText from '@/components/LinkifiedText.vue'
 
-const { text } = defineProps<{ text?: string | null }>();
-const segments = computed(() => groupPlainText(text ?? ""));
-const expanded = ref(new Set<number>());
+const { text } = defineProps<{ text?: string | null }>()
+const segments = computed(() => groupPlainText(text ?? ''))
+const expanded = ref(new Set<number>())
 
 // Opening another message reuses this component, and the indices mean something else there.
 watch(
 	() => text,
 	() => (expanded.value = new Set()),
-);
+)
 
 const toggle = (index: number) => {
-	const next = new Set(expanded.value);
-	if (!next.delete(index)) next.add(index);
-	expanded.value = next;
-};
+	const next = new Set(expanded.value)
+	if (!next.delete(index)) next.add(index)
+	expanded.value = next
+}
 </script>

--- a/frontend/src/apps/mail/components/PlainTextBody.vue
+++ b/frontend/src/apps/mail/components/PlainTextBody.vue
@@ -1,0 +1,53 @@
+<template>
+	<div>
+		<template v-for="(segment, index) in segments" :key="index">
+			<template v-if="segment.kind === 'quote'">
+				<button
+					class="bg-surface-gray-2 text-ink-gray-6 hover:bg-surface-gray-3 my-3 rounded-lg px-1.5 leading-4"
+					:aria-expanded="expanded.has(index)"
+					:aria-label="__('Show quoted text')"
+					@click="toggle(index)"
+				>
+					&middot;&middot;&middot;
+				</button>
+				<div v-if="expanded.has(index)">
+					<LinkifiedText
+						v-for="(block, level) in segment.blocks"
+						:key="level"
+						:text="block.text"
+						class="border-outline-gray-2 text-ink-gray-6 my-1 border-l pl-3"
+						:style="{ marginLeft: (block.depth - 1) * 12 + 'px' }"
+					/>
+				</div>
+			</template>
+			<LinkifiedText
+				v-else-if="segment.kind === 'signature'"
+				:text="segment.blocks[0].text"
+				class="text-ink-gray-5 mt-3"
+			/>
+			<LinkifiedText v-else :text="segment.blocks[0].text" />
+		</template>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { groupPlainText } from "@/apps/mail/utils/plainTextBlocks";
+import LinkifiedText from "@/components/LinkifiedText.vue";
+
+const { text } = defineProps<{ text?: string | null }>();
+const segments = computed(() => groupPlainText(text ?? ""));
+const expanded = ref(new Set<number>());
+
+// Opening another message reuses this component, and the indices mean something else there.
+watch(
+	() => text,
+	() => (expanded.value = new Set()),
+);
+
+const toggle = (index: number) => {
+	const next = new Set(expanded.value);
+	if (!next.delete(index)) next.add(index);
+	expanded.value = next;
+};
+</script>

--- a/frontend/src/apps/mail/components/Settings/IdentitySettings.vue
+++ b/frontend/src/apps/mail/components/Settings/IdentitySettings.vue
@@ -192,7 +192,7 @@ import {
 import AppSettingsHeader from '@/components/settings/AppSettingsHeader.vue'
 import AppSettingsBody from '@/components/settings/AppSettingsBody.vue'
 
-import { convertHtmlToText, raiseToast } from '@/apps/mail/utils'
+import { raiseToast } from '@/apps/mail/utils'
 import { useScreenSize, useTextEditorButtons } from '@/apps/mail/utils/composables'
 import { CustomParagraphExtension } from '@/apps/mail/utils/text-editor'
 import { userStore } from '@/apps/mail/stores/user'
@@ -229,10 +229,9 @@ const getIdentity = () =>
 		},
 	})
 
-const save = () => {
-	identity.value.doc.text_signature = convertHtmlToText(identity.value.doc.html_signature)
-	identity.value.save.submit()
-}
+// text_signature is derived server-side on save (Identity.validate), so the two forms of the
+// signature stay the same signature rather than one being a flattened trace of the other.
+const save = () => identity.value.save.submit()
 
 const identity = ref(getIdentity())
 const savedSignature = ref('')

--- a/frontend/src/apps/mail/components/Settings/VacationResponseSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/VacationResponseSettings.vue
@@ -73,7 +73,7 @@ import {
 import AppSettingsHeader from '@/components/settings/AppSettingsHeader.vue'
 import AppSettingsBody from '@/components/settings/AppSettingsBody.vue'
 
-import { convertHtmlToText, raiseToast } from '@/apps/mail/utils'
+import { raiseToast } from '@/apps/mail/utils'
 import { fromLocalInput, toLocalInput } from '@/apps/mail/utils/datetime'
 import { useScreenSize, useTextEditorButtons } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
@@ -120,7 +120,6 @@ const updateVacationResponse = createResource({
 		from_date: fromLocalInput(vacationResponse.data.from_date),
 		to_date: fromLocalInput(vacationResponse.data.to_date),
 		subject: vacationResponse.data.subject,
-		text_body: convertHtmlToText(vacationResponse.data.html_body),
 		html_body: vacationResponse.data.html_body,
 	}),
 	onSuccess: () => {

--- a/frontend/src/apps/mail/composables/useComposeMail.ts
+++ b/frontend/src/apps/mail/composables/useComposeMail.ts
@@ -163,10 +163,15 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 
 	// ── Signature ───────────────────────────────────────────────────────────────────────────────
 
+	// The wrapper is what lets the text/plain alternative introduce the block with RFC 3676's
+	// "-- " separator; by the time a body reaches the server the signature is ordinary markup.
+	// Gated on the HTML form, which is the one actually inserted.
 	const buildSignature = (email?: string) => {
 		const identity = getIdentity(email!)
-		return identity?.text_signature
-			? `<div><br></div><div><br></div>${identity.html_signature}`
+		return identity?.html_signature
+			? '<div><br></div><div><br></div><div class="frappe_mail_signature">' +
+					identity.html_signature +
+					'</div>'
 			: ''
 	}
 

--- a/frontend/src/apps/mail/utils/html.ts
+++ b/frontend/src/apps/mail/utils/html.ts
@@ -51,6 +51,19 @@ const BRACKETED_ADDRESS = /<([^<>\s]+@[^<>\s]+)>/g
 export const escapeBracketedAddresses = (html: string) =>
 	html.replace(BRACKETED_ADDRESS, '<b>&lt;$1&gt;</b>')
 
+// Plain text as HTML that keeps its shape.
+//
+// The breaks are <br> rather than a white-space style on the wrapper, because a quote the
+// user opens in the composer goes through the editor, which keeps no style it has no
+// attribute for and would run the whole body into one line. Leading indentation is nbsp for
+// the same reason. A wrapper still carries pre-wrap, which is what preserves the runs of
+// spaces inside a line for everyone who reads the message rather than edits it.
+export const plainTextToHtml = (text: string) =>
+	escapeHtml(text.replace(/\r\n?/g, '\n'))
+		.split('\n')
+		.map((line) => line.replace(/^ +/, (run) => '&nbsp;'.repeat(run.length)))
+		.join('<br>')
+
 export const hasHtmlContent = (content: string | null | undefined): boolean => {
 	if (!content) return false
 	return /<(html|head|body|div|p|span|table|td|tr|a|img|br|hr|h[1-6]|ul|ol|li|strong|em|b|i|font|style)[^>]*>/i.test(

--- a/frontend/src/apps/mail/utils/index.ts
+++ b/frontend/src/apps/mail/utils/index.ts
@@ -413,7 +413,7 @@ export const getScriptName = (scriptName: string) => {
 export const isSystemScript = (scriptName: string) =>
 	['vacation', 'frappe_mail_automation'].includes(scriptName)
 
-export { decodeHtmlEntities, escapeHtml, hasHtmlContent } from '@/apps/mail/utils/html'
+export { decodeHtmlEntities, hasHtmlContent, plainTextToHtml } from '@/apps/mail/utils/html'
 
 export const getIcon = (mailbox: MailboxData) => {
 	// The Screener is a system folder: its 'eye' icon is authoritative and can't be overridden by a

--- a/frontend/src/apps/mail/utils/index.ts
+++ b/frontend/src/apps/mail/utils/index.ts
@@ -246,35 +246,6 @@ export const shouldIgnoreKeypress = (
 	)
 }
 
-export const convertHtmlToText = (html: string) => {
-	if (!html) return ''
-
-	const parser = new DOMParser()
-	const doc = parser.parseFromString(html, 'text/html')
-	const body = doc.body || doc.documentElement
-
-	const anchors = body.querySelectorAll('a')
-	const buttons = body.querySelectorAll('button')
-	const inputs = body.querySelectorAll('input')
-
-	anchors.forEach((anchor) => {
-		const text = document.createTextNode(anchor.textContent)
-		anchor.parentNode?.replaceChild(text, anchor)
-	})
-
-	buttons.forEach((button) => button.remove())
-
-	inputs.forEach((input) => {
-		const type = input.getAttribute('type') || 'text'
-		if (['button', 'submit', 'reset'].includes(type)) {
-			input.remove()
-		}
-	})
-
-	const text = body.textContent || body.innerText || ''
-	return text.replace(/\s+/g, ' ').trim()
-}
-
 export const isEmail = (s: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s)
 
 // A domain entry, prefixed with @ (e.g. @example.com). Used by screening to trust/block a whole domain.

--- a/frontend/src/apps/mail/utils/plainTextBlocks.test.ts
+++ b/frontend/src/apps/mail/utils/plainTextBlocks.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+
+import { groupPlainText, splitPlainText } from '@/apps/mail/utils/plainTextBlocks'
+
+const kinds = (text: string) => splitPlainText(text).map((block) => `${block.kind}:${block.depth}`)
+
+describe('quote levels', () => {
+	it('separates a reply from what it quotes', () => {
+		expect(kinds('Agreed.\n\n> Ship Friday?')).toEqual(['body:0', 'quote:1'])
+	})
+
+	it('reads nesting depth', () => {
+		expect(kinds('>> deep')).toEqual(['quote:2'])
+	})
+
+	it('treats spaced markers as the same nesting', () => {
+		expect(kinds('> > spaced')).toEqual(['quote:2'])
+	})
+
+	it('strips the markers so the text renders as prose', () => {
+		expect(splitPlainText('> Ship Friday?')[0].text).toBe('Ship Friday?')
+	})
+
+	it('keeps consecutive lines of one depth together', () => {
+		const blocks = splitPlainText('> one\n> two')
+		expect(blocks).toHaveLength(1)
+		expect(blocks[0].text).toBe('one\ntwo')
+	})
+
+	it('splits when the depth changes', () => {
+		expect(kinds('> outer\n>> inner\n> outer again')).toEqual(['quote:1', 'quote:2', 'quote:1'])
+	})
+
+	it('keeps blank lines inside a quote', () => {
+		expect(splitPlainText('> one\n>\n> two')[0].text).toBe('one\n\ntwo')
+	})
+
+	it('drops the blank line between body and quote', () => {
+		// It is the gap around the quote, not something anyone wrote.
+		expect(kinds('Agreed.\n\n\n> Ship Friday?')).toEqual(['body:0', 'quote:1'])
+	})
+})
+
+describe('signature', () => {
+	it('starts at the separator', () => {
+		expect(kinds('Bye\n-- \nAlex')).toEqual(['body:0', 'signature:0'])
+	})
+
+	it('accepts the separator without its trailing space', () => {
+		// RFC 3676 wants "-- ", but clients trim it often enough to matter.
+		expect(kinds('Bye\n--\nAlex')).toEqual(['body:0', 'signature:0'])
+	})
+
+	it('takes the last separator, so a typed dash does not swallow the real one', () => {
+		const blocks = splitPlainText('Bye\n--\nstill body\n-- \nAlex')
+		expect(blocks.map((b) => b.kind)).toEqual(['body', 'signature'])
+		expect(blocks[1].text).toBe('-- \nAlex')
+	})
+
+	it('ignores a quoted separator, which belongs to the message being quoted', () => {
+		expect(kinds('Agreed.\n\n> Bye\n> -- \n> Jane')).toEqual(['body:0', 'quote:1'])
+	})
+
+	it('runs to the end even over blank lines', () => {
+		expect(kinds('Bye\n-- \nAlex\n\nSupport')).toEqual(['body:0', 'signature:0'])
+	})
+})
+
+describe('plain bodies', () => {
+	it('returns nothing for empty text', () => {
+		expect(splitPlainText('')).toEqual([])
+	})
+
+	it('leaves an unstructured body as one block', () => {
+		expect(kinds('Just a note.\nNothing special.')).toEqual(['body:0'])
+	})
+
+	it('does not mistake a greater-than in prose for a quote', () => {
+		// The marker has to open the line; "a > b" mid-sentence is arithmetic.
+		expect(kinds('2 > 1 is true')).toEqual(['body:0'])
+	})
+
+	it('normalises CRLF', () => {
+		expect(kinds('Agreed.\r\n\r\n> Ship Friday?')).toEqual(['body:0', 'quote:1'])
+	})
+})
+
+describe('grouping for the reader', () => {
+	const shape = (text: string) =>
+		groupPlainText(text).map((s) => `${s.kind}(${s.blocks.map((b) => b.depth).join(',')})`)
+
+	it('folds a whole trail into one segment whatever its depths', () => {
+		// One control for the trail, not one per level.
+		expect(shape('Agreed.\n\n> one\n>> two\n> three')).toEqual(['body(0)', 'quote(1,2,1)'])
+	})
+
+	it('keeps body, trail and signature apart', () => {
+		expect(shape('Agreed.\n\n> Ship Friday?\n\n-- \nAlex')).toEqual([
+			'body(0)',
+			'quote(1)',
+			'signature(0)',
+		])
+	})
+
+	it('starts a new segment when body interrupts a trail', () => {
+		expect(shape('> one\ninline reply\n> two')).toEqual(['quote(1)', 'body(0)', 'quote(1)'])
+	})
+
+	it('returns nothing for empty text', () => {
+		expect(groupPlainText('')).toEqual([])
+	})
+})

--- a/frontend/src/apps/mail/utils/plainTextBlocks.ts
+++ b/frontend/src/apps/mail/utils/plainTextBlocks.ts
@@ -1,0 +1,75 @@
+// Structure a plain-text body carries in its own punctuation: `>` for the reply trail and
+// RFC 3676's "-- " for the signature. The HTML path gets both for free (blockquote elements,
+// a marked signature block); without this the same message read as text is one flat wall.
+
+type PlainTextBlockKind = "body" | "quote" | "signature";
+
+export interface PlainTextBlock {
+	kind: PlainTextBlockKind;
+	/** Quote nesting, 0 for body and signature. */
+	depth: number;
+	/** The text with its quote markers removed, so it renders as prose at any depth. */
+	text: string;
+}
+
+// `>>text`, `> > text` and `>  text` all mean the same nesting. The run is the markers plus
+// the single space each conventionally carries.
+const QUOTE_PREFIX = /^((?:>[ \t]?)+)/;
+
+const quoteDepth = (line: string) =>
+	line.match(QUOTE_PREFIX)?.[1].match(/>/g)?.length ?? 0;
+
+const stripQuotePrefix = (line: string) => line.replace(QUOTE_PREFIX, "");
+
+// RFC 3676 4.3 wants exactly "-- ", but plenty of clients trim the trailing space before it
+// reaches anyone, so both spellings count.
+const isSeparator = (line: string) => line === "-- " || line === "--";
+
+export const splitPlainText = (text: string): PlainTextBlock[] => {
+	if (!text) return [];
+
+	const lines = text.replace(/\r\n?/g, "\n").split("\n");
+
+	// The last separator wins: a "--" someone typed mid-message would otherwise swallow the
+	// real signature below it. Only unquoted ones count, since a quoted separator belongs to
+	// the message being quoted.
+	let signatureAt = -1;
+	lines.forEach((line, index) => {
+		if (quoteDepth(line) === 0 && isSeparator(line)) signatureAt = index;
+	});
+
+	const blocks: PlainTextBlock[] = [];
+	lines.forEach((line, index) => {
+		const inSignature = signatureAt !== -1 && index >= signatureAt;
+		const depth = inSignature ? 0 : quoteDepth(line);
+		const kind: PlainTextBlockKind = inSignature
+			? "signature"
+			: depth
+				? "quote"
+				: "body";
+		const content = inSignature ? line : stripQuotePrefix(line);
+		const last = blocks.at(-1);
+		if (last && last.kind === kind && last.depth === depth)
+			last.text += "\n" + content;
+		else blocks.push({ kind, depth, text: content });
+	});
+
+	// A body block of nothing but blank lines is the gap around a quote, not content.
+	return blocks.filter((block) => block.kind !== "body" || block.text.trim());
+};
+
+export interface PlainTextSegment {
+	kind: PlainTextBlockKind;
+	blocks: PlainTextBlock[];
+}
+
+// A reply trail is one trail however many levels deep it goes, so a reader folds it behind a
+// single control rather than one per level.
+export const groupPlainText = (text: string): PlainTextSegment[] =>
+	splitPlainText(text).reduce<PlainTextSegment[]>((segments, block) => {
+		const last = segments.at(-1);
+		if (block.kind === "quote" && last?.kind === "quote")
+			last.blocks.push(block);
+		else segments.push({ kind: block.kind, blocks: [block] });
+		return segments;
+	}, []);

--- a/frontend/src/apps/mail/utils/plainTextBlocks.ts
+++ b/frontend/src/apps/mail/utils/plainTextBlocks.ts
@@ -1,75 +1,75 @@
 // Structure a plain-text body carries in its own punctuation: `>` for the reply trail and
-// RFC 3676's "-- " for the signature. The HTML path gets both for free (blockquote elements,
+// RFC 3676's '-- ' for the signature. The HTML path gets both for free (blockquote elements,
 // a marked signature block); without this the same message read as text is one flat wall.
 
-type PlainTextBlockKind = "body" | "quote" | "signature";
+type PlainTextBlockKind = 'body' | 'quote' | 'signature'
 
 export interface PlainTextBlock {
-	kind: PlainTextBlockKind;
+	kind: PlainTextBlockKind
 	/** Quote nesting, 0 for body and signature. */
-	depth: number;
+	depth: number
 	/** The text with its quote markers removed, so it renders as prose at any depth. */
-	text: string;
+	text: string
 }
 
 // `>>text`, `> > text` and `>  text` all mean the same nesting. The run is the markers plus
 // the single space each conventionally carries.
-const QUOTE_PREFIX = /^((?:>[ \t]?)+)/;
+const QUOTE_PREFIX = /^((?:>[ \t]?)+)/
 
 const quoteDepth = (line: string) =>
-	line.match(QUOTE_PREFIX)?.[1].match(/>/g)?.length ?? 0;
+	line.match(QUOTE_PREFIX)?.[1].match(/>/g)?.length ?? 0
 
-const stripQuotePrefix = (line: string) => line.replace(QUOTE_PREFIX, "");
+const stripQuotePrefix = (line: string) => line.replace(QUOTE_PREFIX, '')
 
-// RFC 3676 4.3 wants exactly "-- ", but plenty of clients trim the trailing space before it
+// RFC 3676 4.3 wants exactly '-- ', but plenty of clients trim the trailing space before it
 // reaches anyone, so both spellings count.
-const isSeparator = (line: string) => line === "-- " || line === "--";
+const isSeparator = (line: string) => line === '-- ' || line === '--'
 
 export const splitPlainText = (text: string): PlainTextBlock[] => {
-	if (!text) return [];
+	if (!text) return []
 
-	const lines = text.replace(/\r\n?/g, "\n").split("\n");
+	const lines = text.replace(/\r\n?/g, '\n').split('\n')
 
-	// The last separator wins: a "--" someone typed mid-message would otherwise swallow the
+	// The last separator wins: a '--' someone typed mid-message would otherwise swallow the
 	// real signature below it. Only unquoted ones count, since a quoted separator belongs to
 	// the message being quoted.
-	let signatureAt = -1;
+	let signatureAt = -1
 	lines.forEach((line, index) => {
-		if (quoteDepth(line) === 0 && isSeparator(line)) signatureAt = index;
-	});
+		if (quoteDepth(line) === 0 && isSeparator(line)) signatureAt = index
+	})
 
-	const blocks: PlainTextBlock[] = [];
+	const blocks: PlainTextBlock[] = []
 	lines.forEach((line, index) => {
-		const inSignature = signatureAt !== -1 && index >= signatureAt;
-		const depth = inSignature ? 0 : quoteDepth(line);
+		const inSignature = signatureAt !== -1 && index >= signatureAt
+		const depth = inSignature ? 0 : quoteDepth(line)
 		const kind: PlainTextBlockKind = inSignature
-			? "signature"
+			? 'signature'
 			: depth
-				? "quote"
-				: "body";
-		const content = inSignature ? line : stripQuotePrefix(line);
-		const last = blocks.at(-1);
+				? 'quote'
+				: 'body'
+		const content = inSignature ? line : stripQuotePrefix(line)
+		const last = blocks.at(-1)
 		if (last && last.kind === kind && last.depth === depth)
-			last.text += "\n" + content;
-		else blocks.push({ kind, depth, text: content });
-	});
+			last.text += '\n' + content
+		else blocks.push({ kind, depth, text: content })
+	})
 
 	// A body block of nothing but blank lines is the gap around a quote, not content.
-	return blocks.filter((block) => block.kind !== "body" || block.text.trim());
-};
+	return blocks.filter((block) => block.kind !== 'body' || block.text.trim())
+}
 
 export interface PlainTextSegment {
-	kind: PlainTextBlockKind;
-	blocks: PlainTextBlock[];
+	kind: PlainTextBlockKind
+	blocks: PlainTextBlock[]
 }
 
 // A reply trail is one trail however many levels deep it goes, so a reader folds it behind a
 // single control rather than one per level.
 export const groupPlainText = (text: string): PlainTextSegment[] =>
 	splitPlainText(text).reduce<PlainTextSegment[]>((segments, block) => {
-		const last = segments.at(-1);
-		if (block.kind === "quote" && last?.kind === "quote")
-			last.blocks.push(block);
-		else segments.push({ kind: block.kind, blocks: [block] });
-		return segments;
-	}, []);
+		const last = segments.at(-1)
+		if (block.kind === 'quote' && last?.kind === 'quote')
+			last.blocks.push(block)
+		else segments.push({ kind: block.kind, blocks: [block] })
+		return segments
+	}, [])

--- a/frontend/src/apps/mail/utils/plainTextToHtml.test.ts
+++ b/frontend/src/apps/mail/utils/plainTextToHtml.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { plainTextToHtml } from '@/apps/mail/utils/html'
+
+// Quoting or forwarding a plain-text mail used to wrap it in a <pre>, which the composer's
+// editor parses as a code block. The recipient then got the sender's prose in monospace that
+// never wrapped. These pin the shape that replaced it.
+describe('plainTextToHtml', () => {
+	it('turns newlines into breaks', () => {
+		expect(plainTextToHtml('one\ntwo')).toBe('one<br>two')
+	})
+
+	it('keeps blank lines', () => {
+		expect(plainTextToHtml('one\n\ntwo')).toBe('one<br><br>two')
+	})
+
+	it('normalises CRLF', () => {
+		expect(plainTextToHtml('one\r\ntwo\rthree')).toBe('one<br>two<br>three')
+	})
+
+	it('escapes markup so a body cannot become one', () => {
+		expect(plainTextToHtml('<b>not bold</b>')).toBe('&lt;b&gt;not bold&lt;/b&gt;')
+	})
+
+	it('keeps a bracketed address intact', () => {
+		// The bounce-notice case: unescaped, the parser reads this as a tag and the
+		// sanitizer deletes the address the notice is about.
+		expect(plainTextToHtml('RCPT TO:<user@example.com>')).toContain('&lt;user@example.com&gt;')
+	})
+
+	it('does not double-escape an ampersand', () => {
+		expect(plainTextToHtml('Tom & Jerry')).toBe('Tom &amp; Jerry')
+	})
+
+	it('keeps leading indentation', () => {
+		// HTML collapses leading whitespace, and the editor drops the wrapper's style, so
+		// the indent has to be non-breaking to survive either.
+		expect(plainTextToHtml('  indented')).toBe('&nbsp;&nbsp;indented')
+	})
+
+	it('indents every line it needs to', () => {
+		expect(plainTextToHtml('top\n    deep')).toBe('top<br>&nbsp;&nbsp;&nbsp;&nbsp;deep')
+	})
+
+	it('leaves quote markers alone', () => {
+		expect(plainTextToHtml('> quoted\n>> deeper')).toBe('&gt; quoted<br>&gt;&gt; deeper')
+	})
+
+	it('emits no pre or code element', () => {
+		const html = plainTextToHtml('def f():\n    return 1')
+		expect(html).not.toMatch(/<(pre|code)\b/)
+	})
+
+	it('handles an empty string', () => {
+		expect(plainTextToHtml('')).toBe('')
+	})
+})

--- a/suite/mail/api/account.py
+++ b/suite/mail/api/account.py
@@ -20,7 +20,7 @@ from suite.mail.utils.user import (
     has_user_settings,
     is_jmap_configured,
 )
-from suite.utils import convert_html_to_text, user_context
+from suite.utils import user_context
 from suite.utils.rate_limiter import dynamic_rate_limit
 from suite.utils.user import is_suite_admin, is_system_manager
 
@@ -666,5 +666,5 @@ def set_signature(identity: str, signature: str) -> None:
 
     doc = frappe.get_doc("Identity", identity)
     doc.html_signature = signature
-    doc.text_signature = convert_html_to_text(signature)
+    doc.set_text_signature()
     doc.db_update()

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -66,7 +66,6 @@ from suite.mail.utils.delivery_status import parse_delivery_status
 from suite.mail.utils.dt import from_utc_z, normalize_utc_z, to_user_timezone, to_utc_z
 from suite.mail.utils.user import get_account_emails, is_jmap_configured
 from suite.mail.utils.validation import normalize_screened_value, validate_screened_value
-from suite.utils import convert_html_to_text
 from suite.utils.rate_limiter import dynamic_rate_limit
 
 AVATAR_CACHE_TTL = 60 * 60 * 24
@@ -730,7 +729,6 @@ def update_draft_mail(
             )
 
     message.html_body = html_body
-    message.text_body = convert_html_to_text(message.html_body)
 
     message.recipients = []
     for type, emails in [("To", to), ("Cc", cc), ("Bcc", bcc)]:

--- a/suite/mail/doctype/identity/identity.py
+++ b/suite/mail/doctype/identity/identity.py
@@ -11,6 +11,7 @@ from frappe.utils import cint, today
 
 from suite.mail.doctype.user_account.user_account import get_user_for_jmap_account
 from suite.mail.jmap import get_identity_service
+from suite.mail.utils.html_to_text import html_to_text
 from suite.utils import parse_filters
 
 
@@ -53,6 +54,19 @@ class Identity(Document):
         for r in self.reply_to:
             reply_to.append({"name": r.display_name, "email": r.email})
         return reply_to
+
+    def validate(self) -> None:
+        self.set_text_signature()
+
+    def set_text_signature(self) -> None:
+        """Derive the plain-text signature from the HTML one.
+
+        JMAP carries both and a client picks whichever part it renders, so the text form has
+        to be the same signature rather than a flattened trace of it. Kept a method because
+        set_signature writes through db_update and never runs validate.
+        """
+
+        self.text_signature = html_to_text(self.html_signature) or None
 
     def db_insert(self, *args, **kwargs) -> None:
         self.id = add_identity(

--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -623,7 +623,7 @@ class MailMessage(Document):
             recipients=recipients,
             attachments=attachments,
             html_body=self.html_body,
-            text_body=self.text_body,
+            text_body=None if self.html_body else self.text_body,
             message_id=self.message_id,
             id=self.id,
             in_reply_to=self.in_reply_to,
@@ -1137,8 +1137,8 @@ def preview_from_html(html_body: str) -> str:
     soup = BeautifulSoup(html_body, "html.parser")
     # Strip the same quote containers the client collapses (see EmailContent.vue) so the
     # preview surfaces the new content instead of "On ... wrote:" and everything below it.
-    for quote in soup.find_all(class_=["gmail_quote", "frappe_mail_quote"]):
-        quote.decompose()
+    for q in soup.find_all(class_=["gmail_quote", "frappe_mail_quote"]):
+        q.decompose()
 
     # A message that is nothing but a quote would otherwise get a blank preview.
     return convert_html_to_text(str(soup)) or convert_html_to_text(html_body)

--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -1206,13 +1206,16 @@ def format_message(account: str, mailbox_map: dict, message: dict) -> dict:
                     {"type": titled_key, "display_name": rcpt["name"], "email": rcpt["email"]}
                 )
 
-    for key, field in {"htmlBody": "html_body", "textBody": "text_body"}.items():
-        value = (
-            message.get("bodyValues", {}).get(message[key][0]["partId"], {}).get("value")
-            if message.get(key)
-            else None
-        )
-        formatted_message[field] = value
+    # RFC 8621: htmlBody falls back to the text parts when a message carries no HTML, and
+    # textBody to the HTML parts when it carries no plain text. Taken without checking the
+    # part's type, a plain-text mail lands in html_body and the reader treats prose as markup.
+    for key, field, wanted in (
+        ("htmlBody", "html_body", "text/html"),
+        ("textBody", "text_body", "text/plain"),
+    ):
+        part = next((p for p in message.get(key) or [] if p.get("type") == wanted), None)
+        body_values = message.get("bodyValues") or {}
+        formatted_message[field] = body_values.get(part["partId"], {}).get("value") if part else None
 
     if html_body := formatted_message["html_body"]:
         preview = preview_from_html(html_body)

--- a/suite/mail/doctype/mail_queue/mail_queue.py
+++ b/suite/mail/doctype/mail_queue/mail_queue.py
@@ -47,6 +47,7 @@ from suite.mail.jmap.services.mail.email import EmailService
 from suite.mail.jmap.services.mail.mailbox import MailboxService
 from suite.mail.utils import get_config, log_mail_error
 from suite.mail.utils.dt import parsedate_to_datetime
+from suite.mail.utils.html_to_text import html_to_text, to_flowed
 from suite.mail.utils.user import is_jmap_configured
 from suite.utils.permissions import OwnerFromUser
 from suite.utils.user import is_administrator
@@ -172,7 +173,9 @@ class MailQueue(OwnerFromUser, Document):
                 setattr(doc, field, json.dumps(kwargs[field]))
 
         doc.html_body = kwargs.html_body
-        doc.text_body = kwargs.text_body
+        doc.text_body = (
+            to_flowed(kwargs.text_body) if kwargs.text_body else html_to_text(kwargs.html_body, flowed=True)
+        ) or None
         doc.forwarded_from_id = kwargs.forwarded_from_id
         doc.message_id = kwargs.message_id
         doc.id = kwargs.id

--- a/suite/mail/doctype/vacation_response/vacation_response.py
+++ b/suite/mail/doctype/vacation_response/vacation_response.py
@@ -16,7 +16,7 @@ from suite.mail.doctype.sieve_script.sieve_script import (
 from suite.mail.doctype.user_account.user_account import get_user_for_jmap_account
 from suite.mail.jmap import get_vacation_response_service
 from suite.mail.utils.dt import normalize_utc_z
-from suite.utils import convert_html_to_text
+from suite.mail.utils.html_to_text import html_to_text
 
 
 class VacationResponse(Document):
@@ -110,7 +110,12 @@ def update_vacation_response(
     if enabled and (from_date and to_date) and (from_date >= to_date):
         frappe.throw(_("To Date must be after From Date."))
 
-    if not convert_html_to_text(html_body):
+    # Where there is an HTML body it is authoritative, so both parts say the same thing rather
+    # than the text being a flattened trace of it. Plain rather than flowed: Stalwart composes
+    # the auto-reply itself, and nothing on that path declares what a soft break needs.
+    if derived := html_to_text(html_body):
+        text_body = derived
+    else:
         html_body = None
 
     current_active_sieve_script_id = get_active_sieve_script_id(account)

--- a/suite/mail/jmap/services/mail/email.py
+++ b/suite/mail/jmap/services/mail/email.py
@@ -10,6 +10,10 @@ from suite.mail.jmap.services.mail.mailbox import MailboxService
 from suite.mail.jmap.services.mail.submission.email_submission import EmailSubmissionService
 from suite.mail.utils.dt import to_utc_z
 
+# RFC 3676. MailQueue guarantees the text body is encoded this way, generated or supplied.
+# delsp=no keeps the space at a soft break, which is the word separator the reader rejoins on.
+TEXT_PLAIN_FLOWED = "text/plain; format=flowed; delsp=no"
+
 
 class EmailService(MailService):
     """Service for handling email-related functionality based on the JMAP server capabilities."""
@@ -486,7 +490,12 @@ class EmailService(MailService):
         text_part = html_part = None
 
         if email.text_body:
-            text_part = {"partId": "text", "type": "text/plain"}
+            # The parameters ride in `type` because that string is written to the header
+            # verbatim. They are only legal inside `bodyStructure`: reached through the
+            # `textBody` convenience property the server demands `type` be exactly
+            # "text/plain", and setting `header:Content-Type` on a part gets it a second
+            # Content-Type rather than replacing the one the server builds.
+            text_part = {"partId": "text", "type": TEXT_PLAIN_FLOWED}
             draft["bodyValues"]["text"] = {
                 "value": email.text_body,
                 "charset": "utf-8",
@@ -507,44 +516,37 @@ class EmailService(MailService):
         regular_attachments = [a for a in attachments if a.disposition != "inline"]
         body_parts = [p for p in (text_part, html_part) if p]
 
-        if inline_attachments and body_parts:
-            # Inline images are referenced from the HTML body via `cid:` URLs. Build an
-            # explicit MIME structure that nests them inside a `multipart/related` container
-            # (next to the body) instead of letting them become plain siblings of the body in
-            # `multipart/mixed`. Some providers (e.g. AWS) treat every `multipart/mixed` part
-            # as a regular attachment and reject inline images by extension, whereas clients
-            # like Gmail wrap them in `multipart/related` so they are recognized as inline.
-            body_root = (
-                {"type": "multipart/alternative", "subParts": body_parts}
-                if len(body_parts) > 1
-                else body_parts[0]
-            )
+        if not body_parts:
+            if attachments:
+                draft["attachments"] = [EmailService._get_body_part(a) for a in attachments]
+            return draft
 
-            body_structure = {
+        # The structure is always spelled out rather than left to the convenience properties,
+        # because the text part's Content-Type parameters only survive this way.
+        body_root = (
+            {"type": "multipart/alternative", "subParts": body_parts}
+            if len(body_parts) > 1
+            else body_parts[0]
+        )
+
+        if inline_attachments:
+            # Inline images are referenced from the HTML body via `cid:` URLs. Nesting them in
+            # a `multipart/related` container beside the body, rather than leaving them as
+            # siblings in `multipart/mixed`, is what marks them inline: some providers (e.g.
+            # AWS) treat every `multipart/mixed` part as a regular attachment and reject
+            # inline images by extension.
+            body_root = {
                 "type": "multipart/related",
                 "subParts": [body_root, *(EmailService._get_body_part(a) for a in inline_attachments)],
             }
 
-            if regular_attachments:
-                body_structure = {
-                    "type": "multipart/mixed",
-                    "subParts": [
-                        body_structure,
-                        *(EmailService._get_body_part(a) for a in regular_attachments),
-                    ],
-                }
+        if regular_attachments:
+            body_root = {
+                "type": "multipart/mixed",
+                "subParts": [body_root, *(EmailService._get_body_part(a) for a in regular_attachments)],
+            }
 
-            draft["bodyStructure"] = body_structure
-        else:
-            # No inline images: let the server assemble the structure from the convenience
-            # properties (`multipart/alternative` for the body, `multipart/mixed` for attachments).
-            if text_part:
-                draft["textBody"] = [text_part]
-            if html_part:
-                draft["htmlBody"] = [html_part]
-            if attachments:
-                draft["attachments"] = [EmailService._get_body_part(a) for a in attachments]
-
+        draft["bodyStructure"] = body_root
         return draft
 
     @staticmethod

--- a/suite/mail/tests/test_email_draft_body.py
+++ b/suite/mail/tests/test_email_draft_body.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import unittest
+
+from suite.mail.jmap.models import EmailAttachment, EmailCreateModel, EmailRecipient
+from suite.mail.jmap.services.mail.email import TEXT_PLAIN_FLOWED, EmailService
+
+
+def draft(**kwargs) -> dict:
+    email = EmailCreateModel(
+        creation_id="c1",
+        from_email="sender@example.com",
+        recipients=[EmailRecipient(type="to", name=None, email="rcpt@example.com")],
+        **kwargs,
+    )
+    return EmailService._get_draft(email, "mailbox-1")
+
+
+def attachment(disposition: str) -> EmailAttachment:
+    return EmailAttachment(
+        name="file.png", type="image/png", cid="cid-1", blob_id="blob-1", disposition=disposition
+    )
+
+
+class TextPart(unittest.TestCase):
+    def test_declares_format_flowed(self):
+        part = draft(text_body="Hi")["bodyStructure"]
+        self.assertEqual(part["type"], TEXT_PLAIN_FLOWED)
+        self.assertEqual(part["type"], "text/plain; format=flowed; delsp=no")
+
+    def test_body_value_carries_the_text(self):
+        self.assertEqual(draft(text_body="Hi\nthere")["bodyValues"]["text"]["value"], "Hi\nthere")
+
+    def test_no_text_body_means_no_text_part(self):
+        self.assertNotIn("text", draft(html_body="<p>Hi</p>")["bodyValues"])
+
+
+class Structure(unittest.TestCase):
+    def test_convenience_properties_are_never_used(self):
+        # They are what strips the parameters, so nothing may fall back to them.
+        payload = draft(text_body="Hi", html_body="<p>Hi</p>")
+        self.assertNotIn("textBody", payload)
+        self.assertNotIn("htmlBody", payload)
+
+    def test_both_bodies_become_multipart_alternative(self):
+        body = draft(text_body="Hi", html_body="<p>Hi</p>")["bodyStructure"]
+        self.assertEqual(body["type"], "multipart/alternative")
+        # Least faithful representation last, so a reader picks the richest it can show.
+        self.assertEqual([p["partId"] for p in body["subParts"]], ["text", "html"])
+
+    def test_single_body_is_not_wrapped(self):
+        self.assertEqual(draft(text_body="Hi")["bodyStructure"]["partId"], "text")
+
+    def test_inline_attachments_nest_in_multipart_related(self):
+        body = draft(html_body="<p>Hi</p>", attachments=[attachment("inline")])["bodyStructure"]
+        self.assertEqual(body["type"], "multipart/related")
+        self.assertEqual(body["subParts"][0]["partId"], "html")
+
+    def test_regular_attachments_nest_in_multipart_mixed(self):
+        body = draft(text_body="Hi", attachments=[attachment("attachment")])["bodyStructure"]
+        self.assertEqual(body["type"], "multipart/mixed")
+        self.assertEqual(body["subParts"][0]["partId"], "text")
+
+    def test_both_kinds_keep_inline_images_out_of_the_mixed_level(self):
+        body = draft(
+            text_body="Hi",
+            html_body="<p>Hi</p>",
+            attachments=[attachment("inline"), attachment("attachment")],
+        )["bodyStructure"]
+        self.assertEqual(body["type"], "multipart/mixed")
+        related = body["subParts"][0]
+        self.assertEqual(related["type"], "multipart/related")
+        self.assertEqual(related["subParts"][0]["type"], "multipart/alternative")
+
+    def test_attachments_without_a_body_stay_on_the_convenience_property(self):
+        payload = draft(attachments=[attachment("attachment")])
+        self.assertNotIn("bodyStructure", payload)
+        self.assertEqual(len(payload["attachments"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/suite/mail/tests/test_html_to_text.py
+++ b/suite/mail/tests/test_html_to_text.py
@@ -9,7 +9,7 @@ something do not."""
 
 import unittest
 
-from suite.mail.utils.html_to_text import DEFAULT_WIDTH, html_to_text
+from suite.mail.utils.html_to_text import DEFAULT_WIDTH, html_to_text, to_flowed
 
 
 class Empty(unittest.TestCase):
@@ -456,3 +456,41 @@ class ComposedBody(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ToFlowed(unittest.TestCase):
+    """Ready-made text re-encoded as format=flowed. Every line comes out fixed, so the breaks
+    the sender chose are the breaks the reader sees."""
+
+    def test_empty(self):
+        self.assertEqual(to_flowed(None), "")
+        self.assertEqual(to_flowed(""), "")
+
+    def test_plain_lines_are_unchanged(self):
+        self.assertEqual(to_flowed("One\nTwo"), "One\nTwo")
+
+    def test_no_line_ends_with_a_space(self):
+        # A trailing space would be read as a soft break and join the two lines.
+        self.assertEqual(to_flowed("One   \nTwo"), "One\nTwo")
+
+    def test_leading_space_is_stuffed(self):
+        self.assertEqual(to_flowed("  indented"), "   indented")
+
+    def test_from_line_is_stuffed(self):
+        self.assertEqual(to_flowed("From here on"), " From here on")
+
+    def test_quote_marker_is_left_alone(self):
+        # In text written as text a leading `>` is a real quote, not content to protect.
+        self.assertEqual(to_flowed("> quoted"), "> quoted")
+
+    def test_signature_separator_keeps_its_trailing_space(self):
+        self.assertEqual(to_flowed("Bye\n-- \nAlex"), "Bye\n-- \nAlex")
+
+    def test_blank_lines_survive(self):
+        self.assertEqual(to_flowed("One\n\nTwo"), "One\n\nTwo")
+
+    def test_output_is_valid_flowed(self):
+        # The property that matters: nothing the caller wrote can be mistaken for a soft break.
+        text = to_flowed("Para one   \n\n  indented\nFrom X\n-- \nSig")
+        soft = [line for line in text.split("\n") if line.endswith(" ")]
+        self.assertEqual(soft, ["-- "])

--- a/suite/mail/tests/test_html_to_text.py
+++ b/suite/mail/tests/test_html_to_text.py
@@ -1,0 +1,458 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+"""The text/plain rendering contract: an HTML body keeps its shape on the way to a plain-text
+reader. Line breaks survive, paragraphs stay apart, lists keep their markers, quotes keep their
+``>``, links keep their destinations, and nothing a browser hides leaks into view. Under
+``flowed`` the lines that were only broken to fit say so, and the ones whose breaks mean
+something do not."""
+
+import unittest
+
+from suite.mail.utils.html_to_text import DEFAULT_WIDTH, html_to_text
+
+
+class Empty(unittest.TestCase):
+    """Nothing in, nothing out, and never a crash on the way."""
+
+    def test_none(self):
+        self.assertEqual(html_to_text(None), "")
+
+    def test_empty_string(self):
+        self.assertEqual(html_to_text(""), "")
+
+    def test_whitespace_only(self):
+        self.assertEqual(html_to_text("   \n\t "), "")
+
+    def test_markup_with_no_text(self):
+        self.assertEqual(html_to_text("<div><span></span></div>"), "")
+
+    def test_unclosed_tags_keep_their_text(self):
+        # Where the parser closes an unclosed block is its own business; losing the text is not.
+        self.assertEqual(html_to_text("<div><p>Hello<div>World"), "Hello\nWorld")
+
+
+class LineBreaks(unittest.TestCase):
+    """The defect this module exists for: a body must not arrive as one line."""
+
+    def test_br_breaks_the_line(self):
+        self.assertEqual(html_to_text("Hello<br>World"), "Hello\nWorld")
+
+    def test_divs_are_consecutive_lines(self):
+        # What the composer writes: one <div> per line, no blank line between them.
+        self.assertEqual(html_to_text("<div>One</div><div>Two</div>"), "One\nTwo")
+
+    def test_paragraphs_are_separated_by_a_blank_line(self):
+        self.assertEqual(html_to_text("<p>One</p><p>Two</p>"), "One\n\nTwo")
+
+    def test_empty_div_with_a_break_is_a_blank_line(self):
+        # The composer's spelling of "the sender pressed Return".
+        self.assertEqual(
+            html_to_text("<div>Hi,</div><div><br></div><div>Bye</div>"),
+            "Hi,\n\nBye",
+        )
+
+    def test_trailing_break_does_not_add_a_line(self):
+        self.assertEqual(html_to_text("<div>One<br></div><div>Two</div>"), "One\nTwo")
+
+    def test_consecutive_breaks_are_blank_lines(self):
+        self.assertEqual(html_to_text("<div>One<br><br>Two</div>"), "One\n\nTwo")
+
+    def test_empty_div_without_a_break_is_not_a_line(self):
+        self.assertEqual(html_to_text("<div>One</div><div></div><div>Two</div>"), "One\nTwo")
+
+    def test_heading_stands_apart(self):
+        self.assertEqual(html_to_text("<h1>Title</h1><p>Body</p>"), "Title\n\nBody")
+
+    def test_blank_runs_are_capped(self):
+        html = "<div>One</div>" + "<div><br></div>" * 6 + "<div>Two</div>"
+        self.assertEqual(html_to_text(html), "One\n\n\nTwo")
+
+    def test_leading_and_trailing_blank_lines_are_dropped(self):
+        self.assertEqual(html_to_text("<div><br></div><p>Body</p><div><br></div>"), "Body")
+
+
+class Whitespace(unittest.TestCase):
+    """Source formatting is not content, and content is not source formatting."""
+
+    def test_source_newlines_collapse_to_a_space(self):
+        self.assertEqual(html_to_text("<p>Hello\n   there</p>"), "Hello there")
+
+    def test_space_between_tags_does_not_double(self):
+        self.assertEqual(html_to_text("<p><b>Hello</b> <i>there</i></p>"), "Hello there")
+
+    def test_whitespace_between_blocks_is_not_a_paragraph(self):
+        self.assertEqual(html_to_text("<div>One</div>\n  \n<div>Two</div>"), "One\nTwo")
+
+    def test_no_break_space_becomes_a_space(self):
+        self.assertEqual(html_to_text("<p>Hello\xa0there</p>"), "Hello there")
+
+    def test_zero_width_characters_are_removed(self):
+        self.assertEqual(html_to_text("<p>He​llo﻿</p>"), "Hello")
+
+    def test_soft_hyphen_is_removed(self):
+        self.assertEqual(html_to_text("<p>man­uscript</p>"), "manuscript")
+
+
+class Links(unittest.TestCase):
+    """A plain-text reader has no href to fall back on, so the destination is spelled inline."""
+
+    def test_url_follows_the_label(self):
+        self.assertEqual(
+            html_to_text('<p>Read <a href="https://example.com/spec">the spec</a>.</p>'),
+            "Read the spec <https://example.com/spec>.",
+        )
+
+    def test_label_that_is_already_the_url_is_not_repeated(self):
+        self.assertEqual(
+            html_to_text('<p><a href="https://example.com">https://example.com</a></p>'),
+            "https://example.com",
+        )
+
+    def test_label_matching_the_url_but_for_scheme_is_not_repeated(self):
+        self.assertEqual(
+            html_to_text('<p><a href="https://www.example.com/">example.com</a></p>'),
+            "example.com",
+        )
+
+    def test_mailto_is_shown_as_the_address(self):
+        self.assertEqual(
+            html_to_text('<p>Write to <a href="mailto:someone@example.com">Alex</a>.</p>'),
+            "Write to Alex <someone@example.com>.",
+        )
+
+    def test_mailto_matching_its_label_is_not_repeated(self):
+        self.assertEqual(
+            html_to_text('<p><a href="mailto:someone@example.com">someone@example.com</a></p>'),
+            "someone@example.com",
+        )
+
+    def test_mailto_query_is_dropped(self):
+        self.assertEqual(
+            html_to_text('<p><a href="mailto:s@example.com?subject=Hi">Ping</a></p>'),
+            "Ping <s@example.com>",
+        )
+
+    def test_opaque_hrefs_contribute_nothing(self):
+        for href in ("#", "#anchor", "javascript:void(0)", "data:text/plain,x", "cid:logo"):
+            with self.subTest(href=href):
+                self.assertEqual(html_to_text('<p><a href="' + href + '">Label</a></p>'), "Label")
+
+    def test_anchor_without_href_is_just_its_label(self):
+        self.assertEqual(html_to_text("<p><a>Label</a></p>"), "Label")
+
+    def test_unlabelled_link_still_carries_its_url(self):
+        self.assertEqual(
+            html_to_text('<p><a href="https://example.com/x"><img src="l.png"></a></p>'),
+            "<https://example.com/x>",
+        )
+
+    def test_nested_markup_in_the_label_is_kept(self):
+        self.assertEqual(
+            html_to_text('<p><a href="https://example.com"><b>Bold</b> link</a></p>'),
+            "Bold link <https://example.com>",
+        )
+
+    def test_url_is_never_broken_across_lines(self):
+        url = "https://example.com/a/very/long/path/that/keeps/going/and/going/forever"
+        text = html_to_text('<p>See <a href="' + url + '">here</a> now.</p>')
+        self.assertIn("<" + url + ">", text)
+
+
+class Lists(unittest.TestCase):
+    """Markers are what makes a list a list once the bullets are gone."""
+
+    def test_unordered_items_get_a_dash(self):
+        self.assertEqual(
+            html_to_text("<ul><li>First</li><li>Second</li></ul>"),
+            "- First\n- Second",
+        )
+
+    def test_ordered_items_are_numbered(self):
+        self.assertEqual(
+            html_to_text("<ol><li>First</li><li>Second</li></ol>"),
+            "1. First\n2. Second",
+        )
+
+    def test_ordered_list_honours_start(self):
+        self.assertEqual(
+            html_to_text('<ol start="3"><li>Third</li><li>Fourth</li></ol>'),
+            "3. Third\n4. Fourth",
+        )
+
+    def test_list_is_separated_from_surrounding_text(self):
+        self.assertEqual(
+            html_to_text("<p>Agenda:</p><ul><li>One</li></ul><p>Thanks</p>"),
+            "Agenda:\n\n- One\n\nThanks",
+        )
+
+    def test_nested_list_is_indented_under_its_parent(self):
+        self.assertEqual(
+            html_to_text("<ul><li>Outer<ul><li>Inner</li></ul></li></ul>"),
+            "- Outer\n  - Inner",
+        )
+
+    def test_wrapped_item_aligns_under_its_marker(self):
+        text = html_to_text("<ul><li>" + "word " * 30 + "</li></ul>", width=40)
+        lines = text.split("\n")
+        self.assertTrue(lines[0].startswith("- "))
+        self.assertTrue(all(line.startswith("  ") and not line.startswith("- ") for line in lines[1:]))
+
+    def test_second_paragraph_in_an_item_keeps_the_indent(self):
+        self.assertEqual(
+            html_to_text("<ul><li><p>One</p><p>Two</p></li></ul>"),
+            "- One\n\n  Two",
+        )
+
+
+class Quotes(unittest.TestCase):
+    """A blockquote is the reply trail, and `>` is how a plain-text reader sees it."""
+
+    def test_blockquote_is_prefixed(self):
+        self.assertEqual(html_to_text("<blockquote><p>Quoted</p></blockquote>"), "> Quoted")
+
+    def test_nested_blockquotes_stack(self):
+        self.assertEqual(
+            html_to_text("<blockquote><blockquote><p>Deep</p></blockquote></blockquote>"),
+            ">> Deep",
+        )
+
+    def test_blank_line_inside_a_quote_keeps_the_marker(self):
+        self.assertEqual(
+            html_to_text("<blockquote><p>One</p><p>Two</p></blockquote>"),
+            "> One\n>\n> Two",
+        )
+
+    def test_quote_after_body_text(self):
+        self.assertEqual(
+            html_to_text("<p>Agreed.</p><blockquote><p>Original</p></blockquote>"),
+            "Agreed.\n\n> Original",
+        )
+
+    def test_wrapped_quote_keeps_the_marker_on_every_line(self):
+        text = html_to_text("<blockquote><p>" + "word " * 40 + "</p></blockquote>", width=40)
+        self.assertTrue(all(line.startswith("> ") for line in text.split("\n")))
+
+
+class Preformatted(unittest.TestCase):
+    """<pre> means the whitespace is the content."""
+
+    def test_internal_newlines_and_spacing_survive(self):
+        self.assertEqual(
+            html_to_text("<pre>def f():\n    return 1</pre>"),
+            "def f():\n    return 1",
+        )
+
+    def test_surrounding_newlines_are_trimmed(self):
+        self.assertEqual(html_to_text("<pre>\ncode\n</pre>"), "code")
+
+    def test_long_lines_are_not_wrapped(self):
+        line = "x" * 200
+        self.assertEqual(html_to_text("<pre>" + line + "</pre>", width=40), line)
+
+
+class Tables(unittest.TestCase):
+    """A row is a line; cells are separated, not broken."""
+
+    def test_row_becomes_one_line(self):
+        self.assertEqual(
+            html_to_text("<table><tr><td><b>From:</b></td><td>a@example.com</td></tr></table>"),
+            "From: a@example.com",
+        )
+
+    def test_rows_are_consecutive_lines(self):
+        html = "<table><tr><td>From:</td><td>a</td></tr><tr><td>To:</td><td>b</td></tr></table>"
+        self.assertEqual(html_to_text(html), "From: a\nTo: b")
+
+
+class Dropped(unittest.TestCase):
+    """What a browser never shows must not be the first thing a terminal does."""
+
+    def test_style_and_script_contribute_nothing(self):
+        html = "<style>p{color:red}</style><script>alert(1)</script><p>Body</p>"
+        self.assertEqual(html_to_text(html), "Body")
+
+    def test_head_is_skipped(self):
+        html = "<html><head><title>Subject</title></head><body><p>Body</p></body></html>"
+        self.assertEqual(html_to_text(html), "Body")
+
+    def test_display_none_preheader_is_skipped(self):
+        html = '<div style="display:none">Preheader teaser</div><p>Body</p>'
+        self.assertEqual(html_to_text(html), "Body")
+
+    def test_mso_hide_is_skipped(self):
+        self.assertEqual(html_to_text('<div style="mso-hide:all">Hidden</div><p>B</p>'), "B")
+
+    def test_hidden_attribute_is_skipped(self):
+        self.assertEqual(html_to_text("<div hidden>Hidden</div><p>B</p>"), "B")
+
+    def test_button_label_is_dropped(self):
+        self.assertEqual(html_to_text("<p>Body</p><button>Click</button>"), "Body")
+
+    def test_comments_are_not_content(self):
+        self.assertEqual(html_to_text("<p>Body<!-- note --></p>"), "Body")
+
+    def test_image_alt_is_kept(self):
+        self.assertEqual(html_to_text('<p><img alt="Logo" src="l.png"> Corp</p>'), "[Logo] Corp")
+
+    def test_image_without_alt_contributes_nothing(self):
+        self.assertEqual(html_to_text('<p>Body <img src="pixel.gif"></p>'), "Body")
+
+
+class Wrapping(unittest.TestCase):
+    """Long prose is folded to a width a terminal can read without folding it twice."""
+
+    def test_prose_is_wrapped_to_the_width(self):
+        text = html_to_text("<p>" + "word " * 60 + "</p>", width=40)
+        self.assertTrue(all(len(line) <= 40 for line in text.split("\n")))
+        self.assertGreater(len(text.split("\n")), 1)
+
+    def test_default_width_is_used(self):
+        text = html_to_text("<p>" + "word " * 100 + "</p>")
+        self.assertTrue(all(len(line) <= DEFAULT_WIDTH for line in text.split("\n")))
+
+    def test_quote_prefix_counts_towards_the_width(self):
+        text = html_to_text("<blockquote><p>" + "word " * 60 + "</p></blockquote>", width=40)
+        self.assertTrue(all(len(line) <= 40 for line in text.split("\n")))
+
+    def test_hard_breaks_are_not_joined_by_wrapping(self):
+        self.assertEqual(html_to_text("<p>Short<br>Also short</p>", width=72), "Short\nAlso short")
+
+
+class Flowed(unittest.TestCase):
+    """RFC 3676: a soft break says "I wrapped this, feel free to unwrap it"; a fixed line says
+    "this break is mine"."""
+
+    def test_soft_breaks_end_with_a_space(self):
+        lines = html_to_text("<p>" + "word " * 40 + "</p>", width=40, flowed=True).split("\n")
+        self.assertTrue(all(line.endswith(" ") for line in lines[:-1]))
+        self.assertFalse(lines[-1].endswith(" "))
+
+    def test_hard_breaks_stay_fixed(self):
+        text = html_to_text("<p>One<br>Two</p>", width=40, flowed=True)
+        self.assertEqual(text, "One\nTwo")
+
+    def test_paragraph_end_is_fixed(self):
+        text = html_to_text("<p>One</p><p>Two</p>", width=40, flowed=True)
+        self.assertEqual(text, "One\n\nTwo")
+
+    def test_list_items_are_never_flowed(self):
+        text = html_to_text("<ul><li>" + "word " * 30 + "</li></ul>", width=40, flowed=True)
+        self.assertTrue(all(not line.endswith(" ") for line in text.split("\n")))
+
+    def test_preformatted_lines_are_never_flowed(self):
+        text = html_to_text("<pre>code   \nmore</pre>", width=40, flowed=True)
+        self.assertTrue(all(not line.endswith(" ") for line in text.split("\n")))
+
+    def test_quoted_prose_is_flowed(self):
+        lines = html_to_text(
+            "<blockquote><p>" + "word " * 40 + "</p></blockquote>", width=40, flowed=True
+        ).split("\n")
+        self.assertTrue(all(line.startswith("> ") for line in lines))
+        self.assertTrue(all(line.endswith(" ") for line in lines[:-1]))
+
+    def test_line_starting_with_a_space_is_stuffed(self):
+        # <pre> is the only way to open a line with a space; unstuffed, the reader eats it.
+        self.assertEqual(html_to_text("<pre>  indented</pre>", flowed=True), "   indented")
+
+    def test_line_starting_with_a_quote_character_is_stuffed(self):
+        self.assertEqual(html_to_text("<pre>&gt; not a quote</pre>", flowed=True), " > not a quote")
+
+    def test_from_line_is_stuffed(self):
+        self.assertEqual(html_to_text("<p>From here on</p>", flowed=True), " From here on")
+
+    def test_stuffing_is_only_for_flowed(self):
+        self.assertEqual(html_to_text("<p>From here on</p>", flowed=False), "From here on")
+
+    def test_blank_line_is_never_a_soft_break(self):
+        text = html_to_text("<p>One</p><p>Two</p>", flowed=True)
+        self.assertEqual(text.split("\n")[1], "")
+
+    def test_signature_separator_keeps_its_trailing_space(self):
+        # RFC 3676 4.3, the one fixed line that ends in a space on purpose.
+        text = html_to_text("<div>Bye</div><div>-- </div><div>Alex</div>", flowed=True)
+        self.assertEqual(text, "Bye\n-- \nAlex")
+
+
+class RoundTrip(unittest.TestCase):
+    """The receiving half of format=flowed, run against our own output: unwrapping a flowed body
+    the way RFC 3676 §4.2 says to must give back the paragraph that went in."""
+
+    @staticmethod
+    def unflow(text: str) -> list[str]:
+        paragraphs: list[str] = []
+        pending = ""
+
+        for line in text.split("\n"):
+            depth = len(line) - len(line.lstrip(">"))
+            content = line[depth:]
+            if content.startswith(" "):
+                content = content[1:]
+
+            pending += content
+            if not content.endswith(" "):
+                paragraphs.append(">" * depth + pending)
+                pending = ""
+
+        if pending:
+            paragraphs.append(pending)
+
+        return paragraphs
+
+    def test_wrapped_prose_reassembles(self):
+        sentence = "The quick brown fox jumps over the lazy dog and keeps on running."
+        flowed = html_to_text("<p>" + sentence + "</p>", width=30, flowed=True)
+        self.assertGreater(len(flowed.split("\n")), 1)
+        self.assertEqual(self.unflow(flowed), [sentence])
+
+    def test_quoted_prose_reassembles_with_its_depth(self):
+        sentence = "The quick brown fox jumps over the lazy dog and keeps on running."
+        flowed = html_to_text("<blockquote><p>" + sentence + "</p></blockquote>", width=30, flowed=True)
+        self.assertEqual(self.unflow(flowed), [">" + sentence])
+
+    def test_stuffed_leading_space_survives(self):
+        flowed = html_to_text("<pre>  indented</pre>", flowed=True)
+        self.assertEqual(self.unflow(flowed), ["  indented"])
+
+
+class ComposedBody(unittest.TestCase):
+    """The whole point, end to end: what the composer actually writes, as aerc would show it."""
+
+    HTML = (
+        "<div>Hi Team,</div>"
+        "<div><br></div>"
+        '<div>Please review <a href="https://example.com/docs/spec">the spec page</a> '
+        "and mail me at support@example.com.</div>"
+        "<div><br></div>"
+        "<ul><li>First item</li><li>Second item</li></ul>"
+        "<div><br></div>"
+        "<div>Regards,</div>"
+        "<div>Alex</div>"
+    )
+
+    def test_reads_as_written(self):
+        self.assertEqual(
+            html_to_text(self.HTML),
+            "Hi Team,\n"
+            "\n"
+            "Please review the spec page <https://example.com/docs/spec> and mail me\n"
+            "at support@example.com.\n"
+            "\n"
+            "- First item\n"
+            "- Second item\n"
+            "\n"
+            "Regards,\n"
+            "Alex",
+        )
+
+    def test_address_is_not_split_by_punctuation(self):
+        # The bug in convert_html_to_text: the "." before a word gained a space, so every
+        # address and URL path in the body was broken.
+        self.assertIn("support@example.com", html_to_text(self.HTML))
+
+    def test_link_destination_survives(self):
+        self.assertIn("<https://example.com/docs/spec>", html_to_text(self.HTML))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/suite/mail/tests/test_html_to_text.py
+++ b/suite/mail/tests/test_html_to_text.py
@@ -494,3 +494,45 @@ class ToFlowed(unittest.TestCase):
         text = to_flowed("Para one   \n\n  indented\nFrom X\n-- \nSig")
         soft = [line for line in text.split("\n") if line.endswith(" ")]
         self.assertEqual(soft, ["-- "])
+
+
+class Signature(unittest.TestCase):
+    """The composer marks the signature it inserts, so the text part can carry the separator a
+    reader looks for. RFC 3676 4.3: exactly "-- ", trailing space included."""
+
+    SIG = (
+        "<div>Regards,</div><div>Alex</div><div><br></div>"
+        '<div class="frappe_mail_signature"><div>Alex Smith</div>'
+        '<div><a href="mailto:alex@example.com">alex@example.com</a></div></div>'
+    )
+
+    def test_separator_precedes_the_signature(self):
+        self.assertEqual(
+            html_to_text(self.SIG),
+            "Regards,\nAlex\n\n-- \nAlex Smith\nalex@example.com",
+        )
+
+    def test_separator_keeps_its_trailing_space(self):
+        self.assertIn("\n-- \n", html_to_text(self.SIG))
+
+    def test_separator_survives_flowed(self):
+        # It is the one fixed line allowed to end in a space, so it must not be trimmed.
+        self.assertIn("\n-- \n", html_to_text(self.SIG, flowed=True))
+
+    def test_signature_is_never_a_soft_break(self):
+        lines = html_to_text(self.SIG, flowed=True).splitlines()
+        self.assertEqual([line for line in lines if line.endswith(" ")], ["-- "])
+
+    def test_unmarked_body_gets_no_separator(self):
+        self.assertNotIn("--", html_to_text("<div>Regards,</div><div>Alex</div>"))
+
+    def test_empty_signature_block_is_skipped(self):
+        # Nothing to introduce, so the separator would only mislead.
+        self.assertEqual(html_to_text('<div>Body</div><div class="frappe_mail_signature"></div>'), "Body")
+
+    def test_class_is_matched_among_others(self):
+        html = '<div>Body</div><div class="foo frappe_mail_signature"><div>Alex</div></div>'
+        self.assertEqual(html_to_text(html), "Body\n\n-- \nAlex")
+
+    def test_signature_sits_on_the_line_below_the_separator(self):
+        self.assertNotIn("-- \n\n", html_to_text(self.SIG))

--- a/suite/mail/tests/test_mail_identity_settings.py
+++ b/suite/mail/tests/test_mail_identity_settings.py
@@ -45,9 +45,19 @@ class TestMailIdentitySettings(StalwartIntegrationTestCase):
             rows = {i["id"]: i for i in get_identities(self.account)}
             self.assertEqual(rows[identity_id]["_name"], "Renamed Persona")
 
-            set_signature(rows[identity_id]["name"], "<p>Kind regards</p>")
+            set_signature(
+                rows[identity_id]["name"],
+                "<div>Kind regards</div><div>Alex</div>"
+                '<div><a href="https://example.com/team">our team page</a></div>',
+            )
             rows = {i["id"]: i for i in get_identities(self.account)}
             self.assertIn("Kind regards", rows[identity_id]["html_signature"] or "")
+            # The text form is the same signature, not a one-line trace of it: JMAP carries
+            # both and a client renders whichever part it shows.
+            self.assertEqual(
+                rows[identity_id]["text_signature"],
+                "Kind regards\nAlex\nour team page <https://example.com/team>",
+            )
 
             delete_identities(self.account, [identity_id])
             self.assertNotIn(identity_id, [i["id"] for i in get_identities(self.account)])
@@ -99,12 +109,15 @@ class TestMailIdentitySettings(StalwartIntegrationTestCase):
                 self.account,
                 enabled=1,
                 subject="Out of office",
-                html_body="<p>Back next week.</p>",
-                text_body="Back next week.",
+                html_body="<div>Back next week.</div><div>Ask ops@example.com if urgent.</div>",
+                text_body="ignored, the HTML body is authoritative",
             )
             vacation = get_vacation_response(self.account)
             self.assertTrue(vacation["enabled"])
             self.assertEqual(vacation["subject"], "Out of office")
+            # Derived from the HTML rather than taken from the caller, and keeping its shape:
+            # an auto-reply is read as plain text by whoever gets it.
+            self.assertEqual(vacation["text_body"], "Back next week.\nAsk ops@example.com if urgent.")
 
             # Turning vacation off reactivates the previously active (automation) script.
             update_vacation_response(self.account, enabled=0)

--- a/suite/mail/tests/test_mail_plaintext.py
+++ b/suite/mail/tests/test_mail_plaintext.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+from email import message_from_bytes, policy
+
+import frappe
+
+from suite.mail.api.mail import fetch_mail_as_eml
+from suite.mail.tests.base import StalwartIntegrationTestCase, unique_name
+
+BODY = (
+    "<div>Hi Team,</div>"
+    "<div><br></div>"
+    '<div>Please review <a href="https://example.com/docs/spec">the spec page</a> '
+    "and reply to support@example.com if anything looks wrong before Friday.</div>"
+    "<div><br></div>"
+    "<ul><li>First item</li><li>Second item</li></ul>"
+    "<div><br></div>"
+    "<div>Regards,</div>"
+    "<div>Alex</div>"
+)
+
+
+class TestOutgoingPlaintext(StalwartIntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.sender = cls.create_member()
+        cls.receiver = cls.create_member()
+        cls.disable_screening(cls.receiver)
+
+    def delivered(self, html_body: str = BODY, **kwargs):
+        """Sends a mail, waits for it, and returns the parsed MIME message as received."""
+
+        subject = "Plaintext " + unique_name("subject")
+        result = self.send_mail(
+            self.sender, self.receiver.email, subject=subject, html_body=html_body, **kwargs
+        )
+        self.assertEqual(result["status"], "Submitted", result.get("error"))
+
+        thread = self.wait_until(
+            lambda: next((t for t in self.get_inbox_threads(self.receiver) if t["subject"] == subject), None),
+            timeout=60,
+            message="Mail did not arrive.",
+        )
+        with self.set_user(self.receiver.email):
+            eml = bytes(fetch_mail_as_eml(thread["messages"][-1]["name"]))
+        return message_from_bytes(eml, policy=policy.default)
+
+    @staticmethod
+    def body_part(message, content_type: str):
+        """The body part of the given type, skipping attachments that share it."""
+
+        return next(
+            part
+            for part in message.walk()
+            if part.get_content_type() == content_type and not part.get_filename()
+        )
+
+    def text_body(self, message) -> str:
+        """The decoded text part, CRLF normalised so line assertions read naturally.
+
+        Stalwart sends this part quoted-printable, which is what carries a soft break's
+        trailing space over the wire (as =20). The decoder hands it back with CRLF endings,
+        so splitting on "\\n" alone would leave a "\\r" on every line and hide the space.
+        """
+
+        return self.body_part(message, "text/plain").get_content().replace("\r\n", "\n")
+
+    def test_send_carries_a_text_alternative(self):
+        message = self.delivered()
+        self.assertEqual(message.get_content_type(), "multipart/alternative")
+        # Least faithful first, so a reader picks the richest part it can show.
+        self.assertEqual([p.get_content_type() for p in message.iter_parts()], ["text/plain", "text/html"])
+
+    def test_text_part_declares_format_flowed(self):
+        # The whole reason _get_draft spells out bodyStructure. If this fails, Stalwart dropped
+        # the parameters and the flowed encoding should be turned off with it.
+        text = self.body_part(self.delivered(), "text/plain")
+        self.assertEqual(text.get_param("format"), "flowed")
+        self.assertEqual(text.get_param("delsp"), "no")
+        self.assertEqual((text.get_content_charset() or "").lower(), "utf-8")
+
+    def test_content_type_is_not_duplicated(self):
+        text = self.body_part(self.delivered(), "text/plain")
+        self.assertEqual(len(text.get_all("Content-Type") or []), 1)
+
+    def test_text_part_keeps_the_shape_of_the_message(self):
+        body = self.text_body(self.delivered())
+
+        self.assertGreater(len(body.splitlines()), 5, "body arrived as one run: " + repr(body))
+        self.assertIn("- First item", body)
+        self.assertIn("- Second item", body)
+        # The old converter turned this into "support@example. com".
+        self.assertIn("support@example.com", body)
+        self.assertIn("<https://example.com/docs/spec>", body)
+        self.assertRegex(body, r"Regards,\n *Alex")
+
+    def test_soft_breaks_survive_transport(self):
+        body = self.text_body(self.delivered())
+        wrapped = [line for line in body.splitlines() if line.endswith(" ")]
+        self.assertTrue(wrapped, "no soft line breaks reached the reader: " + repr(body))
+
+    def test_attachment_send_still_works(self):
+        # The bodyStructure switch replaced the `attachments` convenience property.
+        message = self.delivered(
+            attachments=[{"file_url": self._text_file(), "file_name": "note.txt", "type": "text/plain"}]
+        )
+        self.assertEqual(message.get_content_type(), "multipart/mixed")
+        self.assertIn("note.txt", [p.get_filename() for p in message.walk()])
+        self.assertEqual(self.body_part(message, "text/plain").get_param("format"), "flowed")
+
+    def _text_file(self) -> str:
+        return (
+            frappe.get_doc(
+                {
+                    "doctype": "File",
+                    "file_name": "note-" + unique_name("f") + ".txt",
+                    "content": "attached",
+                    "is_private": 1,
+                }
+            )
+            .insert(ignore_permissions=True)
+            .file_url
+        )

--- a/suite/mail/tests/test_mail_plaintext.py
+++ b/suite/mail/tests/test_mail_plaintext.py
@@ -123,3 +123,17 @@ class TestOutgoingPlaintext(StalwartIntegrationTestCase):
             .insert(ignore_permissions=True)
             .file_url
         )
+
+    def test_signature_is_introduced_by_the_separator(self):
+        # The composer wraps the signature it inserts; without the marker the block is just
+        # more markup and a reader cannot tell where the message ends.
+        html = (
+            "<div>Regards,</div><div>Alex</div><div><br></div>"
+            '<div class="frappe_mail_signature"><div>Alex Smith</div>'
+            "<div>Support Team</div></div>"
+        )
+        body = self.text_body(self.delivered(html))
+
+        self.assertIn("\n-- \nAlex Smith\nSupport Team", body)
+        # RFC 3676 4.3: the only fixed line allowed to end in a space.
+        self.assertEqual([line for line in body.splitlines() if line.endswith(" ")], ["-- "])

--- a/suite/mail/tests/test_mail_plaintext.py
+++ b/suite/mail/tests/test_mail_plaintext.py
@@ -137,3 +137,30 @@ class TestOutgoingPlaintext(StalwartIntegrationTestCase):
         self.assertIn("\n-- \nAlex Smith\nSupport Team", body)
         # RFC 3676 4.3: the only fixed line allowed to end in a space.
         self.assertEqual([line for line in body.splitlines() if line.endswith(" ")], ["-- "])
+
+    def test_a_text_only_mail_arrives_as_text(self):
+        # RFC 8621 lets htmlBody fall back to the text parts, so a mail with no HTML used to
+        # reach the reader through html_body, where prose is parsed as markup.
+        from suite.mail.api.outbound import send
+        from suite.mail.tests.test_mail_inbound_outbound_api import fake_request
+
+        subject = "Text only " + unique_name("subject")
+        with self.set_user(self.sender.email), fake_request():
+            queue = send(
+                from_=self.sender.email,
+                to=self.receiver.email,
+                subject=subject,
+                text="Line one\nLine two",
+            )
+            frappe.get_doc("Mail Queue", queue)._process()
+
+        thread = self.wait_until(
+            lambda: next((t for t in self.get_inbox_threads(self.receiver) if t["subject"] == subject), None),
+            timeout=60,
+            message="Text-only mail did not arrive.",
+        )
+        message = thread["messages"][-1]
+
+        self.assertFalse(message["html_body"], "a text-only body must not arrive as HTML")
+        self.assertIn("Line one", message["text_body"])
+        self.assertIn("Line two", message["text_body"])

--- a/suite/mail/utils/html_to_text.py
+++ b/suite/mail/utils/html_to_text.py
@@ -1,0 +1,461 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+"""Render an HTML mail body as the text/plain alternative sent alongside it.
+
+suite.utils.convert_html_to_text flattens a body to one line, which suits the preview
+strings it was written for but destroys a message. This keeps the line breaks, list
+markers, quoting and link targets a reader needs, since a terminal client shows this
+part and not the HTML one.
+
+flowed=True emits RFC 3676 (format=flowed; delsp=no). Declaring the matching
+Content-Type parameters is the caller's job.
+"""
+
+import re
+import textwrap
+from dataclasses import dataclass, replace
+from itertools import groupby
+from urllib.parse import urlsplit
+
+from bs4 import BeautifulSoup
+from bs4.element import NavigableString, PreformattedString, Tag
+
+DEFAULT_WIDTH = 72
+# Floor for the wrap column, so deep quoting or list nesting cannot squeeze text down to
+# a word per line.
+MIN_WIDTH = 24
+# Two blank lines is a sender pressing Return twice. Beyond that it is HTML padding.
+MAX_BLANK_RUN = 2
+# RFC 3676 4.3. The trailing space is what identifies it, so it survives every trim here.
+SIGNATURE_SEPARATOR = "-- "
+
+# Tags that never contribute text. `button` is among them because a call to action worth
+# reading is an <a>; a real <button> is a dead control whose label only adds noise.
+_DROPPED = frozenset(
+    {
+        "audio",
+        "button",
+        "canvas",
+        "embed",
+        "head",
+        "iframe",
+        "input",
+        "link",
+        "meta",
+        "noscript",
+        "object",
+        "option",
+        "script",
+        "select",
+        "style",
+        "svg",
+        "template",
+        "textarea",
+        "title",
+        "video",
+    }
+)
+
+# Blank lines a block leaves above and below itself. 1 sets it apart from its neighbours.
+# 0 only ends the line, so consecutive blocks read as consecutive lines, which is what the
+# composer writes (one <div> per line). Tags absent here are treated as inline: reading a
+# block as inline costs a line break, the reverse splits a sentence in half.
+_BLOCK_MARGIN = {
+    "address": 1,
+    "article": 1,
+    "dl": 1,
+    "figure": 1,
+    "footer": 1,
+    "form": 1,
+    "h1": 1,
+    "h2": 1,
+    "h3": 1,
+    "h4": 1,
+    "h5": 1,
+    "h6": 1,
+    "header": 1,
+    "main": 1,
+    "p": 1,
+    "section": 1,
+    "table": 1,
+    "caption": 0,
+    "center": 0,
+    "dd": 0,
+    "div": 0,
+    "dt": 0,
+    "figcaption": 0,
+    "li": 0,
+    "tbody": 0,
+    "tfoot": 0,
+    "thead": 0,
+    "tr": 0,
+}
+
+# Zero width marks, bidi controls, soft hyphen, and controls other than tab and newline.
+# Invisible in a browser, literal mojibake in a terminal.
+_INVISIBLE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f\xad​-‏‪-‮⁠-⁯﻿]")
+_WHITESPACE = re.compile(r"\s+")
+# A line with no content, quote prefix aside.
+_BLANK = re.compile(r"^>*\s*$")
+# How preheaders, tracking pixel wrappers and alternate layouts hide from the HTML reader.
+# Unhidden, the preheader is the first thing in the text part.
+_HIDDEN = re.compile(r"(?:^|;)\s*(?:display\s*:\s*none|mso-hide\s*:\s*all)\s*(?:;|$)", re.I)
+# Hrefs naming no destination a reader could act on.
+_OPAQUE_HREF = ("javascript:", "data:", "cid:", "about:", "#")
+_SCHEME_AND_WWW = re.compile(r"^(?:[a-z][a-z0-9+.-]*:)?(?://)?(?:www\.)?", re.I)
+
+
+def html_to_text(html: str | None, *, width: int = DEFAULT_WIDTH, flowed: bool = False) -> str:
+    """Plain text rendering of an HTML mail body.
+
+    width is the column to wrap at, quote prefix and list indent included. flowed emits
+    RFC 3676 soft line breaks.
+    """
+
+    if not html or not (content := html.strip()):
+        return ""
+    soup = BeautifulSoup(content, "html.parser")
+    return _render(_paragraphs(_tokenize(soup.body or soup, _State())), width, flowed)
+
+
+@dataclass(frozen=True)
+class _State:
+    """What the enclosing elements say about the text being collected."""
+
+    quote: int = 0
+    # Indent a list item's content sits on, the marker's width included.
+    padding: str = ""
+    is_pre: bool = False
+
+
+# The tree is flattened to these before any layout happens, so building paragraphs is a
+# fold over a flat list rather than a walk carrying shared state.
+
+
+@dataclass(frozen=True)
+class _Text:
+    value: str
+    state: _State
+
+
+@dataclass(frozen=True)
+class _Break:
+    state: _State
+
+
+@dataclass(frozen=True)
+class _Boundary:
+    """Ends the paragraph in progress and asks for margin blank lines around it."""
+
+    margin: int
+
+
+@dataclass(frozen=True)
+class _Marker:
+    """First line indent for the next paragraph, set by a list item."""
+
+    indent: str
+
+
+type _Token = _Text | _Break | _Boundary | _Marker
+
+
+@dataclass(frozen=True)
+class _Pending:
+    """Text gathered since the last boundary."""
+
+    line: tuple[str, ...] = ()  # pieces of the line being built
+    lines: tuple[str, ...] = ()  # lines already closed by a <br>
+    # Taken from the first content, so a paragraph renders under the element that produced
+    # it rather than whatever the fold had reached by the time something closed it.
+    state: _State | None = None
+    trailing_break: bool = False
+
+
+@dataclass(frozen=True)
+class _Paragraph:
+    """A block of text, split at its hard breaks but not yet wrapped."""
+
+    lines: tuple[str, ...] = ()
+    quote: int = 0
+    indent: str = ""  # first line, carrying the list marker where there is one
+    hang: str = ""  # every line after it
+    wrap: bool = True  # False for <pre>, whose breaks and spacing are the content
+    margin: int = 0  # blank lines above
+
+
+def _tokenize(node: Tag, state: _State) -> list[_Token]:
+    """Flatten an element's children into tokens."""
+
+    tokens: list[_Token] = []
+    for child in node.children:
+        if isinstance(child, Tag):
+            tokens += _tag_tokens(child, state)
+        # PreformattedString covers comments, doctypes and CDATA, which subclass
+        # NavigableString but are markup rather than content.
+        elif isinstance(child, NavigableString) and not isinstance(child, PreformattedString):
+            tokens.append(_Text(_clean(str(child), state.is_pre), state))
+    return tokens
+
+
+def _tag_tokens(el: Tag, state: _State) -> list[_Token]:
+    """Tokens for one element, chosen by tag."""
+
+    name = (el.name or "").lower()
+    if name in _DROPPED or el.has_attr("hidden") or _HIDDEN.search(str(el.get("style") or "")):
+        return []
+    if name == "br":
+        return [_Break(state)]
+    if name == "hr":
+        return _bounded([_Text("---", state)], 1)
+    if name == "img":
+        alt = _clean(str(el.get("alt") or ""), False).strip()
+        return [_Text("[" + alt + "]", state)] if alt else []
+    if name == "a":
+        return _anchor_tokens(el, state)
+    if name == "pre":
+        return _bounded(_tokenize(el, replace(state, is_pre=True)), 1)
+    if name == "blockquote":
+        return _bounded(_tokenize(el, replace(state, quote=state.quote + 1)), 1)
+    if name in ("ul", "ol"):
+        return _list_tokens(el, state)
+    if name in ("td", "th"):
+        # A row is one line, so cells are separated rather than broken. _add_text drops
+        # this space again when the line is empty or already ends in one.
+        return [_Text(" ", state), *_tokenize(el, state)]
+    if (margin := _BLOCK_MARGIN.get(name)) is not None:
+        return _bounded(_tokenize(el, state), margin)
+    return _tokenize(el, state)
+
+
+def _bounded(inner: list[_Token], margin: int) -> list[_Token]:
+    """Fence tokens off as their own paragraph."""
+
+    return [_Boundary(margin), *inner, _Boundary(margin)]
+
+
+def _list_tokens(el: Tag, state: _State) -> list[_Token]:
+    """Tokens for a <ul> or <ol>, one marker per item."""
+
+    # A nested list belongs to the item above it, so no blank line comes between them.
+    margin = 0 if state.padding else 1
+    ordered = (el.name or "").lower() == "ol"
+    start = str(el.get("start") or "")
+    first = int(start) if start.isdigit() else 1
+
+    tokens: list[_Token] = [_Boundary(margin)]
+    for offset, item in enumerate(el.find_all("li", recursive=False)):
+        marker = (str(first + offset) + ". ") if ordered else "- "
+        # Padding lines the item's later content up under the marker, not under the bullet.
+        inner = _tokenize(item, replace(state, padding=state.padding + " " * len(marker)))
+        # The empty marker stops an item that produced nothing from passing its own on.
+        tokens += [_Boundary(0), _Marker(state.padding + marker), *inner, _Boundary(0), _Marker("")]
+    return [*tokens, _Boundary(margin)]
+
+
+def _anchor_tokens(el: Tag, state: _State) -> list[_Token]:
+    """Tokens for an <a>, with its destination spelled out after the label."""
+
+    inner = _tokenize(el, state)
+    # Only the text after the last break, since that is the line the URL will follow.
+    breaks = [index for index, token in enumerate(inner) if isinstance(token, _Break)]
+    tail = inner[breaks[-1] + 1 :] if breaks else inner
+    label = "".join(token.value for token in tail if isinstance(token, _Text)).strip()
+
+    if not (target := _link_target(str(el.get("href") or ""), label)):
+        return inner
+    return [*inner, _Text((" <" if label else "<") + target + ">", state)]
+
+
+def _paragraphs(tokens: list[_Token]) -> list[_Paragraph]:
+    """Fold tokens into paragraphs."""
+
+    paragraphs: list[_Paragraph] = []
+    pending, marker, margin = _Pending(), "", 0
+
+    # The appended boundary closes whatever the last token left pending.
+    for token in [*tokens, _Boundary(0)]:
+        match token:
+            case _Text(value, state):
+                pending = _add_text(pending, value, state)
+            case _Break(state):
+                pending = _add_break(pending, state)
+            case _Marker(indent):
+                marker = indent
+            case _Boundary(block_margin):
+                # Marker and margin are spent only when a paragraph is actually emitted.
+                # A boundary that closed nothing leaves both for the next one.
+                if paragraph := _close(pending, marker, margin):
+                    paragraphs.append(paragraph)
+                    marker, margin = "", 0
+                pending = _Pending()
+                # The gap between two blocks is the larger of what each asked for.
+                margin = max(margin, block_margin)
+
+    return paragraphs
+
+
+def _add_text(pending: _Pending, value: str, state: _State) -> _Pending:
+    """Append inline text, leaving one space between adjacent runs however many the
+    source spells. Inside <pre> a leading space is indentation and is kept."""
+
+    current = "".join(pending.line)
+    collapse = not state.is_pre and (not current or current.endswith(" "))
+    text = value.lstrip(" ") if collapse else value
+    if not text:
+        return pending
+    return replace(pending, line=(*pending.line, text), state=pending.state or state, trailing_break=False)
+
+
+def _add_break(pending: _Pending, state: _State) -> _Pending:
+    """Close the line on a <br> without closing the paragraph."""
+
+    return replace(
+        pending,
+        line=(),
+        lines=(*pending.lines, "".join(pending.line)),
+        state=pending.state or state,
+        trailing_break=True,
+    )
+
+
+def _close(pending: _Pending, marker: str, margin: int) -> _Paragraph | None:
+    """Turn pending text into a paragraph, or None if it held no content."""
+
+    if (state := pending.state) is None:
+        return None
+
+    tail = ["".join(pending.line)] if pending.line or pending.trailing_break else []
+    collected = [*pending.lines, *tail]
+
+    if state.is_pre:
+        # <pre> arrives as one node holding its own newlines. Keep the blank lines inside
+        # it, drop the ones its tags sit on.
+        parts = [part for line in collected for part in line.split("\n")]
+        filled = [index for index, part in enumerate(parts) if part.strip()]
+        lines = parts[filled[0] : filled[-1] + 1] if filled else []
+    else:
+        stripped = [line if line == SIGNATURE_SEPARATOR else line.rstrip() for line in collected]
+        # A block ending in <br> is one line tall in a browser, not two.
+        ends_blank = pending.trailing_break and stripped and not stripped[-1]
+        lines = stripped[:-1] if ends_blank else stripped
+
+    # A block holding only markup (a spacer <div>, a pixel's wrapper) is not a blank line
+    # anyone wrote. One holding a <br> is.
+    if not any(lines) and not pending.trailing_break:
+        return None
+
+    return _Paragraph(
+        lines=tuple(lines) or ("",),
+        quote=state.quote,
+        indent=marker or state.padding,
+        hang=state.padding,
+        wrap=not state.is_pre,
+        margin=margin,
+    )
+
+
+def _render(paragraphs: list[_Paragraph], width: int, flowed: bool) -> str:
+    """Lay the paragraphs out and join them into the finished body."""
+
+    out: list[str] = []
+    previous_quote = 0
+    for index, paragraph in enumerate(paragraphs):
+        prefix = ">" * paragraph.quote + (" " if paragraph.quote else "")
+        is_blank = not any(line.strip() for line in paragraph.lines)
+        separated = not out or bool(_BLANK.match(out[-1]))
+        # A gap already left by an empty paragraph is the separation. Adding the margin on
+        # top would double the blank line around every list the composer's own empty <div>
+        # happens to sit next to.
+        if index and not is_blank and not separated:
+            # The blank line stays in the quote only where both sides are quoted, and
+            # keeps the `>` without its trailing space, which a fixed line may not have.
+            out += [">" * min(previous_quote, paragraph.quote)] * paragraph.margin
+        out += [
+            _wire(line, prefix, paragraph.quote, flowed)
+            for line in _layout(paragraph, width - len(prefix), flowed)
+        ]
+        previous_quote = paragraph.quote
+
+    # Cap the runs of blank lines that pathological markup piles up.
+    kept = []
+    for blank, run in groupby(out, key=lambda line: bool(_BLANK.match(line))):
+        group = list(run)
+        kept += group[:MAX_BLANK_RUN] if blank else group
+    return "\n".join(kept).strip("\n")
+
+
+def _layout(paragraph: _Paragraph, width: int, flowed: bool) -> list[str]:
+    """Wrap a paragraph to the column, marking the breaks it introduced when flowed."""
+
+    column = max(width, MIN_WIDTH)
+    # Indented text is never flowed: re-wrapping it would pull the continuation up beside
+    # the marker.
+    soft = flowed and paragraph.wrap and not paragraph.indent and not paragraph.hang
+    laid: list[str] = []
+    for index, line in enumerate(paragraph.lines):
+        indent = paragraph.hang if index else paragraph.indent
+        if line == SIGNATURE_SEPARATOR:
+            laid.append(line)  # textwrap would take the space that defines it
+        elif not paragraph.wrap:
+            # Trailing space in <pre> is content, but flowed it would read as a soft break.
+            laid.append((indent + line).rstrip() if flowed else indent + line)
+        elif not line.strip():
+            laid.append("")
+        else:
+            wrapped = textwrap.wrap(
+                line,
+                column,
+                initial_indent=indent,
+                subsequent_indent=paragraph.hang,
+                break_long_words=False,  # a broken URL is an unclickable URL
+                break_on_hyphens=False,
+            ) or [indent.rstrip()]
+            # Every line but the last was broken to fit, so offer it back for re-wrapping.
+            laid += ([piece + " " for piece in wrapped[:-1]] + wrapped[-1:]) if soft else wrapped
+    return laid
+
+
+def _wire(line: str, prefix: str, quote: int, flowed: bool) -> str:
+    """Put one laid out line on the wire, quoted and space stuffed."""
+
+    if line == SIGNATURE_SEPARATOR:
+        return prefix + line if quote else line
+    if quote:
+        # RFC 3676 4.5: the prefix is the run of `>` alone, and a reader deletes one
+        # leading space. So this displays as "> text" everywhere and still arrives as
+        # "text", whatever the content starts with.
+        return prefix + line if line.strip() else prefix.rstrip()
+    # 4.4 space stuffing. Without it the reader eats the line's own leading space, or
+    # reads it as a quote it never was.
+    stuff = flowed and (line[:1] in (" ", ">") or line.startswith("From "))
+    return (" " + line) if stuff else line
+
+
+def _clean(value: str, pre: bool) -> str:
+    """Drop what a terminal cannot show, and collapse whitespace outside <pre>."""
+
+    # A no-break space reads as a space but never wraps, so it becomes one.
+    text = _INVISIBLE.sub("", value.replace("\xa0", " "))
+    return text if pre else _WHITESPACE.sub(" ", text)
+
+
+def _link_target(url: str, label: str) -> str:
+    """The URL worth spelling out beside a label, or "" when it adds nothing."""
+
+    href = url.strip()
+    if not href or href.lower().startswith(_OPAQUE_HREF):
+        return ""
+    # A mailto's query string (?subject=) addresses a composer, not a reader.
+    parts = urlsplit(href)
+    target = parts.path if parts.scheme.lower() == "mailto" else href
+    if not target or (label and _bare(label) in (_bare(target), _bare(href))):
+        return ""
+    return target
+
+
+def _bare(url: str) -> str:
+    """A URL cut down to what a label has to say to be saying the same thing."""
+
+    return _SCHEME_AND_WWW.sub("", url.strip()).rstrip("/").lower()

--- a/suite/mail/utils/html_to_text.py
+++ b/suite/mail/utils/html_to_text.py
@@ -119,6 +119,26 @@ def html_to_text(html: str | None, *, width: int = DEFAULT_WIDTH, flowed: bool =
     return _render(_paragraphs(_tokenize(soup.body or soup, _State())), width, flowed)
 
 
+def to_flowed(text: str | None) -> str:
+    """Re-encode ready-made plain text as `format=flowed`, without reflowing it.
+
+    Every line comes out fixed, so a reader shows the breaks the sender chose. This is for
+    text the app did not generate, so a part can declare one wire format either way.
+
+    Unlike _wire, a leading `>` is left alone: in text written as text it is a quote, and
+    stuffing it would show the reader a literal `>` instead.
+    """
+
+    if not text:
+        return ""
+    lines = []
+    for line in text.splitlines():
+        fixed = line if line == SIGNATURE_SEPARATOR else line.rstrip()
+        stuff = fixed[:1] == " " or fixed.startswith("From ")
+        lines.append((" " + fixed) if stuff else fixed)
+    return "\n".join(lines)
+
+
 @dataclass(frozen=True)
 class _State:
     """What the enclosing elements say about the text being collected."""

--- a/suite/mail/utils/html_to_text.py
+++ b/suite/mail/utils/html_to_text.py
@@ -29,6 +29,8 @@ MIN_WIDTH = 24
 MAX_BLANK_RUN = 2
 # RFC 3676 4.3. The trailing space is what identifies it, so it survives every trim here.
 SIGNATURE_SEPARATOR = "-- "
+# Class the composer puts on the signature it inserts, mirroring frappe_mail_quote.
+SIGNATURE_CLASS = "frappe_mail_signature"
 
 # Tags that never contribute text. `button` is among them because a call to action worth
 # reading is an <a>; a real <button> is a dead control whose label only adds noise.
@@ -225,6 +227,8 @@ def _tag_tokens(el: Tag, state: _State) -> list[_Token]:
     name = (el.name or "").lower()
     if name in _DROPPED or el.has_attr("hidden") or _HIDDEN.search(str(el.get("style") or "")):
         return []
+    if SIGNATURE_CLASS in (el.get("class") or []):
+        return _signature_tokens(el, state)
     if name == "br":
         return [_Break(state)]
     if name == "hr":
@@ -253,6 +257,22 @@ def _bounded(inner: list[_Token], margin: int) -> list[_Token]:
     """Fence tokens off as their own paragraph."""
 
     return [_Boundary(margin), *inner, _Boundary(margin)]
+
+
+def _signature_tokens(el: Tag, state: _State) -> list[_Token]:
+    """The signature block, introduced by the separator a reader looks for.
+
+    The composer marks the block it inserts, because by the time a body reaches here the
+    signature is ordinary markup and nothing else could tell it apart.
+    """
+
+    inner = _tokenize(el, state)
+    if not any(isinstance(token, _Text) and token.value.strip() for token in inner):
+        return []
+
+    # Margin 0 after the separator keeps the signature on the line below it, not a blank
+    # line below it.
+    return [_Boundary(1), _Text(SIGNATURE_SEPARATOR, state), _Boundary(0), *inner, _Boundary(1)]
 
 
 def _list_tokens(el: Tag, state: _State) -> list[_Token]:

--- a/suite/tests/test_text_utils.py
+++ b/suite/tests/test_text_utils.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+"""``clean_text`` and ``convert_html_to_text`` produce the one-line strings previews are made of.
+One line is the point here, unlike ``suite.mail.utils.html_to_text``, which keeps a body's shape
+for the text/plain part. What a preview must not do is take a message's words apart."""
+
+import unittest
+
+from suite.utils import clean_text, convert_html_to_text
+
+
+class CleanText(unittest.TestCase):
+    def test_collapses_whitespace(self):
+        self.assertEqual(clean_text("one   two\n\nthree"), "one two three")
+
+    def test_trims(self):
+        self.assertEqual(clean_text("  padded  "), "padded")
+
+    def test_empty(self):
+        self.assertEqual(clean_text(""), "")
+        self.assertEqual(clean_text(None), "")
+
+    def test_strips_invisible_characters(self):
+        self.assertEqual(clean_text("He​llo﻿"), "Hello")
+
+
+class TokensSurvive(unittest.TestCase):
+    """A rule once split any `,.!?` that ran into a word, to repair sentences whose space had
+    gone missing. Nothing needs it: both callers hand over text that is already spaced. What it
+    did instead was take apart every address, version and filename it met."""
+
+    def test_address_is_not_split(self):
+        self.assertEqual(clean_text("Mail support@example.com today."), "Mail support@example.com today.")
+
+    def test_url_is_not_split(self):
+        self.assertEqual(clean_text("See https://example.com/a/b now"), "See https://example.com/a/b now")
+
+    def test_version_is_not_split(self):
+        self.assertEqual(clean_text("Version 1.2.3 shipped"), "Version 1.2.3 shipped")
+
+    def test_decimal_is_not_split(self):
+        self.assertEqual(clean_text("Costs $3.50 each"), "Costs $3.50 each")
+
+    def test_abbreviation_is_not_split(self):
+        self.assertEqual(clean_text("Use e.g. a filter"), "Use e.g. a filter")
+
+    def test_filename_is_not_split(self):
+        self.assertEqual(clean_text("Attached report.pdf"), "Attached report.pdf")
+
+
+class ConvertHtmlToText(unittest.TestCase):
+    def test_blocks_are_separated(self):
+        # The separator get_text is given, which is what makes the removed rule unnecessary.
+        self.assertEqual(convert_html_to_text("<p>Hello.</p><p>World</p>"), "Hello. World")
+
+    def test_adjacent_inline_nodes_are_separated(self):
+        self.assertEqual(convert_html_to_text("<p><b>Bold.</b>Next</p>"), "Bold. Next")
+
+    def test_anchor_text_is_kept_without_its_url(self):
+        # A preview wants the words, not the destination.
+        html = '<p>Read <a href="https://example.com/spec">the spec</a>.</p>'
+        self.assertEqual(convert_html_to_text(html), "Read the spec .")
+
+    def test_address_survives_the_round_trip(self):
+        self.assertIn("support@example.com", convert_html_to_text("<p>Mail support@example.com.</p>"))
+
+    def test_empty(self):
+        self.assertEqual(convert_html_to_text(""), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/suite/utils/__init__.py
+++ b/suite/utils/__init__.py
@@ -13,7 +13,9 @@ from frappe.types.filter import FilterTuple
 from MySQLdb import OperationalError
 
 INVISIBLE_CHARS = (
-    r"[\u0000-\u001F\u007F-\u009F"  # ASCII control chars
+    # Control chars, but not the whitespace ones (\u0009-\u000D): deleting a newline runs
+    # the words either side of it together, where collapsing leaves the space it stood for.
+    r"[\u0000-\u0008\u000E-\u001F\u007F-\u009F"
     r"\u200B-\u200F\u202A-\u202E"  # zero-width & directional
     r"\u2060-\u206F"  # word joiners etc
     r"\uFEFF"  # byte order mark
@@ -145,7 +147,6 @@ def clean_text(text: str) -> str:
 
     text = unicodedata.normalize("NFKC", text)
     text = re.sub(INVISIBLE_CHARS, "", text)
-    text = re.sub(r"([,.!?])(?=\w)", r"\1 ", text)
 
     return re.sub(r"\s+", " ", text).strip()
 


### PR DESCRIPTION
Current implementation of plaintext conversion (from html) and rendering is not great.

This aims to change that behavior by implementing proper html to plaintext conversion and rendering (including previews).