### PR TITLE
fix(mail): self-heal push subscriptions and seed missing sync state

### DIFF
--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -276,6 +276,10 @@ user_invitation = {
 # Suite's onboarding replaces the built-in desk setup wizard
 setup_wizard_url = "/suite/setup"
 
+# Heal the user's JMAP push subscription on login (enqueued; a lost subscription silently
+# ends webhooks — realtime events and mailbox-count invalidation both ride on them)
+on_login = ["suite.mail.doctype.push_subscription.push_subscription.on_login"]
+
 # ============================================================================
 # Scheduled Tasks (per-frequency lists combined; cron keys de-duplicated)
 # ============================================================================

--- a/suite/mail/doctype/mail_message/mail_message.py
+++ b/suite/mail/doctype/mail_message/mail_message.py
@@ -1407,6 +1407,25 @@ def fetch_changes(user: str, account: str, email_state: str | None = None, ctx: 
     ctx["email_state"] = email_state
 
     if not current_state:
+        if not email_state:
+            # A manual or scheduled run carries no state, and storing None would leave the
+            # account re-"initializing" on every run with changes never fetched — seed from
+            # the server's actual Email state instead.
+            try:
+                email_state = EmailService(account, get_jmap_connection(user)).get_state()
+                ctx["email_state"] = email_state
+            except Exception:
+                logger.error("email-sync-state-init-failed")
+                log_mail_error(
+                    _("Failed to initialize email sync state"),
+                    frappe.get_traceback(with_context=True),
+                )
+                return
+
+        if not email_state:
+            logger.warning("email-sync-state-unavailable")
+            return
+
         logger.info("initializing-email-sync-state")
         return update_sync_state(account, type="email", state=email_state)
 

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -281,7 +281,10 @@ def _add_push_subscription(
     user's account.
 
     Serialized under the same per-user lock healing uses, so a manual creation cannot
-    interleave with a healing run's check-then-create.
+    interleave with a healing run's check-then-create. A default creation (no explicit
+    device client id, url or types) is idempotent: when a live site subscription already
+    exists, perhaps created by a healing run while this request waited on the lock, its
+    id is returned instead of creating a duplicate.
     """
 
     if not ignore_permissions:
@@ -289,11 +292,22 @@ def _add_push_subscription(
 
     is_push_subscription_disabled(user, raise_exception=True)
 
+    site_device_client_id = get_site_device_client_id(user)
+    is_site_default = (
+        not url and not types and (device_client_id or site_device_client_id) == site_device_client_id
+    )
+
     try:
         # A healing run holds the lock for a couple of JMAP round trips; 10 seconds is
         # generous. On timeout, surface a retryable message instead of the raw lock error
         # (which advises deleting the lock file) after a 30 second modal hang.
         with filelock(f"ensure_push_subscription_{user}", timeout=10):
+            # Healing may have created the site's subscription while this request waited
+            # on the lock, or one may simply already exist: the default creation is
+            # idempotent and returns the live subscription instead of adding a duplicate.
+            if is_site_default and (existing_id := _live_site_subscription_id(user, ignore_permissions)):
+                return existing_id
+
             return _create_push_subscription(user, device_client_id, url, types, ignore_permissions)
     except LockTimeoutError:
         frappe.throw(
@@ -349,6 +363,25 @@ def _create_push_subscription(
         frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
     else:
         frappe.throw(_(response["description"]), title=title)
+
+
+def _live_site_subscription_id(user: str, ignore_permissions: bool = False) -> str | None:
+    """Returns the id of the longest-lived live subscription bearing this site's device
+    client id (the one healing's pruning would keep), or None when none is live."""
+
+    device_client_id = get_site_device_client_id(user)
+    now = get_utc_now()
+
+    live = []
+    for subscription in get_push_subscription_service(user, ignore_permissions=ignore_permissions).get():
+        if subscription.get("deviceClientId") != device_client_id:
+            continue
+        expires = subscription.get("expires")
+        if not expires or parse_iso_datetime(expires, as_str=False) > now:
+            live.append(subscription)
+
+    if live:
+        return max(live, key=_subscription_longevity)["id"]
 
 
 @frappe.whitelist()

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -232,6 +232,8 @@ def on_login(login_manager) -> None:
         ensure_push_subscription,
         user=user,
         queue="short",
+        job_id=f"ensure_push_subscription:{user}",
+        deduplicate=True,
         enqueue_after_commit=True,
     )
 

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -221,7 +221,8 @@ def _heal_push_subscription(user: str, service, subscriptions: list[dict]) -> li
 def on_login(login_manager) -> None:
     """Login hook: heal the user's push subscription in the background.
 
-    Enqueued so the JMAP round trips never sit in the login path.
+    Enqueued so the JMAP round trips never sit in the login path, and deduplicated
+    per user so a burst of logins queues one job.
     """
 
     user = login_manager.user
@@ -238,6 +239,7 @@ def on_login(login_manager) -> None:
     )
 
 
+@frappe.whitelist()
 def add_push_subscription(
     user: str,
     device_client_id: str | None = None,

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -368,9 +368,11 @@ def renew_push_subscription(user: str, id: str) -> None:
 def renew_expiring_push_subscriptions() -> None:
     """Renews soon-to-expire push subscriptions for all JMAP configured users.
 
-    Scheduled to run daily. A subscription is renewed when its expiry is within
-    ``RENEW_THRESHOLD_DAYS`` of the run; subscriptions without an expiry or expiring
-    later are left untouched. Users who disabled push subscriptions in their User
+    Scheduled to run daily. A subscription is renewed when its expiry is still ahead
+    but within ``RENEW_THRESHOLD_DAYS`` of the run; subscriptions without an expiry or
+    expiring later are left untouched, and already-expired ones are skipped (renewal
+    cannot revive them, and the server purges them). Users who disabled push
+    subscriptions in their User
     Settings are skipped. Users missing this site's subscription on the mail server get
     one created (self-healing — see ensure_push_subscription); healing and the expiry
     scan share a single fetch, and subscriptions healing deleted are not renewed.
@@ -379,7 +381,8 @@ def renew_expiring_push_subscriptions() -> None:
     if not frappe.utils.get_url().startswith("https://"):
         return
 
-    cutoff = get_utc_now() + timedelta(days=RENEW_THRESHOLD_DAYS)
+    now = get_utc_now()
+    cutoff = now + timedelta(days=RENEW_THRESHOLD_DAYS)
 
     for user in get_jmap_configured_users():
         if is_push_subscription_disabled(user):
@@ -397,7 +400,7 @@ def renew_expiring_push_subscriptions() -> None:
                 if subscription["id"] in deleted_ids:
                     continue
                 expires = subscription.get("expires")
-                if expires and parse_iso_datetime(expires, as_str=False) <= cutoff:
+                if expires and now < parse_iso_datetime(expires, as_str=False) <= cutoff:
                     expiring_ids.append(subscription["id"])
 
             if not expiring_ids:

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -3,6 +3,7 @@
 
 import base64
 import json
+from contextlib import suppress
 from datetime import timedelta
 from uuid import uuid7
 
@@ -178,19 +179,43 @@ def ensure_push_subscription(user: str) -> None:
 
     try:
         with filelock(f"ensure_push_subscription_{user}"):
-            device_client_id = get_site_device_client_id(user)
-            now = get_utc_now()
-
-            for subscription in get_push_subscription_service(user, ignore_permissions=True).get():
-                if subscription.get("deviceClientId") != device_client_id:
-                    continue
-                expires = subscription.get("expires")
-                if not expires or parse_iso_datetime(expires, as_str=False) > now:
-                    return
-
-            _add_push_subscription(user, ignore_permissions=True)
+            service = get_push_subscription_service(user, ignore_permissions=True)
+            _heal_push_subscription(user, service, service.get())
     except LockTimeoutError:
         return
+
+
+def _heal_push_subscription(user: str, service, subscriptions: list[dict]) -> list[str]:
+    """Healing core over an already-fetched subscription list; call under the per-user lock.
+
+    Deletes this site's expired subscriptions (best-effort: they are dead weight the server
+    purges eventually anyway, so a failed delete must not block the replacement) and creates
+    a fresh one unless a live one exists. Returns the ids it deleted so a caller reusing
+    ``subscriptions`` can drop them.
+    """
+
+    device_client_id = get_site_device_client_id(user)
+    now = get_utc_now()
+
+    live = False
+    expired_ids = []
+    for subscription in subscriptions:
+        if subscription.get("deviceClientId") != device_client_id:
+            continue
+        expires = subscription.get("expires")
+        if not expires or parse_iso_datetime(expires, as_str=False) > now:
+            live = True
+        else:
+            expired_ids.append(subscription["id"])
+
+    if expired_ids:
+        with suppress(Exception):
+            service.delete(expired_ids)
+
+    if not live:
+        _add_push_subscription(user, ignore_permissions=True)
+
+    return expired_ids
 
 
 def on_login(login_manager) -> None:
@@ -345,7 +370,8 @@ def renew_expiring_push_subscriptions() -> None:
     ``RENEW_THRESHOLD_DAYS`` of the run; subscriptions without an expiry or expiring
     later are left untouched. Users who disabled push subscriptions in their User
     Settings are skipped. Users missing this site's subscription on the mail server get
-    one created (self-healing — see ensure_push_subscription).
+    one created (self-healing — see ensure_push_subscription); healing and the expiry
+    scan share a single fetch, and subscriptions healing deleted are not renewed.
     """
 
     if not frappe.utils.get_url().startswith("https://"):
@@ -358,11 +384,16 @@ def renew_expiring_push_subscriptions() -> None:
             continue
 
         try:
-            ensure_push_subscription(user)
             service = get_push_subscription_service(user, ignore_permissions=True)
 
+            with filelock(f"ensure_push_subscription_{user}"):
+                subscriptions = service.get()
+                deleted_ids = _heal_push_subscription(user, service, subscriptions)
+
             expiring_ids = []
-            for subscription in service.get():
+            for subscription in subscriptions:
+                if subscription["id"] in deleted_ids:
+                    continue
                 expires = subscription.get("expires")
                 if expires and parse_iso_datetime(expires, as_str=False) <= cutoff:
                     expiring_ids.append(subscription["id"])
@@ -377,6 +408,10 @@ def renew_expiring_push_subscriptions() -> None:
                     _("Push Subscription Renewal Failed"),
                     _("Failed to renew push subscriptions for user {0}:<br>{1}").format(user, errors),
                 )
