### PR TITLE
fix(meet): simplify muted toolbar buttons and pfp in chat panel

### DIFF
--- a/frontend/src/apps/meet/components/ChatPanel.vue
+++ b/frontend/src/apps/meet/components/ChatPanel.vue
@@ -70,6 +70,7 @@
 								<MeetAvatar
 									v-if="item.poll.createdBy !== userId"
 									size="lg"
+									:image="avatarByUser[item.poll.createdBy]"
 									:label="item.poll.createdByName || item.poll.createdBy"
 									class="mt-6 shrink-0"
 								/>
@@ -96,6 +97,7 @@
 							<MeetAvatar
 								v-if="!item.group.isOwn"
 								size="lg"
+								:image="avatarByUser[item.group.user_id]"
 								:label="item.group.user_name"
 								class="mt-6 shrink-0"
 							/>
@@ -271,6 +273,7 @@ const props = defineProps<{
 	open?: boolean;
 	userId?: string;
 	userName?: string;
+	avatarByUser?: Record<string, string | null | undefined>;
 	messages?: ChatMessage[];
 	isHost?: boolean;
 	isCohost?: boolean;
@@ -278,6 +281,8 @@ const props = defineProps<{
 	hostOnlyChat?: boolean;
 	pinnedMessage?: ChatMessage | null;
 }>();
+
+const avatarByUser = computed(() => props.avatarByUser || {});
 
 const pollStore = usePollStore();
 const pollService = inject(pollKey);

--- a/frontend/src/apps/meet/components/ToolbarButton.vue
+++ b/frontend/src/apps/meet/components/ToolbarButton.vue
@@ -36,7 +36,6 @@ defineEmits<{
 			'relative',
 			{
 				'!bg-surface-gray-3': active,
-				'!bg-surface-red-2 hover:!bg-surface-red-3': variant === 'muted',
 			},
 		]"
 		@click="$emit('click')"
@@ -44,7 +43,7 @@ defineEmits<{
 		<template #icon>
 			<span
 				:class="{
-					'text-ink-red-8': variant === 'active' || variant === 'muted',
+					'text-ink-red-7': variant === 'active' || variant === 'muted',
 				}"
 			>
 				<slot />

--- a/frontend/src/apps/meet/pages/Meeting.vue
+++ b/frontend/src/apps/meet/pages/Meeting.vue
@@ -166,6 +166,7 @@
 								v-if="activePanel === 'chat'"
 								:open="true"
 								:messages="chatStore.chatMessages"
+								:avatar-by-user="participantAvatars"
 								:user-id="(currentUser.currentUser.value?.user_id as string) || ''"
 								:user-name="
 									(currentUser.currentUser.value?.full_name as string) ||
@@ -831,6 +832,15 @@ const activePanel = computed(() => {
 
 const participantsForPeoplePanel = computed<Record<string, Participant>>(
 	() => participantStore.participants as Record<string, Participant>,
+);
+
+const participantAvatars = computed(() =>
+	Object.fromEntries(
+		Object.entries(participantsForPeoplePanel.value).map(([userId, participant]) => [
+			userId,
+			participant.avatar,
+		]),
+	),
 );
 
 const { isMobile } = useResponsiveGrid();


### PR DESCRIPTION
## Summary

- remove the filled red background from muted meeting toolbar controls
- use a more prominent red icon treatment for muted controls
- show participant profile images beside chat messages and polls