### PR TITLE
feat(calendar): draft and declined events, and a week-aware header

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,7 +72,7 @@
     "feather-icons": "^4.29.2",
     "file-saver": "^2.0.5",
     "firebase": "^12.2.1",
-    "frappe-ui": "frappe/frappe-ui#c2fce39bcb5ee5514e709fc6b16f9de2caed302c",
+    "frappe-ui": "frappe/frappe-ui#a89a95fa902e18f71d01c369ad92e5cb9d3ec954",
     "fuzzysort": "^3.1.0",
     "gemoji": "^8.1.0",
     "hast-util-to-html": "^9.0.5",

--- a/frontend/src/apps/calendar/components/AppSidebar.vue
+++ b/frontend/src/apps/calendar/components/AppSidebar.vue
@@ -67,7 +67,7 @@ const upcoming = computed(() => {
 	const today = current.format('YYYY-MM-DD')
 	return (events || [])
 		.filter((event) => {
-			if (event.status === 'Cancelled') return false
+			if (event.status === 'Cancelled' || event.isDeclined) return false
 			if (event.fromDate > today || event.toDate < today) return false
 			// An all-day event covers the whole of today; a timed one is over once its end has passed.
 			return event.isAllDay || dayjs(`${event.toDate} ${event.toTime}`).isAfter(current)

--- a/frontend/src/apps/calendar/components/EventDetailSidebar.vue
+++ b/frontend/src/apps/calendar/components/EventDetailSidebar.vue
@@ -16,7 +16,7 @@ import {
 	Users,
 	X,
 } from 'lucide-vue-next'
-import { Button, Dialog, Dropdown, TabButtons, createResource, toast } from 'frappe-ui'
+import { Badge, Button, Dialog, Dropdown, TabButtons, createResource, toast } from 'frappe-ui'
 import DOMPurify from 'dompurify'
 
 import meetLogo from '@/assets/app-logos/meet.png'
@@ -343,7 +343,8 @@ const confirmDelete = (submit: (sendEmail: boolean) => Promise<any>, recurring: 
 		})
 	}
 
-	if (isOrganizer.value && hasParticipantsOtherThanUser.value) {
+	// A draft never sent its invitations, so there is no one to tell it is gone.
+	if (isOrganizer.value && hasParticipantsOtherThanUser.value && !calendarEvent.isDraft) {
 		pendingDelete.value = run
 		showNotifyModal.value = true
 	} else {
@@ -465,8 +466,9 @@ const openUrl = (location: string) => {
 					<h3 class="text-ink-gray-8 break-words text-md font-semibold leading-6">
 						{{ calendarEvent.title || __('Untitled event') }}
 					</h3>
-					<div class="text-ink-gray-6 break-words text-sm">
-						{{ dateLabel }}
+					<div class="flex items-center gap-2 text-sm text-ink-gray-6">
+						<Badge v-if="calendarEvent.isDraft" theme="gray" :label="__('Draft')" />
+						<span class="break-words">{{ dateLabel }}</span>
 					</div>
 				</div>
 			</div>

--- a/frontend/src/apps/calendar/components/MiniMonth.vue
+++ b/frontend/src/apps/calendar/components/MiniMonth.vue
@@ -120,6 +120,8 @@ const loadOn = (key: string) => {
 	let load = 0
 	const colors: string[] = []
 	for (const event of props.events) {
+		// Density answers "how busy am I": a draft claims the time, a decline does not.
+		if (event.isDeclined) continue
 		if (event.fromDate > key || event.toDate < key) continue
 		load++
 		const color = event.color || 'green'

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, inject, nextTick, reactive, ref, watch } from 'vue'
-import { AlignLeft, Bell, Briefcase, Clock, Copy, MapPin, Users, X } from 'lucide-vue-next'
+import { AlignLeft, Bell, Briefcase, ChevronDown, Clock, Copy, MapPin, Users, X } from 'lucide-vue-next'
 import { Button, Dialog, Dropdown, FormControl, Switch, createResource, toast } from 'frappe-ui'
 
 import meetLogo from '@/assets/app-logos/meet.png'
@@ -22,6 +22,12 @@ const store = userStore()
 const { participantIdentities } = store
 
 const isNew = computed(() => !selectedEvent?.calendarEvent)
+// A saved draft: the server holds it but has sent nothing. Only a new event can become
+// one (the server refuses to turn a published event back into a draft), and saving it
+// as a draft again or publishing it are the two ways out of the modal.
+const isDraft = computed(() => !!selectedEvent?.calendarEvent?.isDraft)
+// Set for the length of one save: the resources read it into `draft`.
+const savingDraft = ref(false)
 
 // --- Event initialization ---
 
@@ -359,6 +365,7 @@ const createEvent = createResource({
 	makeParams: ({ sendEmail }: { sendEmail: boolean }) => ({
 		account: store.accountId,
 		...eventParams.value,
+		draft: savingDraft.value,
 		send_scheduling_messages: sendEmail,
 	}),
 	onSuccess: handleSuccess,
@@ -394,6 +401,7 @@ const editEvent = createResource({
 		id: selectedEvent.calendarEvent.master_id || selectedEvent.calendarEvent.id,
 		uid: selectedEvent.calendarEvent.uid,
 		...eventParams.value,
+		draft: savingDraft.value,
 		send_scheduling_messages: sendEmail,
 	}),
 	onSuccess: handleSuccess,
@@ -415,9 +423,11 @@ const submitEvent = (sendEmail: boolean) => {
 		: isInstance
 			? editEventInstance
 			: editEvent
-	const messages = isNew.value
-		? { loading: __('Creating event...'), success: __('Event created.') }
-		: { loading: __('Updating event...'), success: __('Event updated.') }
+	const messages = isDraft.value
+		? { loading: __('Sending event...'), success: __('Event sent.') }
+		: isNew.value
+			? { loading: __('Creating event...'), success: __('Event created.') }
+			: { loading: __('Updating event...'), success: __('Event updated.') }
 
 	// Attaching a Meet link to an existing event: mint the room first, then send the
 	// regular update with the link included (creation bundles this server-side).
@@ -438,6 +448,76 @@ const submitEvent = (sendEmail: boolean) => {
 		error: __('Action failed. Please try again in some time.'),
 	})
 	showNotifyParticipantsModal.value = false
+}
+
+// --- Leaving the modal ---
+//
+// Draft is not a button; it is what happens when you leave without sending,
+// the way mail's compose keeps what you typed. Cancel means "throw this away"
+// and asks first only if there is something to throw away. ✕, Escape and a
+// click outside mean "keep": a new event or a draft is saved as a draft with
+// a toast that can undo it. A published event cannot go back to being a
+// draft, so unsent edits there get the same question Cancel asks.
+
+const isDirty = computed(
+	() => Object.keys(patch.value).length > 0 || pendingMeetAttach.value,
+)
+
+const showDiscardModal = ref(false)
+
+const cancel = () => {
+	if (isDirty.value) showDiscardModal.value = true
+	else show.value = false
+}
+
+const discardChanges = () => {
+	showDiscardModal.value = false
+	show.value = false
+}
+
+const leave = () => {
+	if (!isDirty.value) {
+		show.value = false
+		return
+	}
+	if (isNew.value || isDraft.value) saveDraftAndLeave()
+	else showDiscardModal.value = true
+}
+
+const discardDraft = createResource({
+	url: 'suite.calendar.doctype.calendar_event.calendar_event.delete_calendar_events',
+	makeParams: ({ id }: { id: string }) => ({
+		account: store.accountId,
+		ids: [id],
+		send_scheduling_messages: false,
+	}),
+	onSuccess: () => {
+		toast.success(__('Draft discarded.'))
+		emit('reloadEvents')
+	},
+})
+
+const saveDraftAndLeave = async () => {
+	if (!isDateTimeValid.value) {
+		// Nothing the server would keep; the form's own validation says why.
+		showDiscardModal.value = true
+		return
+	}
+	savingDraft.value = true
+	try {
+		// The plain create/update: a draft has no Meet room and no per-instance edit.
+		const result = await (isNew.value ? createEvent : editEvent).submit({ sendEmail: false })
+		const id = isNew.value
+			? result
+			: selectedEvent.calendarEvent.master_id || selectedEvent.calendarEvent.id
+		toast.success(__('Draft saved.'), {
+			action: { label: __('Discard'), onClick: () => discardDraft.submit({ id }) },
+		})
+	} catch {
+		toast.error(__('Could not save the draft. Please try again.'))
+	} finally {
+		savingDraft.value = false
+	}
 }
 
 const showNotifyParticipantsModal = ref(false)
@@ -497,20 +577,45 @@ const addAlertOptions = computed(() => [
 
 // --- Dialog options ---
 
+const isSaving = computed(
+	() =>
+		createEvent.loading || editEvent.loading || editEventInstance.loading || createMeetEvent.loading,
+)
+
 const disableSave = computed(() => {
-	if (createEvent.loading || editEvent.loading || editEventInstance.loading) return true
-	if (createMeetEvent.loading) return true
+	if (isSaving.value) return true
 	if (!isDateTimeValid.value) return true
+	// Publishing a draft is a change in itself, even with nothing else edited.
+	if (isDraft.value) return false
 	if (!isNew.value && !Object.keys(patch.value).length && !pendingMeetAttach.value) return true
 	return false
 })
+
+// The primary says what it does: "Send" while there are invitations to send —
+// a new event or a draft with participants — and "Save" otherwise.
+// The primary says what it does: "Send" while there are invitations to send
+// (a new event or a draft with participants), "Save" otherwise. A new event
+// or a draft can also be kept as a draft — the split beside the primary, as
+// mail's compose has it; a published event cannot go back to being one, so
+// it gets a plain button.
+const primaryLabel = computed(() =>
+	(isNew.value || isDraft.value) && hasParticipantsOtherThanUser(event.participants)
+		? __('Send')
+		: __('Save'),
+)
+const canSaveDraft = computed(() => isNew.value || isDraft.value)
+const draftOptions = computed(() => [
+	{ label: __('Save as draft'), icon: 'lucide-file-pen-line', onClick: saveDraftAndLeave },
+])
 
 const handleSaveClick = () => {
 	if (shouldShowRecurringEventModal.value) showRecurringEventModal.value = true
 	else handleSave()
 }
 
-const dialogTitle = computed(() => (isNew.value ? __('Add Event') : __('Edit Event')))
+const dialogTitle = computed(() =>
+	isNew.value ? __('Add Event') : isDraft.value ? __('Edit Draft') : __('Edit Event'),
+)
 
 const AVAILABILITY_OPTIONS = [
 	{ label: __('Free'), value: 'Free' },
@@ -525,9 +630,18 @@ const VISIBILITY_OPTIONS = [
 const showNotifyParticipantsOptions = computed(() => ({
 	title: __('Notify Participants'),
 	icon: { name: 'lucide-bell' },
+	message:
+		isNew.value || isDraft.value
+			? __("Send an email to let attendees know they've been invited?")
+			: __('Send an email to let attendees know this event has been updated?'),
+}))
+
+const DISCARD_MODAL_OPTIONS = computed(() => ({
+	title: __('Discard changes?'),
+	icon: { name: 'lucide-trash-2' },
 	message: isNew.value
-		? __("Send an email to let attendees know they've been invited?")
-		: __('Send an email to let attendees know this event has been updated?'),
+		? __('This event has not been saved and will be lost.')
+		: __('Your unsaved edits to this event will be lost.'),
 }))
 
 const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
@@ -538,13 +652,13 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 </script>
 
 <template>
-	<Dialog v-model:open="show" size="4xl" bare>
-		<template #default="{ close }">
+	<Dialog :open="show" size="4xl" bare @update:open="(open) => (open ? (show = true) : leave())">
+		<template #default>
 			<div class="flex max-h-[85vh] flex-col text-ink-gray-8">
 				<!-- header -->
 				<div class="flex items-center border-b px-6 py-4">
 					<span class="text-md font-semibold">{{ dialogTitle }}</span>
-					<Button variant="ghost" class="ml-auto" @click="close">
+					<Button variant="ghost" class="ml-auto" @click="leave">
 						<template #icon><X :size="18" class="icon text-ink-gray-5" /></template>
 					</Button>
 				</div>
@@ -751,14 +865,29 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 
 				<!-- footer -->
 				<div class="flex justify-end gap-2 border-t px-6 py-3.5">
-					<Button :label="__('Cancel')" variant="outline" @click="close" />
-					<Button
-						:label="__('Save')"
-						variant="solid"
-						:disabled="disableSave"
-						class="w-16"
-						@click="handleSaveClick"
-					/>
+					<Button :label="__('Cancel')" variant="outline" @click="cancel" />
+					<!-- Split button, as mail's compose: one pill, the 1px gap shows the
+					     footer background as the divider. -->
+					<div class="flex items-center gap-px">
+						<Button
+							:label="primaryLabel"
+							variant="solid"
+							:disabled="disableSave"
+							class="min-w-16"
+							:class="canSaveDraft && '!rounded-r-none'"
+							@click="handleSaveClick"
+						/>
+						<Dropdown v-if="canSaveDraft" :options="draftOptions">
+							<Button
+								variant="solid"
+								class="!rounded-l-none"
+								:disabled="isSaving || !isDateTimeValid"
+								:aria-label="__('More save options')"
+							>
+								<template #icon><ChevronDown class="h-4 w-4" /></template>
+							</Button>
+						</Dropdown>
+					</div>
 				</div>
 			</div>
 		</template>
@@ -770,6 +899,14 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 		:r-rule="event?.recurrence_rule"
 		@update-recurrence-rule="(val) => (event.recurrence_rule = val)"
 	/>
+	<Dialog v-model:open="showDiscardModal" v-bind="DISCARD_MODAL_OPTIONS">
+		<template #actions>
+			<div class="flex justify-end space-x-2">
+				<Button :label="__('Keep editing')" @click="showDiscardModal = false" />
+				<Button :label="__('Discard')" variant="solid" theme="red" @click="discardChanges" />
+			</div>
+		</template>
+	</Dialog>
 	<Dialog v-model:open="showRecurringEventModal" v-bind="SHOW_RECURRING_EVENT_MODAL_OPTIONS">
 		<template #actions>
 			<div class="flex justify-end space-x-2">

--- a/frontend/src/apps/calendar/pages/CalendarView.vue
+++ b/frontend/src/apps/calendar/pages/CalendarView.vue
@@ -265,6 +265,22 @@ const splitYear = (title: string) => {
 	return match ? { label: match[1], year: match[2] } : { label: title, year: '' }
 }
 
+// The period the calendar is showing, as it reports it on every change of view or date.
+const visibleRange = ref<{ view: string; startDate: string; endDate: string } | null>(null)
+
+// The header names the period in view: the month for Month, the day for Day (the
+// calendar's own title serves both), and for Week the days themselves — "Aug 23 – 29",
+// or "Aug 30 – Sep 5" when the week straddles two months — rather than a month the
+// week only partly belongs to.
+const headerTitle = (title: string) => {
+	const range = visibleRange.value
+	if (range?.view !== 'Week') return splitYear(title)
+	const start = dayjs(range.startDate)
+	const end = dayjs(range.endDate)
+	const endLabel = end.isSame(start, 'month') ? end.format('D') : end.format('MMM D')
+	return { label: `${start.format('MMM D')} – ${endLabel}`, year: end.format('YYYY') }
+}
+
 // A pill in the grid and a row in the sidebar's upcoming list toggle the
 // detail panel the way mail's does: a second click on the open event closes it.
 const toggleEventDetail = (calendarEvent) => {
@@ -474,28 +490,39 @@ const NOTIFY_MODAL_OPTIONS = {
 					:on-dbl-click="(event) => handleOpenEvent(event)"
 					:on-cell-click="(event) => handleOpenEvent(event)"
 					@update="handleUpdate"
+					@range-change="(range) => (visibleRange = range)"
 				>
 					<!-- The month is a label, not a picker: the sidebar's mini month is
 					     where a date gets chosen. The year sits beside it, muted. -->
 					<template
 						#header="{ currentMonthYear, enabledModes, activeView, decrement, increment, updateActiveView, setCalendarDate }"
 					>
+						<!-- Navigation leads: back, Today, forward, then the title they change,
+						     so the title's length moves nothing. New event sits at the far
+						     right, past the view switcher. -->
 						<div class="mb-2 flex items-center justify-between">
-							<div class="flex items-baseline gap-1.5 px-2 text-lg leading-5">
-								<span class="font-medium text-ink-gray-9">{{ splitYear(currentMonthYear).label }}</span>
-								<span v-if="splitYear(currentMonthYear).year" class="text-ink-gray-4">
-									{{ splitYear(currentMonthYear).year }}
-								</span>
-							</div>
-							<div class="flex gap-x-1">
+							<div class="flex items-center gap-x-1">
 								<Button variant="ghost" icon="lucide-chevron-left" @click="decrement" />
 								<Button variant="ghost" :label="__('Today')" @click="setCalendarDate()" />
 								<Button variant="ghost" icon="lucide-chevron-right" @click="increment" />
+								<div class="flex items-baseline gap-1.5 px-2 text-lg leading-5">
+									<span class="font-medium text-ink-gray-9">{{ headerTitle(currentMonthYear).label }}</span>
+									<span v-if="headerTitle(currentMonthYear).year" class="text-ink-gray-4">
+										{{ headerTitle(currentMonthYear).year }}
+									</span>
+								</div>
+							</div>
+							<div class="flex items-center gap-x-2">
 								<TabButtons
-									class="ml-2"
 									:options="enabledModes"
 									:model-value="activeView"
 									@update:model-value="(view) => updateActiveView(view)"
+								/>
+								<Button
+									variant="solid"
+									icon-left="lucide-calendar-plus"
+									:label="__('Event')"
+									@click="handleOpenEvent({ date: new Date() })"
 								/>
 							</div>
 						</div>

--- a/frontend/src/apps/calendar/pages/CalendarView.vue
+++ b/frontend/src/apps/calendar/pages/CalendarView.vue
@@ -291,6 +291,22 @@ const headerTitle = (title: string) => {
 	return { label: `${start.format('MMM D')} – ${endLabel}`, year: end.format('YYYY') }
 }
 
+// The header's "+ Event" opens on the period in view: starting an event while
+// looking at next week should land in next week. Today wins whenever it is on
+// screen, so the ordinary case still gets the modal's next-hour default.
+const newEventDate = () => {
+	const range = visibleRange.value
+	if (!range) return new Date()
+
+	const today = dayjs().format('YYYY-MM-DD')
+	if (today >= range.startDate && today <= range.endDate) return new Date()
+
+	// The Month strip's first week reaches back into the month before it, so a
+	// month in view opens on its own 1st rather than on the strip's first day.
+	const start = dayjs(range.startDate)
+	return range.view === 'Month' ? start.add(1, 'week').startOf('month').toDate() : start.toDate()
+}
+
 // A pill in the grid and a row in the sidebar's upcoming list toggle the
 // detail panel the way mail's does: a second click on the open event closes it.
 const toggleEventDetail = (calendarEvent) => {
@@ -533,7 +549,7 @@ const NOTIFY_MODAL_OPTIONS = {
 									variant="solid"
 									icon-left="lucide-calendar-plus"
 									:label="__('Event')"
-									@click="handleOpenEvent({ date: new Date() })"
+									@click="handleOpenEvent({ date: newEventDate() })"
 								/>
 							</div>
 						</div>

--- a/frontend/src/apps/calendar/pages/CalendarView.vue
+++ b/frontend/src/apps/calendar/pages/CalendarView.vue
@@ -146,6 +146,9 @@ const transformEvent = (event) => {
 		role: getEventRole(event),
 		isAllDay,
 		isFullDay: isAllDay,
+		// The server's `draft` (JMAP isDraft): saved, but nothing sent. The pill draws it
+		// as an outline.
+		isDraft: !!event.draft,
 	}
 }
 
@@ -396,7 +399,8 @@ const handleUpdateRecurringEvent = (updateInstance: boolean) => {
 }
 
 const handleUpdateEvent = () => {
-	if (hasParticipantsOtherThanUser.value) showNotifyModal.value = true
+	// A draft has sent nothing, so there is no one to notify of a move.
+	if (hasParticipantsOtherThanUser.value && !eventToBeUpdated.isDraft) showNotifyModal.value = true
 	else submitEvent(false)
 }
 

--- a/frontend/src/apps/calendar/pages/CalendarView.vue
+++ b/frontend/src/apps/calendar/pages/CalendarView.vue
@@ -149,8 +149,15 @@ const transformEvent = (event) => {
 		// The server's `draft` (JMAP isDraft): saved, but nothing sent. The pill draws it
 		// as an outline.
 		isDraft: !!event.draft,
+		// The viewer declined: struck through in the grid.
+		isDeclined: !!event.participants?.some(
+			(p) => p.participation_status === 'DECLINED' && isOwnEmail(p.email),
+		),
 	}
 }
+
+const isOwnEmail = (email: string) =>
+	!!participantIdentities.data?.some((id) => id.email === email?.replace('mailto:', ''))
 
 const getEventRole = (event) => {
 	if (participantIdentities.data?.some((id) => id.email === event.organizer.replace('mailto:', '')))

--- a/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
+++ b/frontend/src/apps/mail/components/mobile/MobileTabBar.vue
@@ -20,7 +20,7 @@
 		@click="openCompose"
 	>
 		<template #icon>
-			<FeatherIcon name="edit" class="h-6 w-6" />
+			<FeatherIcon name="square-pen" class="h-6 w-6" />
 		</template>
 	</Button>
 

--- a/frontend/src/apps/mail/pages/dashboard/ActionsView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/ActionsView.vue
@@ -97,16 +97,16 @@ const ACTION_FIELDS: Record<string, ActionField[]> = {
 
 // Icon per action, falling back to the section's icon for any action the server adds later.
 const ACTION_ICONS: Record<string, string> = {
-	ReloadSettings: 'sliders',
+	ReloadSettings: 'sliders-horizontal',
 	ReloadTlsCertificates: 'shield',
 	ReloadLookupStores: 'database',
 	ReloadBlockedIps: 'shield-off',
-	UpdateApps: 'download-cloud',
-	TroubleshootDmarc: 'tool',
-	ClassifySpam: 'filter',
+	UpdateApps: 'cloud-download',
+	TroubleshootDmarc: 'wrench',
+	ClassifySpam: 'funnel',
 	InvalidateCaches: 'trash-2',
 	InvalidateNegativeCaches: 'trash',
-	PauseMtaQueue: 'pause-circle',
+	PauseMtaQueue: 'circle-pause',
 	ResumeMtaQueue: 'play-circle',
 }
 const SECTION_ICONS: Record<string, string> = {
@@ -114,7 +114,7 @@ const SECTION_ICONS: Record<string, string> = {
 	Cache: 'trash-2',
 	MTA: 'send',
 	DMARC: 'shield',
-	'Spam Filter': 'filter',
+	'Spam Filter': 'funnel',
 	'Application Management': 'package',
 }
 const FALLBACK_ICON = 'zap'

--- a/frontend/src/apps/sheets/components/SheetEditor/ChartDialog.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/ChartDialog.vue
@@ -204,10 +204,10 @@ import { CHART_TYPES, CHART_PALETTES, ESPRESSO_PALETTE, CHART_AGGREGATIONS } fro
 
 const CHART_ICONS = {
   line:    'trending-up',
-  bar:     'bar-chart-2',
+  bar:     'chart-column',
   area:    'activity',
-  pie:     'pie-chart',
-  scatter: 'git-commit',
+  pie:     'chart-pie',
+  scatter: 'git-commit-horizontal',
 }
 
 const props = defineProps({

--- a/frontend/src/apps/sheets/components/SheetEditor/ChartOverlay.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/ChartOverlay.vue
@@ -29,7 +29,7 @@
       <!-- Action bar (visible while selected) -->
       <div v-if="selectedId === chart.id" class="co-actions" @mousedown.stop>
         <button class="co-action" title="Edit chart" @click="$emit('edit', chart.id)">
-          <FeatherIcon name="edit-2" class="co-action-icon" />
+          <FeatherIcon name="pencil" class="co-action-icon" />
         </button>
         <button class="co-action" title="Refresh data" @click="$emit('refresh', chart.id)">
           <FeatherIcon name="refresh-cw" class="co-action-icon" />

--- a/frontend/src/apps/sheets/components/SheetEditor/PivotDialog.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/PivotDialog.vue
@@ -40,7 +40,7 @@
         <!-- Rows -->
         <div class="pv-bucket">
           <p class="pv-bucket-label">
-            <FeatherIcon name="align-left" class="pv-bucket-icon" /> Rows
+            <FeatherIcon name="text-align-start" class="pv-bucket-icon" /> Rows
           </p>
           <div class="pv-bucket-body">
             <div v-for="f in rowFields" :key="f" class="pv-chip">
@@ -60,7 +60,7 @@
         <!-- Columns -->
         <div class="pv-bucket">
           <p class="pv-bucket-label">
-            <FeatherIcon name="columns" class="pv-bucket-icon" /> Columns
+            <FeatherIcon name="columns-2" class="pv-bucket-icon" /> Columns
           </p>
           <div class="pv-bucket-body">
             <div v-for="f in colFields" :key="f" class="pv-chip">

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -522,7 +522,7 @@
       <Dropdown v-if="activePivotConfig && pivotFabStyle" :options="pivotBannerMenuOptions">
         <template #default="{ open }">
           <button class="sn-pivot-fab" :class="{ open }" :style="pivotFabStyle" title="Pivot table options">
-            <FeatherIcon name="edit-2" class="sn-pivot-fab-icon" />
+            <FeatherIcon name="pencil" class="sn-pivot-fab-icon" />
           </button>
         </template>
       </Dropdown>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4708,9 +4708,9 @@ fraction.js@^5.3.4:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-5.3.4.tgz#8c0fcc6a9908262df4ed197427bdeef563e0699a"
   integrity sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==
 
-frappe-ui@frappe/frappe-ui#c2fce39bcb5ee5514e709fc6b16f9de2caed302c:
+frappe-ui@frappe/frappe-ui#a89a95fa902e18f71d01c369ad92e5cb9d3ec954:
   version "1.0.0-beta.55"
-  resolved "https://codeload.github.com/frappe/frappe-ui/tar.gz/c2fce39bcb5ee5514e709fc6b16f9de2caed302c"
+  resolved "https://codeload.github.com/frappe/frappe-ui/tar.gz/a89a95fa902e18f71d01c369ad92e5cb9d3ec954"
   dependencies:
     "@codemirror/lang-css" "^6.3.0"
     "@codemirror/lang-html" "^6.4.9"


### PR DESCRIPTION
The dashed draft pill and the declined layout are drawn in frappe/frappe-ui#1109, now merged; the `frappe-ui` pin is bumped to it here.

## Draft events

The server already keeps a JMAP draft (saved, nothing sent) and enforces the rules: only a new event can become one, and drafts send no scheduling messages. The UI now uses it, on mail compose's contract.

- The primary button says what it does: **Send** while there are invitations to send, **Save** otherwise. A new event or an existing draft gets a split beside it with **Save as draft**; a published event cannot go back, so it does not.
- Cancel is discard, and asks first only if the form is dirty. ✕, Escape and a click outside keep instead: the draft is saved and a "Draft saved" toast offers Discard, which deletes it.
- Drafts draw as a dashed outline in the grid, wear a Draft badge in the detail panel, and never prompt to notify participants on move or delete.

## Declined events

An event one of the user's identities has declined keeps its fill and colour bar, but its title is struck through and muted, and overlapping events in the Week and Day views lay out as if it were not there. The sidebar's "later today" list and the mini month's density skip it — a decline claims no time.

## Calendar header

The Week view is titled by its days ("Aug 23 – 29", "Aug 30 – Sep 5"), read from the range the calendar reports, rather than a month the week only partly belongs to. The arrows and Today lead the row, so the title's length moves nothing; the view switcher and a new **+ Event** button sit at the right.

## Riding along, unrelated

`fix(frontend): rename the sprite icons lucide no longer ships` — lucide-static 1.31 renamed `edit`, `edit-2`, `filter`, `sliders`, `tool`, the chart types and more, so those pills rendered nothing across mail and sheets; mail's compose FAB was the first one noticed. Happy to split it into its own PR if you'd rather.
