### PR TITLE
fix(mail): give every dialog back its body

### DIFF
--- a/frontend/src/apps/mail/components/InstallPrompt.vue
+++ b/frontend/src/apps/mail/components/InstallPrompt.vue
@@ -3,7 +3,7 @@
 		<template #title>
 			<h2 class="text-lg-bold">{{ __('Install Frappe Mail') }}</h2>
 		</template>
-		<template>
+		<template #default>
 			<p>{{ __('Get the app on your device for easy access & a better experience!') }}</p>
 		</template>
 		<template #actions>

--- a/frontend/src/apps/mail/components/Modals/AddAddressBookContactsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddAddressBookContactsModal.vue
@@ -1,6 +1,6 @@
 <template>
 	<Dialog v-model:open="show" v-bind="options">
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl v-model="search" :placeholder="__('Search...')" />
 				<ListView

--- a/frontend/src/apps/mail/components/Modals/AddAddressBookModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddAddressBookModal.vue
@@ -13,7 +13,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="addressBook.name"

--- a/frontend/src/apps/mail/components/Modals/AddContactAddressBookModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddContactAddressBookModal.vue
@@ -1,6 +1,6 @@
 <template>
 	<Dialog v-model:open="show" v-bind="options">
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="addressBook"

--- a/frontend/src/apps/mail/components/Modals/AddContactAddressModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddContactAddressModal.vue
@@ -1,6 +1,6 @@
 <template>
 	<Dialog v-model:open="show" v-bind="options">
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="address.type"

--- a/frontend/src/apps/mail/components/Modals/AddContactEmailModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddContactEmailModal.vue
@@ -1,6 +1,6 @@
 <template>
 	<Dialog v-model:open="show" v-bind="options">
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="email.address"

--- a/frontend/src/apps/mail/components/Modals/AddContactModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddContactModal.vue
@@ -17,7 +17,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="contact.full_name"

--- a/frontend/src/apps/mail/components/Modals/AddContactPhoneModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddContactPhoneModal.vue
@@ -1,6 +1,6 @@
 <template>
 	<Dialog v-model:open="show" v-bind="options">
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl v-model="email.number" type="tel" :label="__('Number')" required />
 				<FormControl

