### PR TITLE
fix(drive): litmus prepare opts the user in; matcher handles CR lines

### DIFF
--- a/suite/drive/webdav/tests/litmus_setup.py
+++ b/suite/drive/webdav/tests/litmus_setup.py
@@ -7,6 +7,8 @@ bench --site <site> execute suite.drive.webdav.tests.litmus_setup.teardown
 import frappe
 from frappe.utils.password import update_password
 
+from suite.drive.webdav.tests.utils import enable_user_webdav
+
 LITMUS_USER = "litmus@example.com"
 LITMUS_PASSWORD = "litmus-ci-password"
 
@@ -23,6 +25,7 @@ def prepare() -> str:
             }
         ).insert(ignore_permissions=True)
     update_password(LITMUS_USER, LITMUS_PASSWORD)
+    enable_user_webdav(LITMUS_USER)
     frappe.db.set_single_value("Drive Disk Settings", "webdav_enabled", 1)
     frappe.clear_document_cache("Drive Disk Settings", "Drive Disk Settings")
     frappe.db.commit()

--- a/suite/drive/webdav/tests/run_litmus.sh
+++ b/suite/drive/webdav/tests/run_litmus.sh
@@ -28,7 +28,9 @@ echo "litmus target: $URL"
 OUTPUT="$(mktemp)"
 trap 'bench --site "$SITE" execute suite.drive.webdav.tests.litmus_setup.teardown >/dev/null; rm -f "$OUTPUT"' EXIT
 
-"$LITMUS" -k "$URL" "litmus@example.com" "litmus-ci-password" | tee "$OUTPUT" || true
+# tr: litmus rewrites progress with \r; split those into real lines so the
+# anchored matchers below see the final verdict on its own line
+"$LITMUS" -k "$URL" "litmus@example.com" "litmus-ci-password" | tr '\r' '\n' | tee "$OUTPUT" || true
 
 status=0
 group=""


### PR DESCRIPTION
## Summary
- `litmus_setup.prepare` predates the per-user WebDAV opt-in, so a fresh compliance run hits 403 before the first request. It now creates the litmus user's `Drive Settings` row with `webdav_enabled` set, via the same `enable_user_webdav` helper the unit tests use.
- litmus rewrites progress with carriage returns, so a test's progress chunks and final verdict arrive at the ledger matcher as a single line and the anchored patterns miss: ledgered FAILs report as unledgered, and stale entries go undetected. `run_litmus.sh` now pipes litmus output through `tr '\r' '\n'` before `tee`, so both the unledgered-detection loop and the stale-ledger check parse clean lines.

## Test plan
- Ran `litmus_setup.prepare` on a dev site: the per-user flag is set, and an authenticated `OPTIONS /dav/Home/` as the litmus user returns 200 where a fresh run previously got 403.
- Verified the stale-ledger regex matches a synthetic `10%\r 55%\r ... FAIL` sequence after CR normalization.
- Full `run_litmus.sh` pass on a site with the litmus binary installed.