### PR TITLE
refactor(meet): centralize media attachment

### DIFF
--- a/frontend/recorder/RecorderSocketController.test.ts
+++ b/frontend/recorder/RecorderSocketController.test.ts
@@ -32,6 +32,7 @@ interface ParticipantHandlers {
 
 interface ConsumerHandlers {
 	onConsumerAdded?: (consumer: ConsumerFixture) => void;
+	onConsumerRemoved?: (consumerId: string, consumer: ConsumerFixture) => void;
 }
 
 interface MediaHandlers {
@@ -54,7 +55,7 @@ function harness(existing: ProducerFixture[] = [], subscription?: ConsumerFixtur
 	const calls: string[] = [];
 	const socketHandlers = new Map<string, (...args: unknown[]) => void>();
 	const sfuHandlers = new Map<string, (...args: unknown[]) => void>();
-	let consumerAdded: ConsumerHandlers["onConsumerAdded"];
+	let consumerHandlers: ConsumerHandlers = {};
 	let participantHandlers: ParticipantHandlers = {};
 	let mediaHandlers: MediaHandlers = {};
 	const channel = {
@@ -65,16 +66,24 @@ function harness(existing: ProducerFixture[] = [], subscription?: ConsumerFixtur
 	};
 	const bridge = { sign: vi.fn(async () => "signature"), reportCaptureReady: vi.fn(), reportInterruption: vi.fn(), reportProofComplete: vi.fn(), reportJoinComplete: vi.fn(), reportFailure: vi.fn() };
 	const participants = new Map<string, Participant>();
+	const consumers = new Map<string, ConsumerFixture>();
+	const removeConsumer = vi.fn((id: string) => {
+		const consumer = consumers.get(id);
+		if (!consumer) return undefined;
+		consumers.delete(id);
+		consumerHandlers.onConsumerRemoved?.(id, consumer);
+		return consumer;
+	});
 	const dependencies = {
 		sfuClient: { connected: false, connectionDetails: {}, on: vi.fn((event: string, handler: (...args: unknown[]) => void) => sfuHandlers.set(event, handler)), registerEventHandlers: vi.fn(), getRoomParticipants: vi.fn(async (): Promise<ParticipantData[]> => { calls.push("participants"); return []; }), getExistingProducers: vi.fn(async () => { calls.push("producers"); return existing; }), disconnect: vi.fn() },
 		transportManager: { initializeDevice: vi.fn(async () => calls.push("device")), createReceiveTransport: vi.fn(async () => calls.push("recv")), setEventHandlers: vi.fn(), cleanup: vi.fn() },
-		consumerManager: { setEventHandlers: vi.fn((handlers: ConsumerHandlers) => { consumerAdded = handlers.onConsumerAdded; }), getConsumersByParticipant: vi.fn(() => []), getScreenShareConsumers: vi.fn(() => []), cleanupParticipantConsumers: vi.fn(), clear: vi.fn(), removeConsumer: vi.fn() },
-		participantManager: { setEventHandlers: vi.fn((handlers: ParticipantHandlers) => { participantHandlers = handlers; }), syncParticipants: vi.fn((values: RecorderParticipantData[]) => values.forEach((value) => { const participant = participantFixture(value); participants.set(participant.user_id, participant); })), addParticipant: vi.fn((value: RecorderParticipantData) => { const participant = participantFixture(value); participants.set(participant.user_id, participant); return participant; }), removeParticipant: vi.fn((id: string) => participants.delete(id)), updateMediaState: vi.fn(), getAllParticipants: vi.fn(() => [...participants.values()]), hasParticipant: vi.fn((id: string) => participants.has(id)) },
-		videoManager: { removeVideoElement: vi.fn(), cleanup: vi.fn() },
-		mediaManager: { setEventHandlers: vi.fn((handlers: MediaHandlers) => { mediaHandlers = handlers; }), handleNewConsumer: vi.fn(async (consumer: ConsumerFixture) => { if (consumer.isScreen) mediaHandlers.onScreenShareStarted?.({ participantId: consumer.participantId, stream: new MediaStream(), consumer }); }), handleConsumerLost: vi.fn(), subscribeToRemoteProducer: vi.fn(async (event: { producerId: string; participantId: string; isScreen: boolean }) => { if (subscription === null) return null; const consumer: ConsumerFixture = subscription || { id: `c-${event.producerId}`, producerId: event.producerId, participantId: event.participantId, kind: "audio", isScreen: false }; consumerAdded?.(consumer); return consumer; }), cancelPendingSubscriptions: vi.fn(async () => undefined), cleanup: vi.fn() },
+		consumerManager: { setEventHandlers: vi.fn((handlers: ConsumerHandlers) => { consumerHandlers = { ...consumerHandlers, ...handlers }; }), getConsumersByParticipant: vi.fn((id: string) => [...consumers.values()].filter((consumer) => consumer.participantId === id)), getScreenShareConsumers: vi.fn(() => [...consumers.values()].filter((consumer) => consumer.isScreen)), cleanupParticipantConsumers: vi.fn((id: string) => { for (const consumer of [...consumers.values()]) if (consumer.participantId === id) removeConsumer(consumer.id); }), clear: vi.fn(() => { for (const consumer of [...consumers.values()]) removeConsumer(consumer.id); }), removeConsumer },
+		participantManager: { setEventHandlers: vi.fn((handlers: ParticipantHandlers) => { participantHandlers = handlers; }), syncParticipants: vi.fn((values: RecorderParticipantData[]) => values.forEach((value) => { const participant = participantFixture(value); participants.set(participant.user_id, participant); })), addParticipant: vi.fn((value: RecorderParticipantData) => { const participant = participantFixture(value); participants.set(participant.user_id, participant); participantHandlers.onParticipantAdded?.(participant); return participant; }), removeParticipant: vi.fn((id: string) => { const removed = participants.delete(id); if (removed) participantHandlers.onParticipantRemoved?.(id); return removed; }), updateMediaState: vi.fn(), getAllParticipants: vi.fn(() => [...participants.values()]), hasParticipant: vi.fn((id: string) => participants.has(id)) },
+		videoManager: { removeVideoElement: vi.fn(), cancelDeferredAttachment: vi.fn(), cleanup: vi.fn() },
+		mediaManager: { setEventHandlers: vi.fn((handlers: MediaHandlers) => { mediaHandlers = handlers; }), handleNewConsumer: vi.fn(async (consumer: ConsumerFixture) => { if (consumer.isScreen) mediaHandlers.onScreenShareStarted?.({ participantId: consumer.participantId, stream: new MediaStream(), consumer }); }), handleConsumerLost: vi.fn(), subscribeToRemoteProducer: vi.fn(async (event: { producerId: string; participantId: string; isScreen: boolean }) => { if (subscription === null) return null; const consumer: ConsumerFixture = subscription || { id: `c-${event.producerId}`, producerId: event.producerId, participantId: event.participantId, kind: event.isScreen ? "video" : "audio", isScreen: event.isScreen }; consumers.set(consumer.id, consumer); consumerHandlers.onConsumerAdded?.(consumer); return consumer; }), cancelPendingSubscriptions: vi.fn(async () => undefined), cleanup: vi.fn() },
 	};
 	const controller = new RecorderSocketController(bridge as never, channel, state, dependencies as never);
-	return { calls, channel, bridge, dependencies, sfuHandlers, getParticipantHandlers: () => participantHandlers, participants, controller };
+	return { calls, channel, bridge, consumers, dependencies, sfuHandlers, getConsumerHandlers: () => consumerHandlers, getParticipantHandlers: () => participantHandlers, participants, controller };
 }
 
 describe("RecorderSocketController", () => {
@@ -211,6 +220,193 @@ describe("RecorderSocketController", () => {
 		acknowledge();
 		await connected;
 		expect(h.controller.ready.value).toBe(true);
+	});
+
+	it("cancels an initial screen attachment removed before mount", async () => {
+		vi.useFakeTimers();
+		let acknowledge!: () => void;
+		const screenStarted = vi.fn(() => new Promise<void>((resolve) => { acknowledge = resolve; }));
+		const consumer = { id: "screen-c1", producerId: "p1", participantId: "alice", kind: "video", isScreen: true } as const;
+		const h = harness([{ id: "p1", participantId: "alice", isScreen: true }], consumer, { screenStarted });
+		const connected = h.controller.connect(config);
+		await vi.waitFor(() => expect(screenStarted).toHaveBeenCalledOnce());
+
+		h.sfuHandlers.get("producer_closed")?.({
+			producerId: "p1",
+			participantId: "alice",
+			isScreen: true,
+		});
+
+		await connected;
+		expect(h.controller.ready.value).toBe(true);
+		expect(h.bridge.reportFailure).not.toHaveBeenCalled();
+		expect(
+			Reflect.get(h.controller, "attachmentPromises").size,
+		).toBe(0);
+		expect(
+			Reflect.get(h.controller, "screenAttachmentPromises").size,
+		).toBe(0);
+		await vi.advanceTimersByTimeAsync(
+			RecorderSocketController.ATTACHMENT_TIMEOUT_MS,
+		);
+		acknowledge();
+		await Promise.resolve();
+		expect(h.bridge.reportFailure).not.toHaveBeenCalled();
+		expect(h.bridge.reportInterruption).not.toHaveBeenCalled();
+		vi.useRealTimers();
+	});
+
+	it("cancels a participant attachment removed before its tile mounts", async () => {
+		let rejectAttachment!: (error: Error) => void;
+		const h = harness();
+		await h.controller.connect(config);
+		h.dependencies.mediaManager.handleNewConsumer.mockReturnValueOnce(
+			new Promise<void>((_resolve, reject) => {
+				rejectAttachment = reject;
+			}),
+		);
+		h.sfuHandlers.get("participant_joined")?.({
+			participantId: "alice",
+			userData: { name: "Alice" },
+		});
+		h.sfuHandlers.get("producer_created")?.({
+			producerId: "camera-1",
+			participantId: "alice",
+			isScreen: false,
+		});
+		await vi.waitFor(() =>
+			expect(h.dependencies.mediaManager.handleNewConsumer).toHaveBeenCalled(),
+		);
+
+		h.sfuHandlers.get("participant_left")?.({ participantId: "alice" });
+		await vi.waitFor(() =>
+			expect(Reflect.get(h.controller, "attachmentPromises").size).toBe(0),
+		);
+		expect(
+			h.dependencies.videoManager.cancelDeferredAttachment,
+		).toHaveBeenCalledWith("alice");
+		rejectAttachment(new Error("obsolete attachment failed"));
+		await Promise.resolve();
+		expect(h.bridge.reportInterruption).not.toHaveBeenCalled();
+	});
+
+	it("replaces a participant screen and ignores the old producer's late close", async () => {
+		const screenStarted = vi.fn();
+		const screenStopped = vi.fn();
+		const h = harness([], undefined, { screenStarted, screenStopped });
+		await h.controller.connect(config);
+
+		h.sfuHandlers.get("producer_created")?.({
+			producerId: "screen-old",
+			participantId: "alice",
+			isScreen: true,
+		});
+		await vi.waitFor(() => expect(screenStarted).toHaveBeenCalledTimes(1));
+		h.sfuHandlers.get("producer_created")?.({
+			producerId: "screen-current",
+			participantId: "alice",
+			isScreen: true,
+		});
+		await vi.waitFor(() => expect(screenStarted).toHaveBeenCalledTimes(2));
+
+		expect(screenStopped).toHaveBeenCalledWith("alice", "screen-old");
+		screenStopped.mockClear();
+		h.sfuHandlers.get("producer_closed")?.({
+			producerId: "screen-old",
+			participantId: "alice",
+			isScreen: true,
+		});
+
+		expect(screenStopped).not.toHaveBeenCalled();
+		expect(Reflect.get(h.controller, "activeScreens").get("alice")).toEqual({
+			consumerId: "c-screen-current",
+			producerId: "screen-current",
+		});
+	});
+
+	it("matches recorder screen stops by participant and producer", async () => {
+		const screenStopped = vi.fn();
+		const h = harness([], undefined, { screenStopped });
+		await h.controller.connect(config);
+		h.sfuHandlers.get("producer_created")?.({
+			producerId: "screen-1",
+			participantId: "alice",
+			isScreen: true,
+		});
+		await vi.waitFor(() =>
+			expect(h.dependencies.mediaManager.subscribeToRemoteProducer).toHaveBeenCalled(),
+		);
+		h.dependencies.consumerManager.removeConsumer.mockClear();
+
+		h.sfuHandlers.get("screen_share_stopped")?.({
+			participantId: "bob",
+			producerId: "screen-1",
+		});
+
+		expect(h.dependencies.consumerManager.removeConsumer).not.toHaveBeenCalled();
+		expect(screenStopped).not.toHaveBeenCalled();
+	});
+
+	it("ignores an old consumer removal after same-producer resubscription", async () => {
+		const screenStopped = vi.fn();
+		const h = harness([], undefined, { screenStopped });
+		await h.controller.connect(config);
+		const oldConsumer = {
+			id: "screen-old-consumer",
+			producerId: "screen-1",
+			participantId: "alice",
+			kind: "video",
+			isScreen: true,
+		} as const;
+		const replacement = {
+			...oldConsumer,
+			id: "screen-new-consumer",
+		};
+		h.consumers.set(oldConsumer.id, oldConsumer);
+		h.getConsumerHandlers().onConsumerAdded?.(oldConsumer);
+		await vi.waitFor(() =>
+			expect(Reflect.get(h.controller, "activeScreens").get("alice")).toEqual({
+				consumerId: oldConsumer.id,
+				producerId: oldConsumer.producerId,
+			}),
+		);
+		h.consumers.set(replacement.id, replacement);
+		h.getConsumerHandlers().onConsumerAdded?.(replacement);
+		await vi.waitFor(() =>
+			expect(Reflect.get(h.controller, "activeScreens").get("alice")).toEqual({
+				consumerId: replacement.id,
+				producerId: replacement.producerId,
+			}),
+		);
+		screenStopped.mockClear();
+
+		h.getConsumerHandlers().onConsumerRemoved?.(oldConsumer.id, oldConsumer);
+
+		expect(screenStopped).not.toHaveBeenCalled();
+		expect(Reflect.get(h.controller, "activeScreens").get("alice")).toEqual({
+			consumerId: replacement.id,
+			producerId: replacement.producerId,
+		});
+	});
+
+	it("settles active screen state during recorder cleanup", async () => {
+		const screenStopped = vi.fn();
+		const h = harness([], undefined, { screenStopped });
+		await h.controller.connect(config);
+		h.sfuHandlers.get("producer_created")?.({
+			producerId: "screen-1",
+			participantId: "alice",
+			isScreen: true,
+		});
+		await vi.waitFor(() =>
+			expect(Reflect.get(h.controller, "activeScreens").has("alice")).toBe(true),
+		);
+
+		h.controller.disconnect();
+
+		expect(screenStopped).toHaveBeenCalledWith("alice", "screen-1");
+		expect(Reflect.get(h.controller, "activeScreens").size).toBe(0);
+		expect(Reflect.get(h.controller, "screenAttachmentPromises").size).toBe(0);
 	});
 
 	it("reports only failure when initial screen playback is rejected", async () => {

--- a/frontend/recorder/RecorderSocketController.ts
+++ b/frontend/recorder/RecorderSocketController.ts
@@ -19,7 +19,6 @@ import {
 	parseConsumerId,
 	parseHandChange,
 	parseMediaControlMessage,
-	parseParticipantId,
 	parseParticipantMessage,
 	parseParticipantUpdate,
 	parseProducerMessage,
@@ -29,6 +28,7 @@ import {
 	parseRecordingChallenge,
 	parseRequestResponse,
 	parseScreenShareStarted,
+	parseScreenShareStopped,
 	type MediaControlMessage,
 	type ProducerEvent,
 	type RecorderParticipantData,
@@ -43,8 +43,8 @@ export type RecorderState = {
 	participantRemoved?: (participantId: string) => void;
 	participantUpdated?: (participantId: string, updates: RecorderParticipantUpdate) => void;
 	activeSpeakersChanged?: (participantIds: string[]) => void;
-	screenStarted?: (data: { participantId: string; consumerId: string; stream: MediaStream; startedAt: number }) => Promise<void> | void;
-	screenStopped?: (participantId: string) => void;
+	screenStarted?: (data: { participantId: string; consumerId: string; producerId: string; stream: MediaStream; startedAt: number }) => Promise<void> | void;
+	screenStopped?: (participantId: string, producerId: string) => void;
 	reactionReceived?: (userId: string, reaction: string) => void;
 	handChanged?: (userId: string, raised: boolean, timestamp: string) => void;
 	handsSynced?: (hands: Record<string, string>) => void;
@@ -61,6 +61,13 @@ interface RecorderDependencies {
 	mediaManager: SFUMediaManager;
 }
 
+interface PendingAttachment {
+	consumerId: string;
+	participantId: string;
+	promise: Promise<void>;
+	cancel: () => void;
+}
+
 export class RecorderSocketController {
 	static readonly ATTACHMENT_TIMEOUT_MS = 10_000;
 	private channel: SignalChannel;
@@ -69,8 +76,16 @@ export class RecorderSocketController {
 	private reconciliation: MeetingReconciliationState<ReconciledRecorderParticipant> =
 		createMeetingReconciliationState();
 	private producerClaims = new Set<string>();
-	private attachmentPromises = new Map<string, Promise<void>>();
-	private screenAttachmentPromises = new Map<string, Promise<void>>();
+	private attachmentPromises = new Map<string, PendingAttachment>();
+	private screenAttachmentPromises = new Map<string, PendingAttachment>();
+	private currentParticipantAttachments = new Map<
+		string,
+		{ consumerId: string; producerId: string }
+	>();
+	private activeScreens = new Map<
+		string,
+		{ consumerId: string; producerId: string }
+	>();
 	private initialSync = true;
 	private captureStartedAt = 0;
 	private cleaningUp = false;
@@ -185,23 +200,77 @@ export class RecorderSocketController {
 		});
 		this.deps.consumerManager.setEventHandlers({
 			onConsumerAdded: (consumer) => {
-				const attached = this.deps.mediaManager.handleNewConsumer(consumer).then(async () => {
-					if (consumer.isScreen) await this.screenAttachmentPromises.get(consumer.id);
+				const operation = this.deps.mediaManager.handleNewConsumer(consumer).then(async () => {
+					if (consumer.isScreen) {
+						await this.screenAttachmentPromises.get(consumer.id)?.promise;
+					}
 				});
-				this.attachmentPromises.set(consumer.producerId, attached);
-				void attached.catch((error) => {
-					if (this._ready.value) this.interrupt(`Media attachment failed: ${error instanceof Error ? error.message : "unknown error"}`);
-				});
+				const pending = this.cancellableAttachment(consumer, operation);
+				this.attachmentPromises.set(consumer.producerId, pending);
+				if (!consumer.isScreen) {
+					this.currentParticipantAttachments.set(
+						consumer.participantId,
+						{ consumerId: consumer.id, producerId: consumer.producerId },
+					);
+				}
+				void pending.promise
+					.catch((error) => {
+						if (this._ready.value) this.interrupt(`Media attachment failed: ${error instanceof Error ? error.message : "unknown error"}`);
+					})
+					.finally(() => {
+						if (this.attachmentPromises.get(consumer.producerId) === pending) {
+							this.attachmentPromises.delete(consumer.producerId);
+						}
+					});
 			},
-			onConsumerRemoved: (_id, consumer) => { if (consumer.isScreen) this.stopScreen(consumer.participantId); },
+			onConsumerRemoved: (_id, consumer) => {
+				this.cancelConsumerAttachment(consumer);
+				if (consumer.isScreen) this.finishScreen(consumer.participantId, consumer.producerId, consumer.id);
+			},
 			onConsumerLost: (info) => void this.deps.mediaManager.handleConsumerLost(info),
 		});
 		this.deps.mediaManager.setEventHandlers({
 			onScreenShareStarted: (value) => {
 				const data = parseScreenShareStarted(value);
 				if (!data) return;
-				const acknowledged = Promise.resolve(this.state.screenStarted?.({ participantId: data.participantId, consumerId: data.consumerId, stream: data.stream, startedAt: Date.now() }));
-				this.screenAttachmentPromises.set(data.consumerId, this.withTimeout(acknowledged, `Timed out waiting for screen element for ${data.participantId}`));
+				const previous = this.activeScreens.get(data.participantId);
+				if (previous && previous.consumerId !== data.consumerId) {
+					this.finishScreen(
+						data.participantId,
+						previous.producerId,
+						previous.consumerId,
+					);
+					const previousConsumer = this.deps.consumerManager
+						.getScreenShareConsumers()
+						.find(
+							(consumer) =>
+								consumer.id === previous.consumerId &&
+								consumer.participantId === data.participantId &&
+								consumer.producerId === previous.producerId,
+						);
+					if (previousConsumer) {
+						this.deps.consumerManager.removeConsumer(previousConsumer.id);
+					}
+				}
+				this.activeScreens.set(data.participantId, {
+					consumerId: data.consumerId,
+					producerId: data.producerId,
+				});
+				const acknowledged = Promise.resolve().then(() =>
+					this.state.screenStarted?.({ participantId: data.participantId, consumerId: data.consumerId, producerId: data.producerId, stream: data.stream, startedAt: Date.now() }),
+				);
+				const pending = this.withTimeout(
+					data,
+					acknowledged,
+					`Timed out waiting for screen element for ${data.participantId}`,
+				);
+				this.screenAttachmentPromises.set(data.consumerId, pending);
+				const cleanupPending = () => {
+					if (this.screenAttachmentPromises.get(data.consumerId) === pending) {
+						this.screenAttachmentPromises.delete(data.consumerId);
+					}
+				};
+				void pending.promise.then(cleanupPending, cleanupPending);
 			},
 			onRecoveryExhausted: () => this.interrupt("Media subscription recovery exhausted"),
 		});
@@ -219,7 +288,10 @@ export class RecorderSocketController {
 		client.on("consumer_closed", (value) => { const id = parseConsumerId(value); if (id) this.deps.consumerManager.removeConsumer(id); });
 		client.on("media_control_update", (value) => { const message = parseMediaControlMessage(value); if (message) this.updateMedia(message); });
 		client.on("active_speaker", (value) => { const ids = parseActiveSpeakers(value); if (ids) this.state.activeSpeakersChanged?.(ids); });
-		client.on("screen_share_stopped", (value) => { const id = parseParticipantId(value); if (id) this.stopScreen(id); });
+		client.on("screen_share_stopped", (value) => {
+			const stopped = parseScreenShareStopped(value);
+			if (stopped) this.stopScreen(stopped.participantId, stopped.producerId);
+		});
 		client.on("reaction:message", (value) => { const reaction = parseReaction(value); if (reaction) this.state.reactionReceived?.(reaction.fromUser, reaction.reaction); });
 		client.on("hand_raised", (value) => { const hand = parseHandChange(value); if (hand) this.state.handChanged?.(hand.participantId, hand.raised, hand.timestamp); });
 		client.on("existing_raised_hands", (value) => { const hands = parseRaisedHands(value); if (hands) this.state.handsSynced?.(hands); });
@@ -310,7 +382,7 @@ export class RecorderSocketController {
 			const result = await this.deps.mediaManager.subscribeToRemoteProducer(event);
 			if (!this.isCurrentProducer(event)) { this.removeProducer(event); return; }
 			if (!result) throw new Error(`Initial producer ${event.producerId} did not create a consumer`);
-			const attached = this.attachmentPromises.get(event.producerId);
+			const attached = this.attachmentPromises.get(event.producerId)?.promise;
 			if (!attached) throw new Error(`Initial producer ${event.producerId} was not attached`);
 			await attached;
 			if (!this.isCurrentProducer(event)) this.removeProducer(event);
@@ -324,20 +396,163 @@ export class RecorderSocketController {
 	private isCurrentProducer(event: ProducerEvent): boolean { return this.reconciliation.producers.get(event.producerId) === event; }
 	private sanitizeParticipant(p: RecorderParticipantData): RecorderParticipantData { const avatar = trustedAvatar(p.userData?.avatar || p.avatar, this.frappeOrigin); return { ...p, avatar, userData: { ...p.userData, avatar } }; }
 	private frappeOrigin = "";
-	private removeProducer(event: ProducerEvent): void { for (const c of this.deps.consumerManager.getConsumersByParticipant(event.participantId || "")) if (c.producerId === event.producerId || (event.isScreen && c.isScreen)) this.deps.consumerManager.removeConsumer(c.id); }
-	private stopScreen(participantId: string): void { if (!participantId) return; for (const c of this.deps.consumerManager.getScreenShareConsumers().filter((c) => c.participantId === participantId)) this.deps.consumerManager.removeConsumer(c.id); this.state.screenStopped?.(participantId); }
+	private removeProducer(event: ProducerEvent): void {
+		const consumers = this.deps.consumerManager
+			.getConsumersByParticipant(event.participantId)
+			.filter((consumer) => consumer.producerId === event.producerId);
+		for (const consumer of consumers) {
+			this.deps.consumerManager.removeConsumer(consumer.id);
+		}
+		if (!consumers.length) this.cancelProducerAttachment(event);
+		if (event.isScreen) this.finishScreen(event.participantId, event.producerId);
+	}
+	private stopScreen(participantId: string, producerId: string): void {
+		const consumer = this.deps.consumerManager
+			.getScreenShareConsumers()
+			.find((candidate) =>
+				candidate.participantId === participantId &&
+				candidate.producerId === producerId,
+			);
+		if (consumer) {
+			this.deps.consumerManager.removeConsumer(consumer.id);
+			return;
+		}
+		this.finishScreen(participantId, producerId);
+	}
+	private finishScreen(
+		participantId: string,
+		producerId: string,
+		consumerId?: string,
+	): void {
+		const screen = this.activeScreens.get(participantId);
+		if (
+			screen?.producerId !== producerId ||
+			(consumerId && screen.consumerId !== consumerId)
+		) return;
+		this.activeScreens.delete(participantId);
+		this.screenAttachmentPromises.get(screen.consumerId)?.cancel();
+		this.state.screenStopped?.(participantId, producerId);
+	}
 	private updateMedia(data: MediaControlMessage): void { const action = data.action; const update: { audioEnabled?: boolean; videoEnabled?: boolean } = {}; if (typeof action === "object") action.type === "audio" ? update.audioEnabled = action.enabled : update.videoEnabled = action.enabled; else if (action === "mute" || action === "unmute") update.audioEnabled = action === "unmute"; else update.videoEnabled = action === "video_on"; this.deps.participantManager.updateMediaState(data.participantId, update); }
 	private interrupt(reason: string): void { if (!this._ready.value && this._interruption.value) return; this._ready.value = false; this._interruption.value = reason; this.bridge.reportInterruption(reason); }
-	private withTimeout(promise: Promise<void>, message: string): Promise<void> {
-		return new Promise((resolve, reject) => {
-			const timer = setTimeout(() => reject(new Error(message)), RecorderSocketController.ATTACHMENT_TIMEOUT_MS);
-			promise.then((value) => { clearTimeout(timer); resolve(value); }, (error) => { clearTimeout(timer); reject(error); });
+	private cancellableAttachment(
+		consumer: { id: string; participantId: string },
+		operation: Promise<void>,
+	): PendingAttachment {
+		let settled = false;
+		let cancel!: () => void;
+		const promise = new Promise<void>((resolve, reject) => {
+			cancel = () => {
+				if (settled) return;
+				settled = true;
+				resolve();
+			};
+			operation.then(
+				() => {
+					if (settled) return;
+					settled = true;
+					resolve();
+				},
+				(error) => {
+					if (settled) return;
+					settled = true;
+					reject(error);
+				},
+			);
 		});
+		return {
+			consumerId: consumer.id,
+			participantId: consumer.participantId,
+			promise,
+			cancel,
+		};
+	}
+	private withTimeout(
+		consumer: { consumerId: string; participantId: string },
+		operation: Promise<void | undefined>,
+		message: string,
+	): PendingAttachment {
+		let settled = false;
+		let timer: ReturnType<typeof setTimeout>;
+		let cancel!: () => void;
+		const promise = new Promise<void>((resolve, reject) => {
+			cancel = () => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				resolve();
+			};
+			timer = setTimeout(() => {
+				if (settled) return;
+				settled = true;
+				reject(new Error(message));
+			}, RecorderSocketController.ATTACHMENT_TIMEOUT_MS);
+			operation.then(
+				() => {
+					if (settled) return;
+					settled = true;
+					clearTimeout(timer);
+					resolve();
+				},
+				(error) => {
+					if (settled) return;
+					settled = true;
+					clearTimeout(timer);
+					reject(error);
+				},
+			);
+		});
+		return {
+			consumerId: consumer.consumerId,
+			participantId: consumer.participantId,
+			promise,
+			cancel,
+		};
+	}
+	private cancelConsumerAttachment(consumer: {
+		id: string;
+		participantId: string;
+		producerId: string;
+		isScreen: boolean;
+	}): void {
+		const pending = this.attachmentPromises.get(consumer.producerId);
+		if (pending?.consumerId === consumer.id) pending.cancel();
+		if (consumer.isScreen) {
+			this.screenAttachmentPromises.get(consumer.id)?.cancel();
+			return;
+		}
+		const current = this.currentParticipantAttachments.get(consumer.participantId);
+		if (
+			current?.producerId === consumer.producerId &&
+			current.consumerId === consumer.id
+		) {
+			this.currentParticipantAttachments.delete(consumer.participantId);
+			this.deps.videoManager.cancelDeferredAttachment(consumer.participantId);
+		}
+	}
+	private cancelProducerAttachment(event: ProducerEvent): void {
+		this.attachmentPromises.get(event.producerId)?.cancel();
+		if (
+			this.currentParticipantAttachments.get(event.participantId)?.producerId ===
+			event.producerId
+		) {
+			this.currentParticipantAttachments.delete(event.participantId);
+			this.deps.videoManager.cancelDeferredAttachment(event.participantId);
+		}
 	}
 	private cleanup(): void {
 		if (this.cleaningUp) return;
 		this.cleaningUp = true;
 		if (this.roomEmptyTimer) clearTimeout(this.roomEmptyTimer);
+		for (const pending of this.attachmentPromises.values()) pending.cancel();
+		for (const [participantId, screen] of [...this.activeScreens]) {
+			this.finishScreen(participantId, screen.producerId, screen.consumerId);
+		}
+		for (const pending of this.screenAttachmentPromises.values()) pending.cancel();
+		this.attachmentPromises.clear();
+		this.screenAttachmentPromises.clear();
+		this.currentParticipantAttachments.clear();
+		this.activeScreens.clear();
 		void this.deps.mediaManager.cancelPendingSubscriptions();
 		this.deps.mediaManager.cleanup();
 		this.deps.consumerManager.clear();

--- a/frontend/recorder/main.ts
+++ b/frontend/recorder/main.ts
@@ -33,15 +33,29 @@ const app = createApp({
 			participantRemoved: (id) => participantStore.removeParticipant(id),
 			participantUpdated: (id, updates) => participantStore.updateParticipant(id, { ...updates }),
 			activeSpeakersChanged: (ids) => { participantStore.activeSpeakerIds = ids; participantStore.stableSpeakerIds = ids; },
-			screenStarted: ({ participantId, consumerId, stream, startedAt }) => {
+			screenStarted: ({ participantId, consumerId, producerId, stream, startedAt }) => {
+				const replaced = mediaState.activeScreenShareConsumers.filter(
+					(share) =>
+						share.participantId === participantId &&
+						share.consumerId !== consumerId,
+				);
+				for (const share of replaced) {
+					pendingScreenAttachments.get(share.consumerId)?.resolve();
+					pendingScreenAttachments.delete(share.consumerId);
+					delete mediaState.screenShareStreams[share.consumerId];
+				}
 				mediaState.screenShareStreams[consumerId] = stream;
-				mediaState.activeScreenShareConsumers = [...mediaState.activeScreenShareConsumers.filter((s) => s.consumerId !== consumerId), { participantId, consumerId, startedAt }];
+				mediaState.activeScreenShareConsumers = [...mediaState.activeScreenShareConsumers.filter((s) => s.participantId !== participantId), { source: "remote", participantId, consumerId, producerId, startedAt }];
 				return new Promise<void>((resolve, reject) => pendingScreenAttachments.set(consumerId, { resolve, reject }));
 			},
-			screenStopped: (participantId) => {
-				const removed = mediaState.activeScreenShareConsumers.filter((s) => s.participantId === participantId);
-				mediaState.activeScreenShareConsumers = mediaState.activeScreenShareConsumers.filter((s) => s.participantId !== participantId);
-				for (const share of removed) delete mediaState.screenShareStreams[share.consumerId];
+			screenStopped: (participantId, producerId) => {
+				const removed = mediaState.activeScreenShareConsumers.filter((s) => s.participantId === participantId && s.producerId === producerId);
+				mediaState.activeScreenShareConsumers = mediaState.activeScreenShareConsumers.filter((s) => s.participantId !== participantId || s.producerId !== producerId);
+				for (const share of removed) {
+					pendingScreenAttachments.get(share.consumerId)?.resolve();
+					pendingScreenAttachments.delete(share.consumerId);
+					delete mediaState.screenShareStreams[share.consumerId];
+				}
 			},
 			reactionReceived: (id, reaction) => reactionStore.showReactionForUser(id, reaction),
 			handChanged: (id, raised, timestamp) => raised ? raiseHandStore.raiseHand(id, timestamp) : raiseHandStore.lowerHand(id),
@@ -62,7 +76,7 @@ const app = createApp({
 			mediaState, participantStore, currentUser, chatStore, gridLayout, raiseHandStore, reactionStore, lobbyStore,
 			sfuManager: null, processedStream: ref<MediaStream | null>(null), isInMeeting: computed(() => true), onBackgroundEffectsChanged: () => undefined, networkQuality: ref<"good" | "poor" | "critical">("good"),
 		};
-		return () => h(RecorderRenderer, { startedAt: config.startedAt, interruption: controller.interruption.value, messages: messages.value, meetingContext, videoManager: controller.videoManager, onPlaybackFailure: (reason: string) => controller.reportPlaybackFailure(reason), onScreenAttachment: (consumerId: string, attachment: Promise<void>) => attachment.then(pendingScreenAttachments.get(consumerId)?.resolve, pendingScreenAttachments.get(consumerId)?.reject) });
+		return () => h(RecorderRenderer, { startedAt: config.startedAt, interruption: controller.interruption.value, messages: messages.value, meetingContext, videoManager: controller.videoManager, onPlaybackFailure: (reason: string) => controller.reportPlaybackFailure(reason), onScreenAttachment: (consumerId: string, attachment: Promise<void>) => { const pending = pendingScreenAttachments.get(consumerId); const settle = (error?: unknown) => { if (!pending || pendingScreenAttachments.get(consumerId) !== pending) return; pendingScreenAttachments.delete(consumerId); error ? pending.reject(error instanceof Error ? error : new Error("Screen attachment failed")) : pending.resolve(); }; void attachment.then(() => settle(), settle); } });
 	},
 });
 app.use(pinia).mount("#app");

--- a/frontend/recorder/protocol.ts
+++ b/frontend/recorder/protocol.ts
@@ -386,7 +386,12 @@ export const parseRequestResponse = (
 
 export const parseScreenShareStarted = (
 	value: unknown,
-): { participantId: string; consumerId: string; stream: MediaStream } | null => {
+): {
+	participantId: string;
+	consumerId: string;
+	producerId: string;
+	stream: MediaStream;
+} | null => {
 	if (typeof value !== "object" || value === null) return null;
 	const participantId = "participantId" in value ? value.participantId : undefined;
 	const stream = "stream" in value ? value.stream : undefined;
@@ -395,7 +400,30 @@ export const parseScreenShareStarted = (
 		typeof participantId !== "string" || !participantId ||
 		(typeof MediaStream === "undefined" || !(stream instanceof MediaStream)) ||
 		typeof consumer !== "object" || consumer === null ||
-		!("id" in consumer) || typeof consumer.id !== "string" || !consumer.id
+		!("id" in consumer) || typeof consumer.id !== "string" || !consumer.id ||
+		!("producerId" in consumer) ||
+		typeof consumer.producerId !== "string" ||
+		!consumer.producerId
 	) return null;
-	return { participantId, consumerId: consumer.id, stream };
+	return {
+		participantId,
+		consumerId: consumer.id,
+		producerId: consumer.producerId,
+		stream,
+	};
+};
+
+export const parseScreenShareStopped = (
+	value: unknown,
+): { participantId: string; producerId: string } | null => {
+	if (typeof value !== "object" || value === null) return null;
+	const participantId = "participantId" in value ? value.participantId : undefined;
+	const producerId = "producerId" in value ? value.producerId : undefined;
+	if (
+		typeof participantId !== "string" ||
+		!participantId ||
+		typeof producerId !== "string" ||
+		!producerId
+	) return null;
+	return { participantId, producerId };
 };

--- a/frontend/src/apps/meet/composables/__tests__/useScreenShareTiles.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useScreenShareTiles.test.ts
@@ -5,7 +5,7 @@ import { useScreenShareTiles } from "../useScreenShareTiles";
 describe("useScreenShareTiles", () => {
 	it("keeps tile and pin identity when a screen consumer is replaced", async () => {
 		const displayScreenShares = ref([
-			{ consumerId: "consumer-1", participantId: "user-1" },
+			{ consumerId: "consumer-1", participantId: "user-1", source: "remote" as const },
 		]);
 		const pinnedTiles = ref<{ type: "screenshare" | "participant"; id: string }[]>([]);
 		const pinTile = vi.fn((type, id) => pinnedTiles.value.push({ type, id }));
@@ -26,7 +26,7 @@ describe("useScreenShareTiles", () => {
 
 		expect(screenShareTiles.value[0]?.pinId).toBe("user-1");
 		displayScreenShares.value = [
-			{ consumerId: "consumer-2", participantId: "user-1" },
+			{ consumerId: "consumer-2", participantId: "user-1", source: "remote" },
 		];
 		await nextTick();
 

--- a/frontend/src/apps/meet/composables/useBackgroundEffects.ts
+++ b/frontend/src/apps/meet/composables/useBackgroundEffects.ts
@@ -8,6 +8,10 @@ import {
 } from "../data/backgroundEffects";
 import { CameraFramingProcessor } from "../utils/cameraFraming";
 import {
+	type MediaAttachmentFacade,
+	VideoElementManager,
+} from "../utils/media/VideoElementManager";
+import {
 	applyBlurEffect,
 	applyVirtualBackground,
 	CompositingError,
@@ -70,6 +74,12 @@ interface HaltProcessingOptions {
 
 interface UseBackgroundEffectsOptions {
 	autoCleanupOnUnmount?: boolean;
+	mediaAttachments?: Pick<
+		MediaAttachmentFacade,
+		| "attachBackgroundEffectsSource"
+		| "removeBackgroundEffectsSource"
+		| "attachLocalPreview"
+	>;
 }
 
 // MediaPipe Selfie Segmentation instance
@@ -111,7 +121,12 @@ async function getSelfieSegmentationCtor() {
 
 export function useBackgroundEffects({
 	autoCleanupOnUnmount = true,
+	mediaAttachments: providedMediaAttachments,
 }: UseBackgroundEffectsOptions = {}): UseBackgroundEffectsReturn {
+	const fallbackMediaAttachments = providedMediaAttachments
+		? null
+		: new VideoElementManager();
+	const mediaAttachments = providedMediaAttachments ?? fallbackMediaAttachments!;
 	const isProcessing = ref<boolean>(false);
 	const processedStream = ref<MediaStream | null>(null);
 	const error = ref<string | null>(null);
@@ -126,6 +141,7 @@ export function useBackgroundEffects({
 	let animationId: number | null = null;
 	let activeSessionCleanup: (() => void) | null = null;
 	let cameraFramingDisposal: Promise<void> | null = null;
+	const backgroundAttachmentId = `background-effects-${Math.random().toString(36).slice(2)}`;
 
 	let webglManager: WebGLManager | null = null;
 	const ensureWebGL = (): void => {
@@ -397,7 +413,7 @@ export function useBackgroundEffects({
 				activeSessionCleanup = null;
 			}
 			if (video) {
-				video.srcObject = null;
+				mediaAttachments.removeBackgroundEffectsSource(backgroundAttachmentId);
 				video = null;
 			}
 			if (trackProcessor) {
@@ -426,6 +442,11 @@ export function useBackgroundEffects({
 			resultStream = null;
 			trackGenerator = null;
 			stopCameraFraming();
+			if (inputStream.getVideoTracks().some((track) => track.readyState === "live")) {
+				void mediaAttachments.attachLocalPreview(inputStream).catch((error) =>
+					console.warn("Could not restore raw local preview:", error),
+				);
+			}
 		};
 		activeSessionCleanup = cleanupProvisionalResources;
 
@@ -570,11 +591,15 @@ export function useBackgroundEffects({
 			} else {
 				// Fallback to video element for browsers without MediaStreamTrackProcessor
 				video = document.createElement("video");
-				video.srcObject = new MediaStream([videoTrack]);
-				video.muted = true;
-				video.playsInline = true;
 				try {
-					await racePendingWork(video.play(), signal);
+					await racePendingWork(
+						mediaAttachments.attachBackgroundEffectsSource(
+							backgroundAttachmentId,
+							video,
+							new MediaStream([videoTrack]),
+						),
+						signal,
+					);
 					assertOwnerActive(signal);
 				} catch (err) {
 					if (isDisposed || signal?.aborted) throw err;
@@ -1241,6 +1266,7 @@ export function useBackgroundEffects({
 		activeInstanceCount = Math.max(0, activeInstanceCount - 1);
 		disposePromise = (async () => {
 			await haltProcessing({ disposeWebGL: true });
+			fallbackMediaAttachments?.cleanup();
 			if (activeInstanceCount === 0) {
 				await releaseSegmentation();
 			}

--- a/frontend/src/apps/meet/composables/useGridLayout.ts
+++ b/frontend/src/apps/meet/composables/useGridLayout.ts
@@ -1,6 +1,6 @@
 import { type ComputedRef, computed, type Ref, ref } from "vue";
 import { useCurrentUser } from "./useCurrentUser";
-import type { MediaState, ScreenShareConsumer } from "./useMediaState";
+import type { DisplayScreenShare, MediaState } from "./useMediaState";
 
 export interface PinnedTile {
 	type: "screenshare" | "participant";
@@ -9,7 +9,7 @@ export interface PinnedTile {
 
 export interface GridLayout {
 	pinnedTiles: Ref<PinnedTile[]>;
-	displayScreenShares: ComputedRef<ScreenShareConsumer[]>;
+	displayScreenShares: ComputedRef<DisplayScreenShare[]>;
 	pinTile: (type: PinnedTile["type"], id: string) => void;
 	unpinTile: (type: PinnedTile["type"], id: string) => void;
 	resetGridLayout: () => void;
@@ -22,10 +22,10 @@ export function useGridLayout(mediaState?: MediaState): GridLayout {
 
 	const pinnedTiles = ref<PinnedTile[]>([]);
 
-	const displayScreenShares = computed<ScreenShareConsumer[]>(() => {
+	const displayScreenShares = computed<DisplayScreenShare[]>(() => {
 		if (!mediaState) return [];
 
-		const shares: ScreenShareConsumer[] = [];
+		const shares: DisplayScreenShare[] = [];
 
 		for (const share of mediaState.activeScreenShareConsumers) {
 			shares.push(share);
@@ -37,9 +37,9 @@ export function useGridLayout(mediaState?: MediaState): GridLayout {
 			currentUserStore.currentUser.value?.user_id
 		) {
 			shares.push({
+				source: "local",
 				participantId: currentUserStore.currentUser.value?.user_id as string,
 				consumerId: "local-screen",
-				local: true,
 				startedAt: mediaState.localScreenShareStartedAt || 0,
 			});
 		}

--- a/frontend/src/apps/meet/composables/useMediaControls.test.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.test.ts
@@ -171,6 +171,8 @@ interface CameraMediaStateOverrides {
 	isCameraOn?: boolean;
 	localStream?: FakeMediaStream;
 	processedStream?: FakeMediaStream | null;
+	screenShareStream?: FakeMediaStream | null;
+	screenShareStreams?: Record<string, FakeMediaStream>;
 }
 
 function createCameraHarness({
@@ -386,17 +388,22 @@ function createCameraHarness({
 		}),
 		stopScreenShare: vi.fn(async (metadata = {}) => {
 			const producer = getProducer("screen");
+			if (!producer) return;
 			setProducer("screen", null);
-			if (producer?.id) {
+			try {
+				if (sfuClient.isConnected()) {
 				await sfuClient.sendScreenShare("stop_share", {
 					...metadata,
 					producerId: producer.id,
 					stoppedAt: Date.now(),
 				});
+				}
+			} catch {
+			} finally {
 				producer.close?.();
-				await sfuClient.closeProducer(producer.id);
+				await sfuClient.closeProducer(producer.id, metadata);
+				mediaHandler.stopScreenShare();
 			}
-			mediaHandler.stopScreenShare();
 		}),
 		pauseLocalProducer: vi.fn((kind: "audio" | "video" | "screen") => {
 			getProducer(kind)?.pause?.();
@@ -429,6 +436,17 @@ function createCameraHarness({
 	});
 
 	const managerRef = ref(manager);
+	const mediaAttachments = {
+		registerRemoteVideoElement: vi.fn(),
+		registerLocalPreview: vi.fn(),
+		attachLocalPreview: vi.fn().mockResolvedValue(undefined),
+		registerScreenSharePreview: vi.fn(),
+		attachScreenSharePreview: vi.fn().mockResolvedValue(undefined),
+		removeScreenSharePreview: vi.fn(),
+		attachBackgroundEffectsSource: vi.fn().mockResolvedValue(undefined),
+		removeBackgroundEffectsSource: vi.fn(),
+		setAudioOutputDevice: vi.fn().mockResolvedValue(undefined),
+	};
 	const controls = useMediaControls({
 		mediaState: state,
 		connectionState: { connectionError: null },
@@ -436,6 +454,7 @@ function createCameraHarness({
 		currentUser: { currentUser: ref(null) },
 		sfuClient,
 		sfuManager: managerRef,
+		mediaAttachments,
 		deviceManager,
 		backgroundEffects: effectsApi,
 		noiseCancellation: noiseCancellationOverride ?? { error: ref(null) },
@@ -451,6 +470,7 @@ function createCameraHarness({
 		mediaHandler,
 		manager,
 		managerRef,
+		mediaAttachments,
 		publishMedia,
 		setLocalMediaTrack,
 		sfuClient,
@@ -470,6 +490,78 @@ describe("useMediaControls", () => {
 		selectedCameraId.value = "";
 		selectedMicId.value = "";
 		setAutoFramingPaused(false);
+	});
+
+	it("delegates local preview attachment and unmount to the media owner", async () => {
+		const camera = videoTrack("camera");
+		const { controls, mediaAttachments, state } = createCameraHarness({
+			mediaState: { localStream: new FakeMediaStream([camera]) },
+		});
+		const element = document.createElement("video");
+
+		controls.setLocalVideoRef(element);
+		await vi.waitFor(() =>
+			expect(mediaAttachments.attachLocalPreview).toHaveBeenCalledWith(
+				state.localStream,
+			),
+		);
+		controls.setLocalVideoRef(null);
+
+		expect(mediaAttachments.registerLocalPreview).toHaveBeenNthCalledWith(
+			1,
+			element,
+		);
+		expect(mediaAttachments.registerLocalPreview).toHaveBeenLastCalledWith(null);
+		expect(camera.stop).not.toHaveBeenCalled();
+	});
+
+	it("delegates remote video replacement and unmount to the media owner", () => {
+		const { controls, mediaAttachments } = createCameraHarness();
+		const first = document.createElement("video");
+		const replacement = document.createElement("video");
+
+		controls.setRemoteVideoRef("p1", first);
+		controls.setRemoteVideoRef("p1", replacement);
+		controls.setRemoteVideoRef("p1", null);
+
+		expect(mediaAttachments.registerRemoteVideoElement.mock.calls).toEqual([
+			["p1", first],
+			["p1", replacement],
+			["p1", null],
+		]);
+	});
+
+	it("registers local and remote screen-share previews with explicit ownership", async () => {
+		const localScreen = new FakeMediaStream([videoTrack("local-screen")]);
+		const remoteScreen = new FakeMediaStream([videoTrack("remote-screen")]);
+		const { controls, mediaAttachments, state } = createCameraHarness({
+			mediaState: {
+				screenShareStream: localScreen,
+				screenShareStreams: { local: localScreen, remote: remoteScreen },
+			},
+		});
+		const localElement = document.createElement("video");
+		localElement.dataset.participantId = "local";
+		const remoteElement = document.createElement("video");
+		remoteElement.dataset.participantId = "remote";
+		state.screenShareStream = localScreen;
+
+		controls.setScreenShareVideoRef("local-screen", localElement);
+		controls.setScreenShareVideoRef("consumer-1", remoteElement);
+		await vi.waitFor(() =>
+			expect(mediaAttachments.attachScreenSharePreview).toHaveBeenCalledTimes(2),
+		);
+
+		expect(mediaAttachments.attachScreenSharePreview).toHaveBeenCalledWith(
+			"local-screen",
+			localScreen,
+			"borrowed",
+		);
+		expect(mediaAttachments.attachScreenSharePreview).toHaveBeenCalledWith(
+			"consumer-1",
+			remoteScreen,
+			"owned",
+		);
 	});
 
 	it("does not signal screen-share start when publication resolves after stop", async () => {
@@ -493,6 +585,70 @@ describe("useMediaControls", () => {
 			expect.anything(),
 		);
 		expect(harness.state.isScreenSharing).toBe(false);
+	});
+
+	it("does not stop a replacement screen share when an old publication rejects", async () => {
+		const firstTrack = videoTrack("first-screen");
+		const secondTrack = videoTrack("second-screen");
+		const firstStream = new FakeMediaStream([firstTrack]);
+		const secondStream = new FakeMediaStream([secondTrack]);
+		const firstPublication = deferred<{
+			id: string;
+			track: MediaStreamTrack;
+			paused: boolean;
+		}>();
+		const secondPublication = deferred<{
+			id: string;
+			track: MediaStreamTrack;
+			paused: boolean;
+		}>();
+		const secondProducer: TestVideoProducer = {
+			id: "second-screen-producer",
+			track: secondTrack,
+			close: vi.fn(),
+		};
+		let harness!: ReturnType<typeof createCameraHarness>;
+		const publishScreenTrack = vi.fn((track: MediaStreamTrack) => {
+			if (track === firstTrack) return firstPublication.promise;
+			harness.mediaHandler.screenProducer = secondProducer as never;
+			return secondPublication.promise;
+		});
+		harness = createCameraHarness({
+			getDisplayMedia: vi
+				.fn()
+				.mockResolvedValueOnce(firstStream)
+				.mockResolvedValueOnce(secondStream),
+			publishScreenTrack,
+		});
+
+		const firstStarting = harness.controls.toggleScreenShare();
+		await vi.waitFor(() =>
+			expect(publishScreenTrack).toHaveBeenCalledWith(firstTrack),
+		);
+		await harness.controls.toggleScreenShare();
+		void harness.controls.toggleScreenShare();
+		await vi.waitFor(() =>
+			expect(publishScreenTrack).toHaveBeenCalledWith(secondTrack),
+		);
+		expect(harness.state.screenShareStream).toBe(secondStream);
+
+		firstPublication.reject(new Error("first publication failed"));
+		await firstStarting;
+
+		expect(harness.state.screenShareStream).toBe(secondStream);
+		expect(harness.state.isScreenSharing).toBe(true);
+		expect(harness.manager.getLocalProducerState("screen")).toEqual({
+			id: secondProducer.id,
+			track: secondTrack,
+			paused: false,
+		});
+		expect(firstTrack.stop).toHaveBeenCalledOnce();
+		expect(secondTrack.stop).not.toHaveBeenCalled();
+		expect(secondProducer.close).not.toHaveBeenCalled();
+		expect(harness.sfuClient.sendScreenShare).not.toHaveBeenCalledWith(
+			"stop_share",
+			expect.anything(),
+		);
 	});
 
 	it("does not signal screen-share start through a replaced manager", async () => {
@@ -1514,25 +1670,50 @@ describe("useMediaControls", () => {
 		const raw = videoTrack("raw");
 		const endedProcessed = videoTrack("ended-processed", "ended");
 		const replaceTrack = vi.fn().mockResolvedValue(undefined);
-		const { controls, setLocalMediaTrack } = createCameraHarness({
-			getUserMedia: vi.fn().mockResolvedValue(new FakeMediaStream([raw])),
-			videoProducer: {
-				id: "camera-producer",
-				track: videoTrack("old"),
-				replaceTrack,
-			},
-			applyBackgroundEffects: vi.fn().mockResolvedValue({
-				stream: new FakeMediaStream([endedProcessed]),
-				cleanup: vi.fn(),
-				updateOptions: vi.fn(),
-			}),
-		});
+		const { controls, mediaAttachments, setLocalMediaTrack, state } =
+			createCameraHarness({
+				getUserMedia: vi.fn().mockResolvedValue(new FakeMediaStream([raw])),
+				videoProducer: {
+					id: "camera-producer",
+					track: videoTrack("old"),
+					replaceTrack,
+				},
+				applyBackgroundEffects: vi.fn().mockResolvedValue({
+					stream: new FakeMediaStream([endedProcessed]),
+					cleanup: vi.fn(),
+					updateOptions: vi.fn(),
+				}),
+			});
 
 		await controls.toggleCamera();
 
 		expect(replaceTrack).toHaveBeenCalledOnce();
 		expect(replaceTrack).toHaveBeenCalledWith({ track: raw });
 		expect(setLocalMediaTrack).toHaveBeenCalledWith("video", raw);
+		expect(mediaAttachments.attachLocalPreview).toHaveBeenLastCalledWith(
+			state.localStream,
+		);
+	});
+
+	it("restores the raw preview after an effects transformation error", async () => {
+		localStorage.setItem("backgroundEffects.blur", "1");
+		const raw = videoTrack("raw");
+		const { controls, mediaAttachments, state } = createCameraHarness({
+			mediaState: {
+				isCameraOn: true,
+				localStream: new FakeMediaStream([raw]),
+			},
+			applyBackgroundEffects: vi
+				.fn()
+				.mockRejectedValue(new Error("transformation failed")),
+		});
+
+		await controls.applyBackgroundEffectsToLocalStream();
+
+		expect(state.processedStream).toBeNull();
+		expect(mediaAttachments.attachLocalPreview).toHaveBeenLastCalledWith(
+			state.localStream,
+		);
 	});
 
 	it("publishes raw video once when effects return the input stream", async () => {
@@ -1805,18 +1986,19 @@ describe("useMediaControls", () => {
 					producer.track = track;
 				}),
 		};
-		const { controls, mediaHandler, state } = createCameraHarness({
-			mediaState: {
-				isCameraOn: true,
-				localStream: new FakeMediaStream([raw]),
-			},
-			videoProducer: producer,
-			applyBackgroundEffects: vi.fn().mockResolvedValue({
-				stream: candidateStream,
-				cleanup,
-				updateOptions: vi.fn(),
-			}),
-		});
+		const { controls, mediaAttachments, mediaHandler, state } =
+			createCameraHarness({
+				mediaState: {
+					isCameraOn: true,
+					localStream: new FakeMediaStream([raw]),
+				},
+				videoProducer: producer,
+				applyBackgroundEffects: vi.fn().mockResolvedValue({
+					stream: candidateStream,
+					cleanup,
+					updateOptions: vi.fn(),
+				}),
+			});
 
 		await controls.applyBackgroundEffectsToLocalStream();
 
@@ -1828,6 +2010,10 @@ describe("useMediaControls", () => {
 		expect(mediaHandler.videoProducer).toBe(producer);
 		expect(producer.track).toBe(raw);
 		expect(mediaHandler.localStream.getVideoTracks()).toEqual([raw]);
+		expect(mediaAttachments.attachLocalPreview.mock.calls).toEqual([
+			[candidateStream],
+			[state.localStream],
+		]);
 		expect(producer.replaceTrack.mock.invocationCallOrder[1]).toBeLessThan(
 			cleanup.mock.invocationCallOrder[0],
 		);

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -15,6 +15,7 @@ import {
 	setSelectedSpeakerId,
 } from "../data/mediaPreferences";
 import type { DeviceType, deviceManager } from "../utils/media/DeviceManager";
+import type { MediaAttachmentFacade } from "../utils/media/VideoElementManager";
 import notificationContextManager from "../utils/notificationContext";
 import { isMobileDevice } from "../utils/device";
 import type { SFUClient } from "../utils/SFUClient";
@@ -120,6 +121,7 @@ interface MediaControlsDeps {
 	currentUser: CurrentUser;
 	sfuClient: SFUClient;
 	sfuManager: Ref<SFUMeetingManager | null>;
+	mediaAttachments: MediaAttachmentFacade;
 	deviceManager: typeof deviceManager;
 	backgroundEffects: BackgroundEffectsAPI;
 	noiseCancellation: NoiseCancellationAPI;
@@ -142,8 +144,14 @@ interface MediaControlsAPI {
 	applyBackgroundEffectsToLocalStream: () => Promise<void>;
 	republishMediaAfterE2EE: (detail?: E2EEMediaRepublishDetail) => Promise<void>;
 	setLocalVideoRef: (el: HTMLVideoElement | null) => void;
-	setRemoteVideoRef: (participantId: string, el: HTMLVideoElement) => void;
-	setScreenShareVideoRef: (el: HTMLVideoElement) => void;
+	setRemoteVideoRef: (
+		participantId: string,
+		el: HTMLVideoElement | null,
+	) => void;
+	setScreenShareVideoRef: (
+		attachmentId: string,
+		el: HTMLVideoElement | null,
+	) => void;
 	processedStream: MediaStream | null;
 }
 
@@ -276,13 +284,13 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		currentUser,
 		sfuClient,
 		sfuManager,
+		mediaAttachments,
 		deviceManager,
 		backgroundEffects,
 		noiseCancellation,
 	} = deps;
 
 	const localVideo = ref<HTMLVideoElement | null>(null);
-	const screenShareVideoElements = new Map<string, HTMLVideoElement>();
 	const _unmutedByPushToTalk = ref(false);
 
 	let backgroundSession: {
@@ -427,6 +435,12 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		);
 	};
 
+	const updateLocalPreview = (stream: MediaStream | null) => {
+		void mediaAttachments.attachLocalPreview(stream).catch((error) =>
+			console.warn("Could not update local preview:", error),
+		);
+	};
+
 	const reconcileCameraTrack = async (
 		track: MediaStreamTrack | null,
 		reason: string,
@@ -511,6 +525,10 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 					mediaState.processedStream = null;
 				}
 			}
+			const hasLiveRawVideo = mediaState.localStream
+				?.getVideoTracks()
+				.some((track) => track.readyState === "live");
+			updateLocalPreview(hasLiveRawVideo ? mediaState.localStream : null);
 		}
 	};
 
@@ -530,6 +548,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			mediaState.localStream?.removeTrack(track);
 			track.stop();
 		}
+		updateLocalPreview(null);
 		mediaState.isCameraOn = false;
 		setCameraEnabled(false);
 		toast.error("Failed to toggle camera");
@@ -653,6 +672,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				} else {
 					backgroundSession = result;
 					mediaState.processedStream = result.stream;
+					updateLocalPreview(result.stream);
 				}
 			}
 		} catch (error) {
@@ -1438,6 +1458,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				mediaState.localStream?.removeTrack(track);
 				stopLifecycleTrack(track);
 			}
+			updateLocalPreview(null);
 			mediaState.isCameraOn = false;
 			setCameraEnabled(false);
 			toast.error(
@@ -1608,9 +1629,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				"speaker",
 			);
 
-			if (validSpeakerId && sfuManager.value) {
-				await sfuManager.value.setAudioOutputDevice(validSpeakerId);
-			}
+			if (validSpeakerId) await mediaAttachments.setAudioOutputDevice(validSpeakerId);
 		} catch (error) {
 			console.warn("Failed to apply speaker device:", error);
 		}
@@ -1936,12 +1955,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 								mediaState.cameraPermissionGranted = true;
 								if (mediaState.localVideo) {
 									assertCurrentCameraOperation(operation);
-									const localVideoEl =
-										mediaState.localVideo as HTMLVideoElement;
-									const videoTracks = stream.getVideoTracks();
-									if (videoTracks.length > 0) {
-										localVideoEl.srcObject = new MediaStream(videoTracks);
-									}
+									setLocalVideoRef(mediaState.localVideo as HTMLVideoElement);
 								}
 							}
 						} catch (err) {
@@ -1976,11 +1990,12 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				assertCurrentCameraOperation(operation);
 				cleanupBackgroundSession();
 				if (stream) {
-					for (const track of stream.getVideoTracks()) {
-						track.stop();
-						stream.removeTrack(track);
-					}
+				for (const track of stream.getVideoTracks()) {
+					track.stop();
+					stream.removeTrack(track);
 				}
+			}
+			updateLocalPreview(null);
 			}
 
 			assertCurrentCameraOperation(operation);
@@ -2032,6 +2047,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 					mediaState.localStream?.removeTrack(track);
 					track.stop();
 				}
+				updateLocalPreview(null);
 				assertCurrentCameraOperation(operation);
 				mediaState.isCameraOn = false;
 				setCameraEnabled(false);
@@ -2072,6 +2088,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		if (mediaState.screenShareStream === screenStream) {
 			mediaState.screenShareStream = null;
 		}
+		mediaAttachments.removeScreenSharePreview("local-screen");
 
 		await manager?.stopScreenShare(metadata);
 	};
@@ -2183,9 +2200,14 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 					}
 				} catch (pubErr) {
 					console.error("Failed to publish screen share producer:", pubErr);
-					await stopScreenShare("publish-failed", {
-						message: (pubErr as Error)?.message,
-					});
+					if (
+						mediaState.isScreenSharing &&
+						mediaState.screenShareStream === screenStream
+					) {
+						await stopScreenShare("publish-failed", {
+							message: (pubErr as Error)?.message,
+						});
+					}
 					throw pubErr;
 				}
 			}
@@ -2201,56 +2223,42 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 
 	function setLocalVideoRef(el: HTMLVideoElement | null) {
 		localVideo.value = el;
-		if (el && mediaState.localStream) {
-			const videoEl = el;
-			const streamToUse = mediaState.processedStream || mediaState.localStream;
-
-			const currentStreamId = streamToUse.id;
-			const trackedStreamId = el.dataset.sourceStreamId;
-
-			if (!videoEl.srcObject || trackedStreamId !== currentStreamId) {
-				const videoTracks = streamToUse.getVideoTracks();
-				if (videoTracks.length > 0) {
-					videoEl.srcObject = new MediaStream(videoTracks);
-					el.dataset.sourceStreamId = currentStreamId;
-				} else {
-					videoEl.srcObject = streamToUse;
-					el.dataset.sourceStreamId = currentStreamId;
-				}
-				videoEl.muted = true;
-			}
-		}
+		mediaAttachments.registerLocalPreview(el);
+		const stream = mediaState.processedStream || mediaState.localStream;
+		void mediaAttachments.attachLocalPreview(stream).catch((error) =>
+			console.warn("Could not play local preview:", error),
+		);
 		mediaState.localVideo = el;
 	}
 
-	const setRemoteVideoRef = (participantId: string, el: HTMLVideoElement) => {
-		sfuManager.value?.registerVideoElement(participantId, el);
+	const setRemoteVideoRef = (
+		participantId: string,
+		el: HTMLVideoElement | null,
+	) => {
+		mediaAttachments.registerRemoteVideoElement(participantId, el);
 	};
 
-	const setScreenShareVideoRef = (el: HTMLVideoElement) => {
+	const setScreenShareVideoRef = (
+		attachmentId: string,
+		el: HTMLVideoElement | null,
+	) => {
+		mediaAttachments.registerScreenSharePreview(attachmentId, el);
 		if (!el) return;
-
 		const participantId = el.dataset.participantId;
-		if (participantId) {
-			screenShareVideoElements.set(participantId, el);
-
-			const store = mediaState.screenShareStreams || {};
-			let stream: MediaStream | null = store[participantId] ?? null;
-			if (!stream && currentUser.currentUser.value?.user_id === participantId) {
-				stream = mediaState.screenShareStream;
-			}
-
-			if (stream instanceof MediaStream) {
-				const currentStreamId = stream.id;
-				const srcObject = el.srcObject;
-				const existingStreamId =
-					srcObject instanceof MediaStream ? srcObject.id : undefined;
-
-				if (!el.srcObject || existingStreamId !== currentStreamId) {
-					el.srcObject = stream;
-					el.play?.().catch(() => {});
-				}
-			}
+		if (!participantId) return;
+		const stream =
+			mediaState.screenShareStreams?.[participantId] ??
+			(currentUser.currentUser.value?.user_id === participantId
+				? mediaState.screenShareStream
+				: null);
+		if (stream) {
+			void mediaAttachments
+				.attachScreenSharePreview(
+					attachmentId,
+					stream,
+					attachmentId === "local-screen" ? "borrowed" : "owned",
+				)
+				.catch((error) => console.warn("Could not play screen share:", error));
 		}
 	};
 
@@ -2317,6 +2325,9 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 	const cleanupLocalMedia = async () => {
 		cameraLifecycleGeneration++;
 		cameraLifecycleAbortController.abort(cameraLifecycleAbort());
+		mediaAttachments.registerLocalPreview(null);
+		void mediaAttachments.attachLocalPreview(null);
+		mediaAttachments.removeScreenSharePreview("local-screen");
 		mediaState.isCameraOn = false;
 		mediaState.isMicOn = false;
 		mediaState.isScreenSharing = false;
@@ -2366,9 +2377,11 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 								stopLifecycleTrack(track);
 							} catch {}
 						}
+						updateLocalPreview(null);
 					} finally {
 						detachedCameraTracks.clear();
 						await backgroundEffects.dispose();
+						updateLocalPreview(null);
 					}
 				}
 			}

--- a/frontend/src/apps/meet/composables/useMediaState.test.ts
+++ b/frontend/src/apps/meet/composables/useMediaState.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+	findActiveScreenShare,
+	replaceActiveScreenShare,
+	type RemoteScreenShare,
+} from "./useMediaState";
+
+const current: RemoteScreenShare = {
+	source: "remote",
+	participantId: "participant-1",
+	consumerId: "consumer-current",
+	producerId: "producer-current",
+	startedAt: 1,
+};
+
+describe("findActiveScreenShare", () => {
+	it("returns the current share when participant and producer identities match", () => {
+		expect(
+			findActiveScreenShare([current], "participant-1", "producer-current"),
+		).toBe(current);
+	});
+
+	it("does not resolve a stale producer stop to the participant's current share", () => {
+		expect(
+			findActiveScreenShare([current], "participant-1", "producer-old"),
+		).toBeNull();
+	});
+
+	it("evicts an old consumer attachment when the producer is resubscribed", () => {
+		const replacement: RemoteScreenShare = {
+			...current,
+			consumerId: "consumer-replacement",
+		};
+
+		expect(replaceActiveScreenShare([current], replacement)).toEqual({
+			shares: [replacement],
+			replaced: [current],
+		});
+	});
+
+	it("does not resolve an old consumer removal to its same-producer replacement", () => {
+		const replacement: RemoteScreenShare = {
+			...current,
+			consumerId: "consumer-replacement",
+		};
+
+		expect(
+			findActiveScreenShare(
+				[replacement],
+				"participant-1",
+				"producer-current",
+				"consumer-current",
+			),
+		).toBeNull();
+	});
+});

--- a/frontend/src/apps/meet/composables/useMediaState.ts
+++ b/frontend/src/apps/meet/composables/useMediaState.ts
@@ -1,11 +1,52 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
 
-export interface ScreenShareConsumer {
+interface ScreenShareBase {
 	participantId: string;
 	consumerId: string;
 	startedAt: number;
-	local?: boolean;
+}
+
+export interface RemoteScreenShare extends ScreenShareBase {
+	source: "remote";
+	producerId: string;
+}
+
+export interface LocalScreenShare extends ScreenShareBase {
+	source: "local";
+}
+
+export type DisplayScreenShare = RemoteScreenShare | LocalScreenShare;
+
+export function findActiveScreenShare(
+	shares: RemoteScreenShare[],
+	participantId: string,
+	producerId: string,
+	consumerId?: string,
+): RemoteScreenShare | null {
+	const current = shares.find((share) => share.participantId === participantId);
+	return current?.producerId === producerId &&
+		(!consumerId || current.consumerId === consumerId)
+		? current
+		: null;
+}
+
+export function replaceActiveScreenShare(
+	shares: RemoteScreenShare[],
+	next: RemoteScreenShare,
+): { shares: RemoteScreenShare[]; replaced: RemoteScreenShare[] } {
+	const replaced = shares.filter(
+		(share) =>
+			share.participantId === next.participantId &&
+			share.consumerId !== next.consumerId,
+	);
+	return {
+		shares: [
+			...shares.filter((share) => share.participantId !== next.participantId),
+			next,
+		],
+		replaced,
+	};
 }
 
 export interface MediaState {
@@ -18,7 +59,7 @@ export interface MediaState {
 	microphonePermissionGranted: boolean;
 	screenShareStream: MediaStream | null;
 	localScreenShareStartedAt: number;
-	activeScreenShareConsumers: ScreenShareConsumer[];
+	activeScreenShareConsumers: RemoteScreenShare[];
 	screenShareStreams: Record<string, MediaStream>;
 	localVideo: HTMLElement | null;
 	setMedia: (mic: boolean, camera: boolean) => void;
@@ -35,7 +76,7 @@ export const useMediaState = defineStore("meet-media", () => {
 	const microphonePermissionGranted = ref(false);
 	const screenShareStream = ref<MediaStream | null>(null);
 	const localScreenShareStartedAt = ref(0);
-	const activeScreenShareConsumers = ref<ScreenShareConsumer[]>([]);
+	const activeScreenShareConsumers = ref<RemoteScreenShare[]>([]);
 	const screenShareStreams = ref<Record<string, MediaStream>>({});
 	const localVideo = ref<HTMLElement | null>(null);
 

--- a/frontend/src/apps/meet/composables/useParticipantStore.ts
+++ b/frontend/src/apps/meet/composables/useParticipantStore.ts
@@ -36,14 +36,6 @@ export const useParticipantStore = defineStore("meet-participant", () => {
 
 	function removeParticipant(participantId: string) {
 		delete participants.value[participantId];
-		const videoEl = remoteVideos.value[participantId];
-		const srcObj = (videoEl as HTMLVideoElement)?.srcObject;
-		if (srcObj instanceof MediaStream) {
-			for (const track of srcObj.getTracks()) {
-				track.stop();
-			}
-			(videoEl as HTMLVideoElement).srcObject = null;
-		}
 		delete remoteVideos.value[participantId];
 	}
 

--- a/frontend/src/apps/meet/composables/useSFUConnection.ts
+++ b/frontend/src/apps/meet/composables/useSFUConnection.ts
@@ -14,6 +14,10 @@ import { getErrorMessage } from "../utils/error";
 import { waitForE2EEContextReady } from "../utils/media/E2EEContextReady";
 import { SocketIOSignalChannel } from "../utils/media/SignalChannel";
 import {
+	type AttachmentTrackOwnership,
+	VideoElementManager,
+} from "../utils/media/VideoElementManager";
+import {
 	type ConnectionDetails,
 	connectionDetailsFromJoinPayload,
 	SFUClient,
@@ -127,7 +131,8 @@ function getParticipantConnectionConflictId(error: unknown): string | null {
 
 export interface SFUScreenShareData {
 	participantId?: string;
-	consumer?: { id: string };
+	producerId?: string;
+	consumer?: { id: string; producerId?: string };
 	startedAt?: number;
 	stream?: MediaStream;
 }
@@ -148,6 +153,29 @@ interface SFUConnectionAPI {
 	isConnecting: Ref<boolean>;
 	isSetupComplete: Ref<boolean>;
 	recoveryTimeline: Ref<RecoveryTimelineEntry[]>;
+	registerRemoteVideoElement: (
+		participantId: string,
+		element: HTMLVideoElement | null,
+	) => void;
+	registerLocalPreview: (element: HTMLVideoElement | null) => void;
+	attachLocalPreview: (stream: MediaStream | null) => Promise<void>;
+	registerScreenSharePreview: (
+		attachmentId: string,
+		element: HTMLVideoElement | null,
+	) => void;
+	attachScreenSharePreview: (
+		attachmentId: string,
+		stream: MediaStream,
+		trackOwnership?: AttachmentTrackOwnership,
+	) => Promise<void>;
+	removeScreenSharePreview: (attachmentId: string) => void;
+	attachBackgroundEffectsSource: (
+		attachmentId: string,
+		element: HTMLVideoElement,
+		stream: MediaStream,
+	) => Promise<void>;
+	removeBackgroundEffectsSource: (attachmentId: string) => void;
+	setAudioOutputDevice: (deviceId: string) => Promise<void>;
 }
 
 export function useSFUConnection(deps: {
@@ -197,6 +225,7 @@ export function useSFUConnection(deps: {
 
 	const signalChannel = new SocketIOSignalChannel();
 	const sfuClient = new SFUClient(signalChannel);
+	const videoManager = new VideoElementManager();
 	const clientTelemetry = getClientTelemetry(sfuClient);
 	const sfuManager = shallowRef<SFUMeetingManager | null>(null);
 
@@ -474,7 +503,7 @@ export function useSFUConnection(deps: {
 		try {
 			let wasAutomaticallyMuted = false;
 			const wantsAudio = mediaState.isMicOn;
-			manager = new SFUMeetingManager(sfuClient);
+			manager = new SFUMeetingManager(sfuClient, videoManager);
 			manager.initialize({
 				meetingId,
 				currentUser: currentUser.currentUser.value,
@@ -1080,10 +1109,12 @@ export function useSFUConnection(deps: {
 		unsubscribeGuestRealtime();
 		removeFrappeRealtimeEventListeners();
 
-		if (sfuManager.value) {
-			await sfuManager.value.cleanup();
+		try {
+			if (sfuManager.value) await sfuManager.value.cleanup();
+			sfuManager.value = null;
+		} finally {
+			videoManager.cleanup();
 		}
-		sfuManager.value = null;
 
 		realtimeListenersSetup.value = false;
 	});
@@ -1100,6 +1131,27 @@ export function useSFUConnection(deps: {
 		recoveryTimeline: computed(
 			() => participantConnectionState.recoveryTimeline,
 		),
+		registerRemoteVideoElement: (participantId, element) =>
+			videoManager.registerRemoteVideoElement(participantId, element),
+		registerLocalPreview: (element) =>
+			videoManager.registerLocalPreview(element),
+		attachLocalPreview: (stream) => videoManager.attachLocalPreview(stream),
+		registerScreenSharePreview: (attachmentId, element) =>
+			videoManager.registerScreenSharePreview(attachmentId, element),
+		attachScreenSharePreview: (attachmentId, stream, trackOwnership) =>
+			videoManager.attachScreenSharePreview(
+				attachmentId,
+				stream,
+				trackOwnership,
+			),
+		removeScreenSharePreview: (attachmentId) =>
+			videoManager.removeScreenSharePreview(attachmentId),
+		attachBackgroundEffectsSource: (attachmentId, element, stream) =>
+			videoManager.attachBackgroundEffectsSource(attachmentId, element, stream),
+		removeBackgroundEffectsSource: (attachmentId) =>
+			videoManager.removeBackgroundEffectsSource(attachmentId),
+		setAudioOutputDevice: (deviceId) =>
+			videoManager.setAudioOutputDevice(deviceId),
 		joinMeetingRoom,
 		handleGuestJoinResult,
 		setupFrappeRealtimeEventListeners,

--- a/frontend/src/apps/meet/composables/useScreenShareTiles.ts
+++ b/frontend/src/apps/meet/composables/useScreenShareTiles.ts
@@ -5,6 +5,7 @@ import type { GridLayout, PinnedTile } from "./useGridLayout";
 interface ScreenShare {
 	consumerId: string;
 	participantId: string;
+	source: "local" | "remote";
 }
 
 interface CurrentUser {
@@ -81,7 +82,7 @@ export function useScreenShareTiles({
 	const screenShareTiles = computed<ScreenShareTile[]>(() => {
 		return displayScreenShares.value.map((share) => {
 			const participantName = getParticipantName(share.participantId);
-			const isLocalSharer = currentUser.value?.user_id === share.participantId;
+			const isLocalSharer = share.source === "local";
 			const localName = currentUser.value?.full_name || currentUser.value?.name;
 			const displayName = `${
 				isLocalSharer ? localName : participantName

--- a/frontend/src/apps/meet/pages/Meeting.vue
+++ b/frontend/src/apps/meet/pages/Meeting.vue
@@ -310,7 +310,11 @@ import { useGridLayout } from "../composables/useGridLayout";
 import { useLobby } from "../composables/useLobby";
 import { useLobbyStore } from "../composables/useLobbyStore";
 import { useMediaControls } from "../composables/useMediaControls";
-import { useMediaState } from "../composables/useMediaState";
+import {
+	findActiveScreenShare,
+	replaceActiveScreenShare,
+	useMediaState,
+} from "../composables/useMediaState";
 import { provideMeetingContext } from "../composables/useMeetingContext";
 import { useMeetingDoc } from "../composables/useMeetingDoc";
 import {
@@ -450,10 +454,6 @@ watch(
 	},
 );
 
-// --- Background effects & noise cancellation ---
-const backgroundEffects = useBackgroundEffects({ autoCleanupOnUnmount: false });
-const noiseCancellation = useNoiseCancellation();
-
 // --- Lobby notification conversion ---
 const lobbyUsersForNotifications = computed(() => {
 	return lobbyStore.lobbyUsers
@@ -539,22 +539,36 @@ const sfuConnection = useSFUConnection({
 	onParticipantConnectionReplaced: () => mediaControls.cleanupLocalMedia(),
 	onScreenShareStarted: (data: SFUScreenShareData) => {
 		const pid = data.participantId;
-		if (!pid) return;
-		const prev = mediaState.activeScreenShareConsumers || [];
-		const filtered = prev.filter((s) => s.participantId !== pid);
-		mediaState.activeScreenShareConsumers = [
-			...filtered,
+		const producerId = data.producerId ?? data.consumer?.producerId;
+		if (!pid || !producerId) return;
+		const replacement = replaceActiveScreenShare(
+			mediaState.activeScreenShareConsumers || [],
 			{
+				source: "remote",
 				participantId: pid,
 				consumerId: data.consumer?.id || "remote-screen",
+				producerId,
 				startedAt: data.startedAt || Date.now(),
 			},
-		];
+		);
+		for (const share of replacement.replaced) {
+			sfuConnection.removeScreenSharePreview(share.consumerId);
+		}
+		mediaState.activeScreenShareConsumers = replacement.shares;
 		if (data.stream instanceof MediaStream) {
 			try {
 				const store = mediaState.screenShareStreams || {};
 				store[pid] = data.stream;
 				mediaState.screenShareStreams = store;
+				void sfuConnection
+					.attachScreenSharePreview(
+						data.consumer?.id || "remote-screen",
+						data.stream,
+						"owned",
+					)
+					.catch((error) =>
+						console.warn("Failed to attach screen share preview:", error),
+					);
 			} catch (err) {
 				console.warn("Failed to store screen share stream:", err);
 			}
@@ -562,19 +576,22 @@ const sfuConnection = useSFUConnection({
 	},
 	onScreenShareStopped: (data: SFUScreenShareData) => {
 		const pid = data.participantId;
+		const producerId = data.producerId ?? data.consumer?.producerId;
+		if (!pid || !producerId) return;
 		const list = mediaState.activeScreenShareConsumers || [];
+		const current = findActiveScreenShare(
+			list,
+			pid,
+			producerId,
+			data.consumerId ?? data.consumer?.id,
+		);
+		if (!current) return;
+		sfuConnection.removeScreenSharePreview(current.consumerId);
 		mediaState.activeScreenShareConsumers = list.filter(
-			(share) => share.participantId !== pid,
+			(share) => share.producerId !== producerId,
 		);
 		const store = mediaState.screenShareStreams || {};
 		if (pid && store[pid]) {
-			const stream = store[pid];
-			const tracks = stream.getTracks();
-			if (tracks) {
-				for (const t of tracks) {
-					t.stop();
-				}
-			}
 			delete store[pid];
 			mediaState.screenShareStreams = store;
 		}
@@ -586,6 +603,13 @@ const sfuConnection = useSFUConnection({
 	onRecordingEnabled: recording.setGlobalEnabled,
 	onCohostPromoted: () => meetingDoc.reload(),
 });
+
+// --- Background effects & noise cancellation ---
+const backgroundEffects = useBackgroundEffects({
+	autoCleanupOnUnmount: false,
+	mediaAttachments: sfuConnection,
+});
+const noiseCancellation = useNoiseCancellation();
 const { networkQuality, downlinkQuality, isTransportFailed } = useNetworkQuality(
 	sfuConnection.sfuManager,
 );
@@ -614,6 +638,7 @@ const mediaControls = useMediaControls({
 	currentUser,
 	sfuClient: sfuConnection.sfuClient,
 	sfuManager: sfuConnection.sfuManager,
+	mediaAttachments: sfuConnection,
 	deviceManager,
 	backgroundEffects,
 	noiseCancellation,
@@ -716,7 +741,7 @@ provide("setRemoteVideoRef", mediaControls.setRemoteVideoRef);
 provide(
 	"setScreenShareVideoRef",
 	(_consumerId: string, element: HTMLVideoElement | null) => {
-		if (element) mediaControls.setScreenShareVideoRef(element);
+		mediaControls.setScreenShareVideoRef(_consumerId, element);
 	},
 );
 provide("getParticipantName", participantStore.getParticipantName);
@@ -1004,21 +1029,6 @@ const syncFullscreenState = () => {
 	isFullscreen.value = !!document.fullscreenElement;
 };
 
-const setSinkIdOnVideoElements = async (sinkId: string) => {
-	const videoElements = document.querySelectorAll("video");
-	const promises = [];
-	for (const videoEl of videoElements) {
-		promises.push(
-			(videoEl as HTMLVideoElement).setSinkId(sinkId).catch(() => {}),
-		);
-	}
-
-	const manager = sfuConnection.sfuManager.value;
-	if (manager) promises.push(manager.setAudioOutputDevice(sinkId));
-
-	await Promise.all(promises);
-};
-
 const handleE2EENeedsMediaRepublish = async (event: Event) => {
 	const detail = (event as CustomEvent).detail as
 		| { needsCamera?: boolean; needsMicrophone?: boolean }
@@ -1133,63 +1143,12 @@ onUnmounted(() => {
 	document.removeEventListener("meet:e2ee-join-status", handleE2EEJoinStatus);
 });
 
-// Watch for localVideo element and localStream connection
-watch(
-	[
-		() => mediaState.localVideo,
-		() => mediaState.localStream,
-		() => mediaState.processedStream,
-	],
-	async ([videoElement, stream, _processedStream]) => {
-		if (videoElement && stream) {
-			try {
-				// Prefer processed stream (with background effects) over raw local stream
-				const streamToUse = mediaState.processedStream || stream;
-				const currentStreamId = streamToUse.id;
-				const trackedStreamId = (videoElement as HTMLElement).dataset
-					?.sourceStreamId;
-
-				if (trackedStreamId !== currentStreamId) {
-					const videoTracks = streamToUse.getVideoTracks();
-					if (videoTracks.length > 0) {
-						(videoElement as HTMLVideoElement).srcObject = new MediaStream(
-							videoTracks,
-						);
-					} else {
-						(videoElement as HTMLVideoElement).srcObject = streamToUse;
-					}
-					(videoElement as HTMLElement).dataset.sourceStreamId =
-						currentStreamId;
-					(videoElement as HTMLVideoElement).muted = true;
-					await (videoElement as HTMLVideoElement).play();
-				}
-
-				if (
-					selectedSpeakerId.value &&
-					typeof (videoElement as HTMLVideoElement).setSinkId === "function"
-				) {
-					try {
-						await (videoElement as HTMLVideoElement).setSinkId(
-							selectedSpeakerId.value,
-						);
-					} catch (error) {
-						console.warn("Could not set speaker for local video:", error);
-					}
-				}
-			} catch (error) {
-				console.warn("Could not play local video:", error);
-			}
-		}
-	},
-	{ immediate: true },
-);
-
 watch(selectedSpeakerId, async (newSpeakerId) => {
 	if (
 		newSpeakerId &&
 		deviceManager.isDeviceAvailable(newSpeakerId, "speaker")
 	) {
-		await setSinkIdOnVideoElements(newSpeakerId);
+		await mediaControls.applySpeakerDevice();
 	}
 });
 

--- a/frontend/src/apps/meet/utils/SFUClient.ts
+++ b/frontend/src/apps/meet/utils/SFUClient.ts
@@ -1056,7 +1056,10 @@ export class SFUClient {
 	sendScreenShare(
 		action: "start_share" | "stop_share",
 		shareData: ScreenShareSignalData = {},
-	): void {
+	): Promise<unknown> | void {
+		if (action === "stop_share") {
+			return this.sendRequest("screen_share", { action, shareData });
+		}
 		this.sendEvent("screen_share", { action, shareData });
 	}
 

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -12,7 +12,11 @@ import { ConsumerManager } from "./media/ConsumerManager";
 import type { ConsumerEntry } from "./media/ConsumerManager";
 import { ParticipantManager } from "./media/ParticipantManager";
 import { TransportManager } from "./media/TransportManager";
-import { VideoElementManager } from "./media/VideoElementManager";
+import {
+	type AttachmentTrackOwnership,
+	type MediaAttachmentFacade,
+	VideoElementManager,
+} from "./media/VideoElementManager";
 import type { ProducerCloseMetadata, SFUClient } from "./SFUClient";
 import type { User } from "../composables/useCurrentUser";
 import type { JoinRoomMediaState, JoinUserData } from "../types";
@@ -203,9 +207,10 @@ function snapshotRTCStatsReports(stats: unknown): readonly RTCStatsReport[] {
 	);
 }
 
-export class SFUMeetingManager {
+export class SFUMeetingManager implements MediaAttachmentFacade {
 	private readonly sfuClient: SFUClient;
 	private readonly videoManager: VideoElementManager;
+	private readonly ownsVideoManager: boolean;
 	private readonly participantManager: ParticipantManager;
 	private readonly consumerManager: ConsumerManager;
 	private readonly transportManager: TransportManager;
@@ -218,10 +223,14 @@ export class SFUMeetingManager {
 	private screenPublicationGeneration = 0;
 	private screenPublicationTrack: MediaStreamTrack | null = null;
 
-	constructor(sfuClient: SFUClient) {
+	constructor(
+		sfuClient: SFUClient,
+		videoManager?: VideoElementManager,
+	) {
 		this.sfuClient = sfuClient;
 
-		this.videoManager = new VideoElementManager();
+		this.videoManager = videoManager ?? new VideoElementManager();
+		this.ownsVideoManager = !videoManager;
 		this.participantManager = new ParticipantManager();
 		this.consumerManager = new ConsumerManager();
 		this.transportManager = new TransportManager();
@@ -479,8 +488,7 @@ export class SFUMeetingManager {
 			mediaHandler.cleanup();
 			this.mediaManager.setLocalTrack("video", videoTrack);
 			this.mediaManager.setLocalTrack("audio", audioTrack);
-			this.consumerManager.clear();
-			this.mediaManager.processedConsumers.clear();
+			this.connectionManager.clearReceiveConsumers();
 			this.connectionManager.clearBufferedReconciliationEvents();
 			this.transportManager.cleanup();
 
@@ -954,18 +962,62 @@ export class SFUMeetingManager {
 		return this.mediaManager.mediaHandler;
 	}
 
-	registerVideoElement(participantId: string, element: HTMLElement): void {
-		this.videoManager.registerVideoElement(participantId, element);
+	registerRemoteVideoElement(
+		participantId: string,
+		element: HTMLVideoElement | null,
+	): void {
+		this.videoManager.registerRemoteVideoElement(participantId, element);
+	}
+
+	registerLocalPreview(element: HTMLVideoElement | null): void {
+		this.videoManager.registerLocalPreview(element);
+	}
+
+	attachLocalPreview(stream: MediaStream | null): Promise<void> {
+		return this.videoManager.attachLocalPreview(stream);
+	}
+
+	registerScreenSharePreview(
+		attachmentId: string,
+		element: HTMLVideoElement | null,
+	): void {
+		this.videoManager.registerScreenSharePreview(attachmentId, element);
+	}
+
+	attachScreenSharePreview(
+		attachmentId: string,
+		stream: MediaStream,
+		trackOwnership: AttachmentTrackOwnership = "borrowed",
+	): Promise<void> {
+		return this.videoManager.attachScreenSharePreview(
+			attachmentId,
+			stream,
+			trackOwnership,
+		);
+	}
+
+	removeScreenSharePreview(attachmentId: string): void {
+		this.videoManager.removeScreenSharePreview(attachmentId);
+	}
+
+	attachBackgroundEffectsSource(
+		attachmentId: string,
+		element: HTMLVideoElement,
+		stream: MediaStream,
+	): Promise<void> {
+		return this.videoManager.attachBackgroundEffectsSource(
+			attachmentId,
+			element,
+			stream,
+		);
+	}
+
+	removeBackgroundEffectsSource(attachmentId: string): void {
+		this.videoManager.removeBackgroundEffectsSource(attachmentId);
 	}
 
 	async setAudioOutputDevice(deviceId: string): Promise<void> {
-		for (const audioElement of this.videoManager.audioElements.values()) {
-			try {
-				await audioElement.setSinkId(deviceId);
-			} catch (error) {
-				console.warn("Failed to set speaker for participant:", error);
-			}
-		}
+		await this.videoManager.setAudioOutputDevice(deviceId);
 	}
 
 	onRemoteConsumerReady(listener: (event: Event) => void): () => void {
@@ -1159,7 +1211,8 @@ export class SFUMeetingManager {
 		this.mediaHealthMonitor.stop();
 		await this.disconnect();
 
-		this.videoManager.cleanup();
+		if (this.ownsVideoManager) this.videoManager.cleanup();
+		else this.videoManager.cleanupRemoteMedia();
 		this.participantManager.clear();
 
 		this.connectionManager.reset();

--- a/frontend/src/apps/meet/utils/__tests__/SFUClient.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUClient.test.ts
@@ -352,6 +352,24 @@ describe("sendChatPin", () => {
 	});
 });
 
+describe("sendScreenShare", () => {
+	it("sends stop_share as an acknowledged request", async () => {
+		const client = createClient();
+		const sendRequest = vi
+			.spyOn(client, "sendRequest")
+			.mockResolvedValue({ success: true });
+
+		await client.sendScreenShare("stop_share", {
+			producerId: "screen-producer",
+		});
+
+		expect(sendRequest).toHaveBeenCalledWith("screen_share", {
+			action: "stop_share",
+			shareData: { producerId: "screen-producer" },
+		});
+	});
+});
+
 describe("sendReaction", () => {
 	it("throws when not connected", () => {
 		const client = createClient();

--- a/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
@@ -393,7 +393,10 @@ describe("SFUMeetingManager facade operations", () => {
 			source: "screen-share",
 		});
 		await vi.waitFor(() => expect(sendScreenShare).toHaveBeenCalledOnce());
+		const nextMutation = vi.fn();
+		await manager.serializeSendMediaMutation(async () => nextMutation());
 
+		expect(nextMutation).toHaveBeenCalledOnce();
 		expect(producer.close).not.toHaveBeenCalled();
 		expect(closeProducer).not.toHaveBeenCalled();
 		stopSignal.resolve({ success: true });

--- a/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
@@ -360,10 +360,11 @@ describe("SFUMeetingManager facade operations", () => {
 			expect(manager.transportManager.createProducer).toHaveBeenCalledOnce(),
 		);
 		expect(manager.hasLocalMediaPublications()).toBe(true);
-		manager.closeLocalProducer("screen");
+		const stopping = manager.stopScreenShare();
 		creation.resolve(staleProducer);
 
 		await expect(publication).resolves.toBeNull();
+		await stopping;
 		expect(staleProducer.close).toHaveBeenCalledOnce();
 		expect(closeProducer).toHaveBeenCalledWith("stale-screen-producer", {});
 		expect(manager.getLocalProducerState("screen")).toBeNull();
@@ -410,6 +411,34 @@ describe("SFUMeetingManager facade operations", () => {
 		expect(sendScreenShare.mock.invocationCallOrder[0]).toBeLessThan(
 			closeProducer.mock.invocationCallOrder[0],
 		);
+		expect(manager.getLocalProducerState("screen")).toBeNull();
+	});
+
+	it("closes the screen producer when stop signaling rejects", async () => {
+		const stopSignal = deferred<unknown>();
+		const closeProducer = vi.fn().mockResolvedValue(undefined);
+		const manager = createManager({
+			isConnected: vi.fn(() => true),
+			sendScreenShare: vi.fn(() => stopSignal.promise),
+			closeProducer,
+		} as never);
+		const producer = {
+			id: "screen-producer",
+			track: mediaTrack("screen", "video"),
+			closed: false,
+			paused: false,
+			close: vi.fn(),
+		};
+		manager.mediaHandler.setProducers({ screenProducer: producer as never });
+
+		const stopping = manager.stopScreenShare({ reason: "track-ended" });
+		stopSignal.reject(new Error("stop rejected"));
+
+		await expect(stopping).resolves.toBeUndefined();
+		expect(producer.close).toHaveBeenCalledOnce();
+		expect(closeProducer).toHaveBeenCalledWith("screen-producer", {
+			reason: "track-ended",
+		});
 		expect(manager.getLocalProducerState("screen")).toBeNull();
 	});
 
@@ -816,6 +845,30 @@ describe("SFUMeetingManager E2EE recovery tracks", () => {
 		expect(manager.mediaHandler.videoProducer).toBe(producers.get(video));
 		expect(manager.mediaHandler.audioProducer).toBe(producers.get(audio));
 		expect(manager.mediaHandler.screenProducer).toBe(producers.get(screen));
+	});
+
+	it("removes screen consumers before the E2EE receive clear", async () => {
+		const manager = prepareE2EEManager();
+		const screen = {
+			id: "screen-consumer",
+			participantId: "alice",
+			producerId: "screen-producer",
+			isScreen: true,
+		};
+		vi.spyOn(
+			manager.consumerManager,
+			"getScreenShareConsumers",
+		).mockReturnValue([screen] as never);
+		const remove = vi
+			.spyOn(manager.consumerManager, "removeConsumer")
+			.mockReturnValue(screen as never);
+
+		await manager.reconfigureForE2EE(null, null);
+
+		expect(remove).toHaveBeenCalledWith("screen-consumer");
+		expect(remove.mock.invocationCallOrder[0]).toBeLessThan(
+			vi.mocked(manager.consumerManager.clear).mock.invocationCallOrder[0],
+		);
 	});
 
 	it("does not recreate an ended screen track during E2EE transition", async () => {

--- a/frontend/src/apps/meet/utils/media/VideoElementManager.ts
+++ b/frontend/src/apps/meet/utils/media/VideoElementManager.ts
@@ -1,9 +1,39 @@
-/**
- * Video Element Manager
- *
- * Manages video and audio elements for participants.
- */
+/** Owns MediaStream attachment and playback recovery for Meet media elements. */
 import { selectedSpeakerId } from "../../data/mediaPreferences";
+
+export type MediaAttachmentRole =
+	| "remote-video"
+	| "remote-audio"
+	| "local-preview"
+	| "screen-share"
+	| "background-effects";
+export type AttachmentTrackOwnership = "owned" | "borrowed";
+
+export interface MediaAttachmentFacade {
+	registerRemoteVideoElement: (
+		participantId: string,
+		element: HTMLVideoElement | null,
+	) => void;
+	registerLocalPreview: (element: HTMLVideoElement | null) => void;
+	attachLocalPreview: (stream: MediaStream | null) => Promise<void>;
+	registerScreenSharePreview: (
+		attachmentId: string,
+		element: HTMLVideoElement | null,
+	) => void;
+	attachScreenSharePreview: (
+		attachmentId: string,
+		stream: MediaStream,
+		trackOwnership?: AttachmentTrackOwnership,
+	) => Promise<void>;
+	removeScreenSharePreview: (attachmentId: string) => void;
+	attachBackgroundEffectsSource: (
+		attachmentId: string,
+		element: HTMLVideoElement,
+		stream: MediaStream,
+	) => Promise<void>;
+	removeBackgroundEffectsSource: (attachmentId: string) => void;
+	setAudioOutputDevice: (deviceId: string) => Promise<void>;
+}
 
 interface DeferredAttachment {
 	stream: MediaStream;
@@ -13,72 +43,116 @@ interface DeferredAttachment {
 	timer?: ReturnType<typeof setTimeout>;
 }
 
+interface Attachment {
+	role: MediaAttachmentRole;
+	id: string;
+	element: HTMLMediaElement | null;
+	stream: MediaStream | null;
+	ownsTracks: boolean;
+	createdElement: boolean;
+	lastAttachAt?: number;
+	attachedStreamId?: string;
+	attachedTrackIds?: string;
+	revision: number;
+}
+
 const STALE_REATTACH_MS = 60_000;
+const LOCAL_PREVIEW_ID = "local";
 
-export class VideoElementManager {
-	videoElements: Map<string, HTMLVideoElement>;
-	audioElements: Map<string, HTMLAudioElement>;
-	deferredAttachments: Map<string, DeferredAttachment>;
-	private lastVideoAttachAt: Map<string, number>;
-	private lastAudioAttachAt: Map<string, number>;
-	private playbackHandlers: Map<HTMLMediaElement, () => void>;
+const attachmentKey = (role: MediaAttachmentRole, id: string) => `${role}:${id}`;
 
-	constructor(private strictAttachmentTimeoutMs?: number) {
-		this.videoElements = new Map();
-		this.audioElements = new Map();
-		this.deferredAttachments = new Map();
-		this.lastVideoAttachAt = new Map();
-		this.lastAudioAttachAt = new Map();
-		this.playbackHandlers = new Map();
+export class VideoElementManager implements MediaAttachmentFacade {
+	/** Kept public for recorder compatibility and diagnostics. */
+	videoElements = new Map<string, HTMLVideoElement>();
+	/** Kept public for existing diagnostics. Sink routing belongs to this manager. */
+	audioElements = new Map<string, HTMLAudioElement>();
+	deferredAttachments = new Map<string, DeferredAttachment>();
+
+	private attachments = new Map<string, Attachment>();
+	private playbackHandlers = new Map<HTMLMediaElement, () => void>();
+	private speakerId = selectedSpeakerId.value;
+
+	constructor(private strictAttachmentTimeoutMs?: number) {}
+
+	registerRemoteVideoElement(
+		participantId: string,
+		element: HTMLVideoElement | null,
+	): void {
+		if (!participantId) return;
+		const deferred = this.deferredAttachments.get(participantId);
+		this.registerElement(
+			"remote-video",
+			participantId,
+			element,
+			true,
+			false,
+			!deferred,
+		);
+		if (element) this.videoElements.set(participantId, element);
+		else this.videoElements.delete(participantId);
+
+		if (!element || !deferred) return;
+		this.deferredAttachments.delete(participantId);
+		if (deferred.timer) clearTimeout(deferred.timer);
+		void this.attachStream(participantId, deferred.stream, deferred.isLocal).then(
+			deferred.resolve,
+			deferred.reject,
+		);
 	}
 
+	/** Legacy remote-video facade used by the recorder and existing tile callers. */
 	registerVideoElement(participantId: string, element: HTMLElement): void {
-		if (!element || !participantId) return;
+		this.registerRemoteVideoElement(participantId, element as HTMLVideoElement);
+	}
 
-		const videoEl = element as HTMLVideoElement;
-		const previousElement = this.videoElements.get(participantId);
-		const previousVideoStream =
-			previousElement?.srcObject as MediaStream | null;
+	registerLocalPreview(element: HTMLVideoElement | null): void {
+		this.registerElement("local-preview", LOCAL_PREVIEW_ID, element, false);
+	}
 
-		// Only update srcObject if element doesn't have one, or if we're re-registering with a different track
-		if (previousVideoStream && !videoEl.srcObject) {
-			console.log("Preserving stream during video element re-registration", {
-				participantId,
-				streamId: previousVideoStream.id,
-				trackCount: previousVideoStream.getTracks().length,
-			});
-
-			const videoTracks = previousVideoStream.getVideoTracks();
-			if (videoTracks.length > 0) {
-				const previousVideoTrack = videoTracks[0];
-				const existingVideoTrack = (
-					videoEl.srcObject as MediaStream
-				)?.getVideoTracks?.()?.[0];
-				const videoTrackChanged =
-					!existingVideoTrack ||
-					existingVideoTrack.id !== previousVideoTrack.id;
-
-				if (!videoEl.srcObject || videoTrackChanged) {
-					videoEl.srcObject = new MediaStream(videoTracks);
-				}
-			}
-			// we have a separate audio element for audio playback
-			videoEl.muted = true;
+	attachLocalPreview(stream: MediaStream | null): Promise<void> {
+		if (!stream) {
+			this.clearAttachmentStream("local-preview", LOCAL_PREVIEW_ID, false);
+			return Promise.resolve();
 		}
+		return this.attach("local-preview", LOCAL_PREVIEW_ID, stream, false);
+	}
 
-		this.videoElements.set(participantId, videoEl);
+	registerScreenSharePreview(
+		attachmentId: string,
+		element: HTMLVideoElement | null,
+	): void {
+		if (!attachmentId) return;
+		this.registerElement("screen-share", attachmentId, element, false);
+	}
 
-		if (this.deferredAttachments.has(participantId)) {
-			const deferred = this.deferredAttachments.get(
-				participantId,
-			) as DeferredAttachment;
-			this.deferredAttachments.delete(participantId);
-			if (deferred.timer) clearTimeout(deferred.timer);
-			void this.attachStream(participantId, deferred.stream, deferred.isLocal).then(
-				deferred.resolve,
-				deferred.reject,
-			);
-		}
+	attachScreenSharePreview(
+		attachmentId: string,
+		stream: MediaStream,
+		trackOwnership: AttachmentTrackOwnership = "borrowed",
+	): Promise<void> {
+		return this.attach(
+			"screen-share",
+			attachmentId,
+			stream,
+			trackOwnership === "owned",
+		);
+	}
+
+	removeScreenSharePreview(attachmentId: string): void {
+		this.removeAttachment("screen-share", attachmentId);
+	}
+
+	attachBackgroundEffectsSource(
+		attachmentId: string,
+		element: HTMLVideoElement,
+		stream: MediaStream,
+	): Promise<void> {
+		this.registerElement("background-effects", attachmentId, element, false);
+		return this.attach("background-effects", attachmentId, stream, false);
+	}
+
+	removeBackgroundEffectsSource(attachmentId: string): void {
+		this.removeAttachment("background-effects", attachmentId);
 	}
 
 	async attachStream(
@@ -86,188 +160,106 @@ export class VideoElementManager {
 		stream: MediaStream,
 		isLocal = false,
 	): Promise<void> {
-		const videoElement = this.videoElements.get(participantId);
+		if (isLocal) return this.attachLocalPreview(stream);
+
 		const audioTracks = stream.getAudioTracks();
+		if (audioTracks.length) await this.attachAudioStream(participantId, audioTracks);
 
-		// Always attach audio for remote participants, even if no video element exists
-		if (!isLocal && audioTracks.length > 0) {
-			await this.attachAudioStream(participantId, audioTracks);
-		}
-
-		// Only defer if we have video tracks and no video element
-		// Audio-only streams don't need video elements, so don't defer them
-		if (!videoElement && !isLocal && stream.getVideoTracks().length > 0) {
+		if (!stream.getVideoTracks().length) return;
+		const video = this.getAttachment("remote-video", participantId)?.element;
+		if (!video) {
+			this.rememberStream("remote-video", participantId, stream, true);
 			if (!this.strictAttachmentTimeoutMs) {
 				this.deferredAttachments.set(participantId, { stream, isLocal });
 				return;
 			}
+			this.cancelDeferredAttachment(participantId);
 			return new Promise<void>((resolve, reject) => {
 				const timer = setTimeout(() => {
-					this.deferredAttachments.delete(participantId);
+					if (this.deferredAttachments.get(participantId)?.timer === timer) {
+						this.deferredAttachments.delete(participantId);
+					}
 					reject(new Error(`Timed out waiting for video element for ${participantId}`));
 				}, this.strictAttachmentTimeoutMs);
-				this.deferredAttachments.set(participantId, { stream, isLocal, resolve, reject, timer });
+				this.deferredAttachments.set(participantId, {
+					stream,
+					isLocal,
+					resolve,
+					reject,
+					timer,
+				});
 			});
 		}
-
-		if (videoElement) {
-			const videoTracks = stream.getVideoTracks();
-
-			if (videoTracks.length > 0) {
-				const newVideoTrack = videoTracks[0];
-				const existingVideoTrack = (
-					videoElement.srcObject as MediaStream | null
-				)?.getVideoTracks?.()?.[0];
-				const lastAttach = this.lastVideoAttachAt.get(participantId);
-				const isStale =
-					lastAttach !== undefined &&
-					Date.now() - lastAttach > STALE_REATTACH_MS;
-				const videoTrackChanged =
-					!existingVideoTrack || existingVideoTrack.id !== newVideoTrack.id;
-
-				if (!videoElement.srcObject || videoTrackChanged || isStale) {
-					console.log(`Attaching video track for ${participantId}`, {
-						trackId: newVideoTrack.id,
-						hadExisting: !!existingVideoTrack,
-						changed: videoTrackChanged,
-						stale: isStale,
-					});
-					const videoStream = new MediaStream(videoTracks);
-					videoElement.srcObject = videoStream;
-					// we have a separate audio element for audio playback
-					videoElement.muted = true;
-					this.lastVideoAttachAt.set(participantId, Date.now());
-
-					try {
-						await videoElement.play();
-					} catch (err) {
-						console.error(`Error playing video for ${participantId}:`, err);
-						if (this.strictAttachmentTimeoutMs) throw err;
-						if ((err as DOMException).name === "NotAllowedError")
-							this.addUserInteractionHandler(videoElement, participantId);
-					}
-				} else {
-					console.log(
-						`Skipping video re-attach for ${participantId} - same track`,
-					);
-				}
-			}
-		}
+		await this.attach("remote-video", participantId, stream, true);
 	}
 
 	async attachAudioStream(
 		participantId: string,
 		audioTracks: MediaStreamTrack[],
 	): Promise<void> {
-		let audioElement = this.audioElements.get(participantId);
-
-		if (!audioElement) {
-			audioElement = document.createElement("audio");
-			audioElement.autoplay = true;
-			audioElement.setAttribute("playsinline", "");
-			audioElement.style.display = "none";
-			document.body.appendChild(audioElement);
-
-			if (selectedSpeakerId.value) {
-				(
-					audioElement as HTMLAudioElement & {
-						setSinkId?: (id: string) => Promise<void>;
-					}
-				)
-					.setSinkId?.(selectedSpeakerId.value)
-					.catch((err: Error) => {
-						console.warn(
-							`Failed to set initial speaker for ${participantId}:`,
-							err,
-						);
-					});
-			}
-
-			this.audioElements.set(participantId, audioElement);
-			console.log(`Created separate audio element for ${participantId}`);
+		if (!audioTracks.length) return;
+		let audio = this.audioElements.get(participantId);
+		if (!audio) {
+			audio = document.createElement("audio");
+			audio.style.display = "none";
+			document.body.appendChild(audio);
+			this.audioElements.set(participantId, audio);
+			this.registerElement("remote-audio", participantId, audio, true, true);
+			await this.applySink(audio, participantId);
 		}
+		await this.attach(
+			"remote-audio",
+			participantId,
+			new MediaStream(audioTracks),
+			true,
+		);
+	}
 
-		const newAudioTrack = audioTracks[0];
-		const existingAudioTrack = (
-			audioElement.srcObject as MediaStream | null
-		)?.getAudioTracks?.()?.[0];
-		const lastAttach = this.lastAudioAttachAt.get(participantId);
-		const isStale =
-			lastAttach !== undefined && Date.now() - lastAttach > STALE_REATTACH_MS;
-		const audioTrackChanged =
-			!existingAudioTrack || existingAudioTrack.id !== newAudioTrack.id;
-
-		if (!audioElement.srcObject || audioTrackChanged || isStale) {
-			const audioStream = new MediaStream(audioTracks);
-			audioElement.srcObject = audioStream;
-			this.lastAudioAttachAt.set(participantId, Date.now());
-
-			// Try to play audio
-			try {
-				await audioElement.play();
-			} catch (err) {
-				console.warn(
-					`Audio autoplay failed for ${participantId}:`,
-					(err as Error).message,
-				);
-				if (this.strictAttachmentTimeoutMs) throw err;
-				if ((err as DOMException).name === "NotAllowedError")
-					this.addUserInteractionHandler(audioElement, participantId);
-			}
-		}
+	async setAudioOutputDevice(deviceId: string): Promise<void> {
+		this.speakerId = deviceId;
+		await Promise.all(
+			Array.from(this.audioElements, ([participantId, element]) =>
+				this.applySink(element, participantId),
+			),
+		);
 	}
 
 	async playVideo(
 		element: HTMLVideoElement,
 		participantId: string,
 	): Promise<boolean> {
-		try {
-			await element.play();
-			this.clearPlaybackHandler(element);
-			return true;
-		} catch (error) {
-			if ((error as DOMException).name === "NotAllowedError") {
-				console.warn(
-					`Autoplay blocked for ${participantId}, will play on user interaction`,
-				);
-				this.addUserInteractionHandler(element, participantId);
-			} else {
-				console.warn(
-					`Video play failed for ${participantId}:`,
-					(error as Error).message,
-				);
-			}
-			return false;
-		}
+		return this.playElement(element, participantId);
 	}
 
-	/** Retries playback for every attached remote media element after resume. */
+	/** Retries every registered role after browser lifecycle resume. */
 	async retryPlayback(): Promise<void> {
-		await Promise.all([
-			...Array.from(this.videoElements, ([participantId, element]) =>
-				element.srcObject
-					? this.playVideo(element, participantId)
-					: Promise.resolve(false),
-			),
-			...Array.from(this.audioElements, async ([participantId, element]) => {
-				if (!element.srcObject) return false;
-				try {
-					await element.play();
-					this.clearPlaybackHandler(element);
-					return true;
-				} catch (error) {
-					if ((error as DOMException).name === "NotAllowedError") {
-						this.addUserInteractionHandler(element, participantId);
-					}
-					return false;
-				}
+		const registered = new Map<HTMLMediaElement, string>();
+		for (const attachment of this.attachments.values()) {
+			if (attachment.element) {
+				registered.set(
+					attachment.element,
+					`${attachment.role}:${attachment.id}`,
+				);
+			}
+		}
+		for (const [participantId, element] of this.videoElements) {
+			registered.set(element, `remote-video:${participantId}`);
+		}
+		for (const [participantId, element] of this.audioElements) {
+			registered.set(element, `remote-audio:${participantId}`);
+		}
+		await Promise.all(
+			Array.from(registered, ([element, id]) => {
+				return element?.srcObject
+					? this.playElement(element, id)
+					: Promise.resolve(false);
 			}),
-		]);
+		);
 	}
 
 	addUserInteractionHandler(
 		element: HTMLMediaElement,
-		participantId: string,
+		attachmentId: string,
 	): void {
 		if (this.playbackHandlers.has(element)) return;
 		const playOnInteraction = async () => {
@@ -276,15 +268,214 @@ export class VideoElementManager {
 				this.clearPlaybackHandler(element);
 			} catch (error) {
 				console.warn(
-					`Unable to play video for ${participantId}:`,
+					`Unable to play media for ${attachmentId}:`,
 					(error as Error).message,
 				);
 			}
 		};
-
 		this.playbackHandlers.set(element, playOnInteraction);
 		document.addEventListener("click", playOnInteraction);
 		document.addEventListener("touchstart", playOnInteraction);
+	}
+
+	removeVideoElement(participantId: string): void {
+		this.removeAttachment("remote-video", participantId);
+		this.removeAttachment("remote-audio", participantId);
+		this.videoElements.delete(participantId);
+		this.audioElements.delete(participantId);
+		this.cancelDeferredAttachment(participantId);
+	}
+
+	cancelDeferredAttachment(participantId: string): void {
+		const deferred = this.deferredAttachments.get(participantId);
+		if (!deferred) return;
+		if (deferred.timer) clearTimeout(deferred.timer);
+		this.deferredAttachments.delete(participantId);
+		deferred.resolve?.();
+	}
+
+	cleanupRemoteMedia(): void {
+		for (const attachment of [...this.attachments.values()]) {
+			if (
+				attachment.role === "remote-video" ||
+				attachment.role === "remote-audio" ||
+				(attachment.role === "screen-share" && attachment.ownsTracks)
+			) {
+				this.removeAttachment(attachment.role, attachment.id);
+			}
+		}
+		this.videoElements.clear();
+		this.audioElements.clear();
+		for (const deferred of this.deferredAttachments.values()) {
+			if (deferred.timer) clearTimeout(deferred.timer);
+			deferred.reject?.(new Error("Video element manager cleaned up"));
+		}
+		this.deferredAttachments.clear();
+	}
+
+	cleanup(): void {
+		for (const attachment of [...this.attachments.values()]) {
+			this.removeAttachment(attachment.role, attachment.id);
+		}
+		for (const element of [...this.playbackHandlers.keys()]) {
+			this.clearPlaybackHandler(element);
+		}
+		for (const deferred of this.deferredAttachments.values()) {
+			if (deferred.timer) clearTimeout(deferred.timer);
+			deferred.reject?.(new Error("Video element manager cleaned up"));
+		}
+		this.videoElements.clear();
+		this.audioElements.clear();
+		this.deferredAttachments.clear();
+	}
+
+	private registerElement(
+		role: MediaAttachmentRole,
+		id: string,
+		element: HTMLMediaElement | null,
+		ownsTracks: boolean,
+		createdElement = false,
+		attachStoredStream = true,
+	): void {
+		const attachment = this.getOrCreateAttachment(role, id, ownsTracks);
+		const previous = attachment.element;
+		if (previous !== element) attachment.revision++;
+		if (previous && previous !== element) this.detachElement(previous, false);
+		attachment.element = element;
+		attachment.createdElement = createdElement;
+		if (!element) return;
+		this.configureElement(element, role);
+		if (attachment.stream && attachStoredStream) {
+			void this.attachCurrentStream(attachment).catch((error) =>
+				console.warn(`Failed to restore ${role}:${id} playback:`, error),
+			);
+		}
+	}
+
+	private rememberStream(
+		role: MediaAttachmentRole,
+		id: string,
+		stream: MediaStream,
+		ownsTracks: boolean,
+	): Attachment {
+		const attachment = this.getOrCreateAttachment(role, id, ownsTracks);
+		if (
+			attachment.stream &&
+			attachment.stream !== stream &&
+			attachment.ownsTracks
+		) {
+			this.stopReplacedTracks(attachment.stream, stream);
+		}
+		attachment.stream = stream;
+		attachment.ownsTracks = ownsTracks;
+		return attachment;
+	}
+
+	private async attach(
+		role: MediaAttachmentRole,
+		id: string,
+		stream: MediaStream,
+		ownsTracks: boolean,
+	): Promise<void> {
+		const attachment = this.rememberStream(role, id, stream, ownsTracks);
+		if (attachment.element) await this.attachCurrentStream(attachment);
+	}
+
+	private async attachCurrentStream(attachment: Attachment): Promise<void> {
+		const { element, role, stream } = attachment;
+		if (!element || !stream) return;
+		const tracks =
+			role === "remote-audio" ? stream.getAudioTracks() : stream.getVideoTracks();
+		if (!tracks.length) return;
+		const trackIds = tracks.map((track) => track.id).join(",");
+		const currentTracks = (element.srcObject as MediaStream | null)
+			?.getTracks()
+			.map((track) => track.id)
+			.join(",");
+		const stale =
+			attachment.lastAttachAt !== undefined &&
+			Date.now() - attachment.lastAttachAt > STALE_REATTACH_MS;
+		const sourceStreamChanged =
+			role !== "remote-video" &&
+			role !== "remote-audio" &&
+			attachment.attachedStreamId !== stream.id;
+		const changed =
+			!element.srcObject ||
+			sourceStreamChanged ||
+			attachment.attachedTrackIds !== trackIds ||
+			currentTracks !== trackIds;
+		if (!changed && !stale) return;
+
+		this.configureElement(element, role);
+		this.clearPlaybackHandler(element);
+		element.srcObject = new MediaStream(tracks);
+		attachment.attachedStreamId = stream.id;
+		attachment.attachedTrackIds = trackIds;
+		attachment.lastAttachAt = Date.now();
+		const revision = ++attachment.revision;
+		const played = await this.playElement(
+			element,
+			`${role}:${attachment.id}`,
+			() =>
+				this.getAttachment(role, attachment.id) === attachment &&
+				attachment.element === element &&
+				attachment.revision === revision,
+		);
+		if (!played && this.strictAttachmentTimeoutMs) {
+			throw new Error(`Media playback failed for ${attachment.id}`);
+		}
+	}
+
+	private configureElement(
+		element: HTMLMediaElement,
+		role: MediaAttachmentRole,
+	): void {
+		element.autoplay = true;
+		element.setAttribute("playsinline", "");
+		if (element instanceof HTMLVideoElement) {
+			element.playsInline = true;
+			element.muted = true;
+		}
+		if (role === "remote-audio") element.muted = false;
+	}
+
+	private async playElement(
+		element: HTMLMediaElement,
+		attachmentId: string,
+		isCurrent: () => boolean = () => true,
+	): Promise<boolean> {
+		try {
+			await element.play();
+			if (!isCurrent()) return true;
+			this.clearPlaybackHandler(element);
+			return true;
+		} catch (error) {
+			if (!isCurrent()) return true;
+			if ((error as DOMException).name === "NotAllowedError") {
+				if (!this.strictAttachmentTimeoutMs) {
+					this.addUserInteractionHandler(element, attachmentId);
+				}
+			} else {
+				console.warn(
+					`Media play failed for ${attachmentId}:`,
+					(error as Error).message,
+				);
+			}
+			if (this.strictAttachmentTimeoutMs) throw error;
+			return false;
+		}
+	}
+
+	private async applySink(
+		element: HTMLAudioElement,
+		participantId: string,
+	): Promise<void> {
+		if (!this.speakerId || typeof element.setSinkId !== "function") return;
+		try {
+			await element.setSinkId(this.speakerId);
+		} catch (error) {
+			console.warn(`Failed to set speaker for ${participantId}:`, error);
+		}
 	}
 
 	private clearPlaybackHandler(element: HTMLMediaElement): void {
@@ -295,80 +486,81 @@ export class VideoElementManager {
 		this.playbackHandlers.delete(element);
 	}
 
-	removeVideoElement(participantId: string): void {
-		const element = this.videoElements.get(participantId);
-		let hadStream = false;
-		if (element?.srcObject) {
-			hadStream = true;
-			for (const track of (element.srcObject as MediaStream).getTracks()) {
-				track.stop();
-			}
-			element.srcObject = null;
-		}
-
-		const audioElement = this.audioElements.get(participantId);
-		if (audioElement) {
-			if (audioElement.srcObject) {
-				for (const track of (
-					audioElement.srcObject as MediaStream
-				).getTracks()) {
-					track.stop();
-				}
-				audioElement.srcObject = null;
-			}
-			audioElement.remove();
-			this.audioElements.delete(participantId);
-		}
-		if (element) this.clearPlaybackHandler(element);
-		if (audioElement) this.clearPlaybackHandler(audioElement);
-
-		this.videoElements.delete(participantId);
-		const deferred = this.deferredAttachments.get(participantId);
-		if (deferred?.timer) clearTimeout(deferred.timer);
-		this.deferredAttachments.delete(participantId);
-		this.lastVideoAttachAt.delete(participantId);
-		this.lastAudioAttachAt.delete(participantId);
-
-		console.log(`Video/Audio elements removed for ${participantId}`, {
-			hadStream,
-			elementExists: !!element,
-			hadAudioElement: !!audioElement,
-		});
+	private clearAttachmentStream(
+		role: MediaAttachmentRole,
+		id: string,
+		stopOwnedTracks: boolean,
+	): void {
+		const attachment = this.getAttachment(role, id);
+		if (!attachment) return;
+		if (stopOwnedTracks && attachment.ownsTracks) this.stopTracks(attachment.stream);
+		attachment.stream = null;
+		attachment.attachedStreamId = undefined;
+		attachment.attachedTrackIds = undefined;
+		attachment.lastAttachAt = undefined;
+		if (attachment.element) this.detachElement(attachment.element, false);
 	}
 
-	cleanup(): void {
-		for (const element of this.playbackHandlers.keys()) {
-			this.clearPlaybackHandler(element);
+	private removeAttachment(role: MediaAttachmentRole, id: string): void {
+		const key = attachmentKey(role, id);
+		const attachment = this.attachments.get(key);
+		if (!attachment) return;
+		if (attachment.ownsTracks) this.stopTracks(attachment.stream);
+		if (attachment.element) {
+			const element = attachment.element;
+			this.detachElement(element, attachment.createdElement);
 		}
-		for (const deferred of this.deferredAttachments.values()) {
-			if (deferred.timer) clearTimeout(deferred.timer);
-			deferred.reject?.(new Error("Video element manager cleaned up"));
-		}
-		for (const [_participantId, element] of this.videoElements.entries()) {
-			if (element?.srcObject) {
-				for (const track of (element.srcObject as MediaStream).getTracks()) {
-					track.stop();
-				}
-				element.srcObject = null;
-			}
-		}
+		this.attachments.delete(key);
+	}
 
-		for (const [_participantId, audioElement] of this.audioElements.entries()) {
-			if (audioElement?.srcObject) {
-				for (const track of (
-					audioElement.srcObject as MediaStream
-				).getTracks()) {
-					track.stop();
-				}
-				audioElement.srcObject = null;
-			}
-			audioElement.remove();
-		}
+	private detachElement(element: HTMLMediaElement, remove: boolean): void {
+		this.clearPlaybackHandler(element);
+		element.srcObject = null;
+		if (remove) element.remove();
+	}
 
-		this.videoElements.clear();
-		this.audioElements.clear();
-		this.deferredAttachments.clear();
-		this.lastVideoAttachAt.clear();
-		this.lastAudioAttachAt.clear();
+	private stopTracks(stream: MediaStream | null): void {
+		for (const track of stream?.getTracks() ?? []) track.stop();
+	}
+
+	private stopReplacedTracks(previous: MediaStream, replacement: MediaStream): void {
+		const replacementTracks = replacement.getTracks();
+		for (const track of previous.getTracks()) {
+			const retained = replacementTracks.some(
+				(candidate) =>
+					candidate === track ||
+					(!!track.id && candidate.kind === track.kind && candidate.id === track.id),
+			);
+			if (!retained) track.stop();
+		}
+	}
+
+	private getAttachment(
+		role: MediaAttachmentRole,
+		id: string,
+	): Attachment | undefined {
+		return this.attachments.get(attachmentKey(role, id));
+	}
+
+	private getOrCreateAttachment(
+		role: MediaAttachmentRole,
+		id: string,
+		ownsTracks: boolean,
+	): Attachment {
+		const key = attachmentKey(role, id);
+		let attachment = this.attachments.get(key);
+		if (!attachment) {
+			attachment = {
+				role,
+				id,
+				element: null,
+				stream: null,
+				ownsTracks,
+				createdElement: false,
+				revision: 0,
+			};
+			this.attachments.set(key, attachment);
+		}
+		return attachment;
 	}
 }

--- a/frontend/src/apps/meet/utils/media/__tests__/VideoElementManager.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/VideoElementManager.test.ts
@@ -36,6 +36,10 @@ function makeTrack(id: string): MediaStreamTrack {
 	}) as MediaStreamTrack;
 }
 
+function makeAudioTrack(id: string): MediaStreamTrack {
+	return { ...makeTrack(id), kind: "audio" } as MediaStreamTrack;
+}
+
 function makeStream(tracks: MediaStreamTrack[]): MediaStream {
 	const Ctor = globalAny.MediaStream as StreamCtor;
 	return new Ctor(tracks);
@@ -45,6 +49,16 @@ function makeVideoElement(): HTMLVideoElement {
 	const el = document.createElement("video");
 	el.play = vi.fn().mockResolvedValue(undefined) as never;
 	return el;
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
 }
 
 describe("VideoElementManager.attachStream stale re-attach", () => {
@@ -105,6 +119,44 @@ describe("VideoElementManager.attachStream stale re-attach", () => {
 		const rejected = expect(attached).rejects.toThrow("Timed out waiting for video element");
 		await vi.advanceTimersByTimeAsync(100);
 		await rejected;
+	});
+
+	it("settles a strict deferred attachment when its participant is removed", async () => {
+		vi.useFakeTimers();
+		manager = new VideoElementManager(100);
+		const attached = manager.attachStream(
+			"p1",
+			makeStream([makeTrack("track-1")]),
+			false,
+		);
+
+		manager.removeVideoElement("p1");
+
+		await expect(attached).resolves.toBeUndefined();
+		expect(manager.deferredAttachments.size).toBe(0);
+		await vi.advanceTimersByTimeAsync(100);
+	});
+
+	it("settles an obsolete strict attachment when a replacement arrives", async () => {
+		manager = new VideoElementManager(1000);
+		const obsolete = manager.attachStream(
+			"p1",
+			makeStream([makeTrack("track-old")]),
+			false,
+		);
+		const current = manager.attachStream(
+			"p1",
+			makeStream([makeTrack("track-current")]),
+			false,
+		);
+
+		await expect(obsolete).resolves.toBeUndefined();
+		const element = makeVideoElement();
+		manager.registerVideoElement("p1", element);
+		await current;
+		expect((element.srcObject as MediaStream).getVideoTracks()[0]?.id).toBe(
+			"track-current",
+		);
 	});
 
 	it("attaches audio and surfaces autoplay failure", async () => {
@@ -248,5 +300,288 @@ describe("VideoElementManager.attachAudioStream stale re-attach", () => {
 		expect(audioEl?.srcObject).not.toBe(originalSrc);
 
 		createElementSpy.mockRestore();
+	});
+});
+
+describe("VideoElementManager role-aware attachments", () => {
+	let manager: VideoElementManager;
+	let mediaPlay: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		manager = new VideoElementManager();
+		mediaPlay = vi
+			.spyOn(HTMLMediaElement.prototype, "play")
+			.mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		manager.cleanup();
+		mediaPlay.mockRestore();
+	});
+
+	it("attaches and configures a borrowed local preview", async () => {
+		const track = makeTrack("camera");
+		const element = makeVideoElement();
+
+		manager.registerLocalPreview(element);
+		await manager.attachLocalPreview(makeStream([track]));
+
+		expect(element.autoplay).toBe(true);
+		expect(element.muted).toBe(true);
+		expect(element.playsInline).toBe(true);
+		expect(element.play).toHaveBeenCalledOnce();
+		manager.registerLocalPreview(null);
+		expect(element.srcObject).toBeNull();
+		expect(track.stop).not.toHaveBeenCalled();
+	});
+
+	it("moves a local preview to a replacement element without stopping capture", async () => {
+		const track = makeTrack("camera");
+		const first = makeVideoElement();
+		const second = makeVideoElement();
+		manager.registerLocalPreview(first);
+		await manager.attachLocalPreview(makeStream([track]));
+
+		manager.registerLocalPreview(second);
+		await vi.waitFor(() => expect(second.srcObject).not.toBeNull());
+
+		expect(first.srcObject).toBeNull();
+		expect(track.stop).not.toHaveBeenCalled();
+	});
+
+	it("preserves remote media across Vue element unmount and replacement", async () => {
+		const track = makeTrack("remote-camera");
+		const first = makeVideoElement();
+		const replacement = makeVideoElement();
+		manager.registerRemoteVideoElement("p1", first);
+		await manager.attachStream("p1", makeStream([track]));
+
+		manager.registerRemoteVideoElement("p1", null);
+		manager.registerRemoteVideoElement("p1", replacement);
+		await vi.waitFor(() => expect(replacement.srcObject).not.toBeNull());
+
+		expect(first.srcObject).toBeNull();
+		expect(track.stop).not.toHaveBeenCalled();
+	});
+
+	it("cleans remote attachments on manager replacement without detaching local preview", async () => {
+		const localTrack = makeTrack("local-camera");
+		const remoteTrack = makeTrack("remote-camera");
+		const local = makeVideoElement();
+		const remote = makeVideoElement();
+		manager.registerLocalPreview(local);
+		manager.registerRemoteVideoElement("p1", remote);
+		await manager.attachLocalPreview(makeStream([localTrack]));
+		await manager.attachStream("p1", makeStream([remoteTrack]));
+
+		manager.cleanupRemoteMedia();
+
+		expect(local.srcObject).not.toBeNull();
+		expect(remote.srcObject).toBeNull();
+		expect(localTrack.stop).not.toHaveBeenCalled();
+		expect(remoteTrack.stop).toHaveBeenCalledOnce();
+	});
+
+	it("retains an owned remote track across fresh stream wrappers", async () => {
+		manager = new VideoElementManager(1000);
+		const track = makeTrack("remote-camera");
+		manager.registerRemoteVideoElement("p1", makeVideoElement());
+
+		await manager.attachStream("p1", makeStream([track]));
+		await manager.attachStream("p1", makeStream([track]));
+		await manager.attachStream("p1", makeStream([track]));
+
+		expect(track.stop).not.toHaveBeenCalled();
+		manager.removeVideoElement("p1");
+		expect(track.stop).toHaveBeenCalledOnce();
+	});
+
+	it("stops only replaced owned remote tracks", async () => {
+		const retained = makeTrack("retained");
+		const replaced = makeTrack("replaced");
+		const replacement = makeTrack("replacement");
+		manager.registerRemoteVideoElement("p1", makeVideoElement());
+		await manager.attachStream("p1", makeStream([retained, replaced]));
+
+		await manager.attachStream("p1", makeStream([retained, replacement]));
+
+		expect(retained.stop).not.toHaveBeenCalled();
+		expect(replaced.stop).toHaveBeenCalledOnce();
+		expect(replacement.stop).not.toHaveBeenCalled();
+	});
+
+	it("uses a stable track id fallback when wrappers expose equivalent tracks", async () => {
+		const previous = makeTrack("stable-track");
+		const equivalent = makeTrack("stable-track");
+		manager.registerRemoteVideoElement("p1", makeVideoElement());
+		await manager.attachStream("p1", makeStream([previous]));
+
+		await manager.attachStream("p1", makeStream([equivalent]));
+
+		expect(previous.stop).not.toHaveBeenCalled();
+	});
+
+	it("keeps local screen capture alive but stops owned remote screen tracks", async () => {
+		const localTrack = makeTrack("local-screen");
+		const remoteTrack = makeTrack("remote-screen");
+		manager.registerScreenSharePreview("local-screen", makeVideoElement());
+		manager.registerScreenSharePreview("remote-screen", makeVideoElement());
+		await manager.attachScreenSharePreview(
+			"local-screen",
+			makeStream([localTrack]),
+			"borrowed",
+		);
+		await manager.attachScreenSharePreview(
+			"remote-screen",
+			makeStream([remoteTrack]),
+			"owned",
+		);
+
+		manager.removeScreenSharePreview("local-screen");
+		manager.removeScreenSharePreview("remote-screen");
+
+		expect(localTrack.stop).not.toHaveBeenCalled();
+		expect(remoteTrack.stop).toHaveBeenCalledOnce();
+	});
+
+	it("preserves owned screen attachment semantics when its element registers later", async () => {
+		const removedTrack = makeTrack("removed-screen");
+		await manager.attachScreenSharePreview(
+			"consumer-1",
+			makeStream([removedTrack]),
+			"owned",
+		);
+		manager.registerScreenSharePreview("consumer-1", makeVideoElement());
+		manager.registerScreenSharePreview("consumer-1", null);
+		manager.removeScreenSharePreview("consumer-1");
+		expect(removedTrack.stop).toHaveBeenCalledOnce();
+
+		const cleanupTrack = makeTrack("cleanup-screen");
+		await manager.attachScreenSharePreview(
+			"consumer-2",
+			makeStream([cleanupTrack]),
+			"owned",
+		);
+		manager.registerScreenSharePreview("consumer-2", makeVideoElement());
+		manager.registerScreenSharePreview("consumer-2", null);
+		manager.cleanupRemoteMedia();
+		expect(cleanupTrack.stop).toHaveBeenCalledOnce();
+	});
+
+	it("ignores delayed playback failure from a superseded stream", async () => {
+		const firstPlay = deferred<void>();
+		const element = makeVideoElement();
+		element.play = vi
+			.fn()
+			.mockReturnValueOnce(firstPlay.promise)
+			.mockResolvedValue(undefined);
+		manager.registerLocalPreview(element);
+		const firstAttach = manager.attachLocalPreview(makeStream([makeTrack("first")]));
+		await Promise.resolve();
+
+		await manager.attachLocalPreview(makeStream([makeTrack("second")]));
+		firstPlay.reject(new DOMException("blocked", "NotAllowedError"));
+		await firstAttach;
+		document.dispatchEvent(new Event("click"));
+		await Promise.resolve();
+
+		expect(element.play).toHaveBeenCalledTimes(2);
+	});
+
+	it("ignores delayed playback success from a superseded stream", async () => {
+		const firstPlay = deferred<void>();
+		const element = makeVideoElement();
+		element.play = vi
+			.fn()
+			.mockReturnValueOnce(firstPlay.promise)
+			.mockRejectedValueOnce(new DOMException("blocked", "NotAllowedError"))
+			.mockResolvedValue(undefined);
+		manager.registerLocalPreview(element);
+		const firstAttach = manager.attachLocalPreview(makeStream([makeTrack("first")]));
+		await Promise.resolve();
+
+		await manager.attachLocalPreview(makeStream([makeTrack("second")]));
+		firstPlay.resolve();
+		await firstAttach;
+		document.dispatchEvent(new Event("click"));
+		await vi.waitFor(() => expect(element.play).toHaveBeenCalledTimes(3));
+	});
+
+	it("retries NotAllowedError playback on user interaction for local preview", async () => {
+		const element = makeVideoElement();
+		element.play = vi
+			.fn()
+			.mockRejectedValueOnce(new DOMException("blocked", "NotAllowedError"))
+			.mockResolvedValue(undefined);
+		manager.registerLocalPreview(element);
+		await manager.attachLocalPreview(makeStream([makeTrack("camera")]));
+
+		document.dispatchEvent(new Event("click"));
+
+		await vi.waitFor(() => expect(element.play).toHaveBeenCalledTimes(2));
+	});
+
+	it("retries playback across remote, local, screen, and background roles", async () => {
+		const remote = makeVideoElement();
+		const local = makeVideoElement();
+		const screen = makeVideoElement();
+		const background = makeVideoElement();
+		manager.registerRemoteVideoElement("p1", remote);
+		manager.registerLocalPreview(local);
+		manager.registerScreenSharePreview("screen", screen);
+		await manager.attachStream("p1", makeStream([makeTrack("remote")]), false);
+		await manager.attachLocalPreview(makeStream([makeTrack("local")]));
+		await manager.attachScreenSharePreview(
+			"screen",
+			makeStream([makeTrack("screen")]),
+		);
+		await manager.attachBackgroundEffectsSource(
+			"effects",
+			background,
+			makeStream([makeTrack("effects")]),
+		);
+		const audio = manager.audioElements.get("p1");
+		await manager.attachStream("p1", makeStream([makeAudioTrack("audio")]), false);
+		for (const element of [remote, local, screen, background]) {
+			vi.mocked(element.play).mockClear();
+		}
+		const remoteAudio = manager.audioElements.get("p1") ?? audio;
+		if (remoteAudio) remoteAudio.play = vi.fn().mockResolvedValue(undefined);
+
+		await manager.retryPlayback();
+
+		for (const element of [remote, local, screen, background]) {
+			expect(element.play).toHaveBeenCalledOnce();
+		}
+		expect(remoteAudio?.play).toHaveBeenCalledOnce();
+	});
+
+	it("applies the selected sink to existing and future remote audio elements", async () => {
+		const previousDescriptor = Object.getOwnPropertyDescriptor(
+			HTMLMediaElement.prototype,
+			"setSinkId",
+		);
+		const setSinkId = vi.fn().mockResolvedValue(undefined);
+		Object.defineProperty(HTMLMediaElement.prototype, "setSinkId", {
+			configurable: true,
+			value: setSinkId,
+		});
+		await manager.attachAudioStream("p1", [makeAudioTrack("audio-1")]);
+		setSinkId.mockClear();
+		await manager.setAudioOutputDevice("speaker-1");
+		await manager.attachAudioStream("p2", [makeAudioTrack("audio-2")]);
+
+		expect(setSinkId).toHaveBeenCalledTimes(2);
+		expect(setSinkId).toHaveBeenNthCalledWith(1, "speaker-1");
+		expect(setSinkId).toHaveBeenNthCalledWith(2, "speaker-1");
+		if (previousDescriptor) {
+			Object.defineProperty(
+				HTMLMediaElement.prototype,
+				"setSinkId",
+				previousDescriptor,
+			);
+		} else {
+			Reflect.deleteProperty(HTMLMediaElement.prototype, "setSinkId");
+		}
 	});
 });

--- a/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
+++ b/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
@@ -96,11 +96,18 @@ function normalizeProducerClosedEvent(
 
 function normalizeScreenShareEvent(value: unknown): ScreenShareEvent | null {
 	if (!isUnknownRecord(value)) return null;
+	const shareData = isUnknownRecord(value.shareData) ? value.shareData : null;
 	return {
 		participantId:
 			typeof value.participantId === "string" ? value.participantId : undefined,
 		consumerId:
 			typeof value.consumerId === "string" ? value.consumerId : undefined,
+		producerId:
+			typeof value.producerId === "string"
+				? value.producerId
+				: typeof shareData?.producerId === "string"
+					? shareData.producerId
+					: undefined,
 		stream:
 			typeof MediaStream !== "undefined" && value.stream instanceof MediaStream
 				? value.stream
@@ -166,8 +173,9 @@ export interface ParticipantConnectionStartOptions {
 interface ScreenShareEvent {
 	participantId?: string;
 	consumerId?: string;
+	producerId?: string;
 	stream?: MediaStream;
-	consumer?: { id: string };
+	consumer?: { id: string; producerId?: string };
 }
 
 interface ParticipantConnectionOptions {
@@ -708,9 +716,7 @@ export class ParticipantConnection {
 	private async performReceiveReset(generation: number): Promise<void> {
 		const pendingSubscriptions = this.mediaManager.cancelPendingSubscriptions();
 		this.transportManager.closeReceiveTransport();
-		this.mediaManager.consumerManager.clear();
-		this.mediaManager.processedConsumers.clear();
-		this.mediaManager.isScreenShareActive = false;
+		this.clearReceiveConsumers();
 		await pendingSubscriptions;
 		if (generation !== this.lifecycleGeneration) return;
 		if (
@@ -832,9 +838,7 @@ export class ParticipantConnection {
 		this.localProducerBytes.clear();
 		const pendingSubscriptions = this.mediaManager.cancelPendingSubscriptions();
 		this.transportManager.closeReceiveTransport();
-		this.mediaManager.consumerManager.clear();
-		this.mediaManager.processedConsumers.clear();
-		this.mediaManager.isScreenShareActive = false;
+		this.clearReceiveConsumers();
 		await pendingSubscriptions;
 		this.throwIfAborted(signal);
 		await this.sfuClient.disconnect();
@@ -1139,14 +1143,7 @@ export class ParticipantConnection {
 				event.participantId,
 			);
 		for (const consumer of consumers) {
-			const producerMatches =
-				consumer.consumer.producerId === event.producerId ||
-				consumer.appData?.producerId === event.producerId;
-			const isScreen =
-				consumer.isScreen ||
-				consumer.appData?.type === "screen" ||
-				consumer.consumer.appData?.type === "screen";
-			if (producerMatches || (event.isScreen && isScreen)) {
+			if (consumer.producerId === event.producerId) {
 				this.mediaManager.consumerManager.removeConsumer(consumer.id);
 				this.mediaManager.processedConsumers.delete(consumer.id);
 			}
@@ -1156,6 +1153,17 @@ export class ParticipantConnection {
 			.catch((error) =>
 				console.warn("Failed to attach surviving endpoint media:", error),
 			);
+	}
+
+	clearReceiveConsumers(): void {
+		for (const screen of [
+			...this.mediaManager.consumerManager.getScreenShareConsumers(),
+		]) {
+			this.mediaManager.consumerManager.removeConsumer(screen.id);
+		}
+		this.mediaManager.consumerManager.clear();
+		this.mediaManager.processedConsumers.clear();
+		this.mediaManager.isScreenShareActive = false;
 	}
 
 	private applyReconciliationEvent(event: ReconciliationEvent): void {
@@ -1277,11 +1285,14 @@ export class ParticipantConnection {
 			},
 			onConsumerRemoved: (consumerId: string, consumer: ConsumerEntry) => {
 				if (consumer?.isScreen || consumer?.appData?.type === "screen") {
-					this.mediaManager.isScreenShareActive = false;
+					this.mediaManager.isScreenShareActive =
+						this.mediaManager.consumerManager.getScreenShareConsumers().length > 0;
 					if (this.eventHandlers.onScreenShareStopped) {
 						this.eventHandlers.onScreenShareStopped({
 							participantId: consumer.participantId,
 							consumerId,
+							producerId: consumer.producerId,
+							consumer,
 						});
 					}
 				}
@@ -1437,6 +1448,7 @@ export class ParticipantConnection {
 			if (d.isScreen) {
 				this.eventHandlers.onScreenShareStopped?.({
 					participantId: d.participantId,
+					producerId: d.producerId,
 				});
 			}
 		});
@@ -1585,45 +1597,26 @@ export class ParticipantConnection {
 
 		this.sfuClient.on("screen_share_stopped", (value: unknown) => {
 			const d = normalizeScreenShareEvent(value);
-			if (!d) return;
-			console.log("Screen share stopped - resetting sidebar mode flag");
-			this.mediaManager.isScreenShareActive = false;
-
-			if (this.eventHandlers.onScreenShareStopped) {
-				this.eventHandlers.onScreenShareStopped(d);
+			if (!d?.participantId || !d.producerId) return;
+			const screenConsumers =
+				this.mediaManager.consumerManager.getScreenShareConsumers();
+			const matchingConsumer = screenConsumers.find(
+				(consumer) =>
+					consumer.participantId === d.participantId &&
+					consumer.producerId === d.producerId,
+			);
+			this.eventHandlers.onScreenShareStopped?.({
+				...d,
+				consumerId: matchingConsumer?.id,
+				consumer: matchingConsumer,
+			});
+			if (matchingConsumer) {
+				this.mediaManager.consumerManager.removeConsumer(matchingConsumer.id);
+				this.mediaManager.processedConsumers.delete(matchingConsumer.id);
 			}
-
-			const pid = d.participantId;
-			if (pid) {
-				const screenConsumers = this.mediaManager.consumerManager
-					.getScreenShareConsumers()
-					.filter((c) => c.participantId === pid);
-				for (const sc of screenConsumers) {
-					console.log("Removing screen-share consumer on stop:", {
-						consumerId: sc.id,
-						participantId: pid,
-					});
-					this.mediaManager.consumerManager.removeConsumer(sc.id);
-					this.mediaManager.processedConsumers.delete(sc.id);
-				}
-				const allForPid =
-					this.mediaManager.consumerManager.getConsumersByParticipant(pid);
-				for (const c of allForPid) {
-					const maybeScreen =
-						c.isScreen ||
-						c.appData?.type === "screen" ||
-						(c.consumer as { appData?: { type?: string } })?.appData?.type ===
-							"screen";
-					if (maybeScreen) {
-						console.log("(safety) Removing screen-like consumer on stop:", {
-							consumerId: c.id,
-							participantId: pid,
-						});
-						this.mediaManager.consumerManager.removeConsumer(c.id);
-						this.mediaManager.processedConsumers.delete(c.id);
-					}
-				}
-			}
+			this.mediaManager.isScreenShareActive = screenConsumers.some(
+				(consumer) => consumer.producerId !== d.producerId,
+			);
 		});
 
 		this.sfuClient.on("active_speaker", (value: unknown) => {

--- a/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
+++ b/frontend/src/apps/meet/utils/sfu/SFUMediaManager.ts
@@ -81,6 +81,7 @@ interface MediaEventHandlers {
 
 export interface MediaScreenShareEvent {
 	participantId: string;
+	producerId?: string;
 	stream?: MediaStream;
 	consumer?: ConsumerEntry;
 }
@@ -852,6 +853,7 @@ export class SFUMediaManager {
 			if (this.eventHandlers.onScreenShareStarted) {
 				this.eventHandlers.onScreenShareStarted({
 					participantId,
+					producerId: consumer.producerId,
 					stream: screenStream,
 					consumer,
 				});

--- a/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnection.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnection.test.ts
@@ -42,6 +42,8 @@ function createConnection({ e2eeRequired = false } = {}) {
 			clear: vi.fn(),
 			setEventHandlers: vi.fn(),
 			getConsumersByParticipant: vi.fn(() => []),
+			getScreenShareConsumers: vi.fn(() => []),
+			removeConsumer: vi.fn(),
 		},
 		setEventHandlers: vi.fn(),
 	};

--- a/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnectionEvents.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnectionEvents.test.ts
@@ -30,6 +30,7 @@ function createManager({ e2eeRequired = false } = {}) {
 			clear: vi.fn(),
 			setEventHandlers: vi.fn(),
 			getConsumersByParticipant: vi.fn(() => []),
+			getScreenShareConsumers: vi.fn(() => []),
 			removeConsumer: vi.fn(),
 		},
 		reattachAfterProducerClosed: vi.fn().mockResolvedValue(undefined),
@@ -242,6 +243,114 @@ describe("ParticipantConnection", () => {
 			producerId: "screen-producer",
 			isScreen: true,
 		});
+	});
+
+	it("removes only the screen consumer matching a stopped producer", async () => {
+		const { handlers, manager, mediaManager } = createManager();
+		const stopped = vi.fn();
+		manager.eventHandlers.onScreenShareStopped = stopped;
+		const oldScreen = {
+			id: "consumer-old",
+			participantId: "remote-1",
+			producerId: "screen-old",
+			isScreen: true,
+		};
+		const currentScreen = {
+			id: "consumer-current",
+			participantId: "remote-1",
+			producerId: "screen-current",
+			isScreen: true,
+		};
+		mediaManager.consumerManager.getScreenShareConsumers.mockReturnValue([
+			oldScreen,
+			currentScreen,
+		]);
+		await manager.connect("token");
+
+		handlers.get("screen_share_stopped")?.({
+			participantId: "remote-1",
+			producerId: "screen-old",
+		});
+
+		expect(mediaManager.consumerManager.removeConsumer).toHaveBeenCalledOnce();
+		expect(mediaManager.consumerManager.removeConsumer).toHaveBeenCalledWith(
+			"consumer-old",
+		);
+		expect(stopped).toHaveBeenCalledWith(
+			expect.objectContaining({
+				participantId: "remote-1",
+				producerId: "screen-old",
+				consumerId: "consumer-old",
+			}),
+		);
+		expect(mediaManager.isScreenShareActive).toBe(true);
+	});
+
+	it("does not remove a screen consumer for another producer", async () => {
+		const { handlers, manager, mediaManager } = createManager();
+		mediaManager.consumerManager.getScreenShareConsumers.mockReturnValue([
+			{
+				id: "consumer-current",
+				participantId: "remote-1",
+				producerId: "screen-current",
+				isScreen: true,
+			},
+		]);
+		await manager.connect("token");
+
+		handlers.get("screen_share_stopped")?.({
+			participantId: "remote-1",
+			producerId: "screen-old",
+		});
+
+		expect(mediaManager.consumerManager.removeConsumer).not.toHaveBeenCalled();
+		expect(mediaManager.isScreenShareActive).toBe(true);
+	});
+
+	it("preserves a replacement screen when the old producer closes late", async () => {
+		const { handlers, manager, mediaManager } = createManager();
+		const oldScreen = {
+			id: "consumer-old",
+			participantId: "remote-1",
+			producerId: "screen-old",
+			isScreen: true,
+			consumer: { closed: false, producerId: "screen-old" },
+		};
+		const replacement = {
+			id: "consumer-current",
+			participantId: "remote-1",
+			producerId: "screen-current",
+			isScreen: true,
+			consumer: { closed: false, producerId: "screen-current" },
+		};
+		mediaManager.consumerManager.getConsumersByParticipant.mockReturnValue([
+			oldScreen,
+			replacement,
+		]);
+		await manager.connect("token");
+		await handlers.get("producer_created")?.({
+			participantId: "remote-1",
+			producerId: "screen-old",
+			kind: "video",
+			isScreen: true,
+		});
+		await handlers.get("producer_created")?.({
+			participantId: "remote-1",
+			producerId: "screen-current",
+			kind: "video",
+			isScreen: true,
+		});
+
+		handlers.get("producer_closed")?.({
+			participantId: "remote-1",
+			producerId: "screen-old",
+			isScreen: true,
+		});
+
+		expect(mediaManager.consumerManager.removeConsumer).toHaveBeenCalledOnce();
+		expect(mediaManager.consumerManager.removeConsumer).toHaveBeenCalledWith(
+			"consumer-old",
+		);
 	});
 
 	it("ignores producer events for the current user", async () => {
@@ -549,6 +658,38 @@ describe("ParticipantConnection", () => {
 		expect(mediaManager.consumerManager.clear).toHaveBeenCalledTimes(1);
 		expect(transportManager.createReceiveTransport).toHaveBeenCalledTimes(1);
 		expect(sfuClient.getExistingProducers).toHaveBeenCalledTimes(1);
+	});
+
+	it("dispatches screen removal before clearing receive consumers", async () => {
+		const { manager, mediaManager } = createManager();
+		const stopped = vi.fn();
+		const screen = {
+			id: "screen-consumer",
+			participantId: "remote-1",
+			producerId: "screen-producer",
+			isScreen: true,
+			appData: { type: "screen" },
+		};
+		manager.eventHandlers.onScreenShareStopped = stopped;
+		mediaManager.consumerManager.getScreenShareConsumers.mockReturnValue([screen]);
+		mediaManager.consumerManager.removeConsumer.mockImplementation((id: string) => {
+			const events = mediaManager.consumerManager.setEventHandlers.mock.calls.at(-1)?.[0];
+			events?.onConsumerRemoved?.(id, screen);
+		});
+		await manager.connect("token");
+
+		await manager.resetReceiveSide();
+
+		expect(stopped).toHaveBeenCalledWith(
+			expect.objectContaining({
+				participantId: "remote-1",
+				producerId: "screen-producer",
+				consumerId: "screen-consumer",
+			}),
+		);
+		expect(
+			mediaManager.consumerManager.removeConsumer.mock.invocationCallOrder[0],
+		).toBeLessThan(mediaManager.consumerManager.clear.mock.invocationCallOrder[0]);
 	});
 
 	it("fails receive recovery when the producer snapshot fails", async () => {

--- a/suite/meet/sfu-server/src/server/RoomRegistry.ts
+++ b/suite/meet/sfu-server/src/server/RoomRegistry.ts
@@ -469,18 +469,27 @@ export class RoomRegistry {
 		event: 'screen_share_started' | 'screen_share_stopped',
 		data: ScreenShareStartedEvent | ScreenShareStoppedEvent,
 	): void {
-		this.emitToFullAccessParticipants(roomId, event, data);
-		const producerId =
-			'shareData' in data && typeof data.shareData.producerId === 'string'
-				? data.shareData.producerId
-				: undefined;
-		this.emitToRecorders(roomId, event, {
-			participantId: data.participantId,
-			...(event === 'screen_share_started' && producerId
-				? { shareData: { producerId } }
-				: {}),
-			timestamp: data.timestamp,
-		});
+		if (event === 'screen_share_started' && 'shareData' in data) {
+			this.emitToFullAccessParticipants(roomId, event, data);
+			const producerId =
+				typeof data.shareData.producerId === 'string'
+					? data.shareData.producerId
+					: undefined;
+			this.emitToRecorders(roomId, event, {
+				participantId: data.participantId,
+				shareData: producerId ? { producerId } : {},
+				timestamp: data.timestamp,
+			});
+			return;
+		}
+		if (event === 'screen_share_stopped' && 'producerId' in data) {
+			this.emitToFullAccessParticipants(roomId, event, data);
+			this.emitToRecorders(roomId, event, {
+				participantId: data.participantId,
+				producerId: data.producerId,
+				timestamp: data.timestamp,
+			});
+		}
 	}
 
 	emitReaction(roomId: string, data: ReactionMessage): void {

--- a/suite/meet/sfu-server/src/server/__tests__/RoomRegistry.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/RoomRegistry.test.ts
@@ -473,6 +473,11 @@ describe('RoomRegistry', () => {
 				shareData: { producerId: 'screen-1', details: { private: true } },
 				timestamp: 'ts',
 			});
+			registry.emitScreenShare('r1', 'screen_share_stopped', {
+				participantId: 'p1',
+				producerId: 'screen-1',
+				timestamp: 'ts',
+			});
 			registry.emitReaction('r1', {
 				roomId: 'r1',
 				reaction: 'wave',
@@ -508,6 +513,7 @@ describe('RoomRegistry', () => {
 				'producer_created',
 				'producer_closed',
 				'screen_share_started',
+				'screen_share_stopped',
 				'reaction:message',
 				'hand_raised',
 				'chat:message',
@@ -534,6 +540,13 @@ describe('RoomRegistry', () => {
 			).toEqual({
 				participantId: 'p1',
 				shareData: { producerId: 'screen-1' },
+				timestamp: 'ts',
+			});
+			expect(
+				calls.find((call) => call.event === 'screen_share_stopped')?.data,
+			).toEqual({
+				participantId: 'p1',
+				producerId: 'screen-1',
 				timestamp: 'ts',
 			});
 		});

--- a/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
@@ -1165,6 +1165,48 @@ describe('SocketHandlerManager characterization', () => {
 		});
 	});
 
+	it('broadcasts an explicitly validated screen stop in normal flow', async () => {
+		const harness = createManager();
+		const sharer = connectFullSocket(harness, {
+			id: 'sock-sharer',
+			userId: 'sharer-1',
+		});
+		const viewer = connectFullSocket(harness, {
+			id: 'sock-viewer',
+			userId: 'viewer-1',
+		});
+		emitJoin(sharer, { userId: 'sharer-1', name: 'Sharer' });
+		emitJoin(viewer, { userId: 'viewer-1', name: 'Viewer' });
+		await new Promise((resolve) => setImmediate(resolve));
+		vi.mocked(harness.mediasoup.assertProducerAccess).mockReturnValue({
+			producer: { kind: 'video', appData: { type: 'screen' } },
+		} as never);
+		viewer.emitCalls.length = 0;
+		const callback = vi.fn();
+
+		sharer.fire(
+			'screen_share',
+			{
+				action: 'stop_share',
+				shareData: {
+					producerId: 'producer-1',
+					reason: 'user-click',
+				},
+			},
+			callback,
+		);
+
+		expect(callback).toHaveBeenCalledWith({ success: true });
+		expect(viewer.emitCalls).toContainEqual({
+			event: 'screen_share_stopped',
+			data: expect.objectContaining({
+				participantId: 'sharer-1',
+				producerId: 'producer-1',
+				reason: 'user-click',
+			}),
+		});
+	});
+
 	it('reports a producer creation fault without broadcasting and allows retry', async () => {
 		const harness = createManager();
 		const publisher = connectFullSocket(harness, {

--- a/suite/meet/sfu-server/src/server/handlers/ScreenShareHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/ScreenShareHandlers.ts
@@ -1,17 +1,20 @@
 import type { Socket } from 'socket.io';
 import { loggers } from '../../utils/logger';
 import type { HandlerDeps } from './Handler';
+import { getPeerId } from './utils';
 
 export function registerScreenShareHandlers(deps: HandlerDeps) {
 	return (socket: Socket) => {
-		socket.on('screen_share', (data) => {
+		socket.on('screen_share', (data, callback) => {
 			try {
 				deps.authManager.ensureFullAccess(socket);
 				const { action, shareData } = data;
 				const roomId = socket.roomId;
 				const participantId = socket.participantId;
 
-				if (!roomId || !participantId) return;
+				if (!roomId || !participantId) {
+					throw new Error('Screen share requires an active room participant');
+				}
 
 				if (action === 'start_share') {
 					loggers.socketHandler.info(
@@ -40,6 +43,25 @@ export function registerScreenShareHandlers(deps: HandlerDeps) {
 						timestamp: new Date().toISOString(),
 					});
 				} else if (action === 'stop_share') {
+					const producerId = shareData?.producerId;
+					if (typeof producerId !== 'string' || !producerId) {
+						loggers.socketHandler.warn(
+							'screen_share action=stop_share peer=%s missing producer identity',
+							socket.participantId || socket.userId,
+						);
+						throw new Error('Screen share stop requires a producer identity');
+					}
+					const producer = deps.mediasoup.assertProducerAccess(
+						producerId,
+						roomId,
+						getPeerId(socket),
+					);
+					if (
+						producer.producer.kind !== 'video' ||
+						producer.producer.appData?.type !== 'screen'
+					) {
+						throw new Error(`Producer ${producerId} is not a screen producer`);
+					}
 					loggers.socketHandler.info(
 						'screen_share action=stop_share peer=%s producer=%s reason=%s source=%s',
 						socket.participantId || socket.userId,
@@ -49,15 +71,18 @@ export function registerScreenShareHandlers(deps: HandlerDeps) {
 					);
 					deps.registry.emitScreenShare(roomId, 'screen_share_stopped', {
 						participantId,
+						producerId,
 						reason: shareData?.reason,
 						timestamp: new Date().toISOString(),
 					});
 				}
+				callback?.({ success: true });
 			} catch (error) {
 				loggers.socketHandler.warn(
 					'screen_share handling failed: %s',
 					(error as Error).message,
 				);
+				callback?.({ success: false, error: (error as Error).message });
 			}
 		});
 	};

--- a/suite/meet/sfu-server/src/server/handlers/__tests__/ScreenShareHandlers.test.ts
+++ b/suite/meet/sfu-server/src/server/handlers/__tests__/ScreenShareHandlers.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest';
+import { registerScreenShareHandlers } from '../ScreenShareHandlers';
+
+function setup() {
+	const handlers = new Map<
+		string,
+		(data: unknown, callback?: (response: unknown) => void) => void
+	>();
+	const socket = {
+		participantId: 'participant-1',
+		peerId: 'peer-1',
+		roomId: 'room-1',
+		userId: 'user-1',
+		on: vi.fn((event: string, handler: (data: unknown) => void) => {
+			handlers.set(event, handler);
+		}),
+	};
+	const emitScreenShare = vi.fn();
+	const assertProducerAccess = vi.fn(() => ({
+		producer: { kind: 'video', appData: { type: 'screen' } },
+	}));
+	const deps = {
+		authManager: { ensureFullAccess: vi.fn() },
+		mediasoup: { assertProducerAccess },
+		registry: { emitScreenShare },
+	};
+	registerScreenShareHandlers(deps as never)(socket as never);
+	return { assertProducerAccess, emitScreenShare, handlers };
+}
+
+describe('ScreenShareHandlers', () => {
+	it('broadcasts screen stop with producer identity and no consumer identity', () => {
+		const { emitScreenShare, handlers } = setup();
+		const callback = vi.fn();
+
+		handlers.get('screen_share')?.(
+			{
+				action: 'stop_share',
+				shareData: {
+					producerId: 'producer-1',
+					consumerId: 'browser-only-consumer',
+					reason: 'user-click',
+				},
+			},
+			callback,
+		);
+
+		expect(emitScreenShare).toHaveBeenCalledWith(
+			'room-1',
+			'screen_share_stopped',
+			expect.objectContaining({
+				participantId: 'participant-1',
+				producerId: 'producer-1',
+				reason: 'user-click',
+			}),
+		);
+		expect(emitScreenShare.mock.calls[0]?.[2]).not.toHaveProperty('consumerId');
+		expect(callback).toHaveBeenCalledWith({ success: true });
+	});
+
+	it('authorizes the exact screen producer before broadcasting a stop', () => {
+		const { assertProducerAccess, handlers } = setup();
+
+		handlers.get('screen_share')?.({
+			action: 'stop_share',
+			shareData: { producerId: 'producer-1' },
+		});
+
+		expect(assertProducerAccess).toHaveBeenCalledWith(
+			'producer-1',
+			'room-1',
+			'peer-1',
+		);
+	});
+
+	it("does not broadcast another participant's producer stop", () => {
+		const { assertProducerAccess, emitScreenShare, handlers } = setup();
+		const callback = vi.fn();
+		assertProducerAccess.mockImplementation(() => {
+			throw new Error('Producer ownership mismatch');
+		});
+
+		handlers.get('screen_share')?.(
+			{
+				action: 'stop_share',
+				shareData: { producerId: 'other-producer' },
+			},
+			callback,
+		);
+
+		expect(emitScreenShare).not.toHaveBeenCalled();
+		expect(callback).toHaveBeenCalledWith({
+			success: false,
+			error: 'Producer ownership mismatch',
+		});
+	});
+
+	it('does not broadcast a non-screen producer stop', () => {
+		const { assertProducerAccess, emitScreenShare, handlers } = setup();
+		assertProducerAccess.mockReturnValue({
+			producer: { kind: 'video', appData: { type: 'camera' } },
+		});
+
+		handlers.get('screen_share')?.({
+			action: 'stop_share',
+			shareData: { producerId: 'camera-producer' },
+		});
+
+		expect(emitScreenShare).not.toHaveBeenCalled();
+	});
+
+	it('does not broadcast an unidentifiable screen stop', () => {
+		const { emitScreenShare, handlers } = setup();
+		const callback = vi.fn();
+
+		handlers.get('screen_share')?.(
+			{
+				action: 'stop_share',
+				shareData: { reason: 'user-click' },
+			},
+			callback,
+		);
+
+		expect(emitScreenShare).not.toHaveBeenCalled();
+		expect(callback).toHaveBeenCalledWith({
+			success: false,
+			error: 'Screen share stop requires a producer identity',
+		});
+	});
+});

--- a/suite/meet/sfu-server/src/types/index.ts
+++ b/suite/meet/sfu-server/src/types/index.ts
@@ -237,7 +237,10 @@ export interface ClientToServerEvents {
 	) => void;
 	media_control: (data: MediaControlRequest) => void;
 	host_control: (data: HostControlRequest) => void;
-	screen_share: (data: ScreenShareRequest) => void;
+	screen_share: (
+		data: ScreenShareRequest,
+		callback?: (response: SFUResponse) => void,
+	) => void;
 	'chat:send': (
 		data: ChatSendRequest,
 		callback?: (

--- a/suite/meet/types/index.ts
+++ b/suite/meet/types/index.ts
@@ -181,6 +181,7 @@ export interface ScreenShareStartedEvent {
 
 export interface ScreenShareStoppedEvent {
 	participantId: string;
+	producerId: string;
 	timestamp: string;
 	reason?: string;
 }


### PR DESCRIPTION
## Summary

- centralize remote, local, screen, and settings-preview media attachment
- make playback recovery and track ownership role-aware
- make screen-share and recorder replacement/cleanup producer-scoped
- release the media mutation queue while awaiting screen-stop acknowledgment

Depends on #755.