### PR TITLE
fix(drive): hide attachments from home

### DIFF
--- a/suite/drive/api/list.py
+++ b/suite/drive/api/list.py
@@ -230,8 +230,8 @@ def files(
     folders. When `search` is set, results span the whole tree (not just the
     current folder).
     """
-    is_home = not entity_name
-    if is_home:
+    is_home_request = not entity_name
+    if is_home_request:
         entity_name = get_user_folder().name
 
     entity = frappe.get_doc("File", entity_name)
@@ -243,7 +243,7 @@ def files(
         )
 
     query = _get_basic_query(search)
-    if is_home:
+    if is_home_request:
         query = query.where(DriveFile.attached_to_doctype.isnull())
     if not search:
         # Folder browsing; search is tree-wide so it skips the folder filter.

--- a/suite/drive/api/list.py
+++ b/suite/drive/api/list.py
@@ -230,7 +230,8 @@ def files(
     folders. When `search` is set, results span the whole tree (not just the
     current folder).
     """
-    if not entity_name:
+    is_home = not entity_name
+    if is_home:
         entity_name = get_user_folder().name
 
     entity = frappe.get_doc("File", entity_name)
@@ -242,6 +243,8 @@ def files(
         )
 
     query = _get_basic_query(search)
+    if is_home:
+        query = query.where(DriveFile.attached_to_doctype.isnull())
     if not search:
         # Folder browsing; search is tree-wide so it skips the folder filter.
         query = query.where(DriveFile.folder == entity_name)

--- a/suite/drive/api/tests/test_files.py
+++ b/suite/drive/api/tests/test_files.py
@@ -22,7 +22,7 @@ from suite.drive.api.files import (
     update_access,
     upload_file,
 )
-from suite.drive.api.list import files, get_attachments
+from suite.drive.api.list import get_attachments
 from suite.drive.api.permissions import (
     can_create_in_folder,
     get_general_access,
@@ -85,21 +85,6 @@ class TestDriveFilesAPI(IntegrationTestCase):
             attachments = get_attachments("User", OWNER)
 
         self.assertEqual([attachment["name"] for attachment in attachments], [self.file.name])
-
-    def test_home_hides_doctype_attachments(self):
-        with self.set_user(OWNER):
-            attachment = create_drive_file(
-                f"{frappe.generate_hash(8)}.txt",
-                self.home,
-                "Text",
-                f"/private/files/{frappe.generate_hash(8)}.txt",
-                "text/plain",
-                12,
-            )
-            attachment.db_set({"attached_to_doctype": "User", "attached_to_name": OWNER})
-            result = files()
-
-        self.assertNotIn(attachment.name, [row["name"] for row in result])
 
     def test_attachment_patch_normalizes_framework_file_type(self):
         try:

--- a/suite/drive/api/tests/test_files.py
+++ b/suite/drive/api/tests/test_files.py
@@ -22,7 +22,7 @@ from suite.drive.api.files import (
     update_access,
     upload_file,
 )
-from suite.drive.api.list import get_attachments
+from suite.drive.api.list import files, get_attachments
 from suite.drive.api.permissions import (
     can_create_in_folder,
     get_general_access,
@@ -85,6 +85,21 @@ class TestDriveFilesAPI(IntegrationTestCase):
             attachments = get_attachments("User", OWNER)
 
         self.assertEqual([attachment["name"] for attachment in attachments], [self.file.name])
+
+    def test_home_hides_doctype_attachments(self):
+        with self.set_user(OWNER):
+            attachment = create_drive_file(
+                f"{frappe.generate_hash(8)}.txt",
+                self.home,
+                "Text",
+                f"/private/files/{frappe.generate_hash(8)}.txt",
+                "text/plain",
+                12,
+            )
+            attachment.db_set({"attached_to_doctype": "User", "attached_to_name": OWNER})
+            result = files()
+
+        self.assertNotIn(attachment.name, [row["name"] for row in result])
 
     def test_attachment_patch_normalizes_framework_file_type(self):
         try:


### PR DESCRIPTION
DocType attachments are managed through Drive's dedicated Attachments view. Exclude them from the default Home listing while leaving explicit folder listings unchanged.