### PR TITLE
mail: thread view cleanup

### DIFF
--- a/frontend/src/apps/mail/components/EmailContent.vue
+++ b/frontend/src/apps/mail/components/EmailContent.vue
@@ -159,15 +159,26 @@ const collapseQuotes = (doc: Document) => {
 		// Only the outermost quote gets a toggle — hiding it hides any quotes nested inside.
 		if (quote.parentElement?.closest('.gmail_quote, .frappe_mail_quote')) return
 		quote.classList.add('quote-hidden')
+		// A labelled control, not a bare '···' chip — unlabelled, it was easy to miss
+		// that a reply hides a whole conversation underneath it.
 		const button = doc.createElement('button')
-		button.textContent = '···'
+		button.innerHTML =
+			'<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M4 6h16M4 11h16M4 16h10"/></svg>'
+		const label = doc.createElement('span')
+		label.textContent = __('Show trimmed content')
+		// The toggle script runs inside the iframe, where __() doesn't exist — both
+		// translations ride along as data attributes instead.
+		button.dataset.show = __('Show trimmed content')
+		button.dataset.hide = __('Hide trimmed content')
+		button.appendChild(label)
+		// Styled by the .quote-toggle rules in the srcdoc stylesheet — a class, not
+		// inline styles, so the mobile media query can size the touch target up.
+		button.className = 'quote-toggle'
 		button.setAttribute(
-			'style',
-			`background:${colors.value.button};color:${colors.value.text};padding:0.5px 6px;border-radius:8px;cursor:pointer;transition:background .2s;margin:12px 0;`,
+			'onclick',
+			"var hidden = this.nextElementSibling.classList.toggle('quote-hidden');" +
+				'this.lastElementChild.textContent = hidden ? this.dataset.show : this.dataset.hide;',
 		)
-		button.setAttribute('onmouseover', `this.style.background='${colors.value.buttonHover}'`)
-		button.setAttribute('onmouseout', `this.style.background='${colors.value.button}'`)
-		button.setAttribute('onclick', "this.nextElementSibling.classList.toggle('quote-hidden');")
 		quote.parentNode?.insertBefore(button, quote)
 	})
 }