+        except LockTimeoutError:
+            # Another process is healing this user right now; today's renewal scan can
+            # wait for tomorrow's run, the threshold leaves days of headroom.
+            continue
         except Exception as e:
             log_mail_error(
                 _("Push Subscription Renewal Failed"),

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -4,7 +4,7 @@
 import base64
 import json
 from contextlib import suppress
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from uuid import uuid7
 
 import frappe
@@ -188,34 +188,49 @@ def ensure_push_subscription(user: str) -> None:
 def _heal_push_subscription(user: str, service, subscriptions: list[dict]) -> list[str]:
     """Healing core over an already-fetched subscription list; call under the per-user lock.
 
-    Deletes this site's expired subscriptions (best-effort: they are dead weight the server
-    purges eventually anyway, so a failed delete must not block the replacement) and creates
-    a fresh one unless a live one exists. Returns the ids it deleted so a caller reusing
+    Deletes this site's expired subscriptions and, when duplicates exist, every live one
+    but the longest-lived (deletion is best-effort: dead weight the server purges eventually
+    anyway, so a failure must not block the replacement). Creates a fresh subscription
+    unless a live one remains. Returns the ids it deleted so a caller reusing
     ``subscriptions`` can drop them.
     """
 
     device_client_id = get_site_device_client_id(user)
     now = get_utc_now()
 
-    live = False
+    live = []
     expired_ids = []
     for subscription in subscriptions:
         if subscription.get("deviceClientId") != device_client_id:
             continue
         expires = subscription.get("expires")
         if not expires or parse_iso_datetime(expires, as_str=False) > now:
-            live = True
+            live.append(subscription)
         else:
             expired_ids.append(subscription["id"])
 
-    if expired_ids:
+    # Converge on one live subscription: a duplicate (say a manual creation landing next
+    # to a healing run's) would otherwise ride the daily renewal forever.
+    surplus_ids = []
+    if len(live) > 1:
+        live.sort(key=_subscription_longevity, reverse=True)
+        surplus_ids = [subscription["id"] for subscription in live[1:]]
+
+    if delete_ids := expired_ids + surplus_ids:
         with suppress(Exception):
-            service.delete(expired_ids)
+            service.delete(delete_ids)
 
     if not live:
-        _add_push_subscription(user, ignore_permissions=True)
+        _create_push_subscription(user, ignore_permissions=True)
 
-    return expired_ids
+    return delete_ids
+
+
+def _subscription_longevity(subscription: dict) -> datetime:
+    """Sort key: when the subscription dies; no expiry means never."""
+
+    expires = subscription.get("expires")
+    return parse_iso_datetime(expires, as_str=False) if expires else datetime.max.replace(tzinfo=UTC)
 
 
 def on_login(login_manager) -> None:
@@ -264,12 +279,29 @@ def _add_push_subscription(
     parameters onto a whitelisted function's named arguments, so exposing it would let any caller
     turn off the ownership check and register an attacker-controlled callback URL against another
     user's account.
+
+    Serialized under the same per-user lock healing uses, so a manual creation cannot
+    interleave with a healing run's check-then-create.
     """
 
     if not ignore_permissions:
         has_permission_for_user(user, raise_exception=True)
 
     is_push_subscription_disabled(user, raise_exception=True)
+
+    with filelock(f"ensure_push_subscription_{user}"):
+        return _create_push_subscription(user, device_client_id, url, types, ignore_permissions)
+
+
+def _create_push_subscription(
+    user: str,
+    device_client_id: str | None = None,
+    url: str | None = None,
+    types: list[str] | None = None,
+    ignore_permissions: bool = False,
+) -> str:
+    """Unlocked creation core for :func:`_add_push_subscription` and the healing path,
+    which already holds the per-user lock."""
 
     device_client_id = device_client_id or get_site_device_client_id(user)
     if url:

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -289,8 +289,19 @@ def _add_push_subscription(
 
     is_push_subscription_disabled(user, raise_exception=True)
 
-    with filelock(f"ensure_push_subscription_{user}"):
-        return _create_push_subscription(user, device_client_id, url, types, ignore_permissions)
+    try:
+        # A healing run holds the lock for a couple of JMAP round trips; 10 seconds is
+        # generous. On timeout, surface a retryable message instead of the raw lock error
+        # (which advises deleting the lock file) after a 30 second modal hang.
+        with filelock(f"ensure_push_subscription_{user}", timeout=10):
+            return _create_push_subscription(user, device_client_id, url, types, ignore_permissions)
+    except LockTimeoutError:
+        frappe.throw(
+            _(
+                "Push subscriptions for {0} are currently being updated. Please try again in a few moments."
+            ).format(frappe.bold(user)),
+            title=_("Push Subscription Creation Error"),
+        )
 
 
 def _create_push_subscription(

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -15,7 +15,7 @@ from suite.mail.jmap import get_push_subscription_service
 from suite.mail.utils import generate_uuid_style_hash, log_mail_error
 from suite.mail.utils.dt import normalize_utc_z
 from suite.mail.utils.user import get_jmap_configured_users, is_jmap_configured
-from suite.utils import parse_filters
+from suite.utils import enqueue_job, parse_filters
 from suite.utils.dt import get_utc_now, parse_iso_datetime
 from suite.utils.user import is_system_manager
 
@@ -149,6 +149,61 @@ def bulk_delete(names: str | list[str]) -> None:
 
 
 @frappe.whitelist()
+def get_site_device_client_id(user: str) -> str:
+    """Returns this site's deterministic device client id for the user.
+
+    Deterministic so the site's own subscription on the mail server can be recognized
+    (and healed) without storing anything locally.
+    """
+
+    return generate_uuid_style_hash(f"frappe-{frappe.local.site.replace('.', '-')}-{user}")
+
+
+def ensure_push_subscription(user: str) -> None:
+    """Creates this site's push subscription for the user if the mail server holds none.
+
+    A subscription lost to a failed creation, an unrenewed expiry or a server-side delete
+    silently ends the user's webhooks — and with them both realtime events and mailbox-count
+    cache invalidation. The device client id is deterministic per site+user, so presence is
+    a plain lookup.
+    """
+
+    if not frappe.utils.get_url().startswith("https://"):
+        return
+    if is_push_subscription_disabled(user):
+        return
+
+    device_client_id = get_site_device_client_id(user)
+    now = get_utc_now()
+
+    for subscription in get_push_subscription_service(user, ignore_permissions=True).get():
+        if subscription.get("deviceClientId") != device_client_id:
+            continue
+        expires = subscription.get("expires")
+        if not expires or parse_iso_datetime(expires, as_str=False) > now:
+            return
+
+    _add_push_subscription(user, ignore_permissions=True)
+
+
+def on_login(login_manager) -> None:
+    """Login hook: heal the user's push subscription in the background.
+
+    Enqueued so the JMAP round trips never sit in the login path.
+    """
+
+    user = login_manager.user
+    if user in ("Guest", "Administrator") or not is_jmap_configured(user):
+        return
+
+    enqueue_job(
+        ensure_push_subscription,
+        user=user,
+        queue="short",
+        enqueue_after_commit=True,
+    )
+
+
 def add_push_subscription(
     user: str,
     device_client_id: str | None = None,
@@ -180,9 +235,7 @@ def _add_push_subscription(
 
     is_push_subscription_disabled(user, raise_exception=True)
 
-    device_client_id = device_client_id or generate_uuid_style_hash(
-        f"frappe-{frappe.local.site.replace('.', '-')}-{user}"
-    )
+    device_client_id = device_client_id or get_site_device_client_id(user)
     if url:
         if not url.startswith("https://"):
             frappe.throw(_("The URL must start with 'https://'."))
@@ -284,7 +337,8 @@ def renew_expiring_push_subscriptions() -> None:
     Scheduled to run daily. A subscription is renewed when its expiry is within
     ``RENEW_THRESHOLD_DAYS`` of the run; subscriptions without an expiry or expiring
     later are left untouched. Users who disabled push subscriptions in their User
-    Settings are skipped.
+    Settings are skipped. Users missing this site's subscription on the mail server get
+    one created (self-healing — see ensure_push_subscription).
     """
 
     if not frappe.utils.get_url().startswith("https://"):
@@ -297,6 +351,7 @@ def renew_expiring_push_subscriptions() -> None:
             continue
 
         try:
+            ensure_push_subscription(user)
             service = get_push_subscription_service(user, ignore_permissions=True)
 
             expiring_ids = []

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -286,7 +286,8 @@ def _add_push_subscription(
     exists, perhaps created by a healing run while this request waited on the lock, its
     id is returned instead of creating a duplicate. A custom creation without an explicit
     device client id gets a unique one, keeping the site's deterministic id exclusive to
-    the site subscription so healing never prunes a custom webhook as its duplicate.
+    the site subscription so healing never prunes a custom webhook as its duplicate;
+    explicitly claiming the site id for a custom creation is rejected.
     """
 
     if not ignore_permissions:
@@ -330,10 +331,19 @@ def _create_push_subscription(
     """Unlocked creation core for :func:`_add_push_subscription` and the healing path,
     which already holds the per-user lock."""
 
+    site_device_client_id = get_site_device_client_id(user)
     if not device_client_id:
         # The deterministic site id marks the site's own subscription for healing; a custom
         # creation must not wear it, or healing would prune one of the two as a duplicate.
-        device_client_id = get_site_device_client_id(user) if not url and not types else str(uuid7())
+        device_client_id = site_device_client_id if not url and not types else str(uuid7())
+    elif device_client_id == site_device_client_id and (url or types):
+        frappe.throw(
+            _(
+                "The device client id {0} is reserved for this site's own subscription and cannot be"
+                " used with a custom URL or types. Leave it empty to have a unique id assigned."
+            ).format(frappe.bold(device_client_id)),
+            title=_("Push Subscription Creation Error"),
+        )
     if url:
         if not url.startswith("https://"):
             frappe.throw(_("The URL must start with 'https://'."))

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -284,7 +284,9 @@ def _add_push_subscription(
     interleave with a healing run's check-then-create. A default creation (no explicit
     device client id, url or types) is idempotent: when a live site subscription already
     exists, perhaps created by a healing run while this request waited on the lock, its
-    id is returned instead of creating a duplicate.
+    id is returned instead of creating a duplicate. A custom creation without an explicit
+    device client id gets a unique one, keeping the site's deterministic id exclusive to
+    the site subscription so healing never prunes a custom webhook as its duplicate.
     """
 
     if not ignore_permissions:
@@ -328,7 +330,10 @@ def _create_push_subscription(
     """Unlocked creation core for :func:`_add_push_subscription` and the healing path,
     which already holds the per-user lock."""
 
-    device_client_id = device_client_id or get_site_device_client_id(user)
+    if not device_client_id:
+        # The deterministic site id marks the site's own subscription for healing; a custom
+        # creation must not wear it, or healing would prune one of the two as a duplicate.
+        device_client_id = get_site_device_client_id(user) if not url and not types else str(uuid7())
     if url:
         if not url.startswith("https://"):
             frappe.throw(_("The URL must start with 'https://'."))

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -193,6 +193,12 @@ def _heal_push_subscription(user: str, service, subscriptions: list[dict]) -> li
     anyway, so a failure must not block the replacement). Creates a fresh subscription
     unless a live one remains. Returns the ids it deleted so a caller reusing
     ``subscriptions`` can drop them.
+
+    Subscriptions created before device ids were kept exclusive may wear the site id
+    over a custom URL. The server exposes nothing to tell them apart (url is never
+    returned on get, and Stalwart normalizes a null types filter to the full type
+    list), so pruning may remove such a legacy subscription once; recreating it
+    assigns a unique id, taking it permanently out of healing's reach.
     """
 
     device_client_id = get_site_device_client_id(user)

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -10,6 +10,8 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cint, today
+from frappe.utils.file_lock import LockTimeoutError
+from frappe.utils.synchronization import filelock
 
 from suite.mail.jmap import get_push_subscription_service
 from suite.mail.utils import generate_uuid_style_hash, log_mail_error
@@ -165,7 +167,9 @@ def ensure_push_subscription(user: str) -> None:
     A subscription lost to a failed creation, an unrenewed expiry or a server-side delete
     silently ends the user's webhooks — and with them both realtime events and mailbox-count
     cache invalidation. The device client id is deterministic per site+user, so presence is
-    a plain lookup.
+    a plain lookup. A per-user lock serializes overlapping runs (login healing vs. the daily
+    renewal job) so they cannot both observe the subscription as missing and create it twice;
+    a run that cannot get the lock skips, since the holder is doing the same work.
     """
 
     if not frappe.utils.get_url().startswith("https://"):
@@ -173,17 +177,21 @@ def ensure_push_subscription(user: str) -> None:
     if is_push_subscription_disabled(user):
         return
 
-    device_client_id = get_site_device_client_id(user)
-    now = get_utc_now()
+    try:
+        with filelock(f"ensure_push_subscription_{user}"):
+            device_client_id = get_site_device_client_id(user)
+            now = get_utc_now()
 
-    for subscription in get_push_subscription_service(user, ignore_permissions=True).get():
-        if subscription.get("deviceClientId") != device_client_id:
-            continue
-        expires = subscription.get("expires")
-        if not expires or parse_iso_datetime(expires, as_str=False) > now:
-            return
+            for subscription in get_push_subscription_service(user, ignore_permissions=True).get():
+                if subscription.get("deviceClientId") != device_client_id:
+                    continue
+                expires = subscription.get("expires")
+                if not expires or parse_iso_datetime(expires, as_str=False) > now:
+                    return
 
-    _add_push_subscription(user, ignore_permissions=True)
+            _add_push_subscription(user, ignore_permissions=True)
+    except LockTimeoutError:
+        return
 
 
 def on_login(login_manager) -> None:

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -150,7 +150,6 @@ def bulk_delete(names: str | list[str]) -> None:
     frappe.msgprint(_("Push Subscriptions deleted successfully."), alert=True)
 
 
-@frappe.whitelist()
 def get_site_device_client_id(user: str) -> str:
     """Returns this site's deterministic device client id for the user.
 

--- a/suite/mail/jmap/services/core.py
+++ b/suite/mail/jmap/services/core.py
@@ -344,6 +344,17 @@ class CoreService(CoreServiceHelper):
 
         return self._exec("get", ids=ids, properties=properties, **kwargs)
 
+    def get_state(self) -> str | None:
+        """Returns the server's current state string for this type, via an empty 'get'.
+
+        The state is what 'changes' diffs against; an error response yields None.
+        """
+
+        response = self._get(ids=[], properties=["id"])
+        for _name, body, _call_id in response.get("methodResponses") or []:
+            return body.get("state")
+        return None
+
     def _update(self, update: dict, **kwargs) -> dict:
         """Internal method to update objects of the specified type using the JMAP 'set' method."""
 

--- a/suite/mail/tests/test_mail_push_sync.py
+++ b/suite/mail/tests/test_mail_push_sync.py
@@ -40,6 +40,30 @@ class EmailServiceChanges(unittest.TestCase):
         self.assertEqual(self._service({}).changes("s1"), {})
 
 
+class EmailServiceGetState(unittest.TestCase):
+    """``CoreService.get_state`` — unwrap the state from an empty 'get', None when unavailable."""
+
+    def _service(self, response: dict) -> EmailService:
+        service = EmailService("f7", mock.MagicMock())
+        service._exec = mock.MagicMock(return_value=response)
+        return service
+
+    def test_returns_state_from_first_method_response_via_an_empty_get(self):
+        body = {"accountId": "f7", "state": "s9", "list": [], "notFound": []}
+        service = self._service({"methodResponses": [["Email/get", body, "0"]]})
+
+        self.assertEqual(service.get_state(), "s9")
+        service._exec.assert_called_once_with("get", ids=[], properties=["id"])
+
+    def test_error_response_yields_none(self):
+        service = self._service({"methodResponses": [["error", FORBIDDEN, "0"]]})
+
+        self.assertIsNone(service.get_state())
+
+    def test_missing_method_responses_yield_none(self):
+        self.assertIsNone(self._service({}).get_state())
+
+
 class FetchChanges(unittest.TestCase):
     """``fetch_changes`` — server failures are logged and leave the sync state untouched."""
 

--- a/suite/mail/tests/test_mail_push_sync.py
+++ b/suite/mail/tests/test_mail_push_sync.py
@@ -70,3 +70,58 @@ class FetchChanges(unittest.TestCase):
 
         log_mail_error.assert_not_called()
         update_sync_state.assert_not_called()
+
+
+class FetchChangesInit(unittest.TestCase):
+    """``fetch_changes`` with no stored sync state — how the state gets seeded.
+
+    A webhook carries the new state and initializes from it directly. A manual or
+    scheduled run carries none; storing that None would leave the account
+    re-"initializing" on every run with changes never fetched, so the state is seeded
+    from the server instead.
+    """
+
+    def _run(
+        self, email_state: str | None, server_state: str | mock.Mock | None
+    ) -> tuple[mock.Mock, mock.Mock, mock.Mock]:
+        with (
+            mock.patch.object(mail_message, "get_sync_state", return_value=None),
+            mock.patch.object(mail_message, "update_sync_state") as update_sync_state,
+            mock.patch.object(mail_message, "get_jmap_connection"),
+            mock.patch.object(mail_message, "EmailService") as email_service,
+            mock.patch.object(mail_message, "log_mail_error") as log_mail_error,
+        ):
+            if isinstance(server_state, mock.Mock):
+                email_service.return_value.get_state = server_state
+            else:
+                email_service.return_value.get_state = mock.MagicMock(return_value=server_state)
+            mail_message.fetch_changes("user@example.test", "f7", email_state=email_state)
+
+        return update_sync_state, log_mail_error, email_service.return_value.get_state
+
+    def test_webhook_state_initializes_directly(self):
+        update_sync_state, log_mail_error, get_state = self._run("s2", "unused")
+
+        update_sync_state.assert_called_once_with("f7", type="email", state="s2")
+        get_state.assert_not_called()
+        log_mail_error.assert_not_called()
+
+    def test_missing_state_is_seeded_from_server(self):
+        update_sync_state, log_mail_error, _ = self._run(None, "s5")
+
+        update_sync_state.assert_called_once_with("f7", type="email", state="s5")
+        log_mail_error.assert_not_called()
+
+    def test_unavailable_server_state_is_not_stored(self):
+        update_sync_state, log_mail_error, _ = self._run(None, None)
+
+        update_sync_state.assert_not_called()
+        log_mail_error.assert_not_called()
+
+    def test_seed_failure_is_logged_and_not_stored(self):
+        update_sync_state, log_mail_error, _ = self._run(
+            None, mock.MagicMock(side_effect=RuntimeError("boom"))
+        )
+
+        update_sync_state.assert_not_called()
+        log_mail_error.assert_called_once()

--- a/suite/mail/tests/test_push_subscription_healing.py
+++ b/suite/mail/tests/test_push_subscription_healing.py
@@ -236,6 +236,18 @@ class CreatePushSubscription(unittest.TestCase):
     def test_custom_types_creation_gets_a_unique_device_id(self):
         self.assertNotEqual(self._create(types=["Email"])["device_client_id"], "site-device")
 
+    def test_site_device_id_with_custom_parameters_is_rejected(self):
+        with (
+            mock.patch.object(push_subscription, "get_site_device_client_id", return_value="site-device"),
+            mock.patch.object(push_subscription, "get_push_subscription_service") as service,
+            self.assertRaises(push_subscription.frappe.ValidationError),
+        ):
+            push_subscription._create_push_subscription(
+                USER, "site-device", "https://elsewhere.example.test/hook", ignore_permissions=True
+            )
+
+        service.return_value.create.assert_not_called()
+
     def test_explicit_device_id_is_honored(self):
         sub = self._create(device_client_id="my-device", url="https://elsewhere.example.test/hook")
 

--- a/suite/mail/tests/test_push_subscription_healing.py
+++ b/suite/mail/tests/test_push_subscription_healing.py
@@ -128,19 +128,69 @@ class EnsurePushSubscription(unittest.TestCase):
 
 
 class AddPushSubscription(unittest.TestCase):
-    """``_add_push_subscription`` — manual creations serialize under the healing lock."""
+    """``_add_push_subscription`` — manual creations serialize under the healing lock, and
+    the default creation is idempotent against an existing live site subscription."""
 
-    def test_manual_creation_takes_the_per_user_lock(self):
+    def _add(
+        self,
+        subscriptions: list[dict],
+        device_client_id: str | None = None,
+        url: str | None = None,
+        types: list[str] | None = None,
+    ) -> tuple[str, mock.Mock, mock.Mock]:
         with (
             mock.patch.object(push_subscription, "filelock") as filelock,
             mock.patch.object(push_subscription, "is_push_subscription_disabled", return_value=False),
-            mock.patch.object(push_subscription, "_create_push_subscription", return_value="id-1") as create,
+            mock.patch.object(push_subscription, "get_site_device_client_id", return_value="site-device"),
+            mock.patch.object(push_subscription, "get_push_subscription_service") as service,
+            mock.patch.object(
+                push_subscription, "_create_push_subscription", return_value="new-id"
+            ) as create,
         ):
-            result = push_subscription._add_push_subscription(USER, ignore_permissions=True)
+            service.return_value.get.return_value = subscriptions
+            result = push_subscription._add_push_subscription(
+                USER, device_client_id, url, types, ignore_permissions=True
+            )
 
-        self.assertEqual(result, "id-1")
+        return result, create, filelock
+
+    def test_manual_creation_takes_the_per_user_lock(self):
+        result, create, filelock = self._add([])
+
+        self.assertEqual(result, "new-id")
         filelock.assert_called_once_with(f"ensure_push_subscription_{USER}", timeout=10)
         create.assert_called_once_with(USER, None, None, None, True)
+
+    def test_default_creation_returns_the_existing_live_site_subscription(self):
+        result, create, _ = self._add(
+            [
+                {"id": "old", "deviceClientId": "site-device", "expires": "2998-01-01T00:00:00Z"},
+                {"id": "keeper", "deviceClientId": "site-device", "expires": None},
+            ]
+        )
+
+        self.assertEqual(result, "keeper")
+        create.assert_not_called()
+
+    def test_expired_or_foreign_subscriptions_do_not_shortcut_creation(self):
+        result, create, _ = self._add(
+            [
+                {"id": "dead", "deviceClientId": "site-device", "expires": "2000-01-01T00:00:00Z"},
+                {"id": "other", "deviceClientId": "other-device", "expires": None},
+            ]
+        )
+
+        self.assertEqual(result, "new-id")
+        create.assert_called_once()
+
+    def test_custom_parameters_always_create(self):
+        result, create, _ = self._add(
+            [{"id": "existing", "deviceClientId": "site-device", "expires": None}],
+            url="https://elsewhere.example.test/hook",
+        )
+
+        self.assertEqual(result, "new-id")
+        create.assert_called_once_with(USER, None, "https://elsewhere.example.test/hook", None, True)
 
     def test_lock_timeout_surfaces_a_friendly_error(self):
         with (

--- a/suite/mail/tests/test_push_subscription_healing.py
+++ b/suite/mail/tests/test_push_subscription_healing.py
@@ -6,11 +6,13 @@ expiry or a server-side delete silently ends the user's webhooks, so presence mu
 verifiable and recoverable without any locally stored record."""
 
 import unittest
+from datetime import timedelta
 from unittest import mock
 
 from frappe.utils.file_lock import LockTimeoutError
 
 from suite.mail.doctype.push_subscription import push_subscription
+from suite.utils.dt import get_utc_now
 
 USER = "user@example.test"
 
@@ -21,6 +23,7 @@ class EnsurePushSubscription(unittest.TestCase):
         subscriptions: list[dict],
         url: str = "https://mail.example.test",
         disabled: bool = False,
+        delete_error: Exception | None = None,
     ) -> tuple[mock.Mock, mock.Mock]:
         with (
             mock.patch.object(push_subscription.frappe.utils, "get_url", return_value=url),
@@ -30,6 +33,8 @@ class EnsurePushSubscription(unittest.TestCase):
             mock.patch.object(push_subscription, "_add_push_subscription") as add,
         ):
             service.return_value.get.return_value = subscriptions
+            if delete_error:
+                service.return_value.delete.side_effect = delete_error
             push_subscription.ensure_push_subscription(USER)
 
         return add, service
@@ -55,7 +60,29 @@ class EnsurePushSubscription(unittest.TestCase):
         add.assert_called_once_with(USER, ignore_permissions=True)
 
     def test_recreates_when_subscription_expired(self):
-        add, _ = self._run([{"deviceClientId": "site-device", "expires": "2000-01-01T00:00:00Z"}])
+        add, service = self._run(
+            [{"id": "sub-old", "deviceClientId": "site-device", "expires": "2000-01-01T00:00:00Z"}]
+        )
+
+        add.assert_called_once_with(USER, ignore_permissions=True)
+        service.return_value.delete.assert_called_once_with(["sub-old"])
+
+    def test_expired_duplicate_is_deleted_even_when_live_exists(self):
+        add, service = self._run(
+            [
+                {"id": "sub-old", "deviceClientId": "site-device", "expires": "2000-01-01T00:00:00Z"},
+                {"deviceClientId": "site-device", "expires": "2999-01-01T00:00:00Z"},
+            ]
+        )
+
+        add.assert_not_called()
+        service.return_value.delete.assert_called_once_with(["sub-old"])
+
+    def test_delete_failure_does_not_block_recreation(self):
+        add, _ = self._run(
+            [{"id": "sub-old", "deviceClientId": "site-device", "expires": "2000-01-01T00:00:00Z"}],
+            delete_error=RuntimeError("boom"),
+        )
 
         add.assert_called_once_with(USER, ignore_permissions=True)
 
@@ -85,6 +112,52 @@ class EnsurePushSubscription(unittest.TestCase):
 
         service.assert_not_called()
         add.assert_not_called()
+
+
+class RenewExpiringPushSubscriptions(unittest.TestCase):
+    """``renew_expiring_push_subscriptions`` — healing and the expiry scan share one fetch."""
+
+    def _run(self, subscriptions: list[dict]) -> tuple[mock.Mock, mock.Mock]:
+        with (
+            mock.patch.object(
+                push_subscription.frappe.utils, "get_url", return_value="https://mail.example.test"
+            ),
+            mock.patch.object(push_subscription, "get_jmap_configured_users", return_value=[USER]),
+            mock.patch.object(push_subscription, "is_push_subscription_disabled", return_value=False),
+            mock.patch.object(push_subscription, "get_site_device_client_id", return_value="site-device"),
+            mock.patch.object(push_subscription, "get_push_subscription_service") as service_factory,
+            mock.patch.object(push_subscription, "_add_push_subscription") as add,
+            mock.patch.object(push_subscription, "log_mail_error") as log_mail_error,
+        ):
+            service = service_factory.return_value
+            service.get.return_value = subscriptions
+            service.update.return_value = {"updated": {}}
+            push_subscription.renew_expiring_push_subscriptions()
+
+        self.assertEqual(service.get.call_count, 1)
+        log_mail_error.assert_not_called()
+        return service, add
+
+    def test_expiring_subscription_is_renewed_from_the_shared_fetch(self):
+        expiring = (get_utc_now() + timedelta(days=1)).isoformat()
+        service, add = self._run(
+            [
+                {"id": "site-sub", "deviceClientId": "site-device", "expires": "2999-01-01T00:00:00Z"},
+                {"id": "exp-1", "deviceClientId": "other-device", "expires": expiring},
+            ]
+        )
+
+        service.update.assert_called_once_with([{"id": "exp-1"}])
+        add.assert_not_called()
+
+    def test_deleted_expired_subscription_is_not_renewed(self):
+        service, add = self._run(
+            [{"id": "sub-old", "deviceClientId": "site-device", "expires": "2000-01-01T00:00:00Z"}]
+        )
+
+        service.delete.assert_called_once_with(["sub-old"])
+        add.assert_called_once_with(USER, ignore_permissions=True)
+        service.update.assert_not_called()
 
 
 class OnLogin(unittest.TestCase):

--- a/suite/mail/tests/test_push_subscription_healing.py
+++ b/suite/mail/tests/test_push_subscription_healing.py
@@ -190,6 +190,8 @@ class OnLogin(unittest.TestCase):
         enqueue_job.assert_called_once()
         self.assertIs(enqueue_job.call_args.args[0], push_subscription.ensure_push_subscription)
         self.assertEqual(enqueue_job.call_args.kwargs["user"], USER)
+        self.assertEqual(enqueue_job.call_args.kwargs["job_id"], f"ensure_push_subscription:{USER}")
+        self.assertTrue(enqueue_job.call_args.kwargs["deduplicate"])
 
     def test_skips_guest_and_administrator(self):
         self._run("Guest").assert_not_called()

--- a/suite/mail/tests/test_push_subscription_healing.py
+++ b/suite/mail/tests/test_push_subscription_healing.py
@@ -30,7 +30,7 @@ class EnsurePushSubscription(unittest.TestCase):
             mock.patch.object(push_subscription, "is_push_subscription_disabled", return_value=disabled),
             mock.patch.object(push_subscription, "get_site_device_client_id", return_value="site-device"),
             mock.patch.object(push_subscription, "get_push_subscription_service") as service,
-            mock.patch.object(push_subscription, "_add_push_subscription") as add,
+            mock.patch.object(push_subscription, "_create_push_subscription") as add,
         ):
             service.return_value.get.return_value = subscriptions
             if delete_error:
@@ -106,12 +106,41 @@ class EnsurePushSubscription(unittest.TestCase):
             mock.patch.object(push_subscription, "is_push_subscription_disabled", return_value=False),
             mock.patch.object(push_subscription, "filelock", side_effect=LockTimeoutError),
             mock.patch.object(push_subscription, "get_push_subscription_service") as service,
-            mock.patch.object(push_subscription, "_add_push_subscription") as add,
+            mock.patch.object(push_subscription, "_create_push_subscription") as add,
         ):
             push_subscription.ensure_push_subscription(USER)
 
         service.assert_not_called()
         add.assert_not_called()
