### PR TITLE
fix(meet): reduce mobile camera workload

### DIFF
--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -16,6 +16,7 @@ import {
 } from "../data/mediaPreferences";
 import type { DeviceType, deviceManager } from "../utils/media/DeviceManager";
 import notificationContextManager from "../utils/notificationContext";
+import { isMobileDevice } from "../utils/device";
 import type { SFUClient } from "../utils/SFUClient";
 import type { SFUMeetingManager } from "../utils/SFUMeetingManager";
 import type { ConnectionState } from "./useConnectionState";
@@ -31,6 +32,22 @@ const isBluetoothMicLabel = (label: string | undefined): boolean => {
 	if (!label) return false;
 	return BLUETOOTH_DEVICE_LABEL_REGEX.test(label.toLowerCase());
 };
+
+function getCameraVideoConstraints(): MediaTrackConstraints {
+	if (isMobileDevice()) {
+		return {
+			width: { ideal: 640 },
+			height: { ideal: 360 },
+			frameRate: { ideal: 24, max: 24 },
+		};
+	}
+
+	return {
+		width: { ideal: 1280, min: 960 },
+		height: { ideal: 720, min: 540 },
+		frameRate: { ideal: 30, max: 30 },
+	};
+}
 
 function getBackgroundEffectsFromStorage() {
 	const blurEnabled = localStorage.getItem("backgroundEffects.blur") === "1";
@@ -1246,11 +1263,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		};
 
 		if (videoEnabled) {
-			const videoConstraints: MediaTrackConstraints = {
-				width: { ideal: 1280, min: 960 },
-				height: { ideal: 720, min: 540 },
-				frameRate: { ideal: 30, max: 30 },
-			};
+			const videoConstraints = getCameraVideoConstraints();
 
 			const validCameraId = await getValidDeviceId(
 				selectedCameraId.value,

--- a/frontend/src/apps/meet/utils/device.ts
+++ b/frontend/src/apps/meet/utils/device.ts
@@ -20,6 +20,10 @@ export function isMobile(): boolean {
 	return window.innerWidth < 640;
 }
 
+export function isMobileDevice(): boolean {
+	return /android|iphone|ipad|ipod|mobile/i.test(navigator.userAgent);
+}
+
 export function canScreenShare(): boolean {
 	return "getDisplayMedia" in navigator.mediaDevices;
 }

--- a/frontend/src/apps/meet/utils/media/__tests__/TransportManager.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/TransportManager.test.ts
@@ -124,6 +124,11 @@ describe("getVideoEncodingConfig", () => {
 		expect(config.decision.strategy).toBe("simulcast");
 		expect(config.decision.scalabilityMode).toBeNull();
 		expect(config.encodings).toHaveLength(3);
+		expect(config.encodings.map((encoding) => encoding.scaleResolutionDownBy)).toEqual([
+			4,
+			2,
+			undefined,
+		]);
 	});
 
 	it("returns screenEncodings for screen source regardless of strategy", () => {

--- a/frontend/src/apps/meet/utils/media/encodings.ts
+++ b/frontend/src/apps/meet/utils/media/encodings.ts
@@ -16,8 +16,8 @@ interface SVCEncodingLayer {
 }
 
 export const videoEncodings: VideoEncodingLayer[] = [
-	{ maxBitrate: 300000, scaleResolutionDownBy: 2 },
-	{ maxBitrate: 700000, scaleResolutionDownBy: 1 },
+	{ maxBitrate: 300000, scaleResolutionDownBy: 4 },
+	{ maxBitrate: 700000, scaleResolutionDownBy: 2 },
 	{ maxBitrate: 1800000 },
 ];
 


### PR DESCRIPTION
## Summary

- Request a lower-resolution, lower-frame-rate camera stream on mobile devices.
- Use distinct low, medium, and high simulcast resolutions instead of encoding full resolution twice.

## Context

Mobile devices currently use the desktop camera profile and can run hot during video calls. This reduces capture and encoding work while preserving the existing desktop profile and highest simulcast layer.