### PR TITLE
fix(meet): restrict presence previews

### DIFF
--- a/frontend/src/apps/meet/composables/useMeetingPreviewPresence.ts
+++ b/frontend/src/apps/meet/composables/useMeetingPreviewPresence.ts
@@ -43,7 +43,12 @@ export function useMeetingPreviewPresence(meetingId: string) {
 		params: { meeting_id: meetingId },
 		auto: false,
 		onSuccess(data: PresenceTokenResponse) {
-			if (data && (data.auth_token || data.sfu_url)) {
+			if (data.restricted_preview) {
+				hasFetchedParticipants.value = true;
+				return;
+			}
+
+			if (data.auth_token || data.sfu_url) {
 				connectToSFU(data);
 			} else {
 				error.value = data.error || "Failed to get presence token";

--- a/frontend/src/apps/meet/types.ts
+++ b/frontend/src/apps/meet/types.ts
@@ -15,6 +15,7 @@ export interface ParticipantPreview {
 }
 
 export interface PresenceTokenResponse {
+	restricted_preview?: boolean;
 	auth_token?: string;
 	sfu_url?: string;
 	sfu_port?: number;

--- a/suite/meet/api/meeting.py
+++ b/suite/meet/api/meeting.py
@@ -349,6 +349,9 @@ def get_sfu_presence_preview_token(meeting_id: str) -> dict:
     if not meeting.can_join(frappe.session.user):
         frappe.throw(_("Access denied"), frappe.PermissionError)
 
+    if meeting.meeting_type == "restricted" and not meeting.is_user_approved(frappe.session.user):
+        return {"restricted_preview": True}
+
     sfu_config = get_sfu_config()
 
     expiry_seconds = 300

--- a/suite/meet/api/test/test_meeting.py
+++ b/suite/meet/api/test/test_meeting.py
@@ -93,6 +93,13 @@ class IntegrationTestMeetingApi(IntegrationTestCase):
         self.assertFalse(decoded["is_cohost"])
         self.assertFalse(decoded["is_guest"])
 
+    def test_unapproved_user_gets_restricted_preview_without_sfu_token(self):
+        frappe.set_user(self.outsider_email)
+
+        result = get_sfu_presence_preview_token(self.meeting.name)
+
+        self.assertEqual(result, {"restricted_preview": True})
+
     def test_sfu_connection_details_include_disabled_global_recording_setting(self):
         self.meeting.add_user_to_table("members", self.host_email, save=True, ignore_permissions=True)
         frappe.db.set_single_value("Meet Settings", "enable_recording", 0)

--- a/suite/meet/type-policy/allowlist.json
+++ b/suite/meet/type-policy/allowlist.json
@@ -11,7 +11,7 @@
     },
     {
       "path": "frontend/src/apps/meet/types.ts",
-      "line": 116,
+      "line": 117,
       "column": 13,
       "rule": "MTP001",
       "lineText": "): value is Record<string, unknown> {",


### PR DESCRIPTION
## Summary

- prevent unapproved users in restricted meetings from receiving SFU presence-preview tokens
- gracefully skip the frontend SFU preview connection while approval is pending
- add regression coverage for the restricted preview response

Closes #718