+
+    def test_surplus_live_duplicates_are_pruned_keeping_the_longest_lived(self):
+        add, service = self._run(
+            [
+                {"id": "sub-a", "deviceClientId": "site-device", "expires": "2998-01-01T00:00:00Z"},
+                {"id": "sub-b", "deviceClientId": "site-device", "expires": None},
+                {"id": "sub-c", "deviceClientId": "site-device", "expires": "2999-01-01T00:00:00Z"},
+            ]
+        )
+
+        add.assert_not_called()
+        (deleted,), _ = service.return_value.delete.call_args
+        self.assertCountEqual(deleted, ["sub-a", "sub-c"])
+
+
+class AddPushSubscription(unittest.TestCase):
+    """``_add_push_subscription`` — manual creations serialize under the healing lock."""
+
+    def test_manual_creation_takes_the_per_user_lock(self):
+        with (
+            mock.patch.object(push_subscription, "filelock") as filelock,
+            mock.patch.object(push_subscription, "is_push_subscription_disabled", return_value=False),
+            mock.patch.object(push_subscription, "_create_push_subscription", return_value="id-1") as create,
+        ):
+            result = push_subscription._add_push_subscription(USER, ignore_permissions=True)
+
+        self.assertEqual(result, "id-1")
+        filelock.assert_called_once_with(f"ensure_push_subscription_{USER}")
+        create.assert_called_once_with(USER, None, None, None, True)
 
 
 class RenewExpiringPushSubscriptions(unittest.TestCase):
