### PR TITLE
feat(meet): enforce single participant connection

### DIFF
--- a/e2e/meet/fixtures/test.ts
+++ b/e2e/meet/fixtures/test.ts
@@ -71,7 +71,9 @@ async function waitForMeetingReady(page: Page): Promise<void> {
 async function joinFromPreview(page: Page): Promise<void> {
 	const preview = page.getByRole("heading", { name: "Ready to join?" });
 	const meetingLayout = page.getByTestId("meeting-layout");
-	const joinButton = page.getByRole("button", { name: "Join Meeting" });
+	const joinButton = page.getByRole("button", {
+		name: /^(Join Meeting|Switch here)$/,
+	});
 
 	await expect(preview.or(meetingLayout)).toBeVisible({ timeout: previewTimeout });
 

--- a/e2e/meet/specs/participant-connections.spec.ts
+++ b/e2e/meet/specs/participant-connections.spec.ts
@@ -6,9 +6,9 @@ import {
 } from "../helpers/faults";
 import { expectRemoteVideoReceiving } from "../helpers/media";
 
-test.describe("Independent Participant Connections", () => {
+test.describe("Participant Connection switching", () => {
 	test(
-		"closing one endpoint preserves the participant's other endpoint",
+		"keeps the incumbent active until a device switch is confirmed",
 		{ tag: "@meet-group-3" },
 		async ({ hostPage, createMeeting, createParticipant }) => {
 			const meetingId = await createMeeting();
@@ -33,32 +33,40 @@ test.describe("Independent Participant Connections", () => {
 				meetHostName,
 			);
 
-			await secondHostEndpoint.joinAsHost(meetingId);
+			const secondHostJoin = secondHostEndpoint.joinAsHost(meetingId);
+			await expect(
+				secondHostEndpoint.page.getByText("Switch to this device?", {
+					exact: true,
+				}).last(),
+			).toBeVisible();
+			await Promise.all([
+				expect(hostPage.getByTestId("meeting-layout")).toBeVisible(),
+				expectRemoteVideoReceiving(guest.page, meetHostName),
+			]);
+
+			await secondHostEndpoint.page
+				.locator("button")
+				.filter({ hasText: "Switch to this device" })
+				.last()
+				.click();
+			await secondHostJoin;
 			await expectRemoteTrackReplaced(
 				guest.page,
 				meetHostName,
 				firstHostTrack.trackId,
 			);
+			await expect(
+				hostPage.getByRole("heading", {
+					name: "Meeting moved to another device",
+				}),
+			).toBeVisible();
 			await expectRemoteVideoReceiving(
 				secondHostEndpoint.page,
 				"Endpoint Observer",
 			);
-			const secondHostTrack = await readRemoteVideoProgress(
-				guest.page,
-				meetHostName,
-			);
-
-			await secondHostEndpoint.context.close();
-			await expectRemoteTrackReplaced(
-				guest.page,
-				meetHostName,
-				secondHostTrack.trackId,
-			);
 
 			await Promise.all([
-				expect(hostPage.locator("[data-participant-id]")).toHaveCount(2),
 				expect(guest.page.locator("[data-participant-id]")).toHaveCount(2),
-				expectRemoteVideoReceiving(hostPage, "Endpoint Observer"),
 				expectRemoteVideoReceiving(guest.page, meetHostName),
 			]);
 		},

--- a/e2e/meet/specs/participant-connections.spec.ts
+++ b/e2e/meet/specs/participant-connections.spec.ts
@@ -8,7 +8,7 @@ import { expectRemoteVideoReceiving } from "../helpers/media";
 
 test.describe("Participant Connection switching", () => {
 	test(
-		"keeps the incumbent active until a device switch is confirmed",
+		"switches from the preview without a second confirmation",
 		{ tag: "@meet-group-3" },
 		async ({ hostPage, createMeeting, createParticipant }) => {
 			const meetingId = await createMeeting();
@@ -33,23 +33,7 @@ test.describe("Participant Connection switching", () => {
 				meetHostName,
 			);
 
-			const secondHostJoin = secondHostEndpoint.joinAsHost(meetingId);
-			await expect(
-				secondHostEndpoint.page.getByText("Switch to this device?", {
-					exact: true,
-				}).last(),
-			).toBeVisible();
-			await Promise.all([
-				expect(hostPage.getByTestId("meeting-layout")).toBeVisible(),
-				expectRemoteVideoReceiving(guest.page, meetHostName),
-			]);
-
-			await secondHostEndpoint.page
-				.locator("button")
-				.filter({ hasText: "Switch to this device" })
-				.last()
-				.click();
-			await secondHostJoin;
+			await secondHostEndpoint.joinAsHost(meetingId);
 			await expectRemoteTrackReplaced(
 				guest.page,
 				meetHostName,

--- a/frontend/src/apps/meet/components/MeetingPreview.vue
+++ b/frontend/src/apps/meet/components/MeetingPreview.vue
@@ -87,7 +87,7 @@
 							<template #prefix>
 								<lucide-video class="h-5 w-5" />
 							</template>
-							Join Meeting
+							{{ isCurrentUserPresent ? "Switch here" : "Join Meeting" }}
 						</Button>
 					</form>
 				</div>
@@ -132,7 +132,7 @@ const props = defineProps<{
 const emit = defineEmits<{
 	"toggle-microphone": [];
 	"toggle-camera": [];
-	"join-from-preview": [];
+	"join-from-preview": [switchHere: boolean];
 	"device-changed": [event: unknown];
 	"guest-join-complete": [data: { guestName: string; joinResult: unknown }];
 }>();
@@ -181,6 +181,7 @@ const previewVideoRef = (el: unknown) => {
 
 const {
 	participants,
+	isCurrentUserPresent,
 	error: presenceError,
 	hasFetchedParticipants,
 } = useMeetingPreviewPresence(props.meetingId);
@@ -224,7 +225,7 @@ const handleJoin = async () => {
 			toast.error(errorMessage);
 		}
 	} else {
-		emit("join-from-preview");
+		emit("join-from-preview", isCurrentUserPresent.value);
 	}
 };
 </script>

--- a/frontend/src/apps/meet/composables/useConnectionState.ts
+++ b/frontend/src/apps/meet/composables/useConnectionState.ts
@@ -3,6 +3,7 @@ import { ref } from "vue";
 
 export interface ConnectionState {
 	connectionError: string | null;
+	connectionMoved: boolean;
 	isInPreview: boolean;
 	codecStrategy: string;
 	networkQuality: string;
@@ -18,6 +19,7 @@ export interface ConnectionState {
 
 export const useConnectionState = defineStore("meet-connection", () => {
 	const connectionError = ref<string | null>(null);
+	const connectionMoved = ref(false);
 	const isInPreview = ref(true);
 	const codecStrategy = ref("svc");
 	const networkQuality = ref("good");
@@ -31,6 +33,7 @@ export const useConnectionState = defineStore("meet-connection", () => {
 
 	function $reset() {
 		connectionError.value = null;
+		connectionMoved.value = false;
 		isInPreview.value = true;
 		codecStrategy.value = "svc";
 		networkQuality.value = "good";
@@ -45,6 +48,7 @@ export const useConnectionState = defineStore("meet-connection", () => {
 
 	return {
 		connectionError,
+		connectionMoved,
 		isInPreview,
 		codecStrategy,
 		networkQuality,

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -2419,10 +2419,12 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 
 	observeLocalTracks();
 
-	onUnmounted(() => {
+	const cleanupLocalMedia = async () => {
 		cameraLifecycleGeneration++;
 		cameraLifecycleAbortController.abort(cameraLifecycleAbort());
 		mediaState.isCameraOn = false;
+		mediaState.isMicOn = false;
+		mediaState.isScreenSharing = false;
 		if (observedCameraTrack && cameraEndedListener) {
 			observedCameraTrack.removeEventListener("ended", cameraEndedListener);
 		}
@@ -2450,7 +2452,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			}
 		}
 
-		void enqueueCameraTransition(async () => {
+		await enqueueCameraTransition(async () => {
 			try {
 				await reconcileCameraTrack(null, "camera-unmount", false);
 			} finally {
@@ -2475,7 +2477,11 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 					}
 				}
 			}
-		}).catch(() => {});
+		});
+	};
+
+	onUnmounted(() => {
+		void cleanupLocalMedia().catch(() => {});
 	});
 
 	return {
@@ -2488,6 +2494,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		applySpeakerDevice,
 		applyBackgroundEffectsToLocalStream,
 		republishMediaAfterE2EE,
+		cleanupLocalMedia,
 		setLocalVideoRef,
 		setRemoteVideoRef,
 		setScreenShareVideoRef,

--- a/frontend/src/apps/meet/composables/useMeetingHandlers.test.ts
+++ b/frontend/src/apps/meet/composables/useMeetingHandlers.test.ts
@@ -22,4 +22,15 @@ describe("useMeetingHandlers", () => {
 		expect(connectionState.connectionError).toBeNull();
 		expect(connectionState.isInPreview).toBe(true);
 	});
+
+	it("carries preview switch intent into the join", async () => {
+		const joinMeetingRoom = vi.fn().mockResolvedValue(undefined);
+		const handlers = useMeetingHandlers({
+			sfuConnection: { joinMeetingRoom },
+		} as never);
+
+		await handlers.joinMeetingFromPreview(true);
+
+		expect(joinMeetingRoom).toHaveBeenCalledWith({ switchHere: true });
+	});
 });

--- a/frontend/src/apps/meet/composables/useMeetingHandlers.ts
+++ b/frontend/src/apps/meet/composables/useMeetingHandlers.ts
@@ -71,7 +71,7 @@ export type MeetingDocLike = DocumentResource;
 interface SFUConnectionActions {
 	sfuManager: Ref<SFUMeetingManager | null>;
 	sfuClient: SFUClient;
-	joinMeetingRoom: () => Promise<void>;
+	joinMeetingRoom: (options?: { switchHere?: boolean }) => Promise<void>;
 	handleGuestJoinResult: (
 		joinResult: JoinPayload,
 		guestName: string,
@@ -112,8 +112,8 @@ export function useMeetingHandlers(deps: MeetingHandlersDeps) {
 		}
 	};
 
-	const joinMeetingFromPreview = async () => {
-		await deps.sfuConnection.joinMeetingRoom();
+	const joinMeetingFromPreview = async (switchHere = false) => {
+		await deps.sfuConnection.joinMeetingRoom({ switchHere });
 	};
 
 	const handleGuestJoinComplete = async ({

--- a/frontend/src/apps/meet/composables/useMeetingPreviewPresence.ts
+++ b/frontend/src/apps/meet/composables/useMeetingPreviewPresence.ts
@@ -14,6 +14,7 @@ import type {
 
 export function useMeetingPreviewPresence(meetingId: string) {
 	const participants = ref<ParticipantPreview[]>([]);
+	const isCurrentUserPresent = ref(false);
 	const error = ref<string | null>(null);
 	const hasFetchedParticipants = ref(false);
 	let socket: Socket | null = null;
@@ -136,6 +137,7 @@ export function useMeetingPreviewPresence(meetingId: string) {
 				(response: PresenceParticipantsResponse) => {
 					hasFetchedParticipants.value = true;
 					if (response.success && response.participants) {
+						isCurrentUserPresent.value = !!response.isCurrentUserPresent;
 						participants.value = response.participants.map((p) => ({
 							user_id: p.info.userId || p.user_id || p.id,
 							full_name: p.info.name || p.user_id || p.id,
@@ -210,6 +212,7 @@ export function useMeetingPreviewPresence(meetingId: string) {
 
 	return {
 		participants: readonly(participants),
+		isCurrentUserPresent: readonly(isCurrentUserPresent),
 		error: readonly(error),
 		hasFetchedParticipants: readonly(hasFetchedParticipants),
 		refresh,

--- a/frontend/src/apps/meet/composables/useSFUConnection.ts
+++ b/frontend/src/apps/meet/composables/useSFUConnection.ts
@@ -1,4 +1,4 @@
-import { createResource, frappeRequest, toast } from "frappe-ui";
+import { createResource, dialog, frappeRequest, toast } from "frappe-ui";
 import {
 	defineAsyncComponent,
 	computed,
@@ -17,6 +17,7 @@ import {
 	type ConnectionDetails,
 	connectionDetailsFromJoinPayload,
 	SFUClient,
+	SFUResponseError,
 } from "../utils/SFUClient";
 import { SFUMeetingManager } from "../utils/SFUMeetingManager";
 import { getClientTelemetry } from "../utils/telemetry/ClientTelemetry";
@@ -112,6 +113,18 @@ function normalizeWaitingRoomResponse(value: unknown): WaitingRoomResponse | nul
 	return { waiting_users: waitingUsers };
 }
 
+function getParticipantConnectionConflictId(error: unknown): string | null {
+	if (
+		!(error instanceof SFUResponseError) ||
+		error.code !== "PARTICIPANT_CONNECTION_CONFLICT"
+	) {
+		return null;
+	}
+	return typeof error.details?.conflictId === "string"
+		? error.details.conflictId
+		: null;
+}
+
 export interface SFUScreenShareData {
 	participantId?: string;
 	consumer?: { id: string };
@@ -148,6 +161,7 @@ export function useSFUConnection(deps: {
 	notifiedLobbyUsers: Ref<Set<string>>;
 	onHostMutedYou: () => void;
 	onHostKickedYou: () => void;
+	onParticipantConnectionReplaced: () => void | Promise<void>;
 	onScreenShareStarted: (data: SFUScreenShareData) => void;
 	onScreenShareStopped: (data: SFUScreenShareData) => void;
 	onActiveSpeakerChanged: (participantIds: string[]) => void;
@@ -164,6 +178,7 @@ export function useSFUConnection(deps: {
 		notifiedLobbyUsers,
 		onHostMutedYou,
 		onHostKickedYou,
+		onParticipantConnectionReplaced,
 		onScreenShareStarted,
 		onScreenShareStopped,
 		onActiveSpeakerChanged,
@@ -187,6 +202,18 @@ export function useSFUConnection(deps: {
 	const joiningInProgress = shallowRef(false);
 	const hasShownE2EEKeyMismatchToast = shallowRef(false);
 	const isCurrentTabHost = shallowRef(false);
+	const confirmParticipantConnectionSwitch = () =>
+		new Promise<boolean>((resolve) => {
+			dialog.confirm({
+				title: "Switch to this device?",
+				message:
+					"You're already in this meeting on another device. Continuing will move the meeting here.",
+				confirmLabel: "Switch to this device",
+				cancelLabel: "Cancel",
+				onConfirm: () => resolve(true),
+				onCancel: () => resolve(false),
+			});
+		});
 
 	const e2eeHandshake: E2EEConnectionHandshake = useE2EEConnectionHandshake({
 		meetingId,
@@ -417,6 +444,10 @@ export function useSFUConnection(deps: {
 				toast.error("You have been removed from the meeting by the host");
 				onHostKickedYou();
 			},
+			onParticipantConnectionReplaced: async () => {
+				connectionState.connectionMoved = true;
+				await onParticipantConnectionReplaced();
+			},
 		};
 	};
 
@@ -425,6 +456,7 @@ export function useSFUConnection(deps: {
 		initialIsHost = false,
 		initialIsCohost = false,
 		prefetchedDetails: ConnectionDetails | null = null,
+		conflictId?: string,
 	) => {
 		clientTelemetry.startSession();
 		let isHost = initialIsHost;
@@ -454,6 +486,7 @@ export function useSFUConnection(deps: {
 			await manager.startParticipantConnection({
 				authToken: connectionState.guestAuthToken,
 				prefetchedDetails,
+				conflictId,
 				prepareJoin: async (signal) => {
 					if (signal.aborted) throw signal.reason;
 					connectionState.codecStrategy = sfuClient.getCodecStrategy() || "svc";
@@ -589,6 +622,23 @@ export function useSFUConnection(deps: {
 				if (sfuManager.value === manager) sfuManager.value = null;
 				return;
 			}
+			const nextConflictId = getParticipantConnectionConflictId(error);
+			if (nextConflictId) {
+				connectionState.connectionError = null;
+				await manager?.cleanup();
+				if (sfuManager.value === manager) sfuManager.value = null;
+				if (!(await confirmParticipantConnectionSwitch())) {
+					connectionState.isInPreview = true;
+					return;
+				}
+				return setupSFUConnection(
+					guestName,
+					initialIsHost,
+					initialIsCohost,
+					prefetchedDetails,
+					nextConflictId,
+				);
+			}
 			console.error("SFU setup failed:", error);
 			await manager?.cleanup();
 			if (sfuManager.value === manager) {
@@ -690,8 +740,6 @@ export function useSFUConnection(deps: {
 						false,
 						prefetched,
 					);
-
-					connectionState.isInPreview = false;
 				} else {
 					console.error(
 						"Failed to get connection details after approval:",
@@ -782,7 +830,6 @@ export function useSFUConnection(deps: {
 						!!sfuResult.is_cohost,
 						prefetched,
 					);
-					connectionState.isInPreview = false;
 				} else {
 					console.error("Failed to get SFU connection:", sfuResult);
 					lobbyStore.isJoinRequestRejected = true;

--- a/frontend/src/apps/meet/composables/useSFUConnection.ts
+++ b/frontend/src/apps/meet/composables/useSFUConnection.ts
@@ -135,7 +135,7 @@ export interface SFUScreenShareData {
 interface SFUConnectionAPI {
 	sfuClient: SFUClient;
 	sfuManager: Ref<SFUMeetingManager | null>;
-	joinMeetingRoom: () => Promise<void>;
+	joinMeetingRoom: (options?: { switchHere?: boolean }) => Promise<void>;
 	handleGuestJoinResult: (
 		joinResult: JoinPayload,
 		guestName: string,
@@ -457,6 +457,7 @@ export function useSFUConnection(deps: {
 		initialIsCohost = false,
 		prefetchedDetails: ConnectionDetails | null = null,
 		conflictId?: string,
+		switchHere = false,
 	) => {
 		clientTelemetry.startSession();
 		let isHost = initialIsHost;
@@ -627,7 +628,7 @@ export function useSFUConnection(deps: {
 				connectionState.connectionError = null;
 				await manager?.cleanup();
 				if (sfuManager.value === manager) sfuManager.value = null;
-				if (!(await confirmParticipantConnectionSwitch())) {
+				if (!switchHere && !(await confirmParticipantConnectionSwitch())) {
 					connectionState.isInPreview = true;
 					return;
 				}
@@ -637,6 +638,7 @@ export function useSFUConnection(deps: {
 					initialIsCohost,
 					prefetchedDetails,
 					nextConflictId,
+					false,
 				);
 			}
 			console.error("SFU setup failed:", error);
@@ -966,7 +968,7 @@ export function useSFUConnection(deps: {
 		}
 	};
 
-	const joinMeetingRoom = async () => {
+	const joinMeetingRoom = async (options: { switchHere?: boolean } = {}) => {
 		if (joiningInProgress.value) {
 			return;
 		}
@@ -1003,6 +1005,8 @@ export function useSFUConnection(deps: {
 				!!joinResult.is_host,
 				!!joinResult.is_cohost,
 				prefetched,
+				undefined,
+				!!options.switchHere,
 			);
 
 			setupFrappeRealtimeEventListeners();

--- a/frontend/src/apps/meet/pages/Meeting.vue
+++ b/frontend/src/apps/meet/pages/Meeting.vue
@@ -5,7 +5,7 @@
 		data-theme="dark"
 	>
 		<div
-			v-if="!hasConnectionError"
+			v-if="!hasConnectionError && !connectionState.connectionMoved"
 			class="shrink-0 overflow-hidden transition-[height] duration-500 ease-in-out"
 			:class="headerVisible ? 'h-11' : 'h-0'"
 		>
@@ -39,8 +39,22 @@
 			</MeetingHeader>
 		</div>
 
+		<div
+			v-if="connectionState.connectionMoved"
+			class="flex-1 flex items-center justify-center p-6"
+		>
+			<div class="max-w-md text-center text-white">
+				<span class="lucide-monitor-smartphone mx-auto mb-4 block size-12" aria-hidden="true" />
+				<h1 class="mb-2 text-xl font-semibold">Meeting moved to another device</h1>
+				<p class="mb-6 text-ink-gray-4">
+					You joined this meeting from another device, so audio and video have stopped here.
+				</p>
+				<Button variant="outline" @click="router.push('/meet')">Go home</Button>
+			</div>
+		</div>
+
 		<!-- Error state -->
-		<div v-if="hasConnectionError" class="flex-1 flex items-center justify-center">
+		<div v-else-if="hasConnectionError" class="flex-1 flex items-center justify-center">
 			<div class="text-center text-white">
 				<div class="text-red-500 mb-4">
 					<lucide-alert-circle class="w-12 h-12 mx-auto" />
@@ -510,6 +524,7 @@ const sfuConnection = useSFUConnection({
 		}
 	},
 	onHostKickedYou: () => sfuConnection.endCall(),
+	onParticipantConnectionReplaced: () => mediaControls.cleanupLocalMedia(),
 	onScreenShareStarted: (data: SFUScreenShareData) => {
 		const pid = data.participantId;
 		if (!pid) return;

--- a/frontend/src/apps/meet/pages/Meeting.vue
+++ b/frontend/src/apps/meet/pages/Meeting.vue
@@ -41,15 +41,26 @@
 
 		<div
 			v-if="connectionState.connectionMoved"
-			class="flex-1 flex items-center justify-center p-6"
+			class="grid flex-1 place-items-center px-5 py-16"
 		>
-			<div class="max-w-md text-center text-white">
-				<span class="lucide-monitor-smartphone mx-auto mb-4 block size-12" aria-hidden="true" />
-				<h1 class="mb-2 text-xl font-semibold">Meeting moved to another device</h1>
-				<p class="mb-6 text-ink-gray-4">
-					You joined this meeting from another device, so audio and video have stopped here.
+			<div class="flex w-full max-w-sm flex-col items-center text-center">
+				<div class="rounded-full bg-surface-gray-2 p-3 text-ink-gray-5">
+					<span class="lucide-monitor-smartphone block size-6" aria-hidden="true" />
+				</div>
+				<h1 class="mt-4 text-2xl-semibold text-ink-gray-9">
+					Meeting moved to another device
+				</h1>
+				<p class="mt-2 text-p-base text-ink-gray-6">
+					Your audio and video have stopped here because you joined from another device.
 				</p>
-				<Button variant="outline" @click="router.push('/meet')">Go home</Button>
+				<Button
+					class="mt-6"
+					variant="solid"
+					theme="gray"
+					icon-left="lucide-arrow-left"
+					label="Back to Meet"
+					@click="router.push('/meet')"
+				/>
 			</div>
 		</div>
 

--- a/frontend/src/apps/meet/types.ts
+++ b/frontend/src/apps/meet/types.ts
@@ -39,6 +39,7 @@ export interface PresenceParticipant {
 export interface PresenceParticipantsResponse {
 	success: boolean;
 	participants?: PresenceParticipant[];
+	isCurrentUserPresent?: boolean;
 	error?: string;
 }
 

--- a/frontend/src/apps/meet/utils/SFUClient.ts
+++ b/frontend/src/apps/meet/utils/SFUClient.ts
@@ -144,6 +144,12 @@ interface ConnectionStatus {
 interface SFUResponse {
 	success: boolean;
 	error?: string;
+	code?: string;
+	details?: ParticipantConnectionConflictDetails;
+}
+
+interface ParticipantConnectionConflictDetails {
+	conflictId: string;
 }
 
 export interface SFUWebRtcTransportResponse {
@@ -203,6 +209,31 @@ export class SFURequestError extends Error {
 		this.name = "SFURequestError";
 		this.code = code;
 	}
+}
+
+export class SFUResponseError extends Error {
+	readonly code?: string;
+	readonly details?: ParticipantConnectionConflictDetails;
+
+	constructor(
+		message: string,
+		code?: string,
+		details?: ParticipantConnectionConflictDetails,
+	) {
+		super(message);
+		this.name = "SFUResponseError";
+		this.code = code;
+		this.details = details;
+	}
+}
+
+function normalizeSFUResponseDetails(
+	value: unknown,
+): ParticipantConnectionConflictDetails | undefined {
+	if (!isUnknownRecord(value) || typeof value.conflictId !== "string") {
+		return undefined;
+	}
+	return { conflictId: value.conflictId };
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
@@ -909,11 +940,14 @@ export class SFUClient {
 		roomId: string,
 		userData: JoinUserData,
 		mediaState: JoinRoomMediaState,
+		options: { connectionId?: string; conflictId?: string } = {},
 	): Promise<{ success: boolean; senderId?: number }> {
 		const e2eeMode = this.getE2EEMode();
 		const e2eeShouldBeActive = this.isE2EERequired();
 		const result = (await this.sendRequest("join_room", {
 			roomId,
+			...(options.connectionId ? { connectionId: options.connectionId } : {}),
+			...(options.conflictId ? { conflictId: options.conflictId } : {}),
 			userData,
 			mediaState,
 			e2ee: {
@@ -1095,12 +1129,17 @@ export class SFUClient {
 								typeof rawResponse.error === "string"
 									? rawResponse.error
 									: undefined,
+							code:
+								typeof rawResponse.code === "string" ? rawResponse.code : undefined,
+							details: normalizeSFUResponseDetails(rawResponse.details),
 						};
 						if (response.success) {
 							resolve(response);
 						} else {
-							const error = new Error(
+							const error = new SFUResponseError(
 								response.error || `Request failed: ${event}`,
+								response.code,
+								response.details,
 							);
 							console.error(`SFU request failed (${event}):`, response.error);
 							reject(error);

--- a/frontend/src/apps/meet/utils/SFUClient.ts
+++ b/frontend/src/apps/meet/utils/SFUClient.ts
@@ -211,6 +211,7 @@ export class SFURequestError extends Error {
 	}
 }
 
+/** Preserves structured server rejection details, including takeover generations. */
 export class SFUResponseError extends Error {
 	readonly code?: string;
 	readonly details?: ParticipantConnectionConflictDetails;

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -14,6 +14,7 @@ import { TransportManager } from "./media/TransportManager";
 import { VideoElementManager } from "./media/VideoElementManager";
 import type { SFUClient } from "./SFUClient";
 import type { User } from "../composables/useCurrentUser";
+import type { JoinRoomMediaState, JoinUserData } from "../types";
 import {
 	ParticipantConnection,
 	type ParticipantConnectionStartOptions,
@@ -155,6 +156,13 @@ export class SFUMeetingManager {
 		options: ParticipantConnectionStartOptions,
 	): Promise<ParticipantConnectionState> {
 		return this.connectionManager.start(options);
+	}
+
+	rejoinParticipantConnection(
+		userData: JoinUserData,
+		mediaState: JoinRoomMediaState,
+	): Promise<boolean> {
+		return this.connectionManager.joinRoom(userData, mediaState);
 	}
 
 	reconcileExpectedMedia(): Promise<void> {

--- a/frontend/src/apps/meet/utils/__tests__/SFUClient.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUClient.test.ts
@@ -3,6 +3,7 @@ import {
 	connectionDetailsFromJoinPayload,
 	SFUClient,
 	SFURequestError,
+	SFUResponseError,
 } from "../SFUClient";
 
 const mockSignalChannel = () => ({
@@ -190,6 +191,25 @@ describe("sendRequest", () => {
 			cb({ success: false, error: "nope" }),
 		);
 		await expect(client.sendRequest("test", {})).rejects.toThrow("nope");
+	});
+
+	it("preserves structured response errors", async () => {
+		const client = createClient();
+		client.connected = true;
+		client.signalChannel.emit = vi.fn((_event, _data, cb) =>
+			cb({
+				success: false,
+				error: "already connected",
+				code: "PARTICIPANT_CONNECTION_CONFLICT",
+				details: { conflictId: "owner-1" },
+			}),
+		);
+
+		await expect(client.sendRequest("join_room", {})).rejects.toMatchObject<SFUResponseError>({
+			code: "PARTICIPANT_CONNECTION_CONFLICT",
+			details: { conflictId: "owner-1" },
+			message: "already connected",
+		});
 	});
 
 	it("rejects with TIMEOUT when an acknowledgement does not arrive", async () => {
@@ -759,6 +779,29 @@ describe("E2EE signaling payloads", () => {
 				}
 			).RTCRtpReceiver = originalReceiver;
 		}
+	});
+
+	it("includes Participant Connection ownership in join requests", async () => {
+		const client = createClient();
+		client.connected = true;
+		const sendRequest = vi
+			.spyOn(client, "sendRequest")
+			.mockResolvedValue({ success: true });
+
+		await client.joinRoom(
+			"room-1",
+			{ name: "Alice" },
+			{ audio_enabled: false },
+			{ connectionId: "connection-1", conflictId: "owner-1" },
+		);
+
+		expect(sendRequest).toHaveBeenCalledWith(
+			"join_room",
+			expect.objectContaining({
+				connectionId: "connection-1",
+				conflictId: "owner-1",
+			}),
+		);
 	});
 
 	it("reports RTCRtpScriptTransform capability in join request", async () => {

--- a/frontend/src/apps/meet/utils/media/E2EEHandshakeController.ts
+++ b/frontend/src/apps/meet/utils/media/E2EEHandshakeController.ts
@@ -523,8 +523,7 @@ export class E2EEHandshakeController {
 				error,
 			);
 		}
-		await this.sfuClient.joinRoom(
-			this.meetingId,
+		await this.sfuManager.value?.rejoinParticipantConnection(
 			{
 				userId: this.currentUser.currentUser.value?.user_id || "",
 				name:

--- a/frontend/src/apps/meet/utils/media/__tests__/E2EEHandshakeController.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/E2EEHandshakeController.test.ts
@@ -58,7 +58,10 @@ function createMediaReconfigurationController({
 			refreshToken,
 			joinRoom,
 		} as never,
-		sfuManager: shallowRef({ reconfigureForE2EE } as never),
+		sfuManager: shallowRef({
+			reconfigureForE2EE,
+			rejoinParticipantConnection: joinRoom,
+		} as never),
 		currentUser: {
 			currentUser: shallowRef({ user_id: "user-1", full_name: "User One" }),
 		} as never,
@@ -431,6 +434,7 @@ describe("E2EEHandshakeController", () => {
 			sendE2EEEpochEnvelope: vi.fn(),
 		} as never;
 		const sfuManager = shallowRef({
+			rejoinParticipantConnection: vi.fn(async () => true),
 			reconfigureForE2EE: vi.fn(async () => ({
 				videoPublished: true,
 				audioPublished: true,
@@ -486,7 +490,8 @@ describe("E2EEHandshakeController", () => {
 
 		expect(sfuClient.setE2EERequired).toHaveBeenCalledWith(true);
 		expect(sfuClient.refreshToken).toHaveBeenCalled();
-		expect(sfuClient.joinRoom).toHaveBeenCalled();
+		expect(sfuClient.joinRoom).not.toHaveBeenCalled();
+		expect(sfuManager.value.rejoinParticipantConnection).toHaveBeenCalled();
 		expect(sfuManager.value.reconfigureForE2EE).toHaveBeenCalled();
 	});
 

--- a/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
+++ b/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
@@ -125,6 +125,7 @@ export interface SFUEventHandlers {
 	onNetworkQualityUpdated?: (participantId: string, quality: string) => void;
 	onHostMutedYou?: () => void;
 	onHostKickedYou?: (data: { hostId?: string }) => void;
+	onParticipantConnectionReplaced?: (data: { reason: "takeover" }) => void | Promise<void>;
 	onRecoveryStateChange?: (
 		state:
 			| "reconnecting"
@@ -153,6 +154,7 @@ export type ParticipantConnectionState =
 export interface ParticipantConnectionStartOptions {
 	authToken?: string | null;
 	prefetchedDetails?: ConnectionDetails | null;
+	conflictId?: string;
 	prepareJoin: (signal: AbortSignal) => Promise<{
 		userData: JoinUserData;
 		mediaState: JoinRoomMediaState;
@@ -210,6 +212,7 @@ export class ParticipantConnection {
 	private e2eeReadyForLifecycle = false;
 	private lastAuthToken: string | null = null;
 	private activeEscalation: Promise<boolean> | null = null;
+	private readonly connectionId = crypto.randomUUID();
 	private localProducerBytes = new Map<string, number>();
 	private _state: ParticipantConnectionState = "stopped";
 	private static readonly INITIAL_RETRY_DELAY_MS = 1000;
@@ -272,7 +275,7 @@ export class ParticipantConnection {
 					options.prepareJoin(signal),
 					signal,
 				);
-				await this.joinRoom(userData, mediaState);
+				await this.joinRoom(userData, mediaState, options.conflictId);
 				this.throwIfAborted(signal);
 				if (this.sfuClient.isE2EERequired?.()) {
 					await this.awaitAbortable(options.waitForE2EEReady(signal), signal);
@@ -507,10 +510,14 @@ export class ParticipantConnection {
 	async joinRoom(
 		userData: JoinUserData,
 		mediaState: JoinRoomMediaState,
+		conflictId?: string,
 	): Promise<boolean> {
 		const generation = this.lifecycleGeneration;
 		try {
-			await this.sfuClient.joinRoom(this.meetingId ?? "", userData, mediaState);
+			await this.sfuClient.joinRoom(this.meetingId ?? "", userData, mediaState, {
+				connectionId: this.connectionId,
+				...(conflictId ? { conflictId } : {}),
+			});
 			if (generation !== this.lifecycleGeneration) {
 				await this.sfuClient.disconnect();
 				return false;
@@ -1308,6 +1315,17 @@ export class ParticipantConnection {
 	}
 
 	private setupSFUEventHandlers(): void {
+		this.sfuClient.on("participant_connection_replaced", (value: unknown) => {
+			if (!isUnknownRecord(value) || value.reason !== "takeover") return;
+			void Promise.resolve(
+				this.eventHandlers.onParticipantConnectionReplaced?.({ reason: "takeover" }),
+			)
+				.catch((error) =>
+					console.warn("Participant Connection replacement cleanup failed:", error),
+				)
+				.finally(() => void this.disconnect());
+		});
+
 		this.sfuClient.on("reconnect_attempt", () => {
 			this.recoveryManager.reset();
 			this.reportRecoveryState("reconnecting", "signaling reconnect attempt");

--- a/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnection.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnection.test.ts
@@ -135,6 +135,7 @@ describe("ParticipantConnection lifecycle", () => {
 			"meeting-1",
 			expect.objectContaining({ isHost: true }),
 			{ audio_enabled: false, video_enabled: true },
+			expect.objectContaining({ connectionId: expect.any(String) }),
 		);
 	});
 

--- a/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnectionEvents.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnectionEvents.test.ts
@@ -476,6 +476,31 @@ describe("ParticipantConnection", () => {
 		expect(rejoin).toHaveBeenCalledTimes(1);
 	});
 
+	it("cleans up when the meeting moves to another device", async () => {
+		const { handlers, manager, sfuClient } = createManager();
+		const replaced = vi.fn().mockResolvedValue(undefined);
+		manager.eventHandlers.onParticipantConnectionReplaced = replaced;
+		await manager.connect("token");
+
+		handlers.get("participant_connection_replaced")?.({ reason: "takeover" });
+
+		await vi.waitFor(() => expect(sfuClient.disconnect).toHaveBeenCalledOnce());
+		expect(replaced).toHaveBeenCalledWith({ reason: "takeover" });
+		expect(manager.state).toBe("stopped");
+	});
+
+	it("ignores replacement events from its own signaling reconnect", async () => {
+		const { handlers, manager, sfuClient } = createManager();
+		const replaced = vi.fn();
+		manager.eventHandlers.onParticipantConnectionReplaced = replaced;
+		await manager.connect("token");
+
+		handlers.get("participant_connection_replaced")?.({ reason: "reconnect" });
+
+		expect(replaced).not.toHaveBeenCalled();
+		expect(sfuClient.disconnect).not.toHaveBeenCalled();
+	});
+
 	it("escalates signaling reconnect exhaustion through the same coordinator", async () => {
 		const { handlers, manager } = createManager();
 		const escalate = vi.spyOn(manager, "escalateRecovery").mockResolvedValue(true);

--- a/suite/meet/CONTEXT.md
+++ b/suite/meet/CONTEXT.md
@@ -1,0 +1,128 @@
+# Meet
+
+Meet provides persistent rooms in which participants communicate through live audio, video, screen sharing, chat, and other shared-stage interactions.
+
+## Language
+
+**Meet Room**:
+A persistent joinable space whose membership and meeting policies survive individual calls.
+_Avoid_: Meeting Session, Call
+
+**Participant Connection**:
+One browser endpoint's live connection to a Meet Room, from join setup through cleanup. A participant switches explicitly when joining from another tab or device.
+_Avoid_: Meeting Session, SFU Session
+
+**Recording Session**:
+One continuous interval beginning when an authorized start is accepted and ending when recording stops.
+_Avoid_: Recording Job, Recording File
+
+**Recording Artifact**:
+A valid complete or partial composed video produced after a Recording Session ends.
+_Avoid_: Recording Session, Raw Tracks
+
+**Partial Artifact**:
+A Recording Artifact known to omit part of its Recording Session because capture was interrupted or ended unexpectedly.
+_Avoid_: Failed Recording, Recording Segment
+
+**Recording Interruption**:
+A period during an active Recording Session when the Recorder Endpoint cannot capture the Shared Stage.
+_Avoid_: Recording Stop, Processing Failure
+
+**Room Owner**:
+The user who owns the Meet Room and the Recording Artifacts produced in it.
+_Avoid_: Recording Initiator
+
+**Recording Initiator**:
+The host or co-host who starts a Recording Session, whether or not they own the Meet Room.
+_Avoid_: Room Owner
+
+**Recorder Endpoint**:
+A non-participant system endpoint that observes a Meet Room to produce a Recording Artifact.
+_Avoid_: Participant, Recording Initiator
+
+**Shared Stage**:
+The participant-visible meeting presentation composed from shared media and room-wide interactions.
+_Avoid_: Host View, Meeting Controls
+
+**Recording Notice**:
+The informational participant-facing announcement that a Recording Session is starting or already active.
+_Avoid_: Consent, Opt-in
+
+**Recording Estimate**:
+The advisory duration and artifact size shown before a Recording Session starts.
+_Avoid_: Recording Limit, Scheduled End
+
+**Recording Budget**:
+The Drive storage allowance reserved for one Recording Session.
+_Avoid_: Recording Estimate, Drive Quota
+
+**Recording Capacity**:
+The number of Recording Sessions the configured recorder deployment can capture concurrently.
+_Avoid_: Recording Budget, Meeting Capacity
+
+**Meet Media Deployment**:
+A Press infrastructure cluster-scoped managed unit containing shared, separately scalable SFU and recorder services for the Suite sites assigned to that cluster.
+_Avoid_: Meet Service Cluster, Per-Site Media Deployment
+
+**Recording Grant**:
+A single-use, proof-bound authorization for one Recorder Endpoint to observe one Meet Room for one Recording Session.
+_Avoid_: Participant Token, Recorder API Key
+
+**End-to-End Encryption**:
+A Meet Room policy under which only admitted participant endpoints may decrypt live media.
+_Avoid_: Server-side Encryption
+
+## Relationships
+
+- Global recording availability gates new sessions; disabling it does not interrupt an active Recording Session.
+- An authenticated participant has at most one active **Participant Connection** to a Meet Room and switches explicitly between tabs or devices.
+- A **Meet Room** can have many **Recording Sessions** over its lifetime.
+- A **Meet Room** has at most one active **Recording Session**, but earlier sessions may still be processing when another begins.
+- A **Recording Session** produces at most one **Recording Artifact**.
+- A **Recording Session** may exist without a **Recording Artifact** while it is active or processing, or after an unrecoverable failure.
+- A failed **Recording Session** with no Recording Artifact is retained for 30 days and then deleted automatically.
+- A **Recording Artifact** may begin after its Recording Session when recorder startup takes time.
+- A Recording Session with one or more known capture gaps produces one **Partial Artifact**, not multiple artifacts.
+- A **Partial Artifact** omits known gaps from playback and records their session timestamps as metadata; it does not synthesize filler media.
+- A recorder service restart ends the active Recording Session and does not resume capture automatically. The Room Owner receives a Partial Artifact when valid captured media exists; otherwise the session fails without an artifact. A host or co-host may start a new Recording Session after the recorder becomes ready.
+- Other transient capture failures may lose up to the current 30-second capture interval before recovery.
+- A **Recording Interruption** is visible to all participants and may recover for up to 60 seconds before the Recording Session stops; it produces a Partial Artifact only when valid captured media exists, otherwise it fails without an artifact.
+- A **Recording Artifact** belongs to exactly one **Room Owner**.
+- A **Recording Artifact** appears in Drive only after its video is valid and ready.
+- A **Recording Artifact** is named from its Meet Room title and Recording Session start time.
+- Only the **Room Owner** receives post-processing ready, partial, or failed notifications.
+- Trashing a **Recording Artifact** follows normal reversible Drive behavior; permanently deleting it also deletes its Recording Session metadata.
+- A **Recording Initiator** controls a **Recording Session** but does not thereby own its **Recording Artifact**.
+- A **Recorder Endpoint** observes the **Shared Stage** but does not count as a participant or keep the room human-occupied.
+- A **Recording Artifact** contains the **Shared Stage**, including public chat messages sent after artifact capture begins but not earlier chat or messages sent during recorder startup.
+- The recorded **Shared Stage** uses the current desktop Meet layout at 1920x1080: screen shares auto-pin with the standard sidebar, otherwise participants use the standard grid and overflow priorities.
+- The **Recorder Endpoint** never appears as a tile in the recorded Shared Stage.
+- The recorded **Shared Stage** includes names, avatars, active-speaker treatment, reactions, raised hands, timed public-chat overlays, and a small recording timer.
+- The recorded **Shared Stage** excludes meeting controls, sidebars, polls, menus, private notifications, and personalized participant state.
+- A **Recording Notice** informs participants but does not represent explicit individual consent.
+- A **Recording Notice** and live recording indicator appear immediately when the Recording Session begins; there is no countdown.
+- A late joiner's media may enter an active **Recording Session** immediately; a **Recording Notice** does not gate publication.
+- A scheduled **Recording Estimate** uses the time remaining in the Calendar event plus a 15-minute overrun allowance.
+- A recurring scheduled **Recording Estimate** uses one occurrence's full event duration plus a 15-minute overrun allowance.
+- An ad hoc **Recording Estimate** assumes one hour.
+- A **Recording Estimate** does not stop a Recording Session; quota and the four-hour maximum do.
+- A **Recording Budget** constrains a Recording Session independently of its Recording Estimate.
+- A **Recording Budget** grows automatically when the Room Owner frees sufficient Drive space, up to the four-hour session maximum.
+- When a **Recording Budget** will end a session early, hosts and co-hosts receive warnings at ten minutes and two minutes remaining.
+- A Recording Session starts only when **Recording Capacity** is immediately available; recording requests are never queued.
+- A **Meet Media Deployment** is shared by the Suite sites assigned to one Press infrastructure cluster; its SFU and recorder services remain separately deployable and scalable.
+- A **Recorder Endpoint** can observe media only after proving possession of the ephemeral key bound to its **Recording Grant**.
+- A **Recording Grant** is valid for exactly one site, Meet Room, Recording Session, Recorder Endpoint, and initial SFU connection.
+- An **End-to-End Encryption** Meet Room cannot start a Recording Session.
+- **End-to-End Encryption** cannot be enabled during an active **Recording Session**; the session must be stopped first.
+
+## Example Dialogue
+
+> **Dev:** "If a co-host starts recording and stops it ten minutes later, who owns the video?"
+> **Domain expert:** "That is one Recording Session. Its Recording Artifact belongs to the Room Owner, not the Recording Initiator. Starting again creates another Recording Session and another Recording Artifact."
+
+## Flagged Ambiguities
+
+- "Meeting" was used for both the persistent room and a live occurrence. Resolved: **Meet Room** is the durable domain entity; recording does not introduce a separate live Meeting Session entity.
+- "Recording" was used for both the active interval and its resulting video. Resolved: **Recording Session** is the interval; **Recording Artifact** is the video.
+- "Consent" was used for participant notification. Resolved: the MVP provides a **Recording Notice**, not explicit participant opt-in.

--- a/suite/meet/docs/adr/0005-single-participant-connection.md
+++ b/suite/meet/docs/adr/0005-single-participant-connection.md
@@ -1,0 +1,11 @@
+# Use one active Participant Connection per participant
+
+An authenticated participant has at most one active Participant Connection in a Meet Room. The client supplies a stable connection ID for signaling reconnects; the authenticated socket identity remains authoritative. A different device must confirm takeover using an opaque conflict ID tied to the current ownership generation.
+
+## Consequences
+
+- A signaling reconnect with the same connection ID replaces the stale socket automatically.
+- A different connection first receives a structured conflict and cannot disrupt the incumbent.
+- Confirmed takeover atomically changes ownership, notifies and disconnects the exact old socket, and does not create participant-left/joined presence churn.
+- Ownership generations guard cleanup so stale sockets and stale confirmations cannot release or successively evict newer owners.
+- Mediasoup peer IDs remain socket-specific; recorder and presence-preview connections are outside this ownership rule.

--- a/suite/meet/sfu-server/src/server/RoomRegistry.ts
+++ b/suite/meet/sfu-server/src/server/RoomRegistry.ts
@@ -161,6 +161,10 @@ export class RoomRegistry {
 		this.participantToSender.get(roomId)?.delete(participantId);
 	}
 
+	/**
+	 * Claims the participant's active connection. A matching connectionId reconnects;
+	 * a different connection requires the incumbent generation as conflictId.
+	 */
 	acquireParticipant(
 		socket: Socket,
 		roomId: string,
@@ -213,6 +217,7 @@ export class RoomRegistry {
 		};
 	}
 
+	/** Releases ownership only when the socket still holds the current generation. */
 	releaseParticipant(
 		socket: Socket,
 		roomId: string,
@@ -233,11 +238,13 @@ export class RoomRegistry {
 		return true;
 	}
 
+	/** Returns the single active participant socket, if ownership is currently held. */
 	getParticipantSocketIds(roomId: string, participantId: string): string[] {
 		const owner = this.participantConnections.get(roomId)?.get(participantId);
 		return owner ? [owner.socket.id] : [];
 	}
 
+	/** Checks both socket identity and ownership generation to reject stale sockets. */
 	isParticipantOwner(
 		socket: Socket,
 		roomId: string,

--- a/suite/meet/sfu-server/src/server/RoomRegistry.ts
+++ b/suite/meet/sfu-server/src/server/RoomRegistry.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import type { Server, Socket } from 'socket.io';
 import type {
 	ActivePoll,
@@ -35,7 +36,17 @@ export class RoomRegistry {
 	private hostOnlyChat: Record<string, boolean> = {};
 	private recentChatMessages: Record<string, ChatMessage[]> = {};
 	private pinnedChatMessage: Record<string, PinnedChatMessage> = {};
-	private participantConnections = new Map<string, Map<string, Set<string>>>();
+	private participantConnections = new Map<
+		string,
+		Map<
+			string,
+			{
+				socket: Socket;
+				connectionId: string;
+				ownershipId: string;
+			}
+		>
+	>();
 	private activePolls: Record<string, Map<string, ActivePoll>> = {};
 	private fullAccessSockets: Map<string, Set<string>> = new Map();
 	private previewSockets: Map<string, Set<string>> = new Map();
@@ -150,40 +161,93 @@ export class RoomRegistry {
 		this.participantToSender.get(roomId)?.delete(participantId);
 	}
 
-	claimParticipant(
+	acquireParticipant(
 		socket: Socket,
 		roomId: string,
 		participantId: string,
-	): boolean {
+		connectionId: string,
+		conflictId?: string,
+	):
+		| {
+				status: 'acquired' | 'idempotent' | 'reconnect' | 'takeover';
+				ownershipId: string;
+				replacedSocket?: Socket;
+		  }
+		| { status: 'conflict'; conflictId: string } {
 		let participants = this.participantConnections.get(roomId);
 		if (!participants) {
 			participants = new Map();
 			this.participantConnections.set(roomId, participants);
 		}
-		let connections = participants.get(participantId);
-		const isFirstConnection = !connections || connections.size === 0;
-		if (!connections) {
-			connections = new Set();
-			participants.set(participantId, connections);
+		const incumbent = participants.get(participantId);
+		if (!incumbent) {
+			const ownershipId = randomUUID();
+			participants.set(participantId, { socket, connectionId, ownershipId });
+			socket.participantConnectionId = connectionId;
+			socket.participantOwnershipId = ownershipId;
+			return { status: 'acquired', ownershipId };
 		}
-		connections.add(socket.id);
-		return isFirstConnection;
+
+		if (
+			incumbent.socket.id === socket.id &&
+			incumbent.connectionId === connectionId
+		) {
+			socket.participantConnectionId = connectionId;
+			socket.participantOwnershipId = incumbent.ownershipId;
+			return { status: 'idempotent', ownershipId: incumbent.ownershipId };
+		}
+
+		const reconnect = incumbent.connectionId === connectionId;
+		if (!reconnect && conflictId !== incumbent.ownershipId) {
+			return { status: 'conflict', conflictId: incumbent.ownershipId };
+		}
+
+		const ownershipId = randomUUID();
+		participants.set(participantId, { socket, connectionId, ownershipId });
+		socket.participantConnectionId = connectionId;
+		socket.participantOwnershipId = ownershipId;
+		return {
+			status: reconnect ? 'reconnect' : 'takeover',
+			ownershipId,
+			replacedSocket: incumbent.socket,
+		};
 	}
 
 	releaseParticipant(
 		socket: Socket,
 		roomId: string,
 		participantId: string,
+		ownershipId = socket.participantOwnershipId,
 	): boolean {
 		const participants = this.participantConnections.get(roomId);
-		const connections = participants?.get(participantId);
-		if (!connections?.delete(socket.id)) return false;
-		if (connections?.size === 0) {
-			participants?.delete(participantId);
-			if (participants?.size === 0) this.participantConnections.delete(roomId);
-			return true;
-		}
-		return false;
+		const owner = participants?.get(participantId);
+		if (
+			!owner ||
+			owner.socket.id !== socket.id ||
+			!ownershipId ||
+			owner.ownershipId !== ownershipId
+		)
+			return false;
+		participants?.delete(participantId);
+		if (participants?.size === 0) this.participantConnections.delete(roomId);
+		return true;
+	}
+
+	getParticipantSocketIds(roomId: string, participantId: string): string[] {
+		const owner = this.participantConnections.get(roomId)?.get(participantId);
+		return owner ? [owner.socket.id] : [];
+	}
+
+	isParticipantOwner(
+		socket: Socket,
+		roomId: string,
+		participantId: string,
+	): boolean {
+		const owner = this.participantConnections.get(roomId)?.get(participantId);
+		return (
+			owner?.socket.id === socket.id &&
+			owner.ownershipId === socket.participantOwnershipId
+		);
 	}
 
 	hasHumanParticipants(roomId: string): boolean {

--- a/suite/meet/sfu-server/src/server/__tests__/RoomRegistry.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/RoomRegistry.test.ts
@@ -91,34 +91,177 @@ function addRecorderSocket(
 }
 
 describe('RoomRegistry', () => {
-	it('counts a participant as human until all of their sockets leave', () => {
+	it('acquires the first participant connection', () => {
 		const { io } = makeIo();
 		const registry = new RoomRegistry(io);
 		const first = makeSocket('first');
-		const second = makeSocket('second');
 
-		registry.claimParticipant(first, 'r1', 'p1');
-		registry.claimParticipant(second, 'r1', 'p1');
+		const result = registry.acquireParticipant(first, 'r1', 'p1', 'device-1');
+
+		expect(result).toMatchObject({ status: 'acquired' });
+		expect(first.participantConnectionId).toBe('device-1');
+		expect(first.participantOwnershipId).toBe(
+			result.status === 'conflict' ? undefined : result.ownershipId,
+		);
 		expect(registry.hasHumanParticipants('r1')).toBe(true);
-
-		registry.releaseParticipant(first, 'r1', 'p1');
-		expect(registry.hasHumanParticipants('r1')).toBe(true);
-
-		registry.releaseParticipant(second, 'r1', 'p1');
-		expect(registry.hasHumanParticipants('r1')).toBe(false);
+		expect(registry.getParticipantSocketIds('r1', 'p1')).toEqual(['first']);
 	});
 
-	it('reports departure only after the last connection regardless of leave order', () => {
+	it('is idempotent for the same socket and connection ID', () => {
 		const { io } = makeIo();
 		const registry = new RoomRegistry(io);
-		const first = makeSocket('first');
-		const second = makeSocket('second');
+		const socket = makeSocket('first');
+		const first = registry.acquireParticipant(socket, 'r1', 'p1', 'device-1');
+		const repeated = registry.acquireParticipant(
+			socket,
+			'r1',
+			'p1',
+			'device-1',
+		);
 
-		expect(registry.claimParticipant(first, 'r1', 'p1')).toBe(true);
-		expect(registry.claimParticipant(second, 'r1', 'p1')).toBe(false);
-		expect(registry.releaseParticipant(second, 'r1', 'p1')).toBe(false);
+		expect(repeated).toEqual({
+			status: 'idempotent',
+			ownershipId: first.status === 'conflict' ? '' : first.ownershipId,
+		});
+	});
+
+	it('reconnects a stable connection ID on a new socket', () => {
+		const { io } = makeIo();
+		const registry = new RoomRegistry(io);
+		const oldSocket = makeSocket('old');
+		const replacement = makeSocket('replacement');
+		const old = registry.acquireParticipant(oldSocket, 'r1', 'p1', 'device-1');
+		const result = registry.acquireParticipant(
+			replacement,
+			'r1',
+			'p1',
+			'device-1',
+		);
+
+		expect(result).toMatchObject({
+			status: 'reconnect',
+			replacedSocket: oldSocket,
+		});
+		expect(result.status === 'conflict' ? '' : result.ownershipId).not.toBe(
+			old.status === 'conflict' ? '' : old.ownershipId,
+		);
+		expect(registry.getParticipantSocketIds('r1', 'p1')).toEqual([
+			'replacement',
+		]);
+	});
+
+	it('returns a conflict for another connection without mutating ownership', () => {
+		const { io } = makeIo();
+		const registry = new RoomRegistry(io);
+		const incumbent = makeSocket('incumbent');
+		const challenger = makeSocket('challenger');
+		const first = registry.acquireParticipant(
+			incumbent,
+			'r1',
+			'p1',
+			'device-1',
+		);
+		const result = registry.acquireParticipant(
+			challenger,
+			'r1',
+			'p1',
+			'device-2',
+		);
+
+		expect(result).toEqual({
+			status: 'conflict',
+			conflictId: first.status === 'conflict' ? '' : first.ownershipId,
+		});
+		expect(challenger.participantOwnershipId).toBeUndefined();
+		expect(registry.getParticipantSocketIds('r1', 'p1')).toEqual(['incumbent']);
+	});
+
+	it('takes over with the current conflict ID', () => {
+		const { io } = makeIo();
+		const registry = new RoomRegistry(io);
+		const incumbent = makeSocket('incumbent');
+		const challenger = makeSocket('challenger');
+		registry.acquireParticipant(incumbent, 'r1', 'p1', 'device-1');
+		const conflict = registry.acquireParticipant(
+			challenger,
+			'r1',
+			'p1',
+			'device-2',
+		);
+		const result = registry.acquireParticipant(
+			challenger,
+			'r1',
+			'p1',
+			'device-2',
+			conflict.status === 'conflict' ? conflict.conflictId : '',
+		);
+
+		expect(result).toMatchObject({
+			status: 'takeover',
+			replacedSocket: incumbent,
+		});
+		expect(registry.getParticipantSocketIds('r1', 'p1')).toEqual([
+			'challenger',
+		]);
+	});
+
+	it('rejects a stale conflict ID after another takeover', () => {
+		const { io } = makeIo();
+		const registry = new RoomRegistry(io);
+		const incumbent = makeSocket('incumbent');
+		const firstChallenger = makeSocket('challenger-1');
+		const secondChallenger = makeSocket('challenger-2');
+		const initial = registry.acquireParticipant(
+			incumbent,
+			'r1',
+			'p1',
+			'device-1',
+		);
+		const staleConflictId =
+			initial.status === 'conflict' ? '' : initial.ownershipId;
+		registry.acquireParticipant(
+			firstChallenger,
+			'r1',
+			'p1',
+			'device-2',
+			staleConflictId,
+		);
+		const result = registry.acquireParticipant(
+			secondChallenger,
+			'r1',
+			'p1',
+			'device-3',
+			staleConflictId,
+		);
+
+		expect(result).toMatchObject({ status: 'conflict' });
+		expect(result.status === 'conflict' && result.conflictId).not.toBe(
+			staleConflictId,
+		);
+		expect(registry.getParticipantSocketIds('r1', 'p1')).toEqual([
+			'challenger-1',
+		]);
+	});
+
+	it('does not let an old ownership generation release its replacement', () => {
+		const { io } = makeIo();
+		const registry = new RoomRegistry(io);
+		const oldSocket = makeSocket('old');
+		const replacement = makeSocket('replacement');
+		registry.acquireParticipant(oldSocket, 'r1', 'p1', 'device-1');
+		registry.acquireParticipant(replacement, 'r1', 'p1', 'device-1');
+
+		expect(registry.releaseParticipant(oldSocket, 'r1', 'p1')).toBe(false);
 		expect(registry.hasHumanParticipants('r1')).toBe(true);
-		expect(registry.releaseParticipant(first, 'r1', 'p1')).toBe(true);
+	});
+
+	it('releases the current ownership generation', () => {
+		const { io } = makeIo();
+		const registry = new RoomRegistry(io);
+		const socket = makeSocket('current');
+		registry.acquireParticipant(socket, 'r1', 'p1', 'device-1');
+
+		expect(registry.releaseParticipant(socket, 'r1', 'p1')).toBe(true);
 		expect(registry.hasHumanParticipants('r1')).toBe(false);
 	});
 

--- a/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
@@ -25,6 +25,8 @@ function emitJoin(
 		audioEnabled?: boolean;
 		videoEnabled?: boolean;
 		e2ee?: { enabled?: boolean; capability?: { supported?: boolean } };
+		connectionId?: string;
+		conflictId?: string;
 	} = {},
 	callback: (result: unknown) => void = () => {},
 ): void {
@@ -32,6 +34,8 @@ function emitJoin(
 		'join_room',
 		{
 			roomId: opts.roomId ?? 'room-1',
+			connectionId: opts.connectionId,
+			conflictId: opts.conflictId,
 			userData: {
 				name: opts.name ?? 'Alice',
 				userId: opts.userId ?? 'user-1',
@@ -482,46 +486,37 @@ describe('SocketHandlerManager characterization', () => {
 		);
 	});
 
-	it('keeps same-user participant connections and E2EE sender identities independent', async () => {
+	it('returns a structured conflict without disrupting the incumbent connection', async () => {
 		const harness = createManager();
-		const first = connectFullSocket(harness, {
-			id: 'connection-1',
+		const incumbent = connectFullSocket(harness, {
+			id: 'incumbent-socket',
 			userId: 'user-1',
 		});
-		emitJoin(first);
+		emitJoin(incumbent, { connectionId: 'device-1' });
 		await new Promise((resolve) => setImmediate(resolve));
-		first.emitCalls.length = 0;
+		incumbent.emitCalls.length = 0;
+		const disconnect = vi.spyOn(incumbent, 'disconnect');
 
-		const second = connectFullSocket(harness, {
-			id: 'connection-2',
+		const challenger = connectFullSocket(harness, {
+			id: 'challenger-socket',
 			userId: 'user-1',
 		});
-		emitJoin(second);
+		const callback = vi.fn();
+		emitJoin(challenger, { connectionId: 'device-2' }, callback);
 		await new Promise((resolve) => setImmediate(resolve));
 
-		expect(harness.mediasoup.addPeer).toHaveBeenCalledWith(
-			'room-1',
-			'connection-1',
-			expect.objectContaining({ userId: 'user-1' }),
+		expect(callback).toHaveBeenCalledWith({
+			success: false,
+			error: 'Another device is already connected',
+			code: 'PARTICIPANT_CONNECTION_CONFLICT',
+			details: { conflictId: expect.any(String) },
+		});
+		expect(disconnect).not.toHaveBeenCalled();
+		expect(incumbent.emitCalls).not.toContainEqual(
+			expect.objectContaining({ event: 'participant_connection_replaced' }),
 		);
-		expect(harness.mediasoup.addPeer).toHaveBeenCalledWith(
-			'room-1',
-			'connection-2',
-			expect.objectContaining({ userId: 'user-1' }),
-		);
-		expect(first.senderId).not.toBe(second.senderId);
-		expect(
-			await harness.roster.get('room-1', first.senderId ?? -1),
-		).toMatchObject({ participantId: 'connection-1' });
-		expect(
-			await harness.roster.get('room-1', second.senderId ?? -1),
-		).toMatchObject({ participantId: 'connection-2' });
-		expect(
-			first.emitCalls.some((call) => call.event === 'participant_joined'),
-		).toBe(false);
-		expect(
-			second.emitCalls.some((call) => call.event === 'participant_joined'),
-		).toBe(false);
+		expect(harness.mediasoup.addPeer).toHaveBeenCalledTimes(1);
+		expect(challenger.roomId).toBeUndefined();
 	});
 
 	it('join_room with scope:presence-preview tracks the socket in previewSockets, skips mediasoup.addPeer, and still emits existing_raised_hands', async () => {
@@ -867,76 +862,95 @@ describe('SocketHandlerManager characterization', () => {
 		vi.useRealTimers();
 	});
 
-	it('disconnecting one participant connection preserves the other connection', async () => {
+	it('confirmed takeover replaces the incumbent without participant churn and ignores its stale disconnect', async () => {
 		const harness = createManager();
 
-		const older = connectFullSocket(harness, {
+		const incumbent = connectFullSocket(harness, {
 			id: 'sock-old',
 			userId: 'user-1',
 		});
-		emitJoin(older);
+		emitJoin(incumbent, { connectionId: 'device-old' });
 		await new Promise((r) => setImmediate(r));
+		incumbent.emitCalls.length = 0;
+		const disconnect = vi.spyOn(incumbent, 'disconnect');
 
-		const current = connectFullSocket(harness, {
+		const challenger = connectFullSocket(harness, {
 			id: 'sock-current',
 			userId: 'user-1',
 		});
-		emitJoin(current);
+		const conflictCallback = vi.fn();
+		emitJoin(challenger, { connectionId: 'device-new' }, conflictCallback);
 		await new Promise((r) => setImmediate(r));
-
-		(harness.mediasoup.removePeer as ReturnType<typeof vi.fn>).mockClear();
-		older.fire('disconnect');
-		await new Promise((r) => setImmediate(r));
-
-		expect(harness.mediasoup.removePeer).toHaveBeenCalledWith(
-			'room-1',
-			'sock-old',
+		const conflictId = conflictCallback.mock.calls[0]?.[0].details
+			.conflictId as string;
+		const takeoverCallback = vi.fn();
+		emitJoin(
+			challenger,
+			{ connectionId: 'device-new', conflictId },
+			takeoverCallback,
 		);
+		await new Promise((r) => setImmediate(r));
+
+		expect(takeoverCallback).toHaveBeenCalledWith({
+			success: true,
+			senderId: challenger.senderId,
+		});
+		expect(incumbent.emitCalls).toContainEqual({
+			event: 'participant_connection_replaced',
+			data: { reason: 'takeover' },
+		});
+		expect(disconnect).toHaveBeenCalledWith(true);
 		expect(
-			current.emitCalls.some((call) => call.event === 'participant_left'),
+			challenger.emitCalls.some((call) => call.event === 'participant_joined'),
 		).toBe(false);
 
-		(harness.mediasoup.removePeer as ReturnType<typeof vi.fn>).mockClear();
-		current.fire('disconnect');
-		await new Promise((r) => setImmediate(r));
-
-		expect(harness.mediasoup.removePeer).toHaveBeenCalledWith(
-			'room-1',
-			'sock-current',
-		);
-	});
-
-	it('leave_room from one duplicate socket retains the room while another connection remains', async () => {
-		const harness = createManager();
-
-		const older = connectFullSocket(harness, {
-			id: 'sock-old',
-			userId: 'user-1',
-		});
-		emitJoin(older);
-		await new Promise((r) => setImmediate(r));
-
-		const current = connectFullSocket(harness, {
-			id: 'sock-current',
-			userId: 'user-1',
-		});
-		emitJoin(current);
-		await new Promise((r) => setImmediate(r));
-
-		current.leave('room-1:full');
-		(harness.mediasoup.removePeer as ReturnType<typeof vi.fn>).mockClear();
-		(harness.mediasoup.closeRoom as ReturnType<typeof vi.fn>).mockClear();
-
-		older.fire('leave_room');
+		challenger.emitCalls.length = 0;
+		incumbent.fire('disconnect', 'server namespace disconnect');
 		await new Promise((r) => setImmediate(r));
 
 		expect(harness.mediasoup.removePeer).toHaveBeenCalledWith(
 			'room-1',
 			'sock-old',
 		);
-		expect(harness.mediasoup.closeRoom).not.toHaveBeenCalled();
 		expect(
-			current.emitCalls.some((call) => call.event === 'participant_left'),
+			challenger.emitCalls.some((call) => call.event === 'participant_left'),
+		).toBe(false);
+		expect(challenger.roomId).toBe('room-1');
+	});
+
+	it('same-connection signaling reconnect replaces the stale socket automatically', async () => {
+		const harness = createManager();
+		const stale = connectFullSocket(harness, {
+			id: 'sock-old',
+			userId: 'user-1',
+		});
+		emitJoin(stale, { connectionId: 'stable-device' });
+		await new Promise((r) => setImmediate(r));
+		stale.emitCalls.length = 0;
+		const disconnect = vi.spyOn(stale, 'disconnect');
+
+		const reconnected = connectFullSocket(harness, {
+			id: 'sock-current',
+			userId: 'user-1',
+		});
+		const callback = vi.fn();
+		emitJoin(reconnected, { connectionId: 'stable-device' }, callback);
+		await new Promise((r) => setImmediate(r));
+
+		expect(callback).toHaveBeenCalledWith({
+			success: true,
+			senderId: reconnected.senderId,
+		});
+		expect(stale.emitCalls).toContainEqual({
+			event: 'participant_connection_replaced',
+			data: { reason: 'reconnect' },
+		});
+		expect(disconnect).toHaveBeenCalledWith(true);
+		expect(reconnected.participantOwnershipId).not.toBe(
+			stale.participantOwnershipId,
+		);
+		expect(
+			reconnected.emitCalls.some((call) => call.event === 'participant_joined'),
 		).toBe(false);
 	});
 
@@ -1073,45 +1087,6 @@ describe('SocketHandlerManager characterization', () => {
 		expect(
 			anotherTarget.emitCalls.some((c) => c.event === 'host_control_update'),
 		).toBe(false);
-	});
-
-	it('host control targets every Participant Connection for a participant', async () => {
-		const harness = createManager();
-		const host = connectFullSocket(harness, {
-			id: 'sock-host',
-			userId: 'host-1',
-			isHost: true,
-		});
-		const first = connectFullSocket(harness, {
-			id: 'sock-target-1',
-			userId: 'target-1',
-		});
-		const second = connectFullSocket(harness, {
-			id: 'sock-target-2',
-			userId: 'target-1',
-		});
-		emitJoin(host, { userId: 'host-1', name: 'Host' });
-		emitJoin(first, { userId: 'target-1', name: 'Target' });
-		emitJoin(second, { userId: 'target-1', name: 'Target' });
-		await new Promise((resolve) => setImmediate(resolve));
-		harness.io.socketsAdapterRooms.set(
-			'room-1',
-			new Set([host.id, first.id, second.id]),
-		);
-		first.emitCalls.length = 0;
-		second.emitCalls.length = 0;
-
-		host.fire('host_control', {
-			action: 'mute_participant',
-			targetParticipantId: 'target-1',
-		});
-
-		expect(
-			first.emitCalls.some((call) => call.event === 'host_control_update'),
-		).toBe(true);
-		expect(
-			second.emitCalls.some((call) => call.event === 'host_control_update'),
-		).toBe(true);
 	});
 
 	it('create_producer broadcasts screen producers to existing full-access participants', async () => {

--- a/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
@@ -545,6 +545,36 @@ describe('SocketHandlerManager characterization', () => {
 		);
 	});
 
+	it('tells a preview socket when its user already has a participant connection', async () => {
+		const harness = createManager();
+		harness.mediasoup.getRoomParticipants = vi.fn(() => []);
+		const participant = connectFullSocket(harness, {
+			id: 'participant-socket',
+			userId: 'user-1',
+		});
+		emitJoin(participant, { connectionId: 'device-1' });
+		await new Promise((r) => setImmediate(r));
+
+		const preview = connectFullSocket(harness, {
+			id: 'preview-socket',
+			scope: 'presence-preview',
+			userId: 'user-1',
+		});
+		emitJoin(preview, { userId: 'preview-1' });
+		await new Promise((r) => setImmediate(r));
+
+		const callback = vi.fn();
+		preview.fire('get_room_participants', {}, callback);
+		await new Promise((r) => setImmediate(r));
+
+		expect(callback).toHaveBeenCalledWith(
+			expect.objectContaining({
+				success: true,
+				isCurrentUserPresent: true,
+			}),
+		);
+	});
+
 	it('join_room does not add pending encrypted non-host joiners to the e2ee roster', async () => {
 		const harness = createManager();
 		const socket = connectFullSocket(harness, {

--- a/suite/meet/sfu-server/src/server/handlers/RoomJoinHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/RoomJoinHandlers.ts
@@ -10,14 +10,18 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 		data: {
 			roomId: string;
 			participantId: string;
+			connectionId: string;
+			conflictId?: string;
 			userData: UserData;
 			e2ee?: { enabled?: boolean; capability?: { supported?: boolean } };
 		},
 	): Promise<void> {
-		const { roomId, participantId, userData, e2ee } = data;
+		const { roomId, participantId, connectionId, conflictId, userData, e2ee } =
+			data;
 		const startedAt = performance.now();
 		const scope = socket.scope ?? 'unknown';
 		let participantClaimed = false;
+		let firstConnection = false;
 		if (socket.scope === 'full' && !socket.peerId) socket.peerId = socket.id;
 		const peerId = socket.peerId ?? participantId;
 		const rejoin = Boolean(
@@ -35,6 +39,24 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 			if (socket.scope === 'full') {
 				enforceE2EEJoinPolicy(socket, e2ee);
 				await deps.roomLifecycle.humanJoined(scopedRoomId);
+				const acquisition = deps.registry.acquireParticipant(
+					socket,
+					scopedRoomId,
+					participantId,
+					connectionId,
+					conflictId,
+				);
+				if (acquisition.status === 'conflict') {
+					throw new ParticipantConnectionConflictError(acquisition.conflictId);
+				}
+				participantClaimed = true;
+				firstConnection = acquisition.status === 'acquired';
+				if (acquisition.replacedSocket) {
+					acquisition.replacedSocket.emit('participant_connection_replaced', {
+						reason: acquisition.status,
+					});
+					acquisition.replacedSocket.disconnect(true);
+				}
 			}
 
 			if (socket.scope === 'full') {
@@ -47,6 +69,7 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 						);
 					},
 				);
+				assertParticipantOwnership(deps, socket, scopedRoomId, participantId);
 			}
 
 			socket.join(scopedRoomId);
@@ -56,12 +79,6 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 
 			if (socket.scope === 'full') {
 				deps.registry.joinScope(socket, scopedRoomId, 'full');
-				const isFirstConnection = deps.registry.claimParticipant(
-					socket,
-					scopedRoomId,
-					participantId,
-				);
-				participantClaimed = true;
 				const senderId = deps.registry.assignSenderId(scopedRoomId, peerId);
 				socket.senderId = senderId;
 				if (!socket.e2eeRequired) {
@@ -71,8 +88,10 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 						isHost: Boolean(socket.isHost),
 						joinedAt: Date.now(),
 					});
+					assertParticipantOwnership(deps, socket, scopedRoomId, participantId);
 				}
 				await deps.e2eeEpochRelay.retryPendingCommitRequests(scopedRoomId);
+				assertParticipantOwnership(deps, socket, scopedRoomId, participantId);
 
 				const existingPeer = deps.mediasoup
 					.getRoomPeers?.(scopedRoomId)
@@ -91,7 +110,7 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 					isHost: Boolean(socket.isHost),
 				});
 
-				if (isFirstConnection && isRealParticipant(userData.userId)) {
+				if (firstConnection && isRealParticipant(userData.userId)) {
 					deps.registry.emitParticipantEvent(
 						scopedRoomId,
 						'participant_joined',
@@ -159,11 +178,43 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 		} catch (error) {
 			if (socket.scope === 'full') {
 				if (participantClaimed) {
-					deps.registry.releaseParticipant(
+					const participantDeparted = deps.registry.releaseParticipant(
 						socket,
 						getRoomId(socket),
 						participantId,
 					);
+					if (
+						participantDeparted &&
+						!firstConnection &&
+						isRealParticipant(participantId)
+					) {
+						deps.registry.emitParticipantEvent(
+							getRoomId(socket),
+							'participant_left',
+							participantId,
+						);
+					}
+					try {
+						deps.registry.leaveScope(socket, getRoomId(socket), 'full');
+						if (socket.senderId !== undefined) {
+							await deps.e2eeRoster.remove(getRoomId(socket), socket.senderId);
+							deps.e2eeEpochRelay.removePendingJoiner(
+								getRoomId(socket),
+								socket.senderId,
+							);
+						}
+						deps.registry.removeSender(getRoomId(socket), peerId);
+						await deps.mediasoup.removePeer(getRoomId(socket), peerId);
+						socket.leave(getRoomId(socket));
+						socket.roomId = undefined;
+						socket.participantId = undefined;
+					} catch (cleanupError) {
+						loggers.socketHandler.warn(
+							'Join rollback failed for user %s: %s',
+							participantId,
+							(cleanupError as Error).message,
+						);
+					}
 				}
 				deps.roomLifecycle.scheduleCleanupIfHumanEmpty(getRoomId(socket));
 			}
@@ -227,9 +278,11 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 				await handleJoinRoom(socket, {
 					roomId,
 					participantId: socket.userId,
+					connectionId: data.connectionId ?? socket.id,
+					conflictId: data.conflictId,
 					userData: {
 						name: userData.name,
-						userId: userData.userId,
+						userId: socket.userId,
 						avatar: userData.avatar,
 						audio_enabled: mediaState.audio_enabled,
 						video_enabled: mediaState.video_enabled,
@@ -262,6 +315,15 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 					});
 				});
 			} catch (error) {
+				if (error instanceof ParticipantConnectionConflictError) {
+					callback({
+						success: false,
+						error: 'Another device is already connected',
+						code: 'PARTICIPANT_CONNECTION_CONFLICT',
+						details: { conflictId: error.conflictId },
+					});
+					return;
+				}
 				loggers.socketHandler.error(
 					'Error joining room: %s',
 					(error as Error).message,
@@ -338,6 +400,23 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 			}
 		});
 	};
+}
+
+class ParticipantConnectionConflictError extends Error {
+	constructor(readonly conflictId: string) {
+		super('Another device is already connected');
+	}
+}
+
+function assertParticipantOwnership(
+	deps: HandlerDeps,
+	socket: Socket,
+	roomId: string,
+	participantId: string,
+): void {
+	if (!deps.registry.isParticipantOwner(socket, roomId, participantId)) {
+		throw new Error('Participant connection was replaced');
+	}
 }
 
 function participantIdsForPeers(

--- a/suite/meet/sfu-server/src/server/handlers/RoomQueryHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/RoomQueryHandlers.ts
@@ -128,7 +128,15 @@ export function registerRoomQueryHandlers(deps: HandlerDeps) {
 					responseParticipants.length,
 					roomId,
 				);
-				callback({ success: true, participants: responseParticipants });
+				callback({
+					success: true,
+					participants: responseParticipants,
+					...(socket.scope === 'presence-preview' && {
+						isCurrentUserPresent:
+							deps.registry.getParticipantSocketIds(roomId, socket.userId)
+								.length > 0,
+					}),
+				});
 			} catch (error) {
 				loggers.socketHandler.error(
 					'Error getting room participants: %s',

--- a/suite/meet/sfu-server/src/types/index.ts
+++ b/suite/meet/sfu-server/src/types/index.ts
@@ -393,6 +393,7 @@ export interface ExistingProducersResponse extends SFUResponse {
 
 export interface RoomParticipantsResponse extends SFUResponse {
 	participants: ParticipantInfo[] | PreviewParticipantInfo[];
+	isCurrentUserPresent?: boolean;
 }
 
 export interface ProducerInfo {

--- a/suite/meet/sfu-server/src/types/index.ts
+++ b/suite/meet/sfu-server/src/types/index.ts
@@ -128,6 +128,9 @@ export interface ServerToClientEvents {
 	) => void;
 	participant_joined: (data: ParticipantJoinedEvent) => void;
 	participant_left: (data: ParticipantLeftEvent) => void;
+	participant_connection_replaced: (data: {
+		reason: 'takeover' | 'reconnect';
+	}) => void;
 	producer_created: (data: ProducerCreatedEvent) => void;
 	producer_closed: (data: ProducerClosedEvent) => void;
 	consumer_closed: (data: ConsumerClosedEvent) => void;
@@ -338,12 +341,16 @@ export interface SocketData {
 	isGuest?: boolean;
 	roomId?: string;
 	participantId?: string;
+	participantConnectionId?: string;
+	participantOwnershipId?: string;
 	scope?: SFUScope;
 }
 
 export interface SFUResponse {
 	success: boolean;
 	error?: string;
+	code?: string;
+	details?: { conflictId?: string };
 }
 
 export interface RouterRtpCapabilitiesResponse extends SFUResponse {
@@ -678,6 +685,8 @@ declare module 'socket.io' {
 		isGuest?: boolean;
 		roomId?: string;
 		participantId?: string;
+		participantConnectionId?: string;
+		participantOwnershipId?: string;
 		senderId?: number;
 		currentToken?: string;
 		tokenExpiresAt?: number;

--- a/suite/meet/type-policy/allowlist.json
+++ b/suite/meet/type-policy/allowlist.json
@@ -27,7 +27,7 @@
     },
     {
       "path": "frontend/src/apps/meet/utils/SFUClient.ts",
-      "line": 254,
+		"line": 255,
       "column": 58,
       "rule": "MTP001",
       "lineText": "function requireObject(value: unknown, context: string): Record<string, unknown> {",

--- a/suite/meet/type-policy/allowlist.json
+++ b/suite/meet/type-policy/allowlist.json
@@ -11,7 +11,7 @@
     },
     {
       "path": "frontend/src/apps/meet/types.ts",
-      "line": 117,
+		"line": 118,
       "column": 13,
       "rule": "MTP001",
       "lineText": "): value is Record<string, unknown> {",

--- a/suite/meet/type-policy/allowlist.json
+++ b/suite/meet/type-policy/allowlist.json
@@ -27,7 +27,7 @@
     },
     {
       "path": "frontend/src/apps/meet/utils/SFUClient.ts",
-      "line": 223,
+      "line": 254,
       "column": 58,
       "rule": "MTP001",
       "lineText": "function requireObject(value: unknown, context: string): Record<string, unknown> {",

--- a/suite/meet/types/index.ts
+++ b/suite/meet/types/index.ts
@@ -238,6 +238,8 @@ export interface E2EESessionMetadata {
 
 export interface JoinRoomRequest {
 	roomId: string;
+	connectionId?: string;
+	conflictId?: string;
 	userData: UserData;
 	mediaState: MediaState;
 	e2ee?: E2EESessionMetadata;


### PR DESCRIPTION
## Summary
- allow at most one active Participant Connection per participant and Meet Room
- require explicit confirmation before switching devices while preserving signaling reconnects
- notify and clean up the displaced endpoint without participant presence churn
- document the ownership-generation protocol and cover conflict, takeover, reconnect, and stale cleanup behavior
