### PR TITLE
fix: frappe-ui update fallout — tabs, mobile search, and the details chevron

### DIFF
--- a/frontend/src/apps/drive/components/Settings/UserListSettings.vue
+++ b/frontend/src/apps/drive/components/Settings/UserListSettings.vue
@@ -36,9 +36,9 @@
         <div>You have an invite to join this Drive.</div>
       </div>
     </Alert>
-    <Tabs v-model="tabIndex" :tabs>
+    <Tabs v-model="tab" :tabs>
       <template #tab-panel="{ tab }">
-        <template v-if="tab.label === 'Members'">
+        <template v-if="tab.value === 'members'">
           <div class="flex flex-col overflow-y-auto divide-y divide-outline-elevation-2">
             <div
               v-for="user in siteUsers?.data"
@@ -183,7 +183,7 @@ import Alert from '@/apps/drive/components/Alert.vue'
 import UserTooltip from '@/apps/drive/components/UserTooltip.vue'
 
 const currentUserId = computed(() => useSessionStore().user)
-const tabIndex = ref(0)
+const tab = ref('members')
 
 siteUsers.fetch()
 const invites = createResource({
@@ -200,17 +200,20 @@ const invited = ref([])
 const emailInput = ref('')
 const showInvite = ref(false)
 
+// iconLeft, not icon: `icon` makes an icon-only trigger and drops the label.
 const tabs = computed(() => [
   {
+    value: 'members',
     label: 'Members',
-    icon: h(LucideUsers, { class: 'size-4' }),
+    iconLeft: h(LucideUsers, { class: 'size-4' }),
   },
   // Invite management is admin-only.
   ...(isAdmin.data?.is_admin
     ? [
         {
+          value: 'invites',
           label: 'Invites',
-          icon: h(LucideMail, { class: 'size-4' }),
+          iconLeft: h(LucideMail, { class: 'size-4' }),
         },
       ]
     : []),

--- a/frontend/src/apps/drive/ui/drive/components/MoveDialog.vue
+++ b/frontend/src/apps/drive/ui/drive/components/MoveDialog.vue
@@ -192,9 +192,10 @@ const tree = reactive({
 const selected = ref('')
 const breadcrumbs = ref([{ name: '', file_name: 'Home' }])
 
+// iconLeft, not icon: `icon` makes an icon-only trigger and drops the label.
 const tabs = computed(() => [
-  { label: 'Home', value: 'home', icon: h(LucideHome, { class: 'size-4' }) },
-  { label: 'Site', value: 'site', icon: h(LucideBuilding2, { class: 'size-4' }) },
+  { label: 'Home', value: 'home', iconLeft: h(LucideHome, { class: 'size-4' }) },
+  { label: 'Site', value: 'site', iconLeft: h(LucideBuilding2, { class: 'size-4' }) },
 ])
 
 const folderContents = createResource({

--- a/frontend/src/apps/mail/components/MailDetailsPopover.vue
+++ b/frontend/src/apps/mail/components/MailDetailsPopover.vue
@@ -4,8 +4,13 @@
 			<!-- mt-px: the row centers this 14px glyph on a stated 16px (leading-4) line
 			     box, but 13px lowercase text's optical center sits ~1px below the box's
 			     geometric center — the same arithmetic as the remote-images banner icon. -->
+			<!-- click.stop: the thread's header row toggles the mail collapsed, and
+			     the trigger sits inside it — without this the click opened the
+			     popover and immediately collapsed the row out from under it. reka's
+			     as-child merges its own click handler, so the popover still toggles. -->
 			<ChevronDown
 				class="text-ink-gray-5 hover:bg-surface-gray-2 mt-px h-3.5 w-3.5 cursor-pointer rounded-1"
+				@click.stop
 			/>
 		</template>
 		<template #default>

--- a/frontend/src/apps/mail/components/Modals/FolderModal.vue
+++ b/frontend/src/apps/mail/components/Modals/FolderModal.vue
@@ -16,15 +16,17 @@
 		}"
 	>
 		<template #default>
-			<Tabs v-model="tab" :tabs="TABS" class="[&>[role=tablist]]:px-0">
-				<template #tab-panel>
+			<Tabs v-model="tab" :tabs="TABS">
+				<!-- Tabs renders a panel per tab and shows the selected one, so the body
+				     keys off the panel's own tab rather than the model. -->
+				<template #tab-panel="{ tab: panel }">
 					<!-- px-0.5: the tab panel is an `overflow-auto` scroll container, and a focus ring
 					     is a box-shadow — which is clipped by an overflowing ancestor rather than
 					     scrolled to. A full-width control therefore had its ring shaved off both sides.
 					     Two pixels of inset gives it somewhere to draw. -->
 					<div class="space-y-4 px-0.5 pt-4 sm:pt-6">
 						<!-- General -->
-						<template v-if="tab === 0">
+						<template v-if="panel.value === 'general'">
 							<FormControl v-model="folder.name" :label="__('Name')" required />
 							<div class="space-y-1.5">
 								<label class="text-ink-gray-5 block text-xs">
@@ -185,11 +187,12 @@ const automationScript = computed(() =>
 	sieveScripts.data?.find((s) => s._name === 'frappe_mail_automation'),
 )
 
-const tab = ref(0)
+const tab = ref('general')
 
+// iconLeft, not icon: `icon` is Tabs' icon-only trigger — it drops the label.
 const TABS = [
-	{ label: __('General'), icon: Settings },
-	{ label: __('Automation'), icon: Zap },
+	{ value: 'general', label: __('General'), iconLeft: Settings },
+	{ value: 'automation', label: __('Automation'), iconLeft: Zap },
 ]
 
 const DEFAULT_FOLDER = {
@@ -278,7 +281,7 @@ const createAutomationScript = createResource({
 watch(show, (val) => {
 	if (!val) return
 
-	tab.value = 0
+	tab.value = 'general'
 	Object.assign(automationRules, DEFAULT_AUTOMATION_RULES)
 	Object.assign(originalAutomationRules, DEFAULT_AUTOMATION_RULES)
 

--- a/frontend/src/apps/mail/components/SearchMobileLayout.vue
+++ b/frontend/src/apps/mail/components/SearchMobileLayout.vue
@@ -16,7 +16,7 @@
 				keyboardOpen ? 'bottom-0' : 'bottom-[calc(3.75rem+1px+env(safe-area-inset-bottom))]'
 			"
 		>
-			<slot name="body" />
+			<slot />
 		</div>
 	</Teleport>
 </template>

--- a/frontend/src/apps/mail/pages/CalendarExchangesView.vue
+++ b/frontend/src/apps/mail/pages/CalendarExchangesView.vue
@@ -3,12 +3,15 @@
 		<header class="flex items-center border-b px-5 py-2.5">
 			<Breadcrumbs :items="[{ label: __('Calendar Exchanges') }]" />
 		</header>
+		<!-- The tab list carries no padding of its own: inset it to the header's,
+		     and pad it evenly so the 28px triggers sit in a 40px band like the header
+		     above. The underline indicator rides on the list's bottom border, so it
+		     stays on the rail rather than tracking the label. -->
 		<Tabs
-			v-model="tabIndex"
+			v-model="operation"
 			:tabs="TABS"
-			@update:model-value="
-				$router.replace({ query: { operation: tabIndex ? 'Export' : 'Import' } })
-			"
+			class="[&>[data-slot=tab-list]]:px-5 [&>[data-slot=tab-list]]:py-1.5"
+			@update:model-value="$router.replace({ query: { operation } })"
 		>
 			<template #tab-panel>
 				<div class="m-5 flex flex-1 flex-col space-y-5 overflow-y-auto">
@@ -74,7 +77,9 @@ import { formatSystemDateTime } from '@/apps/mail/utils/datetime'
 const user = inject('$user')
 const route = useRoute()
 
-const tabIndex = ref(route.query.operation === 'Export' ? 1 : 0)
+// The tab value is the operation itself, so it doubles as the query param.
+const operation = ref(route.query.operation === 'Export' ? 'Export' : 'Import')
+const isExport = computed(() => operation.value === 'Export')
 const status = ref(' ')
 
 const STATUS_OPTIONS = [
@@ -100,7 +105,7 @@ const calendarExchanges = useList({
 	filters: () => {
 		const filters: Record<string, string> = {
 			user: user.data.name,
-			operation: tabIndex.value ? 'Export' : 'Import',
+			operation: operation.value,
 		}
 		if (status.value !== ' ') filters.status = status.value
 		return filters
@@ -119,10 +124,10 @@ const listColumns = computed(() => {
 		{ label: __('Status'), key: 'status' },
 		{
 			label: __('Format'),
-			key: tabIndex.value ? 'export_format' : 'import_format',
+			key: isExport.value ? 'export_format' : 'import_format',
 		},
 	]
-	if (tabIndex.value) columns.push({ label: __('Archive Type'), key: 'export_archive_type' })
+	if (isExport.value) columns.push({ label: __('Archive Type'), key: 'export_archive_type' })
 	return columns
 })
 
@@ -132,8 +137,9 @@ const LIST_OPTIONS = {
 	emptyState: { description: __('No calendar exchanges found.') },
 }
 
+// iconLeft, not icon: `icon` makes an icon-only trigger and drops the label.
 const TABS = [
-	{ label: __('Import'), icon: CalendarPlus },
-	{ label: __('Export'), icon: CalendarRange },
+	{ value: 'Import', label: __('Import'), iconLeft: CalendarPlus },
+	{ value: 'Export', label: __('Export'), iconLeft: CalendarRange },
 ]
 </script>

--- a/frontend/src/apps/mail/pages/ContactsExchangesView.vue
+++ b/frontend/src/apps/mail/pages/ContactsExchangesView.vue
@@ -3,12 +3,15 @@
 		<header class="flex items-center border-b px-5 py-2.5">
 			<Breadcrumbs :items="[{ label: __('Contacts Exchanges') }]" />
 		</header>
+		<!-- The tab list carries no padding of its own: inset it to the header's,
+		     and pad it evenly so the 28px triggers sit in a 40px band like the header
+		     above. The underline indicator rides on the list's bottom border, so it
+		     stays on the rail rather than tracking the label. -->
 		<Tabs
-			v-model="tabIndex"
+			v-model="operation"
 			:tabs="TABS"
-			@update:model-value="
-				$router.replace({ query: { operation: tabIndex ? 'Export' : 'Import' } })
-			"
+			class="[&>[data-slot=tab-list]]:px-5 [&>[data-slot=tab-list]]:py-1.5"
+			@update:model-value="$router.replace({ query: { operation } })"
 		>
 			<template #tab-panel>
 				<div class="m-5 flex flex-1 flex-col space-y-5 overflow-y-auto">
@@ -74,7 +77,9 @@ import { formatSystemDateTime } from '@/apps/mail/utils/datetime'
 const user = inject('$user')
 const route = useRoute()
 
-const tabIndex = ref(route.query.operation === 'Export' ? 1 : 0)
+// The tab value is the operation itself, so it doubles as the query param.
+const operation = ref(route.query.operation === 'Export' ? 'Export' : 'Import')
+const isExport = computed(() => operation.value === 'Export')
 const status = ref(' ')
 
 const STATUS_OPTIONS = [
@@ -100,7 +105,7 @@ const contactsExchanges = useList({
 	filters: () => {
 		const filters: Record<string, string> = {
 			user: user.data.name,
-			operation: tabIndex.value ? 'Export' : 'Import',
+			operation: operation.value,
 		}
 		if (status.value !== ' ') filters.status = status.value
 		return filters
@@ -119,10 +124,10 @@ const listColumns = computed(() => {
 		{ label: __('Status'), key: 'status' },
 		{
 			label: __('Format'),
-			key: tabIndex.value ? 'export_format' : 'import_format',
+			key: isExport.value ? 'export_format' : 'import_format',
 		},
 	]
-	if (tabIndex.value) columns.push({ label: __('Archive Type'), key: 'export_archive_type' })
+	if (isExport.value) columns.push({ label: __('Archive Type'), key: 'export_archive_type' })
 	return columns
 })
 
@@ -132,8 +137,9 @@ const LIST_OPTIONS = {
 	emptyState: { description: __('No contacts exchanges found.') },
 }
 
+// iconLeft, not icon: `icon` makes an icon-only trigger and drops the label.
 const TABS = [
-	{ label: __('Import'), icon: UserPlus },
-	{ label: __('Export'), icon: Users },
+	{ value: 'Import', label: __('Import'), iconLeft: UserPlus },
+	{ value: 'Export', label: __('Export'), iconLeft: Users },
 ]
 </script>

--- a/frontend/src/apps/mail/pages/MailExchangesView.vue
+++ b/frontend/src/apps/mail/pages/MailExchangesView.vue
@@ -3,12 +3,15 @@
 		<header class="flex items-center border-b px-5 py-2.5">
 			<Breadcrumbs :items="[{ label: __('Mail Exchanges') }]" />
 		</header>
+		<!-- The tab list carries no padding of its own: inset it to the header's,
+		     and pad it evenly so the 28px triggers sit in a 40px band like the header
+		     above. The underline indicator rides on the list's bottom border, so it
+		     stays on the rail rather than tracking the label. -->
 		<Tabs
-			v-model="tabIndex"
+			v-model="operation"
 			:tabs="TABS"
-			@update:model-value="
-				$router.replace({ query: { operation: tabIndex ? 'Export' : 'Import' } })
-			"
+			class="[&>[data-slot=tab-list]]:px-5 [&>[data-slot=tab-list]]:py-1.5"
+			@update:model-value="$router.replace({ query: { operation } })"
 		>
 			<template #tab-panel>
 				<div class="m-5 flex flex-1 flex-col space-y-5 overflow-y-auto">
@@ -71,7 +74,9 @@ import { formatSystemDateTime } from '@/apps/mail/utils/datetime'
 const user = inject('$user')
 const route = useRoute()
 
-const tabIndex = ref(route.query.operation === 'Export' ? 1 : 0)
+// The tab value is the operation itself, so it doubles as the query param.
+const operation = ref(route.query.operation === 'Export' ? 'Export' : 'Import')
+const isExport = computed(() => operation.value === 'Export')
 const status = ref(' ')
 
 const STATUS_OPTIONS = [
@@ -97,7 +102,7 @@ const mailExchanges = useList({
 	filters: () => {
 		const filters: Record<string, string> = {
 			user: user.data.name,
-			operation: tabIndex.value ? 'Export' : 'Import',
+			operation: operation.value,
 		}
 		if (status.value !== ' ') filters.status = status.value
 		return filters
@@ -116,10 +121,10 @@ const listColumns = computed(() => {
 		{ label: __('Status'), key: 'status' },
 		{
 			label: __('Format'),
-			key: tabIndex.value ? 'export_format' : 'import_format',
+			key: isExport.value ? 'export_format' : 'import_format',
 		},
 	]
-	if (tabIndex.value) columns.push({ label: __('Archive Type'), key: 'export_archive_type' })
+	if (isExport.value) columns.push({ label: __('Archive Type'), key: 'export_archive_type' })
 	return columns
 })
 
@@ -129,8 +134,9 @@ const LIST_OPTIONS = {
 	emptyState: { description: __('No mail exchanges found.') },
 }
 
+// iconLeft, not icon: `icon` makes an icon-only trigger and drops the label.
 const TABS = [
-	{ label: __('Import'), icon: HardDriveDownload },
-	{ label: __('Export'), icon: HardDriveUpload },
+	{ value: 'Import', label: __('Import'), iconLeft: HardDriveDownload },
+	{ value: 'Export', label: __('Export'), iconLeft: HardDriveUpload },
 ]
 </script>

--- a/frontend/src/apps/mail/pages/dashboard/MembersView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/MembersView.vue
@@ -5,18 +5,20 @@
 		:button-action="() => (showAddMember = true)"
 		:remove-spacing="true"
 	>
+		<!-- iconLeft, not icon: `icon` makes an icon-only trigger and drops the label. -->
 		<Tabs
-			v-model="tabIndex"
+			v-model="tab"
+			class="[&>[data-slot=tab-list]]:px-3 [&>[data-slot=tab-list]]:py-1.5 sm:[&>[data-slot=tab-list]]:px-5"
 			:tabs="[
-				{ label: __('Users'), icon: Users },
-				{ label: __('Invites'), icon: Mails },
+				{ value: 'users', label: __('Users'), iconLeft: Users },
+				{ value: 'invites', label: __('Invites'), iconLeft: Mails },
 			]"
 		>
-			<template #tab-panel>
+			<template #tab-panel="{ tab: panel }">
 				<!-- Match DashboardLayout's body spacing so the tabbed page doesn't sit
 				     at a different offset than its sibling pages. -->
 				<div class="flex flex-1 flex-col space-y-5 overflow-y-auto px-3 py-5 sm:px-5">
-					<UsersView v-if="tabIndex === 0" ref="usersView" />
+					<UsersView v-if="panel.value === 'users'" ref="usersView" />
 					<InvitesView v-else ref="invitesView" />
 				</div>
 			</template>
@@ -43,11 +45,11 @@ const router = useRouter()
 // Derive the active tab from the route (correct from the first render, so frappe-ui's Tabs has a
 // valid model immediately and its reka-ui indicator doesn't observe an undefined element). The
 // setter only navigates on an actual tab change, avoiding the redundant same-route push that the
-// previous tabIndex<->route watch pair triggered.
-const tabIndex = computed({
-	get: () => (route.name === 'mail-invites' ? 1 : 0),
+// previous tab<->route watch pair triggered.
+const tab = computed({
+	get: () => (route.name === 'mail-invites' ? 'invites' : 'users'),
 	set: (val) => {
-		const name = val ? 'mail-invites' : 'mail-members'
+		const name = val === 'invites' ? 'mail-invites' : 'mail-members'
 		if (route.name !== name) router.push({ name })
 	},
 })
@@ -60,7 +62,7 @@ const usersView = useTemplateRef('usersView')
 const invitesView = useTemplateRef('invitesView')
 
 const reload = () => {
-	if (tabIndex.value === 0) usersView?.value?.reloadMembers()
+	if (tab.value === 'users') usersView?.value?.reloadMembers()
 	else invitesView?.value?.reloadInvites()
 }
 </script>

--- a/frontend/src/apps/writer/components/VersionsSidebar.vue
+++ b/frontend/src/apps/writer/components/VersionsSidebar.vue
@@ -38,7 +38,10 @@
           v-model="tab"
           class="w-full"
           as="div"
-          :tabs="[{ label: 'Automatic' }, { label: 'Manual' }]"
+          :tabs="[
+            { value: 'automatic', label: 'Automatic' },
+            { value: 'manual', label: 'Manual' },
+          ]"
         />
         <Button
           :icon="LucideX"
@@ -49,7 +52,7 @@
       </div>
       <div class="p-3.5 gap-4 flex flex-col flex-1 min-h-0 overflow-y-auto">
         <Button
-          v-if="tab === 1"
+          v-if="tab === 'manual'"
           :icon="LucidePlus"
           class="absolute right-3 bottom-3"
           variant="outline"
@@ -250,7 +253,7 @@ function formatDateDDMMYY(dateStr) {
 }
 
 const groupedVersions = computed(() => {
-  if (tab.value === 0) {
+  if (tab.value === 'automatic') {
     const sortedAutoVersions = [...autoVersions.value].sort((a, b) => {
       return new Date(b.title) - new Date(a.title)
     })
@@ -274,7 +277,7 @@ const groupedVersions = computed(() => {
   }
 })
 
-const tab = ref(versions.data.filter((v) => v.manual).length ? 1 : 0)
+const tab = ref(versions.data.filter((v) => v.manual).length ? 'manual' : 'automatic')
 watch(tab, () => (versionPreview.value = null))
 
 const getPrevious = (version) => {

--- a/frontend/src/apps/writer/components/WriterSettings.vue
+++ b/frontend/src/apps/writer/components/WriterSettings.vue
@@ -4,7 +4,7 @@
     title="Settings"
     @close="model = false"
   >
-    <Tabs v-model="tabIndex" :tabs>
+    <Tabs v-model="tab" :tabs>
         <template #tab-panel>
           <Form>
             <template #default="{ dirty, setDirty, error }">
@@ -16,7 +16,7 @@
                     :options="fontOptions"
                     label="Font family"
                     :description="`Choose the default font family for ${
-                      tabIndex === 1 ? 'this document' : 'new documents'
+                      tab === 'doc' ? 'this document' : 'new documents'
                     }.`"
                   />
                   <FormControl
@@ -66,7 +66,7 @@
                 </div>
 
                 <!-- Print Settings Section -->
-                <div v-if="tabIndex === 1" class="flex flex-col gap-3 pb-5 pr-5">
+                <div v-if="tab === 'doc'" class="flex flex-col gap-3 pb-5 pr-5">
                     <h3 class="text-base font-medium text-ink-gray-7">Print settings</h3>
                     <div class="space-y-2">
                       <FormLabel label="Header & footer" size="md" />
@@ -176,11 +176,12 @@ const props = defineProps({
   globalSettings: { required: true, type: Object },
   editable: Boolean,
 })
+// iconLeft, not icon: `icon` makes an icon-only trigger and drops the label.
 const tabs = dynamicList([
-  { label: 'Everywhere', icon: LucideGlobe2 },
-  { label: 'This document', icon: LucideFileText },
+  { value: 'global', label: 'Everywhere', iconLeft: LucideGlobe2 },
+  { value: 'doc', label: 'This document', iconLeft: LucideFileText },
 ])
-const tabIndex = ref(props.editable ? 1 : 0)
+const tab = ref(props.editable ? 'doc' : 'global')
 
 const fontOptions = computed(() =>
   dynamicList([
@@ -188,14 +189,14 @@ const fontOptions = computed(() =>
       label: 'Automatic',
       value: 'global',
       key: 'global',
-      cond: tabIndex.value === 1,
+      cond: tab.value === 'doc',
     },
     ...FONT_FAMILIES,
   ]),
 )
 
-const resource = computed(() => (tabIndex.value === 1 ? props.docSettings : props.globalSettings))
-const key = computed(() => (tabIndex.value === 1 ? 'settings' : 'writer_settings'))
+const resource = computed(() => (tab.value === 'doc' ? props.docSettings : props.globalSettings))
+const key = computed(() => (tab.value === 'doc' ? 'settings' : 'writer_settings'))
 
 const KEYS = computed(() => [
   'font_family',


### PR DESCRIPTION
Three things the last frappe-ui bump broke, plus one bug it didn't.

**Tabs.** A tab item now needs a `value`, and the model holds that value instead of an index — so every index-based caller selected nothing and rendered no panel. `icon` now means an *icon-only* trigger, which dropped the labels, and panels render one per tab, so the body reads the panel's own tab. Migrated: folder settings, the three exchange views, members, writer settings, writer versions, drive move dialog, drive user list.

The track also no longer pads itself, so full-page tab bars sat flush left in a band shorter than the header above them. Inset and padded to match; the `px-0` override in the folder modal that used to cancel that padding is gone.

**Mobile search** opened as an empty page: `SearchMobileLayout` stands in for `Dialog` there, and the dialog migration moved the content to the default slot while the layout still rendered `#body`.

**Details chevron.** Unrelated to the bump: the thread header row toggles a mail collapsed and the chevron sits inside it, so clicking it opened the popover and then collapsed the row out from under it.