--- a/frontend/src/apps/mail/components/Modals/AddDomainModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddDomainModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<p class="text-p-base">
 					{{

--- a/frontend/src/apps/mail/components/Modals/AddGroupEmailModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddGroupEmailModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<div class="flex items-center justify-between">
 					<FormControl v-model="username" :label="__('Username')" placeholder="team" class="w-full" />

--- a/frontend/src/apps/mail/components/Modals/AddGroupMembersModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddGroupMembersModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-1.5">
 				<label class="text-ink-gray-5 block text-xs">{{ __('Accounts') }}</label>
 				<MultiSelect v-model="accountIds" :options="options" />

--- a/frontend/src/apps/mail/components/Modals/AddGroupModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddGroupModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="name"

--- a/frontend/src/apps/mail/components/Modals/AddMailingListEmailModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddMailingListEmailModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<div class="flex items-center justify-between">
 					<FormControl v-model="username" :label="__('Username')" placeholder="announce" class="w-full" />

--- a/frontend/src/apps/mail/components/Modals/AddMailingListModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddMailingListModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="name"

--- a/frontend/src/apps/mail/components/Modals/AddMailingListRecipientsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddMailingListRecipientsModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<div class="space-y-2">
 					<label class="text-ink-gray-5 block text-xs">{{ __('Recipients') }}</label>

--- a/frontend/src/apps/mail/components/Modals/AddMemberEmailModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddMemberEmailModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<div class="flex items-center justify-between">
 					<FormControl v-model="username" :label="__('Username')" placeholder="johndoe" class="w-full" />

--- a/frontend/src/apps/mail/components/Modals/AddMemberGroupsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddMemberGroupsModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-1.5">
 				<label class="text-ink-gray-5 block text-xs">{{ __('Groups') }}</label>
 				<MultiSelect v-model="groupIds" :options="options" />

--- a/frontend/src/apps/mail/components/Modals/AddMemberMailingListsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddMemberMailingListsModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-1.5">
 				<label class="text-ink-gray-5 block text-xs">{{ __('Mailing Lists') }}</label>
 				<MultiSelect v-model="listIds" :options="options" />

--- a/frontend/src/apps/mail/components/Modals/AddMemberModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddMemberModal.vue
@@ -13,7 +13,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<div class="space-y-3">
 					<div v-for="(email, index) in emails" :key="index" class="space-y-1.5">

--- a/frontend/src/apps/mail/components/Modals/AddOAuthClientModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddOAuthClientModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="clientId"

--- a/frontend/src/apps/mail/components/Modals/AddOAuthContactsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddOAuthContactsModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<div class="space-y-2">
 					<label class="text-ink-gray-5 block text-xs">{{ __('Contacts') }}</label>

--- a/frontend/src/apps/mail/components/Modals/AddOAuthRedirectUrisModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddOAuthRedirectUrisModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<div class="space-y-2">
 					<label class="text-ink-gray-5 block text-xs">{{ __('Redirect URIs') }}</label>

--- a/frontend/src/apps/mail/components/Modals/AddPushSubscriptionModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddPushSubscriptionModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="url"

--- a/frontend/src/apps/mail/components/Modals/AddRoleModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddRoleModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="description"

--- a/frontend/src/apps/mail/components/Modals/AddScreenedSenderModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddScreenedSenderModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="email"

--- a/frontend/src/apps/mail/components/Modals/AddSignatureModal.vue
+++ b/frontend/src/apps/mail/components/Modals/AddSignatureModal.vue
@@ -1,6 +1,6 @@
 <template>
 	<Dialog v-model:open="show" v-bind="addSignatureOptions">
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="signature.doc.signature_name"

--- a/frontend/src/apps/mail/components/Modals/ChangeMemberPasswordModal.vue
+++ b/frontend/src/apps/mail/components/Modals/ChangeMemberPasswordModal.vue
@@ -1,6 +1,6 @@
 <template>
 	<Dialog v-model:open="show" v-bind="dialogOptions">
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="newPassword"

--- a/frontend/src/apps/mail/components/Modals/ChangePasswordModal.vue
+++ b/frontend/src/apps/mail/components/Modals/ChangePasswordModal.vue
@@ -1,6 +1,6 @@
 <template>
 	<Dialog v-model:open="show" v-bind="dialogOptions">
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="currentPassword"

--- a/frontend/src/apps/mail/components/Modals/ContactsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/ContactsModal.vue
@@ -1,6 +1,6 @@
 <template>
 	<Dialog v-model:open="show" v-bind="options">
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="selectFrom"

--- a/frontend/src/apps/mail/components/Modals/EditAddressBookModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditAddressBookModal.vue
@@ -1,6 +1,6 @@
 <template>
 	<Dialog v-model:open="show" v-bind="options">
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="addressBook.name"

--- a/frontend/src/apps/mail/components/Modals/EditContactModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditContactModal.vue
@@ -1,6 +1,6 @@
 <template>
 	<Dialog v-model:open="show" v-bind="options">
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl v-model="contact.fullName" :label="__('Name')" />
 				<FormControl

--- a/frontend/src/apps/mail/components/Modals/EditGroupModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditGroupModal.vue
@@ -13,7 +13,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl v-model="description" :label="__('Description')" />
 				<div class="space-y-1.5">

--- a/frontend/src/apps/mail/components/Modals/EditGroupQuotaModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditGroupQuotaModal.vue
@@ -13,7 +13,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl v-model="quotaGb" type="number" :min="0" :label="__('Quota (GB, 0 = unlimited)')" />
 				<ErrorMessage

--- a/frontend/src/apps/mail/components/Modals/EditInviteModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditInviteModal.vue
@@ -24,7 +24,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					:label="__('Assigned Email')"

--- a/frontend/src/apps/mail/components/Modals/EditMailingListModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditMailingListModal.vue
@@ -13,7 +13,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl v-model="description" :label="__('Description')" />
 				<ErrorMessage

--- a/frontend/src/apps/mail/components/Modals/EditMemberModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditMemberModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl v-model="role" type="select" :label="__('Role')" :options="ROLE_OPTIONS" />
 				<FormControl v-model="description" :label="__('Full Name')" />

--- a/frontend/src/apps/mail/components/Modals/EditMemberQuotaModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditMemberQuotaModal.vue
@@ -13,7 +13,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="quotaGb"

--- a/frontend/src/apps/mail/components/Modals/EditOAuthClientModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditOAuthClientModal.vue
@@ -13,7 +13,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl v-model="clientId" :label="__('Client ID')" autocomplete="off" />
 				<FormControl v-model="description" :label="__('Description')" type="textarea" />

--- a/frontend/src/apps/mail/components/Modals/EditPhotoModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditPhotoModal.vue
@@ -1,6 +1,6 @@
 <template>
 	<Dialog v-model:open="show" v-bind="{ title: __('Edit Photo'), size: 'sm' }">
-		<template>
+		<template #default>
 			<FileUploader
 				class="mb-2 w-full"
 				:file-types="['image/*']"

--- a/frontend/src/apps/mail/components/Modals/EditQueuedMessageModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditQueuedMessageModal.vue
@@ -13,7 +13,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="nextRetry"

--- a/frontend/src/apps/mail/components/Modals/EditQueuedRecipientModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditQueuedRecipientModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-6">
 				<!-- Recipient -->
 				<section class="space-y-3">

--- a/frontend/src/apps/mail/components/Modals/EditRoleModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditRoleModal.vue
@@ -14,7 +14,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="description"

--- a/frontend/src/apps/mail/components/Modals/EditSignatureModal.vue
+++ b/frontend/src/apps/mail/components/Modals/EditSignatureModal.vue
@@ -1,6 +1,6 @@
 <template>
 	<Dialog v-if="signature?.doc" v-model:open="show" v-bind="addSignatureOptions">
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl
 					v-model="signature.doc.signature_name"

--- a/frontend/src/apps/mail/components/Modals/FolderModal.vue
+++ b/frontend/src/apps/mail/components/Modals/FolderModal.vue
@@ -15,7 +15,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<Tabs v-model="tab" :tabs="TABS" class="[&>[role=tablist]]:px-0">
 				<template #tab-panel>
 					<!-- px-0.5: the tab panel is an `overflow-auto` scroll container, and a focus ring

--- a/frontend/src/apps/mail/components/Modals/RunActionModal.vue
+++ b/frontend/src/apps/mail/components/Modals/RunActionModal.vue
@@ -1,6 +1,6 @@
 <template>
 	<Dialog v-model:open="show" v-bind="dialogOptions">
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<template v-for="field in fields" :key="field.name">
 					<!-- A set-valued input (e.g. the recipients): one row per entry. -->

--- a/frontend/src/apps/mail/components/Modals/ScheduleSendModal.vue
+++ b/frontend/src/apps/mail/components/Modals/ScheduleSendModal.vue
@@ -1,6 +1,6 @@
 <template>
 	<Dialog v-model:open="show" v-bind="dialogOptions">
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<div class="flex flex-col gap-1">
 					<button

--- a/frontend/src/apps/mail/components/Modals/SearchModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SearchModal.vue
@@ -6,7 +6,7 @@
 		v-bind="{ size: '2xl', paddingTop: '2%' }"
 		:bare="!isMobile"
 	>
-		<template>
+		<template #default>
 			<div class="bg-surface-base">
 				<div class="flex items-center border-b px-4 py-2">
 					<!-- Mobile trades the decorative magnifier for the way out: search is a

--- a/frontend/src/apps/mail/components/Modals/SetDefaultSignatureModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SetDefaultSignatureModal.vue
@@ -1,6 +1,6 @@
 <template>
 	<Dialog v-model:open="show" v-bind="addSignatureOptions">
-		<template>
+		<template #default>
 			<FormControl
 				v-model="identity"
 				type="combobox"

--- a/frontend/src/apps/mail/components/Modals/ShortcutsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/ShortcutsModal.vue
@@ -1,6 +1,6 @@
 <template>
 	<Dialog v-bind="{ title: __('Shortcuts'), size: '5xl' }">
-		<template>
+		<template #default>
 			<div class="grid max-h-[75vh] w-full grid-cols-2 gap-10 overflow-y-auto py-1">
 				<div v-for="(column, index) in shortcutGroups" :key="index">
 					<div v-for="group in column" :key="group.title" class="pb-8">

--- a/frontend/src/apps/mail/components/Modals/SieveScriptModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SieveScriptModal.vue
@@ -15,7 +15,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<div class="space-y-4">
 				<FormControl v-model="script._name" :label="__('Script Name')" required />
 				<div class="space-y-1.5">

--- a/frontend/src/apps/mail/components/SendMail.vue
+++ b/frontend/src/apps/mail/components/SendMail.vue
@@ -10,15 +10,15 @@
 	     row whose first half is `flex-1` — so it lands flush against ours, and the three read as
 	     8px, 8px, nothing. One row, one gap.
 
-	     `show-close-button` is a prop, not an option: Dialog resolves every other key as
-	     `props.x ?? options.x` but this one only reads the prop, so in `:options` it is dropped
-	     and the built-in close comes back. -->
+	     The title is passed as a prop as well as drawn in the slot: the slot is what renders, and
+	     the prop is what the overlay labels itself with (`data-dialog`). -->
 	<Dialog
 		v-if="state === 'modal'"
 		v-model:open="show"
+		:title="__('Compose Mail')"
+		size="5xl"
 		:show-close-button="false"
 		:dismissible="false"
-	 v-bind="{ title: __('Compose Mail'), size: '5xl' }"
 	>
 		<template #title="{ close }">
 			<div class="flex items-center gap-2">
@@ -51,7 +51,7 @@
 				</Button>
 			</div>
 		</template>
-		<template>
+		<template #default>
 			<div ref="host" class="flex min-h-0 flex-1 flex-col" />
 		</template>
 	</Dialog>

--- a/frontend/src/apps/mail/components/Settings/AdvancedSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/AdvancedSettings.vue
@@ -18,7 +18,7 @@
 			/>
 
 			<Dialog v-model:open="showSecret" v-bind="{ title: __('API Access') }">
-				<template>
+				<template #default>
 					<p class="text-base">
 						{{
 							__(`Please copy the API secret now. You won’t be able to see it again!`)

--- a/frontend/src/apps/mail/components/Settings/IdentitySettings.vue
+++ b/frontend/src/apps/mail/components/Settings/IdentitySettings.vue
@@ -123,7 +123,7 @@
 					],
 				}"
 			>
-				<template>
+				<template #default>
 					<FormControl
 						v-model="email"
 						:label="__('Email')"
@@ -158,7 +158,7 @@
 			],
 		}"
 	>
-		<template>
+		<template #default>
 			<FormControl
 				v-model="newEmail"
 				:label="__('Email')"

--- a/frontend/src/apps/mail/pages/dashboard/QueuedMessageView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/QueuedMessageView.vue
@@ -74,7 +74,7 @@
 	/>
 	<Dialog v-model:open="showCancel" v-bind="cancelDialogOptions" />
 	<Dialog v-model:open="showSource" v-bind="{ title: __('Message Source'), size: '4xl' }">
-		<template>
+		<template #default>
 			<pre
 				v-if="source.data"
 				class="bg-surface-gray-2 max-h-[70vh] overflow-auto rounded-4 p-4 text-xs whitespace-pre-wrap"


### PR DESCRIPTION
Every mail modal — compose included — was rendering as just its header. The frappe-ui v1 migration (#663) rewrote `<template #body-content>` as a bare `<template>`, and Vue doesn't read a directive-less `<template>` as the default slot: it compiles to a literal `<template>` element, whose children the browser never renders.

Names the slot — `<template #default>` — in all 54 dialogs. Also fixes the mangled `v-bind="{ title, size }"` line the migration left in `SendMail.vue`.