### PR TITLE
feat(slides): add open presentation link to desk form

### DIFF
--- a/suite/slides/doctype/presentation/presentation.js
+++ b/suite/slides/doctype/presentation/presentation.js
@@ -3,6 +3,10 @@
 
 frappe.ui.form.on("Presentation", {
 	refresh: function (frm) {
+		if (!frm.doc.__islocal) {
+			const slug = frm.doc.slug ? `/${frm.doc.slug}` : ""
+			frm.add_web_link(`/slides/presentation/${frm.doc.name}${slug}`, __("Open Presentation"))
+		}
 		frm.add_custom_button("Optimize Images", function () {
 			frappe.call({
 				method: "suite.slides.doctype.presentation.presentation.optimize_images",


### PR DESCRIPTION
Adds "Open Presentation" web link on Presentation Desk form similar to Meet Room's "Join Meeting".

Links to `/slides/presentation/<name>/<slug>` when the document is saved.