@@ -126,7 +155,7 @@ class RenewExpiringPushSubscriptions(unittest.TestCase):
             mock.patch.object(push_subscription, "is_push_subscription_disabled", return_value=False),
             mock.patch.object(push_subscription, "get_site_device_client_id", return_value="site-device"),
             mock.patch.object(push_subscription, "get_push_subscription_service") as service_factory,
-            mock.patch.object(push_subscription, "_add_push_subscription") as add,
+            mock.patch.object(push_subscription, "_create_push_subscription") as add,
             mock.patch.object(push_subscription, "log_mail_error") as log_mail_error,
         ):
             service = service_factory.return_value

--- a/suite/mail/tests/test_push_subscription_healing.py
+++ b/suite/mail/tests/test_push_subscription_healing.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+"""``ensure_push_subscription`` — the self-healing check that (re)creates this site's push
+subscription on the mail server. A subscription lost to a failed creation, an unrenewed
+expiry or a server-side delete silently ends the user's webhooks, so presence must be
+verifiable and recoverable without any locally stored record."""
+
+import unittest
+from unittest import mock
+
+from suite.mail.doctype.push_subscription import push_subscription
+
+USER = "user@example.test"
+
+
+class EnsurePushSubscription(unittest.TestCase):
+    def _run(
+        self,
+        subscriptions: list[dict],
+        url: str = "https://mail.example.test",
+        disabled: bool = False,
+    ) -> tuple[mock.Mock, mock.Mock]:
+        with (
+            mock.patch.object(push_subscription.frappe.utils, "get_url", return_value=url),
+            mock.patch.object(push_subscription, "is_push_subscription_disabled", return_value=disabled),
+            mock.patch.object(push_subscription, "get_site_device_client_id", return_value="site-device"),
+            mock.patch.object(push_subscription, "get_push_subscription_service") as service,
+            mock.patch.object(push_subscription, "_add_push_subscription") as add,
+        ):
+            service.return_value.get.return_value = subscriptions
+            push_subscription.ensure_push_subscription(USER)
+
+        return add, service
+
+    def test_creates_when_no_subscription_exists(self):
+        add, _ = self._run([])
+
+        add.assert_called_once_with(USER, ignore_permissions=True)
+
+    def test_skips_when_live_subscription_exists(self):
+        add, _ = self._run([{"deviceClientId": "site-device", "expires": "2999-01-01T00:00:00Z"}])
+
+        add.assert_not_called()
+
+    def test_skips_when_subscription_never_expires(self):
+        add, _ = self._run([{"deviceClientId": "site-device", "expires": None}])
+
+        add.assert_not_called()
+
+    def test_other_devices_subscriptions_do_not_count(self):
+        add, _ = self._run([{"deviceClientId": "other-device", "expires": "2999-01-01T00:00:00Z"}])
+
+        add.assert_called_once_with(USER, ignore_permissions=True)
+
+    def test_recreates_when_subscription_expired(self):
+        add, _ = self._run([{"deviceClientId": "site-device", "expires": "2000-01-01T00:00:00Z"}])
+
+        add.assert_called_once_with(USER, ignore_permissions=True)
+
+    def test_skips_on_non_https_site(self):
+        add, service = self._run([], url="http://site.localhost:8001")
+
+        add.assert_not_called()
+        service.assert_not_called()
+
+    def test_skips_when_user_disabled_push(self):
+        add, service = self._run([], disabled=True)
+
+        add.assert_not_called()
+        service.assert_not_called()
+
+
+class OnLogin(unittest.TestCase):
+    def _run(self, user: str, jmap_configured: bool = True) -> mock.Mock:
+        login_manager = mock.MagicMock()
+        login_manager.user = user
+        with (
+            mock.patch.object(push_subscription, "is_jmap_configured", return_value=jmap_configured),
+            mock.patch.object(push_subscription, "enqueue_job") as enqueue_job,
+        ):
+            push_subscription.on_login(login_manager)
+
+        return enqueue_job
+
+    def test_enqueues_healing_for_jmap_user(self):
+        enqueue_job = self._run(USER)
+
+        enqueue_job.assert_called_once()
+        self.assertIs(enqueue_job.call_args.args[0], push_subscription.ensure_push_subscription)
+        self.assertEqual(enqueue_job.call_args.kwargs["user"], USER)
+
+    def test_skips_guest_and_administrator(self):
+        self._run("Guest").assert_not_called()
+        self._run("Administrator").assert_not_called()
+
+    def test_skips_users_without_jmap(self):
+        self._run(USER, jmap_configured=False).assert_not_called()