@@ -259,6 +270,37 @@ const srcdoc = computed(() => {
 
 				.quote-hidden {
 					display: none;
+				}
+
+				.quote-toggle {
+					display: inline-flex;
+					align-items: center;
+					gap: 6px;
+					background: ${colors.value.button};
+					color: ${colors.value.text};
+					padding: 4px 9px;
+					/* frappe-ui's standard button radius (rounded-4) */
+					border-radius: 8px;
+					transition: background .2s;
+					margin: 12px 0;
+				}
+
+				.quote-toggle:hover {
+					background: ${colors.value.buttonHover};
+				}
+
+				/* A finger target on mobile — matches the app's 40px mobile buttons,
+				   with the lg radius that size takes. */
+				@media (max-width: 640px) {
+					.quote-toggle {
+						padding: 10px 14px;
+						gap: 8px;
+						border-radius: 10px;
+					}
+					.quote-toggle svg {
+						width: 14px;
+						height: 14px;
+					}
 				}
 
 				.email-pixel {

--- a/frontend/src/apps/mail/components/EmailContent.vue
+++ b/frontend/src/apps/mail/components/EmailContent.vue
@@ -226,9 +226,13 @@ const srcdoc = computed(() => {
 					max-width: 100% !important;
 				}
 
+				/* Width only — never height. A blanket height:auto overrules authored
+				   squares (an avatar with border-radius:50% renders as an ellipse of the
+				   photo's intrinsic ratio). Images render as authored; the one case that
+				   can't — a fixed width wider than the pane — is rewritten by
+				   normalizeWidths() below, which drops that image's height with it. */
 				img {
 					max-width: 100% !important;
-					height: auto !important;
 				}
 
 				blockquote {
@@ -290,9 +294,19 @@ const srcdoc = computed(() => {
 					const limit = document.documentElement.clientWidth;
 					if (!limit) return;
 					document.querySelectorAll('[width], [style*="width"]').forEach((el) => {
-						if (parseInt(el.getAttribute('width'), 10) > limit) el.setAttribute('width', '100%');
+						let clamped = false;
+						if (parseInt(el.getAttribute('width'), 10) > limit) {
+							el.setAttribute('width', '100%');
+							clamped = true;
+						}
 						const style = el.style;
-						if (style.width.endsWith('px') && parseFloat(style.width) > limit) style.width = '100%';
+						if (style.width.endsWith('px') && parseFloat(style.width) > limit) {
+							style.width = '100%';
+							clamped = true;
+						}
+						// An image we just narrowed must shed its authored height with the width,
+						// or the photo squashes. Only then — otherwise the email is the author's.
+						if (clamped && el.tagName === 'IMG') style.height = 'auto';
 						if (style.minWidth.endsWith('px') && parseFloat(style.minWidth) > limit) style.minWidth = '0';
 
 						// A percentage width capped by a pixel max-width is how every responsive
@@ -310,8 +324,34 @@ const srcdoc = computed(() => {
 							style.setProperty('max-width', cap > limit ? '100%' : el.dataset.authorMaxWidth, 'important');
 					});
 				};
-				normalizeWidths();
-				window.addEventListener('resize', normalizeWidths);
+
+				// The stylesheet clamp can also shrink an image normalizeWidths never
+				// rewrote — a pixel width in a table cell narrower than the pane, or a
+				// height-only declaration whose intrinsic width overflows. Only layout
+				// knows, and only once the bitmap arrives (naturalWidth is 0 before
+				// load): if the box the image got is narrower than the width its height
+				// was drawn for, shed that height. Percentage widths are left alone —
+				// fluid width against a fixed height is the author's own design.
+				const unsquashImages = () => {
+					document.querySelectorAll('img').forEach((img) => {
+						if (img.style.width.includes('%') || img.getAttribute('width')?.includes('%')) return;
+						const drawn =
+							(img.style.width.endsWith('px') && parseFloat(img.style.width)) ||
+							parseFloat(img.getAttribute('width')) ||
+							img.naturalWidth;
+						if (img.clientWidth && drawn > img.clientWidth + 1) img.style.height = 'auto';
+					});
+				};
+
+				const normalizeAll = () => {
+					normalizeWidths();
+					unsquashImages();
+				};
+				normalizeAll();
+				window.addEventListener('resize', normalizeAll);
+				document.querySelectorAll('img').forEach((img) =>
+					img.addEventListener('load', unsquashImages),
+				);
 
 				// Forward keyboard events to parent
 				['keydown', 'keyup', 'keypress'].forEach(eventType => {

--- a/frontend/src/apps/mail/components/EmailContent.vue
+++ b/frontend/src/apps/mail/components/EmailContent.vue
@@ -336,19 +336,42 @@ const srcdoc = computed(() => {
 					const limit = document.documentElement.clientWidth;
 					if (!limit) return;
 					document.querySelectorAll('[width], [style*="width"]').forEach((el) => {
+						const style = el.style;
+						// The authored box is stashed before the first rewrite, since writing
+						// '100%' destroys it and a resize back to a wide pane must restore it —
+						// the iframe persists across pane-width changes.
+						const img = el.tagName === 'IMG';
+						if (img && el.dataset.authorWidth === undefined) {
+							el.dataset.authorWidth = el.getAttribute('width') ?? '';
+							el.dataset.authorStyleWidth = style.width;
+							el.dataset.authorStyleHeight = style.height;
+						}
+						const attrWidth = img
+							? parseInt(el.dataset.authorWidth, 10)
+							: parseInt(el.getAttribute('width'), 10);
+						const styleWidth = img ? el.dataset.authorStyleWidth : style.width;
 						let clamped = false;
-						if (parseInt(el.getAttribute('width'), 10) > limit) {
+						if (attrWidth > limit) {
 							el.setAttribute('width', '100%');
 							clamped = true;
+						} else if (img && attrWidth > 0) {
+							el.setAttribute('width', el.dataset.authorWidth);
 						}
-						const style = el.style;
-						if (style.width.endsWith('px') && parseFloat(style.width) > limit) {
-							style.width = '100%';
-							clamped = true;
+						if (styleWidth.endsWith('px')) {
+							if (parseFloat(styleWidth) > limit) {
+								style.width = '100%';
+								clamped = true;
+							} else if (img) {
+								style.width = styleWidth;
+							}
 						}
-						// An image we just narrowed must shed its authored height with the width,
-						// or the photo squashes. Only then — otherwise the email is the author's.
-						if (clamped && el.tagName === 'IMG') style.height = 'auto';
+						// An image we narrowed must shed its authored height with the width, or
+						// the photo squashes; one that fits again gets its authored box back —
+						// otherwise the email is the author's.
+						if (img) {
+							if (clamped) style.height = 'auto';
+							else style.height = el.dataset.authorStyleHeight;
+						}
 						if (style.minWidth.endsWith('px') && parseFloat(style.minWidth) > limit) style.minWidth = '0';
 
 						// A percentage width capped by a pixel max-width is how every responsive
@@ -376,12 +399,23 @@ const srcdoc = computed(() => {
 				// fluid width against a fixed height is the author's own design.
 				const unsquashImages = () => {
 					document.querySelectorAll('img').forEach((img) => {
-						if (img.style.width.includes('%') || img.getAttribute('width')?.includes('%')) return;
+						const authored = img.dataset.authorWidth ?? img.getAttribute('width') ?? '';
+						const authoredStyle = img.dataset.authorStyleWidth ?? img.style.width;
+						if (authoredStyle.includes('%') || authored.includes('%')) return;
 						const drawn =
-							(img.style.width.endsWith('px') && parseFloat(img.style.width)) ||
-							parseFloat(img.getAttribute('width')) ||
+							(authoredStyle.endsWith('px') && parseFloat(authoredStyle)) ||
+							parseFloat(authored) ||
 							img.naturalWidth;
-						if (img.clientWidth && drawn > img.clientWidth + 1) img.style.height = 'auto';
+						if (!img.clientWidth) return;
+						if (drawn > img.clientWidth + 1) {
+							// Stash before overwriting, so widening the pane can undo this too.
+							if (img.dataset.authorStyleHeight === undefined)
+								img.dataset.authorStyleHeight = img.style.height;
+							img.style.height = 'auto';
+						} else if (img.style.height === 'auto' && img.dataset.authorStyleHeight !== undefined) {
+							// The box fits again — the authored height comes back with it.
+							img.style.height = img.dataset.authorStyleHeight;
+						}
 					});
 				};
 

--- a/frontend/src/apps/mail/components/MailDate.vue
+++ b/frontend/src/apps/mail/components/MailDate.vue
@@ -10,11 +10,18 @@ import { computed, inject } from 'vue'
 import { useTimeAgo } from '@vueuse/core'
 import { Tooltip } from 'frappe-ui'
 
-const { datetime, inList = false } = defineProps<{ datetime: string; inList?: boolean }>()
+const {
+	datetime,
+	inList = false,
+	clock = false,
+} = defineProps<{ datetime: string; inList?: boolean; clock?: boolean }>()
 
 const dayjs = inject('$dayjs')
 
 const formattedDate = computed(() => {
+	// The thread's day dividers already state the date, so its rows carry only the clock —
+	// the sequence and the gaps between replies, which a relative stamp hides.
+	if (clock) return dayjs(datetime).format('h:mm A')
 	if (!inList) {
 		const timeAgo = useTimeAgo(datetime).value
 		return __(timeAgo.charAt(0).toUpperCase() + timeAgo.slice(1))

--- a/frontend/src/apps/mail/components/MailDetails.vue
+++ b/frontend/src/apps/mail/components/MailDetails.vue
@@ -1,23 +1,40 @@
 <template>
-	<div
-		class="grid grid-cols-5 gap-2 overflow-y-auto rounded border p-3 text-sm sm:max-h-96 sm:max-w-md sm:border-0"
-	>
-		<span class="text-ink-gray-5 col-span-1">{{ __('From:') }}</span>
-		<span class="col-span-4">
-			<span class="font-semibold"> {{ mail.from_name || mail.from_email }} </span>
-			<span v-if="mail.from_name"> {{ ` <${mail.from_email}>` }} </span>
-		</span>
-		<template v-for="field in FIELDS" :key="field.label">
-			<span class="text-ink-gray-4 col-span-1">{{ field.label }}</span>
-			<span class="col-span-4 leading-4">{{ field.value() }} </span>
-		</template>
+	<div class="overflow-y-auto rounded border text-sm sm:max-h-96 sm:w-96 sm:border-0">
+		<!-- The sender is the only person here with a face — a header, not a "From:" row. -->
+		<div class="flex items-center gap-3 border-b px-4 pb-3 pt-3.5">
+			<Avatar :label="getSenderInitial(mail)" :image="mail.user_image" size="xl" />
+			<div class="min-w-0">
+				<!-- text-p-*: the paragraph styles carry a reading line-height, so truncate
+				     has room for descenders without stating leadings by hand. -->
+				<div class="text-ink-gray-9 text-p-base-semibold truncate">
+					{{ mail.from_name || mail.from_email }}
+				</div>
+				<div v-if="mail.from_name" class="text-ink-gray-5 text-p-xs truncate">
+					{{ mail.from_email }}
+				</div>
+			</div>
+		</div>
+
+		<div class="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-2 px-4 py-3">
+			<template v-for="field in recipientFields" :key="field.label">
+				<!-- Label and value share one paragraph style, so their first-line boxes —
+				     and therefore baselines — align by construction, no nudges. Color alone
+				     separates them. -->
+				<span class="text-ink-gray-4 text-p-sm whitespace-nowrap">
+					{{ field.label }}
+				</span>
+				<span class="text-ink-gray-7 text-p-sm break-words">{{ field.value }}</span>
+			</template>
+		</div>
 	</div>
 </template>
 
 <script setup lang="ts">
 import { computed, inject } from 'vue'
+import { Avatar } from 'frappe-ui'
 
 import { getGroupedRecipients } from '@/apps/mail/utils'
+import { getSenderInitial } from '@/apps/mail/utils/participants'
 
 import type { Mail } from '@/apps/mail/types'
 
@@ -27,35 +44,29 @@ const { mail } = defineProps<{ mail: Mail }>()
 
 const recipients = computed(() => getGroupedRecipients(mail.recipients, true, true))
 
-const FIELDS = [
-	{
-		condition: mail.reply_to.length > 0,
-		label: __('Reply To: '),
-		value: () => mail.reply_to.map((rt) => rt.email).join(', '),
-	},
-	{
-		label: __('To: '),
-		value: () => recipients.value.to,
-		condition: () => !!recipients.value.to,
-	},
-	{
-		condition: !!recipients.value.cc,
-		label: __('Cc: '),
-		value: () => recipients.value.cc,
-	},
-	{
-		condition: !!recipients.value.bcc,
-		label: __('Bcc: '),
-		value: () => recipients.value.bcc,
-	},
-	{
-		label: __('Date: '),
-		value: () => dayjs(mail.received_at).format('MMM D, YYYY, h:mm A'),
-	},
-	{
-		condition: !!mail.subject,
-		label: __('Subject: '),
-		value: () => mail.subject,
-	},
-].filter((field) => field.condition !== false)
+// Lowercase, no colons — the labels describe, the values speak.
+const recipientFields = computed(() =>
+	[
+		{ label: __('to'), value: recipients.value.to },
+		{ label: __('cc'), value: recipients.value.cc },
+		{ label: __('bcc'), value: recipients.value.bcc },
+		// Shown only when a reply would go somewhere other than the sender — when it
+		// merely restates From, it is noise and stays out.
+		{ label: __('reply to'), value: divertedReplyTo.value },
+		{ label: __('subject'), value: mail.subject },
+		{ label: __('date'), value: formattedDate.value },
+	].filter((field) => field.value),
+)
+
+const divertedReplyTo = computed(() => {
+	const diverted = mail.reply_to
+		.map((rt) => rt.email)
+		.filter((email) => email.toLowerCase() !== mail.from_email.toLowerCase())
+	return diverted.join(', ')
+})
+
+
+const formattedDate = computed(() =>
+	dayjs(mail.received_at).format('ddd, MMM D, YYYY · h:mm A'),
+)
 </script>

--- a/frontend/src/apps/mail/components/MailDetailsPopover.vue
+++ b/frontend/src/apps/mail/components/MailDetailsPopover.vue
@@ -1,8 +1,11 @@
 <template>
 	<Popover>
 		<template #target="{ togglePopover }">
+			<!-- mt-px: the row centers this 14px glyph on a stated 16px (leading-4) line
+			     box, but 13px lowercase text's optical center sits ~1px below the box's
+			     geometric center — the same arithmetic as the remote-images banner icon. -->
 			<ChevronDown
-				class="text-ink-gray-5 hover:bg-surface-gray-2 h-3.5 w-3.5 cursor-pointer rounded-sm"
+				class="text-ink-gray-5 hover:bg-surface-gray-2 mt-px h-3.5 w-3.5 cursor-pointer rounded-sm"
 				@click.stop="togglePopover()"
 			/>
 		</template>

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -41,7 +41,7 @@
 			     rather than ending beneath it. Not reserved otherwise, or every thread would
 			     end in a gap explaining nothing. -->
 			<div
-				class="sm:space-y-4 sm:px-5 sm:pt-6"
+				class="sm:space-y-3 sm:px-5 sm:pt-6"
 				:class="{
 					'pb-16': isMobile && !thread?.at(-1)?.draft,
 					'sm:pb-24': isComposeWindowOpen(),
@@ -49,9 +49,12 @@
 				}"
 			>
 				<template v-for="group in mailsByDay" :key="group.date">
+					<!-- Borderless: the date is a label, not a control — only the
+					     more-messages toggle keeps the pill outline. -->
 					<ThreadDivider
 						v-if="shouldShowDateDivider(group.mails)"
 						:message="getFormattedDate(group.date)"
+						class="[&_span:not(.border-t)]:text-ink-gray-4 [&_span:not(.border-t)]:border-0 [&_span:not(.border-t)]:text-xs"
 					/>
 					<template v-for="mail in group.mails" :key="mail.name">
 						<ThreadDivider
@@ -80,13 +83,24 @@
 						<div
 							v-if="!collapsedMailNames.has(mail.name) && !isPoppedOut(mail)"
 							:data-mail-name="mail.name"
+							class="group/card"
 							:class="{
-								'px-3.5 py-5': isMobile,
+								'px-3.5': isMobile,
+								// Same tightening the desktop rows got: reading padding for
+								// open mail, slimmer rows for collapsed ones.
+								'py-5': isMobile && !isCollapsed(mail),
+								'py-3.5': isMobile && isCollapsed(mail),
 								'max-sm:border-b':
 									(thread.length > 1 || mail.draft) &&
 									mail.name !== mailBeforeCollapsedGroup &&
 									mail.name !== mailBeforeUnseenMarker,
-								'sm:rounded-xl sm:p-5': thread.length > 1 || mail.draft,
+								'sm:rounded-xl': thread.length > 1 || mail.draft,
+								// A collapsed row only holds one line — reading-card padding
+								// around it is what made the thread feel loose.
+								'sm:px-4 sm:py-5': (thread.length > 1 || mail.draft) && !isCollapsed(mail),
+								// The list rows' hover, so a clickable row answers the cursor.
+								'sm:hover:bg-surface-gray-1 sm:px-4 sm:py-3':
+									thread.length > 1 && isCollapsed(mail),
 								'sm:border':
 									(thread.length > 1 && !mail.draft) ||
 									(mail.draft && dataTheme === 'dark'),
@@ -155,17 +169,36 @@
 									class="flex items-center space-x-3"
 									:class="{
 										'cursor-pointer': mail !== lastMessage,
-										'pb-6': mail.preview || !isCollapsed(mail),
+										'pb-6': !isCollapsed(mail),
+										// Mobile collapsed rows: a step, not a chasm, between the
+										// name row and its preview line.
+										'pb-2': isCollapsed(mail) && isMobile && !!mail.preview,
 									}"
 									@click.stop="mail.collapsed = !mail.collapsed"
 								>
 									<Avatar
 										:label="getSenderInitial(mail)"
 										:image="mail.user_image"
-										size="xl"
+										:size="isCollapsed(mail) ? (isMobile ? 'lg' : 'md') : 'xl'"
 									/>
-									<div class="flex flex-1 justify-between truncate text-sm">
-										<div class="mr-3 flex flex-col space-y-1 truncate">
+									<!-- Collapsed rows align everything on one text baseline —
+									     name, preview and timestamp are three sizes with three
+									     line boxes, and centered boxes leave baselines adrift. -->
+									<!-- min-w-0, not truncate: the flex item still shrinks so the
+									     nested spans can ellipsize, but overflow stays visible — the
+									     hover actions overhang this box and were clipped by it. -->
+									<div
+										class="flex min-w-0 flex-1 justify-between text-sm"
+										:class="{ 'items-baseline': isCollapsed(mail) && !isMobile }"
+									>
+										<div
+											class="mr-3 flex truncate"
+											:class="
+												isCollapsed(mail) && !isMobile
+													? 'flex-1 items-baseline space-x-3'
+													: 'flex-col space-y-1'
+											"
+										>
 											<div class="flex items-center space-x-1.5">
 												<span
 													class="truncate text-[15px] !font-semibold sm:text-base"
@@ -177,7 +210,7 @@
 												     descenders of a g or a p were shaved off. 16px still sits under the
 												     sender name beside it, so the row does not grow. -->
 												<span
-													v-if="!isMobile"
+													v-if="!isMobile && !isCollapsed(mail)"
 													class="text-ink-gray-5 truncate leading-4"
 												>
 													<span>&lt;</span>
@@ -189,12 +222,23 @@
 													</Tooltip>
 													<span>&gt;</span>
 												</span>
-												<template
-													v-if="!(isCollapsed(mail) || mail.draft)"
-												>
+											</div>
+											<!-- Same 13px truncate, same shaved descenders. Collapsed
+											     mails keep just sender + preview — recipients belong to
+											     the expanded reading view. A compact summary, not the
+											     roster: two names carry the line, the rest fold into
+											     "and x others" behind the chevron beside it. -->
+											<div
+												v-if="!isCollapsed(mail)"
+												class="flex items-center space-x-1.5 truncate leading-4"
+											>
+												<span class="truncate">
+													{{ recipientsSummary(mail) }}
+												</span>
+												<template v-if="!mail.draft">
 													<ChevronDown
 														v-if="isMobile"
-														class="text-ink-gray-6 h-3.5 w-3.5 rounded-sm transition-transform duration-200"
+														class="text-ink-gray-6 mt-px h-3.5 w-3.5 shrink-0 rounded-sm transition-transform duration-200"
 														:class="{
 															'rotate-180':
 																showMailDetails === mail.name,
@@ -209,21 +253,64 @@
 													<MailDetailsPopover v-else :mail />
 												</template>
 											</div>
-											<!-- Same 13px truncate, same shaved descenders. -->
-											<div class="truncate leading-4">
-												{{ getFormattedRecipients(mail.recipients) }}
-											</div>
+											<!-- Desktop collapsed rows are one line: the preview rides
+											     beside the name instead of on a row of its own.
+											     leading-5: truncate is overflow-hidden and the preset's
+											     1.15 puts 14px text in a ~16.1px box while Inter's glyph
+											     box wants ~16.4 — descenders were shaved. The row is
+											     avatar-tall, so the stated 20px adds no height. -->
+											<span
+												v-if="isCollapsed(mail) && !isMobile"
+												class="text-ink-gray-7 min-w-0 flex-1 truncate leading-5"
+											>
+												{{ mail.preview }}
+											</span>
 										</div>
-										<div class="flex items-center space-x-1 self-start">
-											<MailDate
+										<!-- self-start suits the expanded card's two-line header; on
+										     a collapsed row the block inherits the parent's baseline
+										     alignment (its own baseline is the timestamp's). -->
+										<div
+											class="flex items-center space-x-1"
+											:class="{
+												'self-start': !isCollapsed(mail),
+												'self-center': isCollapsed(mail) && isMobile,
+												/* Hovered collapsed rows swap text for icon buttons —
+												   no baseline to join, so center the block instead.
+												   group-has [data-state=open]: the ⋯ menu is portaled,
+												   so opening it ends the hover — without this the
+												   trigger unmounts and the menu loses its anchor. */
+												'sm:group-hover/card:self-center sm:group-has-[[data-state=open]]/card:self-center':
+													isCollapsed(mail) && !isMobile,
+											}"
+										>
+											<!-- The timestamp yields to the actions on hover (fixed
+											     right edge), so the row never moves. -->
+											<span
 												v-if="!isMobile || isCollapsed(mail)"
-												:datetime="mail.received_at"
-											/>
-											<MailActions
+												:class="{
+													'sm:group-hover/card:hidden sm:group-has-[[data-state=open]]/card:hidden':
+														isCollapsed(mail),
+												}"
+											>
+												<MailDate
+													:datetime="mail.received_at"
+													:clock="showsClockTime"
+												/>
+											</span>
+											<!-- h-5: the 28px ghost buttons overhang the padding
+											     instead of growing the one-line row on hover. -->
+											<div
 												v-if="!isMobile && !readonly"
+												:class="
+													isCollapsed(mail)
+														? 'hidden h-5 items-center sm:group-hover/card:flex sm:group-has-[[data-state=open]]/card:flex'
+														: 'flex'
+												"
+											>
+											<MailActions
 												:mailbox
 												:mail
-												:is-collapsed="isCollapsed(mail)"
+												:is-collapsed="false"
 												:show-reply-all="showReplyAll(mail)"
 												:pop-out-draft
 												:reply
@@ -240,6 +327,7 @@
 												@mark-mail-spam="(m: Mail, spam: boolean) => emit('markMailSpam', m, spam)"
 												@delete-mail="(m: Mail) => emit('deleteMail', m)"
 											/>
+											</div>
 										</div>
 									</div>
 								</div>
@@ -250,9 +338,14 @@
 									class="mb-4"
 								/>
 
-								<div v-show="isCollapsed(mail)" class="truncate text-base">
+								<div
+									v-show="isCollapsed(mail) && isMobile"
+									class="truncate text-base"
+								>
 									{{ mail.preview }}
 								</div>
+
+
 
 								<div v-show="!isCollapsed(mail)">
 									<Alert
@@ -479,7 +572,6 @@ import {
 	escapeHtml,
 	extractQuotedContent,
 	getFormattedDate,
-	getFormattedRecipients,
 	getGroupedRecipients,
 	hasHtmlContent,
 	matchesScreenedValue,
@@ -519,6 +611,7 @@ import type {
 	Mail,
 	Mailbox,
 	MailboxData,
+	Recipient,
 	ScreenedAddress,
 } from '@/apps/mail/types'
 
@@ -577,8 +670,8 @@ const emit = defineEmits([
 ])
 
 const { isMobile } = useScreenSize()
-const { openSettings } = useSettings()
 const { filterBySender } = useFilterBySender()
+const { openSettings } = useSettings()
 const dayjs = inject('$dayjs')
 const user = inject('$user')
 // The pane acts as the thread's owning account (the active one unless the `account`
@@ -637,6 +730,28 @@ const mailsByDay = computed(() => {
 	}
 	return groups
 })
+
+// The expanded header's second line: "to Pushkar", "to Pushkar and Neha", "to Pushkar,
+// Rushabh and Neha", "to Pushkar, Rushabh and 2 others". First names only — the full
+// roster with addresses is behind the chevron beside it.
+const recipientsSummary = (mail: Mail) => {
+	const ordered = [...mail.recipients].sort(
+		(a, b) => Number(b.type === 'To') - Number(a.type === 'To'),
+	)
+	const names = ordered.map((r: Recipient) => (r.display_name || r.email).split(' ')[0])
+	if (!names.length) return ''
+	if (names.length === 1) return __('to {0}', [names[0]])
+	if (names.length === 2) return __('to {0} and {1}', [names[0], names[1]])
+	if (names.length === 3) return __('to {0}, {1} and {2}', names)
+	return __('to {0}, {1} and {2} others', [names[0], names[1], String(names.length - 2)])
+}
+
+// Rows state clock time only while day dividers state the date (multi-day thread, grouping
+// on, desktop). Otherwise the row's timestamp is the only date there is, and stays relative.
+const showsClockTime = computed(
+	() =>
+		!isMobile.value && mailsByDay.value.length > 1 && user.data.group_messages_by === 'Day',
+)
 
 const shouldShowDateDivider = (mails: Mail[]) =>
 	!isMobile.value &&

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -285,8 +285,12 @@
 										>
 											<!-- The timestamp yields to the actions on hover (fixed
 											     right edge), so the row never moves. -->
+											<!-- flex, not a bare span: MailDate's own mr-1 doesn't
+											     count inside an inline wrapper, and the gap between
+											     time and actions went with it. -->
 											<span
 												v-if="!isMobile || isCollapsed(mail)"
+												class="flex"
 												:class="{
 													'sm:group-hover/card:hidden sm:group-has-[[data-state=open]]/card:hidden':
 														isCollapsed(mail),
@@ -303,8 +307,8 @@
 												v-if="!isMobile && !readonly"
 												:class="
 													isCollapsed(mail)
-														? 'hidden h-5 items-center sm:group-hover/card:flex sm:group-has-[[data-state=open]]/card:flex'
-														: 'flex'
+														? 'hidden h-5 items-center gap-1 sm:group-hover/card:flex sm:group-has-[[data-state=open]]/card:flex'
+														: 'flex gap-1'
 												"
 											>
 											<MailActions


### PR DESCRIPTION
Cleans up the thread reading view. What made it feel busy was repetition rather than volume — every collapsed message repeated the recipient roster, the sender's raw address, and stated time twice.

**Collapsed messages are one line** — avatar · sender · preview · clock time. Roster and raw address are gone from them; a collapsed row costs ~48px instead of ~100px, so a real eight-message thread fits on screen.

**Expanded header** shows "to Pushkar, Rushabh and 2 others" beside the sender, chevron next to it for the full list.

**Details popover redesigned** — sender header (avatar, name, address) over a lowercase to / cc / bcc / reply to / subject / date grid. Reply-To only shows when replies actually leave the sender. Long addresses wrap.

**Thread tightened** — slimmer collapsed padding, smaller avatars, closer cards, borderless quieter date dividers. Rows show clock time when day dividers carry the date. Name, preview and time share one baseline. Row actions (star / reply / ⋯) appear on hover at a fixed right edge, timestamp yields, row height never changes.

**Quote toggle labelled** — the bare "···" chip is now a subtle-style button saying "Show/Hide trimmed content", finger-sized on mobile.

**Fix**: the reading pane forced `height:auto !important` on every email image, so an explicitly sized 40×40 avatar with `border-radius:50%` rendered as an ellipse whenever the source photo wasn't square. Images now render as authored; only images the width clamp actually shrinks shed their height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)