### PR TITLE
fix(writer): compare against actual writer-home route name

### DIFF
--- a/frontend/src/apps/writer/components/ErrorPage.vue
+++ b/frontend/src/apps/writer/components/ErrorPage.vue
@@ -28,7 +28,7 @@
           <LucideArrowBigLeft class="size-4" />Go Back
         </div>
       </Button>
-      <template v-if="$route.name != 'Home'">
+      <template v-if="$route.name != 'writer-home'">
         <Button
           v-if="isLoggedIn"
           variant="solid"


### PR DESCRIPTION
ErrorPage.vue compared $route.name against 'Home', but Writer's routes are namespaced (writer-home, writer-document), so the check was always true and the Go Home/Login button rendered even on the home error page itself. Same stale route-name pattern already fixed for Drive in #605.