### PR TITLE
refactor(meet): extract local capture session

### DIFF
--- a/frontend/src/apps/meet/composables/useMediaControls.test.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.test.ts
@@ -1450,35 +1450,6 @@ describe("useMediaControls", () => {
 		}
 	});
 
-	it("closes a microphone publication resumed by a replaced manager", async () => {
-		noiseCancellationEnabled.value = false;
-		const sourceTrack = audioTrack("source");
-		const reconciliation = deferred<void>();
-		const harness = createCameraHarness({
-			getUserMedia: vi
-				.fn()
-				.mockResolvedValue(new FakeMediaStream([sourceTrack])),
-		});
-		harness.manager.reconcileLocalProducerTrack.mockImplementation(
-			() => reconciliation.promise,
-		);
-
-		const enabling = harness.controls.toggleMicrophone();
-		await vi.waitFor(() =>
-			expect(harness.manager.reconcileLocalProducerTrack).toHaveBeenCalledOnce(),
-		);
-		harness.managerRef.value = {} as never;
-		reconciliation.resolve();
-		await enabling;
-
-		expect(harness.manager.closeLocalProducer).toHaveBeenCalledWith("audio", {
-			reason: "manager-replaced",
-		});
-		expect(harness.state.isMicOn).toBe(false);
-		expect(sourceTrack.stop).toHaveBeenCalledOnce();
-		expect(harness.state.localStream.getAudioTracks()).toEqual([]);
-	});
-
 	it("serializes overlapping camera toggles and finishes camera-off", async () => {
 		const firstAcquisition = deferred<MediaStream>();
 		const firstTrack = videoTrack("first");

--- a/frontend/src/apps/meet/composables/useMediaControls.test.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.test.ts
@@ -42,7 +42,7 @@ vi.mock("../utils/webglShaders", () => ({
 }));
 
 import { useBackgroundEffects } from "./useBackgroundEffects";
-import { mergeReacquiredMedia, useMediaControls } from "./useMediaControls";
+import { useMediaControls } from "./useMediaControls";
 import { toast } from "frappe-ui";
 import {
 	cameraEnabled,
@@ -50,6 +50,7 @@ import {
 	noiseCancellationEnabled,
 	selectedCameraId,
 	selectedMicId,
+	selectedSpeakerId,
 	setCameraEnabled,
 	setMicEnabled,
 	setSelectedCameraId,
@@ -169,7 +170,7 @@ interface TestVideoProducer {
 interface CameraMediaStateOverrides {
 	isMicOn?: boolean;
 	isCameraOn?: boolean;
-	localStream?: FakeMediaStream;
+	localStream?: FakeMediaStream | null;
 	processedStream?: FakeMediaStream | null;
 	screenShareStream?: FakeMediaStream | null;
 	screenShareStreams?: Record<string, FakeMediaStream>;
@@ -229,12 +230,14 @@ function createCameraHarness({
 		videoProducer,
 		screenProducer: null,
 		localStream: new FakeMediaStream(),
-		setProducers: vi.fn((producers: {
-			audioProducer?: TestVideoProducer;
-			videoProducer?: TestVideoProducer;
-		}) => {
-			Object.assign(mediaHandler, producers);
-		}),
+		setProducers: vi.fn(
+			(producers: {
+				audioProducer?: TestVideoProducer;
+				videoProducer?: TestVideoProducer;
+			}) => {
+				Object.assign(mediaHandler, producers);
+			},
+		),
 		stopScreenShare: vi.fn(),
 		cleanup: vi.fn(),
 	};
@@ -282,12 +285,31 @@ function createCameraHarness({
 				stream: MediaStream,
 				options: { publishVideo?: boolean; publishAudio?: boolean },
 			) => {
-				if (!options.publishVideo) return;
-				const track = stream.getVideoTracks()[0] ?? null;
-				setLocalMediaTrack("video", track);
-				if (!track) return;
-				const producer = await createTestProducer(track, { type: "camera" });
-				mediaHandler.setProducers({ videoProducer: producer });
+				const result: {
+					videoProducer?: TestVideoProducer;
+					audioProducer?: TestVideoProducer;
+				} = {};
+				if (options.publishVideo) {
+					const track = stream.getVideoTracks()[0] ?? null;
+					setLocalMediaTrack("video", track);
+					if (track) {
+						const producer = await createTestProducer(track, { type: "camera" });
+						mediaHandler.setProducers({ videoProducer: producer });
+						result.videoProducer = producer;
+					}
+				}
+				if (options.publishAudio) {
+					const track = stream.getAudioTracks()[0] ?? null;
+					setLocalMediaTrack("audio", track);
+					if (track) {
+						const producer = await createTestProducer(track, {
+							type: "microphone",
+						});
+						mediaHandler.setProducers({ audioProducer: producer });
+						result.audioProducer = producer;
+					}
+				}
+				return result;
 			},
 		);
 	const manager = {
@@ -312,7 +334,8 @@ function createCameraHarness({
 			async (kind: "audio" | "video" | "screen", track: MediaStreamTrack) => {
 				const producer = getProducer(kind);
 				if (!producer) return false;
-				if (!producer.replaceTrack) throw new Error("Producer cannot replace track");
+				if (!producer.replaceTrack)
+					throw new Error("Producer cannot replace track");
 				await producer.replaceTrack({ track });
 				return true;
 			},
@@ -356,7 +379,8 @@ function createCameraHarness({
 				let current = producer;
 				if (current) {
 					if (current.track !== track) {
-						if (!current.replaceTrack) throw new Error("Producer cannot replace track");
+						if (!current.replaceTrack)
+							throw new Error("Producer cannot replace track");
 						await current.replaceTrack({ track });
 					}
 				} else {
@@ -487,6 +511,7 @@ describe("useMediaControls", () => {
 		cameraEnabled.value = false;
 		micEnabled.value = false;
 		noiseCancellationEnabled.value = true;
+		selectedSpeakerId.value = "";
 		selectedCameraId.value = "";
 		selectedMicId.value = "";
 		setAutoFramingPaused(false);
@@ -511,7 +536,9 @@ describe("useMediaControls", () => {
 			1,
 			element,
 		);
-		expect(mediaAttachments.registerLocalPreview).toHaveBeenLastCalledWith(null);
+		expect(mediaAttachments.registerLocalPreview).toHaveBeenLastCalledWith(
+			null,
+		);
 		expect(camera.stop).not.toHaveBeenCalled();
 	});
 
@@ -549,7 +576,9 @@ describe("useMediaControls", () => {
 		controls.setScreenShareVideoRef("local-screen", localElement);
 		controls.setScreenShareVideoRef("consumer-1", remoteElement);
 		await vi.waitFor(() =>
-			expect(mediaAttachments.attachScreenSharePreview).toHaveBeenCalledTimes(2),
+			expect(mediaAttachments.attachScreenSharePreview).toHaveBeenCalledTimes(
+				2,
+			),
 		);
 
 		expect(mediaAttachments.attachScreenSharePreview).toHaveBeenCalledWith(
@@ -575,7 +604,9 @@ describe("useMediaControls", () => {
 		});
 
 		const starting = harness.controls.toggleScreenShare();
-		await vi.waitFor(() => expect(publishScreenTrack).toHaveBeenCalledWith(screenTrack));
+		await vi.waitFor(() =>
+			expect(publishScreenTrack).toHaveBeenCalledWith(screenTrack),
+		);
 		await harness.controls.toggleScreenShare();
 		publication.resolve(null);
 		await starting;
@@ -666,7 +697,9 @@ describe("useMediaControls", () => {
 
 		const starting = harness.controls.toggleScreenShare();
 		await vi.waitFor(() =>
-			expect(harness.manager.publishScreenTrack).toHaveBeenCalledWith(screenTrack),
+			expect(harness.manager.publishScreenTrack).toHaveBeenCalledWith(
+				screenTrack,
+			),
 		);
 		harness.mediaHandler.screenProducer = {
 			id: "screen-producer",
@@ -702,7 +735,9 @@ describe("useMediaControls", () => {
 
 		const starting = harness.controls.toggleScreenShare();
 		await vi.waitFor(() =>
-			expect(harness.manager.publishScreenTrack).toHaveBeenCalledWith(screenTrack),
+			expect(harness.manager.publishScreenTrack).toHaveBeenCalledWith(
+				screenTrack,
+			),
 		);
 		harness.mediaHandler.screenProducer = {
 			id: "replacement-producer",
@@ -732,9 +767,9 @@ describe("useMediaControls", () => {
 				producer.track = track;
 			}),
 		};
-		const getUserMedia = vi.fn().mockResolvedValue(
-			new FakeMediaStream([nextTrack]),
-		);
+		const getUserMedia = vi
+			.fn()
+			.mockResolvedValue(new FakeMediaStream([nextTrack]));
 		const harness = createCameraHarness({
 			mediaState: {
 				isCameraOn: true,
@@ -747,7 +782,9 @@ describe("useMediaControls", () => {
 		Reflect.set(oldTrack, "readyState", "ended");
 		oldTrack.dispatchEvent(new Event("ended"));
 
-		await vi.waitFor(() => expect(producer.replaceTrack).toHaveBeenCalledOnce());
+		await vi.waitFor(() =>
+			expect(producer.replaceTrack).toHaveBeenCalledOnce(),
+		);
 		expect(
 			(getUserMedia.mock.calls[0][0].video as MediaTrackConstraints).deviceId,
 		).toEqual({ exact: "selected-camera" });
@@ -768,9 +805,9 @@ describe("useMediaControls", () => {
 				producer.track = track;
 			}),
 		};
-		const getUserMedia = vi.fn().mockResolvedValue(
-			new FakeMediaStream([nextTrack]),
-		);
+		const getUserMedia = vi
+			.fn()
+			.mockResolvedValue(new FakeMediaStream([nextTrack]));
 		const harness = createCameraHarness({
 			mediaState: {
 				isMicOn: true,
@@ -788,7 +825,9 @@ describe("useMediaControls", () => {
 		Reflect.set(oldTrack, "readyState", "ended");
 		oldTrack.dispatchEvent(new Event("ended"));
 
-		await vi.waitFor(() => expect(producer.replaceTrack).toHaveBeenCalledOnce());
+		await vi.waitFor(() =>
+			expect(producer.replaceTrack).toHaveBeenCalledOnce(),
+		);
 		expect(
 			(getUserMedia.mock.calls[0][0].audio as MediaTrackConstraints).deviceId,
 		).toEqual({ exact: "selected-mic" });
@@ -822,7 +861,9 @@ describe("useMediaControls", () => {
 		await vi.waitFor(() => expect(harness.state.isCameraOn).toBe(false));
 		expect(setCameraEnabled).toHaveBeenCalledWith(false);
 		expect(producer.close).toHaveBeenCalledOnce();
-		expect(harness.sfuClient.sendMediaControl).toHaveBeenCalledWith("video_off");
+		expect(harness.sfuClient.sendMediaControl).toHaveBeenCalledWith(
+			"video_off",
+		);
 		expect(toast.error).toHaveBeenCalledWith(
 			"Camera stopped and could not be restarted. Check browser permissions and devices.",
 		);
@@ -884,11 +925,15 @@ describe("useMediaControls", () => {
 		});
 
 		noiseCancellationEnabled.value = false;
-		await vi.waitFor(() => expect(producer.replaceTrack).toHaveBeenCalledOnce());
+		await vi.waitFor(() =>
+			expect(producer.replaceTrack).toHaveBeenCalledOnce(),
+		);
 		Reflect.set(freshTrack, "readyState", "ended");
 		freshTrack.dispatchEvent(new Event("ended"));
 
-		await vi.waitFor(() => expect(getUserMedia.mock.calls.length).toBeGreaterThan(1));
+		await vi.waitFor(() =>
+			expect(getUserMedia.mock.calls.length).toBeGreaterThan(1),
+		);
 	});
 
 	it("stops microphone recovery that resolves after unmount", async () => {
@@ -1332,7 +1377,9 @@ describe("useMediaControls", () => {
 		});
 
 		const enabling = harness.controls.toggleMicrophone();
-		await vi.waitFor(() => expect(applyNoiseCancellation).toHaveBeenCalledOnce());
+		await vi.waitFor(() =>
+			expect(applyNoiseCancellation).toHaveBeenCalledOnce(),
+		);
 		harness.mediaHandler.audioProducer = null;
 		processing.resolve({
 			stream: new FakeMediaStream([processedTrack]) as never,
@@ -1348,37 +1395,59 @@ describe("useMediaControls", () => {
 		expect(harness.state.isMicOn).toBe(true);
 	});
 
-	it("does not enable the microphone after its manager is cleared", async () => {
-		const sourceTrack = audioTrack("source");
-		const processedTrack = audioTrack("processed");
-		const processing = deferred<{
-			stream: MediaStream;
-			cleanup: () => void;
-		}>();
-		const applyNoiseCancellation = vi.fn(() => processing.promise);
-		const harness = createCameraHarness({
-			getUserMedia: vi
-				.fn()
-				.mockResolvedValue(new FakeMediaStream([sourceTrack])),
-			noiseCancellation: {
-				applyNoiseCancellation,
-				isProcessing: ref(false),
-				error: ref(null),
-			},
-		});
+	it("settles two immediate microphone toggles from on back to on", async () => {
+		vi.useFakeTimers();
+		try {
+			const acquisition = deferred<MediaStream>();
+			const oldTrack = audioTrack("old-microphone");
+			const nextTrack = audioTrack("next-microphone");
+			const producer: TestVideoProducer = {
+				id: "audio-producer",
+				track: oldTrack,
+				pause: vi.fn(),
+				resume: vi.fn(),
+				replaceTrack: vi.fn(async ({ track }) => {
+					producer.track = track;
+				}),
+			};
+			const harness = createCameraHarness({
+				mediaState: {
+					isMicOn: true,
+					localStream: new FakeMediaStream([oldTrack]),
+				},
+				getUserMedia: vi.fn(() => acquisition.promise),
+				audioProducer: producer,
+				noiseCancellation: {
+					error: ref(null),
+					applyNoiseCancellation: vi.fn(async (stream: MediaStream) => ({
+						stream,
+						cleanup: vi.fn(),
+					})),
+				},
+			});
 
-		const enabling = harness.controls.toggleMicrophone();
-		await vi.waitFor(() => expect(applyNoiseCancellation).toHaveBeenCalledOnce());
-		harness.managerRef.value = null as never;
-		processing.resolve({
-			stream: new FakeMediaStream([processedTrack]) as never,
-			cleanup: vi.fn(),
-		});
-		await enabling;
+			const toggles = Promise.all([
+				harness.controls.toggleMicrophone(),
+				harness.controls.toggleMicrophone(),
+			]);
+			let settled = false;
+			void toggles.then(() => {
+				settled = true;
+			});
+			await vi.advanceTimersByTimeAsync(0);
+			acquisition.resolve(new FakeMediaStream([nextTrack]) as never);
+			await vi.advanceTimersByTimeAsync(100);
 
-		expect(harness.manager.reconcileLocalProducerTrack).not.toHaveBeenCalled();
-		expect(harness.state.isMicOn).toBe(false);
-		expect(processedTrack.enabled).toBe(false);
+			expect(settled).toBe(true);
+			await toggles;
+			expect(harness.state.isMicOn).toBe(true);
+			expect(harness.state.localStream.getAudioTracks()).toEqual([nextTrack]);
+			expect(producer.track).toBe(nextTrack);
+			expect(oldTrack.stop).toHaveBeenCalledOnce();
+			expect(nextTrack.stop).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("closes a microphone publication resumed by a replaced manager", async () => {
@@ -1437,6 +1506,64 @@ describe("useMediaControls", () => {
 		expect(secondTrack.stop).not.toHaveBeenCalled();
 		expect(mediaHandler.videoProducer).toBeNull();
 	});
+
+	it.each(["camera-first", "microphone-first"] as const)(
+		"atomically merges simultaneous first camera and microphone enables ($s)",
+		async (completionOrder) => {
+			const cameraRequest = deferred<MediaStream>();
+			const microphoneRequest = deferred<MediaStream>();
+			const camera = videoTrack("concurrent-camera");
+			const microphone = audioTrack("concurrent-microphone");
+			const getUserMedia = vi.fn((constraints: MediaStreamConstraints) =>
+				constraints.video ? cameraRequest.promise : microphoneRequest.promise,
+			);
+			const harness = createCameraHarness({
+				mediaState: { localStream: null },
+				getUserMedia,
+				noiseCancellation: {
+					error: ref(null),
+					applyNoiseCancellation: vi.fn(async (stream: MediaStream) => ({
+						stream,
+						cleanup: vi.fn(),
+					})),
+				},
+			});
+
+			const enablingCamera = harness.controls.toggleCamera();
+			const enablingMicrophone = harness.controls.toggleMicrophone();
+			await vi.waitFor(() => {
+				expect(
+					getUserMedia.mock.calls.some(([constraints]) => constraints.video),
+				).toBe(true);
+				expect(
+					getUserMedia.mock.calls.some(([constraints]) => constraints.audio),
+				).toBe(true);
+			});
+			if (completionOrder === "camera-first") {
+				cameraRequest.resolve(new FakeMediaStream([camera]) as never);
+				await vi.waitFor(() => expect(harness.state.isCameraOn).toBe(true));
+				microphoneRequest.resolve(new FakeMediaStream([microphone]) as never);
+			} else {
+				microphoneRequest.resolve(new FakeMediaStream([microphone]) as never);
+				await vi.waitFor(() => expect(harness.state.isMicOn).toBe(true));
+				cameraRequest.resolve(new FakeMediaStream([camera]) as never);
+			}
+			await Promise.all([enablingCamera, enablingMicrophone]);
+
+			expect(harness.state.localStream?.getVideoTracks()).toEqual([camera]);
+			expect(harness.state.localStream?.getAudioTracks()).toEqual([microphone]);
+			expect(camera.stop).not.toHaveBeenCalled();
+			expect(microphone.stop).not.toHaveBeenCalled();
+			expect(camera.addEventListener).toHaveBeenCalledWith(
+				"ended",
+				expect.any(Function),
+			);
+			expect(microphone.addEventListener).toHaveBeenCalledWith(
+				"ended",
+				expect.any(Function),
+			);
+		},
+	);
 
 	it("rolls back acquired video when camera producer creation fails", async () => {
 		const candidate = videoTrack("candidate");
@@ -1966,6 +2093,154 @@ describe("useMediaControls", () => {
 		expect(state.localStream.getAudioTracks()).toEqual([healthyAudio]);
 	});
 
+	it("keeps microphone UI and media on when combined E2EE video publication fails", async () => {
+		const oldCamera = videoTrack("old-camera");
+		const oldMicrophone = audioTrack("old-microphone");
+		const nextCamera = videoTrack("next-camera");
+		const nextMicrophone = audioTrack("next-microphone");
+		const videoError = new Error("video publication failed");
+		const harness = createCameraHarness({
+			mediaState: {
+				isCameraOn: true,
+				isMicOn: true,
+				localStream: new FakeMediaStream([oldCamera, oldMicrophone]),
+			},
+			getUserMedia: vi
+				.fn()
+				.mockResolvedValue(new FakeMediaStream([nextCamera, nextMicrophone])),
+			publishMedia: vi.fn().mockResolvedValue({
+				videoError,
+				audioProducer: {
+					id: "audio-producer",
+					track: nextMicrophone,
+				},
+			}),
+		});
+
+		await expect(
+			harness.controls.republishMediaAfterE2EE({
+				needsCamera: true,
+				needsMicrophone: true,
+			}),
+		).rejects.toBe(videoError);
+
+		expect(harness.state.isCameraOn).toBe(false);
+		expect(harness.state.isMicOn).toBe(true);
+		expect(harness.state.localStream.getVideoTracks()).toEqual([]);
+		expect(harness.state.localStream.getAudioTracks()).toEqual([
+			nextMicrophone,
+		]);
+		expect(nextCamera.stop).toHaveBeenCalledOnce();
+		expect(nextMicrophone.stop).not.toHaveBeenCalled();
+		expect(setCameraEnabled).toHaveBeenCalledWith(false);
+		expect(setMicEnabled).not.toHaveBeenCalledWith(false);
+	});
+
+	it("does not treat a falsy typed error as successful E2EE video publication", async () => {
+			const publication = { videoError: null };
+			const oldCamera = videoTrack("old-camera");
+			const nextCamera = videoTrack("next-camera");
+			const harness = createCameraHarness({
+				mediaState: {
+					isCameraOn: true,
+					localStream: new FakeMediaStream([oldCamera]),
+				},
+				getUserMedia: vi
+					.fn()
+					.mockResolvedValue(new FakeMediaStream([nextCamera])),
+				publishMedia: vi.fn().mockResolvedValue(publication),
+			});
+
+			const outcome = await harness.controls
+				.republishMediaAfterE2EE({ needsCamera: true })
+				.then(
+					() => ({ status: "resolved" as const, error: undefined }),
+					(error: unknown) => ({ status: "rejected" as const, error }),
+				);
+
+			expect(outcome.status).toBe("rejected");
+			expect(outcome.error).toBeNull();
+			expect(harness.state.isCameraOn).toBe(false);
+			expect(harness.state.localStream.getVideoTracks()).toEqual([]);
+			expect(nextCamera.stop).toHaveBeenCalledOnce();
+	});
+
+	it("fails when a detached published producer is removed from current manager state", async () => {
+		const oldCamera = videoTrack("old-camera");
+		const nextCamera = videoTrack("next-camera");
+		const detachedProducer = {
+			id: "detached-camera-producer",
+			track: nextCamera,
+		};
+		const harness = createCameraHarness({
+			mediaState: {
+				isCameraOn: true,
+				localStream: new FakeMediaStream([oldCamera]),
+			},
+			getUserMedia: vi
+				.fn()
+				.mockResolvedValue(new FakeMediaStream([nextCamera])),
+			publishMedia: vi.fn().mockResolvedValue({
+				videoProducer: detachedProducer,
+			}),
+		});
+		harness.manager.getLocalProducerState.mockReturnValue(null);
+		harness.manager.reconcileLocalProducerTrack.mockResolvedValue({
+			id: detachedProducer.id,
+			track: nextCamera,
+			paused: false,
+		});
+
+		await expect(
+			harness.controls.republishMediaAfterE2EE({ needsCamera: true }),
+		).rejects.toThrow("Video publication did not create a producer");
+
+		expect(
+			harness.manager.reconcileLocalProducerTrack,
+		).toHaveBeenCalledWith("video", nextCamera, {});
+		expect(harness.state.isCameraOn).toBe(false);
+		expect(nextCamera.stop).toHaveBeenCalledOnce();
+	});
+
+	it("reconciles a stale pre-existing producer to the requested E2EE track", async () => {
+		const oldMicrophone = audioTrack("old-microphone");
+		const nextMicrophone = audioTrack("next-microphone");
+		const replaceTrack = vi.fn(
+			async ({ track }: { track: MediaStreamTrack }) => {
+				producer.track = track;
+			},
+		);
+		const producer: TestVideoProducer = {
+			id: "stale-audio-producer",
+			track: oldMicrophone,
+			replaceTrack,
+			resume: vi.fn(),
+		};
+		const harness = createCameraHarness({
+			mediaState: {
+				isMicOn: true,
+				localStream: new FakeMediaStream([oldMicrophone]),
+			},
+			getUserMedia: vi
+				.fn()
+				.mockResolvedValue(new FakeMediaStream([nextMicrophone])),
+			audioProducer: producer,
+			publishMedia: vi.fn().mockResolvedValue({}),
+		});
+
+		await harness.controls.republishMediaAfterE2EE({ needsMicrophone: true });
+
+		expect(replaceTrack).toHaveBeenCalledWith({ track: nextMicrophone });
+		expect(producer.track).toBe(nextMicrophone);
+		expect(harness.manager.reconcileLocalProducerTrack).toHaveBeenCalledWith(
+			"audio",
+			nextMicrophone,
+			{ resume: true },
+		);
+		expect(harness.state.isMicOn).toBe(true);
+		expect(nextMicrophone.stop).not.toHaveBeenCalled();
+	});
+
 	it("falls back to raw video when public effect replacement fails", async () => {
 		localStorage.setItem("backgroundEffects.blur", "1");
 		const raw = videoTrack("raw");
@@ -2108,6 +2383,30 @@ describe("useMediaControls", () => {
 		expect(setLocalMediaTrack).not.toHaveBeenCalled();
 	});
 
+	it("keeps the selected speaker when device enumeration fails", async () => {
+		selectedSpeakerId.value = "selected-speaker";
+		const enumerationError = new Error("enumeration failed");
+		const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { controls, mediaAttachments } = createCameraHarness({
+			deviceManager: {
+				enumerateDevices: vi.fn().mockRejectedValue(enumerationError),
+				isDeviceAvailable: vi.fn(),
+				getDefaultDevice: vi.fn(),
+				findDeviceById: vi.fn(),
+			},
+		});
+
+		await controls.applySpeakerDevice();
+
+		expect(mediaAttachments.setAudioOutputDevice).toHaveBeenCalledWith(
+			"selected-speaker",
+		);
+		expect(consoleWarn).toHaveBeenCalledWith(
+			"Could not validate speaker device availability:",
+			enumerationError,
+		);
+	});
+
 	it("restores old raw video when an effects camera switch cannot reconcile", async () => {
 		localStorage.setItem("backgroundEffects.blur", "1");
 		selectedCameraId.value = "old-camera";
@@ -2213,60 +2512,6 @@ describe("useMediaControls", () => {
 		expect(mediaHandler.videoProducer).toBeNull();
 		expect(mediaHandler.localStream.getVideoTracks()).toEqual([]);
 		expect(setLocalMediaTrack).toHaveBeenLastCalledWith("video", null);
-	});
-
-	it("drops a camera acquired after camera intent was disabled", () => {
-		const currentAudio = audioTrack("current-audio");
-		const staleCamera = videoTrack("stale-camera");
-		const unrequestedAudio = audioTrack("unrequested-audio");
-		const currentStream = new FakeMediaStream([currentAudio]);
-
-		const result = mergeReacquiredMedia({
-			acquiredStream: new FakeMediaStream([
-				staleCamera,
-				unrequestedAudio,
-			]) as never,
-			currentStream: currentStream as never,
-			requestedCamera: true,
-			requestedMicrophone: false,
-			cameraEnabled: false,
-			microphoneEnabled: true,
-			cameraTrackBeforeRequest: null,
-			microphoneTrackBeforeRequest: currentAudio,
-		});
-
-		expect(result.adoptedCamera).toBe(false);
-		expect(result.adoptedMicrophone).toBe(false);
-		expect(staleCamera.stop).toHaveBeenCalledOnce();
-		expect(unrequestedAudio.stop).toHaveBeenCalledOnce();
-		expect(currentAudio.stop).not.toHaveBeenCalled();
-		expect(currentStream.getAudioTracks()).toEqual([currentAudio]);
-		expect(currentStream.getVideoTracks()).toEqual([]);
-	});
-
-	it("does not replace a camera restored while acquisition was pending", () => {
-		const currentAudio = audioTrack("current-audio");
-		const restoredCamera = videoTrack("restored-camera");
-		const staleCamera = videoTrack("stale-camera");
-		const currentStream = new FakeMediaStream([currentAudio, restoredCamera]);
-
-		const result = mergeReacquiredMedia({
-			acquiredStream: new FakeMediaStream([staleCamera]) as never,
-			currentStream: currentStream as never,
-			requestedCamera: true,
-			requestedMicrophone: false,
-			cameraEnabled: true,
-			microphoneEnabled: true,
-			cameraTrackBeforeRequest: null,
-			microphoneTrackBeforeRequest: currentAudio,
-		});
-
-		expect(result.adoptedCamera).toBe(false);
-		expect(staleCamera.stop).toHaveBeenCalledOnce();
-		expect(restoredCamera.stop).not.toHaveBeenCalled();
-		expect(currentAudio.stop).not.toHaveBeenCalled();
-		expect(currentStream.getVideoTracks()).toEqual([restoredCamera]);
-		expect(currentStream.getAudioTracks()).toEqual([currentAudio]);
 	});
 
 	it("stops camera media that resolves after its owner unmounts", async () => {
@@ -2627,66 +2872,68 @@ describe("useMediaControls", () => {
 		await vi.waitFor(() => expect(lateTrack.stop).toHaveBeenCalledOnce());
 	});
 
-	it.each([
-		"camera",
-		"microphone",
-	] as const)("silently aborts deferred %s switching during unmount", async (deviceType) => {
-		const acquisition = deferred<MediaStream>();
-		const requestEntered = deferred<void>();
-		const currentTrack =
-			deviceType === "camera"
-				? videoTrack("current-camera")
-				: audioTrack("current-microphone");
-		const lateTrack =
-			deviceType === "camera"
-				? videoTrack("late-camera")
-				: audioTrack("late-microphone");
-		const consoleError = vi
-			.spyOn(console, "error")
-			.mockImplementation(() => {});
-		const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
-		let harness!: ReturnType<typeof createCameraHarness>;
-		const app = createApp(
-			defineComponent({
-				setup() {
-					harness = createCameraHarness({
-						mediaState: {
-							isCameraOn: deviceType === "camera",
-							isMicOn: deviceType === "microphone",
-							localStream: new FakeMediaStream([currentTrack]),
-						},
-						getUserMedia: vi.fn(() => {
-							requestEntered.resolve();
-							return acquisition.promise;
-						}),
-						deviceManager: {
-							enumerateDevices: vi.fn().mockResolvedValue(undefined),
-							isDeviceAvailable: vi.fn(() => true),
-							findDeviceById: vi.fn(),
-						},
-					});
-					return () => null;
-				},
-			}),
-		);
-		app.mount(document.createElement("div"));
+	it.each(["camera", "microphone"] as const)(
+		"silently aborts deferred %s switching during unmount",
+		async (deviceType) => {
+			const acquisition = deferred<MediaStream>();
+			const requestEntered = deferred<void>();
+			const currentTrack =
+				deviceType === "camera"
+					? videoTrack("current-camera")
+					: audioTrack("current-microphone");
+			const lateTrack =
+				deviceType === "camera"
+					? videoTrack("late-camera")
+					: audioTrack("late-microphone");
+			const consoleError = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+			const consoleWarn = vi
+				.spyOn(console, "warn")
+				.mockImplementation(() => {});
+			let harness!: ReturnType<typeof createCameraHarness>;
+			const app = createApp(
+				defineComponent({
+					setup() {
+						harness = createCameraHarness({
+							mediaState: {
+								isCameraOn: deviceType === "camera",
+								isMicOn: deviceType === "microphone",
+								localStream: new FakeMediaStream([currentTrack]),
+							},
+							getUserMedia: vi.fn(() => {
+								requestEntered.resolve();
+								return acquisition.promise;
+							}),
+							deviceManager: {
+								enumerateDevices: vi.fn().mockResolvedValue(undefined),
+								isDeviceAvailable: vi.fn(() => true),
+								findDeviceById: vi.fn(),
+							},
+						});
+						return () => null;
+					},
+				}),
+			);
+			app.mount(document.createElement("div"));
 
-		const switching = harness.controls.switchInputDevice(
-			deviceType,
-			"next-device",
-		);
-		await requestEntered.promise;
-		app.unmount();
-		await expect(switching).resolves.toBeUndefined();
-		await vi.waitFor(() => expect(harness.dispose).toHaveBeenCalledOnce());
+			const switching = harness.controls.switchInputDevice(
+				deviceType,
+				"next-device",
+			);
+			await requestEntered.promise;
+			app.unmount();
+			await expect(switching).resolves.toBeUndefined();
+			await vi.waitFor(() => expect(harness.dispose).toHaveBeenCalledOnce());
 
-		expect(consoleError).not.toHaveBeenCalled();
-		expect(consoleWarn).not.toHaveBeenCalled();
-		expect(toast.error).not.toHaveBeenCalled();
-		expect(toast.warning).not.toHaveBeenCalled();
-		acquisition.resolve(new FakeMediaStream([lateTrack]) as never);
-		await vi.waitFor(() => expect(lateTrack.stop).toHaveBeenCalledOnce());
-	});
+			expect(consoleError).not.toHaveBeenCalled();
+			expect(consoleWarn).not.toHaveBeenCalled();
+			expect(toast.error).not.toHaveBeenCalled();
+			expect(toast.warning).not.toHaveBeenCalled();
+			acquisition.resolve(new FakeMediaStream([lateTrack]) as never);
+			await vi.waitFor(() => expect(lateTrack.stop).toHaveBeenCalledOnce());
+		},
+	);
 
 	it("cancels an acquired camera switch before reconciliation after unmount", async () => {
 		const oldTrack = videoTrack("old-camera");
@@ -3273,7 +3520,9 @@ describe("useMediaControls", () => {
 		await vi.waitFor(() => expect(bitmap.close).toHaveBeenCalledOnce());
 
 		expect(
-			processingContext.drawImage.mock.calls.filter(([source]) => source === bitmap),
+			processingContext.drawImage.mock.calls.filter(
+				([source]) => source === bitmap,
+			),
 		).toHaveLength(1);
 		session.cleanup();
 		await effects.dispose();

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -15,6 +15,12 @@ import {
 	setSelectedSpeakerId,
 } from "../data/mediaPreferences";
 import type { DeviceType, deviceManager } from "../utils/media/DeviceManager";
+import {
+	LocalCaptureSession,
+	type LocalCaptureKindPublicationResult,
+	type LocalCaptureOperation,
+	type MediaDeviceOverrides,
+} from "../utils/media/LocalCaptureSession";
 import type { MediaAttachmentFacade } from "../utils/media/VideoElementManager";
 import notificationContextManager from "../utils/notificationContext";
 import { isMobileDevice } from "../utils/device";
@@ -25,14 +31,6 @@ import type { CurrentUser } from "./useCurrentUser";
 import type { MediaState } from "./useMediaState";
 import type { RaiseHandStore } from "./useRaiseHandStore";
 import type { BackgroundEffectOptions } from "./useBackgroundEffects";
-
-const BLUETOOTH_DEVICE_LABEL_REGEX =
-	/airpods|bluetooth|\bbt\b|wireless|jbl|bose|sony|beats|sennheiser|akg|jabra|anker|skullcandy|shure|bang\s*&\s*olufsen|b\s*&\s*o|marley|skullcandy|logitech\s*bt|plantronics|poly|razer\s*(?:bt|opus)|corsair|steelseries|hyperx|audeze|sennheiser|soundcore|tozo|earfun|earbuds|earbud/i;
-
-const isBluetoothMicLabel = (label: string | undefined): boolean => {
-	if (!label) return false;
-	return BLUETOOTH_DEVICE_LABEL_REGEX.test(label.toLowerCase());
-};
 
 function getCameraVideoConstraints(): MediaTrackConstraints {
 	if (isMobileDevice()) {
@@ -153,123 +151,15 @@ interface MediaControlsAPI {
 		el: HTMLVideoElement | null,
 	) => void;
 	processedStream: MediaStream | null;
+	cleanupLocalMedia: () => Promise<void>;
 }
 
 type ScreenShareStopReason =
-	| "user-click"
-	| "track-ended"
-	| "publish-failed"
-	| "cleanup";
-
-interface MediaDeviceOverrides {
-	cameraDeviceId?: string;
-	micDeviceId?: string;
-}
-
-interface CameraOperation {
-	generation: number;
-	signal: AbortSignal;
-	ownedStreams: Set<MediaStream>;
-}
+	"user-click" | "track-ended" | "publish-failed" | "cleanup";
 
 export interface E2EEMediaRepublishDetail {
 	needsCamera?: boolean;
 	needsMicrophone?: boolean;
-}
-
-interface ReacquiredMediaOptions {
-	acquiredStream: MediaStream;
-	currentStream: MediaStream | null;
-	requestedCamera: boolean;
-	requestedMicrophone: boolean;
-	cameraEnabled: boolean;
-	microphoneEnabled: boolean;
-	cameraTrackBeforeRequest: MediaStreamTrack | null;
-	microphoneTrackBeforeRequest: MediaStreamTrack | null;
-}
-
-export function mergeReacquiredMedia({
-	acquiredStream,
-	currentStream,
-	requestedCamera,
-	requestedMicrophone,
-	cameraEnabled,
-	microphoneEnabled,
-	cameraTrackBeforeRequest,
-	microphoneTrackBeforeRequest,
-}: ReacquiredMediaOptions): {
-	stream: MediaStream;
-	adoptedCamera: boolean;
-	adoptedMicrophone: boolean;
-} {
-	const stream = currentStream ?? new MediaStream();
-	const adoptedTracks = new Set<MediaStreamTrack>();
-	const currentLiveTracks = new Set(
-		stream.getTracks().filter((track) => track.readyState === "live"),
-	);
-	const stoppedTracks = new Set<MediaStreamTrack>();
-	const stopTrack = (track: MediaStreamTrack) => {
-		if (stoppedTracks.has(track)) return;
-		stoppedTracks.add(track);
-		track.stop();
-	};
-	const adoptKind = (
-		kind: "audio" | "video",
-		requested: boolean,
-		enabled: boolean,
-		trackBeforeRequest: MediaStreamTrack | null,
-	) => {
-		const acquiredTracks =
-			kind === "video"
-				? acquiredStream.getVideoTracks()
-				: acquiredStream.getAudioTracks();
-		const candidate = acquiredTracks.find(
-			(track) => track.readyState === "live",
-		);
-		const existingTracks =
-			kind === "video" ? stream.getVideoTracks() : stream.getAudioTracks();
-		const currentLiveTrack = existingTracks.find(
-			(track) => track.readyState === "live",
-		);
-		const newerTrackAppeared =
-			!!currentLiveTrack && currentLiveTrack !== trackBeforeRequest;
-		if (!requested || !enabled || !candidate || newerTrackAppeared) {
-			for (const track of existingTracks) {
-				if (track.readyState !== "live") {
-					stream.removeTrack(track);
-					stopTrack(track);
-				}
-			}
-			return false;
-		}
-
-		for (const track of existingTracks) {
-			stream.removeTrack(track);
-			if (track !== candidate) stopTrack(track);
-		}
-		stream.addTrack(candidate);
-		adoptedTracks.add(candidate);
-		return true;
-	};
-
-	const adoptedCamera = adoptKind(
-		"video",
-		requestedCamera,
-		cameraEnabled,
-		cameraTrackBeforeRequest,
-	);
-	const adoptedMicrophone = adoptKind(
-		"audio",
-		requestedMicrophone,
-		microphoneEnabled,
-		microphoneTrackBeforeRequest,
-	);
-	for (const track of acquiredStream.getTracks()) {
-		if (!adoptedTracks.has(track) && !currentLiveTracks.has(track))
-			stopTrack(track);
-	}
-
-	return { stream, adoptedCamera, adoptedMicrophone };
 }
 
 interface ScreenShareStopExtra {
@@ -302,98 +192,31 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		stream: MediaStream;
 		cleanup: () => void;
 	} | null = null;
-	let cameraTransitionQueue: Promise<unknown> = Promise.resolve();
-	let microphoneTransitionQueue: Promise<unknown> = Promise.resolve();
-	let cameraLifecycleGeneration = 0;
-	const cameraLifecycleAbortController = new AbortController();
-	const lifecycleStoppedTracks = new WeakSet<MediaStreamTrack>();
-	const detachedCameraTracks = new Set<MediaStreamTrack>();
-	let observedCameraTrack: MediaStreamTrack | null = null;
-	let observedMicrophoneTrack: MediaStreamTrack | null = null;
-	let cameraEndedListener: (() => void) | null = null;
-	let microphoneEndedListener: (() => void) | null = null;
-
+	let captureSession!: LocalCaptureSession;
+	type CameraOperation = LocalCaptureOperation;
 	const cameraLifecycleAbort = () =>
-		new DOMException("Camera lifecycle has ended", "AbortError");
-	const createCameraOperation = (): CameraOperation => ({
-		generation: cameraLifecycleGeneration,
-		signal: cameraLifecycleAbortController.signal,
-		ownedStreams: new Set(),
-	});
+		new DOMException("Local capture lifecycle has ended", "AbortError");
+	const createCameraOperation = () => captureSession.createOperation();
 	const isCurrentCameraOperation = (operation: CameraOperation) =>
-		!operation.signal.aborted &&
-		operation.generation === cameraLifecycleGeneration;
+		captureSession.isCurrent(operation);
 	const isCameraLifecycleAbort = (
 		error: unknown,
 		operation?: CameraOperation,
-	) => {
-		const abortError = error as { name?: unknown; message?: unknown } | null;
-		return (
-			abortError?.name === "AbortError" &&
-			((operation?.signal ?? cameraLifecycleAbortController.signal).aborted ||
-				abortError.message === "Camera lifecycle has ended")
-		);
-	};
-	const assertCurrentCameraGeneration = (generation: number) => {
-		if (generation !== cameraLifecycleGeneration) throw cameraLifecycleAbort();
-	};
-	const stopLifecycleTrack = (track: MediaStreamTrack) => {
-		if (lifecycleStoppedTracks.has(track)) return;
-		lifecycleStoppedTracks.add(track);
-		track.stop();
-	};
-	const stopLifecycleStream = (stream: MediaStream) => {
-		for (const track of stream.getTracks()) stopLifecycleTrack(track);
-	};
-	const assertCurrentCameraOperation = (operation?: CameraOperation) => {
-		if (operation && !isCurrentCameraOperation(operation)) {
-			throw cameraLifecycleAbort();
-		}
-	};
-	const ownCameraStream = (operation: CameraOperation, stream: MediaStream) => {
-		operation.ownedStreams.add(stream);
-		if (!isCurrentCameraOperation(operation)) {
-			stopLifecycleStream(stream);
-			throw cameraLifecycleAbort();
-		}
-	};
-	const discardCameraOperationStreams = (operation: CameraOperation) => {
-		for (const stream of operation.ownedStreams) {
-			const tracks = stream.getTracks();
-			for (const track of tracks) {
-				mediaState.localStream?.removeTrack(track);
-				stopLifecycleTrack(track);
-			}
-		}
-		operation.ownedStreams.clear();
-	};
-
-	const enqueueCameraTransition = <T>(
-		operation: () => Promise<T>,
-	): Promise<T> => {
-		const result = cameraTransitionQueue.then(async () => {
-			try {
-				return await operation();
-			} finally {
-				observeLocalTracks();
-			}
-		});
-		cameraTransitionQueue = result.catch(() => undefined);
-		return result;
-	};
-	const enqueueMicrophoneTransition = <T>(
-		operation: () => Promise<T>,
-	): Promise<T> => {
-		const result = microphoneTransitionQueue.then(async () => {
-			try {
-				return await operation();
-			} finally {
-				observeLocalTracks();
-			}
-		});
-		microphoneTransitionQueue = result.catch(() => undefined);
-		return result;
-	};
+	) => captureSession.isLifecycleAbort(error, operation);
+	const assertCurrentCameraOperation = (operation?: CameraOperation) =>
+		captureSession.assertCurrent(operation);
+	const stopLifecycleTrack = (track: MediaStreamTrack) =>
+		captureSession.stopTrack(track);
+	const stopLifecycleStream = (stream: MediaStream) =>
+		captureSession.stopStream(stream);
+	const ownCameraStream = (operation: CameraOperation, stream: MediaStream) =>
+		captureSession.ownStream(operation, stream);
+	const discardCameraOperationStreams = (operation: CameraOperation) =>
+		captureSession.discardOwnedStreams(operation);
+	const enqueueCameraTransition = <T>(operation: () => Promise<T>) =>
+		captureSession.runCameraTransition(operation);
+	const enqueueMicrophoneTransition = <T>(operation: () => Promise<T>) =>
+		captureSession.runMicrophoneTransition(operation);
 
 	const confirmScreenShareOverride = () =>
 		new Promise<boolean>((resolve) => {
@@ -436,12 +259,12 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 	};
 
 	const updateLocalPreview = (stream: MediaStream | null) => {
-		void mediaAttachments.attachLocalPreview(stream).catch((error) =>
-			console.warn("Could not update local preview:", error),
-		);
+		void mediaAttachments
+			.attachLocalPreview(stream)
+			.catch((error) => console.warn("Could not update local preview:", error));
 	};
 
-	const reconcileCameraTrack = async (
+	const reconcileCameraTrackImplementation = async (
 		track: MediaStreamTrack | null,
 		reason: string,
 		createProducerIfMissing = true,
@@ -474,10 +297,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 								previousTrack !== track
 							) {
 								assertCurrentCameraOperation(operation);
-								await manager.replaceLocalProducerTrack(
-									"video",
-									previousTrack,
-								);
+								await manager.replaceLocalProducerTrack("video", previousTrack);
 							}
 							throw new Error(
 								`Camera track ended during reconciliation (${reason})`,
@@ -513,6 +333,192 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		assertCurrentCameraOperation(operation);
 	};
 
+	captureSession = new LocalCaptureSession({
+		capture: (constraints) => navigator.mediaDevices.getUserMedia(constraints),
+		devices: deviceManager,
+		publication: {
+			getOwner: () => sfuManager.value,
+			reconcileCamera: reconcileCameraTrackImplementation,
+			reconcileMicrophone: async (track, resume, operation) => {
+				assertCurrentCameraOperation(operation);
+				const manager = sfuManager.value;
+				if (!manager) return;
+				if (track) {
+					await manager.reconcileLocalProducerTrack("audio", track, { resume });
+				} else {
+					await manager.serializeSendMediaMutation(async () => {
+						assertCurrentCameraOperation(operation);
+						manager.closeLocalProducer("audio");
+						manager.setLocalMediaTrack("audio", null);
+					});
+				}
+				assertCurrentCameraOperation(operation);
+			},
+			publish: async (stream, options) => {
+				const manager = sfuManager.value;
+				if (!manager) return {};
+				const requestedVideoTrack = options.publishVideo
+					? (stream
+							.getVideoTracks()
+							.find((track) => track.readyState === "live") ?? null)
+					: null;
+				const requestedAudioTrack = options.publishAudio
+					? (stream
+							.getAudioTracks()
+							.find((track) => track.readyState === "live") ?? null)
+					: null;
+				const publication = (await manager.publishMedia(stream, options)) ?? {};
+				const producerMatches = (
+					producer: { track?: MediaStreamTrack | null } | null,
+					track: MediaStreamTrack,
+				) =>
+					producer?.track?.readyState === "live" &&
+					(producer.track === track || producer.track.id === track.id);
+				const ensurePublished = async (
+					kind: "video" | "audio",
+					track: MediaStreamTrack | null,
+				): Promise<LocalCaptureKindPublicationResult> => {
+					if (!track) {
+						return {
+							status: "failed",
+							error: new Error(
+								`No live ${kind} track was requested for publication`,
+							),
+						};
+					}
+					const producer = manager.getLocalProducerState(kind);
+					if (!producerMatches(producer, track)) {
+						try {
+							await manager.reconcileLocalProducerTrack(
+								kind,
+								track,
+								kind === "audio" ? { resume: true } : {},
+							);
+						} catch (error) {
+							return { status: "failed", error };
+						}
+					}
+					const currentProducer = manager.getLocalProducerState(kind);
+					if (!currentProducer) {
+						return {
+							status: "failed",
+							error: new Error(
+								`${kind === "video" ? "Video" : "Audio"} publication did not create a producer`,
+							),
+						};
+					}
+					return producerMatches(currentProducer, track)
+						? { status: "published" }
+						: {
+								status: "failed",
+								error: new Error(
+									`${kind === "video" ? "Video" : "Audio"} publication did not publish the requested track`,
+								),
+							};
+				};
+				return {
+					...(options.publishVideo
+						? {
+								video: Object.hasOwn(publication, "videoError")
+									? {
+											status: "failed" as const,
+											error: publication.videoError,
+										}
+									: await ensurePublished(
+											"video",
+											requestedVideoTrack,
+										),
+							}
+						: {}),
+					...(options.publishAudio
+						? {
+								audio: Object.hasOwn(publication, "audioError")
+									? {
+											status: "failed" as const,
+											error: publication.audioError,
+										}
+									: await ensurePublished(
+											"audio",
+											requestedAudioTrack,
+										),
+							}
+						: {}),
+				};
+			},
+		},
+		getLocalStream: () => mediaState.localStream,
+		setLocalStream: (stream) => {
+			mediaState.localStream = stream;
+		},
+		isCameraEnabled: () => mediaState.isCameraOn,
+		isMicrophoneEnabled: () => mediaState.isMicOn,
+		setPermissionGranted: (type) => {
+			if (type === "camera") mediaState.cameraPermissionGranted = true;
+			else mediaState.microphonePermissionGranted = true;
+		},
+		applyCameraEffects: (options) => applyBackgroundEffects(options),
+		cleanupCameraEffects: () => cleanupBackgroundSession(),
+		prepareMicrophone: (stream, operation) =>
+			prepareProcessedAudioTrack(stream, operation),
+		cleanupMicrophoneEffects: () => {
+			noiseCancellationSession?.cleanup();
+			noiseCancellationSession = null;
+		},
+		getEffectiveCameraTrack,
+		getEffectiveMicrophoneTrack: () =>
+			noiseCancellationSession?.stream
+				.getAudioTracks()
+				.find((track) => track.readyState === "live") ??
+			mediaState.localStream
+				?.getAudioTracks()
+				.find((track) => track.readyState === "live") ??
+			null,
+		onLocalStreamChanged: () => {
+			if (mediaState.localVideo) {
+				setLocalVideoRef(mediaState.localVideo as HTMLVideoElement);
+			}
+		},
+		onCameraDisabled: () => {
+			mediaState.isCameraOn = false;
+			setCameraEnabled(false);
+			toast.error("Failed to toggle camera");
+		},
+		onMicrophoneDisabled: () => {
+			mediaState.isMicOn = false;
+			setMicEnabled(false);
+			toast.error("Failed to toggle microphone");
+		},
+		getSelectedDeviceId: (type) =>
+			type === "camera" ? selectedCameraId.value : selectedMicId.value,
+		setSelectedDeviceId: (type, deviceId) => {
+			if (type === "camera") setSelectedCameraId(deviceId);
+			else setSelectedMicId(deviceId);
+		},
+		getCameraConstraints: getCameraVideoConstraints,
+		onCameraTrackEnded: (track) => recoverEndedCameraTrack(track),
+		onMicrophoneTrackEnded: (track) => recoverEndedMicrophoneTrack(track),
+		onTrackRecoveryError: (type, error) =>
+			console.error(
+				type === "camera"
+					? "Camera track recovery failed:"
+					: "Microphone track recovery failed:",
+				error,
+			),
+	});
+
+	const reconcileCameraTrack = (
+		track: MediaStreamTrack | null,
+		reason: string,
+		createProducerIfMissing = true,
+		operation?: CameraOperation,
+	) =>
+		captureSession.reconcileCamera(
+			track,
+			reason,
+			createProducerIfMissing,
+			operation,
+		);
+
 	const cleanupBackgroundSession = () => {
 		try {
 			backgroundSession?.cleanup();
@@ -546,7 +552,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		cleanupBackgroundSession();
 		for (const track of mediaState.localStream?.getVideoTracks() ?? []) {
 			mediaState.localStream?.removeTrack(track);
-			track.stop();
+			stopLifecycleTrack(track);
 		}
 		updateLocalPreview(null);
 		mediaState.isCameraOn = false;
@@ -610,6 +616,15 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			cleanupBackgroundSession();
 			return;
 		}
+		const assertRawTrackCurrent = () => {
+			assertCurrentCameraOperation(operation);
+			if (
+				rawTrack.readyState !== "live" ||
+				!mediaState.localStream?.getVideoTracks().includes(rawTrack)
+			) {
+				throw new Error("Camera source ended during effects startup");
+			}
+		};
 
 		shouldApplyBackgroundEffectsWhenVideoAvailable = false;
 		if (!wantsEffects) {
@@ -636,7 +651,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 					autoFramingPaused: bgEffects.autoFramingPaused,
 					selectedBackgroundImage: bgEffects.selectedImage,
 				});
-				assertCurrentCameraOperation(operation);
+				assertRawTrackCurrent();
 			} else {
 				if (backgroundSession) {
 					await reconcileRawEffectsTrack(
@@ -661,6 +676,13 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 					},
 					operation?.signal,
 				);
+				if (
+					rawTrack.readyState !== "live" ||
+					!mediaState.localStream?.getVideoTracks().includes(rawTrack)
+				) {
+					result.cleanup();
+					throw new Error("Camera source ended during effects startup");
+				}
 				if (operation && !isCurrentCameraOperation(operation)) {
 					result.cleanup();
 					throw cameraLifecycleAbort();
@@ -767,299 +789,26 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 
 	const republishMediaAfterE2EE = (
 		detail: E2EEMediaRepublishDetail = {},
-	): Promise<void> =>
-		enqueueCameraTransition(async () => {
-			const operation = createCameraOperation();
-			assertCurrentCameraOperation(operation);
-			const requestedCamera =
-				detail.needsCamera === true && mediaState.isCameraOn;
-			const requestedMicrophone =
-				detail.needsMicrophone === true && mediaState.isMicOn;
-			if (!requestedCamera && !requestedMicrophone) return;
-			const cameraTrackBeforeRequest =
-				mediaState.localStream
-					?.getVideoTracks()
-					.find((track) => track.readyState === "live") ?? null;
-			const microphoneTrackBeforeRequest =
-				mediaState.localStream
-					?.getAudioTracks()
-					.find((track) => track.readyState === "live") ?? null;
-
-			try {
-				const { stream: acquiredStream } = await acquireUserMedia(
-					requestedCamera,
-					requestedMicrophone,
-					{},
-					operation,
-				);
-				ownCameraStream(operation, acquiredStream);
-				assertCurrentCameraOperation(operation);
-				const { stream, adoptedCamera, adoptedMicrophone } =
-					mergeReacquiredMedia({
-						acquiredStream,
-						currentStream: mediaState.localStream,
-						requestedCamera,
-						requestedMicrophone,
-						cameraEnabled: mediaState.isCameraOn,
-						microphoneEnabled: mediaState.isMicOn,
-						cameraTrackBeforeRequest,
-						microphoneTrackBeforeRequest,
-					});
-				operation.ownedStreams.clear();
-				const adoptedOperationTracks = acquiredStream
-					.getTracks()
-					.filter((track) => stream.getTracks().includes(track));
-				if (adoptedOperationTracks.length > 0) {
-					operation.ownedStreams.add(new MediaStream(adoptedOperationTracks));
-				}
-				assertCurrentCameraOperation(operation);
-				mediaState.localStream = stream;
-				if (adoptedCamera) {
-					assertCurrentCameraOperation(operation);
-					mediaState.cameraPermissionGranted = true;
-					await applyBackgroundEffects({
-						forceRestart: true,
-						createProducerIfMissing: false,
-						recoverPublicationFailure: true,
-						operation,
-					});
-					assertCurrentCameraOperation(operation);
-				}
-				if (adoptedMicrophone) {
-					assertCurrentCameraOperation(operation);
-					mediaState.microphonePermissionGranted = true;
-				}
-				if (mediaState.localVideo) {
-					assertCurrentCameraOperation(operation);
-					setLocalVideoRef(mediaState.localVideo);
-				}
-
-				assertCurrentCameraOperation(operation);
-				const manager = sfuManager.value;
-				if (!manager || (!adoptedCamera && !adoptedMicrophone)) {
-					operation.ownedStreams.clear();
-					return;
-				}
-				const videoTrack = adoptedCamera ? getEffectiveCameraTrack() : null;
-				const audioTrack = adoptedMicrophone
-					? (mediaState.localStream
-							?.getAudioTracks()
-							.find((track) => track.readyState === "live") ?? null)
-					: null;
-				await manager.publishMedia(
-					new MediaStream([
-						...(videoTrack ? [videoTrack] : []),
-						...(audioTrack ? [audioTrack] : []),
-					]),
-					{
-						publishVideo: !!videoTrack,
-						publishAudio: !!audioTrack,
-					},
-				);
-				assertCurrentCameraOperation(operation);
-				operation.ownedStreams.clear();
-			} catch (error) {
-				if (
-					!isCurrentCameraOperation(operation) ||
-					isCameraLifecycleAbort(error, operation)
-				) {
-					discardCameraOperationStreams(operation);
-					return;
-				}
-				throw error;
-			}
-		});
+	): Promise<void> => captureSession.reacquireMediaAfterE2EE(detail);
 
 	const switchSpeaker = async (deviceId: string) => {
 		setSelectedSpeakerId(deviceId);
 		await applySpeakerDevice();
 	};
 
-	const switchMic = async (deviceId: string) => {
-		setSelectedMicId(deviceId);
-		if (!mediaState.isMicOn || !mediaState.localStream) {
-			return;
-		}
+	const switchMic = (deviceId: string) =>
+		captureSession.switchMicrophone(deviceId);
 
-		const { stream: audioOnlyStream } = await acquireUserMedia(false, true, {
-			micDeviceId: deviceId,
-		});
-		const newAudioTrack = audioOnlyStream.getAudioTracks()[0];
-		if (!newAudioTrack) {
-			return;
-		}
-
-		const currentAudioTracks = mediaState.localStream.getAudioTracks();
-		for (const track of currentAudioTracks) {
-			mediaState.localStream.removeTrack(track);
-			track.stop();
-		}
-		mediaState.localStream.addTrack(newAudioTrack);
-
-		if (noiseCancellationSession) {
-			noiseCancellationSession.cleanup();
-			noiseCancellationSession = null;
-		}
-
-		const trackToPublish = await getProcessedAudioTrack(mediaState.localStream);
-		if (!trackToPublish || trackToPublish.readyState !== "live") {
-			return;
-		}
-
-		await sfuManager.value?.reconcileLocalProducerTrack(
-			"audio",
-			trackToPublish,
-			{ resume: true },
-		);
-	};
-
-	const switchCam = async (deviceId: string) => {
-		const operation = createCameraOperation();
-		assertCurrentCameraOperation(operation);
-		if (!mediaState.isCameraOn || !mediaState.localStream) {
-			assertCurrentCameraOperation(operation);
-			setSelectedCameraId(deviceId);
-			return;
-		}
-
-		const oldVideoTracks = mediaState.localStream.getVideoTracks();
-		let videoOnlyStream: MediaStream;
-		try {
-			({ stream: videoOnlyStream } = await acquireUserMedia(
-				true,
-				false,
-				{ cameraDeviceId: deviceId },
-				operation,
-			));
-			ownCameraStream(operation, videoOnlyStream);
-		} catch (error) {
-			if (
-				!isCurrentCameraOperation(operation) ||
-				isCameraLifecycleAbort(error, operation)
-			) {
-				discardCameraOperationStreams(operation);
-				return;
-			}
-			throw error;
-		}
-		const candidateTracks = videoOnlyStream.getVideoTracks();
-		const newVideoTrack = candidateTracks.find(
-			(track) => track.readyState === "live",
-		);
-		if (!newVideoTrack) {
-			for (const track of candidateTracks) track.stop();
-			return;
-		}
-
-		assertCurrentCameraOperation(operation);
-		for (const track of oldVideoTracks) {
-			detachedCameraTracks.add(track);
-			mediaState.localStream.removeTrack(track);
-		}
-		mediaState.localStream.addTrack(newVideoTrack);
-
-		try {
-			await applyBackgroundEffects({ forceRestart: true, operation });
-			assertCurrentCameraOperation(operation);
-
-			for (const track of oldVideoTracks) {
-				track.stop();
-				detachedCameraTracks.delete(track);
-			}
-			assertCurrentCameraOperation(operation);
-			setSelectedCameraId(deviceId);
-			operation.ownedStreams.clear();
-		} catch (error) {
-			if (
-				!isCurrentCameraOperation(operation) ||
-				isCameraLifecycleAbort(error, operation)
-			) {
-				discardCameraOperationStreams(operation);
-				return;
-			}
-			for (const track of oldVideoTracks) {
-				if (track.readyState === "live") {
-					mediaState.localStream.addTrack(track);
-					detachedCameraTracks.delete(track);
-				}
-			}
-			if (!mediaState.isCameraOn) {
-				cleanupBackgroundSession();
-				for (const track of [...candidateTracks, ...oldVideoTracks]) {
-					mediaState.localStream.removeTrack(track);
-					if (track.readyState === "live") track.stop();
-				}
-				throw error;
-			}
-
-			const fallbackTrack = oldVideoTracks.find(
-				(track) => track.readyState === "live",
-			);
-			try {
-				if (!fallbackTrack) throw error;
-				await reconcileCameraTrack(
-					fallbackTrack,
-					"camera-switch-rollback",
-					true,
-					operation,
-				);
-				assertCurrentCameraOperation(operation);
-				cleanupBackgroundSession();
-				for (const track of candidateTracks) {
-					mediaState.localStream.removeTrack(track);
-					track.stop();
-				}
-				operation.ownedStreams.clear();
-			} catch (fallbackError) {
-				if (
-					!isCurrentCameraOperation(operation) ||
-					isCameraLifecycleAbort(fallbackError, operation)
-				) {
-					discardCameraOperationStreams(operation);
-					return;
-				}
-				await reconcileCameraTrack(
-					null,
-					"camera-switch-rollback-failed",
-					true,
-					operation,
-				);
-				assertCurrentCameraOperation(operation);
-				cleanupBackgroundSession();
-				for (const track of candidateTracks) {
-					mediaState.localStream.removeTrack(track);
-					track.stop();
-				}
-				for (const track of oldVideoTracks) {
-					mediaState.localStream.removeTrack(track);
-					track.stop();
-				}
-				assertCurrentCameraOperation(operation);
-				mediaState.isCameraOn = false;
-				assertCurrentCameraOperation(operation);
-				setCameraEnabled(false);
-				assertCurrentCameraOperation(operation);
-				toast.error("Failed to toggle camera");
-				throw fallbackError;
-			}
-			console.warn("Failed to switch camera, restored raw video:", error);
-		}
-
-		assertCurrentCameraOperation(operation);
-		if (localVideo.value) {
-			delete localVideo.value.dataset.sourceStreamId;
-			setLocalVideoRef(localVideo.value);
-		}
-	};
+	const switchCam = (deviceId: string) => captureSession.switchCamera(deviceId);
 
 	const switchInputDevice = async (type: DeviceType, deviceId: string) => {
 		try {
 			if (type === "speaker") {
 				await switchSpeaker(deviceId);
 			} else if (type === "microphone") {
-				await enqueueMicrophoneTransition(() => switchMic(deviceId));
+				await switchMic(deviceId);
 			} else if (type === "camera") {
-				await enqueueCameraTransition(() => switchCam(deviceId));
+				await switchCam(deviceId);
 			}
 		} catch (error) {
 			if (isCameraLifecycleAbort(error)) return;
@@ -1088,7 +837,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				const oldAudioTracks = mediaState.localStream.getAudioTracks();
 				for (const track of oldAudioTracks) {
 					mediaState.localStream.removeTrack(track);
-					track.stop();
+					stopLifecycleTrack(track);
 				}
 				mediaState.localStream.addTrack(freshTrack);
 			}
@@ -1101,26 +850,35 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		}
 	};
 
-	const getProcessedAudioTrack = async (
+	const prepareProcessedAudioTrack = async (
 		stream: MediaStream,
 		operation?: CameraOperation,
 	) => {
 		const originalTrack = stream.getAudioTracks()[0];
-		if (!originalTrack) {
-			return null;
-		}
+		if (!originalTrack) return null;
 
 		if (!prefNoiseCancellationEnabled.value) {
-			if (noiseCancellationSession) {
-				noiseCancellationSession.cleanup();
-				noiseCancellationSession = null;
-			}
-
 			if (originalTrack.readyState === "ended") {
-				return await getFreshMicTrack(operation);
+				const freshTrack = await getFreshMicTrack(operation);
+				if (!freshTrack) return null;
+				return {
+					track: freshTrack,
+					commit: () => {
+						noiseCancellationSession?.cleanup();
+						noiseCancellationSession = null;
+					},
+					discard: () => {},
+				};
 			}
 
-			return originalTrack;
+			return {
+				track: originalTrack,
+				commit: () => {
+					noiseCancellationSession?.cleanup();
+					noiseCancellationSession = null;
+				},
+				discard: () => {},
+			};
 		}
 
 		try {
@@ -1132,309 +890,64 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				stopLifecycleStream(result.stream);
 				throw cameraLifecycleAbort();
 			}
-			noiseCancellationSession = result;
-
 			const processedTrack = result.stream.getAudioTracks()[0];
 			if (processedTrack) {
-				return processedTrack;
+				let settled = false;
+				return {
+					track: processedTrack,
+					commit: () => {
+						if (settled) return;
+						settled = true;
+						noiseCancellationSession?.cleanup();
+						noiseCancellationSession = result;
+					},
+					discard: () => {
+						if (settled) return;
+						settled = true;
+						result.cleanup();
+					},
+				};
 			}
 
 			console.warn("[Noise Cancellation] No processed track returned");
-			return originalTrack;
+			result.cleanup();
+			return {
+				track: originalTrack,
+				commit: () => {},
+				discard: () => {},
+			};
 		} catch (error) {
 			if (isCameraLifecycleAbort(error, operation)) throw error;
 			console.error("[Noise Cancellation] Failed to apply:", error);
-			return originalTrack;
-		}
-	};
-
-	const getValidDeviceId = async (
-		storedDeviceId: string | null,
-		deviceType: DeviceType,
-		cameraGeneration?: number,
-		stagedSelections?: Map<DeviceType, string>,
-	) => {
-		if (!storedDeviceId) return null;
-
-		try {
-			await deviceManager.enumerateDevices();
-			if (cameraGeneration !== undefined) {
-				assertCurrentCameraGeneration(cameraGeneration);
-			}
-
-			if (deviceManager.isDeviceAvailable(storedDeviceId, deviceType)) {
-				return storedDeviceId;
-			}
-
-			const defaultDevice = deviceManager.getDefaultDevice(deviceType);
-			if (defaultDevice) {
-				if (stagedSelections) {
-					stagedSelections.set(deviceType, defaultDevice.deviceId);
-				} else if (deviceType === "camera") {
-					setSelectedCameraId(defaultDevice.deviceId);
-				} else if (deviceType === "microphone") {
-					setSelectedMicId(defaultDevice.deviceId);
-				} else if (deviceType === "speaker") {
-					setSelectedSpeakerId(defaultDevice.deviceId);
-				}
-
-				return defaultDevice.deviceId;
-			}
-
-			if (stagedSelections) {
-				stagedSelections.set(deviceType, "");
-			} else if (deviceType === "camera") {
-				setSelectedCameraId("");
-			} else if (deviceType === "microphone") {
-				setSelectedMicId("");
-			} else if (deviceType === "speaker") {
-				setSelectedSpeakerId("");
-			}
-			return null;
-		} catch (error) {
-			if (isCameraLifecycleAbort(error)) throw error;
-			console.warn(
-				`Could not validate ${deviceType} device availability:`,
-				error,
-			);
-			return storedDeviceId;
-		}
-	};
-
-	const buildMediaConstraints = async (
-		videoEnabled: boolean,
-		audioEnabled: boolean,
-		cameraGeneration: number,
-		stagedSelections: Map<DeviceType, string>,
-	) => {
-		const constraints: MediaStreamConstraints = {};
-
-		const audioConstraints = {
-			channelCount: { ideal: 2 },
-			echoCancellation: true,
-			noiseSuppression: true,
-			autoGainControl: true,
-		};
-
-		if (videoEnabled) {
-			const videoConstraints = getCameraVideoConstraints();
-
-			const validCameraId = await getValidDeviceId(
-				selectedCameraId.value,
-				"camera",
-				cameraGeneration,
-				stagedSelections,
-			);
-			if (validCameraId) {
-				videoConstraints.deviceId = {
-					exact: validCameraId,
-				};
-			}
-			constraints.video = videoConstraints;
-		}
-
-		if (audioEnabled) {
-			const validMicId = await getValidDeviceId(
-				selectedMicId.value,
-				"microphone",
-				cameraGeneration,
-				stagedSelections,
-			);
-			const selectedMic = validMicId
-				? deviceManager.findDeviceById(validMicId, "microphone")
-				: undefined;
-			if (isBluetoothMicLabel(selectedMic?.label)) {
-				audioConstraints.autoGainControl = false;
-			}
-			const mediaAudioConstraints: MediaTrackConstraints = {
-				...audioConstraints,
+			return {
+				track: originalTrack,
+				commit: () => {},
+				discard: () => {},
 			};
-
-			if (validMicId) {
-				mediaAudioConstraints.deviceId = {
-					exact: validMicId,
-				};
-			}
-			constraints.audio = mediaAudioConstraints;
 		}
-
-		return constraints;
 	};
 
-	const acquireUserMedia = async (
+	const getProcessedAudioTrack = async (
+		stream: MediaStream,
+		operation?: CameraOperation,
+	) => {
+		const prepared = await prepareProcessedAudioTrack(stream, operation);
+		prepared?.commit();
+		return prepared?.track ?? null;
+	};
+
+	const acquireUserMedia = (
 		videoEnabled: boolean,
 		audioEnabled: boolean,
 		deviceOverrides: MediaDeviceOverrides = {},
 		operation: CameraOperation = createCameraOperation(),
-	) => {
-		const operationGeneration = operation.generation;
-		const lifecycleSignal = operation.signal;
-		const stagedSelections = new Map<DeviceType, string>();
-		const constraints = await buildMediaConstraints(
+	) =>
+		captureSession.acquireUserMedia(
 			videoEnabled,
 			audioEnabled,
-			operationGeneration,
-			stagedSelections,
+			deviceOverrides,
+			operation,
 		);
-		assertCurrentCameraOperation(operation);
-
-		if (videoEnabled && Object.hasOwn(deviceOverrides, "cameraDeviceId")) {
-			const validCameraId = await getValidDeviceId(
-				deviceOverrides.cameraDeviceId ?? null,
-				"camera",
-				operationGeneration,
-				stagedSelections,
-			);
-			if (validCameraId && typeof constraints.video === "object") {
-				constraints.video.deviceId = {
-					exact: validCameraId,
-				};
-			} else if (typeof constraints.video === "object") {
-				delete constraints.video.deviceId;
-			}
-		}
-
-		if (audioEnabled && Object.hasOwn(deviceOverrides, "micDeviceId")) {
-			const validMicId = await getValidDeviceId(
-				deviceOverrides.micDeviceId ?? null,
-				"microphone",
-				operationGeneration,
-				stagedSelections,
-			);
-			if (validMicId && typeof constraints.audio === "object") {
-				constraints.audio.deviceId = {
-					exact: validMicId,
-				};
-			} else if (typeof constraints.audio === "object") {
-				delete constraints.audio.deviceId;
-			}
-		}
-
-		const requestUserMedia = () => {
-			assertCurrentCameraOperation(operation);
-			const browserRequest = navigator.mediaDevices.getUserMedia(constraints);
-			void browserRequest.then(
-				(requestedStream) => {
-					if (
-						lifecycleSignal.aborted ||
-						operationGeneration !== cameraLifecycleGeneration
-					) {
-						stopLifecycleStream(requestedStream);
-					}
-				},
-				() => {},
-			);
-
-			return new Promise<MediaStream>((resolve, reject) => {
-				const abort = () => reject(cameraLifecycleAbort());
-				lifecycleSignal.addEventListener("abort", abort, { once: true });
-				browserRequest.then(
-					(requestedStream) => {
-						lifecycleSignal.removeEventListener("abort", abort);
-						if (
-							lifecycleSignal.aborted ||
-							operationGeneration !== cameraLifecycleGeneration
-						) {
-							stopLifecycleStream(requestedStream);
-							reject(cameraLifecycleAbort());
-							return;
-						}
-						resolve(requestedStream);
-					},
-					(error) => {
-						lifecycleSignal.removeEventListener("abort", abort);
-						if (
-							lifecycleSignal.aborted ||
-							operationGeneration !== cameraLifecycleGeneration
-						) {
-							reject(cameraLifecycleAbort());
-							return;
-						}
-						reject(error);
-					},
-				);
-			});
-		};
-
-		let stream: MediaStream | null = null;
-		try {
-			stream = await requestUserMedia();
-		} catch (error) {
-			if (isCameraLifecycleAbort(error)) throw error;
-			const isMissingDeviceError = (candidate: unknown) => {
-				const mediaError = candidate as Error & { constraint?: string };
-				return (
-					mediaError.name === "NotFoundError" ||
-					(mediaError.name === "OverconstrainedError" &&
-						mediaError.constraint === "deviceId")
-				);
-			};
-			const audioConstraints =
-				typeof constraints.audio === "object" ? constraints.audio : null;
-			const videoConstraints =
-				typeof constraints.video === "object" ? constraints.video : null;
-			const audioDeviceId = audioConstraints?.deviceId;
-			const videoDeviceId = videoConstraints?.deviceId;
-
-			if (!isMissingDeviceError(error) || (!audioDeviceId && !videoDeviceId)) {
-				throw error;
-			}
-
-			if (audioDeviceId && videoDeviceId) {
-				delete audioConstraints.deviceId;
-				try {
-					stream = await requestUserMedia();
-					stagedSelections.set("microphone", "");
-				} catch (audioFallbackError) {
-					if (isCameraLifecycleAbort(audioFallbackError)) {
-						throw audioFallbackError;
-					}
-					if (!isMissingDeviceError(audioFallbackError)) {
-						throw audioFallbackError;
-					}
-					audioConstraints.deviceId = audioDeviceId;
-					delete videoConstraints.deviceId;
-				}
-
-				if (!stream) {
-					try {
-						stream = await requestUserMedia();
-						stagedSelections.set("camera", "");
-					} catch (videoFallbackError) {
-						if (isCameraLifecycleAbort(videoFallbackError)) {
-							throw videoFallbackError;
-						}
-						if (!isMissingDeviceError(videoFallbackError)) {
-							throw videoFallbackError;
-						}
-						delete audioConstraints.deviceId;
-						stagedSelections.set("microphone", "");
-						stagedSelections.set("camera", "");
-					}
-				}
-			} else if (audioDeviceId) {
-				delete audioConstraints?.deviceId;
-				stagedSelections.set("microphone", "");
-			} else {
-				delete videoConstraints?.deviceId;
-				stagedSelections.set("camera", "");
-			}
-
-			if (!stream) stream = await requestUserMedia();
-		}
-		if (!stream) throw new Error("Media request completed without a stream");
-		if (!isCurrentCameraOperation(operation)) {
-			stopLifecycleStream(stream);
-			throw cameraLifecycleAbort();
-		}
-		for (const [deviceType, deviceId] of stagedSelections) {
-			assertCurrentCameraOperation(operation);
-			if (deviceType === "camera") setSelectedCameraId(deviceId);
-			else if (deviceType === "microphone") setSelectedMicId(deviceId);
-			else if (deviceType === "speaker") setSelectedSpeakerId(deviceId);
-		}
-		return { stream, constraints };
-	};
 
 	const signalMediaDisabled = (kind: "audio" | "video") => {
 		if (!sfuClient.isConnected()) return;
@@ -1449,7 +962,12 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		if (kind === "video") {
 			try {
 				const operation = createCameraOperation();
-				await reconcileCameraTrack(null, "camera-track-ended", false, operation);
+				await reconcileCameraTrack(
+					null,
+					"camera-track-ended",
+					false,
+					operation,
+				);
 			} catch (error) {
 				console.error("Failed to close ended camera publication:", error);
 			}
@@ -1465,14 +983,12 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				"Camera stopped and could not be restarted. Check browser permissions and devices.",
 			);
 		} else {
-			const manager = sfuManager.value;
 			try {
-				if (manager) {
-					await manager.serializeSendMediaMutation(async () => {
-						manager.closeLocalProducer("audio");
-						manager.setLocalMediaTrack("audio", null);
-					});
-				}
+				await captureSession.reconcileMicrophone(
+					null,
+					false,
+					createCameraOperation(),
+				);
 			} catch (error) {
 				console.error("Failed to close ended microphone publication:", error);
 			}
@@ -1493,10 +1009,11 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 
 	const recoverEndedCameraTrack = async (endedTrack: MediaStreamTrack) => {
 		if (
-			cameraLifecycleAbortController.signal.aborted ||
+			captureSession.isDisposed ||
 			!mediaState.isCameraOn ||
 			!mediaState.localStream?.getVideoTracks().includes(endedTrack)
-		) return;
+		)
+			return;
 		try {
 			await switchCam(selectedCameraId.value);
 		} catch (error) {
@@ -1508,61 +1025,13 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 
 	const recoverEndedMicrophoneTrack = async (endedTrack: MediaStreamTrack) => {
 		if (
-			cameraLifecycleAbortController.signal.aborted ||
+			captureSession.isDisposed ||
 			!mediaState.isMicOn ||
 			!mediaState.localStream?.getAudioTracks().includes(endedTrack)
-		) return;
+		)
+			return;
 		try {
-			const currentStream = mediaState.localStream;
-			const operation = createCameraOperation();
-			const { stream: acquiredStream } = await acquireUserMedia(
-				false,
-				true,
-				{ micDeviceId: selectedMicId.value },
-				operation,
-			);
-			ownCameraStream(operation, acquiredStream);
-			assertCurrentCameraOperation(operation);
-			const candidate = acquiredStream
-				.getAudioTracks()
-				.find((track) => track.readyState === "live");
-			if (
-				!candidate ||
-				!isCurrentCameraOperation(operation) ||
-				!mediaState.isMicOn ||
-				mediaState.localStream !== currentStream ||
-				!currentStream.getAudioTracks().includes(endedTrack)
-			) {
-				stopLifecycleStream(acquiredStream);
-				return;
-			}
-
-			for (const track of currentStream.getAudioTracks()) {
-				currentStream.removeTrack(track);
-			}
-			currentStream.addTrack(candidate);
-			noiseCancellationSession?.cleanup();
-			noiseCancellationSession = null;
-			const trackToPublish = await getProcessedAudioTrack(currentStream, operation);
-			assertCurrentCameraOperation(operation);
-			if (!trackToPublish || trackToPublish.readyState !== "live") {
-				throw new Error("No live microphone track available after recovery");
-			}
-
-			assertCurrentCameraOperation(operation);
-			if (!mediaState.isMicOn || candidate.readyState !== "live") {
-				throw new Error("Microphone recovery became stale");
-			}
-			await sfuManager.value?.reconcileLocalProducerTrack(
-				"audio",
-				trackToPublish,
-				{ resume: true },
-			);
-			for (const track of acquiredStream.getTracks()) {
-				if (track !== candidate) stopLifecycleTrack(track);
-			}
-			stopLifecycleTrack(endedTrack);
-			operation.ownedStreams.clear();
+			await switchMic(selectedMicId.value);
 		} catch (error) {
 			if (isCameraLifecycleAbort(error)) return;
 			console.error("Failed to recover ended microphone track:", error);
@@ -1571,65 +1040,24 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		}
 	};
 
-	function observeLocalTracks() {
-		const cameraTrack =
-			mediaState.localStream
-				?.getVideoTracks()
-				.find((track) => track.readyState === "live") ?? null;
-		if (cameraTrack !== observedCameraTrack) {
-			if (observedCameraTrack && cameraEndedListener) {
-				observedCameraTrack.removeEventListener("ended", cameraEndedListener);
-			}
-			observedCameraTrack = cameraTrack;
-			cameraEndedListener = cameraTrack
-				? () => {
-						void enqueueCameraTransition(() =>
-							recoverEndedCameraTrack(cameraTrack),
-						).catch((error) =>
-							console.error("Camera track recovery failed:", error),
-						);
-					}
-				: null;
-			if (cameraTrack && cameraEndedListener) {
-				cameraTrack.addEventListener("ended", cameraEndedListener);
-			}
-		}
-
-		const microphoneTrack =
-			mediaState.localStream
-				?.getAudioTracks()
-				.find((track) => track.readyState === "live") ?? null;
-		if (microphoneTrack !== observedMicrophoneTrack) {
-			if (observedMicrophoneTrack && microphoneEndedListener) {
-				observedMicrophoneTrack.removeEventListener(
-					"ended",
-					microphoneEndedListener,
-				);
-			}
-			observedMicrophoneTrack = microphoneTrack;
-			microphoneEndedListener = microphoneTrack
-				? () => {
-						void enqueueMicrophoneTransition(() =>
-							recoverEndedMicrophoneTrack(microphoneTrack),
-						).catch((error) =>
-							console.error("Microphone track recovery failed:", error),
-						);
-					}
-				: null;
-			if (microphoneTrack && microphoneEndedListener) {
-				microphoneTrack.addEventListener("ended", microphoneEndedListener);
-			}
-		}
-	}
-
 	const applySpeakerDevice = async () => {
-		try {
-			const validSpeakerId = await getValidDeviceId(
-				selectedSpeakerId.value,
-				"speaker",
-			);
+		let validSpeakerId = selectedSpeakerId.value;
+		if (validSpeakerId) {
+			try {
+				await deviceManager.enumerateDevices();
+				if (!deviceManager.isDeviceAvailable(validSpeakerId, "speaker")) {
+					validSpeakerId =
+						deviceManager.getDefaultDevice("speaker")?.deviceId ?? "";
+					setSelectedSpeakerId(validSpeakerId);
+				}
+			} catch (error) {
+				console.warn("Could not validate speaker device availability:", error);
+			}
+		}
 
-			if (validSpeakerId) await mediaAttachments.setAudioOutputDevice(validSpeakerId);
+		try {
+			if (validSpeakerId)
+				await mediaAttachments.setAudioOutputDevice(validSpeakerId);
 		} catch (error) {
 			console.warn("Failed to apply speaker device:", error);
 		}
@@ -1724,123 +1152,15 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 	const toggleMicrophoneImplementation = async () => {
 		try {
 			const enable = !mediaState.isMicOn;
-			const publicationOwner = enable ? sfuManager.value : null;
-			if (enable && !publicationOwner) return;
-			let stream = mediaState.localStream;
 
 			if (enable) {
-				if (!stream) {
-					try {
-						const { stream: nextStream } = await acquireUserMedia(
-							mediaState.isCameraOn,
-							enable,
-						);
-						stream = nextStream;
-						mediaState.localStream = stream;
-						mediaState.cameraPermissionGranted = true;
-						mediaState.microphonePermissionGranted = true;
-					} catch (err) {
-						if (isCameraLifecycleAbort(err)) return;
-						console.error("Failed to get microphone stream:", err);
-						const isPermissionError =
-							(err as Error).name === "NotAllowedError" ||
-							(err as Error).name === "PermissionDeniedError";
-						toast.error(
-							isPermissionError
-								? "Microphone access denied. Enable in browser settings."
-								: "Failed to access microphone",
-						);
-						return;
-					}
-				} else {
-					const hasAudio = stream.getAudioTracks().length > 0;
-					if (!hasAudio) {
-						try {
-							const { stream: audioOnly } = await acquireUserMedia(false, true);
-							const newTrack = audioOnly.getAudioTracks()[0];
-							if (newTrack) {
-								stream.addTrack(newTrack);
-								mediaState.microphonePermissionGranted = true;
-							}
-						} catch (err) {
-							if (isCameraLifecycleAbort(err)) return;
-							console.error("Failed to add audio track:", err);
-							const isPermissionError =
-								(err as Error).name === "NotAllowedError" ||
-								(err as Error).name === "PermissionDeniedError";
-							toast.error(
-								isPermissionError
-									? "Microphone access denied. Enable in browser settings."
-									: "Could not enable microphone",
-							);
-							return;
-						}
-					} else {
-						const at = stream.getAudioTracks()[0];
-						if (at.readyState === "ended") {
-							try {
-								const { stream: audioOnly } = await acquireUserMedia(
-									false,
-									true,
-								);
-								const newTrack = audioOnly.getAudioTracks()[0];
-								if (newTrack) {
-									stream.removeTrack(at);
-									stream.addTrack(newTrack);
-									mediaState.microphonePermissionGranted = true;
-								}
-							} catch (err) {
-								if (isCameraLifecycleAbort(err)) return;
-								console.error("Failed to replace audio track:", err);
-								const isPermissionError =
-									(err as Error).name === "NotAllowedError" ||
-									(err as Error).name === "PermissionDeniedError";
-								toast.error(
-									isPermissionError
-										? "Microphone access denied. Enable in browser settings."
-										: "Could not enable microphone",
-								);
-								return;
-							}
-						} else {
-							at.enabled = true;
-						}
-					}
-				}
-
-				const track = await getProcessedAudioTrack(stream);
-				if (track) {
-					if (sfuManager.value !== publicationOwner) {
-						track.enabled = false;
-						return;
-					}
-					track.enabled = true;
-					await publicationOwner.reconcileLocalProducerTrack("audio", track, {
-						resume: true,
-					});
-					if (sfuManager.value !== publicationOwner) {
-						publicationOwner.closeLocalProducer("audio", {
-							reason: "manager-replaced",
-						});
-						track.enabled = false;
-						const rawAudioTracks = stream.getAudioTracks();
-						for (const audioTrack of rawAudioTracks) {
-							stream.removeTrack(audioTrack);
-							audioTrack.stop();
-						}
-						if (!rawAudioTracks.includes(track)) track.stop();
-						if (noiseCancellationSession) {
-							noiseCancellationSession.cleanup();
-							noiseCancellationSession = null;
-						}
-						return;
-					}
-				}
+				if (!(await captureSession.enableMicrophoneInTransition())) return;
 			} else {
+				const stream = mediaState.localStream;
 				if (stream) {
 					const at = stream.getAudioTracks()[0];
 					if (at) {
-						at.stop();
+						stopLifecycleTrack(at);
 						stream.removeTrack(at);
 					}
 				}
@@ -1899,21 +1219,27 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 					try {
 						const { stream: nextStream } = await acquireUserMedia(
 							true,
-							mediaState.isMicOn,
+							false,
 							{},
 							operation,
 						);
 						ownCameraStream(operation, nextStream);
-						stream = nextStream;
-						assertCurrentCameraOperation(operation);
-						mediaState.localStream = stream;
-						acquiredVideoTracks.push(...stream.getVideoTracks());
+						const newTrack = nextStream
+							.getVideoTracks()
+							.find((track) => track.readyState === "live");
+						if (!newTrack) throw new Error("No live camera track available");
+						const committed = await captureSession.commitLocalTrack(
+							"video",
+							newTrack,
+							operation,
+						);
+						stream = committed.stream;
+						for (const oldTrack of committed.replacedTracks) {
+							stopLifecycleTrack(oldTrack);
+						}
+						acquiredVideoTracks.push(newTrack);
 						assertCurrentCameraOperation(operation);
 						mediaState.cameraPermissionGranted = true;
-						if (mediaState.isMicOn) {
-							assertCurrentCameraOperation(operation);
-							mediaState.microphonePermissionGranted = true;
-						}
 					} catch (err) {
 						if (isCameraLifecycleAbort(err, operation)) throw err;
 						console.error("Failed to get camera stream:", err);
@@ -1946,11 +1272,15 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 							);
 							if (newTrack) {
 								acquiredVideoTracks.push(...newTracks);
-								assertCurrentCameraOperation(operation);
-								for (const oldTrack of stream.getVideoTracks()) {
-									stream.removeTrack(oldTrack);
+								const committed = await captureSession.commitLocalTrack(
+									"video",
+									newTrack,
+									operation,
+								);
+								stream = committed.stream;
+								for (const oldTrack of committed.replacedTracks) {
+									stopLifecycleTrack(oldTrack);
 								}
-								stream.addTrack(newTrack);
 								assertCurrentCameraOperation(operation);
 								mediaState.cameraPermissionGranted = true;
 								if (mediaState.localVideo) {
@@ -1990,12 +1320,12 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				assertCurrentCameraOperation(operation);
 				cleanupBackgroundSession();
 				if (stream) {
-				for (const track of stream.getVideoTracks()) {
-					track.stop();
-					stream.removeTrack(track);
+					for (const track of stream.getVideoTracks()) {
+						stopLifecycleTrack(track);
+						stream.removeTrack(track);
+					}
 				}
-			}
-			updateLocalPreview(null);
+				updateLocalPreview(null);
 			}
 
 			assertCurrentCameraOperation(operation);
@@ -2045,7 +1375,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 				cleanupBackgroundSession();
 				for (const track of acquiredVideoTracks) {
 					mediaState.localStream?.removeTrack(track);
-					track.stop();
+					stopLifecycleTrack(track);
 				}
 				updateLocalPreview(null);
 				assertCurrentCameraOperation(operation);
@@ -2225,9 +1555,9 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		localVideo.value = el;
 		mediaAttachments.registerLocalPreview(el);
 		const stream = mediaState.processedStream || mediaState.localStream;
-		void mediaAttachments.attachLocalPreview(stream).catch((error) =>
-			console.warn("Could not play local preview:", error),
-		);
+		void mediaAttachments
+			.attachLocalPreview(stream)
+			.catch((error) => console.warn("Could not play local preview:", error));
 		mediaState.localVideo = el;
 	}
 
@@ -2290,10 +1620,10 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			}
 			assertCurrentCameraOperation(operation);
 			if (trackToPublish.readyState === "live") {
-				await sfuManager.value?.reconcileLocalProducerTrack(
-					"audio",
+				await captureSession.reconcileMicrophone(
 					trackToPublish,
-					{ resume: true },
+					true,
+					operation,
 				);
 			}
 		}).catch((error) => {
@@ -2320,36 +1650,16 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 		}
 	});
 
-	observeLocalTracks();
-
 	const cleanupLocalMedia = async () => {
-		cameraLifecycleGeneration++;
-		cameraLifecycleAbortController.abort(cameraLifecycleAbort());
 		mediaAttachments.registerLocalPreview(null);
 		void mediaAttachments.attachLocalPreview(null);
 		mediaAttachments.removeScreenSharePreview("local-screen");
 		mediaState.isCameraOn = false;
 		mediaState.isMicOn = false;
 		mediaState.isScreenSharing = false;
-		if (observedCameraTrack && cameraEndedListener) {
-			observedCameraTrack.removeEventListener("ended", cameraEndedListener);
-		}
-		if (observedMicrophoneTrack && microphoneEndedListener) {
-			observedMicrophoneTrack.removeEventListener(
-				"ended",
-				microphoneEndedListener,
-			);
-		}
-
 		if (noiseCancellationSession) {
 			noiseCancellationSession.cleanup();
 			noiseCancellationSession = null;
-		}
-
-		if (mediaState.localStream) {
-			for (const track of mediaState.localStream.getAudioTracks()) {
-				track.stop();
-			}
 		}
 
 		if (mediaState.screenShareStream) {
@@ -2358,34 +1668,23 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			}
 		}
 
-		await enqueueCameraTransition(async () => {
-			try {
-				await reconcileCameraTrack(null, "camera-unmount", false);
-			} finally {
+		await captureSession.dispose(
+			async () => {
 				try {
-					cleanupBackgroundSession();
+					await reconcileCameraTrack(null, "camera-unmount", false);
 				} finally {
-					try {
-						for (const track of mediaState.localStream?.getVideoTracks() ??
-							[]) {
-							try {
-								stopLifecycleTrack(track);
-							} catch {}
-						}
-						for (const track of detachedCameraTracks) {
-							try {
-								stopLifecycleTrack(track);
-							} catch {}
-						}
-						updateLocalPreview(null);
-					} finally {
-						detachedCameraTracks.clear();
-						await backgroundEffects.dispose();
-						updateLocalPreview(null);
-					}
+					cleanupBackgroundSession();
 				}
-			}
-		});
+			},
+			async () => {
+				try {
+					updateLocalPreview(null);
+				} finally {
+					await backgroundEffects.dispose();
+					updateLocalPreview(null);
+				}
+			},
+		);
 	};
 
 	onUnmounted(() => {

--- a/frontend/src/apps/meet/utils/media/LocalCaptureSession.ts
+++ b/frontend/src/apps/meet/utils/media/LocalCaptureSession.ts
@@ -1,0 +1,1436 @@
+import type { DeviceType } from "./DeviceManager";
+
+export interface LocalCaptureDeviceManager {
+	enumerateDevices: () => Promise<void>;
+	isDeviceAvailable: (deviceId: string, deviceType: DeviceType) => boolean;
+	getDefaultDevice: (
+		deviceType: DeviceType,
+	) => { deviceId: string; label?: string } | null;
+	findDeviceById: (
+		deviceId: string,
+		deviceType: DeviceType,
+	) => { label?: string } | undefined;
+}
+
+export interface LocalCaptureOperation {
+	readonly generation: number;
+	readonly signal: AbortSignal;
+	readonly ownedStreams: Set<MediaStream>;
+	publicationOwner?: object | null;
+}
+
+export type LocalCaptureKindPublicationResult =
+	| { status: "published" }
+	| { status: "failed"; error: unknown };
+
+export interface LocalCapturePublicationResult {
+	video?: LocalCaptureKindPublicationResult;
+	audio?: LocalCaptureKindPublicationResult;
+}
+
+export interface PreparedMicrophoneTrack {
+	track: MediaStreamTrack;
+	commit: () => void;
+	discard: () => void;
+}
+
+export interface LocalCapturePublication {
+	getOwner: () => object | null;
+	reconcileCamera: (
+		track: MediaStreamTrack | null,
+		reason: string,
+		createProducerIfMissing: boolean,
+		operation?: LocalCaptureOperation,
+	) => Promise<void>;
+	reconcileMicrophone: (
+		track: MediaStreamTrack | null,
+		resume: boolean,
+		operation?: LocalCaptureOperation,
+	) => Promise<void>;
+	publish: (
+		stream: MediaStream,
+		options: { publishVideo: boolean; publishAudio: boolean },
+	) => Promise<LocalCapturePublicationResult>;
+}
+
+export interface LocalCaptureSessionOptions {
+	capture: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
+	devices: LocalCaptureDeviceManager;
+	publication: LocalCapturePublication;
+	getLocalStream: () => MediaStream | null;
+	setLocalStream: (stream: MediaStream) => void;
+	isCameraEnabled: () => boolean;
+	isMicrophoneEnabled: () => boolean;
+	setPermissionGranted: (type: "camera" | "microphone") => void;
+	applyCameraEffects: (options: {
+		forceRestart?: boolean;
+		createProducerIfMissing?: boolean;
+		recoverPublicationFailure?: boolean;
+		operation: LocalCaptureOperation;
+	}) => Promise<void>;
+	cleanupCameraEffects: () => void;
+	prepareMicrophone: (
+		stream: MediaStream,
+		operation: LocalCaptureOperation,
+	) => Promise<PreparedMicrophoneTrack | null>;
+	cleanupMicrophoneEffects: () => void;
+	getEffectiveCameraTrack: () => MediaStreamTrack | null;
+	getEffectiveMicrophoneTrack: () => MediaStreamTrack | null;
+	onLocalStreamChanged?: () => void;
+	onCameraDisabled: (error: unknown) => void;
+	onMicrophoneDisabled: (error: unknown) => void;
+	getSelectedDeviceId: (type: "camera" | "microphone") => string;
+	setSelectedDeviceId: (
+		type: "camera" | "microphone",
+		deviceId: string,
+	) => void;
+	getCameraConstraints: () => MediaTrackConstraints;
+	onCameraTrackEnded?: (track: MediaStreamTrack) => Promise<void>;
+	onMicrophoneTrackEnded?: (track: MediaStreamTrack) => Promise<void>;
+	onTrackRecoveryError?: (
+		type: "camera" | "microphone",
+		error: unknown,
+	) => void;
+}
+
+export interface MediaDeviceOverrides {
+	cameraDeviceId?: string;
+	micDeviceId?: string;
+}
+
+export interface ReacquireMediaOptions {
+	needsCamera?: boolean;
+	needsMicrophone?: boolean;
+}
+
+interface ReacquiredMediaOptions {
+	acquiredStream: MediaStream;
+	currentStream: MediaStream | null;
+	requestedCamera: boolean;
+	requestedMicrophone: boolean;
+	cameraEnabled: boolean;
+	microphoneEnabled: boolean;
+	cameraTrackBeforeRequest: MediaStreamTrack | null;
+	microphoneTrackBeforeRequest: MediaStreamTrack | null;
+}
+
+const BLUETOOTH_DEVICE_LABEL_REGEX =
+	/airpods|bluetooth|\bbt\b|wireless|jbl|bose|sony|beats|sennheiser|akg|jabra|anker|skullcandy|shure|bang\s*&\s*olufsen|b\s*&\s*o|marley|skullcandy|logitech\s*bt|plantronics|poly|razer\s*(?:bt|opus)|corsair|steelseries|hyperx|audeze|sennheiser|soundcore|tozo|earfun|earbuds|earbud/i;
+
+const isBluetoothMicLabel = (label: string | undefined): boolean =>
+	!!label && BLUETOOTH_DEVICE_LABEL_REGEX.test(label.toLowerCase());
+
+export function mergeReacquiredMedia({
+	acquiredStream,
+	currentStream,
+	requestedCamera,
+	requestedMicrophone,
+	cameraEnabled,
+	microphoneEnabled,
+	cameraTrackBeforeRequest,
+	microphoneTrackBeforeRequest,
+}: ReacquiredMediaOptions): {
+	stream: MediaStream;
+	adoptedCamera: boolean;
+	adoptedMicrophone: boolean;
+} {
+	const stream = currentStream ?? new MediaStream();
+	const adoptedTracks = new Set<MediaStreamTrack>();
+	const currentLiveTracks = new Set(
+		stream.getTracks().filter((track) => track.readyState === "live"),
+	);
+	const stoppedTracks = new Set<MediaStreamTrack>();
+	const stopTrack = (track: MediaStreamTrack) => {
+		if (stoppedTracks.has(track)) return;
+		stoppedTracks.add(track);
+		track.stop();
+	};
+	const adoptKind = (
+		kind: "audio" | "video",
+		requested: boolean,
+		enabled: boolean,
+		trackBeforeRequest: MediaStreamTrack | null,
+	) => {
+		const acquiredTracks =
+			kind === "video"
+				? acquiredStream.getVideoTracks()
+				: acquiredStream.getAudioTracks();
+		const candidate = acquiredTracks.find(
+			(track) => track.readyState === "live",
+		);
+		const existingTracks =
+			kind === "video" ? stream.getVideoTracks() : stream.getAudioTracks();
+		const currentLiveTrack = existingTracks.find(
+			(track) => track.readyState === "live",
+		);
+		const newerTrackAppeared =
+			!!currentLiveTrack && currentLiveTrack !== trackBeforeRequest;
+		if (!requested || !enabled || !candidate || newerTrackAppeared) {
+			for (const track of existingTracks) {
+				if (track.readyState !== "live") {
+					stream.removeTrack(track);
+					stopTrack(track);
+				}
+			}
+			return false;
+		}
+
+		for (const track of existingTracks) {
+			stream.removeTrack(track);
+			if (track !== candidate) stopTrack(track);
+		}
+		stream.addTrack(candidate);
+		adoptedTracks.add(candidate);
+		return true;
+	};
+
+	const adoptedCamera = adoptKind(
+		"video",
+		requestedCamera,
+		cameraEnabled,
+		cameraTrackBeforeRequest,
+	);
+	const adoptedMicrophone = adoptKind(
+		"audio",
+		requestedMicrophone,
+		microphoneEnabled,
+		microphoneTrackBeforeRequest,
+	);
+	for (const track of acquiredStream.getTracks()) {
+		if (!adoptedTracks.has(track) && !currentLiveTracks.has(track))
+			stopTrack(track);
+	}
+
+	return { stream, adoptedCamera, adoptedMicrophone };
+}
+
+export class LocalCaptureSession {
+	private cameraTransitionQueue: Promise<unknown> = Promise.resolve();
+	private microphoneTransitionQueue: Promise<unknown> = Promise.resolve();
+	private streamCommitQueue: Promise<unknown> = Promise.resolve();
+	private lifecycleGeneration = 0;
+	private readonly lifecycleAbortController = new AbortController();
+	private readonly stoppedTracks = new WeakSet<MediaStreamTrack>();
+	private readonly detachedCameraTracks = new Set<MediaStreamTrack>();
+	private observedCameraTrack: MediaStreamTrack | null = null;
+	private observedMicrophoneTrack: MediaStreamTrack | null = null;
+	private cameraEndedListener: (() => void) | null = null;
+	private microphoneEndedListener: (() => void) | null = null;
+	private disposal: Promise<void> | null = null;
+
+	constructor(private readonly options: LocalCaptureSessionOptions) {
+		this.observeLocalTracks();
+	}
+
+	private lifecycleAbort(): DOMException {
+		return new DOMException("Local capture lifecycle has ended", "AbortError");
+	}
+
+	createOperation(): LocalCaptureOperation {
+		const operation: LocalCaptureOperation = {
+			generation: this.lifecycleGeneration,
+			signal: this.lifecycleAbortController.signal,
+			ownedStreams: new Set(),
+		};
+		const owner = this.options.publication.getOwner();
+		if (owner) operation.publicationOwner = owner;
+		return operation;
+	}
+
+	get isDisposed(): boolean {
+		return this.lifecycleAbortController.signal.aborted;
+	}
+
+	isCurrent(operation: LocalCaptureOperation): boolean {
+		return (
+			!operation.signal.aborted &&
+			operation.generation === this.lifecycleGeneration &&
+			(operation.publicationOwner === undefined ||
+				operation.publicationOwner === this.options.publication.getOwner())
+		);
+	}
+
+	isPublicationOwnerReplaced(operation: LocalCaptureOperation): boolean {
+		return (
+			!operation.signal.aborted &&
+			operation.generation === this.lifecycleGeneration &&
+			operation.publicationOwner !== undefined &&
+			operation.publicationOwner !== this.options.publication.getOwner()
+		);
+	}
+
+	isLifecycleAbort(error: unknown, operation?: LocalCaptureOperation): boolean {
+		const candidate = error as { name?: unknown; message?: unknown } | null;
+		return (
+			candidate?.name === "AbortError" &&
+			((operation?.signal ?? this.lifecycleAbortController.signal).aborted ||
+				candidate.message === "Local capture lifecycle has ended")
+		);
+	}
+
+	assertCurrent(operation?: LocalCaptureOperation): void {
+		if (operation && !this.isCurrent(operation)) throw this.lifecycleAbort();
+	}
+
+	assertGeneration(generation: number): void {
+		if (generation !== this.lifecycleGeneration) throw this.lifecycleAbort();
+	}
+
+	runCameraTransition<T>(operation: () => Promise<T>): Promise<T> {
+		const result = this.cameraTransitionQueue.then(async () => {
+			try {
+				return await operation();
+			} finally {
+				this.observeLocalTracks();
+			}
+		});
+		this.cameraTransitionQueue = result.catch(() => undefined);
+		return result;
+	}
+
+	runMicrophoneTransition<T>(operation: () => Promise<T>): Promise<T> {
+		const result = this.microphoneTransitionQueue.then(async () => {
+			try {
+				return await operation();
+			} finally {
+				this.observeLocalTracks();
+			}
+		});
+		this.microphoneTransitionQueue = result.catch(() => undefined);
+		return result;
+	}
+
+	private runCombinedTransition<T>(operation: () => Promise<T>): Promise<T> {
+		const previousCamera = this.cameraTransitionQueue;
+		const previousMicrophone = this.microphoneTransitionQueue;
+		const result = Promise.all([previousCamera, previousMicrophone]).then(
+			async () => {
+				try {
+					return await operation();
+				} finally {
+					this.observeLocalTracks();
+				}
+			},
+		);
+		const settled = result.catch(() => undefined);
+		this.cameraTransitionQueue = settled;
+		this.microphoneTransitionQueue = settled;
+		return result;
+	}
+
+	runStreamCommit<T>(
+		operation: LocalCaptureOperation,
+		commit: () => T,
+	): Promise<T> {
+		const result = this.streamCommitQueue.then(() => {
+			this.assertCurrent(operation);
+			const value = commit();
+			this.assertCurrent(operation);
+			this.observeLocalTracks();
+			return value;
+		});
+		this.streamCommitQueue = result.catch(() => undefined);
+		return result;
+	}
+
+	commitLocalTrack(
+		kind: "audio" | "video",
+		track: MediaStreamTrack,
+		operation: LocalCaptureOperation,
+	): Promise<{ stream: MediaStream; replacedTracks: MediaStreamTrack[] }> {
+		return this.runStreamCommit(operation, () => {
+			if (track.readyState !== "live") {
+				throw new Error(`Cannot commit ended ${kind} track`);
+			}
+			const stream = this.options.getLocalStream() ?? new MediaStream();
+			const replacedTracks =
+				kind === "video" ? stream.getVideoTracks() : stream.getAudioTracks();
+			for (const replacedTrack of replacedTracks) {
+				stream.removeTrack(replacedTrack);
+			}
+			if (!stream.getTracks().includes(track)) stream.addTrack(track);
+			if (this.options.getLocalStream() !== stream) {
+				this.options.setLocalStream(stream);
+			}
+			return { stream, replacedTracks };
+		});
+	}
+
+	stopTrack(track: MediaStreamTrack): void {
+		if (this.stoppedTracks.has(track)) return;
+		this.stoppedTracks.add(track);
+		track.stop();
+	}
+
+	stopStream(stream: MediaStream): void {
+		for (const track of stream.getTracks()) this.stopTrack(track);
+	}
+
+	ownStream(operation: LocalCaptureOperation, stream: MediaStream): void {
+		operation.ownedStreams.add(stream);
+		if (!this.isCurrent(operation)) {
+			this.stopStream(stream);
+			throw this.lifecycleAbort();
+		}
+	}
+
+	releaseOwnedStreams(operation: LocalCaptureOperation): void {
+		operation.ownedStreams.clear();
+	}
+
+	relinquishOwnedStreams(operation: LocalCaptureOperation): void {
+		const sharedTracks = new Set(
+			this.options.getLocalStream()?.getTracks() ?? [],
+		);
+		for (const stream of operation.ownedStreams) {
+			for (const track of stream.getTracks()) {
+				if (!sharedTracks.has(track)) this.stopTrack(track);
+			}
+		}
+		operation.ownedStreams.clear();
+	}
+
+	discardOwnedStreams(operation: LocalCaptureOperation): void {
+		const localStream = this.options.getLocalStream();
+		for (const stream of operation.ownedStreams) {
+			for (const track of stream.getTracks()) {
+				localStream?.removeTrack(track);
+				this.stopTrack(track);
+			}
+		}
+		operation.ownedStreams.clear();
+	}
+
+	detachCameraTrack(track: MediaStreamTrack): void {
+		this.detachedCameraTracks.add(track);
+	}
+
+	releaseDetachedCameraTrack(track: MediaStreamTrack): void {
+		this.detachedCameraTracks.delete(track);
+	}
+
+	async reconcileCamera(
+		track: MediaStreamTrack | null,
+		reason: string,
+		createProducerIfMissing = true,
+		operation?: LocalCaptureOperation,
+	): Promise<void> {
+		this.assertCurrent(operation);
+		if (track && track.readyState !== "live") {
+			throw new Error(`Cannot reconcile ended camera track (${reason})`);
+		}
+		if (operation && operation.publicationOwner === undefined) {
+			const owner = this.options.publication.getOwner();
+			if (owner) operation.publicationOwner = owner;
+		}
+		await this.options.publication.reconcileCamera(
+			track,
+			reason,
+			createProducerIfMissing,
+			operation,
+		);
+		this.assertCurrent(operation);
+		if (track && track.readyState !== "live") {
+			throw new Error(`Camera track ended during reconciliation (${reason})`);
+		}
+	}
+
+	async publish(
+		stream: MediaStream,
+		options: { publishVideo: boolean; publishAudio: boolean },
+		operation: LocalCaptureOperation,
+	): Promise<LocalCapturePublicationResult> {
+		this.assertCurrent(operation);
+		if (operation.publicationOwner === undefined) {
+			const owner = this.options.publication.getOwner();
+			if (owner) operation.publicationOwner = owner;
+		}
+		if (!operation.publicationOwner) {
+			return {
+				...(options.publishVideo
+					? {
+							video: {
+								status: "failed" as const,
+								error: new Error("Video publication owner is unavailable"),
+							},
+						}
+					: {}),
+				...(options.publishAudio
+					? {
+							audio: {
+								status: "failed" as const,
+								error: new Error("Audio publication owner is unavailable"),
+							},
+						}
+					: {}),
+			};
+		}
+		const published = await this.options.publication.publish(stream, options);
+		this.assertCurrent(operation);
+		const result: LocalCapturePublicationResult = {};
+		if (options.publishVideo) {
+			result.video = stream
+				.getVideoTracks()
+				.some((track) => track.readyState === "live")
+				? (published.video ?? {
+						status: "failed",
+						error: new Error("Video publication did not report an outcome"),
+					})
+				: {
+						status: "failed",
+						error: new Error("Local track ended during publication"),
+					};
+		}
+		if (options.publishAudio) {
+			result.audio = stream
+				.getAudioTracks()
+				.some((track) => track.readyState === "live")
+				? (published.audio ?? {
+						status: "failed",
+						error: new Error("Audio publication did not report an outcome"),
+					})
+				: {
+						status: "failed",
+						error: new Error("Local track ended during publication"),
+					};
+		}
+		return result;
+	}
+
+	async reconcileMicrophone(
+		track: MediaStreamTrack | null,
+		resume: boolean,
+		operation?: LocalCaptureOperation,
+	): Promise<void> {
+		this.assertCurrent(operation);
+		if (track && track.readyState !== "live") {
+			throw new Error("Cannot reconcile ended microphone track");
+		}
+		if (operation && operation.publicationOwner === undefined) {
+			const owner = this.options.publication.getOwner();
+			if (owner) operation.publicationOwner = owner;
+		}
+		await this.options.publication.reconcileMicrophone(
+			track,
+			resume,
+			operation,
+		);
+		this.assertCurrent(operation);
+		if (track && track.readyState !== "live") {
+			throw new Error("Microphone track ended during reconciliation");
+		}
+	}
+
+	async acquireUserMedia(
+		videoEnabled: boolean,
+		audioEnabled: boolean,
+		deviceOverrides: MediaDeviceOverrides = {},
+		operation: LocalCaptureOperation = this.createOperation(),
+	): Promise<{ stream: MediaStream; constraints: MediaStreamConstraints }> {
+		const operationGeneration = operation.generation;
+		const lifecycleSignal = operation.signal;
+		const stagedSelections = new Map<DeviceType, string>();
+		const constraints = await this.buildMediaConstraints(
+			videoEnabled,
+			audioEnabled,
+			operationGeneration,
+			stagedSelections,
+		);
+		this.assertCurrent(operation);
+
+		if (videoEnabled && Object.hasOwn(deviceOverrides, "cameraDeviceId")) {
+			const validCameraId = await this.getValidDeviceId(
+				deviceOverrides.cameraDeviceId ?? null,
+				"camera",
+				operationGeneration,
+				stagedSelections,
+			);
+			if (validCameraId && typeof constraints.video === "object") {
+				constraints.video.deviceId = { exact: validCameraId };
+			} else if (typeof constraints.video === "object") {
+				delete constraints.video.deviceId;
+			}
+		}
+
+		if (audioEnabled && Object.hasOwn(deviceOverrides, "micDeviceId")) {
+			const validMicId = await this.getValidDeviceId(
+				deviceOverrides.micDeviceId ?? null,
+				"microphone",
+				operationGeneration,
+				stagedSelections,
+			);
+			if (validMicId && typeof constraints.audio === "object") {
+				constraints.audio.deviceId = { exact: validMicId };
+			} else if (typeof constraints.audio === "object") {
+				delete constraints.audio.deviceId;
+			}
+		}
+
+		const requestUserMedia = () => {
+			this.assertCurrent(operation);
+			const browserRequest = this.options.capture(constraints);
+			void browserRequest.then(
+				(requestedStream) => {
+					if (
+						lifecycleSignal.aborted ||
+						operationGeneration !== this.lifecycleGeneration
+					) {
+						this.stopStream(requestedStream);
+					}
+				},
+				() => {},
+			);
+
+			return new Promise<MediaStream>((resolve, reject) => {
+				const abort = () => reject(this.lifecycleAbort());
+				lifecycleSignal.addEventListener("abort", abort, { once: true });
+				browserRequest.then(
+					(requestedStream) => {
+						lifecycleSignal.removeEventListener("abort", abort);
+						if (
+							lifecycleSignal.aborted ||
+							operationGeneration !== this.lifecycleGeneration
+						) {
+							this.stopStream(requestedStream);
+							reject(this.lifecycleAbort());
+							return;
+						}
+						resolve(requestedStream);
+					},
+					(error) => {
+						lifecycleSignal.removeEventListener("abort", abort);
+						if (
+							lifecycleSignal.aborted ||
+							operationGeneration !== this.lifecycleGeneration
+						) {
+							reject(this.lifecycleAbort());
+							return;
+						}
+						reject(error);
+					},
+				);
+			});
+		};
+
+		let stream: MediaStream | null = null;
+		try {
+			stream = await requestUserMedia();
+		} catch (error) {
+			if (this.isLifecycleAbort(error, operation)) throw error;
+			const audioConstraints =
+				typeof constraints.audio === "object" ? constraints.audio : null;
+			const videoConstraints =
+				typeof constraints.video === "object" ? constraints.video : null;
+			const audioDeviceId = audioConstraints?.deviceId;
+			const videoDeviceId = videoConstraints?.deviceId;
+
+			if (
+				!this.isMissingDeviceError(error) ||
+				(!audioDeviceId && !videoDeviceId)
+			) {
+				throw error;
+			}
+
+			if (audioDeviceId && videoDeviceId) {
+				delete audioConstraints.deviceId;
+				try {
+					stream = await requestUserMedia();
+					stagedSelections.set("microphone", "");
+				} catch (audioFallbackError) {
+					if (this.isLifecycleAbort(audioFallbackError, operation))
+						throw audioFallbackError;
+					if (!this.isMissingDeviceError(audioFallbackError))
+						throw audioFallbackError;
+					audioConstraints.deviceId = audioDeviceId;
+					delete videoConstraints.deviceId;
+				}
+
+				if (!stream) {
+					try {
+						stream = await requestUserMedia();
+						stagedSelections.set("camera", "");
+					} catch (videoFallbackError) {
+						if (this.isLifecycleAbort(videoFallbackError, operation))
+							throw videoFallbackError;
+						if (!this.isMissingDeviceError(videoFallbackError))
+							throw videoFallbackError;
+						delete audioConstraints.deviceId;
+						stagedSelections.set("microphone", "");
+						stagedSelections.set("camera", "");
+					}
+				}
+			} else if (audioDeviceId) {
+				delete audioConstraints?.deviceId;
+				stagedSelections.set("microphone", "");
+			} else {
+				delete videoConstraints?.deviceId;
+				stagedSelections.set("camera", "");
+			}
+
+			if (!stream) stream = await requestUserMedia();
+		}
+		if (!stream) throw new Error("Media request completed without a stream");
+		if (!this.isCurrent(operation)) {
+			this.stopStream(stream);
+			throw this.lifecycleAbort();
+		}
+		for (const [deviceType, deviceId] of stagedSelections) {
+			this.assertCurrent(operation);
+			if (deviceType !== "speaker") {
+				this.options.setSelectedDeviceId(deviceType, deviceId);
+			}
+		}
+		return { stream, constraints };
+	}
+
+	reacquireMediaAfterE2EE(detail: ReacquireMediaOptions = {}): Promise<void> {
+		const runTransition =
+			detail.needsCamera === true && detail.needsMicrophone === true
+				? this.runCombinedTransition.bind(this)
+				: detail.needsMicrophone === true
+					? this.runMicrophoneTransition.bind(this)
+					: this.runCameraTransition.bind(this);
+		return runTransition(async () => {
+			const operation = this.createOperation();
+			this.assertCurrent(operation);
+			const requestedCamera =
+				detail.needsCamera === true && this.options.isCameraEnabled();
+			const requestedMicrophone =
+				detail.needsMicrophone === true && this.options.isMicrophoneEnabled();
+			if (!requestedCamera && !requestedMicrophone) return;
+			const currentStream = this.options.getLocalStream();
+			const cameraTrackBeforeRequest =
+				currentStream
+					?.getVideoTracks()
+					.find((track) => track.readyState === "live") ?? null;
+			const microphoneTrackBeforeRequest =
+				currentStream
+					?.getAudioTracks()
+					.find((track) => track.readyState === "live") ?? null;
+
+			let adoptedCamera = false;
+			let adoptedMicrophone = false;
+			let acquiredCameraTrack: MediaStreamTrack | null = null;
+			let acquiredMicrophoneTrack: MediaStreamTrack | null = null;
+			const rollbackKind = async (
+				kind: "camera" | "microphone",
+				error: unknown,
+			) => {
+				if (kind === "camera") {
+					try {
+						await this.reconcileCamera(
+							null,
+							"e2ee-publication-failed",
+							false,
+							operation,
+						);
+					} finally {
+						if (this.isCurrent(operation)) {
+							this.options.cleanupCameraEffects();
+							if (acquiredCameraTrack) {
+								this.options.getLocalStream()?.removeTrack(acquiredCameraTrack);
+								this.stopTrack(acquiredCameraTrack);
+							}
+							this.options.onCameraDisabled(error);
+						}
+					}
+				} else {
+					try {
+						await this.reconcileMicrophone(null, false, operation);
+					} finally {
+						if (this.isCurrent(operation)) {
+							this.options.cleanupMicrophoneEffects();
+							if (acquiredMicrophoneTrack) {
+								this.options
+									.getLocalStream()
+									?.removeTrack(acquiredMicrophoneTrack);
+								this.stopTrack(acquiredMicrophoneTrack);
+							}
+							this.options.onMicrophoneDisabled(error);
+						}
+					}
+				}
+			};
+			try {
+				const { stream: acquiredStream } = await this.acquireUserMedia(
+					requestedCamera,
+					requestedMicrophone,
+					{},
+					operation,
+				);
+				this.ownStream(operation, acquiredStream);
+				this.assertCurrent(operation);
+				const merged = mergeReacquiredMedia({
+					acquiredStream,
+					currentStream: this.options.getLocalStream(),
+					requestedCamera,
+					requestedMicrophone,
+					cameraEnabled: this.options.isCameraEnabled(),
+					microphoneEnabled: this.options.isMicrophoneEnabled(),
+					cameraTrackBeforeRequest,
+					microphoneTrackBeforeRequest,
+				});
+				adoptedCamera = merged.adoptedCamera;
+				adoptedMicrophone = merged.adoptedMicrophone;
+				const stream = merged.stream;
+				acquiredCameraTrack = adoptedCamera
+					? (acquiredStream.getVideoTracks()[0] ?? null)
+					: null;
+				acquiredMicrophoneTrack = adoptedMicrophone
+					? (acquiredStream.getAudioTracks()[0] ?? null)
+					: null;
+				operation.ownedStreams.clear();
+				const adoptedTracks = acquiredStream
+					.getTracks()
+					.filter((track) => stream.getTracks().includes(track));
+				if (adoptedTracks.length > 0) {
+					operation.ownedStreams.add(new MediaStream(adoptedTracks));
+				}
+				this.assertCurrent(operation);
+				this.options.setLocalStream(stream);
+				if (adoptedCamera) {
+					this.options.setPermissionGranted("camera");
+					await this.options.applyCameraEffects({
+						forceRestart: true,
+						createProducerIfMissing: false,
+						recoverPublicationFailure: true,
+						operation,
+					});
+					this.assertCurrent(operation);
+				}
+				if (adoptedMicrophone) {
+					this.options.setPermissionGranted("microphone");
+				}
+				this.options.onLocalStreamChanged?.();
+
+				if (!adoptedCamera && !adoptedMicrophone) {
+					operation.ownedStreams.clear();
+					return;
+				}
+				const effectiveVideoTrack = adoptedCamera
+					? this.options.getEffectiveCameraTrack()
+					: null;
+				const effectiveAudioTrack = adoptedMicrophone
+					? this.options.getEffectiveMicrophoneTrack()
+					: null;
+				const videoTrack =
+					effectiveVideoTrack?.readyState === "live" ? effectiveVideoTrack : null;
+				const audioTrack =
+					effectiveAudioTrack?.readyState === "live" ? effectiveAudioTrack : null;
+				let publication: LocalCapturePublicationResult = {
+					...(adoptedCamera && !videoTrack
+						? {
+								video: {
+									status: "failed" as const,
+									error: new Error(
+										"No live effective camera track is available for publication",
+									),
+								},
+							}
+						: {}),
+					...(adoptedMicrophone && !audioTrack
+						? {
+								audio: {
+									status: "failed" as const,
+									error: new Error(
+										"No live effective microphone track is available for publication",
+									),
+								},
+							}
+						: {}),
+				};
+				if (videoTrack || audioTrack) {
+					try {
+						publication = {
+							...publication,
+							...(await this.publish(
+								new MediaStream([
+									...(videoTrack ? [videoTrack] : []),
+									...(audioTrack ? [audioTrack] : []),
+								]),
+								{
+									publishVideo: !!videoTrack,
+									publishAudio: !!audioTrack,
+								},
+								operation,
+							)),
+						};
+					} catch (error) {
+						if (!this.isCurrent(operation)) throw error;
+						const rollbacks: Promise<void>[] = [];
+						if (adoptedCamera) rollbacks.push(rollbackKind("camera", error));
+						if (adoptedMicrophone) {
+							rollbacks.push(rollbackKind("microphone", error));
+						}
+						await Promise.allSettled(rollbacks);
+						operation.ownedStreams.clear();
+						throw error;
+					}
+				}
+
+				const failedKinds: Array<{
+					kind: "camera" | "microphone";
+					error: unknown;
+				}> = [];
+				if (adoptedCamera && publication.video?.status === "failed") {
+					failedKinds.push({
+						kind: "camera",
+						error: publication.video.error,
+					});
+				}
+				if (adoptedMicrophone && publication.audio?.status === "failed") {
+					failedKinds.push({
+						kind: "microphone",
+						error: publication.audio.error,
+					});
+				}
+				if (failedKinds.length > 0) {
+					await Promise.allSettled(
+						failedKinds.map(({ kind, error }) => rollbackKind(kind, error)),
+					);
+					operation.ownedStreams.clear();
+					throw failedKinds.length === 1
+						? failedKinds[0].error
+						: new AggregateError(
+								failedKinds.map(({ error }) => error),
+								"Failed to publish reacquired local media",
+							);
+				}
+				operation.ownedStreams.clear();
+			} catch (error) {
+				if (this.isPublicationOwnerReplaced(operation)) {
+					this.relinquishOwnedStreams(operation);
+					return;
+				}
+				this.discardOwnedStreams(operation);
+				if (
+					!this.isCurrent(operation) ||
+					this.isLifecycleAbort(error, operation)
+				) {
+					return;
+				}
+				throw error;
+			}
+		});
+	}
+
+	switchCamera(deviceId: string): Promise<void> {
+		return this.runCameraTransition(async () => {
+			const operation = this.createOperation();
+			this.assertCurrent(operation);
+			const localStream = this.options.getLocalStream();
+			if (!this.options.isCameraEnabled() || !localStream) {
+				this.options.setSelectedDeviceId("camera", deviceId);
+				return;
+			}
+
+			const oldVideoTracks = localStream.getVideoTracks();
+			let candidateStream: MediaStream;
+			try {
+				({ stream: candidateStream } = await this.acquireUserMedia(
+					true,
+					false,
+					{ cameraDeviceId: deviceId },
+					operation,
+				));
+				this.ownStream(operation, candidateStream);
+			} catch (error) {
+				if (
+					!this.isCurrent(operation) ||
+					this.isLifecycleAbort(error, operation)
+				) {
+					this.discardOwnedStreams(operation);
+					return;
+				}
+				throw error;
+			}
+			const candidateTracks = candidateStream.getVideoTracks();
+			const newVideoTrack = candidateTracks.find(
+				(track) => track.readyState === "live",
+			);
+			if (!newVideoTrack) {
+				this.discardOwnedStreams(operation);
+				return;
+			}
+
+			await this.runStreamCommit(operation, () => {
+				for (const track of oldVideoTracks) {
+					this.detachCameraTrack(track);
+					localStream.removeTrack(track);
+				}
+				localStream.addTrack(newVideoTrack);
+			});
+
+			try {
+				await this.options.applyCameraEffects({
+					forceRestart: true,
+					operation,
+				});
+				this.assertCurrent(operation);
+				if (
+					newVideoTrack.readyState !== "live" ||
+					!this.options
+						.getLocalStream()
+						?.getVideoTracks()
+						.includes(newVideoTrack)
+				) {
+					throw new Error("Camera track ended during effects startup");
+				}
+				for (const track of oldVideoTracks) {
+					this.stopTrack(track);
+					this.releaseDetachedCameraTrack(track);
+				}
+				this.options.setSelectedDeviceId("camera", deviceId);
+				this.releaseOwnedStreams(operation);
+			} catch (error) {
+				if (
+					!this.isCurrent(operation) ||
+					this.isLifecycleAbort(error, operation)
+				) {
+					if (this.isPublicationOwnerReplaced(operation)) {
+						this.relinquishOwnedStreams(operation);
+						const currentTracks = new Set(
+							this.options.getLocalStream()?.getTracks() ?? [],
+						);
+						for (const track of oldVideoTracks) {
+							if (!currentTracks.has(track)) this.stopTrack(track);
+							this.releaseDetachedCameraTrack(track);
+						}
+						return;
+					}
+					this.discardOwnedStreams(operation);
+					if (!operation.signal.aborted) {
+						this.options.cleanupCameraEffects();
+						for (const track of oldVideoTracks) {
+							if (track.readyState === "live") localStream.addTrack(track);
+							this.releaseDetachedCameraTrack(track);
+						}
+						this.options.onLocalStreamChanged?.();
+					}
+					return;
+				}
+				for (const track of oldVideoTracks) {
+					if (track.readyState === "live") {
+						localStream.addTrack(track);
+						this.releaseDetachedCameraTrack(track);
+					}
+				}
+				if (!this.options.isCameraEnabled()) {
+					this.options.cleanupCameraEffects();
+					for (const track of [...candidateTracks, ...oldVideoTracks]) {
+						localStream.removeTrack(track);
+						if (track.readyState === "live") this.stopTrack(track);
+					}
+					throw error;
+				}
+
+				const fallbackTrack = oldVideoTracks.find(
+					(track) => track.readyState === "live",
+				);
+				try {
+					if (!fallbackTrack) throw error;
+					await this.reconcileCamera(
+						fallbackTrack,
+						"camera-switch-rollback",
+						true,
+						operation,
+					);
+					this.options.cleanupCameraEffects();
+					for (const track of candidateTracks) {
+						localStream.removeTrack(track);
+						this.stopTrack(track);
+					}
+					this.releaseOwnedStreams(operation);
+				} catch (fallbackError) {
+					if (
+						!this.isCurrent(operation) ||
+						this.isLifecycleAbort(fallbackError, operation)
+					) {
+						this.discardOwnedStreams(operation);
+						return;
+					}
+					await this.reconcileCamera(
+						null,
+						"camera-switch-rollback-failed",
+						true,
+						operation,
+					);
+					this.options.cleanupCameraEffects();
+					for (const track of [...candidateTracks, ...oldVideoTracks]) {
+						localStream.removeTrack(track);
+						this.stopTrack(track);
+					}
+					this.options.onCameraDisabled(fallbackError);
+					throw fallbackError;
+				}
+				console.warn("Failed to switch camera, restored raw video:", error);
+			}
+
+			this.assertCurrent(operation);
+			this.options.onLocalStreamChanged?.();
+		});
+	}
+
+	switchMicrophone(deviceId: string): Promise<void> {
+		this.options.setSelectedDeviceId("microphone", deviceId);
+		return this.runMicrophoneTransition(async () => {
+			if (!this.options.isMicrophoneEnabled()) return;
+			await this.replaceMicrophone({ micDeviceId: deviceId }, true);
+		});
+	}
+
+	enableMicrophone(): Promise<boolean> {
+		return this.runMicrophoneTransition(() =>
+			this.enableMicrophoneInTransition(),
+		);
+	}
+
+	enableMicrophoneInTransition(): Promise<boolean> {
+		return this.replaceMicrophone({}, false);
+	}
+
+	private async replaceMicrophone(
+		deviceOverrides: MediaDeviceOverrides,
+		wasEnabled: boolean,
+	): Promise<boolean> {
+		const operation = this.createOperation();
+		const previousStream = this.options.getLocalStream();
+		const previousRawTracks = previousStream?.getAudioTracks() ?? [];
+		const previousPublishedTrack = this.options.getEffectiveMicrophoneTrack();
+		let prepared: PreparedMicrophoneTrack | null = null;
+		let preparedSettled = false;
+		let publicationMayHaveChanged = false;
+		const discardPrepared = () => {
+			if (!prepared || preparedSettled) return;
+			preparedSettled = true;
+			const wasEnded = prepared.track.readyState === "ended";
+			try {
+				prepared.discard();
+			} finally {
+				if (!wasEnded && prepared.track.readyState === "ended") {
+					this.stoppedTracks.add(prepared.track);
+				}
+			}
+		};
+
+		try {
+			const { stream: candidateStream } = await this.acquireUserMedia(
+				false,
+				true,
+				deviceOverrides,
+				operation,
+			);
+			this.ownStream(operation, candidateStream);
+			const candidateTrack = candidateStream
+				.getAudioTracks()
+				.find((track) => track.readyState === "live");
+			if (!candidateTrack) {
+				throw new Error("No live microphone track was acquired");
+			}
+
+			prepared = await this.options.prepareMicrophone(
+				candidateStream,
+				operation,
+			);
+			this.assertCurrent(operation);
+			if (!prepared || prepared.track.readyState !== "live") {
+				throw new Error("No live processed microphone track is available");
+			}
+			if (this.options.isMicrophoneEnabled() !== wasEnabled) {
+				throw this.lifecycleAbort();
+			}
+
+			publicationMayHaveChanged = true;
+			await this.reconcileMicrophone(prepared.track, true, operation);
+			const committed = await this.runStreamCommit(operation, () => {
+				if (
+					this.options.isMicrophoneEnabled() !== wasEnabled ||
+					candidateTrack.readyState !== "live" ||
+					prepared?.track.readyState !== "live"
+				) {
+					throw this.lifecycleAbort();
+				}
+				const stream = this.options.getLocalStream() ?? new MediaStream();
+				const currentTracks = stream.getAudioTracks();
+				const newerTrack = currentTracks.find(
+					(track) =>
+						track.readyState === "live" && !previousRawTracks.includes(track),
+				);
+				if (newerTrack) throw this.lifecycleAbort();
+				prepared.commit();
+				preparedSettled = true;
+				for (const track of currentTracks) stream.removeTrack(track);
+				stream.addTrack(candidateTrack);
+				if (this.options.getLocalStream() !== stream) {
+					this.options.setLocalStream(stream);
+				}
+				return { stream, replacedTracks: currentTracks };
+			});
+
+			for (const track of candidateStream.getTracks()) {
+				if (track !== candidateTrack) this.stopTrack(track);
+			}
+			this.releaseOwnedStreams(operation);
+			for (const track of committed.replacedTracks) this.stopTrack(track);
+			this.options.setPermissionGranted("microphone");
+			this.options.onLocalStreamChanged?.();
+			return true;
+		} catch (error) {
+			try {
+				discardPrepared();
+			} catch {}
+			this.discardOwnedStreams(operation);
+			if (
+				publicationMayHaveChanged &&
+				!this.isDisposed &&
+				this.isCurrent(operation)
+			) {
+				const canRestore =
+					this.options.isMicrophoneEnabled() === wasEnabled &&
+					wasEnabled &&
+					previousPublishedTrack?.readyState === "live";
+				let rollbackFailed = false;
+				let rollbackError: unknown;
+				try {
+					if (canRestore) {
+						await this.reconcileMicrophone(
+							previousPublishedTrack,
+							true,
+							operation,
+						);
+					} else {
+						await this.reconcileMicrophone(null, false, operation);
+					}
+				} catch (candidateRollbackError) {
+					if (!this.isCurrent(operation)) return false;
+					rollbackFailed = true;
+					rollbackError = candidateRollbackError;
+					try {
+						await this.reconcileMicrophone(null, false, operation);
+					} catch (clearError) {
+						if (!this.isCurrent(operation)) return false;
+						rollbackError = clearError;
+					}
+				}
+
+				if (!this.isCurrent(operation)) return false;
+				if (!canRestore || rollbackFailed) {
+					this.options.cleanupMicrophoneEffects();
+					for (const track of previousRawTracks) {
+						previousStream?.removeTrack(track);
+						this.stopTrack(track);
+					}
+					this.options.onMicrophoneDisabled(
+						rollbackFailed ? rollbackError : error,
+					);
+				}
+				if (rollbackFailed) throw rollbackError;
+			}
+
+			if (
+				!this.isCurrent(operation) ||
+				this.isLifecycleAbort(error, operation)
+			) {
+				return false;
+			}
+			throw error;
+		}
+	}
+
+	private async getValidDeviceId(
+		storedDeviceId: string | null,
+		deviceType: DeviceType,
+		generation?: number,
+		stagedSelections?: Map<DeviceType, string>,
+	): Promise<string | null> {
+		if (!storedDeviceId) return null;
+
+		try {
+			await this.options.devices.enumerateDevices();
+			if (generation !== undefined) this.assertGeneration(generation);
+
+			if (this.options.devices.isDeviceAvailable(storedDeviceId, deviceType)) {
+				return storedDeviceId;
+			}
+
+			const defaultDevice = this.options.devices.getDefaultDevice(deviceType);
+			const nextDeviceId = defaultDevice?.deviceId ?? "";
+			if (stagedSelections) {
+				stagedSelections.set(deviceType, nextDeviceId);
+			} else if (deviceType !== "speaker") {
+				this.options.setSelectedDeviceId(deviceType, nextDeviceId);
+			}
+			return defaultDevice?.deviceId ?? null;
+		} catch (error) {
+			if (this.isLifecycleAbort(error)) throw error;
+			console.warn(
+				`Could not validate ${deviceType} device availability:`,
+				error,
+			);
+			return storedDeviceId;
+		}
+	}
+
+	private async buildMediaConstraints(
+		videoEnabled: boolean,
+		audioEnabled: boolean,
+		generation: number,
+		stagedSelections: Map<DeviceType, string>,
+	): Promise<MediaStreamConstraints> {
+		const constraints: MediaStreamConstraints = {};
+		if (videoEnabled) {
+			const videoConstraints = this.options.getCameraConstraints();
+			const validCameraId = await this.getValidDeviceId(
+				this.options.getSelectedDeviceId("camera"),
+				"camera",
+				generation,
+				stagedSelections,
+			);
+			if (validCameraId) videoConstraints.deviceId = { exact: validCameraId };
+			constraints.video = videoConstraints;
+		}
+
+		if (audioEnabled) {
+			const validMicId = await this.getValidDeviceId(
+				this.options.getSelectedDeviceId("microphone"),
+				"microphone",
+				generation,
+				stagedSelections,
+			);
+			const selectedMic = validMicId
+				? this.options.devices.findDeviceById(validMicId, "microphone")
+				: undefined;
+			const audioConstraints: MediaTrackConstraints = {
+				channelCount: { ideal: 2 },
+				echoCancellation: true,
+				noiseSuppression: true,
+				autoGainControl: !isBluetoothMicLabel(selectedMic?.label),
+			};
+			if (validMicId) audioConstraints.deviceId = { exact: validMicId };
+			constraints.audio = audioConstraints;
+		}
+		return constraints;
+	}
+
+	private isMissingDeviceError(candidate: unknown): boolean {
+		const error = candidate as Error & { constraint?: string };
+		return (
+			error.name === "NotFoundError" ||
+			(error.name === "OverconstrainedError" && error.constraint === "deviceId")
+		);
+	}
+
+	observeLocalTracks(): void {
+		const stream = this.options.getLocalStream();
+		const cameraTrack =
+			stream?.getVideoTracks().find((track) => track.readyState === "live") ??
+			null;
+		if (cameraTrack !== this.observedCameraTrack) {
+			if (this.observedCameraTrack && this.cameraEndedListener) {
+				this.observedCameraTrack.removeEventListener(
+					"ended",
+					this.cameraEndedListener,
+				);
+			}
+			this.observedCameraTrack = cameraTrack;
+			this.cameraEndedListener = cameraTrack
+				? () => {
+						void this.options
+							.onCameraTrackEnded?.(cameraTrack)
+							.catch((error) =>
+								this.options.onTrackRecoveryError?.("camera", error),
+							);
+					}
+				: null;
+			if (cameraTrack && this.cameraEndedListener) {
+				cameraTrack.addEventListener("ended", this.cameraEndedListener);
+			}
+		}
+
+		const microphoneTrack =
+			stream?.getAudioTracks().find((track) => track.readyState === "live") ??
+			null;
+		if (microphoneTrack !== this.observedMicrophoneTrack) {
+			if (this.observedMicrophoneTrack && this.microphoneEndedListener) {
+				this.observedMicrophoneTrack.removeEventListener(
+					"ended",
+					this.microphoneEndedListener,
+				);
+			}
+			this.observedMicrophoneTrack = microphoneTrack;
+			this.microphoneEndedListener = microphoneTrack
+				? () => {
+						void Promise.resolve()
+							.then(() =>
+								this.options.onMicrophoneTrackEnded?.(microphoneTrack),
+							)
+							.catch((error) =>
+								this.options.onTrackRecoveryError?.("microphone", error),
+							);
+					}
+				: null;
+			if (microphoneTrack && this.microphoneEndedListener) {
+				microphoneTrack.addEventListener("ended", this.microphoneEndedListener);
+			}
+		}
+	}
+
+	private stopObserving(): void {
+		if (this.observedCameraTrack && this.cameraEndedListener) {
+			this.observedCameraTrack.removeEventListener(
+				"ended",
+				this.cameraEndedListener,
+			);
+		}
+		if (this.observedMicrophoneTrack && this.microphoneEndedListener) {
+			this.observedMicrophoneTrack.removeEventListener(
+				"ended",
+				this.microphoneEndedListener,
+			);
+		}
+		this.observedCameraTrack = null;
+		this.observedMicrophoneTrack = null;
+		this.cameraEndedListener = null;
+		this.microphoneEndedListener = null;
+	}
+
+	dispose(
+		beforeStoppingTracks: () => Promise<void>,
+		afterStoppingTracks: () => Promise<void> = async () => {},
+	): Promise<void> {
+		if (this.disposal) return this.disposal;
+		this.lifecycleGeneration++;
+		this.lifecycleAbortController.abort(this.lifecycleAbort());
+		this.stopObserving();
+		this.disposal = Promise.all([
+			this.cameraTransitionQueue,
+			this.microphoneTransitionQueue,
+			this.streamCommitQueue,
+		]).then(async () => {
+			let cleanupError: unknown;
+			try {
+				await beforeStoppingTracks();
+			} catch (error) {
+				cleanupError = error;
+			} finally {
+				for (const track of this.options.getLocalStream()?.getTracks() ?? []) {
+					try {
+						this.stopTrack(track);
+					} catch {}
+				}
+				for (const track of this.detachedCameraTracks) {
+					try {
+						this.stopTrack(track);
+					} catch {}
+				}
+				this.detachedCameraTracks.clear();
+			}
+			try {
+				await afterStoppingTracks();
+			} finally {
+				if (cleanupError) throw cleanupError;
+			}
+		});
+		return this.disposal;
+	}
+}

--- a/frontend/src/apps/meet/utils/media/__tests__/LocalCaptureSession.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/LocalCaptureSession.test.ts
@@ -1,0 +1,1185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	LocalCaptureSession,
+	mergeReacquiredMedia,
+	type LocalCaptureSessionOptions,
+} from "../LocalCaptureSession";
+
+class FakeMediaStream {
+	private tracks: MediaStreamTrack[];
+
+	constructor(tracks: MediaStreamTrack[] = []) {
+		this.tracks = [...tracks];
+	}
+
+	getTracks() {
+		return [...this.tracks];
+	}
+
+	getAudioTracks() {
+		return this.tracks.filter((track) => track.kind === "audio");
+	}
+
+	getVideoTracks() {
+		return this.tracks.filter((track) => track.kind === "video");
+	}
+
+	addTrack(track: MediaStreamTrack) {
+		this.tracks.push(track);
+	}
+
+	removeTrack(track: MediaStreamTrack) {
+		this.tracks = this.tracks.filter((candidate) => candidate !== track);
+	}
+}
+
+function track(id: string, kind: "audio" | "video") {
+	const listeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
+	const value = Object.assign(Object.create(null), {
+		id,
+		kind,
+		enabled: true,
+		readyState: "live",
+		stop: vi.fn(() => {
+			value.readyState = "ended";
+		}),
+		addEventListener: vi.fn(
+			(type: string, listener: EventListenerOrEventListenerObject) => {
+				const handlers = listeners.get(type) ?? new Set();
+				handlers.add(listener);
+				listeners.set(type, handlers);
+			},
+		),
+		removeEventListener: vi.fn(
+			(type: string, listener: EventListenerOrEventListenerObject) => {
+				listeners.get(type)?.delete(listener);
+			},
+		),
+		dispatchEvent: vi.fn((event: Event) => {
+			for (const listener of listeners.get(event.type) ?? []) {
+				if (typeof listener === "function") listener.call(value, event);
+				else listener.handleEvent(event);
+			}
+			return true;
+		}),
+	}) as MediaStreamTrack;
+	return value;
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
+function createHarness(overrides: Partial<LocalCaptureSessionOptions> = {}) {
+	let localStream: MediaStream | null = null;
+	let publicationOwner: object | null = {};
+	const selections = { camera: "", microphone: "" };
+	const capture = vi.fn<LocalCaptureSessionOptions["capture"]>();
+	const reconcileCamera = vi.fn().mockResolvedValue(undefined);
+	const reconcileMicrophone = vi.fn().mockResolvedValue(undefined);
+	const publish = vi.fn<LocalCaptureSessionOptions["publication"]["publish"]>(
+		async (_stream, publicationOptions) => ({
+			...(publicationOptions.publishVideo
+				? { video: { status: "published" as const } }
+				: {}),
+			...(publicationOptions.publishAudio
+				? { audio: { status: "published" as const } }
+				: {}),
+		}),
+	);
+	const options: LocalCaptureSessionOptions = {
+		capture,
+		devices: {
+			enumerateDevices: vi.fn().mockResolvedValue(undefined),
+			isDeviceAvailable: vi.fn(() => true),
+			getDefaultDevice: vi.fn(() => null),
+			findDeviceById: vi.fn(() => undefined),
+		},
+		publication: {
+			getOwner: () => publicationOwner,
+			reconcileCamera,
+			reconcileMicrophone,
+			publish,
+		},
+		getLocalStream: () => localStream,
+		setLocalStream: (stream) => {
+			localStream = stream;
+		},
+		isCameraEnabled: () => true,
+		isMicrophoneEnabled: () => true,
+		setPermissionGranted: vi.fn(),
+		applyCameraEffects: vi.fn().mockResolvedValue(undefined),
+		cleanupCameraEffects: vi.fn(),
+		prepareMicrophone: async (stream) => {
+			const microphone = stream.getAudioTracks()[0];
+			return microphone
+				? { track: microphone, commit: vi.fn(), discard: vi.fn() }
+				: null;
+		},
+		cleanupMicrophoneEffects: vi.fn(),
+		getEffectiveCameraTrack: () =>
+			localStream
+				?.getVideoTracks()
+				.find((item) => item.readyState === "live") ?? null,
+		getEffectiveMicrophoneTrack: () =>
+			localStream
+				?.getAudioTracks()
+				.find((item) => item.readyState === "live") ?? null,
+		onCameraDisabled: vi.fn(),
+		onMicrophoneDisabled: vi.fn(),
+		getSelectedDeviceId: (type) => selections[type],
+		setSelectedDeviceId: (type, deviceId) => {
+			selections[type] = deviceId;
+		},
+		getCameraConstraints: () => ({ width: { ideal: 1280 } }),
+		...overrides,
+	};
+	const session = new LocalCaptureSession(options);
+	return {
+		capture,
+		options,
+		publish,
+		reconcileCamera,
+		reconcileMicrophone,
+		selections,
+		session,
+		setLocalStream: (stream: MediaStream | null) => {
+			localStream = stream;
+			session.observeLocalTracks();
+		},
+		replacePublicationOwner: () => {
+			publicationOwner = {};
+		},
+	};
+}
+
+describe("LocalCaptureSession", () => {
+	beforeEach(() => {
+		vi.stubGlobal("MediaStream", FakeMediaStream);
+	});
+
+	it("stops a stale getUserMedia completion exactly once after disposal", async () => {
+		const request = deferred<MediaStream>();
+		const lateCamera = track("late-camera", "video");
+		const harness = createHarness({ capture: vi.fn(() => request.promise) });
+
+		const acquisition = harness.session.acquireUserMedia(true, false);
+		await vi.waitFor(() =>
+			expect(harness.options.capture).toHaveBeenCalledOnce(),
+		);
+		await harness.session.dispose(async () => {});
+		await expect(acquisition).rejects.toMatchObject({ name: "AbortError" });
+		request.resolve(new FakeMediaStream([lateCamera]) as never);
+
+		await vi.waitFor(() => expect(lateCamera.stop).toHaveBeenCalledOnce());
+		expect(harness.reconcileCamera).not.toHaveBeenCalled();
+	});
+
+	it("serializes rapid camera transitions while microphone work stays independent", async () => {
+		const firstCamera = deferred<void>();
+		const events: string[] = [];
+		const harness = createHarness();
+		const cameraOne = harness.session.runCameraTransition(async () => {
+			events.push("camera-one-start");
+			await firstCamera.promise;
+			events.push("camera-one-end");
+		});
+		const cameraTwo = harness.session.runCameraTransition(async () => {
+			events.push("camera-two");
+		});
+		const microphone = harness.session.runMicrophoneTransition(async () => {
+			events.push("microphone");
+		});
+
+		await microphone;
+		expect(events).toEqual(["camera-one-start", "microphone"]);
+		firstCamera.resolve();
+		await Promise.all([cameraOne, cameraTwo]);
+		expect(events).toEqual([
+			"camera-one-start",
+			"microphone",
+			"camera-one-end",
+			"camera-two",
+		]);
+	});
+
+	it("serializes rapid camera device acquisitions in requested order", async () => {
+		const firstRequest = deferred<MediaStream>();
+		const initialTrack = track("initial-camera", "video");
+		const firstTrack = track("first-camera", "video");
+		const secondTrack = track("second-camera", "video");
+		const capture = vi
+			.fn()
+			.mockReturnValueOnce(firstRequest.promise)
+			.mockResolvedValueOnce(new FakeMediaStream([secondTrack]));
+		const harness = createHarness({ capture });
+		harness.setLocalStream(new FakeMediaStream([initialTrack]) as never);
+
+		const first = harness.session.switchCamera("camera-one");
+		const second = harness.session.switchCamera("camera-two");
+		await vi.waitFor(() => expect(capture).toHaveBeenCalledOnce());
+		firstRequest.resolve(new FakeMediaStream([firstTrack]) as never);
+		await Promise.all([first, second]);
+
+		expect(capture).toHaveBeenCalledTimes(2);
+		expect(
+			(capture.mock.calls[0][0].video as MediaTrackConstraints).deviceId,
+		).toEqual({ exact: "camera-one" });
+		expect(
+			(capture.mock.calls[1][0].video as MediaTrackConstraints).deviceId,
+		).toEqual({ exact: "camera-two" });
+		expect(initialTrack.stop).toHaveBeenCalledOnce();
+		expect(firstTrack.stop).toHaveBeenCalledOnce();
+		expect(secondTrack.stop).not.toHaveBeenCalled();
+		expect(harness.selections.camera).toBe("camera-two");
+	});
+
+	it("drops a camera switch when its publication manager is replaced", async () => {
+		const request = deferred<MediaStream>();
+		const initialTrack = track("initial-camera", "video");
+		const staleTrack = track("stale-camera", "video");
+		const harness = createHarness({ capture: vi.fn(() => request.promise) });
+		harness.setLocalStream(new FakeMediaStream([initialTrack]) as never);
+
+		const switching = harness.session.switchCamera("next-camera");
+		await vi.waitFor(() =>
+			expect(harness.options.capture).toHaveBeenCalledOnce(),
+		);
+		harness.replacePublicationOwner();
+		request.resolve(new FakeMediaStream([staleTrack]) as never);
+		await switching;
+
+		expect(staleTrack.stop).toHaveBeenCalledOnce();
+		expect(initialTrack.stop).not.toHaveBeenCalled();
+		expect(harness.selections.camera).toBe("");
+	});
+
+	it("cancels camera effects work and cleans both tracks on disposal", async () => {
+		const effects = deferred<void>();
+		const initialTrack = track("initial-camera", "video");
+		const candidateTrack = track("candidate-camera", "video");
+		const harness = createHarness({
+			capture: vi.fn().mockResolvedValue(new FakeMediaStream([candidateTrack])),
+			applyCameraEffects: vi.fn(() => effects.promise),
+		});
+		harness.setLocalStream(new FakeMediaStream([initialTrack]) as never);
+
+		const switching = harness.session.switchCamera("next-camera");
+		await vi.waitFor(() =>
+			expect(harness.options.applyCameraEffects).toHaveBeenCalledOnce(),
+		);
+		const disposal = harness.session.dispose(async () => {});
+		effects.resolve();
+		await Promise.all([switching, disposal]);
+
+		expect(candidateTrack.stop).toHaveBeenCalledOnce();
+		expect(initialTrack.stop).toHaveBeenCalledOnce();
+		expect(harness.selections.camera).toBe("");
+	});
+
+	it("relinquishes adopted camera media when its publication manager changes during effects", async () => {
+		const effects = deferred<void>();
+		const initialTrack = track("initial-camera", "video");
+		const candidateTrack = track("candidate-camera", "video");
+		const oldOwner = {};
+		const replacementOwner = {};
+		let owner = oldOwner;
+		const managerTracks = new Map<object, MediaStreamTrack | null>([
+			[oldOwner, initialTrack],
+			[replacementOwner, candidateTrack],
+		]);
+		const cleanupCameraEffects = vi.fn(() => managerTracks.set(owner, null));
+		const harness = createHarness({
+			capture: vi.fn().mockResolvedValue(new FakeMediaStream([candidateTrack])),
+			applyCameraEffects: vi.fn(() => effects.promise),
+			cleanupCameraEffects,
+			publication: {
+				getOwner: () => owner,
+				reconcileCamera: vi.fn(),
+				reconcileMicrophone: vi.fn(),
+				publish: vi.fn().mockResolvedValue({}),
+			},
+		});
+		harness.setLocalStream(new FakeMediaStream([initialTrack]) as never);
+
+		const switching = harness.session.switchCamera("next-camera");
+		await vi.waitFor(() =>
+			expect(harness.options.applyCameraEffects).toHaveBeenCalledOnce(),
+		);
+		owner = replacementOwner;
+		harness.selections.camera = "replacement-camera";
+		effects.resolve();
+		await switching;
+
+		expect(cleanupCameraEffects).not.toHaveBeenCalled();
+		expect(harness.options.onCameraDisabled).not.toHaveBeenCalled();
+		expect(managerTracks.get(replacementOwner)).toBe(candidateTrack);
+		expect(candidateTrack.stop).not.toHaveBeenCalled();
+		expect(initialTrack.stop).toHaveBeenCalledOnce();
+		expect(harness.options.getLocalStream()?.getVideoTracks()).toEqual([
+			candidateTrack,
+		]);
+		expect(harness.selections.camera).toBe("replacement-camera");
+	});
+
+	it("waits for queued microphone work before stopping local tracks", async () => {
+		const releaseMicrophone = deferred<void>();
+		const microphone = track("microphone", "audio");
+		const harness = createHarness();
+		harness.setLocalStream(new FakeMediaStream([microphone]) as never);
+		const transition = harness.session.runMicrophoneTransition(
+			() => releaseMicrophone.promise,
+		);
+		const beforeStoppingTracks = vi.fn();
+
+		const disposal = harness.session.dispose(beforeStoppingTracks);
+		await Promise.resolve();
+		expect(beforeStoppingTracks).not.toHaveBeenCalled();
+		expect(microphone.stop).not.toHaveBeenCalled();
+		releaseMicrophone.resolve();
+		await Promise.all([transition, disposal]);
+
+		expect(beforeStoppingTracks).toHaveBeenCalledOnce();
+		expect(microphone.stop).toHaveBeenCalledOnce();
+	});
+
+	it("drops camera media when camera intent changes during acquisition", async () => {
+		const request = deferred<MediaStream>();
+		const staleCamera = track("stale-camera", "video");
+		let cameraEnabled = true;
+		const harness = createHarness({ capture: vi.fn(() => request.promise) });
+		const transition = harness.session.runCameraTransition(async () => {
+			const operation = harness.session.createOperation();
+			const { stream } = await harness.session.acquireUserMedia(
+				true,
+				false,
+				{},
+				operation,
+			);
+			harness.session.ownStream(operation, stream);
+			if (!cameraEnabled) {
+				harness.session.discardOwnedStreams(operation);
+				return;
+			}
+			throw new Error("stale camera was adopted");
+		});
+
+		await vi.waitFor(() =>
+			expect(harness.options.capture).toHaveBeenCalledOnce(),
+		);
+		cameraEnabled = false;
+		request.resolve(new FakeMediaStream([staleCamera]) as never);
+		await transition;
+
+		expect(staleCamera.stop).toHaveBeenCalledOnce();
+		expect(harness.publish).not.toHaveBeenCalled();
+	});
+
+	it("rejects a camera track that ends while replacement is pending", async () => {
+		const replacement = deferred<void>();
+		const candidate = track("candidate", "video");
+		const owner = {};
+		const harness = createHarness({
+			publication: {
+				getOwner: () => owner,
+				reconcileCamera: vi.fn(() => replacement.promise),
+				reconcileMicrophone: vi.fn(),
+				publish: vi.fn().mockResolvedValue({}),
+			},
+		});
+		const operation = harness.session.createOperation();
+		const reconciliation = harness.session.reconcileCamera(
+			candidate,
+			"device-switch",
+			true,
+			operation,
+		);
+		Reflect.set(candidate, "readyState", "ended");
+		replacement.resolve();
+
+		await expect(reconciliation).rejects.toThrow(
+			"Camera track ended during reconciliation",
+		);
+	});
+
+	it("cancels publication when its manager is replaced", async () => {
+		const publication = deferred<unknown>();
+		const camera = track("e2ee-camera", "video");
+		let owner = {};
+		const harness = createHarness({
+			publication: {
+				getOwner: () => owner,
+				reconcileCamera: vi.fn(),
+				reconcileMicrophone: vi.fn(),
+				publish: vi.fn(() => publication.promise),
+			},
+		});
+		const operation = harness.session.createOperation();
+		const publishing = harness.session.publish(
+			new FakeMediaStream([camera]) as never,
+			{ publishVideo: true, publishAudio: false },
+			operation,
+		);
+		owner = {};
+		publication.resolve({ video: { status: "published" } });
+
+		await expect(publishing).rejects.toMatchObject({ name: "AbortError" });
+	});
+
+	it("relinquishes adopted E2EE media when its publication manager changes during publication", async () => {
+		const publication = deferred<unknown>();
+		const camera = track("replacement-camera", "video");
+		const microphone = track("replacement-microphone", "audio");
+		const oldOwner = {};
+		const replacementOwner = {};
+		let owner = oldOwner;
+		const managerTracks = new Map<
+			object,
+			{ video: MediaStreamTrack | null; audio: MediaStreamTrack | null }
+		>([
+			[oldOwner, { video: null, audio: null }],
+			[replacementOwner, { video: camera, audio: microphone }],
+		]);
+		const reconcileCamera = vi.fn(async (nextTrack: MediaStreamTrack | null) => {
+			managerTracks.get(owner)!.video = nextTrack;
+		});
+		const reconcileMicrophone = vi.fn(
+			async (nextTrack: MediaStreamTrack | null) => {
+				managerTracks.get(owner)!.audio = nextTrack;
+			},
+		);
+		const harness = createHarness({
+			capture: vi
+				.fn()
+				.mockResolvedValue(new FakeMediaStream([camera, microphone])),
+			publication: {
+				getOwner: () => owner,
+				reconcileCamera,
+				reconcileMicrophone,
+				publish: vi.fn(() => publication.promise),
+			},
+		});
+
+		const publishing = harness.session.reacquireMediaAfterE2EE({
+			needsCamera: true,
+			needsMicrophone: true,
+		});
+		await vi.waitFor(() =>
+			expect(harness.options.publication.publish).toHaveBeenCalledOnce(),
+		);
+		owner = replacementOwner;
+		harness.selections.camera = "replacement-camera-device";
+		harness.selections.microphone = "replacement-microphone-device";
+		publication.resolve({
+			video: { status: "published" },
+			audio: { status: "published" },
+		});
+
+		await expect(publishing).resolves.toBeUndefined();
+		expect(camera.stop).not.toHaveBeenCalled();
+		expect(microphone.stop).not.toHaveBeenCalled();
+		expect(harness.options.getLocalStream()?.getTracks()).toEqual([
+			camera,
+			microphone,
+		]);
+		expect(managerTracks.get(replacementOwner)).toEqual({
+			video: camera,
+			audio: microphone,
+		});
+		expect(reconcileCamera).not.toHaveBeenCalled();
+		expect(reconcileMicrophone).not.toHaveBeenCalled();
+		expect(harness.options.cleanupCameraEffects).not.toHaveBeenCalled();
+		expect(harness.options.cleanupMicrophoneEffects).not.toHaveBeenCalled();
+		expect(harness.options.onCameraDisabled).not.toHaveBeenCalled();
+		expect(harness.options.onMicrophoneDisabled).not.toHaveBeenCalled();
+		expect(harness.selections).toEqual({
+			camera: "replacement-camera-device",
+			microphone: "replacement-microphone-device",
+		});
+	});
+
+	it("rejects E2EE publication when its reacquired track ends in flight", async () => {
+		const publication = deferred<unknown>();
+		const camera = track("reacquired-camera", "video");
+		const owner = {};
+		const publish = vi.fn(() => publication.promise);
+		const harness = createHarness({
+			capture: vi.fn().mockResolvedValue(new FakeMediaStream([camera])),
+			publication: {
+				getOwner: () => owner,
+				reconcileCamera: vi.fn(),
+				reconcileMicrophone: vi.fn(),
+				publish,
+			},
+		});
+		const publishing = harness.session.reacquireMediaAfterE2EE({
+			needsCamera: true,
+		});
+		await vi.waitFor(() => expect(publish).toHaveBeenCalledOnce());
+		Reflect.set(camera, "readyState", "ended");
+		publication.resolve({});
+
+		await expect(publishing).rejects.toThrow(
+			"Local track ended during publication",
+		);
+		expect(camera.stop).toHaveBeenCalledOnce();
+	});
+
+	it.each([
+		{ endedKind: "video" as const, survivingKind: "audio" as const },
+		{ endedKind: "audio" as const, survivingKind: "video" as const },
+	])(
+		"preserves successful $survivingKind when combined E2EE $endedKind ends during publication",
+		async ({ endedKind, survivingKind }) => {
+			const publication = deferred<unknown>();
+			const camera = track("reacquired-camera", "video");
+			const microphone = track("reacquired-microphone", "audio");
+			const owner = {};
+			const publish = vi.fn(() => publication.promise);
+			const harness = createHarness({
+				capture: vi
+					.fn()
+					.mockResolvedValue(new FakeMediaStream([camera, microphone])),
+				publication: {
+					getOwner: () => owner,
+					reconcileCamera: vi.fn().mockResolvedValue(undefined),
+					reconcileMicrophone: vi.fn().mockResolvedValue(undefined),
+					publish,
+				},
+			});
+
+			const publishing = harness.session.reacquireMediaAfterE2EE({
+				needsCamera: true,
+				needsMicrophone: true,
+			});
+			await vi.waitFor(() => expect(publish).toHaveBeenCalledOnce());
+			const endedTrack = endedKind === "video" ? camera : microphone;
+			const survivingTrack = survivingKind === "video" ? camera : microphone;
+			Reflect.set(endedTrack, "readyState", "ended");
+			publication.resolve({
+				video: { status: "published" },
+				audio: { status: "published" },
+			});
+
+			await expect(publishing).rejects.toThrow(
+				"Local track ended during publication",
+			);
+			expect(endedTrack.stop).toHaveBeenCalledOnce();
+			expect(survivingTrack.stop).not.toHaveBeenCalled();
+			expect(
+				harness.options
+					.getLocalStream()
+					?.getTracks()
+					.filter((item) => item.readyState === "live"),
+			).toEqual([survivingTrack]);
+			if (endedKind === "video") {
+				expect(harness.options.onCameraDisabled).toHaveBeenCalledOnce();
+				expect(harness.options.onMicrophoneDisabled).not.toHaveBeenCalled();
+			} else {
+				expect(harness.options.onMicrophoneDisabled).toHaveBeenCalledOnce();
+				expect(harness.options.onCameraDisabled).not.toHaveBeenCalled();
+			}
+		},
+	);
+
+	it.each([
+		{ endedKind: "video" as const, survivingKind: "audio" as const },
+		{ endedKind: "audio" as const, survivingKind: "video" as const },
+	])(
+		"rolls back adopted $endedKind that ends while camera effects are pending",
+		async ({ endedKind, survivingKind }) => {
+			const effects = deferred<void>();
+			const camera = track("reacquired-camera", "video");
+			const microphone = track("reacquired-microphone", "audio");
+			const harness = createHarness({
+				capture: vi
+					.fn()
+					.mockResolvedValue(new FakeMediaStream([camera, microphone])),
+				applyCameraEffects: vi.fn(() => effects.promise),
+			});
+
+			const publishing = harness.session.reacquireMediaAfterE2EE({
+				needsCamera: true,
+				needsMicrophone: true,
+			});
+			await vi.waitFor(() =>
+				expect(harness.options.applyCameraEffects).toHaveBeenCalledOnce(),
+			);
+			const endedTrack = endedKind === "video" ? camera : microphone;
+			const survivingTrack = survivingKind === "video" ? camera : microphone;
+			Reflect.set(endedTrack, "readyState", "ended");
+			effects.resolve();
+
+			await expect(publishing).rejects.toThrow(
+				endedKind === "video"
+					? "No live effective camera track is available for publication"
+					: "No live effective microphone track is available for publication",
+			);
+			expect(harness.publish).toHaveBeenCalledOnce();
+			expect(harness.publish).toHaveBeenCalledWith(
+				expect.objectContaining({
+					getTracks: expect.any(Function),
+				}),
+				endedKind === "video"
+					? { publishVideo: false, publishAudio: true }
+					: { publishVideo: true, publishAudio: false },
+			);
+			expect(endedTrack.stop).toHaveBeenCalledOnce();
+			expect(survivingTrack.stop).not.toHaveBeenCalled();
+			if (endedKind === "video") {
+				expect(harness.options.onCameraDisabled).toHaveBeenCalledOnce();
+				expect(harness.options.onMicrophoneDisabled).not.toHaveBeenCalled();
+			} else {
+				expect(harness.options.onMicrophoneDisabled).toHaveBeenCalledOnce();
+				expect(harness.options.onCameraDisabled).not.toHaveBeenCalled();
+			}
+		},
+	);
+
+	it("observes replacement tracks and removes listeners on cleanup", async () => {
+		const ended = vi.fn().mockResolvedValue(undefined);
+		const first = track("first", "video");
+		const second = track("second", "video");
+		let localStream: MediaStream | null = new FakeMediaStream([first]) as never;
+		const harness = createHarness({
+			getLocalStream: () => localStream,
+			onCameraTrackEnded: ended,
+		});
+		localStream = new FakeMediaStream([second]) as never;
+		harness.session.observeLocalTracks();
+		Reflect.set(first, "readyState", "ended");
+		first.dispatchEvent(new Event("ended"));
+		Reflect.set(second, "readyState", "ended");
+		second.dispatchEvent(new Event("ended"));
+		await vi.waitFor(() => expect(ended).toHaveBeenCalledWith(second));
+
+		await harness.session.dispose(async () => {});
+		expect(first.removeEventListener).toHaveBeenCalledOnce();
+		expect(second.removeEventListener).toHaveBeenCalledOnce();
+		expect(second.stop).toHaveBeenCalledOnce();
+	});
+
+	it("merges E2EE reacquisition without replacing newer or disabled media", () => {
+		const currentAudio = track("current-audio", "audio");
+		const restoredCamera = track("restored-camera", "video");
+		const staleCamera = track("stale-camera", "video");
+		const unrequestedAudio = track("unrequested-audio", "audio");
+		const currentStream = new FakeMediaStream([currentAudio, restoredCamera]);
+
+		const result = mergeReacquiredMedia({
+			acquiredStream: new FakeMediaStream([
+				staleCamera,
+				unrequestedAudio,
+			]) as never,
+			currentStream: currentStream as never,
+			requestedCamera: true,
+			requestedMicrophone: false,
+			cameraEnabled: true,
+			microphoneEnabled: true,
+			cameraTrackBeforeRequest: null,
+			microphoneTrackBeforeRequest: currentAudio,
+		});
+
+		expect(result.adoptedCamera).toBe(false);
+		expect(result.adoptedMicrophone).toBe(false);
+		expect(staleCamera.stop).toHaveBeenCalledOnce();
+		expect(unrequestedAudio.stop).toHaveBeenCalledOnce();
+		expect(restoredCamera.stop).not.toHaveBeenCalled();
+		expect(currentAudio.stop).not.toHaveBeenCalled();
+	});
+
+	it("stops local and detached tracks once even when cleanup overlaps", async () => {
+		const camera = track("camera", "video");
+		const microphone = track("microphone", "audio");
+		const detached = track("detached", "video");
+		let localStream: MediaStream | null = new FakeMediaStream([
+			camera,
+			microphone,
+		]) as never;
+		const harness = createHarness({ getLocalStream: () => localStream });
+		harness.session.detachCameraTrack(detached);
+
+		const first = harness.session.dispose(async () => {
+			harness.session.stopTrack(camera);
+		});
+		const second = harness.session.dispose(async () => {});
+		expect(second).toBe(first);
+		await first;
+
+		expect(camera.stop).toHaveBeenCalledOnce();
+		expect(microphone.stop).toHaveBeenCalledOnce();
+		expect(detached.stop).toHaveBeenCalledOnce();
+		localStream = null;
+	});
+
+	it.each([
+		{
+			name: "audio-only",
+			request: { needsMicrophone: true },
+			kind: "audio" as const,
+			error: new Error("audio failed"),
+		},
+		{
+			name: "video-only",
+			request: { needsCamera: true },
+			kind: "video" as const,
+			error: new Error("video failed"),
+		},
+	])(
+		"rolls back an E2EE $name per-kind publication failure",
+		async ({ request, kind, error }) => {
+			const candidate = track(`failed-${kind}`, kind);
+			const owner = {};
+			const result = {
+				[kind]: { status: "failed" as const, error },
+			};
+			const harness = createHarness({
+				capture: vi.fn().mockResolvedValue(new FakeMediaStream([candidate])),
+				publication: {
+					getOwner: () => owner,
+					reconcileCamera: vi.fn().mockResolvedValue(undefined),
+					reconcileMicrophone: vi.fn().mockResolvedValue(undefined),
+					publish: vi.fn().mockResolvedValue(result),
+				},
+			});
+
+			await expect(
+				harness.session.reacquireMediaAfterE2EE(request),
+			).rejects.toBe(error);
+
+			expect(candidate.stop).toHaveBeenCalledOnce();
+			expect(harness.options.getLocalStream()?.getTracks()).toEqual([]);
+			if (kind === "video") {
+				expect(harness.options.cleanupCameraEffects).toHaveBeenCalledOnce();
+				expect(harness.options.onCameraDisabled).toHaveBeenCalledWith(error);
+			} else {
+				expect(harness.options.cleanupMicrophoneEffects).toHaveBeenCalledOnce();
+				expect(harness.options.onMicrophoneDisabled).toHaveBeenCalledWith(error);
+			}
+		},
+	);
+
+	it("preserves successful audio when combined E2EE video publication fails", async () => {
+		const camera = track("failed-camera", "video");
+		const microphone = track("published-microphone", "audio");
+		const videoError = new Error("video failed");
+		const owner = {};
+		const harness = createHarness({
+			capture: vi
+				.fn()
+				.mockResolvedValue(new FakeMediaStream([camera, microphone])),
+			publication: {
+				getOwner: () => owner,
+				reconcileCamera: vi.fn().mockResolvedValue(undefined),
+				reconcileMicrophone: vi.fn().mockResolvedValue(undefined),
+				publish: vi.fn().mockResolvedValue({
+					video: { status: "failed", error: videoError },
+					audio: { status: "published" },
+				}),
+			},
+		});
+
+		await expect(
+			harness.session.reacquireMediaAfterE2EE({
+				needsCamera: true,
+				needsMicrophone: true,
+			}),
+		).rejects.toBe(videoError);
+
+		expect(camera.stop).toHaveBeenCalledOnce();
+		expect(microphone.stop).not.toHaveBeenCalled();
+		expect(harness.options.getLocalStream()?.getVideoTracks()).toEqual([]);
+		expect(harness.options.getLocalStream()?.getAudioTracks()).toEqual([
+			microphone,
+		]);
+		expect(harness.options.onCameraDisabled).toHaveBeenCalledWith(videoError);
+		expect(harness.options.onMicrophoneDisabled).not.toHaveBeenCalled();
+	});
+
+	it("rolls back both E2EE kinds when publication throws", async () => {
+		const camera = track("thrown-camera", "video");
+		const microphone = track("thrown-microphone", "audio");
+		const failure = new Error("transport failed");
+		const owner = {};
+		const harness = createHarness({
+			capture: vi
+				.fn()
+				.mockResolvedValue(new FakeMediaStream([camera, microphone])),
+			publication: {
+				getOwner: () => owner,
+				reconcileCamera: vi.fn().mockResolvedValue(undefined),
+				reconcileMicrophone: vi.fn().mockResolvedValue(undefined),
+				publish: vi.fn().mockRejectedValue(failure),
+			},
+		});
+
+		await expect(
+			harness.session.reacquireMediaAfterE2EE({
+				needsCamera: true,
+				needsMicrophone: true,
+			}),
+		).rejects.toBe(failure);
+		expect(camera.stop).toHaveBeenCalledOnce();
+		expect(microphone.stop).toHaveBeenCalledOnce();
+		expect(harness.options.getLocalStream()?.getTracks()).toEqual([]);
+		expect(harness.options.onCameraDisabled).toHaveBeenCalledWith(failure);
+		expect(harness.options.onMicrophoneDisabled).toHaveBeenCalledWith(failure);
+	});
+
+	it("keeps the old microphone when processing returns no track", async () => {
+		const oldTrack = track("old-microphone", "audio");
+		const candidate = track("candidate-microphone", "audio");
+		const harness = createHarness({
+			capture: vi.fn().mockResolvedValue(new FakeMediaStream([candidate])),
+			prepareMicrophone: vi.fn().mockResolvedValue(null),
+		});
+		harness.setLocalStream(new FakeMediaStream([oldTrack]) as never);
+
+		await expect(
+			harness.session.switchMicrophone("next-microphone"),
+		).rejects.toThrow("No live processed microphone track");
+
+		expect(candidate.stop).toHaveBeenCalledOnce();
+		expect(oldTrack.stop).not.toHaveBeenCalled();
+		expect(harness.options.getLocalStream()?.getAudioTracks()).toEqual([
+			oldTrack,
+		]);
+	});
+
+	it("discards microphone effects and restores publication after reconcile failure", async () => {
+		const oldTrack = track("old-microphone", "audio");
+		const candidate = track("candidate-microphone", "audio");
+		const processed = track("processed-microphone", "audio");
+		const discard = vi.fn(() => processed.stop());
+		const owner = {};
+		const reconcileMicrophone = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("replace failed"))
+			.mockResolvedValueOnce(undefined);
+		const harness = createHarness({
+			capture: vi.fn().mockResolvedValue(new FakeMediaStream([candidate])),
+			prepareMicrophone: vi.fn().mockResolvedValue({
+				track: processed,
+				commit: vi.fn(),
+				discard,
+			}),
+			publication: {
+				getOwner: () => owner,
+				reconcileCamera: vi.fn(),
+				reconcileMicrophone,
+				publish: vi.fn().mockResolvedValue({}),
+			},
+		});
+		harness.setLocalStream(new FakeMediaStream([oldTrack]) as never);
+
+		await expect(
+			harness.session.switchMicrophone("preferred-microphone"),
+		).rejects.toThrow("replace failed");
+
+		expect(harness.selections.microphone).toBe("preferred-microphone");
+		expect(discard).toHaveBeenCalledOnce();
+		expect(processed.stop).toHaveBeenCalledOnce();
+		expect(candidate.stop).toHaveBeenCalledOnce();
+		expect(oldTrack.stop).not.toHaveBeenCalled();
+		expect(reconcileMicrophone).toHaveBeenLastCalledWith(
+			oldTrack,
+			true,
+			expect.anything(),
+		);
+		expect(harness.options.getLocalStream()?.getAudioTracks()).toEqual([
+			oldTrack,
+		]);
+	});
+
+	it("stops a candidate exactly once when effect discard already stops it", async () => {
+		const oldTrack = track("old-microphone", "audio");
+		const candidate = track("candidate-microphone", "audio");
+		const failure = new Error("replace failed");
+		const owner = {};
+		const harness = createHarness({
+			capture: vi.fn().mockResolvedValue(new FakeMediaStream([candidate])),
+			prepareMicrophone: vi.fn().mockResolvedValue({
+				track: candidate,
+				commit: vi.fn(),
+				discard: vi.fn(() => {
+					candidate.stop();
+					throw new Error("effect cleanup failed");
+				}),
+			}),
+			publication: {
+				getOwner: () => owner,
+				reconcileCamera: vi.fn(),
+				reconcileMicrophone: vi
+					.fn()
+					.mockRejectedValueOnce(failure)
+					.mockResolvedValueOnce(undefined),
+				publish: vi.fn().mockResolvedValue({}),
+			},
+		});
+		harness.setLocalStream(new FakeMediaStream([oldTrack]) as never);
+
+		await expect(
+			harness.session.switchMicrophone("next-microphone"),
+		).rejects.toBe(failure);
+
+		expect(candidate.stop).toHaveBeenCalledOnce();
+		expect(oldTrack.stop).not.toHaveBeenCalled();
+	});
+
+	it("does not disturb a replacement manager that already republished the current microphone", async () => {
+		const oldTrack = track("old-microphone", "audio");
+		const candidate = track("candidate-microphone", "audio");
+		const processed = track("processed-microphone", "audio");
+		const reconciliation = deferred<void>();
+		const discard = vi.fn(() => processed.stop());
+		const oldOwner = {};
+		const replacementOwner = {};
+		let owner = oldOwner;
+		const producerTracks = new Map<object, MediaStreamTrack | null>([
+			[oldOwner, oldTrack],
+			[replacementOwner, oldTrack],
+		]);
+		const reconcileMicrophone = vi.fn(
+			async (nextTrack: MediaStreamTrack | null) => {
+				const calledOwner = owner;
+				if (calledOwner === oldOwner && nextTrack === processed) {
+					await reconciliation.promise;
+				}
+				producerTracks.set(calledOwner, nextTrack);
+			},
+		);
+		const harness = createHarness({
+			capture: vi.fn().mockResolvedValue(new FakeMediaStream([candidate])),
+			prepareMicrophone: vi.fn().mockResolvedValue({
+				track: processed,
+				commit: vi.fn(),
+				discard,
+			}),
+			publication: {
+				getOwner: () => owner,
+				reconcileCamera: vi.fn(),
+				reconcileMicrophone,
+				publish: vi.fn().mockResolvedValue({}),
+			},
+		});
+		harness.setLocalStream(new FakeMediaStream([oldTrack]) as never);
+
+		const switching = harness.session.switchMicrophone("next-microphone");
+		await vi.waitFor(() =>
+			expect(reconcileMicrophone).toHaveBeenCalled(),
+		);
+		owner = replacementOwner;
+		reconciliation.resolve();
+		await switching;
+
+		expect(discard).toHaveBeenCalledOnce();
+		expect(candidate.stop).toHaveBeenCalledOnce();
+		expect(oldTrack.stop).not.toHaveBeenCalled();
+		expect(harness.options.getLocalStream()?.getAudioTracks()).toEqual([
+			oldTrack,
+		]);
+		expect(producerTracks.get(replacementOwner)).toBe(oldTrack);
+		expect(reconcileMicrophone).toHaveBeenCalledOnce();
+		expect(harness.options.onMicrophoneDisabled).not.toHaveBeenCalled();
+	});
+
+	it("restores the old microphone when a published candidate ends before commit", async () => {
+		const oldTrack = track("old-microphone", "audio");
+		const candidate = track("candidate-microphone", "audio");
+		const commitGate = deferred<void>();
+		let producerTrack: MediaStreamTrack | null = oldTrack;
+		const owner = {};
+		const reconcileMicrophone = vi.fn(async (nextTrack: MediaStreamTrack | null) => {
+			producerTrack = nextTrack;
+		});
+		const harness = createHarness({
+			capture: vi.fn().mockResolvedValue(new FakeMediaStream([candidate])),
+			publication: {
+				getOwner: () => owner,
+				reconcileCamera: vi.fn(),
+				reconcileMicrophone,
+				publish: vi.fn().mockResolvedValue({}),
+			},
+		});
+		harness.setLocalStream(new FakeMediaStream([oldTrack]) as never);
+		const commitSpy = vi.spyOn(harness.session, "runStreamCommit");
+		const blocker = harness.session.runStreamCommit(
+			harness.session.createOperation(),
+			() => commitGate.promise,
+		);
+
+		const switching = harness.session.switchMicrophone("next-microphone");
+		await vi.waitFor(() => expect(commitSpy).toHaveBeenCalledTimes(2));
+		expect(producerTrack).toBe(candidate);
+		Reflect.set(candidate, "readyState", "ended");
+		commitGate.resolve();
+		await Promise.all([blocker, switching]);
+
+		expect(reconcileMicrophone).toHaveBeenLastCalledWith(
+			oldTrack,
+			true,
+			expect.anything(),
+		);
+		expect(producerTrack).toBe(oldTrack);
+		expect(harness.options.getLocalStream()?.getAudioTracks()).toEqual([
+			oldTrack,
+		]);
+		expect(candidate.stop).toHaveBeenCalledOnce();
+		expect(oldTrack.stop).not.toHaveBeenCalled();
+		expect(harness.options.onMicrophoneDisabled).not.toHaveBeenCalled();
+	});
+
+	it("truthfully keeps a first microphone enable disabled when publication fails", async () => {
+		const candidate = track("candidate-microphone", "audio");
+		const failure = new Error("publication failed");
+		const reconcileMicrophone = vi
+			.fn()
+			.mockRejectedValueOnce(failure)
+			.mockResolvedValueOnce(undefined);
+		const owner = {};
+		const harness = createHarness({
+			isMicrophoneEnabled: () => false,
+			capture: vi.fn().mockResolvedValue(new FakeMediaStream([candidate])),
+			publication: {
+				getOwner: () => owner,
+				reconcileCamera: vi.fn(),
+				reconcileMicrophone,
+				publish: vi.fn().mockResolvedValue({}),
+			},
+		});
+
+		await expect(harness.session.enableMicrophone()).rejects.toBe(failure);
+
+		expect(candidate.stop).toHaveBeenCalledOnce();
+		expect(harness.options.getLocalStream()).toBeNull();
+		expect(reconcileMicrophone).toHaveBeenLastCalledWith(
+			null,
+			false,
+			expect.anything(),
+		);
+		expect(harness.options.onMicrophoneDisabled).toHaveBeenCalledWith(failure);
+	});
+
+	it("persists active microphone intent before a failed acquisition", async () => {
+		const oldTrack = track("old-microphone", "audio");
+		const failure = new Error("acquisition failed");
+		let harness!: ReturnType<typeof createHarness>;
+		const capture = vi.fn(() => {
+			expect(harness.selections.microphone).toBe("preferred-microphone");
+			return Promise.reject(failure);
+		});
+		harness = createHarness({ capture });
+		harness.setLocalStream(new FakeMediaStream([oldTrack]) as never);
+
+		await expect(
+			harness.session.switchMicrophone("preferred-microphone"),
+		).rejects.toBe(failure);
+
+		expect(harness.selections.microphone).toBe("preferred-microphone");
+		expect(oldTrack.stop).not.toHaveBeenCalled();
+		expect(harness.options.getLocalStream()?.getAudioTracks()).toEqual([
+			oldTrack,
+		]);
+	});
+
+	it("coordinates combined E2EE work with both transition queues", async () => {
+		const releaseCamera = deferred<void>();
+		const releaseMicrophone = deferred<void>();
+		const camera = track("e2ee-camera", "video");
+		const microphone = track("e2ee-microphone", "audio");
+		const harness = createHarness({
+			capture: vi
+				.fn()
+				.mockResolvedValue(new FakeMediaStream([camera, microphone])),
+		});
+		const cameraWork = harness.session.runCameraTransition(
+			() => releaseCamera.promise,
+		);
+		const microphoneWork = harness.session.runMicrophoneTransition(
+			() => releaseMicrophone.promise,
+		);
+		const reacquisition = harness.session.reacquireMediaAfterE2EE({
+			needsCamera: true,
+			needsMicrophone: true,
+		});
+
+		releaseMicrophone.resolve();
+		releaseCamera.resolve();
+		await Promise.race([
+			reacquisition,
+			new Promise((_, reject) =>
+				setTimeout(
+					() => reject(new Error("combined transition deadlocked")),
+					100,
+				),
+			),
+		]);
+		await Promise.all([cameraWork, microphoneWork]);
+
+		expect(harness.publish).toHaveBeenCalledOnce();
+		expect(harness.options.getLocalStream()?.getVideoTracks()).toEqual([
+			camera,
+		]);
+		expect(harness.options.getLocalStream()?.getAudioTracks()).toEqual([
+			microphone,
+		]);
+	});
+
+	it("observes and rejects a camera that ends during deferred effects startup", async () => {
+		const effects = deferred<void>();
+		const oldTrack = track("old-camera", "video");
+		const candidate = track("candidate-camera", "video");
+		const ended = vi.fn().mockResolvedValue(undefined);
+		const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const harness = createHarness({
+			capture: vi.fn().mockResolvedValue(new FakeMediaStream([candidate])),
+			applyCameraEffects: vi.fn(() => effects.promise),
+			onCameraTrackEnded: ended,
+		});
+		harness.setLocalStream(new FakeMediaStream([oldTrack]) as never);
+
+		const switching = harness.session.switchCamera("next-camera");
+		await vi.waitFor(() =>
+			expect(harness.options.applyCameraEffects).toHaveBeenCalled(),
+		);
+		Reflect.set(candidate, "readyState", "ended");
+		candidate.dispatchEvent(new Event("ended"));
+		effects.resolve();
+		await switching;
+
+		await vi.waitFor(() => expect(ended).toHaveBeenCalledWith(candidate));
+		expect(harness.options.cleanupCameraEffects).toHaveBeenCalledOnce();
+		expect(candidate.stop).toHaveBeenCalledOnce();
+		expect(oldTrack.stop).not.toHaveBeenCalled();
+		expect(harness.options.getLocalStream()?.getVideoTracks()).toEqual([
+			oldTrack,
+		]);
+		consoleWarn.mockRestore();
+	});
+
+	it("invokes microphone-ended recovery outside its transition queue", async () => {
+		const microphone = track("ended-microphone", "audio");
+		const nestedTransition = vi.fn();
+		let session!: LocalCaptureSession;
+		const harness = createHarness({
+			onMicrophoneTrackEnded: async () => {
+				await session.runMicrophoneTransition(async () => {
+					nestedTransition();
+				});
+			},
+		});
+		session = harness.session;
+		harness.setLocalStream(new FakeMediaStream([microphone]) as never);
+
+		Reflect.set(microphone, "readyState", "ended");
+		microphone.dispatchEvent(new Event("ended"));
+
+		await vi.waitFor(() => expect(nestedTransition).toHaveBeenCalledOnce());
+	});
+});


### PR DESCRIPTION
## Summary

- extract camera and microphone lifecycle state into `LocalCaptureSession`
- stage capture and publication changes before committing local media state
- isolate cancellation, owner handoff, and E2EE partial-failure handling from Vue

Depends on #756.