### PR TITLE
refactor(meet): close SFU meeting manager facade

### DIFF
--- a/frontend/src/apps/meet/composables/__tests__/useNetworkQuality.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useNetworkQuality.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createApp, type Ref, ref } from "vue";
+import { createApp, nextTick, type Ref, ref } from "vue";
 import type { SFUMeetingManager } from "../../utils/SFUMeetingManager";
+import type { MediaHealthState } from "../../utils/media/MediaHealthMonitor";
 import { useNetworkQuality } from "../useNetworkQuality";
 
 describe("useNetworkQuality", () => {
@@ -9,29 +10,20 @@ describe("useNetworkQuality", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("mirrors monitor state and stops it on unmount", async () => {
-		vi.useFakeTimers();
-		const getNetworkStats = vi.fn().mockResolvedValue({
-			rtt: 950,
-			packetLoss: 3,
-			availableOutgoingBitrate: 150_000,
-			timestamp: Date.now(),
-			isValid: true,
-		});
+	it("mirrors manager-owned health state and stops it on unmount", () => {
+		const stopMonitoring = vi.fn();
+		const startMediaHealthMonitoring = vi.fn(
+			(listener: (state: MediaHealthState) => void) => {
+				listener({
+					networkQuality: "critical",
+					downlinkQuality: "poor",
+					isTransportFailed: true,
+				});
+				return stopMonitoring;
+			},
+		);
 		const manager = ref({
-			transportManager: {
-				getTransportStats: () => ({
-					sendTransport: { state: "connected" },
-					recvTransport: { state: "connected" },
-				}),
-				getNetworkStats,
-			},
-			mediaManager: {
-				consumerManager: { getAllConsumers: () => [] },
-			},
-			participantManager: { getParticipant: () => undefined },
-			reconcileExpectedMedia: vi.fn().mockResolvedValue(undefined),
-			resetReceiveMedia: vi.fn().mockResolvedValue(undefined),
+			startMediaHealthMonitoring,
 		}) as unknown as Ref<SFUMeetingManager | null>;
 		let quality: ReturnType<typeof useNetworkQuality> | undefined;
 		const app = createApp({
@@ -42,13 +34,94 @@ describe("useNetworkQuality", () => {
 		});
 		app.mount(document.createElement("div"));
 
-		await vi.advanceTimersByTimeAsync(3000);
 		expect(quality?.networkQuality.value).toBe("critical");
-		expect(quality?.downlinkQuality.value).toBe("good");
-		expect(quality?.isTransportFailed.value).toBe(false);
+		expect(quality?.downlinkQuality.value).toBe("poor");
+		expect(quality?.isTransportFailed.value).toBe(true);
+		expect(startMediaHealthMonitoring).toHaveBeenCalledOnce();
 
 		app.unmount();
-		await vi.advanceTimersByTimeAsync(3000);
-		expect(getNetworkStats).toHaveBeenCalledOnce();
+		expect(stopMonitoring).toHaveBeenCalledOnce();
+	});
+
+	it("stops the old monitor and resets state when the manager is removed", async () => {
+		let listener!: (state: MediaHealthState) => void;
+		const stopMonitoring = vi.fn();
+		const manager = ref({
+			startMediaHealthMonitoring: vi.fn((nextListener) => {
+				listener = nextListener;
+				return stopMonitoring;
+			}),
+		}) as unknown as Ref<SFUMeetingManager | null>;
+		let quality!: ReturnType<typeof useNetworkQuality>;
+		const app = createApp({
+			setup() {
+				quality = useNetworkQuality(manager);
+				return () => null;
+			},
+		});
+		app.mount(document.createElement("div"));
+		listener({
+			networkQuality: "critical",
+			downlinkQuality: "poor",
+			isTransportFailed: true,
+		});
+
+		manager.value = null;
+		await nextTick();
+
+		expect(stopMonitoring).toHaveBeenCalledOnce();
+		expect(quality.networkQuality.value).toBe("good");
+		expect(quality.downlinkQuality.value).toBe("good");
+		expect(quality.isTransportFailed.value).toBe(false);
+		app.unmount();
+	});
+
+	it("ignores the old listener and starts monitoring a replacement manager", async () => {
+		let oldListener!: (state: MediaHealthState) => void;
+		let nextListener!: (state: MediaHealthState) => void;
+		const stopOld = vi.fn();
+		const stopNext = vi.fn();
+		const first = {
+			startMediaHealthMonitoring: vi.fn((listener) => {
+				oldListener = listener;
+				return stopOld;
+			}),
+		};
+		const second = {
+			startMediaHealthMonitoring: vi.fn((listener) => {
+				nextListener = listener;
+				return stopNext;
+			}),
+		};
+		const manager = ref(first) as unknown as Ref<SFUMeetingManager | null>;
+		let quality!: ReturnType<typeof useNetworkQuality>;
+		const app = createApp({
+			setup() {
+				quality = useNetworkQuality(manager);
+				return () => null;
+			},
+		});
+		app.mount(document.createElement("div"));
+
+		manager.value = second as never;
+		await nextTick();
+		oldListener({
+			networkQuality: "critical",
+			downlinkQuality: "critical",
+			isTransportFailed: true,
+		});
+		nextListener({
+			networkQuality: "poor",
+			downlinkQuality: "good",
+			isTransportFailed: false,
+		});
+
+		expect(stopOld).toHaveBeenCalledOnce();
+		expect(second.startMediaHealthMonitoring).toHaveBeenCalledOnce();
+		expect(quality.networkQuality.value).toBe("poor");
+		expect(quality.downlinkQuality.value).toBe("good");
+		expect(quality.isTransportFailed.value).toBe(false);
+		app.unmount();
+		expect(stopNext).toHaveBeenCalledOnce();
 	});
 });

--- a/frontend/src/apps/meet/composables/__tests__/useTileAdaptiveStreaming.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useTileAdaptiveStreaming.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, nextTick, ref } from "vue";
+import { useTileAdaptiveStreaming } from "../useTileAdaptiveStreaming";
+
+class ResizeObserverStub {
+	static instances: ResizeObserverStub[] = [];
+	disconnect = vi.fn();
+	observe = vi.fn();
+
+	constructor(readonly callback: ResizeObserverCallback) {
+		ResizeObserverStub.instances.push(this);
+	}
+}
+
+class IntersectionObserverStub {
+	static instances: IntersectionObserverStub[] = [];
+	disconnect = vi.fn();
+	observe = vi.fn();
+
+	constructor(readonly callback: IntersectionObserverCallback) {
+		IntersectionObserverStub.instances.push(this);
+	}
+}
+
+function createManager(consumerId: string) {
+	let listener: ((event: Event) => void) | null = null;
+	const unsubscribe = vi.fn();
+	return {
+		getVideoConsumerId: vi.fn(() => consumerId),
+		updateConsumerStreamPreferences: vi.fn().mockResolvedValue(undefined),
+		onRemoteConsumerReady: vi.fn((nextListener: (event: Event) => void) => {
+			listener = nextListener;
+			return unsubscribe;
+		}),
+		getListener: () => listener,
+		unsubscribe,
+	};
+}
+
+function mountComposable(managerRef: ReturnType<typeof ref>) {
+	let registerTile!: ReturnType<typeof useTileAdaptiveStreaming>["registerTile"];
+	const app = createApp(
+		defineComponent({
+			setup() {
+				({ registerTile } = useTileAdaptiveStreaming());
+				return () => null;
+			},
+		}),
+	);
+	app.provide("sfuManager", managerRef);
+	app.mount(document.createElement("div"));
+	return { app, registerTile };
+}
+
+function visibleVideoElement() {
+	const element = document.createElement("video");
+	Object.defineProperties(element, {
+		readyState: { configurable: true, value: 1 },
+		clientWidth: { configurable: true, value: 640 },
+		clientHeight: { configurable: true, value: 360 },
+	});
+	element.getBoundingClientRect = vi.fn(() => ({
+		bottom: 360,
+		height: 360,
+		left: 0,
+		right: 640,
+		top: 0,
+		width: 640,
+		x: 0,
+		y: 0,
+		toJSON: () => ({}),
+	}));
+	return element;
+}
+
+describe("useTileAdaptiveStreaming", () => {
+	beforeEach(() => {
+		ResizeObserverStub.instances = [];
+		IntersectionObserverStub.instances = [];
+		vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+		vi.stubGlobal("IntersectionObserver", IntersectionObserverStub);
+		Object.defineProperties(window, {
+			innerWidth: { configurable: true, value: 1280 },
+			innerHeight: { configurable: true, value: 720 },
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+	});
+
+	it("rebinds existing tiles and refreshes preferences when the manager changes", async () => {
+		const firstManager = createManager("first-consumer");
+		const secondManager = createManager("second-consumer");
+		const managerRef = ref(firstManager);
+		const { app, registerTile } = mountComposable(managerRef);
+		registerTile("participant-1", visibleVideoElement());
+		await nextTick();
+
+		expect(firstManager.updateConsumerStreamPreferences).toHaveBeenCalledWith(
+			"first-consumer",
+			{ visible: true, width: 640, height: 360 },
+		);
+
+		managerRef.value = secondManager;
+		await nextTick();
+		await Promise.resolve();
+
+		expect(firstManager.unsubscribe).toHaveBeenCalledOnce();
+		expect(secondManager.onRemoteConsumerReady).toHaveBeenCalledOnce();
+		expect(secondManager.updateConsumerStreamPreferences).toHaveBeenCalledWith(
+			"second-consumer",
+			{ visible: true, width: 640, height: 360 },
+		);
+
+		app.unmount();
+	});
+
+	it("cleans up the current manager listener and tile observers", () => {
+		const manager = createManager("consumer-1");
+		const { app, registerTile } = mountComposable(ref(manager));
+		registerTile("participant-1", visibleVideoElement());
+
+		app.unmount();
+
+		expect(manager.unsubscribe).toHaveBeenCalledOnce();
+		expect(ResizeObserverStub.instances[0]?.disconnect).toHaveBeenCalledOnce();
+		expect(
+			IntersectionObserverStub.instances[0]?.disconnect,
+		).toHaveBeenCalledOnce();
+	});
+});

--- a/frontend/src/apps/meet/composables/useAudioLevels.ts
+++ b/frontend/src/apps/meet/composables/useAudioLevels.ts
@@ -25,11 +25,10 @@ export function useAudioStream(
 				if (audioTrack) {
 					stream.value = new MediaStream([audioTrack]);
 				}
-			} else if (sfuManager?.consumerManager) {
-				const audioConsumer =
-					sfuManager.consumerManager.getAudioConsumer(participantId);
-				if (audioConsumer?.track) {
-					stream.value = new MediaStream([audioConsumer.track]);
+			} else if (sfuManager) {
+				const audioTrack = sfuManager.getRemoteAudioTrack(participantId);
+				if (audioTrack) {
+					stream.value = new MediaStream([audioTrack]);
 				}
 			}
 		} catch (error) {

--- a/frontend/src/apps/meet/composables/useMediaControls.test.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.test.ts
@@ -384,6 +384,20 @@ function createCameraHarness({
 			if (producer?.id) void sfuClient.closeProducer(producer.id);
 			if (kind === "screen") mediaHandler.stopScreenShare();
 		}),
+		stopScreenShare: vi.fn(async (metadata = {}) => {
+			const producer = getProducer("screen");
+			setProducer("screen", null);
+			if (producer?.id) {
+				await sfuClient.sendScreenShare("stop_share", {
+					...metadata,
+					producerId: producer.id,
+					stoppedAt: Date.now(),
+				});
+				producer.close?.();
+				await sfuClient.closeProducer(producer.id);
+			}
+			mediaHandler.stopScreenShare();
+		}),
 		pauseLocalProducer: vi.fn((kind: "audio" | "video" | "screen") => {
 			getProducer(kind)?.pause?.();
 		}),
@@ -474,10 +488,9 @@ describe("useMediaControls", () => {
 		publication.resolve(null);
 		await starting;
 
-		expect(harness.sfuClient.sendScreenShare).toHaveBeenCalledOnce();
-		expect(harness.sfuClient.sendScreenShare).toHaveBeenCalledWith(
-			"stop_share",
-			expect.any(Object),
+		expect(harness.sfuClient.sendScreenShare).not.toHaveBeenCalledWith(
+			"start_share",
+			expect.anything(),
 		);
 		expect(harness.state.isScreenSharing).toBe(false);
 	});

--- a/frontend/src/apps/meet/composables/useMediaControls.test.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.test.ts
@@ -1250,6 +1250,8 @@ describe("useMediaControls", () => {
 			reason: "manager-replaced",
 		});
 		expect(harness.state.isMicOn).toBe(false);
+		expect(sourceTrack.stop).toHaveBeenCalledOnce();
+		expect(harness.state.localStream.getAudioTracks()).toEqual([]);
 	});
 
 	it("serializes overlapping camera toggles and finishes camera-off", async () => {

--- a/frontend/src/apps/meet/composables/useMediaControls.test.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.test.ts
@@ -159,7 +159,10 @@ function withDeadline<T>(promise: Promise<T>, timeoutMs = 100): Promise<T> {
 interface TestVideoProducer {
 	id: string;
 	track?: MediaStreamTrack | null;
+	paused?: boolean;
 	replaceTrack?: ReturnType<typeof vi.fn>;
+	pause?: ReturnType<typeof vi.fn>;
+	resume?: ReturnType<typeof vi.fn>;
 	close?: ReturnType<typeof vi.fn>;
 }
 
@@ -173,9 +176,11 @@ interface CameraMediaStateOverrides {
 function createCameraHarness({
 	mediaState = {},
 	getUserMedia = vi.fn(),
+	getDisplayMedia = vi.fn(),
 	videoProducer = null,
 	audioProducer = null,
 	createProducer,
+	publishScreenTrack,
 	applyBackgroundEffects = vi.fn(),
 	backgroundEffects: backgroundEffectsOverride,
 	noiseCancellation: noiseCancellationOverride,
@@ -184,9 +189,11 @@ function createCameraHarness({
 }: {
 	mediaState?: CameraMediaStateOverrides;
 	getUserMedia?: ReturnType<typeof vi.fn>;
+	getDisplayMedia?: ReturnType<typeof vi.fn>;
 	videoProducer?: TestVideoProducer | null;
 	audioProducer?: TestVideoProducer | null;
 	createProducer?: ReturnType<typeof vi.fn>;
+	publishScreenTrack?: ReturnType<typeof vi.fn>;
 	applyBackgroundEffects?: ReturnType<typeof vi.fn>;
 	backgroundEffects?: ReturnType<typeof useBackgroundEffects>;
 	noiseCancellation?: object;
@@ -236,6 +243,23 @@ function createCameraHarness({
 			track,
 			close: vi.fn(),
 		}));
+	const createTestProducer = producerFactory as (
+		track: MediaStreamTrack,
+		options: { type: "microphone" | "camera" | "screen" },
+	) => Promise<TestVideoProducer>;
+	const getProducer = (kind: "audio" | "video" | "screen") => {
+		if (kind === "audio") return mediaHandler.audioProducer;
+		if (kind === "video") return mediaHandler.videoProducer;
+		return mediaHandler.screenProducer as TestVideoProducer | null;
+	};
+	const setProducer = (
+		kind: "audio" | "video" | "screen",
+		producer: TestVideoProducer | null,
+	) => {
+		if (kind === "audio") mediaHandler.audioProducer = producer;
+		else if (kind === "video") mediaHandler.videoProducer = producer;
+		else mediaHandler.screenProducer = producer as never;
+	};
 	const setLocalMediaTrack = vi.fn(
 		(kind: "audio" | "video", track: MediaStreamTrack | null) => {
 			const existingTracks =
@@ -260,7 +284,7 @@ function createCameraHarness({
 				const track = stream.getVideoTracks()[0] ?? null;
 				setLocalMediaTrack("video", track);
 				if (!track) return;
-				const producer = await producerFactory(track, { type: "camera" });
+				const producer = await createTestProducer(track, { type: "camera" });
 				mediaHandler.setProducers({ videoProducer: producer });
 			},
 		);
@@ -272,12 +296,107 @@ function createCameraHarness({
 			operation(),
 		),
 		transportManager: { createProducer: producerFactory },
+		getLocalProducerState: vi.fn((kind: "audio" | "video" | "screen") => {
+			const producer = getProducer(kind);
+			return producer
+				? {
+						id: producer.id,
+						track: producer.track ?? null,
+						paused: producer.paused ?? false,
+					}
+				: null;
+		}),
+		replaceLocalProducerTrack: vi.fn(
+			async (kind: "audio" | "video" | "screen", track: MediaStreamTrack) => {
+				const producer = getProducer(kind);
+				if (!producer) return false;
+				if (!producer.replaceTrack) throw new Error("Producer cannot replace track");
+				await producer.replaceTrack({ track });
+				return true;
+			},
+		),
+		createLocalProducer: vi.fn(
+			async (kind: "audio" | "video" | "screen", track: MediaStreamTrack) => {
+				const producer = await createTestProducer(track, {
+					type:
+						kind === "audio"
+							? "microphone"
+							: kind === "video"
+								? "camera"
+								: "screen",
+				});
+				setProducer(kind, producer);
+				return {
+					id: producer.id,
+					track: producer.track ?? null,
+					paused: producer.paused ?? false,
+				};
+			},
+		),
+		publishScreenTrack:
+			publishScreenTrack ??
+			vi.fn(async (track: MediaStreamTrack) => {
+				const producer = await createTestProducer(track, { type: "screen" });
+				setProducer("screen", producer);
+				return {
+					id: producer.id,
+					track: producer.track ?? null,
+					paused: producer.paused ?? false,
+				};
+			}),
+		reconcileLocalProducerTrack: vi.fn(
+			async (
+				kind: "audio" | "video" | "screen",
+				track: MediaStreamTrack,
+				options: { resume?: boolean } = {},
+			) => {
+				const producer = getProducer(kind);
+				let current = producer;
+				if (current) {
+					if (current.track !== track) {
+						if (!current.replaceTrack) throw new Error("Producer cannot replace track");
+						await current.replaceTrack({ track });
+					}
+				} else {
+					current = await createTestProducer(track, {
+						type:
+							kind === "audio"
+								? "microphone"
+								: kind === "video"
+									? "camera"
+									: "screen",
+					});
+					setProducer(kind, current);
+				}
+				if (options.resume) current.resume?.();
+				if (kind !== "screen") setLocalMediaTrack(kind, track);
+				return {
+					id: current.id,
+					track: current.track ?? null,
+					paused: current.paused ?? false,
+				};
+			},
+		),
+		closeLocalProducer: vi.fn((kind: "audio" | "video" | "screen") => {
+			const producer = getProducer(kind);
+			producer?.close?.();
+			setProducer(kind, null);
+			if (producer?.id) void sfuClient.closeProducer(producer.id);
+			if (kind === "screen") mediaHandler.stopScreenShare();
+		}),
+		pauseLocalProducer: vi.fn((kind: "audio" | "video" | "screen") => {
+			getProducer(kind)?.pause?.();
+		}),
+		resumeLocalProducer: vi.fn((kind: "audio" | "video" | "screen") => {
+			getProducer(kind)?.resume?.();
+		}),
 	};
 	const sfuClient = {
 		getUserId: vi.fn(() => null),
 		isConnected: vi.fn(() => true),
 		closeProducer: vi.fn().mockResolvedValue(undefined),
 		sendMediaControl: vi.fn(),
+		sendScreenShare: vi.fn(),
 	};
 	const stopProcessing = backgroundEffectsOverride?.stopProcessing ?? vi.fn();
 	const dispose =
@@ -292,16 +411,17 @@ function createCameraHarness({
 		} as never);
 	Object.defineProperty(navigator, "mediaDevices", {
 		configurable: true,
-		value: { getUserMedia },
+		value: { getDisplayMedia, getUserMedia },
 	});
 
+	const managerRef = ref(manager);
 	const controls = useMediaControls({
 		mediaState: state,
 		connectionState: { connectionError: null },
 		raiseHandStore: { raisedHands: {}, lowerHand: vi.fn() },
 		currentUser: { currentUser: ref(null) },
 		sfuClient,
-		sfuManager: ref(manager),
+		sfuManager: managerRef,
 		deviceManager,
 		backgroundEffects: effectsApi,
 		noiseCancellation: noiseCancellationOverride ?? { error: ref(null) },
@@ -316,6 +436,7 @@ function createCameraHarness({
 		dispose,
 		mediaHandler,
 		manager,
+		managerRef,
 		publishMedia,
 		setLocalMediaTrack,
 		sfuClient,
@@ -335,6 +456,100 @@ describe("useMediaControls", () => {
 		selectedCameraId.value = "";
 		selectedMicId.value = "";
 		setAutoFramingPaused(false);
+	});
+
+	it("does not signal screen-share start when publication resolves after stop", async () => {
+		const screenTrack = videoTrack("screen");
+		const screenStream = new FakeMediaStream([screenTrack]);
+		const publication = deferred<null>();
+		const publishScreenTrack = vi.fn(() => publication.promise);
+		const harness = createCameraHarness({
+			getDisplayMedia: vi.fn().mockResolvedValue(screenStream),
+			publishScreenTrack,
+		});
+
+		const starting = harness.controls.toggleScreenShare();
+		await vi.waitFor(() => expect(publishScreenTrack).toHaveBeenCalledWith(screenTrack));
+		await harness.controls.toggleScreenShare();
+		publication.resolve(null);
+		await starting;
+
+		expect(harness.sfuClient.sendScreenShare).toHaveBeenCalledOnce();
+		expect(harness.sfuClient.sendScreenShare).toHaveBeenCalledWith(
+			"stop_share",
+			expect.any(Object),
+		);
+		expect(harness.state.isScreenSharing).toBe(false);
+	});
+
+	it("does not signal screen-share start through a replaced manager", async () => {
+		const screenTrack = videoTrack("screen");
+		const screenStream = new FakeMediaStream([screenTrack]);
+		const publication = deferred<{
+			id: string;
+			track: MediaStreamTrack;
+			paused: boolean;
+		}>();
+		const harness = createCameraHarness({
+			getDisplayMedia: vi.fn().mockResolvedValue(screenStream),
+			publishScreenTrack: vi.fn(() => publication.promise),
+		});
+
+		const starting = harness.controls.toggleScreenShare();
+		await vi.waitFor(() =>
+			expect(harness.manager.publishScreenTrack).toHaveBeenCalledWith(screenTrack),
+		);
+		harness.mediaHandler.screenProducer = {
+			id: "screen-producer",
+			track: screenTrack,
+		} as never;
+		harness.managerRef.value = {} as never;
+		publication.resolve({
+			id: "screen-producer",
+			track: screenTrack,
+			paused: false,
+		});
+		await starting;
+
+		expect(harness.sfuClient.sendScreenShare).not.toHaveBeenCalledWith(
+			"start_share",
+			expect.anything(),
+		);
+	});
+
+	it("does not signal an old screen publication after its producer is replaced", async () => {
+		const screenTrack = videoTrack("screen");
+		const replacementTrack = videoTrack("replacement-screen");
+		const screenStream = new FakeMediaStream([screenTrack]);
+		const publication = deferred<{
+			id: string;
+			track: MediaStreamTrack;
+			paused: boolean;
+		}>();
+		const harness = createCameraHarness({
+			getDisplayMedia: vi.fn().mockResolvedValue(screenStream),
+			publishScreenTrack: vi.fn(() => publication.promise),
+		});
+
+		const starting = harness.controls.toggleScreenShare();
+		await vi.waitFor(() =>
+			expect(harness.manager.publishScreenTrack).toHaveBeenCalledWith(screenTrack),
+		);
+		harness.mediaHandler.screenProducer = {
+			id: "replacement-producer",
+			track: replacementTrack,
+		} as never;
+		publication.resolve({
+			id: "old-producer",
+			track: screenTrack,
+			paused: false,
+		});
+		await starting;
+
+		expect(harness.sfuClient.sendScreenShare).not.toHaveBeenCalledWith(
+			"start_share",
+			expect.anything(),
+		);
 	});
 
 	it("reacquires and republishes an enabled camera whose track ends", async () => {
@@ -847,15 +1062,10 @@ describe("useMediaControls", () => {
 				sendMediaControl: vi.fn(),
 			},
 			sfuManager: ref({
-				mediaHandler: {
-					audioProducer,
-					videoProducer: null,
-					screenProducer: null,
-					localStream: null,
-					setProducers: vi.fn(),
-					stopScreenShare: vi.fn(),
-					cleanup: vi.fn(),
-				},
+				reconcileLocalProducerTrack: vi.fn(async (_kind, track) => {
+					await audioProducer.replaceTrack({ track });
+					audioProducer.resume();
+				}),
 			}),
 			deviceManager: {},
 			backgroundEffects: {
@@ -881,6 +1091,92 @@ describe("useMediaControls", () => {
 		expect(replaceTrack.mock.invocationCallOrder[0]).toBeLessThan(
 			resume.mock.invocationCallOrder[0],
 		);
+	});
+
+	it("re-reads a producer that appears while microphone switching acquires media", async () => {
+		noiseCancellationEnabled.value = false;
+		const acquisition = deferred<MediaStream>();
+		const oldTrack = audioTrack("old-microphone");
+		const nextTrack = audioTrack("next-microphone");
+		const appearedProducer: TestVideoProducer = {
+			id: "recovered-producer",
+			track: oldTrack,
+			replaceTrack: vi.fn(async ({ track }) => {
+				appearedProducer.track = track;
+			}),
+			resume: vi.fn(),
+		};
+		const harness = createCameraHarness({
+			mediaState: {
+				isMicOn: true,
+				localStream: new FakeMediaStream([oldTrack]),
+			},
+			getUserMedia: vi.fn(() => acquisition.promise),
+			deviceManager: {
+				enumerateDevices: vi.fn().mockResolvedValue(undefined),
+				isDeviceAvailable: vi.fn(() => true),
+				findDeviceById: vi.fn(),
+			},
+		});
+
+		const switching = harness.controls.switchInputDevice(
+			"microphone",
+			"next-microphone",
+		);
+		await vi.waitFor(() =>
+			expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalled(),
+		);
+		harness.mediaHandler.audioProducer = appearedProducer;
+		acquisition.resolve(new FakeMediaStream([nextTrack]) as never);
+		await switching;
+
+		expect(appearedProducer.replaceTrack).toHaveBeenCalledWith({
+			track: nextTrack,
+		});
+		expect(appearedProducer.resume).toHaveBeenCalledOnce();
+		expect(harness.createProducer).not.toHaveBeenCalled();
+	});
+
+	it("creates a producer that disappears while microphone processing is pending", async () => {
+		const sourceTrack = audioTrack("source");
+		const processedTrack = audioTrack("processed");
+		const processing = deferred<{
+			stream: MediaStream;
+			cleanup: () => void;
+		}>();
+		const applyNoiseCancellation = vi.fn(() => processing.promise);
+		const harness = createCameraHarness({
+			getUserMedia: vi
+				.fn()
+				.mockResolvedValue(new FakeMediaStream([sourceTrack])),
+			audioProducer: {
+				id: "producer-before-recovery",
+				track: audioTrack("stale"),
+				replaceTrack: vi.fn(),
+				resume: vi.fn(),
+			},
+			noiseCancellation: {
+				applyNoiseCancellation,
+				isProcessing: ref(false),
+				error: ref(null),
+			},
+		});
+
+		const enabling = harness.controls.toggleMicrophone();
+		await vi.waitFor(() => expect(applyNoiseCancellation).toHaveBeenCalledOnce());
+		harness.mediaHandler.audioProducer = null;
+		processing.resolve({
+			stream: new FakeMediaStream([processedTrack]) as never,
+			cleanup: vi.fn(),
+		});
+		await enabling;
+
+		expect(harness.createProducer).toHaveBeenCalledOnce();
+		expect(harness.createProducer).toHaveBeenCalledWith(processedTrack, {
+			type: "microphone",
+		});
+		expect(harness.mediaHandler.audioProducer?.track).toBe(processedTrack);
+		expect(harness.state.isMicOn).toBe(true);
 	});
 
 	it("serializes overlapping camera toggles and finishes camera-off", async () => {

--- a/frontend/src/apps/meet/composables/useMediaControls.test.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.test.ts
@@ -1179,6 +1179,39 @@ describe("useMediaControls", () => {
 		expect(harness.state.isMicOn).toBe(true);
 	});
 
+	it("does not enable the microphone after its manager is cleared", async () => {
+		const sourceTrack = audioTrack("source");
+		const processedTrack = audioTrack("processed");
+		const processing = deferred<{
+			stream: MediaStream;
+			cleanup: () => void;
+		}>();
+		const applyNoiseCancellation = vi.fn(() => processing.promise);
+		const harness = createCameraHarness({
+			getUserMedia: vi
+				.fn()
+				.mockResolvedValue(new FakeMediaStream([sourceTrack])),
+			noiseCancellation: {
+				applyNoiseCancellation,
+				isProcessing: ref(false),
+				error: ref(null),
+			},
+		});
+
+		const enabling = harness.controls.toggleMicrophone();
+		await vi.waitFor(() => expect(applyNoiseCancellation).toHaveBeenCalledOnce());
+		harness.managerRef.value = null as never;
+		processing.resolve({
+			stream: new FakeMediaStream([processedTrack]) as never,
+			cleanup: vi.fn(),
+		});
+		await enabling;
+
+		expect(harness.manager.reconcileLocalProducerTrack).not.toHaveBeenCalled();
+		expect(harness.state.isMicOn).toBe(false);
+		expect(processedTrack.enabled).toBe(false);
+	});
+
 	it("serializes overlapping camera toggles and finishes camera-off", async () => {
 		const firstAcquisition = deferred<MediaStream>();
 		const firstTrack = videoTrack("first");

--- a/frontend/src/apps/meet/composables/useMediaControls.test.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.test.ts
@@ -1212,6 +1212,33 @@ describe("useMediaControls", () => {
 		expect(processedTrack.enabled).toBe(false);
 	});
 
+	it("closes a microphone publication resumed by a replaced manager", async () => {
+		noiseCancellationEnabled.value = false;
+		const sourceTrack = audioTrack("source");
+		const reconciliation = deferred<void>();
+		const harness = createCameraHarness({
+			getUserMedia: vi
+				.fn()
+				.mockResolvedValue(new FakeMediaStream([sourceTrack])),
+		});
+		harness.manager.reconcileLocalProducerTrack.mockImplementation(
+			() => reconciliation.promise,
+		);
+
+		const enabling = harness.controls.toggleMicrophone();
+		await vi.waitFor(() =>
+			expect(harness.manager.reconcileLocalProducerTrack).toHaveBeenCalledOnce(),
+		);
+		harness.managerRef.value = {} as never;
+		reconciliation.resolve();
+		await enabling;
+
+		expect(harness.manager.closeLocalProducer).toHaveBeenCalledWith("audio", {
+			reason: "manager-replaced",
+		});
+		expect(harness.state.isMicOn).toBe(false);
+	});
+
 	it("serializes overlapping camera toggles and finishes camera-off", async () => {
 		const firstAcquisition = deferred<MediaStream>();
 		const firstTrack = videoTrack("first");

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -1799,7 +1799,12 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 					await publicationOwner.reconcileLocalProducerTrack("audio", track, {
 						resume: true,
 					});
-					if (sfuManager.value !== publicationOwner) return;
+					if (sfuManager.value !== publicationOwner) {
+						publicationOwner.closeLocalProducer("audio", {
+							reason: "manager-replaced",
+						});
+						return;
+					}
 				}
 			} else {
 				if (stream) {

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -147,30 +147,6 @@ interface MediaControlsAPI {
 	processedStream: MediaStream | null;
 }
 
-interface ProducerLike {
-	id: string;
-	track?: MediaStreamTrack | null;
-	paused?: boolean;
-	replaceTrack?: (args: { track: MediaStreamTrack }) => Promise<unknown>;
-	resume?: () => void;
-	pause?: () => void;
-	close?: () => void;
-}
-
-interface MediaHandlerLike {
-	localStream: MediaStream | null;
-	audioProducer: ProducerLike | null;
-	videoProducer: ProducerLike | null;
-	screenProducer: ProducerLike | null;
-	setProducers: (producers: {
-		audioProducer?: ProducerLike;
-		videoProducer?: ProducerLike;
-		screenProducer?: ProducerLike;
-	}) => void;
-	stopScreenShare: () => void;
-	cleanup: () => void;
-}
-
 type ScreenShareStopReason =
 	| "user-click"
 	| "track-ended"
@@ -290,12 +266,6 @@ export function mergeReacquiredMedia({
 
 interface ScreenShareStopExtra {
 	message?: string;
-}
-
-function getMediaHandler(
-	manager: SFUMeetingManager | null,
-): MediaHandlerLike | null {
-	return (manager?.mediaHandler as MediaHandlerLike | undefined) || null;
 }
 
 export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
@@ -475,20 +445,14 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			if (track && track.readyState !== "live") {
 				throw new Error(`Cannot reconcile ended camera track (${reason})`);
 			}
-			const mediaHandler = getMediaHandler(manager);
-			if (!mediaHandler) return;
-			const videoProducer = mediaHandler.videoProducer;
+			const videoProducer = manager.getLocalProducerState("video");
 
 			if (track) {
 				if (videoProducer?.track?.id !== track.id) {
 					if (videoProducer) {
 						const previousTrack = videoProducer.track;
-						const replaceTrack = videoProducer.replaceTrack;
-						if (typeof replaceTrack !== "function") {
-							throw new Error("Camera producer cannot replace its track");
-						}
 						assertCurrentCameraOperation(operation);
-						await replaceTrack.call(videoProducer, { track });
+						await manager.replaceLocalProducerTrack("video", track);
 						assertCurrentCameraOperation(operation);
 						if (track.readyState !== "live") {
 							if (
@@ -496,41 +460,28 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 								previousTrack !== track
 							) {
 								assertCurrentCameraOperation(operation);
-								await replaceTrack.call(videoProducer, {
-									track: previousTrack,
-								});
+								await manager.replaceLocalProducerTrack(
+									"video",
+									previousTrack,
+								);
 							}
 							throw new Error(
 								`Camera track ended during reconciliation (${reason})`,
 							);
 						}
-					} else if (createProducerIfMissing && manager.transportManager) {
+					} else if (createProducerIfMissing) {
 						assertCurrentCameraOperation(operation);
-						const producer = await manager.transportManager.createProducer(
-							track,
-							{
-								type: "camera",
-							},
-						);
+						await manager.createLocalProducer("video", track);
 						if (operation && !isCurrentCameraOperation(operation)) {
-							producer.close?.();
-							if (producer.id && sfuClient.isConnected()) {
-								void sfuClient.closeProducer(producer.id).catch(() => {});
-							}
+							manager.closeLocalProducer("video");
 							throw cameraLifecycleAbort();
 						}
 						if (track.readyState !== "live") {
-							producer.close?.();
-							if (producer.id && sfuClient.isConnected()) {
-								void sfuClient.closeProducer(producer.id).catch(() => {});
-							}
+							manager.closeLocalProducer("video");
 							throw new Error(
 								`Camera track ended during reconciliation (${reason})`,
 							);
 						}
-						mediaHandler.setProducers({
-							videoProducer: producer as ProducerLike,
-						});
 					}
 				}
 
@@ -540,13 +491,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				}
 			} else {
 				assertCurrentCameraOperation(operation);
-				if (videoProducer) {
-					videoProducer.close?.();
-					if (videoProducer.id && sfuClient.isConnected()) {
-						sfuClient.closeProducer(videoProducer.id).catch(() => {});
-					}
-				}
-				mediaHandler.videoProducer = null;
+				if (videoProducer) manager.closeLocalProducer("video");
 			}
 			assertCurrentCameraOperation(operation);
 			manager.setLocalMediaTrack("video", track);
@@ -916,7 +861,6 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			return;
 		}
 
-		const mh = getMediaHandler(sfuManager.value);
 		const { stream: audioOnlyStream } = await acquireUserMedia(false, true, {
 			micDeviceId: deviceId,
 		});
@@ -942,21 +886,11 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			return;
 		}
 
-		if (
-			mh?.audioProducer &&
-			typeof mh.audioProducer.replaceTrack === "function"
-		) {
-			await mh.audioProducer.replaceTrack({ track: trackToPublish });
-			return;
-		}
-
-		if (!mh?.audioProducer && sfuManager.value?.transportManager) {
-			const producer = await sfuManager.value.transportManager.createProducer(
-				trackToPublish,
-				{ type: "microphone" },
-			);
-			mh?.setProducers({ audioProducer: producer as ProducerLike });
-		}
+		await sfuManager.value?.reconcileLocalProducerTrack(
+			"audio",
+			trackToPublish,
+			{ resume: true },
+		);
 	};
 
 	const switchCam = async (deviceId: string) => {
@@ -1514,13 +1448,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			try {
 				if (manager) {
 					await manager.serializeSendMediaMutation(async () => {
-						const mediaHandler = getMediaHandler(manager);
-						const producer = mediaHandler?.audioProducer;
-						producer?.close?.();
-						if (producer?.id && sfuClient.isConnected()) {
-							void sfuClient.closeProducer(producer.id).catch(() => {});
-						}
-						if (mediaHandler) mediaHandler.audioProducer = null;
+						manager.closeLocalProducer("audio");
 						manager.setLocalMediaTrack("audio", null);
 					});
 				}
@@ -1600,40 +1528,15 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				throw new Error("No live microphone track available after recovery");
 			}
 
-			const manager = sfuManager.value;
-			if (manager) {
-				await manager.serializeSendMediaMutation(async () => {
-					assertCurrentCameraOperation(operation);
-					if (!mediaState.isMicOn || candidate.readyState !== "live") {
-						throw new Error("Microphone recovery became stale");
-					}
-					const mediaHandler = getMediaHandler(manager);
-					const producer = mediaHandler?.audioProducer;
-					if (producer) {
-						if (typeof producer.replaceTrack !== "function") {
-							throw new Error("Microphone producer cannot replace its track");
-						}
-						await producer.replaceTrack({ track: trackToPublish });
-						if (trackToPublish.readyState !== "live") {
-							throw new Error("Microphone track ended during recovery");
-						}
-						producer.resume?.();
-					} else if (manager.transportManager) {
-						const nextProducer = await manager.transportManager.createProducer(
-							trackToPublish,
-							{ type: "microphone" },
-						);
-						if (trackToPublish.readyState !== "live") {
-							nextProducer.close?.();
-							throw new Error("Microphone track ended during recovery");
-						}
-						mediaHandler?.setProducers({
-							audioProducer: nextProducer as ProducerLike,
-						});
-					}
-					manager.setLocalMediaTrack("audio", trackToPublish);
-				});
+			assertCurrentCameraOperation(operation);
+			if (!mediaState.isMicOn || candidate.readyState !== "live") {
+				throw new Error("Microphone recovery became stale");
 			}
+			await sfuManager.value?.reconcileLocalProducerTrack(
+				"audio",
+				trackToPublish,
+				{ resume: true },
+			);
 			for (const track of acquiredStream.getTracks()) {
 				if (track !== candidate) stopLifecycleTrack(track);
 			}
@@ -1705,16 +1608,8 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				"speaker",
 			);
 
-			if (validSpeakerId && sfuManager.value?.videoManager) {
-				const audioElements = sfuManager.value.videoManager.audioElements;
-
-				for (const [, audioElement] of audioElements) {
-					try {
-						await audioElement.setSinkId(validSpeakerId);
-					} catch (error) {
-						console.warn("Failed to set speaker for participant:", error);
-					}
-				}
+			if (validSpeakerId && sfuManager.value) {
+				await sfuManager.value.setAudioOutputDevice(validSpeakerId);
 			}
 		} catch (error) {
 			console.warn("Failed to apply speaker device:", error);
@@ -1810,7 +1705,6 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 	const toggleMicrophoneImplementation = async () => {
 		try {
 			const enable = !mediaState.isMicOn;
-			const mh = getMediaHandler(sfuManager.value);
 			let stream = mediaState.localStream;
 
 			if (enable) {
@@ -1894,29 +1788,11 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				}
 
 				const track = await getProcessedAudioTrack(stream);
-				if (mh?.audioProducer) {
-					const audioProducer = mh.audioProducer;
-					const currentTrack = audioProducer.track;
-					if (track) {
-						track.enabled = true;
-						if (
-							currentTrack !== track &&
-							typeof audioProducer.replaceTrack === "function"
-						) {
-							await audioProducer.replaceTrack({ track });
-						}
-					}
-					audioProducer.resume?.();
-
-					if (sfuClient.isConnected()) {
-						sfuClient.resumeProducer(audioProducer.id).catch(() => {});
-					}
-				} else if (track && sfuManager.value?.transportManager) {
-					const producer =
-						await sfuManager.value.transportManager.createProducer(track, {
-							type: "microphone",
-						});
-					mh?.setProducers({ audioProducer: producer as ProducerLike });
+				if (track) {
+					track.enabled = true;
+					await sfuManager.value?.reconcileLocalProducerTrack("audio", track, {
+						resume: true,
+					});
 				}
 			} else {
 				if (stream) {
@@ -1932,14 +1808,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 					noiseCancellationSession = null;
 				}
 
-				if (mh?.audioProducer) {
-					const audioProducer = mh.audioProducer;
-					audioProducer.pause?.();
-
-					if (sfuClient.isConnected()) {
-						sfuClient.pauseProducer(audioProducer.id);
-					}
-				}
+				sfuManager.value?.pauseLocalProducer("audio");
 			}
 
 			mediaState.isMicOn = enable;
@@ -2114,8 +1983,8 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				return;
 			}
 			if (enable) {
-				const mediaHandler = getMediaHandler(sfuManager.value);
-				if (mediaHandler?.videoProducer) {
+				const manager = sfuManager.value;
+				if (manager?.getLocalProducerState("video")) {
 					try {
 						await reconcileCameraTrack(
 							null,
@@ -2160,25 +2029,17 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		extra: ScreenShareStopExtra = {},
 	) => {
 		const metadata = getScreenShareStopMetadata(reason, extra);
-		const mediaHandler = getMediaHandler(sfuManager.value);
-		const sp = mediaHandler?.screenProducer;
+		const manager = sfuManager.value;
+		const screenProducer = manager?.getLocalProducerState("screen");
 
 		mediaState.isScreenSharing = false;
 
-		if (sp?.id) {
-			sp.close?.();
-
-			if (sfuClient.isConnected()) {
-				sfuClient
-					.closeProducer(sp.id, {
-						...metadata,
-						producerId: sp.id,
-					})
-					.catch(() => {});
-			}
+		if (screenProducer?.id && manager) {
+			manager.closeLocalProducer("screen", {
+				...metadata,
+				producerId: screenProducer.id,
+			});
 		}
-
-		mediaHandler?.stopScreenShare();
 
 		const tracks = mediaState.screenShareStream?.getTracks?.();
 		if (tracks) {
@@ -2197,7 +2058,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		if (sfuClient.isConnected()) {
 			sfuClient.sendScreenShare("stop_share", {
 				...metadata,
-				producerId: sp?.id,
+				producerId: screenProducer?.id,
 				stoppedAt: Date.now(),
 			});
 		}
@@ -2244,45 +2105,53 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 
 				try {
 					const screenTrack = screenStream.getVideoTracks()[0];
-					if (!screenTrack || !sfuManager.value?.transportManager) {
+					const manager = sfuManager.value;
+					if (!screenTrack || !manager) {
 						throw new Error("Screen share transport is not available");
 					}
 
-					const producer =
-						await sfuManager.value.transportManager.createProducer(
-							screenTrack,
-							{ type: "screen" },
-						);
-					const mh = getMediaHandler(sfuManager.value);
-					if (mh) {
-						mh.setProducers({
-							screenProducer: producer,
-						});
+					screenTrack.addEventListener("ended", () => {
+						if (
+							mediaState.isScreenSharing &&
+							mediaState.screenShareStream === screenStream
+						) {
+							stopScreenShare("track-ended").catch((err) => {
+								console.error("track-ended screen share cleanup failed:", err);
+							});
+						}
+					});
+
+					const publication = await manager.publishScreenTrack(screenTrack);
+					if (!publication) {
+						if (
+							mediaState.isScreenSharing &&
+							mediaState.screenShareStream === screenStream
+						) {
+							await stopScreenShare(
+								screenTrack.readyState === "ended"
+									? "track-ended"
+									: "publish-failed",
+							);
+						}
+						return;
 					}
 
 					// Ensure audio producer is available
-					if (mh?.audioProducer?.paused) {
-						mh.audioProducer.resume?.();
-					} else if (!mh?.audioProducer) {
-						const localStream = mediaState.localStream;
-						const micTrack = localStream?.getAudioTracks?.()[0];
-						if (micTrack && sfuManager.value?.transportManager) {
-							try {
-								const newProducer =
-									await sfuManager.value.transportManager.createProducer(
-										micTrack,
-										{ type: "microphone" },
-									);
-								mh?.setProducers({
-									audioProducer: newProducer as ProducerLike,
-								});
-							} catch (err) {
-								console.warn(
-									"Failed to create audio producer after starting screen share",
-									err,
-								);
-							}
+					const audioProducer = manager.getLocalProducerState("audio");
+					const micTrack = mediaState.localStream?.getAudioTracks?.()[0];
+					if (micTrack) {
+						try {
+							await manager.reconcileLocalProducerTrack("audio", micTrack, {
+								resume: true,
+							});
+						} catch (err) {
+							console.warn(
+								"Failed to publish audio after starting screen share",
+								err,
+							);
 						}
+					} else if (audioProducer?.paused) {
+						manager.resumeLocalProducer("audio");
 					}
 				} catch (pubErr) {
 					console.error("Failed to publish screen share producer:", pubErr);
@@ -2292,15 +2161,17 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 					throw pubErr;
 				}
 
-				screenStream.getVideoTracks()[0].addEventListener("ended", () => {
-					if (mediaState.isScreenSharing) {
-						stopScreenShare("track-ended").catch((err) => {
-							console.error("track-ended screen share cleanup failed:", err);
-						});
-					}
-				});
-
-				if (sfuClient.isConnected()) {
+				const currentScreenPublication =
+					manager.getLocalProducerState("screen");
+				if (
+					sfuManager.value === manager &&
+					mediaState.isScreenSharing &&
+					mediaState.screenShareStream === screenStream &&
+					screenStream.getVideoTracks()[0]?.readyState === "live" &&
+					currentScreenPublication?.id === publication.id &&
+					currentScreenPublication.track === screenTrack &&
+					sfuClient.isConnected()
+				) {
 					sfuClient.sendScreenShare("start_share", {
 						startedAt: mediaState.localScreenShareStartedAt,
 					});
@@ -2341,9 +2212,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 	}
 
 	const setRemoteVideoRef = (participantId: string, el: HTMLVideoElement) => {
-		if (sfuManager.value?.videoManager) {
-			sfuManager.value.videoManager.registerVideoElement(participantId, el);
-		}
+		sfuManager.value?.registerVideoElement(participantId, el);
 	};
 
 	const setScreenShareVideoRef = (el: HTMLVideoElement) => {
@@ -2377,8 +2246,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 	watch(prefNoiseCancellationEnabled, (enabled) => {
 		void enqueueMicrophoneTransition(async () => {
 			const operation = createCameraOperation();
-			const mh = getMediaHandler(sfuManager.value);
-			if (!mediaState.isMicOn || !mh) return;
+			if (!mediaState.isMicOn) return;
 
 			const freshTrack = await getFreshMicTrack(operation);
 			assertCurrentCameraOperation(operation);
@@ -2401,10 +2269,12 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				}
 			}
 			assertCurrentCameraOperation(operation);
-			if (mh?.audioProducer && trackToPublish.readyState === "live") {
-				if (typeof mh.audioProducer.replaceTrack === "function") {
-					await mh.audioProducer.replaceTrack({ track: trackToPublish });
-				}
+			if (trackToPublish.readyState === "live") {
+				await sfuManager.value?.reconcileLocalProducerTrack(
+					"audio",
+					trackToPublish,
+					{ resume: true },
+				);
 			}
 		}).catch((error) => {
 			if (isCameraLifecycleAbort(error)) return;

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -2042,18 +2042,11 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 	) => {
 		const metadata = getScreenShareStopMetadata(reason, extra);
 		const manager = sfuManager.value;
-		const screenProducer = manager?.getLocalProducerState("screen");
+		const screenStream = mediaState.screenShareStream;
 
 		mediaState.isScreenSharing = false;
 
-		if (screenProducer?.id && manager) {
-			manager.closeLocalProducer("screen", {
-				...metadata,
-				producerId: screenProducer.id,
-			});
-		}
-
-		const tracks = mediaState.screenShareStream?.getTracks?.();
+		const tracks = screenStream?.getTracks?.();
 		if (tracks) {
 			for (const t of tracks) {
 				t.stop();
@@ -2065,15 +2058,11 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				delete mediaState.screenShareStreams[selfId];
 			}
 		}
-		mediaState.screenShareStream = null;
-
-		if (sfuClient.isConnected()) {
-			sfuClient.sendScreenShare("stop_share", {
-				...metadata,
-				producerId: screenProducer?.id,
-				stoppedAt: Date.now(),
-			});
+		if (mediaState.screenShareStream === screenStream) {
+			mediaState.screenShareStream = null;
 		}
+
+		await manager?.stopScreenShare(metadata);
 	};
 
 	const toggleScreenShare = async () => {

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -2165,28 +2165,28 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 					} else if (audioProducer?.paused) {
 						manager.resumeLocalProducer("audio");
 					}
+
+					const currentScreenPublication =
+						manager.getLocalProducerState("screen");
+					if (
+						sfuManager.value === manager &&
+						mediaState.isScreenSharing &&
+						mediaState.screenShareStream === screenStream &&
+						screenTrack.readyState === "live" &&
+						currentScreenPublication?.id === publication.id &&
+						currentScreenPublication.track === screenTrack &&
+						sfuClient.isConnected()
+					) {
+						sfuClient.sendScreenShare("start_share", {
+							startedAt: mediaState.localScreenShareStartedAt,
+						});
+					}
 				} catch (pubErr) {
 					console.error("Failed to publish screen share producer:", pubErr);
 					await stopScreenShare("publish-failed", {
 						message: (pubErr as Error)?.message,
 					});
 					throw pubErr;
-				}
-
-				const currentScreenPublication =
-					manager.getLocalProducerState("screen");
-				if (
-					sfuManager.value === manager &&
-					mediaState.isScreenSharing &&
-					mediaState.screenShareStream === screenStream &&
-					screenStream.getVideoTracks()[0]?.readyState === "live" &&
-					currentScreenPublication?.id === publication.id &&
-					currentScreenPublication.track === screenTrack &&
-					sfuClient.isConnected()
-				) {
-					sfuClient.sendScreenShare("start_share", {
-						startedAt: mediaState.localScreenShareStartedAt,
-					});
 				}
 			}
 		} catch (error) {

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -1803,6 +1803,17 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 						publicationOwner.closeLocalProducer("audio", {
 							reason: "manager-replaced",
 						});
+						track.enabled = false;
+						const rawAudioTracks = stream.getAudioTracks();
+						for (const audioTrack of rawAudioTracks) {
+							stream.removeTrack(audioTrack);
+							audioTrack.stop();
+						}
+						if (!rawAudioTracks.includes(track)) track.stop();
+						if (noiseCancellationSession) {
+							noiseCancellationSession.cleanup();
+							noiseCancellationSession = null;
+						}
 						return;
 					}
 				}

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -1705,6 +1705,8 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 	const toggleMicrophoneImplementation = async () => {
 		try {
 			const enable = !mediaState.isMicOn;
+			const publicationOwner = enable ? sfuManager.value : null;
+			if (enable && !publicationOwner) return;
 			let stream = mediaState.localStream;
 
 			if (enable) {
@@ -1789,10 +1791,15 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 
 				const track = await getProcessedAudioTrack(stream);
 				if (track) {
+					if (sfuManager.value !== publicationOwner) {
+						track.enabled = false;
+						return;
+					}
 					track.enabled = true;
-					await sfuManager.value?.reconcileLocalProducerTrack("audio", track, {
+					await publicationOwner.reconcileLocalProducerTrack("audio", track, {
 						resume: true,
 					});
+					if (sfuManager.value !== publicationOwner) return;
 				}
 			} else {
 				if (stream) {

--- a/frontend/src/apps/meet/composables/useMeetingHandlers.test.ts
+++ b/frontend/src/apps/meet/composables/useMeetingHandlers.test.ts
@@ -33,4 +33,19 @@ describe("useMeetingHandlers", () => {
 
 		expect(joinMeetingRoom).toHaveBeenCalledWith({ switchHere: true });
 	});
+
+	it.each([
+		["handleMuteParticipant", "mute_participant"],
+		["handleKickParticipant", "kick_participant"],
+		["handleLowerHand", "lower_hand"],
+	] as const)("routes %s through the meeting facade", async (handler, action) => {
+		const sendHostControl = vi.fn();
+		const handlers = useMeetingHandlers({
+			sfuConnection: { sfuManager: ref({ sendHostControl }) },
+		} as never);
+
+		await handlers[handler]("participant-1");
+
+		expect(sendHostControl).toHaveBeenCalledWith(action, "participant-1");
+	});
 });

--- a/frontend/src/apps/meet/composables/useMeetingHandlers.ts
+++ b/frontend/src/apps/meet/composables/useMeetingHandlers.ts
@@ -1,8 +1,6 @@
 import { frappeRequest, toast } from "frappe-ui";
 import type { Ref } from "vue";
 import type { Router } from "vue-router";
-import type { TransportManager } from "../utils/media/TransportManager";
-import type { SFUClient } from "../utils/SFUClient";
 import type { SFUMeetingManager } from "../utils/SFUMeetingManager";
 import type { ChatStore } from "./useChatStore";
 import type { ConnectionState } from "./useConnectionState";
@@ -36,41 +34,10 @@ interface MediaControlsActions {
 	) => Promise<void>;
 }
 
-interface ProducerLike {
-	id: string;
-	track: MediaStreamTrack | null;
-	replaceTrack?: (opts: { track: MediaStreamTrack }) => Promise<void>;
-	pause?: () => void;
-	resume?: () => void;
-	close?: () => void;
-}
-
-interface MediaHandlerLike {
-	audioProducer: ProducerLike | null;
-	videoProducer: ProducerLike | null;
-	screenProducer: ProducerLike | null;
-	setProducers: (producers: Partial<Pick<MediaHandlerLike,
-		"audioProducer" | "videoProducer" | "screenProducer"
-	>>) => void;
-	stopScreenShare: () => void;
-}
-
-interface VideoManagerLike {
-	audioElements: Map<string, HTMLAudioElement>;
-}
-
-interface SFUMeetingManagerLike {
-	sfuClient: SFUClient;
-	transportManager: TransportManager | null;
-	mediaHandler: MediaHandlerLike | null;
-	videoManager: VideoManagerLike | null;
-}
-
 export type MeetingDocLike = DocumentResource;
 
 interface SFUConnectionActions {
 	sfuManager: Ref<SFUMeetingManager | null>;
-	sfuClient: SFUClient;
 	joinMeetingRoom: (options?: { switchHere?: boolean }) => Promise<void>;
 	handleGuestJoinResult: (
 		joinResult: JoinPayload,
@@ -192,15 +159,10 @@ export function useMeetingHandlers(deps: MeetingHandlersDeps) {
 
 	const handleMuteParticipant = async (participantId: string) => {
 		try {
-			if (deps.sfuConnection.sfuManager.value?.sfuClient) {
-				deps.sfuConnection.sfuManager.value.sfuClient.sendEvent(
-					"host_control",
-					{
-						action: "mute_participant",
-						targetParticipantId: participantId,
-					},
-				);
-			}
+			deps.sfuConnection.sfuManager.value?.sendHostControl(
+				"mute_participant",
+				participantId,
+			);
 		} catch (error) {
 			console.error("Failed to mute participant:", error);
 		}
@@ -217,15 +179,10 @@ export function useMeetingHandlers(deps: MeetingHandlersDeps) {
 				});
 			}
 
-			if (deps.sfuConnection.sfuManager.value?.sfuClient) {
-				deps.sfuConnection.sfuManager.value.sfuClient.sendEvent(
-					"host_control",
-					{
-						action: "kick_participant",
-						targetParticipantId: participantId,
-					},
-				);
-			}
+			deps.sfuConnection.sfuManager.value?.sendHostControl(
+				"kick_participant",
+				participantId,
+			);
 		} catch (error) {
 			console.error("Failed to kick participant:", error);
 		}
@@ -233,15 +190,10 @@ export function useMeetingHandlers(deps: MeetingHandlersDeps) {
 
 	const handleLowerHand = async (participantId: string) => {
 		try {
-			if (deps.sfuConnection.sfuManager.value?.sfuClient) {
-				deps.sfuConnection.sfuManager.value.sfuClient.sendEvent(
-					"host_control",
-					{
-						action: "lower_hand",
-						targetParticipantId: participantId,
-					},
-				);
-			}
+			deps.sfuConnection.sfuManager.value?.sendHostControl(
+				"lower_hand",
+				participantId,
+			);
 		} catch (error) {
 			console.error("Failed to lower hand:", error);
 		}
@@ -319,9 +271,9 @@ export function useMeetingHandlers(deps: MeetingHandlersDeps) {
 			meetingId: deps.meetingId,
 			networkQuality: deps.connectionState.networkQuality,
 			localStream: deps.mediaState.localStream,
-			transportManager:
-				deps.sfuConnection.sfuManager.value?.transportManager || null,
-			sfuClient: deps.sfuConnection.sfuClient,
+			diagnostics:
+				(await deps.sfuConnection.sfuManager.value?.getConnectionDiagnostics()) ??
+				null,
 			recoveryTimeline: deps.sfuConnection.recoveryTimeline.value,
 		});
 	};

--- a/frontend/src/apps/meet/composables/useNetworkQuality.ts
+++ b/frontend/src/apps/meet/composables/useNetworkQuality.ts
@@ -1,9 +1,6 @@
-import { inject, onMounted, onUnmounted, type Ref, ref } from "vue";
+import { inject, onMounted, onUnmounted, type Ref, ref, watch } from "vue";
 import type { SFUMeetingManager } from "../utils/SFUMeetingManager";
-import {
-	MediaHealthMonitor,
-	type NetworkQuality,
-} from "../utils/media/MediaHealthMonitor";
+import type { NetworkQuality } from "../utils/media/MediaHealthMonitor";
 
 export type { NetworkQuality };
 
@@ -13,22 +10,53 @@ export function useNetworkQuality(
 	const networkQuality = ref<NetworkQuality>("good");
 	const downlinkQuality = ref<NetworkQuality>("good");
 	const isTransportFailed = ref(false);
-	const monitor = new MediaHealthMonitor(() => sfuManagerRef?.value ?? null);
-	let unsubscribe: (() => void) | null = null;
+	let stopWatching: (() => void) | null = null;
+	let stopMonitoring: (() => void) | null = null;
+	let managerGeneration = 0;
+	const reset = () => {
+		networkQuality.value = "good";
+		downlinkQuality.value = "good";
+		isTransportFailed.value = false;
+	};
+	const stopCurrentMonitoring = () => {
+		const stop = stopMonitoring;
+		stopMonitoring = null;
+		try {
+			stop?.();
+		} catch (error) {
+			console.warn("Failed to stop media health monitoring", error);
+		}
+	};
 
 	onMounted(() => {
-		unsubscribe = monitor.subscribe((state) => {
-			networkQuality.value = state.networkQuality;
-			downlinkQuality.value = state.downlinkQuality;
-			isTransportFailed.value = state.isTransportFailed;
-		});
-		monitor.start();
+		if (!sfuManagerRef) return;
+		stopWatching = watch(
+			sfuManagerRef,
+			(manager) => {
+				const generation = ++managerGeneration;
+				stopCurrentMonitoring();
+				reset();
+				stopMonitoring =
+					manager?.startMediaHealthMonitoring((state) => {
+						if (
+							generation !== managerGeneration ||
+							sfuManagerRef.value !== manager
+						) return;
+						networkQuality.value = state.networkQuality;
+						downlinkQuality.value = state.downlinkQuality;
+						isTransportFailed.value = state.isTransportFailed;
+					}) ?? null;
+			},
+			{ immediate: true },
+		);
 	});
 
 	onUnmounted(() => {
-		unsubscribe?.();
-		unsubscribe = null;
-		monitor.stop();
+		managerGeneration += 1;
+		stopWatching?.();
+		stopWatching = null;
+		stopCurrentMonitoring();
+		reset();
 	});
 
 	return { networkQuality, downlinkQuality, isTransportFailed };

--- a/frontend/src/apps/meet/composables/useRTCStats.ts
+++ b/frontend/src/apps/meet/composables/useRTCStats.ts
@@ -1,13 +1,11 @@
-import type { AppData, Consumer, Producer } from "mediasoup-client/types";
 import { computed, inject, onUnmounted, type Ref, ref, watch } from "vue";
-import type { SFUMeetingManager } from "../utils/SFUMeetingManager";
-import { isUnknownRecord } from "../types";
+import type {
+	RTCStatsReport,
+	RTCStatsSample,
+	SFUMeetingManager,
+} from "../utils/SFUMeetingManager";
 
-type StatsReport = Record<string, unknown> & {
-	id?: string;
-	type?: string;
-	timestamp?: number;
-};
+type StatsReport = RTCStatsReport;
 
 type CounterSample = {
 	bytes: number;
@@ -89,7 +87,8 @@ function reports(stats: unknown): StatsReport[] {
 	const values = (stats as { values?: () => IterableIterator<unknown> }).values?.();
 	return values
 		? Array.from(values).filter(
-				(report): report is StatsReport => isUnknownRecord(report),
+				(report): report is StatsReport =>
+					!!report && typeof report === "object",
 			)
 		: [];
 }
@@ -151,22 +150,6 @@ function qualityFor(snapshot: RTCStatsSnapshot): RTCStatsSnapshot["quality"] {
 	return snapshot.rtt === undefined && snapshot.streams.length === 0 ? "unknown" : "good";
 }
 
-function sourceForProducer(producer: Producer): RTCStreamStats["source"] {
-	if (producer.kind === "audio") return "microphone";
-	return producer.appData?.type === "screen" ? "screen" : "camera";
-}
-
-function sourceForConsumer(entry: {
-	kind: string;
-	isScreen?: boolean;
-	appData?: AppData;
-}): RTCStreamStats["source"] {
-	if (entry.kind === "audio") return "remote audio";
-	return entry.isScreen || entry.appData?.type === "screen"
-		? "remote screen"
-		: "remote video";
-}
-
 export function useRTCStats(active: Ref<boolean>) {
 	const managerRef = inject<Ref<SFUMeetingManager | null>>("sfuManager");
 	const snapshot = ref<RTCStatsSnapshot>({ ...EMPTY_SNAPSHOT });
@@ -183,11 +166,11 @@ export function useRTCStats(active: Ref<boolean>) {
 		participantId?: string;
 		paused: boolean;
 		muted: boolean;
-		track?: MediaStreamTrack | null;
-		getStats: () => Promise<unknown>;
+		trackSettings: Readonly<MediaTrackSettings>;
+		stats: unknown;
 	}): Promise<RTCStreamStats | null> {
 		try {
-			const allReports = reports(await options.getStats());
+			const allReports = reports(options.stats);
 			const primaryType = options.direction === "send" ? "outbound-rtp" : "inbound-rtp";
 			const primary = selectPrimaryRtpReport(allReports, primaryType);
 			if (!primary) return null;
@@ -212,7 +195,7 @@ export function useRTCStats(active: Ref<boolean>) {
 			const currentSample = { bytes, packets, lost, timestamp };
 			const previous = samples.get(key);
 			samples.set(key, currentSample);
-			const trackSettings = options.track?.getSettings?.() ?? {};
+			const trackSettings = options.trackSettings;
 			const jitterBufferEmitted = numberValue(primary.jitterBufferEmittedCount);
 			const jitterBufferTotal = numberValue(primary.jitterBufferDelay);
 
@@ -250,11 +233,10 @@ export function useRTCStats(active: Ref<boolean>) {
 		}
 	}
 
-	async function getRoute(manager: SFUMeetingManager) {
-		const transports = [manager.transportManager.sendTransport, manager.transportManager.recvTransport].filter(Boolean);
-		for (const transport of transports) {
+	function getRoute(sample: RTCStatsSample) {
+		for (const transportReports of sample.transportReports) {
 			try {
-				const allReports = reports(await transport?.getStats());
+				const allReports = reports(transportReports);
 				const candidatePairs = allReports.filter((report) => report.type === "candidate-pair");
 				const pair = candidatePairs.find((report) => report.selected === true || report.nominated === true)
 					?? candidatePairs.find((report) => report.state === "succeeded");
@@ -287,39 +269,19 @@ export function useRTCStats(active: Ref<boolean>) {
 
 		isPolling.value = true;
 		try {
-			const producers = [
-				manager.mediaHandler.audioProducer,
-				manager.mediaHandler.videoProducer,
-				manager.mediaHandler.screenProducer,
-			].filter((producer): producer is Producer => !!producer && !producer.closed);
-			const consumers = manager.consumerManager.getAllConsumers();
-			const streamPromises: Array<Promise<RTCStreamStats | null>> = [
-				...producers.map((producer) => streamStats({
-					id: producer.id,
-					direction: "send",
-					kind: producer.kind,
-					source: sourceForProducer(producer),
-					paused: producer.paused,
-					muted: producer.track?.muted ?? false,
-					track: producer.track,
-					getStats: () => producer.getStats(),
-				})),
-				...consumers.map((entry) => streamStats({
-					id: entry.id,
-					direction: "receive",
-					kind: entry.kind,
-					source: sourceForConsumer(entry),
-					participantId: entry.participantId,
-					paused: entry.consumer.paused,
-					muted: entry.track?.muted ?? false,
-					track: entry.track,
-					getStats: () => entry.consumer.getStats(),
-				})),
-			];
+			const sourceSample = await manager.sampleRTCStats();
+			if (managerRef?.value !== manager || !active.value) return;
+			const streamPromises = sourceSample.streams.map((stream) =>
+				streamStats({
+					...stream,
+					stats: stream.reports,
+				}),
+			);
 			const [route, streamResults] = await Promise.all([
-				getRoute(manager),
+				getRoute(sourceSample),
 				Promise.all(streamPromises),
 			]);
+			if (managerRef?.value !== manager || !active.value) return;
 			const streams = streamResults.filter((stream): stream is RTCStreamStats => !!stream);
 			const sending = streams.filter((stream) => stream.direction === "send");
 			const receiving = streams.filter((stream) => stream.direction === "receive");
@@ -333,9 +295,9 @@ export function useRTCStats(active: Ref<boolean>) {
 				outboundPacketLoss: mean(sending.map((stream) => stream.packetLoss)),
 				uploadBitrate: sum(sending.map((stream) => stream.bitrate)),
 				downloadBitrate: sum(receiving.map((stream) => stream.bitrate)),
-				signalingConnected: manager.sfuClient?.getConnectionStatus?.().connected ?? false,
-				sendTransportState: manager.transportManager.sendTransport?.connectionState ?? "closed",
-				receiveTransportState: manager.transportManager.recvTransport?.connectionState ?? "closed",
+				signalingConnected: sourceSample.signalingConnected,
+				sendTransportState: sourceSample.sendTransportState,
+				receiveTransportState: sourceSample.receiveTransportState,
 				streams,
 			};
 			next.quality = qualityFor(next);
@@ -360,7 +322,10 @@ export function useRTCStats(active: Ref<boolean>) {
 		pollTimer = setInterval(poll, RTC_STATS_POLL_INTERVAL_MS);
 	}, { immediate: true });
 
-	onUnmounted(stop);
+	onUnmounted(() => {
+		stop();
+		samples.clear();
+	});
 
 	return {
 		snapshot,

--- a/frontend/src/apps/meet/composables/useTileAdaptiveStreaming.ts
+++ b/frontend/src/apps/meet/composables/useTileAdaptiveStreaming.ts
@@ -1,14 +1,14 @@
 import { debounce } from "frappe-ui";
 import type { Ref } from "vue";
-import { inject, onBeforeUnmount } from "vue";
+import { inject, onBeforeUnmount, watch } from "vue";
 
 type SFUMeetingManagerLike = {
-	getVideoConsumerEntry: (participantId: string) => { id: string } | null;
+	getVideoConsumerId: (participantId: string) => string | null;
 	updateConsumerStreamPreferences: (
 		consumerId: string,
-		preferences: { visible: boolean; width?: number; height?: number },
+		preferences: { visible: boolean; width: number; height: number },
 	) => Promise<unknown> | unknown;
-	eventTarget?: EventTarget;
+	onRemoteConsumerReady: (listener: (event: Event) => void) => () => void;
 };
 
 interface TileMetrics {
@@ -18,6 +18,7 @@ interface TileMetrics {
 }
 
 interface TileController {
+	active: boolean;
 	participantId: string;
 	element: HTMLVideoElement;
 	resizeObserver: ResizeObserver | null;
@@ -29,7 +30,7 @@ interface TileController {
 	lastSent: TileMetrics | null;
 	debouncedUpdate: (() => void) | null;
 	initialPending: boolean;
-	consumerReadyListener: ((event: Event) => void) | null;
+	stopListeningForConsumer: (() => void) | null;
 }
 
 const VISIBILITY_THRESHOLD = 0.1;
@@ -48,7 +49,7 @@ function isElementInViewport(element: HTMLElement): boolean {
 }
 
 export function useTileAdaptiveStreaming() {
-	const injectedManager = inject<Ref<SFUMeetingManagerLike>>("sfuManager");
+	const injectedManager = inject<Ref<SFUMeetingManagerLike | null>>("sfuManager");
 	const controllers = new Map<string, TileController>();
 
 	function getManager(): SFUMeetingManagerLike | null {
@@ -58,13 +59,12 @@ export function useTileAdaptiveStreaming() {
 	}
 
 	async function updateConsumerPreferences(controller: TileController) {
+		if (!controller.active) return;
 		const manager = getManager();
 		if (!manager) return;
 
-		const consumerEntry = manager.getVideoConsumerEntry(
-			controller.participantId,
-		);
-		if (!consumerEntry?.id) return;
+		const consumerId = manager.getVideoConsumerId(controller.participantId);
+		if (!consumerId) return;
 
 		const visible =
 			controller.visible && controller.width > 0 && controller.height > 0;
@@ -94,11 +94,12 @@ export function useTileAdaptiveStreaming() {
 		controller.forceNext = false;
 
 		try {
-			await manager.updateConsumerStreamPreferences(consumerEntry.id, {
+			await manager.updateConsumerStreamPreferences(consumerId, {
 				visible,
 				width,
 				height,
 			});
+			if (!controller.active || getManager() !== manager) return;
 			controller.lastSent = { visible, width, height };
 			if (controller.initialPending) {
 				controller.initialPending = false;
@@ -113,6 +114,7 @@ export function useTileAdaptiveStreaming() {
 	}
 
 	function scheduleUpdate(controller: TileController, immediate = false) {
+		if (!controller.active) return;
 		if (immediate) {
 			controller.forceNext = true;
 			void updateConsumerPreferences(controller);
@@ -122,26 +124,35 @@ export function useTileAdaptiveStreaming() {
 	}
 
 	function cleanupController(controller: TileController) {
+		controller.active = false;
 		if (controller.resizeObserver) {
 			controller.resizeObserver.disconnect();
 		}
 		if (controller.intersectionObserver) {
 			controller.intersectionObserver.disconnect();
 		}
-		if (controller.consumerReadyListener) {
-			const manager = getManager();
-			if (manager?.eventTarget) {
-				manager.eventTarget.removeEventListener(
-					"consumerReady",
-					controller.consumerReadyListener,
-				);
-			}
-			controller.consumerReadyListener = null;
-		}
+		controller.stopListeningForConsumer?.();
+		controller.stopListeningForConsumer = null;
+	}
+
+	function bindControllerToManager(controller: TileController) {
+		controller.stopListeningForConsumer?.();
+		controller.stopListeningForConsumer = null;
+		const manager = getManager();
+		if (!manager) return;
+		controller.stopListeningForConsumer = manager.onRemoteConsumerReady(
+			(event: Event) => {
+				const customEvent = event as CustomEvent;
+				if (customEvent.detail?.participantId === controller.participantId) {
+					scheduleUpdate(controller, false);
+				}
+			},
+		);
 	}
 
 	function createController(participantId: string, element: HTMLVideoElement) {
 		const controller: TileController = {
+			active: true,
 			participantId,
 			element,
 			resizeObserver: null,
@@ -154,25 +165,14 @@ export function useTileAdaptiveStreaming() {
 			initialPending: true,
 			lastSent: null,
 			debouncedUpdate: null,
-			consumerReadyListener: null,
+			stopListeningForConsumer: null,
 		};
 
 		controller.debouncedUpdate = debounce(() => {
 			void updateConsumerPreferences(controller);
 		}, DEBOUNCE_MS);
 
-		// Listen for consumer ready event
-		const manager = getManager();
-		if (manager?.eventTarget) {
-			const listener = (event: Event) => {
-				const customEvent = event as CustomEvent;
-				if (customEvent.detail?.participantId === participantId) {
-					scheduleUpdate(controller, false);
-				}
-			};
-			controller.consumerReadyListener = listener;
-			manager.eventTarget.addEventListener("consumerReady", listener);
-		}
+		bindControllerToManager(controller);
 
 		// to check size of the tile
 		controller.resizeObserver = new ResizeObserver((entries) => {
@@ -254,7 +254,18 @@ export function useTileAdaptiveStreaming() {
 		controllers.set(participantId, controller);
 	}
 
+	const stopWatchingManager = injectedManager
+		? watch(injectedManager, () => {
+				for (const controller of controllers.values()) {
+					bindControllerToManager(controller);
+					controller.lastSent = null;
+					scheduleUpdate(controller, true);
+				}
+			})
+		: () => {};
+
 	onBeforeUnmount(() => {
+		stopWatchingManager();
 		for (const controller of controllers.values()) {
 			cleanupController(controller);
 		}

--- a/frontend/src/apps/meet/pages/Meeting.vue
+++ b/frontend/src/apps/meet/pages/Meeting.vue
@@ -1013,12 +1013,8 @@ const setSinkIdOnVideoElements = async (sinkId: string) => {
 		);
 	}
 
-	if (sfuConnection.sfuManager.value?.videoManager) {
-		for (const [, audioElement] of sfuConnection.sfuManager.value.videoManager
-			.audioElements) {
-			promises.push(audioElement.setSinkId(sinkId).catch(() => {}));
-		}
-	}
+	const manager = sfuConnection.sfuManager.value;
+	if (manager) promises.push(manager.setAudioOutputDevice(sinkId));
 
 	await Promise.all(promises);
 };

--- a/frontend/src/apps/meet/utils/SFUClient.ts
+++ b/frontend/src/apps/meet/utils/SFUClient.ts
@@ -905,8 +905,17 @@ export class SFUClient {
 		return this.sendRequest("pause_producer", { producerId });
 	}
 
-	async resumeProducer(producerId: string): Promise<unknown> {
-		return this.sendRequest("resume_producer", { producerId });
+	async resumeProducer(
+		producerId: string,
+	): Promise<{ success: true; resumed: boolean }> {
+		const response = requireObject(
+			await this.sendRequest("resume_producer", { producerId }),
+			"producer resume",
+		);
+		if (response.success !== true || typeof response.resumed !== "boolean") {
+			throw new Error("Invalid producer resume response");
+		}
+		return { success: true, resumed: response.resumed };
 	}
 
 	async closeConsumer(consumerId: string): Promise<unknown> {

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -9,10 +9,11 @@
  */
 
 import { ConsumerManager } from "./media/ConsumerManager";
+import type { ConsumerEntry } from "./media/ConsumerManager";
 import { ParticipantManager } from "./media/ParticipantManager";
 import { TransportManager } from "./media/TransportManager";
 import { VideoElementManager } from "./media/VideoElementManager";
-import type { SFUClient } from "./SFUClient";
+import type { ProducerCloseMetadata, SFUClient } from "./SFUClient";
 import type { User } from "../composables/useCurrentUser";
 import type { JoinRoomMediaState, JoinUserData } from "../types";
 import {
@@ -28,6 +29,11 @@ import {
 } from "./sfu/SFURecoveryManager";
 import { ExpectedMediaReconciler } from "./sfu/ExpectedMediaReconciler";
 import { getClientTelemetry } from "./telemetry/ClientTelemetry";
+import {
+	MediaHealthMonitor,
+	type MediaHealthState,
+} from "./media/MediaHealthMonitor";
+import type { Producer } from "mediasoup-client/types";
 
 const isAbortError = (error: unknown) =>
 	(error as { name?: unknown } | null)?.name === "AbortError";
@@ -51,18 +57,166 @@ export interface E2EEPublicationResult {
 	audioPublished: boolean;
 }
 
+export type LocalProducerKind = "audio" | "video" | "screen";
+
+export interface LocalProducerState {
+	id: string;
+	track: MediaStreamTrack | null;
+	paused: boolean;
+}
+
+export interface ConnectionDiagnostics {
+	connectionStatus: ReturnType<SFUClient["getConnectionStatus"]>;
+	transportStats: ReturnType<TransportManager["getTransportStats"]>;
+	networkStats: Awaited<ReturnType<TransportManager["getNetworkStats"]>> | null;
+}
+
+export type RTCStatsReport = Readonly<{
+	id?: string;
+	type?: string;
+	timestamp?: number;
+	isRemote?: boolean;
+	codecId?: string;
+	mimeType?: string;
+	remoteId?: string;
+	localId?: string;
+	bytesSent?: number;
+	bytesReceived?: number;
+	packetsLost?: number;
+	packetsReceived?: number;
+	packetsSent?: number;
+	jitter?: number;
+	roundTripTime?: number;
+	frameWidth?: number;
+	frameHeight?: number;
+	framesPerSecond?: number;
+	framesDropped?: number;
+	framesEncoded?: number;
+	framesDecoded?: number;
+	qualityLimitationReason?: string;
+	scalabilityMode?: string;
+	nackCount?: number;
+	pliCount?: number;
+	firCount?: number;
+	jitterBufferEmittedCount?: number;
+	jitterBufferDelay?: number;
+	concealedSamples?: number;
+	totalSamplesReceived?: number;
+	selected?: boolean;
+	nominated?: boolean;
+	state?: string;
+	localCandidateId?: string;
+	remoteCandidateId?: string;
+	currentRoundTripTime?: number;
+	availableOutgoingBitrate?: number;
+	protocol?: string;
+	candidateType?: string;
+}>;
+
+const RTC_STATS_REPORT_KEYS = [
+	"id",
+	"type",
+	"timestamp",
+	"isRemote",
+	"codecId",
+	"mimeType",
+	"remoteId",
+	"localId",
+	"bytesSent",
+	"bytesReceived",
+	"packetsLost",
+	"packetsReceived",
+	"packetsSent",
+	"jitter",
+	"roundTripTime",
+	"frameWidth",
+	"frameHeight",
+	"framesPerSecond",
+	"framesDropped",
+	"framesEncoded",
+	"framesDecoded",
+	"qualityLimitationReason",
+	"scalabilityMode",
+	"nackCount",
+	"pliCount",
+	"firCount",
+	"jitterBufferEmittedCount",
+	"jitterBufferDelay",
+	"concealedSamples",
+	"totalSamplesReceived",
+	"selected",
+	"nominated",
+	"state",
+	"localCandidateId",
+	"remoteCandidateId",
+	"currentRoundTripTime",
+	"availableOutgoingBitrate",
+	"protocol",
+	"candidateType",
+] as const satisfies readonly (keyof RTCStatsReport)[];
+
+export type RTCStatsStreamSample = Readonly<{
+	id: string;
+	direction: "send" | "receive";
+	kind: "audio" | "video";
+	source:
+		| "microphone"
+		| "camera"
+		| "screen"
+		| "remote audio"
+		| "remote video"
+		| "remote screen";
+	participantId?: string;
+	paused: boolean;
+	muted: boolean;
+	trackSettings: Readonly<MediaTrackSettings>;
+	reports: readonly RTCStatsReport[];
+}>;
+
+export type RTCStatsSample = Readonly<{
+	transportReports: readonly (readonly RTCStatsReport[])[];
+	streams: readonly RTCStatsStreamSample[];
+	signalingConnected: boolean;
+	sendTransportState: string;
+	receiveTransportState: string;
+}>;
+
+function snapshotRTCStatsReports(stats: unknown): readonly RTCStatsReport[] {
+	if (!stats || typeof stats !== "object") return Object.freeze([]);
+	const values = (stats as { values?: () => IterableIterator<unknown> }).values?.();
+	if (!values) return Object.freeze([]);
+	return Object.freeze(
+		Array.from(values).flatMap((report) => {
+			if (!report || typeof report !== "object") return [];
+			const entries = RTC_STATS_REPORT_KEYS.flatMap((key) => {
+				const value = Reflect.get(report, key) as unknown;
+				return typeof value === "string" ||
+					typeof value === "number" ||
+					typeof value === "boolean"
+					? [[key, value] as const]
+					: [];
+			});
+			return [
+				Object.freeze(Object.fromEntries(entries) as RTCStatsReport),
+			];
+		}),
+	);
+}
+
 export class SFUMeetingManager {
-	sfuClient: SFUClient;
-
-	videoManager: VideoElementManager;
-	participantManager: ParticipantManager;
-	consumerManager: ConsumerManager;
-	transportManager: TransportManager;
-
+	private readonly sfuClient: SFUClient;
+	private readonly videoManager: VideoElementManager;
+	private readonly participantManager: ParticipantManager;
+	private readonly consumerManager: ConsumerManager;
+	private readonly transportManager: TransportManager;
 	private connectionManager: ParticipantConnection;
-	mediaManager: SFUMediaManager;
+	private readonly mediaManager: SFUMediaManager;
 	private recoveryManager: SFURecoveryManager;
+	private readonly mediaHealthMonitor: MediaHealthMonitor;
+	private mediaHealthSubscriberCount = 0;
 	private consumerPreferenceGenerations = new Map<string, number>();
+	private screenPublicationGeneration = 0;
+	private screenPublicationTrack: MediaStreamTrack | null = null;
 
 	constructor(sfuClient: SFUClient) {
 		this.sfuClient = sfuClient;
@@ -71,6 +225,7 @@ export class SFUMeetingManager {
 		this.participantManager = new ParticipantManager();
 		this.consumerManager = new ConsumerManager();
 		this.transportManager = new TransportManager();
+		this.transportManager.initialize(sfuClient);
 
 		this.recoveryManager = new SFURecoveryManager({
 			sfuClient,
@@ -117,6 +272,8 @@ export class SFUMeetingManager {
 				videoManager: this.videoManager,
 				consumerManager: this.consumerManager,
 				participantManager: this.participantManager,
+				isScreenPublicationCurrent: (track) =>
+					this.screenPublicationTrack === track && track.readyState === "live",
 			},
 			() => this.connectionManager?.getCurrentUserId() ?? null,
 		);
@@ -142,6 +299,42 @@ export class SFUMeetingManager {
 					);
 			}),
 		});
+
+		this.mediaHealthMonitor = new MediaHealthMonitor({
+			getTransportStats: () => this.transportManager.getTransportStats(),
+			getNetworkStats: () => this.transportManager.getNetworkStats(),
+			getConsumers: () => this.consumerManager.getAllConsumers(),
+			getConsumer: (consumerId) => this.consumerManager.getConsumer(consumerId),
+			isConsumerPaused: (entry) => this.isConsumerPaused(entry),
+			recoverConsumer: (entry) => this.mediaManager.recoverConsumer(entry),
+			requestConsumerKeyFrame: (consumerId) =>
+				this.sfuClient.requestConsumerKeyFrame(consumerId),
+			reconcileExpectedMedia: () => this.reconcileExpectedMedia(),
+			recoverBrowserLifecycle: () => this.recoverBrowserLifecycle(),
+			observeRemoteMediaProgress: (producerId, media, flowing, decoding) =>
+				this.observeRemoteMediaProgress(producerId, media, flowing, decoding),
+			resetReceiveMedia: () => this.resetReceiveMedia(),
+			reportNetworkQuality: (stats) =>
+				getClientTelemetry(this.sfuClient).reportNetworkQuality(stats),
+			markFirstRemoteMedia: (media) =>
+				getClientTelemetry(this.sfuClient).markFirstRemoteMedia(media),
+			reportMediaStalls: (media) =>
+				getClientTelemetry(this.sfuClient).reportMediaStalls(media),
+		});
+	}
+
+	private isConsumerPaused(entry: ConsumerEntry): boolean {
+		const participant = this.participantManager.getParticipant(entry.participantId);
+		return (
+			entry.consumer.paused ||
+			(entry.consumer as typeof entry.consumer & { producerPaused?: boolean })
+				.producerPaused ||
+			entry.adaptivelyPaused ||
+			(entry.kind === "audio" && participant?.audio_enabled === false) ||
+			(entry.kind === "video" &&
+				!entry.isScreen &&
+				participant?.video_enabled === false)
+		);
 	}
 
 	initialize(options: SFUMeetingManagerOptions): void {
@@ -247,16 +440,9 @@ export class SFUMeetingManager {
 
 		try {
 			const mediaHandler = this.mediaManager.mediaHandler;
-			const closeUnusableProducer = (
-				producer: NonNullable<typeof mediaHandler.videoProducer>,
-			) => {
-				producer.close();
-				if (producer.id && this.sfuClient.isConnected()) {
-					void this.sfuClient.closeProducer?.(producer.id).catch(() => {});
-				}
-			};
 			const hadVideo = !!mediaHandler.videoProducer;
 			const hadAudio = !!mediaHandler.audioProducer;
+			const hadScreen = !!mediaHandler.screenProducer;
 			const videoTrack = hadVideo
 				? (videoStream
 						?.getVideoTracks()
@@ -267,6 +453,26 @@ export class SFUMeetingManager {
 						?.getAudioTracks()
 						.find((track) => track.readyState === "live") ?? null)
 				: null;
+			const existingScreenTrack = hadScreen
+				? (mediaHandler.screenProducer?.track ?? null)
+				: null;
+			if (
+				existingScreenTrack?.readyState === "live" &&
+				(!this.screenPublicationTrack ||
+					this.screenPublicationTrack === existingScreenTrack)
+			) {
+				this.screenPublicationTrack = existingScreenTrack;
+			}
+			const screenTrack =
+				existingScreenTrack?.readyState === "live" &&
+				this.screenPublicationTrack === existingScreenTrack
+					? existingScreenTrack
+					: null;
+			const screenGeneration = this.screenPublicationGeneration;
+			const isCurrentScreenTrack = () =>
+				this.screenPublicationGeneration === screenGeneration &&
+				this.screenPublicationTrack === screenTrack &&
+				screenTrack?.readyState === "live";
 
 			await this.mediaManager.cancelPendingSubscriptions();
 			throwIfAborted(signal);
@@ -283,7 +489,7 @@ export class SFUMeetingManager {
 			await this.transportManager.createReceiveTransport();
 			throwIfAborted(signal);
 
-			if (hadVideo || hadAudio) {
+			if (videoTrack || audioTrack || screenTrack) {
 				await this.transportManager.createSendTransport();
 				throwIfAborted(signal);
 
@@ -299,14 +505,14 @@ export class SFUMeetingManager {
 								},
 							);
 							if (signal?.aborted) {
-								closeUnusableProducer(videoProducer);
+								this.closeProducerInstance(videoProducer);
 								throwIfAborted(signal);
 							}
 							if (
 								videoTrack.readyState !== "live" ||
 								videoProducer.track?.readyState === "ended"
 							) {
-								closeUnusableProducer(videoProducer);
+								this.closeProducerInstance(videoProducer);
 								this.mediaManager.setLocalTrack("video", null);
 							} else {
 								mediaHandler.setProducers({ videoProducer });
@@ -334,14 +540,14 @@ export class SFUMeetingManager {
 								},
 							);
 							if (signal?.aborted) {
-								closeUnusableProducer(audioProducer);
+								this.closeProducerInstance(audioProducer);
 								throwIfAborted(signal);
 							}
 							if (
 								audioTrack.readyState !== "live" ||
 								audioProducer.track?.readyState === "ended"
 							) {
-								closeUnusableProducer(audioProducer);
+								this.closeProducerInstance(audioProducer);
 								this.mediaManager.setLocalTrack("audio", null);
 							} else {
 								mediaHandler.setProducers({ audioProducer });
@@ -356,6 +562,33 @@ export class SFUMeetingManager {
 						);
 					}
 				}
+
+				if (screenTrack && isCurrentScreenTrack()) {
+					try {
+						const screenProducer = await this.transportManager.createProducer(
+							screenTrack,
+							{ type: "screen" },
+						);
+						if (signal?.aborted) {
+							this.closeProducerInstance(screenProducer);
+							throwIfAborted(signal);
+						}
+						if (
+							!isCurrentScreenTrack() ||
+							screenProducer.track?.readyState === "ended"
+						) {
+							this.closeProducerInstance(screenProducer);
+						} else {
+							mediaHandler.setProducers({ screenProducer });
+						}
+					} catch (error) {
+						if (isAbortError(error)) throw error;
+						console.warn(
+							"Failed to re-publish screen after E2EE conversion:",
+							error,
+						);
+					}
+				}
 			}
 			await this.connectionManager.setupExistingParticipants();
 			throwIfAborted(signal);
@@ -365,7 +598,7 @@ export class SFUMeetingManager {
 					mediaHandler.videoProducer?.track?.readyState === "ended")
 			) {
 				if (mediaHandler.videoProducer) {
-					closeUnusableProducer(mediaHandler.videoProducer);
+					this.closeProducerInstance(mediaHandler.videoProducer);
 				}
 				mediaHandler.setProducers({ videoProducer: null });
 				this.mediaManager.setLocalTrack("video", null);
@@ -377,11 +610,19 @@ export class SFUMeetingManager {
 					mediaHandler.audioProducer?.track?.readyState === "ended")
 			) {
 				if (mediaHandler.audioProducer) {
-					closeUnusableProducer(mediaHandler.audioProducer);
+					this.closeProducerInstance(mediaHandler.audioProducer);
 				}
 				mediaHandler.setProducers({ audioProducer: null });
 				this.mediaManager.setLocalTrack("audio", null);
 				publicationResult.audioPublished = false;
+			}
+			if (
+				mediaHandler.screenProducer &&
+				(!isCurrentScreenTrack() ||
+					mediaHandler.screenProducer.track?.readyState === "ended")
+			) {
+				this.closeProducerInstance(mediaHandler.screenProducer);
+				mediaHandler.setProducers({ screenProducer: null });
 			}
 			console.log("E2EE reconfiguration completed");
 			return publicationResult;
@@ -423,12 +664,412 @@ export class SFUMeetingManager {
 		});
 	}
 
+	startMediaHealthMonitoring(
+		listener: (state: MediaHealthState) => void,
+	): () => void {
+		this.mediaHealthSubscriberCount += 1;
+		const unsubscribe = this.mediaHealthMonitor.subscribe(listener);
+		this.mediaHealthMonitor.start();
+		let active = true;
+		return () => {
+			if (!active) return;
+			active = false;
+			unsubscribe();
+			this.mediaHealthSubscriberCount = Math.max(
+				0,
+				this.mediaHealthSubscriberCount - 1,
+			);
+			if (this.mediaHealthSubscriberCount === 0) this.mediaHealthMonitor.stop();
+		};
+	}
+
+	sendHostControl(
+		action: "mute_participant" | "kick_participant" | "lower_hand",
+		targetParticipantId: string,
+	): void {
+		this.sfuClient.sendEvent("host_control", { action, targetParticipantId });
+	}
+
+	getRemoteAudioTrack(participantId: string): MediaStreamTrack | null {
+		return this.consumerManager.getAudioConsumer(participantId)?.track ?? null;
+	}
+
+	getLocalProducerState(kind: LocalProducerKind): LocalProducerState | null {
+		const producer = this.getLocalProducer(kind);
+		return producer
+			? {
+					id: producer.id,
+					track: producer.track ?? null,
+					paused: producer.paused,
+				}
+			: null;
+	}
+
+	async replaceLocalProducerTrack(
+		kind: LocalProducerKind,
+		track: MediaStreamTrack,
+	): Promise<boolean> {
+		const producer = this.getLocalProducer(kind);
+		if (!producer) return false;
+		if (typeof producer.replaceTrack !== "function") {
+			throw new Error(`${kind} producer cannot replace its track`);
+		}
+		await producer.replaceTrack({ track });
+		return true;
+	}
+
+	async createLocalProducer(
+		kind: Exclude<LocalProducerKind, "screen">,
+		track: MediaStreamTrack,
+	): Promise<LocalProducerState> {
+		const producer = await this.transportManager.createProducer(track, {
+			type: kind === "audio" ? "microphone" : "camera",
+		});
+		this.setLocalProducer(kind, producer);
+		return {
+			id: producer.id,
+			track: producer.track ?? null,
+			paused: producer.paused,
+		};
+	}
+
+	async reconcileLocalProducerTrack(
+		kind: LocalProducerKind,
+		track: MediaStreamTrack,
+		options: { resume?: boolean } = {},
+	): Promise<LocalProducerState> {
+		const state = await this.mediaManager.serializeSendMediaMutation(() =>
+			this.reconcileLocalProducerTrackNow(kind, track, options),
+		);
+		if (!state) throw new Error(`${kind} producer reconciliation was cancelled`);
+		return state;
+	}
+
+	publishScreenTrack(
+		track: MediaStreamTrack,
+	): Promise<LocalProducerState | null> {
+		const generation = ++this.screenPublicationGeneration;
+		this.screenPublicationTrack = track;
+		return this.mediaManager.serializeSendMediaMutation(() =>
+			this.reconcileLocalProducerTrackNow("screen", track, {}, () =>
+				Boolean(
+					this.screenPublicationGeneration === generation &&
+						this.screenPublicationTrack === track &&
+						track.readyState === "live",
+				),
+			),
+		);
+	}
+
+	private async reconcileLocalProducerTrackNow(
+		kind: LocalProducerKind,
+		track: MediaStreamTrack,
+		options: { resume?: boolean } = {},
+		isCurrent: () => boolean = () => true,
+	): Promise<LocalProducerState | null> {
+		if (!isCurrent()) return null;
+		if (track.readyState !== "live") {
+			if (kind === "screen") return null;
+			throw new Error(`Cannot publish ended ${kind} track`);
+		}
+
+		for (let attempt = 0; attempt < 3; attempt += 1) {
+			if (!isCurrent()) return null;
+			let producer = this.getLocalProducer(kind);
+			if (producer?.closed) {
+				this.setLocalProducer(kind, null);
+				producer = null;
+			}
+
+			if (!producer) {
+				const created = await this.transportManager.createProducer(track, {
+					type:
+						kind === "audio"
+							? "microphone"
+							: kind === "video"
+								? "camera"
+								: "screen",
+				});
+				if (
+					!isCurrent() ||
+					track.readyState !== "live" ||
+					created.track?.readyState === "ended"
+				) {
+					this.closeProducerInstance(created);
+					if (kind === "screen") return null;
+					throw new Error(`${kind} track ended during producer creation`);
+				}
+
+				const current = this.getLocalProducer(kind);
+				if (current && !current.closed) {
+					this.closeProducerInstance(created);
+					if (kind === "screen" && current.track !== track) return null;
+					continue;
+				}
+				this.setLocalProducer(kind, created);
+				producer = created;
+			} else if (producer.track !== track) {
+				if (typeof producer.replaceTrack !== "function") {
+					throw new Error(`${kind} producer cannot replace its track`);
+				}
+				await producer.replaceTrack({ track });
+				if (!isCurrent()) {
+					if (this.getLocalProducer(kind) === producer) {
+						this.setLocalProducer(kind, null);
+						this.closeProducerInstance(producer);
+					}
+					return null;
+				}
+			}
+
+			if (track.readyState !== "live") {
+				if (this.getLocalProducer(kind) === producer) {
+					this.setLocalProducer(kind, null);
+				}
+				this.closeProducerInstance(producer);
+				if (kind === "screen") return null;
+				throw new Error(`${kind} track ended during producer reconciliation`);
+			}
+			if (!isCurrent()) {
+				if (this.getLocalProducer(kind) === producer) {
+					this.setLocalProducer(kind, null);
+					this.closeProducerInstance(producer);
+				}
+				return null;
+			}
+			if (this.getLocalProducer(kind) !== producer || producer.closed) {
+				this.closeProducerInstance(producer);
+				continue;
+			}
+
+			if (options.resume) {
+				producer.resume();
+				if (producer.id && this.sfuClient.isConnected()) {
+					void this.sfuClient.resumeProducer(producer.id).catch(() => {});
+				}
+			}
+			if (kind !== "screen") this.mediaManager.setLocalTrack(kind, track);
+			return {
+				id: producer.id,
+				track: producer.track ?? null,
+				paused: producer.paused,
+			};
+		}
+
+		throw new Error(`${kind} producer changed repeatedly during reconciliation`);
+	}
+
+	private closeProducerInstance(
+		producer: Producer,
+		metadata: ProducerCloseMetadata = {},
+	): void {
+		void this.transportManager.discardProducer(producer, metadata);
+	}
+
+	closeLocalProducer(
+		kind: LocalProducerKind,
+		metadata: ProducerCloseMetadata = {},
+	): void {
+		if (kind === "screen") {
+			this.screenPublicationGeneration += 1;
+			this.screenPublicationTrack = null;
+		}
+		const producer = this.getLocalProducer(kind);
+		this.setLocalProducer(kind, null);
+		if (producer) void this.transportManager.discardProducer(producer, metadata);
+	}
+
+	pauseLocalProducer(kind: LocalProducerKind): void {
+		const producer = this.getLocalProducer(kind);
+		producer?.pause();
+		if (producer?.id && this.sfuClient.isConnected()) {
+			void this.sfuClient.pauseProducer(producer.id);
+		}
+	}
+
+	resumeLocalProducer(kind: LocalProducerKind): void {
+		const producer = this.getLocalProducer(kind);
+		producer?.resume();
+		if (producer?.id && this.sfuClient.isConnected()) {
+			void this.sfuClient.resumeProducer(producer.id).catch(() => {});
+		}
+	}
+
+	hasLocalMediaPublications(): boolean {
+		return Boolean(
+			this.mediaManager.mediaHandler.videoProducer ||
+				this.mediaManager.mediaHandler.audioProducer ||
+				this.mediaManager.mediaHandler.screenProducer ||
+				this.screenPublicationTrack?.readyState === "live",
+		);
+	}
+
+	private getLocalProducer(kind: LocalProducerKind): Producer | null {
+		const mediaHandler = this.mediaManager.mediaHandler;
+		if (kind === "audio") return mediaHandler.audioProducer;
+		if (kind === "video") return mediaHandler.videoProducer;
+		return mediaHandler.screenProducer;
+	}
+
+	private setLocalProducer(
+		kind: LocalProducerKind,
+		producer: Producer | null,
+	): void {
+		if (kind === "audio") {
+			this.mediaManager.mediaHandler.setProducers({ audioProducer: producer });
+		} else if (kind === "video") {
+			this.mediaManager.mediaHandler.setProducers({ videoProducer: producer });
+		} else {
+			this.mediaManager.mediaHandler.setProducers({ screenProducer: producer });
+		}
+	}
+
+	private get mediaHandler() {
+		return this.mediaManager.mediaHandler;
+	}
+
 	registerVideoElement(participantId: string, element: HTMLElement): void {
 		this.videoManager.registerVideoElement(participantId, element);
 	}
 
-	getVideoConsumerEntry(participantId: string): unknown {
-		return this.consumerManager.getVideoConsumer(participantId);
+	async setAudioOutputDevice(deviceId: string): Promise<void> {
+		for (const audioElement of this.videoManager.audioElements.values()) {
+			try {
+				await audioElement.setSinkId(deviceId);
+			} catch (error) {
+				console.warn("Failed to set speaker for participant:", error);
+			}
+		}
+	}
+
+	onRemoteConsumerReady(listener: (event: Event) => void): () => void {
+		this.mediaManager.eventTarget.addEventListener("consumerReady", listener);
+		return () =>
+			this.mediaManager.eventTarget.removeEventListener("consumerReady", listener);
+	}
+
+	getVideoConsumerId(participantId: string): string | null {
+		return this.consumerManager.getVideoConsumer(participantId)?.id ?? null;
+	}
+
+	async sampleRTCStats(): Promise<RTCStatsSample> {
+		const transports = [
+			{ direction: "send" as const, transport: this.transportManager.sendTransport },
+			{ direction: "receive" as const, transport: this.transportManager.recvTransport },
+		].filter((entry) => !!entry.transport);
+		const producers = (["audio", "video", "screen"] as const).flatMap(
+			(kind) => {
+				const producer = this.getLocalProducer(kind);
+				return producer && !producer.closed ? [{ kind, producer }] : [];
+			},
+		);
+		const consumers = this.consumerManager.getAllConsumers();
+
+		const [transportReports, streams] = await Promise.all([
+			Promise.all(
+				transports.map(async ({ direction, transport }) => {
+					try {
+						const reports = snapshotRTCStatsReports(await transport?.getStats());
+						const current =
+							direction === "send"
+								? this.transportManager.sendTransport
+								: this.transportManager.recvTransport;
+						return current === transport ? reports : null;
+					} catch {
+						return null;
+					}
+				}),
+			),
+			Promise.all([
+				...producers.map(async ({ kind, producer }) => {
+					try {
+						const reports = snapshotRTCStatsReports(await producer.getStats());
+						if (this.getLocalProducer(kind) !== producer || producer.closed) return null;
+						const source =
+							producer.kind === "audio"
+								? "microphone"
+								: producer.appData?.type === "screen"
+									? "screen"
+									: "camera";
+						return Object.freeze({
+							id: producer.id,
+							direction: "send" as const,
+							kind: producer.kind,
+							source,
+							paused: producer.paused,
+							muted: producer.track?.muted ?? false,
+							trackSettings: Object.freeze({
+								...(producer.track?.getSettings?.() ?? {}),
+							}),
+							reports,
+						}) satisfies RTCStatsStreamSample;
+					} catch {
+						return null;
+					}
+				}),
+				...consumers.map(async (entry) => {
+					try {
+						const reports = snapshotRTCStatsReports(await entry.consumer.getStats());
+						if (this.consumerManager.getConsumer(entry.id)?.consumer !== entry.consumer) {
+							return null;
+						}
+						const source =
+							entry.kind === "audio"
+								? "remote audio"
+								: entry.isScreen || entry.appData?.type === "screen"
+									? "remote screen"
+									: "remote video";
+						return Object.freeze({
+							id: entry.id,
+							direction: "receive" as const,
+							kind: entry.kind,
+							source,
+							participantId: entry.participantId,
+							paused: entry.consumer.paused,
+							muted: entry.track?.muted ?? false,
+							trackSettings: Object.freeze({
+								...(entry.track?.getSettings?.() ?? {}),
+							}),
+							reports,
+						}) satisfies RTCStatsStreamSample;
+					} catch {
+						return null;
+					}
+				}),
+			]),
+		]);
+
+		return Object.freeze({
+			transportReports: Object.freeze(
+				transportReports.filter(
+					(reports): reports is readonly RTCStatsReport[] => reports !== null,
+				),
+			),
+			streams: Object.freeze(
+				streams.filter(
+					(stream): stream is RTCStatsStreamSample => stream !== null,
+				),
+			),
+			signalingConnected: this.sfuClient.getConnectionStatus().connected,
+			sendTransportState:
+				this.transportManager.sendTransport?.connectionState ?? "closed",
+			receiveTransportState:
+				this.transportManager.recvTransport?.connectionState ?? "closed",
+		});
+	}
+
+	async getConnectionDiagnostics(): Promise<ConnectionDiagnostics> {
+		let networkStats: ConnectionDiagnostics["networkStats"] = null;
+		try {
+			networkStats = await this.transportManager.getNetworkStats();
+		} catch {
+			// Diagnostics should still open when a recovering transport disappears.
+		}
+		return {
+			connectionStatus: this.sfuClient.getConnectionStatus(),
+			transportStats: this.transportManager.getTransportStats(),
+			networkStats,
+		};
 	}
 
 	async updateConsumerStreamPreferences(
@@ -482,10 +1123,14 @@ export class SFUMeetingManager {
 	}
 
 	async disconnect(): Promise<void> {
+		this.screenPublicationGeneration += 1;
+		this.screenPublicationTrack = null;
 		return this.connectionManager.disconnect();
 	}
 
 	async cleanup(): Promise<void> {
+		this.mediaHealthSubscriberCount = 0;
+		this.mediaHealthMonitor.stop();
 		await this.disconnect();
 
 		this.videoManager.cleanup();
@@ -506,23 +1151,4 @@ export class SFUMeetingManager {
 		return this.connectionManager.state;
 	}
 
-	get eventTarget(): EventTarget {
-		return this.mediaManager.eventTarget;
-	}
-
-	get mediaHandler() {
-		return this.mediaManager.mediaHandler;
-	}
-
-	get processedConsumers(): Set<string> {
-		return this.mediaManager.processedConsumers;
-	}
-
-	get isScreenShareActive(): boolean {
-		return this.mediaManager.isScreenShareActive;
-	}
-
-	get currentUser(): { value: unknown } {
-		return this.connectionManager.currentUser;
-	}
 }

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -879,6 +879,32 @@ export class SFUMeetingManager {
 		if (producer) void this.transportManager.discardProducer(producer, metadata);
 	}
 
+	async stopScreenShare(metadata: ProducerCloseMetadata = {}): Promise<void> {
+		this.screenPublicationGeneration += 1;
+		this.screenPublicationTrack = null;
+		const producer = await this.mediaManager.serializeSendMediaMutation(async () => {
+			const producer = this.getLocalProducer("screen");
+			if (!producer) return null;
+			this.setLocalProducer("screen", null);
+			return producer;
+		});
+		if (!producer) return;
+
+		try {
+			if (producer.id && this.sfuClient.isConnected()) {
+				await this.sfuClient.sendScreenShare("stop_share", {
+					...metadata,
+					producerId: producer.id,
+					stoppedAt: Date.now(),
+				});
+			}
+		} catch {
+			// Local producer cleanup remains authoritative if signaling fails.
+		} finally {
+			await this.transportManager.discardProducer(producer, metadata);
+		}
+	}
+
 	pauseLocalProducer(kind: LocalProducerKind): void {
 		const producer = this.getLocalProducer(kind);
 		producer?.pause();

--- a/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
@@ -50,10 +50,12 @@ const mediaTrack = (id: string, kind: "audio" | "video") =>
 
 function deferred<T>() {
 	let resolve!: (value: T) => void;
-	const promise = new Promise<T>((resolvePromise) => {
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
 		resolve = resolvePromise;
+		reject = rejectPromise;
 	});
-	return { promise, resolve };
+	return { promise, reject, resolve };
 }
 
 afterEach(() => {
@@ -364,6 +366,50 @@ describe("SFUMeetingManager facade operations", () => {
 		await expect(publication).resolves.toBeNull();
 		expect(staleProducer.close).toHaveBeenCalledOnce();
 		expect(closeProducer).toHaveBeenCalledWith("stale-screen-producer", {});
+		expect(manager.getLocalProducerState("screen")).toBeNull();
+	});
+
+	it("acknowledges screen stop before closing its producer", async () => {
+		const stopSignal = deferred<unknown>();
+		const sendScreenShare = vi.fn(() => stopSignal.promise);
+		const closeProducer = vi.fn().mockResolvedValue(undefined);
+		const manager = createManager({
+			isConnected: vi.fn(() => true),
+			sendScreenShare,
+			closeProducer,
+		} as never);
+		const producer = {
+			id: "screen-producer",
+			track: mediaTrack("screen", "video"),
+			closed: false,
+			paused: false,
+			close: vi.fn(),
+		};
+		manager.mediaHandler.setProducers({ screenProducer: producer as never });
+
+		const stopping = manager.stopScreenShare({
+			reason: "user-click",
+			source: "screen-share",
+		});
+		await vi.waitFor(() => expect(sendScreenShare).toHaveBeenCalledOnce());
+
+		expect(producer.close).not.toHaveBeenCalled();
+		expect(closeProducer).not.toHaveBeenCalled();
+		stopSignal.resolve({ success: true });
+		await stopping;
+
+		expect(sendScreenShare).toHaveBeenCalledWith(
+			"stop_share",
+			expect.objectContaining({
+				producerId: "screen-producer",
+				reason: "user-click",
+				source: "screen-share",
+				stoppedAt: expect.any(Number),
+			}),
+		);
+		expect(sendScreenShare.mock.invocationCallOrder[0]).toBeLessThan(
+			closeProducer.mock.invocationCallOrder[0],
+		);
 		expect(manager.getLocalProducerState("screen")).toBeNull();
 	});
 

--- a/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
@@ -1,5 +1,25 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SFUMeetingManager } from "../SFUMeetingManager";
+import type { ConsumerManager } from "../media/ConsumerManager";
+import type { ParticipantManager } from "../media/ParticipantManager";
+import type { TransportManager } from "../media/TransportManager";
+import type { VideoElementManager } from "../media/VideoElementManager";
+import type { SFUMediaManager } from "../sfu/SFUMediaManager";
+
+type TestableSFUMeetingManager = Pick<
+	SFUMeetingManager,
+	keyof SFUMeetingManager
+> & {
+	videoManager: VideoElementManager;
+	participantManager: ParticipantManager;
+	consumerManager: ConsumerManager;
+	transportManager: TransportManager;
+	mediaManager: SFUMediaManager;
+	mediaHandler: SFUMediaManager["mediaHandler"];
+};
+
+const createManager = (client: never) =>
+	new SFUMeetingManager(client) as unknown as TestableSFUMeetingManager;
 
 class FakeMediaStream {
 	private tracks: MediaStreamTrack[];
@@ -43,8 +63,9 @@ afterEach(() => {
 
 function prepareE2EEManager() {
 	vi.stubGlobal("MediaStream", FakeMediaStream);
-	const manager = new SFUMeetingManager({
+	const manager = createManager({
 		isConnected: vi.fn(() => true),
+		closeProducer: vi.fn().mockResolvedValue(undefined),
 	} as never);
 	const connectionManager = (
 		manager as unknown as {
@@ -78,7 +99,7 @@ function prepareE2EEManager() {
 
 describe("SFUMeetingManager adaptive streaming", () => {
 	it("escalates exhausted expected publication repair", async () => {
-		const manager = new SFUMeetingManager({} as never);
+		const manager = createManager({} as never);
 		const connection = (
 			manager as unknown as {
 				connectionManager: {
@@ -122,7 +143,7 @@ describe("SFUMeetingManager adaptive streaming", () => {
 	});
 
 	it("retries playback before reconciling media after browser resume", async () => {
-		const manager = new SFUMeetingManager({} as never);
+		const manager = createManager({} as never);
 		const retryPlayback = vi
 			.spyOn(manager.videoManager, "retryPlayback")
 			.mockResolvedValue();
@@ -140,7 +161,7 @@ describe("SFUMeetingManager adaptive streaming", () => {
 	});
 
 	it("rejects visible preferences while disconnected", async () => {
-		const manager = new SFUMeetingManager({
+		const manager = createManager({
 			isConnected: vi.fn(() => false),
 		} as never);
 
@@ -154,7 +175,7 @@ describe("SFUMeetingManager adaptive streaming", () => {
 	});
 
 	it("rejects a failed visible preference without clearing adaptive pause", async () => {
-		const manager = new SFUMeetingManager({
+		const manager = createManager({
 			isConnected: vi.fn(() => true),
 			updateConsumerPreferences: vi.fn().mockRejectedValue(new Error("offline")),
 		} as never);
@@ -177,7 +198,7 @@ describe("SFUMeetingManager adaptive streaming", () => {
 			.fn()
 			.mockReturnValueOnce(visibleRequest.promise)
 			.mockReturnValueOnce(hiddenRequest.promise);
-		const manager = new SFUMeetingManager({
+		const manager = createManager({
 			isConnected: vi.fn(() => true),
 			updateConsumerPreferences,
 		} as never);
@@ -205,9 +226,412 @@ describe("SFUMeetingManager adaptive streaming", () => {
 	});
 });
 
+describe("SFUMeetingManager facade operations", () => {
+	it("owns local producer creation, replacement, signaling, and closure", async () => {
+		const closeProducer = vi.fn().mockResolvedValue(undefined);
+		const pauseProducer = vi.fn().mockResolvedValue(undefined);
+		const resumeProducer = vi.fn().mockResolvedValue(undefined);
+		const client = {
+			isConnected: vi.fn(() => true),
+			closeProducer,
+			pauseProducer,
+			resumeProducer,
+		} as never;
+		const manager = createManager(client);
+		const initialTrack = mediaTrack("initial", "video");
+		const replacementTrack = mediaTrack("replacement", "video");
+		const producer = {
+			id: "video-producer",
+			track: initialTrack,
+			paused: false,
+			closed: false,
+			replaceTrack: vi.fn(async ({ track }: { track: MediaStreamTrack }) => {
+				producer.track = track;
+			}),
+			pause: vi.fn(),
+			resume: vi.fn(),
+			close: vi.fn(),
+		};
+		vi.spyOn(manager.transportManager, "createProducer").mockResolvedValue(
+			producer as never,
+		);
+
+		await manager.createLocalProducer("video", initialTrack);
+		await manager.replaceLocalProducerTrack("video", replacementTrack);
+		manager.pauseLocalProducer("video");
+		manager.resumeLocalProducer("video");
+		manager.closeLocalProducer("video");
+
+		expect(producer.replaceTrack).toHaveBeenCalledWith({
+			track: replacementTrack,
+		});
+		expect(pauseProducer).toHaveBeenCalledWith("video-producer");
+		expect(resumeProducer).toHaveBeenCalledWith("video-producer");
+		expect(closeProducer).toHaveBeenCalledWith("video-producer", {});
+		expect(manager.getLocalProducerState("video")).toBeNull();
+	});
+
+	it("reconciles against a producer that appears while creation is pending", async () => {
+		vi.stubGlobal("MediaStream", FakeMediaStream);
+		const closeProducer = vi.fn().mockResolvedValue(undefined);
+		const resumeProducer = vi.fn().mockResolvedValue(undefined);
+		const manager = createManager({
+			isConnected: vi.fn(() => true),
+			closeProducer,
+			resumeProducer,
+		} as never);
+		const track = mediaTrack("microphone", "audio");
+		const creation = deferred<{
+			id: string;
+			track: MediaStreamTrack;
+			closed: boolean;
+			close: ReturnType<typeof vi.fn>;
+		}>();
+		const abandoned = {
+			id: "abandoned-producer",
+			track,
+			closed: false,
+			paused: false,
+			close: vi.fn(),
+		};
+		const current = {
+			id: "recovered-producer",
+			track: mediaTrack("old-microphone", "audio"),
+			closed: false,
+			paused: true,
+			replaceTrack: vi.fn(async ({ track: replacement }) => {
+				current.track = replacement;
+			}),
+			resume: vi.fn(() => {
+				current.paused = false;
+			}),
+			close: vi.fn(),
+		};
+		vi.spyOn(manager.transportManager, "createProducer").mockReturnValue(
+			creation.promise as never,
+		);
+
+		const reconciliation = manager.reconcileLocalProducerTrack("audio", track, {
+			resume: true,
+		});
+		await vi.waitFor(() =>
+			expect(manager.transportManager.createProducer).toHaveBeenCalledOnce(),
+		);
+		manager.mediaHandler.setProducers({ audioProducer: current as never });
+		creation.resolve(abandoned);
+		await reconciliation;
+
+		expect(abandoned.close).toHaveBeenCalledOnce();
+		expect(closeProducer).toHaveBeenCalledWith("abandoned-producer", {});
+		expect(current.replaceTrack).toHaveBeenCalledWith({ track });
+		expect(current.resume).toHaveBeenCalledOnce();
+		expect(manager.getLocalProducerState("audio")?.id).toBe("recovered-producer");
+	});
+
+	it("abandons a delayed screen producer after screen sharing stops", async () => {
+		const closeProducer = vi.fn().mockResolvedValue(undefined);
+		const manager = createManager({
+			isConnected: vi.fn(() => true),
+			closeProducer,
+		} as never);
+		const track = mediaTrack("screen", "video");
+		const creation = deferred<{
+			id: string;
+			track: MediaStreamTrack;
+			closed: boolean;
+			paused: boolean;
+			close: ReturnType<typeof vi.fn>;
+		}>();
+		const staleProducer = {
+			id: "stale-screen-producer",
+			track,
+			closed: false,
+			paused: false,
+			close: vi.fn(),
+		};
+		vi.spyOn(manager.transportManager, "createProducer").mockReturnValue(
+			creation.promise as never,
+		);
+
+		const publication = manager.publishScreenTrack(track);
+		await vi.waitFor(() =>
+			expect(manager.transportManager.createProducer).toHaveBeenCalledOnce(),
+		);
+		expect(manager.hasLocalMediaPublications()).toBe(true);
+		manager.closeLocalProducer("screen");
+		creation.resolve(staleProducer);
+
+		await expect(publication).resolves.toBeNull();
+		expect(staleProducer.close).toHaveBeenCalledOnce();
+		expect(closeProducer).toHaveBeenCalledWith("stale-screen-producer", {});
+		expect(manager.getLocalProducerState("screen")).toBeNull();
+	});
+
+	it("abandons a delayed screen producer when its track ends", async () => {
+		const closeProducer = vi.fn().mockResolvedValue(undefined);
+		const manager = createManager({
+			isConnected: vi.fn(() => true),
+			closeProducer,
+		} as never);
+		const track = mediaTrack("screen", "video");
+		const creation = deferred<{
+			id: string;
+			track: MediaStreamTrack;
+			closed: boolean;
+			paused: boolean;
+			close: ReturnType<typeof vi.fn>;
+		}>();
+		const staleProducer = {
+			id: "ended-screen-producer",
+			track,
+			closed: false,
+			paused: false,
+			close: vi.fn(),
+		};
+		vi.spyOn(manager.transportManager, "createProducer").mockReturnValue(
+			creation.promise as never,
+		);
+
+		const publication = manager.publishScreenTrack(track);
+		await vi.waitFor(() =>
+			expect(manager.transportManager.createProducer).toHaveBeenCalledOnce(),
+		);
+		Reflect.set(track, "readyState", "ended");
+		creation.resolve(staleProducer);
+
+		await expect(publication).resolves.toBeNull();
+		expect(staleProducer.close).toHaveBeenCalledOnce();
+		expect(closeProducer).toHaveBeenCalledWith("ended-screen-producer", {});
+		expect(manager.getLocalProducerState("screen")).toBeNull();
+	});
+
+	it("invalidates a delayed screen publication when manager cleanup starts", async () => {
+		const closeProducer = vi.fn().mockResolvedValue(undefined);
+		const manager = createManager({
+			isConnected: vi.fn(() => true),
+			closeProducer,
+			disconnect: vi.fn().mockResolvedValue(undefined),
+		} as never);
+		const track = mediaTrack("screen", "video");
+		const creation = deferred<{
+			id: string;
+			track: MediaStreamTrack;
+			closed: boolean;
+			paused: boolean;
+			close: ReturnType<typeof vi.fn>;
+		}>();
+		const staleProducer = {
+			id: "cleanup-screen-producer",
+			track,
+			closed: false,
+			paused: false,
+			close: vi.fn(),
+		};
+		vi.spyOn(manager.transportManager, "createProducer").mockReturnValue(
+			creation.promise as never,
+		);
+
+		const publication = manager.publishScreenTrack(track);
+		await vi.waitFor(() =>
+			expect(manager.transportManager.createProducer).toHaveBeenCalledOnce(),
+		);
+		const cleanup = manager.cleanup();
+		creation.resolve(staleProducer);
+
+		await expect(publication).resolves.toBeNull();
+		await cleanup;
+		expect(staleProducer.close).toHaveBeenCalledOnce();
+		expect(closeProducer).toHaveBeenCalledWith("cleanup-screen-producer", {});
+		expect(manager.getLocalProducerState("screen")).toBeNull();
+	});
+
+	it("keeps a recovered screen producer that replaces delayed creation", async () => {
+		const closeProducer = vi.fn().mockResolvedValue(undefined);
+		const manager = createManager({
+			isConnected: vi.fn(() => true),
+			closeProducer,
+		} as never);
+		const track = mediaTrack("screen", "video");
+		const creation = deferred<{
+			id: string;
+			track: MediaStreamTrack;
+			closed: boolean;
+			paused: boolean;
+			close: ReturnType<typeof vi.fn>;
+		}>();
+		const staleProducer = {
+			id: "stale-screen-producer",
+			track,
+			closed: false,
+			paused: false,
+			close: vi.fn(),
+		};
+		const recoveredProducer = {
+			id: "recovered-screen-producer",
+			track,
+			closed: false,
+			paused: false,
+			close: vi.fn(),
+		};
+		vi.spyOn(manager.transportManager, "createProducer").mockReturnValue(
+			creation.promise as never,
+		);
+
+		const publication = manager.publishScreenTrack(track);
+		await vi.waitFor(() =>
+			expect(manager.transportManager.createProducer).toHaveBeenCalledOnce(),
+		);
+		manager.mediaHandler.setProducers({
+			screenProducer: recoveredProducer as never,
+		});
+		creation.resolve(staleProducer);
+
+		await expect(publication).resolves.toMatchObject({
+			id: "recovered-screen-producer",
+			track,
+		});
+		expect(staleProducer.close).toHaveBeenCalledOnce();
+		expect(closeProducer).toHaveBeenCalledWith("stale-screen-producer", {});
+		expect(manager.getLocalProducerState("screen")?.id).toBe(
+			"recovered-screen-producer",
+		);
+	});
+
+	it("does not overwrite replacement screen state after delayed creation", async () => {
+		const closeProducer = vi.fn().mockResolvedValue(undefined);
+		const manager = createManager({
+			isConnected: vi.fn(() => true),
+			closeProducer,
+		} as never);
+		const requestedTrack = mediaTrack("requested-screen", "video");
+		const replacementTrack = mediaTrack("replacement-screen", "video");
+		const creation = deferred<{
+			id: string;
+			track: MediaStreamTrack;
+			closed: boolean;
+			paused: boolean;
+			close: ReturnType<typeof vi.fn>;
+		}>();
+		const staleProducer = {
+			id: "stale-screen-producer",
+			track: requestedTrack,
+			closed: false,
+			paused: false,
+			close: vi.fn(),
+		};
+		const replacementProducer = {
+			id: "replacement-screen-producer",
+			track: replacementTrack,
+			closed: false,
+			paused: false,
+			close: vi.fn(),
+		};
+		vi.spyOn(manager.transportManager, "createProducer").mockReturnValue(
+			creation.promise as never,
+		);
+
+		const publication = manager.publishScreenTrack(requestedTrack);
+		await vi.waitFor(() =>
+			expect(manager.transportManager.createProducer).toHaveBeenCalledOnce(),
+		);
+		manager.mediaHandler.setProducers({
+			screenProducer: replacementProducer as never,
+		});
+		creation.resolve(staleProducer);
+
+		await expect(publication).resolves.toBeNull();
+		expect(staleProducer.close).toHaveBeenCalledOnce();
+		expect(replacementProducer.close).not.toHaveBeenCalled();
+		expect(manager.getLocalProducerState("screen")?.track).toBe(
+			replacementTrack,
+		);
+	});
+
+	it("exposes only the video consumer id", () => {
+		const manager = createManager({} as never);
+		vi.spyOn(manager.consumerManager, "getVideoConsumer")
+			.mockReturnValueOnce({
+				id: "video-consumer",
+				adaptivelyPaused: false,
+			} as never)
+			.mockReturnValueOnce(undefined);
+
+		expect(manager.getVideoConsumerId("participant-1")).toBe("video-consumer");
+		expect(manager.getVideoConsumerId("missing")).toBeNull();
+	});
+
+	it("returns immutable RTC samples and drops a producer replaced during sampling", async () => {
+		const manager = createManager({
+			getConnectionStatus: vi.fn(() => ({ connected: true })),
+		} as never);
+		const stats = deferred<Map<string, unknown>>();
+		const oldProducer = {
+			id: "old-producer",
+			kind: "audio",
+			track: mediaTrack("old-track", "audio"),
+			closed: false,
+			paused: false,
+			appData: {},
+			getStats: vi.fn(() => stats.promise),
+		};
+		manager.mediaHandler.setProducers({ audioProducer: oldProducer as never });
+
+		const sampling = manager.sampleRTCStats();
+		await vi.waitFor(() => expect(oldProducer.getStats).toHaveBeenCalledOnce());
+		manager.mediaHandler.setProducers({
+			audioProducer: {
+				...oldProducer,
+				id: "replacement-producer",
+				getStats: vi.fn().mockResolvedValue(new Map()),
+			} as never,
+		});
+		stats.resolve(
+			new Map([
+				["outbound", { id: "outbound", type: "outbound-rtp" }],
+			]),
+		);
+		const sample = await sampling;
+
+		expect(sample.streams).toEqual([]);
+		expect(Object.isFrozen(sample)).toBe(true);
+		expect(Object.isFrozen(sample.streams)).toBe(true);
+		expect(sample).not.toHaveProperty("producers");
+		expect(sample).not.toHaveProperty("transports");
+		expect(sample).not.toHaveProperty("consumers");
+	});
+
+	it("routes host control through the client", () => {
+		const sendEvent = vi.fn();
+		const manager = createManager({ sendEvent } as never);
+
+		manager.sendHostControl("mute_participant", "participant-1");
+
+		expect(sendEvent).toHaveBeenCalledWith("host_control", {
+			action: "mute_participant",
+			targetParticipantId: "participant-1",
+		});
+	});
+
+	it("keeps health monitoring active until its last facade subscriber leaves", () => {
+		const manager = createManager({} as never);
+		const monitor = Reflect.get(manager, "mediaHealthMonitor");
+		const start = vi.spyOn(monitor, "start").mockImplementation(() => {});
+		const stop = vi.spyOn(monitor, "stop").mockImplementation(() => {});
+		const stopFirst = manager.startMediaHealthMonitoring(vi.fn());
+		const stopSecond = manager.startMediaHealthMonitoring(vi.fn());
+
+		stopFirst();
+		expect(stop).not.toHaveBeenCalled();
+		stopSecond();
+
+		expect(start).toHaveBeenCalledTimes(2);
+		expect(stop).toHaveBeenCalledOnce();
+	});
+});
+
 describe("SFUMeetingManager recovery fallback", () => {
 	it("keeps existing consumers after a successful ICE restart", async () => {
-		const manager = new SFUMeetingManager({
+		const manager = createManager({
 			isConnected: vi.fn(() => true),
 		} as never);
 		vi.spyOn(
@@ -230,7 +654,7 @@ describe("SFUMeetingManager recovery fallback", () => {
 	});
 
 	it("resets receive media when send rebuild fails", async () => {
-		const manager = new SFUMeetingManager({
+		const manager = createManager({
 			isConnected: vi.fn(() => true),
 		} as never);
 		vi.spyOn(
@@ -270,6 +694,109 @@ describe("SFUMeetingManager recovery fallback", () => {
 });
 
 describe("SFUMeetingManager E2EE recovery tracks", () => {
+	it("recreates a screen-only publication on the E2EE send transport", async () => {
+		const manager = prepareE2EEManager();
+		const screen = mediaTrack("screen", "video");
+		const oldScreenProducer = {
+			id: "old-screen",
+			track: screen,
+			close: vi.fn(),
+		};
+		const e2eeScreenProducer = {
+			id: "e2ee-screen",
+			track: screen,
+			closed: false,
+			paused: false,
+			close: vi.fn(),
+		};
+		manager.mediaHandler.setProducers({
+			screenProducer: oldScreenProducer as never,
+		});
+		const createProducer = vi
+			.spyOn(manager.transportManager, "createProducer")
+			.mockResolvedValue(e2eeScreenProducer as never);
+
+		expect(manager.hasLocalMediaPublications()).toBe(true);
+		await expect(manager.reconfigureForE2EE(null, null)).resolves.toEqual({
+			videoPublished: false,
+			audioPublished: false,
+		});
+
+		expect(oldScreenProducer.close).toHaveBeenCalledOnce();
+		expect(manager.transportManager.createSendTransport).toHaveBeenCalledOnce();
+		expect(createProducer).toHaveBeenCalledWith(screen, { type: "screen" });
+		expect(manager.mediaHandler.screenProducer).toBe(e2eeScreenProducer);
+		expect(screen.readyState).toBe("live");
+	});
+
+	it("recreates screen, camera, and microphone publications for E2EE", async () => {
+		const manager = prepareE2EEManager();
+		const screen = mediaTrack("screen", "video");
+		const video = mediaTrack("video", "video");
+		const audio = mediaTrack("audio", "audio");
+		manager.mediaHandler.setProducers({
+			screenProducer: { id: "old-screen", track: screen, close: vi.fn() } as never,
+			videoProducer: { id: "old-video", track: video, close: vi.fn() } as never,
+			audioProducer: { id: "old-audio", track: audio, close: vi.fn() } as never,
+		});
+		const producers = new Map(
+			[video, audio, screen].map((track) => [
+				track,
+				{
+					id: `e2ee-${track.id}`,
+					track,
+					closed: false,
+					paused: false,
+					close: vi.fn(),
+				},
+			]),
+		);
+		const createProducer = vi
+			.spyOn(manager.transportManager, "createProducer")
+			.mockImplementation(async (track) => producers.get(track) as never);
+
+		await expect(
+			manager.reconfigureForE2EE(
+				new FakeMediaStream([video]) as never,
+				new FakeMediaStream([audio]) as never,
+			),
+		).resolves.toEqual({ videoPublished: true, audioPublished: true });
+
+		expect(createProducer).toHaveBeenNthCalledWith(1, video, { type: "camera" });
+		expect(createProducer).toHaveBeenNthCalledWith(2, audio, {
+			type: "microphone",
+		});
+		expect(createProducer).toHaveBeenNthCalledWith(3, screen, { type: "screen" });
+		expect(manager.mediaHandler.videoProducer).toBe(producers.get(video));
+		expect(manager.mediaHandler.audioProducer).toBe(producers.get(audio));
+		expect(manager.mediaHandler.screenProducer).toBe(producers.get(screen));
+	});
+
+	it("does not recreate an ended screen track during E2EE transition", async () => {
+		const manager = prepareE2EEManager();
+		const screen = mediaTrack("screen", "video");
+		Reflect.set(screen, "readyState", "ended");
+		const oldScreenProducer = {
+			id: "old-screen",
+			track: screen,
+			close: vi.fn(),
+		};
+		manager.mediaHandler.setProducers({
+			screenProducer: oldScreenProducer as never,
+		});
+		const createProducer = vi.spyOn(
+			manager.transportManager,
+			"createProducer",
+		);
+
+		expect(manager.hasLocalMediaPublications()).toBe(true);
+		await manager.reconfigureForE2EE(null, null);
+
+		expect(oldScreenProducer.close).toHaveBeenCalledOnce();
+		expect(createProducer).not.toHaveBeenCalled();
+		expect(manager.mediaHandler.screenProducer).toBeNull();
+	});
+
 	it("restores active recovery tracks before recreating producers", async () => {
 		const manager = prepareE2EEManager();
 		const video = mediaTrack("video", "video");
@@ -541,7 +1068,7 @@ describe("SFUMeetingManager E2EE recovery tracks", () => {
 				},
 			]),
 		} as never;
-		const manager = new SFUMeetingManager(sfuClient);
+		const manager = createManager(sfuClient);
 		manager.initialize({
 			meetingId: "meeting-1",
 			currentUser: { user_id: "me" },

--- a/frontend/src/apps/meet/utils/diagnostics/problemReport.ts
+++ b/frontend/src/apps/meet/utils/diagnostics/problemReport.ts
@@ -1,4 +1,4 @@
-import type { SFUClient } from "../SFUClient";
+import type { ConnectionDiagnostics } from "../SFUMeetingManager";
 import type { RecoveryTimelineEntry } from "../../composables/useParticipantConnectionState";
 import { getConsoleLogLines, getConsoleLogSummary } from "./consoleBuffer";
 
@@ -14,42 +14,15 @@ type NetworkStats = {
 	isValid?: boolean;
 } | null;
 
-type TransportManagerLike = {
-	getTransportStats?: () => TransportStats;
-	getNetworkStats?: () => Promise<NetworkStats>;
-};
-
 type BuildProblemReportMailtoOptions = {
 	meetingId: string;
 	networkQuality?: string;
 	localStream?: MediaStream | null;
-	transportManager?: TransportManagerLike | null;
-	sfuClient?: SFUClient | null;
+	diagnostics?: ConnectionDiagnostics | null;
 	consoleLogLimit?: number;
 	maxBodyChars?: number;
 	recoveryTimeline?: RecoveryTimelineEntry[];
 };
-
-function getTransportStats(
-	transportManager?: TransportManagerLike | null,
-): TransportStats {
-	return (
-		transportManager?.getTransportStats?.() || {
-			sendTransport: { id: null, state: "closed" },
-			recvTransport: { id: null, state: "closed" },
-		}
-	);
-}
-
-async function getNetworkStats(
-	transportManager?: TransportManagerLike | null,
-): Promise<NetworkStats> {
-	try {
-		return (await transportManager?.getNetworkStats?.()) || null;
-	} catch (_error) {
-		return null;
-	}
-}
 
 async function buildProblemReportMailto(
 	options: BuildProblemReportMailtoOptions,
@@ -58,20 +31,22 @@ async function buildProblemReportMailto(
 		meetingId,
 		networkQuality,
 		localStream = null,
-		transportManager = null,
-		sfuClient = null,
+		diagnostics = null,
 		consoleLogLimit = 40,
 		maxBodyChars = 7000,
 		recoveryTimeline = [],
 	} = options;
 
-	const connectionStatus = sfuClient?.getConnectionStatus?.() || {
+	const connectionStatus = diagnostics?.connectionStatus || {
 		connected: false,
 		socketId: null,
 	};
 
-	const transportStats = getTransportStats(transportManager);
-	const networkStats = await getNetworkStats(transportManager);
+	const transportStats: TransportStats = diagnostics?.transportStats || {
+		sendTransport: { id: null, state: "closed" },
+		recvTransport: { id: null, state: "closed" },
+	};
+	const networkStats: NetworkStats = diagnostics?.networkStats || null;
 	const localAudioTrack = localStream?.getAudioTracks?.()?.[0];
 	const localVideoTrack = localStream?.getVideoTracks?.()?.[0];
 	const reportTime = new Date().toISOString();

--- a/frontend/src/apps/meet/utils/media/E2EEHandshakeController.ts
+++ b/frontend/src/apps/meet/utils/media/E2EEHandshakeController.ts
@@ -482,11 +482,7 @@ export class E2EEHandshakeController {
 		this.sfuClient.setE2EERequired(true);
 		if (this.isReconfiguringForE2EE) return;
 		const manager = this.sfuManager.value;
-		if (
-			manager &&
-			!manager.mediaHandler?.videoProducer &&
-			!manager.mediaHandler?.audioProducer
-		) {
+		if (manager && !manager.hasLocalMediaPublications()) {
 			console.log(
 				"[DEBUG-e2ee] handleMeetingE2EEEnabled: skipping reconfiguration, initial setup will create E2EE producers natively",
 			);

--- a/frontend/src/apps/meet/utils/media/MediaHealthMonitor.ts
+++ b/frontend/src/apps/meet/utils/media/MediaHealthMonitor.ts
@@ -5,11 +5,6 @@ import {
 	extractInboundRtpCounters,
 	StallDetector,
 } from "./stallDetector";
-import {
-	type ClientTelemetryEvent,
-	getClientTelemetry,
-} from "../telemetry/ClientTelemetry";
-
 export type NetworkQuality = "good" | "poor" | "critical";
 
 /** Current uplink, downlink, and transport health exposed to the UI. */
@@ -19,7 +14,7 @@ export interface MediaHealthState {
 	isTransportFailed: boolean;
 }
 
-interface NetworkStats {
+export interface MediaHealthNetworkStats {
 	rtt: number;
 	packetLoss: number;
 	availableOutgoingBitrate: number;
@@ -27,40 +22,30 @@ interface NetworkStats {
 	isValid: boolean;
 }
 
-/** Manager operations used to inspect and recover live meeting media. */
-export interface MediaHealthManager {
-	transportManager?: {
-		getTransportStats(): {
-			sendTransport?: { state?: string };
-			recvTransport?: { state?: string };
-		} | null;
-		getNetworkStats?: () => Promise<NetworkStats>;
-	};
-	mediaManager?: {
-		consumerManager?: {
-			getAllConsumers(): ConsumerEntry[];
-			getConsumer?(consumerId: string): ConsumerEntry | undefined;
-		};
-		recoverConsumer(entry: ConsumerEntry): Promise<void>;
-	};
-	participantManager: {
-		getParticipant(participantId: string):
-			| { audio_enabled?: boolean; video_enabled?: boolean }
-			| undefined;
-	};
-	sfuClient?: {
-		requestConsumerKeyFrame?(consumerId: string): Promise<unknown>;
-		sendClientTelemetry(event: ClientTelemetryEvent): void;
-	};
-	reconcileExpectedMedia?(): Promise<void>;
-	recoverBrowserLifecycle?(): Promise<void>;
-	observeRemoteMediaProgress?(
+/** Media inspection, recovery, and telemetry operations used by the monitor. */
+export interface MediaHealthPort {
+	getTransportStats(): {
+		sendTransport?: { state?: string };
+		recvTransport?: { state?: string };
+	} | null;
+	getNetworkStats(): Promise<MediaHealthNetworkStats>;
+	getConsumers(): ConsumerEntry[];
+	getConsumer(consumerId: string): ConsumerEntry | undefined;
+	isConsumerPaused(entry: ConsumerEntry): boolean;
+	recoverConsumer(entry: ConsumerEntry): Promise<void>;
+	requestConsumerKeyFrame(consumerId: string): Promise<unknown>;
+	reconcileExpectedMedia(): Promise<void>;
+	recoverBrowserLifecycle(): Promise<void>;
+	observeRemoteMediaProgress(
 		producerId: string,
 		media: "audio" | "video",
 		flowing: boolean,
 		decoding: boolean,
 	): void;
 	resetReceiveMedia(): Promise<void>;
+	reportNetworkQuality(stats: MediaHealthNetworkStats): void;
+	markFirstRemoteMedia(media: "audio" | "video"): void;
+	reportMediaStalls(media: Array<"audio" | "video">): void;
 }
 
 type LifecycleEvent = "offline" | "online" | "pageshow";
@@ -127,7 +112,7 @@ export class MediaHealthMonitor {
 	private lifecycleGeneration = 0;
 
 	constructor(
-		private readonly getManager: () => MediaHealthManager | null,
+		private readonly port: MediaHealthPort,
 		private readonly environment: MediaHealthEnvironment = browserEnvironment,
 	) {
 		const now = () => this.environment.now();
@@ -196,12 +181,10 @@ export class MediaHealthMonitor {
 		const generation = ++this.lifecycleGeneration;
 		this.resetHealthBaselines();
 		if (this.isLifecycleSuspended()) return;
-		const manager = this.getManager();
-		await manager?.recoverBrowserLifecycle?.();
+		await this.port.recoverBrowserLifecycle();
 		if (
 			generation !== this.lifecycleGeneration ||
-			this.isLifecycleSuspended() ||
-			this.getManager() !== manager
+			this.isLifecycleSuspended()
 		) {
 			return;
 		}
@@ -234,7 +217,7 @@ export class MediaHealthMonitor {
 		for (const listener of this.listeners) listener(next);
 	}
 
-	private updateQuality(stats: NetworkStats): void {
+	private updateQuality(stats: MediaHealthNetworkStats): void {
 		if (!stats.isValid) {
 			this.setState({ networkQuality: "good" });
 			return;
@@ -270,17 +253,7 @@ export class MediaHealthMonitor {
 		this.polling = true;
 		const generation = this.lifecycleGeneration;
 		try {
-			const manager = this.getManager();
-			const transportManager = manager?.transportManager;
-			if (!transportManager) {
-				this.setState({
-					networkQuality: "good",
-					isTransportFailed: false,
-				});
-				return;
-			}
-
-			const transportStats = transportManager.getTransportStats();
+			const transportStats = this.port.getTransportStats();
 			const isFailed =
 				transportStats?.sendTransport?.state === "failed" ||
 				transportStats?.recvTransport?.state === "failed";
@@ -295,21 +268,16 @@ export class MediaHealthMonitor {
 				return;
 			}
 
-			if (transportManager.getNetworkStats) {
-				const stats = await transportManager.getNetworkStats();
-				if (
-					generation !== this.lifecycleGeneration ||
-					this.isLifecycleSuspended()
-				) {
-					return;
-				}
-				this.updateQuality(stats);
-				const telemetryClient = this.getManager()?.sfuClient;
-				if (telemetryClient && stats.isValid) {
-					getClientTelemetry(telemetryClient).reportNetworkQuality(stats);
-				}
+			const stats = await this.port.getNetworkStats();
+			if (
+				generation !== this.lifecycleGeneration ||
+				this.isLifecycleSuspended()
+			) {
+				return;
 			}
-			await this.getManager()?.reconcileExpectedMedia?.();
+			this.updateQuality(stats);
+			if (stats.isValid) this.port.reportNetworkQuality(stats);
+			await this.port.reconcileExpectedMedia();
 			await this.checkConsumerStalls(this.stateValue.networkQuality === "good");
 		} finally {
 			this.polling = false;
@@ -317,15 +285,7 @@ export class MediaHealthMonitor {
 	}
 
 	private async checkConsumerStalls(allowRecovery: boolean): Promise<void> {
-		const manager = this.getManager();
-		if (!manager) return;
-		const consumerManager = manager.mediaManager?.consumerManager;
-		if (!consumerManager) {
-			this.setState({ downlinkQuality: "good" });
-			return;
-		}
-
-		const consumers = consumerManager.getAllConsumers();
+		const consumers = this.port.getConsumers();
 		if (consumers.length === 0) {
 			this.setState({ downlinkQuality: "good" });
 			return;
@@ -350,23 +310,10 @@ export class MediaHealthMonitor {
 				return { entry, bytes: bytesReceived, framesDecoded };
 			}),
 		);
-		if (this.isLifecycleSuspended() || this.getManager() !== manager) return;
+		if (this.isLifecycleSuspended()) return;
 
-		const isPaused = (entry: ConsumerEntry) => {
-			const participant = manager.participantManager.getParticipant(
-				entry.participantId,
-			);
-			return (
-				entry.consumer.paused ||
-				(entry.consumer as typeof entry.consumer & { producerPaused?: boolean })
-					.producerPaused ||
-				entry.adaptivelyPaused ||
-				(entry.kind === "audio" && participant?.audio_enabled === false) ||
-				(entry.kind === "video" &&
-					!entry.isScreen &&
-					participant?.video_enabled === false)
-			);
-		};
+		const isPaused = (entry: ConsumerEntry) =>
+			this.port.isConsumerPaused(entry);
 		const samples: ConsumerSample[] = statsResults.map(({ entry, bytes }) => ({
 			id: entry.id,
 			kind: entry.kind,
@@ -375,12 +322,9 @@ export class MediaHealthMonitor {
 			getBytesReceived: () => bytes,
 			getCreatedAt: () => entry.createdAt,
 		}));
-		const telemetry = manager.sfuClient
-			? getClientTelemetry(manager.sfuClient)
-			: null;
 		for (const { entry, bytes, framesDecoded } of statsResults) {
 			const previous = this.expectedMediaCounters.get(entry.id);
-			manager.observeRemoteMediaProgress?.(
+			this.port.observeRemoteMediaProgress(
 				entry.producerId,
 				entry.kind === "audio" ? "audio" : "video",
 				bytes !== null && bytes > (previous?.bytesReceived ?? 0),
@@ -397,7 +341,7 @@ export class MediaHealthMonitor {
 				bytes > 0 &&
 				(entry.kind === "audio" || entry.kind === "video")
 			) {
-				telemetry?.markFirstRemoteMedia(entry.kind);
+				this.port.markFirstRemoteMedia(entry.kind);
 			}
 		}
 
@@ -422,16 +366,14 @@ export class MediaHealthMonitor {
 		});
 
 		for (const recovery of decodeActions) {
-			if (this.isLifecycleSuspended() || this.getManager() !== manager) return;
+			if (this.isLifecycleSuspended()) return;
 			const result = statsResults.find(
 				({ entry }) => entry.id === recovery.consumerId,
 			);
 			if (!result) continue;
 			const current =
-				consumerManager.getConsumer?.(result.entry.id) ??
-				consumerManager
-					.getAllConsumers()
-					.find((entry) => entry.id === result.entry.id);
+				this.port.getConsumer(result.entry.id) ??
+				this.port.getConsumers().find((entry) => entry.id === result.entry.id);
 			if (
 				!current ||
 				current.consumer !== result.entry.consumer ||
@@ -442,7 +384,7 @@ export class MediaHealthMonitor {
 			}
 			if (recovery.action === "request-keyframe") {
 				try {
-					await manager.sfuClient?.requestConsumerKeyFrame?.(result.entry.id);
+					await this.port.requestConsumerKeyFrame(result.entry.id);
 				} catch (error) {
 					console.warn(
 						"Failed to request a keyframe for decode-stalled consumer",
@@ -453,7 +395,7 @@ export class MediaHealthMonitor {
 			} else {
 				this.decodeStallDetector.dispose(result.entry.id);
 				try {
-					await manager.mediaManager?.recoverConsumer(current);
+					await this.port.recoverConsumer(current);
 				} catch (error) {
 					console.warn(
 						"Failed to recreate decode-stalled consumer",
@@ -462,12 +404,12 @@ export class MediaHealthMonitor {
 					);
 				}
 			}
-			if (this.isLifecycleSuspended() || this.getManager() !== manager) return;
+			if (this.isLifecycleSuspended()) return;
 		}
 
 		if (stalledIds.length === 0) return;
 		const stalledSet = new Set(stalledIds);
-		telemetry?.reportMediaStalls(
+		this.port.reportMediaStalls(
 			samples
 				.filter((sample) => stalledSet.has(sample.id))
 				.map((sample) => sample.kind)
@@ -485,7 +427,7 @@ export class MediaHealthMonitor {
 		);
 		for (const entry of neverStartedEntries) {
 			this.stallDetector.dispose(entry.id);
-			void manager.mediaManager?.recoverConsumer(entry);
+			void this.port.recoverConsumer(entry);
 		}
 		const establishedStalls = stalledEntries.filter((entry) =>
 			this.stallDetector.hasReceivedMedia(entry.id),
@@ -501,7 +443,7 @@ export class MediaHealthMonitor {
 		);
 		if (hasAudioStall || hasExhaustedVideoRecovery) {
 			try {
-				await manager.resetReceiveMedia();
+				await this.port.resetReceiveMedia();
 			} catch (error) {
 				console.warn("Failed to reset stalled receive media", error);
 			}
@@ -511,8 +453,8 @@ export class MediaHealthMonitor {
 
 		for (const entry of establishedStalls) {
 			if (entry.kind === "video") {
-				void manager.sfuClient
-					?.requestConsumerKeyFrame?.(entry.id)
+				void this.port
+					.requestConsumerKeyFrame(entry.id)
 					.catch((error) =>
 						console.warn(
 							"Failed to recover stalled video consumer",

--- a/frontend/src/apps/meet/utils/media/TransportManager.ts
+++ b/frontend/src/apps/meet/utils/media/TransportManager.ts
@@ -10,7 +10,7 @@ import type {
 	Transport,
 	TransportOptions,
 } from "mediasoup-client/types";
-import type { SFUClient } from "../SFUClient";
+import type { ProducerCloseMetadata, SFUClient } from "../SFUClient";
 import { resolveCodecStrategy } from "./codecStrategy";
 import {
 	DefaultE2EETransformPolicy,
@@ -99,6 +99,7 @@ export class TransportManager {
 	private recvTransportCreation: Promise<Transport> | null = null;
 	private sendTransportGeneration = 0;
 	private recvTransportGeneration = 0;
+	private producerDiscards = new WeakMap<Producer, Promise<void>>();
 
 	constructor(e2eePolicy?: E2EETransformPolicy) {
 		this.sendTransport = null;
@@ -433,22 +434,19 @@ export class TransportManager {
 			},
 			stopTracks: false,
 		};
-		let senderTransformSetupStarted = false;
+		let senderTransformSetup: Promise<boolean> | null = null;
 		const setupProducerSenderTransform = async (
 			sender: RTCRtpSender | undefined,
 		) => {
-			if (!e2eeWantedBeforeProduce || !sender || senderTransformSetupStarted) {
+			if (!e2eeWantedBeforeProduce || !sender) {
 				return false;
 			}
-			senderTransformSetupStarted = true;
-			const senderId = this.e2eePolicy.ownSenderId;
-			const mediaType = track?.kind ?? "video";
-			return this.e2eePolicy
-				.setupSenderTransform(sender, senderId, mediaType)
-				.catch((error) => {
-					console.warn("Failed to setup E2EE sender transform:", error);
-					return false;
-				});
+			senderTransformSetup ??= this.e2eePolicy.setupSenderTransform(
+				sender,
+				this.e2eePolicy.ownSenderId,
+				track?.kind ?? "video",
+			);
+			return senderTransformSetup;
 		};
 		if (e2eeWantedBeforeProduce) {
 			produceOptions.onRtpSender = setupProducerSenderTransform;
@@ -501,11 +499,22 @@ export class TransportManager {
 			kind: track?.kind,
 			senderId: this.e2eePolicy.ownSenderId,
 		});
-		if (e2eeGate && producer.rtpSender) {
-			await setupProducerSenderTransform(producer.rtpSender);
-		}
 		if (e2eeWantedBeforeProduce) {
-			await this.sfuClient?.resumeProducer?.(producer.id);
+			try {
+				const transformInstalled = senderTransformSetup
+					? await senderTransformSetup
+					: await setupProducerSenderTransform(producer.rtpSender);
+				if (!transformInstalled) {
+					throw new Error("Failed to install E2EE sender transform");
+				}
+				const { resumed } = await this.getClient().resumeProducer(producer.id);
+				if (!resumed) {
+					throw new Error("Failed to resume E2EE producer");
+				}
+			} catch (error) {
+				await this.discardProducer(producer);
+				throw error;
+			}
 		}
 
 		if (safeAppData.type === "screen") {
@@ -517,6 +526,28 @@ export class TransportManager {
 		}
 
 		return producer;
+	}
+
+	discardProducer(
+		producer: Producer,
+		metadata: ProducerCloseMetadata = {},
+	): Promise<void> {
+		const existing = this.producerDiscards.get(producer);
+		if (existing) return existing;
+
+		try {
+			producer.close();
+		} catch {
+			// The producer may already have closed with its transport.
+		}
+		const discard = producer.id && this.sfuClient
+			? this.sfuClient
+					.closeProducer(producer.id, metadata)
+					.then(() => undefined)
+					.catch(() => undefined)
+			: Promise.resolve();
+		this.producerDiscards.set(producer, discard);
+		return discard;
 	}
 
 	async createConsumer(

--- a/frontend/src/apps/meet/utils/media/__tests__/E2EEHandshakeController.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/E2EEHandshakeController.test.ts
@@ -61,6 +61,7 @@ function createMediaReconfigurationController({
 		sfuManager: shallowRef({
 			reconfigureForE2EE,
 			rejoinParticipantConnection: joinRoom,
+			hasLocalMediaPublications: vi.fn(() => true),
 		} as never),
 		currentUser: {
 			currentUser: shallowRef({ user_id: "user-1", full_name: "User One" }),
@@ -439,10 +440,7 @@ describe("E2EEHandshakeController", () => {
 				videoPublished: true,
 				audioPublished: true,
 			})),
-			mediaHandler: {
-				videoProducer: {} as never,
-				audioProducer: {} as never,
-			},
+			hasLocalMediaPublications: vi.fn(() => true),
 		} as never);
 		const controller = new E2EEHandshakeController({
 			meetingId: "meeting-1",
@@ -521,10 +519,6 @@ describe("E2EEHandshakeController", () => {
 			reconfigurationEntered.resolve();
 			return releaseReconfiguration.promise;
 		});
-		Reflect.set(Reflect.get(controller, "sfuManager").value, "mediaHandler", {
-			videoProducer: {},
-			audioProducer: null,
-		});
 		E2EEMeeting.instance.setMeetingContext(
 			new Uint8Array(32) as Uint8Array<ArrayBuffer>,
 			1,
@@ -558,10 +552,6 @@ describe("E2EEHandshakeController", () => {
 				},
 			});
 		reconfigureForE2EE.mockRejectedValue(abortError);
-		Reflect.set(Reflect.get(controller, "sfuManager").value, "mediaHandler", {
-			videoProducer: {},
-			audioProducer: null,
-		});
 		E2EEMeeting.instance.setMeetingContext(
 			new Uint8Array(32) as Uint8Array<ArrayBuffer>,
 			1,
@@ -592,10 +582,6 @@ describe("E2EEHandshakeController", () => {
 				},
 			});
 		reconfigureForE2EE.mockRejectedValue(failure);
-		Reflect.set(Reflect.get(controller, "sfuManager").value, "mediaHandler", {
-			videoProducer: {},
-			audioProducer: null,
-		});
 		E2EEMeeting.instance.setMeetingContext(
 			new Uint8Array(32) as Uint8Array<ArrayBuffer>,
 			1,

--- a/frontend/src/apps/meet/utils/media/__tests__/MediaHealthMonitor.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/MediaHealthMonitor.test.ts
@@ -3,7 +3,7 @@ import type { ConsumerEntry } from "../ConsumerManager";
 import {
 	MediaHealthMonitor,
 	type MediaHealthEnvironment,
-	type MediaHealthManager,
+	type MediaHealthPort,
 } from "../MediaHealthMonitor";
 
 type LifecycleEvent = "offline" | "online" | "pageshow";
@@ -137,37 +137,45 @@ function makeManager(
 	const reconcileExpectedMedia = vi.fn().mockResolvedValue(undefined);
 	const recoverBrowserLifecycle = vi.fn().mockResolvedValue(undefined);
 	const observeRemoteMediaProgress = vi.fn();
-	const sendClientTelemetry = vi.fn();
-	const manager: MediaHealthManager = {
-		transportManager: {
-			getTransportStats: () => ({
-				sendTransport: { state: options.transportState ?? "connected" },
-				recvTransport: { state: options.transportState ?? "connected" },
-			}),
-			getNetworkStats,
+	const reportNetworkQuality = vi.fn();
+	const markFirstRemoteMedia = vi.fn();
+	const reportMediaStalls = vi.fn();
+	const port: MediaHealthPort = {
+		getTransportStats: () => ({
+			sendTransport: { state: options.transportState ?? "connected" },
+			recvTransport: { state: options.transportState ?? "connected" },
+		}),
+		getNetworkStats,
+		getConsumers: () => consumers,
+		getConsumer: (id) => consumers.find((entry) => entry.id === id),
+		isConsumerPaused: (entry) => {
+			const participant = options.participant ?? {
+				audio_enabled: true,
+				video_enabled: true,
+			};
+			return Boolean(
+				entry.consumer.paused ||
+				(entry.consumer as typeof entry.consumer & { producerPaused?: boolean })
+					.producerPaused ||
+				entry.adaptivelyPaused ||
+				(entry.kind === "audio" && participant.audio_enabled === false) ||
+				(entry.kind === "video" &&
+					!entry.isScreen &&
+					participant.video_enabled === false),
+			);
 		},
-		mediaManager: {
-			consumerManager: {
-				getAllConsumers: () => consumers,
-				getConsumer: (id) => consumers.find((entry) => entry.id === id),
-			},
-			recoverConsumer,
-		},
-		participantManager: {
-			getParticipant: () =>
-				options.participant ?? { audio_enabled: true, video_enabled: true },
-		},
-		sfuClient: {
-			requestConsumerKeyFrame,
-			sendClientTelemetry,
-		},
+		recoverConsumer,
+		requestConsumerKeyFrame,
 		resetReceiveMedia,
 		reconcileExpectedMedia,
 		recoverBrowserLifecycle,
 		observeRemoteMediaProgress,
+		reportNetworkQuality,
+		markFirstRemoteMedia,
+		reportMediaStalls,
 	};
 	return {
-		manager,
+		port,
 		getNetworkStats,
 		recoverConsumer,
 		requestConsumerKeyFrame,
@@ -175,12 +183,14 @@ function makeManager(
 		reconcileExpectedMedia,
 		recoverBrowserLifecycle,
 		observeRemoteMediaProgress,
-		sendClientTelemetry,
+		reportNetworkQuality,
+		markFirstRemoteMedia,
+		reportMediaStalls,
 	};
 }
 
-function startMonitor(manager: MediaHealthManager, environment: TestEnvironment) {
-	const monitor = new MediaHealthMonitor(() => manager, environment);
+function startMonitor(port: MediaHealthPort, environment: TestEnvironment) {
+	const monitor = new MediaHealthMonitor(port, environment);
 	monitor.start();
 	return monitor;
 }
@@ -223,10 +233,10 @@ describe("MediaHealthMonitor", () => {
 		],
 	])("classifies %s network quality", async (quality, stats) => {
 		const environment = new TestEnvironment();
-		const { manager } = makeManager({
+		const { port } = makeManager({
 			networkStats: { ...goodNetworkStats, ...stats },
 		});
-		const monitor = startMonitor(manager, environment);
+		const monitor = startMonitor(port, environment);
 
 		await environment.advance(3000);
 
@@ -237,11 +247,11 @@ describe("MediaHealthMonitor", () => {
 	it("treats only failed transports as hard failures", async () => {
 		const environment = new TestEnvironment();
 		const consumer = makeConsumer(environment);
-		const { manager, getNetworkStats } = makeManager({
+		const { port, getNetworkStats } = makeManager({
 			transportState: "failed",
 			consumers: [consumer],
 		});
-		const monitor = startMonitor(manager, environment);
+		const monitor = startMonitor(port, environment);
 
 		await environment.advance(3000);
 
@@ -256,11 +266,11 @@ describe("MediaHealthMonitor", () => {
 	it("does not recover media disabled by the remote participant", async () => {
 		const environment = new TestEnvironment();
 		const consumer = makeConsumer(environment, { kind: "audio" });
-		const { manager, recoverConsumer, resetReceiveMedia } = makeManager({
+		const { port, recoverConsumer, resetReceiveMedia } = makeManager({
 			consumers: [consumer],
 			participant: { audio_enabled: false },
 		});
-		startMonitor(manager, environment);
+		startMonitor(port, environment);
 
 		await environment.advance(21_000);
 
@@ -284,12 +294,12 @@ describe("MediaHealthMonitor", () => {
 			createdAt: environment.nowValue - 20_000,
 		});
 		const {
-			manager,
+			port,
 			recoverConsumer,
 			requestConsumerKeyFrame,
 			resetReceiveMedia,
 		} = makeManager({ consumers: [expected, adaptivelyPaused] });
-		startMonitor(manager, environment);
+		startMonitor(port, environment);
 
 		await environment.advance(3000);
 
@@ -308,13 +318,13 @@ describe("MediaHealthMonitor", () => {
 			framesDecoded: () => 10,
 		});
 		const {
-			manager,
+			port,
 			recoverConsumer,
 			requestConsumerKeyFrame,
 			resetReceiveMedia,
 			observeRemoteMediaProgress,
 		} = makeManager({ consumers: [consumer] });
-		startMonitor(manager, environment);
+		startMonitor(port, environment);
 
 		await environment.advance(18_000);
 		expect(requestConsumerKeyFrame).toHaveBeenCalledOnce();
@@ -335,10 +345,10 @@ describe("MediaHealthMonitor", () => {
 	it("escalates an established video stall after consumer recovery attempts", async () => {
 		const environment = new TestEnvironment();
 		const consumer = makeConsumer(environment);
-		const { manager, requestConsumerKeyFrame, resetReceiveMedia } = makeManager({
+		const { port, requestConsumerKeyFrame, resetReceiveMedia } = makeManager({
 			consumers: [consumer],
 		});
-		const monitor = startMonitor(manager, environment);
+		const monitor = startMonitor(port, environment);
 
 		await environment.advance(21_000);
 		expect(requestConsumerKeyFrame).toHaveBeenCalledOnce();
@@ -358,39 +368,31 @@ describe("MediaHealthMonitor", () => {
 		const environment = new TestEnvironment();
 		const consumer = makeConsumer(environment);
 		const {
-			manager,
-			sendClientTelemetry,
+			port,
+			reportNetworkQuality,
+			markFirstRemoteMedia,
+			reportMediaStalls,
 		} = makeManager({
 			consumers: [consumer],
 		});
-		startMonitor(manager, environment);
+		startMonitor(port, environment);
 
 		await environment.advance(21_000);
 
-		expect(sendClientTelemetry).toHaveBeenCalledWith({
-			event: "network_quality",
-			rttMs: 50,
-			packetLossPercent: 0,
-			availableOutgoingBitrate: 800_000,
-		});
-		expect(sendClientTelemetry).toHaveBeenCalledWith(
-			expect.objectContaining({ event: "first_remote_media", media: "video" }),
-		);
-		expect(sendClientTelemetry).toHaveBeenCalledWith({
-			event: "media_stall",
-			media: "video",
-		});
+		expect(reportNetworkQuality).toHaveBeenCalledWith(goodNetworkStats);
+		expect(markFirstRemoteMedia).toHaveBeenCalledWith("video");
+		expect(reportMediaStalls).toHaveBeenCalledWith(["video"]);
 	});
 
 	it("suppresses recovery on a poor network and recovers when quality clears", async () => {
 		const environment = new TestEnvironment();
 		const quality = { ...goodNetworkStats, rtt: 1300, packetLoss: 20 };
 		const consumer = makeConsumer(environment);
-		const { manager, requestConsumerKeyFrame, resetReceiveMedia } = makeManager({
+		const { port, requestConsumerKeyFrame, resetReceiveMedia } = makeManager({
 			consumers: [consumer],
 			getNetworkStats: async () => quality,
 		});
-		startMonitor(manager, environment);
+		startMonitor(port, environment);
 
 		await environment.advance(30_000);
 		expect(requestConsumerKeyFrame).not.toHaveBeenCalled();
@@ -405,12 +407,12 @@ describe("MediaHealthMonitor", () => {
 	it("suspends polling while hidden or offline and recovers on resume", async () => {
 		const environment = new TestEnvironment();
 		const {
-			manager,
+			port,
 			getNetworkStats,
 			reconcileExpectedMedia,
 			recoverBrowserLifecycle,
 		} = makeManager();
-		startMonitor(manager, environment);
+		startMonitor(port, environment);
 
 		await environment.setHidden(true);
 		await environment.advance(6000);
@@ -436,8 +438,8 @@ describe("MediaHealthMonitor", () => {
 		const stats = new Promise<typeof goodNetworkStats>((resolve) => {
 			resolveStats = resolve;
 		});
-		const { manager } = makeManager({ getNetworkStats: () => stats });
-		const monitor = startMonitor(manager, environment);
+		const { port } = makeManager({ getNetworkStats: () => stats });
+		const monitor = startMonitor(port, environment);
 
 		const polling = environment.advance(3000);
 		await Promise.resolve();
@@ -451,10 +453,10 @@ describe("MediaHealthMonitor", () => {
 	it("uses fresh expected-media baselines after visibility resumes", async () => {
 		const environment = new TestEnvironment();
 		const consumer = makeConsumer(environment);
-		const { manager, observeRemoteMediaProgress } = makeManager({
+		const { port, observeRemoteMediaProgress } = makeManager({
 			consumers: [consumer],
 		});
-		startMonitor(manager, environment);
+		startMonitor(port, environment);
 
 		await environment.advance(3000);
 		expect(observeRemoteMediaProgress).toHaveBeenLastCalledWith(
@@ -484,8 +486,8 @@ describe("MediaHealthMonitor", () => {
 
 	it("removes timers and lifecycle listeners when stopped", async () => {
 		const environment = new TestEnvironment();
-		const { manager, getNetworkStats, recoverBrowserLifecycle } = makeManager();
-		const monitor = startMonitor(manager, environment);
+		const { port, getNetworkStats, recoverBrowserLifecycle } = makeManager();
+		const monitor = startMonitor(port, environment);
 		monitor.stop();
 
 		await environment.advance(6000);

--- a/frontend/src/apps/meet/utils/media/__tests__/TransportManager.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/TransportManager.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { E2EEMeeting } from "../E2EEMeeting";
 import { DefaultE2EETransformPolicy } from "../E2EETransformPolicy";
+import type { E2EETransformPolicy } from "../E2EETransformPolicy";
 import { TransportManager } from "../TransportManager";
 
 vi.mock("../codecStrategy", () => ({
@@ -33,6 +34,8 @@ function mockSfuClient(getCodecStrategy?: () => string) {
 		connectWebRtcTransport: vi.fn(),
 		createProducer: vi.fn(),
 		createConsumer: vi.fn(),
+		closeProducer: vi.fn().mockResolvedValue(undefined),
+		resumeProducer: vi.fn().mockResolvedValue({ success: true, resumed: true }),
 		restartWebRtcTransportIce: vi.fn(),
 	};
 }
@@ -188,15 +191,18 @@ describe("E2EE transport options", () => {
 			new Uint8Array(32) as Uint8Array<ArrayBuffer>,
 			1,
 		);
-		const policy = new DefaultE2EETransformPolicy({
+		const client = {
 			...mockSfuClient(),
 			isE2EERequired: vi.fn(() => true),
 			getE2EEMode: vi.fn(() => "rtp-script-transform"),
 			getOwnSenderId: vi.fn(() => 7),
-		} as never);
+		};
+		const policy = new DefaultE2EETransformPolicy(client as never);
+		vi.spyOn(policy, "setupSenderTransform").mockResolvedValue(true);
 		const manager = new TransportManager(policy);
+		manager.initialize(client as never);
 		manager.device = { canProduce: vi.fn(() => true) } as never;
-		const produce = vi.fn(async () => ({ rtpSender: {} }));
+		const produce = vi.fn(async () => ({ id: "producer-1", rtpSender: {} }));
 		manager.sendTransport = { produce } as never;
 
 		await manager.createProducer({
@@ -210,6 +216,223 @@ describe("E2EE transport options", () => {
 				onRtpSender: expect.any(Function),
 			}),
 		);
+	});
+
+	it.each([
+		{
+			type: "camera",
+			kind: "video",
+			outcome: "returns false",
+			setupSenderTransform: vi.fn().mockResolvedValue(false),
+		},
+		{
+			type: "microphone",
+			kind: "audio",
+			outcome: "rejects",
+			setupSenderTransform: vi.fn().mockRejectedValue(new Error("transform rejected")),
+		},
+		{
+			type: "screen",
+			kind: "video",
+			outcome: "returns false",
+			setupSenderTransform: vi.fn().mockResolvedValue(false),
+		},
+	] as const)(
+		"discards $type producer when sender transform $outcome",
+		async ({ type, kind, setupSenderTransform }) => {
+			const client = mockSfuClient();
+			const policy = {
+				transformsEnabled: true,
+				legacyInsertableStreamsEnabled: false,
+				ownSenderId: 7,
+				hasContext: true,
+				setSFUClient: vi.fn(),
+				assertContextReady: vi.fn(),
+				setupSenderTransform,
+				preCreateReceiverStreams: vi.fn(),
+				setupReceiverTransform: vi.fn(),
+			} satisfies E2EETransformPolicy;
+			const close = vi.fn();
+			const producer = {
+				id: `${type}-producer`,
+				rtpSender: {},
+				close,
+			};
+			const manager = new TransportManager(policy);
+			manager.initialize(client as never);
+			manager.device = {
+				canProduce: vi.fn(() => true),
+				rtpCapabilities: { codecs: [] },
+			} as never;
+			manager.sendTransport = {
+				produce: vi.fn().mockResolvedValue(producer),
+			} as never;
+			vi.mocked(resolveCodecStrategy).mockReturnValue({
+				strategy: "simulcast",
+				scalabilityMode: null,
+				didDowngrade: false,
+				requested: "simulcast",
+			});
+
+			await expect(
+				manager.createProducer(
+					{ id: `${type}-track`, kind, readyState: "live" } as MediaStreamTrack,
+					{ type },
+				),
+			).rejects.toThrow();
+
+			expect(client.resumeProducer).not.toHaveBeenCalled();
+			expect(close).toHaveBeenCalledOnce();
+			expect(client.closeProducer).toHaveBeenCalledWith(`${type}-producer`, {});
+		},
+	);
+
+	it("discards an encrypted producer when server resume rejects", async () => {
+		const client = mockSfuClient();
+		client.resumeProducer.mockRejectedValue(new Error("resume failed"));
+		const policy = {
+			transformsEnabled: true,
+			legacyInsertableStreamsEnabled: false,
+			ownSenderId: 7,
+			hasContext: true,
+			setSFUClient: vi.fn(),
+			assertContextReady: vi.fn(),
+			setupSenderTransform: vi.fn().mockResolvedValue(true),
+			preCreateReceiverStreams: vi.fn(),
+			setupReceiverTransform: vi.fn(),
+		} satisfies E2EETransformPolicy;
+		const producer = {
+			id: "resumeless-producer",
+			rtpSender: {},
+			close: vi.fn(),
+		};
+		const manager = new TransportManager(policy);
+		manager.initialize(client as never);
+		manager.device = { canProduce: vi.fn(() => true) } as never;
+		manager.sendTransport = {
+			produce: vi.fn().mockResolvedValue(producer),
+		} as never;
+
+		await expect(
+			manager.createProducer({
+				id: "microphone-track",
+				kind: "audio",
+				readyState: "live",
+			} as MediaStreamTrack),
+		).rejects.toThrow("resume failed");
+
+		expect(producer.close).toHaveBeenCalledOnce();
+		expect(client.closeProducer).toHaveBeenCalledWith("resumeless-producer", {});
+	});
+
+	it("can retry producer creation when server does not resume it", async () => {
+		const client = mockSfuClient();
+		client.resumeProducer
+			.mockResolvedValueOnce({ success: true, resumed: false })
+			.mockResolvedValueOnce({ success: true, resumed: true });
+		const policy = {
+			transformsEnabled: true,
+			legacyInsertableStreamsEnabled: false,
+			ownSenderId: 7,
+			hasContext: true,
+			setSFUClient: vi.fn(),
+			assertContextReady: vi.fn(),
+			setupSenderTransform: vi.fn().mockResolvedValue(true),
+			preCreateReceiverStreams: vi.fn(),
+			setupReceiverTransform: vi.fn(),
+		} satisfies E2EETransformPolicy;
+		const failedProducer = {
+			id: "not-resumed-producer",
+			rtpSender: {},
+			close: vi.fn(),
+		};
+		const retriedProducer = {
+			id: "resumed-producer",
+			rtpSender: {},
+			close: vi.fn(),
+		};
+		const manager = new TransportManager(policy);
+		manager.initialize(client as never);
+		manager.device = { canProduce: vi.fn(() => true) } as never;
+		manager.sendTransport = {
+			produce: vi
+				.fn()
+				.mockResolvedValueOnce(failedProducer)
+				.mockResolvedValueOnce(retriedProducer),
+		} as never;
+		const track = {
+			id: "microphone-track",
+			kind: "audio",
+			readyState: "live",
+		} as MediaStreamTrack;
+
+		await expect(manager.createProducer(track)).rejects.toThrow(
+			"Failed to resume E2EE producer",
+		);
+		await expect(manager.createProducer(track)).resolves.toBe(retriedProducer);
+
+		expect(failedProducer.close).toHaveBeenCalledOnce();
+		expect(retriedProducer.close).not.toHaveBeenCalled();
+		expect(client.closeProducer).toHaveBeenCalledOnce();
+		expect(client.closeProducer).toHaveBeenCalledWith("not-resumed-producer", {});
+		expect(client.resumeProducer).toHaveBeenNthCalledWith(
+			1,
+			"not-resumed-producer",
+		);
+		expect(client.resumeProducer).toHaveBeenNthCalledWith(2, "resumed-producer");
+	});
+
+	it("can retry producer creation after E2EE setup fails", async () => {
+		const client = mockSfuClient();
+		const setupSenderTransform = vi
+			.fn()
+			.mockResolvedValueOnce(false)
+			.mockResolvedValueOnce(true);
+		const policy = {
+			transformsEnabled: true,
+			legacyInsertableStreamsEnabled: false,
+			ownSenderId: 7,
+			hasContext: true,
+			setSFUClient: vi.fn(),
+			assertContextReady: vi.fn(),
+			setupSenderTransform,
+			preCreateReceiverStreams: vi.fn(),
+			setupReceiverTransform: vi.fn(),
+		} satisfies E2EETransformPolicy;
+		const failedProducer = {
+			id: "failed-producer",
+			rtpSender: {},
+			close: vi.fn(),
+		};
+		const retriedProducer = {
+			id: "retried-producer",
+			rtpSender: {},
+			close: vi.fn(),
+		};
+		const manager = new TransportManager(policy);
+		manager.initialize(client as never);
+		manager.device = { canProduce: vi.fn(() => true) } as never;
+		manager.sendTransport = {
+			produce: vi
+				.fn()
+				.mockResolvedValueOnce(failedProducer)
+				.mockResolvedValueOnce(retriedProducer),
+		} as never;
+		const track = {
+			id: "microphone-track",
+			kind: "audio",
+			readyState: "live",
+		} as MediaStreamTrack;
+
+		await expect(manager.createProducer(track)).rejects.toThrow(
+			"Failed to install E2EE sender transform",
+		);
+		await expect(manager.createProducer(track)).resolves.toBe(retriedProducer);
+
+		expect(failedProducer.close).toHaveBeenCalledOnce();
+		expect(retriedProducer.close).not.toHaveBeenCalled();
+		expect(client.resumeProducer).toHaveBeenCalledOnce();
+		expect(client.resumeProducer).toHaveBeenCalledWith("retried-producer");
 	});
 });
 

--- a/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
@@ -58,6 +58,7 @@ interface MediaManagerOptions {
 	videoManager: VideoElementManager;
 	consumerManager: ConsumerManager;
 	participantManager: ParticipantManager;
+	isScreenPublicationCurrent?: (track: MediaStreamTrack) => boolean;
 }
 
 export interface PublishedMedia {
@@ -97,6 +98,7 @@ export class SFUMediaManager {
 
 	private eventHandlers: MediaEventHandlers = {};
 	private getCurrentUserId: () => string | null;
+	private isScreenPublicationCurrent: (track: MediaStreamTrack) => boolean;
 	private selectedProducerIds = new Map<string, string>();
 	private attachmentTails = new Map<string, Promise<void>>();
 	private closedProducerIds = new Set<string>();
@@ -127,6 +129,8 @@ export class SFUMediaManager {
 		this.isScreenShareActive = false;
 		this.eventTarget = new EventTarget();
 		this.getCurrentUserId = getCurrentUserId;
+		this.isScreenPublicationCurrent =
+			options.isScreenPublicationCurrent ?? (() => true);
 	}
 
 	setEventHandlers(handlers: MediaEventHandlers): void {
@@ -272,7 +276,7 @@ export class SFUMediaManager {
 						videoTrackToPublish.readyState !== "live" ||
 						videoProducer.track?.readyState === "ended"
 					) {
-						videoProducer.close();
+						await this.transportManager.discardProducer(videoProducer);
 						this.setLocalTrack("video", previousVideoTrack);
 					} else {
 						results.videoProducer = videoProducer;
@@ -299,7 +303,7 @@ export class SFUMediaManager {
 						audioTrackToPublish.readyState !== "live" ||
 						audioProducer.track?.readyState === "ended"
 					) {
-						audioProducer.close();
+						await this.transportManager.discardProducer(audioProducer);
 						this.setLocalTrack("audio", previousAudioTrack);
 					} else {
 						results.audioProducer = audioProducer;
@@ -354,12 +358,24 @@ export class SFUMediaManager {
 				})
 			: (await this.transportManager.createSendTransport(), {});
 
-		if (hasLiveScreen && screenTrack) {
+		if (
+			hasLiveScreen &&
+			screenTrack &&
+			this.isScreenPublicationCurrent(screenTrack)
+		) {
 			const screenProducer = await this.transportManager.createProducer(screenTrack, {
 				type: "screen",
 			});
-			this.mediaHandler.setProducers({ screenProducer });
-			results.screenProducer = screenProducer;
+			if (
+				!this.isScreenPublicationCurrent(screenTrack) ||
+				screenTrack.readyState !== "live" ||
+				screenProducer.track?.readyState === "ended"
+			) {
+				await this.transportManager.discardProducer(screenProducer);
+			} else {
+				this.mediaHandler.setProducers({ screenProducer });
+				results.screenProducer = screenProducer;
+			}
 		}
 
 		return results;

--- a/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/SFUMediaManager.test.ts
@@ -3,6 +3,7 @@ import { SFUMediaManager } from "../SFUMediaManager";
 
 type MockTransportManager = {
 	closeSendTransport: ReturnType<typeof vi.fn>;
+	discardProducer: ReturnType<typeof vi.fn>;
 	createProducer: ReturnType<typeof vi.fn>;
 	createSendTransport: ReturnType<typeof vi.fn>;
 	createConsumer: ReturnType<typeof vi.fn>;
@@ -55,7 +56,11 @@ function deferred<T>() {
 }
 
 function createManager(
-	opts: { currentUserId?: string | null; hasParticipant?: boolean } = {},
+	opts: {
+		currentUserId?: string | null;
+		hasParticipant?: boolean;
+		isScreenPublicationCurrent?: (track: MediaStreamTrack) => boolean;
+	} = {},
 ): {
 	mediaManager: SFUMediaManager;
 	transportManager: MockTransportManager;
@@ -69,6 +74,9 @@ function createManager(
 } {
 	const transportManager: MockTransportManager = {
 		closeSendTransport: vi.fn(),
+		discardProducer: vi.fn(async (producer: { close: () => void }) => {
+			producer.close();
+		}),
 		createProducer: vi.fn().mockResolvedValue({}),
 		createSendTransport: vi.fn(),
 		createConsumer: vi.fn().mockResolvedValue({
@@ -110,6 +118,7 @@ function createManager(
 			videoManager: videoManager as never,
 			consumerManager: consumerManager as never,
 			participantManager: participantManager as never,
+			isScreenPublicationCurrent: opts.isScreenPublicationCurrent,
 		},
 		getCurrentUserId,
 	);
@@ -496,6 +505,66 @@ describe("SFUMediaManager.rebuildSendSide", () => {
 		});
 	});
 
+	it("discards a delayed screen recovery after sharing stops", async () => {
+		let currentScreen: MediaStreamTrack | null = null;
+		const screenTrack = mediaTrack("screen", "video");
+		currentScreen = screenTrack;
+		const { mediaManager, transportManager } = createManager({
+			isScreenPublicationCurrent: (track) => track === currentScreen,
+		});
+		const creation = deferred<{
+			id: string;
+			track: MediaStreamTrack;
+			close: ReturnType<typeof vi.fn>;
+		}>();
+		const staleProducer = {
+			id: "stale-screen",
+			track: screenTrack,
+			close: vi.fn(),
+		};
+		mediaManager.mediaHandler.setProducers({
+			screenProducer: { track: screenTrack } as never,
+		});
+		transportManager.createProducer.mockReturnValue(creation.promise);
+
+		const recovery = mediaManager.rebuildSendSide();
+		await vi.waitFor(() => expect(transportManager.createProducer).toHaveBeenCalledOnce());
+		currentScreen = null;
+		creation.resolve(staleProducer);
+
+		await expect(recovery).resolves.toEqual({});
+		expect(transportManager.discardProducer).toHaveBeenCalledWith(staleProducer);
+		expect(mediaManager.mediaHandler.screenProducer).toBeNull();
+	});
+
+	it("discards a delayed screen recovery when its track ends", async () => {
+		const { mediaManager, transportManager } = createManager();
+		const screenTrack = mediaTrack("screen", "video");
+		const creation = deferred<{
+			id: string;
+			track: MediaStreamTrack;
+			close: ReturnType<typeof vi.fn>;
+		}>();
+		const staleProducer = {
+			id: "ended-screen",
+			track: screenTrack,
+			close: vi.fn(),
+		};
+		mediaManager.mediaHandler.setProducers({
+			screenProducer: { track: screenTrack } as never,
+		});
+		transportManager.createProducer.mockReturnValue(creation.promise);
+
+		const recovery = mediaManager.rebuildSendSide();
+		await vi.waitFor(() => expect(transportManager.createProducer).toHaveBeenCalledOnce());
+		Reflect.set(screenTrack, "readyState", "ended");
+		creation.resolve(staleProducer);
+
+		await expect(recovery).resolves.toEqual({});
+		expect(transportManager.discardProducer).toHaveBeenCalledWith(staleProducer);
+		expect(mediaManager.mediaHandler.screenProducer).toBeNull();
+	});
+
 	it("waits for camera reconciliation before rebuilding the send side", async () => {
 		vi.stubGlobal("MediaStream", FakeMediaStream);
 		const { mediaManager, transportManager } = createManager();
@@ -808,6 +877,7 @@ describe("SFUMediaManager local recovery tracks", () => {
 
 		await expect(publication).resolves.toEqual({});
 		expect(unusableProducer.close).toHaveBeenCalledOnce();
+		expect(transportManager.discardProducer).toHaveBeenCalledWith(unusableProducer);
 		expect(mediaManager.mediaHandler.videoProducer).toBeNull();
 		expect(mediaManager.mediaHandler.localStream?.getVideoTracks()).toEqual([
 			previous,

--- a/suite/meet/type-policy/allowlist.json
+++ b/suite/meet/type-policy/allowlist.json
@@ -2,14 +2,6 @@
   "version": 1,
   "exceptions": [
     {
-      "path": "frontend/src/apps/meet/composables/useRTCStats.ts",
-      "line": 6,
-      "column": 20,
-      "rule": "MTP001",
-      "lineText": "type StatsReport = Record<string, unknown> & {",
-      "reason": "Browser RTC statistics are an extensible cross-browser metadata dictionary with guarded reads."
-    },
-    {
       "path": "frontend/src/apps/meet/types.ts",
 		"line": 118,
       "column": 13,


### PR DESCRIPTION
## Summary

- make `SFUMeetingManager` the public boundary for Meet media operations
- centralize producer reconciliation, RTC sampling, and media-health ownership
- close producer lifecycle, E2EE, screen-share, and manager-replacement races
- prevent microphone enable from committing through a replaced manager
- revoke audio resumed by a stale manager during handoff
- keep screen publication identity checks inside their manager scope

Depends on #754.