### PR TITLE
fix(drive): remove dead get_docs_attached_to endpoint

### DIFF
--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -942,16 +942,6 @@ def track_visit(
     )
 
 
-@frappe.whitelist()
-def get_docs_attached_to(file_name: str):
-    file = frappe.get_doc("File", file_name)
-    return frappe.get_list(
-        "File",
-        filters={"attached_to_doctype": ["is", "set"], "file_url": file.file_url},
-        fields=["attached_to_doctype", "attached_to_name"],
-    )
-
-
 def get_upload_path(file_name):
     root_folder = frappe.get_single("Drive Disk Settings").root_folder or ""
     uploads_path = Path(frappe.get_site_path("private/files"), root_folder, ".uploads")


### PR DESCRIPTION
Zero callers anywhere in suite - no frontend usage, no Python imports, no fixtures. It also loaded the target File via frappe.get_doc with no permission check before querying, so as an unreachable but still network-callable endpoint it was pure downside: dead surface area with a thin (existence-only) permission gap and no product behavior depending on it.