### PR TITLE
fix(drive): remove orphaned temp upload file on quota rejection

### DIFF
--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -101,7 +101,11 @@ def upload_file(
     # Validate that file size is matching
     file_size = temp_path.stat().st_size
     acquire_owner_storage_lock(frappe.session.user)
-    validate_quota(incoming_size=file_size)
+    try:
+        validate_quota(incoming_size=file_size)
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        raise
 
     mime_type = mimemapper.get_mime_type(str(temp_path), native_first=False)
     file_type = get_file_type(mime_type)

--- a/suite/drive/api/tests/test_files.py
+++ b/suite/drive/api/tests/test_files.py
@@ -222,6 +222,30 @@ class TestDriveFilesAPI(IntegrationTestCase):
             self.assertEqual(len(staged_files), 1)
             self.assertEqual(staged_files[0].parent, storage_root / ".uploads")
 
+    def test_upload_removes_temp_file_on_quota_rejection(self):
+        with TemporaryDirectory() as temp_dir:
+            storage_root = Path(temp_dir) / "private" / "files"
+            storage_root.mkdir(parents=True)
+
+            with (
+                self.set_user(OWNER),
+                patch("suite.drive.api.files.frappe.get_site_path", return_value=str(storage_root)),
+                patch(
+                    "suite.drive.api.files.frappe.get_single",
+                    return_value=frappe._dict(root_folder=""),
+                ),
+                patch(
+                    "suite.drive.api.files.validate_quota",
+                    side_effect=ValueError("You're out of storage!"),
+                ),
+                self.upload_request(b"contents", "upload.txt", session=None),
+                self.assertRaises(ValueError),
+            ):
+                upload_file(total_file_size=8, parent=self.folder.name)
+
+            staged_files = list((storage_root / ".uploads").iterdir())
+            self.assertEqual(staged_files, [])
+
     def test_chunked_upload_without_session_is_rejected_before_writing(self):
         with TemporaryDirectory() as temp_dir:
             storage_root = Path(temp_dir) / "private" / "files"


### PR DESCRIPTION
upload_file() writes the entire blob to .uploads before checking validate_quota(). When the check throws, the fully-written temp file was never cleaned up, leaking disk space on every rejected upload. Wrap the check and unlink the temp file before re-raising.

Does not address the broader "no GC for .uploads" gap (abandoned or never-completed uploads still leak) — only closes the deterministic quota-rejection path.