### PR TITLE
fix(mail): preserve the original's formatting when forwarding

### DIFF
--- a/frontend/src/apps/mail/components/EmailContent.vue
+++ b/frontend/src/apps/mail/components/EmailContent.vue
@@ -65,7 +65,7 @@ import { Button } from 'frappe-ui'
 
 import { analyzeRemoteAssets, blockRemoteAssets } from '@/apps/mail/utils'
 import { escapeBracketedAddresses } from '@/apps/mail/utils/html'
-import { useComposeMail, useTheme } from '@/apps/mail/utils/composables'
+import { useComposeMail, useScreenSize, useTheme } from '@/apps/mail/utils/composables'
 import { parseMailto } from '@/apps/mail/utils/mailto'
 import {
 	declaresFixedPalette,
@@ -82,6 +82,7 @@ const {
 const emit = defineEmits<{ trust: [] }>()
 
 const { dataTheme } = useTheme()
+const { isMobile } = useScreenSize()
 const { requestCompose } = useComposeMail()
 const frame = useTemplateRef<{ $el: HTMLIFrameElement }>('frame')
 
@@ -172,7 +173,7 @@ const collapseQuotes = (doc: Document) => {
 		button.dataset.hide = __('Hide trimmed content')
 		button.appendChild(label)
 		// Styled by the .quote-toggle rules in the srcdoc stylesheet — a class, not
-		// inline styles, so the mobile media query can size the touch target up.
+		// inline styles, so the mobile variant can size the touch target up.
 		button.className = 'quote-toggle'
 		button.setAttribute(
 			'onclick',
@@ -290,9 +291,12 @@ const srcdoc = computed(() => {
 				}
 
 				/* A finger target on mobile — matches the app's 40px mobile buttons,
-				   with the lg radius that size takes. */
-				@media (max-width: 640px) {
-					.quote-toggle {
+				   with the lg radius that size takes. Keyed on the app's own isMobile,
+				   not an iframe media query: the iframe only knows the reading pane's
+				   width, and a desktop pane narrowed by the sidebar is not a phone. */
+				${
+					isMobile.value
+						? `.quote-toggle {
 						padding: 10px 14px;
 						gap: 8px;
 						border-radius: 10px;
@@ -300,7 +304,8 @@ const srcdoc = computed(() => {
 					.quote-toggle svg {
 						width: 14px;
 						height: 14px;
-					}
+					}`
+						: ''
 				}
 
 				.email-pixel {
@@ -397,6 +402,10 @@ const srcdoc = computed(() => {
 				// load): if the box the image got is narrower than the width its height
 				// was drawn for, shed that height. Percentage widths are left alone —
 				// fluid width against a fixed height is the author's own design.
+				// A height-only image scales its width from that height, so the width
+				// it was drawn for is the height at the bitmap's aspect — not the
+				// bitmap's own width, which a 24px logo cut from a large PNG never
+				// reaches and must not be inflated to.
 				const unsquashImages = () => {
 					document.querySelectorAll('img').forEach((img) => {
 						const authored = img.dataset.authorWidth ?? img.getAttribute('width') ?? '';
@@ -405,7 +414,7 @@ const srcdoc = computed(() => {
 						const drawn =
 							(authoredStyle.endsWith('px') && parseFloat(authoredStyle)) ||
 							parseFloat(authored) ||
-							img.naturalWidth;
+							(img.naturalHeight ? img.clientHeight * (img.naturalWidth / img.naturalHeight) : 0);
 						if (!img.clientWidth) return;
 						if (drawn > img.clientWidth + 1) {
 							// Stash before overwriting, so widening the pane can undo this too.

--- a/frontend/src/apps/mail/components/MailDetails.vue
+++ b/frontend/src/apps/mail/components/MailDetails.vue
@@ -1,22 +1,7 @@
 <template>
 	<div class="overflow-y-auto rounded border text-sm sm:max-h-96 sm:w-96 sm:border-0">
-		<!-- The sender is the only person here with a face — a header, not a "From:" row. -->
-		<div class="flex items-center gap-3 border-b px-4 pb-3 pt-3.5">
-			<Avatar :label="getSenderInitial(mail)" :image="mail.user_image" size="xl" />
-			<div class="min-w-0">
-				<!-- text-p-*: the paragraph styles carry a reading line-height, so truncate
-				     has room for descenders without stating leadings by hand. -->
-				<div class="text-ink-gray-9 text-p-base-semibold truncate">
-					{{ mail.from_name || mail.from_email }}
-				</div>
-				<div v-if="mail.from_name" class="text-ink-gray-5 text-p-xs truncate">
-					{{ mail.from_email }}
-				</div>
-			</div>
-		</div>
-
 		<div class="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-2 px-4 py-3">
-			<template v-for="field in recipientFields" :key="field.label">
+			<template v-for="field in fields" :key="field.label">
 				<!-- Label and value share one paragraph style, so their first-line boxes —
 				     and therefore baselines — align by construction, no nudges. Color alone
 				     separates them. -->
@@ -31,10 +16,8 @@
 
 <script setup lang="ts">
 import { computed, inject } from 'vue'
-import { Avatar } from 'frappe-ui'
 
 import { getGroupedRecipients } from '@/apps/mail/utils'
-import { getSenderInitial } from '@/apps/mail/utils/participants'
 
 import type { Mail } from '@/apps/mail/types'
 
@@ -45,8 +28,9 @@ const { mail } = defineProps<{ mail: Mail }>()
 const recipients = computed(() => getGroupedRecipients(mail.recipients, true, true))
 
 // Lowercase, no colons — the labels describe, the values speak.
-const recipientFields = computed(() =>
+const fields = computed(() =>
 	[
+		{ label: __('from'), value: sender.value },
 		{ label: __('to'), value: recipients.value.to },
 		{ label: __('cc'), value: recipients.value.cc },
 		{ label: __('bcc'), value: recipients.value.bcc },
@@ -56,6 +40,11 @@ const recipientFields = computed(() =>
 		{ label: __('subject'), value: mail.subject },
 		{ label: __('date'), value: formattedDate.value },
 	].filter((field) => field.value),
+)
+
+// The same shape the recipient rows use: name with the address alongside.
+const sender = computed(() =>
+	mail.from_name ? `${mail.from_name} <${mail.from_email}>` : mail.from_email,
 )
 
 const divertedReplyTo = computed(() => {

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -1507,6 +1507,7 @@ const getForwardHeader = (mail: Mail) => {
 	`
 }
 
-const getForwardedBody = (mail: Mail) => `<div class="frappe_mail_fwd">${getBodyContent(mail)}</div>`
+const getForwardedBody = (mail: Mail) =>
+	`<div class="frappe_mail_fwd"><br><br>${getBodyContent(mail)}</div>`
 </script>
 

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -1199,11 +1199,12 @@ const replyAll = (mail: Mail) =>
 const forward = (mail: Mail) =>
 	createLocalDraft(mail, {
 		subject: `Fwd: ${mail.subject || ''}`,
+		html_body: getForwardHeader(mail),
 		// quoted_content, NOT html_body: content placed in the editor is re-serialized
 		// through its schema, which strips the original mail's tables/styles/attributes.
 		// Like a reply's quote, the forwarded original stays out of the editor and is
 		// concatenated back verbatim at send time.
-		quoted_content: getForwardedContent(mail),
+		quoted_content: getForwardedBody(mail),
 		attachments: mail.attachments || [],
 		forwarded_from_id: mail.id,
 		type: 'forward',
@@ -1487,10 +1488,14 @@ const getQuotedContent = (mail: Mail) =>
 		</div>
 	`
 
-const getForwardedContent = (mail: Mail) => {
+// The header is our own plain text, which the editor round-trips unharmed — so it
+// lives in html_body, visible and editable in the composer, with the signature
+// inserted above it (see useComposeMail's prefilledBody). Only the original's
+// body needs to stay out of the editor (see getForwardedBody).
+const getForwardHeader = (mail: Mail) => {
 	const recipients = getGroupedRecipients(mail.recipients, true, true)
 	return `
-		<div class="frappe_mail_fwd">
+		<div>
 			<br><br>
 			---------- Forwarded message ---------<br>
 			From: ${mail.from_name} &lt;${mail.from_email}&gt;<br>
@@ -1498,10 +1503,10 @@ const getForwardedContent = (mail: Mail) => {
 			Subject: ${mail.subject || ''}<br>
 			To: ${recipients.to}<br>
 			${recipients.cc ? `Cc: ${recipients.cc}<br>` : ''}
-			<br><br>
-			${getBodyContent(mail)}
 		</div>
 	`
 }
+
+const getForwardedBody = (mail: Mail) => `<div class="frappe_mail_fwd">${getBodyContent(mail)}</div>`
 </script>
 

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -582,6 +582,7 @@ import {
 	raiseToast,
 	shouldIgnoreKeypress,
 } from '@/apps/mail/utils'
+import { containEmailHtml } from '@/apps/mail/utils/containEmailHtml'
 import { getSenderInitial } from '@/apps/mail/utils/participants'
 import { useFilterBySender, useScreenSize, useSettings, useTheme } from '@/apps/mail/utils/composables'
 import { provideAccountScope } from '@/apps/mail/utils/accountScope'
@@ -1198,7 +1199,11 @@ const replyAll = (mail: Mail) =>
 const forward = (mail: Mail) =>
 	createLocalDraft(mail, {
 		subject: `Fwd: ${mail.subject || ''}`,
-		html_body: getForwardedContent(mail),
+		// quoted_content, NOT html_body: content placed in the editor is re-serialized
+		// through its schema, which strips the original mail's tables/styles/attributes.
+		// Like a reply's quote, the forwarded original stays out of the editor and is
+		// concatenated back verbatim at send time.
+		quoted_content: getForwardedContent(mail),
 		attachments: mail.attachments || [],
 		forwarded_from_id: mail.id,
 		type: 'forward',
@@ -1464,7 +1469,10 @@ const getPlainTextBody = (mail: Mail) => decodeHtmlEntities(mail.html_body || ma
 // a plain-text mail used to hand the recipient the sender's prose in monospace that never
 // wrapped. plainTextToHtml keeps the line breaks without asking for that.
 const getBodyContent = (mail: Mail) => {
-	if (hasHtmlContent(mail.html_body)) return mail.html_body
+	// Contained, not verbatim: the original's body/html style rules would otherwise
+	// repaint the entire outgoing mail (e.g. a marketing mail's dark backdrop
+	// bleeding over the sender's own text).
+	if (hasHtmlContent(mail.html_body)) return containEmailHtml(mail.html_body)
 	const text = getPlainTextBody(mail)
 	return `<div style="white-space: pre-wrap">${text ? plainTextToHtml(text) : '&nbsp;'}</div>`
 }
@@ -1485,7 +1493,7 @@ const getForwardedContent = (mail: Mail) => {
 		<div class="frappe_mail_fwd">
 			<br><br>
 			---------- Forwarded message ---------<br>
-			From: ${mail.from_name} < ${mail.from_email} ><br>
+			From: ${mail.from_name} &lt;${mail.from_email}&gt;<br>
 			Date: ${dayjs(mail.received_at).format('ddd, MMM D, YYYY [at] h:mm A')}<br>
 			Subject: ${mail.subject || ''}<br>
 			To: ${recipients.to}<br>

--- a/frontend/src/apps/mail/composables/useComposeMail.ts
+++ b/frontend/src/apps/mail/composables/useComposeMail.ts
@@ -190,15 +190,23 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 	// empty, and is where a signature belongs.
 	const isSavedDraft = !!mailDetails?.id
 
+	// A fresh composition can open with prefilled content — a forward's header block. It rides
+	// along untouched: the signature is inserted above it, and the pristine-body comparison
+	// below includes it.
+	const prefilledBody = isSavedDraft ? '' : mailDetails?.html_body || ''
+
 	// Swap the signature when the From identity changes — but only while the body is still the
-	// auto-inserted signature (or empty), so a message the user has written isn't overwritten.
-	// Compared by text so the editor's HTML normalization doesn't defeat the match.
+	// auto-inserted signature (or empty/prefilled), so a message the user has written isn't
+	// overwritten. Compared by text so the editor's HTML normalization doesn't defeat the match.
 	watch(
 		() => mail.from_email,
 		(val, oldVal) => {
 			if (isBodyEmpty.value && isSavedDraft) return
-			if (isBodyEmpty.value || bodyText(mail.html_body) === bodyText(buildSignature(oldVal)))
-				mail.html_body = buildSignature(val)
+			if (
+				isBodyEmpty.value ||
+				bodyText(mail.html_body) === bodyText(buildSignature(oldVal) + prefilledBody)
+			)
+				mail.html_body = buildSignature(val) + prefilledBody
 		},
 		{ immediate: true },
 	)

--- a/frontend/src/apps/mail/utils/containEmailHtml.test.ts
+++ b/frontend/src/apps/mail/utils/containEmailHtml.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { EMBED_CLASS, containEmailHtml } from '@/apps/mail/utils/containEmailHtml'
+
+// Embedding an original mail into a quote/forward: its document-level styling must
+// paint inside the embed only, never across the host mail.
+
+describe('containEmailHtml', () => {
+	it('scopes a body background rule to the container', () => {
+		const out = containEmailHtml(
+			'<html><head><style>body { background-color: rgb(35, 47, 62); }</style></head><body><p>hi</p></body></html>',
+		)
+
+		expect(out).toContain(`class="${EMBED_CLASS}"`)
+		expect(out).toContain(`.${EMBED_CLASS} { background-color: rgb(35, 47, 62); }`)
+		expect(out).not.toMatch(/<style>[^<]*\bbody\b/)
+		expect(out).toContain('<p>hi</p>')
+	})
+
+	it('prefixes ordinary selectors with the container', () => {
+		const out = containEmailHtml('<style>.footer a { color: rgb(255, 0, 0); }</style><p>x</p>')
+
+		expect(out).toContain(`.${EMBED_CLASS} .footer a { color: rgb(255, 0, 0); }`)
+	})
+
+	it('moves body presentation attributes onto the container', () => {
+		const out = containEmailHtml('<html><body bgcolor="#232f3e"><p>x</p></body></html>')
+
+		expect(out).toMatch(new RegExp(`class="${EMBED_CLASS}"[^>]*background-color`))
+	})
+
+	it('drops external stylesheets', () => {
+		const out = containEmailHtml(
+			'<html><head><link rel="stylesheet" href="https://x.test/a.css"></head><body><p>x</p></body></html>',
+		)
+
+		expect(out).not.toContain('<link')
+		expect(out).toContain('<p>x</p>')
+	})
+
+	it('keeps content markup untouched', () => {
+		const out = containEmailHtml(
+			'<table bgcolor="#ffffff"><tbody><tr><td style="padding: 8px">cell</td></tr></tbody></table>',
+		)
+
+		expect(out).toContain('<td style="padding: 8px">cell</td>')
+		expect(out).toContain('bgcolor="#ffffff"')
+	})
+})

--- a/frontend/src/apps/mail/utils/containEmailHtml.test.ts
+++ b/frontend/src/apps/mail/utils/containEmailHtml.test.ts
@@ -100,6 +100,25 @@ describe('containEmailHtml', () => {
 		expect(out).toContain(`.${EMBED_CLASS} p { color: rgb(4, 4, 4); }`)
 	})
 
+	it('scopes and filters inside grouping rules', () => {
+		const out = containEmailHtml(
+			'<style>@media screen { body { color: rgb(5, 5, 5); } @font-face { font-family: "T"; src: url("https://attacker.test/m.woff2"); } }</style><p>x</p>',
+		)
+
+		expect(out).toContain('@media screen')
+		expect(out).toContain(`.${EMBED_CLASS} { color: rgb(5, 5, 5); }`)
+		expect(out).not.toContain('attacker.test')
+	})
+
+	it('drops unrecognized at-rules instead of emitting them verbatim', () => {
+		const out = containEmailHtml(
+			'<style>@keyframes spin { from { transform: rotate(0deg); } } p { color: rgb(6, 6, 6); }</style><p>x</p>',
+		)
+
+		expect(out).not.toContain('@keyframes')
+		expect(out).toContain(`.${EMBED_CLASS} p { color: rgb(6, 6, 6); }`)
+	})
+
 	it('keeps content markup untouched', () => {
 		const out = containEmailHtml(
 			'<table bgcolor="#ffffff"><tbody><tr><td style="padding: 8px">cell</td></tr></tbody></table>',

--- a/frontend/src/apps/mail/utils/containEmailHtml.test.ts
+++ b/frontend/src/apps/mail/utils/containEmailHtml.test.ts
@@ -90,6 +90,16 @@ describe('containEmailHtml', () => {
 		expect(out).toContain(`.${EMBED_CLASS} p { color: rgb(3, 3, 3); }`)
 	})
 
+	it('drops @font-face rules', () => {
+		const out = containEmailHtml(
+			'<style>@font-face { font-family: "T"; src: url("https://attacker.test/t.woff2"); } p { color: rgb(4, 4, 4); }</style><p>x</p>',
+		)
+
+		expect(out).not.toContain('@font-face')
+		expect(out).not.toContain('attacker.test')
+		expect(out).toContain(`.${EMBED_CLASS} p { color: rgb(4, 4, 4); }`)
+	})
+
 	it('keeps content markup untouched', () => {
 		const out = containEmailHtml(
 			'<table bgcolor="#ffffff"><tbody><tr><td style="padding: 8px">cell</td></tr></tbody></table>',

--- a/frontend/src/apps/mail/utils/containEmailHtml.test.ts
+++ b/frontend/src/apps/mail/utils/containEmailHtml.test.ts
@@ -62,6 +62,14 @@ describe('containEmailHtml', () => {
 		expect(out).toContain(`.${EMBED_CLASS} .x, .${EMBED_CLASS} .y { color: rgb(2, 2, 2); }`)
 	})
 
+	it('does not split selectors on commas inside quoted attribute values', () => {
+		const out = containEmailHtml(
+			'<style>[data-x="1,2"] { color: rgb(9, 9, 9); }</style><p>x</p>',
+		)
+
+		expect(out).toContain(`.${EMBED_CLASS} [data-x="1,2"] { color: rgb(9, 9, 9); }`)
+	})
+
 	it('drops @import rules', () => {
 		const out = containEmailHtml(
 			'<style>@import url("https://attacker.test/track.css"); p { color: rgb(3, 3, 3); }</style><p>x</p>',

--- a/frontend/src/apps/mail/utils/containEmailHtml.test.ts
+++ b/frontend/src/apps/mail/utils/containEmailHtml.test.ts
@@ -38,6 +38,40 @@ describe('containEmailHtml', () => {
 		expect(out).toContain('<p>x</p>')
 	})
 
+	it('collapses root chains like `html > body` to the container', () => {
+		const out = containEmailHtml(
+			'<style>html > body { background-color: rgb(1, 2, 3); } html p { color: rgb(4, 5, 6); }</style><p>x</p>',
+		)
+
+		expect(out).toContain(`.${EMBED_CLASS} { background-color: rgb(1, 2, 3); }`)
+		expect(out).toMatch(new RegExp(`\\.${EMBED_CLASS}\\s+p { color: rgb\\(4, 5, 6\\); }`))
+	})
+
+	it('attaches body qualifiers directly to the container', () => {
+		const out = containEmailHtml('<style>body.dark { color: rgb(7, 8, 9); }</style><p>x</p>')
+
+		expect(out).toContain(`.${EMBED_CLASS}.dark { color: rgb(7, 8, 9); }`)
+	})
+
+	it('does not split selectors on commas inside functional pseudo-classes', () => {
+		const out = containEmailHtml(
+			'<style>:not(.a, .b) { color: rgb(1, 1, 1); } .x, .y { color: rgb(2, 2, 2); }</style><p>x</p>',
+		)
+
+		expect(out).toContain(`.${EMBED_CLASS} :not(.a, .b) { color: rgb(1, 1, 1); }`)
+		expect(out).toContain(`.${EMBED_CLASS} .x, .${EMBED_CLASS} .y { color: rgb(2, 2, 2); }`)
+	})
+
+	it('drops @import rules', () => {
+		const out = containEmailHtml(
+			'<style>@import url("https://attacker.test/track.css"); p { color: rgb(3, 3, 3); }</style><p>x</p>',
+		)
+
+		expect(out).not.toContain('@import')
+		expect(out).not.toContain('attacker.test')
+		expect(out).toContain(`.${EMBED_CLASS} p { color: rgb(3, 3, 3); }`)
+	})
+
 	it('keeps content markup untouched', () => {
 		const out = containEmailHtml(
 			'<table bgcolor="#ffffff"><tbody><tr><td style="padding: 8px">cell</td></tr></tbody></table>',

--- a/frontend/src/apps/mail/utils/containEmailHtml.test.ts
+++ b/frontend/src/apps/mail/utils/containEmailHtml.test.ts
@@ -53,6 +53,16 @@ describe('containEmailHtml', () => {
 		expect(out).toContain(`.${EMBED_CLASS}.dark { color: rgb(7, 8, 9); }`)
 	})
 
+	it('keeps root descendants as descendants of the container', () => {
+		const out = containEmailHtml(
+			'<style>html .container { color: rgb(1, 0, 0); } :root #content { color: rgb(2, 0, 0); } html > .message { color: rgb(3, 0, 0); }</style><p>x</p>',
+		)
+
+		expect(out).toMatch(new RegExp(`\\.${EMBED_CLASS}\\s+\\.container { color: rgb\\(1, 0, 0\\); }`))
+		expect(out).toMatch(new RegExp(`\\.${EMBED_CLASS}\\s+#content { color: rgb\\(2, 0, 0\\); }`))
+		expect(out).toMatch(new RegExp(`\\.${EMBED_CLASS}\\s+> \\.message { color: rgb\\(3, 0, 0\\); }`))
+	})
+
 	it('does not split selectors on commas inside functional pseudo-classes', () => {
 		const out = containEmailHtml(
 			'<style>:not(.a, .b) { color: rgb(1, 1, 1); } .x, .y { color: rgb(2, 2, 2); }</style><p>x</p>',

--- a/frontend/src/apps/mail/utils/containEmailHtml.ts
+++ b/frontend/src/apps/mail/utils/containEmailHtml.ts
@@ -69,6 +69,7 @@ const splitSelectors = (text: string): string[] => {
 const STYLE_RULE = 1
 const IMPORT_RULE = 3
 const MEDIA_RULE = 4
+const FONT_FACE_RULE = 5
 const SUPPORTS_RULE = 12
 
 const rewriteRules = (rules: CSSRuleList): string =>
@@ -87,11 +88,12 @@ const rewriteRules = (rules: CSSRuleList): string =>
 				const supportsRule = rule as CSSSupportsRule
 				return `@supports ${supportsRule.conditionText} { ${rewriteRules(supportsRule.cssRules)} }`
 			}
-			// An @import is an external sheet by another door: unscopable, and a remote
-			// request the recipient's client would make on the sender's behalf. Dropped
-			// like <link rel="stylesheet">.
-			if (rule.type === IMPORT_RULE) return ''
-			// @font-face, @keyframes …: nothing selector-scoped to rewrite
+			// @import and @font-face both reach for remote resources — a request the
+			// recipient's client would make on the sender's behalf — and carry almost no
+			// display value in mail (major clients ignore remote fonts; text falls back).
+			// Dropped like <link rel="stylesheet">.
+			if (rule.type === IMPORT_RULE || rule.type === FONT_FACE_RULE) return ''
+			// @keyframes …: nothing selector-scoped to rewrite
 			return rule.cssText
 		})
 		.filter(Boolean)

--- a/frontend/src/apps/mail/utils/containEmailHtml.ts
+++ b/frontend/src/apps/mail/utils/containEmailHtml.ts
@@ -63,14 +63,10 @@ const splitSelectors = (text: string): string[] => {
 	return parts
 }
 
-// Matched by the numeric type constants, not `instanceof CSS*Rule`: not every
-// environment defines all those globals, and a ReferenceError here would trip the
+// Matched by the numeric type constant, not `instanceof CSSStyleRule`: not every
+// environment defines that global, and a ReferenceError here would trip the
 // fallback and silently disable containment.
 const STYLE_RULE = 1
-const IMPORT_RULE = 3
-const MEDIA_RULE = 4
-const FONT_FACE_RULE = 5
-const SUPPORTS_RULE = 12
 
 const rewriteRules = (rules: CSSRuleList): string =>
 	Array.from(rules)
@@ -80,21 +76,20 @@ const rewriteRules = (rules: CSSRuleList): string =>
 				const scoped = splitSelectors(styleRule.selectorText).map(scopeSelector).join(', ')
 				return `${scoped} { ${styleRule.style.cssText} }`
 			}
-			if (rule.type === MEDIA_RULE) {
-				const mediaRule = rule as CSSMediaRule
-				return `@media ${mediaRule.media.mediaText} { ${rewriteRules(mediaRule.cssRules)} }`
+			// Any grouping rule — @media, @supports, @layer, @container, … — keeps its
+			// prelude and has its contents passed back through this rewrite, so nothing
+			// nested escapes scoping or filtering.
+			const inner = (rule as { cssRules?: CSSRuleList }).cssRules
+			if (inner) {
+				const brace = rule.cssText.indexOf('{')
+				if (brace === -1) return ''
+				const body = rewriteRules(inner)
+				return body ? `${rule.cssText.slice(0, brace).trim()} { ${body} }` : ''
 			}
-			if (rule.type === SUPPORTS_RULE) {
-				const supportsRule = rule as CSSSupportsRule
-				return `@supports ${supportsRule.conditionText} { ${rewriteRules(supportsRule.cssRules)} }`
-			}
-			// @import and @font-face both reach for remote resources — a request the
-			// recipient's client would make on the sender's behalf — and carry almost no
-			// display value in mail (major clients ignore remote fonts; text falls back).
-			// Dropped like <link rel="stylesheet">.
-			if (rule.type === IMPORT_RULE || rule.type === FONT_FACE_RULE) return ''
-			// @keyframes …: nothing selector-scoped to rewrite
-			return rule.cssText
+			// Everything else is dropped, not emitted verbatim — the catch-all is how
+			// unknown constructs smuggle unscoped selectors or remote loads (@import,
+			// @font-face src) past containment. Deny by default.
+			return ''
 		})
 		.filter(Boolean)
 		.join('\n')

--- a/frontend/src/apps/mail/utils/containEmailHtml.ts
+++ b/frontend/src/apps/mail/utils/containEmailHtml.ts
@@ -19,9 +19,11 @@ const SCOPE = `.${EMBED_CLASS}`
 
 // A leading chain of document-root tokens — `html`, `:root`, optionally ending in
 // `body` — with optional child combinators: `body`, `html body`, `html > body`,
-// `:root body`. The chain collapses into the scope itself; anything attached to
-// the last token (`body.dark`, `body > table`) stays.
-const ROOT_CHAIN = /^(?:(?::root|html)(?![\w-])\s*>?\s*)*body(?![\w-])|^(?:(?::root|html)(?![\w-])\s*>?\s*)+/i
+// `:root body`. The chain collapses into the scope itself. The match ends AT the
+// last root token, never consuming what follows it: an attached qualifier
+// (`body.dark`) glues onto the scope, while a descendant or child combinator
+// (`html .container`, `html > .message`) keeps its separator.
+const ROOT_CHAIN = /^(?:(?::root|html)(?![\w-])\s*>?\s*)*body(?![\w-])|^(?::root|html)(?![\w-])(?:\s*>?\s*(?::root|html)(?![\w-]))*/i
 
 const scopeSelector = (selector: string): string => {
 	const trimmed = selector.trim()

--- a/frontend/src/apps/mail/utils/containEmailHtml.ts
+++ b/frontend/src/apps/mail/utils/containEmailHtml.ts
@@ -33,19 +33,29 @@ const scopeSelector = (selector: string): string => {
 	return replaced.replace(new RegExp(`^${SCOPE} (?=[.:#[]|$)`), SCOPE)
 }
 
-// selectorText cannot be split on every comma: `:is(.a, .b)` and friends carry
-// commas of their own. Split only at parenthesis depth zero.
+// selectorText cannot be split on every comma: `:is(.a, .b)` carries commas of its
+// own, and so can a quoted attribute value (`[data-x="1,2"]`). Split only at
+// top level — outside parentheses, brackets and strings.
 const splitSelectors = (text: string): string[] => {
 	const parts: string[] = []
 	let depth = 0
+	let quote = ''
+	let escaped = false
 	let current = ''
 	for (const char of text) {
-		if (char === '(') depth++
-		else if (char === ')') depth--
-		if (char === ',' && depth === 0) {
+		if (escaped) escaped = false
+		else if (char === '\\') escaped = true
+		else if (quote) {
+			if (char === quote) quote = ''
+		} else if (char === '"' || char === "'") quote = char
+		else if (char === '(' || char === '[') depth++
+		else if (char === ')' || char === ']') depth--
+		else if (char === ',' && depth === 0) {
 			parts.push(current)
 			current = ''
-		} else current += char
+			continue
+		}
+		current += char
 	}
 	parts.push(current)
 	return parts
@@ -85,13 +95,19 @@ const rewriteRules = (rules: CSSRuleList): string =>
 		.filter(Boolean)
 		.join('\n')
 
+// @import statements, dropped from the raw text. The rule-level filter below is
+// not enough on its own: the parsing probe attaches the sheet to the live
+// document, and browsers fetch a sheet's imports regardless of its media — the
+// remote request would fire at compose time, from the composer's own browser.
+const IMPORT_STATEMENT = /@import\b[^;]*;?/gi
+
 // CSS parsing goes through the browser's CSSOM: the block is attached to the live
 // document under media="not all" (parsed but never applied) just long enough to
 // read its object model back out.
 const scopeCss = (css: string): string => {
 	const probe = document.createElement('style')
 	probe.media = 'not all'
-	probe.textContent = css
+	probe.textContent = css.replace(IMPORT_STATEMENT, '')
 	document.head.appendChild(probe)
 	try {
 		const sheet = probe.sheet

--- a/frontend/src/apps/mail/utils/containEmailHtml.ts
+++ b/frontend/src/apps/mail/utils/containEmailHtml.ts
@@ -95,27 +95,40 @@ const rewriteRules = (rules: CSSRuleList): string =>
 		.filter(Boolean)
 		.join('\n')
 
-// @import statements, dropped from the raw text. The rule-level filter below is
-// not enough on its own: the parsing probe attaches the sheet to the live
-// document, and browsers fetch a sheet's imports regardless of its media — the
-// remote request would fire at compose time, from the composer's own browser.
+// @import statements, dropped from the raw text before the fallback probe: the
+// probe attaches the sheet to the live document, and browsers fetch a sheet's
+// imports regardless of its media — the remote request would fire at compose
+// time, from the composer's own browser.
 const IMPORT_STATEMENT = /@import\b[^;]*;?/gi
 
-// CSS parsing goes through the browser's CSSOM: the block is attached to the live
-// document under media="not all" (parsed but never applied) just long enough to
-// read its object model back out.
-const scopeCss = (css: string): string => {
+// CSS parsing goes through the browser's CSS parser, never a hand-rolled one.
+// Preferred door: a constructable stylesheet — parsed entirely off-document, and
+// the platform itself rejects @import there, so nothing can ever be fetched.
+// Fallback (environments without replaceSync, e.g. jsdom): a <style> probe
+// attached under media="not all", with @import stripped from the text first.
+const parseCss = (css: string): CSSRuleList | null => {
+	try {
+		const sheet = new CSSStyleSheet()
+		sheet.replaceSync(css)
+		return sheet.cssRules
+	} catch {
+		// Constructable sheets unsupported (or the CSS made replaceSync throw)
+	}
+
 	const probe = document.createElement('style')
 	probe.media = 'not all'
 	probe.textContent = css.replace(IMPORT_STATEMENT, '')
 	document.head.appendChild(probe)
 	try {
-		const sheet = probe.sheet
-		if (!sheet) return ''
-		return rewriteRules(sheet.cssRules)
+		return probe.sheet?.cssRules ?? null
 	} finally {
 		probe.remove()
 	}
+}
+
+const scopeCss = (css: string): string => {
+	const rules = parseCss(css)
+	return rules ? rewriteRules(rules) : ''
 }
 
 export const containEmailHtml = (html: string): string => {

--- a/frontend/src/apps/mail/utils/containEmailHtml.ts
+++ b/frontend/src/apps/mail/utils/containEmailHtml.ts
@@ -17,31 +17,72 @@
 export const EMBED_CLASS = 'frappe_mail_embed'
 const SCOPE = `.${EMBED_CLASS}`
 
-// A selector's leading document-root token, to be replaced by the scope itself:
-// `body`, `html`, `html body`, `:root`, including forms like `body.dark` or `body > table`.
-const ROOT_TOKEN = /^(?::root|html(?:\s+body)?|body)(?![\w-])/i
+// A leading chain of document-root tokens — `html`, `:root`, optionally ending in
+// `body` — with optional child combinators: `body`, `html body`, `html > body`,
+// `:root body`. The chain collapses into the scope itself; anything attached to
+// the last token (`body.dark`, `body > table`) stays.
+const ROOT_CHAIN = /^(?:(?::root|html)(?![\w-])\s*>?\s*)*body(?![\w-])|^(?:(?::root|html)(?![\w-])\s*>?\s*)+/i
 
 const scopeSelector = (selector: string): string => {
 	const trimmed = selector.trim()
 	if (!trimmed) return trimmed
-	const replaced = trimmed.replace(ROOT_TOKEN, SCOPE)
-	return replaced === trimmed ? `${SCOPE} ${trimmed}` : replaced
+	const replaced = trimmed.replace(ROOT_CHAIN, `${SCOPE} `).trim()
+	if (replaced === trimmed) return `${SCOPE} ${trimmed}`
+	// The chain was the whole selector, or its remainder attaches directly (`.dark`
+	// from `body.dark`): no descendant space.
+	return replaced.replace(new RegExp(`^${SCOPE} (?=[.:#[]|$)`), SCOPE)
 }
+
+// selectorText cannot be split on every comma: `:is(.a, .b)` and friends carry
+// commas of their own. Split only at parenthesis depth zero.
+const splitSelectors = (text: string): string[] => {
+	const parts: string[] = []
+	let depth = 0
+	let current = ''
+	for (const char of text) {
+		if (char === '(') depth++
+		else if (char === ')') depth--
+		if (char === ',' && depth === 0) {
+			parts.push(current)
+			current = ''
+		} else current += char
+	}
+	parts.push(current)
+	return parts
+}
+
+// Matched by the numeric type constants, not `instanceof CSS*Rule`: not every
+// environment defines all those globals, and a ReferenceError here would trip the
+// fallback and silently disable containment.
+const STYLE_RULE = 1
+const IMPORT_RULE = 3
+const MEDIA_RULE = 4
+const SUPPORTS_RULE = 12
 
 const rewriteRules = (rules: CSSRuleList): string =>
 	Array.from(rules)
 		.map((rule) => {
-			if (rule instanceof CSSStyleRule) {
-				const scoped = rule.selectorText.split(',').map(scopeSelector).join(', ')
-				return `${scoped} { ${rule.style.cssText} }`
+			if (rule.type === STYLE_RULE) {
+				const styleRule = rule as CSSStyleRule
+				const scoped = splitSelectors(styleRule.selectorText).map(scopeSelector).join(', ')
+				return `${scoped} { ${styleRule.style.cssText} }`
 			}
-			if (rule instanceof CSSMediaRule)
-				return `@media ${rule.media.mediaText} { ${rewriteRules(rule.cssRules)} }`
-			if (rule instanceof CSSSupportsRule)
-				return `@supports ${rule.conditionText} { ${rewriteRules(rule.cssRules)} }`
-			// @font-face, @keyframes, @import …: nothing selector-scoped to rewrite
+			if (rule.type === MEDIA_RULE) {
+				const mediaRule = rule as CSSMediaRule
+				return `@media ${mediaRule.media.mediaText} { ${rewriteRules(mediaRule.cssRules)} }`
+			}
+			if (rule.type === SUPPORTS_RULE) {
+				const supportsRule = rule as CSSSupportsRule
+				return `@supports ${supportsRule.conditionText} { ${rewriteRules(supportsRule.cssRules)} }`
+			}
+			// An @import is an external sheet by another door: unscopable, and a remote
+			// request the recipient's client would make on the sender's behalf. Dropped
+			// like <link rel="stylesheet">.
+			if (rule.type === IMPORT_RULE) return ''
+			// @font-face, @keyframes …: nothing selector-scoped to rewrite
 			return rule.cssText
 		})
+		.filter(Boolean)
 		.join('\n')
 
 // CSS parsing goes through the browser's CSSOM: the block is attached to the live

--- a/frontend/src/apps/mail/utils/containEmailHtml.ts
+++ b/frontend/src/apps/mail/utils/containEmailHtml.ts
@@ -1,0 +1,97 @@
+/**
+ * Contain an original mail's markup so it can be embedded inside another mail
+ * (reply quote / forward) without its styling leaking into the host document.
+ *
+ * An email is authored as a full document: its <style> rules target `body`/`html`
+ * and bare element selectors, and its <body> may carry a background of its own.
+ * Embedded verbatim, those rules repaint the ENTIRE host mail (e.g. a dark
+ * marketing backdrop bleeding over the sender's own text). Stripping the styles
+ * instead (what the editor round-trip used to do) destroys the original's look.
+ *
+ * So: keep the styles, but rewrite every selector to live under one container —
+ * `body`/`html`/`:root` become the container itself (its backdrop paints there,
+ * and only there), and every other selector is prefixed with it.
+ */
+
+// The class the returned container carries; selectors are scoped to it.
+export const EMBED_CLASS = 'frappe_mail_embed'
+const SCOPE = `.${EMBED_CLASS}`
+
+// A selector's leading document-root token, to be replaced by the scope itself:
+// `body`, `html`, `html body`, `:root`, including forms like `body.dark` or `body > table`.
+const ROOT_TOKEN = /^(?::root|html(?:\s+body)?|body)(?![\w-])/i
+
+const scopeSelector = (selector: string): string => {
+	const trimmed = selector.trim()
+	if (!trimmed) return trimmed
+	const replaced = trimmed.replace(ROOT_TOKEN, SCOPE)
+	return replaced === trimmed ? `${SCOPE} ${trimmed}` : replaced
+}
+
+const rewriteRules = (rules: CSSRuleList): string =>
+	Array.from(rules)
+		.map((rule) => {
+			if (rule instanceof CSSStyleRule) {
+				const scoped = rule.selectorText.split(',').map(scopeSelector).join(', ')
+				return `${scoped} { ${rule.style.cssText} }`
+			}
+			if (rule instanceof CSSMediaRule)
+				return `@media ${rule.media.mediaText} { ${rewriteRules(rule.cssRules)} }`
+			if (rule instanceof CSSSupportsRule)
+				return `@supports ${rule.conditionText} { ${rewriteRules(rule.cssRules)} }`
+			// @font-face, @keyframes, @import …: nothing selector-scoped to rewrite
+			return rule.cssText
+		})
+		.join('\n')
+
+// CSS parsing goes through the browser's CSSOM: the block is attached to the live
+// document under media="not all" (parsed but never applied) just long enough to
+// read its object model back out.
+const scopeCss = (css: string): string => {
+	const probe = document.createElement('style')
+	probe.media = 'not all'
+	probe.textContent = css
+	document.head.appendChild(probe)
+	try {
+		const sheet = probe.sheet
+		if (!sheet) return ''
+		return rewriteRules(sheet.cssRules)
+	} finally {
+		probe.remove()
+	}
+}
+
+export const containEmailHtml = (html: string): string => {
+	try {
+		const doc = new DOMParser().parseFromString(html, 'text/html')
+
+		// Gather the document's styles (head and body), scoped; drop external sheets —
+		// they can't be scoped and mail clients block them anyway.
+		const styles = Array.from(doc.querySelectorAll('style'))
+			.map((style) => {
+				const css = style.textContent || ''
+				style.remove()
+				return scopeCss(css)
+			})
+			.filter(Boolean)
+		doc.querySelectorAll('link[rel="stylesheet" i]').forEach((link) => link.remove())
+
+		const container = doc.createElement('div')
+		container.className = EMBED_CLASS
+		// The body's own presentation moves onto the container, so an authored
+		// backdrop still paints — inside the embed, not across the host mail.
+		const body = doc.body
+		const bodyStyle = body.getAttribute('style')
+		if (bodyStyle) container.setAttribute('style', bodyStyle)
+		const bgcolor = body.getAttribute('bgcolor')
+		if (bgcolor) container.style.backgroundColor = bgcolor
+
+		if (styles.length) container.innerHTML = `<style>${styles.join('\n')}</style>`
+		container.innerHTML += body.innerHTML
+
+		return container.outerHTML
+	} catch {
+		// Containment is an enhancement; a parser hiccup must not lose the content.
+		return html
+	}
+}

--- a/frontend/src/apps/mail/utils/extractQuotedContent.test.ts
+++ b/frontend/src/apps/mail/utils/extractQuotedContent.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractQuotedContent } from '@/apps/mail/utils'
+
+// Splitting a saved draft back into editable body + opaque quote. The quote wrapper must
+// never re-enter the editor (its schema would strip the original mail's formatting), so
+// both the reply wrapper and the forward wrapper have to be recognized here.
+
+describe('extractQuotedContent', () => {
+	it('splits out a reply quote', () => {
+		const { quoted_content, html_body } = extractQuotedContent(
+			'<div>my reply</div><div class="frappe_mail_quote"><blockquote>original</blockquote></div>',
+		)
+
+		expect(html_body).toBe('<div>my reply</div>')
+		expect(quoted_content).toContain('frappe_mail_quote')
+		expect(quoted_content).toContain('original')
+	})
+
+	it('splits out a forwarded original', () => {
+		const { quoted_content, html_body } = extractQuotedContent(
+			'<div>fyi</div><div class="frappe_mail_fwd">---------- Forwarded message ---------<table><tbody><tr><td style="padding: 8px">original</td></tr></tbody></table></div>',
+		)
+
+		expect(html_body).toBe('<div>fyi</div>')
+		expect(quoted_content).toContain('frappe_mail_fwd')
+		// the point of the split: the original's markup survives untouched
+		expect(quoted_content).toContain('<td style="padding: 8px">original</td>')
+	})
+
+	it('leaves a body without a quote untouched', () => {
+		const { quoted_content, html_body } = extractQuotedContent('<div>just text</div>')
+
+		expect(html_body).toBe('<div>just text</div>')
+		expect(quoted_content).toBe('')
+	})
+
+	it('handles an empty body', () => {
+		expect(extractQuotedContent(undefined)).toEqual({ quoted_content: '', html_body: '' })
+	})
+})

--- a/frontend/src/apps/mail/utils/index.ts
+++ b/frontend/src/apps/mail/utils/index.ts
@@ -210,7 +210,9 @@ export const extractQuotedContent = (htmlBody?: string) => {
 	const doc = parser.parseFromString(htmlBody, 'text/html')
 
 	const topLevelDiv = Array.from(doc.body.children).find(
-		(el) => el.tagName.toLowerCase() === 'div' && el.classList.contains('frappe_mail_quote'),
+		(el) =>
+			el.tagName.toLowerCase() === 'div' &&
+			(el.classList.contains('frappe_mail_quote') || el.classList.contains('frappe_mail_fwd')),
 	)
 
 	let quoted_content = ''


### PR DESCRIPTION
Forwarding a rich email (a notification, a marketing mail, a Google Docs share) destroyed its formatting: the original was placed into `html_body`, i.e. into the compose editor, whose schema re-serializes the HTML — unknown tags/attributes dropped, inline styles stripped, tables rebuilt as bare editor tables. Replies never had this problem because their quote lives in `quoted_content`, outside the editor, and is concatenated back verbatim at send time.

Forward now uses the same mechanism: the forwarded original (with its From/Date/Subject/To header block) goes to `quoted_content`, and `extractQuotedContent` additionally recognizes the `frappe_mail_fwd` wrapper so a saved forward draft re-splits on reopen instead of feeding the original to the editor. In the composer the forwarded content sits behind the existing quoted-content toggle; expanding it (and thereby editing it) is what hands it to the editor — the user's explicit choice, as with replies today.

Preserving the original verbatim exposed a second leak: an email is authored as a full document, and its `body`/`html` style rules repainted the *entire* outgoing mail — e.g. a dark marketing backdrop bleeding over the sender's own text. The new `containEmailHtml` keeps the original's styles but scopes every selector to the embedded block (`body`/`html`/`:root` become the container itself, other selectors are prefixed; the body's `bgcolor`/`style` moves onto the container; external stylesheets are dropped). Any parse failure falls back to the raw HTML so containment can degrade but content can't be lost. Replies get the same containment.

Verified by forwarding an AWS Health notification and a Google Docs share mail: branding, buttons and tables arrive intact, with the original's backdrop confined to the forwarded block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Also rides along: two small thread-view refinements — the quoted-content toggle sizes by the app's own mobile state instead of the iframe's media query, and the message-details popover shows the sender as a "from" row in place of the avatar header.
