### PR TITLE
fix(slides): encode presentation slug and fix statement terminators

### DIFF
--- a/suite/slides/doctype/presentation/presentation.js
+++ b/suite/slides/doctype/presentation/presentation.js
@@ -4,8 +4,8 @@
 frappe.ui.form.on("Presentation", {
 	refresh: function (frm) {
 		if (!frm.doc.__islocal) {
-			const slug = frm.doc.slug ? `/${frm.doc.slug}` : ""
-			frm.add_web_link(`/slides/presentation/${frm.doc.name}${slug}`, __("Open Presentation"))
+			const slug = frm.doc.slug ? `/${encodeURIComponent(frm.doc.slug)}` : "";
+			frm.add_web_link(`/slides/presentation/${frm.doc.name}${slug}`, __("Open Presentation"));
 		}
 		frm.add_custom_button("Optimize Images", function () {
 			frappe.call({


### PR DESCRIPTION
Addresses Greptile review on #741: encode slug with `encodeURIComponent` to handle titles containing `/` and add missing semicolons for style consistency.