### PR TITLE
fix(drive): stop querying dropped old_name field in translate_old_name

### DIFF
--- a/frontend/src/apps/drive/routes.ts
+++ b/frontend/src/apps/drive/routes.ts
@@ -154,7 +154,8 @@ export const routes: RouteRecordRaw[] = [
           return {
             name: 'drive-Folder',
             params: {
-              entityName: translate.data,
+              // Untranslatable ids fall through so the page shows its error state
+              entityName: translate.data || to.params.entityName,
             },
           }
         },
@@ -168,7 +169,7 @@ export const routes: RouteRecordRaw[] = [
           return {
             name: 'drive-Document',
             params: {
-              entityName: translate.data,
+              entityName: translate.data || to.params.entityName,
             },
           }
         },
@@ -182,7 +183,7 @@ export const routes: RouteRecordRaw[] = [
           return {
             name: 'drive-File',
             params: {
-              entityName: translate.data,
+              entityName: translate.data || to.params.entityName,
             },
           }
         },

--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -870,7 +870,10 @@ def search(query: str):
 
 @frappe.whitelist(allow_guest=True)
 def translate_old_name(old_name: str):
-    return frappe.get_value("File", {"old_name": old_name}, "name")
+    # The pre-team-restructure id mapping (Drive File's `old_name` field) was
+    # dropped when Drive File merged into the framework File doctype, so ids
+    # can only be passed through when they survived migration as File names.
+    return frappe.db.exists("File", old_name)
 
 
 @frappe.whitelist(allow_guest=True)

--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -873,7 +873,11 @@ def translate_old_name(old_name: str):
     # The pre-team-restructure id mapping (Drive File's `old_name` field) was
     # dropped when Drive File merged into the framework File doctype, so ids
     # can only be passed through when they survived migration as File names.
-    return frappe.db.exists("File", old_name)
+    # Missing and inaccessible ids both return None so guests can't probe
+    # which private files exist.
+    if not frappe.db.exists("File", old_name):
+        return None
+    return old_name if user_has_permission(old_name, "read") else None
 
 
 @frappe.whitelist(allow_guest=True)


### PR DESCRIPTION
## Summary
- `translate_old_name` still filtered `File` on `old_name`, a Drive File field that was dropped when Drive File merged into the framework `File` doctype — every legacy `/drive/{file,folder,document}/<id>` link (guest-reachable) threw `(1054, "Unknown column 'old_name' in 'WHERE'")` into the Error Log.
- The old-id mapping data no longer exists on migrated sites, so the endpoint now does the only translation still possible: pass through ids that survived migration as `File` names (`frappe.db.exists`), returning `None` for lost pre-restructure ids.
- The three legacy redirect routes in the frontend fall back to the original id when translation returns nothing, so the target page renders its normal not-found error state instead of navigating with a `null` param.

## Test plan
- Hit `/api/method/suite.drive.api.files.translate_old_name?old_name=<current File name>` → returns the name.
- Hit it with a stale pre-restructure uuid (e.g. `38ea275a07614e63a0fdb90214bf90ed`) → returns `null`, no Error Log entry.
- Visit `/drive/file/<stale-id>` as Guest → lands on the file page's error state instead of a 500.