### PR TITLE
fix(mail): render search palette content

### DIFF
--- a/frontend/src/apps/mail/components/Modals/SearchModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SearchModal.vue
@@ -6,7 +6,7 @@
 		v-bind="{ size: '2xl', paddingTop: '2%' }"
 		:bare="!isMobile"
 	>
-		<template>
+		<template #default>
 			<div class="bg-surface-base">
 				<div class="flex items-center border-b px-4 py-2">
 					<!-- Mobile trades the decorative magnifier for the way out: search is a


### PR DESCRIPTION
## Summary

Bind Mail's search content to the dynamic overlay's default slot so the desktop palette renders instead of opening as an empty dialog.