--- a/suite/mail/tests/test_push_subscription_healing.py
+++ b/suite/mail/tests/test_push_subscription_healing.py
@@ -139,8 +139,19 @@ class AddPushSubscription(unittest.TestCase):
             result = push_subscription._add_push_subscription(USER, ignore_permissions=True)
 
         self.assertEqual(result, "id-1")
-        filelock.assert_called_once_with(f"ensure_push_subscription_{USER}")
+        filelock.assert_called_once_with(f"ensure_push_subscription_{USER}", timeout=10)
         create.assert_called_once_with(USER, None, None, None, True)
+
+    def test_lock_timeout_surfaces_a_friendly_error(self):
+        with (
+            mock.patch.object(push_subscription, "filelock", side_effect=LockTimeoutError),
+            mock.patch.object(push_subscription, "is_push_subscription_disabled", return_value=False),
+            mock.patch.object(push_subscription, "_create_push_subscription") as create,
+            self.assertRaises(push_subscription.frappe.ValidationError),
+        ):
+            push_subscription._add_push_subscription(USER, ignore_permissions=True)
+
+        create.assert_not_called()
 
 
 class RenewExpiringPushSubscriptions(unittest.TestCase):

--- a/suite/mail/tests/test_push_subscription_healing.py
+++ b/suite/mail/tests/test_push_subscription_healing.py
@@ -8,6 +8,8 @@ verifiable and recoverable without any locally stored record."""
 import unittest
 from unittest import mock
 
+from frappe.utils.file_lock import LockTimeoutError
+
 from suite.mail.doctype.push_subscription import push_subscription
 
 USER = "user@example.test"
@@ -68,6 +70,21 @@ class EnsurePushSubscription(unittest.TestCase):
 
         add.assert_not_called()
         service.assert_not_called()
+
+    def test_skips_when_concurrent_run_holds_the_lock(self):
+        with (
+            mock.patch.object(
+                push_subscription.frappe.utils, "get_url", return_value="https://mail.example.test"
+            ),
+            mock.patch.object(push_subscription, "is_push_subscription_disabled", return_value=False),
+            mock.patch.object(push_subscription, "filelock", side_effect=LockTimeoutError),
+            mock.patch.object(push_subscription, "get_push_subscription_service") as service,
+            mock.patch.object(push_subscription, "_add_push_subscription") as add,
+        ):
+            push_subscription.ensure_push_subscription(USER)
+
+        service.assert_not_called()
+        add.assert_not_called()
 
 
 class OnLogin(unittest.TestCase):

--- a/suite/mail/tests/test_push_subscription_healing.py
+++ b/suite/mail/tests/test_push_subscription_healing.py
@@ -204,6 +204,44 @@ class AddPushSubscription(unittest.TestCase):
         create.assert_not_called()
 
 
+class CreatePushSubscription(unittest.TestCase):
+    """``_create_push_subscription`` — the site's deterministic device id stays exclusive
+    to the site-default subscription; custom creations get their own identity."""
+
+    def _create(self, **kwargs) -> dict:
+        with (
+            mock.patch.object(
+                push_subscription.frappe.utils, "get_url", return_value="https://site.example.test"
+            ),
+            mock.patch.object(push_subscription, "get_site_device_client_id", return_value="site-device"),
+            mock.patch.object(push_subscription, "get_push_subscription_keys", return_value=None),
+            mock.patch.object(push_subscription, "get_push_subscription_service") as service,
+        ):
+            service.return_value.create.side_effect = lambda subs: {
+                "created": {subs[0]["creation_id"]: {"id": "new-id"}}
+            }
+            push_subscription._create_push_subscription(USER, ignore_permissions=True, **kwargs)
+            (subs,), _ = service.return_value.create.call_args
+
+        return subs[0]
+
+    def test_default_creation_wears_the_site_device_id(self):
+        self.assertEqual(self._create()["device_client_id"], "site-device")
+
+    def test_custom_url_creation_gets_a_unique_device_id(self):
+        sub = self._create(url="https://elsewhere.example.test/hook")
+
+        self.assertNotEqual(sub["device_client_id"], "site-device")
+
+    def test_custom_types_creation_gets_a_unique_device_id(self):
+        self.assertNotEqual(self._create(types=["Email"])["device_client_id"], "site-device")
+
+    def test_explicit_device_id_is_honored(self):
+        sub = self._create(device_client_id="my-device", url="https://elsewhere.example.test/hook")
+
+        self.assertEqual(sub["device_client_id"], "my-device")
+
+
 class RenewExpiringPushSubscriptions(unittest.TestCase):
     """``renew_expiring_push_subscriptions`` — healing and the expiry scan share one fetch."""
 

--- a/suite/mail/tests/test_push_subscription_healing.py
+++ b/suite/mail/tests/test_push_subscription_healing.py
@@ -150,6 +150,18 @@ class RenewExpiringPushSubscriptions(unittest.TestCase):
         service.update.assert_called_once_with([{"id": "exp-1"}])
         add.assert_not_called()
 
+    def test_already_expired_foreign_subscription_is_not_renewed(self):
+        service, add = self._run(
+            [
+                {"id": "site-sub", "deviceClientId": "site-device", "expires": "2999-01-01T00:00:00Z"},
+                {"id": "dead-1", "deviceClientId": "other-device", "expires": "2000-01-01T00:00:00Z"},
+            ]
+        )
+
+        service.update.assert_not_called()
+        service.delete.assert_not_called()
+        add.assert_not_called()
+
     def test_deleted_expired_subscription_is_not_renewed(self):
         service, add = self._run(
             [{"id": "sub-old", "deviceClientId": "site-device", "expires": "2000-01-01T00:00:00Z"}]


### PR DESCRIPTION
Mail realtime rides on JMAP push webhooks: they trigger `fetch_changes`, which publishes the `new_mail_created` socket event the views refresh on. Without webhooks, no realtime event is ever published and new mail only surfaces through the 30s poll or a manual refresh.

Two bugs made webhooks easy to lose and impossible to recover:

**Subscriptions were never created, only renewed.** No code path called `add_push_subscription`, and the daily job only renews subscriptions that already exist. A subscription lost to a failed creation, an unrenewed expiry or a server-side delete silently ended the user's webhooks forever. `ensure_push_subscription` now looks up this site's subscription on the mail server (the device client id is deterministic per site+user) and creates one when it's missing or expired — wired into the daily job and an enqueued `on_login` hook.

**A missing sync state could never initialize itself.** `fetch_changes` with no stored state and no `email_state` argument (any manual or scheduled run) stored `None`, so every subsequent run just "initialized" again and changes were never fetched. It now seeds from the server's actual Email state via a new `CoreService.get_state()`.

Verified end to end against a live mail server (subscription creation → PushVerification → StateChange webhooks → socket refresh in the browser). Unit tests cover the seeding paths and the healing decision table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)