### PR TITLE
ci(meet): gate self-hosted runners by trust

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -1,0 +1,13 @@
+# Vouched contributors for this project.
+#
+# See https://github.com/mitchellh/vouch for details.
+#
+# Only vouched users may open pull requests. Maintainers and users with
+# write access are automatically allowed. Denounced users are blocked.
+#
+# Syntax:
+#   - One handle per line (without @), sorted alphabetically.
+#   - Optional platform prefix: platform:username (e.g., github:user).
+#   - Denounce with minus prefix: -username or -platform:username.
+#   - Optional details after a space following the handle.
+dankgarlic1

--- a/.github/vouch-pr-unvouched.md
+++ b/.github/vouch-pr-unvouched.md
@@ -1,0 +1,5 @@
+Hi @{author}, thanks for your interest in contributing!
+
+This repository uses self-hosted CI runners, so pull request authors must be trusted before their code can run. You are not currently in the [list of vouched contributors](https://github.com/{owner}/{repo}/blob/{default_branch}/.github/VOUCHED.td).
+
+This pull request will be closed automatically. A maintainer can vouch for you by adding your GitHub username to that list, after which the pull request can be reopened.

--- a/.github/workflows/meet-e2e.yml
+++ b/.github/workflows/meet-e2e.yml
@@ -103,8 +103,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  author_check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      vouched: ${{ github.event_name != 'pull_request_target' || steps.vouch.outputs.vouched }}
+    steps:
+      - if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - if: github.event_name == 'pull_request_target'
+        id: vouch
+        uses: mitchellh/vouch/action/check-user@d66fa29a64600490892131ad87597c30c91fcac4 # v1.5.0
+        with:
+          user: ${{ github.event.pull_request.user.login }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   e2e:
-    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
+    needs: author_check
+    if: needs.author_check.outputs.vouched == 'true'
     runs-on: suite-e2e-meet
     # Historical durations keep each self-contained group near the same runtime.
     strategy:

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -1,0 +1,30 @@
+name: Check PR Author
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/recheck'))
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - uses: mitchellh/vouch/action/check-pr@d66fa29a64600490892131ad87597c30c91fcac4 # v1.5.0
+        with:
+          pr-number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          auto-close: true
+          template-file: .github/vouch-pr-unvouched.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- close pull requests from authors who are not vouched contributors
- authorize Meet E2E on a GitHub-hosted runner before scheduling self-hosted jobs
- seed the trusted contributor list with `dankgarlic1`