### PR TITLE
fix(meet): hide tooltips with toolbar

### DIFF
--- a/frontend/src/apps/meet/components/MeetingInfoPopover.vue
+++ b/frontend/src/apps/meet/components/MeetingInfoPopover.vue
@@ -1,7 +1,7 @@
 <template>
 	<Popover v-model:open="show" side="top" align="start" arrow>
 		<template #trigger>
-			<ToolbarButton :title="title">
+			<ToolbarButton :title="title" :show-tooltip="showTooltip">
 				<MeetInfoIcon :encrypted="isE2EEActive" />
 			</ToolbarButton>
 		</template>
@@ -39,10 +39,14 @@ import MeetInfoIcon from "../icons/MeetInfoIcon.vue";
 import ClickToCopyField from "./ClickToCopyField.vue";
 import ToolbarButton from "./ToolbarButton.vue";
 
-const props = defineProps<{
-	open?: boolean;
-	meetingId?: string;
-}>();
+const props = withDefaults(
+	defineProps<{
+		open?: boolean;
+		meetingId?: string;
+		showTooltip?: boolean;
+	}>(),
+	{ showTooltip: true },
+);
 
 const emit = defineEmits<{
 	"update:open": [value: boolean];

--- a/frontend/src/apps/meet/components/MeetingToolbar.vue
+++ b/frontend/src/apps/meet/components/MeetingToolbar.vue
@@ -17,6 +17,7 @@
 				<!-- Microphone -->
 				<ToolbarButton
 					:variant="isMicOn ? 'default' : 'muted'"
+					:show-tooltip="isVisible"
 					:title="`Toggle Audio (${$platform === 'mac' ? '⌘+D' : 'Ctrl+D'})`"
 					@click="$emit('toggle-microphone')"
 				>
@@ -27,6 +28,7 @@
 				<!-- Camera -->
 				<ToolbarButton
 					:variant="isCameraOn ? 'default' : 'muted'"
+					:show-tooltip="isVisible"
 					:title="`Toggle Video (${$platform === 'mac' ? '⌘+E' : 'Ctrl+E'})`"
 					@click="$emit('toggle-camera')"
 				>
@@ -38,6 +40,7 @@
 				<ToolbarButton
 					v-if="canScreenShare()"
 					:variant="isScreenSharing ? 'muted' : 'default'"
+					:show-tooltip="isVisible"
 					title="Toggle Screen Share"
 					@click="$emit('toggle-screen-share')"
 				>
@@ -48,6 +51,7 @@
 				<!-- Raise Hand -->
 				<ToolbarButton
 					:variant="isHandRaised ? 'muted' : 'default'"
+					:show-tooltip="isVisible"
 					title="Raise Hand"
 					@click="$emit('toggle-raise-hand')"
 				>
@@ -62,6 +66,7 @@
 				>
 					<template #trigger>
 						<ToolbarButton
+							:show-tooltip="isVisible"
 							title="Reactions"
 							@click="() => {}"
 						>
@@ -78,7 +83,7 @@
 								size="lg"
 								variant="ghost"
 								label="More options"
-								tooltip="More options"
+								:tooltip="isVisible ? 'More options' : undefined"
 							>
 								<template #icon>
 									<MeetSettingsIcon />
@@ -91,6 +96,7 @@
 				<!-- End Call -->
 				<ToolbarButton
 					variant="active"
+					:show-tooltip="isVisible"
 					title="End Call"
 					@click="$emit('end-call')"
 				>
@@ -114,6 +120,7 @@
 				<ToolbarButton
 					v-if="!isMobile"
 					:active="isPeopleOpen"
+					:show-tooltip="isVisible"
 					variant="default"
 					title="Show Participants"
 					@click="$emit('toggle-people')"
@@ -129,6 +136,7 @@
 				<ToolbarButton
 					v-if="!isMobile"
 					:active="isChatOpen"
+					:show-tooltip="isVisible"
 					variant="default"
 					title="Show Chat"
 					@click="$emit('toggle-chat')"

--- a/frontend/src/apps/meet/components/MeetingToolbar.vue
+++ b/frontend/src/apps/meet/components/MeetingToolbar.vue
@@ -114,6 +114,7 @@
 				<MeetingInfoPopover
 					v-model:open="showMeetingInfo"
 					:meeting-id="meetingId"
+					:show-tooltip="isVisible"
 				/>
 
 				<!-- People -->

--- a/frontend/src/apps/meet/components/ParticipantTile.vue
+++ b/frontend/src/apps/meet/components/ParticipantTile.vue
@@ -7,6 +7,8 @@
 		:data-audio-enabled="String(isAudioEnabled)"
 		:data-video-enabled="String(isVideoEnabled)"
 		:data-tile-id="`${pinType}-${tileId}`"
+		@mouseenter="isTileHovered = true"
+		@mouseleave="isTileHovered = false"
 	>
 		<video
 			:ref="videoRef"
@@ -109,7 +111,7 @@
 				size="xs"
 				class="!rounded-full !text-white hover:!bg-gray-600"
 				:class="{ '!bg-gray-600': isPinned }"
-				:tooltip="isPinned ? 'Unpin participant' : 'Pin participant'"
+				:tooltip="isTileHovered ? (isPinned ? 'Unpin participant' : 'Pin participant') : undefined"
 				@click="togglePin"
 			>
 				<template #icon>
@@ -122,7 +124,7 @@
 				variant="ghost"
 				size="xs"
 				class="!rounded-full !text-white hover:!bg-gray-600"
-				tooltip="Mute participant"
+				:tooltip="isTileHovered ? 'Mute participant' : undefined"
 				@click="handleMute"
 			>
 				<template #icon>
@@ -134,7 +136,7 @@
 				variant="ghost"
 				size="xs"
 				class="!rounded-full !text-white hover:!bg-gray-600"
-				tooltip="Remove participant"
+				:tooltip="isTileHovered ? 'Remove participant' : undefined"
 				@click="showKickDialog = true"
 			>
 				<template #icon>
@@ -227,6 +229,7 @@ const hostControls = inject<{
 const tileId = computed(() => props.pinId || props.participant.user_id);
 
 const showBlur = ref(props.participant.isLocalScreenShare);
+const isTileHovered = ref(false);
 
 const showScreenShareCopy = computed(() => {
 	return !meetingCtx?.gridLayout.pinnedTiles.value.length || isPinned.value;

--- a/frontend/src/apps/meet/components/ToolbarButton.vue
+++ b/frontend/src/apps/meet/components/ToolbarButton.vue
@@ -10,10 +10,12 @@ withDefaults(
 		variant?: "default" | "active" | "muted";
 		active?: boolean;
 		title?: string;
+		showTooltip?: boolean;
 	}>(),
 	{
 		variant: "default",
 		active: false,
+		showTooltip: true,
 	},
 );
 
@@ -29,7 +31,7 @@ defineEmits<{
 		variant="ghost"
 		theme="gray"
 		:label="title"
-		:tooltip="title"
+		:tooltip="showTooltip ? title : undefined"
 		:class="['relative', { '!bg-surface-gray-3': active }]"
 		@click="$emit('click')"
 	>


### PR DESCRIPTION
## Summary

Hide toolbar button tooltips when Meet auto-hides its controls, and dismiss participant tile action tooltips when their hover toolbar disappears.